### PR TITLE
add Upload Dumps on Crash option

### DIFF
--- a/OrbitCore/CoreApp.h
+++ b/OrbitCore/CoreApp.h
@@ -1,6 +1,7 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #pragma once
 
 #include <memory>

--- a/OrbitCore/CoreApp.h
+++ b/OrbitCore/CoreApp.h
@@ -37,6 +37,7 @@ class CoreApp {
   virtual bool GetUnsafeHookingEnabled() { return false; }
   virtual bool GetSamplingEnabled() { return false; }
   virtual bool GetOutputDebugStringEnabled() { return false; }
+  virtual bool GetUploadDumpsToServerEnabled() const { return false; }
   virtual void UpdateVariable(class Variable* /*a_Variable*/) {}
   virtual void Disassemble(const std::string& /*a_FunctionName*/,
                            uint64_t /*a_VirtualAddress*/,

--- a/OrbitCore/CrashHandler.cpp
+++ b/OrbitCore/CrashHandler.cpp
@@ -1,6 +1,6 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #include "CrashHandler.h"
 

--- a/OrbitCore/CrashHandler.h
+++ b/OrbitCore/CrashHandler.h
@@ -1,6 +1,7 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #ifndef ORBIT_CORE_CRASH_HANDLER_H_
 #define ORBIT_CORE_CRASH_HANDLER_H_
 

--- a/OrbitCore/CrashHandler.h
+++ b/OrbitCore/CrashHandler.h
@@ -4,6 +4,7 @@
 #ifndef ORBIT_CORE_CRASH_HANDLER_H_
 #define ORBIT_CORE_CRASH_HANDLER_H_
 
+#include "client/crash_report_database.h"
 #include <client/crashpad_client.h>
 
 #include <string>
@@ -12,13 +13,14 @@ class CrashHandler {
  public:
   explicit CrashHandler(const std::string& dump_path,
                         const std::string& handler_path,
-                        const std::string& crash_server_url,
-                        bool is_upload_enabled);
+                        const std::string& crash_server_url);
   void DumpWithoutCrash() const;
+  void SetUploadsEnabled(bool is_upload_enabled);
 
  private:
   inline static bool is_init_{false};
   crashpad::CrashpadClient crashpad_client_;
+  std::unique_ptr<crashpad::CrashReportDatabase> crash_report_db_;
 };
 
 #endif  // ORBIT_CORE_CRASH_HANDLER_H_

--- a/OrbitCore/Params.cpp
+++ b/OrbitCore/Params.cpp
@@ -29,6 +29,7 @@ Params::Params()
       m_FindFileAndLineInfo(true),
       m_BpftraceCallstacks(false),
       m_SystemWideScheduling(true),
+      m_UploadDumpsToServer(false),
       m_MaxNumTimers(1000000),
       m_FontSize(14.f),
       m_Port(44766),
@@ -59,6 +60,7 @@ ORBIT_SERIALIZE(Params, 16) {
   ORBIT_NVP_VAL(13, m_ProcessFilter);
   ORBIT_NVP_VAL(14, m_BpftraceCallstacks);
   ORBIT_NVP_VAL(15, m_SystemWideScheduling);
+  ORBIT_NVP_VAL(15, m_UploadDumpsToServer);
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitCore/Params.cpp
+++ b/OrbitCore/Params.cpp
@@ -1,6 +1,6 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #include "Params.h"
 

--- a/OrbitCore/Params.h
+++ b/OrbitCore/Params.h
@@ -1,6 +1,7 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #pragma once
 
 #include <string>

--- a/OrbitCore/Params.h
+++ b/OrbitCore/Params.h
@@ -31,6 +31,7 @@ struct Params {
   bool m_BpftraceCallstacks;
   bool m_SystemWideScheduling;
   bool m_UseBpftrace;
+  bool m_UploadDumpsToServer;
   int m_MaxNumTimers;
   float m_FontSize;
   int m_Port;

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -1,6 +1,6 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 // clang-format off
 #include "OrbitAsio.h"

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -293,6 +293,10 @@ bool OrbitApp::Init(ApplicationOptions&& options) {
 
 //-----------------------------------------------------------------------------
 void OrbitApp::PostInit() {
+  if (options_.crash_handler != nullptr) {
+    options_.crash_handler->SetUploadsEnabled(GetUploadDumpsToServerEnabled());
+  }
+
   if (!options_.asio_server_address.empty()) {
     GTcpClient = std::make_unique<TcpClient>();
     GTcpClient->AddMainThreadCallback(
@@ -968,7 +972,11 @@ bool OrbitApp::GetUploadDumpsToServerEnabled() const {
 
 //-----------------------------------------------------------------------------
 void OrbitApp::EnableUploadDumpsToServer(bool a_Value) {
+  if (options_.crash_handler != nullptr) {
+    options_.crash_handler->SetUploadsEnabled(a_Value);
+  }
   GParams.m_UploadDumpsToServer = a_Value;
+  GParams.Save();
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -961,6 +961,17 @@ void OrbitApp::OnProcessSelected(uint32_t pid) {
   }
 }
 
+//-----------------------------------------------------------------------------
+bool OrbitApp::GetUploadDumpsToServerEnabled() const {
+  return GParams.m_UploadDumpsToServer;
+}
+
+//-----------------------------------------------------------------------------
+void OrbitApp::EnableUploadDumpsToServer(bool a_Value) {
+  GParams.m_UploadDumpsToServer = a_Value;
+}
+
+//-----------------------------------------------------------------------------
 void OrbitApp::OnRemoteProcess(const Message& a_Message) {
   std::istringstream buffer(a_Message.GetDataAsString());
   cereal::JSONInputArchive inputAr(buffer);

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -194,6 +194,9 @@ class OrbitApp final : public CoreApp, public DataViewFactory {
   void EnableOutputDebugString(bool a_Value);
   bool GetOutputDebugStringEnabled() override;
 
+  void EnableUploadDumpsToServer(bool a_Value);
+  bool GetUploadDumpsToServerEnabled() const override;
+
   void RequestThaw() { m_NeedsThawing = true; }
   void OnRemoteProcess(const Message& a_Message);
   void OnRemoteProcessList(const Message& a_Message);

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -1,6 +1,7 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #pragma once
 
 #include <functional>

--- a/OrbitGl/ApplicationOptions.h
+++ b/OrbitGl/ApplicationOptions.h
@@ -7,6 +7,8 @@
 
 #include <string>
 
+#include "CrashHandler.h"
+
 // The structure used to store Orbit Client Application options
 // The default values are set by main() and passed over to App
 // class initialization method.
@@ -15,6 +17,8 @@ struct ApplicationOptions {
   std::string asio_server_address;
   // GRPC connection string
   std::string grpc_server_address;
+  
+  CrashHandler* crash_handler = nullptr;
 };
 
 #endif  // ORBIT_GL_APPLICATION_OPTIONS_H_

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -63,6 +63,7 @@ int main(int argc, char* argv[]) {
   CrashHandler crash_handler(dump_path, handler_path, crash_server_url);
 
   ApplicationOptions options;
+  options.crash_handler = &crash_handler;
 
   ParseLegacyCommandLine(argc, argv, &options);
   std::string remote = absl::GetFlag(FLAGS_remote);
@@ -130,7 +131,6 @@ int main(int argc, char* argv[]) {
   }
 
   OrbitMainWindow w(&app, std::move(options));
-  crash_handler.SetUploadsEnabled(GOrbitApp->GetUploadDumpsToServerEnabled());
 
   if (!w.IsHeadless()) {
     w.showMaximized();

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -1,6 +1,6 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #include <QApplication>
 #include <QDir>

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -24,10 +24,6 @@ ABSL_FLAG(uint16_t, asio_port, 44766,
 ABSL_FLAG(uint16_t, grpc_port, 44755,
           "The service's GRPC server port (use default value if unsure)");
 
-// TODO: Remove this flag once we have a dialog with user
-ABSL_FLAG(bool, upload_dumps_to_server, false,
-          "Upload dumps to collection server when crashes");
-
 // TODO: remove this once we deprecated legacy parameters
 static void ParseLegacyCommandLine(int argc, char* argv[],
                                    ApplicationOptions* options) {
@@ -64,8 +60,7 @@ int main(int argc, char* argv[]) {
                                        .toStdString();
   const std::string crash_server_url =
       "https://clients2.google.com/cr/staging_report";
-  const CrashHandler crash_handler(dump_path, handler_path, crash_server_url,
-                                   absl::GetFlag(FLAGS_upload_dumps_to_server));
+  CrashHandler crash_handler(dump_path, handler_path, crash_server_url);
 
   ApplicationOptions options;
 
@@ -135,6 +130,7 @@ int main(int argc, char* argv[]) {
   }
 
   OrbitMainWindow w(&app, std::move(options));
+  crash_handler.SetUploadsEnabled(GOrbitApp->GetUploadDumpsToServerEnabled());
 
   if (!w.IsHeadless()) {
     w.showMaximized();

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -149,6 +149,8 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App,
   ui->actionEnable_Sampling->setChecked(GOrbitApp->GetSamplingEnabled());
   ui->actionOutputDebugString->setChecked(
       GOrbitApp->GetOutputDebugStringEnabled());
+  ui->actionUploadDumpsToServer->setChecked(
+      GOrbitApp->GetUploadDumpsToServerEnabled());
 
   CreateSamplingTab();
   CreateSelectionTab();
@@ -665,3 +667,8 @@ void OrbitMainWindow::on_actionOutputDebugString_triggered(bool checked) {
 
 //-----------------------------------------------------------------------------
 void OrbitMainWindow::on_actionRule_Editor_triggered() { m_RuleEditor->show(); }
+
+//-----------------------------------------------------------------------------
+void OrbitMainWindow::on_actionUploadDumpsToServer_triggered(bool checked) {
+  GOrbitApp->EnableUploadDumpsToServer(checked);
+}

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -1,6 +1,6 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #include "orbitmainwindow.h"
 

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -90,6 +90,8 @@ class OrbitMainWindow : public QMainWindow {
 
   void on_actionRule_Editor_triggered();
 
+  void on_actionUploadDumpsToServer_triggered(bool checked);
+
  private:
   void StartMainTimer();
   void GetLicense();

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -1,6 +1,7 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #pragma once
 
 #include <QMainWindow>

--- a/OrbitQt/orbitmainwindow.ui
+++ b/OrbitQt/orbitmainwindow.ui
@@ -283,6 +283,7 @@
     <addaction name="actionEnable_Unreal_Support"/>
     <addaction name="actionAllow_Unsafe_Hooking"/>
     <addaction name="actionOutputDebugString"/>
+    <addaction name="actionUploadDumpsToServer"/>
    </widget>
    <widget class="QMenu" name="menuTools">
     <property name="title">
@@ -418,6 +419,14 @@
    </property>
    <property name="text">
     <string>OutputDebugString</string>
+   </property>
+  </action>
+  <action name="actionUploadDumpsToServer">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Upload Dumps on Crash</string>
    </property>
   </action>
   <action name="actionRule_Editor">


### PR DESCRIPTION
Added `Upload Dumps on Crash` to drop-down Options menu. This setting is saved as m_UploadDumpsToServer in config.xml. Default value is false.

Moved SetUploadsEnabled call from constructor to the separate function that called a bit later (after config.xml is read when it's possible to read options). In this case all dumps that created between these 2 events (CrashHandler created and config.xml read) will be written only in the database and not send to server. 