### PR TITLE
Make CallStackDataView not inherit FunctionsDataView

### DIFF
--- a/OrbitCore/Callstack.h
+++ b/OrbitCore/Callstack.h
@@ -39,8 +39,8 @@ class CallStackPOD {
 
 //-----------------------------------------------------------------------------
 struct CallStack {
-  CallStack() {}
-  CallStack(CallStackPOD a_CS);
+  CallStack() = default;
+  explicit CallStack(CallStackPOD a_CS);
   inline CallstackID Hash() {
     if (m_Hash != 0) return m_Hash;
     m_Hash = XXH64(m_Data.data(), m_Depth * sizeof(uint64_t), 0xca1157ac);

--- a/OrbitCore/OrbitFunction.h
+++ b/OrbitCore/OrbitFunction.h
@@ -55,19 +55,6 @@ struct FunctionArgInfo {
 
 class Function {
  public:
-  enum MemberID {
-    NAME,
-    ADDRESS,
-    MODULE,
-    FILE,
-    LINE,
-    SELECTED,
-    INDEX,
-    SIZE,
-    CALL_CONV,
-    NUM_EXPOSED_MEMBERS
-  };
-
   enum OrbitType {
     NONE,
     ORBIT_TIMER_START,
@@ -127,7 +114,7 @@ class Function {
   const std::string& Probe() const { return probe_; }
   int CallingConvention() const { return calling_convention_; }
   const Pdb* GetPdb() const { return pdb_; }
-  const FunctionStats* Stats() const { return stats_.get(); }
+  const FunctionStats& Stats() const { return *stats_; }
   const char* GetCallingConventionString();
   void ProcessArgumentInfo();
   bool IsMemberFunction();

--- a/OrbitCore/OrbitProcess.cpp
+++ b/OrbitCore/OrbitProcess.cpp
@@ -268,7 +268,7 @@ Function* Process::GetFunctionFromAddress(uint64_t address, bool a_IsExact) {
 }
 
 //-----------------------------------------------------------------------------
-std::shared_ptr<Module> Process::GetModuleFromAddress(DWORD64 a_Address) {
+std::shared_ptr<Module> Process::GetModuleFromAddress(uint64_t a_Address) {
   if (m_Modules.empty()) {
     return nullptr;
   }

--- a/OrbitCore/OrbitProcess.h
+++ b/OrbitCore/OrbitProcess.h
@@ -86,7 +86,7 @@ class Process {
   void SetCpuUsage(float a_Usage) { m_CpuUsage = a_Usage; }
 
   Function* GetFunctionFromAddress(uint64_t address, bool a_IsExact = true);
-  std::shared_ptr<Module> GetModuleFromAddress(DWORD64 a_Address);
+  std::shared_ptr<Module> GetModuleFromAddress(uint64_t a_Address);
   std::shared_ptr<Module> GetModuleFromName(const std::string& a_Name);
 
 #ifdef _WIN32

--- a/OrbitCore/OrbitType.h
+++ b/OrbitCore/OrbitType.h
@@ -28,21 +28,6 @@ class Type {
  public:
   Type() {}
 
-  enum MemberID {
-    NAME,
-    LENGTH,
-    TYPE_ID,
-    TYPE_ID_UNMODIFIED,
-    NUM_VARIABLES,
-    NUM_FUNCTIONS,
-    NUM_BASE_CLASSES,
-    BASE_OFFSET,
-    MODULE,
-    SELECTED,
-    INDEX,
-    NUM_EXPOSED_MEMBERS
-  };
-
   void LoadDiaInfo();
   void GenerateDiaHierarchy();
   void GenerateDiaHierarchy(struct IDiaSymbol* a_DiaSymbol);
@@ -51,7 +36,7 @@ class Type {
   Pdb* GetPdb() const { return m_Pdb; }
   const std::string& GetName() const { return m_Name; }
   const std::string& GetNameLower() {
-    if (m_NameLower.size() == 0) {
+    if (m_NameLower.empty()) {
       m_NameLower = ToLower(m_Name);
     }
     return m_NameLower;
@@ -63,7 +48,7 @@ class Type {
 
   bool IsA(const std::string& a_TypeName);
   int GetOffset(const std::string& a_Member);
-  bool HasMembers() const { return m_DataMembers.size() > 0; }
+  bool HasMembers() const { return !m_DataMembers.empty(); }
   Variable* FindImmediateChild(const std::string& a_Name);
 
   std::shared_ptr<Variable> GetTemplateVariable();

--- a/OrbitCore/SamplingProfiler.cpp
+++ b/OrbitCore/SamplingProfiler.cpp
@@ -508,7 +508,7 @@ void SamplingProfiler::FillThreadSampleDataSampleReports() {
       function.m_Address = address;
 
       std::shared_ptr<Module> module = m_Process->GetModuleFromAddress(address);
-      function.m_Module = module ? module->m_Name : "unknown module";
+      function.m_Module = module ? module->m_Name : "???";
 
       const LineInfo& lineInfo = m_AddressToLineInfo[address];
       function.m_Line = lineInfo.m_Line;

--- a/OrbitCore/Variable.h
+++ b/OrbitCore/Variable.h
@@ -16,18 +16,6 @@ class Message;
 
 class Variable {
  public:
-  enum MemberID {
-    NAME,
-    TYPE,
-    ADDRESS,
-    FILE,
-    MODULE,
-    LINE,
-    SELECTED,
-    INDEX,
-    NUM_EXPOSED_MEMBERS
-  };
-
   enum BasicType {
     Invalid,
     Int,

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -1053,11 +1053,11 @@ void OrbitApp::ApplySession(const Session& session) {
 void OrbitApp::OnRemoteProcessList(const Message& a_Message) {
   std::istringstream buffer(std::string(a_Message.m_Data, a_Message.m_Size));
   cereal::JSONInputArchive inputAr(buffer);
-  std::shared_ptr<ProcessList> remoteProcessList =
-      std::make_shared<ProcessList>();
-  inputAr(*remoteProcessList);
-  remoteProcessList->SetRemote(true);
-  GOrbitApp->m_ProcessesDataView->SetRemoteProcessList(remoteProcessList);
+  ProcessList remoteProcessList;
+  inputAr(remoteProcessList);
+  remoteProcessList.SetRemote(true);
+  GOrbitApp->m_ProcessesDataView->SetRemoteProcessList(
+      std::move(remoteProcessList));
 
   // Trigger session loading if needed.
   if (!Capture::GPresetToLoad.empty()) {

--- a/OrbitGl/BlackBoard.h
+++ b/OrbitGl/BlackBoard.h
@@ -8,9 +8,7 @@
 class BlackBoard : public GlCanvas {
  public:
   BlackBoard();
-  virtual ~BlackBoard();
-
-  void OnReceiveMessage(const Message& a_Message);
+  ~BlackBoard() override;
 
   void OnTimer() override;
   void ZoomAll();

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -12,7 +12,8 @@
 #include "absl/strings/str_format.h"
 
 //----------------------------------------------------------------------------
-CallStackDataView::CallStackDataView() : m_CallStack(nullptr) {}
+CallStackDataView::CallStackDataView()
+    : DataView(DataViewType::CALLSTACK), m_CallStack(nullptr) {}
 
 //-----------------------------------------------------------------------------
 void CallStackDataView::SetAsMainInstance() {
@@ -20,7 +21,22 @@ void CallStackDataView::SetAsMainInstance() {
 }
 
 //-----------------------------------------------------------------------------
-size_t CallStackDataView::GetNumElements() { return m_Indices.size(); }
+const std::vector<DataView::Column>& CallStackDataView::GetColumns() {
+  static const std::vector<Column> columns = [] {
+    std::vector<Column> columns;
+    columns.resize(COLUMN_NUM);
+    columns[COLUMN_SELECTED] = {"Hooked", .0f, SortingOrder::Descending};
+    columns[COLUMN_INDEX] = {"Index", .0f, SortingOrder::Ascending};
+    columns[COLUMN_NAME] = {"Function", .5f, SortingOrder::Ascending};
+    columns[COLUMN_SIZE] = {"Size", .0f, SortingOrder::Ascending};
+    columns[COLUMN_FILE] = {"File", .0f, SortingOrder::Ascending};
+    columns[COLUMN_LINE] = {"Line", .0f, SortingOrder::Ascending};
+    columns[COLUMN_MODULE] = {"Module", .0f, SortingOrder::Ascending};
+    columns[COLUMN_ADDRESS] = {"Sampled Address", .0f, SortingOrder::Ascending};
+    return columns;
+  }();
+  return columns;
+}
 
 //-----------------------------------------------------------------------------
 std::string CallStackDataView::GetValue(int a_Row, int a_Column) {
@@ -28,29 +44,126 @@ std::string CallStackDataView::GetValue(int a_Row, int a_Column) {
     return "";
   }
 
-  Function& function = GetFunctionOrDummy(m_Indices[a_Row]);
+  CallStackDataViewFrame frame = GetFrameFromRow(a_Row);
+  Function* function = frame.function;
+  Module* module = frame.module.get();
 
   switch (a_Column) {
     case COLUMN_SELECTED:
-      return function.IsSelected() ? "X" : "-";
+      return (function != nullptr && function->IsSelected()) ? "X" : "-";
     case COLUMN_INDEX:
       return absl::StrFormat("%d", a_Row);
     case COLUMN_NAME:
-      return function.PrettyName();
+      return function != nullptr ? function->PrettyName() : frame.fallback_name;
     case COLUMN_SIZE:
-      return absl::StrFormat("%lu", function.Size());
+      return function != nullptr ? absl::StrFormat("%lu", function->Size())
+                                 : "";
     case COLUMN_FILE:
-      return function.File();
+      return function != nullptr ? function->File() : "";
     case COLUMN_LINE:
-      return absl::StrFormat("%i", function.Line());
+      return function != nullptr ? absl::StrFormat("%d", function->Line()) : "";
     case COLUMN_MODULE:
-      return function.GetModuleName();
+      if (function != nullptr && function->GetPdb() != nullptr) {
+        return function->GetPdb()->GetName();
+      }
+      if (module != nullptr) {
+        return module->m_Name;
+      }
+      return "";
     case COLUMN_ADDRESS:
-      return absl::StrFormat("%#llx", function.GetVirtualAddress());
-    case COLUMN_CALL_CONV:
-      return function.GetCallingConventionString();
+      return absl::StrFormat("%#llx", frame.address);
     default:
       return "";
+  }
+}
+
+//-----------------------------------------------------------------------------
+const std::string CallStackDataView::MENU_ACTION_MODULES_LOAD = "Load Symbols";
+const std::string CallStackDataView::MENU_ACTION_SELECT = "Hook";
+const std::string CallStackDataView::MENU_ACTION_UNSELECT = "Unhook";
+const std::string CallStackDataView::MENU_ACTION_VIEW = "Visualize";
+const std::string CallStackDataView::MENU_ACTION_DISASSEMBLY =
+    "Go to Disassembly";
+
+//-----------------------------------------------------------------------------
+std::vector<std::string> CallStackDataView::GetContextMenu(
+    int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) {
+  bool enable_load = false;
+  bool enable_select = false;
+  bool enable_unselect = false;
+  bool enable_view_disassembly = false;
+  for (int index : a_SelectedIndices) {
+    CallStackDataViewFrame frame = GetFrameFromRow(index);
+    Function* function = frame.function;
+    Module* module = frame.module.get();
+
+    if (frame.function != nullptr) {
+      enable_select |= !function->IsSelected();
+      enable_unselect |= function->IsSelected();
+      enable_view_disassembly = true;
+    } else if (module != nullptr && module->m_FoundPdb &&
+               !module->GetLoaded()) {
+      enable_load = true;
+    }
+  }
+
+  std::vector<std::string> menu;
+  if (enable_load) menu.emplace_back(MENU_ACTION_MODULES_LOAD);
+  if (enable_select) menu.emplace_back(MENU_ACTION_SELECT);
+  if (enable_unselect) menu.emplace_back(MENU_ACTION_UNSELECT);
+  if (enable_view_disassembly) {
+    Append(menu, {MENU_ACTION_VIEW, MENU_ACTION_DISASSEMBLY});
+  }
+  Append(menu, DataView::GetContextMenu(a_ClickedIndex, a_SelectedIndices));
+  return menu;
+}
+
+//-----------------------------------------------------------------------------
+void CallStackDataView::OnContextMenu(const std::string& a_Action,
+                                      int a_MenuIndex,
+                                      const std::vector<int>& a_ItemIndices) {
+  if (a_Action == MENU_ACTION_MODULES_LOAD) {
+    for (int i : a_ItemIndices) {
+      CallStackDataViewFrame frame = GetFrameFromRow(i);
+      std::shared_ptr<Module> module = frame.module;
+      if (module != nullptr && module->m_FoundPdb && !module->GetLoaded()) {
+        GOrbitApp->EnqueueModuleToLoad(module);
+      }
+      GOrbitApp->LoadModules();
+    }
+
+  } else if (a_Action == MENU_ACTION_SELECT) {
+    for (int i : a_ItemIndices) {
+      CallStackDataViewFrame frame = GetFrameFromRow(i);
+      Function* function = frame.function;
+      function->Select();
+    }
+
+  } else if (a_Action == MENU_ACTION_UNSELECT) {
+    for (int i : a_ItemIndices) {
+      CallStackDataViewFrame frame = GetFrameFromRow(i);
+      Function* function = frame.function;
+      function->UnSelect();
+    }
+
+  } else if (a_Action == MENU_ACTION_VIEW) {
+    for (int i : a_ItemIndices) {
+      CallStackDataViewFrame frame = GetFrameFromRow(i);
+      Function* function = frame.function;
+      function->Print();
+    }
+    GOrbitApp->SendToUiNow("output");
+
+  } else if (a_Action == MENU_ACTION_DISASSEMBLY) {
+    uint32_t pid = Capture::GTargetProcess->GetID();
+    for (int i : a_ItemIndices) {
+      CallStackDataViewFrame frame = GetFrameFromRow(i);
+      Function* function = frame.function;
+      function->GetDisassembly(pid);
+    }
+
+  } else {
+    DataView::OnContextMenu(a_Action, a_MenuIndex, a_ItemIndices);
   }
 }
 
@@ -62,8 +175,10 @@ void CallStackDataView::OnFilter(const std::string& a_Filter) {
   std::vector<std::string> tokens = Tokenize(ToLower(a_Filter));
 
   for (int i = 0; i < (int)m_CallStack->m_Depth; ++i) {
-    const Function& function = GetFunctionOrDummy(i);
-    std::string name = ToLower(function.PrettyName());
+    CallStackDataViewFrame frame = GetFrameFromIndex(i);
+    Function* function = frame.function;
+    std::string name = ToLower(function != nullptr ? function->PrettyName()
+                                                   : frame.fallback_name);
     bool match = true;
 
     for (std::string& filterToken : tokens) {
@@ -91,36 +206,36 @@ void CallStackDataView::OnDataChanged() {
 }
 
 //-----------------------------------------------------------------------------
-Function* CallStackDataView::GetFunction(int a_Row) {
-  int index = m_Indices[a_Row];
-  if (m_CallStack != nullptr &&
-      index < static_cast<int>(m_CallStack->m_Depth) &&
-      Capture::GTargetProcess != nullptr) {
-    ScopeLock lock(Capture::GTargetProcess->GetDataMutex());
-
-    uint64_t address = m_CallStack->m_Data[index];
-    Function* function =
-        Capture::GTargetProcess->GetFunctionFromAddress(address, false);
-    return function;
-  }
-  return nullptr;
+CallStackDataView::CallStackDataViewFrame CallStackDataView::GetFrameFromRow(
+    int row) {
+  return GetFrameFromIndex(m_Indices[row]);
 }
 
 //-----------------------------------------------------------------------------
-Function& CallStackDataView::GetFunctionOrDummy(int a_IndexInCallstack) {
-  Function* function = GetFunction(a_IndexInCallstack);
-  if (function != nullptr) {
-    return *function;
+CallStackDataView::CallStackDataViewFrame CallStackDataView::GetFrameFromIndex(
+    int index_in_callstack) {
+  if (m_CallStack == nullptr ||
+      index_in_callstack >= static_cast<int>(m_CallStack->m_Depth)) {
+    return CallStackDataViewFrame();
   }
 
-  static Function dummy;
-  if (m_CallStack != nullptr &&
-      a_IndexInCallstack < static_cast<int>(m_CallStack->m_Depth) &&
-      Capture::GSamplingProfiler != nullptr) {
-    uint64_t address = m_CallStack->m_Data[a_IndexInCallstack];
-    dummy.SetPrettyName(
-        Capture::GSamplingProfiler->GetSymbolFromAddress(address));
-    dummy.SetAddress(address);
+  uint64_t address = m_CallStack->m_Data[index_in_callstack];
+  Function* function = nullptr;
+  std::shared_ptr<Module> module = nullptr;
+
+  if (Capture::GTargetProcess != nullptr) {
+    ScopeLock lock(Capture::GTargetProcess->GetDataMutex());
+    function = Capture::GTargetProcess->GetFunctionFromAddress(address, false);
+    module = Capture::GTargetProcess->GetModuleFromAddress(address);
   }
-  return dummy;
+
+  if (function != nullptr) {
+    return CallStackDataViewFrame(address, function, module);
+  } else {
+    std::string fallback_name;
+    if (Capture::GSamplingProfiler != nullptr) {
+      fallback_name = Capture::GSamplingProfiler->GetSymbolFromAddress(address);
+    }
+    return CallStackDataViewFrame(address, fallback_name, module);
+  }
 }

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -8,7 +8,6 @@
 #include "Callstack.h"
 #include "Capture.h"
 #include "Core.h"
-#include "OrbitProcess.h"
 #include "SamplingProfiler.h"
 #include "absl/strings/str_format.h"
 
@@ -31,41 +30,28 @@ std::string CallStackDataView::GetValue(int a_Row, int a_Column) {
 
   Function& function = GetFunctionOrDummy(m_Indices[a_Row]);
 
-  std::string value;
-
-  switch (s_HeaderMap[a_Column]) {
-    case Function::INDEX:
-      value = absl::StrFormat("%d", a_Row);
-      break;
-    case Function::SELECTED:
-      value = function.IsSelected() ? "X" : "-";
-      break;
-    case Function::NAME:
-      value = function.PrettyName();
-      break;
-    case Function::ADDRESS:
-      value = absl::StrFormat("%#llx", function.GetVirtualAddress());
-      break;
-    case Function::FILE:
-      value = function.File();
-      break;
-    case Function::MODULE:
-      value = function.GetModuleName();
-      break;
-    case Function::LINE:
-      value = absl::StrFormat("%i", function.Line());
-      break;
-    case Function::SIZE:
-      value = absl::StrFormat("%lu", function.Size());
-      break;
-    case Function::CALL_CONV:
-      value = function.GetCallingConventionString();
-      break;
+  switch (a_Column) {
+    case COLUMN_SELECTED:
+      return function.IsSelected() ? "X" : "-";
+    case COLUMN_INDEX:
+      return absl::StrFormat("%d", a_Row);
+    case COLUMN_NAME:
+      return function.PrettyName();
+    case COLUMN_SIZE:
+      return absl::StrFormat("%lu", function.Size());
+    case COLUMN_FILE:
+      return function.File();
+    case COLUMN_LINE:
+      return absl::StrFormat("%i", function.Line());
+    case COLUMN_MODULE:
+      return function.GetModuleName();
+    case COLUMN_ADDRESS:
+      return absl::StrFormat("%#llx", function.GetVirtualAddress());
+    case COLUMN_CALL_CONV:
+      return function.GetCallingConventionString();
     default:
-      break;
+      return "";
   }
-
-  return value;
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/CallStackDataView.h
+++ b/OrbitGl/CallStackDataView.h
@@ -5,19 +5,26 @@
 
 #include <utility>
 
-#include "FunctionsDataView.h"
+#include "DataView.h"
+#include "OrbitModule.h"
 #include "OrbitType.h"
 
 struct CallStack;
 
-class CallStackDataView : public FunctionsDataView {
+class CallStackDataView : public DataView {
  public:
   CallStackDataView();
-  bool IsSortingAllowed() override { return false; }
+
   void SetAsMainInstance() override;
-  size_t GetNumElements() override;
+  const std::vector<Column>& GetColumns() override;
+  int GetDefaultSortingColumn() override { return COLUMN_ADDRESS; }
+  bool IsSortingAllowed() override { return false; }
+  std::vector<std::string> GetContextMenu(
+      int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) override;
   std::string GetValue(int a_Row, int a_Column) override;
   void OnFilter(const std::string& a_Filter) override;
+  void OnContextMenu(const std::string& a_Action, int a_MenuIndex,
+                     const std::vector<int>& a_ItemIndices) override;
   void OnDataChanged() override;
   void SetCallStack(std::shared_ptr<CallStack> a_CallStack) {
     m_CallStack = std::move(a_CallStack);
@@ -25,8 +32,43 @@ class CallStackDataView : public FunctionsDataView {
   }
 
  protected:
-  Function* GetFunction(int a_Row) override;
-  Function& GetFunctionOrDummy(int a_IndexInCallstack);
-
   std::shared_ptr<CallStack> m_CallStack;
+
+  struct CallStackDataViewFrame {
+    CallStackDataViewFrame() = default;
+    CallStackDataViewFrame(uint64_t address, Function* function,
+                           std::shared_ptr<Module> module)
+        : address(address), function(function), module(std::move(module)) {}
+    CallStackDataViewFrame(uint64_t address, std::string fallback_name,
+                           std::shared_ptr<Module> module)
+        : address(address),
+          fallback_name(std::move(fallback_name)),
+          module(std::move(module)) {}
+
+    uint64_t address = 0;
+    Function* function = nullptr;
+    std::string fallback_name;
+    std::shared_ptr<Module> module;
+  };
+
+  CallStackDataViewFrame GetFrameFromRow(int row);
+  CallStackDataViewFrame GetFrameFromIndex(int index_in_callstack);
+
+  enum ColumnIndex {
+    COLUMN_SELECTED,
+    COLUMN_INDEX,
+    COLUMN_NAME,
+    COLUMN_SIZE,
+    COLUMN_FILE,
+    COLUMN_LINE,
+    COLUMN_MODULE,
+    COLUMN_ADDRESS,
+    COLUMN_NUM
+  };
+
+  static const std::string MENU_ACTION_MODULES_LOAD;
+  static const std::string MENU_ACTION_SELECT;
+  static const std::string MENU_ACTION_UNSELECT;
+  static const std::string MENU_ACTION_VIEW;
+  static const std::string MENU_ACTION_DISASSEMBLY;
 };

--- a/OrbitGl/CallStackDataView.h
+++ b/OrbitGl/CallStackDataView.h
@@ -10,7 +10,6 @@
 
 struct CallStack;
 
-//-----------------------------------------------------------------------------
 class CallStackDataView : public FunctionsDataView {
  public:
   CallStackDataView();

--- a/OrbitGl/CaptureSerializer.h
+++ b/OrbitGl/CaptureSerializer.h
@@ -9,7 +9,6 @@
 #include "OrbitType.h"
 #include "SerializationMacros.h"
 
-//-----------------------------------------------------------------------------
 class CaptureSerializer {
  public:
   CaptureSerializer();

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -298,8 +298,8 @@ void CaptureWindow::FindCode(DWORD64 address) {
     }
 
     if (lineInfo.m_Address != 0) {
-      GOrbitApp->SendToUiAsync(absl::StrFormat(
-          "code^%s^%i", lineInfo.m_File, lineInfo.m_Line));
+      GOrbitApp->SendToUiAsync(
+          absl::StrFormat("code^%s^%i", lineInfo.m_File, lineInfo.m_Line));
     }
   }
 #else

--- a/OrbitGl/DataView.cpp
+++ b/OrbitGl/DataView.cpp
@@ -86,8 +86,7 @@ const std::vector<float>& DataView::GetColumnHeadersRatios() {
 
 //-----------------------------------------------------------------------------
 const std::vector<DataView::SortingOrder>& DataView::GetColumnInitialOrders() {
-  static std::vector<DataView::SortingOrder> orders = {
-      DataView::AscendingOrder};
+  static std::vector<DataView::SortingOrder> orders = {AscendingOrder};
   return orders;
 }
 

--- a/OrbitGl/DataView.cpp
+++ b/OrbitGl/DataView.cpp
@@ -27,45 +27,31 @@ DataView::~DataView() {
 }
 
 //-----------------------------------------------------------------------------
-DataView* DataView::Create(DataViewType a_Type) {
-  DataView* model = nullptr;
+std::unique_ptr<DataView> DataView::Create(DataViewType a_Type) {
   switch (a_Type) {
     case DataViewType::FUNCTIONS:
-      model = new FunctionsDataView();
-      break;
+      return std::make_unique<FunctionsDataView>();
     case DataViewType::TYPES:
-      model = new TypesDataView();
-      break;
-    case DataViewType::LIVEFUNCTIONS:
-      model = new LiveFunctionsDataView();
-      break;
+      return std::make_unique<TypesDataView>();
+    case DataViewType::LIVE_FUNCTIONS:
+      return std::make_unique<LiveFunctionsDataView>();
     case DataViewType::CALLSTACK:
-      model = new CallStackDataView();
-      break;
+      return std::make_unique<CallStackDataView>();
     case DataViewType::GLOBALS:
-      model = new GlobalsDataView();
-      break;
+      return std::make_unique<GlobalsDataView>();
     case DataViewType::MODULES:
-      model = new ModulesDataView();
-      break;
+      return std::make_unique<ModulesDataView>();
     case DataViewType::SAMPLING:
-      model = new SamplingReportDataView();
-      break;
+      return std::make_unique<SamplingReportDataView>();
     case DataViewType::PROCESSES:
-      model = new ProcessesDataView();
-      break;
+      return std::make_unique<ProcessesDataView>();
     case DataViewType::SESSIONS:
-      model = new SessionsDataView();
-      break;
+      return std::make_unique<SessionsDataView>();
     case DataViewType::LOG:
-      model = new LogDataView();
-      break;
+      return std::make_unique<LogDataView>();
     default:
-      break;
+      return nullptr;
   }
-
-  model->m_Type = a_Type;
-  return model;
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/DataView.h
+++ b/OrbitGl/DataView.h
@@ -9,7 +9,6 @@
 
 #include "DataViewTypes.h"
 
-//-----------------------------------------------------------------------------
 class DataView {
  public:
   enum SortingOrder {
@@ -57,10 +56,6 @@ class DataView {
                                unsigned char& /*r*/, unsigned char& /*g*/,
                                unsigned char& /*b*/) {
     return false;
-  }
-  virtual const std::string& GetName() {
-    static std::string no_name{"noname"};
-    return no_name;
   }
   virtual std::string GetLabel() { return ""; }
   virtual void SetGlPanel(class GlPanel* /*a_GlPanel*/) {}

--- a/OrbitGl/DataView.h
+++ b/OrbitGl/DataView.h
@@ -3,6 +3,7 @@
 //-----------------------------------
 #pragma once
 
+#include <memory>
 #include <optional>
 #include <string>
 #include <utility>
@@ -28,15 +29,15 @@ class DataView {
     SortingOrder initial_order;
   };
 
-  DataView()
+  explicit DataView(DataViewType type)
       : m_LastSortedColumn(-1),
         m_UpdatePeriodMs(-1),
         m_SelectedIndex(-1),
-        m_Type(INVALID) {}
+        m_Type(type) {}
 
   virtual ~DataView();
 
-  static DataView* Create(DataViewType a_Type);
+  static std::unique_ptr<DataView> Create(DataViewType a_Type);
 
   virtual void SetAsMainInstance() {}
   virtual const std::vector<Column>& GetColumns() = 0;

--- a/OrbitGl/DataView.h
+++ b/OrbitGl/DataView.h
@@ -5,15 +5,27 @@
 
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "DataViewTypes.h"
 
 class DataView {
  public:
-  enum SortingOrder {
-    AscendingOrder = 0,
-    DescendingOrder = 1,
+  enum class SortingOrder {
+    Ascending = 0,
+    Descending = 1,
+  };
+
+  struct Column {
+    Column() : Column{"", .0f, SortingOrder::Ascending} {}
+    Column(std::string header, float ratio, SortingOrder initial_order)
+        : header{std::move(header)},
+          ratio{ratio},
+          initial_order{initial_order} {}
+    std::string header;
+    float ratio;
+    SortingOrder initial_order;
   };
 
   DataView()
@@ -27,11 +39,10 @@ class DataView {
   static DataView* Create(DataViewType a_Type);
 
   virtual void SetAsMainInstance() {}
-  virtual const std::vector<std::string>& GetColumnHeaders();
-  virtual const std::vector<float>& GetColumnHeadersRatios();
+  virtual const std::vector<Column>& GetColumns() = 0;
   virtual bool IsSortingAllowed() { return true; }
-  virtual const std::vector<SortingOrder>& GetColumnInitialOrders();
   virtual int GetDefaultSortingColumn() { return 0; }
+  void InitSortingOrders();
   virtual std::vector<std::string> GetContextMenu(
       int a_ClickedIndex, const std::vector<int>& a_SelectedIndices);
   virtual size_t GetNumElements() { return m_Indices.size(); }

--- a/OrbitGl/DataViewTypes.h
+++ b/OrbitGl/DataViewTypes.h
@@ -6,7 +6,7 @@
 //-----------------------------------------------------------------------------
 enum DataViewType {
   FUNCTIONS,
-  LIVEFUNCTIONS,
+  LIVE_FUNCTIONS,
   CALLSTACK,
   TYPES,
   GLOBALS,

--- a/OrbitGl/Debugger.cpp
+++ b/OrbitGl/Debugger.cpp
@@ -73,7 +73,8 @@ std::string GetFileNameFromHandle(HANDLE hFile) {
     void* pMem = MapViewOfFile(hFileMap, FILE_MAP_READ, 0, 0, 1);
 
     if (pMem) {
-      if (GetMappedFileNameA(GetCurrentProcess(), pMem, pszFilename, MAX_PATH)) {
+      if (GetMappedFileNameA(GetCurrentProcess(), pMem, pszFilename,
+                             MAX_PATH)) {
         // Translate path with device name to drive letters.
         char szTemp[BUFSIZE];
         szTemp[0] = '\0';

--- a/OrbitGl/Disassembler.cpp
+++ b/OrbitGl/Disassembler.cpp
@@ -28,9 +28,8 @@ void Disassembler::LogHex(const uint8_t* str, size_t len) {
 }
 
 //-----------------------------------------------------------------------------
-void Disassembler::Disassemble(const uint8_t* machine_code,
-                               size_t size, uint64_t address,
-                               bool is_64bit) {
+void Disassembler::Disassemble(const uint8_t* machine_code, size_t size,
+                               uint64_t address, bool is_64bit) {
   csh handle = 0;
   cs_arch arch = CS_ARCH_X86;
   cs_insn* insn = nullptr;
@@ -55,7 +54,6 @@ void Disassembler::Disassemble(const uint8_t* machine_code,
     for (j = 0; j < count; j++) {
       LOGF("0x%" PRIx64 ":\t%-12s %s\n", insn[j].address, insn[j].mnemonic,
            insn[j].op_str);
-
     }
 
     // print out the next offset, after the last insn

--- a/OrbitGl/Disassembler.h
+++ b/OrbitGl/Disassembler.h
@@ -9,7 +9,6 @@
 #include "Utils.h"
 #include "absl/strings/str_format.h"
 
-//-----------------------------------------------------------------------------
 class Disassembler {
  public:
   void Disassemble(const uint8_t* machine_code, size_t size,

--- a/OrbitGl/Disassembler.h
+++ b/OrbitGl/Disassembler.h
@@ -11,8 +11,8 @@
 
 class Disassembler {
  public:
-  void Disassemble(const uint8_t* machine_code, size_t size,
-                   uint64_t address, bool is_64bit);
+  void Disassemble(const uint8_t* machine_code, size_t size, uint64_t address,
+                   bool is_64bit);
   const std::string& GetResult() const { return result_; }
 
   void LOGF(const std::string& format) { result_ += format; }

--- a/OrbitGl/EventTrack.h
+++ b/OrbitGl/EventTrack.h
@@ -11,10 +11,9 @@
 class GlCanvas;
 class TimeGraph;
 
-//-----------------------------------------------------------------------------
 class EventTrack : public Pickable {
  public:
-  EventTrack(TimeGraph* a_TimeGraph);
+  explicit EventTrack(TimeGraph* a_TimeGraph);
 
   void Draw(GlCanvas* a_Canvas, bool a_Picking) override;
   void OnPick(int a_X, int a_Y) override;

--- a/OrbitGl/FunctionsDataView.h
+++ b/OrbitGl/FunctionsDataView.h
@@ -11,7 +11,7 @@ class FunctionsDataView : public DataView {
   FunctionsDataView();
 
   const std::vector<Column>& GetColumns() override;
-  int GetDefaultSortingColumn() override { return COLUMN_ADDRESS; };
+  int GetDefaultSortingColumn() override { return COLUMN_ADDRESS; }
   std::vector<std::string> GetContextMenu(
       int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) override;
   std::string GetValue(int a_Row, int a_Column) override;
@@ -23,7 +23,7 @@ class FunctionsDataView : public DataView {
   void OnDataChanged() override;
 
  protected:
-  virtual Function* GetFunction(int a_Row);
+  Function& GetFunction(int a_Row) const;
 
   std::vector<std::string> m_FilterTokens;
 

--- a/OrbitGl/FunctionsDataView.h
+++ b/OrbitGl/FunctionsDataView.h
@@ -10,10 +10,8 @@ class FunctionsDataView : public DataView {
  public:
   FunctionsDataView();
 
-  const std::vector<std::string>& GetColumnHeaders() override;
-  const std::vector<float>& GetColumnHeadersRatios() override;
-  const std::vector<SortingOrder>& GetColumnInitialOrders() override;
-  int GetDefaultSortingColumn() override;
+  const std::vector<Column>& GetColumns() override;
+  int GetDefaultSortingColumn() override { return COLUMN_ADDRESS; };
   std::vector<std::string> GetContextMenu(
       int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) override;
   std::string GetValue(int a_Row, int a_Column) override;
@@ -29,11 +27,18 @@ class FunctionsDataView : public DataView {
 
   std::vector<std::string> m_FilterTokens;
 
-  static void InitColumnsIfNeeded();
-  static std::vector<std::string> s_Headers;
-  static std::vector<int> s_HeaderMap;
-  static std::vector<float> s_HeaderRatios;
-  static std::vector<SortingOrder> s_InitialOrders;
+  enum ColumnIndex {
+    COLUMN_SELECTED,
+    COLUMN_INDEX,
+    COLUMN_NAME,
+    COLUMN_SIZE,
+    COLUMN_FILE,
+    COLUMN_LINE,
+    COLUMN_MODULE,
+    COLUMN_ADDRESS,
+    COLUMN_CALL_CONV,
+    COLUMN_NUM
+  };
 
   static const std::string MENU_ACTION_SELECT;
   static const std::string MENU_ACTION_UNSELECT;

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -40,7 +40,7 @@ void ClearCaptureData() {
     GCurrentTimeGraph->Clear();
   }
 
-  GOrbitApp->FireRefreshCallbacks(DataViewType::LIVEFUNCTIONS);
+  GOrbitApp->FireRefreshCallbacks(DataViewType::LIVE_FUNCTIONS);
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/GlobalsDataView.cpp
+++ b/OrbitGl/GlobalsDataView.cpp
@@ -14,7 +14,7 @@
 #include "absl/strings/str_format.h"
 
 //-----------------------------------------------------------------------------
-GlobalsDataView::GlobalsDataView() {
+GlobalsDataView::GlobalsDataView() : DataView(DataViewType::GLOBALS) {
   InitSortingOrders();
   OnDataChanged();
   GOrbitApp->RegisterGlobalsDataView(this);

--- a/OrbitGl/GlobalsDataView.cpp
+++ b/OrbitGl/GlobalsDataView.cpp
@@ -15,74 +15,26 @@
 
 //-----------------------------------------------------------------------------
 GlobalsDataView::GlobalsDataView() {
-  InitColumnsIfNeeded();
-  m_SortingOrders.insert(m_SortingOrders.end(), s_InitialOrders.begin(),
-                         s_InitialOrders.end());
+  InitSortingOrders();
   OnDataChanged();
-
   GOrbitApp->RegisterGlobalsDataView(this);
 }
 
 //-----------------------------------------------------------------------------
-std::vector<std::string> GlobalsDataView::s_Headers;
-std::vector<int> GlobalsDataView::s_HeaderMap;
-std::vector<float> GlobalsDataView::s_HeaderRatios;
-std::vector<DataView::SortingOrder> GlobalsDataView::s_InitialOrders;
-
-//-----------------------------------------------------------------------------
-void GlobalsDataView::InitColumnsIfNeeded() {
-  if (s_Headers.empty()) {
-    s_Headers.emplace_back("Index");
-    s_HeaderMap.push_back(Variable::INDEX);
-    s_HeaderRatios.push_back(0);
-    s_InitialOrders.push_back(AscendingOrder);
-
-    s_Headers.emplace_back("Variable");
-    s_HeaderMap.push_back(Variable::NAME);
-    s_HeaderRatios.push_back(0.5f);
-    s_InitialOrders.push_back(AscendingOrder);
-
-    s_Headers.emplace_back("Type");
-    s_HeaderMap.push_back(Variable::TYPE);
-    s_HeaderRatios.push_back(0);
-    s_InitialOrders.push_back(AscendingOrder);
-
-    s_Headers.emplace_back("Address");
-    s_HeaderMap.push_back(Variable::ADDRESS);
-    s_HeaderRatios.push_back(0);
-    s_InitialOrders.push_back(AscendingOrder);
-
-    s_Headers.emplace_back("File");
-    s_HeaderMap.push_back(Variable::FILE);
-    s_HeaderRatios.push_back(0);
-    s_InitialOrders.push_back(AscendingOrder);
-
-    s_Headers.emplace_back("Line");
-    s_HeaderMap.push_back(Variable::LINE);
-    s_HeaderRatios.push_back(0);
-    s_InitialOrders.push_back(AscendingOrder);
-
-    s_Headers.emplace_back("Module");
-    s_HeaderMap.push_back(Variable::MODULE);
-    s_HeaderRatios.push_back(0);
-    s_InitialOrders.push_back(AscendingOrder);
-  }
-}
-
-//-----------------------------------------------------------------------------
-const std::vector<std::string>& GlobalsDataView::GetColumnHeaders() {
-  return s_Headers;
-}
-
-//-----------------------------------------------------------------------------
-const std::vector<float>& GlobalsDataView::GetColumnHeadersRatios() {
-  return s_HeaderRatios;
-}
-
-//-----------------------------------------------------------------------------
-const std::vector<DataView::SortingOrder>&
-GlobalsDataView::GetColumnInitialOrders() {
-  return s_InitialOrders;
+const std::vector<DataView::Column>& GlobalsDataView::GetColumns() {
+  static const std::vector<Column> columns = [] {
+    std::vector<Column> columns;
+    columns.resize(COLUMN_NUM);
+    columns[COLUMN_INDEX] = {"Index", .0f, SortingOrder::Ascending};
+    columns[COLUMN_NAME] = {"Variable", .5f, SortingOrder::Ascending};
+    columns[COLUMN_TYPE] = {"Type", .0f, SortingOrder::Ascending};
+    columns[COLUMN_FILE] = {"File", .0f, SortingOrder::Ascending};
+    columns[COLUMN_LINE] = {"Line", .0f, SortingOrder::Ascending};
+    columns[COLUMN_MODULE] = {"Module", .0f, SortingOrder::Ascending};
+    columns[COLUMN_ADDRESS] = {"Address", .0f, SortingOrder::Ascending};
+    return columns;
+  }();
+  return columns;
 }
 
 //-----------------------------------------------------------------------------
@@ -91,38 +43,24 @@ std::string GlobalsDataView::GetValue(int a_Row, int a_Column) {
 
   const Variable& variable = GetVariable(a_Row);
 
-  std::string value;
-
-  switch (s_HeaderMap[a_Column]) {
-    case Variable::INDEX:
-      value = absl::StrFormat("%d", a_Row);
-      break;
-    case Variable::SELECTED:
-      value = variable.m_Selected ? "*" : "";
-      break;
-    case Variable::NAME:
-      value = variable.m_Name;
-      break;
-    case Variable::TYPE:
-      value = variable.m_Type;
-      break;
-    case Variable::FILE:
-      value = variable.m_File;
-      break;
-    case Variable::MODULE:
-      value = variable.m_Pdb->GetName();
-      break;
-    case Variable::ADDRESS:
-      value = absl::StrFormat("0x%llx", variable.m_Address);
-      break;
-    case Variable::LINE:
-      value = absl::StrFormat("%i", variable.m_Line);
-      break;
+  switch (a_Column) {
+    case COLUMN_INDEX:
+      return absl::StrFormat("%d", a_Row);
+    case COLUMN_NAME:
+      return variable.m_Name;
+    case COLUMN_TYPE:
+      return variable.m_Type;
+    case COLUMN_FILE:
+      return variable.m_File;
+    case COLUMN_LINE:
+      return absl::StrFormat("%i", variable.m_Line);
+    case COLUMN_MODULE:
+      return variable.m_Pdb->GetName();
+    case COLUMN_ADDRESS:
+      return absl::StrFormat("0x%llx", variable.m_Address);
     default:
-      break;
+      return "";
   }
-
-  return value;
 }
 
 //-----------------------------------------------------------------------------
@@ -137,33 +75,32 @@ void GlobalsDataView::OnSort(int a_Column,
                              std::optional<SortingOrder> a_NewOrder) {
   const std::vector<Variable*>& functions =
       Capture::GTargetProcess->GetGlobals();
-  auto memberId = static_cast<Variable::MemberID>(s_HeaderMap[a_Column]);
 
   if (a_NewOrder.has_value()) {
     m_SortingOrders[a_Column] = a_NewOrder.value();
   }
 
-  bool ascending = m_SortingOrders[a_Column] == AscendingOrder;
+  bool ascending = m_SortingOrders[a_Column] == SortingOrder::Ascending;
   std::function<bool(int a, int b)> sorter = nullptr;
 
-  switch (memberId) {
-    case Variable::NAME:
+  switch (a_Column) {
+    case COLUMN_NAME:
       sorter = ORBIT_FUNC_SORT(m_Name);
       break;
-    case Variable::ADDRESS:
-      sorter = ORBIT_FUNC_SORT(m_Address);
-      break;
-    case Variable::TYPE:
+    case COLUMN_TYPE:
       sorter = ORBIT_FUNC_SORT(m_Type);
       break;
-    case Variable::MODULE:
-      sorter = ORBIT_FUNC_SORT(m_Pdb->GetName());
-      break;
-    case Variable::FILE:
+    case COLUMN_FILE:
       sorter = ORBIT_FUNC_SORT(m_File);
       break;
-    case Variable::SELECTED:
-      sorter = ORBIT_FUNC_SORT(m_Selected);
+    case COLUMN_LINE:
+      sorter = ORBIT_FUNC_SORT(m_Line);
+      break;
+    case COLUMN_MODULE:
+      sorter = ORBIT_FUNC_SORT(m_Pdb->GetName());
+      break;
+    case COLUMN_ADDRESS:
+      sorter = ORBIT_FUNC_SORT(m_Address);
       break;
     default:
       break;

--- a/OrbitGl/GlobalsDataView.h
+++ b/OrbitGl/GlobalsDataView.h
@@ -10,9 +10,8 @@ class GlobalsDataView : public DataView {
  public:
   GlobalsDataView();
 
-  const std::vector<std::string>& GetColumnHeaders() override;
-  const std::vector<float>& GetColumnHeadersRatios() override;
-  const std::vector<SortingOrder>& GetColumnInitialOrders() override;
+  const std::vector<Column>& GetColumns() override;
+  int GetDefaultSortingColumn() override { return COLUMN_ADDRESS; }
   std::vector<std::string> GetContextMenu(
       int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) override;
   std::string GetValue(int a_Row, int a_Column) override;
@@ -29,11 +28,16 @@ class GlobalsDataView : public DataView {
   Variable& GetVariable(unsigned int a_Row) const;
   std::vector<std::string> m_FilterTokens;
 
-  static void InitColumnsIfNeeded();
-  static std::vector<std::string> s_Headers;
-  static std::vector<int> s_HeaderMap;
-  static std::vector<float> s_HeaderRatios;
-  static std::vector<SortingOrder> s_InitialOrders;
+  enum ColumnIndex {
+    COLUMN_INDEX,
+    COLUMN_NAME,
+    COLUMN_TYPE,
+    COLUMN_FILE,
+    COLUMN_LINE,
+    COLUMN_MODULE,
+    COLUMN_ADDRESS,
+    COLUMN_NUM
+  };
 
   static const std::string MENU_ACTION_TYPES_MENU_WATCH;
 };

--- a/OrbitGl/HomeWindow.h
+++ b/OrbitGl/HomeWindow.h
@@ -8,7 +8,7 @@
 class HomeWindow : public GlCanvas {
  public:
   HomeWindow();
-  virtual ~HomeWindow();
+  ~HomeWindow() override;
 
   void VariableTracingCallback(std::vector<std::string>& a_Entries);
   void Draw() override;

--- a/OrbitGl/ImGuiOrbit.h
+++ b/OrbitGl/ImGuiOrbit.h
@@ -42,7 +42,7 @@ void SetupImGuiStyle(bool bStyleDark_, float alpha_);
 extern ImFont* GOrbitImguiFont;
 
 struct ScopeImguiContext {
-  ScopeImguiContext(ImGuiContext* a_State) : m_ImGuiContext(nullptr) {
+  explicit ScopeImguiContext(ImGuiContext* a_State) : m_ImGuiContext(nullptr) {
     ImGuiContext* state = (ImGuiContext*)ImGui::GetCurrentContext();
     if (state != a_State) {
       m_ImGuiContext = state;
@@ -84,7 +84,7 @@ struct DebugWindow {
     // ScrollToBottom = true;
   }
 
-  void Draw(const char* title, bool* p_opened = NULL) {
+  void Draw(const char* title, bool* p_opened = nullptr) {
     ImGui::SetNextWindowSize(ImVec2(500, 400), ImGuiCond_FirstUseEver);
     ImGui::Begin(title, p_opened);
     if (ImGui::Button("Clear")) Clear();
@@ -100,13 +100,13 @@ struct DebugWindow {
     if (Filter.IsActive()) {
       const char* buf_begin = Buf.begin();
       const char* line = buf_begin;
-      for (int line_no = 0; line != NULL; line_no++) {
+      for (int line_no = 0; line != nullptr; line_no++) {
         const char* line_end = (line_no < LineOffsets.Size)
                                    ? buf_begin + LineOffsets[line_no]
-                                   : NULL;
+                                   : nullptr;
         if (Filter.PassFilter(line, line_end))
           ImGui::TextUnformatted(line, line_end);
-        line = line_end && line_end[1] ? line_end + 1 : NULL;
+        line = line_end && line_end[1] ? line_end + 1 : nullptr;
       }
     } else {
       ImGui::TextUnformatted(Buf.begin());
@@ -139,7 +139,7 @@ class LogWindow {
   bool m_Open = false;
 
   void Draw(const char* title, const std::vector<std::string>& lines,
-            bool* p_opened = NULL) {
+            bool* p_opened = nullptr) {
     ImGui::SetNextWindowSize(ImVec2(500, 400), ImGuiCond_FirstUseEver);
     ImGui::Begin(title, p_opened);
 
@@ -204,7 +204,7 @@ struct VizWindow {
     // WindowFlags |= ImGuiWindowFlags_MenuBar;
   }
 
-  void Draw(const char* title, bool* p_opened = NULL,
+  void Draw(const char* title, bool* p_opened = nullptr,
             ImVec2* a_Size = nullptr) {
     ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0.0f);
 
@@ -234,13 +234,13 @@ struct VizWindow {
     if (Filter.IsActive()) {
       const char* buf_begin = Buf.begin();
       const char* line = buf_begin;
-      for (int line_no = 0; line != NULL; line_no++) {
+      for (int line_no = 0; line != nullptr; line_no++) {
         const char* line_end = (line_no < LineOffsets.Size)
                                    ? buf_begin + LineOffsets[line_no]
-                                   : NULL;
+                                   : nullptr;
         if (Filter.PassFilter(line, line_end))
           ImGui::TextUnformatted(line, line_end);
-        line = line_end && line_end[1] ? line_end + 1 : NULL;
+        line = line_end && line_end[1] ? line_end + 1 : nullptr;
       }
     } else {
       ImGui::TextUnformatted(Buf.begin());
@@ -268,5 +268,6 @@ struct OutputWindow {
   }
   void AddLine(const std::string& a_String);
   void AddLog(const char* fmt, ...);
-  void Draw(const char* title, bool* p_opened = NULL, ImVec2* a_Size = nullptr);
+  void Draw(const char* title, bool* p_opened = nullptr,
+            ImVec2* a_Size = nullptr);
 };

--- a/OrbitGl/ImmediateWindow.h
+++ b/OrbitGl/ImmediateWindow.h
@@ -8,7 +8,7 @@
 class ImmediateWindow : public GlCanvas {
  public:
   ImmediateWindow();
-  virtual ~ImmediateWindow();
+  ~ImmediateWindow() override;
 
   void Draw() override;
   void RenderUI() override;

--- a/OrbitGl/LiveFunctionsDataView.cpp
+++ b/OrbitGl/LiveFunctionsDataView.cpp
@@ -13,116 +13,32 @@
 #include "Pdb.h"
 
 //-----------------------------------------------------------------------------
-namespace LiveFunction {
-enum Columns {
-  SELECTED,
-  NAME,
-  COUNT,
-  TIME_TOTAL,
-  TIME_AVG,
-  TIME_MIN,
-  TIME_MAX,
-  ADDRESS,
-  MODULE,
-  INDEX,
-  NUM_EXPOSED_MEMBERS
-};
-}
-
-//-----------------------------------------------------------------------------
 LiveFunctionsDataView::LiveFunctionsDataView() {
-  InitColumnsIfNeeded();
-  m_SortingOrders.insert(m_SortingOrders.end(), s_InitialOrders.begin(),
-                         s_InitialOrders.end());
+  InitSortingOrders();
   GOrbitApp->RegisterLiveFunctionsDataView(this);
   m_UpdatePeriodMs = 300;
   m_LastSortedColumn = 3; /*Count*/
-  GetColumnHeaders();
   OnDataChanged();
 }
 
 //-----------------------------------------------------------------------------
-std::vector<std::string> LiveFunctionsDataView::s_Headers;
-std::vector<int> LiveFunctionsDataView::s_HeaderMap;
-std::vector<float> LiveFunctionsDataView::s_HeaderRatios;
-std::vector<DataView::SortingOrder> LiveFunctionsDataView::s_InitialOrders;
-
-//-----------------------------------------------------------------------------
-void LiveFunctionsDataView::InitColumnsIfNeeded() {
-  if (s_Headers.empty()) {
-    s_Headers.emplace_back("Hooked");
-    s_HeaderMap.push_back(LiveFunction::SELECTED);
-    s_HeaderRatios.push_back(0);
-    s_InitialOrders.push_back(DescendingOrder);
-
-    s_Headers.emplace_back("Index");
-    s_HeaderMap.push_back(LiveFunction::INDEX);
-    s_HeaderRatios.push_back(0);
-    s_InitialOrders.push_back(AscendingOrder);
-
-    s_Headers.emplace_back("Function");
-    s_HeaderMap.push_back(LiveFunction::NAME);
-    s_HeaderRatios.push_back(0.5f);
-    s_InitialOrders.push_back(AscendingOrder);
-
-    s_Headers.emplace_back("Count");
-    s_HeaderMap.push_back(LiveFunction::COUNT);
-    s_HeaderRatios.push_back(0);
-    s_InitialOrders.push_back(DescendingOrder);
-
-    s_Headers.emplace_back("Total");
-    s_HeaderMap.push_back(LiveFunction::TIME_TOTAL);
-    s_HeaderRatios.push_back(0);
-    s_InitialOrders.push_back(DescendingOrder);
-
-    s_Headers.emplace_back("Avg");
-    s_HeaderMap.push_back(LiveFunction::TIME_AVG);
-    s_HeaderRatios.push_back(0);
-    s_InitialOrders.push_back(DescendingOrder);
-
-    s_Headers.emplace_back("Min");
-    s_HeaderMap.push_back(LiveFunction::TIME_MIN);
-    s_HeaderRatios.push_back(0);
-    s_InitialOrders.push_back(DescendingOrder);
-
-    s_Headers.emplace_back("Max");
-    s_HeaderMap.push_back(LiveFunction::TIME_MAX);
-    s_HeaderRatios.push_back(0);
-    s_InitialOrders.push_back(DescendingOrder);
-
-    s_Headers.emplace_back("Module");
-    s_HeaderMap.push_back(LiveFunction::MODULE);
-    s_HeaderRatios.push_back(0);
-    s_InitialOrders.push_back(AscendingOrder);
-
-    s_Headers.emplace_back("Address");
-    s_HeaderMap.push_back(LiveFunction::ADDRESS);
-    s_HeaderRatios.push_back(0);
-    s_InitialOrders.push_back(AscendingOrder);
-  }
-}
-
-//-----------------------------------------------------------------------------
-const std::vector<std::string>& LiveFunctionsDataView::GetColumnHeaders() {
-  return s_Headers;
-}
-
-//-----------------------------------------------------------------------------
-const std::vector<float>& LiveFunctionsDataView::GetColumnHeadersRatios() {
-  return s_HeaderRatios;
-}
-
-//-----------------------------------------------------------------------------
-const std::vector<DataView::SortingOrder>&
-LiveFunctionsDataView::GetColumnInitialOrders() {
-  return s_InitialOrders;
-}
-
-//-----------------------------------------------------------------------------
-int LiveFunctionsDataView::GetDefaultSortingColumn() {
-  return std::distance(
-      s_HeaderMap.begin(),
-      std::find(s_HeaderMap.begin(), s_HeaderMap.end(), LiveFunction::COUNT));
+const std::vector<DataView::Column>& LiveFunctionsDataView::GetColumns() {
+  static const std::vector<Column> columns = [] {
+    std::vector<Column> columns;
+    columns.resize(COLUMN_NUM);
+    columns[COLUMN_SELECTED] = {"Hooked", .0f, SortingOrder::Descending};
+    columns[COLUMN_INDEX] = {"Index", .0f, SortingOrder::Ascending};
+    columns[COLUMN_NAME] = {"Function", .5f, SortingOrder::Ascending};
+    columns[COLUMN_COUNT] = {"Count", .0f, SortingOrder::Descending};
+    columns[COLUMN_TIME_TOTAL] = {"Total", .0f, SortingOrder::Descending};
+    columns[COLUMN_TIME_AVG] = {"Avg", .0f, SortingOrder::Descending};
+    columns[COLUMN_TIME_MIN] = {"Min", .0f, SortingOrder::Descending};
+    columns[COLUMN_TIME_MAX] = {"Max", .0f, SortingOrder::Descending};
+    columns[COLUMN_MODULE] = {"Module", .0f, SortingOrder::Ascending};
+    columns[COLUMN_ADDRESS] = {"Address", .0f, SortingOrder::Ascending};
+    return columns;
+  }();
+  return columns;
 }
 
 //-----------------------------------------------------------------------------
@@ -132,46 +48,32 @@ std::string LiveFunctionsDataView::GetValue(int a_Row, int a_Column) {
   }
 
   Function& function = GetFunction(a_Row);
-  const FunctionStats* stats = function.Stats();
+  const FunctionStats& stats = function.Stats();
 
-  std::string value;
-
-  switch (s_HeaderMap[a_Column]) {
-    case LiveFunction::SELECTED:
-      value = function.IsSelected() ? "X" : "-";
-      break;
-    case LiveFunction::INDEX:
-      value = absl::StrFormat("%d", a_Row);
-      break;
-    case LiveFunction::NAME:
-      value = function.PrettyName();
-      break;
-    case LiveFunction::COUNT:
-      value = absl::StrFormat("%lu", stats->m_Count);
-      break;
-    case LiveFunction::TIME_TOTAL:
-      value = GetPrettyTime(stats->m_TotalTimeMs);
-      break;
-    case LiveFunction::TIME_AVG:
-      value = GetPrettyTime(stats->m_AverageTimeMs);
-      break;
-    case LiveFunction::TIME_MIN:
-      value = GetPrettyTime(stats->m_MinMs);
-      break;
-    case LiveFunction::TIME_MAX:
-      value = GetPrettyTime(stats->m_MaxMs);
-      break;
-    case LiveFunction::ADDRESS:
-      value = absl::StrFormat("0x%llx", function.GetVirtualAddress());
-      break;
-    case LiveFunction::MODULE:
-      value = function.GetPdb() != nullptr ? function.GetPdb()->GetName() : "";
-      break;
+  switch (a_Column) {
+    case COLUMN_SELECTED:
+      return function.IsSelected() ? "X" : "-";
+    case COLUMN_INDEX:
+      return absl::StrFormat("%d", a_Row);
+    case COLUMN_NAME:
+      return function.PrettyName();
+    case COLUMN_COUNT:
+      return absl::StrFormat("%lu", stats.m_Count);
+    case COLUMN_TIME_TOTAL:
+      return GetPrettyTime(stats.m_TotalTimeMs);
+    case COLUMN_TIME_AVG:
+      return GetPrettyTime(stats.m_AverageTimeMs);
+    case COLUMN_TIME_MIN:
+      return GetPrettyTime(stats.m_MinMs);
+    case COLUMN_TIME_MAX:
+      return GetPrettyTime(stats.m_MaxMs);
+    case COLUMN_MODULE:
+      return function.GetPdb() != nullptr ? function.GetPdb()->GetName() : "";
+    case COLUMN_ADDRESS:
+      return absl::StrFormat("0x%llx", function.GetVirtualAddress());
     default:
-      break;
+      return "";
   }
-
-  return value;
 }
 
 //-----------------------------------------------------------------------------
@@ -180,53 +82,52 @@ std::string LiveFunctionsDataView::GetValue(int a_Row, int a_Column) {
     return OrbitUtils::Compare(functions[a]->Member, functions[b]->Member, \
                                ascending);                                 \
   }
-#define ORBIT_STAT_SORT(Member)                                           \
-  [&](int a, int b) {                                                     \
-    return OrbitUtils::Compare(functions[a]->Stats()->Member,             \
-                               functions[b]->Stats()->Member, ascending); \
+#define ORBIT_STAT_SORT(Member)                                          \
+  [&](int a, int b) {                                                    \
+    return OrbitUtils::Compare(functions[a]->Stats().Member,             \
+                               functions[b]->Stats().Member, ascending); \
   }
 
 //-----------------------------------------------------------------------------
 void LiveFunctionsDataView::OnSort(int a_Column,
                                    std::optional<SortingOrder> a_NewOrder) {
   const std::vector<Function*>& functions = m_Functions;
-  auto memberId = static_cast<LiveFunction::Columns>(s_HeaderMap[a_Column]);
 
   if (a_NewOrder.has_value()) {
     m_SortingOrders[a_Column] = a_NewOrder.value();
   }
 
-  bool ascending = m_SortingOrders[a_Column] == AscendingOrder;
+  bool ascending = m_SortingOrders[a_Column] == SortingOrder::Ascending;
   std::function<bool(int a, int b)> sorter = nullptr;
 
-  switch (memberId) {
-    case LiveFunction::NAME:
+  switch (a_Column) {
+    case COLUMN_SELECTED:
+      sorter = ORBIT_FUNC_SORT(IsSelected());
+      break;
+    case COLUMN_NAME:
       sorter = ORBIT_FUNC_SORT(PrettyName());
       break;
-    case LiveFunction::COUNT:
+    case COLUMN_COUNT:
       ascending = false;
       sorter = ORBIT_STAT_SORT(m_Count);
       break;
-    case LiveFunction::TIME_TOTAL:
+    case COLUMN_TIME_TOTAL:
       sorter = ORBIT_STAT_SORT(m_TotalTimeMs);
       break;
-    case LiveFunction::TIME_AVG:
+    case COLUMN_TIME_AVG:
       sorter = ORBIT_STAT_SORT(m_AverageTimeMs);
       break;
-    case LiveFunction::TIME_MIN:
+    case COLUMN_TIME_MIN:
       sorter = ORBIT_STAT_SORT(m_MinMs);
       break;
-    case LiveFunction::TIME_MAX:
+    case COLUMN_TIME_MAX:
       sorter = ORBIT_STAT_SORT(m_MaxMs);
       break;
-    case LiveFunction::ADDRESS:
-      sorter = ORBIT_FUNC_SORT(Address());
-      break;
-    case LiveFunction::MODULE:
+    case COLUMN_MODULE:
       sorter = ORBIT_FUNC_SORT(GetPdb()->GetName());
       break;
-    case LiveFunction::SELECTED:
-      sorter = ORBIT_FUNC_SORT(IsSelected());
+    case COLUMN_ADDRESS:
+      sorter = ORBIT_FUNC_SORT(Address());
       break;
     default:
       break;

--- a/OrbitGl/LiveFunctionsDataView.cpp
+++ b/OrbitGl/LiveFunctionsDataView.cpp
@@ -13,7 +13,8 @@
 #include "Pdb.h"
 
 //-----------------------------------------------------------------------------
-LiveFunctionsDataView::LiveFunctionsDataView() {
+LiveFunctionsDataView::LiveFunctionsDataView()
+    : DataView(DataViewType::LIVE_FUNCTIONS) {
   InitSortingOrders();
   GOrbitApp->RegisterLiveFunctionsDataView(this);
   m_UpdatePeriodMs = 300;

--- a/OrbitGl/LiveFunctionsDataView.h
+++ b/OrbitGl/LiveFunctionsDataView.h
@@ -11,10 +11,8 @@ class LiveFunctionsDataView : public DataView {
  public:
   LiveFunctionsDataView();
 
-  const std::vector<std::string>& GetColumnHeaders() override;
-  const std::vector<float>& GetColumnHeadersRatios() override;
-  const std::vector<SortingOrder>& GetColumnInitialOrders() override;
-  int GetDefaultSortingColumn() override;
+  const std::vector<Column>& GetColumns() override;
+  int GetDefaultSortingColumn() override { return COLUMN_COUNT; }
   std::vector<std::string> GetContextMenu(
       int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) override;
   std::string GetValue(int a_Row, int a_Column) override;
@@ -30,11 +28,19 @@ class LiveFunctionsDataView : public DataView {
   std::vector<Function*> m_Functions;
   Function& GetFunction(unsigned int a_Row) const;
 
-  static void InitColumnsIfNeeded();
-  static std::vector<std::string> s_Headers;
-  static std::vector<int> s_HeaderMap;
-  static std::vector<float> s_HeaderRatios;
-  static std::vector<SortingOrder> s_InitialOrders;
+  enum ColumnIndex {
+    COLUMN_SELECTED,
+    COLUMN_INDEX,
+    COLUMN_NAME,
+    COLUMN_COUNT,
+    COLUMN_TIME_TOTAL,
+    COLUMN_TIME_AVG,
+    COLUMN_TIME_MIN,
+    COLUMN_TIME_MAX,
+    COLUMN_MODULE,
+    COLUMN_ADDRESS,
+    COLUMN_NUM
+  };
 
   static const std::string MENU_ACTION_SELECT;
   static const std::string MENU_ACTION_UNSELECT;

--- a/OrbitGl/LogDataView.cpp
+++ b/OrbitGl/LogDataView.cpp
@@ -10,7 +10,7 @@
 #include "absl/strings/str_format.h"
 
 //-----------------------------------------------------------------------------
-LogDataView::LogDataView() {
+LogDataView::LogDataView() : DataView(DataViewType::LOG) {
   InitSortingOrders();
   GOrbitApp->RegisterOutputLog(this);
   GTcpServer->AddCallback(Msg_OrbitLog, [=](const Message& a_Msg) {
@@ -117,7 +117,7 @@ std::vector<std::string> LogDataView::GetContextMenu(
   std::vector<std::string> menu;
   if (m_SelectedCallstack) {
     for (uint32_t i = 0; i < m_SelectedCallstack->m_Depth; ++i) {
-      DWORD64 addr = m_SelectedCallstack->m_Data[i];
+      uint64_t addr = m_SelectedCallstack->m_Data[i];
       menu.push_back(Capture::GSamplingProfiler->GetSymbolFromAddress(addr));
     }
   }

--- a/OrbitGl/LogDataView.h
+++ b/OrbitGl/LogDataView.h
@@ -13,8 +13,9 @@ struct CallStack;
 class LogDataView : public DataView {
  public:
   LogDataView();
-  const std::vector<std::string>& GetColumnHeaders() override;
-  const std::vector<float>& GetColumnHeadersRatios() override;
+
+  const std::vector<Column>& GetColumns() override;
+  int GetDefaultSortingColumn() override { return COLUMN_TIME; }
   std::vector<std::string> GetContextMenu(
       int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) override;
   std::string GetValue(int a_Row, int a_Column) override;
@@ -31,15 +32,15 @@ class LogDataView : public DataView {
   const OrbitLogEntry& GetEntry(unsigned int a_Row) const;
   void OnReceiveMessage(const Message& a_Msg);
 
-  enum OdvColumn { LDV_Message, LDV_Time, LDV_ThreadId, LDV_NumColumns };
-
  protected:
   std::vector<OrbitLogEntry> m_Entries;
   Mutex m_Mutex;
   std::shared_ptr<CallStack> m_SelectedCallstack;
 
-  static void InitColumnsIfNeeded();
-  static std::vector<std::string> s_Headers;
-  static std::vector<float> s_HeaderRatios;
-  static std::vector<SortingOrder> s_InitialOrders;
+  enum ColumnIndex {
+    COLUMN_MESSAGE,
+    COLUMN_TIME,
+    COLUMN_THREAD_ID,
+    COLUMN_NUM
+  };
 };

--- a/OrbitGl/ModulesDataView.cpp
+++ b/OrbitGl/ModulesDataView.cpp
@@ -9,7 +9,7 @@
 #include "OrbitModule.h"
 
 //-----------------------------------------------------------------------------
-ModulesDataView::ModulesDataView() {
+ModulesDataView::ModulesDataView() : DataView(DataViewType::MODULES) {
   InitSortingOrders();
   GOrbitApp->RegisterModulesDataView(this);
 }

--- a/OrbitGl/ModulesDataView.h
+++ b/OrbitGl/ModulesDataView.h
@@ -11,10 +11,8 @@ class ModulesDataView : public DataView {
  public:
   ModulesDataView();
 
-  const std::vector<std::string>& GetColumnHeaders() override;
-  const std::vector<float>& GetColumnHeadersRatios() override;
-  const std::vector<SortingOrder>& GetColumnInitialOrders() override;
-  int GetDefaultSortingColumn() override;
+  const std::vector<Column>& GetColumns() override;
+  int GetDefaultSortingColumn() override { return COLUMN_PDB_SIZE; }
   std::vector<std::string> GetContextMenu(
       int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) override;
   std::string GetValue(int a_Row, int a_Column) override;
@@ -29,18 +27,7 @@ class ModulesDataView : public DataView {
                        unsigned char& /*g*/, unsigned char& /*b*/) override;
   std::string GetLabel() override { return "Modules"; }
 
-  void SetProcess(std::shared_ptr<Process> a_Process);
-
-  enum MdvColumn {
-    MDV_Index,
-    MDV_ModuleName,
-    MDV_Path,
-    MDV_AddressRange,
-    MDV_HasPdb,
-    MDV_PdbSize,
-    MDV_Loaded,
-    MDV_NumColumns
-  };
+  void SetProcess(const std::shared_ptr<Process>& a_Process);
 
  protected:
   const std::shared_ptr<Module>& GetModule(unsigned int a_Row) const;
@@ -48,10 +35,16 @@ class ModulesDataView : public DataView {
   std::shared_ptr<Process> m_Process;
   std::vector<std::shared_ptr<Module> > m_Modules;
 
-  static void InitColumnsIfNeeded();
-  static std::vector<std::string> s_Headers;
-  static std::vector<float> s_HeaderRatios;
-  static std::vector<SortingOrder> s_InitialOrders;
+  enum ColumnIndex {
+    COLUMN_INDEX,
+    COLUMN_NAME,
+    COLUMN_PATH,
+    COLUMN_ADDRESS_RANGE,
+    COLUMN_HAS_PDB,
+    COLUMN_PDB_SIZE,
+    COLUMN_LOADED,
+    COLUMN_NUM
+  };
 
   static const std::string MENU_ACTION_MODULES_LOAD;
   static const std::string MENU_ACTION_DLL_FIND_PDB;

--- a/OrbitGl/PluginCanvas.h
+++ b/OrbitGl/PluginCanvas.h
@@ -11,10 +11,8 @@ class Plugin;
 
 class PluginCanvas : public GlCanvas {
  public:
-  PluginCanvas(Orbit::Plugin* a_Plugin);
-  virtual ~PluginCanvas();
-
-  void OnReceiveMessage(const Message& a_Message);
+  explicit PluginCanvas(Orbit::Plugin* a_Plugin);
+  ~PluginCanvas() override;
 
   void OnTimer() override;
   void ZoomAll();

--- a/OrbitGl/ProcessesDataView.cpp
+++ b/OrbitGl/ProcessesDataView.cpp
@@ -17,7 +17,7 @@
 #include "absl/strings/str_format.h"
 
 //-----------------------------------------------------------------------------
-ProcessesDataView::ProcessesDataView() {
+ProcessesDataView::ProcessesDataView() : DataView(DataViewType::PROCESSES) {
   InitSortingOrders();
 
   UpdateProcessList();

--- a/OrbitGl/ProcessesDataView.h
+++ b/OrbitGl/ProcessesDataView.h
@@ -9,10 +9,9 @@
 class ProcessesDataView : public DataView {
  public:
   ProcessesDataView();
-  const std::vector<std::string>& GetColumnHeaders() override;
-  const std::vector<float>& GetColumnHeadersRatios() override;
-  const std::vector<SortingOrder>& GetColumnInitialOrders() override;
-  int GetDefaultSortingColumn() override;
+
+  const std::vector<Column>& GetColumns() override;
+  int GetDefaultSortingColumn() override { return COLUMN_CPU; }
   std::string GetValue(int a_Row, int a_Column) override;
   std::string GetToolTip(int a_Row, int a_Column) override;
   std::string GetLabel() override { return "Processes"; }
@@ -25,29 +24,14 @@ class ProcessesDataView : public DataView {
   bool SelectProcess(const std::string& a_ProcessName);
   std::shared_ptr<Process> SelectProcess(DWORD a_ProcessId);
   void UpdateProcessList();
-  void SetRemoteProcessList(std::shared_ptr<ProcessList> a_RemoteProcessList);
-  void SetRemoteProcess(std::shared_ptr<Process> a_Process);
+  void SetRemoteProcessList(ProcessList a_RemoteProcessList);
+  void SetRemoteProcess(const std::shared_ptr<Process>& a_Process);
   void SetModulesDataView(class ModulesDataView* a_ModulesCtrl) {
     m_ModulesDataView = a_ModulesCtrl;
   }
   void Refresh();
-  void UpdateModuleDataView(std::shared_ptr<Process> a_Process);
+  void UpdateModuleDataView(const std::shared_ptr<Process>& a_Process);
   void SetIsRemote(bool a_Value) { m_IsRemote = a_Value; }
-
-  std::shared_ptr<Process> GetSelectedProcess() const {
-    return m_SelectedProcess;
-  }
-
-  // void SetSelectedProcessCtrl(SelectedProcessPanel* a_Panel ) {
-  // m_SelectedProcessPanel = a_Panel; }
-
-  enum PdvColumn {
-    PDV_ProcessID,
-    PDV_ProcessName,
-    PDV_CPU,
-    PDV_Type,
-    PDV_NumColumns
-  };
 
  protected:
   std::shared_ptr<Process> GetProcess(unsigned int a_Row) const;
@@ -55,12 +39,15 @@ class ProcessesDataView : public DataView {
 
   ProcessList m_ProcessList;
   std::shared_ptr<Process> m_RemoteProcess;
-  ModulesDataView* m_ModulesDataView;
+  ModulesDataView* m_ModulesDataView = nullptr;
   std::shared_ptr<Process> m_SelectedProcess;
   bool m_IsRemote;
 
-  static void InitColumnsIfNeeded();
-  static std::vector<std::string> s_Headers;
-  static std::vector<float> s_HeaderRatios;
-  static std::vector<SortingOrder> s_InitialOrders;
+  enum ColumnIndex {
+    COLUMN_PID,
+    COLUMN_NAME,
+    COLUMN_CPU,
+    COLUMN_TYPE,
+    COLUMN_NUM
+  };
 };

--- a/OrbitGl/RuleEditor.cpp
+++ b/OrbitGl/RuleEditor.cpp
@@ -598,7 +598,7 @@ void RuleEditor::OnReceiveMessage(const Message& a_Message) {
 }
 
 //-----------------------------------------------------------------------------
-void RuleEditor::ProcessVariable(const std::shared_ptr<Variable> a_Variable,
+void RuleEditor::ProcessVariable(const std::shared_ptr<Variable>& a_Variable,
                                  char* a_Data) {
   if (a_Variable->m_Size == 4) {
     GCardContainer.Update(a_Variable->m_Name, *((float*)a_Data));

--- a/OrbitGl/RuleEditor.h
+++ b/OrbitGl/RuleEditor.h
@@ -64,7 +64,7 @@ class RuleEditorWindow {
 class RuleEditor : public GlCanvas {
  public:
   RuleEditor();
-  virtual ~RuleEditor();
+  ~RuleEditor() override;
 
   void OnReceiveMessage(const Message& a_Message);
   std::unordered_map<DWORD64, std::shared_ptr<Rule>>& GetRules() {
@@ -76,7 +76,7 @@ class RuleEditor : public GlCanvas {
   void KeyPressed(unsigned int a_KeyCode, bool a_Ctrl, bool a_Shift,
                   bool a_Alt) override;
   void RenderUI() override;
-  void ProcessVariable(const std::shared_ptr<Variable> a_Variable,
+  void ProcessVariable(const std::shared_ptr<Variable>& a_Variable,
                        char* a_Data);
 
   RuleEditorWindow m_Window;

--- a/OrbitGl/SamplingReport.h
+++ b/OrbitGl/SamplingReport.h
@@ -9,17 +9,18 @@
 #include <utility>
 #include <vector>
 
-//-----------------------------------------------------------------------------
+#include "SamplingProfiler.h"
+#include "SamplingReportDataView.h"
+
 class SamplingReport {
  public:
   explicit SamplingReport(
       std::shared_ptr<class SamplingProfiler> a_SamplingProfiler);
 
   void FillReport();
-  std::shared_ptr<class SamplingProfiler> GetProfiler() const {
-    return m_Profiler;
-  }
-  const std::vector<std::shared_ptr<class DataView> >& GetThreadReports() {
+  std::shared_ptr<SamplingProfiler> GetProfiler() const { return m_Profiler; }
+  const std::vector<std::shared_ptr<SamplingReportDataView>>&
+  GetThreadReports() {
     return m_ThreadReports;
   }
   void SetCallstackDataView(class CallStackDataView* a_DataView) {
@@ -39,10 +40,10 @@ class SamplingReport {
 
  protected:
   std::shared_ptr<class SamplingProfiler> m_Profiler;
-  std::vector<std::shared_ptr<class DataView> > m_ThreadReports;
+  std::vector<std::shared_ptr<SamplingReportDataView>> m_ThreadReports;
   CallStackDataView* m_CallstackDataView;
 
-  unsigned long long m_SelectedAddress;
+  uint64_t m_SelectedAddress;
   std::shared_ptr<struct SortedCallstackReport> m_SelectedSortedCallstackReport;
   int m_SelectedAddressCallstackIndex;
   std::function<void()> m_UiRefreshFunc;

--- a/OrbitGl/SamplingReport.h
+++ b/OrbitGl/SamplingReport.h
@@ -14,8 +14,7 @@
 
 class SamplingReport {
  public:
-  explicit SamplingReport(
-      std::shared_ptr<class SamplingProfiler> a_SamplingProfiler);
+  explicit SamplingReport(std::shared_ptr<SamplingProfiler> a_SamplingProfiler);
 
   void FillReport();
   std::shared_ptr<SamplingProfiler> GetProfiler() const { return m_Profiler; }
@@ -39,12 +38,12 @@ class SamplingReport {
   }
 
  protected:
-  std::shared_ptr<class SamplingProfiler> m_Profiler;
+  std::shared_ptr<SamplingProfiler> m_Profiler;
   std::vector<std::shared_ptr<SamplingReportDataView>> m_ThreadReports;
   CallStackDataView* m_CallstackDataView;
 
   uint64_t m_SelectedAddress;
-  std::shared_ptr<struct SortedCallstackReport> m_SelectedSortedCallstackReport;
+  std::shared_ptr<SortedCallstackReport> m_SelectedSortedCallstackReport;
   int m_SelectedAddressCallstackIndex;
   std::function<void()> m_UiRefreshFunc;
 };

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -18,7 +18,7 @@
 
 //-----------------------------------------------------------------------------
 SamplingReportDataView::SamplingReportDataView()
-    : m_CallstackDataView(nullptr) {
+    : DataView(DataViewType::SAMPLING), m_CallstackDataView(nullptr) {
   InitSortingOrders();
 }
 
@@ -29,11 +29,11 @@ const std::vector<DataView::Column>& SamplingReportDataView::GetColumns() {
     columns.resize(COLUMN_NUM);
     columns[COLUMN_SELECTED] = {"Hooked", .0f, SortingOrder::Descending};
     columns[COLUMN_INDEX] = {"Index", .0f, SortingOrder::Ascending};
-    columns[COLUMN_FUNCTION_NAME] = {"Name", .6f, SortingOrder::Ascending};
+    columns[COLUMN_FUNCTION_NAME] = {"Name", .5f, SortingOrder::Ascending};
     columns[COLUMN_EXCLUSIVE] = {"Exclusive", .0f, SortingOrder::Descending};
     columns[COLUMN_INCLUSIVE] = {"Inclusive", .0f, SortingOrder::Descending};
     columns[COLUMN_MODULE_NAME] = {"Module", .0f, SortingOrder::Ascending};
-    columns[COLUMN_FILE] = {"File", .2f, SortingOrder::Ascending};
+    columns[COLUMN_FILE] = {"File", .0f, SortingOrder::Ascending};
     columns[COLUMN_LINE] = {"Line", .0f, SortingOrder::Ascending};
     columns[COLUMN_ADDRESS] = {"Address", .0f, SortingOrder::Ascending};
     return columns;

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -19,129 +19,54 @@
 //-----------------------------------------------------------------------------
 SamplingReportDataView::SamplingReportDataView()
     : m_CallstackDataView(nullptr) {
-  InitColumnsIfNeeded();
-  m_SortingOrders.insert(m_SortingOrders.end(), s_InitialOrders.begin(),
-                         s_InitialOrders.end());
+  InitSortingOrders();
 }
 
 //-----------------------------------------------------------------------------
-std::vector<std::string> SamplingReportDataView::s_Headers;
-std::vector<int> SamplingReportDataView::s_HeaderMap;
-std::vector<float> SamplingReportDataView::s_HeaderRatios;
-std::vector<DataView::SortingOrder> SamplingReportDataView::s_InitialOrders;
-
-//-----------------------------------------------------------------------------
-void SamplingReportDataView::InitColumnsIfNeeded() {
-  if (s_Headers.empty()) {
-    s_Headers.emplace_back("Hooked");
-    s_HeaderMap.push_back(SamplingColumn::Toggle);
-    s_HeaderRatios.push_back(0);
-    s_InitialOrders.push_back(DescendingOrder);
-
-    s_Headers.emplace_back("Index");
-    s_HeaderMap.push_back(SamplingColumn::Index);
-    s_HeaderRatios.push_back(0);
-    s_InitialOrders.push_back(AscendingOrder);
-
-    s_Headers.emplace_back("Name");
-    s_HeaderMap.push_back(SamplingColumn::FunctionName);
-    s_HeaderRatios.push_back(0.6f);
-    s_InitialOrders.push_back(AscendingOrder);
-
-    s_Headers.emplace_back("Exclusive");
-    s_HeaderMap.push_back(SamplingColumn::Exclusive);
-    s_HeaderRatios.push_back(0);
-    s_InitialOrders.push_back(DescendingOrder);
-
-    s_Headers.emplace_back("Inclusive");
-    s_HeaderMap.push_back(SamplingColumn::Inclusive);
-    s_HeaderRatios.push_back(0);
-    s_InitialOrders.push_back(DescendingOrder);
-
-    s_Headers.emplace_back("Module");
-    s_HeaderMap.push_back(SamplingColumn::ModuleName);
-    s_HeaderRatios.push_back(0);
-    s_InitialOrders.push_back(AscendingOrder);
-
-    s_Headers.emplace_back("File");
-    s_HeaderMap.push_back(SamplingColumn::SourceFile);
-    s_HeaderRatios.push_back(0.2f);
-    s_InitialOrders.push_back(AscendingOrder);
-
-    s_Headers.emplace_back("Line");
-    s_HeaderMap.push_back(SamplingColumn::SourceLine);
-    s_HeaderRatios.push_back(0);
-    s_InitialOrders.push_back(AscendingOrder);
-
-    s_Headers.emplace_back("Address");
-    s_HeaderMap.push_back(SamplingColumn::Address);
-    s_HeaderRatios.push_back(0);
-    s_InitialOrders.push_back(AscendingOrder);
-  }
-}
-
-//-----------------------------------------------------------------------------
-const std::vector<std::string>& SamplingReportDataView::GetColumnHeaders() {
-  return s_Headers;
-}
-
-//-----------------------------------------------------------------------------
-const std::vector<float>& SamplingReportDataView::GetColumnHeadersRatios() {
-  return s_HeaderRatios;
-}
-
-//-----------------------------------------------------------------------------
-const std::vector<DataView::SortingOrder>&
-SamplingReportDataView::GetColumnInitialOrders() {
-  return s_InitialOrders;
-}
-
-//-----------------------------------------------------------------------------
-int SamplingReportDataView::GetDefaultSortingColumn() {
-  return std::distance(s_HeaderMap.begin(),
-                       std::find(s_HeaderMap.begin(), s_HeaderMap.end(),
-                                 SamplingColumn::Inclusive));
+const std::vector<DataView::Column>& SamplingReportDataView::GetColumns() {
+  static const std::vector<Column> columns = [] {
+    std::vector<Column> columns;
+    columns.resize(COLUMN_NUM);
+    columns[COLUMN_SELECTED] = {"Hooked", .0f, SortingOrder::Descending};
+    columns[COLUMN_INDEX] = {"Index", .0f, SortingOrder::Ascending};
+    columns[COLUMN_FUNCTION_NAME] = {"Name", .6f, SortingOrder::Ascending};
+    columns[COLUMN_EXCLUSIVE] = {"Exclusive", .0f, SortingOrder::Descending};
+    columns[COLUMN_INCLUSIVE] = {"Inclusive", .0f, SortingOrder::Descending};
+    columns[COLUMN_MODULE_NAME] = {"Module", .0f, SortingOrder::Ascending};
+    columns[COLUMN_FILE] = {"File", .2f, SortingOrder::Ascending};
+    columns[COLUMN_LINE] = {"Line", .0f, SortingOrder::Ascending};
+    columns[COLUMN_ADDRESS] = {"Address", .0f, SortingOrder::Ascending};
+    return columns;
+  }();
+  return columns;
 }
 
 //-----------------------------------------------------------------------------
 std::string SamplingReportDataView::GetValue(int a_Row, int a_Column) {
   SampledFunction& func = GetSampledFunction(a_Row);
 
-  std::string value;
-
-  switch (s_HeaderMap[a_Column]) {
-    case SamplingColumn::Toggle:
-      value = func.GetSelected() ? "X" : "-";
-      break;
-    case SamplingColumn::Index:
-      value = absl::StrFormat("%d", a_Row);
-      break;
-    case SamplingColumn::FunctionName:
-      value = func.m_Name;
-      break;
-    case SamplingColumn::Exclusive:
-      value = absl::StrFormat("%.2f", func.m_Exclusive);
-      break;
-    case SamplingColumn::Inclusive:
-      value = absl::StrFormat("%.2f", func.m_Inclusive);
-      break;
-    case SamplingColumn::ModuleName:
-      value = func.m_Module;
-      break;
-    case SamplingColumn::SourceFile:
-      value = func.m_File;
-      break;
-    case SamplingColumn::SourceLine:
-      value = func.m_Line > 0 ? absl::StrFormat("%d", func.m_Line) : "";
-      break;
-    case SamplingColumn::Address:
-      value = absl::StrFormat("%#llx", func.m_Address);
-      break;
+  switch (a_Column) {
+    case COLUMN_SELECTED:
+      return func.GetSelected() ? "X" : "-";
+    case COLUMN_INDEX:
+      return absl::StrFormat("%d", a_Row);
+    case COLUMN_FUNCTION_NAME:
+      return func.m_Name;
+    case COLUMN_EXCLUSIVE:
+      return absl::StrFormat("%.2f", func.m_Exclusive);
+    case COLUMN_INCLUSIVE:
+      return absl::StrFormat("%.2f", func.m_Inclusive);
+    case COLUMN_MODULE_NAME:
+      return func.m_Module;
+    case COLUMN_FILE:
+      return func.m_File;
+    case COLUMN_LINE:
+      return func.m_Line > 0 ? absl::StrFormat("%d", func.m_Line) : "";
+    case COLUMN_ADDRESS:
+      return absl::StrFormat("%#llx", func.m_Address);
     default:
-      break;
+      return "";
   }
-
-  return value;
 }
 
 //-----------------------------------------------------------------------------
@@ -155,38 +80,37 @@ std::string SamplingReportDataView::GetValue(int a_Row, int a_Column) {
 void SamplingReportDataView::OnSort(int a_Column,
                                     std::optional<SortingOrder> a_NewOrder) {
   std::vector<SampledFunction>& functions = m_Functions;
-  auto column = static_cast<SamplingColumn>(s_HeaderMap[a_Column]);
 
   if (a_NewOrder.has_value()) {
-    m_SortingOrders[column] = a_NewOrder.value();
+    m_SortingOrders[a_Column] = a_NewOrder.value();
   }
 
-  bool ascending = m_SortingOrders[column] == AscendingOrder;
+  bool ascending = m_SortingOrders[a_Column] == SortingOrder::Ascending;
   std::function<bool(int a, int b)> sorter = nullptr;
 
-  switch (column) {
-    case SamplingColumn::Toggle:
+  switch (a_Column) {
+    case COLUMN_SELECTED:
       sorter = ORBIT_PROC_SORT(GetSelected());
       break;
-    case SamplingColumn::FunctionName:
+    case COLUMN_FUNCTION_NAME:
       sorter = ORBIT_PROC_SORT(m_Name);
       break;
-    case SamplingColumn::Exclusive:
+    case COLUMN_EXCLUSIVE:
       sorter = ORBIT_PROC_SORT(m_Exclusive);
       break;
-    case SamplingColumn::Inclusive:
+    case COLUMN_INCLUSIVE:
       sorter = ORBIT_PROC_SORT(m_Inclusive);
       break;
-    case SamplingColumn::ModuleName:
+    case COLUMN_MODULE_NAME:
       sorter = ORBIT_PROC_SORT(m_Module);
       break;
-    case SamplingColumn::SourceFile:
+    case COLUMN_FILE:
       sorter = ORBIT_PROC_SORT(m_File);
       break;
-    case SamplingColumn::SourceLine:
+    case COLUMN_LINE:
       sorter = ORBIT_PROC_SORT(m_Line);
       break;
-    case SamplingColumn::Address:
+    case COLUMN_ADDRESS:
       sorter = ORBIT_PROC_SORT(m_Address);
       break;
     default:

--- a/OrbitGl/SamplingReportDataView.h
+++ b/OrbitGl/SamplingReportDataView.h
@@ -3,6 +3,7 @@
 //-----------------------------------
 #pragma once
 
+#include "CallStackDataView.h"
 #include "DataView.h"
 #include "OrbitType.h"
 #include "ProcessUtils.h"
@@ -44,7 +45,7 @@ class SamplingReportDataView : public DataView {
   std::vector<SampledFunction> m_Functions;
   ThreadID m_TID = -1;
   std::string m_Name;
-  class CallStackDataView* m_CallstackDataView;
+  CallStackDataView* m_CallstackDataView;
   SamplingReport* m_SamplingReport = nullptr;
 
   enum COLUMN_INDEX {

--- a/OrbitGl/SamplingReportDataView.h
+++ b/OrbitGl/SamplingReportDataView.h
@@ -19,7 +19,7 @@ class SamplingReportDataView : public DataView {
   std::vector<std::string> GetContextMenu(
       int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) override;
   std::string GetValue(int a_Row, int a_Column) override;
-  const std::string& GetName() override { return m_Name; }
+  const std::string& GetName() { return m_Name; }
 
   void OnFilter(const std::string& a_Filter) override;
   void OnSort(int a_Column, std::optional<SortingOrder> a_NewOrder) override;

--- a/OrbitGl/SamplingReportDataView.h
+++ b/OrbitGl/SamplingReportDataView.h
@@ -12,10 +12,8 @@ class SamplingReportDataView : public DataView {
  public:
   SamplingReportDataView();
 
-  const std::vector<std::string>& GetColumnHeaders() override;
-  const std::vector<float>& GetColumnHeadersRatios() override;
-  const std::vector<SortingOrder>& GetColumnInitialOrders() override;
-  int GetDefaultSortingColumn() override;
+  const std::vector<Column>& GetColumns() override;
+  int GetDefaultSortingColumn() override { return COLUMN_INCLUSIVE; }
   std::vector<std::string> GetContextMenu(
       int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) override;
   std::string GetValue(int a_Row, int a_Column) override;
@@ -35,19 +33,6 @@ class SamplingReportDataView : public DataView {
   void SetThreadID(ThreadID a_TID);
   std::vector<SampledFunction>& GetSampledFunctions() { return m_Functions; }
 
-  enum SamplingColumn {
-    Toggle,
-    Index,
-    FunctionName,
-    Exclusive,
-    Inclusive,
-    ModuleName,
-    SourceFile,
-    SourceLine,
-    Address,
-    NumColumns
-  };
-
  protected:
   const SampledFunction& GetSampledFunction(unsigned int a_Row) const;
   SampledFunction& GetSampledFunction(unsigned int a_Row);
@@ -62,11 +47,18 @@ class SamplingReportDataView : public DataView {
   class CallStackDataView* m_CallstackDataView;
   SamplingReport* m_SamplingReport = nullptr;
 
-  static void InitColumnsIfNeeded();
-  static std::vector<std::string> s_Headers;
-  static std::vector<int> s_HeaderMap;
-  static std::vector<float> s_HeaderRatios;
-  static std::vector<SortingOrder> s_InitialOrders;
+  enum COLUMN_INDEX {
+    COLUMN_SELECTED,
+    COLUMN_INDEX,
+    COLUMN_FUNCTION_NAME,
+    COLUMN_EXCLUSIVE,
+    COLUMN_INCLUSIVE,
+    COLUMN_MODULE_NAME,
+    COLUMN_FILE,
+    COLUMN_LINE,
+    COLUMN_ADDRESS,
+    COLUMN_NUM
+  };
 
   static const std::string MENU_ACTION_SELECT;
   static const std::string MENU_ACTION_UNSELECT;

--- a/OrbitGl/SessionsDataView.cpp
+++ b/OrbitGl/SessionsDataView.cpp
@@ -14,7 +14,7 @@
 #include "Pdb.h"
 
 //-----------------------------------------------------------------------------
-SessionsDataView::SessionsDataView() {
+SessionsDataView::SessionsDataView() : DataView(DataViewType::SESSIONS) {
   InitSortingOrders();
   GOrbitApp->RegisterSessionsDataView(this);
 }

--- a/OrbitGl/SessionsDataView.h
+++ b/OrbitGl/SessionsDataView.h
@@ -12,9 +12,9 @@ class Session;
 class SessionsDataView : public DataView {
  public:
   SessionsDataView();
-  const std::vector<std::string>& GetColumnHeaders() override;
-  const std::vector<float>& GetColumnHeadersRatios() override;
-  const std::vector<SortingOrder>& GetColumnInitialOrders() override;
+
+  const std::vector<Column>& GetColumns() override;
+  int GetDefaultSortingColumn() override { return COLUMN_SESSION_NAME; }
   std::vector<std::string> GetContextMenu(
       int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) override;
   std::string GetValue(int a_Row, int a_Column) override;
@@ -29,22 +29,12 @@ class SessionsDataView : public DataView {
 
   void SetSessions(const std::vector<std::shared_ptr<Session> >& a_Sessions);
 
-  enum SdvColumn {
-    SDV_SessionName,
-    SDV_ProcessName,
-    //    SDV_LastUsed,
-    SDV_NumColumns
-  };
-
  protected:
   const std::shared_ptr<Session>& GetSession(unsigned int a_Row) const;
 
   std::vector<std::shared_ptr<Session> > m_Sessions;
 
-  static void InitColumnsIfNeeded();
-  static std::vector<std::string> s_Headers;
-  static std::vector<float> s_HeaderRatios;
-  static std::vector<SortingOrder> s_InitialOrders;
+  enum ColumnIndex { COLUMN_SESSION_NAME, COLUMN_PROCESS_NAME, COLUMN_NUM };
 
   static const std::string MENU_ACTION_SESSIONS_LOAD;
 };

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -692,8 +692,7 @@ void TimeGraph::UpdatePrimitives(bool a_Picking) {
                 std::string text = absl::StrFormat(
                     "%s; submitter: %d  %s",
                     string_manager_->Get(timer.m_UserData[0]).value_or(""),
-                    timer.m_SubmitTID,
-                    time.c_str());
+                    timer.m_SubmitTID, time.c_str());
                 textBox.SetText(text);
               } else if (!SystraceManager::Get().IsEmpty()) {
                 textBox.SetText(SystraceManager::Get().GetFunctionName(

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <unordered_map>
+#include <utility>
 
 #include "Batcher.h"
 #include "BlockChain.h"
@@ -28,7 +29,6 @@ class TimeGraph {
   void Draw(bool a_Picking = false);
   void DrawThreadTracks(bool a_Picking = false);
   void DrawMainFrame(TextBox& a_Box);
-  void DrawTime();
   void DrawLineBuffer(bool a_Picking);
   void DrawBoxBuffer(bool a_Picking);
   void DrawBuffered(bool a_Picking);
@@ -44,7 +44,6 @@ class TimeGraph {
   void ProcessTimer(const Timer& a_Timer);
   void UpdateThreadDepth(int a_ThreadId, int a_Depth);
   void UpdateMaxTimeStamp(TickType a_Time);
-  void AddContextSwitch();
 
   float GetThreadTotalHeight();
   float GetTextBoxHeight() const { return m_Layout.GetTextBoxHeight(); }
@@ -90,7 +89,7 @@ class TimeGraph {
   void SetCanvas(GlCanvas* a_Canvas);
   void SetFontSize(int a_FontSize);
   void SetSystrace(std::shared_ptr<Systrace> a_Systrace) {
-    m_Systrace = a_Systrace;
+    m_Systrace = std::move(a_Systrace);
   }
   Batcher& GetBatcher() { return m_Batcher; }
   uint32_t GetNumTimers() const;

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -137,7 +137,6 @@ class TimeGraph {
   double m_ZoomValue = 0;
   double m_MouseRatio = 0;
   unsigned int m_MainFrameCounter = 0;
-  unsigned char m_TrackAlpha = 255;
 
   TimeGraphLayout m_Layout;
 

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -14,7 +14,7 @@ class TimeGraph;
 class Track : public Pickable {
  public:
   Track();
-  virtual ~Track() = default;
+  ~Track() override = default;
 
   // Pickable
   void Draw(GlCanvas* a_Canvas, bool a_Picking) override;

--- a/OrbitGl/TypesDataView.cpp
+++ b/OrbitGl/TypesDataView.cpp
@@ -16,7 +16,7 @@
 #include "absl/strings/str_format.h"
 
 //-----------------------------------------------------------------------------
-TypesDataView::TypesDataView() {
+TypesDataView::TypesDataView() : DataView(DataViewType::TYPES) {
   InitSortingOrders();
   OnDataChanged();
 

--- a/OrbitGl/TypesDataView.h
+++ b/OrbitGl/TypesDataView.h
@@ -12,9 +12,8 @@ class TypesDataView : public DataView {
  public:
   TypesDataView();
 
-  const std::vector<std::string>& GetColumnHeaders() override;
-  const std::vector<float>& GetColumnHeadersRatios() override;
-  const std::vector<SortingOrder>& GetColumnInitialOrders() override;
+  const std::vector<Column>& GetColumns() override;
+  int GetDefaultSortingColumn() override { return COLUMN_NAME; }
   std::vector<std::string> GetContextMenu(
       int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) override;
   std::string GetValue(int a_Row, int a_Column) override;
@@ -35,11 +34,19 @@ class TypesDataView : public DataView {
 
   std::vector<std::string> m_FilterTokens;
 
-  static void InitColumnsIfNeeded();
-  static std::vector<std::string> s_Headers;
-  static std::vector<int> s_HeaderMap;
-  static std::vector<float> s_HeaderRatios;
-  static std::vector<SortingOrder> s_InitialOrders;
+  enum ColumnIndex {
+    COLUMN_INDEX,
+    COLUMN_NAME,
+    COLUMN_LENGTH,
+    COLUMN_TYPE_ID,
+    COLUMN_TYPE_ID_UNMOD,
+    COLUMN_NUM_VARIABLES,
+    COLUMN_NUM_FUNCTIONS,
+    COLUMN_NUM_BASE_CLASSES,
+    COLUMN_BASE_OFFSET,
+    COLUMN_MODULE,
+    COLUMN_NUM
+  };
 
   static const std::string MENU_ACTION_SUMMARY;
   static const std::string MENU_ACTION_DETAILS;

--- a/OrbitQt/licensedialog.h
+++ b/OrbitQt/licensedialog.h
@@ -11,8 +11,8 @@ class LicenseDialog : public QDialog {
   Q_OBJECT
 
  public:
-  explicit LicenseDialog(QWidget* parent = 0);
-  ~LicenseDialog();
+  explicit LicenseDialog(QWidget* parent = nullptr);
+  ~LicenseDialog() override;
 
   std::wstring GetLicense();
 

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -7,13 +7,12 @@
 #include <QFontDatabase>
 #include <QStyleFactory>
 
-#include "absl/flags/flag.h"
-#include "absl/flags/parse.h"
-#include "absl/flags/usage.h"
-
 #include "../OrbitGl/App.h"
 #include "CrashHandler.h"
 #include "Path.h"
+#include "absl/flags/flag.h"
+#include "absl/flags/parse.h"
+#include "absl/flags/usage.h"
 #include "orbitmainwindow.h"
 
 // TODO: Remove this flag once we have a dialog with user

--- a/OrbitQt/orbitcodeeditor.h
+++ b/OrbitQt/orbitcodeeditor.h
@@ -74,7 +74,7 @@ class OrbitCodeEditor : public QPlainTextEdit {
   Q_OBJECT
 
  public:
-  OrbitCodeEditor(QWidget* parent = 0);
+  explicit OrbitCodeEditor(QWidget* parent = nullptr);
 
   void lineNumberAreaPaintEvent(QPaintEvent* event);
   int lineNumberAreaWidth();
@@ -132,7 +132,7 @@ class OrbitCodeEditor : public QPlainTextEdit {
 
 class LineNumberArea : public QWidget {
  public:
-  LineNumberArea(OrbitCodeEditor* editor) : QWidget(editor) {
+  explicit LineNumberArea(OrbitCodeEditor* editor) : QWidget(editor) {
     codeEditor = editor;
   }
 
@@ -154,7 +154,7 @@ class Highlighter : public QSyntaxHighlighter {
   Q_OBJECT
 
  public:
-  Highlighter(QTextDocument* parent = 0);
+  explicit Highlighter(QTextDocument* parent = nullptr);
 
  protected:
   void highlightBlock(const QString& text) Q_DECL_OVERRIDE;

--- a/OrbitQt/orbitdataviewpanel.cpp
+++ b/OrbitQt/orbitdataviewpanel.cpp
@@ -4,6 +4,8 @@
 
 #include "orbitdataviewpanel.h"
 
+#include <utility>
+
 #include "ui_orbitdataviewpanel.h"
 
 //-----------------------------------------------------------------------------
@@ -45,11 +47,11 @@ void OrbitDataViewPanel::Refresh() { ui->treeView->Refresh(); }
 
 //-----------------------------------------------------------------------------
 void OrbitDataViewPanel::SetDataModel(std::shared_ptr<DataView> a_Model) {
-  ui->treeView->SetDataModel(a_Model);
+  ui->treeView->SetDataModel(std::move(a_Model));
 }
 
 //-----------------------------------------------------------------------------
-void OrbitDataViewPanel::SetFilter(QString a_Filter) {
+void OrbitDataViewPanel::SetFilter(const QString& a_Filter) {
   ui->FilterLineEdit->setText(a_Filter);
   ui->treeView->OnFilter(a_Filter);
 }

--- a/OrbitQt/orbitdataviewpanel.h
+++ b/OrbitQt/orbitdataviewpanel.h
@@ -15,14 +15,14 @@ class OrbitDataViewPanel : public QWidget {
   Q_OBJECT
 
  public:
-  explicit OrbitDataViewPanel(QWidget* parent = 0);
-  ~OrbitDataViewPanel();
+  explicit OrbitDataViewPanel(QWidget* parent = nullptr);
+  ~OrbitDataViewPanel() override;
 
   void Initialize(DataViewType a_Type, bool a_MainInstance = true);
   void Link(OrbitDataViewPanel* a_Panel);
   void Refresh();
   void SetDataModel(std::shared_ptr<DataView> a_Model);
-  void SetFilter(QString a_Filter);
+  void SetFilter(const QString& a_Filter);
   void Select(int a_Row);
   class OrbitTreeView* GetTreeView();
 

--- a/OrbitQt/orbitdiffdialog.h
+++ b/OrbitQt/orbitdiffdialog.h
@@ -11,8 +11,8 @@ class OrbitDiffDialog : public QDialog {
   Q_OBJECT
 
  public:
-  explicit OrbitDiffDialog(QWidget* parent = 0);
-  ~OrbitDiffDialog();
+  explicit OrbitDiffDialog(QWidget* parent = nullptr);
+  ~OrbitDiffDialog() override;
 
  private slots:
   void on_pushButton_clicked();

--- a/OrbitQt/orbitdisassemblydialog.h
+++ b/OrbitQt/orbitdisassemblydialog.h
@@ -12,8 +12,8 @@ class OrbitDisassemblyDialog : public QDialog {
   Q_OBJECT
 
  public:
-  explicit OrbitDisassemblyDialog(QWidget* parent = 0);
-  ~OrbitDisassemblyDialog();
+  explicit OrbitDisassemblyDialog(QWidget* parent = nullptr);
+  ~OrbitDisassemblyDialog() override;
 
   void SetText(const std::string& a_Text);
 

--- a/OrbitQt/orbitglwidget.h
+++ b/OrbitQt/orbitglwidget.h
@@ -15,7 +15,7 @@ class OrbitGLWidget : public QOpenGLWidget, protected QOpenGLFunctions {
   Q_OBJECT
 
  public:
-  OrbitGLWidget(QWidget* parent = 0);
+  explicit OrbitGLWidget(QWidget* parent = nullptr);
   void Initialize(GlPanel::Type a_Type, class OrbitMainWindow* a_MainWindow,
                   void* a_UserData = nullptr);
   void initializeGL() override;

--- a/OrbitQt/orbitglwidgetwithheader.h
+++ b/OrbitQt/orbitglwidgetwithheader.h
@@ -13,8 +13,8 @@ class OrbitGlWidgetWithHeader : public QWidget {
   Q_OBJECT
 
  public:
-  explicit OrbitGlWidgetWithHeader(QWidget* parent = 0);
-  ~OrbitGlWidgetWithHeader();
+  explicit OrbitGlWidgetWithHeader(QWidget* parent = nullptr);
+  ~OrbitGlWidgetWithHeader() override;
 
   class OrbitTreeView* GetTreeView();
   class OrbitGLWidget* GetGLWidget();

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -95,7 +95,7 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App, QWidget* parent)
 
   ui->ModulesList->Initialize(DataViewType::MODULES);
   ui->FunctionsList->Initialize(DataViewType::FUNCTIONS);
-  ui->LiveFunctionsList->Initialize(DataViewType::LIVEFUNCTIONS);
+  ui->LiveFunctionsList->Initialize(DataViewType::LIVE_FUNCTIONS);
   ui->CallStackView->Initialize(DataViewType::CALLSTACK);
   ui->TypesList->Initialize(DataViewType::TYPES);
   ui->GlobalsList->Initialize(DataViewType::GLOBALS);
@@ -238,7 +238,7 @@ void OrbitMainWindow::UpdatePanel(DataViewType a_Type) {
     case DataViewType::FUNCTIONS:
       ui->FunctionsList->Refresh();
       break;
-    case DataViewType::LIVEFUNCTIONS:
+    case DataViewType::LIVE_FUNCTIONS:
       ui->LiveFunctionsList->Refresh();
       break;
     case DataViewType::TYPES:

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -18,8 +18,8 @@ class OrbitMainWindow : public QMainWindow {
   Q_OBJECT
 
  public:
-  explicit OrbitMainWindow(QApplication* a_App, QWidget* parent = 0);
-  ~OrbitMainWindow();
+  explicit OrbitMainWindow(QApplication* a_App, QWidget* parent = nullptr);
+  ~OrbitMainWindow() override;
 
   void RegisterGlWidget(class OrbitGLWidget* a_GlWidget) {
     m_GlWidgets.push_back(a_GlWidget);

--- a/OrbitQt/orbitsamplingreport.cpp
+++ b/OrbitQt/orbitsamplingreport.cpp
@@ -44,8 +44,8 @@ void OrbitSamplingReport::Initialize(std::shared_ptr<SamplingReport> a_Report) {
 
   m_SamplingReport->SetUiRefreshFunc([&]() { this->Refresh(); });
 
-  for (std::shared_ptr<DataView> report : a_Report->GetThreadReports()) {
-    // OrbitDataViewPanel *treeView = new OrbitDataViewPanel();
+  for (const std::shared_ptr<SamplingReportDataView>& report :
+       a_Report->GetThreadReports()) {
     QWidget* tab = new QWidget();
     tab->setObjectName(QStringLiteral("tab"));
 

--- a/OrbitQt/orbitsamplingreport.cpp
+++ b/OrbitQt/orbitsamplingreport.cpp
@@ -58,10 +58,10 @@ void OrbitSamplingReport::Initialize(std::shared_ptr<SamplingReport> a_Report) {
       treeView->GetTreeView()->setSortingEnabled(false);
     } else {
       int column = report->GetDefaultSortingColumn();
-      Qt::SortOrder order =
-          report->GetColumnInitialOrders()[column] == DataView::AscendingOrder
-              ? Qt::AscendingOrder
-              : Qt::DescendingOrder;
+      Qt::SortOrder order = report->GetColumns()[column].initial_order ==
+                                    DataView::SortingOrder::Ascending
+                                ? Qt::AscendingOrder
+                                : Qt::DescendingOrder;
       treeView->GetTreeView()->sortByColumn(column, order);
     }
 

--- a/OrbitQt/orbitsamplingreport.h
+++ b/OrbitQt/orbitsamplingreport.h
@@ -14,8 +14,8 @@ class OrbitSamplingReport : public QWidget {
   Q_OBJECT
 
  public:
-  explicit OrbitSamplingReport(QWidget* parent = 0);
-  ~OrbitSamplingReport();
+  explicit OrbitSamplingReport(QWidget* parent = nullptr);
+  ~OrbitSamplingReport() override;
 
   void Initialize(std::shared_ptr<class SamplingReport> a_Report);
 

--- a/OrbitQt/orbittablemodel.cpp
+++ b/OrbitQt/orbittablemodel.cpp
@@ -12,7 +12,7 @@ OrbitTableModel::OrbitTableModel(DataViewType a_Type, QObject* parent)
     : QAbstractTableModel(parent),
       m_DataView(nullptr),
       m_AlternateRowColor(true) {
-  m_DataView = std::shared_ptr<DataView>(DataView::Create(a_Type));
+  m_DataView = DataView::Create(a_Type);
 
   if (a_Type == DataViewType::LOG) {
     m_AlternateRowColor = false;

--- a/OrbitQt/orbittreeitem.h
+++ b/OrbitQt/orbittreeitem.h
@@ -6,7 +6,7 @@
 class OrbitTreeItem {
  public:
   explicit OrbitTreeItem(const QList<QVariant>& data,
-                         OrbitTreeItem* parentItem = 0);
+                         OrbitTreeItem* parentItem = nullptr);
   ~OrbitTreeItem();
 
   void appendChild(OrbitTreeItem* child);

--- a/OrbitQt/orbittreemodel.h
+++ b/OrbitQt/orbittreemodel.h
@@ -10,8 +10,8 @@ class OrbitTreeModel : public QAbstractItemModel {
   Q_OBJECT
 
  public:
-  explicit OrbitTreeModel(const QString& data, QObject* parent = 0);
-  ~OrbitTreeModel();
+  explicit OrbitTreeModel(const QString& data, QObject* parent = nullptr);
+  ~OrbitTreeModel() override;
 
   QVariant data(const QModelIndex& index, int role) const override;
   Qt::ItemFlags flags(const QModelIndex& index) const override;

--- a/OrbitQt/orbittreeview.cpp
+++ b/OrbitQt/orbittreeview.cpp
@@ -161,10 +161,8 @@ void OrbitTreeView::Refresh() {
 void OrbitTreeView::resizeEvent(QResizeEvent* event) {
   if (m_AutoResize && m_Model && m_Model->GetDataView()) {
     QSize headerSize = size();
-    const std::vector<float>& columnRatios =
-        m_Model->GetDataView()->GetColumnHeadersRatios();
-    for (size_t i = 0; i < columnRatios.size(); ++i) {
-      float ratio = columnRatios[i];
+    for (size_t i = 0; i < m_Model->GetDataView()->GetColumns().size(); ++i) {
+      float ratio = m_Model->GetDataView()->GetColumns()[i].ratio;
       if (ratio > 0.f) {
         header()->resizeSection(i,
                                 static_cast<int>(headerSize.width() * ratio));

--- a/OrbitQt/orbittreeview.cpp
+++ b/OrbitQt/orbittreeview.cpp
@@ -80,7 +80,7 @@ void OrbitTreeView::Initialize(DataViewType a_Type) {
   }
 
   if (a_Type == DataViewType::FUNCTIONS ||
-      a_Type == DataViewType::LIVEFUNCTIONS ||
+      a_Type == DataViewType::LIVE_FUNCTIONS ||
       a_Type == DataViewType::CALLSTACK || a_Type == DataViewType::MODULES ||
       a_Type == DataViewType::GLOBALS) {
     setSelectionMode(ExtendedSelection);
@@ -139,7 +139,7 @@ void OrbitTreeView::OnClicked(const QModelIndex& index) {
 void OrbitTreeView::Refresh() {
   QModelIndexList list = selectionModel()->selectedIndexes();
 
-  if (this->m_Model->GetDataView()->GetType() == DataViewType::LIVEFUNCTIONS) {
+  if (this->m_Model->GetDataView()->GetType() == DataViewType::LIVE_FUNCTIONS) {
     m_Model->layoutAboutToBeChanged();
     m_Model->layoutChanged();
     return;

--- a/OrbitQt/orbitvisualizer.h
+++ b/OrbitQt/orbitvisualizer.h
@@ -11,8 +11,8 @@ class OrbitVisualizer : public QMainWindow {
   Q_OBJECT
 
  public:
-  explicit OrbitVisualizer(QWidget* parent = 0);
-  ~OrbitVisualizer();
+  explicit OrbitVisualizer(QWidget* parent = nullptr);
+  ~OrbitVisualizer() override;
 
   void Initialize(class OrbitMainWindow* a_MainWindow);
 

--- a/OrbitQt/orbitwatchwidget.h
+++ b/OrbitQt/orbitwatchwidget.h
@@ -18,8 +18,8 @@ class OrbitWatchWidget : public QWidget {
   Q_OBJECT
 
  public:
-  explicit OrbitWatchWidget(QWidget* parent = 0);
-  ~OrbitWatchWidget();
+  explicit OrbitWatchWidget(QWidget* parent = nullptr);
+  ~OrbitWatchWidget() override;
 
   void SetupPropertyBrowser();
   void AddToWatch(const Variable* a_Variable);

--- a/OrbitQt/outputdialog.h
+++ b/OrbitQt/outputdialog.h
@@ -11,8 +11,8 @@ class OutputDialog : public QDialog {
   Q_OBJECT
 
  public:
-  explicit OutputDialog(QWidget* parent = 0);
-  ~OutputDialog();
+  explicit OutputDialog(QWidget* parent = nullptr);
+  ~OutputDialog() override;
 
   void Reset();
   void SetStatus(const std::string& a_Status);

--- a/OrbitQt/processlauncherwidget.h
+++ b/OrbitQt/processlauncherwidget.h
@@ -11,8 +11,8 @@ class ProcessLauncherWidget : public QWidget {
   Q_OBJECT
 
  public:
-  explicit ProcessLauncherWidget(QWidget* parent = 0);
-  ~ProcessLauncherWidget();
+  explicit ProcessLauncherWidget(QWidget* parent = nullptr);
+  ~ProcessLauncherWidget() override;
 
   void SetProcessParams();
   void UpdateProcessParams();

--- a/OrbitQt/qtpropertybrowser/qtpropertymanager.cpp
+++ b/OrbitQt/qtpropertybrowser/qtpropertymanager.cpp
@@ -4406,13 +4406,18 @@ void QtRectFPropertyManagerPrivate::setConstraint(QtProperty* property,
                                                   const QRectF& constraint,
                                                   const QRectF& val) {
   const bool isNull = constraint.isNull();
-  const qreal left = isNull ? std::numeric_limits<qreal>::min() : constraint.left();
-  const qreal right = isNull ? std::numeric_limits<qreal>::max() : constraint.left() + constraint.width();
-  const qreal top = isNull ? std::numeric_limits<qreal>::min() : constraint.top();
-  const qreal bottom =
-      isNull ? std::numeric_limits<qreal>::max() : constraint.top() + constraint.height();
-  const qreal width = isNull ? std::numeric_limits<qreal>::max() : constraint.width();
-  const qreal height = isNull ? std::numeric_limits<qreal>::max() : constraint.height();
+  const qreal left =
+      isNull ? std::numeric_limits<qreal>::min() : constraint.left();
+  const qreal right = isNull ? std::numeric_limits<qreal>::max()
+                             : constraint.left() + constraint.width();
+  const qreal top =
+      isNull ? std::numeric_limits<qreal>::min() : constraint.top();
+  const qreal bottom = isNull ? std::numeric_limits<qreal>::max()
+                              : constraint.top() + constraint.height();
+  const qreal width =
+      isNull ? std::numeric_limits<qreal>::max() : constraint.width();
+  const qreal height =
+      isNull ? std::numeric_limits<qreal>::max() : constraint.height();
 
   m_doublePropertyManager->setRange(m_propertyToX[property], left, right);
   m_doublePropertyManager->setRange(m_propertyToY[property], top, bottom);

--- a/OrbitQt/showincludesdialog.h
+++ b/OrbitQt/showincludesdialog.h
@@ -14,8 +14,8 @@ class ShowIncludesDialog : public QDialog {
   Q_OBJECT
 
  public:
-  explicit ShowIncludesDialog(QWidget* parent = 0);
-  ~ShowIncludesDialog();
+  explicit ShowIncludesDialog(QWidget* parent = nullptr);
+  ~ShowIncludesDialog() override;
 
  public slots:
   void onCustomContextMenu(const QPoint& point);


### PR DESCRIPTION
This removes some hacks that were in place to reuse some `FunctionsDataView`'s code and allows to solve b/154198298.
Also changes the way `DataView` provides column information by replacing multiple fields and methods with the `DataView::Column` struct and the `DataView::GetColumns` abstract method.
As usual, clang-tidy, clang-format, and other minor tweaks.