### PR TITLE
Remove use_software_opengl switch.

### DIFF
--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -52,10 +52,6 @@ ABSL_FLAG(uint16_t, grpc_port, 44765,
           "The service's GRPC server port (use default value if unsure)");
 ABSL_FLAG(bool, local, false, "Connects to local instance of OrbitService");
 
-ABSL_FLAG(bool, use_software_opengl, false,
-          "Uses software implementation of OpenGL. Requires Mesa's "
-          "opengl32.dll to be placed in the same folder as Orbit.");
-
 // TODO(b/160549506): Remove this flag once it can be specified in the ui.
 ABSL_FLAG(uint16_t, sampling_rate, 1000,
           "Frequency of callstack sampling in samples per second");
@@ -248,10 +244,6 @@ int main(int argc, char* argv[]) {
 #if __linux__
     QCoreApplication::setAttribute(Qt::AA_DontUseNativeDialogs);
 #endif
-
-    if (absl::GetFlag(FLAGS_use_software_opengl)) {
-      QCoreApplication::setAttribute(Qt::AA_UseSoftwareOpenGL);
-    }
 
     QApplication app(argc, argv);
     QCoreApplication::setApplicationName("Orbit Profiler [BETA]");


### PR DESCRIPTION
Never worked. Fortunatelly it is not needed: copying the mesa dll into the same folder makes Orbit use the software renderer.