### PR TITLE
Ack from the service when done sending data and dialog while waiting for it

### DIFF
--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -206,15 +206,6 @@ void Capture::StopCapture() {
 #ifdef WIN32
     GEventTracer.Stop();
 #endif
-  } else if (Capture::IsRemote()) {
-    if (Capture::GSamplingProfiler != nullptr) {
-      Capture::GSamplingProfiler->StopCapture();
-      Capture::GSamplingProfiler->ProcessSamples();
-    }
-
-    if (GCoreApp != nullptr) {
-      GCoreApp->RefreshCaptureView();
-    }
   }
 
   if (!GInjected) {

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -23,6 +23,8 @@ struct CallStack;
 
 class Capture {
  public:
+  enum class State { kEmpty = 0, kStarted, kStopping, kDone };
+
   static void Init();
   static bool Inject(std::string_view remote_address);
   static bool Connect(std::string_view remote_address);
@@ -33,6 +35,7 @@ class Capture {
   static outcome::result<void, std::string> StartCapture(
       std::string_view remote_address);
   static void StopCapture();
+  static void FinalizeCapture();
   static void ClearCaptureData();
   static std::vector<std::shared_ptr<Function>> GetSelectedFunctions();
   static void PreFunctionHooks();
@@ -60,6 +63,7 @@ class Capture {
   static void TestRemoteMessages();
   static class TcpEntity* GetMainTcpEntity();
 
+  static State GState;
   static bool GInjected;
   static std::string GInjectedProcess;
   static std::string GPresetToLoad;  // TODO: allow multiple presets

--- a/OrbitCore/ConnectionManager.cpp
+++ b/OrbitCore/ConnectionManager.cpp
@@ -101,8 +101,8 @@ void ConnectionManager::SetupClientCallbacks() {
     }
   });
 
-  GTcpClient->AddCallback(Msg_CaptureStopped,
-                          [](const Message&) { GCoreApp->OnCaptureStopped(); });
+  GTcpClient->AddMainThreadCallback(
+      Msg_CaptureStopped, [](const Message&) { GCoreApp->OnCaptureStopped(); });
 }
 
 void ConnectionManager::ConnectionThreadWorker() {

--- a/OrbitCore/ConnectionManager.cpp
+++ b/OrbitCore/ConnectionManager.cpp
@@ -100,6 +100,9 @@ void ConnectionManager::SetupClientCallbacks() {
       GCoreApp->UpdateThreadName(tid_and_name.tid, tid_and_name.thread_name);
     }
   });
+
+  GTcpClient->AddCallback(Msg_CaptureStopped,
+                          [](const Message&) { GCoreApp->OnCaptureStopped(); });
 }
 
 void ConnectionManager::ConnectionThreadWorker() {

--- a/OrbitCore/CoreApp.h
+++ b/OrbitCore/CoreApp.h
@@ -49,6 +49,7 @@ class CoreApp {
   virtual void AddKeyAndString(uint64_t /*key*/, std::string_view /*str*/) {}
   virtual void UpdateThreadName(uint32_t /*thread_id*/,
                                 const std::string& /*thread_name*/) {}
+  virtual void OnCaptureStopped() {}
   virtual void OnRemoteModuleDebugInfo(const std::vector<ModuleDebugInfo>&) {}
   virtual void ApplySession(const Session&) {}
   virtual void RefreshCaptureView() {}

--- a/OrbitCore/Message.h
+++ b/OrbitCore/Message.h
@@ -70,6 +70,7 @@ enum MessageType : int16_t {
   Msg_MemoryTransfer,
   Msg_ThreadNames,
   Msg_ValidateFramePointers,
+  Msg_CaptureStopped
 };
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -758,7 +758,6 @@ bool OrbitApp::StartCapture() {
 //-----------------------------------------------------------------------------
 void OrbitApp::StopCapture() {
   Capture::StopCapture();
-  AddSamplingReport(Capture::GSamplingProfiler);
 
   for (const CaptureStopRequestedCallback& callback :
        capture_stop_requested_callbacks_) {
@@ -768,10 +767,19 @@ void OrbitApp::StopCapture() {
 }
 
 void OrbitApp::OnCaptureStopped() {
+  if (Capture::GSamplingProfiler != nullptr) {
+    Capture::GSamplingProfiler->StopCapture();
+    Capture::GSamplingProfiler->ProcessSamples();
+    AddSamplingReport(Capture::GSamplingProfiler);
+  }
+
+  RefreshCaptureView();
+
   for (const CaptureStopRequestedCallback& callback :
        capture_stopped_callbacks_) {
     callback();
   }
+  FireRefreshCallbacks();
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -767,13 +767,9 @@ void OrbitApp::StopCapture() {
 }
 
 void OrbitApp::OnCaptureStopped() {
-  if (Capture::GSamplingProfiler != nullptr) {
-    Capture::GSamplingProfiler->StopCapture();
-    Capture::GSamplingProfiler->ProcessSamples();
-    AddSamplingReport(Capture::GSamplingProfiler);
-  }
+  Capture::FinalizeCapture();
 
-  RefreshCaptureView();
+  AddSamplingReport(Capture::GSamplingProfiler);
 
   for (const CaptureStopRequestedCallback& callback :
        capture_stopped_callbacks_) {

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -990,14 +990,6 @@ void OrbitApp::ApplySession(const Session& session) {
   FireRefreshCallbacks();
 }
 
-//-----------------------------------------------------------------------------
-void OrbitApp::OnRemoteModuleDebugInfo(const Message& a_Message) {
-  std::vector<ModuleDebugInfo> remote_module_debug_infos;
-  DeserializeObjectBinary(a_Message.GetData(), a_Message.GetSize(),
-                          remote_module_debug_infos);
-  OnRemoteModuleDebugInfo(remote_module_debug_infos);
-}
-
 std::shared_ptr<Process> OrbitApp::FindProcessByPid(uint32_t pid) {
   absl::MutexLock lock(&process_map_mutex_);
   auto it = process_map_.find(pid);

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -760,10 +760,18 @@ void OrbitApp::StopCapture() {
   Capture::StopCapture();
   AddSamplingReport(Capture::GSamplingProfiler);
 
-  for (const CaptureStoppedCallback& callback : capture_stopped_callbacks_) {
+  for (const CaptureStopRequestedCallback& callback :
+       capture_stop_requested_callbacks_) {
     callback();
   }
   FireRefreshCallbacks();
+}
+
+void OrbitApp::OnCaptureStopped() {
+  for (const CaptureStopRequestedCallback& callback :
+       capture_stopped_callbacks_) {
+    callback();
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -77,6 +77,7 @@ class OrbitApp final : public CoreApp, public DataViewFactory {
   void Inject(const std::string& file_name);
   bool StartCapture();
   void StopCapture();
+  void OnCaptureStopped() override;
   void ToggleCapture();
   void OnDisconnect();
   void OnPdbLoaded();
@@ -122,6 +123,10 @@ class OrbitApp final : public CoreApp, public DataViewFactory {
   using CaptureStartedCallback = std::function<void()>;
   void AddCaptureStartedCallback(CaptureStartedCallback callback) {
     capture_started_callbacks_.emplace_back(std::move(callback));
+  }
+  using CaptureStopRequestedCallback = std::function<void()>;
+  void AddCaptureStopRequestedCallback(CaptureStopRequestedCallback callback) {
+    capture_stop_requested_callbacks_.emplace_back(std::move(callback));
   }
   using CaptureStoppedCallback = std::function<void()>;
   void AddCaptureStoppedCallback(CaptureStoppedCallback callback) {
@@ -242,6 +247,7 @@ class OrbitApp final : public CoreApp, public DataViewFactory {
 
   std::vector<std::string> m_Arguments;
   std::vector<CaptureStartedCallback> capture_started_callbacks_;
+  std::vector<CaptureStopRequestedCallback> capture_stop_requested_callbacks_;
   std::vector<CaptureStoppedCallback> capture_stopped_callbacks_;
   std::vector<RefreshCallback> m_RefreshCallbacks;
   std::vector<WatchCallback> m_AddToWatchCallbacks;

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -211,7 +211,6 @@ class OrbitApp final : public CoreApp, public DataViewFactory {
 
   void RequestThaw() { m_NeedsThawing = true; }
   void OnRemoteProcess(const Message& a_Message);
-  void OnRemoteModuleDebugInfo(const Message& a_Message);
   void OnRemoteModuleDebugInfo(const std::vector<ModuleDebugInfo>&) override;
   void UpdateSamplingReport();
   void ApplySession(const Session& session) override;

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -173,11 +173,6 @@ class OrbitApp final : public CoreApp, public DataViewFactory {
 
   void SetCommandLineArguments(const std::vector<std::string>& a_Args);
 
-  // TODO(antonrohr) check whether this is still used
-  const std::vector<std::string>& GetCommandLineArguments() {
-    return m_Arguments;
-  }
-
   void SendToUi(const std::string& message) override;
   void SendInfoToUi(const std::string& title, const std::string& text);
   void SendErrorToUi(const std::string& title, const std::string& text);

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -126,7 +126,7 @@ void CaptureSerializer::Save(T& archive) {
     if (!chain) continue;
     for (TimerChainIterator it = chain->begin(); it != chain->end(); ++it) {
       TimerBlock& block = *it;
-      for (int k = 0; k < block.size(); ++k) {
+      for (uint32_t k = 0; k < block.size(); ++k) {
         archive(cereal::binary_data(&(block[k].GetTimer()), sizeof(Timer)));
 
         if (++numWrites > m_NumTimers) {

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -158,7 +158,7 @@ void GpuTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
       min_ignore = std::numeric_limits<uint64_t>::max();
       max_ignore = std::numeric_limits<uint64_t>::min();
 
-      for (int k = 0; k < block.size(); ++k) {
+      for (uint32_t k = 0; k < block.size(); ++k) {
         TextBox& text_box =  block[k];
         const Timer& timer = text_box.GetTimer();
         if (min_tick > timer.m_End || max_tick < timer.m_Start) continue;
@@ -264,7 +264,7 @@ const TextBox* GpuTrack::GetFirstAfterTime(TickType time,
 
   // TODO: do better than linear search...
   for (TimerChainIterator it = chain->begin(); it != chain->end(); ++it) {
-    for (int k = 0; k < it->size(); ++k) {
+    for (uint32_t k = 0; k < it->size(); ++k) {
       const TextBox& text_box = (*it)[k];
       if (text_box.GetTimer().m_Start > time) {
         return &text_box;
@@ -285,7 +285,7 @@ const TextBox* GpuTrack::GetFirstBeforeTime(TickType time,
 
   // TODO: do better than linear search...
   for (TimerChainIterator it = chain->begin(); it != chain->end(); ++it) {
-    for (int k = 0; k < it->size(); ++k) {
+    for (uint32_t k = 0; k < it->size(); ++k) {
       const TextBox& box = (*it)[k];
       if (box.GetTimer().m_Start > time) {
         return text_box;

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -72,13 +72,22 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App,
 
   GOrbitApp->AddCaptureStartedCallback(
       [this] { ui->HomeTab->setDisabled(true); });
-  GOrbitApp->AddCaptureStopRequestedCallback([] {
-    // TODO: Show some kind of "Waiting for remaining capture data" dialog.
+
+  auto finalizing_capture_message_box = std::make_shared<QMessageBox>(this);
+  finalizing_capture_message_box->setWindowTitle("Finalizing capture");
+  finalizing_capture_message_box->setText(
+      "Waiting for the remaining capture data...");
+  finalizing_capture_message_box->setIcon(QMessageBox::Information);
+  finalizing_capture_message_box->setStandardButtons(QMessageBox::NoButton);
+
+  GOrbitApp->AddCaptureStopRequestedCallback([finalizing_capture_message_box] {
+    finalizing_capture_message_box->open();
   });
-  GOrbitApp->AddCaptureStoppedCallback([this] {
-    LOG("All capture data received");
+  GOrbitApp->AddCaptureStoppedCallback([this, finalizing_capture_message_box] {
+    finalizing_capture_message_box->accept();
     ui->HomeTab->setDisabled(false);
   });
+
   GOrbitApp->AddRefreshCallback(
       [this](DataViewType a_Type) { this->OnRefreshDataViewPanels(a_Type); });
   GOrbitApp->AddSamplingReportCallback(

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -72,9 +72,13 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App,
 
   GOrbitApp->AddCaptureStartedCallback(
       [this] { ui->HomeTab->setDisabled(true); });
-  GOrbitApp->AddCaptureStopRequestedCallback(
-      [this] { ui->HomeTab->setDisabled(false); });
-  GOrbitApp->AddCaptureStoppedCallback([] { LOG("Capture stopped"); });
+  GOrbitApp->AddCaptureStopRequestedCallback([] {
+    // TODO: Show some kind of "Waiting for remaining capture data" dialog.
+  });
+  GOrbitApp->AddCaptureStoppedCallback([this] {
+    LOG("All capture data received");
+    ui->HomeTab->setDisabled(false);
+  });
   GOrbitApp->AddRefreshCallback(
       [this](DataViewType a_Type) { this->OnRefreshDataViewPanels(a_Type); });
   GOrbitApp->AddSamplingReportCallback(

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -72,8 +72,9 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App,
 
   GOrbitApp->AddCaptureStartedCallback(
       [this] { ui->HomeTab->setDisabled(true); });
-  GOrbitApp->AddCaptureStoppedCallback(
+  GOrbitApp->AddCaptureStopRequestedCallback(
       [this] { ui->HomeTab->setDisabled(false); });
+  GOrbitApp->AddCaptureStoppedCallback([] { LOG("Capture stopped"); });
   GOrbitApp->AddRefreshCallback(
       [this](DataViewType a_Type) { this->OnRefreshDataViewPanels(a_Type); });
   GOrbitApp->AddSamplingReportCallback(

--- a/OrbitService/OrbitAsioServer.cpp
+++ b/OrbitService/OrbitAsioServer.cpp
@@ -118,6 +118,7 @@ void OrbitAsioServer::StopCapture() {
   if (tracing_buffer_thread_.joinable()) {
     tracing_buffer_thread_.join();
   }
+  tcp_server_->Send(Msg_CaptureStopped);
 }
 
 void OrbitAsioServer::SetupTransactionServices() {


### PR DESCRIPTION
#### Remove unused OrbitApp::OnRemoteModuleDebugInfo(const Message&)
#### Remove unused OrbitApp::GetCommandLineArguments
#### Have service send an ack when done sending data for a capture
Also add the relative callbacks, but do nothing for now.
Bug: http://b/157973915
#### Move some logic from Capture::StopCapture to OrbitApp::OnCaptureStopped
#### Show dialog between the capture stop and the end of data transmission
Show a non-dismissable modal dialog between sending `Msg_StopCapture` and
receiving `Msg_CaptureStopped`.
Bug: http://b/157973915
#### Introduce Capture::FinalizeCapture, State, GState
This is to add support to `Capture` for the ack sent by the service when done
sending all the capture data. In particular, it allows the capture view to keep
scrolling while more data is still coming.
In the process, some logic that was moved from `Capture::StopCapture` to
`OrbitApp::OnCaptureStopped` in a previous commit is brought back to `Capture`
in `FinalizeCapture`.
Also, the use of `GTimerManager` in `Capture::StartCapture`,`StopCapture`,
`IsRecording` is removed.
Bug: http://b/157973915

---
![Screenshot from 2020-06-12 15-18-26](https://user-images.githubusercontent.com/58685940/84508809-281fe300-acc3-11ea-8a34-2e676df994a1.png)
