### PR TITLE
Move gamelet command-line option to main.cpp

### DIFF
--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -47,8 +47,6 @@ ULONG64 Capture::GMainFrameFunction;
 uint64_t Capture::GNumContextSwitches;
 ULONG64 Capture::GNumLinuxEvents;
 ULONG64 Capture::GNumProfileEvents;
-int Capture::GCapturePort = 0;
-std::string Capture::GCaptureHost = "localhost";
 std::string Capture::GPresetToLoad = "";
 std::string Capture::GProcessToInject = "";
 
@@ -84,44 +82,44 @@ void* Capture::sampling_done_callback_user_data_ = nullptr;
 //-----------------------------------------------------------------------------
 void Capture::Init() {
   GTargetProcess = std::make_shared<Process>();
-  Capture::GCapturePort = GParams.m_Port;
 }
 
 //-----------------------------------------------------------------------------
-bool Capture::Inject(bool a_WaitForConnection) {
+bool Capture::Inject(std::string_view remote_address) {
   Injection inject;
   std::string dllName = Path::GetDllPath(GTargetProcess->GetIs64Bit());
 
   GTcpServer->Disconnect();
 
-  GInjected = inject.Inject(dllName, *GTargetProcess, "OrbitInit");
+  GInjected =
+      inject.Inject(remote_address, dllName, *GTargetProcess, "OrbitInit");
   if (GInjected) {
     ORBIT_LOG(
         absl::StrFormat("Injected in %s", GTargetProcess->GetName().c_str()));
     GInjectedProcess = GTargetProcess->GetName();
   }
 
-  if (a_WaitForConnection) {
-    int numTries = 50;
-    while (!GTcpServer->HasConnection() && numTries-- > 0) {
-      ORBIT_LOG(absl::StrFormat("Waiting for connection on port %i",
-                                Capture::GCapturePort));
-      Sleep(100);
-    }
-
-    GInjected = GInjected && GTcpServer->HasConnection();
+  // Wait for connections
+  int numTries = 50;
+  while (!GTcpServer->HasConnection() && numTries-- > 0) {
+    ORBIT_LOG(absl::StrFormat("Waiting for connection on port %i",
+                              GTcpServer->GetPort()));
+    Sleep(100);
   }
+
+  GInjected = GInjected && GTcpServer->HasConnection();
 
   return GInjected;
 }
 
 //-----------------------------------------------------------------------------
-bool Capture::InjectRemote() {
+bool Capture::InjectRemote(std::string_view remote_address) {
   Injection inject;
   std::string dllName = Path::GetDllPath(GTargetProcess->GetIs64Bit());
   GTcpServer->Disconnect();
 
-  GInjected = inject.Inject(dllName, *GTargetProcess, "OrbitInitRemote");
+  GInjected = inject.Inject(remote_address, dllName, *GTargetProcess,
+                            "OrbitInitRemote");
 
   if (GInjected) {
     ORBIT_LOG(
@@ -148,16 +146,20 @@ void Capture::SetTargetProcess(const std::shared_ptr<Process>& a_Process) {
 }
 
 //-----------------------------------------------------------------------------
-bool Capture::Connect() {
+bool Capture::Connect(std::string_view remote_address) {
   if (!GInjected) {
-    Inject();
+    Inject(remote_address);
   }
 
   return GInjected;
 }
 
 //-----------------------------------------------------------------------------
-bool Capture::StartCapture(LinuxTracingSession* session) {
+// TODO: This method is resposible for too many things. We probably want to
+// split the server side logic and client side logic into separate
+// methods/classes.
+bool Capture::StartCapture(LinuxTracingSession* session,
+                           std::string_view remote_address) {
   SCOPE_TIMER_LOG("Capture::StartCapture");
 
   if (GTargetProcess->GetName().size() == 0) return false;
@@ -167,7 +169,7 @@ bool Capture::StartCapture(LinuxTracingSession* session) {
 
 #ifdef WIN32
   if (!IsRemote()) {
-    if (!Connect()) {
+    if (!Connect(remote_address)) {
       return false;
     }
   }
@@ -187,6 +189,7 @@ bool Capture::StartCapture(LinuxTracingSession* session) {
 #else
     CHECK(session != nullptr);
     GEventTracer.Start(GTargetProcess->GetID(), session);
+    UNUSED(remote_address);
 #endif
   } else if (Capture::IsRemote()) {
     Capture::NewSamplingProfiler();
@@ -478,20 +481,6 @@ void Capture::DisplayStats() {
 }
 
 //-----------------------------------------------------------------------------
-bool Capture::IsOtherInstanceRunning() {
-#ifdef _WIN32
-  DWORD procID = 0;
-  HANDLE procHandle = Injection::GetTargetProcessHandle(ORBIT_EXE_NAME, procID);
-  PRINT_FUNC;
-  bool otherInstanceFound = procHandle != NULL;
-  PRINT_VAR(otherInstanceFound);
-  return otherInstanceFound;
-#else
-  return false;
-#endif
-}
-
-//-----------------------------------------------------------------------------
 void Capture::SaveSession(const std::string& a_FileName) {
   Session session;
   session.m_ProcessFullPath = GTargetProcess->GetFullPath();
@@ -535,13 +524,6 @@ bool Capture::IsTrackingEvents() {
 #ifdef __linux
   return !IsRemote();
 #else
-  static bool yieldEvents = false;
-  if (yieldEvents && IsOtherInstanceRunning() && GTargetProcess) {
-    if (absl::StrContains(GTargetProcess->GetName(), "Orbit.exe")) {
-      return false;
-    }
-  }
-
   if (GTargetProcess->GetIsRemote() && !GTcpServer->IsLocalConnection()) {
     return false;
   }

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -20,11 +20,15 @@ struct CallStack;
 class Capture {
  public:
   static void Init();
-  static bool Inject(bool a_WaitForConnection = true);
-  static bool Connect();
-  static bool InjectRemote();
+  static bool Inject(std::string_view remote_address);
+  static bool Connect(std::string_view remote_address);
+  static bool InjectRemote(std::string_view remote_address);
   static void SetTargetProcess(const std::shared_ptr<Process>& a_Process);
-  static bool StartCapture(LinuxTracingSession* session);
+  // TODO: This method needs to be split into 2, the server side and the
+  // client-side. session here is only used by the server side and
+  // remote_address is only used by the client-side.
+  static bool StartCapture(LinuxTracingSession* session,
+                           std::string_view remote_address);
   static void StopCapture();
   static void ClearCaptureData();
   static std::vector<std::shared_ptr<Function>> GetSelectedFunctions();
@@ -37,7 +41,6 @@ class Capture {
   static void Update();
   static void DisplayStats();
   static void TestHooks();
-  static bool IsOtherInstanceRunning();
   static void SaveSession(const std::string& a_FileName);
   static void NewSamplingProfiler();
   static bool IsTrackingEvents();
@@ -69,8 +72,6 @@ class Capture {
 
   static bool GInjected;
   static std::string GInjectedProcess;
-  static int GCapturePort;
-  static std::string GCaptureHost;
   static std::string GPresetToLoad;  // TODO: allow multiple presets
   static std::string GProcessToInject;
   static bool GIsSampling;

--- a/OrbitCore/ConnectionManager.cpp
+++ b/OrbitCore/ConnectionManager.cpp
@@ -147,7 +147,9 @@ void ConnectionManager::StartCaptureAsRemote(uint32_t pid) {
   Capture::SetTargetProcess(process);
   tracing_session_.Reset();
   string_manager_->Clear();
-  Capture::StartCapture(&tracing_session_);
+  // The remote address is only used when StartCapture is called
+  // from the client side. It is not used for the server side code.
+  Capture::StartCapture(&tracing_session_, "" /* remote_address */);
   server_capture_thread_ =
       std::thread{[this]() { ServerCaptureThreadWorker(); }};
 }

--- a/OrbitCore/Injection.cpp
+++ b/OrbitCore/Injection.cpp
@@ -53,7 +53,8 @@ void* Injection::RemoteWrite(const char* data, size_t size) {
 }
 
 //-----------------------------------------------------------------------------
-bool Injection::Inject(const std::string& a_DllName, const Process& a_Process,
+bool Injection::Inject(std::string_view a_RemoteAddress,
+                       const std::string& a_DllName, const Process& a_Process,
                        const std::string& ProcName) {
   SCOPE_TIMER_LOG(
       absl::StrFormat("Injecting in %s", a_Process.GetName().c_str()));
@@ -111,11 +112,9 @@ bool Injection::Inject(const std::string& a_DllName, const Process& a_Process,
   }
 
   // Remote write the host and port number
-  std::string hostString =
-      Capture::GCaptureHost + ":" + std::to_string(Capture::GCapturePort);
-  ORBIT_LOG(absl::StrFormat("Capture port: %i", Capture::GCapturePort));
-  void* hostStringAddress = RemoteWrite(hostString);
-  PRINT_VAR(hostString);
+  ORBIT_LOG(absl::StrFormat("Capture remote address: %s", a_RemoteAddress));
+  void* hostStringAddress = RemoteWrite(std::string(a_RemoteAddress));
+  PRINT_VAR(a_RemoteAddress);
   if (hostStringAddress == nullptr) {
     return false;
   }
@@ -744,7 +743,8 @@ GRPA_FAIL_JMP:
 #else
 
 Injection::Injection() {}
-bool Injection::Inject(const std::string& /*dll_name*/, const Process&,
+bool Injection::Inject(std::string_view /*a_RemoteAddress*/,
+                       const std::string& /*dll_name*/, const Process&,
                        const std::string& /*proc_name*/) {
   return false;
 }

--- a/OrbitCore/Injection.h
+++ b/OrbitCore/Injection.h
@@ -12,8 +12,8 @@ class Injection {
  public:
   Injection();
 
-  bool Inject(const std::string& a_Dll, const Process& a_Process,
-              const std::string& ProcName);
+  bool Inject(std::string_view a_RemoteAddress, const std::string& a_Dll,
+              const Process& a_Process, const std::string& ProcName);
   DWORD GetProcessID() const { return m_InjectedProcessID; }
   HANDLE GetProcessHandle() const { return m_InjectedProcessHandle; }
 

--- a/OrbitCore/TcpServer.cpp
+++ b/OrbitCore/TcpServer.cpp
@@ -52,8 +52,8 @@ TcpServer::~TcpServer() {
 }
 
 //-----------------------------------------------------------------------------
-void TcpServer::Start(unsigned short a_Port) {
-  TcpEntity::Start();
+void TcpServer::StartServer(uint16_t a_Port) {
+  Start();
 
   PRINT_FUNC;
   m_TcpService = new TcpService();
@@ -65,6 +65,7 @@ void TcpServer::Start(unsigned short a_Port) {
 
   m_StatTimer.Start();
   m_IsValid = true;
+  m_Port = a_Port;
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitCore/TcpServer.h
+++ b/OrbitCore/TcpServer.h
@@ -16,8 +16,7 @@ class TcpServer : public TcpEntity {
   TcpServer();
   ~TcpServer();
 
-  using TcpEntity::Start;
-  void Start(unsigned short a_Port);
+  void StartServer(uint16_t port);
 
   void Receive(const Message& a_Message);
 
@@ -37,6 +36,8 @@ class TcpServer : public TcpEntity {
   class tcp_server* GetServer() {
     return m_TcpServer;
   }
+
+  uint16_t GetPort() const { return m_Port; }
 
   void ResetStats();
   std::vector<std::string> GetStats();
@@ -64,6 +65,8 @@ class TcpServer : public TcpEntity {
   uint32_t m_NumTargetFlushedEntries;
   uint32_t m_NumTargetFlushedTcpPackets;
   ULONG64 m_NumMessagesFromPreviousSession;
+
+  uint16_t m_Port;
 };
 
 extern std::unique_ptr<TcpServer> GTcpServer;

--- a/OrbitCore/Variable.cpp
+++ b/OrbitCore/Variable.cpp
@@ -25,7 +25,7 @@ void Variable::SetType(const std::string& a_Type) {
 }
 
 void Variable::SendValue() {
-  if (Capture::Connect()) {
+  if (Capture::GInjected) {
     Message msg(Msg_SetData);
     msg.m_Header.m_DataTransferHeader.m_Address =
         (ULONG64)GPdbDbg->GetHModule() + (ULONG64)m_Address;
@@ -35,7 +35,7 @@ void Variable::SendValue() {
 }
 
 void Variable::SyncValue() {
-  if (Capture::Connect()) {
+  if (Capture::GInjected) {
     Message msg(Msg_GetData);
     ULONG64 address = (ULONG64)m_Pdb->GetHModule() + (ULONG64)m_Address;
     msg.m_Header.m_DataTransferHeader.m_Address = address;

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -79,10 +79,10 @@ float GFontSize;
 bool DoZoom = false;
 
 //-----------------------------------------------------------------------------
-OrbitApp::OrbitApp() {
-  m_Debugger = nullptr;
+OrbitApp::OrbitApp(ApplicationOptions&& options)
+    : options_(std::move(options)) {
 #ifdef _WIN32
-  m_Debugger = new Debugger();
+  m_Debugger = std::make_unique<Debugger>();
 #endif
 }
 
@@ -90,7 +90,6 @@ OrbitApp::OrbitApp() {
 OrbitApp::~OrbitApp() {
 #ifdef _WIN32
   oqpi_tk::stop_scheduler();
-  delete m_Debugger;
 #endif
 }
 
@@ -110,20 +109,7 @@ void OrbitApp::SetCommandLineArguments(const std::vector<std::string>& a_Args) {
   m_Arguments = a_Args;
 
   for (const std::string& arg : a_Args) {
-    if (absl::StrContains(arg, "gamelet:")) {
-      remote_address_ = Replace(arg, "gamelet:", "");
-
-      GTcpClient = std::make_unique<TcpClient>();
-      GTcpClient->AddMainThreadCallback(
-          Msg_RemoteProcess,
-          [=](const Message& a_Msg) { GOrbitApp->OnRemoteProcess(a_Msg); });
-      GTcpClient->AddMainThreadCallback(
-          Msg_RemoteProcessList,
-          [=](const Message& a_Msg) { GOrbitApp->OnRemoteProcessList(a_Msg); });
-      ConnectionManager::Get().ConnectToRemote(remote_address_);
-      m_ProcessesDataView->SetIsRemote(true);
-      SetIsRemote(true);
-    } else if (absl::StrContains(arg, "preset:")) {
+    if (absl::StrContains(arg, "preset:")) {
       std::vector<std::string> vec = Tokenize(arg, ":");
       if (vec.size() > 1) {
         Capture::GPresetToLoad = vec[1];
@@ -300,9 +286,10 @@ void OrbitApp::AppendSystrace(const std::string& a_FileName,
 }
 
 //-----------------------------------------------------------------------------
-bool OrbitApp::Init() {
-  GOrbitApp = std::make_unique<OrbitApp>();
+bool OrbitApp::Init(ApplicationOptions&& options) {
+  GOrbitApp = std::make_unique<OrbitApp>(std::move(options));
   GCoreApp = GOrbitApp.get();
+
   GTimerManager = std::make_unique<TimerManager>();
   GTcpServer = std::make_unique<TcpServer>();
 
@@ -332,8 +319,18 @@ bool OrbitApp::Init() {
 
 //-----------------------------------------------------------------------------
 void OrbitApp::PostInit() {
-  // We do not run tcp server on the client anymore
-  CHECK(!HasTcpServer());
+  if (!options_.asio_server_address.empty()) {
+    GTcpClient = std::make_unique<TcpClient>();
+    GTcpClient->AddMainThreadCallback(
+        Msg_RemoteProcess,
+        [=](const Message& a_Msg) { GOrbitApp->OnRemoteProcess(a_Msg); });
+    GTcpClient->AddMainThreadCallback(
+        Msg_RemoteProcessList,
+        [=](const Message& a_Msg) { GOrbitApp->OnRemoteProcessList(a_Msg); });
+    ConnectionManager::Get().ConnectToRemote(options_.asio_server_address);
+    m_ProcessesDataView->SetIsRemote(true);
+    SetIsRemote(true);
+  }
 
   string_manager_ = std::make_shared<StringManager>();
   GCurrentTimeGraph->SetStringManager(string_manager_);
@@ -472,7 +469,7 @@ void OrbitApp::ClearWatchedVariables() {
 
 //-----------------------------------------------------------------------------
 void OrbitApp::RefreshWatch() {
-  if (Capture::Connect(remote_address_)) {
+  if (Capture::Connect(options_.asio_server_address)) {
     Capture::GTargetProcess->RefreshWatchedVariables();
   }
 }
@@ -533,7 +530,14 @@ void OrbitApp::MainTick() {
   if (GTcpClient) GTcpClient->ProcessMainThreadCallbacks();
 
   // Tick Transaction manager only from client (OrbitApp is client only);
-  GOrbitApp->GetTransactionManager()->Tick();
+  auto transaction_manager = GOrbitApp->GetTransactionManager();
+
+  // Note that MainTick could be called before OrbitApp::PostInit() was complete
+  // in which case translaction namager is not yet initialized - check that it
+  // is not null before calling it.
+  if (transaction_manager != nullptr) {
+    transaction_manager->Tick();
+  }
 
   GMainTimer.Reset();
   Capture::Update();
@@ -542,9 +546,10 @@ void OrbitApp::MainTick() {
   if (!Capture::GProcessToInject.empty()) {
     std::cout << "Injecting into " << Capture::GTargetProcess->GetFullPath()
               << std::endl;
-    std::cout << "Orbit host: " << GOrbitApp->remote_address_ << std::endl;
+    std::cout << "Orbit host: " << GOrbitApp->options_.asio_server_address
+              << std::endl;
     GOrbitApp->SelectProcess(Capture::GProcessToInject);
-    Capture::InjectRemote(GOrbitApp->remote_address_);
+    Capture::InjectRemote(GOrbitApp->options_.asio_server_address);
     exit(0);
   }
 
@@ -839,7 +844,8 @@ void OrbitApp::AddUiMessageCallback(
 void OrbitApp::StartCapture() {
   // Tracing session is only needed when StartCapture is
   // running on the service side
-  Capture::StartCapture(nullptr /* tracing_session */, remote_address_);
+  Capture::StartCapture(nullptr /* tracing_session */,
+                        options_.asio_server_address);
 
   if (m_NeedsThawing) {
 #ifdef _WIN32
@@ -896,7 +902,7 @@ bool OrbitApp::SelectProcess(uint32_t a_ProcessID) {
 //-----------------------------------------------------------------------------
 bool OrbitApp::Inject(unsigned long a_ProcessId) {
   if (SelectProcess(a_ProcessId)) {
-    return Capture::Inject(remote_address_);
+    return Capture::Inject(options_.asio_server_address);
   }
 
   return false;

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -111,8 +111,7 @@ void OrbitApp::SetCommandLineArguments(const std::vector<std::string>& a_Args) {
 
   for (const std::string& arg : a_Args) {
     if (absl::StrContains(arg, "gamelet:")) {
-      std::string address = Replace(arg, "gamelet:", "");
-      Capture::GCaptureHost = address;
+      remote_address_ = Replace(arg, "gamelet:", "");
 
       GTcpClient = std::make_unique<TcpClient>();
       GTcpClient->AddMainThreadCallback(
@@ -121,7 +120,7 @@ void OrbitApp::SetCommandLineArguments(const std::vector<std::string>& a_Args) {
       GTcpClient->AddMainThreadCallback(
           Msg_RemoteProcessList,
           [=](const Message& a_Msg) { GOrbitApp->OnRemoteProcessList(a_Msg); });
-      ConnectionManager::Get().ConnectToRemote(address);
+      ConnectionManager::Get().ConnectToRemote(remote_address_);
       m_ProcessesDataView->SetIsRemote(true);
       SetIsRemote(true);
     } else if (absl::StrContains(arg, "headless")) {
@@ -326,10 +325,6 @@ bool OrbitApp::Init() {
 
   GPluginManager.Initialize();
 
-  if (Capture::IsOtherInstanceRunning()) {
-    ++Capture::GCapturePort;
-  }
-
   GParams.Load();
   GFontSize = GParams.m_FontSize;
   GOrbitApp->LoadFileMapping();
@@ -339,12 +334,11 @@ bool OrbitApp::Init() {
 
 //-----------------------------------------------------------------------------
 void OrbitApp::PostInit() {
+  // We do not run tcp server on the client anymore
+  CHECK(!HasTcpServer());
+
   string_manager_ = std::make_shared<StringManager>();
   GCurrentTimeGraph->SetStringManager(string_manager_);
-
-  if (HasTcpServer()) {
-    GTcpServer->Start(Capture::GCapturePort);
-  }
 
   for (std::string& arg : m_PostInitArguments) {
     if (absl::StrContains(arg, "systrace:")) {
@@ -484,7 +478,9 @@ void OrbitApp::ClearWatchedVariables() {
 
 //-----------------------------------------------------------------------------
 void OrbitApp::RefreshWatch() {
-  Capture::GTargetProcess->RefreshWatchedVariables();
+  if (Capture::Connect(remote_address_)) {
+    Capture::GTargetProcess->RefreshWatchedVariables();
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -534,6 +530,7 @@ int OrbitApp::OnExit() {
 Timer GMainTimer;
 
 //-----------------------------------------------------------------------------
+// TODO: make it non-static
 void OrbitApp::MainTick() {
   ORBIT_SCOPE_FUNC;
   TRACE_VAR(GMainTimer.QueryMillis());
@@ -551,9 +548,9 @@ void OrbitApp::MainTick() {
   if (!Capture::GProcessToInject.empty()) {
     std::cout << "Injecting into " << Capture::GTargetProcess->GetFullPath()
               << std::endl;
-    std::cout << "Orbit host: " << Capture::GCaptureHost << std::endl;
+    std::cout << "Orbit host: " << GOrbitApp->remote_address_ << std::endl;
     GOrbitApp->SelectProcess(Capture::GProcessToInject);
-    Capture::InjectRemote();
+    Capture::InjectRemote(GOrbitApp->remote_address_);
     exit(0);
   }
 
@@ -848,7 +845,7 @@ void OrbitApp::AddUiMessageCallback(
 void OrbitApp::StartCapture() {
   // Tracing session is only needed when StartCapture is
   // running on the service side
-  Capture::StartCapture(nullptr /* tracing_session */);
+  Capture::StartCapture(nullptr /* tracing_session */, remote_address_);
 
   if (m_NeedsThawing) {
 #ifdef _WIN32
@@ -905,7 +902,7 @@ bool OrbitApp::SelectProcess(uint32_t a_ProcessID) {
 //-----------------------------------------------------------------------------
 bool OrbitApp::Inject(unsigned long a_ProcessId) {
   if (SelectProcess(a_ProcessId)) {
-    return Capture::Inject();
+    return Capture::Inject(remote_address_);
   }
 
   return false;

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -123,8 +123,6 @@ void OrbitApp::SetCommandLineArguments(const std::vector<std::string>& a_Args) {
       ConnectionManager::Get().ConnectToRemote(remote_address_);
       m_ProcessesDataView->SetIsRemote(true);
       SetIsRemote(true);
-    } else if (absl::StrContains(arg, "headless")) {
-      SetHeadless(true);
     } else if (absl::StrContains(arg, "preset:")) {
       std::vector<std::string> vec = Tokenize(arg, ":");
       if (vec.size() > 1) {
@@ -355,14 +353,10 @@ void OrbitApp::PostInit() {
     }
   }
 
-  if (!GOrbitApp->GetHeadless()) {
-    int my_argc = 0;
-    glutInit(&my_argc, NULL);
-    glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH);
-    GetDesktopResolution(GOrbitApp->m_ScreenRes[0], GOrbitApp->m_ScreenRes[1]);
-  } else {
-    ConnectionManager::Get().InitAsService();
-  }
+  int my_argc = 0;
+  glutInit(&my_argc, NULL);
+  glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH);
+  GetDesktopResolution(GOrbitApp->m_ScreenRes[0], GOrbitApp->m_ScreenRes[1]);
 
   GOrbitApp->InitializeManagers();
 }

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -191,8 +191,6 @@ class OrbitApp : public CoreApp {
   void ApplySession(const Session& session) override;
   void LoadSession(const std::shared_ptr<Session>& session);
   void LaunchRuleEditor(class Function* a_Function);
-  void SetHeadless(bool a_Headless) { m_Headless = a_Headless; }
-  bool GetHeadless() const { return m_Headless; }
   void SetIsRemote(bool a_IsRemote) { m_IsRemote = a_IsRemote; }
   bool IsRemote() const { return m_IsRemote; }
   bool HasTcpServer() const { return !IsRemote(); }
@@ -212,7 +210,6 @@ class OrbitApp : public CoreApp {
   FindFileCallback m_FindFileCallback;
   SaveFileCallback m_SaveFileCallback;
   ClipboardCallback m_ClipboardCallback;
-  bool m_Headless = false;
   bool m_IsRemote = false;
   std::string remote_address_;
 

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -214,6 +214,7 @@ class OrbitApp : public CoreApp {
   ClipboardCallback m_ClipboardCallback;
   bool m_Headless = false;
   bool m_IsRemote = false;
+  std::string remote_address_;
 
   ProcessesDataView* m_ProcessesDataView = nullptr;
   ModulesDataView* m_ModulesDataView = nullptr;

--- a/OrbitGl/ApplicationOptions.h
+++ b/OrbitGl/ApplicationOptions.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORIBIT_GL_APPLICATION_OPTIONS_H_
+#define ORIBIT_GL_APPLICATION_OPTIONS_H_
+
+#include <string>
+
+// The structure used to store Orbit Client Application options
+// The default values are set by main() and passed over to App
+// class initialization method.
+struct ApplicationOptions {
+  // The host and port of the collection service
+  std::string asio_server_address;
+};
+
+#endif  // ORIBIT_GL_APPLICATION_OPTIONS_H_

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -7,7 +7,8 @@
 #include <QFontDatabase>
 #include <QStyleFactory>
 
-#include "../OrbitGl/App.h"
+#include "App.h"
+#include "ApplicationOptions.h"
 #include "CrashHandler.h"
 #include "OrbitStartupWindow.h"
 #include "Path.h"
@@ -20,6 +21,25 @@
 ABSL_FLAG(bool, upload_dumps_to_server, false,
           "Upload dumps to collection server when crashes");
 
+ABSL_FLAG(std::string, remote, "",
+          "Connect to the specified remote on startup");
+
+constexpr const uint16_t kDefaultAsioPort = 44766;
+
+// TODO: remove this once we deprecated legacy parameters
+static void ParseLegacyCommandLine(int argc, char* argv[],
+                                   ApplicationOptions* options) {
+  for (size_t i = 0; i < static_cast<size_t>(argc); ++i) {
+    const char* arg = argv[i];
+    if (absl::StartsWith(arg, "gamelet:")) {
+      std::cerr << "WARNING: the 'gamelet:<host>:<port>' option is deprecated, "
+                   "please use --gamelet <host> instead."
+                << std::endl;
+      options->asio_server_address = arg + std::strlen("gamelet:");
+    }
+  }
+}
+
 int main(int argc, char* argv[]) {
   absl::SetProgramUsageMessage("CPU Profiler");
   absl::ParseCommandLine(argc, argv);
@@ -27,7 +47,7 @@ int main(int argc, char* argv[]) {
   QCoreApplication::setAttribute(Qt::AA_DontUseNativeDialogs);
 #endif
 
-  QApplication a(argc, argv);
+  QApplication app(argc, argv);
 
   const std::string dump_path = Path::GetDumpPath();
 #ifdef _WIN32
@@ -43,7 +63,20 @@ int main(int argc, char* argv[]) {
   const CrashHandler crash_handler(dump_path, handler_path, crash_server_url,
                                    absl::GetFlag(FLAGS_upload_dumps_to_server));
 
-  a.setStyle(QStyleFactory::create("Fusion"));
+  ApplicationOptions options;
+
+  ParseLegacyCommandLine(argc, argv, &options);
+  std::string remote = absl::GetFlag(FLAGS_remote);
+  if (!remote.empty()) {
+    // Append default port only if the user has not specified one
+    if (!absl::StrContains(remote, ":")) {
+      remote = absl::StrFormat("%s:%d", remote, kDefaultAsioPort);
+    }
+
+    options.asio_server_address = remote;
+  }
+
+  app.setStyle(QStyleFactory::create("Fusion"));
 
   QPalette darkPalette;
   darkPalette.setColor(QPalette::Window, QColor(53, 53, 53));
@@ -59,38 +92,31 @@ int main(int argc, char* argv[]) {
   darkPalette.setColor(QPalette::Link, QColor(42, 130, 218));
   darkPalette.setColor(QPalette::Highlight, QColor(42, 130, 218));
   darkPalette.setColor(QPalette::HighlightedText, Qt::black);
-  a.setPalette(darkPalette);
-  a.setStyleSheet(
+  app.setPalette(darkPalette);
+  app.setStyleSheet(
       "QToolTip { color: #ffffff; background-color: #2a82da; border: 1px solid "
       "white; }");
 
-  // TODO(antonrohr) refactor argument parsing; probably use a external argument
-  // parsing library
-  std::vector<std::string> arguments;
-  bool found_gamelet_arg = false;
-  for (const QString& arg : QApplication::arguments()) {
-    if (arg.contains("gamelet:")) found_gamelet_arg = true;
-    arguments.emplace_back(arg.toStdString());
-  }
-
-  if (!found_gamelet_arg) {
+  if (options.asio_server_address.empty()) {
     OrbitStartupWindow sw;
     std::string ip_address;
     int dialog_result = sw.Run(&ip_address);
     if (dialog_result == 0) return 0;
 
 #ifdef __linux__
-    arguments.emplace_back("gamelet:" + ip_address + ":44766");
+    options.asio_server_address =
+        absl::StrFormat("%s:%d", ip_address, kDefaultAsioPort);
 #else
     // TODO(antonrohr) remove this ifdef as soon as the collector works on
     // windows
     if (ip_address != "127.0.0.1") {
-      arguments.emplace_back("gamelet:" + ip_address + ":44766");
+      options.asio_server_address =
+          absl::StrFormat("%s:%d", ip_address, kDefaultAsioPort);
     }
 #endif
   }
 
-  OrbitMainWindow w(arguments, &a);
+  OrbitMainWindow w(&app, std::move(options));
 
   if (!w.IsHeadless()) {
     w.showMaximized();
@@ -101,7 +127,7 @@ int main(int argc, char* argv[]) {
 
   w.PostInit();
 
-  int errorCode = a.exec();
+  int errorCode = app.exec();
 
   OrbitApp::OnExit();
 

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -42,14 +42,14 @@ OrbitMainWindow* GMainWindow;
 extern QMenu* GContextMenu;
 
 //-----------------------------------------------------------------------------
-OrbitMainWindow::OrbitMainWindow(const std::vector<std::string>& arguments,
-                                 QApplication* a_App, QWidget* parent)
-    : QMainWindow(parent),
+OrbitMainWindow::OrbitMainWindow(QApplication* a_App,
+                                 ApplicationOptions&& options)
+    : QMainWindow(nullptr),
       m_App(a_App),
       ui(new Ui::OrbitMainWindow),
       m_Headless(false),
       m_IsDev(false) {
-  OrbitApp::Init();
+  OrbitApp::Init(std::move(options));
 
   ui->setupUi(this);
   ui->ProcessesList->SetProcessParams();
@@ -88,7 +88,7 @@ OrbitMainWindow::OrbitMainWindow(const std::vector<std::string>& arguments,
   GOrbitApp->SetClipboardCallback(
       [this](const std::wstring& a_Text) { this->OnSetClipboard(a_Text); });
 
-  ParseCommandlineArguments(arguments);
+  ParseCommandlineArguments();
 
   ui->DebugGLWidget->Initialize(GlPanel::DEBUG, this);
   ui->CaptureGLWidget->Initialize(GlPanel::CAPTURE, this);
@@ -169,15 +169,19 @@ OrbitMainWindow::~OrbitMainWindow() {
 }
 
 //-----------------------------------------------------------------------------
-void OrbitMainWindow::ParseCommandlineArguments(
-    const std::vector<std::string>& arguments) {
-  for (const std::string& argument : arguments) {
+void OrbitMainWindow::ParseCommandlineArguments() {
+  std::vector<std::string> arguments;
+  for (const auto& qt_argument : QCoreApplication::arguments()) {
+    std::string argument = qt_argument.toStdString();
     if (absl::StrContains(argument, "inject:")) {
       m_Headless = true;
     } else if (argument == "dev") {
       m_IsDev = true;
     }
+
+    arguments.push_back(std::move(argument));
   }
+
   GOrbitApp->SetCommandLineArguments(arguments);
 }
 

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -8,7 +8,8 @@
 #include <memory>
 #include <thread>
 
-#include "../OrbitGl/DataViewTypes.h"
+#include "ApplicationOptions.h"
+#include "DataViewTypes.h"
 
 namespace Ui {
 class OrbitMainWindow;
@@ -18,8 +19,7 @@ class OrbitMainWindow : public QMainWindow {
   Q_OBJECT
 
  public:
-  explicit OrbitMainWindow(const std::vector<std::string>& arguments,
-                           QApplication* a_App, QWidget* parent = nullptr);
+  OrbitMainWindow(QApplication* a_App, ApplicationOptions&& options);
   ~OrbitMainWindow() override;
 
   void RegisterGlWidget(class OrbitGLWidget* a_GlWidget) {
@@ -37,7 +37,7 @@ class OrbitMainWindow : public QMainWindow {
   void OnAddToWatch(const class Variable* a_Variable);
   std::string OnGetSaveFileName(const std::string& extension);
   void OnSetClipboard(const std::wstring& a_Text);
-  void ParseCommandlineArguments(const std::vector<std::string>& arguments);
+  void ParseCommandlineArguments();
   bool IsHeadless() { return m_Headless; }
   void PostInit();
   bool HideTab(QTabWidget* a_TabWidget, const char* a_TabName);

--- a/OrbitService/OrbitService.cpp
+++ b/OrbitService/OrbitService.cpp
@@ -9,13 +9,16 @@
 #include "TcpServer.h"
 #include "TimerManager.h"
 
+// TODO: we should probably make it configurable
+constexpr uint32_t kAsioServerPort = 44766;
+
 OrbitService::OrbitService() {
   // TODO: these should be a private fields.
   GTimerManager = std::make_unique<TimerManager>();
   GTcpServer = std::make_unique<TcpServer>();
   Capture::Init();
 
-  GTcpServer->Start(Capture::GCapturePort);
+  GTcpServer->StartServer(kAsioServerPort);
   ConnectionManager::Get().InitAsService();
 
   core_app_ = std::make_unique<CoreApp>();


### PR DESCRIPTION
This PR contains following changes:
1. Removed GRemoteHist/Port globals - OrbitApp now holds the remote_address.
2. Removed headless option
3. Added ABSL_FLAG after this commit use "--remote address" instead of "gamelet:<address>"
4. Started moving command-line parsing to corresponding main.cpp

Test: Run client with new option - make sure it connects to the server
