### PR TITLE
Improvements to iterator UI: Buttons repeat when pressed down, location shown is time based

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -468,7 +468,7 @@ std::string OrbitApp::GetCaptureFileName() {
 
 std::string OrbitApp::GetCaptureTime() {
   double time =
-      GCurrentTimeGraph ? GCurrentTimeGraph->GetSessionTimeSpanUs() : 0;
+      GCurrentTimeGraph ? GCurrentTimeGraph->GetCaptureTimeSpanUs() : 0;
   return GetPrettyTime(time * 0.001);
 }
 

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -585,7 +585,7 @@ void CaptureWindow::Draw() {
 
 //-----------------------------------------------------------------------------
 void CaptureWindow::DrawScreenSpace() {
-  double timeSpan = time_graph_.GetSessionTimeSpanUs();
+  double timeSpan = time_graph_.GetCaptureTimeSpanUs();
 
   Color col = m_Slider.GetBarColor();
   float height = m_Slider.GetPixelHeight();
@@ -628,7 +628,7 @@ void CaptureWindow::DrawScreenSpace() {
   ui_batcher_.AddBox(box, kBackgroundColor, PickingID::BOX);
 
   // Time bar
-  if (time_graph_.GetSessionTimeSpanUs() > 0) {
+  if (time_graph_.GetCaptureTimeSpanUs() > 0) {
     Box box(Vec2(0, height), Vec2(getWidth(), height), z);
     ui_batcher_.AddBox(box, Color(70, 70, 70, 200), PickingID::BOX);
   }
@@ -861,7 +861,7 @@ inline double GetIncrementMs(double a_MilliSeconds) {
 void CaptureWindow::RenderTimeBar() {
   static int numTimePoints = 10;
 
-  if (time_graph_.GetSessionTimeSpanUs() > 0) {
+  if (time_graph_.GetCaptureTimeSpanUs() > 0) {
     double millis = time_graph_.GetCurrentTimeSpanUs() * 0.001;
     double incr = millis / float(numTimePoints - 1);
     double unit = GetIncrementMs(incr);

--- a/OrbitGl/LiveFunctionsController.cpp
+++ b/OrbitGl/LiveFunctionsController.cpp
@@ -26,7 +26,8 @@ void LiveFunctionsController::Move() {
     GCurrentTimeGraph->Zoom(min_max.first, min_max.second);
     if (current_textboxes_.find(id_to_select_) != current_textboxes_.end()) {
       GCurrentTimeGraph->Select(current_textboxes_[id_to_select_]);
-      GCurrentTimeGraph->VerticallyScrollIntoView(current_textboxes_[id_to_select_]);
+      GCurrentTimeGraph->VerticallyScrollIntoView(
+          current_textboxes_[id_to_select_]);
     } else {
       CHECK(false);
     }
@@ -42,8 +43,7 @@ bool LiveFunctionsController::OnAllNextButton() {
   uint64_t min_timestamp = std::numeric_limits<uint64_t>::max();
   for (auto it : function_iterators_) {
     Function* function = it.second;
-    auto function_address =
-        FunctionUtils::GetAbsoluteAddress(*function);
+    auto function_address = FunctionUtils::GetAbsoluteAddress(*function);
     const TextBox* current_box = current_textboxes_.find(it.first)->second;
     const TextBox* box = GCurrentTimeGraph->FindNextFunctionCall(
         function_address, current_box->GetTimer().m_End);
@@ -70,8 +70,7 @@ bool LiveFunctionsController::OnAllPreviousButton() {
   uint64_t min_timestamp = std::numeric_limits<uint64_t>::max();
   for (auto it : function_iterators_) {
     Function* function = it.second;
-    auto function_address =
-        FunctionUtils::GetAbsoluteAddress(*function);
+    auto function_address = FunctionUtils::GetAbsoluteAddress(*function);
     const TextBox* current_box = current_textboxes_.find(it.first)->second;
     const TextBox* box = GCurrentTimeGraph->FindPreviousFunctionCall(
         function_address, current_box->GetTimer().m_End);
@@ -94,7 +93,7 @@ bool LiveFunctionsController::OnAllPreviousButton() {
 
 void LiveFunctionsController::OnNextButton(uint64_t id) {
   auto function_address =
-        FunctionUtils::GetAbsoluteAddress(*(function_iterators_[id]));
+      FunctionUtils::GetAbsoluteAddress(*(function_iterators_[id]));
   const TextBox* text_box = GCurrentTimeGraph->FindNextFunctionCall(
       function_address, current_textboxes_[id]->GetTimer().m_End);
   // If text_box is nullptr, then we have reached the right end of the timeline.
@@ -106,7 +105,7 @@ void LiveFunctionsController::OnNextButton(uint64_t id) {
 }
 void LiveFunctionsController::OnPreviousButton(uint64_t id) {
   auto function_address =
-        FunctionUtils::GetAbsoluteAddress(*(function_iterators_[id]));
+      FunctionUtils::GetAbsoluteAddress(*(function_iterators_[id]));
   const TextBox* text_box = GCurrentTimeGraph->FindPreviousFunctionCall(
       function_address, current_textboxes_[id]->GetTimer().m_End);
   // If text_box is nullptr, then we have reached the left end of the timeline.
@@ -135,10 +134,9 @@ void LiveFunctionsController::AddIterator(Function* function) {
   uint64_t id = next_iterator_id_;
   ++next_iterator_id_;
 
-  auto function_address =
-        FunctionUtils::GetAbsoluteAddress(*function);
+  auto function_address = FunctionUtils::GetAbsoluteAddress(*function);
   const TextBox* box = GCurrentTimeGraph->FindNextFunctionCall(
-        function_address,  std::numeric_limits<TickType>::lowest());
+      function_address, std::numeric_limits<TickType>::lowest());
 
   function_iterators_.insert(std::make_pair(id, function));
   current_textboxes_.insert(std::make_pair(id, box));
@@ -147,4 +145,19 @@ void LiveFunctionsController::AddIterator(Function* function) {
     add_iterator_callback_(id, function);
   }
   Move();
+}
+
+TickType LiveFunctionsController::GetStartTime(uint64_t index) {
+  auto& it = current_textboxes_.find(index);
+  if (it != current_textboxes_.end()) {
+    return it->second->GetTimer().m_Start;
+  }
+  return GetCaptureMin();
+}
+
+TickType LiveFunctionsController::GetCaptureMin() {
+  return GCurrentTimeGraph->GetCaptureMin();
+}
+TickType LiveFunctionsController::GetCaptureMax() {
+  return GCurrentTimeGraph->GetCaptureMax();
 }

--- a/OrbitGl/LiveFunctionsController.cpp
+++ b/OrbitGl/LiveFunctionsController.cpp
@@ -148,7 +148,7 @@ void LiveFunctionsController::AddIterator(Function* function) {
 }
 
 TickType LiveFunctionsController::GetStartTime(uint64_t index) {
-  auto& it = current_textboxes_.find(index);
+  const auto& it = current_textboxes_.find(index);
   if (it != current_textboxes_.end()) {
     return it->second->GetTimer().m_Start;
   }

--- a/OrbitGl/LiveFunctionsController.h
+++ b/OrbitGl/LiveFunctionsController.h
@@ -49,7 +49,6 @@ class LiveFunctionsController {
   absl::flat_hash_map<uint64_t, const TextBox*> current_textboxes_;
 
   std::function<void(uint64_t, Function*)> add_iterator_callback_;
-  std::function<void(double)> set_current_time_callback_;
 
   uint64_t next_iterator_id_ = 0;
 

--- a/OrbitGl/LiveFunctionsController.h
+++ b/OrbitGl/LiveFunctionsController.h
@@ -11,6 +11,7 @@
 
 #include "LiveFunctionsDataView.h"
 #include "OrbitFunction.h"
+#include "Profiling.h"
 #include "TextBox.h"
 
 class LiveFunctionsController {
@@ -33,6 +34,10 @@ class LiveFunctionsController {
     add_iterator_callback_ = callback;
   }
 
+  TickType GetCaptureMin();
+  TickType GetCaptureMax();
+  TickType GetStartTime(uint64_t index);
+
   void AddIterator(Function* function);
 
  private:
@@ -44,6 +49,7 @@ class LiveFunctionsController {
   absl::flat_hash_map<uint64_t, const TextBox*> current_textboxes_;
 
   std::function<void(uint64_t, Function*)> add_iterator_callback_;
+  std::function<void(double)> set_current_time_callback_;
 
   uint64_t next_iterator_id_ = 0;
 

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -51,7 +51,7 @@ class TimeGraph {
   double GetUsFromTick(TickType time) const;
   double GetTimeWindowUs() const { return m_TimeWindowUs; }
   void GetWorldMinMax(float& a_Min, float& a_Max) const;
-  bool UpdateSessionMinMaxCounter();
+  bool UpdateCaptureMinMaxCounter();
 
   void Clear();
   void ZoomAll();
@@ -70,7 +70,7 @@ class TimeGraph {
   const TextBox* FindPreviousFunctionCall(uint64_t function_address, TickType current_time) const;
   const TextBox* FindNextFunctionCall(uint64_t function_address, TickType current_time) const;
   void SelectAndZoom(const TextBox* a_TextBox);
-  double GetSessionTimeSpanUs();
+  double GetCaptureTimeSpanUs();
   double GetCurrentTimeSpanUs();
   void NeedsRedraw() { m_NeedsRedraw = true; }
   bool IsRedrawNeeded() const { return m_NeedsRedraw; }
@@ -118,6 +118,13 @@ class TimeGraph {
     overlay_current_textboxes_ = boxes;
   }
 
+  TickType GetCaptureMin() {
+    return m_CaptureMinCounter;
+  }
+  TickType GetCaptureMax() {
+    return m_CaptureMaxCounter;
+  }
+
  protected:
   uint64_t GetGpuTimelineHash(const Timer& timer) const;
   std::shared_ptr<SchedulerTrack> GetOrCreateSchedulerTrack();
@@ -137,8 +144,8 @@ class TimeGraph {
   double m_RefTimeUs = 0;
   double m_MinTimeUs = 0;
   double m_MaxTimeUs = 0;
-  TickType m_SessionMinCounter = 0;
-  TickType m_SessionMaxCounter = 0;
+  TickType m_CaptureMinCounter = 0;
+  TickType m_CaptureMaxCounter = 0;
   std::map<ThreadID, uint32_t> m_EventCount;
   double m_TimeWindowUs = 0;
   float m_WorldStartX = 0;

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -51,7 +51,7 @@ class TimeGraph {
   double GetUsFromTick(TickType time) const;
   double GetTimeWindowUs() const { return m_TimeWindowUs; }
   void GetWorldMinMax(float& a_Min, float& a_Max) const;
-  bool UpdateCaptureMinMaxCounter();
+  bool UpdateCaptureMinMaxTimestamps();
 
   void Clear();
   void ZoomAll();
@@ -118,12 +118,8 @@ class TimeGraph {
     overlay_current_textboxes_ = boxes;
   }
 
-  TickType GetCaptureMin() {
-    return m_CaptureMinCounter;
-  }
-  TickType GetCaptureMax() {
-    return m_CaptureMaxCounter;
-  }
+  TickType GetCaptureMin() { return capture_min_timestamp_; }
+  TickType GetCaptureMax() { return capture_max_timestamp_; }
 
  protected:
   uint64_t GetGpuTimelineHash(const Timer& timer) const;
@@ -144,8 +140,8 @@ class TimeGraph {
   double m_RefTimeUs = 0;
   double m_MinTimeUs = 0;
   double m_MaxTimeUs = 0;
-  TickType m_CaptureMinCounter = 0;
-  TickType m_CaptureMaxCounter = 0;
+  TickType capture_min_timestamp_ = 0;
+  TickType capture_max_timestamp_ = 0;
   std::map<ThreadID, uint32_t> m_EventCount;
   double m_TimeWindowUs = 0;
   float m_WorldStartX = 0;

--- a/OrbitQt/orbiteventiterator.cpp
+++ b/OrbitQt/orbiteventiterator.cpp
@@ -42,39 +42,24 @@ void OrbitEventIterator::SetFunctionName(const std::string& function_name) {
   ui->Label->setTextWithElision(QString::fromStdString(function_name));
 }
 
-//-----------------------------------------------------------------------------
-void OrbitEventIterator::SetMaxCount(int max_count) {
-  max_count_ = max_count;
-  UpdateCountLabel();
+void OrbitEventIterator::SetMinMaxTime(TickType min_time, TickType max_time) {
+  min_time_ = min_time;
+  max_time_ = max_time;
+  current_time_ = std::min(current_time_, max_time_);
+  current_time_ = std::max(current_time_, min_time_);
+  UpdatePositionLabel();
+}
+void OrbitEventIterator::SetCurrentTime(TickType current_time) {
+  current_time_ = current_time;
+  UpdatePositionLabel();
 }
 
 //-----------------------------------------------------------------------------
-void OrbitEventIterator::SetIndex(int current_index) {
-  current_index_ = current_index;
-  UpdateCountLabel();
-}
-
-//-----------------------------------------------------------------------------
-void OrbitEventIterator::IncrementIndex() {
-  if (current_index_ < max_count_ - 1) {
-    ++current_index_;
-    UpdateCountLabel();
-  }
-}
-
-//-----------------------------------------------------------------------------
-void OrbitEventIterator::DecrementIndex() {
-  if (current_index_ > 0) {
-    --current_index_;
-    UpdateCountLabel();
-  }
-}
-
-//-----------------------------------------------------------------------------
-void OrbitEventIterator::UpdateCountLabel() {
-  // Indices start at 0, so we display index + 1 in the UI.
-  ui->CountLabel->setText(QString::fromStdString(
-      absl::StrFormat("%d / %d", current_index_ + 1, max_count_)));
+void OrbitEventIterator::UpdatePositionLabel() {
+  double fraction = static_cast<double>(current_time_ - min_time_) /
+                    static_cast<double>(max_time_ - min_time_);
+  ui->position_label_->setText(
+      QString::fromStdString(absl::StrFormat("%.6f", fraction)));
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitQt/orbiteventiterator.h
+++ b/OrbitQt/orbiteventiterator.h
@@ -12,6 +12,7 @@
 #include <QTextLayout>
 
 #include "absl/container/flat_hash_map.h"
+#include "Profiling.h"
 #include "types.h"
 
 namespace Ui {
@@ -38,11 +39,8 @@ class OrbitEventIterator : public QFrame {
   }
 
   void SetFunctionName(const std::string& function);
-  void SetMaxCount(int max_count);
-  void SetIndex(int current_index);
-
-  void IncrementIndex();
-  void DecrementIndex();
+  void SetMinMaxTime(TickType min_time_us, TickType max_time_us);
+  void SetCurrentTime(TickType current_time_us);
 
   void DisableButtons();
   void EnableButtons();
@@ -54,13 +52,15 @@ class OrbitEventIterator : public QFrame {
   void on_DeleteButton_clicked();
 
  protected:
-  void UpdateCountLabel();
+  void UpdatePositionLabel();
   Ui::OrbitEventIterator* ui;
   std::function<void(void)> next_button_callback_;
   std::function<void(void)> previous_button_callback_;
   std::function<void(void)> delete_button_callback_;
-  int max_count_ = 0;
-  int current_index_ = 0;
+
+  TickType min_time_;
+  TickType max_time_;
+  TickType current_time_;
 };
 
 #endif  // ORBIT_EVENT_ITERATOR_H_

--- a/OrbitQt/orbiteventiterator.ui
+++ b/OrbitQt/orbiteventiterator.ui
@@ -31,6 +31,9 @@
      <property name="text">
       <string>&lt;</string>
      </property>
+     <property name="autoRepeat">
+      <bool>true</bool>
+     </property>
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -43,6 +46,9 @@
     <widget class="QPushButton" name="NextButton">
      <property name="text">
       <string>&gt;</string>
+     </property>
+     <property name="autoRepeat">
+      <bool>true</bool>
      </property>
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -63,7 +69,7 @@
     </widget>
    </item>
    <item row="0" column="3">
-    <widget class="QLabel" name="CountLabel">
+    <widget class="QLabel" name="position_label_">
      <property name="alignment">
       <set>Qt::AlignRight | Qt::AlignVCenter</set>
      </property>

--- a/OrbitQt/orbitlivefunctions.cpp
+++ b/OrbitQt/orbitlivefunctions.cpp
@@ -21,7 +21,9 @@ OrbitLiveFunctions::OrbitLiveFunctions(QWidget* parent)
       return;
     }
     for (auto& iterator_ui : iterator_uis) {
-      iterator_ui.second->IncrementIndex();
+      uint64_t index = iterator_ui.first;
+      iterator_ui.second->SetCurrentTime(
+          this->live_functions_.GetStartTime(index));
     }
   });
   all_events_iterator_->SetPreviousButtonCallback([this]() {
@@ -29,7 +31,9 @@ OrbitLiveFunctions::OrbitLiveFunctions(QWidget* parent)
       return;
     }
     for (auto& iterator_ui : iterator_uis) {
-      iterator_ui.second->DecrementIndex();
+      uint64_t index = iterator_ui.first;
+      iterator_ui.second->SetCurrentTime(
+          this->live_functions_.GetStartTime(index));
     }
   });
   all_events_iterator_->SetFunctionName("All functions");
@@ -39,15 +43,14 @@ OrbitLiveFunctions::OrbitLiveFunctions(QWidget* parent)
 }
 
 //-----------------------------------------------------------------------------
-OrbitLiveFunctions::~OrbitLiveFunctions() {
-  delete ui;
-}
+OrbitLiveFunctions::~OrbitLiveFunctions() { delete ui; }
 
 //-----------------------------------------------------------------------------
 void OrbitLiveFunctions::Initialize(SelectionType selection_type,
                                     FontType font_type, bool is_main_instance) {
   DataView* data_view = &live_functions_.GetDataView();
-  ui->data_view_panel_->Initialize(data_view, selection_type, font_type, is_main_instance);
+  ui->data_view_panel_->Initialize(data_view, selection_type, font_type,
+                                   is_main_instance);
 }
 
 //-----------------------------------------------------------------------------
@@ -66,16 +69,12 @@ void OrbitLiveFunctions::AddIterator(size_t id, Function* function) {
   iterator_ui->SetNextButtonCallback([this, id]() {
     this->live_functions_.OnNextButton(id);
     auto it = this->iterator_uis.find(id);
-    if (it != this->iterator_uis.end()) {
-      it->second->IncrementIndex();
-    }
+    it->second->SetCurrentTime(this->live_functions_.GetStartTime(id));
   });
   iterator_ui->SetPreviousButtonCallback([this, id]() {
     this->live_functions_.OnPreviousButton(id);
     auto it = this->iterator_uis.find(id);
-    if (it != this->iterator_uis.end()) {
-      it->second->DecrementIndex();
-    }
+    it->second->SetCurrentTime(this->live_functions_.GetStartTime(id));
   });
   iterator_ui->SetDeleteButtonCallback([this, id]() {
     this->live_functions_.OnDeleteButton(id);
@@ -88,8 +87,10 @@ void OrbitLiveFunctions::AddIterator(size_t id, Function* function) {
     }
   });
   iterator_ui->SetFunctionName(function->pretty_name());
-  iterator_ui->SetMaxCount(function->stats()->m_Count);
-  iterator_ui->SetIndex(0);
+
+  iterator_ui->SetMinMaxTime(live_functions_.GetCaptureMin(),
+                             live_functions_.GetCaptureMax());
+  iterator_ui->SetCurrentTime(live_functions_.GetStartTime(id));
 
   iterator_uis.insert(std::make_pair(id, iterator_ui));
 


### PR DESCRIPTION
This PR combines two small improvements for the iterator UI:
1) The buttons just repeat firing a press down signal when the user keeps the button pressed down. This makes it easier to quickly move through the capture. Some variables and methods are renamed for more consistency. 
2) The current location of an iterator is now based on the timestamp and the global min/max timestamps. This may seem like a step back compared with the index, but it makes some future improvements easier. For example, jumping to min/max, setting the iterator to the currently selected textbox, and in general more arbitrary movements. 