### PR TITLE
Rename THIRD_PARTY_LICENSES to NOTICE.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,4 +186,4 @@ file(COPY third_party/stb/LICENSE DESTINATION ${CMAKE_BINARY_DIR}/licenses/stb/l
 file(REMOVE ${CMAKE_BINARY_DIR}/licenses/freetype/licenses/LICENSE.TXT)
 file(REMOVE ${CMAKE_BINARY_DIR}/licenses/freetype/licenses/GPLv2.TXT)
 include("cmake/collect_licenses.cmake")
-GenerateThirdPartyLicenseFile("${CMAKE_BINARY_DIR}/THIRD_PARTY_LICENSES.txt" "${CMAKE_BINARY_DIR}/licenses/")
+GenerateThirdPartyLicenseFile("${CMAKE_BINARY_DIR}/NOTICE" "${CMAKE_BINARY_DIR}/licenses/")

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -500,7 +500,7 @@ void OrbitMainWindow::on_actionAbout_triggered() {
   dialog.setVersionString(QCoreApplication::applicationVersion());
 
   QFile licenseFile{QDir{QCoreApplication::applicationDirPath()}.filePath(
-      "THIRD_PARTY_LICENSES.txt")};
+      "NOTICE")};
   if (licenseFile.open(QIODevice::ReadOnly)) {
     dialog.setLicenseText(licenseFile.readAll());
   }

--- a/conanfile.py
+++ b/conanfile.py
@@ -146,7 +146,7 @@ class OrbitConan(ConanFile):
                 self.name, self._version()), symlinks=True)
             self.copy("OrbitService", src="bin/",
                       dst="{}-{}/opt/developer/tools/".format(self.name, self._version()))
-            self.copy("THIRD_PARTY_LICENSES.txt",
+            self.copy("NOTICE",
                       dst="{}-{}/usr/share/doc/{}/".format(self.name, self._version(), self.name))
             self.copy("LICENSE",
                       dst="{}-{}/usr/share/doc/{}/".format(self.name, self._version(), self.name))
@@ -191,7 +191,7 @@ chmod -v 4775 /opt/developer/tools/OrbitService
         self.copy("OrbitService.exe", src="bin/", dst="bin")
         self.copy("OrbitService.debug", src="bin/", dst="bin")
         self.copy("crashpad_handler.exe", src="bin/", dst="bin")
-        self.copy("THIRD_PARTY_LICENSES.txt")
+        self.copy("NOTICE")
         self.copy("LICENSE")
 
     def deploy(self):

--- a/kokoro/gcp_windows/kokoro_build.bat
+++ b/kokoro/gcp_windows/kokoro_build.bat
@@ -42,7 +42,7 @@ if "%symbol_uploading_required%" == "true" (
 cd %REPO_ROOT%\build\package
 Xcopy /E /I bin Orbit
 del /s /q Orbit\*.pdb
-copy /Y THIRD_PARTY_LICENSES.txt Orbit\THIRD_PARTY_LICENSES.txt
+copy /Y NOTICE Orbit\NOTICE
 copy /Y LICENSE Orbit\LICENSE.txt
 zip -r Orbit.zip Orbit
 rd /s /q Orbit


### PR DESCRIPTION
@beckerhe , I noticed that the "about" dialog doesn't work for local builds, is that a known issue?  Basically, the THIRD_PARTY_LICENSES/NOTICE file is not copied to the local bin directory.