### PR TITLE
Replaced CHECK by a branch like it was before.

### DIFF
--- a/OrbitCore/TimerManager.cpp
+++ b/OrbitCore/TimerManager.cpp
@@ -48,8 +48,9 @@ void TimerManager::StartRecording() {
     return;
   }
 
-  CHECK(!consumerThread_.joinable());
-  consumerThread_ = std::thread{[this]() { ConsumeTimers(); }};
+  if (!consumerThread_.joinable()) {
+    consumerThread_ = std::thread{[this]() { ConsumeTimers(); }};
+  }
 
   m_IsRecording = true;
 }


### PR DESCRIPTION
Having this thread running is normal behaviour.

For now I revert to the old behaviour.
For the future it is probably better to start the thread when TimerManager is constructed.