### PR TITLE
Corrected a variable name in grpc_helper

### DIFF
--- a/contrib/conan/recipes/grpc/gRPCTargets-helpers.cmake
+++ b/contrib/conan/recipes/grpc/gRPCTargets-helpers.cmake
@@ -34,7 +34,8 @@ function(grpc_helper)
             "${bin_dir}" -I ${src_folder}
             --plugin=protoc-gen-grpc="${_HELPER_GRPC_CPP_PLUGIN}"
             "${src_filepath}"
-          DEPENDS "${source_filepath}" "${bin_dir}")
+          MAIN_DEPENDENCY "${src_filepath}"
+          DEPENDS "${bin_dir}")
 
         add_library(${target_name} OBJECT)
         target_include_directories(${target_name} PUBLIC ${bin_dir})


### PR DESCRIPTION
"${source_filepath}" should actually be called "${src_filepath}".

Additionally the grpc_helper now defines the proto file as main_dependency.
This makes it look nicer in Visual Studio, at least according to the
cmake docs.