### PR TITLE
Add support for Linux thread names.

### DIFF
--- a/OrbitCore/ConnectionManager.cpp
+++ b/OrbitCore/ConnectionManager.cpp
@@ -350,6 +350,7 @@ void ConnectionManager::SendRemoteProcess(TcpEntity* tcp_entity, uint32_t pid) {
   // and all the messages should to be as stateless as possible.
   Capture::SetTargetProcess(process);
   process->ListModules();
+  process->EnumerateThreads();
   if (process) {
     std::string process_data = SerializeObjectHumanReadable(*process);
     tcp_entity->Send(Msg_RemoteProcess, process_data.data(),

--- a/OrbitCore/LinuxUtils.cpp
+++ b/OrbitCore/LinuxUtils.cpp
@@ -251,8 +251,10 @@ std::string GetProcessDir(pid_t process_id) {
 
 //-----------------------------------------------------------------------------
 std::map<uint32_t, std::string> GetThreadNames(pid_t process_id) {
-  std::string threads_dir = GetProcessDir(process_id) + "task/";
+  // We use std::map rather the flat_hash_map to allow "cereal" serialization
+  // and to get sorted pairs.
   std::map<uint32_t, std::string> thread_ids_to_name;
+  std::string threads_dir = GetProcessDir(process_id) + "task/";
   struct dirent* dir_entry = nullptr;
   DIR* dir = nullptr;
 

--- a/OrbitCore/LinuxUtils.h
+++ b/OrbitCore/LinuxUtils.h
@@ -31,4 +31,6 @@ void DumpClocks();
 std::string GetKernelVersionStr();
 uint32_t GetKernelVersion();
 bool IsKernelOlderThan(const char* a_Version);
+std::string GetProcessDir(pid_t process_id);
+std::map<uint32_t, std::string> GetThreadNames(pid_t process_id);
 }  // namespace LinuxUtils

--- a/OrbitCore/OrbitProcess.cpp
+++ b/OrbitCore/OrbitProcess.cpp
@@ -170,6 +170,8 @@ void Process::EnumerateThreads() {
   for (std::shared_ptr<Thread>& thread : m_Threads) {
     m_ThreadIds.insert(thread->m_TID);
   }
+#else
+  m_ThreadNames = LinuxUtils::GetThreadNames(m_ID);
 #endif
 }
 
@@ -532,7 +534,7 @@ void Process::FindCoreFunctions() {
         {
             func->Select();
             func->m_OrbitType = Function::FREE;
-        } 
+        }
         else if( Contains( name, L"realloc" ) )
         {
             func->Select();
@@ -543,7 +545,7 @@ void Process::FindCoreFunctions() {
 }
 
 //-----------------------------------------------------------------------------
-ORBIT_SERIALIZE(Process, 1) {
+ORBIT_SERIALIZE(Process, 2) {
   ORBIT_NVP_VAL(0, m_Name);
   ORBIT_NVP_VAL(0, m_FullName);
   ORBIT_NVP_VAL(0, m_ID);
@@ -556,4 +558,5 @@ ORBIT_SERIALIZE(Process, 1) {
   ORBIT_NVP_VAL(0, m_NameToModuleMap);
   ORBIT_NVP_VAL(0, m_ThreadIds);
   ORBIT_NVP_VAL(1, m_Modules);
+  ORBIT_NVP_VAL(2, m_ThreadNames);
 }

--- a/OrbitCore/ProcessUtils.cpp
+++ b/OrbitCore/ProcessUtils.cpp
@@ -45,13 +45,6 @@ Wow64SuspendThread_t* fn_Wow64SuspendThread =
                                           "Wow64SuspendThread");
 #endif
 
-int IsNumeric(const char* ccharptr_CharacterList) {
-  for (; *ccharptr_CharacterList; ccharptr_CharacterList++)
-    if (*ccharptr_CharacterList < '0' || *ccharptr_CharacterList > '9')
-      return 0;  // false
-  return 1;      // true
-}
-
 //-----------------------------------------------------------------------------
 bool ProcessUtils::Is64Bit(HANDLE hProcess) {
 #ifdef _WIN32
@@ -101,17 +94,6 @@ ProcessList::ProcessList() {}
 void ProcessList::Clear() {
   m_Processes.clear();
   m_ProcessesMap.clear();
-}
-
-//-----------------------------------------------------------------------------
-static std::string FileToString(const std::string& a_FileName) {
-  std::stringstream buffer;
-  std::ifstream inFile(a_FileName);
-  if (!inFile.fail()) {
-    buffer << inFile.rdbuf();
-    inFile.close();
-  }
-  return buffer.str();
 }
 
 //-----------------------------------------------------------------------------
@@ -199,7 +181,7 @@ void ProcessList::Refresh() {
 
   while ((de_DirEntity = readdir(dir_proc))) {
     if (de_DirEntity->d_type == DT_DIR) {
-      if (IsNumeric(de_DirEntity->d_name)) {
+      if (IsNumber(de_DirEntity->d_name)) {
         int pid = atoi(de_DirEntity->d_name);
         auto iter = m_ProcessesMap.find(pid);
         std::shared_ptr<Process> process = nullptr;

--- a/OrbitCore/SamplingProfiler.cpp
+++ b/OrbitCore/SamplingProfiler.cpp
@@ -46,7 +46,10 @@ void SamplingProfiler::StartCapture() {
   Capture::GNumSamples = 0;
   Capture::GNumSamplingTicks = 0;
   Capture::GIsSampling = true;
-  m_Process->EnumerateThreads();
+
+  if (!m_Process->GetIsRemote()) {
+    m_Process->EnumerateThreads();
+  }
 
   m_SamplingTimer.Start();
   m_ThreadUsageTimer.Start();

--- a/OrbitCore/Utils.h
+++ b/OrbitCore/Utils.h
@@ -9,14 +9,17 @@
 #include <xxhash.h>
 
 #include <algorithm>
+#include <cctype>
 #include <cinttypes>
 #include <codecvt>
 #include <functional>
+#include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <map>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -144,6 +147,25 @@ inline std::vector<std::wstring> Tokenize(std::wstring a_String,
   }
 
   return tokens;
+}
+
+//-----------------------------------------------------------------------------
+inline bool IsDigit(const char value) { return std::isdigit(value); }
+
+//-----------------------------------------------------------------------------
+inline bool IsNumber(const std::string_view value) {
+  return std::all_of(value.begin(), value.end(), IsDigit);
+}
+
+//-----------------------------------------------------------------------------
+inline std::string FileToString(const std::string& a_FileName) {
+  std::stringstream buffer;
+  std::ifstream inFile(a_FileName);
+  if (!inFile.fail()) {
+    buffer << inFile.rdbuf();
+    inFile.close();
+  }
+  return buffer.str();
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitCore/Utils.h
+++ b/OrbitCore/Utils.h
@@ -12,8 +12,8 @@
 #include <cctype>
 #include <cinttypes>
 #include <codecvt>
-#include <functional>
 #include <fstream>
+#include <functional>
 #include <iomanip>
 #include <iostream>
 #include <map>
@@ -153,14 +153,15 @@ inline std::vector<std::wstring> Tokenize(std::wstring a_String,
 inline bool IsDigit(const char value) { return std::isdigit(value); }
 
 //-----------------------------------------------------------------------------
-inline bool IsNumber(const std::string_view value) {
+inline bool IsAllDigits(const std::string_view value) {
   return std::all_of(value.begin(), value.end(), IsDigit);
 }
 
 //-----------------------------------------------------------------------------
-inline std::string FileToString(const std::string& a_FileName) {
+inline std::string FileToString(const std::string_view a_FileName) {
+  std::string file_name(a_FileName);
   std::stringstream buffer;
-  std::ifstream inFile(a_FileName);
+  std::ifstream inFile(file_name);
   if (!inFile.fail()) {
     buffer << inFile.rdbuf();
     inFile.close();


### PR DESCRIPTION
This PR adds support for thread names on Linux.
- Implement the Linux version of Process::EnumerateThreads method.
- Thread names are read from the "/proc/-pid-/Task/-tid-/comm" files.
- Moved and modified existing util functions from ProcessUtils.h to Utils.h.
- This does not catch newly created thread's name, will be a subsequent change.