### PR TITLE
Session-related UI fixes

### DIFF
--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -494,7 +494,7 @@ bool Capture::IsOtherInstanceRunning() {
 //-----------------------------------------------------------------------------
 void Capture::SaveSession(const std::string& a_FileName) {
   Session session;
-  session.m_ProcessFullPath = GTargetProcess->GetFullName();
+  session.m_ProcessFullPath = GTargetProcess->GetFullPath();
 
   GCoreApp->SendToUiNow("UpdateProcessParams");
   session.m_Arguments = GParams.m_Arguments;

--- a/OrbitCore/OrbitModule.cpp
+++ b/OrbitCore/OrbitModule.cpp
@@ -50,7 +50,7 @@ Module::Module(const std::string& file_name, uint64_t address_start,
 
 //-----------------------------------------------------------------------------
 std::string Module::GetPrettyName() {
-  if (m_PrettyName.size() == 0) {
+  if (m_PrettyName.empty()) {
 #ifdef WIN32
     m_PrettyName =
         absl::StrFormat("%s [%I64x - %I64x] %s\r\n", m_Name.c_str(),
@@ -127,8 +127,8 @@ Function* Pdb::FunctionFromName(const std::string& a_Name) {
 }
 
 //-----------------------------------------------------------------------------
-Pdb::Pdb(uint64_t module_address, uint64_t load_bias,
-         const std::string& file_name, const std::string& module_file_name)
+Pdb::Pdb(uint64_t module_address, uint64_t load_bias, std::string file_name,
+         std::string module_file_name)
     : m_MainModule(module_address),
       load_bias_(load_bias),
       m_FileName(std::move(file_name)),

--- a/OrbitCore/OrbitProcess.cpp
+++ b/OrbitCore/OrbitProcess.cpp
@@ -85,7 +85,7 @@ void Process::LoadDebugInfo() {
     // SymInit(m_Handle);
 
     // Load module information
-    /*string symbolPath = Path::GetDirectory(this->GetFullName()).c_str();
+    /*string symbolPath = Path::GetDirectory(this->GetFullPath()).c_str();
     SymSetSearchPath(m_Handle, symbolPath.c_str());*/
 
     // List threads
@@ -534,9 +534,10 @@ void Process::FindCoreFunctions() {
 }
 
 //-----------------------------------------------------------------------------
-ORBIT_SERIALIZE(Process, 2) {
+ORBIT_SERIALIZE(Process, 3) {
   ORBIT_NVP_VAL(0, m_Name);
-  ORBIT_NVP_VAL(0, m_FullName);
+  ORBIT_NVP_VAL(3, m_FullPath);
+  ORBIT_NVP_VAL(3, m_CmdLine);
   ORBIT_NVP_VAL(0, m_ID);
   ORBIT_NVP_VAL(0, m_IsElevated);
   ORBIT_NVP_VAL(0, m_CpuUsage);

--- a/OrbitCore/OrbitProcess.h
+++ b/OrbitCore/OrbitProcess.h
@@ -74,8 +74,9 @@ class Process {
   }
   std::shared_ptr<Module> FindModule(const std::string& a_ModuleName);
 
-  const std::string GetName() const { return m_Name; }
-  const std::string GetFullName() const { return m_FullName; }
+  const std::string& GetName() const { return m_Name; }
+  const std::string& GetFullPath() const { return m_FullPath; }
+  const std::string& GetCmdLine() const { return m_CmdLine; }
   DWORD GetID() const { return m_ID; }
   double GetCpuUsage() const { return m_CpuUsage; }
   HANDLE GetHandle() const { return m_Handle; }
@@ -140,7 +141,8 @@ class Process {
   void FindCoreFunctions();
 
   std::string m_Name;
-  std::string m_FullName;
+  std::string m_FullPath;
+  std::string m_CmdLine;
 
   ORBIT_SERIALIZABLE;
 

--- a/OrbitCore/Pdb.cpp
+++ b/OrbitCore/Pdb.cpp
@@ -52,8 +52,8 @@ Pdb::Pdb(const char* pdb_name)
 }
 
 //-----------------------------------------------------------------------------
-Pdb::Pdb(uint64_t module_address, uint64_t load_bias,
-         const std::string& file_name, const std::string& module_file_name)
+Pdb::Pdb(uint64_t module_address, uint64_t load_bias, std::string file_name,
+         std::string module_file_name)
     : m_MainModule(module_address),
       load_bias_(load_bias),
       m_FileName(std::move(file_name)),

--- a/OrbitCore/Pdb.h
+++ b/OrbitCore/Pdb.h
@@ -27,8 +27,8 @@ struct IDiaDataSource;
 class Pdb {
  public:
   explicit Pdb(const char* pdb_name = "");
-  Pdb(uint64_t module_address, uint64_t load_bias, const std::string& file_name,
-      const std::string& module_file_name);
+  Pdb(uint64_t module_address, uint64_t load_bias, std::string file_name,
+      std::string module_file_name);
   Pdb(const Pdb&) = delete;
   Pdb& operator=(const Pdb&) = delete;
   virtual ~Pdb();
@@ -149,8 +149,8 @@ class Pdb {
 class Pdb {
  public:
   Pdb() = default;
-  Pdb(uint64_t module_address, uint64_t load_bias, const std::string& file_name,
-      const std::string& module_file_name);
+  Pdb(uint64_t module_address, uint64_t load_bias, std::string file_name,
+      std::string module_file_name);
   Pdb(const Pdb&) = delete;
   Pdb& operator=(const Pdb&) = delete;
   virtual ~Pdb() = default;

--- a/OrbitCore/TestRemoteMessages.cpp
+++ b/OrbitCore/TestRemoteMessages.cpp
@@ -40,7 +40,8 @@ std::string SerializeObject(T& a_Object) {
 void TestRemoteMessages::Run() {
   Process process;
   process.m_Name = "process.m_Name";
-  process.m_FullName = "process.m_FullName";
+  process.m_FullPath = "process.m_FullPath";
+  process.m_CmdLine = "process.m_CmdLine";
   process.SetID(22);
   process.m_Is64Bit = true;
   process.m_DebugInfoLoaded = true;

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -737,10 +737,9 @@ std::string OrbitApp::GetSessionFileName() {
 }
 
 //-----------------------------------------------------------------------------
-std::wstring OrbitApp::GetSaveFile(const std::wstring& a_Extension) {
-  std::wstring fileName;
-  if (m_SaveFileCallback) m_SaveFileCallback(a_Extension, fileName);
-  return fileName;
+std::string OrbitApp::GetSaveFile(const std::string& extension) {
+  if (!m_SaveFileCallback) return "";
+  return m_SaveFileCallback(extension);
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -549,7 +549,7 @@ void OrbitApp::MainTick() {
   GTcpServer->MainThreadTick();
 
   if (!Capture::GProcessToInject.empty()) {
-    std::cout << "Injecting into " << Capture::GTargetProcess->GetFullName()
+    std::cout << "Injecting into " << Capture::GTargetProcess->GetFullPath()
               << std::endl;
     std::cout << "Orbit host: " << Capture::GCaptureHost << std::endl;
     GOrbitApp->SelectProcess(Capture::GProcessToInject);

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -38,7 +38,7 @@ class OrbitApp : public CoreApp {
 
   std::wstring GetCaptureFileName();
   std::string GetSessionFileName();
-  std::wstring GetSaveFile(const std::wstring& a_Extension);
+  std::string GetSaveFile(const std::string& extension);
   void SetClipboard(const std::wstring& a_Text);
   void OnSaveSession(const std::string& file_name);
   void OnLoadSession(const std::string& file_name);
@@ -121,8 +121,7 @@ class OrbitApp : public CoreApp {
   void AddWatchCallback(WatchCallback a_Callback) {
     m_AddToWatchCallbacks.emplace_back(std::move(a_Callback));
   }
-  typedef std::function<void(const std::wstring& a_Extension,
-                             std::wstring& o_Variable)>
+  typedef std::function<std::string(const std::string& a_Extension)>
       SaveFileCallback;
   void SetSaveFileCallback(SaveFileCallback a_Callback) {
     m_SaveFileCallback = std::move(a_Callback);

--- a/OrbitGl/DataView.cpp
+++ b/OrbitGl/DataView.cpp
@@ -80,7 +80,10 @@ void DataView::OnContextMenu(const std::string& a_Action, int a_MenuIndex,
   UNUSED(a_MenuIndex);
 
   if (a_Action == MENU_ACTION_EXPORT_TO_CSV) {
-    ExportCSV(ws2s(GOrbitApp->GetSaveFile(L".csv")));
+    std::string save_file = GOrbitApp->GetSaveFile(".csv");
+    if (!save_file.empty()) {
+      ExportCSV(save_file);
+    }
   } else if (a_Action == MENU_ACTION_COPY_SELECTION) {
     CopySelection(a_ItemIndices);
   }

--- a/OrbitGl/ProcessesDataView.cpp
+++ b/OrbitGl/ProcessesDataView.cpp
@@ -61,8 +61,7 @@ std::string ProcessesDataView::GetValue(int row, int col) {
 
 //-----------------------------------------------------------------------------
 std::string ProcessesDataView::GetToolTip(int a_Row, int /*a_Column*/) {
-  const Process& process = *GetProcess(a_Row);
-  return process.GetFullName();
+  return GetProcess(a_Row)->GetCmdLine();
 }
 
 //-----------------------------------------------------------------------------
@@ -204,7 +203,7 @@ void ProcessesDataView::ClearSelectedProcess() {
 bool ProcessesDataView::SelectProcess(const std::string& a_ProcessName) {
   for (size_t i = 0; i < GetNumElements(); ++i) {
     Process& process = *GetProcess(i);
-    if (process.GetFullName().find(a_ProcessName) != std::string::npos) {
+    if (process.GetFullPath().find(a_ProcessName) != std::string::npos) {
       OnSelect(i);
       Capture::GPresetToLoad = "";
       return true;

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -34,8 +34,7 @@ class OrbitMainWindow : public QMainWindow {
   void OnNewSelection(std::shared_ptr<class SamplingReport> a_SamplingReport);
   void OnReceiveMessage(const std::string& message);
   void OnAddToWatch(const class Variable* a_Variable);
-  void OnGetSaveFileName(const std::wstring& a_Extension,
-                         std::wstring& a_FileName);
+  std::string OnGetSaveFileName(const std::string& extension);
   void OnSetClipboard(const std::wstring& a_Text);
   void ParseCommandlineArguments();
   bool IsHeadless() { return m_Headless; }


### PR DESCRIPTION
#### Add Process::m_CmdLine
Distinguish between `Process::m_FullPath` (previously `m_FullName`) and
`Process::m_CmdLine`, sometimes one is needed, sometimes the other.
Fixes b/154602368.
Plus a couple of minor tweaks.

#### Check return value of QFileDialog::getSaveFileName
If an empty string is returned, "Cancel" was pressed.
In particular, prevent the creation of an unnamed ".opr" file in the current
working directory when "File" > "Save Session As..." and then "Cancel".
Also switch from `wstring` to `string`.