### PR TITLE
Display timings between iterators

### DIFF
--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -618,7 +618,7 @@ void CaptureWindow::DrawScreenSpace() {
 
   // Time bar background
   if (time_graph_.GetCaptureTimeSpanUs() > 0) {
-    Box box(Vec2(0, time_graph_.GetLayout().GetTimeBarHeight()),
+    Box box(Vec2(0, time_graph_.GetLayout().GetSliderWidth()),
             Vec2(getWidth(), time_graph_.GetLayout().GetTimeBarHeight()),
             GlCanvas::Z_VALUE_TEXT_UI_BG);
     ui_batcher_.AddBox(box, Color(70, 70, 70, 200), PickingID::BOX);

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -616,9 +616,11 @@ void CaptureWindow::DrawScreenSpace() {
           Vec2(margin_x1 - margin_x0, canvasHeight - height), z);
   ui_batcher_.AddBox(box, kBackgroundColor, PickingID::BOX);
 
-  // Time bar
+  // Time bar background
   if (time_graph_.GetCaptureTimeSpanUs() > 0) {
-    Box box(Vec2(0, height), Vec2(getWidth(), height), z);
+    Box box(Vec2(0, time_graph_.GetLayout().GetTimeBarHeight()),
+            Vec2(getWidth(), time_graph_.GetLayout().GetTimeBarHeight()),
+            GlCanvas::Z_VALUE_TEXT_UI_BG);
     ui_batcher_.AddBox(box, Color(70, 70, 70, 200), PickingID::BOX);
   }
 }
@@ -857,6 +859,9 @@ void CaptureWindow::RenderTimeBar() {
   static int numTimePoints = 10;
 
   if (time_graph_.GetCaptureTimeSpanUs() > 0) {
+
+    const float time_bar_height = time_graph_.GetLayout().GetTimeBarHeight();
+
     double millis = time_graph_.GetCurrentTimeSpanUs() * 0.001;
     double incr = millis / float(numTimePoints - 1);
     double unit = GetIncrementMs(incr);
@@ -866,7 +871,7 @@ void CaptureWindow::RenderTimeBar() {
 
     static int pixelMargin = 2;
     int screenY =
-        getHeight() - static_cast<int>(m_Slider.GetPixelHeight()) - pixelMargin;
+        getHeight() - static_cast<int>(time_bar_height) - pixelMargin;
     float dummy, worldY;
     ScreenToWorld(0, screenY, dummy, worldY);
 
@@ -886,7 +891,7 @@ void CaptureWindow::RenderTimeBar() {
                              Color(255, 255, 255, 255));
 
       Vec2 pos(worldX, worldY);
-      ui_batcher_.AddVerticalLine(pos, height, Z_VALUE_UI,
+      ui_batcher_.AddVerticalLine(pos, height, GlCanvas::Z_VALUE_UI,
                                   Color(255, 255, 255, 255), PickingID::LINE);
     }
   }

--- a/OrbitGl/LiveFunctionsController.cpp
+++ b/OrbitGl/LiveFunctionsController.cpp
@@ -91,7 +91,7 @@ void LiveFunctionsController::Move() {
         TimeGraph::VisibilityType::kFullyVisible, min_max.first, min_max.second,
         0.5);
   }
-  GCurrentTimeGraph->SetCurrentTextBoxes(current_textboxes_);
+  GCurrentTimeGraph->SetOverlayTextBoxes(current_textboxes_);
 }
 
 bool LiveFunctionsController::OnAllNextButton() {

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -580,9 +580,7 @@ void TimeGraph::Draw(GlCanvas* canvas, bool a_Picking) {
   }
 
   DrawTracks(canvas, a_Picking);
-
   DrawOverlay(canvas, a_Picking);
-
   m_Batcher.Draw(a_Picking);
 
   m_NeedsRedraw = false;
@@ -608,7 +606,9 @@ std::string GetTimeString(const TextBox* box_a, const TextBox* box_b) {
 
 Color GetIteratorBoxColor(uint64_t index) {
   constexpr uint64_t kNumColors = 2;
-  Color colors[kNumColors] = {Color(187, 213, 240, 60), Color(91, 112, 147, 60)};
+  const Color kLightBlueGray = Color(177, 203, 250, 60);
+  const Color kMidBlueGray = Color(81, 102, 157, 60);
+  Color colors[kNumColors] = {kLightBlueGray, kMidBlueGray};
   return colors[index % kNumColors];
 }
 

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -612,10 +612,13 @@ Color GetIteratorBoxColor(uint64_t index) {
 
 void DrawIteratorBox(GlCanvas* canvas, Vec2 pos, Vec2 size, const Color& color,
                      const std::string& label, float text_y) {
-  TextBox text_box(pos, size, label, color);
-  text_box.SetTextY(text_y);
-  text_box.Draw(canvas->GetBatcher(), canvas->GetTextRenderer(),
-                std::numeric_limits<float>::lowest(), true, true);
+  Box box(pos, size, GlCanvas::Z_VALUE_OVERLAY);
+  canvas->GetBatcher()->AddBox(box, color,PickingID::BOX);
+
+  float max_size = size[0];
+  canvas->GetTextRenderer().AddTextTrailingCharsPrioritized(
+      label.c_str(), pos[0], text_y, GlCanvas::Z_VALUE_TEXT,
+      Color(255, 255, 255, 255), 20, max_size);
 
   constexpr float kOffsetBelowText = 5.f;
   Vec2 line_from(pos[0], text_y - kOffsetBelowText);

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -630,19 +630,6 @@ void TimeGraph::DrawOverlay(GlCanvas* canvas, bool picking) {
   if (picking || overlay_current_textboxes_.size() == 0) {
     return;
   }
-  float min_x = std::numeric_limits<float>::max();
-  float max_x = std::numeric_limits<float>::lowest();
-
-  TickType min_tick = std::numeric_limits<TickType>::max();
-  TickType max_tick = std::numeric_limits<TickType>::lowest();
-
-  float world_start_x = canvas->GetWorldTopLeftX();
-  float world_width = canvas->GetWorldWidth();
-
-  float world_start_y = canvas->GetWorldTopLeftY();
-  float world_height = canvas->GetWorldHeight();
-
-  double inv_time_window = 1.0 / GetTimeWindowUs();
 
   std::vector<std::pair<uint64_t, const TextBox*>> boxes(
       overlay_current_textboxes_.size());
@@ -661,6 +648,14 @@ void TimeGraph::DrawOverlay(GlCanvas* canvas, bool picking) {
   // we avoid recomputing them and just cache them here.
   std::vector<float> x_coords;
   x_coords.reserve(boxes.size());
+
+  float world_start_x = canvas->GetWorldTopLeftX();
+  float world_width = canvas->GetWorldWidth();
+
+  float world_start_y = canvas->GetWorldTopLeftY();
+  float world_height = canvas->GetWorldHeight();
+
+  double inv_time_window = 1.0 / GetTimeWindowUs();
 
   // Draw lines for iterators.
   for (const auto& box : boxes) {

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -588,8 +588,8 @@ void TimeGraph::Draw(GlCanvas* canvas, bool a_Picking) {
 
 namespace {
 
-std::string GetLabelBetweenIterators(
-    const TextBox* box_a, const TextBox* box_b) {
+std::string GetLabelBetweenIterators(const TextBox* box_a,
+                                     const TextBox* box_b) {
   std::string function_from =
       Capture::GAddressToFunctionName[box_a->GetTimer().m_FunctionAddress];
   std::string function_to =
@@ -625,8 +625,9 @@ void DrawIteratorBox(GlCanvas* canvas, Vec2 pos, Vec2 size, const Color& color,
 
   float max_size = size[0];
   canvas->GetTextRenderer().AddTextTrailingCharsPrioritized(
-      text.c_str(), pos[0] + kLeftOffset, text_y + kAdditionalSpaceForLine, GlCanvas::Z_VALUE_TEXT,
-      Color(255, 255, 255, 255), time.length(), max_size);
+      text.c_str(), pos[0] + kLeftOffset, text_y + kAdditionalSpaceForLine,
+      GlCanvas::Z_VALUE_TEXT, Color(255, 255, 255, 255), time.length(),
+      max_size);
 
   constexpr const float kOffsetBelowText = kAdditionalSpaceForLine / 2.f;
   Vec2 line_from(pos[0], text_y + kOffsetBelowText);

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -620,15 +620,17 @@ void DrawIteratorBox(GlCanvas* canvas, Vec2 pos, Vec2 size, const Color& color,
 
   std::string text = absl::StrFormat("%s: %s", label, time);
 
-  constexpr float kLeftOffset = 5.f;
+  constexpr const float kAdditionalSpaceForLine = 10.f;
+  constexpr const float kLeftOffset = 5.f;
+
   float max_size = size[0];
   canvas->GetTextRenderer().AddTextTrailingCharsPrioritized(
-      text.c_str(), pos[0] + kLeftOffset, text_y, GlCanvas::Z_VALUE_TEXT,
+      text.c_str(), pos[0] + kLeftOffset, text_y + kAdditionalSpaceForLine, GlCanvas::Z_VALUE_TEXT,
       Color(255, 255, 255, 255), time.length(), max_size);
 
-  constexpr float kOffsetBelowText = 5.f;
-  Vec2 line_from(pos[0], text_y - kOffsetBelowText);
-  Vec2 line_to(pos[0] + size[0], text_y - kOffsetBelowText);
+  constexpr const float kOffsetBelowText = kAdditionalSpaceForLine / 2.f;
+  Vec2 line_from(pos[0], text_y + kOffsetBelowText);
+  Vec2 line_to(pos[0] + size[0], text_y + kOffsetBelowText);
   canvas->GetBatcher()->AddLine(line_from, line_to, GlCanvas::Z_VALUE_OVERLAY,
                                 Color(255, 255, 255, 255), PickingID::LINE);
 }
@@ -699,8 +701,7 @@ void TimeGraph::DrawOverlay(GlCanvas* canvas, bool picking) {
     // of the slider (where we have to take the width, as it is rotated), and
     // the time bar.
     float bottom_margin = m_Layout.GetSliderWidth() +
-                          m_Layout.GetTimeBarHeight() +
-                          m_Layout.GetVerticalMargin();
+                          m_Layout.GetTimeBarHeight();
 
     // The height of text is chosen such that the text of the last box drawn is
     // at pos[1] + bottom_margin (lowest possible position) and the height of

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -129,7 +129,8 @@ class TimeGraph {
 
   Color GetThreadColor(ThreadID tid) const;
 
-  void SetCurrentTextBoxes(const absl::flat_hash_map<uint64_t, const TextBox*>& boxes) {
+  void SetOverlayTextBoxes(
+      const absl::flat_hash_map<uint64_t, const TextBox*>& boxes) {
     overlay_current_textboxes_ = boxes;
     NeedsRedraw();
   }

--- a/OrbitGl/TimeGraphLayout.cpp
+++ b/OrbitGl/TimeGraphLayout.cpp
@@ -35,6 +35,7 @@ TimeGraphLayout::TimeGraphLayout() {
   m_TextZ = -0.02f;
   m_TrackZ = -0.1f;
   m_ToolbarIconHeight = 24.f;
+  time_bar_height_ = 15.f;
 };
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/TimeGraphLayout.cpp
+++ b/OrbitGl/TimeGraphLayout.cpp
@@ -65,6 +65,7 @@ bool TimeGraphLayout::DrawProperties() {
   FLOAT_SLIDER(m_SpaceBetweenTracksAndThread);
   FLOAT_SLIDER(m_SpaceBetweenThreadBlocks);
   FLOAT_SLIDER(m_SliderWidth);
+  FLOAT_SLIDER(time_bar_height_);
   FLOAT_SLIDER(m_TrackTabHeight);
   FLOAT_SLIDER(m_TrackTabOffset);
   FLOAT_SLIDER(m_CollapseButtonOffset);

--- a/OrbitGl/TimeGraphLayout.h
+++ b/OrbitGl/TimeGraphLayout.h
@@ -40,6 +40,7 @@ class TimeGraphLayout {
   void SetNumCores(int a_NumCores) { m_NumCores = a_NumCores; }
   bool DrawProperties();
   bool GetDrawTrackBackground() const { return m_DrawTrackBackground; }
+  float GetTimeBarHeight() const { return time_bar_height_; }
 
  protected:
   int m_NumCores;
@@ -67,6 +68,8 @@ class TimeGraphLayout {
   float m_SpaceBetweenTracks;
   float m_SpaceBetweenTracksAndThread;
   float m_SpaceBetweenThreadBlocks;
+
+  float time_bar_height_;
 
   float m_TextZ;
   float m_TrackZ;

--- a/OrbitGl/TimeGraphLayout.h
+++ b/OrbitGl/TimeGraphLayout.h
@@ -19,6 +19,7 @@ class TimeGraphLayout {
   float GetTrackLabelOffsetX() const { return m_TrackLabelOffsetX; }
   float GetTrackLabelOffsetY() const { return m_TrackLabelOffsetY; }
   float GetSliderWidth() const { return m_SliderWidth; }
+  float GetTimeBarHeight() const { return time_bar_height_; }
   float GetTrackTabWidth() const { return m_TrackTabWidth; }
   float GetTrackTabHeight() const { return m_TrackTabHeight; }
   float GetTrackTabOffset() const { return m_TrackTabOffset; }
@@ -40,7 +41,6 @@ class TimeGraphLayout {
   void SetNumCores(int a_NumCores) { m_NumCores = a_NumCores; }
   bool DrawProperties();
   bool GetDrawTrackBackground() const { return m_DrawTrackBackground; }
-  float GetTimeBarHeight() const { return time_bar_height_; }
 
  protected:
   int m_NumCores;
@@ -54,6 +54,7 @@ class TimeGraphLayout {
   float m_TrackLabelOffsetX;
   float m_TrackLabelOffsetY;
   float m_SliderWidth;
+  float time_bar_height_;
   float m_TrackTabWidth;
   float m_TrackTabHeight;
   float m_TrackTabOffset;
@@ -68,8 +69,6 @@ class TimeGraphLayout {
   float m_SpaceBetweenTracks;
   float m_SpaceBetweenTracksAndThread;
   float m_SpaceBetweenThreadBlocks;
-
-  float time_bar_height_;
 
   float m_TextZ;
   float m_TrackZ;


### PR DESCRIPTION
This PR adds displaying timings between all iterators and also adds a visual indication which time is shown. 

Screenshot what this looks like:
![ORBIT_iterator_timings](https://user-images.githubusercontent.com/17818288/88383166-442aa000-cdaa-11ea-813b-0bd41acd62a3.png)