### PR TITLE
Fix memory leaks in OrbitCore's tcp classes.

### DIFF
--- a/OrbitCore/OrbitAsio.cpp
+++ b/OrbitCore/OrbitAsio.cpp
@@ -10,7 +10,7 @@
 #include "VariableTracing.h"
 
 //-----------------------------------------------------------------------------
-TcpService::TcpService() { m_IoService = new asio::io_service(); }
+TcpService::TcpService() { m_IoService = std::make_unique<asio::io_service>(); }
 
 //-----------------------------------------------------------------------------
 TcpService::~TcpService() { PRINT_FUNC; }

--- a/OrbitCore/OrbitAsio.h
+++ b/OrbitCore/OrbitAsio.h
@@ -2,8 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
 #pragma once
+
+#include <memory>
 
 #include "asio.hpp"
 
@@ -14,7 +15,7 @@ class TcpService {
  public:
   TcpService();
   ~TcpService();
-  asio::io_context* m_IoService;
+  std::unique_ptr<asio::io_context> m_IoService;
 };
 
 //-----------------------------------------------------------------------------

--- a/OrbitCore/TcpClient.cpp
+++ b/OrbitCore/TcpClient.cpp
@@ -41,7 +41,7 @@ void TcpClient::Connect(const std::string& address) {
   const std::string& host = vec[0];
   const std::string& port = vec[1];
 
-  m_TcpService->m_IoService = new asio::io_service();
+  m_TcpService->m_IoService = std::make_unique<asio::io_service>();
   m_TcpSocket->m_Socket = new tcp::socket(*m_TcpService->m_IoService);
 
   asio::ip::tcp::socket& socket = *m_TcpSocket->m_Socket;

--- a/OrbitCore/TcpClient.h
+++ b/OrbitCore/TcpClient.h
@@ -26,7 +26,7 @@ class TcpClient : public TcpEntity {
   void ReadFooter();
   void DecodeMessage(Message& a_Message);
   void OnError(const std::error_code& ec);
-  TcpSocket* GetSocket() final { return m_TcpSocket; }
+  TcpSocket* GetSocket() final { return m_TcpSocket.get(); }
 
  private:
   Message m_Message;

--- a/OrbitCore/TcpEntity.cpp
+++ b/OrbitCore/TcpEntity.cpp
@@ -23,8 +23,8 @@ TcpEntity::TcpEntity()
       m_NumFlushedItems(0) {
   PRINT_FUNC;
   m_IsValid = false;
-  m_TcpSocket = new TcpSocket();
-  m_TcpService = new TcpService();
+  m_TcpSocket = std::make_unique<TcpSocket>();
+  m_TcpService = std::make_unique<TcpService>();
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitCore/TcpEntity.h
+++ b/OrbitCore/TcpEntity.h
@@ -102,8 +102,8 @@ class TcpEntity {
   void SendData();
 
  protected:
-  TcpService* m_TcpService;
-  TcpSocket* m_TcpSocket;
+  std::unique_ptr<TcpService> m_TcpService;
+  std::unique_ptr<TcpSocket> m_TcpSocket;
   std::thread senderThread_;
   AutoResetEvent m_ConditionVariable;
   LockFreeQueue<TcpPacket> m_SendQueue;

--- a/OrbitCore/TcpServer.cpp
+++ b/OrbitCore/TcpServer.cpp
@@ -56,7 +56,7 @@ void TcpServer::StartServer(uint16_t a_Port) {
   Start();
 
   PRINT_FUNC;
-  m_TcpService = new TcpService();
+  m_TcpService = std::make_unique<TcpService>();
   m_TcpServer = new tcp_server(*m_TcpService->m_IoService, a_Port);
 
   serverThread_ = std::thread{[this]() { ServerThread(); }};


### PR DESCRIPTION
Replaces two raw pointers by unique_ptr.

This is not really fixing a bug or problem, but it helps with fuzzing. I haven't seen any negative side effects so far.