### PR TITLE
Fix displaying of function names in the iterator UI overlay

### DIFF
--- a/OrbitGl/LiveFunctionsController.cpp
+++ b/OrbitGl/LiveFunctionsController.cpp
@@ -93,7 +93,7 @@ void LiveFunctionsController::Move() {
         TimeGraph::VisibilityType::kFullyVisible, min_max.first, min_max.second,
         0.5);
   }
-  GCurrentTimeGraph->SetOverlayTextBoxes(current_textboxes_);
+  GCurrentTimeGraph->SetIteratorOverlayData(current_textboxes_, function_iterators_);
 }
 
 bool LiveFunctionsController::OnAllNextButton() {
@@ -101,7 +101,7 @@ bool LiveFunctionsController::OnAllNextButton() {
   uint64_t id_with_min_timestamp = 0;
   uint64_t min_timestamp = std::numeric_limits<uint64_t>::max();
   for (auto it : function_iterators_) {
-    FunctionInfo* function = it.second;
+    const FunctionInfo* function = it.second;
     auto function_address = FunctionUtils::GetAbsoluteAddress(*function);
     const TextBox* current_box = current_textboxes_.find(it.first)->second;
     const TextBox* box = GCurrentTimeGraph->FindNextFunctionCall(
@@ -128,7 +128,7 @@ bool LiveFunctionsController::OnAllPreviousButton() {
   uint64_t id_with_min_timestamp = 0;
   uint64_t min_timestamp = std::numeric_limits<uint64_t>::max();
   for (auto it : function_iterators_) {
-    FunctionInfo* function = it.second;
+    const FunctionInfo* function = it.second;
     auto function_address = FunctionUtils::GetAbsoluteAddress(*function);
     const TextBox* current_box = current_textboxes_.find(it.first)->second;
     const TextBox* box = GCurrentTimeGraph->FindPreviousFunctionCall(
@@ -229,7 +229,7 @@ TickType LiveFunctionsController::GetCaptureMax() {
 void LiveFunctionsController::Reset() {
   function_iterators_.clear();
   current_textboxes_.clear();
-  GCurrentTimeGraph->SetOverlayTextBoxes({});
+  GCurrentTimeGraph->SetIteratorOverlayData({}, {});
   next_iterator_id_ = 0;
   id_to_select_ = 0;
 }

--- a/OrbitGl/LiveFunctionsController.h
+++ b/OrbitGl/LiveFunctionsController.h
@@ -47,7 +47,7 @@ class LiveFunctionsController {
 
   LiveFunctionsDataView live_functions_data_view_;
 
-  absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo*>
+  absl::flat_hash_map<uint64_t, const orbit_client_protos::FunctionInfo*>
       function_iterators_;
   absl::flat_hash_map<uint64_t, const TextBox*> current_textboxes_;
 

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -142,9 +142,11 @@ class TimeGraph {
 
   Color GetThreadColor(ThreadID tid) const;
 
-  void SetOverlayTextBoxes(
-      const absl::flat_hash_map<uint64_t, const TextBox*>& boxes) {
-    overlay_current_textboxes_ = boxes;
+  void SetIteratorOverlayData(
+      const absl::flat_hash_map<uint64_t, const TextBox*>& iterator_text_boxes,
+      const absl::flat_hash_map<uint64_t, const orbit_client_protos::FunctionInfo*>& iterator_functions) {
+    iterator_text_boxes_ = iterator_text_boxes;
+    iterator_functions_ = iterator_functions;
     NeedsRedraw();
   }
 
@@ -164,7 +166,8 @@ class TimeGraph {
   int m_NumDrawnTextBoxes = 0;
 
   // First member is id.
-  absl::flat_hash_map<uint64_t, const TextBox*> overlay_current_textboxes_;
+  absl::flat_hash_map<uint64_t, const TextBox*> iterator_text_boxes_;
+  absl::flat_hash_map<uint64_t, const orbit_client_protos::FunctionInfo*> iterator_functions_;
 
   double m_RefTimeUs = 0;
   double m_MinTimeUs = 0;


### PR DESCRIPTION
When a function was not encountered in any samples, then the (global)
map that we maintain to map function addresses to display names did not
contain that function and the displayed string was incorrect. Whenever
we add an iterator, we insert the function address and display name into
the map now.