### PR TITLE
Do not zoom when moving the screen due to iterator movements

### DIFF
--- a/OrbitGl/LiveFunctionsController.cpp
+++ b/OrbitGl/LiveFunctionsController.cpp
@@ -17,7 +17,7 @@ std::pair<uint64_t, uint64_t> ComputeMinMaxTime(
   uint64_t max_time = std::numeric_limits<uint64_t>::min();
   for (auto& text_box : text_boxes) {
     min_time = std::min(min_time, text_box.second->GetTimer().m_Start);
-    max_time = std::max(max_time, text_box.second->GetTimer().m_End);
+    max_time = std::max(max_time, text_box.second->GetTimer().m_Start);
   }
   return std::make_pair(min_time, max_time);
 }
@@ -87,16 +87,8 @@ const TextBox* SnapToClosestStart(uint64_t absolute_function_address) {
 void LiveFunctionsController::Move() {
   if (!current_textboxes_.empty()) {
     auto min_max = ComputeMinMaxTime(current_textboxes_);
-    GCurrentTimeGraph->Zoom(min_max.first, min_max.second);
-    if (current_textboxes_.find(id_to_select_) != current_textboxes_.end()) {
-      GCurrentTimeGraph->Select(current_textboxes_[id_to_select_]);
-      GCurrentTimeGraph->VerticallyMoveIntoView(
-          current_textboxes_[id_to_select_]);
-    } else {
-      CHECK(false);
-    }
-  } else {
-    GCurrentTimeGraph->ZoomAll();
+    GCurrentTimeGraph->HorizontallyMoveIntoView(TimeGraph::kFullyVisible, 
+      min_max.first, min_max.second, 0.5);
   }
   GCurrentTimeGraph->SetCurrentTextBoxes(current_textboxes_);
 }

--- a/OrbitGl/LiveFunctionsController.cpp
+++ b/OrbitGl/LiveFunctionsController.cpp
@@ -87,8 +87,9 @@ const TextBox* SnapToClosestStart(uint64_t absolute_function_address) {
 void LiveFunctionsController::Move() {
   if (!current_textboxes_.empty()) {
     auto min_max = ComputeMinMaxTime(current_textboxes_);
-    GCurrentTimeGraph->HorizontallyMoveIntoView(TimeGraph::kFullyVisible, 
-      min_max.first, min_max.second, 0.5);
+    GCurrentTimeGraph->HorizontallyMoveIntoView(
+        TimeGraph::VisibilityType::kFullyVisible, min_max.first, min_max.second,
+        0.5);
   }
   GCurrentTimeGraph->SetCurrentTextBoxes(current_textboxes_);
 }

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -214,7 +214,8 @@ void TimeGraph::PanTime(int a_InitialX, int a_CurrentX, int a_Width,
   NeedsUpdate();
 }
 
-void TimeGraph::HorizontallyMoveIntoView(VisibilityType vis_type, TickType min, TickType max, double distance) {
+void TimeGraph::HorizontallyMoveIntoView(VisibilityType vis_type, TickType min,
+                                         TickType max, double distance) {
   if (IsVisible(vis_type, min, max)) {
     return;
   }
@@ -234,9 +235,11 @@ void TimeGraph::HorizontallyMoveIntoView(VisibilityType vis_type, TickType min, 
   NeedsUpdate();
 }
 
-void TimeGraph::HorizontallyMoveIntoView(VisibilityType vis_type, const TextBox* text_box,
+void TimeGraph::HorizontallyMoveIntoView(VisibilityType vis_type,
+                                         const TextBox* text_box,
                                          double distance) {
-  HorizontallyMoveIntoView(vis_type, text_box->GetTimer().m_Start, text_box->GetTimer().m_End);
+  HorizontallyMoveIntoView(vis_type, text_box->GetTimer().m_Start,
+                           text_box->GetTimer().m_End, distance);
 }
 
 void TimeGraph::VerticallyMoveIntoView(const TextBox* text_box) {

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -222,13 +222,21 @@ void TimeGraph::HorizontallyMoveIntoView(VisibilityType vis_type, TickType min,
 
   double start = MicroSecondsFromTicks(capture_min_timestamp_, min);
   double end = MicroSecondsFromTicks(capture_min_timestamp_, max);
+
+  double CurrentTimeWindowUs = m_MaxTimeUs - m_MinTimeUs;
+
+  if (vis_type == VisibilityType::kFullyVisible && CurrentTimeWindowUs < (end - start)){
+    Zoom(min, max);
+    return;
+  }
+
   double mid = start + ((end - start) / 2.0);
 
   // Mirror the final center position if we have to move left
   if (start < m_MinTimeUs) {
     distance = 1 - distance;
   }
-  double CurrentTimeWindowUs = m_MaxTimeUs - m_MinTimeUs;
+
   SetMinMax(mid - CurrentTimeWindowUs * (1 - distance),
             mid + CurrentTimeWindowUs * distance);
 
@@ -428,7 +436,7 @@ void TimeGraph::GetWorldMinMax(float& a_Min, float& a_Max) const {
 void TimeGraph::Select(const TextBox* a_TextBox) {
   TextBox* text_box = const_cast<TextBox*>(a_TextBox);
   Capture::GSelectedTextBox = text_box;
-  HorizontallyMoveIntoView(kPartlyVisible, a_TextBox);
+  HorizontallyMoveIntoView(VisibilityType::kPartlyVisible, a_TextBox);
   VerticallyMoveIntoView(a_TextBox);
 }
 
@@ -912,9 +920,9 @@ bool TimeGraph::IsPartlyVisible(TickType min, TickType max) const {
 
 bool TimeGraph::IsVisible(VisibilityType vis_type, TickType min, TickType max) const {
   switch(vis_type) {
-    case kPartlyVisible:
+    case VisibilityType::kPartlyVisible:
       return IsPartlyVisible(min, max);
-    case kFullyVisible:
+    case VisibilityType::kFullyVisible:
       return IsFullyVisible(min, max);
     default:
       return false;   

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -62,7 +62,12 @@ class TimeGraph {
   void SetMinMax(double a_MinTimeUs, double a_MaxTimeUs);
   void PanTime(int a_InitialX, int a_CurrentX, int a_Width,
                double a_InitialTime);
-  void HorizontallyMoveIntoView(const TextBox* text_box, double distance = 0.3);
+  enum VisibilityType {
+    kPartlyVisible,
+    kFullyVisible,
+  };
+  void HorizontallyMoveIntoView(VisibilityType vis_type, TickType min, TickType max, double distance = 0.3); 
+  void HorizontallyMoveIntoView(VisibilityType vis_type, const TextBox* text_box, double distance = 0.3);
   void VerticallyMoveIntoView(const TextBox* text_box);
   double GetTime(double a_Ratio);
   double GetTimeIntervalMicro(double a_Ratio);
@@ -86,7 +91,10 @@ class TimeGraph {
   void ToggleDrawText() { m_DrawText = !m_DrawText; }
   void SetThreadFilter(const std::string& a_Filter);
 
-  bool IsVisible(const Timer& a_Timer);
+  bool IsFullyVisible(TickType min, TickType max) const;
+  bool IsPartlyVisible(TickType min, TickType max) const;
+  bool IsVisible(VisibilityType vis_type, TickType min, TickType max) const;
+
   int GetNumDrawnTextBoxes() { return m_NumDrawnTextBoxes; }
   void SetPickingManager(class PickingManager* a_Manager) {
     m_PickingManager = a_Manager;
@@ -123,6 +131,7 @@ class TimeGraph {
 
   void SetCurrentTextBoxes(const absl::flat_hash_map<uint64_t, const TextBox*>& boxes) {
     overlay_current_textboxes_ = boxes;
+    NeedsRedraw();
   }
 
   TickType GetCaptureMin() { return capture_min_timestamp_; }

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -62,7 +62,7 @@ class TimeGraph {
   void SetMinMax(double a_MinTimeUs, double a_MaxTimeUs);
   void PanTime(int a_InitialX, int a_CurrentX, int a_Width,
                double a_InitialTime);
-  enum VisibilityType {
+  enum class VisibilityType {
     kPartlyVisible,
     kFullyVisible,
   };


### PR DESCRIPTION
This should be less confusing for users. In particular, this allows users to zoom out and see an overview of the iterator range.

The screen is still moved to make sure that current iterators are in view.