### PR TITLE
Add conan recipe for libprotobuf-mutator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,10 @@ find_package(GTest REQUIRED)
 find_package(GMock REQUIRED)
 find_package(Filesystem REQUIRED)
 
+if (WITH_FUZZING)
+  find_package(libprotobuf-mutator CONFIG REQUIRED)
+endif()
+
 # Set preprocessor defines These are only necessary for windows, but we will
 # define them on all platforms, to keep the builds similar as possible.
 add_definitions(-DNOMINMAX)

--- a/conanfile.py
+++ b/conanfile.py
@@ -87,6 +87,10 @@ class OrbitConan(ConanFile):
             if not self.options.system_qt:
                 self.requires("qt/5.14.1@bincrafters/stable#0")
 
+        if self.options.with_fuzzing:
+            self.requires(
+                "libprotobuf-mutator/20200506@{}#5e2c709e22b0ad149482efd73db41e23".format(self._orbit_channel))
+
     def configure(self):
         if self.options.debian_packaging and (self.settings.get_safe("os.platform") != "GGP" or tools.detected_os() != "Linux"):
             raise ConanInvalidConfiguration(

--- a/third_party/conan/recipes/libprotobuf-mutator/conandata.yml
+++ b/third_party/conan/recipes/libprotobuf-mutator/conandata.yml
@@ -1,0 +1,10 @@
+sources:
+        "20200506":
+                url: "https://github.com/google/libprotobuf-mutator/archive/7a2ed51a6b682a83e345ff49fc4cfd7ca47550db.zip"
+                sha256: "88e9e650e4010c142c3d408df66277af425583561ab3207c63cae702ce4065a5"
+patches:
+        "20200506":
+         - patch_file: "patches/001-conanbuildinfo.diff"
+           base_path: "libprotobuf-mutator-7a2ed51a6b682a83e345ff49fc4cfd7ca47550db"
+source_subfolder:
+        "20200506": "libprotobuf-mutator-7a2ed51a6b682a83e345ff49fc4cfd7ca47550db"

--- a/third_party/conan/recipes/libprotobuf-mutator/conanfile.py
+++ b/third_party/conan/recipes/libprotobuf-mutator/conanfile.py
@@ -1,0 +1,49 @@
+from conans import ConanFile, CMake, tools
+
+
+class LibprotobufMutatorConan(ConanFile):
+    name = "libprotobuf-mutator"
+    version = "20200506"
+    license = "Apache-2.0"
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+    exports_sources = "patches/*",
+    build_requires = "protoc_installer/3.9.1@bincrafters/stable",
+    options = { "fPIC" : [True, False] }
+    default_options = { "fPIC" : True }
+
+    def configure(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        for patch in self.conan_data["patches"][self.version]:
+            tools.patch(**patch)
+
+    def requirements(self):
+        self.requires("lzma_sdk/19.00@orbitdeps/stable")
+        self.requires("zlib/1.2.11")
+        self.requires("protobuf/3.9.1@bincrafters/stable")
+
+    def build(self):
+        self._source_subfolder = self.conan_data["source_subfolder"][self.version]
+        cmake = CMake(self)
+        cmake.definitions["LIB_PROTO_MUTATOR_TESTING"] = False
+        cmake.definitions["CMAKE_CXX_FLAGS"] = "-fPIE"
+        cmake.definitions["CMAKE_C_FLAGS"] = "-fPIE"
+        cmake.configure(source_folder=self._source_subfolder)
+        cmake.build()
+
+    def package(self):
+        self.copy("*.h", dst="include",
+                  src="{}/src".format(self._source_subfolder))
+        self.copy("*.h", dst="include/port",
+                  src="{}/port".format(self._source_subfolder))
+        self.copy("*.lib", dst="lib", keep_path=False)
+        self.copy("*.pdb", dst="lib", keep_path=False)
+        self.copy("*.a", dst="lib", keep_path=False)
+
+    def package_info(self):
+        self.cpp_info.libdirs = ["lib"]
+        self.cpp_info.libs = ["protobuf-mutator-libfuzzer", "protobuf-mutator"]

--- a/third_party/conan/recipes/libprotobuf-mutator/patches/001-conanbuildinfo.diff
+++ b/third_party/conan/recipes/libprotobuf-mutator/patches/001-conanbuildinfo.diff
@@ -1,0 +1,60 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d9be154..46c7f52 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -14,6 +14,7 @@
+ 
+ cmake_minimum_required(VERSION 3.5)
+ project(LibProtobufMutator CXX)
++include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+ 
+ enable_language(C)
+ enable_language(CXX)
+@@ -25,9 +26,6 @@ option(LIB_PROTO_MUTATOR_WITH_ASAN "Enable address sanitizer" OFF)
+ option(PKG_CONFIG_PATH "Directory to install pkgconfig file" "share/pkgconfig")
+ set(LIB_PROTO_MUTATOR_FUZZER_LIBRARIES "" CACHE STRING "Fuzzing engine libs")
+ 
+-# External dependencies
+-set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/external)
+-
+ # External dependencies
+ include(ProcessorCount)
+ include(CheckCCompilerFlag)
+@@ -36,11 +34,8 @@ include(CheckCXXCompilerFlag)
+ set(THREADS_PREFER_PTHREAD_FLAG ON)
+ find_package(Threads)
+ 
+-find_package(LibLZMA)
+-include_directories(${LIBLZMA_INCLUDE_DIRS})
+-
+-find_package(ZLIB)
+-include_directories(${ZLIB_INCLUDE_DIRS})
++include_directories(${CONAN_INCLUDE_DIRS_ZLIB})
++set(ZLIB_LIBRARIES ${CONAN_LIBS_ZLIB})
+ 
+ set(CMAKE_CXX_STANDARD 11)
+ 
+@@ -124,9 +119,9 @@ endif()
+ if (LIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF)
+   include(protobuf)
+ else()
+-  find_package(Protobuf REQUIRED)
+-  include_directories(${PROTOBUF_INCLUDE_DIRS})
++  include_directories(${CONAN_INCLUDE_DIRS_PROTOBUF})
+   include_directories(${CMAKE_CURRENT_BINARY_DIR})
++  set(PROTOBUF_LIBRARIES ${CONAN_LIBS_PROTOBUF})
+ endif()
+ 
+ set(LIB_DIR "lib${LIB_SUFFIX}")
+@@ -145,11 +140,6 @@ endif()
+ 
+ add_subdirectory(src)
+ 
+-if (NOT "${LIB_PROTO_MUTATOR_FUZZER_LIBRARIES}" STREQUAL "" OR
+-    NOT "${FUZZING_FLAGS}" STREQUAL "")
+-  add_subdirectory(examples EXCLUDE_FROM_ALL)
+-endif()
+-
+ configure_file("libprotobuf-mutator.pc.in" "libprotobuf-mutator.pc" @ONLY)
+ install(FILES "${CMAKE_BINARY_DIR}/libprotobuf-mutator.pc"
+   DESTINATION ${PKG_CONFIG_PATH})


### PR DESCRIPTION
This PR adds the recipe and integrates it into our conanfile.py. Since no binary packages will be provided this can be done in one step.

The library is only needed for fuzzing, so it won't be integrated with the lockfiles. Hence no lockfile-update in here.