### PR TITLE
Made FindFilesystem.cmake work with gcc-8's libstdc++

### DIFF
--- a/cmake/FindFilesystem.cmake
+++ b/cmake/FindFilesystem.cmake
@@ -104,7 +104,7 @@ endif()
 
 include(CMakePushCheckState)
 include(CheckIncludeFileCXX)
-include(CheckCXXSourceCompiles)
+include(CheckCXXSourceRuns)
 
 cmake_push_check_state()
 
@@ -180,12 +180,17 @@ if(CXX_FILESYSTEM_HAVE_FS)
 
         int main() {
             auto cwd = @CXX_FILESYSTEM_NAMESPACE@::current_path();
-            return static_cast<int>(cwd.string().size());
+            for (auto &_ : @CXX_FILESYSTEM_NAMESPACE@::directory_iterator{cwd}) {
+                (void) _;
+            }
+            auto root = cwd.root_directory();
+            (void) root;
+            return 0;
         }
     ]] code @ONLY)
 
     # Try to compile a simple filesystem program without any linker flags
-    check_cxx_source_compiles("${code}" CXX_FILESYSTEM_NO_LINK_NEEDED)
+    check_cxx_source_runs("${code}" CXX_FILESYSTEM_NO_LINK_NEEDED)
 
     set(can_link ${CXX_FILESYSTEM_NO_LINK_NEEDED})
 
@@ -194,13 +199,13 @@ if(CXX_FILESYSTEM_HAVE_FS)
         # Add the libstdc++ flag
         set(CMAKE_REQUIRED_LIBRARIES ${prev_libraries} -lstdc++fs -lstdc++)
         set(CMAKE_REQUIRED_FLAGS "-std=c++17")
-        check_cxx_source_compiles("${code}" CXX_FILESYSTEM_STDCPPFS_NEEDED)
+        check_cxx_source_runs("${code}" CXX_FILESYSTEM_STDCPPFS_NEEDED)
         set(can_link ${CXX_FILESYSTEM_STDCPPFS_NEEDED})
         if(NOT CXX_FILESYSTEM_STDCPPFS_NEEDED)
             # Try the libc++ flag
             set(CMAKE_REQUIRED_LIBRARIES ${prev_libraries} -lc++fs)
             set(CMAKE_REQUIRED_FLAGS "-std=c++17")
-            check_cxx_source_compiles("${code}" CXX_FILESYSTEM_CPPFS_NEEDED)
+            check_cxx_source_runs("${code}" CXX_FILESYSTEM_CPPFS_NEEDED)
             set(can_link ${CXX_FILESYSTEM_CPPFS_NEEDED})
         endif()
     endif()


### PR DESCRIPTION
gcc-8's libstdc++.so contains experimental filesystem
symbols which make the linker happy but don't match
the definitions in the header files. According to the
devs it is necessary to force linking against libstdc++fs.a

This change requires the std::filesystem test program not only
to compile but also to run properly. In the GCC-8 case it segfaults
and the detection will choose linking against libstdc++fs.a
over not linking.

In the long term we should consider switching to libc++ anyway.
That's already on my to do list.
