### PR TITLE
Fix crash after unsuccessful deployment

### DIFF
--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -212,6 +212,10 @@ FigureOutDeploymentConfiguration() {
   }
 }
 
+static void DisplayErrorToUser(const QString& message) {
+  QMessageBox::critical(nullptr, QApplication::applicationName(), message);
+}
+
 int main(int argc, char* argv[]) {
   absl::SetProgramUsageMessage("CPU Profiler");
   absl::ParseCommandLine(argc, argv);
@@ -247,8 +251,7 @@ int main(int argc, char* argv[]) {
   const auto open_gl_version = OrbitGl::DetectOpenGlVersion(&glut_context);
 
   if (!open_gl_version) {
-    QMessageBox::critical(
-        nullptr, QApplication::applicationName(),
+    DisplayErrorToUser(
         "OpenGL support was not found. Please make sure you're not trying to "
         "start Orbit in a remote session and make sure you have a recent "
         "graphics driver installed. Then try again!");
@@ -259,8 +262,7 @@ int main(int argc, char* argv[]) {
       open_gl_version->minor);
 
   if (open_gl_version->major < 2) {
-    QMessageBox::critical(
-        nullptr, QApplication::applicationName(),
+    DisplayErrorToUser(
         QString(
             "The minimum required version of OpenGL is 2.0. But this machine "
             "only supports up to version %1.%2. Please make sure you're not "
@@ -281,10 +283,7 @@ int main(int argc, char* argv[]) {
       return 0;
     } else if (result.error() !=
                make_error_code(Error::kUserCanceledServiceDeployment)) {
-      QMessageBox::critical(
-          nullptr,
-          QString("%1 %2").arg(QApplication::applicationName(),
-                               QApplication::applicationVersion()),
+      DisplayErrorToUser(
           QString("An error occurred: %1")
               .arg(QString::fromStdString(result.error().message())));
     }

--- a/OrbitQt/servicedeploymanager.cpp
+++ b/OrbitQt/servicedeploymanager.cpp
@@ -43,10 +43,11 @@ static outcome::result<T> MapError(outcome::result<T> result, Error new_error) {
 
 ServiceDeployManager::ServiceDeployManager(
     DeploymentConfiguration deployment_configuration,
-    OrbitSsh::Credentials credentials, ServiceDeployManager::Ports remote_ports,
-    QObject* parent)
+    OrbitSsh::Context* context, OrbitSsh::Credentials credentials,
+    ServiceDeployManager::Ports remote_ports, QObject* parent)
     : QObject(parent),
       deployment_configuration_(std::move(deployment_configuration)),
+      context_(context),
       credentials_(std::move(credentials)),
       remote_ports_(std::move(remote_ports)) {}
 
@@ -324,10 +325,7 @@ outcome::result<void> ServiceDeployManager::ConnectToServer() {
                          .arg(QString::fromStdString(credentials_.host))
                          .arg(credentials_.port));
 
-  OUTCOME_TRY(context, OrbitSsh::Context::Create());
-  context_ = std::move(context);
-
-  session_.emplace(&context_.value());
+  session_.emplace(context_);
 
   using OrbitSshQt::Session;
   auto quit_handler = ConnectQuitHandler(&session_.value(), &Session::started);

--- a/OrbitQt/servicedeploymanager.h
+++ b/OrbitQt/servicedeploymanager.h
@@ -32,8 +32,8 @@ class ServiceDeployManager : public QObject {
 
   explicit ServiceDeployManager(
       DeploymentConfiguration deployment_configuration,
-      OrbitSsh::Credentials creds, Ports remote_ports,
-      QObject* parent = nullptr);
+      OrbitSsh::Context* context, OrbitSsh::Credentials creds,
+      Ports remote_ports, QObject* parent = nullptr);
 
   outcome::result<Ports> Exec();
   void Shutdown();
@@ -47,9 +47,9 @@ class ServiceDeployManager : public QObject {
   EventLoop loop_;
 
   DeploymentConfiguration deployment_configuration_;
+  OrbitSsh::Context* context_ = nullptr;
   OrbitSsh::Credentials credentials_;
   Ports remote_ports_;
-  std::optional<OrbitSsh::Context> context_;
   std::optional<OrbitSshQt::Session> session_;
   std::optional<OrbitSshQt::Task> orbit_service_task_;
   std::optional<OrbitSshQt::Tunnel> asio_tunnel_;


### PR DESCRIPTION
This moves the ssh context out of servicedeploymanager into main, to fix the crash when setting up another ssh connection. 

This should fix b/158275162

(The first commit, does only some minor refactoring to get rid of duplicate code)