### PR TITLE
Changed package sources away from googlesource.com

### DIFF
--- a/contrib/conan/recipes/libunwindstack/conanfile.py
+++ b/contrib/conan/recipes/libunwindstack/conanfile.py
@@ -19,7 +19,7 @@ class LibunwindstackConan(ConanFile):
             del self.options.fPIC
 
     def source(self):
-        self.run("git clone https://github.com/aosp-mirror/platform_system_core.git android-core")
+        self.run("git clone https://android.googlesource.com/platform/system/core.git android-core")
         self.run("git checkout --detach {}".format(self.version), cwd="android-core/")
 
     def build(self):

--- a/contrib/conan/recipes/libunwindstack/conanfile.py
+++ b/contrib/conan/recipes/libunwindstack/conanfile.py
@@ -10,7 +10,7 @@ class LibunwindstackConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake"
     exports_sources = ["CMakeLists.txt", "overrides/file.cpp"]
-    requires = ["lzma_sdk/cb0b018@orbitdeps/stable"]
+    requires = ["lzma_sdk/19.00@orbitdeps/stable"]
     options = {"fPIC" : [True, False]}
     default_options = {"fPIC": True}
 
@@ -19,7 +19,7 @@ class LibunwindstackConan(ConanFile):
             del self.options.fPIC
 
     def source(self):
-        self.run("git clone https://android.googlesource.com/platform/system/core.git android-core")
+        self.run("git clone https://github.com/aosp-mirror/platform_system_core.git android-core")
         self.run("git checkout --detach {}".format(self.version), cwd="android-core/")
 
     def build(self):

--- a/contrib/conan/recipes/lzma/conanfile.py
+++ b/contrib/conan/recipes/lzma/conanfile.py
@@ -1,9 +1,10 @@
 from conans import ConanFile, CMake, tools
+import os
 
 
 class LzmasdkConan(ConanFile):
     name = "lzma_sdk"
-    version = "cb0b018"
+    version = "19.00"
     license = "MIT"
     author = "Henning Becker <henning.becker@gmail.com>"
     homepage = "https://www.7-zip.org/sdk.html"
@@ -13,15 +14,18 @@ class LzmasdkConan(ConanFile):
     exports_sources = "CMakeLists.txt"
     options = {"fPIC" : [True, False]}
     default_options = {"fPIC": True}
+    build_requires = "cmake/[>3.15]"
 
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
     def source(self):
-        self.run("git clone https://android.googlesource.com/platform/external/lzma")
-        self.run("git checkout --detach {}".format(self.version), cwd="lzma/")
-
+        tools.download("https://www.7-zip.org/a/lzma1900.7z", sha256='00f569e624b3d9ed89cf8d40136662c4c5207eaceb92a70b1044c77f84234bad', filename='lzma.7z')
+        os.mkdir("lzma")
+        with tools.chdir("./lzma/"):
+            self.run("cmake -E tar x ../lzma.7z")
+        os.remove("lzma.7z")
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Since googlesource.com gave us some problems we wanted to move away from there.

This PR make the lzma_sdk package download its source from the official server (non-git)
and switches libunwindstack over to the AOSP github mirror for downloading.