### PR TITLE
add developer mode

### DIFF
--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -33,8 +33,8 @@ ABSL_FLAG(bool, enable_stale_features, false,
           "Enable obsolete features that are not working or are not "
           "implemented in the client's UI");
 
-ABSL_FLAG(bool, enable_debug_menu, false,
-          "Enable developer menu in the client's UI");
+ABSL_FLAG(bool, devmode, false,
+          "Enable developer mode in the client's UI");
 
 ABSL_FLAG(std::string, remote, "",
           "Connect to the specified remote on startup");

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -33,6 +33,9 @@ ABSL_FLAG(bool, enable_stale_features, false,
           "Enable obsolete features that are not working or are not "
           "implemented in the client's UI");
 
+ABSL_FLAG(bool, enable_debug_menu, false,
+          "Enable developer menu in the client's UI");
+
 ABSL_FLAG(std::string, remote, "",
           "Connect to the specified remote on startup");
 ABSL_FLAG(uint16_t, asio_port, 44766,

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -39,7 +39,7 @@
 #endif
 
 ABSL_DECLARE_FLAG(bool, enable_stale_features);
-ABSL_DECLARE_FLAG(bool, enable_debug_menu);
+ABSL_DECLARE_FLAG(bool, devmode);
 
 //-----------------------------------------------------------------------------
 OrbitMainWindow* GMainWindow;
@@ -163,7 +163,7 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App,
     ui->menuDev->menuAction()->setVisible(!ui->menuDev->isEmpty());
   }
 
-  if (!absl::GetFlag(FLAGS_enable_debug_menu)) {
+  if (!absl::GetFlag(FLAGS_devmode)) {
     ui->menuDebug->menuAction()->setVisible(false);
   }
 

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -39,6 +39,7 @@
 #endif
 
 ABSL_DECLARE_FLAG(bool, enable_stale_features);
+ABSL_DECLARE_FLAG(bool, enable_debug_menu);
 
 //-----------------------------------------------------------------------------
 OrbitMainWindow* GMainWindow;
@@ -160,6 +161,10 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App,
     ui->actionShow_Includes_Util->setVisible(false);
     ui->menuTools->menuAction()->setVisible(false);
     ui->menuDev->menuAction()->setVisible(!ui->menuDev->isEmpty());
+  }
+
+  if (!absl::GetFlag(FLAGS_enable_debug_menu)) {
+    ui->menuDebug->menuAction()->setVisible(false);
   }
 
   // Output window
@@ -736,4 +741,9 @@ void OrbitMainWindow::on_actionOutputDebugString_triggered(bool checked) {
 //-----------------------------------------------------------------------------
 void OrbitMainWindow::on_actionUploadDumpsToServer_triggered(bool checked) {
   GOrbitApp->EnableUploadDumpsToServer(checked);
+}
+
+//-----------------------------------------------------------------------------
+void OrbitMainWindow::on_actionCheckFalse_triggered() {
+    CHECK(false);
 }

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -88,6 +88,8 @@ class OrbitMainWindow : public QMainWindow {
 
   void on_actionUploadDumpsToServer_triggered(bool checked);
 
+  void on_actionCheckFalse_triggered();
+
  private:
   void StartMainTimer();
 

--- a/OrbitQt/orbitmainwindow.ui
+++ b/OrbitQt/orbitmainwindow.ui
@@ -285,6 +285,18 @@
     <addaction name="actionOutputDebugString"/>
     <addaction name="actionUploadDumpsToServer"/>
    </widget>
+   <widget class="QMenu" name="menuCrash">
+    <property name="title">
+     <string>Crash Test</string>
+    </property>
+    <addaction name="actionCheckFalse"/>
+   </widget>
+   <widget class="QMenu" name="menuDebug">
+    <property name="title">
+     <string>Debug</string>
+    </property>
+    <addaction name="menuCrash"/>
+   </widget>
    <widget class="QMenu" name="menuTools">
     <property name="title">
      <string>Tools</string>
@@ -293,6 +305,7 @@
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuDev"/>
+   <addaction name="menuDebug"/>
    <addaction name="menuTools"/>
    <addaction name="menuHelp"/>
   </widget>
@@ -415,6 +428,11 @@
    </property>
    <property name="text">
     <string>Upload Dumps on Crash</string>
+   </property>
+  </action>
+  <action name="actionCheckFalse">
+   <property name="text">
+    <string>Check false</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Initial commit for add developer mode. Developer mode enables debug menu with menu for crash testing inside for now. Menu is hidden by default, but becomes visible when Orbit is started with --devmode flag.

Only one crash option is added for now (CHECK(false)). 