### PR TITLE
Always load symbols from the local file

### DIFF
--- a/OrbitClientServices/include/OrbitClientServices/ProcessManager.h
+++ b/OrbitClientServices/include/OrbitClientServices/ProcessManager.h
@@ -51,9 +51,8 @@ class ProcessManager {
                                                         uint64_t address,
                                                         uint64_t size) = 0;
 
-  // Get symbols for a module
-  virtual ErrorMessageOr<ModuleSymbols> LoadSymbols(
-      const std::string& module_path) const = 0;
+  virtual ErrorMessageOr<std::string> FindDebugInfoFile(
+      const std::string& module_path, const std::string& build_id) = 0;
 
   // Note that this method waits for the worker thread to stop, which could
   // take up to refresh_timeout.

--- a/OrbitCore/SymbolHelper.cpp
+++ b/OrbitCore/SymbolHelper.cpp
@@ -57,14 +57,16 @@ std::vector<std::string> ReadSymbolsFile() {
   return directories;
 }
 
-ErrorMessageOr<ModuleSymbols> FindSymbols(
-    const std::string& module_path, const std::string& build_id,
-    const std::vector<std::string>& search_directories) {
+ErrorMessageOr<std::string> FindSymbolsFile(
+    const std::string& module_path,
+    const std::vector<std::string>& search_paths, const std::string& build_id) {
   std::string filename = Path::GetFileName(module_path);
   std::string filename_without_extension = Path::StripExtension(filename);
 
   std::vector<std::string> search_file_paths;
-  for (const auto& directory : search_directories) {
+  search_file_paths.push_back(module_path);
+
+  for (const auto& directory : search_paths) {
     search_file_paths.emplace_back(
         Path::JoinPath({directory, filename_without_extension + ".debug"}));
     search_file_paths.emplace_back(
@@ -80,15 +82,47 @@ ErrorMessageOr<ModuleSymbols> FindSymbols(
         ElfFile::Create(symbols_file_path);
     if (!symbols_file) continue;
     if (!symbols_file.value()->HasSymtab()) continue;
+
+    // don't check build_id of module_path itself has symbols
+    // and requested build_id is empty.
+    if (build_id.empty() && symbols_file_path == module_path) {
+      return symbols_file_path;
+    }
+
+    // Otherwise check that build_id is not empty and correct.
+    if (symbols_file.value()->GetBuildId().empty()) continue;
     if (symbols_file.value()->GetBuildId() != build_id) continue;
 
-    LOG("Loading symbols for module \"%s\" from \"%s\"", module_path,
+    LOG("Found debug info for module \"%s\" -> \"%s\"", module_path,
         symbols_file_path);
-    return symbols_file.value()->LoadSymbols();
+    return symbols_file_path;
   }
 
-  return ErrorMessage(
-      absl::StrFormat("Could not find symbols for module \"%s\"", module_path));
+  return ErrorMessage(absl::StrFormat(
+      "Could not find a file with debug symbols for module \"%s\"",
+      module_path));
+}
+
+ErrorMessageOr<ModuleSymbols> FindSymbols(
+    const std::string& module_path, const std::string& build_id,
+    const std::vector<std::string>& search_paths) {
+  ErrorMessageOr<std::string> debug_info_file_path =
+      FindSymbolsFile(module_path, search_paths, build_id);
+
+  if (!debug_info_file_path) {
+    return debug_info_file_path.error();
+  }
+
+  ErrorMessageOr<std::unique_ptr<ElfFile>> elf_file_result =
+      ElfFile::Create(debug_info_file_path.value());
+
+  if (!elf_file_result) {
+    return ErrorMessage(absl::StrFormat(
+        "Failed to load debug symbols for \"%s\" from \"%s\": %s", module_path,
+        debug_info_file_path.value(), elf_file_result.error().message()));
+  }
+
+  return elf_file_result.value()->LoadSymbols();
 }
 
 }  // namespace
@@ -136,4 +170,9 @@ ErrorMessageOr<ModuleSymbols> SymbolHelper::LoadSymbolsCollector(
 ErrorMessageOr<ModuleSymbols> SymbolHelper::LoadUsingSymbolsPathFile(
     const std::string& module_path, const std::string& build_id) const {
   return FindSymbols(module_path, build_id, symbols_file_directories_);
+}
+
+ErrorMessageOr<std::string> SymbolHelper::FindDebugSymbolsFile(
+    const std::string& module_path, const std::string& build_id) const {
+  return FindSymbolsFile(module_path, collector_symbol_directories_, build_id);
 }

--- a/OrbitCore/SymbolHelper.h
+++ b/OrbitCore/SymbolHelper.h
@@ -18,13 +18,18 @@ class SymbolHelper {
       : collector_symbol_directories_(std::move(collector_symbol_directories)),
         symbols_file_directories_(std::move(symbols_file_directories)){};
 
-  ErrorMessageOr<ModuleSymbols> LoadSymbolsCollector(
+  [[nodiscard]] ErrorMessageOr<ModuleSymbols> LoadSymbolsCollector(
       const std::string& module_path) const;
-  ErrorMessageOr<ModuleSymbols> LoadUsingSymbolsPathFile(
+  [[nodiscard]] ErrorMessageOr<ModuleSymbols> LoadUsingSymbolsPathFile(
+      const std::string& module_path, const std::string& build_id) const;
+  [[nodiscard]] ErrorMessageOr<ModuleSymbols> LoadSymbolsFromFile(
+      const std::string& file_path, const std::string& build_id) const;
+
+  [[nodiscard]] ErrorMessageOr<std::string> FindDebugSymbolsFile(
       const std::string& module_path, const std::string& build_id) const;
 
-  ErrorMessageOr<std::string> FindDebugSymbolsFile(
-      const std::string& module_path, const std::string& build_id) const;
+  [[nodiscard]] std::string GenerateCachedFileName(
+      const std::string& file_path) const;
 
  private:
   const std::vector<std::string> collector_symbol_directories_;

--- a/OrbitCore/SymbolHelper.h
+++ b/OrbitCore/SymbolHelper.h
@@ -23,6 +23,9 @@ class SymbolHelper {
   ErrorMessageOr<ModuleSymbols> LoadUsingSymbolsPathFile(
       const std::string& module_path, const std::string& build_id) const;
 
+  ErrorMessageOr<std::string> FindDebugSymbolsFile(
+      const std::string& module_path, const std::string& build_id) const;
+
  private:
   const std::vector<std::string> collector_symbol_directories_;
   const std::vector<std::string> symbols_file_directories_;

--- a/OrbitCore/SymbolHelperTest.cpp
+++ b/OrbitCore/SymbolHelperTest.cpp
@@ -19,10 +19,61 @@ TEST(SymbolHelper, LoadSymbolsCollectorSameFile) {
   const std::string file_path = executable_directory + executable_name;
 
   SymbolHelper symbol_helper({executable_directory}, {});
+  const auto debug_symbol_file_path = symbol_helper.FindDebugSymbolsFile(
+      file_path, "d12d54bc5b72ccce54a408bdeda65e2530740ac8");
+  ASSERT_TRUE(debug_symbol_file_path)
+      << debug_symbol_file_path.error().message();
+  EXPECT_EQ(debug_symbol_file_path.value(), file_path);
   const auto symbols_result = symbol_helper.LoadSymbolsCollector(file_path);
-  ASSERT_TRUE(symbols_result);
+  ASSERT_TRUE(symbols_result) << symbols_result.error().message();
   ModuleSymbols symbols = std::move(symbols_result.value());
   EXPECT_EQ(symbols.symbols_file_path(), file_path);
+}
+
+TEST(SymbolHelper, FindDebugInfoFileSameFile) {
+  const std::string kFilePath =
+      Path::JoinPath({executable_directory, "hello_world_elf"});
+  const std::string kBuildId = "d12d54bc5b72ccce54a408bdeda65e2530740ac8";
+  const std::string kInvalidBuildId = "invalid_build_id";
+  const std::string kEmptyBuildId = "";
+
+  SymbolHelper symbol_helper({executable_directory}, {});
+  const auto debug_symbol_file_path =
+      symbol_helper.FindDebugSymbolsFile(kFilePath, kBuildId);
+  ASSERT_TRUE(debug_symbol_file_path)
+      << debug_symbol_file_path.error().message();
+  EXPECT_EQ(debug_symbol_file_path.value(), kFilePath);
+
+  const auto invalid_build_id_result =
+      symbol_helper.FindDebugSymbolsFile(kFilePath, kInvalidBuildId);
+  ASSERT_FALSE(invalid_build_id_result);
+  EXPECT_THAT(invalid_build_id_result.error().message(),
+              testing::HasSubstr("Could not find a file with debug symbols"));
+
+  const auto empty_build_id_result =
+      symbol_helper.FindDebugSymbolsFile(kFilePath, kEmptyBuildId);
+  ASSERT_TRUE(empty_build_id_result) << empty_build_id_result.error().message();
+  EXPECT_EQ(empty_build_id_result.value(), kFilePath);
+}
+
+TEST(SymbolHelper, FindDebugSymbolsSeparateFile) {
+  const std::string kFilePath =
+      Path::JoinPath({executable_directory, "no_symbols_elf"});
+  const std::string kBuildId = "b5413574bbacec6eacb3b89b1012d0e2cd92ec6b";
+  const std::string kEmptyBuildId = "";
+
+  SymbolHelper symbol_helper({executable_directory}, {});
+  const auto debug_symbol_file_path =
+      symbol_helper.FindDebugSymbolsFile(kFilePath, kBuildId);
+  ASSERT_TRUE(debug_symbol_file_path)
+      << debug_symbol_file_path.error().message();
+  EXPECT_EQ(debug_symbol_file_path.value(), kFilePath + ".debug");
+
+  const auto result =
+      symbol_helper.FindDebugSymbolsFile(kFilePath, kEmptyBuildId);
+  ASSERT_FALSE(result);
+  EXPECT_THAT(result.error().message(),
+              testing::HasSubstr("Could not find a file with debug symbols"));
 }
 
 TEST(SymbolHelper, LoadSymbolsCollectorSeparateFile) {

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -738,32 +738,59 @@ void OrbitApp::LoadModuleOnRemote(int32_t process_id,
                                   const std::shared_ptr<Module>& module,
                                   const std::shared_ptr<PresetFile>& preset) {
   thread_pool_->Schedule([this, process_id, module, preset]() {
-    const auto remote_symbols_result =
-        process_manager_->LoadSymbols(module->m_FullName);
+    const std::string& module_path = module->m_FullName;
+    const std::string& build_id = module->m_DebugSignature;
 
-    if (!remote_symbols_result) {
-      SendErrorToUi(
-          "Error loading symbols",
-          absl::StrFormat(
-              "Did not find symbols on local machine for module \"%s\".\n"
-              "Trying to load symbols from remote resulted in error "
-              "message: %s",
-              module->m_Name, remote_symbols_result.error().message()));
+    const auto result =
+        process_manager_->FindDebugInfoFile(module_path, build_id);
+
+    if (!result) {
+      SendErrorToUi("Error loading symbols",
+                    absl::StrFormat(
+                        "Did not find symbols on remote for module \"%s\": %s",
+                        module_path, result.error().message()));
       main_thread_executor_->Schedule([this, module]() {
         modules_currently_loading_.erase(module->m_FullName);
       });
       return;
     }
 
-    main_thread_executor_->Schedule(
-        [this, symbols = std::move(remote_symbols_result.value()), module,
-         process_id, preset]() {
-          module->LoadSymbols(symbols);
-          LOG("Received and loaded %lu function symbols from remote service "
-              "for module %s",
-              module->m_Pdb->GetFunctions().size(), module->m_Name.c_str());
-          SymbolLoadingFinished(process_id, module, preset);
-        });
+    const std::string& debug_file_path = result.value();
+
+    LOG("Found file on the remote: \"%s\" - loading it using scp...",
+        debug_file_path);
+
+    main_thread_executor_->Schedule([this, module, module_path, build_id,
+                                     process_id, preset, debug_file_path]() {
+      const std::string local_debug_file_path =
+          symbol_helper_.GenerateCachedFileName(module_path);
+
+      auto scp_result =
+          secure_copy_callback_(debug_file_path, local_debug_file_path);
+      if (!scp_result) {
+        SendErrorToUi("Error loading symbols",
+                      absl::StrFormat(
+                          "Could not copy debug info file from the remote: %s",
+                          scp_result.error().message()));
+        return;
+      }
+
+      const auto result =
+          symbol_helper_.LoadSymbolsFromFile(local_debug_file_path, build_id);
+      if (!result) {
+        SendErrorToUi(
+            "Error loading symbols",
+            absl::StrFormat(
+                R"(Did not load symbols for module "%s" (debug info file "%s"): %s)",
+                module_path, local_debug_file_path, result.error().message()));
+        return;
+      }
+      module->LoadSymbols(result.value());
+      LOG("Received and loaded %lu function symbols from remote service "
+          "for module %s",
+          module->m_Pdb->GetFunctions().size(), module->m_Name.c_str());
+      SymbolLoadingFinished(process_id, module, preset);
+    });
   });
 }
 
@@ -799,8 +826,17 @@ void OrbitApp::LoadModules(int32_t process_id,
     modules_currently_loading_.insert(module->m_FullName);
 
     // TODO (159889010) Move symbol loading off the main thread.
-    const auto symbols = symbol_helper_.LoadUsingSymbolsPathFile(
-        module->m_FullName, module->m_DebugSignature);
+    const std::string& module_path = module->m_FullName;
+    const std::string& build_id = module->m_DebugSignature;
+    auto symbols =
+        symbol_helper_.LoadUsingSymbolsPathFile(module_path, build_id);
+
+    // Try loading from the cache
+    if (!symbols) {
+      const std::string cached_file_name =
+          symbol_helper_.GenerateCachedFileName(module_path);
+      symbols = symbol_helper_.LoadSymbolsFromFile(cached_file_name, build_id);
+    }
 
     if (symbols) {
       module->LoadSymbols(symbols.value());

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -765,14 +765,18 @@ void OrbitApp::LoadModuleOnRemote(int32_t process_id,
       const std::string local_debug_file_path =
           symbol_helper_.GenerateCachedFileName(module_path);
 
-      auto scp_result =
-          secure_copy_callback_(debug_file_path, local_debug_file_path);
-      if (!scp_result) {
-        SendErrorToUi("Error loading symbols",
-                      absl::StrFormat(
-                          "Could not copy debug info file from the remote: %s",
-                          scp_result.error().message()));
-        return;
+      {
+        SCOPE_TIMER_LOG(absl::StrFormat("Copying %s", debug_file_path));
+        auto scp_result =
+            secure_copy_callback_(debug_file_path, local_debug_file_path);
+        if (!scp_result) {
+          SendErrorToUi(
+              "Error loading symbols",
+              absl::StrFormat(
+                  "Could not copy debug info file from the remote: %s",
+                  scp_result.error().message()));
+          return;
+        }
       }
 
       const auto result =

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -200,6 +200,12 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
     clipboard_callback_ = std::move(callback);
   }
 
+  using SecureCopyCallback =
+      std::function<ErrorMessageOr<void>(std::string_view, std::string_view)>;
+  void SetSecureCopyCallback(SecureCopyCallback callback) {
+    secure_copy_callback_ = callback;
+  }
+
   void SetCommandLineArguments(const std::vector<std::string>& args);
 
   void RequestOpenCaptureToUi();
@@ -270,6 +276,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   FindFileCallback find_file_callback_;
   SaveFileCallback save_file_callback_;
   ClipboardCallback clipboard_callback_;
+  SecureCopyCallback secure_copy_callback_;
 
   std::unique_ptr<ProcessesDataView> m_ProcessesDataView;
   std::unique_ptr<ModulesDataView> m_ModulesDataView;

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -125,7 +125,13 @@ static outcome::result<void> RunUiInstance(
   options.grpc_server_address =
       absl::StrFormat("127.0.0.1:%d", ports.grpc_port);
 
-  OrbitMainWindow w(app, std::move(options));
+  ServiceDeployManager* service_deploy_manager_ptr = nullptr;
+
+  if (service_deploy_manager) {
+    service_deploy_manager_ptr = &service_deploy_manager.value();
+  }
+
+  OrbitMainWindow w(app, std::move(options), service_deploy_manager_ptr);
   // "resize" is required to make "showMaximized" work properly.
   w.resize(1280, 720);
   w.showMaximized();

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -50,8 +50,9 @@ OrbitMainWindow* GMainWindow;
 extern QMenu* GContextMenu;
 
 //-----------------------------------------------------------------------------
-OrbitMainWindow::OrbitMainWindow(QApplication* a_App,
-                                 ApplicationOptions&& options)
+OrbitMainWindow::OrbitMainWindow(
+    QApplication* a_App, ApplicationOptions&& options,
+    OrbitQt::ServiceDeployManager* service_deploy_manager)
     : QMainWindow(nullptr),
       m_App(a_App),
       ui(new Ui::OrbitMainWindow),
@@ -166,6 +167,13 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App,
   });
   GOrbitApp->SetClipboardCallback(
       [this](const std::string& text) { this->OnSetClipboard(text); });
+
+  GOrbitApp->SetSecureCopyCallback(
+      [service_deploy_manager](std::string_view source,
+                               std::string_view destination) {
+        CHECK(service_deploy_manager != nullptr);
+        return service_deploy_manager->CopyFileToLocal(source, destination);
+      });
 
   ParseCommandlineArguments();
 

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -46,7 +46,6 @@ ABSL_DECLARE_FLAG(bool, enable_stale_features);
 ABSL_DECLARE_FLAG(bool, devmode);
 
 //-----------------------------------------------------------------------------
-OrbitMainWindow* GMainWindow;
 extern QMenu* GContextMenu;
 
 //-----------------------------------------------------------------------------
@@ -231,8 +230,6 @@ OrbitMainWindow::OrbitMainWindow(
   SetTitle({});
   std::string iconFileName = Path::GetExecutablePath() + "orbit.ico";
   this->setWindowIcon(QIcon(iconFileName.c_str()));
-
-  GMainWindow = this;
 
   GOrbitApp->PostInit();
 }

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -20,6 +20,7 @@
 #include "ApplicationOptions.h"
 #include "CallStackDataView.h"
 #include "TopDownView.h"
+#include "servicedeploymanager.h"
 
 namespace Ui {
 class OrbitMainWindow;
@@ -29,7 +30,8 @@ class OrbitMainWindow : public QMainWindow {
   Q_OBJECT
 
  public:
-  OrbitMainWindow(QApplication* a_App, ApplicationOptions&& options);
+  OrbitMainWindow(QApplication* a_App, ApplicationOptions&& options,
+                  OrbitQt::ServiceDeployManager* service_deploy_manager);
   ~OrbitMainWindow() override;
 
   void RegisterGlWidget(class OrbitGLWidget* a_GlWidget) {

--- a/OrbitService/ProcessServiceImpl.cpp
+++ b/OrbitService/ProcessServiceImpl.cpp
@@ -101,3 +101,17 @@ Status ProcessServiceImpl::GetSymbols(ServerContext*,
 
   return Status::OK;
 }
+Status ProcessServiceImpl::GetDebugInfoFile(
+    ::grpc::ServerContext*, const ::GetDebugInfoFileRequest* request,
+    ::GetDebugInfoFileResponse* response) {
+  const SymbolHelper symbol_helper;
+  ErrorMessageOr<std::string> result = symbol_helper.FindDebugSymbolsFile(
+      request->module_path(), request->build_id());
+  if (!result) {
+    return Status(StatusCode::NOT_FOUND, result.error().message());
+  }
+
+  response->set_debug_info_file_path(result.value());
+
+  return Status::OK;
+}

--- a/OrbitService/ProcessServiceImpl.cpp
+++ b/OrbitService/ProcessServiceImpl.cpp
@@ -82,25 +82,6 @@ Status ProcessServiceImpl::GetProcessMemory(
   }
 }
 
-Status ProcessServiceImpl::GetSymbols(ServerContext*,
-                                      const GetSymbolsRequest* request,
-                                      GetSymbolsResponse* response) {
-  const SymbolHelper symbol_helper;
-  const auto load_result =
-      symbol_helper.LoadSymbolsCollector(request->module_path());
-
-  if (load_result.has_error()) {
-    return Status(StatusCode::NOT_FOUND, load_result.error().message());
-  }
-
-  *response->mutable_module_symbols() = std::move(load_result.value());
-
-  LOG("Loaded %lu symbols for module \"%s\" (size: %d bytes)",
-      response->module_symbols().symbol_infos().size(), request->module_path(),
-      response->ByteSize());
-
-  return Status::OK;
-}
 Status ProcessServiceImpl::GetDebugInfoFile(
     ::grpc::ServerContext*, const ::GetDebugInfoFileRequest* request,
     ::GetDebugInfoFileResponse* response) {

--- a/OrbitService/ProcessServiceImpl.h
+++ b/OrbitService/ProcessServiceImpl.h
@@ -18,9 +18,6 @@ class ProcessServiceImpl final : public ProcessService::Service {
   grpc::Status GetProcessList(grpc::ServerContext* context,
                               const GetProcessListRequest* request,
                               GetProcessListResponse* response) override;
-  grpc::Status GetSymbols(grpc::ServerContext* context,
-                          const GetSymbolsRequest* request,
-                          GetSymbolsResponse* response) override;
 
   grpc::Status GetModuleList(grpc::ServerContext* context,
                              const GetModuleListRequest* request,

--- a/OrbitService/ProcessServiceImpl.h
+++ b/OrbitService/ProcessServiceImpl.h
@@ -30,6 +30,10 @@ class ProcessServiceImpl final : public ProcessService::Service {
                                 const GetProcessMemoryRequest* request,
                                 GetProcessMemoryResponse* response) override;
 
+  grpc::Status GetDebugInfoFile(grpc::ServerContext* context,
+                                const GetDebugInfoFileRequest* request,
+                                GetDebugInfoFileResponse* response) override;
+
  private:
   absl::Mutex mutex_;
   ProcessList process_list_;

--- a/OrbitSshQt/SftpCopyToLocalOperation.cpp
+++ b/OrbitSshQt/SftpCopyToLocalOperation.cpp
@@ -60,11 +60,11 @@ outcome::result<void> SftpCopyToLocalOperation::startup() {
       ABSL_FALLTHROUGH_INTENDED;
     }
     case State::kLocalFileOpened: {
-      constexpr size_t kReadBufferMaxSize = 32 * 1024;
+      constexpr size_t kReadBufferMaxSize = 1 * 1024 * 1024;
 
       while (true) {
         OUTCOME_TRY(read_buffer, sftp_file_->Read(kReadBufferMaxSize));
-        if (read_buffer.size() == 0) {
+        if (read_buffer.empty()) {
           // This is end of file
           SetState(State::kLocalFileWritten);
           break;

--- a/protos/services.proto
+++ b/protos/services.proto
@@ -46,14 +46,6 @@ message GetProcessMemoryResponse {
   bytes memory = 1;
 }
 
-message GetSymbolsRequest {
-  string module_path = 1;
-}
-
-message GetSymbolsResponse {
-  ModuleSymbols module_symbols = 1;
-}
-
 message GetDebugInfoFileRequest {
   string module_path = 1;
   string build_id = 2;
@@ -70,8 +62,6 @@ service ProcessService {
 
   rpc GetProcessMemory(GetProcessMemoryRequest)
       returns (GetProcessMemoryResponse) {}
-
-  rpc GetSymbols(GetSymbolsRequest) returns (GetSymbolsResponse) {}
 
   rpc GetDebugInfoFile(GetDebugInfoFileRequest)
       returns (GetDebugInfoFileResponse) {}

--- a/protos/services.proto
+++ b/protos/services.proto
@@ -54,6 +54,15 @@ message GetSymbolsResponse {
   ModuleSymbols module_symbols = 1;
 }
 
+message GetDebugInfoFileRequest {
+  string module_path = 1;
+  string build_id = 2;
+}
+
+message GetDebugInfoFileResponse {
+  string debug_info_file_path = 1;
+}
+
 service ProcessService {
   rpc GetProcessList(GetProcessListRequest) returns (GetProcessListResponse) {}
 
@@ -63,6 +72,9 @@ service ProcessService {
       returns (GetProcessMemoryResponse) {}
 
   rpc GetSymbols(GetSymbolsRequest) returns (GetSymbolsResponse) {}
+
+  rpc GetDebugInfoFile(GetDebugInfoFileRequest)
+      returns (GetDebugInfoFileResponse) {}
 }
 
 message ValidateFramePointersRequest {


### PR DESCRIPTION
This PR consists of 3 parts

part 1:

    Add service call to find debug symbols
    
    This call attempt to find debug symbols on the collector side
    it does not load them but instead return path which could then
    be used to retrieve module via scp.

part 2:

    Keep sftp_channel alive and implement CopyToLocal
    
    This commit makes ServiceDeployManager keep sftp channel
    alive in order to be able to copy debug symbols from remote to
    local while loading symbols. It also adds CopyToLocal method
    to do that.

part 3:

    Always load symbols from local file
    
    This commit modifies Load Symbols shifting symbol loading from
    the service to the client. The modified workflow works in the following
    way:
    
    1. Orbit tries to load symbols from local machine using paths
       from SymbolsPathFile and Cache directory.
    2. If unsuccessful it asks the service to find a debug info file
       on the server side. The call returns path to the file if successful.
    3. If the debug info file was found on the server side Orbit copies
       it to the cache directory and loads symbols.

Test: Start Orbit, load symbols from the server. Restart Orbit, load symbols from the cache.
 Bug: http://b/161352292

