### PR TITLE
Re-enable thread 0 track to enable selecting callstacks from all threads

### DIFF
--- a/OrbitCore/EventBuffer.h
+++ b/OrbitCore/EventBuffer.h
@@ -16,7 +16,8 @@
 
 //-----------------------------------------------------------------------------
 struct CallstackEvent {
-  CallstackEvent(long long a_Time = 0, CallstackID a_Id = 0, ThreadID a_TID = 0)
+  explicit CallstackEvent(long long a_Time = 0, CallstackID a_Id = 0,
+                          ThreadID a_TID = 0)
       : m_Time(a_Time), m_Id(a_Id), m_TID(a_TID) {}
   long long m_Time;
   CallstackID m_Id;

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -10,7 +10,7 @@
 
 //-----------------------------------------------------------------------------
 struct LineBuffer {
-  inline void Reset() {
+  void Reset() {
     m_Lines.Reset();
     m_Colors.Reset();
     m_PickingColors.Reset();
@@ -26,7 +26,7 @@ struct LineBuffer {
 
 //-----------------------------------------------------------------------------
 struct BoxBuffer {
-  inline void Reset() {
+  void Reset() {
     m_Boxes.Reset();
     m_Colors.Reset();
     m_PickingColors.Reset();
@@ -34,7 +34,6 @@ struct BoxBuffer {
   }
 
   static const int NUM_BOXES_PER_BLOCK = 64 * 1024;
-
   BlockChain<Box, NUM_BOXES_PER_BLOCK> m_Boxes;
   BlockChain<Color, 4 * NUM_BOXES_PER_BLOCK> m_Colors;
   BlockChain<Color, 4 * NUM_BOXES_PER_BLOCK> m_PickingColors;
@@ -44,8 +43,8 @@ struct BoxBuffer {
 //-----------------------------------------------------------------------------
 class Batcher {
  public:
-  inline void AddLine(const Line& a_Line, Color* a_Colors,
-                      PickingID::Type a_Type, void* a_UserData = nullptr) {
+  void AddLine(const Line& a_Line, Color* a_Colors, PickingID::Type a_Type,
+               void* a_UserData = nullptr) {
     Color pickCol = PickingID::GetColor(a_Type, m_LineBuffer.m_Lines.size());
     m_LineBuffer.m_Lines.push_back(a_Line);
     m_LineBuffer.m_Colors.push_back(a_Colors, 2);
@@ -53,8 +52,8 @@ class Batcher {
     m_LineBuffer.m_UserData.push_back(a_UserData);
   }
 
-  inline void AddBox(const Box& a_Box, Color* a_Colors, PickingID::Type a_Type,
-                     void* a_UserData = nullptr) {
+  void AddBox(const Box& a_Box, Color* a_Colors, PickingID::Type a_Type,
+              void* a_UserData = nullptr) {
     Color pickCol = PickingID::GetColor(a_Type, m_BoxBuffer.m_Boxes.size());
     m_BoxBuffer.m_Boxes.push_back(a_Box);
     m_BoxBuffer.m_Colors.push_back(a_Colors, 4);
@@ -62,7 +61,7 @@ class Batcher {
     m_BoxBuffer.m_UserData.push_back(a_UserData);
   }
 
-  inline void Reset() {
+  void Reset() {
     m_LineBuffer.Reset();
     m_BoxBuffer.Reset();
   }

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -23,10 +23,6 @@ ThreadTrack::ThreadTrack(TimeGraph* a_TimeGraph, uint32_t a_ThreadID) {
 
 //-----------------------------------------------------------------------------
 void ThreadTrack::Draw(GlCanvas* a_Canvas, bool a_Picking) {
-  // Scheduling information is held in thread "0", don't draw as threadtrack.
-  // TODO: Make a proper "SchedTrack" instead of hack.
-  if (m_ID == 0) return;
-
   TimeGraphLayout& layout = m_TimeGraph->GetLayout();
   float threadOffset = layout.GetThreadBlockStart(m_ID);
   float trackHeight = GetHeight();
@@ -49,7 +45,10 @@ void ThreadTrack::OnDrag(int a_X, int a_Y) { Track::OnDrag(a_X, a_Y); }
 
 //-----------------------------------------------------------------------------
 void ThreadTrack::OnTimer(const Timer& a_Timer) {
-  UpdateDepth(a_Timer.m_Depth + 1);
+  if (a_Timer.m_Type != Timer::CORE_ACTIVITY) {
+    UpdateDepth(a_Timer.m_Depth + 1);
+  }
+
   TextBox textBox(Vec2(0, 0), Vec2(0, 0), "", Color(255, 0, 0, 255));
   textBox.SetTimer(a_Timer);
 

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -53,7 +53,7 @@ class ThreadTrack : public Track {
   void SetEventTrackColor(Color color);
 
  protected:
-  inline void UpdateDepth(uint32_t a_Depth) {
+  void UpdateDepth(uint32_t a_Depth) {
     if (a_Depth > m_Depth) m_Depth = a_Depth;
   }
   std::shared_ptr<TimerChain> GetTimers(uint32_t a_Depth) const;
@@ -61,7 +61,7 @@ class ThreadTrack : public Track {
  protected:
   TextRenderer* m_TextRenderer = nullptr;
   std::shared_ptr<EventTrack> m_EventTrack;
-  uint32_t m_Depth = 1;
+  uint32_t m_Depth = 0;
   ThreadID m_ThreadID;
   bool m_Visible = true;
 

--- a/OrbitGl/TimeGraphLayout.cpp
+++ b/OrbitGl/TimeGraphLayout.cpp
@@ -20,7 +20,7 @@ TimeGraphLayout::TimeGraphLayout() {
   m_SpaceBetweenCoresAndThread = 30.f;
   m_SpaceBetweenTracks = 2.f;
   m_SpaceBetweenTracksAndThread = 5.f;
-  m_SpaceBetweenThreadBlocks = 30.f;
+  m_SpaceBetweenThreadBlocks = 35.f;
   m_TrackLabelOffset = 6.f;
   m_SliderWidth = 15.f;
   m_TextZ = -0.02f;
@@ -63,7 +63,7 @@ void TimeGraphLayout::SortTracksByPosition(
               return a->GetPos()[1] > b->GetPos()[1];
             });
 
-  // Reorder sorted threadIss
+  // Reorder m_SortedThreadIds.
   std::vector<ThreadID> sortedThreadIds;
   for (auto& track : tracks) {
     ThreadID tid = track->GetID();


### PR DESCRIPTION
This conceptually reverts 9348ec76bbc01043a3d32b973731c417a10f5561.
Set a name that points to the fact that it can be used to select from all
threads.
Bug: b/154720177

Also set the initial `ThreadTrack::m_Depth` to 0 but increase
`TimeGraphLayout::m_SpaceBetweenThreadBlocks` to leave more space between the
threads to drag the capture with the left mouse button.