### PR TITLE
Removed missing pieces of curl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,6 @@ if(WITH_GUI)
   find_package(imgui CONFIG REQUIRED)
 endif()
 
-find_package(CURL CONFIG REQUIRED)
 find_package(oqpi REQUIRED)
 find_package(capstone CONFIG REQUIRED)
 if(WITH_GUI)

--- a/OrbitCore/CMakeLists.txt
+++ b/OrbitCore/CMakeLists.txt
@@ -177,7 +177,6 @@ target_link_libraries(
          xxHash::xxHash
          concurrentqueue::concurrentqueue
          multicore::multicore
-         CURL::CURL
          oqpi::oqpi
          asio::asio
          abseil::abseil

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -66,7 +66,6 @@
 #include "TypesDataView.h"
 #include "Utils.h"
 #include "Version.h"
-#include "curl/curl.h"
 
 #define GLUT_DISABLE_ATEXIT_HACK
 #include "GL/freeglut.h"

--- a/conanfile.py
+++ b/conanfile.py
@@ -48,7 +48,6 @@ class OrbitConan(ConanFile):
         self.requires("capstone/4.0.1@{}".format(self._orbit_channel))
         self.requires("cereal/1.3.0@{}".format(self._orbit_channel))
         self.requires("gtest/1.8.1@bincrafters/stable")
-        self.requires("libcurl/7.66.0")
         self.requires("llvm_object/9.0.1@orbitdeps/stable")
         self.requires("openssl/1.1.1d@{}".format(self._orbit_channel))
         if self.settings.os != "Windows":


### PR DESCRIPTION
We currently don't need curl anymore. Hence, we can remove this dependency from conan and cmake.