### PR TITLE
Refactor DataView instanciation

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -555,68 +555,9 @@ void OrbitApp::MainTick() {
 std::string OrbitApp::GetVersion() { return OrbitVersion::GetVersion(); }
 
 //-----------------------------------------------------------------------------
-void OrbitApp::RegisterProcessesDataView(ProcessesDataView* a_Processes) {
-  assert(m_ProcessesDataView == nullptr);
-  m_ProcessesDataView = a_Processes;
-}
-
-//-----------------------------------------------------------------------------
-void OrbitApp::RegisterModulesDataView(ModulesDataView* a_Modules) {
-  assert(m_ModulesDataView == nullptr);
-  assert(m_ProcessesDataView != nullptr);
-  m_ModulesDataView = a_Modules;
-  m_ProcessesDataView->SetModulesDataView(m_ModulesDataView);
-}
-
-//-----------------------------------------------------------------------------
-void OrbitApp::RegisterFunctionsDataView(FunctionsDataView* a_Functions) {
-  m_FunctionsDataView = a_Functions;
-  m_Panels.push_back(a_Functions);
-}
-
-//-----------------------------------------------------------------------------
-void OrbitApp::RegisterLiveFunctionsDataView(
-    LiveFunctionsDataView* a_Functions) {
-  m_LiveFunctionsDataView = a_Functions;
-  m_Panels.push_back(a_Functions);
-}
-
-//-----------------------------------------------------------------------------
-void OrbitApp::RegisterCallStackDataView(CallStackDataView* a_Callstack) {
-  assert(m_CallStackDataView == nullptr);
-  m_CallStackDataView = a_Callstack;
-  m_Panels.push_back(a_Callstack);
-}
-
-//-----------------------------------------------------------------------------
-void OrbitApp::RegisterTypesDataView(TypesDataView* a_Types) {
-  m_TypesDataView = a_Types;
-  m_Panels.push_back(a_Types);
-}
-
-//-----------------------------------------------------------------------------
-void OrbitApp::RegisterGlobalsDataView(GlobalsDataView* a_Globals) {
-  m_GlobalsDataView = a_Globals;
-  m_Panels.push_back(a_Globals);
-}
-
-//-----------------------------------------------------------------------------
-void OrbitApp::RegisterSessionsDataView(SessionsDataView* a_Sessions) {
-  m_SessionsDataView = a_Sessions;
-  m_Panels.push_back(a_Sessions);
-  ListSessions();
-}
-
-//-----------------------------------------------------------------------------
 void OrbitApp::RegisterCaptureWindow(CaptureWindow* a_Capture) {
   assert(m_CaptureWindow == nullptr);
   m_CaptureWindow = a_Capture;
-}
-
-//-----------------------------------------------------------------------------
-void OrbitApp::RegisterOutputLog(LogDataView* a_Log) {
-  assert(m_Log == nullptr);
-  m_Log = a_Log;
 }
 
 //-----------------------------------------------------------------------------
@@ -635,7 +576,7 @@ void OrbitApp::AddSamplingReport(
   auto report = std::make_shared<SamplingReport>(sampling_profiler);
 
   for (SamplingReportCallback& callback : app->m_SamplingReportsCallbacks) {
-    callback(report);
+    callback(app->GetOrCreateDataView(DataViewType::CALLSTACK), report);
   }
 }
 
@@ -646,7 +587,9 @@ void OrbitApp::AddSelectionReport(
 
   for (SamplingReportCallback& callback :
        GOrbitApp->m_SelectionReportCallbacks) {
-    callback(report);
+    DataView* callstack_data_view =
+        GOrbitApp->GetOrCreateDataView(DataViewType::CALLSTACK);
+    callback(callstack_data_view, report);
   }
 }
 
@@ -1091,4 +1034,88 @@ void OrbitApp::OnRemoteModuleDebugInfo(
 void OrbitApp::LaunchRuleEditor(Function* a_Function) {
   m_RuleEditor->m_Window.Launch(a_Function);
   SendToUiNow("RuleEditor");
+}
+
+DataView* OrbitApp::GetOrCreateDataView(DataViewType type) {
+  switch (type) {
+    case DataViewType::FUNCTIONS:
+      if (!m_FunctionsDataView) {
+        m_FunctionsDataView = std::make_unique<FunctionsDataView>();
+        m_Panels.push_back(m_FunctionsDataView.get());
+      }
+      return m_FunctionsDataView.get();
+
+    case DataViewType::TYPES:
+      if (!m_TypesDataView) {
+        m_TypesDataView = std::make_unique<TypesDataView>();
+        m_Panels.push_back(m_TypesDataView.get());
+      }
+      return m_TypesDataView.get();
+
+    case DataViewType::LIVE_FUNCTIONS:
+      if (!m_LiveFunctionsDataView) {
+        m_LiveFunctionsDataView = std::make_unique<LiveFunctionsDataView>();
+        m_Panels.push_back(m_LiveFunctionsDataView.get());
+      }
+      return m_LiveFunctionsDataView.get();
+
+    case DataViewType::CALLSTACK:
+      if (!m_CallStackDataView) {
+        m_CallStackDataView = std::make_unique<CallStackDataView>();
+        m_Panels.push_back(m_CallStackDataView.get());
+      }
+      return m_CallStackDataView.get();
+
+    case DataViewType::GLOBALS:
+      if (!m_GlobalsDataView) {
+        m_GlobalsDataView = std::make_unique<GlobalsDataView>();
+        m_Panels.push_back(m_GlobalsDataView.get());
+      }
+      return m_GlobalsDataView.get();
+
+    case DataViewType::MODULES:
+      if (!m_ModulesDataView) {
+        m_ModulesDataView = std::make_unique<ModulesDataView>();
+        m_Panels.push_back(m_ModulesDataView.get());
+      }
+      return m_ModulesDataView.get();
+
+    case DataViewType::PROCESSES:
+      if (!m_ProcessesDataView) {
+        m_ProcessesDataView = std::make_unique<ProcessesDataView>();
+        m_Panels.push_back(m_ProcessesDataView.get());
+        // TODO: Remove this after ProcessesDataView is untied from
+        // ModulesDataView
+        GetOrCreateDataView(DataViewType::MODULES);
+        m_ProcessesDataView->SetModulesDataView(m_ModulesDataView.get());
+      }
+      return m_ProcessesDataView.get();
+
+    case DataViewType::SESSIONS:
+      if (!m_SessionsDataView) {
+        m_SessionsDataView = std::make_unique<SessionsDataView>();
+        m_Panels.push_back(m_SessionsDataView.get());
+      }
+      return m_SessionsDataView.get();
+
+    case DataViewType::LOG:
+      if (!m_LogDataView) {
+        m_LogDataView = std::make_unique<LogDataView>();
+        m_Panels.push_back(m_LogDataView.get());
+      }
+      return m_LogDataView.get();
+
+    case DataViewType::SAMPLING:
+      FATAL(
+          "DataViewType::SAMPLING Data View construction is not supported by"
+          "the factory.");
+
+    case DataViewType::ALL:
+      FATAL("DataViewType::ALL should not be used with the factory.");
+
+    case DataViewType::INVALID:
+      FATAL("DataViewType::INVALID should not be used with the factory.");
+  }
+
+  FATAL("Unreachable");
 }

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -17,7 +17,6 @@ CallStackDataView::CallStackDataView()
 
 //-----------------------------------------------------------------------------
 void CallStackDataView::SetAsMainInstance() {
-  GOrbitApp->RegisterCallStackDataView(this);
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/DataView.cpp
+++ b/OrbitGl/DataView.cpp
@@ -20,41 +20,6 @@
 #include "TypesDataView.h"
 
 //-----------------------------------------------------------------------------
-DataView::~DataView() {
-  if (GOrbitApp) {
-    GOrbitApp->Unregister(this);
-  }
-}
-
-//-----------------------------------------------------------------------------
-std::unique_ptr<DataView> DataView::Create(DataViewType a_Type) {
-  switch (a_Type) {
-    case DataViewType::FUNCTIONS:
-      return std::make_unique<FunctionsDataView>();
-    case DataViewType::TYPES:
-      return std::make_unique<TypesDataView>();
-    case DataViewType::LIVE_FUNCTIONS:
-      return std::make_unique<LiveFunctionsDataView>();
-    case DataViewType::CALLSTACK:
-      return std::make_unique<CallStackDataView>();
-    case DataViewType::GLOBALS:
-      return std::make_unique<GlobalsDataView>();
-    case DataViewType::MODULES:
-      return std::make_unique<ModulesDataView>();
-    case DataViewType::SAMPLING:
-      return std::make_unique<SamplingReportDataView>();
-    case DataViewType::PROCESSES:
-      return std::make_unique<ProcessesDataView>();
-    case DataViewType::SESSIONS:
-      return std::make_unique<SessionsDataView>();
-    case DataViewType::LOG:
-      return std::make_unique<LogDataView>();
-    default:
-      return nullptr;
-  }
-}
-
-//-----------------------------------------------------------------------------
 void DataView::InitSortingOrders() {
   m_SortingOrders.clear();
   for (const auto& column : GetColumns()) {

--- a/OrbitGl/DataView.h
+++ b/OrbitGl/DataView.h
@@ -34,9 +34,7 @@ class DataView {
   explicit DataView(DataViewType type)
       : m_UpdatePeriodMs(-1), m_SelectedIndex(-1), m_Type(type) {}
 
-  virtual ~DataView();
-
-  static std::unique_ptr<DataView> Create(DataViewType a_Type);
+  virtual ~DataView() = default;
 
   virtual void SetAsMainInstance() {}
   virtual const std::vector<Column>& GetColumns() = 0;

--- a/OrbitGl/DataViewFactory.h
+++ b/OrbitGl/DataViewFactory.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_DATA_VIEW_FACTORY_H_
+#define ORBIT_GL_DATA_VIEW_FACTORY_H_
+
+#include <memory>
+
+#include "DataView.h"
+
+// Interface to DataView factory.
+// This class establishes interface to data view factory
+class DataViewFactory {
+ public:
+  DataViewFactory() = default;
+  virtual ~DataViewFactory() = default;
+
+  // Creates DataView of specified type. The created data view
+  // exists in application scope. The implementation will create
+  // a DataView of specified type or return exiting one. The assumption
+  // here is that there is only one of each type of data view needed.
+  //
+  // Note that SamplingReportDataView should not be created using this method
+  // since it is owned and created by SamplingReport.
+  virtual DataView* GetOrCreateDataView(DataViewType type) = 0;
+};
+
+#endif  // ORBIT_GL_DATA_VIEW_FACTORY_H_

--- a/OrbitGl/DataViewTypes.h
+++ b/OrbitGl/DataViewTypes.h
@@ -4,7 +4,7 @@
 #pragma once
 
 //-----------------------------------------------------------------------------
-enum DataViewType {
+enum class DataViewType {
   FUNCTIONS,
   LIVE_FUNCTIONS,
   CALLSTACK,
@@ -13,7 +13,6 @@ enum DataViewType {
   PROCESSES,
   MODULES,
   SAMPLING,
-  PDB,
   SESSIONS,
   LOG,
   ALL,

--- a/OrbitGl/FunctionsDataView.cpp
+++ b/OrbitGl/FunctionsDataView.cpp
@@ -16,7 +16,6 @@
 
 //-----------------------------------------------------------------------------
 FunctionsDataView::FunctionsDataView() : DataView(DataViewType::FUNCTIONS) {
-  GOrbitApp->RegisterFunctionsDataView(this);
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/GlobalsDataView.cpp
+++ b/OrbitGl/GlobalsDataView.cpp
@@ -16,7 +16,6 @@
 //-----------------------------------------------------------------------------
 GlobalsDataView::GlobalsDataView() : DataView(DataViewType::GLOBALS) {
   OnDataChanged();
-  GOrbitApp->RegisterGlobalsDataView(this);
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/LiveFunctionsDataView.cpp
+++ b/OrbitGl/LiveFunctionsDataView.cpp
@@ -15,7 +15,6 @@
 //-----------------------------------------------------------------------------
 LiveFunctionsDataView::LiveFunctionsDataView()
     : DataView(DataViewType::LIVE_FUNCTIONS) {
-  GOrbitApp->RegisterLiveFunctionsDataView(this);
   m_UpdatePeriodMs = 300;
   OnDataChanged();
 }

--- a/OrbitGl/LogDataView.cpp
+++ b/OrbitGl/LogDataView.cpp
@@ -11,7 +11,6 @@
 
 //-----------------------------------------------------------------------------
 LogDataView::LogDataView() : DataView(DataViewType::LOG) {
-  GOrbitApp->RegisterOutputLog(this);
   GTcpServer->AddCallback(Msg_OrbitLog, [=](const Message& a_Msg) {
     this->OnReceiveMessage(a_Msg);
   });

--- a/OrbitGl/ModulesDataView.cpp
+++ b/OrbitGl/ModulesDataView.cpp
@@ -10,7 +10,6 @@
 
 //-----------------------------------------------------------------------------
 ModulesDataView::ModulesDataView() : DataView(DataViewType::MODULES) {
-  GOrbitApp->RegisterModulesDataView(this);
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/OpenGl.h
+++ b/OrbitGl/OpenGl.h
@@ -15,8 +15,6 @@
 #include <GL/glu.h>
 #include <freetype-gl/freetype-gl.h>
 
-#include "Core.h"
-
 // clang-format off
 #include <GL/gl.h>
 // clang-format on

--- a/OrbitGl/ProcessesDataView.cpp
+++ b/OrbitGl/ProcessesDataView.cpp
@@ -17,7 +17,6 @@
 
 //-----------------------------------------------------------------------------
 ProcessesDataView::ProcessesDataView() : DataView(DataViewType::PROCESSES) {
-  GOrbitApp->RegisterProcessesDataView(this);
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/SamplingReport.cpp
+++ b/OrbitGl/SamplingReport.cpp
@@ -31,12 +31,11 @@ void SamplingReport::FillReport() {
 
     if (tid == 0 && !m_Profiler->GetGenerateSummary()) continue;
 
-    std::shared_ptr<SamplingReportDataView> threadReport =
-        std::make_shared<SamplingReportDataView>();
-    threadReport->SetSampledFunctions(threadSampleData->m_SampleReport);
-    threadReport->SetThreadID(tid);
-    threadReport->SetSamplingReport(this);
-    m_ThreadReports.push_back(threadReport);
+    SamplingReportDataView threadReport;
+    threadReport.SetSampledFunctions(threadSampleData->m_SampleReport);
+    threadReport.SetThreadID(tid);
+    threadReport.SetSamplingReport(this);
+    m_ThreadReports.push_back(std::move(threadReport));
   }
 }
 

--- a/OrbitGl/SamplingReport.h
+++ b/OrbitGl/SamplingReport.h
@@ -18,8 +18,7 @@ class SamplingReport {
 
   void FillReport();
   std::shared_ptr<SamplingProfiler> GetProfiler() const { return m_Profiler; }
-  const std::vector<std::shared_ptr<SamplingReportDataView>>&
-  GetThreadReports() {
+  std::vector<SamplingReportDataView>& GetThreadReports() {
     return m_ThreadReports;
   }
   void SetCallstackDataView(class CallStackDataView* a_DataView) {
@@ -39,7 +38,7 @@ class SamplingReport {
 
  protected:
   std::shared_ptr<SamplingProfiler> m_Profiler;
-  std::vector<std::shared_ptr<SamplingReportDataView>> m_ThreadReports;
+  std::vector<SamplingReportDataView> m_ThreadReports;
   CallStackDataView* m_CallstackDataView;
 
   uint64_t m_SelectedAddress;

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -224,7 +224,7 @@ void SamplingReportDataView::OnSelect(int a_Index) {
 
 //-----------------------------------------------------------------------------
 void SamplingReportDataView::LinkDataView(DataView* a_DataView) {
-  if (a_DataView->GetType() == CALLSTACK) {
+  if (a_DataView->GetType() == DataViewType::CALLSTACK) {
     m_CallstackDataView = static_cast<CallStackDataView*>(a_DataView);
     m_SamplingReport->SetCallstackDataView(m_CallstackDataView);
   }

--- a/OrbitGl/SessionsDataView.cpp
+++ b/OrbitGl/SessionsDataView.cpp
@@ -21,7 +21,6 @@
 
 //-----------------------------------------------------------------------------
 SessionsDataView::SessionsDataView() : DataView(DataViewType::SESSIONS) {
-  GOrbitApp->RegisterSessionsDataView(this);
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/TextRenderer.h
+++ b/OrbitGl/TextRenderer.h
@@ -8,7 +8,6 @@
 #include "OpenGl.h"
 #include "Platform.h"
 #include "TextBox.h"
-#include "freetype-gl/freetype-gl.h"
 #include "mat4.h"
 
 namespace ftgl {

--- a/OrbitGl/TypesDataView.cpp
+++ b/OrbitGl/TypesDataView.cpp
@@ -18,7 +18,6 @@
 //-----------------------------------------------------------------------------
 TypesDataView::TypesDataView() : DataView(DataViewType::TYPES) {
   OnDataChanged();
-  GOrbitApp->RegisterTypesDataView(this);
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/shader.cpp
+++ b/OrbitGl/shader.cpp
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "Core.h"
 #include "OpenGl.h"
 
 #ifdef __cplusplus

--- a/OrbitQt/orbitcodeeditor.cpp
+++ b/OrbitQt/orbitcodeeditor.cpp
@@ -48,6 +48,12 @@
 **
 ****************************************************************************/
 
+// This needs to be first because if it is not GL/glew.h
+// complains about being included after gl.h
+// clang-format off
+#include "OpenGl.h"
+// clang-format on
+
 #include "orbitcodeeditor.h"
 
 #include <QPushButton>
@@ -59,7 +65,7 @@
 #include "../OrbitCore/Path.h"
 #include "../OrbitCore/PrintVar.h"
 #include "../OrbitCore/Utils.h"
-#include "../OrbitGl/App.h"
+#include "App.h"
 #include "absl/strings/str_format.h"
 
 OrbitCodeEditor* OrbitCodeEditor::GFileMapEditor;

--- a/OrbitQt/orbitdataviewpanel.cpp
+++ b/OrbitQt/orbitdataviewpanel.cpp
@@ -19,11 +19,12 @@ OrbitDataViewPanel::OrbitDataViewPanel(QWidget* parent)
 OrbitDataViewPanel::~OrbitDataViewPanel() { delete ui; }
 
 //-----------------------------------------------------------------------------
-void OrbitDataViewPanel::Initialize(DataViewType a_Type,
-                                    bool a_IsMainInstance) {
-  ui->treeView->Initialize(a_Type);
+void OrbitDataViewPanel::Initialize(DataView* data_view,
+                                    SelectionType selection_type,
+                                    FontType font_type, bool is_main_instance) {
+  ui->treeView->Initialize(data_view, selection_type, font_type);
 
-  if (a_IsMainInstance) {
+  if (is_main_instance) {
     ui->treeView->GetModel()->GetDataView()->SetAsMainInstance();
   }
 
@@ -46,8 +47,8 @@ void OrbitDataViewPanel::Link(OrbitDataViewPanel* a_Panel) {
 void OrbitDataViewPanel::Refresh() { ui->treeView->Refresh(); }
 
 //-----------------------------------------------------------------------------
-void OrbitDataViewPanel::SetDataModel(std::shared_ptr<DataView> a_Model) {
-  ui->treeView->SetDataModel(std::move(a_Model));
+void OrbitDataViewPanel::SetDataModel(DataView* model) {
+  ui->treeView->SetDataModel(model);
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitQt/orbitdataviewpanel.h
+++ b/OrbitQt/orbitdataviewpanel.h
@@ -6,6 +6,7 @@
 #include <QWidget>
 
 #include "orbittablemodel.h"
+#include "types.h"
 
 namespace Ui {
 class OrbitDataViewPanel;
@@ -18,10 +19,11 @@ class OrbitDataViewPanel : public QWidget {
   explicit OrbitDataViewPanel(QWidget* parent = nullptr);
   ~OrbitDataViewPanel() override;
 
-  void Initialize(DataViewType a_Type, bool a_MainInstance = true);
+  void Initialize(DataView* data_view, SelectionType selection_type,
+                  FontType font_type, bool is_main_instance = true);
   void Link(OrbitDataViewPanel* a_Panel);
   void Refresh();
-  void SetDataModel(std::shared_ptr<DataView> a_Model);
+  void SetDataModel(DataView* model);
   void SetFilter(const QString& a_Filter);
   void Select(int a_Row);
   class OrbitTreeView* GetTreeView();

--- a/OrbitQt/orbitglwidgetwithheader.cpp
+++ b/OrbitQt/orbitglwidgetwithheader.cpp
@@ -4,6 +4,11 @@
 
 #include "orbitglwidgetwithheader.h"
 
+// This needs to be first because if it is not GL/glew.h
+// complains about being included after gl.h
+// clang-format off
+#include "OpenGl.h"
+// clang-format on
 #include "ui_orbitglwidgetwithheader.h"
 
 //-----------------------------------------------------------------------------

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -9,7 +9,7 @@
 #include <thread>
 
 #include "ApplicationOptions.h"
-#include "DataViewTypes.h"
+#include "CallStackDataView.h"
 
 namespace Ui {
 class OrbitMainWindow;
@@ -28,11 +28,13 @@ class OrbitMainWindow : public QMainWindow {
   void OnRefreshDataViewPanels(DataViewType a_Type);
   void UpdatePanel(DataViewType a_Type);
   void OnNewSamplingReport(
-      std::shared_ptr<class SamplingReport> a_SamplingReport);
+      DataView* callstack_data_view,
+      std::shared_ptr<class SamplingReport> sampling_report);
   void CreateSamplingTab();
   void CreateSelectionTab();
   void CreatePluginTabs();
-  void OnNewSelection(std::shared_ptr<class SamplingReport> a_SamplingReport);
+  void OnNewSelection(DataView* callstack_data_view,
+                      std::shared_ptr<class SamplingReport> sampling_report);
   void OnReceiveMessage(const std::string& message);
   void OnAddToWatch(const class Variable* a_Variable);
   std::string OnGetSaveFileName(const std::string& extension);

--- a/OrbitQt/orbitsamplingreport.h
+++ b/OrbitQt/orbitsamplingreport.h
@@ -6,6 +6,8 @@
 #include <QWidget>
 #include <memory>
 
+#include "CallStackDataView.h"
+
 namespace Ui {
 class OrbitSamplingReport;
 }
@@ -17,7 +19,8 @@ class OrbitSamplingReport : public QWidget {
   explicit OrbitSamplingReport(QWidget* parent = nullptr);
   ~OrbitSamplingReport() override;
 
-  void Initialize(std::shared_ptr<class SamplingReport> a_Report);
+  void Initialize(DataView* callstack_data_view,
+                  std::shared_ptr<class SamplingReport> report);
 
  protected:
   void Refresh();

--- a/OrbitQt/orbittablemodel.cpp
+++ b/OrbitQt/orbittablemodel.cpp
@@ -8,16 +8,11 @@
 #include <memory>
 
 //-----------------------------------------------------------------------------
-OrbitTableModel::OrbitTableModel(DataViewType a_Type, QObject* parent)
+OrbitTableModel::OrbitTableModel(DataView* data_view, bool alternate_row_color,
+                                 QObject* parent)
     : QAbstractTableModel(parent),
-      m_DataView(nullptr),
-      m_AlternateRowColor(true) {
-  m_DataView = DataView::Create(a_Type);
-
-  if (a_Type == DataViewType::LOG) {
-    m_AlternateRowColor = false;
-  }
-}
+      m_DataView(data_view),
+      m_AlternateRowColor(alternate_row_color) {}
 
 //-----------------------------------------------------------------------------
 OrbitTableModel::OrbitTableModel(QObject* parent)

--- a/OrbitQt/orbittablemodel.h
+++ b/OrbitQt/orbittablemodel.h
@@ -7,13 +7,14 @@
 #include <memory>
 #include <utility>
 
-#include "../OrbitGl/DataView.h"
+#include "DataView.h"
 
 //-----------------------------------------------------------------------------
 class OrbitTableModel : public QAbstractTableModel {
   Q_OBJECT
  public:
-  explicit OrbitTableModel(DataViewType a_Type, QObject* parent = nullptr);
+  explicit OrbitTableModel(DataView* data_view, bool alternate_row_color = true,
+                           QObject* parent = nullptr);
   explicit OrbitTableModel(QObject* parent = nullptr);
   ~OrbitTableModel() override;
 
@@ -30,10 +31,8 @@ class OrbitTableModel : public QAbstractTableModel {
   QModelIndex CreateIndex(int a_Row, int a_Column) {
     return createIndex(a_Row, a_Column);
   }
-  std::shared_ptr<DataView> GetDataView() { return m_DataView; }
-  void SetDataView(std::shared_ptr<DataView> a_Model) {
-    m_DataView = std::move(a_Model);
-  }
+  DataView* GetDataView() { return m_DataView; }
+  void SetDataView(DataView* model) { m_DataView = model; }
   bool IsSortingAllowed() { return GetDataView()->IsSortingAllowed(); }
   std::pair<int, Qt::SortOrder> GetDefaultSortingColumnAndOrder();
 
@@ -42,6 +41,6 @@ class OrbitTableModel : public QAbstractTableModel {
   void OnClicked(const QModelIndex& index);
 
  protected:
-  std::shared_ptr<DataView> m_DataView;
+  DataView* m_DataView;
   bool m_AlternateRowColor;
 };

--- a/OrbitQt/orbittreeview.h
+++ b/OrbitQt/orbittreeview.h
@@ -9,13 +9,15 @@
 
 #include "orbitglwidget.h"
 #include "orbittablemodel.h"
+#include "types.h"
 
 class OrbitTreeView : public QTreeView {
   Q_OBJECT
  public:
   explicit OrbitTreeView(QWidget* parent = nullptr);
-  void Initialize(DataViewType a_Type);
-  void SetDataModel(std::shared_ptr<DataView> a_Model);
+  void Initialize(DataView* data_view, SelectionType selection_type,
+                  FontType font_type);
+  void SetDataModel(DataView* model);
   void OnFilter(const QString& a_Filter);
   void Select(int a_Row);
   void Refresh();

--- a/OrbitQt/processlauncherwidget.cpp
+++ b/OrbitQt/processlauncherwidget.cpp
@@ -4,7 +4,7 @@
 #include <QLineEdit>
 
 #include "../OrbitCore/Params.h"
-#include "../OrbitGl/App.h"
+#include "App.h"
 #include "ui_processlauncherwidget.h"
 
 ProcessLauncherWidget::ProcessLauncherWidget(QWidget* parent)
@@ -13,11 +13,6 @@ ProcessLauncherWidget::ProcessLauncherWidget(QWidget* parent)
   ui->ProcessComboBox->lineEdit()->setPlaceholderText("Process");
   ui->WorkingDirComboBox->lineEdit()->setPlaceholderText("Working Directory");
   ui->ArgumentsComboBox->lineEdit()->setPlaceholderText("Arguments");
-  ui->LiveProcessList->Initialize(DataViewType::PROCESSES);
-
-  if (GParams.m_ProcessFilter != "") {
-    ui->LiveProcessList->SetFilter(GParams.m_ProcessFilter.c_str());
-  }
 
   ui->gridLayout_2->setColumnStretch(0, 90);
   ui->checkBoxPause->setChecked(GParams.m_StartPaused);
@@ -26,6 +21,15 @@ ProcessLauncherWidget::ProcessLauncherWidget(QWidget* parent)
 }
 
 ProcessLauncherWidget::~ProcessLauncherWidget() { delete ui; }
+
+void ProcessLauncherWidget::SetDataView(DataView* data_view) {
+  ui->LiveProcessList->Initialize(data_view, SelectionType::kDefault,
+                                  FontType::kDefault);
+
+  if (GParams.m_ProcessFilter != "") {
+    ui->LiveProcessList->SetFilter(GParams.m_ProcessFilter.c_str());
+  }
+}
 
 void ProcessLauncherWidget::Refresh() { ui->LiveProcessList->Refresh(); }
 

--- a/OrbitQt/processlauncherwidget.h
+++ b/OrbitQt/processlauncherwidget.h
@@ -3,6 +3,8 @@
 
 #include <QWidget>
 
+#include "DataView.h"
+
 namespace Ui {
 class ProcessLauncherWidget;
 }
@@ -15,6 +17,7 @@ class ProcessLauncherWidget : public QWidget {
   ~ProcessLauncherWidget() override;
 
   void Refresh();
+  void SetDataView(DataView* data_view);
   void SetProcessParams();
   void UpdateProcessParams();
 

--- a/OrbitQt/types.h
+++ b/OrbitQt/types.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_QT_TYPES_H_
+#define ORBIT_QT_TYPES_H_
+
+enum class SelectionType {
+  kDefault,
+  kExtended,
+};
+
+enum class FontType {
+  kDefault,
+  kFixed,
+};
+
+#endif  // ORBIT_QT_TYPES_H_

--- a/cmake/FindDIA2Dump.cmake
+++ b/cmake/FindDIA2Dump.cmake
@@ -19,6 +19,8 @@ target_link_libraries(DIA2Dump PUBLIC DIASDK::DIASDK)
 target_link_libraries(
   DIA2Dump PUBLIC multicore::multicore concurrentqueue::concurrentqueue
                   oqpi::oqpi xxHash::xxHash cereal::cereal)
-target_include_directories(DIA2Dump PRIVATE "OrbitCore/" "OrbitBase/include/")
+target_include_directories(DIA2Dump PRIVATE "OrbitCore/"
+	                                    "OrbitBase/include/"
+					    "external/gte")
 
 add_library(DIA2Dump::DIA2Dump ALIAS DIA2Dump)


### PR DESCRIPTION
1. Introduce DataViewFactory, it is responsible for creating
   DataViews of almost all types, the only notable exception
   is SamplingReportDataView which is created by SamplingReport
2. Establish explicit ownership of DataViews in OrbitApp. It
   implements DataViewFactory.
3. DataViews are now created in OrbitMainWindows using the factory
   and passed to corresponding widgets.
4. Register methods are removed - they used to be called from DataView
   constructors using GOrbitApp global variable, since OrbitApp is
   currently is the factory there is no longer need in this callback.

Test: build, run app and run a capture session.