### PR TITLE
Just a couple of small preliminary tweaks related to capture loading and saving

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -654,16 +654,16 @@ void OrbitApp::OnLaunchProcess(const std::string& process_name,
 }
 
 //-----------------------------------------------------------------------------
-std::wstring OrbitApp::GetCaptureFileName() {
-  assert(Capture::GTargetProcess);
+std::string OrbitApp::GetCaptureFileName() {
+  CHECK(Capture::GTargetProcess != nullptr);
   time_t timestamp =
       std::chrono::system_clock::to_time_t(Capture::GCaptureTimePoint);
-  std::string timestamp_string = OrbitUtils::FormatTime(timestamp);
-  std::string result =
-      Path::StripExtension(Capture::GTargetProcess->GetName()) + "_" +
-      timestamp_string + ".orbit";
-
-  return s2ws(result);
+  std::string result;
+  result.append(Path::StripExtension(Capture::GTargetProcess->GetName()));
+  result.append("_");
+  result.append(OrbitUtils::FormatTime(timestamp));
+  result.append(".orbit");
+  return result;
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -726,7 +726,7 @@ void OrbitApp::LoadSession(const std::shared_ptr<Session>& session) {
 void OrbitApp::OnSaveCapture(const std::string& file_name) {
   CaptureSerializer ar;
   ar.time_graph_ = GCurrentTimeGraph;
-  ar.Save(s2ws(file_name));
+  ar.Save(file_name);
 }
 
 //-----------------------------------------------------------------------------
@@ -740,7 +740,7 @@ void OrbitApp::OnLoadCapture(const std::string& file_name) {
 
   CaptureSerializer ar;
   ar.time_graph_ = GCurrentTimeGraph;
-  ar.Load(s2ws(file_name));
+  ar.Load(file_name);
   m_ModulesDataView->SetProcess(Capture::GTargetProcess);
   StopCapture();
   DoZoom = true;  // TODO: remove global, review logic

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -59,7 +59,7 @@ class OrbitApp final : public CoreApp, public DataViewFactory {
   void SetLicense(const std::wstring& a_License);
   std::string GetVersion();
 
-  std::wstring GetCaptureFileName();
+  std::string GetCaptureFileName();
   std::string GetSessionFileName();
   std::string GetSaveFile(const std::string& extension);
   void SetClipboard(const std::wstring& a_Text);

--- a/OrbitGl/CaptureSerializer.h
+++ b/OrbitGl/CaptureSerializer.h
@@ -12,11 +12,11 @@
 class CaptureSerializer {
  public:
   CaptureSerializer();
-  void Save(const std::wstring& a_FileName);
-  void Load(const std::wstring& a_FileName);
+  void Save(const std::string& filename);
+  void Load(const std::string& filename);
 
   template <class T>
-  void Save(T& a_Archive);
+  void Save(T& archive);
 
   class TimeGraph* time_graph_;
   class SamplingProfiler* m_SamplingProfiler;

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -640,19 +640,22 @@ void OrbitMainWindow::on_actionSave_Capture_triggered() {
       this, "Save capture...",
       (Path::GetCapturePath() + ws2s(GOrbitApp->GetCaptureFileName())).c_str(),
       "*.orbit");
+  if (file.isEmpty()) {
+    return;
+  }
   GOrbitApp->OnSaveCapture(file.toStdString());
 }
 
 //-----------------------------------------------------------------------------
 void OrbitMainWindow::on_actionOpen_Capture_2_triggered() {
-  QStringList list = QFileDialog::getOpenFileNames(
+  QString file = QFileDialog::getOpenFileName(
       this, "Open capture...", Path::GetCapturePath().c_str(), "*.orbit");
-  for (auto& file : list) {
-    GOrbitApp->OnLoadCapture(file.toStdString());
-    SetTitle(file.toStdString());
-    ui->MainTabWidget->setCurrentWidget(ui->CaptureTab);
-    break;
+  if (file.isEmpty()) {
+    return;
   }
+  GOrbitApp->OnLoadCapture(file.toStdString());
+  SetTitle(file.toStdString());
+  ui->MainTabWidget->setCurrentWidget(ui->CaptureTab);
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -638,7 +638,8 @@ void OrbitMainWindow::on_actionEnable_Sampling_toggled(bool arg1) {
 void OrbitMainWindow::on_actionSave_Capture_triggered() {
   QString file = QFileDialog::getSaveFileName(
       this, "Save capture...",
-      (Path::GetCapturePath() + ws2s(GOrbitApp->GetCaptureFileName())).c_str(),
+      Path::JoinPath({Path::GetCapturePath(), GOrbitApp->GetCaptureFileName()})
+          .c_str(),
       "*.orbit");
   if (file.isEmpty()) {
     return;


### PR DESCRIPTION
#### Allow choosing only one capture file to open
#### Make OrbitApp::GetCaptureFileName return std::string, not std::wstring
#### std::wstring -> std::string for CaptureSerializer::Save,Load