### PR TITLE
Add command line flag for GPU tracing to ORBIT collector

### DIFF
--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -7,6 +7,10 @@
 
 #include "UprobesUnwindingVisitor.h"
 #include "absl/strings/str_format.h"
+#include "absl/flags/flag.h"
+
+ABSL_FLAG(bool, trace_gpu_driver_events, false,
+          "Enables tracing of GPU driver tracepoint events");
 
 namespace LinuxTracing {
 
@@ -284,7 +288,7 @@ void TracerThread::Run(
   }
 
   bool gpu_event_open_errors = false;
-  if (trace_gpu_driver_events_) {
+  if (absl::GetFlag(FLAGS_trace_gpu_driver_events)) {
     // We want to trace all GPU activity, hence we pass 'all_cpus' here.
     gpu_event_open_errors = !OpenGpuTracepoints(all_cpus);
   }

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -9,6 +9,8 @@
 #include "absl/strings/str_format.h"
 #include "absl/flags/flag.h"
 
+// TODO: This is a temporary feature flag. Remove this once we enable this
+// globally or have a tracer configuration that is passed to TracerThread.
 ABSL_FLAG(bool, trace_gpu_driver_events, false,
           "Enables tracing of GPU driver tracepoint events");
 

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -107,7 +107,6 @@ class TracerThread {
   bool trace_context_switches_ = true;
   bool trace_callstacks_ = true;
   bool trace_instrumented_functions_ = true;
-  bool trace_gpu_driver_events_ = false;
 
   std::vector<int> tracing_fds_;
   std::vector<PerfEventRingBuffer> ring_buffers_;

--- a/OrbitService/main.cpp
+++ b/OrbitService/main.cpp
@@ -1,9 +1,11 @@
 #include <iostream>
 
 #include "OrbitService.h"
+#include "absl/flags/parse.h"
 
-int main() {
+int main(int argc, char** argv) {
   std::cout << "Starting OrbitService" << std::endl;
+  absl::ParseCommandLine(argc, argv);
   OrbitService service;
   service.Run();
 }


### PR DESCRIPTION
This is also the first command line flag ever, so this adds parsing of command line flags via the absl::flags library. 

Please let me know if I should add other flags for tracing options, happy to do so.