### PR TITLE
Made crashpad recipe take env variables into account.

### DIFF
--- a/contrib/conan/recipes/crashpad/conanfile.py
+++ b/contrib/conan/recipes/crashpad/conanfile.py
@@ -9,7 +9,7 @@ class CrashpadConan(ConanFile):
     version = "20191009"
     description = "Crashpad is a crash-reporting system."
     license = "Apache-2.0"
-    homepage = "https://chromium.googlesource.com/crashpad/crashpad"
+    homepage = "https://github.com/chromium/crashpad.git"
     url = "https://github.com/bincrafters/conan-crashpad"
     topics = ("conan", "crash-reporting", "logging", "minidump", "crash")
     settings = "os", "compiler", "build_type", "arch"


### PR DESCRIPTION
It was more massaging needed than I expected but now the crashpad recipe should take compilers and compiler flags propagated via environment variables into account.

This is especially important because it's conan standard way to distribute these settings
since all traditional build systems support that. But unfortunately gn does not. That's why
these hacks are needed.

It compiles for me on all platforms and all compilers. Cross compilation works as well.

@IrinaShkviro I haven't uploaded this new recipe yet. I thought you could first have a look. Maybe you spot some problem.

Addendum: Just added the fPIC option as in all other packages. crashpad does not support
to be compiled without fPIC. So this change just ensures that it does not silently fail when fPIC is disabled.