### PR TITLE
Move url to option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,8 @@ enable_testing()
 
 option(WITH_GUI "Setting this option will enable the Qt-based UI client." ON)
 
+set(CRASHDUMP_SERVER "" CACHE STRING "Setting this option will enable uploading crash dumps to the url specified.")
+
 set(CMAKE_CXX_STANDARD 17)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")

--- a/OrbitCore/CMakeLists.txt
+++ b/OrbitCore/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(
          Core.h
          CoreApp.h
          CrashHandler.h
+         CrashOptions.h
          EventBuffer.h
          EventClasses.h
          FramePointerValidator.h
@@ -208,6 +209,9 @@ include("${CMAKE_SOURCE_DIR}/cmake/version.cmake")
 GenerateVersionFile("${CMAKE_CURRENT_BINARY_DIR}/Version.cpp"
                     "${CMAKE_CURRENT_SOURCE_DIR}/Version.cpp.in" OrbitCore)
 target_sources(OrbitCore PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/Version.cpp")
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/CrashOptions.cpp.in ${CMAKE_CURRENT_BINARY_DIR}/CrashOptions.cpp)
+target_sources(OrbitCore PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/CrashOptions.cpp")
 
 add_executable(OrbitCoreTests)
 

--- a/OrbitCore/CrashOptions.cpp.in
+++ b/OrbitCore/CrashOptions.cpp.in
@@ -1,0 +1,13 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "CrashOptions.h"
+
+#define CRASH_SERVER_URL "@CRASHDUMP_SERVER@"
+
+namespace CrashServerOptions {
+    std::string GetUrl() {
+        return CRASH_SERVER_URL;
+    }
+} // namespace CrashServer

--- a/OrbitCore/CrashOptions.h
+++ b/OrbitCore/CrashOptions.h
@@ -1,0 +1,13 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_CORE_CRASH_OPTIONS_H_
+#define ORBIT_CORE_CRASH_OPTIONS_H_
+#include <string>
+
+namespace CrashServerOptions {
+std::string GetUrl();
+}  // namespace CrashServer
+
+#endif  // ORBIT_CORE_CRASH_OPTIONS_H_

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -10,6 +10,7 @@
 #include "App.h"
 #include "ApplicationOptions.h"
 #include "CrashHandler.h"
+#include "CrashOptions.h"
 #include "OrbitSsh/Credentials.h"
 #include "OrbitStartupWindow.h"
 #include "Path.h"
@@ -70,8 +71,7 @@ int main(int argc, char* argv[]) {
   const std::string handler_path = QDir(QCoreApplication::applicationDirPath())
                                        .absoluteFilePath(handler_name)
                                        .toStdString();
-  const std::string crash_server_url =
-      "https://clients2.google.com/cr/staging_report";
+  const std::string crash_server_url = CrashServerOptions::GetUrl();
   CrashHandler crash_handler(dump_path, handler_path, crash_server_url);
 
   ApplicationOptions options;

--- a/conanfile.py
+++ b/conanfile.py
@@ -15,11 +15,13 @@ class OrbitConan(ConanFile):
     options = {"system_mesa": [True, False],
                "system_qt": [True, False], "with_gui": [True, False],
                "debian_packaging": [True, False],
-               "fPIC": [True, False]}
+               "fPIC": [True, False],
+               "crashdump_server": "ANY"}
     default_options = {"system_mesa": True,
                        "system_qt": True, "with_gui": True,
                        "debian_packaging": False,
-                       "fPIC": True}
+                       "fPIC": True,
+                       "crashdump_server": ""}
     _orbit_channel = "orbitdeps/stable"
     exports_sources = "CMakeLists.txt", "Orbit*", "bin/*", "cmake/*", "external/*", "LICENSE"
     build_requires = ('grpc_codegen/1.27.3@orbitdeps/stable',
@@ -111,6 +113,7 @@ class OrbitConan(ConanFile):
     def build(self):
         cmake = CMake(self)
         cmake.definitions["WITH_GUI"] = "ON" if self.options.with_gui else "OFF"
+        cmake.definitions["CRASHDUMP_SERVER"] = self.options.crashdump_server
         cmake.configure()
         cmake.build()
         if not tools.cross_building(self.settings, skip_x64_x86=True) and self.settings.get_safe("os.platform") != "GGP":

--- a/kokoro/gcp_ubuntu/continuous.cfg
+++ b/kokoro/gcp_ubuntu/continuous.cfg
@@ -13,6 +13,12 @@ before_action {
       key_type: RAW
       backend_type: FASTCONFIGPUSH
     }
+    keystore_resource {
+      keystore_config_id: 74938
+      keyname: "orbitprofiler_crashdump_collection_server"
+      key_type: RAW
+      backend_type: FASTCONFIGPUSH
+    }
   }
 }
 

--- a/kokoro/gcp_ubuntu/kokoro_build.sh
+++ b/kokoro/gcp_ubuntu/kokoro_build.sh
@@ -20,7 +20,9 @@ if [ "$0" == "$SCRIPT" ]; then
 
   # Building Orbit
   conan install -u -pr ${CONAN_PROFILE} -if "${DIR}/build/" \
-          --build outdated "${DIR}"
+          --build outdated \
+          -o crashdump_server="$(cat /mnt/keystore/74938_orbitprofiler_crashdump_collection_server | tr -d '\n')" \
+          "${DIR}"
   conan build -bf "${DIR}/build/" "${DIR}"
   conan package -bf "${DIR}/build/" "${DIR}"
 

--- a/kokoro/gcp_ubuntu/presubmit.cfg
+++ b/kokoro/gcp_ubuntu/presubmit.cfg
@@ -5,6 +5,17 @@
 # github_scm.name is specified in the job configuration (next section).
 build_file: "orbitprofiler/kokoro/gcp_ubuntu/kokoro_build.sh"
 
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74938
+      keyname: "orbitprofiler_crashdump_collection_server"
+      key_type: RAW
+      backend_type: FASTCONFIGPUSH
+    }
+  }
+}
+
 action {
   define_artifacts {
     regex: "github/orbitprofiler/build/testresults/*.xml"

--- a/kokoro/gcp_windows/continuous.cfg
+++ b/kokoro/gcp_windows/continuous.cfg
@@ -13,6 +13,12 @@ before_action {
       key_type: RAW
       backend_type: FASTCONFIGPUSH
     }
+    keystore_resource {
+      keystore_config_id: 74938
+      keyname: "orbitprofiler_crashdump_collection_server"
+      key_type: RAW
+      backend_type: FASTCONFIGPUSH
+    }
   }
 }
 

--- a/kokoro/gcp_windows/kokoro_build.bat
+++ b/kokoro/gcp_windows/kokoro_build.bat
@@ -14,7 +14,8 @@ call powershell "& %REPO_ROOT%\contrib\conan\configs\install.ps1"
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 :: Building conan
-call conan install -pr msvc2017_relwithdebinfo -if %REPO_ROOT%\build\ --build outdated %REPO_ROOT%
+set /P CRASHDUMP_SERVER=<%KOKORO_ARTIFACTS_DIR%\keystore\74938_orbitprofiler_crashdump_collection_server
+call conan install -pr msvc2017_relwithdebinfo -if %REPO_ROOT%\build\ --build outdated -o crashdump_server="%CRASHDUMP_SERVER%" %REPO_ROOT%
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 call conan build -bf %REPO_ROOT%\build\ %REPO_ROOT%

--- a/kokoro/gcp_windows/nightly.cfg
+++ b/kokoro/gcp_windows/nightly.cfg
@@ -13,6 +13,12 @@ before_action {
       key_type: RAW
       backend_type: FASTCONFIGPUSH
     }
+    keystore_resource {
+      keystore_config_id: 74938
+      keyname: "orbitprofiler_crashdump_collection_server"
+      key_type: RAW
+      backend_type: FASTCONFIGPUSH
+    }
   }
 }
 

--- a/kokoro/gcp_windows/presubmit.cfg
+++ b/kokoro/gcp_windows/presubmit.cfg
@@ -5,6 +5,17 @@
 # github_scm.name is specified in the job configuration (next section).
 build_file: "orbitprofiler/kokoro/gcp_windows/kokoro_build.bat"
 
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74938
+      keyname: "orbitprofiler_crashdump_collection_server"
+      key_type: RAW
+      backend_type: FASTCONFIGPUSH
+    }
+  }
+}
+
 action {
   define_artifacts {
     regex: "github/orbitprofiler/build/testresults/*.xml"

--- a/kokoro/gcp_windows/release.cfg
+++ b/kokoro/gcp_windows/release.cfg
@@ -13,6 +13,12 @@ before_action {
       key_type: RAW
       backend_type: FASTCONFIGPUSH
     }
+    keystore_resource {
+      keystore_config_id: 74938
+      keyname: "orbitprofiler_crashdump_collection_server"
+      key_type: RAW
+      backend_type: FASTCONFIGPUSH
+    }
   }
 }
 


### PR DESCRIPTION
Moved Crash2 collection server url to the option and switched from staging to production. It is only available in kokoro builds for now. So in other builds crash dumps are written locally and aren't send to the collection server, but it could be enabled by providing the option `-o crashdump_server =<crash_dump_server_url>`.