### PR TITLE
Patch callchain samples.

### DIFF
--- a/OrbitLinuxTracing/PerfEvent.h
+++ b/OrbitLinuxTracing/PerfEvent.h
@@ -278,6 +278,7 @@ class CallchainSamplePerfEvent : public PerfEvent {
 
   uint32_t GetCpu() const { return ring_buffer_record.sample_id.cpu; }
 
+  uint64_t* GetCallchain() { return ips.data(); }
   const uint64_t* GetCallchain() const { return ips.data(); }
 
   uint64_t GetCallchainSize() const { return ring_buffer_record.nr; }

--- a/OrbitLinuxTracing/UprobesReturnAddressManager.h
+++ b/OrbitLinuxTracing/UprobesReturnAddressManager.h
@@ -2,6 +2,8 @@
 #define ORBIT_LINUX_TRACING_UPROBES_RETURN_ADDRESS_MANAGER_H_
 
 #include <OrbitBase/Logging.h>
+#include <unwindstack/MapInfo.h>
+#include <unwindstack/Maps.h>
 
 #include <stack>
 #include <vector>

--- a/OrbitLinuxTracing/UprobesReturnAddressManager.h
+++ b/OrbitLinuxTracing/UprobesReturnAddressManager.h
@@ -65,7 +65,7 @@ class UprobesReturnAddressManager {
   // but only the callchain (as list of instruction pointers). In those,
   // a uprobe address occurs in place of the caller of an instrumented function.
   // This function patches the callchain, using the maps information to identify
-  // instruction pointers of uprobe code and using the return address safed in
+  // instruction pointers of uprobe code and using the return address saved in
   // the uprobes.
   bool PatchCallchain(pid_t tid, uint64_t* callchain, uint64_t callchain_size,
                       unwindstack::Maps* maps) {
@@ -94,16 +94,15 @@ class UprobesReturnAddressManager {
     // In case we already used all uprobes, we need to discard this sample.
     // There are two situations where this may happen:
     //  1. At the beginning of a capture, where we missed the first uprobes
-    //  2. When there are two many events, resulting in lost events or
-    //   processing out of order.
+    //  2. When some events are lost or processed out of order.
     if (tid_uprobes_stack.size() < ips_to_patch.size()) {
       ERROR(
-          "Discarding sample in an uprobe as some uprobe records are missing.");
+          "Discarding sample in a uprobe as some uprobe records are missing.");
       return false;
     }
     // In cases of lost events, or out of order processing, there might be wrong
-    //  uprobes. So we need to discard the event. In general we should be fast
-    //  enough, such that this does not happen.
+    // uprobes. So we need to discard the event. In general we should be fast
+    // enough, such that this does not happen.
     if (tid_uprobes_stack.size() > ips_to_patch.size() + 1) {
       ERROR("Discarding sample in an uprobe as uprobe records are incorrect.");
       return false;
@@ -115,8 +114,8 @@ class UprobesReturnAddressManager {
     //   address was already restored.
     //  2. At the very beginning of an instrumented function, where the return
     //   address was not yet overridden.
-    // In any case, the inner most uprobe has not overridden the return address.
-    // We do not need to patch the affect of this uprobe and can move forward.
+    // In any case, the innermost uprobe has not overridden the return address.
+    // We do not need to patch the effect of this uprobe and can move forward.
     if (tid_uprobes_stack.size() == ips_to_patch.size() + 1) {
       uprobes_it++;
     }

--- a/OrbitLinuxTracing/UprobesReturnAddressManager.h
+++ b/OrbitLinuxTracing/UprobesReturnAddressManager.h
@@ -63,7 +63,7 @@ class UprobesReturnAddressManager {
 
   // In case of callchain sampling we don't have the complete stack to patch,
   // but only the callchain (as list of instruction pointers). In those,
-  // a uprobe address occurs instead of the caller of an instrumented function.
+  // a uprobe address occurs in place of the caller of an instrumented function.
   // This function patches the callchain, using the maps information to identify
   // instruction pointers of uprobe code and using the return address safed in
   // the uprobes.

--- a/OrbitLinuxTracing/UprobesReturnAddressManager.h
+++ b/OrbitLinuxTracing/UprobesReturnAddressManager.h
@@ -79,7 +79,7 @@ class UprobesReturnAddressManager {
     std::vector<uint64_t> frames_to_patch;
 
     // TODO(kuebler): What about tail-call optimization, where two uretprobes
-    //  hijacked an address at the same stack pointer.
+    //  hijacked an address at the same stack pointer?
     for (uint64_t i = 0; i < callchain_size; i++) {
       uint64_t ip = callchain[i];
       unwindstack::MapInfo* map_info = maps->Find(ip);

--- a/OrbitLinuxTracing/UprobesReturnAddressManager.h
+++ b/OrbitLinuxTracing/UprobesReturnAddressManager.h
@@ -72,7 +72,7 @@ class UprobesReturnAddressManager {
 
     uint64_t i = 0;
     // TODO(kuebler): What about tail-call optimization, where two uretprobes
-    //  hijacked an address at the same stack.
+    //  hijacked an address at the same stack pointer?
     for (auto it = tid_uprobes_stack.rbegin(); it != tid_uprobes_stack.rend();
          it++) {
       const OpenUprobes& uprobes = *it;

--- a/OrbitLinuxTracing/UprobesReturnAddressManager.h
+++ b/OrbitLinuxTracing/UprobesReturnAddressManager.h
@@ -104,7 +104,7 @@ class UprobesReturnAddressManager {
     // uprobes. So we need to discard the event. In general we should be fast
     // enough, such that this does not happen.
     if (tid_uprobes_stack.size() > frames_to_patch.size() + 1) {
-      ERROR("Discarding sample in an uprobe as uprobe records are incorrect.");
+      ERROR("Discarding sample in a uprobe as uprobe records are incorrect.");
       return false;
     }
 

--- a/OrbitLinuxTracing/UprobesReturnAddressManagerTest.cpp
+++ b/OrbitLinuxTracing/UprobesReturnAddressManagerTest.cpp
@@ -395,6 +395,7 @@ TEST(UprobesReturnAddressManager, TailCallOptimization) {
 //==============================================================================
 // Tests for frame pointer based callchains start here:
 //==============================================================================
+namespace {
 
 const std::string maps_string =
     "55d0f260c000-55d0f260d000 r--p 00000000 fe:00 3415204                    "
@@ -478,24 +479,25 @@ const std::string maps_string =
     "7fffffffe000-7ffffffff000 --xp 00000000 00:00 0                          "
     "[uprobes]";
 
-auto maps = LibunwindstackUnwinder::ParseMaps(maps_string);
+std::unique_ptr<unwindstack::BufferMaps> maps =
+    LibunwindstackUnwinder::ParseMaps(maps_string);
 
 TEST(UprobesReturnAddressManager, CallchainNoUprobes) {
   UprobesReturnAddressManager return_address_manager;
 
   std::vector<uint64_t> expected_callchain{
-      18446744073709551104lu, 94355907990078lu, 94355907990120lu,
-      94355907990170lu,       94355907990220lu, 94355907990270lu,
-      94355907990320lu,       94355907990370lu, 94355907990423lu,
-      94355907990459lu,       94355907990731lu, 139669574937531lu,
-      6143427251839320320lu};
+      0xFFFFFFFFFFFFFE00lu, 0x55D0F260D23Elu, 0x55D0F260D268lu,
+      0x55D0F260D29Alu,     0x55D0F260D2CClu, 0x55D0F260D2FElu,
+      0x55D0F260D330lu,     0x55D0F260D362lu, 0x55D0F260D397lu,
+      0x55D0F260D3BBlu,     0x55D0F260D4CBlu, 0x7F075B666BBBlu,
+      0x5541D68949564100lu};
 
   std::vector<uint64_t> callchain_sample{
-      18446744073709551104lu, 94355907990078lu, 94355907990120lu,
-      94355907990170lu,       94355907990220lu, 94355907990270lu,
-      94355907990320lu,       94355907990370lu, 94355907990423lu,
-      94355907990459lu,       94355907990731lu, 139669574937531lu,
-      6143427251839320320lu};
+      0xFFFFFFFFFFFFFE00lu, 0x55D0F260D23Elu, 0x55D0F260D268lu,
+      0x55D0F260D29Alu,     0x55D0F260D2CClu, 0x55D0F260D2FElu,
+      0x55D0F260D330lu,     0x55D0F260D362lu, 0x55D0F260D397lu,
+      0x55D0F260D3BBlu,     0x55D0F260D4CBlu, 0x7F075B666BBBlu,
+      0x5541D68949564100lu};
 
   EXPECT_TRUE(return_address_manager.PatchCallchain(
       1, callchain_sample.data(), callchain_sample.size(), maps.get()));
@@ -506,20 +508,20 @@ TEST(UprobesReturnAddressManager, CallchainOneUprobe) {
   UprobesReturnAddressManager return_address_manager;
 
   std::vector<uint64_t> expected_callchain{
-      18446744073709551104lu, 94355907990078lu, 94355907990120lu,
-      94355907990170lu,       94355907990220lu, 94355907990270lu,
-      94355907990320lu,       94355907990370lu, 94355907990423lu,
-      94355907990459lu,       94355907990731lu, 139669574937531lu,
-      6143427251839320320lu};
+      0xFFFFFFFFFFFFFE00lu, 0x55D0F260D23Elu, 0x55D0F260D268lu,
+      0x55D0F260D29Alu,     0x55D0F260D2CClu, 0x55D0F260D2FElu,
+      0x55D0F260D330lu,     0x55D0F260D362lu, 0x55D0F260D397lu,
+      0x55D0F260D3BBlu,     0x55D0F260D4CBlu, 0x7F075B666BBBlu,
+      0x5541D68949564100lu};
 
-  return_address_manager.ProcessUprobes(1, 140723234287848lu, 94355907990270lu);
+  return_address_manager.ProcessUprobes(1, 0x7FFCAE6430E8lu, 0x55D0F260D2FElu);
 
   std::vector<uint64_t> callchain_sample{
-      18446744073709551104lu, 94355907990078lu, 94355907990120lu,
-      94355907990170lu,       94355907990220lu, 140737488347136lu,
-      94355907990320lu,       94355907990370lu, 94355907990423lu,
-      94355907990459lu,       94355907990731lu, 139669574937531lu,
-      6143427251839320320lu};
+      0xFFFFFFFFFFFFFE00lu, 0x55D0F260D23Elu, 0x55D0F260D268lu,
+      0x55D0F260D29Alu,     0x55D0F260D2CClu, 0x7FFFFFFFE000lu,
+      0x55D0F260D330lu,     0x55D0F260D362lu, 0x55D0F260D397lu,
+      0x55D0F260D3BBlu,     0x55D0F260D4CBlu, 0x7F075B666BBBlu,
+      0x5541D68949564100lu};
 
   EXPECT_TRUE(return_address_manager.PatchCallchain(
       1, callchain_sample.data(), callchain_sample.size(), maps.get()));
@@ -530,20 +532,20 @@ TEST(UprobesReturnAddressManager, CallchainTwoUprobes) {
   UprobesReturnAddressManager return_address_manager;
 
   std::vector<uint64_t> expected_callchain{
-      18446744073709551104lu, 94355907990063lu, 94355907990120lu,
-      94355907990170lu,       94355907990220lu, 94355907990270lu,
-      94355907990320lu,       94355907990370lu, 94355907990423lu,
-      94355907990459lu,       94355907990731lu, 139669574937531lu,
-      6143427251839320320lu};
-  return_address_manager.ProcessUprobes(1, 140723234287944lu, 94355907990423lu);
-  return_address_manager.ProcessUprobes(1, 140723234287816lu, 94355907990220lu);
+      0xFFFFFFFFFFFFFE00lu, 0x55D0F260D22Flu, 0x55D0F260D268lu,
+      0x55D0F260D29Alu,     0x55D0F260D2CClu, 0x55D0F260D2FElu,
+      0x55D0F260D330lu,     0x55D0F260D362lu, 0x55D0F260D397lu,
+      0x55D0F260D3BBlu,     0x55D0F260D4CBlu, 0x7F075B666BBBlu,
+      0x5541D68949564100lu};
+  return_address_manager.ProcessUprobes(1, 0x7FFCAE643148lu, 0x55D0F260D397lu);
+  return_address_manager.ProcessUprobes(1, 0x7FFCAE6430C8lu, 0x55D0F260D2CClu);
 
   std::vector<uint64_t> callchain_sample{
-      18446744073709551104lu, 94355907990063lu,  94355907990120lu,
-      94355907990170lu,       140737488347136lu, 94355907990270lu,
-      94355907990320lu,       94355907990370lu,  140737488347136lu,
-      94355907990459lu,       94355907990731lu,  139669574937531lu,
-      6143427251839320320lu};
+      0xFFFFFFFFFFFFFE00lu, 0x55D0F260D22Flu, 0x55D0F260D268lu,
+      0x55D0F260D29Alu,     0x7FFFFFFFE000lu, 0x55D0F260D2FElu,
+      0x55D0F260D330lu,     0x55D0F260D362lu, 0x7FFFFFFFE000lu,
+      0x55D0F260D3BBlu,     0x55D0F260D4CBlu, 0x7F075B666BBBlu,
+      0x5541D68949564100lu};
 
   EXPECT_TRUE(return_address_manager.PatchCallchain(
       1, callchain_sample.data(), callchain_sample.size(), maps.get()));
@@ -553,14 +555,14 @@ TEST(UprobesReturnAddressManager, CallchainTwoUprobes) {
 TEST(UprobesReturnAddressManager, CallchainTwoUprobesMissingOne) {
   UprobesReturnAddressManager return_address_manager;
 
-  return_address_manager.ProcessUprobes(1, 140723234287816lu, 94355907990220lu);
+  return_address_manager.ProcessUprobes(1, 0x7FFCAE6430C8lu, 0x55D0F260D2CClu);
 
   std::vector<uint64_t> callchain_sample{
-      18446744073709551104lu, 94355907990063lu,  94355907990120lu,
-      94355907990170lu,       140737488347136lu, 94355907990270lu,
-      94355907990320lu,       94355907990370lu,  140737488347136lu,
-      94355907990459lu,       94355907990731lu,  139669574937531lu,
-      6143427251839320320lu};
+      0xFFFFFFFFFFFFFE00lu, 0x55D0F260D22Flu, 0x55D0F260D268lu,
+      0x55D0F260D29Alu,     0x7FFFFFFFE000lu, 0x55D0F260D2FElu,
+      0x55D0F260D330lu,     0x55D0F260D362lu, 0x7FFFFFFFE000lu,
+      0x55D0F260D3BBlu,     0x55D0F260D4CBlu, 0x7F075B666BBBlu,
+      0x5541D68949564100lu};
 
   EXPECT_FALSE(return_address_manager.PatchCallchain(
       1, callchain_sample.data(), callchain_sample.size(), maps.get()));
@@ -570,22 +572,22 @@ TEST(UprobesReturnAddressManager, CallchainTwoConsecutiveUprobes) {
   UprobesReturnAddressManager return_address_manager;
 
   std::vector<uint64_t> expected_callchain{
-      18446744073709551104lu, 94355907990063lu, 94355907990120lu,
-      94355907990170lu,       94355907990220lu, 94355907990270lu,
-      94355907990320lu,       94355907990370lu, 94355907990423lu,
-      94355907990459lu,       94355907990731lu, 139669574937531lu,
-      6143427251839320320lu};
+      0xFFFFFFFFFFFFFE00lu, 0x55D0F260D22Flu, 0x55D0F260D268lu,
+      0x55D0F260D29Alu,     0x55D0F260D2CClu, 0x55D0F260D2FElu,
+      0x55D0F260D330lu,     0x55D0F260D362lu, 0x55D0F260D397lu,
+      0x55D0F260D3BBlu,     0x55D0F260D4CBlu, 0x7F075B666BBBlu,
+      0x5541D68949564100lu};
 
-  return_address_manager.ProcessUprobes(1, 140723234287944lu, 94355907990423lu);
-  return_address_manager.ProcessUprobes(1, 140723234287848lu, 94355907990270lu);
-  return_address_manager.ProcessUprobes(1, 140723234287816lu, 94355907990220lu);
+  return_address_manager.ProcessUprobes(1, 0x7FFCAE643148lu, 0x55D0F260D397lu);
+  return_address_manager.ProcessUprobes(1, 0x7FFCAE6430E8lu, 0x55D0F260D2FElu);
+  return_address_manager.ProcessUprobes(1, 0x7FFCAE6430C8lu, 0x55D0F260D2CClu);
 
   std::vector<uint64_t> callchain_sample{
-      18446744073709551104lu, 94355907990063lu,  94355907990120lu,
-      94355907990170lu,       140737488347136lu, 140737488347136lu,
-      94355907990320lu,       94355907990370lu,  140737488347136lu,
-      94355907990459lu,       94355907990731lu,  139669574937531lu,
-      6143427251839320320lu};
+      0xFFFFFFFFFFFFFE00lu, 0x55D0F260D22Flu, 0x55D0F260D268lu,
+      0x55D0F260D29Alu,     0x7FFFFFFFE000lu, 0x7FFFFFFFE000lu,
+      0x55D0F260D330lu,     0x55D0F260D362lu, 0x7FFFFFFFE000lu,
+      0x55D0F260D3BBlu,     0x55D0F260D4CBlu, 0x7F075B666BBBlu,
+      0x5541D68949564100lu};
 
   EXPECT_TRUE(return_address_manager.PatchCallchain(
       1, callchain_sample.data(), callchain_sample.size(), maps.get()));
@@ -596,24 +598,25 @@ TEST(UprobesReturnAddressManager, CallchainBeforeInjectionByUprobe) {
   UprobesReturnAddressManager return_address_manager;
 
   std::vector<uint64_t> expected_callchain{
-      18446744073709551104lu, 94355907990137lu, 94355907990270lu,
-      94355907990320lu,       94355907990370lu, 94355907990423lu,
-      94355907990459lu,       94355907990731lu, 139669574937531lu,
-      6143427251839320320lu};
+      0xFFFFFFFFFFFFFE00lu, 0x55D0F260D279lu, 0x55D0F260D2FElu,
+      0x55D0F260D330lu,     0x55D0F260D362lu, 0x55D0F260D397lu,
+      0x55D0F260D3BBlu,     0x55D0F260D4CBlu, 0x7F075B666BBBlu,
+      0x5541D68949564100lu};
 
-  return_address_manager.ProcessUprobes(1, 140723234287912lu, 94355907990370lu);
-  return_address_manager.ProcessUprobes(1, 140723234287880lu, 94355907990320lu);
-  return_address_manager.ProcessUprobes(1, 140723234287816lu, 94355907990220lu);
+  return_address_manager.ProcessUprobes(1, 0x7FFCAE643128lu, 0x55D0F260D362lu);
+  return_address_manager.ProcessUprobes(1, 0x7FFCAE643108lu, 0x55D0F260D330lu);
+  return_address_manager.ProcessUprobes(1, 0x7FFCAE6430C8lu, 0x55D0F260D2CClu);
 
   std::vector<uint64_t> callchain_sample{
-      18446744073709551104lu, 94355907990137lu,  94355907990270lu,
-      140737488347136lu,      140737488347136lu, 94355907990423lu,
-      94355907990459lu,       94355907990731lu,  139669574937531lu,
-      6143427251839320320lu};
+      0xFFFFFFFFFFFFFE00lu, 0x55D0F260D279lu, 0x55D0F260D2FElu,
+      0x7FFFFFFFE000lu,     0x7FFFFFFFE000lu, 0x55D0F260D397lu,
+      0x55D0F260D3BBlu,     0x55D0F260D4CBlu, 0x7F075B666BBBlu,
+      0x5541D68949564100lu};
 
   EXPECT_TRUE(return_address_manager.PatchCallchain(
       1, callchain_sample.data(), callchain_sample.size(), maps.get()));
   EXPECT_THAT(callchain_sample, testing::ElementsAreArray(expected_callchain));
 }
+}  // namespace
 
 }  // namespace LinuxTracing

--- a/OrbitLinuxTracing/UprobesReturnAddressManagerTest.cpp
+++ b/OrbitLinuxTracing/UprobesReturnAddressManagerTest.cpp
@@ -1,5 +1,7 @@
+#include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
+#include "LibunwindstackUnwinder.h"
 #include "UprobesReturnAddressManager.h"
 
 namespace LinuxTracing {
@@ -388,6 +390,230 @@ TEST(UprobesReturnAddressManager, TailCallOptimization) {
 
   // A returns.
   test_handler.OnNonUretprobesReturn();
+}
+
+//==============================================================================
+// Tests for frame pointer based callchains start here:
+//==============================================================================
+
+const std::string maps_string =
+    "55d0f260c000-55d0f260d000 r--p 00000000 fe:00 3415204                    "
+    "/usr/local/uprobes_target\n"
+    "55d0f260d000-55d0f260f000 r-xp 00001000 fe:00 3415204                    "
+    "/usr/local/uprobes_target\n"
+    "55d0f260f000-55d0f2610000 r--p 00003000 fe:00 3415204                    "
+    "/usr/local/uprobes_target\n"
+    "55d0f2611000-55d0f2612000 r--p 00004000 fe:00 3415204                    "
+    "/usr/local/uprobes_target\n"
+    "55d0f2612000-55d0f2613000 rw-p 00005000 fe:00 3415204                    "
+    "/usr/local/uprobes_target\n"
+    "55d0f3ce1000-55d0f3d14000 rw-p 00000000 00:00 0                          "
+    "[heap]\n"
+    "7f075b495000-7f075b4d6000 rw-p 00000000 00:00 0 \n"
+    "7f075b4f7000-7f075b4fb000 rw-p 00000000 00:00 0 \n"
+    "7f075b4fb000-7f075b50a000 r--p 00000000 fe:00 2131083                    "
+    "/usr/lib/x86_64-linux-gnu/libm-2.29.so\n"
+    "7f075b50a000-7f075b5a5000 r-xp 0000f000 fe:00 2131083                    "
+    "/usr/lib/x86_64-linux-gnu/libm-2.29.so\n"
+    "7f075b5a5000-7f075b63e000 r--p 000aa000 fe:00 2131083                    "
+    "/usr/lib/x86_64-linux-gnu/libm-2.29.so\n"
+    "7f075b63e000-7f075b63f000 r--p 00142000 fe:00 2131083                    "
+    "/usr/lib/x86_64-linux-gnu/libm-2.29.so\n"
+    "7f075b63f000-7f075b640000 rw-p 00143000 fe:00 2131083                    "
+    "/usr/lib/x86_64-linux-gnu/libm-2.29.so\n"
+    "7f075b640000-7f075b665000 r--p 00000000 fe:00 2131081                    "
+    "/usr/lib/x86_64-linux-gnu/libc-2.29.so\n"
+    "7f075b665000-7f075b7ac000 r-xp 00025000 fe:00 2131081                    "
+    "/usr/lib/x86_64-linux-gnu/libc-2.29.so\n"
+    "7f075b7ac000-7f075b7f5000 r--p 0016c000 fe:00 2131081                    "
+    "/usr/lib/x86_64-linux-gnu/libc-2.29.so\n"
+    "7f075b7f5000-7f075b7f6000 ---p 001b5000 fe:00 2131081                    "
+    "/usr/lib/x86_64-linux-gnu/libc-2.29.so\n"
+    "7f075b7f6000-7f075b7f9000 r--p 001b5000 fe:00 2131081                    "
+    "/usr/lib/x86_64-linux-gnu/libc-2.29.so\n"
+    "7f075b7f9000-7f075b7fc000 rw-p 001b8000 fe:00 2131081                    "
+    "/usr/lib/x86_64-linux-gnu/libc-2.29.so\n"
+    "7f075b7fc000-7f075b800000 rw-p 00000000 00:00 0 \n"
+    "7f075b800000-7f075b803000 r--p 00000000 fe:00 2112042                    "
+    "/usr/lib/x86_64-linux-gnu/libgcc_s.so.1\n"
+    "7f075b803000-7f075b814000 r-xp 00003000 fe:00 2112042                    "
+    "/usr/lib/x86_64-linux-gnu/libgcc_s.so.1\n"
+    "7f075b814000-7f075b818000 r--p 00014000 fe:00 2112042                    "
+    "/usr/lib/x86_64-linux-gnu/libgcc_s.so.1\n"
+    "7f075b818000-7f075b819000 r--p 00017000 fe:00 2112042                    "
+    "/usr/lib/x86_64-linux-gnu/libgcc_s.so.1\n"
+    "7f075b819000-7f075b81a000 rw-p 00018000 fe:00 2112042                    "
+    "/usr/lib/x86_64-linux-gnu/libgcc_s.so.1\n"
+    "7f075b81a000-7f075b8b0000 r--p 00000000 fe:00 2112089                    "
+    "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28\n"
+    "7f075b8b0000-7f075b98b000 r-xp 00096000 fe:00 2112089                    "
+    "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28\n"
+    "7f075b98b000-7f075b9d4000 r--p 00171000 fe:00 2112089                    "
+    "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28\n"
+    "7f075b9d4000-7f075b9d5000 ---p 001ba000 fe:00 2112089                    "
+    "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28\n"
+    "7f075b9d5000-7f075b9e0000 r--p 001ba000 fe:00 2112089                    "
+    "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28\n"
+    "7f075b9e0000-7f075b9e3000 rw-p 001c5000 fe:00 2112089                    "
+    "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28\n"
+    "7f075b9e3000-7f075b9e6000 rw-p 00000000 00:00 0 \n"
+    "7f075ba00000-7f075ba02000 rw-p 00000000 00:00 0 \n"
+    "7f075ba02000-7f075ba03000 r--p 00000000 fe:00 2131077                    "
+    "/usr/lib/x86_64-linux-gnu/ld-2.29.so\n"
+    "7f075ba03000-7f075ba22000 r-xp 00001000 fe:00 2131077                    "
+    "/usr/lib/x86_64-linux-gnu/ld-2.29.so\n"
+    "7f075ba22000-7f075ba2a000 r--p 00020000 fe:00 2131077                    "
+    "/usr/lib/x86_64-linux-gnu/ld-2.29.so\n"
+    "7f075ba2a000-7f075ba2b000 r--p 00027000 fe:00 2131077                    "
+    "/usr/lib/x86_64-linux-gnu/ld-2.29.so\n"
+    "7f075ba2b000-7f075ba2c000 rw-p 00028000 fe:00 2131077                    "
+    "/usr/lib/x86_64-linux-gnu/ld-2.29.so\n"
+    "7f075ba2c000-7f075ba2d000 rw-p 00000000 00:00 0 \n"
+    "7ffcae624000-7ffcae646000 rw-p 00000000 00:00 0                          "
+    "[stack]\n"
+    "7ffcae7f0000-7ffcae7f3000 r--p 00000000 00:00 0                          "
+    "[vvar]\n"
+    "7ffcae7f3000-7ffcae7f4000 r-xp 00000000 00:00 0                          "
+    "[vdso]\n"
+    "7fffffffe000-7ffffffff000 --xp 00000000 00:00 0                          "
+    "[uprobes]";
+
+auto maps = LibunwindstackUnwinder::ParseMaps(maps_string);
+
+TEST(UprobesReturnAddressManager, CallchainNoUprobes) {
+  UprobesReturnAddressManager return_address_manager;
+
+  std::vector<uint64_t> expected_callchain{
+      18446744073709551104lu, 94355907990078lu, 94355907990120lu,
+      94355907990170lu,       94355907990220lu, 94355907990270lu,
+      94355907990320lu,       94355907990370lu, 94355907990423lu,
+      94355907990459lu,       94355907990731lu, 139669574937531lu,
+      6143427251839320320lu};
+
+  std::vector<uint64_t> callchain_sample{
+      18446744073709551104lu, 94355907990078lu, 94355907990120lu,
+      94355907990170lu,       94355907990220lu, 94355907990270lu,
+      94355907990320lu,       94355907990370lu, 94355907990423lu,
+      94355907990459lu,       94355907990731lu, 139669574937531lu,
+      6143427251839320320lu};
+
+  EXPECT_TRUE(return_address_manager.PatchCallchain(
+      1, callchain_sample.data(), callchain_sample.size(), maps.get()));
+  EXPECT_THAT(callchain_sample, testing::ElementsAreArray(expected_callchain));
+}
+
+TEST(UprobesReturnAddressManager, CallchainOneUprobe) {
+  UprobesReturnAddressManager return_address_manager;
+
+  std::vector<uint64_t> expected_callchain{
+      18446744073709551104lu, 94355907990078lu, 94355907990120lu,
+      94355907990170lu,       94355907990220lu, 94355907990270lu,
+      94355907990320lu,       94355907990370lu, 94355907990423lu,
+      94355907990459lu,       94355907990731lu, 139669574937531lu,
+      6143427251839320320lu};
+
+  return_address_manager.ProcessUprobes(1, 140723234287848lu, 94355907990270lu);
+
+  std::vector<uint64_t> callchain_sample{
+      18446744073709551104lu, 94355907990078lu, 94355907990120lu,
+      94355907990170lu,       94355907990220lu, 140737488347136lu,
+      94355907990320lu,       94355907990370lu, 94355907990423lu,
+      94355907990459lu,       94355907990731lu, 139669574937531lu,
+      6143427251839320320lu};
+
+  EXPECT_TRUE(return_address_manager.PatchCallchain(
+      1, callchain_sample.data(), callchain_sample.size(), maps.get()));
+  EXPECT_THAT(callchain_sample, testing::ElementsAreArray(expected_callchain));
+}
+
+TEST(UprobesReturnAddressManager, CallchainTwoUprobes) {
+  UprobesReturnAddressManager return_address_manager;
+
+  std::vector<uint64_t> expected_callchain{
+      18446744073709551104lu, 94355907990063lu, 94355907990120lu,
+      94355907990170lu,       94355907990220lu, 94355907990270lu,
+      94355907990320lu,       94355907990370lu, 94355907990423lu,
+      94355907990459lu,       94355907990731lu, 139669574937531lu,
+      6143427251839320320lu};
+  return_address_manager.ProcessUprobes(1, 140723234287944lu, 94355907990423lu);
+  return_address_manager.ProcessUprobes(1, 140723234287816lu, 94355907990220lu);
+
+  std::vector<uint64_t> callchain_sample{
+      18446744073709551104lu, 94355907990063lu,  94355907990120lu,
+      94355907990170lu,       140737488347136lu, 94355907990270lu,
+      94355907990320lu,       94355907990370lu,  140737488347136lu,
+      94355907990459lu,       94355907990731lu,  139669574937531lu,
+      6143427251839320320lu};
+
+  EXPECT_TRUE(return_address_manager.PatchCallchain(
+      1, callchain_sample.data(), callchain_sample.size(), maps.get()));
+  EXPECT_THAT(callchain_sample, testing::ElementsAreArray(expected_callchain));
+}
+
+TEST(UprobesReturnAddressManager, CallchainTwoUprobesMissingOne) {
+  UprobesReturnAddressManager return_address_manager;
+
+  return_address_manager.ProcessUprobes(1, 140723234287816lu, 94355907990220lu);
+
+  std::vector<uint64_t> callchain_sample{
+      18446744073709551104lu, 94355907990063lu,  94355907990120lu,
+      94355907990170lu,       140737488347136lu, 94355907990270lu,
+      94355907990320lu,       94355907990370lu,  140737488347136lu,
+      94355907990459lu,       94355907990731lu,  139669574937531lu,
+      6143427251839320320lu};
+
+  EXPECT_FALSE(return_address_manager.PatchCallchain(
+      1, callchain_sample.data(), callchain_sample.size(), maps.get()));
+}
+
+TEST(UprobesReturnAddressManager, CallchainTwoConsecutiveUprobes) {
+  UprobesReturnAddressManager return_address_manager;
+
+  std::vector<uint64_t> expected_callchain{
+      18446744073709551104lu, 94355907990063lu, 94355907990120lu,
+      94355907990170lu,       94355907990220lu, 94355907990270lu,
+      94355907990320lu,       94355907990370lu, 94355907990423lu,
+      94355907990459lu,       94355907990731lu, 139669574937531lu,
+      6143427251839320320lu};
+
+  return_address_manager.ProcessUprobes(1, 140723234287944lu, 94355907990423lu);
+  return_address_manager.ProcessUprobes(1, 140723234287848lu, 94355907990270lu);
+  return_address_manager.ProcessUprobes(1, 140723234287816lu, 94355907990220lu);
+
+  std::vector<uint64_t> callchain_sample{
+      18446744073709551104lu, 94355907990063lu,  94355907990120lu,
+      94355907990170lu,       140737488347136lu, 140737488347136lu,
+      94355907990320lu,       94355907990370lu,  140737488347136lu,
+      94355907990459lu,       94355907990731lu,  139669574937531lu,
+      6143427251839320320lu};
+
+  EXPECT_TRUE(return_address_manager.PatchCallchain(
+      1, callchain_sample.data(), callchain_sample.size(), maps.get()));
+  EXPECT_THAT(callchain_sample, testing::ElementsAreArray(expected_callchain));
+}
+
+TEST(UprobesReturnAddressManager, CallchainBeforeInjectionByUprobe) {
+  UprobesReturnAddressManager return_address_manager;
+
+  std::vector<uint64_t> expected_callchain{
+      18446744073709551104lu, 94355907990137lu, 94355907990270lu,
+      94355907990320lu,       94355907990370lu, 94355907990423lu,
+      94355907990459lu,       94355907990731lu, 139669574937531lu,
+      6143427251839320320lu};
+
+  return_address_manager.ProcessUprobes(1, 140723234287912lu, 94355907990370lu);
+  return_address_manager.ProcessUprobes(1, 140723234287880lu, 94355907990320lu);
+  return_address_manager.ProcessUprobes(1, 140723234287816lu, 94355907990220lu);
+
+  std::vector<uint64_t> callchain_sample{
+      18446744073709551104lu, 94355907990137lu,  94355907990270lu,
+      140737488347136lu,      140737488347136lu, 94355907990423lu,
+      94355907990459lu,       94355907990731lu,  139669574937531lu,
+      6143427251839320320lu};
+
+  EXPECT_TRUE(return_address_manager.PatchCallchain(
+      1, callchain_sample.data(), callchain_sample.size(), maps.get()));
+  EXPECT_THAT(callchain_sample, testing::ElementsAreArray(expected_callchain));
 }
 
 }  // namespace LinuxTracing

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
@@ -48,7 +48,9 @@ void UprobesUnwindingVisitor::visit(CallchainSamplePerfEvent* event) {
     return;
   }
 
-  // TODO(kuebler): handle the mapping/patching for uprobes
+  return_address_manager_.PatchCallchain(event->GetTid(), event->GetCallchain(),
+                                         event->GetCallchainSize(),
+                                         current_maps_.get());
 
   Callstack returned_callstack{
       event->GetTid(),
@@ -145,7 +147,9 @@ UprobesUnwindingVisitor::CallstackFramesFromInstructionPointers(
     return std::vector<CallstackFrame>();
   }
   std::vector<CallstackFrame> callstack_frames;
-  for (uint64_t i = 0; i < size; i++) {
+  // The top of a callchain is always inside the kernel code.
+  // So we need to discard it.
+  for (uint64_t i = 1; i < size; i++) {
     callstack_frames.emplace_back(frames[i], "",
                                   CallstackFrame::kUnknownFunctionOffset, "");
   }

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
@@ -48,13 +48,16 @@ void UprobesUnwindingVisitor::visit(CallchainSamplePerfEvent* event) {
     return;
   }
 
-  return_address_manager_.PatchCallchain(event->GetTid(), event->GetCallchain(),
-                                         event->GetCallchainSize(),
-                                         current_maps_.get());
+  if (!return_address_manager_.PatchCallchain(
+          event->GetTid(), event->GetCallchain(), event->GetCallchainSize(),
+          current_maps_.get())) {
+    return;
+  }
 
   if (event->GetCallchainSize() == 0) {
     return;
   }
+
   Callstack returned_callstack{
       event->GetTid(),
       // The top of a callchain is always inside the kernel code.


### PR DESCRIPTION
Patches callchain samples that fall into uprobes and always remove the top of the callstack, as this falls into the kernel.