### PR TITLE
Changed vshwere command in crashpad recipe.

### DIFF
--- a/contrib/conan/recipes/crashpad/patches/windows_adaptions.patch
+++ b/contrib/conan/recipes/crashpad/patches/windows_adaptions.patch
@@ -57,4 +57,18 @@ index d8dc6cd..4f55b5f 100644
 +    }
    }
  }
- 
+
+diff --git a/build/win_helper.py b/build/win_helper.py
+index a5e1fdd..edb93eb 100644
+--- a/build/win_helper.py
++++ b/build/win_helper.py
+@@ -178,7 +178,7 @@ class WinTool(object):
+           'Microsoft Visual Studio', 'Installer', 'vswhere.exe')
+       if os.path.exists(vswhere_path):
+         installation_path = subprocess.check_output(
+-            [vswhere_path, '-latest', '-property', 'installationPath']).strip()
++            [vswhere_path, '-products', '*', '-latest', '-property', 'installationPath']).strip()
+         if installation_path:
+           return (installation_path,
+                   os.path.join('VC', 'Auxiliary', 'Build', 'vcvarsall.bat'))
+


### PR DESCRIPTION
When compiling in a Windows docker container we don't install the full-blown Visual Studio. We just install the headless compiler and buildsystem. This is called "Visual Studio BuildTools".

The mini_chromium package uses `vswhere.exe` to detect the installed Visual Studio installations, but `vswhere.exe` won't list build tools installations, at least not by default. Adding the `-products *` command line option changes that and makes crashpad recipe be able to be compiled in a docker container.
For reference: https://github.com/Microsoft/vswhere/issues/22