### PR TITLE
Clean up cereal

### DIFF
--- a/OrbitCore/Callstack.cpp
+++ b/OrbitCore/Callstack.cpp
@@ -166,9 +166,3 @@ ORBIT_SERIALIZE(CallStack, 0) {
   ORBIT_NVP_VAL(0, m_Depth);
   ORBIT_NVP_VAL(0, m_ThreadId);
 }
-
-//-----------------------------------------------------------------------------
-ORBIT_SERIALIZE(HashedCallStack, 0) {
-  ORBIT_NVP_VAL(0, m_Hash);
-  ORBIT_NVP_VAL(0, m_ThreadId);
-}

--- a/OrbitCore/Callstack.h
+++ b/OrbitCore/Callstack.h
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#pragma once
+#ifndef ORBIT_CORE_CALLSTACK_H_
+#define ORBIT_CORE_CALLSTACK_H_
 
 #include "CallstackTypes.h"
 #include "OrbitDbgHelp.h"
@@ -58,14 +59,6 @@ struct CallStack {
   uint32_t m_Depth = 0;
   ThreadID m_ThreadId = 0;
   std::vector<uint64_t> m_Data;
-
-  ORBIT_SERIALIZABLE;
-};
-
-//-----------------------------------------------------------------------------
-struct HashedCallStack {
-  CallstackID m_Hash = 0;
-  ThreadID m_ThreadId = 0;
 
   ORBIT_SERIALIZABLE;
 };
@@ -165,3 +158,5 @@ inline CallStackPOD CallStackPOD::GetCallstackManual(
 #endif
 
 #endif
+
+#endif  // ORBIT_CORE_CALLSTACK_H_

--- a/OrbitCore/ConnectionManager.cpp
+++ b/OrbitCore/ConnectionManager.cpp
@@ -13,7 +13,6 @@
 #include "KeyAndString.h"
 #include "OrbitBase/Logging.h"
 #include "SamplingProfiler.h"
-#include "Serialization.h"
 #include "TcpClient.h"
 #include "TidAndThreadName.h"
 #include "TimerManager.h"

--- a/OrbitCore/ContextSwitch.cpp
+++ b/OrbitCore/ContextSwitch.cpp
@@ -4,8 +4,6 @@
 
 #include "ContextSwitch.h"
 
-#include "Serialization.h"
-
 // Context switches are sent as raw bytes, make sure it's the same size
 // on every platform.
 static_assert(sizeof(ContextSwitch) == 20);
@@ -21,16 +19,3 @@ ContextSwitch::ContextSwitch(SwitchType a_Type)
 
 //-----------------------------------------------------------------------------
 ContextSwitch::~ContextSwitch() = default;
-
-ORBIT_SERIALIZE(ContextSwitch, 0) {
-  ORBIT_NVP_VAL(0, m_ProcessId);
-  ORBIT_NVP_VAL(0, m_ThreadId);
-  ORBIT_NVP_VAL(0, m_Type);
-  ORBIT_NVP_VAL(0, m_Time);
-  ORBIT_NVP_VAL(0, m_ProcessorIndex);
-  ORBIT_NVP_VAL(0, m_ProcessorNumber);
-
-  if constexpr (OrbitCore::is_input_archive_v<Archive>) {
-    CHECK(m_Type >= SwitchType::In && m_Type <= SwitchType::Invalid);
-  }
-}

--- a/OrbitCore/ContextSwitch.h
+++ b/OrbitCore/ContextSwitch.h
@@ -2,9 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#pragma once
+#ifndef ORBIT_CORE_CONTEXT_SWITCH_H_
+#define ORBIT_CORE_CONTEXT_SWITCH_H_
 
-#include "Serialization.h"
+#include <cstdint>
 
 //-----------------------------------------------------------------------------
 #pragma pack(push, 1)
@@ -27,7 +28,7 @@ struct ContextSwitch {
   // https://docs.microsoft.com/en-us/windows/win32/api/relogger/ns-relogger-etw_buffer_context
   // and EVENT_HEADER_FLAG_PROCESSOR_INDEX in
   // https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/fa4f7836-06ee-4ab6-8688-386a5a85f8c5
-
-  ORBIT_SERIALIZABLE;
 };
 #pragma pack(pop)
+
+#endif  // ORBIT_CORE_CONTEXT_SWITCH_H_

--- a/OrbitCore/LinuxCallstackEvent.h
+++ b/OrbitCore/LinuxCallstackEvent.h
@@ -5,14 +5,15 @@
 //-----------------------------------
 // Author: Florian Kuebler
 //-----------------------------------
-#pragma once
+
+#ifndef ORBIT_CORE_LINUX_CALLSTACK_EVENT_H_
+#define ORBIT_CORE_LINUX_CALLSTACK_EVENT_H_
 
 #include <string>
 #include <utility>
 
 #include "Callstack.h"
 #include "Serialization.h"
-#include "SerializationMacros.h"
 
 struct LinuxCallstackEvent {
   LinuxCallstackEvent() = default;
@@ -29,3 +30,5 @@ ORBIT_SERIALIZE(LinuxCallstackEvent, 1) {
   ORBIT_NVP_VAL(1, time_);
   ORBIT_NVP_VAL(1, callstack_);
 }
+
+#endif // ORBIT_CORE_LINUX_CALLSTACK_EVENT_H_

--- a/OrbitCore/OrbitModule.cpp
+++ b/OrbitCore/OrbitModule.cpp
@@ -11,7 +11,6 @@
 #include "OrbitBase/Logging.h"
 #include "Pdb.h"
 #include "ScopeTimer.h"
-#include "Serialization.h"
 #include "absl/strings/str_format.h"
 #include "symbol.pb.h"
 

--- a/OrbitCore/OrbitModule.h
+++ b/OrbitCore/OrbitModule.h
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#pragma once
+#ifndef ORBIT_CORE_ORBIT_MODULE_H_
+#define ORBIT_CORE_ORBIT_MODULE_H_
 
 #include <memory.h>
 
@@ -10,7 +11,6 @@
 
 #include "BaseTypes.h"
 #include "OrbitFunction.h"
-#include "SerializationMacros.h"
 #include "symbol.pb.h"
 
 class Pdb;
@@ -57,3 +57,5 @@ struct Module {
 
   friend class TestRemoteMessages;
 };
+
+#endif // ORBIT_CORE_ORBIT_MODULE_H_

--- a/OrbitCore/OrbitProcess.cpp
+++ b/OrbitCore/OrbitProcess.cpp
@@ -18,7 +18,6 @@
 #include "Path.h"
 #include "Pdb.h"
 #include "ScopeTimer.h"
-#include "Serialization.h"
 #include "Utils.h"
 
 #ifdef _WIN32

--- a/OrbitCore/OrbitProcess.h
+++ b/OrbitCore/OrbitProcess.h
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#pragma once
+#ifndef ORBIT_CORE_ORBIT_PROCESS_H_
+#define ORBIT_CORE_ORBIT_PROCESS_H_
 
 #include <map>
 #include <memory>
@@ -14,7 +15,6 @@
 #include "BaseTypes.h"
 #include "LinuxAddressInfo.h"
 #include "ScopeTimer.h"
-#include "SerializationMacros.h"
 #include "Threading.h"
 #include "absl/container/flat_hash_map.h"
 
@@ -166,3 +166,5 @@ class Process {
 
   friend class TestRemoteMessages;
 };
+
+#endif // ORBIT_CORE_ORBIT_PROCESS_H_

--- a/OrbitCore/OrbitType.cpp
+++ b/OrbitCore/OrbitType.cpp
@@ -14,7 +14,6 @@
 #include "Pdb.h"
 #include "PrintVar.h"
 #include "SamplingProfiler.h"
-#include "Serialization.h"
 #include "TcpServer.h"
 
 void Type::AddParent(Type* a_Parent) { UNUSED(a_Parent); }

--- a/OrbitCore/OrbitType.h
+++ b/OrbitCore/OrbitType.h
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#pragma once
+#ifndef ORBIT_CORE_ORBIT_TYPE_H_
+#define ORBIT_CORE_ORBIT_TYPE_H_
 
 #include <map>
 #include <set>
@@ -12,7 +13,6 @@
 #include "FunctionStats.h"
 #include "OrbitDbgHelp.h"
 #include "OrbitFunction.h"
-#include "SerializationMacros.h"
 #include "Variable.h"
 #include "cvconst.h"
 
@@ -85,3 +85,5 @@ class Type {
   mutable std::map<ULONG, Parent> m_Hierarchy;
   std::shared_ptr<Variable> m_TemplateVariable;
 };
+
+#endif  // ORBIT_CORE_ORBIT_TYPE_H_

--- a/OrbitCore/Pdb.cpp
+++ b/OrbitCore/Pdb.cpp
@@ -18,7 +18,6 @@
 #include "OrbitType.h"
 #include "OrbitUnreal.h"
 #include "Params.h"
-#include "Serialization.h"
 #include "SymbolUtils.h"
 #include "Tcp.h"
 #include "TcpServer.h"
@@ -176,37 +175,6 @@ std::string Pdb::GetCachedKey() {
   std::string cachedName = GetCachedName();
   std::string cachedKey = cachedName.substr(0, cachedName.find_first_of('_'));
   return cachedKey;
-}
-
-//-----------------------------------------------------------------------------
-bool Pdb::Load(const std::string& a_CachedPdb) {
-  /*ifstream is( a_CachedPdb, std::ios::binary );
-  if( !is.fail() )
-  {
-      cereal::BinaryInputArchive Ar( is );
-      Ar(*this);
-      m_LoadedFromCache = true;
-      return true;
-  }*/
-
-  return false;
-}
-
-//-----------------------------------------------------------------------------
-void Pdb::Update() {
-  if (m_FinishedLoading) {
-    m_LoadingCompleteCallback();
-    m_FinishedLoading = false;
-    Print();
-
-    if (!m_LoadedFromCache && false) {
-      Save();
-    }
-  }
-
-  if (m_IsLoading) {
-    SendStatusToUi();
-  }
 }
 
 //-----------------------------------------------------------------------------
@@ -494,16 +462,4 @@ void Pdb::ProcessData() {
   PopulateFunctionMap();
   PopulateStringFunctionMap();
   // TODO: parallelize: PopulateStringFunctionMap();
-}
-
-//-----------------------------------------------------------------------------
-void Pdb::Save() {
-  std::string fullName =
-      Path::JoinPath({Path::GetCachePath(), GetCachedName()});
-
-  SCOPE_TIMER_LOG(absl::StrFormat("Saving %s", fullName.c_str()));
-
-  // ofstream os( fullName, std::ios::binary );
-  // cereal::BinaryOutputArchive Ar(os);
-  // Ar( *this );
 }

--- a/OrbitCore/Pdb.h
+++ b/OrbitCore/Pdb.h
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#pragma once
+#ifndef ORBIT_CORE_PDB_H_
+#define ORBIT_CORE_PDB_H_
 
 #include <atomic>
 #include <functional>
@@ -38,7 +39,6 @@ class Pdb {
 
   bool LoadDataFromPdb();
   bool LoadPdbDia();
-  void Update();
   void AddFunction(const std::shared_ptr<Function>& function);
   void CheckOrbitFunction(Function& a_Function);
   void AddType(const Type& a_Type);
@@ -83,22 +83,8 @@ class Pdb {
 
   std::string GetCachedName();
   std::string GetCachedKey();
-  bool Load(const std::string& a_CachedPdb);
-  void Save();
 
   bool IsLoading() const { return m_IsLoading; }
-
-  template <class Archive>
-  void serialize(Archive& ar, std::uint32_t const version) {
-    /*ar( CEREAL_NVP(m_Name)
-      , CEREAL_NVP(m_FileName)
-      , CEREAL_NVP(m_FileNameW)
-      , CEREAL_NVP(m_Functions)
-      , CEREAL_NVP(m_Types)
-      , CEREAL_NVP(m_Globals)
-      , CEREAL_NVP(m_ModuleInfo)
-      , CEREAL_NVP(m_TypeMap) );*/
-  }
 
   void ProcessData();
 
@@ -157,7 +143,6 @@ class Pdb {
     return true;
   }  // This shouldn't do anything on Linux.
   bool LoadPdbDia() { return false; }
-  void Update() {}
   void CheckOrbitFunction(Function&) {}
   void AddType(const Type&) {}
   void AddGlobal(const Variable&) {}
@@ -202,13 +187,9 @@ class Pdb {
 
   std::string GetCachedName();
   std::string GetCachedKey();
-  bool Load(const std::string& a_CachedPdb);
-  void Save();
 
   bool IsLoading() const { return m_IsLoading; }
 
-  template <class Archive>
-  void serialize(Archive&, uint32_t /*version*/) {}
   void ProcessData();
 
  protected:
@@ -242,3 +223,5 @@ class Pdb {
 #endif
 
 extern std::shared_ptr<Pdb> GPdbDbg;
+
+#endif // ORBIT_CORE_PDB_H_

--- a/OrbitCore/TidAndThreadName.h
+++ b/OrbitCore/TidAndThreadName.h
@@ -9,7 +9,6 @@
 #include <utility>
 
 #include "Serialization.h"
-#include "SerializationMacros.h"
 
 struct TidAndThreadName {
   TidAndThreadName() = default;

--- a/OrbitCore/Variable.cpp
+++ b/OrbitCore/Variable.cpp
@@ -10,7 +10,6 @@
 #include "Log.h"
 #include "Pdb.h"
 #include "ScopeTimer.h"
-#include "Serialization.h"
 #include "TcpServer.h"
 
 Variable::Variable() { m_SyncTimer = new Timer(); }
@@ -260,16 +259,4 @@ void Variable::SetDouble(double a_Value) {
     default:
       break;
   }
-}
-
-ORBIT_SERIALIZE_WSTRING(Variable, 0) {
-  ORBIT_NVP_VAL(0, m_Name);
-  ORBIT_NVP_VAL(0, m_Type);
-  ORBIT_NVP_VAL(0, m_Function);
-  ORBIT_NVP_VAL(0, m_File);
-  ORBIT_NVP_VAL(0, m_Line);
-  ORBIT_NVP_VAL(0, m_Address);
-  ORBIT_NVP_VAL(0, m_Size);
-  ORBIT_NVP_VAL(0, m_TypeIndex);
-  ORBIT_NVP_VAL(0, m_Children);
 }

--- a/OrbitCore/Variable.h
+++ b/OrbitCore/Variable.h
@@ -2,12 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#pragma once
+#ifndef ORBIT_CORE_VARIABLE_H_
+#define ORBIT_CORE_VARIABLE_H_
 
 #include <memory>
 
 #include "BaseTypes.h"
-#include "SerializationMacros.h"
 #include "Utils.h"
 #include "absl/strings/str_format.h"
 
@@ -147,8 +147,6 @@ class Variable {
 
   std::vector<char> m_RawData;
   std::string m_String;
-
-  ORBIT_SERIALIZABLE;
 };
 
 //-----------------------------------------------------------------------------
@@ -160,3 +158,5 @@ inline const std::string& Variable::FilterString() {
 
   return m_FilterString;
 }
+
+#endif  // ORBIT_CORE_VARIABLE_H_

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -46,7 +46,6 @@
 #include "SamplingProfiler.h"
 #include "SamplingReport.h"
 #include "ScopeTimer.h"
-#include "Serialization.h"
 #include "SessionsDataView.h"
 #include "StringManager.h"
 #include "Systrace.h"

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -10,7 +10,6 @@
 #include "EventTracer.h"
 #include "GlUtils.h"
 #include "PluginManager.h"
-#include "Serialization.h"
 #include "Systrace.h"
 #include "TcpClient.h"
 #include "TcpServer.h"

--- a/OrbitQt/orbitmainwindow.ui
+++ b/OrbitQt/orbitmainwindow.ui
@@ -302,7 +302,6 @@
     <addaction name="actionShow_Includes_Util"/>
    </widget>
    <addaction name="menuFile"/>
-   <addaction name="menuDev"/>
    <addaction name="menuDebug"/>
    <addaction name="menuTools"/>
    <addaction name="menuHelp"/>


### PR DESCRIPTION
Remove cereal code and headers (Serialization/SerializationMacros) from where it's no longer used, added #define guards.