### PR TITLE
Move scheduler specific rendering code to SchedulerTrack.

### DIFF
--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -80,9 +80,7 @@ Capture::SamplingDoneCallback Capture::sampling_done_callback_ = nullptr;
 void* Capture::sampling_done_callback_user_data_ = nullptr;
 
 //-----------------------------------------------------------------------------
-void Capture::Init() {
-  GTargetProcess = std::make_shared<Process>();
-}
+void Capture::Init() { GTargetProcess = std::make_shared<Process>(); }
 
 //-----------------------------------------------------------------------------
 bool Capture::Inject(std::string_view remote_address) {

--- a/OrbitCore/EventBuffer.cpp
+++ b/OrbitCore/EventBuffer.cpp
@@ -58,19 +58,6 @@ std::vector<CallstackEvent> EventBuffer::GetCallstackEvents(
 }
 
 //-----------------------------------------------------------------------------
-void EventBuffer::AddCallstackEvent(uint64_t time, CallstackID cs_hash, ThreadID thread_id) {
-  ScopeLock lock(m_Mutex);
-  std::map<uint64_t, CallstackEvent>& event_map = m_CallstackEvents[thread_id];
-  event_map[time] = CallstackEvent(time, cs_hash, thread_id);
-
-  // Add all callstack events to "thread 0".
-  std::map<uint64_t, CallstackEvent>& event_map_0 = m_CallstackEvents[0];
-  event_map_0[time] = CallstackEvent(time, cs_hash, 0);
-
-  RegisterTime(time);
-}
-
-//-----------------------------------------------------------------------------
 ORBIT_SERIALIZE(EventBuffer, 0) {
   ORBIT_NVP_VAL(0, m_CallstackEvents);
 

--- a/OrbitCore/EventBuffer.cpp
+++ b/OrbitCore/EventBuffer.cpp
@@ -58,6 +58,19 @@ std::vector<CallstackEvent> EventBuffer::GetCallstackEvents(
 }
 
 //-----------------------------------------------------------------------------
+void EventBuffer::AddCallstackEvent(uint64_t time, CallstackID cs_hash, ThreadID thread_id) {
+  ScopeLock lock(m_Mutex);
+  std::map<uint64_t, CallstackEvent>& event_map = m_CallstackEvents[thread_id];
+  event_map[time] = CallstackEvent(time, cs_hash, thread_id);
+
+  // Add all callstack events to "thread 0".
+  std::map<uint64_t, CallstackEvent>& event_map_0 = m_CallstackEvents[0];
+  event_map_0[time] = CallstackEvent(time, cs_hash, 0);
+
+  RegisterTime(time);
+}
+
+//-----------------------------------------------------------------------------
 ORBIT_SERIALIZE(EventBuffer, 0) {
   ORBIT_NVP_VAL(0, m_CallstackEvents);
 

--- a/OrbitCore/EventBuffer.cpp
+++ b/OrbitCore/EventBuffer.cpp
@@ -58,7 +58,8 @@ std::vector<CallstackEvent> EventBuffer::GetCallstackEvents(
 }
 
 //-----------------------------------------------------------------------------
-void EventBuffer::AddCallstackEvent(uint64_t time, CallstackID cs_hash, ThreadID thread_id) {
+void EventBuffer::AddCallstackEvent(uint64_t time, CallstackID cs_hash,
+                                    ThreadID thread_id) {
   ScopeLock lock(m_Mutex);
   std::map<uint64_t, CallstackEvent>& event_map = m_CallstackEvents[thread_id];
   event_map[time] = CallstackEvent(time, cs_hash, thread_id);

--- a/OrbitCore/EventBuffer.h
+++ b/OrbitCore/EventBuffer.h
@@ -67,8 +67,13 @@ class EventBuffer {
   }
 
   //-----------------------------------------------------------------------------
-  void AddCallstackEvent(uint64_t time, CallstackID cs_hash,
-                         ThreadID thread_id);
+  void AddCallstackEvent(uint64_t a_Time, CallstackID a_CSHash,
+                         ThreadID a_TID) {
+    ScopeLock lock(m_Mutex);
+    std::map<uint64_t, CallstackEvent>& threadMap = m_CallstackEvents[a_TID];
+    threadMap[a_Time] = CallstackEvent(a_Time, a_CSHash, a_TID);
+    RegisterTime(a_Time);
+  }
 
   ORBIT_SERIALIZABLE;
 

--- a/OrbitCore/EventBuffer.h
+++ b/OrbitCore/EventBuffer.h
@@ -67,13 +67,8 @@ class EventBuffer {
   }
 
   //-----------------------------------------------------------------------------
-  void AddCallstackEvent(uint64_t a_Time, CallstackID a_CSHash,
-                         ThreadID a_TID) {
-    ScopeLock lock(m_Mutex);
-    std::map<uint64_t, CallstackEvent>& threadMap = m_CallstackEvents[a_TID];
-    threadMap[a_Time] = CallstackEvent(a_Time, a_CSHash, a_TID);
-    RegisterTime(a_Time);
-  }
+  void AddCallstackEvent(uint64_t time, CallstackID cs_hash,
+                         ThreadID thread_id);
 
   ORBIT_SERIALIZABLE;
 

--- a/OrbitCore/OrbitProcess.h
+++ b/OrbitCore/OrbitProcess.h
@@ -77,7 +77,7 @@ class Process {
   const std::string& GetName() const { return m_Name; }
   const std::string& GetFullPath() const { return m_FullPath; }
   const std::string& GetCmdLine() const { return m_CmdLine; }
-  uint32_t GetID() const { return m_ID; }
+  DWORD GetID() const { return m_ID; }
   double GetCpuUsage() const { return m_CpuUsage; }
   HANDLE GetHandle() const { return m_Handle; }
   bool GetIs64Bit() const { return m_Is64Bit; }

--- a/OrbitCore/OrbitProcess.h
+++ b/OrbitCore/OrbitProcess.h
@@ -77,7 +77,7 @@ class Process {
   const std::string& GetName() const { return m_Name; }
   const std::string& GetFullPath() const { return m_FullPath; }
   const std::string& GetCmdLine() const { return m_CmdLine; }
-  DWORD GetID() const { return m_ID; }
+  uint32_t GetID() const { return m_ID; }
   double GetCpuUsage() const { return m_CpuUsage; }
   HANDLE GetHandle() const { return m_Handle; }
   bool GetIs64Bit() const { return m_Is64Bit; }

--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -5,95 +5,17 @@
 
 #include "Core.h"
 
-void Batcher::AddLine(const Line& line, const Color* colors,
-                      PickingID::Type picking_type, void* user_data) {
-  Color pickCol = PickingID::GetColor(picking_type, line_buffer_.m_Lines.size());
-  line_buffer_.m_Lines.push_back(line);
-  line_buffer_.m_Colors.push_back(colors, 2);
-  line_buffer_.m_PickingColors.push_back_n(pickCol, 2);
-  line_buffer_.m_UserData.push_back(user_data);
-}
-
-void Batcher::AddLine(const Line& line, Color color, PickingID::Type picking_type,
-    void* user_data)
-{
-  Color colors[2];
-  Fill(colors, color);
-  AddLine(line, colors, picking_type, user_data);
-}
-
-void Batcher::AddLine(Vec2 from, Vec2 to, float z, Color color,
-                      PickingID::Type picking_type,
-                      void* user_data) {
-  Line line;
-  Color colors[2];
-  Fill(colors, color);
-  line.m_Beg = Vec3(from[0], from[1], z);
-  line.m_End = Vec3(to[0], to[1], z);
-  AddLine(line, colors, picking_type, user_data);
-}
-
-void Batcher::AddVerticalLine(Vec2 pos, float size, float z, Color color,
-                              PickingID::Type picking_type,
-                              void* user_data) {
-  Line line;
-  Color colors[2];
-  Fill(colors, color);
-  line.m_Beg = Vec3(pos[0], pos[1], z);
-  line.m_End = Vec3(pos[0], pos[1] + size, z);
-  AddLine(line, colors, picking_type, user_data);
-}
-
-void Batcher::AddBox(const Box& a_Box, const Color* colors,
-                     PickingID::Type picking_type, void* user_data) {
-  Color pickCol = PickingID::GetColor(picking_type, box_buffer_.m_Boxes.size());
-  box_buffer_.m_Boxes.push_back(a_Box);
-  box_buffer_.m_Colors.push_back(colors, 4);
-  box_buffer_.m_PickingColors.push_back_n(pickCol, 4);
-  box_buffer_.m_UserData.push_back(user_data);
-}
-
-void Batcher::AddBox(const Box& a_Box, const Color color, PickingID::Type picking_type,
-    void* user_data)
-{
-  Color colors[4];
-  Fill(colors, color);
-  AddBox(a_Box, colors, picking_type, user_data);
-}
-
-void Batcher::AddShadedBox(Vec2 pos, Vec2 size, float z, Color color,
-                           PickingID::Type picking_type, void* user_data) {
-  Color colors[4];
-  GetBoxGradientColors(color, colors);
-  Box box(pos, size, z);
-  AddBox(box, colors, picking_type, user_data);
-}
-
+//-----------------------------------------------------------------------------
 TextBox* Batcher::GetTextBox(PickingID a_ID) {
   if (a_ID.m_Type == PickingID::BOX) {
-    if (void** textBoxPtr = box_buffer_.m_UserData.SlowAt(a_ID.m_Id)) {
+    if (void** textBoxPtr = m_BoxBuffer.m_UserData.SlowAt(a_ID.m_Id)) {
       return (TextBox*)*textBoxPtr;
     }
   } else if (a_ID.m_Type == PickingID::LINE) {
-    if (void** textBoxPtr = line_buffer_.m_UserData.SlowAt(a_ID.m_Id)) {
+    if (void** textBoxPtr = m_LineBuffer.m_UserData.SlowAt(a_ID.m_Id)) {
       return (TextBox*)*textBoxPtr;
     }
   }
 
   return nullptr;
-}
-
-void Batcher::GetBoxGradientColors(Color color, Color* colors) {
-  const float kGradientCoeff = 0.94f;
-  Vec3 dark = Vec3(color[0], color[1], color[2]) * kGradientCoeff;
-  colors[0] = Color((unsigned char)dark[0], (unsigned char)dark[1],
-                    (unsigned char)dark[2], (unsigned char)color[3]);
-  colors[1] = colors[0];
-  colors[2] = color;
-  colors[3] = color;
-}
-
-void Batcher::Reset() {
-  line_buffer_.Reset();
-  box_buffer_.Reset();
 }

--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -7,24 +7,23 @@
 
 void Batcher::AddLine(const Line& line, const Color* colors,
                       PickingID::Type picking_type, void* user_data) {
-  Color pickCol = PickingID::GetColor(picking_type, line_buffer_.m_Lines.size());
+  Color pickCol =
+      PickingID::GetColor(picking_type, line_buffer_.m_Lines.size());
   line_buffer_.m_Lines.push_back(line);
   line_buffer_.m_Colors.push_back(colors, 2);
   line_buffer_.m_PickingColors.push_back_n(pickCol, 2);
   line_buffer_.m_UserData.push_back(user_data);
 }
 
-void Batcher::AddLine(const Line& line, Color color, PickingID::Type picking_type,
-    void* user_data)
-{
+void Batcher::AddLine(const Line& line, Color color,
+                      PickingID::Type picking_type, void* user_data) {
   Color colors[2];
   Fill(colors, color);
   AddLine(line, colors, picking_type, user_data);
 }
 
 void Batcher::AddLine(Vec2 from, Vec2 to, float z, Color color,
-                      PickingID::Type picking_type,
-                      void* user_data) {
+                      PickingID::Type picking_type, void* user_data) {
   Line line;
   Color colors[2];
   Fill(colors, color);
@@ -34,8 +33,7 @@ void Batcher::AddLine(Vec2 from, Vec2 to, float z, Color color,
 }
 
 void Batcher::AddVerticalLine(Vec2 pos, float size, float z, Color color,
-                              PickingID::Type picking_type,
-                              void* user_data) {
+                              PickingID::Type picking_type, void* user_data) {
   Line line;
   Color colors[2];
   Fill(colors, color);
@@ -53,9 +51,8 @@ void Batcher::AddBox(const Box& a_Box, const Color* colors,
   box_buffer_.m_UserData.push_back(user_data);
 }
 
-void Batcher::AddBox(const Box& a_Box, const Color color, PickingID::Type picking_type,
-    void* user_data)
-{
+void Batcher::AddBox(const Box& a_Box, const Color color,
+                     PickingID::Type picking_type, void* user_data) {
   Color colors[4];
   Fill(colors, color);
   AddBox(a_Box, colors, picking_type, user_data);

--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -51,7 +51,7 @@ void Batcher::AddBox(const Box& a_Box, const Color* colors,
   box_buffer_.m_UserData.push_back(user_data);
 }
 
-void Batcher::AddBox(const Box& a_Box, const Color color,
+void Batcher::AddBox(const Box& a_Box, Color color,
                      PickingID::Type picking_type, void* user_data) {
   Color colors[4];
   Fill(colors, color);
@@ -83,8 +83,9 @@ TextBox* Batcher::GetTextBox(PickingID a_ID) {
 void Batcher::GetBoxGradientColors(Color color, Color* colors) {
   const float kGradientCoeff = 0.94f;
   Vec3 dark = Vec3(color[0], color[1], color[2]) * kGradientCoeff;
-  colors[0] = Color((unsigned char)dark[0], (unsigned char)dark[1],
-                    (unsigned char)dark[2], (unsigned char)color[3]);
+  colors[0] =
+      Color(static_cast<uint8_t>(dark[0]), static_cast<uint8_t>(dark[1]),
+            static_cast<uint8_t>(dark[2]), color[3]);
   colors[1] = colors[0];
   colors[2] = color;
   colors[3] = color;

--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -5,17 +5,95 @@
 
 #include "Core.h"
 
-//-----------------------------------------------------------------------------
+void Batcher::AddLine(const Line& line, const Color* colors,
+                      PickingID::Type picking_type, void* user_data) {
+  Color pickCol = PickingID::GetColor(picking_type, line_buffer_.m_Lines.size());
+  line_buffer_.m_Lines.push_back(line);
+  line_buffer_.m_Colors.push_back(colors, 2);
+  line_buffer_.m_PickingColors.push_back_n(pickCol, 2);
+  line_buffer_.m_UserData.push_back(user_data);
+}
+
+void Batcher::AddLine(const Line& line, Color color, PickingID::Type picking_type,
+    void* user_data)
+{
+  Color colors[2];
+  Fill(colors, color);
+  AddLine(line, colors, picking_type, user_data);
+}
+
+void Batcher::AddLine(Vec2 from, Vec2 to, float z, Color color,
+                      PickingID::Type picking_type,
+                      void* user_data) {
+  Line line;
+  Color colors[2];
+  Fill(colors, color);
+  line.m_Beg = Vec3(from[0], from[1], z);
+  line.m_End = Vec3(to[0], to[1], z);
+  AddLine(line, colors, picking_type, user_data);
+}
+
+void Batcher::AddVerticalLine(Vec2 pos, float size, float z, Color color,
+                              PickingID::Type picking_type,
+                              void* user_data) {
+  Line line;
+  Color colors[2];
+  Fill(colors, color);
+  line.m_Beg = Vec3(pos[0], pos[1], z);
+  line.m_End = Vec3(pos[0], pos[1] + size, z);
+  AddLine(line, colors, picking_type, user_data);
+}
+
+void Batcher::AddBox(const Box& a_Box, const Color* colors,
+                     PickingID::Type picking_type, void* user_data) {
+  Color pickCol = PickingID::GetColor(picking_type, box_buffer_.m_Boxes.size());
+  box_buffer_.m_Boxes.push_back(a_Box);
+  box_buffer_.m_Colors.push_back(colors, 4);
+  box_buffer_.m_PickingColors.push_back_n(pickCol, 4);
+  box_buffer_.m_UserData.push_back(user_data);
+}
+
+void Batcher::AddBox(const Box& a_Box, const Color color, PickingID::Type picking_type,
+    void* user_data)
+{
+  Color colors[4];
+  Fill(colors, color);
+  AddBox(a_Box, colors, picking_type, user_data);
+}
+
+void Batcher::AddShadedBox(Vec2 pos, Vec2 size, float z, Color color,
+                           PickingID::Type picking_type, void* user_data) {
+  Color colors[4];
+  GetBoxGradientColors(color, colors);
+  Box box(pos, size, z);
+  AddBox(box, colors, picking_type, user_data);
+}
+
 TextBox* Batcher::GetTextBox(PickingID a_ID) {
   if (a_ID.m_Type == PickingID::BOX) {
-    if (void** textBoxPtr = m_BoxBuffer.m_UserData.SlowAt(a_ID.m_Id)) {
+    if (void** textBoxPtr = box_buffer_.m_UserData.SlowAt(a_ID.m_Id)) {
       return (TextBox*)*textBoxPtr;
     }
   } else if (a_ID.m_Type == PickingID::LINE) {
-    if (void** textBoxPtr = m_LineBuffer.m_UserData.SlowAt(a_ID.m_Id)) {
+    if (void** textBoxPtr = line_buffer_.m_UserData.SlowAt(a_ID.m_Id)) {
       return (TextBox*)*textBoxPtr;
     }
   }
 
   return nullptr;
+}
+
+void Batcher::GetBoxGradientColors(Color color, Color* colors) {
+  const float kGradientCoeff = 0.94f;
+  Vec3 dark = Vec3(color[0], color[1], color[2]) * kGradientCoeff;
+  colors[0] = Color((unsigned char)dark[0], (unsigned char)dark[1],
+                    (unsigned char)dark[2], (unsigned char)color[3]);
+  colors[1] = colors[0];
+  colors[2] = color;
+  colors[3] = color;
+}
+
+void Batcher::Reset() {
+  line_buffer_.Reset();
+  box_buffer_.Reset();
 }

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -54,7 +54,7 @@ class Batcher {
 
   void AddBox(const Box& a_Box, const Color* colors,
               PickingID::Type picking_type, void* user_data = nullptr);
-  void AddBox(const Box& a_Box, const Color color, PickingID::Type picking_type,
+  void AddBox(const Box& a_Box, Color color, PickingID::Type picking_type,
               void* user_data = nullptr);
   void AddShadedBox(Vec2 pos, Vec2 size, float z, Color color,
                     PickingID::Type picking_type, void* user_data = nullptr);

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -43,35 +43,31 @@ struct BoxBuffer {
 //-----------------------------------------------------------------------------
 class Batcher {
  public:
-  void AddLine(const Line& a_Line, Color* a_Colors, PickingID::Type a_Type,
-               void* a_UserData = nullptr) {
-    Color pickCol = PickingID::GetColor(a_Type, m_LineBuffer.m_Lines.size());
-    m_LineBuffer.m_Lines.push_back(a_Line);
-    m_LineBuffer.m_Colors.push_back(a_Colors, 2);
-    m_LineBuffer.m_PickingColors.push_back_n(pickCol, 2);
-    m_LineBuffer.m_UserData.push_back(a_UserData);
-  }
+  void AddLine(const Line& line, const Color* colors,
+               PickingID::Type picking_type, void* user_data = nullptr);
+  void AddLine(const Line& line, Color color, PickingID::Type picking_type,
+               void* user_data = nullptr);
+  void AddLine(Vec2 from, Vec2 to, float z, Color color,
+               PickingID::Type picking_type, void* user_data = nullptr);
+  void AddVerticalLine(Vec2 pos, float size, float z, Color color,
+                       PickingID::Type picking_type, void* user_data = nullptr);
 
-  void AddBox(const Box& a_Box, Color* a_Colors, PickingID::Type a_Type,
-              void* a_UserData = nullptr) {
-    Color pickCol = PickingID::GetColor(a_Type, m_BoxBuffer.m_Boxes.size());
-    m_BoxBuffer.m_Boxes.push_back(a_Box);
-    m_BoxBuffer.m_Colors.push_back(a_Colors, 4);
-    m_BoxBuffer.m_PickingColors.push_back_n(pickCol, 4);
-    m_BoxBuffer.m_UserData.push_back(a_UserData);
-  }
+  void AddBox(const Box& a_Box, const Color* colors,
+              PickingID::Type picking_type, void* user_data = nullptr);
+  void AddBox(const Box& a_Box, const Color color, PickingID::Type picking_type,
+              void* user_data = nullptr);
+  void AddShadedBox(Vec2 pos, Vec2 size, float z, Color color,
+                    PickingID::Type picking_type, void* user_data = nullptr);
 
-  void Reset() {
-    m_LineBuffer.Reset();
-    m_BoxBuffer.Reset();
-  }
+  void GetBoxGradientColors(Color color, Color* colors);
+
+  void Reset();
 
   TextBox* GetTextBox(PickingID a_ID);
-
-  BoxBuffer& GetBoxBuffer() { return m_BoxBuffer; }
-  LineBuffer& GetLineBuffer() { return m_LineBuffer; }
+  BoxBuffer& GetBoxBuffer() { return box_buffer_; }
+  LineBuffer& GetLineBuffer() { return line_buffer_; }
 
  protected:
-  LineBuffer m_LineBuffer;
-  BoxBuffer m_BoxBuffer;
+  LineBuffer line_buffer_;
+  BoxBuffer box_buffer_;
 };

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -43,31 +43,35 @@ struct BoxBuffer {
 //-----------------------------------------------------------------------------
 class Batcher {
  public:
-  void AddLine(const Line& line, const Color* colors,
-               PickingID::Type picking_type, void* user_data = nullptr);
-  void AddLine(const Line& line, Color color, PickingID::Type picking_type,
-               void* user_data = nullptr);
-  void AddLine(Vec2 from, Vec2 to, float z, Color color,
-               PickingID::Type picking_type, void* user_data = nullptr);
-  void AddVerticalLine(Vec2 pos, float size, float z, Color color,
-                       PickingID::Type picking_type, void* user_data = nullptr);
+  void AddLine(const Line& a_Line, Color* a_Colors, PickingID::Type a_Type,
+               void* a_UserData = nullptr) {
+    Color pickCol = PickingID::GetColor(a_Type, m_LineBuffer.m_Lines.size());
+    m_LineBuffer.m_Lines.push_back(a_Line);
+    m_LineBuffer.m_Colors.push_back(a_Colors, 2);
+    m_LineBuffer.m_PickingColors.push_back_n(pickCol, 2);
+    m_LineBuffer.m_UserData.push_back(a_UserData);
+  }
 
-  void AddBox(const Box& a_Box, const Color* colors,
-              PickingID::Type picking_type, void* user_data = nullptr);
-  void AddBox(const Box& a_Box, const Color color, PickingID::Type picking_type,
-              void* user_data = nullptr);
-  void AddShadedBox(Vec2 pos, Vec2 size, float z, Color color,
-                    PickingID::Type picking_type, void* user_data = nullptr);
+  void AddBox(const Box& a_Box, Color* a_Colors, PickingID::Type a_Type,
+              void* a_UserData = nullptr) {
+    Color pickCol = PickingID::GetColor(a_Type, m_BoxBuffer.m_Boxes.size());
+    m_BoxBuffer.m_Boxes.push_back(a_Box);
+    m_BoxBuffer.m_Colors.push_back(a_Colors, 4);
+    m_BoxBuffer.m_PickingColors.push_back_n(pickCol, 4);
+    m_BoxBuffer.m_UserData.push_back(a_UserData);
+  }
 
-  void GetBoxGradientColors(Color color, Color* colors);
-
-  void Reset();
+  void Reset() {
+    m_LineBuffer.Reset();
+    m_BoxBuffer.Reset();
+  }
 
   TextBox* GetTextBox(PickingID a_ID);
-  BoxBuffer& GetBoxBuffer() { return box_buffer_; }
-  LineBuffer& GetLineBuffer() { return line_buffer_; }
+
+  BoxBuffer& GetBoxBuffer() { return m_BoxBuffer; }
+  LineBuffer& GetLineBuffer() { return m_LineBuffer; }
 
  protected:
-  LineBuffer line_buffer_;
-  BoxBuffer box_buffer_;
+  LineBuffer m_LineBuffer;
+  BoxBuffer m_BoxBuffer;
 };

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -72,20 +72,25 @@ void EventTrack::Draw(GlCanvas* a_Canvas, bool a_Picking) {
 void EventTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
   Batcher* batcher = &time_graph_->GetBatcher();
   const TimeGraphLayout& layout = time_graph_->GetLayout();
-  float z = GlCanvas::Z_VALUE_EVENT;
-  float track_height = layout.GetEventTrackHeight();
+
+  Color lineColor[2];
+  Color white(255, 255, 255, 255);
+  Fill(lineColor, white);
 
   ScopeLock lock(GEventTracer.GetEventBuffer().GetMutex());
   std::map<uint64_t, CallstackEvent>& callstacks =
       GEventTracer.GetEventBuffer().GetCallstacks()[m_ThreadId];
 
   // Sampling Events
-  const Color kWhite(255, 255, 255, 255);
   for (auto& pair : callstacks) {
     uint64_t time = pair.first;
     if (time > min_tick && time < max_tick) {
-      Vec2 pos(time_graph_->GetWorldFromTick(time), m_Pos[1]);
-      batcher->AddVerticalLine(pos, -track_height, z, kWhite, PickingID::EVENT);
+      float x = time_graph_->GetWorldFromTick(time);
+      Line line;
+      line.m_Beg = Vec3(x, m_Pos[1], GlCanvas::Z_VALUE_EVENT);
+      line.m_End = Vec3(x, m_Pos[1] - layout.GetEventTrackHeight(),
+                        GlCanvas::Z_VALUE_EVENT);
+      batcher->AddLine(line, lineColor, PickingID::EVENT);
     }
   }
 
@@ -94,9 +99,12 @@ void EventTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
   Color selectedColor[2];
   Fill(selectedColor, kGreenSelection);
   for (CallstackEvent& event : selected_callstack_events_) {
-    Vec2 pos(time_graph_->GetWorldFromTick(event.m_Time), m_Pos[1]);
-    batcher->AddVerticalLine(pos, -track_height, z, kGreenSelection,
-                             PickingID::EVENT);
+    float x = time_graph_->GetWorldFromTick(event.m_Time);
+    Line line;
+    line.m_Beg = Vec3(x, m_Pos[1], GlCanvas::Z_VALUE_EVENT);
+    line.m_End = Vec3(x, m_Pos[1] - layout.GetEventTrackHeight(),
+                      GlCanvas::Z_VALUE_TEXT);
+    batcher->AddLine(line, selectedColor, PickingID::EVENT);
   }
 }
 

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -72,25 +72,20 @@ void EventTrack::Draw(GlCanvas* a_Canvas, bool a_Picking) {
 void EventTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
   Batcher* batcher = &time_graph_->GetBatcher();
   const TimeGraphLayout& layout = time_graph_->GetLayout();
-
-  Color lineColor[2];
-  Color white(255, 255, 255, 255);
-  Fill(lineColor, white);
+  float z = GlCanvas::Z_VALUE_EVENT;
+  float track_height = layout.GetEventTrackHeight();
 
   ScopeLock lock(GEventTracer.GetEventBuffer().GetMutex());
   std::map<uint64_t, CallstackEvent>& callstacks =
       GEventTracer.GetEventBuffer().GetCallstacks()[m_ThreadId];
 
   // Sampling Events
+  const Color kWhite(255, 255, 255, 255);
   for (auto& pair : callstacks) {
     uint64_t time = pair.first;
     if (time > min_tick && time < max_tick) {
-      float x = time_graph_->GetWorldFromTick(time);
-      Line line;
-      line.m_Beg = Vec3(x, m_Pos[1], GlCanvas::Z_VALUE_EVENT);
-      line.m_End = Vec3(x, m_Pos[1] - layout.GetEventTrackHeight(),
-                        GlCanvas::Z_VALUE_EVENT);
-      batcher->AddLine(line, lineColor, PickingID::EVENT);
+      Vec2 pos(time_graph_->GetWorldFromTick(time), m_Pos[1]);
+      batcher->AddVerticalLine(pos, -track_height, z, kWhite, PickingID::EVENT);
     }
   }
 
@@ -99,12 +94,9 @@ void EventTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
   Color selectedColor[2];
   Fill(selectedColor, kGreenSelection);
   for (CallstackEvent& event : selected_callstack_events_) {
-    float x = time_graph_->GetWorldFromTick(event.m_Time);
-    Line line;
-    line.m_Beg = Vec3(x, m_Pos[1], GlCanvas::Z_VALUE_EVENT);
-    line.m_End = Vec3(x, m_Pos[1] - layout.GetEventTrackHeight(),
-                      GlCanvas::Z_VALUE_TEXT);
-    batcher->AddLine(line, selectedColor, PickingID::EVENT);
+    Vec2 pos(time_graph_->GetWorldFromTick(event.m_Time), m_Pos[1]);
+    batcher->AddVerticalLine(pos, -track_height, z, kGreenSelection,
+                             PickingID::EVENT);
   }
 }
 

--- a/OrbitGl/Geometry.h
+++ b/OrbitGl/Geometry.h
@@ -15,5 +15,12 @@ struct Line {
 
 //-----------------------------------------------------------------------------
 struct Box {
-  Vec3 m_Vertices[4];
+  Box() = default;
+  Box(Vec2 pos, Vec2 size, float z) {
+    vertices_[0] = Vec3(pos[0], pos[1], z);
+    vertices_[1] = Vec3(pos[0], pos[1] + size[1], z);
+    vertices_[2] = Vec3(pos[0] + size[0], pos[1] + size[1], z);
+    vertices_[3] = Vec3(pos[0] + size[0], pos[1], z);
+  }
+  Vec3 vertices_[4];
 };

--- a/OrbitGl/Geometry.h
+++ b/OrbitGl/Geometry.h
@@ -15,12 +15,5 @@ struct Line {
 
 //-----------------------------------------------------------------------------
 struct Box {
-  Box() = default;
-  Box(Vec2 pos, Vec2 size, float z) {
-    vertices_[0] = Vec3(pos[0], pos[1], z);
-    vertices_[1] = Vec3(pos[0], pos[1] + size[1], z);
-    vertices_[2] = Vec3(pos[0] + size[0], pos[1] + size[1], z);
-    vertices_[3] = Vec3(pos[0] + size[0], pos[1], z);
-  }
-  Vec3 vertices_[4];
+  Vec3 m_Vertices[4];
 };

--- a/OrbitGl/GraphTrack.cpp
+++ b/OrbitGl/GraphTrack.cpp
@@ -47,9 +47,7 @@ void GraphTrack::Draw(GlCanvas* canvas, bool picking) {
   glVertex3f(x0, y1, track_z);
   glEnd();
 
-  Color col(0, 128, 255, 128);
-  Color colors[2];
-  Fill(colors, col);
+  const Color kLineColor(0, 128, 255, 128);
 
   // Current time window
   uint64_t min_ns = time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
@@ -70,10 +68,8 @@ void GraphTrack::Draw(GlCanvas* canvas, bool picking) {
     float x1 = time_graph_->GetWorldFromTick(time);
     float y0 = base_y + static_cast<float>(last_normalized_value) * m_Size[1];
     float y1 = base_y + static_cast<float>(normalized_value) * m_Size[1];
-    Line line;
-    line.m_Beg = Vec3(x0, y0, text_z);
-    line.m_End = Vec3(x1, y1, text_z);
-    time_graph_->GetBatcher().AddLine(line, colors, PickingID::LINE, nullptr);
+    time_graph_->GetBatcher().AddLine(Vec2(x0, y0), Vec2(x1, y1), text_z,
+                                      kLineColor, PickingID::LINE, nullptr);
 
     previous_time = time;
     last_normalized_value = normalized_value;

--- a/OrbitGl/GraphTrack.cpp
+++ b/OrbitGl/GraphTrack.cpp
@@ -47,7 +47,9 @@ void GraphTrack::Draw(GlCanvas* canvas, bool picking) {
   glVertex3f(x0, y1, track_z);
   glEnd();
 
-  const Color kLineColor(0, 128, 255, 128);
+  Color col(0, 128, 255, 128);
+  Color colors[2];
+  Fill(colors, col);
 
   // Current time window
   uint64_t min_ns = time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
@@ -68,8 +70,10 @@ void GraphTrack::Draw(GlCanvas* canvas, bool picking) {
     float x1 = time_graph_->GetWorldFromTick(time);
     float y0 = base_y + static_cast<float>(last_normalized_value) * m_Size[1];
     float y1 = base_y + static_cast<float>(normalized_value) * m_Size[1];
-    time_graph_->GetBatcher().AddLine(Vec2(x0, y0), Vec2(x1, y1), text_z,
-                                      kLineColor, PickingID::LINE, nullptr);
+    Line line;
+    line.m_Beg = Vec3(x0, y0, text_z);
+    line.m_End = Vec3(x1, y1, text_z);
+    time_graph_->GetBatcher().AddLine(line, colors, PickingID::LINE, nullptr);
 
     previous_time = time;
     last_normalized_value = normalized_value;

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -1,6 +1,12 @@
 #include "SchedulerTrack.h"
 
+#include "Capture.h"
+#include "EventTrack.h"
+#include "GlCanvas.h"
 #include "TimeGraph.h"
+
+const Color kInactiveColor(100, 100, 100, 255);
+const Color kSelectionColor(0, 128, 255, 255);
 
 void SchedulerTrack::Draw(GlCanvas* canvas, bool picking) {
   ThreadTrack::Draw(canvas, picking);
@@ -8,7 +14,79 @@ void SchedulerTrack::Draw(GlCanvas* canvas, bool picking) {
 
 float SchedulerTrack::GetHeight() const {
   TimeGraphLayout& layout = time_graph_->GetLayout();
-  float depth = static_cast<float>(depth_);
-  return (layout.GetTextCoresHeight() + layout.GetSpaceBetweenCores()) * depth +
-         layout.GetTrackBottomMargin();
+  return depth_ *
+             (layout.GetTextCoresHeight() + layout.GetSpaceBetweenCores()) +
+         layout.GetEventTrackHeight() + layout.GetTrackBottomMargin();
+}
+
+inline Color GetTimerColor(const Timer& timer, TimeGraph* time_graph,
+                           bool is_selected, bool same_tid, bool same_pid,
+                           bool inactive) {
+  if (is_selected) {
+    return kSelectionColor;
+  } else if (!same_tid && (inactive || !same_pid)) {
+    return kInactiveColor;
+  }
+  return time_graph->GetTimesliceColor(timer);
+}
+
+inline float GetYFromDepth(const TimeGraphLayout& layout, float track_y,
+                           uint32_t depth) {
+  return track_y - layout.GetEventTrackHeight() -
+         layout.GetSpaceBetweenTracksAndThread() -
+         (layout.GetTextCoresHeight() + layout.GetSpaceBetweenCores()) *
+             (depth + 1);
+}
+
+void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
+  event_track_->UpdatePrimitives(min_tick, max_tick);
+  
+  Batcher* batcher = &time_graph_->GetBatcher();
+  GlCanvas* canvas = time_graph_->GetCanvas();
+  const TimeGraphLayout& layout = time_graph_->GetLayout();
+  const auto& target_process = Capture::GTargetProcess;
+  uint32_t target_pid = target_process ? target_process->GetID() : 0;
+  uint32_t selected_thread_id = Capture::GSelectedThreadId;
+
+  float world_start_x = canvas->GetWorldTopLeftX();
+  float world_width = canvas->GetWorldWidth();
+  double inv_time_window = 1.0 / time_graph_->GetTimeWindowUs();
+
+  std::vector<std::shared_ptr<TimerChain>> chains_by_depth = GetTimers();
+  for (std::shared_ptr<TimerChain>& timer_chain : chains_by_depth) {
+    for (TextBox& text_box : *timer_chain) {
+      const Timer& timer = text_box.GetTimer();
+      if (min_tick > timer.m_End || max_tick < timer.m_Start) continue;
+
+      UpdateDepth(timer.m_Depth + 1);
+      double start_us = time_graph_->GetUsFromTick(timer.m_Start);
+      double end_us = time_graph_->GetUsFromTick(timer.m_End);
+      double elapsed_us = end_us - start_us;
+      double normalized_start = start_us * inv_time_window;
+      double normalized_length = elapsed_us * inv_time_window;
+      float world_timer_width = normalized_length * world_width;
+      float world_timer_x = world_start_x + normalized_start * world_width;
+      float world_timer_y = GetYFromDepth(layout, m_Pos[1], timer.m_Depth);
+
+      bool is_visible_width = normalized_length * canvas->getWidth() > 1;
+      bool is_same_pid_as_target = target_pid == 0 || target_pid == timer.m_PID;
+      bool is_same_tid_as_selected = timer.m_TID == selected_thread_id;
+      bool is_inactive = selected_thread_id != 0 && !is_same_tid_as_selected;
+      bool is_selected = &text_box == Capture::GSelectedTextBox;
+
+      Vec2 pos(world_timer_x, world_timer_y);
+      Vec2 size(world_timer_width, layout.GetTextCoresHeight());
+      float z = GlCanvas::Z_VALUE_BOX_ACTIVE;
+      Color color = GetTimerColor(timer, time_graph_, is_selected,
+                                  is_same_tid_as_selected,
+                                  is_same_pid_as_target, is_inactive);
+
+      if (is_visible_width) {
+        batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, &text_box);
+      } else {
+        auto type = PickingID::LINE;
+        batcher->AddVerticalLine(pos, size[1], z, color, type, &text_box);
+      }
+    }
+  }
 }

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -40,7 +40,7 @@ inline float GetYFromDepth(const TimeGraphLayout& layout, float track_y,
 
 void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
   event_track_->UpdatePrimitives(min_tick, max_tick);
-  
+
   Batcher* batcher = &time_graph_->GetBatcher();
   GlCanvas* canvas = time_graph_->GetCanvas();
   const TimeGraphLayout& layout = time_graph_->GetLayout();

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -1,12 +1,6 @@
 #include "SchedulerTrack.h"
 
-#include "Capture.h"
-#include "EventTrack.h"
-#include "GlCanvas.h"
 #include "TimeGraph.h"
-
-const Color kInactiveColor(100, 100, 100, 255);
-const Color kSelectionColor(0, 128, 255, 255);
 
 void SchedulerTrack::Draw(GlCanvas* canvas, bool picking) {
   ThreadTrack::Draw(canvas, picking);
@@ -14,79 +8,7 @@ void SchedulerTrack::Draw(GlCanvas* canvas, bool picking) {
 
 float SchedulerTrack::GetHeight() const {
   TimeGraphLayout& layout = time_graph_->GetLayout();
-  return depth_ *
-             (layout.GetTextCoresHeight() + layout.GetSpaceBetweenCores()) +
-         layout.GetEventTrackHeight() + layout.GetTrackBottomMargin();
-}
-
-inline Color GetTimerColor(const Timer& timer, TimeGraph* time_graph,
-                           bool is_selected, bool same_tid, bool same_pid,
-                           bool inactive) {
-  if (is_selected) {
-    return kSelectionColor;
-  } else if (!same_tid && (inactive || !same_pid)) {
-    return kInactiveColor;
-  }
-  return time_graph->GetTimesliceColor(timer);
-}
-
-inline float GetYFromDepth(const TimeGraphLayout& layout, float track_y,
-                           uint32_t depth) {
-  return track_y - layout.GetEventTrackHeight() -
-         layout.GetSpaceBetweenTracksAndThread() -
-         (layout.GetTextCoresHeight() + layout.GetSpaceBetweenCores()) *
-             (depth + 1);
-}
-
-void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
-  event_track_->UpdatePrimitives(min_tick, max_tick);
-  
-  Batcher* batcher = &time_graph_->GetBatcher();
-  GlCanvas* canvas = time_graph_->GetCanvas();
-  const TimeGraphLayout& layout = time_graph_->GetLayout();
-  const auto& target_process = Capture::GTargetProcess;
-  uint32_t target_pid = target_process ? target_process->GetID() : 0;
-  uint32_t selected_thread_id = Capture::GSelectedThreadId;
-
-  float world_start_x = canvas->GetWorldTopLeftX();
-  float world_width = canvas->GetWorldWidth();
-  double inv_time_window = 1.0 / time_graph_->GetTimeWindowUs();
-
-  std::vector<std::shared_ptr<TimerChain>> chains_by_depth = GetTimers();
-  for (std::shared_ptr<TimerChain>& timer_chain : chains_by_depth) {
-    for (TextBox& text_box : *timer_chain) {
-      const Timer& timer = text_box.GetTimer();
-      if (min_tick > timer.m_End || max_tick < timer.m_Start) continue;
-
-      UpdateDepth(timer.m_Depth + 1);
-      double start_us = time_graph_->GetUsFromTick(timer.m_Start);
-      double end_us = time_graph_->GetUsFromTick(timer.m_End);
-      double elapsed_us = end_us - start_us;
-      double normalized_start = start_us * inv_time_window;
-      double normalized_length = elapsed_us * inv_time_window;
-      float world_timer_width = normalized_length * world_width;
-      float world_timer_x = world_start_x + normalized_start * world_width;
-      float world_timer_y = GetYFromDepth(layout, m_Pos[1], timer.m_Depth);
-
-      bool is_visible_width = normalized_length * canvas->getWidth() > 1;
-      bool is_same_pid_as_target = target_pid == 0 || target_pid == timer.m_PID;
-      bool is_same_tid_as_selected = timer.m_TID == selected_thread_id;
-      bool is_inactive = selected_thread_id != 0 && !is_same_tid_as_selected;
-      bool is_selected = &text_box == Capture::GSelectedTextBox;
-
-      Vec2 pos(world_timer_x, world_timer_y);
-      Vec2 size(world_timer_width, layout.GetTextCoresHeight());
-      float z = GlCanvas::Z_VALUE_BOX_ACTIVE;
-      Color color = GetTimerColor(timer, time_graph_, is_selected,
-                                  is_same_tid_as_selected,
-                                  is_same_pid_as_target, is_inactive);
-
-      if (is_visible_width) {
-        batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, &text_box);
-      } else {
-        auto type = PickingID::LINE;
-        batcher->AddVerticalLine(pos, size[1], z, color, type, &text_box);
-      }
-    }
-  }
+  float depth = static_cast<float>(depth_);
+  return (layout.GetTextCoresHeight() + layout.GetSpaceBetweenCores()) * depth +
+         layout.GetTrackBottomMargin();
 }

--- a/OrbitGl/SchedulerTrack.h
+++ b/OrbitGl/SchedulerTrack.h
@@ -10,7 +10,6 @@ class SchedulerTrack : public ThreadTrack {
   ~SchedulerTrack() override = default;
 
   void Draw(GlCanvas* a_Canvas, bool a_Picking) override;
-  void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick);
   Type GetType() const override { return kSchedulerTrack; }
   float GetHeight() const override;
 };

--- a/OrbitGl/SchedulerTrack.h
+++ b/OrbitGl/SchedulerTrack.h
@@ -10,6 +10,7 @@ class SchedulerTrack : public ThreadTrack {
   ~SchedulerTrack() override = default;
 
   void Draw(GlCanvas* a_Canvas, bool a_Picking) override;
+  void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick);
   Type GetType() const override { return kSchedulerTrack; }
   float GetHeight() const override;
 };

--- a/OrbitGl/SchedulerTrack.h
+++ b/OrbitGl/SchedulerTrack.h
@@ -10,7 +10,7 @@ class SchedulerTrack : public ThreadTrack {
   ~SchedulerTrack() override = default;
 
   void Draw(GlCanvas* a_Canvas, bool a_Picking) override;
-  void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick);
+  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) override;
   Type GetType() const override { return kSchedulerTrack; }
   float GetHeight() const override;
 };

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -47,7 +47,7 @@ void ThreadTrack::Draw(GlCanvas* canvas, bool picking) {
 }
 
 //-----------------------------------------------------------------------------
-std::string ThreadTrack::GetExtraInfo(const Timer& timer) {
+std::string GetExtraInfo(const Timer& timer) {
   std::string info;
   static bool show_return_value = absl::GetFlag(FLAGS_show_return_values);
   if (!Capture::IsCapturing() && timer.GetType() == Timer::UNREAL_OBJECT) {
@@ -59,134 +59,188 @@ std::string ThreadTrack::GetExtraInfo(const Timer& timer) {
 }
 
 //-----------------------------------------------------------------------------
-inline Color GetTimerColor(const Timer& timer, TimeGraph* time_graph,
-                           bool is_selected, bool inactive) {
-  const Color kInactiveColor(100, 100, 100, 255);
-  const Color kSelectionColor(0, 128, 255, 255);
-  if (is_selected) {
-    return kSelectionColor;
-  } else if (inactive) {
-    return kInactiveColor;
-  }
-
-  Color color = time_graph->GetTimesliceColor(timer);
-  const uint8_t kOddAlpha = 210;
-  if (!(timer.m_Depth & 0x1)) {
-    color[3] = kOddAlpha;
-  }
-
-  return color;
-}
-
-//-----------------------------------------------------------------------------
-inline float GetYFromDepth(const TimeGraphLayout& layout, float track_y,
-                           uint32_t depth) {
-  return track_y - layout.GetEventTrackHeight() -
-         layout.GetSpaceBetweenTracksAndThread() -
-         layout.GetTextBoxHeight() * (depth + 1);
-}
-
-//-----------------------------------------------------------------------------
-void ThreadTrack::SetTimesliceText(const Timer& timer, double elapsed_us,
-                                   float min_x, TextBox* text_box) {
-  if (text_box->GetText().empty()) {
-      double elapsed_millis = ((double)elapsed_us) * 0.001;
-      std::string time = GetPrettyTime(elapsed_millis);
-      Function* func = Capture::GSelectedFunctionsMap[timer.m_FunctionAddress];
-
-      text_box->SetElapsedTimeTextLength(time.length());
-
-      const char* name = nullptr;
-      if (func) {
-        std::string extra_info = GetExtraInfo(timer);
-        name = func->PrettyName().c_str();
-        std::string text =
-            absl::StrFormat("%s %s %s", name, extra_info.c_str(), time.c_str());
-
-        text_box->SetText(text);
-      } else if (timer.m_Type == Timer::INTROSPECTION) {
-        std::string text = absl::StrFormat(
-            "%s %s",
-            time_graph_->GetStringManager()->Get(timer.m_UserData[0]).value_or(""),
-            time.c_str());
-        text_box->SetText(text);
-      } else if (timer.m_Type == Timer::GPU_ACTIVITY) {
-        std::string text = absl::StrFormat(
-            "%s; submitter: %d  %s",
-            time_graph_->GetStringManager()->Get(timer.m_UserData[0]).value_or(""),
-            timer.m_SubmitTID, time.c_str());
-        text_box->SetText(text);
-      } else if (!SystraceManager::Get().IsEmpty()) {
-        text_box->SetText(
-            SystraceManager::Get().GetFunctionName(timer.m_FunctionAddress));
-      }
-  }
-
-  const Color kTextWhite(255, 255, 255, 255);
-  const Vec2& box_pos = text_box->GetPos();
-  const Vec2& box_size = text_box->GetSize();
-  float pos_x = std::max(box_pos[0], min_x);
-  float max_size = box_pos[0] + box_size[0] - pos_x;
-  TextRenderer* text_renderer = time_graph_->GetTextRenderer();
-  text_renderer->AddTextTrailingCharsPrioritized(
-      text_box->GetText().c_str(), pos_x, text_box->GetPosY() + 1.f,
-      GlCanvas::Z_VALUE_TEXT, kTextWhite, text_box->GetElapsedTimeTextLength(),
-      max_size);
-}
-
-//-----------------------------------------------------------------------------
 void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
   event_track_->UpdatePrimitives(min_tick, max_tick);
-
   Batcher* batcher = &time_graph_->GetBatcher();
+  TextRenderer* text_renderer = time_graph_->GetTextRenderer();
   GlCanvas* canvas = time_graph_->GetCanvas();
+
   const TimeGraphLayout& layout = time_graph_->GetLayout();
   const TextBox& scene_box = canvas->GetSceneBox();
-  const auto& target_process = Capture::GTargetProcess;
-  uint32_t target_pid = target_process ? target_process->GetID() : 0;
-  uint32_t selected_thread_id = Capture::GSelectedThreadId;
-
   float min_x = scene_box.GetPosX();
+
+  double time_window_us = time_graph_->GetTimeWindowUs();
   float world_start_x = canvas->GetWorldTopLeftX();
   float world_width = canvas->GetWorldWidth();
-  double inv_time_window = 1.0 / time_graph_->GetTimeWindowUs();
+  double inv_time_window = 1.0 / time_window_us;
 
-  std::vector<std::shared_ptr<TimerChain>> chains_by_depth = GetTimers();
-  for (auto& text_boxes : chains_by_depth) {
+  std::vector<std::shared_ptr<TimerChain>> depth_chain = GetTimers();
+  for (auto& text_boxes : depth_chain) {
     if (text_boxes == nullptr) continue;
+
     for (TextBox& text_box : *text_boxes) {
       const Timer& timer = text_box.GetTimer();
-      if (min_tick > timer.m_End || max_tick < timer.m_Start) continue;
 
-      UpdateDepth(timer.m_Depth + 1);
-      double start_us = time_graph_->GetUsFromTick(timer.m_Start);
-      double end_us = time_graph_->GetUsFromTick(timer.m_End);
-      double elapsed_us = end_us - start_us;
-      double normalized_start = start_us * inv_time_window;
-      double normalized_length = elapsed_us * inv_time_window;
-      float world_timer_width = normalized_length * world_width;
-      float world_timer_x = world_start_x + normalized_start * world_width;
-      float world_timer_y = GetYFromDepth(layout, m_Pos[1], timer.m_Depth);
+      if (!(min_tick > timer.m_End || max_tick < timer.m_Start)) {
+        double start = time_graph_->GetUsFromTick(timer.m_Start);
+        double end = time_graph_->GetUsFromTick(timer.m_End);
+        double elapsed = end - start;
 
-      bool is_visible_width = normalized_length * canvas->getWidth() > 1;
-      bool is_selected = &text_box == Capture::GSelectedTextBox;
-      bool is_inactive =
-          !Capture::GVisibleFunctionsMap.empty() &&
-          Capture::GVisibleFunctionsMap[timer.m_FunctionAddress] == nullptr;
+        double normalized_start = start * inv_time_window;
+        double normalized_length = elapsed * inv_time_window;
 
-      Vec2 pos(world_timer_x, world_timer_y);
-      Vec2 size(world_timer_width, layout.GetTextBoxHeight());
-      float z = GlCanvas::Z_VALUE_BOX_ACTIVE;
-      Color color = GetTimerColor(timer, time_graph_, is_selected, is_inactive);
-      text_box.SetPos(pos);
-      text_box.SetSize(size);
+        bool is_core = timer.IsType(Timer::CORE_ACTIVITY);
 
-      if (is_visible_width) {
-        SetTimesliceText(timer, elapsed_us, min_x, &text_box);
-        batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, &text_box);
-      } else {
-        auto type = PickingID::LINE;
-        batcher->AddVerticalLine(pos, size[1], z, color, type, &text_box);
+        float y_offset = 0;
+        if (!is_core) {
+          y_offset = m_Pos[1] - layout.GetEventTrackHeight() -
+                     layout.GetSpaceBetweenTracksAndThread() -
+                     layout.GetTextBoxHeight() * (timer.m_Depth + 1);
+        } else {
+          y_offset = layout.GetCoreOffset(timer.m_Processor);
+        }
+
+        float box_height =
+            !is_core ? layout.GetTextBoxHeight() : layout.GetTextCoresHeight();
+
+        float world_timer_start_x =
+            float(world_start_x + normalized_start * world_width);
+        float world_timer_width = float(normalized_length * world_width);
+
+        Vec2 pos(world_timer_start_x, y_offset);
+        Vec2 size(world_timer_width, box_height);
+
+        text_box.SetPos(pos);
+        text_box.SetSize(size);
+
+        if (!is_core) {
+          time_graph_->UpdateThreadDepth(timer.m_TID, timer.m_Depth + 1);
+          UpdateDepth(timer.m_Depth + 1);
+        } else {
+          UpdateDepth(timer.m_Processor + 1);
+        }
+
+        bool is_context_switch = timer.IsType(Timer::THREAD_ACTIVITY);
+        bool is_visible_width = normalized_length * canvas->getWidth() > 1;
+        bool is_same_pid_as_target =
+            is_core && Capture::GTargetProcess != nullptr
+                ? timer.m_PID == Capture::GTargetProcess->GetID()
+                : true;
+        bool is_same_tid_as_selected =
+            is_core && (timer.m_TID == Capture::GSelectedThreadId);
+        bool is_inactive =
+            (!is_context_switch && timer.m_FunctionAddress &&
+             (!Capture::GVisibleFunctionsMap.empty() &&
+              Capture::GVisibleFunctionsMap[timer.m_FunctionAddress] ==
+                  nullptr)) ||
+            (Capture::GSelectedThreadId != 0 && is_core &&
+             !is_same_tid_as_selected);
+        bool is_selected = &text_box == Capture::GSelectedTextBox;
+
+        const unsigned char g = 100;
+        Color grey(g, g, g, 255);
+        static Color selection_color(0, 128, 255, 255);
+
+        Color col = time_graph_->GetTimesliceColor(timer);
+
+        if (is_selected) {
+          col = selection_color;
+        } else if (!is_same_tid_as_selected &&
+                   (is_inactive || !is_same_pid_as_target)) {
+          col = grey;
+        }
+
+        text_box.SetColor(col[0], col[1], col[2]);
+        static int oddAlpha = 210;
+        if (!(timer.m_Depth & 0x1)) {
+          col[3] = oddAlpha;
+        }
+
+        float z = is_inactive ? GlCanvas::Z_VALUE_BOX_INACTIVE
+                              : GlCanvas::Z_VALUE_BOX_ACTIVE;
+
+        if (is_visible_width) {
+          Box box;
+          box.m_Vertices[0] = Vec3(pos[0], pos[1], z);
+          box.m_Vertices[1] = Vec3(pos[0], pos[1] + size[1], z);
+          box.m_Vertices[2] = Vec3(pos[0] + size[0], pos[1] + size[1], z);
+          box.m_Vertices[3] = Vec3(pos[0] + size[0], pos[1], z);
+          Color colors[4];
+          Fill(colors, col);
+
+          static float coeff = 0.94f;
+          Vec3 dark = Vec3(col[0], col[1], col[2]) * coeff;
+          colors[1] = Color((unsigned char)dark[0], (unsigned char)dark[1],
+                            (unsigned char)dark[2], (unsigned char)col[3]);
+          colors[0] = colors[1];
+          batcher->AddBox(box, colors, PickingID::BOX, &text_box);
+
+          if (!is_context_switch && text_box.GetText().empty()) {
+            double elapsed_millis = ((double)elapsed) * 0.001;
+            std::string time = GetPrettyTime(elapsed_millis);
+            Function* func =
+                Capture::GSelectedFunctionsMap[timer.m_FunctionAddress];
+
+            text_box.SetElapsedTimeTextLength(time.length());
+
+            const char* name = nullptr;
+            if (func) {
+              std::string extra_info = GetExtraInfo(timer);
+              name = func->PrettyName().c_str();
+              std::string text = absl::StrFormat(
+                  "%s %s %s", name, extra_info.c_str(), time.c_str());
+
+              text_box.SetText(text);
+            } else if (timer.m_Type == Timer::INTROSPECTION) {
+              std::string text = absl::StrFormat("%s %s",
+                                                 time_graph_->GetStringManager()
+                                                     ->Get(timer.m_UserData[0])
+                                                     .value_or(""),
+                                                 time.c_str());
+              text_box.SetText(text);
+            } else if (timer.m_Type == Timer::GPU_ACTIVITY) {
+              std::string text =
+                  absl::StrFormat("%s; submitter: %d  %s",
+                                  time_graph_->GetStringManager()
+                                      ->Get(timer.m_UserData[0])
+                                      .value_or(""),
+                                  timer.m_SubmitTID, time.c_str());
+              text_box.SetText(text);
+            } else if (!SystraceManager::Get().IsEmpty()) {
+              text_box.SetText(SystraceManager::Get().GetFunctionName(
+                  timer.m_FunctionAddress));
+            } else if (!Capture::IsCapturing()) {
+              // GZoneNames is populated when capturing, prevent race
+              // by accessing it only when not capturing.
+              auto it = Capture::GZoneNames.find(timer.m_FunctionAddress);
+              if (it != Capture::GZoneNames.end()) {
+                name = it->second.c_str();
+                std::string text = absl::StrFormat("%s %s", name, time.c_str());
+                text_box.SetText(text);
+              }
+            }
+          }
+
+          if (!is_core) {
+            static Color s_Color(255, 255, 255, 255);
+
+            const Vec2& box_pos = text_box.GetPos();
+            const Vec2& box_size = text_box.GetSize();
+            float pos_x = std::max(box_pos[0], min_x);
+            float max_size = box_pos[0] + box_size[0] - pos_x;
+            text_renderer->AddTextTrailingCharsPrioritized(
+                text_box.GetText().c_str(), pos_x, text_box.GetPosY() + 1.f,
+                GlCanvas::Z_VALUE_TEXT, s_Color,
+                text_box.GetElapsedTimeTextLength(), max_size);
+          }
+        } else {
+          Line line;
+          line.m_Beg = Vec3(pos[0], pos[1], z);
+          line.m_End = Vec3(pos[0], pos[1] + size[1], z);
+          Color colors[2];
+          Fill(colors, col);
+          batcher->AddLine(line, colors, PickingID::LINE, &text_box);
+        }
       }
     }
   }

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -47,7 +47,7 @@ void ThreadTrack::Draw(GlCanvas* canvas, bool picking) {
 }
 
 //-----------------------------------------------------------------------------
-std::string GetExtraInfo(const Timer& timer) {
+std::string ThreadTrack::GetExtraInfo(const Timer& timer) {
   std::string info;
   static bool show_return_value = absl::GetFlag(FLAGS_show_return_values);
   if (!Capture::IsCapturing() && timer.GetType() == Timer::UNREAL_OBJECT) {
@@ -59,188 +59,134 @@ std::string GetExtraInfo(const Timer& timer) {
 }
 
 //-----------------------------------------------------------------------------
+inline Color GetTimerColor(const Timer& timer, TimeGraph* time_graph,
+                           bool is_selected, bool inactive) {
+  const Color kInactiveColor(100, 100, 100, 255);
+  const Color kSelectionColor(0, 128, 255, 255);
+  if (is_selected) {
+    return kSelectionColor;
+  } else if (inactive) {
+    return kInactiveColor;
+  }
+
+  Color color = time_graph->GetTimesliceColor(timer);
+  const uint8_t kOddAlpha = 210;
+  if (!(timer.m_Depth & 0x1)) {
+    color[3] = kOddAlpha;
+  }
+
+  return color;
+}
+
+//-----------------------------------------------------------------------------
+inline float GetYFromDepth(const TimeGraphLayout& layout, float track_y,
+                           uint32_t depth) {
+  return track_y - layout.GetEventTrackHeight() -
+         layout.GetSpaceBetweenTracksAndThread() -
+         layout.GetTextBoxHeight() * (depth + 1);
+}
+
+//-----------------------------------------------------------------------------
+void ThreadTrack::SetTimesliceText(const Timer& timer, double elapsed_us,
+                                   float min_x, TextBox* text_box) {
+  if (text_box->GetText().empty()) {
+      double elapsed_millis = ((double)elapsed_us) * 0.001;
+      std::string time = GetPrettyTime(elapsed_millis);
+      Function* func = Capture::GSelectedFunctionsMap[timer.m_FunctionAddress];
+
+      text_box->SetElapsedTimeTextLength(time.length());
+
+      const char* name = nullptr;
+      if (func) {
+        std::string extra_info = GetExtraInfo(timer);
+        name = func->PrettyName().c_str();
+        std::string text =
+            absl::StrFormat("%s %s %s", name, extra_info.c_str(), time.c_str());
+
+        text_box->SetText(text);
+      } else if (timer.m_Type == Timer::INTROSPECTION) {
+        std::string text = absl::StrFormat(
+            "%s %s",
+            time_graph_->GetStringManager()->Get(timer.m_UserData[0]).value_or(""),
+            time.c_str());
+        text_box->SetText(text);
+      } else if (timer.m_Type == Timer::GPU_ACTIVITY) {
+        std::string text = absl::StrFormat(
+            "%s; submitter: %d  %s",
+            time_graph_->GetStringManager()->Get(timer.m_UserData[0]).value_or(""),
+            timer.m_SubmitTID, time.c_str());
+        text_box->SetText(text);
+      } else if (!SystraceManager::Get().IsEmpty()) {
+        text_box->SetText(
+            SystraceManager::Get().GetFunctionName(timer.m_FunctionAddress));
+      }
+  }
+
+  const Color kTextWhite(255, 255, 255, 255);
+  const Vec2& box_pos = text_box->GetPos();
+  const Vec2& box_size = text_box->GetSize();
+  float pos_x = std::max(box_pos[0], min_x);
+  float max_size = box_pos[0] + box_size[0] - pos_x;
+  TextRenderer* text_renderer = time_graph_->GetTextRenderer();
+  text_renderer->AddTextTrailingCharsPrioritized(
+      text_box->GetText().c_str(), pos_x, text_box->GetPosY() + 1.f,
+      GlCanvas::Z_VALUE_TEXT, kTextWhite, text_box->GetElapsedTimeTextLength(),
+      max_size);
+}
+
+//-----------------------------------------------------------------------------
 void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
   event_track_->UpdatePrimitives(min_tick, max_tick);
-  Batcher* batcher = &time_graph_->GetBatcher();
-  TextRenderer* text_renderer = time_graph_->GetTextRenderer();
-  GlCanvas* canvas = time_graph_->GetCanvas();
 
+  Batcher* batcher = &time_graph_->GetBatcher();
+  GlCanvas* canvas = time_graph_->GetCanvas();
   const TimeGraphLayout& layout = time_graph_->GetLayout();
   const TextBox& scene_box = canvas->GetSceneBox();
-  float min_x = scene_box.GetPosX();
+  const auto& target_process = Capture::GTargetProcess;
+  uint32_t target_pid = target_process ? target_process->GetID() : 0;
+  uint32_t selected_thread_id = Capture::GSelectedThreadId;
 
-  double time_window_us = time_graph_->GetTimeWindowUs();
+  float min_x = scene_box.GetPosX();
   float world_start_x = canvas->GetWorldTopLeftX();
   float world_width = canvas->GetWorldWidth();
-  double inv_time_window = 1.0 / time_window_us;
+  double inv_time_window = 1.0 / time_graph_->GetTimeWindowUs();
 
-  std::vector<std::shared_ptr<TimerChain>> depth_chain = GetTimers();
-  for (auto& text_boxes : depth_chain) {
+  std::vector<std::shared_ptr<TimerChain>> chains_by_depth = GetTimers();
+  for (auto& text_boxes : chains_by_depth) {
     if (text_boxes == nullptr) continue;
-
     for (TextBox& text_box : *text_boxes) {
       const Timer& timer = text_box.GetTimer();
+      if (min_tick > timer.m_End || max_tick < timer.m_Start) continue;
 
-      if (!(min_tick > timer.m_End || max_tick < timer.m_Start)) {
-        double start = time_graph_->GetUsFromTick(timer.m_Start);
-        double end = time_graph_->GetUsFromTick(timer.m_End);
-        double elapsed = end - start;
+      UpdateDepth(timer.m_Depth + 1);
+      double start_us = time_graph_->GetUsFromTick(timer.m_Start);
+      double end_us = time_graph_->GetUsFromTick(timer.m_End);
+      double elapsed_us = end_us - start_us;
+      double normalized_start = start_us * inv_time_window;
+      double normalized_length = elapsed_us * inv_time_window;
+      float world_timer_width = normalized_length * world_width;
+      float world_timer_x = world_start_x + normalized_start * world_width;
+      float world_timer_y = GetYFromDepth(layout, m_Pos[1], timer.m_Depth);
 
-        double normalized_start = start * inv_time_window;
-        double normalized_length = elapsed * inv_time_window;
+      bool is_visible_width = normalized_length * canvas->getWidth() > 1;
+      bool is_selected = &text_box == Capture::GSelectedTextBox;
+      bool is_inactive =
+          !Capture::GVisibleFunctionsMap.empty() &&
+          Capture::GVisibleFunctionsMap[timer.m_FunctionAddress] == nullptr;
 
-        bool is_core = timer.IsType(Timer::CORE_ACTIVITY);
+      Vec2 pos(world_timer_x, world_timer_y);
+      Vec2 size(world_timer_width, layout.GetTextBoxHeight());
+      float z = GlCanvas::Z_VALUE_BOX_ACTIVE;
+      Color color = GetTimerColor(timer, time_graph_, is_selected, is_inactive);
+      text_box.SetPos(pos);
+      text_box.SetSize(size);
 
-        float y_offset = 0;
-        if (!is_core) {
-          y_offset = m_Pos[1] - layout.GetEventTrackHeight() -
-                     layout.GetSpaceBetweenTracksAndThread() -
-                     layout.GetTextBoxHeight() * (timer.m_Depth + 1);
-        } else {
-          y_offset = layout.GetCoreOffset(timer.m_Processor);
-        }
-
-        float box_height =
-            !is_core ? layout.GetTextBoxHeight() : layout.GetTextCoresHeight();
-
-        float world_timer_start_x =
-            float(world_start_x + normalized_start * world_width);
-        float world_timer_width = float(normalized_length * world_width);
-
-        Vec2 pos(world_timer_start_x, y_offset);
-        Vec2 size(world_timer_width, box_height);
-
-        text_box.SetPos(pos);
-        text_box.SetSize(size);
-
-        if (!is_core) {
-          time_graph_->UpdateThreadDepth(timer.m_TID, timer.m_Depth + 1);
-          UpdateDepth(timer.m_Depth + 1);
-        } else {
-          UpdateDepth(timer.m_Processor + 1);
-        }
-
-        bool is_context_switch = timer.IsType(Timer::THREAD_ACTIVITY);
-        bool is_visible_width = normalized_length * canvas->getWidth() > 1;
-        bool is_same_pid_as_target =
-            is_core && Capture::GTargetProcess != nullptr
-                ? timer.m_PID == Capture::GTargetProcess->GetID()
-                : true;
-        bool is_same_tid_as_selected =
-            is_core && (timer.m_TID == Capture::GSelectedThreadId);
-        bool is_inactive =
-            (!is_context_switch && timer.m_FunctionAddress &&
-             (!Capture::GVisibleFunctionsMap.empty() &&
-              Capture::GVisibleFunctionsMap[timer.m_FunctionAddress] ==
-                  nullptr)) ||
-            (Capture::GSelectedThreadId != 0 && is_core &&
-             !is_same_tid_as_selected);
-        bool is_selected = &text_box == Capture::GSelectedTextBox;
-
-        const unsigned char g = 100;
-        Color grey(g, g, g, 255);
-        static Color selection_color(0, 128, 255, 255);
-
-        Color col = time_graph_->GetTimesliceColor(timer);
-
-        if (is_selected) {
-          col = selection_color;
-        } else if (!is_same_tid_as_selected &&
-                   (is_inactive || !is_same_pid_as_target)) {
-          col = grey;
-        }
-
-        text_box.SetColor(col[0], col[1], col[2]);
-        static int oddAlpha = 210;
-        if (!(timer.m_Depth & 0x1)) {
-          col[3] = oddAlpha;
-        }
-
-        float z = is_inactive ? GlCanvas::Z_VALUE_BOX_INACTIVE
-                              : GlCanvas::Z_VALUE_BOX_ACTIVE;
-
-        if (is_visible_width) {
-          Box box;
-          box.m_Vertices[0] = Vec3(pos[0], pos[1], z);
-          box.m_Vertices[1] = Vec3(pos[0], pos[1] + size[1], z);
-          box.m_Vertices[2] = Vec3(pos[0] + size[0], pos[1] + size[1], z);
-          box.m_Vertices[3] = Vec3(pos[0] + size[0], pos[1], z);
-          Color colors[4];
-          Fill(colors, col);
-
-          static float coeff = 0.94f;
-          Vec3 dark = Vec3(col[0], col[1], col[2]) * coeff;
-          colors[1] = Color((unsigned char)dark[0], (unsigned char)dark[1],
-                            (unsigned char)dark[2], (unsigned char)col[3]);
-          colors[0] = colors[1];
-          batcher->AddBox(box, colors, PickingID::BOX, &text_box);
-
-          if (!is_context_switch && text_box.GetText().empty()) {
-            double elapsed_millis = ((double)elapsed) * 0.001;
-            std::string time = GetPrettyTime(elapsed_millis);
-            Function* func =
-                Capture::GSelectedFunctionsMap[timer.m_FunctionAddress];
-
-            text_box.SetElapsedTimeTextLength(time.length());
-
-            const char* name = nullptr;
-            if (func) {
-              std::string extra_info = GetExtraInfo(timer);
-              name = func->PrettyName().c_str();
-              std::string text = absl::StrFormat(
-                  "%s %s %s", name, extra_info.c_str(), time.c_str());
-
-              text_box.SetText(text);
-            } else if (timer.m_Type == Timer::INTROSPECTION) {
-              std::string text = absl::StrFormat("%s %s",
-                                                 time_graph_->GetStringManager()
-                                                     ->Get(timer.m_UserData[0])
-                                                     .value_or(""),
-                                                 time.c_str());
-              text_box.SetText(text);
-            } else if (timer.m_Type == Timer::GPU_ACTIVITY) {
-              std::string text =
-                  absl::StrFormat("%s; submitter: %d  %s",
-                                  time_graph_->GetStringManager()
-                                      ->Get(timer.m_UserData[0])
-                                      .value_or(""),
-                                  timer.m_SubmitTID, time.c_str());
-              text_box.SetText(text);
-            } else if (!SystraceManager::Get().IsEmpty()) {
-              text_box.SetText(SystraceManager::Get().GetFunctionName(
-                  timer.m_FunctionAddress));
-            } else if (!Capture::IsCapturing()) {
-              // GZoneNames is populated when capturing, prevent race
-              // by accessing it only when not capturing.
-              auto it = Capture::GZoneNames.find(timer.m_FunctionAddress);
-              if (it != Capture::GZoneNames.end()) {
-                name = it->second.c_str();
-                std::string text = absl::StrFormat("%s %s", name, time.c_str());
-                text_box.SetText(text);
-              }
-            }
-          }
-
-          if (!is_core) {
-            static Color s_Color(255, 255, 255, 255);
-
-            const Vec2& box_pos = text_box.GetPos();
-            const Vec2& box_size = text_box.GetSize();
-            float pos_x = std::max(box_pos[0], min_x);
-            float max_size = box_pos[0] + box_size[0] - pos_x;
-            text_renderer->AddTextTrailingCharsPrioritized(
-                text_box.GetText().c_str(), pos_x, text_box.GetPosY() + 1.f,
-                GlCanvas::Z_VALUE_TEXT, s_Color,
-                text_box.GetElapsedTimeTextLength(), max_size);
-          }
-        } else {
-          Line line;
-          line.m_Beg = Vec3(pos[0], pos[1], z);
-          line.m_End = Vec3(pos[0], pos[1] + size[1], z);
-          Color colors[2];
-          Fill(colors, col);
-          batcher->AddLine(line, colors, PickingID::LINE, &text_box);
-        }
+      if (is_visible_width) {
+        SetTimesliceText(timer, elapsed_us, min_x, &text_box);
+        batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, &text_box);
+      } else {
+        auto type = PickingID::LINE;
+        batcher->AddVerticalLine(pos, size[1], z, color, type, &text_box);
       }
     }
   }

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -90,36 +90,38 @@ inline float GetYFromDepth(const TimeGraphLayout& layout, float track_y,
 void ThreadTrack::SetTimesliceText(const Timer& timer, double elapsed_us,
                                    float min_x, TextBox* text_box) {
   if (text_box->GetText().empty()) {
-      double elapsed_millis = ((double)elapsed_us) * 0.001;
-      std::string time = GetPrettyTime(elapsed_millis);
-      Function* func = Capture::GSelectedFunctionsMap[timer.m_FunctionAddress];
+    double elapsed_millis = ((double)elapsed_us) * 0.001;
+    std::string time = GetPrettyTime(elapsed_millis);
+    Function* func = Capture::GSelectedFunctionsMap[timer.m_FunctionAddress];
 
-      text_box->SetElapsedTimeTextLength(time.length());
+    text_box->SetElapsedTimeTextLength(time.length());
 
-      const char* name = nullptr;
-      if (func) {
-        std::string extra_info = GetExtraInfo(timer);
-        name = func->PrettyName().c_str();
-        std::string text =
-            absl::StrFormat("%s %s %s", name, extra_info.c_str(), time.c_str());
+    const char* name = nullptr;
+    if (func) {
+      std::string extra_info = GetExtraInfo(timer);
+      name = func->PrettyName().c_str();
+      std::string text =
+          absl::StrFormat("%s %s %s", name, extra_info.c_str(), time.c_str());
 
-        text_box->SetText(text);
-      } else if (timer.m_Type == Timer::INTROSPECTION) {
-        std::string text = absl::StrFormat(
-            "%s %s",
-            time_graph_->GetStringManager()->Get(timer.m_UserData[0]).value_or(""),
-            time.c_str());
-        text_box->SetText(text);
-      } else if (timer.m_Type == Timer::GPU_ACTIVITY) {
-        std::string text = absl::StrFormat(
-            "%s; submitter: %d  %s",
-            time_graph_->GetStringManager()->Get(timer.m_UserData[0]).value_or(""),
-            timer.m_SubmitTID, time.c_str());
-        text_box->SetText(text);
-      } else if (!SystraceManager::Get().IsEmpty()) {
-        text_box->SetText(
-            SystraceManager::Get().GetFunctionName(timer.m_FunctionAddress));
-      }
+      text_box->SetText(text);
+    } else if (timer.m_Type == Timer::INTROSPECTION) {
+      std::string text = absl::StrFormat("%s %s",
+                                         time_graph_->GetStringManager()
+                                             ->Get(timer.m_UserData[0])
+                                             .value_or(""),
+                                         time.c_str());
+      text_box->SetText(text);
+    } else if (timer.m_Type == Timer::GPU_ACTIVITY) {
+      std::string text = absl::StrFormat("%s; submitter: %d  %s",
+                                         time_graph_->GetStringManager()
+                                             ->Get(timer.m_UserData[0])
+                                             .value_or(""),
+                                         timer.m_SubmitTID, time.c_str());
+      text_box->SetText(text);
+    } else if (!SystraceManager::Get().IsEmpty()) {
+      text_box->SetText(
+          SystraceManager::Get().GetFunctionName(timer.m_FunctionAddress));
+    }
   }
 
   const Color kTextWhite(255, 255, 255, 255);

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -142,9 +142,6 @@ void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
   GlCanvas* canvas = time_graph_->GetCanvas();
   const TimeGraphLayout& layout = time_graph_->GetLayout();
   const TextBox& scene_box = canvas->GetSceneBox();
-  const auto& target_process = Capture::GTargetProcess;
-  uint32_t target_pid = target_process ? target_process->GetID() : 0;
-  uint32_t selected_thread_id = Capture::GSelectedThreadId;
 
   float min_x = scene_box.GetPosX();
   float world_start_x = canvas->GetWorldTopLeftX();

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -70,7 +70,7 @@ inline Color GetTimerColor(const Timer& timer, TimeGraph* time_graph,
   }
 
   Color color = time_graph->GetTimesliceColor(timer);
-  const uint8_t kOddAlpha = 210;
+  constexpr uint8_t kOddAlpha = 210;
   if (!(timer.m_Depth & 0x1)) {
     color[3] = kOddAlpha;
   }
@@ -90,7 +90,7 @@ inline float GetYFromDepth(const TimeGraphLayout& layout, float track_y,
 void ThreadTrack::SetTimesliceText(const Timer& timer, double elapsed_us,
                                    float min_x, TextBox* text_box) {
   if (text_box->GetText().empty()) {
-    double elapsed_millis = ((double)elapsed_us) * 0.001;
+    double elapsed_millis = elapsed_us * 0.001;
     std::string time = GetPrettyTime(elapsed_millis);
     Function* func = Capture::GSelectedFunctionsMap[timer.m_FunctionAddress];
 

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -32,7 +32,6 @@ class ThreadTrack : public Track {
 
   std::vector<std::shared_ptr<TimerChain>> GetTimers() override;
   uint32_t GetDepth() const { return depth_; }
-  std::string GetExtraInfo(const Timer& timer);
 
   Color GetColor() const;
   static Color GetColor(ThreadID a_TID);
@@ -57,10 +56,6 @@ class ThreadTrack : public Track {
     if (depth > depth_) depth_ = depth;
   }
   std::shared_ptr<TimerChain> GetTimers(uint32_t depth) const;
-
- private:
-  void SetTimesliceText(const Timer& timer, double elapsed_us,
-                        float min_x, TextBox* text_box);
 
  protected:
   TextRenderer* text_renderer_ = nullptr;

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -32,6 +32,7 @@ class ThreadTrack : public Track {
 
   std::vector<std::shared_ptr<TimerChain>> GetTimers() override;
   uint32_t GetDepth() const { return depth_; }
+  std::string GetExtraInfo(const Timer& timer);
 
   Color GetColor() const;
   static Color GetColor(ThreadID a_TID);
@@ -56,6 +57,10 @@ class ThreadTrack : public Track {
     if (depth > depth_) depth_ = depth;
   }
   std::shared_ptr<TimerChain> GetTimers(uint32_t depth) const;
+
+ private:
+  void SetTimesliceText(const Timer& timer, double elapsed_us,
+                        float min_x, TextBox* text_box);
 
  protected:
   TextRenderer* text_renderer_ = nullptr;

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -59,8 +59,8 @@ class ThreadTrack : public Track {
   std::shared_ptr<TimerChain> GetTimers(uint32_t depth) const;
 
  private:
-  void SetTimesliceText(const Timer& timer, double elapsed_us,
-                        float min_x, TextBox* text_box);
+  void SetTimesliceText(const Timer& timer, double elapsed_us, float min_x,
+                        TextBox* text_box);
 
  protected:
   TextRenderer* text_renderer_ = nullptr;

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -373,6 +373,7 @@ void TimeGraph::AddContextSwitch(const ContextSwitch& a_CS) {
           timer.m_PID = lastCS.m_ProcessId;
           timer.m_TID = lastCS.m_ThreadId;
           timer.m_Processor = static_cast<int8_t>(lastCS.m_ProcessorIndex);
+          timer.m_Depth = timer.m_Processor;
           timer.m_SessionID = Message::GSessionID;
           timer.SetType(Timer::CORE_ACTIVITY);
 
@@ -418,13 +419,6 @@ void TimeGraph::UpdateMaxTimeStamp(TickType a_Time) {
     m_SessionMaxCounter = a_Time;
   }
 };
-
-//-----------------------------------------------------------------------------
-void TimeGraph::UpdateThreadDepth(int a_ThreadId, int a_Depth) {
-  if (a_Depth > m_ThreadDepths[a_ThreadId]) {
-    m_ThreadDepths[a_ThreadId] = a_Depth;
-  }
-}
 
 //-----------------------------------------------------------------------------
 float TimeGraph::GetThreadTotalHeight() { return std::abs(min_y_); }
@@ -659,9 +653,6 @@ void TimeGraph::SortTracks() {
   // Reorder threads once every second when capturing
   if (!Capture::IsCapturing() || m_LastThreadReorder.QueryMillis() > 1000.0) {
     sorted_tracks_.clear();
-
-    // Sched track is currently held as thread 0, TODO: make it it's own track.
-    sorted_tracks_.emplace_back(GetOrCreateThreadTrack(0));
 
     std::vector<ThreadID> sortedThreadIds;
 

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -373,7 +373,6 @@ void TimeGraph::AddContextSwitch(const ContextSwitch& a_CS) {
           timer.m_PID = lastCS.m_ProcessId;
           timer.m_TID = lastCS.m_ThreadId;
           timer.m_Processor = static_cast<int8_t>(lastCS.m_ProcessorIndex);
-          timer.m_Depth = timer.m_Processor;
           timer.m_SessionID = Message::GSessionID;
           timer.SetType(Timer::CORE_ACTIVITY);
 
@@ -419,6 +418,13 @@ void TimeGraph::UpdateMaxTimeStamp(TickType a_Time) {
     m_SessionMaxCounter = a_Time;
   }
 };
+
+//-----------------------------------------------------------------------------
+void TimeGraph::UpdateThreadDepth(int a_ThreadId, int a_Depth) {
+  if (a_Depth > m_ThreadDepths[a_ThreadId]) {
+    m_ThreadDepths[a_ThreadId] = a_Depth;
+  }
+}
 
 //-----------------------------------------------------------------------------
 float TimeGraph::GetThreadTotalHeight() { return std::abs(min_y_); }
@@ -653,6 +659,9 @@ void TimeGraph::SortTracks() {
   // Reorder threads once every second when capturing
   if (!Capture::IsCapturing() || m_LastThreadReorder.QueryMillis() > 1000.0) {
     sorted_tracks_.clear();
+
+    // Sched track is currently held as thread 0, TODO: make it it's own track.
+    sorted_tracks_.emplace_back(GetOrCreateThreadTrack(0));
 
     std::vector<ThreadID> sortedThreadIds;
 

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -41,6 +41,7 @@ class TimeGraph {
                                            ThreadID a_TID);
 
   void ProcessTimer(const Timer& a_Timer);
+  void UpdateThreadDepth(int a_ThreadId, int a_Depth);
   void UpdateMaxTimeStamp(TickType a_Time);
 
   float GetThreadTotalHeight();
@@ -128,6 +129,7 @@ class TimeGraph {
   double m_MaxTimeUs = 0;
   TickType m_SessionMinCounter = 0;
   TickType m_SessionMaxCounter = 0;
+  std::map<ThreadID, int> m_ThreadDepths;
   std::map<ThreadID, uint32_t> m_EventCount;
   double m_TimeWindowUs = 0;
   float m_WorldStartX = 0;

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -41,7 +41,6 @@ class TimeGraph {
                                            ThreadID a_TID);
 
   void ProcessTimer(const Timer& a_Timer);
-  void UpdateThreadDepth(int a_ThreadId, int a_Depth);
   void UpdateMaxTimeStamp(TickType a_Time);
 
   float GetThreadTotalHeight();
@@ -129,7 +128,6 @@ class TimeGraph {
   double m_MaxTimeUs = 0;
   TickType m_SessionMinCounter = 0;
   TickType m_SessionMaxCounter = 0;
-  std::map<ThreadID, int> m_ThreadDepths;
   std::map<ThreadID, uint32_t> m_EventCount;
   double m_TimeWindowUs = 0;
   float m_WorldStartX = 0;

--- a/OrbitGl/TimeGraphLayout.cpp
+++ b/OrbitGl/TimeGraphLayout.cpp
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------------
 TimeGraphLayout::TimeGraphLayout() {
   m_NumCores = 0;
+  m_WorldY = 0.f;
   m_TextBoxHeight = 20.f;
   m_CoresHeight = 5.f;
   m_EventTrackHeight = 10.f;
@@ -21,6 +22,28 @@ TimeGraphLayout::TimeGraphLayout() {
   m_TextZ = -0.02f;
   m_TrackZ = -0.1f;
 };
+
+//-----------------------------------------------------------------------------
+float TimeGraphLayout::GetThreadStart() {
+  if (Capture::GHasContextSwitches) {
+    return m_WorldY - m_NumCores * m_CoresHeight -
+           std::max(m_NumCores - 1, 0) * m_SpaceBetweenCores -
+           m_SpaceBetweenCoresAndThread;
+  }
+
+  return m_WorldY;
+}
+
+//-----------------------------------------------------------------------------
+float TimeGraphLayout::GetCoreOffset(int a_CoreId) const {
+  if (Capture::GHasContextSwitches) {
+    float coreOffset = m_WorldY - m_CoresHeight -
+                       a_CoreId * (m_CoresHeight + m_SpaceBetweenCores);
+    return coreOffset;
+  }
+
+  return 0.f;
+}
 
 //-----------------------------------------------------------------------------
 #define FLOAT_SLIDER_MIN_MAX(x, min, max)     \

--- a/OrbitGl/TimeGraphLayout.cpp
+++ b/OrbitGl/TimeGraphLayout.cpp
@@ -6,7 +6,6 @@
 //-----------------------------------------------------------------------------
 TimeGraphLayout::TimeGraphLayout() {
   m_NumCores = 0;
-  m_WorldY = 0.f;
   m_TextBoxHeight = 20.f;
   m_CoresHeight = 5.f;
   m_EventTrackHeight = 10.f;
@@ -22,28 +21,6 @@ TimeGraphLayout::TimeGraphLayout() {
   m_TextZ = -0.02f;
   m_TrackZ = -0.1f;
 };
-
-//-----------------------------------------------------------------------------
-float TimeGraphLayout::GetThreadStart() {
-  if (Capture::GHasContextSwitches) {
-    return m_WorldY - m_NumCores * m_CoresHeight -
-           std::max(m_NumCores - 1, 0) * m_SpaceBetweenCores -
-           m_SpaceBetweenCoresAndThread;
-  }
-
-  return m_WorldY;
-}
-
-//-----------------------------------------------------------------------------
-float TimeGraphLayout::GetCoreOffset(int a_CoreId) const {
-  if (Capture::GHasContextSwitches) {
-    float coreOffset = m_WorldY - m_CoresHeight -
-                       a_CoreId * (m_CoresHeight + m_SpaceBetweenCores);
-    return coreOffset;
-  }
-
-  return 0.f;
-}
 
 //-----------------------------------------------------------------------------
 #define FLOAT_SLIDER_MIN_MAX(x, min, max)     \

--- a/OrbitGl/TimeGraphLayout.h
+++ b/OrbitGl/TimeGraphLayout.h
@@ -10,8 +10,6 @@ class TimeGraphLayout {
  public:
   TimeGraphLayout();
 
-  float GetCoreOffset(int a_CoreId) const;
-  float GetThreadStart();
   float GetTextBoxHeight() const { return m_TextBoxHeight; }
   float GetTextCoresHeight() const { return m_CoresHeight; }
   float GetEventTrackHeight() const { return m_EventTrackHeight; }
@@ -34,7 +32,6 @@ class TimeGraphLayout {
  protected:
   int m_NumCores;
 
-  float m_WorldY;
   float m_TextBoxHeight;
   float m_CoresHeight;
   float m_EventTrackHeight;

--- a/OrbitGl/TimeGraphLayout.h
+++ b/OrbitGl/TimeGraphLayout.h
@@ -10,6 +10,8 @@ class TimeGraphLayout {
  public:
   TimeGraphLayout();
 
+  float GetCoreOffset(int a_CoreId) const;
+  float GetThreadStart();
   float GetTextBoxHeight() const { return m_TextBoxHeight; }
   float GetTextCoresHeight() const { return m_CoresHeight; }
   float GetEventTrackHeight() const { return m_EventTrackHeight; }
@@ -32,6 +34,7 @@ class TimeGraphLayout {
  protected:
   int m_NumCores;
 
+  float m_WorldY;
   float m_TextBoxHeight;
   float m_CoresHeight;
   float m_EventTrackHeight;


### PR DESCRIPTION
    - Simplify ThreadTrack mega rendering function
    - Add util functions to Batcher
    - Simplify EventTrack
    - Remove obsolete code in TimeGraph and TimeGraphLayout

This change cleans up the mega ThreadTrack::UpdatePrimitives functions by extracting the scheduling specific code to SchedulerTrack::UpdatePrimitives.  Some helper functions were added to make code easier to read. 