### PR TITLE
Simple local profiling

### DIFF
--- a/OrbitSshQt/include/OrbitSshQt/ScopedConnection.h
+++ b/OrbitSshQt/include/OrbitSshQt/ScopedConnection.h
@@ -18,6 +18,7 @@ class ScopedConnection {
   QMetaObject::Connection connection_;
 
  public:
+  ScopedConnection() = default;
   explicit ScopedConnection(QMetaObject::Connection&& conn)
       : connection_(std::move(conn)) {}
   ScopedConnection(const ScopedConnection&) = delete;


### PR DESCRIPTION
When the "--local"-flags is passed to Orbit-UI then the profiling-target-dialog is bypassed,
no deployment and tunneling is set up and the UI directly connects to the usual ports on localhost (127.0.0.1 to be specific.)

Can be used either for local profiling or in conjunction with the run_service_ssh.{sh,ps1} script, or with manually set-up SSH tunnels. Can also be combined with "--asio_port" and "--grpc_port".

This flags also takes precedence over all the "ORBIT_COLLECTOR_*" env variables.