### PR TITLE
Orbit core error

### DIFF
--- a/OrbitCore/LinuxUtils.h
+++ b/OrbitCore/LinuxUtils.h
@@ -7,6 +7,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <outcome.hpp>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -14,13 +15,11 @@
 #include "BaseTypes.h"
 #include "module.pb.h"
 
-struct Module;
-
 //-----------------------------------------------------------------------------
 namespace LinuxUtils {
-std::string ExecuteCommand(const char* a_Cmd);
-std::vector<std::string> ReadProcMaps(pid_t pid);
-std::vector<ModuleInfo> ListModules(int32_t pid);
-std::unordered_map<pid_t, double> GetCpuUtilization();
-bool Is64Bit(pid_t pid);
+outcome::result<std::string> ExecuteCommand(const std::string& cmd);
+outcome::result<std::vector<std::string>> ReadProcMaps(pid_t pid);
+outcome::result<std::vector<ModuleInfo>, std::string> ListModules(int32_t pid);
+outcome::result<std::unordered_map<pid_t, double>> GetCpuUtilization();
+outcome::result<bool> Is64Bit(pid_t pid);
 }  // namespace LinuxUtils

--- a/OrbitCore/Utils.h
+++ b/OrbitCore/Utils.h
@@ -19,6 +19,7 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <outcome.hpp>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -110,17 +111,21 @@ inline bool IsAllDigits(const std::string_view value) {
   return std::all_of(value.begin(), value.end(), IsDigit);
 }
 
+namespace OrbitUtils {
+
 //-----------------------------------------------------------------------------
-inline std::string FileToString(const std::string_view a_FileName) {
-  std::string file_name(a_FileName);
-  std::stringstream buffer;
-  std::ifstream inFile(file_name);
-  if (!inFile.fail()) {
-    buffer << inFile.rdbuf();
-    inFile.close();
+inline outcome::result<std::string> FileToString(
+    const std::filesystem::path& file_name) {
+  std::ifstream file_stream(file_name);
+  if (file_stream.fail()) {
+    return outcome::failure(static_cast<std::errc>(errno));
   }
-  return buffer.str();
+  return outcome::success(
+      std::string{std::istreambuf_iterator<char>{file_stream},
+                  std::istreambuf_iterator<char>{}});
 }
+
+}  // namespace OrbitUtils
 
 //-----------------------------------------------------------------------------
 template <class T>


### PR DESCRIPTION
This introduces OrbitCore::Error for better error handling. Utils::FileToString uses it and LinuxUtils. 

LinuxUtils::ExecuteCommand is only refactored to use outcome, but does not change the mechanism. I have a feeling that there might be a better way to do this, if that is the case, pointing me into a direction would be appreciated. 