### PR TITLE
Fix VSCode build and launch scripts.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,8 +10,7 @@
       "request": "launch",
       "program": "${workspaceFolder}/build_default_relwithdebinfo/bin/Orbit",
       "args": [
-        "--remote",
-        "127.0.0.1"
+        "--local",
       ],
       "stopAtEntry": false,
       "cwd": "${workspaceFolder}/build_default_relwithdebinfo/bin/",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,7 +7,9 @@
       "command": "cmake",
       "args": [
         "--build",
-        "."
+        ".",
+        "--",
+        "-j16"
       ],
       "options": {
         "cwd": "${workspaceFolder}/build_default_relwithdebinfo"


### PR DESCRIPTION
Remove obsolete --remote flag and replace by --local flag.  Build using -j16.