### PR TITLE
Reimplement capture toolbar in Qt rather than ImGui.

### DIFF
--- a/OrbitCore/Path.cpp
+++ b/OrbitCore/Path.cpp
@@ -234,6 +234,11 @@ std::string Path::GetLogFilePath() {
   return Path::JoinPath({logsDir, "Orbit.log"});
 }
 
+std::string Path::GetIconsPath() {
+  static std::string icons_path = JoinPath({GetExecutablePath(), "icons"});
+  return icons_path;
+}
+
 #ifdef __linux__
 std::string Path::GetHome() {
   std::string home = GetEnvVar("HOME") + "/";

--- a/OrbitCore/Path.h
+++ b/OrbitCore/Path.h
@@ -26,6 +26,7 @@ class Path {
   static std::string GetDumpPath();
   static std::string GetAppDataPath();
   static std::string GetLogFilePath();
+  static std::string GetIconsPath();
   static void Dump();
 
 #ifdef __linux__

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -466,6 +466,12 @@ std::string OrbitApp::GetCaptureFileName() {
   return result;
 }
 
+std::string OrbitApp::GetCaptureTime() {
+  double time =
+      GCurrentTimeGraph ? GCurrentTimeGraph->GetSessionTimeSpanUs() : 0;
+  return GetPrettyTime(time * 0.001);
+}
+
 //-----------------------------------------------------------------------------
 std::string OrbitApp::GetSaveFile(const std::string& extension) {
   if (!save_file_callback_) {
@@ -616,6 +622,18 @@ void OrbitApp::StopCapture() {
     capture_stop_requested_callback_();
   }
   FireRefreshCallbacks();
+}
+
+void OrbitApp::ClearCapture() {
+  Capture::ClearCaptureData();
+  Capture::GClearCaptureDataFunc();
+  GCurrentTimeGraph->Clear();
+}
+
+void OrbitApp::ToggleDrawHelp() {
+  if (m_CaptureWindow) {
+    m_CaptureWindow->ToggleDrawHelp();
+  }
 }
 
 void OrbitApp::OnCaptureStopped() {
@@ -974,7 +992,11 @@ DataView* OrbitApp::GetOrCreateDataView(DataViewType type) {
 //-----------------------------------------------------------------------------
 void OrbitApp::FilterFunctions(const std::string& filter) {
   Capture::GFunctionFilter = filter;
-  m_LiveFunctionsDataView->SetUiFilterString(filter);
+}
+
+//-----------------------------------------------------------------------------
+void OrbitApp::FilterTracks(const std::string& filter) {
+  GCurrentTimeGraph->SetThreadFilter(filter);
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -57,6 +57,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   static void MainTick();
 
   std::string GetCaptureFileName();
+  std::string GetCaptureTime();
   std::string GetSaveFile(const std::string& extension);
   void SetClipboard(const std::string& text);
   ErrorMessageOr<void> OnSavePreset(const std::string& file_name);
@@ -65,6 +66,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   ErrorMessageOr<void> OnLoadCapture(const std::string& file_name);
   bool StartCapture();
   void StopCapture();
+  void ClearCapture();
+  void ToggleDrawHelp();
   void OnCaptureStopped();
   void ToggleCapture();
   void SetCallStack(std::shared_ptr<CallStack> a_CallStack);
@@ -209,6 +212,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void UpdateSamplingReport();
   void LoadPreset(const std::shared_ptr<Preset>& session);
   void FilterFunctions(const std::string& filter);
+  void FilterTracks(const std::string& filter);
 
   void CrashOrbitService(CrashOrbitServiceRequest_CrashType crash_type);
 

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -50,7 +50,6 @@ class CaptureWindow : public GlCanvas {
   void PostRender() override;
   void Resize(int a_Width, int a_Height) override;
   void RenderHelpUi();
-  void RenderToolbars();
   void RenderTimeBar();
   void ResetHoverTimer();
   void SelectTextBox(class TextBox* a_TextBox);
@@ -62,9 +61,7 @@ class CaptureWindow : public GlCanvas {
   std::vector<std::string> GetContextMenu() override;
   void OnContextMenu(const std::string& a_Action, int a_MenuIndex) override;
   void UpdateVerticalSlider();
-
- private:
-  void LoadIcons();
+  void ToggleDrawHelp();
 
  private:
   TimeGraph time_graph_;
@@ -81,25 +78,6 @@ class CaptureWindow : public GlCanvas {
   GlSlider m_Slider;
   GlSlider m_VerticalSlider;
   int m_ProcessX;
-
-  // Toolbars.
-  uint64_t start_capture_icon_id_;
-  uint64_t stop_capture_icon_id_;
-  uint64_t save_capture_icon_id_;
-  uint64_t load_capture_icon_id_;
-  uint64_t clear_capture_icon_id_;
-  uint64_t help_icon_id_;
-  uint64_t filter_tracks_icon_id_;
-  uint64_t search_icon_id_;
-  uint64_t time_icon_id_;
-  uint64_t feedback_icon_id_;
-  uint64_t info_icon_id_;
-  std::string icons_path_;
-  float toolbar_height_ = 0;
-
-  static constexpr size_t kFilterLength = 512;
-  char track_filter_[kFilterLength] = "";
-  char find_filter_[kFilterLength] = "";
 
   static const std::string MENU_ACTION_GO_TO_CALLSTACK;
   static const std::string MENU_ACTION_GO_TO_SOURCE;

--- a/OrbitGl/LiveFunctionsDataView.cpp
+++ b/OrbitGl/LiveFunctionsDataView.cpp
@@ -237,7 +237,7 @@ void LiveFunctionsDataView::OnContextMenu(
 
 //-----------------------------------------------------------------------------
 void LiveFunctionsDataView::DoFilter() {
-  Capture::GFunctionFilter = m_Filter;
+  GOrbitApp->FilterFunctions(m_Filter);
   std::vector<uint32_t> indices;
 
   std::vector<std::string> tokens = absl::StrSplit(ToLower(m_Filter), ' ');

--- a/OrbitGl/TimeGraphLayout.cpp
+++ b/OrbitGl/TimeGraphLayout.cpp
@@ -31,7 +31,7 @@ TimeGraphLayout::TimeGraphLayout() {
   m_RoundingNumSides = 16;
   m_TextOffset = 5.f;
   m_VerticalMargin = 10.f;
-  m_SchedulerTrackOffset = 62.f;
+  m_SchedulerTrackOffset = 10.f;
   m_TextZ = -0.02f;
   m_TrackZ = -0.1f;
   m_ToolbarIconHeight = 24.f;

--- a/OrbitQt/orbitdataviewpanel.cpp
+++ b/OrbitQt/orbitdataviewpanel.cpp
@@ -43,6 +43,11 @@ void OrbitDataViewPanel::Initialize(DataView* data_view,
 OrbitTreeView* OrbitDataViewPanel::GetTreeView() { return ui->treeView; }
 
 //-----------------------------------------------------------------------------
+QLineEdit* OrbitDataViewPanel::GetFilterLineEdit() {
+  return ui->FilterLineEdit;
+}
+
+//-----------------------------------------------------------------------------
 void OrbitDataViewPanel::Link(OrbitDataViewPanel* a_Panel) {
   ui->treeView->Link(a_Panel->ui->treeView);
 }

--- a/OrbitQt/orbitdataviewpanel.h
+++ b/OrbitQt/orbitdataviewpanel.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <QLineEdit>
 #include <QWidget>
 
 #include "orbittablemodel.h"
@@ -27,6 +28,7 @@ class OrbitDataViewPanel : public QWidget {
   void SetDataModel(DataView* model);
   void SetFilter(const QString& a_Filter);
   class OrbitTreeView* GetTreeView();
+  QLineEdit* GetFilterLineEdit();
 
  private slots:
   void on_FilterLineEdit_textEdited(const QString& a_Text);

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -222,27 +222,29 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App,
   GOrbitApp->PostInit();
 }
 
-void SetFontSize(QWidget* widget, uint32_t font_size) {
+namespace {
+static void SetFontSize(QWidget* widget, uint32_t font_size) {
   QFont font = widget->font();
   font.setPointSize(font_size);
   widget->setFont(font);
 }
 
-QWidget* CreateSpacer(QWidget* parent) {
+static QWidget* CreateSpacer(QWidget* parent) {
   QLabel* spacer = new QLabel(parent);
   spacer->setText("    ");
   return spacer;
 }
 
-QAction* CreateDummyAction(const QIcon& icon, QObject* parent) {
+static QAction* CreateDummyAction(const QIcon& icon, QObject* parent) {
   QAction* action = new QAction(icon, "", parent);
   action->setDisabled(true);
   return action;
 }
 
-QIcon GetIcon(const std::string& icon_name) {
+static QIcon GetIcon(const std::string& icon_name) {
   return QIcon(Path::JoinPath({Path::GetIconsPath(), icon_name}).c_str());
 }
+}  // namespace
 
 void OrbitMainWindow::SetupCaptureToolbar() {
   // Sizes.
@@ -291,8 +293,8 @@ void OrbitMainWindow::SetupCaptureToolbar() {
   filter_tracks_line_edit_->setPlaceholderText("filter tracks");
   SetFontSize(filter_tracks_line_edit_, kFontSize);
   toolbar->addWidget(filter_tracks_line_edit_);
-  connect(filter_tracks_line_edit_, SIGNAL(textChanged(const QString&)), this,
-          SLOT(OnFilterTracksTextChanged(const QString&)));
+  connect(filter_tracks_line_edit_, &QLineEdit::textChanged, this,
+          [this](const QString& text) { OnFilterTracksTextChanged(text); });
 
   // Filter functions.
   toolbar->addWidget(CreateSpacer(toolbar));
@@ -302,11 +304,12 @@ void OrbitMainWindow::SetupCaptureToolbar() {
   filter_functions_line_edit_->setPlaceholderText("filter functions");
   SetFontSize(filter_functions_line_edit_, kFontSize);
   toolbar->addWidget(filter_functions_line_edit_);
-  connect(filter_functions_line_edit_, SIGNAL(textChanged(const QString&)),
-          this, SLOT(OnFilterFunctionsTextChanged(const QString&)));
-  connect(ui->LiveFunctionsList->GetFilterLineEdit(),
-          SIGNAL(textChanged(const QString&)), this,
-          SLOT(OnLiveTabFunctionsFilterTextChanged(const QString&)));
+  connect(filter_functions_line_edit_, &QLineEdit::textChanged, this,
+          [this](const QString& text) { OnFilterFunctionsTextChanged(text); });
+  connect(ui->LiveFunctionsList->GetFilterLineEdit(), &QLineEdit::textChanged,
+          this, [this](const QString& text) {
+            OnLiveTabFunctionsFilterTextChanged(text);
+          });
 
   // Timer.
   toolbar->addWidget(CreateSpacer(toolbar));
@@ -602,7 +605,7 @@ void OrbitMainWindow::OnTimer() {
   this->ui->plainTextEdit->OnTimer();
 
   if (timer_label_) {
-    timer_label_->setText(GOrbitApp->GetCaptureTime().c_str());
+    timer_label_->setText(QString::fromStdString(GOrbitApp->GetCaptureTime()));
   }
 }
 

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <QApplication>
+#include <QLabel>
+#include <QLineEdit>
 #include <QMainWindow>
 #include <QString>
 #include <QTimer>
@@ -61,18 +63,22 @@ class OrbitMainWindow : public QMainWindow {
 
   void OnTimer();
   void OnHideSearch();
+  void OnLiveTabFunctionsFilterTextChanged(const QString& text);
+  void OnFilterFunctionsTextChanged(const QString& text);
+  void OnFilterTracksTextChanged(const QString& text);
 
   void on_actionOpen_Preset_triggered();
   void on_actionQuit_triggered();
-
   void on_actionToogleDevMode_toggled(bool arg1);
-
   void on_actionSave_Preset_As_triggered();
 
+  void on_actionStart_Capture_triggered();
+  void on_actionStop_Capture_triggered();
   void on_actionSave_Capture_triggered();
-
   void on_actionOpen_Capture_triggered();
-
+  void on_actionClear_Capture_triggered();
+  void on_actionHelp_triggered();
+  void on_actionFeedback_triggered();
   void on_actionShow_Includes_Util_triggered();
 
   void on_actionCheckFalse_triggered();
@@ -84,6 +90,7 @@ class OrbitMainWindow : public QMainWindow {
 
  private:
   void StartMainTimer();
+  void SetupCaptureToolbar();
   void SetupCodeView();
   void ShowFeedbackDialog();
 
@@ -94,15 +101,20 @@ class OrbitMainWindow : public QMainWindow {
   std::vector<OrbitGLWidget*> m_GlWidgets;
   bool m_Headless;
 
-  // sampling tab
+  // Sampling tab.
   class QWidget* m_SamplingTab;
   class OrbitSamplingReport* m_OrbitSamplingReport;
   class QGridLayout* m_SamplingLayout;
 
-  // selection tab
+  // Selection tab.
   class QWidget* m_SelectionTab;
   class OrbitSamplingReport* m_SelectionReport;
   class QGridLayout* m_SelectionLayout;
+
+  // Capture toolbar.
+  QLabel* timer_label_ = nullptr;
+  QLineEdit* filter_functions_line_edit_ = nullptr;
+  QLineEdit* filter_tracks_line_edit_ = nullptr;
 
   class OutputDialog* m_OutputDialog;
   std::string m_CurrentPdbName;

--- a/OrbitQt/orbitmainwindow.ui
+++ b/OrbitQt/orbitmainwindow.ui
@@ -87,11 +87,26 @@
         <attribute name="title">
          <string>capture</string>
         </attribute>
-        <layout class="QGridLayout" name="gridLayout_5">
-         <item row="0" column="0">
+        <layout class="QVBoxLayout" name="verticalLayout">
+         <item>
+          <widget class="QToolBar" name="capture_toolbar">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="OrbitGLWidget" name="CaptureGLWidget"/>
          </item>
         </layout>
+        <zorder>CaptureGLWidget</zorder>
+        <zorder>capture_toolbar</zorder>
        </widget>
        <widget class="QWidget" name="OutputTab">
         <attribute name="title">
@@ -290,14 +305,57 @@
     <string>Open Preset</string>
    </property>
   </action>
-  <action name="actionStart_Captue">
+  <action name="actionStart_Capture">
    <property name="text">
-    <string>Start Captue</string>
+    <string>Start Capture</string>
+   </property>
+   <property name="toolTip">
+    <string>Start Capture</string>
    </property>
   </action>
   <action name="actionStop_Capture">
    <property name="text">
     <string>Stop Capture</string>
+   </property>
+  </action>
+  <action name="actionClear_Capture">
+   <property name="text">
+    <string>Clear Capture</string>
+   </property>
+   <property name="toolTip">
+    <string>Clear Capture</string>
+   </property>
+  </action>
+  <action name="actionFilter_Tracks">
+   <property name="text">
+    <string>Filter Tracks</string>
+   </property>
+   <property name="toolTip">
+    <string>Filter Tracks</string>
+   </property>
+  </action>
+  <action name="actionFilter_Functions">
+   <property name="text">
+    <string>Search</string>
+   </property>
+   <property name="toolTip">
+    <string>Search</string>
+   </property>
+  </action>
+  <action name="actionFeedback">
+   <property name="text">
+    <string>Feedback</string>
+   </property>
+   <property name="toolTip">
+    <string>Feedback</string>
+   </property>
+  </action>
+  <action name="actionHelp">
+   <property name="text">
+    <string>Help</string>
+   </property>
+   <property name="toolTip">
+    <string>Help</string>
    </property>
   </action>
   <action name="actionQuit">


### PR DESCRIPTION
The toolbar now auto-resizes based on the window width. Fixes b/158244053. 

Note that I removed the process name.  Not sure it adds tremendous value and it takes a lot of screen real estate. We could always have it in the title bar similar to what we see when we load a capture.

![qt_toolbar](https://user-images.githubusercontent.com/3687222/87276955-39ad0400-c496-11ea-8f57-1820345209e0.png)
