### PR TITLE
Fix read access violation when closing the ui while capturing

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -483,7 +483,6 @@ void OrbitApp::OnExit() {
   }
 
   GParams.Save();
-  GTimerManager = nullptr;
 
   ConnectionManager::Get().Stop();
   GTcpClient->Stop();
@@ -494,6 +493,7 @@ void OrbitApp::OnExit() {
 
   process_list_manager_->Shutdown();
 
+  GTimerManager = nullptr;
   GCoreApp = nullptr;
   GOrbitApp = nullptr;
   Orbit_ImGui_Shutdown();


### PR DESCRIPTION
`GTimerManager` was set to `nullptr` on close before stopping receiving
messages.
Bug: http://b/157722384