### PR TITLE
Directly require OpenSSL on Windows as well.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,10 +78,7 @@ if(NOT WIN32 AND WITH_GUI)
   find_package(X11 REQUIRED)
 endif()
 
-if(NOT WIN32)
-  find_package(OpenSSL CONFIG REQUIRED)
-endif()
-
+find_package(OpenSSL CONFIG REQUIRED)
 find_package(Threads REQUIRED)
 find_package(cereal CONFIG REQUIRED)
 find_package(xxHash REQUIRED)


### PR DESCRIPTION
This lead to problems in the past for some team members and I have seen this lately as well.
I still don't know why it sometimes works and sometimes not but requiring the OpenSSL package does not hurt in our case.