### PR TITLE
Fix GPU track hack by separating GPU track and thread track implementations

### DIFF
--- a/OrbitCore/LinuxTracingHandler.cpp
+++ b/OrbitCore/LinuxTracingHandler.cpp
@@ -148,22 +148,9 @@ uint64_t LinuxTracingHandler::ProcessStringAndGetKey(
   return key;
 }
 
-pid_t LinuxTracingHandler::TimelineToThreadId(std::string_view timeline) {
-  auto it = timeline_to_thread_id_.find(timeline);
-  if (it != timeline_to_thread_id_.end()) {
-    return it->second;
-  }
-
-  pid_t new_id = current_timeline_thread_id_;
-  current_timeline_thread_id_++;
-  timeline_to_thread_id_.emplace(timeline, new_id);
-  return new_id;
-}
-
 void LinuxTracingHandler::OnGpuJob(const LinuxTracing::GpuJob& gpu_job) {
   Timer timer_user_to_sched;
-  timer_user_to_sched.m_TID = TimelineToThreadId(gpu_job.GetTimeline());
-  timer_user_to_sched.m_SubmitTID = gpu_job.GetTid();
+  timer_user_to_sched.m_TID = gpu_job.GetTid();
   timer_user_to_sched.m_Start = gpu_job.GetAmdgpuCsIoctlTimeNs();
   timer_user_to_sched.m_End = gpu_job.GetAmdgpuSchedRunJobTimeNs();
   timer_user_to_sched.m_Depth = gpu_job.GetDepth();
@@ -179,8 +166,7 @@ void LinuxTracingHandler::OnGpuJob(const LinuxTracing::GpuJob& gpu_job) {
   tracing_buffer_->RecordTimer(std::move(timer_user_to_sched));
 
   Timer timer_sched_to_start;
-  timer_sched_to_start.m_TID = TimelineToThreadId(gpu_job.GetTimeline());
-  timer_sched_to_start.m_SubmitTID = gpu_job.GetTid();
+  timer_sched_to_start.m_TID = gpu_job.GetTid();
   timer_sched_to_start.m_Start = gpu_job.GetAmdgpuSchedRunJobTimeNs();
   timer_sched_to_start.m_End = gpu_job.GetGpuHardwareStartTimeNs();
   timer_sched_to_start.m_Depth = gpu_job.GetDepth();
@@ -195,8 +181,7 @@ void LinuxTracingHandler::OnGpuJob(const LinuxTracing::GpuJob& gpu_job) {
   tracing_buffer_->RecordTimer(std::move(timer_sched_to_start));
 
   Timer timer_start_to_finish;
-  timer_start_to_finish.m_TID = TimelineToThreadId(gpu_job.GetTimeline());
-  timer_start_to_finish.m_SubmitTID = gpu_job.GetTid();
+  timer_start_to_finish.m_TID = gpu_job.GetTid();
   timer_start_to_finish.m_Start = gpu_job.GetGpuHardwareStartTimeNs();
   timer_start_to_finish.m_End = gpu_job.GetDmaFenceSignaledTimeNs();
   timer_start_to_finish.m_Depth = gpu_job.GetDepth();

--- a/OrbitCore/LinuxTracingHandler.h
+++ b/OrbitCore/LinuxTracingHandler.h
@@ -49,11 +49,6 @@ class LinuxTracingHandler : LinuxTracing::TracerListener {
   absl::flat_hash_set<uint64_t> callstack_hashes_seen_;
   absl::Mutex callstack_hashes_seen_mutex_;
   StringManager string_manager_;
-
-  // TODO: Fix this hack that reuses thread tracks in the UI to show GPU events.
-  pid_t TimelineToThreadId(std::string_view timeline);
-  absl::flat_hash_map<std::string, pid_t> timeline_to_thread_id_;
-  pid_t current_timeline_thread_id_ = 1'000'000'000;
 };
 
 #endif  // ORBIT_CORE_LINUX_TRACING_HANDLER_H_

--- a/OrbitCore/ScopeTimer.h
+++ b/OrbitCore/ScopeTimer.h
@@ -23,8 +23,7 @@ class Timer {
         m_Type(NONE),
         m_Processor(-1),
         m_CallstackHash(0),
-        m_FunctionAddress(0),
-        m_SubmitTID(0) {
+        m_FunctionAddress(0) {
     m_UserData[0] = 0;
     m_UserData[1] = 0;
   }
@@ -76,10 +75,6 @@ class Timer {
   // Needs to have to exact same layout in win32/x64, debug/release
 
   uint32_t m_PID;
-  // Thread ID. For timers that represent CPU activity, this is the
-  // thread id, for GPU activity, this is an artificial thread id
-  // that is larger than any CPU thread id and is in 1:1 relation to
-  // GPU timelines (gfx, sdma, etc.).
   uint32_t m_TID;
   uint8_t m_Depth;
   uint8_t m_SessionID;
@@ -90,8 +85,6 @@ class Timer {
   uint64_t m_UserData[2];
   TickType m_Start;
   TickType m_End;
-  // GPU job submission came from this thread id.
-  uint32_t m_SubmitTID;
 };
 #pragma pack(pop)
 

--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -31,6 +31,7 @@ target_sources(
          GlPanel.h
          GlSlider.h
          GlUtils.h
+	 GpuTrack.h
          GraphTrack.h
          HomeWindow.h
          Images.h
@@ -80,6 +81,7 @@ target_sources(
           GlPanel.cpp
           GlSlider.cpp
           GlUtils.cpp
+	  GpuTrack.cpp
           GraphTrack.cpp
           HomeWindow.cpp
           ImGuiOrbit.cpp

--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -31,7 +31,7 @@ target_sources(
          GlPanel.h
          GlSlider.h
          GlUtils.h
-	 GpuTrack.h
+         GpuTrack.h
          GraphTrack.h
          HomeWindow.h
          Images.h
@@ -81,7 +81,7 @@ target_sources(
           GlPanel.cpp
           GlSlider.cpp
           GlUtils.cpp
-	  GpuTrack.cpp
+          GpuTrack.cpp
           GraphTrack.cpp
           HomeWindow.cpp
           ImGuiOrbit.cpp

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -94,7 +94,6 @@ void GpuTrack::SetTimesliceText(const Timer& timer, double elapsed_us,
 
     text_box->SetElapsedTimeTextLength(time.length());
 
-
     CHECK(timer.m_Type == Timer::GPU_ACTIVITY);
 
     std::string text = absl::StrFormat("%s; submitter: %d  %s",

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -11,10 +11,10 @@
 //-----------------------------------------------------------------------------
 GpuTrack::GpuTrack(TimeGraph* time_graph,
                    std::shared_ptr<StringManager> string_manager,
-                   std::string_view timeline) {
+                   uint64_t timeline_hash) {
   time_graph_ = time_graph;
   text_renderer_ = time_graph->GetTextRenderer();
-  timeline_ = timeline;
+  timeline_hash_ = timeline_hash;
 
   num_timers_ = 0;
   min_time_ = std::numeric_limits<TickType>::max();
@@ -253,8 +253,8 @@ std::shared_ptr<TimerChain> GpuTrack::GetTimers(uint32_t depth) const {
 //-----------------------------------------------------------------------------
 const TextBox* GpuTrack::GetLeft(TextBox* text_box) const {
   const Timer& timer = text_box->GetTimer();
-  std::string timeline = string_manager_->Get(timer.m_UserData[0]).value_or("");
-  if (timeline == timeline_) {
+  uint64_t timeline_hash = timer.m_UserData[0];;
+  if (timeline_hash == timeline_hash_) {
     std::shared_ptr<TimerChain> timers = GetTimers(timer.m_Depth);
     if (timers) return timers->GetElementBefore(text_box);
   }
@@ -264,8 +264,8 @@ const TextBox* GpuTrack::GetLeft(TextBox* text_box) const {
 //-----------------------------------------------------------------------------
 const TextBox* GpuTrack::GetRight(TextBox* text_box) const {
   const Timer& timer = text_box->GetTimer();
-  std::string timeline = string_manager_->Get(timer.m_UserData[0]).value_or("");
-  if (timeline == timeline_) {
+  uint64_t timeline_hash = timer.m_UserData[0];;
+  if (timeline_hash == timeline_hash_) {
     std::shared_ptr<TimerChain> timers = GetTimers(timer.m_Depth);
     if (timers) return timers->GetElementAfter(text_box);
   }

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -3,7 +3,6 @@
 #include <limits>
 
 #include "Capture.h"
-//#include "EventTrack.h"
 #include "GlCanvas.h"
 #include "TimeGraph.h"
 #include "absl/flags/flag.h"
@@ -21,8 +20,6 @@ GpuTrack::GpuTrack(TimeGraph* time_graph,
   min_time_ = std::numeric_limits<TickType>::max();
   max_time_ = std::numeric_limits<TickType>::min();
 
-  //  event_track_ = std::make_shared<EventTrack>(time_graph);
-
   string_manager_ = string_manager;
 }
 
@@ -35,12 +32,6 @@ void GpuTrack::Draw(GlCanvas* canvas, bool picking) {
   SetSize(track_width, track_height);
 
   Track::Draw(canvas, picking);
-
-  // Event track
-  //  float event_track_height = time_graph_->GetLayout().GetEventTrackHeight();
-  //event_track_->SetPos(m_Pos[0], m_Pos[1]);
-  //event_track_->SetSize(track_width, event_track_height);
-  //event_track_->Draw(canvas, picking);
 }
 
 //-----------------------------------------------------------------------------
@@ -89,7 +80,7 @@ Color GpuTrack::GetTimerColor(const Timer& timer,
 //-----------------------------------------------------------------------------
 inline float GetYFromDepth(const TimeGraphLayout& layout, float track_y,
                            uint32_t depth) {
-  return track_y - //layout.GetEventTrackHeight() -
+  return track_y -
          layout.GetSpaceBetweenTracksAndThread() -
          layout.GetTextBoxHeight() * (depth + 1);
 }
@@ -128,8 +119,6 @@ void GpuTrack::SetTimesliceText(const Timer& timer, double elapsed_us,
 
 //-----------------------------------------------------------------------------
 void GpuTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
-  //event_track_->UpdatePrimitives(min_tick, max_tick);
-
   Batcher* batcher = &time_graph_->GetBatcher();
   GlCanvas* canvas = time_graph_->GetCanvas();
   const TimeGraphLayout& layout = time_graph_->GetLayout();
@@ -204,7 +193,6 @@ float GpuTrack::GetHeight() const {
   TimeGraphLayout& layout = time_graph_->GetLayout();
   return layout.GetTextBoxHeight() * GetDepth() +
       layout.GetSpaceBetweenTracksAndThread() +
-      //layout.GetEventTrackHeight() +
       layout.GetTrackBottomMargin();
 }
 
@@ -304,8 +292,3 @@ std::vector<std::shared_ptr<TimerChain>> GpuTrack::GetAllChains() {
   }
   return chains;
 }
-
-//void GpuTrack::SetEventTrackColor(Color color) {
-//  ScopeLock lock(mutex_);
-//  event_track_->SetColor(color);
-//}

--- a/OrbitGl/GpuTrack.h
+++ b/OrbitGl/GpuTrack.h
@@ -8,17 +8,20 @@
 
 #include "BlockChain.h"
 #include "CallstackTypes.h"
-#include "EventTrack.h"
+//#include "EventTrack.h"
+#include "StringManager.h"
 #include "TextBox.h"
 #include "Threading.h"
 #include "Track.h"
 
 class TextRenderer;
 
-class ThreadTrack : public Track {
+class GpuTrack : public Track {
  public:
-  ThreadTrack(TimeGraph* time_graph, uint32_t thread_id);
-  ~ThreadTrack() override = default;
+  GpuTrack(TimeGraph* time_graph,
+           std::shared_ptr<StringManager> string_manager,
+           std::string_view timeline);
+  ~GpuTrack() override = default;
 
   // Pickable
   void Draw(GlCanvas* canvas, bool picking) override;
@@ -27,7 +30,7 @@ class ThreadTrack : public Track {
 
   // Track
   void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) override;
-  Type GetType() const override { return kThreadTrack; }
+  Type GetType() const override { return kGpuTrack; }
   float GetHeight() const override;
 
   std::vector<std::shared_ptr<TimerChain>> GetTimers() override;
@@ -35,7 +38,6 @@ class ThreadTrack : public Track {
   std::string GetExtraInfo(const Timer& timer);
 
   Color GetColor() const;
-  static Color GetColor(ThreadID a_TID);
   uint32_t GetNumTimers() const { return num_timers_; }
   TickType GetMinTime() const { return min_time_; }
   TickType GetMaxTime() const { return max_time_; }
@@ -50,10 +52,8 @@ class ThreadTrack : public Track {
 
   std::vector<std::shared_ptr<TimerChain>> GetAllChains() override;
 
-  void SetEventTrackColor(Color color);
-  void ClearSelectedEvents() { event_track_->ClearSelectedEvents(); }
-
-  uint32_t GetThreadId() const { return thread_id_; }
+  //  void SetEventTrackColor(Color color);
+  //void ClearSelectedEvents() { event_track_->ClearSelectedEvents(); }
 
  protected:
   void UpdateDepth(uint32_t depth) {
@@ -62,14 +62,19 @@ class ThreadTrack : public Track {
   std::shared_ptr<TimerChain> GetTimers(uint32_t depth) const;
 
  private:
+  Color GetTimerColor(const Timer& timer,
+                      bool is_selected, bool inactive) const;
   void SetTimesliceText(const Timer& timer, double elapsed_us, float min_x,
                         TextBox* text_box);
 
  protected:
   TextRenderer* text_renderer_ = nullptr;
-  std::shared_ptr<EventTrack> event_track_;
+  //  std::shared_ptr<EventTrack> event_track_;
   uint32_t depth_ = 0;
-  ThreadID thread_id_;
+  // This is the timeline/queue string, for example, "gfx".
+  std::string timeline_;
   mutable Mutex mutex_;
   std::map<int, std::shared_ptr<TimerChain>> timers_;
+
+  std::shared_ptr<StringManager> string_manager_;
 };

--- a/OrbitGl/GpuTrack.h
+++ b/OrbitGl/GpuTrack.h
@@ -21,7 +21,7 @@ class GpuTrack : public Track {
  public:
   GpuTrack(TimeGraph* time_graph,
            std::shared_ptr<StringManager> string_manager,
-           std::string_view timeline);
+           uint64_t timeline_hash);
   ~GpuTrack() override = default;
 
   // Pickable
@@ -68,8 +68,7 @@ class GpuTrack : public Track {
  protected:
   TextRenderer* text_renderer_ = nullptr;
   uint32_t depth_ = 0;
-  // This is the timeline/queue string, for example, "gfx".
-  std::string timeline_;
+  uint64_t timeline_hash_;
   mutable Mutex mutex_;
   std::map<int, std::shared_ptr<TimerChain>> timers_;
 

--- a/OrbitGl/GpuTrack.h
+++ b/OrbitGl/GpuTrack.h
@@ -1,14 +1,15 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
-#pragma once
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_GPU_TRACK_H_
+#define ORBIT_GL_GPU_TRACK_H_
 
 #include <map>
 #include <memory>
 
 #include "BlockChain.h"
 #include "CallstackTypes.h"
-//#include "EventTrack.h"
 #include "StringManager.h"
 #include "TextBox.h"
 #include "Threading.h"
@@ -52,9 +53,6 @@ class GpuTrack : public Track {
 
   std::vector<std::shared_ptr<TimerChain>> GetAllChains() override;
 
-  //  void SetEventTrackColor(Color color);
-  //void ClearSelectedEvents() { event_track_->ClearSelectedEvents(); }
-
  protected:
   void UpdateDepth(uint32_t depth) {
     if (depth > depth_) depth_ = depth;
@@ -69,7 +67,6 @@ class GpuTrack : public Track {
 
  protected:
   TextRenderer* text_renderer_ = nullptr;
-  //  std::shared_ptr<EventTrack> event_track_;
   uint32_t depth_ = 0;
   // This is the timeline/queue string, for example, "gfx".
   std::string timeline_;
@@ -78,3 +75,5 @@ class GpuTrack : public Track {
 
   std::shared_ptr<StringManager> string_manager_;
 };
+
+#endif  // ORBIT_GL_GPU_TRACK_H_

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -27,7 +27,7 @@ inline Color GetTimerColor(const Timer& timer, TimeGraph* time_graph,
   } else if (!same_tid && (inactive || !same_pid)) {
     return kInactiveColor;
   }
-  return time_graph->GetTimesliceColor(timer);
+  return time_graph->GetThreadColor(timer.m_TID);
 }
 
 inline float GetYFromDepth(const TimeGraphLayout& layout, float track_y,

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -111,16 +111,11 @@ void ThreadTrack::SetTimesliceText(const Timer& timer, double elapsed_us,
                                              .value_or(""),
                                          time.c_str());
       text_box->SetText(text);
-    } else if (timer.m_Type == Timer::GPU_ACTIVITY) {
-      std::string text = absl::StrFormat("%s; submitter: %d  %s",
-                                         time_graph_->GetStringManager()
-                                             ->Get(timer.m_UserData[0])
-                                             .value_or(""),
-                                         timer.m_TID, time.c_str());
-      text_box->SetText(text);
     } else if (!SystraceManager::Get().IsEmpty()) {
       text_box->SetText(
           SystraceManager::Get().GetFunctionName(timer.m_FunctionAddress));
+    } else {
+      CHECK(false);
     }
   }
 

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -637,8 +637,6 @@ void TimeGraph::SortTracks() {
 
   // Reorder threads once every second when capturing
   if (!Capture::IsCapturing() || m_LastThreadReorder.QueryMillis() > 1000.0) {
-    sorted_tracks_.clear();
-
     std::vector<ThreadID> sortedThreadIds;
 
     // Show threads with instrumented functions first
@@ -676,6 +674,8 @@ void TimeGraph::SortTracks() {
       sortedThreadIds = filteredThreadIds;
     }
 
+    sorted_tracks_.clear();
+    // Scheduler track should appear at the top, so we insert it first here.
     sorted_tracks_.emplace_back(GetOrCreateThreadTrack(0));
 
     // Gpu Tracks.

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -227,6 +227,11 @@ double TimeGraph::GetTimeIntervalMicro(double a_Ratio) {
 }
 
 //-----------------------------------------------------------------------------
+std::string TimeGraph::GetGpuTimeline(const Timer& timer) const {
+  return string_manager_->Get(timer.m_UserData[1]).value_or("");
+}
+
+//-----------------------------------------------------------------------------
 void TimeGraph::ProcessTimer(const Timer& a_Timer) {
   if (a_Timer.m_End > m_SessionMaxCounter) {
     m_SessionMaxCounter = a_Timer.m_End;
@@ -257,7 +262,7 @@ void TimeGraph::ProcessTimer(const Timer& a_Timer) {
 
   if (a_Timer.m_Type == Timer::GPU_ACTIVITY) {
     if (string_manager_->Contains(a_Timer.m_UserData[1])) {
-      std::string timeline = string_manager_->Get(a_Timer.m_UserData[1]).value_or("");
+      std::string timeline = GetGpuTimeline(a_Timer);
       std::shared_ptr<GpuTrack> track = GetOrCreateGpuTrack(timeline);
       track->SetName(timeline);
       track->SetLabel(timeline);
@@ -695,8 +700,12 @@ void TimeGraph::OnLeft() {
   TextBox* selection = Capture::GSelectedTextBox;
   if (selection) {
     const Timer& timer = selection->GetTimer();
-    const TextBox* left =
-        GetOrCreateThreadTrack(timer.m_TID)->GetLeft(selection);
+    const TextBox* left = nullptr;
+    if (timer.m_Type == Timer::GPU_ACTIVITY) {
+      left = GetOrCreateGpuTrack(GetGpuTimeline(timer))->GetLeft(selection);
+    } else {
+      left = GetOrCreateThreadTrack(timer.m_TID)->GetLeft(selection);
+    }
     if (left) {
       SelectLeft(left);
     }
@@ -709,8 +718,12 @@ void TimeGraph::OnRight() {
   TextBox* selection = Capture::GSelectedTextBox;
   if (selection) {
     const Timer& timer = selection->GetTimer();
-    const TextBox* right =
-        GetOrCreateThreadTrack(timer.m_TID)->GetRight(selection);
+    const TextBox* right = nullptr;
+    if (timer.m_Type == Timer::GPU_ACTIVITY) {
+      right = GetOrCreateGpuTrack(GetGpuTimeline(timer))->GetRight(selection);
+    } else {
+      right = GetOrCreateThreadTrack(timer.m_TID)->GetRight(selection);
+    }
     if (right) {
       SelectRight(right);
     }
@@ -723,7 +736,12 @@ void TimeGraph::OnUp() {
   TextBox* selection = Capture::GSelectedTextBox;
   if (selection) {
     const Timer& timer = selection->GetTimer();
-    const TextBox* up = GetOrCreateThreadTrack(timer.m_TID)->GetUp(selection);
+    const TextBox* up = nullptr;
+    if (timer.m_Type == Timer::GPU_ACTIVITY) {
+      up = GetOrCreateGpuTrack(GetGpuTimeline(timer))->GetUp(selection);
+    } else {
+      up = GetOrCreateThreadTrack(timer.m_TID)->GetUp(selection);
+    }
     if (up) {
       Select(up);
     }
@@ -736,8 +754,12 @@ void TimeGraph::OnDown() {
   TextBox* selection = Capture::GSelectedTextBox;
   if (selection) {
     const Timer& timer = selection->GetTimer();
-    const TextBox* down =
-        GetOrCreateThreadTrack(timer.m_TID)->GetDown(selection);
+    const TextBox* down = nullptr;
+    if (timer.m_Type == Timer::GPU_ACTIVITY) {
+      down = GetOrCreateGpuTrack(GetGpuTimeline(timer))->GetDown(selection);
+    } else {
+      down = GetOrCreateThreadTrack(timer.m_TID)->GetDown(selection);
+    }
     if (down) {
       Select(down);
     }

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -12,6 +12,7 @@
 #include "Core.h"
 #include "EventBuffer.h"
 #include "Geometry.h"
+#include "GpuTrack.h"
 #include "MemoryTracker.h"
 #include "StringManager.h"
 #include "TextBox.h"
@@ -108,13 +109,13 @@ class TimeGraph {
   void OnUp();
   void OnDown();
 
-  Color GetEventTrackColor(Timer timer);
-  Color GetTimesliceColor(Timer timer);
+  Color GetThreadColor(ThreadID tid) const;
   StringManager* GetStringManager() { return string_manager_.get(); }
 
  protected:
   void AddTrack(std::unique_ptr<Track> track);
   std::shared_ptr<ThreadTrack> GetOrCreateThreadTrack(ThreadID a_TID);
+  std::shared_ptr<GpuTrack> GetOrCreateGpuTrack(std::string_view timeline);
 
  private:
   TextRenderer m_TextRendererStatic;
@@ -147,6 +148,7 @@ class TimeGraph {
       m_CoreUtilizationMap;
 
   std::map<ThreadID, uint32_t> m_ThreadCountMap;
+  std::map<std::string, uint32_t> gpu_timeline_count_map_;
 
   bool m_NeedsUpdatePrimitives = false;
   bool m_DrawText = true;
@@ -160,6 +162,8 @@ class TimeGraph {
   mutable Mutex m_Mutex;
   std::vector<std::shared_ptr<Track>> tracks_;
   std::unordered_map<ThreadID, std::shared_ptr<ThreadTrack>> thread_tracks_;
+  // Mapping from timeline to GPU tracks.
+  std::unordered_map<std::string, std::shared_ptr<GpuTrack>> gpu_tracks_;
   std::vector<std::shared_ptr<Track>> sorted_tracks_;
   std::string m_ThreadFilter;
 

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -114,6 +114,7 @@ class TimeGraph {
 
  protected:
   void AddTrack(std::unique_ptr<Track> track);
+  std::string GetGpuTimeline(const Timer& timer) const;
   std::shared_ptr<ThreadTrack> GetOrCreateThreadTrack(ThreadID a_TID);
   std::shared_ptr<GpuTrack> GetOrCreateGpuTrack(std::string_view timeline);
 

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -114,9 +114,9 @@ class TimeGraph {
 
  protected:
   void AddTrack(std::unique_ptr<Track> track);
-  std::string GetGpuTimeline(const Timer& timer) const;
+  uint64_t GetGpuTimelineHash(const Timer& timer) const;
   std::shared_ptr<ThreadTrack> GetOrCreateThreadTrack(ThreadID a_TID);
-  std::shared_ptr<GpuTrack> GetOrCreateGpuTrack(std::string_view timeline);
+  std::shared_ptr<GpuTrack> GetOrCreateGpuTrack(uint64_t timeline_hash);
 
  private:
   TextRenderer m_TextRendererStatic;
@@ -149,7 +149,6 @@ class TimeGraph {
       m_CoreUtilizationMap;
 
   std::map<ThreadID, uint32_t> m_ThreadCountMap;
-  std::map<std::string, uint32_t> gpu_timeline_count_map_;
 
   bool m_NeedsUpdatePrimitives = false;
   bool m_DrawText = true;
@@ -163,8 +162,8 @@ class TimeGraph {
   mutable Mutex m_Mutex;
   std::vector<std::shared_ptr<Track>> tracks_;
   std::unordered_map<ThreadID, std::shared_ptr<ThreadTrack>> thread_tracks_;
-  // Mapping from timeline to GPU tracks.
-  std::unordered_map<std::string, std::shared_ptr<GpuTrack>> gpu_tracks_;
+  // Mapping from timeline hash to GPU tracks.
+  std::unordered_map<uint64_t, std::shared_ptr<GpuTrack>> gpu_tracks_;
   std::vector<std::shared_ptr<Track>> sorted_tracks_;
   std::string m_ThreadFilter;
 

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -11,7 +11,6 @@
 
 //-----------------------------------------------------------------------------
 Track::Track() {
-  m_ID = 0;
   m_MousePos[0] = m_MousePos[1] = Vec2(0, 0);
   m_Pos = Vec2(0, 0);
   m_Size = Vec2(0, 0);
@@ -19,9 +18,6 @@ Track::Track() {
   m_Picked = false;
   m_Moving = false;
   m_Canvas = nullptr;
-
-  label_display_mode_ = NAME_AND_TID;
-
   unsigned char alpha = 255;
   unsigned char grey = 60;
   m_Color = Color(grey, grey, grey, alpha);
@@ -72,22 +68,7 @@ void Track::Draw(GlCanvas* a_Canvas, bool a_Picking) {
   glVertex3f(x0, y1, track_z);
   glEnd();
 
-  std::string track_label;
-  switch (label_display_mode_) {
-    case NAME_AND_TID:
-      track_label = absl::StrFormat("%s [%u]", m_Name, m_ID);
-      break;
-    case TID_ONLY:
-      track_label = absl::StrFormat("[%u]", m_ID);
-      break;
-    case NAME_ONLY:
-      track_label = absl::StrFormat("%s", m_Name);
-      break;
-    case EMPTY:
-      track_label = "";
-  }
-
-  a_Canvas->AddText(track_label.c_str(), x0, y1 + label_offset + m_Size[1],
+  a_Canvas->AddText(label_.c_str(), x0, y1 + label_offset + m_Size[1],
                     text_z, Color(255, 255, 255, 255));
 
   m_Canvas = a_Canvas;

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -63,22 +63,16 @@ class Track : public Pickable {
   Vec2 GetMoveDelta() const {
     return m_Moving ? m_MousePos[1] - m_MousePos[0] : Vec2(0, 0);
   }
-  void SetName(const std::string& a_Name) { m_Name = a_Name; }
+  void SetName(const std::string& name) { name_= name; }
+  const std::string& GetName() const { return name_; }
+  void SetLabel(const std::string& label) { label_ = label; }
+  const std::string& GetLabel() const { return label_; }
 
-  enum LabelDisplayMode { NAME_AND_TID, TID_ONLY, NAME_ONLY, EMPTY };
-
-  void SetLabelDisplayMode(LabelDisplayMode label_display_mode) {
-    label_display_mode_ = label_display_mode;
-  }
-
-  const std::string& GetName() const { return m_Name; }
   void SetTimeGraph(TimeGraph* timegraph) { time_graph_ = timegraph; }
   void SetPos(float a_X, float a_Y);
   void SetY(float y);
   Vec2 GetPos() const { return m_Pos; }
   void SetSize(float a_SizeX, float a_SizeY);
-  void SetID(uint32_t a_ID) { m_ID = a_ID; }
-  uint32_t GetID() const { return m_ID; }
   void SetColor(Color a_Color) { m_Color = a_Color; }
 
   void AddChild(std::shared_ptr<Track> track) { children_.emplace_back(track); }
@@ -92,9 +86,8 @@ class Track : public Pickable {
   Vec2 m_PickingOffset;
   bool m_Picked;
   bool m_Moving;
-  std::string m_Name;
-  uint32_t m_ID;
-  LabelDisplayMode label_display_mode_;
+  std::string name_;
+  std::string label_;
   Color m_Color;
   bool m_Visible = true;
   std::atomic<uint32_t> num_timers_;


### PR DESCRIPTION
This primarily removes the hack of using a large thread id as a fake thread id for GPU tracks. This is based on the track refactoring by @pierricgimmig and is mostly achieved by introducing a new GpuTrack class parallel to ThreadTrack. 

The ordering of tracks is now changed a little to be (1) scheduling, (2) GPU tracks, (3) thread tracks sorted based on activity

As part of this clean up, a couple of changes were necessary or now possible:
* Removed m_SubmitTID member from Timer as it’s more natural to keep track of the submitting thread using the m_TID member.
* Removed m_ID (identifier) in Track class as we don’t need it and it was misused to provide the thread id for CPU thread tracks.
