### PR TITLE
Disable interaction with the content of the "home" tab while capturing

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -791,22 +791,30 @@ void OrbitApp::StartCapture() {
 #endif
     m_NeedsThawing = false;
   }
+
+  for (const CaptureStartedCallback& callback : capture_started_callbacks_) {
+    callback();
+  }
 }
 
 //-----------------------------------------------------------------------------
 void OrbitApp::StopCapture() {
   Capture::StopCapture();
 
+  for (const CaptureStoppedCallback& callback : capture_stopped_callbacks_) {
+    callback();
+  }
   FireRefreshCallbacks();
 }
 
 //-----------------------------------------------------------------------------
 void OrbitApp::ToggleCapture() {
   if (GTimerManager) {
-    if (GTimerManager->m_IsRecording)
+    if (GTimerManager->m_IsRecording) {
       StopCapture();
-    else
+    } else {
       StartCapture();
+    }
   }
 }
 

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -125,6 +125,15 @@ class OrbitApp final : public CoreApp, public DataViewFactory {
   void GoToCapture();
 
   // Callbacks
+  using CaptureStartedCallback = std::function<void()>;
+  void AddCaptureStartedCallback(CaptureStartedCallback callback) {
+    capture_started_callbacks_.emplace_back(std::move(callback));
+  }
+  using CaptureStoppedCallback = std::function<void()>;
+  void AddCaptureStoppedCallback(CaptureStoppedCallback callback) {
+    capture_stopped_callbacks_.emplace_back(std::move(callback));
+  }
+
   typedef std::function<void(DataViewType a_Type)> RefreshCallback;
   void AddRefreshCallback(RefreshCallback a_Callback) {
     m_RefreshCallbacks.emplace_back(std::move(a_Callback));
@@ -245,6 +254,8 @@ class OrbitApp final : public CoreApp, public DataViewFactory {
   absl::flat_hash_map<uint32_t, std::shared_ptr<Process>> process_map_;
 
   std::vector<std::string> m_Arguments;
+  std::vector<CaptureStartedCallback> capture_started_callbacks_;
+  std::vector<CaptureStoppedCallback> capture_stopped_callbacks_;
   std::vector<RefreshCallback> m_RefreshCallbacks;
   std::vector<WatchCallback> m_AddToWatchCallbacks;
   std::vector<WatchCallback> m_UpdateWatchCallbacks;

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -70,6 +70,10 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App,
   ui->HomeHorizontalSplitter->setSizes(sizes);
   ui->splitter_2->setSizes(sizes);
 
+  GOrbitApp->AddCaptureStartedCallback(
+      [this] { ui->HomeTab->setDisabled(true); });
+  GOrbitApp->AddCaptureStoppedCallback(
+      [this] { ui->HomeTab->setDisabled(false); });
   GOrbitApp->AddRefreshCallback(
       [this](DataViewType a_Type) { this->OnRefreshDataViewPanels(a_Type); });
   GOrbitApp->AddSamplingReportCallback(

--- a/OrbitQt/orbitmainwindow.ui
+++ b/OrbitQt/orbitmainwindow.ui
@@ -33,7 +33,7 @@
        <property name="currentIndex">
         <number>0</number>
        </property>
-       <widget class="QWidget" name="tab">
+       <widget class="QWidget" name="HomeTab">
         <attribute name="title">
          <string>home</string>
         </attribute>


### PR DESCRIPTION
It should not be possible to switch process, load sessions, load modules, etc.,
while taking a capture, as this can cause crashes, inconsistencies, and other
bugs.
Note that the content of the tab doesn't visually change.
Bug: http://b/157641797