### PR TITLE
Enable gpu driver tracing by default (remove feature flag) + minor tweaks

### DIFF
--- a/OrbitCore/LinuxTracingHandler.cpp
+++ b/OrbitCore/LinuxTracingHandler.cpp
@@ -44,7 +44,7 @@ void LinuxTracingHandler::Start(
   tracer_->SetListener(this);
 
   tracer_->SetTraceContextSwitches(GParams.m_TrackContextSwitches);
-  tracer_->SetSamplingMethod(LinuxTracing::kDwarf);
+  tracer_->SetSamplingMethod(LinuxTracing::SamplingMethod::kDwarf);
   tracer_->SetTraceInstrumentedFunctions(true);
   tracer_->SetTraceGpuDriver(absl::GetFlag(FLAGS_trace_gpu_driver));
 

--- a/OrbitCore/LinuxTracingHandler.cpp
+++ b/OrbitCore/LinuxTracingHandler.cpp
@@ -16,11 +16,6 @@
 ABSL_FLAG(uint16_t, sampling_rate, 1000,
           "Frequency of callstack sampling in samples per second");
 
-// TODO: This is a temporary feature flag. Remove this once we enable this
-//  globally.
-ABSL_FLAG(bool, trace_gpu_driver, false,
-          "Enables tracing of GPU driver tracepoint events");
-
 void LinuxTracingHandler::Start(
     pid_t pid,
     const std::vector<std::shared_ptr<Function>>& selected_functions) {
@@ -46,7 +41,7 @@ void LinuxTracingHandler::Start(
   tracer_->SetTraceContextSwitches(GParams.m_TrackContextSwitches);
   tracer_->SetSamplingMethod(LinuxTracing::SamplingMethod::kDwarf);
   tracer_->SetTraceInstrumentedFunctions(true);
-  tracer_->SetTraceGpuDriver(absl::GetFlag(FLAGS_trace_gpu_driver));
+  tracer_->SetTraceGpuDriver(true);
 
   tracer_->Start();
 }

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -183,13 +183,13 @@ bool TracerThread::OpenSampling(const std::vector<int32_t>& cpus) {
   for (int32_t cpu : cpus) {
     int sampling_fd;
     switch (tracing_options_.sampling_method) {
-      case kFramePointers:
+      case SamplingMethod::kFramePointers:
         sampling_fd = callchain_sample_event_open(sampling_period_ns_, -1, cpu);
         break;
-      case kDwarf:
+      case SamplingMethod::kDwarf:
         sampling_fd = sample_event_open(sampling_period_ns_, -1, cpu);
         break;
-      case kOff:
+      case SamplingMethod::kOff:
         FATAL("Sampling is off. This statement is unreachable.");
         CloseFileDescriptors(sampling_tracing_fds);
         return false;
@@ -209,7 +209,7 @@ bool TracerThread::OpenSampling(const std::vector<int32_t>& cpus) {
 
   for (int fd : sampling_tracing_fds) {
     tracing_fds_.push_back(fd);
-    if (tracing_options_.sampling_method == kFramePointers) {
+    if (tracing_options_.sampling_method == SamplingMethod::kFramePointers) {
       frame_pointers_sampling_fds_.emplace(fd);
     }
   }

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -360,14 +360,16 @@ void TracerThread::Run(
   // want to catch it.
   InitUprobesEventProcessor();
 
-  if (!InitGpuTracepointEventProcessor()) {
-    ERROR("Failed to initialize GPU tracepoint event processor");
-  }
-
   bool gpu_event_open_errors = false;
   if (tracing_options_.trace_gpu_driver) {
-    // We want to trace all GPU activity, hence we pass 'all_cpus' here.
-    gpu_event_open_errors = !OpenGpuTracepoints(all_cpus);
+    if (InitGpuTracepointEventProcessor()) {
+      // We want to trace all GPU activity, hence we pass 'all_cpus' here.
+      gpu_event_open_errors = !OpenGpuTracepoints(all_cpus);
+    } else {
+      ERROR(
+          "Failed to initialize GPU tracepoint event processor: "
+          "skipping opening GPU tracepoint events");
+    }
   }
 
   if (gpu_event_open_errors) {

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/Tracer.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/Tracer.h
@@ -73,7 +73,7 @@ class Tracer {
 
   TracerListener* listener_ = nullptr;
   TracingOptions tracing_options_{.trace_context_switches = true,
-                                  .sampling_method = kDwarf,
+                                  .sampling_method = SamplingMethod::kDwarf,
                                   .trace_instrumented_functions = true,
                                   .trace_gpu_driver = true};
 

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/TracingOptions.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/TracingOptions.h
@@ -2,11 +2,11 @@
 #define ORBIT_LINUX_TRACING_TRACING_OPTIONS_H_
 
 namespace LinuxTracing {
-enum SamplingMethod { kOff = 0, kFramePointers, kDwarf };
+enum class SamplingMethod { kOff = 0, kFramePointers, kDwarf };
 
 struct TracingOptions {
   bool trace_context_switches = true;
-  SamplingMethod sampling_method = kDwarf;
+  SamplingMethod sampling_method = SamplingMethod::kDwarf;
   bool trace_instrumented_functions = true;
   bool trace_gpu_driver = true;
 };


### PR DESCRIPTION
#### Make LinuxTracing::SamplingMethod an enum *class*
#### Tweak GPU event processor init and GPU event opening conditions
#### Remove trace_gpu_driver flag, enable by default
Bug: b/155834551