### PR TITLE
Automatically select the process with the highest CPU usage v2

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -273,6 +273,11 @@ void OrbitApp::PostInit() {
     auto callback = [&](ProcessManager* process_manager) {
       main_thread_executor_->Schedule([&, process_manager]() {
         m_ProcessesDataView->SetProcessList(process_manager->GetProcessList());
+        if (m_ProcessesDataView->GetSelectedProcessId() == 0 &&
+            m_ProcessesDataView->GetFirstProcessId() != 0) {
+          m_ProcessesDataView->SelectProcess(
+              m_ProcessesDataView->GetFirstProcessId());
+        }
         FireRefreshCallbacks(DataViewType::PROCESSES);
       });
     };

--- a/OrbitGl/ProcessesDataView.cpp
+++ b/OrbitGl/ProcessesDataView.cpp
@@ -106,6 +106,13 @@ uint32_t ProcessesDataView::GetSelectedProcessId() const {
   return selected_process_id_;
 }
 
+uint32_t ProcessesDataView::GetFirstProcessId() const {
+  if (m_Indices.empty()) {
+    return 0;
+  }
+  return process_list_[m_Indices[0]].pid();
+}
+
 //-----------------------------------------------------------------------------
 void ProcessesDataView::SetSelectedItem() {
   for (size_t i = 0; i < GetNumElements(); ++i) {

--- a/OrbitGl/ProcessesDataView.cpp
+++ b/OrbitGl/ProcessesDataView.cpp
@@ -16,7 +16,8 @@
 #include "Params.h"
 #include "absl/strings/str_format.h"
 
-ProcessesDataView::ProcessesDataView() : DataView(DataViewType::PROCESSES) {}
+ProcessesDataView::ProcessesDataView()
+    : DataView(DataViewType::PROCESSES), selected_process_id_(0) {}
 
 const std::vector<DataView::Column>& ProcessesDataView::GetColumns() {
   static const std::vector<Column> columns = [] {

--- a/OrbitGl/ProcessesDataView.h
+++ b/OrbitGl/ProcessesDataView.h
@@ -26,6 +26,7 @@ class ProcessesDataView final : public DataView {
   bool SelectProcess(uint32_t process_id);
   void SetProcessList(std::vector<ProcessInfo>&& process_list);
   uint32_t GetSelectedProcessId() const;
+  uint32_t GetFirstProcessId() const;
 
  protected:
   void DoSort() override;


### PR DESCRIPTION
#### Fix uninitialized ProcessesDataView::selected_process_id_
#### Automatically select the process with the highest CPU usage
When the list of processes is received from the service and set in
`ProcessesDataView`, if none has been selected, select the one at the top,
which by default is the one with the highest CPU usage as the "CPU" column is by
default the one processes are sorted by.
Bug: http://b/156072922

---
This is an alternative implementation of #684 that relies on the sorting performed by `ProcessesDataView`.