### PR TITLE
Ensure ContextSwitch has the same memory layout on all platforms.

### DIFF
--- a/OrbitCore/ContextSwitch.cpp
+++ b/OrbitCore/ContextSwitch.cpp
@@ -12,12 +12,12 @@ static_assert(sizeof(ContextSwitch) == 20);
 
 //-----------------------------------------------------------------------------
 ContextSwitch::ContextSwitch(SwitchType a_Type)
-    : m_ProcessId(0),
+    : m_Time(0),
+      m_ProcessId(0),
       m_ThreadId(0),
-      m_Type(a_Type),
-      m_Time(0),
       m_ProcessorIndex(0xFF),
-      m_ProcessorNumber(0xFF) {}
+      m_ProcessorNumber(0xFF),
+      m_Type(a_Type) {}
 
 //-----------------------------------------------------------------------------
 ContextSwitch::~ContextSwitch() = default;

--- a/OrbitCore/ContextSwitch.cpp
+++ b/OrbitCore/ContextSwitch.cpp
@@ -6,6 +6,10 @@
 
 #include "Serialization.h"
 
+// Context switches are sent as raw bytes, make sure it's the same size
+// on every platform.
+static_assert(sizeof(ContextSwitch) == 20);
+
 //-----------------------------------------------------------------------------
 ContextSwitch::ContextSwitch(SwitchType a_Type)
     : m_ProcessId(0),

--- a/OrbitCore/ContextSwitch.h
+++ b/OrbitCore/ContextSwitch.h
@@ -9,16 +9,16 @@
 #pragma pack(push, 1)
 struct ContextSwitch {
  public:
-  enum SwitchType { In, Out, Invalid };
+  enum SwitchType : uint8_t { In, Out, Invalid };
   explicit ContextSwitch(SwitchType a_Type = Invalid);
   ~ContextSwitch();
 
+  uint64_t m_Time;
   uint32_t m_ProcessId;
   uint32_t m_ThreadId;
-  SwitchType m_Type;
-  uint64_t m_Time;
   uint16_t m_ProcessorIndex;
   uint8_t m_ProcessorNumber;
+  SwitchType m_Type;
 
   // TODO: The distinction between m_ProcessorIndex and m_ProcessorNumber is
   //  Windows-specific. Consider removing m_ProcessorNumber.


### PR DESCRIPTION
Fix issue when using Windows debug UI with Linux service by
rearranging class members and defining the enum type.