### PR TITLE
DataView filtering and sorting improvements

### DIFF
--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -141,6 +141,7 @@ void Capture::SetTargetProcess(const std::shared_ptr<Process>& a_Process) {
     GTargetProcess = a_Process;
     GSamplingProfiler = std::make_shared<SamplingProfiler>(a_Process);
     GSelectedFunctionsMap.clear();
+    GFunctionCountMap.clear();
     GOrbitUnreal.Clear();
     GTargetProcess->LoadDebugInfo();
     GTargetProcess->ClearWatchedVariables();

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -168,11 +168,11 @@ void CallStackDataView::OnContextMenu(const std::string& a_Action,
 }
 
 //-----------------------------------------------------------------------------
-void CallStackDataView::OnFilter(const std::string& a_Filter) {
+void CallStackDataView::DoFilter() {
   if (!m_CallStack) return;
 
   std::vector<uint32_t> indices;
-  std::vector<std::string> tokens = Tokenize(ToLower(a_Filter));
+  std::vector<std::string> tokens = Tokenize(ToLower(m_Filter));
 
   for (int i = 0; i < (int)m_CallStack->m_Depth; ++i) {
     CallStackDataViewFrame frame = GetFrameFromIndex(i);
@@ -203,6 +203,8 @@ void CallStackDataView::OnDataChanged() {
   for (size_t i = 0; i < numFunctions; ++i) {
     m_Indices[i] = i;
   }
+
+  DataView::OnDataChanged();
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/CallStackDataView.h
+++ b/OrbitGl/CallStackDataView.h
@@ -22,7 +22,7 @@ class CallStackDataView : public DataView {
   std::vector<std::string> GetContextMenu(
       int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) override;
   std::string GetValue(int a_Row, int a_Column) override;
-  void OnFilter(const std::string& a_Filter) override;
+
   void OnContextMenu(const std::string& a_Action, int a_MenuIndex,
                      const std::vector<int>& a_ItemIndices) override;
   void OnDataChanged() override;
@@ -32,6 +32,8 @@ class CallStackDataView : public DataView {
   }
 
  protected:
+  void DoFilter() override;
+
   std::shared_ptr<CallStack> m_CallStack;
 
   struct CallStackDataViewFrame {

--- a/OrbitGl/DataView.cpp
+++ b/OrbitGl/DataView.cpp
@@ -60,6 +60,42 @@ void DataView::InitSortingOrders() {
   for (const auto& column : GetColumns()) {
     m_SortingOrders.push_back(column.initial_order);
   }
+
+  m_SortingColumn = GetDefaultSortingColumn();
+}
+
+//-----------------------------------------------------------------------------
+void DataView::OnSort(int column, std::optional<SortingOrder> new_order) {
+  if (column < 0) {
+    return;
+  }
+
+  if (!IsSortingAllowed()) {
+    return;
+  }
+
+  if (m_SortingOrders.empty()) {
+    InitSortingOrders();
+  }
+
+  m_SortingColumn = column;
+  if (new_order.has_value()) {
+    m_SortingOrders[column] = new_order.value();
+  }
+
+  DoSort();
+}
+
+//-----------------------------------------------------------------------------
+void DataView::OnFilter(const std::string& filter) {
+  m_Filter = filter;
+  DoFilter();
+}
+
+//-----------------------------------------------------------------------------
+void DataView::OnDataChanged() {
+  OnSort(m_SortingColumn, std::optional<SortingOrder>{});
+  OnFilter(m_Filter);
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/DataView.h
+++ b/OrbitGl/DataView.h
@@ -3,6 +3,8 @@
 //-----------------------------------
 #pragma once
 
+#include <OrbitBase/Logging.h>
+
 #include <memory>
 #include <optional>
 #include <string>
@@ -30,10 +32,7 @@ class DataView {
   };
 
   explicit DataView(DataViewType type)
-      : m_LastSortedColumn(-1),
-        m_UpdatePeriodMs(-1),
-        m_SelectedIndex(-1),
-        m_Type(type) {}
+      : m_UpdatePeriodMs(-1), m_SelectedIndex(-1), m_Type(type) {}
 
   virtual ~DataView();
 
@@ -43,25 +42,20 @@ class DataView {
   virtual const std::vector<Column>& GetColumns() = 0;
   virtual bool IsSortingAllowed() { return true; }
   virtual int GetDefaultSortingColumn() { return 0; }
-  void InitSortingOrders();
   virtual std::vector<std::string> GetContextMenu(
       int a_ClickedIndex, const std::vector<int>& a_SelectedIndices);
   virtual size_t GetNumElements() { return m_Indices.size(); }
   virtual std::string GetValue(int /*a_Row*/, int /*a_Column*/) { return ""; }
   virtual std::string GetToolTip(int /*a_Row*/, int /*a_Column*/) { return ""; }
-  virtual void SetFilter(const std::string& a_Filter) {
-    m_Filter = a_Filter;
-    OnFilter(a_Filter);
-  }
-  virtual void OnFilter(const std::string& /*a_Filter*/) {}
-  virtual void OnSort(int /*a_Column*/,
-                      std::optional<SortingOrder> /*a_NewOrder*/) {}
+
+  void OnFilter(const std::string& filter);
+  void OnSort(int column, std::optional<SortingOrder> new_order);
   virtual void OnContextMenu(const std::string& a_Action, int a_MenuIndex,
                              const std::vector<int>& a_ItemIndices);
   virtual void OnItemActivated() {}
   virtual void OnSelect(int /*a_Index*/) {}
   virtual int GetSelectedIndex() { return m_SelectedIndex; }
-  virtual void OnDataChanged() {}
+  virtual void OnDataChanged();
   virtual void OnTimer() {}
   virtual bool WantsDisplayColor() { return false; }
   virtual bool GetDisplayColor(int /*a_Row*/, int /*a_Column*/,
@@ -81,9 +75,13 @@ class DataView {
   DataViewType GetType() const { return m_Type; }
 
  protected:
+  void InitSortingOrders();
+  virtual void DoSort() {}
+  virtual void DoFilter() {}
+
   std::vector<uint32_t> m_Indices;
   std::vector<SortingOrder> m_SortingOrders;
-  int m_LastSortedColumn;
+  int m_SortingColumn = 0;
   std::string m_Filter;
   int m_UpdatePeriodMs;
   int m_SelectedIndex;

--- a/OrbitGl/FunctionsDataView.h
+++ b/OrbitGl/FunctionsDataView.h
@@ -15,14 +15,15 @@ class FunctionsDataView : public DataView {
   std::vector<std::string> GetContextMenu(
       int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) override;
   std::string GetValue(int a_Row, int a_Column) override;
-  void OnFilter(const std::string& a_Filter) override;
-  void ParallelFilter();
-  void OnSort(int a_Column, std::optional<SortingOrder> a_NewOrder) override;
+
   void OnContextMenu(const std::string& a_Action, int a_MenuIndex,
                      const std::vector<int>& a_ItemIndices) override;
   void OnDataChanged() override;
 
  protected:
+  void DoSort() override;
+  void DoFilter() override;
+  void ParallelFilter();
   Function& GetFunction(int a_Row) const;
 
   std::vector<std::string> m_FilterTokens;

--- a/OrbitGl/GlobalsDataView.h
+++ b/OrbitGl/GlobalsDataView.h
@@ -16,16 +16,17 @@ class GlobalsDataView : public DataView {
       int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) override;
   std::string GetValue(int a_Row, int a_Column) override;
 
-  void OnFilter(const std::string& a_Filter) override;
-  void ParallelFilter();
-  void OnSort(int a_Column, std::optional<SortingOrder> a_NewOrder) override;
   void OnContextMenu(const std::string& a_Action, int a_MenuIndex,
                      const std::vector<int>& a_ItemIndices) override;
   void OnDataChanged() override;
-  void OnAddToWatch(const std::vector<int>& a_Items);
 
  protected:
+  void DoSort() override;
+  void DoFilter() override;
+  void ParallelFilter();
   Variable& GetVariable(unsigned int a_Row) const;
+  void AddToWatch(const std::vector<int>& a_Items);
+
   std::vector<std::string> m_FilterTokens;
 
   enum ColumnIndex {

--- a/OrbitGl/LiveFunctionsDataView.cpp
+++ b/OrbitGl/LiveFunctionsDataView.cpp
@@ -15,10 +15,8 @@
 //-----------------------------------------------------------------------------
 LiveFunctionsDataView::LiveFunctionsDataView()
     : DataView(DataViewType::LIVE_FUNCTIONS) {
-  InitSortingOrders();
   GOrbitApp->RegisterLiveFunctionsDataView(this);
   m_UpdatePeriodMs = 300;
-  m_LastSortedColumn = 3; /*Count*/
   OnDataChanged();
 }
 
@@ -90,18 +88,13 @@ std::string LiveFunctionsDataView::GetValue(int a_Row, int a_Column) {
   }
 
 //-----------------------------------------------------------------------------
-void LiveFunctionsDataView::OnSort(int a_Column,
-                                   std::optional<SortingOrder> a_NewOrder) {
-  const std::vector<Function*>& functions = m_Functions;
-
-  if (a_NewOrder.has_value()) {
-    m_SortingOrders[a_Column] = a_NewOrder.value();
-  }
-
-  bool ascending = m_SortingOrders[a_Column] == SortingOrder::Ascending;
+void LiveFunctionsDataView::DoSort() {
+  bool ascending = m_SortingOrders[m_SortingColumn] == SortingOrder::Ascending;
   std::function<bool(int a, int b)> sorter = nullptr;
 
-  switch (a_Column) {
+  const std::vector<Function*>& functions = m_Functions;
+
+  switch (m_SortingColumn) {
     case COLUMN_SELECTED:
       sorter = ORBIT_FUNC_SORT(IsSelected());
       break;
@@ -135,10 +128,8 @@ void LiveFunctionsDataView::OnSort(int a_Column,
   }
 
   if (sorter) {
-    std::sort(m_Indices.begin(), m_Indices.end(), sorter);
+    std::stable_sort(m_Indices.begin(), m_Indices.end(), sorter);
   }
-
-  m_LastSortedColumn = a_Column;
 }
 
 //-----------------------------------------------------------------------------
@@ -183,10 +174,10 @@ void LiveFunctionsDataView::OnContextMenu(
 }
 
 //-----------------------------------------------------------------------------
-void LiveFunctionsDataView::OnFilter(const std::string& a_Filter) {
+void LiveFunctionsDataView::DoFilter() {
   std::vector<uint32_t> indices;
 
-  std::vector<std::string> tokens = Tokenize(ToLower(a_Filter));
+  std::vector<std::string> tokens = Tokenize(ToLower(m_Filter));
 
   for (size_t i = 0; i < m_Functions.size(); ++i) {
     const Function* function = m_Functions[i];
@@ -210,9 +201,7 @@ void LiveFunctionsDataView::OnFilter(const std::string& a_Filter) {
 
   m_Indices = indices;
 
-  if (m_LastSortedColumn != -1) {
-    OnSort(m_LastSortedColumn, {});
-  }
+  OnSort(m_SortingColumn, {});
 
   // Filter drawn textboxes
   Capture::GVisibleFunctionsMap.clear();
@@ -239,13 +228,13 @@ void LiveFunctionsDataView::OnDataChanged() {
     m_Functions.push_back(func);
   }
 
-  OnFilter(m_Filter);
+  DataView::OnDataChanged();
 }
 
 //-----------------------------------------------------------------------------
 void LiveFunctionsDataView::OnTimer() {
   if (Capture::IsCapturing()) {
-    OnSort(m_LastSortedColumn, {});
+    OnSort(m_SortingColumn, {});
   }
 }
 

--- a/OrbitGl/LiveFunctionsDataView.h
+++ b/OrbitGl/LiveFunctionsDataView.h
@@ -17,16 +17,17 @@ class LiveFunctionsDataView : public DataView {
       int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) override;
   std::string GetValue(int a_Row, int a_Column) override;
 
-  void OnFilter(const std::string& a_Filter) override;
-  void OnSort(int a_Column, std::optional<SortingOrder> a_NewOrder) override;
   void OnContextMenu(const std::string& a_Action, int a_MenuIndex,
                      const std::vector<int>& a_ItemIndices) override;
   void OnDataChanged() override;
   void OnTimer() override;
 
  protected:
-  std::vector<Function*> m_Functions;
+  void DoFilter() override;
+  void DoSort() override;
   Function& GetFunction(unsigned int a_Row) const;
+
+  std::vector<Function*> m_Functions;
 
   enum ColumnIndex {
     COLUMN_SELECTED,

--- a/OrbitGl/LogDataView.cpp
+++ b/OrbitGl/LogDataView.cpp
@@ -11,7 +11,6 @@
 
 //-----------------------------------------------------------------------------
 LogDataView::LogDataView() : DataView(DataViewType::LOG) {
-  InitSortingOrders();
   GOrbitApp->RegisterOutputLog(this);
   GTcpServer->AddCallback(Msg_OrbitLog, [=](const Message& a_Msg) {
     this->OnReceiveMessage(a_Msg);
@@ -81,11 +80,13 @@ void LogDataView::OnDataChanged() {
   for (size_t i = 0; i < m_Entries.size(); ++i) {
     m_Indices[i] = i;
   }
+
+  DataView::OnDataChanged();
 }
 
 //-----------------------------------------------------------------------------
-void LogDataView::OnFilter(const std::string& a_Filter) {
-  std::vector<std::string> tokens = Tokenize(ToLower(a_Filter));
+void LogDataView::DoFilter() {
+  std::vector<std::string> tokens = Tokenize(ToLower(m_Filter));
   std::vector<uint32_t> indices;
 
   for (size_t i = 0; i < m_Entries.size(); ++i) {

--- a/OrbitGl/LogDataView.h
+++ b/OrbitGl/LogDataView.h
@@ -24,15 +24,17 @@ class LogDataView : public DataView {
   bool SkipTimer() override;
 
   void OnDataChanged() override;
-  void OnFilter(const std::string& a_Filter) override;
   void OnContextMenu(const std::string& a_Action, int a_MenuIndex,
                      const std::vector<int>& a_ItemIndices) override;
 
   void Add(const OrbitLogEntry& a_Msg);
-  const OrbitLogEntry& GetEntry(unsigned int a_Row) const;
   void OnReceiveMessage(const Message& a_Msg);
 
  protected:
+  // TODO: DoSort() override;
+  void DoFilter() override;
+  const OrbitLogEntry& GetEntry(unsigned int a_Row) const;
+
   std::vector<OrbitLogEntry> m_Entries;
   Mutex m_Mutex;
   std::shared_ptr<CallStack> m_SelectedCallstack;

--- a/OrbitGl/ModulesDataView.cpp
+++ b/OrbitGl/ModulesDataView.cpp
@@ -10,7 +10,6 @@
 
 //-----------------------------------------------------------------------------
 ModulesDataView::ModulesDataView() : DataView(DataViewType::MODULES) {
-  InitSortingOrders();
   GOrbitApp->RegisterModulesDataView(this);
 }
 
@@ -64,16 +63,11 @@ std::string ModulesDataView::GetValue(int row, int col) {
   }
 
 //-----------------------------------------------------------------------------
-void ModulesDataView::OnSort(int a_Column,
-                             std::optional<SortingOrder> a_NewOrder) {
-  if (a_NewOrder.has_value()) {
-    m_SortingOrders[a_Column] = a_NewOrder.value();
-  }
-
-  bool ascending = m_SortingOrders[a_Column] == SortingOrder::Ascending;
+void ModulesDataView::DoSort() {
+  bool ascending = m_SortingOrders[m_SortingColumn] == SortingOrder::Ascending;
   std::function<bool(int a, int b)> sorter = nullptr;
 
-  switch (a_Column) {
+  switch (m_SortingColumn) {
     case COLUMN_NAME:
       sorter = ORBIT_PROC_SORT(m_Name);
       break;
@@ -97,10 +91,8 @@ void ModulesDataView::OnSort(int a_Column,
   }
 
   if (sorter) {
-    std::sort(m_Indices.begin(), m_Indices.end(), sorter);
+    std::stable_sort(m_Indices.begin(), m_Indices.end(), sorter);
   }
-
-  m_LastSortedColumn = a_Column;
 }
 
 //-----------------------------------------------------------------------------
@@ -180,9 +172,9 @@ void ModulesDataView::OnContextMenu(const std::string& a_Action,
 void ModulesDataView::OnTimer() {}
 
 //-----------------------------------------------------------------------------
-void ModulesDataView::OnFilter(const std::string& a_Filter) {
+void ModulesDataView::DoFilter() {
   std::vector<uint32_t> indices;
-  std::vector<std::string> tokens = Tokenize(ToLower(a_Filter));
+  std::vector<std::string> tokens = Tokenize(ToLower(m_Filter));
 
   for (int i = 0; i < (int)m_Modules.size(); ++i) {
     std::shared_ptr<Module>& module = m_Modules[i];
@@ -204,9 +196,7 @@ void ModulesDataView::OnFilter(const std::string& a_Filter) {
 
   m_Indices = indices;
 
-  if (m_LastSortedColumn != -1) {
-    OnSort(m_LastSortedColumn, {});
-  }
+  OnSort(m_SortingColumn, {});
 }
 
 //-----------------------------------------------------------------------------
@@ -225,9 +215,7 @@ void ModulesDataView::SetProcess(const std::shared_ptr<Process>& a_Process) {
     m_Indices[i] = i;
   }
 
-  if (m_LastSortedColumn != -1) {
-    OnSort(m_LastSortedColumn, {});
-  }
+  OnDataChanged();
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/ModulesDataView.h
+++ b/OrbitGl/ModulesDataView.h
@@ -17,8 +17,6 @@ class ModulesDataView : public DataView {
       int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) override;
   std::string GetValue(int a_Row, int a_Column) override;
 
-  void OnFilter(const std::string& a_Filter) override;
-  void OnSort(int a_Column, std::optional<SortingOrder> a_NewOrder) override;
   void OnContextMenu(const std::string& a_Action, int a_MenuIndex,
                      const std::vector<int>& a_ItemIndices) override;
   void OnTimer() override;
@@ -30,6 +28,8 @@ class ModulesDataView : public DataView {
   void SetProcess(const std::shared_ptr<Process>& a_Process);
 
  protected:
+  void DoSort() override;
+  void DoFilter() override;
   const std::shared_ptr<Module>& GetModule(unsigned int a_Row) const;
 
   std::shared_ptr<Process> m_Process;

--- a/OrbitGl/ProcessesDataView.h
+++ b/OrbitGl/ProcessesDataView.h
@@ -16,8 +16,6 @@ class ProcessesDataView : public DataView {
   std::string GetToolTip(int a_Row, int a_Column) override;
   std::string GetLabel() override { return "Processes"; }
 
-  void OnFilter(const std::string& a_Filter) override;
-  void OnSort(int a_Column, std::optional<SortingOrder> a_NewOrder) override;
   void OnSelect(int a_Index) override;
   void OnTimer() override;
   void SetSelectedItem();
@@ -34,6 +32,8 @@ class ProcessesDataView : public DataView {
   void SetIsRemote(bool a_Value) { m_IsRemote = a_Value; }
 
  protected:
+  void DoSort() override;
+  void DoFilter() override;
   std::shared_ptr<Process> GetProcess(unsigned int a_Row) const;
   void ClearSelectedProcess();
 

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -18,9 +18,7 @@
 
 //-----------------------------------------------------------------------------
 SamplingReportDataView::SamplingReportDataView()
-    : DataView(DataViewType::SAMPLING), m_CallstackDataView(nullptr) {
-  InitSortingOrders();
-}
+    : DataView(DataViewType::SAMPLING), m_CallstackDataView(nullptr) {}
 
 //-----------------------------------------------------------------------------
 const std::vector<DataView::Column>& SamplingReportDataView::GetColumns() {
@@ -77,18 +75,13 @@ std::string SamplingReportDataView::GetValue(int a_Row, int a_Column) {
   }
 
 //-----------------------------------------------------------------------------
-void SamplingReportDataView::OnSort(int a_Column,
-                                    std::optional<SortingOrder> a_NewOrder) {
-  std::vector<SampledFunction>& functions = m_Functions;
-
-  if (a_NewOrder.has_value()) {
-    m_SortingOrders[a_Column] = a_NewOrder.value();
-  }
-
-  bool ascending = m_SortingOrders[a_Column] == SortingOrder::Ascending;
+void SamplingReportDataView::DoSort() {
+  bool ascending = m_SortingOrders[m_SortingColumn] == SortingOrder::Ascending;
   std::function<bool(int a, int b)> sorter = nullptr;
 
-  switch (a_Column) {
+  std::vector<SampledFunction>& functions = m_Functions;
+
+  switch (m_SortingColumn) {
     case COLUMN_SELECTED:
       sorter = ORBIT_PROC_SORT(GetSelected());
       break;
@@ -118,10 +111,8 @@ void SamplingReportDataView::OnSort(int a_Column,
   }
 
   if (sorter) {
-    std::sort(m_Indices.begin(), m_Indices.end(), sorter);
+    std::stable_sort(m_Indices.begin(), m_Indices.end(), sorter);
   }
-
-  m_LastSortedColumn = a_Column;
 }
 
 //-----------------------------------------------------------------------------
@@ -249,6 +240,8 @@ void SamplingReportDataView::SetSampledFunctions(
   for (size_t i = 0; i < numFunctions; ++i) {
     m_Indices[i] = i;
   }
+
+  OnDataChanged();
 }
 
 //-----------------------------------------------------------------------------
@@ -262,10 +255,10 @@ void SamplingReportDataView::SetThreadID(ThreadID a_TID) {
 }
 
 //-----------------------------------------------------------------------------
-void SamplingReportDataView::OnFilter(const std::string& a_Filter) {
+void SamplingReportDataView::DoFilter() {
   std::vector<uint32_t> indices;
 
-  std::vector<std::string> tokens = Tokenize(ToLower(a_Filter));
+  std::vector<std::string> tokens = Tokenize(ToLower(m_Filter));
 
   for (size_t i = 0; i < m_Functions.size(); ++i) {
     SampledFunction& func = m_Functions[i];
@@ -289,9 +282,7 @@ void SamplingReportDataView::OnFilter(const std::string& a_Filter) {
 
   m_Indices = indices;
 
-  if (m_LastSortedColumn != -1) {
-    OnSort(m_LastSortedColumn, {});
-  }
+  OnSort(m_SortingColumn, {});
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/SamplingReportDataView.h
+++ b/OrbitGl/SamplingReportDataView.h
@@ -20,8 +20,6 @@ class SamplingReportDataView : public DataView {
   std::string GetValue(int a_Row, int a_Column) override;
   const std::string& GetName() { return m_Name; }
 
-  void OnFilter(const std::string& a_Filter) override;
-  void OnSort(int a_Column, std::optional<SortingOrder> a_NewOrder) override;
   void OnContextMenu(const std::string& a_Action, int a_MenuIndex,
                      const std::vector<int>& a_ItemIndices) override;
   void OnSelect(int a_Index) override;
@@ -35,6 +33,8 @@ class SamplingReportDataView : public DataView {
   std::vector<SampledFunction>& GetSampledFunctions() { return m_Functions; }
 
  protected:
+  void DoSort() override;
+  void DoFilter() override;
   const SampledFunction& GetSampledFunction(unsigned int a_Row) const;
   SampledFunction& GetSampledFunction(unsigned int a_Row);
   std::vector<Function*> GetFunctionsFromIndices(

--- a/OrbitGl/SessionsDataView.h
+++ b/OrbitGl/SessionsDataView.h
@@ -22,14 +22,14 @@ class SessionsDataView : public DataView {
   std::string GetLabel() override { return "Sessions"; }
 
   void OnDataChanged() override;
-  void OnFilter(const std::string& a_Filter) override;
-  void OnSort(int a_Column, std::optional<SortingOrder> a_NewOrder) override;
   void OnContextMenu(const std::string& a_Action, int a_MenuIndex,
                      const std::vector<int>& a_ItemIndices) override;
 
   void SetSessions(const std::vector<std::shared_ptr<Session> >& a_Sessions);
 
  protected:
+  void DoSort() override;
+  void DoFilter() override;
   const std::shared_ptr<Session>& GetSession(unsigned int a_Row) const;
 
   std::vector<std::shared_ptr<Session> > m_Sessions;

--- a/OrbitGl/TypesDataView.cpp
+++ b/OrbitGl/TypesDataView.cpp
@@ -17,9 +17,7 @@
 
 //-----------------------------------------------------------------------------
 TypesDataView::TypesDataView() : DataView(DataViewType::TYPES) {
-  InitSortingOrders();
   OnDataChanged();
-
   GOrbitApp->RegisterTypesDataView(this);
 }
 
@@ -30,6 +28,8 @@ void TypesDataView::OnDataChanged() {
   for (int i = 0; i < numTypes; ++i) {
     m_Indices[i] = i;
   }
+
+  DataView::OnDataChanged();
 }
 
 //-----------------------------------------------------------------------------
@@ -87,18 +87,19 @@ std::string TypesDataView::GetValue(int a_Row, int a_Column) {
 }
 
 //-----------------------------------------------------------------------------
-void TypesDataView::OnFilter(const std::string& a_Filter) {
-  ParallelFilter(a_Filter);
+void TypesDataView::DoFilter() {
+  m_FilterTokens = Tokenize(ToLower(m_Filter));
 
-  if (m_LastSortedColumn != -1) {
-    OnSort(m_LastSortedColumn, {});
-  }
+  // TODO: This only performs work on Windows. It is currently not an issue as
+  //  globals are not supported elsewhere.
+  ParallelFilter();
+
+  OnSort(m_SortingColumn, {});
 }
 
 //-----------------------------------------------------------------------------
-void TypesDataView::ParallelFilter(const std::string& a_Filter) {
+void TypesDataView::ParallelFilter() {
 #ifdef _WIN32
-  m_FilterTokens = Tokenize(ToLower(a_Filter));
   std::vector<Type*>& types = Capture::GTargetProcess->GetTypes();
   const auto prio = oqpi::task_priority::normal;
   auto numWorkers = oqpi_tk::scheduler().workersCount(prio);
@@ -131,8 +132,6 @@ void TypesDataView::ParallelFilter(const std::string& a_Filter) {
   for (int i : indicesSet) {
     m_Indices.push_back(i);
   }
-#else
-  UNUSED(a_Filter);
 #endif
 }
 
@@ -143,18 +142,13 @@ void TypesDataView::ParallelFilter(const std::string& a_Filter) {
   }
 
 //-----------------------------------------------------------------------------
-void TypesDataView::OnSort(int a_Column,
-                           std::optional<SortingOrder> a_NewOrder) {
-  const std::vector<Type*>& types = Capture::GTargetProcess->GetTypes();
-
-  if (a_NewOrder.has_value()) {
-    m_SortingOrders[a_Column] = a_NewOrder.value();
-  }
-
-  bool ascending = m_SortingOrders[a_Column] == SortingOrder::Ascending;
+void TypesDataView::DoSort() {
+  bool ascending = m_SortingOrders[m_SortingColumn] == SortingOrder::Ascending;
   std::function<bool(int a, int b)> sorter = nullptr;
 
-  switch (a_Column) {
+  const std::vector<Type*>& types = Capture::GTargetProcess->GetTypes();
+
+  switch (m_SortingColumn) {
     case COLUMN_NAME:
       sorter = ORBIT_TYPE_SORT(m_Name);
       break;
@@ -189,8 +183,6 @@ void TypesDataView::OnSort(int a_Column,
   if (sorter) {
     std::sort(m_Indices.begin(), m_Indices.end(), sorter);
   }
-
-  m_LastSortedColumn = a_Column;
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/TypesDataView.h
+++ b/OrbitGl/TypesDataView.h
@@ -18,14 +18,14 @@ class TypesDataView : public DataView {
       int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) override;
   std::string GetValue(int a_Row, int a_Column) override;
 
-  void OnFilter(const std::string& a_Filter) override;
-  void ParallelFilter(const std::string& a_Filter);
-  void OnSort(int a_Column, std::optional<SortingOrder> a_NewOrder) override;
   void OnContextMenu(const std::string& a_Action, int a_MenuIndex,
                      const std::vector<int>& a_ItemIndices) override;
   void OnDataChanged() override;
 
  protected:
+  void DoSort() override;
+  void DoFilter() override;
+  void ParallelFilter();
   Type& GetType(unsigned int a_Row) const;
 
   void OnProp(const std::vector<int>& a_Items);

--- a/OrbitQt/orbittablemodel.cpp
+++ b/OrbitQt/orbittablemodel.cpp
@@ -125,7 +125,7 @@ void OrbitTableModel::OnTimer() { m_DataView->OnTimer(); }
 
 //-----------------------------------------------------------------------------
 void OrbitTableModel::OnFilter(const QString& a_Filter) {
-  m_DataView->SetFilter(a_Filter.toStdString());
+  m_DataView->OnFilter(a_Filter.toStdString());
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Split `virtual OnSort` and `virtual OnFilter` in `OnSort` and `virtual DoSort`,
`OnFilter` and `virtual DoFilter`.
Re-sort and re-filter when `DataView`'s subclasses' data is changed, in
particular in `OnDataChanged`, to tackle b/154599995.
Use `std::stable_sort` for sorting, so that sorting consecutively by different
columns yields the expected behavior.