### PR TITLE
Catch exceptions when deserializing a session

### DIFF
--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -41,7 +41,7 @@ class OrbitApp : public CoreApp {
   std::string GetSaveFile(const std::string& extension);
   void SetClipboard(const std::wstring& a_Text);
   void OnSaveSession(const std::string& file_name);
-  void OnLoadSession(const std::string& file_name);
+  bool OnLoadSession(const std::string& file_name);
   void OnSaveCapture(const std::string& file_name);
   void OnLoadCapture(const std::string& file_name);
   void OnOpenPdb(const std::string& file_name);

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -81,10 +81,9 @@ OrbitMainWindow::OrbitMainWindow(const std::vector<std::string>& arguments,
   });
   GOrbitApp->AddWatchCallback(
       [this](const Variable* a_Variable) { this->OnAddToWatch(a_Variable); });
-  GOrbitApp->SetSaveFileCallback(
-      [this](const std::string& extension) {
-        return this->OnGetSaveFileName(extension);
-      });
+  GOrbitApp->SetSaveFileCallback([this](const std::string& extension) {
+    return this->OnGetSaveFileName(extension);
+  });
   GOrbitApp->SetClipboardCallback(
       [this](const std::wstring& a_Text) { this->OnSetClipboard(a_Text); });
 
@@ -397,8 +396,10 @@ void OrbitMainWindow::OnAddToWatch(const class Variable* a_Variable) {
 
 //-----------------------------------------------------------------------------
 std::string OrbitMainWindow::OnGetSaveFileName(const std::string& extension) {
-  std::string filename = QFileDialog::getSaveFileName(
-      this, "Specify a file to save...", nullptr, extension.c_str()).toStdString();
+  std::string filename =
+      QFileDialog::getSaveFileName(this, "Specify a file to save...", nullptr,
+                                   extension.c_str())
+          .toStdString();
   if (!filename.empty() && !absl::EndsWith(filename, extension)) {
     filename += extension;
   }
@@ -462,8 +463,15 @@ void OrbitMainWindow::on_actionSave_Session_triggered() {
 void OrbitMainWindow::on_actionOpen_Session_triggered() {
   QStringList list = QFileDialog::getOpenFileNames(
       this, "Select a file to open...", Path::GetPresetPath().c_str(), "*.opr");
-  for (auto& file : list) {
-    GOrbitApp->OnLoadSession(file.toStdString());
+  for (const auto& file : list) {
+    bool loaded = GOrbitApp->OnLoadSession(file.toStdString());
+    if (!loaded) {
+      QMessageBox::critical(
+          this, "Error loading session",
+          absl::StrFormat("Could not load session from \"%s\".",
+                          file.toStdString())
+              .c_str());
+    }
     break;
   }
 }


### PR DESCRIPTION
Bug: b/154780659
`cereal::BinaryInputArchive` throws an exception when failing to deserialize
(`std::bad_alloc` in the case of the bug).