### PR TITLE
Move grpc_helper from gRPC package into repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,13 +69,6 @@ list(PREPEND CMAKE_FIND_ROOT_PATH "${CMAKE_BINARY_DIR}")
 # scripts in a cross compilation environment.
 list(APPEND CMAKE_FIND_ROOT_PATH "${CONAN_CMAKE_MODULE_PATH}")
 
-# Temporary workaround for GRPC as long as
-# conan does not support library components yet.
-# This ensures that cmake will use the library-provided
-# cmake config files instead of the conan-generated ones.
-list(PREPEND CMAKE_PREFIX_PATH "${CONAN_GRPC_ROOT}")
-list(PREPEND CMAKE_FIND_ROOT_PATH "${CONAN_GRPC_ROOT}")
-
 if(NOT WIN32 AND WITH_GUI)
   find_package(X11 REQUIRED)
 endif()
@@ -88,16 +81,10 @@ find_package(multicore REQUIRED)
 find_package(concurrentqueue REQUIRED)
 find_package(gte REQUIRED)
 find_package(protobuf CONFIG REQUIRED)
+find_package(grpc CONFIG REQUIRED)
 
-# Conan's protobuf target is called protobuf::protobuf while
-# the original one is called protobuf::libprotobuf, so we create
-# an alias here to make it work with packages requiring the original
-# name like gRPC.
-add_library(protobuf::libprotobuf INTERFACE IMPORTED)
-target_link_libraries(protobuf::libprotobuf INTERFACE protobuf::protobuf)
 include("third_party/protobuf/protobuf-generate.cmake")
-
-find_package(gRPC CONFIG REQUIRED)
+include("cmake/grpc_helper.cmake")
 
 
 if(WITH_GUI)

--- a/cmake/grpc_helper.cmake
+++ b/cmake/grpc_helper.cmake
@@ -1,0 +1,47 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved. Use of this source
+# code is governed by a BSD-style license that can be found in the LICENSE file.
+
+cmake_minimum_required(VERSION 3.12)
+
+function(grpc_helper)
+  find_program(_HELPER_PROTOC protoc)
+  find_program(_HELPER_GRPC_CPP_PLUGIN grpc_cpp_plugin)
+
+  get_target_property(_sources ${ARGV0} SOURCES)
+  set(new_sources "")
+  set(bin_dir "${CMAKE_CURRENT_BINARY_DIR}/grpc_codegen")
+
+  foreach(source_file ${_sources})
+    if(source_file MATCHES ".*\.proto")
+      get_filename_component(basename ${source_file} NAME_WE)
+
+      get_filename_component(src_filepath ${source_file} ABSOLUTE)
+      get_filename_component(src_folder ${src_filepath} PATH)
+
+      set(proto_cpp "${bin_dir}/${basename}.pb.cc")
+      set(proto_h "${bin_dir}/${basename}.pb.h")
+      set(grpc_cpp "${bin_dir}/${basename}.grpc.pb.cc")
+      set(grpc_h "${bin_dir}/${basename}.grpc.pb.h")
+
+      add_custom_command(
+        OUTPUT "${proto_cpp}" "${proto_h}" "${grpc_cpp}" "${grpc_h}"
+        COMMAND ${CMAKE_COMMAND} ARGS -E make_directory "${bin_dir}"
+        COMMAND
+          ${_HELPER_PROTOC} ARGS --grpc_out "${bin_dir}" --cpp_out "${bin_dir}"
+          -I ${src_folder} --plugin=protoc-gen-grpc="${_HELPER_GRPC_CPP_PLUGIN}"
+          "${src_filepath}"
+        MAIN_DEPENDENCY "${src_filepath}")
+
+      list(APPEND new_sources "${proto_cpp}")
+      list(APPEND new_sources "${grpc_cpp}")
+
+    endif()
+  endforeach()
+
+  list(FILTER _sources EXCLUDE REGEX ".*\.proto")
+  list(APPEND _sources ${new_sources})
+  set_target_properties(${ARGV0} PROPERTIES SOURCES "${_sources}")
+
+  target_link_libraries(${ARGV0} PUBLIC grpc::grpc)
+  target_include_directories(${ARGV0} PUBLIC ${bin_dir})
+endfunction()


### PR DESCRIPTION
This change allows us to use the conan-generated cmake config files
instead of the grpc-package supplied ones. That simplifies the cmake
config in a cross compilation environment and allowed to remove some
hacks from the top-level CMakeLists.txt-file.

Additionally some changes to the grpc_helper function work around a bug
in MSBuild 16.* which always triggered a rebuild of OrbitProtos.