### PR TITLE
Clear iterator UI when clearing the capture, loading a new capture, or capturing a new capture

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -556,11 +556,7 @@ ErrorMessageOr<void> OrbitApp::OnSaveCapture(const std::string& file_name) {
 
 //-----------------------------------------------------------------------------
 ErrorMessageOr<void> OrbitApp::OnLoadCapture(const std::string& file_name) {
-  Capture::ClearCaptureData();
-  GCurrentTimeGraph->Clear();
-  if (Capture::GClearCaptureDataFunc) {
-    Capture::GClearCaptureDataFunc();
-  }
+  ClearCapture();
 
   CaptureSerializer ar;
   ar.time_graph_ = GCurrentTimeGraph;
@@ -585,6 +581,8 @@ void OrbitApp::FireRefreshCallbacks(DataViewType type) {
 
 bool OrbitApp::StartCapture() {
   CHECK(!Capture::IsCapturing());
+
+  ClearCapture();
 
   ErrorMessageOr<void> result = Capture::StartCapture();
   if (result.has_error()) {
@@ -626,6 +624,9 @@ void OrbitApp::ClearCapture() {
   Capture::ClearCaptureData();
   Capture::GClearCaptureDataFunc();
   GCurrentTimeGraph->Clear();
+  if (capture_cleared_callback_) {
+    capture_cleared_callback_();
+  }
 }
 
 void OrbitApp::ToggleDrawHelp() {

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -112,6 +112,11 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
     capture_stopped_callback_ = std::move(callback);
   }
 
+  using CaptureClearedCallback = std::function<void()>;
+  void SetCaptureClearedCallback(CaptureClearedCallback callback) {
+    capture_cleared_callback_ = std::move(callback);
+  }
+
   using OpenCaptureCallback = std::function<void()>;
   void SetOpenCaptureCallback(OpenCaptureCallback callback) {
     open_capture_callback_ = std::move(callback);
@@ -238,6 +243,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   CaptureStartedCallback capture_started_callback_;
   CaptureStopRequestedCallback capture_stop_requested_callback_;
   CaptureStoppedCallback capture_stopped_callback_;
+  CaptureClearedCallback capture_cleared_callback_;
   OpenCaptureCallback open_capture_callback_;
   SaveCaptureCallback save_capture_callback_;
   SelectLiveTabCallback select_live_tab_callback_;

--- a/OrbitGl/LiveFunctionsController.cpp
+++ b/OrbitGl/LiveFunctionsController.cpp
@@ -223,3 +223,11 @@ TickType LiveFunctionsController::GetCaptureMin() {
 TickType LiveFunctionsController::GetCaptureMax() {
   return GCurrentTimeGraph->GetCaptureMax();
 }
+
+void LiveFunctionsController::Reset() {
+  function_iterators_.clear();
+  current_textboxes_.clear();
+  GCurrentTimeGraph->SetOverlayTextBoxes({});
+  next_iterator_id_ = 0;
+  id_to_select_ = 0;
+}

--- a/OrbitGl/LiveFunctionsController.h
+++ b/OrbitGl/LiveFunctionsController.h
@@ -27,6 +27,7 @@ class LiveFunctionsController {
   void OnPreviousButton(uint64_t id);
   void OnDeleteButton(uint64_t id);
 
+  void Reset();
   void OnDataChanged() { live_functions_data_view_.OnDataChanged(); }
 
   void SetAddIteratorCallback(

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -94,6 +94,8 @@ void TimeGraph::Clear() {
 
   // The process track is a special ThreadTrack of id "0".
   process_track_ = GetOrCreateThreadTrack(0);
+
+  SetOverlayTextBoxes({});
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitQt/orbitlivefunctions.cpp
+++ b/OrbitQt/orbitlivefunctions.cpp
@@ -103,3 +103,14 @@ void OrbitLiveFunctions::AddIterator(size_t id, Function* function) {
 QLineEdit* OrbitLiveFunctions::GetFilterLineEdit() {
   return ui->data_view_panel_->GetFilterLineEdit();
 }
+
+void OrbitLiveFunctions::Reset() {
+  live_functions_.Reset();
+
+  for (auto& [_, iterator_ui] : iterator_uis) {
+    ui->iteratorLayout->removeWidget(iterator_ui);
+    delete iterator_ui;
+  }
+  iterator_uis.clear();
+  all_events_iterator_->DisableButtons();
+}

--- a/OrbitQt/orbitlivefunctions.h
+++ b/OrbitQt/orbitlivefunctions.h
@@ -31,6 +31,7 @@ class OrbitLiveFunctions : public QWidget {
                   bool is_main_instance = true);
   void Refresh();
   void OnDataChanged();
+  void Reset();
   void SetFilter(const QString& a_Filter);
   void AddIterator(uint64_t id, Function* function);
   QLineEdit* GetFilterLineEdit();

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -109,6 +109,9 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App,
     ui->actionSave_Preset_As->setDisabled(false);
     ui->HomeTab->setDisabled(false);
   });
+  GOrbitApp->SetCaptureClearedCallback([this] {
+    OnCaptureCleared();
+  });
 
   GOrbitApp->SetRefreshCallback([this](DataViewType a_Type) {
     this->OnRefreshDataViewPanels(a_Type);
@@ -874,4 +877,8 @@ void OrbitMainWindow::on_actionServiceNullPointerDereference_triggered() {
 void OrbitMainWindow::on_actionServiceStackOverflow_triggered() {
   GOrbitApp->CrashOrbitService(
       CrashOrbitServiceRequest_CrashType_STACK_OVERFLOW);
+}
+
+void OrbitMainWindow::OnCaptureCleared() {
+  live_functions_->Reset();
 }

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -55,6 +55,7 @@ class OrbitMainWindow : public QMainWindow {
                        const std::function<double(size_t)>& line_to_hit_ratio);
   void SetTitle(const QString& task_description);
   outcome::result<void> OpenCapture(const std::string& filepath);
+  void OnCaptureCleared();
 
  private slots:
   void on_actionAbout_triggered();


### PR DESCRIPTION
Using existing iterators in the UI does not make sense when the capture changes, which can happen due to clearing the capture, loading a capture, or when starting a new capture. In all these cases we reset the iterator UI. 