### PR TITLE
Disable more ui buttons/actions based on the state of the capture

### DIFF
--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -955,7 +955,7 @@ void CaptureWindow::RenderToolbars() {
 
   // Stop Capture.
   ImGui::SameLine();
-  bool stop_enabled = is_capturing;
+  bool stop_enabled = Capture::GState == Capture::State::kStarted;
   if (IconButton(stop_capture_icon_id_, "Stop Capture", icon_size,
                  stop_enabled)) {
     GOrbitApp->StopCapture();

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -71,8 +71,14 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App,
   ui->HomeHorizontalSplitter->setSizes(sizes);
   ui->splitter_2->setSizes(sizes);
 
-  GOrbitApp->AddCaptureStartedCallback(
-      [this] { ui->HomeTab->setDisabled(true); });
+  GOrbitApp->AddCaptureStartedCallback([this] {
+    ui->actionOpen_Capture->setDisabled(true);
+    ui->actionSave_Capture->setDisabled(true);
+    ui->actionOpen_Session->setDisabled(true);
+    ui->actionSave_Session->setDisabled(true);
+    ui->actionSave_Session_As->setDisabled(true);
+    ui->HomeTab->setDisabled(true);
+  });
 
   auto finalizing_capture_dialog = new QProgressDialog(
       "Waiting for the remaining capture data...", "OK", 0, 0, this, Qt::Tool);
@@ -88,6 +94,11 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App,
       [finalizing_capture_dialog] { finalizing_capture_dialog->show(); });
   GOrbitApp->AddCaptureStoppedCallback([this, finalizing_capture_dialog] {
     finalizing_capture_dialog->close();
+    ui->actionOpen_Capture->setDisabled(false);
+    ui->actionSave_Capture->setDisabled(false);
+    ui->actionOpen_Session->setDisabled(false);
+    ui->actionSave_Session->setDisabled(false);
+    ui->actionSave_Session_As->setDisabled(false);
     ui->HomeTab->setDisabled(false);
   });
 


### PR DESCRIPTION
#### Disable File > Load/Save Capture/Session while capturing
Loading and saving a capture while capturing is already disabled in the capture
view's toolbar. Loading a session while capturing is already disabled while
capturing by disabling the content of the "home" tab. Make sure these actions
are also disabled in the "File" menu, as in general they can causes
inconsistencies and their expected behavior is unclear.
Bug: http://b/158256946
#### Disable toolbar's stop button when waiting for remaining capture data