### PR TITLE
Grey out all context switches from processes other than the target

### DIFF
--- a/OrbitCore/ContextSwitch.cpp
+++ b/OrbitCore/ContextSwitch.cpp
@@ -8,16 +8,18 @@
 
 //-----------------------------------------------------------------------------
 ContextSwitch::ContextSwitch(SwitchType a_Type)
-    : m_ThreadId(0),
+    : m_ProcessId(0),
+      m_ThreadId(0),
       m_Type(a_Type),
       m_Time(0),
       m_ProcessorIndex(0xFF),
       m_ProcessorNumber(0xFF) {}
 
 //-----------------------------------------------------------------------------
-ContextSwitch::~ContextSwitch() {}
+ContextSwitch::~ContextSwitch() = default;
 
 ORBIT_SERIALIZE(ContextSwitch, 0) {
+  ORBIT_NVP_VAL(0, m_ProcessId);
   ORBIT_NVP_VAL(0, m_ThreadId);
   ORBIT_NVP_VAL(0, m_Type);
   ORBIT_NVP_VAL(0, m_Time);

--- a/OrbitCore/ContextSwitch.h
+++ b/OrbitCore/ContextSwitch.h
@@ -10,9 +10,10 @@
 struct ContextSwitch {
  public:
   enum SwitchType { In, Out, Invalid };
-  ContextSwitch(SwitchType a_Type = Invalid);
+  explicit ContextSwitch(SwitchType a_Type = Invalid);
   ~ContextSwitch();
 
+  uint32_t m_ProcessId;
   uint32_t m_ThreadId;
   SwitchType m_Type;
   uint64_t m_Time;
@@ -29,9 +30,3 @@ struct ContextSwitch {
   ORBIT_SERIALIZABLE;
 };
 #pragma pack(pop)
-// static_assert(sizeof(ContextSwitch) == 19);
-// static_assert(offsetof(ContextSwitch, m_ThreadId) == 0);
-// static_assert(offsetof(ContextSwitch, m_Type) == 4);
-// static_assert(offsetof(ContextSwitch, m_Time) == 8);
-// static_assert(offsetof(ContextSwitch, m_ProcessorIndex) == 16);
-// static_assert(offsetof(ContextSwitch, m_ProcessorNumber) == 18);

--- a/OrbitCore/LinuxTracingHandler.cpp
+++ b/OrbitCore/LinuxTracingHandler.cpp
@@ -76,6 +76,7 @@ void LinuxTracingHandler::OnContextSwitchIn(
   ++(*num_context_switches_);
 
   ContextSwitch context_switch(ContextSwitch::In);
+  context_switch.m_ProcessId = context_switch_in.GetPid();
   context_switch.m_ThreadId = context_switch_in.GetTid();
   context_switch.m_Time = context_switch_in.GetTimestampNs();
   context_switch.m_ProcessorIndex = context_switch_in.GetCore();
@@ -89,6 +90,7 @@ void LinuxTracingHandler::OnContextSwitchOut(
   ++(*num_context_switches_);
 
   ContextSwitch context_switch(ContextSwitch::Out);
+  context_switch.m_ProcessId = context_switch_out.GetPid();
   context_switch.m_ThreadId = context_switch_out.GetTid();
   context_switch.m_Time = context_switch_out.GetTimestampNs();
   context_switch.m_ProcessorIndex = context_switch_out.GetCore();

--- a/OrbitCore/LinuxTracingSessionTests.cpp
+++ b/OrbitCore/LinuxTracingSessionTests.cpp
@@ -30,6 +30,7 @@ TEST(LinuxTracingSession, ContextSwitches) {
 
   {
     ContextSwitch context_switch;
+    context_switch.m_ProcessId = 1;
     context_switch.m_ThreadId = 1;
     context_switch.m_Type = ContextSwitch::Out;
     context_switch.m_Time = 87;
@@ -41,7 +42,7 @@ TEST(LinuxTracingSession, ContextSwitches) {
 
   {
     ContextSwitch context_switch;
-
+    context_switch.m_ProcessId = 1;
     context_switch.m_ThreadId = 2;
     context_switch.m_Type = ContextSwitch::In;
     context_switch.m_Time = 78;
@@ -57,11 +58,13 @@ TEST(LinuxTracingSession, ContextSwitches) {
 
   EXPECT_EQ(context_switches.size(), 2);
 
+  EXPECT_EQ(context_switches[0].m_ProcessId, 1);
   EXPECT_EQ(context_switches[0].m_ThreadId, 1);
   EXPECT_EQ(context_switches[0].m_Time, 87);
   EXPECT_EQ(context_switches[0].m_ProcessorIndex, 7);
   EXPECT_EQ(context_switches[0].m_ProcessorNumber, 8);
 
+  EXPECT_EQ(context_switches[1].m_ProcessId, 1);
   EXPECT_EQ(context_switches[1].m_ThreadId, 2);
   EXPECT_EQ(context_switches[1].m_Time, 78);
   EXPECT_EQ(context_switches[1].m_ProcessorIndex, 17);
@@ -69,7 +72,7 @@ TEST(LinuxTracingSession, ContextSwitches) {
 
   {
     ContextSwitch context_switch;
-
+    context_switch.m_ProcessId = 11;
     context_switch.m_ThreadId = 12;
     context_switch.m_Type = ContextSwitch::Out;
     context_switch.m_Time = 187;
@@ -85,6 +88,7 @@ TEST(LinuxTracingSession, ContextSwitches) {
 
   EXPECT_EQ(context_switches.size(), 1);
 
+  EXPECT_EQ(context_switches[0].m_ProcessId, 11);
   EXPECT_EQ(context_switches[0].m_ThreadId, 12);
   EXPECT_EQ(context_switches[0].m_Time, 187);
   EXPECT_EQ(context_switches[0].m_ProcessorIndex, 27);
@@ -96,6 +100,7 @@ TEST(LinuxTracingSession, Timers) {
 
   {
     Timer timer;
+    timer.m_PID = 1;
     timer.m_TID = 1;
     timer.m_Depth = 0;
     timer.m_SessionID = 42;
@@ -113,7 +118,7 @@ TEST(LinuxTracingSession, Timers) {
 
   {
     Timer timer;
-
+    timer.m_PID = 1;
     timer.m_TID = 2;
     timer.m_Depth = 0;
     timer.m_SessionID = 42;
@@ -135,6 +140,7 @@ TEST(LinuxTracingSession, Timers) {
 
   EXPECT_EQ(timers.size(), 2);
 
+  EXPECT_EQ(timers[0].m_PID, 1);
   EXPECT_EQ(timers[0].m_TID, 1);
   EXPECT_EQ(timers[0].m_Depth, 0);
   EXPECT_EQ(timers[0].m_SessionID, 42);
@@ -146,6 +152,7 @@ TEST(LinuxTracingSession, Timers) {
   EXPECT_EQ(timers[0].m_Start, 800);
   EXPECT_EQ(timers[0].m_End, 900);
 
+  EXPECT_EQ(timers[1].m_PID, 1);
   EXPECT_EQ(timers[1].m_TID, 2);
   EXPECT_EQ(timers[1].m_Depth, 0);
   EXPECT_EQ(timers[1].m_SessionID, 42);
@@ -160,6 +167,7 @@ TEST(LinuxTracingSession, Timers) {
   // Check that the vector is reset, even if it was not empty
   {
     Timer timer;
+    timer.m_PID = 11;
     timer.m_TID = 12;
     timer.m_Depth = 10;
     timer.m_SessionID = 42;
@@ -181,6 +189,7 @@ TEST(LinuxTracingSession, Timers) {
   EXPECT_FALSE(session.ReadAllTimers(&timers));
   EXPECT_EQ(timers.size(), 1);
 
+  EXPECT_EQ(timers[0].m_PID, 11);
   EXPECT_EQ(timers[0].m_TID, 12);
   EXPECT_EQ(timers[0].m_Depth, 10);
   EXPECT_EQ(timers[0].m_SessionID, 42);
@@ -306,6 +315,7 @@ TEST(LinuxTracingSession, Reset) {
 
   {
     ContextSwitch context_switch;
+    context_switch.m_ProcessId = 1;
     context_switch.m_ThreadId = 1;
     context_switch.m_Type = ContextSwitch::Out;
     context_switch.m_Time = 87;
@@ -317,6 +327,7 @@ TEST(LinuxTracingSession, Reset) {
 
   {
     Timer timer;
+    timer.m_PID = 1;
     timer.m_TID = 1;
     timer.m_Depth = 0;
     timer.m_SessionID = 42;

--- a/OrbitCore/ScopeTimer.h
+++ b/OrbitCore/ScopeTimer.h
@@ -16,7 +16,8 @@ extern thread_local size_t CurrentDepth;
 class Timer {
  public:
   Timer()
-      : m_TID(0),
+      : m_PID(0),
+        m_TID(0),
         m_Depth(0),
         m_SessionID(-1),
         m_Type(NONE),
@@ -74,6 +75,7 @@ class Timer {
  public:
   // Needs to have to exact same layout in win32/x64, debug/release
 
+  uint32_t m_PID;
   // Thread ID. For timers that represent CPU activity, this is the
   // thread id, for GPU activity, this is an artificial thread id
   // that is larger than any CPU thread id and is in 1:1 relation to
@@ -92,17 +94,6 @@ class Timer {
   uint32_t m_SubmitTID;
 };
 #pragma pack(pop)
-// static_assert(sizeof(Timer) == 56);
-// static_assert(offsetof(Timer, m_TID) == 0);
-// static_assert(offsetof(Timer, m_Depth) == 4);
-// static_assert(offsetof(Timer, m_SessionID) == 5);
-// static_assert(offsetof(Timer, m_Type) == 6);
-// static_assert(offsetof(Timer, m_Processor) == 7);
-// static_assert(offsetof(Timer, m_CallstackHash) == 8);
-// static_assert(offsetof(Timer, m_FunctionAddress) == 16);
-// static_assert(offsetof(Timer, m_UserData) == 24);
-// static_assert(offsetof(Timer, m_Start) == 40);
-// static_assert(offsetof(Timer, m_End) == 48);
 
 //-----------------------------------------------------------------------------
 class ScopeTimer {

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -48,11 +48,10 @@ CaptureWindow::CaptureWindow() {
   m_WorldMaxY = 0;
   m_ProcessX = 0;
 
-  GTimerManager->m_TimerAddedCallbacks.push_back(
-      [=](Timer& a_Timer) { this->OnTimerAdded(a_Timer); });
-  GTimerManager->m_ContextSwitchAddedCallback = [=](const ContextSwitch& a_CS) {
-    this->OnContextSwitchAdded(a_CS);
-  };
+  GTimerManager->m_TimerAddedCallbacks.emplace_back(
+      [this](Timer& a_Timer) { this->OnTimerAdded(a_Timer); });
+  GTimerManager->m_ContextSwitchAddedCallback =
+      [this](const ContextSwitch& a_CS) { this->OnContextSwitchAdded(a_CS); };
 
   m_HoverDelayMs = 300;
   m_CanHover = false;
@@ -760,8 +759,8 @@ void CaptureWindow::DrawStatus() {
   int PosY = (int)s_PosY;
   int LeftY = (int)s_PosY;
 
-  m_TextRenderer.AddText2D(" Press 'H' for help", s_PosX, LeftY, Z_VALUE_TEXT_UI,
-                           s_Color);
+  m_TextRenderer.AddText2D(" Press 'H' for help", s_PosX, LeftY,
+                           Z_VALUE_TEXT_UI, s_Color);
   LeftY += s_IncY;
 
   if (Capture::GInjected) {

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -4,8 +4,9 @@
 
 #include "TimeGraph.h"
 
-#include <algorithm>
 #include <OrbitBase/Logging.h>
+
+#include <algorithm>
 
 #include "App.h"
 #include "Batcher.h"
@@ -305,6 +306,7 @@ void TimeGraph::AddContextSwitch(const ContextSwitch& a_CS) {
           // When a context switch out is caused by a thread exiting, the
           // perf_event_open event has pid and tid set to -1: hence, use pid and
           // tid from the context switch in.
+          timer.m_PID = lastCS.m_ProcessId;
           timer.m_TID = lastCS.m_ThreadId;
           timer.m_Processor = static_cast<int8_t>(lastCS.m_ProcessorIndex);
           timer.m_SessionID = Message::GSessionID;
@@ -329,6 +331,7 @@ void TimeGraph::AddContextSwitch(const ContextSwitch& a_CS) {
           // When a context switch out is caused by a thread exiting, the
           // perf_event_open event has pid and tid set to -1: hence, use pid and
           // tid from the context switch in.
+          timer.m_PID = lastCS.m_ProcessId;
           timer.m_TID = lastCS.m_ThreadId;
           timer.m_SessionID = Message::GSessionID;
           timer.SetType(Timer::THREAD_ACTIVITY);
@@ -545,6 +548,10 @@ void TimeGraph::UpdatePrimitives(bool a_Picking) {
 
           bool isContextSwitch = timer.IsType(Timer::THREAD_ACTIVITY);
           bool isVisibleWidth = NormalizedLength * m_Canvas->getWidth() > 1;
+          bool isSameProcessIdAsTarget =
+              isCore && Capture::GTargetProcess != nullptr
+                  ? timer.m_PID == Capture::GTargetProcess->GetID()
+                  : true;
           bool isSameThreadIdAsSelected =
               isCore && (timer.m_TID == Capture::GSelectedThreadId);
           bool isInactive =
@@ -587,9 +594,13 @@ void TimeGraph::UpdatePrimitives(bool a_Picking) {
             col[2] = coeff * col[2];
           }
 
-          col = isSelected
-                    ? selectionColor
-                    : isSameThreadIdAsSelected ? col : isInactive ? grey : col;
+          if (isSelected) {
+            col = selectionColor;
+          } else if (!isSameThreadIdAsSelected &&
+                     (isInactive || !isSameProcessIdAsTarget)) {
+            col = grey;
+          }
+
           textBox.SetColor(col[0], col[1], col[2]);
           static int oddAlpha = 210;
           if (!(timer.m_Depth & 0x1)) {
@@ -864,8 +875,7 @@ void TimeGraph::UpdateThreadIds() {
     for (auto& pair : sortedThreads) {
       // Scheduling information is held in thread "0", show it last.
       // TODO: Make a proper "SchedTrack" instead of hack.
-      if(pair.first != 0)
-        sortedThreadIds.push_back(pair.first);
+      if (pair.first != 0) sortedThreadIds.push_back(pair.first);
     }
 
     // Then show threads sorted by number of events

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -302,8 +302,11 @@ void TimeGraph::AddContextSwitch(const ContextSwitch& a_CS) {
           Timer timer;
           timer.m_Start = lastCS.m_Time;
           timer.m_End = a_CS.m_Time;
-          timer.m_TID = a_CS.m_ThreadId;
-          timer.m_Processor = (int8_t)a_CS.m_ProcessorIndex;
+          // When a context switch out is caused by a thread exiting, the
+          // perf_event_open event has pid and tid set to -1: hence, use pid and
+          // tid from the context switch in.
+          timer.m_TID = lastCS.m_ThreadId;
+          timer.m_Processor = static_cast<int8_t>(lastCS.m_ProcessorIndex);
           timer.m_SessionID = Message::GSessionID;
           timer.SetType(Timer::CORE_ACTIVITY);
 
@@ -323,7 +326,10 @@ void TimeGraph::AddContextSwitch(const ContextSwitch& a_CS) {
           Timer timer;
           timer.m_Start = lastCS.m_Time;
           timer.m_End = a_CS.m_Time;
-          timer.m_TID = a_CS.m_ThreadId;
+          // When a context switch out is caused by a thread exiting, the
+          // perf_event_open event has pid and tid set to -1: hence, use pid and
+          // tid from the context switch in.
+          timer.m_TID = lastCS.m_ThreadId;
           timer.m_SessionID = Message::GSessionID;
           timer.SetType(Timer::THREAD_ACTIVITY);
 

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -514,6 +514,8 @@ void TracerThread::ProcessContextSwitchCpuWideEvent(
   if (tid != 0) {
     // TODO: Consider deferring context switches.
     if (event.IsSwitchOut()) {
+      // Careful: when a switch out is caused by the thread exiting, pid and tid
+      // have value -1.
       listener_->OnContextSwitchOut(ContextSwitchOut(tid, cpu, time));
     } else {
       listener_->OnContextSwitchIn(ContextSwitchIn(tid, cpu, time));

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -512,6 +512,7 @@ void TracerThread::ProcessContextSwitchCpuWideEvent(
 
   // Switches with pid/tid 0 are associated with idle state, discard them.
   if (tid != 0) {
+    // TODO: Consider deferring context switches.
     if (event.IsSwitchOut()) {
       listener_->OnContextSwitchOut(ContextSwitchOut(tid, cpu, time));
     } else {
@@ -599,7 +600,7 @@ void TracerThread::ProcessSampleEvent(const perf_event_header& header,
     ++stats_.uprobes_count;
 
   } else if (is_gpu_event) {
-    // TODO: Consider deferring events.
+    // TODO: Consider deferring GPU events.
     auto event = ConsumeSampleRaw(ring_buffer, header);
     // Do not filter GPU tracepoint events based on pid as we want to have
     // visibility into all GPU activity across the system.

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -489,14 +489,15 @@ void TracerThread::ProcessContextSwitchEvent(const perf_event_header& header,
                                              PerfEventRingBuffer* ring_buffer) {
   ContextSwitchPerfEvent event;
   ring_buffer->ConsumeRecord(header, &event.ring_buffer_record);
+  pid_t pid = event.GetPid();
   pid_t tid = event.GetTid();
   uint16_t cpu = static_cast<uint16_t>(event.GetCpu());
   uint64_t time = event.GetTimestamp();
 
   if (event.IsSwitchOut()) {
-    listener_->OnContextSwitchOut(ContextSwitchOut(tid, cpu, time));
+    listener_->OnContextSwitchOut(ContextSwitchOut(pid, tid, cpu, time));
   } else {
-    listener_->OnContextSwitchIn(ContextSwitchIn(tid, cpu, time));
+    listener_->OnContextSwitchIn(ContextSwitchIn(pid, tid, cpu, time));
   }
 
   ++stats_.sched_switch_count;
@@ -506,6 +507,7 @@ void TracerThread::ProcessContextSwitchCpuWideEvent(
     const perf_event_header& header, PerfEventRingBuffer* ring_buffer) {
   SystemWideContextSwitchPerfEvent event;
   ring_buffer->ConsumeRecord(header, &event.ring_buffer_record);
+  pid_t pid = event.GetPid();
   pid_t tid = event.GetTid();
   uint16_t cpu = static_cast<uint16_t>(event.GetCpu());
   uint64_t time = event.GetTimestamp();
@@ -516,9 +518,9 @@ void TracerThread::ProcessContextSwitchCpuWideEvent(
     if (event.IsSwitchOut()) {
       // Careful: when a switch out is caused by the thread exiting, pid and tid
       // have value -1.
-      listener_->OnContextSwitchOut(ContextSwitchOut(tid, cpu, time));
+      listener_->OnContextSwitchOut(ContextSwitchOut(pid, tid, cpu, time));
     } else {
-      listener_->OnContextSwitchIn(ContextSwitchIn(tid, cpu, time));
+      listener_->OnContextSwitchIn(ContextSwitchIn(pid, tid, cpu, time));
     }
   }
 

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/Events.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/Events.h
@@ -12,15 +12,17 @@ namespace LinuxTracing {
 
 class ContextSwitch {
  public:
+  pid_t GetPid() const { return pid_; }
   pid_t GetTid() const { return tid_; }
   uint16_t GetCore() const { return core_; }
   uint64_t GetTimestampNs() const { return timestamp_ns_; }
 
  protected:
-  ContextSwitch(pid_t tid, uint16_t core, uint64_t timestamp_ns)
-      : tid_(tid), core_(core), timestamp_ns_(timestamp_ns) {}
+  ContextSwitch(pid_t pid, pid_t tid, uint16_t core, uint64_t timestamp_ns)
+      : pid_(pid), tid_(tid), core_(core), timestamp_ns_(timestamp_ns) {}
 
  private:
+  pid_t pid_;
   pid_t tid_;
   uint16_t core_;
   uint64_t timestamp_ns_;
@@ -28,14 +30,14 @@ class ContextSwitch {
 
 class ContextSwitchIn : public ContextSwitch {
  public:
-  ContextSwitchIn(pid_t tid, uint16_t core, uint64_t timestamp_ns)
-      : ContextSwitch(tid, core, timestamp_ns) {}
+  ContextSwitchIn(pid_t pid, pid_t tid, uint16_t core, uint64_t timestamp_ns)
+      : ContextSwitch(pid, tid, core, timestamp_ns) {}
 };
 
 class ContextSwitchOut : public ContextSwitch {
  public:
-  ContextSwitchOut(pid_t tid, uint16_t core, uint64_t timestamp_ns)
-      : ContextSwitch(tid, core, timestamp_ns) {}
+  ContextSwitchOut(pid_t pid, pid_t tid, uint16_t core, uint64_t timestamp_ns)
+      : ContextSwitch(pid, tid, core, timestamp_ns) {}
 };
 
 class CallstackFrame {


### PR DESCRIPTION
Only color context switch slices related to the same process as the target.
Note that when selecting a (grey) context switch slice associated with another
process, all and only the other context switch slices associated with the same
thread are still colored.

A PID field has been added to ContextSwitch and Timer and this breaks
compatibility of the communication with previous builds.

Bug: b/152363779