### PR TITLE
Added a prototype of call stack sampling using framepointers

### DIFF
--- a/OrbitCore/LinuxTracingHandler.cpp
+++ b/OrbitCore/LinuxTracingHandler.cpp
@@ -4,9 +4,9 @@
 
 #include "Callstack.h"
 #include "ContextSwitch.h"
-#include "OrbitModule.h"
 #include "OrbitLinuxTracing/Events.h"
 #include "OrbitLinuxTracing/TracingOptions.h"
+#include "OrbitModule.h"
 #include "Params.h"
 #include "absl/flags/flag.h"
 #include "llvm/Demangle/Demangle.h"
@@ -95,14 +95,14 @@ void LinuxTracingHandler::OnCallstack(
   CallStack cs;
   cs.m_ThreadId = callstack.GetTid();
 
-  uint64_t unknownOffset = LinuxTracing::CallstackFrame::kUnknownFunctionOffset;
   for (const auto& frame : callstack.GetFrames()) {
     uint64_t address = frame.GetPc();
     cs.m_Data.push_back(address);
 
     // TODO(kuebler): This is mainly for clustering IPs to their functions.
     //  We should enable this also as a post-processing step.
-    if (frame.GetFunctionOffset() != unknownOffset) {
+    if (frame.GetFunctionOffset() !=
+        LinuxTracing::CallstackFrame::kUnknownFunctionOffset) {
       absl::MutexLock lock{&addresses_seen_mutex_};
       if (!addresses_seen_.contains(address)) {
         LinuxAddressInfo address_info{address, frame.GetMapName(),

--- a/OrbitCore/LinuxTracingHandler.cpp
+++ b/OrbitCore/LinuxTracingHandler.cpp
@@ -103,7 +103,7 @@ void LinuxTracingHandler::OnCallstack(
 
     // TODO(kuebler): This is mainly for clustering IPs to their functions.
     //  We should enable this also as a post-processing step.
-    if (frame.GetFunctionOffset() == unknownOffset) {
+    if (frame.GetFunctionOffset() != unknownOffset) {
       absl::MutexLock lock{&addresses_seen_mutex_};
       if (!addresses_seen_.contains(address)) {
         LinuxAddressInfo address_info{address, frame.GetMapName(),

--- a/OrbitCore/LinuxTracingHandler.cpp
+++ b/OrbitCore/LinuxTracingHandler.cpp
@@ -44,8 +44,7 @@ void LinuxTracingHandler::Start(
   tracer_->SetListener(this);
 
   tracer_->SetTraceContextSwitches(GParams.m_TrackContextSwitches);
-  tracer_->SetTraceCallstacks(true);
-  tracer_->SetTraceUnwindingMethod(LinuxTracing::kDwarf);
+  tracer_->SetSamplingMethod(LinuxTracing::kDwarf);
   tracer_->SetTraceInstrumentedFunctions(true);
   tracer_->SetTraceGpuDriver(absl::GetFlag(FLAGS_trace_gpu_driver));
 

--- a/OrbitCore/LinuxTracingHandler.cpp
+++ b/OrbitCore/LinuxTracingHandler.cpp
@@ -6,6 +6,7 @@
 #include "ContextSwitch.h"
 #include "OrbitModule.h"
 #include "OrbitLinuxTracing/Events.h"
+#include "OrbitLinuxTracing/TracingOptions.h"
 #include "Params.h"
 #include "absl/flags/flag.h"
 #include "llvm/Demangle/Demangle.h"
@@ -44,7 +45,7 @@ void LinuxTracingHandler::Start(
 
   tracer_->SetTraceContextSwitches(GParams.m_TrackContextSwitches);
   tracer_->SetTraceCallstacks(true);
-  tracer_->SetTraceFPCallstacks(false);
+  tracer_->SetTraceUnwindingMethod(LinuxTracing::kDwarf);
   tracer_->SetTraceInstrumentedFunctions(true);
   tracer_->SetTraceGpuDriver(absl::GetFlag(FLAGS_trace_gpu_driver));
 
@@ -100,6 +101,8 @@ void LinuxTracingHandler::OnCallstack(
     uint64_t address = frame.GetPc();
     cs.m_Data.push_back(address);
 
+    // TODO(kuebler): This is mainly for clustering IPs to their functions.
+    //  We should enable this also as a post-processing step.
     if (frame.GetFunctionOffset() == unknownOffset) {
       absl::MutexLock lock{&addresses_seen_mutex_};
       if (!addresses_seen_.contains(address)) {

--- a/OrbitLinuxTracing/CMakeLists.txt
+++ b/OrbitLinuxTracing/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.15)
 
 project(OrbitLinuxTracing)
 
-add_library(OrbitLinuxTracing STATIC include/OrbitLinuxTracing/TracingOptions.h)
+add_library(OrbitLinuxTracing STATIC)
 
 target_compile_options(OrbitLinuxTracing PRIVATE ${STRICT_COMPILE_FLAGS})
 
@@ -23,7 +23,8 @@ target_sources(OrbitLinuxTracing PUBLIC
         include/OrbitLinuxTracing/Function.h
         include/OrbitLinuxTracing/OrbitTracing.h
         include/OrbitLinuxTracing/Tracer.h
-        include/OrbitLinuxTracing/TracerListener.h)
+        include/OrbitLinuxTracing/TracerListener.h
+        include/OrbitLinuxTracing/TracingOptions.h)
 
 target_sources(OrbitLinuxTracing PRIVATE
         GpuTracepointEventProcessor.h

--- a/OrbitLinuxTracing/CMakeLists.txt
+++ b/OrbitLinuxTracing/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.15)
 
 project(OrbitLinuxTracing)
 
-add_library(OrbitLinuxTracing STATIC)
+add_library(OrbitLinuxTracing STATIC include/OrbitLinuxTracing/TracingOptions.h)
 
 target_compile_options(OrbitLinuxTracing PRIVATE ${STRICT_COMPILE_FLAGS})
 

--- a/OrbitLinuxTracing/PerfEvent.cpp
+++ b/OrbitLinuxTracing/PerfEvent.cpp
@@ -24,7 +24,7 @@ void SamplePerfEvent::Accept(PerfEventVisitor* visitor) {
   visitor->visit(this);
 }
 
-void SampleCallchainPerfEvent::Accept(PerfEventVisitor* visitor) {
+void CallchainSamplePerfEvent::Accept(PerfEventVisitor* visitor) {
   visitor->visit(this);
 }
 

--- a/OrbitLinuxTracing/PerfEvent.cpp
+++ b/OrbitLinuxTracing/PerfEvent.cpp
@@ -24,6 +24,10 @@ void SamplePerfEvent::Accept(PerfEventVisitor* visitor) {
   visitor->visit(this);
 }
 
+void SampleFPPerfEvent::Accept(PerfEventVisitor* visitor) {
+  visitor->visit(this);
+}
+
 void UprobesPerfEvent::Accept(PerfEventVisitor* visitor) {
   visitor->visit(this);
 }

--- a/OrbitLinuxTracing/PerfEvent.cpp
+++ b/OrbitLinuxTracing/PerfEvent.cpp
@@ -24,7 +24,7 @@ void SamplePerfEvent::Accept(PerfEventVisitor* visitor) {
   visitor->visit(this);
 }
 
-void SampleFPPerfEvent::Accept(PerfEventVisitor* visitor) {
+void SampleCallChainPerfEvent::Accept(PerfEventVisitor* visitor) {
   visitor->visit(this);
 }
 

--- a/OrbitLinuxTracing/PerfEvent.cpp
+++ b/OrbitLinuxTracing/PerfEvent.cpp
@@ -24,7 +24,7 @@ void SamplePerfEvent::Accept(PerfEventVisitor* visitor) {
   visitor->visit(this);
 }
 
-void SampleCallChainPerfEvent::Accept(PerfEventVisitor* visitor) {
+void SampleCallchainPerfEvent::Accept(PerfEventVisitor* visitor) {
   visitor->visit(this);
 }
 

--- a/OrbitLinuxTracing/PerfEvent.h
+++ b/OrbitLinuxTracing/PerfEvent.h
@@ -258,7 +258,8 @@ class CallchainSamplePerfEvent : public PerfEvent {
  public:
   perf_event_callchain_sample ring_buffer_record;
   std::vector<uint64_t> ips;
-  explicit CallchainSamplePerfEvent(uint64_t nr) : ips(nr) {}
+  explicit CallchainSamplePerfEvent(uint64_t callchain_size)
+      : ips(callchain_size) {}
 
   uint64_t GetTimestamp() const override {
     return ring_buffer_record.sample_id.time;
@@ -275,13 +276,9 @@ class CallchainSamplePerfEvent : public PerfEvent {
 
   uint32_t GetCpu() const { return ring_buffer_record.sample_id.cpu; }
 
-  const uint64_t* GetCallchain() const {
-    return ips.data();
-  }
+  const uint64_t* GetCallchain() const { return ips.data(); }
 
-  uint64_t GetCallchainSize() const {
-    return ring_buffer_record.nr;
-  }
+  uint64_t GetCallchainSize() const { return ring_buffer_record.nr; }
 };
 
 class AbstractUprobesPerfEvent {

--- a/OrbitLinuxTracing/PerfEvent.h
+++ b/OrbitLinuxTracing/PerfEvent.h
@@ -188,11 +188,11 @@ struct dynamically_sized_perf_event_stack_sample {
 struct dynamically_sized_perf_event_call_chain_sample {
   struct dynamically_sized_perf_event_call_chain {
     uint64_t dyn_size;
-    std::unique_ptr<uint64_t[]> data;
+    std::unique_ptr<uint64_t[]> instruction_pointers;
 
     explicit dynamically_sized_perf_event_call_chain(uint64_t dyn_size)
         : dyn_size{dyn_size},
-          data{make_unique_for_overwrite<uint64_t[]>(dyn_size)} {}
+          instruction_pointers{make_unique_for_overwrite<uint64_t[]>(dyn_size)} {}
   };
 
   perf_event_header header;
@@ -203,12 +203,12 @@ struct dynamically_sized_perf_event_call_chain_sample {
       : call_chain{dyn_size} {}
 };
 
-class SampleFPPerfEvent : public PerfEvent {
+class SampleCallChainPerfEvent : public PerfEvent {
  public:
   std::unique_ptr<dynamically_sized_perf_event_call_chain_sample>
       ring_buffer_record;
 
-  explicit SampleFPPerfEvent(uint64_t dyn_size)
+  explicit SampleCallChainPerfEvent(uint64_t dyn_size)
       : ring_buffer_record{
             std::make_unique<dynamically_sized_perf_event_call_chain_sample>(
                 dyn_size)} {}
@@ -229,7 +229,7 @@ class SampleFPPerfEvent : public PerfEvent {
   uint32_t GetCpu() const { return ring_buffer_record->sample_id.cpu; }
 
   const uint64_t* GetCallChain() const {
-    return ring_buffer_record->call_chain.data.get();
+    return ring_buffer_record->call_chain.instruction_pointers.get();
   }
 
   uint64_t GetCallChainSize() const {

--- a/OrbitLinuxTracing/PerfEvent.h
+++ b/OrbitLinuxTracing/PerfEvent.h
@@ -185,32 +185,31 @@ struct dynamically_sized_perf_event_stack_sample {
       : stack{dyn_size} {}
 };
 
-struct dynamically_sized_perf_event_call_chain_sample {
-  struct dynamically_sized_perf_event_call_chain {
-    uint64_t dyn_size;
-    std::unique_ptr<uint64_t[]> instruction_pointers;
+struct dynamically_sized_perf_event_callchain_sample {
+  struct dynamically_sized_perf_event_callchain {
+    uint64_t nr;
+    std::unique_ptr<uint64_t[]> ips;
 
-    explicit dynamically_sized_perf_event_call_chain(uint64_t dyn_size)
-        : dyn_size{dyn_size},
-          instruction_pointers{make_unique_for_overwrite<uint64_t[]>(dyn_size)} {}
+    explicit dynamically_sized_perf_event_callchain(uint64_t dyn_size)
+        : nr{dyn_size}, ips{make_unique_for_overwrite<uint64_t[]>(dyn_size)} {}
   };
 
   perf_event_header header;
   perf_event_sample_id_tid_time_streamid_cpu sample_id;
-  dynamically_sized_perf_event_call_chain call_chain;
+  dynamically_sized_perf_event_callchain call_chain;
 
-  explicit dynamically_sized_perf_event_call_chain_sample(uint64_t dyn_size)
+  explicit dynamically_sized_perf_event_callchain_sample(uint64_t dyn_size)
       : call_chain{dyn_size} {}
 };
 
-class SampleCallChainPerfEvent : public PerfEvent {
+class SampleCallchainPerfEvent : public PerfEvent {
  public:
-  std::unique_ptr<dynamically_sized_perf_event_call_chain_sample>
+  std::unique_ptr<dynamically_sized_perf_event_callchain_sample>
       ring_buffer_record;
 
-  explicit SampleCallChainPerfEvent(uint64_t dyn_size)
+  explicit SampleCallchainPerfEvent(uint64_t dyn_size)
       : ring_buffer_record{
-            std::make_unique<dynamically_sized_perf_event_call_chain_sample>(
+            std::make_unique<dynamically_sized_perf_event_callchain_sample>(
                 dyn_size)} {}
 
   uint64_t GetTimestamp() const override {
@@ -229,11 +228,11 @@ class SampleCallChainPerfEvent : public PerfEvent {
   uint32_t GetCpu() const { return ring_buffer_record->sample_id.cpu; }
 
   const uint64_t* GetCallChain() const {
-    return ring_buffer_record->call_chain.instruction_pointers.get();
+    return ring_buffer_record->call_chain.ips.get();
   }
 
   uint64_t GetCallChainSize() const {
-    return ring_buffer_record->call_chain.dyn_size;
+    return ring_buffer_record->call_chain.nr;
   }
 };
 

--- a/OrbitLinuxTracing/PerfEvent.h
+++ b/OrbitLinuxTracing/PerfEvent.h
@@ -185,6 +185,58 @@ struct dynamically_sized_perf_event_stack_sample {
       : stack{dyn_size} {}
 };
 
+struct dynamically_sized_perf_event_call_chain_sample {
+  struct dynamically_sized_perf_event_call_chain {
+    uint64_t dyn_size;
+    std::unique_ptr<uint64_t[]> data;
+
+    explicit dynamically_sized_perf_event_call_chain(uint64_t dyn_size)
+        : dyn_size{dyn_size},
+          data{make_unique_for_overwrite<uint64_t[]>(dyn_size)} {}
+  };
+
+  perf_event_header header;
+  perf_event_sample_id_tid_time_streamid_cpu sample_id;
+  dynamically_sized_perf_event_call_chain call_chain;
+
+  explicit dynamically_sized_perf_event_call_chain_sample(uint64_t dyn_size)
+      : call_chain{dyn_size} {}
+};
+
+class SampleFPPerfEvent : public PerfEvent {
+ public:
+  std::unique_ptr<dynamically_sized_perf_event_call_chain_sample>
+      ring_buffer_record;
+
+  explicit SampleFPPerfEvent(uint64_t dyn_size)
+      : ring_buffer_record{
+            std::make_unique<dynamically_sized_perf_event_call_chain_sample>(
+                dyn_size)} {}
+
+  uint64_t GetTimestamp() const override {
+    return ring_buffer_record->sample_id.time;
+  }
+
+  void Accept(PerfEventVisitor* visitor) override;
+
+  pid_t GetPid() const { return ring_buffer_record->sample_id.pid; }
+  pid_t GetTid() const { return ring_buffer_record->sample_id.tid; }
+
+  uint64_t GetStreamId() const {
+    return ring_buffer_record->sample_id.stream_id;
+  }
+
+  uint32_t GetCpu() const { return ring_buffer_record->sample_id.cpu; }
+
+  const uint64_t* GetCallChain() const {
+    return ring_buffer_record->call_chain.data.get();
+  }
+
+  uint64_t GetCallChainSize() const {
+    return ring_buffer_record->call_chain.dyn_size;
+  }
+};
+
 class SamplePerfEvent : public PerfEvent {
  public:
   std::unique_ptr<dynamically_sized_perf_event_stack_sample> ring_buffer_record;

--- a/OrbitLinuxTracing/PerfEvent.h
+++ b/OrbitLinuxTracing/PerfEvent.h
@@ -185,11 +185,11 @@ struct dynamically_sized_perf_event_stack_sample {
       : stack{dyn_size} {}
 };
 
-class SampleCallchainPerfEvent : public PerfEvent {
+class CallchainSamplePerfEvent : public PerfEvent {
  public:
   perf_event_callchain_sample ring_buffer_record;
   std::vector<uint64_t> ips;
-  explicit SampleCallchainPerfEvent(uint64_t nr) : ips(nr) {}
+  explicit CallchainSamplePerfEvent(uint64_t nr) : ips(nr) {}
 
   uint64_t GetTimestamp() const override {
     return ring_buffer_record.sample_id.time;

--- a/OrbitLinuxTracing/PerfEvent.h
+++ b/OrbitLinuxTracing/PerfEvent.h
@@ -185,36 +185,6 @@ struct dynamically_sized_perf_event_stack_sample {
       : stack{dyn_size} {}
 };
 
-class CallchainSamplePerfEvent : public PerfEvent {
- public:
-  perf_event_callchain_sample ring_buffer_record;
-  std::vector<uint64_t> ips;
-  explicit CallchainSamplePerfEvent(uint64_t nr) : ips(nr) {}
-
-  uint64_t GetTimestamp() const override {
-    return ring_buffer_record.sample_id.time;
-  }
-
-  void Accept(PerfEventVisitor* visitor) override;
-
-  pid_t GetPid() const { return ring_buffer_record.sample_id.pid; }
-  pid_t GetTid() const { return ring_buffer_record.sample_id.tid; }
-
-  uint64_t GetStreamId() const {
-    return ring_buffer_record.sample_id.stream_id;
-  }
-
-  uint32_t GetCpu() const { return ring_buffer_record.sample_id.cpu; }
-
-  const uint64_t* GetCallchain() const {
-    return ips.data();
-  }
-
-  uint64_t GetCallchainSize() const {
-    return ring_buffer_record.nr;
-  }
-};
-
 class SamplePerfEvent : public PerfEvent {
  public:
   std::unique_ptr<dynamically_sized_perf_event_stack_sample> ring_buffer_record;
@@ -281,6 +251,36 @@ class SamplePerfEvent : public PerfEvent {
     registers[PERF_REG_X86_R14] = regs.r14;
     registers[PERF_REG_X86_R15] = regs.r15;
     return registers;
+  }
+};
+
+class CallchainSamplePerfEvent : public PerfEvent {
+ public:
+  perf_event_callchain_sample ring_buffer_record;
+  std::vector<uint64_t> ips;
+  explicit CallchainSamplePerfEvent(uint64_t nr) : ips(nr) {}
+
+  uint64_t GetTimestamp() const override {
+    return ring_buffer_record.sample_id.time;
+  }
+
+  void Accept(PerfEventVisitor* visitor) override;
+
+  pid_t GetPid() const { return ring_buffer_record.sample_id.pid; }
+  pid_t GetTid() const { return ring_buffer_record.sample_id.tid; }
+
+  uint64_t GetStreamId() const {
+    return ring_buffer_record.sample_id.stream_id;
+  }
+
+  uint32_t GetCpu() const { return ring_buffer_record.sample_id.cpu; }
+
+  const uint64_t* GetCallchain() const {
+    return ips.data();
+  }
+
+  uint64_t GetCallchainSize() const {
+    return ring_buffer_record.nr;
   }
 };
 

--- a/OrbitLinuxTracing/PerfEventOpen.cpp
+++ b/OrbitLinuxTracing/PerfEventOpen.cpp
@@ -77,6 +77,20 @@ int sample_event_open(uint64_t period_ns, pid_t pid, int32_t cpu) {
   return generic_event_open(&pe, pid, cpu);
 }
 
+int sample_event_fp_open(uint64_t period_ns, pid_t pid, int32_t cpu) {
+  perf_event_attr pe = generic_event_attr();
+  pe.type = PERF_TYPE_SOFTWARE;
+  pe.config = PERF_COUNT_SW_CPU_CLOCK;
+  pe.sample_period = period_ns;
+  pe.sample_type |= PERF_SAMPLE_CALLCHAIN;
+  // TODO(kuebler): This shouldn't be a random constant
+  pe.sample_max_stack = 100;
+  pe.sample_regs_user = SAMPLE_REGS_USER_ALL;
+  pe.sample_stack_user = SAMPLE_STACK_USER_SIZE;
+
+  return generic_event_open(&pe, pid, cpu);
+}
+
 int uprobes_retaddr_event_open(const char* module, uint64_t function_offset,
                                pid_t pid, int32_t cpu) {
   perf_event_attr pe = uprobe_event_attr(module, function_offset);

--- a/OrbitLinuxTracing/PerfEventOpen.cpp
+++ b/OrbitLinuxTracing/PerfEventOpen.cpp
@@ -83,8 +83,8 @@ int sample_callchain_event_open(uint64_t period_ns, pid_t pid, int32_t cpu) {
   pe.config = PERF_COUNT_SW_CPU_CLOCK;
   pe.sample_period = period_ns;
   pe.sample_type |= PERF_SAMPLE_CALLCHAIN;
-  // TODO(kuebler): This shouldn't be a random constant
-  pe.sample_max_stack = 100;
+  // TODO(kuebler): Read this from /proc/sys/kernel/perf_event_max_stack
+  pe.sample_max_stack = 127;
 
   return generic_event_open(&pe, pid, cpu);
 }

--- a/OrbitLinuxTracing/PerfEventOpen.cpp
+++ b/OrbitLinuxTracing/PerfEventOpen.cpp
@@ -77,7 +77,7 @@ int sample_event_open(uint64_t period_ns, pid_t pid, int32_t cpu) {
   return generic_event_open(&pe, pid, cpu);
 }
 
-int sample_event_fp_open(uint64_t period_ns, pid_t pid, int32_t cpu) {
+int sample_event_callchain_open(uint64_t period_ns, pid_t pid, int32_t cpu) {
   perf_event_attr pe = generic_event_attr();
   pe.type = PERF_TYPE_SOFTWARE;
   pe.config = PERF_COUNT_SW_CPU_CLOCK;

--- a/OrbitLinuxTracing/PerfEventOpen.cpp
+++ b/OrbitLinuxTracing/PerfEventOpen.cpp
@@ -77,7 +77,7 @@ int sample_event_open(uint64_t period_ns, pid_t pid, int32_t cpu) {
   return generic_event_open(&pe, pid, cpu);
 }
 
-int sample_callchain_event_open(uint64_t period_ns, pid_t pid, int32_t cpu) {
+int callchain_sample_event_open(uint64_t period_ns, pid_t pid, int32_t cpu) {
   perf_event_attr pe = generic_event_attr();
   pe.type = PERF_TYPE_SOFTWARE;
   pe.config = PERF_COUNT_SW_CPU_CLOCK;

--- a/OrbitLinuxTracing/PerfEventOpen.cpp
+++ b/OrbitLinuxTracing/PerfEventOpen.cpp
@@ -77,7 +77,7 @@ int sample_event_open(uint64_t period_ns, pid_t pid, int32_t cpu) {
   return generic_event_open(&pe, pid, cpu);
 }
 
-int sample_event_callchain_open(uint64_t period_ns, pid_t pid, int32_t cpu) {
+int sample_callchain_event_open(uint64_t period_ns, pid_t pid, int32_t cpu) {
   perf_event_attr pe = generic_event_attr();
   pe.type = PERF_TYPE_SOFTWARE;
   pe.config = PERF_COUNT_SW_CPU_CLOCK;
@@ -85,8 +85,6 @@ int sample_event_callchain_open(uint64_t period_ns, pid_t pid, int32_t cpu) {
   pe.sample_type |= PERF_SAMPLE_CALLCHAIN;
   // TODO(kuebler): This shouldn't be a random constant
   pe.sample_max_stack = 100;
-  pe.sample_regs_user = SAMPLE_REGS_USER_ALL;
-  pe.sample_stack_user = SAMPLE_STACK_USER_SIZE;
 
   return generic_event_open(&pe, pid, cpu);
 }

--- a/OrbitLinuxTracing/PerfEventOpen.h
+++ b/OrbitLinuxTracing/PerfEventOpen.h
@@ -122,7 +122,7 @@ int mmap_task_event_open(pid_t pid, int32_t cpu);
 int sample_event_open(uint64_t period_ns, pid_t pid, int32_t cpu);
 
 // perf_event_open for stack sampling using frame pointers.
-int sample_event_callchain_open(uint64_t period_ns, pid_t pid, int32_t cpu);
+int sample_callchain_event_open(uint64_t period_ns, pid_t pid, int32_t cpu);
 
 // perf_event_open for uprobes and uretprobes.
 int uprobes_retaddr_event_open(const char* module, uint64_t function_offset,

--- a/OrbitLinuxTracing/PerfEventOpen.h
+++ b/OrbitLinuxTracing/PerfEventOpen.h
@@ -122,7 +122,7 @@ int mmap_task_event_open(pid_t pid, int32_t cpu);
 int sample_event_open(uint64_t period_ns, pid_t pid, int32_t cpu);
 
 // perf_event_open for stack sampling using frame pointers.
-int sample_event_fp_open(uint64_t period_ns, pid_t pid, int32_t cpu);
+int sample_event_callchain_open(uint64_t period_ns, pid_t pid, int32_t cpu);
 
 // perf_event_open for uprobes and uretprobes.
 int uprobes_retaddr_event_open(const char* module, uint64_t function_offset,

--- a/OrbitLinuxTracing/PerfEventOpen.h
+++ b/OrbitLinuxTracing/PerfEventOpen.h
@@ -122,7 +122,7 @@ int mmap_task_event_open(pid_t pid, int32_t cpu);
 int sample_event_open(uint64_t period_ns, pid_t pid, int32_t cpu);
 
 // perf_event_open for stack sampling using frame pointers.
-int sample_callchain_event_open(uint64_t period_ns, pid_t pid, int32_t cpu);
+int callchain_sample_event_open(uint64_t period_ns, pid_t pid, int32_t cpu);
 
 // perf_event_open for uprobes and uretprobes.
 int uprobes_retaddr_event_open(const char* module, uint64_t function_offset,

--- a/OrbitLinuxTracing/PerfEventOpen.h
+++ b/OrbitLinuxTracing/PerfEventOpen.h
@@ -121,6 +121,9 @@ int mmap_task_event_open(pid_t pid, int32_t cpu);
 // perf_event_open for stack sampling.
 int sample_event_open(uint64_t period_ns, pid_t pid, int32_t cpu);
 
+// perf_event_open for stack sampling using frame pointers.
+int sample_event_fp_open(uint64_t period_ns, pid_t pid, int32_t cpu);
+
 // perf_event_open for uprobes and uretprobes.
 int uprobes_retaddr_event_open(const char* module, uint64_t function_offset,
                                pid_t pid, int32_t cpu);

--- a/OrbitLinuxTracing/PerfEventReaders.cpp
+++ b/OrbitLinuxTracing/PerfEventReaders.cpp
@@ -52,6 +52,25 @@ std::unique_ptr<SamplePerfEvent> ConsumeSamplePerfEvent(
   return event;
 }
 
+std::unique_ptr<SampleFPPerfEvent> ConsumeSampleFPPerfEvent(
+    PerfEventRingBuffer* ring_buffer, const perf_event_header& header) {
+  uint64_t dyn_size;
+  ring_buffer->ReadValueAtOffset(
+      &dyn_size, offsetof(perf_event_call_chain_sample, dyn_size));
+  auto event = std::make_unique<SampleFPPerfEvent>(dyn_size);
+  event->ring_buffer_record->header = header;
+  ring_buffer->ReadValueAtOffset(&event->ring_buffer_record->sample_id,
+                                 offsetof(perf_event_stack_sample, sample_id));
+
+  // TODO(kuebler): we should have templated read methods
+  uint64_t size_in_bytes = dyn_size * sizeof(uint64_t) / sizeof(char);
+  ring_buffer->ReadRawAtOffset(
+      reinterpret_cast<char*>(event->ring_buffer_record->call_chain.data.get()),
+      offsetof(perf_event_sample_raw, size) + sizeof(uint64_t), size_in_bytes);
+  ring_buffer->SkipRecord(header);
+  return event;
+}
+
 std::unique_ptr<PerfEventSampleRaw> ConsumeSampleRaw(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header) {
   uint32_t size = 0;

--- a/OrbitLinuxTracing/PerfEventReaders.cpp
+++ b/OrbitLinuxTracing/PerfEventReaders.cpp
@@ -52,12 +52,12 @@ std::unique_ptr<SamplePerfEvent> ConsumeSamplePerfEvent(
   return event;
 }
 
-std::unique_ptr<SampleCallchainPerfEvent> ConsumeSampleCallchainPerfEvent(
+std::unique_ptr<CallchainSamplePerfEvent> ConsumeSampleCallchainPerfEvent(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header) {
   uint64_t nr = 0;
   ring_buffer->ReadValueAtOffset(&nr,
                                  offsetof(perf_event_callchain_sample, nr));
-  auto event = std::make_unique<SampleCallchainPerfEvent>(nr);
+  auto event = std::make_unique<CallchainSamplePerfEvent>(nr);
   event->ring_buffer_record.header = header;
   ring_buffer->ReadValueAtOffset(
       &event->ring_buffer_record.sample_id,

--- a/OrbitLinuxTracing/PerfEventReaders.cpp
+++ b/OrbitLinuxTracing/PerfEventReaders.cpp
@@ -52,7 +52,7 @@ std::unique_ptr<SamplePerfEvent> ConsumeSamplePerfEvent(
   return event;
 }
 
-std::unique_ptr<CallchainSamplePerfEvent> ConsumeSampleCallchainPerfEvent(
+std::unique_ptr<CallchainSamplePerfEvent> ConsumeCallchainSamplePerfEvent(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header) {
   uint64_t nr = 0;
   ring_buffer->ReadValueAtOffset(&nr,

--- a/OrbitLinuxTracing/PerfEventReaders.cpp
+++ b/OrbitLinuxTracing/PerfEventReaders.cpp
@@ -52,25 +52,25 @@ std::unique_ptr<SamplePerfEvent> ConsumeSamplePerfEvent(
   return event;
 }
 
-std::unique_ptr<SampleCallChainPerfEvent> ConsumeSampleCallChainPerfEvent(
+std::unique_ptr<SampleCallchainPerfEvent> ConsumeSampleCallChainPerfEvent(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header) {
   uint64_t dyn_size;
   ring_buffer->ReadValueAtOffset(
       &dyn_size, offsetof(perf_event_call_chain_sample, dyn_size));
-  auto event = std::make_unique<SampleCallChainPerfEvent>(dyn_size);
+  auto event = std::make_unique<SampleCallchainPerfEvent>(dyn_size);
   event->ring_buffer_record->header = header;
-  ring_buffer->ReadValueAtOffset(&event->ring_buffer_record->sample_id,
-                                 offsetof(perf_event_call_chain_sample,
-                                          sample_id));
+  ring_buffer->ReadValueAtOffset(
+      &event->ring_buffer_record->sample_id,
+      offsetof(perf_event_call_chain_sample, sample_id));
 
   // TODO(kuebler): we should have templated read methods
   uint64_t size_in_bytes = dyn_size * sizeof(uint64_t) / sizeof(char);
-  uint64_t
-      * ips = event->ring_buffer_record->call_chain.instruction_pointers.get();
+  uint64_t* ips = event->ring_buffer_record->call_chain.ips.get();
   ring_buffer->ReadRawAtOffset(
       reinterpret_cast<char*>(ips),
-      offsetof(perf_event_call_chain_sample, dyn_size)
-          + sizeof(perf_event_call_chain_sample::dyn_size), size_in_bytes);
+      offsetof(perf_event_call_chain_sample, dyn_size) +
+          sizeof(perf_event_call_chain_sample::dyn_size),
+      size_in_bytes);
   ring_buffer->SkipRecord(header);
   return event;
 }

--- a/OrbitLinuxTracing/PerfEventReaders.h
+++ b/OrbitLinuxTracing/PerfEventReaders.h
@@ -15,7 +15,7 @@ pid_t ReadSampleRecordPid(PerfEventRingBuffer* ring_buffer);
 std::unique_ptr<SamplePerfEvent> ConsumeSamplePerfEvent(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header);
 
-std::unique_ptr<SampleCallchainPerfEvent> ConsumeSampleCallchainPerfEvent(
+std::unique_ptr<CallchainSamplePerfEvent> ConsumeSampleCallchainPerfEvent(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header);
 
 std::unique_ptr<PerfEventSampleRaw> ConsumeSampleRaw(

--- a/OrbitLinuxTracing/PerfEventReaders.h
+++ b/OrbitLinuxTracing/PerfEventReaders.h
@@ -15,7 +15,7 @@ pid_t ReadSampleRecordPid(PerfEventRingBuffer* ring_buffer);
 std::unique_ptr<SamplePerfEvent> ConsumeSamplePerfEvent(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header);
 
-std::unique_ptr<SampleCallChainPerfEvent> ConsumeSampleCallChainPerfEvent(
+std::unique_ptr<SampleCallchainPerfEvent> ConsumeSampleCallChainPerfEvent(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header);
 
 std::unique_ptr<PerfEventSampleRaw> ConsumeSampleRaw(

--- a/OrbitLinuxTracing/PerfEventReaders.h
+++ b/OrbitLinuxTracing/PerfEventReaders.h
@@ -15,7 +15,7 @@ pid_t ReadSampleRecordPid(PerfEventRingBuffer* ring_buffer);
 std::unique_ptr<SamplePerfEvent> ConsumeSamplePerfEvent(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header);
 
-std::unique_ptr<SampleFPPerfEvent> ConsumeSampleFPPerfEvent(
+std::unique_ptr<SampleCallChainPerfEvent> ConsumeSampleCallChainPerfEvent(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header);
 
 std::unique_ptr<PerfEventSampleRaw> ConsumeSampleRaw(

--- a/OrbitLinuxTracing/PerfEventReaders.h
+++ b/OrbitLinuxTracing/PerfEventReaders.h
@@ -15,7 +15,7 @@ pid_t ReadSampleRecordPid(PerfEventRingBuffer* ring_buffer);
 std::unique_ptr<SamplePerfEvent> ConsumeSamplePerfEvent(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header);
 
-std::unique_ptr<CallchainSamplePerfEvent> ConsumeSampleCallchainPerfEvent(
+std::unique_ptr<CallchainSamplePerfEvent> ConsumeCallchainSamplePerfEvent(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header);
 
 std::unique_ptr<PerfEventSampleRaw> ConsumeSampleRaw(

--- a/OrbitLinuxTracing/PerfEventReaders.h
+++ b/OrbitLinuxTracing/PerfEventReaders.h
@@ -15,7 +15,7 @@ pid_t ReadSampleRecordPid(PerfEventRingBuffer* ring_buffer);
 std::unique_ptr<SamplePerfEvent> ConsumeSamplePerfEvent(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header);
 
-std::unique_ptr<SampleCallchainPerfEvent> ConsumeSampleCallChainPerfEvent(
+std::unique_ptr<SampleCallchainPerfEvent> ConsumeSampleCallchainPerfEvent(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header);
 
 std::unique_ptr<PerfEventSampleRaw> ConsumeSampleRaw(

--- a/OrbitLinuxTracing/PerfEventReaders.h
+++ b/OrbitLinuxTracing/PerfEventReaders.h
@@ -15,6 +15,9 @@ pid_t ReadSampleRecordPid(PerfEventRingBuffer* ring_buffer);
 std::unique_ptr<SamplePerfEvent> ConsumeSamplePerfEvent(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header);
 
+std::unique_ptr<SampleFPPerfEvent> ConsumeSampleFPPerfEvent(
+    PerfEventRingBuffer* ring_buffer, const perf_event_header& header);
+
 std::unique_ptr<PerfEventSampleRaw> ConsumeSampleRaw(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header);
 

--- a/OrbitLinuxTracing/PerfEventRecords.h
+++ b/OrbitLinuxTracing/PerfEventRecords.h
@@ -100,11 +100,11 @@ struct __attribute__((__packed__)) perf_event_stack_sample {
   perf_event_sample_stack_user stack;
 };
 
-struct __attribute__((__packed__)) perf_event_call_chain_sample {
+struct __attribute__((__packed__)) perf_event_callchain_sample {
   perf_event_header header;
   perf_event_sample_id_tid_time_streamid_cpu sample_id;
-  uint64_t dyn_size;
-  // The rest of the sample is a uint64_t[dyn_size] that we read dynamically.
+  uint64_t nr;
+  // The rest of the sample is a uint64_t[nr] that we read dynamically.
 };
 
 struct __attribute__((__packed__)) perf_event_sp_ip_8bytes_sample {

--- a/OrbitLinuxTracing/PerfEventRecords.h
+++ b/OrbitLinuxTracing/PerfEventRecords.h
@@ -100,6 +100,13 @@ struct __attribute__((__packed__)) perf_event_stack_sample {
   perf_event_sample_stack_user stack;
 };
 
+struct __attribute__((__packed__)) perf_event_call_chain_sample {
+  perf_event_header header;
+  perf_event_sample_id_tid_time_streamid_cpu sample_id;
+  uint64_t dyn_size;
+  // The rest of the sample is a uint64_t[dyn_size] that we read dynamically.
+};
+
 struct __attribute__((__packed__)) perf_event_sp_ip_8bytes_sample {
   perf_event_header header;
   perf_event_sample_id_tid_time_streamid_cpu sample_id;

--- a/OrbitLinuxTracing/PerfEventVisitor.h
+++ b/OrbitLinuxTracing/PerfEventVisitor.h
@@ -14,7 +14,7 @@ class PerfEventVisitor {
   virtual void visit(ContextSwitchPerfEvent*) {}
   virtual void visit(SystemWideContextSwitchPerfEvent*) {}
   virtual void visit(SamplePerfEvent*) {}
-  virtual void visit(SampleCallchainPerfEvent*) {}
+  virtual void visit(CallchainSamplePerfEvent*) {}
   virtual void visit(UprobesPerfEvent*) {}
   virtual void visit(UretprobesPerfEvent*) {}
   virtual void visit(LostPerfEvent*) {}

--- a/OrbitLinuxTracing/PerfEventVisitor.h
+++ b/OrbitLinuxTracing/PerfEventVisitor.h
@@ -14,7 +14,7 @@ class PerfEventVisitor {
   virtual void visit(ContextSwitchPerfEvent*) {}
   virtual void visit(SystemWideContextSwitchPerfEvent*) {}
   virtual void visit(SamplePerfEvent*) {}
-  virtual void visit(SampleCallChainPerfEvent*) {}
+  virtual void visit(SampleCallchainPerfEvent*) {}
   virtual void visit(UprobesPerfEvent*) {}
   virtual void visit(UretprobesPerfEvent*) {}
   virtual void visit(LostPerfEvent*) {}

--- a/OrbitLinuxTracing/PerfEventVisitor.h
+++ b/OrbitLinuxTracing/PerfEventVisitor.h
@@ -14,7 +14,7 @@ class PerfEventVisitor {
   virtual void visit(ContextSwitchPerfEvent*) {}
   virtual void visit(SystemWideContextSwitchPerfEvent*) {}
   virtual void visit(SamplePerfEvent*) {}
-  virtual void visit(SampleFPPerfEvent*) {}
+  virtual void visit(SampleCallChainPerfEvent*) {}
   virtual void visit(UprobesPerfEvent*) {}
   virtual void visit(UretprobesPerfEvent*) {}
   virtual void visit(LostPerfEvent*) {}

--- a/OrbitLinuxTracing/PerfEventVisitor.h
+++ b/OrbitLinuxTracing/PerfEventVisitor.h
@@ -14,6 +14,7 @@ class PerfEventVisitor {
   virtual void visit(ContextSwitchPerfEvent*) {}
   virtual void visit(SystemWideContextSwitchPerfEvent*) {}
   virtual void visit(SamplePerfEvent*) {}
+  virtual void visit(SampleFPPerfEvent*) {}
   virtual void visit(UprobesPerfEvent*) {}
   virtual void visit(UretprobesPerfEvent*) {}
   virtual void visit(LostPerfEvent*) {}

--- a/OrbitLinuxTracing/Tracer.cpp
+++ b/OrbitLinuxTracing/Tracer.cpp
@@ -22,7 +22,8 @@ Tracer::Tracer(pid_t pid, double sampling_frequency,
 
 void Tracer::Run(pid_t pid, uint64_t sampling_period_ns,
                  const std::vector<Function>& instrumented_functions,
-                 TracerListener* listener, TracingOptions tracing_options,
+                 TracerListener* listener,
+                 const TracingOptions& tracing_options,
                  const std::shared_ptr<std::atomic<bool>>& exit_requested) {
   TracerThread session{pid, sampling_period_ns, instrumented_functions};
   session.SetListener(listener);

--- a/OrbitLinuxTracing/Tracer.cpp
+++ b/OrbitLinuxTracing/Tracer.cpp
@@ -23,13 +23,14 @@ Tracer::Tracer(pid_t pid, double sampling_frequency,
 void Tracer::Run(pid_t pid, uint64_t sampling_period_ns,
                  const std::vector<Function>& instrumented_functions,
                  TracerListener* listener, bool trace_context_switches,
-                 bool trace_callstacks, bool trace_instrumented_functions,
-                 bool trace_gpu_driver,
+                 bool trace_callstacks, bool trace_fp_callstacks,
+                 bool trace_instrumented_functions, bool trace_gpu_driver,
                  const std::shared_ptr<std::atomic<bool>>& exit_requested) {
   TracerThread session{pid, sampling_period_ns, instrumented_functions};
   session.SetListener(listener);
   session.SetTraceContextSwitches(trace_context_switches);
   session.SetTraceCallstacks(trace_callstacks);
+  session.SetTraceFPCallstacks(trace_fp_callstacks);
   session.SetTraceInstrumentedFunctions(trace_instrumented_functions);
   session.SetTraceGpuDriver(trace_gpu_driver);
   session.Run(exit_requested);

--- a/OrbitLinuxTracing/Tracer.cpp
+++ b/OrbitLinuxTracing/Tracer.cpp
@@ -22,17 +22,11 @@ Tracer::Tracer(pid_t pid, double sampling_frequency,
 
 void Tracer::Run(pid_t pid, uint64_t sampling_period_ns,
                  const std::vector<Function>& instrumented_functions,
-                 TracerListener* listener, bool trace_context_switches,
-                 bool trace_callstacks, bool trace_fp_callstacks,
-                 bool trace_instrumented_functions, bool trace_gpu_driver,
+                 TracerListener* listener, TracingOptions tracing_options,
                  const std::shared_ptr<std::atomic<bool>>& exit_requested) {
   TracerThread session{pid, sampling_period_ns, instrumented_functions};
   session.SetListener(listener);
-  session.SetTraceContextSwitches(trace_context_switches);
-  session.SetTraceCallstacks(trace_callstacks);
-  session.SetTraceFPCallstacks(trace_fp_callstacks);
-  session.SetTraceInstrumentedFunctions(trace_instrumented_functions);
-  session.SetTraceGpuDriver(trace_gpu_driver);
+  session.SetTracingOptions(tracing_options);
   session.Run(exit_requested);
 }
 

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -670,7 +670,7 @@ void TracerThread::ProcessSampleEvent(const perf_event_header& header,
       ring_buffer->SkipRecord(header);
       return;
     }
-    auto event = ConsumeSampleCallChainPerfEvent(ring_buffer, header);
+    auto event = ConsumeSampleCallchainPerfEvent(ring_buffer, header);
     event->SetOriginFileDescriptor(fd);
     DeferEvent(std::move(event));
     ++stats_.sample_count;

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -184,7 +184,7 @@ bool TracerThread::OpenSampling(const std::vector<int32_t>& cpus) {
     int sampling_fd;
     switch (tracing_options_.sampling_method) {
       case kFramePointers:
-        sampling_fd = sample_callchain_event_open(sampling_period_ns_, -1, cpu);
+        sampling_fd = callchain_sample_event_open(sampling_period_ns_, -1, cpu);
         break;
       case kDwarf:
         sampling_fd = sample_event_open(sampling_period_ns_, -1, cpu);

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -181,7 +181,12 @@ bool TracerThread::OpenSampling(const std::vector<int32_t>& cpus) {
   std::vector<int> sampling_tracing_fds;
   std::vector<PerfEventRingBuffer> sampling_ring_buffers;
   for (int32_t cpu : cpus) {
-    int sampling_fd = sample_event_open(sampling_period_ns_, -1, cpu);
+    int sampling_fd;
+    if (trace_fp_callstacks_) {
+      sampling_fd = sample_event_fp_open(sampling_period_ns_, -1, cpu);
+    } else {
+      sampling_fd = sample_event_open(sampling_period_ns_, -1, cpu);
+    }
     std::string buffer_name = absl::StrFormat("sampling_%d", cpu);
     PerfEventRingBuffer sampling_ring_buffer{
         sampling_fd, SAMPLING_RING_BUFFER_SIZE_KB, buffer_name};
@@ -197,6 +202,9 @@ bool TracerThread::OpenSampling(const std::vector<int32_t>& cpus) {
 
   for (int fd : sampling_tracing_fds) {
     tracing_fds_.push_back(fd);
+    if (trace_fp_callstacks_) {
+      fp_sampling_fds_.emplace(fd);
+    }
   }
   for (PerfEventRingBuffer& buffer : sampling_ring_buffers) {
     ring_buffers_.emplace_back(std::move(buffer));
@@ -587,20 +595,25 @@ void TracerThread::ProcessSampleEvent(const perf_event_header& header,
                                       PerfEventRingBuffer* ring_buffer) {
   int fd = ring_buffer->GetFileDescriptor();
   bool is_gpu_event = gpu_tracing_fds_.contains(fd);
+  bool is_sample_fp = fp_sampling_fds_.contains(fd);
 
   constexpr size_t size_of_uprobes = sizeof(perf_event_sp_ip_8bytes_sample);
-  bool is_uprobe = !is_gpu_event && (header.size == size_of_uprobes);
+  bool is_uprobe =
+      !is_gpu_event && !is_sample_fp && (header.size == size_of_uprobes);
 
   constexpr size_t size_of_uretprobes = sizeof(perf_event_ax_sample);
-  bool is_uretprobe = !is_gpu_event && (header.size == size_of_uretprobes);
+  bool is_uretprobe =
+      !is_gpu_event && !is_sample_fp && (header.size == size_of_uretprobes);
 
   constexpr size_t size_of_sample = sizeof(perf_event_stack_sample);
-  bool is_sample = !is_gpu_event && (header.size == size_of_sample);
+  bool is_sample =
+      !is_gpu_event && !is_sample_fp && (header.size == size_of_sample);
 
   static_assert(size_of_uprobes != size_of_uretprobes &&
                 size_of_uprobes != size_of_sample &&
                 size_of_uretprobes != size_of_sample);
-  CHECK(is_gpu_event + is_uprobe + is_uretprobe + is_sample <= 1);
+  CHECK(is_gpu_event + is_uprobe + is_uretprobe + is_sample + is_sample_fp <=
+        1);
 
   if (is_uprobe) {
     auto event = make_unique_for_overwrite<UprobesPerfEvent>();
@@ -639,6 +652,17 @@ void TracerThread::ProcessSampleEvent(const perf_event_header& header,
       return;
     }
     auto event = ConsumeSamplePerfEvent(ring_buffer, header);
+    event->SetOriginFileDescriptor(fd);
+    DeferEvent(std::move(event));
+    ++stats_.sample_count;
+
+  } else if (is_sample_fp) {
+    pid_t pid = ReadSampleRecordPid(ring_buffer);
+    if (pid != pid_) {
+      ring_buffer->SkipRecord(header);
+      return;
+    }
+    auto event = ConsumeSampleFPPerfEvent(ring_buffer, header);
     event->SetOriginFileDescriptor(fd);
     DeferEvent(std::move(event));
     ++stats_.sample_count;
@@ -702,6 +726,8 @@ void TracerThread::Reset() {
   ring_buffers_.clear();
   uprobes_ids_to_function_.clear();
   gpu_tracing_fds_.clear();
+  fp_sampling_fds_.clear();
+
   deferred_events_.clear();
   stop_deferred_thread_ = false;
 }

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -190,7 +190,7 @@ bool TracerThread::OpenSampling(const std::vector<int32_t>& cpus) {
         sampling_fd = sample_event_open(sampling_period_ns_, -1, cpu);
         break;
       case kOff:
-        ERROR("Sampling is off");
+        FATAL("Sampling is off. This statement is unreachable.");
         CloseFileDescriptors(sampling_tracing_fds);
         return false;
     }
@@ -670,7 +670,7 @@ void TracerThread::ProcessSampleEvent(const perf_event_header& header,
       ring_buffer->SkipRecord(header);
       return;
     }
-    auto event = ConsumeSampleCallchainPerfEvent(ring_buffer, header);
+    auto event = ConsumeCallchainSamplePerfEvent(ring_buffer, header);
     event->SetOriginFileDescriptor(fd);
     DeferEvent(std::move(event));
     ++stats_.sample_count;

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -41,7 +41,7 @@ class TracerThread {
 
   void SetListener(TracerListener* listener) { listener_ = listener; }
 
-  void SetTracingOptions(TracingOptions tracing_options) {
+  void SetTracingOptions(const TracingOptions& tracing_options) {
     tracing_options_ = tracing_options;
   }
 
@@ -107,7 +107,7 @@ class TracerThread {
   std::vector<PerfEventRingBuffer> ring_buffers_;
   absl::flat_hash_map<uint64_t, const Function*> uprobes_ids_to_function_;
   absl::flat_hash_set<int> gpu_tracing_fds_;
-  absl::flat_hash_set<int> fp_sampling_fds_;
+  absl::flat_hash_set<int> frame_pointers_sampling_fds_;
 
   std::atomic<bool> stop_deferred_thread_ = false;
   std::vector<std::unique_ptr<PerfEvent>> deferred_events_;

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -48,6 +48,10 @@ class TracerThread {
     trace_callstacks_ = trace_callstacks;
   }
 
+  void SetTraceFPCallstacks(bool trace_fp_callstacks) {
+    trace_fp_callstacks_ = trace_fp_callstacks;
+  }
+
   void SetTraceInstrumentedFunctions(bool trace_instrumented_functions) {
     trace_instrumented_functions_ = trace_instrumented_functions;
   }
@@ -64,6 +68,7 @@ class TracerThread {
   bool OpenUprobes(const std::vector<int32_t>& cpus);
   bool OpenMmapTask(const std::vector<int32_t>& cpus);
   bool OpenSampling(const std::vector<int32_t>& cpus);
+  bool OpenFPSampling(const std::vector<int32_t>& cpus);
 
   bool InitGpuTracepointEventProcessor();
   static bool OpenRingBufferForGpuTracepoint(
@@ -115,6 +120,7 @@ class TracerThread {
 
   bool trace_context_switches_ = true;
   bool trace_callstacks_ = true;
+  bool trace_fp_callstacks_ = false;
   bool trace_instrumented_functions_ = true;
   bool trace_gpu_driver_ = true;
 
@@ -122,6 +128,7 @@ class TracerThread {
   std::vector<PerfEventRingBuffer> ring_buffers_;
   absl::flat_hash_map<uint64_t, const Function*> uprobes_ids_to_function_;
   absl::flat_hash_set<int> gpu_tracing_fds_;
+  absl::flat_hash_set<int> fp_sampling_fds_;
 
   std::atomic<bool> stop_deferred_thread_ = false;
   std::vector<std::unique_ptr<PerfEvent>> deferred_events_;

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -4,6 +4,7 @@
 #include <OrbitLinuxTracing/Events.h>
 #include <OrbitLinuxTracing/Function.h>
 #include <OrbitLinuxTracing/TracerListener.h>
+#include <OrbitLinuxTracing/TracingOptions.h>
 #include <linux/perf_event.h>
 
 #include <atomic>
@@ -40,24 +41,8 @@ class TracerThread {
 
   void SetListener(TracerListener* listener) { listener_ = listener; }
 
-  void SetTraceContextSwitches(bool trace_context_switches) {
-    trace_context_switches_ = trace_context_switches;
-  }
-
-  void SetTraceCallstacks(bool trace_callstacks) {
-    trace_callstacks_ = trace_callstacks;
-  }
-
-  void SetTraceFPCallstacks(bool trace_fp_callstacks) {
-    trace_fp_callstacks_ = trace_fp_callstacks;
-  }
-
-  void SetTraceInstrumentedFunctions(bool trace_instrumented_functions) {
-    trace_instrumented_functions_ = trace_instrumented_functions;
-  }
-
-  void SetTraceGpuDriver(bool trace_gpu_driver) {
-    trace_gpu_driver_ = trace_gpu_driver;
+  void SetTracingOptions(TracingOptions tracing_options) {
+    tracing_options_ = tracing_options;
   }
 
   void Run(const std::shared_ptr<std::atomic<bool>>& exit_requested);
@@ -68,7 +53,6 @@ class TracerThread {
   bool OpenUprobes(const std::vector<int32_t>& cpus);
   bool OpenMmapTask(const std::vector<int32_t>& cpus);
   bool OpenSampling(const std::vector<int32_t>& cpus);
-  bool OpenFPSampling(const std::vector<int32_t>& cpus);
 
   bool InitGpuTracepointEventProcessor();
   static bool OpenRingBufferForGpuTracepoint(
@@ -117,12 +101,7 @@ class TracerThread {
   std::vector<Function> instrumented_functions_;
 
   TracerListener* listener_ = nullptr;
-
-  bool trace_context_switches_ = true;
-  bool trace_callstacks_ = true;
-  bool trace_fp_callstacks_ = false;
-  bool trace_instrumented_functions_ = true;
-  bool trace_gpu_driver_ = true;
+  TracingOptions tracing_options_;
 
   std::vector<int> tracing_fds_;
   std::vector<PerfEventRingBuffer> ring_buffers_;

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
@@ -52,8 +52,8 @@ void UprobesUnwindingVisitor::visit(SampleCallchainPerfEvent* event) {
 
   Callstack returned_callstack{
       event->GetTid(),
-      CallstackFramesFromInstructionPointers(event->GetCallChain(),
-                                             event->GetCallChainSize()),
+      CallstackFramesFromInstructionPointers(event->GetCallchain(),
+                                             event->GetCallchainSize()),
       event->GetTimestamp()};
   listener_->OnCallstack(returned_callstack);
 }

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
@@ -41,37 +41,14 @@ void UprobesUnwindingVisitor::visit(SamplePerfEvent* event) {
   listener_->OnCallstack(returned_callstack);
 }
 
-void UprobesUnwindingVisitor::visit(SampleFPPerfEvent* event) {
+void UprobesUnwindingVisitor::visit(SampleCallChainPerfEvent* event) {
   CHECK(listener_ != nullptr);
 
   if (current_maps_ == nullptr) {
     return;
   }
 
-  /* TODO(kuebler): handle the mapping/patching for uprobes
-    return_address_manager_.PatchSample(
-      event->GetTid(), event->GetRegisters()[PERF_REG_X86_SP],
-      event->GetStackData(), event->GetStackSize());
-
-  const std::vector<unwindstack::FrameData>& full_callstack =
-      unwinder_.Unwind(current_maps_.get(), event->GetRegisters(),
-                       event->GetStackData(), event->GetStackSize());
-
-  if (full_callstack.empty()) {
-    if (unwind_error_counter_ != nullptr) {
-      ++(*unwind_error_counter_);
-    }
-    return;
-  }
-
-  // Some samples can actually fall inside u(ret)probes code. Discard them,
-  // because when they are unwound successfully the result is wrong.
-  if (full_callstack.front().map_name == "[uprobes]") {
-    if (discarded_samples_in_uretprobes_counter_ != nullptr) {
-      ++(*discarded_samples_in_uretprobes_counter_);
-    }
-    return;
-  }*/
+  // TODO(kuebler): handle the mapping/patching for uprobes
 
   // TODO(kuebler): we only have the IP here, however, that should be sufficient
   Callstack returned_callstack{

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
@@ -41,7 +41,7 @@ void UprobesUnwindingVisitor::visit(SamplePerfEvent* event) {
   listener_->OnCallstack(returned_callstack);
 }
 
-void UprobesUnwindingVisitor::visit(SampleCallChainPerfEvent* event) {
+void UprobesUnwindingVisitor::visit(SampleCallchainPerfEvent* event) {
   CHECK(listener_ != nullptr);
 
   if (current_maps_ == nullptr) {
@@ -50,7 +50,6 @@ void UprobesUnwindingVisitor::visit(SampleCallChainPerfEvent* event) {
 
   // TODO(kuebler): handle the mapping/patching for uprobes
 
-  // TODO(kuebler): we only have the IP here, however, that should be sufficient
   Callstack returned_callstack{
       event->GetTid(),
       CallstackFramesFromInstructionPointers(event->GetCallChain(),
@@ -86,7 +85,7 @@ void UprobesUnwindingVisitor::visit(UprobesPerfEvent* event) {
       ERROR("MISSING URETPROBE OR DUPLICATE UPROBE");
       return;
     } else if (uprobe_sp == last_uprobe_sp && uprobe_ip == last_uprobe_ip &&
-        uprobe_cpu != last_uprobe_cpu) {
+               uprobe_cpu != last_uprobe_cpu) {
       ERROR("Duplicate uprobe on thread migration");
       return;
     }
@@ -131,7 +130,7 @@ UprobesUnwindingVisitor::CallstackFramesFromLibunwindstackFrames(
   std::vector<CallstackFrame> callstack_frames;
   callstack_frames.reserve(libunwindstack_frames.size());
   for (const unwindstack::FrameData& libunwindstack_frame :
-      libunwindstack_frames) {
+       libunwindstack_frames) {
     callstack_frames.emplace_back(
         libunwindstack_frame.pc, libunwindstack_frame.function_name,
         libunwindstack_frame.function_offset, libunwindstack_frame.map_name);
@@ -147,10 +146,8 @@ UprobesUnwindingVisitor::CallstackFramesFromInstructionPointers(
   }
   std::vector<CallstackFrame> callstack_frames;
   for (uint64_t i = 0; i < size; i++) {
-    callstack_frames.emplace_back(frames[i],
-                                  "",
-                                  CallstackFrame::kUnknownFunctionOffset,
-                                  "");
+    callstack_frames.emplace_back(frames[i], "",
+                                  CallstackFrame::kUnknownFunctionOffset, "");
   }
   return callstack_frames;
 }

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
@@ -41,7 +41,7 @@ void UprobesUnwindingVisitor::visit(SamplePerfEvent* event) {
   listener_->OnCallstack(returned_callstack);
 }
 
-void UprobesUnwindingVisitor::visit(SampleCallchainPerfEvent* event) {
+void UprobesUnwindingVisitor::visit(CallchainSamplePerfEvent* event) {
   CHECK(listener_ != nullptr);
 
   if (current_maps_ == nullptr) {

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.h
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.h
@@ -55,7 +55,7 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   }
 
   void visit(SamplePerfEvent* event) override;
-  void visit(SampleFPPerfEvent* event) override;
+  void visit(SampleCallChainPerfEvent* event) override;
   void visit(UprobesPerfEvent* event) override;
   void visit(UretprobesPerfEvent* event) override;
   void visit(MapsPerfEvent* event) override;

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.h
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.h
@@ -55,7 +55,7 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   }
 
   void visit(SamplePerfEvent* event) override;
-  void visit(SampleCallChainPerfEvent* event) override;
+  void visit(SampleCallchainPerfEvent* event) override;
   void visit(UprobesPerfEvent* event) override;
   void visit(UretprobesPerfEvent* event) override;
   void visit(MapsPerfEvent* event) override;

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.h
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.h
@@ -55,7 +55,7 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   }
 
   void visit(SamplePerfEvent* event) override;
-  void visit(SampleCallchainPerfEvent* event) override;
+  void visit(CallchainSamplePerfEvent* event) override;
   void visit(UprobesPerfEvent* event) override;
   void visit(UretprobesPerfEvent* event) override;
   void visit(MapsPerfEvent* event) override;

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.h
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.h
@@ -55,6 +55,7 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   }
 
   void visit(SamplePerfEvent* event) override;
+  void visit(SampleFPPerfEvent* event) override;
   void visit(UprobesPerfEvent* event) override;
   void visit(UretprobesPerfEvent* event) override;
   void visit(MapsPerfEvent* event) override;
@@ -72,6 +73,9 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
 
   static std::vector<CallstackFrame> CallstackFramesFromLibunwindstackFrames(
       const std::vector<unwindstack::FrameData>& libunwindstack_frames);
+
+  static std::vector<CallstackFrame> CallstackFramesFromInstructionPointers(
+      const uint64_t* frames, uint64_t size);
 
   absl::flat_hash_map<pid_t,
                       std::vector<std::tuple<uint64_t, uint64_t, uint32_t>>>

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/Events.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/Events.h
@@ -53,6 +53,7 @@ class CallstackFrame {
   const std::string& GetFunctionName() const { return function_name_; }
   uint64_t GetFunctionOffset() const { return function_offset_; }
   const std::string& GetMapName() const { return map_name_; }
+  static constexpr uint64_t kUnknownFunctionOffset  = static_cast<uint64_t>(-1);
 
  private:
   uint64_t pc_;

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/Events.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/Events.h
@@ -53,7 +53,8 @@ class CallstackFrame {
   const std::string& GetFunctionName() const { return function_name_; }
   uint64_t GetFunctionOffset() const { return function_offset_; }
   const std::string& GetMapName() const { return map_name_; }
-  static constexpr uint64_t kUnknownFunctionOffset  = static_cast<uint64_t>(-1);
+  static constexpr uint64_t
+      kUnknownFunctionOffset = std::numeric_limits<uint64_t>::max();
 
  private:
   uint64_t pc_;

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/Events.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/Events.h
@@ -53,8 +53,8 @@ class CallstackFrame {
   const std::string& GetFunctionName() const { return function_name_; }
   uint64_t GetFunctionOffset() const { return function_offset_; }
   const std::string& GetMapName() const { return map_name_; }
-  static constexpr uint64_t
-      kUnknownFunctionOffset = std::numeric_limits<uint64_t>::max();
+  static constexpr uint64_t kUnknownFunctionOffset =
+      std::numeric_limits<uint64_t>::max();
 
  private:
   uint64_t pc_;

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/Tracer.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/Tracer.h
@@ -72,7 +72,10 @@ class Tracer {
   std::vector<Function> instrumented_functions_;
 
   TracerListener* listener_ = nullptr;
-  TracingOptions tracing_options_;
+  TracingOptions tracing_options_{.trace_context_switches = true,
+                                  .sampling_method = kDwarf,
+                                  .trace_instrumented_functions = true,
+                                  .trace_gpu_driver = true};
 
   // exit_requested_ must outlive this object because it is used by thread_.
   // The control block of shared_ptr is thread safe (i.e., reference counting

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/Tracer.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/Tracer.h
@@ -39,6 +39,10 @@ class Tracer {
     trace_callstacks_ = trace_callstacks;
   }
 
+  void SetTraceFPCallstacks(bool trace_fp_callstacks) {
+    trace_fp_callstacks_ = trace_fp_callstacks;
+  }
+
   void SetTraceInstrumentedFunctions(bool trace_instrumented_functions) {
     trace_instrumented_functions_ = trace_instrumented_functions;
   }
@@ -52,7 +56,8 @@ class Tracer {
     thread_ = std::make_shared<std::thread>(
         &Tracer::Run, pid_, sampling_period_ns_, instrumented_functions_,
         listener_, trace_context_switches_, trace_callstacks_,
-        trace_instrumented_functions_, trace_gpu_driver_, exit_requested_);
+        trace_fp_callstacks_, trace_instrumented_functions_,
+        trace_gpu_driver_, exit_requested_);
   }
 
   bool IsTracing() {
@@ -76,6 +81,9 @@ class Tracer {
 
   bool trace_context_switches_ = true;
   bool trace_callstacks_ = true;
+  // if trace_callstacks_ and trace_fp_callstacks_, use frame pointers for
+  // unwinding
+  bool trace_fp_callstacks_ = false;
   bool trace_instrumented_functions_ = true;
   bool trace_gpu_driver_ = true;
 
@@ -89,8 +97,8 @@ class Tracer {
   static void Run(pid_t pid, uint64_t sampling_period_ns,
                   const std::vector<Function>& instrumented_functions,
                   TracerListener* listener, bool trace_context_switches,
-                  bool trace_callstacks, bool trace_instrumented_functions,
-                  bool trace_gpu_driver,
+                  bool trace_callstacks, bool trace_fp_callstacks,
+                  bool trace_instrumented_functions, bool trace_gpu_driver,
                   const std::shared_ptr<std::atomic<bool>>& exit_requested);
 
   static std::optional<uint64_t> ComputeSamplingPeriodNs(

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/Tracer.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/Tracer.h
@@ -33,23 +33,20 @@ class Tracer {
   void SetListener(TracerListener* listener) { listener_ = listener; }
 
   void SetTraceContextSwitches(bool trace_context_switches) {
-    tracing_options_.trace_context_switches_ = trace_context_switches;
+    tracing_options_.trace_context_switches = trace_context_switches;
   }
 
-  void SetTraceCallstacks(bool trace_callstacks) {
-    tracing_options_.trace_callstacks_ = trace_callstacks;
-  }
-
-  void SetTraceUnwindingMethod(UnwindingMethod unwinding_method) {
-    tracing_options_.unwinding_method_ = unwinding_method;
+  void SetSamplingMethod(SamplingMethod sampling_method) {
+    tracing_options_.sampling_method = sampling_method;
   }
 
   void SetTraceInstrumentedFunctions(bool trace_instrumented_functions) {
-    tracing_options_.trace_instrumented_functions_ = trace_instrumented_functions;
+    tracing_options_.trace_instrumented_functions =
+        trace_instrumented_functions;
   }
 
   void SetTraceGpuDriver(bool trace_gpu_driver) {
-    tracing_options_.trace_gpu_driver_ = trace_gpu_driver;
+    tracing_options_.trace_gpu_driver = trace_gpu_driver;
   }
 
   void Start() {
@@ -59,9 +56,7 @@ class Tracer {
         listener_, tracing_options_, exit_requested_);
   }
 
-  bool IsTracing() {
-    return thread_ != nullptr && thread_->joinable();
-  }
+  bool IsTracing() { return thread_ != nullptr && thread_->joinable(); }
 
   void Stop() {
     *exit_requested_ = true;
@@ -88,7 +83,8 @@ class Tracer {
 
   static void Run(pid_t pid, uint64_t sampling_period_ns,
                   const std::vector<Function>& instrumented_functions,
-                  TracerListener* listener, TracingOptions tracing_options,
+                  TracerListener* listener,
+                  const TracingOptions& tracing_options,
                   const std::shared_ptr<std::atomic<bool>>& exit_requested);
 
   static std::optional<uint64_t> ComputeSamplingPeriodNs(

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/TracingOptions.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/TracingOptions.h
@@ -1,21 +1,16 @@
-#ifndef ORBITLINUXTRACING_INCLUDE_ORBITLINUXTRACING_TRACINGOPTIONS_H_
-#define ORBITLINUXTRACING_INCLUDE_ORBITLINUXTRACING_TRACINGOPTIONS_H_
+#ifndef ORBIT_LINUX_TRACING_TRACING_OPTIONS_H_
+#define ORBIT_LINUX_TRACING_TRACING_OPTIONS_H_
 
 namespace LinuxTracing {
-enum UnwindingMethod {
-  kUndefined = 0,
-  kFramePointers,
-  kDwarf
-};
+enum SamplingMethod { kOff = 0, kFramePointers, kDwarf };
 
 struct TracingOptions {
-  bool trace_context_switches_ = true;
-  bool trace_callstacks_ = true;
-  UnwindingMethod unwinding_method_ = kDwarf;
-  bool trace_instrumented_functions_ = true;
-  bool trace_gpu_driver_ = true;
+  bool trace_context_switches = true;
+  SamplingMethod sampling_method = kDwarf;
+  bool trace_instrumented_functions = true;
+  bool trace_gpu_driver = true;
 };
 
 }  // namespace LinuxTracing
 
-#endif //ORBITLINUXTRACING_INCLUDE_ORBITLINUXTRACING_TRACINGOPTIONS_H_
+#endif  // ORBIT_LINUX_TRACING_TRACING_OPTIONS_H_

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/TracingOptions.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/TracingOptions.h
@@ -1,0 +1,21 @@
+#ifndef ORBITLINUXTRACING_INCLUDE_ORBITLINUXTRACING_TRACINGOPTIONS_H_
+#define ORBITLINUXTRACING_INCLUDE_ORBITLINUXTRACING_TRACINGOPTIONS_H_
+
+namespace LinuxTracing {
+enum UnwindingMethod {
+  kUndefined = 0,
+  kFramePointers,
+  kDwarf
+};
+
+struct TracingOptions {
+  bool trace_context_switches_ = true;
+  bool trace_callstacks_ = true;
+  UnwindingMethod unwinding_method_ = kDwarf;
+  bool trace_instrumented_functions_ = true;
+  bool trace_gpu_driver_ = true;
+};
+
+}  // namespace LinuxTracing
+
+#endif //ORBITLINUXTRACING_INCLUDE_ORBITLINUXTRACING_TRACINGOPTIONS_H_


### PR DESCRIPTION
The current implementation is disabled by default. So far there is also no flag to activate it.
It uses `perf_event_open`'s `PERF_SAMPLE_CALLCHAIN` flag.