### PR TITLE
Added capture loading support to OrbitStartupWindow

### DIFF
--- a/OrbitQt/OrbitStartupWindow.cpp
+++ b/OrbitQt/OrbitStartupWindow.cpp
@@ -25,7 +25,8 @@
 #include "Path.h"
 
 OrbitStartupWindow::OrbitStartupWindow(QWidget* parent)
-    : QDialog{parent, Qt::Dialog}, model_(QPointer(new GgpInstanceItemModel)) {
+    : QDialog{parent, Qt::Dialog},
+      model_{new GgpInstanceItemModel{{}, this}} {
   // General UI
   const int width = 700;
   const int height = 400;
@@ -182,7 +183,7 @@ void OrbitStartupWindow::ReloadInstances(QPointer<QPushButton> refresh_button) {
   refresh_button->setText("Loading...");
 
   ggp_client_->GetInstancesAsync(
-      [&, refresh_button](
+      [model = model_, refresh_button](
           GgpClient::ResultOrQString<QVector<GgpInstance>> instances) {
         if (refresh_button) {
           refresh_button->setEnabled(true);
@@ -191,7 +192,7 @@ void OrbitStartupWindow::ReloadInstances(QPointer<QPushButton> refresh_button) {
 
         if (!instances) {
           QMessageBox::critical(
-              this, QApplication::applicationDisplayName(),
+              nullptr, QApplication::applicationDisplayName(),
               QString(
                   "Orbit was unable to retrieve the list of available Stadia "
                   "Instances. The error message was: %1")
@@ -199,7 +200,8 @@ void OrbitStartupWindow::ReloadInstances(QPointer<QPushButton> refresh_button) {
           return;
         }
 
-        if (!model_) return;
-        model_->SetInstances(std::move(instances.value()));
+        if (model) {
+          model->SetInstances(std::move(instances.value()));
+        }
       });
 }

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -723,8 +723,9 @@ void OrbitMainWindow::OpenDisassembly(const std::string& a_String) {
 //-----------------------------------------------------------------------------
 void OrbitMainWindow::SetTitle(const QString& task_description) {
   if (task_description.isEmpty()) {
-    setWindowTitle(QString("%1 %2 [BETA]").arg(QApplication::applicationName(),
-                                        QApplication::applicationVersion()));
+    setWindowTitle(QString("%1 %2 [BETA]")
+                       .arg(QApplication::applicationName(),
+                            QApplication::applicationVersion()));
   } else {
     setWindowTitle(QString("%1 %2 [BETA] - %3")
                        .arg(QApplication::applicationName(),
@@ -744,9 +745,7 @@ void OrbitMainWindow::on_actionUploadDumpsToServer_triggered(bool checked) {
 }
 
 //-----------------------------------------------------------------------------
-void OrbitMainWindow::on_actionCheckFalse_triggered() {
-  CHECK(false);
-}
+void OrbitMainWindow::on_actionCheckFalse_triggered() { CHECK(false); }
 
 //-----------------------------------------------------------------------------
 void OrbitMainWindow::on_actionNullPointerDereference_triggered() {

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -4,10 +4,14 @@
 
 #pragma once
 
+#include <QApplication>
 #include <QMainWindow>
-#include <atomic>
+#include <QString>
+#include <QTimer>
 #include <memory>
-#include <thread>
+#include <outcome.hpp>
+#include <string>
+#include <vector>
 
 #include "ApplicationOptions.h"
 #include "CallStackDataView.h"
@@ -49,6 +53,7 @@ class OrbitMainWindow : public QMainWindow {
                         const std::wstring& a_Filter);
   void OpenDisassembly(const std::string& a_String);
   void SetTitle(const QString& task_description);
+  outcome::result<void> OpenCapture(const std::string& filepath);
 
  private slots:
   void on_actionAbout_triggered();

--- a/OrbitQt/orbitmainwindow.ui
+++ b/OrbitQt/orbitmainwindow.ui
@@ -255,13 +255,13 @@
     <property name="title">
      <string>File</string>
     </property>
-    <addaction name="actionSave_Capture"/>
     <addaction name="actionOpen_Capture"/>
+    <addaction name="actionSave_Capture"/>
     <addaction name="separator"/>
+    <addaction name="actionOpen_PDB"/>
+    <addaction name="actionOpen_Session"/>
     <addaction name="actionSave_Session"/>
     <addaction name="actionSave_Session_As"/>
-    <addaction name="actionOpen_Session"/>
-    <addaction name="actionOpen_PDB"/>
     <addaction name="separator"/>
     <addaction name="actionLaunch_Process"/>
     <addaction name="actionDisconnect"/>


### PR DESCRIPTION
This PR adds a button to Orbit's startup window which allows to load a capture without connecting to a remote profile target.

![image](https://user-images.githubusercontent.com/43133967/83150674-d6406000-a0fb-11ea-92d0-409f28f7f157.png)
