### PR TITLE
Break infinite loop for processes without modules

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -489,11 +489,6 @@ void OrbitApp::ListSessions() {
 }
 
 //-----------------------------------------------------------------------------
-void OrbitApp::SetRemoteProcess(std::shared_ptr<Process> a_Process) {
-  m_ProcessesDataView->SetRemoteProcess(a_Process);
-}
-
-//-----------------------------------------------------------------------------
 void OrbitApp::RefreshCaptureView() {
   NeedsRedraw();
   GOrbitApp->FireRefreshCallbacks();

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -60,7 +60,6 @@ class OrbitApp : public CoreApp {
   void LoadSystrace(const std::string& a_FileName);
   void AppendSystrace(const std::string& a_FileName, uint64_t a_TimeOffset);
   void ListSessions();
-  void SetRemoteProcess(std::shared_ptr<Process> a_Process);
   void RefreshCaptureView() override;
   void RequestRemoteModules(const std::vector<std::string> a_Modules);
   void AddWatchedVariable(Variable* a_Variable);

--- a/OrbitGl/ProcessesDataView.cpp
+++ b/OrbitGl/ProcessesDataView.cpp
@@ -158,20 +158,20 @@ void ProcessesDataView::OnSort(int a_Column,
 //-----------------------------------------------------------------------------
 void ProcessesDataView::OnSelect(int a_Index) {
   m_SelectedProcess = GetProcess(a_Index);
+  if (!m_IsRemote) {
+    m_SelectedProcess->ListModules();
+  } else if (m_SelectedProcess->GetModules().size() == 0) {
+    Message msg(Msg_RemoteProcessRequest);
+    msg.m_Header.m_GenericHeader.m_Address = m_SelectedProcess->GetID();
+    GTcpClient->Send(msg);
+  }
+
   UpdateModuleDataView(m_SelectedProcess);
 }
 
 void ProcessesDataView::UpdateModuleDataView(
     std::shared_ptr<Process> a_Process) {
   if (m_ModulesDataView) {
-    if (!m_IsRemote) {
-      a_Process->ListModules();
-    } else if (a_Process->GetModules().size() == 0) {
-      Message msg(Msg_RemoteProcessRequest);
-      msg.m_Header.m_GenericHeader.m_Address = a_Process->GetID();
-      GTcpClient->Send(msg);
-    }
-
     m_ModulesDataView->SetProcess(a_Process);
     Capture::SetTargetProcess(a_Process);
     GOrbitApp->FireRefreshCallbacks();


### PR DESCRIPTION
Only request modules from the server on select, do not re-request it
while processing result with emoty list of modules.

Bug: http://b/152612326
Test: Build, select a process without modules, select process with
modules.