### PR TITLE
Removed ggp version extraction logic.

### DIFF
--- a/OrbitGgp/GgpClient.cpp
+++ b/OrbitGgp/GgpClient.cpp
@@ -85,16 +85,7 @@ GgpClient::ResultOrQString<GgpClient> GgpClient::Create() {
         .arg(ggp_process.errorString().arg(ggp_process.exitCode()));
   }
 
-  const QByteArray process_result = ggp_process.readAllStandardOutput();
-  const QList<QByteArray> tokens = process_result.split(' ');
-
-  if (tokens.size() < 2) {
-    return QString{
-        "The current version of GGP is not supported by this integration."};
-  }
-
   GgpClient client{};
-  client.version_ = tokens.first().toStdString();
   return client;
 }
 

--- a/OrbitGgp/include/OrbitGgp/GgpClient.h
+++ b/OrbitGgp/include/OrbitGgp/GgpClient.h
@@ -23,7 +23,6 @@ class GgpClient {
 
   static ResultOrQString<GgpClient> Create();
 
-  const std::string& GetVersion() const { return version_; }
   int GetNumberOfRequestsRunning() const { return number_of_requests_running_; }
 
   void GetInstancesAsync(
@@ -36,7 +35,6 @@ class GgpClient {
  private:
   GgpClient() = default;
 
-  std::string version_;
   int number_of_requests_running_ = 0;
 };
 


### PR DESCRIPTION
We don't use this version number and the parsing has already been broken
at least once.