### PR TITLE
Enable internal Artifactory server

### DIFF
--- a/bootstrap-orbit-ggp.bat
+++ b/bootstrap-orbit-ggp.bat
@@ -1,8 +1,6 @@
+REM Copyright (c) 2020 The Orbit Authors. All rights reserved.
+REM Use of this source code is governed by a BSD-style license that can be
+REM found in the LICENSE file.
+
 @echo off
 call powershell "& %~dp0\bootstrap-orbit-ggp.ps1 %*"
-
-echo[
-echo ---------------------------------------------------------------------------------
-echo - By the way: "bootstrap-orbit-ggp.bat" is deprecated and will be removed soon. -
-echo - Please use "bootstrap-orbit-ggp.ps1" - the PowerShell equivalent - instead.   -
-echo ---------------------------------------------------------------------------------

--- a/bootstrap-orbit-ggp.ps1
+++ b/bootstrap-orbit-ggp.ps1
@@ -1,65 +1,13 @@
-$conan = Get-Command -ErrorAction Ignore conan
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
 
-if (!$conan) {
-  Write-Host "Conan not found. Trying to install it via python-pip..."
-	
-  $pip3 = Get-Command -ErrorAction Ignore pip3
-	
-  if(!$pip3) {	
-    Write-Error -ErrorAction Stop @"
-It seems you don't have Python3 installed (pip3.exe not found).
-Please install Python or make it available in the path.
-Alternatively you could also just install conan manually and make
-it available in the path.
-"@
-  }
+& "$PSScriptRoot\bootstrap-orbit.ps1" "ggp_release"
 
-  $result = Start-Process -FilePath $pip3.Path -ArgumentList "install","conan" -Wait -NoNewWindow -ErrorAction Stop -PassThru
-  if ($result.ExitCode -ne 0) {
-    Throw "Error while installing conan via pip3."
-  }
-    
-  $conan = Get-Command -ErrorAction Ignore conan
-  if (!$conan) {
-    Write-Error -ErrorAction Stop @"
-It seems we installed conan sucessfully, but it is not available
-in the path. Please ensure that your Python user-executable folder is
-in the path and call this script again.
-You can call 'pip3 show -f conan' to figure out where conan.exe was placed.
-"@
-  }
-} else {
-  Write-Host "Conan found. Skipping installation..."
-}
+Write-Host @'
 
-# Install conan config
-$result = Start-Process -FilePath $conan.Path -ArgumentList "config","install","$PSScriptRoot\contrib\conan\configs\windows" -Wait -NoNewWindow -ErrorAction Stop -PassThru
-if ($result.ExitCode -ne 0) {
-  Throw "Error while installing conan config."
-}
-
-# Install Stadia GGP SDK
-$search_result = & $conan.Path search ggp_sdk 2>&1
-if (-not ($search_result -like "*orbitdeps*")) {
-  if (-not (Test-Path -Path "$PSScriptRoot\contrib\conan\recipes\ggp_sdk" -PathType Container)) {
-    $git = Get-Command -ErrorAction Stop git
-    $result = Start-Process -FilePath $git.Path -Wait -NoNewWindow -ErrorAction Stop -PassThru -ArgumentList "clone","sso://user/hebecker/conan-ggp_sdk","$PSScriptRoot\contrib\conan\recipes\ggp_sdk"
-    if ($result.ExitCode -ne 0) {
-      Throw "Error in git clone command."
-    }
-  }
-
-  $result = Start-Process -FilePath $conan.Path -Wait -NoNewWindow -ErrorAction Stop -PassThru -ArgumentList "export","$PSScriptRoot\contrib\conan\recipes\ggp_sdk","orbitdeps/stable"
-  if ($result.ExitCode -ne 0) {
-      Throw "Error in conan export command."
-  }
-} ELSE {
-  Write-Host "ggp_sdk seems to be installed already. Skipping installation step..."
-}
-
-# Start build
-if ($args) {
-  & "$PSScriptRoot\build.ps1" $args
-} else {
-  & "$PSScriptRoot\build.ps1" "ggp_release"
-}
+---------------------------------------------------------------------------------------
+- By the way: "bootstrap-orbit-ggp.*" is not needed anymore and will be removed soon. -
+- Please use "bootstrap-orbit.ps1 ggp_release" instead.                               -
+---------------------------------------------------------------------------------------
+'@

--- a/bootstrap-orbit-ggp.sh
+++ b/bootstrap-orbit-ggp.sh
@@ -1,26 +1,15 @@
 #!/bin/bash
-
+#
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-which conan >/dev/null
-if [ $? -ne 0 ]; then
-        sudo pip3 install conan
-fi
+"${DIR}/bootstrap-orbit.sh" ggp_release
 
-unset GGP_SDK_PATH
-
-conan config install $DIR/contrib/conan/configs/linux || exit $?
-
-# Install Stadia GGP SDK
-conan search ggp_sdk | grep orbitdeps/stable > /dev/null
-if [ $? -ne 0 ]; then
-  if [ ! -d $DIR/contrib/conan/recipes/ggp_sdk ]; then
-    git clone sso://user/hebecker/conan-ggp_sdk $DIR/contrib/conan/recipes/ggp_sdk || exit $?
-  fi
-  conan export $DIR/contrib/conan/recipes/ggp_sdk orbitdeps/stable || exit $?
-else
-  echo "ggp_sdk seems to be installed already. Skipping installation step..."
-fi
-
-$DIR/build.sh ggp_release
+echo ''
+echo '----------------------------------------------------------------------------------------'
+echo '- By the way: "bootstrap-orbit-ggp.sh" is not needed anymore and will be removed soon. -'
+echo '- Please use "bootstrap-orbit.sh ggp_release" instead.                                 -'
+echo '----------------------------------------------------------------------------------------'

--- a/bootstrap-orbit.bat
+++ b/bootstrap-orbit.bat
@@ -1,3 +1,7 @@
+REM Copyright (c) 2020 The Orbit Authors. All rights reserved.
+REM Use of this source code is governed by a BSD-style license that can be
+REM found in the LICENSE file.
+
 @echo off
 call powershell "& %~dp0\bootstrap-orbit.ps1 %*"
 

--- a/bootstrap-orbit.ps1
+++ b/bootstrap-orbit.ps1
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 $conan = Get-Command -ErrorAction Ignore conan
 
 if (!$conan) {
@@ -33,10 +37,7 @@ You can call 'pip3 show -f conan' to figure out where conan.exe was placed.
 }
 
 # Install conan config
-$result = Start-Process -FilePath $conan.Path -ArgumentList "config","install","$PSScriptRoot\contrib\conan\configs\windows" -Wait -NoNewWindow -ErrorAction Stop -PassThru
-if ($result.ExitCode -ne 0) {
-  Throw "Error while installing conan config."
-}
+& "$PSScriptRoot\contrib\conan\configs\install.ps1"
 
 # Start build
 if ($args) {

--- a/bootstrap-orbit.sh
+++ b/bootstrap-orbit.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+#
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
@@ -38,7 +42,7 @@ else
 fi
 
 echo "Installing conan configuration (profiles, settings, etc.)..."
-conan config install $DIR/contrib/conan/configs/linux || exit $?
+$DIR/contrib/conan/configs/install.sh || exit $?
 
 exec $DIR/build.sh "$@"
 

--- a/contrib/conan/configs/install.ps1
+++ b/contrib/conan/configs/install.ps1
@@ -1,0 +1,53 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+$conan = Get-Command conan -ErrorAction Stop
+
+function conan_disable_public_remotes() {
+  $remotes = "bintray", "conan-center", "bincrafters"
+  foreach ($remote in $remotes) {
+    $process = Start-Process $conan.Path -Wait -NoNewWindow -ErrorAction Stop -PassThru -ArgumentList "remote","disable",$remote
+    if ($process.ExitCode -ne 0) { Throw "Error while disabling conan-remote $remote." }
+  }
+}
+
+# Installs conan config (build settings, public remotes, conan profiles, conan options). Have a look in \contrib\conan\configs\windows for more information.
+$process = Start-Process $conan.Path -Wait -NoNewWindow -ErrorAction Stop -PassThru -ArgumentList "config","install","$PSScriptRoot\windows"
+if ($process.ExitCode -ne 0) { Throw "Error while installing conan config." }
+
+if (Test-Path Env:ORBIT_OVERRIDE_ARTIFACTORY_URL) {
+  Write-Host "Artifactory override detected. Adjusting remotes..."
+
+  $process = Start-Process $conan.Path -Wait -NoNewWindow -ErrorAction Stop -PassThru -ArgumentList "remote","add","-i","0","-f","artifactory",$Env:ORBIT_OVERRIDE_ARTIFACTORY_URL
+  if ($process.ExitCode -ne 0) { Throw "Error while adding conan remote." }
+
+  conan_disable_public_remotes
+} else {
+  try {
+    $response = Invoke-WebRequest -URI http://artifactory.internal/ -ErrorAction Ignore -MaximumRedirection 0
+    Write-Host "CI machine detected. Adjusting remotes..."
+
+    $process = Start-Process $conan.Path -Wait -NoNewWindow -ErrorAction Stop -PassThru -ArgumentList "remote","add","-i","0","-f","artifactory","http://artifactory.internal/artifactory/api/conan/conan"
+    if ($process.ExitCode -ne 0) { Throw "Error while adding conan remote." }
+
+    conan_disable_public_remotes
+  } catch {
+    try {
+      $response = Invoke-WebRequest -URI http://orbit-artifactory/ -ErrorAction Ignore -MaximumRedirection 0
+      Write-Host "Internal machine detected. Adjusting remotes..."
+
+      $location = $response.Headers['Location'].Split("/")[2]
+
+      $process = Start-Process $conan.Path -Wait -NoNewWindow -ErrorAction Stop -PassThru -ArgumentList "remote","add","-i","0","-f","artifactory","http://$location/artifactory/api/conan/conan"
+      if ($process.ExitCode -ne 0) { Throw "Error while adding conan remote." }
+
+      $process = Start-Process $conan.Path -Wait -NoNewWindow -ErrorAction Stop -PassThru -ArgumentList "config","set","proxies.http=`"$location=http://127.0.0.2:999`""
+      if ($process.ExitCode -ne 0) { Throw "Error while adding proxy setting to conan." }
+
+      conan_disable_public_remotes
+    } catch {
+      Write-Host "Using public remotes for conan."
+    }
+  }
+}

--- a/contrib/conan/configs/install.sh
+++ b/contrib/conan/configs/install.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+function conan_disable_public_remotes {
+  conan remote disable bintray || return $?
+  conan remote disable conan-center || return $?
+  conan remote disable bincrafters || return $?
+  return 0
+}
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# Installs conan config (build settings, public remotes, conan profiles, conan options). Have a look in \contrib\conan\configs\windows for more information.
+if [ "$(uname -s)" == "Linux" ]; then
+  conan config install "$DIR/linux" || exit $?
+else
+  conan config install "$DIR/windows" || exit $?
+fi
+
+if [ -n "$ORBIT_OVERRIDE_ARTIFACTORY_URL" ]; then
+  echo "Artifactory override detected. Adjusting remotes..."
+  conan remote add -i 0 -f artifactory "$ORBIT_OVERRIDE_ARTIFACTORY_URL" || exit $?
+  conan_disable_public_remotes || exit $?
+else
+  curl -s http://artifactory.internal/ >/dev/null 2>&1
+  
+  if [ $? -eq 0 ]; then
+    echo "CI machine detected. Adjusting remotes..."
+    conan remote add -i 0 -f artifactory "http://artifactory.internal/artifactory/api/conan/conan" || exit $?
+    conan_disable_public_remotes || exit $?
+  else
+    LOCATION="$(curl -sI http://orbit-artifactory/ 2>/dev/null)"
+
+    if [ $? -eq 0 ]; then
+      echo "Internal machine detected. Adjusting remotes..."
+      LOCATION="$(echo "$LOCATION" | grep -e "^Location:" | cut -d ' ' -f 2 | cut -d '/' -f 3)"
+
+      conan remote add -i 0 -f artifactory "http://$LOCATION/artifactory/api/conan/conan" || exit $?
+      conan config set proxies.http="$LOCATION=http://127.0.0.2:999" || exit $?
+      conan_disable_public_remotes || exit $?
+    else
+      echo "Using public remotes for conan."
+    fi
+  fi
+fi

--- a/contrib/conan/configs/linux/config/conan.conf
+++ b/contrib/conan/configs/linux/config/conan.conf
@@ -1,0 +1,3 @@
+[general]
+revisions_enabled=True
+parallel_download=4

--- a/contrib/conan/configs/windows/config/conan.conf
+++ b/contrib/conan/configs/windows/config/conan.conf
@@ -1,0 +1,3 @@
+[general]
+revisions_enabled=True
+parallel_download=4

--- a/kokoro/conan/config/remotes.json
+++ b/kokoro/conan/config/remotes.json
@@ -1,9 +1,0 @@
-{
- "remotes": [
-  {
-   "name": "artifactory",
-   "url": "http://artifactory.internal/artifactory/api/conan/conan",
-   "verify_ssl": false
-  }
- ]
-}

--- a/kokoro/gcp_ubuntu/kokoro_build.sh
+++ b/kokoro/gcp_ubuntu/kokoro_build.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+#
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
 
 # Fail on any error.
 set -e
@@ -10,10 +14,7 @@ if [ "$0" == "$SCRIPT" ]; then
   # We are inside the docker container
 
   echo "Installing conan configuration (profiles, settings, etc.)..."
-  conan config install "${DIR}/contrib/conan/configs/linux"
-  cp -v "${DIR}/kokoro/conan/config/remotes.json" ~/.conan/remotes.json
-  conan config set general.revisions_enabled=True
-  conan config set general.parallel_download=8
+  ${DIR}/contrib/conan/configs/install.sh || exit $?
 
   CONAN_PROFILE="clang7_release"
 

--- a/kokoro/gcp_ubuntu_ggp/kokoro_build.sh
+++ b/kokoro/gcp_ubuntu_ggp/kokoro_build.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+#
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
 
 # Fail on any error.
 set -e
@@ -10,10 +14,7 @@ if [ "$0" == "$SCRIPT" ]; then
   # We are inside the docker container
 
   echo "Installing conan configuration (profiles, settings, etc.)..."
-  conan config install "${DIR}/contrib/conan/configs/linux"
-  cp -v "${DIR}/kokoro/conan/config/remotes.json" ~/.conan/remotes.json
-  conan config set general.revisions_enabled=True
-  conan config set general.parallel_download=8
+  ${DIR}/contrib/conan/configs/install.sh || exit $?
 
   CONAN_PROFILE="ggp_relwithdebinfo"
 

--- a/kokoro/gcp_windows/kokoro_build.bat
+++ b/kokoro/gcp_windows/kokoro_build.bat
@@ -1,22 +1,16 @@
+@echo off
+REM Copyright (c) 2020 The Orbit Authors. All rights reserved.
+REM Use of this source code is governed by a BSD-style license that can be
+REM found in the LICENSE file.
+
 :: Code under repo is checked out to %KOKORO_ARTIFACTS_DIR%\github.
 :: The final directory name in this path is determined by the scm name specified
 :: in the job configuration
-@echo off
 
 SET REPO_ROOT=%KOKORO_ARTIFACTS_DIR%\github\orbitprofiler
 
-conan config install %REPO_ROOT%\contrib\conan\configs\windows
-if %errorlevel% neq 0 exit /b %errorlevel%
-
-REM We replace the default remotes by our internal artifactory server
-REM which acts as a secure source for prebuilt dependencies.
-copy /Y %REPO_ROOT%\kokoro\conan\config\remotes.json %HOME%\.conan\remotes.json
-if %errorlevel% neq 0 exit /b %errorlevel%
-
-conan config set general.revisions_enabled=True
-if %errorlevel% neq 0 exit /b %errorlevel%
-
-conan config set general.parallel_download=8
+:: Install conan config
+call powershell "& %REPO_ROOT%\contrib\conan\configs\install.ps1"
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 :: Building conan


### PR DESCRIPTION
This PR enables the internal Artifactory server if reachable.

The bootstrap scripts now call a script called `contrib/conan/configs/install.{ps1,sh}`.
This script takes care of installing the conan configuration. That involves the following points:
- Install the static windows or linux configuration depending on the platform.
- Detect whether the internal artifactory server is reachable (either because it's a CI server or it's an internal workstation) and change the remote servers accordingly. If the internal artifactory is available public remotes will be disabled and only the internal package remote server will be used.

Further changes: 
- Added License headers to all the involved scripts
- The CI build scripts also call the `install.{ps1,sh}`-script.
- `bootstrap-orbit-ggp.{sh,ps1,bat}` is now deprecated because it is not needed anymore since we have the `ggp_sdk` on our internal artifactory server. So no special treatment for a GGP build is necessary anymore.