### PR TITLE
Fix generation of wrong extra events on thread-thread sched switches

### DIFF
--- a/OrbitLinuxTracing/PerfEventReaders.cpp
+++ b/OrbitLinuxTracing/PerfEventReaders.cpp
@@ -1,6 +1,7 @@
 #include "PerfEventReaders.h"
 
 #include <OrbitBase/Logging.h>
+
 #include "PerfEventRecords.h"
 #include "PerfEventRingBuffer.h"
 


### PR DESCRIPTION
See b/152205493. From the bug:
When a cpu switches from a thread to another (and not from/to an idle state),
PERF_RECORD_SWITCH_CPU_WIDE carries information on both the thread being
de-scheduled and the one being scheduled, but two of those events are generated,
one for de-scheduling and one for scheduling. Instead of using the first one to
generate a de-scheduling event and the second one to generate a scheduling
event, we use both to generate both. The result is a sequence of the type
out-in,out-in where the events in each out-in pair have the same timestamp,
which is wrong. This causes several problems down the line.