### PR TITLE
Use Path::JoinPath in SymbolHelper::FindAndLoadSymbols

### DIFF
--- a/OrbitCore/Path.cpp
+++ b/OrbitCore/Path.cpp
@@ -227,12 +227,23 @@ std::string Path::GetDirectory(const std::string& a_FullName) {
 }
 
 std::string Path::GetParentDirectory(std::string a_Directory) {
-  if (a_Directory.size() < 1) return "";
+  if (a_Directory.empty()) return "";
   std::replace(a_Directory.begin(), a_Directory.end(), '\\', '/');
   wchar_t lastChar = a_Directory.c_str()[a_Directory.size() - 1];
   if (lastChar == '/') a_Directory.erase(a_Directory.size() - 1);
 
   return GetDirectory(a_Directory);
+}
+
+std::string Path::JoinPath(const std::vector<std::string>& parts) {
+  if (parts.empty()) {
+    return "";
+  }
+  std::filesystem::path joined{parts[0]};
+  for (size_t i = 1; i < parts.size(); ++i) {
+    joined.append(parts[i]);
+  }
+  return joined.string();
 }
 
 std::string Path::GetProgramFilesPath() {

--- a/OrbitCore/Path.h
+++ b/OrbitCore/Path.h
@@ -40,6 +40,7 @@ class Path {
   static std::string GetExtension(const std::string& a_FullName);
   static std::string GetDirectory(const std::string& a_FullName);
   static std::string GetParentDirectory(std::string a_FullName);
+  static std::string JoinPath(const std::vector<std::string>& parts);
 
   static bool FileExists(const std::string& a_File);
   static uint64_t FileSize(const std::string& a_File);

--- a/OrbitCore/PathTest.cpp
+++ b/OrbitCore/PathTest.cpp
@@ -35,3 +35,72 @@ TEST(Path, FileExistsDevNull) {
   EXPECT_TRUE(Path::FileExists(filename));
 }
 #endif
+
+TEST(Path, JoinPathPartsEmpty) {
+  std::string actual = Path::JoinPath({});
+  std::string expected{};
+  EXPECT_EQ(actual, expected);
+}
+
+TEST(Path, JoinPathPartsRelativeSlash) {
+  std::string actual = Path::JoinPath({"dir1/dir2", "dir3/dir4/", "dir5/dir6"});
+#ifdef _WIN32
+  std::string expected = "dir1/dir2\\dir3/dir4/dir5/dir6";
+#else
+  std::string expected = "dir1/dir2/dir3/dir4/dir5/dir6";
+#endif
+  EXPECT_EQ(actual, expected);
+}
+
+TEST(Path, JoinPathPartsAbsoluteSlash) {
+  std::string actual =
+      Path::JoinPath({"/dir1/dir2", "dir3/dir4/", "dir5/dir6"});
+#ifdef _WIN32
+  std::string expected = "/dir1/dir2\\dir3/dir4/dir5/dir6";
+#else
+  std::string expected = "/dir1/dir2/dir3/dir4/dir5/dir6";
+#endif
+  EXPECT_EQ(actual, expected);
+}
+
+TEST(Path, JoinPathPartsAbsoluteRootSlash) {
+  std::string actual = Path::JoinPath({"/", "dir1/dir2", "dir3/dir4"});
+#ifdef _WIN32
+  std::string expected = "/dir1/dir2\\dir3/dir4";
+#else
+  std::string expected = "/dir1/dir2/dir3/dir4";
+#endif
+  EXPECT_EQ(actual, expected);
+}
+
+TEST(Path, JoinPathPartsRelativeBackslash) {
+  std::string actual =
+      Path::JoinPath({"dir1\\dir2", "dir3\\dir4\\", "dir5\\dir6"});
+#ifdef _WIN32
+  std::string expected = "dir1\\dir2\\dir3\\dir4\\dir5\\dir6";
+#else
+  std::string expected = "dir1\\dir2/dir3\\dir4\\/dir5\\dir6";
+#endif
+  EXPECT_EQ(actual, expected);
+}
+
+TEST(Path, JoinPathPartsAbsoluteBackslash) {
+  std::string actual =
+      Path::JoinPath({"C:\\dir1\\dir2", "dir3\\dir4\\", "dir5\\dir6"});
+#ifdef _WIN32
+  std::string expected = "C:\\dir1\\dir2\\dir3\\dir4\\dir5\\dir6";
+#else
+  std::string expected = "C:\\dir1\\dir2/dir3\\dir4\\/dir5\\dir6";
+#endif
+  EXPECT_EQ(actual, expected);
+}
+
+TEST(Path, JoinPathPartsAbsoluteRootBackslash) {
+  std::string actual = Path::JoinPath({"C:", "dir1\\dir2", "dir3\\dir4"});
+#ifdef _WIN32
+  std::string expected = "C:dir1\\dir2\\dir3\\dir4";
+#else
+  std::string expected = "C:/dir1\\dir2/dir3\\dir4";
+#endif
+  EXPECT_EQ(actual, expected);
+}

--- a/OrbitCore/SymbolHelper.cpp
+++ b/OrbitCore/SymbolHelper.cpp
@@ -83,10 +83,11 @@ bool FindAndLoadSymbols(std::shared_ptr<Module> module,
 
   std::vector<std::string> search_file_paths;
   for (const auto& directory : search_directories) {
-    search_file_paths.emplace_back(directory + name_without_extension +
-                                   ".debug");
-    search_file_paths.emplace_back(directory + module->m_Name + ".debug");
-    search_file_paths.emplace_back(directory + module->m_Name);
+    search_file_paths.emplace_back(
+        Path::JoinPath({directory, name_without_extension + ".debug"}));
+    search_file_paths.emplace_back(
+        Path::JoinPath({directory, module->m_Name + ".debug"}));
+    search_file_paths.emplace_back(Path::JoinPath({directory, module->m_Name}));
   }
 
   LOG("Trying to find symbols for module: %s", module->m_Name);


### PR DESCRIPTION
#### Minor changes to `SymbolHelper`'s output messages
Clearly delimit module/file names.
#### Add `Path::JoinPath` with tests
#### Use `Path::JoinPath` in `SymbolHelper::FindAndLoadSymbols`
Bug: b/153458022