### PR TITLE
Disable frame pointer omission in GGP builds on Windows

### DIFF
--- a/contrib/conan/configs/windows/profiles/ggp_debug
+++ b/contrib/conan/configs/windows/profiles/ggp_debug
@@ -7,6 +7,7 @@ arch_build=x86_64
 compiler=clang
 compiler.version=7.0
 compiler.libcxx=libc++
+compiler.fpo=False
 build_type=Debug
 [options]
 OrbitProfiler:with_gui=False
@@ -17,3 +18,5 @@ ninja/1.9.0@
 
 [env]
 CONAN_CMAKE_GENERATOR=Ninja
+CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer
+CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer

--- a/contrib/conan/configs/windows/profiles/ggp_release
+++ b/contrib/conan/configs/windows/profiles/ggp_release
@@ -7,6 +7,7 @@ arch_build=x86_64
 compiler=clang
 compiler.version=7.0
 compiler.libcxx=libc++
+compiler.fpo=False
 build_type=Release
 [options]
 OrbitProfiler:with_gui=False
@@ -17,3 +18,5 @@ ninja/1.9.0@
 
 [env]
 CONAN_CMAKE_GENERATOR=Ninja
+CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer
+CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer

--- a/contrib/conan/configs/windows/profiles/ggp_relwithdebinfo
+++ b/contrib/conan/configs/windows/profiles/ggp_relwithdebinfo
@@ -7,6 +7,7 @@ arch_build=x86_64
 compiler=clang
 compiler.version=7.0
 compiler.libcxx=libc++
+compiler.fpo=False
 build_type=RelWithDebInfo
 [options]
 OrbitProfiler:with_gui=False
@@ -17,3 +18,5 @@ ninja/1.9.0@
 
 [env]
 CONAN_CMAKE_GENERATOR=Ninja
+CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer
+CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer

--- a/contrib/conan/configs/windows/settings.yml
+++ b/contrib/conan/configs/windows/settings.yml
@@ -56,6 +56,7 @@ compiler:
         threads: [None, posix, win32] #  Windows MinGW
         exception: [None, dwarf2, sjlj, seh] # Windows MinGW
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
+        fpo: [None, True, False]
     Visual Studio: &visual_studio
         runtime: [MD, MT, MTd, MDd]
         version: ["8", "9", "10", "11", "12", "14", "15", "16"]
@@ -70,6 +71,7 @@ compiler:
                   "8", "9", "10"]
         libcxx: [libstdc++, libstdc++11, libc++, c++_shared, c++_static]
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
+        fpo: [None, True, False]
     apple-clang:
         version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1", "10.0", "11.0"]
         libcxx: [libstdc++, libc++]


### PR DESCRIPTION
When I disabled frame pointer omission some time ago for all Linux builds I missed disabling it for GGP builds running on Windows.

This PR fixes that.