### PR TITLE
Remove LOG("Received message from previous capture");

### DIFF
--- a/OrbitCore/TcpClient.cpp
+++ b/OrbitCore/TcpClient.cpp
@@ -163,9 +163,8 @@ void TcpClient::OnError(const std::error_code& ec) {
 
 //-----------------------------------------------------------------------------
 void TcpClient::DecodeMessage(Message& a_Message) {
+  // Don't process messages from previous captures.
   if (a_Message.m_CaptureID == Message::GCaptureID) {
     Callback(a_Message);
-  } else {
-    LOG("Received message from previous capture");
   }
 }


### PR DESCRIPTION
If this happens with one message, it probably happens with several, flooding the
log.