### PR TITLE
Fix selection of events on EventTrack.

### DIFF
--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -20,17 +20,22 @@ void EventTrack::Draw(GlCanvas* canvas, bool picking) {
   PickingManager& picking_manager = canvas->GetPickingManager();
   PickingID id = picking_manager.CreatePickableId(this);
 
-  Color color = !picking ? m_Color : picking_manager.ColorFromPickingID(id);
+  constexpr float kNormalZ = -0.1f;
+  constexpr float kPickingZ = 0.1f;
+  float z = kNormalZ;
+  Color color = m_Color;
+
+  if (picking) {
+    z = kPickingZ;
+    color = picking_manager.ColorFromPickingID(id);
+  }
+
   glColor4ubv(&color[0]);
 
   float x0 = m_Pos[0];
   float y0 = m_Pos[1];
   float x1 = x0 + m_Size[0];
   float y1 = y0 - m_Size[1];
-
-  constexpr float kNormalZ = -0.1f;
-  constexpr float kPickingZ = 0.1f;
-  float z = picking ? kPickingZ : kNormalZ;
 
   glBegin(GL_QUADS);
   glVertex3f(x0, y0, z);
@@ -39,10 +44,11 @@ void EventTrack::Draw(GlCanvas* canvas, bool picking) {
   glVertex3f(x0, y1, z);
   glEnd();
 
-  if (canvas->GetPickingManager().GetPicked() == this)
+  if (canvas->GetPickingManager().GetPicked() == this) {
     glColor4ub(255, 255, 255, 255);
-  else
+  } else {
     glColor4ubv(&color[0]);
+  }
 
   glBegin(GL_LINES);
   glVertex3f(x0, y0, -0.1f);

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -20,8 +20,6 @@ void EventTrack::Draw(GlCanvas* canvas, bool picking) {
   PickingManager& picking_manager = canvas->GetPickingManager();
   PickingID id = picking_manager.CreatePickableId(this);
 
-  bool is_picked = canvas->GetPickingManager().GetPicked() == this;
-
   Color color = !picking ? m_Color : picking_manager.ColorFromPickingID(id);
   glColor4ubv(&color[0]);
 
@@ -41,7 +39,7 @@ void EventTrack::Draw(GlCanvas* canvas, bool picking) {
   glVertex3f(x0, y1, z);
   glEnd();
 
-  if (is_picked)
+  if (canvas->GetPickingManager().GetPicked() == this)
     glColor4ub(255, 255, 255, 255);
   else
     glColor4ubv(&color[0]);

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -16,29 +16,35 @@ EventTrack::EventTrack(TimeGraph* a_TimeGraph) : time_graph_(a_TimeGraph) {
 }
 
 //-----------------------------------------------------------------------------
-void EventTrack::Draw(GlCanvas* a_Canvas, bool a_Picking) {
-  Color col = m_Color;
+void EventTrack::Draw(GlCanvas* canvas, bool picking) {
+  PickingManager& picking_manager = canvas->GetPickingManager();
+  PickingID id = picking_manager.CreatePickableId(this);
 
-  a_Picking ? PickingManager::SetPickingColor(
-                  a_Canvas->GetPickingManager().CreatePickableId(this))
-            : glColor4ubv(&col[0]);
+  bool is_picked = canvas->GetPickingManager().GetPicked() == this;
+
+  Color color = !picking ? m_Color : picking_manager.ColorFromPickingID(id);
+  glColor4ubv(&color[0]);
 
   float x0 = m_Pos[0];
   float y0 = m_Pos[1];
   float x1 = x0 + m_Size[0];
   float y1 = y0 - m_Size[1];
 
+  constexpr float kNormalZ = -0.1f;
+  constexpr float kPickingZ = 0.1f;
+  float z = picking ? kPickingZ : kNormalZ;
+
   glBegin(GL_QUADS);
-  glVertex3f(x0, y0, -0.1f);
-  glVertex3f(x1, y0, -0.1f);
-  glVertex3f(x1, y1, -0.1f);
-  glVertex3f(x0, y1, -0.1f);
+  glVertex3f(x0, y0, z);
+  glVertex3f(x1, y0, z);
+  glVertex3f(x1, y1, z);
+  glVertex3f(x0, y1, z);
   glEnd();
 
-  if (a_Canvas->GetPickingManager().GetPicked() == this)
+  if (is_picked)
     glColor4ub(255, 255, 255, 255);
   else
-    glColor4ubv(&col[0]);
+    glColor4ubv(&color[0]);
 
   glBegin(GL_LINES);
   glVertex3f(x0, y0, -0.1f);
@@ -65,7 +71,7 @@ void EventTrack::Draw(GlCanvas* a_Canvas, bool a_Picking) {
     glEnd();
   }
 
-  m_Canvas = a_Canvas;
+  m_Canvas = canvas;
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/EventTrack.h
+++ b/OrbitGl/EventTrack.h
@@ -15,7 +15,7 @@ class EventTrack : public Track {
   explicit EventTrack(TimeGraph* a_TimeGraph);
   Type GetType() const override { return kEventTrack; }
 
-  void Draw(GlCanvas* a_Canvas, bool a_Picking) override;
+  void Draw(GlCanvas* canvas, bool picking) override;
   void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) override;
 
   void OnPick(int a_X, int a_Y) override;
@@ -29,6 +29,9 @@ class EventTrack : public Track {
   void SetPos(float a_X, float a_Y);
   void SetSize(float a_SizeX, float a_SizeY);
   void SetColor(Color color) { m_Color = color; }
+  void ClearSelectedEvents() { selected_callstack_events_.clear(); }
+
+ protected:
   void SelectEvents();
 
  protected:

--- a/OrbitGl/PickingManager.cpp
+++ b/OrbitGl/PickingManager.cpp
@@ -49,3 +49,11 @@ void PickingManager::Drag(int a_X, int a_Y) {
 void PickingManager::SetPickingColor(PickingID a_ID) {
   glColor4ubv(reinterpret_cast<const uint8_t*>(&a_ID));
 }
+
+//-----------------------------------------------------------------------------
+Color PickingManager::ColorFromPickingID(PickingID id) const {
+  static_assert(sizeof(PickingID) == sizeof(Color),
+                "PickingID should be same size as Color");
+  const Color* color = reinterpret_cast<const Color*>(&id);
+  return *color;
+}

--- a/OrbitGl/PickingManager.h
+++ b/OrbitGl/PickingManager.h
@@ -59,6 +59,7 @@ class PickingManager {
   bool IsDragging() const { return m_Picked && m_Picked->Draggable(); }
 
   static void SetPickingColor(PickingID a_ID);
+  Color ColorFromPickingID(PickingID id) const;
 
  protected:
   std::vector<Pickable*> m_Pickables;

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -8,6 +8,7 @@
 
 #include "BlockChain.h"
 #include "CallstackTypes.h"
+#include "EventTrack.h"
 #include "TextBox.h"
 #include "Threading.h"
 #include "Track.h"
@@ -51,6 +52,7 @@ class ThreadTrack : public Track {
   std::vector<std::shared_ptr<TimerChain>> GetAllChains() override;
 
   void SetEventTrackColor(Color color);
+  void ClearSelectedEvents() { event_track_->ClearSelectedEvents(); }
 
  protected:
   void UpdateDepth(uint32_t depth) {

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -552,6 +552,10 @@ std::vector<CallstackEvent> TimeGraph::SelectEvents(float a_WorldStart,
   TickType t0 = GetTickFromWorld(a_WorldStart);
   TickType t1 = GetTickFromWorld(a_WorldEnd);
 
+  for (auto& pair : thread_tracks_) {
+    pair.second->ClearSelectedEvents();
+  }
+
   std::vector<CallstackEvent> selected_callstack_events =
       GEventTracer.GetEventBuffer().GetCallstackEvents(t0, t1, a_TID);
 


### PR DESCRIPTION
- When picking, render track quad on top of events.
- Fix sticky selection bug when picking events on different threads.

@dpallotti , the layout is still not as before.  The proper fix will be to introduce a "ProcessTrack" that will encompass all the threads for a single process.  Will do that shortly.