### PR TITLE
Added stderr reading to OrbitSshQt::Task

### DIFF
--- a/OrbitSshQt/IntegrationTests.cpp
+++ b/OrbitSshQt/IntegrationTests.cpp
@@ -93,8 +93,8 @@ TEST(OrbitSshQtTests, IntegrationTest) {
 
   // Task
 
-  QObject::connect(&task, &OrbitSshQt::Task::readyRead, &loop,
-                   [&]() { data_sink.append(task.Read()); });
+  QObject::connect(&task, &OrbitSshQt::Task::readyReadStdOut, &loop,
+                   [&]() { data_sink.append(task.ReadStdOut()); });
 
   QObject::connect(&task, &OrbitSshQt::Task::started, &loop, [&]() {
     LOG("process started. Starting tunnel...");

--- a/OrbitSshQt/include/OrbitSshQt/Task.h
+++ b/OrbitSshQt/include/OrbitSshQt/Task.h
@@ -57,7 +57,8 @@ class Task : public StateMachineHelper<Task, details::TaskState> {
   void Start();
   void Stop();
 
-  std::string Read();
+  std::string ReadStdOut();
+  std::string ReadStdErr();
   void Write(std::string_view data);
 
  signals:
@@ -65,7 +66,8 @@ class Task : public StateMachineHelper<Task, details::TaskState> {
   void finished(int exit_code);
   void stopped();
   void errorOccurred(std::error_code);
-  void readyRead();
+  void readyReadStdOut();
+  void readyReadStdErr();
   void bytesWritten(size_t bytes);
   void aboutToShutdown();
 
@@ -86,7 +88,8 @@ class Task : public StateMachineHelper<Task, details::TaskState> {
 
   std::string command_;
   std::optional<OrbitSsh::Channel> channel_;
-  std::string read_buffer_;
+  std::string read_std_out_buffer_;
+  std::string read_std_err_buffer_;
   std::string write_buffer_;
 };
 


### PR DESCRIPTION
and used it where appropriate in ServiceDeployManager.

The result should be that all logging of OrbitService should also be displayed in OrbitQt log