### PR TITLE
Added missing include of functional

### DIFF
--- a/OrbitQt/orbitdisassemblydialog.h
+++ b/OrbitQt/orbitdisassemblydialog.h
@@ -6,6 +6,7 @@
 #define ORBITDISASSEMBLYDIALOG_H
 
 #include <QDialog>
+#include <functional>
 #include <string>
 
 namespace Ui {


### PR DESCRIPTION
This include was missing in OrbitQt/orbitdisassemblydialog.h and it
fails to compile dependending on the version of standard library.