### PR TITLE
Asio: Do not send process list to the client

### DIFF
--- a/OrbitCore/Message.h
+++ b/OrbitCore/Message.h
@@ -56,7 +56,6 @@ enum MessageType : int16_t {
   Msg_RemoteProcessRequest,
   Msg_RemoteModule,
   Msg_RemoteFunctions,
-  Msg_RemoteProcessList,
   Msg_RemoteModuleDebugInfo,
   Msg_Timers,
   Msg_RemoteCallStack,

--- a/OrbitService/OrbitAsioServer.cpp
+++ b/OrbitService/OrbitAsioServer.cpp
@@ -53,17 +53,12 @@ void OrbitAsioServer::SetupIntrospection() {
 
 void OrbitAsioServer::ProcessListThread(std::atomic<bool>* exit_requested) {
   while (!(*exit_requested)) {
-    SendProcessList();
+    // Some Asio services rely on process_list_ being somewhat up-to-date
+    // TODO: Remove this once these services are removed.
+    process_list_.Refresh();
+    process_list_.UpdateCpuTimes();
     Sleep(2000);
   }
-}
-
-void OrbitAsioServer::SendProcessList() {
-  process_list_.Refresh();
-  process_list_.UpdateCpuTimes();
-  std::string process_data = SerializeObjectHumanReadable(process_list_);
-  tcp_server_->Send(Msg_RemoteProcessList, process_data.data(),
-                    process_data.size());
 }
 
 void OrbitAsioServer::SetupServerCallbacks() {

--- a/OrbitService/OrbitAsioServer.h
+++ b/OrbitService/OrbitAsioServer.h
@@ -23,7 +23,6 @@ class OrbitAsioServer {
   void SetupIntrospection();
 
   void ProcessListThread(std::atomic<bool>* exit_requested);
-  void SendProcessList();
 
   void SetupServerCallbacks();
   void SendProcess(uint32_t pid);


### PR DESCRIPTION
This part is done via grpc now and client is no longer
handles this request.