### PR TITLE
Increase soft limit on max open files

### DIFF
--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -317,6 +317,10 @@ void TracerThread::Run(
     cpuset_cpus = all_cpus;
   }
 
+  // As we open two perf_event_open file descriptors (uprobe and uretprobe) per
+  // cpu per instrumented function, increase the maximum number of open files.
+  SetMaxOpenFilesSoftLimit(GetMaxOpenFilesHardLimit());
+
   bool perf_event_open_errors = false;
 
   if (trace_context_switches_) {

--- a/OrbitLinuxTracing/Utils.h
+++ b/OrbitLinuxTracing/Utils.h
@@ -31,6 +31,16 @@ std::vector<int> ParseCpusetCpus(const std::string& cpuset_cpus_content);
 
 std::vector<int> GetCpusetCpus(pid_t pid);
 
+// Looks up the tracepoint id for the given category (example: "sched")
+// and name (example: "sched_waking"). Returns the tracepoint id or
+// -1 in case of any errors.
+int GetTracepointId(const char* tracepoint_category,
+                    const char* tracepoint_name);
+
+uint64_t GetMaxOpenFilesHardLimit();
+
+bool SetMaxOpenFilesSoftLimit(uint64_t soft_limit);
+
 #if defined(__x86_64__)
 
 #define READ_ONCE(x) (*(volatile typeof(x)*)&x)
@@ -51,12 +61,6 @@ std::vector<int> GetCpusetCpus(pid_t pid);
   })
 
 #endif
-
-// Looks up the tracepoint id for the given category (example: "sched")
-// and name (example: "sched_waking"). Returns the tracepoint id or
-// -1 in case of any errors.
-int GetTracepointId(const char* tracepoint_category,
-                    const char* tracepoint_name);
 
 }  // namespace LinuxTracing
 


### PR DESCRIPTION
This is because we open two perf_event_open file descriptors per cpu per
instrumented function.
See b/153086949.