### PR TITLE
Store PID, process name, thread names in Capture

### DIFF
--- a/OrbitCore/Callstack.cpp
+++ b/OrbitCore/Callstack.cpp
@@ -9,26 +9,6 @@
 #include "absl/strings/str_format.h"
 
 //-----------------------------------------------------------------------------
-std::string CallStack::GetString() {
-  std::string callstackString;
-
-  ScopeLock lock(Capture::GTargetProcess->GetDataMutex());
-  for (uint32_t i = 0; i < m_Depth; ++i) {
-    DWORD64 addr = m_Data[i];
-    Function* func =
-        Capture::GTargetProcess->GetFunctionFromAddress(addr, false);
-
-    if (func) {
-      callstackString += func->PrettyName() + "\n";
-    } else {
-      callstackString += absl::StrFormat("%" PRIx64 "\n", addr);
-    }
-  }
-
-  return callstackString;
-}
-
-//-----------------------------------------------------------------------------
 ORBIT_SERIALIZE(CallStack, 0) {
   ORBIT_NVP_VAL(0, m_Data);
   ORBIT_NVP_VAL(0, m_Hash);

--- a/OrbitCore/Callstack.h
+++ b/OrbitCore/Callstack.h
@@ -21,7 +21,6 @@ struct CallStack {
     m_Hash = XXH64(m_Data.data(), m_Depth * sizeof(uint64_t), 0xca1157ac);
     return m_Hash;
   }
-  std::string GetString();
 
   CallstackID m_Hash = 0;
   uint32_t m_Depth = 0;

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -46,6 +46,7 @@ std::map<uint64_t, Function*> Capture::GVisibleFunctionsMap;
 std::unordered_map<uint64_t, uint64_t> Capture::GFunctionCountMap;
 std::shared_ptr<CallStack> Capture::GSelectedCallstack;
 std::unordered_map<uint64_t, std::shared_ptr<CallStack>> Capture::GCallstacks;
+std::unordered_map<int32_t, std::string> Capture::GThreadNames;
 std::unordered_map<uint64_t, LinuxAddressInfo> Capture::GAddressInfos;
 std::unordered_map<uint64_t, std::string> Capture::GAddressToFunctionName;
 Mutex Capture::GCallstackMutex;
@@ -125,6 +126,7 @@ void Capture::FinalizeCapture() {
 void Capture::ClearCaptureData() {
   GFunctionCountMap.clear();
   GCallstacks.clear();
+  GThreadNames.clear();
   GAddressInfos.clear();
   GAddressToFunctionName.clear();
   GZoneNames.clear();

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -53,7 +53,6 @@ Mutex Capture::GCallstackMutex;
 std::unordered_map<uint64_t, std::string> Capture::GZoneNames;
 TextBox* Capture::GSelectedTextBox;
 ThreadID Capture::GSelectedThreadId;
-Timer Capture::GCaptureTimer;
 std::chrono::system_clock::time_point Capture::GCaptureTimePoint;
 
 std::shared_ptr<SamplingProfiler> Capture::GSamplingProfiler = nullptr;
@@ -62,7 +61,6 @@ std::shared_ptr<Preset> Capture::GSessionPresets = nullptr;
 
 void (*Capture::GClearCaptureDataFunc)();
 std::vector<std::shared_ptr<SamplingProfiler>> GOldSamplingProfilers;
-bool Capture::GUnrealSupported = false;
 
 //-----------------------------------------------------------------------------
 void Capture::Init() { GTargetProcess = std::make_shared<Process>(); }
@@ -87,7 +85,6 @@ outcome::result<void, std::string> Capture::StartCapture() {
         "No process selected. Please choose a target process for the capture.");
   }
 
-  GCaptureTimer.Start();
   GCaptureTimePoint = std::chrono::system_clock::now();
 
   GInjected = true;
@@ -236,20 +233,6 @@ void Capture::NewSamplingProfiler() {
 
   Capture::GSamplingProfiler =
       std::make_shared<SamplingProfiler>(Capture::GTargetProcess);
-}
-
-//-----------------------------------------------------------------------------
-bool Capture::IsRemote() {
-  return GTargetProcess && GTargetProcess->GetIsRemote();
-}
-
-//-----------------------------------------------------------------------------
-bool Capture::IsLinuxData() {
-  bool isLinux = false;
-#if __linux__
-  isLinux = true;
-#endif
-  return IsRemote() || isLinux;
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -46,6 +46,8 @@ std::map<uint64_t, Function*> Capture::GVisibleFunctionsMap;
 std::unordered_map<uint64_t, uint64_t> Capture::GFunctionCountMap;
 std::shared_ptr<CallStack> Capture::GSelectedCallstack;
 std::unordered_map<uint64_t, std::shared_ptr<CallStack>> Capture::GCallstacks;
+int32_t Capture::GProcessId = -1;
+std::string Capture::GProcessName;
 std::unordered_map<int32_t, std::string> Capture::GThreadNames;
 std::unordered_map<uint64_t, LinuxAddressInfo> Capture::GAddressInfos;
 std::unordered_map<uint64_t, std::string> Capture::GAddressToFunctionName;
@@ -85,11 +87,14 @@ outcome::result<void, std::string> Capture::StartCapture() {
         "No process selected. Please choose a target process for the capture.");
   }
 
+  ClearCaptureData();
+
   GCaptureTimePoint = std::chrono::system_clock::now();
+  GProcessId = GTargetProcess->GetID();
+  GProcessName = GTargetProcess->GetName();
 
   GInjected = true;
 
-  ClearCaptureData();
   PreFunctionHooks();
 
   Capture::NewSamplingProfiler();
@@ -123,6 +128,8 @@ void Capture::FinalizeCapture() {
 void Capture::ClearCaptureData() {
   GFunctionCountMap.clear();
   GCallstacks.clear();
+  GProcessId = -1;
+  GProcessName = "";
   GThreadNames.clear();
   GAddressInfos.clear();
   GAddressToFunctionName.clear();

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -39,10 +39,6 @@ class Capture {
   static outcome::result<void, std::string> SavePreset(
       const std::string& filename);
   static void NewSamplingProfiler();
-  // True when Orbit is receiving data from remote source
-  static bool IsRemote();
-  // True if receiving data from Linux remote source
-  static bool IsLinuxData();
   static void RegisterZoneName(uint64_t a_ID, const char* a_Name);
   static void AddCallstack(CallStack& a_CallStack);
   static std::shared_ptr<CallStack> GetCallstack(CallstackID a_ID);
@@ -81,10 +77,6 @@ class Capture {
   static std::unordered_map<uint64_t, std::string> GZoneNames;
   static class TextBox* GSelectedTextBox;
   static ThreadID GSelectedThreadId;
-  static Timer GCaptureTimer;
   static std::chrono::system_clock::time_point GCaptureTimePoint;
   static Mutex GCallstackMutex;
-
- private:
-  static bool GUnrealSupported;
 };

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -75,6 +75,7 @@ class Capture {
   static std::map<uint64_t, Function*> GVisibleFunctionsMap;
   static std::unordered_map<uint64_t, uint64_t> GFunctionCountMap;
   static std::unordered_map<uint64_t, std::shared_ptr<CallStack>> GCallstacks;
+  static std::unordered_map<int32_t, std::string> GThreadNames;
   static std::unordered_map<uint64_t, LinuxAddressInfo> GAddressInfos;
   static std::unordered_map<uint64_t, std::string> GAddressToFunctionName;
   static std::unordered_map<uint64_t, std::string> GZoneNames;

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -71,6 +71,8 @@ class Capture {
   static std::map<uint64_t, Function*> GVisibleFunctionsMap;
   static std::unordered_map<uint64_t, uint64_t> GFunctionCountMap;
   static std::unordered_map<uint64_t, std::shared_ptr<CallStack>> GCallstacks;
+  static int32_t GProcessId;
+  static std::string GProcessName;
   static std::unordered_map<int32_t, std::string> GThreadNames;
   static std::unordered_map<uint64_t, LinuxAddressInfo> GAddressInfos;
   static std::unordered_map<uint64_t, std::string> GAddressToFunctionName;

--- a/OrbitCore/OrbitFunction.cpp
+++ b/OrbitCore/OrbitFunction.cpp
@@ -40,32 +40,12 @@ Function::Function(std::string_view name, std::string_view pretty_name,
   SetOrbitTypeFromName();
 }
 
-bool Function::Hookable() {
-  if (Capture::IsLinuxData()) {
-    return true;
-  } else {
-    // Don't allow hooking in asm implemented functions (strcpy, stccat...)
-    // TODO: give this better thought.  Here is the theory:
-    // Functions that loop back to first 5 bytes of instructions will explode as
-    // the IP lands in the middle of the relative jump instruction...
-    // Ideally, we would detect such a loop back and not allow hooking.
-    if (file_.find(".asm") != std::string::npos) {
-      return false;
-    }
-
-    CV_call_e conv = static_cast<CV_call_e>(calling_convention_);
-    return ((conv == CV_CALL_NEAR_C || conv == CV_CALL_THISCALL) && size_ >= 5);
-  }
-}
-
 void Function::Select() {
-  if (Hookable()) {
-    LOG("Selected %s at 0x%" PRIx64 " (address_=0x%" PRIx64
-        ", load_bias_= 0x%" PRIx64 ", base_address=0x%" PRIx64 ")",
-        pretty_name_, GetVirtualAddress(), address_, load_bias_,
-        module_base_address_);
-    Capture::GSelectedFunctionsMap[GetVirtualAddress()] = this;
-  }
+  LOG("Selected %s at 0x%" PRIx64 " (address_=0x%" PRIx64
+      ", load_bias_= 0x%" PRIx64 ", base_address=0x%" PRIx64 ")",
+      pretty_name_, GetVirtualAddress(), address_, load_bias_,
+      module_base_address_);
+  Capture::GSelectedFunctionsMap[GetVirtualAddress()] = this;
 }
 
 void Function::UnSelect() {

--- a/OrbitCore/OrbitFunction.h
+++ b/OrbitCore/OrbitFunction.h
@@ -105,7 +105,6 @@ class Function {
   ORBIT_SERIALIZABLE;
 
  private:
-  bool Hookable();
   static const absl::flat_hash_map<const char*, OrbitType>&
   GetFunctionNameToOrbitTypeMap();
   std::string name_;

--- a/OrbitCore/OrbitProcess.h
+++ b/OrbitCore/OrbitProcess.h
@@ -26,12 +26,6 @@ class Process {
  public:
   Process();
 
-  void SetThreadName(int32_t thread_id, std::string thread_name) {
-    m_ThreadNames[thread_id] = std::move(thread_name);
-  }
-  std::string GetThreadNameFromTID(DWORD a_ThreadId) {
-    return m_ThreadNames[a_ThreadId];
-  }
   void AddModule(std::shared_ptr<Module>& a_Module);
 
   std::map<std::string, std::shared_ptr<Module>>& GetNameToModulesMap() {
@@ -83,7 +77,6 @@ class Process {
   // (/usr/lib/libbase.so and /opt/somedir/libbase.so)
   std::map<std::string, std::shared_ptr<Module>> m_NameToModuleMap;
   std::map<std::string, std::shared_ptr<Module>> path_to_module_map_;
-  std::map<int32_t, std::string> m_ThreadNames;
 
   // Transients
   std::vector<std::shared_ptr<Function>> m_Functions;

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -123,7 +123,7 @@ void OrbitApp::OnCallstackEvent(CallstackEvent callstack_event) {
 }
 
 void OrbitApp::OnThreadName(int32_t thread_id, std::string thread_name) {
-  Capture::GTargetProcess->SetThreadName(thread_id, std::move(thread_name));
+  Capture::GThreadNames.insert_or_assign(thread_id, std::move(thread_name));
 }
 
 void OrbitApp::OnAddressInfo(LinuxAddressInfo address_info) {

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -409,11 +409,10 @@ void OrbitApp::AddSelectionReport(
 
 //-----------------------------------------------------------------------------
 std::string OrbitApp::GetCaptureFileName() {
-  CHECK(Capture::GTargetProcess != nullptr);
   time_t timestamp =
       std::chrono::system_clock::to_time_t(Capture::GCaptureTimePoint);
   std::string result;
-  result.append(Path::StripExtension(Capture::GTargetProcess->GetName()));
+  result.append(Path::StripExtension(Capture::GProcessName));
   result.append("_");
   result.append(OrbitUtils::FormatTime(timestamp));
   result.append(".orbit");
@@ -546,7 +545,7 @@ bool OrbitApp::StartCapture() {
     return false;
   }
 
-  int32_t pid = Capture::GTargetProcess->GetID();
+  int32_t pid = Capture::GProcessId;
   std::vector<std::shared_ptr<Function>> selected_functions =
       Capture::GSelectedFunctions;
   thread_pool_->Schedule([this, pid, selected_functions] {

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -94,6 +94,16 @@ void CaptureSerializer::SaveImpl(T& archive) {
   }
 
   {
+    ORBIT_SIZE_SCOPE("Capture::GProcessId");
+    archive(Capture::GProcessId);
+  }
+
+  {
+    ORBIT_SIZE_SCOPE("Capture::GProcessName");
+    archive(Capture::GProcessName);
+  }
+
+  {
     ORBIT_SIZE_SCOPE("Capture::GThreadNames");
     archive(Capture::GThreadNames);
   }
@@ -185,6 +195,10 @@ outcome::result<void, std::string> CaptureSerializer::Load(
   archive(Capture::GFunctionCountMap);
 
   archive(Capture::GCallstacks);
+
+  archive(Capture::GProcessId);
+
+  archive(Capture::GProcessName);
 
   archive(Capture::GThreadNames);
 

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -94,6 +94,11 @@ void CaptureSerializer::SaveImpl(T& archive) {
   }
 
   {
+    ORBIT_SIZE_SCOPE("Capture::GThreadNames");
+    archive(Capture::GThreadNames);
+  }
+
+  {
     ORBIT_SIZE_SCOPE("Capture::GAddressInfos");
     archive(Capture::GAddressInfos);
   }
@@ -180,6 +185,8 @@ outcome::result<void, std::string> CaptureSerializer::Load(
   archive(Capture::GFunctionCountMap);
 
   archive(Capture::GCallstacks);
+
+  archive(Capture::GThreadNames);
 
   archive(Capture::GAddressInfos);
 

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -1023,10 +1023,8 @@ void CaptureWindow::RenderToolbars() {
   if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
     ImGui::SetTooltip("Process Info");
   ImGui::SameLine();
-  std::string process_info = Capture::GTargetProcess->GetName();
-  if (!process_info.empty()) {
-    int32_t process_id = Capture::GTargetProcess->GetID();
-    ImGui::Text("%s [%d]", process_info.c_str(), process_id);
+  if (Capture::GProcessId > 0 && !Capture::GProcessName.empty()) {
+    ImGui::Text("%s [%d]", Capture::GProcessName.c_str(), Capture::GProcessId);
   }
   ImGui::End();
 

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -48,8 +48,7 @@ void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
   Batcher* batcher = &time_graph_->GetBatcher();
   GlCanvas* canvas = time_graph_->GetCanvas();
   const TimeGraphLayout& layout = time_graph_->GetLayout();
-  const auto& target_process = Capture::GTargetProcess;
-  int32_t target_pid = target_process ? target_process->GetID() : 0;
+  int32_t target_pid = Capture::GProcessId;
   int32_t selected_thread_id = Capture::GSelectedThreadId;
 
   float world_start_x = canvas->GetWorldTopLeftX();

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -524,7 +524,7 @@ void TimeGraph::DrawTracks(GlCanvas* canvas, bool a_Picking) {
       int32_t tid = thread_track->GetThreadId();
       if (tid == 0) {
         // This is the process_track_.
-        std::string process_name = Capture::GTargetProcess->GetName();
+        std::string process_name = Capture::GProcessName;
         thread_track->SetName(process_name);
         thread_track->SetLabel(process_name + " (all threads)");
       } else {

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -528,8 +528,7 @@ void TimeGraph::DrawTracks(GlCanvas* canvas, bool a_Picking) {
         thread_track->SetName(process_name);
         thread_track->SetLabel(process_name + " (all threads)");
       } else {
-        std::string thread_name =
-            Capture::GTargetProcess->GetThreadNameFromTID(tid);
+        const std::string& thread_name = Capture::GThreadNames[tid];
         track->SetName(thread_name);
         std::string track_label = absl::StrFormat("%s [%u]", thread_name, tid);
         track->SetLabel(track_label);


### PR DESCRIPTION
#### Store thread names in Capture::GThreadNames instead of in Process
The selected process might have changed after the capture has been takes. This
is also always the case when loading a capture.
Bug: http://b/156891478
Of course this is quick fix until we completely rework `Capture` and everything
related.
#### Remove unused Callstack::GetString
#### Remove Capture::IsRemote, Capture::IsLinuxData, Function::Hookable
#### Introduce and use Capture::GProcessId,GProcessName
Instead of using `Capture::GTargetProcess->GetID`,`GetName` in places that refer
not to the current selected process to profile but to the already taken capture
(the selected process might have changed).
Bug: http://b/156891478