### PR TITLE
Add Vertical Zoom by scaling drawn elements

### DIFF
--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -382,19 +382,21 @@ void CaptureWindow::MouseWheelMoved(int a_X, int a_Y, int a_Delta,
   if (delta > m_MaxWheelDelta) m_MaxWheelDelta = delta;
 
   float mousex = a_X;
+  float mousey = a_Y;
 
   float worldx;
   float worldy;
 
   ScreenToWorld(a_X, a_Y, worldx, worldy);
-  m_MouseRatio = static_cast<double>(mousex) / getWidth();
 
   bool zoomWidth = !a_Ctrl;
   if (zoomWidth) {
+    m_MouseRatio = static_cast<double>(mousex) / getWidth();
     time_graph_.ZoomTime(delta, m_MouseRatio);
     m_WheelMomentum = delta * m_WheelMomentum < 0 ? 0 : m_WheelMomentum + delta;
   } else {
-    // TODO: reimplement vertical zoom by scaling track heights.
+    double mouse_relative_y_position = static_cast<double>(mousey) / getHeight();
+    time_graph_.VerticalZoom(delta, mouse_relative_y_position);
   }
 
   // Use the original sign of a_Delta here.

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -196,6 +196,34 @@ void TimeGraph::ZoomTime(float a_ZoomValue, double a_MouseRatio) {
   SetMinMax(minTimeUs, maxTimeUs);
 }
 
+void TimeGraph::VerticalZoom(float zoom_value, double mouse_relative_position) {
+  static double increment_ratio = 0.1;
+
+  double ratio = zoom_value > 0 ? 1 + increment_ratio : 1 - increment_ratio;
+
+  float world_height = m_Canvas->GetWorldHeight();
+  double y_mouse_position = m_Canvas->GetWorldTopLeftY() - mouse_relative_position * world_height;
+  double top_distance = m_Canvas->GetWorldTopLeftY() - y_mouse_position;
+
+  double new_y_mouse_position = y_mouse_position / ratio;
+
+  float new_world_top_left_y = new_y_mouse_position + top_distance;
+
+  // If we zoomed-out, we would like to see most part of the screen with events,
+  // so we set a minimum and maximum for the y-top coordinate.
+  new_world_top_left_y =
+      std::max(new_world_top_left_y, world_height - GetThreadTotalHeight());
+  // TODO: TopMargin has to be 1.5f * m_Layout.GetSliderWidth()?
+  new_world_top_left_y =
+      std::min(new_world_top_left_y, 1.5f * m_Layout.GetSliderWidth());
+
+  m_Canvas->SetWorldTopLeftY(new_world_top_left_y);
+
+  // Finally, we have to scale every item in the layout.
+  float old_scale = m_Layout.GetScale();
+  m_Layout.SetScale(old_scale / ratio);
+}
+
 //-----------------------------------------------------------------------------
 void TimeGraph::SetMinMax(double a_MinTimeUs, double a_MaxTimeUs) {
   double desiredTimeWindow = a_MaxTimeUs - a_MinTimeUs;

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -64,6 +64,7 @@ class TimeGraph {
   void Zoom(const TextBox* a_TextBox);
   void Zoom(TickType min, TickType max);
   void ZoomTime(float a_ZoomValue, double a_MouseRatio);
+  void VerticalZoom(float a_ZoomValue, double a_MouseRatio);
   void SetMinMax(double a_MinTimeUs, double a_MaxTimeUs);
   void PanTime(int a_InitialX, int a_CurrentX, int a_Width,
                double a_InitialTime);

--- a/OrbitGl/TimeGraphLayout.cpp
+++ b/OrbitGl/TimeGraphLayout.cpp
@@ -35,6 +35,7 @@ TimeGraphLayout::TimeGraphLayout() {
   m_TextZ = -0.02f;
   m_TrackZ = -0.1f;
   m_ToolbarIconHeight = 24.f;
+  scale_ = 1.f;
   time_bar_height_ = 15.f;
 };
 
@@ -80,6 +81,7 @@ bool TimeGraphLayout::DrawProperties() {
   FLOAT_SLIDER_MIN_MAX(m_TextZ, -1.f, 1.f);
   FLOAT_SLIDER_MIN_MAX(m_TrackZ, -1.f, 1.f);
   FLOAT_SLIDER(m_ToolbarIconHeight);
+  FLOAT_SLIDER_MIN_MAX(scale_, 0.05f, 20.f);
   ImGui::Checkbox("DrawTrackBackground", &m_DrawTrackBackground);
   ImGui::End();
 
@@ -89,5 +91,5 @@ bool TimeGraphLayout::DrawProperties() {
 float TimeGraphLayout::GetBottomMargin() const {
   // The bottom consists of the slider (where we have to take the width, as it
   // is rotated), and the time bar.
-  return GetSliderWidth() + GetTimeBarHeight(); 
+  return GetSliderWidth() + GetTimeBarHeight();
 }

--- a/OrbitGl/TimeGraphLayout.h
+++ b/OrbitGl/TimeGraphLayout.h
@@ -10,35 +10,39 @@ class TimeGraphLayout {
  public:
   TimeGraphLayout();
 
-  float GetTextBoxHeight() const { return m_TextBoxHeight; }
-  float GetTextCoresHeight() const { return m_CoresHeight; }
-  float GetEventTrackHeight() const { return m_EventTrackHeight; }
-  float GetGraphTrackHeight() const { return m_GraphTrackHeight; }
-  float GetTrackBottomMargin() const { return m_TrackBottomMargin; }
-  float GetTrackTopMargin() const { return m_TrackTopMargin; }
+  float GetTextBoxHeight() const { return m_TextBoxHeight * scale_; }
+  float GetTextCoresHeight() const { return m_CoresHeight * scale_; }
+  float GetEventTrackHeight() const { return m_EventTrackHeight * scale_; }
+  float GetGraphTrackHeight() const { return m_GraphTrackHeight * scale_; }
+  float GetTrackBottomMargin() const { return m_TrackBottomMargin * scale_; }
+  float GetTrackTopMargin() const { return m_TrackTopMargin * scale_; }
   float GetTrackLabelOffsetX() const { return m_TrackLabelOffsetX; }
   float GetTrackLabelOffsetY() const { return m_TrackLabelOffsetY; }
   float GetSliderWidth() const { return m_SliderWidth; }
   float GetTimeBarHeight() const { return time_bar_height_; }
   float GetTrackTabWidth() const { return m_TrackTabWidth; }
-  float GetTrackTabHeight() const { return m_TrackTabHeight; }
+  float GetTrackTabHeight() const { return m_TrackTabHeight * scale_; }
   float GetTrackTabOffset() const { return m_TrackTabOffset; }
   float GetCollapseButtonOffset() const { return m_CollapseButtonOffset; }
-  float GetRoundingRadius() const { return m_RoundingRadius; }
+  float GetRoundingRadius() const { return m_RoundingRadius * scale_; }
   float GetRoundingNumSides() const { return m_RoundingNumSides; }
   float GetTextOffset() const { return m_TextOffset; }
   float GetBottomMargin() const;
   float GetTopMargin() const { return GetSchedulerTrackOffset(); }
   float GetVerticalMargin() const { return m_VerticalMargin; }
-  float GetSchedulerTrackOffset() const { return m_SchedulerTrackOffset; }
-  float GetSpaceBetweenTracks() const { return m_SpaceBetweenTracks; }
-  float GetSpaceBetweenCores() const { return m_SpaceBetweenCores; }
+  float GetSchedulerTrackOffset() const {
+    return m_SchedulerTrackOffset * scale_;
+  }
+  float GetSpaceBetweenTracks() const { return m_SpaceBetweenTracks * scale_; }
+  float GetSpaceBetweenCores() const { return m_SpaceBetweenCores * scale_; }
   float GetSpaceBetweenTracksAndThread() const {
-    return m_SpaceBetweenTracksAndThread;
+    return m_SpaceBetweenTracksAndThread * scale_;
   }
   float GetTextZ() const { return m_TextZ; }
   float GetTrackZ() const { return m_TrackZ; }
   float GetToolbarIconHeight() const { return m_ToolbarIconHeight; }
+  float GetScale() const { return scale_; }
+  void SetScale(float value) { scale_ = value; }
   void SetDrawProperties(bool value) { m_DrawProperties = value; }
   void SetNumCores(int a_NumCores) { m_NumCores = a_NumCores; }
   bool DrawProperties();
@@ -75,6 +79,7 @@ class TimeGraphLayout {
   float m_TextZ;
   float m_TrackZ;
   float m_ToolbarIconHeight;
+  float scale_;
 
   bool m_DrawProperties = false;
   bool m_DrawTrackBackground = true;

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -113,6 +113,7 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   float label_height = layout.GetTrackTabHeight();
   float half_label_height = 0.5f * label_height;
   float label_width = layout.GetTrackTabWidth();
+  float half_label_width = 0.5f * label_width;
   float tab_x0 = x0 + layout.GetTrackTabOffset();
 
   Box box(Vec2(tab_x0, y0), Vec2(label_width, label_height), track_z);
@@ -124,6 +125,7 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
     const Color kBackgroundColor(70, 70, 70, 255);
 
     float radius = std::min(layout.GetRoundingRadius(), half_label_height);
+    radius = std::min(radius, half_label_width);
     uint32_t sides = static_cast<uint32_t>(layout.GetRoundingNumSides() + 0.5f);
     auto rounded_corner = GetRoundedCornerMask(radius, sides);
     Vec2 bottom_left(x0, y1);


### PR DESCRIPTION
We can make a vertical zoom pressing ctrl + wheel. For this, we are
scaling the heights of each element in the TimeGraph. Also, we are preserving the
distance from the mouse to make a proper zoom similar to the horizontal
one.

This is actually in draft, to receive feedback.