### PR TITLE
Classify all PERF_RECORD_SAMPLEs by stream_id instead of fd or size

### DIFF
--- a/OrbitLinuxTracing/PerfEvent.cpp
+++ b/OrbitLinuxTracing/PerfEvent.cpp
@@ -20,7 +20,7 @@ void SystemWideContextSwitchPerfEvent::Accept(PerfEventVisitor* visitor) {
   visitor->visit(this);
 }
 
-void SamplePerfEvent::Accept(PerfEventVisitor* visitor) {
+void StackSamplePerfEvent::Accept(PerfEventVisitor* visitor) {
   visitor->visit(this);
 }
 

--- a/OrbitLinuxTracing/PerfEvent.h
+++ b/OrbitLinuxTracing/PerfEvent.h
@@ -185,11 +185,11 @@ struct dynamically_sized_perf_event_stack_sample {
       : stack{dyn_size} {}
 };
 
-class SamplePerfEvent : public PerfEvent {
+class StackSamplePerfEvent : public PerfEvent {
  public:
   std::unique_ptr<dynamically_sized_perf_event_stack_sample> ring_buffer_record;
 
-  explicit SamplePerfEvent(uint64_t dyn_size)
+  explicit StackSamplePerfEvent(uint64_t dyn_size)
       : ring_buffer_record{
             std::make_unique<dynamically_sized_perf_event_stack_sample>(
                 dyn_size)} {}

--- a/OrbitLinuxTracing/PerfEventOpen.cpp
+++ b/OrbitLinuxTracing/PerfEventOpen.cpp
@@ -65,7 +65,7 @@ int mmap_task_event_open(pid_t pid, int32_t cpu) {
   return generic_event_open(&pe, pid, cpu);
 }
 
-int sample_event_open(uint64_t period_ns, pid_t pid, int32_t cpu) {
+int stack_sample_event_open(uint64_t period_ns, pid_t pid, int32_t cpu) {
   perf_event_attr pe = generic_event_attr();
   pe.type = PERF_TYPE_SOFTWARE;
   pe.config = PERF_COUNT_SW_CPU_CLOCK;

--- a/OrbitLinuxTracing/PerfEventOpen.h
+++ b/OrbitLinuxTracing/PerfEventOpen.h
@@ -119,7 +119,7 @@ int context_switch_event_open(pid_t pid, int32_t cpu);
 int mmap_task_event_open(pid_t pid, int32_t cpu);
 
 // perf_event_open for stack sampling.
-int sample_event_open(uint64_t period_ns, pid_t pid, int32_t cpu);
+int stack_sample_event_open(uint64_t period_ns, pid_t pid, int32_t cpu);
 
 // perf_event_open for stack sampling using frame pointers.
 int callchain_sample_event_open(uint64_t period_ns, pid_t pid, int32_t cpu);

--- a/OrbitLinuxTracing/PerfEventReaders.cpp
+++ b/OrbitLinuxTracing/PerfEventReaders.cpp
@@ -48,14 +48,14 @@ pid_t ReadSampleRecordPid(PerfEventRingBuffer* ring_buffer) {
   return pid;
 }
 
-std::unique_ptr<SamplePerfEvent> ConsumeSamplePerfEvent(
+std::unique_ptr<StackSamplePerfEvent> ConsumeStackSamplePerfEvent(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header) {
   // Data in the ring buffer has the layout of perf_event_stack_sample, but we
   // copy it into dynamically_sized_perf_event_stack_sample.
   uint64_t dyn_size;
   ring_buffer->ReadValueAtOffset(
       &dyn_size, offsetof(perf_event_stack_sample, stack.dyn_size));
-  auto event = std::make_unique<SamplePerfEvent>(dyn_size);
+  auto event = std::make_unique<StackSamplePerfEvent>(dyn_size);
   event->ring_buffer_record->header = header;
   ring_buffer->ReadValueAtOffset(&event->ring_buffer_record->sample_id,
                                  offsetof(perf_event_stack_sample, sample_id));

--- a/OrbitLinuxTracing/PerfEventReaders.cpp
+++ b/OrbitLinuxTracing/PerfEventReaders.cpp
@@ -25,10 +25,26 @@ pid_t ReadMmapRecordPid(PerfEventRingBuffer* ring_buffer) {
   return pid;
 }
 
+uint64_t ReadSampleRecordStreamId(PerfEventRingBuffer* ring_buffer) {
+  uint64_t stream_id;
+  // All PERF_RECORD_SAMPLEs start with
+  //   perf_event_header header;
+  //   perf_event_sample_id_tid_time_streamid_cpu sample_id;
+  ring_buffer->ReadValueAtOffset(
+      &stream_id,
+      sizeof(perf_event_header) +
+          offsetof(perf_event_sample_id_tid_time_streamid_cpu, stream_id));
+  return stream_id;
+}
+
 pid_t ReadSampleRecordPid(PerfEventRingBuffer* ring_buffer) {
   pid_t pid;
+  // All PERF_RECORD_SAMPLEs start with
+  //   perf_event_header header;
+  //   perf_event_sample_id_tid_time_streamid_cpu sample_id;
   ring_buffer->ReadValueAtOffset(
-      &pid, offsetof(perf_event_stack_sample, sample_id.pid));
+      &pid, sizeof(perf_event_header) +
+                offsetof(perf_event_sample_id_tid_time_streamid_cpu, pid));
   return pid;
 }
 

--- a/OrbitLinuxTracing/PerfEventReaders.h
+++ b/OrbitLinuxTracing/PerfEventReaders.h
@@ -14,7 +14,7 @@ uint64_t ReadSampleRecordStreamId(PerfEventRingBuffer* ring_buffer);
 
 pid_t ReadSampleRecordPid(PerfEventRingBuffer* ring_buffer);
 
-std::unique_ptr<SamplePerfEvent> ConsumeSamplePerfEvent(
+std::unique_ptr<StackSamplePerfEvent> ConsumeStackSamplePerfEvent(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header);
 
 std::unique_ptr<CallchainSamplePerfEvent> ConsumeCallchainSamplePerfEvent(

--- a/OrbitLinuxTracing/PerfEventReaders.h
+++ b/OrbitLinuxTracing/PerfEventReaders.h
@@ -10,6 +10,8 @@ namespace LinuxTracing {
 // more complex operations than simply copying an entire perf_event_open record.
 pid_t ReadMmapRecordPid(PerfEventRingBuffer* ring_buffer);
 
+uint64_t ReadSampleRecordStreamId(PerfEventRingBuffer* ring_buffer);
+
 pid_t ReadSampleRecordPid(PerfEventRingBuffer* ring_buffer);
 
 std::unique_ptr<SamplePerfEvent> ConsumeSamplePerfEvent(

--- a/OrbitLinuxTracing/PerfEventRecords.h
+++ b/OrbitLinuxTracing/PerfEventRecords.h
@@ -120,18 +120,18 @@ struct __attribute__((__packed__)) perf_event_ax_sample {
   perf_event_sample_regs_user_ax regs;
 };
 
-struct __attribute__((__packed__)) perf_event_lost {
-  perf_event_header header;
-  uint64_t id;
-  uint64_t lost;
-  perf_event_sample_id_tid_time_streamid_cpu sample_id;
-};
-
 struct __attribute__((__packed__)) perf_event_sample_raw {
   perf_event_header header;
   perf_event_sample_id_tid_time_streamid_cpu sample_id;
   uint32_t size;
   // The rest of the sample is a char[size] that we read dynamically.
+};
+
+struct __attribute__((__packed__)) perf_event_lost {
+  perf_event_header header;
+  uint64_t id;
+  uint64_t lost;
+  perf_event_sample_id_tid_time_streamid_cpu sample_id;
 };
 
 }  // namespace LinuxTracing

--- a/OrbitLinuxTracing/PerfEventVisitor.h
+++ b/OrbitLinuxTracing/PerfEventVisitor.h
@@ -13,7 +13,7 @@ class PerfEventVisitor {
   virtual void visit(ExitPerfEvent*) {}
   virtual void visit(ContextSwitchPerfEvent*) {}
   virtual void visit(SystemWideContextSwitchPerfEvent*) {}
-  virtual void visit(SamplePerfEvent*) {}
+  virtual void visit(StackSamplePerfEvent*) {}
   virtual void visit(CallchainSamplePerfEvent*) {}
   virtual void visit(UprobesPerfEvent*) {}
   virtual void visit(UretprobesPerfEvent*) {}

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -113,7 +113,7 @@ class TracerThread {
       uprobes_uretprobes_ids_to_function_;
   absl::flat_hash_set<uint64_t> uprobes_ids_;
   absl::flat_hash_set<uint64_t> uretprobes_ids_;
-  absl::flat_hash_set<uint64_t> sampling_ids_;
+  absl::flat_hash_set<uint64_t> stack_sampling_ids_;
   absl::flat_hash_set<uint64_t> gpu_tracing_ids_;
   absl::flat_hash_set<uint64_t> callchain_sampling_ids_;
 

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -108,9 +108,14 @@ class TracerThread {
 
   std::vector<int> tracing_fds_;
   std::vector<PerfEventRingBuffer> ring_buffers_;
-  absl::flat_hash_map<uint64_t, const Function*> uprobes_ids_to_function_;
-  absl::flat_hash_set<int> gpu_tracing_fds_;
-  absl::flat_hash_set<int> frame_pointers_sampling_fds_;
+
+  absl::flat_hash_map<uint64_t, const Function*>
+      uprobes_uretprobes_ids_to_function_;
+  absl::flat_hash_set<uint64_t> uprobes_ids_;
+  absl::flat_hash_set<uint64_t> uretprobes_ids_;
+  absl::flat_hash_set<uint64_t> sampling_ids_;
+  absl::flat_hash_set<uint64_t> gpu_tracing_ids_;
+  absl::flat_hash_set<uint64_t> callchain_sampling_ids_;
 
   std::atomic<bool> stop_deferred_thread_ = false;
   std::vector<std::unique_ptr<PerfEvent>> deferred_events_;

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
@@ -4,7 +4,7 @@
 
 namespace LinuxTracing {
 
-void UprobesUnwindingVisitor::visit(SamplePerfEvent* event) {
+void UprobesUnwindingVisitor::visit(StackSamplePerfEvent* event) {
   CHECK(listener_ != nullptr);
 
   if (current_maps_ == nullptr) {

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.h
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.h
@@ -54,7 +54,7 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
         std::move(discarded_samples_in_uretprobes_counter);
   }
 
-  void visit(SamplePerfEvent* event) override;
+  void visit(StackSamplePerfEvent* event) override;
   void visit(CallchainSamplePerfEvent* event) override;
   void visit(UprobesPerfEvent* event) override;
   void visit(UretprobesPerfEvent* event) override;


### PR DESCRIPTION
#### Classify all PERF_RECORD_SAMPLEs by stream_id instead of fd or size
For this, also added `ReadSampleRecordStreamId` to PerfEventReaders.
Modified `ReadSampleRecordPid` to follow the same code pattern as it is not used
only for *stack* samples.
#### General renaming of "sample" to "stack sample" in OrbitLinuxTracing
This is because `PERF_RECORD_SAMPLE` has a broader meaning and this is now even
more evident having introduced callchain (frame-pointer-unwound) samples.

---
Please review the commits separately.