### PR TITLE
Skip PERF_RECORD_SAMPLEs with unexpected size

### DIFF
--- a/OrbitLinuxTracing/PerfEventRingBuffer.cpp
+++ b/OrbitLinuxTracing/PerfEventRingBuffer.cpp
@@ -133,14 +133,15 @@ void PerfEventRingBuffer::ReadAtOffsetFromTail(uint8_t* dest,
 
   uint64_t head = ReadRingBufferHead(metadata_page_);
   if (offset_from_tail + count > head - metadata_page_->data_tail) {
-    ERROR("Reading more data than it is available from the ring buffer");
+    ERROR("Reading more data than it is available from ring buffer '%s'",
+          name_.c_str());
   } else if (offset_from_tail + count > ring_buffer_size_) {
-    ERROR("Reading more than the size of the ring buffer");
+    ERROR("Reading more than the size of ring buffer '%s'", name_.c_str());
   } else if (head > metadata_page_->data_tail + ring_buffer_size_) {
     // If mmap has been called with PROT_WRITE and
     // perf_event_mmap_page::data_tail is used properly, this should not happen,
     // as the kernel would not overwrite unread data.
-    ERROR("Too slow reading from the ring buffer");
+    ERROR("Too slow reading from ring buffer '%s'", name_.c_str());
   }
 
   const uint64_t index = metadata_page_->data_tail + offset_from_tail;

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -435,8 +435,9 @@ void TracerThread::Run(
             // Note: as we are recording context switches on CPUs and not on
             // threads, we don't expect this type of record.
             ERROR(
-                "Unexpected PERF_RECORD_SWITCH (only "
-                "PERF_RECORD_SWITCH_CPU_WIDE are expected)");
+                "Unexpected PERF_RECORD_SWITCH in ring buffer '%s' (only "
+                "PERF_RECORD_SWITCH_CPU_WIDE are expected)",
+                ring_buffer.GetName().c_str());
             ProcessContextSwitchEvent(header, &ring_buffer);
             break;
           case PERF_RECORD_SWITCH_CPU_WIDE:
@@ -458,7 +459,8 @@ void TracerThread::Run(
             ProcessLostEvent(header, &ring_buffer);
             break;
           default:
-            ERROR("Unexpected perf_event_header::type: %u", header.type);
+            ERROR("Unexpected perf_event_header::type in ring buffer '%s': %u",
+                  ring_buffer.GetName().c_str(), header.type);
             ring_buffer.SkipRecord(header);
             break;
         }

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -458,6 +458,18 @@ void TracerThread::Run(
           case PERF_RECORD_LOST:
             ProcessLostEvent(header, &ring_buffer);
             break;
+          case PERF_RECORD_THROTTLE:
+            // We don't use throttle/unthrottle events, but log them separately
+            // from the default 'Unexpected perf_event_header::type' case.
+            LOG("PERF_RECORD_THROTTLE in ring buffer '%s'",
+                ring_buffer.GetName().c_str());
+            ring_buffer.SkipRecord(header);
+            break;
+          case PERF_RECORD_UNTHROTTLE:
+            LOG("PERF_RECORD_UNTHROTTLE in ring buffer '%s'",
+                ring_buffer.GetName().c_str());
+            ring_buffer.SkipRecord(header);
+            break;
           default:
             ERROR("Unexpected perf_event_header::type in ring buffer '%s': %u",
                   ring_buffer.GetName().c_str(), header.type);


### PR DESCRIPTION
Skip PERF_RECORD_SAMPLEs with an unknown size. These are normally
time-based samples with abi == PERF_SAMPLE_REGS_ABI_NONE and no
registers, and with size == 0 and no stack. Usually, these samples have
pid == tid == 0, but that's not always the case, for example when a
process exits while tracing.

Bug: b/153389111