### PR TITLE
Clean up iterator UI when function live data changes

### DIFF
--- a/OrbitGl/LiveFunctionsController.cpp
+++ b/OrbitGl/LiveFunctionsController.cpp
@@ -223,3 +223,23 @@ TickType LiveFunctionsController::GetCaptureMin() {
 TickType LiveFunctionsController::GetCaptureMax() {
   return GCurrentTimeGraph->GetCaptureMax();
 }
+
+void LiveFunctionsController::Reset() {
+  function_iterators_.clear();
+  current_textboxes_.clear();
+  GCurrentTimeGraph->SetCurrentTextBoxes({});
+  next_iterator_id_ = 0;
+  id_to_select_ = 0;
+}
+
+void LiveFunctionsController::OnDataChanged() {
+  live_functions_data_view_.OnDataChanged();
+  // A data change means that all iterators should be invalidated, so we
+  // completely reset everything here.
+  Reset();
+}
+
+void LiveFunctionsController::SetAddIteratorCallback(
+    std::function<void(uint64_t, Function*)> callback) {
+  add_iterator_callback_ = callback;
+}

--- a/OrbitGl/LiveFunctionsController.h
+++ b/OrbitGl/LiveFunctionsController.h
@@ -27,12 +27,11 @@ class LiveFunctionsController {
   void OnPreviousButton(uint64_t id);
   void OnDeleteButton(uint64_t id);
 
-  void OnDataChanged() { live_functions_data_view_.OnDataChanged(); }
+  void Reset();
+  void OnDataChanged();
 
   void SetAddIteratorCallback(
-      std::function<void(uint64_t, Function*)> callback) {
-    add_iterator_callback_ = callback;
-  }
+      std::function<void(uint64_t, Function*)> callback);
 
   TickType GetCaptureMin();
   TickType GetCaptureMax();

--- a/OrbitQt/orbitlivefunctions.cpp
+++ b/OrbitQt/orbitlivefunctions.cpp
@@ -61,7 +61,17 @@ void OrbitLiveFunctions::SetFilter(const QString& a_Filter) {
 //-----------------------------------------------------------------------------
 void OrbitLiveFunctions::Refresh() { ui->data_view_panel_->Refresh(); }
 
-void OrbitLiveFunctions::OnDataChanged() { live_functions_.OnDataChanged(); }
+void OrbitLiveFunctions::OnDataChanged() {
+  live_functions_.OnDataChanged();
+  // A data change in the live view panel means that all iterators need to be
+  // invalidated, so we clean up here.
+  for (auto& [_, iterator_ui] : iterator_uis) {
+    ui->iteratorLayout->removeWidget(iterator_ui);
+    delete iterator_ui;
+  }
+  iterator_uis.clear();
+  all_events_iterator_->DisableButtons();
+  }
 
 void OrbitLiveFunctions::AddIterator(size_t id, Function* function) {
   OrbitEventIterator* iterator_ui = new OrbitEventIterator(this);


### PR DESCRIPTION
When live data changes, it is likely necessary to remove the iterators that exist. Even if they still make sense for the newly hooked functions, it would be hard to update all data correctly to the new capture. We therefore completely clean up the UI whenever the live data changes. 