### PR TITLE
Add various "Expand ..." / "Collapse ..." context menu actions to the top-down view

### DIFF
--- a/OrbitQt/CMakeLists.txt
+++ b/OrbitQt/CMakeLists.txt
@@ -32,7 +32,8 @@ target_sources(
           processlauncherwidget.h
           resource.h
           servicedeploymanager.h
-          TopDownViewItemModel.h)
+          TopDownViewItemModel.h
+          topdownwidget.h)
 
 target_sources(
   OrbitQt
@@ -60,7 +61,8 @@ target_sources(
           outputdialog.cpp
           processlauncherwidget.cpp
           servicedeploymanager.cpp
-          TopDownViewItemModel.cpp)
+          TopDownViewItemModel.cpp
+          topdownwidget.cpp)
 
 target_include_directories(OrbitQt PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -516,17 +516,7 @@ void OrbitMainWindow::OnNewSelectionReport(
 
 void OrbitMainWindow::OnNewTopDownView(
     std::unique_ptr<TopDownView> top_down_view) {
-  auto* model =
-      new TopDownViewItemModel{std::move(top_down_view), ui->topDownView};
-  auto* proxy_model = new QSortFilterProxyModel{ui->topDownView};
-  proxy_model->setSourceModel(model);
-  proxy_model->setSortRole(Qt::EditRole);
-  ui->topDownView->setModel(proxy_model);
-  ui->topDownView->sortByColumn(TopDownViewItemModel::kInclusive,
-                                Qt::DescendingOrder);
-  for (int column = 0; column < TopDownViewItemModel::kColumnCount; ++column) {
-    ui->topDownView->resizeColumnToContents(column);
-  }
+  ui->topDownWidget->SetTopDownView(std::move(top_down_view));
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitQt/orbitmainwindow.ui
+++ b/OrbitQt/orbitmainwindow.ui
@@ -177,16 +177,9 @@
         <attribute name="title">
          <string>top-down</string>
         </attribute>
-        <layout class="QGridLayout" name="gridLayout_9">
+        <layout class="QGridLayout" name="topDownGridLayout">
          <item row="0" column="0">
-          <widget class="QTreeView" name="topDownView">
-           <property name="alternatingRowColors">
-            <bool>true</bool>
-           </property>
-           <property name="sortingEnabled">
-            <bool>true</bool>
-           </property>
-          </widget>
+          <widget class="TopDownWidget" name="topDownWidget"/>
          </item>
         </layout>
        </widget>

--- a/OrbitQt/topdownwidget.cpp
+++ b/OrbitQt/topdownwidget.cpp
@@ -1,0 +1,21 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "topdownwidget.h"
+
+#include "TopDownViewItemModel.h"
+
+void TopDownWidget::SetTopDownView(std::unique_ptr<TopDownView> top_down_view) {
+  auto* model =
+      new TopDownViewItemModel{std::move(top_down_view), ui_->topDownTreeView};
+  auto* proxy_model = new QSortFilterProxyModel{ui_->topDownTreeView};
+  proxy_model->setSourceModel(model);
+  proxy_model->setSortRole(Qt::EditRole);
+  ui_->topDownTreeView->setModel(proxy_model);
+  ui_->topDownTreeView->sortByColumn(TopDownViewItemModel::kInclusive,
+                                     Qt::DescendingOrder);
+  for (int column = 0; column < TopDownViewItemModel::kColumnCount; ++column) {
+    ui_->topDownTreeView->resizeColumnToContents(column);
+  }
+}

--- a/OrbitQt/topdownwidget.cpp
+++ b/OrbitQt/topdownwidget.cpp
@@ -4,6 +4,8 @@
 
 #include "topdownwidget.h"
 
+#include <QMenu>
+
 #include "TopDownViewItemModel.h"
 
 void TopDownWidget::SetTopDownView(std::unique_ptr<TopDownView> top_down_view) {
@@ -17,5 +19,64 @@ void TopDownWidget::SetTopDownView(std::unique_ptr<TopDownView> top_down_view) {
                                      Qt::DescendingOrder);
   for (int column = 0; column < TopDownViewItemModel::kColumnCount; ++column) {
     ui_->topDownTreeView->resizeColumnToContents(column);
+  }
+}
+
+const std::string TopDownWidget::kActionExpandAll = "Expand all";
+const std::string TopDownWidget::kActionCollapseAll = "Collapse all";
+
+static void ExpandRecursively(QTreeView* tree_view, const QModelIndex& index) {
+  if (!index.isValid()) {
+    return;
+  }
+  for (int i = 0; i < index.model()->rowCount(index); ++i) {
+    const QModelIndex& child = index.child(i, 0);
+    ExpandRecursively(tree_view, child);
+  }
+  if (!tree_view->isExpanded(index)) {
+    tree_view->expand(index);
+  }
+}
+
+static void CollapseRecursively(QTreeView* tree_view,
+                                const QModelIndex& index) {
+  if (!index.isValid()) {
+    return;
+  }
+  for (int i = 0; i < index.model()->rowCount(index); ++i) {
+    const QModelIndex& child = index.child(i, 0);
+    CollapseRecursively(tree_view, child);
+  }
+  if (tree_view->isExpanded(index)) {
+    tree_view->collapse(index);
+  }
+}
+
+void TopDownWidget::onCustomContextMenuRequested(const QPoint& point) {
+  QModelIndex index = ui_->topDownTreeView->indexAt(point);
+  if (!index.isValid()) {
+    return;
+  }
+  QMenu menu{ui_->topDownTreeView};
+
+  if (index.model()->rowCount(index) > 0) {
+    // Always show "Expand all", as even if the selected node is expanded there
+    // could be subtrees not expanded, but only show "Collapse all" when the
+    // selected node is expanded, as it would otherwise be unintuitive to
+    // collapse subtrees none of which is visible.
+    menu.addAction(kActionExpandAll.c_str());
+    if (ui_->topDownTreeView->isExpanded(index)) {
+      menu.addAction(kActionCollapseAll.c_str());
+    }
+  }
+
+  QAction* action = menu.exec(ui_->topDownTreeView->mapToGlobal(point));
+  if (action == nullptr) {
+    return;
+  }
+  if (action->text().toStdString() == kActionExpandAll) {
+    ExpandRecursively(ui_->topDownTreeView, index);
+  } else if (action->text().toStdString() == kActionCollapseAll) {
+    CollapseRecursively(ui_->topDownTreeView, index);
   }
 }

--- a/OrbitQt/topdownwidget.cpp
+++ b/OrbitQt/topdownwidget.cpp
@@ -17,9 +17,7 @@ void TopDownWidget::SetTopDownView(std::unique_ptr<TopDownView> top_down_view) {
   ui_->topDownTreeView->setModel(proxy_model);
   ui_->topDownTreeView->sortByColumn(TopDownViewItemModel::kInclusive,
                                      Qt::DescendingOrder);
-  for (int column = 0; column < TopDownViewItemModel::kColumnCount; ++column) {
-    ui_->topDownTreeView->resizeColumnToContents(column);
-  }
+  ui_->topDownTreeView->header()->resizeSections(QHeaderView::ResizeToContents);
 }
 
 const std::string TopDownWidget::kActionExpandAll = "&Expand all";

--- a/OrbitQt/topdownwidget.cpp
+++ b/OrbitQt/topdownwidget.cpp
@@ -24,6 +24,8 @@ const std::string TopDownWidget::kActionExpandRecursively =
     "&Expand recursively";
 const std::string TopDownWidget::kActionCollapseRecursively =
     "&Collapse recursively";
+const std::string TopDownWidget::kActionExpandAll = "Expand all";
+const std::string TopDownWidget::kActionCollapseAll = "Collapse all";
 
 static void ExpandRecursively(QTreeView* tree_view, const QModelIndex& index) {
   if (!index.isValid()) {
@@ -49,6 +51,20 @@ static void CollapseRecursively(QTreeView* tree_view,
   }
   if (tree_view->isExpanded(index)) {
     tree_view->collapse(index);
+  }
+}
+
+static void ExpandAll(QTreeView* tree_view) {
+  for (int i = 0; i < tree_view->model()->rowCount(); ++i) {
+    const QModelIndex& child = tree_view->model()->index(i, 0);
+    ExpandRecursively(tree_view, child);
+  }
+}
+
+static void CollapseAll(QTreeView* tree_view) {
+  for (int i = 0; i < tree_view->model()->rowCount(); ++i) {
+    const QModelIndex& child = tree_view->model()->index(i, 0);
+    CollapseRecursively(tree_view, child);
   }
 }
 
@@ -84,10 +100,15 @@ void TopDownWidget::onCustomContextMenuRequested(const QPoint& point) {
   }
 
   QMenu menu{ui_->topDownTreeView};
-  if (enable_expand_recursively)
+  if (enable_expand_recursively){
     menu.addAction(kActionExpandRecursively.c_str());
-  if (enable_collapse_recursively)
+  }
+  if (enable_collapse_recursively){
     menu.addAction(kActionCollapseRecursively.c_str());
+  }
+  menu.addSeparator();
+  menu.addAction(kActionExpandAll.c_str());
+  menu.addAction(kActionCollapseAll.c_str());
 
   QAction* action = menu.exec(ui_->topDownTreeView->mapToGlobal(point));
   if (action == nullptr) {
@@ -102,5 +123,9 @@ void TopDownWidget::onCustomContextMenuRequested(const QPoint& point) {
     for (const QModelIndex& selected_index : selected_tree_indices) {
       CollapseRecursively(ui_->topDownTreeView, selected_index);
     }
+  } else if (action->text().toStdString() == kActionExpandAll) {
+    ExpandAll(ui_->topDownTreeView);
+  } else if (action->text().toStdString() == kActionCollapseAll) {
+    CollapseAll(ui_->topDownTreeView);
   }
 }

--- a/OrbitQt/topdownwidget.cpp
+++ b/OrbitQt/topdownwidget.cpp
@@ -5,6 +5,7 @@
 #include "topdownwidget.h"
 
 #include <QMenu>
+#include <QSortFilterProxyModel>
 
 #include "TopDownViewItemModel.h"
 

--- a/OrbitQt/topdownwidget.cpp
+++ b/OrbitQt/topdownwidget.cpp
@@ -20,8 +20,10 @@ void TopDownWidget::SetTopDownView(std::unique_ptr<TopDownView> top_down_view) {
   ui_->topDownTreeView->header()->resizeSections(QHeaderView::ResizeToContents);
 }
 
-const std::string TopDownWidget::kActionExpandAll = "&Expand all";
-const std::string TopDownWidget::kActionCollapseAll = "&Collapse all";
+const std::string TopDownWidget::kActionExpandRecursively =
+    "&Expand recursively";
+const std::string TopDownWidget::kActionCollapseRecursively =
+    "&Collapse recursively";
 
 static void ExpandRecursively(QTreeView* tree_view, const QModelIndex& index) {
   if (!index.isValid()) {
@@ -65,36 +67,38 @@ void TopDownWidget::onCustomContextMenuRequested(const QPoint& point) {
     selected_tree_indices.push_back(selected_index);
   }
 
-  bool enable_expand_all = false;
-  bool enable_collapse_all = false;
+  bool enable_expand_recursively = false;
+  bool enable_collapse_recursively = false;
   for (const QModelIndex& selected_index : selected_tree_indices) {
     if (selected_index.model()->rowCount(selected_index) > 0) {
       // As long as at least one of the selected nodes has children, always show
-      // "Expand all", as even if the selected node is expanded there could be
-      // subtrees not expanded. But only show "Collapse all" when at least one
-      // selected node is expanded, as it would otherwise be unintuitive to
-      // collapse subtrees none of which is visible.
-      enable_expand_all = true;
+      // "Expand recursively", as even if the selected node is expanded there
+      // could be subtrees not expanded. But only show "Collapse recursively"
+      // when at least one selected node is expanded, as it would otherwise be
+      // unintuitive to collapse subtrees none of which is visible.
+      enable_expand_recursively = true;
       if (ui_->topDownTreeView->isExpanded(selected_index)) {
-        enable_collapse_all = true;
+        enable_collapse_recursively = true;
       }
     }
   }
 
   QMenu menu{ui_->topDownTreeView};
-  if (enable_expand_all) menu.addAction(kActionExpandAll.c_str());
-  if (enable_collapse_all) menu.addAction(kActionCollapseAll.c_str());
+  if (enable_expand_recursively)
+    menu.addAction(kActionExpandRecursively.c_str());
+  if (enable_collapse_recursively)
+    menu.addAction(kActionCollapseRecursively.c_str());
 
   QAction* action = menu.exec(ui_->topDownTreeView->mapToGlobal(point));
   if (action == nullptr) {
     return;
   }
 
-  if (action->text().toStdString() == kActionExpandAll) {
+  if (action->text().toStdString() == kActionExpandRecursively) {
     for (const QModelIndex& selected_index : selected_tree_indices) {
       ExpandRecursively(ui_->topDownTreeView, selected_index);
     }
-  } else if (action->text().toStdString() == kActionCollapseAll) {
+  } else if (action->text().toStdString() == kActionCollapseRecursively) {
     for (const QModelIndex& selected_index : selected_tree_indices) {
       CollapseRecursively(ui_->topDownTreeView, selected_index);
     }

--- a/OrbitQt/topdownwidget.cpp
+++ b/OrbitQt/topdownwidget.cpp
@@ -67,20 +67,6 @@ static void CollapseChildrenRecursively(QTreeView* tree_view,
   }
 }
 
-static void ExpandAll(QTreeView* tree_view) {
-  for (int i = 0; i < tree_view->model()->rowCount(); ++i) {
-    const QModelIndex& child = tree_view->model()->index(i, 0);
-    ExpandRecursively(tree_view, child);
-  }
-}
-
-static void CollapseAll(QTreeView* tree_view) {
-  for (int i = 0; i < tree_view->model()->rowCount(); ++i) {
-    const QModelIndex& child = tree_view->model()->index(i, 0);
-    CollapseRecursively(tree_view, child);
-  }
-}
-
 void TopDownWidget::onCustomContextMenuRequested(const QPoint& point) {
   QModelIndex index = ui_->topDownTreeView->indexAt(point);
   if (!index.isValid()) {
@@ -144,8 +130,8 @@ void TopDownWidget::onCustomContextMenuRequested(const QPoint& point) {
       CollapseChildrenRecursively(ui_->topDownTreeView, selected_index);
     }
   } else if (action->text().toStdString() == kActionExpandAll) {
-    ExpandAll(ui_->topDownTreeView);
+    ui_->topDownTreeView->expandAll();
   } else if (action->text().toStdString() == kActionCollapseAll) {
-    CollapseAll(ui_->topDownTreeView);
+    ui_->topDownTreeView->collapseAll();
   }
 }

--- a/OrbitQt/topdownwidget.cpp
+++ b/OrbitQt/topdownwidget.cpp
@@ -21,14 +21,15 @@ void TopDownWidget::SetTopDownView(std::unique_ptr<TopDownView> top_down_view) {
   ui_->topDownTreeView->header()->resizeSections(QHeaderView::ResizeToContents);
 }
 
-const std::string TopDownWidget::kActionExpandRecursively =
-    "&Expand recursively";
-const std::string TopDownWidget::kActionCollapseRecursively =
-    "&Collapse recursively";
-const std::string TopDownWidget::kActionCollapseChildrenRecursively =
-    "Collapse children recursively";
-const std::string TopDownWidget::kActionExpandAll = "Expand all";
-const std::string TopDownWidget::kActionCollapseAll = "Collapse all";
+const QString TopDownWidget::kActionExpandRecursively =
+    QStringLiteral("&Expand recursively");
+const QString TopDownWidget::kActionCollapseRecursively =
+    QStringLiteral("&Collapse recursively");
+const QString TopDownWidget::kActionCollapseChildrenRecursively =
+    QStringLiteral("Collapse children recursively");
+const QString TopDownWidget::kActionExpandAll = QStringLiteral("Expand all");
+const QString TopDownWidget::kActionCollapseAll =
+    QStringLiteral("Collapse all");
 
 static void ExpandRecursively(QTreeView* tree_view, const QModelIndex& index) {
   if (!index.isValid()) {
@@ -102,37 +103,36 @@ void TopDownWidget::onCustomContextMenuRequested(const QPoint& point) {
 
   QMenu menu{ui_->topDownTreeView};
   if (enable_expand_recursively) {
-    menu.addAction(kActionExpandRecursively.c_str());
+    menu.addAction(kActionExpandRecursively);
   }
   if (enable_collapse_recursively) {
-    menu.addAction(kActionCollapseRecursively.c_str());
-    menu.addAction(kActionCollapseChildrenRecursively.c_str());
+    menu.addAction(kActionCollapseRecursively);
+    menu.addAction(kActionCollapseChildrenRecursively);
   }
   menu.addSeparator();
-  menu.addAction(kActionExpandAll.c_str());
-  menu.addAction(kActionCollapseAll.c_str());
+  menu.addAction(kActionExpandAll);
+  menu.addAction(kActionCollapseAll);
 
   QAction* action = menu.exec(ui_->topDownTreeView->mapToGlobal(point));
   if (action == nullptr) {
     return;
   }
 
-  if (action->text().toStdString() == kActionExpandRecursively) {
+  if (action->text() == kActionExpandRecursively) {
     for (const QModelIndex& selected_index : selected_tree_indices) {
       ExpandRecursively(ui_->topDownTreeView, selected_index);
     }
-  } else if (action->text().toStdString() == kActionCollapseRecursively) {
+  } else if (action->text() == kActionCollapseRecursively) {
     for (const QModelIndex& selected_index : selected_tree_indices) {
       CollapseRecursively(ui_->topDownTreeView, selected_index);
     }
-  } else if (action->text().toStdString() ==
-             kActionCollapseChildrenRecursively) {
+  } else if (action->text() == kActionCollapseChildrenRecursively) {
     for (const QModelIndex& selected_index : selected_tree_indices) {
       CollapseChildrenRecursively(ui_->topDownTreeView, selected_index);
     }
-  } else if (action->text().toStdString() == kActionExpandAll) {
+  } else if (action->text() == kActionExpandAll) {
     ui_->topDownTreeView->expandAll();
-  } else if (action->text().toStdString() == kActionCollapseAll) {
+  } else if (action->text() == kActionCollapseAll) {
     ui_->topDownTreeView->collapseAll();
   }
 }

--- a/OrbitQt/topdownwidget.h
+++ b/OrbitQt/topdownwidget.h
@@ -28,8 +28,8 @@ class TopDownWidget : public QWidget {
   void onCustomContextMenuRequested(const QPoint& point);
 
  private:
-  static const std::string kActionExpandAll;
-  static const std::string kActionCollapseAll;
+  static const std::string kActionExpandRecursively;
+  static const std::string kActionCollapseRecursively;
 
   std::unique_ptr<Ui::TopDownWidget> ui_;
 };

--- a/OrbitQt/topdownwidget.h
+++ b/OrbitQt/topdownwidget.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_QT_TOP_DOWN_WIDGET_H_
+#define ORBIT_QT_TOP_DOWN_WIDGET_H_
+
+#include <QSortFilterProxyModel>
+#include <memory>
+
+#include "TopDownView.h"
+#include "ui_topdownwidget.h"
+
+class TopDownWidget : public QWidget {
+  Q_OBJECT
+
+ public:
+  explicit TopDownWidget(QWidget* parent = nullptr)
+      : QWidget{parent}, ui_{std::make_unique<Ui::TopDownWidget>()} {
+    ui_->setupUi(this);
+  }
+
+  void SetTopDownView(std::unique_ptr<TopDownView> top_down_view);
+
+ private:
+  std::unique_ptr<Ui::TopDownWidget> ui_;
+};
+
+#endif  // ORBIT_QT_TOP_DOWN_WIDGET_H_

--- a/OrbitQt/topdownwidget.h
+++ b/OrbitQt/topdownwidget.h
@@ -18,9 +18,8 @@ class TopDownWidget : public QWidget {
   explicit TopDownWidget(QWidget* parent = nullptr)
       : QWidget{parent}, ui_{std::make_unique<Ui::TopDownWidget>()} {
     ui_->setupUi(this);
-    connect(ui_->topDownTreeView,
-            SIGNAL(customContextMenuRequested(const QPoint&)), this,
-            SLOT(onCustomContextMenuRequested(const QPoint&)));
+    connect(ui_->topDownTreeView, &QTreeView::customContextMenuRequested, this,
+            &TopDownWidget::onCustomContextMenuRequested);
   }
 
   void SetTopDownView(std::unique_ptr<TopDownView> top_down_view);

--- a/OrbitQt/topdownwidget.h
+++ b/OrbitQt/topdownwidget.h
@@ -30,6 +30,7 @@ class TopDownWidget : public QWidget {
  private:
   static const std::string kActionExpandRecursively;
   static const std::string kActionCollapseRecursively;
+  static const std::string kActionCollapseChildrenRecursively;
   static const std::string kActionExpandAll;
   static const std::string kActionCollapseAll;
 

--- a/OrbitQt/topdownwidget.h
+++ b/OrbitQt/topdownwidget.h
@@ -5,7 +5,7 @@
 #ifndef ORBIT_QT_TOP_DOWN_WIDGET_H_
 #define ORBIT_QT_TOP_DOWN_WIDGET_H_
 
-#include <QSortFilterProxyModel>
+#include <QWidget>
 #include <memory>
 
 #include "TopDownView.h"

--- a/OrbitQt/topdownwidget.h
+++ b/OrbitQt/topdownwidget.h
@@ -30,6 +30,8 @@ class TopDownWidget : public QWidget {
  private:
   static const std::string kActionExpandRecursively;
   static const std::string kActionCollapseRecursively;
+  static const std::string kActionExpandAll;
+  static const std::string kActionCollapseAll;
 
   std::unique_ptr<Ui::TopDownWidget> ui_;
 };

--- a/OrbitQt/topdownwidget.h
+++ b/OrbitQt/topdownwidget.h
@@ -18,11 +18,20 @@ class TopDownWidget : public QWidget {
   explicit TopDownWidget(QWidget* parent = nullptr)
       : QWidget{parent}, ui_{std::make_unique<Ui::TopDownWidget>()} {
     ui_->setupUi(this);
+    connect(ui_->topDownTreeView,
+            SIGNAL(customContextMenuRequested(const QPoint&)), this,
+            SLOT(onCustomContextMenuRequested(const QPoint&)));
   }
 
   void SetTopDownView(std::unique_ptr<TopDownView> top_down_view);
 
+ private slots:
+  void onCustomContextMenuRequested(const QPoint& point);
+
  private:
+  static const std::string kActionExpandAll;
+  static const std::string kActionCollapseAll;
+
   std::unique_ptr<Ui::TopDownWidget> ui_;
 };
 

--- a/OrbitQt/topdownwidget.h
+++ b/OrbitQt/topdownwidget.h
@@ -5,6 +5,7 @@
 #ifndef ORBIT_QT_TOP_DOWN_WIDGET_H_
 #define ORBIT_QT_TOP_DOWN_WIDGET_H_
 
+#include <QString>
 #include <QWidget>
 #include <memory>
 
@@ -28,11 +29,11 @@ class TopDownWidget : public QWidget {
   void onCustomContextMenuRequested(const QPoint& point);
 
  private:
-  static const std::string kActionExpandRecursively;
-  static const std::string kActionCollapseRecursively;
-  static const std::string kActionCollapseChildrenRecursively;
-  static const std::string kActionExpandAll;
-  static const std::string kActionCollapseAll;
+  static const QString kActionExpandRecursively;
+  static const QString kActionCollapseRecursively;
+  static const QString kActionCollapseChildrenRecursively;
+  static const QString kActionExpandAll;
+  static const QString kActionCollapseAll;
 
   std::unique_ptr<Ui::TopDownWidget> ui_;
 };

--- a/OrbitQt/topdownwidget.ui
+++ b/OrbitQt/topdownwidget.ui
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TopDownWidget</class>
+ <widget class="QWidget" name="TopDownWidget">
+  <layout class="QGridLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item row="0" column="0">
+    <widget class="QTreeView" name="topDownTreeView">
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/OrbitQt/topdownwidget.ui
+++ b/OrbitQt/topdownwidget.ui
@@ -17,6 +17,9 @@
    </property>
    <item row="0" column="0">
     <widget class="QTreeView" name="topDownTreeView">
+     <property name="contextMenuPolicy">
+      <enum>Qt::CustomContextMenu</enum>
+     </property>
      <property name="alternatingRowColors">
       <bool>true</bool>
      </property>

--- a/OrbitQt/topdownwidget.ui
+++ b/OrbitQt/topdownwidget.ui
@@ -23,6 +23,9 @@
      <property name="alternatingRowColors">
       <bool>true</bool>
      </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::ExtendedSelection</enum>
+     </property>
      <property name="sortingEnabled">
       <bool>true</bool>
      </property>


### PR DESCRIPTION
#### Move topDownView from OrbitMainWindow to new TopDownWidget
#### Add "Expand all", "Collapse all" context menu actions to TopDownWidget
Bug: http://b/162704044
#### Allow multiple selections in TopDownWidget
...and hence multiple nodes to be "expanded all" or "collapsed all" at once.
#### Use Qt 5 signal-slot syntax in TopDownWidget
#### Use header()->resizeSections instead of a loop on resizeColumnToContents
This doesn't change the functionality, only shortens the code.
#### Rename "Expand / Collapse all" to "Expand / Collapse recursively"
"Expand / Collapse all" seems to usually refer to the entire tree.
#### Add "Expand / Collapse all" (the real ones this time) to top-down view
#### Add "Collapse children recursively" to TopDownWidget