### PR TITLE
Tooltips for callstacks are shortened (both in depth and line length) if needed

### DIFF
--- a/OrbitCore/CMakeLists.txt
+++ b/OrbitCore/CMakeLists.txt
@@ -144,6 +144,7 @@ target_sources(OrbitCoreTests PRIVATE
     RingBufferTest.cpp
     StringManagerTest.cpp
     SymbolHelperTest.cpp
+    UtilsTest.cpp
 )
 
 if(NOT WIN32)

--- a/OrbitCore/Utils.h
+++ b/OrbitCore/Utils.h
@@ -276,6 +276,25 @@ class CWindowsMessageToString {
 #endif
 
 //-----------------------------------------------------------------------------
+inline std::string ShortenStringWithEllipsis(const std::string& text, int max_len) {
+  if (max_len < 0) {
+    return text;
+  }
+  if (max_len <= 3) {
+    return text.length() <= 3 ? text : "...";
+  }
+  if (text.length() <= max_len) {
+    return text;
+  }
+
+  const size_t chars_to_cut =
+      text.length() - static_cast<uint32_t>(max_len) + 3;
+  const size_t l = (text.length() - chars_to_cut) / 2;
+  const size_t r = l + chars_to_cut;
+  return text.substr(0, l) + "..." + text.substr(r);
+}
+
+//-----------------------------------------------------------------------------
 inline std::string GetPrettySize(uint64_t size) {
   constexpr double KB = 1024.0;
   constexpr double MB = 1024.0 * KB;

--- a/OrbitCore/Utils.h
+++ b/OrbitCore/Utils.h
@@ -276,24 +276,32 @@ class CWindowsMessageToString {
 #endif
 
 //-----------------------------------------------------------------------------
-inline std::string ShortenStringWithEllipsis(const std::string& text,
+inline std::string ShortenStringWithEllipsis(std::string_view text,
                                              int max_len) {
   if (max_len < 0) {
-    return text;
+    return std::string(text);
   }
 
   size_t max_len_unsigned = static_cast<size_t>(max_len);
   if (max_len_unsigned <= 3) {
-    return text.length() <= 3 ? text : "...";
+    return text.length() <= 3 ? std::string(text) : "...";
   }
   if (text.length() <= max_len_unsigned) {
-    return text;
+    return std::string(text);
   }
 
   const size_t chars_to_cut = text.length() - max_len_unsigned + 3;
-  const size_t l = (text.length() - chars_to_cut) / 2;
+  size_t l = text.length() - chars_to_cut;
+  // Integer division by two, rounded up
+  if (l & 0x1) {
+    l = (l + 1) >> 1;
+  } else {
+    l = l >> 1;
+  }
+
   const size_t r = l + chars_to_cut;
-  return text.substr(0, l) + "..." + text.substr(r);
+  return std::string(text.substr(0, l)) + "..." +
+         std::string(text.substr(r));
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitCore/Utils.h
+++ b/OrbitCore/Utils.h
@@ -276,21 +276,21 @@ class CWindowsMessageToString {
 #endif
 
 //-----------------------------------------------------------------------------
-inline std::string ShortenStringWithEllipsis(std::string_view text,
-                                             int max_len) {
-  if (max_len < 0) {
+enum class EllipsisPosition { kMiddle };
+
+inline std::string ShortenStringWithEllipsis(
+    std::string_view text, size_t max_len,
+    EllipsisPosition pos = EllipsisPosition::kMiddle) {
+  constexpr const size_t kNumCharsEllipsis = 3;
+
+  if (max_len <= kNumCharsEllipsis) {
+    return text.length() <= kNumCharsEllipsis ? std::string(text) : "...";
+  }
+  if (text.length() <= max_len) {
     return std::string(text);
   }
 
-  size_t max_len_unsigned = static_cast<size_t>(max_len);
-  if (max_len_unsigned <= 3) {
-    return text.length() <= 3 ? std::string(text) : "...";
-  }
-  if (text.length() <= max_len_unsigned) {
-    return std::string(text);
-  }
-
-  const size_t chars_to_cut = text.length() - max_len_unsigned + 3;
+  const size_t chars_to_cut = text.length() - max_len + kNumCharsEllipsis;
   size_t l = text.length() - chars_to_cut;
   // Integer division by two, rounded up
   if (l & 0x1) {
@@ -300,8 +300,7 @@ inline std::string ShortenStringWithEllipsis(std::string_view text,
   }
 
   const size_t r = l + chars_to_cut;
-  return std::string(text.substr(0, l)) + "..." +
-         std::string(text.substr(r));
+  return std::string(text.substr(0, l)) + "..." + std::string(text.substr(r));
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitCore/Utils.h
+++ b/OrbitCore/Utils.h
@@ -276,19 +276,21 @@ class CWindowsMessageToString {
 #endif
 
 //-----------------------------------------------------------------------------
-inline std::string ShortenStringWithEllipsis(const std::string& text, int max_len) {
+inline std::string ShortenStringWithEllipsis(const std::string& text,
+                                             int max_len) {
   if (max_len < 0) {
     return text;
   }
-  if (max_len <= 3) {
+
+  size_t max_len_unsigned = static_cast<size_t>(max_len);
+  if (max_len_unsigned <= 3) {
     return text.length() <= 3 ? text : "...";
   }
-  if (text.length() <= max_len) {
+  if (text.length() <= max_len_unsigned) {
     return text;
   }
 
-  const size_t chars_to_cut =
-      text.length() - static_cast<uint32_t>(max_len) + 3;
+  const size_t chars_to_cut = text.length() - max_len_unsigned + 3;
   const size_t l = (text.length() - chars_to_cut) / 2;
   const size_t r = l + chars_to_cut;
   return text.substr(0, l) + "..." + text.substr(r);

--- a/OrbitCore/Utils.h
+++ b/OrbitCore/Utils.h
@@ -32,6 +32,12 @@
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_split.h"
 
+#define CONCAT_(x, y) x##y
+#define CONCAT(x, y) CONCAT_(x, y)
+#define UNIQUE_VAR CONCAT(Unique, __LINE__)
+#define UNIQUE_ID CONCAT(Id_, __LINE__)
+#define UNUSED(x) (void)(x)
+
 //-----------------------------------------------------------------------------
 inline std::string ws2s(const std::wstring& wstr) {
   std::string str;
@@ -281,6 +287,9 @@ enum class EllipsisPosition { kMiddle };
 inline std::string ShortenStringWithEllipsis(
     std::string_view text, size_t max_len,
     EllipsisPosition pos = EllipsisPosition::kMiddle) {
+  // Parameter is mainly here to indicate how the util works,
+  // and to be potentially extended later
+  UNUSED(pos);
   constexpr const size_t kNumCharsEllipsis = 3;
 
   if (max_len <= kNumCharsEllipsis) {
@@ -477,12 +486,6 @@ std::string FormatTime(const time_t& rawtime);
 //-----------------------------------------------------------------------------
 bool ReadProcessMemory(int32_t pid, uint64_t address, byte* buffer,
                        uint64_t size, uint64_t* num_bytes_read);
-
-#define CONCAT_(x, y) x##y
-#define CONCAT(x, y) CONCAT_(x, y)
-#define UNIQUE_VAR CONCAT(Unique, __LINE__)
-#define UNIQUE_ID CONCAT(Id_, __LINE__)
-#define UNUSED(x) (void)(x)
 
 #if __linux__
 #define FUNCTION_NAME __PRETTY_FUNCTION__

--- a/OrbitCore/UtilsTest.cpp
+++ b/OrbitCore/UtilsTest.cpp
@@ -1,0 +1,17 @@
+#include <gtest/gtest.h>
+
+#include "Utils.h"
+
+TEST(Utils, TestEllipsis) {
+  EXPECT_EQ(ShortenStringWithEllipsis("17 char long text", 18), "17 char long text");
+  EXPECT_EQ(ShortenStringWithEllipsis("17 char long text", 17), "17 char long text");
+  EXPECT_EQ(ShortenStringWithEllipsis("17 char long text", 7), "17...xt");
+  EXPECT_EQ(ShortenStringWithEllipsis("17 char long text", 6), "1...xt");
+  EXPECT_EQ(ShortenStringWithEllipsis("short", 4), "...t");
+  EXPECT_EQ(ShortenStringWithEllipsis("short", 3), "...");
+  EXPECT_EQ(ShortenStringWithEllipsis("sh", 2), "sh");
+  EXPECT_EQ(ShortenStringWithEllipsis("17 char long text", 2), "...");
+  EXPECT_EQ(ShortenStringWithEllipsis("sh", 1), "sh");
+  EXPECT_EQ(ShortenStringWithEllipsis("17 char long text", -1), "17 char long text");
+}
+

--- a/OrbitCore/UtilsTest.cpp
+++ b/OrbitCore/UtilsTest.cpp
@@ -6,8 +6,8 @@ TEST(Utils, TestEllipsis) {
   EXPECT_EQ(ShortenStringWithEllipsis("17 char long text", 18), "17 char long text");
   EXPECT_EQ(ShortenStringWithEllipsis("17 char long text", 17), "17 char long text");
   EXPECT_EQ(ShortenStringWithEllipsis("17 char long text", 7), "17...xt");
-  EXPECT_EQ(ShortenStringWithEllipsis("17 char long text", 6), "1...xt");
-  EXPECT_EQ(ShortenStringWithEllipsis("short", 4), "...t");
+  EXPECT_EQ(ShortenStringWithEllipsis("17 char long text", 6), "17...t");
+  EXPECT_EQ(ShortenStringWithEllipsis("short", 4), "s...");
   EXPECT_EQ(ShortenStringWithEllipsis("short", 3), "...");
   EXPECT_EQ(ShortenStringWithEllipsis("sh", 2), "sh");
   EXPECT_EQ(ShortenStringWithEllipsis("17 char long text", 2), "...");

--- a/OrbitCore/UtilsTest.cpp
+++ b/OrbitCore/UtilsTest.cpp
@@ -9,9 +9,12 @@ TEST(Utils, TestEllipsis) {
   EXPECT_EQ(ShortenStringWithEllipsis("17 char long text", 6), "17...t");
   EXPECT_EQ(ShortenStringWithEllipsis("short", 4), "s...");
   EXPECT_EQ(ShortenStringWithEllipsis("short", 3), "...");
-  EXPECT_EQ(ShortenStringWithEllipsis("sh", 2), "sh");
   EXPECT_EQ(ShortenStringWithEllipsis("17 char long text", 2), "...");
-  EXPECT_EQ(ShortenStringWithEllipsis("sh", 1), "sh");
-  EXPECT_EQ(ShortenStringWithEllipsis("17 char long text", -1), "17 char long text");
+  EXPECT_EQ(ShortenStringWithEllipsis("17 char long text", 1), "...");
+  EXPECT_EQ(ShortenStringWithEllipsis("17 char long text", 0), "...");
+  // Texts with 3 or less characters are not shortened as it makes no sense
+  EXPECT_EQ(ShortenStringWithEllipsis("abc", 2), "abc");
+  EXPECT_EQ(ShortenStringWithEllipsis("abc", 1), "abc");
+  EXPECT_EQ(ShortenStringWithEllipsis("abc", 0), "abc");
 }
 

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -661,6 +661,18 @@ Batcher& CaptureWindow::GetBatcherById(uint32_t batcher_id) {
                          : ui_batcher_;
 }
 
+PickingMode CaptureWindow::GetPickingMode() { 
+  PickingMode picking_mode = PickingMode::kNone;
+  if (m_Picking) {
+    picking_mode = PickingMode::kClick;
+  }
+  if (m_IsHovering) {
+    picking_mode = PickingMode::kHover;
+  }
+
+  return picking_mode;
+}
+
 [[nodiscard]] PickingMode CaptureWindow::GetPickingMode() { 
   PickingMode picking_mode = PickingMode::kNone;
   if (m_Picking) {

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -661,18 +661,6 @@ Batcher& CaptureWindow::GetBatcherById(uint32_t batcher_id) {
                          : ui_batcher_;
 }
 
-PickingMode CaptureWindow::GetPickingMode() { 
-  PickingMode picking_mode = PickingMode::kNone;
-  if (m_Picking) {
-    picking_mode = PickingMode::kClick;
-  }
-  if (m_IsHovering) {
-    picking_mode = PickingMode::kHover;
-  }
-
-  return picking_mode;
-}
-
 [[nodiscard]] PickingMode CaptureWindow::GetPickingMode() { 
   PickingMode picking_mode = PickingMode::kNone;
   if (m_Picking) {

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -187,7 +187,8 @@ bool EventTrack::IsEmpty() const {
 }
 
 //-----------------------------------------------------------------------------
-std::string SafeGetFormattedFunctionName(uint64_t addr, int max_line_length) {
+static std::string SafeGetFormattedFunctionName(uint64_t addr,
+                                                int max_line_length) {
   auto it = Capture::GAddressToFunctionName.find(addr);
   if (it == Capture::GAddressToFunctionName.end()) {
     return std::string("<i>") + "???" + "</i>";
@@ -202,9 +203,9 @@ std::string SafeGetFormattedFunctionName(uint64_t addr, int max_line_length) {
 };
 
 //-----------------------------------------------------------------------------
-std::string FormatCallstackForTooltip(std::shared_ptr<CallStack> callstack,
-                                      int max_line_length = 80,
-                                      int max_lines = 13) {
+static std::string FormatCallstackForTooltip(
+    std::shared_ptr<CallStack> callstack, int max_line_length = 80,
+    int max_lines = 13) {
   std::string result;
   int size = static_cast<int>(callstack->m_Data.size());
   if (max_lines <= 0) {

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -194,7 +194,11 @@ static std::string SafeGetFormattedFunctionName(uint64_t addr,
     return std::string("<i>") + "???" + "</i>";
   }
 
-  std::string fn_name = ShortenStringWithEllipsis(it->second, max_line_length);
+  std::string fn_name =
+      max_line_length >= 0
+          ? ShortenStringWithEllipsis(it->second,
+                                      static_cast<size_t>(max_line_length))
+          : it->second;
   // Simple HTML escaping
   fn_name = Replace(fn_name, "&", "&amp;");
   fn_name = Replace(fn_name, "<", "&lt;");

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -209,13 +209,13 @@ static std::string SafeGetFormattedFunctionName(uint64_t addr,
 //-----------------------------------------------------------------------------
 static std::string FormatCallstackForTooltip(
     std::shared_ptr<CallStack> callstack, int max_line_length = 80,
-    int max_lines = 13) {
+    int max_lines = 20, int bottom_n_lines = 5) {
   std::string result;
   int size = static_cast<int>(callstack->m_Data.size());
   if (max_lines <= 0) {
     max_lines = size;
   }
-  const int bottom_n = std::min(std::min(max_lines - 1, 3), size);
+  const int bottom_n = std::min(std::min(max_lines - 1, bottom_n_lines), size);
   const int top_n = std::min(max_lines, size) - bottom_n;
 
   for (int i = 0; i < top_n; ++i) {


### PR DESCRIPTION
Following a comment from Ronald in the last PR, callstacks in tooltips are now shortened if needed.