### PR TITLE
Print unwind errors in aggregate form

### DIFF
--- a/OrbitLinuxTracing/LibunwindstackUnwinder.cpp
+++ b/OrbitLinuxTracing/LibunwindstackUnwinder.cpp
@@ -51,9 +51,11 @@ std::vector<unwindstack::FrameData> LibunwindstackUnwinder::Unwind(
   // those callstacks.
   if (unwinder.LastErrorCode() != 0 &&
       unwinder.frames().back().map_name != "[uprobes]") {
+#ifndef NDEBUG
     ERROR("%s at %#016lx",
           LibunwindstackErrorString(unwinder.LastErrorCode()).c_str(),
           unwinder.LastErrorAddress());
+#endif
     return {};
   }
 

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
@@ -22,6 +22,8 @@ void UprobesUnwindingVisitor::visit(SamplePerfEvent* event) {
         CallstackFramesFromLibunwindstackFrames(full_callstack),
         event->GetTimestamp()};
     listener_->OnCallstack(returned_callstack);
+  } else if (unwind_error_counter_ != nullptr) {
+    ++(*unwind_error_counter_);
   }
 }
 

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.h
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.h
@@ -5,6 +5,7 @@
 #include <OrbitLinuxTracing/TracerListener.h>
 
 #include <stack>
+#include <utility>
 
 #include "LibunwindstackUnwinder.h"
 #include "PerfEvent.h"
@@ -43,6 +44,10 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   UprobesUnwindingVisitor& operator=(UprobesUnwindingVisitor&&) = default;
 
   void SetListener(TracerListener* listener) { listener_ = listener; }
+  void SetUnwindErrorCounter(
+      std::shared_ptr<std::atomic<uint64_t>> unwind_error_counter) {
+    unwind_error_counter_ = std::move(unwind_error_counter);
+  }
 
   void visit(SamplePerfEvent* event) override;
   void visit(UprobesPerfEvent* event) override;
@@ -56,6 +61,7 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   LibunwindstackUnwinder unwinder_{};
 
   TracerListener* listener_ = nullptr;
+  std::shared_ptr<std::atomic<uint64_t>> unwind_error_counter_ = nullptr;
 
   static std::vector<CallstackFrame> CallstackFramesFromLibunwindstackFrames(
       const std::vector<unwindstack::FrameData>& libunwindstack_frames);


### PR DESCRIPTION
Remove the overwhelming prints of unwinding errors.
Instead, count and print them with the other event statistics.