### PR TITLE
Ssh watchdog

### DIFF
--- a/OrbitService/OrbitAsioServer.h
+++ b/OrbitService/OrbitAsioServer.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #pragma once
 
 #include <memory>
@@ -17,12 +21,13 @@ class OrbitAsioServer {
  public:
   explicit OrbitAsioServer(uint16_t port,
                            LinuxTracing::TracingOptions tracing_options);
-  void Run(std::atomic<bool>* exit_requested);
+  ~OrbitAsioServer();
+  void LoopTick();
 
  private:
   void SetupIntrospection();
 
-  void ProcessListThread(std::atomic<bool>* exit_requested);
+  void ProcessListThread();
 
   void SetupServerCallbacks();
   void SendProcess(uint32_t pid);
@@ -49,4 +54,7 @@ class OrbitAsioServer {
   LinuxTracingBuffer tracing_buffer_;
   LinuxTracing::TracingOptions tracing_options_;
   LinuxTracingHandler tracing_handler_{&tracing_buffer_, tracing_options_};
+
+  std::thread process_list_thread_;
+  std::atomic<bool> exit_requested_;
 };

--- a/OrbitService/OrbitService.cpp
+++ b/OrbitService/OrbitService.cpp
@@ -1,4 +1,10 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "OrbitService.h"
+
+#include <fcntl.h>
 
 #include "OrbitAsioServer.h"
 #include "OrbitGrpcServer.h"
@@ -10,7 +16,22 @@ void OrbitService::Run(std::atomic<bool>* exit_requested) {
 
   std::cout << "Starting Asio server on port " << asio_port_ << std::endl;
   OrbitAsioServer asio_server{asio_port_, tracing_options_};
-  asio_server.Run(exit_requested);
+
+  // make stdin non blocking
+  fcntl(STDIN_FILENO, F_SETFL, O_NONBLOCK);
+  // buffer for reading from stdin.
+  char buffer[0x10] = "";
+
+  // Main loop
+  while (!(*exit_requested)) {
+    // read from stdin to buffer. This detect the potentially sent EOF
+    while (fgets(buffer, sizeof(buffer), stdin) != nullptr) continue;
+    // exit if EOF occurred. This is used to shutdown via ssh.
+    if (feof(stdin)) *exit_requested = true;
+
+    asio_server.LoopTick();
+    Sleep(16);
+  }
 
   grpc_server->Shutdown();
   grpc_server->Wait();

--- a/OrbitService/OrbitService.h
+++ b/OrbitService/OrbitService.h
@@ -2,6 +2,8 @@
 #define ORBIT_SERVICE_ORBIT_SERVICE_H
 
 #include <atomic>
+#include <chrono>
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -18,9 +20,16 @@ class OrbitService {
   void Run(std::atomic<bool>* exit_requested);
 
  private:
+  bool IsSshWatchdogActive() { return last_stdin_message_ != std::nullopt; }
+
   std::string grpc_address_;
   uint16_t asio_port_;
   LinuxTracing::TracingOptions tracing_options_;
+
+  std::optional<std::chrono::time_point<std::chrono::steady_clock>>
+      last_stdin_message_ = std::nullopt;
+  const std::string_view start_passphrase_ = "start_watchdog";
+  const int timeout_in_seconds_ = 10;
 };
 
 #endif  // ORBIT_SERVICE_ORBIT_SERVICE_H


### PR DESCRIPTION
The first commit moves the OrbitService loop on the main thread from OrbitAsioServer into OrbitService. 

The second commit is the SshWatchdog class that provides functionality to automatically shutdown OrbitService when the ssh connection crashes. It is implemented with a simple timeout mechanism currently set to 10 seconds (`SshWatchdog.timeout_in_seconds`).

This only works when the watchdog is activated (not yet implemented on the UI side). 