### PR TITLE
Bootstrap improvements

### DIFF
--- a/bootstrap-orbit.ps1
+++ b/bootstrap-orbit.ps1
@@ -42,6 +42,8 @@ You can call 'pip3 show -f conan' to figure out where conan.exe was placed.
 # Start build
 if ($args) {
   & "$PSScriptRoot\build.ps1" $args
+} elseif (conan remote list | Select-String -NotMatch "Disabled:" | Select-String "artifactory:") {
+  & "$PSScriptRoot\build.ps1" "default_relwithdebinfo" "ggp_relwithdebinfo"
 } else {
   & "$PSScriptRoot\build.ps1"
 }

--- a/bootstrap-orbit.sh
+++ b/bootstrap-orbit.sh
@@ -44,5 +44,14 @@ fi
 echo "Installing conan configuration (profiles, settings, etc.)..."
 $DIR/contrib/conan/configs/install.sh || exit $?
 
-exec $DIR/build.sh "$@"
+if [ -n "$1"] ; then
+  exec $DIR/build.sh "$@"
+else
+  conan remote list | grep -v 'Disabled:' | grep -e '^artifactory:' > /dev/null 2>&1
+  if [ $? -eq 0 ]; then
+    exec $DIR/build.sh default_relwithdebinfo ggp_relwithdebinfo
+  else
+    exec $DIR/build.sh
+  fi
+fi
 

--- a/build.ps1
+++ b/build.ps1
@@ -17,7 +17,7 @@ function conan_create_profile($profile) {
   (Get-Content $profile_path) -replace '\[build_requires\]', "[build_requires]`r`ncmake/3.16.4@" | Out-File -encoding ASCII $profile_path
 }
 
-$profiles = if ($args.Count) { $args } else { @("default_release") }
+$profiles = if ($args.Count) { $args } else { @("default_relwithdebinfo") }
 
 foreach ($profile in $profiles) {
 

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-default_profiles=( default_release )
+default_profiles=( default_relwithdebinfo )
 
 if [ "$#" -eq 0 ]; then
   profiles=( "${default_profiles[@]}" )


### PR DESCRIPTION
Two things:

- Compile `default_relwithdebinfo` by default instead of `default_release`
- Compile both `default_relwithdebinfo` and `ggp_relwithdebinfo` by default when an internal machine is detected. That's probably the most common use case when bootstrapping on an internal machine.