### PR TITLE
Introduce specialized TimerChain data structure to replace BlockChain for Timers

### DIFF
--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -61,6 +61,7 @@ target_sources(
          ThreadTrack.h
          TimeGraph.h
          TimeGraphLayout.h
+         TimerChain.h
          Track.h
          TransactionClient.h
          TriangleToggle.h
@@ -113,6 +114,7 @@ target_sources(
           TextRenderer.cpp
           TimeGraph.cpp
           TimeGraphLayout.cpp
+          TimerChain.cpp
           ThreadTrack.cpp
           Track.cpp
           TransactionClient.cpp

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -124,8 +124,8 @@ void CaptureSerializer::Save(T& archive) {
       time_graph_->GetAllTimerChains();
   for (const std::shared_ptr<TimerChain>& chain : chains) {
     for (int i = 0; i < chain->size(); ++i) {
-      for (int k = 0; k < (*chain)[i]->size(); ++k) {
-        archive(cereal::binary_data(&((*(*chain)[i])[k].GetTimer()), sizeof(Timer)));
+      for (int k = 0; k < (*chain)[i].size(); ++k) {
+        archive(cereal::binary_data(&((*chain)[i][k].GetTimer()), sizeof(Timer)));
 
         if (++numWrites > m_NumTimers) {
           return;

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -21,6 +21,7 @@
 #include "Serialization.h"
 #include "TextBox.h"
 #include "TimeGraph.h"
+#include "TimerChain.h"
 #include "absl/strings/str_format.h"
 
 //-----------------------------------------------------------------------------
@@ -122,11 +123,13 @@ void CaptureSerializer::Save(T& archive) {
   std::vector<std::shared_ptr<TimerChain>> chains =
       time_graph_->GetAllTimerChains();
   for (const std::shared_ptr<TimerChain>& chain : chains) {
-    for (const TextBox& box : *chain) {
-      archive(cereal::binary_data(&box.GetTimer(), sizeof(Timer)));
+    for (int i = 0; i < chain->size(); ++i) {
+      for (int k = 0; k < (*chain)[i]->size(); ++k) {
+        archive(cereal::binary_data(&((*(*chain)[i])[k].GetTimer()), sizeof(Timer)));
 
-      if (++numWrites > m_NumTimers) {
-        return;
+        if (++numWrites > m_NumTimers) {
+          return;
+        }
       }
     }
   }

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -122,7 +122,7 @@ void CaptureSerializer::Save(T& archive) {
   int numWrites = 0;
   std::vector<std::shared_ptr<TimerChain>> chains =
       time_graph_->GetAllTimerChains();
-  for (const std::shared_ptr<TimerChain>& chain : chains) {
+  for (auto& chain : chains) {
     if (!chain) continue;
     for (TimerChainIterator& it = chain->begin(); it != chain->end(); ++it) {
       TimerBlock& block = *it;

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -124,7 +124,7 @@ void CaptureSerializer::Save(T& archive) {
       time_graph_->GetAllTimerChains();
   for (auto& chain : chains) {
     if (!chain) continue;
-    for (TimerChainIterator& it = chain->begin(); it != chain->end(); ++it) {
+    for (TimerChainIterator it = chain->begin(); it != chain->end(); ++it) {
       TimerBlock& block = *it;
       for (int k = 0; k < block.size(); ++k) {
         archive(cereal::binary_data(&(block[k].GetTimer()), sizeof(Timer)));

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -123,9 +123,11 @@ void CaptureSerializer::Save(T& archive) {
   std::vector<std::shared_ptr<TimerChain>> chains =
       time_graph_->GetAllTimerChains();
   for (const std::shared_ptr<TimerChain>& chain : chains) {
-    for (int i = 0; i < chain->size(); ++i) {
-      for (int k = 0; k < (*chain)[i]->size(); ++k) {
-        archive(cereal::binary_data(&((*(*chain)[i])[k].GetTimer()), sizeof(Timer)));
+    if (!chain) continue;
+    for (TimerChainIterator& it = chain->begin(); it != chain->end(); ++it) {
+      TimerBlock& block = *it;
+      for (int k = 0; k < block.size(); ++k) {
+        archive(cereal::binary_data(&(block[k].GetTimer()), sizeof(Timer)));
 
         if (++numWrites > m_NumTimers) {
           return;

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -124,8 +124,8 @@ void CaptureSerializer::Save(T& archive) {
       time_graph_->GetAllTimerChains();
   for (const std::shared_ptr<TimerChain>& chain : chains) {
     for (int i = 0; i < chain->size(); ++i) {
-      for (int k = 0; k < (*chain)[i].size(); ++k) {
-        archive(cereal::binary_data(&((*chain)[i][k].GetTimer()), sizeof(Timer)));
+      for (int k = 0; k < (*chain)[i]->size(); ++k) {
+        archive(cereal::binary_data(&((*(*chain)[i])[k].GetTimer()), sizeof(Timer)));
 
         if (++numWrites > m_NumTimers) {
           return;

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -258,35 +258,39 @@ std::vector<std::shared_ptr<TimerChain>> GpuTrack::GetTimers() {
 //-----------------------------------------------------------------------------
 const TextBox* GpuTrack::GetFirstAfterTime(TickType time,
                                            uint32_t depth) const {
-  // std::shared_ptr<TimerChain> text_boxes = GetTimers(depth);
-  // if (text_boxes == nullptr) return nullptr;
+  std::shared_ptr<TimerChain> chain = GetTimers(depth);
+  if (chain == nullptr) return nullptr;
 
-  // // TODO: do better than linear search...
-  // for (TextBox& text_box : *text_boxes) {
-  //   if (text_box.GetTimer().m_Start > time) {
-  //     return &text_box;
-  //   }
-  // }
-
+  // TODO: do better than linear search...
+  for (int i = 0; i < chain->size(); ++i) {
+    for (int k = 0; k < (*chain)[i]->size(); ++k) {
+      const TextBox& text_box = (*(*chain)[i])[k];
+      if (text_box.GetTimer().m_Start > time) {
+        return &text_box;
+      }
+    }
+  }
   return nullptr;
 }
 
 //-----------------------------------------------------------------------------
 const TextBox* GpuTrack::GetFirstBeforeTime(TickType time,
                                             uint32_t depth) const {
-  // std::shared_ptr<TimerChain> text_boxes = GetTimers(depth);
-  // if (text_boxes == nullptr) return nullptr;
+  std::shared_ptr<TimerChain> chain = GetTimers(depth);
+  if (chain == nullptr) return nullptr;
 
-  // TextBox* text_box = nullptr;
+  const TextBox* text_box = nullptr;
 
-  // // TODO: do better than linear search...
-  // for (TextBox& box : *text_boxes) {
-  //   if (box.GetTimer().m_Start > time) {
-  //     return text_box;
-  //   }
-
-  //   text_box = &box;
-  // }
+  // TODO: do better than linear search...
+  for (int i = 0; i < chain->size(); ++i) {
+    for (int k = 0; k < (*chain)[i]->size(); ++k) {
+      const TextBox& box = (*(*chain)[i])[k];
+      if (box.GetTimer().m_Start > time) {
+        return text_box;
+      }
+      text_box = &box;
+    }
+  }
 
   return nullptr;
 }
@@ -301,23 +305,23 @@ std::shared_ptr<TimerChain> GpuTrack::GetTimers(uint32_t depth) const {
 
 //-----------------------------------------------------------------------------
 const TextBox* GpuTrack::GetLeft(TextBox* text_box) const {
-  // const Timer& timer = text_box->GetTimer();
-  // uint64_t timeline_hash = timer.m_UserData[0];
-  // if (timeline_hash == timeline_hash_) {
-  //   std::shared_ptr<TimerChain> timers = GetTimers(timer.m_Depth);
-  //   if (timers) return timers->GetElementBefore(text_box);
-  // }
+  const Timer& timer = text_box->GetTimer();
+  uint64_t timeline_hash = timer.m_UserData[0];
+  if (timeline_hash == timeline_hash_) {
+    std::shared_ptr<TimerChain> timers = GetTimers(timer.m_Depth);
+    if (timers) return timers->GetElementBefore(text_box);
+  }
   return nullptr;
 }
 
 //-----------------------------------------------------------------------------
 const TextBox* GpuTrack::GetRight(TextBox* text_box) const {
-  // const Timer& timer = text_box->GetTimer();
-  // uint64_t timeline_hash = timer.m_UserData[0];
-  // if (timeline_hash == timeline_hash_) {
-  //   std::shared_ptr<TimerChain> timers = GetTimers(timer.m_Depth);
-  //   if (timers) return timers->GetElementAfter(text_box);
-  // }
+  const Timer& timer = text_box->GetTimer();
+  uint64_t timeline_hash = timer.m_UserData[0];
+  if (timeline_hash == timeline_hash_) {
+    std::shared_ptr<TimerChain> timers = GetTimers(timer.m_Depth);
+    if (timers) return timers->GetElementAfter(text_box);
+  }
   return nullptr;
 }
 

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -135,75 +135,84 @@ void GpuTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
 
   std::vector<std::shared_ptr<TimerChain>> chains_by_depth = GetTimers();
 
-  // We minimize overdraw when drawing lines for small events by discarding events
-  // that would just draw over an already drawn line. When zoomed in enough that all 
-  // events are drawn as boxes, this has no effect. When zoomed out, many events
-  // will be discarded quickly.
+  // We minimize overdraw when drawing lines for small events by discarding
+  // events that would just draw over an already drawn line. When zoomed in
+  // enough that all events are drawn as boxes, this has no effect. When zoomed
+  // out, many events will be discarded quickly.
   uint64_t min_ignore = std::numeric_limits<uint64_t>::max();
   uint64_t max_ignore = std::numeric_limits<uint64_t>::min();
 
-  uint64_t pixel_delta_in_ticks = 
-    static_cast<uint64_t>(TicksFromMicroseconds(time_graph_->GetTimeWindowUs())) / canvas->getWidth();
-  uint64_t min_timegraph_tick = time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
+  uint64_t pixel_delta_in_ticks = static_cast<uint64_t>(TicksFromMicroseconds(
+                                      time_graph_->GetTimeWindowUs())) /
+                                  canvas->getWidth();
+  uint64_t min_timegraph_tick =
+      time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
 
-  for (auto& text_boxes : chains_by_depth) {
-    if (text_boxes == nullptr) continue;
-    // We have to reset this when we go to the next depth, as otherwise we would miss
-    // drawing events that should be drawn.
-    min_ignore = std::numeric_limits<uint64_t>::max();
-    max_ignore = std::numeric_limits<uint64_t>::min();
-    
-    for (TextBox& text_box : *text_boxes) {
-      const Timer& timer = text_box.GetTimer();
-      if (min_tick > timer.m_End || max_tick < timer.m_Start) continue;
-      if (timer.m_Start >= min_ignore && timer.m_End <= max_ignore) continue;
+  for (auto& chain : chains_by_depth) {
+    for (int i = 0; i < chain->size(); ++i) {
+      TimerBlock& block = *(*chain)[i];
+      if (!block.Intersects(min_tick, max_tick)) continue;
+      // We have to reset this when we go to the next depth, as otherwise we
+      // would miss drawing events that should be drawn.
+      min_ignore = std::numeric_limits<uint64_t>::max();
+      max_ignore = std::numeric_limits<uint64_t>::min();
 
-      UpdateDepth(timer.m_Depth + 1);
-      double start_us = time_graph_->GetUsFromTick(timer.m_Start);
-      double end_us = time_graph_->GetUsFromTick(timer.m_End);
-      double elapsed_us = end_us - start_us;
-      double normalized_start = start_us * inv_time_window;
-      double normalized_length = elapsed_us * inv_time_window;
-      float world_timer_width =
-          static_cast<float>(normalized_length * world_width);
-      float world_timer_x =
-          static_cast<float>(world_start_x + normalized_start * world_width);
-      uint8_t timer_depth = is_collapsed ? 0 : timer.m_Depth;
-      float world_timer_y = GetYFromDepth(layout, m_Pos[1], timer_depth);
+      for (int k = 0; k < block.size(); ++k) {
+        TextBox& text_box =  block[k];
+        const Timer& timer = text_box.GetTimer();
+        if (min_tick > timer.m_End || max_tick < timer.m_Start) continue;
+        if (timer.m_Start >= min_ignore && timer.m_End <= max_ignore) continue;
 
-      bool is_visible_width = normalized_length * canvas->getWidth() > 1;
-      bool is_selected = &text_box == Capture::GSelectedTextBox;
+        UpdateDepth(timer.m_Depth + 1);
+        double start_us = time_graph_->GetUsFromTick(timer.m_Start);
+        double end_us = time_graph_->GetUsFromTick(timer.m_End);
+        double elapsed_us = end_us - start_us;
+        double normalized_start = start_us * inv_time_window;
+        double normalized_length = elapsed_us * inv_time_window;
+        float world_timer_width =
+            static_cast<float>(normalized_length * world_width);
+        float world_timer_x =
+            static_cast<float>(world_start_x + normalized_start * world_width);
+        uint8_t timer_depth = is_collapsed ? 0 : timer.m_Depth;
+        float world_timer_y = GetYFromDepth(layout, m_Pos[1], timer_depth);
 
-      Vec2 pos(world_timer_x, world_timer_y);
-      Vec2 size(world_timer_width, layout.GetTextBoxHeight());
-      float z = GlCanvas::Z_VALUE_BOX_ACTIVE;
-      Color color = GetTimerColor(timer, is_selected, false);
-      text_box.SetPos(pos);
-      text_box.SetSize(size);
+        bool is_visible_width = normalized_length * canvas->getWidth() > 1;
+        bool is_selected = &text_box == Capture::GSelectedTextBox;
 
-      // When track is collapsed, only draw "hardware execution" timers.
-      if (is_collapsed) {
-        std::string gpu_stage =
-            string_manager_->Get(timer.m_UserData[0]).value_or("");
-        constexpr const char* kHwExecutionString = "hw execution";
-        if (gpu_stage != kHwExecutionString) {
-          continue;
+        Vec2 pos(world_timer_x, world_timer_y);
+        Vec2 size(world_timer_width, layout.GetTextBoxHeight());
+        float z = GlCanvas::Z_VALUE_BOX_ACTIVE;
+        Color color = GetTimerColor(timer, is_selected, false);
+        text_box.SetPos(pos);
+        text_box.SetSize(size);
+
+        // When track is collapsed, only draw "hardware execution" timers.
+        if (is_collapsed) {
+          std::string gpu_stage =
+              string_manager_->Get(timer.m_UserData[0]).value_or("");
+          constexpr const char* kHwExecutionString = "hw execution";
+          if (gpu_stage != kHwExecutionString) {
+            continue;
+          }
         }
-      }
 
-      if (is_visible_width) {
-        if (!is_collapsed) {
-          SetTimesliceText(timer, elapsed_us, min_x, &text_box);
+        if (is_visible_width) {
+          if (!is_collapsed) {
+            SetTimesliceText(timer, elapsed_us, min_x, &text_box);
+          }
+          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, &text_box);
+        } else {
+          auto type = PickingID::LINE;
+          batcher->AddVerticalLine(pos, size[1], z, color, type, &text_box);
+          // For lines, we can ignore the entire pixel into which this event
+          // falls. We align this precisely on the pixel x-coordinate of the
+          // current line being drawn (in ticks).
+          min_ignore =
+              min_timegraph_tick +
+              ((timer.m_Start - min_timegraph_tick) / pixel_delta_in_ticks) *
+                  pixel_delta_in_ticks;
+          max_ignore = min_ignore + pixel_delta_in_ticks;
         }
-        batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, &text_box);
-      } else {
-        auto type = PickingID::LINE;
-        batcher->AddVerticalLine(pos, size[1], z, color, type, &text_box);
-        // For lines, we can ignore the entire pixel into which this event falls. We align
-        // this precisely on the pixel x-coordinate of the current line being drawn (in ticks).
-        min_ignore =  min_timegraph_tick + 
-          ((timer.m_Start - min_timegraph_tick) / pixel_delta_in_ticks) * pixel_delta_in_ticks;
-        max_ignore = min_ignore + pixel_delta_in_ticks;
       }
     }
   }
@@ -249,15 +258,15 @@ std::vector<std::shared_ptr<TimerChain>> GpuTrack::GetTimers() {
 //-----------------------------------------------------------------------------
 const TextBox* GpuTrack::GetFirstAfterTime(TickType time,
                                            uint32_t depth) const {
-  std::shared_ptr<TimerChain> text_boxes = GetTimers(depth);
-  if (text_boxes == nullptr) return nullptr;
+  // std::shared_ptr<TimerChain> text_boxes = GetTimers(depth);
+  // if (text_boxes == nullptr) return nullptr;
 
-  // TODO: do better than linear search...
-  for (TextBox& text_box : *text_boxes) {
-    if (text_box.GetTimer().m_Start > time) {
-      return &text_box;
-    }
-  }
+  // // TODO: do better than linear search...
+  // for (TextBox& text_box : *text_boxes) {
+  //   if (text_box.GetTimer().m_Start > time) {
+  //     return &text_box;
+  //   }
+  // }
 
   return nullptr;
 }
@@ -265,19 +274,19 @@ const TextBox* GpuTrack::GetFirstAfterTime(TickType time,
 //-----------------------------------------------------------------------------
 const TextBox* GpuTrack::GetFirstBeforeTime(TickType time,
                                             uint32_t depth) const {
-  std::shared_ptr<TimerChain> text_boxes = GetTimers(depth);
-  if (text_boxes == nullptr) return nullptr;
+  // std::shared_ptr<TimerChain> text_boxes = GetTimers(depth);
+  // if (text_boxes == nullptr) return nullptr;
 
-  TextBox* text_box = nullptr;
+  // TextBox* text_box = nullptr;
 
-  // TODO: do better than linear search...
-  for (TextBox& box : *text_boxes) {
-    if (box.GetTimer().m_Start > time) {
-      return text_box;
-    }
+  // // TODO: do better than linear search...
+  // for (TextBox& box : *text_boxes) {
+  //   if (box.GetTimer().m_Start > time) {
+  //     return text_box;
+  //   }
 
-    text_box = &box;
-  }
+  //   text_box = &box;
+  // }
 
   return nullptr;
 }
@@ -292,23 +301,23 @@ std::shared_ptr<TimerChain> GpuTrack::GetTimers(uint32_t depth) const {
 
 //-----------------------------------------------------------------------------
 const TextBox* GpuTrack::GetLeft(TextBox* text_box) const {
-  const Timer& timer = text_box->GetTimer();
-  uint64_t timeline_hash = timer.m_UserData[0];
-  if (timeline_hash == timeline_hash_) {
-    std::shared_ptr<TimerChain> timers = GetTimers(timer.m_Depth);
-    if (timers) return timers->GetElementBefore(text_box);
-  }
+  // const Timer& timer = text_box->GetTimer();
+  // uint64_t timeline_hash = timer.m_UserData[0];
+  // if (timeline_hash == timeline_hash_) {
+  //   std::shared_ptr<TimerChain> timers = GetTimers(timer.m_Depth);
+  //   if (timers) return timers->GetElementBefore(text_box);
+  // }
   return nullptr;
 }
 
 //-----------------------------------------------------------------------------
 const TextBox* GpuTrack::GetRight(TextBox* text_box) const {
-  const Timer& timer = text_box->GetTimer();
-  uint64_t timeline_hash = timer.m_UserData[0];
-  if (timeline_hash == timeline_hash_) {
-    std::shared_ptr<TimerChain> timers = GetTimers(timer.m_Depth);
-    if (timers) return timers->GetElementAfter(text_box);
-  }
+  // const Timer& timer = text_box->GetTimer();
+  // uint64_t timeline_hash = timer.m_UserData[0];
+  // if (timeline_hash == timeline_hash_) {
+  //   std::shared_ptr<TimerChain> timers = GetTimers(timer.m_Depth);
+  //   if (timers) return timers->GetElementAfter(text_box);
+  // }
   return nullptr;
 }
 

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -150,7 +150,7 @@ void GpuTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
 
   for (auto& chain : chains_by_depth) {
     if (!chain) continue;
-    for (TimerChainIterator& it = chain->begin(); it != chain->end(); ++it) {
+    for (TimerChainIterator it = chain->begin(); it != chain->end(); ++it) {
       TimerBlock& block = *it;
       if (!block.Intersects(min_tick, max_tick)) continue;
       // We have to reset this when we go to the next depth, as otherwise we

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -150,8 +150,8 @@ void GpuTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
 
   for (auto& chain : chains_by_depth) {
     if (!chain) continue;
-    for (int i = 0; i < chain->size(); ++i) {
-      TimerBlock& block = *(*chain)[i];
+    for (TimerChainIterator& it = chain->begin(); it != chain->end(); ++it) {
+      TimerBlock& block = *it;
       if (!block.Intersects(min_tick, max_tick)) continue;
       // We have to reset this when we go to the next depth, as otherwise we
       // would miss drawing events that should be drawn.
@@ -263,14 +263,15 @@ const TextBox* GpuTrack::GetFirstAfterTime(TickType time,
   if (chain == nullptr) return nullptr;
 
   // TODO: do better than linear search...
-  for (int i = 0; i < chain->size(); ++i) {
-    for (int k = 0; k < (*chain)[i]->size(); ++k) {
-      const TextBox& text_box = (*(*chain)[i])[k];
+  for (TimerChainIterator& it = chain->begin(); it != chain->end(); ++it) {
+    for (int k = 0; k < it->size(); ++k) {
+      const TextBox& text_box = (*it)[k];
       if (text_box.GetTimer().m_Start > time) {
         return &text_box;
       }
     }
   }
+
   return nullptr;
 }
 
@@ -283,9 +284,9 @@ const TextBox* GpuTrack::GetFirstBeforeTime(TickType time,
   const TextBox* text_box = nullptr;
 
   // TODO: do better than linear search...
-  for (int i = 0; i < chain->size(); ++i) {
-    for (int k = 0; k < (*chain)[i]->size(); ++k) {
-      const TextBox& box = (*(*chain)[i])[k];
+  for (TimerChainIterator& it = chain->begin(); it != chain->end(); ++it) {
+    for (int k = 0; k < it->size(); ++k) {
+      const TextBox& box = (*it)[k];
       if (box.GetTimer().m_Start > time) {
         return text_box;
       }

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -263,7 +263,7 @@ const TextBox* GpuTrack::GetFirstAfterTime(TickType time,
   if (chain == nullptr) return nullptr;
 
   // TODO: do better than linear search...
-  for (TimerChainIterator& it = chain->begin(); it != chain->end(); ++it) {
+  for (TimerChainIterator it = chain->begin(); it != chain->end(); ++it) {
     for (int k = 0; k < it->size(); ++k) {
       const TextBox& text_box = (*it)[k];
       if (text_box.GetTimer().m_Start > time) {
@@ -284,7 +284,7 @@ const TextBox* GpuTrack::GetFirstBeforeTime(TickType time,
   const TextBox* text_box = nullptr;
 
   // TODO: do better than linear search...
-  for (TimerChainIterator& it = chain->begin(); it != chain->end(); ++it) {
+  for (TimerChainIterator it = chain->begin(); it != chain->end(); ++it) {
     for (int k = 0; k < it->size(); ++k) {
       const TextBox& box = (*it)[k];
       if (box.GetTimer().m_Start > time) {

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -149,8 +149,9 @@ void GpuTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
       time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
 
   for (auto& chain : chains_by_depth) {
+    if (!chain) continue;
     for (int i = 0; i < chain->size(); ++i) {
-      TimerBlock& block = (*chain)[i];
+      TimerBlock& block = *(*chain)[i];
       if (!block.Intersects(min_tick, max_tick)) continue;
       // We have to reset this when we go to the next depth, as otherwise we
       // would miss drawing events that should be drawn.
@@ -263,8 +264,8 @@ const TextBox* GpuTrack::GetFirstAfterTime(TickType time,
 
   // TODO: do better than linear search...
   for (int i = 0; i < chain->size(); ++i) {
-    for (int k = 0; k < (*chain)[i].size(); ++k) {
-      const TextBox& text_box = (*chain)[i][k];
+    for (int k = 0; k < (*chain)[i]->size(); ++k) {
+      const TextBox& text_box = (*(*chain)[i])[k];
       if (text_box.GetTimer().m_Start > time) {
         return &text_box;
       }
@@ -283,8 +284,8 @@ const TextBox* GpuTrack::GetFirstBeforeTime(TickType time,
 
   // TODO: do better than linear search...
   for (int i = 0; i < chain->size(); ++i) {
-    for (int k = 0; k < (*chain)[i].size(); ++k) {
-      const TextBox& box = (*chain)[i][k];
+    for (int k = 0; k < (*chain)[i]->size(); ++k) {
+      const TextBox& box = (*(*chain)[i])[k];
       if (box.GetTimer().m_Start > time) {
         return text_box;
       }

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -150,7 +150,7 @@ void GpuTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
 
   for (auto& chain : chains_by_depth) {
     for (int i = 0; i < chain->size(); ++i) {
-      TimerBlock& block = *(*chain)[i];
+      TimerBlock& block = (*chain)[i];
       if (!block.Intersects(min_tick, max_tick)) continue;
       // We have to reset this when we go to the next depth, as otherwise we
       // would miss drawing events that should be drawn.
@@ -263,8 +263,8 @@ const TextBox* GpuTrack::GetFirstAfterTime(TickType time,
 
   // TODO: do better than linear search...
   for (int i = 0; i < chain->size(); ++i) {
-    for (int k = 0; k < (*chain)[i]->size(); ++k) {
-      const TextBox& text_box = (*(*chain)[i])[k];
+    for (int k = 0; k < (*chain)[i].size(); ++k) {
+      const TextBox& text_box = (*chain)[i][k];
       if (text_box.GetTimer().m_Start > time) {
         return &text_box;
       }
@@ -283,8 +283,8 @@ const TextBox* GpuTrack::GetFirstBeforeTime(TickType time,
 
   // TODO: do better than linear search...
   for (int i = 0; i < chain->size(); ++i) {
-    for (int k = 0; k < (*chain)[i]->size(); ++k) {
-      const TextBox& box = (*(*chain)[i])[k];
+    for (int k = 0; k < (*chain)[i].size(); ++k) {
+      const TextBox& box = (*chain)[i][k];
       if (box.GetTimer().m_Start > time) {
         return text_box;
       }

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -73,7 +73,7 @@ void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
 
   for (auto& chain : chains_by_depth) {
     for (int i = 0; i < chain->size(); ++i) {
-      TimerBlock& block = *(*chain)[i];
+      TimerBlock& block = (*chain)[i];
       if (!block.Intersects(min_tick, max_tick)) continue;
 
       // We have to reset this when we go to the next depth, as otherwise we

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -72,8 +72,9 @@ void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
       time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
 
   for (auto& chain : chains_by_depth) {
+    if (!chain) continue;
     for (int i = 0; i < chain->size(); ++i) {
-      TimerBlock& block = (*chain)[i];
+      TimerBlock& block = *(*chain)[i];
       if (!block.Intersects(min_tick, max_tick)) continue;
 
       // We have to reset this when we go to the next depth, as otherwise we

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -73,8 +73,8 @@ void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
 
   for (auto& chain : chains_by_depth) {
     if (!chain) continue;
-    for (int i = 0; i < chain->size(); ++i) {
-      TimerBlock& block = *(*chain)[i];
+    for (TimerChainIterator& it = chain->begin(); it != chain->end(); ++it) {
+      TimerBlock& block = *it;
       if (!block.Intersects(min_tick, max_tick)) continue;
 
       // We have to reset this when we go to the next depth, as otherwise we

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -7,6 +7,7 @@
 #include "Capture.h"
 #include "EventTrack.h"
 #include "GlCanvas.h"
+#include "TextBox.h"
 #include "TimeGraph.h"
 
 const Color kInactiveColor(100, 100, 100, 255);
@@ -57,66 +58,77 @@ void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
 
   std::vector<std::shared_ptr<TimerChain>> chains_by_depth = GetTimers();
 
-  // We minimize overdraw when drawing lines for small events by discarding events
-  // that would just draw over an already drawn line. When zoomed in enough that all 
-  // events are drawn as boxes, this has no effect. When zoomed out, many events
-  // will be discarded quickly.
+  // We minimize overdraw when drawing lines for small events by discarding
+  // events that would just draw over an already drawn line. When zoomed in
+  // enough that all events are drawn as boxes, this has no effect. When zoomed
+  // out, many events will be discarded quickly.
   uint64_t min_ignore = std::numeric_limits<uint64_t>::max();
   uint64_t max_ignore = std::numeric_limits<uint64_t>::min();
 
-  uint64_t pixel_delta_in_ticks = 
-    static_cast<uint64_t>(TicksFromMicroseconds(time_graph_->GetTimeWindowUs())) / canvas->getWidth();
-  uint64_t min_timegraph_tick = time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
+  uint64_t pixel_delta_in_ticks = static_cast<uint64_t>(TicksFromMicroseconds(
+                                      time_graph_->GetTimeWindowUs())) /
+                                  canvas->getWidth();
+  uint64_t min_timegraph_tick =
+      time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
 
-  for (std::shared_ptr<TimerChain>& timer_chain : chains_by_depth) {
-    if (timer_chain == nullptr) continue;
-    // We have to reset this when we go to the next depth, as otherwise we would miss
-    // drawing events that should be drawn.
-    min_ignore = std::numeric_limits<uint64_t>::max();
-    max_ignore = std::numeric_limits<uint64_t>::min();
+  for (auto& chain : chains_by_depth) {
+    for (int i = 0; i < chain->size(); ++i) {
+      TimerBlock& block = *(*chain)[i];
+      if (!block.Intersects(min_tick, max_tick)) continue;
 
-    for (TextBox& text_box : *timer_chain) {
-      const Timer& timer = text_box.GetTimer();
-      if (min_tick > timer.m_End || max_tick < timer.m_Start) continue;
-      if (timer.m_Start >= min_ignore && timer.m_End <= max_ignore) continue;
+      // We have to reset this when we go to the next depth, as otherwise we
+      // would miss drawing events that should be drawn.
+      min_ignore = std::numeric_limits<uint64_t>::max();
+      max_ignore = std::numeric_limits<uint64_t>::min();
 
-      UpdateDepth(timer.m_Depth + 1);
-      
-      double start_us = time_graph_->GetUsFromTick(timer.m_Start);
-      double end_us = time_graph_->GetUsFromTick(timer.m_End);
-      double elapsed_us = end_us - start_us;
-      double normalized_start = start_us * inv_time_window;
-      double normalized_length = elapsed_us * inv_time_window;
-      float world_timer_width =
-          static_cast<float>(normalized_length * world_width);
-      float world_timer_x =
-          static_cast<float>(world_start_x + normalized_start * world_width);
-      float world_timer_y =
-          GetYFromDepth(m_Pos[1], timer.m_Depth, /*collapsed*/ false);
+      for (int k = 0; k < block.size(); ++k) {
+        TextBox& text_box = block[k];
+        const Timer& timer = text_box.GetTimer();
+        if (min_tick > timer.m_End || max_tick < timer.m_Start) continue;
+        if (timer.m_Start >= min_ignore && timer.m_End <= max_ignore) continue;
 
-      bool is_visible_width = normalized_length * canvas->getWidth() > 1;
-      bool is_same_pid_as_target = target_pid == 0 || target_pid == timer.m_PID;
-      bool is_same_tid_as_selected = timer.m_TID == selected_thread_id;
-      bool is_inactive = selected_thread_id != 0 && !is_same_tid_as_selected;
-      bool is_selected = &text_box == Capture::GSelectedTextBox;
+        UpdateDepth(timer.m_Depth + 1);
 
-      Vec2 pos(world_timer_x, world_timer_y);
-      Vec2 size(world_timer_width, layout.GetTextCoresHeight());
-      float z = GlCanvas::Z_VALUE_BOX_ACTIVE;
-      Color color = GetTimerColor(timer, time_graph_, is_selected,
-                                  is_same_tid_as_selected,
-                                  is_same_pid_as_target, is_inactive);
+        double start_us = time_graph_->GetUsFromTick(timer.m_Start);
+        double end_us = time_graph_->GetUsFromTick(timer.m_End);
+        double elapsed_us = end_us - start_us;
+        double normalized_start = start_us * inv_time_window;
+        double normalized_length = elapsed_us * inv_time_window;
+        float world_timer_width =
+            static_cast<float>(normalized_length * world_width);
+        float world_timer_x =
+            static_cast<float>(world_start_x + normalized_start * world_width);
+        float world_timer_y =
+            GetYFromDepth(m_Pos[1], timer.m_Depth, /*collapsed*/ false);
 
-      if (is_visible_width) {
-        batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, &text_box);
-      } else {
-        auto type = PickingID::LINE;
-        batcher->AddVerticalLine(pos, size[1], z, color, type, &text_box);
-        // For lines, we can ignore the entire pixel into which this event falls. We align
-        // this precisely on the pixel x-coordinate of the current line being drawn (in ticks).
-        min_ignore =  min_timegraph_tick + 
-          ((timer.m_Start - min_timegraph_tick) / pixel_delta_in_ticks) * pixel_delta_in_ticks;
-        max_ignore = min_ignore + pixel_delta_in_ticks;
+        bool is_visible_width = normalized_length * canvas->getWidth() > 1;
+        bool is_same_pid_as_target =
+            target_pid == 0 || target_pid == timer.m_PID;
+        bool is_same_tid_as_selected = timer.m_TID == selected_thread_id;
+        bool is_inactive = selected_thread_id != 0 && !is_same_tid_as_selected;
+        bool is_selected = &text_box == Capture::GSelectedTextBox;
+
+        Vec2 pos(world_timer_x, world_timer_y);
+        Vec2 size(world_timer_width, layout.GetTextCoresHeight());
+        float z = GlCanvas::Z_VALUE_BOX_ACTIVE;
+        Color color = GetTimerColor(timer, time_graph_, is_selected,
+                                    is_same_tid_as_selected,
+                                    is_same_pid_as_target, is_inactive);
+
+        if (is_visible_width) {
+          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, &text_box);
+        } else {
+          auto type = PickingID::LINE;
+          batcher->AddVerticalLine(pos, size[1], z, color, type, &text_box);
+          // For lines, we can ignore the entire pixel into which this event
+          // falls. We align this precisely on the pixel x-coordinate of the
+          // current line being drawn (in ticks).
+          min_ignore =
+              min_timegraph_tick +
+              ((timer.m_Start - min_timegraph_tick) / pixel_delta_in_ticks) *
+                  pixel_delta_in_ticks;
+          max_ignore = min_ignore + pixel_delta_in_ticks;
+        }
       }
     }
   }

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -73,7 +73,7 @@ void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
 
   for (auto& chain : chains_by_depth) {
     if (!chain) continue;
-    for (TimerChainIterator& it = chain->begin(); it != chain->end(); ++it) {
+    for (TimerChainIterator it = chain->begin(); it != chain->end(); ++it) {
       TimerBlock& block = *it;
       if (!block.Intersects(min_tick, max_tick)) continue;
 

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -181,8 +181,9 @@ void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
       time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
 
   for (auto& chain : chains_by_depth) {
+    if (!chain) continue;
     for (int i = 0; i < chain->size(); ++i) {
-      TimerBlock& block = (*chain)[i];
+      TimerBlock& block = *(*chain)[i];
       if (!block.Intersects(min_tick, max_tick)) continue;
 
       // We have to reset this when we go to the next depth, as otherwise we
@@ -296,8 +297,8 @@ const TextBox* ThreadTrack::GetFirstAfterTime(TickType time,
 
   // TODO: do better than linear search...
   for (int i = 0; i < chain->size(); ++i) {
-    for (int k = 0; k < (*chain)[i].size(); ++k) {
-      const TextBox& text_box = (*chain)[i][k];
+    for (int k = 0; k < (*chain)[i]->size(); ++k) {
+      const TextBox& text_box = (*(*chain)[i])[k];
       if (text_box.GetTimer().m_Start > time) {
         return &text_box;
       }
@@ -316,8 +317,8 @@ const TextBox* ThreadTrack::GetFirstBeforeTime(TickType time,
 
   // TODO: do better than linear search...
   for (int i = 0; i < chain->size(); ++i) {
-    for (int k = 0; k < (*chain)[i].size(); ++k) {
-      const TextBox& box = (*chain)[i][k];
+    for (int k = 0; k < (*chain)[i]->size(); ++k) {
+      const TextBox& box = (*(*chain)[i])[k];
       if (box.GetTimer().m_Start > time) {
         return text_box;
       }

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -296,7 +296,7 @@ const TextBox* ThreadTrack::GetFirstAfterTime(TickType time,
   if (chain == nullptr) return nullptr;
 
   // TODO: do better than linear search...
-  for (TimerChainIterator& it = chain->begin(); it != chain->end(); ++it) {
+  for (TimerChainIterator it = chain->begin(); it != chain->end(); ++it) {
     for (int k = 0; k < it->size(); ++k) {
       const TextBox& text_box = (*it)[k];
       if (text_box.GetTimer().m_Start > time) {
@@ -316,7 +316,7 @@ const TextBox* ThreadTrack::GetFirstBeforeTime(TickType time,
   const TextBox* text_box = nullptr;
 
   // TODO: do better than linear search...
-  for (TimerChainIterator& it = chain->begin(); it != chain->end(); ++it) {
+  for (TimerChainIterator it = chain->begin(); it != chain->end(); ++it) {
     for (int k = 0; k < it->size(); ++k) {
       const TextBox& box = (*it)[k];
       if (box.GetTimer().m_Start > time) {

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -291,7 +291,7 @@ std::vector<std::shared_ptr<TimerChain>> ThreadTrack::GetTimers() {
 //-----------------------------------------------------------------------------
 const TextBox* ThreadTrack::GetFirstAfterTime(TickType time,
                                               uint32_t depth) const {
-   std::shared_ptr<TimerChain> chain = GetTimers(depth);
+  std::shared_ptr<TimerChain> chain = GetTimers(depth);
   if (chain == nullptr) return nullptr;
 
   // TODO: do better than linear search...
@@ -314,7 +314,7 @@ const TextBox* ThreadTrack::GetFirstBeforeTime(TickType time,
 
   const TextBox* text_box = nullptr;
 
-// TODO: do better than linear search...
+  // TODO: do better than linear search...
   for (int i = 0; i < chain->size(); ++i) {
     for (int k = 0; k < (*chain)[i]->size(); ++k) {
       const TextBox& box = (*(*chain)[i])[k];

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -182,7 +182,7 @@ void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
 
   for (auto& chain : chains_by_depth) {
     for (int i = 0; i < chain->size(); ++i) {
-      TimerBlock& block = *(*chain)[i];
+      TimerBlock& block = (*chain)[i];
       if (!block.Intersects(min_tick, max_tick)) continue;
 
       // We have to reset this when we go to the next depth, as otherwise we
@@ -296,8 +296,8 @@ const TextBox* ThreadTrack::GetFirstAfterTime(TickType time,
 
   // TODO: do better than linear search...
   for (int i = 0; i < chain->size(); ++i) {
-    for (int k = 0; k < (*chain)[i]->size(); ++k) {
-      const TextBox& text_box = (*(*chain)[i])[k];
+    for (int k = 0; k < (*chain)[i].size(); ++k) {
+      const TextBox& text_box = (*chain)[i][k];
       if (text_box.GetTimer().m_Start > time) {
         return &text_box;
       }
@@ -316,8 +316,8 @@ const TextBox* ThreadTrack::GetFirstBeforeTime(TickType time,
 
   // TODO: do better than linear search...
   for (int i = 0; i < chain->size(); ++i) {
-    for (int k = 0; k < (*chain)[i]->size(); ++k) {
-      const TextBox& box = (*(*chain)[i])[k];
+    for (int k = 0; k < (*chain)[i].size(); ++k) {
+      const TextBox& box = (*chain)[i][k];
       if (box.GetTimer().m_Start > time) {
         return text_box;
       }

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -182,7 +182,7 @@ void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
 
   for (auto& chain : chains_by_depth) {
     if (!chain) continue;
-    for (TimerChainIterator& it = chain->begin(); it != chain->end(); ++it) {
+    for (TimerChainIterator it = chain->begin(); it != chain->end(); ++it) {
       TimerBlock& block = *it;
       if (!block.Intersects(min_tick, max_tick)) continue;
 

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -182,8 +182,8 @@ void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
 
   for (auto& chain : chains_by_depth) {
     if (!chain) continue;
-    for (int i = 0; i < chain->size(); ++i) {
-      TimerBlock& block = *(*chain)[i];
+    for (TimerChainIterator& it = chain->begin(); it != chain->end(); ++it) {
+      TimerBlock& block = *it;
       if (!block.Intersects(min_tick, max_tick)) continue;
 
       // We have to reset this when we go to the next depth, as otherwise we
@@ -296,9 +296,9 @@ const TextBox* ThreadTrack::GetFirstAfterTime(TickType time,
   if (chain == nullptr) return nullptr;
 
   // TODO: do better than linear search...
-  for (int i = 0; i < chain->size(); ++i) {
-    for (int k = 0; k < (*chain)[i]->size(); ++k) {
-      const TextBox& text_box = (*(*chain)[i])[k];
+  for (TimerChainIterator& it = chain->begin(); it != chain->end(); ++it) {
+    for (int k = 0; k < it->size(); ++k) {
+      const TextBox& text_box = (*it)[k];
       if (text_box.GetTimer().m_Start > time) {
         return &text_box;
       }
@@ -316,9 +316,9 @@ const TextBox* ThreadTrack::GetFirstBeforeTime(TickType time,
   const TextBox* text_box = nullptr;
 
   // TODO: do better than linear search...
-  for (int i = 0; i < chain->size(); ++i) {
-    for (int k = 0; k < (*chain)[i]->size(); ++k) {
-      const TextBox& box = (*(*chain)[i])[k];
+  for (TimerChainIterator& it = chain->begin(); it != chain->end(); ++it) {
+    for (int k = 0; k < it->size(); ++k) {
+      const TextBox& box = (*it)[k];
       if (box.GetTimer().m_Start > time) {
         return text_box;
       }

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
 #pragma once
 
 #include <map>
@@ -14,6 +13,7 @@
 #include "TextBox.h"
 #include "Threading.h"
 #include "Track.h"
+#include "TimerChain.h"
 
 class TextRenderer;
 

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -22,6 +22,7 @@
 #include "TextRenderer.h"
 #include "ThreadTrack.h"
 #include "TimeGraphLayout.h"
+#include "TimerChain.h"
 #include "absl/container/flat_hash_map.h"
 
 class Systrace;

--- a/OrbitGl/TimerChain.cpp
+++ b/OrbitGl/TimerChain.cpp
@@ -1,0 +1,95 @@
+#include "TimerChain.h"
+
+#include <vector>
+#include "TextBox.h"
+
+TimerBlock::TimerBlock()
+    : size_(0),
+      min_timestamp_(std::numeric_limits<uint64_t>::max()),
+      max_timestamp_(0) {}
+
+void TimerBlock::Add(const TextBox& box) {
+  if (size_ == kMaxSize) {
+    return;
+  }
+
+  assert(size_ < kMaxSize);
+  data_[size_] = box;
+  if (box.GetTimer().m_Start < min_timestamp_) {
+    min_timestamp_ = box.GetTimer().m_Start;
+  }
+  if (box.GetTimer().m_End > max_timestamp_) {
+    max_timestamp_ = box.GetTimer().m_End;
+  }
+  ++size_;
+}
+
+bool TimerBlock::Intersects(uint64_t min, uint64_t max) {
+  return (min <= max_timestamp_ && max >= min_timestamp_);
+}
+
+TimerChain::TimerChain() { blocks_.push_back(new TimerBlock()); }
+
+TimerChain::~TimerChain() {
+  for (int i = 0; i < blocks_.size(); ++i) {
+    delete blocks_[i];
+  }
+}
+
+void TimerChain::push_back(const TextBox& box) {
+  if (!(*(blocks_.end() - 1))->AtCapacity()) {
+    TimerBlock* current = *(blocks_.end() - 1);
+    current->Add(box);
+  } else {
+    blocks_.push_back(new TimerBlock());
+    TimerBlock* current = *(blocks_.end() - 1);
+    current->Add(box);
+  }
+}
+
+int TimerChain::GetBlockContaining(const TextBox* element) {
+  for (int k = 0; k < blocks_.size(); ++k) {
+    auto& block = *blocks_[k];
+    int size = block.size();
+    if (size > 0) {
+      TextBox* begin = &block[0];
+      TextBox* end = &block[size - 1];
+      if (begin <= element && end >= element) {
+        return k;
+      }
+    }
+  }
+  return blocks_.size();
+}
+
+TextBox* TimerChain::GetElementAfter(const TextBox* element) {
+  int k = GetBlockContaining(element);
+  if (k < blocks_.size()) {
+    auto& block = *blocks_[k];
+    TextBox* begin = &block[0];
+    int index = element - begin;
+    if (index < block.size() - 1) {
+      return &block[index + 1];
+    } else if (k + 1 < blocks_.size()) {
+      auto& next_block = *blocks_[k+1];
+      return &next_block[0];
+    }
+  }
+  return nullptr;
+}
+
+TextBox* TimerChain::GetElementBefore(const TextBox* element) {
+  int k = GetBlockContaining(element);
+  if (k < blocks_.size()) {
+    auto& block = *blocks_[k];
+    TextBox* begin = &block[0];
+    int index = element - begin;
+    if (index > 0) {
+      return &block[index - 1];
+    } else if (k > 0) {
+      auto& previous_block = *blocks_[k - 1];
+      return &previous_block[previous_block.size() - 1];
+    }
+  }
+  return nullptr;
+}

--- a/OrbitGl/TimerChain.cpp
+++ b/OrbitGl/TimerChain.cpp
@@ -1,95 +1,82 @@
 #include "TimerChain.h"
 
-#include <vector>
-#include "TextBox.h"
+#include <algorithm>
 
-TimerBlock::TimerBlock()
-    : size_(0),
-      min_timestamp_(std::numeric_limits<uint64_t>::max()),
-      max_timestamp_(0) {}
+void TimerBlock::Add(const TextBox& item) {
+  if (size_ == kBlockSize) {
+    if (next_ == nullptr) {
+      next_ = new TimerBlock(chain_, this);
+    }
 
-void TimerBlock::Add(const TextBox& box) {
-  if (size_ == kMaxSize) {
+    chain_->current_ = next_;
+    ++chain_->num_blocks_;
+    next_->Add(item);
     return;
   }
 
-  assert(size_ < kMaxSize);
-  data_[size_] = box;
-  if (box.GetTimer().m_Start < min_timestamp_) {
-    min_timestamp_ = box.GetTimer().m_Start;
-  }
-  if (box.GetTimer().m_End > max_timestamp_) {
-    max_timestamp_ = box.GetTimer().m_End;
-  }
+  assert(size_ < kBlockSize);
+  data_[size_] = item;
   ++size_;
+  ++chain_->num_items_;
+  min_timestamp_ = std::min(item.GetTimer().m_Start, min_timestamp_);
+  max_timestamp_ = std::max(item.GetTimer().m_End, max_timestamp_);
 }
 
 bool TimerBlock::Intersects(uint64_t min, uint64_t max) {
   return (min <= max_timestamp_ && max >= min_timestamp_);
 }
 
-TimerChain::TimerChain() { blocks_.push_back(new TimerBlock()); }
-
 TimerChain::~TimerChain() {
-  for (int i = 0; i < blocks_.size(); ++i) {
-    delete blocks_[i];
+  // Find last block in chain
+  while (current_->next_) current_ = current_->next_;
+
+  TimerBlock* prev = current_;
+  while (prev) {
+    prev = current_->prev_;
+    delete current_;
+    current_ = prev;
   }
 }
 
-void TimerChain::push_back(const TextBox& box) {
-  if (!(*(blocks_.end() - 1))->AtCapacity()) {
-    TimerBlock* current = *(blocks_.end() - 1);
-    current->Add(box);
-  } else {
-    blocks_.push_back(new TimerBlock());
-    TimerBlock* current = *(blocks_.end() - 1);
-    current->Add(box);
-  }
-}
-
-int TimerChain::GetBlockContaining(const TextBox* element) {
-  for (int k = 0; k < blocks_.size(); ++k) {
-    auto& block = *blocks_[k];
-    int size = block.size();
-    if (size > 0) {
-      TextBox* begin = &block[0];
-      TextBox* end = &block[size - 1];
+TimerBlock* TimerChain::GetBlockContaining(const TextBox* element) {
+  TimerBlock* block = root_;
+  while (block) {
+    uint32_t size = block->size_;
+    if (size) {
+      TextBox* begin = &block->data_[0];
+      TextBox* end = &block->data_[size - 1];
       if (begin <= element && end >= element) {
-        return k;
+        return block;
       }
     }
+    block = block->next_;
   }
-  return blocks_.size();
+
+  return nullptr;
 }
 
 TextBox* TimerChain::GetElementAfter(const TextBox* element) {
-  int k = GetBlockContaining(element);
-  if (k < blocks_.size()) {
-    auto& block = *blocks_[k];
-    TextBox* begin = &block[0];
-    int index = element - begin;
-    if (index < block.size() - 1) {
-      return &block[index + 1];
-    } else if (k + 1 < blocks_.size()) {
-      auto& next_block = *blocks_[k+1];
-      return &next_block[0];
-    }
+  auto block = GetBlockContaining(element);
+  if (block) {
+    TextBox* begin = &block->data_[0];
+    uint32_t index = element - begin;
+    if (index < block->size_ - 1)
+      return &block->data_[++index];
+    else if (block->next_ && block->next_->size_)
+      return &block->next_->data_[0];
   }
   return nullptr;
 }
 
 TextBox* TimerChain::GetElementBefore(const TextBox* element) {
-  int k = GetBlockContaining(element);
-  if (k < blocks_.size()) {
-    auto& block = *blocks_[k];
-    TextBox* begin = &block[0];
-    int index = element - begin;
-    if (index > 0) {
-      return &block[index - 1];
-    } else if (k > 0) {
-      auto& previous_block = *blocks_[k - 1];
-      return &previous_block[previous_block.size() - 1];
-    }
+  auto block = GetBlockContaining(element);
+  if (block) {
+    TextBox* begin = &block->data_[0];
+    uint32_t index = element - begin;
+    if (index > 0)
+      return &block->data_[--index];
+    else if (block->prev_)
+      return &block->prev_->data_[block->prev_->size_ - 1];
   }
   return nullptr;
 }

--- a/OrbitGl/TimerChain.cpp
+++ b/OrbitGl/TimerChain.cpp
@@ -28,22 +28,28 @@ bool TimerBlock::Intersects(uint64_t min, uint64_t max) {
   return (min <= max_timestamp_ && max >= min_timestamp_);
 }
 
-TimerChain::TimerChain() { blocks_.push_back(TimerBlock()); }
+TimerChain::TimerChain() { blocks_.push_back(new TimerBlock()); }
+
+TimerChain::~TimerChain() {
+  for (int i = 0; i < blocks_.size(); ++i) {
+    delete blocks_[i];
+  }
+}
 
 void TimerChain::push_back(const TextBox& box) {
-  if (!(blocks_.end() - 1)->AtCapacity()) {
-    TimerBlock& current = *(blocks_.end() - 1);
-    current.Add(box);
+  if (!(*(blocks_.end() - 1))->AtCapacity()) {
+    TimerBlock* current = *(blocks_.end() - 1);
+    current->Add(box);
   } else {
-    blocks_.push_back(TimerBlock());
-    TimerBlock& current = *(blocks_.end() - 1);
-    current.Add(box);
+    blocks_.push_back(new TimerBlock());
+    TimerBlock* current = *(blocks_.end() - 1);
+    current->Add(box);
   }
 }
 
 int TimerChain::GetBlockContaining(const TextBox* element) {
   for (int k = 0; k < blocks_.size(); ++k) {
-    auto& block = blocks_[k];
+    auto& block = *blocks_[k];
     int size = block.size();
     if (size > 0) {
       TextBox* begin = &block[0];
@@ -59,13 +65,13 @@ int TimerChain::GetBlockContaining(const TextBox* element) {
 TextBox* TimerChain::GetElementAfter(const TextBox* element) {
   int k = GetBlockContaining(element);
   if (k < blocks_.size()) {
-    auto& block = blocks_[k];
+    auto& block = *blocks_[k];
     TextBox* begin = &block[0];
     int index = element - begin;
     if (index < block.size() - 1) {
       return &block[index + 1];
     } else if (k + 1 < blocks_.size()) {
-      auto& next_block = blocks_[k+1];
+      auto& next_block = *blocks_[k+1];
       return &next_block[0];
     }
   }
@@ -75,13 +81,13 @@ TextBox* TimerChain::GetElementAfter(const TextBox* element) {
 TextBox* TimerChain::GetElementBefore(const TextBox* element) {
   int k = GetBlockContaining(element);
   if (k < blocks_.size()) {
-    auto& block = blocks_[k];
+    auto& block = *blocks_[k];
     TextBox* begin = &block[0];
     int index = element - begin;
     if (index > 0) {
       return &block[index - 1];
     } else if (k > 0) {
-      auto& previous_block = blocks_[k - 1];
+      auto& previous_block = *blocks_[k - 1];
       return &previous_block[previous_block.size() - 1];
     }
   }

--- a/OrbitGl/TimerChain.cpp
+++ b/OrbitGl/TimerChain.cpp
@@ -28,28 +28,22 @@ bool TimerBlock::Intersects(uint64_t min, uint64_t max) {
   return (min <= max_timestamp_ && max >= min_timestamp_);
 }
 
-TimerChain::TimerChain() { blocks_.push_back(new TimerBlock()); }
-
-TimerChain::~TimerChain() {
-  for (int i = 0; i < blocks_.size(); ++i) {
-    delete blocks_[i];
-  }
-}
+TimerChain::TimerChain() { blocks_.push_back(TimerBlock()); }
 
 void TimerChain::push_back(const TextBox& box) {
-  if (!(*(blocks_.end() - 1))->AtCapacity()) {
-    TimerBlock* current = *(blocks_.end() - 1);
-    current->Add(box);
+  if (!(blocks_.end() - 1)->AtCapacity()) {
+    TimerBlock& current = *(blocks_.end() - 1);
+    current.Add(box);
   } else {
-    blocks_.push_back(new TimerBlock());
-    TimerBlock* current = *(blocks_.end() - 1);
-    current->Add(box);
+    blocks_.push_back(TimerBlock());
+    TimerBlock& current = *(blocks_.end() - 1);
+    current.Add(box);
   }
 }
 
 int TimerChain::GetBlockContaining(const TextBox* element) {
   for (int k = 0; k < blocks_.size(); ++k) {
-    auto& block = *blocks_[k];
+    auto& block = blocks_[k];
     int size = block.size();
     if (size > 0) {
       TextBox* begin = &block[0];
@@ -65,13 +59,13 @@ int TimerChain::GetBlockContaining(const TextBox* element) {
 TextBox* TimerChain::GetElementAfter(const TextBox* element) {
   int k = GetBlockContaining(element);
   if (k < blocks_.size()) {
-    auto& block = *blocks_[k];
+    auto& block = blocks_[k];
     TextBox* begin = &block[0];
     int index = element - begin;
     if (index < block.size() - 1) {
       return &block[index + 1];
     } else if (k + 1 < blocks_.size()) {
-      auto& next_block = *blocks_[k+1];
+      auto& next_block = blocks_[k+1];
       return &next_block[0];
     }
   }
@@ -81,13 +75,13 @@ TextBox* TimerChain::GetElementAfter(const TextBox* element) {
 TextBox* TimerChain::GetElementBefore(const TextBox* element) {
   int k = GetBlockContaining(element);
   if (k < blocks_.size()) {
-    auto& block = *blocks_[k];
+    auto& block = blocks_[k];
     TextBox* begin = &block[0];
     int index = element - begin;
     if (index > 0) {
       return &block[index - 1];
     } else if (k > 0) {
-      auto& previous_block = *blocks_[k - 1];
+      auto& previous_block = blocks_[k - 1];
       return &previous_block[previous_block.size() - 1];
     }
   }

--- a/OrbitGl/TimerChain.h
+++ b/OrbitGl/TimerChain.h
@@ -15,7 +15,7 @@
 #include "TextBox.h"
 
 static constexpr int kBlockSize = 1024;
-struct TimerChain;
+class TimerChain;
 
 // TimerBlock is a straightforward specialization of Block (see BlockChain.h)
 // with the added bonus that it keeps track of the minimum and maximum

--- a/OrbitGl/TimerChain.h
+++ b/OrbitGl/TimerChain.h
@@ -50,7 +50,7 @@ class TimerBlock {
  private:
   static constexpr int kMaxSize = 1024;
   TextBox data_[kMaxSize];
-  int size_;
+  int32_t size_;
 
   uint64_t min_timestamp_;
   uint64_t max_timestamp_;
@@ -59,16 +59,17 @@ class TimerBlock {
 class TimerChain {
  public:
   TimerChain();
+  ~TimerChain();
 
   void push_back(const TextBox& box);
 
   int size() const { return blocks_.size(); }
 
-  TimerBlock& operator[](std::size_t idx) {
+  TimerBlock* operator[](std::size_t idx) {
     return blocks_[idx];
   }
     
-  const TimerBlock& operator[](std::size_t idx) const {
+  const TimerBlock* operator[](std::size_t idx) const {
     return blocks_[idx];
   }
 
@@ -79,7 +80,7 @@ class TimerChain {
   TextBox* GetElementBefore(const TextBox* element);
 
  private:
-  std::vector<TimerBlock> blocks_;
+  std::vector<TimerBlock*> blocks_;
 };
 
 #endif

--- a/OrbitGl/TimerChain.h
+++ b/OrbitGl/TimerChain.h
@@ -50,7 +50,7 @@ class TimerBlock {
  private:
   static constexpr int kMaxSize = 1024;
   TextBox data_[kMaxSize];
-  std::atomic<int> size_;
+  int size_;
 
   uint64_t min_timestamp_;
   uint64_t max_timestamp_;
@@ -59,17 +59,16 @@ class TimerBlock {
 class TimerChain {
  public:
   TimerChain();
-  ~TimerChain();
 
   void push_back(const TextBox& box);
 
   int size() const { return blocks_.size(); }
 
-  TimerBlock* operator[](std::size_t idx) { 
+  TimerBlock& operator[](std::size_t idx) {
     return blocks_[idx];
   }
     
-  const TimerBlock* operator[](std::size_t idx) const { 
+  const TimerBlock& operator[](std::size_t idx) const {
     return blocks_[idx];
   }
 
@@ -80,7 +79,7 @@ class TimerChain {
   TextBox* GetElementBefore(const TextBox* element);
 
  private:
-  std::vector<TimerBlock*> blocks_;
+  std::vector<TimerBlock> blocks_;
 };
 
 #endif

--- a/OrbitGl/TimerChain.h
+++ b/OrbitGl/TimerChain.h
@@ -1,0 +1,86 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_TIMER_CHAIN_
+#define ORBIT_GL_TIMER_CHAIN_
+
+#include <assert.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cstdint>
+#include <limits>
+
+#include "TextBox.h"
+
+class TimerBlock {
+ public:
+  TimerBlock();
+
+  bool AtCapacity() const {
+    return size_ == kMaxSize;
+  }
+
+  // Silently fails when the block is full.
+  void Add(const TextBox& box);
+  
+  bool Intersects(uint64_t min, uint64_t max);
+
+  int size() const {
+    return size_;
+  }
+
+  uint64_t min_timestamp() {
+    return min_timestamp_;
+  }
+
+  uint64_t max_timestamp() {
+    return max_timestamp_;
+  }
+
+  TextBox& operator[](std::size_t idx) { 
+    return data_[idx];
+  }
+    
+  const TextBox& operator[](std::size_t idx) const { 
+    return data_[idx];
+  }
+  
+ private:
+  static constexpr int kMaxSize = 1024;
+  TextBox data_[kMaxSize];
+  std::atomic<int> size_;
+
+  uint64_t min_timestamp_;
+  uint64_t max_timestamp_;
+};
+
+class TimerChain {
+ public:
+  TimerChain();
+  ~TimerChain();
+
+  void push_back(const TextBox& box);
+
+  int size() const { return blocks_.size(); }
+
+  TimerBlock* operator[](std::size_t idx) { 
+    return blocks_[idx];
+  }
+    
+  const TimerBlock* operator[](std::size_t idx) const { 
+    return blocks_[idx];
+  }
+
+  int GetBlockContaining(const TextBox* element);
+
+  TextBox* GetElementAfter(const TextBox* element);
+
+  TextBox* GetElementBefore(const TextBox* element);
+
+ private:
+  std::vector<TimerBlock*> blocks_;
+};
+
+#endif

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -17,12 +17,11 @@
 #include "TextBox.h"
 #include "TextRenderer.h"
 #include "TimeGraphLayout.h"
+#include "TimerChain.h"
 #include "TriangleToggle.h"
 
 class GlCanvas;
 class TimeGraph;
-
-typedef BlockChain<TextBox, 4 * 1024> TimerChain;
 
 //-----------------------------------------------------------------------------
 class Track : public Pickable {


### PR DESCRIPTION
This allows simple discarding of blocks based on timestamps and leads to a strong speed-up of rendering of longer captures. Example: For a 20s capture with > 8M instrumentation events, TimeGraph::UpdatePrimitives now takes ~21ms, down from ~108ms before this change. 

I'm not sure the definitions of TimerBlock and TimerChain are good C++, happy to hear suggestions for improvements. 