### PR TITLE
Small OrbitService tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,11 +136,11 @@ else()
   target_include_directories(OrbitAsm INTERFACE OrbitAsm/)
 
   add_subdirectory(OrbitLinuxTracing)
+  add_subdirectory(OrbitService)
 endif()
 
 add_subdirectory(OrbitBase)
 add_subdirectory(OrbitCore)
-add_subdirectory(OrbitService)
 add_subdirectory(OrbitTest)
 add_subdirectory(protos)
 

--- a/OrbitCore/ConnectionManager.cpp
+++ b/OrbitCore/ConnectionManager.cpp
@@ -96,7 +96,7 @@ void ConnectionManager::SetSelectedFunctionsOnRemote(const Message& a_Msg) {
 void ConnectionManager::ServerCaptureThreadWorker() {
 #ifdef __linux__
   while (tracing_handler_.IsStarted()) {
-    OrbitSleepMs(20);
+    Sleep(20);
 
     std::vector<Timer> timers;
     if (tracing_buffer_.ReadAllTimers(&timers)) {

--- a/OrbitCore/Utils.h
+++ b/OrbitCore/Utils.h
@@ -301,15 +301,6 @@ inline uint64_t GetMicros(std::string a_TimeStamp) {
 }
 
 //-----------------------------------------------------------------------------
-inline void OrbitSleepMs(uint64_t a_Ms) {
-#if __linux__
-  usleep(a_Ms * 1000);
-#else
-  Sleep(a_Ms);
-#endif
-}
-
-//-----------------------------------------------------------------------------
 inline void PrintBuffer(const void* a_Buffer, uint32_t a_Size,
                         uint32_t a_Width = 16) {
   const uint8_t* buffer = static_cast<const uint8_t*>(a_Buffer);

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -17,16 +17,16 @@
 #include "absl/flags/usage.h"
 #include "orbitmainwindow.h"
 
-// TODO: Remove this flag once we have a dialog with user
-ABSL_FLAG(bool, upload_dumps_to_server, false,
-          "Upload dumps to collection server when crashes");
-
 ABSL_FLAG(std::string, remote, "",
           "Connect to the specified remote on startup");
 ABSL_FLAG(uint16_t, asio_port, 44766,
-          "The service Asio tcp_server port (use default velue if unsure)");
+          "The service's Asio tcp_server port (use default value if unsure)");
 ABSL_FLAG(uint16_t, grpc_port, 44755,
-          "The service GRPC server port (use default velue if unsure)");
+          "The service's GRPC server port (use default value if unsure)");
+
+// TODO: Remove this flag once we have a dialog with user
+ABSL_FLAG(bool, upload_dumps_to_server, false,
+          "Upload dumps to collection server when crashes");
 
 // TODO: remove this once we deprecated legacy parameters
 static void ParseLegacyCommandLine(int argc, char* argv[],

--- a/OrbitService/OrbitService.cpp
+++ b/OrbitService/OrbitService.cpp
@@ -1,24 +1,18 @@
 #include "OrbitService.h"
 
-#include <iostream>
-
-#include "Capture.h"
 #include "ConnectionManager.h"
 #include "Core.h"
 #include "CoreApp.h"
 #include "TcpServer.h"
-#include "TimerManager.h"
 
 // TODO: we should probably make it configurable
 constexpr uint32_t kAsioServerPort = 44766;
 
 OrbitService::OrbitService() {
-  // TODO: these should be a private fields.
-  GTimerManager = std::make_unique<TimerManager>();
+  // TODO: These should be private fields.
   GTcpServer = std::make_unique<TcpServer>();
-  Capture::Init();
-
   GTcpServer->StartServer(kAsioServerPort);
+
   ConnectionManager::Get().InitAsService();
 
   core_app_ = std::make_unique<CoreApp>();
@@ -29,7 +23,6 @@ OrbitService::OrbitService() {
 void OrbitService::Run(std::atomic<bool>* exit_requested) {
   while (!(*exit_requested)) {
     GTcpServer->ProcessMainThreadCallbacks();
-    Capture::Update();
     Sleep(16);
   }
 

--- a/OrbitService/OrbitService.cpp
+++ b/OrbitService/OrbitService.cpp
@@ -26,8 +26,8 @@ OrbitService::OrbitService() {
   GCoreApp->InitializeManagers();
 }
 
-void OrbitService::Run() {
-  while (!exit_requested_) {
+void OrbitService::Run(std::atomic<bool>* exit_requested) {
+  while (!(*exit_requested)) {
     GTcpServer->ProcessMainThreadCallbacks();
     Capture::Update();
     Sleep(16);

--- a/OrbitService/OrbitService.cpp
+++ b/OrbitService/OrbitService.cpp
@@ -5,13 +5,10 @@
 #include "CoreApp.h"
 #include "TcpServer.h"
 
-// TODO: we should probably make it configurable
-constexpr uint32_t kAsioServerPort = 44766;
-
-OrbitService::OrbitService() {
+OrbitService::OrbitService(uint16_t port) {
   // TODO: These should be private fields.
   GTcpServer = std::make_unique<TcpServer>();
-  GTcpServer->StartServer(kAsioServerPort);
+  GTcpServer->StartServer(port);
 
   ConnectionManager::Get().InitAsService();
 

--- a/OrbitService/OrbitService.h
+++ b/OrbitService/OrbitService.h
@@ -9,10 +9,8 @@
 class OrbitService {
  public:
   OrbitService();
-  void Run();
+  void Run(std::atomic<bool>* exit_requested);
 
  private:
-  // TODO: where is this set?
-  bool exit_requested_ = false;
   std::unique_ptr<CoreApp> core_app_;
 };

--- a/OrbitService/OrbitService.h
+++ b/OrbitService/OrbitService.h
@@ -8,7 +8,7 @@
 
 class OrbitService {
  public:
-  OrbitService();
+  explicit OrbitService(uint16_t port);
   void Run(std::atomic<bool>* exit_requested);
 
  private:

--- a/OrbitService/main.cpp
+++ b/OrbitService/main.cpp
@@ -1,5 +1,7 @@
 #include <iostream>
 
+#include <csignal>
+
 #include "OrbitGrpcServer.h"
 #include "OrbitService.h"
 #include "absl/flags/flag.h"
@@ -10,9 +12,30 @@
 ABSL_FLAG(std::string, grpc_server_address, "0.0.0.0:44755",
           "Grpc server address");
 
+namespace {
+std::atomic<bool> exit_requested;
+
+void sigint_handler(int signum) {
+  if (signum == SIGINT) {
+    exit_requested = true;
+  }
+}
+
+void install_sigint_handler() {
+  struct sigaction act;
+  act.sa_handler = sigint_handler;
+  sigemptyset(&act.sa_mask);
+  act.sa_flags = 0;
+  act.sa_restorer = nullptr;
+  sigaction(SIGINT, &act, nullptr);
+}
+}  // namespace
+
 int main(int argc, char** argv) {
   absl::SetProgramUsageMessage("Orbit CPU Profiler Service");
   absl::ParseCommandLine(argc, argv);
+
+  install_sigint_handler();
 
   std::unique_ptr<OrbitGrpcServer> grpc_server;
   std::string grpc_server_address = absl::GetFlag(FLAGS_grpc_server_address);
@@ -21,5 +44,6 @@ int main(int argc, char** argv) {
 
   std::cout << "Starting OrbitService" << std::endl;
   OrbitService service;
-  service.Run();
+  exit_requested = false;
+  service.Run(&exit_requested);
 }

--- a/OrbitService/main.cpp
+++ b/OrbitService/main.cpp
@@ -49,4 +49,7 @@ int main(int argc, char** argv) {
   OrbitService service{asio_port};
   exit_requested = false;
   service.Run(&exit_requested);
+
+  grpc_server->Shutdown();
+  grpc_server->Wait();
 }

--- a/OrbitService/main.cpp
+++ b/OrbitService/main.cpp
@@ -8,6 +8,8 @@
 #include "absl/flags/parse.h"
 #include "absl/flags/usage.h"
 
+ABSL_FLAG(uint16_t, asio_port, 44766, "Asio TCP server port");
+
 // TODO: Default it 127.0.0.1 once ssh tunneling is enabled.
 ABSL_FLAG(std::string, grpc_server_address, "0.0.0.0:44755",
           "Grpc server address");
@@ -42,8 +44,9 @@ int main(int argc, char** argv) {
   std::cout << "Starting GRPC server at " << grpc_server_address << std::endl;
   grpc_server = OrbitGrpcServer::Create(grpc_server_address);
 
+  uint16_t asio_port = absl::GetFlag(FLAGS_asio_port);
   std::cout << "Starting OrbitService" << std::endl;
-  OrbitService service;
+  OrbitService service{asio_port};
   exit_requested = false;
   service.Run(&exit_requested);
 }


### PR DESCRIPTION
#### Remove `OrbitSleepMs`, used only in one place, use `Sleep` like the rest of Orbit
#### Handle Ctrl-C in OrbitService and don't build OrbitService on Windows
#### Simple line removals in `OrbitService.cpp`
#### Add `-asio_port` command line flag for OrbitService
#### Call `grpc_server->Shutdown()` and `->Wait()` in OrbitService's `main`