### PR TITLE
Get updated Y-position from only one box

### DIFF
--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -95,6 +95,10 @@ float ThreadTrack::GetYFromDepth(float track_y, uint32_t depth,
          layout.GetSpaceBetweenTracksAndThread() - box_height * (depth + 1);
 }
 
+float ThreadTrack::GetYFromDepth(uint32_t depth) {
+  return GetYFromDepth(m_Pos[1], depth, collapse_toggle_.IsCollapsed());
+}
+
 //-----------------------------------------------------------------------------
 void ThreadTrack::SetTimesliceText(const Timer& timer, double elapsed_us,
                                    float min_x, TextBox* text_box) {
@@ -201,8 +205,7 @@ void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
             static_cast<float>(normalized_length * world_width);
         float world_timer_x =
             static_cast<float>(world_start_x + normalized_start * world_width);
-        float world_timer_y =
-            GetYFromDepth(m_Pos[1], timer.m_Depth, is_collapsed);
+        float world_timer_y = GetYFromDepth(timer.m_Depth);
 
         bool is_visible_width = normalized_length * canvas->getWidth() > 1;
         bool is_selected = &text_box == Capture::GSelectedTextBox;

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -58,6 +58,7 @@ class ThreadTrack : public Track {
 
   int32_t GetThreadId() const { return thread_id_; }
   bool IsCollapsable() const override { return depth_ > 1; }
+  float GetYFromDepth(uint32_t depth);
 
  protected:
   void UpdateDepth(uint32_t depth) {

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -242,18 +242,19 @@ void TimeGraph::HorizontallyMoveIntoView(const TextBox* text_box,
 
 void TimeGraph::VerticallyMoveIntoView(const TextBox* text_box) {
   CHECK(text_box != nullptr);
-  // TODO: Sometimes the Y-coordinate is not set. We only need to update the
-  // Y-coordinate from this text box
-  UpdatePrimitives();
+  const Timer& timer = text_box->GetTimer();
+  auto thread_track = GetOrCreateThreadTrack(timer.m_TID);
+  auto text_box_y_position = thread_track->GetYFromDepth(timer.m_Depth);
 
   auto world_top_left_y = m_Canvas->GetWorldTopLeftY();
   auto top_margin =
       m_Layout.GetSchedulerTrackOffset() + m_Layout.GetVerticalMargin();
   auto down_margin = m_Layout.GetSliderWidth() + m_Layout.GetVerticalMargin();
   auto min_world_top_left_y =
-      text_box->GetPosY() + m_Layout.GetSpaceBetweenTracks() + top_margin;
-  auto max_world_top_left_y = text_box->GetPosY() + m_Canvas->GetWorldHeight() -
+      text_box_y_position + m_Layout.GetSpaceBetweenTracks() + top_margin;
+  auto max_world_top_left_y = text_box_y_position + m_Canvas->GetWorldHeight() -
                               text_box->GetSizeY() - down_margin;
+  CHECK (min_world_top_left_y <= max_world_top_left_y);
   world_top_left_y = std::min(world_top_left_y, max_world_top_left_y);
   world_top_left_y = std::max(world_top_left_y, min_world_top_left_y);
   m_Canvas->SetWorldTopLeftY(world_top_left_y);


### PR DESCRIPTION
We were updating all primitives in the screen to only get the updated y-position from only one text box. Now, we get directly from the corresponding thread track.