### PR TITLE
Group by function instead of address in SamplingReportDataView

### DIFF
--- a/OrbitCore/CMakeLists.txt
+++ b/OrbitCore/CMakeLists.txt
@@ -25,8 +25,8 @@ target_sources(
          Hashing.h
          Injection.h
          Introspection.h
+         LinuxAddressInfo.h
          LinuxCallstackEvent.h
-         LinuxSymbol.h
          LinuxTracingSession.h
          Log.h
          LogInterface.h

--- a/OrbitCore/Callstack.h
+++ b/OrbitCore/Callstack.h
@@ -13,8 +13,8 @@ class CallStackPOD {
  public:
   CallStackPOD() { memset(this, 0, sizeof(*this)); }
   static CallStackPOD Walk(uint64_t ip, uint64_t sp);
-  static inline CallStackPOD GetCallstackManual(uint64_t a_ProgramCounter,
-                                       uint64_t a_AddressOfReturnAddress);
+  static inline CallStackPOD GetCallstackManual(
+      uint64_t a_ProgramCounter, uint64_t a_AddressOfReturnAddress);
   size_t GetSizeInBytes() {
     return offsetof(CallStackPOD, data_) + depth_ * sizeof(data_[0]);
   }
@@ -143,8 +143,8 @@ inline CallStack GetCallstack(uint64_t a_ProgramCounter,
 }
 
 //-----------------------------------------------------------------------------
-inline CallStackPOD CallStackPOD::GetCallstackManual(uint64_t a_ProgramCounter,
-                                       uint64_t a_AddressOfReturnAddress) {
+inline CallStackPOD CallStackPOD::GetCallstackManual(
+    uint64_t a_ProgramCounter, uint64_t a_AddressOfReturnAddress) {
   CallStackPOD CS;
 
   CS.data_[CS.depth_++] = a_ProgramCounter;

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -527,7 +527,7 @@ void Capture::NewSamplingProfiler() {
   }
 
   Capture::GSamplingProfiler =
-      std::make_shared<SamplingProfiler>(Capture::GTargetProcess, true);
+      std::make_shared<SamplingProfiler>(Capture::GTargetProcess);
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -6,8 +6,8 @@
 #include <chrono>
 #include <string>
 
-#include "LinuxTracingSession.h"
 #include "CallstackTypes.h"
+#include "LinuxTracingSession.h"
 #include "OrbitType.h"
 #include "Threading.h"
 

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -94,7 +94,7 @@ class Capture {
   static std::map<uint64_t, Function*> GVisibleFunctionsMap;
   static std::unordered_map<ULONG64, ULONG64> GFunctionCountMap;
   static std::vector<ULONG64> GSelectedAddressesByType[Function::NUM_TYPES];
-  static std::unordered_map<DWORD64, std::shared_ptr<CallStack> > GCallstacks;
+  static std::unordered_map<DWORD64, std::shared_ptr<CallStack>> GCallstacks;
   static std::unordered_map<DWORD64, std::string> GZoneNames;
   static class TextBox* GSelectedTextBox;
   static ThreadID GSelectedThreadId;

--- a/OrbitCore/CoreApp.h
+++ b/OrbitCore/CoreApp.h
@@ -50,12 +50,10 @@ class CoreApp {
   }
   virtual void ProcessCallStack(CallStack& /*a_CallStack*/) {}
   virtual void ProcessContextSwitch(const ContextSwitch& /*a_ContextSwitch*/) {}
-  virtual void AddSymbol(uint64_t /*a_Address*/,
-                         const std::string& /*a_Module*/,
-                         const std::string& /*a_Name*/) {}
+  virtual void AddAddressInfo(LinuxAddressInfo /*address_info*/) {}
   virtual void AddKeyAndString(uint64_t /*key*/, std::string_view /*str*/) {}
   virtual void OnRemoteModuleDebugInfo(const std::vector<ModuleDebugInfo>&) {}
-  virtual void ApplySession(const Session&) {};
+  virtual void ApplySession(const Session&) {}
   virtual const std::unordered_map<DWORD64, std::shared_ptr<class Rule> >*
   GetRules() {
     return nullptr;

--- a/OrbitCore/CrashHandler.cpp
+++ b/OrbitCore/CrashHandler.cpp
@@ -5,29 +5,26 @@
 #include "CrashHandler.h"
 
 #include "Core.h"
+#include "OrbitBase/Logging.h"
 #include "OrbitDbgHelp.h"
 #include "ScopeTimer.h"
 #include "TcpClient.h"
 
-#include "OrbitBase/Logging.h"
-
-
 namespace {
-  template<typename StringType = base::FilePath::StringType>
-  struct StringTypeConverter {
-    StringType operator() (const std::string& source_string) const {
-      return StringType(source_string);
-    }
-  };
+template <typename StringType = base::FilePath::StringType>
+struct StringTypeConverter {
+  StringType operator()(const std::string& source_string) const {
+    return StringType(source_string);
+  }
+};
 
-  template<>
-  struct StringTypeConverter<std::wstring> {
-    std::wstring operator() (const std::string& source_string) const {
-      return s2ws(source_string);
-    }
-  };
-} // namespace
-
+template <>
+struct StringTypeConverter<std::wstring> {
+  std::wstring operator()(const std::string& source_string) const {
+    return s2ws(source_string);
+  }
+};
+}  // namespace
 
 //-----------------------------------------------------------------------------
 CrashHandler::CrashHandler(const std::string& dump_path,

--- a/OrbitCore/CrashHandler.h
+++ b/OrbitCore/CrashHandler.h
@@ -3,9 +3,9 @@
 //-----------------------------------
 #pragma once
 
-#include <string>
-
 #include <client/crashpad_client.h>
+
+#include <string>
 
 class CrashHandler {
  public:

--- a/OrbitCore/EventBuffer.h
+++ b/OrbitCore/EventBuffer.h
@@ -82,4 +82,3 @@ class EventBuffer {
   std::atomic<long long> m_MaxTime;
   std::atomic<long long> m_MinTime;
 };
-

--- a/OrbitCore/Introspection.h
+++ b/OrbitCore/Introspection.h
@@ -1,9 +1,8 @@
 #ifndef ORBIT_CORE_INTROSPECTION_H_
 #define ORBIT_CORE_INTROSPECTION_H_
 
-#include "OrbitBase/Tracing.h"
-
 #include "LinuxTracingSession.h"
+#include "OrbitBase/Tracing.h"
 #include "ScopeTimer.h"
 #include "StringManager.h"
 

--- a/OrbitCore/KeyAndString.h
+++ b/OrbitCore/KeyAndString.h
@@ -2,13 +2,14 @@
 #define ORBIT_CORE_KEY_AND_STRING_H_
 
 #include <string>
+
 #include "Serialization.h"
 #include "SerializationMacros.h"
 
 struct KeyAndString {
   uint64_t key;
   std::string str;
-  
+
   ORBIT_SERIALIZABLE;
 };
 
@@ -17,4 +18,4 @@ ORBIT_SERIALIZE(KeyAndString, 0) {
   ORBIT_NVP_VAL(0, str);
 }
 
-#endif 
+#endif

--- a/OrbitCore/LinuxAddressInfo.h
+++ b/OrbitCore/LinuxAddressInfo.h
@@ -9,20 +9,18 @@
 #include "SerializationMacros.h"
 
 //-----------------------------------------------------------------------------
-struct LinuxSymbol {
-  std::string m_Module;
-  std::string m_Name;
-  std::string m_File;
-  uint32_t m_Line = 0;
-  uint64_t m_Address = 0;
+struct LinuxAddressInfo {
+  uint64_t address = 0;
+  std::string module_name;
+  std::string function_name;
+  uint64_t offset_in_function = 0;
 
   ORBIT_SERIALIZABLE;
 };
 
-ORBIT_SERIALIZE(LinuxSymbol, 0) {
-  ORBIT_NVP_VAL(0, m_Module);
-  ORBIT_NVP_VAL(0, m_Name);
-  ORBIT_NVP_VAL(0, m_File);
-  ORBIT_NVP_VAL(0, m_Line);
-  ORBIT_NVP_VAL(0, m_Address);
+ORBIT_SERIALIZE(LinuxAddressInfo, 0) {
+  ORBIT_NVP_VAL(0, module_name);
+  ORBIT_NVP_VAL(0, function_name);
+  ORBIT_NVP_VAL(0, address);
+  ORBIT_NVP_VAL(0, offset_in_function);
 }

--- a/OrbitCore/LinuxTracingHandler.cpp
+++ b/OrbitCore/LinuxTracingHandler.cpp
@@ -116,7 +116,7 @@ void LinuxTracingHandler::OnCallstack(
     if (!frame.GetFunctionName().empty() &&
         !target_process_->HasSymbol(address)) {
       std::string symbol_name =
-          absl::StrFormat("%s+%#x", llvm::demangle(frame.GetFunctionName()),
+          absl::StrFormat("%s+%#lx", llvm::demangle(frame.GetFunctionName()),
                           frame.GetFunctionOffset());
       std::shared_ptr<LinuxSymbol> symbol = std::make_shared<LinuxSymbol>();
       symbol->m_Module = frame.GetMapName();

--- a/OrbitCore/LinuxTracingSessionTests.cpp
+++ b/OrbitCore/LinuxTracingSessionTests.cpp
@@ -1,9 +1,9 @@
-#include "LinuxTracingSession.h"
-
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
 #include <utility>
+
+#include "LinuxTracingSession.h"
 
 TEST(LinuxTracingSession, Empty) {
   LinuxTracingSession session(nullptr);

--- a/OrbitCore/Log.h
+++ b/OrbitCore/Log.h
@@ -8,9 +8,9 @@
 #include "Core.h"
 
 #define ORBIT_LOG(msg) GLogger.Log(OrbitLog::Global, msg)
-#define ORBIT_LOGV(var) GLogger.Log(OrbitLog::Global, #var, var);
+#define ORBIT_LOGV(var) GLogger.Log(OrbitLog::Global, #var, var)
 #define ORBIT_VIZ(msg) GLogger.Logf(OrbitLog::Viz, msg)
-#define ORBIT_VIZV(var) GLogger.Log(OrbitLog::Viz, #var, var);
+#define ORBIT_VIZV(var) GLogger.Log(OrbitLog::Viz, #var, var)
 #define ORBIT_LOG_DEBUG(msg) GLogger.Log(OrbitLog::Debug, msg)
 #define ORBIT_PRINTF(msg) GLogger.Logf(OrbitLog::Viz, msg)
 #define ORBIT_LOG_PDB(msg)
@@ -22,12 +22,12 @@ class OrbitLog {
   enum Type { Global, Debug, Pdb, Viz, NumLogTypes };
 
   void Log(const std::string& a_String) {
-    m_Entries.push_back(a_String.c_str());
+    m_Entries.push_back(a_String);
   }
-  void Log(const char* a_String) { m_Entries.push_back(a_String); }
+  void Log(const char* a_String) { m_Entries.emplace_back(a_String); }
   void Log(const wchar_t* a_String) { Log(ws2s(a_String)); }
   void Logf(const std::string& a_String) {
-    if (m_Entries.size() == 0)
+    if (m_Entries.empty())
       m_Entries.push_back(a_String);
     else
       m_Entries[0] += a_String;

--- a/OrbitCore/Log.h
+++ b/OrbitCore/Log.h
@@ -21,9 +21,7 @@ class OrbitLog {
  public:
   enum Type { Global, Debug, Pdb, Viz, NumLogTypes };
 
-  void Log(const std::string& a_String) {
-    m_Entries.push_back(a_String);
-  }
+  void Log(const std::string& a_String) { m_Entries.push_back(a_String); }
   void Log(const char* a_String) { m_Entries.emplace_back(a_String); }
   void Log(const wchar_t* a_String) { Log(ws2s(a_String)); }
   void Logf(const std::string& a_String) {

--- a/OrbitCore/Message.h
+++ b/OrbitCore/Message.h
@@ -61,7 +61,7 @@ enum MessageType : int16_t {
   Msg_RemoteModuleDebugInfo,
   Msg_RemoteTimers,
   Msg_RemoteCallStack,
-  Msg_RemoteSymbol,
+  Msg_RemoteLinuxAddressInfo,
   Msg_SamplingCallstack,
   Msg_TimerCallstack,
   Msg_RemoteSelectedFunctionsMap,

--- a/OrbitCore/OrbitFunction.cpp
+++ b/OrbitCore/OrbitFunction.cpp
@@ -150,7 +150,7 @@ void Function::FindFile() {
 #ifdef _WIN32
   LineInfo lineInfo;
   SymUtils::GetLineInfo(GetVirtualAddress(), lineInfo);
-  if (lineInfo.m_File != L"") file_ = ws2s(lineInfo.m_File);
+  if (lineInfo.m_File != "") file_ = lineInfo.m_File;
   file_ = ToLower(file_);
   line_ = lineInfo.m_Line;
 #endif

--- a/OrbitCore/OrbitFunction.h
+++ b/OrbitCore/OrbitFunction.h
@@ -116,7 +116,7 @@ class Function {
   const std::string& Name() const { return name_; }
   const std::string& PrettyName() const;
   const std::string& Lower() {
-    if (pretty_name_lower_.size() == 0) {
+    if (pretty_name_lower_.empty()) {
       pretty_name_lower_ = ToLower(pretty_name_);
     }
     return pretty_name_lower_;

--- a/OrbitCore/OrbitLib.cpp
+++ b/OrbitCore/OrbitLib.cpp
@@ -49,9 +49,7 @@ void Orbit::Init(const std::string& a_Host) {
 }
 
 //-----------------------------------------------------------------------------
-void Orbit::InitRemote(const std::string& a_Host) {
-  Init(a_Host);
-}
+void Orbit::InitRemote(const std::string& a_Host) { Init(a_Host); }
 
 //-----------------------------------------------------------------------------
 HMODULE GetCurrentModule() {

--- a/OrbitCore/OrbitProcess.cpp
+++ b/OrbitCore/OrbitProcess.cpp
@@ -299,9 +299,9 @@ std::shared_ptr<Module> Process::GetModuleFromName(const std::string& a_Name) {
 }
 
 //-----------------------------------------------------------------------------
-void Process::AddSymbol(uint64_t a_Address,
-                        std::shared_ptr<LinuxSymbol> a_Symbol) {
-  m_Symbols[a_Address] = std::move(a_Symbol);
+void Process::AddAddressInfo(LinuxAddressInfo address_info) {
+  uint64_t address = address_info.address;
+  m_AddressInfos[address] = std::move(address_info);
 }
 
 #ifdef _WIN32

--- a/OrbitCore/Path.h
+++ b/OrbitCore/Path.h
@@ -51,8 +51,9 @@ class Path {
 
   static std::vector<std::string> ListFiles(
       const std::string& directory,
-      std::function<bool(const std::string&)> filter =
-          [](const std::string&) { return true; });
+      std::function<bool(const std::string&)> filter = [](const std::string&) {
+        return true;
+      });
   static std::vector<std::string> ListFiles(const std::string& directory,
                                             const std::string& filter);
   static bool ContainsFile(const std::string a_Dir, const std::string a_File);

--- a/OrbitCore/Pdb.cpp
+++ b/OrbitCore/Pdb.cpp
@@ -77,8 +77,7 @@ Pdb::~Pdb() {
 }
 
 //-----------------------------------------------------------------------------
-void Pdb::AddFunction(const std::shared_ptr<Function>& function)
-{
+void Pdb::AddFunction(const std::shared_ptr<Function>& function) {
   functions_.push_back(function);
   functions_.back()->SetPdb(this);
   CheckOrbitFunction(*functions_.back());

--- a/OrbitCore/Pdb.cpp
+++ b/OrbitCore/Pdb.cpp
@@ -617,7 +617,7 @@ bool Pdb::LineInfoFromAddress(uint64_t a_Address, LineInfo& o_LineInfo) {
         if (SUCCEEDED(sourceFile->get_fileName(&fileName))) {
           fileNameW = std::wstring(fileName);
           o_LineInfo.m_Address = a_Address;
-          o_LineInfo.m_File = fileName;
+          o_LineInfo.m_File = ws2s(fileName);
           o_LineInfo.m_Line = 0;
 
           SysFreeString(fileName);

--- a/OrbitCore/Pdb.h
+++ b/OrbitCore/Pdb.h
@@ -124,7 +124,7 @@ class Pdb {
   bool m_LoadedFromCache;
   std::vector<Variable> m_WatchedVariables;
   std::set<std::string> m_ArgumentRegisters;
-  std::map<std::string, std::vector<std::string> > m_RegFunctionsMap;
+  std::map<std::string, std::vector<std::string>> m_RegFunctionsMap;
 
   // Data
   std::string m_Name;
@@ -178,7 +178,9 @@ class Pdb {
   const std::string& GetName() const { return m_Name; }
   const std::string& GetFileName() const { return m_FileName; }
   const std::string& GetLoadedModuleName() const { return m_LoadedModuleName; }
-  const std::vector<std::shared_ptr<Function>>& GetFunctions() { return functions_; }
+  const std::vector<std::shared_ptr<Function>>& GetFunctions() {
+    return functions_;
+  }
   void AddFunction(const std::shared_ptr<Function>& function);
   std::vector<Type>& GetTypes() { return m_Types; }
   std::vector<Variable>& GetGlobals() { return m_Globals; }
@@ -236,7 +238,7 @@ class Pdb {
   float m_LastLoadTime = 0;
   std::vector<Variable> m_WatchedVariables;
   std::set<std::string> m_ArgumentRegisters;
-  std::map<std::string, std::vector<std::string> > m_RegFunctionsMap;
+  std::map<std::string, std::vector<std::string>> m_RegFunctionsMap;
 
   // Data
   std::string m_Name;              // name of the file containing the symbols

--- a/OrbitCore/ProcessUtils.cpp
+++ b/OrbitCore/ProcessUtils.cpp
@@ -95,7 +95,7 @@ void ProcessList::Clear() {
 void ProcessList::Refresh() {
 #ifdef _WIN32
   processes_.clear();
-  std::unordered_map<uint32_t, std::shared_ptr<Process> > previousProcessesMap =
+  std::unordered_map<uint32_t, std::shared_ptr<Process>> previousProcessesMap =
       processes_map_;
   processes_map_.clear();
 
@@ -258,9 +258,7 @@ const std::vector<std::shared_ptr<Process>>& ProcessList::GetProcesses() const {
   return processes_;
 }
 
-size_t ProcessList::Size() const {
-  return processes_.size();
-}
+size_t ProcessList::Size() const { return processes_.size(); }
 
 void ProcessList::AddProcess(std::shared_ptr<Process> process) {
   uint32_t pid = process->GetID();

--- a/OrbitCore/ProcessUtils.h
+++ b/OrbitCore/ProcessUtils.h
@@ -32,10 +32,10 @@ class ProcessList {
   void AddProcess(std::shared_ptr<Process> process);
 
   ORBIT_SERIALIZABLE;
+
  private:
   std::vector<std::shared_ptr<Process>> processes_;
   std::unordered_map<uint32_t, std::shared_ptr<Process>> processes_map_;
-
 };
 
 #endif  // ORBIT_CORE_PROCESS_UTILS_H_

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -15,26 +15,26 @@ class Thread;
 
 //-----------------------------------------------------------------------------
 struct SampledFunction {
-  SampledFunction() {}
-  unsigned long long Hash();
+  SampledFunction() = default;
+
   bool GetSelected();
-  std::wstring m_Name;
-  std::wstring m_Module;
-  std::wstring m_File;
+  std::string m_Name;
+  std::string m_Module;
+  std::string m_File;
   float m_Exclusive = 0;
   float m_Inclusive = 0;
   int m_Line = 0;
   uint64_t m_Address = 0;
-  uint64_t m_Hash = 0;
-  Function* m_Function = 0;
+  Function* m_Function = nullptr;
 
   ORBIT_SERIALIZABLE;
 };
 
 //-----------------------------------------------------------------------------
 struct LineInfo {
-  LineInfo() {}
-  std::wstring m_File;
+  LineInfo() = default;
+
+  std::string m_File;
   uint32_t m_Line = 0;
   uint64_t m_Address = 0;
   uint64_t m_FileNameHash = 0;
@@ -47,7 +47,7 @@ struct ThreadSampleData {
   ThreadSampleData() { m_ThreadUsage.push_back(0); }
   void ComputeAverageThreadUsage();
   std::multimap<int, CallstackID> SortCallstacks(
-      const std::set<CallstackID>& a_CallStacks, int& o_TotalCallStacks);
+      const std::set<CallstackID>& a_CallStacks, int* o_TotalCallStacks);
   std::unordered_map<CallstackID, unsigned int> m_CallstackCount;
   std::unordered_map<uint64_t, unsigned int> m_AddressCount;
   std::unordered_map<uint64_t, unsigned int> m_ExclusiveCount;
@@ -63,27 +63,28 @@ struct ThreadSampleData {
 
 //-----------------------------------------------------------------------------
 struct CallstackCount {
-  CallstackCount() {}
+  CallstackCount() = default;
+
   int m_Count = 0;
-  CallstackID m_CallstackId;
+  CallstackID m_CallstackId = 0;
+
   ORBIT_SERIALIZABLE;
 };
 
 //-----------------------------------------------------------------------------
 struct SortedCallstackReport {
-  SortedCallstackReport() {}
+  SortedCallstackReport() = default;
   int m_NumCallStacksTotal = 0;
   std::vector<CallstackCount> m_CallStacks;
+
   ORBIT_SERIALIZABLE;
 };
 
 //-----------------------------------------------------------------------------
 class SamplingProfiler {
  public:
-  explicit SamplingProfiler(const std::shared_ptr<Process>& a_Process,
-                            bool a_ETW = false);
+  explicit SamplingProfiler(const std::shared_ptr<Process>& a_Process);
   SamplingProfiler();
-  ~SamplingProfiler();
 
   void StartCapture();
   void StopCapture();
@@ -97,19 +98,19 @@ class SamplingProfiler {
   void AddHashedCallStack(CallstackEvent& a_CallStack);
   void AddUniqueCallStack(CallStack& a_CallStack);
 
-  const std::shared_ptr<CallStack> GetCallStack(CallstackID a_ID) {
+  std::shared_ptr<CallStack> GetCallStack(CallstackID a_ID) {
     ScopeLock lock(m_Mutex);
     return m_UniqueCallstacks[a_ID];
   }
 
-  inline bool HasCallStack(CallstackID a_ID) {
+  bool HasCallStack(CallstackID a_ID) {
     ScopeLock lock(m_Mutex);
     auto it = m_UniqueCallstacks.find(a_ID);
     return it != m_UniqueCallstacks.end();
   }
 
-  std::multimap<int, CallstackID> GetCallStacksFromAddress(
-      uint64_t a_Addr, ThreadID a_TID, int& o_NumCallstacks);
+  std::multimap<int, CallstackID> GetCallstacksFromAddress(
+      uint64_t a_Addr, ThreadID a_TID, int* o_NumCallstacks);
   std::shared_ptr<SortedCallstackReport> GetSortedCallstacksFromAddress(
       uint64_t a_Addr, ThreadID a_TID);
 
@@ -129,11 +130,9 @@ class SamplingProfiler {
   void SetIsLinuxPerf(bool a_Value = true) { m_IsLinuxPerf = a_Value; }
 
   typedef std::function<void()> ProcessingDoneCallback;
-  void AddCallback(ProcessingDoneCallback a_Callback) {
+  void AddCallback(const ProcessingDoneCallback& a_Callback) {
     m_Callbacks.push_back(a_Callback);
   }
-  void SetSelectedFunctions(
-      std::unordered_map<uint64_t, SampledFunction>& a_SelectedFunctions);
   void SetGenerateSummary(bool a_Value) { m_GenerateSummary = a_Value; }
   bool GetGenerateSummary() const { return m_GenerateSummary; }
   void SortByThreadUsage();
@@ -145,7 +144,7 @@ class SamplingProfiler {
   void ProcessSamplesAsync();
   void AddAddress(uint64_t a_Address);
 
-  std::wstring GetSymbolFromAddress(uint64_t a_Address);
+  std::string GetSymbolFromAddress(uint64_t a_Address);
   const ThreadSampleData& GetSummary() { return m_ThreadSampleData[0]; }
 
   ORBIT_SERIALIZABLE;
@@ -181,9 +180,9 @@ class SamplingProfiler {
   std::unordered_map<CallstackID, CallstackID> m_RawToResolvedMap;
   std::unordered_map<uint64_t, std::set<CallstackID>> m_FunctionToCallstacks;
   std::unordered_map<uint64_t, uint64_t> m_ExactAddresses;
-  std::unordered_map<uint64_t, std::wstring> m_AddressToSymbol;
+  std::unordered_map<uint64_t, std::string> m_AddressToSymbol;
   std::unordered_map<uint64_t, LineInfo> m_AddressToLineInfo;
-  std::unordered_map<uint64_t, std::wstring> m_FileNames;
+  std::unordered_map<uint64_t, std::string> m_FileNames;
   std::vector<ProcessingDoneCallback> m_Callbacks;
   std::vector<ThreadSampleData*> m_SortedThreadSampleData;
 };

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -154,8 +154,8 @@ class SamplingProfiler {
   void SampleThreadsAsync();
   void GetThreadCallstack(Thread* a_Thread);
   void GetThreadsUsage();
-  void ProcessAddresses();
-  void OutputStats();
+  void ResolveCallstacks();
+  void FillThreadSampleDataSampleReports();
 
  protected:
   std::shared_ptr<Process> m_Process;
@@ -177,10 +177,11 @@ class SamplingProfiler {
       m_UniqueCallstacks;
   std::unordered_map<CallstackID, std::shared_ptr<CallStack>>
       m_UniqueResolvedCallstacks;
-  std::unordered_map<CallstackID, CallstackID> m_RawToResolvedMap;
+  std::unordered_map<CallstackID, CallstackID>
+      m_OriginalCallstackToResolvedCallstack;
   std::unordered_map<uint64_t, std::set<CallstackID>> m_FunctionToCallstacks;
-  std::unordered_map<uint64_t, uint64_t> m_ExactAddresses;
-  std::unordered_map<uint64_t, std::string> m_AddressToSymbol;
+  std::unordered_map<uint64_t, uint64_t> m_ExactAddressToFunctionAddress;
+  std::unordered_map<uint64_t, std::string> m_AddressToName;
   std::unordered_map<uint64_t, LineInfo> m_AddressToLineInfo;
   std::unordered_map<uint64_t, std::string> m_FileNames;
   std::vector<ProcessingDoneCallback> m_Callbacks;

--- a/OrbitCore/StringManager.cpp
+++ b/OrbitCore/StringManager.cpp
@@ -1,9 +1,6 @@
 #include "StringManager.h"
 
-StringManager::StringManager() {}
-StringManager::~StringManager() {}
-
-void StringManager::Add(uint64_t key, const std::string_view str) {
+void StringManager::Add(uint64_t key, std::string_view str) {
   std::lock_guard<std::mutex> lock(mutex_);
   if (key_to_string_.count(key) == 0) {
     key_to_string_.emplace(key, str);
@@ -24,6 +21,7 @@ bool StringManager::Exists(uint64_t key) {
   std::lock_guard<std::mutex> lock(mutex_);
   return key_to_string_.count(key) > 0;
 }
+
 void StringManager::Clear() {
   std::lock_guard<std::mutex> lock(mutex_);
   key_to_string_.clear();

--- a/OrbitCore/StringManager.h
+++ b/OrbitCore/StringManager.h
@@ -4,20 +4,21 @@
 #include <mutex>
 #include <optional>
 #include <string>
+
 #include "absl/container/flat_hash_map.h"
 
 class StringManager {
  public:
-  StringManager();
-  ~StringManager();
+  StringManager() = default;
 
-  void Add(uint64_t key, const std::string_view str);
+  void Add(uint64_t key, std::string_view str);
   std::optional<std::string> Get(uint64_t key);
   bool Exists(uint64_t key);
   void Clear();
-private:
+
+ private:
   absl::flat_hash_map<uint64_t, std::string> key_to_string_;
   std::mutex mutex_;
 };
 
-#endif
+#endif  // ORBIT_CORE_STRING_MANAGER_H_

--- a/OrbitCore/StringManagerTest.cpp
+++ b/OrbitCore/StringManagerTest.cpp
@@ -1,6 +1,6 @@
-#include "StringManager.h"
-
 #include <gtest/gtest.h>
+
+#include "StringManager.h"
 
 TEST(StringManager, Exists) {
   StringManager string_manager;

--- a/OrbitCore/SymbolsManager.cpp
+++ b/OrbitCore/SymbolsManager.cpp
@@ -137,7 +137,7 @@ void SymbolsManager::HandleResponse(const Message& message, uint32_t id) {
 
 void SymbolsManager::FinalizeTransaction(Session* session) {
   // Apply session.
-  if(session != nullptr) {
+  if (session != nullptr) {
     core_app_->ApplySession(*session);
   }
 }

--- a/OrbitCore/SymbolsManager.h
+++ b/OrbitCore/SymbolsManager.h
@@ -36,7 +36,7 @@ class SymbolsManager {
   SymbolsManager(SymbolsManager&&) = delete;
   SymbolsManager& operator=(SymbolsManager&&) = delete;
 
-private:
+ private:
   void HandleRequest(const Message& message);
   void HandleResponse(const Message& message, uint32_t id);
   void FinalizeTransaction(Session* session);

--- a/OrbitCore/TransactionManager.cpp
+++ b/OrbitCore/TransactionManager.cpp
@@ -49,7 +49,7 @@ std::shared_ptr<Transaction> TransactionManager::PopTransaction() {
 }
 
 uint32_t TransactionManager::EnqueueRequestInternal(MessageType type,
-                                                std::string&& object) {
+                                                    std::string&& object) {
   absl::MutexLock lock(&mutex_);
   auto transaction = std::make_shared<Transaction>();
   transaction->type = type;

--- a/OrbitCore/TransactionManager.h
+++ b/OrbitCore/TransactionManager.h
@@ -36,7 +36,7 @@ namespace orbit {
 
 class TransactionManager {
  public:
-  TransactionManager(TcpClient* client,TcpServer* server);
+  TransactionManager(TcpClient* client, TcpServer* server);
 
   void RegisterTransactionHandler(const TransactionHandler& handler);
 

--- a/OrbitCore/Utils.h
+++ b/OrbitCore/Utils.h
@@ -3,15 +3,15 @@
 //-----------------------------------
 #pragma once
 
-#include <stdarg.h>
-#include <stdio.h>
-#include <string.h>
 #include <xxhash.h>
 
 #include <algorithm>
 #include <cctype>
 #include <cinttypes>
 #include <codecvt>
+#include <cstdarg>
+#include <cstdio>
+#include <cstring>
 #include <fstream>
 #include <functional>
 #include <iomanip>

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -227,6 +227,7 @@ void OrbitApp::AddSymbol(uint64_t a_Address, const std::string& a_Module,
   CHECK(!ConnectionManager::Get().IsService());
 
   auto symbol = std::make_shared<LinuxSymbol>();
+  symbol->m_Address = a_Address;
   symbol->m_Name = a_Name;
   symbol->m_Module = a_Module;
   Capture::GTargetProcess->AddSymbol(a_Address, symbol);
@@ -396,25 +397,26 @@ void OrbitApp::LoadFileMapping() {
             << std::endl
             << "// \"D:\\NoAccess\\File.cpp\" \"C:\\Available\\\"" << std::endl
             << std::endl
-            << "\"D:\\NoAccess\" \"C:\\Avalaible\"" << std::endl;
+            << "\"D:\\NoAccess\" \"C:\\Available\"" << std::endl;
 
     outfile.close();
   }
 
   std::wfstream infile(fileName);
   if (!infile.fail()) {
-    std::wstring line;
-    while (std::getline(infile, line)) {
-      if (StartsWith(line, L"//")) continue;
+    std::wstring wline;
+    while (std::getline(infile, wline)) {
+      std::string line = ws2s(wline);
+      if (StartsWith(line, "//")) continue;
 
-      bool containsQuotes = Contains(line, L"\"");
+      bool containsQuotes = Contains(line, "\"");
 
-      std::vector<std::wstring> tokens = Tokenize(line);
+      std::vector<std::string> tokens = Tokenize(line);
       if (tokens.size() == 2 && !containsQuotes) {
         m_FileMapping[ToLower(tokens[0])] = ToLower(tokens[1]);
       } else {
-        std::vector<std::wstring> validTokens;
-        for (const std::wstring& token : Tokenize(line, L"\"//")) {
+        std::vector<std::string> validTokens;
+        for (const std::string& token : Tokenize(line, "\"//")) {
           if (!IsBlank(token)) {
             validTokens.push_back(token);
           }

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -221,16 +221,11 @@ void OrbitApp::ProcessContextSwitch(const ContextSwitch& a_ContextSwitch) {
 }
 
 //-----------------------------------------------------------------------------
-void OrbitApp::AddSymbol(uint64_t a_Address, const std::string& a_Module,
-                         const std::string& a_Name) {
+void OrbitApp::AddAddressInfo(LinuxAddressInfo address_info) {
   // This should not be called for the service - make sure it doesn't
   CHECK(!ConnectionManager::Get().IsService());
 
-  auto symbol = std::make_shared<LinuxSymbol>();
-  symbol->m_Address = a_Address;
-  symbol->m_Name = a_Name;
-  symbol->m_Module = a_Module;
-  Capture::GTargetProcess->AddSymbol(a_Address, symbol);
+  Capture::GTargetProcess->AddAddressInfo(std::move(address_info));
 }
 //-----------------------------------------------------------------------------
 void OrbitApp::AddKeyAndString(uint64_t key, std::string_view str) {
@@ -792,7 +787,7 @@ void OrbitApp::OnLoadSession(const std::string& file_name) {
 
 //-----------------------------------------------------------------------------
 void OrbitApp::LoadSession(const std::shared_ptr<Session>& session) {
-  if(SelectProcess(Path::GetFileName(session->m_ProcessFullPath))) {
+  if (SelectProcess(Path::GetFileName(session->m_ProcessFullPath))) {
     Capture::GSessionPresets = session;
   }
 }
@@ -962,9 +957,9 @@ void OrbitApp::LoadModules() {
       return;
     }
 #ifdef _WIN32
-  for (std::shared_ptr<Module> module : m_ModulesToLoad) {
-    GLoadPdbAsync(module);
-  }
+    for (std::shared_ptr<Module> module : m_ModulesToLoad) {
+      GLoadPdbAsync(module);
+    }
 #else
     for (std::shared_ptr<Module> module : m_ModulesToLoad) {
       if (symbol_helper_.LoadSymbolsIncludedInBinary(module)) continue;
@@ -1046,14 +1041,14 @@ void OrbitApp::OnRemoteProcess(const Message& a_Message) {
 
   // Trigger session loading if needed.
   std::shared_ptr<Session> session = Capture::GSessionPresets;
-  if (session){
-      GetSymbolsManager()->LoadSymbols(session, remoteProcess);
-      GParams.m_ProcessPath = session->m_ProcessFullPath;
-      GParams.m_Arguments = session->m_Arguments;
-      GParams.m_WorkingDirectory = session->m_WorkingDirectory;
-      GCoreApp->SendToUiNow(L"SetProcessParams");
-      Capture::GSessionPresets = nullptr;
-    }
+  if (session) {
+    GetSymbolsManager()->LoadSymbols(session, remoteProcess);
+    GParams.m_ProcessPath = session->m_ProcessFullPath;
+    GParams.m_Arguments = session->m_Arguments;
+    GParams.m_WorkingDirectory = session->m_WorkingDirectory;
+    GCoreApp->SendToUiNow(L"SetProcessParams");
+    Capture::GSessionPresets = nullptr;
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -163,7 +163,7 @@ class OrbitApp : public CoreApp {
   void SendToUiNow(const std::wstring& a_Msg) override;
   void NeedsRedraw();
 
-  const std::map<std::wstring, std::wstring>& GetFileMapping() {
+  const std::map<std::string, std::string>& GetFileMapping() {
     return m_FileMapping;
   }
 
@@ -235,7 +235,7 @@ class OrbitApp : public CoreApp {
   bool m_UnrealEnabled = false;
 
   std::vector<std::shared_ptr<class SamplingReport> > m_SamplingReports;
-  std::map<std::wstring, std::wstring> m_FileMapping;
+  std::map<std::string, std::string> m_FileMapping;
   std::vector<std::string> m_SymbolDirectories;
   std::function<void(const std::wstring&)> m_UiCallback;
 

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -74,8 +74,7 @@ class OrbitApp : public CoreApp {
   void ProcessHashedSamplingCallStack(CallstackEvent& a_CallStack) override;
   void ProcessCallStack(CallStack& a_CallStack) override;
   void ProcessContextSwitch(const ContextSwitch& a_ContextSwitch) override;
-  void AddSymbol(uint64_t a_Address, const std::string& a_Module,
-                 const std::string& a_Name) override;
+  void AddAddressInfo(LinuxAddressInfo address_info) override;
   void AddKeyAndString(uint64_t key, std::string_view str) override;
 
   int* GetScreenRes() { return m_ScreenRes; }

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -44,7 +44,7 @@ std::string CallStackDataView::GetValue(int a_Row, int a_Column) {
       value = function.PrettyName();
       break;
     case Function::ADDRESS:
-      value = absl::StrFormat("0x%llx", function.GetVirtualAddress());
+      value = absl::StrFormat("%#llx", function.GetVirtualAddress());
       break;
     case Function::FILE:
       value = function.File();
@@ -107,7 +107,8 @@ void CallStackDataView::OnDataChanged() {
 //-----------------------------------------------------------------------------
 Function* CallStackDataView::GetFunction(int a_Row) {
   int index = m_Indices[a_Row];
-  if (m_CallStack != nullptr && index < static_cast<int>(m_CallStack->m_Depth) &&
+  if (m_CallStack != nullptr &&
+      index < static_cast<int>(m_CallStack->m_Depth) &&
       Capture::GTargetProcess != nullptr) {
     ScopeLock lock(Capture::GTargetProcess->GetDataMutex());
 
@@ -127,11 +128,12 @@ Function& CallStackDataView::GetFunctionOrDummy(int a_IndexInCallstack) {
   }
 
   static Function dummy;
-  if (m_CallStack != nullptr && a_IndexInCallstack < static_cast<int>(m_CallStack->m_Depth) &&
+  if (m_CallStack != nullptr &&
+      a_IndexInCallstack < static_cast<int>(m_CallStack->m_Depth) &&
       Capture::GSamplingProfiler != nullptr) {
     uint64_t address = m_CallStack->m_Data[a_IndexInCallstack];
     dummy.SetPrettyName(
-        ws2s(Capture::GSamplingProfiler->GetSymbolFromAddress(address)));
+        Capture::GSamplingProfiler->GetSymbolFromAddress(address));
     dummy.SetAddress(address);
   }
   return dummy;

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -27,7 +27,7 @@ CaptureSerializer::CaptureSerializer() {
 }
 
 //-----------------------------------------------------------------------------
-void CaptureSerializer::Save(const std::wstring a_FileName) {
+void CaptureSerializer::Save(const std::wstring& a_FileName) {
   Capture::PreSave();
 
   std::basic_ostream<char> Stream(&GStreamCounter);
@@ -101,7 +101,7 @@ void CaptureSerializer::Save(T& a_Archive) {
 
   // Timers
   int numWrites = 0;
-  std::vector<std::shared_ptr<TimerChain> > chains =
+  std::vector<std::shared_ptr<TimerChain>> chains =
       m_TimeGraph->GetAllTimerChains();
   for (const std::shared_ptr<TimerChain>& chain : chains) {
     for (const TextBox& box : *chain) {
@@ -115,7 +115,7 @@ void CaptureSerializer::Save(T& a_Archive) {
 }
 
 //-----------------------------------------------------------------------------
-void CaptureSerializer::Load(const std::wstring a_FileName) {
+void CaptureSerializer::Load(const std::wstring& a_FileName) {
   SCOPE_TIMER_LOG(
       absl::StrFormat("Loading capture %s", ws2s(a_FileName).c_str()));
 
@@ -131,7 +131,8 @@ void CaptureSerializer::Load(const std::wstring a_FileName) {
     std::shared_ptr<Module> module = std::make_shared<Module>();
     Capture::GTargetProcess->AddModule(module);
     module->m_Pdb = std::make_shared<Pdb>(ws2s(a_FileName).c_str());
-    std::vector<std::shared_ptr<Function>> functions = module->m_Pdb->GetFunctions();
+    std::vector<std::shared_ptr<Function>> functions =
+        module->m_Pdb->GetFunctions();
     archive(functions);
     module->m_Pdb->ProcessData();
     GPdbDbg = module->m_Pdb;

--- a/OrbitGl/CaptureSerializer.h
+++ b/OrbitGl/CaptureSerializer.h
@@ -13,8 +13,8 @@
 class CaptureSerializer {
  public:
   CaptureSerializer();
-  void Save(const std::wstring a_FileName);
-  void Load(const std::wstring a_FileName);
+  void Save(const std::wstring& a_FileName);
+  void Load(const std::wstring& a_FileName);
 
   template <class T>
   void Save(T& a_Archive);

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -292,15 +292,15 @@ void CaptureWindow::FindCode(DWORD64 address) {
     --lineInfo.m_Line;
 
     // File mapping
-    const std::map<std::wstring, std::wstring>& fileMap =
+    const std::map<std::string, std::string>& fileMap =
         GOrbitApp->GetFileMapping();
     for (const auto& pair : fileMap) {
       ReplaceStringInPlace(lineInfo.m_File, pair.first, pair.second);
     }
 
     if (lineInfo.m_Address != 0) {
-      GOrbitApp->SendToUiAsync(
-          Format(L"code^%s^%i", lineInfo.m_File.c_str(), lineInfo.m_Line));
+      GOrbitApp->SendToUiAsync(Format(
+          L"code^%s^%i", s2ws(lineInfo.m_File).c_str(), lineInfo.m_Line));
     }
   }
 #else

--- a/OrbitGl/FunctionsDataView.cpp
+++ b/OrbitGl/FunctionsDataView.cpp
@@ -342,11 +342,12 @@ void FunctionsDataView::OnFilter(const std::string& a_Filter) {
 //-----------------------------------------------------------------------------
 void FunctionsDataView::ParallelFilter() {
 #ifdef _WIN32
-  const std::vector<std::shared_ptr<Function>>& functions = Capture::GTargetProcess->GetFunctions();
+  const std::vector<std::shared_ptr<Function>>& functions =
+      Capture::GTargetProcess->GetFunctions();
   const auto prio = oqpi::task_priority::normal;
   auto numWorkers = oqpi_tk::scheduler().workersCount(prio);
   // int numWorkers = oqpi::thread::hardware_concurrency();
-  std::vector<std::vector<int> > indicesArray;
+  std::vector<std::vector<int>> indicesArray;
   indicesArray.resize(numWorkers);
 
   oqpi_tk::parallel_for(

--- a/OrbitGl/LogDataView.cpp
+++ b/OrbitGl/LogDataView.cpp
@@ -140,8 +140,7 @@ std::vector<std::string> LogDataView::GetContextMenu(
   if (m_SelectedCallstack) {
     for (uint32_t i = 0; i < m_SelectedCallstack->m_Depth; ++i) {
       DWORD64 addr = m_SelectedCallstack->m_Data[i];
-      menu.push_back(
-          ws2s(Capture::GSamplingProfiler->GetSymbolFromAddress(addr)));
+      menu.push_back(Capture::GSamplingProfiler->GetSymbolFromAddress(addr));
     }
   }
   Append(menu, DataView::GetContextMenu(a_ClickedIndex, a_SelectedIndices));

--- a/OrbitGl/ProcessesDataView.cpp
+++ b/OrbitGl/ProcessesDataView.cpp
@@ -190,8 +190,7 @@ void ProcessesDataView::Refresh() {
 
   if (m_RemoteProcess) {
     std::shared_ptr<Process> CurrentRemoteProcess =
-        m_ProcessList.Size() == 1 ? m_ProcessList.GetProcesses()[0]
-                                  : nullptr;
+        m_ProcessList.Size() == 1 ? m_ProcessList.GetProcesses()[0] : nullptr;
 
     if (m_RemoteProcess != CurrentRemoteProcess) {
       m_ProcessList.Clear();

--- a/OrbitGl/SamplingReport.cpp
+++ b/OrbitGl/SamplingReport.cpp
@@ -9,6 +9,7 @@
 #include "CallStackDataView.h"
 #include "SamplingProfiler.h"
 #include "SamplingReportDataView.h"
+#include "absl/strings/str_format.h"
 
 //-----------------------------------------------------------------------------
 SamplingReport::SamplingReport(
@@ -17,11 +18,9 @@ SamplingReport::SamplingReport(
   m_SelectedAddress = 0;
   m_CallstackDataView = nullptr;
   m_SelectedSortedCallstackReport = nullptr;
+  m_SelectedAddressCallstackIndex = 0;
   FillReport();
 }
-
-//-----------------------------------------------------------------------------
-SamplingReport::~SamplingReport() { m_ThreadReports.clear(); }
 
 //-----------------------------------------------------------------------------
 void SamplingReport::FillReport() {
@@ -39,9 +38,6 @@ void SamplingReport::FillReport() {
     threadReport->SetSamplingReport(this);
     m_ThreadReports.push_back(threadReport);
   }
-
-  static int cnt = 0;
-  std::string panelName = "samplingReport" + std::to_string(cnt++);
 }
 
 //-----------------------------------------------------------------------------
@@ -83,21 +79,21 @@ void SamplingReport::DecrementCallstackIndex() {
 }
 
 //-----------------------------------------------------------------------------
-std::wstring SamplingReport::GetSelectedCallstackString() {
+std::string SamplingReport::GetSelectedCallstackString() {
   if (m_SelectedSortedCallstackReport) {
     int numOccurances = m_SelectedSortedCallstackReport
                             ->m_CallStacks[m_SelectedAddressCallstackIndex]
                             .m_Count;
     int totalCallstacks = m_SelectedSortedCallstackReport->m_NumCallStacksTotal;
 
-    return Format(
-        L"%i of %i unique callstacks.  [%i/%i total callstacks](%.2f%%)",
+    return absl::StrFormat(
+        "%i of %i unique callstacks.  [%i/%i total callstacks](%.2f%%)",
         m_SelectedAddressCallstackIndex + 1,
         m_SelectedSortedCallstackReport->m_CallStacks.size(), numOccurances,
         totalCallstacks, 100.f * (float)numOccurances / (float)totalCallstacks);
   }
 
-  return L"Callstacks";
+  return "Callstacks";
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/SamplingReport.h
+++ b/OrbitGl/SamplingReport.h
@@ -6,13 +6,14 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 //-----------------------------------------------------------------------------
 class SamplingReport {
  public:
-  SamplingReport(std::shared_ptr<class SamplingProfiler> a_SamplingProfiler);
-  ~SamplingReport();
+  explicit SamplingReport(
+      std::shared_ptr<class SamplingProfiler> a_SamplingProfiler);
 
   void FillReport();
   std::shared_ptr<class SamplingProfiler> GetProfiler() const {
@@ -28,9 +29,9 @@ class SamplingReport {
   void OnCallstackIndexChanged(int a_Index);
   void IncrementCallstackIndex();
   void DecrementCallstackIndex();
-  std::wstring GetSelectedCallstackString();
+  std::string GetSelectedCallstackString();
   void SetUiRefreshFunc(std::function<void()> a_Func) {
-    m_UiRefreshFunc = a_Func;
+    m_UiRefreshFunc = std::move(a_Func);
   }
   bool HasCallstacks() const {
     return m_SelectedSortedCallstackReport != nullptr;

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -117,7 +117,7 @@ std::string SamplingReportDataView::GetValue(int a_Row, int a_Column) {
       value = absl::StrFormat("%d", a_Row);
       break;
     case SamplingColumn::FunctionName:
-      value = ws2s(func.m_Name);
+      value = func.m_Name;
       break;
     case SamplingColumn::Exclusive:
       value = absl::StrFormat("%.2f", func.m_Exclusive);
@@ -126,16 +126,16 @@ std::string SamplingReportDataView::GetValue(int a_Row, int a_Column) {
       value = absl::StrFormat("%.2f", func.m_Inclusive);
       break;
     case SamplingColumn::ModuleName:
-      value = ws2s(func.m_Module);
+      value = func.m_Module;
       break;
     case SamplingColumn::SourceFile:
-      value = ws2s(func.m_File);
+      value = func.m_File;
       break;
     case SamplingColumn::SourceLine:
       value = func.m_Line > 0 ? absl::StrFormat("%d", func.m_Line) : "";
       break;
     case SamplingColumn::Address:
-      value = absl::StrFormat("0x%llx", func.m_Address);
+      value = absl::StrFormat("%#llx", func.m_Address);
       break;
     default:
       break;
@@ -232,7 +232,7 @@ SamplingReportDataView::GetModulesFromIndices(
     std::set<std::string> module_names;
     for (int index : a_Indices) {
       SampledFunction& sampled_function = GetSampledFunction(index);
-      module_names.emplace(ws2s(sampled_function.m_Module));
+      module_names.emplace(sampled_function.m_Module);
     }
 
     auto& module_map = Capture::GTargetProcess->GetNameToModulesMap();
@@ -345,8 +345,8 @@ void SamplingReportDataView::OnFilter(const std::string& a_Filter) {
 
   for (size_t i = 0; i < m_Functions.size(); ++i) {
     SampledFunction& func = m_Functions[i];
-    std::string name = ToLower(ws2s(func.m_Name));
-    std::string module = ToLower(ws2s(func.m_Module));
+    std::string name = ToLower(func.m_Name);
+    std::string module = ToLower(func.m_Module);
 
     bool match = true;
 

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -29,8 +29,8 @@
 #include "ThreadTrack.h"
 #include "TimerManager.h"
 #include "Utils.h"
-#include "absl/strings/str_format.h"
 #include "absl/flags/flag.h"
+#include "absl/strings/str_format.h"
 
 // TODO: Remove this flag once we have a way to toggle the display return values
 ABSL_FLAG(bool, show_return_values, false, "Show return values on time slices");
@@ -531,8 +531,7 @@ std::string GetExtraInfo(const Timer& a_Timer) {
   if (!Capture::IsCapturing() && a_Timer.GetType() == Timer::UNREAL_OBJECT) {
     info =
         "[" + ws2s(GOrbitUnreal.GetObjectNames()[a_Timer.m_UserData[0]]) + "]";
-  }
-  else if (show_return_value && (a_Timer.GetType() == Timer::NONE)) {
+  } else if (show_return_value && (a_Timer.GetType() == Timer::NONE)) {
     info = absl::StrFormat("[%lu]", a_Timer.m_UserData[0]);
   }
   return info;

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -65,7 +65,7 @@ class TimeGraph {
                double a_InitialTime);
   double GetTime(double a_Ratio);
   double GetTimeIntervalMicro(double a_Ratio);
-  void Select(const Vec2& a_WorldStart, const Vec2 a_WorldStop);
+  void Select(const Vec2& a_WorldStart, const Vec2& a_WorldStop);
   void Select(const TextBox* a_TextBox) { SelectRight(a_TextBox); }
   void SelectLeft(const TextBox* a_TextBox);
   void SelectRight(const TextBox* a_TextBox);

--- a/OrbitLinuxTracing/Utils.cpp
+++ b/OrbitLinuxTracing/Utils.cpp
@@ -4,7 +4,6 @@
 #include <OrbitBase/Logging.h>
 #include <OrbitBase/SafeStrerror.h>
 #include <sys/resource.h>
-#include <sys/time.h>
 
 #include <fstream>
 #include <thread>

--- a/OrbitLinuxTracing/Utils.h
+++ b/OrbitLinuxTracing/Utils.h
@@ -4,6 +4,7 @@
 #include <OrbitBase/Logging.h>
 #include <unistd.h>
 
+#include <ctime>
 #include <optional>
 
 namespace LinuxTracing {

--- a/OrbitQt/orbitsamplingreport.cpp
+++ b/OrbitQt/orbitsamplingreport.cpp
@@ -99,7 +99,7 @@ void OrbitSamplingReport::Refresh() {
     ui->NextCallstackButton->setEnabled(true);
     ui->PreviousCallstackButton->setEnabled(true);
   }
-  std::wstring label = m_SamplingReport->GetSelectedCallstackString();
-  ui->CallStackLabel->setText(QString::fromStdWString(label));
+  std::string label = m_SamplingReport->GetSelectedCallstackString();
+  ui->CallStackLabel->setText(QString::fromStdString(label));
   ui->CallstackTreeView->Refresh();
 }


### PR DESCRIPTION
This is done by properly filling `m_ExactAddressToFunctionAddress` in
`SamplingProfiler::AddAddress` (per the TODO), the rest of the code was already
in place.
Also rename some members of `SamplingProfiler` to better reflect their role.

Bug: b/153333476