### PR TITLE
Change default build configs

### DIFF
--- a/bootstrap-orbit-ggp.bat
+++ b/bootstrap-orbit-ggp.bat
@@ -48,4 +48,4 @@ if ERRORLEVEL 1 (
   echo "ggp_sdk seems to be installed already. Skipping installation step..."
 )
 
-call build.bat ggp_release ggp_debug
+call build.bat ggp_release

--- a/bootstrap-orbit-ggp.sh
+++ b/bootstrap-orbit-ggp.sh
@@ -23,4 +23,4 @@ else
   echo "ggp_sdk seems to be installed already. Skipping installation step..."
 fi
 
-$DIR/build.sh ggp_release ggp_debug
+$DIR/build.sh ggp_release

--- a/build.bat
+++ b/build.bat
@@ -11,9 +11,8 @@ for %%x in (%*) do (
 )
 
 if %argCount% == 0 (
-    set /a argCount=2
-    set argVec[1]=default_release_x86
-    set argVec[2]=default_release_x64
+    set /a argCount=1
+    set argVec[1]=default_release
 )
 
 
@@ -21,6 +20,7 @@ for /L %%i in (1,1,%argCount%) do (
     set profile=!argVec[%%i]!
 
     set defaultprofile=NO
+    if "!profile!" == "default_release" set defaultprofile=YES
     if "!profile!" == "default_release_x86" set defaultprofile=YES
     if "!profile!" == "default_release_x64" set defaultprofile=YES
 

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-default_profiles=( default_release default_debug )
+default_profiles=( default_release )
 
 if [ "$#" -eq 0 ]; then
   profiles=( "${default_profiles[@]}" )

--- a/conanfile.py
+++ b/conanfile.py
@@ -68,6 +68,10 @@ class OrbitConan(ConanFile):
             raise ConanInvalidConfiguration(
                 "Debian packaging is only supported for GGP builds!")
 
+        if self.options.with_gui and self.settings.arch == "x86":
+            raise ConanInvalidConfiguration(
+                "We don't actively support building the UI for 32bit platforms. Please remove this check in conanfile.py if you still want to do so!")
+
         self.options["abseil"].cxx_standard = 17
         if self.options.with_gui:
             self.options["glew"].system_mesa = self.options.system_mesa

--- a/contrib/conan/configs/windows/profiles/msvc2017_debug
+++ b/contrib/conan/configs/windows/profiles/msvc2017_debug
@@ -1,0 +1,14 @@
+[settings]
+os=Windows
+os_build=Windows
+arch=x86_64
+arch_build=x86_64
+compiler=Visual Studio
+compiler.version=15
+build_type=Debug
+[options]
+OrbitProfiler:system_qt=False
+[build_requires]
+cmake/3.16.4@
+[env]
+CONAN_CMAKE_SYSTEM_VERSION=10.0.18362.0

--- a/contrib/conan/configs/windows/profiles/msvc2017_debug_x86
+++ b/contrib/conan/configs/windows/profiles/msvc2017_debug_x86
@@ -8,6 +8,7 @@ compiler.version=15
 build_type=Debug
 [options]
 OrbitProfiler:system_qt=False
+OrbitProfiler:with_gui=False
 [build_requires]
 cmake/3.16.4@
 [env]

--- a/contrib/conan/configs/windows/profiles/msvc2017_release
+++ b/contrib/conan/configs/windows/profiles/msvc2017_release
@@ -1,0 +1,14 @@
+[settings]
+os=Windows
+os_build=Windows
+arch=x86_64
+arch_build=x86_64
+compiler=Visual Studio
+compiler.version=15
+build_type=Release
+[options]
+OrbitProfiler:system_qt=False
+[build_requires]
+cmake/3.16.4@
+[env]
+CONAN_CMAKE_SYSTEM_VERSION=10.0.18362.0

--- a/contrib/conan/configs/windows/profiles/msvc2017_release_x86
+++ b/contrib/conan/configs/windows/profiles/msvc2017_release_x86
@@ -8,6 +8,7 @@ compiler.version=15
 build_type=Release
 [options]
 OrbitProfiler:system_qt=False
+OrbitProfiler:with_gui=False
 [build_requires]
 cmake/3.16.4@
 [env]

--- a/contrib/conan/configs/windows/profiles/msvc2017_relwithdebinfo
+++ b/contrib/conan/configs/windows/profiles/msvc2017_relwithdebinfo
@@ -1,0 +1,14 @@
+[settings]
+os=Windows
+os_build=Windows
+arch=x86_64
+arch_build=x86_64
+compiler=Visual Studio
+compiler.version=15
+build_type=RelWithDebInfo
+[options]
+OrbitProfiler:system_qt=False
+[build_requires]
+cmake/3.16.4@
+[env]
+CONAN_CMAKE_SYSTEM_VERSION=10.0.18362.0

--- a/contrib/conan/configs/windows/profiles/msvc2017_relwithdebinfo_x86
+++ b/contrib/conan/configs/windows/profiles/msvc2017_relwithdebinfo_x86
@@ -8,6 +8,7 @@ compiler.version=15
 build_type=RelWithDebInfo
 [options]
 OrbitProfiler:system_qt=False
+OrbitProfiler:with_gui=False
 [build_requires]
 cmake/3.16.4@
 [env]

--- a/contrib/conan/configs/windows/profiles/msvc2019_debug
+++ b/contrib/conan/configs/windows/profiles/msvc2019_debug
@@ -1,0 +1,14 @@
+[settings]
+os=Windows
+os_build=Windows
+arch=x86_64
+arch_build=x86_64
+compiler=Visual Studio
+compiler.version=16
+build_type=Debug
+[options]
+OrbitProfiler:system_qt=False
+[build_requires]
+cmake/3.16.4@
+[env]
+CONAN_CMAKE_SYSTEM_VERSION=10.0.18362.0

--- a/contrib/conan/configs/windows/profiles/msvc2019_debug_x86
+++ b/contrib/conan/configs/windows/profiles/msvc2019_debug_x86
@@ -8,6 +8,7 @@ compiler.version=16
 build_type=Debug
 [options]
 OrbitProfiler:system_qt=False
+OrbitProfiler:with_gui=False
 [build_requires]
 cmake/3.16.4@
 [env]

--- a/contrib/conan/configs/windows/profiles/msvc2019_release
+++ b/contrib/conan/configs/windows/profiles/msvc2019_release
@@ -1,0 +1,14 @@
+[settings]
+os=Windows
+os_build=Windows
+arch=x86_64
+arch_build=x86_64
+compiler=Visual Studio
+compiler.version=16
+build_type=Release
+[options]
+OrbitProfiler:system_qt=False
+[build_requires]
+cmake/3.16.4@
+[env]
+CONAN_CMAKE_SYSTEM_VERSION=10.0.18362.0

--- a/contrib/conan/configs/windows/profiles/msvc2019_release_x86
+++ b/contrib/conan/configs/windows/profiles/msvc2019_release_x86
@@ -8,6 +8,7 @@ compiler.version=16
 build_type=Release
 [options]
 OrbitProfiler:system_qt=False
+OrbitProfiler:with_gui=False
 [build_requires]
 cmake/3.16.4@
 [env]

--- a/contrib/conan/configs/windows/profiles/msvc2019_relwithdebinfo
+++ b/contrib/conan/configs/windows/profiles/msvc2019_relwithdebinfo
@@ -1,0 +1,14 @@
+[settings]
+os=Windows
+os_build=Windows
+arch=x86_64
+arch_build=x86_64
+compiler=Visual Studio
+compiler.version=16
+build_type=RelWithDebInfo
+[options]
+OrbitProfiler:system_qt=False
+[build_requires]
+cmake/3.16.4@
+[env]
+CONAN_CMAKE_SYSTEM_VERSION=10.0.18362.0

--- a/contrib/conan/configs/windows/profiles/msvc2019_relwithdebinfo_x86
+++ b/contrib/conan/configs/windows/profiles/msvc2019_relwithdebinfo_x86
@@ -8,6 +8,7 @@ compiler.version=16
 build_type=RelWithDebInfo
 [options]
 OrbitProfiler:system_qt=False
+OrbitProfiler:with_gui=False
 [build_requires]
 cmake/3.16.4@
 [env]


### PR DESCRIPTION
This PR does the following:

* By default (when calling `bootstrap` or `build` without arguments) it builds just one configuration (release build) instead of two
* Building the GUI in 32bits is now discouraged. `conan` will throw an error which can be removed easily in case it is still needed.
* The x86-conan-windows-profiles now default to not build the GUI. 32bit-support is still necessary for building OrbitDll in 32bits.
* Additional conan profiles for Windows have been added. `msvc20{17,19}_{release,debug,relwithdebinfo}` now default to 64bits. Usage of the old profiles `msvc20{17,19}_{release,debug,relwithdebinfo}_x64` is discouraged.