### PR TITLE
add symupload and dump_syms tools

### DIFF
--- a/contrib/conan/recipes/breakpad/CMakeLists.txt
+++ b/contrib/conan/recipes/breakpad/CMakeLists.txt
@@ -1,0 +1,119 @@
+cmake_minimum_required(VERSION 3.8)
+project(symbols_uploading)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_definitions(
+    -DNOMINMAX
+    -DUNICODE
+    -DWIN32_LEAN_AND_MEAN
+    -D_CRT_SECURE_NO_WARNINGS
+    -D_CRT_SECURE_NO_DEPRECATE
+    -D_CRT_NONSTDC_NO_DEPRECATE
+    -D_LIBCPP_VERSION
+)
+
+if(WIN32)
+	set (DIA_SDK_DIR 
+		"${VSINSTALLDIR}/DIA SDK"
+	)
+	include_directories(src/ src/common/windows ${DIA_SDK_DIR}/include)
+
+	set(COMMON_LIB_SRC
+		src/common/windows/dia_util.cc
+		src/common/windows/guid_string.cc
+		src/common/windows/http_upload.cc
+		src/common/windows/omap.cc
+		src/common/windows/pdb_source_line_writer.cc
+		src/common/windows/pe_source_line_writer.cc
+		src/common/windows/pe_util.cc
+		src/common/windows/string_utils.cc
+		src/common/windows/symbol_collector_client.cc
+	)
+	find_library(DIAGUIDS_LIB diaguids PATHS ${DIA_SDK_DIR}/lib/amd64)
+	set (COMMON_LIB_LIB
+		${DIAGUIDS_LIB}
+		Imagehlp
+	)
+	
+	set(DUMP_SYMS_SRC
+		src/tools/windows/dump_syms/dump_syms.cc
+	)
+	
+	set(SYMUPLOAD_SRC
+		src/tools/windows/symupload/symupload.cc
+	)
+	set (SYMUPLOAD_LIB
+		Wininet
+		Version
+	)
+elseif(UNIX)
+	add_definitions(
+		-DHAVE_A_OUT_H
+		-DHAVE_GETCONTEXT
+	)
+	include_directories(src/ src/common src/common/dwarf src/common/linux)
+	
+	set(COMMON_LIB_SRC
+		src/common/convert_UTF.cc
+		src/common/dwarf/bytereader.cc
+		src/common/dwarf/cfi_assembler.cc
+		src/common/dwarf/dwarf2diehandler.cc
+		src/common/dwarf/dwarf2reader.cc
+		src/common/dwarf/elf_reader.cc
+		src/common/dwarf/functioninfo.cc
+		src/common/dwarf_cfi_to_module.cc
+		src/common/dwarf_cu_to_module.cc
+		src/common/dwarf_line_to_module.cc
+		src/common/dwarf_range_list_handler.cc
+		src/common/language.cc
+		src/common/linux/crc32.cc
+		src/common/linux/dump_symbols.cc
+		src/common/linux/elf_core_dump.cc
+		src/common/linux/elf_symbols_to_module.cc
+		src/common/linux/elfutils.cc
+		src/common/linux/file_id.cc
+		src/common/linux/google_crashdump_uploader.cc
+		src/common/linux/guid_creator.cc
+		src/common/linux/http_upload.cc
+		src/common/linux/libcurl_wrapper.cc
+		src/common/linux/linux_libc_support.cc
+		src/common/linux/memory_mapped_file.cc
+		src/common/linux/safe_readlink.cc
+		src/common/linux/synth_elf.cc
+		src/common/linux/symbol_upload.cc
+		src/common/long_string_dictionary.cc
+		src/common/md5.cc
+		src/common/module.cc
+		src/common/path_helper.cc
+		src/common/simple_string_dictionary.cc
+		src/common/stabs_reader.cc
+		src/common/stabs_to_module.cc
+		src/common/string_conversion.cc
+		src/common/test_assembler.cc
+	)
+
+	set(DUMP_SYMS_SRC
+		src/tools/linux/dump_syms/dump_syms.cc
+	)
+
+	set(SYMUPLOAD_SRC
+		src/tools/linux/symupload/sym_upload.cc
+	)
+	set (SYMUPLOAD_LIB
+		dl
+	)
+endif()
+
+add_library(common STATIC ${COMMON_LIB_SRC})
+target_link_libraries(common ${COMMON_LIB_LIB})
+
+add_executable(dump_syms ${DUMP_SYMS_SRC})
+target_link_libraries(dump_syms common)
+
+add_executable(symupload ${SYMUPLOAD_SRC})
+target_link_libraries(symupload common ${SYMUPLOAD_LIB})

--- a/contrib/conan/recipes/breakpad/LICENSE.md
+++ b/contrib/conan/recipes/breakpad/LICENSE.md
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2018 ArsenStudio
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/contrib/conan/recipes/breakpad/conanfile.py
+++ b/contrib/conan/recipes/breakpad/conanfile.py
@@ -1,0 +1,66 @@
+from conans import ConanFile, CMake, MSBuild, tools
+import os
+import shutil
+
+
+class BreakpadConan(ConanFile):
+    description = "Breakpad tools for symbol uploading"
+    name = 'breakpad'
+    version = "216cea7b"
+    license = 'https://chromium.googlesource.com/breakpad/breakpad/+/master/LICENSE'
+    url = 'https://gitlab.com/ArsenStudio/ArsenEngine/dependencies/conan-breakpad'
+    generators = 'cmake'
+    branch = 'master'
+    exports = ["CMakeLists.txt", "fix-unique_ptr.patch"]
+    build_requires = "libdisasm/0.23@orbitdeps/stable"
+    
+    settings = 'os_build', 'arch_build', 'compiler', 'arch'
+    options = {
+        "fPIC": [True, False]
+    }
+    default_options = {
+        "fPIC": True
+    }
+    
+    _source_dir = "breakpad"
+
+    def source(self):
+        self.run( 'git clone https://chromium.googlesource.com/breakpad/breakpad')
+        if self.settings.os_build == 'Linux':
+            self.run(
+                'git clone https://chromium.googlesource.com/linux-syscall-support breakpad/src/third_party/lss')
+        self.run('git checkout {}'.format(self.version), cwd='breakpad/')
+        shutil.move('CMakeLists.txt', self._source_dir)
+        tools.patch(patch_file="fix-unique_ptr.patch",
+                    base_path=self._source_dir)
+
+    def build(self):
+        cmake = CMake(self)
+        
+        if self.settings.os_build == "Windows":
+            vcvars = tools.vcvars_dict(self.settings)
+            cmake.definitions["VSINSTALLDIR"] = vcvars["VSINSTALLDIR"].rstrip('\\')
+
+        cmake.configure(source_folder=self._source_dir)
+        cmake.build()
+        
+    def copy_sym_upload_tools(self):
+        if self.settings.os_build == "Windows":
+            self.copy("dump_syms.exe", src=os.path.join(self.build_folder, "bin"), dst="bin")
+            self.copy("symupload.exe", src=os.path.join(self.build_folder, "bin"), dst="bin")
+        else:
+            self.copy("dump_syms", src=os.path.join(self.build_folder, "bin"), dst="bin")
+            self.copy("symupload", src=os.path.join(self.build_folder, "bin"), dst="bin")
+
+    def package(self):
+        self.copy(pattern="LICENSE", dst="licenses", src=self._source_dir,
+                                     ignore_case=True, keep_path=False)                             
+        self.copy_sym_upload_tools()
+
+    def package_info(self):
+        self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))
+        
+    def package_id(self):
+        del self.info.settings.compiler
+        del self.info.settings.arch
+        self.info.include_build_settings()

--- a/contrib/conan/recipes/breakpad/fix-unique_ptr.patch
+++ b/contrib/conan/recipes/breakpad/fix-unique_ptr.patch
@@ -1,0 +1,13 @@
+diff --git a/src/common/windows/pe_util.cc b/src/common/windows/pe_util.cc
+index 9f9e8fa..d912635 100644
+--- a/src/common/windows/pe_util.cc
++++ b/src/common/windows/pe_util.cc
+@@ -28,7 +28,7 @@
+ // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ #include "pe_util.h"
+-
++#include <memory>
+ #include <windows.h>
+ #include <winnt.h>
+ #include <atlbase.h>


### PR DESCRIPTION
Added Breakpad tools for symbols uploading
- dump_syms: convert symbols to platform-independant format (.sym)
- symupload: upload debug symbols to the Crash server