### PR TITLE
Replace HANDLE macro by type-alias

### DIFF
--- a/OrbitCore/BaseTypes.h
+++ b/OrbitCore/BaseTypes.h
@@ -34,9 +34,7 @@ typedef DWORD64 EpochType;
 typedef int64_t __int64;
 #define TCHAR wchar_t
 #define MAX_PATH PATH_MAX
-#define HANDLE void*
-#define __int8 char
-#define LONG long
+using HANDLE = void*;
 typedef DWORD ULONG;
 typedef unsigned char byte;
 // struct TypeInfo{};


### PR DESCRIPTION
When including headers from the QtNetwork modules which defines an
internal `Qt::HANDLE` type a name-clash occurs. This can be fixed by
making our `HANDLE` a type-alias to `void*` instead of a preprocessor
macro.

Additionally I removed macros which haven't been in use anymore.