### PR TITLE
Do not crash when encountering unexpected case in ThreadTrack::SetTimesliceText

### DIFF
--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -127,7 +127,9 @@ void ThreadTrack::SetTimesliceText(const Timer& timer, double elapsed_us,
       text_box->SetText(
           SystraceManager::Get().GetFunctionName(timer.m_FunctionAddress));
     } else {
-      CHECK(false);
+      ERROR("Unexpected case in ThreadTrack::SetTimesliceText");
+      PRINT_VAR(timer.m_Type);
+      PRINT_VAR(func);
     }
   }
 


### PR DESCRIPTION
See b/158019419. 

I do *not* know the root cause of this and what case we are encountering here that we did not expect. The crash report we have for this does not have a minidump and I was not able to reproduce. I think the best we can do here is not crash and log info about what is happening. The only (?) negative effect of passing though the if block is that the textbox text will not be set in this case and will be shown as an empty string.