### PR TITLE
Fixed paths in run{,_service}.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-exec $DIR/build_default_release/package/bin/Orbit
+exec $DIR/build_default_release/bin/Orbit

--- a/run_service.sh
+++ b/run_service.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-exec $DIR/build_default_release/package/bin/OrbitService
+exec $DIR/build_default_release/bin/OrbitService


### PR DESCRIPTION
Since I'm in the mood of fixing all the small things, here is one more!

`build.{sh,bat}` does not run `conan package` anymore,
so we should call the executables in `build_default_release/bin/`.