### PR TITLE
Made UI-files conformant to what QtDesigner expects

### DIFF
--- a/OrbitQt/orbitdataviewpanel.h
+++ b/OrbitQt/orbitdataviewpanel.h
@@ -8,6 +8,7 @@
 #include <QWidget>
 
 #include "orbittablemodel.h"
+#include "orbittreeview.h"
 #include "types.h"
 
 namespace Ui {
@@ -27,7 +28,7 @@ class OrbitDataViewPanel : public QWidget {
   void Refresh();
   void SetDataModel(DataView* model);
   void SetFilter(const QString& a_Filter);
-  class OrbitTreeView* GetTreeView();
+  OrbitTreeView* GetTreeView();
   QLineEdit* GetFilterLineEdit();
 
  private slots:

--- a/OrbitQt/orbitdataviewpanel.ui
+++ b/OrbitQt/orbitdataviewpanel.ui
@@ -54,10 +54,10 @@
    </item>
    <item row="1" column="0">
     <widget class="OrbitTreeView" name="treeView">
-     <attribute name="headerDefaultSectionSize">
+     <attribute name="headerMinimumSectionSize">
       <number>0</number>
      </attribute>
-     <attribute name="headerMinimumSectionSize">
+     <attribute name="headerDefaultSectionSize">
       <number>0</number>
      </attribute>
     </widget>

--- a/OrbitQt/orbiteventiterator.ui
+++ b/OrbitQt/orbiteventiterator.ui
@@ -28,33 +28,33 @@
   <layout class="QGridLayout" name="IteratorLayout">
    <item row="0" column="0">
     <widget class="QPushButton" name="PreviousButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
       <string>&lt;</string>
      </property>
      <property name="autoRepeat">
       <bool>true</bool>
      </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QPushButton" name="NextButton">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QPushButton" name="NextButton">
      <property name="text">
       <string>&gt;</string>
      </property>
      <property name="autoRepeat">
       <bool>true</bool>
-     </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
      </property>
     </widget>
    </item>
@@ -71,20 +71,20 @@
    <item row="0" column="3">
     <widget class="QLabel" name="position_label_">
      <property name="alignment">
-      <set>Qt::AlignRight | Qt::AlignVCenter</set>
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
    <item row="0" column="4">
     <widget class="QPushButton" name="DeleteButton">
-     <property name="text">
-      <string>Delete</string>
-     </property>
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Delete</string>
      </property>
     </widget>
    </item>

--- a/OrbitQt/orbitglwidgetwithheader.ui
+++ b/OrbitQt/orbitglwidgetwithheader.ui
@@ -73,21 +73,17 @@
     </layout>
    </item>
   </layout>
-  <zorder>treeView</zorder>
-  <zorder>scrollArea</zorder>
-  <zorder>openGLWidget</zorder>
-  <zorder>openGLWidget</zorder>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>OrbitGLWidget</class>
-   <extends>QOpenGLWidget</extends>
-   <header>orbitglwidget.h</header>
-  </customwidget>
   <customwidget>
    <class>OrbitTreeView</class>
    <extends>QTreeView</extends>
    <header>orbittreeview.h</header>
+  </customwidget>
+  <customwidget>
+   <class>OrbitGLWidget</class>
+   <extends>QOpenGLWidget</extends>
+   <header>orbitglwidget.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/OrbitQt/orbitlivefunctions.ui
+++ b/OrbitQt/orbitlivefunctions.ui
@@ -33,8 +33,7 @@
     <number>0</number>
    </property>
    <item row="0" column="0">
-    <widget class="OrbitDataViewPanel" name="data_view_panel_">
-    </widget>
+    <widget class="OrbitDataViewPanel" name="data_view_panel_" native="true"/>
    </item>
    <item row="1" column="0">
     <layout class="QVBoxLayout" name="iteratorLayout">

--- a/OrbitQt/orbitmainwindow.ui
+++ b/OrbitQt/orbitmainwindow.ui
@@ -149,7 +149,7 @@
         </attribute>
         <layout class="QGridLayout" name="liveGridLayout">
          <item row="0" column="0">
-          <widget class="OrbitLiveFunctions" name="liveFunctions"/>
+          <widget class="OrbitLiveFunctions" name="liveFunctions" native="true"/>
          </item>
         </layout>
        </widget>
@@ -159,7 +159,7 @@
         </attribute>
         <layout class="QGridLayout" name="samplingGridLayout">
          <item row="0" column="0">
-          <widget class="OrbitSamplingReport" name="samplingReport"/>
+          <widget class="OrbitSamplingReport" name="samplingReport" native="true"/>
          </item>
         </layout>
        </widget>
@@ -179,7 +179,7 @@
         </attribute>
         <layout class="QGridLayout" name="selectionGridLayout">
          <item row="0" column="0">
-          <widget class="OrbitSamplingReport" name="selectionReport"/>
+          <widget class="OrbitSamplingReport" name="selectionReport" native="true"/>
          </item>
         </layout>
        </widget>
@@ -243,7 +243,7 @@
      <x>0</x>
      <y>0</y>
      <width>976</width>
-     <height>21</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -271,26 +271,25 @@
     <addaction name="actionReport_Missing_Feature"/>
     <addaction name="actionReport_Bug"/>
    </widget>
-   <widget class="QMenu" name="menuCrash">
-    <property name="title">
-     <string>Crash Test</string>
-    </property>
-    <addaction name="actionCheckFalse"/>
-    <addaction name="actionNullPointerDereference"/>
-    <addaction name="actionStackOverflow"/>
-    <addaction name="actionServiceCheckFalse"/>
-    <addaction name="actionServiceNullPointerDereference"/>
-    <addaction name="actionServiceStackOverflow"/>
-   </widget>
    <widget class="QMenu" name="menuDebug">
     <property name="title">
      <string>Debug</string>
     </property>
+    <widget class="QMenu" name="menuCrash">
+     <property name="title">
+      <string>Crash Test</string>
+     </property>
+     <addaction name="actionCheckFalse"/>
+     <addaction name="actionNullPointerDereference"/>
+     <addaction name="actionStackOverflow"/>
+     <addaction name="actionServiceCheckFalse"/>
+     <addaction name="actionServiceNullPointerDereference"/>
+     <addaction name="actionServiceStackOverflow"/>
+    </widget>
     <addaction name="menuCrash"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuDebug"/>
-   <addaction name="menuTools"/>
    <addaction name="menuHelp"/>
    <addaction name="menuFeedback"/>
   </widget>
@@ -420,7 +419,7 @@
     <string>[Service] Check False</string>
    </property>
   </action>
-    <action name="actionServiceNullPointerDereference">
+  <action name="actionServiceNullPointerDereference">
    <property name="text">
     <string>[Service] Null Pointer Dereference</string>
    </property>
@@ -453,6 +452,16 @@
    <extends>QWidget</extends>
    <header>processlauncherwidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>OrbitLiveFunctions</class>
+   <extends>QWidget</extends>
+   <header>orbitlivefunctions.h</header>
+  </customwidget>
+  <customwidget>
+   <class>OrbitSamplingReport</class>
+   <extends>QWidget</extends>
+   <header>orbitsamplingreport.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/OrbitQt/orbitsamplingreport.cpp
+++ b/OrbitQt/orbitsamplingreport.cpp
@@ -4,6 +4,8 @@
 
 #include "orbitsamplingreport.h"
 
+#include <QHeaderView>
+
 #include "SamplingReport.h"
 #include "orbitdataviewpanel.h"
 #include "orbittreeview.h"

--- a/OrbitQt/orbitsamplingreport.ui
+++ b/OrbitQt/orbitsamplingreport.ui
@@ -113,7 +113,7 @@
           </widget>
          </item>
          <item row="1" column="0">
-          <widget class="OrbitDataViewPanel" name="CallstackTreeView">
+          <widget class="OrbitDataViewPanel" name="CallstackTreeView" native="true">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
              <horstretch>0</horstretch>
@@ -133,7 +133,7 @@
  <customwidgets>
   <customwidget>
    <class>OrbitDataViewPanel</class>
-   <extends>QTreeView</extends>
+   <extends>QWidget</extends>
    <header>orbitdataviewpanel.h</header>
   </customwidget>
  </customwidgets>

--- a/OrbitQt/processlauncherwidget.ui
+++ b/OrbitQt/processlauncherwidget.ui
@@ -31,7 +31,7 @@
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <widget class="OrbitDataViewPanel" name="LiveProcessList"/>
+     <widget class="OrbitDataViewPanel" name="LiveProcessList" native="true"/>
     </widget>
    </item>
   </layout>
@@ -39,7 +39,7 @@
  <customwidgets>
   <customwidget>
    <class>OrbitDataViewPanel</class>
-   <extends>QTreeView</extends>
+   <extends>QWidget</extends>
    <header>orbitdataviewpanel.h</header>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
Opening one of our Qt-UI-files lead often to unrelated changes triggered
by QtDesigner's UI-parser. Since we want to be able to edit them in QtDesigner,
this commit tries to fix them once and for all.

Ideally this should not lead to any behavioural change in the
application. Most changes are reorderings even though they might look
weird depending on the diffing-algorithm.

Additionally two header-include changes in non-auto-generated-files were
necessary due to now missing transitive includes.