### PR TITLE
Use the task_rename,task_newtask tracepoints for thread names, unify (a bit) handling of GPU tracepoints and other tracepoints

### DIFF
--- a/OrbitLinuxTracing/CMakeLists.txt
+++ b/OrbitLinuxTracing/CMakeLists.txt
@@ -29,6 +29,7 @@ target_sources(OrbitLinuxTracing PRIVATE
         Function.h
         GpuTracepointEventProcessor.h
         GpuTracepointEventProcessor.cpp
+        KernelTracepoints.h
         LibunwindstackUnwinder.cpp
         LibunwindstackUnwinder.h
         MakeUniqueForOverwrite.h

--- a/OrbitLinuxTracing/GpuTracepointEventProcessor.cpp
+++ b/OrbitLinuxTracing/GpuTracepointEventProcessor.cpp
@@ -147,7 +147,7 @@ void GpuTracepointEventProcessor::CreateGpuExecutionEventIfComplete(
 }
 
 void GpuTracepointEventProcessor::PushEvent(
-    const std::unique_ptr<PerfEventSampleRaw>& sample) {
+    const std::unique_ptr<RawSamplePerfEvent>& sample) {
   pid_t tid = sample->ring_buffer_record.sample_id.tid;
   uint64_t timestamp_ns = sample->ring_buffer_record.sample_id.time;
   int tp_id =

--- a/OrbitLinuxTracing/GpuTracepointEventProcessor.cpp
+++ b/OrbitLinuxTracing/GpuTracepointEventProcessor.cpp
@@ -10,50 +10,6 @@
 
 namespace LinuxTracing {
 
-namespace {
-
-// Format is based on the content of the event's format file:
-// /sys/kernel/debug/tracing/events/<category>/<name>/format
-struct __attribute__((__packed__)) perf_event_amdgpu_cs_ioctl {
-  uint16_t common_type;
-  uint8_t common_flags;
-  uint8_t common_preempt_count;
-  int32_t common_pid;
-  uint64_t sched_job_id;
-  int32_t timeline;
-  uint32_t context;
-  uint32_t seqno;
-  uint64_t dma_fence;  // This is an address.
-  uint64_t ring_name;  // This is an address.
-  uint32_t num_ibs;
-};
-
-struct __attribute__((__packed__)) perf_event_amdgpu_sched_run_job {
-  uint16_t common_type;
-  uint8_t common_flags;
-  uint8_t common_preempt_count;
-  int32_t common_pid;
-  uint64_t sched_job_id;
-  int32_t timeline;
-  uint32_t context;
-  uint32_t seqno;
-  uint64_t ring_name;  // This is an address.
-  uint32_t num_ibs;
-};
-
-struct __attribute__((__packed__)) perf_event_dma_fence_signaled {
-  uint16_t common_type;
-  uint8_t common_flags;
-  uint8_t common_preempt_count;
-  int32_t common_pid;
-  int32_t driver;
-  int32_t timeline;
-  uint32_t context;
-  uint32_t seqno;
-};
-
-}  // namespace
-
 int GpuTracepointEventProcessor::ComputeDepthForEvent(
     const std::string& timeline, uint64_t start_timestamp,
     uint64_t end_timestamp) {
@@ -146,64 +102,50 @@ void GpuTracepointEventProcessor::CreateGpuExecutionEventIfComplete(
   dma_fence_signaled_events_.erase(key);
 }
 
-void GpuTracepointEventProcessor::PushEvent(const RawSamplePerfEvent& sample) {
-  pid_t tid = sample.ring_buffer_record.sample_id.tid;
-  uint64_t timestamp_ns = sample.ring_buffer_record.sample_id.time;
-  int tp_id =
-      static_cast<int>(*reinterpret_cast<const uint16_t*>(&sample.data[0]));
+// The following three overloaded PushEvent methods handle the three different
+// types of events that we can get from the GPU driver tracepoints we are
+// tracing.
+// We allow for the possibility that these events arrive out-of-order
+// (which is something we have actually observed) with the following approach:
+// We record all three types of events in different maps. Whenever a new event
+// arrives, we add it to the corresponding map and then try to create a complete
+// GPU execution event. This event is only created when all three types of GPU
+// events have been received.
 
-  // Handle the three different types of events that we can get from the GPU
-  // driver tracepoints we are tracing. We allow for the possibility that these
-  // events arrive out-of-order (which is something we have actually observed)
-  // with the following approach: We record all three types of events in
-  // different maps. Whenever a new event arrives, we add it to the
-  // corresponding map and then try to create a complete GPU execution event.
-  // This event is only be created when all three types of GPU events have been
-  // received.
-  if (tp_id == amdgpu_cs_ioctl_id_) {
-    const perf_event_amdgpu_cs_ioctl* tracepoint_data =
-        reinterpret_cast<const perf_event_amdgpu_cs_ioctl*>(&sample.data[0]);
+void GpuTracepointEventProcessor::PushEvent(
+    const AmdgpuCsIoctlPerfEvent& sample) {
+  AmdgpuCsIoctlEvent event{sample.GetTid(), sample.GetTimestamp(),
+                           sample.GetContext(), sample.GetSeqno(),
+                           sample.ExtractTimelineString()};
+  Key key = std::make_tuple(sample.GetContext(), sample.GetSeqno(),
+                            sample.ExtractTimelineString());
 
-    uint32_t context = tracepoint_data->context;
-    uint32_t seqno = tracepoint_data->seqno;
-    std::string timeline = ExtractTimelineString(tracepoint_data);
+  amdgpu_cs_ioctl_events_.emplace(key, std::move(event));
+  CreateGpuExecutionEventIfComplete(key);
+}
 
-    AmdgpuCsIoctlEvent event{tid, timestamp_ns, context, seqno, timeline};
-    Key key = std::make_tuple(context, seqno, timeline);
+void GpuTracepointEventProcessor::PushEvent(
+    const AmdgpuSchedRunJobPerfEvent& sample) {
+  AmdgpuSchedRunJobEvent event{sample.GetTimestamp(), sample.GetContext(),
+                               sample.GetSeqno(),
+                               sample.ExtractTimelineString()};
+  Key key = std::make_tuple(sample.GetContext(), sample.GetSeqno(),
+                            sample.ExtractTimelineString());
 
-    amdgpu_cs_ioctl_events_.emplace(key, event);
+  amdgpu_sched_run_job_events_.emplace(key, std::move(event));
+  CreateGpuExecutionEventIfComplete(key);
+}
 
-    CreateGpuExecutionEventIfComplete(key);
-  } else if (tp_id == amdgpu_sched_run_job_id_) {
-    const perf_event_amdgpu_sched_run_job* tracepoint_data =
-        reinterpret_cast<const perf_event_amdgpu_sched_run_job*>(
-            &sample.data[0]);
+void GpuTracepointEventProcessor::PushEvent(
+    const DmaFenceSignaledPerfEvent& sample) {
+  DmaFenceSignaledEvent event{sample.GetTimestamp(), sample.GetContext(),
+                              sample.GetSeqno(),
+                              sample.ExtractTimelineString()};
+  Key key = std::make_tuple(sample.GetContext(), sample.GetSeqno(),
+                            sample.ExtractTimelineString());
 
-    uint32_t context = tracepoint_data->context;
-    uint32_t seqno = tracepoint_data->seqno;
-    std::string timeline = ExtractTimelineString(tracepoint_data);
-
-    AmdgpuSchedRunJobEvent event{timestamp_ns, context, seqno, timeline};
-    Key key = std::make_tuple(context, seqno, timeline);
-
-    amdgpu_sched_run_job_events_.emplace(key, event);
-    CreateGpuExecutionEventIfComplete(key);
-  } else if (tp_id == dma_fence_signaled_id_) {
-    const perf_event_dma_fence_signaled* tracepoint_data =
-        reinterpret_cast<const perf_event_dma_fence_signaled*>(&sample.data[0]);
-
-    uint32_t context = tracepoint_data->context;
-    uint32_t seqno = tracepoint_data->seqno;
-    std::string timeline = ExtractTimelineString(tracepoint_data);
-
-    DmaFenceSignaledEvent event{timestamp_ns, context, seqno, timeline};
-    Key key = std::make_tuple(context, seqno, timeline);
-
-    dma_fence_signaled_events_.emplace(key, event);
-    CreateGpuExecutionEventIfComplete(key);
-  } else {
-    FATAL("Unexpected tracepoint id here: %d", tp_id);
-  }
+  dma_fence_signaled_events_.emplace(key, std::move(event));
+  CreateGpuExecutionEventIfComplete(key);
 }
 
 void GpuTracepointEventProcessor::SetListener(TracerListener* listener) {

--- a/OrbitLinuxTracing/GpuTracepointEventProcessor.h
+++ b/OrbitLinuxTracing/GpuTracepointEventProcessor.h
@@ -15,47 +15,20 @@ namespace LinuxTracing {
 
 class GpuTracepointEventProcessor {
  public:
-  GpuTracepointEventProcessor(int amdgpu_cs_ioctl_id,
-                              int amdgpu_sched_run_job_id,
-                              int dma_fence_signaled_id)
-      : amdgpu_cs_ioctl_id_(amdgpu_cs_ioctl_id),
-        amdgpu_sched_run_job_id_(amdgpu_sched_run_job_id),
-        dma_fence_signaled_id_(dma_fence_signaled_id) {}
+  void PushEvent(const AmdgpuCsIoctlPerfEvent& sample);
+  void PushEvent(const AmdgpuSchedRunJobPerfEvent& sample);
+  void PushEvent(const DmaFenceSignaledPerfEvent& sample);
 
-  void PushEvent(const RawSamplePerfEvent& sample);
   void SetListener(TracerListener* listener);
 
  private:
   // Keys are context, seqno, and timeline
   typedef std::tuple<uint32_t, uint32_t, std::string> Key;
 
-  template <typename T>
-  std::string ExtractTimelineString(const T* tracepoint_data) {
-    int32_t data_loc = tracepoint_data->timeline;
-    int16_t data_loc_size = static_cast<int16_t>(data_loc >> 16);
-    int16_t data_loc_offset = static_cast<int16_t>(data_loc & 0x00ff);
-
-    std::vector<char> data_loc_data(data_loc_size);
-    std::memcpy(
-        &data_loc_data[0],
-        reinterpret_cast<const char*>(tracepoint_data) + data_loc_offset,
-        data_loc_size);
-
-    // While the string should be null terminated here, we make sure that it
-    // actually is by adding a zero in the last position. In the case of
-    // expected behavior, this is a no-op.
-    data_loc_data[data_loc_data.size() - 1] = 0;
-    return std::string(&data_loc_data[0]);
-  }
-
   int ComputeDepthForEvent(const std::string& timeline,
                            uint64_t start_timestamp, uint64_t end_timestamp);
 
   void CreateGpuExecutionEventIfComplete(const Key& key);
-
-  int amdgpu_cs_ioctl_id_ = 0;
-  int amdgpu_sched_run_job_id_ = 0;
-  int dma_fence_signaled_id_ = 0;
 
   TracerListener* listener_ = nullptr;
 

--- a/OrbitLinuxTracing/GpuTracepointEventProcessor.h
+++ b/OrbitLinuxTracing/GpuTracepointEventProcessor.h
@@ -22,7 +22,7 @@ class GpuTracepointEventProcessor {
         amdgpu_sched_run_job_id_(amdgpu_sched_run_job_id),
         dma_fence_signaled_id_(dma_fence_signaled_id) {}
 
-  void PushEvent(const std::unique_ptr<RawSamplePerfEvent>& sample);
+  void PushEvent(const RawSamplePerfEvent& sample);
   void SetListener(TracerListener* listener);
 
  private:

--- a/OrbitLinuxTracing/GpuTracepointEventProcessor.h
+++ b/OrbitLinuxTracing/GpuTracepointEventProcessor.h
@@ -22,7 +22,7 @@ class GpuTracepointEventProcessor {
         amdgpu_sched_run_job_id_(amdgpu_sched_run_job_id),
         dma_fence_signaled_id_(dma_fence_signaled_id) {}
 
-  void PushEvent(const std::unique_ptr<PerfEventSampleRaw>& sample);
+  void PushEvent(const std::unique_ptr<RawSamplePerfEvent>& sample);
   void SetListener(TracerListener* listener);
 
  private:

--- a/OrbitLinuxTracing/KernelTracepoints.h
+++ b/OrbitLinuxTracing/KernelTracepoints.h
@@ -16,6 +16,14 @@ struct __attribute__((__packed__)) tracepoint_common {
   int32_t common_pid;
 };
 
+struct __attribute__((__packed__)) task_newtask_tracepoint {
+  tracepoint_common common;
+  int32_t pid;
+  char comm[16];
+  uint64_t clone_flags;
+  int16_t oom_score_adj;
+};
+
 struct __attribute__((__packed__)) task_rename_tracepoint {
   tracepoint_common common;
   int32_t pid;

--- a/OrbitLinuxTracing/KernelTracepoints.h
+++ b/OrbitLinuxTracing/KernelTracepoints.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_LINUX_TRACING_TRACEPOINTS_H_
+#define ORBIT_LINUX_TRACING_TRACEPOINTS_H_
+
+#include <cstdint>
+
+// Format described in /sys/kernel/debug/tracing/events/<category>/<name>/format
+
+struct __attribute__((__packed__)) tracepoint_common {
+  uint16_t common_type;
+  uint8_t common_flags;
+  uint8_t common_preempt_count;
+  int32_t common_pid;
+};
+
+struct __attribute__((__packed__)) task_rename_tracepoint {
+  tracepoint_common common;
+  int32_t pid;
+  char oldcomm[16];
+  char newcomm[16];
+  int16_t oom_score_adj;
+};
+
+#endif  // ORBIT_LINUX_TRACING_TRACEPOINTS_H_

--- a/OrbitLinuxTracing/KernelTracepoints.h
+++ b/OrbitLinuxTracing/KernelTracepoints.h
@@ -7,7 +7,8 @@
 
 #include <cstdint>
 
-// Format described in /sys/kernel/debug/tracing/events/<category>/<name>/format
+// Format is based on the content of the event's format file:
+// /sys/kernel/debug/tracing/events/<category>/<name>/format
 
 struct __attribute__((__packed__)) tracepoint_common {
   uint16_t common_type;
@@ -30,6 +31,35 @@ struct __attribute__((__packed__)) task_rename_tracepoint {
   char oldcomm[16];
   char newcomm[16];
   int16_t oom_score_adj;
+};
+
+struct __attribute__((__packed__)) amdgpu_cs_ioctl_tracepoint {
+  tracepoint_common common;
+  uint64_t sched_job_id;
+  int32_t timeline;
+  uint32_t context;
+  uint32_t seqno;
+  uint64_t dma_fence;  // This is an address.
+  uint64_t ring_name;  // This is an address.
+  uint32_t num_ibs;
+};
+
+struct __attribute__((__packed__)) amdgpu_sched_run_job_tracepoint {
+  tracepoint_common common;
+  uint64_t sched_job_id;
+  int32_t timeline;
+  uint32_t context;
+  uint32_t seqno;
+  uint64_t ring_name;  // This is an address.
+  uint32_t num_ibs;
+};
+
+struct __attribute__((__packed__)) dma_fence_signaled_tracepoint {
+  tracepoint_common common;
+  int32_t driver;
+  int32_t timeline;
+  uint32_t context;
+  uint32_t seqno;
 };
 
 #endif  // ORBIT_LINUX_TRACING_TRACEPOINTS_H_

--- a/OrbitLinuxTracing/PerfEvent.cpp
+++ b/OrbitLinuxTracing/PerfEvent.cpp
@@ -44,6 +44,10 @@ void LostPerfEvent::Accept(PerfEventVisitor* visitor) { visitor->visit(this); }
 
 void MapsPerfEvent::Accept(PerfEventVisitor* visitor) { visitor->visit(this); }
 
+void TaskNewtaskPerfEvent::Accept(PerfEventVisitor* visitor) {
+  visitor->visit(this);
+}
+
 void TaskRenamePerfEvent::Accept(PerfEventVisitor* visitor) {
   visitor->visit(this);
 }

--- a/OrbitLinuxTracing/PerfEvent.cpp
+++ b/OrbitLinuxTracing/PerfEvent.cpp
@@ -52,4 +52,16 @@ void TaskRenamePerfEvent::Accept(PerfEventVisitor* visitor) {
   visitor->visit(this);
 }
 
+void AmdgpuCsIoctlPerfEvent::Accept(PerfEventVisitor* visitor) {
+  visitor->visit(this);
+}
+
+void AmdgpuSchedRunJobPerfEvent::Accept(PerfEventVisitor* visitor) {
+  visitor->visit(this);
+}
+
+void DmaFenceSignaledPerfEvent::Accept(PerfEventVisitor* visitor) {
+  visitor->visit(this);
+}
+
 }  // namespace LinuxTracing

--- a/OrbitLinuxTracing/PerfEvent.cpp
+++ b/OrbitLinuxTracing/PerfEvent.cpp
@@ -44,4 +44,8 @@ void LostPerfEvent::Accept(PerfEventVisitor* visitor) { visitor->visit(this); }
 
 void MapsPerfEvent::Accept(PerfEventVisitor* visitor) { visitor->visit(this); }
 
+void TaskRenamePerfEvent::Accept(PerfEventVisitor* visitor) {
+  visitor->visit(this);
+}
+
 }  // namespace LinuxTracing

--- a/OrbitLinuxTracing/PerfEvent.h
+++ b/OrbitLinuxTracing/PerfEvent.h
@@ -380,12 +380,28 @@ class TracepointPerfEventBase : public PerfEvent {
   }
 };
 
+class TaskNewtaskPerfEvent
+    : public TracepointPerfEventBase<task_newtask_tracepoint> {
+ public:
+  void Accept(PerfEventVisitor* visitor) override;
+
+  // The tracepoint format calls this "pid" but it's effectively the thread id.
+  pid_t GetTid() const { return tracepoint_data.pid; }
+
+  const char* GetComm() const { return tracepoint_data.comm; }
+
+  uint64_t GetStreamId() const {
+    return ring_buffer_record.sample_id.stream_id;
+  }
+
+  uint32_t GetCpu() const { return ring_buffer_record.sample_id.cpu; }
+};
+
 class TaskRenamePerfEvent
     : public TracepointPerfEventBase<task_rename_tracepoint> {
  public:
   void Accept(PerfEventVisitor* visitor) override;
 
-  // The tracepoint format calls this "pid" but it's effectively the thread id.
   pid_t GetTid() const { return tracepoint_data.pid; }
 
   const char* GetOldComm() const { return tracepoint_data.oldcomm; }

--- a/OrbitLinuxTracing/PerfEvent.h
+++ b/OrbitLinuxTracing/PerfEvent.h
@@ -259,7 +259,7 @@ class StackSamplePerfEvent : public PerfEvent {
 
 class CallchainSamplePerfEvent : public PerfEvent {
  public:
-  perf_event_callchain_sample ring_buffer_record;
+  perf_event_callchain_sample_fixed ring_buffer_record;
   std::vector<uint64_t> ips;
   explicit CallchainSamplePerfEvent(uint64_t callchain_size)
       : ips(callchain_size) {
@@ -368,11 +368,11 @@ class MapsPerfEvent : public PerfEvent {
   std::string maps_;
 };
 
-class PerfEventSampleRaw {
+class RawSamplePerfEvent {
  public:
-  perf_event_sample_raw ring_buffer_record;
+  perf_event_raw_sample_fixed ring_buffer_record;
   std::vector<uint8_t> data;
-  explicit PerfEventSampleRaw(uint32_t size) : data(size) {}
+  explicit RawSamplePerfEvent(uint32_t size) : data(size) {}
 };
 
 }  // namespace LinuxTracing

--- a/OrbitLinuxTracing/PerfEventOpen.cpp
+++ b/OrbitLinuxTracing/PerfEventOpen.cpp
@@ -154,6 +154,9 @@ void* perf_event_open_mmap_ring_buffer(int fd, uint64_t mmap_length) {
 int tracepoint_event_open(const char* tracepoint_category,
                           const char* tracepoint_name, pid_t pid, int32_t cpu) {
   int tp_id = GetTracepointId(tracepoint_category, tracepoint_name);
+  if (tp_id == -1) {
+    return -1;
+  }
   perf_event_attr pe = generic_event_attr();
   pe.type = PERF_TYPE_TRACEPOINT;
   pe.config = tp_id;

--- a/OrbitLinuxTracing/PerfEventReaders.cpp
+++ b/OrbitLinuxTracing/PerfEventReaders.cpp
@@ -94,20 +94,4 @@ std::unique_ptr<CallchainSamplePerfEvent> ConsumeCallchainSamplePerfEvent(
   return event;
 }
 
-std::unique_ptr<RawSamplePerfEvent> ConsumeRawSamplePerfEvent(
-    PerfEventRingBuffer* ring_buffer, const perf_event_header& header) {
-  uint32_t size = 0;
-  ring_buffer->ReadValueAtOffset(&size,
-                                 offsetof(perf_event_raw_sample_fixed, size));
-  auto event = std::make_unique<RawSamplePerfEvent>(size);
-  ring_buffer->ReadRawAtOffset(
-      reinterpret_cast<uint8_t*>(&event->ring_buffer_record), 0,
-      sizeof(perf_event_raw_sample_fixed));
-  ring_buffer->ReadRawAtOffset(
-      &event->data[0],
-      offsetof(perf_event_raw_sample_fixed, size) + sizeof(uint32_t), size);
-  ring_buffer->SkipRecord(header);
-  return event;
-}
-
 }  // namespace LinuxTracing

--- a/OrbitLinuxTracing/PerfEventReaders.h
+++ b/OrbitLinuxTracing/PerfEventReaders.h
@@ -24,7 +24,7 @@ std::unique_ptr<StackSamplePerfEvent> ConsumeStackSamplePerfEvent(
 std::unique_ptr<CallchainSamplePerfEvent> ConsumeCallchainSamplePerfEvent(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header);
 
-std::unique_ptr<PerfEventSampleRaw> ConsumeSampleRaw(
+std::unique_ptr<RawSamplePerfEvent> ConsumeRawSamplePerfEvent(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header);
 
 }  // namespace LinuxTracing

--- a/OrbitLinuxTracing/PerfEventRecords.h
+++ b/OrbitLinuxTracing/PerfEventRecords.h
@@ -104,7 +104,7 @@ struct __attribute__((__packed__)) perf_event_stack_sample {
   perf_event_sample_stack_user stack;
 };
 
-struct __attribute__((__packed__)) perf_event_callchain_sample {
+struct __attribute__((__packed__)) perf_event_callchain_sample_fixed {
   perf_event_header header;
   perf_event_sample_id_tid_time_streamid_cpu sample_id;
   uint64_t nr;
@@ -124,7 +124,7 @@ struct __attribute__((__packed__)) perf_event_ax_sample {
   perf_event_sample_regs_user_ax regs;
 };
 
-struct __attribute__((__packed__)) perf_event_sample_raw {
+struct __attribute__((__packed__)) perf_event_raw_sample_fixed {
   perf_event_header header;
   perf_event_sample_id_tid_time_streamid_cpu sample_id;
   uint32_t size;

--- a/OrbitLinuxTracing/PerfEventVisitor.h
+++ b/OrbitLinuxTracing/PerfEventVisitor.h
@@ -23,6 +23,7 @@ class PerfEventVisitor {
   virtual void visit(UretprobesPerfEvent*) {}
   virtual void visit(LostPerfEvent*) {}
   virtual void visit(MapsPerfEvent*) {}
+  virtual void visit(TaskNewtaskPerfEvent*) {}
   virtual void visit(TaskRenamePerfEvent*) {}
 };
 

--- a/OrbitLinuxTracing/PerfEventVisitor.h
+++ b/OrbitLinuxTracing/PerfEventVisitor.h
@@ -23,6 +23,7 @@ class PerfEventVisitor {
   virtual void visit(UretprobesPerfEvent*) {}
   virtual void visit(LostPerfEvent*) {}
   virtual void visit(MapsPerfEvent*) {}
+  virtual void visit(TaskRenamePerfEvent*) {}
 };
 
 }  // namespace LinuxTracing

--- a/OrbitLinuxTracing/PerfEventVisitor.h
+++ b/OrbitLinuxTracing/PerfEventVisitor.h
@@ -25,6 +25,9 @@ class PerfEventVisitor {
   virtual void visit(MapsPerfEvent*) {}
   virtual void visit(TaskNewtaskPerfEvent*) {}
   virtual void visit(TaskRenamePerfEvent*) {}
+  virtual void visit(AmdgpuCsIoctlPerfEvent*) {}
+  virtual void visit(AmdgpuSchedRunJobPerfEvent*) {}
+  virtual void visit(DmaFenceSignaledPerfEvent*) {}
 };
 
 }  // namespace LinuxTracing

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -699,7 +699,7 @@ void TracerThread::ProcessSampleEvent(const perf_event_header& header,
     auto event = ConsumeRawSamplePerfEvent(ring_buffer, header);
     // Do not filter GPU tracepoint events based on pid as we want to have
     // visibility into all GPU activity across the system.
-    gpu_event_processor_->PushEvent(event);
+    gpu_event_processor_->PushEvent(*event);
     ++stats_.gpu_events_count;
 
   } else if (is_callchain_sample) {

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -696,7 +696,7 @@ void TracerThread::ProcessSampleEvent(const perf_event_header& header,
 
   } else if (is_gpu_event) {
     // TODO: Consider deferring GPU events.
-    auto event = ConsumeSampleRaw(ring_buffer, header);
+    auto event = ConsumeRawSamplePerfEvent(ring_buffer, header);
     // Do not filter GPU tracepoint events based on pid as we want to have
     // visibility into all GPU activity across the system.
     gpu_event_processor_->PushEvent(event);

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -136,15 +136,17 @@ class TracerThread {
   absl::flat_hash_set<uint64_t> stack_sampling_ids_;
   absl::flat_hash_set<uint64_t> task_newtask_ids_;
   absl::flat_hash_set<uint64_t> task_rename_ids_;
-  absl::flat_hash_set<uint64_t> gpu_tracing_ids_;
+  absl::flat_hash_set<uint64_t> amdgpu_cs_ioctl_ids_;
+  absl::flat_hash_set<uint64_t> amdgpu_sched_run_job_ids_;
+  absl::flat_hash_set<uint64_t> dma_fence_signaled_ids_;
   absl::flat_hash_set<uint64_t> callchain_sampling_ids_;
 
   std::atomic<bool> stop_deferred_thread_ = false;
   std::vector<std::unique_ptr<PerfEvent>> deferred_events_;
   std::mutex deferred_events_mutex_;
   ContextSwitchManager context_switch_manager_;
-  std::shared_ptr<PerfEventProcessor2> uprobes_event_processor_;
-  std::shared_ptr<GpuTracepointEventProcessor> gpu_event_processor_;
+  std::unique_ptr<PerfEventProcessor2> uprobes_event_processor_;
+  std::unique_ptr<GpuTracepointEventProcessor> gpu_event_processor_;
 
   struct EventStats {
     void Reset() {

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -62,7 +62,13 @@ class TracerThread {
   bool OpenMmapTask(const std::vector<int32_t>& cpus);
   bool OpenSampling(const std::vector<int32_t>& cpus);
 
-  static bool OpenRingBuffersForTracepointAndRedirectOnExistingIfNecessary(
+  static void OpenRingBuffersOrRedirectOnExisting(
+      const absl::flat_hash_map<int32_t, int>& fds_per_cpu,
+      absl::flat_hash_map<int32_t, int>* ring_buffer_fds_per_cpu,
+      std::vector<PerfEventRingBuffer>* ring_buffers,
+      uint64_t ring_buffer_size_kb, std::string_view buffer_name_prefix);
+
+  static bool OpenRingBuffersForTracepoint(
       const char* tracepoint_category, const char* tracepoint_name,
       const std::vector<int32_t>& cpus, std::vector<int>* tracing_fds,
       absl::flat_hash_set<uint64_t>* tracepoint_ids,

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -77,10 +77,6 @@ class TracerThread {
   bool OpenTracepoints(const std::vector<int32_t>& cpus);
 
   bool InitGpuTracepointEventProcessor();
-  static bool OpenRingBufferForGpuTracepoint(
-      const char* tracepoint_category, const char* tracepoint_name, int32_t cpu,
-      std::vector<int>* gpu_tracing_fds,
-      std::vector<PerfEventRingBuffer>* gpu_ring_buffers);
   bool OpenGpuTracepoints(const std::vector<int32_t>& cpus);
 
   void ProcessContextSwitchCpuWideEvent(const perf_event_header& header,

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -94,7 +94,7 @@ class TracerThread {
   std::vector<std::unique_ptr<PerfEvent>> ConsumeDeferredEvents();
   void ProcessDeferredEvents();
 
-  void UpdateThreadNamesIfDelayElapsed();
+  void RetrieveThreadNames();
 
   void PrintStatsIfTimerElapsed();
 
@@ -144,10 +144,6 @@ class TracerThread {
   ContextSwitchManager context_switch_manager_;
   std::shared_ptr<PerfEventProcessor2> uprobes_event_processor_;
   std::shared_ptr<GpuTracepointEventProcessor> gpu_event_processor_;
-
-  static constexpr uint64_t THREAD_NAMES_UPDATE_DELAY_MS = 1000;
-  absl::flat_hash_map<pid_t, std::string> thread_names_;
-  uint64_t last_thread_names_update = 0;
 
   struct EventStats {
     void Reset() {

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -134,6 +134,7 @@ class TracerThread {
   absl::flat_hash_set<uint64_t> uprobes_ids_;
   absl::flat_hash_set<uint64_t> uretprobes_ids_;
   absl::flat_hash_set<uint64_t> stack_sampling_ids_;
+  absl::flat_hash_set<uint64_t> task_newtask_ids_;
   absl::flat_hash_set<uint64_t> task_rename_ids_;
   absl::flat_hash_set<uint64_t> gpu_tracing_ids_;
   absl::flat_hash_set<uint64_t> callchain_sampling_ids_;

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -62,6 +62,14 @@ class TracerThread {
   bool OpenMmapTask(const std::vector<int32_t>& cpus);
   bool OpenSampling(const std::vector<int32_t>& cpus);
 
+  static bool OpenRingBuffersForTracepointAndRedirectOnExistingIfNecessary(
+      const char* tracepoint_category, const char* tracepoint_name,
+      const std::vector<int32_t>& cpus, std::vector<int>* tracing_fds,
+      absl::flat_hash_set<uint64_t>* tracepoint_ids,
+      absl::flat_hash_map<int32_t, int>* tracepoint_ring_buffer_fds_per_cpu,
+      std::vector<PerfEventRingBuffer>* ring_buffers);
+  bool OpenTracepoints(const std::vector<int32_t>& cpus);
+
   bool InitGpuTracepointEventProcessor();
   static bool OpenRingBufferForGpuTracepoint(
       const char* tracepoint_category, const char* tracepoint_name, int32_t cpu,
@@ -103,6 +111,7 @@ class TracerThread {
   static constexpr uint64_t UPROBES_RING_BUFFER_SIZE_KB = 8 * 1024;
   static constexpr uint64_t MMAP_TASK_RING_BUFFER_SIZE_KB = 64;
   static constexpr uint64_t SAMPLING_RING_BUFFER_SIZE_KB = 16 * 1024;
+  static constexpr uint64_t TRACEPOINTS_RING_BUFFER_SIZE_KB = 256;
   static constexpr uint64_t GPU_TRACING_RING_BUFFER_SIZE_KB = 256;
 
   static constexpr uint32_t IDLE_TIME_ON_EMPTY_RING_BUFFERS_US = 100;
@@ -125,6 +134,7 @@ class TracerThread {
   absl::flat_hash_set<uint64_t> uprobes_ids_;
   absl::flat_hash_set<uint64_t> uretprobes_ids_;
   absl::flat_hash_set<uint64_t> stack_sampling_ids_;
+  absl::flat_hash_set<uint64_t> task_rename_ids_;
   absl::flat_hash_set<uint64_t> gpu_tracing_ids_;
   absl::flat_hash_set<uint64_t> callchain_sampling_ids_;
 

--- a/OrbitLinuxTracing/Utils.cpp
+++ b/OrbitLinuxTracing/Utils.cpp
@@ -189,7 +189,7 @@ int GetTracepointId(const char* tracepoint_category,
   }
   int tp_id = -1;
   if (!absl::SimpleAtoi(file_content.value(), &tp_id)) {
-    ERROR("Error parsing tracepoint id for: %s:%s", tracepoint_category,
+    ERROR("Parsing tracepoint id for: %s:%s", tracepoint_category,
           tracepoint_name);
     return -1;
   }


### PR DESCRIPTION
Here's the change that tracks the two `task` tracepoints for thread names.
In particular, the last commit refactors quite a bit how GPU tracepoints are handled.

---
### Commits

#### Rename PerfEventSampleRaw to RawSamplePerfEvent for consistency
For consistency with the other `PerfEvent` classes.
#### Replace const std::unique_ptr<T>& with const T& in PushEvent
#### Define task_rename_tracepoint in new Tracepoints.h, TaskRenamePerfEvent
#### Use perf_event_open to obtain task:task_rename tracepoint events
Only use them to print logs for now.
#### Use the task_rename tracepoint to notify listener_ of a new ThreadName
Instead of periodically calling `UpdateThreadNamesIfDelayElapsed`.
#### Also use the task:task_newtask tracepoint for thread names
When a new thread is created, it inherits the name of the parent. We want to
catch this as the thread doesn't necessarily sets its own name.
#### Make GPU events part of PerfEvent's hierarchy like other tracepoints
This aims to unify how we handle GPU tracepoints and other tracepoints.
Moves the format of GPU tracepoints to `Tracepoints.h`.
Makes the events part of the `PerfEvent` class's hierarchy.
Moves parsing GPU tracepoints from `GpuTracepointEventProcessor` to their
`PerfEvent` class.
Unifies reading tracepoints with `ConsumeTracepointPerfEvent`.
Moves GPU tracepoints' ids out of `GpuTracepointEventProcessor`.
Moves the classification of GPU tracepoints to `TracerThread`, which now records
separate stream ids for GPU tracepoints too.