### PR TITLE
Also show kernel modules like [uprobes].

### DIFF
--- a/OrbitCore/ModuleManager.cpp
+++ b/OrbitCore/ModuleManager.cpp
@@ -51,7 +51,7 @@ void ModuleManager::OnReceiveMessage(const Message& a_Msg) {
 //-----------------------------------------------------------------------------
 void ModuleManager::LoadPdbAsync(const std::shared_ptr<Module>& a_Module,
                                  std::function<void()> a_CompletionCallback) {
-  if (!a_Module->GetLoaded()) {
+  if (!a_Module->IsKernelModule() && !a_Module->GetLoaded()) {
     bool loadExports = a_Module->IsDll() && !a_Module->m_FoundPdb;
     if (a_Module->m_FoundPdb || loadExports) {
       const std::string& pdbName =

--- a/OrbitCore/OrbitModule.cpp
+++ b/OrbitCore/OrbitModule.cpp
@@ -28,7 +28,7 @@
 //-----------------------------------------------------------------------------
 Module::Module(const std::string& file_name, uint64_t address_start,
                uint64_t address_end, bool is_kernel_module) {
-  if (!Path::FileExists(file_name)) {
+  if (!is_kernel_module && !Path::FileExists(file_name)) {
     ERROR("Creating Module from path \"%s\": file does not exist",
           file_name.c_str());
   }

--- a/OrbitCore/OrbitModule.cpp
+++ b/OrbitCore/OrbitModule.cpp
@@ -27,7 +27,7 @@
 
 //-----------------------------------------------------------------------------
 Module::Module(const std::string& file_name, uint64_t address_start,
-               uint64_t address_end) {
+               uint64_t address_end, bool is_kernel_module) {
   if (!Path::FileExists(file_name)) {
     ERROR("Creating Module from path \"%s\": file does not exist",
           file_name.c_str());
@@ -40,6 +40,7 @@ Module::Module(const std::string& file_name, uint64_t address_start,
 
   m_AddressStart = address_start;
   m_AddressEnd = address_end;
+  m_IsKernelModule = is_kernel_module;
 
   m_PrettyName = m_FullName;
   m_AddressRange = absl::StrFormat("[%016" PRIx64 " - %016" PRIx64 "]",
@@ -100,7 +101,7 @@ uint64_t Module::ValidateAddress(uint64_t a_Address) {
 void Module::SetLoaded(bool a_Value) { m_Loaded = a_Value; }
 
 //-----------------------------------------------------------------------------
-ORBIT_SERIALIZE(Module, 0) {
+ORBIT_SERIALIZE(Module, 1) {
   ORBIT_NVP_VAL(0, m_Name);
   ORBIT_NVP_VAL(0, m_FullName);
   ORBIT_NVP_VAL(0, m_PdbName);
@@ -115,6 +116,7 @@ ORBIT_SERIALIZE(Module, 0) {
   ORBIT_NVP_VAL(0, m_Selected);
   ORBIT_NVP_VAL(0, m_Loaded);
   ORBIT_NVP_VAL(0, m_PdbSize);
+  ORBIT_NVP_VAL(1, m_IsKernelModule);
 }
 
 #ifndef WIN32

--- a/OrbitCore/OrbitModule.h
+++ b/OrbitCore/OrbitModule.h
@@ -17,7 +17,7 @@ class Pdb;
 struct Module {
   Module(){};
   Module(const std::string& file_name, uint64_t address_start,
-         uint64_t address_end);
+         uint64_t address_end, bool is_kernel_module);
 
   std::string GetPrettyName();
   bool IsDll() const;
@@ -25,6 +25,7 @@ struct Module {
   bool ContainsAddress(uint64_t a_Address) {
     return m_AddressStart <= a_Address && m_AddressEnd > a_Address;
   }
+  bool IsKernelModule() { return m_IsKernelModule; }
   uint64_t ValidateAddress(uint64_t a_Address);
   void SetLoaded(bool a_Value);
   bool GetLoaded() const { return m_Loaded; }
@@ -43,6 +44,7 @@ struct Module {
   uint64_t m_EntryPoint = 0;
   bool m_FoundPdb = false;
   bool m_Selected = false;
+  bool m_IsKernelModule = false;
 
   uint64_t m_PdbSize = 0;  // Size in bytes; windows: pdb, linux: module
 

--- a/OrbitCore/OrbitModuleTest.cpp
+++ b/OrbitCore/OrbitModuleTest.cpp
@@ -19,7 +19,7 @@ TEST(OrbitModule, Constructor) {
   uint64_t address_start = 0x700;  // sample test data
   uint64_t address_end = 0x1000;
 
-  Module module(file_path, address_start, address_end);
+  Module module(file_path, address_start, address_end, false);
 
   EXPECT_EQ(module.m_FullName, file_path);
   EXPECT_EQ(module.m_Name, executable_name);
@@ -33,6 +33,7 @@ TEST(OrbitModule, Constructor) {
   EXPECT_EQ(module.m_AddressRange, "[0000000000000700 - 0000000000001000]");
 
   EXPECT_TRUE(module.m_FoundPdb);
+  EXPECT_FALSE(module.m_IsKernelModule);
 
   EXPECT_EQ(module.m_Pdb, nullptr);
   EXPECT_EQ(module.m_PdbName, "");
@@ -43,7 +44,8 @@ TEST(OrbitModule, LoadFunctions) {
   const std::string executable_name = "hello_world_elf";
   const std::string file_path = executable_directory + executable_name;
 
-  std::shared_ptr<Module> module = std::make_shared<Module>(file_path, 0, 0);
+  std::shared_ptr<Module> module =
+      std::make_shared<Module>(file_path, 0, 0, false);
 
   SymbolHelper symbolHelper;
   ASSERT_TRUE(symbolHelper.LoadSymbolsIncludedInBinary(module));
@@ -80,7 +82,7 @@ TEST(OrbitModule, GetFunctionFromExactAddress) {
   const std::string file_path = executable_directory + "hello_world_static_elf";
 
   std::shared_ptr<Module> module =
-      std::make_shared<Module>(file_path, 0x400000, 0);
+      std::make_shared<Module>(file_path, 0x400000, 0, false);
 
   SymbolHelper symbolHelper;
   ASSERT_TRUE(symbolHelper.LoadSymbolsIncludedInBinary(module));
@@ -105,7 +107,7 @@ TEST(OrbitModule, GetFunctionFromProgramCounter) {
   const std::string file_path = executable_directory + "hello_world_static_elf";
 
   std::shared_ptr<Module> module =
-      std::make_shared<Module>(file_path, 0x400000, 0);
+      std::make_shared<Module>(file_path, 0x400000, 0, false);
 
   SymbolHelper symbolHelper;
 

--- a/OrbitCore/SymbolHelperTest.cpp
+++ b/OrbitCore/SymbolHelperTest.cpp
@@ -15,7 +15,8 @@ TEST(SymbolHelper, LoadSymbolsIncludedInBinary) {
   const std::string executable_name = "hello_world_elf";
   const std::string file_path = executable_directory + executable_name;
 
-  std::shared_ptr<Module> module = std::make_shared<Module>(file_path, 0, 0);
+  std::shared_ptr<Module> module =
+      std::make_shared<Module>(file_path, 0, 0, false);
 
   SymbolHelper symbolHelper;
   ASSERT_TRUE(symbolHelper.LoadSymbolsIncludedInBinary(module));
@@ -34,7 +35,8 @@ TEST(SymbolHelper, LoadSymbolsCollectorSameFile) {
   const std::string executable_name = "hello_world_elf";
   const std::string file_path = executable_directory + executable_name;
 
-  std::shared_ptr<Module> module = std::make_shared<Module>(file_path, 0, 0);
+  std::shared_ptr<Module> module =
+      std::make_shared<Module>(file_path, 0, 0, false);
 
   SymbolHelper symbolHelper({executable_directory}, {});
   ASSERT_TRUE(symbolHelper.LoadSymbolsCollector(module));
@@ -53,7 +55,8 @@ TEST(SymbolHelper, LoadSymbolsCollectorSeparateFile) {
   const std::string executable_name = "no_symbols_elf";
   const std::string file_path = executable_directory + executable_name;
 
-  std::shared_ptr<Module> module = std::make_shared<Module>(file_path, 0, 0);
+  std::shared_ptr<Module> module =
+      std::make_shared<Module>(file_path, 0, 0, false);
   module->m_DebugSignature = "b5413574bbacec6eacb3b89b1012d0e2cd92ec6b";
 
   std::string symbols_file_name = "no_symbols_elf.debug";
@@ -76,7 +79,8 @@ TEST(SymbolHelper, LoadSymbolsUsingSymbolsFile) {
   const std::string executable_name = "no_symbols_elf";
   const std::string file_path = executable_directory + executable_name;
 
-  std::shared_ptr<Module> module = std::make_shared<Module>(file_path, 0, 0);
+  std::shared_ptr<Module> module =
+      std::make_shared<Module>(file_path, 0, 0, false);
   module->m_DebugSignature = "b5413574bbacec6eacb3b89b1012d0e2cd92ec6b";
 
   std::string symbols_file_name = "no_symbols_elf.debug";
@@ -107,7 +111,8 @@ TEST(SymbolHelper, LoadSymbolsFromDebugInfo) {
                                              0, 0, 0, "", 0);
   module_info.m_Functions = {function};
 
-  std::shared_ptr<Module> module = std::make_shared<Module>(file_path, 0x40, 0);
+  std::shared_ptr<Module> module =
+      std::make_shared<Module>(file_path, 0x40, 0, false);
   SymbolHelper symbolHelper;
   symbolHelper.LoadSymbolsFromDebugInfo(module, module_info);
 
@@ -128,7 +133,8 @@ TEST(SymbolHelper, FillDebugInfoFromModule) {
   const std::string executable_name = "hello_world_elf";
   const std::string file_path = executable_directory + executable_name;
 
-  std::shared_ptr<Module> module = std::make_shared<Module>(file_path, 0, 0);
+  std::shared_ptr<Module> module =
+      std::make_shared<Module>(file_path, 0, 0, false);
   SymbolHelper symbolHelper;
   ASSERT_TRUE(symbolHelper.LoadSymbolsIncludedInBinary(module));
 

--- a/OrbitCore/TestRemoteMessages.cpp
+++ b/OrbitCore/TestRemoteMessages.cpp
@@ -67,6 +67,7 @@ void TestRemoteMessages::Run() {
   module.m_AddressEnd = 3;
   module.m_EntryPoint = 4;
   module.m_FoundPdb = true;
+  module.m_IsKernelModule = false;
 
   module.m_Selected = true;
   module.m_Loaded = true;

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -104,7 +104,7 @@ std::vector<std::string> CallStackDataView::GetContextMenu(
       enable_view = true;
       enable_disassembly = true;
     } else if (module != nullptr && module->m_FoundPdb &&
-               !module->GetLoaded()) {
+               !module->GetLoaded() && !module->m_IsKernelModule) {
       enable_load = true;
     }
   }
@@ -128,7 +128,8 @@ void CallStackDataView::OnContextMenu(const std::string& a_Action,
     for (int i : a_ItemIndices) {
       CallStackDataViewFrame frame = GetFrameFromRow(i);
       std::shared_ptr<Module> module = frame.module;
-      if (module != nullptr && module->m_FoundPdb && !module->GetLoaded()) {
+      if (module != nullptr && module->m_FoundPdb && !module->GetLoaded() &&
+          !module->IsKernelModule()) {
         GOrbitApp->EnqueueModuleToLoad(module);
       }
       GOrbitApp->LoadModules();

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -179,7 +179,8 @@ std::vector<std::string> SamplingReportDataView::GetContextMenu(
 
   bool enable_load = false;
   for (const auto& module : GetModulesFromIndices(a_SelectedIndices)) {
-    if (module->m_FoundPdb && !module->GetLoaded()) {
+    if (module->m_FoundPdb && !module->GetLoaded() &&
+        !module->IsKernelModule()) {
       enable_load = true;
     }
   }
@@ -206,7 +207,8 @@ void SamplingReportDataView::OnContextMenu(
     }
   } else if (a_Action == MENU_ACTION_MODULES_LOAD) {
     for (const auto& module : GetModulesFromIndices(a_ItemIndices)) {
-      if (module->m_FoundPdb && !module->GetLoaded()) {
+      if (module->m_FoundPdb && !module->GetLoaded() &&
+          !module->IsKernelModule()) {
         GOrbitApp->EnqueueModuleToLoad(module);
       }
     }


### PR DESCRIPTION
However, those modules can not be loaded.

The main reason for this PR is, to be able to detect, that a certain address is a uprobe.
However, some of those "named maps" also show up in samples, resulting in having "???" as module, rather than e.g. "[stack]". So the experience would be a bit nicer.