### PR TITLE
Add "process" track that holds all sampling data.

### DIFF
--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -158,7 +158,7 @@ void EventTrack::SelectEvents() {
 //-----------------------------------------------------------------------------
 bool EventTrack::IsEmpty() const {
   ScopeLock lock(GEventTracer.GetEventBuffer().GetMutex());
-  std::map<uint64_t, CallstackEvent>& callstacks =
+  const std::map<uint64_t, CallstackEvent>& callstacks =
   GEventTracer.GetEventBuffer().GetCallstacks()[m_ThreadId];
   return callstacks.empty();
 }

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -159,6 +159,6 @@ void EventTrack::SelectEvents() {
 bool EventTrack::IsEmpty() const {
   ScopeLock lock(GEventTracer.GetEventBuffer().GetMutex());
   const std::map<uint64_t, CallstackEvent>& callstacks =
-  GEventTracer.GetEventBuffer().GetCallstacks()[m_ThreadId];
+      GEventTracer.GetEventBuffer().GetCallstacks()[m_ThreadId];
   return callstacks.empty();
 }

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -9,7 +9,7 @@
 #include "GlCanvas.h"
 
 //-----------------------------------------------------------------------------
-EventTrack::EventTrack(TimeGraph* a_TimeGraph) : time_graph_(a_TimeGraph) {
+EventTrack::EventTrack(TimeGraph* a_TimeGraph) : Track(a_TimeGraph) {
   m_MousePos[0] = m_MousePos[1] = Vec2(0, 0);
   m_Picked = false;
   m_Color = Color(0, 255, 0, 255);
@@ -153,4 +153,12 @@ void EventTrack::SelectEvents() {
 
   selected_callstack_events_ =
       time_graph_->SelectEvents(from[0], to[0], m_ThreadId);
+}
+
+//-----------------------------------------------------------------------------
+bool EventTrack::IsEmpty() const {
+  ScopeLock lock(GEventTracer.GetEventBuffer().GetMutex());
+  std::map<uint64_t, CallstackEvent>& callstacks =
+  GEventTracer.GetEventBuffer().GetCallstacks()[m_ThreadId];
+  return callstacks.empty();
 }

--- a/OrbitGl/EventTrack.h
+++ b/OrbitGl/EventTrack.h
@@ -30,6 +30,7 @@ class EventTrack : public Track {
   void SetSize(float a_SizeX, float a_SizeY);
   void SetColor(Color color) { m_Color = color; }
   void ClearSelectedEvents() { selected_callstack_events_.clear(); }
+  bool IsEmpty() const;
 
  protected:
   void SelectEvents();
@@ -38,7 +39,6 @@ class EventTrack : public Track {
   TextBox m_ThreadName;
   GlCanvas* m_Canvas;
   ThreadID m_ThreadId;
-  TimeGraph* time_graph_;
   Vec2 m_Pos;
   Vec2 m_Size;
   Vec2 m_MousePos[2];

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -11,8 +11,7 @@
 //-----------------------------------------------------------------------------
 GpuTrack::GpuTrack(TimeGraph* time_graph,
                    std::shared_ptr<StringManager> string_manager,
-                   uint64_t timeline_hash) {
-  time_graph_ = time_graph;
+                   uint64_t timeline_hash) : Track(time_graph) {
   text_renderer_ = time_graph->GetTextRenderer();
   timeline_hash_ = timeline_hash;
 

--- a/OrbitGl/GraphTrack.cpp
+++ b/OrbitGl/GraphTrack.cpp
@@ -2,7 +2,7 @@
 
 #include "GlCanvas.h"
 
-GraphTrack::GraphTrack(TimeGraph* time_graph) { SetTimeGraph(time_graph); }
+GraphTrack::GraphTrack(TimeGraph* time_graph) : Track(time_graph) {}
 
 void GraphTrack::Draw(GlCanvas* canvas, bool picking) {
   UNUSED(picking);

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -8,6 +8,10 @@
 const Color kInactiveColor(100, 100, 100, 255);
 const Color kSelectionColor(0, 128, 255, 255);
 
+SchedulerTrack::SchedulerTrack(TimeGraph* time_graph)
+    : ThreadTrack(time_graph, /*thread_id*/ 0) {
+}
+
 void SchedulerTrack::Draw(GlCanvas* /*canvas*/, bool /*picking*/) {}
 
 float SchedulerTrack::GetHeight() const {

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -8,15 +8,13 @@
 const Color kInactiveColor(100, 100, 100, 255);
 const Color kSelectionColor(0, 128, 255, 255);
 
-void SchedulerTrack::Draw(GlCanvas* canvas, bool picking) {
-  ThreadTrack::Draw(canvas, picking);
-}
+void SchedulerTrack::Draw(GlCanvas* /*canvas*/, bool /*picking*/) {}
 
 float SchedulerTrack::GetHeight() const {
   TimeGraphLayout& layout = time_graph_->GetLayout();
   return depth_ *
              (layout.GetTextCoresHeight() + layout.GetSpaceBetweenCores()) +
-         layout.GetEventTrackHeight() + layout.GetTrackBottomMargin();
+         layout.GetTrackBottomMargin();
 }
 
 inline Color GetTimerColor(const Timer& timer, TimeGraph* time_graph,
@@ -32,15 +30,12 @@ inline Color GetTimerColor(const Timer& timer, TimeGraph* time_graph,
 
 inline float GetYFromDepth(const TimeGraphLayout& layout, float track_y,
                            uint32_t depth) {
-  return track_y - layout.GetEventTrackHeight() -
-         layout.GetSpaceBetweenTracksAndThread() -
+  return track_y - layout.GetSpaceBetweenTracksAndThread() -
          (layout.GetTextCoresHeight() + layout.GetSpaceBetweenCores()) *
              (depth + 1);
 }
 
 void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
-  event_track_->UpdatePrimitives(min_tick, max_tick);
-
   Batcher* batcher = &time_graph_->GetBatcher();
   GlCanvas* canvas = time_graph_->GetCanvas();
   const TimeGraphLayout& layout = time_graph_->GetLayout();

--- a/OrbitGl/SchedulerTrack.h
+++ b/OrbitGl/SchedulerTrack.h
@@ -5,8 +5,8 @@
 
 class SchedulerTrack : public ThreadTrack {
  public:
-  SchedulerTrack(TimeGraph* time_graph, uint32_t thread_id)
-      : ThreadTrack(time_graph, thread_id) {}
+  SchedulerTrack(TimeGraph* time_graph)
+      : ThreadTrack(time_graph, 0) {}
   ~SchedulerTrack() override = default;
 
   void Draw(GlCanvas* a_Canvas, bool a_Picking) override;

--- a/OrbitGl/SchedulerTrack.h
+++ b/OrbitGl/SchedulerTrack.h
@@ -5,8 +5,7 @@
 
 class SchedulerTrack : public ThreadTrack {
  public:
-  SchedulerTrack(TimeGraph* time_graph)
-      : ThreadTrack(time_graph, 0) {}
+  SchedulerTrack(TimeGraph* time_graph);
   ~SchedulerTrack() override = default;
 
   void Draw(GlCanvas* a_Canvas, bool a_Picking) override;

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -15,8 +15,8 @@
 ABSL_FLAG(bool, show_return_values, false, "Show return values on time slices");
 
 //-----------------------------------------------------------------------------
-ThreadTrack::ThreadTrack(TimeGraph* time_graph, uint32_t thread_id) {
-  time_graph_ = time_graph;
+ThreadTrack::ThreadTrack(TimeGraph* time_graph, uint32_t thread_id)
+    : Track(time_graph) {
   text_renderer_ = time_graph->GetTextRenderer();
   thread_id_ = thread_id;
 
@@ -318,4 +318,9 @@ std::vector<std::shared_ptr<TimerChain>> ThreadTrack::GetAllChains() {
 void ThreadTrack::SetEventTrackColor(Color color) {
   ScopeLock lock(mutex_);
   event_track_->SetColor(color);
+}
+
+//-----------------------------------------------------------------------------
+bool ThreadTrack::IsEmpty() const { 
+  return (GetNumTimers() == 0) && event_track_->IsEmpty(); 
 }

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -52,6 +52,7 @@ class ThreadTrack : public Track {
 
   void SetEventTrackColor(Color color);
   void ClearSelectedEvents() { event_track_->ClearSelectedEvents(); }
+  bool IsEmpty() const;
 
   uint32_t GetThreadId() const { return thread_id_; }
 

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -41,6 +41,8 @@ TimeGraph* GCurrentTimeGraph = nullptr;
 TimeGraph::TimeGraph() {
   m_LastThreadReorder.Start();
   scheduler_track_ = std::make_shared<SchedulerTrack>(this);
+  
+  // The process track is a special ThreadTrack of id "0".
   process_track_ = GetOrCreateThreadTrack(0);
 }
 
@@ -89,6 +91,8 @@ void TimeGraph::Clear() {
   tracks_.clear();
   thread_tracks_.clear();
   scheduler_track_ = std::make_shared<SchedulerTrack>(this);
+
+  // The process track is a special ThreadTrack of id "0".
   process_track_ = GetOrCreateThreadTrack(0);
 
   m_ContextSwitchesMap.clear();

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -14,6 +14,7 @@
 #include "Geometry.h"
 #include "GpuTrack.h"
 #include "MemoryTracker.h"
+#include "SchedulerTrack.h"
 #include "StringManager.h"
 #include "TextBox.h"
 #include "TextRenderer.h"
@@ -166,6 +167,9 @@ class TimeGraph {
   std::unordered_map<uint64_t, std::shared_ptr<GpuTrack>> gpu_tracks_;
   std::vector<std::shared_ptr<Track>> sorted_tracks_;
   std::string m_ThreadFilter;
+
+  std::shared_ptr<SchedulerTrack> scheduler_track_;
+  std::shared_ptr<ThreadTrack> process_track_;
 
   std::shared_ptr<StringManager> string_manager_;
 };

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -10,7 +10,7 @@
 #include "absl/strings/str_format.h"
 
 //-----------------------------------------------------------------------------
-Track::Track() {
+Track::Track(TimeGraph* time_graph) : time_graph_(time_graph) {
   m_MousePos[0] = m_MousePos[1] = Vec2(0, 0);
   m_Pos = Vec2(0, 0);
   m_Size = Vec2(0, 0);

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -33,7 +33,7 @@ class Track : public Pickable {
     kUnknown,
   };
 
-  Track();
+  Track(TimeGraph* time_graph);
   ~Track() override = default;
 
   // Pickable


### PR DESCRIPTION
- Add EventTrack::IsEmpty() and ThreadTrack::IsEmpty()
- Don't draw empty tracks
- TimeGraph now has an explicit "process_track_" member instead
  of using a ThreadTrack of id "0"