### PR TITLE
Fix callchain patching with tail calls.

### DIFF
--- a/OrbitLinuxTracing/PerfEventOpen.cpp
+++ b/OrbitLinuxTracing/PerfEventOpen.cpp
@@ -89,6 +89,7 @@ int callchain_sample_event_open(uint64_t period_ns, pid_t pid, int32_t cpu) {
   pe.sample_type |= PERF_SAMPLE_CALLCHAIN;
   // TODO(kuebler): Read this from /proc/sys/kernel/perf_event_max_stack
   pe.sample_max_stack = 127;
+  pe.exclude_callchain_kernel = true;
 
   return generic_event_open(&pe, pid, cpu);
 }

--- a/OrbitLinuxTracing/UprobesReturnAddressManager.h
+++ b/OrbitLinuxTracing/UprobesReturnAddressManager.h
@@ -120,7 +120,7 @@ class UprobesReturnAddressManager {
       return false;
     }
 
-    // Process frames from outermost to the innermost.
+    // Process frames from the outermost to the innermost.
     auto frames_to_patch_it = frames_to_patch.rbegin();
     size_t uprobes_size = tid_uprobes_stack.size();
 

--- a/OrbitLinuxTracing/UprobesReturnAddressManager.h
+++ b/OrbitLinuxTracing/UprobesReturnAddressManager.h
@@ -136,7 +136,7 @@ class UprobesReturnAddressManager {
     // On tail-call optimization, when instrumenting the caller and the callee,
     // the correct call-stack will only contain the callee.
     // However, there are two uprobe records (with the same stack pointer),
-    // where the first one contains the correct return address.
+    // where the first one (the caller's) contains the correct return address.
     prev_uprobe_stack_pointer = -1;
     size_t unique_uprobes_so_far = 0;
     for (size_t uprobe_i = 0; uprobe_i < uprobes_size; uprobe_i++) {

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
@@ -78,11 +78,11 @@ void UprobesUnwindingVisitor::visit(CallchainSamplePerfEvent* event) {
   }
 
   uint64_t top_ip = event->GetCallchain()[1];
-  unwindstack::MapInfo* map_info = current_maps_->Find(top_ip);
+  unwindstack::MapInfo* top_ip_map_info = current_maps_->Find(top_ip);
 
   // Some samples can actually fall inside u(ret)probes code. Discard them,
   // as we don't want to show the unnamed uprobes module in the samples.
-  if (map_info == nullptr || map_info->name == "[uprobes]") {
+  if (top_ip_map_info == nullptr || top_ip_map_info->name == "[uprobes]") {
     if (discarded_samples_in_uretprobes_counter_ != nullptr) {
       ++(*discarded_samples_in_uretprobes_counter_);
     }

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
@@ -81,7 +81,7 @@ void UprobesUnwindingVisitor::visit(CallchainSamplePerfEvent* event) {
   unwindstack::MapInfo* map_info = current_maps_->Find(top_ip);
 
   // Some samples can actually fall inside u(ret)probes code. Discard them,
-  // because when they are unwound successfully the result is wrong.
+  // as we don't want to show the unnamed uprobes module in the samples.
   if (map_info == nullptr || map_info->name == "[uprobes]") {
     if (discarded_samples_in_uretprobes_counter_ != nullptr) {
       ++(*discarded_samples_in_uretprobes_counter_);


### PR DESCRIPTION
On tail-call optimization, when instrumenting the caller and the callee, the correct call-stack will only contain the callee. However, there are two uprobe records (with the same stack pointer), where the first one (the one for the callee) contains the correct return address. 
Prior this change, we would have discarded the sample, as the number of uprobes and frames to patch did not match.
No we fix this, by skipping the uprobes, if the prev. uprobe had the same stack pointer.

Further, we now also discard samples, that directly fall into a uprobe (as we do with DWARF based unwinding). Further 
Fixes patching of samples that have uprobes in their call stack and contain tail calls. Further, excluded kernel call stack and discard samples that actually fall into the uprobe. In order to do this, we also now only collect callchain information of user code and excluded the kernel one. This way we can check, that the top of the stack actually is inside the uprobes map.