### PR TITLE
Add GpuTracepointEventProcessor to combine GPU events into a single GPU job event

### DIFF
--- a/OrbitLinuxTracing/CMakeLists.txt
+++ b/OrbitLinuxTracing/CMakeLists.txt
@@ -22,6 +22,8 @@ target_sources(OrbitLinuxTracing PUBLIC
         include/OrbitLinuxTracing/TracerListener.h)
 
 target_sources(OrbitLinuxTracing PRIVATE
+        GpuTracepointEventProcessor.h
+        GpuTracepointEventProcessor.cpp
         LibunwindstackUnwinder.cpp
         LibunwindstackUnwinder.h
         MakeUniqueForOverwrite.h

--- a/OrbitLinuxTracing/CMakeLists.txt
+++ b/OrbitLinuxTracing/CMakeLists.txt
@@ -35,6 +35,7 @@ target_sources(OrbitLinuxTracing PRIVATE
         PerfEventProcessor2.cpp
         PerfEventProcessor2.h
         PerfEventReaders.h
+        PerfEventReaders.cpp
         PerfEventRecords.h
         PerfEventRingBuffer.cpp
         PerfEventRingBuffer.h

--- a/OrbitLinuxTracing/GpuTracepointEventProcessor.cpp
+++ b/OrbitLinuxTracing/GpuTracepointEventProcessor.cpp
@@ -141,7 +141,6 @@ void GpuTracepointEventProcessor::PushEvent(
   // corresponding map and then try to create a complete GPU execution event.
   // This event is only be created when all three types of GPU events have been
   // received.
-
   if (tp_id == amdgpu_cs_ioctl_id_) {
     const perf_event_amdgpu_cs_ioctl* tracepoint_data =
         reinterpret_cast<const perf_event_amdgpu_cs_ioctl*>(&sample->data[0]);

--- a/OrbitLinuxTracing/GpuTracepointEventProcessor.cpp
+++ b/OrbitLinuxTracing/GpuTracepointEventProcessor.cpp
@@ -22,7 +22,6 @@ struct __attribute__((__packed__)) perf_event_amdgpu_cs_ioctl {
   uint64_t dma_fence;  // This is an address.
   uint64_t ring_name;  // This is an address.
   uint32_t num_ibs;
-
 };
 
 struct __attribute__((__packed__)) perf_event_amdgpu_sched_run_job {

--- a/OrbitLinuxTracing/GpuTracepointEventProcessor.cpp
+++ b/OrbitLinuxTracing/GpuTracepointEventProcessor.cpp
@@ -1,5 +1,9 @@
 #include "GpuTracepointEventProcessor.h"
 
+#include <string>
+#include <tuple>
+#include <vector>
+
 namespace LinuxTracing {
 
 namespace {

--- a/OrbitLinuxTracing/GpuTracepointEventProcessor.cpp
+++ b/OrbitLinuxTracing/GpuTracepointEventProcessor.cpp
@@ -141,6 +141,7 @@ void GpuTracepointEventProcessor::PushEvent(
   // corresponding map and then try to create a complete GPU execution event.
   // This event is only be created when all three types of GPU events have been
   // received.
+
   if (tp_id == amdgpu_cs_ioctl_id_) {
     const perf_event_amdgpu_cs_ioctl* tracepoint_data =
         reinterpret_cast<const perf_event_amdgpu_cs_ioctl*>(&sample->data[0]);

--- a/OrbitLinuxTracing/GpuTracepointEventProcessor.cpp
+++ b/OrbitLinuxTracing/GpuTracepointEventProcessor.cpp
@@ -1,0 +1,174 @@
+#include "GpuTracepointEventProcessor.h"
+
+namespace LinuxTracing {
+
+namespace {
+
+// Format is based on the content the the event's format file:
+// /sys/kernel/debug/tracing/events/<category>/<name>/format
+struct __attribute__((__packed__)) perf_event_amdgpu_cs_ioctl {
+  uint16_t common_type;
+  uint8_t common_flags;
+  uint8_t common_preempt_count;
+  int32_t common_pid;
+  uint64_t sched_job_id;
+  int32_t timeline;
+  uint32_t context;
+  uint32_t seqno;
+  uint64_t dma_fence;  // This is an address.
+  uint64_t ring_name;  // This is an address.
+  uint32_t num_ibs;
+
+};
+
+struct __attribute__((__packed__)) perf_event_amdgpu_sched_run_job {
+  uint16_t common_type;
+  uint8_t common_flags;
+  uint8_t common_preempt_count;
+  int32_t common_pid;
+  uint64_t sched_job_id;
+  int32_t timeline;
+  uint32_t context;
+  uint32_t seqno;
+  uint64_t ring_name;  // This is an address.
+  uint32_t num_ibs;
+};
+
+struct __attribute__((__packed__)) perf_event_dma_fence_signaled {
+  uint16_t common_type;
+  uint8_t common_flags;
+  uint8_t common_preempt_count;
+  int32_t common_pid;
+  int32_t driver;
+  int32_t timeline;
+  uint32_t context;
+  uint32_t seqno;
+};
+
+}  // namespace
+
+int GpuTracepointEventProcessor::ComputeDepthForEvent(
+    const std::string& timeline,
+    uint64_t start_timestamp, uint64_t end_timestamp) {
+  if (timeline_to_latest_timestamp_per_depth_.count(timeline) == 0) {
+    std::vector<uint64_t> vec;
+    timeline_to_latest_timestamp_per_depth_.emplace(timeline, vec);
+  }
+  auto it = timeline_to_latest_timestamp_per_depth_.find(timeline);
+  std::vector<uint64_t>& vec = it->second;
+
+  for (int d = 0; d < vec.size(); ++d) {
+    // We add a small slack on each row of the GPU track timeline to
+    // make sure events don't get too crowded.
+    constexpr uint64_t slack_ns = 5 * 1000000;
+    if (start_timestamp >= (vec[d] + slack_ns)) {
+      vec[d] = end_timestamp;
+      return d;
+    }
+  }
+  vec.push_back(end_timestamp);
+  return static_cast<int>(vec.size());
+}
+
+void GpuTracepointEventProcessor::CreateGpuExecutionEventIfComplete(
+    const Key& key) {
+  auto cs_it = amdgpu_cs_ioctl_events_.find(key);
+  auto sched_it = amdgpu_sched_run_job_events_.find(key);
+  auto dma_it = dma_fence_signaled_events_.find(key);
+
+  // First check if we have received all three events that are needed
+  // to complete a full GPU execution event. Otherwise, we need to
+  // keep waiting for events for this context, seqno, and timeline.
+  if (cs_it == amdgpu_cs_ioctl_events_.end() ||
+      sched_it == amdgpu_sched_run_job_events_.end() ||
+      dma_it == dma_fence_signaled_events_.end()) {
+    return;
+  }
+
+  std::string timeline = cs_it->second.timeline;
+
+  // We assume that GPU jobs (command buffer submissions) immediately
+  // start running on the hardware when they are scheduled by the
+  // driver (this is the best we can do), *unless* there is already a
+  // job running. We keep track of when jobs finish in
+  // timeline_to_latest_dma_signal_. If a previous job is still running
+  // at the timestamp of scheduling the current job, we push the start
+  // time for starting on the hardware back.
+  if (timeline_to_latest_dma_signal_.count(timeline) == 0) {
+    timeline_to_latest_dma_signal_.emplace(
+        timeline, dma_it->second.timestamp_ns);
+  }
+  auto it = timeline_to_latest_dma_signal_.find(timeline);
+  uint64_t hw_start_time = sched_it->second.timestamp_ns;
+  if (hw_start_time < it->second) {
+    hw_start_time = it->second;
+  }
+
+  int depth = ComputeDepthForEvent(timeline, cs_it->second.timestamp_ns,
+                                   dma_it->second.timestamp_ns);
+
+  // TODO: Remove debug output and send the actual event to the listener.
+  LOG("GPU event complete: %d, %d, %s\n",
+      std::get<0>(key), std::get<1>(key), std::get<2>(key).c_str());
+
+  // GpuExecutionEvent gpu_event();
+  // listener_->OnGpuExecutionEvent(gpu_event);
+
+  amdgpu_cs_ioctl_events_.erase(key);
+  amdgpu_sched_run_job_events_.erase(key);
+  dma_fence_signaled_events_.erase(key);
+}
+
+void GpuTracepointEventProcessor::PushEvent(
+    const std::unique_ptr<PerfEventSampleRaw>& sample) {
+  uint32_t tid = sample->ring_buffer_record.sample_id.tid;
+  uint64_t timestamp_ns = sample->ring_buffer_record.sample_id.time;
+  int tp_id =
+      static_cast<int>(*reinterpret_cast<const uint16_t*>(&sample->data[0]));
+
+  if (tp_id == amdgpu_cs_ioctl_id_) {
+    const perf_event_amdgpu_cs_ioctl* tracepoint_data =
+        reinterpret_cast<const perf_event_amdgpu_cs_ioctl*>(&sample->data[0]);
+
+    uint32_t context = tracepoint_data->context;
+    uint32_t seqno = tracepoint_data->seqno;
+    std::string timeline = ExtractTimelineString(tracepoint_data);
+
+    AmdgpuCsIoctlEvent event{timestamp_ns, context, seqno, timeline};
+    Key key = std::make_tuple(context, seqno, timeline);
+
+    amdgpu_cs_ioctl_events_.emplace(key, event);
+
+    CreateGpuExecutionEventIfComplete(key);
+  } else if (tp_id == amdgpu_sched_run_job_id_) {
+    const perf_event_amdgpu_sched_run_job* tracepoint_data =
+        reinterpret_cast<const perf_event_amdgpu_sched_run_job*>(
+            &sample->data[0]);
+    uint32_t context = tracepoint_data->context;
+    uint32_t seqno = tracepoint_data->seqno;
+    std::string timeline = ExtractTimelineString(tracepoint_data);
+
+    AmdgpuSchedRunJobEvent event{timestamp_ns, context, seqno, timeline};
+    Key key = std::make_tuple(context, seqno, timeline);
+
+    amdgpu_sched_run_job_events_.emplace(key, event);
+    CreateGpuExecutionEventIfComplete(key);
+  } else if (tp_id == dma_fence_signaled_id_) {
+    const perf_event_dma_fence_signaled* tracepoint_data =
+        reinterpret_cast<const perf_event_dma_fence_signaled*>(
+            &sample->data[0]);
+    uint32_t context = tracepoint_data->context;
+    uint32_t seqno = tracepoint_data->seqno;
+    std::string timeline = ExtractTimelineString(tracepoint_data);
+
+    DmaFenceSignaledEvent event{timestamp_ns, context, seqno, timeline};
+    Key key = std::make_tuple(context, seqno, timeline);
+
+    dma_fence_signaled_events_.emplace(key, event);
+    CreateGpuExecutionEventIfComplete(key);
+  } else {
+    CHECK(false);
+  }
+}
+
+}  // namespace LinuxTracing

--- a/OrbitLinuxTracing/GpuTracepointEventProcessor.cpp
+++ b/OrbitLinuxTracing/GpuTracepointEventProcessor.cpp
@@ -148,6 +148,7 @@ void GpuTracepointEventProcessor::PushEvent(
     const perf_event_amdgpu_sched_run_job* tracepoint_data =
         reinterpret_cast<const perf_event_amdgpu_sched_run_job*>(
             &sample->data[0]);
+
     uint32_t context = tracepoint_data->context;
     uint32_t seqno = tracepoint_data->seqno;
     std::string timeline = ExtractTimelineString(tracepoint_data);
@@ -161,6 +162,7 @@ void GpuTracepointEventProcessor::PushEvent(
     const perf_event_dma_fence_signaled* tracepoint_data =
         reinterpret_cast<const perf_event_dma_fence_signaled*>(
             &sample->data[0]);
+
     uint32_t context = tracepoint_data->context;
     uint32_t seqno = tracepoint_data->seqno;
     std::string timeline = ExtractTimelineString(tracepoint_data);

--- a/OrbitLinuxTracing/GpuTracepointEventProcessor.cpp
+++ b/OrbitLinuxTracing/GpuTracepointEventProcessor.cpp
@@ -8,7 +8,7 @@ namespace LinuxTracing {
 
 namespace {
 
-// Format is based on the content the the event's format file:
+// Format is based on the content of the event's format file:
 // /sys/kernel/debug/tracing/events/<category>/<name>/format
 struct __attribute__((__packed__)) perf_event_amdgpu_cs_ioctl {
   uint16_t common_type;

--- a/OrbitLinuxTracing/GpuTracepointEventProcessor.h
+++ b/OrbitLinuxTracing/GpuTracepointEventProcessor.h
@@ -35,20 +35,25 @@ class GpuTracepointEventProcessor {
     std::memcpy(&data_loc_data[0],
                 reinterpret_cast<const char*>(tracepoint_data)
                 + data_loc_offset, data_loc_size);
+
+    // While the string should be null terminated here, we make sure that it
+    // actually is by adding a zero in the last position. In the case of
+    // expected behavior, this is a no-op.
+    data_loc_data[data_loc_data.size()-1] = 0;
     return std::string(&data_loc_data[0]);
   }
 
   int ComputeDepthForEvent(const std::string& timeline,
     uint64_t start_timestamp, uint64_t end_timestamp);
-  
+
   void CreateGpuExecutionEventIfComplete(const Key& key);
-  
+
   int amdgpu_cs_ioctl_id_ = 0;
   int amdgpu_sched_run_job_id_ = 0;
   int dma_fence_signaled_id_ = 0;
 
   TracerListener* listener_;
-  
+
   struct AmdgpuCsIoctlEvent {
     uint64_t timestamp_ns;
     uint32_t context;
@@ -74,10 +79,10 @@ class GpuTracepointEventProcessor {
   };
   absl::flat_hash_map<Key, DmaFenceSignaledEvent>
       dma_fence_signaled_events_;
-  
+
   absl::flat_hash_map<std::string, uint64_t>
       timeline_to_latest_dma_signal_;
-  
+
   absl::flat_hash_map<std::string, std::vector<uint64_t>>
       timeline_to_latest_timestamp_per_depth_;
 };

--- a/OrbitLinuxTracing/GpuTracepointEventProcessor.h
+++ b/OrbitLinuxTracing/GpuTracepointEventProcessor.h
@@ -1,0 +1,87 @@
+
+#ifndef ORBIT_LINUX_TRACING_GPU_TRACEPOINT_EVENT_PROCESSOR
+#define ORBIT_LINUX_TRACING_GPU_TRACEPOINT_EVENT_PROCESSOR
+
+#include <tuple>
+#include "OrbitLinuxTracing/TracerListener.h"
+#include "PerfEvent.h"
+#include "absl/container/flat_hash_map.h"
+
+namespace LinuxTracing {
+
+class GpuTracepointEventProcessor {
+ public:
+  GpuTracepointEventProcessor(int amdgpu_cs_ioctl_id,
+                              int amdgpu_sched_run_job_id,
+                              int dma_fence_signaled_id)
+      : amdgpu_cs_ioctl_id_(amdgpu_cs_ioctl_id),
+      amdgpu_sched_run_job_id_(amdgpu_sched_run_job_id),
+      dma_fence_signaled_id_(dma_fence_signaled_id) {}
+
+  void PushEvent(const std::unique_ptr<PerfEventSampleRaw>& sample);
+  void SetListener(TracerListener* listener);
+
+ private:
+  // Keys are context, seqno, and timeline
+  typedef std::tuple<uint32_t, uint32_t, std::string> Key;
+
+  template<typename T> std::string ExtractTimelineString(
+      const T* tracepoint_data) {
+    int32_t data_loc = tracepoint_data->timeline;
+    int16_t data_loc_size = static_cast<int16_t>(data_loc >> 16);
+    int16_t data_loc_offset = static_cast<int16_t>(data_loc & 0x00ff);
+
+    std::vector<char> data_loc_data(data_loc_size);
+    std::memcpy(&data_loc_data[0],
+                reinterpret_cast<const char*>(tracepoint_data)
+                + data_loc_offset, data_loc_size);
+    return std::string(&data_loc_data[0]);
+  }
+
+  int ComputeDepthForEvent(const std::string& timeline,
+    uint64_t start_timestamp, uint64_t end_timestamp);
+  
+  void CreateGpuExecutionEventIfComplete(const Key& key);
+  
+  int amdgpu_cs_ioctl_id_ = 0;
+  int amdgpu_sched_run_job_id_ = 0;
+  int dma_fence_signaled_id_ = 0;
+
+  TracerListener* listener_;
+  
+  struct AmdgpuCsIoctlEvent {
+    uint64_t timestamp_ns;
+    uint32_t context;
+    uint32_t seqno;
+    std::string timeline;
+  };
+  absl::flat_hash_map<Key, AmdgpuCsIoctlEvent> amdgpu_cs_ioctl_events_;
+
+  struct AmdgpuSchedRunJobEvent {
+    uint64_t timestamp_ns;
+    uint32_t context;
+    uint32_t seqno;
+    std::string timeline;
+  };
+  absl::flat_hash_map<Key, AmdgpuSchedRunJobEvent>
+      amdgpu_sched_run_job_events_;
+
+  struct DmaFenceSignaledEvent {
+    uint64_t timestamp_ns;
+    uint32_t context;
+    uint32_t seqno;
+    std::string timeline;
+  };
+  absl::flat_hash_map<Key, DmaFenceSignaledEvent>
+      dma_fence_signaled_events_;
+  
+  absl::flat_hash_map<std::string, uint64_t>
+      timeline_to_latest_dma_signal_;
+  
+  absl::flat_hash_map<std::string, std::vector<uint64_t>>
+      timeline_to_latest_timestamp_per_depth_;
+};
+
+}
+
+#endif

--- a/OrbitLinuxTracing/GpuTracepointEventProcessor.h
+++ b/OrbitLinuxTracing/GpuTracepointEventProcessor.h
@@ -83,6 +83,9 @@ class GpuTracepointEventProcessor {
   absl::flat_hash_map<std::string, uint64_t>
       timeline_to_latest_dma_signal_;
 
+  absl::flat_hash_map<std::string, uint64_t>
+      timeline_to_latest_dma_signal_;
+
   absl::flat_hash_map<std::string, std::vector<uint64_t>>
       timeline_to_latest_timestamp_per_depth_;
 };

--- a/OrbitLinuxTracing/PerfEvent.h
+++ b/OrbitLinuxTracing/PerfEvent.h
@@ -309,6 +309,14 @@ class MapsPerfEvent : public PerfEvent {
   std::string maps_;
 };
 
+class PerfEventSampleRaw {
+ public:
+  perf_event_sample_raw ring_buffer_record;
+  std::vector<uint8_t> data;
+  explicit PerfEventSampleRaw(uint32_t size)
+      : data(size) {}
+};
+
 }  // namespace LinuxTracing
 
 #endif  // ORBIT_LINUX_TRACING_PERF_EVENT_H_

--- a/OrbitLinuxTracing/PerfEventReaders.cpp
+++ b/OrbitLinuxTracing/PerfEventReaders.cpp
@@ -1,14 +1,47 @@
 #include "PerfEventReaders.h"
 
 #include <OrbitBase/Logging.h>
+#include "PerfEventRecords.h"
 #include "PerfEventRingBuffer.h"
 
 namespace LinuxTracing {
 
+pid_t ReadMmapRecordPid(PerfEventRingBuffer* ring_buffer) {
+  // Mmap records have the following layout:
+  // struct {
+  //   struct perf_event_header header;
+  //   u32    pid, tid;
+  //   u64    addr;
+  //   u64    len;
+  //   u64    pgoff;
+  //   char   filename[];
+  //   struct sample_id sample_id; /* if sample_id_all */
+  // };
+  // Because of filename, the layout is not fixed.
+
+  pid_t pid;
+  ring_buffer->ReadValueAtOffset(&pid, sizeof(perf_event_header));
+  return pid;
+}
+
+pid_t ReadSampleRecordPid(PerfEventRingBuffer* ring_buffer) {
+  pid_t pid;
+  ring_buffer->ReadValueAtOffset(
+      &pid, offsetof(perf_event_stack_sample, sample_id.pid));
+  return pid;
+}
+
+pid_t ReadUretprobesRecordPid(PerfEventRingBuffer* ring_buffer) {
+  pid_t pid;
+  ring_buffer->ReadValueAtOffset(
+      &pid, offsetof(perf_event_empty_sample, sample_id.pid));
+  return pid;
+}
+
 uint16_t ReadTracepointCommonType(PerfEventRingBuffer* ring_buffer) {
   uint16_t common_type = -1;
   ring_buffer->ReadValueAtOffset(
-      &common_type, offsetof(perf_event_tracepoint, common_type));
+      &common_type, offsetof(perf_event_tracepoint_common, common_type));
   return common_type;
 }
 

--- a/OrbitLinuxTracing/PerfEventReaders.cpp
+++ b/OrbitLinuxTracing/PerfEventReaders.cpp
@@ -6,7 +6,6 @@
 
 namespace LinuxTracing {
 
-<<<<<<< HEAD
 pid_t ReadMmapRecordPid(PerfEventRingBuffer* ring_buffer) {
   // Mmap records have the following layout:
   // struct {

--- a/OrbitLinuxTracing/PerfEventReaders.cpp
+++ b/OrbitLinuxTracing/PerfEventReaders.cpp
@@ -1,0 +1,15 @@
+#include "PerfEventReaders.h"
+
+#include <OrbitBase/Logging.h>
+#include "PerfEventRingBuffer.h"
+
+namespace LinuxTracing {
+
+uint16_t ReadTracepointCommonType(PerfEventRingBuffer* ring_buffer) {
+  uint16_t common_type = -1;
+  ring_buffer->ReadValueAtOffset(
+      &common_type, offsetof(perf_event_tracepoint, common_type));
+  return common_type;
+}
+
+}  // namespace LinuxTracing

--- a/OrbitLinuxTracing/PerfEventReaders.cpp
+++ b/OrbitLinuxTracing/PerfEventReaders.cpp
@@ -6,6 +6,7 @@
 
 namespace LinuxTracing {
 
+<<<<<<< HEAD
 pid_t ReadMmapRecordPid(PerfEventRingBuffer* ring_buffer) {
   // Mmap records have the following layout:
   // struct {

--- a/OrbitLinuxTracing/PerfEventReaders.cpp
+++ b/OrbitLinuxTracing/PerfEventReaders.cpp
@@ -38,11 +38,21 @@ pid_t ReadUretprobesRecordPid(PerfEventRingBuffer* ring_buffer) {
   return pid;
 }
 
-uint16_t ReadTracepointCommonType(PerfEventRingBuffer* ring_buffer) {
-  uint16_t common_type = -1;
+std::unique_ptr<PerfEventSampleRaw> ConsumeSampleRaw(
+    PerfEventRingBuffer* ring_buffer, const perf_event_header& header) {
+  uint32_t size = 0;
   ring_buffer->ReadValueAtOffset(
-      &common_type, offsetof(perf_event_tracepoint_common, common_type));
-  return common_type;
+      &size, offsetof(perf_event_sample_raw, size));
+  auto event = std::make_unique<PerfEventSampleRaw>(size);
+  ring_buffer->ReadRawAtOffset(
+      reinterpret_cast<uint8_t*>(&event->ring_buffer_record),
+      0, sizeof(perf_event_sample_raw));
+  ring_buffer->ReadRawAtOffset(
+      &event->data[0],
+      offsetof(perf_event_sample_raw, size) + sizeof(uint32_t),
+      size);
+  ring_buffer->SkipRecord(header);
+  return event;
 }
 
 }  // namespace LinuxTracing

--- a/OrbitLinuxTracing/PerfEventReaders.h
+++ b/OrbitLinuxTracing/PerfEventReaders.h
@@ -17,6 +17,8 @@ pid_t ReadUretprobesRecordPid(PerfEventRingBuffer* ring_buffer);
 std::unique_ptr<PerfEventSampleRaw> ConsumeSampleRaw(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header);
 
+uint16_t ReadTracepointCommonType(PerfEventRingBuffer* ring_buffer);
+
 template <typename SamplePerfEventT>
 inline std::unique_ptr<SamplePerfEventT> ConsumeSamplePerfEvent(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header) {

--- a/OrbitLinuxTracing/PerfEventReaders.h
+++ b/OrbitLinuxTracing/PerfEventReaders.h
@@ -41,6 +41,8 @@ inline pid_t ReadUretprobesRecordPid(PerfEventRingBuffer* ring_buffer) {
   return pid;
 }
 
+uint16_t ReadTracepointCommonType(PerfEventRingBuffer* ring_buffer);
+
 template <typename SamplePerfEventT>
 inline std::unique_ptr<SamplePerfEventT> ConsumeSamplePerfEvent(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header) {

--- a/OrbitLinuxTracing/PerfEventReaders.h
+++ b/OrbitLinuxTracing/PerfEventReaders.h
@@ -17,8 +17,6 @@ pid_t ReadUretprobesRecordPid(PerfEventRingBuffer* ring_buffer);
 std::unique_ptr<PerfEventSampleRaw> ConsumeSampleRaw(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header);
 
-uint16_t ReadTracepointCommonType(PerfEventRingBuffer* ring_buffer);
-
 template <typename SamplePerfEventT>
 inline std::unique_ptr<SamplePerfEventT> ConsumeSamplePerfEvent(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header) {

--- a/OrbitLinuxTracing/PerfEventReaders.h
+++ b/OrbitLinuxTracing/PerfEventReaders.h
@@ -14,7 +14,8 @@ pid_t ReadSampleRecordPid(PerfEventRingBuffer* ring_buffer);
 
 pid_t ReadUretprobesRecordPid(PerfEventRingBuffer* ring_buffer);
 
-uint16_t ReadTracepointCommonType(PerfEventRingBuffer* ring_buffer);
+std::unique_ptr<PerfEventSampleRaw> ConsumeSampleRaw(
+    PerfEventRingBuffer* ring_buffer, const perf_event_header& header);
 
 template <typename SamplePerfEventT>
 inline std::unique_ptr<SamplePerfEventT> ConsumeSamplePerfEvent(

--- a/OrbitLinuxTracing/PerfEventReaders.h
+++ b/OrbitLinuxTracing/PerfEventReaders.h
@@ -8,38 +8,11 @@ namespace LinuxTracing {
 
 // Helper functions for reads from a perf_event_open ring buffer that require
 // more complex operations than simply copying an entire perf_event_open record.
+pid_t ReadMmapRecordPid(PerfEventRingBuffer* ring_buffer);
 
-inline pid_t ReadMmapRecordPid(PerfEventRingBuffer* ring_buffer) {
-  // Mmap records have the following layout:
-  // struct {
-  //   struct perf_event_header header;
-  //   u32    pid, tid;
-  //   u64    addr;
-  //   u64    len;
-  //   u64    pgoff;
-  //   char   filename[];
-  //   struct sample_id sample_id; /* if sample_id_all */
-  // };
-  // Because of filename, the layout is not fixed.
+pid_t ReadSampleRecordPid(PerfEventRingBuffer* ring_buffer);
 
-  pid_t pid;
-  ring_buffer->ReadValueAtOffset(&pid, sizeof(perf_event_header));
-  return pid;
-}
-
-inline pid_t ReadSampleRecordPid(PerfEventRingBuffer* ring_buffer) {
-  pid_t pid;
-  ring_buffer->ReadValueAtOffset(
-      &pid, offsetof(perf_event_stack_sample, sample_id.pid));
-  return pid;
-}
-
-inline pid_t ReadUretprobesRecordPid(PerfEventRingBuffer* ring_buffer) {
-  pid_t pid;
-  ring_buffer->ReadValueAtOffset(
-      &pid, offsetof(perf_event_empty_sample, sample_id.pid));
-  return pid;
-}
+pid_t ReadUretprobesRecordPid(PerfEventRingBuffer* ring_buffer);
 
 uint16_t ReadTracepointCommonType(PerfEventRingBuffer* ring_buffer);
 

--- a/OrbitLinuxTracing/PerfEventRecords.h
+++ b/OrbitLinuxTracing/PerfEventRecords.h
@@ -99,7 +99,7 @@ struct __attribute__((__packed__)) perf_event_tracepoint_common {
   perf_event_sample_id_tid_time_streamid_cpu sample_id;
   uint32_t size;
   // The rest of the struct is a char[size], but all tracepoints record the
-  // tracepoint id in the first two types. Since we need to identify the
+  // tracepoint id in the first two bytes. Since we need to identify the
   // type of the tracepoint before we can determine which event to handle, we
   // add this common field here for easier access.
   uint16_t common_type;

--- a/OrbitLinuxTracing/PerfEventRecords.h
+++ b/OrbitLinuxTracing/PerfEventRecords.h
@@ -96,7 +96,7 @@ struct __attribute__((__packed__)) perf_event_lost {
 // here.
 struct __attribute__((__packed__)) perf_event_tracepoint {
   perf_event_header header;
-  perf_event_sample_id_tid_time_cpu sample_id;
+  perf_event_sample_id_tid_time_streamid_cpu sample_id;
   uint32_t size;
   uint16_t common_type;
 };

--- a/OrbitLinuxTracing/PerfEventRecords.h
+++ b/OrbitLinuxTracing/PerfEventRecords.h
@@ -90,7 +90,7 @@ struct __attribute__((__packed__)) perf_event_lost {
 // perf sample, that is, with the header and the common fields like sample_id,
 // tid, timestamp, etc. The next field is the size of the rest of the tracepoint
 // record and the common type. The common type is the same as the tracepoint id
-// and we use it to identify the end events and how to handle them. The actual
+// and we use it to identify the events and how to handle them. The actual
 // record is thus larger than the size of this struct but since it is dynamic
 // and depends on the type of the tracepoint, we only hardcode the common part
 // here.

--- a/OrbitLinuxTracing/PerfEventRecords.h
+++ b/OrbitLinuxTracing/PerfEventRecords.h
@@ -94,10 +94,14 @@ struct __attribute__((__packed__)) perf_event_lost {
 // record is thus larger than the size of this struct but since it is dynamic
 // and depends on the type of the tracepoint, we only hardcode the common part
 // here.
-struct __attribute__((__packed__)) perf_event_tracepoint {
+struct __attribute__((__packed__)) perf_event_tracepoint_common {
   perf_event_header header;
   perf_event_sample_id_tid_time_streamid_cpu sample_id;
   uint32_t size;
+  // The rest of the struct is a char[size], but all tracepoints record the
+  // tracepoint id in the first two types. Since we need to identify the
+  // type of the tracepoint before we can determine which event to handle, we
+  // add this common field here for easier access.
   uint16_t common_type;
 };
 

--- a/OrbitLinuxTracing/PerfEventRecords.h
+++ b/OrbitLinuxTracing/PerfEventRecords.h
@@ -86,6 +86,21 @@ struct __attribute__((__packed__)) perf_event_lost {
   perf_event_sample_id_tid_time_streamid_cpu sample_id;
 };
 
+// Tracepoints are perf samples, so they start with the same layout as a regular
+// perf sample, that is, with the header and the common fields like sample_id,
+// tid, timestamp, etc. The next field is the size of the rest of the tracepoint
+// record and the common type. The common type is the same as the tracepoint id
+// and we use it to identify the end events and how to handle them. The actual
+// record is thus larger than the size of this struct but since it is dynamic
+// and depends on the type of the tracepoint, we only hardcode the common part
+// here.
+struct __attribute__((__packed__)) perf_event_tracepoint {
+  perf_event_header header;
+  perf_event_sample_id_tid_time_cpu sample_id;
+  uint32_t size;
+  uint16_t common_type;
+};
+
 }  // namespace LinuxTracing
 
 #endif  // ORBIT_LINUX_TRACING_PERF_EVENT_RECORDS_H_

--- a/OrbitLinuxTracing/PerfEventRecords.h
+++ b/OrbitLinuxTracing/PerfEventRecords.h
@@ -90,7 +90,7 @@ struct __attribute__((__packed__)) perf_event_sample_raw {
   perf_event_header header;
   perf_event_sample_id_tid_time_streamid_cpu sample_id;
   uint32_t size;
-  // The rest of the sample is a char[size] that we read dynamically.
+  // The rest of the sample is a char[size] that we read dynamically
 };
 
 }  // namespace LinuxTracing

--- a/OrbitLinuxTracing/PerfEventRecords.h
+++ b/OrbitLinuxTracing/PerfEventRecords.h
@@ -86,23 +86,11 @@ struct __attribute__((__packed__)) perf_event_lost {
   perf_event_sample_id_tid_time_streamid_cpu sample_id;
 };
 
-// Tracepoints are perf samples, so they start with the same layout as a regular
-// perf sample, that is, with the header and the common fields like sample_id,
-// tid, timestamp, etc. The next field is the size of the rest of the tracepoint
-// record and the common type. The common type is the same as the tracepoint id
-// and we use it to identify the events and how to handle them. The actual
-// record is thus larger than the size of this struct but since it is dynamic
-// and depends on the type of the tracepoint, we only hardcode the common part
-// here.
-struct __attribute__((__packed__)) perf_event_tracepoint_common {
+struct __attribute__((__packed__)) perf_event_sample_raw {
   perf_event_header header;
   perf_event_sample_id_tid_time_streamid_cpu sample_id;
   uint32_t size;
-  // The rest of the struct is a char[size], but all tracepoints record the
-  // tracepoint id in the first two bytes. Since we need to identify the
-  // type of the tracepoint before we can determine which event to handle, we
-  // add this common field here for easier access.
-  uint16_t common_type;
+  // The rest of the sample is a char[size] that we read dynamically.
 };
 
 }  // namespace LinuxTracing

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -541,8 +541,8 @@ void TracerThread::ProcessSampleEvent(const perf_event_header& header,
     ++stats_.uprobes_count;
 
   } else if (is_gpu_event) {
-    int32_t common_type = ReadTracepointCommonType(ring_buffer);
-    LOG("Received GPU event with common type: %d", common_type);
+    auto event = ConsumeSampleRaw(ring_buffer, header);
+    gpu_event_processor_->PushEvent(event);
     ++stats_.gpu_events_count;
   } else {
     auto event =

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -541,9 +541,8 @@ void TracerThread::ProcessSampleEvent(const perf_event_header& header,
     ++stats_.uprobes_count;
 
   } else if (is_gpu_event) {
-    // TODO: Consider deferring events.
-    auto event = ConsumeSampleRaw(ring_buffer, header);
-    gpu_event_processor_->PushEvent(event);
+    int32_t common_type = ReadTracepointCommonType(ring_buffer);
+    LOG("Received GPU event with common type: %d", common_type);
     ++stats_.gpu_events_count;
   } else {
     auto event =

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -518,7 +518,8 @@ void TracerThread::ProcessSampleEvent(const perf_event_header& header,
     ++stats_.uprobes_count;
 
   } else if (is_gpu_event) {
-    LOG("Received GPU event.");
+    int32_t common_type = ReadTracepointCommonType(ring_buffer);
+    LOG("Received GPU event with common type: %d", common_type);
     ++stats_.gpu_events_count;
   } else {
     auto event =

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -541,6 +541,7 @@ void TracerThread::ProcessSampleEvent(const perf_event_header& header,
     ++stats_.uprobes_count;
 
   } else if (is_gpu_event) {
+    // TODO: Consider deferring events.
     auto event = ConsumeSampleRaw(ring_buffer, header);
     gpu_event_processor_->PushEvent(event);
     ++stats_.gpu_events_count;

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -107,7 +107,7 @@ class TracerThread {
   bool trace_context_switches_ = true;
   bool trace_callstacks_ = true;
   bool trace_instrumented_functions_ = true;
-  bool trace_gpu_driver_events_ = false;
+  bool trace_gpu_driver_events_ = true;
 
   std::vector<int> tracing_fds_;
   std::vector<PerfEventRingBuffer> ring_buffers_;

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -13,6 +13,7 @@
 #include <regex>
 #include <vector>
 
+#include "GpuTracepointEventProcessor.h"
 #include "PerfEvent.h"
 #include "PerfEventProcessor.h"
 #include "PerfEventProcessor2.h"
@@ -60,7 +61,7 @@ class TracerThread {
       std::vector<PerfEventRingBuffer>* ring_buffers);
 
   bool OpenGpuTracepoints(const std::vector<int32_t>& cpus);
-  void CleanupGpuTracepoints();
+  bool InitGpuTracepointEventProcessor();
 
   void ProcessContextSwitchEvent(const perf_event_header& header,
                                  PerfEventRingBuffer* ring_buffer);
@@ -106,7 +107,7 @@ class TracerThread {
   bool trace_context_switches_ = true;
   bool trace_callstacks_ = true;
   bool trace_instrumented_functions_ = true;
-  bool trace_gpu_driver_events_ = false;
+  bool trace_gpu_driver_events_ = true;
 
   std::vector<int> tracing_fds_;
   std::vector<PerfEventRingBuffer> ring_buffers_;
@@ -118,6 +119,7 @@ class TracerThread {
   std::vector<std::unique_ptr<PerfEvent>> deferred_events_;
   std::mutex deferred_events_mutex_;
   std::shared_ptr<PerfEventProcessor2> uprobes_event_processor_;
+  std::shared_ptr<GpuTracepointEventProcessor> gpu_event_processor_;
 
   struct EventStats {
     void Reset() { *this = EventStats(); }

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -107,7 +107,7 @@ class TracerThread {
   bool trace_context_switches_ = true;
   bool trace_callstacks_ = true;
   bool trace_instrumented_functions_ = true;
-  bool trace_gpu_driver_events_ = true;
+  bool trace_gpu_driver_events_ = false;
 
   std::vector<int> tracing_fds_;
   std::vector<PerfEventRingBuffer> ring_buffers_;


### PR DESCRIPTION
The main addition here is the GpuTracepointEventProcessor class, which handles combining three GPU events into a single GPU job that is then forwarded to the UI via the listener (the latter part is still today). 

As part of this change I have simplified reading from the ring buffer. We now just read a generic raw sample and then parse the contents in GpuTracepointEventProcessor, as parsing the data requires specific knowledge about the tracepoint data format.

