### PR TITLE
hide flag upload_dumps from the options menu

### DIFF
--- a/OrbitCore/CrashHandler.cpp
+++ b/OrbitCore/CrashHandler.cpp
@@ -48,6 +48,7 @@ CrashHandler::CrashHandler(const std::string& dump_path,
   const std::vector<std::string> arguments = {"--no-rate-limit"};
 
   crash_report_db_ = crashpad::CrashReportDatabase::Initialize(dump_file_path);
+  SetUploadsEnabled(true);
 
   crashpad_client_.StartHandler(handler_file_path,
                                 /*database=*/dump_file_path,

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -276,10 +276,6 @@ bool OrbitApp::Init(ApplicationOptions&& options) {
 
 //-----------------------------------------------------------------------------
 void OrbitApp::PostInit() {
-  if (options_.crash_handler != nullptr) {
-    options_.crash_handler->SetUploadsEnabled(GetUploadDumpsToServerEnabled());
-  }
-
   if (!options_.asio_server_address.empty()) {
     GTcpClient = std::make_unique<TcpClient>();
     GTcpClient->AddMainThreadCallback(
@@ -953,9 +949,6 @@ bool OrbitApp::GetUploadDumpsToServerEnabled() const {
 
 //-----------------------------------------------------------------------------
 void OrbitApp::EnableUploadDumpsToServer(bool a_Value) {
-  if (options_.crash_handler != nullptr) {
-    options_.crash_handler->SetUploadsEnabled(a_Value);
-  }
   GParams.m_UploadDumpsToServer = a_Value;
   GParams.Save();
 }

--- a/OrbitGl/ApplicationOptions.h
+++ b/OrbitGl/ApplicationOptions.h
@@ -7,8 +7,6 @@
 
 #include <string>
 
-#include "CrashHandler.h"
-
 // The struct used to store Orbit Client Application options.
 // The default values are set by main() and passed to OrbitApp::Init.
 struct ApplicationOptions {
@@ -16,8 +14,6 @@ struct ApplicationOptions {
   std::string asio_server_address;
   // GRPC connection string
   std::string grpc_server_address;
-
-  CrashHandler* crash_handler = nullptr;
 };
 
 #endif  // ORBIT_GL_APPLICATION_OPTIONS_H_

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -75,7 +75,6 @@ int main(int argc, char* argv[]) {
   CrashHandler crash_handler(dump_path, handler_path, crash_server_url);
 
   ApplicationOptions options;
-  options.crash_handler = &crash_handler;
 
   ParseLegacyCommandLine(argc, argv, &options);
   std::string remote = absl::GetFlag(FLAGS_remote);

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -155,9 +155,11 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App,
     ui->actionEnable_Unreal_Support->setVisible(false);
     ui->actionAllow_Unsafe_Hooking->setVisible(false);
     ui->actionOutputDebugString->setVisible(false);
+    ui->actionUploadDumpsToServer->setVisible(false);
 
     ui->actionShow_Includes_Util->setVisible(false);
     ui->menuTools->menuAction()->setVisible(false);
+    ui->menuDev->menuAction()->setVisible(!ui->menuDev->isEmpty());
   }
 
   // Output window


### PR DESCRIPTION
As discussed last week we don't need to have `Upload Dumps on Crash` in the menu for now.
Url was moved to the option and passed in our builds, so we expect crash dumps only from our builds.