### PR TITLE
Move FLAGS_sampling_rate, FLAGS_frame_pointer_unwinding to the client

### DIFF
--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -19,11 +19,15 @@ TracerThread::TracerThread(const CaptureOptions& capture_options)
       pid_{capture_options.pid()},
       unwinding_method_{capture_options.unwinding_method()},
       trace_gpu_driver_{capture_options.trace_gpu_driver()} {
-  std::optional<uint64_t> sampling_period_ns =
-      ComputeSamplingPeriodNs(capture_options.sampling_rate());
-  FAIL_IF(!sampling_period_ns.has_value(), "Invalid sampling rate: %.1f",
-          capture_options.sampling_rate());
-  sampling_period_ns_ = sampling_period_ns.value();
+  if (unwinding_method_ != CaptureOptions::kUndefined) {
+    std::optional<uint64_t> sampling_period_ns =
+        ComputeSamplingPeriodNs(capture_options.sampling_rate());
+    FAIL_IF(!sampling_period_ns.has_value(), "Invalid sampling rate: %.1f",
+            capture_options.sampling_rate());
+    sampling_period_ns_ = sampling_period_ns.value();
+  } else {
+    sampling_period_ns_ = 0;
+  }
 
   instrumented_functions_.clear();
   instrumented_functions_.reserve(

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -54,6 +54,14 @@ ABSL_FLAG(bool, use_software_opengl, false, "Uses software implementation of "
 	      "OpenGL. Requires Mesa's opengl32.dll to be placed in the same "
 	      "folder as Orbit.");
 
+// TODO(b/160549506): Remove this flag once it can be specified in the ui.
+ABSL_FLAG(uint16_t, sampling_rate, 1000,
+          "Frequency of callstack sampling in samples per second");
+
+// TODO(b/160549506): Remove this flag once it can be specified in the ui.
+ABSL_FLAG(bool, frame_pointer_unwinding, false,
+          "Use frame pointers for unwinding");
+
 // TODO: remove this once we deprecated legacy parameters
 static void ParseLegacyCommandLine(int argc, char* argv[],
                                    ApplicationOptions* options) {

--- a/OrbitService/main.cpp
+++ b/OrbitService/main.cpp
@@ -19,15 +19,6 @@ ABSL_FLAG(uint64_t, grpc_port, 44765, "Grpc server port");
 
 ABSL_FLAG(bool, devmode, false, "Enable developer mode");
 
-// TODO: Remove this flag once we enable specifying the sampling frequency or
-//  period in the client.
-ABSL_FLAG(uint16_t, sampling_rate, 1000,
-          "Frequency of callstack sampling in samples per second");
-
-// TODO: Remove this flag once we have a ui option to specify.
-ABSL_FLAG(bool, frame_pointer_unwinding, false,
-          "Use frame pointers for unwinding");
-
 namespace {
 std::atomic<bool> exit_requested;
 
@@ -59,18 +50,7 @@ int main(int argc, char** argv) {
   uint16_t grpc_port = absl::GetFlag(FLAGS_grpc_port);
   uint16_t asio_port = absl::GetFlag(FLAGS_asio_port);
 
-  CaptureOptions capture_options;
-  capture_options.set_sampling_rate(absl::GetFlag(FLAGS_sampling_rate));
-  capture_options.set_trace_gpu_driver(true);
-  capture_options.set_trace_context_switches(true);
-
-  if (absl::GetFlag(FLAGS_frame_pointer_unwinding)) {
-    capture_options.set_unwinding_method(CaptureOptions::kFramePointers);
-  } else {
-    capture_options.set_unwinding_method(CaptureOptions::kDwarf);
-  }
-
   exit_requested = false;
-  OrbitService service{grpc_port, asio_port, capture_options};
+  OrbitService service{grpc_port, asio_port, CaptureOptions{}};
   service.Run(&exit_requested);
 }


### PR DESCRIPTION
`CaptureOptions` are now sent over gRPC and hence filled on the client.