### PR TITLE
Simplify build scripts.

### DIFF
--- a/kokoro/gcp_ubuntu_ggp/kokoro_build.sh
+++ b/kokoro/gcp_ubuntu_ggp/kokoro_build.sh
@@ -52,6 +52,9 @@ if [ "$0" == "$SCRIPT" ]; then
     echo "No access token available. Won't upload packages."
   fi
 
+  # Package the Debian package and the signature into a zip for integration in the installer.
+  zip a -r OrbitProfiler*.deb OrbitProfiler*.deb.asc Collector.zip
+
   # Uncomment the three lines below to print the external ip into the log and
   # keep the vm alive for two hours. This is useful to debug build failures that
   # can not be resolved by looking into sponge alone. Also comment out the

--- a/kokoro/gcp_windows/kokoro_build.bat
+++ b/kokoro/gcp_windows/kokoro_build.bat
@@ -29,6 +29,10 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 call conan package -bf %REPO_ROOT%\build\ %REPO_ROOT%
 if %errorlevel% neq 0 exit /b %errorlevel%
 
+:: Package build artifacts into a zip for integration in the installer.
+cd %REPO_ROOT%\build\package
+ren bin Orbit
+zip -r Orbit.zip Orbit
 
 :: Uploading prebuilt packages of our dependencies
 if EXIST %KOKORO_ARTIFACTS_DIR%\keystore\74938_orbitprofiler_artifactory_access_token (

--- a/kokoro/gcp_windows/kokoro_build_release.bat
+++ b/kokoro/gcp_windows/kokoro_build_release.bat
@@ -1,7 +1,0 @@
-SET PACKAGE_DIR=%KOKORO_ARTIFACTS_DIR%\github\orbitprofiler\build\package
-
-call %KOKORO_ARTIFACTS_DIR%\github\orbitprofiler\kokoro\gcp_windows\kokoro_build.bat
-
-cd %PACKAGE_DIR%
-ren bin Orbit
-zip -r Orbit.zip Orbit

--- a/kokoro/gcp_windows/release.cfg
+++ b/kokoro/gcp_windows/release.cfg
@@ -3,7 +3,7 @@
 
 # Location of the bash script. Should have value <github_scm.name>/<path_from_repository_root>.
 # github_scm.name is specified in the job configuration (next section).
-build_file: "orbitprofiler/kokoro/gcp_windows/kokoro_build_release.bat"
+build_file: "orbitprofiler/kokoro/gcp_windows/kokoro_build.bat"
 
 before_action {
   fetch_keystore {


### PR DESCRIPTION
Just unconditionally pack artifacts into a zip. This is only required for the
installer / the release build but it makes the scripts easier and does not
really hurt.