### PR TITLE
Restore usage of Process::SetName

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -986,6 +986,10 @@ void OrbitApp::OnProcessSelected(uint32_t pid) {
         // new data model.
         std::shared_ptr<Process> process = std::make_shared<Process>();
         process->SetID(pid);
+        ProcessData* process_data = data_manager_->GetProcessByPid(pid);
+        if (process_data != nullptr) {
+          process->SetName(process_data->name());
+        }
         process->SetIsRemote(true);
 
         Capture::SetTargetProcess(process);

--- a/OrbitGl/DataManager.cpp
+++ b/OrbitGl/DataManager.cpp
@@ -36,7 +36,18 @@ void DataManager::UpdateModuleInfos(
   it->second->UpdateModuleInfos(module_infos);
 }
 
-const std::vector<ModuleData*> DataManager::GetModules(uint32_t process_id) {
+ProcessData* DataManager::GetProcessByPid(uint32_t process_id) {
+  CHECK(std::this_thread::get_id() == main_thread_id_);
+
+  auto it = process_map_.find(process_id);
+  if (it == process_map_.end()) {
+    return nullptr;
+  }
+
+  return it->second.get();
+}
+
+const std::vector<ModuleData*>& DataManager::GetModules(uint32_t process_id) {
   CHECK(std::this_thread::get_id() == main_thread_id_);
 
   auto it = process_map_.find(process_id);

--- a/OrbitGl/DataManager.h
+++ b/OrbitGl/DataManager.h
@@ -23,7 +23,8 @@ class DataManager final {
   void UpdateModuleInfos(uint32_t process_id,
                          const std::vector<ModuleInfo>& module_infos);
 
-  const std::vector<ModuleData*> GetModules(uint32_t process_id);
+  ProcessData* GetProcessByPid(uint32_t process_id);
+  const std::vector<ModuleData*>& GetModules(uint32_t process_id);
   ModuleData* FindModuleByAddressStart(uint32_t process_id,
                                        uint64_t address_start);
 

--- a/OrbitGl/ModuleData.h
+++ b/OrbitGl/ModuleData.h
@@ -8,6 +8,7 @@
 #include <cinttypes>
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "absl/strings/str_format.h"
 #include "module.pb.h"
@@ -15,8 +16,8 @@
 // Represents information about module on the client
 class ModuleData final {
  public:
-  explicit ModuleData(const ModuleInfo& info)
-      : module_info_(info), is_loaded_(false) {}
+  explicit ModuleData(ModuleInfo info)
+      : module_info_(std::move(info)), is_loaded_(false) {}
 
   void SetModuleInfo(const ModuleInfo& info) { module_info_ = info; }
 

--- a/OrbitGl/ProcessData.h
+++ b/OrbitGl/ProcessData.h
@@ -5,6 +5,8 @@
 #ifndef ORBIT_GL_PROCESS_DATA_H_
 #define ORBIT_GL_PROCESS_DATA_H_
 
+#include <utility>
+
 #include "ModuleData.h"
 #include "OrbitBase/Logging.h"
 #include "absl/container/flat_hash_map.h"
@@ -19,14 +21,23 @@ class ProcessData final {
   ProcessData(ProcessData&&) = default;
   ProcessData& operator=(ProcessData&&) = default;
 
-  explicit ProcessData(const ProcessInfo& process_info)
-      : process_info_(process_info) {}
+  explicit ProcessData(ProcessInfo process_info)
+      : process_info_(std::move(process_info)) {}
 
   void SetProcessInfo(const ProcessInfo& process_info) {
     process_info_ = process_info;
   }
 
-  void UpdateModuleInfos(const std::vector<ModuleInfo> module_infos) {
+  uint32_t pid() const { return process_info_.pid(); }
+  const std::string& name() const { return process_info_.name(); }
+  double cpu_usage() const { return process_info_.cpu_usage(); }
+  const std::string& full_path() const { return process_info_.full_path(); }
+  const std::string& command_line() const {
+    return process_info_.command_line();
+  }
+  bool is_64_bit() const { return process_info_.is_64_bit(); }
+
+  void UpdateModuleInfos(const std::vector<ModuleInfo>& module_infos) {
     current_module_list_.clear();
     for (const ModuleInfo& info : module_infos) {
       uint64_t module_id = info.address_start();
@@ -43,7 +54,7 @@ class ProcessData final {
     }
   }
 
-  const std::vector<ModuleData*> GetModules() const {
+  const std::vector<ModuleData*>& GetModules() const {
     return current_module_list_;
   }
 


### PR DESCRIPTION
Even if we are moving to a new data model, for now we still need
`Process::GetName` in various places, e.g. in the capture view and in the
default file name for a saved capture.