### PR TITLE
Add support for fuzz-testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ build*/
 /cmake-build*/
 .clangd/
 compile_commands.json
+corpora/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ include(cmake/tests.cmake)
 enable_testing()
 
 option(WITH_GUI "Setting this option will enable the Qt-based UI client." ON)
+option(WITH_FUZZING "Setting this option will enable the fuzzing mode." OFF)
 
 set(CRASHDUMP_SERVER "" CACHE STRING "Setting this option will enable uploading crash dumps to the url specified.")
 
@@ -74,7 +75,7 @@ list(PREPEND CMAKE_PREFIX_PATH "${CONAN_PROTOBUF_ROOT}")
 list(PREPEND CMAKE_FIND_ROOT_PATH "${CONAN_GRPC_ROOT}")
 list(PREPEND CMAKE_FIND_ROOT_PATH "${CONAN_PROTOBUF_ROOT}")
 
-if(NOT WIN32 AND WITH_GUI)
+if(NOT WIN32 AND (WITH_GUI OR WITH_FUZZING))
   find_package(X11 REQUIRED)
 endif()
 
@@ -89,7 +90,7 @@ find_package(Protobuf CONFIG REQUIRED)
 find_package(gRPC CONFIG REQUIRED)
 
 
-if(WITH_GUI)
+if(WITH_GUI OR WITH_FUZZING)
   find_package(freetype CONFIG REQUIRED)
   find_package(freetype-gl CONFIG REQUIRED)
   find_package(OpenGL REQUIRED)
@@ -101,8 +102,10 @@ endif()
 find_package(oqpi REQUIRED)
 find_package(stb REQUIRED)
 find_package(capstone CONFIG REQUIRED)
-if(WITH_GUI)
+if(WITH_GUI OR WITH_FUZZING)
   find_package(freeglut CONFIG REQUIRED)
+endif()
+if(WITH_GUI)
   find_package(Qt5 CONFIG REQUIRED COMPONENTS Core Network Widgets)
   find_package(qtpropertybrowser REQUIRED)
   find_package(crashpad CONFIG REQUIRED)
@@ -144,8 +147,18 @@ if(WITH_GUI)
   add_subdirectory(OrbitGgp)
   add_subdirectory(OrbitSsh)
   add_subdirectory(OrbitSshQt)
+endif()
+
+if(WITH_GUI OR WITH_FUZZING)
   add_subdirectory(OrbitGl)
+endif()
+
+if (WITH_GUI)
   add_subdirectory(OrbitQt)
+endif()
+
+if (WITH_FUZZING)
+  add_subdirectory(OrbitFuzzing)
 endif()
 
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,10 @@ endif()
 add_definitions(-DNOMINMAX)
 add_definitions(-DUNICODE -D_UNICODE)
 
+if(WITH_FUZZING)
+  add_definitions(-DORBIT_FUZZING=1)
+endif()
+
 if(WIN32)
   add_definitions(-DWIN32)
 else()

--- a/OrbitCore/ElfFile.cpp
+++ b/OrbitCore/ElfFile.cpp
@@ -220,10 +220,33 @@ bool ElfFileImpl<llvm::object::ELF32LE>::Is64Bit() const {
 
 }  // namespace
 
-std::unique_ptr<ElfFile> ElfFile::Create(const std::string& file_path) {
+std::unique_ptr<ElfFile> ElfFile::CreateFromBuffer(std::string_view file_path,
+                                                   const void* buf,
+                                                   size_t len) {
+  std::unique_ptr<llvm::MemoryBuffer> buffer = llvm::MemoryBuffer::getMemBuffer(
+      llvm::StringRef(static_cast<const char*>(buf), len),
+      llvm::StringRef("buffer name"), false);
+  llvm::Expected<std::unique_ptr<llvm::object::ObjectFile>>
+      object_file_or_error =
+          llvm::object::ObjectFile::createObjectFile(buffer->getMemBufferRef());
+
+  if (!object_file_or_error) {
+    return nullptr;
+  }
+
+  return ElfFile::Create(
+      file_path, llvm::object::OwningBinary<llvm::object::ObjectFile>(
+                     std::move(object_file_or_error.get()), std::move(buffer)));
+}
+
+std::unique_ptr<ElfFile> ElfFile::Create(std::string_view file_path) {
+  // TODO(hebecker): Remove this explicit construction of StringRef when we
+  // switch to LLVM10.
+  const llvm::StringRef file_path_llvm{file_path.data(), file_path.size()};
+
   llvm::Expected<llvm::object::OwningBinary<llvm::object::ObjectFile>>
       object_file_or_error =
-          llvm::object::ObjectFile::createObjectFile(file_path);
+          llvm::object::ObjectFile::createObjectFile(file_path_llvm);
 
   if (!object_file_or_error) {
     return nullptr;
@@ -232,6 +255,12 @@ std::unique_ptr<ElfFile> ElfFile::Create(const std::string& file_path) {
   llvm::object::OwningBinary<llvm::object::ObjectFile>& file =
       object_file_or_error.get();
 
+  return ElfFile::Create(file_path, std::move(file));
+}
+
+std::unique_ptr<ElfFile> ElfFile::Create(
+    std::string_view file_path,
+    llvm::object::OwningBinary<llvm::object::ObjectFile>&& file) {
   llvm::object::ObjectFile* object_file = file.getBinary();
 
   std::unique_ptr<ElfFile> result;

--- a/OrbitCore/ElfFile.h
+++ b/OrbitCore/ElfFile.h
@@ -40,5 +40,10 @@ class ElfFile {
   virtual std::string GetBuildId() const = 0;
   virtual std::string GetFilePath() const = 0;
 
-  static std::unique_ptr<ElfFile> Create(const std::string& file_path);
+  static std::unique_ptr<ElfFile> Create(std::string_view file_path);
+  static std::unique_ptr<ElfFile> Create(
+      std::string_view file_path,
+      llvm::object::OwningBinary<llvm::object::ObjectFile>&& file);
+  static std::unique_ptr<ElfFile> CreateFromBuffer(std::string_view file_path,
+                                                   const void* buf, size_t len);
 };

--- a/OrbitCore/ElfFileTest.cpp
+++ b/OrbitCore/ElfFileTest.cpp
@@ -122,3 +122,19 @@ TEST(ElfFile, GetFilePath) {
 
   EXPECT_EQ(hello_world->GetFilePath(), hello_world_path);
 }
+
+TEST(ElfFile, CreateFromBuffer) {
+  std::string executable_path = Path::GetExecutablePath();
+  std::string test_elf_file = executable_path + "/testdata/hello_world_elf";
+
+  std::ifstream test_elf_stream{test_elf_file, std::ios::binary};
+  const std::string buffer{std::istreambuf_iterator<char>{test_elf_stream},
+                           std::istreambuf_iterator<char>{}};
+  ASSERT_NE(buffer.size(), 0);
+
+  auto elf_file =
+      ElfFile::CreateFromBuffer(test_elf_file, buffer.data(), buffer.size());
+  ASSERT_NE(elf_file, nullptr);
+  EXPECT_EQ(elf_file->GetBuildId(),
+            "d12d54bc5b72ccce54a408bdeda65e2530740ac8");
+}

--- a/OrbitCore/Serialization.h
+++ b/OrbitCore/Serialization.h
@@ -163,3 +163,19 @@ struct is_input_archive
 template <typename Archive>
 inline constexpr bool is_input_archive_v = is_input_archive<Archive>::value;
 }  // namespace OrbitCore
+
+#ifdef ORBIT_FUZZING
+namespace cereal {
+// This overload takes precedence over the one provided by cereal, so it allows
+// us to change the behaviour. Of course, that's a (temporary) hack and will be
+// removed as soon as we remove cereal from the codebase. It only applies to the
+// fuzz testing build.
+template <class T>
+void CEREAL_SERIALIZE_FUNCTION_NAME(BinaryInputArchive& ar, SizeTag<T>& t) {
+  ar(t.size);
+  if (t.size > 100 * 1024 * 1024) {  // 100 MiB
+    throw Exception("size limit reached!");
+  }
+}
+}  // namespace cereal
+#endif

--- a/OrbitFuzzing/CMakeLists.txt
+++ b/OrbitFuzzing/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+project(OrbitFuzzing)
+
+add_executable(OrbitFuzzerElf elfFuzzer.cpp)
+target_compile_options(OrbitFuzzerElf PRIVATE ${STRICT_COMPILE_FLAGS})
+target_link_libraries(OrbitFuzzerElf PRIVATE OrbitCore)
+target_compile_options(OrbitFuzzerElf PUBLIC "-fsanitize=fuzzer")
+set_target_properties(OrbitFuzzerElf PROPERTIES LINK_OPTIONS "-fsanitize=fuzzer")
+
+add_executable(OrbitFuzzerLoadCapture loadCaptureFuzzer.cpp)
+target_compile_options(OrbitFuzzerLoadCapture PRIVATE ${STRICT_COMPILE_FLAGS})
+target_link_libraries(OrbitFuzzerLoadCapture PRIVATE OrbitGl)
+target_compile_options(OrbitFuzzerLoadCapture PUBLIC "-fsanitize=fuzzer")
+set_target_properties(OrbitFuzzerLoadCapture PROPERTIES LINK_OPTIONS "-fsanitize=fuzzer")
+
+add_executable(OrbitFuzzerTcpServer TcpServerFuzzer.cpp)
+target_compile_options(OrbitFuzzerTcpServer PRIVATE ${STRICT_COMPILE_FLAGS})
+target_link_libraries(OrbitFuzzerTcpServer PRIVATE OrbitServiceLib)
+target_compile_options(OrbitFuzzerTcpServer PUBLIC "-fsanitize=fuzzer")
+set_target_properties(OrbitFuzzerTcpServer PROPERTIES LINK_OPTIONS "-fsanitize=fuzzer")
+
+add_executable(OrbitFuzzerTcpClient TcpClientFuzzer.cpp)
+target_compile_options(OrbitFuzzerTcpClient PRIVATE ${STRICT_COMPILE_FLAGS})
+target_link_libraries(OrbitFuzzerTcpClient PRIVATE OrbitGl)
+target_compile_options(OrbitFuzzerTcpClient PUBLIC "-fsanitize=fuzzer")
+set_target_properties(OrbitFuzzerTcpClient PROPERTIES LINK_OPTIONS "-fsanitize=fuzzer")

--- a/OrbitFuzzing/TcpClientFuzzer.cpp
+++ b/OrbitFuzzing/TcpClientFuzzer.cpp
@@ -1,0 +1,48 @@
+#include <absl/flags/flag.h>
+
+#include <filesystem>
+
+#include "App.h"
+#include "Capture.h"
+#include "CaptureWindow.h"
+#include "Message.h"
+#include "TcpClient.h"
+#include "TimeGraph.h"
+
+// Hack: This is declared in a header we include here
+// and the definition needs to take place somewhere.
+ABSL_FLAG(bool, enable_stale_features, false,
+          "Enable obsolete features that are not working or are not "
+          "implemented in the client's UI");
+ABSL_FLAG(bool, devmode, false, "Enable developer mode in the client's UI");
+
+std::unique_ptr<CaptureWindow> capture_window;
+
+extern "C" {
+
+int LLVMFuzzerTestOneInput(uint8_t* buf, size_t len) {
+  Capture::NewSamplingProfiler();
+
+  Message message{};
+  std::memcpy(&message, buf, std::min(len, sizeof(message)));
+
+  const bool payload_available = len > sizeof(message);
+  const auto payload_size = len - sizeof(message);
+  std::vector<char> payload(payload_available ? payload_size : 0);
+  std::memcpy(payload.data(), buf + sizeof(message), payload.size());
+
+  try {
+    GTcpClient->Callback(MessageOwner{message, std::move(payload)});
+    GTcpClient->ProcessMainThreadCallbacks();
+  } catch (...) {
+  }
+  return 0;
+}
+
+int LLVMFuzzerInitialize(int*, char***) {
+  OrbitApp::Init({"127.0.0.1:65001", ""});
+  capture_window = std::make_unique<CaptureWindow>();
+  GOrbitApp->PostInit();
+  return 0;
+}
+}  // extern "C"

--- a/OrbitFuzzing/TcpServerFuzzer.cpp
+++ b/OrbitFuzzing/TcpServerFuzzer.cpp
@@ -1,0 +1,29 @@
+
+#include <filesystem>
+
+#include "Message.h"
+#include "OrbitAsioServer.h"
+
+OrbitAsioServer asioServer{65001, LinuxTracing::TracingOptions{}};
+
+extern "C" {
+
+int LLVMFuzzerTestOneInput(uint8_t* buf, size_t len) {
+  Message message{};
+  std::memcpy(&message, buf, std::min(len, sizeof(message)));
+
+  const bool payload_available = len > sizeof(message);
+  const auto payload_size = len - sizeof(message);
+  std::vector<char> payload(payload_available ? payload_size : 0);
+  std::memcpy(payload.data(), buf + sizeof(message), payload.size());
+
+  try {
+    GTcpServer->Callback(MessageOwner{message, std::move(payload)});
+    GTcpServer->ProcessMainThreadCallbacks();
+  } catch (...) {
+  }
+  return 0;
+}
+
+int LLVMFuzzerInitialize(int*, char***) { return 0; }
+}  // extern "C"

--- a/OrbitFuzzing/elfFuzzer.cpp
+++ b/OrbitFuzzing/elfFuzzer.cpp
@@ -1,0 +1,10 @@
+#include "ElfFile.h"
+#include <cstdio>
+#include <cstdlib>
+
+
+extern "C"
+int LLVMFuzzerTestOneInput(uint8_t *buf, size_t len) {
+ ElfFile::CreateFromBuffer("INMEMORY", buf, len);
+ return 0;
+}

--- a/OrbitFuzzing/loadCaptureFuzzer.cpp
+++ b/OrbitFuzzing/loadCaptureFuzzer.cpp
@@ -1,0 +1,44 @@
+#include <absl/flags/flag.h>
+
+#include <cstdio>
+#include <filesystem>
+
+#include "App.h"
+#include "CaptureSerializer.h"
+#include "SamplingProfiler.h"
+#include "TimeGraph.h"
+
+// Hack: This is declared in a header we include here
+// and the definition needs to take place somewhere.
+ABSL_FLAG(bool, enable_stale_features, false,
+          "Enable obsolete features that are not working or are not "
+          "implemented in the client's UI");
+ABSL_FLAG(bool, devmode, false, "Enable developer mode in the client's UI");
+
+std::string capture_file;
+
+extern "C" {
+
+int LLVMFuzzerTestOneInput(uint8_t* buf, size_t len) {
+  CaptureSerializer serializer{};
+  TimeGraph time_graph{};
+  auto string_manager = std::make_shared<StringManager>();
+  time_graph.SetStringManager(string_manager);
+  serializer.time_graph_ = &time_graph;
+
+  std::istringstream stream(
+      std::string(reinterpret_cast<const char*>(buf), len));
+  try {
+    (void)serializer.Load(stream);
+  } catch (...) {
+  }
+
+  Capture::GSamplingProfiler.reset();
+  return 0;
+}
+
+int LLVMFuzzerInitialize(int*, char***) {
+  OrbitApp::Init({});
+  return 0;
+}
+}  // extern "C"

--- a/OrbitGl/CaptureSerializer.h
+++ b/OrbitGl/CaptureSerializer.h
@@ -7,6 +7,7 @@
 #include <outcome.hpp>
 #include <string>
 #include <unordered_map>
+#include <iosfwd>
 
 #include "OrbitType.h"
 #include "SerializationMacros.h"
@@ -14,11 +15,12 @@
 class CaptureSerializer {
  public:
   CaptureSerializer();
-  outcome::result<void, std::string> Save(const std::string& filename);
-  outcome::result<void, std::string> Load(const std::string& filename);
 
-  template <class T>
-  void Save(T& archive);
+  void Save(std::ostream& stream);
+  outcome::result<void, std::string> Save(const std::string& filename);
+
+  outcome::result<void, std::string> Load(std::istream& stream);
+  outcome::result<void, std::string> Load(const std::string& filename);
 
   class TimeGraph* time_graph_;
   class SamplingProfiler* m_SamplingProfiler;
@@ -30,4 +32,8 @@ class CaptureSerializer {
   int m_SizeOfTimer;
 
   ORBIT_SERIALIZABLE;
+
+ private:
+  template <class T>
+  void SaveImpl(T& archive);
 };

--- a/OrbitService/CMakeLists.txt
+++ b/OrbitService/CMakeLists.txt
@@ -2,14 +2,15 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-project(OrbitService)
+# To make OrbitAsioServer and OrbitGrpcServer available for fuzz-testing
+# the target OrbitServiceLib was introduced. OrbitService still exists,
+# but only builds main.cpp and links to OrbitServiceLib.
+project(OrbitServiceLib)
 
-add_executable(OrbitService)
+add_library(OrbitServiceLib STATIC)
+target_compile_options(OrbitServiceLib PRIVATE ${STRICT_COMPILE_FLAGS})
 
-target_compile_options(OrbitService PRIVATE ${STRICT_COMPILE_FLAGS})
-
-target_sources(OrbitService PRIVATE
-        main.cpp
+target_sources(OrbitServiceLib PRIVATE
         CrashServiceImpl.cpp
         CrashServiceImpl.h
         FramePointerValidatorServiceImpl.h
@@ -24,14 +25,19 @@ target_sources(OrbitService PRIVATE
         ProcessServiceImpl.h)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-  set_target_properties(OrbitService PROPERTIES COMPILE_FLAGS /wd4127)
+  set_target_properties(OrbitServiceLib PROPERTIES COMPILE_FLAGS /wd4127)
 endif()
 
-target_include_directories(OrbitService PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(OrbitServiceLib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(OrbitService PRIVATE
+target_link_libraries(OrbitServiceLib PUBLIC
         OrbitCore
         OrbitProtos)
+
+project(OrbitService)
+add_executable(OrbitService main.cpp)
+target_link_libraries(OrbitService PRIVATE OrbitServiceLib)
+target_compile_options(OrbitService PRIVATE ${STRICT_COMPILE_FLAGS})
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   # Administrator privileges

--- a/third_party/conan/configs/linux/profiles/libfuzzer_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/libfuzzer_relwithdebinfo
@@ -1,0 +1,23 @@
+[settings]
+os=Linux
+os_build=Linux
+arch=x86_64
+arch_build=x86_64
+compiler=clang
+compiler.version=9
+compiler.libcxx=libstdc++11
+compiler.fpo=False
+compiler.address_sanitizer=True
+compiler.fuzzer_sanitizer=True
+build_type=RelWithDebInfo
+[options]
+OrbitProfiler:with_gui=False
+OrbitProfiler:with_fuzzing=True
+[build_requires]
+cmake/3.16.4@
+[env]
+CC=clang-9
+CXX=clang++-9
+CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all -fsanitize=fuzzer-no-link,address
+CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all -fsanitize=fuzzer-no-link,address
+LDFLAGS= -Wl,-z,relro,-z,now,-z,noexecstack -fsanitize=address


### PR DESCRIPTION
This PR bundles all the changes necessary to perform fuzz-testing.

- It introduces a cmake and conan setting called `WITH_FUZZING` which switches the codebase into fuzzing-mode.
- In fuzzing mode, all targets are compiled except OrbitQt (so it deviates from the `WITH_GUI` mode).
- Some fundemental behaviour changes to the codebase have been necessary, so they are all guarded by #ifdef WITH_FUZZING.
- Changes have been: The LOG macros don't output anything. The CHECK macros do throw instead of aborting.
- Some APIs needed extra overloads to be able to read data from a buffer. This includes CaptureSerializer's and ElfFile's methods.
- The OrbitService target was splitted into two targets OrbitService and OrbitServiceLib. OrbitServiceLib contains all the compilation units from the previous OrbitService excluding main.cpp. Thus the tcp-server fuzz test can link against OrbitServiceLib and instantiate OrbitAsioServer.

Please let me know if you think these changes are too intrusive at some point. I can try to make them less intrusive. Of course I'm open to suggestions here as well.