### PR TITLE
Re-enable STRICT_COMPILE_FLAGS and fix errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,17 @@
 cmake_minimum_required(VERSION 3.15)
 
+project(Orbit C CXX)
+
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   set(STRICT_COMPILE_FLAGS -Werror=all
                            -Werror=float-conversion
                            -Werror=inconsistent-missing-override
-                           -Werror=unused-parameter)
+                           -Werror=unused-parameter
+                           -Werror=unused-variable)
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   set(STRICT_COMPILE_FLAGS -Werror=all
                            -Werror=float-conversion)
 endif()
-
-project(Orbit C CXX)
 
 include(cmake/tests.cmake)
 enable_testing()

--- a/OrbitCore/ConnectionManager.cpp
+++ b/OrbitCore/ConnectionManager.cpp
@@ -37,9 +37,9 @@
 #include <streambuf>
 
 ConnectionManager::ConnectionManager()
-    : exit_requested_(false),
-      is_service_(false),
-      tracing_session_(GTcpServer.get()) {}
+    : tracing_session_(GTcpServer.get()),
+      exit_requested_(false),
+      is_service_(false) {}
 
 ConnectionManager::~ConnectionManager() {
   StopThread();

--- a/OrbitCore/CoreApp.h
+++ b/OrbitCore/CoreApp.h
@@ -44,7 +44,7 @@ class CoreApp {
   virtual void AddSymbol(uint64_t /*a_Address*/,
                          const std::string& /*a_Module*/,
                          const std::string& /*a_Name*/) {}
-  virtual void AddKeyAndString(uint64_t key, std::string_view str) {}
+  virtual void AddKeyAndString(uint64_t /*key*/, std::string_view /*str*/) {}
   virtual const std::unordered_map<DWORD64, std::shared_ptr<class Rule> >*
   GetRules() {
     return nullptr;

--- a/OrbitCore/EventBuffer.cpp
+++ b/OrbitCore/EventBuffer.cpp
@@ -80,7 +80,7 @@ ORBIT_SERIALIZE(CallstackEvent, 0) {
 #ifdef __linux
 
 //-----------------------------------------------------------------------------
-void EventTracer::Start(uint32_t a_PID, LinuxTracingSession* session) {
+void EventTracer::Start(uint32_t /*pid*/, LinuxTracingSession* session) {
   Capture::NewSamplingProfiler();
   Capture::GSamplingProfiler->StartCapture();
 

--- a/OrbitCore/Pdb.h
+++ b/OrbitCore/Pdb.h
@@ -154,7 +154,7 @@ class Pdb {
 
   void Init() {}
 
-  bool LoadPdb(const char* file_name) {
+  bool LoadPdb(const char* /*file_name*/) {
     return false;  // Should not do anything on linux
   }
   virtual void LoadPdbAsync(const char* pdb_name,

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -750,7 +750,6 @@ float CaptureWindow::GetTopBarTextY() {
 
 //-----------------------------------------------------------------------------
 void CaptureWindow::DrawStatus() {
-  float iconSize = m_Slider.GetPixelHeight();
   int s_PosX = 0;
   float s_PosY = GetTopBarTextY();
   static int s_IncY = 20;

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -493,7 +493,6 @@ void TimeGraph::UpdatePrimitives(bool a_Picking) {
 
   UpdateThreadIds();
 
-  double span = m_MaxTimeUs - m_MinTimeUs;
   TickType rawStart = GetTickFromUs(m_MinTimeUs);
   TickType rawStop = GetTickFromUs(m_MaxTimeUs);
 
@@ -589,9 +588,9 @@ void TimeGraph::UpdatePrimitives(bool a_Picking) {
               coeff = 1.0f;
             }
 
-            col[0] = coeff * col[0];
-            col[1] = coeff * col[1];
-            col[2] = coeff * col[2];
+            col[0] = static_cast<uint8_t>(coeff * col[0]);
+            col[1] = static_cast<uint8_t>(coeff * col[1]);
+            col[2] = static_cast<uint8_t>(coeff * col[2]);
           }
 
           if (isSelected) {
@@ -1089,7 +1088,6 @@ bool TimeGraph::IsVisible(const Timer& a_Timer) {
   double start = MicroSecondsFromTicks(m_SessionMinCounter, a_Timer.m_Start);
   double end = MicroSecondsFromTicks(m_SessionMinCounter, a_Timer.m_End);
 
-  double span = m_MaxTimeUs - m_MinTimeUs;
   double startUs = m_MinTimeUs;
 
   if (startUs > end || m_MaxTimeUs < start) {

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/Events.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/Events.h
@@ -109,8 +109,8 @@ class GpuJob {
          uint64_t gpu_hardware_start_time_ns,
          uint64_t dma_fence_signaled_time_ns)
       : tid_(tid),
-        seqno_(seqno),
         context_(context),
+        seqno_(seqno),
         timeline_(std::move(timeline)),
         depth_(depth),
         amdgpu_cs_ioctl_time_ns_(amdgpu_cs_ioctl_time_ns),

--- a/OrbitTest/OrbitTest.cpp
+++ b/OrbitTest/OrbitTest.cpp
@@ -79,7 +79,6 @@ void NO_INLINE OrbitTest::TestFunc2(uint32_t a_Depth) {
 
 //-----------------------------------------------------------------------------
 void NO_INLINE OrbitTest::BusyWork(uint64_t microseconds) {
-  static volatile uint32_t count;
   auto start = std::chrono::system_clock::now();
   while (true) {
     auto end = std::chrono::system_clock::now();


### PR DESCRIPTION
The CMAKE_CXX_COMPILER_ID is emtpy if checked before proejct() line
in cmake - this led to effectively not having STRING_COMPILE_FLAGS
enabled for the project for some time. This change re-enables them
and fixes errors introduced while it was disabled.

Test: cmake --build .