### PR TITLE
Reprocess SamplingProfiler entirely when loading a new module

### DIFF
--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -73,12 +73,6 @@ void (*Capture::GClearCaptureDataFunc)();
 std::vector<std::shared_ptr<SamplingProfiler>> GOldSamplingProfilers;
 bool Capture::GUnrealSupported = false;
 
-// The user_data pointer is provided by caller when registering capture
-// callback. It is then passed to the callback and can be used to store context
-// such as a pointer to a class.
-Capture::SamplingDoneCallback Capture::sampling_done_callback_ = nullptr;
-void* Capture::sampling_done_callback_user_data_ = nullptr;
-
 //-----------------------------------------------------------------------------
 void Capture::Init() { GTargetProcess = std::make_shared<Process>(); }
 
@@ -415,36 +409,6 @@ TcpEntity* Capture::GetMainTcpEntity() {
     return GTcpClient.get();
   }
   return GTcpServer.get();
-}
-
-//-----------------------------------------------------------------------------
-void Capture::Update() {
-  if (GIsSampling) {
-#ifdef WIN32
-    if (GSamplingProfiler->ShouldStop()) {
-      GSamplingProfiler->StopCapture();
-    }
-#endif
-
-    if (GSamplingProfiler->GetState() == SamplingProfiler::DoneProcessing) {
-      if (sampling_done_callback_ != nullptr) {
-        sampling_done_callback_(GSamplingProfiler,
-                                sampling_done_callback_user_data_);
-      }
-      GIsSampling = false;
-    }
-  }
-
-  if (GPdbDbg) {
-    GPdbDbg->Update();
-  }
-
-#ifdef WIN32
-  if (!Capture::IsRemote() && GInjected && !GTcpServer->HasConnection()) {
-    StopCapture();
-    GInjected = false;
-  }
-#endif
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -186,7 +186,6 @@ outcome::result<void, std::string> Capture::StartCapture(
 #endif
   } else if (Capture::IsRemote()) {
     Capture::NewSamplingProfiler();
-    Capture::GSamplingProfiler->SetIsLinuxPerf(true);
     Capture::GSamplingProfiler->StartCapture();
   }
 

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -40,7 +40,6 @@ class Capture {
   static void StartSampling();
   static void StopSampling();
   static bool IsCapturing();
-  static void Update();
   static void DisplayStats();
   static void TestHooks();
   static outcome::result<void, std::string> SaveSession(
@@ -57,14 +56,6 @@ class Capture {
   static LinuxAddressInfo* GetAddressInfo(uint64_t address);
   static void CheckForUnrealSupport();
   static void PreSave();
-
-  typedef void (*SamplingDoneCallback)(
-      std::shared_ptr<SamplingProfiler>& sampling_profiler, void* user_data);
-  static void SetSamplingDoneCallback(SamplingDoneCallback callback,
-                                      void* user_data) {
-    sampling_done_callback_ = callback;
-    sampling_done_callback_user_data_ = user_data;
-  }
 
   static void TestRemoteMessages();
   static class TcpEntity* GetMainTcpEntity();
@@ -105,6 +96,4 @@ class Capture {
 
  private:
   static bool GUnrealSupported;
-  static SamplingDoneCallback sampling_done_callback_;
-  static void* sampling_done_callback_user_data_;
 };

--- a/OrbitCore/EventTracer.cpp
+++ b/OrbitCore/EventTracer.cpp
@@ -165,7 +165,7 @@ void EventTracer::Stop() {
     m_IsTracing = false;
     if (Capture::GSamplingProfiler) {
       Capture::GSamplingProfiler->StopCapture();
-      Capture::GSamplingProfiler->ProcessSamplesAsync();
+      Capture::GSamplingProfiler->ProcessSamples();
     }
   }
 

--- a/OrbitCore/SamplingProfiler.cpp
+++ b/OrbitCore/SamplingProfiler.cpp
@@ -242,13 +242,6 @@ void SamplingProfiler::Print() {
 }
 
 //-----------------------------------------------------------------------------
-void SamplingProfiler::ProcessSamplesAsync() {
-  m_SamplingThread =
-      std::make_unique<std::thread>(&SamplingProfiler::ProcessSamples, this);
-  m_SamplingThread->detach();
-}
-
-//-----------------------------------------------------------------------------
 void SamplingProfiler::ProcessSamples() {
   ScopeLock lock(m_Mutex);
 

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -139,8 +139,6 @@ class SamplingProfiler {
 
     return &it->second;
   }
-  void SetLoadedFromFile(bool a_Value = true) { m_LoadedFromFile = a_Value; }
-  void SetIsLinuxPerf(bool a_Value = true) { m_IsLinuxPerf = a_Value; }
 
   typedef std::function<void()> ProcessingDoneCallback;
   void AddCallback(const ProcessingDoneCallback& a_Callback) {
@@ -150,8 +148,6 @@ class SamplingProfiler {
   bool GetGenerateSummary() const { return m_GenerateSummary; }
   void SortByThreadUsage();
   void SortByThreadID();
-  bool GetLineInfo(uint64_t a_Address, LineInfo& a_LineInfo);
-  void Print();
   void ProcessSamples();
   // Like ProcessSamples, but after m_Callstacks has been cleared and the other
   // fields have been filled. Call this after loading a module.
@@ -172,7 +168,6 @@ class SamplingProfiler {
 
  protected:
   std::shared_ptr<Process> m_Process;
-  std::unique_ptr<std::thread> m_SamplingThread;
   std::atomic<SamplingState> m_State;
   Timer m_SamplingTimer;
   Timer m_ThreadUsageTimer;
@@ -181,8 +176,6 @@ class SamplingProfiler {
   bool m_GenerateSummary = true;
   Mutex m_Mutex;
   int m_NumSamples = 0;
-  bool m_LoadedFromFile = false;
-  bool m_IsLinuxPerf = false;
 
   std::vector<ProcessingDoneCallback> m_Callbacks;
 
@@ -200,7 +193,4 @@ class SamplingProfiler {
   std::unordered_map<uint64_t, std::set<CallstackID>> m_FunctionToCallstacks;
   std::unordered_map<uint64_t, uint64_t> m_ExactAddressToFunctionAddress;
   std::vector<ThreadSampleData*> m_SortedThreadSampleData;
-
-  std::unordered_map<uint64_t, LineInfo> m_AddressToLineInfo;
-  std::unordered_map<uint64_t, std::string> m_FileNames;
 };

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -156,7 +156,6 @@ class SamplingProfiler {
   // Updates names of sampled functions for all threads.
   // Call this after loading a module.
   void UpdateSampledFunctions();
-  void ProcessSamplesAsync();
   void UpdateAddressInfo(uint64_t address);
 
   const ThreadSampleData& GetSummary() { return m_ThreadSampleData[0]; }

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -149,9 +149,6 @@ class SamplingProfiler {
   void SortByThreadUsage();
   void SortByThreadID();
   void ProcessSamples();
-  // Like ProcessSamples, but after m_Callstacks has been cleared and the other
-  // fields have been filled. Call this after loading a module.
-  void ReprocessSamples();
   void UpdateAddressInfo(uint64_t address);
 
   const ThreadSampleData& GetSummary() { return m_ThreadSampleData[0]; }

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -104,16 +104,15 @@ class OrbitApp final : public CoreApp, public DataViewFactory {
 
   void OnProcessSelected(uint32_t pid);
 
+  void AddSamplingReport(
+      std::shared_ptr<class SamplingProfiler>& sampling_profiler);
+  void AddSelectionReport(
+      std::shared_ptr<SamplingProfiler>& a_SamplingProfiler);
+
   void Unregister(class DataView* a_Model);
   bool SelectProcess(const std::string& a_Process);
   bool SelectProcess(uint32_t a_ProcessID);
   bool Inject(unsigned long a_ProcessId);
-  static void AddSamplingReport(
-      std::shared_ptr<class SamplingProfiler>& sampling_profiler,
-      void* app_ptr);
-
-  static void AddSelectionReport(
-      std::shared_ptr<SamplingProfiler>& a_SamplingProfiler);
 
   void GoToCode(DWORD64 a_Address);
   void GoToCallstack();

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -176,7 +176,6 @@ outcome::result<void, std::string> CaptureSerializer::Load(
       Capture::GSamplingProfiler = std::make_shared<SamplingProfiler>();
     }
     Capture::GSamplingProfiler->SortByThreadUsage();
-    Capture::GSamplingProfiler->SetLoadedFromFile(true);
 
     time_graph_->Clear();
 

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -191,7 +191,7 @@ outcome::result<void, std::string> CaptureSerializer::Load(
       time_graph_->ProcessTimer(timer);
     }
 
-    GOrbitApp->AddSamplingReport(Capture::GSamplingProfiler, GOrbitApp.get());
+    GOrbitApp->AddSamplingReport(Capture::GSamplingProfiler);
     GOrbitApp->FireRefreshCallbacks();
     return outcome::success();
 

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -284,9 +284,7 @@ void CaptureWindow::FindCode(DWORD64 address) {
 
   LineInfo lineInfo;
 
-  if (SymUtils::GetLineInfo(address, lineInfo) ||
-      (Capture::GSamplingProfiler &&
-       Capture::GSamplingProfiler->GetLineInfo(address, lineInfo))) {
+  if (SymUtils::GetLineInfo(address, lineInfo)) {
     --lineInfo.m_Line;
 
     // File mapping

--- a/OrbitGl/SamplingReport.cpp
+++ b/OrbitGl/SamplingReport.cpp
@@ -43,7 +43,7 @@ void SamplingReport::FillReport() {
 }
 
 void SamplingReport::UpdateReport() {
-  m_Profiler->ReprocessSamples();
+  m_Profiler->ProcessSamples();
   for (SamplingReportDataView& thread_report : m_ThreadReports) {
     uint32_t thread_id = thread_report.GetThreadID();
     const ThreadSampleData* thread_sample_data =

--- a/OrbitGl/SamplingReport.h
+++ b/OrbitGl/SamplingReport.h
@@ -45,7 +45,8 @@ class SamplingReport {
   CallStackDataView* m_CallstackDataView;
 
   uint64_t m_SelectedAddress;
+  uint32_t m_SelectedTid;
   std::shared_ptr<SortedCallstackReport> m_SelectedSortedCallstackReport;
-  size_t m_SelectedAddressCallstackIndex;
+  size_t m_SelectedCallstackIndex;
   std::function<void()> m_UiRefreshFunc;
 };

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -471,8 +471,6 @@ std::vector<CallstackEvent> TimeGraph::SelectEvents(float a_WorldStart,
   std::shared_ptr<SamplingProfiler> samplingProfiler =
       std::make_shared<SamplingProfiler>(Capture::GTargetProcess);
 
-  samplingProfiler->SetIsLinuxPerf(
-      Capture::IsRemote());  // TODO: could be windows->windows remote capture
   samplingProfiler->SetState(SamplingProfiler::Sampling);
   samplingProfiler->SetGenerateSummary(a_TID == 0);
 

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -84,7 +84,7 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App,
   GOrbitApp->AddSelectionReportCallback(
       [this](DataView* callstack_data_view,
              std::shared_ptr<SamplingReport> report) {
-        this->OnNewSelection(callstack_data_view, std::move(report));
+        this->OnNewSelectionReport(callstack_data_view, std::move(report));
       });
   GOrbitApp->AddUiMessageCallback([this](const std::string& a_Message) {
     this->OnReceiveMessage(a_Message);
@@ -379,7 +379,7 @@ void OrbitMainWindow::CreateSelectionTab() {
 }
 
 //-----------------------------------------------------------------------------
-void OrbitMainWindow::OnNewSelection(
+void OrbitMainWindow::OnNewSelectionReport(
     DataView* callstack_data_view,
     std::shared_ptr<class SamplingReport> sampling_report) {
   m_SelectionLayout->removeWidget(m_SelectionReport);

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -38,8 +38,9 @@ class OrbitMainWindow : public QMainWindow {
   void CreateSamplingTab();
   void CreateSelectionTab();
   void CreatePluginTabs();
-  void OnNewSelection(DataView* callstack_data_view,
-                      std::shared_ptr<class SamplingReport> sampling_report);
+  void OnNewSelectionReport(
+      DataView* callstack_data_view,
+      std::shared_ptr<class SamplingReport> sampling_report);
   void OnReceiveMessage(const std::string& message);
   void OnAddToWatch(const class Variable* a_Variable);
   std::string OnGetSaveFileName(const std::string& extension);

--- a/OrbitQt/orbitsamplingreport.cpp
+++ b/OrbitQt/orbitsamplingreport.cpp
@@ -105,10 +105,8 @@ void OrbitSamplingReport::RefreshCallstackView() {
     return;
   }
 
-  if (m_SamplingReport->HasCallstacks()) {
-    ui->NextCallstackButton->setEnabled(true);
-    ui->PreviousCallstackButton->setEnabled(true);
-  }
+  ui->NextCallstackButton->setEnabled(m_SamplingReport->HasCallstacks());
+  ui->PreviousCallstackButton->setEnabled(m_SamplingReport->HasCallstacks());
 
   std::string label = m_SamplingReport->GetSelectedCallstackString();
   ui->CallStackLabel->setText(QString::fromStdString(label));


### PR DESCRIPTION
#### Remove SamplingProfiler::ProcessSamplesAsync
This is only used in Windows code that is currently unused and should be
implemented differently as it detaches a thread.
#### Simplify confusing sequence of callbacks to OrbitApp::AddSamplingReport
#### Add SamplingProfiler::ReprocessSamples to redo the entire processing
This replaces `SamplingProfiler::UpdateSampledFunctions` for use in
`SamplingReport::UpdateReport`. This is needed after loading a module as we
might have more information on addresses belonging to the same function.
Bug: http://b/157632145
#### Remove some old code from SamplingProfiler