### PR TITLE
add attachments to the crashpad

### DIFF
--- a/third_party/conan/recipes/crashpad/conanfile.py
+++ b/third_party/conan/recipes/crashpad/conanfile.py
@@ -6,10 +6,10 @@ import re
 
 class CrashpadConan(ConanFile):
     name = "crashpad"
-    version = "20191105"
+    version = "20200616"
     description = "Crashpad is a crash-reporting system."
     license = "Apache-2.0"
-    homepage = "https://github.com/chromium/crashpad.git"
+    homepage = "https://github.com/IrinaShkviro/crashpad.git"
     url = "https://github.com/bincrafters/conan-crashpad"
     topics = ("conan", "crash-reporting", "logging", "minidump", "crash")
     settings = "os", "compiler", "build_type", "arch"
@@ -18,7 +18,7 @@ class CrashpadConan(ConanFile):
     exports = [ "patches/*", "LICENSE.md" ]
     short_paths = True
 
-    _commit_id = "1b60c8172c783040b86c3c6960aba4df73990bc5"
+    _commit_id = "ae89bc807a2fd8c7cea9696b2c7b83b4fd4f4647"
     _source_dir = "crashpad"
     _build_name = "out/Conan"
     _build_dir = os.path.join(_source_dir, _build_name)
@@ -58,6 +58,7 @@ class CrashpadConan(ConanFile):
         if self.settings.os == "Windows":
             del self.options.fPIC
 
+
     def configure(self):
         # It's not a C project, but libcxx is hardcoded in the project
         del self.settings.compiler.libcxx
@@ -68,7 +69,7 @@ class CrashpadConan(ConanFile):
 
     def source(self):
         self.run("gclient config --spec=\"%s\"" % self._make_spec(), run_environment=True)
-        self.run("gclient sync --no-history", run_environment=True)
+        self.run("gclient sync --no-history -A", run_environment=True)
 
         if self.settings.os == "Windows":
             tools.patch(base_path=os.path.join(self._source_dir, "third_party/mini_chromium/mini_chromium"),

--- a/third_party/conan/recipes/crashpad/patches/openssl_lib_order.patch
+++ b/third_party/conan/recipes/crashpad/patches/openssl_lib_order.patch
@@ -1,6 +1,8 @@
---- a/crashpad/util/BUILD.gn	2020-04-22 20:02:56.937547710 +0000
-+++ b/crashpad/util/BUILD.gn	2020-04-22 20:14:14.443421318 +0000
-@@ -285,8 +285,8 @@
+diff --git a/util/BUILD.gn b/util/BUILD.gn
+index 21f70048..c4724f8d 100644
+--- a/crashpad/util/BUILD.gn
++++ b/crashpad/util/BUILD.gn
+@@ -377,8 +377,8 @@ static_library("util") {
          deps += [ "//third_party/boringssl" ]
        } else {
          libs = [
@@ -10,7 +12,7 @@
          ]
        }
      }
-@@ -535,8 +535,8 @@
+@@ -635,8 +635,8 @@ if (!crashpad_is_android && !crashpad_is_ios) {
          deps += [ "//third_party/boringssl" ]
        } else {
          libs = [

--- a/third_party/conan/recipes/crashpad/patches/windows_adaptions.patch
+++ b/third_party/conan/recipes/crashpad/patches/windows_adaptions.patch
@@ -1,8 +1,8 @@
 diff --git a/build/BUILD.gn b/build/BUILD.gn
-index d8dc6cd..4f55b5f 100644
+index 8a1949c..095ce0b 100644
 --- a/build/BUILD.gn
 +++ b/build/BUILD.gn
-@@ -39,10 +39,23 @@ if (mini_chromium_is_mac) {
+@@ -39,6 +39,12 @@ if (mini_chromium_is_mac) {
      # win_sdk\bin\SetEnv.cmd inside this path will be used to configure the
      # Windows toolchain.
      win_toolchain_path = "<autodetect>"
@@ -14,7 +14,10 @@ index d8dc6cd..4f55b5f 100644
 +    dynamic_crt = false
    }
  }
- 
+
+@@ -79,6 +85,13 @@ declare_args() {
+ }
+
  config("debug") {
 +  if (mini_chromium_is_win) {
 +    if (dynamic_crt) {
@@ -23,10 +26,10 @@ index d8dc6cd..4f55b5f 100644
 +      cflags = [ "/MTd" ]
 +    }
 +  }
- }
- 
- config("release") {
-@@ -64,7 +77,6 @@ config("release") {
+   if (!mini_chromium_is_win) {
+     cflags = [ "-g" ]
+   }
+@@ -103,7 +116,6 @@ config("release") {
      }
    } else if (mini_chromium_is_win) {
      cflags = [
@@ -34,7 +37,7 @@ index d8dc6cd..4f55b5f 100644
        "/O2",
        "/Ob2",  # Both explicit and auto inlining.
        "/Oy-",  # Disable omitting frame pointers, must be after /O2.
-@@ -73,10 +85,20 @@ config("release") {
+@@ -112,10 +124,20 @@ config("release") {
      ]
      ldflags = [
        "/OPT:ICF",
@@ -57,6 +60,7 @@ index d8dc6cd..4f55b5f 100644
 +    }
    }
  }
+
 
 diff --git a/build/win_helper.py b/build/win_helper.py
 index a5e1fdd..edb93eb 100644


### PR DESCRIPTION
Updated crashpad recipe: it looks at my github as temporary solution until I contribute to the crashpad itself.
It allows us to use --attachment argument in the StartHandler function to be able to pass list of files that should be attached to the crash report.