### PR TITLE
upload dumps to STAGING

### DIFF
--- a/OrbitCore/CrashHandler.cpp
+++ b/OrbitCore/CrashHandler.cpp
@@ -33,7 +33,8 @@ struct StringTypeConverter<std::wstring> {
 //-----------------------------------------------------------------------------
 CrashHandler::CrashHandler(const std::string& dump_path,
                            const std::string& handler_path,
-                           const std::string& crash_server_url) {
+                           const std::string& crash_server_url,
+                           bool is_upload_enabled) {
   CHECK(!is_init_);
   is_init_ = true;
 
@@ -44,16 +45,16 @@ CrashHandler::CrashHandler(const std::string& dump_path,
   const base::FilePath dump_file_path(StringTypeConverter<>()(dump_path));
   const base::FilePath handler_file_path(StringTypeConverter<>()(handler_path));
 
-  std::map<std::string, std::string> annotations = {
+  const std::map<std::string, std::string> annotations = {
       {"product", "OrbitProfiler"}, {"version", OrbitVersion::GetVersion()}};
 
-  std::vector<std::string> arguments = {"--no-rate-limit"};
+  const std::vector<std::string> arguments = {"--no-rate-limit"};
 
-  // allow dumps submission to collection server
+  // set user preferences for dumps submission to collection server
   std::unique_ptr<crashpad::CrashReportDatabase> crash_report_db =
       crashpad::CrashReportDatabase::Initialize(dump_file_path);
   if (crash_report_db != nullptr && crash_report_db->GetSettings() != nullptr) {
-    crash_report_db->GetSettings()->SetUploadsEnabled(true);
+    crash_report_db->GetSettings()->SetUploadsEnabled(is_upload_enabled);
   }
 
   crashpad_client_.StartHandler(handler_file_path,

--- a/OrbitCore/CrashHandler.h
+++ b/OrbitCore/CrashHandler.h
@@ -12,7 +12,8 @@ class CrashHandler {
  public:
   explicit CrashHandler(const std::string& dump_path,
                         const std::string& handler_path,
-                        const std::string& crash_server_url);
+                        const std::string& crash_server_url,
+                        bool is_upload_enabled);
   void DumpWithoutCrash() const;
 
  private:

--- a/OrbitCore/CrashHandler.h
+++ b/OrbitCore/CrashHandler.h
@@ -1,7 +1,8 @@
 //-----------------------------------
 // Copyright Pierric Gimmig 2013-2017
 //-----------------------------------
-#pragma once
+#ifndef ORBIT_CORE_CRASH_HANDLER_H_
+#define ORBIT_CORE_CRASH_HANDLER_H_
 
 #include <client/crashpad_client.h>
 
@@ -18,3 +19,5 @@ class CrashHandler {
   inline static bool is_init_{false};
   crashpad::CrashpadClient crashpad_client_;
 };
+
+#endif  // ORBIT_CORE_CRASH_HANDLER_H_

--- a/OrbitCore/CrashHandler.h
+++ b/OrbitCore/CrashHandler.h
@@ -10,7 +10,8 @@
 class CrashHandler {
  public:
   explicit CrashHandler(const std::string& dump_path,
-                        const std::string& handler_path);
+                        const std::string& handler_path,
+                        const std::string& crash_server_url);
   void DumpWithoutCrash() const;
 
  private:

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -26,13 +26,17 @@ int main(int argc, char* argv[]) {
   const std::string dump_path = Path::GetDumpPath();
 #ifdef _WIN32
   const char* handler_name = "crashpad_handler.exe";
+  const std::string crash_server_url =
+      "https://clients2.google.com/cr/staging_report";
 #else
   const char* handler_name = "crashpad_handler";
+  const std::string crash_server_url =
+      "http://clients2.google.com/cr/staging_report";
 #endif
   const std::string handler_path = QDir(QCoreApplication::applicationDirPath())
-                                 .absoluteFilePath(handler_name)
-                                 .toStdString();
-  const CrashHandler crash_handler(dump_path, handler_path);
+                                       .absoluteFilePath(handler_name)
+                                       .toStdString();
+  const CrashHandler crash_handler(dump_path, handler_path, crash_server_url);
 
   a.setStyle(QStyleFactory::create("Fusion"));
 

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -7,12 +7,18 @@
 #include <QFontDatabase>
 #include <QStyleFactory>
 
+#include "absl/flags/flag.h"
+#include "absl/flags/parse.h"
+#include "absl/flags/usage.h"
+
 #include "../OrbitGl/App.h"
 #include "CrashHandler.h"
 #include "Path.h"
 #include "orbitmainwindow.h"
-#include "absl/flags/parse.h"
-#include "absl/flags/usage.h"
+
+// TODO: Remove this flag once we have a dialog with user
+ABSL_FLAG(bool, upload_dumps_to_server, false,
+          "Upload dumps to collection server when crashes");
 
 int main(int argc, char* argv[]) {
   absl::SetProgramUsageMessage("CPU Profiler");
@@ -34,7 +40,8 @@ int main(int argc, char* argv[]) {
                                        .toStdString();
   const std::string crash_server_url =
       "https://clients2.google.com/cr/staging_report";
-  const CrashHandler crash_handler(dump_path, handler_path, crash_server_url);
+  const CrashHandler crash_handler(dump_path, handler_path, crash_server_url,
+                                   absl::GetFlag(FLAGS_upload_dumps_to_server));
 
   a.setStyle(QStyleFactory::create("Fusion"));
 

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -26,16 +26,14 @@ int main(int argc, char* argv[]) {
   const std::string dump_path = Path::GetDumpPath();
 #ifdef _WIN32
   const char* handler_name = "crashpad_handler.exe";
-  const std::string crash_server_url =
-      "https://clients2.google.com/cr/staging_report";
 #else
   const char* handler_name = "crashpad_handler";
-  const std::string crash_server_url =
-      "http://clients2.google.com/cr/staging_report";
 #endif
   const std::string handler_path = QDir(QCoreApplication::applicationDirPath())
                                        .absoluteFilePath(handler_name)
                                        .toStdString();
+  const std::string crash_server_url =
+      "https://clients2.google.com/cr/staging_report";
   const CrashHandler crash_handler(dump_path, handler_path, crash_server_url);
 
   a.setStyle(QStyleFactory::create("Fusion"));

--- a/contrib/conan/recipes/crashpad/conanfile.py
+++ b/contrib/conan/recipes/crashpad/conanfile.py
@@ -108,6 +108,8 @@ class CrashpadConan(ConanFile):
         if self.settings.os == "Windows" and self.settings.get_safe("compiler.runtime"):
             crt = str(self.settings.compiler.runtime)
             args += [ "dynamic_crt=%s" % ("true" if crt.startswith("MD") else "false") ]
+        if self.settings.os == "Linux":
+            args += [ "crashpad_use_boringssl_for_http_transport_socket=true"]
         return " ".join(args)
 
     def build(self):


### PR DESCRIPTION
Add loading dumps to STAGING Crash2 server.

For now I specified just 2 necessary parameters: product (product name) and version. We can extend this list for future. Also Henning mentioned that it would be a good idea to use version generated by git with `git describe --always --tags` instead of using `OrbitVersion::GetVersion`. 

Added --upload_dumps_to_server flag which is false by default to check if user wants to send dumps to server or not.