### PR TITLE
Added conan package uploading to CI jobs

### DIFF
--- a/kokoro/gcp_ubuntu/continuous.cfg
+++ b/kokoro/gcp_ubuntu/continuous.cfg
@@ -5,10 +5,21 @@
 # github_scm.name is specified in the job configuration (next section).
 build_file: "orbitprofiler/kokoro/gcp_ubuntu/kokoro_build.sh"
 
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74938
+      keyname: "orbitprofiler_artifactory_access_token"
+      key_type: RAW
+      backend_type: FASTCONFIGPUSH
+    }
+  }
+}
+
 action {
   define_artifacts {
-    regex: "**/testresults/*.xml"
-    regex: "github/orbitprofiler/build_clang7_release/package/**"
-    strip_prefix: "github/orbitprofiler/build_clang7_release/package"
+    regex: "github/orbitprofiler/build/testresults/*.xml"
+    regex: "github/orbitprofiler/build/package/**"
+    strip_prefix: "github/orbitprofiler/build/package"
   }
 }

--- a/kokoro/gcp_ubuntu/presubmit.cfg
+++ b/kokoro/gcp_ubuntu/presubmit.cfg
@@ -7,7 +7,7 @@ build_file: "orbitprofiler/kokoro/gcp_ubuntu/kokoro_build.sh"
 
 action {
   define_artifacts {
-    regex: "github/orbitprofiler/build_clang7_release/testresults/*.xml"
+    regex: "github/orbitprofiler/build/testresults/*.xml"
     strip_prefix: "github/orbitprofiler"
   }
 }

--- a/kokoro/gcp_ubuntu_ggp/continuous.cfg
+++ b/kokoro/gcp_ubuntu_ggp/continuous.cfg
@@ -30,12 +30,20 @@ before_action {
       backend_type: FASTCONFIGPUSH
     }
   }
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74938
+      keyname: "orbitprofiler_artifactory_access_token"
+      key_type: RAW
+      backend_type: FASTCONFIGPUSH
+    }
+  }
 }
 
 action {
   define_artifacts {
-    regex: "**/testresults/*.xml"
-    regex: "github/orbitprofiler/build_ggp_relwithdebinfo/package/**"
-    strip_prefix: "github/orbitprofiler/build_ggp_relwithdebinfo/package"
+    regex: "github/orbitprofiler/build/testresults/*.xml"
+    regex: "github/orbitprofiler/build/package/**"
+    strip_prefix: "github/orbitprofiler/build/package"
   }
 }

--- a/kokoro/gcp_ubuntu_ggp/kokoro_build.sh
+++ b/kokoro/gcp_ubuntu_ggp/kokoro_build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Fail on any error.
-set -ex
+set -e
 
 DIR="/mnt/github/orbitprofiler"
 SCRIPT="${DIR}/kokoro/gcp_ubuntu_ggp/kokoro_build.sh"
@@ -12,8 +12,9 @@ if [ "$0" == "$SCRIPT" ]; then
   echo "Installing conan configuration (profiles, settings, etc.)..."
   conan config install "${DIR}/contrib/conan/configs/linux"
   cp -v "${DIR}/kokoro/conan/config/remotes.json" ~/.conan/remotes.json
+  conan config set general.revisions_enabled=True
+  conan config set general.parallel_download=8
 
-  export CONAN_REVISIONS_ENABLED=1
   CONAN_PROFILE="ggp_relwithdebinfo"
 
   # This variable is picked up by the `conan package` call.
@@ -21,13 +22,11 @@ if [ "$0" == "$SCRIPT" ]; then
   # the install_signed_package.sh script.
   export ORBIT_SIGNING_PUBLIC_KEY_FILE="/mnt/keystore/74938_SigningPublicGpg"
 
-  # PACKAGES=$(conan info -pr $CONAN_PROFILE . -j 2>/dev/null | grep build_id | \
-  #         jq '.[] | select(.is_ref) | .reference' | grep -v 'llvm/' | tr -d '"')
-
-  conan install -u -pr ${CONAN_PROFILE} -if "${DIR}/build_${CONAN_PROFILE}/" \
+  # Building Orbit
+  conan install -u -pr ${CONAN_PROFILE} -if "${DIR}/build/" \
           --build outdated -o debian_packaging=True "${DIR}"
-  conan build -bf "${DIR}/build_${CONAN_PROFILE}/" "${DIR}"
-  conan package -bf "${DIR}/build_${CONAN_PROFILE}/" "${DIR}"
+  conan build -bf "${DIR}/build/" "${DIR}"
+  conan package -bf "${DIR}/build/" "${DIR}"
 
   rm -rf ~/.gnupg/
   rm -rf /dev/shm/signing.gpg
@@ -39,13 +38,19 @@ if [ "$0" == "$SCRIPT" ]; then
 
   gpg ${GPG_OPTIONS} --import /mnt/keystore/74938_SigningPrivateGpg
 
-  for deb in ${DIR}/build_${CONAN_PROFILE}/package/*.deb; do
+  for deb in ${DIR}/build/package/*.deb; do
     gpg ${GPG_OPTIONS} --output "$deb.asc" --detach-sign "$deb"
   done
 
-  # echo -n "${PACKAGES}" | while read package; do
-  #   conan upload -r artifactory --all --no-overwrite all --confirm $package
-  # done
+  # Uploading prebuilt packages of our dependencies
+  if [ -f /mnt/keystore/74938_orbitprofiler_artifactory_access_token ]; then
+    conan user -r artifactory -p "$(cat /mnt/keystore/74938_orbitprofiler_artifactory_access_token | tr -d '\n')" kokoro
+    # The llvm-package is very large and not needed as a prebuilt because it is not consumed directly.
+    conan remove 'llvm/*@orbitdeps/stable'
+    conan upload -r artifactory --all --no-overwrite all --confirm  --parallel \*
+  else
+    echo "No access token available. Won't upload packages."
+  fi
 
   # Uncomment the three lines below to print the external ip into the log and
   # keep the vm alive for two hours. This is useful to debug build failures that

--- a/kokoro/gcp_ubuntu_ggp/release.cfg
+++ b/kokoro/gcp_ubuntu_ggp/release.cfg
@@ -30,11 +30,19 @@ before_action {
       backend_type: FASTCONFIGPUSH
     }
   }
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74938
+      keyname: "orbitprofiler_artifactory_access_token"
+      key_type: RAW
+      backend_type: FASTCONFIGPUSH
+    }
+  }
 }
 
 action {
   define_artifacts {
-    regex: "github/orbitprofiler/build_ggp_relwithdebinfo/package/**"
-    strip_prefix: "github/orbitprofiler/build_ggp_relwithdebinfo/package"
+    regex: "github/orbitprofiler/build/package/**"
+    strip_prefix: "github/orbitprofiler/build/package"
   }
 }

--- a/kokoro/gcp_windows/continuous.cfg
+++ b/kokoro/gcp_windows/continuous.cfg
@@ -5,11 +5,22 @@
 # github_scm.name is specified in the job configuration (next section).
 build_file: "orbitprofiler/kokoro/gcp_windows/kokoro_build.bat"
 
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74938
+      keyname: "orbitprofiler_artifactory_access_token"
+      key_type: RAW
+      backend_type: FASTCONFIGPUSH
+    }
+  }
+}
+
 action {
   define_artifacts {
-    regex: "**/testresults/*.xml"
-    regex: "github/orbitprofiler/build_msvc2019_release_x64/package/**"
-    strip_prefix: "github/orbitprofiler/build_msvc2019_release_x64/package"
+    regex: "github/orbitprofiler/build/testresults/*.xml"
+    regex: "github/orbitprofiler/build/package/**"
+    strip_prefix: "github/orbitprofiler/build/package"
   }
 }
 

--- a/kokoro/gcp_windows/kokoro_build.bat
+++ b/kokoro/gcp_windows/kokoro_build.bat
@@ -1,6 +1,8 @@
 :: Code under repo is checked out to %KOKORO_ARTIFACTS_DIR%\github.
 :: The final directory name in this path is determined by the scm name specified
 :: in the job configuration
+@echo off
+
 SET REPO_ROOT=%KOKORO_ARTIFACTS_DIR%\github\orbitprofiler
 
 conan config install %REPO_ROOT%\contrib\conan\configs\windows
@@ -8,13 +10,39 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 
 REM We replace the default remotes by our internal artifactory server
 REM which acts as a secure source for prebuilt dependencies.
-copy /Y %REPO_ROOT%\kokoro\conan\config\remotes.json C:\cygwin64\home\kbuilder\.conan\remotes.json
+copy /Y %REPO_ROOT%\kokoro\conan\config\remotes.json %HOME%\.conan\remotes.json
 if %errorlevel% neq 0 exit /b %errorlevel%
 
-set CONAN_REVISIONS_ENABLED=1
+conan config set general.revisions_enabled=True
+if %errorlevel% neq 0 exit /b %errorlevel%
 
-cd %KOKORO_ARTIFACTS_DIR%\github\orbitprofiler
-call build.bat msvc2019_release_x64
-IF ERRORLEVEL 1 exit %ERRORLEVEL%
+conan config set general.parallel_download=8
+if %errorlevel% neq 0 exit /b %errorlevel%
 
-call conan package -bf %REPO_ROOT%\build_msvc2019_release_x64 %REPO_ROOT%
+:: Building conan
+call conan install -pr msvc2019_release -if %REPO_ROOT%\build\ --build outdated %REPO_ROOT%
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+call conan build -bf %REPO_ROOT%\build\ %REPO_ROOT%
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+call conan package -bf %REPO_ROOT%\build\ %REPO_ROOT%
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+
+:: Uploading prebuilt packages of our dependencies
+if EXIST %KOKORO_ARTIFACTS_DIR%\keystore\74938_orbitprofiler_artifactory_access_token (
+  set /p ACCESS_TOKEN=<%KOKORO_ARTIFACTS_DIR%\keystore\74938_orbitprofiler_artifactory_access_token
+
+  call conan user -r artifactory -p "%ACCESS_TOKEN%" kokoro
+  if %errorlevel% neq 0 exit /b %errorlevel%
+
+  REM The llvm-package is very large and not needed as a prebuilt because it is not consumed directly.
+  call conan remove 'llvm/*@orbitdeps/stable'
+  if %errorlevel% neq 0 exit /b %errorlevel%
+
+  call conan upload -r artifactory --all --no-overwrite all --confirm  --parallel *
+  if %errorlevel% neq 0 exit /b %errorlevel%
+) else (
+  echo No access token available. Skipping package upload.
+)

--- a/kokoro/gcp_windows/kokoro_build_release.bat
+++ b/kokoro/gcp_windows/kokoro_build_release.bat
@@ -1,4 +1,4 @@
-SET PACKAGE_DIR=%KOKORO_ARTIFACTS_DIR%\github\orbitprofiler\build_msvc2019_release_x64\package
+SET PACKAGE_DIR=%KOKORO_ARTIFACTS_DIR%\github\orbitprofiler\build\package
 
 call %KOKORO_ARTIFACTS_DIR%\github\orbitprofiler\kokoro\gcp_windows\kokoro_build.bat
 

--- a/kokoro/gcp_windows/presubmit.cfg
+++ b/kokoro/gcp_windows/presubmit.cfg
@@ -7,7 +7,7 @@ build_file: "orbitprofiler/kokoro/gcp_windows/kokoro_build.bat"
 
 action {
   define_artifacts {
-    regex: "github/orbitprofiler/build_msvc2019_release_x64/testresults/*.xml"
+    regex: "github/orbitprofiler/build/testresults/*.xml"
     strip_prefix: "github/orbitprofiler"
   }
 }

--- a/kokoro/gcp_windows/release.cfg
+++ b/kokoro/gcp_windows/release.cfg
@@ -5,10 +5,21 @@
 # github_scm.name is specified in the job configuration (next section).
 build_file: "orbitprofiler/kokoro/gcp_windows/kokoro_build_release.bat"
 
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74938
+      keyname: "orbitprofiler_artifactory_access_token"
+      key_type: RAW
+      backend_type: FASTCONFIGPUSH
+    }
+  }
+}
+
 action {
   define_artifacts {
-    regex: "github/orbitprofiler/build_msvc2019_release_x64/package/**"
-    strip_prefix: "github/orbitprofiler/build_msvc2019_release_x64/package"
+    regex: "github/orbitprofiler/build/package/**"
+    strip_prefix: "github/orbitprofiler/build/package"
   }
 }
 


### PR DESCRIPTION
This PR adds automic package uploading to Kokoro.

During a orbit build, conan builds all the necessary dependency-packages if no matching and non-outdated prebuilts are found on the artifactory server.

This PR adds the necessary steps to automatically upload these packages to the artifactory server after a successful orbit-build. Hence the next job will find a matching prebuilt and can use that to speed-up its own build.

Furthermore some small changes:
* The `kokoro_build.sh` in `gcp_ubuntu` and `gcp_ubuntu_ggp` have been unified as much as possible.
* The `kokoro_build.bat` of the Windows build does not call `build.bat` anymore rather calls conan directly. That simplifies the script and makes it more similar to the linux scripts
* All jobs that potentially upload packages got access to the access token in keystore.
* Parallel downloading for conan has been enabled. This speeds up retrieving of packages by at least a factor of 4.
* All jobs now build inside a subdirectory called `build` which greatly simplifies the config and makes it less prone to typos in future changes.