### PR TITLE
Separated data and logic in OrbitFunction

### DIFF
--- a/OrbitCore/CMakeLists.txt
+++ b/OrbitCore/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(
          Core.h
          EventBuffer.h
          FunctionStats.h
+         FunctionUtils.h
          Injection.h
          Introspection.h
          LinuxAddressInfo.h
@@ -59,6 +60,7 @@ target_sources(
           Core.cpp
           EventBuffer.cpp
           FunctionStats.cpp
+          FunctionUtils.cpp
           Injection.cpp
           Introspection.cpp
           LinuxTracingBuffer.cpp

--- a/OrbitCore/Callstack.cpp
+++ b/OrbitCore/Callstack.cpp
@@ -5,6 +5,7 @@
 #include "Callstack.h"
 
 #include "Capture.h"
+#include "FunctionUtils.h"
 #include "Serialization.h"
 #include "absl/strings/str_format.h"
 

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -148,7 +148,7 @@ void Capture::PreFunctionHooks() {
   GSelectedFunctions = GetSelectedFunctions();
 
   for (auto& func : GSelectedFunctions) {
-    uint64_t address = function::GetAbsoluteAddress(*func);
+    uint64_t address = FunctionUtils::GetAbsoluteAddress(*func);
     GSelectedFunctionsMap[address] = func.get();
     func->ResetStats();
     GFunctionCountMap[address] = 0;
@@ -164,7 +164,7 @@ void Capture::PreFunctionHooks() {
 std::vector<std::shared_ptr<Function>> Capture::GetSelectedFunctions() {
   std::vector<std::shared_ptr<Function>> selected_functions;
   for (auto& func : GTargetProcess->GetFunctions()) {
-    if (function::IsSelected(*func) || function::IsOrbitFunc(*func)) {
+    if (FunctionUtils::IsSelected(*func) || FunctionUtils::IsOrbitFunc(*func)) {
       selected_functions.push_back(func);
     }
   }
@@ -189,9 +189,9 @@ ErrorMessageOr<void> Capture::SavePreset(const std::string& filename) {
   preset.m_ProcessFullPath = GTargetProcess->GetFullPath();
 
   for (auto& func : GTargetProcess->GetFunctions()) {
-    if (function::IsSelected(*func)) {
+    if (FunctionUtils::IsSelected(*func)) {
       preset.m_Modules[func->loaded_module_path()].m_FunctionHashes.push_back(
-          function::GetHash(*func));
+          FunctionUtils::GetHash(*func));
     }
   }
 

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -9,6 +9,7 @@
 
 #include "Core.h"
 #include "EventBuffer.h"
+#include "FunctionUtils.h"
 #include "Injection.h"
 #include "Log.h"
 #include "OrbitBase/Logging.h"
@@ -147,7 +148,7 @@ void Capture::PreFunctionHooks() {
   GSelectedFunctions = GetSelectedFunctions();
 
   for (auto& func : GSelectedFunctions) {
-    uint64_t address = func->GetVirtualAddress();
+    uint64_t address = function::GetAbsoluteAddress(*func);
     GSelectedFunctionsMap[address] = func.get();
     func->ResetStats();
     GFunctionCountMap[address] = 0;
@@ -163,7 +164,7 @@ void Capture::PreFunctionHooks() {
 std::vector<std::shared_ptr<Function>> Capture::GetSelectedFunctions() {
   std::vector<std::shared_ptr<Function>> selected_functions;
   for (auto& func : GTargetProcess->GetFunctions()) {
-    if (func->IsSelected() || func->IsOrbitFunc()) {
+    if (function::IsSelected(*func) || function::IsOrbitFunc(*func)) {
       selected_functions.push_back(func);
     }
   }
@@ -188,9 +189,9 @@ ErrorMessageOr<void> Capture::SavePreset(const std::string& filename) {
   preset.m_ProcessFullPath = GTargetProcess->GetFullPath();
 
   for (auto& func : GTargetProcess->GetFunctions()) {
-    if (func->IsSelected()) {
-      preset.m_Modules[func->GetLoadedModulePath()].m_FunctionHashes.push_back(
-          func->Hash());
+    if (function::IsSelected(*func)) {
+      preset.m_Modules[func->loaded_module_path()].m_FunctionHashes.push_back(
+          function::GetHash(*func));
     }
   }
 

--- a/OrbitCore/FunctionStats.cpp
+++ b/OrbitCore/FunctionStats.cpp
@@ -9,28 +9,6 @@
 #include "Serialization.h"
 
 //-----------------------------------------------------------------------------
-template <class T>
-inline void UpdateMax(T& a_Max, T a_Value) {
-  if (a_Value > a_Max) a_Max = a_Value;
-}
-
-//-----------------------------------------------------------------------------
-template <class T>
-inline void UpdateMin(T& a_Min, T a_Value) {
-  if (a_Min == 0 || a_Value < a_Min) a_Min = a_Value;
-}
-
-//-----------------------------------------------------------------------------
-void FunctionStats::Update(const Timer& a_Timer) {
-  ++m_Count;
-  double elapsedMillis = a_Timer.ElapsedMillis();
-  m_TotalTimeMs += elapsedMillis;
-  m_AverageTimeMs = m_TotalTimeMs / static_cast<double>(m_Count);
-  UpdateMax(m_MaxMs, elapsedMillis);
-  UpdateMin(m_MinMs, elapsedMillis);
-}
-
-//-----------------------------------------------------------------------------
 ORBIT_SERIALIZE(FunctionStats, 0) {
   ORBIT_NVP_VAL(0, m_Address);
   ORBIT_NVP_VAL(0, m_Count);

--- a/OrbitCore/FunctionStats.h
+++ b/OrbitCore/FunctionStats.h
@@ -13,7 +13,6 @@
 struct FunctionStats {
   FunctionStats() { Reset(); }
   void Reset() { memset(this, 0, sizeof(*this)); }
-  void Update(const class Timer& a_Timer);
 
   uint64_t m_Address;
   uint64_t m_Count;

--- a/OrbitCore/FunctionUtils.cpp
+++ b/OrbitCore/FunctionUtils.cpp
@@ -11,7 +11,7 @@
 #include "OrbitBase/Logging.h"
 #include "Utils.h"
 
-namespace function {
+namespace FunctionUtils {
 
 std::string GetLoadedModuleName(const Function& func) {
   return Path::GetFileName(func.loaded_module_path());
@@ -109,4 +109,4 @@ bool IsSelected(const SampledFunction& func) {
   return Capture::GSelectedFunctionsMap.count(func.m_Address) > 0;
 }
 
-}  // namespace function
+}  // namespace FunctionUtils

--- a/OrbitCore/FunctionUtils.cpp
+++ b/OrbitCore/FunctionUtils.cpp
@@ -105,4 +105,8 @@ void UpdateStats(Function* func, const Timer& timer) {
   }
 }
 
+bool IsSelected(const SampledFunction& func) {
+  return Capture::GSelectedFunctionsMap.count(func.m_Address) > 0;
+}
+
 }  // namespace function

--- a/OrbitCore/FunctionUtils.h
+++ b/OrbitCore/FunctionUtils.h
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "OrbitFunction.h"
+#include "SamplingProfiler.h"
 #include "ScopeTimer.h"
 
 namespace function {
@@ -36,6 +37,8 @@ void Print(const Function& func);
 
 bool SetOrbitTypeFromName(Function* func);
 void UpdateStats(Function* func, const Timer& timer);
+
+bool IsSelected(const SampledFunction& func);
 
 }  // namespace function
 

--- a/OrbitCore/FunctionUtils.h
+++ b/OrbitCore/FunctionUtils.h
@@ -12,7 +12,7 @@
 #include "SamplingProfiler.h"
 #include "ScopeTimer.h"
 
-namespace function {
+namespace FunctionUtils {
 
 inline const std::string& GetDisplayName(const Function& func) {
   return func.pretty_name().empty() ? func.name() : func.pretty_name();
@@ -40,6 +40,6 @@ void UpdateStats(Function* func, const Timer& timer);
 
 bool IsSelected(const SampledFunction& func);
 
-}  // namespace function
+}  // namespace FunctionUtils
 
 #endif  // ORBIT_CORE_FUNCTION_UTILS_H_

--- a/OrbitCore/FunctionUtils.h
+++ b/OrbitCore/FunctionUtils.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_CORE_FUNCTION_UTILS_H_
+#define ORBIT_CORE_FUNCTION_UTILS_H_
+
+#include <cstdint>
+#include <string>
+
+#include "OrbitFunction.h"
+#include "ScopeTimer.h"
+
+namespace function {
+
+inline const std::string& GetDisplayName(const Function& func) {
+  return func.pretty_name().empty() ? func.name() : func.pretty_name();
+}
+
+std::string GetLoadedModuleName(const Function& func);
+uint64_t GetHash(const Function& func);
+
+// Calculates and returns the absolute address of the function.
+uint64_t Offset(const Function& func);
+inline uint64_t GetAbsoluteAddress(const Function& func) {
+  return func.address() + func.module_base_address() - func.load_bias();
+}
+
+bool IsOrbitFunc(const Function& func);
+
+void Select(Function* func);
+void UnSelect(Function* func);
+bool IsSelected(const Function& func);
+
+void Print(const Function& func);
+
+bool SetOrbitTypeFromName(Function* func);
+void UpdateStats(Function* func, const Timer& timer);
+
+}  // namespace function
+
+#endif  // ORBIT_CORE_FUNCTION_UTILS_H_

--- a/OrbitCore/OrbitFunction.cpp
+++ b/OrbitCore/OrbitFunction.cpp
@@ -4,23 +4,8 @@
 
 #include "OrbitFunction.h"
 
-#include <OrbitBase/Logging.h>
-#include <absl/container/flat_hash_set.h>
-#include <absl/strings/match.h>
-
-#include <map>
-
-#include "Capture.h"
-#include "Core.h"
-#include "Log.h"
-#include "OrbitModule.h"
-#include "OrbitProcess.h"
-#include "Params.h"
-#include "Pdb.h"
-#include "PrintVar.h"
-#include "SamplingProfiler.h"
+#include "FunctionUtils.h"
 #include "Serialization.h"
-#include "Utils.h"
 
 Function::Function(std::string_view name, std::string_view pretty_name,
                    uint64_t address, uint64_t load_bias, uint64_t size,
@@ -33,23 +18,7 @@ Function::Function(std::string_view name, std::string_view pretty_name,
       file_(file),
       line_(line) {
   ResetStats();
-  SetOrbitTypeFromName();
-}
-
-void Function::Select() {
-  LOG("Selected %s at 0x%" PRIx64 " (address_=0x%" PRIx64
-      ", load_bias_= 0x%" PRIx64 ", base_address=0x%" PRIx64 ")",
-      pretty_name_, GetVirtualAddress(), address_, load_bias_,
-      module_base_address_);
-  Capture::GSelectedFunctionsMap[GetVirtualAddress()] = this;
-}
-
-void Function::UnSelect() {
-  Capture::GSelectedFunctionsMap.erase(GetVirtualAddress());
-}
-
-bool Function::IsSelected() const {
-  return Capture::GSelectedFunctionsMap.count(GetVirtualAddress()) > 0;
+  function::SetOrbitTypeFromName(this);
 }
 
 void Function::ResetStats() {
@@ -58,46 +27,6 @@ void Function::ResetStats() {
   } else {
     stats_->Reset();
   }
-}
-
-void Function::UpdateStats(const Timer& timer) {
-  if (stats_ != nullptr) {
-    stats_->Update(timer);
-  }
-}
-
-const absl::flat_hash_map<const char*, Function::OrbitType>&
-Function::GetFunctionNameToOrbitTypeMap() {
-  static absl::flat_hash_map<const char*, OrbitType> function_name_to_type_map{
-      {"Start(", ORBIT_TIMER_START},
-      {"Stop(", ORBIT_TIMER_STOP},
-      {"StartAsync(", ORBIT_TIMER_START_ASYNC},
-      {"StopAsync(", ORBIT_TIMER_STOP_ASYNC},
-      {"TrackInt(", ORBIT_TRACK_INT},
-      {"TrackInt64(", ORBIT_TRACK_INT_64},
-      {"TrackUint(", ORBIT_TRACK_UINT},
-      {"TrackUint64(", ORBIT_TRACK_UINT_64},
-      {"TrackFloat(", ORBIT_TRACK_FLOAT},
-      {"TrackDouble(", ORBIT_TRACK_DOUBLE},
-      {"TrackFloatAsInt(", ORBIT_TRACK_FLOAT_AS_INT},
-      {"TrackDoubleAsInt64(", ORBIT_TRACK_DOUBLE_AS_INT_64},
-  };
-  return function_name_to_type_map;
-}
-
-// Detect Orbit API functions by looking for special function names part of the
-// orbit_api namespace. On a match, set the corresponding function type.
-bool Function::SetOrbitTypeFromName() {
-  const std::string& name = PrettyName();
-  if (absl::StartsWith(name, "orbit_api::")) {
-    for (auto& pair : GetFunctionNameToOrbitTypeMap()) {
-      if (absl::StrContains(name, pair.first)) {
-        SetOrbitType(pair.second);
-        return true;
-      }
-    }
-  }
-  return false;
 }
 
 ORBIT_SERIALIZE(Function, 5) {
@@ -111,11 +40,4 @@ ORBIT_SERIALIZE(Function, 5) {
   ORBIT_NVP_VAL(4, file_);
   ORBIT_NVP_VAL(4, line_);
   ORBIT_NVP_VAL(4, stats_);
-}
-
-void Function::Print() {
-  ORBIT_VIZV(address_);
-  ORBIT_VIZV(file_);
-  ORBIT_VIZV(line_);
-  ORBIT_VIZV(IsSelected());
 }

--- a/OrbitCore/OrbitFunction.cpp
+++ b/OrbitCore/OrbitFunction.cpp
@@ -9,9 +9,13 @@
 
 Function::Function(std::string_view name, std::string_view pretty_name,
                    uint64_t address, uint64_t load_bias, uint64_t size,
-                   std::string_view file, uint32_t line)
+                   std::string_view file, uint32_t line,
+                   std::string_view loaded_module_path,
+                   uint64_t module_base_address)
     : name_(name),
       pretty_name_(pretty_name),
+      loaded_module_path_(loaded_module_path),
+      module_base_address_(module_base_address),
       address_(address),
       load_bias_(load_bias),
       size_(size),

--- a/OrbitCore/OrbitFunction.cpp
+++ b/OrbitCore/OrbitFunction.cpp
@@ -22,7 +22,7 @@ Function::Function(std::string_view name, std::string_view pretty_name,
       file_(file),
       line_(line) {
   ResetStats();
-  function::SetOrbitTypeFromName(this);
+  FunctionUtils::SetOrbitTypeFromName(this);
 }
 
 void Function::ResetStats() {

--- a/OrbitCore/OrbitFunction.h
+++ b/OrbitCore/OrbitFunction.h
@@ -33,11 +33,12 @@ class Function {
     NUM_TYPES
   };
 
-  Function() : Function{"", "", 0, 0, 0, "", 0} {}
+  Function() : Function{"", "", 0, 0, 0, "", 0, "", 0} {}
 
   Function(std::string_view name, std::string_view pretty_name,
            uint64_t address, uint64_t load_bias, uint64_t size,
-           std::string_view file, uint32_t line);
+           std::string_view file, uint32_t line,
+           std::string_view loaded_module_path, uint64_t module_base_address);
 
   const std::string& name() const { return name_; }
   const std::string& pretty_name() const { return pretty_name_; }

--- a/OrbitCore/OrbitFunction.h
+++ b/OrbitCore/OrbitFunction.h
@@ -6,17 +6,9 @@
 
 #include <string>
 #include <string_view>
-#include <vector>
 
-#include "BaseTypes.h"
 #include "FunctionStats.h"
-#include "OrbitDbgHelp.h"
-#include "Path.h"
 #include "SerializationMacros.h"
-#include "Utils.h"
-#include "absl/container/flat_hash_map.h"
-
-class Pdb;
 
 class Function {
  public:
@@ -47,52 +39,33 @@ class Function {
            uint64_t address, uint64_t load_bias, uint64_t size,
            std::string_view file, uint32_t line);
 
-  const std::string& Name() const { return name_; }
-  const std::string& PrettyName() const {
-    return pretty_name_.empty() ? name_ : pretty_name_;
+  const std::string& name() const { return name_; }
+  const std::string& pretty_name() const { return pretty_name_; }
+  const std::string& loaded_module_path() const { return loaded_module_path_; }
+  void set_loaded_module_path(const std::string& loaded_module_path) {
+    loaded_module_path_ = loaded_module_path;
   }
-  std::string Lower() { return ToLower(PrettyName()); }
-  const std::string& GetLoadedModulePath() const { return loaded_module_path_; }
-  std::string GetLoadedModuleName() const {
-    return Path::GetFileName(loaded_module_path_);
-  }
-  void SetModulePathAndAddress(std::string_view module_path,
-                               uint64_t module_adddress) {
-    loaded_module_path_ = module_path;
-    module_base_address_ = module_adddress;
-  }
-  uint64_t Size() const { return size_; }
-  const std::string& File() const { return file_; }
-  uint32_t Line() const { return line_; }
-
-  uint64_t Hash() const { return StringHash(pretty_name_); }
-
-  // Calculates and returns the absolute address of the function.
-  uint64_t Address() const { return address_; }
-  uint64_t Offset() const { return address_ - load_bias_; }
-  uint64_t GetVirtualAddress() const {
-    return address_ + module_base_address_ - load_bias_;
+  uint64_t module_base_address() const { return module_base_address_; }
+  void set_module_base_address(uint64_t module_base_address) {
+    module_base_address_ = module_base_address;
   }
 
-  void SetOrbitType(OrbitType type) { type_ = type; }
-  bool SetOrbitTypeFromName();
-  bool IsOrbitFunc() const { return type_ != OrbitType::NONE; }
+  uint64_t size() const { return size_; }
+  const std::string& file() const { return file_; }
+  void set_file(std::string file) { file_ = std::move(file); }
+  uint32_t line() const { return line_; }
+  void set_line(uint32_t line) { line_ = line; }
+  uint64_t address() const { return address_; }
+  uint64_t load_bias() const { return load_bias_; }
+  OrbitType orbit_type() const { return type_; }
+  void set_orbit_type(OrbitType type) { type_ = type; }
+  std::shared_ptr<FunctionStats> stats() const { return stats_; }
 
-  const FunctionStats& GetStats() const { return *stats_; }
-  void UpdateStats(const Timer& timer);
   void ResetStats();
-
-  void Select();
-  void UnSelect();
-  bool IsSelected() const;
-
-  void Print();
 
   ORBIT_SERIALIZABLE;
 
  private:
-  static const absl::flat_hash_map<const char*, OrbitType>&
-  GetFunctionNameToOrbitTypeMap();
   std::string name_;
   std::string pretty_name_;
   std::string loaded_module_path_;

--- a/OrbitCore/OrbitModule.cpp
+++ b/OrbitCore/OrbitModule.cpp
@@ -53,7 +53,8 @@ void Module::LoadSymbols(const ModuleSymbols& module_symbols) {
     std::shared_ptr<Function> function = std::make_shared<Function>(
         symbol_info.name(), symbol_info.demangled_name(), symbol_info.address(),
         module_symbols.load_bias(), symbol_info.size(),
-        symbol_info.source_file(), symbol_info.source_line());
+        symbol_info.source_file(), symbol_info.source_line(), m_FullName,
+        m_AddressStart);
     m_Pdb->AddFunction(function);
   }
 

--- a/OrbitCore/OrbitModuleTest.cpp
+++ b/OrbitCore/OrbitModuleTest.cpp
@@ -68,21 +68,21 @@ TEST(OrbitModule, LoadFunctions) {
   EXPECT_EQ(function->pretty_name(), "deregister_tm_clones");
   EXPECT_EQ(function->address(), 0x1080);
   EXPECT_EQ(function->size(), 0);
-  EXPECT_EQ(function::GetLoadedModuleName(*function), executable_name);
+  EXPECT_EQ(FunctionUtils::GetLoadedModuleName(*function), executable_name);
 
   function = functions[4].get();
   EXPECT_EQ(function->name(), "_init");
   EXPECT_EQ(function->pretty_name(), "_init");
   EXPECT_EQ(function->address(), 0x1000);
   EXPECT_EQ(function->size(), 0);
-  EXPECT_EQ(function::GetLoadedModuleName(*function), executable_name);
+  EXPECT_EQ(FunctionUtils::GetLoadedModuleName(*function), executable_name);
 
   function = functions[9].get();
   EXPECT_EQ(function->name(), "main");
   EXPECT_EQ(function->pretty_name(), "main");
   EXPECT_EQ(function->address(), 0x1135);
   EXPECT_EQ(function->size(), 35);
-  EXPECT_EQ(function::GetLoadedModuleName(*function), executable_name);
+  EXPECT_EQ(FunctionUtils::GetLoadedModuleName(*function), executable_name);
 }
 
 TEST(OrbitModule, GetFunctionFromExactAddress) {

--- a/OrbitCore/OrbitModuleTest.cpp
+++ b/OrbitCore/OrbitModuleTest.cpp
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "ElfUtils/ElfFile.h"
+#include "FunctionUtils.h"
 #include "OrbitModule.h"
 #include "Path.h"
 #include "Pdb.h"
@@ -63,25 +64,25 @@ TEST(OrbitModule, LoadFunctions) {
   EXPECT_EQ(functions.size(), 10);
   const Function* function = functions[0].get();
 
-  EXPECT_EQ(function->Name(), "deregister_tm_clones");
-  EXPECT_EQ(function->PrettyName(), "deregister_tm_clones");
-  EXPECT_EQ(function->Address(), 0x1080);
-  EXPECT_EQ(function->Size(), 0);
-  EXPECT_EQ(function->GetLoadedModuleName(), executable_name);
+  EXPECT_EQ(function->name(), "deregister_tm_clones");
+  EXPECT_EQ(function->pretty_name(), "deregister_tm_clones");
+  EXPECT_EQ(function->address(), 0x1080);
+  EXPECT_EQ(function->size(), 0);
+  EXPECT_EQ(function::GetLoadedModuleName(*function), executable_name);
 
   function = functions[4].get();
-  EXPECT_EQ(function->Name(), "_init");
-  EXPECT_EQ(function->PrettyName(), "_init");
-  EXPECT_EQ(function->Address(), 0x1000);
-  EXPECT_EQ(function->Size(), 0);
-  EXPECT_EQ(function->GetLoadedModuleName(), executable_name);
+  EXPECT_EQ(function->name(), "_init");
+  EXPECT_EQ(function->pretty_name(), "_init");
+  EXPECT_EQ(function->address(), 0x1000);
+  EXPECT_EQ(function->size(), 0);
+  EXPECT_EQ(function::GetLoadedModuleName(*function), executable_name);
 
   function = functions[9].get();
-  EXPECT_EQ(function->Name(), "main");
-  EXPECT_EQ(function->PrettyName(), "main");
-  EXPECT_EQ(function->Address(), 0x1135);
-  EXPECT_EQ(function->Size(), 35);
-  EXPECT_EQ(function->GetLoadedModuleName(), executable_name);
+  EXPECT_EQ(function->name(), "main");
+  EXPECT_EQ(function->pretty_name(), "main");
+  EXPECT_EQ(function->address(), 0x1135);
+  EXPECT_EQ(function->size(), 35);
+  EXPECT_EQ(function::GetLoadedModuleName(*function), executable_name);
 }
 
 TEST(OrbitModule, GetFunctionFromExactAddress) {
@@ -109,7 +110,7 @@ TEST(OrbitModule, GetFunctionFromExactAddress) {
   constexpr const uint64_t __free_pc_addr = 0x41b854;
   const Function* function = pdb.GetFunctionFromExactAddress(__free_start_addr);
   ASSERT_NE(function, nullptr);
-  EXPECT_EQ(function->Name(), "__free");
+  EXPECT_EQ(function->name(), "__free");
 
   EXPECT_EQ(pdb.GetFunctionFromExactAddress(__free_pc_addr), nullptr);
 }
@@ -142,11 +143,11 @@ TEST(OrbitModule, GetFunctionFromProgramCounter) {
   const Function* function =
       pdb.GetFunctionFromProgramCounter(__free_start_addr);
   ASSERT_NE(function, nullptr);
-  EXPECT_EQ(function->Name(), "__free");
+  EXPECT_EQ(function->name(), "__free");
 
   function = pdb.GetFunctionFromProgramCounter(__free_pc_addr);
   ASSERT_NE(function, nullptr);
-  EXPECT_EQ(function->Name(), "__free");
+  EXPECT_EQ(function->name(), "__free");
 }
 
 TEST(SymbolHelper, LoadSymbols) {
@@ -176,10 +177,10 @@ TEST(SymbolHelper, LoadSymbols) {
   EXPECT_EQ(pdb.GetLoadBias(), 0x400);
   ASSERT_EQ(pdb.GetFunctions().size(), 1);
   auto resulting_function = pdb.GetFunctions()[0];
-  EXPECT_EQ(resulting_function->Name(), "function name");
-  EXPECT_EQ(resulting_function->PrettyName(), "pretty name");
-  EXPECT_EQ(resulting_function->Address(), 15);
-  EXPECT_EQ(resulting_function->Size(), 12);
-  EXPECT_EQ(resulting_function->File(), "file name");
-  EXPECT_EQ(resulting_function->Line(), 70);
+  EXPECT_EQ(resulting_function->name(), "function name");
+  EXPECT_EQ(resulting_function->pretty_name(), "pretty name");
+  EXPECT_EQ(resulting_function->address(), 15);
+  EXPECT_EQ(resulting_function->size(), 12);
+  EXPECT_EQ(resulting_function->file(), "file name");
+  EXPECT_EQ(resulting_function->line(), 70);
 }

--- a/OrbitCore/Pdb.cpp
+++ b/OrbitCore/Pdb.cpp
@@ -20,15 +20,8 @@ Pdb::Pdb(uint64_t module_address, uint64_t load_bias, std::string file_name,
 }
 
 //-----------------------------------------------------------------------------
-void Pdb::SetModulePathAndAddress(Function* func) {
-  func->set_loaded_module_path(GetLoadedModuleName());
-  func->set_module_base_address(GetHModule());
-}
-
-//-----------------------------------------------------------------------------
 void Pdb::AddFunction(const std::shared_ptr<Function>& function) {
   functions_.push_back(function);
-  SetModulePathAndAddress(functions_.back().get());
 }
 
 //-----------------------------------------------------------------------------
@@ -40,7 +33,6 @@ void Pdb::ProcessData() {
   ScopeLock lock(process->GetDataMutex());
 
   for (auto& func : functions_) {
-    SetModulePathAndAddress(func.get());
     process->AddFunction(func);
   }
 

--- a/OrbitCore/Pdb.cpp
+++ b/OrbitCore/Pdb.cpp
@@ -58,7 +58,7 @@ void Pdb::PopulateStringFunctionMap() {
   {
     // SCOPE_TIMER_LOG("Map inserts");
     for (auto& function : functions_) {
-      m_StringFunctionMap[function::GetHash(*function)] = function.get();
+      m_StringFunctionMap[FunctionUtils::GetHash(*function)] = function.get();
     }
   }
 }
@@ -100,7 +100,7 @@ void Pdb::ApplyPreset(const Preset& preset) {
       auto fit = m_StringFunctionMap.find(hash);
       if (fit != m_StringFunctionMap.end()) {
         Function* function = fit->second;
-        function::Select(function);
+        FunctionUtils::Select(function);
       }
     }
   }

--- a/OrbitCore/Pdb.h
+++ b/OrbitCore/Pdb.h
@@ -48,6 +48,8 @@ class Pdb {
   std::vector<std::shared_ptr<Function>> functions_;
   std::map<uint64_t, Function*> m_FunctionMap;
   std::unordered_map<unsigned long long, Function*> m_StringFunctionMap;
+
+  void SetModulePathAndAddress(Function* func);
 };
 
 #endif  // ORBIT_CORE_PDB_H_

--- a/OrbitCore/SamplingProfiler.cpp
+++ b/OrbitCore/SamplingProfiler.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "Capture.h"
+#include "FunctionUtils.h"
 #include "Injection.h"
 #include "Log.h"
 #include "OrbitModule.h"
@@ -339,8 +340,8 @@ void SamplingProfiler::UpdateAddressInfo(uint64_t address) {
   uint64_t function_address;
   std::string function_name = "???";
   if (function != nullptr) {
-    function_address = function->GetVirtualAddress();
-    function_name = function->PrettyName();
+    function_address = function::GetAbsoluteAddress(*function);
+    function_name = function::GetDisplayName(*function);
   } else if (address_info != nullptr) {
     function_address = address - address_info->offset_in_function;
     if (!address_info->function_name.empty()) {
@@ -351,7 +352,7 @@ void SamplingProfiler::UpdateAddressInfo(uint64_t address) {
   }
 
   if (function != nullptr && address_info != nullptr) {
-    address_info->function_name = function->PrettyName();
+    address_info->function_name = function::GetDisplayName(*function);
   }
 
   m_ExactAddressToFunctionAddress[address] = function_address;

--- a/OrbitCore/SamplingProfiler.cpp
+++ b/OrbitCore/SamplingProfiler.cpp
@@ -340,8 +340,8 @@ void SamplingProfiler::UpdateAddressInfo(uint64_t address) {
   uint64_t function_address;
   std::string function_name = "???";
   if (function != nullptr) {
-    function_address = function::GetAbsoluteAddress(*function);
-    function_name = function::GetDisplayName(*function);
+    function_address = FunctionUtils::GetAbsoluteAddress(*function);
+    function_name = FunctionUtils::GetDisplayName(*function);
   } else if (address_info != nullptr) {
     function_address = address - address_info->offset_in_function;
     if (!address_info->function_name.empty()) {
@@ -352,7 +352,7 @@ void SamplingProfiler::UpdateAddressInfo(uint64_t address) {
   }
 
   if (function != nullptr && address_info != nullptr) {
-    address_info->function_name = function::GetDisplayName(*function);
+    address_info->function_name = FunctionUtils::GetDisplayName(*function);
   }
 
   m_ExactAddressToFunctionAddress[address] = function_address;

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -19,9 +19,6 @@ class Process;
 struct SampledFunction {
   SampledFunction() = default;
 
-  bool GetSelected() {
-    return Capture::GSelectedFunctionsMap.count(m_Address) > 0;
-  }
   std::string m_Name;
   std::string m_Module;
   std::string m_File;

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -22,6 +22,7 @@
 #include "CaptureWindow.h"
 #include "Disassembler.h"
 #include "EventTracer.h"
+#include "FunctionUtils.h"
 #include "FunctionsDataView.h"
 #include "GlCanvas.h"
 #include "ImGuiOrbit.h"
@@ -315,7 +316,7 @@ void OrbitApp::RefreshCaptureView() {
 void OrbitApp::Disassemble(int32_t pid, const Function& function) {
   thread_pool_->Schedule([this, pid, function] {
     auto result = process_manager_->LoadProcessMemory(
-        pid, function.GetVirtualAddress(), function.Size());
+        pid, function::GetAbsoluteAddress(function), function.size());
     if (!result.has_value()) {
       SendErrorToUi("Error reading memory",
                     absl::StrFormat("Could not read process memory: %s.",
@@ -325,9 +326,10 @@ void OrbitApp::Disassemble(int32_t pid, const Function& function) {
 
     const std::string& memory = result.value();
     Disassembler disasm;
-    disasm.LOGF(absl::StrFormat("asm: /* %s */\n", function.PrettyName()));
+    disasm.LOGF(
+        absl::StrFormat("asm: /* %s */\n", function::GetDisplayName(function)));
     disasm.Disassemble(reinterpret_cast<const uint8_t*>(memory.data()),
-                       memory.size(), function.GetVirtualAddress(),
+                       memory.size(), function::GetAbsoluteAddress(function),
                        Capture::GTargetProcess->GetIs64Bit());
     if (!sampling_report_ || !sampling_report_->GetProfiler()) {
       SendDisassemblyToUi(disasm.GetResult());
@@ -336,7 +338,7 @@ void OrbitApp::Disassemble(int32_t pid, const Function& function) {
     std::shared_ptr<SamplingProfiler> profiler =
         sampling_report_->GetProfiler();
     unsigned int count_of_function =
-        profiler->GetCountOfFunction(function.GetVirtualAddress());
+        profiler->GetCountOfFunction(function::GetAbsoluteAddress(function));
     if (count_of_function == 0) {
       SendDisassemblyToUi(disasm.GetResult());
       return;

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -316,7 +316,7 @@ void OrbitApp::RefreshCaptureView() {
 void OrbitApp::Disassemble(int32_t pid, const Function& function) {
   thread_pool_->Schedule([this, pid, function] {
     auto result = process_manager_->LoadProcessMemory(
-        pid, function::GetAbsoluteAddress(function), function.size());
+        pid, FunctionUtils::GetAbsoluteAddress(function), function.size());
     if (!result.has_value()) {
       SendErrorToUi("Error reading memory",
                     absl::StrFormat("Could not read process memory: %s.",
@@ -327,9 +327,9 @@ void OrbitApp::Disassemble(int32_t pid, const Function& function) {
     const std::string& memory = result.value();
     Disassembler disasm;
     disasm.LOGF(
-        absl::StrFormat("asm: /* %s */\n", function::GetDisplayName(function)));
+        absl::StrFormat("asm: /* %s */\n", FunctionUtils::GetDisplayName(function)));
     disasm.Disassemble(reinterpret_cast<const uint8_t*>(memory.data()),
-                       memory.size(), function::GetAbsoluteAddress(function),
+                       memory.size(), FunctionUtils::GetAbsoluteAddress(function),
                        Capture::GTargetProcess->GetIs64Bit());
     if (!sampling_report_ || !sampling_report_->GetProfiler()) {
       SendDisassemblyToUi(disasm.GetResult());
@@ -338,7 +338,7 @@ void OrbitApp::Disassemble(int32_t pid, const Function& function) {
     std::shared_ptr<SamplingProfiler> profiler =
         sampling_report_->GetProfiler();
     unsigned int count_of_function =
-        profiler->GetCountOfFunction(function::GetAbsoluteAddress(function));
+        profiler->GetCountOfFunction(FunctionUtils::GetAbsoluteAddress(function));
     if (count_of_function == 0) {
       SendDisassemblyToUi(disasm.GetResult());
       return;

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -49,12 +49,12 @@ std::string CallStackDataView::GetValue(int a_Row, int a_Column) {
 
   switch (a_Column) {
     case COLUMN_SELECTED:
-      return (function != nullptr && function::IsSelected(*function)) ? "X"
+      return (function != nullptr && FunctionUtils::IsSelected(*function)) ? "X"
                                                                       : "-";
     case COLUMN_INDEX:
       return absl::StrFormat("%d", a_Row);
     case COLUMN_NAME:
-      return function != nullptr ? function::GetDisplayName(*function)
+      return function != nullptr ? FunctionUtils::GetDisplayName(*function)
                                  : frame.fallback_name;
     case COLUMN_SIZE:
       return function != nullptr ? absl::StrFormat("%lu", function->size()) : "";
@@ -64,8 +64,8 @@ std::string CallStackDataView::GetValue(int a_Row, int a_Column) {
       return function != nullptr ? absl::StrFormat("%d", function->line()) : "";
     case COLUMN_MODULE:
       if (function != nullptr &&
-          !function::GetLoadedModuleName(*function).empty()) {
-        return function::GetLoadedModuleName(*function);
+          !FunctionUtils::GetLoadedModuleName(*function).empty()) {
+        return FunctionUtils::GetLoadedModuleName(*function);
       }
       if (module != nullptr) {
         return module->m_Name;
@@ -98,8 +98,8 @@ std::vector<std::string> CallStackDataView::GetContextMenu(
     Module* module = frame.module.get();
 
     if (frame.function != nullptr) {
-      enable_select |= !function::IsSelected(*function);
-      enable_unselect |= function::IsSelected(*function);
+      enable_select |= !FunctionUtils::IsSelected(*function);
+      enable_unselect |= FunctionUtils::IsSelected(*function);
       enable_disassembly = true;
     } else if (module != nullptr && module->IsLoadable() &&
                !module->IsLoaded()) {
@@ -133,14 +133,14 @@ void CallStackDataView::OnContextMenu(const std::string& a_Action,
     for (int i : a_ItemIndices) {
       CallStackDataViewFrame frame = GetFrameFromRow(i);
       Function* function = frame.function;
-      function::Select(function);
+      FunctionUtils::Select(function);
     }
 
   } else if (a_Action == MENU_ACTION_UNSELECT) {
     for (int i : a_ItemIndices) {
       CallStackDataViewFrame frame = GetFrameFromRow(i);
       Function* function = frame.function;
-      function::UnSelect(function);
+      FunctionUtils::UnSelect(function);
     }
 
   } else if (a_Action == MENU_ACTION_DISASSEMBLY) {
@@ -165,7 +165,7 @@ void CallStackDataView::DoFilter() {
     CallStackDataViewFrame frame = GetFrameFromIndex(i);
     Function* function = frame.function;
     std::string name =
-        ToLower(function != nullptr ? function::GetDisplayName(*function)
+        ToLower(function != nullptr ? FunctionUtils::GetDisplayName(*function)
                                     : frame.fallback_name);
     bool match = true;
 

--- a/OrbitGl/CaptureClient.cpp
+++ b/OrbitGl/CaptureClient.cpp
@@ -42,9 +42,9 @@ void CaptureClient::Capture(
     CaptureOptions::InstrumentedFunction* instrumented_function =
         capture_options->add_instrumented_functions();
     instrumented_function->set_file_path(function->loaded_module_path());
-    instrumented_function->set_file_offset(function::Offset(*function));
+    instrumented_function->set_file_offset(FunctionUtils::Offset(*function));
     instrumented_function->set_absolute_address(
-        function::GetAbsoluteAddress(*function));
+        FunctionUtils::GetAbsoluteAddress(*function));
   }
 
   if (!reader_writer_->Write(request)) {

--- a/OrbitGl/CaptureClient.cpp
+++ b/OrbitGl/CaptureClient.cpp
@@ -4,7 +4,8 @@
 
 #include "CaptureClient.h"
 
-#include <OrbitBase/Logging.h>
+#include "FunctionUtils.h"
+#include "OrbitBase/Logging.h"
 
 #include "absl/flags/flag.h"
 
@@ -40,9 +41,10 @@ void CaptureClient::Capture(
   for (const std::shared_ptr<Function>& function : selected_functions) {
     CaptureOptions::InstrumentedFunction* instrumented_function =
         capture_options->add_instrumented_functions();
-    instrumented_function->set_file_path(function->GetLoadedModulePath());
-    instrumented_function->set_file_offset(function->Offset());
-    instrumented_function->set_absolute_address(function->GetVirtualAddress());
+    instrumented_function->set_file_path(function->loaded_module_path());
+    instrumented_function->set_file_offset(function::Offset(*function));
+    instrumented_function->set_absolute_address(
+        function::GetAbsoluteAddress(*function));
   }
 
   if (!reader_writer_->Write(request)) {

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -12,6 +12,7 @@
 #include "Capture.h"
 #include "Core.h"
 #include "EventTracer.h"
+#include "FunctionUtils.h"
 #include "OrbitModule.h"
 #include "OrbitProcess.h"
 #include "Pdb.h"
@@ -184,7 +185,7 @@ ErrorMessageOr<void> CaptureSerializer::Load(std::istream& stream) {
     std::shared_ptr<Function> function_ptr =
         std::make_shared<Function>(function);
     Capture::GSelectedFunctions.push_back(function_ptr);
-    Capture::GSelectedFunctionsMap[function_ptr->GetVirtualAddress()] =
+    Capture::GSelectedFunctionsMap[function::GetAbsoluteAddress(*function_ptr)] =
         function_ptr.get();
   }
   Capture::GVisibleFunctionsMap = Capture::GSelectedFunctionsMap;

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -185,7 +185,7 @@ ErrorMessageOr<void> CaptureSerializer::Load(std::istream& stream) {
     std::shared_ptr<Function> function_ptr =
         std::make_shared<Function>(function);
     Capture::GSelectedFunctions.push_back(function_ptr);
-    Capture::GSelectedFunctionsMap[function::GetAbsoluteAddress(*function_ptr)] =
+    Capture::GSelectedFunctionsMap[FunctionUtils::GetAbsoluteAddress(*function_ptr)] =
         function_ptr.get();
   }
   Capture::GVisibleFunctionsMap = Capture::GSelectedFunctionsMap;

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -259,7 +259,7 @@ void CaptureWindow::Hover(int a_X, int a_Y) {
       Function* func =
           Capture::GSelectedFunctionsMap[textBox->GetTimer().m_FunctionAddress];
       m_ToolTip =
-          absl::StrFormat("%s %s", func ? function::GetDisplayName(*func) : "",
+          absl::StrFormat("%s %s", func ? FunctionUtils::GetDisplayName(*func) : "",
                           textBox->GetText());
       GOrbitApp->SendTooltipToUi(m_ToolTip);
       NeedsRedraw();

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -7,6 +7,7 @@
 #include "App.h"
 #include "Capture.h"
 #include "EventTracer.h"
+#include "FunctionUtils.h"
 #include "GlUtils.h"
 #include "absl/strings/str_format.h"
 
@@ -257,8 +258,9 @@ void CaptureWindow::Hover(int a_X, int a_Y) {
     if (!textBox->GetTimer().IsType(Timer::CORE_ACTIVITY)) {
       Function* func =
           Capture::GSelectedFunctionsMap[textBox->GetTimer().m_FunctionAddress];
-      m_ToolTip = absl::StrFormat("%s %s", func ? func->PrettyName() : "",
-                                  textBox->GetText());
+      m_ToolTip =
+          absl::StrFormat("%s %s", func ? function::GetDisplayName(*func) : "",
+                          textBox->GetText());
       GOrbitApp->SendTooltipToUi(m_ToolTip);
       NeedsRedraw();
     }

--- a/OrbitGl/FramePointerValidatorClient.cpp
+++ b/OrbitGl/FramePointerValidatorClient.cpp
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "App.h"
+#include "FunctionUtils.h"
 #include "Pdb.h"
 #include "grpcpp/grpcpp.h"
 #include "services.grpc.pb.h"
@@ -38,8 +39,8 @@ void FramePointerValidatorClient::AnalyzeModules(
     request.set_module_path(module->m_FullName);
     for (const auto& function : module->m_Pdb->GetFunctions()) {
       CodeBlock* function_info = request.add_functions();
-      function_info->set_offset(function->Offset());
-      function_info->set_size(function->Size());
+      function_info->set_offset(function::Offset(*function));
+      function_info->set_size(function->size());
     }
     grpc::ClientContext context;
     std::chrono::time_point deadline =

--- a/OrbitGl/FramePointerValidatorClient.cpp
+++ b/OrbitGl/FramePointerValidatorClient.cpp
@@ -39,7 +39,7 @@ void FramePointerValidatorClient::AnalyzeModules(
     request.set_module_path(module->m_FullName);
     for (const auto& function : module->m_Pdb->GetFunctions()) {
       CodeBlock* function_info = request.add_functions();
-      function_info->set_offset(function::Offset(*function));
+      function_info->set_offset(FunctionUtils::Offset(*function));
       function_info->set_size(function->size());
     }
     grpc::ClientContext context;

--- a/OrbitGl/FunctionsDataView.cpp
+++ b/OrbitGl/FunctionsDataView.cpp
@@ -47,11 +47,11 @@ std::string FunctionsDataView::GetValue(int a_Row, int a_Column) {
 
   switch (a_Column) {
     case COLUMN_SELECTED:
-      return function::IsSelected(function) ? "X" : "-";
+      return FunctionUtils::IsSelected(function) ? "X" : "-";
     case COLUMN_INDEX:
       return absl::StrFormat("%d", a_Row);
     case COLUMN_NAME:
-      return function::GetDisplayName(function);
+      return FunctionUtils::GetDisplayName(function);
     case COLUMN_SIZE:
       return absl::StrFormat("%lu", function.size());
     case COLUMN_FILE:
@@ -59,9 +59,9 @@ std::string FunctionsDataView::GetValue(int a_Row, int a_Column) {
     case COLUMN_LINE:
       return absl::StrFormat("%i", function.line());
     case COLUMN_MODULE:
-      return function::GetLoadedModuleName(function);
+      return FunctionUtils::GetLoadedModuleName(function);
     case COLUMN_ADDRESS:
-      return absl::StrFormat("0x%llx", function::GetAbsoluteAddress(function));
+      return absl::StrFormat("0x%llx", FunctionUtils::GetAbsoluteAddress(function));
     default:
       return "";
   }
@@ -98,10 +98,10 @@ void FunctionsDataView::DoSort() {
 
   switch (m_SortingColumn) {
     case COLUMN_SELECTED:
-      sorter = ORBIT_CUSTOM_FUNC_SORT(function::IsSelected);
+      sorter = ORBIT_CUSTOM_FUNC_SORT(FunctionUtils::IsSelected);
       break;
     case COLUMN_NAME:
-      sorter = ORBIT_CUSTOM_FUNC_SORT(function::GetDisplayName);
+      sorter = ORBIT_CUSTOM_FUNC_SORT(FunctionUtils::GetDisplayName);
       break;
     case COLUMN_SIZE:
       sorter = ORBIT_FUNC_SORT(size());
@@ -113,7 +113,7 @@ void FunctionsDataView::DoSort() {
       sorter = ORBIT_FUNC_SORT(line());
       break;
     case COLUMN_MODULE:
-      sorter = ORBIT_CUSTOM_FUNC_SORT(function::GetLoadedModuleName);
+      sorter = ORBIT_CUSTOM_FUNC_SORT(FunctionUtils::GetLoadedModuleName);
       break;
     case COLUMN_ADDRESS:
       sorter = ORBIT_FUNC_SORT(address());
@@ -140,8 +140,8 @@ std::vector<std::string> FunctionsDataView::GetContextMenu(
   bool enable_unselect = false;
   for (int index : a_SelectedIndices) {
     const Function& function = GetFunction(index);
-    enable_select |= !function::IsSelected(function);
-    enable_unselect |= function::IsSelected(function);
+    enable_select |= !FunctionUtils::IsSelected(function);
+    enable_unselect |= FunctionUtils::IsSelected(function);
   }
 
   std::vector<std::string> menu;
@@ -158,11 +158,11 @@ void FunctionsDataView::OnContextMenu(const std::string& a_Action,
                                       const std::vector<int>& a_ItemIndices) {
   if (a_Action == MENU_ACTION_SELECT) {
     for (int i : a_ItemIndices) {
-      function::Select(&GetFunction(i));
+      FunctionUtils::Select(&GetFunction(i));
     }
   } else if (a_Action == MENU_ACTION_UNSELECT) {
     for (int i : a_ItemIndices) {
-      function::UnSelect(&GetFunction(i));
+      FunctionUtils::UnSelect(&GetFunction(i));
     }
   } else if (a_Action == MENU_ACTION_DISASSEMBLY) {
     int32_t pid = Capture::GTargetProcess->GetID();
@@ -194,8 +194,8 @@ void FunctionsDataView::DoFilter() {
       Capture::GTargetProcess->GetFunctions();
   for (size_t i = 0; i < functions.size(); ++i) {
     auto& function = functions[i];
-    std::string name = ToLower(function::GetDisplayName(*function)) +
-                       function::GetLoadedModuleName(*function);
+    std::string name = ToLower(FunctionUtils::GetDisplayName(*function)) +
+                       FunctionUtils::GetLoadedModuleName(*function);
 
     bool match = true;
 
@@ -233,7 +233,7 @@ void FunctionsDataView::ParallelFilter() {
       [&](int32_t a_BlockIndex, int32_t a_ElementIndex) {
         std::vector<int>& result = indicesArray[a_BlockIndex];
         const std::string& name =
-            ToLower(function::GetDisplayName(*functions[a_ElementIndex]));
+            ToLower(FunctionUtils::GetDisplayName(*functions[a_ElementIndex]));
         const std::string& file = functions[a_ElementIndex]->file();
 
         for (std::string& filterToken : m_FilterTokens) {

--- a/OrbitGl/LiveFunctionsDataView.cpp
+++ b/OrbitGl/LiveFunctionsDataView.cpp
@@ -54,11 +54,11 @@ std::string LiveFunctionsDataView::GetValue(int a_Row, int a_Column) {
 
   switch (a_Column) {
     case COLUMN_SELECTED:
-      return function::IsSelected(function) ? "X" : "-";
+      return FunctionUtils::IsSelected(function) ? "X" : "-";
     case COLUMN_INDEX:
       return absl::StrFormat("%d", a_Row);
     case COLUMN_NAME:
-      return function::GetDisplayName(function);
+      return FunctionUtils::GetDisplayName(function);
     case COLUMN_COUNT:
       return absl::StrFormat("%lu", stats->m_Count);
     case COLUMN_TIME_TOTAL:
@@ -72,7 +72,7 @@ std::string LiveFunctionsDataView::GetValue(int a_Row, int a_Column) {
     case COLUMN_MODULE:
       return function.loaded_module_path();
     case COLUMN_ADDRESS:
-      return absl::StrFormat("0x%llx", function::GetAbsoluteAddress(function));
+      return absl::StrFormat("0x%llx", FunctionUtils::GetAbsoluteAddress(function));
     default:
       return "";
   }
@@ -104,10 +104,10 @@ void LiveFunctionsDataView::DoSort() {
 
   switch (m_SortingColumn) {
     case COLUMN_SELECTED:
-      sorter = ORBIT_CUSTOM_FUNC_SORT(function::IsSelected);
+      sorter = ORBIT_CUSTOM_FUNC_SORT(FunctionUtils::IsSelected);
       break;
     case COLUMN_NAME:
-      sorter = ORBIT_CUSTOM_FUNC_SORT(function::GetDisplayName);
+      sorter = ORBIT_CUSTOM_FUNC_SORT(FunctionUtils::GetDisplayName);
       break;
     case COLUMN_COUNT:
       sorter = ORBIT_STAT_SORT(m_Count);
@@ -125,7 +125,7 @@ void LiveFunctionsDataView::DoSort() {
       sorter = ORBIT_STAT_SORT(m_MaxMs);
       break;
     case COLUMN_MODULE:
-      sorter = ORBIT_CUSTOM_FUNC_SORT(function::GetLoadedModuleName);
+      sorter = ORBIT_CUSTOM_FUNC_SORT(FunctionUtils::GetLoadedModuleName);
       break;
     case COLUMN_ADDRESS:
       sorter = ORBIT_FUNC_SORT(address());
@@ -161,8 +161,8 @@ std::vector<std::string> LiveFunctionsDataView::GetContextMenu(
   bool enable_disassembly = !a_SelectedIndices.empty();
   for (int index : a_SelectedIndices) {
     const Function& function = GetFunction(index);
-    enable_select |= !function::IsSelected(function);
-    enable_unselect |= function::IsSelected(function);
+    enable_select |= !FunctionUtils::IsSelected(function);
+    enable_unselect |= FunctionUtils::IsSelected(function);
   }
 
   std::vector<std::string> menu;
@@ -188,12 +188,12 @@ void LiveFunctionsDataView::OnContextMenu(
   if (a_Action == MENU_ACTION_SELECT) {
     for (int i : a_ItemIndices) {
       Function& function = GetFunction(i);
-      function::Select(&function);
+      FunctionUtils::Select(&function);
     }
   } else if (a_Action == MENU_ACTION_UNSELECT) {
     for (int i : a_ItemIndices) {
       Function& function = GetFunction(i);
-      function::UnSelect(&function);
+      FunctionUtils::UnSelect(&function);
     }
   } else if (a_Action == MENU_ACTION_DISASSEMBLY) {
     int32_t pid = Capture::GTargetProcess->GetID();
@@ -232,7 +232,7 @@ void LiveFunctionsDataView::DoFilter() {
   for (size_t i = 0; i < m_Functions.size(); ++i) {
     const Function* function = m_Functions[i];
     if (function != nullptr) {
-      std::string name = ToLower(function::GetDisplayName(*function));
+      std::string name = ToLower(FunctionUtils::GetDisplayName(*function));
 
       bool match = true;
 
@@ -257,7 +257,7 @@ void LiveFunctionsDataView::DoFilter() {
   Capture::GVisibleFunctionsMap.clear();
   for (size_t i = 0; i < m_Indices.size(); ++i) {
     Function& func = GetFunction(i);
-    Capture::GVisibleFunctionsMap[function::GetAbsoluteAddress(func)] = &func;
+    Capture::GVisibleFunctionsMap[FunctionUtils::GetAbsoluteAddress(func)] = &func;
   }
 
   GOrbitApp->NeedsRedraw();
@@ -303,7 +303,7 @@ void LiveFunctionsDataView::JumpToBox(const TextBox* box) const {
 
 std::pair<TextBox*, TextBox*> LiveFunctionsDataView::GetMinMax(
     Function& function) const {
-  auto function_address = function::GetAbsoluteAddress(function);
+  auto function_address = FunctionUtils::GetAbsoluteAddress(function);
   TextBox *min_box = nullptr, *max_box = nullptr;
   std::vector<std::shared_ptr<TimerChain>> chains =
       GCurrentTimeGraph->GetAllThreadTrackTimerChains();
@@ -329,7 +329,7 @@ std::pair<TextBox*, TextBox*> LiveFunctionsDataView::GetMinMax(
 
 void LiveFunctionsDataView::JumpToNext(Function& function,
                                        TickType current_time) const {
-  auto function_address = function::GetAbsoluteAddress(function);
+  auto function_address = FunctionUtils::GetAbsoluteAddress(function);
   TextBox* box_to_jump = nullptr;
   TickType best_time = std::numeric_limits<TickType>::max();
   std::vector<std::shared_ptr<TimerChain>> chains =
@@ -355,7 +355,7 @@ void LiveFunctionsDataView::JumpToNext(Function& function,
 
 void LiveFunctionsDataView::JumpToPrevious(Function& function,
                                            TickType current_time) const {
-  auto function_address = function::GetAbsoluteAddress(function);
+  auto function_address = FunctionUtils::GetAbsoluteAddress(function);
   TextBox* box_to_jump = nullptr;
   TickType best_time = std::numeric_limits<TickType>::min();
   std::vector<std::shared_ptr<TimerChain>> chains =

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -45,7 +45,7 @@ std::string SamplingReportDataView::GetValue(int a_Row, int a_Column) {
 
   switch (a_Column) {
     case COLUMN_SELECTED:
-      return function::IsSelected(func) ? "X" : "-";
+      return FunctionUtils::IsSelected(func) ? "X" : "-";
     case COLUMN_INDEX:
       return absl::StrFormat("%d", a_Row);
     case COLUMN_FUNCTION_NAME:
@@ -90,7 +90,7 @@ void SamplingReportDataView::DoSort() {
 
   switch (m_SortingColumn) {
     case COLUMN_SELECTED:
-      sorter = ORBIT_CUSTOM_FUNC_SORT(function::IsSelected);
+      sorter = ORBIT_CUSTOM_FUNC_SORT(FunctionUtils::IsSelected);
       break;
     case COLUMN_FUNCTION_NAME:
       sorter = ORBIT_PROC_SORT(m_Name);
@@ -188,8 +188,8 @@ std::vector<std::string> SamplingReportDataView::GetContextMenu(
   bool enable_disassembly = !selected_functions.empty();
 
   for (const Function* function : selected_functions) {
-    enable_select |= !function::IsSelected(*function);
-    enable_unselect |= function::IsSelected(*function);
+    enable_select |= !FunctionUtils::IsSelected(*function);
+    enable_unselect |= FunctionUtils::IsSelected(*function);
   }
 
   bool enable_load = false;
@@ -214,11 +214,11 @@ void SamplingReportDataView::OnContextMenu(
     const std::vector<int>& a_ItemIndices) {
   if (a_Action == MENU_ACTION_SELECT) {
     for (Function* function : GetFunctionsFromIndices(a_ItemIndices)) {
-      function::Select(function);
+      FunctionUtils::Select(function);
     }
   } else if (a_Action == MENU_ACTION_UNSELECT) {
     for (Function* function : GetFunctionsFromIndices(a_ItemIndices)) {
-      function::UnSelect(function);
+      FunctionUtils::UnSelect(function);
     }
   } else if (a_Action == MENU_ACTION_MODULES_LOAD) {
     std::vector<std::shared_ptr<Module>> modules;

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -45,7 +45,7 @@ std::string SamplingReportDataView::GetValue(int a_Row, int a_Column) {
 
   switch (a_Column) {
     case COLUMN_SELECTED:
-      return func.GetSelected() ? "X" : "-";
+      return function::IsSelected(func) ? "X" : "-";
     case COLUMN_INDEX:
       return absl::StrFormat("%d", a_Row);
     case COLUMN_FUNCTION_NAME:
@@ -75,6 +75,13 @@ std::string SamplingReportDataView::GetValue(int a_Row, int a_Column) {
   }
 
 //-----------------------------------------------------------------------------
+#define ORBIT_CUSTOM_FUNC_SORT(Func)                                   \
+  [&](int a, int b) {                                                  \
+    return OrbitUtils::Compare(Func(functions[a]), Func(functions[b]), \
+                               ascending);                             \
+  }
+
+//-----------------------------------------------------------------------------
 void SamplingReportDataView::DoSort() {
   bool ascending = m_SortingOrders[m_SortingColumn] == SortingOrder::Ascending;
   std::function<bool(int a, int b)> sorter = nullptr;
@@ -83,7 +90,7 @@ void SamplingReportDataView::DoSort() {
 
   switch (m_SortingColumn) {
     case COLUMN_SELECTED:
-      sorter = ORBIT_PROC_SORT(GetSelected());
+      sorter = ORBIT_CUSTOM_FUNC_SORT(function::IsSelected);
       break;
     case COLUMN_FUNCTION_NAME:
       sorter = ORBIT_PROC_SORT(m_Name);

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -11,6 +11,7 @@
 #include "CallStackDataView.h"
 #include "Capture.h"
 #include "Core.h"
+#include "FunctionUtils.h"
 #include "OrbitModule.h"
 #include "SamplingReport.h"
 #include "absl/strings/str_format.h"
@@ -180,8 +181,8 @@ std::vector<std::string> SamplingReportDataView::GetContextMenu(
   bool enable_disassembly = !selected_functions.empty();
 
   for (const Function* function : selected_functions) {
-    enable_select |= !function->IsSelected();
-    enable_unselect |= function->IsSelected();
+    enable_select |= !function::IsSelected(*function);
+    enable_unselect |= function::IsSelected(*function);
   }
 
   bool enable_load = false;
@@ -206,11 +207,11 @@ void SamplingReportDataView::OnContextMenu(
     const std::vector<int>& a_ItemIndices) {
   if (a_Action == MENU_ACTION_SELECT) {
     for (Function* function : GetFunctionsFromIndices(a_ItemIndices)) {
-      function->Select();
+      function::Select(function);
     }
   } else if (a_Action == MENU_ACTION_UNSELECT) {
     for (Function* function : GetFunctionsFromIndices(a_ItemIndices)) {
-      function->UnSelect();
+      function::UnSelect(function);
     }
   } else if (a_Action == MENU_ACTION_MODULES_LOAD) {
     std::vector<std::shared_ptr<Module>> modules;

--- a/OrbitGl/TextBox.cpp
+++ b/OrbitGl/TextBox.cpp
@@ -5,6 +5,7 @@
 #include "TextBox.h"
 
 #include "Capture.h"
+#include "FunctionUtils.h"
 #include "GlCanvas.h"
 #include "OpenGl.h"
 #include "Params.h"
@@ -121,7 +122,7 @@ void TextBox::Draw(Batcher* batcher, TextRenderer& a_TextRenderer, float a_MinX,
 
     Function* func = Capture::GSelectedFunctionsMap[m_Timer.m_FunctionAddress];
     std::string text = absl::StrFormat(
-        "%s %s", func ? func->PrettyName().c_str() : "", m_Text.c_str());
+        "%s %s", func ? function::GetDisplayName(*func).c_str() : "", m_Text.c_str());
 
     if (!a_IsPicking && !isCoreActivity) {
       a_TextRenderer.AddText(

--- a/OrbitGl/TextBox.cpp
+++ b/OrbitGl/TextBox.cpp
@@ -122,7 +122,7 @@ void TextBox::Draw(Batcher* batcher, TextRenderer& a_TextRenderer, float a_MinX,
 
     Function* func = Capture::GSelectedFunctionsMap[m_Timer.m_FunctionAddress];
     std::string text = absl::StrFormat(
-        "%s %s", func ? function::GetDisplayName(*func).c_str() : "", m_Text.c_str());
+        "%s %s", func ? FunctionUtils::GetDisplayName(*func).c_str() : "", m_Text.c_str());
 
     if (!a_IsPicking && !isCoreActivity) {
       a_TextRenderer.AddText(

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -109,7 +109,7 @@ void ThreadTrack::SetTimesliceText(const Timer& timer, double elapsed_us,
     const char* name = nullptr;
     if (func) {
       std::string extra_info = GetExtraInfo(timer);
-      name = function::GetDisplayName(*func).c_str();
+      name = FunctionUtils::GetDisplayName(*func).c_str();
       std::string text =
           absl::StrFormat("%s %s %s", name, extra_info.c_str(), time.c_str());
 

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -8,6 +8,7 @@
 
 #include "Capture.h"
 #include "EventTrack.h"
+#include "FunctionUtils.h"
 #include "GlCanvas.h"
 #include "TextBox.h"
 #include "TimeGraph.h"
@@ -108,7 +109,7 @@ void ThreadTrack::SetTimesliceText(const Timer& timer, double elapsed_us,
     const char* name = nullptr;
     if (func) {
       std::string extra_info = GetExtraInfo(timer);
-      name = func->PrettyName().c_str();
+      name = function::GetDisplayName(*func).c_str();
       std::string text =
           absl::StrFormat("%s %s %s", name, extra_info.c_str(), time.c_str());
 

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -256,7 +256,7 @@ void TimeGraph::ProcessTimer(const Timer& a_Timer) {
         a_Timer.m_FunctionAddress);
     if (func != nullptr) {
       ++Capture::GFunctionCountMap[a_Timer.m_FunctionAddress];
-      function::UpdateStats(func, a_Timer);
+      FunctionUtils::UpdateStats(func, a_Timer);
     }
   }
 

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -14,6 +14,7 @@
 #include "Capture.h"
 #include "EventTracer.h"
 #include "EventTrack.h"
+#include "FunctionUtils.h"
 #include "Geometry.h"
 #include "GlCanvas.h"
 #include "GpuTrack.h"
@@ -255,7 +256,7 @@ void TimeGraph::ProcessTimer(const Timer& a_Timer) {
         a_Timer.m_FunctionAddress);
     if (func != nullptr) {
       ++Capture::GFunctionCountMap[a_Timer.m_FunctionAddress];
-      func->UpdateStats(a_Timer);
+      function::UpdateStats(func, a_Timer);
     }
   }
 


### PR DESCRIPTION
This PR separates OrbitFunction into 2 classes: OrbitFunction that only stores data, and FunctionUtils for procedures. So, OrbitFunction class could be easily converted to proto.