### PR TITLE
Do not draw green timing box when picking, so that picking text boxes is also possible under the green timing box

### DIFF
--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -555,7 +555,7 @@ void CaptureWindow::Draw() {
 
   time_graph_.Draw(this, m_Picking);
 
-  if (m_SelectStart[0] != m_SelectStop[0]) {
+  if (!m_Picking && m_SelectStart[0] != m_SelectStop[0]) {
     TickType minTime = std::min(m_TimeStart, m_TimeStop);
     TickType maxTime = std::max(m_TimeStart, m_TimeStop);
 


### PR DESCRIPTION
Since picking is based on color, drawing the timing box over the background will make it impossible to pick the text boxes underneath. 