### PR TITLE
Moved OrbitService in Debian packaging step to /opt/developer/tools/.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -138,7 +138,7 @@ class OrbitConan(ConanFile):
             self.copy("*.so*", src="bin/", dst="{}-{}/usr/lib/x86_64-linux-gnu/".format(
                 self.name, self._version()), symlinks=True)
             self.copy("OrbitService", src="bin/",
-                      dst="{}-{}/usr/bin/".format(self.name, self._version()))
+                      dst="{}-{}/opt/developer/tools/".format(self.name, self._version()))
             self.copy("THIRD_PARTY_LICENSES.txt",
                       dst="{}-{}/usr/share/doc/{}/".format(self.name, self._version(), self.name))
             self.copy("LICENSE",


### PR DESCRIPTION
After this PR the content of the deb-package will like so:
```
drwxr-xr-x root/root         0 2020-05-14 13:33 ./
drwxr-xr-x root/root         0 2020-05-14 13:33 ./opt/
drwxr-xr-x root/root         0 2020-05-14 13:33 ./opt/developer/
drwxr-xr-x root/root         0 2020-05-14 13:33 ./opt/developer/tools/
-rwxr-xr-x root/root  20314544 2020-05-12 13:37 ./opt/developer/tools/OrbitService
drwxr-xr-x root/root         0 2020-05-14 13:33 ./usr/
drwxr-xr-x root/root         0 2020-05-14 13:33 ./usr/share/
drwxr-xr-x root/root         0 2020-05-14 13:33 ./usr/share/doc/
drwxr-xr-x root/root         0 2020-05-14 13:33 ./usr/share/doc/OrbitProfiler/
-rw-r--r-- root/root      1319 2020-01-17 21:09 ./usr/share/doc/OrbitProfiler/LICENSE
-rw-r--r-- root/root     93548 2020-05-12 13:40 ./usr/share/doc/OrbitProfiler/THIRD_PARTY_LICENSES.txt
```