### PR TITLE
Get RAX on uretprobe to track integer return values.

### DIFF
--- a/OrbitCore/LinuxTracingHandler.cpp
+++ b/OrbitCore/LinuxTracingHandler.cpp
@@ -146,7 +146,7 @@ void LinuxTracingHandler::OnFunctionCall(
   timer.m_End = function_call.GetEndTimestampNs();
   timer.m_Depth = static_cast<uint8_t>(function_call.GetDepth());
   timer.m_FunctionAddress = function_call.GetVirtualAddress();
-  timer.m_UserData[0] = function_call.GetReturnValue();
+  timer.m_UserData[0] = function_call.GetIntegerReturnValue();
 
   session_->RecordTimer(std::move(timer));
 }

--- a/OrbitCore/LinuxTracingHandler.cpp
+++ b/OrbitCore/LinuxTracingHandler.cpp
@@ -146,6 +146,7 @@ void LinuxTracingHandler::OnFunctionCall(
   timer.m_End = function_call.GetEndTimestampNs();
   timer.m_Depth = static_cast<uint8_t>(function_call.GetDepth());
   timer.m_FunctionAddress = function_call.GetVirtualAddress();
+  timer.m_UserData[0] = function_call.GetReturnValue();
 
   session_->RecordTimer(std::move(timer));
 }

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -31,7 +31,10 @@
 #include "TimerManager.h"
 #include "Utils.h"
 #include "absl/strings/str_format.h"
+#include "absl/flags/flag.h"
 
+// TODO: Remove this flag once we have a way to toggle the display return values
+ABSL_FLAG(bool, show_return_values, false, "Show return values on time slices");
 TimeGraph* GCurrentTimeGraph = nullptr;
 
 //-----------------------------------------------------------------------------
@@ -462,11 +465,15 @@ void TimeGraph::SelectRight(const TextBox* a_TextBox) {
 void TimeGraph::NeedsUpdate() { m_NeedsUpdatePrimitives = true; }
 
 //-----------------------------------------------------------------------------
-inline std::string GetExtraInfo(const Timer& a_Timer) {
+std::string GetExtraInfo(const Timer& a_Timer) {
   std::string info;
+  static bool show_return_value = absl::GetFlag(FLAGS_show_return_values);
   if (!Capture::IsCapturing() && a_Timer.GetType() == Timer::UNREAL_OBJECT) {
     info =
         "[" + ws2s(GOrbitUnreal.GetObjectNames()[a_Timer.m_UserData[0]]) + "]";
+  }
+  else if (show_return_value && (a_Timer.GetType() == Timer::NONE)) {
+    info = absl::StrFormat("[%lu]", a_Timer.m_UserData[0]);
   }
   return info;
 }

--- a/OrbitLinuxTracing/PerfEvent.h
+++ b/OrbitLinuxTracing/PerfEvent.h
@@ -296,7 +296,7 @@ class UprobesPerfEvent : public PerfEvent, public AbstractUprobesPerfEvent {
 
 class UretprobesPerfEvent : public PerfEvent, public AbstractUprobesPerfEvent {
  public:
-  perf_event_empty_sample ring_buffer_record;
+  perf_event_uretprobe ring_buffer_record;
 
   uint64_t GetTimestamp() const override {
     return ring_buffer_record.sample_id.time;
@@ -306,6 +306,9 @@ class UretprobesPerfEvent : public PerfEvent, public AbstractUprobesPerfEvent {
 
   pid_t GetPid() const { return ring_buffer_record.sample_id.pid; }
   pid_t GetTid() const { return ring_buffer_record.sample_id.tid; }
+
+  // Get AX register which typically holds return value.
+  uint64_t GetAx() const { return ring_buffer_record.ax; }
 
   uint64_t GetStreamId() const {
     return ring_buffer_record.sample_id.stream_id;

--- a/OrbitLinuxTracing/PerfEvent.h
+++ b/OrbitLinuxTracing/PerfEvent.h
@@ -296,7 +296,7 @@ class UprobesPerfEvent : public PerfEvent, public AbstractUprobesPerfEvent {
 
 class UretprobesPerfEvent : public PerfEvent, public AbstractUprobesPerfEvent {
  public:
-  perf_event_ax ring_buffer_record;
+  perf_event_ax_sample ring_buffer_record;
 
   uint64_t GetTimestamp() const override {
     return ring_buffer_record.sample_id.time;

--- a/OrbitLinuxTracing/PerfEvent.h
+++ b/OrbitLinuxTracing/PerfEvent.h
@@ -296,7 +296,7 @@ class UprobesPerfEvent : public PerfEvent, public AbstractUprobesPerfEvent {
 
 class UretprobesPerfEvent : public PerfEvent, public AbstractUprobesPerfEvent {
  public:
-  perf_event_uretprobe ring_buffer_record;
+  perf_event_ax ring_buffer_record;
 
   uint64_t GetTimestamp() const override {
     return ring_buffer_record.sample_id.time;
@@ -307,8 +307,9 @@ class UretprobesPerfEvent : public PerfEvent, public AbstractUprobesPerfEvent {
   pid_t GetPid() const { return ring_buffer_record.sample_id.pid; }
   pid_t GetTid() const { return ring_buffer_record.sample_id.tid; }
 
-  // Get AX register which typically holds return value.
-  uint64_t GetAx() const { return ring_buffer_record.ax; }
+  // Get AX register which holds integer return value.
+  // See https://wiki.osdev.org/System_V_ABI.
+  uint64_t GetAx() const { return ring_buffer_record.regs.ax; }
 
   uint64_t GetStreamId() const {
     return ring_buffer_record.sample_id.stream_id;

--- a/OrbitLinuxTracing/PerfEventOpen.cpp
+++ b/OrbitLinuxTracing/PerfEventOpen.cpp
@@ -109,7 +109,7 @@ int uretprobes_event_open(const char* module, uint64_t function_offset,
   pe.config = 1;  // Set bit 0 of config for uretprobe.
 
   pe.sample_type |= PERF_SAMPLE_REGS_USER;
-  pe.sample_regs_user = SAMPLE_REGS_URET_PROBE;
+  pe.sample_regs_user = SAMPLE_REGS_USER_AX;
 
   return generic_event_open(&pe, pid, cpu);
 }

--- a/OrbitLinuxTracing/PerfEventOpen.cpp
+++ b/OrbitLinuxTracing/PerfEventOpen.cpp
@@ -108,6 +108,9 @@ int uretprobes_event_open(const char* module, uint64_t function_offset,
   perf_event_attr pe = uprobe_event_attr(module, function_offset);
   pe.config = 1;  // Set bit 0 of config for uretprobe.
 
+  pe.sample_type |= PERF_SAMPLE_REGS_USER;
+  pe.sample_regs_user = SAMPLE_REGS_URET_PROBE;
+
   return generic_event_open(&pe, pid, cpu);
 }
 

--- a/OrbitLinuxTracing/PerfEventOpen.h
+++ b/OrbitLinuxTracing/PerfEventOpen.h
@@ -93,6 +93,12 @@ static constexpr uint64_t SAMPLE_REGS_USER_ALL =
 static constexpr uint64_t SAMPLE_REGS_USER_SP_IP =
     (1lu << PERF_REG_X86_SP) | (1lu << PERF_REG_X86_IP);
 
+// This must be in sync with struct perf_event_uret_probe in
+// PerfEventRecords.h.
+static constexpr uint64_t SAMPLE_REGS_URET_PROBE = (1lu << PERF_REG_X86_SP) |
+                                                   (1lu << PERF_REG_X86_IP) |
+                                                   (1lu << PERF_REG_X86_AX);
+
 // Max to pass to perf_event_open without getting an error is (1u << 16u) - 8,
 // because the kernel stores this in a short and because of alignment reasons.
 // But the size the kernel actually returns is smaller, because the maximum size

--- a/OrbitLinuxTracing/PerfEventOpen.h
+++ b/OrbitLinuxTracing/PerfEventOpen.h
@@ -93,11 +93,9 @@ static constexpr uint64_t SAMPLE_REGS_USER_ALL =
 static constexpr uint64_t SAMPLE_REGS_USER_SP_IP =
     (1lu << PERF_REG_X86_SP) | (1lu << PERF_REG_X86_IP);
 
-// This must be in sync with struct perf_event_uret_probe in
+// This must be in sync with struct perf_event_ax in
 // PerfEventRecords.h.
-static constexpr uint64_t SAMPLE_REGS_URET_PROBE = (1lu << PERF_REG_X86_SP) |
-                                                   (1lu << PERF_REG_X86_IP) |
-                                                   (1lu << PERF_REG_X86_AX);
+static constexpr uint64_t SAMPLE_REGS_USER_AX = (1lu << PERF_REG_X86_AX);
 
 // Max to pass to perf_event_open without getting an error is (1u << 16u) - 8,
 // because the kernel stores this in a short and because of alignment reasons.

--- a/OrbitLinuxTracing/PerfEventOpen.h
+++ b/OrbitLinuxTracing/PerfEventOpen.h
@@ -93,7 +93,7 @@ static constexpr uint64_t SAMPLE_REGS_USER_ALL =
 static constexpr uint64_t SAMPLE_REGS_USER_SP_IP =
     (1lu << PERF_REG_X86_SP) | (1lu << PERF_REG_X86_IP);
 
-// This must be in sync with struct perf_event_ax in
+// This must be in sync with struct perf_event_ax_sample in
 // PerfEventRecords.h.
 static constexpr uint64_t SAMPLE_REGS_USER_AX = (1lu << PERF_REG_X86_AX);
 

--- a/OrbitLinuxTracing/PerfEventRecords.h
+++ b/OrbitLinuxTracing/PerfEventRecords.h
@@ -61,6 +61,14 @@ struct __attribute__((__packed__)) perf_event_sample_regs_user_all {
   uint64_t r15;
 };
 
+// This struct must be in sync with the SAMPLE_REGS_USER_AX in
+// PerfEventOpen.h.
+struct __attribute__((__packed__)) perf_event_sample_regs_user_ax
+{
+  uint64_t abi;
+  uint64_t ax;
+};
+
 // This struct must be in sync with the SAMPLE_REGS_USER_SP_IP in
 // PerfEventOpen.h.
 struct __attribute__((__packed__)) perf_event_sample_regs_user_sp_ip {
@@ -86,15 +94,10 @@ struct __attribute__((__packed__)) perf_event_empty_sample {
   perf_event_sample_id_tid_time_streamid_cpu sample_id;
 };
 
-// This struct must be in sync with the SAMPLE_REGS_URET_PROBE in
-// PerfEventOpen.h.
-struct __attribute__((__packed__)) perf_event_uretprobe {
+struct __attribute__((__packed__)) perf_event_ax {
   perf_event_header header;
   perf_event_sample_id_tid_time_streamid_cpu sample_id;
-  uint64_t abi;
-  uint64_t ax;
-  uint64_t sp;
-  uint64_t ip;
+  perf_event_sample_regs_user_ax regs;
 };
 
 struct __attribute__((__packed__)) perf_event_stack_sample {

--- a/OrbitLinuxTracing/PerfEventRecords.h
+++ b/OrbitLinuxTracing/PerfEventRecords.h
@@ -94,12 +94,6 @@ struct __attribute__((__packed__)) perf_event_empty_sample {
   perf_event_sample_id_tid_time_streamid_cpu sample_id;
 };
 
-struct __attribute__((__packed__)) perf_event_ax {
-  perf_event_header header;
-  perf_event_sample_id_tid_time_streamid_cpu sample_id;
-  perf_event_sample_regs_user_ax regs;
-};
-
 struct __attribute__((__packed__)) perf_event_stack_sample {
   perf_event_header header;
   perf_event_sample_id_tid_time_streamid_cpu sample_id;
@@ -112,6 +106,12 @@ struct __attribute__((__packed__)) perf_event_sp_ip_8bytes_sample {
   perf_event_sample_id_tid_time_streamid_cpu sample_id;
   perf_event_sample_regs_user_sp_ip regs;
   perf_event_sample_stack_user_8bytes stack;
+};
+
+struct __attribute__((__packed__)) perf_event_ax_sample {
+  perf_event_header header;
+  perf_event_sample_id_tid_time_streamid_cpu sample_id;
+  perf_event_sample_regs_user_ax regs;
 };
 
 struct __attribute__((__packed__)) perf_event_lost {

--- a/OrbitLinuxTracing/PerfEventRecords.h
+++ b/OrbitLinuxTracing/PerfEventRecords.h
@@ -86,6 +86,17 @@ struct __attribute__((__packed__)) perf_event_empty_sample {
   perf_event_sample_id_tid_time_streamid_cpu sample_id;
 };
 
+// This struct must be in sync with the SAMPLE_REGS_URET_PROBE in
+// PerfEventOpen.h.
+struct __attribute__((__packed__)) perf_event_uretprobe {
+  perf_event_header header;
+  perf_event_sample_id_tid_time_streamid_cpu sample_id;
+  uint64_t abi;
+  uint64_t ax;
+  uint64_t sp;
+  uint64_t ip;
+};
+
 struct __attribute__((__packed__)) perf_event_stack_sample {
   perf_event_header header;
   perf_event_sample_id_tid_time_streamid_cpu sample_id;

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -591,7 +591,7 @@ void TracerThread::ProcessSampleEvent(const perf_event_header& header,
   constexpr size_t size_of_uprobes = sizeof(perf_event_sp_ip_8bytes_sample);
   bool is_uprobe = !is_gpu_event && (header.size == size_of_uprobes);
 
-  constexpr size_t size_of_uretprobes = sizeof(perf_event_ax);
+  constexpr size_t size_of_uretprobes = sizeof(perf_event_ax_sample);
   bool is_uretprobe = !is_gpu_event && (header.size == size_of_uretprobes);
 
   constexpr size_t size_of_sample = sizeof(perf_event_stack_sample);

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -591,7 +591,7 @@ void TracerThread::ProcessSampleEvent(const perf_event_header& header,
   constexpr size_t size_of_uprobes = sizeof(perf_event_sp_ip_8bytes_sample);
   bool is_uprobe = !is_gpu_event && (header.size == size_of_uprobes);
 
-  constexpr size_t size_of_uretprobes = sizeof(perf_event_empty_sample);
+  constexpr size_t size_of_uretprobes = sizeof(perf_event_uretprobe);
   bool is_uretprobe = !is_gpu_event && (header.size == size_of_uretprobes);
 
   constexpr size_t size_of_sample = sizeof(perf_event_stack_sample);

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -591,7 +591,7 @@ void TracerThread::ProcessSampleEvent(const perf_event_header& header,
   constexpr size_t size_of_uprobes = sizeof(perf_event_sp_ip_8bytes_sample);
   bool is_uprobe = !is_gpu_event && (header.size == size_of_uprobes);
 
-  constexpr size_t size_of_uretprobes = sizeof(perf_event_uretprobe);
+  constexpr size_t size_of_uretprobes = sizeof(perf_event_ax);
   bool is_uretprobe = !is_gpu_event && (header.size == size_of_uretprobes);
 
   constexpr size_t size_of_sample = sizeof(perf_event_stack_sample);

--- a/OrbitLinuxTracing/UprobesFunctionCallManager.h
+++ b/OrbitLinuxTracing/UprobesFunctionCallManager.h
@@ -30,7 +30,8 @@ class UprobesFunctionCallManager {
   }
 
   std::optional<FunctionCall> ProcessUretprobes(pid_t tid,
-                                                uint64_t end_timestamp) {
+                                                uint64_t end_timestamp,
+                                                uint64_t return_value) {
     if (!tid_uprobes_stacks_.contains(tid)) {
       return std::optional<FunctionCall>{};
     }
@@ -43,7 +44,7 @@ class UprobesFunctionCallManager {
     auto function_call = std::make_optional<FunctionCall>(
         tid, tid_uprobes_stack.top().function_address,
         tid_uprobes_stack.top().begin_timestamp, end_timestamp,
-        tid_uprobes_stack.size() - 1);
+        tid_uprobes_stack.size() - 1, return_value);
     tid_uprobes_stack.pop();
     if (tid_uprobes_stack.empty()) {
       tid_uprobes_stacks_.erase(tid);

--- a/OrbitLinuxTracing/UprobesFunctionCallManagerTest.cpp
+++ b/OrbitLinuxTracing/UprobesFunctionCallManagerTest.cpp
@@ -19,7 +19,7 @@ TEST(UprobesFunctionCallManager, OneUprobe) {
   EXPECT_EQ(processed_function_call.value().GetBeginTimestampNs(), 1);
   EXPECT_EQ(processed_function_call.value().GetEndTimestampNs(), 2);
   EXPECT_EQ(processed_function_call.value().GetDepth(), 0);
-  EXPECT_EQ(processed_function_call.value().GetReturnValue(), 3);
+  EXPECT_EQ(processed_function_call.value().GetIntegerReturnValue(), 3);
 }
 
 TEST(UprobesFunctionCallManager, TwoNestedUprobesAndAnotherUprobe) {
@@ -38,7 +38,7 @@ TEST(UprobesFunctionCallManager, TwoNestedUprobesAndAnotherUprobe) {
   EXPECT_EQ(processed_function_call.value().GetBeginTimestampNs(), 2);
   EXPECT_EQ(processed_function_call.value().GetEndTimestampNs(), 3);
   EXPECT_EQ(processed_function_call.value().GetDepth(), 1);
-  EXPECT_EQ(processed_function_call.value().GetReturnValue(), 4);
+  EXPECT_EQ(processed_function_call.value().GetIntegerReturnValue(), 4);
 
   processed_function_call = function_call_manager.ProcessUretprobes(tid, 4, 5);
   ASSERT_TRUE(processed_function_call.has_value());
@@ -47,7 +47,7 @@ TEST(UprobesFunctionCallManager, TwoNestedUprobesAndAnotherUprobe) {
   EXPECT_EQ(processed_function_call.value().GetBeginTimestampNs(), 1);
   EXPECT_EQ(processed_function_call.value().GetEndTimestampNs(), 4);
   EXPECT_EQ(processed_function_call.value().GetDepth(), 0);
-  EXPECT_EQ(processed_function_call.value().GetReturnValue(), 5);
+  EXPECT_EQ(processed_function_call.value().GetIntegerReturnValue(), 5);
 
   function_call_manager.ProcessUprobes(tid, 300, 5);
 
@@ -58,7 +58,7 @@ TEST(UprobesFunctionCallManager, TwoNestedUprobesAndAnotherUprobe) {
   EXPECT_EQ(processed_function_call.value().GetBeginTimestampNs(), 5);
   EXPECT_EQ(processed_function_call.value().GetEndTimestampNs(), 6);
   EXPECT_EQ(processed_function_call.value().GetDepth(), 0);
-  EXPECT_EQ(processed_function_call.value().GetReturnValue(), 7);
+  EXPECT_EQ(processed_function_call.value().GetIntegerReturnValue(), 7);
 }
 
 TEST(UprobesFunctionCallManager, TwoUprobesDifferentThreads) {
@@ -78,7 +78,7 @@ TEST(UprobesFunctionCallManager, TwoUprobesDifferentThreads) {
   EXPECT_EQ(processed_function_call.value().GetBeginTimestampNs(), 1);
   EXPECT_EQ(processed_function_call.value().GetEndTimestampNs(), 3);
   EXPECT_EQ(processed_function_call.value().GetDepth(), 0);
-  EXPECT_EQ(processed_function_call.value().GetReturnValue(), 4);
+  EXPECT_EQ(processed_function_call.value().GetIntegerReturnValue(), 4);
 
   processed_function_call = function_call_manager.ProcessUretprobes(tid2, 4, 5);
   ASSERT_TRUE(processed_function_call.has_value());
@@ -87,7 +87,7 @@ TEST(UprobesFunctionCallManager, TwoUprobesDifferentThreads) {
   EXPECT_EQ(processed_function_call.value().GetBeginTimestampNs(), 2);
   EXPECT_EQ(processed_function_call.value().GetEndTimestampNs(), 4);
   EXPECT_EQ(processed_function_call.value().GetDepth(), 0);
-  EXPECT_EQ(processed_function_call.value().GetReturnValue(), 5);
+  EXPECT_EQ(processed_function_call.value().GetIntegerReturnValue(), 5);
 }
 
 TEST(UprobesFunctionCallManager, OnlyUretprobe) {

--- a/OrbitLinuxTracing/UprobesFunctionCallManagerTest.cpp
+++ b/OrbitLinuxTracing/UprobesFunctionCallManagerTest.cpp
@@ -12,13 +12,14 @@ TEST(UprobesFunctionCallManager, OneUprobe) {
 
   function_call_manager.ProcessUprobes(tid, 100, 1);
 
-  processed_function_call = function_call_manager.ProcessUretprobes(tid, 2);
+  processed_function_call = function_call_manager.ProcessUretprobes(tid, 2, 3);
   ASSERT_TRUE(processed_function_call.has_value());
   EXPECT_EQ(processed_function_call.value().GetTid(), tid);
   EXPECT_EQ(processed_function_call.value().GetVirtualAddress(), 100);
   EXPECT_EQ(processed_function_call.value().GetBeginTimestampNs(), 1);
   EXPECT_EQ(processed_function_call.value().GetEndTimestampNs(), 2);
   EXPECT_EQ(processed_function_call.value().GetDepth(), 0);
+  EXPECT_EQ(processed_function_call.value().GetReturnValue(), 3);
 }
 
 TEST(UprobesFunctionCallManager, TwoNestedUprobesAndAnotherUprobe) {
@@ -30,31 +31,34 @@ TEST(UprobesFunctionCallManager, TwoNestedUprobesAndAnotherUprobe) {
 
   function_call_manager.ProcessUprobes(tid, 200, 2);
 
-  processed_function_call = function_call_manager.ProcessUretprobes(tid, 3);
+  processed_function_call = function_call_manager.ProcessUretprobes(tid, 3, 4);
   ASSERT_TRUE(processed_function_call.has_value());
   EXPECT_EQ(processed_function_call.value().GetTid(), tid);
   EXPECT_EQ(processed_function_call.value().GetVirtualAddress(), 200);
   EXPECT_EQ(processed_function_call.value().GetBeginTimestampNs(), 2);
   EXPECT_EQ(processed_function_call.value().GetEndTimestampNs(), 3);
   EXPECT_EQ(processed_function_call.value().GetDepth(), 1);
+  EXPECT_EQ(processed_function_call.value().GetReturnValue(), 4);
 
-  processed_function_call = function_call_manager.ProcessUretprobes(tid, 4);
+  processed_function_call = function_call_manager.ProcessUretprobes(tid, 4, 5);
   ASSERT_TRUE(processed_function_call.has_value());
   EXPECT_EQ(processed_function_call.value().GetTid(), tid);
   EXPECT_EQ(processed_function_call.value().GetVirtualAddress(), 100);
   EXPECT_EQ(processed_function_call.value().GetBeginTimestampNs(), 1);
   EXPECT_EQ(processed_function_call.value().GetEndTimestampNs(), 4);
   EXPECT_EQ(processed_function_call.value().GetDepth(), 0);
+  EXPECT_EQ(processed_function_call.value().GetReturnValue(), 5);
 
   function_call_manager.ProcessUprobes(tid, 300, 5);
 
-  processed_function_call = function_call_manager.ProcessUretprobes(tid, 6);
+  processed_function_call = function_call_manager.ProcessUretprobes(tid, 6, 7);
   ASSERT_TRUE(processed_function_call.has_value());
   EXPECT_EQ(processed_function_call.value().GetTid(), tid);
   EXPECT_EQ(processed_function_call.value().GetVirtualAddress(), 300);
   EXPECT_EQ(processed_function_call.value().GetBeginTimestampNs(), 5);
   EXPECT_EQ(processed_function_call.value().GetEndTimestampNs(), 6);
   EXPECT_EQ(processed_function_call.value().GetDepth(), 0);
+  EXPECT_EQ(processed_function_call.value().GetReturnValue(), 7);
 }
 
 TEST(UprobesFunctionCallManager, TwoUprobesDifferentThreads) {
@@ -67,21 +71,23 @@ TEST(UprobesFunctionCallManager, TwoUprobesDifferentThreads) {
 
   function_call_manager.ProcessUprobes(tid2, 200, 2);
 
-  processed_function_call = function_call_manager.ProcessUretprobes(tid, 3);
+  processed_function_call = function_call_manager.ProcessUretprobes(tid, 3, 4);
   ASSERT_TRUE(processed_function_call.has_value());
   EXPECT_EQ(processed_function_call.value().GetTid(), tid);
   EXPECT_EQ(processed_function_call.value().GetVirtualAddress(), 100);
   EXPECT_EQ(processed_function_call.value().GetBeginTimestampNs(), 1);
   EXPECT_EQ(processed_function_call.value().GetEndTimestampNs(), 3);
   EXPECT_EQ(processed_function_call.value().GetDepth(), 0);
+  EXPECT_EQ(processed_function_call.value().GetReturnValue(), 4);
 
-  processed_function_call = function_call_manager.ProcessUretprobes(tid2, 4);
+  processed_function_call = function_call_manager.ProcessUretprobes(tid2, 4, 5);
   ASSERT_TRUE(processed_function_call.has_value());
   EXPECT_EQ(processed_function_call.value().GetTid(), tid2);
   EXPECT_EQ(processed_function_call.value().GetVirtualAddress(), 200);
   EXPECT_EQ(processed_function_call.value().GetBeginTimestampNs(), 2);
   EXPECT_EQ(processed_function_call.value().GetEndTimestampNs(), 4);
   EXPECT_EQ(processed_function_call.value().GetDepth(), 0);
+  EXPECT_EQ(processed_function_call.value().GetReturnValue(), 5);
 }
 
 TEST(UprobesFunctionCallManager, OnlyUretprobe) {
@@ -89,7 +95,7 @@ TEST(UprobesFunctionCallManager, OnlyUretprobe) {
   std::optional<FunctionCall> processed_function_call;
   UprobesFunctionCallManager function_call_manager;
 
-  processed_function_call = function_call_manager.ProcessUretprobes(tid, 2);
+  processed_function_call = function_call_manager.ProcessUretprobes(tid, 2, 3);
   ASSERT_FALSE(processed_function_call.has_value());
 }
 

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
@@ -1,5 +1,5 @@
 #include "UprobesUnwindingVisitor.h"
-
+#include "OrbitBase/Logging.h"
 namespace LinuxTracing {
 
 void UprobesUnwindingVisitor::visit(SamplePerfEvent* event) {
@@ -93,7 +93,8 @@ void UprobesUnwindingVisitor::visit(UretprobesPerfEvent* event) {
 
   std::optional<FunctionCall> function_call =
       function_call_manager_.ProcessUretprobes(event->GetTid(),
-                                               event->GetTimestamp());
+                                               event->GetTimestamp(),
+                                               event->GetAx());
   if (function_call.has_value()) {
     listener_->OnFunctionCall(function_call.value());
   }

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/Events.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/Events.h
@@ -92,7 +92,7 @@ class FunctionCall {
   uint64_t GetBeginTimestampNs() const { return begin_timestamp_ns_; }
   uint64_t GetEndTimestampNs() const { return end_timestamp_ns_; }
   uint32_t GetDepth() const { return depth_; }
-  uint64_t GetReturnValue() const { return return_value_; }
+  uint64_t GetIntegerReturnValue() const { return return_value_; }
 
  private:
   pid_t tid_;

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/Events.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/Events.h
@@ -80,18 +80,19 @@ class Callstack {
 class FunctionCall {
  public:
   FunctionCall(pid_t tid, uint64_t virtual_address, uint64_t begin_timestamp_ns,
-               uint64_t end_timestamp_ns, uint32_t depth)
+               uint64_t end_timestamp_ns, uint32_t depth, uint64_t return_value)
       : tid_(tid),
         virtual_address_(virtual_address),
         begin_timestamp_ns_(begin_timestamp_ns),
         end_timestamp_ns_(end_timestamp_ns),
-        depth_{depth} {}
+        depth_{depth}, return_value_(return_value) {}
 
   pid_t GetTid() const { return tid_; }
   uint64_t GetVirtualAddress() const { return virtual_address_; }
   uint64_t GetBeginTimestampNs() const { return begin_timestamp_ns_; }
   uint64_t GetEndTimestampNs() const { return end_timestamp_ns_; }
   uint32_t GetDepth() const { return depth_; }
+  uint64_t GetReturnValue() const { return return_value_; }
 
  private:
   pid_t tid_;
@@ -99,6 +100,7 @@ class FunctionCall {
   uint64_t begin_timestamp_ns_;
   uint64_t end_timestamp_ns_;
   uint32_t depth_;
+  uint64_t return_value_;
 };
 
 class GpuJob {

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -11,8 +11,12 @@
 #include "CrashHandler.h"
 #include "Path.h"
 #include "orbitmainwindow.h"
+#include "absl/flags/parse.h"
+#include "absl/flags/usage.h"
 
 int main(int argc, char* argv[]) {
+  absl::SetProgramUsageMessage("CPU Profiler");
+  absl::ParseCommandLine(argc, argv);
 #if __linux__
   QCoreApplication::setAttribute(Qt::AA_DontUseNativeDialogs);
 #endif

--- a/OrbitService/main.cpp
+++ b/OrbitService/main.cpp
@@ -2,10 +2,12 @@
 
 #include "OrbitService.h"
 #include "absl/flags/parse.h"
+#include "absl/flags/usage.h"
 
 int main(int argc, char** argv) {
-  std::cout << "Starting OrbitService" << std::endl;
+  absl::SetProgramUsageMessage("Orbit CPU Profiler Service");
   absl::ParseCommandLine(argc, argv);
+  std::cout << "Starting OrbitService" << std::endl;
   OrbitService service;
   service.Run();
 }


### PR DESCRIPTION
Added a temporary --show_return_values flag to set on the Orbit UI
to enable the feature.  The value of RAX will be displayed with the
function name and duration in the time slices.  The flag will be
removed once we have a way to specify if we should show the return
value on a per function basis.

This was motivated by an internal user request to investigate a pressing
issue.