### PR TITLE
Fail compilation on sign-comparison-warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,14 +13,16 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
                            -Werror=inconsistent-missing-override
                            -Werror=old-style-cast
                            -Werror=unused-parameter
-                           -Werror=unused-variable)
+                           -Werror=unused-variable
+                           -Werror=sign-compare)
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   set(STRICT_COMPILE_FLAGS -Werror=all
                            -Werror=float-conversion
                            -Werror=format=2
                            -Werror=old-style-cast
                            -Werror=unused-parameter
-                           -Werror=unused-variable)
+                           -Werror=unused-variable
+                           -Werror=sign-compare)
 endif()
 
 include(cmake/strip.cmake)

--- a/OrbitGl/LiveFunctionsDataView.cpp
+++ b/OrbitGl/LiveFunctionsDataView.cpp
@@ -305,7 +305,7 @@ std::pair<TextBox*, TextBox*> LiveFunctionsDataView::GetMinMax(
     if (!chain) continue;
     for (TimerChainIterator it = chain->begin(); it != chain->end(); ++it) {
       TimerBlock& block = *it;
-      for (int i = 0; i < block.size(); i++) {
+      for (size_t i = 0; i < block.size(); i++) {
         TextBox& box = block[i];
         if (box.GetTimer().m_FunctionAddress == function_address) {
           if (!min_box || box.GetTimer().ElapsedMicros() <
@@ -333,7 +333,7 @@ void LiveFunctionsDataView::JumpToNext(Function& function,
     for (TimerChainIterator it = chain->begin(); it != chain->end(); ++it) {
       TimerBlock& block = *it;
       if (!block.Intersects(current_time, best_time)) continue;
-      for (int i = 0; i < block.size(); i++) {
+      for (size_t i = 0; i < block.size(); i++) {
         TextBox& box = block[i];
         auto box_time = box.GetTimer().m_End;
         if ((box.GetTimer().m_FunctionAddress == function_address) &&
@@ -359,7 +359,7 @@ void LiveFunctionsDataView::JumpToPrevious(Function& function,
     for (TimerChainIterator it = chain->begin(); it != chain->end(); ++it) {
       TimerBlock& block = *it;
       if (!block.Intersects(best_time, current_time)) continue;
-      for (int i = 0; i < block.size(); i++) {
+      for (size_t i = 0; i < block.size(); i++) {
         TextBox& box = block[i];
         auto box_time = box.GetTimer().m_End;
         if ((box.GetTimer().m_FunctionAddress == function_address) &&

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -72,7 +72,7 @@ void DrawTriangleFan(Batcher* batcher, const std::vector<Vec2>& points,
   Vec3 vertices[2];
   vertices[0] = position + Vec3(rotated_points[1][0], rotated_points[1][1], z);
 
-  for (int i = 1; i < rotated_points.size() - 1; ++i) {
+  for (size_t i = 1; i < rotated_points.size() - 1; ++i) {
     vertices[i % 2] =
         position + Vec3(rotated_points[i + 1][0], rotated_points[i + 1][1], z);
     Triangle triangle(pivot, vertices[i % 2], vertices[(i + 1) % 2]);


### PR DESCRIPTION
This PR straightens a difference in behaviour between GCC and Clang. GCC was failing on sign-comparison-warnings, but Clang was not. Now Clang also fails on these warnings.