### PR TITLE
Revised Orbit's about dialog

### DIFF
--- a/OrbitQt/CMakeLists.txt
+++ b/OrbitQt/CMakeLists.txt
@@ -10,7 +10,8 @@ target_compile_options(OrbitQt PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(
   OrbitQt
-  PRIVATE orbitcodeeditor.h
+  PRIVATE orbitaboutdialog.h
+          orbitcodeeditor.h
           orbitdataviewpanel.h
           orbitdiffdialog.h
           orbitdisassemblydialog.h
@@ -33,6 +34,8 @@ target_sources(
 target_sources(
   OrbitQt
   PRIVATE main.cpp
+          orbitaboutdialog.cpp
+          orbitaboutdialog.ui
           orbitcodeeditor.cpp
           orbitdataviewpanel.cpp
           orbitdiffdialog.cpp

--- a/OrbitQt/orbitaboutdialog.cpp
+++ b/OrbitQt/orbitaboutdialog.cpp
@@ -1,0 +1,25 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "orbitaboutdialog.h"
+
+#include "ui_orbitaboutdialog.h"
+
+namespace OrbitQt {
+
+OrbitAboutDialog::OrbitAboutDialog(QWidget* parent)
+    : QDialog(parent), ui_(new Ui::OrbitAboutDialog) {
+  ui_->setupUi(this);
+}
+
+void OrbitAboutDialog::setLicenseText(const QString& text) {
+  ui_->licenseTextEdit->setPlainText(text);
+}
+
+void OrbitAboutDialog::setVersionString(const QString& version) {
+  ui_->versionLabel->setText(QString{"Version %1"}.arg(version));
+}
+
+OrbitAboutDialog::~OrbitAboutDialog() noexcept = default;
+}  // namespace OrbitQt

--- a/OrbitQt/orbitaboutdialog.h
+++ b/OrbitQt/orbitaboutdialog.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_QT_ORBITABOUTDIALOG_H_
+#define ORBIT_QT_ORBITABOUTDIALOG_H_
+
+#include <QDialog>
+#include <memory>
+
+namespace Ui {
+class OrbitAboutDialog;
+}  // namespace Ui
+
+namespace OrbitQt {
+
+class OrbitAboutDialog : public QDialog {
+ public:
+  explicit OrbitAboutDialog(QWidget* parent = nullptr);
+
+  void setLicenseText(const QString& text);
+  void setVersionString(const QString& version);
+
+  ~OrbitAboutDialog() noexcept;
+
+ private:
+  std::unique_ptr<Ui::OrbitAboutDialog> ui_;
+};
+
+}  // namespace OrbitQt
+
+#endif  // ORBIT_QT_ORBITABOUTDIALOG_H_

--- a/OrbitQt/orbitaboutdialog.ui
+++ b/OrbitQt/orbitaboutdialog.ui
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>OrbitAboutDialog</class>
+ <widget class="QDialog" name="OrbitAboutDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>799</width>
+    <height>516</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>OrbitAboutDialog</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="5" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="titleLanel">
+     <property name="font">
+      <font>
+       <pointsize>16</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Orbit Profiler</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QGroupBox" name="licenseGrooupBox">
+     <property name="title">
+      <string>Third Party Licenses:</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QPlainTextEdit" name="licenseTextEdit">
+        <property name="autoFillBackground">
+         <bool>false</bool>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::StyledPanel</enum>
+        </property>
+        <property name="lineWrapMode">
+         <enum>QPlainTextEdit::NoWrap</enum>
+        </property>
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+        <property name="backgroundVisible">
+         <bool>true</bool>
+        </property>
+        <property name="placeholderText">
+         <string>License text not available.</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="versionLabel">
+     <property name="text">
+      <string>Version 1.42</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="copyrightLabel">
+     <property name="text">
+      <string>Copyright © 2020 The Orbit Authors. All rights reserved.</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>OrbitAboutDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>OrbitAboutDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -25,6 +25,7 @@
 #include "../external/concurrentqueue/concurrentqueue.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_format.h"
+#include "orbitaboutdialog.h"
 #include "orbitdiffdialog.h"
 #include "orbitdisassemblydialog.h"
 #include "orbitsamplingreport.h"
@@ -454,9 +455,16 @@ void OrbitMainWindow::OnSetClipboard(const std::wstring& a_Text) {
 
 //-----------------------------------------------------------------------------
 void OrbitMainWindow::on_actionAbout_triggered() {
-  const QString text{
-      "Copyright (c) 2020 The Orbit Authors. All rights reserved."};
-  QMessageBox::about(this, windowTitle(), text);
+  OrbitQt::OrbitAboutDialog dialog{this};
+  dialog.setWindowTitle(windowTitle());
+  dialog.setVersionString(QCoreApplication::applicationVersion());
+
+  QFile licenseFile{QDir{QCoreApplication::applicationDirPath()}.filePath(
+      "THIRD_PARTY_LICENSES.txt")};
+  if (licenseFile.open(QIODevice::ReadOnly)) {
+    dialog.setLicenseText(licenseFile.readAll());
+  }
+  dialog.exec();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
- Added version display.
- Added third party license scroll box.

The license-box expects a file in parallel to `Orbit.exe` called `THIRD_PARTY_LICENSES.txt`.

![image](https://user-images.githubusercontent.com/43133967/81662324-b2172a80-943d-11ea-88b0-f75ef13758f7.png)

If the license file is not available it looks like so:
![image](https://user-images.githubusercontent.com/43133967/81662568-120dd100-943e-11ea-83d7-4cb61f1af034.png)
