### PR TITLE
Fix saving and loading a capture

### DIFF
--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -7,9 +7,10 @@
 #include <string>
 
 #include "CallstackTypes.h"
-#include "LinuxTracingBuffer.h"
+#include "LinuxAddressInfo.h"
 #include "OrbitType.h"
 #include "Threading.h"
+#include "absl/container/flat_hash_map.h"
 
 class Process;
 class Session;
@@ -48,6 +49,7 @@ class Capture {
   static void RegisterZoneName(uint64_t a_ID, const char* a_Name);
   static void AddCallstack(CallStack& a_CallStack);
   static std::shared_ptr<CallStack> GetCallstack(CallstackID a_ID);
+  static LinuxAddressInfo* GetAddressInfo(uint64_t address);
   static void CheckForUnrealSupport();
   static void PreSave();
 
@@ -84,9 +86,11 @@ class Capture {
   static std::vector<std::shared_ptr<Function>> GSelectedFunctions;
   static std::map<uint64_t, Function*> GSelectedFunctionsMap;
   static std::map<uint64_t, Function*> GVisibleFunctionsMap;
-  static std::unordered_map<ULONG64, ULONG64> GFunctionCountMap;
-  static std::vector<ULONG64> GSelectedAddressesByType[Function::NUM_TYPES];
-  static std::unordered_map<DWORD64, std::shared_ptr<CallStack>> GCallstacks;
+  static std::unordered_map<uint64_t, uint64_t> GFunctionCountMap;
+  static std::vector<uint64_t> GSelectedAddressesByType[Function::NUM_TYPES];
+  static std::unordered_map<uint64_t, std::shared_ptr<CallStack>> GCallstacks;
+  static std::unordered_map<uint64_t, LinuxAddressInfo> GAddressInfos;
+  static std::unordered_map<uint64_t, std::string> GAddressToFunctionName;
   static std::unordered_map<uint64_t, std::string> GZoneNames;
   static class TextBox* GSelectedTextBox;
   static ThreadID GSelectedThreadId;

--- a/OrbitCore/ConnectionManager.cpp
+++ b/OrbitCore/ConnectionManager.cpp
@@ -7,13 +7,16 @@
 #include <streambuf>
 
 #include "Capture.h"
+#include "ContextSwitch.h"
 #include "CoreApp.h"
 #include "EventBuffer.h"
+#include "KeyAndString.h"
 #include "OrbitBase/Logging.h"
 #include "SamplingProfiler.h"
 #include "Serialization.h"
 #include "TcpClient.h"
 #include "TestRemoteMessages.h"
+#include "TidAndThreadName.h"
 #include "TimerManager.h"
 
 ConnectionManager::ConnectionManager() : exit_requested_(false) {}

--- a/OrbitCore/ConnectionManager.cpp
+++ b/OrbitCore/ConnectionManager.cpp
@@ -42,19 +42,6 @@ void ConnectionManager::ConnectToRemote(std::string remote_address) {
 void ConnectionManager::Stop() { exit_requested_ = true; }
 
 void ConnectionManager::SetupClientCallbacks() {
-  GTcpClient->AddMainThreadCallback(Msg_RemotePerf, [=](const Message& msg) {
-    PRINT_VAR(msg.m_Size);
-    std::string msgStr = msg.GetDataAsString();
-    std::istringstream buffer(msgStr);
-
-    Capture::NewSamplingProfiler();
-    Capture::GSamplingProfiler->StartCapture();
-    Capture::GSamplingProfiler->SetIsLinuxPerf(true);
-    Capture::GSamplingProfiler->StopCapture();
-    Capture::GSamplingProfiler->ProcessSamples();
-    GCoreApp->RefreshCaptureView();
-  });
-
   GTcpClient->AddCallback(Msg_Timers, [=](const Message& msg) {
     uint32_t numTimers = msg.m_Size / sizeof(Timer);
     const Timer* timers = static_cast<const Timer*>(msg.GetData());

--- a/OrbitCore/Message.h
+++ b/OrbitCore/Message.h
@@ -56,7 +56,6 @@ enum MessageType : int16_t {
   Msg_RemoteProcessRequest,
   Msg_RemoteModule,
   Msg_RemoteFunctions,
-  Msg_RemotePerf,
   Msg_RemoteProcessList,
   Msg_RemoteModuleDebugInfo,
   Msg_Timers,

--- a/OrbitCore/OrbitProcess.cpp
+++ b/OrbitCore/OrbitProcess.cpp
@@ -298,12 +298,6 @@ std::shared_ptr<Module> Process::GetModuleFromName(const std::string& a_Name) {
   return nullptr;
 }
 
-//-----------------------------------------------------------------------------
-void Process::AddAddressInfo(LinuxAddressInfo address_info) {
-  uint64_t address = address_info.address;
-  m_AddressInfos[address] = std::move(address_info);
-}
-
 #ifdef _WIN32
 //-----------------------------------------------------------------------------
 std::shared_ptr<OrbitDiaSymbol> Process::SymbolFromAddress(DWORD64 a_Address) {

--- a/OrbitCore/OrbitProcess.h
+++ b/OrbitCore/OrbitProcess.h
@@ -97,17 +97,6 @@ class Process {
 #ifdef _WIN32
   std::shared_ptr<OrbitDiaSymbol> SymbolFromAddress(uint64_t a_Address);
 #endif
-  LinuxAddressInfo* GetLinuxAddressInfo(uint64_t a_Address) {
-    if (m_AddressInfos.contains(a_Address)) {
-      return &m_AddressInfos.at(a_Address);
-    } else {
-      return nullptr;
-    }
-  }
-  void AddAddressInfo(LinuxAddressInfo address_info);
-  bool HasAddressInfo(uint64_t address) const {
-    return m_AddressInfos.contains(address);
-  }
 
   bool LineInfoFromAddress(uint64_t a_Address, struct LineInfo& o_LineInfo);
 
@@ -176,8 +165,6 @@ class Process {
   std::vector<std::shared_ptr<Thread>> m_Threads;
   std::unordered_set<uint32_t> m_ThreadIds;
   std::map<uint32_t, std::string> m_ThreadNames;
-
-  absl::flat_hash_map<uint64_t, LinuxAddressInfo> m_AddressInfos;
 
   // Transients
   std::vector<std::shared_ptr<Function>> m_Functions;

--- a/OrbitCore/Pdb.h
+++ b/OrbitCore/Pdb.h
@@ -148,7 +148,7 @@ class Pdb {
 #else
 class Pdb {
  public:
-  Pdb() = default;
+  explicit Pdb(const char* filename = "") { m_FileName = filename; }
   Pdb(uint64_t module_address, uint64_t load_bias, std::string file_name,
       std::string module_file_name);
   Pdb(const Pdb&) = delete;

--- a/OrbitCore/SamplingProfiler.cpp
+++ b/OrbitCore/SamplingProfiler.cpp
@@ -562,15 +562,6 @@ std::string SamplingProfiler::GetSymbolFromAddress(uint64_t a_Address) {
 }
 
 //-----------------------------------------------------------------------------
-bool SampledFunction::GetSelected() {
-  if (m_Function == nullptr) {
-    m_Function =
-        Capture::GTargetProcess->GetFunctionFromAddress(m_Address, false);
-  }
-  return m_Function ? m_Function->IsSelected() : false;
-}
-
-//-----------------------------------------------------------------------------
 ORBIT_SERIALIZE_WSTRING(SampledFunction, 0) {
   ORBIT_NVP_VAL(0, m_Name);
   ORBIT_NVP_VAL(0, m_Module);

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -5,6 +5,7 @@
 
 #include "BlockChain.h"
 #include "Callstack.h"
+#include "Capture.h"
 #include "Core.h"
 #include "EventBuffer.h"
 #include "Pdb.h"
@@ -17,7 +18,9 @@ class Thread;
 struct SampledFunction {
   SampledFunction() = default;
 
-  bool GetSelected();
+  bool GetSelected() {
+    return Capture::GSelectedFunctionsMap.count(m_Address) > 0;
+  }
   std::string m_Name;
   std::string m_Module;
   std::string m_File;

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -147,7 +147,6 @@ class SamplingProfiler {
   void ProcessSamplesAsync();
   void AddAddress(uint64_t a_Address);
 
-  std::string GetSymbolFromAddress(uint64_t a_Address);
   const ThreadSampleData& GetSummary() { return m_ThreadSampleData[0]; }
 
   ORBIT_SERIALIZABLE;
@@ -184,7 +183,6 @@ class SamplingProfiler {
       m_OriginalCallstackToResolvedCallstack;
   std::unordered_map<uint64_t, std::set<CallstackID>> m_FunctionToCallstacks;
   std::unordered_map<uint64_t, uint64_t> m_ExactAddressToFunctionAddress;
-  std::unordered_map<uint64_t, std::string> m_AddressToName;
   std::unordered_map<uint64_t, LineInfo> m_AddressToLineInfo;
   std::unordered_map<uint64_t, std::string> m_FileNames;
   std::vector<ProcessingDoneCallback> m_Callbacks;

--- a/OrbitCore/StringManager.cpp
+++ b/OrbitCore/StringManager.cpp
@@ -1,5 +1,7 @@
 #include "StringManager.h"
 
+#include "Serialization.h"
+
 bool StringManager::AddIfNotPresent(uint64_t key, std::string_view str) {
   absl::MutexLock lock{&mutex_};
   if (key_to_string_.contains(key)) {
@@ -28,3 +30,5 @@ void StringManager::Clear() {
   absl::MutexLock lock{&mutex_};
   key_to_string_.clear();
 }
+
+ORBIT_SERIALIZE(StringManager, 0) { ORBIT_NVP_VAL(0, key_to_string_); }

--- a/OrbitCore/StringManager.h
+++ b/OrbitCore/StringManager.h
@@ -4,6 +4,7 @@
 #include <optional>
 #include <string>
 
+#include "SerializationMacros.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/synchronization/mutex.h"
 
@@ -15,6 +16,8 @@ class StringManager {
   std::optional<std::string> Get(uint64_t key);
   bool Contains(uint64_t key);
   void Clear();
+
+  ORBIT_SERIALIZABLE;
 
  private:
   absl::flat_hash_map<uint64_t, std::string> key_to_string_;

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -171,7 +171,8 @@ void OrbitApp::ProcessContextSwitch(const ContextSwitch& a_ContextSwitch) {
 
 //-----------------------------------------------------------------------------
 void OrbitApp::AddAddressInfo(LinuxAddressInfo address_info) {
-  Capture::GTargetProcess->AddAddressInfo(std::move(address_info));
+  uint64_t address = address_info.address;
+  Capture::GAddressInfos.emplace(address, std::move(address_info));
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -126,7 +126,7 @@ class OrbitApp final : public CoreApp, public DataViewFactory {
   }
   typedef std::function<void(DataView*, std::shared_ptr<class SamplingReport>)>
       SamplingReportCallback;
-  void AddSamplingReoprtCallback(SamplingReportCallback a_Callback) {
+  void AddSamplingReportCallback(SamplingReportCallback a_Callback) {
     m_SamplingReportsCallbacks.emplace_back(std::move(a_Callback));
   }
   void AddSelectionReportCallback(SamplingReportCallback a_Callback) {

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -238,7 +238,7 @@ CallStackDataView::CallStackDataViewFrame CallStackDataView::GetFrameFromIndex(
   } else {
     std::string fallback_name;
     if (Capture::GSamplingProfiler != nullptr) {
-      fallback_name = Capture::GSamplingProfiler->GetSymbolFromAddress(address);
+      fallback_name = Capture::GAddressToFunctionName[address];
     }
     return CallStackDataViewFrame(address, fallback_name, module);
   }

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -151,6 +151,8 @@ void CaptureSerializer::Load(const std::string& filename) {
     Capture::GSamplingProfiler->SortByThreadUsage();
     Capture::GSamplingProfiler->SetLoadedFromFile(true);
 
+    time_graph_->Clear();
+
     // Event buffer
     archive(GEventTracer.GetEventBuffer());
 

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -56,7 +56,6 @@ void CaptureSerializer::Save(T& archive) {
   // Header
   archive(cereal::make_nvp("Capture", *this));
 
-  // Functions
   {
     ORBIT_SIZE_SCOPE("Functions");
     std::vector<Function> functions;
@@ -70,25 +69,31 @@ void CaptureSerializer::Save(T& archive) {
     archive(functions);
   }
 
-  // Function Count
   {
     ORBIT_SIZE_SCOPE("Capture::GFunctionCountMap");
     archive(Capture::GFunctionCountMap);
   }
 
-  // Callstacks
   {
     ORBIT_SIZE_SCOPE("Capture::GCallstacks");
     archive(Capture::GCallstacks);
   }
 
-  // Sampling profiler
+  {
+    ORBIT_SIZE_SCOPE("Capture::GAddressInfos");
+    archive(Capture::GAddressInfos);
+  }
+
+  {
+    ORBIT_SIZE_SCOPE("Capture::GAddressToFunctionName");
+    archive(Capture::GAddressToFunctionName);
+  }
+
   {
     ORBIT_SIZE_SCOPE("SamplingProfiler");
     archive(Capture::GSamplingProfiler);
   }
 
-  // Event buffer
   {
     ORBIT_SIZE_SCOPE("Event Buffer");
     archive(GEventTracer.GetEventBuffer());
@@ -116,11 +121,11 @@ void CaptureSerializer::Load(const std::string& filename) {
   // Binary
   std::ifstream file(filename, std::ios::binary);
   if (!file.fail()) {
-    // header
+    // Header
     cereal::BinaryInputArchive archive(file);
     archive(*this);
 
-    // functions
+    // Functions
     std::vector<Function> functions;
     archive(functions);
     Capture::GSelectedFunctions.clear();
@@ -134,13 +139,14 @@ void CaptureSerializer::Load(const std::string& filename) {
     }
     Capture::GVisibleFunctionsMap = Capture::GSelectedFunctionsMap;
 
-    // Function count
     archive(Capture::GFunctionCountMap);
 
-    // Callstacks
     archive(Capture::GCallstacks);
 
-    // Sampling profiler
+    archive(Capture::GAddressInfos);
+
+    archive(Capture::GAddressToFunctionName);
+
     archive(Capture::GSamplingProfiler);
     Capture::GSamplingProfiler->SortByThreadUsage();
     Capture::GSamplingProfiler->SetLoadedFromFile(true);

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -41,7 +41,7 @@ void CaptureSerializer::Save(const std::string& filename) {
   m_CaptureName = filename;
   std::ofstream file(m_CaptureName, std::ios::binary);
   if (!file.fail()) {
-    SCOPE_TIMER_LOG(absl::StrFormat("Saving capture in %s", filename));
+    SCOPE_TIMER_LOG(absl::StrFormat("Saving capture in \"%s\"", filename));
     cereal::BinaryOutputArchive archive(file);
     Save(archive);
     file.close();
@@ -62,7 +62,7 @@ void CaptureSerializer::Save(T& archive) {
     std::vector<Function> functions;
     for (auto& pair : Capture::GSelectedFunctionsMap) {
       Function* func = pair.second;
-      if (func) {
+      if (func != nullptr) {
         functions.push_back(*func);
       }
     }
@@ -71,7 +71,10 @@ void CaptureSerializer::Save(T& archive) {
   }
 
   // Function Count
-  archive(Capture::GFunctionCountMap);
+  {
+    ORBIT_SIZE_SCOPE("Capture::GFunctionCountMap");
+    archive(Capture::GFunctionCountMap);
+  }
 
   // Process
   {
@@ -114,7 +117,7 @@ void CaptureSerializer::Save(T& archive) {
 
 //-----------------------------------------------------------------------------
 void CaptureSerializer::Load(const std::string& filename) {
-  SCOPE_TIMER_LOG(absl::StrFormat("Loading capture %s", filename));
+  SCOPE_TIMER_LOG(absl::StrFormat("Loading capture from \"%s\"", filename));
 
 #ifdef _WIN32
   // Binary

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -95,6 +95,11 @@ void CaptureSerializer::Save(T& archive) {
   }
 
   {
+    ORBIT_SIZE_SCOPE("String manager");
+    archive(*time_graph_->GetStringManager());
+  }
+
+  {
     ORBIT_SIZE_SCOPE("Event Buffer");
     archive(GEventTracer.GetEventBuffer());
   }
@@ -152,6 +157,8 @@ void CaptureSerializer::Load(const std::string& filename) {
     Capture::GSamplingProfiler->SetLoadedFromFile(true);
 
     time_graph_->Clear();
+
+    archive(*time_graph_->GetStringManager());
 
     // Event buffer
     archive(GEventTracer.GetEventBuffer());

--- a/OrbitGl/LogDataView.cpp
+++ b/OrbitGl/LogDataView.cpp
@@ -117,8 +117,8 @@ std::vector<std::string> LogDataView::GetContextMenu(
   std::vector<std::string> menu;
   if (m_SelectedCallstack) {
     for (uint32_t i = 0; i < m_SelectedCallstack->m_Depth; ++i) {
-      uint64_t addr = m_SelectedCallstack->m_Data[i];
-      menu.push_back(Capture::GSamplingProfiler->GetSymbolFromAddress(addr));
+      uint64_t address = m_SelectedCallstack->m_Data[i];
+      menu.push_back(Capture::GAddressToFunctionName[address]);
     }
   }
   Append(menu, DataView::GetContextMenu(a_ClickedIndex, a_SelectedIndices));

--- a/OrbitGl/SamplingReportDataView.h
+++ b/OrbitGl/SamplingReportDataView.h
@@ -30,7 +30,6 @@ class SamplingReportDataView : public DataView {
   }
   void SetSampledFunctions(const std::vector<SampledFunction>& a_Functions);
   void SetThreadID(ThreadID a_TID);
-  std::vector<SampledFunction>& GetSampledFunctions() { return m_Functions; }
 
  protected:
   void DoSort() override;

--- a/OrbitGl/SchedulerTrack.h
+++ b/OrbitGl/SchedulerTrack.h
@@ -5,7 +5,7 @@
 
 class SchedulerTrack : public ThreadTrack {
  public:
-  SchedulerTrack(TimeGraph* time_graph);
+  explicit SchedulerTrack(TimeGraph* time_graph);
   ~SchedulerTrack() override = default;
 
   void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) override;

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -118,6 +118,7 @@ class TimeGraph {
  protected:
   void AddTrack(std::unique_ptr<Track> track);
   uint64_t GetGpuTimelineHash(const Timer& timer) const;
+  std::shared_ptr<SchedulerTrack> GetOrCreateSchedulerTrack();
   std::shared_ptr<ThreadTrack> GetOrCreateThreadTrack(ThreadID a_TID);
   std::shared_ptr<GpuTrack> GetOrCreateGpuTrack(uint64_t timeline_hash);
 
@@ -171,6 +172,7 @@ class TimeGraph {
   std::vector<std::shared_ptr<Track>> sorted_tracks_;
   std::string m_ThreadFilter;
 
+  std::set<uint32_t> cores_seen_;
   std::shared_ptr<SchedulerTrack> scheduler_track_;
   std::shared_ptr<ThreadTrack> process_track_;
 

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -71,7 +71,7 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App,
 
   GOrbitApp->AddRefreshCallback(
       [this](DataViewType a_Type) { this->OnRefreshDataViewPanels(a_Type); });
-  GOrbitApp->AddSamplingReoprtCallback(
+  GOrbitApp->AddSamplingReportCallback(
       [this](DataView* callstack_data_view,
              std::shared_ptr<SamplingReport> report) {
         this->OnNewSamplingReport(callstack_data_view, std::move(report));


### PR DESCRIPTION
#### Add one-argument (filename) constructor to Linux implementation of Pdb
To match the constructor in the Windows implementation.
#### Minor tweaks to CaptureSerializer (doesn't fix it)
#### Make capture loading build on Linux and fix some related crashes,issues
Bug: http://b/156005953
#### Fix typo AddSamplingReoprtCallback
#### Remove unnecessary MessageType::Msg_RemotePerf
#### Remove unused SamplingReportDataView::GetSampledFunctions
#### Move SamplingProfiler::m_AddressToName,Process::m_AddressInfos to Capture
#### Also add scheduler_track_ to TimeGraph::tracks_, so that it can be saved
#### Also save and load StringManager's strings
---
Note that this is indeed more of a hacky fix to the current implementation than a proper solution, as for the most part it saves and loads specific globals and is very prone to breaking again. But a better solution would probably involve a huge rework of the client's data model.