### PR TITLE
Do not condition TimerManager::AddTimer with m_IsRecording

### DIFF
--- a/OrbitCore/ConnectionManager.cpp
+++ b/OrbitCore/ConnectionManager.cpp
@@ -51,7 +51,7 @@ void ConnectionManager::SetupClientCallbacks() {
     uint32_t numTimers = msg.m_Size / sizeof(Timer);
     const Timer* timers = static_cast<const Timer*>(msg.GetData());
     for (uint32_t i = 0; i < numTimers; ++i) {
-      GTimerManager->Add(timers[i]);
+      GTimerManager->AddTimer(timers[i]);
     }
   });
 

--- a/OrbitCore/EventCallbacks.cpp
+++ b/OrbitCore/EventCallbacks.cpp
@@ -272,7 +272,7 @@ inline void ProcessContextSwitch(PEVENT_RECORD a_EventRecord) {
     CS.m_Time = CycleTime;
     CS.m_ProcessorIndex = ProcessorIndex;
     CS.m_ProcessorNumber = ProcessorNumber;
-    GTimerManager->Add(CS);
+    GTimerManager->AddContextSwitch(CS);
   }
 
   if (GThreadToProcessMap[switchEvent->OldThreadId] == processId) {
@@ -281,7 +281,7 @@ inline void ProcessContextSwitch(PEVENT_RECORD a_EventRecord) {
     CS.m_Time = CycleTime;
     CS.m_ProcessorIndex = ProcessorIndex;
     CS.m_ProcessorNumber = ProcessorNumber;
-    GTimerManager->Add(CS);
+    GTimerManager->AddContextSwitch(CS);
   }
 }
 

--- a/OrbitCore/Hijacking.cpp
+++ b/OrbitCore/Hijacking.cpp
@@ -411,7 +411,7 @@ void* Hijacking::Epilog() {
   timer.Stop();
 
   // Send timer
-  GTimerManager->Add(timer);
+  GTimerManager->AddTimer(timer);
 
   // Pop timer
   TlsData->m_Timers.pop_back();
@@ -476,7 +476,7 @@ void* Hijacking::EpilogZoneStop() {
     }
 
     // Send timer
-    GTimerManager->Add(timer);
+    GTimerManager->AddTimer(timer);
 
     // Pop timer
     TlsData->m_Timers.pop_back();
@@ -515,7 +515,7 @@ void* Hijacking::EpilogAlloc() {
   timer.m_Type = Timer::ALLOC;
 
   // Send timer
-  GTimerManager->Add(timer);
+  GTimerManager->AddTimer(timer);
 
   // Pop timer
   TlsData->m_Timers.pop_back();

--- a/OrbitCore/TcpServer.cpp
+++ b/OrbitCore/TcpServer.cpp
@@ -119,7 +119,7 @@ void TcpServer::Receive(const Message& a_Message) {
       uint32_t numTimers = a_Message.m_Size / sizeof(Timer);
       const Timer* timers = static_cast<const Timer*>(a_Message.GetData());
       for (uint32_t i = 0; i < numTimers; ++i) {
-        GTimerManager->Add(timers[i]);
+        GTimerManager->AddTimer(timers[i]);
       }
 
       if (numTimers > m_MaxTimersAtOnce) {

--- a/OrbitCore/TimerManager.cpp
+++ b/OrbitCore/TimerManager.cpp
@@ -178,7 +178,7 @@ void TimerManager::SendTimers() {
 }
 
 //-----------------------------------------------------------------------------
-void TimerManager::Add(const Timer& a_Timer) {
+void TimerManager::AddTimer(const Timer& a_Timer) {
   if (m_IsRecording) {
     m_LockFreeQueue.enqueue(a_Timer);
     m_ConditionVariable.signal();
@@ -188,6 +188,6 @@ void TimerManager::Add(const Timer& a_Timer) {
 }
 
 //-----------------------------------------------------------------------------
-void TimerManager::Add(const ContextSwitch& a_CS) {
+void TimerManager::AddContextSwitch(const ContextSwitch& a_CS) {
   if (m_ContextSwitchAddedCallback) m_ContextSwitchAddedCallback(a_CS);
 }

--- a/OrbitCore/TimerManager.cpp
+++ b/OrbitCore/TimerManager.cpp
@@ -188,16 +188,6 @@ void TimerManager::Add(const Timer& a_Timer) {
 }
 
 //-----------------------------------------------------------------------------
-void TimerManager::Add(const Message& a_Message) {
-  if (m_IsRecording || m_IsClient) {
-    m_LockFreeMessageQueue.enqueue(a_Message);
-    m_ConditionVariable.signal();
-    ++m_NumQueuedEntries;
-    ++m_NumQueuedMessages;
-  }
-}
-
-//-----------------------------------------------------------------------------
 void TimerManager::Add(const ContextSwitch& a_CS) {
   if (m_ContextSwitchAddedCallback) m_ContextSwitchAddedCallback(a_CS);
 }

--- a/OrbitCore/TimerManager.cpp
+++ b/OrbitCore/TimerManager.cpp
@@ -179,12 +179,10 @@ void TimerManager::SendTimers() {
 
 //-----------------------------------------------------------------------------
 void TimerManager::AddTimer(const Timer& a_Timer) {
-  if (m_IsRecording) {
-    m_LockFreeQueue.enqueue(a_Timer);
-    m_ConditionVariable.signal();
-    ++m_NumQueuedEntries;
-    ++m_NumQueuedTimers;
-  }
+  m_LockFreeQueue.enqueue(a_Timer);
+  m_ConditionVariable.signal();
+  ++m_NumQueuedEntries;
+  ++m_NumQueuedTimers;
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitCore/TimerManager.h
+++ b/OrbitCore/TimerManager.h
@@ -36,7 +36,6 @@ class TimerManager {
   void StopClient();
 
   void Add(const Timer& a_Timer);
-  void Add(const Message& a_Message);
   void Add(const ContextSwitch& a_CS);
 
   void ConsumeTimers();

--- a/OrbitCore/TimerManager.h
+++ b/OrbitCore/TimerManager.h
@@ -35,8 +35,8 @@ class TimerManager {
   void StartClient();
   void StopClient();
 
-  void Add(const Timer& a_Timer);
-  void Add(const ContextSwitch& a_CS);
+  void AddTimer(const Timer& a_Timer);
+  void AddContextSwitch(const ContextSwitch& a_CS);
 
   void ConsumeTimers();
   void SendTimers();

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -123,26 +123,6 @@ void OrbitApp::SetCommandLineArguments(const std::vector<std::string>& a_Args) {
   }
 }
 
-// Get the horizontal and vertical screen sizes in pixel
-//-----------------------------------------------------------------------------
-void GetDesktopResolution(int& horizontal, int& vertical) {
-#ifdef _WIN32
-  RECT desktop;
-  // Get a handle to the desktop window
-  const HWND hDesktop = GetDesktopWindow();
-  // Get the size of screen to the variable desktop
-  GetWindowRect(hDesktop, &desktop);
-  // The top left corner will have coordinates (0,0)
-  // and the bottom right corner will have coordinates
-  // (horizontal, vertical)
-  horizontal = desktop.right;
-  vertical = desktop.bottom;
-#else
-  UNUSED(horizontal);
-  UNUSED(vertical);
-#endif
-}
-
 //-----------------------------------------------------------------------------
 void OrbitApp::ProcessTimer(const Timer& a_Timer, const std::string&) {
   GCurrentTimeGraph->ProcessTimer(a_Timer);
@@ -335,7 +315,6 @@ void OrbitApp::PostInit() {
   int my_argc = 0;
   glutInit(&my_argc, NULL);
   glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH);
-  GetDesktopResolution(GOrbitApp->m_ScreenRes[0], GOrbitApp->m_ScreenRes[1]);
 
   GOrbitApp->InitializeClientTransactions();
 }

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -150,7 +150,7 @@ void OrbitApp::ProcessHashedSamplingCallStack(CallstackEvent& a_CallStack) {
 
 //-----------------------------------------------------------------------------
 void OrbitApp::ProcessContextSwitch(const ContextSwitch& a_ContextSwitch) {
-  GTimerManager->Add(a_ContextSwitch);
+  GTimerManager->AddContextSwitch(a_ContextSwitch);
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -103,8 +103,6 @@ class OrbitApp final : public CoreApp, public DataViewFactory {
   void UpdateThreadName(uint32_t thread_id,
                         const std::string& thread_name) override;
 
-  int* GetScreenRes() { return m_ScreenRes; }
-
   void RegisterCaptureWindow(class CaptureWindow* a_Capture);
 
   void OnProcessSelected(uint32_t pid);
@@ -278,7 +276,6 @@ class OrbitApp final : public CoreApp, public DataViewFactory {
   std::unique_ptr<LogDataView> m_LogDataView;
 
   CaptureWindow* m_CaptureWindow = nullptr;
-  int m_ScreenRes[2];
   bool m_HasPromptedForUpdate = false;
   bool m_NeedsThawing = false;
   bool m_UnrealEnabled = false;

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -350,7 +350,7 @@ void TimeGraph::AddContextSwitch(const ContextSwitch& a_CS) {
           timer.m_CaptureID = Message::GCaptureID;
           timer.SetType(Timer::CORE_ACTIVITY);
 
-          GTimerManager->Add(timer);
+          GTimerManager->AddTimer(timer);
         }
       }
     }
@@ -374,7 +374,7 @@ void TimeGraph::AddContextSwitch(const ContextSwitch& a_CS) {
           timer.m_CaptureID = Message::GCaptureID;
           timer.SetType(Timer::THREAD_ACTIVITY);
 
-          GTimerManager->Add(timer);
+          GTimerManager->AddTimer(timer);
         }
       }
     }


### PR DESCRIPTION
#### Remove unused OrbitApp::GetScreenRes
#### Remove TimerManager::Add(const Message& a_Message)
#### Rename overloaded TimerManager::Add to AddTimer,AddContextSwitch
#### Do not condition TimerManager::AddTimer with m_IsRecording
Events are still coming from the service after the client has sent the
`Msg_StopCapture` message.
Bug: http://b/157973915