### PR TITLE
Add runtime detection for thread name support on Windows

### DIFF
--- a/OrbitCore/Threading.h
+++ b/OrbitCore/Threading.h
@@ -10,20 +10,19 @@
 #include <thread>
 
 // Moodycamel's concurrent queue
-#ifdef WIN32
+#ifdef _WIN32
 #pragma warning(push, 0)
 #endif
 #include <concurrentqueue.h>
-#ifdef WIN32
+#ifdef _WIN32
 #pragma warning(pop)
-#endif
 
 // HEA-L's oqpi
-#ifdef _WIN32
 #include <processthreadsapi.h>
 #define OQPI_USE_DEFAULT
 #include "oqpi.hpp"
 using oqpi_tk = oqpi::default_helpers;
+#include <Windows.h>
 #endif
 
 #include "Utils.h"
@@ -48,31 +47,77 @@ typedef struct tagTHREADNAME_INFO {
 } THREADNAME_INFO;
 #pragma pack(pop)
 
-//-----------------------------------------------------------------------------
-inline void SetThreadName(HANDLE a_Thread, const wchar_t* a_ThreadName) {
-  SetThreadDescription(a_Thread, a_ThreadName);
+inline void SetThreadNameFallback(HANDLE thread,
+                                  const std::string& threadName) {
+  THREADNAME_INFO info;
+  info.dwType = 0x1000;
+  info.szName = threadName.c_str();
+  info.dwThreadID = GetThreadId(thread);
+  info.dwFlags = 0;
+#pragma warning(push)
+#pragma warning(disable : 6320 6322)
+  __try {
+    RaiseException(MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(ULONG_PTR),
+                   (ULONG_PTR*)&info);
+  } __except (EXCEPTION_EXECUTE_HANDLER) {
+  }
+#pragma warning(pop)
 }
 
-//-----------------------------------------------------------------------------
-inline void SetCurrentThreadName(const wchar_t* a_ThreadName) {
-  SetThreadDescription(GetCurrentThread(), a_ThreadName);
+inline void SetThreadName(HANDLE thread, const wchar_t* threadName) {
+  using SetThreadDescriptionPtr = HRESULT(WINAPI*)(HANDLE, PCWSTR);
+  static auto const setThreadDescriptionPtr = []() -> SetThreadDescriptionPtr {
+    HMODULE kernel32 = LoadLibraryA("kernel32.dll");
+
+    SetThreadDescriptionPtr ptr = nullptr;
+    if (kernel32 != NULL) {
+      return reinterpret_cast<SetThreadDescriptionPtr>(
+          GetProcAddress(kernel32, "SetThreadDescription"));
+    } else {
+      return nullptr;
+    }
+  }();
+
+  if (setThreadDescriptionPtr != nullptr) {
+    (*setThreadDescriptionPtr)(thread, threadName);
+  } else {
+    SetThreadNameFallback(thread, ws2s(threadName));
+  }
 }
 
-//-----------------------------------------------------------------------------
-inline std::string GetThreadName(HANDLE a_Thread) {
+inline void SetCurrentThreadName(const wchar_t* threadName) {
+  SetThreadName(GetCurrentThread(), threadName);
+}
+
+inline std::string GetThreadName(HANDLE thread) {
   std::string name;
-  PWSTR data = nullptr;
-  HRESULT hr = GetThreadDescription(a_Thread, &data);
 
-  if (SUCCEEDED(hr)) {
-    name = ws2s(data);
-    LocalFree(data);
+  using GetThreadDescriptionPtr = HRESULT(WINAPI*)(HANDLE, PWSTR*);
+  static auto const getThreadDescriptionPtr = []() -> GetThreadDescriptionPtr {
+    HMODULE kernel32 = LoadLibraryA("kernel32.dll");
+
+    GetThreadDescriptionPtr ptr = nullptr;
+    if (kernel32 != NULL) {
+      return reinterpret_cast<GetThreadDescriptionPtr>(
+          GetProcAddress(kernel32, "GetThreadDescription"));
+    } else {
+      return nullptr;
+    }
+  }();
+
+  if (getThreadDescriptionPtr != nullptr) {
+    PWSTR data = nullptr;
+    HRESULT hr = (*getThreadDescriptionPtr)(thread, &data);
+
+    if (SUCCEEDED(hr)) {
+      name = ws2s(data);
+      LocalFree(data);
+    }
   }
 
   return name;
 }
 
-//-----------------------------------------------------------------------------
 inline std::string GetCurrentThreadName() {
   return GetThreadName(GetCurrentThread());
 }

--- a/OrbitCore/Threading.h
+++ b/OrbitCore/Threading.h
@@ -1,6 +1,6 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 #pragma once
 
 #include <autoresetevent.h>

--- a/kokoro/gcp_ubuntu/kokoro_build.sh
+++ b/kokoro/gcp_ubuntu/kokoro_build.sh
@@ -15,7 +15,7 @@ if [ "$0" == "$SCRIPT" ]; then
   conan config set general.revisions_enabled=True
   conan config set general.parallel_download=8
 
-  CONAN_PROFILE="clang7_release"
+  CONAN_PROFILE="clang7_relwithdebinfo"
 
   # Building Orbit
   conan install -u -pr ${CONAN_PROFILE} -if "${DIR}/build/" \

--- a/kokoro/gcp_windows/kokoro_build.bat
+++ b/kokoro/gcp_windows/kokoro_build.bat
@@ -20,7 +20,7 @@ conan config set general.parallel_download=8
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 :: Building conan
-call conan install -pr msvc2019_release -if %REPO_ROOT%\build\ --build outdated %REPO_ROOT%
+call conan install -pr msvc2019_relwithdebinfo -if %REPO_ROOT%\build\ --build outdated %REPO_ROOT%
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 call conan build -bf %REPO_ROOT%\build\ %REPO_ROOT%


### PR DESCRIPTION
Two related things in here:
1. This PR adds runtime detection for Windows' SetThreadDescription/GetThreadDescription-API which is only available in the most recent version of the Windows 10 SDK. Since we want to compile against the Windows 8.1 SDK to make Orbit workable on older machines and at the same time don't want to loose Thread-Naming-support on newer machines, it's the best approach to move to runtime detection.
2. This PR switches the CI to release builds with debug symbols. The runtime detection from above is a requirement for this to work because our Windows-Server-2016-based CI machines only support an older version of the windows SDK. That's a problem when running the tests on the CI machines. I'm not sure why this works without problems in the non-debug-symbol-build. Probably the linker removes everyhting not needed and this problem never occurs.