### PR TITLE
Disable frame pointer omission in Linux builds

### DIFF
--- a/contrib/conan/configs/linux/profiles/clang7_debug
+++ b/contrib/conan/configs/linux/profiles/clang7_debug
@@ -13,3 +13,5 @@ cmake/3.16.4@
 [env]
 CC=clang-7
 CXX=clang++-7
+CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer
+CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer

--- a/contrib/conan/configs/linux/profiles/clang7_release
+++ b/contrib/conan/configs/linux/profiles/clang7_release
@@ -13,3 +13,5 @@ cmake/3.16.4@
 [env]
 CC=clang-7
 CXX=clang++-7
+CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer
+CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer

--- a/contrib/conan/configs/linux/profiles/clang7_relwithdebinfo
+++ b/contrib/conan/configs/linux/profiles/clang7_relwithdebinfo
@@ -13,3 +13,5 @@ cmake/3.16.4@
 [env]
 CC=clang-7
 CXX=clang++-7
+CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer
+CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer

--- a/contrib/conan/configs/linux/profiles/clang8_debug
+++ b/contrib/conan/configs/linux/profiles/clang8_debug
@@ -13,3 +13,5 @@ cmake/3.16.4@
 [env]
 CC=clang-8
 CXX=clang++-8
+CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer
+CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer

--- a/contrib/conan/configs/linux/profiles/clang8_release
+++ b/contrib/conan/configs/linux/profiles/clang8_release
@@ -13,3 +13,5 @@ cmake/3.16.4@
 [env]
 CC=clang-8
 CXX=clang++-8
+CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer
+CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer

--- a/contrib/conan/configs/linux/profiles/clang8_relwithdebinfo
+++ b/contrib/conan/configs/linux/profiles/clang8_relwithdebinfo
@@ -13,3 +13,5 @@ cmake/3.16.4@
 [env]
 CC=clang-8
 CXX=clang++-8
+CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer
+CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer

--- a/contrib/conan/configs/linux/profiles/clang9_debug
+++ b/contrib/conan/configs/linux/profiles/clang9_debug
@@ -13,3 +13,5 @@ cmake/3.16.4@
 [env]
 CC=clang-9
 CXX=clang++-9
+CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer
+CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer

--- a/contrib/conan/configs/linux/profiles/clang9_release
+++ b/contrib/conan/configs/linux/profiles/clang9_release
@@ -13,3 +13,5 @@ cmake/3.16.4@
 [env]
 CC=clang-9
 CXX=clang++-9
+CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer
+CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer

--- a/contrib/conan/configs/linux/profiles/clang9_relwithdebinfo
+++ b/contrib/conan/configs/linux/profiles/clang9_relwithdebinfo
@@ -13,3 +13,5 @@ cmake/3.16.4@
 [env]
 CC=clang-9
 CXX=clang++-9
+CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer
+CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer

--- a/contrib/conan/configs/linux/profiles/gcc8_debug
+++ b/contrib/conan/configs/linux/profiles/gcc8_debug
@@ -13,3 +13,5 @@ cmake/3.16.4@
 [env]
 CC=gcc-8
 CXX=g++-8
+CFLAGS= -fno-omit-frame-pointer
+CXXFLAGS= -fno-omit-frame-pointer

--- a/contrib/conan/configs/linux/profiles/gcc8_release
+++ b/contrib/conan/configs/linux/profiles/gcc8_release
@@ -11,3 +11,5 @@ build_type=Release
 [build_requires]
 cmake/3.16.4@
 [env]
+CC=gcc-8
+CXX=g++-8

--- a/contrib/conan/configs/linux/profiles/gcc8_release
+++ b/contrib/conan/configs/linux/profiles/gcc8_release
@@ -13,3 +13,5 @@ cmake/3.16.4@
 [env]
 CC=gcc-8
 CXX=g++-8
+CFLAGS= -fno-omit-frame-pointer
+CXXFLAGS= -fno-omit-frame-pointer

--- a/contrib/conan/configs/linux/profiles/gcc8_relwithdebinfo
+++ b/contrib/conan/configs/linux/profiles/gcc8_relwithdebinfo
@@ -11,3 +11,5 @@ build_type=RelWithDebInfo
 [build_requires]
 cmake/3.16.4@
 [env]
+CC=gcc-8
+CXX=g++-8

--- a/contrib/conan/configs/linux/profiles/gcc8_relwithdebinfo
+++ b/contrib/conan/configs/linux/profiles/gcc8_relwithdebinfo
@@ -13,3 +13,5 @@ cmake/3.16.4@
 [env]
 CC=gcc-8
 CXX=g++-8
+CFLAGS= -fno-omit-frame-pointer
+CXXFLAGS= -fno-omit-frame-pointer

--- a/contrib/conan/configs/linux/profiles/gcc9_debug
+++ b/contrib/conan/configs/linux/profiles/gcc9_debug
@@ -13,3 +13,5 @@ cmake/3.16.4@
 [env]
 CC=gcc-9
 CXX=g++-9
+CFLAGS= -fno-omit-frame-pointer
+CXXFLAGS= -fno-omit-frame-pointer

--- a/contrib/conan/configs/linux/profiles/gcc9_release
+++ b/contrib/conan/configs/linux/profiles/gcc9_release
@@ -13,3 +13,5 @@ cmake/3.16.4@
 [env]
 CC=gcc-9
 CXX=g++-9
+CFLAGS= -fno-omit-frame-pointer
+CXXFLAGS= -fno-omit-frame-pointer

--- a/contrib/conan/configs/linux/profiles/gcc9_release
+++ b/contrib/conan/configs/linux/profiles/gcc9_release
@@ -11,3 +11,5 @@ build_type=Release
 [build_requires]
 cmake/3.16.4@
 [env]
+CC=gcc-9
+CXX=g++-9

--- a/contrib/conan/configs/linux/profiles/gcc9_relwithdebinfo
+++ b/contrib/conan/configs/linux/profiles/gcc9_relwithdebinfo
@@ -11,3 +11,5 @@ build_type=RelWithDebInfo
 [build_requires]
 cmake/3.16.4@
 [env]
+CC=gcc-9
+CXX=g++-9

--- a/contrib/conan/configs/linux/profiles/gcc9_relwithdebinfo
+++ b/contrib/conan/configs/linux/profiles/gcc9_relwithdebinfo
@@ -13,3 +13,5 @@ cmake/3.16.4@
 [env]
 CC=gcc-9
 CXX=g++-9
+CFLAGS= -fno-omit-frame-pointer
+CXXFLAGS= -fno-omit-frame-pointer

--- a/contrib/conan/configs/linux/profiles/ggp_debug
+++ b/contrib/conan/configs/linux/profiles/ggp_debug
@@ -15,3 +15,5 @@ cmake/3.16.4@
 ggp_sdk/1.43.0.14282@orbitdeps/stable
 
 [env]
+CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer
+CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer

--- a/contrib/conan/configs/linux/profiles/ggp_release
+++ b/contrib/conan/configs/linux/profiles/ggp_release
@@ -15,3 +15,5 @@ cmake/3.16.4@
 ggp_sdk/1.43.0.14282@orbitdeps/stable
 
 [env]
+CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer
+CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer

--- a/contrib/conan/configs/linux/profiles/ggp_relwithdebinfo
+++ b/contrib/conan/configs/linux/profiles/ggp_relwithdebinfo
@@ -15,3 +15,5 @@ cmake/3.16.4@
 ggp_sdk/1.43.0.14282@orbitdeps/stable
 
 [env]
+CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer
+CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer


### PR DESCRIPTION
This PR adds the necessary compiler flags to our conan profiles such that
Orbit and all its dependencies compile with frame pointers enabled.

This only applies to the linux builds, most importantly to the GGP builds.

**Note:** Even though these flags also apply to dependencies conan is not yet triggering
a recompilation of all the dependencies. Since we have to rebuild everything I first
want to try if the CI can cope with that. As soon as I'm confident I'm going to add a setting which allows conan to differentiate between FPO and non-FPO packages.

Tests: I haven't examined any of the executables. I only checked whether the compiler is actually invoked with these flags.