### PR TITLE
Add log file for UI

### DIFF
--- a/OrbitBase/CMakeLists.txt
+++ b/OrbitBase/CMakeLists.txt
@@ -25,6 +25,7 @@ target_sources(OrbitBase PRIVATE
         include/OrbitBase/SafeStrerror.h)
 
 target_sources(OrbitBase PRIVATE
+        Logging.cpp
         MainThreadExecutor.cpp
         SafeStrerror.cpp)
 

--- a/OrbitBase/Logging.cpp
+++ b/OrbitBase/Logging.cpp
@@ -1,0 +1,12 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <OrbitBase/Logging.h>
+
+std::ofstream log_file;
+
+void InitLogFile(const std::string& path) {
+  CHECK(!log_file.is_open());
+  log_file.open(path, std::ofstream::out);
+}

--- a/OrbitBase/Logging.cpp
+++ b/OrbitBase/Logging.cpp
@@ -4,9 +4,19 @@
 
 #include <OrbitBase/Logging.h>
 
+static absl::Mutex log_file_mutex;
 std::ofstream log_file;
 
 void InitLogFile(const std::string& path) {
+  absl::MutexLock lock(&log_file_mutex);
   CHECK(!log_file.is_open());
   log_file.open(path, std::ofstream::out);
+}
+
+void LogToFile(const std::string& message) {
+  absl::MutexLock lock(&log_file_mutex);
+  if (log_file.is_open()) {
+    log_file << message;
+    log_file.flush();
+  }
 }

--- a/OrbitBase/include/OrbitBase/Logging.h
+++ b/OrbitBase/include/OrbitBase/Logging.h
@@ -14,6 +14,7 @@
 #endif
 
 #include "absl/strings/str_format.h"
+#include "absl/synchronization/mutex.h"
 
 #ifdef __clang__
 #pragma clang diagnostic push
@@ -80,6 +81,7 @@
 
 extern std::ofstream log_file;
 void InitLogFile(const std::string& path);
+void LogToFile(const std::string& message);
 
 // Internal.
 #if defined(_WIN32)
@@ -87,18 +89,12 @@ void InitLogFile(const std::string& path);
   do {                              \
     fprintf(stderr, "%s", message); \
     OutputDebugStringA(message);    \
-    if (log_file.is_open()) {       \
-      log_file << message;          \
-      log_file.flush();             \
-    }                               \
+    LogToFile(message);             \
   } while (0)
 #else
 #define PLATFORM_LOG(message) {     \
     fprintf(stderr, "%s", message); \
-    if (log_file.is_open()) {       \
-      log_file << message;          \
-      log_file.flush();             \
-    }                               \
+    LogToFile(message);             \
   }
 #endif
 

--- a/OrbitBase/include/OrbitBase/Logging.h
+++ b/OrbitBase/include/OrbitBase/Logging.h
@@ -7,6 +7,7 @@
 
 #include <cstdio>
 #include <filesystem>
+#include <fstream>
 
 #ifdef _WIN32
 #include <Windows.h>
@@ -77,15 +78,28 @@
   } while (0 && (assertion))
 #endif
 
+extern std::ofstream log_file;
+void InitLogFile(const std::string& path);
+
 // Internal.
 #if defined(_WIN32)
 #define PLATFORM_LOG(message)       \
   do {                              \
     fprintf(stderr, "%s", message); \
     OutputDebugStringA(message);    \
+    if (log_file.is_open()) {       \
+      log_file << message;          \
+      log_file.flush();             \
+    }                               \
   } while (0)
 #else
-#define PLATFORM_LOG(message) fprintf(stderr, "%s", message)
+#define PLATFORM_LOG(message) {     \
+    fprintf(stderr, "%s", message); \
+    if (log_file.is_open()) {       \
+      log_file << message;          \
+      log_file.flush();             \
+    }                               \
+  }
 #endif
 
 #ifdef __clang__

--- a/OrbitCore/Path.cpp
+++ b/OrbitCore/Path.cpp
@@ -283,9 +283,9 @@ std::string Path::GetHome() {
 }
 
 std::string Path::GetLogFilePath() {
-  std::string logsDir = Path::GetAppDataPath() + "logs/";
+  std::string logsDir = Path::JoinPath({Path::GetAppDataPath(), "logs"});
   Path::MakeDir(logsDir);
-  return logsDir + "Orbit.log";
+  return Path::JoinPath({logsDir, "Orbit.log"});
 }
 
 void Path::Dump() {

--- a/OrbitCore/Path.cpp
+++ b/OrbitCore/Path.cpp
@@ -282,6 +282,12 @@ std::string Path::GetHome() {
   return home;
 }
 
+std::string Path::GetLogFilePath() {
+  std::string logsDir = Path::GetAppDataPath() + "logs/";
+  Path::MakeDir(logsDir);
+  return logsDir + "Orbit.log";
+}
+
 void Path::Dump() {
   PRINT_VAR(GetExecutableName());
   PRINT_VAR(GetExecutablePath());

--- a/OrbitCore/Path.h
+++ b/OrbitCore/Path.h
@@ -34,6 +34,7 @@ class Path {
   static std::string GetMainDrive();
   static std::string GetSourceRoot();
   static std::string GetHome();
+  static std::string GetLogFilePath();
   static void Dump();
 
   static std::string GetFileName(const std::string& a_FullName);

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -22,6 +22,7 @@
 #include "Error.h"
 #include "GlutContext.h"
 #include "OpenGlDetect.h"
+#include "OrbitBase/Logging.h"
 #include "OrbitSsh/Context.h"
 #include "OrbitSsh/Credentials.h"
 #include "OrbitSshQt/Session.h"
@@ -213,6 +214,9 @@ FigureOutDeploymentConfiguration() {
 }
 
 int main(int argc, char* argv[]) {
+  const std::string log_file_path = Path::GetLogFilePath();
+  InitLogFile(log_file_path);
+
   absl::SetProgramUsageMessage("CPU Profiler");
   absl::ParseCommandLine(argc, argv);
 #if __linux__


### PR DESCRIPTION
Duplicated log entries to Orbit.log file (`%USERPROFILE%\AppData\Roaming\OrbitProfiler\logs` on Windows and `~/.orbitprofiler/logs` on Linux))