### PR TITLE
Removed unused header-include from CrashHandler.cpp

### DIFF
--- a/OrbitQt/CrashHandler.cpp
+++ b/OrbitQt/CrashHandler.cpp
@@ -7,7 +7,6 @@
 #include "Core.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitVersion.h"
-#include "OrbitDbgHelp.h"
 #include "ScopeTimer.h"
 #include "client/settings.h"
 


### PR DESCRIPTION
I'm currently recompiling a lot of stuff and this header lead to "ambiguous symbol" error messages and it's not needed anyway here, so it shoudln't be included.