### PR TITLE
Refactor start orbit service privileged

### DIFF
--- a/OrbitQt/servicedeploymanager.cpp
+++ b/OrbitQt/servicedeploymanager.cpp
@@ -57,8 +57,7 @@ outcome::result<bool> ServiceDeployManager::CheckIfInstalled() {
   const auto command = absl::StrFormat(
       "/usr/bin/dpkg-query -W orbitprofiler 2>/dev/null | grep %s", version);
 
-  OrbitSshQt::Task check_if_installed_task{&session_.value(), command,
-                                           OrbitSshQt::Task::Tty::kNo};
+  OrbitSshQt::Task check_if_installed_task{&session_.value(), command};
 
   QObject::connect(&check_if_installed_task, &OrbitSshQt::Task::finished,
                    &loop_, &EventLoop::exit);
@@ -200,8 +199,7 @@ outcome::result<void> ServiceDeployManager::StartOrbitService() {
   emit statusMessage("Starting OrbitService on the remote instance...");
 
   orbit_service_task_.emplace(&session_.value(),
-                              "/opt/developer/tools/OrbitService",
-                              OrbitSshQt::Task::Tty::kNo);
+                              "/opt/developer/tools/OrbitService");
 
   auto quit_handler = ConnectQuitHandler(&orbit_service_task_.value(),
                                          &OrbitSshQt::Task::started);
@@ -232,8 +230,7 @@ outcome::result<void> ServiceDeployManager::StartOrbitServicePrivileged() {
   emit statusMessage("Starting OrbitService on the remote instance...");
 
   orbit_service_task_.emplace(&session_.value(),
-                              "sudo --stdin /tmp/OrbitService",
-                              OrbitSshQt::Task::Tty::kNo);
+                              "sudo --stdin /tmp/OrbitService");
 
   const auto& config =
       std::get<OrbitQt::BareExecutableAndRootPasswordDeployment>(
@@ -272,8 +269,7 @@ outcome::result<void> ServiceDeployManager::InstallOrbitServicePackage() {
   const auto command = absl::StrFormat(
       "sudo /usr/local/cloudcast/sbin/install_signed_package.sh %s",
       kDebDestinationPath);
-  OrbitSshQt::Task install_service_task{&session_.value(), command,
-                                        OrbitSshQt::Task::Tty::kNo};
+  OrbitSshQt::Task install_service_task{&session_.value(), command};
 
   QObject::connect(
       &install_service_task, &OrbitSshQt::Task::finished, this,

--- a/OrbitSsh/Channel.cpp
+++ b/OrbitSsh/Channel.cpp
@@ -99,17 +99,6 @@ outcome::result<void> Channel::WriteBlocking(std::string_view text) {
   return outcome::success();
 }
 
-outcome::result<void> Channel::RequestPty(const std::string& term) {
-  const int rc =
-      libssh2_channel_request_pty(raw_channel_ptr_.get(), term.c_str());
-
-  if (rc == 0) {
-    return outcome::success();
-  } else {
-    return static_cast<Error>(rc);
-  }
-}
-
 outcome::result<void> Channel::SendEOF() {
   const int rc = libssh2_channel_send_eof(raw_channel_ptr_.get());
 

--- a/OrbitSsh/include/OrbitSsh/Channel.h
+++ b/OrbitSsh/include/OrbitSsh/Channel.h
@@ -32,7 +32,6 @@ class Channel {
   outcome::result<void> WriteBlocking(std::string_view text);
   outcome::result<int> Write(std::string_view text);
   outcome::result<void> Exec(const std::string& command);
-  outcome::result<void> RequestPty(const std::string& term);
   outcome::result<void> SendEOF();
   outcome::result<void> WaitRemoteEOF();
   outcome::result<void> Close();

--- a/OrbitSshQt/IntegrationTests.cpp
+++ b/OrbitSshQt/IntegrationTests.cpp
@@ -37,8 +37,7 @@ TEST(OrbitSshQtTests, IntegrationTest) {
 
   OrbitSshQt::Session session{&context.value()};
   const uint16_t port_number = 1025;
-  OrbitSshQt::Task task{&session, absl::StrFormat("nc -l %d", port_number),
-                        OrbitSshQt::Task::Tty::kNo};
+  OrbitSshQt::Task task{&session, absl::StrFormat("nc -l %d", port_number)};
   OrbitSshQt::Tunnel tunnel{&session, "127.0.0.1", port_number};
   QTcpSocket client;
   std::string data_sink;
@@ -91,7 +90,6 @@ TEST(OrbitSshQtTests, IntegrationTest) {
     task.Start();
     CheckCheckpoint(Checkpoint::kSessionStarted);
   });
-
 
   // Task
 
@@ -177,8 +175,8 @@ TEST(OrbitSshQtTests, IntegrationTest) {
   QObject::connect(&sftp_channel, &OrbitSshQt::SftpChannel::errorOccurred,
                    &loop, [&](std::error_code e) {
                      loop.quit();
-                     FAIL() << absl::StrFormat("SFTP channel error occurred: %s",
-                                               e.message());
+                     FAIL() << absl::StrFormat(
+                         "SFTP channel error occurred: %s", e.message());
                    });
 
   QObject::connect(&sftp_channel, &OrbitSshQt::SftpChannel::stopped, &loop,
@@ -207,9 +205,10 @@ TEST(OrbitSshQtTests, IntegrationTest) {
   LOG("connect to server");
   QTimer::singleShot(std::chrono::seconds{5}, [&]() {
     loop.quit();
-    FAIL() << "Timeout occurred. The whole integration test should be done in 5 "
-              "seconds. If not, probably it's stuck somewhere in the callback "
-              "logic.";
+    FAIL()
+        << "Timeout occurred. The whole integration test should be done in 5 "
+           "seconds. If not, probably it's stuck somewhere in the callback "
+           "logic.";
   });
 
   loop.exec();

--- a/OrbitSshQt/include/OrbitSshQt/Task.h
+++ b/OrbitSshQt/include/OrbitSshQt/Task.h
@@ -20,7 +20,6 @@ enum class TaskState {
   kInitial,
   kNoChannel,
   kChannelInitialized,
-  kTtyAcquired,
   kStarted,
   kCommandRunning,
   kShutdown,
@@ -54,8 +53,7 @@ class Task : public StateMachineHelper<Task, details::TaskState> {
   friend StateMachineHelper;
 
  public:
-  enum class Tty { kYes, kNo };
-  explicit Task(Session* session, std::string command, Tty tty);
+  explicit Task(Session* session, std::string command);
   void Start();
   void Stop();
 
@@ -87,7 +85,6 @@ class Task : public StateMachineHelper<Task, details::TaskState> {
   std::optional<ScopedConnection> about_to_shutdown_connection_;
 
   std::string command_;
-  Tty tty_ = Tty::kNo;
   std::optional<OrbitSsh::Channel> channel_;
   std::string read_buffer_;
   std::string write_buffer_;


### PR DESCRIPTION
I found a way to execute OrbitService somewhat more elegantly, it uses `sudo --stdin'. All the tty code is then not necessary anymore and the ssh watchdog can be used.