### PR TITLE
Add thread_ttl parameter for thread pool

### DIFF
--- a/OrbitBase/ThreadPool.cpp
+++ b/OrbitBase/ThreadPool.cpp
@@ -17,6 +17,7 @@ class ThreadPoolImpl : public ThreadPool {
   explicit ThreadPoolImpl(size_t thread_pool_min_size,
                           size_t thread_pool_max_size);
 
+  size_t GetPoolSize() override;
   void Schedule(std::unique_ptr<Action> action) override;
   void Shutdown() override;
   void Wait() override;
@@ -67,6 +68,11 @@ void ThreadPoolImpl::Schedule(std::unique_ptr<Action> action) {
       worker_threads_.size() < thread_pool_max_size_) {
     CreateWorker();
   }
+}
+
+size_t ThreadPoolImpl::GetPoolSize() {
+  absl::MutexLock lock(&mutex_);
+  return worker_threads_.size();
 }
 
 void ThreadPoolImpl::Shutdown() {

--- a/OrbitBase/ThreadPoolTest.cpp
+++ b/OrbitBase/ThreadPoolTest.cpp
@@ -93,7 +93,7 @@ TEST(ThreadPool, ExtendThreadPool) {
   };
 
   {
-    // Schedule 2 actions and check we have one worker thread
+    // Schedule an action and check we have one worker thread
     absl::MutexLock lock(&actions_executed_mutex);
     thread_pool->Schedule(action);
 
@@ -105,6 +105,8 @@ TEST(ThreadPool, ExtendThreadPool) {
         << "actions_started=" << actions_started << ", expected 1";
     actions_started_mutex.Unlock();
 
+    EXPECT_EQ(thread_pool->GetPoolSize(), 1);
+
     // Schedule another action and check that there are 2 workers threads now.
     thread_pool->Schedule(action);
 
@@ -115,6 +117,8 @@ TEST(ThreadPool, ExtendThreadPool) {
         absl::Milliseconds(100)));
     actions_started_mutex.Unlock();
 
+    EXPECT_EQ(thread_pool->GetPoolSize(), 2);
+
     // Add more and make sure worker thread number remains kThreadPoolMaxSize
     for (size_t i = 0; i < 5; ++i) {
       thread_pool->Schedule(action);
@@ -122,6 +126,8 @@ TEST(ThreadPool, ExtendThreadPool) {
 
     // I do not think there is a way around it - sleep for 100ms
     absl::SleepFor(absl::Milliseconds(100));
+
+    EXPECT_EQ(thread_pool->GetPoolSize(), kThreadPoolMaxSize);
 
     actions_started_mutex.Lock();
     EXPECT_EQ(actions_started, kThreadPoolMaxSize);

--- a/OrbitBase/ThreadPoolTest.cpp
+++ b/OrbitBase/ThreadPoolTest.cpp
@@ -15,8 +15,9 @@
 TEST(ThreadPool, Smoke) {
   constexpr size_t kThreadPoolMinSize = 1;
   constexpr size_t kThreadPoolMaxSize = 2;
+  constexpr absl::Duration kThreadTtl = absl::Milliseconds(5);
   std::unique_ptr<ThreadPool> thread_pool =
-      ThreadPool::Create(kThreadPoolMinSize, kThreadPoolMaxSize);
+      ThreadPool::Create(kThreadPoolMinSize, kThreadPoolMaxSize, kThreadTtl);
 
   absl::Mutex mutex;
   bool called = false;
@@ -47,8 +48,9 @@ TEST(ThreadPool, Smoke) {
 TEST(ThreadPool, QueuedActionsExecutedOnShutdown) {
   constexpr size_t kThreadPoolMinSize = 1;
   constexpr size_t kThreadPoolMaxSize = 2;
+  constexpr absl::Duration kThreadTtl = absl::Milliseconds(5);
   std::unique_ptr<ThreadPool> thread_pool =
-      ThreadPool::Create(kThreadPoolMinSize, kThreadPoolMaxSize);
+      ThreadPool::Create(kThreadPoolMinSize, kThreadPoolMaxSize, kThreadTtl);
 
   absl::Mutex mutex;
   size_t counter = 0;
@@ -72,11 +74,69 @@ TEST(ThreadPool, QueuedActionsExecutedOnShutdown) {
   EXPECT_EQ(counter, kNumberOfActions);
 }
 
+TEST(ThreadPool, CheckTtl) {
+  constexpr size_t kThreadPoolMinSize = 1;
+  constexpr size_t kThreadPoolMaxSize = 5;
+  constexpr size_t kThreadTtlMillis = 5;
+  std::unique_ptr<ThreadPool> thread_pool =
+      ThreadPool::Create(kThreadPoolMinSize, kThreadPoolMaxSize,
+                         absl::Milliseconds(kThreadTtlMillis));
+
+  absl::Mutex actions_started_mutex;
+  size_t actions_started = 0;
+  absl::Mutex actions_executed_mutex;
+  size_t actions_executed = 0;
+
+  auto action = [&] {
+    actions_started_mutex.Lock();
+    actions_started++;
+    actions_started_mutex.Unlock();
+
+    absl::MutexLock lock(&actions_executed_mutex);
+    actions_executed++;
+  };
+
+  constexpr size_t kNumberOfActions = 7;
+  {
+    absl::MutexLock lock(&actions_executed_mutex);
+    for (size_t i = 0; i < kNumberOfActions; ++i) {
+      thread_pool->Schedule(action);
+    }
+    // Wait until actions are on worker threads
+    actions_started_mutex.Lock();
+    EXPECT_TRUE(actions_started_mutex.AwaitWithTimeout(
+        absl::Condition(
+            +[](size_t* started) { return *started == 5; }, &actions_started),
+        absl::Milliseconds(50)));
+    actions_started_mutex.Unlock();
+
+    // Now check the thread_pool size
+    EXPECT_EQ(thread_pool->GetPoolSize(), kThreadPoolMaxSize);
+
+    // Wait until all actions completed.
+    EXPECT_TRUE(actions_executed_mutex.AwaitWithTimeout(
+        absl::Condition(
+            +[](size_t* executed) { return *executed == 7; },
+            &actions_executed),
+        absl::Milliseconds(50)));
+  }
+
+  // +1 because there might be some nanoseconds between action is complete and
+  // thread went idle
+  absl::SleepFor(absl::Milliseconds(kThreadTtlMillis + 1));
+
+  EXPECT_EQ(thread_pool->GetPoolSize(), kThreadPoolMinSize);
+
+  thread_pool->ShutdownAndWait();
+}
+
 TEST(ThreadPool, ExtendThreadPool) {
   constexpr size_t kThreadPoolMinSize = 1;
-  constexpr size_t kThreadPoolMaxSize = 2;
+  constexpr size_t kThreadPoolMaxSize = 5;
+  constexpr size_t kThreadTtlMillis = 5;
   std::unique_ptr<ThreadPool> thread_pool =
-      ThreadPool::Create(kThreadPoolMinSize, kThreadPoolMaxSize);
+      ThreadPool::Create(kThreadPoolMinSize, kThreadPoolMaxSize,
+                         absl::Milliseconds(kThreadTtlMillis));
 
   absl::Mutex actions_started_mutex;
   size_t actions_started = 0;
@@ -120,30 +180,116 @@ TEST(ThreadPool, ExtendThreadPool) {
     EXPECT_EQ(thread_pool->GetPoolSize(), 2);
 
     // Add more and make sure worker thread number remains kThreadPoolMaxSize
-    for (size_t i = 0; i < 5; ++i) {
+    for (size_t i = 0; i < 10; ++i) {
       thread_pool->Schedule(action);
     }
 
-    // I do not think there is a way around it - sleep for 100ms
-    absl::SleepFor(absl::Milliseconds(100));
+    // I do not think there is a way around it - sleep for 50ms
+    absl::SleepFor(absl::Milliseconds(50));
 
     EXPECT_EQ(thread_pool->GetPoolSize(), kThreadPoolMaxSize);
 
     actions_started_mutex.Lock();
     EXPECT_EQ(actions_started, kThreadPoolMaxSize);
     actions_started_mutex.Unlock();
+
+    EXPECT_TRUE(actions_executed_mutex.AwaitWithTimeout(
+        absl::Condition(
+            +[](size_t* executed) { return *executed == 12; },
+            &actions_executed),
+        absl::Milliseconds(100)))
+        << "actions_executed=" << actions_executed << ", expected 12";
+  }
+
+  // Wait for ttl+1 and check that ThreadPool has reduced
+  // number of worker threads
+  absl::SleepFor(absl::Milliseconds(kThreadTtlMillis + 1));
+  EXPECT_EQ(thread_pool->GetPoolSize(), kThreadPoolMinSize);
+
+  EXPECT_EQ(actions_started, 12);
+  EXPECT_EQ(actions_executed, 12);
+
+  // Now make sure thread_pool increases number of threads
+  // correctly after reducing number of worker threads.
+  {
+    absl::MutexLock lock(&actions_executed_mutex);
+    thread_pool->Schedule(action);
+
+    actions_started_mutex.Lock();
+    EXPECT_TRUE(actions_started_mutex.AwaitWithTimeout(
+        absl::Condition(
+            +[](size_t* started) { return *started == 13; }, &actions_started),
+        absl::Milliseconds(100)));
+    actions_started_mutex.Unlock();
+
+    EXPECT_EQ(thread_pool->GetPoolSize(), 1);
+
+    thread_pool->Schedule(action);
+
+    actions_started_mutex.Lock();
+    EXPECT_TRUE(actions_started_mutex.AwaitWithTimeout(
+        absl::Condition(
+            +[](size_t* started) { return *started == 14; }, &actions_started),
+        absl::Milliseconds(100)));
+    actions_started_mutex.Unlock();
+
+    EXPECT_EQ(thread_pool->GetPoolSize(), 2);
+
+    // Add more and make sure worker thread number remains kThreadPoolMaxSize
+    for (size_t i = 0; i < 10; ++i) {
+      thread_pool->Schedule(action);
+    }
+
+    // I do not think there is a way around it - sleep for 50ms
+    absl::SleepFor(absl::Milliseconds(50));
+
+    EXPECT_EQ(thread_pool->GetPoolSize(), kThreadPoolMaxSize);
+    actions_started_mutex.Lock();
+    EXPECT_EQ(actions_started, 12 + kThreadPoolMaxSize);
+    actions_started_mutex.Unlock();
   }
 
   thread_pool->ShutdownAndWait();
 
-  EXPECT_EQ(actions_started, 7);
-  EXPECT_EQ(actions_executed, 7);
+  EXPECT_EQ(actions_started, 24);
+  EXPECT_EQ(actions_executed, 24);
 }
 
 TEST(ThreadPool, InvalidArguments) {
-  EXPECT_DEATH(ThreadPool::Create(0, 1), "");
-  EXPECT_DEATH(ThreadPool::Create(2, 1), "");
-  EXPECT_DEATH(ThreadPool::Create(0, 0), "");
+  EXPECT_DEATH(
+      {
+        auto thread_pool = ThreadPool::Create(0, 1, absl::Milliseconds(1));
+        thread_pool->ShutdownAndWait();
+      },
+      "");
+  EXPECT_DEATH(
+      {
+        auto thread_pool = ThreadPool::Create(2, 1, absl::Milliseconds(1));
+        thread_pool->ShutdownAndWait();
+      },
+      "");
+  EXPECT_DEATH(
+      {
+        auto thread_pool = ThreadPool::Create(0, 0, absl::Milliseconds(1));
+        thread_pool->ShutdownAndWait();
+      },
+      "");
+  EXPECT_DEATH(
+      {
+        auto thread_pool = ThreadPool::Create(1, 2, absl::Milliseconds(0));
+        thread_pool->ShutdownAndWait();
+      },
+      "");
+  EXPECT_DEATH(
+      {
+        auto thread_pool = ThreadPool::Create(1, 2, absl::Nanoseconds(999));
+        thread_pool->ShutdownAndWait();
+      },
+      "");
+}
+
+TEST(ThreadPool, NoShutdown) {
+  EXPECT_DEATH(ThreadPool::Create(1, 4, absl::Milliseconds(10)), "");
 }
 
 TEST(ThreadPool, ScheduleAfterShutdown) {
@@ -151,8 +297,9 @@ TEST(ThreadPool, ScheduleAfterShutdown) {
       {
         constexpr size_t kThreadPoolMinSize = 1;
         constexpr size_t kThreadPoolMaxSize = 2;
-        std::unique_ptr<ThreadPool> thread_pool =
-            ThreadPool::Create(kThreadPoolMinSize, kThreadPoolMaxSize);
+        constexpr absl::Duration kThreadTtl = absl::Milliseconds(5);
+        std::unique_ptr<ThreadPool> thread_pool = ThreadPool::Create(
+            kThreadPoolMinSize, kThreadPoolMaxSize, kThreadTtl);
 
         thread_pool->Shutdown();
         thread_pool->Schedule([] {});
@@ -165,8 +312,9 @@ TEST(ThreadPool, WaitWithoutShutdown) {
       {
         constexpr size_t kThreadPoolMinSize = 1;
         constexpr size_t kThreadPoolMaxSize = 2;
-        std::unique_ptr<ThreadPool> thread_pool =
-            ThreadPool::Create(kThreadPoolMinSize, kThreadPoolMaxSize);
+        constexpr absl::Duration kThreadTtl = absl::Milliseconds(5);
+        std::unique_ptr<ThreadPool> thread_pool = ThreadPool::Create(
+            kThreadPoolMinSize, kThreadPoolMaxSize, kThreadTtl);
 
         thread_pool->Wait();
       },

--- a/OrbitBase/include/OrbitBase/ThreadPool.h
+++ b/OrbitBase/include/OrbitBase/ThreadPool.h
@@ -51,6 +51,8 @@ class ThreadPool {
     Wait();
   }
 
+  virtual size_t GetPoolSize() = 0;
+
   // Create ThreadPool with specified minimum and maximum number of worker
   // threads.
   //

--- a/OrbitBase/include/OrbitBase/ThreadPool.h
+++ b/OrbitBase/include/OrbitBase/ThreadPool.h
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "OrbitBase/Action.h"
+#include "absl/time/time.h"
 
 // This class implements a thread pool. ThreadPool allows to execute
 // actions in another thread without the need to manage creation and destruction
@@ -62,10 +63,13 @@ class ThreadPool {
   // the thread pool creates a new worker thread if current number of worker
   // threads is less than maximum pool size.
   //
-  // TODO: If queue is empty thread_pool reduces number of worker threads
-  // until they hit thread_pool_min_size
+  // If queue is empty thread_pool reduces number of worker threads
+  // until they hit thread_pool_min_size. thread_ttl specifies the duration
+  // for the such a thread to remain in idle state before it finishes the
+  // execution.
   static std::unique_ptr<ThreadPool> Create(size_t thread_pool_min_size,
-                                            size_t thread_pool_max_size);
+                                            size_t thread_pool_max_size,
+                                            absl::Duration thread_ttl);
 };
 
 #endif  // ORBIT_BASE_THREAD_POOL_H_

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -76,7 +76,8 @@ bool DoZoom = false;
 OrbitApp::OrbitApp(ApplicationOptions&& options)
     : options_(std::move(options)) {
   main_thread_executor_ = MainThreadExecutor::Create();
-  thread_pool_ = ThreadPool::Create(4 /*min_size*/, 256 /*max_size*/);
+  thread_pool_ =
+      ThreadPool::Create(4 /*min_size*/, 256 /*max_size*/, absl::Seconds(1));
   data_manager_ = std::make_unique<DataManager>(std::this_thread::get_id());
 #ifdef _WIN32
   m_Debugger = std::make_unique<Debugger>();


### PR DESCRIPTION
With this the thread pool will reduced number of worker threads if they remain idle for specified duration (thread_ttl), the default value is 50ms.