### PR TITLE
Fixed reading the callchain record and added a flag

### DIFF
--- a/OrbitCore/LinuxTracingHandler.cpp
+++ b/OrbitCore/LinuxTracingHandler.cpp
@@ -7,7 +7,6 @@
 #include "OrbitLinuxTracing/Events.h"
 #include "OrbitLinuxTracing/TracingOptions.h"
 #include "OrbitModule.h"
-#include "Params.h"
 #include "absl/flags/flag.h"
 #include "llvm/Demangle/Demangle.h"
 
@@ -37,11 +36,7 @@ void LinuxTracingHandler::Start(
                                                    instrumented_functions);
 
   tracer_->SetListener(this);
-
-  tracer_->SetTraceContextSwitches(GParams.m_TrackContextSwitches);
-  tracer_->SetSamplingMethod(sampling_method_);
-  tracer_->SetTraceInstrumentedFunctions(true);
-  tracer_->SetTraceGpuDriver(true);
+  tracer_->SetTracingOptions(tracing_options_);
 
   tracer_->Start();
 }

--- a/OrbitCore/LinuxTracingHandler.cpp
+++ b/OrbitCore/LinuxTracingHandler.cpp
@@ -16,6 +16,10 @@
 ABSL_FLAG(uint16_t, sampling_rate, 1000,
           "Frequency of callstack sampling in samples per second");
 
+// TODO: Remove this flag once we have an ui option to specify.
+ABSL_FLAG(bool, frame_pointer_unwinding, false,
+          "Use frame pointer information for unwinding");
+
 void LinuxTracingHandler::Start(
     pid_t pid,
     const std::vector<std::shared_ptr<Function>>& selected_functions) {
@@ -39,7 +43,11 @@ void LinuxTracingHandler::Start(
   tracer_->SetListener(this);
 
   tracer_->SetTraceContextSwitches(GParams.m_TrackContextSwitches);
-  tracer_->SetSamplingMethod(LinuxTracing::SamplingMethod::kDwarf);
+  if (absl::GetFlag(FLAGS_frame_pointer_unwinding)) {
+    tracer_->SetSamplingMethod(LinuxTracing::SamplingMethod::kFramePointers);
+  } else {
+    tracer_->SetSamplingMethod(LinuxTracing::SamplingMethod::kDwarf);
+  }
   tracer_->SetTraceInstrumentedFunctions(true);
   tracer_->SetTraceGpuDriver(true);
 

--- a/OrbitCore/LinuxTracingHandler.cpp
+++ b/OrbitCore/LinuxTracingHandler.cpp
@@ -16,10 +16,6 @@
 ABSL_FLAG(uint16_t, sampling_rate, 1000,
           "Frequency of callstack sampling in samples per second");
 
-// TODO: Remove this flag once we have an ui option to specify.
-ABSL_FLAG(bool, frame_pointer_unwinding, false,
-          "Use frame pointers for unwinding");
-
 void LinuxTracingHandler::Start(
     pid_t pid,
     const std::vector<std::shared_ptr<Function>>& selected_functions) {
@@ -43,11 +39,7 @@ void LinuxTracingHandler::Start(
   tracer_->SetListener(this);
 
   tracer_->SetTraceContextSwitches(GParams.m_TrackContextSwitches);
-  if (absl::GetFlag(FLAGS_frame_pointer_unwinding)) {
-    tracer_->SetSamplingMethod(LinuxTracing::SamplingMethod::kFramePointers);
-  } else {
-    tracer_->SetSamplingMethod(LinuxTracing::SamplingMethod::kDwarf);
-  }
+  tracer_->SetSamplingMethod(sampling_method_);
   tracer_->SetTraceInstrumentedFunctions(true);
   tracer_->SetTraceGpuDriver(true);
 

--- a/OrbitCore/LinuxTracingHandler.cpp
+++ b/OrbitCore/LinuxTracingHandler.cpp
@@ -18,7 +18,7 @@ ABSL_FLAG(uint16_t, sampling_rate, 1000,
 
 // TODO: Remove this flag once we have an ui option to specify.
 ABSL_FLAG(bool, frame_pointer_unwinding, false,
-          "Use frame pointer information for unwinding");
+          "Use frame pointers for unwinding");
 
 void LinuxTracingHandler::Start(
     pid_t pid,

--- a/OrbitCore/LinuxTracingHandler.h
+++ b/OrbitCore/LinuxTracingHandler.h
@@ -17,8 +17,8 @@
 class LinuxTracingHandler : public LinuxTracing::TracerListener {
  public:
   explicit LinuxTracingHandler(LinuxTracingBuffer* tracing_buffer,
-                               LinuxTracing::SamplingMethod sampling_method)
-      : tracing_buffer_{tracing_buffer}, sampling_method_{sampling_method} {}
+                               LinuxTracing::TracingOptions tracing_options)
+      : tracing_buffer_{tracing_buffer}, tracing_options_{tracing_options} {}
 
   ~LinuxTracingHandler() override = default;
   LinuxTracingHandler(const LinuxTracingHandler&) = delete;
@@ -45,7 +45,7 @@ class LinuxTracingHandler : public LinuxTracing::TracerListener {
   uint64_t ProcessStringAndGetKey(const std::string& string);
 
   LinuxTracingBuffer* tracing_buffer_;
-  LinuxTracing::SamplingMethod sampling_method_;
+  LinuxTracing::TracingOptions tracing_options_;
   std::unique_ptr<LinuxTracing::Tracer> tracer_;
 
   absl::flat_hash_set<uint64_t> addresses_seen_;

--- a/OrbitCore/LinuxTracingHandler.h
+++ b/OrbitCore/LinuxTracingHandler.h
@@ -7,6 +7,7 @@
 #include "ContextSwitch.h"
 #include "LinuxCallstackEvent.h"
 #include "LinuxTracingBuffer.h"
+#include "OrbitLinuxTracing/TracingOptions.h"
 #include "OrbitProcess.h"
 #include "SamplingProfiler.h"
 #include "ScopeTimer.h"
@@ -15,8 +16,9 @@
 
 class LinuxTracingHandler : public LinuxTracing::TracerListener {
  public:
-  explicit LinuxTracingHandler(LinuxTracingBuffer* tracing_buffer)
-      : tracing_buffer_{tracing_buffer} {}
+  explicit LinuxTracingHandler(LinuxTracingBuffer* tracing_buffer,
+                               LinuxTracing::SamplingMethod sampling_method)
+      : tracing_buffer_{tracing_buffer}, sampling_method_{sampling_method} {}
 
   ~LinuxTracingHandler() override = default;
   LinuxTracingHandler(const LinuxTracingHandler&) = delete;
@@ -43,6 +45,7 @@ class LinuxTracingHandler : public LinuxTracing::TracerListener {
   uint64_t ProcessStringAndGetKey(const std::string& string);
 
   LinuxTracingBuffer* tracing_buffer_;
+  LinuxTracing::SamplingMethod sampling_method_;
   std::unique_ptr<LinuxTracing::Tracer> tracer_;
 
   absl::flat_hash_set<uint64_t> addresses_seen_;

--- a/OrbitLinuxTracing/PerfEvent.h
+++ b/OrbitLinuxTracing/PerfEvent.h
@@ -259,7 +259,9 @@ class CallchainSamplePerfEvent : public PerfEvent {
   perf_event_callchain_sample ring_buffer_record;
   std::vector<uint64_t> ips;
   explicit CallchainSamplePerfEvent(uint64_t callchain_size)
-      : ips(callchain_size) {}
+      : ips(callchain_size) {
+    ring_buffer_record.nr = callchain_size;
+  }
 
   uint64_t GetTimestamp() const override {
     return ring_buffer_record.sample_id.time;

--- a/OrbitLinuxTracing/PerfEventReaders.cpp
+++ b/OrbitLinuxTracing/PerfEventReaders.cpp
@@ -79,9 +79,6 @@ std::unique_ptr<CallchainSamplePerfEvent> ConsumeCallchainSamplePerfEvent(
       &event->ring_buffer_record.sample_id,
       offsetof(perf_event_callchain_sample, sample_id));
 
-  ring_buffer->ReadValueAtOffset(&event->ring_buffer_record.nr,
-                                 offsetof(perf_event_callchain_sample, nr));
-
   // TODO(kuebler): we should have templated read methods
   uint64_t size_in_bytes = nr * sizeof(uint64_t) / sizeof(char);
   ring_buffer->ReadRawAtOffset(reinterpret_cast<char*>(event->ips.data()),

--- a/OrbitLinuxTracing/PerfEventReaders.cpp
+++ b/OrbitLinuxTracing/PerfEventReaders.cpp
@@ -79,6 +79,9 @@ std::unique_ptr<CallchainSamplePerfEvent> ConsumeCallchainSamplePerfEvent(
       &event->ring_buffer_record.sample_id,
       offsetof(perf_event_callchain_sample, sample_id));
 
+  ring_buffer->ReadValueAtOffset(&event->ring_buffer_record.nr,
+                                 offsetof(perf_event_callchain_sample, nr));
+
   // TODO(kuebler): we should have templated read methods
   uint64_t size_in_bytes = nr * sizeof(uint64_t) / sizeof(char);
   ring_buffer->ReadRawAtOffset(reinterpret_cast<char*>(event->ips.data()),

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/Tracer.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/Tracer.h
@@ -32,21 +32,8 @@ class Tracer {
 
   void SetListener(TracerListener* listener) { listener_ = listener; }
 
-  void SetTraceContextSwitches(bool trace_context_switches) {
-    tracing_options_.trace_context_switches = trace_context_switches;
-  }
-
-  void SetSamplingMethod(SamplingMethod sampling_method) {
-    tracing_options_.sampling_method = sampling_method;
-  }
-
-  void SetTraceInstrumentedFunctions(bool trace_instrumented_functions) {
-    tracing_options_.trace_instrumented_functions =
-        trace_instrumented_functions;
-  }
-
-  void SetTraceGpuDriver(bool trace_gpu_driver) {
-    tracing_options_.trace_gpu_driver = trace_gpu_driver;
+  void SetTracingOptions(TracingOptions tracing_options) {
+    tracing_options_ = tracing_options;
   }
 
   void Start() {

--- a/OrbitService/OrbitAsioServer.cpp
+++ b/OrbitService/OrbitAsioServer.cpp
@@ -6,7 +6,9 @@
 #include "Introspection.h"
 #include "TcpServer.h"
 
-OrbitAsioServer::OrbitAsioServer(uint16_t port) {
+OrbitAsioServer::OrbitAsioServer(uint16_t port,
+                                 LinuxTracing::SamplingMethod sampling_method)
+    : sampling_method_{sampling_method} {
   // TODO: Don't use the GTcpServer global. Unfortunately, it's needed in
   //  TcpConnection::DecodeMessage.
   GTcpServer = std::make_unique<TcpServer>();

--- a/OrbitService/OrbitAsioServer.cpp
+++ b/OrbitService/OrbitAsioServer.cpp
@@ -7,8 +7,8 @@
 #include "TcpServer.h"
 
 OrbitAsioServer::OrbitAsioServer(uint16_t port,
-                                 LinuxTracing::SamplingMethod sampling_method)
-    : sampling_method_{sampling_method} {
+                                 LinuxTracing::TracingOptions tracing_options)
+    : tracing_options_{tracing_options} {
   // TODO: Don't use the GTcpServer global. Unfortunately, it's needed in
   //  TcpConnection::DecodeMessage.
   GTcpServer = std::make_unique<TcpServer>();

--- a/OrbitService/OrbitAsioServer.h
+++ b/OrbitService/OrbitAsioServer.h
@@ -6,6 +6,7 @@
 
 #include "LinuxTracingBuffer.h"
 #include "LinuxTracingHandler.h"
+#include "OrbitLinuxTracing/TracingOptions.h"
 #include "ProcessMemoryService.h"
 #include "ProcessUtils.h"
 #include "SymbolsService.h"
@@ -13,7 +14,8 @@
 
 class OrbitAsioServer {
  public:
-  explicit OrbitAsioServer(uint16_t port);
+  explicit OrbitAsioServer(uint16_t port,
+                           LinuxTracing::SamplingMethod sampling_method);
   void Run(std::atomic<bool>* exit_requested);
 
  private:
@@ -43,5 +45,6 @@ class OrbitAsioServer {
   std::vector<std::shared_ptr<Function>> selected_functions_;
   std::thread tracing_buffer_thread_;
   LinuxTracingBuffer tracing_buffer_;
-  LinuxTracingHandler tracing_handler_{&tracing_buffer_};
+  LinuxTracing::SamplingMethod sampling_method_;
+  LinuxTracingHandler tracing_handler_{&tracing_buffer_, sampling_method_};
 };

--- a/OrbitService/OrbitAsioServer.h
+++ b/OrbitService/OrbitAsioServer.h
@@ -15,7 +15,7 @@
 class OrbitAsioServer {
  public:
   explicit OrbitAsioServer(uint16_t port,
-                           LinuxTracing::SamplingMethod sampling_method);
+                           LinuxTracing::TracingOptions tracing_options);
   void Run(std::atomic<bool>* exit_requested);
 
  private:
@@ -45,6 +45,6 @@ class OrbitAsioServer {
   std::vector<std::shared_ptr<Function>> selected_functions_;
   std::thread tracing_buffer_thread_;
   LinuxTracingBuffer tracing_buffer_;
-  LinuxTracing::SamplingMethod sampling_method_;
-  LinuxTracingHandler tracing_handler_{&tracing_buffer_, sampling_method_};
+  LinuxTracing::TracingOptions tracing_options_;
+  LinuxTracingHandler tracing_handler_{&tracing_buffer_, tracing_options_};
 };

--- a/OrbitService/OrbitService.cpp
+++ b/OrbitService/OrbitService.cpp
@@ -9,7 +9,7 @@ void OrbitService::Run(std::atomic<bool>* exit_requested) {
   grpc_server = OrbitGrpcServer::Create(grpc_address_);
 
   std::cout << "Starting Asio server on port " << asio_port_ << std::endl;
-  OrbitAsioServer asio_server{asio_port_};
+  OrbitAsioServer asio_server{asio_port_, sampling_method_};
   asio_server.Run(exit_requested);
 
   grpc_server->Shutdown();

--- a/OrbitService/OrbitService.cpp
+++ b/OrbitService/OrbitService.cpp
@@ -9,7 +9,7 @@ void OrbitService::Run(std::atomic<bool>* exit_requested) {
   grpc_server = OrbitGrpcServer::Create(grpc_address_);
 
   std::cout << "Starting Asio server on port " << asio_port_ << std::endl;
-  OrbitAsioServer asio_server{asio_port_, sampling_method_};
+  OrbitAsioServer asio_server{asio_port_, tracing_options_};
   asio_server.Run(exit_requested);
 
   grpc_server->Shutdown();

--- a/OrbitService/OrbitService.h
+++ b/OrbitService/OrbitService.h
@@ -5,16 +5,22 @@
 #include <string>
 #include <utility>
 
+#include "OrbitLinuxTracing/TracingOptions.h"
+
 class OrbitService {
  public:
-  OrbitService(std::string grpc_address, uint16_t asio_port)
-      : grpc_address_{std::move(grpc_address)}, asio_port_{asio_port} {}
+  OrbitService(std::string grpc_address, uint16_t asio_port,
+               LinuxTracing::SamplingMethod sampling_method)
+      : grpc_address_{std::move(grpc_address)},
+        asio_port_{asio_port},
+        sampling_method_{sampling_method} {}
 
   void Run(std::atomic<bool>* exit_requested);
 
  private:
   std::string grpc_address_;
   uint16_t asio_port_;
+  LinuxTracing::SamplingMethod sampling_method_;
 };
 
 #endif  // ORBIT_SERVICE_ORBIT_SERVICE_H

--- a/OrbitService/OrbitService.h
+++ b/OrbitService/OrbitService.h
@@ -10,17 +10,17 @@
 class OrbitService {
  public:
   OrbitService(std::string grpc_address, uint16_t asio_port,
-               LinuxTracing::SamplingMethod sampling_method)
+               LinuxTracing::TracingOptions tracing_options)
       : grpc_address_{std::move(grpc_address)},
         asio_port_{asio_port},
-        sampling_method_{sampling_method} {}
+        tracing_options_{tracing_options} {}
 
   void Run(std::atomic<bool>* exit_requested);
 
  private:
   std::string grpc_address_;
   uint16_t asio_port_;
-  LinuxTracing::SamplingMethod sampling_method_;
+  LinuxTracing::TracingOptions tracing_options_;
 };
 
 #endif  // ORBIT_SERVICE_ORBIT_SERVICE_H

--- a/OrbitService/main.cpp
+++ b/OrbitService/main.cpp
@@ -3,6 +3,7 @@
 
 #include "OrbitLinuxTracing/TracingOptions.h"
 #include "OrbitService.h"
+#include "Params.h"
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
 #include "absl/flags/usage.h"
@@ -45,16 +46,17 @@ int main(int argc, char** argv) {
   std::string grpc_server_address = absl::GetFlag(FLAGS_grpc_server_address);
   uint16_t asio_port = absl::GetFlag(FLAGS_asio_port);
 
-  LinuxTracing::SamplingMethod sampling_method =
-      LinuxTracing::SamplingMethod::kDwarf;
+  LinuxTracing::TracingOptions tracing_options;
+  tracing_options.trace_context_switches = GParams.m_TrackContextSwitches;
+
   bool use_frame_pointer_unwinding =
       absl::GetFlag(FLAGS_frame_pointer_unwinding);
-
   if (use_frame_pointer_unwinding) {
-    sampling_method = LinuxTracing::SamplingMethod::kFramePointers;
+    tracing_options.sampling_method =
+        LinuxTracing::SamplingMethod::kFramePointers;
   }
 
   exit_requested = false;
-  OrbitService service{grpc_server_address, asio_port, sampling_method};
+  OrbitService service{grpc_server_address, asio_port, tracing_options};
   service.Run(&exit_requested);
 }

--- a/OrbitService/main.cpp
+++ b/OrbitService/main.cpp
@@ -3,7 +3,6 @@
 
 #include "OrbitLinuxTracing/TracingOptions.h"
 #include "OrbitService.h"
-#include "Params.h"
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
 #include "absl/flags/usage.h"
@@ -14,7 +13,7 @@ ABSL_FLAG(uint16_t, asio_port, 44766, "Asio TCP server port");
 ABSL_FLAG(std::string, grpc_server_address, "0.0.0.0:44755",
           "Grpc server address");
 
-// TODO: Remove this flag once we have an ui option to specify.
+// TODO: Remove this flag once we have a ui option to specify.
 ABSL_FLAG(bool, frame_pointer_unwinding, false,
           "Use frame pointers for unwinding");
 
@@ -47,11 +46,8 @@ int main(int argc, char** argv) {
   uint16_t asio_port = absl::GetFlag(FLAGS_asio_port);
 
   LinuxTracing::TracingOptions tracing_options;
-  tracing_options.trace_context_switches = GParams.m_TrackContextSwitches;
 
-  bool use_frame_pointer_unwinding =
-      absl::GetFlag(FLAGS_frame_pointer_unwinding);
-  if (use_frame_pointer_unwinding) {
+  if (absl::GetFlag(FLAGS_frame_pointer_unwinding)) {
     tracing_options.sampling_method =
         LinuxTracing::SamplingMethod::kFramePointers;
   }

--- a/OrbitService/main.cpp
+++ b/OrbitService/main.cpp
@@ -1,6 +1,7 @@
 #include <csignal>
 #include <iostream>
 
+#include "OrbitLinuxTracing/TracingOptions.h"
 #include "OrbitService.h"
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
@@ -11,6 +12,10 @@ ABSL_FLAG(uint16_t, asio_port, 44766, "Asio TCP server port");
 // TODO: Default it 127.0.0.1 once ssh tunneling is enabled.
 ABSL_FLAG(std::string, grpc_server_address, "0.0.0.0:44755",
           "Grpc server address");
+
+// TODO: Remove this flag once we have an ui option to specify.
+ABSL_FLAG(bool, frame_pointer_unwinding, false,
+          "Use frame pointers for unwinding");
 
 namespace {
 std::atomic<bool> exit_requested;
@@ -40,7 +45,16 @@ int main(int argc, char** argv) {
   std::string grpc_server_address = absl::GetFlag(FLAGS_grpc_server_address);
   uint16_t asio_port = absl::GetFlag(FLAGS_asio_port);
 
+  LinuxTracing::SamplingMethod sampling_method =
+      LinuxTracing::SamplingMethod::kDwarf;
+  bool use_frame_pointer_unwinding =
+      absl::GetFlag(FLAGS_frame_pointer_unwinding);
+
+  if (use_frame_pointer_unwinding) {
+    sampling_method = LinuxTracing::SamplingMethod::kFramePointers;
+  }
+
   exit_requested = false;
-  OrbitService service{grpc_server_address, asio_port};
+  OrbitService service{grpc_server_address, asio_port, sampling_method};
   service.Run(&exit_requested);
 }


### PR DESCRIPTION
Fixed a bug, when reading a callchain record, which resulted in a segfault.
Further added a flag (frame_pointer_unwinding) to enable frame-pointer based unwinding as long as there is no UI option for this.