### PR TITLE
Mark samples selected in both the thread's and the process's EventTrack

### DIFF
--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -89,7 +89,8 @@ void EventTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
   const Color kGreenSelection(0, 255, 0, 255);
   Color selectedColor[2];
   Fill(selectedColor, kGreenSelection);
-  for (CallstackEvent& event : selected_callstack_events_) {
+  for (const CallstackEvent& event :
+       time_graph_->GetSelectedCallstackEvents(m_ThreadId)) {
     Vec2 pos(time_graph_->GetWorldFromTick(event.m_Time), m_Pos[1]);
     batcher->AddVerticalLine(pos, -track_height, z, kGreenSelection,
                              PickingID::LINE);
@@ -137,8 +138,7 @@ void EventTrack::SelectEvents() {
   Vec2& from = m_MousePos[0];
   Vec2& to = m_MousePos[1];
 
-  selected_callstack_events_ =
-      time_graph_->SelectEvents(from[0], to[0], m_ThreadId);
+  time_graph_->SelectEvents(from[0], to[0], m_ThreadId);
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/EventTrack.h
+++ b/OrbitGl/EventTrack.h
@@ -30,7 +30,6 @@ class EventTrack : public Track {
   void SetPos(float a_X, float a_Y);
   void SetSize(float a_SizeX, float a_SizeY);
   void SetColor(Color color) { m_Color = color; }
-  void ClearSelectedEvents() { selected_callstack_events_.clear(); }
   bool IsEmpty() const;
 
  protected:
@@ -45,5 +44,4 @@ class EventTrack : public Track {
   Vec2 m_MousePos[2];
   bool m_Picked;
   Color m_Color;
-  std::vector<CallstackEvent> selected_callstack_events_;
 };

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -53,7 +53,6 @@ class ThreadTrack : public Track {
   std::vector<std::shared_ptr<TimerChain>> GetAllChains() override;
 
   void SetEventTrackColor(Color color);
-  void ClearSelectedEvents() { event_track_->ClearSelectedEvents(); }
   bool IsEmpty() const;
   virtual bool HasEventTrack() const { return true; }
 

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -37,6 +37,7 @@ class TimeGraph {
   void SortTracks();
   std::vector<CallstackEvent> SelectEvents(float a_WorldStart, float a_WorldEnd,
                                            ThreadID a_TID);
+  const std::vector<CallstackEvent>& GetSelectedCallstackEvents(ThreadID tid);
 
   void ProcessTimer(const Timer& a_Timer);
   void UpdateMaxTimeStamp(TickType a_Time);
@@ -67,8 +68,10 @@ class TimeGraph {
   void Select(const TextBox* a_TextBox) { SelectRight(a_TextBox); }
   void SelectLeft(const TextBox* a_TextBox);
   void SelectRight(const TextBox* a_TextBox);
-  const TextBox* FindPreviousFunctionCall(uint64_t function_address, TickType current_time) const;
-  const TextBox* FindNextFunctionCall(uint64_t function_address, TickType current_time) const;
+  const TextBox* FindPreviousFunctionCall(uint64_t function_address,
+                                          TickType current_time) const;
+  const TextBox* FindNextFunctionCall(uint64_t function_address,
+                                      TickType current_time) const;
   void SelectAndZoom(const TextBox* a_TextBox);
   double GetCaptureTimeSpanUs();
   double GetCurrentTimeSpanUs();
@@ -87,6 +90,7 @@ class TimeGraph {
   }
   TextRenderer* GetTextRenderer() { return &m_TextRendererStatic; }
   void SetStringManager(std::shared_ptr<StringManager> str_manager);
+  StringManager* GetStringManager() { return string_manager_.get(); }
   void SetCanvas(GlCanvas* a_Canvas);
   GlCanvas* GetCanvas() { return m_Canvas; }
   void SetFontSize(int a_FontSize);
@@ -112,7 +116,6 @@ class TimeGraph {
   void OnDown();
 
   Color GetThreadColor(ThreadID tid) const;
-  StringManager* GetStringManager() { return string_manager_.get(); }
 
   void SetCurrentTextBoxes(const absl::flat_hash_map<uint64_t, const TextBox*>& boxes) {
     overlay_current_textboxes_ = boxes;
@@ -184,6 +187,9 @@ class TimeGraph {
   std::set<uint32_t> cores_seen_;
   std::shared_ptr<SchedulerTrack> scheduler_track_;
   std::shared_ptr<ThreadTrack> process_track_;
+
+  absl::flat_hash_map<ThreadID, std::vector<CallstackEvent>>
+      selected_callstack_events_per_thread_;
 
   std::shared_ptr<StringManager> string_manager_;
 };


### PR DESCRIPTION
Bug: http://b/156082703

---
Another options would be to keep `EventTrack::selected_callstack_events_` and have `TimeGraph::SelectEvents` set/fill it.