### PR TITLE
Preserve symbols in the Process

### DIFF
--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -232,8 +232,12 @@ class OrbitApp final : public CoreApp, public DataViewFactory {
   void SymbolLoadingFinished(uint32_t process_id,
                              const std::shared_ptr<Module>& module,
                              const std::shared_ptr<Session>& session);
+  std::shared_ptr<Process> FindProcessByPid(int32_t pid);
 
   ApplicationOptions options_;
+
+  absl::Mutex process_map_mutex_;
+  absl::flat_hash_map<uint32_t, std::shared_ptr<Process>> process_map_;
 
   std::vector<std::string> m_Arguments;
   std::vector<CaptureStartedCallback> capture_started_callbacks_;


### PR DESCRIPTION
Return process_map in App in order to preserve
symbols in the process when it is unselected and then
selected again

Bug: http://b/159806028
Test: Load symbols, select different process, select the process again.
      Check that symbols did not disappear