### PR TITLE
Use 64bit information in GTargetProcess

### DIFF
--- a/OrbitCore/OrbitProcess.h
+++ b/OrbitCore/OrbitProcess.h
@@ -38,6 +38,7 @@ class Process {
   const std::string& GetFullPath() const { return m_FullPath; }
   void SetID(int32_t id) { m_ID = id; }
   int32_t GetID() const { return m_ID; }
+  void SetIs64Bit(bool value) { m_Is64Bit = value; }
   bool GetIs64Bit() const { return m_Is64Bit; }
 
   Function* GetFunctionFromAddress(uint64_t address, bool a_IsExact = true);

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -203,6 +203,7 @@ void OrbitApp::PostInit() {
             process->SetID(info.pid());
             process->SetName(info.name());
             process->SetFullPath(info.full_path());
+            process->SetIs64Bit(info.is_64_bit());
             // The other fields do not appear to be used at the moment.
 
             process_map_.insert_or_assign(process->GetID(), process);


### PR DESCRIPTION
The information if a process is used in `OrbitApp::Disassemble` (App.cpp line 335)

@dpallotti this is what I talked about in the standup this morning