### PR TITLE
Clear string manager on remote after capture

### DIFF
--- a/OrbitCore/ConnectionManager.cpp
+++ b/OrbitCore/ConnectionManager.cpp
@@ -165,6 +165,7 @@ void ConnectionManager::StartCaptureAsRemote(uint32_t pid) {
   }
   Capture::SetTargetProcess(process);
   tracing_session_.Reset();
+  string_manager_->Clear();
   Capture::StartCapture(&tracing_session_);
   server_capture_thread_ = std::make_unique<std::thread>(
       &ConnectionManager::ServerCaptureThreadWorker, this);

--- a/OrbitCore/StringManager.cpp
+++ b/OrbitCore/StringManager.cpp
@@ -24,3 +24,7 @@ bool StringManager::Exists(uint64_t key) {
   std::lock_guard<std::mutex> lock(mutex_);
   return key_to_string_.count(key) > 0;
 }
+void StringManager::Clear() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  key_to_string_.clear();
+}

--- a/OrbitCore/StringManager.h
+++ b/OrbitCore/StringManager.h
@@ -14,6 +14,7 @@ class StringManager {
   void Add(uint64_t key, const std::string_view str);
   std::optional<std::string> Get(uint64_t key);
   bool Exists(uint64_t key);
+  void Clear();
 private:
   absl::flat_hash_map<uint64_t, std::string> key_to_string_;
   std::mutex mutex_;


### PR DESCRIPTION
This ensures that strings are sent again when restarting the ORBIT UI. Before, strings were kept in the map on the remote service and were not sent again. Hence, the newly started UI didn't know about them and couldn't display the right strings. 