### PR TITLE
Regression fix: Crashed when connection got refused.

### DIFF
--- a/OrbitCore/ConnectionManager.cpp
+++ b/OrbitCore/ConnectionManager.cpp
@@ -382,6 +382,7 @@ void ConnectionManager::SendRemoteProcess(TcpEntity* tcp_entity, uint32_t pid) {
 void ConnectionManager::ConnectionThreadWorker() {
   while (!exit_requested_) {
     if (!GTcpClient->IsValid()) {
+      GTcpClient->Stop();
       GTcpClient->Connect(remote_address_);
       GTcpClient->Start();
     } else {

--- a/OrbitCore/TcpClient.cpp
+++ b/OrbitCore/TcpClient.cpp
@@ -72,7 +72,10 @@ void TcpClient::Connect(const std::string& a_Host) {
 }
 
 void TcpClient::Stop() {
-  if (workerThread_.joinable()) {
+  const bool inWorkerThread = std::this_thread::get_id()
+          == workerThread_.get_id();
+
+  if (!inWorkerThread && workerThread_.joinable()) {
     CHECK(m_TcpService);
     CHECK(m_TcpService->m_IoService);
     m_TcpService->m_IoService->stop();

--- a/OrbitCore/TimerManager.cpp
+++ b/OrbitCore/TimerManager.cpp
@@ -44,6 +44,8 @@ TimerManager::~TimerManager() {}
 
 //-----------------------------------------------------------------------------
 void TimerManager::StartRecording() {
+  CHECK(!m_IsClient);
+
   if (m_IsRecording) {
     return;
   }
@@ -57,15 +59,20 @@ void TimerManager::StartRecording() {
 
 //-----------------------------------------------------------------------------
 void TimerManager::StopRecording() {
+  CHECK(!m_IsClient);
   m_IsRecording = false;
   FlushQueue();
 }
 
 //-----------------------------------------------------------------------------
-void TimerManager::StartClient() { m_IsRecording = true; }
+void TimerManager::StartClient() {
+  CHECK(m_IsClient);
+  m_IsRecording = true;
+}
 
 //-----------------------------------------------------------------------------
 void TimerManager::StopClient() {
+  CHECK(m_IsClient);
   m_IsRecording = false;
   GTimerManager->FlushQueue();
 


### PR DESCRIPTION
Fixes a regression which was introduced by my thread changes.

TcpClient::Stop is can be called from workerThread_ which resulted in a dead lock.

The fix introduces a check for the currently executing thread and avoids the
join if the code is running in the very same thread.

Test: Manual testing in the connection-refused and the success case.