### PR TITLE
Condition context menus of DataViews by the state of the selected elements

### DIFF
--- a/OrbitCore/OrbitFunction.cpp
+++ b/OrbitCore/OrbitFunction.cpp
@@ -292,7 +292,7 @@ void Function::Print() {
   ORBIT_VIZV(address_);
   ORBIT_VIZV(selected_);
 
-  if (params_.size()) {
+  if (!params_.empty()) {
     ORBIT_VIZ("\nParams:");
     for (auto& var : params_) {
       ORBIT_VIZV(var.m_Name);

--- a/OrbitCore/OrbitModule.h
+++ b/OrbitCore/OrbitModule.h
@@ -27,7 +27,7 @@ struct Module {
   }
   uint64_t ValidateAddress(uint64_t a_Address);
   void SetLoaded(bool a_Value);
-  bool GetLoaded() { return m_Loaded; }
+  bool GetLoaded() const { return m_Loaded; }
 
   std::string m_Name;       // name of the file (without path)
   std::string m_FullName;   // full filename (including path)

--- a/OrbitCore/SamplingProfiler.cpp
+++ b/OrbitCore/SamplingProfiler.cpp
@@ -480,7 +480,7 @@ void SamplingProfiler::OutputStats() {
           100.f * ((float)numOccurences) / (float)threadSampleData.m_NumSamples;
 
       SampledFunction function;
-      function.m_Name = m_AddressToSymbol[address].c_str();
+      function.m_Name = m_AddressToSymbol[address];
       function.m_Inclusive = prct;
       function.m_Exclusive = 0.f;
       auto it = threadSampleData.m_ExclusiveCount.find(address);

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -80,8 +80,8 @@ struct SortedCallstackReport {
 //-----------------------------------------------------------------------------
 class SamplingProfiler {
  public:
-  SamplingProfiler(const std::shared_ptr<Process>& a_Process,
-                   bool a_ETW = false);
+  explicit SamplingProfiler(const std::shared_ptr<Process>& a_Process,
+                            bool a_ETW = false);
   SamplingProfiler();
   ~SamplingProfiler();
 

--- a/OrbitCore/TcpServer.h
+++ b/OrbitCore/TcpServer.h
@@ -48,7 +48,7 @@ class TcpServer : public TcpEntity {
   std::vector<std::string> GetStats();
 
  protected:
-  class TcpSocket* GetSocket() override final;
+  class TcpSocket* GetSocket() final;
 
  private:
   class tcp_server* m_TcpServer = nullptr;

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -12,6 +12,7 @@
 #include <cmath>
 #include <fstream>
 #include <thread>
+#include <utility>
 
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Tracing.h"
@@ -416,7 +417,7 @@ void OrbitApp::LoadFileMapping() {
         m_FileMapping[ToLower(tokens[0])] = ToLower(tokens[1]);
       } else {
         std::vector<std::wstring> validTokens;
-        for (std::wstring token : Tokenize(line, L"\"//")) {
+        for (const std::wstring& token : Tokenize(line, L"\"//")) {
           if (!IsBlank(token)) {
             validTokens.push_back(token);
           }
@@ -861,7 +862,7 @@ void OrbitApp::OnDisconnect() { GTcpServer->Send(Msg_Unload); }
 void OrbitApp::OnPdbLoaded() {
   FireRefreshCallbacks();
 
-  if (m_ModulesToLoad.size() == 0) {
+  if (m_ModulesToLoad.empty()) {
     SendToUiAsync(L"pdbloaded");
   } else {
     LoadModules();
@@ -961,7 +962,7 @@ bool OrbitApp::Inject(unsigned long a_ProcessId) {
 
 //-----------------------------------------------------------------------------
 void OrbitApp::SetCallStack(std::shared_ptr<CallStack> a_CallStack) {
-  m_CallStackDataView->SetCallStack(a_CallStack);
+  m_CallStackDataView->SetCallStack(std::move(a_CallStack));
   FireRefreshCallbacks(DataViewType::CALLSTACK);
 }
 
@@ -984,7 +985,7 @@ void OrbitApp::EnqueueModuleToLoad(const std::shared_ptr<Module>& a_Module) {
 
 //-----------------------------------------------------------------------------
 void OrbitApp::LoadModules() {
-  if (m_ModulesToLoad.size() > 0) {
+  if (!m_ModulesToLoad.empty()) {
     if (Capture::IsRemote()) {
       LoadRemoteModules();
       return;

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <queue>
 #include <string>
+#include <utility>
 
 #include "ContextSwitch.h"
 #include "CoreApp.h"
@@ -60,7 +61,7 @@ class OrbitApp : public CoreApp {
   void AppendSystrace(const std::string& a_FileName, uint64_t a_TimeOffset);
   void ListSessions();
   void RefreshCaptureView() override;
-  void RequestRemoteModules(const std::vector<std::string> a_Modules);
+  void RequestRemoteModules(const std::vector<std::string>& a_Modules);
   void AddWatchedVariable(Variable* a_Variable);
   void UpdateVariable(Variable* a_Variable) override;
   void ClearWatchedVariables();
@@ -111,28 +112,28 @@ class OrbitApp : public CoreApp {
   // Callbacks
   typedef std::function<void(DataViewType a_Type)> RefreshCallback;
   void AddRefreshCallback(RefreshCallback a_Callback) {
-    m_RefreshCallbacks.push_back(a_Callback);
+    m_RefreshCallbacks.emplace_back(std::move(a_Callback));
   }
   typedef std::function<void(std::shared_ptr<class SamplingReport>)>
       SamplingReportCallback;
   void AddSamplingReoprtCallback(SamplingReportCallback a_Callback) {
-    m_SamplingReportsCallbacks.push_back(a_Callback);
+    m_SamplingReportsCallbacks.emplace_back(std::move(a_Callback));
   }
   void AddSelectionReportCallback(SamplingReportCallback a_Callback) {
-    m_SelectionReportCallbacks.push_back(a_Callback);
+    m_SelectionReportCallbacks.emplace_back(std::move(a_Callback));
   }
   typedef std::function<void(Variable* a_Variable)> WatchCallback;
   void AddWatchCallback(WatchCallback a_Callback) {
-    m_AddToWatchCallbacks.push_back(a_Callback);
+    m_AddToWatchCallbacks.emplace_back(std::move(a_Callback));
   }
   typedef std::function<void(const std::wstring& a_Extension,
                              std::wstring& o_Variable)>
       SaveFileCallback;
   void SetSaveFileCallback(SaveFileCallback a_Callback) {
-    m_SaveFileCallback = a_Callback;
+    m_SaveFileCallback = std::move(a_Callback);
   }
   void AddUpdateWatchCallback(WatchCallback a_Callback) {
-    m_UpdateWatchCallbacks.push_back(a_Callback);
+    m_UpdateWatchCallbacks.emplace_back(std::move(a_Callback));
   }
   void FireRefreshCallbacks(DataViewType a_Type = DataViewType::ALL);
   void Refresh(DataViewType a_Type = DataViewType::ALL) {
@@ -145,14 +146,14 @@ class OrbitApp : public CoreApp {
                                      const std::wstring& a_Filter)>
       FindFileCallback;
   void SetFindFileCallback(FindFileCallback a_Callback) {
-    m_FindFileCallback = a_Callback;
+    m_FindFileCallback = std::move(a_Callback);
   }
   std::wstring FindFile(const std::wstring& a_Caption,
                         const std::wstring& a_Dir,
                         const std::wstring& a_Filter);
   typedef std::function<void(const std::wstring&)> ClipboardCallback;
   void SetClipboardCallback(ClipboardCallback a_Callback) {
-    m_ClipboardCallback = a_Callback;
+    m_ClipboardCallback = std::move(a_Callback);
   }
 
   void SetCommandLineArguments(const std::vector<std::string>& a_Args);

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -9,7 +9,6 @@
 #include "Capture.h"
 #include "Core.h"
 #include "OrbitProcess.h"
-#include "Pdb.h"
 #include "SamplingProfiler.h"
 #include "absl/strings/str_format.h"
 
@@ -28,7 +27,7 @@ size_t CallStackDataView::GetNumElements() { return m_Indices.size(); }
 void CallStackDataView::OnDataChanged() {
   size_t numFunctions = m_CallStack ? m_CallStack->m_Depth : 0;
   m_Indices.resize(numFunctions);
-  for (uint32_t i = 0; i < numFunctions; ++i) {
+  for (size_t i = 0; i < numFunctions; ++i) {
     m_Indices[i] = i;
   }
 }
@@ -91,9 +90,7 @@ void CallStackDataView::OnFilter(const std::wstring& a_Filter) {
     bool match = true;
 
     for (std::wstring& filterToken : tokens) {
-      if( !( name.find( filterToken ) != std::wstring::npos/* ||
-                   file.find( filterToken ) != std::string::npos*/ ) )
-            {
+      if (name.find(filterToken) == std::wstring::npos) {
         match = false;
         break;
       }

--- a/OrbitGl/CallStackDataView.h
+++ b/OrbitGl/CallStackDataView.h
@@ -3,6 +3,8 @@
 //-----------------------------------
 #pragma once
 
+#include <utility>
+
 #include "FunctionsDataView.h"
 #include "OrbitType.h"
 
@@ -19,7 +21,7 @@ class CallStackDataView : public FunctionsDataView {
   std::wstring GetValue(int a_Row, int a_Column) override;
   void OnFilter(const std::wstring& a_Filter) override;
   void SetCallStack(std::shared_ptr<CallStack> a_CallStack) {
-    m_CallStack = a_CallStack;
+    m_CallStack = std::move(a_CallStack);
     OnDataChanged();
   }
 

--- a/OrbitGl/DataView.cpp
+++ b/OrbitGl/DataView.cpp
@@ -105,7 +105,7 @@ std::vector<std::wstring> DataView::GetContextMenu(
 
 //-----------------------------------------------------------------------------
 void DataView::OnContextMenu(const std::wstring& a_Action, int a_MenuIndex,
-                             std::vector<int>& a_ItemIndices) {
+                             const std::vector<int>& a_ItemIndices) {
   UNUSED(a_MenuIndex);
 
   if (a_Action == MENU_ACTION_EXPORT_TO_CSV) {
@@ -144,7 +144,7 @@ void DataView::ExportCSV(const std::wstring& a_FileName) {
 }
 
 //-----------------------------------------------------------------------------
-void DataView::CopySelection(std::vector<int>& selection) {
+void DataView::CopySelection(const std::vector<int>& selection) {
   std::wstring clipboard;
   const std::vector<std::wstring>& headers = GetColumnHeaders();
 

--- a/OrbitGl/DataView.cpp
+++ b/OrbitGl/DataView.cpp
@@ -92,12 +92,14 @@ const std::vector<DataView::SortingOrder>& DataView::GetColumnInitialOrders() {
 }
 
 //-----------------------------------------------------------------------------
-const std::wstring DV_COPY_SELECTION = L"Copy Selection";
-const std::wstring DV_EXPORT_TO_CSV = L"Export to CSV";
+const std::wstring DataView::MENU_ACTION_COPY_SELECTION = L"Copy Selection";
+const std::wstring DataView::MENU_ACTION_EXPORT_TO_CSV = L"Export to CSV";
 
 //-----------------------------------------------------------------------------
-std::vector<std::wstring> DataView::GetContextMenu(int /*a_Index*/) {
-  static std::vector<std::wstring> menu = {DV_COPY_SELECTION, DV_EXPORT_TO_CSV};
+std::vector<std::wstring> DataView::GetContextMenu(
+    int /*a_ClickedIndex*/, const std::vector<int>& /*a_SelectedIndices*/) {
+  static std::vector<std::wstring> menu = {MENU_ACTION_COPY_SELECTION,
+                                           MENU_ACTION_EXPORT_TO_CSV};
   return menu;
 }
 
@@ -106,9 +108,9 @@ void DataView::OnContextMenu(const std::wstring& a_Action, int a_MenuIndex,
                              std::vector<int>& a_ItemIndices) {
   UNUSED(a_MenuIndex);
 
-  if (a_Action == DV_EXPORT_TO_CSV) {
+  if (a_Action == MENU_ACTION_EXPORT_TO_CSV) {
     ExportCSV(GOrbitApp->GetSaveFile(L".csv"));
-  } else if (a_Action == DV_COPY_SELECTION) {
+  } else if (a_Action == MENU_ACTION_COPY_SELECTION) {
     CopySelection(a_ItemIndices);
   }
 }

--- a/OrbitGl/DataView.h
+++ b/OrbitGl/DataView.h
@@ -33,7 +33,8 @@ class DataView {
   virtual bool IsSortingAllowed() { return true; }
   virtual const std::vector<SortingOrder>& GetColumnInitialOrders();
   virtual int GetDefaultSortingColumn() { return 0; }
-  virtual std::vector<std::wstring> GetContextMenu(int a_Index);
+  virtual std::vector<std::wstring> GetContextMenu(
+      int a_ClickedIndex, const std::vector<int>& a_SelectedIndices);
   virtual size_t GetNumElements() { return m_Indices.size(); }
   virtual std::wstring GetValue(int /*a_Row*/, int /*a_Column*/) { return L""; }
   virtual std::wstring GetToolTip(int /*a_Row*/, int /*a_Column*/) {
@@ -82,4 +83,7 @@ class DataView {
   int m_UpdatePeriodMs;
   int m_SelectedIndex;
   DataViewType m_Type;
+
+  static const std::wstring MENU_ACTION_COPY_SELECTION;
+  static const std::wstring MENU_ACTION_EXPORT_TO_CSV;
 };

--- a/OrbitGl/DataView.h
+++ b/OrbitGl/DataView.h
@@ -48,7 +48,7 @@ class DataView {
   virtual void OnSort(int /*a_Column*/,
                       std::optional<SortingOrder> /*a_NewOrder*/) {}
   virtual void OnContextMenu(const std::wstring& a_Action, int a_MenuIndex,
-                             std::vector<int>& a_ItemIndices);
+                             const std::vector<int>& a_ItemIndices);
   virtual void OnItemActivated() {}
   virtual void OnSelect(int /*a_Index*/) {}
   virtual int GetSelectedIndex() { return m_SelectedIndex; }
@@ -70,7 +70,7 @@ class DataView {
   virtual bool ScrollToBottom() { return false; }
   virtual bool SkipTimer() { return false; }
   virtual void ExportCSV(const std::wstring& a_FileName);
-  virtual void CopySelection(std::vector<int>& selection);
+  virtual void CopySelection(const std::vector<int>& selection);
 
   int GetUpdatePeriodMs() const { return m_UpdatePeriodMs; }
   DataViewType GetType() const { return m_Type; }

--- a/OrbitGl/FunctionsDataView.cpp
+++ b/OrbitGl/FunctionsDataView.cpp
@@ -218,11 +218,12 @@ std::wstring FUN_CREATE_RULE = L"Create Rule";
 std::wstring FUN_SET_AS_FRAME = L"Set As Main Frame";
 
 //-----------------------------------------------------------------------------
-std::vector<std::wstring> FunctionsDataView::GetContextMenu(int a_Index) {
+std::vector<std::wstring> FunctionsDataView::GetContextMenu(
+    int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) {
   std::vector<std::wstring> menu = {FUN_SELECT, FUN_UNSELECT, FUN_VIEW,
                                     FUN_DISASSEMBLY, FUN_CREATE_RULE};
 
-  Append(menu, DataView::GetContextMenu(a_Index));
+  Append(menu, DataView::GetContextMenu(a_ClickedIndex, a_SelectedIndices));
 
   return menu;
 }

--- a/OrbitGl/FunctionsDataView.cpp
+++ b/OrbitGl/FunctionsDataView.cpp
@@ -245,7 +245,7 @@ std::vector<std::wstring> FunctionsDataView::GetContextMenu(
 //-----------------------------------------------------------------------------
 void FunctionsDataView::OnContextMenu(const std::wstring& a_Action,
                                       int a_MenuIndex,
-                                      std::vector<int>& a_ItemIndices) {
+                                      const std::vector<int>& a_ItemIndices) {
   if (a_Action == MENU_ACTION_SELECT) {
     for (int i : a_ItemIndices) {
       Function& function = GetFunction(i);

--- a/OrbitGl/FunctionsDataView.h
+++ b/OrbitGl/FunctionsDataView.h
@@ -14,7 +14,8 @@ class FunctionsDataView : public DataView {
   const std::vector<float>& GetColumnHeadersRatios() override;
   const std::vector<SortingOrder>& GetColumnInitialOrders() override;
   int GetDefaultSortingColumn() override;
-  std::vector<std::wstring> GetContextMenu(int a_Index) override;
+  std::vector<std::wstring> GetContextMenu(
+      int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) override;
   std::wstring GetValue(int a_Row, int a_Column) override;
   void OnFilter(const std::wstring& a_Filter) override;
   void ParallelFilter();

--- a/OrbitGl/FunctionsDataView.h
+++ b/OrbitGl/FunctionsDataView.h
@@ -21,7 +21,7 @@ class FunctionsDataView : public DataView {
   void ParallelFilter();
   void OnSort(int a_Column, std::optional<SortingOrder> a_NewOrder) override;
   void OnContextMenu(const std::wstring& a_Action, int a_MenuIndex,
-                     std::vector<int>& a_ItemIndices) override;
+                     const std::vector<int>& a_ItemIndices) override;
   void OnDataChanged() override;
 
  protected:

--- a/OrbitGl/FunctionsDataView.h
+++ b/OrbitGl/FunctionsDataView.h
@@ -34,4 +34,11 @@ class FunctionsDataView : public DataView {
   static std::vector<int> s_HeaderMap;
   static std::vector<float> s_HeaderRatios;
   static std::vector<SortingOrder> s_InitialOrders;
+
+  static const std::wstring MENU_ACTION_SELECT;
+  static const std::wstring MENU_ACTION_UNSELECT;
+  static const std::wstring MENU_ACTION_VIEW;
+  static const std::wstring MENU_ACTION_DISASSEMBLY;
+  static const std::wstring MENU_ACTION_CREATE_RULE;
+  static const std::wstring MENU_ACTION_SET_AS_FRAME;
 };

--- a/OrbitGl/GlobalsDataView.cpp
+++ b/OrbitGl/GlobalsDataView.cpp
@@ -183,9 +183,10 @@ void GlobalsDataView::OnSort(int a_Column,
 std::wstring TYPES_MENU_WATCH = L"Add to watch";
 
 //-----------------------------------------------------------------------------
-std::vector<std::wstring> GlobalsDataView::GetContextMenu(int a_Index) {
+std::vector<std::wstring> GlobalsDataView::GetContextMenu(
+    int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) {
   std::vector<std::wstring> menu = {TYPES_MENU_WATCH};
-  Append(menu, DataView::GetContextMenu(a_Index));
+  Append(menu, DataView::GetContextMenu(a_ClickedIndex, a_SelectedIndices));
   return menu;
 }
 

--- a/OrbitGl/GlobalsDataView.cpp
+++ b/OrbitGl/GlobalsDataView.cpp
@@ -193,7 +193,7 @@ std::vector<std::wstring> GlobalsDataView::GetContextMenu(
 //-----------------------------------------------------------------------------
 void GlobalsDataView::OnContextMenu(const std::wstring& a_Action,
                                     int a_MenuIndex,
-                                    std::vector<int>& a_ItemIndices) {
+                                    const std::vector<int>& a_ItemIndices) {
   if (a_Action == TYPES_MENU_WATCH) {
     OnAddToWatch(a_ItemIndices);
   } else {
@@ -202,7 +202,7 @@ void GlobalsDataView::OnContextMenu(const std::wstring& a_Action,
 }
 
 //-----------------------------------------------------------------------------
-void GlobalsDataView::OnAddToWatch(std::vector<int>& a_Items) {
+void GlobalsDataView::OnAddToWatch(const std::vector<int>& a_Items) {
   for (auto& item : a_Items) {
     Variable& variable = GetVariable(item);
     variable.Populate();

--- a/OrbitGl/GlobalsDataView.cpp
+++ b/OrbitGl/GlobalsDataView.cpp
@@ -112,8 +112,6 @@ std::wstring GlobalsDataView::GetValue(int a_Row, int a_Column) {
     case Variable::MODULE:
       value = variable.m_Pdb->GetName();
       break;
-    /*case Variable::MODBASE:
-        value = wxString::Format("0x%I64x", function.m_ModBase);  break;*/
     case Variable::ADDRESS:
       value = absl::StrFormat("0x%llx", variable.m_Address);
       break;
@@ -122,7 +120,6 @@ std::wstring GlobalsDataView::GetValue(int a_Row, int a_Column) {
       break;
     default:
       break;
-      ;
   }
 
   return s2ws(value);
@@ -180,12 +177,13 @@ void GlobalsDataView::OnSort(int a_Column,
 }
 
 //-----------------------------------------------------------------------------
-std::wstring TYPES_MENU_WATCH = L"Add to watch";
+const std::wstring GlobalsDataView::MENU_ACTION_TYPES_MENU_WATCH =
+    L"Add to watch";
 
 //-----------------------------------------------------------------------------
 std::vector<std::wstring> GlobalsDataView::GetContextMenu(
     int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) {
-  std::vector<std::wstring> menu = {TYPES_MENU_WATCH};
+  std::vector<std::wstring> menu = {MENU_ACTION_TYPES_MENU_WATCH};
   Append(menu, DataView::GetContextMenu(a_ClickedIndex, a_SelectedIndices));
   return menu;
 }
@@ -194,7 +192,7 @@ std::vector<std::wstring> GlobalsDataView::GetContextMenu(
 void GlobalsDataView::OnContextMenu(const std::wstring& a_Action,
                                     int a_MenuIndex,
                                     const std::vector<int>& a_ItemIndices) {
-  if (a_Action == TYPES_MENU_WATCH) {
+  if (a_Action == MENU_ACTION_TYPES_MENU_WATCH) {
     OnAddToWatch(a_ItemIndices);
   } else {
     DataView::OnContextMenu(a_Action, a_MenuIndex, a_ItemIndices);
@@ -274,7 +272,7 @@ void GlobalsDataView::ParallelFilter() {
 void GlobalsDataView::OnDataChanged() {
   size_t numGlobals = Capture::GTargetProcess->GetGlobals().size();
   m_Indices.resize(numGlobals);
-  for (uint32_t i = 0; i < numGlobals; ++i) {
+  for (size_t i = 0; i < numGlobals; ++i) {
     m_Indices[i] = i;
   }
 }

--- a/OrbitGl/GlobalsDataView.h
+++ b/OrbitGl/GlobalsDataView.h
@@ -34,4 +34,6 @@ class GlobalsDataView : public DataView {
   static std::vector<int> s_HeaderMap;
   static std::vector<float> s_HeaderRatios;
   static std::vector<SortingOrder> s_InitialOrders;
+
+  static const std::wstring MENU_ACTION_TYPES_MENU_WATCH;
 };

--- a/OrbitGl/GlobalsDataView.h
+++ b/OrbitGl/GlobalsDataView.h
@@ -13,7 +13,8 @@ class GlobalsDataView : public DataView {
   const std::vector<std::wstring>& GetColumnHeaders() override;
   const std::vector<float>& GetColumnHeadersRatios() override;
   const std::vector<SortingOrder>& GetColumnInitialOrders() override;
-  std::vector<std::wstring> GetContextMenu(int a_Index) override;
+  std::vector<std::wstring> GetContextMenu(
+      int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) override;
   std::wstring GetValue(int a_Row, int a_Column) override;
 
   void OnFilter(const std::wstring& a_Filter) override;

--- a/OrbitGl/GlobalsDataView.h
+++ b/OrbitGl/GlobalsDataView.h
@@ -21,9 +21,9 @@ class GlobalsDataView : public DataView {
   void ParallelFilter();
   void OnSort(int a_Column, std::optional<SortingOrder> a_NewOrder) override;
   void OnContextMenu(const std::wstring& a_Action, int a_MenuIndex,
-                     std::vector<int>& a_ItemIndices) override;
+                     const std::vector<int>& a_ItemIndices) override;
   void OnDataChanged() override;
-  void OnAddToWatch(std::vector<int>& a_Items);
+  void OnAddToWatch(const std::vector<int>& a_Items);
 
  protected:
   Variable& GetVariable(unsigned int a_Row) const;

--- a/OrbitGl/LiveFunctionsDataView.cpp
+++ b/OrbitGl/LiveFunctionsDataView.cpp
@@ -251,9 +251,9 @@ std::vector<std::wstring> LiveFunctionsDataView::GetContextMenu(
 }
 
 //-----------------------------------------------------------------------------
-void LiveFunctionsDataView::OnContextMenu(const std::wstring& a_Action,
-                                          int a_MenuIndex,
-                                          std::vector<int>& a_ItemIndices) {
+void LiveFunctionsDataView::OnContextMenu(
+    const std::wstring& a_Action, int a_MenuIndex,
+    const std::vector<int>& a_ItemIndices) {
   if (a_Action == TOGGLE_SELECT) {
     for (int i : a_ItemIndices) {
       Function& func = GetFunction(i);

--- a/OrbitGl/LiveFunctionsDataView.cpp
+++ b/OrbitGl/LiveFunctionsDataView.cpp
@@ -243,9 +243,10 @@ void LiveFunctionsDataView::OnSort(int a_Column,
 std::wstring TOGGLE_SELECT = L"Toggle Hook";
 
 //-----------------------------------------------------------------------------
-std::vector<std::wstring> LiveFunctionsDataView::GetContextMenu(int a_Index) {
+std::vector<std::wstring> LiveFunctionsDataView::GetContextMenu(
+    int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) {
   std::vector<std::wstring> menu = {TOGGLE_SELECT};
-  Append(menu, DataView::GetContextMenu(a_Index));
+  Append(menu, DataView::GetContextMenu(a_ClickedIndex, a_SelectedIndices));
   return menu;
 }
 

--- a/OrbitGl/LiveFunctionsDataView.h
+++ b/OrbitGl/LiveFunctionsDataView.h
@@ -22,7 +22,7 @@ class LiveFunctionsDataView : public DataView {
   void OnFilter(const std::wstring& a_Filter) override;
   void OnSort(int a_Column, std::optional<SortingOrder> a_NewOrder) override;
   void OnContextMenu(const std::wstring& a_Action, int a_MenuIndex,
-                     std::vector<int>& a_ItemIndices) override;
+                     const std::vector<int>& a_ItemIndices) override;
   void OnDataChanged() override;
   void OnTimer() override;
 

--- a/OrbitGl/LiveFunctionsDataView.h
+++ b/OrbitGl/LiveFunctionsDataView.h
@@ -15,7 +15,8 @@ class LiveFunctionsDataView : public DataView {
   const std::vector<float>& GetColumnHeadersRatios() override;
   const std::vector<SortingOrder>& GetColumnInitialOrders() override;
   int GetDefaultSortingColumn() override;
-  std::vector<std::wstring> GetContextMenu(int a_Index) override;
+  std::vector<std::wstring> GetContextMenu(
+      int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) override;
   std::wstring GetValue(int a_Row, int a_Column) override;
 
   void OnFilter(const std::wstring& a_Filter) override;

--- a/OrbitGl/LiveFunctionsDataView.h
+++ b/OrbitGl/LiveFunctionsDataView.h
@@ -35,4 +35,7 @@ class LiveFunctionsDataView : public DataView {
   static std::vector<int> s_HeaderMap;
   static std::vector<float> s_HeaderRatios;
   static std::vector<SortingOrder> s_InitialOrders;
+
+  static const std::wstring MENU_ACTION_SELECT;
+  static const std::wstring MENU_ACTION_UNSELECT;
 };

--- a/OrbitGl/LogDataView.cpp
+++ b/OrbitGl/LogDataView.cpp
@@ -134,8 +134,9 @@ void LogDataView::OnFilter(const std::wstring& a_Filter) {
 }
 
 //-----------------------------------------------------------------------------
-std::vector<std::wstring> LogDataView::GetContextMenu(int a_Index) {
-  const OrbitLogEntry& entry = LogDataView::GetEntry(a_Index);
+std::vector<std::wstring> LogDataView::GetContextMenu(
+    int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) {
+  const OrbitLogEntry& entry = LogDataView::GetEntry(a_ClickedIndex);
   m_SelectedCallstack = Capture::GetCallstack(entry.m_CallstackHash);
   std::vector<std::wstring> menu;
   if (m_SelectedCallstack) {
@@ -144,7 +145,7 @@ std::vector<std::wstring> LogDataView::GetContextMenu(int a_Index) {
       menu.push_back(Capture::GSamplingProfiler->GetSymbolFromAddress(addr));
     }
   }
-  Append(menu, DataView::GetContextMenu(a_Index));
+  Append(menu, DataView::GetContextMenu(a_ClickedIndex, a_SelectedIndices));
   return menu;
 }
 

--- a/OrbitGl/LogDataView.cpp
+++ b/OrbitGl/LogDataView.cpp
@@ -151,7 +151,7 @@ std::vector<std::wstring> LogDataView::GetContextMenu(
 
 //-----------------------------------------------------------------------------
 void LogDataView::OnContextMenu(const std::wstring& a_Action, int a_MenuIndex,
-                                std::vector<int>& a_ItemIndices) {
+                                const std::vector<int>& a_ItemIndices) {
   if (m_SelectedCallstack && (int)m_SelectedCallstack->m_Depth > a_MenuIndex) {
     GOrbitApp->GoToCode(m_SelectedCallstack->m_Data[a_MenuIndex]);
   } else {

--- a/OrbitGl/LogDataView.cpp
+++ b/OrbitGl/LogDataView.cpp
@@ -102,7 +102,7 @@ bool LogDataView::SkipTimer() { return !Capture::IsCapturing(); }
 void LogDataView::OnDataChanged() {
   ScopeLock lock(m_Mutex);
   m_Indices.resize(m_Entries.size());
-  for (uint32_t i = 0; i < m_Entries.size(); ++i) {
+  for (size_t i = 0; i < m_Entries.size(); ++i) {
     m_Indices[i] = i;
   }
 }
@@ -112,14 +112,14 @@ void LogDataView::OnFilter(const std::wstring& a_Filter) {
   std::vector<std::string> tokens = Tokenize(ToLower(ws2s(a_Filter)));
   std::vector<uint32_t> indices;
 
-  for (uint32_t i = 0; i < m_Entries.size(); ++i) {
+  for (size_t i = 0; i < m_Entries.size(); ++i) {
     const OrbitLogEntry& entry = m_Entries[i];
     std::string text = ToLower(entry.m_Text);
 
     bool match = true;
 
     for (std::string& filterToken : tokens) {
-      if (!(text.find(filterToken) != std::wstring::npos)) {
+      if (text.find(filterToken) == std::wstring::npos) {
         match = false;
         break;
       }

--- a/OrbitGl/LogDataView.h
+++ b/OrbitGl/LogDataView.h
@@ -15,7 +15,8 @@ class LogDataView : public DataView {
   LogDataView();
   const std::vector<std::wstring>& GetColumnHeaders() override;
   const std::vector<float>& GetColumnHeadersRatios() override;
-  std::vector<std::wstring> GetContextMenu(int a_Index) override;
+  std::vector<std::wstring> GetContextMenu(
+      int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) override;
   std::wstring GetValue(int a_Row, int a_Column) override;
   std::wstring GetToolTip(int a_Row, int a_Column) override;
   bool ScrollToBottom() override;

--- a/OrbitGl/LogDataView.h
+++ b/OrbitGl/LogDataView.h
@@ -25,7 +25,7 @@ class LogDataView : public DataView {
   void OnDataChanged() override;
   void OnFilter(const std::wstring& a_Filter) override;
   void OnContextMenu(const std::wstring& a_Action, int a_MenuIndex,
-                     std::vector<int>& a_ItemIndices) override;
+                     const std::vector<int>& a_ItemIndices) override;
 
   void Add(const OrbitLogEntry& a_Msg);
   const OrbitLogEntry& GetEntry(unsigned int a_Row) const;

--- a/OrbitGl/ModulesDataView.cpp
+++ b/OrbitGl/ModulesDataView.cpp
@@ -183,7 +183,7 @@ std::vector<std::wstring> ModulesDataView::GetContextMenu(
 //-----------------------------------------------------------------------------
 void ModulesDataView::OnContextMenu(const std::wstring& a_Action,
                                     int a_MenuIndex,
-                                    std::vector<int>& a_ItemIndices) {
+                                    const std::vector<int>& a_ItemIndices) {
   PRINT_VAR(a_Action);
   if (a_Action == MODULES_LOAD) {
     for (int index : a_ItemIndices) {

--- a/OrbitGl/ModulesDataView.cpp
+++ b/OrbitGl/ModulesDataView.cpp
@@ -163,10 +163,11 @@ const std::wstring DLL_FIND_PDB = L"Find Pdb";
 const std::wstring DLL_EXPORTS = L"Load Symbols";
 
 //-----------------------------------------------------------------------------
-std::vector<std::wstring> ModulesDataView::GetContextMenu(int a_Index) {
+std::vector<std::wstring> ModulesDataView::GetContextMenu(
+    int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) {
   std::vector<std::wstring> menu;
 
-  std::shared_ptr<Module> module = GetModule(a_Index);
+  std::shared_ptr<Module> module = GetModule(a_ClickedIndex);
   if (!module->GetLoaded()) {
     if (module->m_FoundPdb) {
       menu = {MODULES_LOAD};
@@ -175,7 +176,7 @@ std::vector<std::wstring> ModulesDataView::GetContextMenu(int a_Index) {
     }
   }
 
-  Append(menu, DataView::GetContextMenu(a_Index));
+  Append(menu, DataView::GetContextMenu(a_ClickedIndex, a_SelectedIndices));
   return menu;
 }
 

--- a/OrbitGl/ModulesDataView.h
+++ b/OrbitGl/ModulesDataView.h
@@ -22,7 +22,7 @@ class ModulesDataView : public DataView {
   void OnFilter(const std::wstring& a_Filter) override;
   void OnSort(int a_Column, std::optional<SortingOrder> a_NewOrder) override;
   void OnContextMenu(const std::wstring& a_Action, int a_MenuIndex,
-                     std::vector<int>& a_ItemIndices) override;
+                     const std::vector<int>& a_ItemIndices) override;
   void OnTimer() override;
   bool WantsDisplayColor() override { return true; }
   bool GetDisplayColor(int /*a_Row*/, int /*a_Column*/, unsigned char& /*r*/,

--- a/OrbitGl/ModulesDataView.h
+++ b/OrbitGl/ModulesDataView.h
@@ -52,4 +52,8 @@ class ModulesDataView : public DataView {
   static std::vector<std::wstring> s_Headers;
   static std::vector<float> s_HeaderRatios;
   static std::vector<SortingOrder> s_InitialOrders;
+
+  static const std::wstring MENU_ACTION_MODULES_LOAD;
+  static const std::wstring MENU_ACTION_DLL_FIND_PDB;
+  static const std::wstring MENU_ACTION_DLL_EXPORTS;
 };

--- a/OrbitGl/ModulesDataView.h
+++ b/OrbitGl/ModulesDataView.h
@@ -15,7 +15,8 @@ class ModulesDataView : public DataView {
   const std::vector<float>& GetColumnHeadersRatios() override;
   const std::vector<SortingOrder>& GetColumnInitialOrders() override;
   int GetDefaultSortingColumn() override;
-  std::vector<std::wstring> GetContextMenu(int a_Index) override;
+  std::vector<std::wstring> GetContextMenu(
+      int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) override;
   std::wstring GetValue(int a_Row, int a_Column) override;
 
   void OnFilter(const std::wstring& a_Filter) override;

--- a/OrbitGl/SamplingReport.cpp
+++ b/OrbitGl/SamplingReport.cpp
@@ -4,6 +4,8 @@
 
 #include "SamplingReport.h"
 
+#include <utility>
+
 #include "CallStackDataView.h"
 #include "SamplingProfiler.h"
 #include "SamplingReportDataView.h"
@@ -11,7 +13,7 @@
 //-----------------------------------------------------------------------------
 SamplingReport::SamplingReport(
     std::shared_ptr<class SamplingProfiler> a_SamplingProfiler) {
-  m_Profiler = a_SamplingProfiler;
+  m_Profiler = std::move(a_SamplingProfiler);
   m_SelectedAddress = 0;
   m_CallstackDataView = nullptr;
   m_SelectedSortedCallstackReport = nullptr;
@@ -28,13 +30,12 @@ void SamplingReport::FillReport() {
   for (ThreadSampleData* threadSampleData : sampleData) {
     ThreadID tid = threadSampleData->m_TID;
 
-    if (tid == 0 && m_Profiler->GetGenerateSummary() == false) continue;
+    if (tid == 0 && !m_Profiler->GetGenerateSummary()) continue;
 
     std::shared_ptr<SamplingReportDataView> threadReport =
         std::make_shared<SamplingReportDataView>();
     threadReport->SetSampledFunctions(threadSampleData->m_SampleReport);
     threadReport->SetThreadID(tid);
-    threadReport->SetSamplingProfiler(m_Profiler);
     threadReport->SetSamplingReport(this);
     m_ThreadReports.push_back(threadReport);
   }

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -200,14 +200,14 @@ void SamplingReportDataView::OnSort(int a_Column,
 
 //-----------------------------------------------------------------------------
 std::wstring SELECT = L"Hook";
-std::wstring DESELECT = L"Unhook";
+std::wstring UNSELECT = L"Unhook";
 std::wstring MODULES_LOAD = L"Load Symbols";
 std::wstring MODULES_DIS = L"Go To Disassembly";
 
 //-----------------------------------------------------------------------------
 std::vector<std::wstring> SamplingReportDataView::GetContextMenu(
     int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) {
-  std::vector<std::wstring> menu = {SELECT, DESELECT, MODULES_LOAD,
+  std::vector<std::wstring> menu = {SELECT, UNSELECT, MODULES_LOAD,
                                     MODULES_DIS};
   Append(menu, DataView::GetContextMenu(a_ClickedIndex, a_SelectedIndices));
   return menu;
@@ -236,8 +236,8 @@ void SamplingReportDataView::OnContextMenu(
 
       GOrbitApp->LoadModules();
     }
-  } else if (a_Action == DESELECT || a_Action == SELECT) {
-    bool unhook = a_Action == DESELECT;
+  } else if (a_Action == UNSELECT || a_Action == SELECT) {
+    bool unhook = a_Action == UNSELECT;
 
     if (Capture::GTargetProcess) {
       for (size_t i = 0; i < a_ItemIndices.size(); ++i) {

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -214,9 +214,9 @@ std::vector<std::wstring> SamplingReportDataView::GetContextMenu(
 }
 
 //-----------------------------------------------------------------------------
-void SamplingReportDataView::OnContextMenu(const std::wstring& a_Action,
-                                           int a_MenuIndex,
-                                           std::vector<int>& a_ItemIndices) {
+void SamplingReportDataView::OnContextMenu(
+    const std::wstring& a_Action, int a_MenuIndex,
+    const std::vector<int>& a_ItemIndices) {
   if (a_Action == MODULES_LOAD) {
     if (Capture::GTargetProcess) {
       std::set<std::wstring> moduleNames;

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -205,10 +205,11 @@ std::wstring MODULES_LOAD = L"Load Symbols";
 std::wstring MODULES_DIS = L"Go To Disassembly";
 
 //-----------------------------------------------------------------------------
-std::vector<std::wstring> SamplingReportDataView::GetContextMenu(int a_Index) {
+std::vector<std::wstring> SamplingReportDataView::GetContextMenu(
+    int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) {
   std::vector<std::wstring> menu = {SELECT, DESELECT, MODULES_LOAD,
                                     MODULES_DIS};
-  Append(menu, DataView::GetContextMenu(a_Index));
+  Append(menu, DataView::GetContextMenu(a_ClickedIndex, a_SelectedIndices));
   return menu;
 }
 

--- a/OrbitGl/SamplingReportDataView.h
+++ b/OrbitGl/SamplingReportDataView.h
@@ -16,7 +16,8 @@ class SamplingReportDataView : public DataView {
   const std::vector<float>& GetColumnHeadersRatios() override;
   const std::vector<SortingOrder>& GetColumnInitialOrders() override;
   int GetDefaultSortingColumn() override;
-  std::vector<std::wstring> GetContextMenu(int a_Index) override;
+  std::vector<std::wstring> GetContextMenu(
+      int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) override;
   std::wstring GetValue(int a_Row, int a_Column) override;
   const std::wstring& GetName() override { return m_Name; }
 

--- a/OrbitGl/SamplingReportDataView.h
+++ b/OrbitGl/SamplingReportDataView.h
@@ -28,15 +28,12 @@ class SamplingReportDataView : public DataView {
   void OnSelect(int a_Index) override;
 
   void LinkDataView(DataView* a_DataView) override;
-  void SetSamplingProfiler(std::shared_ptr<SamplingProfiler>& a_Profiler) {
-    m_SamplingProfiler = a_Profiler;
-  }
   void SetSamplingReport(class SamplingReport* a_SamplingReport) {
     m_SamplingReport = a_SamplingReport;
   }
   void SetSampledFunctions(const std::vector<SampledFunction>& a_Functions);
   void SetThreadID(ThreadID a_TID);
-  std::vector<SampledFunction>& GetFunctions() { return m_Functions; }
+  std::vector<SampledFunction>& GetSampledFunctions() { return m_Functions; }
 
   enum SamplingColumn {
     Toggle,
@@ -52,19 +49,27 @@ class SamplingReportDataView : public DataView {
   };
 
  protected:
-  const SampledFunction& GetFunction(unsigned int a_Row) const;
-  SampledFunction& GetFunction(unsigned int a_Row);
+  const SampledFunction& GetSampledFunction(unsigned int a_Row) const;
+  SampledFunction& GetSampledFunction(unsigned int a_Row);
+  std::vector<Function*> GetFunctionsFromIndices(
+      const std::vector<int>& a_Indices);
+  std::vector<std::shared_ptr<Module>> GetModulesFromIndices(
+      const std::vector<int>& a_Indices);
 
   std::vector<SampledFunction> m_Functions;
-  ThreadID m_TID;
+  ThreadID m_TID = -1;
   std::wstring m_Name;
-  std::shared_ptr<SamplingProfiler> m_SamplingProfiler;
   class CallStackDataView* m_CallstackDataView;
-  SamplingReport* m_SamplingReport;
+  SamplingReport* m_SamplingReport = nullptr;
 
   static void InitColumnsIfNeeded();
   static std::vector<std::wstring> s_Headers;
   static std::vector<int> s_HeaderMap;
   static std::vector<float> s_HeaderRatios;
   static std::vector<SortingOrder> s_InitialOrders;
+
+  static const std::wstring MENU_ACTION_SELECT;
+  static const std::wstring MENU_ACTION_UNSELECT;
+  static const std::wstring MENU_ACTION_MODULES_LOAD;
+  static const std::wstring MENU_ACTION_DISASSEMBLY;
 };

--- a/OrbitGl/SamplingReportDataView.h
+++ b/OrbitGl/SamplingReportDataView.h
@@ -24,7 +24,7 @@ class SamplingReportDataView : public DataView {
   void OnFilter(const std::wstring& a_Filter) override;
   void OnSort(int a_Column, std::optional<SortingOrder> a_NewOrder) override;
   void OnContextMenu(const std::wstring& a_Action, int a_MenuIndex,
-                     std::vector<int>& a_ItemIndices) override;
+                     const std::vector<int>& a_ItemIndices) override;
   void OnSelect(int a_Index) override;
 
   void LinkDataView(DataView* a_DataView) override;

--- a/OrbitGl/SessionsDataView.cpp
+++ b/OrbitGl/SessionsDataView.cpp
@@ -139,7 +139,7 @@ std::vector<std::wstring> SessionsDataView::GetContextMenu(
 //-----------------------------------------------------------------------------
 void SessionsDataView::OnContextMenu(const std::wstring& a_Action,
                                      int a_MenuIndex,
-                                     std::vector<int>& a_ItemIndices) {
+                                     const std::vector<int>& a_ItemIndices) {
   if (a_Action == SESSIONS_LOAD) {
     for (int index : a_ItemIndices) {
       const std::shared_ptr<Session>& session = GetSession(index);

--- a/OrbitGl/SessionsDataView.cpp
+++ b/OrbitGl/SessionsDataView.cpp
@@ -126,12 +126,13 @@ void SessionsDataView::OnSort(int a_Column,
 }
 
 //-----------------------------------------------------------------------------
-std::wstring SESSIONS_LOAD = L"Load Session";
+const std::wstring SessionsDataView::MENU_ACTION_SESSIONS_LOAD =
+    L"Load Session";
 
 //-----------------------------------------------------------------------------
 std::vector<std::wstring> SessionsDataView::GetContextMenu(
     int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) {
-  std::vector<std::wstring> menu = {SESSIONS_LOAD};
+  std::vector<std::wstring> menu = {MENU_ACTION_SESSIONS_LOAD};
   Append(menu, DataView::GetContextMenu(a_ClickedIndex, a_SelectedIndices));
   return menu;
 }
@@ -140,7 +141,7 @@ std::vector<std::wstring> SessionsDataView::GetContextMenu(
 void SessionsDataView::OnContextMenu(const std::wstring& a_Action,
                                      int a_MenuIndex,
                                      const std::vector<int>& a_ItemIndices) {
-  if (a_Action == SESSIONS_LOAD) {
+  if (a_Action == MENU_ACTION_SESSIONS_LOAD) {
     for (int index : a_ItemIndices) {
       const std::shared_ptr<Session>& session = GetSession(index);
       if (GOrbitApp->SelectProcess(
@@ -161,7 +162,7 @@ void SessionsDataView::OnFilter(const std::wstring& a_Filter) {
 
   std::vector<std::wstring> tokens = Tokenize(ToLower(a_Filter));
 
-  for (uint32_t i = 0; i < m_Sessions.size(); ++i) {
+  for (size_t i = 0; i < m_Sessions.size(); ++i) {
     const Session& session = *m_Sessions[i];
     std::wstring name = s2ws(Path::GetFileName(ToLower(session.m_FileName)));
     std::wstring path = s2ws(ToLower(session.m_ProcessFullPath));
@@ -191,7 +192,7 @@ void SessionsDataView::OnFilter(const std::wstring& a_Filter) {
 //-----------------------------------------------------------------------------
 void SessionsDataView::OnDataChanged() {
   m_Indices.resize(m_Sessions.size());
-  for (uint32_t i = 0; i < m_Sessions.size(); ++i) {
+  for (size_t i = 0; i < m_Sessions.size(); ++i) {
     m_Indices[i] = i;
   }
 

--- a/OrbitGl/SessionsDataView.cpp
+++ b/OrbitGl/SessionsDataView.cpp
@@ -129,9 +129,10 @@ void SessionsDataView::OnSort(int a_Column,
 std::wstring SESSIONS_LOAD = L"Load Session";
 
 //-----------------------------------------------------------------------------
-std::vector<std::wstring> SessionsDataView::GetContextMenu(int a_Index) {
+std::vector<std::wstring> SessionsDataView::GetContextMenu(
+    int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) {
   std::vector<std::wstring> menu = {SESSIONS_LOAD};
-  Append(menu, DataView::GetContextMenu(a_Index));
+  Append(menu, DataView::GetContextMenu(a_ClickedIndex, a_SelectedIndices));
   return menu;
 }
 

--- a/OrbitGl/SessionsDataView.h
+++ b/OrbitGl/SessionsDataView.h
@@ -25,7 +25,7 @@ class SessionsDataView : public DataView {
   void OnFilter(const std::wstring& a_Filter) override;
   void OnSort(int a_Column, std::optional<SortingOrder> a_NewOrder) override;
   void OnContextMenu(const std::wstring& a_Action, int a_MenuIndex,
-                     std::vector<int>& a_ItemIndices) override;
+                     const std::vector<int>& a_ItemIndices) override;
 
   void SetSessions(const std::vector<std::shared_ptr<Session> >& a_Sessions);
 

--- a/OrbitGl/SessionsDataView.h
+++ b/OrbitGl/SessionsDataView.h
@@ -45,4 +45,6 @@ class SessionsDataView : public DataView {
   static std::vector<std::wstring> s_Headers;
   static std::vector<float> s_HeaderRatios;
   static std::vector<SortingOrder> s_InitialOrders;
+
+  static const std::wstring MENU_ACTION_SESSIONS_LOAD;
 };

--- a/OrbitGl/SessionsDataView.h
+++ b/OrbitGl/SessionsDataView.h
@@ -15,7 +15,8 @@ class SessionsDataView : public DataView {
   const std::vector<std::wstring>& GetColumnHeaders() override;
   const std::vector<float>& GetColumnHeadersRatios() override;
   const std::vector<SortingOrder>& GetColumnInitialOrders() override;
-  std::vector<std::wstring> GetContextMenu(int a_Index) override;
+  std::vector<std::wstring> GetContextMenu(
+      int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) override;
   std::wstring GetValue(int a_Row, int a_Column) override;
   std::wstring GetToolTip(int a_Row, int a_Column) override;
   std::wstring GetLabel() override { return L"Sessions"; }

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -105,8 +105,7 @@ void Track::SetSize(float a_SizeX, float a_SizeY) {
 
 //-----------------------------------------------------------------------------
 void Track::OnPick(int a_X, int a_Y) {
-  if (!m_PickingEnabled)
-    return;
+  if (!m_PickingEnabled) return;
 
   Vec2& mousePos = m_MousePos[0];
   m_Canvas->ScreenToWorld(a_X, a_Y, mousePos[0], mousePos[1]);
@@ -117,8 +116,7 @@ void Track::OnPick(int a_X, int a_Y) {
 
 //-----------------------------------------------------------------------------
 void Track::OnRelease() {
-  if (!m_PickingEnabled)
-    return;
+  if (!m_PickingEnabled) return;
 
   m_Picked = false;
   m_Moving = false;
@@ -127,8 +125,7 @@ void Track::OnRelease() {
 
 //-----------------------------------------------------------------------------
 void Track::OnDrag(int a_X, int a_Y) {
-  if (!m_PickingEnabled)
-    return;
+  if (!m_PickingEnabled) return;
 
   m_Moving = true;
   float x = 0.f;

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -32,12 +32,7 @@ class Track : public Pickable {
   }
   void SetName(const std::string& a_Name) { m_Name = a_Name; }
 
-  enum LabelDisplayMode {
-    NAME_AND_TID,
-    TID_ONLY,
-    NAME_ONLY,
-    EMPTY
-  };
+  enum LabelDisplayMode { NAME_AND_TID, TID_ONLY, NAME_ONLY, EMPTY };
 
   void SetLabelDisplayMode(LabelDisplayMode label_display_mode) {
     label_display_mode_ = label_display_mode;

--- a/OrbitGl/TypesDataView.cpp
+++ b/OrbitGl/TypesDataView.cpp
@@ -284,7 +284,7 @@ std::vector<std::wstring> TypesDataView::GetContextMenu(
 }
 
 //-----------------------------------------------------------------------------
-void TypesDataView::OnProp(std::vector<int>& a_Items) {
+void TypesDataView::OnProp(const std::vector<int>& a_Items) {
   for (auto& item : a_Items) {
     Type& type = GetType(item);
     std::shared_ptr<Variable> var = type.GetTemplateVariable();
@@ -294,7 +294,7 @@ void TypesDataView::OnProp(std::vector<int>& a_Items) {
 }
 
 //-----------------------------------------------------------------------------
-void TypesDataView::OnView(std::vector<int>& a_Items) {
+void TypesDataView::OnView(const std::vector<int>& a_Items) {
   for (auto& item : a_Items) {
     Type& type = GetType(item);
     std::shared_ptr<Variable> var = type.GetTemplateVariable();
@@ -308,14 +308,14 @@ void TypesDataView::OnView(std::vector<int>& a_Items) {
 }
 
 //-----------------------------------------------------------------------------
-void TypesDataView::OnClip(std::vector<int>& a_Items) {
+void TypesDataView::OnClip(const std::vector<int>& a_Items) {
   UNUSED(a_Items);
   GOrbitApp->SendToUiAsync(L"output");
 }
 
 //-----------------------------------------------------------------------------
 void TypesDataView::OnContextMenu(const std::wstring& a_Action, int a_MenuIndex,
-                                  std::vector<int>& a_ItemIndices) {
+                                  const std::vector<int>& a_ItemIndices) {
   if (a_Action == TYPES_SUMMARY) {
     OnProp(a_ItemIndices);
   } else if (a_Action == TYPES_DETAILS) {

--- a/OrbitGl/TypesDataView.cpp
+++ b/OrbitGl/TypesDataView.cpp
@@ -272,13 +272,13 @@ void TypesDataView::OnSort(int a_Column,
 }
 
 //-----------------------------------------------------------------------------
-std::wstring TYPES_SUMMARY = L"Summary";
-std::wstring TYPES_DETAILS = L"Details";
+const std::wstring TypesDataView::MENU_ACTION_SUMMARY = L"Summary";
+const std::wstring TypesDataView::MENU_ACTION_DETAILS = L"Details";
 
 //-----------------------------------------------------------------------------
 std::vector<std::wstring> TypesDataView::GetContextMenu(
     int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) {
-  std::vector<std::wstring> menu = {TYPES_SUMMARY, TYPES_DETAILS};
+  std::vector<std::wstring> menu = {MENU_ACTION_SUMMARY, MENU_ACTION_DETAILS};
   Append(menu, DataView::GetContextMenu(a_ClickedIndex, a_SelectedIndices));
   return menu;
 }
@@ -316,9 +316,9 @@ void TypesDataView::OnClip(const std::vector<int>& a_Items) {
 //-----------------------------------------------------------------------------
 void TypesDataView::OnContextMenu(const std::wstring& a_Action, int a_MenuIndex,
                                   const std::vector<int>& a_ItemIndices) {
-  if (a_Action == TYPES_SUMMARY) {
+  if (a_Action == MENU_ACTION_SUMMARY) {
     OnProp(a_ItemIndices);
-  } else if (a_Action == TYPES_DETAILS) {
+  } else if (a_Action == MENU_ACTION_DETAILS) {
     OnView(a_ItemIndices);
   } else {
     DataView::OnContextMenu(a_Action, a_MenuIndex, a_ItemIndices);

--- a/OrbitGl/TypesDataView.cpp
+++ b/OrbitGl/TypesDataView.cpp
@@ -276,9 +276,10 @@ std::wstring TYPES_SUMMARY = L"Summary";
 std::wstring TYPES_DETAILS = L"Details";
 
 //-----------------------------------------------------------------------------
-std::vector<std::wstring> TypesDataView::GetContextMenu(int a_Index) {
+std::vector<std::wstring> TypesDataView::GetContextMenu(
+    int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) {
   std::vector<std::wstring> menu = {TYPES_SUMMARY, TYPES_DETAILS};
-  Append(menu, DataView::GetContextMenu(a_Index));
+  Append(menu, DataView::GetContextMenu(a_ClickedIndex, a_SelectedIndices));
   return menu;
 }
 

--- a/OrbitGl/TypesDataView.h
+++ b/OrbitGl/TypesDataView.h
@@ -40,4 +40,7 @@ class TypesDataView : public DataView {
   static std::vector<int> s_HeaderMap;
   static std::vector<float> s_HeaderRatios;
   static std::vector<SortingOrder> s_InitialOrders;
+
+  static const std::wstring MENU_ACTION_SUMMARY;
+  static const std::wstring MENU_ACTION_DETAILS;
 };

--- a/OrbitGl/TypesDataView.h
+++ b/OrbitGl/TypesDataView.h
@@ -23,15 +23,15 @@ class TypesDataView : public DataView {
   void ParallelFilter(const std::wstring& a_Filter);
   void OnSort(int a_Column, std::optional<SortingOrder> a_NewOrder) override;
   void OnContextMenu(const std::wstring& a_Action, int a_MenuIndex,
-                     std::vector<int>& a_ItemIndices) override;
+                     const std::vector<int>& a_ItemIndices) override;
   void OnDataChanged() override;
 
  protected:
   Type& GetType(unsigned int a_Row) const;
 
-  void OnProp(std::vector<int>& a_Items);
-  void OnView(std::vector<int>& a_Items);
-  void OnClip(std::vector<int>& a_Items);
+  void OnProp(const std::vector<int>& a_Items);
+  void OnView(const std::vector<int>& a_Items);
+  void OnClip(const std::vector<int>& a_Items);
 
   std::vector<std::wstring> m_FilterTokens;
 

--- a/OrbitGl/TypesDataView.h
+++ b/OrbitGl/TypesDataView.h
@@ -15,7 +15,8 @@ class TypesDataView : public DataView {
   const std::vector<std::wstring>& GetColumnHeaders() override;
   const std::vector<float>& GetColumnHeadersRatios() override;
   const std::vector<SortingOrder>& GetColumnInitialOrders() override;
-  std::vector<std::wstring> GetContextMenu(int a_Index) override;
+  std::vector<std::wstring> GetContextMenu(
+      int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) override;
   std::wstring GetValue(int a_Row, int a_Column) override;
 
   void OnFilter(const std::wstring& a_Filter) override;

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -11,6 +11,7 @@
 #include <QMouseEvent>
 #include <QTimer>
 #include <QToolTip>
+#include <utility>
 
 #include "../OrbitCore/Path.h"
 #include "../OrbitCore/PrintVar.h"
@@ -62,11 +63,11 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App, QWidget* parent)
       [this](DataViewType a_Type) { this->OnRefreshDataViewPanels(a_Type); });
   GOrbitApp->AddSamplingReoprtCallback(
       [this](std::shared_ptr<SamplingReport> a_Report) {
-        this->OnNewSamplingReport(a_Report);
+        this->OnNewSamplingReport(std::move(a_Report));
       });
   GOrbitApp->AddSelectionReportCallback(
       [this](std::shared_ptr<SamplingReport> a_Report) {
-        this->OnNewSelection(a_Report);
+        this->OnNewSelection(std::move(a_Report));
       });
   GOrbitApp->AddUiMessageCallback([this](const std::wstring& a_Message) {
     this->OnReceiveMessage(a_Message);

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -300,7 +300,7 @@ void OrbitMainWindow::OnNewSamplingReport(
   m_SamplingLayout->addWidget(m_OrbitSamplingReport, 0, 0, 1, 1);
 
   // Automatically switch to sampling tab if not already in live tab.
-  if( ui->RightTabWidget->currentWidget() != ui->LiveTab) {
+  if (ui->RightTabWidget->currentWidget() != ui->LiveTab) {
     ui->RightTabWidget->setCurrentWidget(m_SamplingTab);
   }
 }

--- a/OrbitQt/orbittreeview.cpp
+++ b/OrbitQt/orbittreeview.cpp
@@ -208,39 +208,34 @@ void OrbitTreeView::ShowContextMenu(const QPoint& pos) {
     if (!menu.empty()) {
       QMenu contextMenu(tr("ContextMenu"), this);
       GContextMenu = &contextMenu;
-      QSignalMapper signalMapper(this);
-      std::vector<QAction*> actions;
+      std::vector<std::unique_ptr<QAction>> actions;
 
       for (int i = 0; i < (int)menu.size(); ++i) {
-        actions.push_back(new QAction(QString::fromStdWString(menu[i])));
-        connect(actions[i], SIGNAL(triggered()), &signalMapper, SLOT(map()));
-        signalMapper.setMapping(actions[i], i);
-        contextMenu.addAction(actions[i]);
+        actions.push_back(
+            std::make_unique<QAction>(QString::fromStdWString(menu[i])));
+        connect(actions[i].get(), &QAction::triggered,
+                [this, &menu, i] { OnMenuClicked(menu[i], i); });
+        contextMenu.addAction(actions[i].get());
       }
 
-      connect(&signalMapper, SIGNAL(mapped(int)), this,
-              SLOT(OnMenuClicked(int)));
       contextMenu.exec(mapToGlobal(pos));
       GContextMenu = nullptr;
-
-      for (QAction* action : actions) delete action;
     }
   }
 }
 
 //-----------------------------------------------------------------------------
-void OrbitTreeView::OnMenuClicked(int a_Index) {
-  QModelIndexList list = selectionModel()->selectedIndexes();
-  std::set<int> selection;
-  for (QModelIndex& index : list) {
-    selection.insert(index.row());
+void OrbitTreeView::OnMenuClicked(const std::wstring& a_Action,
+                                  int a_MenuIndex) {
+  QModelIndexList selection_list = selectionModel()->selectedIndexes();
+  std::set<int> selection_set;
+  for (QModelIndex& index : selection_list) {
+    selection_set.insert(index.row());
   }
 
-  std::vector<int> indices(selection.begin(), selection.end());
+  std::vector<int> indices(selection_set.begin(), selection_set.end());
   if (!indices.empty()) {
-    const std::vector<std::wstring>& menu =
-        m_Model->GetDataView()->GetContextMenu(indices[0]);
-    m_Model->GetDataView()->OnContextMenu(menu[a_Index], a_Index, indices);
+    m_Model->GetDataView()->OnContextMenu(a_Action, a_MenuIndex, indices);
   }
 }
 

--- a/OrbitQt/orbittreeview.cpp
+++ b/OrbitQt/orbittreeview.cpp
@@ -202,9 +202,18 @@ QMenu* GContextMenu;
 void OrbitTreeView::ShowContextMenu(const QPoint& pos) {
   QModelIndex index = this->indexAt(pos);
   if (index.isValid()) {
-    std::vector<std::wstring> menu =
-        m_Model->GetDataView()->GetContextMenu(index.row());
+    int clicked_index = index.row();
 
+    QModelIndexList selection_list = selectionModel()->selectedIndexes();
+    std::set<int> selection_set;
+    for (QModelIndex& selected_index : selection_list) {
+      selection_set.insert(selected_index.row());
+    }
+    std::vector<int> selected_indices(selection_set.begin(),
+                                      selection_set.end());
+
+    std::vector<std::wstring> menu =
+        m_Model->GetDataView()->GetContextMenu(clicked_index, selected_indices);
     if (!menu.empty()) {
       QMenu contextMenu(tr("ContextMenu"), this);
       GContextMenu = &contextMenu;

--- a/OrbitQt/orbittreeview.h
+++ b/OrbitQt/orbittreeview.h
@@ -40,7 +40,7 @@ class OrbitTreeView : public QTreeView {
   void OnTimer();
   void OnClicked(const QModelIndex& index);
   void ShowContextMenu(const QPoint& pos);
-  void OnMenuClicked(int a_Index);
+  void OnMenuClicked(const std::wstring& a_Action, int a_MenuIndex);
   void OnRangeChanged(int a_Min, int a_Max);
 
  private:


### PR DESCRIPTION
Setup OrbigGl/DataView::GetContextMenu so that it accepts the selected indices and use them in the overriding implementations. Overall a small cleanup of context menus.
Note that some actions don't work (e.g., "Go to Disassembly"), but I left them there for now.

Bug: b/153333554