### PR TITLE
Fix ProcessList file path

### DIFF
--- a/OrbitCore/LinuxUtils.h
+++ b/OrbitCore/LinuxUtils.h
@@ -23,4 +23,5 @@ outcome::result<std::vector<std::string>> ReadProcMaps(pid_t pid);
 ErrorMessageOr<std::vector<ModuleInfo>> ListModules(int32_t pid);
 outcome::result<std::unordered_map<pid_t, double>> GetCpuUtilization();
 outcome::result<bool> Is64Bit(pid_t pid);
+ErrorMessageOr<std::string> GetExecutablePath(int32_t pid);
 }  // namespace LinuxUtils


### PR DESCRIPTION
The file path of a process used to be determined by reading
/proc/pid/cmdline which contains the command how the process was
started. This is not absolute file path, but can be relative (./app).
Now it is determined by reading the link /proc/pid/exe which points to
the executable.

Also added todo comments to LinuxUtils. 


Besides just making a thing "more correct", this also fixes a bug where preset loading is not working as intended when the process is started with a different command. for example: /path/to/somewhere/game vs ./game