### PR TITLE
Fix nodiscard-error in ElfFileLoadSymbolsFuzzer

### DIFF
--- a/ElfUtils/ElfFileLoadSymbolsFuzzer.cpp
+++ b/ElfUtils/ElfFileLoadSymbolsFuzzer.cpp
@@ -7,6 +7,6 @@
 #include "ElfUtils/ElfFile.h"
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t* buf, size_t len) {
-  ElfUtils::ElfFile::CreateFromBuffer("INMEMORY", buf, len);
+  (void) ElfUtils::ElfFile::CreateFromBuffer("INMEMORY", buf, len);
   return 0;
 }


### PR DESCRIPTION
This fixes a compile error on master. In my defense, I rebased this time before merging. But there still were changes between rebasing and merging. My apologies.

Description:

We have to explicitly discard the result in the fuzz-test case.

This fixup was necessary because the nodiscard-change went in just after
the rebase of the fuzzing branch.