### PR TITLE
Simplify processing/sending/receiving context switches and Timers

### DIFF
--- a/OrbitCore/ConnectionManager.cpp
+++ b/OrbitCore/ConnectionManager.cpp
@@ -51,7 +51,7 @@ void ConnectionManager::SetupClientCallbacks() {
     uint32_t numTimers = msg.m_Size / sizeof(Timer);
     const Timer* timers = static_cast<const Timer*>(msg.GetData());
     for (uint32_t i = 0; i < numTimers; ++i) {
-      GTimerManager->AddTimer(timers[i]);
+      GCoreApp->ProcessTimer(timers[i]);
     }
   });
 

--- a/OrbitCore/ConnectionManager.cpp
+++ b/OrbitCore/ConnectionManager.cpp
@@ -73,15 +73,6 @@ void ConnectionManager::SetupClientCallbacks() {
     }
   });
 
-  GTcpClient->AddCallback(Msg_ContextSwitches, [=](const Message& msg) {
-    uint32_t num_context_switches = msg.m_Size / sizeof(ContextSwitch);
-    const ContextSwitch* context_switches =
-        static_cast<const ContextSwitch*>(msg.GetData());
-    for (uint32_t i = 0; i < num_context_switches; i++) {
-      GCoreApp->ProcessContextSwitch(context_switches[i]);
-    }
-  });
-
   GTcpClient->AddCallback(Msg_SamplingCallstacks, [=](const Message& msg) {
     std::vector<LinuxCallstackEvent> callstacks;
     DeserializeObjectBinary(msg.GetDataAsString(), callstacks);

--- a/OrbitCore/CoreApp.h
+++ b/OrbitCore/CoreApp.h
@@ -41,8 +41,7 @@ class CoreApp {
                            uint64_t /*a_VirtualAddress*/,
                            const uint8_t* /*a_MachineCode*/,
                            size_t /*a_Size*/) {}
-  virtual void ProcessTimer(const Timer& /*a_Timer*/,
-                            const std::string& /*a_FunctionName*/) {}
+  virtual void ProcessTimer(const Timer& /*timer*/) {}
   virtual void ProcessSamplingCallStack(LinuxCallstackEvent& /*a_CS*/) {}
   virtual void ProcessHashedSamplingCallStack(CallstackEvent& /*a_CallStack*/) {
   }

--- a/OrbitCore/CoreApp.h
+++ b/OrbitCore/CoreApp.h
@@ -46,7 +46,6 @@ class CoreApp {
   virtual void ProcessSamplingCallStack(LinuxCallstackEvent& /*a_CS*/) {}
   virtual void ProcessHashedSamplingCallStack(CallstackEvent& /*a_CallStack*/) {
   }
-  virtual void ProcessContextSwitch(const ContextSwitch& /*a_ContextSwitch*/) {}
   virtual void AddAddressInfo(LinuxAddressInfo /*address_info*/) {}
   virtual void AddKeyAndString(uint64_t /*key*/, std::string_view /*str*/) {}
   virtual void UpdateThreadName(uint32_t /*thread_id*/,

--- a/OrbitCore/LinuxTracingBuffer.h
+++ b/OrbitCore/LinuxTracingBuffer.h
@@ -27,7 +27,6 @@ class LinuxTracingBuffer {
   LinuxTracingBuffer(LinuxTracingBuffer&&) = delete;
   LinuxTracingBuffer& operator=(LinuxTracingBuffer&&) = delete;
 
-  void RecordContextSwitch(ContextSwitch&& context_switch);
   void RecordTimer(Timer&& timer);
   void RecordCallstack(LinuxCallstackEvent&& callstack);
   void RecordHashedCallstack(CallstackEvent&& hashed_callstack);
@@ -39,7 +38,6 @@ class LinuxTracingBuffer {
 
   // These move the content of the corresponding buffer to the output vector.
   // They return true if the buffer was not empty.
-  bool ReadAllContextSwitches(std::vector<ContextSwitch>* out_buffer);
   bool ReadAllTimers(std::vector<Timer>* out_buffer);
   bool ReadAllCallstacks(std::vector<LinuxCallstackEvent>* out_buffer);
   bool ReadAllHashedCallstacks(std::vector<CallstackEvent>* out_buffer);
@@ -51,9 +49,6 @@ class LinuxTracingBuffer {
 
  private:
   // Buffering data to send large messages instead of small ones.
-  absl::Mutex context_switch_buffer_mutex_;
-  std::vector<ContextSwitch> context_switch_buffer_;
-
   absl::Mutex timer_buffer_mutex_;
   std::vector<Timer> timer_buffer_;
 

--- a/OrbitCore/LinuxTracingBufferTest.cpp
+++ b/OrbitCore/LinuxTracingBufferTest.cpp
@@ -12,10 +12,6 @@
 TEST(LinuxTracingBuffer, Empty) {
   LinuxTracingBuffer buffer;
 
-  std::vector<ContextSwitch> context_switches;
-  EXPECT_FALSE(buffer.ReadAllContextSwitches(&context_switches));
-  EXPECT_TRUE(context_switches.empty());
-
   std::vector<Timer> timers;
   EXPECT_FALSE(buffer.ReadAllTimers(&timers));
   EXPECT_TRUE(timers.empty());
@@ -27,77 +23,6 @@ TEST(LinuxTracingBuffer, Empty) {
   std::vector<CallstackEvent> hashed_callstacks;
   EXPECT_FALSE(buffer.ReadAllHashedCallstacks(&hashed_callstacks));
   EXPECT_TRUE(hashed_callstacks.empty());
-}
-
-TEST(LinuxTracingBuffer, ContextSwitches) {
-  LinuxTracingBuffer buffer;
-
-  {
-    ContextSwitch context_switch;
-    context_switch.m_ProcessId = 1;
-    context_switch.m_ThreadId = 1;
-    context_switch.m_Type = ContextSwitch::Out;
-    context_switch.m_Time = 87;
-    context_switch.m_ProcessorIndex = 7;
-    context_switch.m_ProcessorNumber = 8;
-
-    buffer.RecordContextSwitch(std::move(context_switch));
-  }
-
-  {
-    ContextSwitch context_switch;
-    context_switch.m_ProcessId = 1;
-    context_switch.m_ThreadId = 2;
-    context_switch.m_Type = ContextSwitch::In;
-    context_switch.m_Time = 78;
-    context_switch.m_ProcessorIndex = 17;
-    context_switch.m_ProcessorNumber = 18;
-
-    buffer.RecordContextSwitch(std::move(context_switch));
-  }
-
-  std::vector<ContextSwitch> context_switches;
-  EXPECT_TRUE(buffer.ReadAllContextSwitches(&context_switches));
-  EXPECT_FALSE(buffer.ReadAllContextSwitches(&context_switches));
-
-  EXPECT_EQ(context_switches.size(), 2);
-
-  EXPECT_EQ(context_switches[0].m_ProcessId, 1);
-  EXPECT_EQ(context_switches[0].m_ThreadId, 1);
-  EXPECT_EQ(context_switches[0].m_Time, 87);
-  EXPECT_EQ(context_switches[0].m_ProcessorIndex, 7);
-  EXPECT_EQ(context_switches[0].m_ProcessorNumber, 8);
-
-  EXPECT_EQ(context_switches[1].m_ProcessId, 1);
-  EXPECT_EQ(context_switches[1].m_ThreadId, 2);
-  EXPECT_EQ(context_switches[1].m_Time, 78);
-  EXPECT_EQ(context_switches[1].m_ProcessorIndex, 17);
-  EXPECT_EQ(context_switches[1].m_ProcessorNumber, 18);
-
-  {
-    ContextSwitch context_switch;
-    context_switch.m_ProcessId = 11;
-    context_switch.m_ThreadId = 12;
-    context_switch.m_Type = ContextSwitch::Out;
-    context_switch.m_Time = 187;
-    context_switch.m_ProcessorIndex = 27;
-    context_switch.m_ProcessorNumber = 28;
-
-    buffer.RecordContextSwitch(std::move(context_switch));
-  }
-
-  // Check that the vector is reset, even if it was not empty.
-  EXPECT_TRUE(buffer.ReadAllContextSwitches(&context_switches));
-  EXPECT_EQ(context_switches.size(), 1);
-
-  EXPECT_FALSE(buffer.ReadAllContextSwitches(&context_switches));
-  EXPECT_EQ(context_switches.size(), 1);
-
-  EXPECT_EQ(context_switches[0].m_ProcessId, 11);
-  EXPECT_EQ(context_switches[0].m_ThreadId, 12);
-  EXPECT_EQ(context_switches[0].m_Time, 187);
-  EXPECT_EQ(context_switches[0].m_ProcessorIndex, 27);
-  EXPECT_EQ(context_switches[0].m_ProcessorNumber, 28);
 }
 
 TEST(LinuxTracingBuffer, Timers) {
@@ -428,18 +353,6 @@ TEST(LinuxTracingBuffer, Reset) {
   LinuxTracingBuffer buffer;
 
   {
-    ContextSwitch context_switch;
-    context_switch.m_ProcessId = 1;
-    context_switch.m_ThreadId = 1;
-    context_switch.m_Type = ContextSwitch::Out;
-    context_switch.m_Time = 87;
-    context_switch.m_ProcessorIndex = 7;
-    context_switch.m_ProcessorNumber = 8;
-
-    buffer.RecordContextSwitch(std::move(context_switch));
-  }
-
-  {
     Timer timer;
     timer.m_PID = 1;
     timer.m_TID = 1;
@@ -476,9 +389,6 @@ TEST(LinuxTracingBuffer, Reset) {
   buffer.RecordThreadName(42, "thread42");
 
   buffer.Reset();
-
-  std::vector<ContextSwitch> context_switches;
-  EXPECT_FALSE(buffer.ReadAllContextSwitches(&context_switches));
 
   std::vector<Timer> timers;
   EXPECT_FALSE(buffer.ReadAllTimers(&timers));

--- a/OrbitCore/LinuxTracingHandler.cpp
+++ b/OrbitCore/LinuxTracingHandler.cpp
@@ -70,32 +70,8 @@ void LinuxTracingHandler::OnSchedulingSlice(
   timer.m_Processor = static_cast<int8_t>(scheduling_slice.GetCore());
   timer.m_Depth = timer.m_Processor;
   timer.SetType(Timer::CORE_ACTIVITY);
-  
+
   tracing_buffer_->RecordTimer(std::move(timer));
-}
-
-void LinuxTracingHandler::OnContextSwitchIn(
-    const LinuxTracing::ContextSwitchIn& context_switch_in) {
-  ContextSwitch context_switch(ContextSwitch::In);
-  context_switch.m_ProcessId = context_switch_in.GetPid();
-  context_switch.m_ThreadId = context_switch_in.GetTid();
-  context_switch.m_Time = context_switch_in.GetTimestampNs();
-  context_switch.m_ProcessorIndex = context_switch_in.GetCore();
-  context_switch.m_ProcessorNumber = context_switch_in.GetCore();
-
-  tracing_buffer_->RecordContextSwitch(std::move(context_switch));
-}
-
-void LinuxTracingHandler::OnContextSwitchOut(
-    const LinuxTracing::ContextSwitchOut& context_switch_out) {
-  ContextSwitch context_switch(ContextSwitch::Out);
-  context_switch.m_ProcessId = context_switch_out.GetPid();
-  context_switch.m_ThreadId = context_switch_out.GetTid();
-  context_switch.m_Time = context_switch_out.GetTimestampNs();
-  context_switch.m_ProcessorIndex = context_switch_out.GetCore();
-  context_switch.m_ProcessorNumber = context_switch_out.GetCore();
-
-  tracing_buffer_->RecordContextSwitch(std::move(context_switch));
 }
 
 void LinuxTracingHandler::OnCallstack(

--- a/OrbitCore/LinuxTracingHandler.cpp
+++ b/OrbitCore/LinuxTracingHandler.cpp
@@ -60,6 +60,20 @@ void LinuxTracingHandler::OnTid(pid_t /*tid*/) {
   // Do nothing.
 }
 
+void LinuxTracingHandler::OnSchedulingSlice(
+    const LinuxTracing::SchedulingSlice& scheduling_slice) {
+  Timer timer;
+  timer.m_Start = scheduling_slice.GetInTimestampNs();
+  timer.m_End = scheduling_slice.GetOutTimestampNs();
+  timer.m_PID = scheduling_slice.GetPid();
+  timer.m_TID = scheduling_slice.GetTid();
+  timer.m_Processor = static_cast<int8_t>(scheduling_slice.GetCore());
+  timer.m_Depth = timer.m_Processor;
+  timer.SetType(Timer::CORE_ACTIVITY);
+  
+  tracing_buffer_->RecordTimer(std::move(timer));
+}
+
 void LinuxTracingHandler::OnContextSwitchIn(
     const LinuxTracing::ContextSwitchIn& context_switch_in) {
   ContextSwitch context_switch(ContextSwitch::In);

--- a/OrbitCore/LinuxTracingHandler.h
+++ b/OrbitCore/LinuxTracingHandler.h
@@ -38,10 +38,6 @@ class LinuxTracingHandler : public LinuxTracing::TracerListener {
   void OnTid(pid_t tid) override;
   void OnSchedulingSlice(
       const LinuxTracing::SchedulingSlice& scheduling_slice) override;
-  void OnContextSwitchIn(
-      const LinuxTracing::ContextSwitchIn& context_switch_in) override;
-  void OnContextSwitchOut(
-      const LinuxTracing::ContextSwitchOut& context_switch_out) override;
   void OnCallstack(const LinuxTracing::Callstack& callstack) override;
   void OnFunctionCall(const LinuxTracing::FunctionCall& function_call) override;
   void OnGpuJob(const LinuxTracing::GpuJob& gpu_job) override;

--- a/OrbitCore/LinuxTracingHandler.h
+++ b/OrbitCore/LinuxTracingHandler.h
@@ -36,6 +36,8 @@ class LinuxTracingHandler : public LinuxTracing::TracerListener {
   void Stop();
 
   void OnTid(pid_t tid) override;
+  void OnSchedulingSlice(
+      const LinuxTracing::SchedulingSlice& scheduling_slice) override;
   void OnContextSwitchIn(
       const LinuxTracing::ContextSwitchIn& context_switch_in) override;
   void OnContextSwitchOut(

--- a/OrbitCore/Message.h
+++ b/OrbitCore/Message.h
@@ -63,7 +63,6 @@ enum MessageType : int16_t {
   Msg_SamplingCallstack,
   Msg_TimerCallstack,
   Msg_RemoteSelectedFunctionsMap,
-  Msg_ContextSwitches,
   Msg_SamplingCallstacks,
   Msg_SamplingHashedCallstacks,
   Msg_KeysAndStrings,

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -149,11 +149,6 @@ void OrbitApp::ProcessHashedSamplingCallStack(CallstackEvent& a_CallStack) {
 }
 
 //-----------------------------------------------------------------------------
-void OrbitApp::ProcessContextSwitch(const ContextSwitch& a_ContextSwitch) {
-  GTimerManager->AddContextSwitch(a_ContextSwitch);
-}
-
-//-----------------------------------------------------------------------------
 void OrbitApp::AddAddressInfo(LinuxAddressInfo address_info) {
   uint64_t address = address_info.address;
   Capture::GAddressInfos.emplace(address, std::move(address_info));

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -124,9 +124,8 @@ void OrbitApp::SetCommandLineArguments(const std::vector<std::string>& a_Args) {
 }
 
 //-----------------------------------------------------------------------------
-void OrbitApp::ProcessTimer(const Timer& a_Timer, const std::string&) {
-  GCurrentTimeGraph->ProcessTimer(a_Timer);
-  ++Capture::GFunctionCountMap[a_Timer.m_FunctionAddress];
+void OrbitApp::ProcessTimer(const Timer& timer) {
+  GCurrentTimeGraph->ProcessTimer(timer);
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -96,7 +96,6 @@ class OrbitApp final : public CoreApp, public DataViewFactory {
                     const std::string& a_FunctionName) override;
   void ProcessSamplingCallStack(LinuxCallstackEvent& a_CallStack) override;
   void ProcessHashedSamplingCallStack(CallstackEvent& a_CallStack) override;
-  void ProcessContextSwitch(const ContextSwitch& a_ContextSwitch) override;
   void AddAddressInfo(LinuxAddressInfo address_info) override;
   void AddKeyAndString(uint64_t key, std::string_view str) override;
   void UpdateThreadName(uint32_t thread_id,

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -92,8 +92,7 @@ class OrbitApp final : public CoreApp, public DataViewFactory {
   void RefreshWatch();
   void Disassemble(const std::string& a_FunctionName, uint64_t a_VirtualAddress,
                    const uint8_t* a_MachineCode, size_t a_Size) override;
-  void ProcessTimer(const Timer& a_Timer,
-                    const std::string& a_FunctionName) override;
+  void ProcessTimer(const Timer& timer) override;
   void ProcessSamplingCallStack(LinuxCallstackEvent& a_CallStack) override;
   void ProcessHashedSamplingCallStack(CallstackEvent& a_CallStack) override;
   void AddAddressInfo(LinuxAddressInfo address_info) override;

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -53,8 +53,6 @@ CaptureWindow::CaptureWindow() {
 
   GTimerManager->m_TimerAddedCallbacks.emplace_back(
       [this](Timer& a_Timer) { this->OnTimerAdded(a_Timer); });
-  GTimerManager->m_ContextSwitchAddedCallback =
-      [this](const ContextSwitch& a_CS) { this->OnContextSwitchAdded(a_CS); };
 
   m_HoverDelayMs = 300;
   m_CanHover = false;
@@ -1236,11 +1234,6 @@ void CaptureWindow::RenderTimeBar() {
 //-----------------------------------------------------------------------------
 void CaptureWindow::OnTimerAdded(Timer& a_Timer) {
   time_graph_.ProcessTimer(a_Timer);
-}
-
-//-----------------------------------------------------------------------------
-void CaptureWindow::OnContextSwitchAdded(const ContextSwitch& a_CS) {
-  time_graph_.AddContextSwitch(a_CS);
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -51,9 +51,6 @@ CaptureWindow::CaptureWindow() {
   m_WorldMaxY = 0;
   m_ProcessX = 0;
 
-  GTimerManager->m_TimerAddedCallbacks.emplace_back(
-      [this](Timer& a_Timer) { this->OnTimerAdded(a_Timer); });
-
   m_HoverDelayMs = 300;
   m_CanHover = false;
   m_IsHovering = false;
@@ -1229,11 +1226,6 @@ void CaptureWindow::RenderTimeBar() {
       glEnd();
     }
   }
-}
-
-//-----------------------------------------------------------------------------
-void CaptureWindow::OnTimerAdded(Timer& a_Timer) {
-  time_graph_.ProcessTimer(a_Timer);
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -53,7 +53,6 @@ class CaptureWindow : public GlCanvas {
   void RenderMemTracker();
   void RenderTimeBar();
   void OnTimerAdded(Timer& a_Timer);
-  void OnContextSwitchAdded(const ContextSwitch& a_CS);
   void ResetHoverTimer();
   void SelectTextBox(class TextBox* a_TextBox);
   void OnDrag(float a_Ratio);

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -52,7 +52,6 @@ class CaptureWindow : public GlCanvas {
   void RenderToolbars();
   void RenderMemTracker();
   void RenderTimeBar();
-  void OnTimerAdded(Timer& a_Timer);
   void ResetHoverTimer();
   void SelectTextBox(class TextBox* a_TextBox);
   void OnDrag(float a_Ratio);

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -80,7 +80,6 @@ class TimeGraph {
 
   bool IsVisible(const Timer& a_Timer);
   int GetNumDrawnTextBoxes() { return m_NumDrawnTextBoxes; }
-  void AddContextSwitch(const ContextSwitch& a_CS);
   void SetPickingManager(class PickingManager* a_Manager) {
     m_PickingManager = a_Manager;
   }
@@ -149,11 +148,6 @@ class TimeGraph {
   unsigned int m_MainFrameCounter = 0;
 
   TimeGraphLayout m_Layout;
-
-  std::map<DWORD /*ThreadId*/, std::map<long long, ContextSwitch>>
-      m_ContextSwitchesMap;
-  std::map<DWORD /*CoreId*/, std::map<long long, ContextSwitch>>
-      m_CoreUtilizationMap;
 
   std::map<ThreadID, uint32_t> m_ThreadCountMap;
 

--- a/OrbitLinuxTracing/CMakeLists.txt
+++ b/OrbitLinuxTracing/CMakeLists.txt
@@ -27,6 +27,8 @@ target_sources(OrbitLinuxTracing PUBLIC
         include/OrbitLinuxTracing/TracingOptions.h)
 
 target_sources(OrbitLinuxTracing PRIVATE
+        ContextSwitchManager.cpp
+        ContextSwitchManager.h
         GpuTracepointEventProcessor.h
         GpuTracepointEventProcessor.cpp
         LibunwindstackUnwinder.cpp
@@ -66,6 +68,7 @@ add_executable(OrbitLinuxTracingTests)
 
 if (NOT WIN32)
     target_sources(OrbitLinuxTracingTests PRIVATE
+            ContextSwitchManagerTest.cpp
             PerfEventProcessor2Test.cpp
             UprobesFunctionCallManagerTest.cpp
             UprobesReturnAddressManagerTest.cpp

--- a/OrbitLinuxTracing/ContextSwitchManager.cpp
+++ b/OrbitLinuxTracing/ContextSwitchManager.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ContextSwitchManager.h"
+
+namespace LinuxTracing {
+
+void ContextSwitchManager::ProcessContextSwitchIn(pid_t pid, pid_t tid,
+                                                  uint16_t core,
+                                                  uint64_t timestamp_ns) {
+  // In case of lost out switches, a previous OpenSwitchIn for this core can
+  // be present. Simply overwrite it.
+  open_switches_by_core_.emplace(core, OpenSwitchIn{pid, tid, timestamp_ns});
+}
+
+std::optional<SchedulingSlice> ContextSwitchManager::ProcessContextSwitchOut(
+    pid_t pid, pid_t tid, uint16_t core, uint64_t timestamp_ns) {
+  auto open_switch_it = open_switches_by_core_.find(core);
+  // This can happen at the beginning or in case of lost in switches.
+  if (open_switch_it == open_switches_by_core_.end()) {
+    return std::nullopt;
+  }
+
+  pid_t open_pid = open_switch_it->second.pid;
+  pid_t open_tid = open_switch_it->second.tid;
+  uint64_t open_timestamp_ns = open_switch_it->second.timestamp_ns;
+
+  CHECK(timestamp_ns >= open_timestamp_ns);
+
+  // Remove the OpenSwitchIn for this core before returning,
+  // as it will have been processed.
+  open_switches_by_core_.erase(core);
+
+  // When a context switch out is caused by a thread exiting, the
+  // perf_event_open event has pid and tid set to -1:
+  // in such case, use pid and tid from the OpenSwitchIn.
+  if (pid == -1 || tid == -1) {
+    return SchedulingSlice{open_pid, open_tid, core, open_timestamp_ns,
+                           timestamp_ns};
+  }
+
+  // This can happen in case of lost in/out switches.
+  if (open_pid != pid || open_tid != tid) {
+    return std::nullopt;
+  }
+
+  return SchedulingSlice{pid, tid, core, open_timestamp_ns, timestamp_ns};
+}
+
+}  // namespace LinuxTracing

--- a/OrbitLinuxTracing/ContextSwitchManager.h
+++ b/OrbitLinuxTracing/ContextSwitchManager.h
@@ -1,0 +1,51 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_LINUX_TRACING_CONTEXT_SWITCH_MANAGER_H_
+#define ORBIT_LINUX_TRACING_CONTEXT_SWITCH_MANAGER_H_
+
+#include <OrbitBase/Logging.h>
+#include <OrbitLinuxTracing/Events.h>
+
+#include "absl/container/flat_hash_map.h"
+
+namespace LinuxTracing {
+
+// For each core, keeps the last context switch into a process and matches it
+// with the next context switch away from a process to produce SchedulingSlice
+// events. It assumes that context switches for the same core come in order.
+class ContextSwitchManager {
+ public:
+  ContextSwitchManager() = default;
+
+  ContextSwitchManager(const ContextSwitchManager&) = delete;
+  ContextSwitchManager& operator=(const ContextSwitchManager&) = delete;
+
+  ContextSwitchManager(ContextSwitchManager&&) = default;
+  ContextSwitchManager& operator=(ContextSwitchManager&&) = default;
+
+  void ProcessContextSwitchIn(pid_t pid, pid_t tid, uint16_t core,
+                              uint64_t timestamp_ns);
+
+  std::optional<SchedulingSlice> ProcessContextSwitchOut(pid_t pid, pid_t tid,
+                                                         uint16_t core,
+                                                         uint64_t timestamp_ns);
+
+  void Clear() { open_switches_by_core_.clear(); }
+
+ private:
+  struct OpenSwitchIn {
+    OpenSwitchIn(pid_t pid, pid_t tid, uint64_t timestamp_ns)
+        : pid(pid), tid(tid), timestamp_ns(timestamp_ns) {}
+    pid_t pid;
+    pid_t tid;
+    uint64_t timestamp_ns;
+  };
+
+  absl::flat_hash_map<uint16_t, OpenSwitchIn> open_switches_by_core_;
+};
+
+}  // namespace LinuxTracing
+
+#endif  // ORBIT_LINUX_TRACING_CONTEXT_SWITCH_MANAGER_H_

--- a/OrbitLinuxTracing/ContextSwitchManagerTest.cpp
+++ b/OrbitLinuxTracing/ContextSwitchManagerTest.cpp
@@ -1,0 +1,191 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include "ContextSwitchManager.h"
+
+namespace LinuxTracing {
+
+TEST(ContextSwitchManager, OneCoreMatch) {
+  constexpr pid_t kPid = 42;
+  constexpr pid_t kTid = 43;
+  constexpr uint16_t kCore = 1;
+  std::optional<SchedulingSlice> processed_scheduling_slice;
+  ContextSwitchManager context_switch_manager;
+
+  context_switch_manager.ProcessContextSwitchIn(kPid, kTid, kCore, 100);
+
+  processed_scheduling_slice =
+      context_switch_manager.ProcessContextSwitchOut(kPid, kTid, kCore, 101);
+  ASSERT_TRUE(processed_scheduling_slice.has_value());
+  EXPECT_EQ(processed_scheduling_slice.value().GetPid(), kPid);
+  EXPECT_EQ(processed_scheduling_slice.value().GetTid(), kTid);
+  EXPECT_EQ(processed_scheduling_slice.value().GetCore(), kCore);
+  EXPECT_EQ(processed_scheduling_slice.value().GetInTimestampNs(), 100);
+  EXPECT_EQ(processed_scheduling_slice.value().GetOutTimestampNs(), 101);
+
+  processed_scheduling_slice =
+      context_switch_manager.ProcessContextSwitchOut(kPid, kTid, kCore, 102);
+  ASSERT_FALSE(processed_scheduling_slice.has_value());
+}
+
+TEST(ContextSwitchManager, OneCoreThreadExit) {
+  constexpr pid_t kPid = 42;
+  constexpr pid_t kTid = 43;
+  constexpr uint16_t kCore = 1;
+  std::optional<SchedulingSlice> processed_scheduling_slice;
+  ContextSwitchManager context_switch_manager;
+
+  context_switch_manager.ProcessContextSwitchIn(kPid, kTid, kCore, 100);
+
+  processed_scheduling_slice =
+      context_switch_manager.ProcessContextSwitchOut(-1, -1, kCore, 101);
+  ASSERT_TRUE(processed_scheduling_slice.has_value());
+  EXPECT_EQ(processed_scheduling_slice.value().GetPid(), kPid);
+  EXPECT_EQ(processed_scheduling_slice.value().GetTid(), kTid);
+  EXPECT_EQ(processed_scheduling_slice.value().GetCore(), kCore);
+  EXPECT_EQ(processed_scheduling_slice.value().GetInTimestampNs(), 100);
+  EXPECT_EQ(processed_scheduling_slice.value().GetOutTimestampNs(), 101);
+
+  processed_scheduling_slice =
+      context_switch_manager.ProcessContextSwitchOut(kPid, kTid, kCore, 102);
+  ASSERT_FALSE(processed_scheduling_slice.has_value());
+}
+
+TEST(ContextSwitchManager, OneCoreInMissing) {
+  constexpr pid_t kPid = 42;
+  constexpr pid_t kTid = 43;
+  constexpr uint16_t kCore = 1;
+  std::optional<SchedulingSlice> processed_scheduling_slice;
+  ContextSwitchManager context_switch_manager;
+
+  processed_scheduling_slice =
+      context_switch_manager.ProcessContextSwitchOut(kPid, kTid, kCore, 101);
+  ASSERT_FALSE(processed_scheduling_slice.has_value());
+}
+
+TEST(ContextSwitchManager, OneCoreMismatch) {
+  constexpr pid_t kPid = 42;
+  constexpr pid_t kTid = 43;
+  constexpr uint16_t kCore = 1;
+  std::optional<SchedulingSlice> processed_scheduling_slice;
+  ContextSwitchManager context_switch_manager;
+
+  context_switch_manager.ProcessContextSwitchIn(kPid, kTid, kCore, 100);
+
+  processed_scheduling_slice =
+      context_switch_manager.ProcessContextSwitchOut(kPid, 77, kCore, 101);
+  ASSERT_FALSE(processed_scheduling_slice.has_value());
+}
+
+TEST(ContextSwitchManager, OneCoreTwoMatches) {
+  constexpr pid_t kPid1 = 42;
+  constexpr pid_t kTid1 = 43;
+  constexpr pid_t kPid2 = 52;
+  constexpr pid_t kTid2 = 53;
+  constexpr uint16_t kCore = 1;
+  std::optional<SchedulingSlice> processed_scheduling_slice;
+  ContextSwitchManager context_switch_manager;
+
+  context_switch_manager.ProcessContextSwitchIn(kPid1, kTid1, kCore, 100);
+
+  processed_scheduling_slice =
+      context_switch_manager.ProcessContextSwitchOut(kPid1, kTid1, kCore, 101);
+  ASSERT_TRUE(processed_scheduling_slice.has_value());
+  EXPECT_EQ(processed_scheduling_slice.value().GetPid(), kPid1);
+  EXPECT_EQ(processed_scheduling_slice.value().GetTid(), kTid1);
+  EXPECT_EQ(processed_scheduling_slice.value().GetCore(), kCore);
+  EXPECT_EQ(processed_scheduling_slice.value().GetInTimestampNs(), 100);
+  EXPECT_EQ(processed_scheduling_slice.value().GetOutTimestampNs(), 101);
+
+  context_switch_manager.ProcessContextSwitchIn(kPid2, kTid2, kCore, 102);
+
+  processed_scheduling_slice =
+      context_switch_manager.ProcessContextSwitchOut(kPid2, kTid2, kCore, 103);
+  ASSERT_TRUE(processed_scheduling_slice.has_value());
+  EXPECT_EQ(processed_scheduling_slice.value().GetPid(), kPid2);
+  EXPECT_EQ(processed_scheduling_slice.value().GetTid(), kTid2);
+  EXPECT_EQ(processed_scheduling_slice.value().GetCore(), kCore);
+  EXPECT_EQ(processed_scheduling_slice.value().GetInTimestampNs(), 102);
+  EXPECT_EQ(processed_scheduling_slice.value().GetOutTimestampNs(), 103);
+
+  processed_scheduling_slice =
+      context_switch_manager.ProcessContextSwitchOut(kPid2, kTid2, kCore, 104);
+  ASSERT_FALSE(processed_scheduling_slice.has_value());
+}
+
+TEST(ContextSwitchManager, TwoCoresMatches) {
+  constexpr pid_t kPid1 = 42;
+  constexpr pid_t kTid1 = 43;
+  constexpr uint16_t kCore1 = 1;
+  constexpr pid_t kPid2 = 52;
+  constexpr pid_t kTid2 = 53;
+  constexpr uint16_t kCore2 = 2;
+  std::optional<SchedulingSlice> processed_scheduling_slice;
+  ContextSwitchManager context_switch_manager;
+
+  context_switch_manager.ProcessContextSwitchIn(kPid1, kTid1, kCore1, 100);
+
+  context_switch_manager.ProcessContextSwitchIn(kPid2, kTid2, kCore2, 101);
+
+  processed_scheduling_slice =
+      context_switch_manager.ProcessContextSwitchOut(kPid2, kTid2, kCore2, 103);
+  ASSERT_TRUE(processed_scheduling_slice.has_value());
+  EXPECT_EQ(processed_scheduling_slice.value().GetPid(), kPid2);
+  EXPECT_EQ(processed_scheduling_slice.value().GetTid(), kTid2);
+  EXPECT_EQ(processed_scheduling_slice.value().GetCore(), kCore2);
+  EXPECT_EQ(processed_scheduling_slice.value().GetInTimestampNs(), 101);
+  EXPECT_EQ(processed_scheduling_slice.value().GetOutTimestampNs(), 103);
+
+  processed_scheduling_slice =
+      context_switch_manager.ProcessContextSwitchOut(kPid1, kTid1, kCore1, 102);
+  ASSERT_TRUE(processed_scheduling_slice.has_value());
+  EXPECT_EQ(processed_scheduling_slice.value().GetPid(), kPid1);
+  EXPECT_EQ(processed_scheduling_slice.value().GetTid(), kTid1);
+  EXPECT_EQ(processed_scheduling_slice.value().GetCore(), kCore1);
+  EXPECT_EQ(processed_scheduling_slice.value().GetInTimestampNs(), 100);
+  EXPECT_EQ(processed_scheduling_slice.value().GetOutTimestampNs(), 102);
+
+  processed_scheduling_slice =
+      context_switch_manager.ProcessContextSwitchOut(kPid1, kTid1, kCore1, 104);
+  ASSERT_FALSE(processed_scheduling_slice.has_value());
+
+  processed_scheduling_slice =
+      context_switch_manager.ProcessContextSwitchOut(kPid2, kTid2, kCore2, 105);
+  ASSERT_FALSE(processed_scheduling_slice.has_value());
+
+  processed_scheduling_slice =
+      context_switch_manager.ProcessContextSwitchOut(62, 63, 3, 106);
+  ASSERT_FALSE(processed_scheduling_slice.has_value());
+}
+
+TEST(ContextSwitchManager, TwoCoresOutOnDifferentCore) {
+  constexpr pid_t kPid = 42;
+  constexpr pid_t kTid = 43;
+  constexpr uint16_t kCore = 1;
+  std::optional<SchedulingSlice> processed_scheduling_slice;
+  ContextSwitchManager context_switch_manager;
+
+  context_switch_manager.ProcessContextSwitchIn(kPid, kTid, kCore, 100);
+
+  processed_scheduling_slice =
+      context_switch_manager.ProcessContextSwitchOut(kPid, kTid, 2, 101);
+}
+
+TEST(ContextSwitchManager, OneCoreOutOfOrder) {
+  constexpr pid_t kPid = 42;
+  constexpr pid_t kTid = 43;
+  constexpr uint16_t kCore = 1;
+  std::optional<SchedulingSlice> processed_scheduling_slice;
+  ContextSwitchManager context_switch_manager;
+
+  context_switch_manager.ProcessContextSwitchIn(kPid, kTid, kCore, 100);
+
+  EXPECT_DEATH(
+      context_switch_manager.ProcessContextSwitchOut(52, 53, kCore, 99), "");
+}
+
+}  // namespace LinuxTracing

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -18,6 +18,7 @@
 #include <regex>
 #include <vector>
 
+#include "ContextSwitchManager.h"
 #include "GpuTracepointEventProcessor.h"
 #include "PerfEvent.h"
 #include "PerfEventProcessor.h"
@@ -124,6 +125,7 @@ class TracerThread {
   std::atomic<bool> stop_deferred_thread_ = false;
   std::vector<std::unique_ptr<PerfEvent>> deferred_events_;
   std::mutex deferred_events_mutex_;
+  ContextSwitchManager context_switch_manager_;
   std::shared_ptr<PerfEventProcessor2> uprobes_event_processor_;
   std::shared_ptr<GpuTracepointEventProcessor> gpu_event_processor_;
 

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -66,8 +66,6 @@ class TracerThread {
       std::vector<PerfEventRingBuffer>* gpu_ring_buffers);
   bool OpenGpuTracepoints(const std::vector<int32_t>& cpus);
 
-  void ProcessContextSwitchEvent(const perf_event_header& header,
-                                 PerfEventRingBuffer* ring_buffer);
   void ProcessContextSwitchCpuWideEvent(const perf_event_header& header,
                                         PerfEventRingBuffer* ring_buffer);
   void ProcessForkEvent(const perf_event_header& header,

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/Events.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/Events.h
@@ -14,36 +14,6 @@
 
 namespace LinuxTracing {
 
-class ContextSwitch {
- public:
-  pid_t GetPid() const { return pid_; }
-  pid_t GetTid() const { return tid_; }
-  uint16_t GetCore() const { return core_; }
-  uint64_t GetTimestampNs() const { return timestamp_ns_; }
-
- protected:
-  ContextSwitch(pid_t pid, pid_t tid, uint16_t core, uint64_t timestamp_ns)
-      : pid_(pid), tid_(tid), core_(core), timestamp_ns_(timestamp_ns) {}
-
- private:
-  pid_t pid_;
-  pid_t tid_;
-  uint16_t core_;
-  uint64_t timestamp_ns_;
-};
-
-class ContextSwitchIn : public ContextSwitch {
- public:
-  ContextSwitchIn(pid_t pid, pid_t tid, uint16_t core, uint64_t timestamp_ns)
-      : ContextSwitch(pid, tid, core, timestamp_ns) {}
-};
-
-class ContextSwitchOut : public ContextSwitch {
- public:
-  ContextSwitchOut(pid_t pid, pid_t tid, uint16_t core, uint64_t timestamp_ns)
-      : ContextSwitch(pid, tid, core, timestamp_ns) {}
-};
-
 class SchedulingSlice {
  public:
   SchedulingSlice(pid_t pid, pid_t tid, uint16_t core, uint64_t in_timestamp_ns,

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/Events.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/Events.h
@@ -44,6 +44,30 @@ class ContextSwitchOut : public ContextSwitch {
       : ContextSwitch(pid, tid, core, timestamp_ns) {}
 };
 
+class SchedulingSlice {
+ public:
+  SchedulingSlice(pid_t pid, pid_t tid, uint16_t core, uint64_t in_timestamp_ns,
+                  uint64_t out_timestamp_ns)
+      : pid_(pid),
+        tid_(tid),
+        core_(core),
+        in_timestamp_ns_(in_timestamp_ns),
+        out_timestamp_ns_(out_timestamp_ns) {}
+
+  pid_t GetPid() const { return pid_; }
+  pid_t GetTid() const { return tid_; }
+  uint16_t GetCore() const { return core_; }
+  uint64_t GetInTimestampNs() const { return in_timestamp_ns_; }
+  uint64_t GetOutTimestampNs() const { return out_timestamp_ns_; }
+
+ private:
+  pid_t pid_;
+  pid_t tid_;
+  uint16_t core_;
+  uint64_t in_timestamp_ns_;
+  uint64_t out_timestamp_ns_;
+};
+
 class CallstackFrame {
  public:
   CallstackFrame(uint64_t pc, std::string function_name,

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/TracerListener.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/TracerListener.h
@@ -13,6 +13,7 @@ class TracerListener {
  public:
   virtual ~TracerListener() = default;
   virtual void OnTid(pid_t tid) = 0;
+  virtual void OnSchedulingSlice(const SchedulingSlice& scheduling_slice) = 0;
   virtual void OnContextSwitchIn(const ContextSwitchIn& context_switch_in) = 0;
   virtual void OnContextSwitchOut(
       const ContextSwitchOut& context_switch_out) = 0;

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/TracerListener.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/TracerListener.h
@@ -14,9 +14,6 @@ class TracerListener {
   virtual ~TracerListener() = default;
   virtual void OnTid(pid_t tid) = 0;
   virtual void OnSchedulingSlice(const SchedulingSlice& scheduling_slice) = 0;
-  virtual void OnContextSwitchIn(const ContextSwitchIn& context_switch_in) = 0;
-  virtual void OnContextSwitchOut(
-      const ContextSwitchOut& context_switch_out) = 0;
   virtual void OnCallstack(const Callstack& callstack) = 0;
   virtual void OnFunctionCall(const FunctionCall& function_call) = 0;
   virtual void OnGpuJob(const GpuJob& gpu_job) = 0;

--- a/OrbitService/OrbitAsioServer.cpp
+++ b/OrbitService/OrbitAsioServer.cpp
@@ -163,12 +163,6 @@ void OrbitAsioServer::SendBufferedMessages() {
                       message_data.size());
   }
 
-  std::vector<ContextSwitch> context_switches;
-  if (tracing_buffer_.ReadAllContextSwitches(&context_switches)) {
-    Message Msg(Msg_ContextSwitches);
-    tcp_server_->Send(Msg, context_switches);
-  }
-
   std::vector<LinuxAddressInfo> address_infos;
   if (tracing_buffer_.ReadAllAddressInfos(&address_infos)) {
     std::string message_data = SerializeObjectBinary(address_infos);


### PR DESCRIPTION
The goals of this change are:
- to move the processing of context switches to the service, where they are known to come in order, the same way it's done for dynamically-instrumented functions and gpu jobs;
- to send scheduling slices already as `Timer`s the same way as dynamically-instrumented functions and gpu jobs, to make to code simpler and more consistent;
- to simplify how `Timer`s are handled on the client, in particular avoiding the old `TimerManager`.

### Commits:

#### Add ContextSwitchManager with tests to OrbitLinuxTracing
This class matches in and out context switches assuming they come in order on
the same core.
The goal is to move the matching of in and out context switches to the service.
#### Use ContextSwitchManager and send scheduling slices already as Timers
The processing of context switches into `Timer`s is moved from `TimeGraph`
(where it doesn't belong) all the way to service in `OrbitLinuxTracing`.
- We can assume context switches on the same core come in order.
  This means that using the `std::map m_CoreUtilizationMap` is not necessary.
- The code is greatly simplified. In particular, scheduling slices are now dealt
  with in the same way as slices from dynamic instrumentation and gpu jobs.
#### Remove TracerThread::ProcessContextSwitchEvent
As `PERF_RECORD_SWITCH`es are unexpected, only `PERF_RECORD_SWITCH_CPU_WIDE`
(we print an error when the former type is encountered), this code is basically
dead.
#### Remove all code related to sending context switches instead of Timers
As all the processing of context switches into `Timer`s has been moved to the
service, remove all the code that is now unnecessary.
#### Bypass the obsolete GTimerManager entirely to add Timers
The `TimerManager` is a leftover from Windows profiling, its logic is not
necessary to add `Timer`s received from the service (unfortunately, it cannot be
removed as a lot of old Windows-profiling-related code depends on it).