### PR TITLE
Untie ProcessesDataView from ModulesDataView

### DIFF
--- a/OrbitCore/Params.cpp
+++ b/OrbitCore/Params.cpp
@@ -27,7 +27,6 @@ Params::Params()
       m_AllowUnsafeHooking(false),
       m_HookOutputDebugString(false),
       m_FindFileAndLineInfo(true),
-      m_AutoReleasePdb(false),
       m_BpftraceCallstacks(false),
       m_SystemWideScheduling(true),
       m_MaxNumTimers(1000000),
@@ -57,7 +56,6 @@ ORBIT_SERIALIZE(Params, 16) {
   ORBIT_NVP_VAL(10, m_Arguments);
   ORBIT_NVP_VAL(10, m_WorkingDirectory);
   ORBIT_NVP_VAL(11, m_FindFileAndLineInfo);
-  ORBIT_NVP_VAL(12, m_AutoReleasePdb);
   ORBIT_NVP_VAL(13, m_ProcessFilter);
   ORBIT_NVP_VAL(14, m_BpftraceCallstacks);
   ORBIT_NVP_VAL(15, m_SystemWideScheduling);

--- a/OrbitCore/Params.h
+++ b/OrbitCore/Params.h
@@ -28,7 +28,6 @@ struct Params {
   bool m_AllowUnsafeHooking;
   bool m_HookOutputDebugString;
   bool m_FindFileAndLineInfo;
-  bool m_AutoReleasePdb;
   bool m_BpftraceCallstacks;
   bool m_SystemWideScheduling;
   bool m_UseBpftrace;

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -30,6 +30,7 @@
 #include "SymbolHelper.h"
 #include "Threading.h"
 #include "TypesDataView.h"
+#include "absl/container/flat_hash_map.h"
 #include "grpcpp/grpcpp.h"
 
 #if defined(_WIN32)
@@ -96,6 +97,8 @@ class OrbitApp final : public CoreApp, public DataViewFactory {
 
   void RegisterCaptureWindow(class CaptureWindow* a_Capture);
   void RegisterRuleEditor(RuleEditor* a_RuleEditor);
+
+  void OnProcessSelected(uint32_t pid);
 
   void Unregister(class DataView* a_Model);
   bool SelectProcess(const std::string& a_Process);
@@ -210,7 +213,14 @@ class OrbitApp final : public CoreApp, public DataViewFactory {
   DataView* GetOrCreateDataView(DataViewType type) override;
 
  private:
+  // TODO(dimitry): Move this to process manager
+  std::shared_ptr<Process> FindProcessByPid(uint32_t pid);
+  void UpdateProcess(const std::shared_ptr<Process>& process);
+
   ApplicationOptions options_;
+
+  absl::Mutex process_map_mutex_;
+  absl::flat_hash_map<uint32_t, std::shared_ptr<Process>> process_map_;
 
   std::vector<std::string> m_Arguments;
   std::vector<RefreshCallback> m_RefreshCallbacks;

--- a/OrbitGl/ProcessesDataView.h
+++ b/OrbitGl/ProcessesDataView.h
@@ -10,6 +10,8 @@ class ProcessesDataView final : public DataView {
  public:
   ProcessesDataView();
 
+  void SetSelectionListener(
+      const std::function<void(uint32_t)>& selection_listener);
   const std::vector<Column>& GetColumns() override;
   int GetDefaultSortingColumn() override { return COLUMN_CPU; }
   std::string GetValue(int row, int column) override;
@@ -21,11 +23,7 @@ class ProcessesDataView final : public DataView {
   std::shared_ptr<Process> SelectProcess(uint32_t process_id);
   void SetProcessList(
       const std::vector<std::shared_ptr<Process>>& process_list);
-  void UpdateProcess(const std::shared_ptr<Process>& process);
-  void SetModulesDataView(class ModulesDataView* modules_data_view) {
-    modules_data_view_ = modules_data_view;
-  }
-  void UpdateModuleDataView(const std::shared_ptr<Process>& process);
+  uint32_t GetSelectedProcessId() const;
 
  protected:
   void DoSort() override;
@@ -35,11 +33,11 @@ class ProcessesDataView final : public DataView {
   void UpdateProcessList();
   void SetSelectedItem();
   std::shared_ptr<Process> GetProcess(uint32_t row) const;
-  void ClearSelectedProcess();
 
   std::vector<std::shared_ptr<Process>> process_list_;
-  ModulesDataView* modules_data_view_ = nullptr;
   uint32_t selected_process_id_;
+
+  std::function<void(uint32_t)> selection_listener_;
 
   enum ColumnIndex {
     COLUMN_PID,


### PR DESCRIPTION
1. Holding and updating process list is now OrbitApp responsibility
2. Update of ModulesDataView is moved from ProcessesDataView to OrbitApp.
3. ProcessDataView no longer needs to be updated when loading details about the process.
    
This PR is based on PR#36. Please review only the last commit.