### PR TITLE
Fix displaying of function names in the iterator UI overlay

### DIFF
--- a/OrbitGl/LiveFunctionsController.cpp
+++ b/OrbitGl/LiveFunctionsController.cpp
@@ -190,10 +190,19 @@ void LiveFunctionsController::OnDeleteButton(uint64_t id) {
 }
 
 void LiveFunctionsController::AddIterator(FunctionInfo* function) {
+  CHECK(function != nullptr);
   uint64_t id = next_iterator_id_;
   ++next_iterator_id_;
 
   auto function_address = FunctionUtils::GetAbsoluteAddress(*function);
+
+  // It's possible that this function does not appear in any samples and
+  // in that case, GAddressToFunctionName would not contain the display
+  // name, so we have to add it here, so we can easily look up the display
+  // name when drawing iterators.
+  std::string function_name = FunctionUtils::GetDisplayName(*function);
+  Capture::GAddressToFunctionName[function_address] = function_name;
+
   const TextBox* box = Capture::GSelectedTextBox;
   // If no box is currently selected or the selected box is a different
   // function, we search for the closest box to the current center of the

--- a/OrbitGl/LiveFunctionsDataView.cpp
+++ b/OrbitGl/LiveFunctionsDataView.cpp
@@ -249,7 +249,7 @@ void LiveFunctionsDataView::OnContextMenu(
   } else if (a_Action == MENU_ACTION_ITERATE) {
     for (int i : a_ItemIndices) {
       FunctionInfo* function = GetFunction(i);
-      if (function->stats().count() > 0) {
+      if (function != nullptr && function->stats().count() > 0) {
         live_functions_->AddIterator(function);
       }
     }


### PR DESCRIPTION
When a function was not encountered in any samples, then the (global)
map that we maintain to map function addresses to display names did not
contain that function and the displayed string was incorrect. Whenever
we add an iterator, we insert the function address and display name into
the map now.