### PR TITLE
Added simple Kokoro presubmit configs

### DIFF
--- a/kokoro/gcp_ubuntu/presubmit.cfg
+++ b/kokoro/gcp_ubuntu/presubmit.cfg
@@ -1,0 +1,6 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+
+# Location of the bash script. Should have value <github_scm.name>/<path_from_repository_root>.
+# github_scm.name is specified in the job configuration (next section).
+build_file: "orbitprofiler/kokoro/gcp_ubuntu/kokoro_build.sh"

--- a/kokoro/gcp_windows/presubmit.cfg
+++ b/kokoro/gcp_windows/presubmit.cfg
@@ -1,0 +1,6 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+
+# Location of the bash script. Should have value <github_scm.name>/<path_from_repository_root>.
+# github_scm.name is specified in the job configuration (next section).
+build_file: "orbitprofiler/kokoro/gcp_windows/kokoro_build.bat"


### PR DESCRIPTION
For the presubmit builds to work we need not only supply
a Kokoro job config, but also build config files which
reside inside of the github repo.

This PR adds these file in a very simple way. No artifacts
will be generated. This needs more work in the future,
when we want to show test results from presubmit builds.