### PR TITLE
Redraw capture window when TimeGraph::Zoom is called

### DIFF
--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -147,7 +147,6 @@ void TimeGraph::Zoom(const TextBox* a_TextBox) {
   double extent = 1.1 * (end - start) / 2.0;
 
   SetMinMax(mid - extent, mid + extent);
-  NeedsUpdate();
 }
 
 //-----------------------------------------------------------------------------
@@ -455,7 +454,6 @@ void TimeGraph::UpdatePrimitives() {
 
   min_y_ = current_y;
   m_NeedsUpdatePrimitives = false;
-  NeedsRedraw();
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -147,7 +147,7 @@ void TimeGraph::Zoom(const TextBox* a_TextBox) {
   double extent = 1.1 * (end - start) / 2.0;
 
   SetMinMax(mid - extent, mid + extent);
-  m_NeedsRedraw = true;
+  NeedsRedraw();
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -147,7 +147,7 @@ void TimeGraph::Zoom(const TextBox* a_TextBox) {
   double extent = 1.1 * (end - start) / 2.0;
 
   SetMinMax(mid - extent, mid + extent);
-  NeedsRedraw();
+  NeedsUpdate();
 }
 
 //-----------------------------------------------------------------------------
@@ -421,7 +421,11 @@ void TimeGraph::SelectRight(const TextBox* a_TextBox) {
 }
 
 //-----------------------------------------------------------------------------
-void TimeGraph::NeedsUpdate() { m_NeedsUpdatePrimitives = true; }
+void TimeGraph::NeedsUpdate() {
+  m_NeedsUpdatePrimitives = true;
+  // If the primitives need to be updated, we also have to redraw.
+  m_NeedsRedraw = true;
+}
 
 //-----------------------------------------------------------------------------
 void TimeGraph::UpdatePrimitives() {
@@ -451,7 +455,7 @@ void TimeGraph::UpdatePrimitives() {
 
   min_y_ = current_y;
   m_NeedsUpdatePrimitives = false;
-  m_NeedsRedraw = true;
+  NeedsRedraw();
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -147,6 +147,7 @@ void TimeGraph::Zoom(const TextBox* a_TextBox) {
   double extent = 1.1 * (end - start) / 2.0;
 
   SetMinMax(mid - extent, mid + extent);
+  m_Canvas->NeedsRedraw();
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -147,7 +147,7 @@ void TimeGraph::Zoom(const TextBox* a_TextBox) {
   double extent = 1.1 * (end - start) / 2.0;
 
   SetMinMax(mid - extent, mid + extent);
-  m_Canvas->NeedsRedraw();
+  m_NeedsRedraw = true;
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -141,9 +141,18 @@ class TimeGraph {
 
   std::map<ThreadID, uint32_t> m_ThreadCountMap;
 
+  // Be careful when directly changing these members without using the
+  // methods NeedsRedraw() or NeedsUpdate():
+  // m_NeedsUpdatePrimitives should always imply m_NeedsRedraw, that is
+  // m_NeedsUpdatePrimitives => m_NeedsRedraw is an invariant of this
+  // class. When updating the primitives, which computes the primitives
+  // to be drawn and their coordinates, we always have to redraw the
+  // timeline.
   bool m_NeedsUpdatePrimitives = false;
-  bool m_DrawText = true;
   bool m_NeedsRedraw = false;
+
+  bool m_DrawText = true;
+
   Batcher m_Batcher;
   PickingManager* m_PickingManager = nullptr;
   Timer m_LastThreadReorder;


### PR DESCRIPTION
The capture window was not redrawn when using the jump to first/min/max/last actions as TimeGraph::NeedsUpdate() would not actually cause a redraw of the capture window. 

This PR makes all changes so that "update needed" => "redraw needed" is now an invariant of the TimeGraph class. In particular, NeedsUpdate() now also sets m_NeedsRedraw to true. 

Clarifying comments are added.