### PR TITLE
Hide "output" tab and related "Visualize" context action for functions

### DIFF
--- a/OrbitGl/FunctionsDataView.cpp
+++ b/OrbitGl/FunctionsDataView.cpp
@@ -11,7 +11,10 @@
 #include "OrbitProcess.h"
 #include "OrbitType.h"
 #include "Pdb.h"
+#include "absl/flags/flag.h"
 #include "absl/strings/str_format.h"
+
+ABSL_DECLARE_FLAG(bool, enable_stale_features);
 
 //-----------------------------------------------------------------------------
 FunctionsDataView::FunctionsDataView() : DataView(DataViewType::FUNCTIONS) {}
@@ -132,6 +135,7 @@ std::vector<std::string> FunctionsDataView::GetContextMenu(
     int a_ClickedIndex, const std::vector<int>& a_SelectedIndices) {
   bool enable_select = false;
   bool enable_unselect = false;
+  bool enable_view = absl::GetFlag(FLAGS_enable_stale_features);
   for (int index : a_SelectedIndices) {
     const Function& function = GetFunction(index);
     enable_select |= !function.IsSelected();
@@ -141,7 +145,8 @@ std::vector<std::string> FunctionsDataView::GetContextMenu(
   std::vector<std::string> menu;
   if (enable_select) menu.emplace_back(MENU_ACTION_SELECT);
   if (enable_unselect) menu.emplace_back(MENU_ACTION_UNSELECT);
-  Append(menu, {MENU_ACTION_VIEW, MENU_ACTION_DISASSEMBLY});
+  if (enable_view) menu.emplace_back(MENU_ACTION_VIEW);
+  menu.emplace_back(MENU_ACTION_DISASSEMBLY);
   // TODO: MENU_ACTION_SET_AS_FRAME is never shown, should it be removed?
   Append(menu, DataView::GetContextMenu(a_ClickedIndex, a_SelectedIndices));
   return menu;

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -136,6 +136,7 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App,
   }
 
   if (!absl::GetFlag(FLAGS_enable_stale_features)) {
+    ui->MainTabWidget->removeTab(ui->MainTabWidget->indexOf(ui->OutputTab));
     ui->MainTabWidget->removeTab(ui->MainTabWidget->indexOf(ui->WatchTab));
 
     ui->RightTabWidget->removeTab(ui->RightTabWidget->indexOf(ui->TypesTab));


### PR DESCRIPTION
Behind the usual `enable_stale_features` command line flag.

Bug: http://b/147659481