### PR TITLE
Fix gcc compile errors with caused by sign checks

### DIFF
--- a/OrbitSsh/Channel.cpp
+++ b/OrbitSsh/Channel.cpp
@@ -116,7 +116,7 @@ ResultType Channel::Read(std::string* result, int buffer_size) {
   return ResultType::kAgain;
 }
 
-ResultType Channel::Write(const std::string& text, int* written_length) {
+ResultType Channel::Write(const std::string& text, size_t* written_length) {
   CHECK(text.size() >= *written_length);
   int rc =
       libssh2_channel_write(raw_channel_ptr_, text.data() + *written_length,
@@ -132,7 +132,7 @@ ResultType Channel::Write(const std::string& text, int* written_length) {
 }
 
 ResultType Channel::WriteBlocking(const std::string& text) {
-  int written_length = 0;
+  size_t written_length = 0;
   do {
     ResultType result = Write(text, &written_length);
     if (result == ResultType::kError) return result;

--- a/OrbitSsh/Socket.cpp
+++ b/OrbitSsh/Socket.cpp
@@ -126,7 +126,7 @@ ResultType Socket::Receive(std::string* result, int buffer_size) {
   return ResultType::kSuccess;
 }
 
-ResultType Socket::Send(const std::string& text, int* sent_length) {
+ResultType Socket::Send(const std::string& text, size_t* sent_length) {
   int rc = send(descriptor_, text.data() + *sent_length,
                 text.length() - *sent_length, 0);
 
@@ -139,7 +139,7 @@ ResultType Socket::Send(const std::string& text, int* sent_length) {
 }
 
 ResultType Socket::SendBlocking(const std::string& text) {
-  int sent_length = 0;
+  size_t sent_length = 0;
   do {
     ResultType result = Send(text, &sent_length);
     if (result == ResultType::kError) return result;

--- a/OrbitSsh/include/OrbitSsh/Channel.h
+++ b/OrbitSsh/include/OrbitSsh/Channel.h
@@ -49,7 +49,7 @@ class Channel {
 
  private:
   explicit Channel(LIBSSH2_CHANNEL* raw_channel_ptr);
-  ResultType Write(const std::string& text, int* written_length);
+  ResultType Write(const std::string& text, size_t* written_length);
   LIBSSH2_CHANNEL* raw_channel_ptr_;
 };
 

--- a/OrbitSsh/include/OrbitSsh/Socket.h
+++ b/OrbitSsh/include/OrbitSsh/Socket.h
@@ -59,7 +59,7 @@ class Socket {
 
  private:
   explicit Socket(Descriptor descriptor);
-  ResultType Send(const std::string& text, int* sent_length);
+  ResultType Send(const std::string& text, size_t* sent_length);
   Descriptor descriptor_ = LIBSSH2_INVALID_SOCKET;
 };
 


### PR DESCRIPTION
This is affecting OrbitSsh::Socket and OrbitSsh::Channel