### PR TITLE
Added a heat map for the instruction hits in the disassembly window

### DIFF
--- a/OrbitCore/SamplingProfiler.cpp
+++ b/OrbitCore/SamplingProfiler.cpp
@@ -298,12 +298,12 @@ void SamplingProfiler::ResolveCallstacks() {
 }
 
 //-----------------------------------------------------------------------------
-std::shared_ptr<ThreadSampleData> SamplingProfiler::GetSummary() const {
+const ThreadSampleData* SamplingProfiler::GetSummary() const {
   auto summary_it = m_ThreadSampleData.find(0);
   if (summary_it == m_ThreadSampleData.end()) {
     return nullptr;
   }
-  return std::make_shared<ThreadSampleData>((*summary_it).second);
+  return &((*summary_it).second);
 }
 
 //-----------------------------------------------------------------------------
@@ -315,7 +315,7 @@ unsigned int SamplingProfiler::GetCountOfFunction(
     return 0;
   }
   unsigned int result = 0;
-  const std::shared_ptr<ThreadSampleData> summary = GetSummary();
+  const ThreadSampleData* summary = GetSummary();
   if (summary == nullptr) {
     return 0;
   }

--- a/OrbitCore/SamplingProfiler.cpp
+++ b/OrbitCore/SamplingProfiler.cpp
@@ -305,11 +305,12 @@ unsigned int SamplingProfiler::GetCountOfFunction(uint64_t function_address) {
     return 0;
   }
   unsigned int result = 0;
+  // We assert that a summary for all threads was created!
   CHECK(GetGenerateSummary());
   const ThreadSampleData& summary = GetSummary();
   auto function_addresses = (*addresses_of_functions_itr).second;
-  for (uint64_t a : function_addresses) {
-    auto count_itr = summary.m_RawAddressCount.find(a);
+  for (uint64_t address : function_addresses) {
+    auto count_itr = summary.m_RawAddressCount.find(address);
     if (count_itr != summary.m_RawAddressCount.end()) {
       result += (*count_itr).second;
     }

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -139,7 +139,7 @@ class SamplingProfiler {
   void SortByThreadUsage();
   void ProcessSamples();
   void UpdateAddressInfo(uint64_t address);
-  [[nodiscard]] std::shared_ptr<ThreadSampleData> GetSummary() const;
+  [[nodiscard]] const ThreadSampleData* GetSummary() const;
   [[nodiscard]] unsigned int GetCountOfFunction(
       uint64_t function_address) const;
 

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -139,7 +139,7 @@ class SamplingProfiler {
   void SortByThreadUsage();
   void ProcessSamples();
   void UpdateAddressInfo(uint64_t address);
-  ThreadSampleData& GetSummary() { return m_ThreadSampleData[0]; }
+  [[nodiscard]] ThreadSampleData GetSummary() { return m_ThreadSampleData[0]; }
   [[nodiscard]] unsigned int GetCountOfFunction(uint64_t function_address);
 
   ORBIT_SERIALIZABLE;

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -49,10 +49,12 @@ struct LineInfo {
 struct ThreadSampleData {
   ThreadSampleData() { m_ThreadUsage.push_back(0); }
   void ComputeAverageThreadUsage();
+  [[nodiscard]] unsigned int CountOfAddress(uint64_t address) const;
   std::multimap<int, CallstackID> SortCallstacks(
       const std::set<CallstackID>& a_CallStacks, int* o_TotalCallStacks);
   std::unordered_map<CallstackID, unsigned int> m_CallstackCount;
   std::unordered_map<uint64_t, unsigned int> m_AddressCount;
+  std::unordered_map<uint64_t, unsigned int> m_RawAddressCount;
   std::unordered_map<uint64_t, unsigned int> m_ExclusiveCount;
   std::multimap<unsigned int, uint64_t> m_AddressCountSorted;
   unsigned int m_NumSamples = 0;
@@ -137,6 +139,8 @@ class SamplingProfiler {
   void SortByThreadUsage();
   void ProcessSamples();
   void UpdateAddressInfo(uint64_t address);
+  ThreadSampleData& GetSummary() { return m_ThreadSampleData[0]; }
+  [[nodiscard]] unsigned int GetCountOfFunction(uint64_t function_address);
 
   ORBIT_SERIALIZABLE;
 
@@ -166,6 +170,8 @@ class SamplingProfiler {
       m_OriginalCallstackToResolvedCallstack;
   std::unordered_map<uint64_t, std::set<CallstackID>> m_FunctionToCallstacks;
   std::unordered_map<uint64_t, uint64_t> m_ExactAddressToFunctionAddress;
+  std::unordered_map<uint64_t, std::set<uint64_t>>
+      m_FunctionAddressToExactAddresses;
   std::vector<ThreadSampleData*> m_SortedThreadSampleData;
 };
 

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -139,8 +139,9 @@ class SamplingProfiler {
   void SortByThreadUsage();
   void ProcessSamples();
   void UpdateAddressInfo(uint64_t address);
-  [[nodiscard]] ThreadSampleData GetSummary() { return m_ThreadSampleData[0]; }
-  [[nodiscard]] unsigned int GetCountOfFunction(uint64_t function_address);
+  [[nodiscard]] std::shared_ptr<ThreadSampleData> GetSummary() const;
+  [[nodiscard]] unsigned int GetCountOfFunction(
+      uint64_t function_address) const;
 
   ORBIT_SERIALIZABLE;
 
@@ -170,7 +171,7 @@ class SamplingProfiler {
       m_OriginalCallstackToResolvedCallstack;
   std::unordered_map<uint64_t, std::set<CallstackID>> m_FunctionToCallstacks;
   std::unordered_map<uint64_t, uint64_t> m_ExactAddressToFunctionAddress;
-  std::unordered_map<uint64_t, std::set<uint64_t>>
+  std::unordered_map<uint64_t, std::unordered_set<uint64_t>>
       m_FunctionAddressToExactAddresses;
   std::vector<ThreadSampleData*> m_SortedThreadSampleData;
 };

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -359,7 +359,7 @@ void OrbitApp::Disassemble(int32_t pid, const Function& function) {
           if (next_address == 0) {
             next_address = address + 1;
           }
-          std::shared_ptr<ThreadSampleData> data = profiler->GetSummary();
+          const ThreadSampleData* data = profiler->GetSummary();
           if (data == nullptr) {
             return 0.0;
           }

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -344,14 +344,13 @@ void OrbitApp::Disassemble(int32_t pid, const Function& function) {
 
     const std::function<const double(size_t)> line_to_hits =
         [profiler, disasm, count_of_function](size_t line) {
-          LOG("Hits of line: %d", line);
           uint64_t address = disasm.GetAddressAtLine(line);
           if (address == 0) {
             return 0.0;
           }
 
           const ThreadSampleData& data = profiler->GetSummary();
-          // OI calls the address sampled might not be the address of the
+          // On calls the address sampled might not be the address of the
           // beginning of the instruction, but instead at the end. Thus, we
           // iterate over all addresses that fall into this instruction.
           uint64_t next_address = disasm.GetAddressAtLine(line + 1);
@@ -366,7 +365,7 @@ void OrbitApp::Disassemble(int32_t pid, const Function& function) {
             count += data.CountOfAddress(address);
             address++;
           }
-          double result = (count * 1.0) / count_of_function;
+          double result = static_cast<double>(count) / count_of_function;
           return result;
         };
     SendDisassemblyToUi(disasm.GetResult(), line_to_hits);

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -123,7 +123,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void SetSelectLiveTabCallback(SelectLiveTabCallback callback) {
     select_live_tab_callback_ = std::move(callback);
   }
-  using DisassemblyCallback = std::function<void(const std::string&)>;
+  using DisassemblyCallback = std::function<void(
+      const std::string&, const std::function<double(size_t)>&)>;
   void SetDisassemblyCallback(DisassemblyCallback callback) {
     disassembly_callback_ = std::move(callback);
   }
@@ -185,7 +186,11 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
 
   void RequestOpenCaptureToUi();
   void RequestSaveCaptureToUi();
-  void SendDisassemblyToUi(const std::string& disassembly);
+  void SendDisassemblyToUi(
+      const std::string& disassembly,
+      const std::function<double(size_t)>& line_to_hit_ratio = [](size_t) {
+        return 0.0;
+      });
   void SendTooltipToUi(const std::string& tooltip);
   void RequestFeedbackDialogToUi();
   void SendInfoToUi(const std::string& title, const std::string& text);

--- a/OrbitGl/Disassembler.cpp
+++ b/OrbitGl/Disassembler.cpp
@@ -38,8 +38,10 @@ void Disassembler::Disassemble(const uint8_t* machine_code, size_t size,
   cs_mode mode = is_64bit ? CS_MODE_64 : CS_MODE_32;
 
   LOG("\n");
+  line_to_address_.push_back(0);
   LOGF("Platform: %s\n",
        is_64bit ? "X86 64 (Intel syntax)" : "X86 32 (Intel syntax)");
+  line_to_address_.push_back(0);
   err = cs_open(arch, mode, &handle);
   if (err) {
     LOGF("Failed on cs_open() with error returned: %u\n", err);
@@ -54,6 +56,7 @@ void Disassembler::Disassemble(const uint8_t* machine_code, size_t size,
     for (j = 0; j < count; j++) {
       LOGF("0x%" PRIx64 ":\t%-12s %s\n", insn[j].address, insn[j].mnemonic,
            insn[j].op_str);
+      line_to_address_.push_back(insn[j].address);
     }
 
     // print out the next offset, after the last insn
@@ -69,4 +72,10 @@ void Disassembler::Disassemble(const uint8_t* machine_code, size_t size,
   LOG("\n");
 
   cs_close(&handle);
+}
+
+//-----------------------------------------------------------------------------
+uint64_t Disassembler::GetAddressAtLine(size_t line) const {
+  if (line >= line_to_address_.size()) return 0;
+  return line_to_address_[line];
 }

--- a/OrbitGl/Disassembler.h
+++ b/OrbitGl/Disassembler.h
@@ -14,12 +14,17 @@ class Disassembler {
  public:
   void Disassemble(const uint8_t* machine_code, size_t size, uint64_t address,
                    bool is_64bit);
-  const std::string& GetResult() const { return result_; }
+  [[nodiscard]] const std::string& GetResult() const { return result_; }
+  [[nodiscard]] uint64_t GetAddressAtLine(size_t line) const;
 
-  void LOGF(const std::string& format) { result_ += format; }
+  void LOGF(const std::string& format) {
+    result_ += format;
+    line_to_address_.push_back(0);
+  }
 
   void LogHex(const uint8_t* str, size_t len);
 
  private:
   std::string result_;
+  std::vector<uint64_t> line_to_address_;
 };

--- a/OrbitQt/orbitcodeeditor.cpp
+++ b/OrbitQt/orbitcodeeditor.cpp
@@ -266,20 +266,22 @@ void OrbitCodeEditor::updateLineNumberAreaWidth(int /* newBlockCount */) {
 
 //-----------------------------------------------------------------------------
 void OrbitCodeEditor::updateLineNumberArea(const QRect& rect, int dy) {
-  if (dy)
+  if (dy) {
     lineNumberArea->scroll(0, dy);
-  else
+  } else {
     lineNumberArea->update(0, rect.y(), lineNumberArea->width(), rect.height());
+  }
 
   if (rect.contains(viewport()->rect())) updateLineNumberAreaWidth(0);
 }
 
 //-----------------------------------------------------------------------------
 void OrbitCodeEditor::UpdateHeatMapArea(const QRect& rect, int dy) {
-  if (dy)
+  if (dy) {
     heatMapArea->scroll(0, dy);
-  else
+  } else {
     heatMapArea->update(0, rect.y(), heatMapArea->width(), rect.height());
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -477,16 +479,12 @@ void OrbitCodeEditor::HeatMapAreaPaintEvent(QPaintEvent* event) {
     if (block.isVisible() && bottom >= event->rect().top()) {
       // % of hits in this function from 0.0 to 1.0
       const double hit_ratio = line_to_hit_ratio_(blockNumber);
-      // Create a log-scale, values smaller or equal to 1% gets mapped to a
-      // value greater then 0. However, the value 1.0 should still be mapped to
-      // 1.0, thus log(101) is used instead of log(100).
-      double log_hits =
-          std::log(std::ceil(hit_ratio * 100) + 1) / std::log(101);
-      if (log_hits < 0) {
-        log_hits = 0;
-      }
+      // The sqrt maps 0.0 to 0.0 and 1.0 to 1.0 but makes small rations larger,
+      // such that in the ui you can still see that the instruction was actually
+      // hit in the sampling.
+      double sqrt_hits = std::sqrt(hit_ratio);
       // Ceil again, so we display all instructions that are hit at least once.
-      const int alpha = static_cast<int>(std::ceil(log_hits * 255));
+      const int alpha = static_cast<int>(std::ceil(sqrt_hits * 255));
       painter.fillRect(0, top, heatMapArea->width(), fontMetrics().height(),
                        QColor(255, 0, 0, alpha));
     }

--- a/OrbitQt/orbitcodeeditor.h
+++ b/OrbitQt/orbitcodeeditor.h
@@ -78,12 +78,17 @@ class OrbitCodeEditor : public QPlainTextEdit {
 
   void lineNumberAreaPaintEvent(QPaintEvent* event);
   int lineNumberAreaWidth();
+  void HeatMapAreaPaintEvent(QPaintEvent* event);
+  int HeatMapAreaWidth();
   bool loadCode(std::string a_Msg);
   void loadFileMap();
   void saveFileMap();
   void gotoLine(int a_Line);
   void OnTimer();
   void SetText(const std::string& a_Text);
+  void SetLineToHits(const std::function<double(size_t)>& line_to_hit_ratio) {
+    line_to_hit_ratio_ = line_to_hit_ratio;
+  }
   void HighlightWord(const std::string& a_Text, const QColor& a_Color,
                      QList<QTextEdit::ExtraSelection>& extraSelections);
 
@@ -108,16 +113,19 @@ class OrbitCodeEditor : public QPlainTextEdit {
   void updateLineNumberAreaWidth(int newBlockCount);
   void highlightCurrentLine();
   void updateLineNumberArea(const QRect&, int);
+  void UpdateHeatMapArea(const QRect&, int);
   void OnFindTextEntered(const QString&);
   void OnSaveMapFile();
 
  private:
+  QWidget* heatMapArea;
   QWidget* lineNumberArea;
   class Highlighter* highlighter;
   class QLineEdit* m_FindLineEdit;
   class QPushButton* m_SaveButton;
   EditorType m_Type;
   bool m_IsOutput;
+  std::function<double(size_t)> line_to_hit_ratio_ = [](size_t) { return 0.0; };
 
   static OrbitCodeEditor* GFileMapEditor;
   static QWidget* GFileMapWidget;
@@ -136,13 +144,32 @@ class LineNumberArea : public QWidget {
     codeEditor = editor;
   }
 
-  QSize sizeHint() const Q_DECL_OVERRIDE {
+  [[nodiscard]] QSize sizeHint() const Q_DECL_OVERRIDE {
     return QSize(codeEditor->lineNumberAreaWidth(), 0);
   }
 
  protected:
   void paintEvent(QPaintEvent* event) Q_DECL_OVERRIDE {
     codeEditor->lineNumberAreaPaintEvent(event);
+  }
+
+ private:
+  OrbitCodeEditor* codeEditor;
+};
+
+class HeatMapArea : public QWidget {
+ public:
+  explicit HeatMapArea(OrbitCodeEditor* editor) : QWidget(editor) {
+    codeEditor = editor;
+  }
+
+  [[nodiscard]] QSize sizeHint() const Q_DECL_OVERRIDE {
+    return QSize(codeEditor->lineNumberAreaWidth(), 0);
+  }
+
+ protected:
+  void paintEvent(QPaintEvent* event) Q_DECL_OVERRIDE {
+    codeEditor->HeatMapAreaPaintEvent(event);
   }
 
  private:

--- a/OrbitQt/orbitdisassemblydialog.cpp
+++ b/OrbitQt/orbitdisassemblydialog.cpp
@@ -21,3 +21,9 @@ void OrbitDisassemblyDialog::SetText(const std::string& a_Text) {
   ui->plainTextEdit->moveCursor(QTextCursor::Start);
   ui->plainTextEdit->ensureCursorVisible();
 }
+
+//-----------------------------------------------------------------------------
+void OrbitDisassemblyDialog::SetLineToHitRatio(
+    const std::function<double(size_t)>& line_to_hit_ratio) {
+  ui->plainTextEdit->SetLineToHits(line_to_hit_ratio);
+}

--- a/OrbitQt/orbitdisassemblydialog.h
+++ b/OrbitQt/orbitdisassemblydialog.h
@@ -20,6 +20,8 @@ class OrbitDisassemblyDialog : public QDialog {
   ~OrbitDisassemblyDialog() override;
 
   void SetText(const std::string& a_Text);
+  void SetLineToHitRatio(
+      const std::function<double(size_t)>& line_to_hit_ratio);
 
  private:
   Ui::OrbitDisassemblyDialog* ui;

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -123,7 +123,10 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App,
   GOrbitApp->SetSelectLiveTabCallback(
       [this] { ui->RightTabWidget->setCurrentWidget(ui->LiveTab); });
   GOrbitApp->SetDisassemblyCallback(
-      [this](const std::string& disassembly) { OpenDisassembly(disassembly); });
+      [this](const std::string& disassembly,
+             const std::function<double(size_t)>& line_to_hits) {
+        OpenDisassembly(disassembly, line_to_hits);
+      });
   GOrbitApp->SetErrorMessageCallback(
       [this](const std::string& title, const std::string& text) {
         QMessageBox::critical(this, QString::fromStdString(title),
@@ -616,9 +619,12 @@ void OrbitMainWindow::on_actionShow_Includes_Util_triggered() {
 }
 
 //-----------------------------------------------------------------------------
-void OrbitMainWindow::OpenDisassembly(const std::string& a_String) {
-  OrbitDisassemblyDialog* dialog = new OrbitDisassemblyDialog(this);
+void OrbitMainWindow::OpenDisassembly(
+    const std::string& a_String,
+    const std::function<double(size_t)>& line_to_hit_ratio) {
+  auto* dialog = new OrbitDisassemblyDialog(this);
   dialog->SetText(a_String);
+  dialog->SetLineToHitRatio(line_to_hit_ratio);
   dialog->setWindowTitle("Orbit Disassembly");
   dialog->setAttribute(Qt::WA_DeleteOnClose);
   dialog->setWindowFlags(dialog->windowFlags() | Qt::WindowMinimizeButtonHint |

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -48,7 +48,8 @@ class OrbitMainWindow : public QMainWindow {
   bool HideTab(QTabWidget* a_TabWidget, const char* a_TabName);
   std::string FindFile(const std::string& caption, const std::string& dir,
                        const std::string& filter);
-  void OpenDisassembly(const std::string& a_String);
+  void OpenDisassembly(const std::string& a_String,
+                       const std::function<double(size_t)>& line_to_hit_ratio);
   void SetTitle(const QString& task_description);
   outcome::result<void> OpenCapture(const std::string& filepath);
 


### PR DESCRIPTION
When looking at the disassembly window, users should see which instructions take the most time (occur in most samples), thus this adds a (log-scale) heat map to the left of each code editor. It colors that area red (with transparency) if the instructions occur int the sampling results. In cases like there are no samples, it will just leaf the area in the background color.

In order to get the data, we needed to add a counting map for all "raw" addresses occurring on sampling callstacks (i.e addresses that are not yet resolved to its function address).

### Follow up:
It currently only shows a color as indication. Concrete numbers are desired.
It should display:
1. Number of samples of this instruction.
2. Number of samples of this instruction / total number of samples.
3. Number of samples of this instruction / number of samples in that function.

We should also indicate to the user why and that no heat map is shown on dead functions or if no sampling done before.

![Capture](https://user-images.githubusercontent.com/2725914/87141989-276b7400-c2a4-11ea-8964-3889c1e2c3d0.PNG)

