### PR TITLE
Switch Imgui t use more modern OpenGL.

### DIFF
--- a/OrbitGl/ImGuiOrbit.cpp
+++ b/OrbitGl/ImGuiOrbit.cpp
@@ -602,7 +602,7 @@ void Orbit_ImGui_RenderDrawLists(ImDrawData* draw_data) {
   else
     glDisable(GL_SCISSOR_TEST);
 #ifdef GL_POLYGON_MODE
-  glPolygonMode(GL_FRONT_AND_BACK, (GLenum)last_polygon_mode[0]);
+  glPolygonMode(GL_FRONT_AND_BACK, static_cast<GLenum>(last_polygon_mode[0]));
 #endif
   glViewport(last_viewport[0], last_viewport[1], (GLsizei)last_viewport[2],
              (GLsizei)last_viewport[3]);

--- a/OrbitGl/ImGuiOrbit.cpp
+++ b/OrbitGl/ImGuiOrbit.cpp
@@ -81,14 +81,15 @@ static bool CheckShader(GLuint handle, const char* desc) {
   glGetShaderiv(handle, GL_INFO_LOG_LENGTH, &log_length);
   if (log_length > 1) {
     ImVector<char> buf;
-    buf.resize((int)(log_length + 1));
-    glGetShaderInfoLog(handle, log_length, NULL, (GLchar*)buf.begin());
+    buf.resize(static_cast<int>(log_length + 1));
+    glGetShaderInfoLog(handle, log_length, NULL,
+                       static_cast<GLchar*>(buf.begin()));
     LOG("Log from shader compilation: %s", buf.begin());
   }
-  if ((GLboolean)status == GL_FALSE) {
+  if (static_cast<GLboolean>(status) == GL_FALSE) {
     FATAL("Orbit_ImGui_CreateDeviceObjects: failed to compile %s!", desc);
   }
-  return (GLboolean)status == GL_TRUE;
+  return static_cast<GLboolean>(status) == GL_TRUE;
 }
 
 // If you get an error please report on GitHub. You may try different GL context
@@ -99,14 +100,15 @@ static bool CheckProgram(GLuint handle, const char* desc) {
   glGetProgramiv(handle, GL_INFO_LOG_LENGTH, &log_length);
   if (log_length > 1) {
     ImVector<char> buf;
-    buf.resize((int)(log_length + 1));
-    glGetProgramInfoLog(handle, log_length, NULL, (GLchar*)buf.begin());
+    buf.resize(static_cast<int>(log_length + 1));
+    glGetProgramInfoLog(handle, log_length, NULL,
+                        static_cast<GLchar*>(buf.begin()));
     LOG("Log from shader program linking: %s", buf.begin());
   }
-  if ((GLboolean)status == GL_FALSE) {
+  if (static_cast<GLboolean>(status) == GL_FALSE) {
     FATAL("Orbit_ImGui_CreateDeviceObjects: failed to link %s!", desc);
   }
-  return (GLboolean)status == GL_TRUE;
+  return static_cast<GLboolean>(status) == GL_TRUE;
 }
 
 bool Orbit_ImGui_CreateTextures() {
@@ -175,7 +177,8 @@ bool Orbit_ImGui_CreateTextures() {
                record_image.pixel_data);
 
   // Store our identifier
-  io.Fonts->TexID = (ImTextureID)(intptr_t)g_FontTexture;
+  io.Fonts->TexID =
+      reinterpret_cast<ImTextureID>(static_cast<intptr_t>(g_FontTexture));
 
   // Restore state
   glBindTexture(GL_TEXTURE_2D, last_texture);
@@ -387,15 +390,15 @@ void SetupImGuiStyle(bool bStyleDark_, float alpha_) {
 void Orbit_ImGui_RenderDrawLists(ImDrawData* draw_data) {
   // Avoid rendering when minimized, scale coordinates for retina displays
   // (screen coordinates != framebuffer coordinates)
-  int fb_width =
-      (int)(draw_data->DisplaySize.x * draw_data->FramebufferScale.x);
-  int fb_height =
-      (int)(draw_data->DisplaySize.y * draw_data->FramebufferScale.y);
+  int fb_width = static_cast<int>(draw_data->DisplaySize.x *
+                                  draw_data->FramebufferScale.x);
+  int fb_height = static_cast<int>(draw_data->DisplaySize.y *
+                                   draw_data->FramebufferScale.y);
   if (fb_width <= 0 || fb_height <= 0) return;
 
-    // Backup GL state
-  GLenum last_active_texture;
-  glGetIntegerv(GL_ACTIVE_TEXTURE, (GLint*)&last_active_texture);
+  // Backup GL state
+  GLint last_active_texture;
+  glGetIntegerv(GL_ACTIVE_TEXTURE, static_cast<GLint*>(&last_active_texture));
   glActiveTexture(GL_TEXTURE0);
   GLint last_program;
   glGetIntegerv(GL_CURRENT_PROGRAM, &last_program);
@@ -419,18 +422,18 @@ void Orbit_ImGui_RenderDrawLists(ImDrawData* draw_data) {
   glGetIntegerv(GL_VIEWPORT, last_viewport);
   GLint last_scissor_box[4];
   glGetIntegerv(GL_SCISSOR_BOX, last_scissor_box);
-  GLenum last_blend_src_rgb;
-  glGetIntegerv(GL_BLEND_SRC_RGB, (GLint*)&last_blend_src_rgb);
-  GLenum last_blend_dst_rgb;
-  glGetIntegerv(GL_BLEND_DST_RGB, (GLint*)&last_blend_dst_rgb);
-  GLenum last_blend_src_alpha;
-  glGetIntegerv(GL_BLEND_SRC_ALPHA, (GLint*)&last_blend_src_alpha);
-  GLenum last_blend_dst_alpha;
-  glGetIntegerv(GL_BLEND_DST_ALPHA, (GLint*)&last_blend_dst_alpha);
-  GLenum last_blend_equation_rgb;
-  glGetIntegerv(GL_BLEND_EQUATION_RGB, (GLint*)&last_blend_equation_rgb);
-  GLenum last_blend_equation_alpha;
-  glGetIntegerv(GL_BLEND_EQUATION_ALPHA, (GLint*)&last_blend_equation_alpha);
+  GLint last_blend_src_rgb;
+  glGetIntegerv(GL_BLEND_SRC_RGB, &last_blend_src_rgb);
+  GLint last_blend_dst_rgb;
+  glGetIntegerv(GL_BLEND_DST_RGB, &last_blend_dst_rgb);
+  GLint last_blend_src_alpha;
+  glGetIntegerv(GL_BLEND_SRC_ALPHA, &last_blend_src_alpha);
+  GLint last_blend_dst_alpha;
+  glGetIntegerv(GL_BLEND_DST_ALPHA, &last_blend_dst_alpha);
+  GLint last_blend_equation_rgb;
+  glGetIntegerv(GL_BLEND_EQUATION_RGB, &last_blend_equation_rgb);
+  GLint last_blend_equation_alpha;
+  glGetIntegerv(GL_BLEND_EQUATION_ALPHA, &last_blend_equation_alpha);
   GLboolean last_enable_blend = glIsEnabled(GL_BLEND);
   GLboolean last_enable_cull_face = glIsEnabled(GL_CULL_FACE);
   GLboolean last_enable_depth_test = glIsEnabled(GL_DEPTH_TEST);

--- a/OrbitGl/ImGuiOrbit.cpp
+++ b/OrbitGl/ImGuiOrbit.cpp
@@ -25,9 +25,12 @@
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
 
+
+ImFont* GOrbitImguiFont;
+
+namespace {
+
 // Data
-struct GLFWwindow {};
-// static GLFWwindow*  g_Window = NULL;
 static bool g_MousePressed[3] = {false, false, false};
 static float g_MouseWheel = 0.0f;
 static GLuint g_FontTexture = 0;
@@ -36,6 +39,185 @@ GLuint GTextureInjected = 0;
 GLuint GTextureTimer = 0;
 GLuint GTextureHelp = 0;
 GLuint GTextureRecord = 0;
+
+void Orbit_ImGui_InvalidateDeviceObjects() {
+  if (g_FontTexture) {
+    glDeleteTextures(1, &g_FontTexture);
+    ImGui::GetIO().Fonts->TexID = 0;
+    g_FontTexture = 0;
+  }
+}
+
+bool Orbit_ImGui_CreateDeviceObjects() {
+  // Build texture atlas
+  ImGuiIO& io = ImGui::GetIO();
+  unsigned char* pixels;
+  int width, height;
+  io.Fonts->GetTexDataAsAlpha8(&pixels, &width, &height);
+
+  // Upload texture to graphics system
+  GLint last_texture;
+  glGetIntegerv(GL_TEXTURE_BINDING_2D, &last_texture);
+  glGenTextures(1, &g_FontTexture);
+  glBindTexture(GL_TEXTURE_2D, g_FontTexture);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_ALPHA, width, height, 0, GL_ALPHA,
+               GL_UNSIGNED_BYTE, pixels);
+
+  glGenTextures(1, &GTextureInjected);
+  glBindTexture(GL_TEXTURE_2D, GTextureInjected);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, inject_image.width,
+               inject_image.height, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+               inject_image.pixel_data);
+
+  glGenTextures(1, &GTextureTimer);
+  glBindTexture(GL_TEXTURE_2D, GTextureTimer);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, inject_image.width,
+               inject_image.height, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+               timer_image.pixel_data);
+
+  glGenTextures(1, &GTextureHelp);
+  glBindTexture(GL_TEXTURE_2D, GTextureHelp);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, help_image.width, help_image.height,
+               0, GL_RGBA, GL_UNSIGNED_BYTE, help_image.pixel_data);
+
+  glGenTextures(1, &GTextureRecord);
+  glBindTexture(GL_TEXTURE_2D, GTextureRecord);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, record_image.width,
+               record_image.height, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+               record_image.pixel_data);
+
+  // Restore state
+  glBindTexture(GL_TEXTURE_2D, last_texture);
+
+  return true;
+}
+
+// Simple helper function to load an image into a OpenGL texture with common
+// settings
+bool LoadTextureFromFile(const char* filename, uint32_t* out_texture,
+                         int* out_width, int* out_height) {
+  // Load from file
+  int image_width = 0;
+  int image_height = 0;
+  unsigned char* image_data =
+      stbi_load(filename, &image_width, &image_height, nullptr, 4);
+  if (image_data == nullptr) return false;
+
+  // Create an OpenGL texture identifier
+  GLuint image_texture;
+  glGenTextures(1, &image_texture);
+  glBindTexture(GL_TEXTURE_2D, image_texture);
+
+  // Setup filtering parameters for display
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+
+  // Upload pixels into texture
+  glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, image_width, image_height, 0, GL_RGBA,
+               GL_UNSIGNED_BYTE, image_data);
+  stbi_image_free(image_data);
+
+  *out_texture = image_texture;
+  *out_width = image_width;
+  *out_height = image_height;
+
+  return true;
+}
+
+// From Avoid/Doug Binks
+void SetupImGuiStyle(bool bStyleDark_, float alpha_) {
+  ImGuiStyle& style = ImGui::GetStyle();
+
+  // light style from Pacome Danhiez (user itamago)
+  // https://github.com/ocornut/imgui/pull/511#issuecomment-175719267
+  style.Alpha = 1.0f;
+  style.FrameRounding = 3.0f;
+  style.Colors[ImGuiCol_Text] = ImVec4(0.00f, 0.00f, 0.00f, 1.00f);
+  style.Colors[ImGuiCol_TextDisabled] = ImVec4(0.60f, 0.60f, 0.60f, 1.00f);
+  style.Colors[ImGuiCol_WindowBg] = ImVec4(0.94f, 0.94f, 0.94f, 0.94f);
+  style.Colors[ImGuiCol_ChildWindowBg] = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
+  // style.Colors[ImGuiCol_PopupBg] = ImVec4( 1.00f, 1.00f, 1.00f, 0.94f );
+  style.Colors[ImGuiCol_Border] = ImVec4(0.00f, 0.00f, 0.00f, 0.19f);
+  style.Colors[ImGuiCol_BorderShadow] = ImVec4(1.00f, 1.00f, 1.00f, 0.10f);
+  style.Colors[ImGuiCol_FrameBg] = ImVec4(0.16f, 0.29f, 0.48f, 0.54f);
+  style.Colors[ImGuiCol_FrameBgHovered] = ImVec4(0.26f, 0.59f, 0.98f, 0.40f);
+  style.Colors[ImGuiCol_FrameBgActive] = ImVec4(0.26f, 0.59f, 0.98f, 0.67f);
+  style.Colors[ImGuiCol_TitleBg] = ImVec4(0.96f, 0.96f, 0.96f, 1.00f);
+  style.Colors[ImGuiCol_TitleBgCollapsed] = ImVec4(1.00f, 1.00f, 1.00f, 0.51f);
+  style.Colors[ImGuiCol_TitleBgActive] = ImVec4(0.82f, 0.82f, 0.82f, 1.00f);
+  style.Colors[ImGuiCol_MenuBarBg] = ImVec4(0.86f, 0.86f, 0.86f, 1.00f);
+  style.Colors[ImGuiCol_ScrollbarBg] = ImVec4(0.98f, 0.98f, 0.98f, 0.53f);
+  style.Colors[ImGuiCol_ScrollbarGrab] = ImVec4(0.69f, 0.69f, 0.69f, 1.00f);
+  style.Colors[ImGuiCol_ScrollbarGrabHovered] =
+      ImVec4(0.59f, 0.59f, 0.59f, 1.00f);
+  style.Colors[ImGuiCol_ScrollbarGrabActive] =
+      ImVec4(0.49f, 0.49f, 0.49f, 1.00f);
+  // style.Colors[ImGuiCol_ComboBg] = ImVec4( 0.86f, 0.86f, 0.86f, 0.99f );
+  style.Colors[ImGuiCol_CheckMark] = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
+  style.Colors[ImGuiCol_SliderGrab] = ImVec4(0.24f, 0.52f, 0.88f, 1.00f);
+  style.Colors[ImGuiCol_SliderGrabActive] = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
+  style.Colors[ImGuiCol_Button] = ImVec4(0.26f, 0.59f, 0.98f, 0.40f);
+  style.Colors[ImGuiCol_ButtonHovered] = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
+  style.Colors[ImGuiCol_ButtonActive] = ImVec4(0.06f, 0.53f, 0.98f, 1.00f);
+  style.Colors[ImGuiCol_Header] = ImVec4(0.26f, 0.59f, 0.98f, 0.31f);
+  style.Colors[ImGuiCol_HeaderHovered] = ImVec4(0.26f, 0.59f, 0.98f, 0.80f);
+  style.Colors[ImGuiCol_HeaderActive] = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
+  style.Colors[ImGuiCol_Separator] = ImVec4(0.39f, 0.39f, 0.39f, 1.00f);
+  style.Colors[ImGuiCol_SeparatorHovered] = ImVec4(0.26f, 0.59f, 0.98f, 0.78f);
+  style.Colors[ImGuiCol_SeparatorActive] = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
+  style.Colors[ImGuiCol_ResizeGrip] = ImVec4(0.26f, 0.59f, 0.98f, 0.25f);
+  style.Colors[ImGuiCol_ResizeGripHovered] = ImVec4(0.26f, 0.59f, 0.98f, 0.67f);
+  style.Colors[ImGuiCol_ResizeGripActive] = ImVec4(0.26f, 0.59f, 0.98f, 0.95f);
+  // style.Colors[ImGuiCol_CloseButton] = ImVec4( 0.59f, 0.59f, 0.59f, 0.50f );
+  // style.Colors[ImGuiCol_CloseButtonHovered] = ImVec4( 0.98f, 0.39f,
+  // 0.36f, 1.00f ); style.Colors[ImGuiCol_CloseButtonActive] = ImVec4( 0.98f,
+  // 0.39f, 0.36f, 1.00f );
+  style.Colors[ImGuiCol_PlotLines] = ImVec4(0.39f, 0.39f, 0.39f, 1.00f);
+  style.Colors[ImGuiCol_PlotLinesHovered] = ImVec4(1.00f, 0.43f, 0.35f, 1.00f);
+  style.Colors[ImGuiCol_PlotHistogram] = ImVec4(0.90f, 0.70f, 0.00f, 1.00f);
+  style.Colors[ImGuiCol_PlotHistogramHovered] =
+      ImVec4(1.00f, 0.60f, 0.00f, 1.00f);
+  style.Colors[ImGuiCol_TextSelectedBg] = ImVec4(0.26f, 0.59f, 0.98f, 0.35f);
+  style.Colors[ImGuiCol_ModalWindowDarkening] =
+      ImVec4(0.20f, 0.20f, 0.20f, 0.35f);
+
+  if (bStyleDark_) {
+    for (int i = 0; i <= ImGuiCol_COUNT; i++) {
+      ImVec4& col = style.Colors[i];
+      float H, S, V;
+      ImGui::ColorConvertRGBtoHSV(col.x, col.y, col.z, H, S, V);
+
+      if (S < 0.1f) {
+        V = 1.0f - V;
+      }
+      ImGui::ColorConvertHSVtoRGB(H, S, V, col.x, col.y, col.z);
+      if (col.w < 1.00f) {
+        col.w *= alpha_;
+      }
+    }
+  } else {
+    for (int i = 0; i <= ImGuiCol_COUNT; i++) {
+      ImVec4& col = style.Colors[i];
+      if (col.w < 1.00f) {
+        col.x *= alpha_;
+        col.y *= alpha_;
+        col.z *= alpha_;
+        col.w *= alpha_;
+      }
+    }
+  }
+}
 
 // This is the main rendering function that you have to implement and provide to
 // ImGui (via setting up 'RenderDrawListsFn' in the ImGuiIO structure) If text
@@ -132,13 +314,15 @@ void Orbit_ImGui_RenderDrawLists(ImDrawData* draw_data) {
              static_cast<GLsizei>(last_viewport[3]));
 }
 
-const char* Orbit_ImGui_GetClipboardText() {
-  return nullptr;  // return glfwGetClipboardString(g_Window);
+ImFont* AddOrbitFont(float pixel_size) {
+  const auto exe_path = Path::GetExecutablePath();
+  const auto font_file_name = exe_path + "fonts/Vera.ttf";
+  return ImGui::GetIO().Fonts->AddFontFromFileTTF(font_file_name.c_str(),
+                                                  pixel_size);
 }
 
-void Orbit_ImGui_SetClipboardText(const char*) {
-  // TODO
-}
+}  // namespace
+
 
 void Orbit_ImGui_MouseButtonCallback(GlCanvas* a_GlCanvas, int button,
                                      bool down) {
@@ -170,39 +354,6 @@ void Orbit_ImGui_CharCallback(GlCanvas* a_GlCanvas, unsigned int c) {
   if (c > 0 && c < 0x10000) io.AddInputCharacter(static_cast<uint16_t>(c));
 }
 
-// Simple helper function to load an image into a OpenGL texture with common
-// settings
-bool LoadTextureFromFile(const char* filename, uint32_t* out_texture,
-                         int* out_width, int* out_height) {
-  // Load from file
-  int image_width = 0;
-  int image_height = 0;
-  unsigned char* image_data =
-      stbi_load(filename, &image_width, &image_height, nullptr, 4);
-  if (image_data == nullptr) return false;
-
-  // Create an OpenGL texture identifier
-  GLuint image_texture;
-  glGenTextures(1, &image_texture);
-  glBindTexture(GL_TEXTURE_2D, image_texture);
-
-  // Setup filtering parameters for display
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-
-  // Upload pixels into texture
-  glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, image_width, image_height, 0, GL_RGBA,
-               GL_UNSIGNED_BYTE, image_data);
-  stbi_image_free(image_data);
-
-  *out_texture = image_texture;
-  *out_width = image_width;
-  *out_height = image_height;
-
-  return true;
-}
-
 uint32_t LoadTextureFromFile(const char* file_name) {
   uint32_t texture_id = 0;
   int image_width = 0;
@@ -215,332 +366,7 @@ uint32_t LoadTextureFromFile(const char* file_name) {
   return texture_id;
 }
 
-bool Orbit_ImGui_CreateDeviceObjects() {
-  // Build texture atlas
-  ImGuiIO& io = ImGui::GetIO();
-  unsigned char* pixels;
-  int width, height;
-  io.Fonts->GetTexDataAsAlpha8(&pixels, &width, &height);
-
-  // Upload texture to graphics system
-  GLint last_texture;
-  glGetIntegerv(GL_TEXTURE_BINDING_2D, &last_texture);
-  glGenTextures(1, &g_FontTexture);
-  glBindTexture(GL_TEXTURE_2D, g_FontTexture);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_ALPHA, width, height, 0, GL_ALPHA,
-               GL_UNSIGNED_BYTE, pixels);
-
-  glGenTextures(1, &GTextureInjected);
-  glBindTexture(GL_TEXTURE_2D, GTextureInjected);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, inject_image.width,
-               inject_image.height, 0, GL_RGBA, GL_UNSIGNED_BYTE,
-               inject_image.pixel_data);
-
-  glGenTextures(1, &GTextureTimer);
-  glBindTexture(GL_TEXTURE_2D, GTextureTimer);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, inject_image.width,
-               inject_image.height, 0, GL_RGBA, GL_UNSIGNED_BYTE,
-               timer_image.pixel_data);
-
-  glGenTextures(1, &GTextureHelp);
-  glBindTexture(GL_TEXTURE_2D, GTextureHelp);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, help_image.width, help_image.height,
-               0, GL_RGBA, GL_UNSIGNED_BYTE, help_image.pixel_data);
-
-  glGenTextures(1, &GTextureRecord);
-  glBindTexture(GL_TEXTURE_2D, GTextureRecord);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, record_image.width,
-               record_image.height, 0, GL_RGBA, GL_UNSIGNED_BYTE,
-               record_image.pixel_data);
-
-  // Restore state
-  glBindTexture(GL_TEXTURE_2D, last_texture);
-
-  return true;
-}
-
-void Orbit_ImGui_InvalidateDeviceObjects() {
-  if (g_FontTexture) {
-    glDeleteTextures(1, &g_FontTexture);
-    ImGui::GetIO().Fonts->TexID = 0;
-    g_FontTexture = 0;
-  }
-}
-
-ImFont* GOrbitImguiFont;
-
-//-----------------------------------------------------------------------------
-// ProggyClean.ttf
-// Copyright (c) 2004, 2005 Tristan Grimmer
-// MIT license (see License.txt in
-// http://www.upperbounds.net/download/ProggyClean.ttf.zip) Download and more
-// information at http://upperbounds.net
-//-----------------------------------------------------------------------------
-// File: 'ProggyClean.ttf' (41208 bytes)
-// Exported using binary_to_compressed_c.cpp
-//-----------------------------------------------------------------------------
-static const char proggy_clean_ttf_compressed_data_base85[11980 + 1] =
-    "7])#######hV0qs'/###[),##/l:$#Q6>##5[n42>c-TH`->>#/"
-    "e>11NNV=Bv(*:.F?uu#(gRU.o0XGH`$vhLG1hxt9?W`#,5LsCp#-i>.r$<$6pD>Lb';"
-    "9Crc6tgXmKVeU2cD4Eo3R/"
-    "2*>]b(MC;$jPfY.;h^`IWM9<Lh2TlS+f-s$o6Q<BWH`YiU.xfLq$N;$0iR/GX:U(jcW2p/"
-    "W*q?-qmnUCI;jHSAiFWM.R*kU@C=GH?a9wp8f$e.-4^Qg1)Q-GL(lf(r/7GrRgwV%MS=C#"
-    "`8ND>Qo#t'X#(v#Y9w0#1D$CIf;W'#pWUPXOuxXuU(H9M(1<q-UE31#^-V'8IRUo7Qf./"
-    "L>=Ke$$'5F%)]0^#0X@U.a<r:QLtFsLcL6##lOj)#.Y5<-R&KgLwqJfLgN&;Q?gI^#DY2uL"
-    "i@^rMl9t=cWq6##weg>$FBjVQTSDgEKnIS7EM9>ZY9w0#L;>>#Mx&4Mvt//"
-    "L[MkA#W@lK.N'[0#7RL_&#w+F%HtG9M#XL`N&.,GM4Pg;-<nLENhvx>-VsM.M0rJfLH2eTM`*"
-    "oJMHRC`N"
-    "kfimM2J,W-jXS:)r0wK#@Fge$U>`w'N7G#$#fB#$E^$#:9:hk+eOe--6x)F7*E%?76%^"
-    "GMHePW-Z5l'&GiF#$956:rS?dA#fiK:)Yr+`&#0j@'DbG&#^$PG.Ll+DNa<XCMKEV*N)LN/N"
-    "*b=%Q6pia-Xg8I$<MR&,VdJe$<(7G;Ckl'&hF;;$<_=X(b.RS%%)###MPBuuE1V:v&cX&#2m#("
-    "&cV]`k9OhLMbn%s$G2,B$BfD3X*sp5#l,$R#]x_X1xKX%b5U*[r5iMfUo9U`N99hG)"
-    "tm+/Us9pG)XPu`<0s-)WTt(gCRxIg(%6sfh=ktMKn3j)<6<b5Sk_/0(^]AaN#(p/"
-    "L>&VZ>1i%h1S9u5o@YaaW$e+b<TWFn/"
-    "Z:Oh(Cx2$lNEoN^e)#CFY@@I;BOQ*sRwZtZxRcU7uW6CX"
-    "ow0i(?$Q[cjOd[P4d)]>ROPOpxTO7Stwi1::iB1q)C_=dV26J;2,]7op$]uQr@_V7$q^%"
-    "lQwtuHY]=DX,n3L#0PHDO4f9>dC@O>HBuKPpP*E,N+b3L#lpR/MrTEH.IAQk.a>D[.e;mc."
-    "x]Ip.PH^'/aqUO/$1WxLoW0[iLA<QT;5HKD+@qQ'NQ(3_PLhE48R.qAPSwQ0/"
-    "WK?Z,[x?-J;jQTWA0X@KJ(_Y8N-:/M74:/"
-    "-ZpKrUss?d#dZq]DAbkU*JqkL+nwX@@47`5>w=4h(9.`G"
-    "CRUxHPeR`5Mjol(dUWxZa(>STrPkrJiWx`5U7F#.g*jrohGg`cg:lSTvEY/"
-    "EV_7H4Q9[Z%cnv;JQYZ5q.l7Zeas:HOIZOB?G<Nald$qs]@]L<J7bR*>gv:[7MI2k).'2($"
-    "5FNP&EQ(,)"
-    "U]W]+fh18.vsai00);D3@4ku5P?DP8aJt+;qUM]=+b'8@;mViBKx0DE[-auGl8:PJ&Dj+M6OC]"
-    "O^((##]`0i)drT;-7X`=-H3[igUnPG-NZlo.#k@h#=Ork$m>a>$-?Tm$UV(?#P6YY#"
-    "'/###xe7q.73rI3*pP/$1>s9)W,JrM7SN]'/"
-    "4C#v$U`0#V.[0>xQsH$fEmPMgY2u7Kh(G%siIfLSoS+MK2eTM$=5,M8p`A.;_R%#u[K#$"
-    "x4AG8.kK/HSB==-'Ie/QTtG?-.*^N-4B/ZM"
-    "_3YlQC7(p7q)&](`6_c)$/"
-    "*JL(L-^(]$wIM`dPtOdGA,U3:w2M-0<q-]L_?^)1vw'.,MRsqVr.L;aN&#/"
-    "EgJ)PBc[-f>+WomX2u7lqM2iEumMTcsF?-aT=Z-97UEnXglEn1K-bnEO`gu"
-    "Ft(c%=;Am_Qs@jLooI&NX;]0#j4#F14;gl8-GQpgwhrq8'=l_f-b49'UOqkLu7-##oDY2L(te+"
-    "Mch&gLYtJ,MEtJfLh'x'M=$CS-ZZ%P]8bZ>#S?YY#%Q&q'3^Fw&?D)UDNrocM3A76/"
-    "/oL?#h7gl85[qW/"
-    "NDOk%16ij;+:1a'iNIdb-ou8.P*w,v5#EI$TWS>Pot-R*H'-SEpA:g)f+O$%%`kA#G=8RMmG1&"
-    "O`>to8bC]T&$,n.LoO>29sp3dt-52U%VM#q7'DHpg+#Z9%H[K<L"
-    "%a2E-grWVM3@2=-k22tL]4$##6We'8UJCKE[d_=%wI;'6X-GsLX4j^SgJ$##R*w,vP3wK#iiW&"
-    "#*h^D&R?jp7+/u&#(AP##XU8c$fSYW-J95_-Dp[g9wcO&#M-h1OcJlc-*vpw0xUX&#"
-    "OQFKNX@QI'IoPp7nb,QU//"
-    "MQ&ZDkKP)X<WSVL(68uVl&#c'[0#(s1X&xm$Y%B7*K:eDA323j998GXbA#pwMs-jgD$9QISB-"
-    "A_(aN4xoFM^@C58D0+Q+q3n0#3U1InDjF682-SjMXJK)("
-    "h$hxua_K]ul92%'BOU&#BRRh-slg8KDlr:%L71Ka:.A;%YULjDPmL<LYs8i#XwJOYaKPKc1h:'"
-    "9Ke,g)b),78=I39B;xiY$bgGw-&.Zi9InXDuYa%G*f2Bq7mn9^#p1vv%#(Wi-;/Z5h"
-    "o;#2:;%d&#x9v68C5g?ntX0X)pT`;%pB3q7mgGN)3%(P8nTd5L7GeA-GL@+%J3u2:(Yf>et`e;"
-    ")f#Km8&+DC$I46>#Kr]]u-[=99tts1.qb#q72g1WJO81q+eN'03'eM>&1XxY-caEnO"
-    "j%2n8)),?ILR5^.Ibn<-X-Mq7[a82Lq:F&#ce+S9wsCK*x`569E8ew'He]h:sI[2LM$["
-    "guka3ZRd6:t%IG:;$%YiJ:Nq=?eAw;/:nnDq0(CYcMpG)qLN4$##&J<j$UpK<Q4a1]MupW^-"
-    "sj_$%[HK%'F####QRZJ::Y3EGl4'@%FkiAOg#p[##O`gukTfBHagL<LHw%q&OV0##F=6/"
-    ":chIm0@eCP8X]:kFI%hl8hgO@RcBhS-@Qb$%+m=hPDLg*%K8ln(wcf3/'DW-$.lR?n[nCH-"
-    "eXOONTJlh:.RYF%3'p6sq:UIMA945&^HFS87@$EP2iG<-lCO$%c`uKGD3rC$x0BL8aFn--`ke%"
-    "#HMP'vh1/R&O_J9'um,.<tx[@%wsJk&bUT2`0uMv7gg#qp/ij.L56'hl;.s5CUrxjO"
-    "M7-##.l+Au'A&O:-T72L]P`&=;ctp'XScX*rU.>-XTt,%OVU4)S1+R-#dg0/"
-    "Nn?Ku1^0f$B*P:Rowwm-`0PKjYDDM'3]d39VZHEl4,.j']Pk-M.h^&:0FACm$maq-&sgw0t7/"
-    "6(^xtk%"
-    "LuH88Fj-ekm>GA#_>568x6(OFRl-IZp`&b,_P'$M<Jnq79VsJW/mWS*PUiq76;]/"
-    "NM_>hLbxfc$mj`,O;&%W2m`Zh:/"
-    ")Uetw:aJ%]K9h:TcF]u_-Sj9,VK3M.*'&0D[Ca]J9gp8,kAW]"
-    "%(?A%R$f<->Zts'^kn=-^@c4%-pY6qI%J%1IGxfLU9CP8cbPlXv);C=b),<2mOvP8up,"
-    "UVf3839acAWAW-W?#ao/^#%KYo8fRULNd2.>%m]UK:n%r$'sw]J;5pAoO_#2mO3n,'=H5(et"
-    "Hg*`+RLgv>=4U8guD$I%D:W>-r5V*%j*W:Kvej.Lp$<M-SGZ':+Q_k+uvOSLiEo(<aD/"
-    "K<CCc`'Lx>'?;++O'>()jLR-^u68PHm8ZFWe+ej8h:9r6L*0//c&iH&R8pRbA#Kjm%upV1g:"
-    "a_#Ur7FuA#(tRh#.Y5K+@?3<-8m0$PEn;J:rh6?I6uG<-`wMU'ircp0LaE_OtlMb&1#6T.#"
-    "FDKu#1Lw%u%+GM+X'e?YLfjM[VO0MbuFp7;>Q&#WIo)0@F%q7c#4XAXN-U&VB<HFF*qL("
-    "$/V,;(kXZejWO`<[5?\?ewY(*9=%wDc;,u<'9t3W-(H1th3+G]ucQ]kLs7df($/"
-    "*JL]@*t7Bu_G3_7mp7<iaQjO@.kLg;x3B0lqp7Hf,^Ze7-##@/"
-    "c58Mo(3;knp0%)A7?-W+eI'o8)b<"
-    "nKnw'Ho8C=Y>pqB>0ie&jhZ[?iLR@@_AvA-iQC(=ksRZRVp7`.=+NpBC%rh&3]R:8XDmE5^"
-    "V8O(x<<aG/1N$#FX$0V5Y6x'aErI3I$7x%E`v<-BY,)%-?Psf*l?%C3.mM(=/M0:JxG'?"
-    "7WhH%o'a<-80g0NBxoO(GH<dM]n.+%q@jH?f.UsJ2Ggs&4<-e47&Kl+f//"
-    "9@`b+?.TeN_&B8Ss?v;^Trk;f#YvJkl&w$]>-+k?'(<S:68tq*WoDfZu';mM?8X[ma8W%*`-=;"
-    "D.(nc7/;"
-    ")g:T1=^J$&BRV(-lTmNB6xqB[@0*o.erM*<SWF]u2=st-*(6v>^](H.aREZSi,#1:[IXaZFOm<"
-    "-ui#qUq2$##Ri;u75OK#(RtaW-K-F`S+cF]uN`-KMQ%rP/Xri.LRcB##=YL3BgM/3M"
-    "D?@f&1'BW-)Ju<L25gl8uhVm1hL$##*8###'A3/"
-    "LkKW+(^rWX?5W_8g)a(m&K8P>#bmmWCMkk&#TR`C,5d>g)F;t,4:@_l8G/"
-    "5h4vUd%&%950:VXD'QdWoY-F$BtUwmfe$YqL'8(PWX("
-    "P?^@Po3$##`MSs?DWBZ/S>+4%>fX,VWv/w'KD`LP5IbH;rTV>n3cEK8U#bX]l-/"
-    "V+^lj3;vlMb&[5YQ8#pekX9JP3XUC72L,,?+Ni&co7ApnO*5NK,((W-i:$,kp'UDAO("
-    "G0Sq7MVjJs"
-    "bIu)'Z,*[>br5fX^:FPAWr-m2KgL<LUN098kTF&#lvo58=/vjDo;.;)Ka*hLR#/"
-    "k=rKbxuV`>Q_nN6'8uTG&#1T5g)uLv:873UpTLgH+#FgpH'_o1780Ph8KmxQJ8#H72L4@768@"
-    "Tm&Q"
-    "h4CB/5OvmA&,Q&QbUoi$a_%3M01H)4x7I^&KQVgtFnV+;[Pc>[m4k//"
-    ",]1?#`VY[Jr*3&&slRfLiVZJ:]?=K3Sw=[$=uRB?3xk48@aeg<Z'<$#4H)6,>e0jT6'N#(q%."
-    "O=?2S]u*(m<-"
-    "V8J'(1)G][68hW$5'q[GC&5j`TE?m'esFGNRM)j,ffZ?-qx8;->g4t*:CIP/[Qap7/"
-    "9'#(1sao7w-.qNUdkJ)tCF&#B^;xGvn2r9FEPFFFcL@.iFNkTve$m%#QvQS8U@)2Z+3K:AKM5i"
-    "sZ88+dKQ)W6>J%CL<KE>`.d*(B`-n8D9oK<Up]c$X$(,)M8Zt7/"
-    "[rdkqTgl-0cuGMv'?>-XV1q['-5k'cAZ69e;D_?$ZPP&s^+7])$*$#@QYi9,5P&#9r+$%CE="
-    "68>K8r0=dSC%%(@p7"
-    ".m7jilQ02'0-VWAg<a/''3u.=4L$Y)6k/K:_[3=&jvL<L0C/"
-    "2'v:^;-DIBW,B4E68:kZ;%?8(Q8BH=kO65BW?xSG&#@uU,DS*,?.+(o(#1vCS8#CHF>TlGW'b)"
-    "Tq7VT9q^*^$$.:&N@@"
-    "$&)WHtPm*5_rO0&e%K&#-30j(E4#'Zb.o/"
-    "(Tpm$>K'f@[PvFl,hfINTNU6u'0pao7%XUp9]5.>%h`8_=VYbxuel.NTSsJfLacFu3B'lQSu/"
-    "m6-Oqem8T+oE--$0a/k]uj9EwsG>%veR*"
-    "hv^BFpQj:K'#SJ,sB-'#](j.Lg92rTw-*n%@/;39rrJF,l#qV%OrtBeC6/"
-    ",;qB3ebNW[?,Hqj2L.1NP&GjUR=1D8QaS3Up&@*9wP?+lo7b?@%'k4`p0Z$22%K3+iCZj?"
-    "XJN4Nm&+YF]u"
-    "@-W$U%VEQ/,,>>#)D<h#`)h0:<Q6909ua+&VU%n2:cG3FJ-%@Bj-DgLr`Hw&HAKjKjseK</"
-    "xKT*)B,N9X3]krc12t'pgTV(Lv-tL[xg_%=M_q7a^x?7Ubd>#%8cY#YZ?=,`Wdxu/ae&#"
-    "w6)R89tI#6@s'(6Bf7a&?S=^ZI_kS&ai`&=tE72L_D,;^R)7[$s<Eh#c&)q.MXI%#"
-    "v9ROa5FZO%sF7q7Nwb&#ptUJ:aqJe$Sl68%.D###EC><?-aF&#RNQv>o8lKN%5/"
-    "$(vdfq7+ebA#"
-    "u1p]ovUKW&Y%q]'>$1@-[xfn$7ZTp7mM,G,Ko7a&Gu%G[RMxJs[0MM%wci.LFDK)(<c`Q8N)"
-    "jEIF*+?P2a8g%)$q]o2aH8C&<SibC/q,(e:v;-b#6[$NtDZ84Je2KNvB#$P5?tQ3nt(0"
-    "d=j.LQf./"
-    "Ll33+(;q3L-w=8dX$#WF&uIJ@-bfI>%:_i2B5CsR8&9Z&#=mPEnm0f`<&c)QL5uJ#%u%lJj+D-"
-    "r;BoF&#4DoS97h5g)E#o:&S4weDF,9^Hoe`h*L+_a*NrLW-1pG_&2UdB8"
-    "6e%B/:=>)N4xeW.*wft-;$'58-ESqr<b?UI(_%@[P46>#U`'6AQ]m&6/"
-    "`Z>#S?YY#Vc;r7U2&326d=w&H####?TZ`*4?&.MK?LP8Vxg>$[QXc%QJv92.(Db*B)gb*"
-    "BM9dM*hJMAo*c&#"
-    "b0v=Pjer]$gG&JXDf->'StvU7505l9$AFvgYRI^&<^b68?j#q9QX4SM'RO#&sL1IM."
-    "rJfLUAj221]d##DW=m83u5;'bYx,*Sl0hL(W;;$doB&O/TQ:(Z^xBdLjL<Lni;''X.`$#8+1GD"
-    ":k$YUWsbn8ogh6rxZ2Z9]%nd+>V#*8U_72Lh+2Q8Cj0i:6hp&$C/"
-    ":p(HK>T8Y[gHQ4`4)'$Ab(Nof%V'8hL&#<NEdtg(n'=S1A(Q1/"
-    "I&4([%dM`,Iu'1:_hL>SfD07&6D<fp8dHM7/g+"
-    "tlPN9J*rKaPct&?'uBCem^jn%9_K)<,C5K3s=5g&GmJb*[SYq7K;TRLGCsM-$$;S%:Y@"
-    "r7AK0pprpL<Lrh,q7e/%KWK:50I^+m'vi`3?%Zp+<-d+$L-Sv:@.o19n$s0&39;kn;S%BSq*"
-    "$3WoJSCLweV[aZ'MQIjO<7;X-X;&+dMLvu#^UsGEC9WEc[X(wI7#2.(F0jV*eZf<-Qv3J-c+"
-    "J5AlrB#$p(H68LvEA'q3n0#m,[`*8Ft)FcYgEud]CWfm68,(aLA$@EFTgLXoBq/UPlp7"
-    ":d[/"
-    ";r_ix=:TF`S5H-b<LI&HY(K=h#)]Lk$K14lVfm:x$H<3^Ql<M`$OhapBnkup'D#L$Pb_`N*g]"
-    "2e;X/Dtg,bsj&K#2[-:iYr'_wgH)NUIR8a1n#S?Yej'h8^58UbZd+^FKD*T@;6A"
-    "7aQC[K8d-(v6GI$x:T<&'Gp5Uf>@M.*J:;$-rv29'M]8qMv-tLp,'886iaC=Hb*YJoKJ,(j%K="
-    "H`K.v9HggqBIiZu'QvBT.#=)0ukruV&.)3=(^1`o*Pj4<-<aN((^7('#Z0wK#5GX@7"
-    "u][`*S^43933A4rl][`*O4CgLEl]v$1Q3AeF37dbXk,.)vj#x'd`;qgbQR%FW,2(?LO=s%"
-    "Sc68%NP'##Aotl8x=BE#j1UD([3$M(]UI2LX3RpKN@;/#f'f/&_mt&F)XdF<9t4)Qa.*kT"
-    "LwQ'(TTB9.xH'>#MJ+gLq9-##@HuZPN0]u:h7.T..G:;$/"
-    "Usj(T7`Q8tT72LnYl<-qx8;-HV7Q-&Xdx%1a,hC=0u+HlsV>nuIQL-5<N?)NBS)QN*_I,?&)2'"
-    "IM%L3I)X((e/dl2&8'<M"
-    ":^#M*Q+[T.Xri.LYS3v%fF`68h;b-X[/En'CR.q7E)p'/"
-    "kle2HM,u;^%OKC-N+Ll%F9CF<Nf'^#t2L,;27W:0O@6##U6W7:$rJfLWHj$#)woqBefIZ.PK<"
-    "b*t7ed;p*_m;4ExK#h@&]>"
-    "_>@kXQtMacfD.m-VAb8;IReM3$wf0''hra*so568'Ip&vRs849'MRYSp%:t:h5qSgwpEr$B>Q,"
-    ";s(C#$)`svQuF$##-D,##,g68@2[T;.XSdN9Qe)rpt._K-#5wF)sP'##p#C0c%-Gb%"
-    "hd+<-j'Ai*x&&HMkT]C'OSl##5RG[JXaHN;d'uA#x._U;.`PU@(Z3dt4r152@:v,'R.Sj'w#0<"
-    "-;kPI)FfJ&#AYJ&#//)>-k=m=*XnK$>=)72L]0I%>.G690a:$##<,);?;72#?x9+d;"
-    "^V'9;jY@;)br#q^YQpx:X#Te$Z^'=-=bGhLf:D6&bNwZ9-ZD#n^9HhLMr5G;']d&6'wYmTFmL<"
-    "LD)F^%[tC'8;+9E#C$g%#5Y>q9wI>P(9mI[>kC-ekLC/R&CH+s'B;K-M6$EB%is00:"
-    "+A4[7xks.LrNk0&E)wILYF@2L'0Nb$+pv<(2.768/"
-    "FrY&h$^3i&@+G%JT'<-,v`3;_)I9M^AE]CN?Cl2AZg+%4iTpT3<n-&%H%b<FDj2M<hH=&Eh<"
-    "2Len$b*aTX=-8QxN)k11IM1c^j%"
-    "9s<L<NFSo)B?+<-(GxsF,^-Eh@$4dXhN$+#rxK8'je'D7k`e;)2pYwPA'_p9&@^18ml1^[@"
-    "g4t*[JOa*[=Qp7(qJ_oOL^('7fB&Hq-:sf,sNj8xq^>$U4O]GKx'm9)b@p7YsvK3w^YR-"
-    "CdQ*:Ir<($u&)#(&?L9Rg3H)4fiEp^iI9O8KnTj,]H?D*r7'M;PwZ9K0E^k&-cpI;.p/"
-    "6_vwoFMV<->#%Xi.LxVnrU(4&8/P+:hLSKj$#U%]49t'I:rgMi'FL@a:0Y-uA[39',(vbma*"
-    "hU%<-SRF`Tt:542R_VV$p@[p8DV[A,?1839FWdF<TddF<9Ah-6&9tWoDlh]&1SpGMq>Ti1O*H&"
-    "#(AL8[_P%.M>v^-))qOT*F5Cq0`Ye%+$B6i:7@0IX<N+T+0MlMBPQ*Vj>SsD<U4JHY"
-    "8kD2)2fU/M#$e.)T4,_=8hLim[&);?UkK'-x?'(:siIfL<$pFM`i<?%W(mGDHM%>iWP,##P`%/"
-    "L<eXi:@Z9C.7o=@(pXdAO/NLQ8lPl+HPOQa8wD8=^GlPa8TKI1CjhsCTSLJM'/Wl>-"
-    "S(qw%sf/@%#B6;/"
-    "U7K]uZbi^Oc^2n<bhPmUkMw>%t<)'mEVE''n`WnJra$^TKvX5B>;_aSEK',(hwa0:i4G?.Bci."
-    "(X[?b*($,=-n<.Q%`(X=?+@Am*Js0&=3bh8K]mL<LoNs'6,'85`"
-    "0?t/'_U59@]ddF<#LdF<eWdF<OuN/45rY<-L@&#+fm>69=Lb,OcZV/"
-    ");TTm8VI;?%OtJ<(b4mq7M6:u?KRdF<gR@2L=FNU-<b[(9c/"
-    "ML3m;Z[$oF3g)GAWqpARc=<ROu7cL5l;-[A]%/"
-    "+fsd;l#SafT/"
-    "f*W]0=O'$(Tb<[)*@e775R-:Yob%g*>l*:xP?Yb.5)%w_I?7uk5JC+FS(m#i'k.'a0i)9<7b'"
-    "fs'59hq$*5Uhv##pi^8+hIEBF`nvo`;'l0.^S1<-wUK2/Coh58KKhLj"
-    "M=SO*rfO`+qC`W-On.=AJ56>>i2@2LH6A:&5q`?9I3@@'04&p2/"
-    "LVa*T-4<-i3;M9UvZd+N7>b*eIwg:CC)c<>nO&#<IGe;__.thjZl<%w(Wk2xmp4Q@I#I9,DF]"
-    "u7-P=.-_:YJ]aS@V"
-    "?6*C()dOp7:WL,b&3Rg/"
-    ".cmM9&r^>$(>.Z-I&J(Q0Hd5Q%7Co-b`-c<N(6r@ip+AurK<m86QIth*#v;-OBqi+L7wDE-"
-    "Ir8K['m+DDSLwK&/.?-V%U_%3:qKNu$_b*B-kp7NaD'QdWQPK"
-    "Yq[@>P)hI;*_F]u`Rb[.j8_Q/"
-    "<&>uu+VsH$sM9TA%?)(vmJ80),P7E>)tjD%2L=-t#fK[%`v=Q8<FfNkgg^oIbah*#8/"
-    "Qt$F&:K*-(N/'+1vMB,u()-a.VUU*#[e%gAAO(S>WlA2);Sa"
-    ">gXm8YB`1d@K#n]76-a$U,mF<fX]idqd)<3,]J7JmW4`6]uks=4-72L(jEk+:bJ0M^q-8Dm_Z?"
-    "0olP1C9Sa&H[d&c$ooQUj]Exd*3ZM@-WGW2%s',B-_M%>%Ul:#/'xoFM9QX-$.QN'>"
-    "[%$Z$uF6pA6Ki2O5:8w*vP1<-1`[G,)-m#>0`P&#eb#.3i)rtB61(o'$?X3B</"
-    "R90;eZ]%Ncq;-Tl]#F>2Qft^ae_5tKL9MUe9b*sLEQ95C&`=G?@Mj=wh*'3E>=-<)Gt*Iw)'"
-    "QG:`@I"
-    "wOf7&]1i'S01B+Ev/Nac#9S;=;YQpg_6U`*kVY39xK,[/"
-    "6Aj7:'1Bm-_1EYfa1+o&o4hp7KN_Q(OlIo@S%;jVdn0'1<Vc52=u`3^o-n1'g4v58Hj&6_t7$#"
-    "#?M)c<$bgQ_'SY((-xkA#"
-    "Y(,p'H9rIVY-b,'%bCPF7.J<Up^,(dU1VY*5#WkTU>h19w,WQhLI)3S#f$2(eb,jr*b;3Vw]*"
-    "7NH%$c4Vs,eD9>XW8?N]o+(*pgC%/72LV-u<Hp,3@e^9UB1J+ak9-TN/mhKPg+AJYd$"
-    "MlvAF_jCK*.O-^(63adMT->W%iewS8W6m2rtCpo'RS1R84=@paTKt)>=%&1[)*vp'u+x,VrwN;"
-    "&]kuO9JDbg=pO$J*.jVe;u'm0dr9l,<*wMK*Oe=g8lV_KEBFkO'oU]^=[-792#ok,)"
-    "i]lR8qQ2oA8wcRCZ^7w/Njh;?.stX?Q1>S1q4Bn$)K1<-rGdO'$Wr.Lc.CG)$/*JL4tNR/"
-    ",SVO3,aUw'DJN:)Ss;wGn9A32ijw%FL+Z0Fn.U9;reSq)bmI32U==5ALuG&#Vf1398/pVo"
-    "1*c-(aY168o<`JsSbk-,1N;$>0:OUas(3:8Z972LSfF8eb=c-;>SPw7.6hn3m`9^Xkn(r.qS["
-    "0;T%&Qc=+STRxX'q1BNk3&*eu2;&8q$&x>Q#Q7^Tf+6<(d%ZVmj2bDi%.3L2n+4W'$P"
-    "iDDG)g,r%+?,$@?uou5tSe2aN_AQU*<h`e-GI7)?OK2A.d7_c)?wQ5AS@DL3r#7fSkgl6-++D:"
-    "'A,uq7SvlB$pcpH'q3n0#_%dY#xCpr-l<F0NR@-##FEV6NTF6##$l84N1w?AO>'IAO"
-    "URQ##V^Fv-XFbGM7Fl(N<3DhLGF%q.1rC$#:T__&Pi68%0xi_&[qFJ(77j_&JWoF.V735&T,["
-    "R*:xFR*K5>>#`bW-?4Ne_&6Ne_&6Ne_&n`kr-#GJcM6X;uM6X;uM(.a..^2TkL%oR(#"
-    ";u.T%fAr%4tJ8&><1=GHZ_+m9/#H1F^R#SC#*N=BA9(D?v[UiFY>>^8p,KKF.W]L29uLkLlu/"
-    "+4T<XoIB&hx=T1PcDaB&;HH+-AFr?(m9HZV)FKS8JCw;SD=6[^/DZUL`EUDf]GGlG&>"
-    "w$)F./^n3+rlo+DB;5sIYGNk+i1t-69Jg--0pao7Sm#K)pdHW&;LuDNH@H>#/"
-    "X-TI(;P>#,Gc>#0Su>#4`1?#8lC?#<xU?#@.i?#D:%@#HF7@#LRI@#P_[@#Tkn@#Xw*A#]-=A#"
-    "a9OA#"
-    "d<F&#*;G##.GY##2Sl##6`($#:l:$#>xL$#B.`$#F:r$#JF.%#NR@%#R_R%#Vke%#Zww%#_-4&"
-    "#3^Rh%Sflr-k'MS.o?.5/sWel/wpEM0%3'/1)K^f1-d>G21&v(35>V`39V7A4=onx4"
-    "A1OY5EI0;6Ibgr6M$HS7Q<)58C5w,;WoA*#[%T*#`1g*#d=#+#hI5+#lUG+#pbY+#tnl+#x$),"
-    "#&1;,#*=M,#.I`,#2Ur,#6b.-#;w[H#iQtA#m^0B#qjBB#uvTB##-hB#'9$C#+E6C#"
-    "/QHC#3^ZC#7jmC#;v)D#?,<D#C8ND#GDaD#KPsD#O]/"
-    "E#g1A5#KA*1#gC17#MGd;#8(02#L-d3#rWM4#Hga1#,<w0#T.j<#O#'2#CYN1#qa^:#_4m3#o@"
-    "/=#eG8=#t8J5#`+78#4uI-#"
-    "m3B2#SB[8#Q0@8#i[*9#iOn8#1Nm;#^sN9#qh<9#:=x-#P;K2#$%X9#bC+.#Rg;<#mN=.#MTF."
-    "#RZO.#2?)4#Y#(/#[)1/#b;L/#dAU/#0Sv;#lY$0#n`-0#sf60#(F24#wrH0#%/e0#"
-    "TmD<#%JSMFove:CTBEXI:<eh2g)B,3h2^G3i;#d3jD>)4kMYD4lVu`4m`:&5niUA5@(A5BA1]"
-    "PBB:xlBCC=2CDLXMCEUtiCf&0g2'tN?PGT4CPGT4CPGT4CPGT4CPGT4CPGT4CPGT4CP"
-    "GT4CPGT4CPGT4CPGT4CPGT4CPGT4CP-qekC`.9kEg^+F$kwViFJTB&5KTB&5KTB&5KTB&5KTB&"
-    "5KTB&5KTB&5KTB&5KTB&5KTB&5KTB&5KTB&5KTB&5KTB&5KTB&5o,^<-28ZI'O?;xp"
-    "O?;xpO?;xpO?;xpO?;xpO?;xpO?;xpO?;xpO?;xpO?;xpO?;xpO?;xpO?;xpO?;xp;7q-#"
-    "lLYI:xvD=#";
-
-static const char* GetDefaultCompressedFontDataTTFBase85() {
-  return proggy_clean_ttf_compressed_data_base85;
-}
-
-// Load embedded ProggyClean.ttf at size 13, disable oversampling
-ImFont* AddFontDefault() {
-  ImFontConfig font_cfg = ImFontConfig();
-  // if (!font_cfg_template)
-  {
-    font_cfg.OversampleH = font_cfg.OversampleV = 1;
-    font_cfg.PixelSnapH = true;
-  }
-
-  if (font_cfg.Name[0] == '\0') {
-#ifdef WIN32
-    strcpy_s(font_cfg.Name, SizeOfArray(font_cfg.Name),
-             "ProggyClean.ttf, 13px");
-#else
-    strcpy(font_cfg.Name, "ProggyClean.ttf, 13px");
-#endif
-  }
-
-  const char* ttf_compressed_base85 = GetDefaultCompressedFontDataTTFBase85();
-  ImFont* font = ImGui::GetIO().Fonts->AddFontFromMemoryCompressedBase85TTF(
-      ttf_compressed_base85, GParams.font_size, &font_cfg,
-      ImGui::GetIO().Fonts->GetGlyphRangesDefault());
-  return font;
-}
-
-ImFont* AddOrbitFont(float pixel_size) {
-  const auto exe_path = Path::GetExecutablePath();
-  const auto font_file_name = exe_path + "fonts/Vera.ttf";
-  return ImGui::GetIO().Fonts->AddFontFromFileTTF(font_file_name.c_str(),
-                                                  pixel_size);
-}
-
 bool Orbit_ImGui_Init() {
-  // g_Window = window;
-
   ImGuiIO& io = ImGui::GetIO();
 
   // http://doc.qt.io/qt-4.8/qt.html#Key-enum
@@ -572,12 +398,6 @@ bool Orbit_ImGui_Init() {
                                     // and call ImGui::GetDrawData() after
                                     // ImGui::Render() to get the same
                                     // ImDrawData pointer.
-  /*io.SetClipboardTextFn = Orbit_ImGui_SetClipboardText;
-  io.GetClipboardTextFn = Orbit_ImGui_GetClipboardText;*/
-
-#ifdef _WIN32
-  // io.ImeWindowHandle = glfwGetWin32Window(g_Window);
-#endif
 
   SetupImGuiStyle(true, 1.f);
 
@@ -671,90 +491,6 @@ void Orbit_ImGui_NewFrame(GlCanvas* a_Canvas) {
 
   // Start the frame
   ImGui::NewFrame();
-}
-
-// From Avoid/Doug Binks
-void SetupImGuiStyle(bool bStyleDark_, float alpha_) {
-  ImGuiStyle& style = ImGui::GetStyle();
-
-  // light style from Pacome Danhiez (user itamago)
-  // https://github.com/ocornut/imgui/pull/511#issuecomment-175719267
-  style.Alpha = 1.0f;
-  style.FrameRounding = 3.0f;
-  style.Colors[ImGuiCol_Text] = ImVec4(0.00f, 0.00f, 0.00f, 1.00f);
-  style.Colors[ImGuiCol_TextDisabled] = ImVec4(0.60f, 0.60f, 0.60f, 1.00f);
-  style.Colors[ImGuiCol_WindowBg] = ImVec4(0.94f, 0.94f, 0.94f, 0.94f);
-  style.Colors[ImGuiCol_ChildWindowBg] = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
-  // style.Colors[ImGuiCol_PopupBg] = ImVec4( 1.00f, 1.00f, 1.00f, 0.94f );
-  style.Colors[ImGuiCol_Border] = ImVec4(0.00f, 0.00f, 0.00f, 0.19f);
-  style.Colors[ImGuiCol_BorderShadow] = ImVec4(1.00f, 1.00f, 1.00f, 0.10f);
-  style.Colors[ImGuiCol_FrameBg] = ImVec4(0.16f, 0.29f, 0.48f, 0.54f);
-  style.Colors[ImGuiCol_FrameBgHovered] = ImVec4(0.26f, 0.59f, 0.98f, 0.40f);
-  style.Colors[ImGuiCol_FrameBgActive] = ImVec4(0.26f, 0.59f, 0.98f, 0.67f);
-  style.Colors[ImGuiCol_TitleBg] = ImVec4(0.96f, 0.96f, 0.96f, 1.00f);
-  style.Colors[ImGuiCol_TitleBgCollapsed] = ImVec4(1.00f, 1.00f, 1.00f, 0.51f);
-  style.Colors[ImGuiCol_TitleBgActive] = ImVec4(0.82f, 0.82f, 0.82f, 1.00f);
-  style.Colors[ImGuiCol_MenuBarBg] = ImVec4(0.86f, 0.86f, 0.86f, 1.00f);
-  style.Colors[ImGuiCol_ScrollbarBg] = ImVec4(0.98f, 0.98f, 0.98f, 0.53f);
-  style.Colors[ImGuiCol_ScrollbarGrab] = ImVec4(0.69f, 0.69f, 0.69f, 1.00f);
-  style.Colors[ImGuiCol_ScrollbarGrabHovered] =
-      ImVec4(0.59f, 0.59f, 0.59f, 1.00f);
-  style.Colors[ImGuiCol_ScrollbarGrabActive] =
-      ImVec4(0.49f, 0.49f, 0.49f, 1.00f);
-  // style.Colors[ImGuiCol_ComboBg] = ImVec4( 0.86f, 0.86f, 0.86f, 0.99f );
-  style.Colors[ImGuiCol_CheckMark] = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
-  style.Colors[ImGuiCol_SliderGrab] = ImVec4(0.24f, 0.52f, 0.88f, 1.00f);
-  style.Colors[ImGuiCol_SliderGrabActive] = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
-  style.Colors[ImGuiCol_Button] = ImVec4(0.26f, 0.59f, 0.98f, 0.40f);
-  style.Colors[ImGuiCol_ButtonHovered] = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
-  style.Colors[ImGuiCol_ButtonActive] = ImVec4(0.06f, 0.53f, 0.98f, 1.00f);
-  style.Colors[ImGuiCol_Header] = ImVec4(0.26f, 0.59f, 0.98f, 0.31f);
-  style.Colors[ImGuiCol_HeaderHovered] = ImVec4(0.26f, 0.59f, 0.98f, 0.80f);
-  style.Colors[ImGuiCol_HeaderActive] = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
-  style.Colors[ImGuiCol_Separator] = ImVec4(0.39f, 0.39f, 0.39f, 1.00f);
-  style.Colors[ImGuiCol_SeparatorHovered] = ImVec4(0.26f, 0.59f, 0.98f, 0.78f);
-  style.Colors[ImGuiCol_SeparatorActive] = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
-  style.Colors[ImGuiCol_ResizeGrip] = ImVec4(0.26f, 0.59f, 0.98f, 0.25f);
-  style.Colors[ImGuiCol_ResizeGripHovered] = ImVec4(0.26f, 0.59f, 0.98f, 0.67f);
-  style.Colors[ImGuiCol_ResizeGripActive] = ImVec4(0.26f, 0.59f, 0.98f, 0.95f);
-  // style.Colors[ImGuiCol_CloseButton] = ImVec4( 0.59f, 0.59f, 0.59f, 0.50f );
-  // style.Colors[ImGuiCol_CloseButtonHovered] = ImVec4( 0.98f, 0.39f,
-  // 0.36f, 1.00f ); style.Colors[ImGuiCol_CloseButtonActive] = ImVec4( 0.98f,
-  // 0.39f, 0.36f, 1.00f );
-  style.Colors[ImGuiCol_PlotLines] = ImVec4(0.39f, 0.39f, 0.39f, 1.00f);
-  style.Colors[ImGuiCol_PlotLinesHovered] = ImVec4(1.00f, 0.43f, 0.35f, 1.00f);
-  style.Colors[ImGuiCol_PlotHistogram] = ImVec4(0.90f, 0.70f, 0.00f, 1.00f);
-  style.Colors[ImGuiCol_PlotHistogramHovered] =
-      ImVec4(1.00f, 0.60f, 0.00f, 1.00f);
-  style.Colors[ImGuiCol_TextSelectedBg] = ImVec4(0.26f, 0.59f, 0.98f, 0.35f);
-  style.Colors[ImGuiCol_ModalWindowDarkening] =
-      ImVec4(0.20f, 0.20f, 0.20f, 0.35f);
-
-  if (bStyleDark_) {
-    for (int i = 0; i <= ImGuiCol_COUNT; i++) {
-      ImVec4& col = style.Colors[i];
-      float H, S, V;
-      ImGui::ColorConvertRGBtoHSV(col.x, col.y, col.z, H, S, V);
-
-      if (S < 0.1f) {
-        V = 1.0f - V;
-      }
-      ImGui::ColorConvertHSVtoRGB(H, S, V, col.x, col.y, col.z);
-      if (col.w < 1.00f) {
-        col.w *= alpha_;
-      }
-    }
-  } else {
-    for (int i = 0; i <= ImGuiCol_COUNT; i++) {
-      ImVec4& col = style.Colors[i];
-      if (col.w < 1.00f) {
-        col.x *= alpha_;
-        col.y *= alpha_;
-        col.z *= alpha_;
-        col.w *= alpha_;
-      }
-    }
-  }
 }
 
 void OutputWindow::AddLine(const std::string& a_String) {

--- a/OrbitGl/ImGuiOrbit.cpp
+++ b/OrbitGl/ImGuiOrbit.cpp
@@ -548,21 +548,24 @@ void Orbit_ImGui_RenderDrawLists(ImDrawData* draw_data) {
             clip_rect.z >= 0.0f && clip_rect.w >= 0.0f) {
           // Apply scissor/clipping rectangle
           if (clip_origin_lower_left)
-            glScissor(clip_rect.x, (fb_height - clip_rect.w),
-                      (clip_rect.z - clip_rect.x),
-                      (clip_rect.w - clip_rect.y));
+            glScissor(static_cast<int>(clip_rect.x),
+                      static_cast<int>(fb_height - clip_rect.w),
+                      static_cast<int>(clip_rect.z - clip_rect.x),
+                      static_cast<int>(clip_rect.w - clip_rect.y));
           else {
             // Support for GL 4.5's glClipControl(GL_UPPER_LEFT)
-            glScissor(clip_rect.x, clip_rect.y, clip_rect.z, clip_rect.w);
+            glScissor(
+                static_cast<int>(clip_rect.x), static_cast<int>(clip_rect.y),
+                static_cast<int>(clip_rect.z), static_cast<int>(clip_rect.w));
           }
           // Bind texture, Draw
           glBindTexture(
               GL_TEXTURE_2D,
               static_cast<GLuint>(reinterpret_cast<intptr_t>(pcmd->TextureId)));
           glDrawElements(
-              GL_TRIANGLES, (GLsizei)pcmd->ElemCount,
+              GL_TRIANGLES, static_cast<GLsizei>(pcmd->ElemCount),
               sizeof(ImDrawIdx) == 2 ? GL_UNSIGNED_SHORT : GL_UNSIGNED_INT,
-              (void*)idx_buffer_offset);
+              reinterpret_cast<void*>(idx_buffer_offset));
         }
       }
       idx_buffer_offset += pcmd->ElemCount * sizeof(ImDrawIdx);
@@ -605,9 +608,10 @@ void Orbit_ImGui_RenderDrawLists(ImDrawData* draw_data) {
   glPolygonMode(GL_FRONT_AND_BACK, static_cast<GLenum>(last_polygon_mode[0]));
 #endif
   glViewport(last_viewport[0], last_viewport[1], (GLsizei)last_viewport[2],
-             (GLsizei)last_viewport[3]);
+             static_cast<GLsizei>(last_viewport[3]));
   glScissor(last_scissor_box[0], last_scissor_box[1],
-            (GLsizei)last_scissor_box[2], (GLsizei)last_scissor_box[3]);
+            static_cast<GLsizei>(last_scissor_box[2]),
+            static_cast<GLsizei>(last_scissor_box[3]));
 }
 
 ImFont* AddOrbitFont(float pixel_size) {

--- a/OrbitGl/ImGuiOrbit.cpp
+++ b/OrbitGl/ImGuiOrbit.cpp
@@ -607,7 +607,8 @@ void Orbit_ImGui_RenderDrawLists(ImDrawData* draw_data) {
 #ifdef GL_POLYGON_MODE
   glPolygonMode(GL_FRONT_AND_BACK, static_cast<GLenum>(last_polygon_mode[0]));
 #endif
-  glViewport(last_viewport[0], last_viewport[1], (GLsizei)last_viewport[2],
+  glViewport(last_viewport[0], last_viewport[1],
+             static_cast<GLsizei>(last_viewport[2]),
              static_cast<GLsizei>(last_viewport[3]));
   glScissor(last_scissor_box[0], last_scissor_box[1],
             static_cast<GLsizei>(last_scissor_box[2]),

--- a/OrbitGl/ImGuiOrbit.cpp
+++ b/OrbitGl/ImGuiOrbit.cpp
@@ -40,35 +40,111 @@ GLuint GTextureTimer = 0;
 GLuint GTextureHelp = 0;
 GLuint GTextureRecord = 0;
 
+static char g_GlslVersionString[32] = "#version 100\n";
+static unsigned int g_VboHandle = 0, g_ElementsHandle = 0;
+static GLuint g_ShaderHandle = 0, g_VertHandle = 0, g_FragHandle = 0;
+static int g_AttribLocationTex = 0, g_AttribLocationProjMtx = 0;
+static int g_AttribLocationPosition = 0, g_AttribLocationUV = 0,
+           g_AttribLocationColor = 0;
+
 void Orbit_ImGui_InvalidateDeviceObjects() {
-  if (g_FontTexture) {
-    glDeleteTextures(1, &g_FontTexture);
-    ImGui::GetIO().Fonts->TexID = 0;
-    g_FontTexture = 0;
-  }
+	if (g_VboHandle) glDeleteBuffers(1, &g_VboHandle);
+	if (g_ElementsHandle) glDeleteBuffers(1, &g_ElementsHandle);
+	g_VboHandle = g_ElementsHandle = 0;
+
+	if (g_ShaderHandle && g_VertHandle)
+		glDetachShader(g_ShaderHandle, g_VertHandle);
+	if (g_VertHandle) glDeleteShader(g_VertHandle);
+	g_VertHandle = 0;
+
+	if (g_ShaderHandle && g_FragHandle)
+		glDetachShader(g_ShaderHandle, g_FragHandle);
+	if (g_FragHandle) glDeleteShader(g_FragHandle);
+	g_FragHandle = 0;
+
+	if (g_ShaderHandle) glDeleteProgram(g_ShaderHandle);
+	g_ShaderHandle = 0;
+
+	if (g_FontTexture) {
+		glDeleteTextures(1, &g_FontTexture);
+		ImGui::GetIO().Fonts->TexID = 0;
+		g_FontTexture = 0;
+	}
 }
 
-bool Orbit_ImGui_CreateDeviceObjects() {
+// If you get an error please report on github. You may try different GL context
+// version or GLSL version. See GL<>GLSL version table at the top of this file.
+static bool CheckShader(GLuint handle, const char* desc) {
+  // TODO(dfenner):Fix stuff below to use LOG and see if this makes sense at all
+  // in our case.
+  GLint status = 0, log_length = 0;
+  glGetShaderiv(handle, GL_COMPILE_STATUS, &status);
+  glGetShaderiv(handle, GL_INFO_LOG_LENGTH, &log_length);
+  if ((GLboolean)status == GL_FALSE)
+    fprintf(
+        stderr,
+        "ERROR: ImGui_ImplOpenGL3_CreateDeviceObjects: failed to compile %s!\n",
+        desc);
+  if (log_length > 0) {
+    ImVector<char> buf;
+    buf.resize((int)(log_length + 1));
+    glGetShaderInfoLog(handle, log_length, NULL, (GLchar*)buf.begin());
+    fprintf(stderr, "%s\n", buf.begin());
+  }
+  return (GLboolean)status == GL_TRUE;
+}
+
+// If you get an error please report on GitHub. You may try different GL context
+// version or GLSL version.
+static bool CheckProgram(GLuint handle, const char* desc) {
+  // TODO(dfenner):Fix stuff below to use LOG and see if this makes sense at all
+  // in our case.
+  GLint status = 0, log_length = 0;
+  glGetProgramiv(handle, GL_LINK_STATUS, &status);
+  glGetProgramiv(handle, GL_INFO_LOG_LENGTH, &log_length);
+  if ((GLboolean)status == GL_FALSE)
+    fprintf(stderr,
+            "ERROR: ImGui_ImplOpenGL3_CreateDeviceObjects: failed to link %s! "
+            "(with GLSL '%s')\n",
+            desc, g_GlslVersionString);
+  if (log_length > 0) {
+    ImVector<char> buf;
+    buf.resize((int)(log_length + 1));
+    glGetProgramInfoLog(handle, log_length, NULL, (GLchar*)buf.begin());
+    fprintf(stderr, "%s\n", buf.begin());
+  }
+  return (GLboolean)status == GL_TRUE;
+}
+
+bool Orbit_ImGui_CreateTextures() {
   // Build texture atlas
   ImGuiIO& io = ImGui::GetIO();
   unsigned char* pixels;
   int width, height;
-  io.Fonts->GetTexDataAsAlpha8(&pixels, &width, &height);
+  io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);  
 
   // Upload texture to graphics system
   GLint last_texture;
   glGetIntegerv(GL_TEXTURE_BINDING_2D, &last_texture);
+
   glGenTextures(1, &g_FontTexture);
   glBindTexture(GL_TEXTURE_2D, g_FontTexture);
+
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_ALPHA, width, height, 0, GL_ALPHA,
+#ifdef GL_UNPACK_ROW_LENGTH
+  glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+#endif
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA,
                GL_UNSIGNED_BYTE, pixels);
 
   glGenTextures(1, &GTextureInjected);
   glBindTexture(GL_TEXTURE_2D, GTextureInjected);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+#ifdef GL_UNPACK_ROW_LENGTH
+  glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+#endif
   glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, inject_image.width,
                inject_image.height, 0, GL_RGBA, GL_UNSIGNED_BYTE,
                inject_image.pixel_data);
@@ -77,6 +153,9 @@ bool Orbit_ImGui_CreateDeviceObjects() {
   glBindTexture(GL_TEXTURE_2D, GTextureTimer);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+#ifdef GL_UNPACK_ROW_LENGTH
+  glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+#endif
   glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, inject_image.width,
                inject_image.height, 0, GL_RGBA, GL_UNSIGNED_BYTE,
                timer_image.pixel_data);
@@ -85,6 +164,9 @@ bool Orbit_ImGui_CreateDeviceObjects() {
   glBindTexture(GL_TEXTURE_2D, GTextureHelp);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+#ifdef GL_UNPACK_ROW_LENGTH
+  glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+#endif
   glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, help_image.width, help_image.height,
                0, GL_RGBA, GL_UNSIGNED_BYTE, help_image.pixel_data);
 
@@ -92,12 +174,95 @@ bool Orbit_ImGui_CreateDeviceObjects() {
   glBindTexture(GL_TEXTURE_2D, GTextureRecord);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+#ifdef GL_UNPACK_ROW_LENGTH
+  glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+#endif
   glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, record_image.width,
                record_image.height, 0, GL_RGBA, GL_UNSIGNED_BYTE,
                record_image.pixel_data);
 
+  // Store our identifier
+  io.Fonts->TexID = (ImTextureID)(intptr_t)g_FontTexture;
+
   // Restore state
   glBindTexture(GL_TEXTURE_2D, last_texture);
+
+  return true;
+}
+
+bool Orbit_ImGui_CreateDeviceObjects() {
+  // Backup GL state
+  GLint last_texture, last_array_buffer;
+  glGetIntegerv(GL_TEXTURE_BINDING_2D, &last_texture);
+  glGetIntegerv(GL_ARRAY_BUFFER_BINDING, &last_array_buffer);
+#ifndef IMGUI_IMPL_OPENGL_ES2
+  GLint last_vertex_array;
+  glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &last_vertex_array);
+#endif
+
+  const GLchar* vertex_shader =
+      "uniform mat4 ProjMtx;\n"
+      "attribute vec2 Position;\n"
+      "attribute vec2 UV;\n"
+      "attribute vec4 Color;\n"
+      "varying vec2 Frag_UV;\n"
+      "varying vec4 Frag_Color;\n"
+      "void main()\n"
+      "{\n"
+      "    Frag_UV = UV;\n"
+      "    Frag_Color = Color;\n"
+      "    gl_Position = ProjMtx * vec4(Position.xy,0,1);\n"
+      "}\n";
+  const GLchar* fragment_shader =
+      "#ifdef GL_ES\n"
+      "    precision mediump float;\n"
+      "#endif\n"
+      "uniform sampler2D Texture;\n"
+      "varying vec2 Frag_UV;\n"
+      "varying vec4 Frag_Color;\n"
+      "void main()\n"
+      "{\n"
+      "    gl_FragColor = Frag_Color * texture2D(Texture, Frag_UV.st);\n"
+      "}\n";
+  // Create shaders
+  const GLchar* vertex_shader_with_version[2] = {g_GlslVersionString,
+                                                 vertex_shader};
+  g_VertHandle = glCreateShader(GL_VERTEX_SHADER);
+  glShaderSource(g_VertHandle, 2, vertex_shader_with_version, NULL);
+  glCompileShader(g_VertHandle);
+  CheckShader(g_VertHandle, "vertex shader");
+
+  const GLchar* fragment_shader_with_version[2] = {g_GlslVersionString,
+                                                   fragment_shader};
+  g_FragHandle = glCreateShader(GL_FRAGMENT_SHADER);
+  glShaderSource(g_FragHandle, 2, fragment_shader_with_version, NULL);
+  glCompileShader(g_FragHandle);
+  CheckShader(g_FragHandle, "fragment shader");
+
+  g_ShaderHandle = glCreateProgram();
+  glAttachShader(g_ShaderHandle, g_VertHandle);
+  glAttachShader(g_ShaderHandle, g_FragHandle);
+  glLinkProgram(g_ShaderHandle);
+  CheckProgram(g_ShaderHandle, "shader program");
+
+  g_AttribLocationTex = glGetUniformLocation(g_ShaderHandle, "Texture");
+  g_AttribLocationProjMtx = glGetUniformLocation(g_ShaderHandle, "ProjMtx");
+  g_AttribLocationPosition = glGetAttribLocation(g_ShaderHandle, "Position");
+  g_AttribLocationUV = glGetAttribLocation(g_ShaderHandle, "UV");
+  g_AttribLocationColor = glGetAttribLocation(g_ShaderHandle, "Color");
+
+  // Create buffers
+  glGenBuffers(1, &g_VboHandle);
+  glGenBuffers(1, &g_ElementsHandle);
+
+  Orbit_ImGui_CreateTextures();
+  
+   // Restore modified GL state
+  glBindTexture(GL_TEXTURE_2D, last_texture);
+  glBindBuffer(GL_ARRAY_BUFFER, last_array_buffer);
+#ifndef IMGUI_IMPL_OPENGL_ES2
+  glBindVertexArray(last_vertex_array);
+#endif
 
   return true;
 }
@@ -106,6 +271,9 @@ bool Orbit_ImGui_CreateDeviceObjects() {
 // settings
 bool LoadTextureFromFile(const char* filename, uint32_t* out_texture,
                          int* out_width, int* out_height) {
+  GLint last_texture;
+  glGetIntegerv(GL_TEXTURE_BINDING_2D, &last_texture);
+
   // Load from file
   int image_width = 0;
   int image_height = 0;
@@ -131,6 +299,8 @@ bool LoadTextureFromFile(const char* filename, uint32_t* out_texture,
   *out_texture = image_texture;
   *out_width = image_width;
   *out_height = image_height;
+
+  glBindTexture(GL_TEXTURE_2D, last_texture);
 
   return true;
 }
@@ -219,99 +389,316 @@ void SetupImGuiStyle(bool bStyleDark_, float alpha_) {
   }
 }
 
-// This is the main rendering function that you have to implement and provide to
-// ImGui (via setting up 'RenderDrawListsFn' in the ImGuiIO structure) If text
-// or lines are blurry when integrating ImGui in your engine:
-// - in your Render function, try translating your projection matrix by
-// (0.5f,0.5f) or (0.375f,0.375f)
+// TODO(dfenner): There are a bunch of defines in the backup/restore part where I don't know in what they do.
+
 void Orbit_ImGui_RenderDrawLists(ImDrawData* draw_data) {
-  // We are using the OpenGL fixed pipeline to make the example code simpler to
-  // read! Setup render state: alpha-blending enabled, no face culling, no depth
-  // testing, scissor enabled, vertex/texcoord/color pointers.
+  // Avoid rendering when minimized, scale coordinates for retina displays
+  // (screen coordinates != framebuffer coordinates)
+  int fb_width =
+      (int)(draw_data->DisplaySize.x * draw_data->FramebufferScale.x);
+  int fb_height =
+      (int)(draw_data->DisplaySize.y * draw_data->FramebufferScale.y);
+  if (fb_width <= 0 || fb_height <= 0) return;
+
+    // Backup GL state
+  GLenum last_active_texture;
+  glGetIntegerv(GL_ACTIVE_TEXTURE, (GLint*)&last_active_texture);
+  glActiveTexture(GL_TEXTURE0);
+  GLint last_program;
+  glGetIntegerv(GL_CURRENT_PROGRAM, &last_program);
   GLint last_texture;
   glGetIntegerv(GL_TEXTURE_BINDING_2D, &last_texture);
+#ifdef GL_SAMPLER_BINDING
+  GLint last_sampler;
+  glGetIntegerv(GL_SAMPLER_BINDING, &last_sampler);
+#endif
+  GLint last_array_buffer;
+  glGetIntegerv(GL_ARRAY_BUFFER_BINDING, &last_array_buffer);
+#ifndef IMGUI_IMPL_OPENGL_ES2
+  GLint last_vertex_array;
+  glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &last_vertex_array);
+#endif
+#ifdef GL_POLYGON_MODE
+  GLint last_polygon_mode[2];
+  glGetIntegerv(GL_POLYGON_MODE, last_polygon_mode);
+#endif
   GLint last_viewport[4];
   glGetIntegerv(GL_VIEWPORT, last_viewport);
-  glPushAttrib(GL_ENABLE_BIT | GL_COLOR_BUFFER_BIT | GL_TRANSFORM_BIT);
+  GLint last_scissor_box[4];
+  glGetIntegerv(GL_SCISSOR_BOX, last_scissor_box);
+  GLenum last_blend_src_rgb;
+  glGetIntegerv(GL_BLEND_SRC_RGB, (GLint*)&last_blend_src_rgb);
+  GLenum last_blend_dst_rgb;
+  glGetIntegerv(GL_BLEND_DST_RGB, (GLint*)&last_blend_dst_rgb);
+  GLenum last_blend_src_alpha;
+  glGetIntegerv(GL_BLEND_SRC_ALPHA, (GLint*)&last_blend_src_alpha);
+  GLenum last_blend_dst_alpha;
+  glGetIntegerv(GL_BLEND_DST_ALPHA, (GLint*)&last_blend_dst_alpha);
+  GLenum last_blend_equation_rgb;
+  glGetIntegerv(GL_BLEND_EQUATION_RGB, (GLint*)&last_blend_equation_rgb);
+  GLenum last_blend_equation_alpha;
+  glGetIntegerv(GL_BLEND_EQUATION_ALPHA, (GLint*)&last_blend_equation_alpha);
+  GLboolean last_enable_blend = glIsEnabled(GL_BLEND);
+  GLboolean last_enable_cull_face = glIsEnabled(GL_CULL_FACE);
+  GLboolean last_enable_depth_test = glIsEnabled(GL_DEPTH_TEST);
+  GLboolean last_enable_scissor_test = glIsEnabled(GL_SCISSOR_TEST);
+  bool clip_origin_lower_left = true;
+#if defined(GL_CLIP_ORIGIN) && !defined(__APPLE__)
+  GLenum last_clip_origin = 0;
+  glGetIntegerv(GL_CLIP_ORIGIN,
+                (GLint*)&last_clip_origin);  // Support for GL 4.5's
+                                             // glClipControl(GL_UPPER_LEFT)
+  if (last_clip_origin == GL_UPPER_LEFT) clip_origin_lower_left = false;
+#endif
+
+  // Setup render state: alpha-blending enabled, no face culling, no depth
+  // testing, scissor enabled, polygon fill
   glEnable(GL_BLEND);
+  glBlendEquation(GL_FUNC_ADD);
   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
   glDisable(GL_CULL_FACE);
-  // glDisable(GL_DEPTH_TEST);
+  glDisable(GL_DEPTH_TEST);
   glEnable(GL_SCISSOR_TEST);
-  glEnableClientState(GL_VERTEX_ARRAY);
-  glEnableClientState(GL_TEXTURE_COORD_ARRAY);
-  glEnableClientState(GL_COLOR_ARRAY);
-  glEnable(GL_TEXTURE_2D);
-  glUseProgram(
-      0);  // You may want this if using this code in an OpenGL 3+ context
-
-  // Handle cases of screen coordinates != from framebuffer coordinates (e.g.
-  // retina displays)
-  ImGuiIO& io = ImGui::GetIO();
-  int fb_width =
-      static_cast<int>(io.DisplaySize.x * io.DisplayFramebufferScale.x);
-  int fb_height =
-      static_cast<int>(io.DisplaySize.y * io.DisplayFramebufferScale.y);
-  draw_data->ScaleClipRects(io.DisplayFramebufferScale);
+#ifdef GL_POLYGON_MODE
+  glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+#endif
 
   // Setup viewport, orthographic projection matrix
-  glViewport(0, 0, static_cast<GLsizei>(fb_width),
-             static_cast<GLsizei>(fb_height));
-  glMatrixMode(GL_PROJECTION);
-  glPushMatrix();
-  glLoadIdentity();
-  glOrtho(0.0f, io.DisplaySize.x, io.DisplaySize.y, 0.0f, -1.0f, +1.0f);
-  glMatrixMode(GL_MODELVIEW);
-  glPushMatrix();
-  glLoadIdentity();
+  // Our visible imgui space lies from draw_data->DisplayPos (top left) to
+  // draw_data->DisplayPos+data_data->DisplaySize (bottom right). DisplayMin is
+  // typically (0,0) for single viewport apps.
+  glViewport(0, 0, (GLsizei)fb_width, (GLsizei)fb_height);
+  float L = draw_data->DisplayPos.x;
+  float R = draw_data->DisplayPos.x + draw_data->DisplaySize.x;
+  float T = draw_data->DisplayPos.y;
+  float B = draw_data->DisplayPos.y + draw_data->DisplaySize.y;
+  const float ortho_projection[4][4] = {
+      {2.0f / (R - L), 0.0f, 0.0f, 0.0f},
+      {0.0f, 2.0f / (T - B), 0.0f, 0.0f},
+      {0.0f, 0.0f, -1.0f, 0.0f},
+      {(R + L) / (L - R), (T + B) / (B - T), 0.0f, 1.0f},
+  };
+  glUseProgram(g_ShaderHandle);
+  glUniform1i(g_AttribLocationTex, 0);
+  glUniformMatrix4fv(g_AttribLocationProjMtx, 1, GL_FALSE,
+                     &ortho_projection[0][0]);
+#ifdef GL_SAMPLER_BINDING
+  glBindSampler(0, 0);  // We use combined texture/sampler state. Applications
+                        // using GL 3.3 may set that otherwise.
+#endif
 
-  // Render command lists
+#ifndef IMGUI_IMPL_OPENGL_ES2
+  // Recreate the VAO every time
+  // (This is to easily allow multiple GL contexts. VAO are not shared among GL
+  // contexts, and we don't track creation/deletion of windows so we don't have
+  // an obvious key to use to cache them.)
+  GLuint vao_handle = 0;
+  glGenVertexArrays(1, &vao_handle);
+  glBindVertexArray(vao_handle);
+#endif
+  glBindBuffer(GL_ARRAY_BUFFER, g_VboHandle);
+  glEnableVertexAttribArray(g_AttribLocationPosition);
+  glEnableVertexAttribArray(g_AttribLocationUV);
+  glEnableVertexAttribArray(g_AttribLocationColor);
+  glVertexAttribPointer(g_AttribLocationPosition, 2, GL_FLOAT, GL_FALSE,
+                        sizeof(ImDrawVert),
+                        (GLvoid*)IM_OFFSETOF(ImDrawVert, pos));
+  glVertexAttribPointer(g_AttribLocationUV, 2, GL_FLOAT, GL_FALSE,
+                        sizeof(ImDrawVert),
+                        (GLvoid*)IM_OFFSETOF(ImDrawVert, uv));
+  glVertexAttribPointer(g_AttribLocationColor, 4, GL_UNSIGNED_BYTE, GL_TRUE,
+                        sizeof(ImDrawVert),
+                        (GLvoid*)IM_OFFSETOF(ImDrawVert, col));
+
+  // Will project scissor/clipping rectangles into framebuffer space
+  ImVec2 clip_off =
+      draw_data->DisplayPos;  // (0,0) unless using multi-viewports
+  ImVec2 clip_scale =
+      draw_data->FramebufferScale;  // (1,1) unless using retina display which
+                                    // are often (2,2)
+
+    // Render command lists
   for (int n = 0; n < draw_data->CmdListsCount; n++) {
     const ImDrawList* cmd_list = draw_data->CmdLists[n];
-    const uint8_t* vtx_buffer =
-        reinterpret_cast<const uint8_t*>(&cmd_list->VtxBuffer.front());
-    const ImDrawIdx* idx_buffer = &cmd_list->IdxBuffer.front();
-    glVertexPointer(2, GL_FLOAT, sizeof(ImDrawVert),
-                    vtx_buffer + offsetof(ImDrawVert, pos));
-    glTexCoordPointer(2, GL_FLOAT, sizeof(ImDrawVert),
-                      vtx_buffer + offsetof(ImDrawVert, uv));
-    glColorPointer(4, GL_UNSIGNED_BYTE, sizeof(ImDrawVert),
-                   vtx_buffer + offsetof(ImDrawVert, col));
+    size_t idx_buffer_offset = 0;
 
-    for (int cmd_i = 0; cmd_i < cmd_list->CmdBuffer.size(); cmd_i++) {
+    glBindBuffer(GL_ARRAY_BUFFER, g_VboHandle);
+    glBufferData(GL_ARRAY_BUFFER,
+                 (GLsizeiptr)cmd_list->VtxBuffer.Size * sizeof(ImDrawVert),
+                 (const GLvoid*)cmd_list->VtxBuffer.Data, GL_STREAM_DRAW);
+
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, g_ElementsHandle);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER,
+                 (GLsizeiptr)cmd_list->IdxBuffer.Size * sizeof(ImDrawIdx),
+                 (const GLvoid*)cmd_list->IdxBuffer.Data, GL_STREAM_DRAW);
+
+    for (int cmd_i = 0; cmd_i < cmd_list->CmdBuffer.Size; cmd_i++) {
       const ImDrawCmd* pcmd = &cmd_list->CmdBuffer[cmd_i];
       if (pcmd->UserCallback) {
+        // User callback (registered via ImDrawList::AddCallback)
         pcmd->UserCallback(cmd_list, pcmd);
       } else {
-        glBindTexture(
-            GL_TEXTURE_2D,
-            static_cast<GLuint>(reinterpret_cast<intptr_t>(pcmd->TextureId)));
-        glScissor(static_cast<int>(pcmd->ClipRect.x),
-                  static_cast<int>(fb_height - pcmd->ClipRect.w),
-                  static_cast<int>(pcmd->ClipRect.z - pcmd->ClipRect.x),
-                  static_cast<int>(pcmd->ClipRect.w - pcmd->ClipRect.y));
-        glDrawElements(
-            GL_TRIANGLES, static_cast<GLsizei>(pcmd->ElemCount),
-            sizeof(ImDrawIdx) == 2 ? GL_UNSIGNED_SHORT : GL_UNSIGNED_INT,
-            idx_buffer);
+        // Project scissor/clipping rectangles into framebuffer space
+        ImVec4 clip_rect;
+        clip_rect.x = (pcmd->ClipRect.x - clip_off.x) * clip_scale.x;
+        clip_rect.y = (pcmd->ClipRect.y - clip_off.y) * clip_scale.y;
+        clip_rect.z = (pcmd->ClipRect.z - clip_off.x) * clip_scale.x;
+        clip_rect.w = (pcmd->ClipRect.w - clip_off.y) * clip_scale.y;
+
+        if (clip_rect.x < fb_width && clip_rect.y < fb_height &&
+            clip_rect.z >= 0.0f && clip_rect.w >= 0.0f) {
+          // Apply scissor/clipping rectangle
+          if (clip_origin_lower_left)
+            glScissor((int)clip_rect.x, (int)(fb_height - clip_rect.w),
+                      (int)(clip_rect.z - clip_rect.x),
+                      (int)(clip_rect.w - clip_rect.y));
+          else
+            glScissor(
+                (int)clip_rect.x, (int)clip_rect.y, (int)clip_rect.z,
+                (int)clip_rect
+                    .w);  // Support for GL 4.5's glClipControl(GL_UPPER_LEFT)
+
+          // Bind texture, Draw
+          glBindTexture(GL_TEXTURE_2D, (GLuint)(intptr_t)pcmd->TextureId);
+          glDrawElements(
+              GL_TRIANGLES, (GLsizei)pcmd->ElemCount,
+              sizeof(ImDrawIdx) == 2 ? GL_UNSIGNED_SHORT : GL_UNSIGNED_INT,
+              (void*)idx_buffer_offset);
+        }
       }
-      idx_buffer += pcmd->ElemCount;
+      idx_buffer_offset += pcmd->ElemCount * sizeof(ImDrawIdx);
     }
   }
-
-  // Restore modified state
-  glDisableClientState(GL_COLOR_ARRAY);
-  glDisableClientState(GL_TEXTURE_COORD_ARRAY);
-  glDisableClientState(GL_VERTEX_ARRAY);
+#ifndef IMGUI_IMPL_OPENGL_ES2
+  glDeleteVertexArrays(1, &vao_handle);
+#endif
+  // Restore modified GL state
+  glUseProgram(last_program);
   glBindTexture(GL_TEXTURE_2D, last_texture);
-  glMatrixMode(GL_MODELVIEW);
-  glPopMatrix();
-  glMatrixMode(GL_PROJECTION);
-  glPopMatrix();
-  glPopAttrib();
-  glViewport(last_viewport[0], last_viewport[1],
-             static_cast<GLsizei>(last_viewport[2]),
-             static_cast<GLsizei>(last_viewport[3]));
+#ifdef GL_SAMPLER_BINDING
+  glBindSampler(0, last_sampler);
+#endif
+  glActiveTexture(last_active_texture);
+#ifndef IMGUI_IMPL_OPENGL_ES2
+  glBindVertexArray(last_vertex_array);
+#endif
+  glBindBuffer(GL_ARRAY_BUFFER, last_array_buffer);
+  glBlendEquationSeparate(last_blend_equation_rgb, last_blend_equation_alpha);
+  glBlendFuncSeparate(last_blend_src_rgb, last_blend_dst_rgb,
+                      last_blend_src_alpha, last_blend_dst_alpha);
+  if (last_enable_blend)
+    glEnable(GL_BLEND);
+  else
+    glDisable(GL_BLEND);
+  if (last_enable_cull_face)
+    glEnable(GL_CULL_FACE);
+  else
+    glDisable(GL_CULL_FACE);
+  if (last_enable_depth_test)
+    glEnable(GL_DEPTH_TEST);
+  else
+    glDisable(GL_DEPTH_TEST);
+  if (last_enable_scissor_test)
+    glEnable(GL_SCISSOR_TEST);
+  else
+    glDisable(GL_SCISSOR_TEST);
+#ifdef GL_POLYGON_MODE
+  glPolygonMode(GL_FRONT_AND_BACK, (GLenum)last_polygon_mode[0]);
+#endif
+  glViewport(last_viewport[0], last_viewport[1], (GLsizei)last_viewport[2],
+             (GLsizei)last_viewport[3]);
+  glScissor(last_scissor_box[0], last_scissor_box[1],
+            (GLsizei)last_scissor_box[2], (GLsizei)last_scissor_box[3]);
+
+  // **************************************************************************************
+
+  //// We are using the OpenGL fixed pipeline to make the example code simpler to
+  //// read! Setup render state: alpha-blending enabled, no face culling, no depth
+  //// testing, scissor enabled, vertex/texcoord/color pointers.
+  //GLint last_texture;
+  //glGetIntegerv(GL_TEXTURE_BINDING_2D, &last_texture);
+  //GLint last_viewport[4];
+  //glGetIntegerv(GL_VIEWPORT, last_viewport);
+  //glPushAttrib(GL_ENABLE_BIT | GL_COLOR_BUFFER_BIT | GL_TRANSFORM_BIT);
+  //glEnable(GL_BLEND);
+  //glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+  //glDisable(GL_CULL_FACE);
+  //// glDisable(GL_DEPTH_TEST);
+  //glEnable(GL_SCISSOR_TEST);
+  //glEnableClientState(GL_VERTEX_ARRAY);
+  //glEnableClientState(GL_TEXTURE_COORD_ARRAY);
+  //glEnableClientState(GL_COLOR_ARRAY);
+  //glEnable(GL_TEXTURE_2D);
+  //glUseProgram(
+  //    0);  // You may want this if using this code in an OpenGL 3+ context
+
+  //// Handle cases of screen coordinates != from framebuffer coordinates (e.g.
+  //// retina displays)
+  //ImGuiIO& io = ImGui::GetIO();
+  //int fb_width =
+  //    static_cast<int>(io.DisplaySize.x * io.DisplayFramebufferScale.x);
+  //int fb_height =
+  //    static_cast<int>(io.DisplaySize.y * io.DisplayFramebufferScale.y);
+  //draw_data->ScaleClipRects(io.DisplayFramebufferScale);
+
+  //// Setup viewport, orthographic projection matrix
+  //glViewport(0, 0, static_cast<GLsizei>(fb_width),
+  //           static_cast<GLsizei>(fb_height));
+  //glMatrixMode(GL_PROJECTION);
+  //glPushMatrix();
+  //glLoadIdentity();
+  //glOrtho(0.0f, io.DisplaySize.x, io.DisplaySize.y, 0.0f, -1.0f, +1.0f);
+  //glMatrixMode(GL_MODELVIEW);
+  //glPushMatrix();
+  //glLoadIdentity();
+
+  //// Render command lists
+  //for (int n = 0; n < draw_data->CmdListsCount; n++) {
+  //  const ImDrawList* cmd_list = draw_data->CmdLists[n];
+  //  const uint8_t* vtx_buffer =
+  //      reinterpret_cast<const uint8_t*>(&cmd_list->VtxBuffer.front());
+  //  const ImDrawIdx* idx_buffer = &cmd_list->IdxBuffer.front();
+  //  glVertexPointer(2, GL_FLOAT, sizeof(ImDrawVert),
+  //                  vtx_buffer + offsetof(ImDrawVert, pos));
+  //  glTexCoordPointer(2, GL_FLOAT, sizeof(ImDrawVert),
+  //                    vtx_buffer + offsetof(ImDrawVert, uv));
+  //  glColorPointer(4, GL_UNSIGNED_BYTE, sizeof(ImDrawVert),
+  //                 vtx_buffer + offsetof(ImDrawVert, col));
+
+  //  for (int cmd_i = 0; cmd_i < cmd_list->CmdBuffer.size(); cmd_i++) {
+  //    const ImDrawCmd* pcmd = &cmd_list->CmdBuffer[cmd_i];
+  //    if (pcmd->UserCallback) {
+  //      pcmd->UserCallback(cmd_list, pcmd);
+  //    } else {
+  //      glBindTexture(
+  //          GL_TEXTURE_2D,
+  //          static_cast<GLuint>(reinterpret_cast<intptr_t>(pcmd->TextureId)));
+  //      glScissor(static_cast<int>(pcmd->ClipRect.x),
+  //                static_cast<int>(fb_height - pcmd->ClipRect.w),
+  //                static_cast<int>(pcmd->ClipRect.z - pcmd->ClipRect.x),
+  //                static_cast<int>(pcmd->ClipRect.w - pcmd->ClipRect.y));
+  //      glDrawElements(
+  //          GL_TRIANGLES, static_cast<GLsizei>(pcmd->ElemCount),
+  //          sizeof(ImDrawIdx) == 2 ? GL_UNSIGNED_SHORT : GL_UNSIGNED_INT,
+  //          idx_buffer);
+  //    }
+  //    idx_buffer += pcmd->ElemCount;
+  //  }
+  //}
+
+  //// Restore modified state
+  //glDisableClientState(GL_COLOR_ARRAY);
+  //glDisableClientState(GL_TEXTURE_COORD_ARRAY);
+  //glDisableClientState(GL_VERTEX_ARRAY);
+  //glBindTexture(GL_TEXTURE_2D, last_texture);
+  //glMatrixMode(GL_MODELVIEW);
+  //glPopMatrix();
+  //glMatrixMode(GL_PROJECTION);
+  //glPopMatrix();
+  //glPopAttrib();
+  //glViewport(last_viewport[0], last_viewport[1],
+  //           static_cast<GLsizei>(last_viewport[2]),
+  //           static_cast<GLsizei>(last_viewport[3]));
 }
 
 ImFont* AddOrbitFont(float pixel_size) {
@@ -415,58 +802,55 @@ void Orbit_ImGui_NewFrame(GlCanvas* a_Canvas) {
 
   ImGuiIO& io = ImGui::GetIO();
 
-  static volatile bool doSsetTexture = true;
-  if (doSsetTexture) {
-    // SCOPE_TIMER_LOG( "glTexImage2D" );
-    unsigned char* pixels;
-    int width, height;
-    io.Fonts->GetTexDataAsAlpha8(&pixels, &width, &height);
-    glBindTexture(GL_TEXTURE_2D, g_FontTexture);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_ALPHA, width, height, 0, GL_ALPHA,
-                 GL_UNSIGNED_BYTE, pixels);
+  // WTF?
+  //static volatile bool doSsetTexture = true;
+  //if (doSsetTexture) {
+  //  // SCOPE_TIMER_LOG( "glTexImage2D" );
+  //  unsigned char* pixels;
+  //  int width, height;
+  //  io.Fonts->GetTexDataAsAlpha8(&pixels, &width, &height);
+  //  glBindTexture(GL_TEXTURE_2D, g_FontTexture);
+  //  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  //  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  //  glTexImage2D(GL_TEXTURE_2D, 0, GL_ALPHA, width, height, 0, GL_ALPHA,
+  //               GL_UNSIGNED_BYTE, pixels);
 
-    glBindTexture(GL_TEXTURE_2D, GTextureInjected);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, inject_image.width,
-                 inject_image.height, 0, GL_RGBA, GL_UNSIGNED_BYTE,
-                 inject_image.pixel_data);
+  //  glBindTexture(GL_TEXTURE_2D, GTextureInjected);
+  //  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  //  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  //  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, inject_image.width,
+  //               inject_image.height, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+  //               inject_image.pixel_data);
 
-    glBindTexture(GL_TEXTURE_2D, GTextureTimer);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, timer_image.width,
-                 timer_image.height, 0, GL_RGBA, GL_UNSIGNED_BYTE,
-                 timer_image.pixel_data);
+  //  glBindTexture(GL_TEXTURE_2D, GTextureTimer);
+  //  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  //  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  //  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, timer_image.width,
+  //               timer_image.height, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+  //               timer_image.pixel_data);
 
-    glBindTexture(GL_TEXTURE_2D, GTextureHelp);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, help_image.width, help_image.height,
-                 0, GL_RGBA, GL_UNSIGNED_BYTE, help_image.pixel_data);
+  //  glBindTexture(GL_TEXTURE_2D, GTextureHelp);
+  //  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  //  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  //  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, help_image.width, help_image.height,
+  //               0, GL_RGBA, GL_UNSIGNED_BYTE, help_image.pixel_data);
 
-    glBindTexture(GL_TEXTURE_2D, GTextureRecord);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, record_image.width,
-                 record_image.height, 0, GL_RGBA, GL_UNSIGNED_BYTE,
-                 record_image.pixel_data);
-  }
+  //  glBindTexture(GL_TEXTURE_2D, GTextureRecord);
+  //  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  //  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  //  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, record_image.width,
+  //               record_image.height, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+  //               record_image.pixel_data);
+  //}
 
-  // Store our identifier
-  io.Fonts->TexID =
-      reinterpret_cast<void*>(static_cast<intptr_t>(g_FontTexture));
+  //// Store our identifier
+  //io.Fonts->TexID =
+  //    reinterpret_cast<void*>(static_cast<intptr_t>(g_FontTexture));
 
   // Setup display size (every frame to accommodate for window resizing)
-  int w = a_Canvas->getWidth();
-  int h = a_Canvas->getHeight();
-  // int display_w;
-  // int display_h;
+  const int w = a_Canvas->getWidth();
+  const int h = a_Canvas->getHeight();
   io.DisplaySize = ImVec2(w, h);
-  // io.DisplayFramebufferScale = ImVec2((float)display_w / w, (float)display_h
-  // / h);
 
   // Setup time step
   // TODO: Does this make sense?

--- a/OrbitGl/ImGuiOrbit.h
+++ b/OrbitGl/ImGuiOrbit.h
@@ -19,8 +19,6 @@
 #include "imgui.h"
 #include "imgui_internal.h"
 
-#define IMGUI_IMPL_OPENGL_LOADER_GLEW
-
 class GlCanvas;
 
 extern ImFont* GOrbitImguiFont;

--- a/OrbitGl/ImGuiOrbit.h
+++ b/OrbitGl/ImGuiOrbit.h
@@ -21,13 +21,11 @@
 
 class GlCanvas;
 
+extern ImFont* GOrbitImguiFont;
+
 IMGUI_API bool Orbit_ImGui_Init();
 IMGUI_API void Orbit_ImGui_Shutdown();
 IMGUI_API void Orbit_ImGui_NewFrame(GlCanvas* a_Canvas);
-
-// Use if you want to reset your rendering device without losing ImGui state.
-IMGUI_API void Orbit_ImGui_InvalidateDeviceObjects();
-IMGUI_API bool Orbit_ImGui_CreateDeviceObjects();
 
 // GLFW callbacks (installed by default if you enable 'install_callbacks' during
 // initialization) Provided here if you want to chain callbacks. You can also
@@ -38,14 +36,9 @@ IMGUI_API void Orbit_ImGui_ScrollCallback(GlCanvas* a_Canvas, int scroll);
 IMGUI_API void Orbit_ImGui_KeyCallback(GlCanvas* a_Canvas, int key, bool down);
 IMGUI_API void Orbit_ImGui_CharCallback(GlCanvas* a_Canvas, unsigned int c);
 
-void SetupImGuiStyle(bool bStyleDark_, float alpha_);
-bool LoadTextureFromFile(const char* filename, uint32_t* out_texture,
-                         int* out_width, int* out_height);
-
 // Returns OpenGL texture id or 0 in case of an error.
 uint32_t LoadTextureFromFile(const char* filename);
 
-extern ImFont* GOrbitImguiFont;
 
 struct ScopeImguiContext {
   explicit ScopeImguiContext(ImGuiContext* a_State) : m_ImGuiContext(nullptr) {

--- a/OrbitGl/ImGuiOrbit.h
+++ b/OrbitGl/ImGuiOrbit.h
@@ -19,6 +19,8 @@
 #include "imgui.h"
 #include "imgui_internal.h"
 
+#define IMGUI_IMPL_OPENGL_LOADER_GLEW
+
 class GlCanvas;
 
 extern ImFont* GOrbitImguiFont;


### PR DESCRIPTION
This is intended to facilitate a switch to OpenGles2/ANGLE in the future. 

I'm not exactly sure which version of Opengl is required to run this. I think 2.0 should do. I tried with a OpenGL 2.1 driver from mesa and it works fine.  Switching to ES2 later should be as easy as removing Glew and adding the ES2 headers.

I moved some stuff from the header into the cpp file. Besides that I tried to change only what is necessary following the example from imgui here: https://github.com/ocornut/imgui/blob/v1.69/examples/imgui_impl_opengl3.cpp
