### PR TITLE
Preserve selection on refresh

### DIFF
--- a/OrbitGl/DataView.cpp
+++ b/OrbitGl/DataView.cpp
@@ -29,7 +29,13 @@ void DataView::InitSortingOrders() {
   m_SortingColumn = GetDefaultSortingColumn();
 }
 
-//-----------------------------------------------------------------------------
+void DataView::OnSelect(const std::vector<int>& selected_indexes,
+                        int current_index) {
+  current_selected_index_ = current_index;
+  selected_indexes_ = selected_indexes;
+  DoSelect(current_index);
+}
+
 void DataView::OnSort(int column, std::optional<SortingOrder> new_order) {
   if (column < 0) {
     return;

--- a/OrbitGl/DataView.h
+++ b/OrbitGl/DataView.h
@@ -32,7 +32,7 @@ class DataView {
   };
 
   explicit DataView(DataViewType type)
-      : m_UpdatePeriodMs(-1), m_SelectedIndex(-1), m_Type(type) {}
+      : m_UpdatePeriodMs(-1), m_Type(type), current_selected_index_(-1) {}
 
   virtual ~DataView() = default;
 
@@ -51,8 +51,11 @@ class DataView {
   virtual void OnContextMenu(const std::string& a_Action, int a_MenuIndex,
                              const std::vector<int>& a_ItemIndices);
   virtual void OnItemActivated() {}
-  virtual void OnSelect(int /*a_Index*/) {}
-  virtual int GetSelectedIndex() { return m_SelectedIndex; }
+  void OnSelect(const std::vector<int>& selected_indexes, int current_index);
+  int GetCurrentSelectedIndex() const { return current_selected_index_; }
+  const std::vector<int> GetSelectedIndexes() const {
+    return selected_indexes_;
+  }
   virtual void OnDataChanged();
   virtual void OnTimer() {}
   virtual bool WantsDisplayColor() { return false; }
@@ -74,6 +77,7 @@ class DataView {
 
  protected:
   void InitSortingOrders();
+  virtual void DoSelect(int /*current_index*/) {}
   virtual void DoSort() {}
   virtual void DoFilter() {}
 
@@ -82,9 +86,13 @@ class DataView {
   int m_SortingColumn = 0;
   std::string m_Filter;
   int m_UpdatePeriodMs;
-  int m_SelectedIndex;
+
   DataViewType m_Type;
 
   static const std::string MENU_ACTION_COPY_SELECTION;
   static const std::string MENU_ACTION_EXPORT_TO_CSV;
+
+ private:
+  int current_selected_index_;
+  std::vector<int> selected_indexes_;
 };

--- a/OrbitGl/ProcessesDataView.h
+++ b/OrbitGl/ProcessesDataView.h
@@ -19,7 +19,6 @@ class ProcessesDataView final : public DataView {
   std::string GetToolTip(int row, int column) override;
   std::string GetLabel() override { return "Processes"; }
 
-  void OnSelect(int index) override;
   bool SelectProcess(const std::string& process_name);
   bool SelectProcess(uint32_t process_id);
   void SetProcessList(std::vector<ProcessInfo>&& process_list);
@@ -28,6 +27,7 @@ class ProcessesDataView final : public DataView {
  protected:
   void DoSort() override;
   void DoFilter() override;
+  void DoSelect(int index) override;
 
  private:
   void UpdateProcessList();

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -217,8 +217,7 @@ void SamplingReportDataView::OnContextMenu(
 }
 
 //-----------------------------------------------------------------------------
-void SamplingReportDataView::OnSelect(int index) {
-  m_SelectedIndex = index;
+void SamplingReportDataView::DoSelect(int index) {
   SampledFunction& func = GetSampledFunction(index);
   m_SamplingReport->OnSelectAddress(func.m_Address, m_TID);
 }

--- a/OrbitGl/SamplingReportDataView.h
+++ b/OrbitGl/SamplingReportDataView.h
@@ -22,7 +22,6 @@ class SamplingReportDataView : public DataView {
 
   void OnContextMenu(const std::string& a_Action, int a_MenuIndex,
                      const std::vector<int>& a_ItemIndices) override;
-  void OnSelect(int a_Index) override;
 
   void LinkDataView(DataView* a_DataView) override;
   void SetSamplingReport(class SamplingReport* a_SamplingReport) {
@@ -33,6 +32,7 @@ class SamplingReportDataView : public DataView {
   ThreadID GetThreadID() const { return m_TID; }
 
  protected:
+  void DoSelect(int index) override;
   void DoSort() override;
   void DoFilter() override;
   const SampledFunction& GetSampledFunction(unsigned int a_Row) const;

--- a/OrbitQt/orbittablemodel.cpp
+++ b/OrbitQt/orbittablemodel.cpp
@@ -123,9 +123,9 @@ void OrbitTableModel::OnFilter(const QString& a_Filter) {
   m_DataView->OnFilter(a_Filter.toStdString());
 }
 
-//-----------------------------------------------------------------------------
-void OrbitTableModel::OnClicked(const QModelIndex& index) {
-  if (static_cast<int>(m_DataView->GetNumElements()) > index.row()) {
-    m_DataView->OnSelect(index.row());
+void OrbitTableModel::OnSelected(const std::vector<int>& selected_indexes,
+                                 int current_selected_index) {
+  if (static_cast<int>(m_DataView->GetNumElements()) > current_selected_index) {
+    m_DataView->OnSelect(selected_indexes, current_selected_index);
   }
 }

--- a/OrbitQt/orbittablemodel.h
+++ b/OrbitQt/orbittablemodel.h
@@ -27,7 +27,14 @@ class OrbitTableModel : public QAbstractTableModel {
   void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) override;
 
   int GetUpdatePeriodMs() { return m_DataView->GetUpdatePeriodMs(); }
-  int GetSelectedIndex() { return m_DataView->GetSelectedIndex(); }
+
+  int GetCurrentSelectedIndex() const {
+    return m_DataView->GetCurrentSelectedIndex();
+  }
+  const std::vector<int> GetSelectedIndexes() const {
+    return m_DataView->GetSelectedIndexes();
+  }
+
   QModelIndex CreateIndex(int a_Row, int a_Column) {
     return createIndex(a_Row, a_Column);
   }
@@ -38,7 +45,7 @@ class OrbitTableModel : public QAbstractTableModel {
 
   void OnTimer();
   void OnFilter(const QString& a_Filter);
-  void OnClicked(const QModelIndex& index);
+  void OnSelected(const std::vector<int>& selected_indexes, int current_index);
 
  protected:
   DataView* m_DataView;

--- a/OrbitQt/orbittreeview.h
+++ b/OrbitQt/orbittreeview.h
@@ -46,6 +46,8 @@ class OrbitTreeView : public QTreeView {
   void OnRangeChanged(int a_Min, int a_Max);
 
  private:
+  std::vector<int> GetSelectedIndexes();
+
   std::unique_ptr<OrbitTableModel> model_;
   std::unique_ptr<QTimer> timer_;
   std::vector<OrbitTreeView*> links_;


### PR DESCRIPTION
This change refactors the way selection is done in DataViews
1. Now the base class is responsible for storing selections
2. Refresh method is able to restore selection for multi-select
   selection models.

Bug: http://b/157534259
Test: sample a process, select multiple functions in sampling view