### PR TITLE
Remove PRINT macro and replace by LOG.  Simplify PrintVar.h.

### DIFF
--- a/OrbitBase/include/OrbitBase/Logging.h
+++ b/OrbitBase/include/OrbitBase/Logging.h
@@ -4,6 +4,10 @@
 #include <cstdio>
 #include <filesystem>
 
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+
 #include "absl/strings/str_format.h"
 
 #ifdef __clang__
@@ -75,10 +79,7 @@
     OutputDebugStringA(message);    \
   } while (0)
 #else
-#define PLATFORM_LOG(message)       \
-  do {                              \
-    fprintf(stderr, "%s", message); \
-  } while (0)
+#define PLATFORM_LOG(message) fprintf(stderr, "%s", message)
 #endif
 
 #ifdef __clang__

--- a/OrbitCore/BaseTypes.h
+++ b/OrbitCore/BaseTypes.h
@@ -58,10 +58,6 @@ typedef struct _M128A {
   uint64_t High;
 } M128A;
 
-inline void OutputDebugStringA(const char* msg) { std::cout << msg; }
-
-inline void OutputDebugStringW(const wchar_t* wmsg) { std::wcout << wmsg; }
-
 #define vsnprintf_s vsnprintf
 #define _vsnwprintf_s vswprintf
 

--- a/OrbitCore/Callstack.cpp
+++ b/OrbitCore/Callstack.cpp
@@ -28,8 +28,8 @@ void CallStack::Print() {
   PRINT_VAR(m_ThreadId);
 
   for (uint32_t i = 0; i < m_Depth; ++i) {
-    std::string address = ws2s(VAR_TO_STR((void*)m_Data[i]));
-    PRINT_VAR_INL(address);
+    std::string address = VAR_TO_STR((void*)m_Data[i]);
+    PRINT_VAR(address);
   }
 }
 

--- a/OrbitCore/ConnectionManager.cpp
+++ b/OrbitCore/ConnectionManager.cpp
@@ -141,7 +141,7 @@ void ConnectionManager::StartCaptureAsRemote(uint32_t pid) {
   PRINT_FUNC;
   std::shared_ptr<Process> process = process_list_.GetProcess(pid);
   if (!process) {
-    PRINT("Process not found (pid=%d)\n", pid);
+    LOG("Process not found (pid=%d)", pid);
     return;
   }
   Capture::SetTargetProcess(process);

--- a/OrbitCore/CoreApp.h
+++ b/OrbitCore/CoreApp.h
@@ -52,7 +52,7 @@ class CoreApp {
   virtual void AddAddressInfo(LinuxAddressInfo /*address_info*/) {}
   virtual void AddKeyAndString(uint64_t /*key*/, std::string_view /*str*/) {}
   virtual void OnRemoteModuleDebugInfo(const std::vector<ModuleDebugInfo>&) {}
-  virtual void ApplySession(const Session&){}
+  virtual void ApplySession(const Session&) {}
   virtual const std::unordered_map<DWORD64, std::shared_ptr<class Rule> >*
   GetRules() {
     return nullptr;

--- a/OrbitCore/CrashHandler.cpp
+++ b/OrbitCore/CrashHandler.cpp
@@ -4,15 +4,14 @@
 
 #include "CrashHandler.h"
 
-#include "client/crash_report_database.h"
-#include "client/settings.h"
-
 #include "Core.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitDbgHelp.h"
 #include "ScopeTimer.h"
 #include "TcpClient.h"
 #include "Version.h"
+#include "client/crash_report_database.h"
+#include "client/settings.h"
 
 namespace {
 template <typename StringType = base::FilePath::StringType>

--- a/OrbitCore/ElfFile.cpp
+++ b/OrbitCore/ElfFile.cpp
@@ -58,7 +58,7 @@ void ElfFileImpl<ElfT>::InitSections() {
   llvm::Expected<typename ElfT::ShdrRange> sections_or_err =
       elf_file->sections();
   if (!sections_or_err) {
-    PRINT("Unable to load sections\n");
+    LOG("Unable to load sections");
     return;
   }
 
@@ -66,7 +66,7 @@ void ElfFileImpl<ElfT>::InitSections() {
     llvm::Expected<llvm::StringRef> name_or_error =
         elf_file->getSectionName(&section);
     if (!name_or_error) {
-      PRINT("Unable to get section name\n");
+      LOG("Unable to get section name");
       continue;
     }
     llvm::StringRef name = name_or_error.get();
@@ -91,7 +91,7 @@ void ElfFileImpl<ElfT>::InitSections() {
         }
       }
       if (error) {
-        PRINT("Error while reading elf notes\n");
+        LOG("Error while reading elf notes");
       }
     }
   }
@@ -100,7 +100,7 @@ void ElfFileImpl<ElfT>::InitSections() {
 template <typename ElfT>
 bool ElfFileImpl<ElfT>::IsAddressInTextSection(uint64_t address) const {
   if (!text_section_) {
-    PRINT(".text section was not found\n");
+    LOG(".text section was not found");
     return false;
   }
 
@@ -137,10 +137,8 @@ bool ElfFileImpl<ElfT>::LoadFunctions(Pdb* pdb) const {
 
     // Unknown type - skip and generate a warning
     if (!symbol_ref.getType()) {
-      PRINT(
-          absl::StrFormat("WARNING: Type is not set for symbol \"%s\" in "
-                          "\"%s\", skipping.",
-                          name, file_path_));
+      LOG("WARNING: Type is not set for symbol \"%s\" in \"%s\", skipping.",
+          name.c_str(), file_path_.c_str());
       continue;
     }
 
@@ -176,7 +174,7 @@ std::optional<uint64_t> ElfFileImpl<ElfT>::GetLoadBias() const {
   llvm::Expected<typename ElfT::PhdrRange> range = elf_file->program_headers();
 
   if (!range) {
-    PRINT(absl::StrFormat("No program headers found in %s\n", file_path_));
+    LOG("No program headers found in %s\n", file_path_);
     return {};
   }
 
@@ -192,8 +190,7 @@ std::optional<uint64_t> ElfFileImpl<ElfT>::GetLoadBias() const {
   }
 
   if (!pt_load_found) {
-    PRINT(absl::StrFormat("No PT_LOAD program headers found in %s\n",
-                          file_path_));
+    LOG("No PT_LOAD program headers found in %s", file_path_);
     return {};
   }
   return min_vaddr;

--- a/OrbitCore/EventBuffer.cpp
+++ b/OrbitCore/EventBuffer.cpp
@@ -17,7 +17,7 @@ EventTracer GEventTracer;
 
 //-----------------------------------------------------------------------------
 void EventBuffer::Print() {
-  PRINT("Orbit Callstack Events:");
+  LOG("Orbit Callstack Events:");
 
   size_t numCallstacks = 0;
   for (auto& pair : m_CallstackEvents) {

--- a/OrbitCore/LinuxUtils.cpp
+++ b/OrbitCore/LinuxUtils.cpp
@@ -255,7 +255,7 @@ uint32_t GetVersion(const std::string& a_Version) {
   std::vector<std::string> v = Tokenize(a_Version, ".");
   if (v.size() == 3)
     return KERNEL_VERSION(std::stoi(v[0]), std::stoi(v[1]), std::stoi(v[2]));
-  PRINT("Error: GetVersion: Invalid argument\n");
+  LOG("Error: GetVersion: Invalid argument");
   return 0;
 }
 

--- a/OrbitCore/OrbitFunction.cpp
+++ b/OrbitCore/OrbitFunction.cpp
@@ -83,10 +83,10 @@ bool Function::Hookable() {
 void Function::Select() {
   if (Hookable()) {
     selected_ = true;
-    PRINT("Selected %s at 0x%" PRIx64 " (address_=0x%" PRIx64
-          ", load_bias_= 0x%" PRIx64 ", base_address=0x%" PRIx64 ")\n",
-          pretty_name_.c_str(), GetVirtualAddress(), address_, load_bias_,
-          module_base_address_);
+    LOG("Selected %s at 0x%" PRIx64 " (address_=0x%" PRIx64
+        ", load_bias_= 0x%" PRIx64 ", base_address=0x%" PRIx64 ")",
+        pretty_name_.c_str(), GetVirtualAddress(), address_, load_bias_,
+        module_base_address_);
     Capture::GSelectedFunctionsMap[GetVirtualAddress()] = this;
   }
 }

--- a/OrbitCore/OrbitLib.cpp
+++ b/OrbitCore/OrbitLib.cpp
@@ -82,7 +82,7 @@ void Orbit::Start() {
     GTimerManager->StartClient();
     GIsCaptureEnabled = true;
   } else {
-    PRINT("GTimerManager not created yet");
+    LOG("GTimerManager not created yet");
   }
 }
 

--- a/OrbitCore/OrbitProcess.cpp
+++ b/OrbitCore/OrbitProcess.cpp
@@ -446,7 +446,7 @@ bool Process::SetPrivilege(LPCTSTR a_Name, bool a_Enable) {
   LUID luid;
   if (!LookupPrivilegeValue(NULL, a_Name, &luid)) {
     ORBIT_ERROR;
-    PRINT("LookupPrivilegeValue error: ");
+    LOG("LookupPrivilegeValue error: ");
     PRINT_VAR(GetLastErrorAsString());
     return false;
   }
@@ -458,13 +458,13 @@ bool Process::SetPrivilege(LPCTSTR a_Name, bool a_Enable) {
   if (!AdjustTokenPrivileges(hToken, FALSE, &tp, sizeof(TOKEN_PRIVILEGES),
                              (PTOKEN_PRIVILEGES)NULL, (PDWORD)NULL)) {
     ORBIT_ERROR;
-    PRINT("AdjustTokenPrivileges error: ");
+    LOG("AdjustTokenPrivileges error: ");
     PRINT_VAR(GetLastErrorAsString());
     return false;
   }
 
   if (GetLastError() == ERROR_NOT_ALL_ASSIGNED) {
-    PRINT("The token does not have the specified privilege. \n");
+    LOG("The token does not have the specified privilege.");
     return false;
   }
 

--- a/OrbitCore/OrbitType.cpp
+++ b/OrbitCore/OrbitType.cpp
@@ -80,7 +80,7 @@ void Type::AddParent(IDiaSymbol* a_Parent) {
 
         Parent parent;
         parent.m_BaseOffset = offset;
-        parent.m_Name = ws2s(VAR_TO_STR(typeId));
+        parent.m_Name = VAR_TO_STR(typeId);
         parent.m_TypeId = typeId;
         m_ParentTypes[typeId] = parent;
       }

--- a/OrbitCore/Pdb.cpp
+++ b/OrbitCore/Pdb.cpp
@@ -235,8 +235,8 @@ void Pdb::Update() {
 //-----------------------------------------------------------------------------
 void Pdb::SendStatusToUi() {
   std::string status = absl::StrFormat(
-      "status:Parsing %s\nFunctions: %i\nTypes: %i\nGlobals: %i\n",
-      m_Name, functions_.size(), m_Types.size(), m_Globals.size());
+      "status:Parsing %s\nFunctions: %i\nTypes: %i\nGlobals: %i\n", m_Name,
+      functions_.size(), m_Types.size(), m_Globals.size());
 
   if (m_IsPopulatingFunctionMap) {
     status += "PopulatingFunctionMap\n";

--- a/OrbitCore/PrintVar.h
+++ b/OrbitCore/PrintVar.h
@@ -1,116 +1,25 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
-#pragma once
+#ifndef ORBIT_CORE_PRINT_VAR_H_
+#define ORBIT_CORE_PRINT_VAR_H_
 
 #include <sstream>
 
+#include "OrbitBase/Logging.h"
 #include "Utils.h"
 #include "absl/strings/str_format.h"
 
-#if __linux__
-#define FUNCTION_NAME __PRETTY_FUNCTION__
-#else
-#define FUNCTION_NAME __FUNCTION__
-#endif
-
-#define PRINT PrintDbg
-#define PRINT_VAR(var) PrintVar(#var, var)
-#define PRINT_VAR_INL(var) PrintVar(#var, var, true)
-#define PRINT_FUNC PrintFunc(FUNCTION_NAME, __FILE__, __LINE__)
-#define VAR_TO_STR(var) VarToStr(#var, var)
-#define VAR_TO_CHAR(var) VarToStr(#var, var).c_str()
-#define VAR_TO_ANSI(var) VarToAnsi(#var, var).c_str()
-
-//-----------------------------------------------------------------------------
-inline void PrintVar(const char* a_VarName, const std::wstring& a_Value,
-                     bool a_SameLine = false) {
-  OutputDebugStringA(a_VarName);
-  std::wstring value = std::wstring(L" = ") + a_Value;
-  OutputDebugStringW(value.c_str());
-  if (!a_SameLine) {
-    OutputDebugStringA("\r\n");
-  }
-}
+#define PRINT_VAR(var) LOG("%s", VAR_TO_STR(var).c_str())
+#define PRINT_FUNC LOG("%s tid:%u", FUNCTION_NAME, GetCurrentThreadId())
+#define VAR_TO_STR(var) VariableToString(#var, var)
 
 //-----------------------------------------------------------------------------
 template <class T>
-inline void PrintVar(const char* a_VarName, const T& a_Value,
-                     bool a_SameLine = false) {
-  std::stringstream l_StringStream;
-  l_StringStream << a_VarName << " = " << a_Value;
-  if (!a_SameLine) l_StringStream << std::endl;
-  OutputDebugStringA(l_StringStream.str().c_str());
+inline std::string VariableToString(const char* name, const T& value) {
+  std::stringstream string_stream;
+  string_stream << name << " = " << value;
+  return string_stream.str();
 }
 
 //-----------------------------------------------------------------------------
-inline void PrintVar(const char* a_VarName, const wchar_t* a_Value,
-                     bool a_SameLine = false) {
-  std::wstring value(a_Value);
-  PrintVar(a_VarName, value, a_SameLine);
-}
+inline void PrintLastError() { PRINT_VAR(GetLastErrorAsString()); }
 
-//-----------------------------------------------------------------------------
-template <class T>
-inline std::wstring VarToStr(const char* a_VarName, const T& a_Value) {
-  std::stringstream l_StringStream;
-  l_StringStream << a_VarName << " = " << a_Value << std::endl;
-  return s2ws(l_StringStream.str());
-}
-
-//-----------------------------------------------------------------------------
-template <class T>
-inline std::string VarToAnsi(const char* a_VarName, const T& a_Value) {
-  std::stringstream l_StringStream;
-  l_StringStream << a_VarName << " = " << a_Value;
-  return l_StringStream.str();
-}
-
-//-----------------------------------------------------------------------------
-inline void PrintFunc(const char* function, const char* file, int line) {
-  std::string func = absl::StrFormat("%s %s(%i) TID: %u\n", function, file,
-                                     line, GetCurrentThreadId());
-  OutputDebugStringA(func.c_str());
-}
-
-//-----------------------------------------------------------------------------
-inline void PrintDbg(const char* msg, ...) {
-  va_list ap;
-  const int BUFF_SIZE = 4096;
-  char text[BUFF_SIZE] = {
-      0,
-  };
-  va_start(ap, msg);
-  vsnprintf_s(text, BUFF_SIZE - 1, msg, ap);
-  va_end(ap);
-
-  OutputDebugStringA(text);
-}
-
-//-----------------------------------------------------------------------------
-inline void PrintDbg(const WCHAR* msg, ...) {
-  va_list ap;
-  const int BUFF_SIZE = 4096;
-  WCHAR text[BUFF_SIZE] = {
-      0,
-  };
-  va_start(ap, msg);
-  _vsnwprintf_s(text, BUFF_SIZE - 1, msg, ap);
-  va_end(ap);
-  OutputDebugStringW(text);
-}
-
-//-----------------------------------------------------------------------------
-inline void PrintDbg(const std::string& a_Msg) {
-  OutputDebugStringA(a_Msg.c_str());
-}
-
-//-----------------------------------------------------------------------------
-inline void PrintDbg(const std::wstring& a_Msg) {
-  OutputDebugStringW(a_Msg.c_str());
-}
-
-//-----------------------------------------------------------------------------
-inline void PrintLastError() {
-  PrintVar("Last error: ", GetLastErrorAsString());
-}
+#endif  // ORBIT_CORE_PRINT_VAR_H_

--- a/OrbitCore/SamplingProfiler.cpp
+++ b/OrbitCore/SamplingProfiler.cpp
@@ -140,9 +140,7 @@ void SamplingProfiler::AddCallStack(CallStack& a_CallStack) {
 //-----------------------------------------------------------------------------
 void SamplingProfiler::AddHashedCallStack(CallstackEvent& a_CallStack) {
   if (!HasCallStack(a_CallStack.m_Id)) {
-    PRINT(
-        "Error: Callstacks can only be added by hash when they are already "
-        "present.\n");
+    LOG("Error: Callstacks can only be added by hash when already present.");
   }
   ScopeLock lock(m_Mutex);
   m_Callstacks.push_back(a_CallStack);
@@ -233,7 +231,7 @@ void SamplingProfiler::Print() {
       PRINT_VAR((void*)callstack->m_Hash);
       PRINT_VAR(callstack->m_Depth);
       for (uint32_t i = 0; i < callstack->m_Depth; ++i) {
-        PRINT("%s\n", m_AddressToName[callstack->m_Data[i]].c_str());
+        LOG("%s", m_AddressToName[callstack->m_Data[i]].c_str());
       }
     }
   }
@@ -255,7 +253,7 @@ void SamplingProfiler::ProcessSamples() {
   // Unique call stacks and per thread data
   for (const CallstackEvent& callstack : m_Callstacks) {
     if (!HasCallStack(callstack.m_Id)) {
-      PRINT("Error: Processed unknown callstack!\n");
+      LOG("Error: Processed unknown callstack!");
     }
 
     ThreadSampleData& threadSampleData = m_ThreadSampleData[callstack.m_TID];

--- a/OrbitCore/ScopeTimer.cpp
+++ b/OrbitCore/ScopeTimer.cpp
@@ -40,7 +40,7 @@ LocalScopeTimer::LocalScopeTimer(const std::string& message)
   for (size_t i = 0; i < CurrentDepthLocal; ++i) {
     tabs += "  ";
   }
-  PRINT(absl::StrFormat("%sStarting %s...\n", tabs.c_str(), message_.c_str()));
+  LOG("%sStarting %s...", tabs.c_str(), message_.c_str());
 
   ++CurrentDepthLocal;
   timer_.Start();
@@ -60,8 +60,8 @@ LocalScopeTimer::~LocalScopeTimer() {
       tabs += "  ";
     }
 
-    PRINT(absl::StrFormat("%s%s took %f ms.\n", tabs.c_str(), message_.c_str(),
-                          timer_.ElapsedMillis()));
+    LOG("%s%s took %f ms.", tabs.c_str(), message_.c_str(),
+        timer_.ElapsedMillis());
   }
 }
 

--- a/OrbitCore/Serialization.h
+++ b/OrbitCore/Serialization.h
@@ -75,7 +75,7 @@ struct ScopeCounter {
   ~ScopeCounter() {
     m_SizeEnd = GStreamCounter.Size();
     std::string size = GetPrettySize(m_SizeEnd - m_SizeBegin);
-    PRINT(L"%s size: %s\n", s2ws(m_Message).c_str(), s2ws(size).c_str());
+    LOG("%s size: %s", m_Message.c_str(), size.c_str());
   }
 
   std::string m_Message;

--- a/OrbitCore/TcpClient.cpp
+++ b/OrbitCore/TcpClient.cpp
@@ -90,7 +90,6 @@ void TcpClient::Start() {
   TcpEntity::Start();
 
   PRINT_FUNC;
-  OutputDebugStringW(L"TcpClient::Start()\n");
   CHECK(!workerThread_.joinable());
   workerThread_ = std::thread{[this]() { ClientThread(); }};
 
@@ -103,10 +102,10 @@ void TcpClient::Start() {
 //-----------------------------------------------------------------------------
 void TcpClient::ClientThread() {
   SetCurrentThreadName(L"OrbitTcpClient");
-  OutputDebugStringW(L"io_service started...\n");
+  LOG("io_service started...");
   asio::io_service::work work(*m_TcpService->m_IoService);
   m_TcpService->m_IoService->run();
-  OutputDebugStringW(L"io_service ended...\n");
+  LOG("io_service ended...");
 }
 
 //-----------------------------------------------------------------------------
@@ -160,7 +159,7 @@ void TcpClient::OnError(const std::error_code& ec) {
   }
 
   PRINT_VAR(ec.message().c_str());
-  OutputDebugStringW(L"Closing socket\n");
+  LOG("Closing socket");
   m_IsValid = false;
   Stop();
 }
@@ -214,9 +213,7 @@ void TcpClient::DecodeMessage(Message& a_Message) {
       uint32_t numAddresses = (uint32_t)a_Message.m_Size / sizeof(ULONG64);
       for (uint32_t i = 0; i < numAddresses; ++i) {
         void* address = (void*)addresses[i];
-        std::string dbgMsg =
-            absl::StrFormat("Hooking function at address: %p\n", address);
-        OutputDebugStringA(dbgMsg.c_str());
+        LOG("Hooking function at address: %p", address);
         Hijacking::CreateHook(address);
         GTcpClient->Send(Msg_NumInstalledHooks, i + 1);
       }
@@ -230,9 +227,7 @@ void TcpClient::DecodeMessage(Message& a_Message) {
       uint32_t numAddresses = (uint32_t)a_Message.m_Size / sizeof(ULONG64);
       for (uint32_t i = 0; i < numAddresses; ++i) {
         void* address = (void*)addresses[i];
-        std::string dbgMsg =
-            absl::StrFormat("Hooking zone function at address: %p\n", address);
-        OutputDebugStringA(dbgMsg.c_str());
+        LOG("Hooking zone function at address: %p", address);
         Hijacking::CreateZoneStartHook(address);
       }
 
@@ -245,9 +240,7 @@ void TcpClient::DecodeMessage(Message& a_Message) {
       uint32_t numAddresses = (uint32_t)a_Message.m_Size / sizeof(ULONG64);
       for (uint32_t i = 0; i < numAddresses; ++i) {
         void* address = (void*)addresses[i];
-        std::string dbgMsg =
-            absl::StrFormat("Hooking zone function at address: %p\n", address);
-        OutputDebugStringA(dbgMsg.c_str());
+        LOG("Hooking zone function at address: %p", address);
         Hijacking::CreateZoneStopHook(address);
       }
 
@@ -260,9 +253,7 @@ void TcpClient::DecodeMessage(Message& a_Message) {
       uint32_t numAddresses = (uint32_t)a_Message.m_Size / sizeof(ULONG64);
       for (uint32_t i = 0; i < numAddresses; ++i) {
         void* address = (void*)addresses[i];
-        std::string dbgMsg = absl::StrFormat(
-            "Hooking OutputDebugString function at address: %p\n", address);
-        OutputDebugStringA(dbgMsg.c_str());
+        LOG("Hooking OutputDebugString function at address: %p", address);
         Hijacking::CreateOutputDebugStringHook(address);
       }
 
@@ -275,9 +266,7 @@ void TcpClient::DecodeMessage(Message& a_Message) {
       uint32_t numAddresses = (uint32_t)a_Message.m_Size / sizeof(ULONG64);
       for (uint32_t i = 0; i < numAddresses; ++i) {
         void* address = (void*)addresses[i];
-        std::string dbgMsg = absl::StrFormat(
-            "Hooking Unreal Actor function at address: %p\n", address);
-        OutputDebugStringA(dbgMsg.c_str());
+        LOG("Hooking Unreal Actor function at address: %p", address);
         Hijacking::CreateUnrealActorHook(address);
       }
 
@@ -290,9 +279,7 @@ void TcpClient::DecodeMessage(Message& a_Message) {
       uint32_t numAddresses = (uint32_t)a_Message.m_Size / sizeof(ULONG64);
       for (uint32_t i = 0; i < numAddresses; ++i) {
         void* address = (void*)addresses[i];
-        std::string dbgMsg = absl::StrFormat(
-            "Hooking OrbitSendData function at address: %p\n", address);
-        OutputDebugStringA(dbgMsg.c_str());
+        LOG("Hooking OrbitSendData function at address: %p", address);
         Hijacking::CreateSendDataHook(address);
       }
 
@@ -305,9 +292,7 @@ void TcpClient::DecodeMessage(Message& a_Message) {
       uint32_t numAddresses = (uint32_t)a_Message.m_Size / sizeof(ULONG64);
       for (uint32_t i = 0; i < numAddresses; ++i) {
         void* address = (void*)addresses[i];
-        std::string dbgMsg =
-            absl::StrFormat("Hooking Alloc function at address: %p\n", address);
-        OutputDebugStringA(dbgMsg.c_str());
+        LOG("Hooking Alloc function at address: %p", address);
         Hijacking::CreateAllocHook(address);
       }
 
@@ -320,9 +305,7 @@ void TcpClient::DecodeMessage(Message& a_Message) {
       uint32_t numAddresses = (uint32_t)a_Message.m_Size / sizeof(ULONG64);
       for (uint32_t i = 0; i < numAddresses; ++i) {
         void* address = (void*)addresses[i];
-        std::string dbgMsg =
-            absl::StrFormat("Hooking Free function at address: %p\n", address);
-        OutputDebugStringA(dbgMsg.c_str());
+        LOG("Hooking Free function at address: %p", address);
         Hijacking::CreateFreeHook(address);
       }
 
@@ -360,9 +343,7 @@ void TcpClient::DecodeMessage(Message& a_Message) {
       uint32_t numAddresses = (uint32_t)a_Message.m_Size / sizeof(ULONG64);
       for (uint32_t i = 0; i < numAddresses; ++i) {
         void* address = (void*)addresses[i];
-        std::string dbgMsg =
-            absl::StrFormat("Callstack tracking for address: %p\n", address);
-        OutputDebugStringA(dbgMsg.c_str());
+        LOG("Callstack tracking for address: %p", address);
         Hijacking::TrackCallstack(addresses[i]);
       }
       break;

--- a/OrbitCore/TcpServer.cpp
+++ b/OrbitCore/TcpServer.cpp
@@ -78,8 +78,8 @@ void TcpServer::ResetStats() {
 //-----------------------------------------------------------------------------
 std::vector<std::string> TcpServer::GetStats() {
   std::vector<std::string> stats;
-  stats.push_back(VAR_TO_ANSI(m_NumReceivedMessages));
-  stats.push_back(VAR_TO_ANSI(m_NumMessagesPerSecond));
+  stats.push_back(VAR_TO_STR(m_NumReceivedMessages));
+  stats.push_back(VAR_TO_STR(m_NumMessagesPerSecond));
 
   if (m_TcpServer) {
     std::string bytesRcv = "Capture::GNumBytesReceiced = " +

--- a/OrbitCore/Utils.h
+++ b/OrbitCore/Utils.h
@@ -540,3 +540,9 @@ bool ReadProcessMemory(uint32_t pid, uint64_t address, byte* buffer,
 #define UNIQUE_VAR CONCAT(Unique, __LINE__)
 #define UNIQUE_ID CONCAT(Id_, __LINE__)
 #define UNUSED(x) (void)(x)
+
+#if __linux__
+#define FUNCTION_NAME __PRETTY_FUNCTION__
+#else
+#define FUNCTION_NAME __FUNCTION__
+#endif

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -809,15 +809,15 @@ void CaptureWindow::RenderUI() {
 
     m_StatsWindow.Clear();
 
-    m_StatsWindow.AddLine(VAR_TO_ANSI(m_Width));
-    m_StatsWindow.AddLine(VAR_TO_ANSI(m_Height));
-    m_StatsWindow.AddLine(VAR_TO_ANSI(m_DesiredWorldHeight));
-    m_StatsWindow.AddLine(VAR_TO_ANSI(m_DesiredWorldWidth));
-    m_StatsWindow.AddLine(VAR_TO_ANSI(m_WorldHeight));
-    m_StatsWindow.AddLine(VAR_TO_ANSI(m_WorldWidth));
-    m_StatsWindow.AddLine(VAR_TO_ANSI(m_WorldTopLeftX));
-    m_StatsWindow.AddLine(VAR_TO_ANSI(m_WorldTopLeftY));
-    m_StatsWindow.AddLine(VAR_TO_ANSI(m_WorldMinWidth));
+    m_StatsWindow.AddLine(VAR_TO_STR(m_Width));
+    m_StatsWindow.AddLine(VAR_TO_STR(m_Height));
+    m_StatsWindow.AddLine(VAR_TO_STR(m_DesiredWorldHeight));
+    m_StatsWindow.AddLine(VAR_TO_STR(m_DesiredWorldWidth));
+    m_StatsWindow.AddLine(VAR_TO_STR(m_WorldHeight));
+    m_StatsWindow.AddLine(VAR_TO_STR(m_WorldWidth));
+    m_StatsWindow.AddLine(VAR_TO_STR(m_WorldTopLeftX));
+    m_StatsWindow.AddLine(VAR_TO_STR(m_WorldTopLeftY));
+    m_StatsWindow.AddLine(VAR_TO_STR(m_WorldMinWidth));
 
     /*
             m_StatsWindow.AddLog( VAR_TO_CHAR(
@@ -837,15 +837,15 @@ void CaptureWindow::RenderUI() {
        Capture::GNumTimersAtOnce ) ); m_StatsWindow.AddLog( VAR_TO_CHAR(
        Capture::GNumTargetQueuedEntries ) ); m_StatsWindow.AddLog( VAR_TO_CHAR(
        m_MousePosX ) ); m_StatsWindow.AddLog( VAR_TO_CHAR( m_MousePosY ) );*/
-    m_StatsWindow.AddLine(VAR_TO_ANSI(Capture::GNumContextSwitches));
-    m_StatsWindow.AddLine(VAR_TO_ANSI(Capture::GNumLinuxEvents));
-    m_StatsWindow.AddLine(VAR_TO_ANSI(Capture::GNumProfileEvents));
-    m_StatsWindow.AddLine(VAR_TO_ANSI(Capture::GNumInstalledHooks));
-    m_StatsWindow.AddLine(VAR_TO_ANSI(Capture::GSelectedFunctionsMap.size()));
-    m_StatsWindow.AddLine(VAR_TO_ANSI(Capture::GVisibleFunctionsMap.size()));
-    m_StatsWindow.AddLine(VAR_TO_ANSI(m_TimeGraph.GetNumDrawnTextBoxes()));
-    m_StatsWindow.AddLine(VAR_TO_ANSI(m_TimeGraph.GetNumTimers()));
-    m_StatsWindow.AddLine(VAR_TO_ANSI(m_TimeGraph.GetThreadTotalHeight()));
+    m_StatsWindow.AddLine(VAR_TO_STR(Capture::GNumContextSwitches));
+    m_StatsWindow.AddLine(VAR_TO_STR(Capture::GNumLinuxEvents));
+    m_StatsWindow.AddLine(VAR_TO_STR(Capture::GNumProfileEvents));
+    m_StatsWindow.AddLine(VAR_TO_STR(Capture::GNumInstalledHooks));
+    m_StatsWindow.AddLine(VAR_TO_STR(Capture::GSelectedFunctionsMap.size()));
+    m_StatsWindow.AddLine(VAR_TO_STR(Capture::GVisibleFunctionsMap.size()));
+    m_StatsWindow.AddLine(VAR_TO_STR(m_TimeGraph.GetNumDrawnTextBoxes()));
+    m_StatsWindow.AddLine(VAR_TO_STR(m_TimeGraph.GetNumTimers()));
+    m_StatsWindow.AddLine(VAR_TO_STR(m_TimeGraph.GetThreadTotalHeight()));
 
 #ifdef WIN32
     for (std::string& line : GTcpServer->GetStats()) {
@@ -853,12 +853,12 @@ void CaptureWindow::RenderUI() {
     }
 
     bool hasConnection = GTcpServer->HasConnection();
-    m_StatsWindow.AddLine(VAR_TO_ANSI(hasConnection));
+    m_StatsWindow.AddLine(VAR_TO_STR(hasConnection));
 #else
     m_StatsWindow.AddLine(
-        VAR_TO_ANSI(GEventTracer.GetEventBuffer().GetCallstacks().size()));
+        VAR_TO_STR(GEventTracer.GetEventBuffer().GetCallstacks().size()));
     m_StatsWindow.AddLine(
-        VAR_TO_ANSI(GEventTracer.GetEventBuffer().GetNumEvents()));
+        VAR_TO_STR(GEventTracer.GetEventBuffer().GetNumEvents()));
 #endif
 
     m_StatsWindow.Draw("Capture Stats", &m_DrawStats);
@@ -1016,15 +1016,15 @@ void CaptureWindow::RenderMemTracker() {
 
   const MemoryTracker& memTracker = m_TimeGraph.GetMemoryTracker();
   if (memTracker.NumAllocatedBytes() == 0) {
-    std::string str = VAR_TO_ANSI(memTracker.NumAllocatedBytes()) +
+    std::string str = VAR_TO_STR(memTracker.NumAllocatedBytes()) +
                       std::string("            ");
     ImGui::Text("%s", str.c_str());
-    ImGui::Text("%s", VAR_TO_ANSI(memTracker.NumFreedBytes()));
-    ImGui::Text("%s", VAR_TO_ANSI(memTracker.NumLiveBytes()));
+    ImGui::Text("%s", VAR_TO_STR(memTracker.NumFreedBytes()).c_str());
+    ImGui::Text("%s", VAR_TO_STR(memTracker.NumLiveBytes()).c_str());
   } else {
-    ImGui::Text("%s", VAR_TO_ANSI(memTracker.NumAllocatedBytes()));
-    ImGui::Text("%s", VAR_TO_ANSI(memTracker.NumFreedBytes()));
-    ImGui::Text("%s", VAR_TO_ANSI(memTracker.NumLiveBytes()));
+    ImGui::Text("%s", VAR_TO_STR(memTracker.NumAllocatedBytes()).c_str());
+    ImGui::Text("%s", VAR_TO_STR(memTracker.NumFreedBytes()).c_str());
+    ImGui::Text("%s", VAR_TO_STR(memTracker.NumLiveBytes()).c_str());
   }
 
   ImGui::End();

--- a/OrbitGl/GlUtils.cpp
+++ b/OrbitGl/GlUtils.cpp
@@ -7,6 +7,7 @@
 #include "Core.h"
 #include "Log.h"
 #include "OpenGl.h"
+#include "OrbitBase/Logging.h"
 #include "absl/strings/str_format.h"
 #include "freetype-gl/freetype-gl.h"
 
@@ -15,8 +16,7 @@ void CheckGlError() {
   const char* errString;
   if (errCode != GL_NO_ERROR) {
     errString = reinterpret_cast<const char*>(gluErrorString(errCode));
-    ORBIT_LOG(absl::StrFormat("OpenGL ERROR : %s\n", errString));
-    PRINT(absl::StrFormat("OpenGL ERROR : %s\n", errString));
+    LOG("OpenGL ERROR : %s", errString);
   }
 }
 

--- a/OrbitLinuxTracing/PerfEventRecords.h
+++ b/OrbitLinuxTracing/PerfEventRecords.h
@@ -63,8 +63,7 @@ struct __attribute__((__packed__)) perf_event_sample_regs_user_all {
 
 // This struct must be in sync with the SAMPLE_REGS_USER_AX in
 // PerfEventOpen.h.
-struct __attribute__((__packed__)) perf_event_sample_regs_user_ax
-{
+struct __attribute__((__packed__)) perf_event_sample_regs_user_ax {
   uint64_t abi;
   uint64_t ax;
 };

--- a/OrbitLinuxTracing/PerfEventRingBuffer.cpp
+++ b/OrbitLinuxTracing/PerfEventRingBuffer.cpp
@@ -43,8 +43,7 @@ PerfEventRingBuffer::PerfEventRingBuffer(int perf_event_fd, uint64_t size_kb,
   // The size of a perf_event_open ring buffer is required to be a power of two
   // memory pages (from perf_event_open's manpage: "The mmap size should be
   // 1+2^n pages"), otherwise mmap on the file descriptor fails.
-  if (1024 * size_kb < GetPageSize() ||
-      __builtin_popcountl(size_kb) != 1) {
+  if (1024 * size_kb < GetPageSize() || __builtin_popcountl(size_kb) != 1) {
     return;
   }
 

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
@@ -1,4 +1,5 @@
 #include "UprobesUnwindingVisitor.h"
+
 #include "OrbitBase/Logging.h"
 
 namespace LinuxTracing {
@@ -93,9 +94,8 @@ void UprobesUnwindingVisitor::visit(UretprobesPerfEvent* event) {
   }
 
   std::optional<FunctionCall> function_call =
-      function_call_manager_.ProcessUretprobes(event->GetTid(),
-                                               event->GetTimestamp(),
-                                               event->GetAx());
+      function_call_manager_.ProcessUretprobes(
+          event->GetTid(), event->GetTimestamp(), event->GetAx());
   if (function_call.has_value()) {
     listener_->OnFunctionCall(function_call.value());
   }

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/Events.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/Events.h
@@ -85,7 +85,8 @@ class FunctionCall {
         virtual_address_(virtual_address),
         begin_timestamp_ns_(begin_timestamp_ns),
         end_timestamp_ns_(end_timestamp_ns),
-        depth_{depth}, return_value_(return_value) {}
+        depth_{depth},
+        return_value_(return_value) {}
 
   pid_t GetTid() const { return tid_; }
   uint64_t GetVirtualAddress() const { return virtual_address_; }

--- a/cmake/FindDIA2Dump.cmake
+++ b/cmake/FindDIA2Dump.cmake
@@ -15,6 +15,6 @@ target_link_libraries(DIA2Dump PUBLIC DIASDK::DIASDK)
 target_link_libraries(
   DIA2Dump PUBLIC multicore::multicore concurrentqueue::concurrentqueue
                   oqpi::oqpi xxHash::xxHash cereal::cereal)
-target_include_directories(DIA2Dump PRIVATE "OrbitCore/")
+target_include_directories(DIA2Dump PRIVATE "OrbitCore/" "OrbitBase/include/")
 
 add_library(DIA2Dump::DIA2Dump ALIAS DIA2Dump)

--- a/cmake/Findpeparse.cmake
+++ b/cmake/Findpeparse.cmake
@@ -13,6 +13,6 @@ target_include_directories(peparse SYSTEM PUBLIC ${DIR})
 target_link_libraries(
   peparse PUBLIC multicore::multicore concurrentqueue::concurrentqueue
                  oqpi::oqpi xxHash::xxHash cereal::cereal)
-target_include_directories(peparse PRIVATE "OrbitCore/")
+target_include_directories(peparse PRIVATE "OrbitCore/" "OrbitBase/include/")
 
 add_library(peparse::peparse ALIAS peparse)

--- a/external/DIA2Dump/dia2dump.cpp
+++ b/external/DIA2Dump/dia2dump.cpp
@@ -838,7 +838,6 @@ bool DumpAllFunctions(IDiaSymbol* pGlobal) {
   HRESULT res = pGlobal->findChildren(SymTagFunction, NULL, nsNone,
                                       &pEnumSymbols.m_Symbol);
   if (FAILED(res)) {
-    PRINT_VAR(res);
     PrintLastError();
     return false;
   }


### PR DESCRIPTION
- Remove OutputDebugStringA from Linux build, replace by LOG
- Fix compilation error due to not including Windows.h in OrbitBase/Loggins.h