### PR TITLE
Add or replace copyright and license headers in all our own source files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
-BSD 2-Clause License
+Copyright (c) 2020 The Orbit Authors. All rights reserved.
 
-Copyright (c) 2018, Pierric Gimmig
-All rights reserved.
+BSD 2-Clause License
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/OrbitAsm/OrbitAsm.cpp
+++ b/OrbitAsm/OrbitAsm.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "OrbitAsm.h"
 
 #include <cstdint>

--- a/OrbitAsm/OrbitAsm.h
+++ b/OrbitAsm/OrbitAsm.h
@@ -1,9 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
-
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #pragma once
 

--- a/OrbitAsm/OrbitAsm.h
+++ b/OrbitAsm/OrbitAsm.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <cstring>

--- a/OrbitAsm/OrbitAsmC.h
+++ b/OrbitAsm/OrbitAsmC.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #pragma once
 
 #include <stddef.h>

--- a/OrbitAsm/OrbitAsmC.h
+++ b/OrbitAsm/OrbitAsmC.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #pragma once
 

--- a/OrbitBase/SafeStrerror.cpp
+++ b/OrbitBase/SafeStrerror.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <OrbitBase/SafeStrerror.h>
 
 #include <cstring>

--- a/OrbitBase/include/OrbitBase/Logging.h
+++ b/OrbitBase/include/OrbitBase/Logging.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_BASE_LOGGING_H_
 #define ORBIT_BASE_LOGGING_H_

--- a/OrbitBase/include/OrbitBase/Logging.h
+++ b/OrbitBase/include/OrbitBase/Logging.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_BASE_LOGGING_H_
 #define ORBIT_BASE_LOGGING_H_
 

--- a/OrbitBase/include/OrbitBase/SafeStrerror.h
+++ b/OrbitBase/include/OrbitBase/SafeStrerror.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_BASE_SAFE_STRERROR_H_
 #define ORBIT_BASE_SAFE_STRERROR_H_
 

--- a/OrbitBase/include/OrbitBase/SafeStrerror.h
+++ b/OrbitBase/include/OrbitBase/SafeStrerror.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_BASE_SAFE_STRERROR_H_
 #define ORBIT_BASE_SAFE_STRERROR_H_

--- a/OrbitBase/include/OrbitBase/Tracing.h
+++ b/OrbitBase/include/OrbitBase/Tracing.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_TRACING_TRACING_H_
 #define ORBIT_TRACING_TRACING_H_

--- a/OrbitBase/include/OrbitBase/Tracing.h
+++ b/OrbitBase/include/OrbitBase/Tracing.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_TRACING_TRACING_H_
 #define ORBIT_TRACING_TRACING_H_
 

--- a/OrbitCore/BaseTypes.h
+++ b/OrbitCore/BaseTypes.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <cstdint>

--- a/OrbitCore/BaseTypes.h
+++ b/OrbitCore/BaseTypes.h
@@ -1,9 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
-
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #pragma once
 

--- a/OrbitCore/BlockChain.h
+++ b/OrbitCore/BlockChain.h
@@ -1,9 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
-
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #pragma once
 #include <assert.h>

--- a/OrbitCore/BlockChain.h
+++ b/OrbitCore/BlockChain.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 #include <assert.h>
 

--- a/OrbitCore/Callstack.cpp
+++ b/OrbitCore/Callstack.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "Callstack.h"
 

--- a/OrbitCore/Callstack.h
+++ b/OrbitCore/Callstack.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include "CallstackTypes.h"

--- a/OrbitCore/Callstack.h
+++ b/OrbitCore/Callstack.h
@@ -1,9 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
-
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #pragma once
 

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "Capture.h"
 

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <chrono>

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/ConnectionManager.cpp
+++ b/OrbitCore/ConnectionManager.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "ConnectionManager.h"
 

--- a/OrbitCore/ConnectionManager.h
+++ b/OrbitCore/ConnectionManager.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <atomic>

--- a/OrbitCore/ConnectionManager.h
+++ b/OrbitCore/ConnectionManager.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/Context.h
+++ b/OrbitCore/Context.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/Context.h
+++ b/OrbitCore/Context.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include "Core.h"

--- a/OrbitCore/ContextSwitch.cpp
+++ b/OrbitCore/ContextSwitch.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "ContextSwitch.h"
 

--- a/OrbitCore/ContextSwitch.h
+++ b/OrbitCore/ContextSwitch.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include "Serialization.h"

--- a/OrbitCore/ContextSwitch.h
+++ b/OrbitCore/ContextSwitch.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/Core.cpp
+++ b/OrbitCore/Core.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "Core.h"
 

--- a/OrbitCore/Core.h
+++ b/OrbitCore/Core.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/Core.h
+++ b/OrbitCore/Core.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <assert.h>

--- a/OrbitCore/CoreApp.cpp
+++ b/OrbitCore/CoreApp.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 #include "CoreApp.h"
 
 CoreApp* GCoreApp;

--- a/OrbitCore/DiaManager.cpp
+++ b/OrbitCore/DiaManager.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "DiaManager.h"
 

--- a/OrbitCore/DiaManager.h
+++ b/OrbitCore/DiaManager.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #ifdef _WIN32

--- a/OrbitCore/DiaManager.h
+++ b/OrbitCore/DiaManager.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/DiaParser.cpp
+++ b/OrbitCore/DiaParser.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "DiaParser.h"
 
 #include <malloc.h>

--- a/OrbitCore/DiaParser.h
+++ b/OrbitCore/DiaParser.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <string>

--- a/OrbitCore/DiaParser.h
+++ b/OrbitCore/DiaParser.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/ElfFile.cpp
+++ b/OrbitCore/ElfFile.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "ElfFile.h"
 
 #include <string_view>

--- a/OrbitCore/ElfFile.h
+++ b/OrbitCore/ElfFile.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #pragma once
 
 #include <memory>

--- a/OrbitCore/ElfFile.h
+++ b/OrbitCore/ElfFile.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #pragma once
 

--- a/OrbitCore/ElfFileTest.cpp
+++ b/OrbitCore/ElfFileTest.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 

--- a/OrbitCore/EventBuffer.cpp
+++ b/OrbitCore/EventBuffer.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "EventBuffer.h"
 

--- a/OrbitCore/EventBuffer.h
+++ b/OrbitCore/EventBuffer.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <set>

--- a/OrbitCore/EventBuffer.h
+++ b/OrbitCore/EventBuffer.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/EventCallbacks.cpp
+++ b/OrbitCore/EventCallbacks.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 // clang-format off
 #include "Platform.h"

--- a/OrbitCore/EventCallbacks.h
+++ b/OrbitCore/EventCallbacks.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/EventCallbacks.h
+++ b/OrbitCore/EventCallbacks.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <evntcons.h>

--- a/OrbitCore/EventClasses.h
+++ b/OrbitCore/EventClasses.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/EventClasses.h
+++ b/OrbitCore/EventClasses.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include "Core.h"

--- a/OrbitCore/EventGuid.h
+++ b/OrbitCore/EventGuid.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <Guiddef.h>

--- a/OrbitCore/EventGuid.h
+++ b/OrbitCore/EventGuid.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/EventTracer.cpp
+++ b/OrbitCore/EventTracer.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 // clang-format off
 #include "Platform.h"

--- a/OrbitCore/EventTracer.h
+++ b/OrbitCore/EventTracer.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <thread>

--- a/OrbitCore/EventTracer.h
+++ b/OrbitCore/EventTracer.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/EventUtils.cpp
+++ b/OrbitCore/EventUtils.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 // clang-format off
 #include "Platform.h"

--- a/OrbitCore/EventUtils.h
+++ b/OrbitCore/EventUtils.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/EventUtils.h
+++ b/OrbitCore/EventUtils.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <evntcons.h>

--- a/OrbitCore/FunctionStats.cpp
+++ b/OrbitCore/FunctionStats.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "FunctionStats.h"
 
 #include "Core.h"

--- a/OrbitCore/FunctionStats.h
+++ b/OrbitCore/FunctionStats.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <memory>

--- a/OrbitCore/FunctionStats.h
+++ b/OrbitCore/FunctionStats.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/Hashing.h
+++ b/OrbitCore/Hashing.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/Hashing.h
+++ b/OrbitCore/Hashing.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include "xxhash.h"

--- a/OrbitCore/Hijacking.cpp
+++ b/OrbitCore/Hijacking.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include <intrin.h>
 

--- a/OrbitCore/Hijacking.h
+++ b/OrbitCore/Hijacking.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 struct OrbitWaitLoop;

--- a/OrbitCore/Hijacking.h
+++ b/OrbitCore/Hijacking.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/Injection.cpp
+++ b/OrbitCore/Injection.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "Injection.h"
 

--- a/OrbitCore/Injection.h
+++ b/OrbitCore/Injection.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <string>

--- a/OrbitCore/Injection.h
+++ b/OrbitCore/Injection.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/Introspection.cpp
+++ b/OrbitCore/Introspection.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "Introspection.h"
 
 #if ORBIT_TRACING_ENABLED

--- a/OrbitCore/Introspection.h
+++ b/OrbitCore/Introspection.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_CORE_INTROSPECTION_H_
 #define ORBIT_CORE_INTROSPECTION_H_
 

--- a/OrbitCore/Introspection.h
+++ b/OrbitCore/Introspection.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_CORE_INTROSPECTION_H_
 #define ORBIT_CORE_INTROSPECTION_H_

--- a/OrbitCore/KeyAndString.h
+++ b/OrbitCore/KeyAndString.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_CORE_KEY_AND_STRING_H_
 #define ORBIT_CORE_KEY_AND_STRING_H_

--- a/OrbitCore/KeyAndString.h
+++ b/OrbitCore/KeyAndString.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_CORE_KEY_AND_STRING_H_
 #define ORBIT_CORE_KEY_AND_STRING_H_
 

--- a/OrbitCore/LinuxAddressInfo.h
+++ b/OrbitCore/LinuxAddressInfo.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <string>

--- a/OrbitCore/LinuxAddressInfo.h
+++ b/OrbitCore/LinuxAddressInfo.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/LinuxCallstackEvent.h
+++ b/OrbitCore/LinuxCallstackEvent.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 
 //-----------------------------------
 // Author: Florian Kuebler

--- a/OrbitCore/LinuxCallstackEvent.h
+++ b/OrbitCore/LinuxCallstackEvent.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 

--- a/OrbitCore/LinuxTracingBuffer.cpp
+++ b/OrbitCore/LinuxTracingBuffer.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "LinuxTracingBuffer.h"
 
 #include <utility>

--- a/OrbitCore/LinuxTracingBuffer.h
+++ b/OrbitCore/LinuxTracingBuffer.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_CORE_LINUX_TRACING_BUFFER_H_
 #define ORBIT_CORE_LINUX_TRACING_BUFFER_H_
 

--- a/OrbitCore/LinuxTracingBuffer.h
+++ b/OrbitCore/LinuxTracingBuffer.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_CORE_LINUX_TRACING_BUFFER_H_
 #define ORBIT_CORE_LINUX_TRACING_BUFFER_H_

--- a/OrbitCore/LinuxTracingBufferTest.cpp
+++ b/OrbitCore/LinuxTracingBufferTest.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 

--- a/OrbitCore/LinuxTracingHandler.cpp
+++ b/OrbitCore/LinuxTracingHandler.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "LinuxTracingHandler.h"
 
 #include <functional>

--- a/OrbitCore/LinuxTracingHandler.h
+++ b/OrbitCore/LinuxTracingHandler.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_CORE_LINUX_TRACING_HANDLER_H_
 #define ORBIT_CORE_LINUX_TRACING_HANDLER_H_

--- a/OrbitCore/LinuxTracingHandler.h
+++ b/OrbitCore/LinuxTracingHandler.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_CORE_LINUX_TRACING_HANDLER_H_
 #define ORBIT_CORE_LINUX_TRACING_HANDLER_H_
 

--- a/OrbitCore/LinuxUtils.cpp
+++ b/OrbitCore/LinuxUtils.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "LinuxUtils.h"
 

--- a/OrbitCore/LinuxUtils.h
+++ b/OrbitCore/LinuxUtils.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <functional>

--- a/OrbitCore/LinuxUtils.h
+++ b/OrbitCore/LinuxUtils.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/Log.cpp
+++ b/OrbitCore/Log.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "Log.h"
 

--- a/OrbitCore/Log.h
+++ b/OrbitCore/Log.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/Log.h
+++ b/OrbitCore/Log.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <vector>

--- a/OrbitCore/LogInterface.cpp
+++ b/OrbitCore/LogInterface.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "LogInterface.h"
 

--- a/OrbitCore/LogInterface.h
+++ b/OrbitCore/LogInterface.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <string>

--- a/OrbitCore/LogInterface.h
+++ b/OrbitCore/LogInterface.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/MemoryTracker.cpp
+++ b/OrbitCore/MemoryTracker.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "MemoryTracker.h"
 

--- a/OrbitCore/MemoryTracker.h
+++ b/OrbitCore/MemoryTracker.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <unordered_map>

--- a/OrbitCore/MemoryTracker.h
+++ b/OrbitCore/MemoryTracker.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/Message.cpp
+++ b/OrbitCore/Message.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "Message.h"
 

--- a/OrbitCore/Message.h
+++ b/OrbitCore/Message.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <string>

--- a/OrbitCore/Message.h
+++ b/OrbitCore/Message.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/ObjectCount.cpp
+++ b/OrbitCore/ObjectCount.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "ObjectCount.h"
 
 ObjectCounter GObjectCounter;

--- a/OrbitCore/ObjectCount.h
+++ b/OrbitCore/ObjectCount.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #pragma once
 

--- a/OrbitCore/ObjectCount.h
+++ b/OrbitCore/ObjectCount.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #pragma once
 
 #include <map>

--- a/OrbitCore/OrbitAsio.cpp
+++ b/OrbitCore/OrbitAsio.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "OrbitAsio.h"
 

--- a/OrbitCore/OrbitAsio.h
+++ b/OrbitCore/OrbitAsio.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/OrbitAsio.h
+++ b/OrbitCore/OrbitAsio.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include "asio.hpp"

--- a/OrbitCore/OrbitDbgHelp.h
+++ b/OrbitCore/OrbitDbgHelp.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #ifdef _WIN32

--- a/OrbitCore/OrbitDbgHelp.h
+++ b/OrbitCore/OrbitDbgHelp.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/OrbitDia.cpp
+++ b/OrbitCore/OrbitDia.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "OrbitDia.h"
 

--- a/OrbitCore/OrbitDia.h
+++ b/OrbitCore/OrbitDia.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/OrbitDia.h
+++ b/OrbitCore/OrbitDia.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <ostream>

--- a/OrbitCore/OrbitFunction.cpp
+++ b/OrbitCore/OrbitFunction.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "OrbitFunction.h"
 

--- a/OrbitCore/OrbitFunction.h
+++ b/OrbitCore/OrbitFunction.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <string>

--- a/OrbitCore/OrbitFunction.h
+++ b/OrbitCore/OrbitFunction.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/OrbitLib.cpp
+++ b/OrbitCore/OrbitLib.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "OrbitLib.h"
 

--- a/OrbitCore/OrbitLib.h
+++ b/OrbitCore/OrbitLib.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #define ORBIT_FUNCTION

--- a/OrbitCore/OrbitLib.h
+++ b/OrbitCore/OrbitLib.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/OrbitModule.cpp
+++ b/OrbitCore/OrbitModule.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "OrbitModule.h"
 

--- a/OrbitCore/OrbitModule.h
+++ b/OrbitCore/OrbitModule.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <memory.h>

--- a/OrbitCore/OrbitModule.h
+++ b/OrbitCore/OrbitModule.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/OrbitModuleTest.cpp
+++ b/OrbitCore/OrbitModuleTest.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 

--- a/OrbitCore/OrbitProcess.cpp
+++ b/OrbitCore/OrbitProcess.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "OrbitProcess.h"
 

--- a/OrbitCore/OrbitProcess.h
+++ b/OrbitCore/OrbitProcess.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <map>

--- a/OrbitCore/OrbitProcess.h
+++ b/OrbitCore/OrbitProcess.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/OrbitSession.cpp
+++ b/OrbitCore/OrbitSession.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "OrbitSession.h"
 

--- a/OrbitCore/OrbitSession.h
+++ b/OrbitCore/OrbitSession.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/OrbitSession.h
+++ b/OrbitCore/OrbitSession.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include "Core.h"

--- a/OrbitCore/OrbitThread.cpp
+++ b/OrbitCore/OrbitThread.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "OrbitThread.h"
 

--- a/OrbitCore/OrbitThread.h
+++ b/OrbitCore/OrbitThread.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include "RingBuffer.h"

--- a/OrbitCore/OrbitThread.h
+++ b/OrbitCore/OrbitThread.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/OrbitType.cpp
+++ b/OrbitCore/OrbitType.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "OrbitType.h"
 

--- a/OrbitCore/OrbitType.h
+++ b/OrbitCore/OrbitType.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <map>

--- a/OrbitCore/OrbitType.h
+++ b/OrbitCore/OrbitType.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/OrbitUnreal.cpp
+++ b/OrbitCore/OrbitUnreal.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "OrbitUnreal.h"
 

--- a/OrbitCore/OrbitUnreal.h
+++ b/OrbitCore/OrbitUnreal.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <string>

--- a/OrbitCore/OrbitUnreal.h
+++ b/OrbitCore/OrbitUnreal.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/Path.cpp
+++ b/OrbitCore/Path.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "Path.h"
 

--- a/OrbitCore/Path.h
+++ b/OrbitCore/Path.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <functional>

--- a/OrbitCore/Path.h
+++ b/OrbitCore/Path.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/Pdb.cpp
+++ b/OrbitCore/Pdb.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "Pdb.h"
 

--- a/OrbitCore/Pdb.h
+++ b/OrbitCore/Pdb.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <atomic>

--- a/OrbitCore/Pdb.h
+++ b/OrbitCore/Pdb.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/Platform.h
+++ b/OrbitCore/Platform.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #pragma once
 
 #if defined(_WIN32)

--- a/OrbitCore/Platform.h
+++ b/OrbitCore/Platform.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #pragma once
 

--- a/OrbitCore/PrintVar.h
+++ b/OrbitCore/PrintVar.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_CORE_PRINT_VAR_H_
 #define ORBIT_CORE_PRINT_VAR_H_

--- a/OrbitCore/PrintVar.h
+++ b/OrbitCore/PrintVar.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_CORE_PRINT_VAR_H_
 #define ORBIT_CORE_PRINT_VAR_H_
 

--- a/OrbitCore/ProcessMemoryRequest.cpp
+++ b/OrbitCore/ProcessMemoryRequest.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "ProcessMemoryRequest.h"
 
 #include "Serialization.h"

--- a/OrbitCore/ProcessMemoryRequest.h
+++ b/OrbitCore/ProcessMemoryRequest.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_CORE_PROCESS_MEMORY_REQUEST_H_
 #define ORBIT_CORE_PROCESS_MEMORY_REQUEST_H_
 

--- a/OrbitCore/ProcessMemoryRequest.h
+++ b/OrbitCore/ProcessMemoryRequest.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_CORE_PROCESS_MEMORY_REQUEST_H_
 #define ORBIT_CORE_PROCESS_MEMORY_REQUEST_H_

--- a/OrbitCore/ProcessUtils.cpp
+++ b/OrbitCore/ProcessUtils.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "ProcessUtils.h"
 

--- a/OrbitCore/ProcessUtils.h
+++ b/OrbitCore/ProcessUtils.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 

--- a/OrbitCore/ProcessUtils.h
+++ b/OrbitCore/ProcessUtils.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 
 #ifndef ORBIT_CORE_PROCESS_UTILS_H_
 #define ORBIT_CORE_PROCESS_UTILS_H_

--- a/OrbitCore/Profiling.cpp
+++ b/OrbitCore/Profiling.cpp
@@ -1,5 +1,7 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "Profiling.h"

--- a/OrbitCore/Profiling.h
+++ b/OrbitCore/Profiling.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include "BaseTypes.h"

--- a/OrbitCore/Profiling.h
+++ b/OrbitCore/Profiling.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/RingBuffer.h
+++ b/OrbitCore/RingBuffer.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <cstddef>

--- a/OrbitCore/RingBuffer.h
+++ b/OrbitCore/RingBuffer.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/RingBufferTest.cpp
+++ b/OrbitCore/RingBufferTest.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <gtest/gtest.h>
 
 #include <cstdint>

--- a/OrbitCore/SamplingProfiler.cpp
+++ b/OrbitCore/SamplingProfiler.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "SamplingProfiler.h"
 

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include "BlockChain.h"

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/ScopeTimer.cpp
+++ b/OrbitCore/ScopeTimer.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "ScopeTimer.h"
 

--- a/OrbitCore/ScopeTimer.h
+++ b/OrbitCore/ScopeTimer.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <string>

--- a/OrbitCore/ScopeTimer.h
+++ b/OrbitCore/ScopeTimer.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/Serialization.h
+++ b/OrbitCore/Serialization.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/Serialization.h
+++ b/OrbitCore/Serialization.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include "PrintVar.h"

--- a/OrbitCore/SerializationMacros.h
+++ b/OrbitCore/SerializationMacros.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #define ORBIT_SERIALIZABLE \

--- a/OrbitCore/SerializationMacros.h
+++ b/OrbitCore/SerializationMacros.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/StringManager.cpp
+++ b/OrbitCore/StringManager.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "StringManager.h"
 
 #include "Serialization.h"

--- a/OrbitCore/StringManager.h
+++ b/OrbitCore/StringManager.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_CORE_STRING_MANAGER_H_
 #define ORBIT_CORE_STRING_MANAGER_H_
 

--- a/OrbitCore/StringManager.h
+++ b/OrbitCore/StringManager.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_CORE_STRING_MANAGER_H_
 #define ORBIT_CORE_STRING_MANAGER_H_

--- a/OrbitCore/StringManagerTest.cpp
+++ b/OrbitCore/StringManagerTest.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <gtest/gtest.h>
 
 #include "StringManager.h"

--- a/OrbitCore/SymbolHelper.cpp
+++ b/OrbitCore/SymbolHelper.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "SymbolHelper.h"
 
 #include <fstream>

--- a/OrbitCore/SymbolHelper.h
+++ b/OrbitCore/SymbolHelper.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef SYMBOL_HELPER_H_
 #define SYMBOL_HELPER_H_
 #include <string>

--- a/OrbitCore/SymbolHelper.h
+++ b/OrbitCore/SymbolHelper.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef SYMBOL_HELPER_H_
 #define SYMBOL_HELPER_H_

--- a/OrbitCore/SymbolHelperTest.cpp
+++ b/OrbitCore/SymbolHelperTest.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 

--- a/OrbitCore/SymbolUtils.cpp
+++ b/OrbitCore/SymbolUtils.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "SymbolUtils.h"
 

--- a/OrbitCore/SymbolUtils.h
+++ b/OrbitCore/SymbolUtils.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/SymbolUtils.h
+++ b/OrbitCore/SymbolUtils.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include "Core.h"

--- a/OrbitCore/Systrace.cpp
+++ b/OrbitCore/Systrace.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "Systrace.h"
 
 #include <fstream>

--- a/OrbitCore/Systrace.h
+++ b/OrbitCore/Systrace.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <map>

--- a/OrbitCore/Systrace.h
+++ b/OrbitCore/Systrace.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/Tcp.cpp
+++ b/OrbitCore/Tcp.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "Tcp.h"
 

--- a/OrbitCore/Tcp.h
+++ b/OrbitCore/Tcp.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #ifdef _WIN32

--- a/OrbitCore/Tcp.h
+++ b/OrbitCore/Tcp.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/TcpClient.cpp
+++ b/OrbitCore/TcpClient.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 // clang-format off
 #include "OrbitAsio.h"

--- a/OrbitCore/TcpClient.h
+++ b/OrbitCore/TcpClient.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <thread>

--- a/OrbitCore/TcpClient.h
+++ b/OrbitCore/TcpClient.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/TcpEntity.cpp
+++ b/OrbitCore/TcpEntity.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 // clang-format off
 #include "OrbitAsio.h"

--- a/OrbitCore/TcpEntity.h
+++ b/OrbitCore/TcpEntity.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <atomic>

--- a/OrbitCore/TcpEntity.h
+++ b/OrbitCore/TcpEntity.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/TcpForward.h
+++ b/OrbitCore/TcpForward.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <string>

--- a/OrbitCore/TcpForward.h
+++ b/OrbitCore/TcpForward.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/TcpServer.cpp
+++ b/OrbitCore/TcpServer.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "TcpServer.h"
 

--- a/OrbitCore/TcpServer.h
+++ b/OrbitCore/TcpServer.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <functional>

--- a/OrbitCore/TcpServer.h
+++ b/OrbitCore/TcpServer.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/TestRemoteMessages.cpp
+++ b/OrbitCore/TestRemoteMessages.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "TestRemoteMessages.h"
 
 #include <fstream>

--- a/OrbitCore/TestRemoteMessages.h
+++ b/OrbitCore/TestRemoteMessages.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <memory.h>

--- a/OrbitCore/TestRemoteMessages.h
+++ b/OrbitCore/TestRemoteMessages.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/TidAndThreadName.h
+++ b/OrbitCore/TidAndThreadName.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_CORE_TID_AND_THREAD_NAME_H_
 #define ORBIT_CORE_TID_AND_THREAD_NAME_H_
 

--- a/OrbitCore/TidAndThreadName.h
+++ b/OrbitCore/TidAndThreadName.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_CORE_TID_AND_THREAD_NAME_H_
 #define ORBIT_CORE_TID_AND_THREAD_NAME_H_

--- a/OrbitCore/TimerManager.cpp
+++ b/OrbitCore/TimerManager.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "TimerManager.h"
 

--- a/OrbitCore/TimerManager.h
+++ b/OrbitCore/TimerManager.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <atomic>

--- a/OrbitCore/TimerManager.h
+++ b/OrbitCore/TimerManager.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/Transaction.h
+++ b/OrbitCore/Transaction.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_CORE_TRANSACTION_H_
 #define ORBIT_CORE_TRANSACTION_H_

--- a/OrbitCore/Transaction.h
+++ b/OrbitCore/Transaction.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_CORE_TRANSACTION_H_
 #define ORBIT_CORE_TRANSACTION_H_
 

--- a/OrbitCore/TypeInfoStructs.h
+++ b/OrbitCore/TypeInfoStructs.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 // Author: Oleg Starodumov
 

--- a/OrbitCore/TypeInfoStructs.h
+++ b/OrbitCore/TypeInfoStructs.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 // Author: Oleg Starodumov
 
 #ifndef TypeInfoStructs_h

--- a/OrbitCore/Utils.cpp
+++ b/OrbitCore/Utils.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "Utils.h"
 

--- a/OrbitCore/Utils.h
+++ b/OrbitCore/Utils.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <xxhash.h>

--- a/OrbitCore/Utils.h
+++ b/OrbitCore/Utils.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/Variable.cpp
+++ b/OrbitCore/Variable.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "Variable.h"
 

--- a/OrbitCore/Variable.h
+++ b/OrbitCore/Variable.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <memory>

--- a/OrbitCore/Variable.h
+++ b/OrbitCore/Variable.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitCore/VariableTracing.cpp
+++ b/OrbitCore/VariableTracing.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "VariableTracing.h"
 

--- a/OrbitCore/VariableTracing.h
+++ b/OrbitCore/VariableTracing.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <iomanip>

--- a/OrbitCore/VariableTracing.h
+++ b/OrbitCore/VariableTracing.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitDll/OrbitDll.cpp
+++ b/OrbitDll/OrbitDll.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "OrbitDll.h"
 

--- a/OrbitDll/OrbitDll.h
+++ b/OrbitDll/OrbitDll.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #pragma once
 
 extern "C" {

--- a/OrbitDll/OrbitDll.h
+++ b/OrbitDll/OrbitDll.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #pragma once
 

--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 #include "Batcher.h"
 
 #include "Core.h"

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 #include <vector>
 

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/BlackBoard.cpp
+++ b/OrbitGl/BlackBoard.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "BlackBoard.h"
 

--- a/OrbitGl/BlackBoard.h
+++ b/OrbitGl/BlackBoard.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/BlackBoard.h
+++ b/OrbitGl/BlackBoard.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include "GlCanvas.h"

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "CallStackDataView.h"
 

--- a/OrbitGl/CallStackDataView.h
+++ b/OrbitGl/CallStackDataView.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/CallStackDataView.h
+++ b/OrbitGl/CallStackDataView.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <utility>

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "CaptureSerializer.h"
 
 #include <fstream>

--- a/OrbitGl/CaptureSerializer.h
+++ b/OrbitGl/CaptureSerializer.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/CaptureSerializer.h
+++ b/OrbitGl/CaptureSerializer.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <outcome.hpp>

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "CaptureWindow.h"
 

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include "GlCanvas.h"

--- a/OrbitGl/Card.cpp
+++ b/OrbitGl/Card.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "Card.h"
 

--- a/OrbitGl/Card.h
+++ b/OrbitGl/Card.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <unordered_map>

--- a/OrbitGl/Card.h
+++ b/OrbitGl/Card.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/CoreMath.h
+++ b/OrbitGl/CoreMath.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/CoreMath.h
+++ b/OrbitGl/CoreMath.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <math.h>

--- a/OrbitGl/DataView.cpp
+++ b/OrbitGl/DataView.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "DataView.h"
 

--- a/OrbitGl/DataView.h
+++ b/OrbitGl/DataView.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/DataView.h
+++ b/OrbitGl/DataView.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <OrbitBase/Logging.h>

--- a/OrbitGl/DataViewTypes.h
+++ b/OrbitGl/DataViewTypes.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/DataViewTypes.h
+++ b/OrbitGl/DataViewTypes.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/Debugger.cpp
+++ b/OrbitGl/Debugger.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #ifdef _WIN32
 

--- a/OrbitGl/Debugger.h
+++ b/OrbitGl/Debugger.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <atomic>

--- a/OrbitGl/Debugger.h
+++ b/OrbitGl/Debugger.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/Disassembler.cpp
+++ b/OrbitGl/Disassembler.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "Disassembler.h"
 

--- a/OrbitGl/Disassembler.h
+++ b/OrbitGl/Disassembler.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <string>

--- a/OrbitGl/Disassembler.h
+++ b/OrbitGl/Disassembler.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "EventTrack.h"
 

--- a/OrbitGl/EventTrack.h
+++ b/OrbitGl/EventTrack.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include "CallstackTypes.h"

--- a/OrbitGl/EventTrack.h
+++ b/OrbitGl/EventTrack.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/FunctionsDataView.cpp
+++ b/OrbitGl/FunctionsDataView.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "FunctionsDataView.h"
 

--- a/OrbitGl/FunctionsDataView.h
+++ b/OrbitGl/FunctionsDataView.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/FunctionsDataView.h
+++ b/OrbitGl/FunctionsDataView.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include "DataView.h"

--- a/OrbitGl/Geometry.h
+++ b/OrbitGl/Geometry.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 #include "BlockChain.h"
 #include "CoreMath.h"

--- a/OrbitGl/Geometry.h
+++ b/OrbitGl/Geometry.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "GlCanvas.h"
 

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include "GlPanel.h"

--- a/OrbitGl/GlPanel.cpp
+++ b/OrbitGl/GlPanel.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "GlPanel.h"
 

--- a/OrbitGl/GlPanel.h
+++ b/OrbitGl/GlPanel.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 #include <string>
 #include <vector>

--- a/OrbitGl/GlPanel.h
+++ b/OrbitGl/GlPanel.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/GlSlider.cpp
+++ b/OrbitGl/GlSlider.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "GlSlider.h"
 

--- a/OrbitGl/GlSlider.h
+++ b/OrbitGl/GlSlider.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <functional>

--- a/OrbitGl/GlSlider.h
+++ b/OrbitGl/GlSlider.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/GlUtils.cpp
+++ b/OrbitGl/GlUtils.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "GlUtils.h"
 

--- a/OrbitGl/GlUtils.h
+++ b/OrbitGl/GlUtils.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/GlUtils.h
+++ b/OrbitGl/GlUtils.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <iostream>

--- a/OrbitGl/GlobalsDataView.cpp
+++ b/OrbitGl/GlobalsDataView.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "GlobalsDataView.h"
 

--- a/OrbitGl/GlobalsDataView.h
+++ b/OrbitGl/GlobalsDataView.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/GlobalsDataView.h
+++ b/OrbitGl/GlobalsDataView.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include "DataView.h"

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "GpuTrack.h"
 
 #include <limits>

--- a/OrbitGl/GraphTrack.cpp
+++ b/OrbitGl/GraphTrack.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "GraphTrack.h"
 
 #include "GlCanvas.h"

--- a/OrbitGl/GraphTrack.h
+++ b/OrbitGl/GraphTrack.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_GL_GRAPH_TRACK_H
 #define ORBIT_GL_GRAPH_TRACK_H
 

--- a/OrbitGl/GraphTrack.h
+++ b/OrbitGl/GraphTrack.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_GL_GRAPH_TRACK_H
 #define ORBIT_GL_GRAPH_TRACK_H

--- a/OrbitGl/HomeWindow.cpp
+++ b/OrbitGl/HomeWindow.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "HomeWindow.h"
 

--- a/OrbitGl/HomeWindow.h
+++ b/OrbitGl/HomeWindow.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/HomeWindow.h
+++ b/OrbitGl/HomeWindow.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include "GlCanvas.h"

--- a/OrbitGl/ImGuiOrbit.cpp
+++ b/OrbitGl/ImGuiOrbit.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 // ImGui GLFW binding with OpenGL
 // You can copy and use unmodified imgui_impl_* files in your project. See

--- a/OrbitGl/ImGuiOrbit.h
+++ b/OrbitGl/ImGuiOrbit.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 // ImGui GLFW binding with OpenGL

--- a/OrbitGl/ImGuiOrbit.h
+++ b/OrbitGl/ImGuiOrbit.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/Images.h
+++ b/OrbitGl/Images.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 /* GIMP RGBA C-Source image dump (inject.c) */
 
 #ifdef WIN32

--- a/OrbitGl/Images.h
+++ b/OrbitGl/Images.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 /* GIMP RGBA C-Source image dump (inject.c) */
 

--- a/OrbitGl/ImmediateWindow.cpp
+++ b/OrbitGl/ImmediateWindow.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "ImmediateWindow.h"
 

--- a/OrbitGl/ImmediateWindow.h
+++ b/OrbitGl/ImmediateWindow.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/ImmediateWindow.h
+++ b/OrbitGl/ImmediateWindow.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include "GlCanvas.h"

--- a/OrbitGl/LiveFunctionsDataView.cpp
+++ b/OrbitGl/LiveFunctionsDataView.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "LiveFunctionsDataView.h"
 

--- a/OrbitGl/LiveFunctionsDataView.h
+++ b/OrbitGl/LiveFunctionsDataView.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/LiveFunctionsDataView.h
+++ b/OrbitGl/LiveFunctionsDataView.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include "DataView.h"

--- a/OrbitGl/LogDataView.cpp
+++ b/OrbitGl/LogDataView.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "LogDataView.h"
 
 #include <chrono>

--- a/OrbitGl/LogDataView.h
+++ b/OrbitGl/LogDataView.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/LogDataView.h
+++ b/OrbitGl/LogDataView.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include "DataView.h"

--- a/OrbitGl/ModulesDataView.cpp
+++ b/OrbitGl/ModulesDataView.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "ModulesDataView.h"
 

--- a/OrbitGl/ModulesDataView.h
+++ b/OrbitGl/ModulesDataView.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/ModulesDataView.h
+++ b/OrbitGl/ModulesDataView.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include "DataView.h"

--- a/OrbitGl/OpenGl.h
+++ b/OrbitGl/OpenGl.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/OpenGl.h
+++ b/OrbitGl/OpenGl.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 // clang-format off

--- a/OrbitGl/PickingManager.cpp
+++ b/OrbitGl/PickingManager.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "PickingManager.h"
 

--- a/OrbitGl/PickingManager.h
+++ b/OrbitGl/PickingManager.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <unordered_map>

--- a/OrbitGl/PickingManager.h
+++ b/OrbitGl/PickingManager.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/PluginCanvas.cpp
+++ b/OrbitGl/PluginCanvas.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "PluginCanvas.h"
 

--- a/OrbitGl/PluginCanvas.h
+++ b/OrbitGl/PluginCanvas.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/PluginCanvas.h
+++ b/OrbitGl/PluginCanvas.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include "GlCanvas.h"

--- a/OrbitGl/PluginManager.cpp
+++ b/OrbitGl/PluginManager.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "PluginManager.h"
 

--- a/OrbitGl/PluginManager.h
+++ b/OrbitGl/PluginManager.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/PluginManager.h
+++ b/OrbitGl/PluginManager.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <vector>

--- a/OrbitGl/ProcessesDataView.cpp
+++ b/OrbitGl/ProcessesDataView.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "ProcessesDataView.h"
 

--- a/OrbitGl/ProcessesDataView.h
+++ b/OrbitGl/ProcessesDataView.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/ProcessesDataView.h
+++ b/OrbitGl/ProcessesDataView.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include "DataView.h"

--- a/OrbitGl/SamplingReport.cpp
+++ b/OrbitGl/SamplingReport.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "SamplingReport.h"
 

--- a/OrbitGl/SamplingReport.h
+++ b/OrbitGl/SamplingReport.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <functional>

--- a/OrbitGl/SamplingReport.h
+++ b/OrbitGl/SamplingReport.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "SamplingReportDataView.h"
 

--- a/OrbitGl/SamplingReportDataView.h
+++ b/OrbitGl/SamplingReportDataView.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/SamplingReportDataView.h
+++ b/OrbitGl/SamplingReportDataView.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include "CallStackDataView.h"

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "SchedulerTrack.h"
 
 #include "Capture.h"

--- a/OrbitGl/SchedulerTrack.h
+++ b/OrbitGl/SchedulerTrack.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_GL_SCHEDULER_TRACK_H_
 #define ORBIT_GL_SCHEDULER_TRACK_H_
 

--- a/OrbitGl/SchedulerTrack.h
+++ b/OrbitGl/SchedulerTrack.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_GL_SCHEDULER_TRACK_H_
 #define ORBIT_GL_SCHEDULER_TRACK_H_

--- a/OrbitGl/SessionsDataView.cpp
+++ b/OrbitGl/SessionsDataView.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "SessionsDataView.h"
 

--- a/OrbitGl/SessionsDataView.h
+++ b/OrbitGl/SessionsDataView.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <memory>

--- a/OrbitGl/SessionsDataView.h
+++ b/OrbitGl/SessionsDataView.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/TextBox.cpp
+++ b/OrbitGl/TextBox.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "TextBox.h"
 

--- a/OrbitGl/TextBox.h
+++ b/OrbitGl/TextBox.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/TextBox.h
+++ b/OrbitGl/TextBox.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include "CoreMath.h"

--- a/OrbitGl/TextRenderer.cpp
+++ b/OrbitGl/TextRenderer.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "TextRenderer.h"
 

--- a/OrbitGl/TextRenderer.h
+++ b/OrbitGl/TextRenderer.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <map>

--- a/OrbitGl/TextRenderer.h
+++ b/OrbitGl/TextRenderer.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "ThreadTrack.h"
 
 #include <limits>

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <map>

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "TimeGraph.h"
 

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <unordered_map>

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/TimeGraphLayout.cpp
+++ b/OrbitGl/TimeGraphLayout.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "TimeGraphLayout.h"
 
 #include "Capture.h"

--- a/OrbitGl/TimeGraphLayout.h
+++ b/OrbitGl/TimeGraphLayout.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 

--- a/OrbitGl/TimeGraphLayout.h
+++ b/OrbitGl/TimeGraphLayout.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 
 #ifndef ORBIT_GL_TIME_GRAPH_LAYOUT_H_
 #define ORBIT_GL_TIME_GRAPH_LAYOUT_H_

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "Track.h"
 

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <atomic>

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/TypesDataView.cpp
+++ b/OrbitGl/TypesDataView.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "TypesDataView.h"
 

--- a/OrbitGl/TypesDataView.h
+++ b/OrbitGl/TypesDataView.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitGl/TypesDataView.h
+++ b/OrbitGl/TypesDataView.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <vector>

--- a/OrbitLinuxTracing/GpuTracepointEventProcessor.cpp
+++ b/OrbitLinuxTracing/GpuTracepointEventProcessor.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "GpuTracepointEventProcessor.h"
 
 #include <OrbitLinuxTracing/Events.h>

--- a/OrbitLinuxTracing/GpuTracepointEventProcessor.h
+++ b/OrbitLinuxTracing/GpuTracepointEventProcessor.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #ifndef ORBIT_LINUX_TRACING_GPU_TRACEPOINT_EVENT_PROCESSOR

--- a/OrbitLinuxTracing/GpuTracepointEventProcessor.h
+++ b/OrbitLinuxTracing/GpuTracepointEventProcessor.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 
 #ifndef ORBIT_LINUX_TRACING_GPU_TRACEPOINT_EVENT_PROCESSOR
 #define ORBIT_LINUX_TRACING_GPU_TRACEPOINT_EVENT_PROCESSOR

--- a/OrbitLinuxTracing/LibunwindstackUnwinder.cpp
+++ b/OrbitLinuxTracing/LibunwindstackUnwinder.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "LibunwindstackUnwinder.h"
 
 #include <OrbitBase/Logging.h>

--- a/OrbitLinuxTracing/LibunwindstackUnwinder.h
+++ b/OrbitLinuxTracing/LibunwindstackUnwinder.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_LIBUNWINDSTACK_UNWINDER_H_
 #define ORBIT_LINUX_TRACING_LIBUNWINDSTACK_UNWINDER_H_
 

--- a/OrbitLinuxTracing/LibunwindstackUnwinder.h
+++ b/OrbitLinuxTracing/LibunwindstackUnwinder.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_LINUX_TRACING_LIBUNWINDSTACK_UNWINDER_H_
 #define ORBIT_LINUX_TRACING_LIBUNWINDSTACK_UNWINDER_H_

--- a/OrbitLinuxTracing/MakeUniqueForOverwrite.h
+++ b/OrbitLinuxTracing/MakeUniqueForOverwrite.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_LINUX_TRACING_MAKE_UNIQUE_FOR_OVERWRITE_H_
 #define ORBIT_LINUX_TRACING_MAKE_UNIQUE_FOR_OVERWRITE_H_

--- a/OrbitLinuxTracing/MakeUniqueForOverwrite.h
+++ b/OrbitLinuxTracing/MakeUniqueForOverwrite.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_MAKE_UNIQUE_FOR_OVERWRITE_H_
 #define ORBIT_LINUX_TRACING_MAKE_UNIQUE_FOR_OVERWRITE_H_
 

--- a/OrbitLinuxTracing/OrbitTracing.cpp
+++ b/OrbitLinuxTracing/OrbitTracing.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <OrbitLinuxTracing/OrbitTracing.h>
 
 #if ORBIT_TRACING_ENABLED

--- a/OrbitLinuxTracing/PerfEvent.cpp
+++ b/OrbitLinuxTracing/PerfEvent.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "PerfEvent.h"
 
 #include "PerfEventVisitor.h"

--- a/OrbitLinuxTracing/PerfEvent.h
+++ b/OrbitLinuxTracing/PerfEvent.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_LINUX_TRACING_PERF_EVENT_H_
 #define ORBIT_LINUX_TRACING_PERF_EVENT_H_

--- a/OrbitLinuxTracing/PerfEvent.h
+++ b/OrbitLinuxTracing/PerfEvent.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_PERF_EVENT_H_
 #define ORBIT_LINUX_TRACING_PERF_EVENT_H_
 

--- a/OrbitLinuxTracing/PerfEventOpen.cpp
+++ b/OrbitLinuxTracing/PerfEventOpen.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "PerfEventOpen.h"
 
 #include <OrbitBase/Logging.h>

--- a/OrbitLinuxTracing/PerfEventOpen.h
+++ b/OrbitLinuxTracing/PerfEventOpen.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_LINUX_TRACING_PERF_EVENT_OPEN_H_
 #define ORBIT_LINUX_TRACING_PERF_EVENT_OPEN_H_

--- a/OrbitLinuxTracing/PerfEventOpen.h
+++ b/OrbitLinuxTracing/PerfEventOpen.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_PERF_EVENT_OPEN_H_
 #define ORBIT_LINUX_TRACING_PERF_EVENT_OPEN_H_
 

--- a/OrbitLinuxTracing/PerfEventProcessor.cpp
+++ b/OrbitLinuxTracing/PerfEventProcessor.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "PerfEventProcessor.h"
 
 #include <OrbitBase/Logging.h>

--- a/OrbitLinuxTracing/PerfEventProcessor.h
+++ b/OrbitLinuxTracing/PerfEventProcessor.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_LINUX_TRACING_PERF_EVENT_PROCESSOR_H_
 #define ORBIT_LINUX_TRACING_PERF_EVENT_PROCESSOR_H_

--- a/OrbitLinuxTracing/PerfEventProcessor.h
+++ b/OrbitLinuxTracing/PerfEventProcessor.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_PERF_EVENT_PROCESSOR_H_
 #define ORBIT_LINUX_TRACING_PERF_EVENT_PROCESSOR_H_
 

--- a/OrbitLinuxTracing/PerfEventProcessor2.cpp
+++ b/OrbitLinuxTracing/PerfEventProcessor2.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "PerfEventProcessor2.h"
 
 #include <OrbitBase/Logging.h>

--- a/OrbitLinuxTracing/PerfEventProcessor2.h
+++ b/OrbitLinuxTracing/PerfEventProcessor2.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_PERF_EVENT_PROCESSOR_2_H_
 #define ORBIT_LINUX_TRACING_PERF_EVENT_PROCESSOR_2_H_
 

--- a/OrbitLinuxTracing/PerfEventProcessor2.h
+++ b/OrbitLinuxTracing/PerfEventProcessor2.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_LINUX_TRACING_PERF_EVENT_PROCESSOR_2_H_
 #define ORBIT_LINUX_TRACING_PERF_EVENT_PROCESSOR_2_H_

--- a/OrbitLinuxTracing/PerfEventProcessor2Test.cpp
+++ b/OrbitLinuxTracing/PerfEventProcessor2Test.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <gtest/gtest.h>
 
 #include "PerfEventProcessor2.h"

--- a/OrbitLinuxTracing/PerfEventReaders.cpp
+++ b/OrbitLinuxTracing/PerfEventReaders.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "PerfEventReaders.h"
 
 #include <OrbitBase/Logging.h>

--- a/OrbitLinuxTracing/PerfEventReaders.h
+++ b/OrbitLinuxTracing/PerfEventReaders.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_LINUX_TRACING_PERF_EVENT_READERS_H_
 #define ORBIT_LINUX_TRACING_PERF_EVENT_READERS_H_

--- a/OrbitLinuxTracing/PerfEventReaders.h
+++ b/OrbitLinuxTracing/PerfEventReaders.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_PERF_EVENT_READERS_H_
 #define ORBIT_LINUX_TRACING_PERF_EVENT_READERS_H_
 

--- a/OrbitLinuxTracing/PerfEventRecords.h
+++ b/OrbitLinuxTracing/PerfEventRecords.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_LINUX_TRACING_PERF_EVENT_RECORDS_H_
 #define ORBIT_LINUX_TRACING_PERF_EVENT_RECORDS_H_

--- a/OrbitLinuxTracing/PerfEventRecords.h
+++ b/OrbitLinuxTracing/PerfEventRecords.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_PERF_EVENT_RECORDS_H_
 #define ORBIT_LINUX_TRACING_PERF_EVENT_RECORDS_H_
 

--- a/OrbitLinuxTracing/PerfEventRingBuffer.cpp
+++ b/OrbitLinuxTracing/PerfEventRingBuffer.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "PerfEventRingBuffer.h"
 
 #include <OrbitBase/Logging.h>

--- a/OrbitLinuxTracing/PerfEventRingBuffer.h
+++ b/OrbitLinuxTracing/PerfEventRingBuffer.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_LINUX_TRACING_PERF_RING_BUFFER_H_
 #define ORBIT_LINUX_TRACING_PERF_RING_BUFFER_H_

--- a/OrbitLinuxTracing/PerfEventRingBuffer.h
+++ b/OrbitLinuxTracing/PerfEventRingBuffer.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_PERF_RING_BUFFER_H_
 #define ORBIT_LINUX_TRACING_PERF_RING_BUFFER_H_
 

--- a/OrbitLinuxTracing/PerfEventVisitor.h
+++ b/OrbitLinuxTracing/PerfEventVisitor.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_LINUX_TRACING_PERF_EVENT_VISITOR_H_
 #define ORBIT_LINUX_TRACING_PERF_EVENT_VISITOR_H_

--- a/OrbitLinuxTracing/PerfEventVisitor.h
+++ b/OrbitLinuxTracing/PerfEventVisitor.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_PERF_EVENT_VISITOR_H_
 #define ORBIT_LINUX_TRACING_PERF_EVENT_VISITOR_H_
 

--- a/OrbitLinuxTracing/Tracer.cpp
+++ b/OrbitLinuxTracing/Tracer.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <OrbitBase/Logging.h>
 #include <OrbitLinuxTracing/Tracer.h>
 

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "TracerThread.h"
 
 #include <OrbitBase/Logging.h>

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_LINUX_TRACING_TRACER_THREAD_H_
 #define ORBIT_LINUX_TRACING_TRACER_THREAD_H_

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_TRACER_THREAD_H_
 #define ORBIT_LINUX_TRACING_TRACER_THREAD_H_
 

--- a/OrbitLinuxTracing/UprobesFunctionCallManager.h
+++ b/OrbitLinuxTracing/UprobesFunctionCallManager.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_UPROBES_FUNCTION_CALL_MANAGER_H_
 #define ORBIT_LINUX_TRACING_UPROBES_FUNCTION_CALL_MANAGER_H_
 

--- a/OrbitLinuxTracing/UprobesFunctionCallManager.h
+++ b/OrbitLinuxTracing/UprobesFunctionCallManager.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_LINUX_TRACING_UPROBES_FUNCTION_CALL_MANAGER_H_
 #define ORBIT_LINUX_TRACING_UPROBES_FUNCTION_CALL_MANAGER_H_

--- a/OrbitLinuxTracing/UprobesFunctionCallManagerTest.cpp
+++ b/OrbitLinuxTracing/UprobesFunctionCallManagerTest.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 

--- a/OrbitLinuxTracing/UprobesReturnAddressManager.h
+++ b/OrbitLinuxTracing/UprobesReturnAddressManager.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_UPROBES_RETURN_ADDRESS_MANAGER_H_
 #define ORBIT_LINUX_TRACING_UPROBES_RETURN_ADDRESS_MANAGER_H_
 

--- a/OrbitLinuxTracing/UprobesReturnAddressManager.h
+++ b/OrbitLinuxTracing/UprobesReturnAddressManager.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_LINUX_TRACING_UPROBES_RETURN_ADDRESS_MANAGER_H_
 #define ORBIT_LINUX_TRACING_UPROBES_RETURN_ADDRESS_MANAGER_H_

--- a/OrbitLinuxTracing/UprobesReturnAddressManagerTest.cpp
+++ b/OrbitLinuxTracing/UprobesReturnAddressManagerTest.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "UprobesUnwindingVisitor.h"
 
 #include "OrbitBase/Logging.h"

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.h
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_UPROBES_UNWINDING_VISITOR_H_
 #define ORBIT_LINUX_TRACING_UPROBES_UNWINDING_VISITOR_H_
 

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.h
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_LINUX_TRACING_UPROBES_UNWINDING_VISITOR_H_
 #define ORBIT_LINUX_TRACING_UPROBES_UNWINDING_VISITOR_H_

--- a/OrbitLinuxTracing/Utils.cpp
+++ b/OrbitLinuxTracing/Utils.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #ifndef ORBIT_LINUX_TRACING_UTILS_H_
 #define ORBIT_LINUX_TRACING_UTILS_H_
 

--- a/OrbitLinuxTracing/Utils.h
+++ b/OrbitLinuxTracing/Utils.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_LINUX_TRACING_UTILS_H_
 #define ORBIT_LINUX_TRACING_UTILS_H_

--- a/OrbitLinuxTracing/Utils.h
+++ b/OrbitLinuxTracing/Utils.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_UTILS_H_
 #define ORBIT_LINUX_TRACING_UTILS_H_
 

--- a/OrbitLinuxTracing/UtilsTest.cpp
+++ b/OrbitLinuxTracing/UtilsTest.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 #include <sys/syscall.h>

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/Events.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/Events.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_EVENTS_H_
 #define ORBIT_LINUX_TRACING_EVENTS_H_
 

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/Events.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/Events.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_LINUX_TRACING_EVENTS_H_
 #define ORBIT_LINUX_TRACING_EVENTS_H_

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/Function.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/Function.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_LINUX_TRACING_FUNCTION_H_
 #define ORBIT_LINUX_TRACING_FUNCTION_H_

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/Function.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/Function.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_FUNCTION_H_
 #define ORBIT_LINUX_TRACING_FUNCTION_H_
 

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/OrbitTracing.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/OrbitTracing.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_LINUX_TRACING_ORBIT_TRACING_H_
 #define ORBIT_LINUX_TRACING_ORBIT_TRACING_H_

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/OrbitTracing.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/OrbitTracing.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_ORBIT_TRACING_H_
 #define ORBIT_LINUX_TRACING_ORBIT_TRACING_H_
 

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/Tracer.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/Tracer.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_LINUX_TRACING_TRACER_H_
 #define ORBIT_LINUX_TRACING_TRACER_H_

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/Tracer.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/Tracer.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_TRACER_H_
 #define ORBIT_LINUX_TRACING_TRACER_H_
 

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/TracerListener.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/TracerListener.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_TRACER_LISTENER_H_
 #define ORBIT_LINUX_TRACING_TRACER_LISTENER_H_
 

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/TracerListener.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/TracerListener.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_LINUX_TRACING_TRACER_LISTENER_H_
 #define ORBIT_LINUX_TRACING_TRACER_LISTENER_H_

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/TracingOptions.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/TracingOptions.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_LINUX_TRACING_TRACING_OPTIONS_H_
 #define ORBIT_LINUX_TRACING_TRACING_OPTIONS_H_
 

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/TracingOptions.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/TracingOptions.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_LINUX_TRACING_TRACING_OPTIONS_H_
 #define ORBIT_LINUX_TRACING_TRACING_OPTIONS_H_

--- a/OrbitPlugin/OrbitData.h
+++ b/OrbitPlugin/OrbitData.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <cstdint>

--- a/OrbitPlugin/OrbitData.h
+++ b/OrbitPlugin/OrbitData.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitPlugin/OrbitSDK.h
+++ b/OrbitPlugin/OrbitSDK.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include "OrbitData.h"

--- a/OrbitPlugin/OrbitSDK.h
+++ b/OrbitPlugin/OrbitSDK.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitPlugin/OrbitUserData.h
+++ b/OrbitPlugin/OrbitUserData.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <cstdint>

--- a/OrbitPlugin/OrbitUserData.h
+++ b/OrbitPlugin/OrbitUserData.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitPlugin/UserPlugin.cpp
+++ b/OrbitPlugin/UserPlugin.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "UserPlugin.h"
 

--- a/OrbitPlugin/UserPlugin.h
+++ b/OrbitPlugin/UserPlugin.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #pragma once
 #include "imgui.h"
 #include "imgui_internal.h"

--- a/OrbitPlugin/UserPlugin.h
+++ b/OrbitPlugin/UserPlugin.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #pragma once
 #include "imgui.h"

--- a/OrbitQt/eventloop.h
+++ b/OrbitQt/eventloop.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #ifndef ORBIT_QT_EVENT_LOOP_H_

--- a/OrbitQt/eventloop.h
+++ b/OrbitQt/eventloop.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 
 #ifndef ORBIT_QT_EVENT_LOOP_H_
 #define ORBIT_QT_EVENT_LOOP_H_

--- a/OrbitQt/orbitdataviewpanel.cpp
+++ b/OrbitQt/orbitdataviewpanel.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "orbitdataviewpanel.h"
 

--- a/OrbitQt/orbitdataviewpanel.h
+++ b/OrbitQt/orbitdataviewpanel.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <QWidget>

--- a/OrbitQt/orbitdataviewpanel.h
+++ b/OrbitQt/orbitdataviewpanel.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitQt/orbitdisassemblydialog.cpp
+++ b/OrbitQt/orbitdisassemblydialog.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "orbitdisassemblydialog.h"
 
 #include "ui_orbitdisassemblydialog.h"

--- a/OrbitQt/orbitdisassemblydialog.h
+++ b/OrbitQt/orbitdisassemblydialog.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBITDISASSEMBLYDIALOG_H
 #define ORBITDISASSEMBLYDIALOG_H
 

--- a/OrbitQt/orbitdisassemblydialog.h
+++ b/OrbitQt/orbitdisassemblydialog.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBITDISASSEMBLYDIALOG_H
 #define ORBITDISASSEMBLYDIALOG_H

--- a/OrbitQt/orbitglwidget.cpp
+++ b/OrbitQt/orbitglwidget.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "orbitglwidget.h"
 

--- a/OrbitQt/orbitglwidget.h
+++ b/OrbitQt/orbitglwidget.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitQt/orbitglwidget.h
+++ b/OrbitQt/orbitglwidget.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <QOpenGLFunctions>

--- a/OrbitQt/orbitglwidgetwithheader.cpp
+++ b/OrbitQt/orbitglwidgetwithheader.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "orbitglwidgetwithheader.h"
 

--- a/OrbitQt/orbitglwidgetwithheader.h
+++ b/OrbitQt/orbitglwidgetwithheader.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <QWidget>

--- a/OrbitQt/orbitglwidgetwithheader.h
+++ b/OrbitQt/orbitglwidgetwithheader.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitQt/orbitsamplingreport.cpp
+++ b/OrbitQt/orbitsamplingreport.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "orbitsamplingreport.h"
 

--- a/OrbitQt/orbitsamplingreport.h
+++ b/OrbitQt/orbitsamplingreport.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <QWidget>

--- a/OrbitQt/orbitsamplingreport.h
+++ b/OrbitQt/orbitsamplingreport.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitQt/orbittablemodel.cpp
+++ b/OrbitQt/orbittablemodel.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 #include "orbittablemodel.h"
 

--- a/OrbitQt/orbittablemodel.h
+++ b/OrbitQt/orbittablemodel.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <QAbstractTableModel>

--- a/OrbitQt/orbittablemodel.h
+++ b/OrbitQt/orbittablemodel.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitQt/orbittreeitem.cpp
+++ b/OrbitQt/orbittreeitem.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "orbittreeitem.h"
 
 #include <QStringList>

--- a/OrbitQt/orbittreeitem.h
+++ b/OrbitQt/orbittreeitem.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #pragma once
 

--- a/OrbitQt/orbittreeitem.h
+++ b/OrbitQt/orbittreeitem.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #pragma once
 
 #include <QList>

--- a/OrbitQt/orbittreemodel.cpp
+++ b/OrbitQt/orbittreemodel.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "orbittreemodel.h"
 
 #include <QColor>

--- a/OrbitQt/orbittreemodel.h
+++ b/OrbitQt/orbittreemodel.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #pragma once
 
 #include <QAbstractItemModel>

--- a/OrbitQt/orbittreemodel.h
+++ b/OrbitQt/orbittreemodel.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #pragma once
 

--- a/OrbitQt/orbittreeview.cpp
+++ b/OrbitQt/orbittreeview.cpp
@@ -1,6 +1,8 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 
 // This needs to be first because if it is not GL/glew.h
 // complains about being included after gl.h

--- a/OrbitQt/orbittreeview.h
+++ b/OrbitQt/orbittreeview.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 
 #pragma once

--- a/OrbitQt/orbittreeview.h
+++ b/OrbitQt/orbittreeview.h
@@ -1,6 +1,10 @@
-//-----------------------------------
-// Copyright Pierric Gimmig 2013-2017
-//-----------------------------------
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+
 #pragma once
 
 #include <QTimer>

--- a/OrbitQt/orbitwatchwidget.cpp
+++ b/OrbitQt/orbitwatchwidget.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "orbitwatchwidget.h"
 
 #include <QGridLayout>

--- a/OrbitQt/orbitwatchwidget.h
+++ b/OrbitQt/orbitwatchwidget.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBITWATCHWIDGET_H
 #define ORBITWATCHWIDGET_H

--- a/OrbitQt/orbitwatchwidget.h
+++ b/OrbitQt/orbitwatchwidget.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBITWATCHWIDGET_H
 #define ORBITWATCHWIDGET_H
 

--- a/OrbitQt/outputdialog.cpp
+++ b/OrbitQt/outputdialog.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "outputdialog.h"
 
 #include "ui_outputdialog.h"

--- a/OrbitQt/outputdialog.h
+++ b/OrbitQt/outputdialog.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef OUTPUTDIALOG_H
 #define OUTPUTDIALOG_H
 

--- a/OrbitQt/outputdialog.h
+++ b/OrbitQt/outputdialog.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef OUTPUTDIALOG_H
 #define OUTPUTDIALOG_H

--- a/OrbitQt/processlauncherwidget.cpp
+++ b/OrbitQt/processlauncherwidget.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "processlauncherwidget.h"
 
 #include <QFileDialog>

--- a/OrbitQt/processlauncherwidget.h
+++ b/OrbitQt/processlauncherwidget.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef PROCESSLAUNCHERWIDGET_H
 #define PROCESSLAUNCHERWIDGET_H

--- a/OrbitQt/processlauncherwidget.h
+++ b/OrbitQt/processlauncherwidget.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef PROCESSLAUNCHERWIDGET_H
 #define PROCESSLAUNCHERWIDGET_H
 

--- a/OrbitQt/showincludesdialog.cpp
+++ b/OrbitQt/showincludesdialog.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "showincludesdialog.h"
 
 #include <QMenu>

--- a/OrbitQt/showincludesdialog.h
+++ b/OrbitQt/showincludesdialog.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef SHOWINCLUDESDIALOG_H
 #define SHOWINCLUDESDIALOG_H

--- a/OrbitQt/showincludesdialog.h
+++ b/OrbitQt/showincludesdialog.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef SHOWINCLUDESDIALOG_H
 #define SHOWINCLUDESDIALOG_H
 

--- a/OrbitService/OrbitService.h
+++ b/OrbitService/OrbitService.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #ifndef ORBIT_SERVICE_ORBIT_SERVICE_H
 #define ORBIT_SERVICE_ORBIT_SERVICE_H
 

--- a/OrbitService/OrbitService.h
+++ b/OrbitService/OrbitService.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef ORBIT_SERVICE_ORBIT_SERVICE_H
 #define ORBIT_SERVICE_ORBIT_SERVICE_H

--- a/OrbitService/main.cpp
+++ b/OrbitService/main.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <csignal>
 #include <iostream>
 

--- a/OrbitSsh/SocketTests.cpp
+++ b/OrbitSsh/SocketTests.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <gtest/gtest.h>
 
 #include <memory>

--- a/OrbitTest/OrbitTest.cpp
+++ b/OrbitTest/OrbitTest.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "OrbitTest.h"
 
 #include <stdio.h>

--- a/OrbitTest/OrbitTest.h
+++ b/OrbitTest/OrbitTest.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2020 The Orbit Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #pragma once
 #include <memory>

--- a/OrbitTest/OrbitTest.h
+++ b/OrbitTest/OrbitTest.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 The Orbit Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
 #pragma once
 #include <memory>
 #include <thread>

--- a/OrbitTest/main.cpp
+++ b/OrbitTest/main.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <memory>
 #include <string>
 

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 
 default_profiles=( default_relwithdebinfo )
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 from conans import ConanFile, CMake, tools
 from conans.errors import ConanInvalidConfiguration
 import os

--- a/protos/dummy.cpp
+++ b/protos/dummy.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 // This file is there as a workaround for a problem
 // with grpc_helpers where it does not work for proto-only
 // static libraries. It needs to have at least one non-proto

--- a/protos/process.proto
+++ b/protos/process.proto
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 syntax = "proto3";
 
 message ProcessInfo {

--- a/protos/services.proto
+++ b/protos/services.proto
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 syntax = "proto3";
 
 import "process.proto";

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 exec $DIR/build_default_release/bin/Orbit

--- a/run_clang_format.sh
+++ b/run_clang_format.sh
@@ -1,2 +1,7 @@
 #!/bin/bash
+
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 find . \( -name '*.cpp' -o -name '*.h' \) ! -path './third_party/*' ! -path './build/*' ! -path './cmake-*' ! -name 'resource.h' | xargs clang-format -i

--- a/run_service.sh
+++ b/run_service.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 exec $DIR/build_default_release/bin/OrbitService

--- a/run_service_ssh.sh
+++ b/run_service_ssh.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 
 # This script first runs the ggp ssh init command to get the needed
 # credentials to connect via ssh. Then it connects to the instance


### PR DESCRIPTION
Removed all old copyright notices and ran

addlicense -f license_file
git checkout third_party/*
git checkout (some other files that we don't have the copyright)

where license_file contains:

Copyright (c) 2020 The Orbit Authors. All rights reserved.
Use of this source code is governed by a BSD-style license that can be
found in the LICENSE file.

I then changed the header style comments from /* */ to // for consistency (as discussed below).

addlicense can be found here: github.com/google/addlicense