### PR TITLE
Replace atomic counters in BlockChain by properly aligned uint32_t's.

### DIFF
--- a/OrbitCore/BlockChain.h
+++ b/OrbitCore/BlockChain.h
@@ -5,7 +5,6 @@
 #include <assert.h>
 
 #include <algorithm>
-#include <atomic>
 #include <cstdint>
 
 //-----------------------------------------------------------------------------
@@ -40,9 +39,9 @@ struct Block {
 
   Block<T, Size>* m_Prev;
   Block<T, Size>* m_Next;
-  T m_Data[Size];
   BlockChain<T, Size>* m_Chain;
-  std::atomic<uint32_t> m_Size;
+  alignas(4) uint32_t m_Size;
+  T m_Data[Size];
 };
 
 //-----------------------------------------------------------------------------
@@ -224,6 +223,6 @@ struct BlockChain {
 
   Block<T, BlockSize>* m_Root;
   Block<T, BlockSize>* m_Current;
-  std::atomic<uint32_t> m_NumBlocks;
-  std::atomic<uint32_t> m_NumItems;
+  alignas(4) uint32_t m_NumBlocks;
+  alignas(4) uint32_t m_NumItems;
 };


### PR DESCRIPTION
The BlockChain data structure is not thread safe.  As such, the atomic
counters were not necessary to begin with and slowed down insertion
significantly.  In benchmarks, removing atomics make the test run in
a third of the time it takes with the atomics in place.  Also, having
those uint32_t counters properly aligned gives us atomicity anyway so
there is no change in behavior.