### PR TITLE
Some refactoring and fix some OrbitQt crashes on quit

### DIFF
--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -210,7 +210,10 @@ void Capture::StopCapture() {
   } else if (Capture::IsRemote()) {
     Capture::GSamplingProfiler->StopCapture();
     Capture::GSamplingProfiler->ProcessSamples();
-    GCoreApp->RefreshCaptureView();
+
+    if (GCoreApp != nullptr) {
+      GCoreApp->RefreshCaptureView();
+    }
   }
 
   if (!GInjected) {
@@ -219,7 +222,9 @@ void Capture::StopCapture() {
 
   TcpEntity* tcpEntity = Capture::GetMainTcpEntity();
   tcpEntity->Send(Msg_StopCapture);
-  GTimerManager->StopRecording();
+  if (GTimerManager) {
+    GTimerManager->StopRecording();
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -422,8 +422,10 @@ bool Capture::IsCapturing() {
 
 //-----------------------------------------------------------------------------
 TcpEntity* Capture::GetMainTcpEntity() {
-  return Capture::IsRemote() ? (TcpEntity*)GTcpClient.get()
-                             : (TcpEntity*)GTcpServer;
+  if (Capture::IsRemote()) {
+    return GTcpClient.get();
+  }
+  return GTcpServer.get();
 }
 
 //-----------------------------------------------------------------------------
@@ -601,7 +603,8 @@ std::shared_ptr<CallStack> Capture::GetCallstack(CallstackID a_ID) {
 //-----------------------------------------------------------------------------
 void Capture::CheckForUnrealSupport() {
   GUnrealSupported = GCoreApp != nullptr &&
-      GCoreApp->GetUnrealSupportEnabled() && GOrbitUnreal.HasFnameInfo();
+                     GCoreApp->GetUnrealSupportEnabled() &&
+                     GOrbitUnreal.HasFnameInfo();
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitCore/ConnectionManager.cpp
+++ b/OrbitCore/ConnectionManager.cpp
@@ -39,7 +39,7 @@
 ConnectionManager::ConnectionManager()
     : exit_requested_(false),
       is_service_(false),
-      tracing_session_(GTcpServer) {}
+      tracing_session_(GTcpServer.get()) {}
 
 ConnectionManager::~ConnectionManager() {
   StopThread();
@@ -203,7 +203,7 @@ void ConnectionManager::SetupServerCallbacks() {
         uint32_t pid =
             static_cast<uint32_t>(msg.m_Header.m_GenericHeader.m_Address);
 
-        SendRemoteProcess(GTcpServer, pid);
+        SendRemoteProcess(GTcpServer.get(), pid);
       });
 
   GTcpServer->AddMainThreadCallback(
@@ -397,7 +397,7 @@ void ConnectionManager::ConnectionThreadWorker() {
 void ConnectionManager::RemoteThreadWorker() {
   while (!exit_requested_) {
     if (GTcpServer && GTcpServer->HasConnection()) {
-      SendProcesses(GTcpServer);
+      SendProcesses(GTcpServer.get());
     }
 
     Sleep(2000);

--- a/OrbitCore/LinuxTracingSession.cpp
+++ b/OrbitCore/LinuxTracingSession.cpp
@@ -34,8 +34,8 @@ void LinuxTracingSession::SetStringManager(
   string_manager_ = string_manager;
 }
 
-void LinuxTracingSession::SendKeyAndString(
-    uint64_t key, const std::string& str) {
+void LinuxTracingSession::SendKeyAndString(uint64_t key,
+                                           const std::string& str) {
   KeyAndString key_and_string;
   key_and_string.key = key;
   key_and_string.str = str;
@@ -45,7 +45,7 @@ void LinuxTracingSession::SendKeyAndString(
     std::string message_data = SerializeObjectBinary(key_and_string);
     // TODO: Remove networking from here.
     tcp_server_->Send(Msg_KeyAndString, message_data.c_str(),
-                     message_data.size());
+                      message_data.size());
     string_manager_->Add(key, str);
   }
 }

--- a/OrbitCore/LinuxTracingSession.h
+++ b/OrbitCore/LinuxTracingSession.h
@@ -7,7 +7,6 @@
 #include "ScopeTimer.h"
 #include "StringManager.h"
 #include "TcpServer.h"
-
 #include "absl/synchronization/mutex.h"
 
 // This class stores information about tracing session

--- a/OrbitCore/TcpClient.cpp
+++ b/OrbitCore/TcpClient.cpp
@@ -34,7 +34,7 @@ TcpClient::TcpClient() {}
 TcpClient::TcpClient(const std::string& a_Host) { Connect(a_Host); }
 
 //-----------------------------------------------------------------------------
-TcpClient::~TcpClient() {}
+TcpClient::~TcpClient() { Stop(); }
 
 //-----------------------------------------------------------------------------
 void TcpClient::Connect(const std::string& a_Host) {
@@ -72,8 +72,8 @@ void TcpClient::Connect(const std::string& a_Host) {
 }
 
 void TcpClient::Stop() {
-  const bool inWorkerThread = std::this_thread::get_id()
-          == workerThread_.get_id();
+  const bool inWorkerThread =
+      std::this_thread::get_id() == workerThread_.get_id();
 
   if (!inWorkerThread && workerThread_.joinable()) {
     CHECK(m_TcpService);

--- a/OrbitCore/TcpServer.cpp
+++ b/OrbitCore/TcpServer.cpp
@@ -21,7 +21,7 @@
 #include "TimerManager.h"
 #include "VariableTracing.h"
 
-TcpServer* GTcpServer;
+std::unique_ptr<TcpServer> GTcpServer;
 
 //-----------------------------------------------------------------------------
 TcpServer::TcpServer() : m_TcpServer(nullptr) {

--- a/OrbitCore/TcpServer.h
+++ b/OrbitCore/TcpServer.h
@@ -72,4 +72,4 @@ class TcpServer : public TcpEntity {
   ULONG64 m_NumMessagesFromPreviousSession;
 };
 
-extern TcpServer* GTcpServer;
+extern std::unique_ptr<TcpServer> GTcpServer;

--- a/OrbitCore/TimerManager.cpp
+++ b/OrbitCore/TimerManager.cpp
@@ -40,7 +40,7 @@ TimerManager::TimerManager(bool a_IsClient)
 }
 
 //-----------------------------------------------------------------------------
-TimerManager::~TimerManager() {}
+TimerManager::~TimerManager() { Stop(); }
 
 //-----------------------------------------------------------------------------
 void TimerManager::StartRecording() {

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -535,6 +535,9 @@ int OrbitApp::OnExit() {
   GParams.Save();
   GTimerManager = nullptr;
 
+  ConnectionManager::Get().Stop();
+  GTcpClient->Stop();
+
   if (GOrbitApp->HasTcpServer()) {
     GTcpServer->Stop();
   }

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -270,4 +270,4 @@ class OrbitApp : public CoreApp {
 };
 
 //-----------------------------------------------------------------------------
-extern class OrbitApp* GOrbitApp;
+extern std::unique_ptr<OrbitApp> GOrbitApp;

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -152,7 +152,7 @@ void CaptureSerializer::Load(const std::wstring a_FileName) {
     // Sampling profiler
     archive(Capture::GSamplingProfiler);
     Capture::GSamplingProfiler->SortByThreadUsage();
-    GOrbitApp->AddSamplingReport(Capture::GSamplingProfiler, GOrbitApp);
+    GOrbitApp->AddSamplingReport(Capture::GSamplingProfiler, GOrbitApp.get());
     Capture::GSamplingProfiler->SetLoadedFromFile(true);
 
     // Event buffer

--- a/OrbitService/OrbitService.cpp
+++ b/OrbitService/OrbitService.cpp
@@ -5,13 +5,13 @@
 #include "Capture.h"
 #include "ConnectionManager.h"
 #include "Core.h"
-#include "TimerManager.h"
 #include "TcpServer.h"
+#include "TimerManager.h"
 
 OrbitService::OrbitService() {
   // TODO: these should be a private fields.
   GTimerManager = std::make_unique<TimerManager>();
-  GTcpServer = new TcpServer();
+  GTcpServer = std::make_unique<TcpServer>();
   Capture::Init();
 
   GTcpServer->Start(Capture::GCapturePort);
@@ -25,4 +25,3 @@ void OrbitService::Run() {
     Sleep(16);
   }
 }
-


### PR DESCRIPTION
Hi, 

This PR is two commits, 1. refactoring of some globals to use smart pointers instead of c-style pointers and 2. fixes for crashes when the user quits OrbitQt. 

This is a pre step to the ggp integration, which is supposed to connect, disconnect and reconnect to stadia instances. Fixing the crashes is a necessary step to enable the closing and opening of the OrbitQt main window without ckosing the whole application. 

A proper refactoring and restructuring of OrbitQt would be better, but also a bigger undertaking. 