### PR TITLE
Do not refresh sampling view on every selection

### DIFF
--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -220,7 +220,6 @@ void SamplingReportDataView::OnContextMenu(
 
 //-----------------------------------------------------------------------------
 void SamplingReportDataView::OnSelect(int index) {
-  m_SelectedIndex = index;
   SampledFunction& func = GetSampledFunction(index);
   m_SamplingReport->OnSelectAddress(func.m_Address, m_TID);
 }

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -310,8 +310,10 @@ void OrbitMainWindow::UpdatePanel(DataViewType a_Type) {
       ui->SessionList->Refresh();
       break;
     case DataViewType::SAMPLING:
-      m_OrbitSamplingReport->Refresh();
-      m_SelectionReport->Refresh();
+      m_OrbitSamplingReport->RefreshCallstackView();
+      m_OrbitSamplingReport->RefreshTabs();
+      m_SelectionReport->RefreshCallstackView();
+      m_SelectionReport->RefreshTabs();
       break;
     default:
       break;

--- a/OrbitQt/orbitsamplingreport.cpp
+++ b/OrbitQt/orbitsamplingreport.cpp
@@ -44,7 +44,7 @@ void OrbitSamplingReport::Initialize(DataView* callstack_data_view,
 
   if (!report) return;
 
-  m_SamplingReport->SetUiRefreshFunc([&]() { this->Refresh(); });
+  m_SamplingReport->SetUiRefreshFunc([&]() { this->RefreshCallstackView(); });
 
   for (SamplingReportDataView& report_data_view : report->GetThreadReports()) {
     QWidget* tab = new QWidget();
@@ -89,18 +89,18 @@ void OrbitSamplingReport::Initialize(DataView* callstack_data_view,
 void OrbitSamplingReport::on_NextCallstackButton_clicked() {
   assert(m_SamplingReport);
   m_SamplingReport->IncrementCallstackIndex();
-  Refresh();
+  RefreshCallstackView();
 }
 
 //-----------------------------------------------------------------------------
 void OrbitSamplingReport::on_PreviousCallstackButton_clicked() {
   assert(m_SamplingReport);
   m_SamplingReport->DecrementCallstackIndex();
-  Refresh();
+  RefreshCallstackView();
 }
 
 //-----------------------------------------------------------------------------
-void OrbitSamplingReport::Refresh() {
+void OrbitSamplingReport::RefreshCallstackView() {
   if (m_SamplingReport == nullptr) {
     return;
   }
@@ -109,9 +109,16 @@ void OrbitSamplingReport::Refresh() {
     ui->NextCallstackButton->setEnabled(true);
     ui->PreviousCallstackButton->setEnabled(true);
   }
+
   std::string label = m_SamplingReport->GetSelectedCallstackString();
   ui->CallStackLabel->setText(QString::fromStdString(label));
   ui->CallstackTreeView->Refresh();
+}
+
+void OrbitSamplingReport::RefreshTabs() {
+  if (m_SamplingReport == nullptr) {
+    return;
+  }
 
   for (OrbitDataViewPanel* panel : m_OrbitDataViews) {
     panel->Refresh();

--- a/OrbitQt/orbitsamplingreport.h
+++ b/OrbitQt/orbitsamplingreport.h
@@ -25,7 +25,8 @@ class OrbitSamplingReport : public QWidget {
   void Initialize(DataView* callstack_data_view,
                   std::shared_ptr<class SamplingReport> report);
 
-  void Refresh();
+  void RefreshCallstackView();
+  void RefreshTabs();
 
  private slots:
   void on_NextCallstackButton_clicked();


### PR DESCRIPTION
Separate Refresh method into RefreshCallstackView and RefreshTabs
the latter is only called when new symbols are available.

Bug: http://b/157534259
Test: capture, shift-select, hook; capture -> load symbols