### PR TITLE
Fix TextRenderer not initialized

### DIFF
--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -110,8 +110,7 @@ void GpuTrack::SetTimesliceText(const Timer& timer, double elapsed_us,
   const Vec2& box_size = text_box->GetSize();
   float pos_x = std::max(box_pos[0], min_x);
   float max_size = box_pos[0] + box_size[0] - pos_x;
-  TextRenderer* text_renderer = time_graph_->GetTextRenderer();
-  text_renderer->AddTextTrailingCharsPrioritized(
+  text_renderer_->AddTextTrailingCharsPrioritized(
       text_box->GetText().c_str(), pos_x,
       text_box->GetPosY() + layout.GetTextOffset(), GlCanvas::Z_VALUE_TEXT,
       kTextWhite, text_box->GetElapsedTimeTextLength(), max_size);

--- a/OrbitGl/TextRenderer.cpp
+++ b/OrbitGl/TextRenderer.cpp
@@ -238,6 +238,10 @@ void TextRenderer::AddText(const char* a_Text, float a_X, float a_Y, float a_Z,
 void TextRenderer::AddTextTrailingCharsPrioritized(
     const char* a_Text, float a_X, float a_Y, float a_Z, const Color& a_Color,
     size_t a_TrailingCharsLength, float a_MaxSize) {
+  if (!m_Initialized) {
+    Init();
+  }
+
   float tempPenX = ToScreenSpace(a_X);
   float maxWidth = a_MaxSize == -1.f ? FLT_MAX : ToScreenSpace(a_MaxSize);
   float strWidth = 0.f;

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -132,8 +132,7 @@ void ThreadTrack::SetTimesliceText(const Timer& timer, double elapsed_us,
   const Vec2& box_size = text_box->GetSize();
   float pos_x = std::max(box_pos[0], min_x);
   float max_size = box_pos[0] + box_size[0] - pos_x;
-  TextRenderer* text_renderer = time_graph_->GetTextRenderer();
-  text_renderer->AddTextTrailingCharsPrioritized(
+  text_renderer_->AddTextTrailingCharsPrioritized(
       text_box->GetText().c_str(), pos_x,
       text_box->GetPosY() + layout.GetTextOffset(), GlCanvas::Z_VALUE_TEXT,
       kTextWhite, text_box->GetElapsedTimeTextLength(), max_size);


### PR DESCRIPTION
Bug: http://b/157121534

Also remove unnecessary calls to `TimeGraph::GetTextRenderer`.