### PR TITLE
Updated Ubuntu version in docker containers

### DIFF
--- a/third_party/conan/docker/Dockerfile.clang7_opengl_qt
+++ b/third_party/conan/docker/Dockerfile.clang7_opengl_qt
@@ -1,4 +1,4 @@
-FROM ubuntu:disco
+FROM ubuntu:eoan
 
 LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
@@ -10,15 +10,13 @@ ENV LLVM_VERSION=7.0 \
     PYENV_ROOT=/opt/pyenv \
     PATH=/opt/pyenv/shims:${PATH}
 
-ADD sources.list.disco /etc/apt/sources.list
-
 RUN dpkg --add-architecture i386 \
     && apt-get -qq update \
     && apt-get install -y --no-install-recommends \
        sudo=1.* \
        wget=1.* \
        git=1:2.* \
-       g++-multilib=4:8.* \
+       g++-multilib=4:9.* \
        clang-7=1:7* \
        make=4.* \
        libc6-dev-i386=2.* \

--- a/third_party/conan/docker/Dockerfile.clang8_opengl_qt
+++ b/third_party/conan/docker/Dockerfile.clang8_opengl_qt
@@ -1,16 +1,100 @@
-FROM conanio/clang8:latest
+FROM ubuntu:eoan
 
-ADD sources.list.disco /etc/apt/sources.list
+LABEL maintainer="Luis Martinez de Bartolome <luism@jfrog.com>"
 
-RUN sudo apt-get -qq update \
-    && sudo apt-get install -y --no-install-recommends \
-    libstdc++-9-dev \
-    libglu1-mesa-dev \
-    mesa-common-dev \
-    libxmu-dev \
-    libxi-dev \
-    qt5-default \
-    jq \
-    python2.7 \
-    zip \
-    && sudo rm -rf /var/lib/apt/lists/*
+ENV LLVM_VERSION=8.0 \
+    CC=clang \
+    CXX=clang++ \
+    CMAKE_C_COMPILER=clang \
+    CMAKE_CXX_COMPILER=clang++ \
+    PYENV_ROOT=/opt/pyenv \
+    PATH=/opt/pyenv/shims:${PATH}
+
+RUN dpkg --add-architecture i386 \
+    && apt-get -qq update \
+    && apt-get install -y --no-install-recommends \
+       sudo=1.* \
+       wget=1.* \
+       git=1:2.* \
+       g++-multilib=4:9.* \
+       clang-8=1:8* \
+       make=4.* \
+       libc6-dev-i386=2.* \
+       libgmp-dev=2:6.* \
+       libmpfr-dev=4.* \
+       libmpc-dev=1.* \
+       nasm=2.* \
+       dh-autoreconf=19 \
+       libffi-dev=3.* \
+       libssl-dev=1* \
+       ninja-build=1.* \
+       libc++-8-dev=1:8.* \
+       libc++abi-8-dev=1:8.* \
+       pkg-config=0.* \
+       subversion=1.* \
+       zlib1g-dev=1:1.* \
+       libbz2-dev=1.* \
+       libsqlite3-dev=3.* \
+       libreadline-dev=8.* \
+       xz-utils=5.* \
+       curl=7.* \
+       libncurses5-dev=6.* \
+       libncursesw5-dev=6.* \
+       liblzma-dev=5.* \
+       gnupg=2.* \
+       ca-certificates \
+       libstdc++-9-dev \
+       libglu1-mesa-dev \
+       mesa-common-dev \
+       libxmu-dev \
+       libxi-dev \
+       qt5-default \
+       jq \
+       python2.7 \
+       zip \
+    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-8 100 \
+    && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 100 \
+    && update-alternatives --install /usr/bin/cc cc /usr/bin/clang-8 100 \
+    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-8 100 \
+    && update-alternatives --install /usr/bin/cpp cpp /usr/bin/clang++-8 100 \
+    && ln -s /usr/include/locale.h /usr/include/xlocale.h \
+    && rm -rf /var/lib/apt/lists/* \
+    && wget -q --no-check-certificate https://cmake.org/files/v3.16/cmake-3.16.4-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.16.4-Linux-x86_64.tar.gz \
+       --exclude=bin/cmake-gui \
+       --exclude=doc/cmake \
+       --exclude=share/cmake-3.12/Help \
+    && cp -fR cmake-3.16.4-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.16.4-Linux-x86_64 \
+    && rm cmake-3.16.4-Linux-x86_64.tar.gz \
+    && groupadd 1001 -g 1001 \
+    && groupadd 1000 -g 1000 \
+    && groupadd 2000 -g 2000 \
+    && groupadd 999 -g 999 \
+    && useradd -ms /bin/bash conan -g 1001 -G 1000,2000,999 \
+    && printf "conan:conan" | chpasswd \
+    && adduser conan sudo \
+    && printf "conan ALL= NOPASSWD: ALL\\n" >> /etc/sudoers \
+    && wget --no-check-certificate --quiet -O /tmp/pyenv-installer https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer \
+    && chmod +x /tmp/pyenv-installer \
+    && /tmp/pyenv-installer \
+    && rm /tmp/pyenv-installer \
+    && update-alternatives --install /usr/bin/pyenv pyenv /opt/pyenv/bin/pyenv 100 \
+    && PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.5 \
+    && pyenv global 3.7.5 \
+    && pip install -q --upgrade --no-cache-dir pip \
+    && pip install -q --no-cache-dir conan conan-package-tools \
+    && chown -R conan:1001 /opt/pyenv \
+    # remove all __pycache__ directories created by pyenv
+    && find /opt/pyenv -iname __pycache__ -print0 | xargs -0 rm -rf \
+    && update-alternatives --install /usr/bin/python python /opt/pyenv/shims/python 100 \
+    && update-alternatives --install /usr/bin/python3 python3 /opt/pyenv/shims/python3 100 \
+    && update-alternatives --install /usr/bin/pip pip /opt/pyenv/shims/pip 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /opt/pyenv/shims/pip3 100
+
+USER conan
+WORKDIR /home/conan
+
+RUN mkdir -p /home/conan/.conan \
+    && printf 'eval "$(pyenv init -)"\n' >> ~/.bashrc \
+    && printf 'eval "$(pyenv virtualenv-init -)"\n' >> ~/.bashrc

--- a/third_party/conan/docker/sources.list.disco
+++ b/third_party/conan/docker/sources.list.disco
@@ -1,4 +1,0 @@
-deb http://old-releases.ubuntu.com/ubuntu/ disco main restricted universe multiverse
-deb http://old-releases.ubuntu.com/ubuntu/ disco-updates main restricted universe multiverse
-deb http://old-releases.ubuntu.com/ubuntu/ disco-security main restricted universe multiverse
-


### PR DESCRIPTION
This commit updates the ubuntu version from disco to eoan
in the linux docker containers with Qt support.

We encountered a bug/missing feature in Qt 5.12
(https://bugreports.qt.io/browse/QTBUG-69683) which is fixed with the
sub-release included in eoan (5.12.4). Ubuntu Disco Dingo ships with Qt
5.12.2.

Windows is not affected since we use Qt from conan on Windows in a very
recent release (5.14.4).