### PR TITLE
Added python2.7 to our CI build containers

### DIFF
--- a/contrib/conan/docker/Dockerfile.clang7
+++ b/contrib/conan/docker/Dockerfile.clang7
@@ -4,4 +4,5 @@ RUN sudo apt-get -qq update \
     && sudo apt-get install -y --no-install-recommends \
     jq \
     libtinfo5 \
+    python2.7 \
     && sudo rm -rf /var/lib/apt/lists/*

--- a/contrib/conan/docker/Dockerfile.clang7_gpg
+++ b/contrib/conan/docker/Dockerfile.clang7_gpg
@@ -6,4 +6,5 @@ RUN sudo apt-get -qq update \
     libtinfo5 \
     gpg \
     gpg-agent \
+    python2.7 \
     && sudo rm -rf /var/lib/apt/lists/*

--- a/contrib/conan/docker/Dockerfile.clang7_opengl_qt
+++ b/contrib/conan/docker/Dockerfile.clang7_opengl_qt
@@ -10,6 +10,8 @@ ENV LLVM_VERSION=7.0 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH}
 
+ADD sources.list.clang7 /etc/apt/sources.list
+
 RUN dpkg --add-architecture i386 \
     && apt-get -qq update \
     && apt-get install -y --no-install-recommends \
@@ -49,6 +51,7 @@ RUN dpkg --add-architecture i386 \
        libxi-dev \
        qt5-default \
        jq \
+       python2.7 \
     && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-7 100 \
     && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-7 100 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/clang-7 100 \

--- a/contrib/conan/docker/Dockerfile.clang8_opengl_qt
+++ b/contrib/conan/docker/Dockerfile.clang8_opengl_qt
@@ -8,4 +8,5 @@ RUN sudo apt-get -qq update \
     libxi-dev \
     qt5-default \
     jq \
+    python2.7 \
     && sudo rm -rf /var/lib/apt/lists/*

--- a/contrib/conan/docker/Dockerfile.clang9_opengl_qt
+++ b/contrib/conan/docker/Dockerfile.clang9_opengl_qt
@@ -8,4 +8,5 @@ RUN sudo apt-get -qq update \
     libxi-dev \
     qt5-default \
     jq \
+    python2.7 \
     && sudo rm -rf /var/lib/apt/lists/*

--- a/contrib/conan/docker/Dockerfile.gcc8
+++ b/contrib/conan/docker/Dockerfile.gcc8
@@ -7,4 +7,5 @@ RUN sudo apt-get -qq update \
     libxmu-dev \
     libxi-dev \
     qt5-default \
-    jq 
+    jq \
+    python2.7

--- a/contrib/conan/docker/Dockerfile.gcc9
+++ b/contrib/conan/docker/Dockerfile.gcc9
@@ -7,4 +7,5 @@ RUN sudo apt-get -qq update \
     libxmu-dev \
     libxi-dev \
     qt5-default \
-    jq 
+    jq \
+    python2.7

--- a/contrib/conan/docker/sources.list.clang7
+++ b/contrib/conan/docker/sources.list.clang7
@@ -1,0 +1,4 @@
+deb http://old-releases.ubuntu.com/ubuntu/ disco main restricted universe multiverse
+deb http://old-releases.ubuntu.com/ubuntu/ disco-updates main restricted universe multiverse
+deb http://old-releases.ubuntu.com/ubuntu/ disco-security main restricted universe multiverse
+


### PR DESCRIPTION
depot_tools still need python2.7 and crashpad needs depot_tools for building.

Note: This PR does not update the container itself. It only updates the Dockerfile which we
use to build the containers from.