### PR TITLE
Replaced deprecated getpagesize() by its successor

### DIFF
--- a/OrbitLinuxTracing/PerfEventOpen.cpp
+++ b/OrbitLinuxTracing/PerfEventOpen.cpp
@@ -117,8 +117,8 @@ int uretprobes_event_open(const char* module, uint64_t function_offset,
 void* perf_event_open_mmap_ring_buffer(int fd, uint64_t mmap_length) {
   // The size of the ring buffer excluding the metadata page must be a power of
   // two number of pages.
-  if (mmap_length < static_cast<size_t>(getpagesize()) ||
-      __builtin_popcountl(mmap_length - getpagesize()) != 1) {
+  if (mmap_length < GetPageSize() ||
+      __builtin_popcountl(mmap_length - GetPageSize()) != 1) {
     ERROR("mmap length for perf_event_open not 1+2^n pages: %lu", mmap_length);
     return nullptr;
   }

--- a/OrbitLinuxTracing/PerfEventRingBuffer.cpp
+++ b/OrbitLinuxTracing/PerfEventRingBuffer.cpp
@@ -43,14 +43,14 @@ PerfEventRingBuffer::PerfEventRingBuffer(int perf_event_fd, uint64_t size_kb,
   // The size of a perf_event_open ring buffer is required to be a power of two
   // memory pages (from perf_event_open's manpage: "The mmap size should be
   // 1+2^n pages"), otherwise mmap on the file descriptor fails.
-  if (1024 * size_kb < static_cast<size_t>(getpagesize()) ||
+  if (1024 * size_kb < GetPageSize() ||
       __builtin_popcountl(size_kb) != 1) {
     return;
   }
 
   ring_buffer_size_ = 1024 * size_kb;
   ring_buffer_size_log2_ = __builtin_ffsl(ring_buffer_size_) - 1;
-  mmap_length_ = static_cast<size_t>(getpagesize()) + ring_buffer_size_;
+  mmap_length_ = GetPageSize() + ring_buffer_size_;
 
   void* mmap_address =
       perf_event_open_mmap_ring_buffer(perf_event_fd, mmap_length_);
@@ -64,7 +64,7 @@ PerfEventRingBuffer::PerfEventRingBuffer(int perf_event_fd, uint64_t size_kb,
 
   ring_buffer_ =
       reinterpret_cast<char*>(mmap_address) + metadata_page_->data_offset;
-  CHECK(metadata_page_->data_offset == static_cast<size_t>(getpagesize()));
+  CHECK(metadata_page_->data_offset == GetPageSize());
 }
 
 PerfEventRingBuffer::PerfEventRingBuffer(PerfEventRingBuffer&& o) noexcept {

--- a/OrbitLinuxTracing/Utils.h
+++ b/OrbitLinuxTracing/Utils.h
@@ -62,6 +62,11 @@ bool SetMaxOpenFilesSoftLimit(uint64_t soft_limit);
 
 #endif
 
+inline size_t GetPageSize() {
+  // POSIX guarantees the result to be greater or equal than 1.
+  // So we can safely cast here.
+  return static_cast<size_t>(sysconf(_SC_PAGESIZE));
+}
 }  // namespace LinuxTracing
 
 #endif  // ORBIT_LINUX_TRACING_UTILS_H_


### PR DESCRIPTION
Since this came up this morning in the GCC-warning-discussion and I had some minutes
of waiting time I thought I will just replace the deprecated getpagesize function.

According to the man page instead of `getpagesize()`, `sysconf(_SC_PAGESIZE)`
should be used. This patch replaces all occurences of `getpagesize()` by a wrapper
function `getpagesize_portable` which eventually calls sysconf. I didn't come up
with a better name for this function. So if you have one, please suggest it.