### PR TITLE
Fixed bug in conan version handling code.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -31,7 +31,7 @@ class OrbitConan(ConanFile):
             self.run("git describe --always --tags", output=buf)
             self.version = buf.getvalue().strip()
             if self.version[0] == 'v':
-                self.version[1:]
+                self.version = self.version[1:]
 
         return self.version
 


### PR DESCRIPTION
This regression was introduced by pull/466 and not caught by my tests due to unfortunate circumstances. I apologize.

It should fix the failing ggp continuous build.