### PR TITLE
Refactor of tracks by introducing a new base class TimerTrack

### DIFF
--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -55,6 +55,7 @@ target_sources(
          TimeGraphLayout.h
          TimerChain.h
          TopDownView.h
+         TimerTrack.h
          Track.h
          TriangleToggle.h)
 
@@ -99,6 +100,7 @@ target_sources(
           TimeGraph.cpp
           TimeGraphLayout.cpp
           TimerChain.cpp
+          TimerTrack.cpp
           ThreadTrack.cpp
           TopDownView.cpp
           Track.cpp

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -4,13 +4,10 @@
 
 #include "GpuTrack.h"
 
-#include <limits>
-
 #include "Capture.h"
 #include "GlCanvas.h"
 #include "Profiling.h"
 #include "TimeGraph.h"
-#include "absl/flags/flag.h"
 #include "absl/strings/str_format.h"
 
 using orbit_client_protos::TimerInfo;
@@ -44,7 +41,7 @@ std::string MapGpuTimelineToTrackLabel(std::string_view timeline) {
 GpuTrack::GpuTrack(TimeGraph* time_graph,
                    std::shared_ptr<StringManager> string_manager,
                    uint64_t timeline_hash)
-    : Track(time_graph) {
+    : TimerTrack(time_graph) {
   text_renderer_ = time_graph->GetTextRenderer();
   timeline_hash_ = timeline_hash;
 
@@ -60,25 +57,23 @@ GpuTrack::GpuTrack(TimeGraph* time_graph,
       TriangleToggle::InitialStateUpdate::kReplaceInitialState);
 }
 
-//-----------------------------------------------------------------------------
-void GpuTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
-  float track_height = GetHeight();
-  float track_width = canvas->GetWorldWidth();
+bool GpuTrack::IsTimerActive(const TimerInfo& timer_info) const {
+  bool is_same_tid_as_selected = timer_info.thread_id() == Capture::GSelectedThreadId;
+  // We do not properly track the PID for GPU jobs and we still want to show
+  // all jobs as active when no thread is selected, so this logic is a bit
+  // different than SchedulerTrack::IsTimerActive.
+  bool no_thread_selected = Capture::GSelectedThreadId == 0;
 
-  SetPos(canvas->GetWorldTopLeftX(), m_Pos[1]);
-  SetSize(track_width, track_height);
-
-  Track::Draw(canvas, picking_mode);
+  return is_same_tid_as_selected || no_thread_selected;
 }
 
-//-----------------------------------------------------------------------------
-Color GpuTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected,
-                              bool inactive) const {
+// //-----------------------------------------------------------------------------
+Color GpuTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected) const {
   const Color kInactiveColor(100, 100, 100, 255);
   const Color kSelectionColor(0, 128, 255, 255);
   if (is_selected) {
     return kSelectionColor;
-  } else if (inactive) {
+  } else if (!IsTimerActive(timer_info)) {
     return kInactiveColor;
   }
 
@@ -112,9 +107,25 @@ Color GpuTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected,
 }
 
 //-----------------------------------------------------------------------------
-inline float GetYFromDepth(const TimeGraphLayout& layout, float track_y,
-                           uint32_t depth) {
-  return track_y - layout.GetTextBoxHeight() * (depth + 1);
+float GpuTrack::GetYFromDepth(uint32_t depth) const {
+  float adjusted_depth = static_cast<float>(depth);
+  if (collapse_toggle_.IsCollapsed()) {
+    adjusted_depth = 0.f;
+  }
+  return m_Pos[1] -
+         time_graph_->GetLayout().GetTextBoxHeight() * (adjusted_depth + 1.f);
+}
+
+// When track is collapsed, only draw "hardware execution" timers.
+bool GpuTrack::TimerFilter(const TimerInfo& timer_info) const {
+  if (collapse_toggle_.IsCollapsed()) {
+    std::string gpu_stage =
+        string_manager_->Get(timer_info.user_data_key()).value_or("");
+    if (gpu_stage != kHwExecutionString) {
+      return false;
+    }
+  }
+  return true;
 }
 
 //-----------------------------------------------------------------------------
@@ -147,135 +158,6 @@ void GpuTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_us,
       kTextWhite, text_box->GetElapsedTimeTextLength(), max_size);
 }
 
-//-----------------------------------------------------------------------------
-void GpuTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
-                                PickingMode /*picking_mode*/) {
-  Batcher* batcher = &time_graph_->GetBatcher();
-  GlCanvas* canvas = time_graph_->GetCanvas();
-  const TimeGraphLayout& layout = time_graph_->GetLayout();
-  const TextBox& scene_box = canvas->GetSceneBox();
-
-  float min_x = scene_box.GetPosX();
-  float world_start_x = canvas->GetWorldTopLeftX();
-  float world_width = canvas->GetWorldWidth();
-  double inv_time_window = 1.0 / time_graph_->GetTimeWindowUs();
-  bool is_collapsed = collapse_toggle_.IsCollapsed();
-
-  std::vector<std::shared_ptr<TimerChain>> chains_by_depth = GetTimers();
-
-  // We minimize overdraw when drawing lines for small events by discarding
-  // events that would just draw over an already drawn line. When zoomed in
-  // enough that all events are drawn as boxes, this has no effect. When zoomed
-  // out, many events will be discarded quickly.
-  uint64_t min_ignore = std::numeric_limits<uint64_t>::max();
-  uint64_t max_ignore = std::numeric_limits<uint64_t>::min();
-
-  uint64_t pixel_delta_in_ticks = static_cast<uint64_t>(MicrosecondsToTicks(
-                                      time_graph_->GetTimeWindowUs())) /
-                                  canvas->getWidth();
-  uint64_t min_timegraph_tick =
-      time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
-
-  for (auto& chain : chains_by_depth) {
-    if (!chain) continue;
-    for (TimerChainIterator it = chain->begin(); it != chain->end(); ++it) {
-      TimerBlock& block = *it;
-      if (!block.Intersects(min_tick, max_tick)) continue;
-      // We have to reset this when we go to the next depth, as otherwise we
-      // would miss drawing events that should be drawn.
-      min_ignore = std::numeric_limits<uint64_t>::max();
-      max_ignore = std::numeric_limits<uint64_t>::min();
-
-      for (uint32_t k = 0; k < block.size(); ++k) {
-        TextBox& text_box = block[k];
-        const TimerInfo& timer_info = text_box.GetTimerInfo();
-        if (min_tick > timer_info.end() || max_tick < timer_info.start())
-          continue;
-        if (timer_info.start() >= min_ignore && timer_info.end() <= max_ignore)
-          continue;
-
-        UpdateDepth(timer_info.depth() + 1);
-        double start_us = time_graph_->GetUsFromTick(timer_info.start());
-        double end_us = time_graph_->GetUsFromTick(timer_info.end());
-        double elapsed_us = end_us - start_us;
-        double normalized_start = start_us * inv_time_window;
-        double normalized_length = elapsed_us * inv_time_window;
-        float world_timer_width =
-            static_cast<float>(normalized_length * world_width);
-        float world_timer_x =
-            static_cast<float>(world_start_x + normalized_start * world_width);
-        uint8_t timer_depth = is_collapsed ? 0 : timer_info.depth();
-        float world_timer_y = GetYFromDepth(layout, m_Pos[1], timer_depth);
-
-        bool is_visible_width = normalized_length * canvas->getWidth() > 1;
-        bool is_selected = &text_box == Capture::GSelectedTextBox;
-
-        Vec2 pos(world_timer_x, world_timer_y);
-        Vec2 size(world_timer_width, layout.GetTextBoxHeight());
-        float z = GlCanvas::Z_VALUE_BOX_ACTIVE;
-        Color color = GetTimerColor(timer_info, is_selected, false);
-        text_box.SetPos(pos);
-        text_box.SetSize(size);
-
-        // When track is collapsed, only draw "hardware execution" timers.
-        if (is_collapsed) {
-          std::string gpu_stage =
-              string_manager_->Get(timer_info.user_data_key()).value_or("");
-          if (gpu_stage != kHwExecutionString) {
-            continue;
-          }
-        }
-
-        auto user_data = std::make_unique<PickingUserData>(
-            &text_box, [&](PickingID id) { return this->GetBoxTooltip(id); });
-
-        if (is_visible_width) {
-          if (!is_collapsed) {
-            SetTimesliceText(timer_info, elapsed_us, min_x, &text_box);
-          }
-          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX,
-                                std::move(user_data));
-        } else {
-          auto type = PickingID::LINE;
-          batcher->AddVerticalLine(pos, size[1], z, color, type,
-                                   std::move(user_data));
-          // For lines, we can ignore the entire pixel into which this event
-          // falls. We align this precisely on the pixel x-coordinate of the
-          // current line being drawn (in ticks). If pixel_delta_in_ticks is
-          // zero, we need to avoid dividing by zero, but we also wouldn't
-          // gain anything here.
-          if (pixel_delta_in_ticks != 0) {
-            min_ignore = min_timegraph_tick +
-                         ((timer_info.start() - min_timegraph_tick) /
-                          pixel_delta_in_ticks) *
-                             pixel_delta_in_ticks;
-            max_ignore = min_ignore + pixel_delta_in_ticks;
-          }
-        }
-      }
-    }
-  }
-}
-
-//-----------------------------------------------------------------------------
-void GpuTrack::OnDrag(int x, int y) { Track::OnDrag(x, y); }
-
-//-----------------------------------------------------------------------------
-void GpuTrack::OnTimer(const TimerInfo& timer_info) {
-  TextBox text_box(Vec2(0, 0), Vec2(0, 0), "", Color(255, 0, 0, 255));
-  text_box.SetTimerInfo(timer_info);
-
-  std::shared_ptr<TimerChain> timer_chain = timers_[timer_info.depth()];
-  if (timer_chain == nullptr) {
-    timer_chain = std::make_shared<TimerChain>();
-    timers_[timer_info.depth()] = timer_chain;
-  }
-  timer_chain->push_back(text_box);
-  ++num_timers_;
-  if (timer_info.start() < min_time_) min_time_ = timer_info.start();
-  if (timer_info.end() > max_time_) max_time_ = timer_info.end();
-}
-
 std::string GpuTrack::GetTooltip() const {
   return "Shows scheduling and execution times for selected GPU job "
          "submissions";
@@ -287,65 +169,6 @@ float GpuTrack::GetHeight() const {
   bool collapsed = collapse_toggle_.IsCollapsed();
   uint32_t depth = collapsed ? 1 : GetDepth();
   return layout.GetTextBoxHeight() * depth + layout.GetTrackBottomMargin();
-}
-
-//-----------------------------------------------------------------------------
-std::vector<std::shared_ptr<TimerChain>> GpuTrack::GetTimers() {
-  std::vector<std::shared_ptr<TimerChain>> timers;
-  ScopeLock lock(mutex_);
-  for (auto& pair : timers_) {
-    timers.push_back(pair.second);
-  }
-  return timers;
-}
-
-//-----------------------------------------------------------------------------
-const TextBox* GpuTrack::GetFirstAfterTime(TickType time,
-                                           uint32_t depth) const {
-  std::shared_ptr<TimerChain> chain = GetTimers(depth);
-  if (chain == nullptr) return nullptr;
-
-  // TODO: do better than linear search...
-  for (TimerChainIterator it = chain->begin(); it != chain->end(); ++it) {
-    for (uint32_t k = 0; k < it->size(); ++k) {
-      const TextBox& text_box = (*it)[k];
-      if (text_box.GetTimerInfo().start() > time) {
-        return &text_box;
-      }
-    }
-  }
-
-  return nullptr;
-}
-
-//-----------------------------------------------------------------------------
-const TextBox* GpuTrack::GetFirstBeforeTime(TickType time,
-                                            uint32_t depth) const {
-  std::shared_ptr<TimerChain> chain = GetTimers(depth);
-  if (chain == nullptr) return nullptr;
-
-  const TextBox* text_box = nullptr;
-
-  // TODO: do better than linear search...
-  for (TimerChainIterator it = chain->begin(); it != chain->end(); ++it) {
-    for (uint32_t k = 0; k < it->size(); ++k) {
-      const TextBox& box = (*it)[k];
-      if (box.GetTimerInfo().start() > time) {
-        return text_box;
-      }
-      text_box = &box;
-    }
-  }
-
-  return nullptr;
-}
-
-//-----------------------------------------------------------------------------
-std::shared_ptr<TimerChain> GpuTrack::GetTimers(uint32_t depth) const {
-  ScopeLock lock(mutex_);
-  auto it = timers_.find(depth);
-  if (it != timers_.end()) return it->second;
-  return nullptr;
 }
 
 //-----------------------------------------------------------------------------
@@ -368,27 +191,6 @@ const TextBox* GpuTrack::GetRight(TextBox* text_box) const {
     if (timers) return timers->GetElementAfter(text_box);
   }
   return nullptr;
-}
-
-//-----------------------------------------------------------------------------
-const TextBox* GpuTrack::GetUp(TextBox* text_box) const {
-  const TimerInfo& timer_info = text_box->GetTimerInfo();
-  return GetFirstBeforeTime(timer_info.start(), timer_info.depth() - 1);
-}
-
-//-----------------------------------------------------------------------------
-const TextBox* GpuTrack::GetDown(TextBox* text_box) const {
-  const TimerInfo& timer_info = text_box->GetTimerInfo();
-  return GetFirstAfterTime(timer_info.start(), timer_info.depth() + 1);
-}
-
-//-----------------------------------------------------------------------------
-std::vector<std::shared_ptr<TimerChain>> GpuTrack::GetAllChains() {
-  std::vector<std::shared_ptr<TimerChain>> chains;
-  for (const auto& pair : timers_) {
-    chains.push_back(pair.second);
-  }
-  return chains;
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/GpuTrack.h
+++ b/OrbitGl/GpuTrack.h
@@ -5,15 +5,12 @@
 #ifndef ORBIT_GL_GPU_TRACK_H_
 #define ORBIT_GL_GPU_TRACK_H_
 
-#include <map>
 #include <memory>
 
-#include "BlockChain.h"
-#include "CallstackTypes.h"
 #include "StringManager.h"
 #include "TextBox.h"
 #include "Threading.h"
-#include "Track.h"
+#include "TimerTrack.h"
 #include "capture_data.pb.h"
 
 class TextRenderer;
@@ -26,71 +23,40 @@ std::string MapGpuTimelineToTrackLabel(std::string_view timeline);
 
 }  // namespace OrbitGl
 
-class GpuTrack : public Track {
+class GpuTrack : public TimerTrack {
  public:
   GpuTrack(TimeGraph* time_graph, std::shared_ptr<StringManager> string_manager,
            uint64_t timeline_hash);
   ~GpuTrack() override = default;
+  [[nodiscard]] std::string GetTooltip() const override;
+  [[nodiscard]] Type GetType() const override { return kGpuTrack; }
+  [[nodiscard]] float GetHeight() const override;
 
-  // Pickable
-  void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
-  void OnDrag(int x, int y) override;
-  void OnTimer(const orbit_client_protos::TimerInfo& timer_info);
-  std::string GetTooltip() const override;
+  [[nodiscard]] const TextBox* GetLeft(TextBox* text_box) const override;
+  [[nodiscard]] const TextBox* GetRight(TextBox* text_box) const override;
 
-  // Track
-  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
-                        PickingMode /*picking_mode*/) override;
-  Type GetType() const override { return kGpuTrack; }
-  float GetHeight() const override;
-
-  std::vector<std::shared_ptr<TimerChain>> GetTimers() override;
-  uint32_t GetDepth() const { return depth_; }
-  std::string GetExtraInfo(const orbit_client_protos::TimerInfo& timer_info);
-
-  Color GetColor() const;
-  uint32_t GetNumTimers() const { return num_timers_; }
-  TickType GetMinTime() const { return min_time_; }
-  TickType GetMaxTime() const { return max_time_; }
-
-  const TextBox* GetFirstAfterTime(TickType time, uint32_t depth) const;
-  const TextBox* GetFirstBeforeTime(TickType time, uint32_t depth) const;
-
-  const TextBox* GetLeft(TextBox* textbox) const;
-  const TextBox* GetRight(TextBox* textbox) const;
-  const TextBox* GetUp(TextBox* textbox) const;
-  const TextBox* GetDown(TextBox* textbox) const;
-
-  std::vector<std::shared_ptr<TimerChain>> GetAllChains() override;
-  bool IsCollapsable() const override { return depth_ > 1; }
+  [[nodiscard]] float GetYFromDepth(uint32_t depth) const override;
 
  protected:
-  void UpdateDepth(uint32_t depth) {
-    if (depth > depth_) depth_ = depth;
-  }
-  std::shared_ptr<TimerChain> GetTimers(uint32_t depth) const;
+  [[nodiscard]] bool IsTimerActive(
+      const orbit_client_protos::TimerInfo& timer) const override;
+  [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer,
+                                    bool is_selected) const override;
+  [[nodiscard]] bool TimerFilter(
+      const orbit_client_protos::TimerInfo& timer) const override;
+  [[nodiscard]] void SetTimesliceText(
+      const orbit_client_protos::TimerInfo& timer, double elapsed_us,
+      float min_x, TextBox* text_box) override;
+  [[nodiscard]] std::string GetBoxTooltip(PickingID id) const override;
 
  private:
-  Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
-                      bool is_selected, bool inactive) const;
-  void SetTimesliceText(const orbit_client_protos::TimerInfo& timer_info,
-                        double elapsed_us, float min_x, TextBox* text_box);
-
- protected:
-  TextRenderer* text_renderer_ = nullptr;
-  uint32_t depth_ = 0;
   uint64_t timeline_hash_;
-  mutable Mutex mutex_;
-  std::map<int, std::shared_ptr<TimerChain>> timers_;
-
   std::shared_ptr<StringManager> string_manager_;
-
-  std::string GetBoxTooltip(PickingID id) const;
-  std::string GetSwQueueTooltip(
+  [[nodiscard]] std::string GetSwQueueTooltip(
       const orbit_client_protos::TimerInfo& timer_info) const;
-  std::string GetHwQueueTooltip(
+  [[nodiscard]] std::string GetHwQueueTooltip(
       const orbit_client_protos::TimerInfo& timer_info) const;
-  std::string GetHwExecutionTooltip(
+  [[nodiscard]] std::string GetHwExecutionTooltip(
       const orbit_client_protos::TimerInfo& timer_info) const;
 };
 

--- a/OrbitGl/GraphTrack.h
+++ b/OrbitGl/GraphTrack.h
@@ -15,10 +15,10 @@ class TimeGraph;
 class GraphTrack : public Track {
  public:
   explicit GraphTrack(TimeGraph* time_graph);
-  Type GetType() const override { return kGraphTrack; }
+  [[nodiscard]] Type GetType() const override { return kGraphTrack; }
   void Draw(GlCanvas* canvas, PickingMode /*picking_mode*/) override;
   void OnDrag(int x, int y) override;
-  float GetHeight() const override;
+  [[nodiscard]] float GetHeight() const override;
 
  protected:
   std::map<uint64_t, double> values_;

--- a/OrbitGl/SchedulerTrack.h
+++ b/OrbitGl/SchedulerTrack.h
@@ -5,25 +5,29 @@
 #ifndef ORBIT_GL_SCHEDULER_TRACK_H_
 #define ORBIT_GL_SCHEDULER_TRACK_H_
 
-#include "ThreadTrack.h"
+#include "TimerTrack.h"
+#include "capture_data.pb.h"
 
-class SchedulerTrack : public ThreadTrack {
+class SchedulerTrack : public TimerTrack {
  public:
   explicit SchedulerTrack(TimeGraph* time_graph);
   ~SchedulerTrack() override = default;
 
-  std::string GetTooltip() const override;
+  [[nodiscard]] Type GetType() const override { return kSchedulerTrack; }
+  [[nodiscard]] std::string GetTooltip() const override;
 
-  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
-                        PickingMode /*picking_mode*/) override;
-  Type GetType() const override { return kSchedulerTrack; }
-  float GetHeight() const override;
-  bool HasEventTrack() const override { return false; }
-  bool IsCollapsable() const override { return false; }
+  [[nodiscard]] float GetHeight() const override;
+  [[nodiscard]] bool IsCollapsable() const override { return false; }
+
+  void UpdateBoxHeight() override;
+  [[nodiscard]] float GetYFromDepth(uint32_t depth) const override;
 
  protected:
-  float GetYFromDepth(float track_y, uint32_t depth, bool collapsed) override;
-  std::string GetBoxTooltip(PickingID id) const;
+  [[nodiscard]] bool IsTimerActive(
+      const orbit_client_protos::TimerInfo& timer_info) const override;
+  [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
+                      bool is_selected) const override;
+  [[nodiscard]] std::string GetBoxTooltip(PickingID id) const override;
 };
 
 #endif  // ORBIT_GL_SCHEDULER_TRACK_H_

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -4,79 +4,84 @@
 
 #include "ThreadTrack.h"
 
-#include <limits>
-
-#include "Capture.h"
-#include "EventTrack.h"
 #include "FunctionUtils.h"
 #include "GlCanvas.h"
 #include "Profiling.h"
 #include "TextBox.h"
 #include "TimeGraph.h"
-#include "absl/flags/flag.h"
-#include "absl/strings/str_format.h"
-
-// TODO: Remove this flag once we have a way to toggle the display return values
-ABSL_FLAG(bool, show_return_values, false, "Show return values on time slices");
 
 using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::TimerInfo;
 
 //-----------------------------------------------------------------------------
 ThreadTrack::ThreadTrack(TimeGraph* time_graph, int32_t thread_id)
-    : Track(time_graph) {
-  text_renderer_ = time_graph->GetTextRenderer();
-  thread_id_ = thread_id;
-
-  num_timers_ = 0;
-  min_time_ = std::numeric_limits<TickType>::max();
-  max_time_ = std::numeric_limits<TickType>::min();
-
+    : TimerTrack(time_graph), thread_id_(thread_id) {
   event_track_ = std::make_shared<EventTrack>(time_graph);
   event_track_->SetThreadId(thread_id);
 }
 
 //-----------------------------------------------------------------------------
-void ThreadTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
-  float track_height = GetHeight();
-  float track_width = canvas->GetWorldWidth();
-
-  SetPos(canvas->GetWorldTopLeftX(), m_Pos[1]);
-  SetSize(track_width, track_height);
-
-  Track::Draw(canvas, picking_mode);
-
-  // Event track
-  if (HasEventTrack()) {
-    float event_track_height = time_graph_->GetLayout().GetEventTrackHeight();
-    event_track_->SetPos(m_Pos[0], m_Pos[1]);
-    event_track_->SetSize(track_width, event_track_height);
-    event_track_->Draw(canvas, picking_mode);
+const TextBox* ThreadTrack::GetLeft(TextBox* text_box) const {
+  const TimerInfo& timer_info = text_box->GetTimerInfo();
+  if (timer_info.thread_id() == thread_id_) {
+    std::shared_ptr<TimerChain> timers = GetTimers(timer_info.depth());
+    if (timers) return timers->GetElementBefore(text_box);
   }
+  return nullptr;
 }
 
 //-----------------------------------------------------------------------------
-std::string ThreadTrack::GetExtraInfo(const TimerInfo& timer_info) {
-  std::string info;
-  static bool show_return_value = absl::GetFlag(FLAGS_show_return_values);
-  if (show_return_value && timer_info.type() == TimerInfo::kNone) {
-    info = absl::StrFormat("[%lu]", timer_info.user_data_key());
+const TextBox* ThreadTrack::GetRight(TextBox* text_box) const {
+  const TimerInfo& timer_info = text_box->GetTimerInfo();
+  if (timer_info.thread_id() == thread_id_) {
+    std::shared_ptr<TimerChain> timers = GetTimers(timer_info.depth());
+    if (timers) return timers->GetElementAfter(text_box);
   }
-  return info;
+  return nullptr;
 }
 
 //-----------------------------------------------------------------------------
-inline Color GetTimerColor(const TimerInfo& timer_info, TimeGraph* time_graph,
-                           bool is_selected, bool inactive) {
+std::string ThreadTrack::GetBoxTooltip(PickingID id) const {
+  TextBox* text_box = time_graph_->GetBatcher().GetTextBox(id);
+  if (!text_box ||
+      text_box->GetTimerInfo().type() == TimerInfo::kCoreActivity) {
+    return "";
+  }
+
+  FunctionInfo* func = Capture::GSelectedFunctionsMap[text_box->GetTimerInfo()
+                                                          .function_address()];
+  if (!func) {
+    return text_box->GetText();
+  }
+
+  return absl::StrFormat(
+    "<b>%s</b><br/>"
+    "<i>Timing measured through dynamic instrumentation</i>"
+    "<br/><br/>"
+    "<b>Module:</b> %s<br/>"
+    "<b>Time:</b> %s",
+    FunctionUtils::GetDisplayName(*func),
+    FunctionUtils::GetLoadedModuleName(*func),
+    GetPrettyTime(TicksToDuration(text_box->GetTimerInfo().start(),
+                                  text_box->GetTimerInfo().end()))
+  );
+}
+
+bool ThreadTrack::IsTimerActive(const TimerInfo& timer_info) const {
+  return Capture::GVisibleFunctionsMap.find(timer_info.function_address()) !=
+         Capture::GVisibleFunctionsMap.end();
+}
+
+Color ThreadTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected) const {
   const Color kInactiveColor(100, 100, 100, 255);
   const Color kSelectionColor(0, 128, 255, 255);
   if (is_selected) {
     return kSelectionColor;
-  } else if (inactive) {
+  } else if (!IsTimerActive(timer_info)) {
     return kInactiveColor;
   }
 
-  Color color = time_graph->GetThreadColor(timer_info.thread_id());
+  Color color = time_graph_->GetThreadColor(timer_info.thread_id());
 
   constexpr uint8_t kOddAlpha = 210;
   if (!(timer_info.depth() & 0x1)) {
@@ -86,21 +91,39 @@ inline Color GetTimerColor(const TimerInfo& timer_info, TimeGraph* time_graph,
   return color;
 }
 
-//-----------------------------------------------------------------------------
-float ThreadTrack::GetYFromDepth(float track_y, uint32_t depth,
-                                 bool collapsed) {
-  const TimeGraphLayout& layout = time_graph_->GetLayout();
-  float box_height = layout.GetTextBoxHeight();
-  if (collapsed && depth_ > 0) {
-    box_height /= static_cast<float>(depth_);
+void ThreadTrack::UpdateBoxHeight() {
+  box_height_ = time_graph_->GetLayout().GetTextBoxHeight();
+  if (collapse_toggle_.IsCollapsed() && depth_ > 0) {
+    box_height_ /= static_cast<float>(depth_);
   }
-
-  return track_y - layout.GetEventTrackHeight() -
-         layout.GetSpaceBetweenTracksAndThread() - box_height * (depth + 1);
 }
 
-float ThreadTrack::GetYFromDepth(uint32_t depth) {
-  return GetYFromDepth(m_Pos[1], depth, collapse_toggle_.IsCollapsed());
+bool ThreadTrack::IsEmpty() const {
+  return (GetNumTimers() == 0) && (event_track_->IsEmpty());
+}
+
+//-----------------------------------------------------------------------------
+void ThreadTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
+  TimerTrack::Draw(canvas, picking_mode);
+
+  float event_track_height = time_graph_->GetLayout().GetEventTrackHeight();
+  event_track_->SetPos(m_Pos[0], m_Pos[1]);
+  event_track_->SetSize(canvas->GetWorldWidth(), event_track_height);
+  event_track_->Draw(canvas, picking_mode);
+}
+
+//-----------------------------------------------------------------------------
+void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
+                                   PickingMode picking_mode) {
+  event_track_->SetPos(m_Pos[0], m_Pos[1]);
+  event_track_->UpdatePrimitives(min_tick, max_tick, picking_mode);
+  TimerTrack::UpdatePrimitives(min_tick, max_tick, picking_mode);
+}
+
+//-----------------------------------------------------------------------------
+void ThreadTrack::SetEventTrackColor(Color color) {
+  ScopeLock lock(mutex_);
+  event_track_->SetColor(color);
 }
 
 //-----------------------------------------------------------------------------
@@ -148,287 +171,7 @@ void ThreadTrack::SetTimesliceText(const TimerInfo& timer_info,
       kTextWhite, text_box->GetElapsedTimeTextLength(), max_size);
 }
 
-//-----------------------------------------------------------------------------
-void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode) {
-  event_track_->SetPos(m_Pos[0], m_Pos[1]);
-  event_track_->UpdatePrimitives(min_tick, max_tick, picking_mode);
-
-  Batcher* batcher = &time_graph_->GetBatcher();
-  GlCanvas* canvas = time_graph_->GetCanvas();
-  const TimeGraphLayout& layout = time_graph_->GetLayout();
-  const TextBox& scene_box = canvas->GetSceneBox();
-
-  float min_x = scene_box.GetPosX();
-  float world_start_x = canvas->GetWorldTopLeftX();
-  float world_width = canvas->GetWorldWidth();
-  double inv_time_window = 1.0 / time_graph_->GetTimeWindowUs();
-  bool is_collapsed = collapse_toggle_.IsCollapsed();
-  float box_height = layout.GetTextBoxHeight();
-  if (is_collapsed && depth_ > 0) {
-    box_height /= static_cast<float>(depth_);
-  }
-
-  std::vector<std::shared_ptr<TimerChain>> chains_by_depth = GetTimers();
-
-  // We minimize overdraw when drawing lines for small events by discarding
-  // events that would just draw over an already drawn line. When zoomed in
-  // enough that all events are drawn as boxes, this has no effect. When zoomed
-  // out, many events will be discarded quickly.
-  uint64_t min_ignore = std::numeric_limits<uint64_t>::max();
-  uint64_t max_ignore = std::numeric_limits<uint64_t>::min();
-
-  uint64_t pixel_delta_in_ticks = static_cast<uint64_t>(MicrosecondsToTicks(
-                                      time_graph_->GetTimeWindowUs())) /
-                                  canvas->getWidth();
-  uint64_t min_timegraph_tick =
-      time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
-
-  for (auto& chain : chains_by_depth) {
-    if (!chain) continue;
-    for (TimerChainIterator it = chain->begin(); it != chain->end(); ++it) {
-      TimerBlock& block = *it;
-      if (!block.Intersects(min_tick, max_tick)) continue;
-
-      // We have to reset this when we go to the next depth, as otherwise we
-      // would miss drawing events that should be drawn.
-      min_ignore = std::numeric_limits<uint64_t>::max();
-      max_ignore = std::numeric_limits<uint64_t>::min();
-
-      for (size_t k = 0; k < block.size(); ++k) {
-        TextBox& text_box = block[k];
-        const TimerInfo& timer_info = text_box.GetTimerInfo();
-        if (min_tick > timer_info.end() || max_tick < timer_info.start())
-          continue;
-        if (timer_info.start() >= min_ignore && timer_info.end() <= max_ignore)
-          continue;
-
-        UpdateDepth(timer_info.depth() + 1);
-        double start_us = time_graph_->GetUsFromTick(timer_info.start());
-        double end_us = time_graph_->GetUsFromTick(timer_info.end());
-        double elapsed_us = end_us - start_us;
-        double normalized_start = start_us * inv_time_window;
-        double normalized_length = elapsed_us * inv_time_window;
-        float world_timer_width =
-            static_cast<float>(normalized_length * world_width);
-        float world_timer_x =
-            static_cast<float>(world_start_x + normalized_start * world_width);
-        float world_timer_y = GetYFromDepth(timer_info.depth());
-
-        bool is_visible_width = normalized_length * canvas->getWidth() > 1;
-        bool is_selected = &text_box == Capture::GSelectedTextBox;
-        bool is_inactive =
-            !Capture::GVisibleFunctionsMap.empty() &&
-            Capture::GVisibleFunctionsMap[timer_info.function_address()] ==
-                nullptr;
-
-        Vec2 pos(world_timer_x, world_timer_y);
-        Vec2 size(world_timer_width, box_height);
-        float z = GlCanvas::Z_VALUE_BOX_ACTIVE;
-        Color color =
-            GetTimerColor(timer_info, time_graph_, is_selected, is_inactive);
-        text_box.SetPos(pos);
-        text_box.SetSize(size);
-
-        auto user_data = std::make_unique<PickingUserData>(
-          &text_box, [&](PickingID id) { return this->GetBoxTooltip(id); });
-
-        if (is_visible_width) {
-          if (!is_collapsed) {
-            SetTimesliceText(timer_info, elapsed_us, min_x, &text_box);
-          }
-          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX, std::move(user_data));
-        } else {
-          auto type = PickingID::LINE;
-          batcher->AddVerticalLine(pos, size[1], z, color, type, std::move(user_data));
-          // For lines, we can ignore the entire pixel into which this event
-          // falls. We align this precisely on the pixel x-coordinate of the
-          // current line being drawn (in ticks). If pixel_delta_in_ticks is
-          // zero, we need to avoid dividing by zero, but we also wouldn't
-          // gain anything here.
-          if (pixel_delta_in_ticks != 0) {
-            min_ignore = min_timegraph_tick +
-                         ((timer_info.start() - min_timegraph_tick) /
-                          pixel_delta_in_ticks) *
-                             pixel_delta_in_ticks;
-            max_ignore = min_ignore + pixel_delta_in_ticks;
-          }
-        }
-      }
-    }
-  }
-}
-
-//-----------------------------------------------------------------------------
-void ThreadTrack::OnDrag(int x, int y) { Track::OnDrag(x, y); }
-
-//-----------------------------------------------------------------------------
-void ThreadTrack::OnTimer(const TimerInfo& timer_info) {
-  if (timer_info.type() != TimerInfo::kCoreActivity) {
-    UpdateDepth(timer_info.depth() + 1);
-  }
-
-  TextBox text_box(Vec2(0, 0), Vec2(0, 0), "", Color(255, 0, 0, 255));
-  text_box.SetTimerInfo(timer_info);
-
-  std::shared_ptr<TimerChain> timer_chain = timers_[timer_info.depth()];
-  if (timer_chain == nullptr) {
-    timer_chain = std::make_shared<TimerChain>();
-    timers_[timer_info.depth()] = timer_chain;
-  }
-  timer_chain->push_back(text_box);
-  ++num_timers_;
-  if (timer_info.start() < min_time_) min_time_ = timer_info.start();
-  if (timer_info.end() > max_time_) max_time_ = timer_info.end();
-}
-
 std::string ThreadTrack::GetTooltip() const {
-  return "Shows collected samples and timings from dynamically instrumented functions";
-}
-
-//-----------------------------------------------------------------------------
-float ThreadTrack::GetHeight() const {
-  TimeGraphLayout& layout = time_graph_->GetLayout();
-  bool is_collapsed = collapse_toggle_.IsCollapsed();
-  uint32_t collapsed_depth = (GetNumTimers() == 0) ? 0 : 1;
-  uint32_t depth = is_collapsed ? collapsed_depth : GetDepth();
-  return layout.GetTextBoxHeight() * depth +
-         (depth > 0 ? layout.GetSpaceBetweenTracksAndThread() : 0) +
-         layout.GetEventTrackHeight() + layout.GetTrackBottomMargin();
-}
-
-//-----------------------------------------------------------------------------
-std::vector<std::shared_ptr<TimerChain>> ThreadTrack::GetTimers() {
-  std::vector<std::shared_ptr<TimerChain>> timers;
-  ScopeLock lock(mutex_);
-  for (auto& pair : timers_) {
-    timers.push_back(pair.second);
-  }
-  return timers;
-}
-
-//-----------------------------------------------------------------------------
-const TextBox* ThreadTrack::GetFirstAfterTime(TickType time,
-                                              uint32_t depth) const {
-  std::shared_ptr<TimerChain> chain = GetTimers(depth);
-  if (chain == nullptr) return nullptr;
-
-  // TODO: do better than linear search...
-  for (TimerChainIterator it = chain->begin(); it != chain->end(); ++it) {
-    for (size_t k = 0; k < it->size(); ++k) {
-      const TextBox& text_box = (*it)[k];
-      if (text_box.GetTimerInfo().start() > time) {
-        return &text_box;
-      }
-    }
-  }
-  return nullptr;
-}
-
-//-----------------------------------------------------------------------------
-const TextBox* ThreadTrack::GetFirstBeforeTime(TickType time,
-                                               uint32_t depth) const {
-  std::shared_ptr<TimerChain> chain = GetTimers(depth);
-  if (chain == nullptr) return nullptr;
-
-  const TextBox* text_box = nullptr;
-
-  // TODO: do better than linear search...
-  for (TimerChainIterator it = chain->begin(); it != chain->end(); ++it) {
-    for (size_t k = 0; k < it->size(); ++k) {
-      const TextBox& box = (*it)[k];
-      if (box.GetTimerInfo().start() > time) {
-        return text_box;
-      }
-      text_box = &box;
-    }
-  }
-
-  return nullptr;
-}
-
-//-----------------------------------------------------------------------------
-std::shared_ptr<TimerChain> ThreadTrack::GetTimers(uint32_t depth) const {
-  ScopeLock lock(mutex_);
-  auto it = timers_.find(depth);
-  if (it != timers_.end()) return it->second;
-  return nullptr;
-}
-
-//-----------------------------------------------------------------------------
-const TextBox* ThreadTrack::GetLeft(TextBox* text_box) const {
-  const TimerInfo& timer_info = text_box->GetTimerInfo();
-  if (timer_info.thread_id() == thread_id_) {
-    std::shared_ptr<TimerChain> timers = GetTimers(timer_info.depth());
-    if (timers) return timers->GetElementBefore(text_box);
-  }
-  return nullptr;
-}
-
-//-----------------------------------------------------------------------------
-const TextBox* ThreadTrack::GetRight(TextBox* text_box) const {
-  const TimerInfo& timer_info = text_box->GetTimerInfo();
-  if (timer_info.thread_id() == thread_id_) {
-    std::shared_ptr<TimerChain> timers = GetTimers(timer_info.depth());
-    if (timers) return timers->GetElementAfter(text_box);
-  }
-  return nullptr;
-}
-
-//-----------------------------------------------------------------------------
-const TextBox* ThreadTrack::GetUp(TextBox* text_box) const {
-  const TimerInfo& timer_info = text_box->GetTimerInfo();
-  return GetFirstBeforeTime(timer_info.start(), timer_info.depth() - 1);
-}
-
-//-----------------------------------------------------------------------------
-const TextBox* ThreadTrack::GetDown(TextBox* text_box) const {
-  const TimerInfo& timer_info = text_box->GetTimerInfo();
-  return GetFirstAfterTime(timer_info.start(), timer_info.depth() + 1);
-}
-
-//-----------------------------------------------------------------------------
-std::vector<std::shared_ptr<TimerChain>> ThreadTrack::GetAllChains() {
-  std::vector<std::shared_ptr<TimerChain>> chains;
-  for (const auto& pair : timers_) {
-    chains.push_back(pair.second);
-  }
-  return chains;
-}
-
-//-----------------------------------------------------------------------------
-void ThreadTrack::SetEventTrackColor(Color color) {
-  ScopeLock lock(mutex_);
-  event_track_->SetColor(color);
-}
-
-//-----------------------------------------------------------------------------
-bool ThreadTrack::IsEmpty() const {
-  return (GetNumTimers() == 0) && event_track_->IsEmpty();
-}
-
-//-----------------------------------------------------------------------------
-std::string ThreadTrack::GetBoxTooltip(PickingID id) const {
-  TextBox* text_box = time_graph_->GetBatcher().GetTextBox(id);
-  if (!text_box ||
-      text_box->GetTimerInfo().type() == TimerInfo::kCoreActivity) {
-    return "";
-  }
-
-  FunctionInfo* func = Capture::GSelectedFunctionsMap[text_box->GetTimerInfo()
-                                                          .function_address()];
-  if (!func) {
-    return text_box->GetText();
-  }
-
-  return absl::StrFormat(
-    "<b>%s</b><br/>"
-    "<i>Timing measured through dynamic instrumentation</i>"
-    "<br/><br/>"
-    "<b>Module:</b> %s<br/>"
-    "<b>Time:</b> %s",
-    FunctionUtils::GetDisplayName(*func),
-    FunctionUtils::GetLoadedModuleName(*func),
-    GetPrettyTime(TicksToDuration(text_box->GetTimerInfo().start(),
-                                  text_box->GetTimerInfo().end()))
-  );
+  return "Shows collected samples and timings from dynamically instrumented "
+         "functions";
 }

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -8,82 +8,42 @@
 #include <map>
 #include <memory>
 
-#include "BlockChain.h"
-#include "CallstackTypes.h"
-#include "EventTrack.h"
-#include "TextBox.h"
-#include "Threading.h"
-#include "TimerChain.h"
-#include "Track.h"
+#include "TimerTrack.h"
 #include "capture_data.pb.h"
 
-class TextRenderer;
-
-class ThreadTrack : public Track {
+class ThreadTrack : public TimerTrack {
  public:
   ThreadTrack(TimeGraph* time_graph, int32_t thread_id);
-  ~ThreadTrack() override = default;
 
-  // Pickable
+  [[nodiscard]] int32_t GetThreadId() const { return thread_id_; }
+
+  [[nodiscard]] Type GetType() const override { return kThreadTrack; }
+  [[nodiscard]] std::string GetTooltip() const override;
+
+  [[nodiscard]] const TextBox* GetLeft(TextBox* textbox) const override;
+  [[nodiscard]] const TextBox* GetRight(TextBox* textbox) const override;
+
   void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
-  void OnDrag(int x, int y) override;
-  void OnTimer(const orbit_client_protos::TimerInfo& timer_info);
-  std::string GetTooltip() const override;
 
-  // Track
+  void UpdateBoxHeight() override;
+  void SetEventTrackColor(Color color);
+  [[nodiscard]] bool IsEmpty() const override;
+
   void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode) override;
-  Type GetType() const override { return kThreadTrack; }
-  float GetHeight() const override;
-
-  std::vector<std::shared_ptr<TimerChain>> GetTimers() override;
-  uint32_t GetDepth() const { return depth_; }
-  std::string GetExtraInfo(const orbit_client_protos::TimerInfo& timer_info);
-
-  Color GetColor() const;
-  static Color GetColor(ThreadID a_TID);
-  uint32_t GetNumTimers() const { return num_timers_; }
-  TickType GetMinTime() const { return min_time_; }
-  TickType GetMaxTime() const { return max_time_; }
-
-  const TextBox* GetFirstAfterTime(TickType time, uint32_t depth) const;
-  const TextBox* GetFirstBeforeTime(TickType time, uint32_t depth) const;
-
-  const TextBox* GetLeft(TextBox* textbox) const;
-  const TextBox* GetRight(TextBox* textbox) const;
-  const TextBox* GetUp(TextBox* textbox) const;
-  const TextBox* GetDown(TextBox* textbox) const;
-
-  std::vector<std::shared_ptr<TimerChain>> GetAllChains() override;
-
-  void SetEventTrackColor(Color color);
-  bool IsEmpty() const;
-  virtual bool HasEventTrack() const { return true; }
-
-  int32_t GetThreadId() const { return thread_id_; }
-  bool IsCollapsable() const override { return depth_ > 1; }
-  float GetYFromDepth(uint32_t depth);
 
  protected:
-  void UpdateDepth(uint32_t depth) {
-    if (depth > depth_) depth_ = depth;
-  }
-  virtual float GetYFromDepth(float track_y, uint32_t depth, bool collapsed);
-  std::shared_ptr<TimerChain> GetTimers(uint32_t depth) const;
+  [[nodiscard]] bool IsTimerActive(
+      const orbit_client_protos::TimerInfo& timer) const override;
+  [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer,
+                                    bool is_selected) const override;
+  void SetTimesliceText(const orbit_client_protos::TimerInfo& timer,
+                        double elapsed_us, float min_x,
+                        TextBox* text_box) override;
+  [[nodiscard]] std::string GetBoxTooltip(PickingID id) const override;
 
- private:
-  void SetTimesliceText(const orbit_client_protos::TimerInfo& timer_info,
-                        double elapsed_us, float min_x, TextBox* text_box);
-
- protected:
-  TextRenderer* text_renderer_ = nullptr;
   std::shared_ptr<EventTrack> event_track_;
-  uint32_t depth_ = 0;
-  ThreadID thread_id_;
-  mutable Mutex mutex_;
-  std::map<int, std::shared_ptr<TimerChain>> timers_;
-
-  std::string GetBoxTooltip(PickingID id) const;
+  int32_t thread_id_;
 };
 
 #endif  // ORBIT_GL_THREAD_TRACK_H_

--- a/OrbitGl/TimerTrack.cpp
+++ b/OrbitGl/TimerTrack.cpp
@@ -1,0 +1,288 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "TimerTrack.h"
+
+#include <limits>
+
+#include "Capture.h"
+#include "EventTrack.h"
+#include "FunctionUtils.h"
+#include "GlCanvas.h"
+#include "TextBox.h"
+#include "TimeGraph.h"
+#include "absl/flags/flag.h"
+#include "absl/strings/str_format.h"
+
+using orbit_client_protos::FunctionInfo;
+using orbit_client_protos::TimerInfo;
+
+// TODO: Remove this flag once we have a way to toggle the display return values
+ABSL_FLAG(bool, show_return_values, false, "Show return values on time slices");
+
+//-----------------------------------------------------------------------------
+TimerTrack::TimerTrack(TimeGraph* time_graph) : Track(time_graph) {
+  text_renderer_ = time_graph->GetTextRenderer();
+
+  num_timers_ = 0;
+  min_time_ = std::numeric_limits<TickType>::max();
+  max_time_ = std::numeric_limits<TickType>::min();
+}
+
+//-----------------------------------------------------------------------------
+void TimerTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
+  float track_height = GetHeight();
+  float track_width = canvas->GetWorldWidth();
+
+  SetPos(canvas->GetWorldTopLeftX(), m_Pos[1]);
+  SetSize(track_width, track_height);
+
+  Track::Draw(canvas, picking_mode);
+}
+
+//-----------------------------------------------------------------------------
+std::string TimerTrack::GetExtraInfo(const TimerInfo& timer_info) {
+  std::string info;
+  static bool show_return_value = absl::GetFlag(FLAGS_show_return_values);
+  if (show_return_value && timer_info.type() == TimerInfo::kNone) {
+    info = absl::StrFormat("[%lu]", timer_info.user_data_key());
+  }
+  return info;
+}
+
+float TimerTrack::GetYFromDepth(uint32_t depth) const {
+  const TimeGraphLayout& layout = time_graph_->GetLayout();
+  float box_height = layout.GetTextBoxHeight();
+  if (collapse_toggle_.IsCollapsed() && depth_ > 0) {
+    box_height /= static_cast<float>(depth_);
+  }
+
+  return m_Pos[1] - layout.GetEventTrackHeight() -
+         layout.GetSpaceBetweenTracksAndThread() - box_height * (depth + 1);
+}
+
+void TimerTrack::UpdateBoxHeight() {
+  box_height_ = time_graph_->GetLayout().GetTextBoxHeight();
+}
+
+//-----------------------------------------------------------------------------
+void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode /*picking_mode*/) {
+  UpdateBoxHeight();
+
+  Batcher* batcher = &time_graph_->GetBatcher();
+  GlCanvas* canvas = time_graph_->GetCanvas();
+  const TextBox& scene_box = canvas->GetSceneBox();
+
+  float min_x = scene_box.GetPosX();
+  float world_start_x = canvas->GetWorldTopLeftX();
+  float world_width = canvas->GetWorldWidth();
+  double inv_time_window = 1.0 / time_graph_->GetTimeWindowUs();
+  bool is_collapsed = collapse_toggle_.IsCollapsed();
+
+  std::vector<std::shared_ptr<TimerChain>> chains_by_depth = GetTimers();
+
+  // We minimize overdraw when drawing lines for small events by discarding
+  // events that would just draw over an already drawn line. When zoomed in
+  // enough that all events are drawn as boxes, this has no effect. When zoomed
+  // out, many events will be discarded quickly.
+  uint64_t min_ignore = std::numeric_limits<uint64_t>::max();
+  uint64_t max_ignore = std::numeric_limits<uint64_t>::min();
+
+  uint64_t pixel_delta_in_ticks = static_cast<uint64_t>(MicrosecondsToTicks(
+                                      time_graph_->GetTimeWindowUs())) /
+                                  canvas->getWidth();
+  uint64_t min_timegraph_tick =
+      time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
+
+  for (auto& chain : chains_by_depth) {
+    if (!chain) continue;
+    for (TimerChainIterator it = chain->begin(); it != chain->end(); ++it) {
+      TimerBlock& block = *it;
+      if (!block.Intersects(min_tick, max_tick)) continue;
+
+      // We have to reset this when we go to the next depth, as otherwise we
+      // would miss drawing events that should be drawn.
+      min_ignore = std::numeric_limits<uint64_t>::max();
+      max_ignore = std::numeric_limits<uint64_t>::min();
+
+      for (size_t k = 0; k < block.size(); ++k) {
+        TextBox& text_box = block[k];
+        const TimerInfo& timer_info = text_box.GetTimerInfo();
+        if (min_tick > timer_info.end() || max_tick < timer_info.start()) continue;
+        if (timer_info.start() >= min_ignore && timer_info.end() <= max_ignore) continue;
+        if (!TimerFilter(timer_info)) continue;
+
+        UpdateDepth(timer_info.depth() + 1);
+        double start_us = time_graph_->GetUsFromTick(timer_info.start());
+        double end_us = time_graph_->GetUsFromTick(timer_info.end());
+        double elapsed_us = end_us - start_us;
+        double normalized_start = start_us * inv_time_window;
+        double normalized_length = elapsed_us * inv_time_window;
+        float world_timer_width =
+            static_cast<float>(normalized_length * world_width);
+        float world_timer_x =
+            static_cast<float>(world_start_x + normalized_start * world_width);
+        float world_timer_y = GetYFromDepth(timer_info.depth());
+
+        bool is_visible_width = normalized_length * canvas->getWidth() > 1;
+        bool is_selected = &text_box == Capture::GSelectedTextBox;
+
+        Vec2 pos(world_timer_x, world_timer_y);
+        Vec2 size(world_timer_width, box_height_);
+        float z = GlCanvas::Z_VALUE_BOX_ACTIVE;
+        Color color = GetTimerColor(timer_info, is_selected);
+        text_box.SetPos(pos);
+        text_box.SetSize(size);
+
+        auto user_data = std::make_unique<PickingUserData>(
+            &text_box, [&](PickingID id) { return this->GetBoxTooltip(id); });
+
+        if (is_visible_width) {
+          if (!is_collapsed) {
+            SetTimesliceText(timer_info, elapsed_us, min_x, &text_box);
+          }
+          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX,
+                                std::move(user_data));
+        } else {
+          auto type = PickingID::LINE;
+          batcher->AddVerticalLine(pos, size[1], z, color, type,
+                                   std::move(user_data));
+          // For lines, we can ignore the entire pixel into which this event
+          // falls. We align this precisely on the pixel x-coordinate of the
+          // current line being drawn (in ticks). If pixel_delta_in_ticks is
+          // zero, we need to avoid dividing by zero, but we also wouldn't
+          // gain anything here.
+          if (pixel_delta_in_ticks != 0) {
+            min_ignore =
+                min_timegraph_tick +
+                ((timer_info.start() - min_timegraph_tick) / pixel_delta_in_ticks) *
+                    pixel_delta_in_ticks;
+            max_ignore = min_ignore + pixel_delta_in_ticks;
+          }
+        }
+      }
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
+void TimerTrack::OnTimer(const TimerInfo& timer_info) {
+  if (timer_info.type() != TimerInfo::kCoreActivity) {
+    UpdateDepth(timer_info.depth() + 1);
+  }
+
+  TextBox text_box(Vec2(0, 0), Vec2(0, 0), "", Color(255, 0, 0, 255));
+  text_box.SetTimerInfo(timer_info);
+
+  std::shared_ptr<TimerChain> timer_chain = timers_[timer_info.depth()];
+  if (timer_chain == nullptr) {
+    timer_chain = std::make_shared<TimerChain>();
+    timers_[timer_info.depth()] = timer_chain;
+  }
+  timer_chain->push_back(text_box);
+  ++num_timers_;
+  if (timer_info.start() < min_time_) min_time_ = timer_info.start();
+  if (timer_info.end() > max_time_) max_time_ = timer_info.end();
+}
+
+std::string TimerTrack::GetTooltip() const {
+  return "Shows collected samples and timings from dynamically instrumented "
+         "functions";
+}
+
+//-----------------------------------------------------------------------------
+float TimerTrack::GetHeight() const {
+  TimeGraphLayout& layout = time_graph_->GetLayout();
+  bool is_collapsed = collapse_toggle_.IsCollapsed();
+  uint32_t collapsed_depth = (GetNumTimers() == 0) ? 0 : 1;
+  uint32_t depth = is_collapsed ? collapsed_depth : GetDepth();
+  return layout.GetTextBoxHeight() * depth +
+         (depth > 0 ? layout.GetSpaceBetweenTracksAndThread() : 0) +
+         layout.GetEventTrackHeight() + layout.GetTrackBottomMargin();
+}
+
+//-----------------------------------------------------------------------------
+std::vector<std::shared_ptr<TimerChain>> TimerTrack::GetTimers() {
+  std::vector<std::shared_ptr<TimerChain>> timers;
+  ScopeLock lock(mutex_);
+  for (auto& pair : timers_) {
+    timers.push_back(pair.second);
+  }
+  return timers;
+}
+
+//-----------------------------------------------------------------------------
+const TextBox* TimerTrack::GetFirstAfterTime(TickType time,
+                                              uint32_t depth) const {
+  std::shared_ptr<TimerChain> chain = GetTimers(depth);
+  if (chain == nullptr) return nullptr;
+
+  // TODO: do better than linear search...
+  for (TimerChainIterator it = chain->begin(); it != chain->end(); ++it) {
+    for (size_t k = 0; k < it->size(); ++k) {
+      const TextBox& text_box = (*it)[k];
+      if (text_box.GetTimerInfo().start() > time) {
+        return &text_box;
+      }
+    }
+  }
+  return nullptr;
+}
+
+//-----------------------------------------------------------------------------
+const TextBox* TimerTrack::GetFirstBeforeTime(TickType time,
+                                               uint32_t depth) const {
+  std::shared_ptr<TimerChain> chain = GetTimers(depth);
+  if (chain == nullptr) return nullptr;
+
+  const TextBox* text_box = nullptr;
+
+  // TODO: do better than linear search...
+  for (TimerChainIterator it = chain->begin(); it != chain->end(); ++it) {
+    for (size_t k = 0; k < it->size(); ++k) {
+      const TextBox& box = (*it)[k];
+      if (box.GetTimerInfo().start() > time) {
+        return text_box;
+      }
+      text_box = &box;
+    }
+  }
+
+  return nullptr;
+}
+
+//-----------------------------------------------------------------------------
+std::shared_ptr<TimerChain> TimerTrack::GetTimers(uint32_t depth) const {
+  ScopeLock lock(mutex_);
+  auto it = timers_.find(depth);
+  if (it != timers_.end()) return it->second;
+  return nullptr;
+}
+
+//-----------------------------------------------------------------------------
+const TextBox* TimerTrack::GetUp(TextBox* text_box) const {
+  const TimerInfo& timer_info = text_box->GetTimerInfo();
+  return GetFirstBeforeTime(timer_info.start(), timer_info.depth() - 1);
+}
+
+//-----------------------------------------------------------------------------
+const TextBox* TimerTrack::GetDown(TextBox* text_box) const {
+  const TimerInfo& timer_info = text_box->GetTimerInfo();
+  return GetFirstAfterTime(timer_info.start(), timer_info.depth() + 1);
+}
+
+//-----------------------------------------------------------------------------
+std::vector<std::shared_ptr<TimerChain>> TimerTrack::GetAllChains() {
+  std::vector<std::shared_ptr<TimerChain>> chains;
+  for (const auto& pair : timers_) {
+    chains.push_back(pair.second);
+  }
+  return chains;
+}
+
+//-----------------------------------------------------------------------------
+bool TimerTrack::IsEmpty() const { return GetNumTimers() == 0; }
+
+//-----------------------------------------------------------------------------
+std::string TimerTrack::GetBoxTooltip(PickingID /*id*/) const { return ""; }

--- a/OrbitGl/TimerTrack.h
+++ b/OrbitGl/TimerTrack.h
@@ -1,0 +1,107 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef TIMER_TRACK_H_
+#define TIMER_TRACK_H_
+
+#include <map>
+#include <memory>
+
+#include "BlockChain.h"
+#include "CallstackTypes.h"
+#include "EventTrack.h"
+#include "TextBox.h"
+#include "Threading.h"
+#include "TimerChain.h"
+#include "Track.h"
+#include "capture_data.pb.h"
+
+class TextRenderer;
+
+class TimerTrack : public Track {
+ public:
+  explicit TimerTrack(TimeGraph* time_graph);
+  ~TimerTrack() override = default;
+
+  // Pickable
+  void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
+  void OnTimer(const orbit_client_protos::TimerInfo& timer_info);
+  [[nodiscard]] std::string GetTooltip() const override;
+
+  // Track
+  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
+                        PickingMode /*picking_mode*/) override;
+  [[nodiscard]] Type GetType() const override { return kTimerTrack; }
+  [[nodiscard]] float GetHeight() const override;
+
+  [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetTimers() override;
+  [[nodiscard]] uint32_t GetDepth() const { return depth_; }
+  [[nodiscard]] std::string GetExtraInfo(
+      const orbit_client_protos::TimerInfo& timer);
+
+  [[nodiscard]] Color GetColor() const;
+  [[nodiscard]] static Color GetColor(ThreadID a_TID);
+  [[nodiscard]] uint32_t GetNumTimers() const { return num_timers_; }
+  [[nodiscard]] TickType GetMinTime() const { return min_time_; }
+  [[nodiscard]] TickType GetMaxTime() const { return max_time_; }
+
+  [[nodiscard]] const TextBox* GetFirstAfterTime(TickType time,
+                                                 uint32_t depth) const;
+  [[nodiscard]] const TextBox* GetFirstBeforeTime(TickType time,
+                                                  uint32_t depth) const;
+
+  // Must be overriden by child class for sensible behavior.
+  [[nodiscard]] virtual const TextBox* GetLeft(TextBox* textbox) const {
+    return textbox;
+  };
+  // Must be overriden by child class for sensible behavior.
+  [[nodiscard]] virtual const TextBox* GetRight(TextBox* textbox) const {
+    return textbox;
+  };
+
+  [[nodiscard]] virtual const TextBox* GetUp(TextBox* textbox) const;
+  [[nodiscard]] virtual const TextBox* GetDown(TextBox* textbox) const;
+
+  [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllChains()
+      override;
+  [[nodiscard]] virtual bool IsEmpty() const;
+
+  [[nodiscard]] bool IsCollapsable() const override { return depth_ > 1; }
+
+  [[nodiscard]] float GetTextBoxHeight() const;
+
+  virtual void UpdateBoxHeight();
+  [[nodiscard]] virtual float GetYFromDepth(uint32_t depth) const;
+
+ protected:
+  [[nodiscard]] virtual bool IsTimerActive(
+      const orbit_client_protos::TimerInfo& /*timer_info*/) const {
+    return true;
+  }
+  [[nodiscard]] virtual Color GetTimerColor(
+      const orbit_client_protos::TimerInfo& timer_info,
+      bool is_selected) const = 0;
+  [[nodiscard]] virtual bool TimerFilter(
+      const orbit_client_protos::TimerInfo& /*timer_info*/) const {
+    return true;
+  }
+
+  void UpdateDepth(uint32_t depth) {
+    if (depth > depth_) depth_ = depth;
+  }
+  [[nodiscard]] std::shared_ptr<TimerChain> GetTimers(uint32_t depth) const;
+
+  virtual void SetTimesliceText(const orbit_client_protos::TimerInfo& /*timer*/,
+                                double /*elapsed_us*/, float /*min_x*/,
+                                TextBox* /*text_box*/) {}
+  TextRenderer* text_renderer_ = nullptr;
+  uint32_t depth_ = 0;
+  mutable Mutex mutex_;
+  std::map<int, std::shared_ptr<TimerChain>> timers_;
+
+  [[nodiscard]] virtual std::string GetBoxTooltip(PickingID /*id*/) const;
+  float box_height_;
+};
+
+#endif  // ORBIT_GL_TIMER_TRACK_H_

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -26,6 +26,7 @@ class TimeGraph;
 class Track : public Pickable {
  public:
   enum Type {
+    kTimerTrack,
     kThreadTrack,
     kEventTrack,
     kGraphTrack,
@@ -39,45 +40,51 @@ class Track : public Pickable {
 
   // Pickable
   void Draw(GlCanvas* a_Canvas, PickingMode a_PickingMode) override;
-  virtual void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode);
+  virtual void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
+                                PickingMode picking_mode);
   void OnPick(int a_X, int a_Y) override;
   void OnRelease() override;
   void OnDrag(int a_X, int a_Y) override;
-  bool Draggable() override { return true; }
-  bool Movable() override { return true; }
+  [[nodiscard]] bool Draggable() override { return true; }
+  [[nodiscard]] bool Movable() override { return true; }
 
-  virtual Type GetType() const = 0;
+  [[nodiscard]] virtual Type GetType() const = 0;
 
-  virtual float GetHeight() const { return 0.f; };
-  bool GetVisible() const { return m_Visible; }
+  [[nodiscard]] virtual float GetHeight() const { return 0.f; };
+  [[nodiscard]] bool GetVisible() const { return m_Visible; }
   void SetVisible(bool value) { m_Visible = value; }
 
-  uint32_t GetNumTimers() const { return num_timers_; }
-  TickType GetMinTime() const { return min_time_; }
-  TickType GetMaxTime() const { return max_time_; }
+  [[nodiscard]] uint32_t GetNumTimers() const { return num_timers_; }
+  [[nodiscard]] TickType GetMinTime() const { return min_time_; }
+  [[nodiscard]] TickType GetMaxTime() const { return max_time_; }
 
-  virtual std::vector<std::shared_ptr<TimerChain>> GetTimers() { return {}; }
-  virtual std::vector<std::shared_ptr<TimerChain>> GetAllChains() { return {}; }
+  [[nodiscard]] virtual std::vector<std::shared_ptr<TimerChain>> GetTimers() {
+    return {};
+  }
+  [[nodiscard]] virtual std::vector<std::shared_ptr<TimerChain>>
+  GetAllChains() {
+    return {};
+  }
 
-  bool IsMoving() const { return m_Moving; }
-  Vec2 GetMoveDelta() const {
+  [[nodiscard]] bool IsMoving() const { return m_Moving; }
+  [[nodiscard]] Vec2 GetMoveDelta() const {
     return m_Moving ? m_MousePos[1] - m_MousePos[0] : Vec2(0, 0);
   }
   void SetName(const std::string& name) { name_ = name; }
-  const std::string& GetName() const { return name_; }
+  [[nodiscard]] const std::string& GetName() const { return name_; }
   void SetLabel(const std::string& label) { label_ = label; }
-  const std::string& GetLabel() const { return label_; }
+  [[nodiscard]] const std::string& GetLabel() const { return label_; }
 
   void SetTimeGraph(TimeGraph* timegraph) { time_graph_ = timegraph; }
   void SetPos(float a_X, float a_Y);
   void SetY(float y);
-  Vec2 GetPos() const { return m_Pos; }
+  [[nodiscard]] Vec2 GetPos() const { return m_Pos; }
   void SetSize(float a_SizeX, float a_SizeY);
   void SetColor(Color a_Color) { m_Color = a_Color; }
 
   void AddChild(std::shared_ptr<Track> track) { children_.emplace_back(track); }
   virtual void OnCollapseToggle(TriangleToggle::State state);
-  virtual bool IsCollapsable() const { return false; }
+  [[nodiscard]] virtual bool IsCollapsable() const { return false; }
 
  protected:
   GlCanvas* m_Canvas;


### PR DESCRIPTION
This is a refactor for all track classes that are using timers (Timer class) as their main primitive to display. Distinct behavior between the classes is defined using virtual functions. Performance difference is neligible: Measurements for UpdatePrimitives ranged from 23-39ms before the change to 10-32ms (due to how we filter timers), so potentially the new code is actually faster than the previous code, though precise measurements are difficult to do.

After this refactor, there is now a single implementation of UpdatePrimitives for timer based tracks instead of three (scheduler, thread, GPU).

