### PR TITLE
Defined build artifacts for presubmit builds

### DIFF
--- a/kokoro/gcp_ubuntu/presubmit.cfg
+++ b/kokoro/gcp_ubuntu/presubmit.cfg
@@ -4,3 +4,10 @@
 # Location of the bash script. Should have value <github_scm.name>/<path_from_repository_root>.
 # github_scm.name is specified in the job configuration (next section).
 build_file: "orbitprofiler/kokoro/gcp_ubuntu/kokoro_build.sh"
+
+action {
+  define_artifacts {
+    regex: "github/orbitprofiler/build_clang7_release/testresults/*.xml"
+    strip_prefix: "github/orbitprofiler"
+  }
+}

--- a/kokoro/gcp_windows/presubmit.cfg
+++ b/kokoro/gcp_windows/presubmit.cfg
@@ -4,3 +4,10 @@
 # Location of the bash script. Should have value <github_scm.name>/<path_from_repository_root>.
 # github_scm.name is specified in the job configuration (next section).
 build_file: "orbitprofiler/kokoro/gcp_windows/kokoro_build.bat"
+
+action {
+  define_artifacts {
+    regex: "github/orbitprofiler/build_msvc2019_release_x64/testresults/*.xml"
+    strip_prefix: "github/orbitprofiler"
+  }
+}


### PR DESCRIPTION
Even though the presubmit build should not generate
binaries we are still interested in their test results.

For showing those in Sponge it is necessary to define
the test result XML files as build artifacts.