### PR TITLE
Remove "Calling convention" column from "functions" tab

### DIFF
--- a/OrbitCore/OrbitFunction.cpp
+++ b/OrbitCore/OrbitFunction.cpp
@@ -66,53 +66,6 @@ void Function::UpdateStats(const Timer& timer) {
   }
 }
 
-const char* Function::GetCallingConventionString() {
-  static const char* kCallingConventions[] = {
-      "NEAR_C",       // CV_CALL_NEAR_C      = 0x00, // near right to left push,
-                      // caller pops stack
-      "FAR_C",        // CV_CALL_FAR_C       = 0x01, // far right to left push,
-                      // caller pops stack
-      "NEAR_PASCAL",  // CV_CALL_NEAR_PASCAL = 0x02, // near left to right
-                      // push, callee pops stack
-      "FAR_PASCAL",   // CV_CALL_FAR_PASCAL  = 0x03, // far left to right push,
-                      // callee pops stack
-      "NEAR_FAST",    // CV_CALL_NEAR_FAST   = 0x04, // near left to right push
-                      // with regs, callee pops stack
-      "FAR_FAST",     // CV_CALL_FAR_FAST    = 0x05, // far left to right push
-                      // with regs, callee pops stack
-      "SKIPPED",   // CV_CALL_SKIPPED     = 0x06, // skipped (unused) call index
-      "NEAR_STD",  // CV_CALL_NEAR_STD    = 0x07, // near standard call
-      "FAR_STD",   // CV_CALL_FAR_STD     = 0x08, // far standard call
-      "NEAR_SYS",  // CV_CALL_NEAR_SYS    = 0x09, // near sys call
-      "FAR_SYS",   // CV_CALL_FAR_SYS     = 0x0a, // far sys call
-      "THISCALL",  // CV_CALL_THISCALL    = 0x0b, // this call (this passed in
-                   // register)
-      "MIPSCALL",  // CV_CALL_MIPSCALL    = 0x0c, // Mips call
-      "GENERIC",   // CV_CALL_GENERIC     = 0x0d, // Generic call sequence
-      "ALPHACALL",  // CV_CALL_ALPHACALL   = 0x0e, // Alpha call
-      "PPCCALL",    // CV_CALL_PPCCALL     = 0x0f, // PPC call
-      "SHCALL",     // CV_CALL_SHCALL      = 0x10, // Hitachi SuperH call
-      "ARMCALL",    // CV_CALL_ARMCALL     = 0x11, // ARM call
-      "AM33CALL",   // CV_CALL_AM33CALL    = 0x12, // AM33 call
-      "TRICALL",    // CV_CALL_TRICALL     = 0x13, // TriCore Call
-      "SH5CALL",    // CV_CALL_SH5CALL     = 0x14, // Hitachi SuperH-5 call
-      "M32RCALL",   // CV_CALL_M32RCALL    = 0x15, // M32R Call
-      "CLRCALL",    // CV_CALL_CLRCALL     = 0x16, // clr call
-      "INLINE",     // CV_CALL_INLINE      = 0x17, // Marker for routines always
-                    // inlined and thus lacking a convention
-      "NEAR_VECTOR",  // CV_CALL_NEAR_VECTOR = 0x18, // near left to right push
-                      // with regs, callee pops stack
-      "RESERVED"};    // CV_CALL_RESERVED    = 0x19  // first unused call
-                      // enumeration
-  if (calling_convention_ < 0 ||
-      static_cast<size_t>(calling_convention_) >=
-          (sizeof(kCallingConventions) / sizeof(kCallingConventions[0]))) {
-    return "UnknownCallConv";
-  }
-
-  return kCallingConventions[calling_convention_];
-}
-
 const absl::flat_hash_map<const char*, Function::OrbitType>&
 Function::GetFunctionNameToOrbitTypeMap() {
   static absl::flat_hash_map<const char*, OrbitType> function_name_to_type_map{
@@ -147,7 +100,7 @@ bool Function::SetOrbitTypeFromName() {
   return false;
 }
 
-ORBIT_SERIALIZE(Function, 4) {
+ORBIT_SERIALIZE(Function, 5) {
   ORBIT_NVP_VAL(4, name_);
   ORBIT_NVP_VAL(4, pretty_name_);
   ORBIT_NVP_VAL(4, loaded_module_path_);
@@ -157,7 +110,6 @@ ORBIT_SERIALIZE(Function, 4) {
   ORBIT_NVP_VAL(4, size_);
   ORBIT_NVP_VAL(4, file_);
   ORBIT_NVP_VAL(4, line_);
-  ORBIT_NVP_VAL(4, calling_convention_);
   ORBIT_NVP_VAL(4, stats_);
 }
 

--- a/OrbitCore/OrbitFunction.h
+++ b/OrbitCore/OrbitFunction.h
@@ -64,11 +64,6 @@ class Function {
   uint64_t Size() const { return size_; }
   const std::string& File() const { return file_; }
   uint32_t Line() const { return line_; }
-  int CallingConvention() const { return calling_convention_; }
-  const char* GetCallingConventionString();
-  void SetCallingConvention(int calling_convention) {
-    calling_convention_ = calling_convention;
-  }
 
   uint64_t Hash() const { return StringHash(pretty_name_); }
 
@@ -107,7 +102,6 @@ class Function {
   uint64_t size_;
   std::string file_;
   uint32_t line_;
-  int calling_convention_ = -1;
   OrbitType type_ = NONE;
   std::shared_ptr<FunctionStats> stats_;
 };

--- a/OrbitGl/FunctionsDataView.cpp
+++ b/OrbitGl/FunctionsDataView.cpp
@@ -23,13 +23,12 @@ const std::vector<DataView::Column>& FunctionsDataView::GetColumns() {
     columns.resize(COLUMN_NUM);
     columns[COLUMN_SELECTED] = {"Hooked", .0f, SortingOrder::Descending};
     columns[COLUMN_INDEX] = {"Index", .0f, SortingOrder::Ascending};
-    columns[COLUMN_NAME] = {"Function", .5f, SortingOrder::Ascending};
+    columns[COLUMN_NAME] = {"Function", .6f, SortingOrder::Ascending};
     columns[COLUMN_SIZE] = {"Size", .0f, SortingOrder::Ascending};
     columns[COLUMN_FILE] = {"File", .0f, SortingOrder::Ascending};
     columns[COLUMN_LINE] = {"Line", .0f, SortingOrder::Ascending};
     columns[COLUMN_MODULE] = {"Module", .0f, SortingOrder::Ascending};
     columns[COLUMN_ADDRESS] = {"Address", .0f, SortingOrder::Ascending};
-    columns[COLUMN_CALL_CONV] = {"Call conv", .0f, SortingOrder::Ascending};
     return columns;
   }();
   return columns;
@@ -62,8 +61,6 @@ std::string FunctionsDataView::GetValue(int a_Row, int a_Column) {
       return function.GetLoadedModuleName();
     case COLUMN_ADDRESS:
       return absl::StrFormat("0x%llx", function.GetVirtualAddress());
-    case COLUMN_CALL_CONV:
-      return function.GetCallingConventionString();
     default:
       return "";
   }
@@ -112,9 +109,6 @@ void FunctionsDataView::DoSort() {
       break;
     case COLUMN_ADDRESS:
       sorter = ORBIT_FUNC_SORT(Address());
-      break;
-    case COLUMN_CALL_CONV:
-      sorter = ORBIT_FUNC_SORT(CallingConvention());
       break;
     default:
       break;

--- a/OrbitGl/FunctionsDataView.h
+++ b/OrbitGl/FunctionsDataView.h
@@ -38,7 +38,6 @@ class FunctionsDataView : public DataView {
     COLUMN_LINE,
     COLUMN_MODULE,
     COLUMN_ADDRESS,
-    COLUMN_CALL_CONV,
     COLUMN_NUM
   };
 


### PR DESCRIPTION
#### Remove "Calling convention" column from FunctionsDataView
Its content is always "unknown calling convention" as this is not supported
Bug: http://b/159096545
#### Remove now unused calling-convention-related methods from Function