### PR TITLE
Fixed regression in OrbitStartupWindow

### DIFF
--- a/OrbitQt/OrbitStartupWindow.cpp
+++ b/OrbitQt/OrbitStartupWindow.cpp
@@ -123,9 +123,10 @@ OrbitStartupWindow::OrbitStartupWindow(QWidget* parent)
                               "necessary to connect via ssh. The error message "
                               "was: %1")
                           .arg(ssh_info.error()));
+                } else {
+                  self->result_ = ssh_info.value();
+                  self->accept();
                 }
-                self->result_ = ssh_info.value();
-                self->accept();
               }
             });
       });

--- a/OrbitQt/OrbitStartupWindow.cpp
+++ b/OrbitQt/OrbitStartupWindow.cpp
@@ -25,8 +25,7 @@
 #include "Path.h"
 
 OrbitStartupWindow::OrbitStartupWindow(QWidget* parent)
-    : QDialog{parent, Qt::Dialog},
-      model_{new GgpInstanceItemModel{{}, this}} {
+    : QDialog{parent, Qt::Dialog}, model_{new GgpInstanceItemModel{{}, this}} {
   // General UI
   const int width = 700;
   const int height = 400;


### PR DESCRIPTION
Orbit crashes when the ggp command fails because the error was not properly handled.

While refactoring this the else-branch seems to have slipped away.