### PR TITLE
Add ggp init command

### DIFF
--- a/OrbitGgp/CMakeLists.txt
+++ b/OrbitGgp/CMakeLists.txt
@@ -16,12 +16,14 @@ target_include_directories(OrbitGgp PUBLIC
 target_sources(OrbitGgp PUBLIC
           include/OrbitGgp/GgpClient.h
           include/OrbitGgp/GgpInstance.h
-          include/OrbitGgp/GgpInstanceItemModel.h)
+          include/OrbitGgp/GgpInstanceItemModel.h
+          include/OrbitGgp/GgpSshInfo.h)
 
 target_sources(OrbitGgp PRIVATE
           GgpClient.cpp
           GgpInstance.cpp
-          GgpInstanceItemModel.cpp)
+          GgpInstanceItemModel.cpp
+          GgpSshInfo.cpp)
 
 target_link_libraries(
   OrbitGgp
@@ -38,6 +40,7 @@ add_executable(OrbitGgpTests)
 target_sources(OrbitGgpTests PRIVATE 
           GgpInstanceTests.cpp
           GgpInstanceItemModelTests.cpp
+          GgpSshInfoTests.cpp
 )
 
 target_link_libraries(OrbitGgpTests PRIVATE 

--- a/OrbitGgp/GgpSshInfo.cpp
+++ b/OrbitGgp/GgpSshInfo.cpp
@@ -1,0 +1,47 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "OrbitGgp/GgpSshInfo.h"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+
+#include "OrbitBase/Logging.h"
+
+std::optional<GgpSshInfo> GgpSshInfo::CreateFromJson(const QByteArray& json) {
+  const QJsonDocument doc = QJsonDocument::fromJson(json);
+
+  if (!doc.isObject()) return {};
+  const QJsonObject obj = doc.object();
+
+  const QJsonValue host_val = obj.value("host");
+  const QJsonValue key_path_val = obj.value("keyPath");
+  const QJsonValue known_hosts_path_val = obj.value("knownHostsPath");
+  const QJsonValue port_val = obj.value("port");
+  const QJsonValue user_val = obj.value("user");
+
+  if (host_val.isUndefined() || !host_val.isString() ||
+      key_path_val.isUndefined() || !key_path_val.isString() ||
+      known_hosts_path_val.isUndefined() || !known_hosts_path_val.isString() ||
+      port_val.isUndefined() || !port_val.isString() ||
+      user_val.isUndefined() || !user_val.isString()) {
+    return {};
+  }
+
+  // The json has the port formatted as a string ("port":"333"), hence this
+  // conversion. This is standard the Qt way to check whether the casting worked
+  bool ok;
+  int port = port_val.toString().toInt(&ok);
+  if (!ok) return {};
+
+  GgpSshInfo ggp_ssh_info;
+
+  ggp_ssh_info.host = host_val.toString();
+  ggp_ssh_info.key_path = key_path_val.toString();
+  ggp_ssh_info.known_hosts_path = known_hosts_path_val.toString();
+  ggp_ssh_info.port = port;
+  ggp_ssh_info.user = user_val.toString();
+
+  return ggp_ssh_info;
+}

--- a/OrbitGgp/GgpSshInfoTests.cpp
+++ b/OrbitGgp/GgpSshInfoTests.cpp
@@ -1,0 +1,71 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <optional>
+
+#include "OrbitGgp/GgpSshInfo.h"
+
+TEST(GgpSshInfoTest, CreateFromJson) {
+  QByteArray json;
+  std::optional<GgpSshInfo> test_info_opt;
+
+  // Empty json
+  json = QString("").toUtf8();
+  test_info_opt = GgpSshInfo::CreateFromJson(json);
+  EXPECT_FALSE(test_info_opt);
+
+  // invalid json
+  json = QString("{..dfP}").toUtf8();
+  test_info_opt = GgpSshInfo::CreateFromJson(json);
+  EXPECT_FALSE(test_info_opt);
+
+  // empty object
+  json = QString("{}").toUtf8();
+  test_info_opt = GgpSshInfo::CreateFromJson(json);
+  EXPECT_FALSE(test_info_opt);
+
+  // object without all necessary fields
+  json = QString("{\"host\":\"0.0.0.1\"}").toUtf8();
+  test_info_opt = GgpSshInfo::CreateFromJson(json);
+  EXPECT_FALSE(test_info_opt);
+
+  // valid object
+
+  // Pretty print test data
+  // {
+  //  "host": "1.1.0.1",
+  //  "keyPath": "/usr/local/some/path/.ssh/id_rsa",
+  //  "knownHostsPath": "/usr/local/another/path/known_hosts",
+  //  "port": "11123",
+  //  "user": "a username"
+  // }
+  json = QString(
+             "{\"host\":\"1.1.0.1\",\"keyPath\":\"/usr/local/some/path/.ssh/"
+             "id_rsa\",\"knownHostsPath\":\"/usr/local/another/path/"
+             "known_hosts\",\"port\":\"11123\",\"user\":\"a username\"}")
+             .toUtf8();
+  test_info_opt = GgpSshInfo::CreateFromJson(json);
+  ASSERT_TRUE(test_info_opt);
+  EXPECT_EQ(test_info_opt->host, "1.1.0.1");
+  EXPECT_EQ(test_info_opt->key_path,
+            "/usr/local/some/path/.ssh/"
+            "id_rsa");
+  EXPECT_EQ(test_info_opt->known_hosts_path,
+            "/usr/local/another/path/"
+            "known_hosts");
+  EXPECT_EQ(test_info_opt->port, 11123);
+  EXPECT_EQ(test_info_opt->user, "a username");
+
+  // valid object - but port is formatted as an int.
+  json = QString(
+             "{\"host\":\"1.1.0.1\",\"keyPath\":\"/usr/local/some/path/.ssh/"
+             "id_rsa\",\"knownHostsPath\":\"/usr/local/another/path/"
+             "known_hosts\",\"port\":11123,\"user\":\"a username\"}")
+             .toUtf8();
+  test_info_opt = GgpSshInfo::CreateFromJson(json);
+  // This is supposed to fail, since its expected that the port is a string
+  EXPECT_FALSE(test_info_opt);
+}

--- a/OrbitGgp/include/OrbitGgp/GgpClient.h
+++ b/OrbitGgp/include/OrbitGgp/GgpClient.h
@@ -11,6 +11,7 @@
 #include <string>
 
 #include "GgpInstance.h"
+#include "GgpSshInfo.h"
 
 class GgpClient {
  public:
@@ -28,6 +29,9 @@ class GgpClient {
   void GetInstancesAsync(
       const std::function<void(ResultOrQString<QVector<GgpInstance>>)>&
           callback);
+  void GetSshInformationAsync(
+      const GgpInstance& ggpInstance,
+      const std::function<void(ResultOrQString<GgpSshInfo>)>& callback);
 
  private:
   GgpClient() = default;

--- a/OrbitGgp/include/OrbitGgp/GgpSshInfo.h
+++ b/OrbitGgp/include/OrbitGgp/GgpSshInfo.h
@@ -1,0 +1,22 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBITGGP_GGP_SSH_INFO_H_
+#define ORBITGGP_GGP_SSH_INFO_H_
+
+#include <QByteArray>
+#include <QString>
+#include <optional>
+
+struct GgpSshInfo {
+  QString host;
+  QString key_path;
+  QString known_hosts_path;
+  int port;
+  QString user;
+
+  static std::optional<GgpSshInfo> CreateFromJson(const QByteArray& json);
+};
+
+#endif  // ORBITGGP_GGP_SSH_INFO_H_


### PR DESCRIPTION
The class GgpClient can now execute the command ggp ssh init -s --instance <instance_id>. This command provides the information that is needed to connect to the instance via ssh. 