### PR TITLE
Fix capture not starting with "No process selected"

### DIFF
--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -153,7 +153,7 @@ bool Capture::Connect(std::string_view remote_address) {
 //  server side logic and client side logic into separate methods/classes.
 outcome::result<void, std::string> Capture::StartCapture(
     std::string_view remote_address) {
-  if (GTargetProcess->GetName().empty()) {
+  if (GTargetProcess->GetID() == 0) {
     return outcome::failure(
         "No process selected. Please choose a target process for the capture.");
   }


### PR DESCRIPTION
This is because Process::SetName is not called anymore.