### PR TITLE
Validate enum values during deserialization

### DIFF
--- a/OrbitCore/ContextSwitch.cpp
+++ b/OrbitCore/ContextSwitch.cpp
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
-
 #include "ContextSwitch.h"
 
 #include "Serialization.h"
@@ -31,4 +29,8 @@ ORBIT_SERIALIZE(ContextSwitch, 0) {
   ORBIT_NVP_VAL(0, m_Time);
   ORBIT_NVP_VAL(0, m_ProcessorIndex);
   ORBIT_NVP_VAL(0, m_ProcessorNumber);
+
+  if constexpr (OrbitCore::is_input_archive_v<Archive>) {
+    CHECK(m_Type >= SwitchType::In && m_Type <= SwitchType::Invalid);
+  }
 }

--- a/OrbitCore/Serialization.h
+++ b/OrbitCore/Serialization.h
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
 #pragma once
 
 #include "PrintVar.h"
@@ -87,17 +86,6 @@ struct ScopeCounter {
 
 //-----------------------------------------------------------------------------
 template <typename T>
-inline std::string SerializeObjectHumanReadable(T& a_Object) {
-  std::stringstream ss;
-  {
-    cereal::JSONOutputArchive archive(ss);
-    archive(a_Object);
-  }
-  return ss.str();
-}
-
-//-----------------------------------------------------------------------------
-template <typename T>
 inline std::string SerializeObjectBinary(T& a_Object) {
   std::stringstream ss;
   {
@@ -151,15 +139,7 @@ inline void DeserializeObjectBinary(const std::string& data, T& object) {
   template void x::serialize<cereal::BinaryOutputArchive>(                     \
       cereal::BinaryOutputArchive & a_Archive, std::uint32_t const a_Version); \
   template void x::serialize<cereal::BinaryInputArchive>(                      \
-      cereal::BinaryInputArchive & a_Archive, std::uint32_t const a_Version);  \
-  template void x::serialize<cereal::XMLOutputArchive>(                        \
-      cereal::XMLOutputArchive & a_Archive, std::uint32_t const a_Version);    \
-  template void x::serialize<cereal::XMLInputArchive>(                         \
-      cereal::XMLInputArchive & a_Archive, std::uint32_t const a_Version);     \
-  template void x::serialize<cereal::JSONOutputArchive>(                       \
-      cereal::JSONOutputArchive & a_Archive, std::uint32_t const a_Version);   \
-  template void x::serialize<cereal::JSONInputArchive>(                        \
-      cereal::JSONInputArchive & a_Archive, std::uint32_t const a_Version);
+      cereal::BinaryInputArchive & a_Archive, std::uint32_t const a_Version);
 
 #define ORBIT_SERIALIZE_WSTRING(x, v)           \
   CEREAL_CLASS_VERSION(x, v);                   \

--- a/OrbitCore/Serialization.h
+++ b/OrbitCore/Serialization.h
@@ -152,3 +152,14 @@ inline void DeserializeObjectBinary(const std::string& data, T& object) {
   ORBIT_SERIALIZATION_TEMPLATE_INST(x); \
   template <class Archive>              \
   void x::serialize(Archive& a_Archive, std::uint32_t const a_Version)
+
+namespace OrbitCore {
+template <typename Archive>
+struct is_input_archive
+    : std::integral_constant<
+          bool,
+          std::is_base_of_v<cereal::detail::InputArchiveBase,
+                            cereal::traits::detail::decay_archive<Archive>>> {};
+template <typename Archive>
+inline constexpr bool is_input_archive_v = is_input_archive<Archive>::value;
+}  // namespace OrbitCore


### PR DESCRIPTION
Fuzz-testing uncovered some problems with invalid enum values we don't check for.
#718 fixed some problems with the MessageType-enum.

For this PR I tried to look at all the invariants in all the deserialized classes and add a check for it.
Unfortunately this can't be fuzzed so easily because we mostly interpret the deserialized objects
in parts of the codebase which are very much tied to the UI.

So I went through the codebase and added checks for the obvious invariants. Unfortunately there was only
one. More might come later.

