### PR TITLE
Replace hit-count function with a class to prepare display of more information in the heat-map.

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -21,6 +21,7 @@
 #include "CaptureSerializer.h"
 #include "CaptureWindow.h"
 #include "Disassembler.h"
+#include "DisassemblyReport.h"
 #include "EventTracer.h"
 #include "FunctionUtils.h"
 #include "FunctionsDataView.h"
@@ -347,48 +348,16 @@ void OrbitApp::Disassemble(int32_t pid, const FunctionInfo& function) {
                        FunctionUtils::GetAbsoluteAddress(function),
                        Capture::GTargetProcess->GetIs64Bit());
     if (!sampling_report_ || !sampling_report_->GetProfiler()) {
-      SendDisassemblyToUi(disasm.GetResult());
+      DisassemblyReport empty_report(disasm);
+      SendDisassemblyToUi(disasm.GetResult(), empty_report);
       return;
     }
     std::shared_ptr<SamplingProfiler> profiler =
         sampling_report_->GetProfiler();
-    uint32_t count_of_function = profiler->GetCountOfFunction(
-        FunctionUtils::GetAbsoluteAddress(function));
-    if (count_of_function == 0) {
-      SendDisassemblyToUi(disasm.GetResult());
-      return;
-    }
 
-    const std::function<double(size_t)> line_to_hit_ratio =
-        [profiler, disasm, count_of_function](size_t line) {
-          uint64_t address = disasm.GetAddressAtLine(line);
-          if (address == 0) {
-            return 0.0;
-          }
-
-          // On calls the address sampled might not be the address of the
-          // beginning of the instruction, but instead at the end. Thus, we
-          // iterate over all addresses that fall into this instruction.
-          uint64_t next_address = disasm.GetAddressAtLine(line + 1);
-
-          // If the current instruction is the last one (next address is 0), it
-          // can not be a call, thus we can only consider this address.
-          if (next_address == 0) {
-            next_address = address + 1;
-          }
-          const ThreadSampleData* data = profiler->GetSummary();
-          if (data == nullptr) {
-            return 0.0;
-          }
-          size_t count = 0;
-          while (address < next_address) {
-            count += SamplingUtils::GetCountForAddress(*data, address);
-            address++;
-          }
-          double result = static_cast<double>(count) / count_of_function;
-          return result;
-        };
-    SendDisassemblyToUi(disasm.GetResult(), line_to_hit_ratio);
+    DisassemblyReport report(
+        disasm, FunctionUtils::GetAbsoluteAddress(function), profiler);
+    SendDisassemblyToUi(disasm.GetResult(), report);
   });
 }
 
@@ -724,12 +693,11 @@ void OrbitApp::RequestSaveCaptureToUi() {
   });
 }
 
-void OrbitApp::SendDisassemblyToUi(
-    const std::string& disassembly,
-    const std::function<double(size_t)>& line_to_hit_ratio) {
-  main_thread_executor_->Schedule([this, disassembly, line_to_hit_ratio] {
+void OrbitApp::SendDisassemblyToUi(const std::string& disassembly,
+                                   const DisassemblyReport& report) {
+  main_thread_executor_->Schedule([this, disassembly, report] {
     if (disassembly_callback_) {
-      disassembly_callback_(disassembly, line_to_hit_ratio);
+      disassembly_callback_(disassembly, report);
     }
   });
 }

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -21,6 +21,7 @@
 #include "DataManager.h"
 #include "DataViewFactory.h"
 #include "DataViewTypes.h"
+#include "DisassemblyReport.h"
 #include "FramePointerValidatorClient.h"
 #include "FunctionsDataView.h"
 #include "LinuxCallstackEvent.h"
@@ -136,8 +137,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void SetSelectLiveTabCallback(SelectLiveTabCallback callback) {
     select_live_tab_callback_ = std::move(callback);
   }
-  using DisassemblyCallback = std::function<void(
-      const std::string&, const std::function<double(size_t)>&)>;
+  using DisassemblyCallback =
+      std::function<void(const std::string&, const DisassemblyReport&)>;
   void SetDisassemblyCallback(DisassemblyCallback callback) {
     disassembly_callback_ = std::move(callback);
   }
@@ -203,11 +204,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
 
   void RequestOpenCaptureToUi();
   void RequestSaveCaptureToUi();
-  void SendDisassemblyToUi(
-      const std::string& disassembly,
-      const std::function<double(size_t)>& line_to_hit_ratio = [](size_t) {
-        return 0.0;
-      });
+  void SendDisassemblyToUi(const std::string& disassembly,
+                           const DisassemblyReport& report);
   void SendTooltipToUi(const std::string& tooltip);
   void RequestFeedbackDialogToUi();
   void SendInfoToUi(const std::string& title, const std::string& text);

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -138,7 +138,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
     select_live_tab_callback_ = std::move(callback);
   }
   using DisassemblyCallback =
-      std::function<void(const std::string&, const DisassemblyReport&)>;
+      std::function<void(std::string, DisassemblyReport)>;
   void SetDisassemblyCallback(DisassemblyCallback callback) {
     disassembly_callback_ = std::move(callback);
   }
@@ -204,8 +204,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
 
   void RequestOpenCaptureToUi();
   void RequestSaveCaptureToUi();
-  void SendDisassemblyToUi(const std::string& disassembly,
-                           const DisassemblyReport& report);
+  void SendDisassemblyToUi(std::string disassembly, DisassemblyReport report);
   void SendTooltipToUi(const std::string& tooltip);
   void RequestFeedbackDialogToUi();
   void SendInfoToUi(const std::string& title, const std::string& text);

--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -18,10 +18,12 @@ target_sources(
          CaptureSerializer.h
          CaptureWindow.h
          Card.h
+         CodeReport.h
          CoreMath.h
          DataView.h
          DataViewTypes.h
          Disassembler.h
+         DisassemblyReport.h
          EventTrack.h
          FramePointerValidatorClient.h
          FunctionsDataView.h
@@ -69,6 +71,7 @@ target_sources(
           DataManager.cpp
           DataView.cpp
           Disassembler.cpp
+          DisassemblyReport.cc
           EventTrack.cpp
           FramePointerValidatorClient.cpp
           LiveFunctionsController.cpp

--- a/OrbitGl/CodeReport.h
+++ b/OrbitGl/CodeReport.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_CODE_REPORT_H_
+#define ORBIT_GL_CODE_REPORT_H_
+
+#include <cstddef>
+#include <cstdint>
+
+class CodeReport {
+ public:
+  virtual ~CodeReport() = default;
+  [[nodiscard]] virtual uint32_t GetNumSamplesInFunction() const = 0;
+  [[nodiscard]] virtual uint32_t GetNumSamples() const = 0;
+  [[nodiscard]] virtual uint32_t GetNumSamplesAtLine(size_t line) const = 0;
+};
+
+#endif  // ORBIT_GL_CODE_REPORT_H_

--- a/OrbitGl/DisassemblyReport.cc
+++ b/OrbitGl/DisassemblyReport.cc
@@ -3,8 +3,11 @@
 #include "SamplingUtils.h"
 
 uint32_t DisassemblyReport::GetNumSamplesAtLine(size_t line) const {
+  if (function_count_ == 0 || profiler_ == nullptr) {
+    return 0;
+  }
   uint64_t address = disasm_.GetAddressAtLine(line);
-  if (address == 0 || function_count_ == 0 || profiler_ == nullptr) {
+  if (address == 0) {
     return 0;
   }
 

--- a/OrbitGl/DisassemblyReport.cc
+++ b/OrbitGl/DisassemblyReport.cc
@@ -1,0 +1,31 @@
+#include "DisassemblyReport.h"
+
+#include "SamplingUtils.h"
+
+uint32_t DisassemblyReport::GetNumSamplesAtLine(size_t line) const {
+  uint64_t address = disasm_.GetAddressAtLine(line);
+  if (address == 0 || function_count_ == 0 || profiler_ == nullptr) {
+    return 0;
+  }
+
+  // On calls the address sampled might not be the address of the
+  // beginning of the instruction, but instead at the end. Thus, we
+  // iterate over all addresses that fall into this instruction.
+  uint64_t next_address = disasm_.GetAddressAtLine(line + 1);
+
+  // If the current instruction is the last one (next address is 0), it
+  // can not be a call, thus we can only consider this address.
+  if (next_address == 0) {
+    next_address = address + 1;
+  }
+  const ThreadSampleData* data = profiler_->GetSummary();
+  if (data == nullptr) {
+    return 0.0;
+  }
+  uint32_t count = 0;
+  while (address < next_address) {
+    count += SamplingUtils::GetCountForAddress(*data, address);
+    address++;
+  }
+  return count;
+}

--- a/OrbitGl/DisassemblyReport.h
+++ b/OrbitGl/DisassemblyReport.h
@@ -17,7 +17,10 @@ class DisassemblyReport : public CodeReport {
                     std::shared_ptr<SamplingProfiler> profiler)
       : disasm_{std::move(disasm)},
         profiler_{std::move(profiler)},
-        function_count_{profiler_->GetCountOfFunction(function_address)} {}
+        function_count_{(profiler_ == nullptr)
+                            ? 0
+                            : profiler_->GetCountOfFunction(function_address)} {
+  }
 
   explicit DisassemblyReport(Disassembler disasm)
       : disasm_{std::move(disasm)}, profiler_{nullptr}, function_count_{0} {};
@@ -26,6 +29,9 @@ class DisassemblyReport : public CodeReport {
     return function_count_;
   }
   [[nodiscard]] uint32_t GetNumSamples() const override {
+    if (profiler_ == nullptr) {
+      return 0;
+    }
     return profiler_->GetNumSamples();
   }
   [[nodiscard]] uint32_t GetNumSamplesAtLine(size_t line) const override;

--- a/OrbitGl/DisassemblyReport.h
+++ b/OrbitGl/DisassemblyReport.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_DISASSEMBLY_REPORT_H_
+#define ORBIT_GL_DISASSEMBLY_REPORT_H_
+
+#include <utility>
+
+#include "CodeReport.h"
+#include "Disassembler.h"
+#include "SamplingProfiler.h"
+
+class DisassemblyReport : public CodeReport {
+ public:
+  DisassemblyReport(Disassembler disasm, uint64_t function_address,
+                    std::shared_ptr<SamplingProfiler> profiler)
+      : disasm_{std::move(disasm)},
+        profiler_{std::move(profiler)},
+        function_count_{profiler_->GetCountOfFunction(function_address)} {}
+
+  explicit DisassemblyReport(Disassembler disasm)
+      : disasm_{std::move(disasm)}, profiler_{nullptr}, function_count_{0} {};
+
+  [[nodiscard]] uint32_t GetNumSamplesInFunction() const override {
+    return function_count_;
+  }
+  [[nodiscard]] uint32_t GetNumSamples() const override {
+    return profiler_->GetNumSamples();
+  }
+  [[nodiscard]] uint32_t GetNumSamplesAtLine(size_t line) const override;
+
+ private:
+  const Disassembler disasm_;
+  const std::shared_ptr<SamplingProfiler> profiler_;
+  const uint32_t function_count_;
+};
+
+#endif  // ORBIT_GL_DISASSEMBLY_REPORT_H_

--- a/OrbitQt/orbitcodeeditor.cpp
+++ b/OrbitQt/orbitcodeeditor.cpp
@@ -255,7 +255,7 @@ void OrbitCodeEditor::OnTimer() {
 }
 
 //-----------------------------------------------------------------------------
-void OrbitCodeEditor::SetText(const std::string& a_Text) {
+void OrbitCodeEditor::SetText(std::string a_Text) {
   this->document()->setPlainText(QString::fromStdString(a_Text));
 }
 
@@ -464,6 +464,13 @@ void OrbitCodeEditor::HeatMapAreaPaintEvent(QPaintEvent* event) {
   QPainter painter(heatMapArea);
   painter.fillRect(event->rect(), QColor(30, 30, 30));
 
+  uint32_t function_sample_count = report_->GetNumSamplesInFunction();
+  // If there are no samples in that function, there is no need to draw the
+  // heatmap. However, we still need to fill the background rect. above.
+  if (function_sample_count == 0) {
+    return;
+  }
+
   //![extraAreaPaintEvent_0]
 
   //![extraAreaPaintEvent_1]
@@ -480,7 +487,7 @@ void OrbitCodeEditor::HeatMapAreaPaintEvent(QPaintEvent* event) {
       // % of hits in this function from 0.0 to 1.0
       const double hit_ratio =
           static_cast<double>(report_->GetNumSamplesAtLine(blockNumber)) /
-          report_->GetNumSamplesInFunction();
+          function_sample_count;
       // The sqrt maps 0.0 to 0.0 and 1.0 to 1.0 but makes small rations larger,
       // such that in the ui you can still see that the instruction was actually
       // hit in the sampling.

--- a/OrbitQt/orbitcodeeditor.cpp
+++ b/OrbitQt/orbitcodeeditor.cpp
@@ -478,7 +478,9 @@ void OrbitCodeEditor::HeatMapAreaPaintEvent(QPaintEvent* event) {
   while (block.isValid() && top <= event->rect().bottom()) {
     if (block.isVisible() && bottom >= event->rect().top()) {
       // % of hits in this function from 0.0 to 1.0
-      const double hit_ratio = line_to_hit_ratio_(blockNumber);
+      const double hit_ratio =
+          static_cast<double>(report_->GetNumSamplesAtLine(blockNumber)) /
+          report_->GetNumSamplesInFunction();
       // The sqrt maps 0.0 to 0.0 and 1.0 to 1.0 but makes small rations larger,
       // such that in the ui you can still see that the instruction was actually
       // hit in the sampling.

--- a/OrbitQt/orbitcodeeditor.h
+++ b/OrbitQt/orbitcodeeditor.h
@@ -87,7 +87,7 @@ class OrbitCodeEditor : public QPlainTextEdit {
   void saveFileMap();
   void gotoLine(int a_Line);
   void OnTimer();
-  void SetText(const std::string& a_Text);
+  void SetText(std::string a_Text);
   void SetReport(std::unique_ptr<CodeReport> report) {
     report_ = std::move(report);
   }

--- a/OrbitQt/orbitcodeeditor.h
+++ b/OrbitQt/orbitcodeeditor.h
@@ -55,8 +55,10 @@
 #include <QPlainTextEdit>
 #include <QSyntaxHighlighter>
 #include <QTextCharFormat>
+#include <memory>
 
 #include "../OrbitCore/RingBuffer.h"
+#include "CodeReport.h"
 
 QT_BEGIN_NAMESPACE
 class QPaintEvent;
@@ -86,8 +88,8 @@ class OrbitCodeEditor : public QPlainTextEdit {
   void gotoLine(int a_Line);
   void OnTimer();
   void SetText(const std::string& a_Text);
-  void SetLineToHits(const std::function<double(size_t)>& line_to_hit_ratio) {
-    line_to_hit_ratio_ = line_to_hit_ratio;
+  void SetReport(std::unique_ptr<CodeReport> report) {
+    report_ = std::move(report);
   }
   void HighlightWord(const std::string& a_Text, const QColor& a_Color,
                      QList<QTextEdit::ExtraSelection>& extraSelections);
@@ -125,7 +127,7 @@ class OrbitCodeEditor : public QPlainTextEdit {
   class QPushButton* m_SaveButton;
   EditorType m_Type;
   bool m_IsOutput;
-  std::function<double(size_t)> line_to_hit_ratio_ = [](size_t) { return 0.0; };
+  std::unique_ptr<CodeReport> report_;
 
   static OrbitCodeEditor* GFileMapEditor;
   static QWidget* GFileMapWidget;

--- a/OrbitQt/orbitdisassemblydialog.cpp
+++ b/OrbitQt/orbitdisassemblydialog.cpp
@@ -16,14 +16,14 @@ OrbitDisassemblyDialog::OrbitDisassemblyDialog(QWidget* parent)
 OrbitDisassemblyDialog::~OrbitDisassemblyDialog() { delete ui; }
 
 //-----------------------------------------------------------------------------
-void OrbitDisassemblyDialog::SetText(const std::string& a_Text) {
-  ui->plainTextEdit->SetText(a_Text);
+void OrbitDisassemblyDialog::SetText(std::string a_Text) {
+  ui->plainTextEdit->SetText(std::move(a_Text));
   ui->plainTextEdit->moveCursor(QTextCursor::Start);
   ui->plainTextEdit->ensureCursorVisible();
 }
 
 //-----------------------------------------------------------------------------
-void OrbitDisassemblyDialog::SetDisassemblyReport(
-    const DisassemblyReport& report) {
-  ui->plainTextEdit->SetReport(std::make_unique<DisassemblyReport>(report));
+void OrbitDisassemblyDialog::SetDisassemblyReport(DisassemblyReport report) {
+  ui->plainTextEdit->SetReport(
+      std::make_unique<DisassemblyReport>(std::move(report)));
 }

--- a/OrbitQt/orbitdisassemblydialog.cpp
+++ b/OrbitQt/orbitdisassemblydialog.cpp
@@ -23,7 +23,7 @@ void OrbitDisassemblyDialog::SetText(const std::string& a_Text) {
 }
 
 //-----------------------------------------------------------------------------
-void OrbitDisassemblyDialog::SetLineToHitRatio(
-    const std::function<double(size_t)>& line_to_hit_ratio) {
-  ui->plainTextEdit->SetLineToHits(line_to_hit_ratio);
+void OrbitDisassemblyDialog::SetDisassemblyReport(
+    const DisassemblyReport& report) {
+  ui->plainTextEdit->SetReport(std::make_unique<DisassemblyReport>(report));
 }

--- a/OrbitQt/orbitdisassemblydialog.h
+++ b/OrbitQt/orbitdisassemblydialog.h
@@ -5,6 +5,8 @@
 #ifndef ORBITDISASSEMBLYDIALOG_H
 #define ORBITDISASSEMBLYDIALOG_H
 
+#include <DisassemblyReport.h>
+
 #include <QDialog>
 #include <functional>
 #include <string>
@@ -21,8 +23,7 @@ class OrbitDisassemblyDialog : public QDialog {
   ~OrbitDisassemblyDialog() override;
 
   void SetText(const std::string& a_Text);
-  void SetLineToHitRatio(
-      const std::function<double(size_t)>& line_to_hit_ratio);
+  void SetDisassemblyReport(const DisassemblyReport& report);
 
  private:
   Ui::OrbitDisassemblyDialog* ui;

--- a/OrbitQt/orbitdisassemblydialog.h
+++ b/OrbitQt/orbitdisassemblydialog.h
@@ -22,8 +22,8 @@ class OrbitDisassemblyDialog : public QDialog {
   explicit OrbitDisassemblyDialog(QWidget* parent = nullptr);
   ~OrbitDisassemblyDialog() override;
 
-  void SetText(const std::string& a_Text);
-  void SetDisassemblyReport(const DisassemblyReport& report);
+  void SetText(std::string a_Text);
+  void SetDisassemblyReport(DisassemblyReport report);
 
  private:
   Ui::OrbitDisassemblyDialog* ui;

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -139,9 +139,8 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App,
   GOrbitApp->SetSelectLiveTabCallback(
       [this] { ui->RightTabWidget->setCurrentWidget(ui->liveTab); });
   GOrbitApp->SetDisassemblyCallback(
-      [this](const std::string& disassembly,
-             const std::function<double(size_t)>& line_to_hits) {
-        OpenDisassembly(disassembly, line_to_hits);
+      [this](const std::string& disassembly, const DisassemblyReport& report) {
+        OpenDisassembly(disassembly, report);
       });
   GOrbitApp->SetErrorMessageCallback(
       [this](const std::string& title, const std::string& text) {
@@ -784,10 +783,10 @@ outcome::result<void> OrbitMainWindow::OpenCapture(
 //-----------------------------------------------------------------------------
 void OrbitMainWindow::OpenDisassembly(
     const std::string& a_String,
-    const std::function<double(size_t)>& line_to_hit_ratio) {
+    const DisassemblyReport& report) {
   auto* dialog = new OrbitDisassemblyDialog(this);
   dialog->SetText(a_String);
-  dialog->SetLineToHitRatio(line_to_hit_ratio);
+  dialog->SetDisassemblyReport(report);
   dialog->setWindowTitle("Orbit Disassembly");
   dialog->setAttribute(Qt::WA_DeleteOnClose);
   dialog->setWindowFlags(dialog->windowFlags() | Qt::WindowMinimizeButtonHint |

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -139,7 +139,7 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App,
   GOrbitApp->SetSelectLiveTabCallback(
       [this] { ui->RightTabWidget->setCurrentWidget(ui->liveTab); });
   GOrbitApp->SetDisassemblyCallback(
-      [this](const std::string& disassembly, const DisassemblyReport& report) {
+      [this](std::string disassembly, DisassemblyReport report) {
         OpenDisassembly(disassembly, report);
       });
   GOrbitApp->SetErrorMessageCallback(
@@ -781,12 +781,11 @@ outcome::result<void> OrbitMainWindow::OpenCapture(
 }
 
 //-----------------------------------------------------------------------------
-void OrbitMainWindow::OpenDisassembly(
-    const std::string& a_String,
-    const DisassemblyReport& report) {
+void OrbitMainWindow::OpenDisassembly(std::string a_String,
+                                      DisassemblyReport report) {
   auto* dialog = new OrbitDisassemblyDialog(this);
-  dialog->SetText(a_String);
-  dialog->SetDisassemblyReport(report);
+  dialog->SetText(std::move(a_String));
+  dialog->SetDisassemblyReport(std::move(report));
   dialog->setWindowTitle("Orbit Disassembly");
   dialog->setAttribute(Qt::WA_DeleteOnClose);
   dialog->setWindowFlags(dialog->windowFlags() | Qt::WindowMinimizeButtonHint |

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -52,8 +52,7 @@ class OrbitMainWindow : public QMainWindow {
   bool HideTab(QTabWidget* a_TabWidget, const char* a_TabName);
   std::string FindFile(const std::string& caption, const std::string& dir,
                        const std::string& filter);
-  void OpenDisassembly(const std::string& a_String,
-                       const DisassemblyReport& report);
+  void OpenDisassembly(std::string a_String, DisassemblyReport report);
   void SetTitle(const QString& task_description);
   outcome::result<void> OpenCapture(const std::string& filepath);
   void OnCaptureCleared();

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <DisassemblyReport.h>
+
 #include <QApplication>
 #include <QLabel>
 #include <QLineEdit>
@@ -51,7 +53,7 @@ class OrbitMainWindow : public QMainWindow {
   std::string FindFile(const std::string& caption, const std::string& dir,
                        const std::string& filter);
   void OpenDisassembly(const std::string& a_String,
-                       const std::function<double(size_t)>& line_to_hit_ratio);
+                       const DisassemblyReport& report);
   void SetTitle(const QString& task_description);
   outcome::result<void> OpenCapture(const std::string& filepath);
   void OnCaptureCleared();


### PR DESCRIPTION
Prio to this change, we passed a function to the ui that computed the
ratio of samples hit that line to samples that hit the function. As we
want to display more data, like the actual numbers and the percentages
relative to the function and the overall result, this will introduce
an interface CodeReport providing functions to retrieve these numbers.
Currently DisassemblyReport derives from this class in order to provide
the heat-map for the disassembly view.