### PR TITLE
Don't zoom on shift key press.

### DIFF
--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -492,7 +492,9 @@ void CaptureWindow::KeyPressed(unsigned int a_KeyCode, bool a_Ctrl,
   if (!m_ImguiActive) {
     switch (a_KeyCode) {
       case ' ':
-        ZoomAll();
+        if (!a_Shift) {
+          ZoomAll();
+        }
         break;
       case 'A':
         Pan(0.1f);


### PR DESCRIPTION
The "shift" and "space" keys currently map to the same key code.  Differentiate based on the dedicated "a_Shift" argument.