### PR TITLE
Make Ssh tunneling default

### DIFF
--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -17,7 +17,11 @@
 #include "absl/flags/usage.h"
 #include "orbitmainwindow.h"
 
-ABSL_FLAG(std::string, remote, "",
+// SSH Tunneling via run_service_ssh.{ps1/sh} is the default for now. To make
+// this work the remote is set here to localhost. This will also disable the
+// StartUpWindow for now.
+// TODO(antonrohr) replace "localhost" with "" as soon as ssh is implemented
+ABSL_FLAG(std::string, remote, "localhost",
           "Connect to the specified remote on startup");
 ABSL_FLAG(uint16_t, asio_port, 44766,
           "The service's Asio tcp_server port (use default value if unsure)");


### PR DESCRIPTION
This PR makes ssh tunnelling default. 

this is done by setting the default remote to `localhost`

To run Orbit with Ssh Tunneling
* start `run_service_ssh.{ps1/sh}`
* start Orbit main executable without any arguments `./Orbit`