### PR TITLE
Added OrbitGgp::Error class

### DIFF
--- a/OrbitGgp/CMakeLists.txt
+++ b/OrbitGgp/CMakeLists.txt
@@ -15,12 +15,14 @@ target_include_directories(OrbitGgp PUBLIC
 
 target_sources(OrbitGgp PUBLIC
           include/OrbitGgp/Client.h
+          include/OrbitGgp/Error.h
           include/OrbitGgp/Instance.h
           include/OrbitGgp/InstanceItemModel.h
           include/OrbitGgp/SshInfo.h)
 
 target_sources(OrbitGgp PRIVATE
           Client.cpp
+          Error.cpp
           Instance.cpp
           InstanceItemModel.cpp
           SshInfo.cpp)

--- a/OrbitGgp/Error.cpp
+++ b/OrbitGgp/Error.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "OrbitGgp/Error.h"
+
+#include <absl/strings/str_format.h>
+
+namespace OrbitGgp {
+
+std::string ErrorCategory::message(int condition) const {
+  switch (static_cast<Error>(condition)) {
+    case Error::kCouldNotUseGgpCli:
+      return "Unable to use the ggp command line interface.";
+    case Error::kGgpListInstancesFailed:
+      return "Listing available instances failed.";
+    case Error::kRequestTimedOut:
+      return "Request timed out.";
+    case Error::kUnableToParseJson:
+      return "Unable to parse JSON.";
+  }
+
+  return absl::StrFormat("Unkown error condition: %i.", condition);
+}
+
+}  // namespace OrbitGgp

--- a/OrbitGgp/Instance.cpp
+++ b/OrbitGgp/Instance.cpp
@@ -4,65 +4,73 @@
 
 #include "OrbitGgp/Instance.h"
 
+#include <qjsonvalue.h>
+
 #include <QByteArray>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonValue>
 
+#include "OrbitBase/Logging.h"
+#include "OrbitGgp/Error.h"
+
 namespace OrbitGgp {
 
 namespace {
 
-Instance GetInstanceFromJson(const QJsonObject& obj) {
+outcome::result<Instance> GetInstanceFromJson(const QJsonObject& obj) {
+  const auto process = [](const QJsonValue& val) -> outcome::result<QString> {
+    if (!val.isString()) {
+      return Error::kUnableToParseJson;
+    } else {
+      return val.toString();
+    }
+  };
+
+  OUTCOME_TRY(display_name, process(obj.value("displayName")));
+  OUTCOME_TRY(id, process(obj.value("id")));
+  OUTCOME_TRY(ip_address, process(obj.value("ipAddress")));
+  OUTCOME_TRY(last_updated, process(obj.value("lastUpdated")));
+  OUTCOME_TRY(owner, process(obj.value("owner")));
+  OUTCOME_TRY(pool, process(obj.value("pool")));
+
+  auto last_updated_date_time =
+      QDateTime::fromString(last_updated, Qt::ISODate);
+  if (!last_updated_date_time.isValid()) {
+    return Error::kUnableToParseJson;
+  }
+
   Instance inst{};
 
-  if (const QJsonValue val = obj.value("displayName"); !val.isUndefined()) {
-    inst.display_name = val.toString();
-  }
-
-  if (const QJsonValue val = obj.value("id"); !val.isUndefined()) {
-    inst.id = val.toString();
-  }
-
-  if (const QJsonValue val = obj.value("ipAddress"); !val.isUndefined()) {
-    inst.ip_address = val.toString();
-  }
-
-  if (const QJsonValue val = obj.value("lastUpdated"); !val.isUndefined()) {
-    inst.last_updated = QDateTime::fromString(val.toString(), Qt::ISODate);
-  }
-
-  if (const QJsonValue val = obj.value("owner"); !val.isUndefined()) {
-    inst.owner = val.toString();
-  }
-
-  if (const QJsonValue val = obj.value("pool"); !val.isUndefined()) {
-    inst.pool = val.toString();
-  }
+  inst.display_name = display_name;
+  inst.id = id;
+  inst.ip_address = ip_address;
+  inst.last_updated = last_updated_date_time;
+  inst.owner = owner;
+  inst.pool = pool;
 
   return inst;
 }
 
 }  // namespace
 
-QVector<Instance> Instance::GetListFromJson(const QByteArray& json) {
+outcome::result<QVector<Instance>> Instance::GetListFromJson(
+    const QByteArray& json) {
   const QJsonDocument doc = QJsonDocument::fromJson(json);
 
-  if (!doc.isArray()) return {};
+  if (!doc.isArray()) return Error::kUnableToParseJson;
 
   const QJsonArray arr = doc.array();
 
   QVector<Instance> list;
 
-  std::transform(arr.begin(), arr.end(), std::back_inserter(list),
-                 [](const QJsonValue& val) -> Instance {
-                   if (!val.isObject()) return {};
+  for (const auto& json_value : arr) {
+    if (!json_value.isObject()) return Error::kUnableToParseJson;
 
-                   const QJsonObject obj = val.toObject();
-
-                   return GetInstanceFromJson(obj);
-                 });
+    OUTCOME_TRY(instance, GetInstanceFromJson(json_value.toObject()));
+    list.push_back(std::move(instance));
+  }
 
   return list;
 }

--- a/OrbitGgp/InstanceTests.cpp
+++ b/OrbitGgp/InstanceTests.cpp
@@ -13,73 +13,65 @@
 namespace OrbitGgp {
 
 TEST(InstanceTests, GetListFromJson) {
-  QByteArray json;
-  QVector<Instance> test_instances;
-  Instance test_instance;
+  {
+    // invalid json
+    const auto json = QString("json").toUtf8();
+    EXPECT_FALSE(Instance::GetListFromJson(json));
+  }
 
-  // invalid json
-  json = QString("json").toUtf8();
-  test_instances = Instance::GetListFromJson(json);
-  EXPECT_TRUE(test_instances.empty());
+  {
+    // empty json
+    const auto json = QString("[]").toUtf8();
+    const auto empty_instances = Instance::GetListFromJson(json);
+    ASSERT_TRUE(empty_instances);
+    EXPECT_TRUE(empty_instances.value().empty());
+  }
 
-  // empty json
-  json = QString("[]").toUtf8();
-  test_instances = Instance::GetListFromJson(json);
-  EXPECT_TRUE(test_instances.empty());
+  {
+    // one empty json object
+    const auto json = QString("[{}]").toUtf8();
+    EXPECT_FALSE(Instance::GetListFromJson(json));
+  }
 
-  // one empty json object
-  json = QString("[{}]").toUtf8();
-  test_instances = Instance::GetListFromJson(json);
-  ASSERT_EQ(test_instances.size(), 1);
-  test_instance = test_instances[0];
-  EXPECT_TRUE(test_instance.display_name.isEmpty());
-  EXPECT_TRUE(test_instance.id.isEmpty());
-  EXPECT_TRUE(test_instance.ip_address.isEmpty());
-  EXPECT_EQ(test_instance.last_updated, QDateTime{});
-  EXPECT_TRUE(test_instance.owner.isEmpty());
-  EXPECT_TRUE(test_instance.pool.isEmpty());
-
-  // two empty json objects
-  json = QString("[{},{}]").toUtf8();
-  test_instances = Instance::GetListFromJson(json);
-  ASSERT_EQ(test_instances.size(), 2);
-  EXPECT_EQ(test_instances[0], Instance{});
-  EXPECT_EQ(test_instances[1], Instance{});
-
-  // one full json object
-  // pretty json:
-  // [
-  //  {
-  //   "displayName": "a display name",
-  //   "id": "instance id",
-  //   "ipAddress": "1.1.0.1",
-  //   "lastUpdated": "2020-04-09T09:55:20Z",
-  //   "owner": "a username",
-  //   "pool": "a pool",
-  //   "other key": "other value",
-  //   "other complex object": {
-  //    "object key": "object value"
-  //   },
-  //  }
-  // ]
-  json = QString(
-             "[{\"displayName\":\"a display name\",\"id\":\"instance "
-             "id\",\"ipAddress\":\"1.1.0.1\",\"lastUpdated\":\"2020-04-09T09:"
-             "55:20Z\",\"owner\":\"a username\",\"pool\":\"a pool\",\"other "
-             "key\":\"other value\",\"other complex object\":{\"object "
-             "key\":\"object value\"}}]")
-             .toUtf8();
-  test_instances = Instance::GetListFromJson(json);
-  ASSERT_EQ(test_instances.size(), 1);
-  test_instance = test_instances[0];
-  EXPECT_EQ(test_instance.display_name, QString{"a display name"});
-  EXPECT_EQ(test_instance.id, QString{"instance id"});
-  EXPECT_EQ(test_instance.ip_address, QString{"1.1.0.1"});
-  EXPECT_EQ(
-      test_instance.last_updated,
-      QDateTime::fromString(QString{"2020-04-09T09:55:20Z"}, Qt::ISODate));
-  EXPECT_EQ(test_instance.owner, QString{"a username"});
-  EXPECT_EQ(test_instance.pool, QString{"a pool"});
+  {
+    // one full json object
+    // pretty json:
+    // [
+    //  {
+    //   "displayName": "a display name",
+    //   "id": "instance id",
+    //   "ipAddress": "1.1.0.1",
+    //   "lastUpdated": "2020-04-09T09:55:20Z",
+    //   "owner": "a username",
+    //   "pool": "a pool",
+    //   "other key": "other value",
+    //   "other complex object": {
+    //    "object key": "object value"
+    //   },
+    //  }
+    // ]
+    const auto json =
+        QString(
+            "[{\"displayName\":\"a display name\",\"id\":\"instance "
+            "id\",\"ipAddress\":\"1.1.0.1\",\"lastUpdated\":\"2020-04-09T09:"
+            "55:20Z\",\"owner\":\"a username\",\"pool\":\"a pool\",\"other "
+            "key\":\"other value\",\"other complex object\":{\"object "
+            "key\":\"object value\"}}]")
+            .toUtf8();
+    const auto result = Instance::GetListFromJson(json);
+    ASSERT_TRUE(result);
+    const QVector<Instance> instances = std::move(result.value());
+    ASSERT_EQ(instances.size(), 1);
+    const Instance instance = instances[0];
+    EXPECT_EQ(instance.display_name, QString{"a display name"});
+    EXPECT_EQ(instance.id, QString{"instance id"});
+    EXPECT_EQ(instance.ip_address, QString{"1.1.0.1"});
+    EXPECT_EQ(
+        instance.last_updated,
+        QDateTime::fromString(QString{"2020-04-09T09:55:20Z"}, Qt::ISODate));
+    EXPECT_EQ(instance.owner, QString{"a username"});
+    EXPECT_EQ(instance.pool, QString{"a pool"});
+  }
 }
 
 TEST(InstanceTests, CmpById) {

--- a/OrbitGgp/SshInfoTests.cpp
+++ b/OrbitGgp/SshInfoTests.cpp
@@ -12,27 +12,22 @@ namespace OrbitGgp {
 
 TEST(SshInfoTest, CreateFromJson) {
   QByteArray json;
-  std::optional<SshInfo> test_info_opt;
 
   // Empty json
   json = QString("").toUtf8();
-  test_info_opt = SshInfo::CreateFromJson(json);
-  EXPECT_FALSE(test_info_opt);
+  EXPECT_FALSE(SshInfo::CreateFromJson(json));
 
   // invalid json
   json = QString("{..dfP}").toUtf8();
-  test_info_opt = SshInfo::CreateFromJson(json);
-  EXPECT_FALSE(test_info_opt);
+  EXPECT_FALSE(SshInfo::CreateFromJson(json));
 
   // empty object
   json = QString("{}").toUtf8();
-  test_info_opt = SshInfo::CreateFromJson(json);
-  EXPECT_FALSE(test_info_opt);
+  EXPECT_FALSE(SshInfo::CreateFromJson(json));
 
   // object without all necessary fields
   json = QString("{\"host\":\"0.0.0.1\"}").toUtf8();
-  test_info_opt = SshInfo::CreateFromJson(json);
-  EXPECT_FALSE(test_info_opt);
+  EXPECT_FALSE(SshInfo::CreateFromJson(json));
 
   // valid object
 
@@ -49,17 +44,18 @@ TEST(SshInfoTest, CreateFromJson) {
              "id_rsa\",\"knownHostsPath\":\"/usr/local/another/path/"
              "known_hosts\",\"port\":\"11123\",\"user\":\"a username\"}")
              .toUtf8();
-  test_info_opt = SshInfo::CreateFromJson(json);
-  ASSERT_TRUE(test_info_opt);
-  EXPECT_EQ(test_info_opt->host, "1.1.0.1");
-  EXPECT_EQ(test_info_opt->key_path,
+  const auto ssh_info_result = SshInfo::CreateFromJson(json);
+  ASSERT_TRUE(ssh_info_result);
+  const SshInfo ssh_info = std::move(ssh_info_result.value());
+  EXPECT_EQ(ssh_info.host, "1.1.0.1");
+  EXPECT_EQ(ssh_info.key_path,
             "/usr/local/some/path/.ssh/"
             "id_rsa");
-  EXPECT_EQ(test_info_opt->known_hosts_path,
+  EXPECT_EQ(ssh_info.known_hosts_path,
             "/usr/local/another/path/"
             "known_hosts");
-  EXPECT_EQ(test_info_opt->port, 11123);
-  EXPECT_EQ(test_info_opt->user, "a username");
+  EXPECT_EQ(ssh_info.port, 11123);
+  EXPECT_EQ(ssh_info.user, "a username");
 
   // valid object - but port is formatted as an int.
   json = QString(
@@ -67,9 +63,8 @@ TEST(SshInfoTest, CreateFromJson) {
              "id_rsa\",\"knownHostsPath\":\"/usr/local/another/path/"
              "known_hosts\",\"port\":11123,\"user\":\"a username\"}")
              .toUtf8();
-  test_info_opt = SshInfo::CreateFromJson(json);
   // This is supposed to fail, since its expected that the port is a string
-  EXPECT_FALSE(test_info_opt);
+  EXPECT_FALSE(SshInfo::CreateFromJson(json));
 }
 
 }  // namespace OrbitGgp

--- a/OrbitGgp/include/OrbitGgp/Client.h
+++ b/OrbitGgp/include/OrbitGgp/Client.h
@@ -17,21 +17,15 @@ namespace OrbitGgp {
 
 class Client {
  public:
-  // this policy means when a result is wrongly accessed, std::terminate() will
-  // be called. (.value() is accessed even though it is an error, or vice versa)
-  template <class T>
-  using ResultOrQString =
-      outcome::result<T, QString, outcome::policy::terminate>;
-
-  static ResultOrQString<Client> Create();
+  static outcome::result<Client> Create();
 
   int GetNumberOfRequestsRunning() const { return number_of_requests_running_; }
 
   void GetInstancesAsync(
-      const std::function<void(ResultOrQString<QVector<Instance>>)>& callback);
+      const std::function<void(outcome::result<QVector<Instance>>)>& callback);
   void GetSshInformationAsync(
       const Instance& ggpInstance,
-      const std::function<void(ResultOrQString<SshInfo>)>& callback);
+      const std::function<void(outcome::result<SshInfo>)>& callback);
 
  private:
   Client() = default;

--- a/OrbitGgp/include/OrbitGgp/Error.h
+++ b/OrbitGgp/include/OrbitGgp/Error.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GGP_ERROR_H_
+#define ORBIT_GGP_ERROR_H_
+
+#include <system_error>
+
+namespace OrbitGgp {
+
+enum class Error {
+  kCouldNotUseGgpCli,
+  kGgpListInstancesFailed,
+  kRequestTimedOut,
+  kUnableToParseJson
+};
+
+struct ErrorCategory : std::error_category {
+  using std::error_category::error_category;
+
+  const char* name() const noexcept override { return "OrbitGgp_Error"; }
+  std::string message(int condition) const override;
+};
+
+inline const ErrorCategory& GetErrorCategory() {
+  static ErrorCategory category{};
+  return category;
+}
+
+inline std::error_code make_error_code(Error e) {
+  return std::error_code{static_cast<int>(e), GetErrorCategory()};
+}
+
+}  // namespace OrbitGgp
+
+namespace std {
+template <>
+struct is_error_condition_enum<OrbitGgp::Error> : std::true_type {};
+}  // namespace std
+
+#endif  // ORBIT_GGP_ERROR_H_

--- a/OrbitGgp/include/OrbitGgp/Instance.h
+++ b/OrbitGgp/include/OrbitGgp/Instance.h
@@ -8,6 +8,7 @@
 #include <QDateTime>
 #include <QMetaType>
 #include <QVector>
+#include <outcome.hpp>
 
 namespace OrbitGgp {
 
@@ -19,7 +20,8 @@ struct Instance {
   QString owner;
   QString pool;
 
-  static QVector<Instance> GetListFromJson(const QByteArray& json);
+  static outcome::result<QVector<Instance>> GetListFromJson(
+      const QByteArray& json);
   static bool CmpById(const Instance& lhs, const Instance& rhs);
 
   friend bool operator==(const Instance& lhs, const Instance& rhs) {

--- a/OrbitGgp/include/OrbitGgp/SshInfo.h
+++ b/OrbitGgp/include/OrbitGgp/SshInfo.h
@@ -7,7 +7,7 @@
 
 #include <QByteArray>
 #include <QString>
-#include <optional>
+#include <outcome.hpp>
 
 namespace OrbitGgp {
 
@@ -18,7 +18,7 @@ struct SshInfo {
   int port;
   QString user;
 
-  static std::optional<SshInfo> CreateFromJson(const QByteArray& json);
+  static outcome::result<SshInfo> CreateFromJson(const QByteArray& json);
 };
 
 }  // namespace OrbitGgp


### PR DESCRIPTION
This introduces OrbitGgp::Error based on std::error_code and uses it in
OrbitGgp where appropriate. This removes the need of ResultOrQString
which was used before.

This also changes some logic of OrbitGgp::Instance json parsing,
which is now stricter than before. The tests have been modified
appropriately.

This was intended to be a smaller refactor before fixing a bug in GgpClient, but ended up being bigger. 