### PR TITLE
Changed Windows Target Platform Version to 8.1

### DIFF
--- a/contrib/conan/configs/windows/profiles/msvc2017_debug
+++ b/contrib/conan/configs/windows/profiles/msvc2017_debug
@@ -11,4 +11,4 @@ OrbitProfiler:system_qt=False
 [build_requires]
 cmake/3.16.4@
 [env]
-CONAN_CMAKE_SYSTEM_VERSION=10.0.18362.0
+CONAN_CMAKE_SYSTEM_VERSION=8.1

--- a/contrib/conan/configs/windows/profiles/msvc2017_debug_x64
+++ b/contrib/conan/configs/windows/profiles/msvc2017_debug_x64
@@ -11,4 +11,4 @@ OrbitProfiler:system_qt=False
 [build_requires]
 cmake/3.16.4@
 [env]
-CONAN_CMAKE_SYSTEM_VERSION=10.0.18362.0
+CONAN_CMAKE_SYSTEM_VERSION=8.1

--- a/contrib/conan/configs/windows/profiles/msvc2017_debug_x86
+++ b/contrib/conan/configs/windows/profiles/msvc2017_debug_x86
@@ -12,4 +12,4 @@ OrbitProfiler:with_gui=False
 [build_requires]
 cmake/3.16.4@
 [env]
-CONAN_CMAKE_SYSTEM_VERSION=10.0.18362.0
+CONAN_CMAKE_SYSTEM_VERSION=8.1

--- a/contrib/conan/configs/windows/profiles/msvc2017_release
+++ b/contrib/conan/configs/windows/profiles/msvc2017_release
@@ -11,4 +11,4 @@ OrbitProfiler:system_qt=False
 [build_requires]
 cmake/3.16.4@
 [env]
-CONAN_CMAKE_SYSTEM_VERSION=10.0.18362.0
+CONAN_CMAKE_SYSTEM_VERSION=8.1

--- a/contrib/conan/configs/windows/profiles/msvc2017_release_x64
+++ b/contrib/conan/configs/windows/profiles/msvc2017_release_x64
@@ -11,4 +11,4 @@ OrbitProfiler:system_qt=False
 [build_requires]
 cmake/3.16.4@
 [env]
-CONAN_CMAKE_SYSTEM_VERSION=10.0.18362.0
+CONAN_CMAKE_SYSTEM_VERSION=8.1

--- a/contrib/conan/configs/windows/profiles/msvc2017_release_x86
+++ b/contrib/conan/configs/windows/profiles/msvc2017_release_x86
@@ -12,4 +12,4 @@ OrbitProfiler:with_gui=False
 [build_requires]
 cmake/3.16.4@
 [env]
-CONAN_CMAKE_SYSTEM_VERSION=10.0.18362.0
+CONAN_CMAKE_SYSTEM_VERSION=8.1

--- a/contrib/conan/configs/windows/profiles/msvc2017_relwithdebinfo
+++ b/contrib/conan/configs/windows/profiles/msvc2017_relwithdebinfo
@@ -11,4 +11,4 @@ OrbitProfiler:system_qt=False
 [build_requires]
 cmake/3.16.4@
 [env]
-CONAN_CMAKE_SYSTEM_VERSION=10.0.18362.0
+CONAN_CMAKE_SYSTEM_VERSION=8.1

--- a/contrib/conan/configs/windows/profiles/msvc2017_relwithdebinfo_x64
+++ b/contrib/conan/configs/windows/profiles/msvc2017_relwithdebinfo_x64
@@ -11,4 +11,4 @@ OrbitProfiler:system_qt=False
 [build_requires]
 cmake/3.16.4@
 [env]
-CONAN_CMAKE_SYSTEM_VERSION=10.0.18362.0
+CONAN_CMAKE_SYSTEM_VERSION=8.1

--- a/contrib/conan/configs/windows/profiles/msvc2017_relwithdebinfo_x86
+++ b/contrib/conan/configs/windows/profiles/msvc2017_relwithdebinfo_x86
@@ -12,4 +12,4 @@ OrbitProfiler:with_gui=False
 [build_requires]
 cmake/3.16.4@
 [env]
-CONAN_CMAKE_SYSTEM_VERSION=10.0.18362.0
+CONAN_CMAKE_SYSTEM_VERSION=8.1

--- a/contrib/conan/configs/windows/profiles/msvc2019_debug
+++ b/contrib/conan/configs/windows/profiles/msvc2019_debug
@@ -11,4 +11,4 @@ OrbitProfiler:system_qt=False
 [build_requires]
 cmake/3.16.4@
 [env]
-CONAN_CMAKE_SYSTEM_VERSION=10.0.18362.0
+CONAN_CMAKE_SYSTEM_VERSION=8.1

--- a/contrib/conan/configs/windows/profiles/msvc2019_debug_x64
+++ b/contrib/conan/configs/windows/profiles/msvc2019_debug_x64
@@ -11,4 +11,4 @@ OrbitProfiler:system_qt=False
 [build_requires]
 cmake/3.16.4@
 [env]
-CONAN_CMAKE_SYSTEM_VERSION=10.0.18362.0
+CONAN_CMAKE_SYSTEM_VERSION=8.1

--- a/contrib/conan/configs/windows/profiles/msvc2019_debug_x86
+++ b/contrib/conan/configs/windows/profiles/msvc2019_debug_x86
@@ -12,4 +12,4 @@ OrbitProfiler:with_gui=False
 [build_requires]
 cmake/3.16.4@
 [env]
-CONAN_CMAKE_SYSTEM_VERSION=10.0.18362.0
+CONAN_CMAKE_SYSTEM_VERSION=8.1

--- a/contrib/conan/configs/windows/profiles/msvc2019_release
+++ b/contrib/conan/configs/windows/profiles/msvc2019_release
@@ -11,4 +11,4 @@ OrbitProfiler:system_qt=False
 [build_requires]
 cmake/3.16.4@
 [env]
-CONAN_CMAKE_SYSTEM_VERSION=10.0.18362.0
+CONAN_CMAKE_SYSTEM_VERSION=8.1

--- a/contrib/conan/configs/windows/profiles/msvc2019_release_x64
+++ b/contrib/conan/configs/windows/profiles/msvc2019_release_x64
@@ -11,4 +11,4 @@ OrbitProfiler:system_qt=False
 [build_requires]
 cmake/3.16.4@
 [env]
-CONAN_CMAKE_SYSTEM_VERSION=10.0.18362.0
+CONAN_CMAKE_SYSTEM_VERSION=8.1

--- a/contrib/conan/configs/windows/profiles/msvc2019_release_x86
+++ b/contrib/conan/configs/windows/profiles/msvc2019_release_x86
@@ -12,4 +12,4 @@ OrbitProfiler:with_gui=False
 [build_requires]
 cmake/3.16.4@
 [env]
-CONAN_CMAKE_SYSTEM_VERSION=10.0.18362.0
+CONAN_CMAKE_SYSTEM_VERSION=8.1

--- a/contrib/conan/configs/windows/profiles/msvc2019_relwithdebinfo
+++ b/contrib/conan/configs/windows/profiles/msvc2019_relwithdebinfo
@@ -11,4 +11,4 @@ OrbitProfiler:system_qt=False
 [build_requires]
 cmake/3.16.4@
 [env]
-CONAN_CMAKE_SYSTEM_VERSION=10.0.18362.0
+CONAN_CMAKE_SYSTEM_VERSION=8.1

--- a/contrib/conan/configs/windows/profiles/msvc2019_relwithdebinfo_x64
+++ b/contrib/conan/configs/windows/profiles/msvc2019_relwithdebinfo_x64
@@ -11,4 +11,4 @@ OrbitProfiler:system_qt=False
 [build_requires]
 cmake/3.16.4@
 [env]
-CONAN_CMAKE_SYSTEM_VERSION=10.0.18362.0
+CONAN_CMAKE_SYSTEM_VERSION=8.1

--- a/contrib/conan/configs/windows/profiles/msvc2019_relwithdebinfo_x86
+++ b/contrib/conan/configs/windows/profiles/msvc2019_relwithdebinfo_x86
@@ -12,4 +12,4 @@ OrbitProfiler:with_gui=False
 [build_requires]
 cmake/3.16.4@
 [env]
-CONAN_CMAKE_SYSTEM_VERSION=10.0.18362.0
+CONAN_CMAKE_SYSTEM_VERSION=8.1


### PR DESCRIPTION
This PR changes our windows conan profiles such that Orbit is built against Windows SDK version 8.1  instead of 10.0.18362.0. That makes our Orbit build compatible with Windows 8.1.