### PR TITLE
Fix bugs in new version handling logic

### DIFF
--- a/OrbitCore/CMakeLists.txt
+++ b/OrbitCore/CMakeLists.txt
@@ -220,7 +220,8 @@ target_compile_definitions(OrbitCore PUBLIC _UNICODE)
 target_compile_features(OrbitCore PUBLIC cxx_std_11)
 
 include("${CMAKE_SOURCE_DIR}/cmake/version.cmake")
-GenerateVersionFile("${CMAKE_CURRENT_BINARY_DIR}/Version.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/Version.cpp.in")
+GenerateVersionFile("${CMAKE_CURRENT_BINARY_DIR}/Version.cpp"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/Version.cpp.in" OrbitCore)
 target_sources(OrbitCore PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/Version.cpp")
 
 add_executable(OrbitCoreTests)

--- a/OrbitQt/CMakeLists.txt
+++ b/OrbitQt/CMakeLists.txt
@@ -80,7 +80,7 @@ target_link_libraries(OrbitQt PRIVATE OrbitCore OrbitGl OrbitGgp Qt5::Widgets
 
 include(${CMAKE_SOURCE_DIR}/cmake/version.cmake)
 GenerateVersionFile("${CMAKE_CURRENT_BINARY_DIR}/version.h"
-                    "${CMAKE_CURRENT_SOURCE_DIR}/version.h.in")
+                    "${CMAKE_CURRENT_SOURCE_DIR}/version.h.in" OrbitQt)
 target_sources(OrbitQt PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/version.h")
 target_include_directories(OrbitQt PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
 
@@ -93,7 +93,7 @@ if(WIN32)
   set_target_properties(OrbitQt PROPERTIES WIN32_EXECUTABLE ON)
 
   GenerateVersionFile("${CMAKE_CURRENT_BINARY_DIR}/OrbitQt.rc"
-                      "${CMAKE_CURRENT_SOURCE_DIR}/OrbitQt.rc.in")
+                      "${CMAKE_CURRENT_SOURCE_DIR}/OrbitQt.rc.in" OrbitQt)
   target_sources(OrbitQt PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/OrbitQt.rc)
 
   get_target_property(_qmake_executable Qt5::qmake IMPORTED_LOCATION)

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -4,7 +4,7 @@
 
 set(VERSION_CMAKE_SCRIPT "${CMAKE_CURRENT_LIST_FILE}")
 
-function(GenerateVersionFile OUTPUT_FILE INPUT_FILE)
+function(GenerateVersionFile OUTPUT_FILE INPUT_FILE COMPILE_TARGET)
   get_filename_component(OUTPUT_FILE "${OUTPUT_FILE}" ABSOLUTE)
   get_filename_component(INPUT_FILE "${INPUT_FILE}" ABSOLUTE)
 
@@ -21,6 +21,10 @@ function(GenerateVersionFile OUTPUT_FILE INPUT_FILE)
       "-DGIT_COMMIT_STATE_FILE=${GIT_COMMIT_STATE_FILE}"
       "-DINPUT_FILE=${INPUT_FILE}" "-DOUTPUT_FILE=${OUTPUT_FILE}" -P
       "${VERSION_CMAKE_SCRIPT}")
+
+  if(COMPILE_TARGET)
+    add_dependencies(${COMPILE_TARGET} "${TARGET_NAME}")
+  endif()
 endfunction()
 
 function(DoGenerateVersionFile OUTPUT_FILE INPUT_FILE GIT_COMMIT_STATE_FILE

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -10,9 +10,16 @@ function(GenerateVersionFile OUTPUT_FILE INPUT_FILE COMPILE_TARGET)
 
   set(GIT_COMMIT_STATE_FILE "${OUTPUT_FILE}.state")
 
-  string(MAKE_C_IDENTIFIER "${OUTPUT_FILE}" TARGET_NAME)
+  set(TARGET_NAME "${OUTPUT_FILE}")
+
+  if("${OUTPUT_FILE}" MATCHES "${CMAKE_BINARY_DIR}*")
+    string(LENGTH "${CMAKE_BINARY_DIR}" PREFIX_LENGTH)
+    string(SUBSTRING "${OUTPUT_FILE}" ${PREFIX_LENGTH} -1 TARGET_NAME)
+  endif()
+
+  string(MAKE_C_IDENTIFIER "${TARGET_NAME}" TARGET_NAME)
   add_custom_target(
-    "check_git_version_${TARGET_NAME}" ALL
+    "${TARGET_NAME}" ALL
     DEPENDS ${INPUT_FILE}
     BYPRODUCTS ${OUTPUT_FILE} ${GIT_COMMIT_STATE_FILE}
     COMMENT "Checking Orbit's version by calling git describe"


### PR DESCRIPTION
Fixes two problems:

- Reduced target name lengths such that paths won't exceed the 260 character limit.
- Adds explicit compile time dependency such that version targets are built before the targets using the version files. I couldn't figure out why it wasn't working before this change in cmake 3.15. maybe a bug, maybe a missing feature, maybe just coincidence.

TESTS: I tried Windows and Linux. Works fine for me, but yeah... Before it also worked fine.