### PR TITLE
Remove unused fields from Callstack and FunctionStats

### DIFF
--- a/OrbitCore/Callstack.cpp
+++ b/OrbitCore/Callstack.cpp
@@ -13,6 +13,4 @@
 ORBIT_SERIALIZE(CallStack, 0) {
   ORBIT_NVP_VAL(0, m_Data);
   ORBIT_NVP_VAL(0, m_Hash);
-  ORBIT_NVP_VAL(0, m_Depth);
-  ORBIT_NVP_VAL(0, m_ThreadId);
 }

--- a/OrbitCore/Callstack.h
+++ b/OrbitCore/Callstack.h
@@ -18,13 +18,11 @@ struct CallStack {
   CallStack() = default;
   inline CallstackID Hash() {
     if (m_Hash != 0) return m_Hash;
-    m_Hash = XXH64(m_Data.data(), m_Depth * sizeof(uint64_t), 0xca1157ac);
+    m_Hash = XXH64(m_Data.data(), m_Data.size() * sizeof(uint64_t), 0xca1157ac);
     return m_Hash;
   }
 
   CallstackID m_Hash = 0;
-  uint32_t m_Depth = 0;
-  ThreadID m_ThreadId = 0;
   std::vector<uint64_t> m_Data;
 
   ORBIT_SERIALIZABLE;

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -237,7 +237,7 @@ void Capture::RegisterZoneName(uint64_t a_ID, const char* a_Name) {
 //-----------------------------------------------------------------------------
 void Capture::AddCallstack(CallStack& a_CallStack) {
   ScopeLock lock(GCallstackMutex);
-  Capture::GCallstacks[a_CallStack.m_Hash] =
+  Capture::GCallstacks[a_CallStack.Hash()] =
       std::make_shared<CallStack>(a_CallStack);
 }
 

--- a/OrbitCore/FunctionStats.cpp
+++ b/OrbitCore/FunctionStats.cpp
@@ -10,7 +10,6 @@
 
 //-----------------------------------------------------------------------------
 ORBIT_SERIALIZE(FunctionStats, 0) {
-  ORBIT_NVP_VAL(0, m_Address);
   ORBIT_NVP_VAL(0, m_Count);
   ORBIT_NVP_VAL(0, m_TotalTimeMs);
   ORBIT_NVP_VAL(0, m_AverageTimeMs);

--- a/OrbitCore/FunctionStats.h
+++ b/OrbitCore/FunctionStats.h
@@ -14,7 +14,6 @@ struct FunctionStats {
   FunctionStats() { Reset(); }
   void Reset() { memset(this, 0, sizeof(*this)); }
 
-  uint64_t m_Address;
   uint64_t m_Count;
   double m_TotalTimeMs;
   double m_AverageTimeMs;

--- a/OrbitCore/LinuxTracingBufferTest.cpp
+++ b/OrbitCore/LinuxTracingBufferTest.cpp
@@ -133,8 +133,6 @@ TEST(LinuxTracingBuffer, Callstacks) {
     LinuxCallstackEvent event;
     event.time_ = 1;
     event.callstack_.m_Hash = 0;
-    event.callstack_.m_Depth = 2;
-    event.callstack_.m_ThreadId = 5;
     event.callstack_.m_Data.push_back(21);
     event.callstack_.m_Data.push_back(22);
 
@@ -145,8 +143,6 @@ TEST(LinuxTracingBuffer, Callstacks) {
     LinuxCallstackEvent event;
     event.time_ = 2;
     event.callstack_.m_Hash = 1;
-    event.callstack_.m_Depth = 12;
-    event.callstack_.m_ThreadId = 15;
     event.callstack_.m_Data.push_back(121);
     event.callstack_.m_Data.push_back(122);
 
@@ -161,22 +157,18 @@ TEST(LinuxTracingBuffer, Callstacks) {
 
   EXPECT_EQ(callstacks[0].time_, 1);
   EXPECT_EQ(callstacks[0].callstack_.m_Hash, 0);
-  EXPECT_EQ(callstacks[0].callstack_.m_Depth, 2);
-  EXPECT_EQ(callstacks[0].callstack_.m_ThreadId, 5);
+  EXPECT_EQ(callstacks[0].callstack_.m_Data.size(), 2);
   EXPECT_THAT(callstacks[0].callstack_.m_Data, testing::ElementsAre(21, 22));
 
   EXPECT_EQ(callstacks[1].time_, 2);
   EXPECT_EQ(callstacks[1].callstack_.m_Hash, 1);
-  EXPECT_EQ(callstacks[1].callstack_.m_Depth, 12);
-  EXPECT_EQ(callstacks[1].callstack_.m_ThreadId, 15);
+  EXPECT_EQ(callstacks[1].callstack_.m_Data.size(), 2);
   EXPECT_THAT(callstacks[1].callstack_.m_Data, testing::ElementsAre(121, 122));
 
   {
     LinuxCallstackEvent event;
     event.time_ = 3;
     event.callstack_.m_Hash = 21;
-    event.callstack_.m_Depth = 22;
-    event.callstack_.m_ThreadId = 25;
     event.callstack_.m_Data.push_back(221);
     event.callstack_.m_Data.push_back(222);
 
@@ -191,8 +183,7 @@ TEST(LinuxTracingBuffer, Callstacks) {
 
   EXPECT_EQ(callstacks[0].time_, 3);
   EXPECT_EQ(callstacks[0].callstack_.m_Hash, 21);
-  EXPECT_EQ(callstacks[0].callstack_.m_Depth, 22);
-  EXPECT_EQ(callstacks[0].callstack_.m_ThreadId, 25);
+  EXPECT_EQ(callstacks[0].callstack_.m_Data.size(), 2);
   EXPECT_THAT(callstacks[0].callstack_.m_Data, testing::ElementsAre(221, 222));
 }
 
@@ -367,8 +358,6 @@ TEST(LinuxTracingBuffer, Reset) {
     LinuxCallstackEvent event;
     event.time_ = 3;
     event.callstack_.m_Hash = 21;
-    event.callstack_.m_Depth = 22;
-    event.callstack_.m_ThreadId = 25;
     event.callstack_.m_Data.push_back(221);
     event.callstack_.m_Data.push_back(222);
 

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -74,7 +74,7 @@ class SamplingProfiler {
 
   int GetNumSamples() const { return m_NumSamples; }
 
-  void AddCallStack(CallStack& a_CallStack);
+  void AddCallStack(CallstackEvent& callstack_event);
   void AddHashedCallStack(CallstackEvent& a_CallStack);
   void AddUniqueCallStack(CallStack& a_CallStack);
 

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -158,7 +158,7 @@ void CallStackDataView::DoFilter() {
   std::vector<uint32_t> indices;
   std::vector<std::string> tokens = absl::StrSplit(ToLower(m_Filter), ' ');
 
-  for (size_t i = 0; i < m_CallStack->m_Depth; ++i) {
+  for (size_t i = 0; i < m_CallStack->m_Data.size(); ++i) {
     CallStackDataViewFrame frame = GetFrameFromIndex(i);
     Function* function = frame.function;
     std::string name =
@@ -183,7 +183,7 @@ void CallStackDataView::DoFilter() {
 
 //-----------------------------------------------------------------------------
 void CallStackDataView::OnDataChanged() {
-  size_t numFunctions = m_CallStack ? m_CallStack->m_Depth : 0;
+  size_t numFunctions = m_CallStack ? m_CallStack->m_Data.size() : 0;
   m_Indices.resize(numFunctions);
   for (size_t i = 0; i < numFunctions; ++i) {
     m_Indices[i] = i;
@@ -202,7 +202,7 @@ CallStackDataView::CallStackDataViewFrame CallStackDataView::GetFrameFromRow(
 CallStackDataView::CallStackDataViewFrame CallStackDataView::GetFrameFromIndex(
     int index_in_callstack) {
   if (m_CallStack == nullptr ||
-      index_in_callstack >= static_cast<int>(m_CallStack->m_Depth)) {
+      index_in_callstack >= static_cast<int>(m_CallStack->m_Data.size())) {
     return CallStackDataViewFrame();
   }
 

--- a/OrbitGl/CaptureEventProcessor.cpp
+++ b/OrbitGl/CaptureEventProcessor.cpp
@@ -183,7 +183,6 @@ uint64_t CaptureEventProcessor::GetCallstackHashAndSendToListenerIfNecessary(
   for (uint64_t pc : callstack.pcs()) {
     cs.m_Data.push_back(pc);
   }
-  cs.m_Depth = cs.m_Data.size();
   // TODO: Compute the hash without creating the CallStack if not necessary.
   uint64_t hash = cs.Hash();
 

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -115,10 +115,10 @@ bool TimeGraph::UpdateCaptureMinMaxTimestamps() {
   m_Mutex.unlock();
 
   if (GEventTracer.GetEventBuffer().HasEvent()) {
-    capture_min_timestamp_ = std::min(capture_min_timestamp_,
-                                   GEventTracer.GetEventBuffer().GetMinTime());
-    capture_max_timestamp_ = std::max(capture_max_timestamp_,
-                                   GEventTracer.GetEventBuffer().GetMaxTime());
+    capture_min_timestamp_ = std::min(
+        capture_min_timestamp_, GEventTracer.GetEventBuffer().GetMinTime());
+    capture_max_timestamp_ = std::max(
+        capture_max_timestamp_, GEventTracer.GetEventBuffer().GetMaxTime());
   }
 
   return capture_min_timestamp_ != std::numeric_limits<TickType>::max();
@@ -155,7 +155,8 @@ void TimeGraph::Zoom(const TextBox* a_TextBox) {
 //-----------------------------------------------------------------------------
 double TimeGraph::GetCaptureTimeSpanUs() {
   if (UpdateCaptureMinMaxTimestamps()) {
-    return MicroSecondsFromTicks(capture_min_timestamp_, capture_max_timestamp_);
+    return MicroSecondsFromTicks(capture_min_timestamp_,
+                                 capture_max_timestamp_);
   }
 
   return 0;
@@ -540,11 +541,8 @@ std::vector<CallstackEvent> TimeGraph::SelectEvents(float a_WorldStart,
   samplingProfiler->SetGenerateSummary(a_TID == 0);
 
   for (CallstackEvent& event : selected_callstack_events) {
-    std::shared_ptr<CallStack> callstack =
-        Capture::GSamplingProfiler->GetCallStack(event.m_Id);
-    if (callstack) {
-      callstack->m_ThreadId = event.m_TID;
-      samplingProfiler->AddCallStack(*callstack);
+    if (Capture::GSamplingProfiler->GetCallStack(event.m_Id)) {
+      samplingProfiler->AddCallStack(event);
     }
   }
   samplingProfiler->ProcessSamples();
@@ -614,7 +612,8 @@ void TimeGraph::DrawOverlay(GlCanvas* canvas, bool picking) {
     Color color = GetThreadColor(timer.m_TID);
 
     auto type = PickingID::LINE;
-    canvas->GetBatcher()->AddVerticalLine(pos, -world_height, z, color, type, nullptr);
+    canvas->GetBatcher()->AddVerticalLine(pos, -world_height, z, color, type,
+                                          nullptr);
   }
   if (overlay_current_textboxes_.size() > 1) {
     float from = min_x;
@@ -631,7 +630,7 @@ void TimeGraph::DrawOverlay(GlCanvas* canvas, bool picking) {
     int current_font_size = canvas->GetTextRenderer().GetFontSize();
     canvas->GetTextRenderer().SetFontSize(20);
     text_box.Draw(canvas->GetBatcher(), canvas->GetTextRenderer(),
-      std::numeric_limits<float>::lowest(), true, true);
+                  std::numeric_limits<float>::lowest(), true, true);
     canvas->GetTextRenderer().SetFontSize(current_font_size);
   }
 }


### PR DESCRIPTION
- Removed m_Address from FunctionStats because it's not used

- m_Depth in CallStack is set up as m_Data.size() and never changed (except the test), so can be removed

- m_ThreadId is used only once: it's set up from CallstackEvent and used to set up the field in another CallstackEvent. We can avoid it by passing CallstackEvent instead of Callstack.

- Replaced m_Hash with Hash (which basically returns m_Hash, but also initialize it if it wasn't done before)