### PR TITLE
Fixed abseil linking problem in grpc package recipes

### DIFF
--- a/contrib/conan/recipes/grpc/CMakeLists.txt
+++ b/contrib/conan/recipes/grpc/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(cmake_wrapper)
 
+set(CMAKE_CXX_STANDARD 17)
+
 include(conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 

--- a/contrib/conan/recipes/grpc/conanfile.py
+++ b/contrib/conan/recipes/grpc/conanfile.py
@@ -38,6 +38,7 @@ class grpcConan(ConanFile):
     )
 
     build_requires = (
+        "protoc_installer/3.9.1@bincrafters/stable",
         "grpc_codegen/{}@orbitdeps/stable".format(version),
     )
 
@@ -47,6 +48,8 @@ class grpcConan(ConanFile):
             compiler_version = int(str(self.settings.compiler.version))
             if compiler_version < 14:
                 raise ConanInvalidConfiguration("gRPC can only be built with Visual Studio 2015 or higher.")
+
+        self.options["abseil"].cxx_standard = 17
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])

--- a/contrib/conan/recipes/grpc_codegen/CMakeLists.txt
+++ b/contrib/conan/recipes/grpc_codegen/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(cmake_wrapper)
 
+set(CMAKE_CXX_STANDARD 17)
+
 include(conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 

--- a/contrib/conan/recipes/grpc_codegen/conanfile.py
+++ b/contrib/conan/recipes/grpc_codegen/conanfile.py
@@ -28,7 +28,7 @@ class grpcConan(ConanFile):
     _source_subfolder = "source_subfolder"
     _build_subfolder = "build_subfolder"
 
-    requires = (
+    build_requires = (
         "abseil/20190808@orbitdeps/stable",
         "zlib/1.2.11",
         "openssl/1.0.2t",
@@ -43,6 +43,8 @@ class grpcConan(ConanFile):
             compiler_version = int(str(self.settings.compiler.version))
             if compiler_version < 14:
                 raise ConanInvalidConfiguration("gRPC can only be built with Visual Studio 2015 or higher.")
+
+        self.options["abseil"].cxx_standard = 17
 
     def source(self):
         tools.get(**self.conan_data["sources"][self.version])


### PR DESCRIPTION
Fixes some dependency diamond problems in the grpc packages.
Especially abseil needed extra care.

These packages are not yet in use. Problems occured because I never tried
to include them into the orbit project. My apologies.