### PR TITLE
Fix crash on "Hook" from a CallStackDataView

### DIFF
--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -29,7 +29,7 @@ std::string CallStackDataView::GetValue(int a_Row, int a_Column) {
     return "";
   }
 
-  Function& function = GetFunctionOrDummy(a_Row);
+  Function& function = GetFunctionOrDummy(m_Indices[a_Row]);
 
   std::string value;
 
@@ -106,11 +106,12 @@ void CallStackDataView::OnDataChanged() {
 
 //-----------------------------------------------------------------------------
 Function* CallStackDataView::GetFunction(int a_Row) {
-  if (m_CallStack != nullptr && a_Row < m_CallStack->m_Depth &&
+  int index = m_Indices[a_Row];
+  if (m_CallStack != nullptr && index < m_CallStack->m_Depth &&
       Capture::GTargetProcess != nullptr) {
     ScopeLock lock(Capture::GTargetProcess->GetDataMutex());
 
-    uint64_t address = m_CallStack->m_Data[a_Row];
+    uint64_t address = m_CallStack->m_Data[index];
     Function* function =
         Capture::GTargetProcess->GetFunctionFromAddress(address, false);
     return function;
@@ -119,16 +120,16 @@ Function* CallStackDataView::GetFunction(int a_Row) {
 }
 
 //-----------------------------------------------------------------------------
-Function& CallStackDataView::GetFunctionOrDummy(int a_Row) {
-  Function* function = GetFunction(a_Row);
+Function& CallStackDataView::GetFunctionOrDummy(int a_IndexInCallstack) {
+  Function* function = GetFunction(a_IndexInCallstack);
   if (function != nullptr) {
     return *function;
   }
 
   static Function dummy;
-  if (m_CallStack != nullptr && a_Row < m_CallStack->m_Depth &&
+  if (m_CallStack != nullptr && a_IndexInCallstack < m_CallStack->m_Depth &&
       Capture::GSamplingProfiler != nullptr) {
-    uint64_t address = m_CallStack->m_Data[a_Row];
+    uint64_t address = m_CallStack->m_Data[a_IndexInCallstack];
     dummy.SetPrettyName(
         ws2s(Capture::GSamplingProfiler->GetSymbolFromAddress(address)));
     dummy.SetAddress(address);

--- a/OrbitGl/CallStackDataView.h
+++ b/OrbitGl/CallStackDataView.h
@@ -17,16 +17,17 @@ class CallStackDataView : public FunctionsDataView {
   bool IsSortingAllowed() override { return false; }
   void SetAsMainInstance() override;
   size_t GetNumElements() override;
-  void OnDataChanged() override;
   std::string GetValue(int a_Row, int a_Column) override;
   void OnFilter(const std::string& a_Filter) override;
+  void OnDataChanged() override;
   void SetCallStack(std::shared_ptr<CallStack> a_CallStack) {
     m_CallStack = std::move(a_CallStack);
     OnDataChanged();
   }
 
  protected:
-  Function& GetFunction(unsigned int a_Row) override;
+  Function* GetFunction(int a_Row) override;
+  Function& GetFunctionOrDummy(int a_Row);
 
   std::shared_ptr<CallStack> m_CallStack;
 };

--- a/OrbitGl/CallStackDataView.h
+++ b/OrbitGl/CallStackDataView.h
@@ -27,7 +27,7 @@ class CallStackDataView : public FunctionsDataView {
 
  protected:
   Function* GetFunction(int a_Row) override;
-  Function& GetFunctionOrDummy(int a_Row);
+  Function& GetFunctionOrDummy(int a_IndexInCallstack);
 
   std::shared_ptr<CallStack> m_CallStack;
 };

--- a/OrbitGl/FunctionsDataView.cpp
+++ b/OrbitGl/FunctionsDataView.cpp
@@ -109,7 +109,10 @@ std::string FunctionsDataView::GetValue(int a_Row, int a_Column) {
     return "";
   }
 
-  Function& function = GetFunction(a_Row);
+  Function* function = GetFunction(a_Row);
+  if (function == nullptr) {
+    return "";
+  }
 
   std::string value;
 
@@ -118,28 +121,29 @@ std::string FunctionsDataView::GetValue(int a_Row, int a_Column) {
       value = absl::StrFormat("%d", a_Row);
       break;
     case Function::SELECTED:
-      value = function.IsSelected() ? "X" : "-";
+      value = function->IsSelected() ? "X" : "-";
       break;
     case Function::NAME:
-      value = function.PrettyName();
+      value = function->PrettyName();
       break;
     case Function::ADDRESS:
-      value = absl::StrFormat("0x%llx", function.GetVirtualAddress());
+      value = absl::StrFormat("0x%llx", function->GetVirtualAddress());
       break;
     case Function::FILE:
-      value = function.File();
+      value = function->File();
       break;
     case Function::MODULE:
-      value = function.GetPdb() != nullptr ? function.GetPdb()->GetName() : "";
+      value =
+          function->GetPdb() != nullptr ? function->GetPdb()->GetName() : "";
       break;
     case Function::LINE:
-      value = absl::StrFormat("%i", function.Line());
+      value = absl::StrFormat("%i", function->Line());
       break;
     case Function::SIZE:
-      value = absl::StrFormat("%lu", function.Size());
+      value = absl::StrFormat("%lu", function->Size());
       break;
     case Function::CALL_CONV:
-      value = function.GetCallingConventionString();
+      value = function->GetCallingConventionString();
       break;
     default:
       break;
@@ -224,18 +228,27 @@ std::vector<std::string> FunctionsDataView::GetContextMenu(
     int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) {
   bool enable_select = false;
   bool enable_unselect = false;
+  bool enable_view_disassembly = false;
   for (int index : a_SelectedIndices) {
-    const Function& function = GetFunction(index);
-    enable_select |= !function.IsSelected();
-    enable_unselect |= function.IsSelected();
+    const Function* function = GetFunction(index);
+    if (function == nullptr) continue;
+    enable_select |= !function->IsSelected();
+    enable_unselect |= function->IsSelected();
+    enable_view_disassembly = true;
   }
 
-  bool enable_create_rule = a_SelectedIndices.size() == 1;
+  bool enable_create_rule = false;
+  if (a_SelectedIndices.size() == 1 &&
+      GetFunction(a_SelectedIndices[0]) != nullptr) {
+    enable_create_rule = true;
+  }
 
   std::vector<std::string> menu;
   if (enable_select) menu.emplace_back(MENU_ACTION_SELECT);
   if (enable_unselect) menu.emplace_back(MENU_ACTION_UNSELECT);
-  Append(menu, {MENU_ACTION_VIEW, MENU_ACTION_DISASSEMBLY});
+  if (enable_view_disassembly) {
+    Append(menu, {MENU_ACTION_VIEW, MENU_ACTION_DISASSEMBLY});
+  }
   if (enable_create_rule) menu.emplace_back(MENU_ACTION_CREATE_RULE);
   // TODO: MENU_ACTION_SET_AS_FRAME is never shown, should it be removed?
   Append(menu, DataView::GetContextMenu(a_ClickedIndex, a_SelectedIndices));
@@ -246,39 +259,43 @@ std::vector<std::string> FunctionsDataView::GetContextMenu(
 void FunctionsDataView::OnContextMenu(const std::string& a_Action,
                                       int a_MenuIndex,
                                       const std::vector<int>& a_ItemIndices) {
+  std::vector<Function*> functions;
+  for (int i : a_ItemIndices) {
+    Function* function = GetFunction(i);
+    if (function != nullptr) {
+      functions.push_back(function);
+    }
+  }
+
   if (a_Action == MENU_ACTION_SELECT) {
-    for (int i : a_ItemIndices) {
-      Function& function = GetFunction(i);
-      function.Select();
+    for (Function* function : functions) {
+      function->Select();
     }
   } else if (a_Action == MENU_ACTION_UNSELECT) {
-    for (int i : a_ItemIndices) {
-      Function& func = GetFunction(i);
-      func.UnSelect();
+    for (Function* function : functions) {
+      function->UnSelect();
     }
   } else if (a_Action == MENU_ACTION_VIEW) {
-    for (int i : a_ItemIndices) {
-      Function& function = GetFunction(i);
-      function.Print();
+    for (Function* function : functions) {
+      function->Print();
     }
 
     GOrbitApp->SendToUiNow(L"output");
   } else if (a_Action == MENU_ACTION_DISASSEMBLY) {
     // TODO: does this action work or should we hide it?
-    for (int i : a_ItemIndices) {
-      Function& function = GetFunction(i);
-      function.GetDisassembly();
+    for (Function* function : functions) {
+      function->GetDisassembly();
     }
   } else if (a_Action == MENU_ACTION_CREATE_RULE) {
-    if (a_ItemIndices.size() == 1) {
-      Function& function = GetFunction(a_ItemIndices[0]);
-      GOrbitApp->LaunchRuleEditor(&function);
+    if (functions.size() != 1) {
+      return;
     }
+    GOrbitApp->LaunchRuleEditor(functions[0]);
   } else if (a_Action == MENU_ACTION_SET_AS_FRAME) {
-    if (a_ItemIndices.size() == 1) {
-      Function& function = GetFunction(a_ItemIndices[0]);
-      function.SetAsMainFrameFunction();
+    if (functions.size() != 1) {
+      return;
     }
+    functions[0]->SetAsMainFrameFunction();
   } else {
     DataView::OnContextMenu(a_Action, a_MenuIndex, a_ItemIndices);
   }
@@ -378,7 +395,8 @@ void FunctionsDataView::OnDataChanged() {
 }
 
 //-----------------------------------------------------------------------------
-Function& FunctionsDataView::GetFunction(unsigned int a_Row) {
+Function* FunctionsDataView::GetFunction(int a_Row) {
+  ScopeLock lock(Capture::GTargetProcess->GetDataMutex());
   std::vector<Function*>& functions = Capture::GTargetProcess->GetFunctions();
-  return *functions[m_Indices[a_Row]];
+  return functions[m_Indices[a_Row]];
 }

--- a/OrbitGl/FunctionsDataView.cpp
+++ b/OrbitGl/FunctionsDataView.cpp
@@ -271,12 +271,12 @@ void FunctionsDataView::OnContextMenu(const std::string& a_Action,
     }
   } else if (a_Action == MENU_ACTION_CREATE_RULE) {
     if (a_ItemIndices.size() == 1) {
-      Function& function = GetFunction(0);
+      Function& function = GetFunction(a_ItemIndices[0]);
       GOrbitApp->LaunchRuleEditor(&function);
     }
   } else if (a_Action == MENU_ACTION_SET_AS_FRAME) {
     if (a_ItemIndices.size() == 1) {
-      Function& function = GetFunction(0);
+      Function& function = GetFunction(a_ItemIndices[0]);
       function.SetAsMainFrameFunction();
     }
   } else {

--- a/OrbitGl/FunctionsDataView.h
+++ b/OrbitGl/FunctionsDataView.h
@@ -25,7 +25,7 @@ class FunctionsDataView : public DataView {
   void OnDataChanged() override;
 
  protected:
-  virtual Function& GetFunction(unsigned int a_Row);
+  virtual Function* GetFunction(int a_Row);
 
   std::vector<std::string> m_FilterTokens;
 


### PR DESCRIPTION
The problem was that `CallStackDataView` is a subclass of `FunctionsDataView`
and `CallStackDataView::GetFunction` returned a "dummy" `Function` (e.g, with
`pdb_ == nullptr`) when the row selected corresponds to an unknown function.
Calling `Function::Select` on such dummy `Function` would cause segmentation
fault.
Let's return a `nullptr` instead of a dummy so that we can check for it even in
`FunctionsDataView`.
Let's have a different function to return a dummy when necessary.

Bug: b/153149392

Note that for a better fix we would probably want a `CallStackDataView` that
is not a subclass of `FunctionsDataView`, so that we can have a behavior
independent from FunctionsDataView, include some feature like context menu
action "Load Symbols" from `SamplingReportDataView`. But let's fix this first.