### PR TITLE
Fix crash in PerfEventProcessor/2 in debug builds

### DIFF
--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -77,7 +77,7 @@ void Track::Draw(GlCanvas* a_Canvas, bool a_Picking) {
       track_label = absl::StrFormat("[%u]", m_ID);
       break;
     case NAME_ONLY:
-      track_label = absl::StrFormat("%s", m_Name, m_ID);
+      track_label = absl::StrFormat("%s", m_Name);
       break;
     case EMPTY:
       track_label = "";

--- a/OrbitLinuxTracing/PerfEventProcessor.cpp
+++ b/OrbitLinuxTracing/PerfEventProcessor.cpp
@@ -24,12 +24,10 @@ void PerfEventProcessor::AddEvent(int /*origin_fd*/,
 void PerfEventProcessor::ProcessAllEvents() {
   while (!event_queue_.empty()) {
     PerfEvent* event = event_queue_.top().get();
-    event->Accept(visitor_.get());
-
 #ifndef NDEBUG
     last_processed_timestamp_ = event->GetTimestamp();
 #endif
-
+    event->Accept(visitor_.get());
     event_queue_.pop();
   }
 }
@@ -45,12 +43,11 @@ void PerfEventProcessor::ProcessOldEvents() {
         max_timestamp) {
       break;
     }
-    event->Accept(visitor_.get());
 
 #ifndef NDEBUG
     last_processed_timestamp_ = event->GetTimestamp();
 #endif
-
+    event->Accept(visitor_.get());
     event_queue_.pop();
   }
 }

--- a/OrbitLinuxTracing/PerfEventProcessor2.cpp
+++ b/OrbitLinuxTracing/PerfEventProcessor2.cpp
@@ -71,10 +71,10 @@ void PerfEventProcessor2::AddEvent(int origin_fd,
 void PerfEventProcessor2::ProcessAllEvents() {
   while (event_queue_.HasEvent()) {
     std::unique_ptr<PerfEvent> event = event_queue_.PopEvent();
-    event->Accept(visitor_.get());
 #ifndef NDEBUG
     last_processed_timestamp_ = event->GetTimestamp();
 #endif
+    event->Accept(visitor_.get());
   }
 }
 
@@ -90,10 +90,10 @@ void PerfEventProcessor2::ProcessOldEvents() {
       break;
     }
 
-    event->Accept(visitor_.get());
 #ifndef NDEBUG
     last_processed_timestamp_ = event->GetTimestamp();
 #endif
+    event->Accept(visitor_.get());
     event_queue_.PopEvent();
   }
 }


### PR DESCRIPTION
See b/152441105. This is caused by SamplePerfEvent::ring_buffer_record now being
a unique_ptr that is moved from by UprobesCallstackManager.