### PR TITLE
Fix 32bit windows compilation

### DIFF
--- a/OrbitCore/Injection.cpp
+++ b/OrbitCore/Injection.cpp
@@ -196,7 +196,7 @@ HANDLE Injection::GetTargetProcessHandle(const std::string& a_Target,
 
 #ifndef _WIN64
       // If the process is 64 bit, skip it.
-      if (ProcessUtils::Is64Bit(process_handle)) {
+      if (BOOL is_64_bit = false; !IsWow64Process(process_handle, &is_64_bit) || !is_64_bit) {
         CloseHandle(process_handle);
         continue;
       }

--- a/OrbitFramePointerValidator/FramePointerValidator.cpp
+++ b/OrbitFramePointerValidator/FramePointerValidator.cpp
@@ -37,7 +37,7 @@ std::optional<std::vector<CodeBlock>> FramePointerValidator::GetFpoFunctions(
     }
 
     FunctionFramePointerValidator validator{
-        handle, binary.data() + function.offset(), function.size()};
+        handle, binary.data() + function.offset(), static_cast<size_t>(function.size())};
 
     if (!validator.Validate()) {
       result.push_back(function);


### PR DESCRIPTION
This is needed for OrbitDLL to compile and I personally need that to build packages for the _x86 profiles.