### PR TITLE
Moved to MSVC2017 in CI build

### DIFF
--- a/kokoro/gcp_windows/kokoro_build.bat
+++ b/kokoro/gcp_windows/kokoro_build.bat
@@ -20,7 +20,7 @@ conan config set general.parallel_download=8
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 :: Building conan
-call conan install -pr msvc2019_release -if %REPO_ROOT%\build\ --build outdated %REPO_ROOT%
+call conan install -pr msvc2017_release -if %REPO_ROOT%\build\ --build outdated %REPO_ROOT%
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 call conan build -bf %REPO_ROOT%\build\ %REPO_ROOT%


### PR DESCRIPTION
> **I withdraw that until we know if we can just statically link and don't need a certain toolset version.**

This change is to be aligned with the runtime requirements of other tools.