### PR TITLE
Added Windows 10 SDK to docker containers

### DIFF
--- a/third_party/conan/docker/Dockerfile.msvc2017
+++ b/third_party/conan/docker/Dockerfile.msvc2017
@@ -34,6 +34,7 @@ RUN C:\TEMP\Install.cmd C:\TEMP\vs_buildtools.exe --quiet --wait --norestart --n
     --add Microsoft.Component.VC.Runtime.UCRTSDK `
     --add Microsoft.Component.MSBuild `
     --add Microsoft.VisualStudio.Component.VC.ATL `
+    --add Microsoft.VisualStudio.Component.Windows10SDK.17763 `
     --installPath C:\BuildTools
 
 

--- a/third_party/conan/docker/Dockerfile.msvc2019
+++ b/third_party/conan/docker/Dockerfile.msvc2019
@@ -34,6 +34,7 @@ RUN C:\TEMP\Install.cmd C:\TEMP\vs_buildtools.exe --quiet --wait --norestart --n
     --add Microsoft.Component.VC.Runtime.UCRTSDK `
     --add Microsoft.Component.MSBuild `
     --add Microsoft.VisualStudio.Component.VC.ATL `
+    --add Microsoft.VisualStudio.Component.Windows10SDK.17763 `
     --installPath C:\BuildTools
 
 


### PR DESCRIPTION
When building Qt from source with ANGLE enabled DirectX 11 headers are
needed which are only available in the Windows 10 SDK even though we
build Orbit against the Windows 8.1 SDK.