### PR TITLE
Verify availability of OpenGL 2.0

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -332,9 +332,6 @@ void OrbitApp::PostInit() {
     }
   }
 
-  int my_argc = 0;
-  glutInit(&my_argc, NULL);
-  glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH);
   GetDesktopResolution(GOrbitApp->m_ScreenRes[0], GOrbitApp->m_ScreenRes[1]);
 
   GOrbitApp->InitializeClientTransactions();

--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -31,6 +31,7 @@ target_sources(
          GlobalsDataView.h
          GlPanel.h
          GlSlider.h
+         GlutContext.h
          GlUtils.h
          GpuTrack.h
          GraphTrack.h
@@ -43,6 +44,7 @@ target_sources(
          mat4.h
          ModulesDataView.h
          OpenGl.h
+         OpenGlDetect.h
          PickingManager.h
          PluginCanvas.h
          PluginManager.h
@@ -85,6 +87,7 @@ target_sources(
           GlobalsDataView.cpp
           GlPanel.cpp
           GlSlider.cpp
+          GlutContext.cpp
           GlUtils.cpp
           GpuTrack.cpp
           GraphTrack.cpp
@@ -94,6 +97,7 @@ target_sources(
           LiveFunctionsDataView.cpp
           LogDataView.cpp
           ModulesDataView.cpp
+          OpenGlDetect.cpp
           PickingManager.cpp
           PluginCanvas.cpp
           PluginManager.cpp

--- a/OrbitGl/GlutContext.cpp
+++ b/OrbitGl/GlutContext.cpp
@@ -1,0 +1,10 @@
+#include "GlutContext.h"
+
+#include "OpenGl.h"
+
+namespace OrbitGl {
+GlutContext::GlutContext(int* argc, char** argv) {
+  glutInit(argc, argv);
+  glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH);
+}
+}  // namespace OrbitGl

--- a/OrbitGl/GlutContext.h
+++ b/OrbitGl/GlutContext.h
@@ -1,0 +1,12 @@
+#ifndef ORBIT_GL_GLUT_CONTEXT_H_
+#define ORBIT_GL_GLUT_CONTEXT_H_
+
+namespace OrbitGl {
+
+struct GlutContext {
+  explicit GlutContext(int* argc, char** argv);
+};
+
+}  // namespace OrbitGl
+
+#endif  // ORBIT_GL_GLUT_CONTEXT_H_

--- a/OrbitGl/OpenGl.h
+++ b/OrbitGl/OpenGl.h
@@ -16,6 +16,7 @@
 #include <GL/glew.h>
 #include <GL/glu.h>
 #include <freetype-gl/freetype-gl.h>
+#include "GL/freeglut.h"
 
 // clang-format off
 #include <GL/gl.h>

--- a/OrbitGl/OpenGlDetect.cpp
+++ b/OrbitGl/OpenGlDetect.cpp
@@ -1,0 +1,68 @@
+#include "OpenGlDetect.h"
+
+#include <absl/strings/str_split.h>
+
+#include <charconv>
+
+#include "OpenGl.h"
+#include "OrbitBase/Logging.h"
+
+namespace OrbitGl {
+
+std::optional<OpenGlVersion> DetectOpenGlVersion(GlutContext*) {
+  const auto window =
+      glutCreateWindow("Determining supported OpenGL version...");
+
+  if (window <= 0) {
+    return std::nullopt;
+  }
+
+  glewInit();
+
+  const auto str_ptr = glGetString(GL_VERSION);
+  std::string str{};
+
+  if (str_ptr != nullptr) {
+    str = std::string{reinterpret_cast<const char*>(str_ptr)};
+  }
+
+  glutDestroyWindow(window);
+
+  if (str_ptr == nullptr) {
+    return std::nullopt;
+  }
+
+  // We have to trigger the event loop three times to destroy the window fully.
+  glutMainLoopEvent();
+  glutMainLoopEvent();
+  glutMainLoopEvent();
+
+  std::vector<std::string> pieces =
+      absl::StrSplit(str, absl::MaxSplits(absl::ByAnyChar(". "), 2));
+
+  if (pieces.size() < 2) {
+    ERROR("Could not split OpenGL version string: %s", str);
+    return std::nullopt;
+  }
+
+  OpenGlVersion version{};
+  const auto major_result = std::from_chars(
+      pieces[0].data(), pieces[0].data() + pieces[0].size(), version.major);
+
+  if (major_result.ec != std::errc()) {
+    ERROR("Could not parse major version in OpenGL version string: %s", str);
+    return std::nullopt;
+  }
+
+  const auto minor_result = std::from_chars(
+      pieces[1].data(), pieces[1].data() + pieces[1].size(), version.minor);
+
+  if (minor_result.ec != std::errc()) {
+    ERROR("Could not parse minor version in OpenGL version string: %s", str);
+    return std::nullopt;
+  }
+
+  return version;
+}
+
+}  // namespace OrbitGl

--- a/OrbitGl/OpenGlDetect.h
+++ b/OrbitGl/OpenGlDetect.h
@@ -1,0 +1,19 @@
+#ifndef ORBIT_GL_OPEN_GL_DETECT__H_
+#define ORBIT_GL_OPEN_GL_DETECT__H_
+
+#include <optional>
+
+#include "GlutContext.h"
+
+namespace OrbitGl {
+
+struct OpenGlVersion {
+  int major;
+  int minor;
+};
+
+std::optional<OpenGlVersion> DetectOpenGlVersion(GlutContext*);
+
+}  // namespace OrbitGl
+
+#endif  // ORBIT_GL_OPEN_GL_DETECT__H_

--- a/conanfile.py
+++ b/conanfile.py
@@ -113,6 +113,7 @@ class OrbitConan(ConanFile):
                     self.options["qt"].qttools = True
                     self.options["qt"].with_glib = False
                     self.options["qt"].with_harfbuzz = False
+                    self.options["qt"].opengl = "dynamic"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
After this PR Orbit UI will check whether OpenGL 2.0 is available and if not show a message box and exit. (Please have a look at the error message. I have the feeling it's not proper English.)

For checking the OpenGL version a windows has to be opened for a split second. So this is a hack and has to be removed eventually.

Furthermore this PR enables Qt to be compiled in dynamic-mode which means the availability of OpenGL is detected at runtime and it falls back to software rasterization if not. Unfortunately this only works for the Qt-based parts of the codebase because the software rasterization library only supports OpenGL ES and no Desktop OpenGL.