### PR TITLE
Changed ssh watchdog timeout to 25 seconds

### DIFF
--- a/OrbitGl/FunctionsDataView.cpp
+++ b/OrbitGl/FunctionsDataView.cpp
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
-
 #include "FunctionsDataView.h"
 
 #include "App.h"
@@ -83,6 +81,14 @@ std::string FunctionsDataView::GetValue(int a_Row, int a_Column) {
 
 //-----------------------------------------------------------------------------
 void FunctionsDataView::DoSort() {
+  // TODO(antonrohr) This sorting function can take a lot of time when a large
+  // number of functions is used (several seconds). This function is currently
+  // executed on the main thread and therefore freezes the UI and interrupts the
+  // ssh watchdog signals that are sent to the service. Therefore this should
+  // not be called on the main thread and as soon as this is done the watchdog
+  // timeout should be rolled back from 25 seconds to 10 seconds in
+  // OrbitService.h
+  SCOPE_TIMER_LOG("FunctionsDataView::DoSort");
   bool ascending = m_SortingOrders[m_SortingColumn] == SortingOrder::Ascending;
   std::function<bool(int a, int b)> sorter = nullptr;
 
@@ -182,6 +188,14 @@ void FunctionsDataView::OnContextMenu(const std::string& a_Action,
 
 //-----------------------------------------------------------------------------
 void FunctionsDataView::DoFilter() {
+  // TODO(antonrohr) This filter function can take a lot of time when a large
+  // number of functions is used (several seconds). This function is currently
+  // executed on the main thread and therefore freezes the UI and interrupts the
+  // ssh watchdog signals that are sent to the service. Therefore this should
+  // not be called on the main thread and as soon as this is done the watchdog
+  // timeout should be rolled back from 25 seconds to 10 seconds in
+  // OrbitService.h
+  SCOPE_TIMER_LOG("FunctionsDataView::DoFilter");
   m_FilterTokens = absl::StrSplit(ToLower(m_Filter), ' ');
 
 #ifdef WIN32

--- a/OrbitService/OrbitService.h
+++ b/OrbitService/OrbitService.h
@@ -33,7 +33,12 @@ class OrbitService {
   std::optional<std::chrono::time_point<std::chrono::steady_clock>>
       last_stdin_message_ = std::nullopt;
   const std::string_view start_passphrase_ = "start_watchdog";
-  const int timeout_in_seconds_ = 10;
+  // TODO(antonrohr) The main thread can currently be blocked by slow functions
+  // like FunctionsDataView::DoSort and FunctionsDataView::DoFilter. The default
+  // timeout of 10 seconds is not enough with the blocking behaviour. As soon as
+  // the main thread does not block anymore, revert this from 25 seconds back to
+  // 10 seconds.
+  const int timeout_in_seconds_ = 25;
 };
 
 #endif  // ORBIT_SERVICE_ORBIT_SERVICE_H


### PR DESCRIPTION
Also added additional scope timer to some slow functions.

Sorting and filtering of the FunctionsDataView is currently done on the main thread. With large amounts of functions (InfiltratorDemo) this can take more than 10 seconds, in which no watchdog message will be send to the Service. 

I know that this is not a good solution, the better solution would be doing the slow things off the main thread