### PR TITLE
Cleaning up worker threads

### DIFF
--- a/OrbitBase/include/OrbitBase/Logging.h
+++ b/OrbitBase/include/OrbitBase/Logging.h
@@ -23,6 +23,10 @@
             ##__VA_ARGS__);                                            \
   } while (0)
 
+#if defined(_WIN32) && defined(ERROR)
+#undef ERROR
+#endif
+
 #define ERROR(format, ...) LOG("Error: " format, ##__VA_ARGS__)
 
 #define FATAL(format, ...)                \

--- a/OrbitCore/ConnectionManager.h
+++ b/OrbitCore/ConnectionManager.h
@@ -47,8 +47,8 @@ class ConnectionManager {
   LinuxTracingSession tracing_session_;
   std::shared_ptr<StringManager> string_manager_;
 
-  std::unique_ptr<std::thread> thread_;
-  std::unique_ptr<std::thread> server_capture_thread_;
+  std::thread thread_;
+  std::thread server_capture_thread_;
   std::string remote_address_;
   std::atomic<bool> exit_requested_;
   bool is_service_;

--- a/OrbitCore/EventTracer.cpp
+++ b/OrbitCore/EventTracer.cpp
@@ -152,8 +152,7 @@ void EventTracer::Start() {
     return;
   }
 
-  std::thread* thread = new std::thread([&]() { EventTracerThread(); });
-  thread->detach();
+  thread_ = std::thread{[this]() { EventTracerThread(); }};
 }
 
 //-----------------------------------------------------------------------------
@@ -173,6 +172,10 @@ void EventTracer::Stop() {
 
 //-----------------------------------------------------------------------------
 void EventTracer::CleanupTrace() {
+  if (thread_.joinable()) {
+    thread_.join();
+  }
+
   if (ControlTrace(m_TraceHandle, KERNEL_LOGGER_NAME, m_SessionProperties,
                    EVENT_TRACE_CONTROL_STOP) != ERROR_SUCCESS) {
     PrintLastError();

--- a/OrbitCore/EventTracer.h
+++ b/OrbitCore/EventTracer.h
@@ -3,6 +3,8 @@
 //-----------------------------------
 #pragma once
 
+#include <thread>
+
 #ifdef _WIN32
 
 #include <evntrace.h>
@@ -35,6 +37,9 @@ class EventTracer {
   std::atomic<bool> m_IsTracing;
   _EVENT_TRACE_PROPERTIES* m_SessionProperties;
   EventBuffer m_EventBuffer;
+
+ private:
+  std::thread thread_;
 };
 
 extern EventTracer GEventTracer;
@@ -52,6 +57,7 @@ class EventTracer {
  private:
   // TODO: Fix circular dependencies in header files.
   std::shared_ptr<class LinuxTracingHandler> m_LinuxTracer;
+  std::thread thread_;
 };
 
 extern EventTracer GEventTracer;

--- a/OrbitCore/LinuxUtils.h
+++ b/OrbitCore/LinuxUtils.h
@@ -7,7 +7,6 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <thread>
 #include <unordered_map>
 #include <vector>
 

--- a/OrbitCore/TcpClient.h
+++ b/OrbitCore/TcpClient.h
@@ -3,6 +3,7 @@
 //-----------------------------------
 #pragma once
 
+#include <thread>
 #include <vector>
 
 #include "TcpEntity.h"
@@ -15,6 +16,7 @@ class TcpClient : public TcpEntity {
 
   void Connect(const std::string& a_Host);
   void Start() override;
+  void Stop() override;
 
  protected:
   void ClientThread();
@@ -28,6 +30,7 @@ class TcpClient : public TcpEntity {
  private:
   Message m_Message;
   std::vector<char> m_Payload;
+  std::thread workerThread_;
 };
 
 extern std::unique_ptr<TcpClient> GTcpClient;

--- a/OrbitCore/TcpEntity.h
+++ b/OrbitCore/TcpEntity.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <atomic>
+#include <thread>
 #include <type_traits>
 #include <unordered_map>
 #include <vector>
@@ -51,7 +52,7 @@ class TcpEntity {
   virtual ~TcpEntity();
 
   virtual void Start();
-  void Stop();
+  virtual void Stop();
   void FlushSendQueue();
 
   // Note: All Send methods can be called concurrently from multiple threads
@@ -101,7 +102,7 @@ class TcpEntity {
  protected:
   TcpService* m_TcpService;
   TcpSocket* m_TcpSocket;
-  std::thread* m_SenderThread = nullptr;
+  std::thread senderThread_;
   AutoResetEvent m_ConditionVariable;
   LockFreeQueue<TcpPacket> m_SendQueue;
   std::atomic<uint32_t> m_NumQueuedEntries;

--- a/OrbitCore/TcpServer.h
+++ b/OrbitCore/TcpServer.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <functional>
+#include <thread>
 #include <unordered_map>
 
 #include "Core.h"
@@ -48,10 +49,12 @@ class TcpServer : public TcpEntity {
 
  protected:
   class TcpSocket* GetSocket() override final;
-  void ServerThread();
 
  private:
   class tcp_server* m_TcpServer = nullptr;
+  std::thread serverThread_;
+  void ServerThread();
+
   StrCallback m_UiCallback;
   moodycamel::ConcurrentQueue<std::wstring> m_UiLockFreeQueue;
 

--- a/OrbitCore/TimerManager.h
+++ b/OrbitCore/TimerManager.h
@@ -6,6 +6,7 @@
 #include <atomic>
 #include <map>
 #include <memory>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 
@@ -59,7 +60,7 @@ class TimerManager {
   int m_ThreadCounter;
   LockFreeQueue<Timer> m_LockFreeQueue;
   LockFreeQueue<Message> m_LockFreeMessageQueue;
-  std::thread* m_ConsumerThread = nullptr;
+  std::thread consumerThread_;
   bool m_IsClient = false;
 
   typedef std::function<void(Timer&)> TimerAddedCallback;


### PR DESCRIPTION
This PR makes some clean-ups to the worker threads, meaning:

* Stack-allocating thread objects.  Since all these threads call member functions there lifetime is already tied to their parent object. No raw pointers anymore.
* Properly joining threads. Some of these threads haven't been joined properly which lead to UB.
* Unified the threads' function objects. All are lambdas now, no std::bind anymore, no explicit member function pointers.

These changes will help to properly shut down the UI which will be necessary for proper Remote Profiling support.

Tests: Compiles on all platforms. Tested on Windows (UI) and Stadia (Service) with InfiltratorDemo. 