### PR TITLE
Automatically select the process with the highest CPU usage

### DIFF
--- a/OrbitGl/ProcessesDataView.cpp
+++ b/OrbitGl/ProcessesDataView.cpp
@@ -16,7 +16,8 @@
 #include "Params.h"
 #include "absl/strings/str_format.h"
 
-ProcessesDataView::ProcessesDataView() : DataView(DataViewType::PROCESSES) {}
+ProcessesDataView::ProcessesDataView()
+    : DataView(DataViewType::PROCESSES), selected_process_id_(0) {}
 
 const std::vector<DataView::Column>& ProcessesDataView::GetColumns() {
   static const std::vector<Column> columns = [] {


### PR DESCRIPTION
#### Fix uninitialized ProcessesDataView::selected_process_id_
#### Automatically select the process with the highest CPU usage
When the list of processes is received from the service, if none has been
selected, find and select the one that in that moment has the highest CPU usage.
If all are zero, select the process with the lowest pid.
Bug: http://b/156072922