### PR TITLE
Trigger row selection callback when using arrow keys in treeviews.

### DIFF
--- a/OrbitQt/orbitdataviewpanel.cpp
+++ b/OrbitQt/orbitdataviewpanel.cpp
@@ -62,9 +62,6 @@ void OrbitDataViewPanel::SetFilter(const QString& a_Filter) {
 }
 
 //-----------------------------------------------------------------------------
-void OrbitDataViewPanel::Select(int a_Row) { ui->treeView->Select(a_Row); }
-
-//-----------------------------------------------------------------------------
 void OrbitDataViewPanel::on_FilterLineEdit_textEdited(const QString& a_Text) {
   ui->treeView->OnFilter(a_Text);
 }

--- a/OrbitQt/orbitdataviewpanel.h
+++ b/OrbitQt/orbitdataviewpanel.h
@@ -26,7 +26,6 @@ class OrbitDataViewPanel : public QWidget {
   void Refresh();
   void SetDataModel(DataView* model);
   void SetFilter(const QString& a_Filter);
-  void Select(int a_Row);
   class OrbitTreeView* GetTreeView();
 
  private slots:

--- a/OrbitQt/orbittablemodel.cpp
+++ b/OrbitQt/orbittablemodel.cpp
@@ -110,8 +110,8 @@ void OrbitTableModel::OnFilter(const QString& a_Filter) {
 }
 
 //-----------------------------------------------------------------------------
-void OrbitTableModel::OnClicked(const QModelIndex& index) {
-  if (static_cast<int>(m_DataView->GetNumElements()) > index.row()) {
-    m_DataView->OnSelect(index.row());
+void OrbitTableModel::OnRowSelected(int row) {
+  if (static_cast<int>(m_DataView->GetNumElements()) > row) {
+    m_DataView->OnSelect(row);
   }
 }

--- a/OrbitQt/orbittablemodel.h
+++ b/OrbitQt/orbittablemodel.h
@@ -38,7 +38,7 @@ class OrbitTableModel : public QAbstractTableModel {
 
   void OnTimer();
   void OnFilter(const QString& a_Filter);
-  void OnClicked(const QModelIndex& index);
+  void OnRowSelected(int row);
 
  protected:
   DataView* m_DataView;

--- a/OrbitQt/orbittreeview.cpp
+++ b/OrbitQt/orbittreeview.cpp
@@ -249,7 +249,7 @@ void OrbitTreeView::selectionChanged(const QItemSelection& selected,
                                      const QItemSelection& deselected) {
   QTreeView::selectionChanged(selected, deselected);
 
-  // Dont trigger callbacks if selection was initiated internally.
+  // Don't trigger callbacks if selection was initiated internally.
   if (is_internal_refresh_) return;
 
   // Row selection callback.

--- a/OrbitQt/orbittreeview.cpp
+++ b/OrbitQt/orbittreeview.cpp
@@ -47,9 +47,6 @@ OrbitTreeView::OrbitTreeView(QWidget* parent)
   connect(header(), SIGNAL(sectionResized(int, int, int)), this,
           SLOT(columnResized(int, int, int)));
 
-  connect(this, SIGNAL(clicked(const QModelIndex)), this,
-          SLOT(OnClicked(const QModelIndex)));
-
   connect(verticalScrollBar(), SIGNAL(rangeChanged(int, int)), this,
           SLOT(OnRangeChanged(int, int)));
 }
@@ -256,9 +253,9 @@ void OrbitTreeView::selectionChanged(const QItemSelection& selected,
   if (is_internal_refresh_) return;
 
   // Row selection callback.
-  QModelIndexList rows = selectionModel()->selectedRows();
-  if (rows.size() == 1) {
-    OnRowSelected(rows[0].row());
+  QModelIndex index = selectionModel()->currentIndex();
+  if (index.isValid()) {
+    OnRowSelected(selectionModel()->currentIndex().row());
   }
 }
 

--- a/OrbitQt/orbittreeview.cpp
+++ b/OrbitQt/orbittreeview.cpp
@@ -136,10 +136,10 @@ void OrbitTreeView::Refresh() {
     QModelIndex idx = model_->CreateIndex(selected, 0);
 
     // Don't re-trigger row selection callback when re-selecting.
-    is_internal_refresh = true;
+    is_internal_refresh_ = true;
     selection->select(
         idx, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
-    is_internal_refresh = false;
+    is_internal_refresh_ = false;
   }
 }
 
@@ -253,7 +253,7 @@ void OrbitTreeView::selectionChanged(const QItemSelection& selected,
   QTreeView::selectionChanged(selected, deselected);
 
   // Dont trigger callbacks if selection was initiated internally.
-  if (is_internal_refresh) return;
+  if (is_internal_refresh_) return;
 
   // Row selection callback.
   QModelIndexList rows = selectionModel()->selectedRows();

--- a/OrbitQt/orbittreeview.h
+++ b/OrbitQt/orbittreeview.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <QItemSelection>
 #include <QTimer>
 #include <QTreeView>
 #include <memory>
@@ -20,12 +21,13 @@ class OrbitTreeView : public QTreeView {
                   FontType font_type);
   void SetDataModel(DataView* model);
   void OnFilter(const QString& a_Filter);
-  void Select(int a_Row);
   void Refresh();
   void Link(OrbitTreeView* a_Link);
   void SetGlWidget(OrbitGLWidget* a_Link);
   void resizeEvent(QResizeEvent* event) override;
   void keyPressEvent(QKeyEvent* event) override;
+  void selectionChanged(const QItemSelection& selected,
+                        const QItemSelection& deselected) override;
   OrbitTableModel* GetModel() { return model_.get(); }
   std::string GetLabel();
 
@@ -41,14 +43,15 @@ class OrbitTreeView : public QTreeView {
  private slots:
   void OnSort(int a_Section, Qt::SortOrder a_Order);
   void OnTimer();
-  void OnClicked(const QModelIndex& index);
   void ShowContextMenu(const QPoint& pos);
   void OnMenuClicked(const std::string& a_Action, int a_MenuIndex);
   void OnRangeChanged(int a_Min, int a_Max);
+  void OnRowSelected(int row);
 
  private:
   std::unique_ptr<OrbitTableModel> model_;
   std::unique_ptr<QTimer> timer_;
   std::vector<OrbitTreeView*> links_;
   bool auto_resize_;
+  bool is_internal_refresh = false;
 };

--- a/OrbitQt/orbittreeview.h
+++ b/OrbitQt/orbittreeview.h
@@ -53,5 +53,5 @@ class OrbitTreeView : public QTreeView {
   std::unique_ptr<QTimer> timer_;
   std::vector<OrbitTreeView*> links_;
   bool auto_resize_;
-  bool is_internal_refresh = false;
+  bool is_internal_refresh_ = false;
 };


### PR DESCRIPTION
With this change, we use Qt's "selectionChanged" callback instead of relying on click events to trigger row selection callbacks.  This catches arrow key generated selections. We have some logic that re-selects selected items on data change, we have to take special care of not re-triggering the row selection callback in that case.

Tested on Windows and Linux, in all dataviews.

b/159598152