### PR TITLE
Raw serialization

### DIFF
--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -51,6 +51,7 @@ std::string Capture::GProcessName;
 std::unordered_map<int32_t, std::string> Capture::GThreadNames;
 std::unordered_map<uint64_t, LinuxAddressInfo> Capture::GAddressInfos;
 std::unordered_map<uint64_t, std::string> Capture::GAddressToFunctionName;
+std::unordered_map<uint64_t, std::string> Capture::GAddressToModuleName;
 Mutex Capture::GCallstackMutex;
 std::unordered_map<uint64_t, std::string> Capture::GZoneNames;
 TextBox* Capture::GSelectedTextBox = nullptr;
@@ -131,6 +132,7 @@ void Capture::ClearCaptureData() {
   GThreadNames.clear();
   GAddressInfos.clear();
   GAddressToFunctionName.clear();
+  GAddressToModuleName.clear();
   GZoneNames.clear();
   GSelectedTextBox = nullptr;
   GSelectedThreadId = 0;

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -75,6 +75,7 @@ class Capture {
   static std::unordered_map<int32_t, std::string> GThreadNames;
   static std::unordered_map<uint64_t, LinuxAddressInfo> GAddressInfos;
   static std::unordered_map<uint64_t, std::string> GAddressToFunctionName;
+  static std::unordered_map<uint64_t, std::string> GAddressToModuleName;
   static std::unordered_map<uint64_t, std::string> GZoneNames;
   static class TextBox* GSelectedTextBox;
   static ThreadID GSelectedThreadId;

--- a/OrbitCore/EventBuffer.cpp
+++ b/OrbitCore/EventBuffer.cpp
@@ -49,19 +49,6 @@ void EventBuffer::AddCallstackEvent(uint64_t time, CallstackID cs_hash,
 }
 
 //-----------------------------------------------------------------------------
-ORBIT_SERIALIZE(EventBuffer, 0) {
-  ORBIT_NVP_VAL(0, m_CallstackEvents);
-
-  uint64_t maxTime = m_MaxTime;
-  ORBIT_NVP_VAL(0, maxTime);
-  m_MaxTime = maxTime;
-
-  uint64_t minTime = m_MinTime;
-  ORBIT_NVP_VAL(0, minTime);
-  m_MinTime = minTime;
-}
-
-//-----------------------------------------------------------------------------
 ORBIT_SERIALIZE(CallstackEvent, 1) {
   ORBIT_NVP_VAL(1, m_Time);
   ORBIT_NVP_VAL(0, m_Id);

--- a/OrbitCore/EventBuffer.h
+++ b/OrbitCore/EventBuffer.h
@@ -66,8 +66,6 @@ class EventBuffer {
   void AddCallstackEvent(uint64_t time, CallstackID cs_hash,
                          ThreadID thread_id);
 
-  ORBIT_SERIALIZABLE;
-
  private:
   Mutex m_Mutex;
   std::map<ThreadID, std::map<uint64_t, CallstackEvent> > m_CallstackEvents;

--- a/OrbitCore/SamplingProfiler.cpp
+++ b/OrbitCore/SamplingProfiler.cpp
@@ -314,6 +314,16 @@ void SamplingProfiler::UpdateAddressInfo(uint64_t address) {
 
   Capture::GAddressToFunctionName[address] = function_name;
   Capture::GAddressToFunctionName[function_address] = function_name;
+
+  std::string module_name = "???";
+  std::shared_ptr<Module> module = m_Process->GetModuleFromAddress(address);
+  if (module != nullptr) {
+    module_name = module->m_Name;
+  } else if (address_info != nullptr) {
+    module_name = Path::GetFileName(address_info->module_name);
+  }
+  Capture::GAddressToModuleName[address] = module_name;
+  Capture::GAddressToModuleName[function_address] = module_name;
 }
 
 //-----------------------------------------------------------------------------
@@ -335,7 +345,10 @@ void SamplingProfiler::FillThreadSampleDataSampleReports() {
           100.f * numOccurences / threadSampleData.m_NumSamples;
 
       SampledFunction function;
-      function.m_Name = Capture::GAddressToFunctionName[address];
+      // GAddressToFunctionName and GAddressToModuleName should be filled in
+      // UpdateAddressInfo()
+      CHECK(Capture::GAddressToFunctionName.count(address) > 0);
+      function.m_Name = Capture::GAddressToFunctionName.at(address);
       function.m_Inclusive = inclusive_percent;
       function.m_Exclusive = 0.f;
       auto it = threadSampleData.m_ExclusiveCount.find(address);
@@ -344,9 +357,8 @@ void SamplingProfiler::FillThreadSampleDataSampleReports() {
             100.f * it->second / threadSampleData.m_NumSamples;
       }
       function.m_Address = address;
-
-      std::shared_ptr<Module> module = m_Process->GetModuleFromAddress(address);
-      function.m_Module = module ? module->m_Name : "???";
+      CHECK(Capture::GAddressToModuleName.count(address) > 0);
+      function.m_Module = Capture::GAddressToModuleName.at(address);
 
       sampleReport.push_back(function);
     }
@@ -354,38 +366,7 @@ void SamplingProfiler::FillThreadSampleDataSampleReports() {
 }
 
 //-----------------------------------------------------------------------------
-ORBIT_SERIALIZE_WSTRING(SampledFunction, 0) {
-  ORBIT_NVP_VAL(0, m_Name);
-  ORBIT_NVP_VAL(0, m_Module);
-  ORBIT_NVP_VAL(0, m_File);
-  ORBIT_NVP_VAL(0, m_Exclusive);
-  ORBIT_NVP_VAL(0, m_Inclusive);
-  ORBIT_NVP_VAL(0, m_Line);
-  ORBIT_NVP_VAL(0, m_Address);
-}
-
-//-----------------------------------------------------------------------------
-ORBIT_SERIALIZE_WSTRING(SamplingProfiler, 4) {
-  ORBIT_NVP_VAL(0, m_NumSamples);
-  ORBIT_NVP_DEBUG(0, m_ThreadSampleData);
+ORBIT_SERIALIZE_WSTRING(SamplingProfiler, 5) {
   ORBIT_NVP_DEBUG(0, m_UniqueCallstacks);
-  ORBIT_NVP_DEBUG(0, m_UniqueResolvedCallstacks);
-  ORBIT_NVP_DEBUG(0, m_OriginalCallstackToResolvedCallstack);
-  ORBIT_NVP_DEBUG(0, m_FunctionToCallstacks);
-  ORBIT_NVP_DEBUG(0, m_ExactAddressToFunctionAddress);
-  ORBIT_NVP_VAL(4, m_FunctionAddressToExactAddresses);
-}
-
-//-----------------------------------------------------------------------------
-ORBIT_SERIALIZE_WSTRING(ThreadSampleData, 1) {
-  ORBIT_NVP_VAL(0, m_CallstackCount);
-  ORBIT_NVP_VAL(0, m_AddressCount);
-  ORBIT_NVP_VAL(0, m_ExclusiveCount);
-  ORBIT_NVP_VAL(0, m_AddressCountSorted);
-  ORBIT_NVP_VAL(0, m_NumSamples);
-  ORBIT_NVP_VAL(0, m_SampleReport);
-  ORBIT_NVP_VAL(0, m_ThreadUsage);
-  ORBIT_NVP_VAL(0, m_AverageThreadUsage);
-  ORBIT_NVP_VAL(0, m_TID);
-  ORBIT_NVP_VAL(1, m_RawAddressCount);
+  ORBIT_NVP_VAL(5, callstacks_vector);
 }

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -29,8 +29,6 @@ struct SampledFunction {
   int m_Line = 0;
   uint64_t m_Address = 0;
   Function* m_Function = nullptr;
-
-  ORBIT_SERIALIZABLE;
 };
 
 //-----------------------------------------------------------------------------
@@ -46,8 +44,6 @@ struct ThreadSampleData {
   std::vector<float> m_ThreadUsage;
   float m_AverageThreadUsage = 0;
   ThreadID m_TID = 0;
-
-  ORBIT_SERIALIZABLE;
 };
 
 //-----------------------------------------------------------------------------
@@ -111,6 +107,22 @@ class SamplingProfiler {
   [[nodiscard]] const ThreadSampleData* GetSummary() const;
   [[nodiscard]] uint32_t GetCountOfFunction(uint64_t function_address) const;
 
+  // TODO(irinashkviro): remove this when move to protobuf
+  void SaveCallstacks() {
+    callstacks_vector.clear();
+    for (const CallstackEvent& callstack : m_Callstacks) {
+      callstacks_vector.push_back(callstack);
+    }
+  }
+
+  // TODO(irinashkviro): remove this when move to protobuf
+  void LoadCallstacks() {
+    m_Callstacks.clear();
+    for (const CallstackEvent& callstack : callstacks_vector) {
+      m_Callstacks.push_back(callstack);
+    }
+  }
+
   ORBIT_SERIALIZABLE;
 
  protected:
@@ -126,6 +138,9 @@ class SamplingProfiler {
   BlockChain<CallstackEvent, 16 * 1024> m_Callstacks;
   std::unordered_map<CallstackID, std::shared_ptr<CallStack>>
       m_UniqueCallstacks;
+
+  // TODO(irinashkviro): remove this when move to protobuf
+  std::vector<CallstackEvent> callstacks_vector;
 
   // Filled by ProcessSamples.
   std::unordered_map<ThreadID, ThreadSampleData> m_ThreadSampleData;

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -87,6 +87,10 @@ class SamplingProfiler {
   std::shared_ptr<SortedCallstackReport> GetSortedCallstacksFromAddress(
       uint64_t a_Addr, ThreadID a_TID);
 
+  BlockChain<CallstackEvent, 16 * 1024>* GetCallstacks() {
+    return &m_Callstacks;
+  }
+
   const std::vector<ThreadSampleData*>& GetThreadSampleData() const {
     return m_SortedThreadSampleData;
   }

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -48,13 +48,15 @@ std::string CallStackDataView::GetValue(int a_Row, int a_Column) {
 
   switch (a_Column) {
     case COLUMN_SELECTED:
-      return (function != nullptr && FunctionUtils::IsSelected(*function)) ? "X"
-                                                                      : "-";
+      return (function != nullptr && FunctionUtils::IsSelected(*function))
+                 ? "X"
+                 : "-";
     case COLUMN_NAME:
       return function != nullptr ? FunctionUtils::GetDisplayName(*function)
                                  : frame.fallback_name;
     case COLUMN_SIZE:
-      return function != nullptr ? absl::StrFormat("%lu", function->size()) : "";
+      return function != nullptr ? absl::StrFormat("%lu", function->size())
+                                 : "";
     case COLUMN_FILE:
       return function != nullptr ? function->file() : "";
     case COLUMN_LINE:
@@ -66,6 +68,9 @@ std::string CallStackDataView::GetValue(int a_Row, int a_Column) {
       }
       if (module != nullptr) {
         return module->m_Name;
+      }
+      if (Capture::GSamplingProfiler != nullptr) {
+        return Capture::GAddressToModuleName[frame.address];
       }
       return "";
     case COLUMN_ADDRESS:

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -84,11 +84,6 @@ void CaptureSerializer::SaveImpl(T& archive) {
   }
 
   {
-    ORBIT_SIZE_SCOPE("Capture::GFunctionCountMap");
-    archive(Capture::GFunctionCountMap);
-  }
-
-  {
     ORBIT_SIZE_SCOPE("Capture::GCallstacks");
     archive(Capture::GCallstacks);
   }
@@ -167,6 +162,15 @@ ErrorMessageOr<void> CaptureSerializer::Load(const std::string& filename) {
   }
 }
 
+void FillFunctionCountMap() {
+  Capture::GFunctionCountMap.clear();
+  for (const auto& pair : Capture::GSelectedFunctionsMap) {
+    uint64_t address = pair.first;
+    Function* function = pair.second;
+    Capture::GFunctionCountMap[address] = function->stats()->m_Count;
+  }
+}
+
 ErrorMessageOr<void> CaptureSerializer::Load(std::istream& stream) {
   // Header
   cereal::BinaryInputArchive archive(stream);
@@ -186,7 +190,7 @@ ErrorMessageOr<void> CaptureSerializer::Load(std::istream& stream) {
   }
   Capture::GVisibleFunctionsMap = Capture::GSelectedFunctionsMap;
 
-  archive(Capture::GFunctionCountMap);
+  FillFunctionCountMap();
 
   archive(Capture::GCallstacks);
 

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -82,12 +82,6 @@ void CaptureSerializer::SaveImpl(T& archive) {
 
     archive(functions);
   }
-
-  {
-    ORBIT_SIZE_SCOPE("Capture::GCallstacks");
-    archive(Capture::GCallstacks);
-  }
-
   {
     ORBIT_SIZE_SCOPE("Capture::GProcessId");
     archive(Capture::GProcessId);
@@ -191,8 +185,6 @@ ErrorMessageOr<void> CaptureSerializer::Load(std::istream& stream) {
   Capture::GVisibleFunctionsMap = Capture::GSelectedFunctionsMap;
 
   FillFunctionCountMap();
-
-  archive(Capture::GCallstacks);
 
   archive(Capture::GProcessId);
 

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -113,11 +113,6 @@ void CaptureSerializer::SaveImpl(T& archive) {
     archive(*time_graph_->GetStringManager());
   }
 
-  {
-    ORBIT_SIZE_SCOPE("Event Buffer");
-    archive(GEventTracer.GetEventBuffer());
-  }
-
   // Timers
   int numWrites = 0;
   std::vector<std::shared_ptr<TimerChain>> chains =
@@ -165,6 +160,15 @@ void FillFunctionCountMap() {
   }
 }
 
+void FillEventBuffer() {
+  GEventTracer.GetEventBuffer().Reset();
+  for (const CallstackEvent& callstack_event :
+       *Capture::GSamplingProfiler->GetCallstacks()) {
+    GEventTracer.GetEventBuffer().AddCallstackEvent(
+        callstack_event.m_Time, callstack_event.m_Id, callstack_event.m_TID);
+  }
+}
+
 ErrorMessageOr<void> CaptureSerializer::Load(std::istream& stream) {
   // Header
   cereal::BinaryInputArchive archive(stream);
@@ -205,8 +209,7 @@ ErrorMessageOr<void> CaptureSerializer::Load(std::istream& stream) {
 
   archive(*time_graph_->GetStringManager());
 
-  // Event buffer
-  archive(GEventTracer.GetEventBuffer());
+  FillEventBuffer();
 
   // Timers
   Timer timer;


### PR DESCRIPTION
This PR reduce amount of serialized data:

- for SamplingProfiler we need just m_Callstacks and m_UniqueCallstack, other data are filled during the ProcessSamples call

- FunctionCountMap also could be filled on load (probably, we can use Capture::GSelectedFunctionsMap instead of it)

- seems like Capture::GCallstacks and Capture::GProcessId are not used after loading so we can remove it from saving

- EventBuffer could be filled from Capture::GSamplingProfiler, so not necessary to save it too