### PR TITLE
Fix live tab filtering.

### DIFF
--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -49,6 +49,7 @@ ULONG64 Capture::GNumLinuxEvents;
 ULONG64 Capture::GNumProfileEvents;
 std::string Capture::GPresetToLoad;
 std::string Capture::GProcessToInject;
+std::string Capture::GFunctionFilter;
 
 std::vector<std::shared_ptr<Function>> Capture::GSelectedFunctions;
 std::map<uint64_t, Function*> Capture::GSelectedFunctionsMap;

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -68,6 +68,7 @@ class Capture {
   static std::string GInjectedProcess;
   static std::string GPresetToLoad;  // TODO: allow multiple presets
   static std::string GProcessToInject;
+  static std::string GFunctionFilter;
   static bool GIsSampling;
   static bool GIsTesting;
   static uint32_t GFunctionIndex;

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -1173,5 +1173,6 @@ void OrbitApp::InitializeClientTransactions() {
 
 //-----------------------------------------------------------------------------
 void OrbitApp::FilterFunctions(const std::string& filter) {
-  m_LiveFunctionsDataView->OnFilter(filter);
+  Capture::GFunctionFilter = filter;
+  m_LiveFunctionsDataView->SetUiFilterString(filter);
 }

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -1032,7 +1032,7 @@ void CaptureWindow::RenderToolbars() {
 
   // Set function filter text programmatically if needed.
   bool new_filter = Capture::GFunctionFilter != find_filter_;
-  if( new_filter ) {
+  if (new_filter) {
     strncpy(find_filter_, Capture::GFunctionFilter.c_str(), kFilterLength);
     ImGui::ClearActiveID();
   }
@@ -1053,7 +1053,7 @@ void CaptureWindow::RenderToolbars() {
 
   if (ImGui::InputText("##Search", find_filter_, kFilterLength)) {
     // Don't treat programmatically set InputText as user input.
-    if( !new_filter ) {
+    if (!new_filter) {
       GOrbitApp->FilterFunctions(find_filter_);
     }
   }

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -1034,7 +1034,7 @@ void CaptureWindow::RenderToolbars() {
   bool new_filter = Capture::GFunctionFilter != find_filter_;
   if (new_filter) {
     strncpy(find_filter_, Capture::GFunctionFilter.c_str(), kFilterLength);
-    find_filter_[kFilterLength-1] = 0;
+    find_filter_[kFilterLength - 1] = 0;
     ImGui::ClearActiveID();
   }
 

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -1034,6 +1034,7 @@ void CaptureWindow::RenderToolbars() {
   bool new_filter = Capture::GFunctionFilter != find_filter_;
   if (new_filter) {
     strncpy(find_filter_, Capture::GFunctionFilter.c_str(), kFilterLength);
+    find_filter_[kFilterLength-1] = 0;
     ImGui::ClearActiveID();
   }
 

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -1030,6 +1030,13 @@ void CaptureWindow::RenderToolbars() {
   current_x += ImGui::GetWindowWidth() + space_between_toolbars;
   ImGui::End();
 
+  // Set function filter text programmatically if needed.
+  bool new_filter = Capture::GFunctionFilter != find_filter_;
+  if( new_filter ) {
+    strncpy(find_filter_, Capture::GFunctionFilter.c_str(), kFilterLength);
+    ImGui::ClearActiveID();
+  }
+
   // Search Toolbar.
   ImGui::SetNextWindowPos(ImVec2(current_x, 0));
   ImGui::Begin("Search", &m_DrawHelp, ImVec2(0, 0), 1.f,
@@ -1043,9 +1050,14 @@ void CaptureWindow::RenderToolbars() {
     ImGui::SetTooltip("Search");
   ImGui::SameLine();
   ImGui::PushItemWidth(300.f);
-  ImGui::InputText("##Search", find_filter_, IM_ARRAYSIZE(find_filter_));
+
+  if (ImGui::InputText("##Search", find_filter_, kFilterLength)) {
+    // Don't treat programmatically set InputText as user input.
+    if( !new_filter ) {
+      GOrbitApp->FilterFunctions(find_filter_);
+    }
+  }
   ImGui::PopItemWidth();
-  GOrbitApp->FilterFunctions(find_filter_);
 
   current_x += ImGui::GetWindowWidth() + space_between_toolbars;
   ImGui::End();

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -100,7 +100,7 @@ class CaptureWindow : public GlCanvas {
   std::string icons_path_;
   float toolbar_height_ = 0;
 
-  static constexpr size_t kFilterLength = 64;
+  static constexpr size_t kFilterLength = 512;
   char track_filter_[kFilterLength] = "";
   char find_filter_[kFilterLength] = "";
 

--- a/OrbitGl/DataView.cpp
+++ b/OrbitGl/DataView.cpp
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
-
 #include "DataView.h"
 
 #include <fstream>
@@ -57,6 +55,13 @@ void DataView::OnSort(int column, std::optional<SortingOrder> new_order) {
 void DataView::OnFilter(const std::string& filter) {
   m_Filter = filter;
   DoFilter();
+}
+
+//-----------------------------------------------------------------------------
+void DataView::SetUiFilterString(const std::string& filter) {
+  if (filter_callback_) {
+    filter_callback_(filter);
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/DataView.h
+++ b/OrbitGl/DataView.h
@@ -7,6 +7,7 @@
 
 #include <OrbitBase/Logging.h>
 
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -48,7 +49,16 @@ class DataView {
   virtual std::string GetValue(int /*a_Row*/, int /*a_Column*/) { return ""; }
   virtual std::string GetToolTip(int /*a_Row*/, int /*a_Column*/) { return ""; }
 
+  // Called from UI layer.
   void OnFilter(const std::string& filter);
+  // Called internally to set the filter string programmatically in the UI.
+  void SetUiFilterString(const std::string& filter);
+  // Filter callback set from UI layer.
+  typedef std::function<void(const std::string&)> FilterCallback;
+  void SetUiFilterCallback(FilterCallback callback) {
+    filter_callback_ = callback;
+  }
+
   void OnSort(int column, std::optional<SortingOrder> new_order);
   virtual void OnContextMenu(const std::string& a_Action, int a_MenuIndex,
                              const std::vector<int>& a_ItemIndices);
@@ -78,6 +88,7 @@ class DataView {
   void InitSortingOrders();
   virtual void DoSort() {}
   virtual void DoFilter() {}
+  FilterCallback filter_callback_;
 
   std::vector<uint32_t> m_Indices;
   std::vector<SortingOrder> m_SortingOrders;

--- a/OrbitGl/LiveFunctionsDataView.cpp
+++ b/OrbitGl/LiveFunctionsDataView.cpp
@@ -176,6 +176,7 @@ void LiveFunctionsDataView::OnContextMenu(
 
 //-----------------------------------------------------------------------------
 void LiveFunctionsDataView::DoFilter() {
+  Capture::GFunctionFilter = m_Filter;
   std::vector<uint32_t> indices;
 
   std::vector<std::string> tokens = absl::StrSplit(ToLower(m_Filter), ' ');

--- a/OrbitQt/orbitdataviewpanel.cpp
+++ b/OrbitQt/orbitdataviewpanel.cpp
@@ -2,10 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
-
 #include "orbitdataviewpanel.h"
 
+#include <string>
 #include <utility>
 
 #include "ui_orbitdataviewpanel.h"
@@ -35,6 +34,9 @@ void OrbitDataViewPanel::Initialize(DataView* data_view,
     this->ui->label->setText(QString::fromStdString(label));
     this->ui->label->show();
   }
+
+  data_view->SetUiFilterCallback(
+      [this](const std::string& filter) { SetFilter(filter.c_str()); });
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
There was regression introduced recently that broke live tab filtering.  Basically, the ImGui "search box" in the capture view interfered with the live tab filtering.  Also, there was a bug where if we set the filter from the capture tab, the live tab would update but would not display the new filter string.  Now we mirror the filter in the capture view and in the live tab.

- Revive function filtering in "live" tab
- Add way to programmatically set the qt filter text from OrbitGl layer
- Mirror the capture-view and live-tab filter text

b/159836346