### PR TITLE
Remove GRemoteHost/Port globals

### DIFF
--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -47,8 +47,6 @@ ULONG64 Capture::GMainFrameFunction;
 uint64_t Capture::GNumContextSwitches;
 ULONG64 Capture::GNumLinuxEvents;
 ULONG64 Capture::GNumProfileEvents;
-int Capture::GCapturePort = 0;
-std::string Capture::GCaptureHost = "localhost";
 std::string Capture::GPresetToLoad = "";
 std::string Capture::GProcessToInject = "";
 
@@ -84,44 +82,44 @@ void* Capture::sampling_done_callback_user_data_ = nullptr;
 //-----------------------------------------------------------------------------
 void Capture::Init() {
   GTargetProcess = std::make_shared<Process>();
-  Capture::GCapturePort = GParams.m_Port;
 }
 
 //-----------------------------------------------------------------------------
-bool Capture::Inject(bool a_WaitForConnection) {
+bool Capture::Inject(std::string_view remote_address) {
   Injection inject;
   std::string dllName = Path::GetDllPath(GTargetProcess->GetIs64Bit());
 
   GTcpServer->Disconnect();
 
-  GInjected = inject.Inject(dllName, *GTargetProcess, "OrbitInit");
+  GInjected =
+      inject.Inject(remote_address, dllName, *GTargetProcess, "OrbitInit");
   if (GInjected) {
     ORBIT_LOG(
         absl::StrFormat("Injected in %s", GTargetProcess->GetName().c_str()));
     GInjectedProcess = GTargetProcess->GetName();
   }
 
-  if (a_WaitForConnection) {
-    int numTries = 50;
-    while (!GTcpServer->HasConnection() && numTries-- > 0) {
-      ORBIT_LOG(absl::StrFormat("Waiting for connection on port %i",
-                                Capture::GCapturePort));
-      Sleep(100);
-    }
-
-    GInjected = GInjected && GTcpServer->HasConnection();
+  // Wait for connections
+  int numTries = 50;
+  while (!GTcpServer->HasConnection() && numTries-- > 0) {
+    ORBIT_LOG(absl::StrFormat("Waiting for connection on port %i",
+                              GTcpServer->GetPort()));
+    Sleep(100);
   }
+
+  GInjected = GInjected && GTcpServer->HasConnection();
 
   return GInjected;
 }
 
 //-----------------------------------------------------------------------------
-bool Capture::InjectRemote() {
+bool Capture::InjectRemote(std::string_view remote_address) {
   Injection inject;
   std::string dllName = Path::GetDllPath(GTargetProcess->GetIs64Bit());
   GTcpServer->Disconnect();
 
-  GInjected = inject.Inject(dllName, *GTargetProcess, "OrbitInitRemote");
+  GInjected = inject.Inject(remote_address, dllName, *GTargetProcess,
+                            "OrbitInitRemote");
 
   if (GInjected) {
     ORBIT_LOG(
@@ -148,16 +146,20 @@ void Capture::SetTargetProcess(const std::shared_ptr<Process>& a_Process) {
 }
 
 //-----------------------------------------------------------------------------
-bool Capture::Connect() {
+bool Capture::Connect(std::string_view remote_address) {
   if (!GInjected) {
-    Inject();
+    Inject(remote_address);
   }
 
   return GInjected;
 }
 
 //-----------------------------------------------------------------------------
-bool Capture::StartCapture(LinuxTracingSession* session) {
+// TODO: This method is resposible for too many things. We probably want to
+// split the server side logic and client side logic into separate
+// methods/classes.
+bool Capture::StartCapture(LinuxTracingSession* session,
+                           std::string_view remote_address) {
   SCOPE_TIMER_LOG("Capture::StartCapture");
 
   if (GTargetProcess->GetName().size() == 0) return false;
@@ -167,7 +169,7 @@ bool Capture::StartCapture(LinuxTracingSession* session) {
 
 #ifdef WIN32
   if (!IsRemote()) {
-    if (!Connect()) {
+    if (!Connect(remote_address)) {
       return false;
     }
   }
@@ -187,6 +189,7 @@ bool Capture::StartCapture(LinuxTracingSession* session) {
 #else
     CHECK(session != nullptr);
     GEventTracer.Start(GTargetProcess->GetID(), session);
+    UNUSED(remote_address);
 #endif
   } else if (Capture::IsRemote()) {
     Capture::NewSamplingProfiler();
@@ -478,20 +481,6 @@ void Capture::DisplayStats() {
 }
 
 //-----------------------------------------------------------------------------
-bool Capture::IsOtherInstanceRunning() {
-#ifdef _WIN32
-  DWORD procID = 0;
-  HANDLE procHandle = Injection::GetTargetProcessHandle(ORBIT_EXE_NAME, procID);
-  PRINT_FUNC;
-  bool otherInstanceFound = procHandle != NULL;
-  PRINT_VAR(otherInstanceFound);
-  return otherInstanceFound;
-#else
-  return false;
-#endif
-}
-
-//-----------------------------------------------------------------------------
 void Capture::SaveSession(const std::string& a_FileName) {
   Session session;
   session.m_ProcessFullPath = GTargetProcess->GetFullName();
@@ -535,13 +524,6 @@ bool Capture::IsTrackingEvents() {
 #ifdef __linux
   return !IsRemote();
 #else
-  static bool yieldEvents = false;
-  if (yieldEvents && IsOtherInstanceRunning() && GTargetProcess) {
-    if (absl::StrContains(GTargetProcess->GetName(), "Orbit.exe")) {
-      return false;
-    }
-  }
-
   if (GTargetProcess->GetIsRemote() && !GTcpServer->IsLocalConnection()) {
     return false;
   }

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -20,11 +20,15 @@ struct CallStack;
 class Capture {
  public:
   static void Init();
-  static bool Inject(bool a_WaitForConnection = true);
-  static bool Connect();
-  static bool InjectRemote();
+  static bool Inject(std::string_view remote_address);
+  static bool Connect(std::string_view remote_address);
+  static bool InjectRemote(std::string_view remote_address);
   static void SetTargetProcess(const std::shared_ptr<Process>& a_Process);
-  static bool StartCapture(LinuxTracingSession* session);
+  // TODO: This method needs to be split into 2, the server side and the
+  // client-side. session here is only used by the server side and
+  // remote_address is only used by the client-side.
+  static bool StartCapture(LinuxTracingSession* session,
+                           std::string_view remote_address);
   static void StopCapture();
   static void ClearCaptureData();
   static std::vector<std::shared_ptr<Function>> GetSelectedFunctions();
@@ -37,7 +41,6 @@ class Capture {
   static void Update();
   static void DisplayStats();
   static void TestHooks();
-  static bool IsOtherInstanceRunning();
   static void SaveSession(const std::string& a_FileName);
   static void NewSamplingProfiler();
   static bool IsTrackingEvents();
@@ -69,8 +72,6 @@ class Capture {
 
   static bool GInjected;
   static std::string GInjectedProcess;
-  static int GCapturePort;
-  static std::string GCaptureHost;
   static std::string GPresetToLoad;  // TODO: allow multiple presets
   static std::string GProcessToInject;
   static bool GIsSampling;

--- a/OrbitCore/ConnectionManager.cpp
+++ b/OrbitCore/ConnectionManager.cpp
@@ -147,7 +147,7 @@ void ConnectionManager::StartCaptureAsRemote(uint32_t pid) {
   Capture::SetTargetProcess(process);
   tracing_session_.Reset();
   string_manager_->Clear();
-  Capture::StartCapture(&tracing_session_);
+  Capture::StartCapture(&tracing_session_, "" /* remote_address */);
   server_capture_thread_ =
       std::thread{[this]() { ServerCaptureThreadWorker(); }};
 }

--- a/OrbitCore/Injection.cpp
+++ b/OrbitCore/Injection.cpp
@@ -53,7 +53,8 @@ void* Injection::RemoteWrite(const char* data, size_t size) {
 }
 
 //-----------------------------------------------------------------------------
-bool Injection::Inject(const std::string& a_DllName, const Process& a_Process,
+bool Injection::Inject(std::string_view a_RemoteAddress,
+                       const std::string& a_DllName, const Process& a_Process,
                        const std::string& ProcName) {
   SCOPE_TIMER_LOG(
       absl::StrFormat("Injecting in %s", a_Process.GetName().c_str()));
@@ -111,11 +112,9 @@ bool Injection::Inject(const std::string& a_DllName, const Process& a_Process,
   }
 
   // Remote write the host and port number
-  std::string hostString =
-      Capture::GCaptureHost + ":" + std::to_string(Capture::GCapturePort);
-  ORBIT_LOG(absl::StrFormat("Capture port: %i", Capture::GCapturePort));
-  void* hostStringAddress = RemoteWrite(hostString);
-  PRINT_VAR(hostString);
+  ORBIT_LOG(absl::StrFormat("Capture remote address: %s", a_RemoteAddress));
+  void* hostStringAddress = RemoteWrite(std::string(a_RemoteAddress));
+  PRINT_VAR(a_RemoteAddress);
   if (hostStringAddress == nullptr) {
     return false;
   }
@@ -744,7 +743,8 @@ GRPA_FAIL_JMP:
 #else
 
 Injection::Injection() {}
-bool Injection::Inject(const std::string& /*dll_name*/, const Process&,
+bool Injection::Inject(std::string_view /*a_RemoteAddress*/,
+                       const std::string& /*dll_name*/, const Process&,
                        const std::string& /*proc_name*/) {
   return false;
 }

--- a/OrbitCore/Injection.h
+++ b/OrbitCore/Injection.h
@@ -12,8 +12,8 @@ class Injection {
  public:
   Injection();
 
-  bool Inject(const std::string& a_Dll, const Process& a_Process,
-              const std::string& ProcName);
+  bool Inject(std::string_view a_RemoteAddress, const std::string& a_Dll,
+              const Process& a_Process, const std::string& ProcName);
   DWORD GetProcessID() const { return m_InjectedProcessID; }
   HANDLE GetProcessHandle() const { return m_InjectedProcessHandle; }
 

--- a/OrbitCore/TcpServer.cpp
+++ b/OrbitCore/TcpServer.cpp
@@ -52,8 +52,8 @@ TcpServer::~TcpServer() {
 }
 
 //-----------------------------------------------------------------------------
-void TcpServer::Start(unsigned short a_Port) {
-  TcpEntity::Start();
+void TcpServer::StartServer(uint16_t a_Port) {
+  Start();
 
   PRINT_FUNC;
   m_TcpService = new TcpService();
@@ -65,6 +65,7 @@ void TcpServer::Start(unsigned short a_Port) {
 
   m_StatTimer.Start();
   m_IsValid = true;
+  m_Port = a_Port;
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitCore/TcpServer.h
+++ b/OrbitCore/TcpServer.h
@@ -16,8 +16,7 @@ class TcpServer : public TcpEntity {
   TcpServer();
   ~TcpServer();
 
-  using TcpEntity::Start;
-  void Start(unsigned short a_Port);
+  void StartServer(uint16_t port);
 
   void Receive(const Message& a_Message);
 
@@ -37,6 +36,8 @@ class TcpServer : public TcpEntity {
   class tcp_server* GetServer() {
     return m_TcpServer;
   }
+
+  uint16_t GetPort() const { return m_Port; }
 
   void ResetStats();
   std::vector<std::string> GetStats();
@@ -64,6 +65,8 @@ class TcpServer : public TcpEntity {
   uint32_t m_NumTargetFlushedEntries;
   uint32_t m_NumTargetFlushedTcpPackets;
   ULONG64 m_NumMessagesFromPreviousSession;
+
+  uint16_t m_Port;
 };
 
 extern std::unique_ptr<TcpServer> GTcpServer;

--- a/OrbitCore/Variable.cpp
+++ b/OrbitCore/Variable.cpp
@@ -25,7 +25,7 @@ void Variable::SetType(const std::string& a_Type) {
 }
 
 void Variable::SendValue() {
-  if (Capture::Connect()) {
+  if (Capture::GInjected) {
     Message msg(Msg_SetData);
     msg.m_Header.m_DataTransferHeader.m_Address =
         (ULONG64)GPdbDbg->GetHModule() + (ULONG64)m_Address;
@@ -35,7 +35,7 @@ void Variable::SendValue() {
 }
 
 void Variable::SyncValue() {
-  if (Capture::Connect()) {
+  if (Capture::GInjected) {
     Message msg(Msg_GetData);
     ULONG64 address = (ULONG64)m_Pdb->GetHModule() + (ULONG64)m_Address;
     msg.m_Header.m_DataTransferHeader.m_Address = address;

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -111,8 +111,7 @@ void OrbitApp::SetCommandLineArguments(const std::vector<std::string>& a_Args) {
 
   for (const std::string& arg : a_Args) {
     if (absl::StrContains(arg, "gamelet:")) {
-      std::string address = Replace(arg, "gamelet:", "");
-      Capture::GCaptureHost = address;
+      remote_address_ = Replace(arg, "gamelet:", "");
 
       GTcpClient = std::make_unique<TcpClient>();
       GTcpClient->AddMainThreadCallback(
@@ -121,7 +120,7 @@ void OrbitApp::SetCommandLineArguments(const std::vector<std::string>& a_Args) {
       GTcpClient->AddMainThreadCallback(
           Msg_RemoteProcessList,
           [=](const Message& a_Msg) { GOrbitApp->OnRemoteProcessList(a_Msg); });
-      ConnectionManager::Get().ConnectToRemote(address);
+      ConnectionManager::Get().ConnectToRemote(remote_address_);
       m_ProcessesDataView->SetIsRemote(true);
       SetIsRemote(true);
     } else if (absl::StrContains(arg, "headless")) {
@@ -326,10 +325,6 @@ bool OrbitApp::Init() {
 
   GPluginManager.Initialize();
 
-  if (Capture::IsOtherInstanceRunning()) {
-    ++Capture::GCapturePort;
-  }
-
   GParams.Load();
   GFontSize = GParams.m_FontSize;
   GOrbitApp->LoadFileMapping();
@@ -339,12 +334,11 @@ bool OrbitApp::Init() {
 
 //-----------------------------------------------------------------------------
 void OrbitApp::PostInit() {
+  // We do not run tcp server on the client anymore
+  CHECK(!HasTcpServer());
+
   string_manager_ = std::make_shared<StringManager>();
   GCurrentTimeGraph->SetStringManager(string_manager_);
-
-  if (HasTcpServer()) {
-    GTcpServer->Start(Capture::GCapturePort);
-  }
 
   for (std::string& arg : m_PostInitArguments) {
     if (absl::StrContains(arg, "systrace:")) {
@@ -484,7 +478,9 @@ void OrbitApp::ClearWatchedVariables() {
 
 //-----------------------------------------------------------------------------
 void OrbitApp::RefreshWatch() {
-  Capture::GTargetProcess->RefreshWatchedVariables();
+  if (Capture::Connect(remote_address_)) {
+    Capture::GTargetProcess->RefreshWatchedVariables();
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -534,6 +530,7 @@ int OrbitApp::OnExit() {
 Timer GMainTimer;
 
 //-----------------------------------------------------------------------------
+// TODO: make it non-static
 void OrbitApp::MainTick() {
   ORBIT_SCOPE_FUNC;
   TRACE_VAR(GMainTimer.QueryMillis());
@@ -551,9 +548,9 @@ void OrbitApp::MainTick() {
   if (!Capture::GProcessToInject.empty()) {
     std::cout << "Injecting into " << Capture::GTargetProcess->GetFullName()
               << std::endl;
-    std::cout << "Orbit host: " << Capture::GCaptureHost << std::endl;
+    std::cout << "Orbit host: " << GOrbitApp->remote_address_ << std::endl;
     GOrbitApp->SelectProcess(Capture::GProcessToInject);
-    Capture::InjectRemote();
+    Capture::InjectRemote(GOrbitApp->remote_address_);
     exit(0);
   }
 
@@ -849,7 +846,7 @@ void OrbitApp::AddUiMessageCallback(
 void OrbitApp::StartCapture() {
   // Tracing session is only needed when StartCapture is
   // running on the service side
-  Capture::StartCapture(nullptr /* tracing_session */);
+  Capture::StartCapture(nullptr /* tracing_session */, remote_address_);
 
   if (m_NeedsThawing) {
 #ifdef _WIN32
@@ -906,7 +903,7 @@ bool OrbitApp::SelectProcess(uint32_t a_ProcessID) {
 //-----------------------------------------------------------------------------
 bool OrbitApp::Inject(unsigned long a_ProcessId) {
   if (SelectProcess(a_ProcessId)) {
-    return Capture::Inject();
+    return Capture::Inject(remote_address_);
   }
 
   return false;

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -213,6 +213,7 @@ class OrbitApp : public CoreApp {
   ClipboardCallback m_ClipboardCallback;
   bool m_Headless = false;
   bool m_IsRemote = false;
+  std::string remote_address_;
 
   ProcessesDataView* m_ProcessesDataView = nullptr;
   ModulesDataView* m_ModulesDataView = nullptr;

--- a/OrbitService/OrbitService.cpp
+++ b/OrbitService/OrbitService.cpp
@@ -9,13 +9,16 @@
 #include "TcpServer.h"
 #include "TimerManager.h"
 
+// TODO: we should probably make it configurable
+constexpr uint32_t kAsioServerPort = 44766;
+
 OrbitService::OrbitService() {
   // TODO: these should be a private fields.
   GTimerManager = std::make_unique<TimerManager>();
   GTcpServer = std::make_unique<TcpServer>();
   Capture::Init();
 
-  GTcpServer->Start(Capture::GCapturePort);
+  GTcpServer->StartServer(kAsioServerPort);
   ConnectionManager::Get().InitAsService();
 
   core_app_ = std::make_unique<CoreApp>();


### PR DESCRIPTION
The connection string is now being held by GOrbitApp on the client side and TcpServer on the server side. 

Test: build on linux and windows