### PR TITLE
Discard samples falling directly inside u(ret?)probes code

### DIFF
--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -50,7 +50,8 @@ void TracerThread::InitUprobesEventProcessor() {
   auto uprobes_unwinding_visitor =
       std::make_unique<UprobesUnwindingVisitor>(ReadMaps(pid_));
   uprobes_unwinding_visitor->SetListener(listener_);
-  uprobes_unwinding_visitor->SetUnwindErrorCounter(stats_.unwind_error_count);
+  uprobes_unwinding_visitor->SetUnwindErrorsAndDiscardedSamplesCounters(
+      stats_.unwind_error_count, stats_.discarded_samples_in_uretprobes_count);
   // Switch between PerfEventProcessor and PerfEventProcessor2 here.
   // PerfEventProcessor2 is supposedly faster but assumes that events from the
   // same perf_event_open ring buffer are already sorted.
@@ -690,6 +691,11 @@ void TracerThread::PrintStatsIfTimerElapsed() {
     uint64_t unwind_error_count = *stats_.unwind_error_count;
     LOG("  unwind errors: %.0f (%.1f%%)", unwind_error_count / actual_window_s,
         100.0 * unwind_error_count / stats_.sample_count);
+    uint64_t discarded_samples_in_uretprobes_count =
+        *stats_.discarded_samples_in_uretprobes_count;
+    LOG("  discarded samples in u(ret)probes: %.0f (%.1f%%)",
+        discarded_samples_in_uretprobes_count / actual_window_s,
+        100.0 * discarded_samples_in_uretprobes_count / stats_.sample_count);
     stats_.Reset();
   }
 }

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -138,6 +138,7 @@ class TracerThread {
       lost_count = 0;
       lost_count_per_buffer.clear();
       *unwind_error_count = 0;
+      *discarded_samples_in_uretprobes_count = 0;
     }
 
     uint64_t event_count_begin_ns = 0;
@@ -149,6 +150,9 @@ class TracerThread {
     absl::flat_hash_map<PerfEventRingBuffer*, uint64_t> lost_count_per_buffer{};
     std::shared_ptr<std::atomic<uint64_t>> unwind_error_count =
         std::make_unique<std::atomic<uint64_t>>(0);
+    std::shared_ptr<std::atomic<uint64_t>>
+        discarded_samples_in_uretprobes_count =
+            std::make_unique<std::atomic<uint64_t>>(0);
   };
 
   static constexpr uint64_t EVENT_STATS_WINDOW_S = 5;

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
@@ -16,13 +16,16 @@ void UprobesUnwindingVisitor::visit(SamplePerfEvent* event) {
   const std::vector<unwindstack::FrameData>& full_callstack =
       unwinder_.Unwind(current_maps_.get(), event->GetRegisters(),
                        event->GetStackData(), event->GetStackSize());
-  if (!full_callstack.empty()) {
+  // Some samples can actually fall inside u(ret)probes code. Discard them,
+  // because when they are unwound successfully the result is wrong.
+  if (!full_callstack.empty() &&
+      full_callstack.front().map_name != "[uprobes]") {
     Callstack returned_callstack{
         event->GetTid(),
         CallstackFramesFromLibunwindstackFrames(full_callstack),
         event->GetTimestamp()};
     listener_->OnCallstack(returned_callstack);
-  } else if (unwind_error_counter_ != nullptr) {
+  } else if (full_callstack.empty() && unwind_error_counter_ != nullptr) {
     ++(*unwind_error_counter_);
   }
 }

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.h
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.h
@@ -44,9 +44,14 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   UprobesUnwindingVisitor& operator=(UprobesUnwindingVisitor&&) = default;
 
   void SetListener(TracerListener* listener) { listener_ = listener; }
-  void SetUnwindErrorCounter(
-      std::shared_ptr<std::atomic<uint64_t>> unwind_error_counter) {
+
+  void SetUnwindErrorsAndDiscardedSamplesCounters(
+      std::shared_ptr<std::atomic<uint64_t>> unwind_error_counter,
+      std::shared_ptr<std::atomic<uint64_t>>
+          discarded_samples_in_uretprobes_counter) {
     unwind_error_counter_ = std::move(unwind_error_counter);
+    discarded_samples_in_uretprobes_counter_ =
+        std::move(discarded_samples_in_uretprobes_counter);
   }
 
   void visit(SamplePerfEvent* event) override;
@@ -62,6 +67,8 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
 
   TracerListener* listener_ = nullptr;
   std::shared_ptr<std::atomic<uint64_t>> unwind_error_counter_ = nullptr;
+  std::shared_ptr<std::atomic<uint64_t>>
+      discarded_samples_in_uretprobes_counter_ = nullptr;
 
   static std::vector<CallstackFrame> CallstackFramesFromLibunwindstackFrames(
       const std::vector<unwindstack::FrameData>& libunwindstack_frames);


### PR DESCRIPTION
This is rare but can happen when instrumenting tiny functions called very
frequently.
While this seems like throwing away information that might be useful,
when such samples are unwound successfully, the result of unwinding is wrong
(and weird, alternating one frame looking correct and the next at an unknown
location).
Note that without patching the stack with saved return addresses from uprobes
those samples are not unwound successfully in the first place, but it's possible
that with this kind of special samples stack patching should be done
differently.
Possibly not worth investigating deeper though.
See b/153026037.