### PR TITLE
Bugfixes for GPU Track collapse behavior

### DIFF
--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -52,7 +52,7 @@ GpuTrack::GpuTrack(TimeGraph* time_graph,
   string_manager_ = string_manager;
 
   // Gpu tracks are collapsed by default.
-  collapse_toggle_.SetState(TriangleToggle::State::kCollapsed);
+  collapse_toggle_.SetState(TriangleToggle::State::kCollapsed, true);
 }
 
 //-----------------------------------------------------------------------------
@@ -154,7 +154,7 @@ void GpuTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
   float world_start_x = canvas->GetWorldTopLeftX();
   float world_width = canvas->GetWorldWidth();
   double inv_time_window = 1.0 / time_graph_->GetTimeWindowUs();
-  bool is_collapsed = collapse_toggle_.IsCollapsed() && (depth_ > 1);
+  bool is_collapsed = collapse_toggle_.IsCollapsed();
 
   std::vector<std::shared_ptr<TimerChain>> chains_by_depth = GetTimers();
 

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -52,7 +52,9 @@ GpuTrack::GpuTrack(TimeGraph* time_graph,
   string_manager_ = string_manager;
 
   // Gpu tracks are collapsed by default.
-  collapse_toggle_.SetState(TriangleToggle::State::kCollapsed, true);
+  collapse_toggle_.SetState(
+      TriangleToggle::State::kCollapsed,
+      TriangleToggle::InitialStateUpdate::kReplaceInitialState);
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -95,9 +95,9 @@ void TimeGraph::Clear() {
   // The process track is a special ThreadTrack of id "0".
   process_track_ = GetOrCreateThreadTrack(0);
 
-  NeedsUpdate();
-
   SetOverlayTextBoxes({});
+
+  NeedsUpdate();
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -95,6 +95,8 @@ void TimeGraph::Clear() {
   // The process track is a special ThreadTrack of id "0".
   process_track_ = GetOrCreateThreadTrack(0);
 
+  NeedsUpdate();
+
   SetOverlayTextBoxes({});
 }
 
@@ -339,6 +341,8 @@ void TimeGraph::ProcessTimer(const Timer& a_Timer) {
       cores_seen_.insert(a_Timer.m_Processor);
     }
   }
+
+  NeedsUpdate();
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/TriangleToggle.cpp
+++ b/OrbitGl/TriangleToggle.cpp
@@ -68,9 +68,9 @@ void TriangleToggle::OnRelease() {
   time_graph_->NeedsUpdate();
 }
 
-void TriangleToggle::SetState(State state, bool replace_initial_state) {
+void TriangleToggle::SetState(State state, InitialStateUpdate behavior) {
   state_ = state;
-  if (replace_initial_state) {
+  if (behavior == InitialStateUpdate::kReplaceInitialState) {
     initial_state_ = state;
   }
 }

--- a/OrbitGl/TriangleToggle.cpp
+++ b/OrbitGl/TriangleToggle.cpp
@@ -68,4 +68,9 @@ void TriangleToggle::OnRelease() {
   time_graph_->NeedsUpdate();
 }
 
-void TriangleToggle::SetState(State state) { state_ = state; }
+void TriangleToggle::SetState(State state, bool replace_initial_state) {
+  state_ = state;
+  if (replace_initial_state) {
+    initial_state_ = state;
+  }
+}

--- a/OrbitGl/TriangleToggle.h
+++ b/OrbitGl/TriangleToggle.h
@@ -15,6 +15,7 @@ class GlCanvas;
 class TriangleToggle : public Pickable {
  public:
   enum class State { kInactive, kExpanded, kCollapsed };
+  enum class InitialStateUpdate { kKeepInitialState, kReplaceInitialState };
 
   using StateChangeHandler = std::function<void(TriangleToggle::State)>;
   explicit TriangleToggle(State initial_state, StateChangeHandler handler,
@@ -33,7 +34,8 @@ class TriangleToggle : public Pickable {
   void OnRelease() override;
 
   State GetState() const { return state_; }
-  void SetState(State state, bool replace_initial_state = false);
+  void SetState(State state, InitialStateUpdate update_initial_state =
+                                 InitialStateUpdate::kKeepInitialState);
   void ResetToInitialState() { state_ = initial_state_; }
   bool IsCollapsed() const { return state_ == State::kCollapsed; }
   bool IsExpanded() const { return state_ == State::kExpanded; }

--- a/OrbitGl/TriangleToggle.h
+++ b/OrbitGl/TriangleToggle.h
@@ -33,7 +33,7 @@ class TriangleToggle : public Pickable {
   void OnRelease() override;
 
   State GetState() const { return state_; }
-  void SetState(State state);
+  void SetState(State state, bool replace_initial_state = false);
   void ResetToInitialState() { state_ = initial_state_; }
   bool IsCollapsed() const { return state_ == State::kCollapsed; }
   bool IsExpanded() const { return state_ == State::kExpanded; }


### PR DESCRIPTION
* Redraw forced after clearing the timeline
* Initial state of TriangleToggle can be set after construction (through an additional parameter in setState)
* GPUTrack does no longer check for depth_ > 1 to determine if the track is collapsed. The depth_ is updated in the loop after this check, which leads to inconsistent drawing after a capture is loaded