### PR TITLE
[Release] Fixed symbol loading of separate files on remote

### DIFF
--- a/OrbitCore/SymbolHelper.h
+++ b/OrbitCore/SymbolHelper.h
@@ -4,6 +4,7 @@
 
 #ifndef SYMBOL_HELPER_H_
 #define SYMBOL_HELPER_H_
+#include <outcome.hpp>
 #include <string>
 #include <vector>
 
@@ -20,7 +21,8 @@ class SymbolHelper {
         symbols_file_directories_(std::move(symbols_file_directories)){};
 
   bool LoadSymbolsIncludedInBinary(std::shared_ptr<Module> module) const;
-  bool LoadSymbolsCollector(std::shared_ptr<Module> module) const;
+  outcome::result<ModuleSymbols, std::string> LoadSymbolsCollector(
+      const std::string& module_path) const;
   bool LoadSymbolsUsingSymbolsFile(std::shared_ptr<Module> module) const;
   void LoadSymbolsIntoModule(const std::shared_ptr<Module>& module,
                              const ModuleSymbols& module_symbols) const;

--- a/OrbitCore/SymbolHelperTest.cpp
+++ b/OrbitCore/SymbolHelperTest.cpp
@@ -39,42 +39,25 @@ TEST(SymbolHelper, LoadSymbolsCollectorSameFile) {
   const std::string executable_name = "hello_world_elf";
   const std::string file_path = executable_directory + executable_name;
 
-  std::shared_ptr<Module> module = std::make_shared<Module>(file_path, 0, 0);
-
   SymbolHelper symbol_helper({executable_directory}, {});
-  ASSERT_TRUE(symbol_helper.LoadSymbolsCollector(module));
-
-  EXPECT_NE(module->m_Pdb, nullptr);
-  EXPECT_EQ(module->m_PdbName, file_path);
-  EXPECT_TRUE(module->IsLoaded());
-
-  Pdb& pdb = *module->m_Pdb;
-  EXPECT_EQ(pdb.GetLoadedModuleName(), file_path);
-  EXPECT_EQ(pdb.GetFileName(), file_path);
-  EXPECT_EQ(pdb.GetName(), executable_name);
+  const auto symbols_result = symbol_helper.LoadSymbolsCollector(file_path);
+  ASSERT_TRUE(symbols_result);
+  ModuleSymbols symbols = std::move(symbols_result.value());
+  EXPECT_EQ(symbols.symbols_file_path(), file_path);
 }
 
 TEST(SymbolHelper, LoadSymbolsCollectorSeparateFile) {
   const std::string executable_name = "no_symbols_elf";
   const std::string file_path = executable_directory + executable_name;
 
-  std::shared_ptr<Module> module = std::make_shared<Module>(file_path, 0, 0);
-  module->m_DebugSignature = "b5413574bbacec6eacb3b89b1012d0e2cd92ec6b";
-
   std::string symbols_file_name = "no_symbols_elf.debug";
   std::string symbols_path = executable_directory + symbols_file_name;
 
   SymbolHelper symbol_helper({executable_directory}, {});
-  ASSERT_TRUE(symbol_helper.LoadSymbolsCollector(module));
-
-  EXPECT_NE(module->m_Pdb, nullptr);
-  EXPECT_EQ(module->m_PdbName, symbols_path);
-  EXPECT_TRUE(module->IsLoaded());
-
-  Pdb& pdb = *module->m_Pdb;
-  EXPECT_EQ(pdb.GetLoadedModuleName(), file_path);
-  EXPECT_EQ(pdb.GetFileName(), symbols_path);
-  EXPECT_EQ(pdb.GetName(), symbols_file_name);
+  const auto symbols_result = symbol_helper.LoadSymbolsCollector(file_path);
+  ASSERT_TRUE(symbols_result);
+  ModuleSymbols symbols = std::move(symbols_result.value());
+  EXPECT_EQ(symbols.symbols_file_path(), symbols_path);
 }
 
 TEST(SymbolHelper, LoadSymbolsUsingSymbolsFile) {


### PR DESCRIPTION
This fixes the bug that symbol loading from a separate debug file on the remote did not work anymore. This was because of a missing build_id, which is now properly loaded. 

This also removes OrbitModule as a dependency of ProcessService. 

A full refactor of SymbolHelper to not use OrbitModule anymore will be done in the future, but does not need to be on the release branch. 