### PR TITLE
Rewrote windows helper scripts in powershell

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -18,8 +18,8 @@ You should prefer clang over GCC, since most of the developers build with clang 
 Orbit relies on `conan` as its package manager.  Conan is written in Python3,
 so make sure you have either Conan installed or at least have Python3 installed.
 
-The `bootstrap-orbit.{sh,bat}` will try to install `conan` via `pip3` if not
-installed and reachable via `PATH`. Afterwards it calls `build.{sh,bat}` which
+The `bootstrap-orbit.{sh,ps1}` will try to install `conan` via `pip3` if not
+installed and reachable via `PATH`. Afterwards it calls `build.{sh,ps1}` which
 will compile Orbit for you.
 
 On Linux, `python3` should be preinstalled anyway, but you might need to install
@@ -68,25 +68,25 @@ style.
 
 ## FAQ
 
-### What's the difference between `bootstrap-orbit.{sh,bat}` and `build.{sh,bat}`?
+### What's the difference between `bootstrap-orbit.{sh,ps1}` and `build.{sh,ps1}`?
 
-`bootstrap-orbit.{sh,bat}` performs all the tasks which have to be done once per developer machine.
+`bootstrap-orbit.{sh,ps1}` performs all the tasks which have to be done once per developer machine.
 This includes:
 * Installing system dependencies
 * Installing conan if necessary.
 
-Afterwards `bootstrap-orbit.{sh,bat}` calls `build.{sh,bat}`.
+Afterwards `bootstrap-orbit.{sh,ps1}` calls `build.{sh,ps1}`.
 
-`build.{sh,bat}` on the other hand performs all the tasks which have to be done
+`build.{sh,ps1}` on the other hand performs all the tasks which have to be done
 once per build configuration. It creates a build directory, named after the
 given conan profile, installs the conan-managed dependencies into this build folder,
 calls `cmake` for build configuration and starts the build.
 
-Whenever the dependencies change you have to call `build.{sh,bat}` again.
+Whenever the dependencies change you have to call `build.{sh,ps1}` again.
 A dependency change might be introduced by a pull from upstream or by a switch
 to a different branch.
 
-`build.{sh,bat}` can initialize as many build configurations as you like from the
+`build.{sh,ps1}` can initialize as many build configurations as you like from the
 same invocation. Just pass conan profile names as command line arguments. Example for Linux:
 ```bash
 ./build.sh clang7_debug gcc9_release clang9_relwithdebinfo ggp_release
@@ -97,10 +97,10 @@ same invocation. Just pass conan profile names as command line arguments. Exampl
 ./build.sh ggp_release
 ```
 
-### Calling `build.{sh,bat}` after every one-line-change takes forever! What should I do?
+### Calling `build.{sh,ps1}` after every one-line-change takes forever! What should I do?
 
-`build.{sh,bat}` is not meant for incremental builds. It should be called only once to initialize
-a build directory. (Check out the previous section for more information on what `build.{sh,bat}`
+`build.{sh,ps1}` is not meant for incremental builds. It should be called only once to initialize
+a build directory. (Check out the previous section for more information on what `build.{sh,ps1}`
 does.)
 
 For incremental builds, switch to the build directory and ask cmake to run the build:
@@ -148,7 +148,7 @@ ninja
 
 ### How do I integrate with CLion?
 
-In CLion, the IDE itself manages your build configurations, which is incompatible with our `build.{sh,bat}`
+In CLion, the IDE itself manages your build configurations, which is incompatible with our `build.{sh,ps1}`
 script. That means, you have to manually install conan dependencies into CLion's build directories
 and you have to manually verify that the directory's build configuration matches the used conan profile
 in terms of compiler, standard library, build type, target platform, etc.
@@ -227,7 +227,7 @@ _Note:_ Cross compiling the UI is not supported.
 _Note:_ Since the GGP SDK is not publicly available, this only works inside
 of Google, at least for now.
 
-Call the script `bootstrap-orbit-ggp.{sh,bat}` which creates a package out of the GGP
+Call the script `bootstrap-orbit-ggp.{sh,ps1}` which creates a package out of the GGP
 SDK (you do not need to have the SDK installed for this to work, but you will need it
 for deployment), and compiles Orbit against the toolchain from the GGP SDK package.
 

--- a/bootstrap-orbit-ggp.bat
+++ b/bootstrap-orbit-ggp.bat
@@ -1,51 +1,8 @@
 @echo off
+call powershell "& %~dp0\bootstrap-orbit-ggp.ps1 %*"
 
-SET REPO_ROOT=%~dp0
-
-where /q conan
-if ERRORLEVEL 1 (
-    echo "Conan not found. Trying to install it via python-pip..."
-
-    where /q pip3
-    if ERRORLEVEL 1 (
-        echo "It seems you don't have Python3 installed (pip3.exe not found)."
-        echo "Please install Python or make it available in the path."
-        echo "Alternatively you could also just install conan manually and make"
-        echo "it available in the path."
-        GOTO :EOF
-    )
-
-    pip3 install conan
-    if ERRORLEVEL 1 GOTO :EOF
-
-    where /q conan
-    if ERRORLEVEL 1 (
-        echo "It seems we installed conan sucessfully, but it is not available"
-        echo "in the path. Please ensure that your Python user-executable folder is"
-        echo "in the path and call this script again."
-        echo "You can call 'pip3 show -f conan' to figure out where conan.exe was placed."
-        GOTO :EOF
-    )
-) else (
-    echo "Conan found. Installation skipped."
-)
-
-conan config install %REPO_ROOT%\contrib\conan\configs\windows
-if ERRORLEVEL 1 GOTO :EOF
-
-REM Install Stadia GGP SDK
-conan search ggp_sdk | findstr "orbitdeps/stable" > NUL
-if ERRORLEVEL 1 (
-  if not exist %REPO_ROOT%\contrib\conan\recipes\ggp_sdk\ (
-    git clone sso://user/hebecker/conan-ggp_sdk %REPO_ROOT%\contrib\conan\recipes\ggp_sdk
-    if ERRORLEVEL 1 GOTO :EOF
-  )
-
-  conan export %REPO_ROOT%\contrib\conan\recipes\ggp_sdk orbitdeps/stable
-  if ERRORLEVEL 1 GOTO :EOF
-
-) ELSE (
-  echo "ggp_sdk seems to be installed already. Skipping installation step..."
-)
-
-call build.bat ggp_release
+echo[
+echo ---------------------------------------------------------------------------------
+echo - By the way: "bootstrap-orbit-ggp.bat" is deprecated and will be removed soon. -
+echo - Please use "bootstrap-orbit-ggp.ps1" - the PowerShell equivalent - instead.   -
+echo ---------------------------------------------------------------------------------

--- a/bootstrap-orbit-ggp.ps1
+++ b/bootstrap-orbit-ggp.ps1
@@ -1,0 +1,65 @@
+$conan = Get-Command -ErrorAction Ignore conan
+
+if (!$conan) {
+  Write-Host "Conan not found. Trying to install it via python-pip..."
+	
+  $pip3 = Get-Command -ErrorAction Ignore pip3
+	
+  if(!$pip3) {	
+    Write-Error -ErrorAction Stop @"
+It seems you don't have Python3 installed (pip3.exe not found).
+Please install Python or make it available in the path.
+Alternatively you could also just install conan manually and make
+it available in the path.
+"@
+  }
+
+  $result = Start-Process -FilePath $pip3.Path -ArgumentList "install","conan" -Wait -NoNewWindow -ErrorAction Stop -PassThru
+  if ($result.ExitCode -ne 0) {
+    Throw "Error while installing conan via pip3."
+  }
+    
+  $conan = Get-Command -ErrorAction Ignore conan
+  if (!$conan) {
+    Write-Error -ErrorAction Stop @"
+It seems we installed conan sucessfully, but it is not available
+in the path. Please ensure that your Python user-executable folder is
+in the path and call this script again.
+You can call 'pip3 show -f conan' to figure out where conan.exe was placed.
+"@
+  }
+} else {
+  Write-Host "Conan found. Skipping installation..."
+}
+
+# Install conan config
+$result = Start-Process -FilePath $conan.Path -ArgumentList "config","install","$PSScriptRoot\contrib\conan\configs\windows" -Wait -NoNewWindow -ErrorAction Stop -PassThru
+if ($result.ExitCode -ne 0) {
+  Throw "Error while installing conan config."
+}
+
+# Install Stadia GGP SDK
+$search_result = & $conan.Path search ggp_sdk 2>&1
+if (-not ($search_result -like "*orbitdeps*")) {
+  if (-not (Test-Path -Path "$PSScriptRoot\contrib\conan\recipes\ggp_sdk" -PathType Container)) {
+    $git = Get-Command -ErrorAction Stop git
+    $result = Start-Process -FilePath $git.Path -Wait -NoNewWindow -ErrorAction Stop -PassThru -ArgumentList "clone","sso://user/hebecker/conan-ggp_sdk","$PSScriptRoot\contrib\conan\recipes\ggp_sdk"
+    if ($result.ExitCode -ne 0) {
+      Throw "Error in git clone command."
+    }
+  }
+
+  $result = Start-Process -FilePath $conan.Path -Wait -NoNewWindow -ErrorAction Stop -PassThru -ArgumentList "export","$PSScriptRoot\contrib\conan\recipes\ggp_sdk","orbitdeps/stable"
+  if ($result.ExitCode -ne 0) {
+      Throw "Error in conan export command."
+  }
+} ELSE {
+  Write-Host "ggp_sdk seems to be installed already. Skipping installation step..."
+}
+
+# Start build
+if ($args) {
+  & "$PSScriptRoot\build.ps1" $args
+} else {
+  & "$PSScriptRoot\build.ps1" "ggp_release"
+}

--- a/bootstrap-orbit.bat
+++ b/bootstrap-orbit.bat
@@ -1,36 +1,8 @@
 @echo off
+call powershell "& %~dp0\bootstrap-orbit.ps1 %*"
 
-SET REPO_ROOT=%~dp0
-
-where /q conan
-if ERRORLEVEL 1 (
-    echo "Conan not found. Trying to install it via python-pip..."
-
-    where /q pip3
-    if ERRORLEVEL 1 (
-        echo "It seems you don't have Python3 installed (pip3.exe not found)."
-        echo "Please install Python or make it available in the path."
-        echo "Alternatively you could also just install conan manually and make"
-        echo "it available in the path."
-	GOTO :EOF
-    )
-
-    pip3 install conan
-    if ERRORLEVEL 1 GOTO :EOF
-
-    where /q conan
-    if ERRORLEVEL 1 (
-        echo "It seems we installed conan sucessfully, but it is not available"
-        echo "in the path. Please ensure that your Python user-executable folder is"
-        echo "in the path and call this script again."
-        echo "You can call 'pip3 show -f conan' to figure out where conan.exe was placed."
-        GOTO :EOF
-    )
-) else (
-    echo "Conan found. Installation skipped."
-)
-
-conan config install %REPO_ROOT%\contrib\conan\configs\windows
-if ERRORLEVEL 1 GOTO :EOF
-
-call build.bat %*
+echo[
+echo -----------------------------------------------------------------------------
+echo - By the way: "bootstrap-orbit.bat" is deprecated and will be removed soon. -
+echo - Please use "bootstrap-orbit.ps1" - the PowerShell equivalent - instead.   -
+echo -----------------------------------------------------------------------------

--- a/bootstrap-orbit.ps1
+++ b/bootstrap-orbit.ps1
@@ -1,0 +1,46 @@
+$conan = Get-Command -ErrorAction Ignore conan
+
+if (!$conan) {
+  Write-Host "Conan not found. Trying to install it via python-pip..."
+	
+  $pip3 = Get-Command -ErrorAction Ignore pip3
+	
+  if(!$pip3) {	
+    Write-Error -ErrorAction Stop @"
+It seems you don't have Python3 installed (pip3.exe not found).
+Please install Python or make it available in the path.
+Alternatively you could also just install conan manually and make
+it available in the path.
+"@
+  }
+
+  $result = Start-Process -FilePath $pip3.Path -ArgumentList "install","conan" -Wait -NoNewWindow -ErrorAction Stop -PassThru
+  if ($result.ExitCode -ne 0) {
+    Throw "Error while installing conan via pip3."
+  }
+    
+  $conan = Get-Command -ErrorAction Ignore conan
+  if (!$conan) {
+    Write-Error -ErrorAction Stop @"
+It seems we installed conan sucessfully, but it is not available
+in the path. Please ensure that your Python user-executable folder is
+in the path and call this script again.
+You can call 'pip3 show -f conan' to figure out where conan.exe was placed.
+"@
+  }
+} else {
+  Write-Host "Conan found. Skipping installation..."
+}
+
+# Install conan config
+$result = Start-Process -FilePath $conan.Path -ArgumentList "config","install","$PSScriptRoot\contrib\conan\configs\windows" -Wait -NoNewWindow -ErrorAction Stop -PassThru
+if ($result.ExitCode -ne 0) {
+  Throw "Error while installing conan config."
+}
+
+# Start build
+if ($args) {
+  & "$PSScriptRoot\build.ps1" $args
+} else {
+  & "$PSScriptRoot\build.ps1"
+}

--- a/build.bat
+++ b/build.bat
@@ -1,63 +1,8 @@
 @echo off
+call powershell "& %~dp0\build.ps1 %*"
 
-setlocal enabledelayedexpansion
-
-SET REPO_ROOT=%~dp0
-
-set argCount=0
-for %%x in (%*) do (
-   set /A argCount+=1
-   set "argVec[!argCount!]=%%~x"
-)
-
-if %argCount% == 0 (
-    set /a argCount=1
-    set argVec[1]=default_release
-)
-
-
-for /L %%i in (1,1,%argCount%) do (
-    set profile=!argVec[%%i]!
-
-    set defaultprofile=NO
-    if "!profile!" == "default_release" set defaultprofile=YES
-    if "!profile!" == "default_release_x86" set defaultprofile=YES
-    if "!profile!" == "default_release_x64" set defaultprofile=YES
-
-    if "!defaultprofile!" == "YES" (
-        call :conan_profile_exists !profile!
-        if !errorlevel! neq 0 (
-            echo "Creating conan profile !profile!"
-            call :create_conan_profile !profile!
-        )
-    )
-
-    echo Building Orbit in build_!profile!/ with conan profile !profile!
-
-    call conan install -pr !profile! -o system_qt=False -if build_!profile!/ --build outdated !REPO_ROOT!
-    if !errorlevel! neq 0 exit /b !errorlevel!
-
-    call conan build -bf build_!profile!/ !REPO_ROOT!
-    if !errorlevel! neq 0 exit /b !errorlevel!
-)
-
-EXIT /B 0
-
-:create_conan_profile
-    conan profile new --detect %~1
-
-    IF "%~1" == "default_release_x86" (
-        conan profile update settings.arch=x86 %~1
-    ) ELSE (
-        conan profile update settings.arch=x86_64 %~1
-    )
-
-	powershell -Command "(gc !USERPROFILE!/.conan/profiles/%~1) -replace '\[build_requires\]', \"[build_requires]`r`ncmake/3.16.4@\" | Out-File -encoding ASCII !USERPROFILE!/.conan/profiles/%~1"
-
-    EXIT /B 0
-Rem End of create_conan_profile
-
-:conan_profile_exists
-    conan profile show %~1 >NUL 2>&1
-    EXIT /B !errorlevel!
-Rem End of conan_profile_exists
+echo[
+echo -------------------------------------------------------------------
+echo - By the way: "build.bat" is deprecated and will be removed soon. -
+echo - Please use "build.ps1" - the PowerShell equivalent - instead.   -
+echo -------------------------------------------------------------------

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,40 @@
+$conan = Get-Command conan -ErrorAction Stop
+
+function conan_profile_exists($profile) {
+  $process = Start-Process $conan.Path -windowstyle Hidden -ArgumentList "profile","show",$profile -PassThru -Wait  
+  return ($process.ExitCode -eq 0)
+}
+
+function conan_create_profile($profile) {
+  $process = Start-Process $conan.Path -Wait -NoNewWindow -ErrorAction Stop -PassThru -ArgumentList "profile","new","--detect",$profile
+  if ($process.ExitCode -ne 0) { Throw "Error while creating conan profile." }
+  
+  $arch = If ($profile.EndsWith("x86")) { "x86" } Else { "x86_64" }
+  $process = Start-Process $conan.Path -Wait -NoNewWindow -ErrorAction Stop -PassThru -ArgumentList "profile","update","settings.arch=$arch",$profile
+  if ($process.ExitCode -ne 0) { Throw "Error while creating conan profile." }
+  
+  $profile_path = "$Env:USERPROFILE\.conan\profiles\$profile"
+  (Get-Content $profile_path) -replace '\[build_requires\]', "[build_requires]`r`ncmake/3.16.4@" | Out-File -encoding ASCII $profile_path
+}
+
+$profiles = if ($args.Count) { $args } else { @("default_release") }
+
+foreach ($profile in $profiles) {
+
+  if ($profile.StartsWith("default_") -and (-not (conan_profile_exists $profile))) {    
+    Write-Host "Creating conan profile $profile"
+    conan_create_profile $profile
+  }
+  
+  Write-Host "Building Orbit in build_$profile/ with conan profile $profile"
+
+  $process = Start-Process $conan.Path -Wait -NoNewWindow -ErrorAction Stop -PassThru -ArgumentList "install","-pr",$profile,"-o","system_qt=False","-if","build_$profile/","--build","outdated",$PSScriptRoot
+  if ($process.ExitCode -ne 0) {
+    Throw "Error while running conan install."
+  }
+  
+  $process = Start-Process $conan.Path -Wait -NoNewWindow -ErrorAction Stop -PassThru -ArgumentList "build","-bf","build_$profile/",$PSScriptRoot
+  if ($process.ExitCode -ne 0) {
+    Throw "Error while running conan build."
+  }
+}


### PR DESCRIPTION
`build.bat` and `bootstrap-orbit{,-ggp}.bat` have been replaced by
powershell scripts `build.ps1` and `bootstrap-orbit{,-ggp}.ps1`.
The old scripts still exist for compatibility reasons. They
forward the call to the new scripts and can be removed in the future.

The old and the new scripts are feature- and behaviour-wise identical.

This change happens in anticipation of more complex logic in the
bootstrap-scripts. I'm going to require a HTTP-request which is easy
on Linux with curl but just not possible to do on Windows Batch
in a portable way.

`DEVELOPMENT.md` was updated as well.