### PR TITLE
Fixed memory leak in FramePointerValidator

### DIFF
--- a/OrbitBase/CMakeLists.txt
+++ b/OrbitBase/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(OrbitBase PRIVATE
         include/OrbitBase/Action.h
         include/OrbitBase/Logging.h
         include/OrbitBase/MainThreadExecutor.h
+        include/OrbitBase/UniqueResource.h
         include/OrbitBase/ThreadPool.h
         include/OrbitBase/SafeStrerror.h)
 
@@ -40,6 +41,7 @@ add_executable(OrbitBaseTests)
 target_sources(OrbitBaseTests PRIVATE
     MainThreadExecutorTest.cpp
     ThreadPoolTest.cpp
+    UniqueResourceTest.cpp
 )
 
 target_link_libraries(OrbitBaseTests PRIVATE

--- a/OrbitBase/UniqueResourceTest.cpp
+++ b/OrbitBase/UniqueResourceTest.cpp
@@ -1,0 +1,62 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "OrbitBase/UniqueResource.h"
+
+void my_delete(size_t) {}
+
+TEST(UniqueResource, Construct) {
+  OrbitBase::unique_resource<size_t, void (*)(size_t)> ur1(123, my_delete);
+  OrbitBase::unique_resource ur2(123, my_delete);
+
+  size_t was_deleted = 0;
+  {
+    OrbitBase::unique_resource ur{123,
+                                  [&was_deleted](size_t) { was_deleted++; }};
+    ASSERT_TRUE(static_cast<bool>(ur));
+    ASSERT_TRUE(static_cast<size_t>(ur) == 123);
+  }
+  ASSERT_EQ(was_deleted, 1);
+}
+
+TEST(UniqueResource, Move) {
+  size_t was_deleted = 0;
+  {
+    OrbitBase::unique_resource ur1{123,
+                                   [&was_deleted](size_t) { was_deleted++; }};
+    ASSERT_TRUE(static_cast<bool>(ur1));
+
+    {
+      auto ur2 = std::move(ur1);
+      ASSERT_TRUE(static_cast<bool>(ur2));
+      ASSERT_FALSE(static_cast<bool>(ur1));
+      ASSERT_EQ(was_deleted, 0);
+    }
+    ASSERT_EQ(was_deleted, 1);
+  }
+  ASSERT_EQ(was_deleted, 1);
+}
+
+TEST(UniqueResource, Release) {
+  size_t was_deleted = 0;
+  {
+    OrbitBase::unique_resource ur1{123,
+                                   [&was_deleted](size_t) { was_deleted++; }};
+    ur1.release();
+  }
+  ASSERT_EQ(was_deleted, 0);
+}
+
+TEST(UniqueResource, Reset) {
+  size_t last_deleted_resource = 0;
+  {
+    OrbitBase::unique_resource ur1{123,
+                                   [&last_deleted_resource](size_t r) { last_deleted_resource = r; }};
+    ur1.reset(456);
+    ASSERT_EQ(last_deleted_resource, 123);
+  }
+  ASSERT_EQ(last_deleted_resource, 456);
+}

--- a/OrbitBase/include/OrbitBase/UniqueResource.h
+++ b/OrbitBase/include/OrbitBase/UniqueResource.h
@@ -1,0 +1,88 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_BASE_UNIQUE_RESOURCE_H_
+#define ORBIT_BASE_UNIQUE_RESOURCE_H_
+
+#include <functional>
+#include <optional>
+
+namespace OrbitBase {
+
+/* unique_resource helps to manage a unique identity which is not a pointer,
+   so unique_ptr cannot be used. Typical examples are file or window handles
+   from C libraries. The resource (handle) is typically small and trivially
+   copyable, but that's not required. Though we require it to be noexcept
+   moveable.
+
+   Unlike unique_ptr this resource requires you to provide a Deleter type.
+   No default deleter exists.
+
+   Empty base class optimization for Deleter is not implemented (yet).
+*/
+template <typename Resource_, typename Deleter_>
+class unique_resource {
+ public:
+  using Resource = Resource_;
+  using Deleter = Deleter_;
+
+  constexpr unique_resource() {}
+  constexpr unique_resource(Resource resource, Deleter deleter = Deleter{})
+      : resource_(std::move(resource)), deleter_(std::move(deleter)) {}
+
+  unique_resource(const unique_resource&) = delete;
+  unique_resource& operator=(const unique_resource&) = delete;
+
+  unique_resource(unique_resource&& other)
+      : resource_(std::move(other.resource_)),
+        deleter_(std::move(other.deleter_)) {
+    other.resource_ = std::nullopt;
+  }
+  unique_resource& operator=(unique_resource&& other) noexcept {
+    if (&other != this) {
+      RunDeleter();
+
+      get_deleter() = std::move(other.get_deleter());
+      resource_ = std::move(other.resource_);
+      other.resource_ = std::nullopt;
+    }
+
+    return *this;
+  }
+
+  ~unique_resource() noexcept { RunDeleter(); }
+
+  Resource get() const noexcept { return resource_.value(); }
+  Deleter& get_deleter() noexcept { return deleter_; }
+  const Deleter& get_deleter() const noexcept { return deleter_; }
+
+  void release() noexcept { resource_ = std::nullopt; }
+
+  explicit operator bool() const noexcept { return resource_.has_value(); }
+  operator Resource() const { return resource_.value(); }
+
+  void reset(Resource resource) {
+    RunDeleter();
+    resource_ = std::move(resource);
+  }
+
+ private:
+  void RunDeleter() {
+    if (resource_) {
+      std::invoke(get_deleter(), resource_.value());
+    }
+  }
+
+  std::optional<Resource> resource_;
+  Deleter deleter_;
+};
+
+template <typename Resource, typename Deleter>
+unique_resource(Resource, Deleter)
+    -> unique_resource<std::decay_t<Resource>, std::remove_cv_t<Deleter>>;
+
+}  // namespace OrbitBase
+
+#endif  // ORBIT_BASE_UNIQUE_RESOURCE_H_
+#

--- a/OrbitCore/FramePointerValidator.cpp
+++ b/OrbitCore/FramePointerValidator.cpp
@@ -8,6 +8,7 @@
 
 #include "FunctionFramePointerValidator.h"
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/UniqueResource.h"
 
 std::optional<std::vector<std::shared_ptr<Function>>>
 FramePointerValidator::GetFpoFunctions(
@@ -16,11 +17,13 @@ FramePointerValidator::GetFpoFunctions(
   std::vector<std::shared_ptr<Function>> result;
 
   cs_mode mode = is_64_bit ? CS_MODE_64 : CS_MODE_32;
-  csh handle;
-  if (cs_open(CS_ARCH_X86, mode, &handle) != CS_ERR_OK) {
+  csh temp_handle;
+  if (cs_open(CS_ARCH_X86, mode, &temp_handle) != CS_ERR_OK) {
     ERROR("Unable to open capstone.");
     return {};
   }
+  OrbitBase::unique_resource handle{std::move(temp_handle),
+                                    [](csh handle) { cs_close(&handle); }};
 
   cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
 


### PR DESCRIPTION
That's the first thing which came out of the fuzz-testing. Better to say, it came out the usage of address sanitizer which is requirement for fuzz testing.

`FramePointerValidator::GetFpoFunctions` needs to call `cs_close` when it's done. Otherwise the internal data structure is leaked. And since I wasn't sure if some parts of this function might throw, I added a RAII-wrapper (which was quickly written but unfortunately adds some boilerplate.)

EDIT: I was running and had some time to think about that. I came to the conclusion that we need a resource management class. OrbitSsh::Context will benefit from that as well. Looping in @dimitry- for code review of the generic part.