### PR TITLE
Add option to only show the thread name and not the thread id on a track

### DIFF
--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -243,7 +243,7 @@ void TimeGraph::ProcessTimer(const Timer& a_Timer) {
     std::shared_ptr<ThreadTrack> track = GetThreadTrack(a_Timer.m_TID);
     if (a_Timer.m_Type == Timer::GPU_ACTIVITY) {
       track->SetName(string_manager_->Get(a_Timer.m_UserData[1]).value_or(""));
-      track->SetDisplayNameOnly(true);
+      track->SetLabelDisplayMode(Track::NAME_ONLY);
     }
 
     track->OnTimer(a_Timer);

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -243,6 +243,7 @@ void TimeGraph::ProcessTimer(const Timer& a_Timer) {
     std::shared_ptr<ThreadTrack> track = GetThreadTrack(a_Timer.m_TID);
     if (a_Timer.m_Type == Timer::GPU_ACTIVITY) {
       track->SetName(string_manager_->Get(a_Timer.m_UserData[1]).value_or(""));
+      track->SetDisplayNameOnly(true);
     }
 
     track->OnTimer(a_Timer);

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -23,6 +23,8 @@ Track::Track() {
   m_Moving = false;
   m_Canvas = nullptr;
 
+  display_name_only_ = false;
+
   unsigned char alpha = 255;
   unsigned char grey = 60;
   m_Color = Color(grey, grey, grey, alpha);

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -23,7 +23,7 @@ Track::Track() {
   m_Moving = false;
   m_Canvas = nullptr;
 
-  display_name_only_ = false;
+  label_display_mode_ = NAME_AND_TID;
 
   unsigned char alpha = 255;
   unsigned char grey = 60;
@@ -68,13 +68,23 @@ void Track::Draw(GlCanvas* a_Canvas, bool a_Picking) {
   glVertex3f(x0, y1, TRACK_Z);
   glEnd();
 
-  std::string name;
-  if (display_name_only_) {
-    name = absl::StrFormat("%s", m_Name.c_str());
-  } else {
-    name = absl::StrFormat("%s [%u]", m_Name.c_str(), m_ID);
+  std::string track_label;
+  switch(label_display_mode_) {
+    case NAME_AND_TID:
+      track_label = absl::StrFormat("%s [%u]", m_Name, m_ID);
+      break;
+    case TID_ONLY:
+      track_label = absl::StrFormat("[%u]", m_ID);
+      break;
+    case NAME_ONLY:
+      track_label = absl::StrFormat("%s", m_Name, m_ID);
+      break;
+    case EMPTY:
+      track_label = "";
   }
-  a_Canvas->AddText(name.c_str(), x0, y1, TEXT_Z, Color(255, 255, 255, 255));
+
+  a_Canvas->AddText(track_label.c_str(),
+                    x0, y1, TEXT_Z, Color(255, 255, 255, 255));
 
   m_Canvas = a_Canvas;
 }

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -66,7 +66,12 @@ void Track::Draw(GlCanvas* a_Canvas, bool a_Picking) {
   glVertex3f(x0, y1, TRACK_Z);
   glEnd();
 
-  std::string name = absl::StrFormat("%s [%u]", m_Name.c_str(), m_ID);
+  std::string name;
+  if (display_name_only_) {
+    name = absl::StrFormat("%s", m_Name.c_str());
+  } else {
+    name = absl::StrFormat("%s [%u]", m_Name.c_str(), m_ID);
+  }
   a_Canvas->AddText(name.c_str(), x0, y1, TEXT_Z, Color(255, 255, 255, 255));
 
   m_Canvas = a_Canvas;

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -31,8 +31,16 @@ class Track : public Pickable {
     return m_Moving ? m_MousePos[1] - m_MousePos[0] : Vec2(0, 0);
   }
   void SetName(const std::string& a_Name) { m_Name = a_Name; }
-  void SetDisplayNameOnly(bool display_name_only) {
-    display_name_only_ = display_name_only;
+
+  enum LabelDisplayMode {
+    NAME_AND_TID,
+    TID_ONLY,
+    NAME_ONLY,
+    EMPTY
+  };
+
+  void SetLabelDisplayMode(LabelDisplayMode label_display_mode) {
+    label_display_mode_ = label_display_mode;
   }
 
   const std::string& GetName() const { return m_Name; }
@@ -55,6 +63,6 @@ class Track : public Pickable {
   bool m_Moving;
   std::string m_Name;
   uint32_t m_ID;
-  bool display_name_only_;
+  LabelDisplayMode label_display_mode_;
   Color m_Color;
 };

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -31,6 +31,10 @@ class Track : public Pickable {
     return m_Moving ? m_MousePos[1] - m_MousePos[0] : Vec2(0, 0);
   }
   void SetName(const std::string& a_Name) { m_Name = a_Name; }
+  void SetDisplayNameOnly(bool display_name_only) {
+    display_name_only_ = display_name_only;
+  }
+
   const std::string& GetName() const { return m_Name; }
   void SetTimeGraph(TimeGraph* a_TimeGraph) { m_TimeGraph = a_TimeGraph; }
   void SetPos(float a_X, float a_Y);
@@ -51,5 +55,6 @@ class Track : public Pickable {
   bool m_Moving;
   std::string m_Name;
   uint32_t m_ID;
+  bool display_name_only_;
   Color m_Color;
 };


### PR DESCRIPTION
This is used by GPU timelines to show only the timeline name and not the (fake) thread id.