### PR TITLE
Adding build-on-docker to kokoro configuration

### DIFF
--- a/contrib/conan/docker/Dockerfile.clang7_gpg
+++ b/contrib/conan/docker/Dockerfile.clang7_gpg
@@ -4,4 +4,6 @@ RUN sudo apt-get -qq update \
     && sudo apt-get install -y --no-install-recommends \
     jq \
     libtinfo5 \
+    gpg \
+    gpg-agent \
     && sudo rm -rf /var/lib/apt/lists/*

--- a/contrib/conan/docker/Dockerfile.clang7_opengl_qt
+++ b/contrib/conan/docker/Dockerfile.clang7_opengl_qt
@@ -1,0 +1,97 @@
+FROM ubuntu:disco
+
+LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
+
+ENV LLVM_VERSION=7.0 \
+    CC=clang \
+    CXX=clang++ \
+    CMAKE_C_COMPILER=clang \
+    CMAKE_CXX_COMPILER=clang++ \
+    PYENV_ROOT=/opt/pyenv \
+    PATH=/opt/pyenv/shims:${PATH}
+
+RUN dpkg --add-architecture i386 \
+    && apt-get -qq update \
+    && apt-get install -y --no-install-recommends \
+       sudo=1.* \
+       wget=1.* \
+       git=1:2.* \
+       g++-multilib=4:8.* \
+       clang-7=1:7* \
+       make=4.* \
+       libc6-dev-i386=2.* \
+       libgmp-dev=2:6.* \
+       libmpfr-dev=4.* \
+       libmpc-dev=1.* \
+       nasm=2.* \
+       dh-autoreconf=19 \
+       libffi-dev=3.* \
+       libssl-dev=1* \
+       ninja-build=1.* \
+       libc++-7-dev=1:7* \
+       libc++abi-7-dev=1:7* \
+       pkg-config=0.* \
+       subversion=1.* \
+       zlib1g-dev=1:1.* \
+       libbz2-dev=1.* \
+       libsqlite3-dev=3.* \
+       libreadline-dev=8.* \
+       xz-utils=5.* \
+       curl=7.* \
+       libncurses5-dev=6.* \
+       libncursesw5-dev=6.* \
+       liblzma-dev=5.* \
+       libstdc++-9-dev \
+       ca-certificates \
+       libglu1-mesa-dev \
+       mesa-common-dev \
+       libxmu-dev \
+       libxi-dev \
+       qt5-default \
+       jq \
+    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-7 100 \
+    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-7 100 \
+    && update-alternatives --install /usr/bin/cc cc /usr/bin/clang-7 100 \
+    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-7 100 \
+    && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-7 100 \
+    && ln -s /usr/include/locale.h /usr/include/xlocale.h \
+    && rm -rf /var/lib/apt/lists/* \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.4-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.16.4-Linux-x86_64.tar.gz \
+       --exclude=bin/cmake-gui \
+       --exclude=doc/cmake \
+       --exclude=share/cmake-3.12/Help \
+    && cp -fR cmake-3.16.4-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.16.4-Linux-x86_64 \
+    && rm cmake-3.16.4-Linux-x86_64.tar.gz \
+    && groupadd 1001 -g 1001 \
+    && groupadd 1000 -g 1000 \
+    && groupadd 2000 -g 2000 \
+    && groupadd 999 -g 999 \
+    && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
+    && printf "conan:conan" | chpasswd \
+    && adduser conan sudo \
+    && printf "conan ALL= NOPASSWD: ALL\\n" >> /etc/sudoers \
+    && wget --no-check-certificate --quiet -O /tmp/pyenv-installer https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer \
+    && chmod +x /tmp/pyenv-installer \
+    && /tmp/pyenv-installer \
+    && rm /tmp/pyenv-installer \
+    && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
+    && pip install -q --upgrade --no-cache-dir pip \
+    && pip install -q --no-cache-dir conan conan-package-tools \
+    && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
+
+USER conan
+WORKDIR /home/conan
+
+RUN mkdir -p /home/conan/.conan \
+    && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \
+    && printf 'eval "$(pyenv virtualenv-init -)"\n' >> ~/.bashrc

--- a/contrib/conan/docker/Dockerfile.clang8_opengl_qt
+++ b/contrib/conan/docker/Dockerfile.clang8_opengl_qt
@@ -1,4 +1,4 @@
-FROM conanio/clang9:latest
+FROM conanio/clang8:latest
 
 RUN sudo apt-get -qq update \
     && sudo apt-get install -y --no-install-recommends \
@@ -7,4 +7,5 @@ RUN sudo apt-get -qq update \
     libxmu-dev \
     libxi-dev \
     qt5-default \
-    jq 
+    jq \
+    && sudo rm -rf /var/lib/apt/lists/*

--- a/contrib/conan/docker/Dockerfile.clang9_opengl_qt
+++ b/contrib/conan/docker/Dockerfile.clang9_opengl_qt
@@ -1,4 +1,4 @@
-FROM conanio/clang8:latest
+FROM conanio/clang9:latest
 
 RUN sudo apt-get -qq update \
     && sudo apt-get install -y --no-install-recommends \
@@ -7,4 +7,5 @@ RUN sudo apt-get -qq update \
     libxmu-dev \
     libxi-dev \
     qt5-default \
-    jq 
+    jq \
+    && sudo rm -rf /var/lib/apt/lists/*

--- a/kokoro/gcp_ubuntu/kokoro_build.sh
+++ b/kokoro/gcp_ubuntu/kokoro_build.sh
@@ -1,40 +1,44 @@
 #!/bin/bash
 
 # Fail on any error.
-set -e
+set -ex
 
-# Display commands being run.
-# WARNING: please only enable 'set -x' if necessary for debugging, and be very
-#  careful if you handle credentials (e.g. from Keystore) with 'set -x':
-#  statements like "export VAR=$(cat /tmp/keystore/credentials)" will result in
-#  the credentials being printed in build logs.
-#  Additionally, recursive invocation with credentials as command-line
-#  parameters, will print the full command, with credentials, in the build logs.
-# set -x
+DIR="/mnt/github/orbitprofiler"
+SCRIPT="${DIR}/kokoro/gcp_ubuntu/kokoro_build.sh"
 
+if [ "$0" == "$SCRIPT" ]; then
+  # We are inside the docker container
 
-# Code under repo is checked out to ${KOKORO_ARTIFACTS_DIR}/github.
-# The final directory name in this path is determined by the scm name specified
-# in the job configuration.
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../" >/dev/null 2>&1 && pwd )"
-echo "Installing conan configuration (profiles, settings, etc.)..."
-conan config install $DIR/contrib/conan/configs/linux || exit $?
+  echo "Installing conan configuration (profiles, settings, etc.)..."
+  conan config install "${DIR}/contrib/conan/configs/linux"
+  cp -v "${DIR}/kokoro/conan/config/remotes.json" ~/.conan/remotes.json
 
-# We replace the default remotes by our internal artifactory server
-# which acts as a secure source for prebuilt dependencies.
-cp -v $DIR/kokoro/conan/config/remotes.json ~/.conan/remotes.json
+  export CONAN_REVISIONS_ENABLED=1
+  CONAN_PROFILE="clang7_release"
 
-export CONAN_REVISIONS_ENABLED=1
+  # PACKAGES=$(conan info -pr $CONAN_PROFILE . -j 2>/dev/null | grep build_id | \
+  #         jq '.[] | select(.is_ref) | .reference' | grep -v 'llvm/' | tr -d '"')
 
-cd ${KOKORO_ARTIFACTS_DIR}/github/orbitprofiler
-$DIR/build.sh clang7_release || exit $?
-conan package -bf $DIR/build_clang7_release/ $DIR
+  conan install -u -pr ${CONAN_PROFILE} -if "${DIR}/build_${CONAN_PROFILE}/" \
+          --build outdated "${DIR}"
+  conan build -bf "${DIR}/build_${CONAN_PROFILE}/" "${DIR}"
+  conan package -bf "${DIR}/build_${CONAN_PROFILE}/" "${DIR}"
 
-# Uncomment the three lines below to print the external ip into the log and
-# keep the vm alive for two hours. This is useful to debug build failures that
-# can not be resolved by looking into sponge alone. Also comment out the
-# "set -e" at the top of this file (otherwise a failed build will exit this
-# script immediately).
-# external_ip=$(curl -s -H "Metadata-Flavor: Google" http://metadata/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip)
-# echo "INSTANCE_EXTERNAL_IP=${external_ip}"
-# sleep 7200;
+  # echo -n "${PACKAGES}" | while read package; do
+  #   conan upload -r artifactory --all --no-overwrite all --confirm $package
+  # done
+
+  # Uncomment the three lines below to print the external ip into the log and
+  # keep the vm alive for two hours. This is useful to debug build failures that
+  # can not be resolved by looking into sponge alone. Also comment out the
+  # "set -e" at the top of this file (otherwise a failed build will exit this
+  # script immediately).
+  # external_ip=$(curl -s -H "Metadata-Flavor: Google" http://metadata/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip)
+  # echo "INSTANCE_EXTERNAL_IP=${external_ip}"
+  # sleep 7200;
+
+else
+  gcloud auth configure-docker --quiet
+  docker run --rm --network host -v ${KOKORO_ARTIFACTS_DIR}:/mnt gcr.io/orbitprofiler/clang7_opengl_qt:latest $SCRIPT
+fi
+

--- a/kokoro/gcp_ubuntu_ggp/kokoro_build.sh
+++ b/kokoro/gcp_ubuntu_ggp/kokoro_build.sh
@@ -1,61 +1,63 @@
 #!/bin/bash
 
 # Fail on any error.
-# set -e
+set -ex
 
-# Display commands being run.
-# WARNING: please only enable 'set -x' if necessary for debugging, and be very
-#  careful if you handle credentials (e.g. from Keystore) with 'set -x':
-#  statements like "export VAR=$(cat /tmp/keystore/credentials)" will result in
-#  the credentials being printed in build logs.
-#  Additionally, recursive invocation with credentials as command-line
-#  parameters, will print the full command, with credentials, in the build logs.
-# set -x
+DIR="/mnt/github/orbitprofiler"
+SCRIPT="${DIR}/kokoro/gcp_ubuntu_ggp/kokoro_build.sh"
 
+if [ "$0" == "$SCRIPT" ]; then
+  # We are inside the docker container
 
-# Code under repo is checked out to ${KOKORO_ARTIFACTS_DIR}/github.
-# The final directory name in this path is determined by the scm name specified
-# in the job configuration.
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../" >/dev/null 2>&1 && pwd )"
-echo "Installing conan configuration (profiles, settings, etc.)..."
-conan config install $DIR/contrib/conan/configs/linux || exit $?
+  echo "Installing conan configuration (profiles, settings, etc.)..."
+  conan config install "${DIR}/contrib/conan/configs/linux"
+  cp -v "${DIR}/kokoro/conan/config/remotes.json" ~/.conan/remotes.json
 
-# We replace the default remotes by our internal artifactory server
-# which acts as a secure source for prebuilt dependencies.
-cp -v $DIR/kokoro/conan/config/remotes.json ~/.conan/remotes.json
+  export CONAN_REVISIONS_ENABLED=1
+  CONAN_PROFILE="ggp_relwithdebinfo"
 
-export CONAN_REVISIONS_ENABLED=1
-profile=ggp_relwithdebinfo
+  # This variable is picked up by the `conan package` call.
+  # The current public key from keystore will be embedded into
+  # the install_signed_package.sh script.
+  export ORBIT_SIGNING_PUBLIC_KEY_FILE="/mnt/keystore/74938_SigningPublicGpg"
 
-# This variable is picked up by the `conan package` call.
-# The current public key from keystore will be embedded into
-# the install_signed_package.sh script.
-export ORBIT_SIGNING_PUBLIC_KEY_FILE="/tmpfs/src/keystore/74938_SigningPublicGpg"
+  # PACKAGES=$(conan info -pr $CONAN_PROFILE . -j 2>/dev/null | grep build_id | \
+  #         jq '.[] | select(.is_ref) | .reference' | grep -v 'llvm/' | tr -d '"')
 
-cd ${KOKORO_ARTIFACTS_DIR}/github/orbitprofiler
-conan install -u -pr $profile -if build_$profile/ --build outdated -o debian_packaging=True $DIR
-conan build -bf build_$profile/ $DIR
-conan package -bf $DIR/build_$profile/ $DIR
+  conan install -u -pr ${CONAN_PROFILE} -if "${DIR}/build_${CONAN_PROFILE}/" \
+          --build outdated -o debian_packaging=True "${DIR}"
+  conan build -bf "${DIR}/build_${CONAN_PROFILE}/" "${DIR}"
+  conan package -bf "${DIR}/build_${CONAN_PROFILE}/" "${DIR}"
 
-rm -rf ~/.gnupg/
-rm -rf /dev/shm/signing.gpg
-mkdir -p ~/.gnupg
-chmod 700 ~/.gnupg
-echo "allow-loopback-pinentry" > ~/.gnupg/gpg-agent.conf
+  rm -rf ~/.gnupg/
+  rm -rf /dev/shm/signing.gpg
+  mkdir -p ~/.gnupg
+  chmod 700 ~/.gnupg
+  echo "allow-loopback-pinentry" > ~/.gnupg/gpg-agent.conf
 
-GPG_OPTIONS="--pinentry-mode loopback --batch --no-tty --yes --no-default-keyring --keyring /dev/shm/signing.gpg --passphrase-file /tmpfs/src/keystore/74938_SigningPrivateGpgKeyPassword"
+  GPG_OPTIONS="--pinentry-mode loopback --batch --no-tty --yes --no-default-keyring --keyring /dev/shm/signing.gpg --passphrase-file /mnt/keystore/74938_SigningPrivateGpgKeyPassword"
 
-gpg $GPG_OPTIONS --import /tmpfs/src/keystore/74938_SigningPrivateGpg
+  gpg ${GPG_OPTIONS} --import /mnt/keystore/74938_SigningPrivateGpg
 
-for deb in $DIR/build_$profile/package/*.deb; do
-    gpg $GPG_OPTIONS --output "$deb.asc" --detach-sign "$deb"
-done
+  for deb in ${DIR}/build_${CONAN_PROFILE}/package/*.deb; do
+    gpg ${GPG_OPTIONS} --output "$deb.asc" --detach-sign "$deb"
+  done
 
-# Uncomment the three lines below to print the external ip into the log and
-# keep the vm alive for two hours. This is useful to debug build failures that
-# can not be resolved by looking into sponge alone. Also comment out the
-# "set -e" at the top of this file (otherwise a failed build will exit this
-# script immediately).
-# external_ip=$(curl -s -H "Metadata-Flavor: Google" http://metadata/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip)
-# echo "INSTANCE_EXTERNAL_IP=${external_ip}"
-# sleep 7200;
+  # echo -n "${PACKAGES}" | while read package; do
+  #   conan upload -r artifactory --all --no-overwrite all --confirm $package
+  # done
+
+  # Uncomment the three lines below to print the external ip into the log and
+  # keep the vm alive for two hours. This is useful to debug build failures that
+  # can not be resolved by looking into sponge alone. Also comment out the
+  # "set -e" at the top of this file (otherwise a failed build will exit this
+  # script immediately).
+  # external_ip=$(curl -s -H "Metadata-Flavor: Google" http://metadata/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip)
+  # echo "INSTANCE_EXTERNAL_IP=${external_ip}"
+  # sleep 7200;
+
+else
+  gcloud auth configure-docker --quiet
+  docker run --rm --network host -v ${KOKORO_ARTIFACTS_DIR}:/mnt gcr.io/orbitprofiler/clang7_gpg:latest $SCRIPT
+fi
+


### PR DESCRIPTION
This PR makes the Kokoro-Linux-builds run in docker containers.

The docker containers are taken from our internal container registry,
reachable via gcr.io/orbitprofiler which is hosted on GCP.

Additionally this PR contains the Dockerfiles which haven been used
to build these containers. There are dedicated containers for both builds.

gcp_ubuntu_ggp uses the clang7_gpg container while the gcp_ubuntu build is based on the clang7_opengl_qt container.