### PR TITLE
More descriptive names for the GPU tracks

### DIFF
--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -12,9 +12,28 @@
 #include "absl/flags/flag.h"
 #include "absl/strings/str_format.h"
 
+<<<<<<< HEAD
 constexpr const char* kSwQueueString = "sw queue";
 constexpr const char* kHwQueueString = "hw queue";
 constexpr const char* kHwExecutionString = "hw execution";
+=======
+std::string MapGpuTimelineToTrackLabel(std::string_view timeline) {
+  std::string label;
+  if (timeline.rfind("gfx", 0) == 0) {
+    return absl::StrFormat("Graphics queue (%s)", timeline);
+  } else if (timeline.rfind("sdma", 0) == 0) {
+    return absl::StrFormat("Transfer queue (%s)", timeline);
+  } else if (timeline.rfind("comp", 0) == 0) {
+    return absl::StrFormat("Compute queue (%s)", timeline);
+  } else {
+    // On AMD, this should not happen and we don't support tracepoints for
+    // other GPUs (at the moment). We return the timeline to make sure we
+    // at least display something. When we add support for other GPU
+    // tracepoints, this needs to be changed.
+    return std::string(timeline);
+  }
+}
+>>>>>>> Define GPU timeline to track label conversion in free function; add some clarifying comments.
 
 //-----------------------------------------------------------------------------
 GpuTrack::GpuTrack(TimeGraph* time_graph,

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -12,11 +12,12 @@
 #include "absl/flags/flag.h"
 #include "absl/strings/str_format.h"
 
-<<<<<<< HEAD
 constexpr const char* kSwQueueString = "sw queue";
 constexpr const char* kHwQueueString = "hw queue";
 constexpr const char* kHwExecutionString = "hw execution";
-=======
+
+namespace OrbitGl {
+
 std::string MapGpuTimelineToTrackLabel(std::string_view timeline) {
   std::string label;
   if (timeline.rfind("gfx", 0) == 0) {
@@ -33,7 +34,8 @@ std::string MapGpuTimelineToTrackLabel(std::string_view timeline) {
     return std::string(timeline);
   }
 }
->>>>>>> Define GPU timeline to track label conversion in free function; add some clarifying comments.
+
+}  // namespace OrbitGl
 
 //-----------------------------------------------------------------------------
 GpuTrack::GpuTrack(TimeGraph* time_graph,

--- a/OrbitGl/GpuTrack.h
+++ b/OrbitGl/GpuTrack.h
@@ -54,7 +54,7 @@ class GpuTrack : public Track {
   std::vector<std::shared_ptr<TimerChain>> GetAllChains() override;
   bool IsCollapsable() const override { return depth_ > 1; }
 
-  void SetTimeline(const std::string& timeline);
+  void SetTimeline(std::string_view timeline);
 
  protected:
   void UpdateDepth(uint32_t depth) {

--- a/OrbitGl/GpuTrack.h
+++ b/OrbitGl/GpuTrack.h
@@ -54,6 +54,8 @@ class GpuTrack : public Track {
   std::vector<std::shared_ptr<TimerChain>> GetAllChains() override;
   bool IsCollapsable() const override { return depth_ > 1; }
 
+  void SetTimeline(const std::string& timeline);
+
  protected:
   void UpdateDepth(uint32_t depth) {
     if (depth > depth_) depth_ = depth;

--- a/OrbitGl/GpuTrack.h
+++ b/OrbitGl/GpuTrack.h
@@ -20,7 +20,7 @@ class TextRenderer;
 namespace OrbitGl {
 
 // Maps the Linux kernel timeline names (like "gfx", "sdma0") to a more
-// descriptive human readable form that is used for the track labe.
+// descriptive human readable form that is used for the track label.
 std::string MapGpuTimelineToTrackLabel(std::string_view timeline);
 
 }  // namespace OrbitGl

--- a/OrbitGl/GpuTrack.h
+++ b/OrbitGl/GpuTrack.h
@@ -17,9 +17,13 @@
 
 class TextRenderer;
 
+namespace OrbitGl {
+
 // Maps the Linux kernel timeline names (like "gfx", "sdma0") to a more
 // descriptive human readable form that is used for the track labe.
 std::string MapGpuTimelineToTrackLabel(std::string_view timeline);
+
+}  // namespace OrbitGl
 
 class GpuTrack : public Track {
  public:

--- a/OrbitGl/GpuTrack.h
+++ b/OrbitGl/GpuTrack.h
@@ -17,6 +17,10 @@
 
 class TextRenderer;
 
+// Maps the Linux kernel timeline names (like "gfx", "sdma0") to a more
+// descriptive human readable form that is used for the track labe.
+std::string MapGpuTimelineToTrackLabel(std::string_view timeline);
+
 class GpuTrack : public Track {
  public:
   GpuTrack(TimeGraph* time_graph, std::shared_ptr<StringManager> string_manager,
@@ -53,8 +57,6 @@ class GpuTrack : public Track {
 
   std::vector<std::shared_ptr<TimerChain>> GetAllChains() override;
   bool IsCollapsable() const override { return depth_ > 1; }
-
-  void SetTimeline(std::string_view timeline);
 
  protected:
   void UpdateDepth(uint32_t depth) {

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -324,8 +324,6 @@ void TimeGraph::ProcessTimer(const Timer& a_Timer) {
   if (a_Timer.m_Type == Timer::GPU_ACTIVITY) {
     uint64_t timeline_hash = GetGpuTimelineHash(a_Timer);
     std::shared_ptr<GpuTrack> track = GetOrCreateGpuTrack(timeline_hash);
-    track->SetName(string_manager_->Get(timeline_hash).value_or(""));
-    track->SetLabel(string_manager_->Get(timeline_hash).value_or(""));
     track->OnTimer(a_Timer);
   } else {
     std::shared_ptr<ThreadTrack> track = GetOrCreateThreadTrack(a_Timer.m_TID);
@@ -707,6 +705,7 @@ std::shared_ptr<GpuTrack> TimeGraph::GetOrCreateGpuTrack(
   std::shared_ptr<GpuTrack> track = gpu_tracks_[timeline_hash];
   if (track == nullptr) {
     track = std::make_shared<GpuTrack>(this, string_manager_, timeline_hash);
+    track->SetTimeline(string_manager_->Get(timeline_hash).value_or(""));
     tracks_.emplace_back(track);
     gpu_tracks_[timeline_hash] = track;
   }

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -706,7 +706,7 @@ std::shared_ptr<GpuTrack> TimeGraph::GetOrCreateGpuTrack(
   if (track == nullptr) {
     track = std::make_shared<GpuTrack>(this, string_manager_, timeline_hash);
     std::string timeline = string_manager_->Get(timeline_hash).value_or("");
-    std::string label = MapGpuTimelineToTrackLabel(timeline);
+    std::string label = OrbitGl::MapGpuTimelineToTrackLabel(timeline);
     track->SetName(timeline);
     track->SetLabel(label);
     tracks_.emplace_back(track);

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -705,7 +705,10 @@ std::shared_ptr<GpuTrack> TimeGraph::GetOrCreateGpuTrack(
   std::shared_ptr<GpuTrack> track = gpu_tracks_[timeline_hash];
   if (track == nullptr) {
     track = std::make_shared<GpuTrack>(this, string_manager_, timeline_hash);
-    track->SetTimeline(string_manager_->Get(timeline_hash).value_or(""));
+    std::string timeline = string_manager_->Get(timeline_hash).value_or("");
+    std::string label = MapGpuTimelineToTrackLabel(timeline);
+    track->SetName(timeline);
+    track->SetLabel(label);
     tracks_.emplace_back(track);
     gpu_tracks_[timeline_hash] = track;
   }


### PR DESCRIPTION
There are three names of queues that we can encounter (on AMD): "gfx", "sdmaX", and "comp_X.Y.Z". After this change, these names are used for more descriptive track names ("Graphics queue", "Transfer queue", "Compute queue"). The original name passed from the tracepoint is still used in the name to disambiguate if, for instance, multiple compute queues are used.