### PR TITLE
Add ability to schedule method calls

### DIFF
--- a/OrbitBase/include/OrbitBase/MainThreadExecutor.h
+++ b/OrbitBase/include/OrbitBase/MainThreadExecutor.h
@@ -43,6 +43,11 @@ class MainThreadExecutor {
     Schedule(CreateAction(std::forward<F>(functor)));
   }
 
+  template <typename T>
+  void Schedule(T* object, void (internal::identity<T>::type::*method)()) {
+    Schedule(CreateAction(object, method));
+  }
+
   // Called from the main thread to perform scheduled actions.
   // The method checks that it is called from the thread specified
   // in Create method and fails otherwise.

--- a/OrbitBase/include/OrbitBase/ThreadPool.h
+++ b/OrbitBase/include/OrbitBase/ThreadPool.h
@@ -38,6 +38,11 @@ class ThreadPool {
     Schedule(CreateAction(std::forward<F>(functor)));
   }
 
+  template <typename T>
+  void Schedule(T* object, void (internal::identity<T>::type::*method)()) {
+    Schedule(CreateAction(object, method));
+  }
+
   // Initiates shutdown, any Schedule after this call will fail.
   virtual void Shutdown() = 0;
 

--- a/OrbitBase/include/OrbitBase/internal/identity.h
+++ b/OrbitBase/include/OrbitBase/internal/identity.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_BASE_INTERNAL_IDENTITY_H_
+#define ORBIT_BASE_INTERNAL_IDENTITY_H_
+
+namespace internal {
+
+template <typename T>
+struct identity {
+  typedef T type;
+};
+
+};  // namespace internal
+
+#endif  // ORBIT_BASE_INTERNAL_IDENTITY_H_


### PR DESCRIPTION
This commit adds ability to schedule method calls on thread-pool
and main-thread executor.

thread_pool_->Schedule(app, &OrbitApp::CalculateWatermelonVolume);

Test: run OrbitBaseTests