### PR TITLE
Discard broken samples, where no uprobe records are available

### DIFF
--- a/OrbitLinuxTracing/UprobesReturnAddressManager.h
+++ b/OrbitLinuxTracing/UprobesReturnAddressManager.h
@@ -88,9 +88,13 @@ class UprobesReturnAddressManager {
 
     if (!tid_uprobes_stacks_.contains(tid)) {
       // There are very rare cases where we don't have uprobes records, but need
-      // to patch some frames. In this case, we need to discard the sample.
-      // Otherwise, we don't need to patch it at all.
-      return frames_to_patch.empty();
+      // to patch some frames. This results either from loosing events or
+      // processing events out of order.
+      if (!frames_to_patch.empty()) {
+        ERROR("Discarding sample in a uprobe as uprobe records are missing.");
+        return false;
+      }
+      return true;
     }
 
     auto& tid_uprobes_stack = tid_uprobes_stacks_.at(tid);

--- a/OrbitLinuxTracing/UprobesReturnAddressManager.h
+++ b/OrbitLinuxTracing/UprobesReturnAddressManager.h
@@ -111,7 +111,7 @@ class UprobesReturnAddressManager {
       prev_uprobe_stack_pointer = uprobe.stack_pointer;
     }
 
-    // In case we have less uprobes (with correct return address), than samples
+    // In case we have less uprobes (with correct return address) than frames
     // to be patched, we need to discard this sample.
     // There are two situations where this may happen:
     //  1. At the beginning of a capture, where we missed the first uprobes

--- a/OrbitLinuxTracing/UprobesReturnAddressManagerTest.cpp
+++ b/OrbitLinuxTracing/UprobesReturnAddressManagerTest.cpp
@@ -622,6 +622,20 @@ TEST(UprobesReturnAddressManager, CallchainBeforeInjectionByUprobe) {
   EXPECT_THAT(callchain_sample, testing::ElementsAreArray(expected_callchain));
 }
 
+TEST(UprobesReturnAddressManager, CallchainWithoutUprobeRecord) {
+  UprobesReturnAddressManager return_address_manager;
+
+  std::vector<uint64_t> callchain_sample{
+      0xFFFFFFFFFFFFFE00lu, 0x55D0F260D23Elu, 0x55D0F260D268lu,
+      0x55D0F260D29Alu,     0x55D0F260D2CClu, 0x7FFFFFFFE000lu,
+      0x55D0F260D330lu,     0x55D0F260D362lu, 0x55D0F260D397lu,
+      0x55D0F260D3BBlu,     0x55D0F260D4CBlu, 0x7F075B666BBBlu,
+      0x5541D68949564100lu};
+
+  EXPECT_FALSE(return_address_manager.PatchCallchain(
+      1, callchain_sample.data(), callchain_sample.size(), maps.get()));
+}
+
 TEST(UprobesReturnAddressManager, CallchainOfTailcall) {
   UprobesReturnAddressManager return_address_manager;
 


### PR DESCRIPTION
There are very rare situations where no uprobe records are available, but the callchain contains a uprobe. In those situations, we need to discard the broken sample, as we can't fix it.