### PR TITLE
Add "disabled" state logic for capture view icon toolbars.

### DIFF
--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -899,7 +899,9 @@ void CaptureWindow::RenderHelpUi() {
 }
 
 //-----------------------------------------------------------------------------
-ImTextureID TextureId(uint64_t id) { return reinterpret_cast<ImTextureID>(id); }
+ImTextureID TextureId(uint64_t id) {
+  return reinterpret_cast<ImTextureID>(static_cast<uintptr_t>(id));
+}
 
 //-----------------------------------------------------------------------------
 bool IconButton(uint64_t texture_id, const char* tooltip, ImVec2 size,

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -88,17 +88,17 @@ class CaptureWindow : public GlCanvas {
   int m_ProcessX;
 
   // Toolbars.
-  uint32_t start_capture_icon_id_;
-  uint32_t stop_capture_icon_id_;
-  uint32_t save_capture_icon_id_;
-  uint32_t load_capture_icon_id_;
-  uint32_t clear_capture_icon_id_;
-  uint32_t help_icon_id_;
-  uint32_t filter_tracks_icon_id_;
-  uint32_t search_icon_id_;
-  uint32_t time_icon_id_;
-  uint32_t feedback_icon_id_;
-  uint32_t info_icon_id_;
+  uint64_t start_capture_icon_id_;
+  uint64_t stop_capture_icon_id_;
+  uint64_t save_capture_icon_id_;
+  uint64_t load_capture_icon_id_;
+  uint64_t clear_capture_icon_id_;
+  uint64_t help_icon_id_;
+  uint64_t filter_tracks_icon_id_;
+  uint64_t search_icon_id_;
+  uint64_t time_icon_id_;
+  uint64_t feedback_icon_id_;
+  uint64_t info_icon_id_;
   std::string icons_path_;
   float toolbar_height_ = 0;
 

--- a/OrbitGl/ImGuiOrbit.h
+++ b/OrbitGl/ImGuiOrbit.h
@@ -19,6 +19,7 @@
 #include "OrbitType.h"
 #include "ProcessUtils.h"
 #include "imgui.h"
+#include "imgui_internal.h"
 
 class GlCanvas;
 


### PR DESCRIPTION
Icons in capture view toolbars are now disabled (greyed out) when not usable.