### PR TITLE
Don't update primitives every frame.

### DIFF
--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -949,10 +949,11 @@ void CaptureWindow::RenderToolbars() {
 
   ImGui::SameLine();
   ImGui::PushItemWidth(300.f);
-  ImGui::InputText("##Track Filter", track_filter_,
-                   IM_ARRAYSIZE(track_filter_));
+  if (ImGui::InputText("##Track Filter", track_filter_,
+                       IM_ARRAYSIZE(track_filter_))) {
+    GCurrentTimeGraph->SetThreadFilter(track_filter_);
+  }
   ImGui::PopItemWidth();
-  GCurrentTimeGraph->SetThreadFilter(track_filter_);
 
   current_x += ImGui::GetWindowWidth() + space_between_toolbars;
   ImGui::End();


### PR DESCRIPTION
A bug introduced when adding the toolbar in the capture forced to constantly set the m_UpdatePrimitives flag which means that we updated primitives on every draw (note that we don't draw every frame, only when needed).  This change fixes the issue allowing for separation between a simple draw and a costly update of timer data (UpdatePrimitives). 

In TimeGraph, if we need to regenerate timer data to be rendered (on zoom, pan, new timers, etc.) then we should use NeedsUpdate(). If we want to redraw the capture view for any other reason, we should use NeedsRedraw() which doesn't regenerate the timer data to be rendered.