### PR TITLE
More descriptive tooltips for the capture window

### DIFF
--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -94,7 +94,7 @@ void Batcher::AddTriangle(Vec3 v0, Vec3 v1, Vec3 v2, Color color,
 }
 
 std::shared_ptr<PickingUserData> Batcher::GetUserData(PickingID a_ID) {
-  std::shared_ptr<PickingUserData>* data;
+  std::shared_ptr<PickingUserData>* data = nullptr;
   switch (a_ID.m_Type) {
     case PickingID::BOX:
       data = box_buffer_.m_UserData.SlowAt(a_ID.m_Id);

--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -9,112 +9,111 @@
 
 void Batcher::AddLine(const Line& line, const Color* colors,
                       PickingID::Type picking_type,
-                      std::shared_ptr<PickingUserData> user_data) {
+                      std::unique_ptr<PickingUserData> user_data) {
   Color picking_color = PickingID::GetColor(
       picking_type, line_buffer_.m_Lines.size(), batcher_id_);
   line_buffer_.m_Lines.push_back(line);
   line_buffer_.m_Colors.push_back(colors, 2);
   line_buffer_.m_PickingColors.push_back_n(picking_color, 2);
-  line_buffer_.m_UserData.push_back(user_data);
+  line_buffer_.m_UserData.push_back(std::move(user_data));
 }
 
 void Batcher::AddLine(const Line& line, Color color,
                       PickingID::Type picking_type,
-                      std::shared_ptr<PickingUserData> user_data) {
+                      std::unique_ptr<PickingUserData> user_data) {
   Color colors[2];
   Fill(colors, color);
-  AddLine(line, colors, picking_type, user_data);
+  AddLine(line, colors, picking_type, std::move(user_data));
 }
 
 void Batcher::AddLine(Vec2 from, Vec2 to, float z, Color color,
                       PickingID::Type picking_type,
-                      std::shared_ptr<PickingUserData> user_data) {
+                      std::unique_ptr<PickingUserData> user_data) {
   Line line;
   Color colors[2];
   Fill(colors, color);
   line.m_Beg = Vec3(from[0], from[1], z);
   line.m_End = Vec3(to[0], to[1], z);
-  AddLine(line, colors, picking_type, user_data);
+  AddLine(line, colors, picking_type, std::move(user_data));
 }
 
 void Batcher::AddVerticalLine(Vec2 pos, float size, float z, Color color,
                               PickingID::Type picking_type,
-                              std::shared_ptr<PickingUserData> user_data) {
+                              std::unique_ptr<PickingUserData> user_data) {
   Line line;
   Color colors[2];
   Fill(colors, color);
   line.m_Beg = Vec3(pos[0], pos[1], z);
   line.m_End = Vec3(pos[0], pos[1] + size, z);
-  AddLine(line, colors, picking_type, user_data);
+  AddLine(line, colors, picking_type, std::move(user_data));
 }
 
 void Batcher::AddBox(const Box& a_Box, const Color* colors,
                      PickingID::Type picking_type,
-                     std::shared_ptr<PickingUserData> user_data) {
+                     std::unique_ptr<PickingUserData> user_data) {
   Color picking_color = PickingID::GetColor(
       picking_type, box_buffer_.m_Boxes.size(), batcher_id_);
   box_buffer_.m_Boxes.push_back(a_Box);
   box_buffer_.m_Colors.push_back(colors, 4);
   box_buffer_.m_PickingColors.push_back_n(picking_color, 4);
-  box_buffer_.m_UserData.push_back(user_data);
+  box_buffer_.m_UserData.push_back(std::move(user_data));
 }
 
 void Batcher::AddBox(const Box& a_Box, Color color,
                      PickingID::Type picking_type,
-                     std::shared_ptr<PickingUserData> user_data) {
+                     std::unique_ptr<PickingUserData> user_data) {
   Color colors[4];
   Fill(colors, color);
-  AddBox(a_Box, colors, picking_type, user_data);
+  AddBox(a_Box, colors, picking_type, std::move(user_data));
 }
 
 void Batcher::AddShadedBox(Vec2 pos, Vec2 size, float z, Color color,
                            PickingID::Type picking_type,
-                           std::shared_ptr<PickingUserData> user_data) {
+                           std::unique_ptr<PickingUserData> user_data) {
   Color colors[4];
   GetBoxGradientColors(color, colors);
   Box box(pos, size, z);
-  AddBox(box, colors, picking_type, user_data);
+  AddBox(box, colors, picking_type, std::move(user_data));
 }
 
 void Batcher::AddTriangle(const Triangle& triangle, Color color,
                           PickingID::Type picking_type,
-                          std::shared_ptr<PickingUserData> user_data) {
+                          std::unique_ptr<PickingUserData> user_data) {
   Color picking_color = PickingID::GetColor(
       picking_type, triangle_buffer_.triangles_.size(), batcher_id_);
   triangle_buffer_.triangles_.push_back(triangle);
   triangle_buffer_.colors_.push_back_n(color, 3);
   triangle_buffer_.picking_colors_.push_back_n(picking_color, 3);
-  triangle_buffer_.user_data_.push_back(user_data);
+  triangle_buffer_.user_data_.push_back(std::move(user_data));
 }
 
 void Batcher::AddTriangle(Vec3 v0, Vec3 v1, Vec3 v2, Color color,
                           PickingID::Type picking_type,
-                          std::shared_ptr<PickingUserData> user_data) {
-  AddTriangle(Triangle(v0, v1, v2), color, picking_type, user_data);
+                          std::unique_ptr<PickingUserData> user_data) {
+  AddTriangle(Triangle(v0, v1, v2), color, picking_type, std::move(user_data));
 }
 
-std::shared_ptr<PickingUserData> Batcher::GetUserData(PickingID a_ID) {
-  std::shared_ptr<PickingUserData>* data = nullptr;
+PickingUserData* Batcher::GetUserData(PickingID a_ID) {
+  CHECK(a_ID.m_Id >= 0);
+
   switch (a_ID.m_Type) {
     case PickingID::BOX:
-      data = box_buffer_.m_UserData.SlowAt(a_ID.m_Id);
-      break;
+      CHECK(a_ID.m_Id < box_buffer_.m_UserData.size());
+      return box_buffer_.m_UserData[a_ID.m_Id].get();
     case PickingID::LINE:
-      data = line_buffer_.m_UserData.SlowAt(a_ID.m_Id);
-      break;
+      CHECK(a_ID.m_Id < line_buffer_.m_UserData.size());
+      return line_buffer_.m_UserData[a_ID.m_Id].get();
     case PickingID::TRIANGLE:
-      data = triangle_buffer_.user_data_.SlowAt(a_ID.m_Id);
-      break;
+      CHECK(a_ID.m_Id < triangle_buffer_.user_data_.size());
+      return triangle_buffer_.user_data_[a_ID.m_Id].get();
   }
 
-  if (data) {
-    return *data;
-  }
   return nullptr;
+ ;
 }
 
 TextBox* Batcher::GetTextBox(PickingID a_ID) {
-  std::shared_ptr<PickingUserData> data = GetUserData(a_ID);
+  PickingUserData* data = GetUserData(a_ID);
 
   if (data && data->m_TextBox) {
     return data->m_TextBox; 

--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -84,7 +84,7 @@ void Batcher::AddTriangle(const Triangle& triangle, Color color,
   triangle_buffer_.triangles_.push_back(triangle);
   triangle_buffer_.colors_.push_back_n(color, 3);
   triangle_buffer_.picking_colors_.push_back_n(picking_color, 3);
-  triangle_buffer_.m_UserData.push_back(user_data);
+  triangle_buffer_.user_data_.push_back(user_data);
 }
 
 void Batcher::AddTriangle(Vec3 v0, Vec3 v1, Vec3 v2, Color color,
@@ -103,7 +103,7 @@ std::shared_ptr<PickingUserData> Batcher::GetUserData(PickingID a_ID) {
       data = line_buffer_.m_UserData.SlowAt(a_ID.m_Id);
       break;
     case PickingID::TRIANGLE:
-      data = triangle_buffer_.m_UserData.SlowAt(a_ID.m_Id);
+      data = triangle_buffer_.user_data_.SlowAt(a_ID.m_Id);
       break;
   }
 

--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -117,7 +117,7 @@ TextBox* Batcher::GetTextBox(PickingID a_ID) {
   std::shared_ptr<PickingUserData> data = GetUserData(a_ID);
 
   if (data && data->m_TextBox) {
-      return data->m_TextBox; 
+    return data->m_TextBox; 
   }
 
   return nullptr;

--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -9,7 +9,7 @@
 
 void Batcher::AddLine(const Line& line, const Color* colors,
                       PickingID::Type picking_type,
-                      PickingUserData user_data) {
+                      std::shared_ptr<PickingUserData> user_data) {
   Color picking_color = PickingID::GetColor(
       picking_type, line_buffer_.m_Lines.size(), batcher_id_);
   line_buffer_.m_Lines.push_back(line);
@@ -20,7 +20,7 @@ void Batcher::AddLine(const Line& line, const Color* colors,
 
 void Batcher::AddLine(const Line& line, Color color,
                       PickingID::Type picking_type,
-                      PickingUserData user_data) {
+                      std::shared_ptr<PickingUserData> user_data) {
   Color colors[2];
   Fill(colors, color);
   AddLine(line, colors, picking_type, user_data);
@@ -28,7 +28,7 @@ void Batcher::AddLine(const Line& line, Color color,
 
 void Batcher::AddLine(Vec2 from, Vec2 to, float z, Color color,
                       PickingID::Type picking_type,
-                      PickingUserData user_data) {
+                      std::shared_ptr<PickingUserData> user_data) {
   Line line;
   Color colors[2];
   Fill(colors, color);
@@ -39,7 +39,7 @@ void Batcher::AddLine(Vec2 from, Vec2 to, float z, Color color,
 
 void Batcher::AddVerticalLine(Vec2 pos, float size, float z, Color color,
                               PickingID::Type picking_type,
-                              PickingUserData user_data) {
+                              std::shared_ptr<PickingUserData> user_data) {
   Line line;
   Color colors[2];
   Fill(colors, color);
@@ -50,7 +50,7 @@ void Batcher::AddVerticalLine(Vec2 pos, float size, float z, Color color,
 
 void Batcher::AddBox(const Box& a_Box, const Color* colors,
                      PickingID::Type picking_type,
-                     PickingUserData user_data) {
+                     std::shared_ptr<PickingUserData> user_data) {
   Color picking_color = PickingID::GetColor(
       picking_type, box_buffer_.m_Boxes.size(), batcher_id_);
   box_buffer_.m_Boxes.push_back(a_Box);
@@ -61,7 +61,7 @@ void Batcher::AddBox(const Box& a_Box, const Color* colors,
 
 void Batcher::AddBox(const Box& a_Box, Color color,
                      PickingID::Type picking_type,
-                     PickingUserData user_data) {
+                     std::shared_ptr<PickingUserData> user_data) {
   Color colors[4];
   Fill(colors, color);
   AddBox(a_Box, colors, picking_type, user_data);
@@ -69,7 +69,7 @@ void Batcher::AddBox(const Box& a_Box, Color color,
 
 void Batcher::AddShadedBox(Vec2 pos, Vec2 size, float z, Color color,
                            PickingID::Type picking_type,
-                           PickingUserData user_data) {
+                           std::shared_ptr<PickingUserData> user_data) {
   Color colors[4];
   GetBoxGradientColors(color, colors);
   Box box(pos, size, z);
@@ -78,7 +78,7 @@ void Batcher::AddShadedBox(Vec2 pos, Vec2 size, float z, Color color,
 
 void Batcher::AddTriangle(const Triangle& triangle, Color color,
                           PickingID::Type picking_type,
-                          PickingUserData user_data) {
+                          std::shared_ptr<PickingUserData> user_data) {
   Color picking_color = PickingID::GetColor(
       picking_type, triangle_buffer_.triangles_.size(), batcher_id_);
   triangle_buffer_.triangles_.push_back(triangle);
@@ -89,26 +89,35 @@ void Batcher::AddTriangle(const Triangle& triangle, Color color,
 
 void Batcher::AddTriangle(Vec3 v0, Vec3 v1, Vec3 v2, Color color,
                           PickingID::Type picking_type,
-                          PickingUserData user_data) {
+                          std::shared_ptr<PickingUserData> user_data) {
   AddTriangle(Triangle(v0, v1, v2), color, picking_type, user_data);
 }
 
-TextBox* Batcher::GetTextBox(PickingID a_ID) {
-  PickingUserData* data = nullptr;
+std::shared_ptr<PickingUserData> Batcher::GetUserData(PickingID a_ID) {
+  std::shared_ptr<PickingUserData>* data;
   switch (a_ID.m_Type) {
-      case PickingID::BOX:
-        data = box_buffer_.m_UserData.SlowAt(a_ID.m_Id);
-        break;
-      case PickingID::LINE:
-        data = line_buffer_.m_UserData.SlowAt(a_ID.m_Id);
-        break;
-      case PickingID::TRIANGLE:
-        data = triangle_buffer_.m_UserData.SlowAt(a_ID.m_Id);
-        break;
-    }
+    case PickingID::BOX:
+      data = box_buffer_.m_UserData.SlowAt(a_ID.m_Id);
+      break;
+    case PickingID::LINE:
+      data = line_buffer_.m_UserData.SlowAt(a_ID.m_Id);
+      break;
+    case PickingID::TRIANGLE:
+      data = triangle_buffer_.m_UserData.SlowAt(a_ID.m_Id);
+      break;
+  }
 
-  if (data && data->m_UserData) {
-      return static_cast<TextBox*>(data->m_UserData); 
+  if (data) {
+    return *data;
+  }
+  return nullptr;
+}
+
+TextBox* Batcher::GetTextBox(PickingID a_ID) {
+  std::shared_ptr<PickingUserData> data = GetUserData(a_ID);
+
+  if (data && data->m_TextBox) {
+      return data->m_TextBox; 
   }
 
   return nullptr;

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -18,9 +18,7 @@ struct PickingUserData {
 
   PickingUserData(
       TextBox* text_box = nullptr,
-      TooltipCallback generate_tooltip = [](PickingID id) -> std::string {
-        return "";
-      })
+      TooltipCallback generate_tooltip = nullptr)
       : m_TextBox(text_box), m_GenerateTooltip(generate_tooltip) {}
 };
 

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -10,6 +10,11 @@
 #include "PickingManager.h"
 
 //-----------------------------------------------------------------------------
+struct PickingUserData {
+  void* m_UserData = nullptr;
+};
+
+//-----------------------------------------------------------------------------
 struct LineBuffer {
   void Reset() {
     m_Lines.Reset();
@@ -22,7 +27,7 @@ struct LineBuffer {
   BlockChain<Line, NUM_LINES_PER_BLOCK> m_Lines;
   BlockChain<Color, 2 * NUM_LINES_PER_BLOCK> m_Colors;
   BlockChain<Color, 2 * NUM_LINES_PER_BLOCK> m_PickingColors;
-  BlockChain<void*, NUM_LINES_PER_BLOCK> m_UserData;
+  BlockChain<PickingUserData, NUM_LINES_PER_BLOCK> m_UserData;
 };
 
 //-----------------------------------------------------------------------------
@@ -38,7 +43,7 @@ struct BoxBuffer {
   BlockChain<Box, NUM_BOXES_PER_BLOCK> m_Boxes;
   BlockChain<Color, 4 * NUM_BOXES_PER_BLOCK> m_Colors;
   BlockChain<Color, 4 * NUM_BOXES_PER_BLOCK> m_PickingColors;
-  BlockChain<void*, NUM_BOXES_PER_BLOCK> m_UserData;
+  BlockChain<PickingUserData, NUM_BOXES_PER_BLOCK> m_UserData;
 };
 
 //-----------------------------------------------------------------------------
@@ -47,14 +52,14 @@ struct TriangleBuffer {
     triangles_.Reset();
     colors_.Reset();
     picking_colors_.Reset();
-    user_data_.Reset();
+    m_UserData.Reset();
   }
 
   static const int NUM_TRIANGLES_PER_BLOCK = 64 * 1024;
   BlockChain<Triangle, NUM_TRIANGLES_PER_BLOCK> triangles_;
   BlockChain<Color, 3 * NUM_TRIANGLES_PER_BLOCK> colors_;
   BlockChain<Color, 3 * NUM_TRIANGLES_PER_BLOCK> picking_colors_;
-  BlockChain<void*, NUM_TRIANGLES_PER_BLOCK> user_data_;
+  BlockChain<PickingUserData, NUM_TRIANGLES_PER_BLOCK> m_UserData;
 };
 
 //-----------------------------------------------------------------------------
@@ -64,25 +69,32 @@ class Batcher {
   Batcher() : batcher_id_(PickingID::BatcherId::TIME_GRAPH) {}
 
   void AddLine(const Line& line, const Color* colors,
-               PickingID::Type picking_type, void* user_data = nullptr);
+               PickingID::Type picking_type, 
+               PickingUserData user_data = PickingUserData());
   void AddLine(const Line& line, Color color, PickingID::Type picking_type,
-               void* user_data = nullptr);
+               PickingUserData user_data = PickingUserData());
   void AddLine(Vec2 from, Vec2 to, float z, Color color,
-               PickingID::Type picking_type, void* user_data = nullptr);
+               PickingID::Type picking_type,
+               PickingUserData user_data = PickingUserData());
   void AddVerticalLine(Vec2 pos, float size, float z, Color color,
-                       PickingID::Type picking_type, void* user_data = nullptr);
+                       PickingID::Type picking_type,
+                       PickingUserData user_data = PickingUserData());
 
   void AddBox(const Box& a_Box, const Color* colors,
-              PickingID::Type picking_type, void* user_data = nullptr);
+              PickingID::Type picking_type,
+              PickingUserData user_data = PickingUserData());
   void AddBox(const Box& a_Box, Color color, PickingID::Type picking_type,
-              void* user_data = nullptr);
+              PickingUserData user_data = PickingUserData());
   void AddShadedBox(Vec2 pos, Vec2 size, float z, Color color,
-                    PickingID::Type picking_type, void* user_data = nullptr);
+                    PickingID::Type picking_type,
+                    PickingUserData user_data = PickingUserData());
 
   void AddTriangle(const Triangle& triangle, Color color,
-                   PickingID::Type picking_type, void* user_data = nullptr);
+                   PickingID::Type picking_type,
+                   PickingUserData user_data = PickingUserData());
   void AddTriangle(Vec3 v0, Vec3 v1, Vec3 v2, Color color,
-                   PickingID::Type picking_type, void* user_data = nullptr);
+                   PickingID::Type picking_type,
+                   PickingUserData user_data = PickingUserData());
 
   void GetBoxGradientColors(Color color, Color* colors);
 

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -60,7 +60,7 @@ struct TriangleBuffer {
     triangles_.Reset();
     colors_.Reset();
     picking_colors_.Reset();
-    m_UserData.Reset();
+    user_data_.Reset();
   }
 
   static const int NUM_TRIANGLES_PER_BLOCK = 64 * 1024;
@@ -68,7 +68,7 @@ struct TriangleBuffer {
   BlockChain<Color, 3 * NUM_TRIANGLES_PER_BLOCK> colors_;
   BlockChain<Color, 3 * NUM_TRIANGLES_PER_BLOCK> picking_colors_;
   BlockChain<std::shared_ptr<PickingUserData>, NUM_TRIANGLES_PER_BLOCK>
-      m_UserData;
+      user_data_;
 };
 
 //-----------------------------------------------------------------------------
@@ -96,14 +96,14 @@ class Batcher {
               std::shared_ptr<PickingUserData> user_data = nullptr);
   void AddShadedBox(Vec2 pos, Vec2 size, float z, Color color,
                     PickingID::Type picking_type,
-      std::shared_ptr<PickingUserData> user_data = nullptr);
+                    std::shared_ptr<PickingUserData> user_data = nullptr);
 
   void AddTriangle(const Triangle& triangle, Color color,
                    PickingID::Type picking_type,
-      std::shared_ptr<PickingUserData> user_data = nullptr);
+                   std::shared_ptr<PickingUserData> user_data = nullptr);
   void AddTriangle(Vec3 v0, Vec3 v1, Vec3 v2, Color color,
                    PickingID::Type picking_type,
-      std::shared_ptr<PickingUserData> user_data = nullptr);
+                   std::shared_ptr<PickingUserData> user_data = nullptr);
 
   void GetBoxGradientColors(Color color, Color* colors);
 

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -28,14 +28,14 @@ struct LineBuffer {
     m_Lines.Reset();
     m_Colors.Reset();
     m_PickingColors.Reset();
-    m_UserData.Reset();
+    m_UserData.clear();
   }
 
   static const int NUM_LINES_PER_BLOCK = 64 * 1024;
   BlockChain<Line, NUM_LINES_PER_BLOCK> m_Lines;
   BlockChain<Color, 2 * NUM_LINES_PER_BLOCK> m_Colors;
   BlockChain<Color, 2 * NUM_LINES_PER_BLOCK> m_PickingColors;
-  BlockChain<std::shared_ptr<PickingUserData>, NUM_LINES_PER_BLOCK> m_UserData;
+  std::vector<std::unique_ptr<PickingUserData>> m_UserData;
 };
 
 //-----------------------------------------------------------------------------
@@ -44,14 +44,14 @@ struct BoxBuffer {
     m_Boxes.Reset();
     m_Colors.Reset();
     m_PickingColors.Reset();
-    m_UserData.Reset();
+    m_UserData.clear();
   }
 
   static const int NUM_BOXES_PER_BLOCK = 64 * 1024;
   BlockChain<Box, NUM_BOXES_PER_BLOCK> m_Boxes;
   BlockChain<Color, 4 * NUM_BOXES_PER_BLOCK> m_Colors;
   BlockChain<Color, 4 * NUM_BOXES_PER_BLOCK> m_PickingColors;
-  BlockChain<std::shared_ptr<PickingUserData>, NUM_BOXES_PER_BLOCK> m_UserData;
+  std::vector<std::unique_ptr<PickingUserData>> m_UserData;
 };
 
 //-----------------------------------------------------------------------------
@@ -60,15 +60,14 @@ struct TriangleBuffer {
     triangles_.Reset();
     colors_.Reset();
     picking_colors_.Reset();
-    user_data_.Reset();
+    user_data_.clear();
   }
 
   static const int NUM_TRIANGLES_PER_BLOCK = 64 * 1024;
   BlockChain<Triangle, NUM_TRIANGLES_PER_BLOCK> triangles_;
   BlockChain<Color, 3 * NUM_TRIANGLES_PER_BLOCK> colors_;
   BlockChain<Color, 3 * NUM_TRIANGLES_PER_BLOCK> picking_colors_;
-  BlockChain<std::shared_ptr<PickingUserData>, NUM_TRIANGLES_PER_BLOCK>
-    user_data_;
+  std::vector<std::unique_ptr<PickingUserData>> user_data_;
 };
 
 //-----------------------------------------------------------------------------
@@ -79,31 +78,31 @@ class Batcher {
 
   void AddLine(const Line& line, const Color* colors,
                PickingID::Type picking_type, 
-               std::shared_ptr<PickingUserData> user_data = nullptr);
+               std::unique_ptr<PickingUserData> user_data = nullptr);
   void AddLine(const Line& line, Color color, PickingID::Type picking_type,
-               std::shared_ptr<PickingUserData> user_data = nullptr);
+               std::unique_ptr<PickingUserData> user_data = nullptr);
   void AddLine(Vec2 from, Vec2 to, float z, Color color,
                PickingID::Type picking_type,
-               std::shared_ptr<PickingUserData> user_data = nullptr);
+               std::unique_ptr<PickingUserData> user_data = nullptr);
   void AddVerticalLine(Vec2 pos, float size, float z, Color color,
                        PickingID::Type picking_type,
-                       std::shared_ptr<PickingUserData> user_data = nullptr);
+                       std::unique_ptr<PickingUserData> user_data = nullptr);
 
   void AddBox(const Box& a_Box, const Color* colors,
               PickingID::Type picking_type,
-              std::shared_ptr<PickingUserData> user_data = nullptr);
+              std::unique_ptr<PickingUserData> user_data = nullptr);
   void AddBox(const Box& a_Box, Color color, PickingID::Type picking_type,
-              std::shared_ptr<PickingUserData> user_data = nullptr);
+              std::unique_ptr<PickingUserData> user_data = nullptr);
   void AddShadedBox(Vec2 pos, Vec2 size, float z, Color color,
                     PickingID::Type picking_type,
-                    std::shared_ptr<PickingUserData> user_data = nullptr);
+                    std::unique_ptr<PickingUserData> user_data = nullptr);
 
   void AddTriangle(const Triangle& triangle, Color color,
                    PickingID::Type picking_type,
-                   std::shared_ptr<PickingUserData> user_data = nullptr);
+                   std::unique_ptr<PickingUserData> user_data = nullptr);
   void AddTriangle(Vec3 v0, Vec3 v1, Vec3 v2, Color color,
                    PickingID::Type picking_type,
-                   std::shared_ptr<PickingUserData> user_data = nullptr);
+                   std::unique_ptr<PickingUserData> user_data = nullptr);
 
   void GetBoxGradientColors(Color color, Color* colors);
 
@@ -111,7 +110,7 @@ class Batcher {
 
   void Reset();
 
-  std::shared_ptr<PickingUserData> GetUserData(PickingID a_ID);
+  PickingUserData* GetUserData(PickingID a_ID);
   TextBox* GetTextBox(PickingID a_ID);
   BoxBuffer& GetBoxBuffer() { return box_buffer_; }
   LineBuffer& GetLineBuffer() { return line_buffer_; }

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -17,9 +17,9 @@ struct PickingUserData {
   TooltipCallback m_GenerateTooltip;
 
   PickingUserData(
-      TextBox* text_box = nullptr,
-      TooltipCallback generate_tooltip = nullptr)
-      : m_TextBox(text_box), m_GenerateTooltip(generate_tooltip) {}
+    TextBox* text_box = nullptr,
+    TooltipCallback generate_tooltip = nullptr)
+    : m_TextBox(text_box), m_GenerateTooltip(generate_tooltip) {}
 };
 
 //-----------------------------------------------------------------------------
@@ -68,7 +68,7 @@ struct TriangleBuffer {
   BlockChain<Color, 3 * NUM_TRIANGLES_PER_BLOCK> colors_;
   BlockChain<Color, 3 * NUM_TRIANGLES_PER_BLOCK> picking_colors_;
   BlockChain<std::shared_ptr<PickingUserData>, NUM_TRIANGLES_PER_BLOCK>
-      user_data_;
+    user_data_;
 };
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -242,7 +242,7 @@ void CaptureWindow::FindCode(DWORD64 /*address*/) {}
 
 //-----------------------------------------------------------------------------
 void CaptureWindow::PreRender() {
-  if (m_CanHover && m_HoverTimer.QueryMillis() > m_HoverDelayMs) {
+  if (m_IsMouseOver && m_CanHover && m_HoverTimer.QueryMillis() > m_HoverDelayMs) {
     m_IsHovering = true;
     m_Picking = true;
     NeedsRedraw();

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -225,8 +225,16 @@ void CaptureWindow::Hover(int a_X, int a_Y) {
                &pixels[0]);
 
   PickingID pickId = *reinterpret_cast<PickingID*>(&pixels[0]);
+  std::shared_ptr<PickingUserData> userData = time_graph_.GetBatcher().GetUserData(pickId);
+  if (userData) {
+    auto tooltip = userData->m_GenerateTooltip(pickId);
+    if (!tooltip.empty()) {
+      GOrbitApp->SendTooltipToUi(tooltip);
+      NeedsRedraw();
+    }
+  }
 
-  TextBox* textBox = time_graph_.GetBatcher().GetTextBox(pickId);
+  /*TextBox* textBox = time_graph_.GetBatcher().GetTextBox(pickId);
   if (textBox) {
     if (textBox->GetTimer().m_Type != Timer::CORE_ACTIVITY) {
       Function* func =
@@ -237,7 +245,7 @@ void CaptureWindow::Hover(int a_X, int a_Y) {
       GOrbitApp->SendTooltipToUi(m_ToolTip);
       NeedsRedraw();
     }
-  }
+  }*/
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -187,34 +187,15 @@ void CaptureWindow::Pick(PickingID a_PickingID, int a_X, int a_Y) {
                          ? time_graph_.GetBatcher()
                          : ui_batcher_;
 
-  switch (type) {
-    case PickingID::BOX: {
-      void** textBoxPtr = batcher.GetBoxBuffer().m_UserData.SlowAt(id);
-      if (textBoxPtr) {
-        TextBox* textBox = static_cast<TextBox*>(*textBoxPtr);
-        SelectTextBox(textBox);
-      }
-      break;
+  TextBox* textBox = batcher.GetTextBox(a_PickingID);
+  if (textBox) {
+    SelectTextBox(textBox);
+  } else {
+    switch (type) {
+      case PickingID::PICKABLE:
+        m_PickingManager.Pick(a_PickingID.m_Id, a_X, a_Y);
+        break;
     }
-    case PickingID::LINE: {
-      void** textBoxPtr = batcher.GetLineBuffer().m_UserData.SlowAt(id);
-      if (textBoxPtr) {
-        TextBox* textBox = static_cast<TextBox*>(*textBoxPtr);
-        SelectTextBox(textBox);
-      }
-      break;
-    }
-    case PickingID::TRIANGLE: {
-      void** textBoxPtr = batcher.GetTriangleBuffer().user_data_.SlowAt(id);
-      if (textBoxPtr) {
-        TextBox* textBox = static_cast<TextBox*>(*textBoxPtr);
-        SelectTextBox(textBox);
-      }
-      break;
-    }
-    case PickingID::PICKABLE:
-      m_PickingManager.Pick(a_PickingID.m_Id, a_X, a_Y);
-      break;
   }
 }
 

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -226,26 +226,13 @@ void CaptureWindow::Hover(int a_X, int a_Y) {
 
   PickingID pickId = *reinterpret_cast<PickingID*>(&pixels[0]);
   std::shared_ptr<PickingUserData> userData = time_graph_.GetBatcher().GetUserData(pickId);
-  if (userData) {
+  if (userData && userData->m_GenerateTooltip) {
     auto tooltip = userData->m_GenerateTooltip(pickId);
     if (!tooltip.empty()) {
       GOrbitApp->SendTooltipToUi(tooltip);
       NeedsRedraw();
     }
   }
-
-  /*TextBox* textBox = time_graph_.GetBatcher().GetTextBox(pickId);
-  if (textBox) {
-    if (textBox->GetTimer().m_Type != Timer::CORE_ACTIVITY) {
-      Function* func =
-          Capture::GSelectedFunctionsMap[textBox->GetTimer().m_FunctionAddress];
-      m_ToolTip = absl::StrFormat(
-          "%s %s", func ? FunctionUtils::GetDisplayName(*func) : "",
-          textBox->GetText());
-      GOrbitApp->SendTooltipToUi(m_ToolTip);
-      NeedsRedraw();
-    }
-  }*/
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -181,12 +181,8 @@ void CaptureWindow::Pick(int a_X, int a_Y) {
 void CaptureWindow::Pick(PickingID a_PickingID, int a_X, int a_Y) {
   uint32_t type = a_PickingID.m_Type;
   uint32_t id = a_PickingID.m_Id;
-  uint32_t batcher_id = a_PickingID.batcher_id_;
 
-  Batcher& batcher = (batcher_id == PickingID::TIME_GRAPH)
-                         ? time_graph_.GetBatcher()
-                         : ui_batcher_;
-
+  Batcher& batcher = GetBatcherById(a_PickingID.batcher_id_);
   TextBox* textBox = batcher.GetTextBox(a_PickingID);
   if (textBox) {
     SelectTextBox(textBox);
@@ -225,8 +221,9 @@ void CaptureWindow::Hover(int a_X, int a_Y) {
                &pixels[0]);
 
   PickingID pickId = *reinterpret_cast<PickingID*>(&pixels[0]);
-  std::shared_ptr<PickingUserData> userData =
-      time_graph_.GetBatcher().GetUserData(pickId);
+  Batcher& batcher = GetBatcherById(pickId.batcher_id_);
+
+  std::shared_ptr<PickingUserData> userData = batcher.GetUserData(pickId);
   std::string tooltip = "";
 
   if (userData && userData->m_GenerateTooltip) {
@@ -652,6 +649,12 @@ void CaptureWindow::UpdateVerticalSlider() {
 void CaptureWindow::ToggleDrawHelp() {
   m_DrawHelp = !m_DrawHelp;
   NeedsRedraw();
+}
+
+Batcher& CaptureWindow::GetBatcherById(uint32_t batcher_id) {
+  return batcher_id == PickingID::TIME_GRAPH
+                         ? time_graph_.GetBatcher()
+                         : ui_batcher_;
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -180,12 +180,11 @@ void CaptureWindow::Pick(int a_X, int a_Y) {
 //-----------------------------------------------------------------------------
 void CaptureWindow::Pick(PickingID a_PickingID, int a_X, int a_Y) {
   uint32_t type = a_PickingID.m_Type;
-  uint32_t id = a_PickingID.m_Id;
 
   Batcher& batcher = GetBatcherById(a_PickingID.batcher_id_);
-  TextBox* textBox = batcher.GetTextBox(a_PickingID);
-  if (textBox) {
-    SelectTextBox(textBox);
+  TextBox* text_box = batcher.GetTextBox(a_PickingID);
+  if (text_box) {
+    SelectTextBox(text_box);
   } else if (type == PickingID::PICKABLE) {
     m_PickingManager.Pick(a_PickingID.m_Id, a_X, a_Y);
   }
@@ -227,10 +226,10 @@ void CaptureWindow::Hover(int a_X, int a_Y) {
       tooltip = pickable->GetTooltip();
     }
   } else {
-    std::shared_ptr<PickingUserData> userData = batcher.GetUserData(pickId);
+    std::shared_ptr<PickingUserData> user_data = batcher.GetUserData(pickId);
 
-    if (userData && userData->m_GenerateTooltip) {
-      tooltip = userData->m_GenerateTooltip(pickId);
+    if (user_data && user_data->m_GenerateTooltip) {
+      tooltip = user_data->m_GenerateTooltip(pickId);
     }
   }
 

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -226,7 +226,7 @@ void CaptureWindow::Hover(int a_X, int a_Y) {
       tooltip = pickable->GetTooltip();
     }
   } else {
-    std::shared_ptr<PickingUserData> user_data = batcher.GetUserData(pickId);
+    PickingUserData* user_data = batcher.GetUserData(pickId);
 
     if (user_data && user_data->m_GenerateTooltip) {
       tooltip = user_data->m_GenerateTooltip(pickId);

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -241,7 +241,7 @@ void CaptureWindow::FindCode(DWORD64 /*address*/) {}
 
 //-----------------------------------------------------------------------------
 void CaptureWindow::PreRender() {
-  if (m_IsMouseOver && m_CanHover && m_HoverTimer.QueryMillis() > m_HoverDelayMs) {
+  if (is_mouse_over_ && m_CanHover && m_HoverTimer.QueryMillis() > m_HoverDelayMs) {
     m_IsHovering = true;
     m_Picking = true;
     NeedsRedraw();

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -186,12 +186,8 @@ void CaptureWindow::Pick(PickingID a_PickingID, int a_X, int a_Y) {
   TextBox* textBox = batcher.GetTextBox(a_PickingID);
   if (textBox) {
     SelectTextBox(textBox);
-  } else {
-    switch (type) {
-      case PickingID::PICKABLE:
-        m_PickingManager.Pick(a_PickingID.m_Id, a_X, a_Y);
-        break;
-    }
+  } else if (type == PickingID::PICKABLE) {
+    m_PickingManager.Pick(a_PickingID.m_Id, a_X, a_Y);
   }
 }
 

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -223,17 +223,22 @@ void CaptureWindow::Hover(int a_X, int a_Y) {
   PickingID pickId = *reinterpret_cast<PickingID*>(&pixels[0]);
   Batcher& batcher = GetBatcherById(pickId.batcher_id_);
 
-  std::shared_ptr<PickingUserData> userData = batcher.GetUserData(pickId);
   std::string tooltip = "";
 
-  if (userData && userData->m_GenerateTooltip) {
-    tooltip = userData->m_GenerateTooltip(pickId);
+  if (pickId.m_Type == PickingID::PICKABLE) {
+    Pickable* pickable = GetPickingManager().GetPickableFromId(pickId.m_Id);
+    if (pickable) {
+      tooltip = pickable->GetTooltip();
+    }
+  } else {
+    std::shared_ptr<PickingUserData> userData = batcher.GetUserData(pickId);
+
+    if (userData && userData->m_GenerateTooltip) {
+      tooltip = userData->m_GenerateTooltip(pickId);
+    }
   }
 
-  if (tooltip != m_ToolTip) {
-    GOrbitApp->SendTooltipToUi(tooltip);
-    m_ToolTip = tooltip;
-  }
+  GOrbitApp->SendTooltipToUi(tooltip);
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -225,13 +225,17 @@ void CaptureWindow::Hover(int a_X, int a_Y) {
                &pixels[0]);
 
   PickingID pickId = *reinterpret_cast<PickingID*>(&pixels[0]);
-  std::shared_ptr<PickingUserData> userData = time_graph_.GetBatcher().GetUserData(pickId);
+  std::shared_ptr<PickingUserData> userData =
+      time_graph_.GetBatcher().GetUserData(pickId);
+  std::string tooltip = "";
+
   if (userData && userData->m_GenerateTooltip) {
-    auto tooltip = userData->m_GenerateTooltip(pickId);
-    if (!tooltip.empty()) {
-      GOrbitApp->SendTooltipToUi(tooltip);
-      NeedsRedraw();
-    }
+    tooltip = userData->m_GenerateTooltip(pickId);
+  }
+
+  if (tooltip != m_ToolTip) {
+    GOrbitApp->SendTooltipToUi(tooltip);
+    m_ToolTip = tooltip;
   }
 }
 

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -69,7 +69,6 @@ class CaptureWindow : public GlCanvas {
   TimeGraph time_graph_;
   OutputWindow m_StatsWindow;
   Timer m_HoverTimer;
-  std::string m_ToolTip;
   int m_HoverDelayMs;
   bool m_IsHovering;
   bool m_CanHover;

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -63,6 +63,8 @@ class CaptureWindow : public GlCanvas {
   void UpdateVerticalSlider();
   void ToggleDrawHelp();
 
+  Batcher& GetBatcherById(uint32_t batcher_id);
+
  private:
   TimeGraph time_graph_;
   OutputWindow m_StatsWindow;

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -17,9 +17,7 @@ EventTrack::EventTrack(TimeGraph* a_TimeGraph) : Track(a_TimeGraph) {
 }
 
 std::string EventTrack::GetTooltip() const {
-  return "Left-click and drag to select samples. "
-         "Selecting samples generates a profiling report accessible "
-         "through the \"selection\" tab that allows a filtered analysis.";
+  return "Left-click and drag to select samples.";
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -16,6 +16,12 @@ EventTrack::EventTrack(TimeGraph* a_TimeGraph) : Track(a_TimeGraph) {
   m_Color = Color(0, 255, 0, 255);
 }
 
+std::string EventTrack::GetTooltip() const {
+  return "Left-click and drag to select samples. "
+         "Selecting samples generates a profiling report accessible "
+         "through the \"selection\" tab that allows a filtered analysis.";
+}
+
 //-----------------------------------------------------------------------------
 void EventTrack::Draw(GlCanvas* canvas, bool picking) {
   Batcher* batcher = canvas->GetBatcher();

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -17,7 +17,7 @@ EventTrack::EventTrack(TimeGraph* a_TimeGraph) : Track(a_TimeGraph) {
 }
 
 std::string EventTrack::GetTooltip() const {
-  return "Left-click and drag to select samples.";
+  return "Left-click and drag to select samples";
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/EventTrack.h
+++ b/OrbitGl/EventTrack.h
@@ -16,6 +16,8 @@ class EventTrack : public Track {
   explicit EventTrack(TimeGraph* a_TimeGraph);
   Type GetType() const override { return kEventTrack; }
 
+  std::string GetTooltip() const override;
+
   void Draw(GlCanvas* canvas, bool picking) override;
   void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) override;
 

--- a/OrbitGl/GlPanel.h
+++ b/OrbitGl/GlPanel.h
@@ -54,8 +54,8 @@ class GlPanel {
   virtual void OnContextMenu(const std::string& /*a_Action*/,
                              int /*a_MenuIndex*/) {}
 
-  bool GetIsMouseOver() const { return m_IsMouseOver; }
-  void SetIsMouseOver(bool value) { m_IsMouseOver = value; }
+  bool GetIsMouseOver() const { return is_mouse_over_; }
+  void SetIsMouseOver(bool value) { is_mouse_over_ = value; }
 
   Type GetType() const { return m_Type; }
   virtual bool GetNeedsRedraw() const { return m_NeedsRedraw; }
@@ -68,5 +68,5 @@ class GlPanel {
   int m_MainWindowHeight;
   bool m_NeedsRedraw;
 
-  bool m_IsMouseOver;
+  bool is_mouse_over_;
 };

--- a/OrbitGl/GlPanel.h
+++ b/OrbitGl/GlPanel.h
@@ -54,6 +54,9 @@ class GlPanel {
   virtual void OnContextMenu(const std::string& /*a_Action*/,
                              int /*a_MenuIndex*/) {}
 
+  bool GetIsMouseOver() const { return m_IsMouseOver; }
+  void SetIsMouseOver(bool value) { m_IsMouseOver = value; }
+
   Type GetType() const { return m_Type; }
   virtual bool GetNeedsRedraw() const { return m_NeedsRedraw; }
   void NeedsRedraw() { m_NeedsRedraw = true; }
@@ -64,4 +67,6 @@ class GlPanel {
   int m_MainWindowWidth;
   int m_MainWindowHeight;
   bool m_NeedsRedraw;
+
+  bool m_IsMouseOver;
 };

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -203,14 +203,14 @@ void GpuTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
           }
           batcher->AddShadedBox(pos, size, z, color, PickingID::BOX,
               std::make_shared<PickingUserData>(&text_box, [&](PickingID id) {
-                return this->GetTooltip(id);
+                return this->GetBoxTooltip(id);
               }));
         } else {
           auto type = PickingID::LINE;
           batcher->AddVerticalLine(
               pos, size[1], z, color, type,
               std::make_shared<PickingUserData>(&text_box, [&](PickingID id) {
-                return this->GetTooltip(id);
+                return this->GetBoxTooltip(id);
               }));
           // For lines, we can ignore the entire pixel into which this event
           // falls. We align this precisely on the pixel x-coordinate of the
@@ -243,6 +243,10 @@ void GpuTrack::OnTimer(const Timer& timer) {
   ++num_timers_;
   if (timer.m_Start < min_time_) min_time_ = timer.m_Start;
   if (timer.m_End > max_time_) max_time_ = timer.m_End;
+}
+
+std::string GpuTrack::GetTooltip() const {
+  return "Shows scheduling and execution times for selected GPU calls.";
 }
 
 //-----------------------------------------------------------------------------
@@ -356,7 +360,7 @@ std::vector<std::shared_ptr<TimerChain>> GpuTrack::GetAllChains() {
 }
 
 //-----------------------------------------------------------------------------
-std::string GpuTrack::GetTooltip(PickingID id) const {
+std::string GpuTrack::GetBoxTooltip(PickingID id) const {
   TextBox* textBox = time_graph_->GetBatcher().GetTextBox(id);
   if (textBox) {
     if (textBox->GetTimer().m_Type != Timer::CORE_ACTIVITY) {

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -201,10 +201,11 @@ void GpuTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
           if (!is_collapsed) {
             SetTimesliceText(timer, elapsed_us, min_x, &text_box);
           }
-          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, &text_box);
+          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX,
+                                {&text_box});
         } else {
           auto type = PickingID::LINE;
-          batcher->AddVerticalLine(pos, size[1], z, color, type, &text_box);
+          batcher->AddVerticalLine(pos, size[1], z, color, type, {&text_box});
           // For lines, we can ignore the entire pixel into which this event
           // falls. We align this precisely on the pixel x-coordinate of the
           // current line being drawn (in ticks).

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -197,17 +197,17 @@ void GpuTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
           }
         }
 
-        auto userData = std::make_shared<PickingUserData>(
+        auto user_data = std::make_shared<PickingUserData>(
           &text_box, [&](PickingID id) { return this->GetBoxTooltip(id); });
 
         if (is_visible_width) {
           if (!is_collapsed) {
             SetTimesliceText(timer, elapsed_us, min_x, &text_box);
           }
-          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, userData);
+          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, user_data);
         } else {
           auto type = PickingID::LINE;
-          batcher->AddVerticalLine(pos, size[1], z, color, type, userData);
+          batcher->AddVerticalLine(pos, size[1], z, color, type, user_data);
           // For lines, we can ignore the entire pixel into which this event
           // falls. We align this precisely on the pixel x-coordinate of the
           // current line being drawn (in ticks).
@@ -357,17 +357,17 @@ std::vector<std::shared_ptr<TimerChain>> GpuTrack::GetAllChains() {
 
 //-----------------------------------------------------------------------------
 std::string GpuTrack::GetBoxTooltip(PickingID id) const {
-  TextBox* textBox = time_graph_->GetBatcher().GetTextBox(id);
-  if (textBox) {
-    if (textBox->GetTimer().m_Type != Timer::CORE_ACTIVITY) {
+  TextBox* text_box = time_graph_->GetBatcher().GetTextBox(id);
+  if (text_box) {
+    if (text_box->GetTimer().m_Type != Timer::CORE_ACTIVITY) {
       std::string gpu_stage =
-          string_manager_->Get(textBox->GetTimer().m_UserData[0]).value_or("");
+          string_manager_->Get(text_box->GetTimer().m_UserData[0]).value_or("");
       if (gpu_stage == kSwQueueString) {
-        return GetSwQueueTooltip(textBox->GetTimer());
+        return GetSwQueueTooltip(text_box->GetTimer());
       } else if (gpu_stage == kHwQueueString) {
-        return GetHwQueueTooltip(textBox->GetTimer());
+        return GetHwQueueTooltip(text_box->GetTimer());
       } else if (gpu_stage == kHwExecutionString) {
-        return GetHwExecutionTooltip(textBox->GetTimer());
+        return GetHwExecutionTooltip(text_box->GetTimer());
       }
     }
   }

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -358,18 +358,18 @@ std::vector<std::shared_ptr<TimerChain>> GpuTrack::GetAllChains() {
 //-----------------------------------------------------------------------------
 std::string GpuTrack::GetBoxTooltip(PickingID id) const {
   TextBox* text_box = time_graph_->GetBatcher().GetTextBox(id);
-  if (text_box) {
-    if (text_box->GetTimer().m_Type != Timer::CORE_ACTIVITY) {
-      std::string gpu_stage =
-          string_manager_->Get(text_box->GetTimer().m_UserData[0]).value_or("");
-      if (gpu_stage == kSwQueueString) {
-        return GetSwQueueTooltip(text_box->GetTimer());
-      } else if (gpu_stage == kHwQueueString) {
-        return GetHwQueueTooltip(text_box->GetTimer());
-      } else if (gpu_stage == kHwExecutionString) {
-        return GetHwExecutionTooltip(text_box->GetTimer());
-      }
-    }
+  if (!text_box || text_box->GetTimer().m_Type == Timer::CORE_ACTIVITY) {
+    return "";
+  }
+
+  std::string gpu_stage =
+      string_manager_->Get(text_box->GetTimer().m_UserData[0]).value_or("");
+  if (gpu_stage == kSwQueueString) {
+    return GetSwQueueTooltip(text_box->GetTimer());
+  } else if (gpu_stage == kHwQueueString) {
+    return GetHwQueueTooltip(text_box->GetTimer());
+  } else if (gpu_stage == kHwExecutionString) {
+    return GetHwExecutionTooltip(text_box->GetTimer());
   }
 
   return "";

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -198,7 +198,8 @@ void GpuTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
         }
 
         auto userData = std::make_shared<PickingUserData>(
-            &text_box, [&](PickingID id) { return this->GetBoxTooltip(id); });
+          &text_box, [&](PickingID id) { return this->GetBoxTooltip(id); });
+
         if (is_visible_width) {
           if (!is_collapsed) {
             SetTimesliceText(timer, elapsed_us, min_x, &text_box);

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -202,10 +202,12 @@ void GpuTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
             SetTimesliceText(timer, elapsed_us, min_x, &text_box);
           }
           batcher->AddShadedBox(pos, size, z, color, PickingID::BOX,
-                                {&text_box});
+                                std::make_shared<PickingUserData>(&text_box));
         } else {
           auto type = PickingID::LINE;
-          batcher->AddVerticalLine(pos, size[1], z, color, type, {&text_box});
+          batcher->AddVerticalLine(
+              pos, size[1], z, color, type,
+              std::make_shared<PickingUserData>(&text_box));
           // For lines, we can ignore the entire pixel into which this event
           // falls. We align this precisely on the pixel x-coordinate of the
           // current line being drawn (in ticks).

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -197,21 +197,16 @@ void GpuTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
           }
         }
 
+        auto userData = std::make_shared<PickingUserData>(
+            &text_box, [&](PickingID id) { return this->GetBoxTooltip(id); });
         if (is_visible_width) {
           if (!is_collapsed) {
             SetTimesliceText(timer, elapsed_us, min_x, &text_box);
           }
-          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX,
-              std::make_shared<PickingUserData>(&text_box, [&](PickingID id) {
-                return this->GetBoxTooltip(id);
-              }));
+          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, userData);
         } else {
           auto type = PickingID::LINE;
-          batcher->AddVerticalLine(
-              pos, size[1], z, color, type,
-              std::make_shared<PickingUserData>(&text_box, [&](PickingID id) {
-                return this->GetBoxTooltip(id);
-              }));
+          batcher->AddVerticalLine(pos, size[1], z, color, type, userData);
           // For lines, we can ignore the entire pixel into which this event
           // falls. We align this precisely on the pixel x-coordinate of the
           // current line being drawn (in ticks).

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -242,7 +242,7 @@ void GpuTrack::OnTimer(const Timer& timer) {
 }
 
 std::string GpuTrack::GetTooltip() const {
-  return "Shows scheduling and execution times for selected GPU calls.";
+  return "Shows scheduling and execution times for selected GPU job submissions";
 }
 
 //-----------------------------------------------------------------------------
@@ -378,10 +378,10 @@ std::string GpuTrack::GetBoxTooltip(PickingID id) const {
 std::string GpuTrack::GetSwQueueTooltip(const Timer& timer) const { 
   return absl::StrFormat(
     "<b>Software Queue</b><br/>"
-    "<i>Time between amdgpu_cs_ioctl and amdgpu_sched_run_job.</i>"
+    "<i>Time between amdgpu_cs_ioctl (job submitted) and amdgpu_sched_run_job (job scheduled)</i>"
     "<br/>"
     "<br/>"
-    "<b>Submitter thread:</b> %s [%d]<br/>"
+    "<b>Submitted from thread:</b> %s [%d]<br/>"
     "<b>Time:</b> %s",
     Capture::GThreadNames[timer.m_TID].c_str(),
     timer.m_TID,
@@ -389,7 +389,8 @@ std::string GpuTrack::GetSwQueueTooltip(const Timer& timer) const {
 }
 
 std::string GpuTrack::GetHwQueueTooltip(const Timer& timer) const {
-  return absl::StrFormat("<b>Hardware Queue</b><br/><i>Time between amdgpu_sched_run_job and start of GPU execution</i>"
+  return absl::StrFormat("<b>Hardware Queue</b><br/><i>Time between amdgpu_sched_run_job "
+    "(job scheduled) and start of GPU execution</i>"
     "<br/>"
     "<br/>"
     "<b>Time:</b> %s",

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -197,17 +197,17 @@ void GpuTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
           }
         }
 
-        auto user_data = std::make_shared<PickingUserData>(
+        auto user_data = std::make_unique<PickingUserData>(
           &text_box, [&](PickingID id) { return this->GetBoxTooltip(id); });
 
         if (is_visible_width) {
           if (!is_collapsed) {
             SetTimesliceText(timer, elapsed_us, min_x, &text_box);
           }
-          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, user_data);
+          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, std::move(user_data));
         } else {
           auto type = PickingID::LINE;
-          batcher->AddVerticalLine(pos, size[1], z, color, type, user_data);
+          batcher->AddVerticalLine(pos, size[1], z, color, type, std::move(user_data));
           // For lines, we can ignore the entire pixel into which this event
           // falls. We align this precisely on the pixel x-coordinate of the
           // current line being drawn (in ticks).

--- a/OrbitGl/GpuTrack.h
+++ b/OrbitGl/GpuTrack.h
@@ -65,6 +65,7 @@ class GpuTrack : public Track {
   void SetTimesliceText(const Timer& timer, double elapsed_us, float min_x,
                         TextBox* text_box);
 
+
  protected:
   TextRenderer* text_renderer_ = nullptr;
   uint32_t depth_ = 0;
@@ -73,6 +74,11 @@ class GpuTrack : public Track {
   std::map<int, std::shared_ptr<TimerChain>> timers_;
 
   std::shared_ptr<StringManager> string_manager_;
+
+  std::string GetTooltip(PickingID id) const;
+  std::string GetSwQueueTooltip(const Timer& timer) const;
+  std::string GetHwQueueTooltip(const Timer& timer) const;
+  std::string GetHwExecutionTooltip(const Timer& timer) const;
 };
 
 #endif  // ORBIT_GL_GPU_TRACK_H_

--- a/OrbitGl/GpuTrack.h
+++ b/OrbitGl/GpuTrack.h
@@ -27,6 +27,7 @@ class GpuTrack : public Track {
   void Draw(GlCanvas* canvas, bool picking) override;
   void OnDrag(int x, int y) override;
   void OnTimer(const Timer& timer);
+  std::string GetTooltip() const override;
 
   // Track
   void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) override;
@@ -75,7 +76,7 @@ class GpuTrack : public Track {
 
   std::shared_ptr<StringManager> string_manager_;
 
-  std::string GetTooltip(PickingID id) const;
+  std::string GetBoxTooltip(PickingID id) const;
   std::string GetSwQueueTooltip(const Timer& timer) const;
   std::string GetHwQueueTooltip(const Timer& timer) const;
   std::string GetHwExecutionTooltip(const Timer& timer) const;

--- a/OrbitGl/GraphTrack.cpp
+++ b/OrbitGl/GraphTrack.cpp
@@ -67,7 +67,7 @@ void GraphTrack::Draw(GlCanvas* canvas, bool picking) {
     float y0 = base_y + static_cast<float>(last_normalized_value) * m_Size[1];
     float y1 = base_y + static_cast<float>(normalized_value) * m_Size[1];
     time_graph_->GetBatcher().AddLine(Vec2(x0, y0), Vec2(x1, y1), text_z,
-                                      kLineColor, PickingID::LINE, nullptr);
+                                      kLineColor, PickingID::LINE);
 
     previous_time = time;
     last_normalized_value = normalized_value;

--- a/OrbitGl/PickingManager.h
+++ b/OrbitGl/PickingManager.h
@@ -23,6 +23,7 @@ class Pickable {
   virtual void Draw(GlCanvas* a_Canvas, bool a_Picking) = 0;
   virtual bool Draggable() { return false; }
   virtual bool Movable() { return false; }
+  virtual std::string GetTooltip() const { return ""; }
 };
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -116,10 +116,11 @@ void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
                                     is_same_pid_as_target, is_inactive);
 
         if (is_visible_width) {
-          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, &text_box);
+          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX,
+                                {&text_box});
         } else {
           auto type = PickingID::LINE;
-          batcher->AddVerticalLine(pos, size[1], z, color, type, &text_box);
+          batcher->AddVerticalLine(pos, size[1], z, color, type, {&text_box});
           // For lines, we can ignore the entire pixel into which this event
           // falls. We align this precisely on the pixel x-coordinate of the
           // current line being drawn (in ticks).

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -120,25 +120,15 @@ void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
                                     is_same_tid_as_selected,
                                     is_same_pid_as_target, is_inactive);
 
+        auto userData = std::make_shared<PickingUserData>(
+          &text_box,
+          [&](PickingID id) -> std::string { return GetBoxTooltip(id); });
+
         if (is_visible_width) {
-          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX,
-            std::make_shared<PickingUserData>(
-              &text_box, 
-              [&](PickingID id) -> std::string {
-                    return GetBoxTooltip(id);
-                  }
-            )
-          );
+          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, userData);
         } else {
           auto type = PickingID::LINE;
-          batcher->AddVerticalLine(
-            pos, size[1], z, color, type,
-            std::make_shared<PickingUserData>(
-              &text_box, [&](PickingID id) -> std::string {
-                    return GetBoxTooltip(id);
-                  }
-            )
-          );
+          batcher->AddVerticalLine(pos, size[1], z, color, type, userData);
           // For lines, we can ignore the entire pixel into which this event
           // falls. We align this precisely on the pixel x-coordinate of the
           // current line being drawn (in ticks).

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -120,15 +120,15 @@ void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
                                     is_same_tid_as_selected,
                                     is_same_pid_as_target, is_inactive);
 
-        auto user_data = std::make_shared<PickingUserData>(
+        auto user_data = std::make_unique<PickingUserData>(
           &text_box,
           [&](PickingID id) -> std::string { return GetBoxTooltip(id); });
 
         if (is_visible_width) {
-          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, user_data);
+          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, std::move(user_data));
         } else {
           auto type = PickingID::LINE;
-          batcher->AddVerticalLine(pos, size[1], z, color, type, user_data);
+          batcher->AddVerticalLine(pos, size[1], z, color, type, std::move(user_data));
           // For lines, we can ignore the entire pixel into which this event
           // falls. We align this precisely on the pixel x-coordinate of the
           // current line being drawn (in ticks).

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -120,15 +120,15 @@ void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
                                     is_same_tid_as_selected,
                                     is_same_pid_as_target, is_inactive);
 
-        auto userData = std::make_shared<PickingUserData>(
+        auto user_data = std::make_shared<PickingUserData>(
           &text_box,
           [&](PickingID id) -> std::string { return GetBoxTooltip(id); });
 
         if (is_visible_width) {
-          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, userData);
+          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, user_data);
         } else {
           auto type = PickingID::LINE;
-          batcher->AddVerticalLine(pos, size[1], z, color, type, userData);
+          batcher->AddVerticalLine(pos, size[1], z, color, type, user_data);
           // For lines, we can ignore the entire pixel into which this event
           // falls. We align this precisely on the pixel x-coordinate of the
           // current line being drawn (in ticks).
@@ -144,16 +144,16 @@ void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
 }
 
 std::string SchedulerTrack::GetBoxTooltip(PickingID id) const {
-  TextBox* textBox = time_graph_->GetBatcher().GetTextBox(id);
-  if (textBox) {
+  TextBox* text_box = time_graph_->GetBatcher().GetTextBox(id);
+  if (text_box) {
     return absl::StrFormat(
       "<b>CPU Core activity</b><br/>"
       "<br/>"
       "<b>Core:</b> %d<br/>"
       "<b>Thread:</b> %s [%d]<br/>",
-      textBox->GetTimer().m_Processor,
-      Capture::GThreadNames[textBox->GetTimer().m_TID],
-      textBox->GetTimer().m_TID
+      text_box->GetTimer().m_Processor,
+      Capture::GThreadNames[text_box->GetTimer().m_TID],
+      text_box->GetTimer().m_TID
     );
   }
 

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -46,7 +46,7 @@ float SchedulerTrack::GetYFromDepth(float track_y, uint32_t depth,
 }
 
 std::string SchedulerTrack::GetTooltip() const { 
-  return "Shows scheduling information for CPU cores.";
+  return "Shows scheduling information for CPU cores";
 }
 
 void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -117,10 +117,12 @@ void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
 
         if (is_visible_width) {
           batcher->AddShadedBox(pos, size, z, color, PickingID::BOX,
-                                {&text_box});
+                                std::make_shared<PickingUserData>(&text_box));
         } else {
           auto type = PickingID::LINE;
-          batcher->AddVerticalLine(pos, size[1], z, color, type, {&text_box});
+          batcher->AddVerticalLine(
+              pos, size[1], z, color, type,
+              std::make_shared<PickingUserData>(&text_box));
           // For lines, we can ignore the entire pixel into which this event
           // falls. We align this precisely on the pixel x-coordinate of the
           // current line being drawn (in ticks).

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -145,17 +145,17 @@ void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
 
 std::string SchedulerTrack::GetBoxTooltip(PickingID id) const {
   TextBox* text_box = time_graph_->GetBatcher().GetTextBox(id);
-  if (text_box) {
-    return absl::StrFormat(
-      "<b>CPU Core activity</b><br/>"
-      "<br/>"
-      "<b>Core:</b> %d<br/>"
-      "<b>Thread:</b> %s [%d]<br/>",
-      text_box->GetTimer().m_Processor,
-      Capture::GThreadNames[text_box->GetTimer().m_TID],
-      text_box->GetTimer().m_TID
-    );
+  if (!text_box) {
+    return "";
   }
 
-  return "";
+  return absl::StrFormat(
+    "<b>CPU Core activity</b><br/>"
+    "<br/>"
+    "<b>Core:</b> %d<br/>"
+    "<b>Thread:</b> %s [%d]<br/>",
+    text_box->GetTimer().m_Processor,
+    Capture::GThreadNames[text_box->GetTimer().m_TID],
+    text_box->GetTimer().m_TID
+  );
 }

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -45,6 +45,10 @@ float SchedulerTrack::GetYFromDepth(float track_y, uint32_t depth,
          num_gaps * gap_size;
 }
 
+std::string SchedulerTrack::GetTooltip() const { 
+  return "Shows scheduling information for CPU cores.";
+}
+
 void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
   Batcher* batcher = &time_graph_->GetBatcher();
   GlCanvas* canvas = time_graph_->GetCanvas();
@@ -120,7 +124,9 @@ void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
           batcher->AddShadedBox(pos, size, z, color, PickingID::BOX,
             std::make_shared<PickingUserData>(
               &text_box, 
-              [&](PickingID id) -> std::string { return GetTooltip(id); }
+              [&](PickingID id) -> std::string {
+                    return GetBoxTooltip(id);
+                  }
             )
           );
         } else {
@@ -128,8 +134,9 @@ void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
           batcher->AddVerticalLine(
             pos, size[1], z, color, type,
             std::make_shared<PickingUserData>(
-              &text_box,
-              [&](PickingID id) -> std::string { return GetTooltip(id); }
+              &text_box, [&](PickingID id) -> std::string {
+                    return GetBoxTooltip(id);
+                  }
             )
           );
           // For lines, we can ignore the entire pixel into which this event
@@ -146,7 +153,7 @@ void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
   }
 }
 
-std::string SchedulerTrack::GetTooltip(PickingID id) const {
+std::string SchedulerTrack::GetBoxTooltip(PickingID id) const {
   TextBox* textBox = time_graph_->GetBatcher().GetTextBox(id);
   if (textBox) {
     return absl::StrFormat(

--- a/OrbitGl/SchedulerTrack.h
+++ b/OrbitGl/SchedulerTrack.h
@@ -20,6 +20,7 @@ class SchedulerTrack : public ThreadTrack {
 
  protected:
   float GetYFromDepth(float track_y, uint32_t depth, bool collapsed) override;
+  std::string GetTooltip(PickingID id) const;
 };
 
 #endif  // ORBIT_GL_SCHEDULER_TRACK_H_

--- a/OrbitGl/SchedulerTrack.h
+++ b/OrbitGl/SchedulerTrack.h
@@ -12,6 +12,8 @@ class SchedulerTrack : public ThreadTrack {
   explicit SchedulerTrack(TimeGraph* time_graph);
   ~SchedulerTrack() override = default;
 
+  std::string GetTooltip() const override;
+
   void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) override;
   Type GetType() const override { return kSchedulerTrack; }
   float GetHeight() const override;
@@ -20,7 +22,7 @@ class SchedulerTrack : public ThreadTrack {
 
  protected:
   float GetYFromDepth(float track_y, uint32_t depth, bool collapsed) override;
-  std::string GetTooltip(PickingID id) const;
+  std::string GetBoxTooltip(PickingID id) const;
 };
 
 #endif  // ORBIT_GL_SCHEDULER_TRACK_H_

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -394,25 +394,23 @@ bool ThreadTrack::IsEmpty() const {
 //-----------------------------------------------------------------------------
 std::string ThreadTrack::GetBoxTooltip(PickingID id) const {
   TextBox* text_box = time_graph_->GetBatcher().GetTextBox(id);
-  if (text_box) {
-    if (text_box->GetTimer().m_Type != Timer::CORE_ACTIVITY) {
-      Function* func =
-          Capture::GSelectedFunctionsMap[text_box->GetTimer().m_FunctionAddress];
-      if (func) {
-        return absl::StrFormat(
-          "<b>%s</b><br/>"
-          "<i>Timing measured through dynamic instrumentation</i>"
-          "<br/><br/>"
-          "<b>Module:</b> %s<br/>"
-          "<b>Time:</b> %s",
-          FunctionUtils::GetDisplayName(*func),
-          FunctionUtils::GetLoadedModuleName(*func),
-          GetPrettyTime(text_box->GetTimer().ElapsedMillis()));
-      } else {
-        return text_box->GetText();
-      }
-    }
+  if (!text_box || text_box->GetTimer().m_Type == Timer::CORE_ACTIVITY) {
+    return "";
   }
 
-  return "";
+  Function* func =
+      Capture::GSelectedFunctionsMap[text_box->GetTimer().m_FunctionAddress];
+  if (func) {
+    return absl::StrFormat(
+      "<b>%s</b><br/>"
+      "<i>Timing measured through dynamic instrumentation</i>"
+      "<br/><br/>"
+      "<b>Module:</b> %s<br/>"
+      "<b>Time:</b> %s",
+      FunctionUtils::GetDisplayName(*func),
+      FunctionUtils::GetLoadedModuleName(*func),
+      GetPrettyTime(text_box->GetTimer().ElapsedMillis()));
+  } else {
+    return text_box->GetText();
+  }
 }

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -218,17 +218,17 @@ void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
         text_box.SetPos(pos);
         text_box.SetSize(size);
 
-        auto userData = std::make_shared<PickingUserData>(
+        auto user_data = std::make_shared<PickingUserData>(
           &text_box, [&](PickingID id) { return this->GetBoxTooltip(id); });
 
         if (is_visible_width) {
           if (!is_collapsed) {
             SetTimesliceText(timer, elapsed_us, min_x, &text_box);
           }
-          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, userData);
+          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, user_data);
         } else {
           auto type = PickingID::LINE;
-          batcher->AddVerticalLine(pos, size[1], z, color, type, userData);
+          batcher->AddVerticalLine(pos, size[1], z, color, type, user_data);
           // For lines, we can ignore the entire pixel into which this event
           // falls.
           min_ignore =
@@ -393,11 +393,11 @@ bool ThreadTrack::IsEmpty() const {
 
 //-----------------------------------------------------------------------------
 std::string ThreadTrack::GetBoxTooltip(PickingID id) const {
-  TextBox* textBox = time_graph_->GetBatcher().GetTextBox(id);
-  if (textBox) {
-    if (textBox->GetTimer().m_Type != Timer::CORE_ACTIVITY) {
+  TextBox* text_box = time_graph_->GetBatcher().GetTextBox(id);
+  if (text_box) {
+    if (text_box->GetTimer().m_Type != Timer::CORE_ACTIVITY) {
       Function* func =
-          Capture::GSelectedFunctionsMap[textBox->GetTimer().m_FunctionAddress];
+          Capture::GSelectedFunctionsMap[text_box->GetTimer().m_FunctionAddress];
       if (func) {
         return absl::StrFormat(
           "<b>%s</b><br/>"
@@ -407,9 +407,9 @@ std::string ThreadTrack::GetBoxTooltip(PickingID id) const {
           "<b>Time:</b> %s",
           FunctionUtils::GetDisplayName(*func),
           FunctionUtils::GetLoadedModuleName(*func),
-          GetPrettyTime(textBox->GetTimer().ElapsedMillis()));
+          GetPrettyTime(text_box->GetTimer().ElapsedMillis()));
       } else {
-        return textBox->GetText();
+        return text_box->GetText();
       }
     }
   }

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -218,17 +218,17 @@ void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
         text_box.SetPos(pos);
         text_box.SetSize(size);
 
-        auto user_data = std::make_shared<PickingUserData>(
+        auto user_data = std::make_unique<PickingUserData>(
           &text_box, [&](PickingID id) { return this->GetBoxTooltip(id); });
 
         if (is_visible_width) {
           if (!is_collapsed) {
             SetTimesliceText(timer, elapsed_us, min_x, &text_box);
           }
-          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, user_data);
+          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, std::move(user_data));
         } else {
           auto type = PickingID::LINE;
-          batcher->AddVerticalLine(pos, size[1], z, color, type, user_data);
+          batcher->AddVerticalLine(pos, size[1], z, color, type, std::move(user_data));
           // For lines, we can ignore the entire pixel into which this event
           // falls.
           min_ignore =

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -398,9 +398,19 @@ std::string ThreadTrack::GetTooltip(PickingID id) {
     if (textBox->GetTimer().m_Type != Timer::CORE_ACTIVITY) {
       Function* func =
           Capture::GSelectedFunctionsMap[textBox->GetTimer().m_FunctionAddress];
-      return absl::StrFormat(
-          "%s %s", func ? FunctionUtils::GetDisplayName(*func) : "",
-          textBox->GetText());
+      if (func) {
+        return absl::StrFormat(
+          "<b>%s</b><br/>"
+          "<i>Method hooked through dynamic instrumentation</i>"
+          "<br/><br/>"
+          "<b>Module:</b> %s"
+          "<b>Time:</b> %s",
+          FunctionUtils::GetDisplayName(*func),
+          FunctionUtils::GetLoadedModuleName(*func),
+          GetPrettyTime(textBox->GetTimer().ElapsedMillis()));
+      } else {
+        return textBox->GetText();
+      }
     }
   }
 

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -276,7 +276,7 @@ void ThreadTrack::OnTimer(const Timer& timer) {
 }
 
 std::string ThreadTrack::GetTooltip() const {
-  return "Shows collected samples";
+  return "Shows collected samples and instrumented function timings (if existing).";
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -218,27 +218,17 @@ void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
         text_box.SetPos(pos);
         text_box.SetSize(size);
 
+        auto userData = std::make_shared<PickingUserData>(
+          &text_box, [&](PickingID id) { return this->GetBoxTooltip(id); });
+
         if (is_visible_width) {
           if (!is_collapsed) {
             SetTimesliceText(timer, elapsed_us, min_x, &text_box);
           }
-          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX,
-            std::make_shared<PickingUserData>(&text_box, 
-              [&](PickingID id) {
-                return this->GetBoxTooltip(id);
-              }
-            )
-          );
+          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, userData);
         } else {
           auto type = PickingID::LINE;
-          batcher->AddVerticalLine(
-            pos, size[1], z, color, type,
-            std::make_shared<PickingUserData>(&text_box, 
-              [&](PickingID id) {
-                return this->GetBoxTooltip(id);
-              }
-            )
-          );
+          batcher->AddVerticalLine(pos, size[1], z, color, type, userData);
           // For lines, we can ignore the entire pixel into which this event
           // falls.
           min_ignore =

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -392,7 +392,7 @@ bool ThreadTrack::IsEmpty() const {
 
 
 //-----------------------------------------------------------------------------
-std::string ThreadTrack::GetTooltip(PickingID id) {
+std::string ThreadTrack::GetTooltip(PickingID id) const {
   TextBox* textBox = time_graph_->GetBatcher().GetTextBox(id);
   if (textBox) {
     if (textBox->GetTimer().m_Type != Timer::CORE_ACTIVITY) {

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -400,17 +400,18 @@ std::string ThreadTrack::GetBoxTooltip(PickingID id) const {
 
   Function* func =
       Capture::GSelectedFunctionsMap[text_box->GetTimer().m_FunctionAddress];
-  if (func) {
-    return absl::StrFormat(
-      "<b>%s</b><br/>"
-      "<i>Timing measured through dynamic instrumentation</i>"
-      "<br/><br/>"
-      "<b>Module:</b> %s<br/>"
-      "<b>Time:</b> %s",
-      FunctionUtils::GetDisplayName(*func),
-      FunctionUtils::GetLoadedModuleName(*func),
-      GetPrettyTime(text_box->GetTimer().ElapsedMillis()));
-  } else {
+  if (!func) {
     return text_box->GetText();
   }
+
+  return absl::StrFormat(
+    "<b>%s</b><br/>"
+    "<i>Timing measured through dynamic instrumentation</i>"
+    "<br/><br/>"
+    "<b>Module:</b> %s<br/>"
+    "<b>Time:</b> %s",
+    FunctionUtils::GetDisplayName(*func),
+    FunctionUtils::GetLoadedModuleName(*func),
+    GetPrettyTime(text_box->GetTimer().ElapsedMillis())
+  );
 }

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -223,16 +223,22 @@ void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
             SetTimesliceText(timer, elapsed_us, min_x, &text_box);
           }
           batcher->AddShadedBox(pos, size, z, color, PickingID::BOX,
-                                std::make_shared<PickingUserData>(&text_box, 
-                                    [&](PickingID id) { return this->GetTooltip(id); }));
+            std::make_shared<PickingUserData>(&text_box, 
+              [&](PickingID id) {
+                return this->GetBoxTooltip(id);
+              }
+            )
+          );
         } else {
           auto type = PickingID::LINE;
           batcher->AddVerticalLine(
-              pos, size[1], z, color, type,
-                                   std::make_shared<PickingUserData>(
-                                       &text_box, [&](PickingID id) {
-                return this->GetTooltip(id);
-                                       }));
+            pos, size[1], z, color, type,
+            std::make_shared<PickingUserData>(&text_box, 
+              [&](PickingID id) {
+                return this->GetBoxTooltip(id);
+              }
+            )
+          );
           // For lines, we can ignore the entire pixel into which this event
           // falls.
           min_ignore =
@@ -267,6 +273,10 @@ void ThreadTrack::OnTimer(const Timer& timer) {
   ++num_timers_;
   if (timer.m_Start < min_time_) min_time_ = timer.m_Start;
   if (timer.m_End > max_time_) max_time_ = timer.m_End;
+}
+
+std::string ThreadTrack::GetTooltip() const {
+  return "Shows collected samples";
 }
 
 //-----------------------------------------------------------------------------
@@ -392,7 +402,7 @@ bool ThreadTrack::IsEmpty() const {
 
 
 //-----------------------------------------------------------------------------
-std::string ThreadTrack::GetTooltip(PickingID id) const {
+std::string ThreadTrack::GetBoxTooltip(PickingID id) const {
   TextBox* textBox = time_graph_->GetBatcher().GetTextBox(id);
   if (textBox) {
     if (textBox->GetTimer().m_Type != Timer::CORE_ACTIVITY) {
@@ -401,9 +411,9 @@ std::string ThreadTrack::GetTooltip(PickingID id) const {
       if (func) {
         return absl::StrFormat(
           "<b>%s</b><br/>"
-          "<i>Method hooked through dynamic instrumentation</i>"
+          "<i>Timing measured through dynamic instrumentation</i>"
           "<br/><br/>"
-          "<b>Module:</b> %s"
+          "<b>Module:</b> %s<br/>"
           "<b>Time:</b> %s",
           FunctionUtils::GetDisplayName(*func),
           FunctionUtils::GetLoadedModuleName(*func),

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -222,10 +222,10 @@ void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
           if (!is_collapsed) {
             SetTimesliceText(timer, elapsed_us, min_x, &text_box);
           }
-          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, &text_box);
+          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, {&text_box});
         } else {
           auto type = PickingID::LINE;
-          batcher->AddVerticalLine(pos, size[1], z, color, type, &text_box);
+          batcher->AddVerticalLine(pos, size[1], z, color, type, {&text_box});
           // For lines, we can ignore the entire pixel into which this event
           // falls.
           min_ignore =

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -266,7 +266,7 @@ void ThreadTrack::OnTimer(const Timer& timer) {
 }
 
 std::string ThreadTrack::GetTooltip() const {
-  return "Shows collected samples and instrumented function timings (if existing).";
+  return "Shows collected samples and timings from dynamically instrumented functions";
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -26,6 +26,7 @@ class ThreadTrack : public Track {
   void Draw(GlCanvas* canvas, bool picking) override;
   void OnDrag(int x, int y) override;
   void OnTimer(const Timer& timer);
+  std::string GetTooltip() const override;
 
   // Track
   void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) override;
@@ -78,5 +79,5 @@ class ThreadTrack : public Track {
   mutable Mutex mutex_;
   std::map<int, std::shared_ptr<TimerChain>> timers_;
 
-  std::string GetTooltip(PickingID id) const;
+  std::string GetBoxTooltip(PickingID id) const;
 };

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -78,5 +78,5 @@ class ThreadTrack : public Track {
   mutable Mutex mutex_;
   std::map<int, std::shared_ptr<TimerChain>> timers_;
 
-  std::string GetTooltip(PickingID id);
+  std::string GetTooltip(PickingID id) const;
 };

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -77,4 +77,6 @@ class ThreadTrack : public Track {
   ThreadID thread_id_;
   mutable Mutex mutex_;
   std::map<int, std::shared_ptr<TimerChain>> timers_;
+
+  std::string GetTooltip(PickingID id);
 };

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -118,9 +118,10 @@ void Track::Draw(GlCanvas* canvas, bool picking) {
   batcher->AddBox(box, color, PickingID::PICKABLE);
 
   // Draw rounded corners.
-  float vertical_margin = time_graph_->GetVerticalMargin();
-  const Color kBackgroundColor(70, 70, 70, 255);
   if (!picking) {
+    float vertical_margin = time_graph_->GetVerticalMargin();
+    const Color kBackgroundColor(70, 70, 70, 255);
+  
     float radius = std::min(layout.GetRoundingRadius(), half_label_height);
     uint32_t sides = static_cast<uint32_t>(layout.GetRoundingNumSides() + 0.5f);
     auto rounded_corner = GetRoundedCornerMask(radius, sides);
@@ -142,28 +143,29 @@ void Track::Draw(GlCanvas* canvas, bool picking) {
                     z);
     DrawTriangleFan(batcher, rounded_corner, end_top, kBackgroundColor, 180.f,
                     z);
+
+    // Collapse toggle state management.
+    if (!this->IsCollapsable()) {
+      collapse_toggle_.SetState(TriangleToggle::State::kInactive);
+    } else if (collapse_toggle_.IsInactive()) {
+      collapse_toggle_.ResetToInitialState();
+    }
+
+    // Draw collapsing triangle.
+    float button_offset = layout.GetCollapseButtonOffset();
+    Vec2 toggle_pos =
+        Vec2(tab_x0 + button_offset, m_Pos[1] + half_label_height);
+    collapse_toggle_.SetPos(toggle_pos);
+    collapse_toggle_.Draw(canvas, picking);
+
+    // Draw label.
+    float label_offset_x = layout.GetTrackLabelOffsetX();
+    float label_offset_y = layout.GetTrackLabelOffsetY();
+    const Color kTextWhite(255, 255, 255, 255);
+    canvas->AddText(label_.c_str(), tab_x0 + label_offset_x,
+                    y1 + label_offset_y + m_Size[1], text_z, kTextWhite,
+                    label_width - label_offset_x);
   }
-
-  // Collapse toggle state management.
-  if (!this->IsCollapsable()) {
-    collapse_toggle_.SetState(TriangleToggle::State::kInactive);
-  } else if (collapse_toggle_.IsInactive()) {
-    collapse_toggle_.ResetToInitialState();
-  }
-
-  // Draw collapsing triangle.
-  float button_offset = layout.GetCollapseButtonOffset();
-  Vec2 toggle_pos = Vec2(tab_x0 + button_offset, m_Pos[1] + half_label_height);
-  collapse_toggle_.SetPos(toggle_pos);
-  collapse_toggle_.Draw(canvas, picking);
-
-  // Draw label.
-  float label_offset_x = layout.GetTrackLabelOffsetX();
-  float label_offset_y = layout.GetTrackLabelOffsetY();
-  const Color kTextWhite(255, 255, 255, 255);
-  canvas->AddText(label_.c_str(), tab_x0 + label_offset_x,
-                  y1 + label_offset_y + m_Size[1], text_z, kTextWhite,
-                  label_width - label_offset_x);
 
   m_Canvas = canvas;
 }

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -115,7 +115,11 @@ void Track::Draw(GlCanvas* canvas, bool picking) {
   float tab_x0 = x0 + layout.GetTrackTabOffset();
 
   Box box(Vec2(tab_x0, y0), Vec2(label_width, label_height), track_z);
-  batcher->AddBox(box, color, PickingID::PICKABLE);
+  batcher->AddBox(box, color, PickingID::PICKABLE, 
+    std::make_shared<PickingUserData>(nullptr, [&](PickingID id) { 
+      return GetGenericTooltip(id);
+    })
+  );
 
   // Draw rounded corners.
   if (!picking) {
@@ -196,6 +200,10 @@ void Track::SetSize(float a_SizeX, float a_SizeY) {
 void Track::OnCollapseToggle(TriangleToggle::State /*state*/) {
   time_graph_->NeedsUpdate();
   time_graph_->NeedsRedraw();
+}
+
+std::string Track::GetGenericTooltip(PickingID _) const {
+  return std::string("Displays all hooked functions executed from thread ") + GetLabel();
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -115,17 +115,16 @@ void Track::Draw(GlCanvas* canvas, bool picking) {
   float tab_x0 = x0 + layout.GetTrackTabOffset();
 
   Box box(Vec2(tab_x0, y0), Vec2(label_width, label_height), track_z);
-  batcher->AddBox(box, color, PickingID::PICKABLE, 
-    std::make_shared<PickingUserData>(nullptr, [&](PickingID id) { 
-      return GetGenericTooltip(id);
-    })
-  );
+  batcher->AddBox(box, color, PickingID::PICKABLE,
+                  std::make_shared<PickingUserData>(nullptr, [&](PickingID id) {
+                    return GetGenericTooltip(id);
+                  }));
 
   // Draw rounded corners.
   if (!picking) {
     float vertical_margin = time_graph_->GetVerticalMargin();
     const Color kBackgroundColor(70, 70, 70, 255);
-  
+
     float radius = std::min(layout.GetRoundingRadius(), half_label_height);
     uint32_t sides = static_cast<uint32_t>(layout.GetRoundingNumSides() + 0.5f);
     auto rounded_corner = GetRoundedCornerMask(radius, sides);
@@ -147,21 +146,22 @@ void Track::Draw(GlCanvas* canvas, bool picking) {
                     z);
     DrawTriangleFan(batcher, rounded_corner, end_top, kBackgroundColor, 180.f,
                     z);
+  }
 
-    // Collapse toggle state management.
-    if (!this->IsCollapsable()) {
-      collapse_toggle_.SetState(TriangleToggle::State::kInactive);
-    } else if (collapse_toggle_.IsInactive()) {
-      collapse_toggle_.ResetToInitialState();
-    }
+  // Collapse toggle state management.
+  if (!this->IsCollapsable()) {
+    collapse_toggle_.SetState(TriangleToggle::State::kInactive);
+  } else if (collapse_toggle_.IsInactive()) {
+    collapse_toggle_.ResetToInitialState();
+  }
 
-    // Draw collapsing triangle.
-    float button_offset = layout.GetCollapseButtonOffset();
-    Vec2 toggle_pos =
-        Vec2(tab_x0 + button_offset, m_Pos[1] + half_label_height);
-    collapse_toggle_.SetPos(toggle_pos);
-    collapse_toggle_.Draw(canvas, picking);
+  // Draw collapsing triangle.
+  float button_offset = layout.GetCollapseButtonOffset();
+  Vec2 toggle_pos = Vec2(tab_x0 + button_offset, m_Pos[1] + half_label_height);
+  collapse_toggle_.SetPos(toggle_pos);
+  collapse_toggle_.Draw(canvas, picking);
 
+  if (!picking) {
     // Draw label.
     float label_offset_x = layout.GetTrackLabelOffsetX();
     float label_offset_y = layout.GetTrackLabelOffsetY();

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -115,10 +115,7 @@ void Track::Draw(GlCanvas* canvas, bool picking) {
   float tab_x0 = x0 + layout.GetTrackTabOffset();
 
   Box box(Vec2(tab_x0, y0), Vec2(label_width, label_height), track_z);
-  batcher->AddBox(box, color, PickingID::PICKABLE,
-                  std::make_shared<PickingUserData>(nullptr, [&](PickingID id) {
-                    return GetGenericTooltip(id);
-                  }));
+  batcher->AddBox(box, color, PickingID::PICKABLE);
 
   // Draw rounded corners.
   if (!picking) {
@@ -200,10 +197,6 @@ void Track::SetSize(float a_SizeX, float a_SizeY) {
 void Track::OnCollapseToggle(TriangleToggle::State /*state*/) {
   time_graph_->NeedsUpdate();
   time_graph_->NeedsRedraw();
-}
-
-std::string Track::GetGenericTooltip(PickingID _) const {
-  return std::string("Displays all hooked functions executed from thread ") + GetLabel();
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -100,6 +100,4 @@ class Track : public Pickable {
   Type type_ = kUnknown;
   std::vector<std::shared_ptr<Track>> children_;
   TriangleToggle collapse_toggle_;
-
-  virtual std::string GetGenericTooltip(PickingID _) const;
 };

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -100,4 +100,6 @@ class Track : public Pickable {
   Type type_ = kUnknown;
   std::vector<std::shared_ptr<Track>> children_;
   TriangleToggle collapse_toggle_;
+
+  virtual std::string GetGenericTooltip(PickingID _) const;
 };

--- a/OrbitQt/orbitglwidget.cpp
+++ b/OrbitQt/orbitglwidget.cpp
@@ -295,6 +295,14 @@ void OrbitGLWidget::mouseMoveEvent(QMouseEvent* event) {
   update();
 }
 
+void OrbitGLWidget::enterEvent(QEvent* event) {
+  m_OrbitPanel->SetIsMouseOver(true);
+}
+
+void OrbitGLWidget::leaveEvent(QEvent* event) {
+  m_OrbitPanel->SetIsMouseOver(false);
+}
+
 //-----------------------------------------------------------------------------
 void OrbitGLWidget::keyPressEvent(QKeyEvent* event) {
   if (m_OrbitPanel) {

--- a/OrbitQt/orbitglwidget.cpp
+++ b/OrbitQt/orbitglwidget.cpp
@@ -296,10 +296,12 @@ void OrbitGLWidget::mouseMoveEvent(QMouseEvent* event) {
 }
 
 void OrbitGLWidget::enterEvent(QEvent* event) {
+  UNUSED(event);
   m_OrbitPanel->SetIsMouseOver(true);
 }
 
 void OrbitGLWidget::leaveEvent(QEvent* event) {
+  UNUSED(event);
   m_OrbitPanel->SetIsMouseOver(false);
 }
 

--- a/OrbitQt/orbitglwidget.cpp
+++ b/OrbitQt/orbitglwidget.cpp
@@ -295,13 +295,11 @@ void OrbitGLWidget::mouseMoveEvent(QMouseEvent* event) {
   update();
 }
 
-void OrbitGLWidget::enterEvent(QEvent* event) {
-  UNUSED(event);
+void OrbitGLWidget::enterEvent(QEvent*) {
   m_OrbitPanel->SetIsMouseOver(true);
 }
 
-void OrbitGLWidget::leaveEvent(QEvent* event) {
-  UNUSED(event);
+void OrbitGLWidget::leaveEvent(QEvent*) {
   m_OrbitPanel->SetIsMouseOver(false);
 }
 

--- a/OrbitQt/orbitglwidget.h
+++ b/OrbitQt/orbitglwidget.h
@@ -30,6 +30,8 @@ class OrbitGLWidget : public QOpenGLWidget, protected QOpenGLFunctions {
   void mouseReleaseEvent(QMouseEvent* event) override;
   void mouseDoubleClickEvent(QMouseEvent* event) override;
   void mouseMoveEvent(QMouseEvent* event) override;
+  void enterEvent(QEvent* event) override;
+  void leaveEvent(QEvent* event) override;
   void keyPressEvent(QKeyEvent* event) override;
   void keyReleaseEvent(QKeyEvent* event) override;
   void wheelEvent(QWheelEvent* event) override;

--- a/OrbitQt/orbitglwidget.h
+++ b/OrbitQt/orbitglwidget.h
@@ -30,8 +30,8 @@ class OrbitGLWidget : public QOpenGLWidget, protected QOpenGLFunctions {
   void mouseReleaseEvent(QMouseEvent* event) override;
   void mouseDoubleClickEvent(QMouseEvent* event) override;
   void mouseMoveEvent(QMouseEvent* event) override;
-  void enterEvent(QEvent* event) override;
-  void leaveEvent(QEvent* event) override;
+  void enterEvent(QEvent*) override;
+  void leaveEvent(QEvent*) override;
   void keyPressEvent(QKeyEvent* event) override;
   void keyReleaseEvent(QKeyEvent* event) override;
   void wheelEvent(QWheelEvent* event) override;


### PR DESCRIPTION
Added tooltips for certain elements in the capture window. I did not touch the behavior of how elements of type PickingID::Pickable are stored - in short, their user_data cannot be accessed in the hover or pick callbacks, and tooltips won't work for them (since the tooltip is in the user_data).

I added a seperate GetTooltip() method in _Pickable_ that provides an easy way to add tooltips to those as well. In general, this only refers to the "larger elements" of the UI: Tracks (but not their content), Scrollbars, Tabs... I added a Tooltip for the event tracks with a hint that the samples can be selected as this was mentioned in a UX interview.

I have some more work open on the tooltips for samples, but didn't want to put too much into a single request.