### PR TITLE
Refresh only views that need to be refreshed

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -313,7 +313,7 @@ void OrbitApp::PostInit() {
       main_thread_executor_->Schedule(
           [&, list = std::move(process_list)]() mutable {
             m_ProcessesDataView->SetProcessList(std::move(list));
-            FireRefreshCallbacks();
+            FireRefreshCallbacks(DataViewType::PROCESSES);
           });
     };
 


### PR DESCRIPTION
This fixes regression where Orbit unnecessary refreshes module view and
function view which leads to clearing selection and in case of large
function list it continuesly sorting it making UI quite unresposive.

Bug: http://b/156339359
Test: Select something in modules list wait 1 second - make sure
selection is not reset