### PR TITLE
Updates GRPC conan package

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -57,7 +57,7 @@ class OrbitConan(ConanFile):
         self.requires("bzip2/1.0.8@conan/stable#0")
         self.requires("capstone/4.0.1@{}#0".format(self._orbit_channel))
         self.requires("cereal/1.3.0@{}#0".format(self._orbit_channel))
-        self.requires("grpc/1.27.3@{}#0".format(self._orbit_channel))
+        self.requires("grpc/1.27.3@{}#dc2368a2df63276188566e36a6b7868a".format(self._orbit_channel))
         self.requires("gtest/1.8.1@bincrafters/stable#0")
         self.requires("llvm_object/9.0.1@orbitdeps/stable#0")
         self.requires("openssl/1.1.1d@{}#0".format(self._orbit_channel))

--- a/protos/CMakeLists.txt
+++ b/protos/CMakeLists.txt
@@ -4,10 +4,10 @@ project(OrbitProtos)
 
 add_library(OrbitProtos STATIC)
 target_compile_options(OrbitProtos PRIVATE ${STRICT_COMPILE_FLAGS})
+target_compile_definitions(OrbitProtos PRIVATE -D_WIN32_WINNT=0x0700)
+target_compile_definitions(OrbitProtos PRIVATE -DNTDDI_VERSION=0x06030000)
 
-target_sources(OrbitProtos PRIVATE dummy.cpp
-                                   process.proto
+target_sources(OrbitProtos PRIVATE process.proto
                                    services.proto)
 
 grpc_helper(OrbitProtos)
-

--- a/protos/dummy.cpp
+++ b/protos/dummy.cpp
@@ -1,8 +1,0 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
-// This file is there as a workaround for a problem
-// with grpc_helpers where it does not work for proto-only
-// static libraries. It needs to have at least one non-proto
-// file in sources

--- a/third_party/conan/lockfiles/linux/clang7_debug/conan.lock
+++ b/third_party/conan/lockfiles/linux/clang7_debug/conan.lock
@@ -61,7 +61,7 @@
     "options": "thread_safe=False"
    },
    "7": {
-    "pref": "grpc/1.27.3@orbitdeps/stable#0:087693a233c10298deebb4daedd739ca6d075f85#cce0c705541b0bb056d3ea01e9b440fd",
+    "pref": "grpc/1.27.3@orbitdeps/stable#dc2368a2df63276188566e36a6b7868a:668701dab9aebd3d0664009f43d221222397b3b0",
     "options": "fPIC=True\nabseil:cxx_standard=17\nabseil:fPIC=True\nc-ares:fPIC=True\nc-ares:shared=False\ncctz:build_tools=False\ncctz:fPIC=True\ncctz:shared=False\nopenssl:386=False\nopenssl:fPIC=True\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_cast=False\nopenssl:no_des=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_hmac=False\nopenssl:no_md2=False\nopenssl:no_md5=False\nopenssl:no_mdc2=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rsa=False\nopenssl:no_sha=False\nopenssl:no_sse2=False\nopenssl:no_threads=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "2",

--- a/third_party/conan/lockfiles/linux/clang7_release/conan.lock
+++ b/third_party/conan/lockfiles/linux/clang7_release/conan.lock
@@ -61,7 +61,7 @@
     "options": "thread_safe=False"
    },
    "7": {
-    "pref": "grpc/1.27.3@orbitdeps/stable#0:087693a233c10298deebb4daedd739ca6d075f85#cce0c705541b0bb056d3ea01e9b440fd",
+    "pref": "grpc/1.27.3@orbitdeps/stable#dc2368a2df63276188566e36a6b7868a:b8b598fd7ccc631c8a8746caf99c79e733934508",
     "options": "fPIC=True\nabseil:cxx_standard=17\nabseil:fPIC=True\nc-ares:fPIC=True\nc-ares:shared=False\ncctz:build_tools=False\ncctz:fPIC=True\ncctz:shared=False\nopenssl:386=False\nopenssl:fPIC=True\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_cast=False\nopenssl:no_des=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_hmac=False\nopenssl:no_md2=False\nopenssl:no_md5=False\nopenssl:no_mdc2=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rsa=False\nopenssl:no_sha=False\nopenssl:no_sse2=False\nopenssl:no_threads=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "2",

--- a/third_party/conan/lockfiles/linux/clang7_relwithdebinfo/conan.lock
+++ b/third_party/conan/lockfiles/linux/clang7_relwithdebinfo/conan.lock
@@ -61,7 +61,7 @@
     "options": "thread_safe=False"
    },
    "7": {
-    "pref": "grpc/1.27.3@orbitdeps/stable#0:087693a233c10298deebb4daedd739ca6d075f85#cce0c705541b0bb056d3ea01e9b440fd",
+    "pref": "grpc/1.27.3@orbitdeps/stable#dc2368a2df63276188566e36a6b7868a:28dbd2fe360965995488a93be5d96e63d0a8e6cb",
     "options": "fPIC=True\nabseil:cxx_standard=17\nabseil:fPIC=True\nc-ares:fPIC=True\nc-ares:shared=False\ncctz:build_tools=False\ncctz:fPIC=True\ncctz:shared=False\nopenssl:386=False\nopenssl:fPIC=True\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_cast=False\nopenssl:no_des=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_hmac=False\nopenssl:no_md2=False\nopenssl:no_md5=False\nopenssl:no_mdc2=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rsa=False\nopenssl:no_sha=False\nopenssl:no_sse2=False\nopenssl:no_threads=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "2",

--- a/third_party/conan/lockfiles/linux/clang8_debug/conan.lock
+++ b/third_party/conan/lockfiles/linux/clang8_debug/conan.lock
@@ -61,7 +61,7 @@
     "options": "thread_safe=False"
    },
    "7": {
-    "pref": "grpc/1.27.3@orbitdeps/stable#0:eda5d796c7b5834041ab34a55761d7a66e6c569a#e8890b763c909817600e98f80dd439a2",
+    "pref": "grpc/1.27.3@orbitdeps/stable#dc2368a2df63276188566e36a6b7868a:fbdd7377fe3ddfd562e39b2bc5c6e6a44c982ba4",
     "options": "fPIC=True\nabseil:cxx_standard=17\nabseil:fPIC=True\nc-ares:fPIC=True\nc-ares:shared=False\ncctz:build_tools=False\ncctz:fPIC=True\ncctz:shared=False\nopenssl:386=False\nopenssl:fPIC=True\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_cast=False\nopenssl:no_des=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_hmac=False\nopenssl:no_md2=False\nopenssl:no_md5=False\nopenssl:no_mdc2=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rsa=False\nopenssl:no_sha=False\nopenssl:no_sse2=False\nopenssl:no_threads=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "2",

--- a/third_party/conan/lockfiles/linux/clang8_release/conan.lock
+++ b/third_party/conan/lockfiles/linux/clang8_release/conan.lock
@@ -61,7 +61,7 @@
     "options": "thread_safe=False"
    },
    "7": {
-    "pref": "grpc/1.27.3@orbitdeps/stable#0:eda5d796c7b5834041ab34a55761d7a66e6c569a#e8890b763c909817600e98f80dd439a2",
+    "pref": "grpc/1.27.3@orbitdeps/stable#dc2368a2df63276188566e36a6b7868a:6c561cc5cefc32a3afb0ed376ab77cd10d2a56a3",
     "options": "fPIC=True\nabseil:cxx_standard=17\nabseil:fPIC=True\nc-ares:fPIC=True\nc-ares:shared=False\ncctz:build_tools=False\ncctz:fPIC=True\ncctz:shared=False\nopenssl:386=False\nopenssl:fPIC=True\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_cast=False\nopenssl:no_des=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_hmac=False\nopenssl:no_md2=False\nopenssl:no_md5=False\nopenssl:no_mdc2=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rsa=False\nopenssl:no_sha=False\nopenssl:no_sse2=False\nopenssl:no_threads=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "2",

--- a/third_party/conan/lockfiles/linux/clang8_relwithdebinfo/conan.lock
+++ b/third_party/conan/lockfiles/linux/clang8_relwithdebinfo/conan.lock
@@ -61,7 +61,7 @@
     "options": "thread_safe=False"
    },
    "7": {
-    "pref": "grpc/1.27.3@orbitdeps/stable#0:eda5d796c7b5834041ab34a55761d7a66e6c569a#e8890b763c909817600e98f80dd439a2",
+    "pref": "grpc/1.27.3@orbitdeps/stable#dc2368a2df63276188566e36a6b7868a:13ec953f88d851a8ae72f076e6e01ba0a88616e2",
     "options": "fPIC=True\nabseil:cxx_standard=17\nabseil:fPIC=True\nc-ares:fPIC=True\nc-ares:shared=False\ncctz:build_tools=False\ncctz:fPIC=True\ncctz:shared=False\nopenssl:386=False\nopenssl:fPIC=True\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_cast=False\nopenssl:no_des=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_hmac=False\nopenssl:no_md2=False\nopenssl:no_md5=False\nopenssl:no_mdc2=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rsa=False\nopenssl:no_sha=False\nopenssl:no_sse2=False\nopenssl:no_threads=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "2",

--- a/third_party/conan/lockfiles/linux/clang9_debug/conan.lock
+++ b/third_party/conan/lockfiles/linux/clang9_debug/conan.lock
@@ -313,7 +313,7 @@
     "options": "fPIC=True\nshared=False\nsystem_mesa=True"
    },
    "36": {
-    "pref": "libssh2/1.9.0#df2b6034da12cc5cb68bd3c5c22601bf:76cc5e69b30eb59eaa43aebe5e3df5ff49a2dd7f#38b62fc9a560d073f0f2c52be49c3ec9",
+    "pref": "libssh2/1.9.0#df2b6034da12cc5cb68bd3c5c22601bf:76cc5e69b30eb59eaa43aebe5e3df5ff49a2dd7f#7536d33de730427d0cd36688d0e16348",
     "options": "crypto_backend=openssl\nenable_crypt_none=False\nenable_mac_none=False\nfPIC=True\nshared=False\nwith_zlib=True\nopenssl:386=False\nopenssl:fPIC=True\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_cast=False\nopenssl:no_des=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_hmac=False\nopenssl:no_md2=False\nopenssl:no_md5=False\nopenssl:no_mdc2=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rsa=False\nopenssl:no_sha=False\nopenssl:no_sse2=False\nopenssl:no_threads=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "8",

--- a/third_party/conan/lockfiles/linux/clang9_debug/conan.lock
+++ b/third_party/conan/lockfiles/linux/clang9_debug/conan.lock
@@ -61,7 +61,7 @@
     "options": "thread_safe=False"
    },
    "7": {
-    "pref": "grpc/1.27.3@orbitdeps/stable#0:6fc747216252124c87ab0d71a03c3947241756c4#2f5326922cb4e790961a6266acd92eb6",
+    "pref": "grpc/1.27.3@orbitdeps/stable#dc2368a2df63276188566e36a6b7868a:9814ade38d6232ca9d263687bf9bbcd94c566f03",
     "options": "fPIC=True\nabseil:cxx_standard=17\nabseil:fPIC=True\nc-ares:fPIC=True\nc-ares:shared=False\ncctz:build_tools=False\ncctz:fPIC=True\ncctz:shared=False\nopenssl:386=False\nopenssl:fPIC=True\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_cast=False\nopenssl:no_des=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_hmac=False\nopenssl:no_md2=False\nopenssl:no_md5=False\nopenssl:no_mdc2=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rsa=False\nopenssl:no_sha=False\nopenssl:no_sse2=False\nopenssl:no_threads=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "2",

--- a/third_party/conan/lockfiles/linux/clang9_release/conan.lock
+++ b/third_party/conan/lockfiles/linux/clang9_release/conan.lock
@@ -61,7 +61,7 @@
     "options": "thread_safe=False"
    },
    "7": {
-    "pref": "grpc/1.27.3@orbitdeps/stable#0:6fc747216252124c87ab0d71a03c3947241756c4#2f5326922cb4e790961a6266acd92eb6",
+    "pref": "grpc/1.27.3@orbitdeps/stable#dc2368a2df63276188566e36a6b7868a:8aec00dadbf7c197e4e9009b992275cdf0e4eec0",
     "options": "fPIC=True\nabseil:cxx_standard=17\nabseil:fPIC=True\nc-ares:fPIC=True\nc-ares:shared=False\ncctz:build_tools=False\ncctz:fPIC=True\ncctz:shared=False\nopenssl:386=False\nopenssl:fPIC=True\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_cast=False\nopenssl:no_des=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_hmac=False\nopenssl:no_md2=False\nopenssl:no_md5=False\nopenssl:no_mdc2=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rsa=False\nopenssl:no_sha=False\nopenssl:no_sse2=False\nopenssl:no_threads=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "2",

--- a/third_party/conan/lockfiles/linux/clang9_relwithdebinfo/conan.lock
+++ b/third_party/conan/lockfiles/linux/clang9_relwithdebinfo/conan.lock
@@ -313,7 +313,7 @@
     "options": "fPIC=True\nshared=False\nsystem_mesa=True"
    },
    "36": {
-    "pref": "libssh2/1.9.0#df2b6034da12cc5cb68bd3c5c22601bf:6d442a3c2264a4ad7d6f6319dbad6f77ac3e3ad6#a2d5f25abc0bf7ccf9abce3419a3355d",
+    "pref": "libssh2/1.9.0#df2b6034da12cc5cb68bd3c5c22601bf:6d442a3c2264a4ad7d6f6319dbad6f77ac3e3ad6#26f273e5e4a5105bac19b2daf3963740",
     "options": "crypto_backend=openssl\nenable_crypt_none=False\nenable_mac_none=False\nfPIC=True\nshared=False\nwith_zlib=True\nopenssl:386=False\nopenssl:fPIC=True\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_cast=False\nopenssl:no_des=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_hmac=False\nopenssl:no_md2=False\nopenssl:no_md5=False\nopenssl:no_mdc2=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rsa=False\nopenssl:no_sha=False\nopenssl:no_sse2=False\nopenssl:no_threads=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "8",

--- a/third_party/conan/lockfiles/linux/clang9_relwithdebinfo/conan.lock
+++ b/third_party/conan/lockfiles/linux/clang9_relwithdebinfo/conan.lock
@@ -61,7 +61,7 @@
     "options": "thread_safe=False"
    },
    "7": {
-    "pref": "grpc/1.27.3@orbitdeps/stable#0:6fc747216252124c87ab0d71a03c3947241756c4#2f5326922cb4e790961a6266acd92eb6",
+    "pref": "grpc/1.27.3@orbitdeps/stable#dc2368a2df63276188566e36a6b7868a:7fc935f5d3abc070b21054ffe1efe461490ffc4c#97d613d7ab739c27e8f0868d7155b8c3",
     "options": "fPIC=True\nabseil:cxx_standard=17\nabseil:fPIC=True\nc-ares:fPIC=True\nc-ares:shared=False\ncctz:build_tools=False\ncctz:fPIC=True\ncctz:shared=False\nopenssl:386=False\nopenssl:fPIC=True\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_cast=False\nopenssl:no_des=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_hmac=False\nopenssl:no_md2=False\nopenssl:no_md5=False\nopenssl:no_mdc2=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rsa=False\nopenssl:no_sha=False\nopenssl:no_sse2=False\nopenssl:no_threads=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "2",

--- a/third_party/conan/lockfiles/linux/gcc8_debug/conan.lock
+++ b/third_party/conan/lockfiles/linux/gcc8_debug/conan.lock
@@ -61,7 +61,7 @@
     "options": "thread_safe=False"
    },
    "7": {
-    "pref": "grpc/1.27.3@orbitdeps/stable#0:af0366896eee570e5cda0e4fbd33173a02c8ea25#fbcedffe4bb3e7c6a043c52d4096dfd3",
+    "pref": "grpc/1.27.3@orbitdeps/stable#dc2368a2df63276188566e36a6b7868a:91cbd894a2b356e3c026cae298f2242a527ac820",
     "options": "fPIC=True\nabseil:cxx_standard=17\nabseil:fPIC=True\nc-ares:fPIC=True\nc-ares:shared=False\ncctz:build_tools=False\ncctz:fPIC=True\ncctz:shared=False\nopenssl:386=False\nopenssl:fPIC=True\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_cast=False\nopenssl:no_des=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_hmac=False\nopenssl:no_md2=False\nopenssl:no_md5=False\nopenssl:no_mdc2=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rsa=False\nopenssl:no_sha=False\nopenssl:no_sse2=False\nopenssl:no_threads=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "2",

--- a/third_party/conan/lockfiles/linux/gcc8_release/conan.lock
+++ b/third_party/conan/lockfiles/linux/gcc8_release/conan.lock
@@ -61,7 +61,7 @@
     "options": "thread_safe=False"
    },
    "7": {
-    "pref": "grpc/1.27.3@orbitdeps/stable#0:af0366896eee570e5cda0e4fbd33173a02c8ea25#fbcedffe4bb3e7c6a043c52d4096dfd3",
+    "pref": "grpc/1.27.3@orbitdeps/stable#dc2368a2df63276188566e36a6b7868a:9f0fd90e00abb660e15771b9814c5a84e3b4f64d",
     "options": "fPIC=True\nabseil:cxx_standard=17\nabseil:fPIC=True\nc-ares:fPIC=True\nc-ares:shared=False\ncctz:build_tools=False\ncctz:fPIC=True\ncctz:shared=False\nopenssl:386=False\nopenssl:fPIC=True\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_cast=False\nopenssl:no_des=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_hmac=False\nopenssl:no_md2=False\nopenssl:no_md5=False\nopenssl:no_mdc2=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rsa=False\nopenssl:no_sha=False\nopenssl:no_sse2=False\nopenssl:no_threads=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "2",

--- a/third_party/conan/lockfiles/linux/gcc8_relwithdebinfo/conan.lock
+++ b/third_party/conan/lockfiles/linux/gcc8_relwithdebinfo/conan.lock
@@ -61,7 +61,7 @@
     "options": "thread_safe=False"
    },
    "7": {
-    "pref": "grpc/1.27.3@orbitdeps/stable#0:af0366896eee570e5cda0e4fbd33173a02c8ea25#fbcedffe4bb3e7c6a043c52d4096dfd3",
+    "pref": "grpc/1.27.3@orbitdeps/stable#dc2368a2df63276188566e36a6b7868a:7c3dbdda59f2d9af5226fad6ff5cc744e2328755",
     "options": "fPIC=True\nabseil:cxx_standard=17\nabseil:fPIC=True\nc-ares:fPIC=True\nc-ares:shared=False\ncctz:build_tools=False\ncctz:fPIC=True\ncctz:shared=False\nopenssl:386=False\nopenssl:fPIC=True\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_cast=False\nopenssl:no_des=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_hmac=False\nopenssl:no_md2=False\nopenssl:no_md5=False\nopenssl:no_mdc2=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rsa=False\nopenssl:no_sha=False\nopenssl:no_sse2=False\nopenssl:no_threads=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "2",

--- a/third_party/conan/lockfiles/linux/gcc9_debug/conan.lock
+++ b/third_party/conan/lockfiles/linux/gcc9_debug/conan.lock
@@ -61,7 +61,7 @@
     "options": "thread_safe=False"
    },
    "7": {
-    "pref": "grpc/1.27.3@orbitdeps/stable#0:d9aea019fc2dc4ecea117df2edb881a3fe34b382#05d0b13a0ff679ebf4612f9696cc69c6",
+    "pref": "grpc/1.27.3@orbitdeps/stable#dc2368a2df63276188566e36a6b7868a:d3d2251a221795138f0a75b37fa3ac7085865f51",
     "options": "fPIC=True\nabseil:cxx_standard=17\nabseil:fPIC=True\nc-ares:fPIC=True\nc-ares:shared=False\ncctz:build_tools=False\ncctz:fPIC=True\ncctz:shared=False\nopenssl:386=False\nopenssl:fPIC=True\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_cast=False\nopenssl:no_des=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_hmac=False\nopenssl:no_md2=False\nopenssl:no_md5=False\nopenssl:no_mdc2=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rsa=False\nopenssl:no_sha=False\nopenssl:no_sse2=False\nopenssl:no_threads=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "2",

--- a/third_party/conan/lockfiles/linux/gcc9_release/conan.lock
+++ b/third_party/conan/lockfiles/linux/gcc9_release/conan.lock
@@ -61,7 +61,7 @@
     "options": "thread_safe=False"
    },
    "7": {
-    "pref": "grpc/1.27.3@orbitdeps/stable#0:d9aea019fc2dc4ecea117df2edb881a3fe34b382#05d0b13a0ff679ebf4612f9696cc69c6",
+    "pref": "grpc/1.27.3@orbitdeps/stable#dc2368a2df63276188566e36a6b7868a:0e3b8c660eb28df2e633cd34ea68428114dda1a4",
     "options": "fPIC=True\nabseil:cxx_standard=17\nabseil:fPIC=True\nc-ares:fPIC=True\nc-ares:shared=False\ncctz:build_tools=False\ncctz:fPIC=True\ncctz:shared=False\nopenssl:386=False\nopenssl:fPIC=True\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_cast=False\nopenssl:no_des=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_hmac=False\nopenssl:no_md2=False\nopenssl:no_md5=False\nopenssl:no_mdc2=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rsa=False\nopenssl:no_sha=False\nopenssl:no_sse2=False\nopenssl:no_threads=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "2",

--- a/third_party/conan/lockfiles/linux/gcc9_relwithdebinfo/conan.lock
+++ b/third_party/conan/lockfiles/linux/gcc9_relwithdebinfo/conan.lock
@@ -61,7 +61,7 @@
     "options": "thread_safe=False"
    },
    "7": {
-    "pref": "grpc/1.27.3@orbitdeps/stable#0:d9aea019fc2dc4ecea117df2edb881a3fe34b382#05d0b13a0ff679ebf4612f9696cc69c6",
+    "pref": "grpc/1.27.3@orbitdeps/stable#dc2368a2df63276188566e36a6b7868a:8bc57d977c128ac90632bb9dcd43e484d4478203",
     "options": "fPIC=True\nabseil:cxx_standard=17\nabseil:fPIC=True\nc-ares:fPIC=True\nc-ares:shared=False\ncctz:build_tools=False\ncctz:fPIC=True\ncctz:shared=False\nopenssl:386=False\nopenssl:fPIC=True\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_cast=False\nopenssl:no_des=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_hmac=False\nopenssl:no_md2=False\nopenssl:no_md5=False\nopenssl:no_mdc2=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rsa=False\nopenssl:no_sha=False\nopenssl:no_sse2=False\nopenssl:no_threads=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "2",

--- a/third_party/conan/lockfiles/linux/ggp_debug/conan.lock
+++ b/third_party/conan/lockfiles/linux/ggp_debug/conan.lock
@@ -55,7 +55,7 @@
     "options": "thread_safe=False"
    },
    "7": {
-    "pref": "grpc/1.27.3@orbitdeps/stable#0:0064ad28063fec11c3ea6a573cd6b1c88de7f218#644ecd85a12bdf4086d6b1c3598ef8ff",
+    "pref": "grpc/1.27.3@orbitdeps/stable#dc2368a2df63276188566e36a6b7868a:fb75ba9d29bdaa675098ac962d18ce43f0ac9b2b",
     "options": "fPIC=True\nabseil:cxx_standard=17\nabseil:fPIC=True\nc-ares:fPIC=True\nc-ares:shared=False\ncctz:build_tools=False\ncctz:fPIC=True\ncctz:shared=False\nopenssl:386=False\nopenssl:fPIC=True\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_cast=False\nopenssl:no_des=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_hmac=False\nopenssl:no_md2=False\nopenssl:no_md5=False\nopenssl:no_mdc2=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rsa=False\nopenssl:no_sha=False\nopenssl:no_sse2=False\nopenssl:no_threads=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "2",

--- a/third_party/conan/lockfiles/linux/ggp_release/conan.lock
+++ b/third_party/conan/lockfiles/linux/ggp_release/conan.lock
@@ -55,7 +55,7 @@
     "options": "thread_safe=False"
    },
    "7": {
-    "pref": "grpc/1.27.3@orbitdeps/stable#0:0064ad28063fec11c3ea6a573cd6b1c88de7f218#644ecd85a12bdf4086d6b1c3598ef8ff",
+    "pref": "grpc/1.27.3@orbitdeps/stable#dc2368a2df63276188566e36a6b7868a:8cac184c89d0ce80fbda7d88b7a289da8b1b1e7a",
     "options": "fPIC=True\nabseil:cxx_standard=17\nabseil:fPIC=True\nc-ares:fPIC=True\nc-ares:shared=False\ncctz:build_tools=False\ncctz:fPIC=True\ncctz:shared=False\nopenssl:386=False\nopenssl:fPIC=True\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_cast=False\nopenssl:no_des=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_hmac=False\nopenssl:no_md2=False\nopenssl:no_md5=False\nopenssl:no_mdc2=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rsa=False\nopenssl:no_sha=False\nopenssl:no_sse2=False\nopenssl:no_threads=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "2",

--- a/third_party/conan/lockfiles/linux/ggp_relwithdebinfo/conan.lock
+++ b/third_party/conan/lockfiles/linux/ggp_relwithdebinfo/conan.lock
@@ -55,7 +55,7 @@
     "options": "thread_safe=False"
    },
    "7": {
-    "pref": "grpc/1.27.3@orbitdeps/stable#0:0064ad28063fec11c3ea6a573cd6b1c88de7f218#644ecd85a12bdf4086d6b1c3598ef8ff",
+    "pref": "grpc/1.27.3@orbitdeps/stable#dc2368a2df63276188566e36a6b7868a:d0a98eb921bd1f4c48e9d21d0c4797047fea9209",
     "options": "fPIC=True\nabseil:cxx_standard=17\nabseil:fPIC=True\nc-ares:fPIC=True\nc-ares:shared=False\ncctz:build_tools=False\ncctz:fPIC=True\ncctz:shared=False\nopenssl:386=False\nopenssl:fPIC=True\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_cast=False\nopenssl:no_des=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_hmac=False\nopenssl:no_md2=False\nopenssl:no_md5=False\nopenssl:no_mdc2=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rsa=False\nopenssl:no_sha=False\nopenssl:no_sse2=False\nopenssl:no_threads=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "2",

--- a/third_party/conan/lockfiles/windows/ggp_debug/conan.lock
+++ b/third_party/conan/lockfiles/windows/ggp_debug/conan.lock
@@ -56,7 +56,7 @@
     "options": "thread_safe=False"
    },
    "7": {
-    "pref": "grpc/1.27.3@orbitdeps/stable#0:0064ad28063fec11c3ea6a573cd6b1c88de7f218#644ecd85a12bdf4086d6b1c3598ef8ff",
+    "pref": "grpc/1.27.3@orbitdeps/stable#dc2368a2df63276188566e36a6b7868a:fb75ba9d29bdaa675098ac962d18ce43f0ac9b2b",
     "options": "fPIC=True\nabseil:cxx_standard=17\nabseil:fPIC=True\nc-ares:fPIC=True\nc-ares:shared=False\ncctz:build_tools=False\ncctz:fPIC=True\ncctz:shared=False\nopenssl:386=False\nopenssl:fPIC=True\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_cast=False\nopenssl:no_des=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_hmac=False\nopenssl:no_md2=False\nopenssl:no_md5=False\nopenssl:no_mdc2=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rsa=False\nopenssl:no_sha=False\nopenssl:no_sse2=False\nopenssl:no_threads=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "2",

--- a/third_party/conan/lockfiles/windows/ggp_release/conan.lock
+++ b/third_party/conan/lockfiles/windows/ggp_release/conan.lock
@@ -56,7 +56,7 @@
     "options": "thread_safe=False"
    },
    "7": {
-    "pref": "grpc/1.27.3@orbitdeps/stable#0:0064ad28063fec11c3ea6a573cd6b1c88de7f218#644ecd85a12bdf4086d6b1c3598ef8ff",
+    "pref": "grpc/1.27.3@orbitdeps/stable#dc2368a2df63276188566e36a6b7868a:8cac184c89d0ce80fbda7d88b7a289da8b1b1e7a",
     "options": "fPIC=True\nabseil:cxx_standard=17\nabseil:fPIC=True\nc-ares:fPIC=True\nc-ares:shared=False\ncctz:build_tools=False\ncctz:fPIC=True\ncctz:shared=False\nopenssl:386=False\nopenssl:fPIC=True\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_cast=False\nopenssl:no_des=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_hmac=False\nopenssl:no_md2=False\nopenssl:no_md5=False\nopenssl:no_mdc2=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rsa=False\nopenssl:no_sha=False\nopenssl:no_sse2=False\nopenssl:no_threads=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "2",

--- a/third_party/conan/lockfiles/windows/ggp_relwithdebinfo/conan.lock
+++ b/third_party/conan/lockfiles/windows/ggp_relwithdebinfo/conan.lock
@@ -56,7 +56,7 @@
     "options": "thread_safe=False"
    },
    "7": {
-    "pref": "grpc/1.27.3@orbitdeps/stable#0:0064ad28063fec11c3ea6a573cd6b1c88de7f218#644ecd85a12bdf4086d6b1c3598ef8ff",
+    "pref": "grpc/1.27.3@orbitdeps/stable#dc2368a2df63276188566e36a6b7868a:d0a98eb921bd1f4c48e9d21d0c4797047fea9209",
     "options": "fPIC=True\nabseil:cxx_standard=17\nabseil:fPIC=True\nc-ares:fPIC=True\nc-ares:shared=False\ncctz:build_tools=False\ncctz:fPIC=True\ncctz:shared=False\nopenssl:386=False\nopenssl:fPIC=True\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_cast=False\nopenssl:no_des=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_hmac=False\nopenssl:no_md2=False\nopenssl:no_md5=False\nopenssl:no_mdc2=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rsa=False\nopenssl:no_sha=False\nopenssl:no_sse2=False\nopenssl:no_threads=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "2",

--- a/third_party/conan/lockfiles/windows/msvc2017_debug/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2017_debug/conan.lock
@@ -61,7 +61,7 @@
     "options": "thread_safe=False"
    },
    "7": {
-    "pref": "grpc/1.27.3@orbitdeps/stable#0:dac816a9a968af27e2e0e6af51c0268415611bbd#88f0c1b71076650b4f1be6d1d68e3064",
+    "pref": "grpc/1.27.3@orbitdeps/stable#dc2368a2df63276188566e36a6b7868a:a1ee1976b761e5b88b10a8d2f0e3a2cc6303739c",
     "options": "abseil:cxx_standard=17\nc-ares:shared=False\ncctz:build_tools=False\ncctz:shared=False\nopenssl:386=False\nopenssl:capieng_dialog=False\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_cast=False\nopenssl:no_des=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_hmac=False\nopenssl:no_md2=False\nopenssl:no_md5=False\nopenssl:no_mdc2=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rsa=False\nopenssl:no_sha=False\nopenssl:no_sse2=False\nopenssl:no_threads=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "2",

--- a/third_party/conan/lockfiles/windows/msvc2017_release/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2017_release/conan.lock
@@ -61,7 +61,7 @@
     "options": "thread_safe=False"
    },
    "7": {
-    "pref": "grpc/1.27.3@orbitdeps/stable#0:6e68bf4c570504974ebec147ea51431d6106f6fe#cfc65f129f60cd9cbc2c6b1752b182d6",
+    "pref": "grpc/1.27.3@orbitdeps/stable#dc2368a2df63276188566e36a6b7868a:f2e9f0195456bbd4c0b3923533eaad66572ae566",
     "options": "abseil:cxx_standard=17\nc-ares:shared=False\ncctz:build_tools=False\ncctz:shared=False\nopenssl:386=False\nopenssl:capieng_dialog=False\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_cast=False\nopenssl:no_des=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_hmac=False\nopenssl:no_md2=False\nopenssl:no_md5=False\nopenssl:no_mdc2=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rsa=False\nopenssl:no_sha=False\nopenssl:no_sse2=False\nopenssl:no_threads=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "2",

--- a/third_party/conan/lockfiles/windows/msvc2017_relwithdebinfo/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2017_relwithdebinfo/conan.lock
@@ -61,7 +61,7 @@
     "options": "thread_safe=False"
    },
    "7": {
-    "pref": "grpc/1.27.3@orbitdeps/stable#0:6e68bf4c570504974ebec147ea51431d6106f6fe#cfc65f129f60cd9cbc2c6b1752b182d6",
+    "pref": "grpc/1.27.3@orbitdeps/stable#dc2368a2df63276188566e36a6b7868a:cccc9d5aecdb5c0405ab249506118f37a5b73cde",
     "options": "abseil:cxx_standard=17\nc-ares:shared=False\ncctz:build_tools=False\ncctz:shared=False\nopenssl:386=False\nopenssl:capieng_dialog=False\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_cast=False\nopenssl:no_des=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_hmac=False\nopenssl:no_md2=False\nopenssl:no_md5=False\nopenssl:no_mdc2=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rsa=False\nopenssl:no_sha=False\nopenssl:no_sse2=False\nopenssl:no_threads=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "2",

--- a/third_party/conan/lockfiles/windows/msvc2019_debug/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2019_debug/conan.lock
@@ -61,7 +61,7 @@
     "options": "thread_safe=False"
    },
    "7": {
-    "pref": "grpc/1.27.3@orbitdeps/stable#0:7a9e290f42de6e80892d7762437ac3cf434e6b66#aed17ed44f0b77c5f32162f2a4e63b74",
+    "pref": "grpc/1.27.3@orbitdeps/stable#dc2368a2df63276188566e36a6b7868a:d04918d1cbe275718aabc715cf9bad7c889b4c71",
     "options": "abseil:cxx_standard=17\nc-ares:shared=False\ncctz:build_tools=False\ncctz:shared=False\nopenssl:386=False\nopenssl:capieng_dialog=False\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_cast=False\nopenssl:no_des=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_hmac=False\nopenssl:no_md2=False\nopenssl:no_md5=False\nopenssl:no_mdc2=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rsa=False\nopenssl:no_sha=False\nopenssl:no_sse2=False\nopenssl:no_threads=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "2",

--- a/third_party/conan/lockfiles/windows/msvc2019_release/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2019_release/conan.lock
@@ -61,7 +61,7 @@
     "options": "thread_safe=False"
    },
    "7": {
-    "pref": "grpc/1.27.3@orbitdeps/stable#0:a70fd1036ed51f40312945964159cd7eea45dde0#d2a28eebef188850884be2eb7486938e",
+    "pref": "grpc/1.27.3@orbitdeps/stable#dc2368a2df63276188566e36a6b7868a:45dcd50731f81e83f8bf3eb0a9ce8113d6438f51",
     "options": "abseil:cxx_standard=17\nc-ares:shared=False\ncctz:build_tools=False\ncctz:shared=False\nopenssl:386=False\nopenssl:capieng_dialog=False\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_cast=False\nopenssl:no_des=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_hmac=False\nopenssl:no_md2=False\nopenssl:no_md5=False\nopenssl:no_mdc2=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rsa=False\nopenssl:no_sha=False\nopenssl:no_sse2=False\nopenssl:no_threads=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "2",

--- a/third_party/conan/lockfiles/windows/msvc2019_relwithdebinfo/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2019_relwithdebinfo/conan.lock
@@ -61,7 +61,7 @@
     "options": "thread_safe=False"
    },
    "7": {
-    "pref": "grpc/1.27.3@orbitdeps/stable#0:a70fd1036ed51f40312945964159cd7eea45dde0#d2a28eebef188850884be2eb7486938e",
+    "pref": "grpc/1.27.3@orbitdeps/stable#dc2368a2df63276188566e36a6b7868a:e57620c4bba9ed32ba378eda16c8811b1c209249#d846ef671638e5c8c62109a347f8c8c0",
     "options": "abseil:cxx_standard=17\nc-ares:shared=False\ncctz:build_tools=False\ncctz:shared=False\nopenssl:386=False\nopenssl:capieng_dialog=False\nopenssl:no_asm=False\nopenssl:no_async=False\nopenssl:no_bf=False\nopenssl:no_cast=False\nopenssl:no_des=False\nopenssl:no_dh=False\nopenssl:no_dsa=False\nopenssl:no_dso=False\nopenssl:no_hmac=False\nopenssl:no_md2=False\nopenssl:no_md5=False\nopenssl:no_mdc2=False\nopenssl:no_rc2=False\nopenssl:no_rc4=False\nopenssl:no_rc5=False\nopenssl:no_rsa=False\nopenssl:no_sha=False\nopenssl:no_sse2=False\nopenssl:no_threads=False\nopenssl:no_zlib=False\nopenssl:openssldir=None\nopenssl:shared=False\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "2",

--- a/third_party/conan/recipes/grpc/conanfile.py
+++ b/third_party/conan/recipes/grpc/conanfile.py
@@ -18,7 +18,7 @@ class grpcConan(ConanFile):
     generators = "cmake"
     short_paths = True  # Otherwise some folders go out of the 260 chars path length scope rapidly (on windows)
 
-    settings = "os", "arch", "compiler", "arch"
+    settings = "os", "arch", "compiler", "build_type"
     options = {
         "fPIC": [True, False],
     }
@@ -65,7 +65,11 @@ class grpcConan(ConanFile):
         tools.replace_in_file(cmake_path, "set(_gRPC_CPP_PLUGIN $<TARGET_FILE:grpc_cpp_plugin>)", "find_program(_gRPC_CPP_PLUGIN grpc_cpp_plugin)")
         tools.replace_in_file(cmake_path, "DEPENDS ${ABS_FIL} ${_gRPC_PROTOBUF_PROTOC} grpc_cpp_plugin", "DEPENDS ${ABS_FIL} ${_gRPC_PROTOBUF_PROTOC} ${_gRPC_CPP_PLUGIN}")
 
+    _cmake = None
     def _configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+
         cmake = CMake(self)
 
         cmake.definitions['gRPC_BUILD_CODEGEN'] = "ON"
@@ -99,6 +103,7 @@ class grpcConan(ConanFile):
             cmake.definitions["CMAKE_C_FLAGS"] = "-D_WIN32_WINNT=0x600"
 
         cmake.configure(build_folder=self._build_subfolder)
+        self._cmake = cmake
         return cmake
 
     def build(self):

--- a/third_party/conan/recipes/grpc/gRPCTargets-helpers.cmake
+++ b/third_party/conan/recipes/grpc/gRPCTargets-helpers.cmake
@@ -5,54 +5,47 @@ function(grpc_helper)
   find_program(_HELPER_GRPC_CPP_PLUGIN grpc_cpp_plugin)
 
   get_target_property(_sources ${ARGV0} SOURCES)
+  set(new_sources "")
+  set(bin_dir "${CMAKE_CURRENT_BINARY_DIR}/grpc_codegen")
 
   foreach(source_file ${_sources})
     if(source_file MATCHES ".*\.proto")
-      string(REGEX REPLACE "[./:;]" "_" target_name ${source_file})
-      set(target_name "_grpc_${target_name}")
+      get_filename_component(basename ${source_file} NAME_WE)
 
-      if(NOT TARGET ${target_name})
-        get_filename_component(basename ${source_file} NAME_WE)
+      get_filename_component(src_filepath ${source_file} ABSOLUTE)
+      get_filename_component(src_folder ${src_filepath} PATH)
 
-        get_filename_component(src_filepath ${source_file} ABSOLUTE)
-        get_filename_component(src_folder ${src_filepath} PATH)
+      set(proto_cpp "${bin_dir}/${basename}.pb.cc")
+      set(proto_h "${bin_dir}/${basename}.pb.h")
+      set(grpc_cpp "${bin_dir}/${basename}.grpc.pb.cc")
+      set(grpc_h "${bin_dir}/${basename}.grpc.pb.h")
 
-        set(bin_dir "${CMAKE_CURRENT_BINARY_DIR}/grpc_codegen")
-        set(proto_cpp "${bin_dir}/${basename}.pb.cc")
-        set(proto_h "${bin_dir}/${basename}.pb.h")
-        set(grpc_cpp "${bin_dir}/${basename}.grpc.pb.cc")
-        set(grpc_h "${bin_dir}/${basename}.grpc.pb.h")
+      add_custom_command(
+        OUTPUT "${bin_dir}" COMMAND ${CMAKE_COMMAND} ARGS -E make_directory
+                                    "${bin_dir}")
 
-        add_custom_command(
-          OUTPUT "${bin_dir}" COMMAND ${CMAKE_COMMAND} ARGS -E make_directory
-                                      "${bin_dir}")
+      add_custom_command(
+        OUTPUT "${proto_cpp}" "${proto_h}" "${grpc_cpp}" "${grpc_h}"
+        COMMAND
+          ${_HELPER_PROTOC} ARGS --grpc_out "${bin_dir}" --cpp_out
+          "${bin_dir}" -I ${src_folder}
+          --plugin=protoc-gen-grpc="${_HELPER_GRPC_CPP_PLUGIN}"
+          "${src_filepath}"
+        MAIN_DEPENDENCY "${src_filepath}"
+        DEPENDS "${bin_dir}")
 
-        add_custom_command(
-          OUTPUT "${proto_cpp}" "${proto_h}" "${grpc_cpp}" "${grpc_h}"
-          COMMAND
-            ${_HELPER_PROTOC} ARGS --grpc_out "${bin_dir}" --cpp_out
-            "${bin_dir}" -I ${src_folder}
-            --plugin=protoc-gen-grpc="${_HELPER_GRPC_CPP_PLUGIN}"
-            "${src_filepath}"
-          MAIN_DEPENDENCY "${src_filepath}"
-          DEPENDS "${bin_dir}")
+      list(APPEND new_sources "${proto_cpp}")
+      list(APPEND new_sources "${grpc_cpp}")
 
-        add_library(${target_name} OBJECT)
-        target_include_directories(${target_name} PUBLIC ${bin_dir})
-        target_link_libraries(
-          ${target_name} PUBLIC gRPC::grpc++_reflection gRPC::grpc++_unsecure
-                                protobuf::libprotobuf)
-        target_sources(${target_name} PRIVATE "${proto_cpp}" "${grpc_cpp}")
-        target_compile_definitions(${target_name} PRIVATE -D_WIN32_WINNT=0x0700)
-        target_compile_definitions(${target_name} PRIVATE -DNTDDI_VERSION=0x06030000)
-
-      endif()
-
-      target_link_libraries(${ARGV0} PUBLIC ${target_name})
-      add_dependencies(${ARGV0} ${target_name})
     endif()
   endforeach()
 
   list(FILTER _sources EXCLUDE REGEX ".*\.proto")
-  set_target_properties(${ARGV0} PROPERTIES SOURCES ${_sources})
+  list(APPEND _sources ${new_sources})
+  set_target_properties(${ARGV0} PROPERTIES SOURCES "${_sources}")
+
+  target_link_libraries(${ARGV0} PUBLIC gRPC::grpc++_reflection
+                                        gRPC::grpc++_unsecure
+                                        protobuf::libprotobuf)
+  target_include_directories(${ARGV0} PUBLIC ${bin_dir})
 endfunction()


### PR DESCRIPTION
Fixes two bugs in the GRPC conan package: 

1. The build_type was not taken into account when creating packages
2. The cmake grpc helper function had problems with imported proto files. This change moves the dependency management from manual management on cmake-target level to automatic management on file level. So the usual automatic header-file dependency management of cmake should apply now.
3. The changes to the helper function made the integration easier. No more dummy.cpp

Packages are being built right now. This shouldn't be merged before all packages are done.

