### PR TITLE
Added signed-package-verfication script-generation to the Kokoro GGP CI-buildjob

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -143,6 +143,13 @@ chmod -v 4775 /usr/bin/OrbitService
             self.run("dpkg --contents {}.deb".format(basedir))
             shutil.rmtree(basedir)
 
+            basedir = "{}/install-signed-package-{}".format(self.package_folder, self._version())
+            self.run("cmake -D DESTDIR=\"{0}\" -D SRCDIR=\"{1}/contrib/signing\" -D VERSION=\"{2}\" -P \"{1}/contrib/signing/gen.cmake\"".format(basedir, self.source_folder, self._version()))
+            self.run("chmod g-s {}/DEBIAN".format(basedir))
+            self.run("chmod g-s {}/".format(basedir))
+            self.run("dpkg-deb -b --root-owner-group {}".format(basedir))
+            self.run("dpkg --contents {}.deb".format(basedir))
+
         self.copy("*", src="bin/dri", dst="bin/dri", symlinks=True)
         self.copy("*", src="bin/fonts", dst="bin/fonts", symlinks=True)
         self.copy("*", src="bin/shaders", dst="bin/shaders", symlinks=True)

--- a/contrib/signing/DEBIAN/control.in
+++ b/contrib/signing/DEBIAN/control.in
@@ -1,0 +1,8 @@
+Package: install-signed-packages
+Version: @VERSION@
+Section: development
+Priority: optional
+Architecture: any
+Maintainer: OrbitProfiler Team <orbitprofiler-eng@google.com>
+Description: Allows the installation of signed packages without root permissions
+Installed-Size: `du -ks . | cut -f 1`

--- a/contrib/signing/etc/sudoers.d/install_signed_packages.in
+++ b/contrib/signing/etc/sudoers.d/install_signed_packages.in
@@ -1,0 +1,1 @@
+%sudo ALL= NOPASSWD:/usr/sbin/install_signed_package.sh *

--- a/contrib/signing/gen.cmake
+++ b/contrib/signing/gen.cmake
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.13)
+
+# Variables SRCDIR and DESTDIR have to be set by the caller!
+
+execute_process(
+  COMMAND "base64"
+  INPUT_FILE "$ENV{ORBIT_SIGNING_PUBLIC_KEY_FILE}"
+  OUTPUT_VARIABLE PUBLIC_KEY_BASE64)
+
+configure_file("${SRCDIR}/etc/sudoers.d/install_signed_packages.in"
+               "${DESTDIR}/etc/sudoers.d/install_signed_package")
+
+configure_file("${SRCDIR}/DEBIAN/control.in" "${DESTDIR}/DEBIAN/control")
+
+configure_file("${SRCDIR}/usr/sbin/install_signed_package.sh.in"
+               "${DESTDIR}/usr/sbin/install_signed_package.sh")

--- a/contrib/signing/usr/sbin/install_signed_package.sh.in
+++ b/contrib/signing/usr/sbin/install_signed_package.sh.in
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+if [ $(id -u) != 0 ]; then
+    echo "You have to run this a root!"
+    exit 1
+fi
+
+show_help() {
+        echo "$0 filename.deb"
+}
+
+if [ $# -ne 1 ]; then
+        echo "You have to provide the path to a debian package!"
+        show_help
+        exit 2
+fi
+
+if [ ! -f $1 ]; then
+        echo "The given debian package has to be a regular file!"
+        show_help
+        exit 3
+fi
+
+if [ ! -f $1.asc ]; then
+        echo "Signature $1.asc not found or not a regular file!"
+        show_help
+        exit 3
+fi
+
+umask 077 # Create files and directories with root-only access
+
+DIR="$(mktemp -d)"
+cp -v "$1" "$1.asc" "$DIR/" || exit $?
+
+FILENAME="$(basename -- "$1")"
+
+cleanup() {
+  rm -v -rf "$DIR"
+}
+
+base64 -d > "$DIR/$FILENAME.keyring" <<EOF
+@PUBLIC_KEY_BASE64@
+EOF
+
+echo "Note: A warning about a non-certified public key is expected and can be ignored!"
+gpg --no-default-keyring --keyring "$DIR/$FILENAME.keyring" --verify \
+        "$DIR/$FILENAME.asc" "$DIR/$FILENAME" && \
+        dpkg -i "$DIR/$FILENAME"
+cleanup

--- a/kokoro/gcp_ubuntu_ggp/kokoro_build.sh
+++ b/kokoro/gcp_ubuntu_ggp/kokoro_build.sh
@@ -27,6 +27,11 @@ cp -v $DIR/kokoro/conan/config/remotes.json ~/.conan/remotes.json
 export CONAN_REVISIONS_ENABLED=1
 profile=ggp_relwithdebinfo
 
+# This variable is picked up by the `conan package` call.
+# The current public key from keystore will be embedded into
+# the install_signed_package.sh script.
+export ORBIT_SIGNING_PUBLIC_KEY_FILE="/tmpfs/src/keystore/74938_SigningPublicGpg"
+
 cd ${KOKORO_ARTIFACTS_DIR}/github/orbitprofiler
 conan install -u -pr $profile -if build_$profile/ --build outdated -o debian_packaging=True $DIR
 conan build -bf build_$profile/ $DIR


### PR DESCRIPTION
This PR adds an additional build step to the gcp_ubuntu_ggp kokoro build job.

Additionally a script called `install_signed_package.sh` will be generated. This
script verifies the signature of a debian package and if valid installs the package.

The signature is verified against an embedded public key. During the additional
build step the public key is extracted from keystore and embedded into the
script's template.

This dynamic generation of the script is the first step towards automatic key rotation
which we will probably need when this goes live.

Everything in this PR is meant to be run solely on the CI and does not affect the
usual build of Orbit.

This PR was carefully crafted not to expose any confidential information.