### PR TITLE
Introducing Result and ErrorMessage

### DIFF
--- a/ElfUtils/ElfFile.cpp
+++ b/ElfUtils/ElfFile.cpp
@@ -27,8 +27,8 @@ class ElfFileImpl : public ElfFile {
       std::string_view file_path,
       llvm::object::OwningBinary<llvm::object::ObjectFile>&& owning_binary);
 
-  Result<ModuleSymbols, ErrorMessage> LoadSymbols() const override;
-  Result<uint64_t, ErrorMessage> GetLoadBias() const override;
+  ErrorMessageOr<ModuleSymbols> LoadSymbols() const override;
+  ErrorMessageOr<uint64_t> GetLoadBias() const override;
   bool IsAddressInTextSection(uint64_t address) const override;
   bool HasSymtab() const override;
   bool Is64Bit() const override;
@@ -118,7 +118,7 @@ bool ElfFileImpl<ElfT>::IsAddressInTextSection(uint64_t address) const {
 }
 
 template <typename ElfT>
-Result<ModuleSymbols, ErrorMessage> ElfFileImpl<ElfT>::LoadSymbols() const {
+ErrorMessageOr<ModuleSymbols> ElfFileImpl<ElfT>::LoadSymbols() const {
   // TODO: if we want to use other sections than .symtab in the future for
   //       example .dynsym, than we have to change this.
   if (!has_symtab_section_) {
@@ -172,7 +172,7 @@ Result<ModuleSymbols, ErrorMessage> ElfFileImpl<ElfT>::LoadSymbols() const {
 }
 
 template <typename ElfT>
-Result<uint64_t, ErrorMessage> ElfFileImpl<ElfT>::GetLoadBias() const {
+ErrorMessageOr<uint64_t> ElfFileImpl<ElfT>::GetLoadBias() const {
   const llvm::object::ELFFile<ElfT>* elf_file = object_file_->getELFFile();
 
   uint64_t min_vaddr = UINT64_MAX;

--- a/ElfUtils/ElfFile.cpp
+++ b/ElfUtils/ElfFile.cpp
@@ -27,8 +27,8 @@ class ElfFileImpl : public ElfFile {
       std::string_view file_path,
       llvm::object::OwningBinary<llvm::object::ObjectFile>&& owning_binary);
 
-  outcome::result<ModuleSymbols, std::string> LoadSymbols() const override;
-  outcome::result<uint64_t, std::string> GetLoadBias() const override;
+  Result<ModuleSymbols, ErrorMessage> LoadSymbols() const override;
+  Result<uint64_t, ErrorMessage> GetLoadBias() const override;
   bool IsAddressInTextSection(uint64_t address) const override;
   bool HasSymtab() const override;
   bool Is64Bit() const override;
@@ -118,8 +118,7 @@ bool ElfFileImpl<ElfT>::IsAddressInTextSection(uint64_t address) const {
 }
 
 template <typename ElfT>
-outcome::result<ModuleSymbols, std::string> ElfFileImpl<ElfT>::LoadSymbols()
-    const {
+Result<ModuleSymbols, ErrorMessage> ElfFileImpl<ElfT>::LoadSymbols() const {
   // TODO: if we want to use other sections than .symtab in the future for
   //       example .dynsym, than we have to change this.
   if (!has_symtab_section_) {
@@ -173,7 +172,7 @@ outcome::result<ModuleSymbols, std::string> ElfFileImpl<ElfT>::LoadSymbols()
 }
 
 template <typename ElfT>
-outcome::result<uint64_t, std::string> ElfFileImpl<ElfT>::GetLoadBias() const {
+Result<uint64_t, ErrorMessage> ElfFileImpl<ElfT>::GetLoadBias() const {
   const llvm::object::ELFFile<ElfT>* elf_file = object_file_->getELFFile();
 
   uint64_t min_vaddr = UINT64_MAX;

--- a/ElfUtils/ElfFile.cpp
+++ b/ElfUtils/ElfFile.cpp
@@ -122,7 +122,7 @@ ErrorMessageOr<ModuleSymbols> ElfFileImpl<ElfT>::LoadSymbols() const {
   // TODO: if we want to use other sections than .symtab in the future for
   //       example .dynsym, than we have to change this.
   if (!has_symtab_section_) {
-    return outcome::failure("Elf file does not contain a .symtab section.");
+    return ErrorMessage("Elf file does not contain a .symtab section.");
   }
   bool symbols_added = false;
 
@@ -164,7 +164,7 @@ ErrorMessageOr<ModuleSymbols> ElfFileImpl<ElfT>::LoadSymbols() const {
     symbols_added = true;
   }
   if (!symbols_added) {
-    return outcome::failure(
+    return ErrorMessage(
         "Unable to load symbols from elf file, not even a single symbol of "
         "type function found.");
   }
@@ -185,7 +185,7 @@ ErrorMessageOr<uint64_t> ElfFileImpl<ElfT>::GetLoadBias() const {
         "found.",
         file_path_);
     ERROR("%s", error.c_str());
-    return outcome::failure(error);
+    return ErrorMessage(std::move(error));
   }
 
   for (const typename ElfT::Phdr& phdr : range.get()) {
@@ -205,9 +205,9 @@ ErrorMessageOr<uint64_t> ElfFileImpl<ElfT>::GetLoadBias() const {
         "headers found.",
         file_path_);
     ERROR("%s", error.c_str());
-    return outcome::failure(error);
+    return ErrorMessage(std::move(error));
   }
-  return outcome::success(min_vaddr);
+  return min_vaddr;
 }
 
 template <typename ElfT>

--- a/ElfUtils/ElfFileTest.cpp
+++ b/ElfUtils/ElfFileTest.cpp
@@ -99,7 +99,7 @@ TEST(ElfFile, CalculateLoadBiasNoProgramHeaders) {
   const auto load_bias_result = elf_file->GetLoadBias();
   ASSERT_FALSE(load_bias_result);
   EXPECT_EQ(
-      load_bias_result.error(),
+      load_bias_result.error().message(),
       absl::StrFormat(
           "Unable to get load bias of elf file: \"%s\". No PT_LOAD program "
           "headers found.",

--- a/ElfUtils/include/ElfUtils/ElfFile.h
+++ b/ElfUtils/include/ElfUtils/ElfFile.h
@@ -21,7 +21,7 @@ class ElfFile {
   ElfFile() = default;
   virtual ~ElfFile() = default;
 
-  virtual Result<ModuleSymbols, ErrorMessage> LoadSymbols() const = 0;
+  virtual ErrorMessageOr<ModuleSymbols> LoadSymbols() const = 0;
   // Background and some terminology
   // When an elf file is loaded to memory it has its load segments
   // (segments of PT_LOAD type from program headers) mapped to some
@@ -36,7 +36,7 @@ class ElfFile {
   //
   // This method returns load bias for the elf-file if program headers are
   // available. This should be the case for all loadable elf-files.
-  virtual Result<uint64_t, ErrorMessage> GetLoadBias() const = 0;
+  virtual ErrorMessageOr<uint64_t> GetLoadBias() const = 0;
   virtual bool IsAddressInTextSection(uint64_t address) const = 0;
   virtual bool HasSymtab() const = 0;
   virtual bool Is64Bit() const = 0;

--- a/ElfUtils/include/ElfUtils/ElfFile.h
+++ b/ElfUtils/include/ElfUtils/ElfFile.h
@@ -9,9 +9,9 @@
 #include <optional>
 #include <vector>
 
+#include "OrbitBase/Result.h"
 #include "llvm/Object/Binary.h"
 #include "llvm/Object/ObjectFile.h"
-#include "outcome.hpp"
 #include "symbol.pb.h"
 
 namespace ElfUtils {
@@ -21,7 +21,7 @@ class ElfFile {
   ElfFile() = default;
   virtual ~ElfFile() = default;
 
-  virtual outcome::result<ModuleSymbols, std::string> LoadSymbols() const = 0;
+  virtual Result<ModuleSymbols, ErrorMessage> LoadSymbols() const = 0;
   // Background and some terminology
   // When an elf file is loaded to memory it has its load segments
   // (segments of PT_LOAD type from program headers) mapped to some
@@ -36,7 +36,7 @@ class ElfFile {
   //
   // This method returns load bias for the elf-file if program headers are
   // available. This should be the case for all loadable elf-files.
-  virtual outcome::result<uint64_t, std::string> GetLoadBias() const = 0;
+  virtual Result<uint64_t, ErrorMessage> GetLoadBias() const = 0;
   virtual bool IsAddressInTextSection(uint64_t address) const = 0;
   virtual bool HasSymtab() const = 0;
   virtual bool Is64Bit() const = 0;

--- a/OrbitBase/include/OrbitBase/Result.h
+++ b/OrbitBase/include/OrbitBase/Result.h
@@ -9,9 +9,6 @@
 
 #include "outcome.hpp"
 
-template <typename T, typename E>
-using Result = outcome::result<T, E, outcome::policy::terminate>;
-
 class ErrorMessage final {
  public:
   ErrorMessage() = default;
@@ -22,5 +19,11 @@ class ErrorMessage final {
  private:
   std::string message_;
 };
+
+template <typename T, typename E>
+using Result = outcome::result<T, E, outcome::policy::terminate>;
+
+template <typename T>
+using ErrorMessageOr = Result<T, ErrorMessage>;
 
 #endif  // ORBIT_BASE_RESULT_H_

--- a/OrbitBase/include/OrbitBase/Result.h
+++ b/OrbitBase/include/OrbitBase/Result.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_BASE_RESULT_H_
+#define ORBIT_BASE_RESULT_H_
+
+#include <string_view>
+
+#include "outcome.hpp"
+
+template <typename T, typename E>
+using Result = outcome::result<T, E, outcome::policy::terminate>;
+
+class ErrorMessage final {
+ public:
+  ErrorMessage() = default;
+  explicit ErrorMessage(std::string_view message)
+      : message_(message.data(), message.size()) {}
+
+  ErrorMessage(const ErrorMessage&) = default;
+  ErrorMessage& operator=(const ErrorMessage&) = default;
+  ErrorMessage(ErrorMessage&&) = default;
+  ErrorMessage& operator=(ErrorMessage&&) = default;
+
+  [[nodiscard]] const std::string& message() const { return message_; }
+
+ private:
+  std::string message_;
+};
+
+#endif  // ORBIT_BASE_RESULT_H_

--- a/OrbitBase/include/OrbitBase/Result.h
+++ b/OrbitBase/include/OrbitBase/Result.h
@@ -5,7 +5,7 @@
 #ifndef ORBIT_BASE_RESULT_H_
 #define ORBIT_BASE_RESULT_H_
 
-#include <string_view>
+#include <string>
 
 #include "outcome.hpp"
 
@@ -15,13 +15,7 @@ using Result = outcome::result<T, E, outcome::policy::terminate>;
 class ErrorMessage final {
  public:
   ErrorMessage() = default;
-  explicit ErrorMessage(std::string_view message)
-      : message_(message.data(), message.size()) {}
-
-  ErrorMessage(const ErrorMessage&) = default;
-  ErrorMessage& operator=(const ErrorMessage&) = default;
-  ErrorMessage(ErrorMessage&&) = default;
-  ErrorMessage& operator=(ErrorMessage&&) = default;
+  explicit ErrorMessage(std::string message) : message_(std::move(message)) {}
 
   [[nodiscard]] const std::string& message() const { return message_; }
 

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -83,7 +83,7 @@ void Capture::SetTargetProcess(const std::shared_ptr<Process>& a_Process) {
 //-----------------------------------------------------------------------------
 ErrorMessageOr<void> Capture::StartCapture() {
   if (GTargetProcess->GetID() == 0) {
-    return outcome::failure(
+    return ErrorMessage(
         "No process selected. Please choose a target process for the capture.");
   }
 
@@ -209,7 +209,7 @@ ErrorMessageOr<void> Capture::SavePreset(const std::string& filename) {
   std::ofstream file(filename_with_ext, std::ios::binary);
   if (file.fail()) {
     ERROR("Saving preset in \"%s\": %s", filename_with_ext, "file.fail()");
-    return outcome::failure("Error opening the file for writing");
+    return ErrorMessage("Error opening the file for writing");
   }
 
   try {
@@ -221,7 +221,8 @@ ErrorMessageOr<void> Capture::SavePreset(const std::string& filename) {
     return outcome::success();
   } catch (std::exception& e) {
     ERROR("Saving preset in \"%s\": %s", filename_with_ext, e.what());
-    return outcome::failure("Error serializing the preset");
+    return ErrorMessage(
+        absl::StrFormat("Error serializing the preset: %s", e.what()));
   }
 }
 

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -81,7 +81,7 @@ void Capture::SetTargetProcess(const std::shared_ptr<Process>& a_Process) {
 }
 
 //-----------------------------------------------------------------------------
-Result<void, ErrorMessage> Capture::StartCapture() {
+ErrorMessageOr<void> Capture::StartCapture() {
   if (GTargetProcess->GetID() == 0) {
     return outcome::failure(
         "No process selected. Please choose a target process for the capture.");
@@ -190,7 +190,7 @@ void Capture::DisplayStats() {
 }
 
 //-----------------------------------------------------------------------------
-Result<void, ErrorMessage> Capture::SavePreset(const std::string& filename) {
+ErrorMessageOr<void> Capture::SavePreset(const std::string& filename) {
   Preset preset;
   preset.m_ProcessFullPath = GTargetProcess->GetFullPath();
 

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -81,7 +81,7 @@ void Capture::SetTargetProcess(const std::shared_ptr<Process>& a_Process) {
 }
 
 //-----------------------------------------------------------------------------
-outcome::result<void, std::string> Capture::StartCapture() {
+Result<void, ErrorMessage> Capture::StartCapture() {
   if (GTargetProcess->GetID() == 0) {
     return outcome::failure(
         "No process selected. Please choose a target process for the capture.");
@@ -190,8 +190,7 @@ void Capture::DisplayStats() {
 }
 
 //-----------------------------------------------------------------------------
-outcome::result<void, std::string> Capture::SavePreset(
-    const std::string& filename) {
+Result<void, ErrorMessage> Capture::SavePreset(const std::string& filename) {
   Preset preset;
   preset.m_ProcessFullPath = GTargetProcess->GetFullPath();
 

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -10,6 +10,7 @@
 
 #include "CallstackTypes.h"
 #include "LinuxAddressInfo.h"
+#include "OrbitBase/Result.h"
 #include "OrbitFunction.h"
 #include "OrbitProcess.h"
 #include "Threading.h"
@@ -27,7 +28,7 @@ class Capture {
 
   static void Init();
   static void SetTargetProcess(const std::shared_ptr<Process>& a_Process);
-  static outcome::result<void, std::string> StartCapture();
+  static Result<void, ErrorMessage> StartCapture();
   static void StopCapture();
   static void FinalizeCapture();
   static void ClearCaptureData();
@@ -36,8 +37,7 @@ class Capture {
   static bool IsCapturing();
   static void DisplayStats();
   static void TestHooks();
-  static outcome::result<void, std::string> SavePreset(
-      const std::string& filename);
+  static Result<void, ErrorMessage> SavePreset(const std::string& filename);
   static void NewSamplingProfiler();
   // True when Orbit is receiving data from remote source
   static bool IsRemote();

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -28,7 +28,7 @@ class Capture {
 
   static void Init();
   static void SetTargetProcess(const std::shared_ptr<Process>& a_Process);
-  static Result<void, ErrorMessage> StartCapture();
+  static ErrorMessageOr<void> StartCapture();
   static void StopCapture();
   static void FinalizeCapture();
   static void ClearCaptureData();
@@ -37,7 +37,7 @@ class Capture {
   static bool IsCapturing();
   static void DisplayStats();
   static void TestHooks();
-  static Result<void, ErrorMessage> SavePreset(const std::string& filename);
+  static ErrorMessageOr<void> SavePreset(const std::string& filename);
   static void NewSamplingProfiler();
   // True when Orbit is receiving data from remote source
   static bool IsRemote();

--- a/OrbitCore/LinuxUtils.cpp
+++ b/OrbitCore/LinuxUtils.cpp
@@ -67,7 +67,7 @@ outcome::result<std::string> ExecuteCommand(const std::string& cmd) {
   return outcome::success(result);
 }
 
-outcome::result<std::vector<ModuleInfo>, std::string> ListModules(int32_t pid) {
+ErrorMessageOr<std::vector<ModuleInfo>> ListModules(int32_t pid) {
   struct AddressRange {
     uint64_t start_address;
     uint64_t end_address;
@@ -78,8 +78,8 @@ outcome::result<std::vector<ModuleInfo>, std::string> ListModules(int32_t pid) {
 
   const auto proc_maps = ReadProcMaps(pid);
   if (!proc_maps) {
-    return outcome::failure(absl::StrFormat("Unable to read /proc/%d/maps: %s",
-                                            pid, proc_maps.error().message()));
+    return ErrorMessage(absl::StrFormat("Unable to read /proc/%d/maps: %s", pid,
+                                        proc_maps.error().message()));
   }
 
   for (const std::string& line : proc_maps.value()) {
@@ -135,7 +135,7 @@ outcome::result<std::vector<ModuleInfo>, std::string> ListModules(int32_t pid) {
     result.push_back(module_info);
   }
 
-  return outcome::success(result);
+  return result;
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitCore/LinuxUtils.h
+++ b/OrbitCore/LinuxUtils.h
@@ -13,13 +13,14 @@
 #include <vector>
 
 #include "BaseTypes.h"
+#include "OrbitBase/Result.h"
 #include "module.pb.h"
 
 //-----------------------------------------------------------------------------
 namespace LinuxUtils {
 outcome::result<std::string> ExecuteCommand(const std::string& cmd);
 outcome::result<std::vector<std::string>> ReadProcMaps(pid_t pid);
-outcome::result<std::vector<ModuleInfo>, std::string> ListModules(int32_t pid);
+ErrorMessageOr<std::vector<ModuleInfo>> ListModules(int32_t pid);
 outcome::result<std::unordered_map<pid_t, double>> GetCpuUtilization();
 outcome::result<bool> Is64Bit(pid_t pid);
 }  // namespace LinuxUtils

--- a/OrbitCore/SymbolHelper.cpp
+++ b/OrbitCore/SymbolHelper.cpp
@@ -86,7 +86,7 @@ ErrorMessageOr<ModuleSymbols> FindSymbols(
     return symbols_file->LoadSymbols();
   }
 
-  return outcome::failure(
+  return ErrorMessage(
       absl::StrFormat("Could not find symbols for module \"%s\"", module_path));
 }
 
@@ -106,7 +106,7 @@ ErrorMessageOr<ModuleSymbols> SymbolHelper::LoadSymbolsCollector(
   std::unique_ptr<ElfFile> elf_file = ElfFile::Create(module_path);
 
   if (!elf_file) {
-    return outcome::failure(
+    return ErrorMessage(
         absl::StrFormat("Unable to load ELF file: \"%s\"", module_path));
   }
 
@@ -115,7 +115,7 @@ ErrorMessageOr<ModuleSymbols> SymbolHelper::LoadSymbolsCollector(
   }
 
   if (elf_file->GetBuildId().empty()) {
-    return outcome::failure(absl::StrFormat(
+    return ErrorMessage(absl::StrFormat(
         "No symbols are contained in the module \"%s\". Symbols cannot be "
         "loaded from a separate symbols file, because module does not "
         "contain a build_id,",

--- a/OrbitCore/SymbolHelper.cpp
+++ b/OrbitCore/SymbolHelper.cpp
@@ -57,7 +57,7 @@ std::vector<std::string> ReadSymbolsFile() {
   return directories;
 }
 
-outcome::result<ModuleSymbols, std::string> FindSymbols(
+Result<ModuleSymbols, ErrorMessage> FindSymbols(
     const std::string& module_path, const std::string& build_id,
     const std::vector<std::string>& search_directories) {
   std::string filename = Path::GetFileName(module_path);
@@ -86,8 +86,8 @@ outcome::result<ModuleSymbols, std::string> FindSymbols(
     return symbols_file->LoadSymbols();
   }
 
-  return absl::StrFormat("Could not find symbols for module \"%s\"",
-                         module_path);
+  return outcome::failure(
+      absl::StrFormat("Could not find symbols for module \"%s\"", module_path));
 }
 
 }  // namespace
@@ -101,7 +101,7 @@ SymbolHelper::SymbolHelper()
                                     "/srv/game/assets/debug_symbols/"},
       symbols_file_directories_(ReadSymbolsFile()) {}
 
-outcome::result<ModuleSymbols, std::string> SymbolHelper::LoadSymbolsCollector(
+Result<ModuleSymbols, ErrorMessage> SymbolHelper::LoadSymbolsCollector(
     const std::string& module_path) const {
   std::unique_ptr<ElfFile> elf_file = ElfFile::Create(module_path);
 
@@ -128,8 +128,7 @@ outcome::result<ModuleSymbols, std::string> SymbolHelper::LoadSymbolsCollector(
   return FindSymbols(module_path, elf_file->GetBuildId(), search_directories);
 }
 
-outcome::result<ModuleSymbols, std::string>
-SymbolHelper::LoadUsingSymbolsPathFile(const std::string& module_path,
-                                       const std::string& build_id) const {
+Result<ModuleSymbols, ErrorMessage> SymbolHelper::LoadUsingSymbolsPathFile(
+    const std::string& module_path, const std::string& build_id) const {
   return FindSymbols(module_path, build_id, symbols_file_directories_);
 }

--- a/OrbitCore/SymbolHelper.cpp
+++ b/OrbitCore/SymbolHelper.cpp
@@ -57,7 +57,7 @@ std::vector<std::string> ReadSymbolsFile() {
   return directories;
 }
 
-Result<ModuleSymbols, ErrorMessage> FindSymbols(
+ErrorMessageOr<ModuleSymbols> FindSymbols(
     const std::string& module_path, const std::string& build_id,
     const std::vector<std::string>& search_directories) {
   std::string filename = Path::GetFileName(module_path);
@@ -101,7 +101,7 @@ SymbolHelper::SymbolHelper()
                                     "/srv/game/assets/debug_symbols/"},
       symbols_file_directories_(ReadSymbolsFile()) {}
 
-Result<ModuleSymbols, ErrorMessage> SymbolHelper::LoadSymbolsCollector(
+ErrorMessageOr<ModuleSymbols> SymbolHelper::LoadSymbolsCollector(
     const std::string& module_path) const {
   std::unique_ptr<ElfFile> elf_file = ElfFile::Create(module_path);
 
@@ -128,7 +128,7 @@ Result<ModuleSymbols, ErrorMessage> SymbolHelper::LoadSymbolsCollector(
   return FindSymbols(module_path, elf_file->GetBuildId(), search_directories);
 }
 
-Result<ModuleSymbols, ErrorMessage> SymbolHelper::LoadUsingSymbolsPathFile(
+ErrorMessageOr<ModuleSymbols> SymbolHelper::LoadUsingSymbolsPathFile(
     const std::string& module_path, const std::string& build_id) const {
   return FindSymbols(module_path, build_id, symbols_file_directories_);
 }

--- a/OrbitCore/SymbolHelper.h
+++ b/OrbitCore/SymbolHelper.h
@@ -4,10 +4,10 @@
 
 #ifndef SYMBOL_HELPER_H_
 #define SYMBOL_HELPER_H_
-#include <outcome.hpp>
 #include <string>
 #include <vector>
 
+#include "OrbitBase/Result.h"
 #include "symbol.pb.h"
 
 class SymbolHelper {
@@ -18,9 +18,9 @@ class SymbolHelper {
       : collector_symbol_directories_(std::move(collector_symbol_directories)),
         symbols_file_directories_(std::move(symbols_file_directories)){};
 
-  outcome::result<ModuleSymbols, std::string> LoadSymbolsCollector(
+  Result<ModuleSymbols, ErrorMessage> LoadSymbolsCollector(
       const std::string& module_path) const;
-  outcome::result<ModuleSymbols, std::string> LoadUsingSymbolsPathFile(
+  Result<ModuleSymbols, ErrorMessage> LoadUsingSymbolsPathFile(
       const std::string& module_path, const std::string& build_id) const;
 
  private:

--- a/OrbitCore/SymbolHelper.h
+++ b/OrbitCore/SymbolHelper.h
@@ -18,9 +18,9 @@ class SymbolHelper {
       : collector_symbol_directories_(std::move(collector_symbol_directories)),
         symbols_file_directories_(std::move(symbols_file_directories)){};
 
-  Result<ModuleSymbols, ErrorMessage> LoadSymbolsCollector(
+  ErrorMessageOr<ModuleSymbols> LoadSymbolsCollector(
       const std::string& module_path) const;
-  Result<ModuleSymbols, ErrorMessage> LoadUsingSymbolsPathFile(
+  ErrorMessageOr<ModuleSymbols> LoadUsingSymbolsPathFile(
       const std::string& module_path, const std::string& build_id) const;
 
  private:

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -455,7 +455,7 @@ ErrorMessageOr<void> OrbitApp::ReadPresetFromFile(const std::string& filename,
   std::ifstream file(file_path, std::ios::binary);
   if (file.fail()) {
     ERROR("Loading preset from \"%s\": file.fail()", file_path);
-    return outcome::failure("Error opening the file for reading");
+    return ErrorMessage("Error opening the file for reading");
   }
 
   try {
@@ -465,7 +465,8 @@ ErrorMessageOr<void> OrbitApp::ReadPresetFromFile(const std::string& filename,
     return outcome::success();
   } catch (std::exception& e) {
     ERROR("Loading preset from \"%s\": %s", file_path, e.what());
-    return outcome::failure("Error reading the preset");
+    return ErrorMessage(
+        absl::StrFormat("Error reading the preset: %s", e.what()));
   }
 }
 

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -320,7 +320,7 @@ void OrbitApp::Disassemble(int32_t pid, const Function& function) {
     if (!result.has_value()) {
       SendErrorToUi("Error reading memory",
                     absl::StrFormat("Could not read process memory: %s.",
-                                    result.error().message));
+                                    result.error().message()));
       return;
     }
 
@@ -697,7 +697,7 @@ void OrbitApp::LoadModuleOnRemote(int32_t process_id,
               "Did not find symbols on local machine for module \"%s\".\n"
               "Trying to load symbols from remote resulted in error "
               "message: %s",
-              module->m_Name, remote_symbols_result.error()));
+              module->m_Name, remote_symbols_result.error().message()));
       return;
     }
 
@@ -778,51 +778,51 @@ bool OrbitApp::IsLoading() { return GPdbDbg->IsLoading(); }
 
 void OrbitApp::OnProcessSelected(int32_t pid) {
   thread_pool_->Schedule([pid, this] {
-    outcome::result<std::vector<ModuleInfo>, std::string> result =
+    Result<std::vector<ModuleInfo>, ErrorMessage> result =
         process_manager_->LoadModuleList(pid);
 
-    if (result) {
-      main_thread_executor_->Schedule([pid, result, this] {
-        // Make sure that pid is actually what user has selected at
-        // the moment we arrive here. If not - ignore the result.
-        const std::vector<ModuleInfo>& module_infos = result.value();
-        data_manager_->UpdateModuleInfos(pid, module_infos);
-        if (pid != m_ProcessesDataView->GetSelectedProcessId()) {
-          return;
-        }
-
-        m_ModulesDataView->SetModules(pid, data_manager_->GetModules(pid));
-
-        // TODO: remove this part when all client code is moved to
-        // new data model.
-        std::shared_ptr<Process> process = FindProcessByPid(pid);
-        Capture::SetTargetProcess(process);
-
-        for (const ModuleInfo& info : module_infos) {
-          std::shared_ptr<Module> module = std::make_shared<Module>();
-          module->m_Name = info.name();
-          module->m_FullName = info.file_path();
-          module->m_PdbSize = info.file_size();
-          module->m_AddressStart = info.address_start();
-          module->m_AddressEnd = info.address_end();
-          module->m_DebugSignature = info.build_id();
-          module->SetLoadable(true);
-          process->AddModule(module);
-        }
-
-        std::shared_ptr<Preset> preset = Capture::GSessionPresets;
-        if (preset) {
-          LoadModulesFromPreset(process, preset);
-          Capture::GSessionPresets = nullptr;
-        }
-        // To this point ----------------------------------
-
-        FireRefreshCallbacks();
-      });
-    } else {
-      ERROR("Error retrieving modules: %s", result.error());
-      SendErrorToUi("Error retrieving modules", result.error());
+    if (!result) {
+      ERROR("Error retrieving modules: %s", result.error().message());
+      SendErrorToUi("Error retrieving modules", result.error().message());
+      return;
     }
+    main_thread_executor_->Schedule([pid, result, this] {
+      // Make sure that pid is actually what user has selected at
+      // the moment we arrive here. If not - ignore the result.
+      const std::vector<ModuleInfo>& module_infos = result.value();
+      data_manager_->UpdateModuleInfos(pid, module_infos);
+      if (pid != m_ProcessesDataView->GetSelectedProcessId()) {
+        return;
+      }
+
+      m_ModulesDataView->SetModules(pid, data_manager_->GetModules(pid));
+
+      // TODO: remove this part when all client code is moved to
+      // new data model.
+      std::shared_ptr<Process> process = FindProcessByPid(pid);
+      Capture::SetTargetProcess(process);
+
+      for (const ModuleInfo& info : module_infos) {
+        std::shared_ptr<Module> module = std::make_shared<Module>();
+        module->m_Name = info.name();
+        module->m_FullName = info.file_path();
+        module->m_PdbSize = info.file_size();
+        module->m_AddressStart = info.address_start();
+        module->m_AddressEnd = info.address_end();
+        module->m_DebugSignature = info.build_id();
+        module->SetLoadable(true);
+        process->AddModule(module);
+      }
+
+      std::shared_ptr<Preset> preset = Capture::GSessionPresets;
+      if (preset) {
+        LoadModulesFromPreset(process, preset);
+        Capture::GSessionPresets = nullptr;
+      }
+      // To this point ----------------------------------
+
+      FireRefreshCallbacks();
+    });
   });
 }
 

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -291,10 +291,11 @@ void OrbitApp::ListPresets() {
   std::vector<std::shared_ptr<Preset>> presets;
   for (std::string& filename : preset_filenames) {
     auto preset = std::make_shared<Preset>();
-    outcome::result<void, std::string> result =
+    Result<void, ErrorMessage> result =
         ReadPresetFromFile(filename, preset.get());
     if (result.has_error()) {
-      ERROR("Loading preset failed: \"%s\"", result.error());
+      ERROR("Loading preset from \"%s\" failed: %s", filename,
+            result.error().message());
       continue;
     }
     preset->m_FileName = filename;
@@ -436,8 +437,7 @@ void OrbitApp::SetClipboard(const std::string& text) {
 }
 
 //-----------------------------------------------------------------------------
-outcome::result<void, std::string> OrbitApp::OnSavePreset(
-    const std::string& filename) {
+Result<void, ErrorMessage> OrbitApp::OnSavePreset(const std::string& filename) {
   OUTCOME_TRY(Capture::SavePreset(filename));
   ListPresets();
   Refresh(DataViewType::PRESETS);
@@ -445,7 +445,7 @@ outcome::result<void, std::string> OrbitApp::OnSavePreset(
 }
 
 //-----------------------------------------------------------------------------
-outcome::result<void, std::string> OrbitApp::ReadPresetFromFile(
+Result<void, ErrorMessage> OrbitApp::ReadPresetFromFile(
     const std::string& filename, Preset* preset) {
   std::string file_path = filename;
 
@@ -471,8 +471,7 @@ outcome::result<void, std::string> OrbitApp::ReadPresetFromFile(
 }
 
 //-----------------------------------------------------------------------------
-outcome::result<void, std::string> OrbitApp::OnLoadPreset(
-    const std::string& filename) {
+Result<void, ErrorMessage> OrbitApp::OnLoadPreset(const std::string& filename) {
   auto preset = std::make_shared<Preset>();
   OUTCOME_TRY(ReadPresetFromFile(filename, preset.get()));
   preset->m_FileName = filename;
@@ -497,7 +496,7 @@ void OrbitApp::LoadPreset(const std::shared_ptr<Preset>& preset) {
 }
 
 //-----------------------------------------------------------------------------
-outcome::result<void, std::string> OrbitApp::OnSaveCapture(
+Result<void, ErrorMessage> OrbitApp::OnSaveCapture(
     const std::string& file_name) {
   CaptureSerializer ar;
   ar.time_graph_ = GCurrentTimeGraph;
@@ -505,7 +504,7 @@ outcome::result<void, std::string> OrbitApp::OnSaveCapture(
 }
 
 //-----------------------------------------------------------------------------
-outcome::result<void, std::string> OrbitApp::OnLoadCapture(
+Result<void, ErrorMessage> OrbitApp::OnLoadCapture(
     const std::string& file_name) {
   Capture::ClearCaptureData();
   GCurrentTimeGraph->Clear();

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -539,9 +539,9 @@ bool OrbitApp::StartCapture() {
     return false;
   }
 
-  outcome::result<void, std::string> result = Capture::StartCapture();
+  Result<void, ErrorMessage> result = Capture::StartCapture();
   if (result.has_error()) {
-    SendErrorToUi("Error starting capture", result.error());
+    SendErrorToUi("Error starting capture", result.error().message());
     return false;
   }
 

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -59,10 +59,10 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   std::string GetCaptureFileName();
   std::string GetSaveFile(const std::string& extension);
   void SetClipboard(const std::string& text);
-  Result<void, ErrorMessage> OnSavePreset(const std::string& file_name);
-  Result<void, ErrorMessage> OnLoadPreset(const std::string& file_name);
-  Result<void, ErrorMessage> OnSaveCapture(const std::string& file_name);
-  Result<void, ErrorMessage> OnLoadCapture(const std::string& file_name);
+  ErrorMessageOr<void> OnSavePreset(const std::string& file_name);
+  ErrorMessageOr<void> OnLoadPreset(const std::string& file_name);
+  ErrorMessageOr<void> OnSaveCapture(const std::string& file_name);
+  ErrorMessageOr<void> OnLoadCapture(const std::string& file_name);
   bool StartCapture();
   void StopCapture();
   void OnCaptureStopped();
@@ -219,8 +219,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
                              const std::shared_ptr<Preset>& preset);
   std::shared_ptr<Process> FindProcessByPid(int32_t pid);
 
-  Result<void, ErrorMessage> ReadPresetFromFile(const std::string& filename,
-                                                Preset* preset);
+  ErrorMessageOr<void> ReadPresetFromFile(const std::string& filename,
+                                          Preset* preset);
 
   ApplicationOptions options_;
 

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -27,6 +27,7 @@
 #include "LiveFunctionsDataView.h"
 #include "ModulesDataView.h"
 #include "OrbitBase/MainThreadExecutor.h"
+#include "OrbitBase/Result.h"
 #include "OrbitBase/ThreadPool.h"
 #include "ProcessManager.h"
 #include "ProcessesDataView.h"
@@ -58,12 +59,10 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   std::string GetCaptureFileName();
   std::string GetSaveFile(const std::string& extension);
   void SetClipboard(const std::string& text);
-  outcome::result<void, std::string> OnSavePreset(const std::string& file_name);
-  outcome::result<void, std::string> OnLoadPreset(const std::string& file_name);
-  outcome::result<void, std::string> OnSaveCapture(
-      const std::string& file_name);
-  outcome::result<void, std::string> OnLoadCapture(
-      const std::string& file_name);
+  Result<void, ErrorMessage> OnSavePreset(const std::string& file_name);
+  Result<void, ErrorMessage> OnLoadPreset(const std::string& file_name);
+  Result<void, ErrorMessage> OnSaveCapture(const std::string& file_name);
+  Result<void, ErrorMessage> OnLoadCapture(const std::string& file_name);
   bool StartCapture();
   void StopCapture();
   void OnCaptureStopped();
@@ -220,8 +219,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
                              const std::shared_ptr<Preset>& preset);
   std::shared_ptr<Process> FindProcessByPid(int32_t pid);
 
-  outcome::result<void, std::string> ReadPresetFromFile(
-      const std::string& filename, Preset* preset);
+  Result<void, ErrorMessage> ReadPresetFromFile(const std::string& filename,
+                                                Preset* preset);
 
   ApplicationOptions options_;
 

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -25,7 +25,7 @@
 #include "absl/strings/str_format.h"
 
 //-----------------------------------------------------------------------------
-outcome::result<void, std::string> CaptureSerializer::Save(
+Result<void, ErrorMessage> CaptureSerializer::Save(
     const std::string& filename) {
   Capture::PreSave();
 
@@ -138,7 +138,7 @@ void CaptureSerializer::SaveImpl(T& archive) {
 }
 
 //-----------------------------------------------------------------------------
-outcome::result<void, std::string> CaptureSerializer::Load(
+Result<void, ErrorMessage> CaptureSerializer::Load(
     const std::string& filename) {
   SCOPE_TIMER_LOG(absl::StrFormat("Loading capture from \"%s\"", filename));
 
@@ -157,8 +157,7 @@ outcome::result<void, std::string> CaptureSerializer::Load(
   }
 }
 
-outcome::result<void, std::string> CaptureSerializer::Load(
-    std::istream& stream) {
+Result<void, ErrorMessage> CaptureSerializer::Load(std::istream& stream) {
   // Header
   cereal::BinaryInputArchive archive(stream);
   archive(*this);

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -25,8 +25,7 @@
 #include "absl/strings/str_format.h"
 
 //-----------------------------------------------------------------------------
-Result<void, ErrorMessage> CaptureSerializer::Save(
-    const std::string& filename) {
+ErrorMessageOr<void> CaptureSerializer::Save(const std::string& filename) {
   Capture::PreSave();
 
   // Binary
@@ -138,8 +137,7 @@ void CaptureSerializer::SaveImpl(T& archive) {
 }
 
 //-----------------------------------------------------------------------------
-Result<void, ErrorMessage> CaptureSerializer::Load(
-    const std::string& filename) {
+ErrorMessageOr<void> CaptureSerializer::Load(const std::string& filename) {
   SCOPE_TIMER_LOG(absl::StrFormat("Loading capture from \"%s\"", filename));
 
   // Binary
@@ -157,7 +155,7 @@ Result<void, ErrorMessage> CaptureSerializer::Load(
   }
 }
 
-Result<void, ErrorMessage> CaptureSerializer::Load(std::istream& stream) {
+ErrorMessageOr<void> CaptureSerializer::Load(std::istream& stream) {
   // Header
   cereal::BinaryInputArchive archive(stream);
   archive(*this);

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -34,7 +34,7 @@ ErrorMessageOr<void> CaptureSerializer::Save(const std::string& filename) {
   std::ofstream file(m_CaptureName, std::ios::binary);
   if (file.fail()) {
     ERROR("Saving capture in \"%s\": %s", filename, "file.fail()");
-    return outcome::failure("Error opening the file for writing");
+    return ErrorMessage("Error opening the file for writing");
   }
 
   try {
@@ -42,7 +42,7 @@ ErrorMessageOr<void> CaptureSerializer::Save(const std::string& filename) {
     Save(file);
   } catch (std::exception& e) {
     ERROR("Saving capture in \"%s\": %s", filename, e.what());
-    return outcome::failure("Error serializing the capture");
+    return ErrorMessage("Error serializing the capture");
   }
 
   return outcome::success();
@@ -144,14 +144,14 @@ ErrorMessageOr<void> CaptureSerializer::Load(const std::string& filename) {
   std::ifstream file(filename, std::ios::binary);
   if (file.fail()) {
     ERROR("Loading capture from \"%s\": %s", filename, "file.fail()");
-    return outcome::failure("Error opening the file for reading");
+    return ErrorMessage("Error opening the file for reading");
   }
 
   try {
     return Load(file);
   } catch (std::exception& e) {
     ERROR("Loading capture from \"%s\": %s", filename, e.what());
-    return outcome::failure("Error parsing the capture");
+    return ErrorMessage("Error parsing the capture");
   }
 }
 

--- a/OrbitGl/CaptureSerializer.h
+++ b/OrbitGl/CaptureSerializer.h
@@ -8,15 +8,16 @@
 #include <outcome.hpp>
 #include <string>
 
+#include "OrbitBase/Result.h"
 #include "SerializationMacros.h"
 
 class CaptureSerializer {
  public:
   void Save(std::ostream& stream);
-  outcome::result<void, std::string> Save(const std::string& filename);
+  Result<void, ErrorMessage> Save(const std::string& filename);
 
-  outcome::result<void, std::string> Load(std::istream& stream);
-  outcome::result<void, std::string> Load(const std::string& filename);
+  Result<void, ErrorMessage> Load(std::istream& stream);
+  Result<void, ErrorMessage> Load(const std::string& filename);
 
   class TimeGraph* time_graph_;
 

--- a/OrbitGl/CaptureSerializer.h
+++ b/OrbitGl/CaptureSerializer.h
@@ -14,10 +14,10 @@
 class CaptureSerializer {
  public:
   void Save(std::ostream& stream);
-  Result<void, ErrorMessage> Save(const std::string& filename);
+  ErrorMessageOr<void> Save(const std::string& filename);
 
-  Result<void, ErrorMessage> Load(std::istream& stream);
-  Result<void, ErrorMessage> Load(const std::string& filename);
+  ErrorMessageOr<void> Load(std::istream& stream);
+  ErrorMessageOr<void> Load(const std::string& filename);
 
   class TimeGraph* time_graph_;
 

--- a/OrbitGl/ProcessManager.cpp
+++ b/OrbitGl/ProcessManager.cpp
@@ -31,14 +31,12 @@ class ProcessManagerImpl final : public ProcessManager {
       const std::function<void(ProcessManager*)>& listener) override;
 
   std::vector<ProcessInfo> GetProcessList() const override;
-  Result<std::vector<ModuleInfo>, ErrorMessage> LoadModuleList(
-      int32_t pid) override;
+  ErrorMessageOr<std::vector<ModuleInfo>> LoadModuleList(int32_t pid) override;
 
-  Result<std::string, ErrorMessage> LoadProcessMemory(int32_t pid,
-                                                      uint64_t address,
-                                                      uint64_t size) override;
+  ErrorMessageOr<std::string> LoadProcessMemory(int32_t pid, uint64_t address,
+                                                uint64_t size) override;
 
-  Result<ModuleSymbols, ErrorMessage> LoadSymbols(
+  ErrorMessageOr<ModuleSymbols> LoadSymbols(
       const std::string& module_path) const override;
 
   void Start();
@@ -75,8 +73,8 @@ void ProcessManagerImpl::SetProcessListUpdateListener(
   process_list_update_listener_ = listener;
 }
 
-Result<std::vector<ModuleInfo>, ErrorMessage>
-ProcessManagerImpl::LoadModuleList(int32_t pid) {
+ErrorMessageOr<std::vector<ModuleInfo>> ProcessManagerImpl::LoadModuleList(
+    int32_t pid) {
   GetModuleListRequest request;
   GetModuleListResponse response;
   request.set_process_id(pid);
@@ -102,7 +100,7 @@ std::vector<ProcessInfo> ProcessManagerImpl::GetProcessList() const {
   return process_list_;
 }
 
-Result<ModuleSymbols, ErrorMessage> ProcessManagerImpl::LoadSymbols(
+ErrorMessageOr<ModuleSymbols> ProcessManagerImpl::LoadSymbols(
     const std::string& module_path) const {
   GetSymbolsRequest request;
   GetSymbolsResponse response;
@@ -182,7 +180,7 @@ void ProcessManagerImpl::WorkerFunction() {
   }
 }
 
-Result<std::string, ErrorMessage> ProcessManagerImpl::LoadProcessMemory(
+ErrorMessageOr<std::string> ProcessManagerImpl::LoadProcessMemory(
     int32_t pid, uint64_t address, uint64_t size) {
   GetProcessMemoryRequest request;
   request.set_pid(pid);

--- a/OrbitGl/ProcessManager.cpp
+++ b/OrbitGl/ProcessManager.cpp
@@ -87,7 +87,7 @@ ErrorMessageOr<std::vector<ModuleInfo>> ProcessManagerImpl::LoadModuleList(
   if (!status.ok()) {
     ERROR("Grpc call failed: code=%d, message=%s", status.error_code(),
           status.error_message());
-    return outcome::failure(status.error_message());
+    return ErrorMessage(status.error_message());
   }
 
   const auto& modules = response.modules();
@@ -114,7 +114,7 @@ ErrorMessageOr<ModuleSymbols> ProcessManagerImpl::LoadSymbols(
       process_service_->GetSymbols(context.get(), request, &response);
   if (!status.ok()) {
     ERROR("gRPC call to GetSymbols failed: %s", status.error_message());
-    return outcome::failure(status.error_message());
+    return ErrorMessage(status.error_message());
   }
 
   return response.module_symbols();
@@ -196,10 +196,10 @@ ErrorMessageOr<std::string> ProcessManagerImpl::LoadProcessMemory(
       process_service_->GetProcessMemory(context.get(), request, &response);
   if (!status.ok()) {
     ERROR("gRPC call to GetProcessMemory failed: %s", status.error_message());
-    return outcome::failure(status.error_message());
+    return ErrorMessage(status.error_message());
   }
 
-  return outcome::success(std::move(*response.mutable_memory()));
+  return std::move(*response.mutable_memory());
 }
 
 }  // namespace

--- a/OrbitGl/ProcessManager.h
+++ b/OrbitGl/ProcessManager.h
@@ -41,17 +41,18 @@ class ProcessManager {
   virtual void SetProcessListUpdateListener(
       const std::function<void(ProcessManager*)>& listener) = 0;
 
-  virtual Result<std::vector<ModuleInfo>, ErrorMessage> LoadModuleList(
+  virtual ErrorMessageOr<std::vector<ModuleInfo>> LoadModuleList(
       int32_t pid) = 0;
 
   // Get a copy of process list.
   virtual std::vector<ProcessInfo> GetProcessList() const = 0;
 
-  virtual Result<std::string, ErrorMessage> LoadProcessMemory(
-      int32_t pid, uint64_t address, uint64_t size) = 0;
+  virtual ErrorMessageOr<std::string> LoadProcessMemory(int32_t pid,
+                                                        uint64_t address,
+                                                        uint64_t size) = 0;
 
   // Get symbols for a module
-  virtual Result<ModuleSymbols, ErrorMessage> LoadSymbols(
+  virtual ErrorMessageOr<ModuleSymbols> LoadSymbols(
       const std::string& module_path) const = 0;
 
   // Note that this method waits for the worker thread to stop, which could

--- a/OrbitGl/ProcessManager.h
+++ b/OrbitGl/ProcessManager.h
@@ -9,10 +9,10 @@
 #include <string>
 #include <thread>
 
+#include "OrbitBase/Result.h"
 #include "absl/synchronization/mutex.h"
 #include "grpcpp/grpcpp.h"
 #include "module.pb.h"
-#include "outcome.hpp"
 #include "process.pb.h"
 #include "symbol.pb.h"
 
@@ -35,27 +35,23 @@
 //
 class ProcessManager {
  public:
-  struct Error {
-    std::string message;
-  };
-
   ProcessManager() = default;
   virtual ~ProcessManager() = default;
 
   virtual void SetProcessListUpdateListener(
       const std::function<void(ProcessManager*)>& listener) = 0;
 
-  virtual outcome::result<std::vector<ModuleInfo>, std::string> LoadModuleList(
+  virtual Result<std::vector<ModuleInfo>, ErrorMessage> LoadModuleList(
       int32_t pid) = 0;
 
   // Get a copy of process list.
   virtual std::vector<ProcessInfo> GetProcessList() const = 0;
 
-  virtual outcome::result<std::string, Error, outcome::policy::terminate>
-  LoadProcessMemory(int32_t pid, uint64_t address, uint64_t size) = 0;
+  virtual Result<std::string, ErrorMessage> LoadProcessMemory(
+      int32_t pid, uint64_t address, uint64_t size) = 0;
 
   // Get symbols for a module
-  virtual outcome::result<ModuleSymbols, std::string> LoadSymbols(
+  virtual Result<ModuleSymbols, ErrorMessage> LoadSymbols(
       const std::string& module_path) const = 0;
 
   // Note that this method waits for the worker thread to stop, which could

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -499,8 +499,7 @@ void OrbitMainWindow::on_actionOpen_Preset_triggered() {
   QStringList list = QFileDialog::getOpenFileNames(
       this, "Select a file to open...", Path::GetPresetPath().c_str(), "*.opr");
   for (const auto& file : list) {
-    Result<void, ErrorMessage> result =
-        GOrbitApp->OnLoadPreset(file.toStdString());
+    ErrorMessageOr<void> result = GOrbitApp->OnLoadPreset(file.toStdString());
     if (result.has_error()) {
       QMessageBox::critical(
           this, "Error loading session",
@@ -542,8 +541,7 @@ void OrbitMainWindow::on_actionSave_Preset_As_triggered() {
     return;
   }
 
-  Result<void, ErrorMessage> result =
-      GOrbitApp->OnSavePreset(file.toStdString());
+  ErrorMessageOr<void> result = GOrbitApp->OnSavePreset(file.toStdString());
   if (result.has_error()) {
     QMessageBox::critical(
         this, "Error saving session",
@@ -564,8 +562,7 @@ void OrbitMainWindow::on_actionSave_Capture_triggered() {
     return;
   }
 
-  Result<void, ErrorMessage> result =
-      GOrbitApp->OnSaveCapture(file.toStdString());
+  ErrorMessageOr<void> result = GOrbitApp->OnSaveCapture(file.toStdString());
   if (result.has_error()) {
     QMessageBox::critical(
         this, "Error saving capture",
@@ -589,7 +586,7 @@ void OrbitMainWindow::on_actionOpen_Capture_triggered() {
 
 outcome::result<void> OrbitMainWindow::OpenCapture(
     const std::string& filepath) {
-  Result<void, ErrorMessage> result = GOrbitApp->OnLoadCapture(filepath);
+  ErrorMessageOr<void> result = GOrbitApp->OnLoadCapture(filepath);
 
   if (result.has_error()) {
     SetTitle({});

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -499,13 +499,13 @@ void OrbitMainWindow::on_actionOpen_Preset_triggered() {
   QStringList list = QFileDialog::getOpenFileNames(
       this, "Select a file to open...", Path::GetPresetPath().c_str(), "*.opr");
   for (const auto& file : list) {
-    outcome::result<void, std::string> result =
+    Result<void, ErrorMessage> result =
         GOrbitApp->OnLoadPreset(file.toStdString());
     if (result.has_error()) {
       QMessageBox::critical(
           this, "Error loading session",
           absl::StrFormat("Could not load session from \"%s\":\n%s.",
-                          file.toStdString(), result.error())
+                          file.toStdString(), result.error().message())
               .c_str());
     }
     break;
@@ -542,13 +542,13 @@ void OrbitMainWindow::on_actionSave_Preset_As_triggered() {
     return;
   }
 
-  outcome::result<void, std::string> result =
+  Result<void, ErrorMessage> result =
       GOrbitApp->OnSavePreset(file.toStdString());
   if (result.has_error()) {
     QMessageBox::critical(
         this, "Error saving session",
         absl::StrFormat("Could not save session in \"%s\":\n%s.",
-                        file.toStdString(), result.error())
+                        file.toStdString(), result.error().message())
             .c_str());
   }
 }
@@ -564,13 +564,13 @@ void OrbitMainWindow::on_actionSave_Capture_triggered() {
     return;
   }
 
-  outcome::result<void, std::string> result =
+  Result<void, ErrorMessage> result =
       GOrbitApp->OnSaveCapture(file.toStdString());
   if (result.has_error()) {
     QMessageBox::critical(
         this, "Error saving capture",
         absl::StrFormat("Could not save capture in \"%s\":\n%s.",
-                        file.toStdString(), result.error())
+                        file.toStdString(), result.error().message())
             .c_str());
   }
 }
@@ -589,15 +589,14 @@ void OrbitMainWindow::on_actionOpen_Capture_triggered() {
 
 outcome::result<void> OrbitMainWindow::OpenCapture(
     const std::string& filepath) {
-  outcome::result<void, std::string> result =
-      GOrbitApp->OnLoadCapture(filepath);
+  Result<void, ErrorMessage> result = GOrbitApp->OnLoadCapture(filepath);
 
   if (result.has_error()) {
     SetTitle({});
     QMessageBox::critical(this, "Error loading capture",
                           QString::fromStdString(absl::StrFormat(
                               "Could not load capture from \"%s\":\n%s.",
-                              filepath, result.error())));
+                              filepath, result.error().message())));
     return std::errc::no_such_file_or_directory;
   }
   SetTitle(QString::fromStdString(filepath));

--- a/OrbitService/ProcessServiceImpl.cpp
+++ b/OrbitService/ProcessServiceImpl.cpp
@@ -89,8 +89,9 @@ Status ProcessServiceImpl::GetSymbols(ServerContext*,
   const auto load_result =
       symbol_helper.LoadSymbolsCollector(request->module_path());
 
-  if (!load_result)
+  if (load_result.has_error()) {
     return Status(StatusCode::NOT_FOUND, load_result.error().message());
+  }
 
   *response->mutable_module_symbols() = std::move(load_result.value());
 

--- a/OrbitService/ProcessServiceImpl.cpp
+++ b/OrbitService/ProcessServiceImpl.cpp
@@ -48,7 +48,7 @@ Status ProcessServiceImpl::GetModuleList(ServerContext*,
 
   const auto module_infos = LinuxUtils::ListModules(pid);
   if (!module_infos) {
-    return Status(StatusCode::NOT_FOUND, module_infos.error());
+    return Status(StatusCode::NOT_FOUND, module_infos.error().message());
   }
 
   for (const auto& module_info : module_infos.value()) {

--- a/OrbitService/ProcessServiceImpl.cpp
+++ b/OrbitService/ProcessServiceImpl.cpp
@@ -89,7 +89,8 @@ Status ProcessServiceImpl::GetSymbols(ServerContext*,
   const auto load_result =
       symbol_helper.LoadSymbolsCollector(request->module_path());
 
-  if (!load_result) return Status(StatusCode::NOT_FOUND, load_result.error());
+  if (!load_result)
+    return Status(StatusCode::NOT_FOUND, load_result.error().message());
 
   *response->mutable_module_symbols() = std::move(load_result.value());
 


### PR DESCRIPTION
From now on we should use Result in place of outcome::result, the only difference here is that Result uses policy::terminate for as a NoValuePolicy. Accessing errors/values when they do not exist should be a fatal error because in most cases this is not what you want to do.

This PR also moves usages of result<T, std::string> to Result<T, ErrorMessage>.