### PR TITLE
Tooltips for samples in the capture window

### DIFF
--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -115,8 +115,8 @@ PickingUserData* Batcher::GetUserData(PickingID a_ID) {
 TextBox* Batcher::GetTextBox(PickingID a_ID) {
   PickingUserData* data = GetUserData(a_ID);
 
-  if (data && data->m_TextBox) {
-    return data->m_TextBox; 
+  if (data && data->text_box_) {
+    return data->text_box_; 
   }
 
   return nullptr;

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -15,6 +15,7 @@ using TooltipCallback = std::function<std::string(PickingID)>;
 struct PickingUserData {
   TextBox* m_TextBox;
   TooltipCallback m_GenerateTooltip;
+  void* m_CustomData = nullptr;
 
   PickingUserData(
     TextBox* text_box = nullptr,

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -13,14 +13,14 @@
 using TooltipCallback = std::function<std::string(PickingID)>;
 
 struct PickingUserData {
-  TextBox* m_TextBox;
-  TooltipCallback m_GenerateTooltip;
-  void* m_CustomData = nullptr;
+  TextBox* text_box_;
+  TooltipCallback generate_tooltip_;
+  void* custom_data_ = nullptr;
 
   PickingUserData(
     TextBox* text_box = nullptr,
     TooltipCallback generate_tooltip = nullptr)
-    : m_TextBox(text_box), m_GenerateTooltip(generate_tooltip) {}
+    : text_box_(text_box), generate_tooltip_(generate_tooltip) {}
 };
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -542,7 +542,7 @@ void CaptureWindow::Draw() {
   // Reset picking manager before each draw.
   m_PickingManager.Reset();
 
-  time_graph_.Draw(this, m_Picking);
+  time_graph_.Draw(this, GetPickingMode());
 
   if (!m_Picking && m_SelectStart[0] != m_SelectStop[0]) {
     TickType minTime = std::min(m_TimeStart, m_TimeStop);
@@ -584,6 +584,8 @@ void CaptureWindow::DrawScreenSpace() {
   const TimeGraphLayout& layout = time_graph_.GetLayout();
   float vertical_margin = layout.GetVerticalMargin();
 
+  const auto picking_mode = GetPickingMode();
+
   if (timeSpan > 0) {
     double start = time_graph_.GetMinTimeUs();
     double stop = time_graph_.GetMaxTimeUs();
@@ -595,13 +597,13 @@ void CaptureWindow::DrawScreenSpace() {
     m_Slider.SetPixelHeight(slider_width);
     m_Slider.SetSliderRatio(static_cast<float>(ratio));
     m_Slider.SetSliderWidthRatio(static_cast<float>(width / timeSpan));
-    m_Slider.Draw(this, m_Picking);
+    m_Slider.Draw(this, picking_mode);
 
     float verticalRatio = m_WorldHeight / time_graph_.GetThreadTotalHeight();
     if (verticalRatio < 1.f) {
       m_VerticalSlider.SetPixelHeight(slider_width);
       m_VerticalSlider.SetSliderWidthRatio(verticalRatio);
-      m_VerticalSlider.Draw(this, m_Picking);
+      m_VerticalSlider.Draw(this, picking_mode);
       vertical_margin += slider_width;
     }
   }
@@ -657,6 +659,18 @@ Batcher& CaptureWindow::GetBatcherById(uint32_t batcher_id) {
   return batcher_id == PickingID::TIME_GRAPH
                          ? time_graph_.GetBatcher()
                          : ui_batcher_;
+}
+
+PickingMode CaptureWindow::GetPickingMode() { 
+  PickingMode picking_mode = PickingMode::kNone;
+  if (m_Picking) {
+    picking_mode = PickingMode::kClick;
+  }
+  if (m_IsHovering) {
+    picking_mode = PickingMode::kHover;
+  }
+
+  return picking_mode;
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -228,8 +228,8 @@ void CaptureWindow::Hover(int a_X, int a_Y) {
   } else {
     PickingUserData* user_data = batcher.GetUserData(pickId);
 
-    if (user_data && user_data->m_GenerateTooltip) {
-      tooltip = user_data->m_GenerateTooltip(pickId);
+    if (user_data && user_data->generate_tooltip_) {
+      tooltip = user_data->generate_tooltip_(pickId);
     }
   }
 
@@ -661,7 +661,7 @@ Batcher& CaptureWindow::GetBatcherById(uint32_t batcher_id) {
                          : ui_batcher_;
 }
 
-PickingMode CaptureWindow::GetPickingMode() { 
+[[nodiscard]] PickingMode CaptureWindow::GetPickingMode() { 
   PickingMode picking_mode = PickingMode::kNone;
   if (m_Picking) {
     picking_mode = PickingMode::kClick;

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -64,6 +64,9 @@ class CaptureWindow : public GlCanvas {
   void ToggleDrawHelp();
 
   Batcher& GetBatcherById(uint32_t batcher_id);
+ 
+ private:
+  PickingMode GetPickingMode();
 
  private:
   TimeGraph time_graph_;

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -66,7 +66,7 @@ class CaptureWindow : public GlCanvas {
   Batcher& GetBatcherById(uint32_t batcher_id);
  
  private:
-  PickingMode GetPickingMode();
+  [[nodiscard]] PickingMode GetPickingMode();
 
  private:
   TimeGraph time_graph_;

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -186,7 +186,9 @@ bool EventTrack::IsEmpty() const {
 std::string EventTrack::GetSampleTooltip(PickingID id) const {
   auto SafeGetFormattedFunctionName = [](uint64_t addr) -> std::string {
     auto it = Capture::GAddressToFunctionName.find(addr);
-    return it == Capture::GAddressToFunctionName.end() ? "<i>???</i>" : it->second;
+    return it == Capture::GAddressToFunctionName.end()
+               ? std::string("<i>") + "???" + "</i>"
+               : it->second;
   };
 
   static const std::string unknown_return_text = "Function call information missing";

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -31,7 +31,9 @@ void EventTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   // have a tooltip. For picking, we want to draw the event bar over them if
   // handling a click, and underneath otherwise.
   // This simulates "click-through" behavior.
-  const float eventBarZ = picking_mode == PickingMode::kClick ? 0.1f : -0.1f;
+  const float eventBarZ = picking_mode == PickingMode::kClick
+                              ? GlCanvas::Z_VALUE_EVENT_BAR_PICKING
+                              : GlCanvas::Z_VALUE_EVENT_BAR;
   Color color = m_Color;
 
   if (picking) {
@@ -50,8 +52,10 @@ void EventTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   float x1 = x0 + m_Size[0];
   float y1 = y0 - m_Size[1];
 
-  batcher->AddLine(m_Pos, Vec2(x1, y0), -0.1f, color, PickingID::PICKABLE);
-  batcher->AddLine(Vec2(x1, y1), Vec2(x0, y1), -0.1f, color,
+  batcher->AddLine(m_Pos, Vec2(x1, y0), GlCanvas::Z_VALUE_EVENT_BAR, color,
+                   PickingID::PICKABLE);
+  batcher->AddLine(Vec2(x1, y1), Vec2(x0, y1), GlCanvas::Z_VALUE_EVENT_BAR,
+                   color,
                    PickingID::PICKABLE);
 
   if (m_Picked) {

--- a/OrbitGl/EventTrack.h
+++ b/OrbitGl/EventTrack.h
@@ -19,7 +19,7 @@ class EventTrack : public Track {
   std::string GetTooltip() const override;
 
   void Draw(GlCanvas* canvas, bool picking) override;
-  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) override;
+  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, bool picking) override;
 
   void OnPick(int a_X, int a_Y) override;
   void OnRelease() override;
@@ -36,6 +36,7 @@ class EventTrack : public Track {
 
  protected:
   void SelectEvents();
+  std::string GetSampleTooltip(PickingID id) const;
 
  protected:
   TextBox m_ThreadName;

--- a/OrbitGl/EventTrack.h
+++ b/OrbitGl/EventTrack.h
@@ -18,8 +18,9 @@ class EventTrack : public Track {
 
   std::string GetTooltip() const override;
 
-  void Draw(GlCanvas* canvas, bool picking) override;
-  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, bool picking) override;
+  void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
+  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
+                        PickingMode picking_mode) override;
 
   void OnPick(int a_X, int a_Y) override;
   void OnRelease() override;

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -34,6 +34,8 @@ float GlCanvas::Z_VALUE_CONTEXT_SWITCH = -0.015f;
 float GlCanvas::Z_VALUE_EVENT = -0.015f;
 float GlCanvas::Z_VALUE_BOX_ACTIVE = -0.02f;
 float GlCanvas::Z_VALUE_BOX_INACTIVE = -0.03f;
+float GlCanvas::Z_VALUE_EVENT_BAR = -0.1f;
+float GlCanvas::Z_VALUE_EVENT_BAR_PICKING = 0.1f;
 
 //-----------------------------------------------------------------------------
 void ClearCaptureData() {

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -112,6 +112,8 @@ class GlCanvas : public GlPanel {
   static float Z_VALUE_BOX_ACTIVE;
   static float Z_VALUE_BOX_INACTIVE;
   static float Z_VALUE_TEXT_BG;
+  static float Z_VALUE_EVENT_BAR;
+  static float Z_VALUE_EVENT_BAR_PICKING;
 
  protected:
   int m_Width;

--- a/OrbitGl/GlSlider.cpp
+++ b/OrbitGl/GlSlider.cpp
@@ -105,13 +105,15 @@ void GlSlider::OnDragHorizontal(int a_X, int /*a_Y*/) {
 }
 
 //-----------------------------------------------------------------------------
-void GlSlider::Draw(GlCanvas* a_Canvas, bool a_Picking) {
-  m_Vertical ? DrawVertical(a_Canvas, a_Picking)
-             : DrawHorizontal(a_Canvas, a_Picking);
+void GlSlider::Draw(GlCanvas* a_Canvas, PickingMode picking_mode) {
+  m_Vertical ? DrawVertical(a_Canvas, picking_mode)
+             : DrawHorizontal(a_Canvas, picking_mode);
 }
 
 //-----------------------------------------------------------------------------
-void GlSlider::DrawHorizontal(GlCanvas* canvas, bool picking) {
+void GlSlider::DrawHorizontal(GlCanvas* canvas, PickingMode picking_mode) {
+  const bool picking = picking_mode != PickingMode::kNone;
+
   m_Canvas = canvas;
   Batcher* batcher = canvas->GetBatcher();
 
@@ -143,7 +145,8 @@ void GlSlider::DrawHorizontal(GlCanvas* canvas, bool picking) {
 }
 
 //-----------------------------------------------------------------------------
-void GlSlider::DrawVertical(GlCanvas* canvas, bool picking) {
+void GlSlider::DrawVertical(GlCanvas* canvas, PickingMode picking_mode) {
+  const bool picking = picking_mode != PickingMode::kNone;
   m_Canvas = canvas;
   Batcher* batcher = canvas->GetBatcher();
 

--- a/OrbitGl/GlSlider.h
+++ b/OrbitGl/GlSlider.h
@@ -19,7 +19,7 @@ class GlSlider : public Pickable {
 
   void OnPick(int a_X, int a_Y) override;
   void OnDrag(int a_X, int a_Y) override;
-  void Draw(GlCanvas* a_Canvas, bool a_Picking) override;
+  void Draw(GlCanvas* a_Canvas, PickingMode picking_mode) override;
   bool Draggable() override { return true; }
   void SetSliderRatio(float a_Start);       // [0,1]
   void SetSliderWidthRatio(float a_Ratio);  // [0,1]
@@ -33,8 +33,8 @@ class GlSlider : public Pickable {
   void SetDragCallback(DragCallback a_Callback) { m_DragCallback = a_Callback; }
 
  protected:
-  void DrawHorizontal(GlCanvas* a_Canvas, bool a_Picking);
-  void DrawVertical(GlCanvas* a_Canvas, bool a_Picking);
+  void DrawHorizontal(GlCanvas* a_Canvas, PickingMode picking_mode);
+  void DrawVertical(GlCanvas* a_Canvas, PickingMode picking_mode);
   void OnDragHorizontal(int a_X, int a_Y);
   void OnDragVertical(int a_X, int a_Y);
   void OnPickHorizontal(int a_X, int a_Y);

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -56,14 +56,14 @@ GpuTrack::GpuTrack(TimeGraph* time_graph,
 }
 
 //-----------------------------------------------------------------------------
-void GpuTrack::Draw(GlCanvas* canvas, bool picking) {
+void GpuTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   float track_height = GetHeight();
   float track_width = canvas->GetWorldWidth();
 
   SetPos(canvas->GetWorldTopLeftX(), m_Pos[1]);
   SetSize(track_width, track_height);
 
-  Track::Draw(canvas, picking);
+  Track::Draw(canvas, picking_mode);
 }
 
 //-----------------------------------------------------------------------------
@@ -143,7 +143,8 @@ void GpuTrack::SetTimesliceText(const Timer& timer, double elapsed_us,
 }
 
 //-----------------------------------------------------------------------------
-void GpuTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, bool picking) {
+void GpuTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
+                                PickingMode picking_mode) {
   Batcher* batcher = &time_graph_->GetBatcher();
   GlCanvas* canvas = time_graph_->GetCanvas();
   const TimeGraphLayout& layout = time_graph_->GetLayout();

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -143,7 +143,7 @@ void GpuTrack::SetTimesliceText(const Timer& timer, double elapsed_us,
 }
 
 //-----------------------------------------------------------------------------
-void GpuTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
+void GpuTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, bool picking) {
   Batcher* batcher = &time_graph_->GetBatcher();
   GlCanvas* canvas = time_graph_->GetCanvas();
   const TimeGraphLayout& layout = time_graph_->GetLayout();

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -144,7 +144,7 @@ void GpuTrack::SetTimesliceText(const Timer& timer, double elapsed_us,
 
 //-----------------------------------------------------------------------------
 void GpuTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
-                                PickingMode picking_mode) {
+                                PickingMode /*picking_mode*/) {
   Batcher* batcher = &time_graph_->GetBatcher();
   GlCanvas* canvas = time_graph_->GetCanvas();
   const TimeGraphLayout& layout = time_graph_->GetLayout();

--- a/OrbitGl/GpuTrack.h
+++ b/OrbitGl/GpuTrack.h
@@ -39,7 +39,7 @@ class GpuTrack : public Track {
 
   // Track
   void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
-                        PickingMode picking_mode) override;
+                        PickingMode /*picking_mode*/) override;
   Type GetType() const override { return kGpuTrack; }
   float GetHeight() const override;
 

--- a/OrbitGl/GpuTrack.h
+++ b/OrbitGl/GpuTrack.h
@@ -38,7 +38,7 @@ class GpuTrack : public Track {
   std::string GetTooltip() const override;
 
   // Track
-  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) override;
+  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, bool picking) override;
   Type GetType() const override { return kGpuTrack; }
   float GetHeight() const override;
 

--- a/OrbitGl/GpuTrack.h
+++ b/OrbitGl/GpuTrack.h
@@ -32,13 +32,14 @@ class GpuTrack : public Track {
   ~GpuTrack() override = default;
 
   // Pickable
-  void Draw(GlCanvas* canvas, bool picking) override;
+  void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
   void OnDrag(int x, int y) override;
   void OnTimer(const Timer& timer);
   std::string GetTooltip() const override;
 
   // Track
-  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, bool picking) override;
+  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
+                        PickingMode picking_mode) override;
   Type GetType() const override { return kGpuTrack; }
   float GetHeight() const override;
 

--- a/OrbitGl/GraphTrack.cpp
+++ b/OrbitGl/GraphTrack.cpp
@@ -8,8 +8,8 @@
 
 GraphTrack::GraphTrack(TimeGraph* time_graph) : Track(time_graph) {}
 
-void GraphTrack::Draw(GlCanvas* canvas, bool picking) {
-  UNUSED(picking);
+void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
+  UNUSED(picking_mode);
 
   Batcher* batcher = canvas->GetBatcher();
 

--- a/OrbitGl/GraphTrack.cpp
+++ b/OrbitGl/GraphTrack.cpp
@@ -8,9 +8,7 @@
 
 GraphTrack::GraphTrack(TimeGraph* time_graph) : Track(time_graph) {}
 
-void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
-  UNUSED(picking_mode);
-
+void GraphTrack::Draw(GlCanvas* canvas, PickingMode /*picking_mode*/) {
   Batcher* batcher = canvas->GetBatcher();
 
   TimeGraphLayout& layout = time_graph_->GetLayout();

--- a/OrbitGl/GraphTrack.h
+++ b/OrbitGl/GraphTrack.h
@@ -16,7 +16,7 @@ class GraphTrack : public Track {
  public:
   explicit GraphTrack(TimeGraph* time_graph);
   Type GetType() const override { return kGraphTrack; }
-  void Draw(GlCanvas* canvas, bool picking) override;
+  void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
   void OnDrag(int x, int y) override;
   void AddTimer(const Timer& timer) override;
   float GetHeight() const override;

--- a/OrbitGl/GraphTrack.h
+++ b/OrbitGl/GraphTrack.h
@@ -16,7 +16,7 @@ class GraphTrack : public Track {
  public:
   explicit GraphTrack(TimeGraph* time_graph);
   Type GetType() const override { return kGraphTrack; }
-  void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
+  void Draw(GlCanvas* canvas, PickingMode /*picking_mode*/) override;
   void OnDrag(int x, int y) override;
   void AddTimer(const Timer& timer) override;
   float GetHeight() const override;

--- a/OrbitGl/PickingManager.h
+++ b/OrbitGl/PickingManager.h
@@ -14,13 +14,19 @@
 class GlCanvas;
 
 //-----------------------------------------------------------------------------
+enum class PickingMode {
+  kNone,
+  kHover,
+  kClick
+};
+
 class Pickable {
  public:
   virtual ~Pickable() = default;
   virtual void OnPick(int a_X, int a_Y) = 0;
   virtual void OnDrag(int /*a_X*/, int /*a_Y*/) {}
   virtual void OnRelease(){};
-  virtual void Draw(GlCanvas* a_Canvas, bool a_Picking) = 0;
+  virtual void Draw(GlCanvas* a_Canvas, PickingMode a_PickingMode) = 0;
   virtual bool Draggable() { return false; }
   virtual bool Movable() { return false; }
   virtual std::string GetTooltip() const { return ""; }

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -121,11 +121,12 @@ void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
                                     is_same_tid_as_selected,
                                     is_same_pid_as_target, is_inactive);
 
-        auto user_data = std::make_unique<PickingUserData>(&text_box,
+        auto user_data = std::make_unique<PickingUserData>(
+          &text_box,
           [&](PickingID id) -> std::string { return GetBoxTooltip(id); });
 
         if (is_visible_width) {
-          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, userData);
+          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, std::move(user_data));
         } else {
           auto type = PickingID::LINE;
           batcher->AddVerticalLine(pos, size[1], z, color, type, std::move(user_data));

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -50,7 +50,7 @@ std::string SchedulerTrack::GetTooltip() const {
 }
 
 void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
-                                      PickingMode picking_mode) {
+                                      PickingMode /*picking_mode*/) {
   Batcher* batcher = &time_graph_->GetBatcher();
   GlCanvas* canvas = time_graph_->GetCanvas();
   const TimeGraphLayout& layout = time_graph_->GetLayout();

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -120,18 +120,14 @@ void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, bool
                                     is_same_tid_as_selected,
                                     is_same_pid_as_target, is_inactive);
 
-        auto user_data = std::make_unique<PickingUserData>(
+        auto user_data = std::make_unique<PickingUserData>(&text_box,
+          [&](PickingID id) -> std::string { return GetBoxTooltip(id); });
+
         if (is_visible_width) {
-          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, std::move(user_data));
+          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, userData);
         } else {
           auto type = PickingID::LINE;
           batcher->AddVerticalLine(pos, size[1], z, color, type, std::move(user_data));
-            pos, size[1], z, color, type,
-            std::make_shared<PickingUserData>(
-              &text_box,
-              [&](PickingID id) -> std::string { return GetTooltip(id); }
-            )
-          );
           // For lines, we can ignore the entire pixel into which this event
           // falls. We align this precisely on the pixel x-coordinate of the
           // current line being drawn (in ticks). If pixel_delta_in_ticks is
@@ -150,7 +146,7 @@ void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, bool
   }
 }
 
-std::string SchedulerTrack::GetTooltip(PickingID id) const {
+std::string SchedulerTrack::GetBoxTooltip(PickingID id) const {
   TextBox* text_box = time_graph_->GetBatcher().GetTextBox(id);
   if (!text_box) {
     return "";

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -49,7 +49,8 @@ std::string SchedulerTrack::GetTooltip() const {
   return "Shows scheduling information for CPU cores";
 }
 
-void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, bool picking) {
+void SchedulerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
+                                      PickingMode picking_mode) {
   Batcher* batcher = &time_graph_->GetBatcher();
   GlCanvas* canvas = time_graph_->GetCanvas();
   const TimeGraphLayout& layout = time_graph_->GetLayout();

--- a/OrbitGl/SchedulerTrack.h
+++ b/OrbitGl/SchedulerTrack.h
@@ -11,10 +11,10 @@ class SchedulerTrack : public ThreadTrack {
  public:
   explicit SchedulerTrack(TimeGraph* time_graph);
   ~SchedulerTrack() override = default;
-
+  
   std::string GetTooltip() const override;
 
-  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) override;
+  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, bool picking) override;
   Type GetType() const override { return kSchedulerTrack; }
   float GetHeight() const override;
   bool HasEventTrack() const override { return false; }

--- a/OrbitGl/SchedulerTrack.h
+++ b/OrbitGl/SchedulerTrack.h
@@ -14,7 +14,8 @@ class SchedulerTrack : public ThreadTrack {
   
   std::string GetTooltip() const override;
 
-  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, bool picking) override;
+  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
+                        PickingMode picking_mode) override;
   Type GetType() const override { return kSchedulerTrack; }
   float GetHeight() const override;
   bool HasEventTrack() const override { return false; }

--- a/OrbitGl/SchedulerTrack.h
+++ b/OrbitGl/SchedulerTrack.h
@@ -11,7 +11,7 @@ class SchedulerTrack : public ThreadTrack {
  public:
   explicit SchedulerTrack(TimeGraph* time_graph);
   ~SchedulerTrack() override = default;
-  
+
   std::string GetTooltip() const override;
 
   void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,

--- a/OrbitGl/SchedulerTrack.h
+++ b/OrbitGl/SchedulerTrack.h
@@ -15,7 +15,7 @@ class SchedulerTrack : public ThreadTrack {
   std::string GetTooltip() const override;
 
   void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
-                        PickingMode picking_mode) override;
+                        PickingMode /*picking_mode*/) override;
   Type GetType() const override { return kSchedulerTrack; }
   float GetHeight() const override;
   bool HasEventTrack() const override { return false; }

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -144,9 +144,9 @@ void ThreadTrack::SetTimesliceText(const Timer& timer, double elapsed_us,
 }
 
 //-----------------------------------------------------------------------------
-void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) {
+void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, bool picking) {
   event_track_->SetPos(m_Pos[0], m_Pos[1]);
-  event_track_->UpdatePrimitives(min_tick, max_tick);
+  event_track_->UpdatePrimitives(min_tick, max_tick, picking);
 
   Batcher* batcher = &time_graph_->GetBatcher();
   GlCanvas* canvas = time_graph_->GetCanvas();

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -33,21 +33,21 @@ ThreadTrack::ThreadTrack(TimeGraph* time_graph, int32_t thread_id)
 }
 
 //-----------------------------------------------------------------------------
-void ThreadTrack::Draw(GlCanvas* canvas, bool picking) {
+void ThreadTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   float track_height = GetHeight();
   float track_width = canvas->GetWorldWidth();
 
   SetPos(canvas->GetWorldTopLeftX(), m_Pos[1]);
   SetSize(track_width, track_height);
 
-  Track::Draw(canvas, picking);
+  Track::Draw(canvas, picking_mode);
 
   // Event track
   if (HasEventTrack()) {
     float event_track_height = time_graph_->GetLayout().GetEventTrackHeight();
     event_track_->SetPos(m_Pos[0], m_Pos[1]);
     event_track_->SetSize(track_width, event_track_height);
-    event_track_->Draw(canvas, picking);
+    event_track_->Draw(canvas, picking_mode);
   }
 }
 
@@ -144,9 +144,9 @@ void ThreadTrack::SetTimesliceText(const Timer& timer, double elapsed_us,
 }
 
 //-----------------------------------------------------------------------------
-void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, bool picking) {
+void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode) {
   event_track_->SetPos(m_Pos[0], m_Pos[1]);
-  event_track_->UpdatePrimitives(min_tick, max_tick, picking);
+  event_track_->UpdatePrimitives(min_tick, max_tick, picking_mode);
 
   Batcher* batcher = &time_graph_->GetBatcher();
   GlCanvas* canvas = time_graph_->GetCanvas();

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -23,13 +23,14 @@ class ThreadTrack : public Track {
   ~ThreadTrack() override = default;
 
   // Pickable
-  void Draw(GlCanvas* canvas, bool picking) override;
+  void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
   void OnDrag(int x, int y) override;
   void OnTimer(const Timer& timer);
   std::string GetTooltip() const override;
 
   // Track
-  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, bool picking) override;
+  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
+                        PickingMode picking_mode) override;
   Type GetType() const override { return kThreadTrack; }
   float GetHeight() const override;
 

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -29,7 +29,7 @@ class ThreadTrack : public Track {
   std::string GetTooltip() const override;
 
   // Track
-  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick) override;
+  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, bool picking) override;
   Type GetType() const override { return kThreadTrack; }
   float GetHeight() const override;
 

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -497,7 +497,7 @@ void TimeGraph::NeedsUpdate() {
 }
 
 //-----------------------------------------------------------------------------
-void TimeGraph::UpdatePrimitives(bool picking) {
+void TimeGraph::UpdatePrimitives(PickingMode picking_mode) {
   CHECK(string_manager_);
 
   m_Batcher.Reset();
@@ -518,7 +518,7 @@ void TimeGraph::UpdatePrimitives(bool picking) {
 
   for (auto& track : sorted_tracks_) {
     track->SetY(current_y);
-    track->UpdatePrimitives(min_tick, max_tick, picking);
+    track->UpdatePrimitives(min_tick, max_tick, picking_mode);
     current_y -= (track->GetHeight() + m_Layout.GetSpaceBetweenTracks());
   }
 
@@ -574,14 +574,15 @@ const std::vector<CallstackEvent>& TimeGraph::GetSelectedCallstackEvents(
 }
 
 //-----------------------------------------------------------------------------
-void TimeGraph::Draw(GlCanvas* canvas, bool a_Picking) {
-  if ((!a_Picking && m_NeedsUpdatePrimitives) || a_Picking) {
-    UpdatePrimitives(a_Picking);
+void TimeGraph::Draw(GlCanvas* canvas, PickingMode picking_mode) {
+  const bool picking = picking_mode != PickingMode::kNone;
+  if ((!picking && m_NeedsUpdatePrimitives) || picking) {
+    UpdatePrimitives(picking_mode);
   }
 
-  DrawTracks(canvas, a_Picking);
-  DrawOverlay(canvas, a_Picking);
-  m_Batcher.Draw(a_Picking);
+  DrawTracks(canvas, picking_mode);
+  DrawOverlay(canvas, picking_mode);
+  m_Batcher.Draw(picking);
 
   m_NeedsRedraw = false;
 }
@@ -638,8 +639,9 @@ void DrawIteratorBox(GlCanvas* canvas, Vec2 pos, Vec2 size, const Color& color,
 
 }  // namespace
 
-void TimeGraph::DrawOverlay(GlCanvas* canvas, bool picking) {
-  if (picking || overlay_current_textboxes_.size() == 0) {
+void TimeGraph::DrawOverlay(GlCanvas* canvas, PickingMode picking_mode) {
+  if (picking_mode != PickingMode::kNone || 
+      overlay_current_textboxes_.size() == 0) {
     return;
   }
 
@@ -740,7 +742,7 @@ void TimeGraph::DrawOverlay(GlCanvas* canvas, bool picking) {
 }
 
 //-----------------------------------------------------------------------------
-void TimeGraph::DrawTracks(GlCanvas* canvas, bool a_Picking) {
+void TimeGraph::DrawTracks(GlCanvas* canvas, PickingMode picking_mode) {
   uint32_t num_cores = GetNumCores();
   m_Layout.SetNumCores(num_cores);
   scheduler_track_->SetLabel(
@@ -762,7 +764,7 @@ void TimeGraph::DrawTracks(GlCanvas* canvas, bool a_Picking) {
       }
     }
 
-    track->Draw(canvas, a_Picking);
+    track->Draw(canvas, picking_mode);
   }
 }
 

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -497,7 +497,7 @@ void TimeGraph::NeedsUpdate() {
 }
 
 //-----------------------------------------------------------------------------
-void TimeGraph::UpdatePrimitives() {
+void TimeGraph::UpdatePrimitives(bool picking) {
   CHECK(string_manager_);
 
   m_Batcher.Reset();
@@ -518,7 +518,7 @@ void TimeGraph::UpdatePrimitives() {
 
   for (auto& track : sorted_tracks_) {
     track->SetY(current_y);
-    track->UpdatePrimitives(min_tick, max_tick);
+    track->UpdatePrimitives(min_tick, max_tick, picking);
     current_y -= (track->GetHeight() + m_Layout.GetSpaceBetweenTracks());
   }
 
@@ -576,7 +576,7 @@ const std::vector<CallstackEvent>& TimeGraph::GetSelectedCallstackEvents(
 //-----------------------------------------------------------------------------
 void TimeGraph::Draw(GlCanvas* canvas, bool a_Picking) {
   if ((!a_Picking && m_NeedsUpdatePrimitives) || a_Picking) {
-    UpdatePrimitives();
+    UpdatePrimitives(a_Picking);
   }
 
   DrawTracks(canvas, a_Picking);

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -33,7 +33,7 @@ class TimeGraph {
   void DrawText(GlCanvas* canvas);
 
   void NeedsUpdate();
-  void UpdatePrimitives();
+  void UpdatePrimitives(bool picking);
   void SortTracks();
   std::vector<CallstackEvent> SelectEvents(float a_WorldStart, float a_WorldEnd,
                                            ThreadID a_TID);

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -27,13 +27,14 @@ class TimeGraph {
  public:
   TimeGraph();
 
-  void Draw(GlCanvas* canvas, bool a_Picking = false);
-  void DrawTracks(GlCanvas* canvas, bool a_Picking = false);
-  void DrawOverlay(GlCanvas* canvas, bool picking);
+  void Draw(GlCanvas* canvas, PickingMode picking_mode = PickingMode::kNone);
+  void DrawTracks(GlCanvas* canvas,
+                  PickingMode picking_mode = PickingMode::kNone);
+  void DrawOverlay(GlCanvas* canvas, PickingMode picking_mode);
   void DrawText(GlCanvas* canvas);
 
   void NeedsUpdate();
-  void UpdatePrimitives(bool picking);
+  void UpdatePrimitives(PickingMode picking_mode);
   void SortTracks();
   std::vector<CallstackEvent> SelectEvents(float a_WorldStart, float a_WorldEnd,
                                            ThreadID a_TID);

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -172,7 +172,7 @@ void Track::Draw(GlCanvas* canvas, bool picking) {
 }
 
 //-----------------------------------------------------------------------------
-void Track::UpdatePrimitives(uint64_t /*t_min*/, uint64_t /*t_max*/) {}
+void Track::UpdatePrimitives(uint64_t /*t_min*/, uint64_t /*t_max*/, bool /*  picking*/) {}
 
 //-----------------------------------------------------------------------------
 void Track::SetPos(float a_X, float a_Y) {

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -81,13 +81,14 @@ void DrawTriangleFan(Batcher* batcher, const std::vector<Vec2>& points,
 }
 
 //-----------------------------------------------------------------------------
-void Track::Draw(GlCanvas* canvas, bool picking) {
+void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   Batcher* batcher = canvas->GetBatcher();
 
   const TimeGraphLayout& layout = time_graph_->GetLayout();
   Color picking_color = canvas->GetPickingManager().GetPickableColor(
       this, PickingID::BatcherId::UI);
   const Color kTabColor(50, 50, 50, 255);
+  const bool picking = picking_mode != PickingMode::kNone;
   Color color = picking ? picking_color : kTabColor;
   glColor4ubv(&color[0]);
 
@@ -156,7 +157,7 @@ void Track::Draw(GlCanvas* canvas, bool picking) {
   float button_offset = layout.GetCollapseButtonOffset();
   Vec2 toggle_pos = Vec2(tab_x0 + button_offset, m_Pos[1] + half_label_height);
   collapse_toggle_.SetPos(toggle_pos);
-  collapse_toggle_.Draw(canvas, picking);
+  collapse_toggle_.Draw(canvas, picking_mode);
 
   if (!picking) {
     // Draw label.
@@ -172,7 +173,7 @@ void Track::Draw(GlCanvas* canvas, bool picking) {
 }
 
 //-----------------------------------------------------------------------------
-void Track::UpdatePrimitives(uint64_t /*t_min*/, uint64_t /*t_max*/, bool /*  picking*/) {}
+void Track::UpdatePrimitives(uint64_t /*t_min*/, uint64_t /*t_max*/, PickingMode /*  picking_mode*/) {}
 
 //-----------------------------------------------------------------------------
 void Track::SetPos(float a_X, float a_Y) {

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -38,8 +38,8 @@ class Track : public Pickable {
   ~Track() override = default;
 
   // Pickable
-  void Draw(GlCanvas* a_Canvas, bool a_Picking) override;
-  virtual void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, bool picking);
+  void Draw(GlCanvas* a_Canvas, PickingMode a_PickingMode) override;
+  virtual void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode);
   void OnPick(int a_X, int a_Y) override;
   void OnRelease() override;
   void OnDrag(int a_X, int a_Y) override;

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -39,7 +39,7 @@ class Track : public Pickable {
 
   // Pickable
   void Draw(GlCanvas* a_Canvas, bool a_Picking) override;
-  virtual void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick);
+  virtual void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, bool picking);
   void OnPick(int a_X, int a_Y) override;
   void OnRelease() override;
   void OnDrag(int a_X, int a_Y) override;

--- a/OrbitGl/TriangleToggle.cpp
+++ b/OrbitGl/TriangleToggle.cpp
@@ -14,9 +14,10 @@ TriangleToggle::TriangleToggle(State initial_state, StateChangeHandler handler,
       handler_(handler),
       time_graph_(time_graph) {}
 
-void TriangleToggle::Draw(GlCanvas* canvas, bool picking) {
+void TriangleToggle::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   Batcher* batcher = canvas->GetBatcher();
 
+  const float picking = picking_mode != PickingMode::kNone;
   const Color kWhite(255, 255, 255, 255);
   const Color kGrey(100, 100, 100, 255);
   Color color = state_ == State::kInactive ? kGrey : kWhite;

--- a/OrbitGl/TriangleToggle.cpp
+++ b/OrbitGl/TriangleToggle.cpp
@@ -17,7 +17,7 @@ TriangleToggle::TriangleToggle(State initial_state, StateChangeHandler handler,
 void TriangleToggle::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   Batcher* batcher = canvas->GetBatcher();
 
-  const float picking = picking_mode != PickingMode::kNone;
+  const bool picking = picking_mode != PickingMode::kNone;
   const Color kWhite(255, 255, 255, 255);
   const Color kGrey(100, 100, 100, 255);
   Color color = state_ == State::kInactive ? kGrey : kWhite;

--- a/OrbitGl/TriangleToggle.h
+++ b/OrbitGl/TriangleToggle.h
@@ -28,7 +28,7 @@ class TriangleToggle : public Pickable {
   TriangleToggle& operator=(TriangleToggle&&) = delete;
 
   // Pickable
-  void Draw(GlCanvas* canvas, bool picking) override;
+  void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
   void OnPick(int x, int y) override;
   void OnRelease() override;
 


### PR DESCRIPTION
Added tooltips for samples in the capture window.
The concept is the same as for the remaining tooltips, but there is one key difference: Samples should have a tooltip, but they are not pickable (so it is still possible to "click through" them onto the event track). To achieve this, the "picking" flag is now an enum that distinguishes between "hover" and "click", so each element can decide for itself for which of those actions it needs to draw itself into the picking buffer.
The picking enum is also passed to updatePrimitives(), which is consistent to how the method is being used anyways.