### PR TITLE
Use numeric_limits<double>::lowest instead of numeric_limits<double>::min

### DIFF
--- a/OrbitGl/GraphTrack.h
+++ b/OrbitGl/GraphTrack.h
@@ -24,7 +24,7 @@ class GraphTrack : public Track {
  protected:
   std::map<uint64_t, double> values_;
   double min_ = std::numeric_limits<double>::max();
-  double max_ = std::numeric_limits<double>::min();
+  double max_ = std::numeric_limits<double>::lowest();
   double value_range_ = 0;
   double inv_value_range_ = 0;
 };


### PR DESCRIPTION
From https://en.cppreference.com/w/cpp/types/numeric_limits/min:

"For floating-point types with denormalization, min returns the minimum positive normalized value. Note that this behavior may be unexpected, especially when compared to the behavior of min for integral types. To find the value that has no values less than it, use numeric_limits::lowest."

Depending on the values one can get on the track, using min might be okay, buy by using lowest we remove all doubt.