### PR TITLE
added conan file for outcome package

### DIFF
--- a/contrib/conan/recipes/outcome/conanfile.py
+++ b/contrib/conan/recipes/outcome/conanfile.py
@@ -1,0 +1,21 @@
+# from https://github.com/ned14/outcome/blob/develop/conan/conanfile.py
+from conans import ConanFile, tools
+
+class OutcomeConan(ConanFile):
+    name = "Outcome"
+    version = "3dae433e"
+    license = "Apache-2.0"
+    description = "Provides very lightweight outcome<T> and result<T>"
+    repo_url = "https://github.com/ned14/outcome"
+
+    def source(self):
+        file_url = "https://raw.githubusercontent.com/ned14/outcome/{}/".format(self.version)
+        tools.download(file_url + "single-header/outcome.hpp", filename="outcome.hpp")
+        tools.download(file_url + "Licence.txt", filename="LICENCE")
+
+    def package(self):
+        self.copy("outcome.hpp", dst="include")
+        self.copy("LICENCE", dst="licenses")
+
+    def package_id(self):
+        self.info.header_only()


### PR DESCRIPTION
I ran 
```
conan create -pr clang8_debug . orbitdeps/stable
conan create -pr clang8_release . orbitdeps/stable
conan create -pr gcc8_release . orbitdeps/stable
conan create -pr gcc9_release . orbitdeps/stable
conan create -pr msvc2017_debug . orbitdeps/stable
conan create -pr msvc2017_release . orbitdeps/stable
```
and it seems to work fine. 

The package does not have a version just `Outcome/master@orbitdeps/stable`, but I guess that is fine?

I also don't know if the `build_policy = "always"` is a good idea. 