### PR TITLE
Fix loading of sessions when using the menu entry

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -645,7 +645,7 @@ outcome::result<void, std::string> OrbitApp::ReadSessionFromFile(
 
   std::ifstream file(file_path, std::ios::binary);
   if (file.fail()) {
-    ERROR("Loading session from \"%s\": %s", file_path, "file.fail()");
+    ERROR("Loading session from \"%s\": file.fail()", file_path);
     return outcome::failure("Error opening the file for reading");
   }
 

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -389,15 +389,16 @@ void OrbitApp::LoadFileMapping() {
 
 //-----------------------------------------------------------------------------
 void OrbitApp::ListSessions() {
-  std::vector<std::string> sessionFileNames =
+  std::vector<std::string> session_filenames =
       Path::ListFiles(Path::GetPresetPath(), ".opr");
   std::vector<std::shared_ptr<Session>> sessions;
-  for (std::string& filename : sessionFileNames) {
+  for (std::string& filename : session_filenames) {
     auto session = std::make_shared<Session>();
     outcome::result<void, std::string> result = 
       ReadSessionFromFile(filename, session.get());
     if (result.has_error()) {
       ERROR("Loading session failed: \"%s\"", result.error());
+      continue;
     }
     session->m_FileName = filename;
     sessions.push_back(session);
@@ -636,7 +637,7 @@ outcome::result<void, std::string> OrbitApp::OnSaveSession(
 
 //-----------------------------------------------------------------------------
 outcome::result<void, std::string> OrbitApp::ReadSessionFromFile(
-  const std::string& filename, Session* session) {
+    const std::string& filename, Session* session) {
   std::string file_path = filename;
 
   if (Path::GetDirectory(filename).empty()) {

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -393,22 +393,14 @@ void OrbitApp::ListSessions() {
       Path::ListFiles(Path::GetPresetPath(), ".opr");
   std::vector<std::shared_ptr<Session>> sessions;
   for (std::string& filename : sessionFileNames) {
-    std::ifstream file(filename, std::ios::binary);
-    if (file.fail()) {
-      ERROR("Loading session from \"%s\": %s", filename, "file.fail()");
-      continue;
+    auto session = std::make_shared<Session>();
+    outcome::result<void, std::string> result = 
+      ReadSessionFromFile(filename, session.get());
+    if (result.has_error()) {
+      ERROR("Loading session failed: \"%s\"", result.error());
     }
-
-    try {
-      auto session = std::make_shared<Session>();
-      cereal::BinaryInputArchive archive(file);
-      archive(*session);
-      file.close();
-      session->m_FileName = filename;
-      sessions.push_back(session);
-    } catch (std::exception& e) {
-      ERROR("Loading session from \"%s\": %s", filename, e.what());
-    }
+    session->m_FileName = filename;
+    sessions.push_back(session);
   }
 
   m_SessionsDataView->SetSessions(sessions);
@@ -635,40 +627,51 @@ void OrbitApp::SetClipboard(const std::string& text) {
 
 //-----------------------------------------------------------------------------
 outcome::result<void, std::string> OrbitApp::OnSaveSession(
-    const std::string& file_name) {
-  OUTCOME_TRY(Capture::SaveSession(file_name));
+    const std::string& filename) {
+  OUTCOME_TRY(Capture::SaveSession(filename));
   ListSessions();
   Refresh(DataViewType::SESSIONS);
   return outcome::success();
 }
 
 //-----------------------------------------------------------------------------
-outcome::result<void, std::string> OrbitApp::OnLoadSession(
-    const std::string& file_name) {
-  std::string file_path = file_name;
+outcome::result<void, std::string> OrbitApp::ReadSessionFromFile(
+  const std::string& filename, Session* session) {
+  std::string file_path = filename;
 
-  if (Path::GetDirectory(file_name).empty()) {
-    file_path = Path::JoinPath({Path::GetPresetPath(), file_name});
+  if (Path::GetDirectory(filename).empty()) {
+    file_path = Path::JoinPath({Path::GetPresetPath(), filename});
   }
 
-  std::ifstream file(file_path);
+  std::ifstream file(file_path, std::ios::binary);
   if (file.fail()) {
     ERROR("Loading session from \"%s\": %s", file_path, "file.fail()");
     return outcome::failure("Error opening the file for reading");
   }
 
   try {
-    auto session = std::make_shared<Session>();
     cereal::BinaryInputArchive archive(file);
     archive(*session);
     file.close();
-    session->m_FileName = file_path;
-    LoadSession(session);
     return outcome::success();
   } catch (std::exception& e) {
     ERROR("Loading session from \"%s\": %s", file_path, e.what());
-    return outcome::failure("Error parsing the session");
+    return outcome::failure("Error reading the session");
   }
+}
+
+//-----------------------------------------------------------------------------
+outcome::result<void, std::string> OrbitApp::OnLoadSession(
+    const std::string& filename) {
+  auto session = std::make_shared<Session>();
+  outcome::result<void, std::string> result = 
+    ReadSessionFromFile(filename, session.get());
+  if (result.has_error()) {
+    return result;
+  }
+  session->m_FileName = filename;
+  LoadSession(session);
+  return outcome::success();
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -665,7 +665,7 @@ outcome::result<void, std::string> OrbitApp::ReadSessionFromFile(
 outcome::result<void, std::string> OrbitApp::OnLoadSession(
     const std::string& filename) {
   auto session = std::make_shared<Session>();
-OUTCOME_TRY(ReadSessionFromFile(filename, session.get()));
+  OUTCOME_TRY(ReadSessionFromFile(filename, session.get()));
   session->m_FileName = filename;
   LoadSession(session);
   return outcome::success();

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -664,11 +664,7 @@ outcome::result<void, std::string> OrbitApp::ReadSessionFromFile(
 outcome::result<void, std::string> OrbitApp::OnLoadSession(
     const std::string& filename) {
   auto session = std::make_shared<Session>();
-  outcome::result<void, std::string> result = 
-    ReadSessionFromFile(filename, session.get());
-  if (result.has_error()) {
-    return result;
-  }
+OUTCOME_TRY(ReadSessionFromFile(filename, session.get()));
   session->m_FileName = filename;
   LoadSession(session);
   return outcome::success();

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -233,6 +233,9 @@ class OrbitApp final : public CoreApp, public DataViewFactory {
                              const std::shared_ptr<Module>& module,
                              const std::shared_ptr<Session>& session);
 
+  outcome::result<void, std::string> ReadSessionFromFile(
+    const std::string& filename, Session* session);
+
   ApplicationOptions options_;
 
   std::vector<std::string> m_Arguments;


### PR DESCRIPTION
The issue was that when loading from the menu entry, the file was not opened with the binary flag. The code is now unified to use the same path for loading from a file. 