### PR TITLE
Catch std::exception when using cereal to read/write files

### DIFF
--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -483,7 +483,7 @@ bool Capture::SaveSession(const std::string& filename) {
     cereal::BinaryOutputArchive archive(file);
     archive(cereal::make_nvp("Session", session));
     return true;
-  } catch (cereal::Exception& e) {
+  } catch (std::exception& e) {
     ERROR("Saving session in \"%s\": %s", filenameWithExt, e.what());
     return false;
   }

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -41,7 +41,8 @@ class Capture {
   static void Update();
   static void DisplayStats();
   static void TestHooks();
-  static bool SaveSession(const std::string& filename);
+  static outcome::result<void, std::string> SaveSession(
+      const std::string& filename);
   static void NewSamplingProfiler();
   static bool IsTrackingEvents();
   // True when Orbit is receiving data from remote source

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -41,7 +41,7 @@ class Capture {
   static void Update();
   static void DisplayStats();
   static void TestHooks();
-  static void SaveSession(const std::string& a_FileName);
+  static bool SaveSession(const std::string& filename);
   static void NewSamplingProfiler();
   static bool IsTrackingEvents();
   // True when Orbit is receiving data from remote source

--- a/OrbitCore/Params.cpp
+++ b/OrbitCore/Params.cpp
@@ -72,7 +72,7 @@ void Params::Save() {
   try {
     cereal::XMLOutputArchive archive(file);
     archive(cereal::make_nvp("Params", *this));
-  } catch (cereal::Exception& e) {
+  } catch (std::exception& e) {
     ERROR("Saving Params in \"%s\": %s", filename, e.what());
   }
 }
@@ -91,7 +91,7 @@ void Params::Load() {
   try {
     cereal::XMLInputArchive archive(file);
     archive(*this);
-  } catch (cereal::Exception& e) {
+  } catch (std::exception& e) {
     ERROR("Loading Params from \"%s\": %s", filename, e.what());
     // Try overwriting the file with default values, in case it's malformed.
     Save();

--- a/OrbitCore/Params.cpp
+++ b/OrbitCore/Params.cpp
@@ -65,7 +65,7 @@ void Params::Save() {
   std::string filename = Path::GetParamsFileName();
   std::ofstream file(filename);
   if (file.fail()) {
-    ERROR("Saving Params in \"%s\"", filename);
+    ERROR("Saving Params in \"%s\": %s", filename, "file.fail()");
     return;
   }
 
@@ -82,7 +82,7 @@ void Params::Load() {
   std::string filename = Path::GetParamsFileName();
   std::ifstream file(filename);
   if (file.fail()) {
-    ERROR("Loading Params from \"%s\"", filename);
+    ERROR("Loading Params from \"%s\": %s", filename, "file.fail()");
     // Try creating the file with default values, in case it doesn't exist.
     Save();
     return;

--- a/OrbitCore/Params.cpp
+++ b/OrbitCore/Params.cpp
@@ -59,42 +59,45 @@ ORBIT_SERIALIZE(Params, 19) {
 }
 
 //-----------------------------------------------------------------------------
-void Params::Save() {
+bool Params::Save() {
   GCoreApp->SendToUiNow("UpdateProcessParams");
 
   std::string filename = Path::GetParamsFileName();
   std::ofstream file(filename);
   if (file.fail()) {
     ERROR("Saving Params in \"%s\": %s", filename, "file.fail()");
-    return;
+    return false;
   }
 
   try {
     cereal::XMLOutputArchive archive(file);
     archive(cereal::make_nvp("Params", *this));
+    return true;
   } catch (std::exception& e) {
     ERROR("Saving Params in \"%s\": %s", filename, e.what());
+    return false;
   }
 }
 
 //-----------------------------------------------------------------------------
-void Params::Load() {
+bool Params::Load() {
   std::string filename = Path::GetParamsFileName();
   std::ifstream file(filename);
   if (file.fail()) {
     ERROR("Loading Params from \"%s\": %s", filename, "file.fail()");
     // Try creating the file with default values, in case it doesn't exist.
-    Save();
-    return;
+    return Save();
   }
 
   try {
     cereal::XMLInputArchive archive(file);
     archive(*this);
+    return true;
   } catch (std::exception& e) {
     ERROR("Loading Params from \"%s\": %s", filename, e.what());
     // Try overwriting the file with default values, in case it's malformed.
     Save();
+    return false;
   }
 }
 

--- a/OrbitCore/Params.h
+++ b/OrbitCore/Params.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <outcome.hpp>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -13,8 +14,8 @@
 
 struct Params {
   Params();
-  void Load();
-  void Save();
+  bool Load();
+  bool Save();
 
   void AddToPdbHistory(const std::string& a_PdbName);
 

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -407,7 +407,7 @@ void OrbitApp::ListSessions() {
       file.close();
       session->m_FileName = filename;
       sessions.push_back(session);
-    } catch (cereal::Exception& e) {
+    } catch (std::exception& e) {
       ERROR("Loading session from \"%s\": %s", filename.c_str(), e.what());
     }
   }
@@ -700,7 +700,7 @@ bool OrbitApp::OnLoadSession(const std::string& file_name) {
     session->m_FileName = file_path;
     LoadSession(session);
     return true;
-  } catch (cereal::Exception& e) {
+  } catch (std::exception& e) {
     ERROR("Loading session from \"%s\": %s", file_path, e.what());
     return false;
   }

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -63,9 +63,9 @@ class OrbitApp final : public CoreApp, public DataViewFactory {
   std::string GetSessionFileName();
   std::string GetSaveFile(const std::string& extension);
   void SetClipboard(const std::wstring& a_Text);
-  void OnSaveSession(const std::string& file_name);
+  bool OnSaveSession(const std::string& file_name);
   bool OnLoadSession(const std::string& file_name);
-  void OnSaveCapture(const std::string& file_name);
+  bool OnSaveCapture(const std::string& file_name);
   bool OnLoadCapture(const std::string& file_name);
   void OnOpenPdb(const std::string& file_name);
   void OnLaunchProcess(const std::string& process_name,

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -7,6 +7,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <outcome.hpp>
 #include <queue>
 #include <string>
 #include <utility>
@@ -63,10 +64,14 @@ class OrbitApp final : public CoreApp, public DataViewFactory {
   std::string GetSessionFileName();
   std::string GetSaveFile(const std::string& extension);
   void SetClipboard(const std::wstring& a_Text);
-  bool OnSaveSession(const std::string& file_name);
-  bool OnLoadSession(const std::string& file_name);
-  bool OnSaveCapture(const std::string& file_name);
-  bool OnLoadCapture(const std::string& file_name);
+  outcome::result<void, std::string> OnSaveSession(
+      const std::string& file_name);
+  outcome::result<void, std::string> OnLoadSession(
+      const std::string& file_name);
+  outcome::result<void, std::string> OnSaveCapture(
+      const std::string& file_name);
+  outcome::result<void, std::string> OnLoadCapture(
+      const std::string& file_name);
   void OnOpenPdb(const std::string& file_name);
   void OnLaunchProcess(const std::string& process_name,
                        const std::string& working_dir, const std::string& args);

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -50,7 +50,7 @@ bool CaptureSerializer::Save(const std::string& filename) {
     cereal::BinaryOutputArchive archive(file);
     Save(archive);
     return true;
-  } catch (cereal::Exception& e) {
+  } catch (std::exception& e) {
     ERROR("Saving capture in \"%s\": %s", filename, e.what());
     return false;
   }

--- a/OrbitGl/CaptureSerializer.h
+++ b/OrbitGl/CaptureSerializer.h
@@ -3,6 +3,7 @@
 //-----------------------------------
 #pragma once
 
+#include <outcome.hpp>
 #include <string>
 #include <unordered_map>
 
@@ -12,8 +13,8 @@
 class CaptureSerializer {
  public:
   CaptureSerializer();
-  bool Save(const std::string& filename);
-  bool Load(const std::string& filename);
+  outcome::result<void, std::string> Save(const std::string& filename);
+  outcome::result<void, std::string> Load(const std::string& filename);
 
   template <class T>
   void Save(T& archive);

--- a/OrbitGl/CaptureSerializer.h
+++ b/OrbitGl/CaptureSerializer.h
@@ -12,7 +12,7 @@
 class CaptureSerializer {
  public:
   CaptureSerializer();
-  void Save(const std::string& filename);
+  bool Save(const std::string& filename);
   bool Load(const std::string& filename);
 
   template <class T>

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -526,11 +526,13 @@ void OrbitMainWindow::on_actionSave_Session_triggered() {
     on_actionSave_Session_As_triggered();
     return;
   }
-  bool saved = GOrbitApp->OnSaveSession(sessionName);
-  if (!saved) {
+  outcome::result<void, std::string> result =
+      GOrbitApp->OnSaveSession(sessionName);
+  if (result.has_error()) {
     QMessageBox::critical(
         this, "Error saving session",
-        absl::StrFormat("Could not save session in \"%s\".", sessionName)
+        absl::StrFormat("Could not save session in \"%s\":\n%s.", sessionName,
+                        result.error())
             .c_str());
   }
 }
@@ -540,12 +542,13 @@ void OrbitMainWindow::on_actionOpen_Session_triggered() {
   QStringList list = QFileDialog::getOpenFileNames(
       this, "Select a file to open...", Path::GetPresetPath().c_str(), "*.opr");
   for (const auto& file : list) {
-    bool loaded = GOrbitApp->OnLoadSession(file.toStdString());
-    if (!loaded) {
+    outcome::result<void, std::string> result =
+        GOrbitApp->OnLoadSession(file.toStdString());
+    if (result.has_error()) {
       QMessageBox::critical(
           this, "Error loading session",
-          absl::StrFormat("Could not load session from \"%s\".",
-                          file.toStdString())
+          absl::StrFormat("Could not load session from \"%s\":\n%s.",
+                          file.toStdString(), result.error())
               .c_str());
     }
     break;
@@ -596,11 +599,14 @@ void OrbitMainWindow::on_actionSave_Session_As_triggered() {
   if (file.isEmpty()) {
     return;
   }
-  bool saved = GOrbitApp->OnSaveSession(file.toStdString());
-  if (!saved) {
+
+  outcome::result<void, std::string> result =
+      GOrbitApp->OnSaveSession(file.toStdString());
+  if (result.has_error()) {
     QMessageBox::critical(
         this, "Error saving session",
-        absl::StrFormat("Could not save session in \"%s\".", file.toStdString())
+        absl::StrFormat("Could not save session in \"%s\":\n%s.",
+                        file.toStdString(), result.error())
             .c_str());
   }
 }
@@ -653,11 +659,14 @@ void OrbitMainWindow::on_actionSave_Capture_triggered() {
   if (file.isEmpty()) {
     return;
   }
-  bool saved = GOrbitApp->OnSaveCapture(file.toStdString());
-  if (!saved) {
+
+  outcome::result<void, std::string> result =
+      GOrbitApp->OnSaveCapture(file.toStdString());
+  if (result.has_error()) {
     QMessageBox::critical(
         this, "Error saving capture",
-        absl::StrFormat("Could not save capture in \"%s\".", file.toStdString())
+        absl::StrFormat("Could not save capture in \"%s\":\n%s.",
+                        file.toStdString(), result.error())
             .c_str());
   }
 }
@@ -669,13 +678,16 @@ void OrbitMainWindow::on_actionOpen_Capture_triggered() {
   if (file.isEmpty()) {
     return;
   }
-  bool loaded = GOrbitApp->OnLoadCapture(file.toStdString());
-  if (!loaded) {
+
+  outcome::result<void, std::string> result =
+      GOrbitApp->OnLoadCapture(file.toStdString());
+  if (result.has_error()) {
     SetTitle({});
-    QMessageBox::critical(this, "Error loading capture",
-                          absl::StrFormat("Could not load capture from \"%s\".",
-                                          file.toStdString())
-                              .c_str());
+    QMessageBox::critical(
+        this, "Error loading capture",
+        absl::StrFormat("Could not load capture from \"%s\":\n%s.",
+                        file.toStdString(), result.error())
+            .c_str());
     return;
   }
   SetTitle(file);

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -522,10 +522,16 @@ void OrbitMainWindow::OnHideSearch() { ui->lineEdit->hide(); }
 //-----------------------------------------------------------------------------
 void OrbitMainWindow::on_actionSave_Session_triggered() {
   std::string sessionName = GOrbitApp->GetSessionFileName();
-  if (!sessionName.empty()) {
-    GOrbitApp->OnSaveSession(sessionName);
-  } else {
+  if (sessionName.empty()) {
     on_actionSave_Session_As_triggered();
+    return;
+  }
+  bool saved = GOrbitApp->OnSaveSession(sessionName);
+  if (!saved) {
+    QMessageBox::critical(
+        this, "Error saving session",
+        absl::StrFormat("Could not save session in \"%s\".", sessionName)
+            .c_str());
   }
 }
 
@@ -587,9 +593,15 @@ void OrbitMainWindow::on_actionSave_Session_As_triggered() {
   QString file =
       QFileDialog::getSaveFileName(this, "Specify a file to save...",
                                    Path::GetPresetPath().c_str(), "*.opr");
-  if (!file.isEmpty()) {
-    printf("filename: %s\n", file.toStdString().c_str());
-    GOrbitApp->OnSaveSession(file.toStdString());
+  if (file.isEmpty()) {
+    return;
+  }
+  bool saved = GOrbitApp->OnSaveSession(file.toStdString());
+  if (!saved) {
+    QMessageBox::critical(
+        this, "Error saving session",
+        absl::StrFormat("Could not save session in \"%s\".", file.toStdString())
+            .c_str());
   }
 }
 
@@ -641,7 +653,13 @@ void OrbitMainWindow::on_actionSave_Capture_triggered() {
   if (file.isEmpty()) {
     return;
   }
-  GOrbitApp->OnSaveCapture(file.toStdString());
+  bool saved = GOrbitApp->OnSaveCapture(file.toStdString());
+  if (!saved) {
+    QMessageBox::critical(
+        this, "Error saving capture",
+        absl::StrFormat("Could not save capture in \"%s\".", file.toStdString())
+            .c_str());
+  }
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
#### Catch `cereal::Exception` when saving/loading `Params`/sessions/captures
Bug: http://b/157113705
#### Catch `std::exception` instead of `cereal::Exception`
This is because we have seen `cereal::BinaryInputArchive` throw `std::bad_alloc`.
#### Return an `outcome::result` when reading and writing sessions/captures
#### Have `Params::Save`,`Load` return `bool`