### PR TITLE
Add missing copyright and license headers to all source files

### DIFF
--- a/OrbitAsm/OrbitAsm.cpp
+++ b/OrbitAsm/OrbitAsm.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "OrbitAsm.h"
 
 #include <cstdint>

--- a/OrbitAsm/OrbitAsmC.h
+++ b/OrbitAsm/OrbitAsmC.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #pragma once
 
 #include <stddef.h>

--- a/OrbitBase/SafeStrerror.cpp
+++ b/OrbitBase/SafeStrerror.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <OrbitBase/SafeStrerror.h>
 
 #include <cstring>

--- a/OrbitBase/include/OrbitBase/Logging.h
+++ b/OrbitBase/include/OrbitBase/Logging.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_BASE_LOGGING_H_
 #define ORBIT_BASE_LOGGING_H_
 

--- a/OrbitBase/include/OrbitBase/SafeStrerror.h
+++ b/OrbitBase/include/OrbitBase/SafeStrerror.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_BASE_SAFE_STRERROR_H_
 #define ORBIT_BASE_SAFE_STRERROR_H_
 

--- a/OrbitBase/include/OrbitBase/Tracing.h
+++ b/OrbitBase/include/OrbitBase/Tracing.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_TRACING_TRACING_H_
 #define ORBIT_TRACING_TRACING_H_
 

--- a/OrbitCore/DiaParser.cpp
+++ b/OrbitCore/DiaParser.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "DiaParser.h"
 
 #include <malloc.h>

--- a/OrbitCore/ElfFile.cpp
+++ b/OrbitCore/ElfFile.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "ElfFile.h"
 
 #include <string_view>

--- a/OrbitCore/ElfFile.h
+++ b/OrbitCore/ElfFile.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #pragma once
 
 #include <memory>

--- a/OrbitCore/ElfFileTest.cpp
+++ b/OrbitCore/ElfFileTest.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 

--- a/OrbitCore/FunctionStats.cpp
+++ b/OrbitCore/FunctionStats.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "FunctionStats.h"
 
 #include "Core.h"

--- a/OrbitCore/Introspection.cpp
+++ b/OrbitCore/Introspection.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "Introspection.h"
 
 #if ORBIT_TRACING_ENABLED

--- a/OrbitCore/Introspection.h
+++ b/OrbitCore/Introspection.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_CORE_INTROSPECTION_H_
 #define ORBIT_CORE_INTROSPECTION_H_
 

--- a/OrbitCore/KeyAndString.h
+++ b/OrbitCore/KeyAndString.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_CORE_KEY_AND_STRING_H_
 #define ORBIT_CORE_KEY_AND_STRING_H_
 

--- a/OrbitCore/LinuxTracingBuffer.cpp
+++ b/OrbitCore/LinuxTracingBuffer.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "LinuxTracingBuffer.h"
 
 #include <utility>

--- a/OrbitCore/LinuxTracingBuffer.h
+++ b/OrbitCore/LinuxTracingBuffer.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_CORE_LINUX_TRACING_BUFFER_H_
 #define ORBIT_CORE_LINUX_TRACING_BUFFER_H_
 

--- a/OrbitCore/LinuxTracingBufferTest.cpp
+++ b/OrbitCore/LinuxTracingBufferTest.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 

--- a/OrbitCore/LinuxTracingHandler.cpp
+++ b/OrbitCore/LinuxTracingHandler.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "LinuxTracingHandler.h"
 
 #include <functional>

--- a/OrbitCore/LinuxTracingHandler.h
+++ b/OrbitCore/LinuxTracingHandler.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_CORE_LINUX_TRACING_HANDLER_H_
 #define ORBIT_CORE_LINUX_TRACING_HANDLER_H_
 

--- a/OrbitCore/ObjectCount.cpp
+++ b/OrbitCore/ObjectCount.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "ObjectCount.h"
 
 ObjectCounter GObjectCounter;

--- a/OrbitCore/ObjectCount.h
+++ b/OrbitCore/ObjectCount.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #pragma once
 
 #include <map>

--- a/OrbitCore/OrbitModuleTest.cpp
+++ b/OrbitCore/OrbitModuleTest.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 

--- a/OrbitCore/Platform.h
+++ b/OrbitCore/Platform.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #pragma once
 
 #if defined(_WIN32)

--- a/OrbitCore/PrintVar.h
+++ b/OrbitCore/PrintVar.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_CORE_PRINT_VAR_H_
 #define ORBIT_CORE_PRINT_VAR_H_
 

--- a/OrbitCore/ProcessMemoryRequest.cpp
+++ b/OrbitCore/ProcessMemoryRequest.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "ProcessMemoryRequest.h"
 
 #include "Serialization.h"

--- a/OrbitCore/ProcessMemoryRequest.h
+++ b/OrbitCore/ProcessMemoryRequest.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_CORE_PROCESS_MEMORY_REQUEST_H_
 #define ORBIT_CORE_PROCESS_MEMORY_REQUEST_H_
 

--- a/OrbitCore/RingBufferTest.cpp
+++ b/OrbitCore/RingBufferTest.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <gtest/gtest.h>
 
 #include <cstdint>

--- a/OrbitCore/StringManager.cpp
+++ b/OrbitCore/StringManager.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "StringManager.h"
 
 #include "Serialization.h"

--- a/OrbitCore/StringManager.h
+++ b/OrbitCore/StringManager.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_CORE_STRING_MANAGER_H_
 #define ORBIT_CORE_STRING_MANAGER_H_
 

--- a/OrbitCore/StringManagerTest.cpp
+++ b/OrbitCore/StringManagerTest.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <gtest/gtest.h>
 
 #include "StringManager.h"

--- a/OrbitCore/SymbolHelper.cpp
+++ b/OrbitCore/SymbolHelper.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "SymbolHelper.h"
 
 #include <fstream>

--- a/OrbitCore/SymbolHelper.h
+++ b/OrbitCore/SymbolHelper.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef SYMBOL_HELPER_H_
 #define SYMBOL_HELPER_H_
 #include <string>

--- a/OrbitCore/SymbolHelperTest.cpp
+++ b/OrbitCore/SymbolHelperTest.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 

--- a/OrbitCore/Systrace.cpp
+++ b/OrbitCore/Systrace.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "Systrace.h"
 
 #include <fstream>

--- a/OrbitCore/TestRemoteMessages.cpp
+++ b/OrbitCore/TestRemoteMessages.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "TestRemoteMessages.h"
 
 #include <fstream>

--- a/OrbitCore/TidAndThreadName.h
+++ b/OrbitCore/TidAndThreadName.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_CORE_TID_AND_THREAD_NAME_H_
 #define ORBIT_CORE_TID_AND_THREAD_NAME_H_
 

--- a/OrbitCore/Transaction.h
+++ b/OrbitCore/Transaction.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_CORE_TRANSACTION_H_
 #define ORBIT_CORE_TRANSACTION_H_
 

--- a/OrbitCore/TypeInfoStructs.h
+++ b/OrbitCore/TypeInfoStructs.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 // Author: Oleg Starodumov
 
 #ifndef TypeInfoStructs_h

--- a/OrbitDll/OrbitDll.h
+++ b/OrbitDll/OrbitDll.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #pragma once
 
 extern "C" {

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "CaptureSerializer.h"
 
 #include <fstream>

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "GpuTrack.h"
 
 #include <limits>

--- a/OrbitGl/GraphTrack.cpp
+++ b/OrbitGl/GraphTrack.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "GraphTrack.h"
 
 #include "GlCanvas.h"

--- a/OrbitGl/GraphTrack.h
+++ b/OrbitGl/GraphTrack.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_GL_GRAPH_TRACK_H
 #define ORBIT_GL_GRAPH_TRACK_H
 

--- a/OrbitGl/Images.h
+++ b/OrbitGl/Images.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 /* GIMP RGBA C-Source image dump (inject.c) */
 
 #ifdef WIN32

--- a/OrbitGl/LogDataView.cpp
+++ b/OrbitGl/LogDataView.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "LogDataView.h"
 
 #include <chrono>

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "SchedulerTrack.h"
 
 #include "Capture.h"

--- a/OrbitGl/SchedulerTrack.h
+++ b/OrbitGl/SchedulerTrack.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_GL_SCHEDULER_TRACK_H_
 #define ORBIT_GL_SCHEDULER_TRACK_H_
 

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "ThreadTrack.h"
 
 #include <limits>

--- a/OrbitGl/TimeGraphLayout.cpp
+++ b/OrbitGl/TimeGraphLayout.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "TimeGraphLayout.h"
 
 #include "Capture.h"

--- a/OrbitGl/mat4.cpp
+++ b/OrbitGl/mat4.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 /* Freetype GL - A C OpenGL Freetype engine
  *
  * Distributed under the OSI-approved BSD 2-Clause License.  See accompanying

--- a/OrbitGl/mat4.h
+++ b/OrbitGl/mat4.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 /* Freetype GL - A C OpenGL Freetype engine
  *
  * Distributed under the OSI-approved BSD 2-Clause License.  See accompanying

--- a/OrbitLinuxTracing/GpuTracepointEventProcessor.cpp
+++ b/OrbitLinuxTracing/GpuTracepointEventProcessor.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "GpuTracepointEventProcessor.h"
 
 #include <OrbitLinuxTracing/Events.h>

--- a/OrbitLinuxTracing/GpuTracepointEventProcessor.h
+++ b/OrbitLinuxTracing/GpuTracepointEventProcessor.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 
 #ifndef ORBIT_LINUX_TRACING_GPU_TRACEPOINT_EVENT_PROCESSOR
 #define ORBIT_LINUX_TRACING_GPU_TRACEPOINT_EVENT_PROCESSOR

--- a/OrbitLinuxTracing/LibunwindstackUnwinder.cpp
+++ b/OrbitLinuxTracing/LibunwindstackUnwinder.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "LibunwindstackUnwinder.h"
 
 #include <OrbitBase/Logging.h>

--- a/OrbitLinuxTracing/LibunwindstackUnwinder.h
+++ b/OrbitLinuxTracing/LibunwindstackUnwinder.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_LIBUNWINDSTACK_UNWINDER_H_
 #define ORBIT_LINUX_TRACING_LIBUNWINDSTACK_UNWINDER_H_
 

--- a/OrbitLinuxTracing/MakeUniqueForOverwrite.h
+++ b/OrbitLinuxTracing/MakeUniqueForOverwrite.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_MAKE_UNIQUE_FOR_OVERWRITE_H_
 #define ORBIT_LINUX_TRACING_MAKE_UNIQUE_FOR_OVERWRITE_H_
 

--- a/OrbitLinuxTracing/OrbitTracing.cpp
+++ b/OrbitLinuxTracing/OrbitTracing.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <OrbitLinuxTracing/OrbitTracing.h>
 
 #if ORBIT_TRACING_ENABLED

--- a/OrbitLinuxTracing/PerfEvent.cpp
+++ b/OrbitLinuxTracing/PerfEvent.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "PerfEvent.h"
 
 #include "PerfEventVisitor.h"

--- a/OrbitLinuxTracing/PerfEvent.h
+++ b/OrbitLinuxTracing/PerfEvent.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_PERF_EVENT_H_
 #define ORBIT_LINUX_TRACING_PERF_EVENT_H_
 

--- a/OrbitLinuxTracing/PerfEventOpen.cpp
+++ b/OrbitLinuxTracing/PerfEventOpen.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "PerfEventOpen.h"
 
 #include <OrbitBase/Logging.h>

--- a/OrbitLinuxTracing/PerfEventOpen.h
+++ b/OrbitLinuxTracing/PerfEventOpen.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_PERF_EVENT_OPEN_H_
 #define ORBIT_LINUX_TRACING_PERF_EVENT_OPEN_H_
 

--- a/OrbitLinuxTracing/PerfEventProcessor.cpp
+++ b/OrbitLinuxTracing/PerfEventProcessor.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "PerfEventProcessor.h"
 
 #include <OrbitBase/Logging.h>

--- a/OrbitLinuxTracing/PerfEventProcessor.h
+++ b/OrbitLinuxTracing/PerfEventProcessor.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_PERF_EVENT_PROCESSOR_H_
 #define ORBIT_LINUX_TRACING_PERF_EVENT_PROCESSOR_H_
 

--- a/OrbitLinuxTracing/PerfEventProcessor2.cpp
+++ b/OrbitLinuxTracing/PerfEventProcessor2.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "PerfEventProcessor2.h"
 
 #include <OrbitBase/Logging.h>

--- a/OrbitLinuxTracing/PerfEventProcessor2.h
+++ b/OrbitLinuxTracing/PerfEventProcessor2.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_PERF_EVENT_PROCESSOR_2_H_
 #define ORBIT_LINUX_TRACING_PERF_EVENT_PROCESSOR_2_H_
 

--- a/OrbitLinuxTracing/PerfEventProcessor2Test.cpp
+++ b/OrbitLinuxTracing/PerfEventProcessor2Test.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <gtest/gtest.h>
 
 #include "PerfEventProcessor2.h"

--- a/OrbitLinuxTracing/PerfEventReaders.cpp
+++ b/OrbitLinuxTracing/PerfEventReaders.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "PerfEventReaders.h"
 
 #include <OrbitBase/Logging.h>

--- a/OrbitLinuxTracing/PerfEventReaders.h
+++ b/OrbitLinuxTracing/PerfEventReaders.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_PERF_EVENT_READERS_H_
 #define ORBIT_LINUX_TRACING_PERF_EVENT_READERS_H_
 

--- a/OrbitLinuxTracing/PerfEventRecords.h
+++ b/OrbitLinuxTracing/PerfEventRecords.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_PERF_EVENT_RECORDS_H_
 #define ORBIT_LINUX_TRACING_PERF_EVENT_RECORDS_H_
 

--- a/OrbitLinuxTracing/PerfEventRingBuffer.cpp
+++ b/OrbitLinuxTracing/PerfEventRingBuffer.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "PerfEventRingBuffer.h"
 
 #include <OrbitBase/Logging.h>

--- a/OrbitLinuxTracing/PerfEventRingBuffer.h
+++ b/OrbitLinuxTracing/PerfEventRingBuffer.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_PERF_RING_BUFFER_H_
 #define ORBIT_LINUX_TRACING_PERF_RING_BUFFER_H_
 

--- a/OrbitLinuxTracing/PerfEventVisitor.h
+++ b/OrbitLinuxTracing/PerfEventVisitor.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_PERF_EVENT_VISITOR_H_
 #define ORBIT_LINUX_TRACING_PERF_EVENT_VISITOR_H_
 

--- a/OrbitLinuxTracing/Tracer.cpp
+++ b/OrbitLinuxTracing/Tracer.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <OrbitBase/Logging.h>
 #include <OrbitLinuxTracing/Tracer.h>
 

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "TracerThread.h"
 
 #include <OrbitBase/Logging.h>

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_TRACER_THREAD_H_
 #define ORBIT_LINUX_TRACING_TRACER_THREAD_H_
 

--- a/OrbitLinuxTracing/UprobesFunctionCallManager.h
+++ b/OrbitLinuxTracing/UprobesFunctionCallManager.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_UPROBES_FUNCTION_CALL_MANAGER_H_
 #define ORBIT_LINUX_TRACING_UPROBES_FUNCTION_CALL_MANAGER_H_
 

--- a/OrbitLinuxTracing/UprobesFunctionCallManagerTest.cpp
+++ b/OrbitLinuxTracing/UprobesFunctionCallManagerTest.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 

--- a/OrbitLinuxTracing/UprobesReturnAddressManager.h
+++ b/OrbitLinuxTracing/UprobesReturnAddressManager.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_UPROBES_RETURN_ADDRESS_MANAGER_H_
 #define ORBIT_LINUX_TRACING_UPROBES_RETURN_ADDRESS_MANAGER_H_
 

--- a/OrbitLinuxTracing/UprobesReturnAddressManagerTest.cpp
+++ b/OrbitLinuxTracing/UprobesReturnAddressManagerTest.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "UprobesUnwindingVisitor.h"
 
 #include "OrbitBase/Logging.h"

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.h
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_UPROBES_UNWINDING_VISITOR_H_
 #define ORBIT_LINUX_TRACING_UPROBES_UNWINDING_VISITOR_H_
 

--- a/OrbitLinuxTracing/Utils.cpp
+++ b/OrbitLinuxTracing/Utils.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #ifndef ORBIT_LINUX_TRACING_UTILS_H_
 #define ORBIT_LINUX_TRACING_UTILS_H_
 

--- a/OrbitLinuxTracing/Utils.h
+++ b/OrbitLinuxTracing/Utils.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_UTILS_H_
 #define ORBIT_LINUX_TRACING_UTILS_H_
 

--- a/OrbitLinuxTracing/UtilsTest.cpp
+++ b/OrbitLinuxTracing/UtilsTest.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 #include <sys/syscall.h>

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/Events.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/Events.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_EVENTS_H_
 #define ORBIT_LINUX_TRACING_EVENTS_H_
 

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/Function.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/Function.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_FUNCTION_H_
 #define ORBIT_LINUX_TRACING_FUNCTION_H_
 

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/OrbitTracing.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/OrbitTracing.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_ORBIT_TRACING_H_
 #define ORBIT_LINUX_TRACING_ORBIT_TRACING_H_
 

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/Tracer.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/Tracer.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_TRACER_H_
 #define ORBIT_LINUX_TRACING_TRACER_H_
 

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/TracerListener.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/TracerListener.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_TRACER_LISTENER_H_
 #define ORBIT_LINUX_TRACING_TRACER_LISTENER_H_
 

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/TracingOptions.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/TracingOptions.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_TRACING_OPTIONS_H_
 #define ORBIT_LINUX_TRACING_TRACING_OPTIONS_H_
 

--- a/OrbitPlugin/UserPlugin.h
+++ b/OrbitPlugin/UserPlugin.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #pragma once
 #include "../external/imgui/imgui.h"
 #include "../external/imgui/imgui_internal.h"

--- a/OrbitQt/eventloop.h
+++ b/OrbitQt/eventloop.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 
 #ifndef ORBIT_QT_EVENT_LOOP_H_
 #define ORBIT_QT_EVENT_LOOP_H_

--- a/OrbitQt/orbitdisassemblydialog.cpp
+++ b/OrbitQt/orbitdisassemblydialog.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "orbitdisassemblydialog.h"
 
 #include "ui_orbitdisassemblydialog.h"

--- a/OrbitQt/orbitdisassemblydialog.h
+++ b/OrbitQt/orbitdisassemblydialog.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBITDISASSEMBLYDIALOG_H
 #define ORBITDISASSEMBLYDIALOG_H
 

--- a/OrbitQt/orbittreeitem.cpp
+++ b/OrbitQt/orbittreeitem.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "orbittreeitem.h"
 
 #include <QStringList>

--- a/OrbitQt/orbittreeitem.h
+++ b/OrbitQt/orbittreeitem.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #pragma once
 
 #include <QList>

--- a/OrbitQt/orbittreemodel.cpp
+++ b/OrbitQt/orbittreemodel.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "orbittreemodel.h"
 
 #include <QColor>

--- a/OrbitQt/orbittreemodel.h
+++ b/OrbitQt/orbittreemodel.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #pragma once
 
 #include <QAbstractItemModel>

--- a/OrbitQt/orbitwatchwidget.cpp
+++ b/OrbitQt/orbitwatchwidget.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "orbitwatchwidget.h"
 
 #include <QGridLayout>

--- a/OrbitQt/orbitwatchwidget.h
+++ b/OrbitQt/orbitwatchwidget.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBITWATCHWIDGET_H
 #define ORBITWATCHWIDGET_H
 

--- a/OrbitQt/outputdialog.cpp
+++ b/OrbitQt/outputdialog.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "outputdialog.h"
 
 #include "ui_outputdialog.h"

--- a/OrbitQt/outputdialog.h
+++ b/OrbitQt/outputdialog.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef OUTPUTDIALOG_H
 #define OUTPUTDIALOG_H
 

--- a/OrbitQt/processlauncherwidget.cpp
+++ b/OrbitQt/processlauncherwidget.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "processlauncherwidget.h"
 
 #include <QFileDialog>

--- a/OrbitQt/processlauncherwidget.h
+++ b/OrbitQt/processlauncherwidget.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef PROCESSLAUNCHERWIDGET_H
 #define PROCESSLAUNCHERWIDGET_H
 

--- a/OrbitQt/showincludesdialog.cpp
+++ b/OrbitQt/showincludesdialog.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "showincludesdialog.h"
 
 #include <QMenu>

--- a/OrbitQt/showincludesdialog.h
+++ b/OrbitQt/showincludesdialog.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef SHOWINCLUDESDIALOG_H
 #define SHOWINCLUDESDIALOG_H
 

--- a/OrbitService/OrbitService.h
+++ b/OrbitService/OrbitService.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_SERVICE_ORBIT_SERVICE_H
 #define ORBIT_SERVICE_ORBIT_SERVICE_H
 

--- a/OrbitService/main.cpp
+++ b/OrbitService/main.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <csignal>
 #include <iostream>
 

--- a/OrbitSsh/ExecChannelManager.cpp
+++ b/OrbitSsh/ExecChannelManager.cpp
@@ -1,0 +1,4 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+

--- a/OrbitSsh/SocketTests.cpp
+++ b/OrbitSsh/SocketTests.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <gtest/gtest.h>
 
 #include <memory>

--- a/OrbitTest/OrbitTest.cpp
+++ b/OrbitTest/OrbitTest.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "OrbitTest.h"
 
 #include <stdio.h>

--- a/OrbitTest/OrbitTest.h
+++ b/OrbitTest/OrbitTest.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #pragma once
 #include <memory>
 #include <thread>

--- a/OrbitTest/main.cpp
+++ b/OrbitTest/main.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <memory>
 #include <string>
 

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 
 default_profiles=( default_relwithdebinfo )
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 import os

--- a/contrib/conan/configs/linux/settings.yml
+++ b/contrib/conan/configs/linux/settings.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 
 # Only for cross building, 'os_build/arch_build' is the system that runs Conan
 os_build: [Windows, WindowsStore, Linux, Macos, FreeBSD, SunOS, AIX]

--- a/contrib/conan/configs/windows/settings.yml
+++ b/contrib/conan/configs/windows/settings.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 
 # Only for cross building, 'os_build/arch_build' is the system that runs Conan
 os_build: [Windows, WindowsStore, Linux, Macos, FreeBSD, SunOS, AIX]

--- a/contrib/conan/docker/build_containers.sh
+++ b/contrib/conan/docker/build_containers.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 

--- a/contrib/conan/docker/upload_containers.sh
+++ b/contrib/conan/docker/upload_containers.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 

--- a/contrib/conan/recipes/abseil/conandata.yml
+++ b/contrib/conan/recipes/abseil/conandata.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 sources:
   "20190808":
     url: "https://github.com/abseil/abseil-cpp/archive/aa844899c937bde5d2b24f276b59997e5b668bde.zip"

--- a/contrib/conan/recipes/abseil/conanfile.py
+++ b/contrib/conan/recipes/abseil/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 from conans.tools import Version

--- a/contrib/conan/recipes/breakpad/conanfile.py
+++ b/contrib/conan/recipes/breakpad/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import ConanFile, CMake, MSBuild, tools
 import os
 import shutil

--- a/contrib/conan/recipes/capstone/conanfile.py
+++ b/contrib/conan/recipes/capstone/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import ConanFile, CMake, tools
 
 

--- a/contrib/conan/recipes/cereal/conanfile.py
+++ b/contrib/conan/recipes/cereal/conanfile.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 # -*- coding: utf-8 -*-
 import os
 from conans import ConanFile, CMake, tools

--- a/contrib/conan/recipes/crashpad/conanfile.py
+++ b/contrib/conan/recipes/crashpad/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 import os

--- a/contrib/conan/recipes/export_packages.sh
+++ b/contrib/conan/recipes/export_packages.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 
 cd "$( dirname "${BASH_SOURCE[0]}" )"
 

--- a/contrib/conan/recipes/freeglut/conanfile.py
+++ b/contrib/conan/recipes/freeglut/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import ConanFile, CMake, tools
 import os
 

--- a/contrib/conan/recipes/freetype-gl/conanfile.py
+++ b/contrib/conan/recipes/freetype-gl/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import ConanFile, CMake, tools
 import shutil, os
 

--- a/contrib/conan/recipes/glew/build.py
+++ b/contrib/conan/recipes/glew/build.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 # -*- coding: utf-8 -*-
 
 

--- a/contrib/conan/recipes/glew/conanfile.py
+++ b/contrib/conan/recipes/glew/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 import os
 from conans import ConanFile, CMake, tools
 

--- a/contrib/conan/recipes/glew/test_package/conanfile.py
+++ b/contrib/conan/recipes/glew/test_package/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import ConanFile, CMake, tools, RunEnvironment
 import os
 

--- a/contrib/conan/recipes/glew/test_package/test_package.c
+++ b/contrib/conan/recipes/glew/test_package/test_package.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #include <GL/glew.h>
 
 #include <assert.h>

--- a/contrib/conan/recipes/grpc/conandata.yml
+++ b/contrib/conan/recipes/grpc/conandata.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 sources:
   "1.25.0":
     url: https://github.com/grpc/grpc/archive/v1.25.0.zip

--- a/contrib/conan/recipes/grpc/conanfile.py
+++ b/contrib/conan/recipes/grpc/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 import os

--- a/contrib/conan/recipes/grpc/examples/helloworld/conanfile.py
+++ b/contrib/conan/recipes/grpc/examples/helloworld/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import ConanFile, CMake, tools
 import os
 

--- a/contrib/conan/recipes/grpc_codegen/conandata.yml
+++ b/contrib/conan/recipes/grpc_codegen/conandata.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 sources:
   "1.25.0":
     url: https://github.com/grpc/grpc/archive/v1.25.0.zip

--- a/contrib/conan/recipes/grpc_codegen/conanfile.py
+++ b/contrib/conan/recipes/grpc_codegen/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 import os

--- a/contrib/conan/recipes/libdisasm/conanfile.py
+++ b/contrib/conan/recipes/libdisasm/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import ConanFile, CMake, tools
 import shutil
 

--- a/contrib/conan/recipes/libunwindstack/conanfile.py
+++ b/contrib/conan/recipes/libunwindstack/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import ConanFile, CMake, tools
 
 

--- a/contrib/conan/recipes/libunwindstack/overrides/file.cpp
+++ b/contrib/conan/recipes/libunwindstack/overrides/file.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "android-base/file.h"
 
 #include <sys/stat.h>

--- a/contrib/conan/recipes/llvm-common/conanfile.py
+++ b/contrib/conan/recipes/llvm-common/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import ConanFile
 
 from llvmpackage import *

--- a/contrib/conan/recipes/llvm-common/llvmcomponentpackage.py
+++ b/contrib/conan/recipes/llvm-common/llvmcomponentpackage.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import CMake
 from llvmpackage import LLVMPackage, replace_in_file
 import conans.tools

--- a/contrib/conan/recipes/llvm-common/llvmmodulepackage.py
+++ b/contrib/conan/recipes/llvm-common/llvmmodulepackage.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from llvmpackage import LLVMPackage
 from conans import tools
 import os

--- a/contrib/conan/recipes/llvm-common/llvmpackage.py
+++ b/contrib/conan/recipes/llvm-common/llvmpackage.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import ConanFile
 import os, re
 

--- a/contrib/conan/recipes/llvm/.travis/install.sh
+++ b/contrib/conan/recipes/llvm/.travis/install.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 
 set -e
 set -x

--- a/contrib/conan/recipes/llvm/.travis/run.sh
+++ b/contrib/conan/recipes/llvm/.travis/run.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 
 set -e
 set -x

--- a/contrib/conan/recipes/llvm/build.py
+++ b/contrib/conan/recipes/llvm/build.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conan.packager import ConanMultiPackager
 import platform
 import os

--- a/contrib/conan/recipes/llvm/conanfile.py
+++ b/contrib/conan/recipes/llvm/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 llvm_common = python_requires('llvm-common/0.0.0@orbitdeps/stable')
 

--- a/contrib/conan/recipes/llvm/test_package/conanfile.py
+++ b/contrib/conan/recipes/llvm/test_package/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans.model.conan_file import ConanFile
 from conans import CMake
 import os

--- a/contrib/conan/recipes/llvm/test_package/skeleton/Skeleton.cpp
+++ b/contrib/conan/recipes/llvm/test_package/skeleton/Skeleton.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "llvm/IR/Function.h"
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/Pass.h"

--- a/contrib/conan/recipes/llvm_analysis/conanfile.py
+++ b/contrib/conan/recipes/llvm_analysis/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 
 common = python_requires('llvm-common/0.0.0@orbitdeps/stable')

--- a/contrib/conan/recipes/llvm_asm_printer/conanfile.py
+++ b/contrib/conan/recipes/llvm_asm_printer/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 
 common = python_requires('llvm-common/0.0.0@orbitdeps/stable')

--- a/contrib/conan/recipes/llvm_binary_format/conanfile.py
+++ b/contrib/conan/recipes/llvm_binary_format/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 
 common = python_requires('llvm-common/0.0.0@orbitdeps/stable')

--- a/contrib/conan/recipes/llvm_bit_reader/conanfile.py
+++ b/contrib/conan/recipes/llvm_bit_reader/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 import os
 

--- a/contrib/conan/recipes/llvm_bit_writer/conanfile.py
+++ b/contrib/conan/recipes/llvm_bit_writer/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 import os
 

--- a/contrib/conan/recipes/llvm_bitstream_reader/conanfile.py
+++ b/contrib/conan/recipes/llvm_bitstream_reader/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 import os
 

--- a/contrib/conan/recipes/llvm_codegen/conanfile.py
+++ b/contrib/conan/recipes/llvm_codegen/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 
 common = python_requires('llvm-common/0.0.0@orbitdeps/stable')

--- a/contrib/conan/recipes/llvm_core/conanfile.py
+++ b/contrib/conan/recipes/llvm_core/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 import os
 

--- a/contrib/conan/recipes/llvm_debuginfo_codeview/conanfile.py
+++ b/contrib/conan/recipes/llvm_debuginfo_codeview/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 import os
 

--- a/contrib/conan/recipes/llvm_debuginfo_msf/conanfile.py
+++ b/contrib/conan/recipes/llvm_debuginfo_msf/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 import os
 

--- a/contrib/conan/recipes/llvm_demangle/conanfile.py
+++ b/contrib/conan/recipes/llvm_demangle/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 import os
 

--- a/contrib/conan/recipes/llvm_global_isel/conanfile.py
+++ b/contrib/conan/recipes/llvm_global_isel/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 import os
 

--- a/contrib/conan/recipes/llvm_headers/conanfile.py
+++ b/contrib/conan/recipes/llvm_headers/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 
 common = python_requires('llvm-common/0.0.0@orbitdeps/stable')

--- a/contrib/conan/recipes/llvm_instcombine/conanfile.py
+++ b/contrib/conan/recipes/llvm_instcombine/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 import os
 

--- a/contrib/conan/recipes/llvm_mc/conanfile.py
+++ b/contrib/conan/recipes/llvm_mc/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 import os
 

--- a/contrib/conan/recipes/llvm_mc_disassembler/conanfile.py
+++ b/contrib/conan/recipes/llvm_mc_disassembler/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 import os
 

--- a/contrib/conan/recipes/llvm_mc_parser/conanfile.py
+++ b/contrib/conan/recipes/llvm_mc_parser/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 import os
 

--- a/contrib/conan/recipes/llvm_object/conanfile.py
+++ b/contrib/conan/recipes/llvm_object/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 import os
 

--- a/contrib/conan/recipes/llvm_option/conanfile.py
+++ b/contrib/conan/recipes/llvm_option/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 import os
 

--- a/contrib/conan/recipes/llvm_profile_data/conanfile.py
+++ b/contrib/conan/recipes/llvm_profile_data/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 
 common = python_requires('llvm-common/0.0.0@orbitdeps/stable')

--- a/contrib/conan/recipes/llvm_remarks/conanfile.py
+++ b/contrib/conan/recipes/llvm_remarks/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 import os
 

--- a/contrib/conan/recipes/llvm_scalar_opts/conanfile.py
+++ b/contrib/conan/recipes/llvm_scalar_opts/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 import os
 

--- a/contrib/conan/recipes/llvm_selection_dag/conanfile.py
+++ b/contrib/conan/recipes/llvm_selection_dag/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 import os
 

--- a/contrib/conan/recipes/llvm_support/conanfile.py
+++ b/contrib/conan/recipes/llvm_support/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 
 common = python_requires('llvm-common/0.0.0@orbitdeps/stable')

--- a/contrib/conan/recipes/llvm_target/conanfile.py
+++ b/contrib/conan/recipes/llvm_target/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 
 common = python_requires('llvm-common/0.0.0@orbitdeps/stable')

--- a/contrib/conan/recipes/llvm_textapi/conanfile.py
+++ b/contrib/conan/recipes/llvm_textapi/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 import os
 

--- a/contrib/conan/recipes/llvm_transform_utils/conanfile.py
+++ b/contrib/conan/recipes/llvm_transform_utils/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 import os
 

--- a/contrib/conan/recipes/llvm_x86_asm_parser/conanfile.py
+++ b/contrib/conan/recipes/llvm_x86_asm_parser/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 
 common = python_requires('llvm-common/0.0.0@orbitdeps/stable')

--- a/contrib/conan/recipes/llvm_x86_asm_printer/conanfile.py
+++ b/contrib/conan/recipes/llvm_x86_asm_printer/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 
 common = python_requires('llvm-common/0.0.0@orbitdeps/stable')

--- a/contrib/conan/recipes/llvm_x86_codegen/conanfile.py
+++ b/contrib/conan/recipes/llvm_x86_codegen/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 
 common = python_requires('llvm-common/0.0.0@orbitdeps/stable')

--- a/contrib/conan/recipes/llvm_x86_desc/conanfile.py
+++ b/contrib/conan/recipes/llvm_x86_desc/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 
 common = python_requires('llvm-common/0.0.0@orbitdeps/stable')

--- a/contrib/conan/recipes/llvm_x86_info/conanfile.py
+++ b/contrib/conan/recipes/llvm_x86_info/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 
 common = python_requires('llvm-common/0.0.0@orbitdeps/stable')

--- a/contrib/conan/recipes/llvm_x86_utils/conanfile.py
+++ b/contrib/conan/recipes/llvm_x86_utils/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import python_requires
 
 common = python_requires('llvm-common/0.0.0@orbitdeps/stable')

--- a/contrib/conan/recipes/lzma/conanfile.py
+++ b/contrib/conan/recipes/lzma/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import ConanFile, CMake, tools
 import os
 

--- a/contrib/conan/recipes/openssl/conandata.yml
+++ b/contrib/conan/recipes/openssl/conandata.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 sources:
   1.1.1d:
     sha256: 1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2

--- a/contrib/conan/recipes/openssl/conanfile.py
+++ b/contrib/conan/recipes/openssl/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 import os
 import fnmatch
 import platform

--- a/contrib/conan/recipes/outcome/conanfile.py
+++ b/contrib/conan/recipes/outcome/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 # from https://github.com/ned14/outcome/blob/develop/conan/conanfile.py
 from conans import ConanFile, tools
 

--- a/contrib/conan/scripts/build_and_upload_dependencies.sh
+++ b/contrib/conan/scripts/build_and_upload_dependencies.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 
 function conan_profile_exists {
   conan profile show $profile >/dev/null 2>&1

--- a/protos/dummy.cpp
+++ b/protos/dummy.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 // This file is there as a workaround for a problem
 // with grpc_helpers where it does not work for proto-only
 // static libraries. It needs to have at least one non-proto

--- a/protos/process.proto
+++ b/protos/process.proto
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 syntax = "proto3";
 
 message ProcessInfo {

--- a/protos/services.proto
+++ b/protos/services.proto
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 syntax = "proto3";
 
 import "process.proto";

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 exec $DIR/build_default_release/bin/Orbit

--- a/run_clang_format.sh
+++ b/run_clang_format.sh
@@ -1,2 +1,6 @@
 #!/bin/bash
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 find . \( -name '*.cpp' -o -name '*.h' \) ! -path './external/*' ! -path './build/*' ! -path './cmake-*' ! -path './contrib*' ! -name 'resource.h' | xargs clang-format -i

--- a/run_service.sh
+++ b/run_service.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 exec $DIR/build_default_release/bin/OrbitService

--- a/run_service_ssh.sh
+++ b/run_service_ssh.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 
 # This script first runs the ggp ssh init command to get the needed
 # credentials to connect via ssh. Then it connects to the instance


### PR DESCRIPTION
Ran 

addlicense -f license_file
git checkout external/*
git checkout <other files that we should not change>

where license_files contains:

Copyright (c) 2020 The Orbit Authors. All rights reserved.
Use of this source code is governed by a BSD-style license that can be
found in the LICENSE file.

Note that addlicense considers .h files as C files and hence uses /* */ style comments. 

addlicense can be found here: github.com/google/addlicense