### PR TITLE
Fixed address of callers on sampling based on frame pointers

### DIFF
--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
@@ -94,9 +94,9 @@ void UprobesUnwindingVisitor::visit(CallchainSamplePerfEvent* event) {
   sample.set_timestamp_ns(event->GetTimestamp());
 
   Callstack* callstack = sample.mutable_callstack();
+  uint64_t* raw_callchain = event->GetCallchain();
   // Skip the first frame as the top of a perf_event_open callchain is always
   // inside kernel code.
-  uint64_t* raw_callchain = event->GetCallchain();
   callstack->add_pcs(raw_callchain[1]);
   // Only the address of the top of the stack is correct. Frame-based unwinding
   // uses the return address of a function call as the caller's address.

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
@@ -100,8 +100,8 @@ void UprobesUnwindingVisitor::visit(CallchainSamplePerfEvent* event) {
   callstack->add_pcs(raw_callchain[1]);
   // Only the address of the top of the stack is correct. Frame-based unwinding
   // uses the return address of a function call as the caller's address.
-  // However, the actuall address of the call instruction is before that.
-  // As we don't know the size of the call instruction, we subtract 1 to the
+  // However, the actual address of the call instruction is before that.
+  // As we don't know the size of the call instruction, we subtract 1 from the
   // return address. This way we fall into the range of the call instruction.
   // Note: This is also done the same way in Libunwindstack.
   for (uint64_t frame_index = 2; frame_index < event->GetCallchainSize();


### PR DESCRIPTION
When doing callstack unwinding using frame pointers, the return address is used in the call stack for the caller. However, this is the instruction directly after the call. The correct address, would be the address of the call instruction. As we don't know the size of the call instruction, we just subtract 1 from the return address, such that the address at least falls into the range of the call instruction. Same is done by libunwindstack, though. 