### PR TITLE
Sync crash reporting and symbol uploading

### DIFF
--- a/kokoro/gcp_ubuntu_ggp/kokoro_build.sh
+++ b/kokoro/gcp_ubuntu_ggp/kokoro_build.sh
@@ -25,7 +25,7 @@ if [ "$0" == "$SCRIPT" ]; then
   conan package -bf "${DIR}/build/" "${DIR}"
 
   build_type=${KOKORO_JOB_NAME##*/}
-  if [ $build_type=release ] || [ $build_type=nightly ]; then
+  if [ $build_type=release ] || [ $build_type=nightly ] || [ $build_type=continuous_on_release_branch ]; then
     set +e
     ${DIR}/kokoro/gcp_ubuntu_ggp/upload_symbols.sh "${DIR}/build/bin"
     set -e

--- a/kokoro/gcp_windows/continuous.cfg
+++ b/kokoro/gcp_windows/continuous.cfg
@@ -13,12 +13,6 @@ before_action {
       key_type: RAW
       backend_type: FASTCONFIGPUSH
     }
-    keystore_resource {
-      keystore_config_id: 74938
-      keyname: "orbitprofiler_crashdump_collection_server"
-      key_type: RAW
-      backend_type: FASTCONFIGPUSH
-    }
   }
 }
 

--- a/kokoro/gcp_windows/kokoro_build.bat
+++ b/kokoro/gcp_windows/kokoro_build.bat
@@ -28,6 +28,7 @@ for %%g in ("%KOKORO_JOB_NAME:/=" "%") do set build_type=%%g
 set symbol_uploading_required=false
 if %build_type% == "release" set symbol_uploading_required=true
 if %build_type% == "nightly" set symbol_uploading_required=true
+if %build_type% == "continuous_on_release_branch" set symbol_uploading_required=true
 if "%symbol_uploading_required%" == "true" (
   :: Upload debug symbols
   call powershell "& %REPO_ROOT%\kokoro\gcp_windows\upload_symbols.ps1" %REPO_ROOT%\build\bin

--- a/kokoro/gcp_windows/presubmit.cfg
+++ b/kokoro/gcp_windows/presubmit.cfg
@@ -5,17 +5,6 @@
 # github_scm.name is specified in the job configuration (next section).
 build_file: "orbitprofiler/kokoro/gcp_windows/kokoro_build.bat"
 
-before_action {
-  fetch_keystore {
-    keystore_resource {
-      keystore_config_id: 74938
-      keyname: "orbitprofiler_crashdump_collection_server"
-      key_type: RAW
-      backend_type: FASTCONFIGPUSH
-    }
-  }
-}
-
 action {
   define_artifacts {
     regex: "github/orbitprofiler/build/testresults/*.xml"


### PR DESCRIPTION
Removed uploading dumps on crash for presubmit and continuous builds (master branch). 

Added uploading dumps on crash for continuous build (release branch). 