### PR TITLE
Detect Orbit API functions when loading symbols.

### DIFF
--- a/Orbit.h
+++ b/Orbit.h
@@ -19,23 +19,23 @@
 #if ORBIT_API_ENABLED
 
 // ORBIT_SCOPE: profile current scope.
-#define ORBIT_SCOPE(name) orbit::Scope ORBIT_UNIQUE(ORB)(ORBIT_LITERAL(name))
+#define ORBIT_SCOPE(name) orbit_api::Scope ORBIT_VAR(ORBIT_STR(name))
 
 // ORBIT_START/ORBIT_STOP: profile time span on a single thread.
-#define ORBIT_START(name) orbit::Start(ORBIT_LITERAL(name))
-#define ORBIT_STOP() orbit::Stop()
+#define ORBIT_START(name) orbit_api::Start(ORBIT_STR(name))
+#define ORBIT_STOP() orbit_api::Stop()
 
 // ORBIT_START_ASYNC/ORBIT_STOP_ASYNC: profile time span across threads.
-#define ORBIT_START_ASYNC(name, id) orbit::StartAsync(ORBIT_LITERAL(name), id)
-#define ORBIT_STOP_ASYNC(id) orbit::StopAsync(id)
+#define ORBIT_START_ASYNC(name, id) orbit_api::StartAsync(ORBIT_STR(name), id)
+#define ORBIT_STOP_ASYNC(id) orbit_api::StopAsync(id)
 
 // ORBIT_[type]: graph variables.
-#define ORBIT_INT(name, value) orbit::TrackInt(ORBIT_LITERAL(name), value)
-#define ORBIT_INT64(name, value) orbit::TrackInt64(ORBIT_LITERAL(name), value)
-#define ORBIT_UINT(name, value) orbit::TrackUint(ORBIT_LITERAL(name), value)
-#define ORBIT_UINT64(name, value) orbit::TrackUint64(ORBIT_LITERAL(name), value)
-#define ORBIT_FLOAT(name, value) orbit::TrackFloat(ORBIT_LITERAL(name), value)
-#define ORBIT_DOUBLE(name, value) orbit::TrackDouble(ORBIT_LITERAL(name), value)
+#define ORBIT_INT(name, val) orbit_api::TrackInt(ORBIT_STR(name), val)
+#define ORBIT_INT64(name, val) orbit_api::TrackInt64(ORBIT_STR(name), val)
+#define ORBIT_UINT(name, val) orbit_api::TrackUint(ORBIT_STR(name), val)
+#define ORBIT_UINT64(name, val) orbit_api::TrackUint64(ORBIT_STR(name), val)
+#define ORBIT_FLOAT(name, val) orbit_api::TrackFloat(ORBIT_STR(name), val)
+#define ORBIT_DOUBLE(name, val) orbit_api::TrackDouble(ORBIT_STR(name), val)
 
 #else
 
@@ -56,10 +56,11 @@
 // NOTE: Do not use any of the code below directly.
 
 // Internal macros.
-#define ORBIT_LITERAL(x) ("" x)
+#define ORBIT_STR(x) ("" x)
 #define ORBIT_CONCAT_IND(x, y) (x##y)
 #define ORBIT_CONCAT(x, y) ORBIT_CONCAT_IND(x, y)
 #define ORBIT_UNIQUE(x) ORBIT_CONCAT(x, __COUNTER__)
+#define ORBIT_VAR ORBIT_UNIQUE(ORB)
 #define ORBIT_NOOP()       \
   do {                     \
     static volatile int x; \
@@ -72,7 +73,7 @@
 #define ORBIT_STUB inline __attribute__((noinline))
 #endif
 
-namespace orbit {
+namespace orbit_api {
 
 // NOTE: Do not use these directly, use corresponding macros instead.
 ORBIT_STUB void Start(const char*) { ORBIT_NOOP(); }

--- a/OrbitCore/OrbitFunction.cpp
+++ b/OrbitCore/OrbitFunction.cpp
@@ -178,10 +178,10 @@ Function::GetFunctionNameToOrbitTypeMap() {
 }
 
 // Detect Orbit API functions by looking for special function names part of the
-// orbit namespace. If there is a match, set the corresponding function type.
+// orbit_api namespace. On a match, set the corresponding function type.
 bool Function::SetOrbitTypeFromName() {
   const std::string& name = PrettyName();
-  if (absl::StartsWith(name, "orbit::")) {
+  if (absl::StartsWith(name, "orbit_api::")) {
     for (auto& pair : GetFunctionNameToOrbitTypeMap()) {
       if (absl::StrContains(name, pair.first)) {
         SetOrbitType(pair.second);

--- a/OrbitCore/OrbitFunction.cpp
+++ b/OrbitCore/OrbitFunction.cpp
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
-
 #include "OrbitFunction.h"
 
 #include <OrbitBase/Logging.h>
@@ -158,6 +156,40 @@ const char* Function::GetCallingConventionString() {
   }
 
   return kCallingConventions[calling_convention_];
+}
+
+const absl::flat_hash_map<const char*, Function::OrbitType>&
+Function::GetFunctionNameToOrbitTypeMap() {
+  static absl::flat_hash_map<const char*, OrbitType> function_name_to_type_map{
+      {"Start(", ORBIT_TIMER_START},
+      {"Stop(", ORBIT_TIMER_STOP},
+      {"StartAsync(", ORBIT_TIMER_START_ASYNC},
+      {"StopAsync(", ORBIT_TIMER_STOP_ASYNC},
+      {"TrackInt(", ORBIT_TRACK_INT},
+      {"TrackInt64(", ORBIT_TRACK_INT_64},
+      {"TrackUint(", ORBIT_TRACK_UINT},
+      {"TrackUint64(", ORBIT_TRACK_UINT_64},
+      {"TrackFloat(", ORBIT_TRACK_FLOAT},
+      {"TrackDouble(", ORBIT_TRACK_DOUBLE},
+      {"TrackFloatAsInt(", ORBIT_TRACK_FLOAT_AS_INT},
+      {"TrackDoubleAsInt64(", ORBIT_TRACK_DOUBLE_AS_INT_64},
+  };
+  return function_name_to_type_map;
+}
+
+// Detect Orbit API functions by looking for special function names part of the
+// orbit namespace. If there is a match, set the corresponding function type.
+bool Function::SetOrbitTypeFromName() {
+  const std::string& name = PrettyName();
+  if (absl::StartsWith(name, "orbit::")) {
+    for (auto& pair : GetFunctionNameToOrbitTypeMap()) {
+      if (absl::StrContains(name, pair.first)) {
+        SetOrbitType(pair.second);
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 ORBIT_SERIALIZE(Function, 4) {

--- a/OrbitCore/OrbitFunction.h
+++ b/OrbitCore/OrbitFunction.h
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
 #pragma once
 
 #include <string>
@@ -15,6 +14,7 @@
 #include "Path.h"
 #include "SerializationMacros.h"
 #include "Utils.h"
+#include "absl/container/flat_hash_map.h"
 #include "cvconst.h"
 
 class Pdb;
@@ -65,6 +65,18 @@ class Function {
     FREE,
     REALLOC,
     ORBIT_DATA,
+    ORBIT_TIMER_START_ASYNC,
+    ORBIT_TIMER_STOP_ASYNC,
+    ORBIT_TRACK_INT,
+    ORBIT_TRACK_INT_64,
+    ORBIT_TRACK_UINT,
+    ORBIT_TRACK_UINT_64,
+    ORBIT_TRACK_FLOAT,
+    ORBIT_TRACK_DOUBLE,
+    ORBIT_TRACK_FLOAT_AS_INT,
+    ORBIT_TRACK_DOUBLE_AS_INT_64,
+    // Append new types here.
+
     NUM_TYPES
   };
 
@@ -108,6 +120,7 @@ class Function {
 
   OrbitType GetOrbitType() const { return type_; }
   void SetOrbitType(OrbitType type) { type_ = type; }
+  bool SetOrbitTypeFromName();
   bool IsOrbitFunc() const { return type_ != OrbitType::NONE; }
   bool IsOrbitZone() const {
     return type_ == ORBIT_TIMER_START || type_ == ORBIT_TIMER_STOP;
@@ -137,6 +150,10 @@ class Function {
   void FindFile();
 
   ORBIT_SERIALIZABLE;
+
+ private:
+  static const absl::flat_hash_map<const char*, OrbitType>&
+  GetFunctionNameToOrbitTypeMap();
 
  private:
   std::string name_;

--- a/OrbitCore/OrbitModule.cpp
+++ b/OrbitCore/OrbitModule.cpp
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
-
 #include "OrbitModule.h"
 
 #include <cinttypes>
@@ -132,10 +130,12 @@ Pdb::Pdb(uint64_t module_address, uint64_t load_bias, std::string file_name,
   m_Name = Path::GetFileName(m_FileName);
 }
 
+//-----------------------------------------------------------------------------
 void Pdb::AddFunction(const std::shared_ptr<Function>& function) {
   functions_.push_back(function);
   functions_.back()->SetModulePathAndAddress(GetLoadedModuleName(),
                                              GetHModule());
+  functions_.back()->SetOrbitTypeFromName();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Detect Orbit API functions and set their "OrbitType" accordingly.  This will be used to automatically hook into manual instrumentation api functions.