### PR TITLE
Increase fake thread id for GPU tracks to a much higher number 

### DIFF
--- a/OrbitCore/LinuxTracingHandler.h
+++ b/OrbitCore/LinuxTracingHandler.h
@@ -60,7 +60,7 @@ class LinuxTracingHandler : LinuxTracing::TracerListener {
   absl::flat_hash_map<std::string, pid_t> timeline_to_thread_id_;
   // TODO: This is a hack to reuse thread tracks in the UI to show GPU events.
   // This needs to be fixed.
-  pid_t current_timeline_thread_id_ = 100000;
+  pid_t current_timeline_thread_id_ = 1'000'000'000;
 };
 
 #endif  // ORBIT_CORE_LINUX_TRACING_HANDLER_H_

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -98,7 +98,7 @@ Color ThreadTrack::GetColor(ThreadID a_TID) {
   };
 
   // This is a GPU thread track.
-  constexpr ThreadID kMinGpuThreadId = 100000;
+  constexpr ThreadID kMinGpuThreadId = 1'000'000'000;
   if (a_TID >= kMinGpuThreadId) {
     const Color gray(100, 100, 100, 255);
     return gray;


### PR DESCRIPTION
This is done to avoid conflicts with actual CPU thread ids (depending on max_pid, this can happen). It's still a temporary solution, long-term we want to replace the hack by using a proper GPU track in the UI. 