### PR TITLE
Fixes for the windows docker containers.

### DIFF
--- a/contrib/conan/configs/install.ps1
+++ b/contrib/conan/configs/install.ps1
@@ -25,7 +25,7 @@ if (Test-Path Env:ORBIT_OVERRIDE_ARTIFACTORY_URL) {
   conan_disable_public_remotes
 } else {
   try {
-    $response = Invoke-WebRequest -URI http://artifactory.internal/ -ErrorAction Ignore -MaximumRedirection 0
+    $response = Invoke-WebRequest -URI http://artifactory.internal/ -ErrorAction Ignore -MaximumRedirection 0 -UseBasicParsing
     Write-Host "CI machine detected. Adjusting remotes..."
 
     $process = Start-Process $conan.Path -Wait -NoNewWindow -ErrorAction Stop -PassThru -ArgumentList "remote","add","-i","0","-f","artifactory","http://artifactory.internal/artifactory/api/conan/conan"
@@ -34,7 +34,7 @@ if (Test-Path Env:ORBIT_OVERRIDE_ARTIFACTORY_URL) {
     conan_disable_public_remotes
   } catch {
     try {
-      $response = Invoke-WebRequest -URI http://orbit-artifactory/ -ErrorAction Ignore -MaximumRedirection 0
+      $response = Invoke-WebRequest -URI http://orbit-artifactory/ -ErrorAction Ignore -MaximumRedirection 0 -UseBasicParsing
       Write-Host "Internal machine detected. Adjusting remotes..."
 
       $location = $response.Headers['Location'].Split("/")[2]

--- a/contrib/conan/docker/Dockerfile.msvc2017
+++ b/contrib/conan/docker/Dockerfile.msvc2017
@@ -3,7 +3,7 @@
 # Copyright (C) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT license. See LICENSE.txt in the project root for license information.
 
-FROM mcr.microsoft.com/windows/servercore:1903-amd64
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
 SHELL ["powershell.exe", "-ExecutionPolicy", "Bypass", "-Command"]
 
@@ -31,7 +31,7 @@ RUN C:\TEMP\Install.cmd C:\TEMP\vs_buildtools.exe --quiet --wait --norestart --n
     --installChannelUri C:\TEMP\VisualStudio.chman `
     --add Microsoft.VisualStudio.Workload.VCTools `
     --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
-    --add Microsoft.VisualStudio.Component.Windows10SDK.17763 `
+    --add Microsoft.Component.VC.Runtime.UCRTSDK `
     --add Microsoft.Component.MSBuild `
     --add Microsoft.VisualStudio.Component.VC.ATL `
     --installPath C:\BuildTools

--- a/contrib/conan/docker/Dockerfile.msvc2019
+++ b/contrib/conan/docker/Dockerfile.msvc2019
@@ -3,7 +3,7 @@
 # Copyright (C) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT license. See LICENSE.txt in the project root for license information.
 
-FROM mcr.microsoft.com/windows/servercore:1903-amd64
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
 SHELL ["powershell.exe", "-ExecutionPolicy", "Bypass", "-Command"]
 
@@ -31,11 +31,8 @@ RUN C:\TEMP\Install.cmd C:\TEMP\vs_buildtools.exe --quiet --wait --norestart --n
     --installChannelUri C:\TEMP\VisualStudio.chman `
     --add Microsoft.VisualStudio.Workload.VCTools `
     --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
-    --add Microsoft.VisualStudio.Component.Windows10SDK.18362 `
+    --add Microsoft.Component.VC.Runtime.UCRTSDK `
     --add Microsoft.Component.MSBuild `
-    --remove Microsoft.VisualStudio.Component.Windows10SDK.16299 `
-    --remove Microsoft.VisualStudio.Component.Windows10SDK.17134 `
-    --remove Microsoft.VisualStudio.Component.Windows10SDK.17763 `
     --add Microsoft.VisualStudio.Component.VC.ATL `
     --installPath C:\BuildTools
 


### PR DESCRIPTION
Some more fixes for the Docker containers.

The promised documentation is in the making, but not finished yet.

I needed to add the -UseBasicParsing flag because the non-basic parsing requires the web components from the Edge Browser which is not available in docker containers.

The updates to the Dockerfile clean up the build tool components and rebase the image on Windows Server 2019 instead of Windows Server 1909 (which is only available in as a headless version.)