### PR TITLE
OrbitStartUpWindow don't use blocking modal for open file dialog

### DIFF
--- a/OrbitGgp/Client.cpp
+++ b/OrbitGgp/Client.cpp
@@ -31,12 +31,14 @@ void RunProcessWithTimeout(
 
   QObject::connect(timeout_timer, &QTimer::timeout, parent,
                    [process, timeout_timer, callback]() {
-                     ERROR("Process request timed out after %dms",
-                           kDefaultTimeoutInMs);
-                     callback(Error::kRequestTimedOut);
-                     process->terminate();
-                     process->waitForFinished();
-                     if (process != nullptr) process->deleteLater();
+                     if (!process->waitForFinished(10)) {
+                       ERROR("Process request timed out after %dms",
+                             kDefaultTimeoutInMs);
+                       callback(Error::kRequestTimedOut);
+                       process->terminate();
+                       process->waitForFinished();
+                       process->deleteLater();
+                     }
 
                      timeout_timer->deleteLater();
                    });

--- a/OrbitQt/OrbitStartupWindow.cpp
+++ b/OrbitQt/OrbitStartupWindow.cpp
@@ -161,7 +161,7 @@ void OrbitStartupWindow::ReloadInstances() {
               this, QApplication::applicationDisplayName(),
               QString(
                   "Orbit was unable to retrieve the list of available Stadia "
-                  "Instances. The error message was: %1")
+                  "instances. The error message was: %1")
                   .arg(QString::fromStdString(instances.error().message())));
         } else {
           model_->SetInstances(std::move(instances.value()));


### PR DESCRIPTION
This is to fix b/160928265

This uses the non modal version of a file picking dialog, because it turned out on windows a blocking modal starts its own event loop, which is then supposed to not dispatch any QTimers, but it turns out it does anyways. This resulted in a timeout being dispatched before the result of the ggp call is read, even though the call finished before the timeout.

Anyways, non blocking modal means no new event loop means bug is fixed.