### PR TITLE
Fix determination of Orbit's collector subdirectory.

### DIFF
--- a/OrbitQt/deploymentconfigurations.cpp
+++ b/OrbitQt/deploymentconfigurations.cpp
@@ -22,8 +22,9 @@ SignedDebianPackageDeployment::SignedDebianPackageDeployment() {
     return ver;
   }();
 
-  auto collector_directory = QDir{QCoreApplication::applicationDirPath()};
-  collector_directory.cd(kCollectorSubdirectory);
+  const auto collector_directory =
+      QDir{QDir{QCoreApplication::applicationDirPath()}.absoluteFilePath(
+          kCollectorSubdirectory)};
 
   const auto deb_path = collector_directory.absoluteFilePath(
       QString(kPackageNameTemplate).arg(version));


### PR DESCRIPTION
QDir's change directory function only works if the directory really
exists which leads to Orbit trying to read the debian package from a
different location if it can't find the collector subdirectory. We
should avoid that. Might be a potential security problem.