### PR TITLE
Removed COLUMN_HAS_PDB from ModulesDataView

### DIFF
--- a/OrbitGl/ModulesDataView.cpp
+++ b/OrbitGl/ModulesDataView.cpp
@@ -28,8 +28,7 @@ const std::vector<DataView::Column>& ModulesDataView::GetColumns() {
     columns[COLUMN_PATH] = {"Path", .3f, SortingOrder::Ascending};
     columns[COLUMN_ADDRESS_RANGE] = {"Address Range", .15f,
                                      SortingOrder::Ascending};
-    columns[COLUMN_HAS_PDB] = {"Debug info", .0f, SortingOrder::Descending};
-    columns[COLUMN_PDB_SIZE] = {"Pdb Size", .0f, SortingOrder::Descending};
+    columns[COLUMN_FILE_SIZE] = {"File Size", .0f, SortingOrder::Descending};
     columns[COLUMN_LOADED] = {"Loaded", .0f, SortingOrder::Descending};
     return columns;
   }();
@@ -49,9 +48,7 @@ std::string ModulesDataView::GetValue(int row, int col) {
       return module->file_path();
     case COLUMN_ADDRESS_RANGE:
       return module->address_range();
-    case COLUMN_HAS_PDB:
-      return "*";
-    case COLUMN_PDB_SIZE:
+    case COLUMN_FILE_SIZE:
       return GetPrettySize(module->file_size());
     case COLUMN_LOADED:
       return module->is_loaded() ? "*" : "";
@@ -82,7 +79,7 @@ void ModulesDataView::DoSort() {
     case COLUMN_ADDRESS_RANGE:
       sorter = ORBIT_PROC_SORT(address_start());
       break;
-    case COLUMN_PDB_SIZE:
+    case COLUMN_FILE_SIZE:
       sorter = ORBIT_PROC_SORT(file_size());
       break;
     case COLUMN_LOADED:

--- a/OrbitGl/ModulesDataView.h
+++ b/OrbitGl/ModulesDataView.h
@@ -15,7 +15,7 @@ class ModulesDataView : public DataView {
   ModulesDataView();
 
   const std::vector<Column>& GetColumns() override;
-  int GetDefaultSortingColumn() override { return COLUMN_PDB_SIZE; }
+  int GetDefaultSortingColumn() override { return COLUMN_FILE_SIZE; }
   std::vector<std::string> GetContextMenu(
       int clicked_index, const std::vector<int>& selected_indices) override;
   std::string GetValue(int row, int column) override;
@@ -44,8 +44,7 @@ class ModulesDataView : public DataView {
     COLUMN_NAME,
     COLUMN_PATH,
     COLUMN_ADDRESS_RANGE,
-    COLUMN_HAS_PDB,
-    COLUMN_PDB_SIZE,
+    COLUMN_FILE_SIZE,
     COLUMN_LOADED,
     COLUMN_NUM
   };


### PR DESCRIPTION
This column is unused and did not reflect reality when it
was used. We assume every module is loadable.

Renamed 'Pdb Size' column to 'File Size'

Bug: http://b/159096545