### PR TITLE
Remove all instances of glBegin/glEnd usage and use batcher instead

### DIFF
--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -9,11 +9,11 @@
 
 void Batcher::AddLine(const Line& line, const Color* colors,
                       PickingID::Type picking_type, void* user_data) {
-  Color pickCol =
+  Color picking_color =
       PickingID::GetColor(picking_type, line_buffer_.m_Lines.size());
   line_buffer_.m_Lines.push_back(line);
   line_buffer_.m_Colors.push_back(colors, 2);
-  line_buffer_.m_PickingColors.push_back_n(pickCol, 2);
+  line_buffer_.m_PickingColors.push_back_n(picking_color, 2);
   line_buffer_.m_UserData.push_back(user_data);
 }
 
@@ -46,10 +46,10 @@ void Batcher::AddVerticalLine(Vec2 pos, float size, float z, Color color,
 
 void Batcher::AddBox(const Box& a_Box, const Color* colors,
                      PickingID::Type picking_type, void* user_data) {
-  Color pickCol = PickingID::GetColor(picking_type, box_buffer_.m_Boxes.size());
+  Color picking_color = PickingID::GetColor(picking_type, box_buffer_.m_Boxes.size());
   box_buffer_.m_Boxes.push_back(a_Box);
   box_buffer_.m_Colors.push_back(colors, 4);
-  box_buffer_.m_PickingColors.push_back_n(pickCol, 4);
+  box_buffer_.m_PickingColors.push_back_n(picking_color, 4);
   box_buffer_.m_UserData.push_back(user_data);
 }
 
@@ -118,7 +118,7 @@ void Batcher::Reset() {
 }
 
 //----------------------------------------------------------------------------
-void Batcher::Draw(bool a_Picking) {
+void Batcher::Draw(bool picking) {
   glPushAttrib(GL_ENABLE_BIT | GL_COLOR_BUFFER_BIT);
   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
   glDisable(GL_CULL_FACE);
@@ -126,9 +126,9 @@ void Batcher::Draw(bool a_Picking) {
   glEnableClientState(GL_COLOR_ARRAY);
   glEnable(GL_TEXTURE_2D);
 
-  DrawBoxBuffer(a_Picking);
-  DrawLineBuffer(a_Picking);
-  DrawTriangleBuffer(a_Picking);
+  DrawBoxBuffer(picking);
+  DrawLineBuffer(picking);
+  DrawTriangleBuffer(picking);
 
   glDisableClientState(GL_COLOR_ARRAY);
   glDisableClientState(GL_VERTEX_ARRAY);
@@ -136,44 +136,44 @@ void Batcher::Draw(bool a_Picking) {
 }
 
 //----------------------------------------------------------------------------
-void Batcher::DrawBoxBuffer(bool a_Picking) {
-  Block<Box, BoxBuffer::NUM_BOXES_PER_BLOCK>* boxBlock =
+void Batcher::DrawBoxBuffer(bool picking) {
+  Block<Box, BoxBuffer::NUM_BOXES_PER_BLOCK>* box_block =
       GetBoxBuffer().m_Boxes.m_Root;
-  Block<Color, BoxBuffer::NUM_BOXES_PER_BLOCK * 4>* colorBlock;
+  Block<Color, BoxBuffer::NUM_BOXES_PER_BLOCK * 4>* color_block;
 
-  colorBlock = !a_Picking ? GetBoxBuffer().m_Colors.m_Root
+  color_block = !picking ? GetBoxBuffer().m_Colors.m_Root
                           : GetBoxBuffer().m_PickingColors.m_Root;
 
-  while (boxBlock) {
-    if (int numElems = boxBlock->m_Size) {
-      glVertexPointer(3, GL_FLOAT, sizeof(Vec3), boxBlock->m_Data);
-      glColorPointer(4, GL_UNSIGNED_BYTE, sizeof(Color), colorBlock->m_Data);
-      glDrawArrays(GL_QUADS, 0, numElems * 4);
+  while (box_block) {
+    if (int num_elems = box_block->m_Size) {
+      glVertexPointer(3, GL_FLOAT, sizeof(Vec3), box_block->m_Data);
+      glColorPointer(4, GL_UNSIGNED_BYTE, sizeof(Color), color_block->m_Data);
+      glDrawArrays(GL_QUADS, 0, num_elems * 4);
     }
 
-    boxBlock = boxBlock->m_Next;
-    colorBlock = colorBlock->m_Next;
+    box_block = box_block->m_Next;
+    color_block = color_block->m_Next;
   }
 }
 
 //----------------------------------------------------------------------------
-void Batcher::DrawLineBuffer(bool a_Picking) {
-  Block<Line, LineBuffer::NUM_LINES_PER_BLOCK>* lineBlock =
+void Batcher::DrawLineBuffer(bool picking) {
+  Block<Line, LineBuffer::NUM_LINES_PER_BLOCK>* line_block =
       GetLineBuffer().m_Lines.m_Root;
-  Block<Color, LineBuffer::NUM_LINES_PER_BLOCK * 2>* colorBlock;
+  Block<Color, LineBuffer::NUM_LINES_PER_BLOCK * 2>* color_block;
 
-  colorBlock = !a_Picking ? GetLineBuffer().m_Colors.m_Root
+  color_block = !picking ? GetLineBuffer().m_Colors.m_Root
                           : GetLineBuffer().m_PickingColors.m_Root;
 
-  while (lineBlock) {
-    if (int numElems = lineBlock->m_Size) {
-      glVertexPointer(3, GL_FLOAT, sizeof(Vec3), lineBlock->m_Data);
-      glColorPointer(4, GL_UNSIGNED_BYTE, sizeof(Color), colorBlock->m_Data);
-      glDrawArrays(GL_LINES, 0, numElems * 2);
+  while (line_block) {
+    if (int num_elems = lineBlock->m_Size) {
+      glVertexPointer(3, GL_FLOAT, sizeof(Vec3), line_block->m_Data);
+      glColorPointer(4, GL_UNSIGNED_BYTE, sizeof(Color), color_block->m_Data);
+      glDrawArrays(GL_LINES, 0, num_elems * 2);
     }
 
-    lineBlock = lineBlock->m_Next;
-    colorBlock = colorBlock->m_Next;
+    line_block = line_block->m_Next;
+    color_block = color_block->m_Next;
   }
 }
 

--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -166,7 +166,7 @@ void Batcher::DrawLineBuffer(bool picking) {
                           : GetLineBuffer().m_PickingColors.m_Root;
 
   while (line_block) {
-    if (int num_elems = lineBlock->m_Size) {
+    if (int num_elems = line_block->m_Size) {
       glVertexPointer(3, GL_FLOAT, sizeof(Vec3), line_block->m_Data);
       glColorPointer(4, GL_UNSIGNED_BYTE, sizeof(Color), color_block->m_Data);
       glDrawArrays(GL_LINES, 0, num_elems * 2);

--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -10,7 +10,7 @@
 void Batcher::AddLine(const Line& line, const Color* colors,
                       PickingID::Type picking_type, void* user_data) {
   Color picking_color =
-      PickingID::GetColor(picking_type, line_buffer_.m_Lines.size());
+      PickingID::GetColor(picking_type, line_buffer_.m_Lines.size(), batcher_id_);
   line_buffer_.m_Lines.push_back(line);
   line_buffer_.m_Colors.push_back(colors, 2);
   line_buffer_.m_PickingColors.push_back_n(picking_color, 2);
@@ -46,7 +46,8 @@ void Batcher::AddVerticalLine(Vec2 pos, float size, float z, Color color,
 
 void Batcher::AddBox(const Box& a_Box, const Color* colors,
                      PickingID::Type picking_type, void* user_data) {
-  Color picking_color = PickingID::GetColor(picking_type, box_buffer_.m_Boxes.size());
+  Color picking_color = PickingID::GetColor(picking_type,
+    box_buffer_.m_Boxes.size(), batcher_id_);
   box_buffer_.m_Boxes.push_back(a_Box);
   box_buffer_.m_Colors.push_back(colors, 4);
   box_buffer_.m_PickingColors.push_back_n(picking_color, 4);
@@ -70,7 +71,8 @@ void Batcher::AddShadedBox(Vec2 pos, Vec2 size, float z, Color color,
 
 void Batcher::AddTriangle(const Triangle& triangle, Color color,
                           PickingID::Type picking_type, void* user_data) {
-  Color picking_color = PickingID::GetColor(picking_type, triangle_buffer_.triangles_.size());
+  Color picking_color = PickingID::GetColor(picking_type,
+    triangle_buffer_.triangles_.size(), batcher_id_);
   triangle_buffer_.triangles_.push_back(triangle);
   triangle_buffer_.colors_.push_back_n(color, 3);
   triangle_buffer_.picking_colors_.push_back_n(picking_color, 3);

--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -70,13 +70,18 @@ void Batcher::AddShadedBox(Vec2 pos, Vec2 size, float z, Color color,
   AddBox(box, colors, picking_type, user_data);
 }
 
-void Batcher::AddTriangle(Vec3 v0, Vec3 v1, Vec3 v2, Color color,
+void Batcher::AddTriangle(const Triangle& triangle, Color color,
                           PickingID::Type picking_type, void* user_data) {
   Color picking_color = PickingID::GetColor(picking_type, triangle_buffer_.triangles_.size());
-  triangle_buffer_.triangles_.push_back(Triangle(v0, v1, v2));
-  triangle_buffer_.colors_.push_back(color);
-  triangle_buffer_.picking_colors_.push_back(picking_color);
+  triangle_buffer_.triangles_.push_back(triangle);
+  triangle_buffer_.colors_.push_back_n(color, 3);
+  triangle_buffer_.picking_colors_.push_back_n(picking_color, 3);
   triangle_buffer_.user_data_.push_back(user_data);
+}
+
+void Batcher::AddTriangle(Vec3 v0, Vec3 v1, Vec3 v2, Color color,
+                          PickingID::Type picking_type, void* user_data) {
+  AddTriangle(Triangle(v0, v1, v2), color, picking_type, user_data);
 }
 
 TextBox* Batcher::GetTextBox(PickingID a_ID) {
@@ -111,6 +116,7 @@ void Batcher::GetBoxGradientColors(Color color, Color* colors) {
 void Batcher::Reset() {
   line_buffer_.Reset();
   box_buffer_.Reset();
+  triangle_buffer_.Reset();
 }
 
 //----------------------------------------------------------------------------

--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -5,6 +5,8 @@
 #include "Batcher.h"
 
 #include "Core.h"
+
+// Just to get the GL includes, should be removed and replaced by the right includes
 #include "GlCanvas.h"
 
 void Batcher::AddLine(const Line& line, const Color* colors,

--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -5,9 +5,7 @@
 #include "Batcher.h"
 
 #include "Core.h"
-
-// Just to get the GL includes, should be removed and replaced by the right includes
-#include "GlCanvas.h"
+#include "OpenGl.h"
 
 void Batcher::AddLine(const Line& line, const Color* colors,
                       PickingID::Type picking_type, void* user_data) {

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -76,6 +76,8 @@ class Batcher {
   void AddShadedBox(Vec2 pos, Vec2 size, float z, Color color,
                     PickingID::Type picking_type, void* user_data = nullptr);
 
+  void AddTriangle(const Triangle& triangle, Color color, 
+                  PickingID::Type picking_type, void* user_data = nullptr);
   void AddTriangle(Vec3 v0, Vec3 v1, Vec3 v2, Color color,
                    PickingID::Type picking_type, void* user_data = nullptr);
 

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -60,6 +60,9 @@ struct TriangleBuffer {
 //-----------------------------------------------------------------------------
 class Batcher {
  public:
+  explicit Batcher(PickingID::BatcherId batcher_id) : batcher_id_(batcher_id) {}
+  Batcher() : batcher_id_(PickingID::BatcherId::TIME_GRAPH) {}
+
   void AddLine(const Line& line, const Color* colors,
                PickingID::Type picking_type, void* user_data = nullptr);
   void AddLine(const Line& line, Color color, PickingID::Type picking_type,
@@ -99,4 +102,5 @@ class Batcher {
   LineBuffer line_buffer_;
   BoxBuffer box_buffer_;
   TriangleBuffer triangle_buffer_;
+  PickingID::BatcherId batcher_id_;
 };

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -62,7 +62,7 @@ class Batcher {
 
   void GetBoxGradientColors(Color color, Color* colors);
 
-  void Draw(bool picking);
+  void Draw(bool picking = false);
 
   void Reset();
 

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -62,6 +62,8 @@ class Batcher {
 
   void GetBoxGradientColors(Color color, Color* colors);
 
+  void Draw(bool picking);
+
   void Reset();
 
   TextBox* GetTextBox(PickingID a_ID);
@@ -69,6 +71,8 @@ class Batcher {
   LineBuffer& GetLineBuffer() { return line_buffer_; }
 
  protected:
+  void DrawLineBuffer(bool picking);
+  void DrawBoxBuffer(bool picking);
   LineBuffer line_buffer_;
   BoxBuffer box_buffer_;
 };

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -42,6 +42,22 @@ struct BoxBuffer {
 };
 
 //-----------------------------------------------------------------------------
+struct TriangleBuffer {
+  void Reset() {
+    triangles_.Reset();
+    colors_.Reset();
+    picking_colors_.Reset();
+    user_data_.Reset();
+  }
+
+  static const int NUM_TRIANGLES_PER_BLOCK = 64 * 1024;
+  BlockChain<Triangle, NUM_TRIANGLES_PER_BLOCK> triangles_;
+  BlockChain<Color, 3 * NUM_TRIANGLES_PER_BLOCK> colors_;
+  BlockChain<Color, 3 * NUM_TRIANGLES_PER_BLOCK> picking_colors_;
+  BlockChain<void*, NUM_TRIANGLES_PER_BLOCK> user_data_;
+};
+
+//-----------------------------------------------------------------------------
 class Batcher {
  public:
   void AddLine(const Line& line, const Color* colors,
@@ -60,6 +76,9 @@ class Batcher {
   void AddShadedBox(Vec2 pos, Vec2 size, float z, Color color,
                     PickingID::Type picking_type, void* user_data = nullptr);
 
+  void AddTriangle(Vec3 v0, Vec3 v1, Vec3 v2, Color color,
+                   PickingID::Type picking_type, void* user_data = nullptr);
+
   void GetBoxGradientColors(Color color, Color* colors);
 
   void Draw(bool picking = false);
@@ -69,10 +88,13 @@ class Batcher {
   TextBox* GetTextBox(PickingID a_ID);
   BoxBuffer& GetBoxBuffer() { return box_buffer_; }
   LineBuffer& GetLineBuffer() { return line_buffer_; }
+  TriangleBuffer& GetTriangleBuffer() { return triangle_buffer_; }
 
  protected:
   void DrawLineBuffer(bool picking);
   void DrawBoxBuffer(bool picking);
+  void DrawTriangleBuffer(bool picking);
   LineBuffer line_buffer_;
   BoxBuffer box_buffer_;
+  TriangleBuffer triangle_buffer_;
 };

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -583,13 +583,12 @@ void CaptureWindow::Draw() {
     DrawStatus();
     RenderTimeBar();
 
-    // Vertical line
-    glColor4f(0, 1, 0, 0.5f);
-    glBegin(GL_LINES);
-    glVertex3f(m_MouseX, m_WorldTopLeftY, Z_VALUE_TEXT);
-    glVertex3f(m_MouseX, m_WorldTopLeftY - m_WorldHeight, Z_VALUE_TEXT);
-    glEnd();
+    Vec2 pos(m_MouseX, m_WorldTopLeftY);
+    batcher_.AddVerticalLine(pos, -m_WorldHeight, Z_VALUE_TEXT,
+      Color(0, 255, 0, 127), PickingID::LINE);
   }
+  batcher_.Draw(m_Picking);
+  batcher_.Reset();
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -577,7 +577,7 @@ void CaptureWindow::Draw() {
     std::string time = GetPrettyTime(micros * 0.001);
     TextBox box(pos, size, time, Color(0, 128, 0, 128));
     box.SetTextY(m_SelectStop[1]);
-    box.Draw(m_TextRenderer, -FLT_MAX, true, true);
+    box.Draw(&batcher_, m_TextRenderer, -FLT_MAX, true, true);
   }
 
   if (!m_Picking && !m_IsHovering) {

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -219,6 +219,15 @@ void CaptureWindow::Pick(PickingID a_PickingID, int a_X, int a_Y) {
       }
       break;
     }
+    case PickingID::TRIANGLE: {
+      void** textBoxPtr =
+          time_graph_.GetBatcher().GetTriangleBuffer().user_data_.SlowAt(id);
+      if (textBoxPtr) {
+        TextBox* textBox = static_cast<TextBox*>(*textBoxPtr);
+        SelectTextBox(textBox);
+      }
+      break;
+    }
     case PickingID::PICKABLE:
       m_PickingManager.Pick(a_PickingID.m_Id, a_X, a_Y);
       break;
@@ -549,7 +558,6 @@ void CaptureWindow::ResetHoverTimer() {
 
 //-----------------------------------------------------------------------------
 void CaptureWindow::Draw() {
-  batcher_.Reset();
   m_WorldMaxY =
       1.5f * ScreenToWorldHeight(static_cast<int>(m_Slider.GetPixelHeight()));
 
@@ -560,7 +568,7 @@ void CaptureWindow::Draw() {
   // Reset picking manager before each draw.
   m_PickingManager.Reset();
 
-  time_graph_.Draw(m_Picking);
+  time_graph_.Draw(this, m_Picking);
 
   if (m_SelectStart[0] != m_SelectStop[0]) {
     TickType minTime = std::min(m_TimeStart, m_TimeStop);
@@ -588,13 +596,10 @@ void CaptureWindow::Draw() {
     batcher_.AddVerticalLine(pos, -m_WorldHeight, Z_VALUE_TEXT,
       Color(0, 255, 0, 127), PickingID::LINE);
   }
-  batcher_.Draw(m_Picking);
-  batcher_.Reset();
 }
 
 //-----------------------------------------------------------------------------
 void CaptureWindow::DrawScreenSpace() {
-  batcher_.Reset();
   double timeSpan = time_graph_.GetSessionTimeSpanUs();
 
   Color col = m_Slider.GetBarColor();
@@ -641,9 +646,6 @@ void CaptureWindow::DrawScreenSpace() {
     Box box(Vec2(0, height), Vec2(getWidth(), height), z);
     batcher_.AddBox(box, Color(70,70,70,200), PickingID::BOX);
   }
-
-  batcher_.Draw(m_Picking);
-  batcher_.Reset();
 }
 
 //-----------------------------------------------------------------------------
@@ -784,7 +786,7 @@ void CaptureWindow::RenderUI() {
 //-----------------------------------------------------------------------------
 void CaptureWindow::RenderText() {
   if (!m_Picking) {
-    time_graph_.DrawText();
+    time_graph_.DrawText(this);
   }
 }
 

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -106,7 +106,4 @@ class CaptureWindow : public GlCanvas {
 
   static const std::string MENU_ACTION_GO_TO_CALLSTACK;
   static const std::string MENU_ACTION_GO_TO_SOURCE;
-
-  // Batcher to draw elements in the UI.
-  Batcher batcher_;
 };

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "Batcher.h"
 #include "GlCanvas.h"
 #include "GlSlider.h"
 
@@ -102,4 +103,10 @@ class CaptureWindow : public GlCanvas {
   static constexpr size_t kFilterLength = 512;
   char track_filter_[kFilterLength] = "";
   char find_filter_[kFilterLength] = "";
+
+  static const std::string MENU_ACTION_GO_TO_CALLSTACK;
+  static const std::string MENU_ACTION_GO_TO_SOURCE;
+
+  // Batcher to draw elements in the UI.
+  Batcher batcher_;
 };

--- a/OrbitGl/Card.cpp
+++ b/OrbitGl/Card.cpp
@@ -4,6 +4,7 @@
 
 #include "Card.h"
 
+#include "Batcher.h"
 #include "GlCanvas.h"
 #include "ImGuiOrbit.h"
 #include "absl/strings/str_format.h"
@@ -35,16 +36,12 @@ std::map<int, std::string>& Card::GetTypeMap() {
 }
 
 //-----------------------------------------------------------------------------
-void Card::Draw(GlCanvas*) {
+void Card::Draw(GlCanvas* canvas) {
   if (!m_Active) return;
-
-  batcher_.Reset();
+  Batcher* batcher = canvas->GetBatcher();
 
   Box box(m_Pos, m_Size, 0.f);
   batcher_.AddBox(box, m_Color, PickingID::BOX);
-
-  batcher_.Draw();
-  batcher_.Reset();
 }
 
 //-----------------------------------------------------------------------------
@@ -112,7 +109,7 @@ void CardContainer::DrawImgui(GlCanvas* a_Canvas) {
 //-----------------------------------------------------------------------------
 void FloatGraphCard::Draw(GlCanvas* a_Canvas) {
   if (!m_Active) return;
-  batcher_.Reset();
+  Batcher* batcher = a_Canvas->GetBatcher();
 
   Card::Draw(a_Canvas);
 
@@ -143,9 +140,6 @@ void FloatGraphCard::Draw(GlCanvas* a_Canvas) {
   a_Canvas->GetTextRenderer().AddText2D(
       cardValue.c_str(), static_cast<int>(m_Pos[0]), static_cast<int>(m_Pos[1]),
       GlCanvas::Z_VALUE_TEXT, col, -1.f, false, false);
-
-  batcher_.Draw();
-  batcher_.Reset();
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/Card.cpp
+++ b/OrbitGl/Card.cpp
@@ -15,7 +15,7 @@ CardContainer GCardContainer;
 Card::Card()
     : m_Pos(500, 0),
       m_Size(512, 64),
-      m_Color(255, 0, 255, 32),
+      m_Color(0, 0, 255, 32),
       m_Active(true),
       m_Open(true) {}
 

--- a/OrbitGl/Card.cpp
+++ b/OrbitGl/Card.cpp
@@ -41,7 +41,7 @@ void Card::Draw(GlCanvas* canvas) {
   Batcher* batcher = canvas->GetBatcher();
 
   Box box(m_Pos, m_Size, 0.f);
-  batcher->AddBox(box, m_Color, PickingID::BOX);
+  batcher->AddBox(box, m_Color, PickingID::PICKABLE);
 }
 
 //-----------------------------------------------------------------------------
@@ -129,7 +129,8 @@ void FloatGraphCard::Draw(GlCanvas* a_Canvas) {
     float y1 = m_Pos[1] + textHeight +
                (m_Data[i + 1] - m_Min) * YRangeInv * YGraphSize;
 
-    batcher->AddLine(Vec2(x0, y0), Vec2(x1, y1), 0.f, Color(255, 255, 255, 255), PickingID::LINE);
+    batcher->AddLine(Vec2(x0, y0), Vec2(x1, y1), 0.f,
+      Color(255, 255, 255, 255), PickingID::PICKABLE);
   }
 
   Color col(255, 255, 255, 255);

--- a/OrbitGl/Card.cpp
+++ b/OrbitGl/Card.cpp
@@ -41,7 +41,7 @@ void Card::Draw(GlCanvas* canvas) {
   Batcher* batcher = canvas->GetBatcher();
 
   Box box(m_Pos, m_Size, 0.f);
-  batcher_.AddBox(box, m_Color, PickingID::BOX);
+  batcher->AddBox(box, m_Color, PickingID::BOX);
 }
 
 //-----------------------------------------------------------------------------
@@ -129,7 +129,7 @@ void FloatGraphCard::Draw(GlCanvas* a_Canvas) {
     float y1 = m_Pos[1] + textHeight +
                (m_Data[i + 1] - m_Min) * YRangeInv * YGraphSize;
 
-    batcher_.AddLine(Vec2(x0, y0), Vec2(x1, y1), 0.f, Color(255, 255, 255, 255), PickingID::LINE);
+    batcher->AddLine(Vec2(x0, y0), Vec2(x1, y1), 0.f, Color(255, 255, 255, 255), PickingID::LINE);
   }
 
   Color col(255, 255, 255, 255);

--- a/OrbitGl/Card.h
+++ b/OrbitGl/Card.h
@@ -6,6 +6,7 @@
 
 #include <unordered_map>
 
+#include "Batcher.h"
 #include "../OrbitCore/RingBuffer.h"
 #include "../OrbitCore/Threading.h"
 #include "CoreMath.h"
@@ -34,6 +35,8 @@ class Card {
   Color m_Color;
   bool m_Active;
   bool m_Open;
+ protected:
+  Batcher batcher_;
 };
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/Card.h
+++ b/OrbitGl/Card.h
@@ -35,8 +35,6 @@ class Card {
   Color m_Color;
   bool m_Active;
   bool m_Open;
- protected:
-  Batcher batcher_;
 };
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -18,7 +18,6 @@ EventTrack::EventTrack(TimeGraph* a_TimeGraph) : Track(a_TimeGraph) {
 //-----------------------------------------------------------------------------
 void EventTrack::Draw(GlCanvas* canvas, bool picking) {
   Batcher* batcher = canvas->GetBatcher();
-  batcher->Reset();
   PickingManager& picking_manager = canvas->GetPickingManager();
 
   constexpr float kNormalZ = -0.1f;
@@ -61,9 +60,6 @@ void EventTrack::Draw(GlCanvas* canvas, bool picking) {
   }
 
   m_Canvas = canvas;
-
-  batcher->Draw();
-  batcher->Reset();
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -7,6 +7,7 @@
 #include "Capture.h"
 #include "EventTracer.h"
 #include "GlCanvas.h"
+#include "PickingManager.h"
 
 //-----------------------------------------------------------------------------
 EventTrack::EventTrack(TimeGraph* a_TimeGraph) : Track(a_TimeGraph) {
@@ -27,11 +28,11 @@ void EventTrack::Draw(GlCanvas* canvas, bool picking) {
 
   if (picking) {
     z = kPickingZ;
-    color = picking_manager.GetPickableColor(this);
+    color = picking_manager.GetPickableColor(this, PickingID::BatcherId::UI);
   }
 
   Box box(m_Pos, Vec2(m_Size[0], -m_Size[1]), z);
-  batcher->AddBox(box, color, PickingID::BOX);
+  batcher->AddBox(box, color, PickingID::PICKABLE);
 
   if (canvas->GetPickingManager().GetPicked() == this) {
     color = Color(255, 255, 255, 255);
@@ -42,8 +43,8 @@ void EventTrack::Draw(GlCanvas* canvas, bool picking) {
   float x1 = x0 + m_Size[0];
   float y1 = y0 - m_Size[1];
 
-  batcher->AddLine(m_Pos, Vec2(x1, y0), -0.1f, color, PickingID::LINE);
-  batcher->AddLine(Vec2(x1, y1), Vec2(x0, y1), -0.1f, color, PickingID::LINE);
+  batcher->AddLine(m_Pos, Vec2(x1, y0), -0.1f, color, PickingID::PICKABLE);
+  batcher->AddLine(Vec2(x1, y1), Vec2(x0, y1), -0.1f, color, PickingID::PICKABLE);
 
   if (m_Picked) {
     Vec2& from = m_MousePos[0];
@@ -56,7 +57,7 @@ void EventTrack::Draw(GlCanvas* canvas, bool picking) {
 
     Color picked_color(0, 128, 255, 128);
     Box box(Vec2(x0, y0), Vec2(x1 - x0, -m_Size[1]), -0.f);
-    batcher->AddBox(box, picked_color, PickingID::BOX);
+    batcher->AddBox(box, picked_color, PickingID::PICKABLE);
   }
 
   m_Canvas = canvas;
@@ -79,7 +80,7 @@ void EventTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
     uint64_t time = pair.first;
     if (time > min_tick && time < max_tick) {
       Vec2 pos(time_graph_->GetWorldFromTick(time), m_Pos[1]);
-      batcher->AddVerticalLine(pos, -track_height, z, kWhite, PickingID::EVENT);
+      batcher->AddVerticalLine(pos, -track_height, z, kWhite, PickingID::LINE);
     }
   }
 
@@ -90,7 +91,7 @@ void EventTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
   for (CallstackEvent& event : selected_callstack_events_) {
     Vec2 pos(time_graph_->GetWorldFromTick(event.m_Time), m_Pos[1]);
     batcher->AddVerticalLine(pos, -track_height, z, kGreenSelection,
-                             PickingID::EVENT);
+                             PickingID::LINE);
   }
 }
 

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -56,7 +56,7 @@ void EventTrack::Draw(GlCanvas* canvas, bool picking) {
     y1 = y0 - m_Size[1];
 
     Color picked_color(0, 128, 255, 128);
-    Box box(Vec2(x0, y0), Vec2(x1 - x0, m_Size[1]), -0.f);
+    Box box(Vec2(x0, y0), Vec2(x1 - x0, -m_Size[1]), -0.f);
     batcher->AddBox(box, picked_color, PickingID::BOX);
   }
 

--- a/OrbitGl/Geometry.h
+++ b/OrbitGl/Geometry.h
@@ -25,3 +25,14 @@ struct Box {
   }
   Vec3 vertices_[4];
 };
+
+//-----------------------------------------------------------------------------
+struct Triangle {
+  Triangle() = default;
+  Triangle(Vec3 v0, Vec3 v1, Vec3 v2) {
+    vertices_[0] = v0;
+    vertices_[1] = v1;
+    vertices_[2] = v2;
+  }
+  Vec3 vertices_[3];
+};

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -44,7 +44,7 @@ void ClearCaptureData() {
 }
 
 //-----------------------------------------------------------------------------
-GlCanvas::GlCanvas() {
+GlCanvas::GlCanvas() : ui_batcher_(PickingID::BatcherId::UI) {
   m_TextRenderer.SetCanvas(this);
 
   m_Width = 0;
@@ -436,7 +436,7 @@ void GlCanvas::Render(int a_Width, int a_Height) {
   }
 
   m_NeedsRedraw = false;
-  batcher_.Reset();
+  ui_batcher_.Reset();
 
   ScopeImguiContext state(m_ImGuiContext);
 
@@ -459,20 +459,20 @@ void GlCanvas::Render(int a_Width, int a_Height) {
 
   // We have to draw everything collected in the batcher at this point,
   // as prepareScreenSpaceViewport() changes the coordinate system.
-  batcher_.Draw();
-  batcher_.Reset();
+  ui_batcher_.Draw();
+  ui_batcher_.Reset();
 
   prepareScreenSpaceViewport();
 
   DrawScreenSpace();
 
   RenderUI();
-  m_TextRenderer.Display(&batcher_);
+  m_TextRenderer.Display(&ui_batcher_);
   RenderText();
 
   // Draw remaining elements collected with the batcher.
-  batcher_.Draw();
-  batcher_.Reset();
+  ui_batcher_.Draw();
+  ui_batcher_.Reset();
 
   glFlush();
 

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -436,6 +436,7 @@ void GlCanvas::Render(int a_Width, int a_Height) {
   }
 
   m_NeedsRedraw = false;
+  batcher_.Reset();
 
   ScopeImguiContext state(m_ImGuiContext);
 
@@ -456,13 +457,22 @@ void GlCanvas::Render(int a_Width, int a_Height) {
 
   Draw();
 
+  // We have to draw everything collected in the batcher at this point,
+  // as prepareScreenSpaceViewport() changes the coordinate system.
+  batcher_.Draw();
+  batcher_.Reset();
+
   prepareScreenSpaceViewport();
+
   DrawScreenSpace();
 
   RenderUI();
-
   m_TextRenderer.Display(&batcher_);
   RenderText();
+
+  // Draw remaining elements collected with the batcher.
+  batcher_.Draw();
+  batcher_.Reset();
 
   glFlush();
 

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -461,7 +461,7 @@ void GlCanvas::Render(int a_Width, int a_Height) {
 
   RenderUI();
 
-  m_TextRenderer.Display();
+  m_TextRenderer.Display(&batcher_);
   RenderText();
 
   glFlush();

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -421,34 +421,6 @@ float GlCanvas::ScreenToworldWidth(int a_Width) const {
 }
 
 //-----------------------------------------------------------------------------
-void GlCanvas::drawSquareGrid(float size, float delta) {
-  int halfIncrements = static_cast<int>(size * 0.5f / delta);
-  float halfSize = delta * halfIncrements;
-
-  glBegin(GL_LINES);
-
-  glColor4f(0.5f, 0.5f, 0.5f, 1);
-  for (float x = -halfSize; x <= halfSize; x += delta) {
-    for (float y = -halfSize; y <= halfSize; y += delta) {
-      glVertex3f(-x, y, 0);
-      glVertex3f(x, y, 0);
-      glVertex3f(x, -y, 0);
-      glVertex3f(x, y, 0);
-    }
-  }
-
-  glColor4f(1, 0, 0, 1);
-  glVertex3f(-halfSize, 0, 0);
-  glVertex3f(halfSize, 0, 0);
-
-  glColor4f(0, 1, 0, 1);
-  glVertex3f(0, -halfSize, 0);
-  glVertex3f(0, halfSize, 0);
-
-  glEnd();
-}
-
-//-----------------------------------------------------------------------------
 int GlCanvas::getWidth() const { return m_Width; }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -98,7 +98,7 @@ class GlCanvas : public GlPanel {
   void RenderSamplingUI();
 
   ImGuiContext* GetImGuiContext() { return m_ImGuiContext; }
-  Batcher* GetBatcher() { return &batcher_; }
+  Batcher* GetBatcher() { return &ui_batcher_; }
 
   PickingManager& GetPickingManager() { return m_PickingManager; }
 
@@ -159,5 +159,5 @@ class GlCanvas : public GlPanel {
   bool m_AltKey;
 
   // Batcher to draw elements in the UI.
-  Batcher batcher_;
+  Batcher ui_batcher_;
 };

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -98,6 +98,7 @@ class GlCanvas : public GlPanel {
   void RenderSamplingUI();
 
   ImGuiContext* GetImGuiContext() { return m_ImGuiContext; }
+  Batcher* GetBatcher() { return &batcher_; }
 
   PickingManager& GetPickingManager() { return m_PickingManager; }
 

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -29,7 +29,6 @@ class GlCanvas : public GlPanel {
   void prepare2DViewport(int topleft_x, int topleft_y, int bottomrigth_x,
                          int bottomrigth_y);
   void prepareScreenSpaceViewport();
-  void drawSquareGrid(float size, float delta);
   void ScreenToWorld(int x, int y, float& wx, float& wy) const;
   void WorldToScreen(float wx, float wy, int& x, int& y) const;
   int WorldToScreenHeight(float a_Height) const;
@@ -157,4 +156,7 @@ class GlCanvas : public GlPanel {
   bool m_ControlKey;
   bool m_ShiftKey;
   bool m_AltKey;
+
+  // Batcher to draw elements in the UI.
+  Batcher batcher_;
 };

--- a/OrbitGl/GlSlider.cpp
+++ b/OrbitGl/GlSlider.cpp
@@ -112,6 +112,7 @@ void GlSlider::Draw(GlCanvas* a_Canvas, bool a_Picking) {
 //-----------------------------------------------------------------------------
 void GlSlider::DrawHorizontal(GlCanvas* canvas, bool picking) {
   m_Canvas = canvas;
+  batcher_.Reset();
 
   static float y = 0;
 
@@ -121,13 +122,8 @@ void GlSlider::DrawHorizontal(GlCanvas* canvas, bool picking) {
 
   // Bar
   if (!picking) {
-    glColor4ubv(&m_BarColor[0]);
-    glBegin(GL_QUADS);
-    glVertex3f(0, y, 0);
-    glVertex3f(canvasWidth, y, 0);
-    glVertex3f(canvasWidth, y + GetPixelHeight(), 0);
-    glVertex3f(0, y + GetPixelHeight(), 0);
-    glEnd();
+    Box box(Vec2(0, y), Vec2(canvasWidth, GetPixelHeight()), 0.f);
+    batcher_.AddBox(box, m_BarColor, PickingID::BOX);
   }
 
   float start = m_Ratio * nonSliderWidth;
@@ -140,18 +136,17 @@ void GlSlider::DrawHorizontal(GlCanvas* canvas, bool picking) {
     color = m_SelectedColor;
   }
 
-  glColor4ubv(&color[0]);
-  glBegin(GL_QUADS);
-  glVertex3f(start, y, 0);
-  glVertex3f(stop, y, 0);
-  glVertex3f(stop, y + GetPixelHeight(), 0);
-  glVertex3f(start, y + GetPixelHeight(), 0);
-  glEnd();
+  Box box(Vec2(start, y), Vec2(stop - start, GetPixelHeight()), 0.f);
+  batcher_.AddBox(box, color, PickingID::BOX);
+
+  batcher_.Draw();
+  batcher_.Reset();
 }
 
 //-----------------------------------------------------------------------------
 void GlSlider::DrawVertical(GlCanvas* canvas, bool picking) {
   m_Canvas = canvas;
+  batcher_.Reset();
 
   float x = m_Canvas->getWidth() - GetPixelHeight();
 
@@ -161,13 +156,8 @@ void GlSlider::DrawVertical(GlCanvas* canvas, bool picking) {
 
   // Bar
   if (!picking) {
-    glColor4ubv(&m_BarColor[0]);
-    glBegin(GL_QUADS);
-    glVertex3f(x, 0, 0);
-    glVertex3f(x, canvasHeight, 0);
-    glVertex3f(x + GetPixelHeight(), canvasHeight, 0);
-    glVertex3f(x + GetPixelHeight(), 0, 0);
-    glEnd();
+    Box box(Vec2(x, 0), Vec2(GetPixelHeight(), canvasHeight), 0.f);
+    batcher_.AddBox(box, m_BarColor, PickingID::BOX);
   }
 
   float start = canvasHeight - m_Ratio * nonSliderHeight;
@@ -180,12 +170,9 @@ void GlSlider::DrawVertical(GlCanvas* canvas, bool picking) {
     color = m_SelectedColor;
   }
 
-  glColor4ubv(&color[0]);
+  Box box(Vec2(x, start), Vec2(GetPixelHeight(), stop - start), 0.f);
+  batcher_.AddBox(box, color, PickingID::BOX);
 
-  glBegin(GL_QUADS);
-  glVertex3f(x, start, 0);
-  glVertex3f(x, stop, 0);
-  glVertex3f(x + GetPixelHeight(), stop, 0);
-  glVertex3f(x + GetPixelHeight(), start, 0);
-  glEnd();
+  batcher_.Draw();
+  batcher_.Reset();
 }

--- a/OrbitGl/GlSlider.cpp
+++ b/OrbitGl/GlSlider.cpp
@@ -112,7 +112,7 @@ void GlSlider::Draw(GlCanvas* a_Canvas, bool a_Picking) {
 //-----------------------------------------------------------------------------
 void GlSlider::DrawHorizontal(GlCanvas* canvas, bool picking) {
   m_Canvas = canvas;
-  batcher_.Reset();
+  Batcher* batcher = canvas->GetBatcher();
 
   static float y = 0;
 
@@ -123,7 +123,7 @@ void GlSlider::DrawHorizontal(GlCanvas* canvas, bool picking) {
   // Bar
   if (!picking) {
     Box box(Vec2(0, y), Vec2(canvasWidth, GetPixelHeight()), 0.f);
-    batcher_.AddBox(box, m_BarColor, PickingID::BOX);
+    batcher->AddBox(box, m_BarColor, PickingID::BOX);
   }
 
   float start = m_Ratio * nonSliderWidth;
@@ -137,16 +137,13 @@ void GlSlider::DrawHorizontal(GlCanvas* canvas, bool picking) {
   }
 
   Box box(Vec2(start, y), Vec2(stop - start, GetPixelHeight()), 0.f);
-  batcher_.AddBox(box, color, PickingID::BOX);
-
-  batcher_.Draw();
-  batcher_.Reset();
+  batcher->AddBox(box, color, PickingID::BOX);
 }
 
 //-----------------------------------------------------------------------------
 void GlSlider::DrawVertical(GlCanvas* canvas, bool picking) {
   m_Canvas = canvas;
-  batcher_.Reset();
+  Batcher* batcher = canvas->GetBatcher();
 
   float x = m_Canvas->getWidth() - GetPixelHeight();
 
@@ -157,7 +154,7 @@ void GlSlider::DrawVertical(GlCanvas* canvas, bool picking) {
   // Bar
   if (!picking) {
     Box box(Vec2(x, 0), Vec2(GetPixelHeight(), canvasHeight), 0.f);
-    batcher_.AddBox(box, m_BarColor, PickingID::BOX);
+    batcher->AddBox(box, m_BarColor, PickingID::BOX);
   }
 
   float start = canvasHeight - m_Ratio * nonSliderHeight;
@@ -171,8 +168,5 @@ void GlSlider::DrawVertical(GlCanvas* canvas, bool picking) {
   }
 
   Box box(Vec2(x, start), Vec2(GetPixelHeight(), stop - start), 0.f);
-  batcher_.AddBox(box, color, PickingID::BOX);
-
-  batcher_.Draw();
-  batcher_.Reset();
+  batcher->AddBox(box, color, PickingID::BOX);
 }

--- a/OrbitGl/GlSlider.cpp
+++ b/OrbitGl/GlSlider.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 
 #include "GlCanvas.h"
+#include "PickingManager.h"
 
 //-----------------------------------------------------------------------------
 GlSlider::GlSlider()
@@ -123,7 +124,7 @@ void GlSlider::DrawHorizontal(GlCanvas* canvas, bool picking) {
   // Bar
   if (!picking) {
     Box box(Vec2(0, y), Vec2(canvasWidth, GetPixelHeight()), 0.f);
-    batcher->AddBox(box, m_BarColor, PickingID::BOX);
+    batcher->AddBox(box, m_BarColor, PickingID::PICKABLE);
   }
 
   float start = m_Ratio * nonSliderWidth;
@@ -131,13 +132,14 @@ void GlSlider::DrawHorizontal(GlCanvas* canvas, bool picking) {
 
   Color color = m_SliderColor;
   if (picking) {
-    color = canvas->GetPickingManager().GetPickableColor(this);
+    color =
+      canvas->GetPickingManager().GetPickableColor(this, PickingID::BatcherId::UI);
   } else if (canvas->GetPickingManager().GetPicked() == this) {
     color = m_SelectedColor;
   }
 
   Box box(Vec2(start, y), Vec2(stop - start, GetPixelHeight()), 0.f);
-  batcher->AddBox(box, color, PickingID::BOX);
+  batcher->AddBox(box, color, PickingID::PICKABLE);
 }
 
 //-----------------------------------------------------------------------------
@@ -154,7 +156,7 @@ void GlSlider::DrawVertical(GlCanvas* canvas, bool picking) {
   // Bar
   if (!picking) {
     Box box(Vec2(x, 0), Vec2(GetPixelHeight(), canvasHeight), 0.f);
-    batcher->AddBox(box, m_BarColor, PickingID::BOX);
+    batcher->AddBox(box, m_BarColor, PickingID::PICKABLE);
   }
 
   float start = canvasHeight - m_Ratio * nonSliderHeight;
@@ -162,11 +164,12 @@ void GlSlider::DrawVertical(GlCanvas* canvas, bool picking) {
 
   Color color = m_SliderColor;
   if (picking) {
-    color = canvas->GetPickingManager().GetPickableColor(this);
+    color =
+      canvas->GetPickingManager().GetPickableColor(this, PickingID::BatcherId::UI);
   } else if (canvas->GetPickingManager().GetPicked() == this) {
     color = m_SelectedColor;
   }
 
   Box box(Vec2(x, start), Vec2(GetPixelHeight(), stop - start), 0.f);
-  batcher->AddBox(box, color, PickingID::BOX);
+  batcher->AddBox(box, color, PickingID::PICKABLE);
 }

--- a/OrbitGl/GlSlider.h
+++ b/OrbitGl/GlSlider.h
@@ -6,7 +6,7 @@
 
 #include <functional>
 
-#include "Batcher.h"
+//#include "Batcher.h"
 #include "Params.h"
 #include "PickingManager.h"
 #include "TextBox.h"
@@ -55,6 +55,4 @@ class GlSlider : public Pickable {
   float m_MinSliderPixelWidth;
   float m_PixelHeight;
   bool m_Vertical;
-
-  Batcher batcher_;
 };

--- a/OrbitGl/GlSlider.h
+++ b/OrbitGl/GlSlider.h
@@ -6,7 +6,6 @@
 
 #include <functional>
 
-//#include "Batcher.h"
 #include "Params.h"
 #include "PickingManager.h"
 #include "TextBox.h"

--- a/OrbitGl/GlSlider.h
+++ b/OrbitGl/GlSlider.h
@@ -6,6 +6,7 @@
 
 #include <functional>
 
+#include "Batcher.h"
 #include "Params.h"
 #include "PickingManager.h"
 #include "TextBox.h"
@@ -54,4 +55,6 @@ class GlSlider : public Pickable {
   float m_MinSliderPixelWidth;
   float m_PixelHeight;
   bool m_Vertical;
+
+  Batcher batcher_;
 };

--- a/OrbitGl/GraphTrack.cpp
+++ b/OrbitGl/GraphTrack.cpp
@@ -35,14 +35,14 @@ void GraphTrack::Draw(GlCanvas* canvas, bool picking) {
   float text_z = layout.GetTextZ();
 
   Box box(m_Pos, Vec2(m_Size[0], -m_Size[1]), track_z);
-  batcher->AddBox(box, color, PickingID::BOX);
+  batcher->AddBox(box, color, PickingID::PICKABLE);
 
   if (canvas->GetPickingManager().GetPicked() == this) {
     color = Color(255, 255, 255, 255);
   }
 
-  batcher->AddLine(m_Pos, Vec2(x1, y0), track_z, color, PickingID::LINE);
-  batcher->AddLine(Vec2(x1, y1), Vec2(x0, y1), track_z, color, PickingID::LINE);
+  batcher->AddLine(m_Pos, Vec2(x1, y0), track_z, color, PickingID::PICKABLE);
+  batcher->AddLine(Vec2(x1, y1), Vec2(x0, y1), track_z, color, PickingID::PICKABLE);
 
   const Color kLineColor(0, 128, 255, 128);
 

--- a/OrbitGl/GraphTrack.cpp
+++ b/OrbitGl/GraphTrack.cpp
@@ -71,9 +71,6 @@ void GraphTrack::Draw(GlCanvas* canvas, bool picking) {
     previous_time = time;
     last_normalized_value = normalized_value;
   }
-
-  batcher->Draw();
-  batcher->Reset();
 }
 
 void GraphTrack::OnDrag(int /*x*/, int /*y*/) {}

--- a/OrbitGl/PickingManager.cpp
+++ b/OrbitGl/PickingManager.cpp
@@ -8,10 +8,10 @@
 #include "OrbitBase/Logging.h"
 
 //-----------------------------------------------------------------------------
-PickingID PickingManager::CreatePickableId(Pickable* a_Pickable) {
+PickingID PickingManager::CreatePickableId(Pickable* a_Pickable, PickingID::BatcherId batcher_id) {
   absl::MutexLock lock(&mutex_);
   ++m_IdCounter;
-  PickingID id = PickingID::Get(PickingID::PICKABLE, m_IdCounter);
+  PickingID id = PickingID::Get(PickingID::PICKABLE, m_IdCounter, batcher_id);
   m_PickableIdMap[a_Pickable] = m_IdCounter;
   m_IdPickableMap[m_IdCounter] = a_Pickable;
   return id;
@@ -77,8 +77,8 @@ bool PickingManager::IsDragging() const {
 }
 
 //-----------------------------------------------------------------------------
-Color PickingManager::GetPickableColor(Pickable* pickable) {
-  PickingID id = CreatePickableId(pickable);
+Color PickingManager::GetPickableColor(Pickable* pickable, PickingID::BatcherId batcher_id) {
+  PickingID id = CreatePickableId(pickable, batcher_id);
   return ColorFromPickingID(id);
 }
 

--- a/OrbitGl/PickingManager.h
+++ b/OrbitGl/PickingManager.h
@@ -26,7 +26,7 @@ class Pickable {
 
 //-----------------------------------------------------------------------------
 struct PickingID {
-  enum Type { INVALID, LINE, EVENT, BOX, PICKABLE };
+  enum Type { INVALID, LINE, EVENT, BOX, PICKABLE, TRIANGLE };
 
   static PickingID Get(Type a_Type, unsigned a_ID) {
     static_assert(sizeof(PickingID) == 4, "PickingID must be 32 bits");

--- a/OrbitGl/PickingManager.h
+++ b/OrbitGl/PickingManager.h
@@ -33,6 +33,15 @@ struct PickingID {
     PICKABLE,
   };
 
+  // Instances of batchers used to draw must be in 1:1 correspondence with values in the
+  // following enum. Currently, two batchers are used, one to draw UI elements
+  // (corresponding to BatcherId::UI), and one for drawing events on the time graph
+  // (corresponding to BatcherId::TIME_GRAPH). If you want to add more batchers, this enum
+  // must be extended and you need to spend more bits on the batcher_id_ field below.
+  // The total number of elements that can be correctly picked is limited to the number
+  // of elements that can be encoded in the bits remaining after encoding the batcher id,
+  // and the PickingID::Type, so adding more batchers or types has to be carefully
+  // considered.
   enum BatcherId {
     TIME_GRAPH,
     UI

--- a/OrbitGl/PickingManager.h
+++ b/OrbitGl/PickingManager.h
@@ -21,7 +21,7 @@ class Pickable {
   virtual void OnRelease(){};
   virtual void Draw(GlCanvas* a_Canvas, bool a_Picking) = 0;
   virtual bool Draggable() { return false; }
-  virtual bool Movable() { return false; }
+  virtual bool Movable() { return false; } 
 };
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/PickingManager.h
+++ b/OrbitGl/PickingManager.h
@@ -26,24 +26,36 @@ class Pickable {
 
 //-----------------------------------------------------------------------------
 struct PickingID {
-  enum Type { INVALID, LINE, EVENT, BOX, PICKABLE, TRIANGLE };
+  enum Type {
+    LINE,
+    BOX,
+    TRIANGLE,
+    PICKABLE,
+  };
 
-  static PickingID Get(Type a_Type, unsigned a_ID) {
+  enum BatcherId {
+    TIME_GRAPH,
+    UI
+  };
+
+  static PickingID Get(Type a_Type, uint32_t a_ID, BatcherId batcher_id = TIME_GRAPH) {
     static_assert(sizeof(PickingID) == 4, "PickingID must be 32 bits");
     PickingID id;
     id.m_Type = a_Type;
     id.m_Id = a_ID;
+    id.batcher_id_ = batcher_id;
     return id;
   }
-  static Color GetColor(Type a_Type, unsigned a_ID) {
-    PickingID id = Get(a_Type, a_ID);
+  static Color GetColor(Type a_Type, uint32_t a_ID, BatcherId batcher_id = TIME_GRAPH) {
+    PickingID id = Get(a_Type, a_ID, batcher_id);
     return *(reinterpret_cast<Color*>(&id));
   }
   static PickingID Get(uint32_t a_Value) {
     return *(reinterpret_cast<PickingID*>(&a_Value));
   }
   uint32_t m_Id : 29;
-  uint32_t m_Type : 3;
+  uint32_t m_Type : 2;
+  uint32_t batcher_id_ : 1;
 };
 
 //-----------------------------------------------------------------------------
@@ -59,10 +71,10 @@ class PickingManager {
   Pickable* GetPickableFromId(uint32_t id);
   bool IsDragging() const;
 
-  Color GetPickableColor(Pickable* pickable);
+  Color GetPickableColor(Pickable* pickable, PickingID::BatcherId batcher_id);
 
  private:
-  PickingID CreatePickableId(Pickable* a_Pickable);
+  PickingID CreatePickableId(Pickable* a_Pickable, PickingID::BatcherId batcher_id);
   Color ColorFromPickingID(PickingID id) const;
 
  private:

--- a/OrbitGl/TextBox.cpp
+++ b/OrbitGl/TextBox.cpp
@@ -78,7 +78,7 @@ void TextBox::Draw(Batcher* batcher,
                    TextRenderer& a_TextRenderer, float a_MinX, bool a_Visible,
                    bool a_RightJustify, bool isInactive, unsigned int a_ID,
                    bool a_IsPicking, bool a_IsHighlighted) {
-  batcher->Reset();
+  //batcher->Reset();
   bool isCoreActivity = m_Timer.IsType(Timer::CORE_ACTIVITY);
   bool isSameThreadIdAsSelected =
       isCoreActivity && m_Timer.m_TID == Capture::GSelectedThreadId;
@@ -134,6 +134,6 @@ void TextBox::Draw(Batcher* batcher,
 
   batcher->AddVerticalLine(m_Pos, m_Size[1], z, grey, PickingID::LINE);
 
-  batcher->Draw();
-  batcher->Reset();
+  //batcher->Draw();
+  //batcher->Reset();
 }

--- a/OrbitGl/TextBox.cpp
+++ b/OrbitGl/TextBox.cpp
@@ -78,7 +78,6 @@ void TextBox::Draw(Batcher* batcher,
                    TextRenderer& a_TextRenderer, float a_MinX, bool a_Visible,
                    bool a_RightJustify, bool isInactive, unsigned int a_ID,
                    bool a_IsPicking, bool a_IsHighlighted) {
-  //batcher->Reset();
   bool isCoreActivity = m_Timer.IsType(Timer::CORE_ACTIVITY);
   bool isSameThreadIdAsSelected =
       isCoreActivity && m_Timer.m_TID == Capture::GSelectedThreadId;
@@ -133,7 +132,4 @@ void TextBox::Draw(Batcher* batcher,
   }
 
   batcher->AddVerticalLine(m_Pos, m_Size[1], z, grey, PickingID::LINE);
-
-  //batcher->Draw();
-  //batcher->Reset();
 }

--- a/OrbitGl/TextBox.cpp
+++ b/OrbitGl/TextBox.cpp
@@ -109,7 +109,7 @@ void TextBox::Draw(Batcher* batcher,
 
   if (a_Visible) {
     Box box(m_Pos, m_Size, z);
-    batcher->AddBox(box, color, PickingID::BOX);
+    batcher->AddBox(box, color, PickingID::PICKABLE);
 
     static Color s_Color(255, 255, 255, 255);
 
@@ -131,5 +131,5 @@ void TextBox::Draw(Batcher* batcher,
     }
   }
 
-  batcher->AddVerticalLine(m_Pos, m_Size[1], z, grey, PickingID::LINE);
+  batcher->AddVerticalLine(m_Pos, m_Size[1], z, grey, PickingID::PICKABLE);
 }

--- a/OrbitGl/TextBox.h
+++ b/OrbitGl/TextBox.h
@@ -22,7 +22,8 @@ class TextBox {
 
   ~TextBox();
 
-  void Draw(TextRenderer& a_TextRenderer, float a_MinX = -FLT_MAX,
+  void Draw(Batcher* batcher, 
+            TextRenderer& a_TextRenderer, float a_MinX = -FLT_MAX,
             bool a_Visible = true, bool a_RightJustify = false,
             bool a_IsInactive = false, unsigned int a_ID = 0xFFFFFFFF,
             bool a_IsPicking = false, bool a_IsHighlighted = false);

--- a/OrbitGl/TextBox.h
+++ b/OrbitGl/TextBox.h
@@ -114,8 +114,6 @@ class TextBox {
   bool m_Selected;
   float m_TextY;
   size_t m_ElapsedTimeTextLength;
-
-  Batcher batcher_;
 };
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/TextBox.h
+++ b/OrbitGl/TextBox.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "Batcher.h"
 #include "CoreMath.h"
 #include "ScopeTimer.h"
 
@@ -113,6 +114,8 @@ class TextBox {
   bool m_Selected;
   float m_TextY;
   size_t m_ElapsedTimeTextLength;
+
+  Batcher batcher_;
 };
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/TextRenderer.cpp
+++ b/OrbitGl/TextRenderer.cpp
@@ -154,9 +154,9 @@ void TextRenderer::DrawOutline(Batcher* batcher, vertex_buffer_t* a_Buffer) {
     vertex_t v2 =
         *static_cast<const vertex_t*>(vector_get(a_Buffer->vertices, i2));
 
-    batcher->AddLine(Vec2(v0.x, v0.y), Vec2(v1.x, v1.y), v0.z, color, PickingID::LINE);
-    batcher->AddLine(Vec2(v1.x, v1.y), Vec2(v2.x, v2.y), v1.z, color, PickingID::LINE); 
-    batcher->AddLine(Vec2(v2.x, v2.y), Vec2(v0.x, v0.y), v2.z, color, PickingID::LINE);
+    batcher->AddLine(Vec2(v0.x, v0.y), Vec2(v1.x, v1.y), v0.z, color, PickingID::PICKABLE);
+    batcher->AddLine(Vec2(v1.x, v1.y), Vec2(v2.x, v2.y), v1.z, color, PickingID::PICKABLE);
+    batcher->AddLine(Vec2(v2.x, v2.y), Vec2(v0.x, v0.y), v2.z, color, PickingID::PICKABLE);
   }
 }
 

--- a/OrbitGl/TextRenderer.cpp
+++ b/OrbitGl/TextRenderer.cpp
@@ -85,9 +85,9 @@ void TextRenderer::SetFontSize(int a_Size) {
 }
 
 //-----------------------------------------------------------------------------
-void TextRenderer::Display() {
+void TextRenderer::Display(Batcher* batcher) {
   if (m_DrawOutline) {
-    DrawOutline(m_Buffer);
+    DrawOutline(batcher, m_Buffer);
   }
 
   // Lazy init
@@ -135,8 +135,11 @@ void TextRenderer::Display() {
 }
 
 //-----------------------------------------------------------------------------
-void TextRenderer::DrawOutline(vertex_buffer_t* a_Buffer) {
-  glBegin(GL_LINES);
+void TextRenderer::DrawOutline(Batcher* batcher, vertex_buffer_t* a_Buffer) {
+  batcher->Reset();
+
+  // TODO: No color was set here before. 
+  Color color(255, 255, 255, 255);
 
   for (size_t i = 0; i < a_Buffer->indices->size; i += 3) {
     GLuint i0 =
@@ -153,17 +156,13 @@ void TextRenderer::DrawOutline(vertex_buffer_t* a_Buffer) {
     vertex_t v2 =
         *static_cast<const vertex_t*>(vector_get(a_Buffer->vertices, i2));
 
-    glVertex3f(v0.x, v0.y, v0.z);
-    glVertex3f(v1.x, v1.y, v1.z);
-
-    glVertex3f(v1.x, v1.y, v1.z);
-    glVertex3f(v2.x, v2.y, v2.z);
-
-    glVertex3f(v2.x, v2.y, v2.z);
-    glVertex3f(v0.x, v0.y, v0.z);
+    batcher->AddLine(Vec2(v0.x, v0.y), Vec2(v1.x, v1.y), v0.z, color, PickingID::LINE);
+    batcher->AddLine(Vec2(v1.x, v1.y), Vec2(v2.x, v2.y), v1.z, color, PickingID::LINE); 
+    batcher->AddLine(Vec2(v2.x, v2.y), Vec2(v0.x, v0.y), v2.z, color, PickingID::LINE);
   }
 
-  glEnd();
+  batcher->Draw();
+  batcher->Reset();
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/TextRenderer.cpp
+++ b/OrbitGl/TextRenderer.cpp
@@ -136,8 +136,6 @@ void TextRenderer::Display(Batcher* batcher) {
 
 //-----------------------------------------------------------------------------
 void TextRenderer::DrawOutline(Batcher* batcher, vertex_buffer_t* a_Buffer) {
-  batcher->Reset();
-
   // TODO: No color was set here before. 
   Color color(255, 255, 255, 255);
 
@@ -160,9 +158,6 @@ void TextRenderer::DrawOutline(Batcher* batcher, vertex_buffer_t* a_Buffer) {
     batcher->AddLine(Vec2(v1.x, v1.y), Vec2(v2.x, v2.y), v1.z, color, PickingID::LINE); 
     batcher->AddLine(Vec2(v2.x, v2.y), Vec2(v0.x, v0.y), v2.z, color, PickingID::LINE);
   }
-
-  batcher->Draw();
-  batcher->Reset();
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/TextRenderer.h
+++ b/OrbitGl/TextRenderer.h
@@ -8,6 +8,7 @@
 
 #include <map>
 
+#include "Batcher.h"
 #include "OpenGl.h"
 #include "Platform.h"
 #include "TextBox.h"
@@ -23,7 +24,7 @@ class TextRenderer {
   ~TextRenderer();
 
   void Init();
-  void Display();
+  void Display(Batcher* batcher);
   void AddText(const char* a_Text, float a_X, float a_Y, float a_Z,
                const Color& a_Color, float a_MaxSize = -1.f,
                bool a_RightJustified = false);
@@ -52,7 +53,7 @@ class TextRenderer {
                        float a_Z = -0.01f, bool a_Static = false);
   void ToScreenSpace(float a_X, float a_Y, float& o_X, float& o_Y);
   float ToScreenSpace(float a_Size);
-  void DrawOutline(vertex_buffer_t* a_Buffer);
+  void DrawOutline(Batcher* batcher, vertex_buffer_t* a_Buffer);
 
  private:
   texture_atlas_t* m_Atlas;

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -500,19 +500,19 @@ std::vector<CallstackEvent> TimeGraph::SelectEvents(float a_WorldStart,
 }
 
 //-----------------------------------------------------------------------------
-void TimeGraph::Draw(bool a_Picking) {
+void TimeGraph::Draw(GlCanvas* canvas, bool a_Picking) {
   if ((!a_Picking && m_NeedsUpdatePrimitives) || a_Picking) {
     UpdatePrimitives();
   }
 
-  DrawTracks(a_Picking);
+  DrawTracks(canvas, a_Picking);
   m_Batcher.Draw(a_Picking);
 
   m_NeedsRedraw = false;
 }
 
 //-----------------------------------------------------------------------------
-void TimeGraph::DrawTracks(bool a_Picking) {
+void TimeGraph::DrawTracks(GlCanvas* canvas, bool a_Picking) {
   uint32_t num_cores = GetNumCores();
   m_Layout.SetNumCores(num_cores);
   scheduler_track_->SetLabel(
@@ -535,7 +535,7 @@ void TimeGraph::DrawTracks(bool a_Picking) {
       }
     }
 
-    track->Draw(m_Canvas, a_Picking);
+    track->Draw(canvas, a_Picking);
   }
 }
 
@@ -741,31 +741,9 @@ void TimeGraph::OnDown() {
 }
 
 //----------------------------------------------------------------------------
-void TimeGraph::DrawText() {
+void TimeGraph::DrawText(GlCanvas* canvas) {
   if (m_DrawText) {
-    m_TextRendererStatic.Display(&m_Batcher);
-  }
-}
-
-//-----------------------------------------------------------------------------
-void TimeGraph::DrawMainFrame(TextBox& a_Box) {
-  if (a_Box.GetMainFrameCounter() == -1) {
-    a_Box.SetMainFrameCounter(++m_MainFrameCounter);
-  }
-
-  static unsigned char grey = 180;
-  static Color frameColor(grey, grey, grey, 10);
-
-  if (a_Box.GetMainFrameCounter() % 2 == 0) {
-    float minX = m_SceneBox.GetPosX();
-    TextBox frameBox;
-
-    frameBox.SetPosX(a_Box.GetPosX());
-    frameBox.SetPosY(m_SceneBox.GetPosY());
-    frameBox.SetSizeX(a_Box.GetSize()[0]);
-    frameBox.SetSizeY(m_SceneBox.GetSize()[0]);
-    frameBox.SetColor(frameColor);
-    frameBox.Draw(&m_Batcher, *m_TextRenderer, minX, true, false, false);
+    m_TextRendererStatic.Display(canvas->GetBatcher());
   }
 }
 

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -506,7 +506,7 @@ void TimeGraph::Draw(bool a_Picking) {
   }
 
   DrawTracks(a_Picking);
-  DrawBuffered(a_Picking);
+  m_Batcher.Draw(a_Picking);
 
   m_NeedsRedraw = false;
 }
@@ -744,65 +744,6 @@ void TimeGraph::OnDown() {
 void TimeGraph::DrawText() {
   if (m_DrawText) {
     m_TextRendererStatic.Display();
-  }
-}
-
-//----------------------------------------------------------------------------
-void TimeGraph::DrawBuffered(bool a_Picking) {
-  glPushAttrib(GL_ENABLE_BIT | GL_COLOR_BUFFER_BIT);
-  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-  glDisable(GL_CULL_FACE);
-  glEnableClientState(GL_VERTEX_ARRAY);
-  glEnableClientState(GL_COLOR_ARRAY);
-  glEnable(GL_TEXTURE_2D);
-
-  DrawBoxBuffer(a_Picking);
-  DrawLineBuffer(a_Picking);
-
-  glDisableClientState(GL_COLOR_ARRAY);
-  glDisableClientState(GL_VERTEX_ARRAY);
-  glPopAttrib();
-}
-
-//----------------------------------------------------------------------------
-void TimeGraph::DrawBoxBuffer(bool a_Picking) {
-  Block<Box, BoxBuffer::NUM_BOXES_PER_BLOCK>* boxBlock =
-      m_Batcher.GetBoxBuffer().m_Boxes.m_Root;
-  Block<Color, BoxBuffer::NUM_BOXES_PER_BLOCK * 4>* colorBlock;
-
-  colorBlock = !a_Picking ? m_Batcher.GetBoxBuffer().m_Colors.m_Root
-                          : m_Batcher.GetBoxBuffer().m_PickingColors.m_Root;
-
-  while (boxBlock) {
-    if (int numElems = boxBlock->m_Size) {
-      glVertexPointer(3, GL_FLOAT, sizeof(Vec3), boxBlock->m_Data);
-      glColorPointer(4, GL_UNSIGNED_BYTE, sizeof(Color), colorBlock->m_Data);
-      glDrawArrays(GL_QUADS, 0, numElems * 4);
-    }
-
-    boxBlock = boxBlock->m_Next;
-    colorBlock = colorBlock->m_Next;
-  }
-}
-
-//----------------------------------------------------------------------------
-void TimeGraph::DrawLineBuffer(bool a_Picking) {
-  Block<Line, LineBuffer::NUM_LINES_PER_BLOCK>* lineBlock =
-      m_Batcher.GetLineBuffer().m_Lines.m_Root;
-  Block<Color, LineBuffer::NUM_LINES_PER_BLOCK * 2>* colorBlock;
-
-  colorBlock = !a_Picking ? m_Batcher.GetLineBuffer().m_Colors.m_Root
-                          : m_Batcher.GetLineBuffer().m_PickingColors.m_Root;
-
-  while (lineBlock) {
-    if (int numElems = lineBlock->m_Size) {
-      glVertexPointer(3, GL_FLOAT, sizeof(Vec3), lineBlock->m_Data);
-      glColorPointer(4, GL_UNSIGNED_BYTE, sizeof(Color), colorBlock->m_Data);
-      glDrawArrays(GL_LINES, 0, numElems * 2);
-    }
-
-    lineBlock = lineBlock->m_Next;
-    colorBlock = colorBlock->m_Next;
   }
 }
 

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -743,7 +743,7 @@ void TimeGraph::OnDown() {
 //----------------------------------------------------------------------------
 void TimeGraph::DrawText() {
   if (m_DrawText) {
-    m_TextRendererStatic.Display();
+    m_TextRendererStatic.Display(&m_Batcher);
   }
 }
 
@@ -765,7 +765,7 @@ void TimeGraph::DrawMainFrame(TextBox& a_Box) {
     frameBox.SetSizeX(a_Box.GetSize()[0]);
     frameBox.SetSizeY(m_SceneBox.GetSize()[0]);
     frameBox.SetColor(frameColor);
-    frameBox.Draw(*m_TextRenderer, minX, true, false, false);
+    frameBox.Draw(&m_Batcher, *m_TextRenderer, minX, true, false, false);
   }
 }
 

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -136,7 +136,6 @@ class TimeGraph {
 
   double m_ZoomValue = 0;
   double m_MouseRatio = 0;
-  unsigned int m_MainFrameCounter = 0;
 
   TimeGraphLayout m_Layout;
 

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -28,10 +28,9 @@ class TimeGraph {
  public:
   TimeGraph();
 
-  void Draw(bool a_Picking = false);
-  void DrawTracks(bool a_Picking = false);
-  void DrawMainFrame(TextBox& a_Box);
-  void DrawText();
+  void Draw(GlCanvas* canvas, bool a_Picking = false);
+  void DrawTracks(GlCanvas* canvas, bool a_Picking = false);
+  void DrawText(GlCanvas* canvas);
 
   void NeedsUpdate();
   void UpdatePrimitives();

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -31,9 +31,6 @@ class TimeGraph {
   void Draw(bool a_Picking = false);
   void DrawTracks(bool a_Picking = false);
   void DrawMainFrame(TextBox& a_Box);
-  void DrawLineBuffer(bool a_Picking);
-  void DrawBoxBuffer(bool a_Picking);
-  void DrawBuffered(bool a_Picking);
   void DrawText();
 
   void NeedsUpdate();

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -66,18 +66,18 @@ void DrawTriangleFan(Batcher* batcher, const std::vector<Vec2>& points,
 
   std::vector<Vec2> rotated_points = RotatePoints(points, rotation);
 
-  Vec3 position(pos[0], pos[1], 0.f);
+  Vec3 position(pos[0], pos[1], z);
   std::vector<Triangle> triangles;
 
-  Vec3 pivot = position + Vec3(rotated_points[0][0], rotated_points[0][1], 0.f);
+  Vec3 pivot = position + Vec3(rotated_points[0][0], rotated_points[0][1], z);
 
   Vec3 vertices[2];
   vertices[0] =
-      position + Vec3(rotated_points[1][0], rotated_points[1][1], 0.f);
+      position + Vec3(rotated_points[1][0], rotated_points[1][1], z);
 
   for (int i = 1; i < rotated_points.size() - 1; ++i) {
     vertices[i % 2] = position + Vec3(rotated_points[i + 1][0],
-                                      rotated_points[i + 1][1], 0.f);
+                                      rotated_points[i + 1][1], z);
     Triangle triangle(pivot, vertices[i % 2], vertices[(i + 1) % 2]);
     batcher->AddTriangle(triangle, color, PickingID::TRIANGLE);
   }

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -86,7 +86,6 @@ void DrawTriangleFan(Batcher* batcher, const std::vector<Vec2>& points,
 //-----------------------------------------------------------------------------
 void Track::Draw(GlCanvas* canvas, bool picking) {
   Batcher* batcher = canvas->GetBatcher();
-  batcher->Reset();
 
   const TimeGraphLayout& layout = time_graph_->GetLayout();
   Color picking_color = canvas->GetPickingManager().GetPickableColor(this);
@@ -140,9 +139,6 @@ void Track::Draw(GlCanvas* canvas, bool picking) {
     DrawTriangleFan(batcher, rounded_corner, end_bottom, kBackgroundColor, 90.f, z);
     DrawTriangleFan(batcher, rounded_corner, end_top, kBackgroundColor, 180.f, z);
   }
-
-  batcher->Draw();
-  batcher->Reset();
 
   // Collapse toggle state management.
   if (!this->IsCollapsable()) {

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -43,6 +43,7 @@ std::vector<Vec2> GetRoundedCornerMask(float radius, uint32_t num_sides) {
   return points;
 }
 
+//-----------------------------------------------------------------------------
 std::vector<Vec2> RotatePoints(const std::vector<Vec2>& points,
                                float rotation) {
   float cos_r = cosf(kPiFloat * rotation / 180.f);
@@ -65,10 +66,7 @@ void DrawTriangleFan(Batcher* batcher, const std::vector<Vec2>& points,
   }
 
   std::vector<Vec2> rotated_points = RotatePoints(points, rotation);
-
   Vec3 position(pos[0], pos[1], z);
-  std::vector<Triangle> triangles;
-
   Vec3 pivot = position + Vec3(rotated_points[0][0], rotated_points[0][1], z);
 
   Vec3 vertices[2];

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -77,7 +77,7 @@ void DrawTriangleFan(Batcher* batcher, const std::vector<Vec2>& points,
     vertices[i % 2] = position + Vec3(rotated_points[i + 1][0],
                                       rotated_points[i + 1][1], z);
     Triangle triangle(pivot, vertices[i % 2], vertices[(i + 1) % 2]);
-    batcher->AddTriangle(triangle, color, PickingID::TRIANGLE);
+    batcher->AddTriangle(triangle, color, PickingID::PICKABLE);
   }
 }
 
@@ -86,7 +86,8 @@ void Track::Draw(GlCanvas* canvas, bool picking) {
   Batcher* batcher = canvas->GetBatcher();
 
   const TimeGraphLayout& layout = time_graph_->GetLayout();
-  Color picking_color = canvas->GetPickingManager().GetPickableColor(this);
+  Color picking_color =
+    canvas->GetPickingManager().GetPickableColor(this, PickingID::BatcherId::UI);
   const Color kTabColor(50, 50, 50, 255);
   Color color = picking ? picking_color : kTabColor;
   glColor4ubv(&color[0]);
@@ -103,7 +104,7 @@ void Track::Draw(GlCanvas* canvas, bool picking) {
   if (!picking) {
     if (layout.GetDrawTrackBackground()) {
       Box box(Vec2(x0, y0 + top_margin), Vec2(m_Size[0], -m_Size[1] - top_margin), track_z);
-      batcher->AddBox(box, color, PickingID::BOX);
+      batcher->AddBox(box, color, PickingID::PICKABLE);
     }
   }
 
@@ -114,7 +115,7 @@ void Track::Draw(GlCanvas* canvas, bool picking) {
   float tab_x0 = x0 + layout.GetTrackTabOffset();
 
   Box box(Vec2(tab_x0, y0), Vec2(label_width, label_height), track_z);
-  batcher->AddBox(box, color, PickingID::BOX);
+  batcher->AddBox(box, color, PickingID::PICKABLE);
 
   // Draw rounded corners.
   float vertical_margin = time_graph_->GetVerticalMargin();

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -60,6 +60,9 @@ void DrawTriangleFan(const std::vector<Vec2>& points, const Vec2& pos,
 
 //-----------------------------------------------------------------------------
 void Track::Draw(GlCanvas* canvas, bool picking) {
+  Batcher* batcher = canvas->GetBatcher();
+  batcher->Reset();
+
   const TimeGraphLayout& layout = time_graph_->GetLayout();
   Color picking_color = canvas->GetPickingManager().GetPickableColor(this);
   const Color kTabColor(50, 50, 50, 255);
@@ -77,12 +80,8 @@ void Track::Draw(GlCanvas* canvas, bool picking) {
   // Draw track background.
   if (!picking) {
     if (layout.GetDrawTrackBackground()) {
-      glBegin(GL_QUADS);
-      glVertex3f(x0, y0 + top_margin, track_z);
-      glVertex3f(x1, y0 + top_margin, track_z);
-      glVertex3f(x1, y1, track_z);
-      glVertex3f(x0, y1, track_z);
-      glEnd();
+      Box box(Vec2(x0, y0 + top_margin), Vec2(m_Size[0], -m_Size[1] - top_margin), track_z);
+      batcher->AddBox(box, color, PickingID::BOX);
     }
   }
 
@@ -91,12 +90,12 @@ void Track::Draw(GlCanvas* canvas, bool picking) {
   float half_label_height = 0.5f * label_height;
   float label_width = layout.GetTrackTabWidth();
   float tab_x0 = x0 + layout.GetTrackTabOffset();
-  glBegin(GL_QUADS);
-  glVertex3f(tab_x0, y0, track_z);
-  glVertex3f(tab_x0 + label_width, y0, track_z);
-  glVertex3f(tab_x0 + label_width, y0 + label_height, track_z);
-  glVertex3f(tab_x0, y0 + label_height, track_z);
-  glEnd();
+
+  Box box(Vec2(tab_x0, y0), Vec2(label_width, label_height), track_z);
+  batcher->AddBox(box, color, PickingID::BOX);
+
+  batcher->Draw();
+  batcher->Reset();
 
   // Draw rounded corners.
   float vertical_margin = time_graph_->GetVerticalMargin();

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -45,8 +45,8 @@ std::vector<Vec2> GetRoundedCornerMask(float radius, uint32_t num_sides) {
 
 std::vector<Vec2> RotatePoints(const std::vector<Vec2>& points,
                                float rotation) {
-  float cos_r = std::cosf(kPiFloat * rotation / 180.f);
-  float sin_r = std::sinf(kPiFloat * rotation / 180.f);
+  float cos_r = cosf(kPiFloat * rotation / 180.f);
+  float sin_r = sinf(kPiFloat * rotation / 180.f);
   std::vector<Vec2> result;
   for (const Vec2 point : points) {
     float x_rotated = cos_r * point[0] - sin_r * point[1];

--- a/OrbitGl/TriangleToggle.cpp
+++ b/OrbitGl/TriangleToggle.cpp
@@ -23,7 +23,7 @@ void TriangleToggle::Draw(GlCanvas* canvas, bool picking) {
 
   if (picking) {
     PickingManager& picking_manager = canvas->GetPickingManager();
-    color = picking_manager.GetPickableColor(this);
+    color = picking_manager.GetPickableColor(this, PickingID::BatcherId::UI);
   }
 
   // Draw triangle.
@@ -44,14 +44,14 @@ void TriangleToggle::Draw(GlCanvas* canvas, bool picking) {
         position + Vec3(-half_w, half_h, 0.f), 
         position + Vec3(0.f, -half_w, 0.f));
     }
-    batcher->AddTriangle(triangle, color, PickingID::TRIANGLE);
+    batcher->AddTriangle(triangle, color, PickingID::PICKABLE);
   } else {
     // When picking, draw a big square for easier picking.
     float original_width = 2 * half_w;
     float large_width = 2 * original_width;
     Box box(Vec2(pos_[0] - original_width, pos_[1] - original_width),
       Vec2(large_width, large_width), 0.f);
-    batcher->AddBox(box, color, PickingID::BOX);
+    batcher->AddBox(box, color, PickingID::PICKABLE);
   }
 }
 

--- a/OrbitGl/TriangleToggle.cpp
+++ b/OrbitGl/TriangleToggle.cpp
@@ -31,20 +31,21 @@ void TriangleToggle::Draw(GlCanvas* canvas, bool picking) {
   static float half_sqrt_three = 0.5f * sqrtf(3.f);
   float half_w = 0.5f * size_;
   float half_h = half_sqrt_three * half_w;
-  glPushMatrix();
-  glTranslatef(pos_[0], pos_[1], 0);
-  if (state_ == State::kCollapsed) {
-    glRotatef(90.f, 0, 0, 1.f);
-  }
-
-  glColor4ubv(&color[0]);
 
   if (!picking) {
-    glBegin(GL_TRIANGLES);
-    glVertex3f(half_w, half_h, 0);
-    glVertex3f(-half_w, half_h, 0);
-    glVertex3f(0, -half_w, 0);
-    glEnd();
+    Vec3 position(pos_[0], pos_[1], 0.0f);
+
+    Triangle triangle;
+    if (state_ == State::kCollapsed) {
+      triangle = Triangle(position + Vec3(-half_h, half_w, 0.f),
+        position + Vec3(-half_h, -half_w, 0.f),
+        position + Vec3(half_w, 0.f, 0.f));
+    } else {
+      triangle = Triangle(position + Vec3(half_w, half_h, 0.f), 
+        position + Vec3(-half_w, half_h, 0.f), 
+        position + Vec3(0.f, -half_w, 0.f));
+    }
+    batcher->AddTriangle(triangle, color, PickingID::TRIANGLE);
   } else {
     // When picking, draw a big square for easier picking.
     float original_width = 2 * half_w;
@@ -53,8 +54,6 @@ void TriangleToggle::Draw(GlCanvas* canvas, bool picking) {
       Vec2(large_width, large_width), 0.f);
     batcher->AddBox(box, color, PickingID::BOX);
   }
-
-  glPopMatrix();
 
   batcher->Draw();
   batcher->Reset();

--- a/OrbitGl/TriangleToggle.cpp
+++ b/OrbitGl/TriangleToggle.cpp
@@ -15,6 +15,9 @@ TriangleToggle::TriangleToggle(State initial_state, StateChangeHandler handler,
       time_graph_(time_graph) {}
 
 void TriangleToggle::Draw(GlCanvas* canvas, bool picking) {
+  Batcher* batcher = canvas->GetBatcher();
+  batcher->Reset();
+
   const Color kWhite(255, 255, 255, 255);
   const Color kGrey(100, 100, 100, 255);
   Color color = state_ == State::kInactive ? kGrey : kWhite;
@@ -44,17 +47,17 @@ void TriangleToggle::Draw(GlCanvas* canvas, bool picking) {
     glEnd();
   } else {
     // When picking, draw a big square for easier picking.
-    const float scale = 2.f;
-    glScalef(scale, scale, scale);
-    glBegin(GL_QUADS);
-    glVertex3f(half_w, half_w, 0);
-    glVertex3f(-half_w, half_w, 0);
-    glVertex3f(-half_w, -half_w, 0);
-    glVertex3f(half_w, -half_w, 0);
-    glEnd();
+    float original_width = 2 * half_w;
+    float large_width = 2 * original_width;
+    Box box(Vec2(pos_[0] - original_width, pos_[1] - original_width),
+      Vec2(large_width, large_width), 0.f);
+    batcher->AddBox(box, color, PickingID::BOX);
   }
 
   glPopMatrix();
+
+  batcher->Draw();
+  batcher->Reset();
 }
 
 void TriangleToggle::OnPick(int /*x*/, int /*y*/) {}

--- a/OrbitGl/TriangleToggle.cpp
+++ b/OrbitGl/TriangleToggle.cpp
@@ -16,7 +16,6 @@ TriangleToggle::TriangleToggle(State initial_state, StateChangeHandler handler,
 
 void TriangleToggle::Draw(GlCanvas* canvas, bool picking) {
   Batcher* batcher = canvas->GetBatcher();
-  batcher->Reset();
 
   const Color kWhite(255, 255, 255, 255);
   const Color kGrey(100, 100, 100, 255);
@@ -54,9 +53,6 @@ void TriangleToggle::Draw(GlCanvas* canvas, bool picking) {
       Vec2(large_width, large_width), 0.f);
     batcher->AddBox(box, color, PickingID::BOX);
   }
-
-  batcher->Draw();
-  batcher->Reset();
 }
 
 void TriangleToggle::OnPick(int /*x*/, int /*y*/) {}


### PR DESCRIPTION
This PR removes all instances of using glBegin/glEnd for drawing ("OpenGL immediate mode"). These calls are replaced by pushing primitives into a batcher (Batcher class) that is used for drawing all UI elements.

There are two batcher instances being used: One for drawing UI elements (member of GlCanvas), and one for drawing events on the timeline (Timer, callstack events; member of TimeGraph). The batcher in TimeGraph existed before. The one in GlCanvas is added here. It is pushed through all calls for drawing UI elements and these methods just add whatever elements they want to draw to the batcher. 

With the current batcher capabilities, some vertex transformations had to be implemented on the CPU (rotation for the toggle triangle, rotation for the rounded corners). 