### PR TITLE
Manual instrumentation API.

### DIFF
--- a/Orbit.h
+++ b/Orbit.h
@@ -60,7 +60,7 @@
 #define ORBIT_CONCAT_IND(x, y) (x##y)
 #define ORBIT_CONCAT(x, y) ORBIT_CONCAT_IND(x, y)
 #define ORBIT_UNIQUE(x) ORBIT_CONCAT(x, __COUNTER__)
-#define ORBIT_NOOP()         \
+#define ORBIT_NOOP()       \
   do {                     \
     static volatile int x; \
     x;                     \

--- a/Orbit.h
+++ b/Orbit.h
@@ -1,122 +1,104 @@
-//----------------------------------------
-// Orbit Profiler
-// Copyright Pierric Gimmig 2013-2017
-//----------------------------------------
-#pragma once
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-//-----------------------------------------------------------------------------
-// Orbit API
+#ifndef ORBIT_H_
+#define ORBIT_H_
+
+#include <stdint.h>
+
+// Orbit API (header-only)
 //
-// Simply include this header in your project, there is no lib and no cpp file.
-//
-// MANUAL INSTRUMENTATION:
-// The main feature of Orbit is its ability to dynamically instrument functions
-// without having to recompile or even relaunch your application.  However,
-// if you still want to manually instrument your code, you can.
-//
-// Use ORBIT_SCOPE or ORBIT_START/ORBIT_STOP *macros* only.
-// DO NOT use OrbitScope(...)/OrbitStart(...)/OrbitStop() directly.
-// NOTE: You need to use string literals.  Dynamic strings are not supported
-// yet.
-//
-// DLL LOADING:
-// If you want to control the loading of Orbit64.dll, i.e. you don't want to
-// have to manually inject it into your application, use the OrbitAPI class.
-// Calling OrbitAPI::Connect(...) will load the dll and try to connect to the
-// Orbit instance specified in parameters.  Note that Orbit64.dll needs to be
-// next to your exectutable.  You can also change the code below
-// (OrbitAPI::Init()).
-//-----------------------------------------------------------------------------
+// While the main feature of Orbit is its ability to dynamically instrument
+// functions, manual instrumentation is still possible using the macros below.
+// These macros call empty functions that Orbit dynamically instruments.
 
-#define ORBIT_SCOPE(name) OrbitScope ORBIT_UNIQUE(ORB)(ORBIT_LITERAL(name))
-#define ORBIT_START(name) OrbitStart(ORBIT_LITERAL(name))
-#define ORBIT_STOP OrbitStop()
-#define ORBIT_SEND(ptr, num) OrbitSendData(ptr, num)
+// To disable manual instrumentation macros, set ORBIT_API_ENABLED to 0.
+#define ORBIT_API_ENABLED 1
 
-//-----------------------------------------------------------------------------
-struct OrbitAPI {
-  static inline bool Connect(const char* a_Host, int a_Port = 1789);
-  static inline bool IsConnected();
+#if ORBIT_API_ENABLED
 
- private:
-  static inline void Init();
+// ORBIT_SCOPE: profile current scope.
+#define ORBIT_SCOPE(name) orbit::Scope ORBIT_UNIQUE(ORB)(ORBIT_LITERAL(name))
 
-  typedef void (*InitRemote)(char*);
-  typedef bool (*GetBool)();
+// ORBIT_START/ORBIT_STOP: profile time span on a single thread.
+#define ORBIT_START(name) orbit::Start(ORBIT_LITERAL(name))
+#define ORBIT_STOP orbit::Stop()
 
-  static inline HINSTANCE& GetHandle();
-  static inline InitRemote& GetInitRemote();
-  static inline GetBool& GetIsConnected();
-};
+// ORBIT_START_ASYNC/ORBIT_STOP_ASYNC: profile time span across threads.
+#define ORBIT_START_ASYNC(name, id) orbit::StartAsync(ORBIT_LITERAL(name), id)
+#define ORBIT_STOP_ASYNC(id) orbit::StopAsync(id)
 
-//-----------------------------------------------------------------------------
-#define ORBIT_NOOP       \
-  static volatile int x; \
-  x;
+// ORBIT_[type]: graph variables.
+#define ORBIT_INT(name, value) orbit::TrackInt(ORBIT_LITERAL(name), value)
+#define ORBIT_INT64(name, value) orbit::TrackInt64(ORBIT_LITERAL(name), value)
+#define ORBIT_UINT(name, value) orbit::TrackUint(ORBIT_LITERAL(name), value)
+#define ORBIT_UINT64(name, value) orbit::TrackUint64(ORBIT_LITERAL(name), value)
+#define ORBIT_FLOAT(name, value) orbit::TrackFloat(ORBIT_LITERAL(name), value)
+#define ORBIT_DOUBLE(name, value) orbit::TrackDouble(ORBIT_LITERAL(name), value)
+
+#else
+
+#define ORBIT_SCOPE(name)
+#define ORBIT_START(name)
+#define ORBIT_STOP
+#define ORBIT_START_ASYNC(name, id)
+#define ORBIT_STOP_ASYNC(id)
+#define ORBIT_INT(name, value)
+#define ORBIT_INT64(name, value)
+#define ORBIT_UINT(name, value)
+#define ORBIT_UINT64(name, value)
+#define ORBIT_FLOAT(name, value)
+#define ORBIT_DOUBLE(name, value)
+
+#endif
+
+// NOTE: Do not use any of the code below directly.
+
+// Internal macros.
 #define ORBIT_LITERAL(x) ("" x)
-
-//-----------------------------------------------------------------------------
-#pragma optimize( \
-    "", off)  // On purpose to prevent compiler from stripping functions
-// NOTE: Do not use these directly, use above macros instead
-__declspec(noinline) inline void OrbitStart(const char*) { ORBIT_NOOP; }
-__declspec(noinline) inline void OrbitStop() { ORBIT_NOOP; }
-__declspec(noinline) inline void OrbitLog(const char*) { ORBIT_NOOP; }
-__declspec(noinline) inline void OrbitSendData(void*, int) { ORBIT_NOOP; }
-#pragma optimize("", on)
-
-//-----------------------------------------------------------------------------
-struct OrbitScope {
-  OrbitScope(const char* a_Name) { OrbitStart(a_Name); }
-  ~OrbitScope() { OrbitStop(); }
-};
-
-//-----------------------------------------------------------------------------
 #define ORBIT_CONCAT_IND(x, y) (x##y)
 #define ORBIT_CONCAT(x, y) ORBIT_CONCAT_IND(x, y)
 #define ORBIT_UNIQUE(x) ORBIT_CONCAT(x, __COUNTER__)
+#define ORBIT_UNUSED(x) (void)(x)
+#define ORBIT_NOOP       \
+  static volatile int x; \
+  x;
 
-//-----------------------------------------------------------------------------
-void OrbitAPI::Init() {
-  HINSTANCE& dllHandle = GetHandle();
-  if (!dllHandle) {
-    const TCHAR* dllName =
-        sizeof(size_t) == 4 ? TEXT("Orbit32.dll") : TEXT("Orbit64.dll");
-    if (dllHandle = LoadLibrary(dllName)) {
-      GetInitRemote() =
-          (InitRemote)GetProcAddress(dllHandle, "OrbitInitRemote");
-    }
-  }
+#if _WIN32
+#define NO_INLINE __declspec(noinline)
+#else
+#define NO_INLINE __attribute__((noinline))
+#endif
+
+namespace orbit {
+
+// NOTE: Do not use these directly, use corresponding macros instead.
+inline void NO_INLINE Start(const char*) { ORBIT_NOOP; }
+inline void NO_INLINE Stop() { ORBIT_NOOP; }
+inline void NO_INLINE StartAsync(const char*, uint64_t) { ORBIT_NOOP; }
+inline void NO_INLINE StopAsync(uint64_t) { ORBIT_NOOP; }
+inline void NO_INLINE TrackInt(const char*, int32_t) { ORBIT_NOOP; }
+inline void NO_INLINE TrackInt64(const char*, int64_t) { ORBIT_NOOP; }
+inline void NO_INLINE TrackUint(const char*, uint32_t) { ORBIT_NOOP; }
+inline void NO_INLINE TrackUint64(const char*, uint64_t) { ORBIT_NOOP; }
+inline void NO_INLINE TrackFloatAsInt(const char*, int32_t) { ORBIT_NOOP; }
+inline void NO_INLINE TrackDoubleAsInt64(const char*, int64_t) { ORBIT_NOOP; }
+
+// Convert floating point arguments to integer arguments as we can't access
+// XMM registers with our current dynamic instrumentation on Linux (uprobes).
+inline void TrackFloat(const char* name, float value) {
+  TrackFloatAsInt(name, *reinterpret_cast<int32_t*>(&value));
+}
+inline void TrackDouble(const char* name, double value) {
+  TrackDoubleAsInt64(name, *reinterpret_cast<int64_t*>(&value));
 }
 
-//-----------------------------------------------------------------------------
-bool OrbitAPI::Connect(const char* a_Host, int a_Port) {
-  Init();
-  if (GetHandle() && GetInitRemote()) {
-    char host[256] = {0};
-    sprintf_s(host, sizeof(host), "%s:%i", a_Host, a_Port);
-    GetInitRemote()(host);
-    return IsConnected();
-  }
+struct Scope {
+  Scope(const char* name) { Start(name); }
+  ~Scope() { Stop(); }
+};
 
-  return false;
-}
+}  // namespace orbit
 
-//-----------------------------------------------------------------------------
-bool OrbitAPI::IsConnected() {
-  return GetIsConnected() ? GetIsConnected()() : false;
-}
-
-//-----------------------------------------------------------------------------
-HINSTANCE& OrbitAPI::GetHandle() {
-  static HINSTANCE s_DllHandle;
-  return s_DllHandle;
-}
-OrbitAPI::InitRemote& OrbitAPI::GetInitRemote() {
-  static InitRemote s_InitRemote;
-  return s_InitRemote;
-}
-OrbitAPI::GetBool& OrbitAPI::GetIsConnected() {
-  static GetBool s_IsConnected;
-  return s_IsConnected;
-}
+#endif  // ORBIT_H_

--- a/Orbit.h
+++ b/Orbit.h
@@ -60,7 +60,6 @@
 #define ORBIT_CONCAT_IND(x, y) (x##y)
 #define ORBIT_CONCAT(x, y) ORBIT_CONCAT_IND(x, y)
 #define ORBIT_UNIQUE(x) ORBIT_CONCAT(x, __COUNTER__)
-#define ORBIT_UNUSED(x) (void)(x)
 #define ORBIT_NOOP()         \
   do {                     \
     static volatile int x; \

--- a/Orbit.h
+++ b/Orbit.h
@@ -67,24 +67,24 @@
   } while (0)
 
 #if _WIN32
-#define NO_INLINE __declspec(noinline)
+#define ORBIT_STUB inline __declspec(noinline)
 #else
-#define NO_INLINE __attribute__((noinline))
+#define ORBIT_STUB inline __attribute__((noinline))
 #endif
 
 namespace orbit {
 
 // NOTE: Do not use these directly, use corresponding macros instead.
-inline void NO_INLINE Start(const char*) { ORBIT_NOOP(); }
-inline void NO_INLINE Stop() { ORBIT_NOOP(); }
-inline void NO_INLINE StartAsync(const char*, uint64_t) { ORBIT_NOOP(); }
-inline void NO_INLINE StopAsync(uint64_t) { ORBIT_NOOP(); }
-inline void NO_INLINE TrackInt(const char*, int32_t) { ORBIT_NOOP(); }
-inline void NO_INLINE TrackInt64(const char*, int64_t) { ORBIT_NOOP(); }
-inline void NO_INLINE TrackUint(const char*, uint32_t) { ORBIT_NOOP(); }
-inline void NO_INLINE TrackUint64(const char*, uint64_t) { ORBIT_NOOP(); }
-inline void NO_INLINE TrackFloatAsInt(const char*, int32_t) { ORBIT_NOOP(); }
-inline void NO_INLINE TrackDoubleAsInt64(const char*, int64_t) { ORBIT_NOOP(); }
+ORBIT_STUB void Start(const char*) { ORBIT_NOOP(); }
+ORBIT_STUB void Stop() { ORBIT_NOOP(); }
+ORBIT_STUB void StartAsync(const char*, uint64_t) { ORBIT_NOOP(); }
+ORBIT_STUB void StopAsync(uint64_t) { ORBIT_NOOP(); }
+ORBIT_STUB void TrackInt(const char*, int32_t) { ORBIT_NOOP(); }
+ORBIT_STUB void TrackInt64(const char*, int64_t) { ORBIT_NOOP(); }
+ORBIT_STUB void TrackUint(const char*, uint32_t) { ORBIT_NOOP(); }
+ORBIT_STUB void TrackUint64(const char*, uint64_t) { ORBIT_NOOP(); }
+ORBIT_STUB void TrackFloatAsInt(const char*, int32_t) { ORBIT_NOOP(); }
+ORBIT_STUB void TrackDoubleAsInt64(const char*, int64_t) { ORBIT_NOOP(); }
 
 // Convert floating point arguments to integer arguments as we can't access
 // XMM registers with our current dynamic instrumentation on Linux (uprobes).

--- a/Orbit.h
+++ b/Orbit.h
@@ -13,7 +13,7 @@
 // functions, manual instrumentation is still possible using the macros below.
 // These macros call empty functions that Orbit dynamically instruments.
 
-// To disable manual instrumentation macros, set ORBIT_API_ENABLED to 0.
+// To disable manual instrumentation macros, define ORBIT_API_ENABLED as 0.
 #define ORBIT_API_ENABLED 1
 
 #if ORBIT_API_ENABLED
@@ -23,7 +23,7 @@
 
 // ORBIT_START/ORBIT_STOP: profile time span on a single thread.
 #define ORBIT_START(name) orbit::Start(ORBIT_LITERAL(name))
-#define ORBIT_STOP orbit::Stop()
+#define ORBIT_STOP() orbit::Stop()
 
 // ORBIT_START_ASYNC/ORBIT_STOP_ASYNC: profile time span across threads.
 #define ORBIT_START_ASYNC(name, id) orbit::StartAsync(ORBIT_LITERAL(name), id)
@@ -41,7 +41,7 @@
 
 #define ORBIT_SCOPE(name)
 #define ORBIT_START(name)
-#define ORBIT_STOP
+#define ORBIT_STOP()
 #define ORBIT_START_ASYNC(name, id)
 #define ORBIT_STOP_ASYNC(id)
 #define ORBIT_INT(name, value)
@@ -61,9 +61,11 @@
 #define ORBIT_CONCAT(x, y) ORBIT_CONCAT_IND(x, y)
 #define ORBIT_UNIQUE(x) ORBIT_CONCAT(x, __COUNTER__)
 #define ORBIT_UNUSED(x) (void)(x)
-#define ORBIT_NOOP       \
-  static volatile int x; \
-  x;
+#define ORBIT_NOOP()         \
+  do {                     \
+    static volatile int x; \
+    x;                     \
+  } while (0)
 
 #if _WIN32
 #define NO_INLINE __declspec(noinline)
@@ -74,16 +76,16 @@
 namespace orbit {
 
 // NOTE: Do not use these directly, use corresponding macros instead.
-inline void NO_INLINE Start(const char*) { ORBIT_NOOP; }
-inline void NO_INLINE Stop() { ORBIT_NOOP; }
-inline void NO_INLINE StartAsync(const char*, uint64_t) { ORBIT_NOOP; }
-inline void NO_INLINE StopAsync(uint64_t) { ORBIT_NOOP; }
-inline void NO_INLINE TrackInt(const char*, int32_t) { ORBIT_NOOP; }
-inline void NO_INLINE TrackInt64(const char*, int64_t) { ORBIT_NOOP; }
-inline void NO_INLINE TrackUint(const char*, uint32_t) { ORBIT_NOOP; }
-inline void NO_INLINE TrackUint64(const char*, uint64_t) { ORBIT_NOOP; }
-inline void NO_INLINE TrackFloatAsInt(const char*, int32_t) { ORBIT_NOOP; }
-inline void NO_INLINE TrackDoubleAsInt64(const char*, int64_t) { ORBIT_NOOP; }
+inline void NO_INLINE Start(const char*) { ORBIT_NOOP(); }
+inline void NO_INLINE Stop() { ORBIT_NOOP(); }
+inline void NO_INLINE StartAsync(const char*, uint64_t) { ORBIT_NOOP(); }
+inline void NO_INLINE StopAsync(uint64_t) { ORBIT_NOOP(); }
+inline void NO_INLINE TrackInt(const char*, int32_t) { ORBIT_NOOP(); }
+inline void NO_INLINE TrackInt64(const char*, int64_t) { ORBIT_NOOP(); }
+inline void NO_INLINE TrackUint(const char*, uint32_t) { ORBIT_NOOP(); }
+inline void NO_INLINE TrackUint64(const char*, uint64_t) { ORBIT_NOOP(); }
+inline void NO_INLINE TrackFloatAsInt(const char*, int32_t) { ORBIT_NOOP(); }
+inline void NO_INLINE TrackDoubleAsInt64(const char*, int64_t) { ORBIT_NOOP(); }
 
 // Convert floating point arguments to integer arguments as we can't access
 // XMM registers with our current dynamic instrumentation on Linux (uprobes).

--- a/OrbitTest/OrbitTest.cpp
+++ b/OrbitTest/OrbitTest.cpp
@@ -107,7 +107,7 @@ void OrbitTest::ManualInstrumentationApiTest(){
 
     ORBIT_START("ORBIT_START_TEST");
     std::this_thread::sleep_for(std::chrono::microseconds(500));
-    ORBIT_STOP;
+    ORBIT_STOP();
 
     ORBIT_START_ASYNC("ORBIT_START_ASYNC_TEST", 0);
     std::this_thread::sleep_for(std::chrono::microseconds(500));

--- a/OrbitTest/OrbitTest.cpp
+++ b/OrbitTest/OrbitTest.cpp
@@ -7,9 +7,12 @@
 #include <stdio.h>
 
 #include <chrono>
+#include <cmath>
 #include <iostream>
 #include <sstream>
 #include <thread>
+
+#include "../Orbit.h"
 
 #if __linux__
 #define NO_INLINE __attribute__((noinline))
@@ -56,6 +59,9 @@ void OrbitTest::Start() {
     auto thread = std::make_shared<std::thread>(&OrbitTest::Loop, this);
     m_Threads.push_back(thread);
   }
+
+  m_Threads.push_back( std::make_shared<std::thread>(
+      &OrbitTest::ManualInstrumentationApiTest, this));
 }
 
 //-----------------------------------------------------------------------------
@@ -91,4 +97,47 @@ void NO_INLINE OrbitTest::BusyWork(uint64_t microseconds) {
             .count();
     if (us > microseconds) break;
   }
+}
+
+//-----------------------------------------------------------------------------
+void OrbitTest::ManualInstrumentationApiTest(){
+#if ORBIT_API_ENABLED
+  while (!m_ExitRequested) {
+    ORBIT_SCOPE("ORBIT_SCOPE_TEST");
+
+    ORBIT_START("ORBIT_START_TEST");
+    std::this_thread::sleep_for(std::chrono::microseconds(500));
+    ORBIT_STOP;
+
+    ORBIT_START_ASYNC("ORBIT_START_ASYNC_TEST", 0);
+    std::this_thread::sleep_for(std::chrono::microseconds(500));
+    ORBIT_STOP_ASYNC(0);
+
+    static int int_var = -1000;
+    if(++int_var>1000) int_var = -1000;
+    ORBIT_INT("int_var", int_var);
+
+    static int64_t int64_var = -1000;
+    if(++int64_var>1000) int64_var = -1000;
+    ORBIT_INT64("int64_var", int64_var);
+
+    static int uint_var = 0;
+    if(++uint_var>1000) uint_var = 0;
+    ORBIT_UINT("uint_var", uint_var);
+
+    static uint64_t uint64_var = 0;
+    if(++uint64_var>1000) uint64_var = 0;
+    ORBIT_UINT64("uint64_var", uint64_var);
+
+    static float float_var = 0.f;
+    static volatile float sinf_coeff = 0.001f;
+    ORBIT_FLOAT("float_var", sinf((++float_var) * sinf_coeff));
+
+    static double double_var = 0.f;
+    static volatile double sin_coeff = 0.001f;
+    ORBIT_DOUBLE("float_var", sin((++double_var) * sin_coeff));
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(15));
+  }
+#endif
 }

--- a/OrbitTest/OrbitTest.cpp
+++ b/OrbitTest/OrbitTest.cpp
@@ -134,7 +134,7 @@ void OrbitTest::ManualInstrumentationApiTest(){
     ORBIT_FLOAT("float_var", sinf((++float_var) * sinf_coeff));
 
     static double double_var = 0.f;
-    static volatile double sin_coeff = 0.001f;
+    static volatile double sin_coeff = 0.001;
     ORBIT_DOUBLE("float_var", sin((++double_var) * sin_coeff));
 
     std::this_thread::sleep_for(std::chrono::milliseconds(15));

--- a/OrbitTest/OrbitTest.h
+++ b/OrbitTest/OrbitTest.h
@@ -20,6 +20,7 @@ class OrbitTest {
   void TestFunc(uint32_t a_Depth = 0);
   void TestFunc2(uint32_t a_Depth = 0);
   void BusyWork(uint64_t microseconds);
+  void ManualInstrumentationApiTest();
 
  private:
   bool m_ExitRequested = false;


### PR DESCRIPTION
Clean up Orbit.h and add test code for manual instrumentation API in OrbitTest/OrbitTest.cpp.

The idea is to call into empty functions that Orbit will dynamically instrument.  This PR is the API only, the instrumentation part will come soon.