### PR TITLE
Add "[BETA]" to initial dialog title.

### DIFF
--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -215,7 +215,7 @@ int main(int argc, char* argv[]) {
 #endif
 
   QApplication app(argc, argv);
-  QCoreApplication::setApplicationName("Orbit Profiler");
+  QCoreApplication::setApplicationName("Orbit Profiler [BETA]");
   QCoreApplication::setApplicationVersion(OrbitQt::kVersionString);
 
   const std::string dump_path = Path::GetDumpPath();

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -740,11 +740,11 @@ void OrbitMainWindow::OpenDisassembly(const std::string& a_String) {
 //-----------------------------------------------------------------------------
 void OrbitMainWindow::SetTitle(const QString& task_description) {
   if (task_description.isEmpty()) {
-    setWindowTitle(QString("%1 %2 [BETA]")
+    setWindowTitle(QString("%1 %2")
                        .arg(QApplication::applicationName(),
                             QApplication::applicationVersion()));
   } else {
-    setWindowTitle(QString("%1 %2 [BETA] - %3")
+    setWindowTitle(QString("%1 %2 - %3")
                        .arg(QApplication::applicationName(),
                             QApplication::applicationVersion(),
                             task_description));


### PR DESCRIPTION
"[BETA]" appeared int the main application window but not on the initial dialog.  Make sure users see that they are using a beta version on startup.  "[BETA]" is now part of the application name instead of explicitly being added to the window title.