### PR TITLE
Use Function::PrettyName() when LinuxAddressInfo::function_name.empty()

### DIFF
--- a/OrbitCore/SamplingProfiler.cpp
+++ b/OrbitCore/SamplingProfiler.cpp
@@ -465,12 +465,13 @@ void SamplingProfiler::AddAddress(uint64_t a_Address) {
       if (function != nullptr) {
         function_name = function->PrettyName();
       }
-    } else if (absl::StrContains(address_info->function_name, "[unknown]")) {
+    } else if (address_info->function_name.empty() ||
+               absl::StrContains(address_info->function_name, "[unknown]")) {
       if (function != nullptr) {
         function_name = function->PrettyName();
         address_info->function_name = function->PrettyName();
       }
-    } else if (!address_info->function_name.empty()) {
+    } else {
       function_name = address_info->function_name;
     }
     m_AddressToName[a_Address] = function_name;


### PR DESCRIPTION
Bug: b/155454822