### PR TITLE
Make run.sh and run_service.sh use the relwithdebinfo build.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -5,4 +5,4 @@
 
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-exec $DIR/build_default_release/bin/Orbit
+exec $DIR/build_default_relwithdebinfo/bin/Orbit --local

--- a/run_service.sh
+++ b/run_service.sh
@@ -5,4 +5,4 @@
 
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-exec $DIR/build_default_release/bin/OrbitService
+exec $DIR/build_default_relwithdebinfo/bin/OrbitService


### PR DESCRIPTION
Also, run.sh now runs Orbit with the --local flag.  This was done to facilitate local profiling on Linux, basically a user would call "sudo ./run_service.sh" to start OrbitService locally, and then "./run.sh" to launch Orbit in local mode.