### PR TITLE
Display more information on GPU and introspection timeslices

### DIFF
--- a/OrbitCore/Introspection.cpp
+++ b/OrbitCore/Introspection.cpp
@@ -50,9 +50,9 @@ void Handler::End() {
   scopes.pop_back();
 }
 
-void Handler::Track(const char* name, int) {}
+void Handler::Track(const char*, int) {}
 
-void Handler::Track(const char* name, float) {}
+void Handler::Track(const char*, float) {}
 
 }  // namespace introspection
 }  // namespace orbit

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -169,5 +169,6 @@ std::vector<std::shared_ptr<TimerChain>> ThreadTrack::GetAllChains() const {
 
 //-----------------------------------------------------------------------------
 void ThreadTrack::SetEventTrackColor(Color color) {
+  ScopeLock lock(m_Mutex);
   m_EventTrack->SetColor(color);
 }

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -683,11 +683,18 @@ void TimeGraph::UpdatePrimitives(bool a_Picking) {
 
                 textBox.SetText(text);
               } else if (timer.m_Type == Timer::INTROSPECTION) {
-                textBox.SetText(
-                    string_manager_->Get(timer.m_UserData[0]).value_or(""));
+                std::string text = absl::StrFormat(
+                    "%s %s",
+                    string_manager_->Get(timer.m_UserData[0]).value_or(""),
+                    time.c_str());
+                textBox.SetText(text);
               } else if (timer.m_Type == Timer::GPU_ACTIVITY) {
-                textBox.SetText(
-                    string_manager_->Get(timer.m_UserData[0]).value_or(""));
+                std::string text = absl::StrFormat(
+                    "%s; submitter tid: %d  %s",
+                    string_manager_->Get(timer.m_UserData[0]).value_or(""),
+                    timer.m_SubmitTID,
+                    time.c_str());
+                textBox.SetText(text);
               } else if (!SystraceManager::Get().IsEmpty()) {
                 textBox.SetText(SystraceManager::Get().GetFunctionName(
                     timer.m_FunctionAddress));

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -690,7 +690,7 @@ void TimeGraph::UpdatePrimitives(bool a_Picking) {
                 textBox.SetText(text);
               } else if (timer.m_Type == Timer::GPU_ACTIVITY) {
                 std::string text = absl::StrFormat(
-                    "%s; submitter tid: %d  %s",
+                    "%s; submitter: %d  %s",
                     string_manager_->Get(timer.m_UserData[0]).value_or(""),
                     timer.m_SubmitTID,
                     time.c_str());


### PR DESCRIPTION
GPU timeslices now display the thread if that submitted the job (the thread that did the QueueSubmit) and the delta time between start and end of the slice.

Introspection timeslices now display the time delta.

Other small fixes:
- Added a mutex when writing the event track color.
- Removed an unused parameter name that was causing a warning.