### PR TITLE
Added ModuleList refresh button

### DIFF
--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -208,6 +208,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
                    const std::shared_ptr<Preset>& preset = nullptr);
   void LoadModulesFromPreset(const std::shared_ptr<Process>& process,
                              const std::shared_ptr<Preset>& preset);
+  void UpdateModuleList(int32_t pid);
 
   void UpdateSamplingReport();
   void LoadPreset(const std::shared_ptr<Preset>& session);

--- a/OrbitGl/DataView.h
+++ b/OrbitGl/DataView.h
@@ -73,6 +73,8 @@ class DataView {
     return false;
   }
   virtual std::string GetLabel() { return ""; }
+  virtual bool HasRefreshButton() const { return false; }
+  virtual void OnRefreshButtonClicked() {}
   virtual void SetGlPanel(class GlPanel* /*a_GlPanel*/) {}
   virtual void LinkDataView(DataView* /*a_DataView*/) {}
   virtual bool ScrollToBottom() { return false; }

--- a/OrbitGl/ModulesDataView.cpp
+++ b/OrbitGl/ModulesDataView.cpp
@@ -14,10 +14,8 @@
 ABSL_FLAG(bool, enable_frame_pointer_validator, false,
           "Enable validation of frame pointers");
 
-//-----------------------------------------------------------------------------
 ModulesDataView::ModulesDataView() : DataView(DataViewType::MODULES) {}
 
-//-----------------------------------------------------------------------------
 const std::vector<DataView::Column>& ModulesDataView::GetColumns() {
   static const std::vector<Column> columns = [] {
     std::vector<Column> columns;
@@ -33,7 +31,6 @@ const std::vector<DataView::Column>& ModulesDataView::GetColumns() {
   return columns;
 }
 
-//-----------------------------------------------------------------------------
 std::string ModulesDataView::GetValue(int row, int col) {
   const ModuleData* module = GetModule(row);
 
@@ -53,14 +50,12 @@ std::string ModulesDataView::GetValue(int row, int col) {
   }
 }
 
-//-----------------------------------------------------------------------------
 #define ORBIT_PROC_SORT(Member)                                          \
   [&](int a, int b) {                                                    \
     return OrbitUtils::Compare(modules_[a]->Member, modules_[b]->Member, \
                                ascending);                               \
   }
 
-//-----------------------------------------------------------------------------
 void ModulesDataView::DoSort() {
   bool ascending = m_SortingOrders[m_SortingColumn] == SortingOrder::Ascending;
   std::function<bool(int a, int b)> sorter = nullptr;
@@ -90,12 +85,10 @@ void ModulesDataView::DoSort() {
   }
 }
 
-//-----------------------------------------------------------------------------
 const std::string ModulesDataView::MENU_ACTION_MODULES_LOAD = "Load Symbols";
 const std::string ModulesDataView::MENU_ACTION_MODULES_VERIFY =
     "Verify Frame Pointers";
 
-//-----------------------------------------------------------------------------
 std::vector<std::string> ModulesDataView::GetContextMenu(
     int clicked_index, const std::vector<int>& selected_indices) {
   bool enable_load = false;
@@ -122,7 +115,6 @@ std::vector<std::string> ModulesDataView::GetContextMenu(
   return menu;
 }
 
-//-----------------------------------------------------------------------------
 void ModulesDataView::OnContextMenu(const std::string& action, int menu_index,
                                     const std::vector<int>& item_indices) {
   if (action == MENU_ACTION_MODULES_LOAD) {
@@ -152,7 +144,6 @@ void ModulesDataView::OnContextMenu(const std::string& action, int menu_index,
   }
 }
 
-//-----------------------------------------------------------------------------
 void ModulesDataView::DoFilter() {
   std::vector<uint32_t> indices;
   std::vector<std::string> tokens = absl::StrSplit(ToLower(m_Filter), ' ');
@@ -182,7 +173,6 @@ void ModulesDataView::DoFilter() {
   OnSort(m_SortingColumn, {});
 }
 
-//-----------------------------------------------------------------------------
 void ModulesDataView::SetModules(int32_t process_id,
                                  const std::vector<ModuleData*>& modules) {
   process_id_ = process_id;
@@ -196,12 +186,14 @@ void ModulesDataView::SetModules(int32_t process_id,
   OnDataChanged();
 }
 
-//-----------------------------------------------------------------------------
+void ModulesDataView::OnRefreshButtonClicked() {
+  GOrbitApp->UpdateModuleList(Capture::GTargetProcess->GetID());
+}
+
 const ModuleData* ModulesDataView::GetModule(uint32_t row) const {
   return modules_[m_Indices[row]];
 }
 
-//-----------------------------------------------------------------------------
 bool ModulesDataView::GetDisplayColor(int row, int /*column*/,
                                       unsigned char& red, unsigned char& green,
                                       unsigned char& blue) {

--- a/OrbitGl/ModulesDataView.h
+++ b/OrbitGl/ModulesDataView.h
@@ -24,6 +24,8 @@ class ModulesDataView : public DataView {
   bool GetDisplayColor(int row, int column, unsigned char& red,
                        unsigned char& green, unsigned char& blue) override;
   std::string GetLabel() override { return "Modules"; }
+  bool HasRefreshButton() const override { return true; }
+  void OnRefreshButtonClicked() override;
 
   void SetModules(int32_t process_id, const std::vector<ModuleData*>& modules);
 

--- a/OrbitQt/orbitdataviewpanel.cpp
+++ b/OrbitQt/orbitdataviewpanel.cpp
@@ -9,17 +9,14 @@
 
 #include "ui_orbitdataviewpanel.h"
 
-//-----------------------------------------------------------------------------
 OrbitDataViewPanel::OrbitDataViewPanel(QWidget* parent)
     : QWidget(parent), ui(new Ui::OrbitDataViewPanel) {
   ui->setupUi(this);
   ui->label->hide();
 }
 
-//-----------------------------------------------------------------------------
 OrbitDataViewPanel::~OrbitDataViewPanel() { delete ui; }
 
-//-----------------------------------------------------------------------------
 void OrbitDataViewPanel::Initialize(DataView* data_view,
                                     SelectionType selection_type,
                                     FontType font_type, bool is_main_instance) {
@@ -35,38 +32,43 @@ void OrbitDataViewPanel::Initialize(DataView* data_view,
     this->ui->label->show();
   }
 
+  if (ui->treeView->HasRefreshButton()) {
+    ui->refreshButton->setIcon(
+        QApplication::style()->standardIcon(QStyle::SP_BrowserReload));
+    ui->refreshButton->show();
+  } else {
+    ui->refreshButton->hide();
+  }
+
   data_view->SetUiFilterCallback(
       [this](const std::string& filter) { SetFilter(filter.c_str()); });
 }
 
-//-----------------------------------------------------------------------------
 OrbitTreeView* OrbitDataViewPanel::GetTreeView() { return ui->treeView; }
 
-//-----------------------------------------------------------------------------
 QLineEdit* OrbitDataViewPanel::GetFilterLineEdit() {
   return ui->FilterLineEdit;
 }
 
-//-----------------------------------------------------------------------------
 void OrbitDataViewPanel::Link(OrbitDataViewPanel* a_Panel) {
   ui->treeView->Link(a_Panel->ui->treeView);
 }
 
-//-----------------------------------------------------------------------------
 void OrbitDataViewPanel::Refresh() { ui->treeView->Refresh(); }
 
-//-----------------------------------------------------------------------------
 void OrbitDataViewPanel::SetDataModel(DataView* model) {
   ui->treeView->SetDataModel(model);
 }
 
-//-----------------------------------------------------------------------------
 void OrbitDataViewPanel::SetFilter(const QString& a_Filter) {
   ui->FilterLineEdit->setText(a_Filter);
   ui->treeView->OnFilter(a_Filter);
 }
 
-//-----------------------------------------------------------------------------
 void OrbitDataViewPanel::on_FilterLineEdit_textEdited(const QString& a_Text) {
   ui->treeView->OnFilter(a_Text);
+}
+
+void OrbitDataViewPanel::on_refreshButton_clicked() {
+  ui->treeView->OnRefreshButtonClicked();
 }

--- a/OrbitQt/orbitdataviewpanel.h
+++ b/OrbitQt/orbitdataviewpanel.h
@@ -32,6 +32,7 @@ class OrbitDataViewPanel : public QWidget {
 
  private slots:
   void on_FilterLineEdit_textEdited(const QString& a_Text);
+  void on_refreshButton_clicked();
 
  private:
   Ui::OrbitDataViewPanel* ui;

--- a/OrbitQt/orbitdataviewpanel.ui
+++ b/OrbitQt/orbitdataviewpanel.ui
@@ -47,6 +47,9 @@
      <item>
       <widget class="QLineEdit" name="FilterLineEdit"/>
      </item>
+     <item>
+      <widget class="QPushButton" name="refreshButton"/>
+     </item>
     </layout>
    </item>
    <item row="1" column="0">

--- a/OrbitQt/orbittreeview.cpp
+++ b/OrbitQt/orbittreeview.cpp
@@ -25,7 +25,6 @@
 #include "DataView.h"
 #include "orbitglwidget.h"
 
-//-----------------------------------------------------------------------------
 OrbitTreeView::OrbitTreeView(QWidget* parent)
     : QTreeView(parent), auto_resize_(true) {
   header()->setSortIndicatorShown(true);
@@ -51,7 +50,6 @@ OrbitTreeView::OrbitTreeView(QWidget* parent)
           SLOT(OnRangeChanged(int, int)));
 }
 
-//-----------------------------------------------------------------------------
 void OrbitTreeView::Initialize(DataView* data_view,
                                SelectionType selection_type,
                                FontType font_type) {
@@ -87,26 +85,22 @@ void OrbitTreeView::Initialize(DataView* data_view,
   }
 }
 
-//-----------------------------------------------------------------------------
 void OrbitTreeView::SetDataModel(DataView* data_view) {
   model_ = std::make_unique<OrbitTableModel>();
   model_->SetDataView(data_view);
   setModel(model_.get());
 }
 
-//-----------------------------------------------------------------------------
 void OrbitTreeView::OnSort(int section, Qt::SortOrder order) {
   model_->sort(section, order);
   Refresh();
 }
 
-//-----------------------------------------------------------------------------
 void OrbitTreeView::OnFilter(const QString& filter) {
   model_->OnFilter(filter);
   Refresh();
 }
 
-//-----------------------------------------------------------------------------
 void OrbitTreeView::OnTimer() {
   if (isVisible() && !model_->GetDataView()->SkipTimer()) {
     model_->OnTimer();
@@ -114,7 +108,6 @@ void OrbitTreeView::OnTimer() {
   }
 }
 
-//-----------------------------------------------------------------------------
 void OrbitTreeView::Refresh() {
   QModelIndexList list = selectionModel()->selectedIndexes();
 
@@ -140,7 +133,6 @@ void OrbitTreeView::Refresh() {
   }
 }
 
-//-----------------------------------------------------------------------------
 void OrbitTreeView::resizeEvent(QResizeEvent* event) {
   if (auto_resize_ && model_ && model_->GetDataView()) {
     QSize headerSize = size();
@@ -156,7 +148,6 @@ void OrbitTreeView::resizeEvent(QResizeEvent* event) {
   QTreeView::resizeEvent(event);
 }
 
-//-----------------------------------------------------------------------------
 void OrbitTreeView::Link(OrbitTreeView* link) {
   links_.push_back(link);
 
@@ -164,22 +155,18 @@ void OrbitTreeView::Link(OrbitTreeView* link) {
   model_->GetDataView()->LinkDataView(data_view);
 }
 
-//-----------------------------------------------------------------------------
 void OrbitTreeView::SetGlWidget(OrbitGLWidget* a_GlWidget) {
   model_->GetDataView()->SetGlPanel(a_GlWidget->GetPanel());
 }
 
-//-----------------------------------------------------------------------------
 void OrbitTreeView::drawRow(QPainter* painter,
                             const QStyleOptionViewItem& options,
                             const QModelIndex& index) const {
   QTreeView::drawRow(painter, options, index);
 }
 
-//-----------------------------------------------------------------------------
 QMenu* GContextMenu;
 
-//-----------------------------------------------------------------------------
 void OrbitTreeView::ShowContextMenu(const QPoint& pos) {
   QModelIndex index = indexAt(pos);
   if (index.isValid()) {
@@ -214,7 +201,6 @@ void OrbitTreeView::ShowContextMenu(const QPoint& pos) {
   }
 }
 
-//-----------------------------------------------------------------------------
 void OrbitTreeView::OnMenuClicked(const std::string& a_Action,
                                   int a_MenuIndex) {
   QModelIndexList selection_list = selectionModel()->selectedIndexes();
@@ -229,7 +215,6 @@ void OrbitTreeView::OnMenuClicked(const std::string& a_Action,
   }
 }
 
-//-----------------------------------------------------------------------------
 void OrbitTreeView::keyPressEvent(QKeyEvent* event) {
   if (event->matches(QKeySequence::Copy)) {
     QModelIndexList list = selectionModel()->selectedIndexes();
@@ -266,7 +251,6 @@ void OrbitTreeView::OnRowSelected(int row) {
   }
 }
 
-//-----------------------------------------------------------------------------
 void OrbitTreeView::OnRangeChanged(int /*a_Min*/, int a_Max) {
   DataView* data_view = model_->GetDataView();
   if (data_view->ScrollToBottom()) {
@@ -274,7 +258,6 @@ void OrbitTreeView::OnRangeChanged(int /*a_Min*/, int a_Max) {
   }
 }
 
-//-----------------------------------------------------------------------------
 std::string OrbitTreeView::GetLabel() {
   if (model_ != nullptr && model_->GetDataView() != nullptr) {
     return model_->GetDataView()->GetLabel();
@@ -282,7 +265,19 @@ std::string OrbitTreeView::GetLabel() {
   return "";
 }
 
-//-----------------------------------------------------------------------------
+bool OrbitTreeView::HasRefreshButton() const {
+  if (model_ != nullptr && model_->GetDataView() != nullptr) {
+    return model_->GetDataView()->HasRefreshButton();
+  }
+  return false;
+}
+
+void OrbitTreeView::OnRefreshButtonClicked() {
+  if (model_ != nullptr && model_->GetDataView() != nullptr) {
+    model_->GetDataView()->OnRefreshButtonClicked();
+  }
+}
+
 void OrbitTreeView::columnResized(int /*column*/, int /*oldSize*/,
                                   int /*newSize*/) {
   if (QApplication::mouseButtons() == Qt::LeftButton) {

--- a/OrbitQt/orbittreeview.h
+++ b/OrbitQt/orbittreeview.h
@@ -30,6 +30,8 @@ class OrbitTreeView : public QTreeView {
                         const QItemSelection& deselected) override;
   OrbitTableModel* GetModel() { return model_.get(); }
   std::string GetLabel();
+  bool HasRefreshButton() const;
+  void OnRefreshButtonClicked();
 
  protected:
   void drawRow(QPainter* painter, const QStyleOptionViewItem& options,


### PR DESCRIPTION
This is to address b/156732790

After running into several problems trying to reload modules periodically I decided the best fix for now is to implement a refresh button for the module list.

These problems are because with the current way things are done (`DataView`) there is no good way of saving a multi selection across data changes. This is mainly because `OrbitTreeView` discards the content of the multi selection events (`selectionChanged`) and just passes on a single selection event. This could be changed, but I think this work is not really justified if we want implement a more appropriate Qt Item model soon. 


