### PR TITLE
Catch exception thrown by asio::write

### DIFF
--- a/OrbitCore/TcpEntity.cpp
+++ b/OrbitCore/TcpEntity.cpp
@@ -103,7 +103,13 @@ void TcpEntity::SendData() {
       --m_NumQueuedEntries;
       TcpSocket* socket = GetSocket();
       if (socket && socket->m_Socket && socket->m_Socket->is_open()) {
-        asio::write(*socket->m_Socket, SharedConstBuffer(buffer));
+        try {
+          asio::write(*socket->m_Socket, SharedConstBuffer(buffer));
+        } catch (std::exception& e) {
+          // We observed std::system_error being thrown by OrbitService when the
+          // client is stopped while being debugged. Refer to b/155464095.
+          ERROR("asio::write: %s", e.what());
+        }
       } else {
         ORBIT_ERROR;
       }


### PR DESCRIPTION
Bug: http://b/155464095

---
I'm open for suggestions on how to do this better/differently. At the same time, this is meant to be a limited-scope fix, as we are moving to gRPC and I'm not sure how much it's worth to investigate improving all these `Tcp...` classes.