### PR TITLE
Upload debug symbols

### DIFF
--- a/OrbitQt/CMakeLists.txt
+++ b/OrbitQt/CMakeLists.txt
@@ -103,7 +103,7 @@ if(WIN32)
     TARGET OrbitQt
     POST_BUILD
     COMMAND "${CMAKE_COMMAND}" -E env PATH="${_qt_bin_dir}"
-            "${WINDEPLOYQT_EXECUTABLE}" "$<TARGET_FILE:OrbitQt>"
+            "${WINDEPLOYQT_EXECUTABLE}" --pdb "$<TARGET_FILE:OrbitQt>"
     COMMENT "Running windeployqt...")
 endif()
 

--- a/kokoro/gcp_windows/kokoro_release_build.bat
+++ b/kokoro/gcp_windows/kokoro_release_build.bat
@@ -1,0 +1,51 @@
+@echo off
+REM Copyright (c) 2020 The Orbit Authors. All rights reserved.
+REM Use of this source code is governed by a BSD-style license that can be
+REM found in the LICENSE file.
+
+:: Code under repo is checked out to %KOKORO_ARTIFACTS_DIR%\github.
+:: The final directory name in this path is determined by the scm name specified
+:: in the job configuration
+
+SET REPO_ROOT=%KOKORO_ARTIFACTS_DIR%\github\orbitprofiler
+
+:: Install conan config
+call powershell "& %REPO_ROOT%\contrib\conan\configs\install.ps1"
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+:: Building conan
+set /P CRASHDUMP_SERVER=<%KOKORO_ARTIFACTS_DIR%\keystore\74938_orbitprofiler_crashdump_collection_server
+call conan install -pr msvc2017_relwithdebinfo -if %REPO_ROOT%\build\ --build outdated -o crashdump_server="%CRASHDUMP_SERVER%" %REPO_ROOT%
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+call conan build -bf %REPO_ROOT%\build\ %REPO_ROOT%
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+call conan package -bf %REPO_ROOT%\build\ %REPO_ROOT%
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+:: Upload debug symbols
+call powershell "& %REPO_ROOT%\kokoro\gcp_windows\upload_symbols.ps1" %REPO_ROOT%\build\package\bin
+
+:: Package build artifacts into a zip for integration in the installer.
+cd %REPO_ROOT%\build\package
+ren bin Orbit
+copy /Y THIRD_PARTY_LICENSES.txt Orbit\THIRD_PARTY_LICENSES.txt
+copy /Y LICENSE Orbit\LICENSE.txt
+zip -r Orbit.zip Orbit
+
+:: Uploading prebuilt packages of our dependencies
+set /P ACCESS_TOKEN=<%KOKORO_ARTIFACTS_DIR%\keystore\74938_orbitprofiler_artifactory_access_token
+if EXIST %KOKORO_ARTIFACTS_DIR%\keystore\74938_orbitprofiler_artifactory_access_token (
+  call conan user -r artifactory -p "%ACCESS_TOKEN%" kokoro
+  if %errorlevel% neq 0 exit /b %errorlevel%
+
+  REM The llvm-package is very large and not needed as a prebuilt because it is not consumed directly.
+  call conan remove 'llvm/*@orbitdeps/stable'
+  if %errorlevel% neq 0 exit /b %errorlevel%
+
+  call conan upload -r artifactory --all --no-overwrite all --confirm  --parallel *
+  if %errorlevel% neq 0 exit /b %errorlevel%
+) else (
+  echo No access token available. Skipping package upload.
+)

--- a/kokoro/gcp_windows/kokoro_release_build.bat
+++ b/kokoro/gcp_windows/kokoro_release_build.bat
@@ -25,7 +25,7 @@ call conan package -bf %REPO_ROOT%\build\ %REPO_ROOT%
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 :: Upload debug symbols
-call powershell "& %REPO_ROOT%\kokoro\gcp_windows\upload_symbols.ps1" %REPO_ROOT%\build\package\bin
+call powershell "& %REPO_ROOT%\kokoro\gcp_windows\upload_symbols.ps1" %REPO_ROOT%\build\bin
 
 :: Package build artifacts into a zip for integration in the installer.
 cd %REPO_ROOT%\build\package

--- a/kokoro/gcp_windows/release.cfg
+++ b/kokoro/gcp_windows/release.cfg
@@ -3,7 +3,7 @@
 
 # Location of the bash script. Should have value <github_scm.name>/<path_from_repository_root>.
 # github_scm.name is specified in the job configuration (next section).
-build_file: "orbitprofiler/kokoro/gcp_windows/kokoro_build.bat"
+build_file: "orbitprofiler/kokoro/gcp_windows/kokoro_release_build.bat"
 
 before_action {
   fetch_keystore {

--- a/kokoro/gcp_windows/upload_symbols.ps1
+++ b/kokoro/gcp_windows/upload_symbols.ps1
@@ -1,0 +1,64 @@
+function install_oauth2l {
+  if (-Not (Test-Path 'oauth2l.tgz' -PathType Leaf)) {
+    Invoke-WebRequest -Uri https://storage.googleapis.com/oauth2l/latest/windows_amd64.tgz -OutFile oauth2l.tgz
+  }
+
+  $oauth2l_path = Join-Path -Path $pwd -ChildPath "oauth2l"
+  if (-Not (Test-Path ($oauth2l_path + '\oauth2l.exe') -PathType Leaf)) {
+    New-Item -Path . -Name "oauth2l" -ItemType "directory" -errorAction SilentlyContinue
+    tar -zxvf oauth2l.tgz -C $oauth2l_path --strip-components 1
+	Rename-Item -Path ($oauth2l_path + '\oauth2l') -NewName ($oauth2l_path + '\oauth2l.exe')
+  }
+}
+
+function get_authorization_header {
+  $authorization = oauth2l\oauth2l.exe header cloud-platform userinfo.email
+  $authorization = $authorization -Replace ': ', ' = ' | ConvertFrom-StringData
+  return $authorization
+}
+
+function get_crash_symbol_collector_key_name($authorization) {
+  $keys = Invoke-RestMethod -Header $authorization  -ContentType "application/json" -Uri "https://apikeys.googleapis.com/v2beta1/projects/60941241589/keys"
+  if (-Not $keys) { Throw "Can't get list of API keys" }
+  
+  $key = $keys.keys | where {$_.displayName -eq "Crash Symbol Collector API key"}
+  if (-Not $key) { Throw "'Crash Symbol Collector API key' not found" }
+  
+  return $key.name.Substring($key.name.LastIndexOf('/') + 1)
+}
+
+function get_api_key_by_key_name($authorization, $key_name) {
+  $key = Invoke-RestMethod -Header $authorization  -ContentType "application/json" -uri "https://apikeys.googleapis.com/v2beta1/projects/60941241589/keys/$key_name/keyString"
+  return $key.keyString
+}
+
+function get_crash_symbol_collector_api_key {
+  $authorization = get_authorization_header
+  $crash_symbol_key_name = get_crash_symbol_collector_key_name $authorization
+  $crash_symbol_collector_api_key = get_api_key_by_key_name $authorization $crash_symbol_key_name
+  
+  return $crash_symbol_collector_api_key
+}
+
+function install_breakpad_tools {
+  if (-Not (Test-Path -Path 'breakpad' -PathType Container)) {
+    conan install -g deploy breakpad/2ffe116@orbitdeps/stable
+  }
+}
+
+function upload_debug_symbols_for_exe($api_key, $exe_path) {
+  breakpad\bin\symupload -p $exe_path https://prod-crashsymbolcollector-pa.googleapis.com $api_key
+}
+
+function upload_debug_symbols($bin_folder) {
+  install_oauth2l
+
+  $api_key = get_crash_symbol_collector_api_key
+  if (-Not $api_key) { Throw "Error on getting API key" }
+  
+  install_breakpad_tools
+  
+  upload_debug_symbols_for_exe $api_key $bin_folder\Orbit.exe
+}
+
+upload_debug_symbols $args[0]

--- a/kokoro/gcp_windows/upload_symbols.ps1
+++ b/kokoro/gcp_windows/upload_symbols.ps1
@@ -46,8 +46,8 @@ function install_breakpad_tools {
   }
 }
 
-function upload_debug_symbols_for_exe($api_key, $exe_path) {
-  breakpad\bin\symupload -p $exe_path https://prod-crashsymbolcollector-pa.googleapis.com $api_key
+function upload_symbol_file($api_key, $symbol_file_path) {
+  breakpad\bin\symupload -p $symbol_file_path https://prod-crashsymbolcollector-pa.googleapis.com $api_key
 }
 
 function upload_debug_symbols($bin_folder) {
@@ -58,7 +58,17 @@ function upload_debug_symbols($bin_folder) {
   
   install_breakpad_tools
   
-  upload_debug_symbols_for_exe $api_key $bin_folder\Orbit.exe
+  upload_symbol_file $api_key $bin_folder\Orbit.exe
+  upload_symbol_file $api_key $bin_folder\Qt5Core.dll
+  upload_symbol_file $api_key $bin_folder\Qt5Gui.dll
+  upload_symbol_file $api_key $bin_folder\Qt5Network.dll
+  upload_symbol_file $api_key $bin_folder\Qt5Widgets.dll
+  upload_symbol_file $api_key $bin_folder\bearer\qgenericbearer.dll
+  upload_symbol_file $api_key $bin_folder\imageformats\qgif.dll
+  upload_symbol_file $api_key $bin_folder\imageformats\qico.dll
+  upload_symbol_file $api_key $bin_folder\imageformats\qjpeg.dll
+  upload_symbol_file $api_key $bin_folder\platforms\qwindows.dll
+  upload_symbol_file $api_key $bin_folder\styles\qwindowsvistastyle.dll
 }
 
 upload_debug_symbols $args[0]


### PR DESCRIPTION
Added uploading symbols for Orbit and the dependencies.

Script is available for Windows only, included in release build and does the following:

- download oauth2l (https://github.com/google/oauth2l)

- get API key 

- install breakpad tools (including symupload)

- upload symbols to collection server with symupload