### PR TITLE
Added zip cli tool to CI build containers

### DIFF
--- a/contrib/conan/docker/Dockerfile.clang7
+++ b/contrib/conan/docker/Dockerfile.clang7
@@ -5,4 +5,5 @@ RUN sudo apt-get -qq update \
     jq \
     libtinfo5 \
     python2.7 \
+    zip \
     && sudo rm -rf /var/lib/apt/lists/*

--- a/contrib/conan/docker/Dockerfile.clang7_gpg
+++ b/contrib/conan/docker/Dockerfile.clang7_gpg
@@ -7,4 +7,5 @@ RUN sudo apt-get -qq update \
     gpg \
     gpg-agent \
     python2.7 \
+    zip \
     && sudo rm -rf /var/lib/apt/lists/*

--- a/contrib/conan/docker/Dockerfile.clang7_opengl_qt
+++ b/contrib/conan/docker/Dockerfile.clang7_opengl_qt
@@ -52,6 +52,7 @@ RUN dpkg --add-architecture i386 \
        qt5-default \
        jq \
        python2.7 \
+       zip \
     && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-7 100 \
     && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-7 100 \
     && update-alternatives --install /usr/bin/cc cc /usr/bin/clang-7 100 \

--- a/contrib/conan/docker/Dockerfile.clang8_opengl_qt
+++ b/contrib/conan/docker/Dockerfile.clang8_opengl_qt
@@ -9,4 +9,5 @@ RUN sudo apt-get -qq update \
     qt5-default \
     jq \
     python2.7 \
+    zip \
     && sudo rm -rf /var/lib/apt/lists/*

--- a/contrib/conan/docker/Dockerfile.clang9_opengl_qt
+++ b/contrib/conan/docker/Dockerfile.clang9_opengl_qt
@@ -9,4 +9,5 @@ RUN sudo apt-get -qq update \
     qt5-default \
     jq \
     python2.7 \
+    zip \
     && sudo rm -rf /var/lib/apt/lists/*

--- a/contrib/conan/docker/Dockerfile.gcc8
+++ b/contrib/conan/docker/Dockerfile.gcc8
@@ -8,4 +8,5 @@ RUN sudo apt-get -qq update \
     libxi-dev \
     qt5-default \
     jq \
-    python2.7
+    python2.7 \
+    zip

--- a/contrib/conan/docker/Dockerfile.gcc9
+++ b/contrib/conan/docker/Dockerfile.gcc9
@@ -8,4 +8,5 @@ RUN sudo apt-get -qq update \
     libxi-dev \
     qt5-default \
     jq \
-    python2.7
+    python2.7 \
+    zip


### PR DESCRIPTION
zip is needed to package artifacts after building.

**Note:** The containers have already been built and pushed to the container registry.
This PR just updated the Dockerfiles which are blueprints for these containers