### PR TITLE
Add VSCode build and debug scripts.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "(gdb) Launch",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/build_default_relwithdebinfo/bin/Orbit",
+      "args": ["--remote", "127.0.0.1" ],
+      "stopAtEntry": false,
+      "cwd": "${workspaceFolder}/build_default_relwithdebinfo/bin/",
+      "environment": [],
+      "externalConsole": false,
+      "MIMode": "gdb",
+      "setupCommands": [
+        {
+          "description": "Enable pretty-printing for gdb",
+          "text": "-enable-pretty-printing",
+          "ignoreFailures": true
+        }
+      ]
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,10 @@
       "type": "cppdbg",
       "request": "launch",
       "program": "${workspaceFolder}/build_default_relwithdebinfo/bin/Orbit",
-      "args": ["--remote", "127.0.0.1" ],
+      "args": [
+        "--remote",
+        "127.0.0.1"
+      ],
       "stopAtEntry": false,
       "cwd": "${workspaceFolder}/build_default_relwithdebinfo/bin/",
       "environment": [],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,8 @@
 			"label": "shell: build default relwithdebinfo",
 			"command": "cmake",
 			"args": [
-				"--build", "."
+				"--build",
+				"."
 			],
 			"options": {
 				"cwd": "${workspaceFolder}/build_default_relwithdebinfo"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,20 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "shell",
+			"label": "shell: build default relwithdebinfo",
+			"command": "cmake",
+			"args": [
+				"--build", "."
+			],
+			"options": {
+				"cwd": "${workspaceFolder}/build_default_relwithdebinfo"
+			},
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		}
+	]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,21 +1,21 @@
 {
-	"version": "2.0.0",
-	"tasks": [
-		{
-			"type": "shell",
-			"label": "shell: build default relwithdebinfo",
-			"command": "cmake",
-			"args": [
-				"--build",
-				"."
-			],
-			"options": {
-				"cwd": "${workspaceFolder}/build_default_relwithdebinfo"
-			},
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			}
-		}
-	]
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "shell",
+      "label": "shell: build default relwithdebinfo",
+      "command": "cmake",
+      "args": [
+        "--build",
+        "."
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/build_default_relwithdebinfo"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Linux only scripts for building and debugging Orbit through VSCode.

tasks.json calls "cmake --build ." in build_default_relwithdebinfo.  It is 
triggered when pressing "Ctrl-Shift-B" in vscode or by selecting 
"terminal->Run Build Tasks".  

launch.json calls "Orbit --remote 127.0.0.1" and sets up gdb debugging 
from VSCode. It is triggered by pressing "F5" or selecting 
"run->Start Debugging" .

With this we can have a decent debugging experience on Linux.