### PR TITLE
Discard events early by ignoring events that would draw over the previously drawn event

### DIFF
--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -135,12 +135,10 @@ void GpuTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
 
   std::vector<std::shared_ptr<TimerChain>> chains_by_depth = GetTimers();
 
-  // We minimize overdraw by recording the previous span that we know to be drawn and
-  // don't overdraw this with any of the timer events that fall into the same span.
-  // When zoomed in a lot, this typically has no effect, as the timeslices are disjoint
-  // and no timer falls entirely into a span that was already drawn. However, when
-  // zoomed out and many events fall onto a span that is a single pixel wide, many will
-  // fall onto the same pixel and thus many will be discarded.
+  // We minimize overdraw when drawing lines for small events by discarding events
+  // that would just draw over an already drawn line. When zoomed in enough that all 
+  // events are drawn as boxes, this has no effect. When zoomed out, many events
+  // will be discarded quickly.
   uint64_t min_ignore = std::numeric_limits<uint64_t>::max();
   uint64_t max_ignore = std::numeric_limits<uint64_t>::min();
 

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -197,9 +197,6 @@ void GpuTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
           SetTimesliceText(timer, elapsed_us, min_x, &text_box);
         }
         batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, &text_box);
-        // For boxes, we can ignore the entire timespan from start to end.
-        min_ignore = timer.m_Start;
-        max_ignore = timer.m_End;
       } else {
         auto type = PickingID::LINE;
         batcher->AddVerticalLine(pos, size[1], z, color, type, &text_box);

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -146,6 +146,7 @@ void GpuTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
 
   uint64_t pixel_delta_in_ticks = 
     static_cast<uint64_t>(TicksFromMicroseconds(time_graph_->GetTimeWindowUs())) / canvas->getWidth();
+  uint64_t min_timegraph_tick = time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
 
   for (auto& text_boxes : chains_by_depth) {
     if (text_boxes == nullptr) continue;
@@ -202,7 +203,6 @@ void GpuTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
         batcher->AddVerticalLine(pos, size[1], z, color, type, &text_box);
         // For lines, we can ignore the entire pixel into which this event falls. We align
         // this precisely on the pixel x-coordinate of the current line being drawn (in ticks).
-        uint64_t min_timegraph_tick = time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
         min_ignore =  min_timegraph_tick + 
           ((timer.m_Start - min_timegraph_tick) / pixel_delta_in_ticks) * pixel_delta_in_ticks;
         max_ignore = min_ignore + pixel_delta_in_ticks;

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -200,8 +200,11 @@ void GpuTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
       } else {
         auto type = PickingID::LINE;
         batcher->AddVerticalLine(pos, size[1], z, color, type, &text_box);
-        // For lines, we can ignore the entire pixel into which this event falls.
-        min_ignore = time_graph_->GetTickFromWorld(std::floor(pos[0]));
+        // For lines, we can ignore the entire pixel into which this event falls. We align
+        // this precisely on the pixel x-coordinate of the current line being drawn (in ticks).
+        uint64_t min_timegraph_tick = time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
+        min_ignore =  min_timegraph_tick + 
+          ((timer.m_Start - min_timegraph_tick) / pixel_delta_in_ticks) * pixel_delta_in_ticks;
         max_ignore = min_ignore + pixel_delta_in_ticks;
       }
     }

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -134,11 +134,30 @@ void GpuTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
   bool is_collapsed = collapse_toggle_.IsCollapsed() && (depth_ > 1);
 
   std::vector<std::shared_ptr<TimerChain>> chains_by_depth = GetTimers();
+
+  // We minimize overdraw by recording the previous span that we know to be drawn and
+  // don't overdraw this with any of the timer events that fall into the same span.
+  // When zoomed in a lot, this typically has no effect, as the timeslices are disjoint
+  // and no timer falls entirely into a span that was already drawn. However, when
+  // zoomed out and many events fall onto a span that is a single pixel wide, many will
+  // fall onto the same pixel and thus many will be discarded.
+  uint64_t min_ignore = std::numeric_limits<uint64_t>::max();
+  uint64_t max_ignore = std::numeric_limits<uint64_t>::min();
+
+  uint64_t pixel_delta_in_ticks = 
+    static_cast<uint64_t>(TicksFromMicroseconds(time_graph_->GetTimeWindowUs())) / canvas->getWidth();
+
   for (auto& text_boxes : chains_by_depth) {
     if (text_boxes == nullptr) continue;
+    // We have to reset this when we go to the next depth, as otherwise we would miss
+    // drawing events that should be drawn.
+    min_ignore = std::numeric_limits<uint64_t>::max();
+    max_ignore = std::numeric_limits<uint64_t>::min();
+    
     for (TextBox& text_box : *text_boxes) {
       const Timer& timer = text_box.GetTimer();
       if (min_tick > timer.m_End || max_tick < timer.m_Start) continue;
+      if (timer.m_Start >= min_ignore && timer.m_End <= max_ignore) continue;
 
       UpdateDepth(timer.m_Depth + 1);
       double start_us = time_graph_->GetUsFromTick(timer.m_Start);
@@ -178,9 +197,15 @@ void GpuTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
           SetTimesliceText(timer, elapsed_us, min_x, &text_box);
         }
         batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, &text_box);
+        // For boxes, we can ignore the entire timespan from start to end.
+        min_ignore = timer.m_Start;
+        max_ignore = timer.m_End;
       } else {
         auto type = PickingID::LINE;
         batcher->AddVerticalLine(pos, size[1], z, color, type, &text_box);
+        // For lines, we can ignore the entire pixel into which this event falls.
+        min_ignore = time_graph_->GetTickFromWorld(std::floor(pos[0]));
+        max_ignore = min_ignore + pixel_delta_in_ticks;
       }
     }
   }

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -57,12 +57,10 @@ void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
 
   std::vector<std::shared_ptr<TimerChain>> chains_by_depth = GetTimers();
 
-  // We minimize overdraw by recording the previous span that we know to be drawn and
-  // don't overdraw this with any of the timer events that fall into the same span.
-  // When zoomed in a lot, this typically has no effect, as the timeslices are disjoint
-  // and no timer falls entirely into a span that was already drawn. However, when
-  // zoomed out and many events fall onto a span that is a single pixel wide, many will
-  // fall onto the same pixel and thus many will be discarded.
+  // We minimize overdraw when drawing lines for small events by discarding events
+  // that would just draw over an already drawn line. When zoomed in enough that all 
+  // events are drawn as boxes, this has no effect. When zoomed out, many events
+  // will be discarded quickly.
   uint64_t min_ignore = std::numeric_limits<uint64_t>::max();
   uint64_t max_ignore = std::numeric_limits<uint64_t>::min();
 

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -113,8 +113,11 @@ void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
       } else {
         auto type = PickingID::LINE;
         batcher->AddVerticalLine(pos, size[1], z, color, type, &text_box);
-        // For lines, we can ignore the entire pixel into which this event falls.
-        min_ignore = time_graph_->GetTickFromWorld(std::floor(pos[0]));
+        // For lines, we can ignore the entire pixel into which this event falls. We align
+        // this precisely on the pixel x-coordinate of the current line being drawn (in ticks).
+        uint64_t min_timegraph_tick = time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
+        min_ignore =  min_timegraph_tick + 
+          ((timer.m_Start - min_timegraph_tick) / pixel_delta_in_ticks) * pixel_delta_in_ticks;
         max_ignore = min_ignore + pixel_delta_in_ticks;
       }
     }

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -68,6 +68,7 @@ void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
 
   uint64_t pixel_delta_in_ticks = 
     static_cast<uint64_t>(TicksFromMicroseconds(time_graph_->GetTimeWindowUs())) / canvas->getWidth();
+  uint64_t min_timegraph_tick = time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
 
   for (std::shared_ptr<TimerChain>& timer_chain : chains_by_depth) {
     if (timer_chain == nullptr) continue;
@@ -115,7 +116,6 @@ void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
         batcher->AddVerticalLine(pos, size[1], z, color, type, &text_box);
         // For lines, we can ignore the entire pixel into which this event falls. We align
         // this precisely on the pixel x-coordinate of the current line being drawn (in ticks).
-        uint64_t min_timegraph_tick = time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
         min_ignore =  min_timegraph_tick + 
           ((timer.m_Start - min_timegraph_tick) / pixel_delta_in_ticks) * pixel_delta_in_ticks;
         max_ignore = min_ignore + pixel_delta_in_ticks;

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -110,9 +110,6 @@ void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
 
       if (is_visible_width) {
         batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, &text_box);
-        // For boxes, we can ignore the entire timespan from start to end.
-        min_ignore = timer.m_Start;
-        max_ignore = timer.m_End; 
       } else {
         auto type = PickingID::LINE;
         batcher->AddVerticalLine(pos, size[1], z, color, type, &text_box);

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -221,9 +221,6 @@ void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
           SetTimesliceText(timer, elapsed_us, min_x, &text_box);
         }
         batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, &text_box);
-        // For boxes, we can ignore the entire timespan from start to end.
-        min_ignore = timer.m_Start;
-        max_ignore = timer.m_End;
       } else {
         auto type = PickingID::LINE;
         batcher->AddVerticalLine(pos, size[1], z, color, type, &text_box);

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -165,11 +165,30 @@ void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
   }
 
   std::vector<std::shared_ptr<TimerChain>> chains_by_depth = GetTimers();
+
+  // We minimize overdraw by recording the previous span that we know to be drawn and
+  // don't overdraw this with any of the timer events that fall into the same span.
+  // When zoomed in a lot, this typically has no effect, as the timeslices are disjoint
+  // and no timer falls entirely into a span that was already drawn. However, when
+  // zoomed out and many events fall onto a span that is a single pixel wide, many will
+  // fall onto the same pixel and thus many will be discarded.
+  uint64_t min_ignore = std::numeric_limits<uint64_t>::max();
+  uint64_t max_ignore = std::numeric_limits<uint64_t>::min();
+
+  uint64_t pixel_delta = 
+    static_cast<uint64_t>(TicksFromMicroseconds(time_graph_->GetTimeWindowUs())) / canvas->getWidth();
+
   for (auto& text_boxes : chains_by_depth) {
     if (text_boxes == nullptr) continue;
+    // We have to reset this when we go to the next depth, as otherwise we would miss
+    // drawing events that should be drawn.
+    min_ignore = std::numeric_limits<uint64_t>::max();
+    max_ignore = std::numeric_limits<uint64_t>::min();
+    
     for (TextBox& text_box : *text_boxes) {
       const Timer& timer = text_box.GetTimer();
       if (min_tick > timer.m_End || max_tick < timer.m_Start) continue;
+      if (timer.m_Start >= min_ignore && timer.m_End <= max_ignore) continue;
 
       UpdateDepth(timer.m_Depth + 1);
       double start_us = time_graph_->GetUsFromTick(timer.m_Start);
@@ -202,9 +221,16 @@ void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
           SetTimesliceText(timer, elapsed_us, min_x, &text_box);
         }
         batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, &text_box);
+        // For boxes, we can ignore the entire timespan from start to end.
+        min_ignore = timer.m_Start;
+        max_ignore = timer.m_End;
       } else {
         auto type = PickingID::LINE;
         batcher->AddVerticalLine(pos, size[1], z, color, type, &text_box);
+        // For lines, we can ignore the entire pixel into which this event falls.
+        min_ignore = time_graph_->GetTickFromWorld(std::floor(pos[0]));
+        max_ignore = min_ignore + pixel_delta;
+
       }
     }
   }

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -177,6 +177,7 @@ void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
 
   uint64_t pixel_delta_in_ticks =
     static_cast<uint64_t>(TicksFromMicroseconds(time_graph_->GetTimeWindowUs())) / canvas->getWidth();
+  uint64_t min_timegraph_tick = time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
 
   for (auto& text_boxes : chains_by_depth) {
     if (text_boxes == nullptr) continue;
@@ -225,7 +226,6 @@ void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
         auto type = PickingID::LINE;
         batcher->AddVerticalLine(pos, size[1], z, color, type, &text_box);
         // For lines, we can ignore the entire pixel into which this event falls.
-        uint64_t min_timegraph_tick = time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
         min_ignore = min_timegraph_tick +
           ((timer.m_Start - min_timegraph_tick)/pixel_delta_in_ticks) * pixel_delta_in_ticks;
         max_ignore = min_ignore + pixel_delta_in_ticks;

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -166,12 +166,10 @@ void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
 
   std::vector<std::shared_ptr<TimerChain>> chains_by_depth = GetTimers();
 
-  // We minimize overdraw by recording the previous span that we know to be drawn and
-  // don't overdraw this with any of the timer events that fall into the same span.
-  // When zoomed in a lot, this typically has no effect, as the timeslices are disjoint
-  // and no timer falls entirely into a span that was already drawn. However, when
-  // zoomed out and many events fall onto a span that is a single pixel wide, many will
-  // fall onto the same pixel and thus many will be discarded.
+  // We minimize overdraw when drawing lines for small events by discarding events
+  // that would just draw over an already drawn line. When zoomed in enough that all 
+  // events are drawn as boxes, this has no effect. When zoomed out, many events
+  // will be discarded quickly.
   uint64_t min_ignore = std::numeric_limits<uint64_t>::max();
   uint64_t max_ignore = std::numeric_limits<uint64_t>::min();
 

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -175,7 +175,7 @@ void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
   uint64_t min_ignore = std::numeric_limits<uint64_t>::max();
   uint64_t max_ignore = std::numeric_limits<uint64_t>::min();
 
-  uint64_t pixel_delta = 
+  uint64_t pixel_delta_in_ticks =
     static_cast<uint64_t>(TicksFromMicroseconds(time_graph_->GetTimeWindowUs())) / canvas->getWidth();
 
   for (auto& text_boxes : chains_by_depth) {
@@ -225,9 +225,10 @@ void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
         auto type = PickingID::LINE;
         batcher->AddVerticalLine(pos, size[1], z, color, type, &text_box);
         // For lines, we can ignore the entire pixel into which this event falls.
-        min_ignore = time_graph_->GetTickFromWorld(std::floor(pos[0]));
-        max_ignore = min_ignore + pixel_delta;
-
+        uint64_t min_timegraph_tick = time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
+        min_ignore = min_timegraph_tick +
+          ((timer.m_Start - min_timegraph_tick)/pixel_delta_in_ticks) * pixel_delta_in_ticks;
+        max_ignore = min_ignore + pixel_delta_in_ticks;
       }
     }
   }


### PR DESCRIPTION
For every event that we draw, we record the min and max of the drawn area (in ticks) to quickly discard any following events that would draw over the same area. This dramatically reduces overdraw, in particular for many successive events that would only be drawn as a single vertical line (in this case these often fall onto the same pixel). 

Please carefully check if my coordinate computations are correct, I checked visually by taking screenshots with / without my changes. There are some small differences at the pixel level (I don't think they matter, but we can look into why they occur). 

For a capture that spans roughly a single capture window and has ~100k instrumentation events, UpdatePrimitives time goes from ~18ms to 3.1ms. 

For longer captures, the differences is less pronounced as we still run through all events and thus most of the time is spent discarding events that do not fall into the current time window.