### PR TITLE
Use variables for flags in conan profiles

### DIFF
--- a/third_party/conan/configs/linux/profiles/clang7_debug
+++ b/third_party/conan/configs/linux/profiles/clang7_debug
@@ -1,3 +1,8 @@
+C_COMPILER=clang-7
+CXX_COMPILER=clang++-7
+C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux
 os_build=Linux
@@ -12,8 +17,8 @@ build_type=Debug
 [build_requires]
 cmake_installer/3.16.3@conan/stable
 [env]
-CC=clang-7
-CXX=clang++-7
-CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-LDFLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
+CC=$C_COMPILER
+CXX=$CXX_COMPILER
+CFLAGS=$C_FLAGS
+CXXFLAGS=$CXX_FLAGS
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/linux/profiles/clang7_release
+++ b/third_party/conan/configs/linux/profiles/clang7_release
@@ -1,3 +1,8 @@
+C_COMPILER=clang-7
+CXX_COMPILER=clang++-7
+C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux
 os_build=Linux
@@ -12,8 +17,8 @@ build_type=Release
 [build_requires]
 cmake_installer/3.16.3@conan/stable
 [env]
-CC=clang-7
-CXX=clang++-7
-CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-LDFLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
+CC=$C_COMPILER
+CXX=$CXX_COMPILER
+CFLAGS=$C_FLAGS
+CXXFLAGS=$CXX_FLAGS
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/linux/profiles/clang7_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/clang7_relwithdebinfo
@@ -1,3 +1,8 @@
+C_COMPILER=clang-7
+CXX_COMPILER=clang++-7
+C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux
 os_build=Linux
@@ -12,8 +17,8 @@ build_type=RelWithDebInfo
 [build_requires]
 cmake_installer/3.16.3@conan/stable
 [env]
-CC=clang-7
-CXX=clang++-7
-CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-LDFLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
+CC=$C_COMPILER
+CXX=$CXX_COMPILER
+CFLAGS=$C_FLAGS
+CXXFLAGS=$CXX_FLAGS
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/linux/profiles/clang8_debug
+++ b/third_party/conan/configs/linux/profiles/clang8_debug
@@ -1,3 +1,8 @@
+C_COMPILER=clang-8
+CXX_COMPILER=clang++-8
+C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux
 os_build=Linux
@@ -12,8 +17,8 @@ build_type=Debug
 [build_requires]
 cmake_installer/3.16.3@conan/stable
 [env]
-CC=clang-8
-CXX=clang++-8
-CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-LDFLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
+CC=$C_COMPILER
+CXX=$CXX_COMPILER
+CFLAGS=$C_FLAGS
+CXXFLAGS=$CXX_FLAGS
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/linux/profiles/clang8_release
+++ b/third_party/conan/configs/linux/profiles/clang8_release
@@ -1,3 +1,8 @@
+C_COMPILER=clang-8
+CXX_COMPILER=clang++-8
+C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux
 os_build=Linux
@@ -12,8 +17,8 @@ build_type=Release
 [build_requires]
 cmake_installer/3.16.3@conan/stable
 [env]
-CC=clang-8
-CXX=clang++-8
-CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-LDFLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
+CC=$C_COMPILER
+CXX=$CXX_COMPILER
+CFLAGS=$C_FLAGS
+CXXFLAGS=$CXX_FLAGS
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/linux/profiles/clang8_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/clang8_relwithdebinfo
@@ -1,3 +1,8 @@
+C_COMPILER=clang-8
+CXX_COMPILER=clang++-8
+C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux
 os_build=Linux
@@ -12,8 +17,8 @@ build_type=RelWithDebInfo
 [build_requires]
 cmake_installer/3.16.3@conan/stable
 [env]
-CC=clang-8
-CXX=clang++-8
-CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-LDFLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
+CC=$C_COMPILER
+CXX=$CXX_COMPILER
+CFLAGS=$C_FLAGS
+CXXFLAGS=$CXX_FLAGS
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/linux/profiles/clang9_debug
+++ b/third_party/conan/configs/linux/profiles/clang9_debug
@@ -1,3 +1,8 @@
+C_COMPILER=clang-9
+CXX_COMPILER=clang++-9
+C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux
 os_build=Linux
@@ -12,8 +17,8 @@ build_type=Debug
 [build_requires]
 cmake_installer/3.16.3@conan/stable
 [env]
-CC=clang-9
-CXX=clang++-9
-CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-LDFLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
+CC=$C_COMPILER
+CXX=$CXX_COMPILER
+CFLAGS=$C_FLAGS
+CXXFLAGS=$CXX_FLAGS
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/linux/profiles/clang9_release
+++ b/third_party/conan/configs/linux/profiles/clang9_release
@@ -1,3 +1,8 @@
+C_COMPILER=clang-9
+CXX_COMPILER=clang++-9
+C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux
 os_build=Linux
@@ -12,8 +17,8 @@ build_type=Release
 [build_requires]
 cmake_installer/3.16.3@conan/stable
 [env]
-CC=clang-9
-CXX=clang++-9
-CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-LDFLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
+CC=$C_COMPILER
+CXX=$CXX_COMPILER
+CFLAGS=$C_FLAGS
+CXXFLAGS=$CXX_FLAGS
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/linux/profiles/clang9_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/clang9_relwithdebinfo
@@ -1,3 +1,8 @@
+C_COMPILER=clang-9
+CXX_COMPILER=clang++-9
+C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux
 os_build=Linux
@@ -12,8 +17,8 @@ build_type=RelWithDebInfo
 [build_requires]
 cmake_installer/3.16.3@conan/stable
 [env]
-CC=clang-9
-CXX=clang++-9
-CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-LDFLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
+CC=$C_COMPILER
+CXX=$CXX_COMPILER
+CFLAGS=$C_FLAGS
+CXXFLAGS=$CXX_FLAGS
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/linux/profiles/gcc8_debug
+++ b/third_party/conan/configs/linux/profiles/gcc8_debug
@@ -1,3 +1,8 @@
+C_COMPILER=gcc-8
+CXX_COMPILER=g++-8
+C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux
 os_build=Linux
@@ -12,8 +17,8 @@ build_type=Debug
 [build_requires]
 cmake_installer/3.16.3@conan/stable
 [env]
-CC=gcc-8
-CXX=g++-8
-CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-LDFLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
+CC=$C_COMPILER
+CXX=$CXX_COMPILER
+CFLAGS=$C_FLAGS
+CXXFLAGS=$CXX_FLAGS
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/linux/profiles/gcc8_release
+++ b/third_party/conan/configs/linux/profiles/gcc8_release
@@ -1,3 +1,8 @@
+C_COMPILER=gcc-8
+CXX_COMPILER=g++-8
+C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux
 os_build=Linux
@@ -12,8 +17,8 @@ build_type=Release
 [build_requires]
 cmake_installer/3.16.3@conan/stable
 [env]
-CC=gcc-8
-CXX=g++-8
-CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-LDFLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
+CC=$C_COMPILER
+CXX=$CXX_COMPILER
+CFLAGS=$C_FLAGS
+CXXFLAGS=$CXX_FLAGS
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/linux/profiles/gcc8_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/gcc8_relwithdebinfo
@@ -1,3 +1,8 @@
+C_COMPILER=gcc-8
+CXX_COMPILER=g++-8
+C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux
 os_build=Linux
@@ -12,8 +17,8 @@ build_type=RelWithDebInfo
 [build_requires]
 cmake_installer/3.16.3@conan/stable
 [env]
-CC=gcc-8
-CXX=g++-8
-CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-LDFLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
+CC=$C_COMPILER
+CXX=$CXX_COMPILER
+CFLAGS=$C_FLAGS
+CXXFLAGS=$CXX_FLAGS
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/linux/profiles/gcc9_debug
+++ b/third_party/conan/configs/linux/profiles/gcc9_debug
@@ -1,3 +1,8 @@
+C_COMPILER=gcc-9
+CXX_COMPILER=g++-9
+C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux
 os_build=Linux
@@ -12,8 +17,8 @@ build_type=Debug
 [build_requires]
 cmake_installer/3.16.3@conan/stable
 [env]
-CC=gcc-9
-CXX=g++-9
-CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-LDFLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
+CC=$C_COMPILER
+CXX=$CXX_COMPILER
+CFLAGS=$C_FLAGS
+CXXFLAGS=$CXX_FLAGS
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/linux/profiles/gcc9_release
+++ b/third_party/conan/configs/linux/profiles/gcc9_release
@@ -1,3 +1,8 @@
+C_COMPILER=gcc-9
+CXX_COMPILER=g++-9
+C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux
 os_build=Linux
@@ -12,8 +17,8 @@ build_type=Release
 [build_requires]
 cmake_installer/3.16.3@conan/stable
 [env]
-CC=gcc-9
-CXX=g++-9
-CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-LDFLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
+CC=$C_COMPILER
+CXX=$CXX_COMPILER
+CFLAGS=$C_FLAGS
+CXXFLAGS=$CXX_FLAGS
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/linux/profiles/gcc9_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/gcc9_relwithdebinfo
@@ -1,3 +1,8 @@
+C_COMPILER=gcc-9
+CXX_COMPILER=g++-9
+C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux
 os_build=Linux
@@ -12,8 +17,8 @@ build_type=RelWithDebInfo
 [build_requires]
 cmake_installer/3.16.3@conan/stable
 [env]
-CC=gcc-9
-CXX=g++-9
-CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-LDFLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
+CC=$C_COMPILER
+CXX=$CXX_COMPILER
+CFLAGS=$C_FLAGS
+CXXFLAGS=$CXX_FLAGS
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/ggp_debug
+++ b/third_party/conan/configs/windows/profiles/ggp_debug
@@ -1,3 +1,6 @@
+C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux
 os.platform=GGP
@@ -18,6 +21,6 @@ ninja/1.9.0@
 
 [env]
 CONAN_CMAKE_GENERATOR=Ninja
-CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-LDFLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
+CFLAGS=$C_FLAGS
+CXXFLAGS=$CXX_FLAGS
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/ggp_release
+++ b/third_party/conan/configs/windows/profiles/ggp_release
@@ -1,3 +1,6 @@
+C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux
 os.platform=GGP
@@ -18,6 +21,6 @@ ninja/1.9.0@
 
 [env]
 CONAN_CMAKE_GENERATOR=Ninja
-CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-LDFLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
+CFLAGS=$C_FLAGS
+CXXFLAGS=$CXX_FLAGS
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/ggp_relwithdebinfo
+++ b/third_party/conan/configs/windows/profiles/ggp_relwithdebinfo
@@ -1,3 +1,6 @@
+C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux
 os.platform=GGP
@@ -18,6 +21,6 @@ ninja/1.9.0@
 
 [env]
 CONAN_CMAKE_GENERATOR=Ninja
-CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-LDFLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
+CFLAGS=$C_FLAGS
+CXXFLAGS=$CXX_FLAGS
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2017_debug
+++ b/third_party/conan/configs/windows/profiles/msvc2017_debug
@@ -1,3 +1,4 @@
+LINKER_FLAGS=/FIXED:NO
 [settings]
 os=Windows
 os_build=Windows
@@ -12,4 +13,4 @@ OrbitProfiler:system_qt=False
 cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
-LDFLAGS=/FIXED:NO
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2017_debug_x86
+++ b/third_party/conan/configs/windows/profiles/msvc2017_debug_x86
@@ -1,3 +1,4 @@
+LINKER_FLAGS=/FIXED:NO
 [settings]
 os=Windows
 os_build=Windows
@@ -13,4 +14,4 @@ OrbitProfiler:with_gui=False
 cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
-LDFLAGS=/FIXED:NO
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2017_release
+++ b/third_party/conan/configs/windows/profiles/msvc2017_release
@@ -1,3 +1,4 @@
+LINKER_FLAGS=/FIXED:NO
 [settings]
 os=Windows
 os_build=Windows
@@ -12,4 +13,4 @@ OrbitProfiler:system_qt=False
 cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
-LDFLAGS=/FIXED:NO
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2017_release_x86
+++ b/third_party/conan/configs/windows/profiles/msvc2017_release_x86
@@ -1,3 +1,4 @@
+LINKER_FLAGS=/FIXED:NO
 [settings]
 os=Windows
 os_build=Windows
@@ -13,4 +14,4 @@ OrbitProfiler:with_gui=False
 cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
-LDFLAGS=/FIXED:NO
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2017_relwithdebinfo
+++ b/third_party/conan/configs/windows/profiles/msvc2017_relwithdebinfo
@@ -1,3 +1,4 @@
+LINKER_FLAGS=/FIXED:NO
 [settings]
 os=Windows
 os_build=Windows
@@ -12,4 +13,4 @@ OrbitProfiler:system_qt=False
 cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
-LDFLAGS=/FIXED:NO
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2017_relwithdebinfo_x86
+++ b/third_party/conan/configs/windows/profiles/msvc2017_relwithdebinfo_x86
@@ -1,3 +1,4 @@
+LINKER_FLAGS=/FIXED:NO
 [settings]
 os=Windows
 os_build=Windows
@@ -13,4 +14,4 @@ OrbitProfiler:with_gui=False
 cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
-LDFLAGS=/FIXED:NO
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2019_debug
+++ b/third_party/conan/configs/windows/profiles/msvc2019_debug
@@ -1,3 +1,4 @@
+LINKER_FLAGS=/FIXED:NO
 [settings]
 os=Windows
 os_build=Windows
@@ -12,4 +13,4 @@ OrbitProfiler:system_qt=False
 cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
-LDFLAGS=/FIXED:NO
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2019_debug_x86
+++ b/third_party/conan/configs/windows/profiles/msvc2019_debug_x86
@@ -1,3 +1,4 @@
+LINKER_FLAGS=/FIXED:NO
 [settings]
 os=Windows
 os_build=Windows
@@ -13,4 +14,4 @@ OrbitProfiler:with_gui=False
 cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
-LDFLAGS=/FIXED:NO
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2019_release
+++ b/third_party/conan/configs/windows/profiles/msvc2019_release
@@ -1,3 +1,4 @@
+LINKER_FLAGS=/FIXED:NO
 [settings]
 os=Windows
 os_build=Windows
@@ -12,4 +13,4 @@ OrbitProfiler:system_qt=False
 cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
-LDFLAGS=/FIXED:NO
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2019_release_x86
+++ b/third_party/conan/configs/windows/profiles/msvc2019_release_x86
@@ -1,3 +1,4 @@
+LINKER_FLAGS=/FIXED:NO
 [settings]
 os=Windows
 os_build=Windows
@@ -13,4 +14,4 @@ OrbitProfiler:with_gui=False
 cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
-LDFLAGS=/FIXED:NO
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2019_relwithdebinfo
+++ b/third_party/conan/configs/windows/profiles/msvc2019_relwithdebinfo
@@ -1,3 +1,4 @@
+LINKER_FLAGS=/FIXED:NO
 [settings]
 os=Windows
 os_build=Windows
@@ -12,4 +13,4 @@ OrbitProfiler:system_qt=False
 cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
-LDFLAGS=/FIXED:NO
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2019_relwithdebinfo_x86
+++ b/third_party/conan/configs/windows/profiles/msvc2019_relwithdebinfo_x86
@@ -1,3 +1,4 @@
+LINKER_FLAGS=/FIXED:NO
 [settings]
 os=Windows
 os_build=Windows
@@ -13,4 +14,4 @@ OrbitProfiler:with_gui=False
 cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
-LDFLAGS=/FIXED:NO
+LDFLAGS=$LINKER_FLAGS


### PR DESCRIPTION
Using variables allows the repository-provided profile to be used as a
template for own modifications. For example I could have a profile
`debug`:

```conan
include(clang9_debug)

[env]
CMAKE_EXPORT_COMPILE_COMMANDS=On
CONAN_CMAKE_GENERATOR=Ninja
CXXFLAGS=$CXX_FLAGS -fcolor-diagnostics
CFLAGS=$C_FLAGS -fcolor-diagnostics
```

I'm introducing this now, because I want to make the default-profiles updatable (by using an include).

More information about profile-variables and profile-includes is here: https://docs.conan.io/en/latest/reference/profiles.html#profile-includes