### PR TITLE
Remove [[nodiscard]] from void SetTimesliceText

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   set(STRICT_COMPILE_FLAGS -Werror=all
                            -Werror=float-conversion
                            -Werror=format=2
+                           -Werror=ignored-attributes
                            -Werror=inconsistent-missing-override
                            -Werror=old-style-cast
                            -Werror=unused-parameter
@@ -19,6 +20,7 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   set(STRICT_COMPILE_FLAGS -Werror=all
                            -Werror=float-conversion
                            -Werror=format=2
+                           -Werror=ignored-attributes
                            -Werror=old-style-cast
                            -Werror=unused-parameter
                            -Werror=unused-variable

--- a/OrbitGl/GpuTrack.h
+++ b/OrbitGl/GpuTrack.h
@@ -44,7 +44,7 @@ class GpuTrack : public TimerTrack {
                                     bool is_selected) const override;
   [[nodiscard]] bool TimerFilter(
       const orbit_client_protos::TimerInfo& timer) const override;
-  [[nodiscard]] void SetTimesliceText(
+  void SetTimesliceText(
       const orbit_client_protos::TimerInfo& timer, double elapsed_us,
       float min_x, TextBox* text_box) override;
   [[nodiscard]] std::string GetBoxTooltip(PickingID id) const override;


### PR DESCRIPTION
This caused one `warning: attribute 'nodiscard' cannot be applied to functions
without return value` for each .cpp that includes the file.