### PR TITLE
Make PickingManager thread safe and simplify interface.

### DIFF
--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -644,6 +644,9 @@ void CaptureWindow::Draw() {
     ZoomAll();
   }
 
+  // Reset picking manager before each draw.
+  m_PickingManager.Reset();
+
   time_graph_.Draw(m_Picking);
 
   if (m_SelectStart[0] != m_SelectStop[0]) {

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -18,7 +18,6 @@ EventTrack::EventTrack(TimeGraph* a_TimeGraph) : Track(a_TimeGraph) {
 //-----------------------------------------------------------------------------
 void EventTrack::Draw(GlCanvas* canvas, bool picking) {
   PickingManager& picking_manager = canvas->GetPickingManager();
-  PickingID id = picking_manager.CreatePickableId(this);
 
   constexpr float kNormalZ = -0.1f;
   constexpr float kPickingZ = 0.1f;
@@ -27,7 +26,7 @@ void EventTrack::Draw(GlCanvas* canvas, bool picking) {
 
   if (picking) {
     z = kPickingZ;
-    color = picking_manager.ColorFromPickingID(id);
+    color = picking_manager.GetPickableColor(this);
   }
 
   glColor4ubv(&color[0]);

--- a/OrbitGl/GlSlider.cpp
+++ b/OrbitGl/GlSlider.cpp
@@ -110,8 +110,8 @@ void GlSlider::Draw(GlCanvas* a_Canvas, bool a_Picking) {
 }
 
 //-----------------------------------------------------------------------------
-void GlSlider::DrawHorizontal(GlCanvas* a_Canvas, bool a_Picking) {
-  m_Canvas = a_Canvas;
+void GlSlider::DrawHorizontal(GlCanvas* canvas, bool picking) {
+  m_Canvas = canvas;
 
   static float y = 0;
 
@@ -120,7 +120,7 @@ void GlSlider::DrawHorizontal(GlCanvas* a_Canvas, bool a_Picking) {
   float nonSliderWidth = canvasWidth - sliderWidth;
 
   // Bar
-  if (!a_Picking) {
+  if (!picking) {
     glColor4ubv(&m_BarColor[0]);
     glBegin(GL_QUADS);
     glVertex3f(0, y, 0);
@@ -133,12 +133,14 @@ void GlSlider::DrawHorizontal(GlCanvas* a_Canvas, bool a_Picking) {
   float start = m_Ratio * nonSliderWidth;
   float stop = start + sliderWidth;
 
-  a_Picking ? PickingManager::SetPickingColor(
-                  a_Canvas->GetPickingManager().CreatePickableId(this))
-            : a_Canvas->GetPickingManager().GetPicked() == this
-                  ? glColor4ubv(&m_SelectedColor[0])
-                  : glColor4ubv(&m_SliderColor[0]);
+  Color color = m_SliderColor;
+  if (picking) {
+    color = canvas->GetPickingManager().GetPickableColor(this);
+  } else if (canvas->GetPickingManager().GetPicked() == this) {
+    color = m_SelectedColor;
+  }
 
+  glColor4ubv(&color[0]);
   glBegin(GL_QUADS);
   glVertex3f(start, y, 0);
   glVertex3f(stop, y, 0);
@@ -148,8 +150,8 @@ void GlSlider::DrawHorizontal(GlCanvas* a_Canvas, bool a_Picking) {
 }
 
 //-----------------------------------------------------------------------------
-void GlSlider::DrawVertical(GlCanvas* a_Canvas, bool a_Picking) {
-  m_Canvas = a_Canvas;
+void GlSlider::DrawVertical(GlCanvas* canvas, bool picking) {
+  m_Canvas = canvas;
 
   float x = m_Canvas->getWidth() - GetPixelHeight();
 
@@ -158,7 +160,7 @@ void GlSlider::DrawVertical(GlCanvas* a_Canvas, bool a_Picking) {
   float nonSliderHeight = canvasHeight - sliderHeight;
 
   // Bar
-  if (!a_Picking) {
+  if (!picking) {
     glColor4ubv(&m_BarColor[0]);
     glBegin(GL_QUADS);
     glVertex3f(x, 0, 0);
@@ -171,11 +173,14 @@ void GlSlider::DrawVertical(GlCanvas* a_Canvas, bool a_Picking) {
   float start = canvasHeight - m_Ratio * nonSliderHeight;
   float stop = start - sliderHeight;
 
-  a_Picking ? PickingManager::SetPickingColor(
-                  a_Canvas->GetPickingManager().CreatePickableId(this))
-            : a_Canvas->GetPickingManager().GetPicked() == this
-                  ? glColor4ubv(&m_SelectedColor[0])
-                  : glColor4ubv(&m_SliderColor[0]);
+  Color color = m_SliderColor;
+  if (picking) {
+    color = canvas->GetPickingManager().GetPickableColor(this);
+  } else if (canvas->GetPickingManager().GetPicked() == this) {
+    color = m_SelectedColor;
+  }
+
+  glColor4ubv(&color[0]);
 
   glBegin(GL_QUADS);
   glVertex3f(x, start, 0);

--- a/OrbitGl/PickingManager.cpp
+++ b/OrbitGl/PickingManager.cpp
@@ -5,6 +5,7 @@
 #include "PickingManager.h"
 
 #include "OpenGl.h"
+#include "OrbitBase/Logging.h"
 
 //-----------------------------------------------------------------------------
 PickingID PickingManager::CreatePickableId(Pickable* a_Pickable) {
@@ -27,7 +28,11 @@ void PickingManager::Reset() {
 //-----------------------------------------------------------------------------
 Pickable* PickingManager::GetPickableFromId(uint32_t id) {
   absl::MutexLock lock(&mutex_);
-  return m_IdPickableMap[id];
+  auto it = m_IdPickableMap.find(id);
+  if (it == m_IdPickableMap.end()) {
+    return nullptr;
+  }
+  return it->second;
 }
 
 //-----------------------------------------------------------------------------
@@ -79,6 +84,8 @@ Color PickingManager::GetPickableColor(Pickable* pickable) {
 
 //-----------------------------------------------------------------------------
 Color PickingManager::ColorFromPickingID(PickingID id) const {
+  static_assert(sizeof(PickingID) == sizeof(Color),
+                "PickingID should be same size as Color");
   const Color* color = reinterpret_cast<const Color*>(&id);
   return *color;
 }

--- a/OrbitGl/PickingManager.h
+++ b/OrbitGl/PickingManager.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "CoreMath.h"
+#include "absl/synchronization/mutex.h"
 
 class GlCanvas;
 
@@ -48,24 +49,26 @@ struct PickingID {
 class PickingManager {
  public:
   PickingManager() {}
-
-  PickingID CreatePickableId(Pickable* a_Pickable);
-  void ClearIds();
+  void Reset();
 
   void Pick(uint32_t a_Id, int a_X, int a_Y);
   void Release();
   void Drag(int a_X, int a_Y);
-  Pickable* GetPicked() { return m_Picked; }
-  bool IsDragging() const { return m_Picked && m_Picked->Draggable(); }
+  Pickable* GetPicked();
+  Pickable* GetPickableFromId(uint32_t id);
+  bool IsDragging() const;
 
-  static void SetPickingColor(PickingID a_ID);
+  Color GetPickableColor(Pickable* pickable);
+
+ private:
+  PickingID CreatePickableId(Pickable* a_Pickable);
   Color ColorFromPickingID(PickingID id) const;
 
- protected:
+ private:
   std::vector<Pickable*> m_Pickables;
   uint32_t m_IdCounter = 0;
-  uint32_t m_IdStart = 0;
   std::unordered_map<Pickable*, uint32_t> m_PickableIdMap;
   std::unordered_map<uint32_t, Pickable*> m_IdPickableMap;
   Pickable* m_Picked = nullptr;
+  mutable absl::Mutex mutex_;
 };

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -61,8 +61,7 @@ void DrawTriangleFan(const std::vector<Vec2>& points, const Vec2& pos,
 //-----------------------------------------------------------------------------
 void Track::Draw(GlCanvas* canvas, bool picking) {
   const TimeGraphLayout& layout = time_graph_->GetLayout();
-  PickingID id = canvas->GetPickingManager().CreatePickableId(this);
-  Color picking_color = canvas->GetPickingManager().ColorFromPickingID(id);
+  Color picking_color = canvas->GetPickingManager().GetPickableColor(this);
   const Color kTabColor(50, 50, 50, 255);
   Color color = picking ? picking_color : kTabColor;
   glColor4ubv(&color[0]);

--- a/OrbitGl/TriangleToggle.cpp
+++ b/OrbitGl/TriangleToggle.cpp
@@ -21,8 +21,7 @@ void TriangleToggle::Draw(GlCanvas* canvas, bool picking) {
 
   if (picking) {
     PickingManager& picking_manager = canvas->GetPickingManager();
-    PickingID id = picking_manager.CreatePickableId(this);
-    color = picking_manager.ColorFromPickingID(id);
+    color = picking_manager.GetPickableColor(this);
   }
 
   // Draw triangle.


### PR DESCRIPTION
This was started as an investigation into a rare crash that happens on picking, although I couldn't repro the crash after the changes, I'm still not 100% sure it is fixed.  I'll keep an eye on it.  Making PickingManager thread safe is needed for the upcoming parallelization of rendering.