### PR TITLE
Discard messages from previous capture.

### DIFF
--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -178,7 +178,7 @@ outcome::result<void, std::string> Capture::StartCapture(
 
   GInjected = true;
   ++Message::GSessionID;
-  GTcpServer->Send(Msg_NewSession);
+  GTcpClient->Send(Msg_NewSession);
   GTimerManager->StartRecording();
 
   ClearCaptureData();

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -177,8 +177,8 @@ outcome::result<void, std::string> Capture::StartCapture(
 #endif
 
   GInjected = true;
-  ++Message::GSessionID;
-  GTcpClient->Send(Msg_NewSession);
+  ++Message::GCaptureID;
+  GTcpClient->Send(Msg_NewCaptureID);
   GTimerManager->StartRecording();
 
   ClearCaptureData();

--- a/OrbitCore/LinuxTracingBufferTest.cpp
+++ b/OrbitCore/LinuxTracingBufferTest.cpp
@@ -108,7 +108,7 @@ TEST(LinuxTracingBuffer, Timers) {
     timer.m_PID = 1;
     timer.m_TID = 1;
     timer.m_Depth = 0;
-    timer.m_SessionID = 42;
+    timer.m_CaptureID = 42;
     timer.m_Type = Timer::CORE_ACTIVITY;
     timer.m_Processor = 1;
     timer.m_CallstackHash = 2;
@@ -126,7 +126,7 @@ TEST(LinuxTracingBuffer, Timers) {
     timer.m_PID = 1;
     timer.m_TID = 2;
     timer.m_Depth = 0;
-    timer.m_SessionID = 42;
+    timer.m_CaptureID = 42;
     timer.m_Type = Timer::CORE_ACTIVITY;
     timer.m_Processor = 3;
     timer.m_CallstackHash = 4;
@@ -148,7 +148,7 @@ TEST(LinuxTracingBuffer, Timers) {
   EXPECT_EQ(timers[0].m_PID, 1);
   EXPECT_EQ(timers[0].m_TID, 1);
   EXPECT_EQ(timers[0].m_Depth, 0);
-  EXPECT_EQ(timers[0].m_SessionID, 42);
+  EXPECT_EQ(timers[0].m_CaptureID, 42);
   EXPECT_EQ(timers[0].m_Type, Timer::CORE_ACTIVITY);
   EXPECT_EQ(timers[0].m_Processor, 1);
   EXPECT_EQ(timers[0].m_CallstackHash, 2);
@@ -160,7 +160,7 @@ TEST(LinuxTracingBuffer, Timers) {
   EXPECT_EQ(timers[1].m_PID, 1);
   EXPECT_EQ(timers[1].m_TID, 2);
   EXPECT_EQ(timers[1].m_Depth, 0);
-  EXPECT_EQ(timers[1].m_SessionID, 42);
+  EXPECT_EQ(timers[1].m_CaptureID, 42);
   EXPECT_EQ(timers[1].m_Type, Timer::CORE_ACTIVITY);
   EXPECT_EQ(timers[1].m_Processor, 3);
   EXPECT_EQ(timers[1].m_CallstackHash, 4);
@@ -175,7 +175,7 @@ TEST(LinuxTracingBuffer, Timers) {
     timer.m_PID = 11;
     timer.m_TID = 12;
     timer.m_Depth = 10;
-    timer.m_SessionID = 42;
+    timer.m_CaptureID = 42;
     timer.m_Type = Timer::CORE_ACTIVITY;
     timer.m_Processor = 3;
     timer.m_CallstackHash = 4;
@@ -197,7 +197,7 @@ TEST(LinuxTracingBuffer, Timers) {
   EXPECT_EQ(timers[0].m_PID, 11);
   EXPECT_EQ(timers[0].m_TID, 12);
   EXPECT_EQ(timers[0].m_Depth, 10);
-  EXPECT_EQ(timers[0].m_SessionID, 42);
+  EXPECT_EQ(timers[0].m_CaptureID, 42);
   EXPECT_EQ(timers[0].m_Type, Timer::CORE_ACTIVITY);
   EXPECT_EQ(timers[0].m_Processor, 3);
   EXPECT_EQ(timers[0].m_CallstackHash, 4);
@@ -444,7 +444,7 @@ TEST(LinuxTracingBuffer, Reset) {
     timer.m_PID = 1;
     timer.m_TID = 1;
     timer.m_Depth = 0;
-    timer.m_SessionID = 42;
+    timer.m_CaptureID = 42;
     timer.m_Type = Timer::CORE_ACTIVITY;
     timer.m_Processor = 1;
     timer.m_CallstackHash = 2;

--- a/OrbitCore/Message.cpp
+++ b/OrbitCore/Message.cpp
@@ -9,21 +9,21 @@
 #include "PrintVar.h"
 
 //-----------------------------------------------------------------------------
-uint32_t Message::GSessionID;
+uint32_t Message::GCaptureID;
 
 //-----------------------------------------------------------------------------
 void Message::Dump() {
   PRINT_VAR(offsetof(Message, m_Type));
   PRINT_VAR(offsetof(Message, m_Header));
   PRINT_VAR(offsetof(Message, m_Size));
-  PRINT_VAR(offsetof(Message, m_SessionID));
+  PRINT_VAR(offsetof(Message, m_CaptureID));
   PRINT_VAR(offsetof(Message, m_ThreadId));
   PRINT_VAR(offsetof(Message, m_Data));
 
   PRINT_VAR(sizeof(m_Type));
   PRINT_VAR(sizeof(m_Header));
   PRINT_VAR(sizeof(m_Size));
-  PRINT_VAR(sizeof(m_SessionID));
+  PRINT_VAR(sizeof(m_CaptureID));
   PRINT_VAR(sizeof(m_ThreadId));
   PRINT_VAR(sizeof(m_Data));
 

--- a/OrbitCore/Message.h
+++ b/OrbitCore/Message.h
@@ -19,7 +19,7 @@ enum MessageType : int16_t {
   Msg_GetData,
   Msg_String,
   Msg_Timer,
-  Msg_NewSession,
+  Msg_NewCaptureID,
   Msg_StartCapture,
   Msg_StopCapture,
   Msg_FunctionHook,
@@ -107,7 +107,7 @@ class Message {
           char* a_Data = nullptr)
       : m_Type(a_Type),
         m_Size(a_Size),
-        m_SessionID(GSessionID),
+        m_CaptureID(GCaptureID),
         m_ThreadId(0),
         m_Data(a_Data) {}
 
@@ -133,7 +133,7 @@ class Message {
   MessageType m_Type;
   Header m_Header;
   uint32_t m_Size;
-  uint32_t m_SessionID;
+  uint32_t m_CaptureID;
   uint32_t m_ThreadId;
   void* m_Data;
 #ifdef WIN32
@@ -142,7 +142,7 @@ class Message {
 #endif
 #endif
 
-  static uint32_t GSessionID;
+  static uint32_t GCaptureID;
 };
 
 class MessageOwner : public Message {

--- a/OrbitCore/ScopeTimer.cpp
+++ b/OrbitCore/ScopeTimer.cpp
@@ -16,7 +16,7 @@ thread_local size_t CurrentDepthLocal = 0;
 void Timer::Start() {
   m_TID = GetCurrentThreadId();
   m_Depth = CurrentDepth++;
-  m_SessionID = Message::GSessionID;
+  m_CaptureID = Message::GCaptureID;
   m_Start = OrbitTicks();
 }
 

--- a/OrbitCore/ScopeTimer.h
+++ b/OrbitCore/ScopeTimer.h
@@ -21,7 +21,7 @@ class Timer {
       : m_PID(0),
         m_TID(0),
         m_Depth(0),
-        m_SessionID(-1),
+        m_CaptureID(-1),
         m_Type(NONE),
         m_Processor(-1),
         m_CallstackHash(0),
@@ -79,7 +79,7 @@ class Timer {
   uint32_t m_PID;
   uint32_t m_TID;
   uint8_t m_Depth;
-  uint8_t m_SessionID;
+  uint8_t m_CaptureID;
   Type m_Type;
   uint8_t m_Processor;
   uint64_t m_CallstackHash;

--- a/OrbitCore/TcpClient.cpp
+++ b/OrbitCore/TcpClient.cpp
@@ -168,7 +168,11 @@ void TcpClient::OnError(const std::error_code& ec) {
 
 //-----------------------------------------------------------------------------
 void TcpClient::DecodeMessage(Message& a_Message) {
-  Callback(a_Message);
+  if (a_Message.m_SessionID == Message::GSessionID) {
+    Callback(a_Message);
+  } else {
+    LOG("Received message from previous session");
+  }
 
 #ifdef _WIN32
   Message::Header MessageHeader = a_Message.GetHeader();

--- a/OrbitCore/TcpClient.cpp
+++ b/OrbitCore/TcpClient.cpp
@@ -168,10 +168,10 @@ void TcpClient::OnError(const std::error_code& ec) {
 
 //-----------------------------------------------------------------------------
 void TcpClient::DecodeMessage(Message& a_Message) {
-  if (a_Message.m_SessionID == Message::GSessionID) {
+  if (a_Message.m_CaptureID == Message::GCaptureID) {
     Callback(a_Message);
   } else {
-    LOG("Received message from previous session");
+    LOG("Received message from previous capture");
   }
 
 #ifdef _WIN32
@@ -205,8 +205,8 @@ void TcpClient::DecodeMessage(Message& a_Message) {
       Send(msg, buffer);
       break;
     }
-    case Msg_NewSession:
-      Message::GSessionID = a_Message.m_SessionID;
+    case Msg_NewCaptureID:
+      Message::GCaptureID = a_Message.m_CaptureID;
       break;
     case Msg_StartCapture:
       Orbit::Start();

--- a/OrbitCore/TimerManager.cpp
+++ b/OrbitCore/TimerManager.cpp
@@ -137,17 +137,9 @@ void TimerManager::ConsumeTimers() {
       --m_NumQueuedEntries;
       --m_NumQueuedTimers;
 
-      // if( Timer.m_SessionID == Message::GSessionID ) // TODO: re-enable
-      // check.
-      {
-        for (TimerAddedCallback& Callback : m_TimerAddedCallbacks) {
-          Callback(Timer);
-        }
+      for (TimerAddedCallback& Callback : m_TimerAddedCallbacks) {
+        Callback(Timer);
       }
-      /*else
-      {
-          ++m_NumTimersFromPreviousSession;
-      }*/
     }
   }
 }

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -347,7 +347,7 @@ void TimeGraph::AddContextSwitch(const ContextSwitch& a_CS) {
           timer.m_TID = lastCS.m_ThreadId;
           timer.m_Processor = static_cast<int8_t>(lastCS.m_ProcessorIndex);
           timer.m_Depth = timer.m_Processor;
-          timer.m_SessionID = Message::GSessionID;
+          timer.m_CaptureID = Message::GCaptureID;
           timer.SetType(Timer::CORE_ACTIVITY);
 
           GTimerManager->Add(timer);
@@ -371,7 +371,7 @@ void TimeGraph::AddContextSwitch(const ContextSwitch& a_CS) {
           // tid from the context switch in.
           timer.m_PID = lastCS.m_ProcessId;
           timer.m_TID = lastCS.m_ThreadId;
-          timer.m_SessionID = Message::GSessionID;
+          timer.m_CaptureID = Message::GCaptureID;
           timer.SetType(Timer::THREAD_ACTIVITY);
 
           GTimerManager->Add(timer);

--- a/OrbitService/OrbitAsioServer.cpp
+++ b/OrbitService/OrbitAsioServer.cpp
@@ -74,6 +74,11 @@ void OrbitAsioServer::SetupServerCallbacks() {
 
   tcp_server_->AddMainThreadCallback(Msg_StopCapture,
                                      [this](const Message&) { StopCapture(); });
+
+  tcp_server_->AddMainThreadCallback(Msg_NewSession, [](const Message& msg) {
+    Message::GSessionID = msg.m_SessionID;
+    LOG("Received new session ID: %u", msg.m_SessionID);
+  });
 }
 
 void OrbitAsioServer::SendProcess(uint32_t pid) {

--- a/OrbitService/OrbitAsioServer.cpp
+++ b/OrbitService/OrbitAsioServer.cpp
@@ -75,9 +75,9 @@ void OrbitAsioServer::SetupServerCallbacks() {
   tcp_server_->AddMainThreadCallback(Msg_StopCapture,
                                      [this](const Message&) { StopCapture(); });
 
-  tcp_server_->AddMainThreadCallback(Msg_NewSession, [](const Message& msg) {
-    Message::GSessionID = msg.m_SessionID;
-    LOG("Received new session ID: %u", msg.m_SessionID);
+  tcp_server_->AddMainThreadCallback(Msg_NewCaptureID, [](const Message& msg) {
+    Message::GCaptureID = msg.m_CaptureID;
+    LOG("Received new capture ID: %u", msg.m_CaptureID);
   });
 }
 


### PR DESCRIPTION
Make sure that messages from a previous capture are not processed as valid messages.  This can occur if we have buffered or in-flight messages as we start a new capture.  Simply discard those messages and warn.  This rarely happens, but can be triggered by button mashing (starting and stopping captures rapidly).