### PR TITLE
Send users to different locations on community.stadia.dev for bugs and feature requests

### DIFF
--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -246,41 +246,40 @@ void OrbitMainWindow::SetupCodeView() {
 
 //-----------------------------------------------------------------------------
 void OrbitMainWindow::ShowFeedbackDialog() {
-  QPointer<QDialog> feedback_dialog = QPointer{
-      new QDialog{this, Qt::WindowTitleHint | Qt::WindowCloseButtonHint}};
+  QDialog feedback_dialog{nullptr, Qt::WindowTitleHint | Qt::WindowCloseButtonHint};
 
-  const auto layout = QPointer{new QGridLayout{feedback_dialog}};
+  const auto layout = QPointer{new QGridLayout{&feedback_dialog}};
   const auto button_box =
       QPointer{new QDialogButtonBox{QDialogButtonBox::StandardButton::Close}};
 
   const QPointer<QPushButton> report_missing_feature_button =
-      QPointer{new QPushButton{feedback_dialog}};
+      QPointer{new QPushButton{&feedback_dialog}};
   button_box->addButton(report_missing_feature_button,
                         QDialogButtonBox::AcceptRole);
   report_missing_feature_button->setText("Report Missing Feature");
   const QPointer<QPushButton> report_bug_button =
-      QPointer{new QPushButton{feedback_dialog}};
+      QPointer{new QPushButton{&feedback_dialog}};
   button_box->addButton(report_bug_button, QDialogButtonBox::AcceptRole);
   report_bug_button->setText("Report Bug");
 
   layout->addWidget(button_box, 0, 0);
 
   QObject::connect(report_missing_feature_button, &QPushButton::clicked,
-                   feedback_dialog, [this, feedback_dialog]() {
+                   &feedback_dialog, [this, &feedback_dialog]() {
                      on_actionReport_Missing_Feature_triggered();
-                     feedback_dialog->accept();
+                     feedback_dialog.accept();
                    });
 
-  QObject::connect(report_bug_button, &QPushButton::clicked, feedback_dialog,
-                   [this, feedback_dialog]() {
+  QObject::connect(report_bug_button, &QPushButton::clicked, &feedback_dialog,
+                   [this, &feedback_dialog]() {
                      on_actionReport_Bug_triggered();
-                     feedback_dialog->accept();
+                     feedback_dialog.accept();
                    });
 
-  QObject::connect(button_box, &QDialogButtonBox::rejected, feedback_dialog,
+  QObject::connect(button_box, &QDialogButtonBox::rejected, &feedback_dialog,
                    &QDialog::reject);
 
-  feedback_dialog->exec();
+  feedback_dialog.exec();
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -56,8 +56,11 @@ class OrbitMainWindow : public QMainWindow {
   outcome::result<void> OpenCapture(const std::string& filepath);
 
  private slots:
-  void on_actionFeedback_triggered();
   void on_actionAbout_triggered();
+  
+  void on_actionReport_Missing_Feature_triggered();
+  void on_actionReport_Bug_triggered();
+
   void OnTimer();
   void OnHideSearch();
 
@@ -99,8 +102,8 @@ class OrbitMainWindow : public QMainWindow {
 
  private:
   void StartMainTimer();
-
   void SetupCodeView();
+  void ShowFeedbackDialog();
 
  private:
   QApplication* m_App;

--- a/OrbitQt/orbitmainwindow.ui
+++ b/OrbitQt/orbitmainwindow.ui
@@ -271,8 +271,14 @@
     <property name="title">
      <string>Help</string>
     </property>
-    <addaction name="actionFeedback"/>
     <addaction name="actionAbout"/>
+   </widget>
+   <widget class="QMenu" name="menuFeedback">
+    <property name="title">
+     <string>Feedback</string>
+    </property>
+    <addaction name="actionReport_Missing_Feature"/>
+    <addaction name="actionReport_Bug"/>
    </widget>
    <widget class="QMenu" name="menuDev">
     <property name="title">
@@ -310,15 +316,21 @@
    <addaction name="menuDebug"/>
    <addaction name="menuTools"/>
    <addaction name="menuHelp"/>
+   <addaction name="menuFeedback"/>
   </widget>
   <action name="actionSave_Session">
    <property name="text">
     <string>Save Session</string>
    </property>
   </action>
-  <action name="actionFeedback">
+  <action name="actionReport_Missing_Feature">
    <property name="text">
-    <string>Feedback</string>
+    <string>Report Missing Feature</string>
+   </property>
+  </action>
+  <action name="actionReport_Bug">
+   <property name="text">
+    <string>Report Bug</string>
    </property>
   </action>
   <action name="actionAbout">


### PR DESCRIPTION
There are different pages on community.stadia.dev for getting support and filing bugs and for filing feature requests. We introduce different menu entries to send users to the appropriate place. The feedback button now pops up a dialog that gives the user an option to report a missing feature or a bug. 