### PR TITLE
 Update non-thread-safe data on the main thread

### DIFF
--- a/OrbitCaptureClient/CaptureClient.cpp
+++ b/OrbitCaptureClient/CaptureClient.cpp
@@ -63,12 +63,16 @@ void CaptureClient::Capture(
   LOG("Sent CaptureRequest on Capture's gRPC stream: asking to start "
       "capturing");
 
+  capture_listener_->OnCaptureStarted();
+
   CaptureResponse response;
   while (reader_writer_->Read(&response)) {
     event_processor_->ProcessEvents(response.capture_events());
   }
   LOG("Finished reading from Capture's gRPC stream: all capture data has been "
       "received");
+
+  capture_listener_->OnCaptureComplete();
   FinishCapture();
 }
 

--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
@@ -14,6 +14,12 @@
 class CaptureListener {
  public:
   virtual ~CaptureListener() = default;
+
+  // Called after capture started but before the first event arrived.
+  virtual void OnCaptureStarted() = 0;
+  // Called when capture is complete
+  virtual void OnCaptureComplete() = 0;
+
   virtual void OnTimer(const orbit_client_protos::TimerInfo& timer_info) = 0;
   virtual void OnKeyAndString(uint64_t key, std::string str) = 0;
   virtual void OnCallstack(CallStack callstack) = 0;

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -101,7 +101,6 @@ void Capture::ClearCaptureData() {
   GAddressToModuleName.clear();
   GSelectedTextBox = nullptr;
   GSelectedThreadId = 0;
-  GState = State::kEmpty;
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitCore/SamplingProfiler.cpp
+++ b/OrbitCore/SamplingProfiler.cpp
@@ -69,7 +69,7 @@ std::multimap<int, CallstackID> SamplingProfiler::GetCallstacksFromAddress(
 }
 
 //-----------------------------------------------------------------------------
-void SamplingProfiler::AddCallStack(CallstackEvent& callstack_event) {
+void SamplingProfiler::AddCallStack(CallstackEvent callstack_event) {
   CallstackID hash = callstack_event.callstack_hash();
   if (!HasCallStack(hash)) {
     std::shared_ptr<CallStack> callstack =
@@ -77,14 +77,14 @@ void SamplingProfiler::AddCallStack(CallstackEvent& callstack_event) {
     AddUniqueCallStack(*callstack);
   }
 
-  m_Callstacks.push_back(callstack_event);
+  m_Callstacks.push_back(std::move(callstack_event));
 }
 
 //-----------------------------------------------------------------------------
-void SamplingProfiler::AddUniqueCallStack(CallStack& a_CallStack) {
+void SamplingProfiler::AddUniqueCallStack(CallStack call_stack) {
   absl::MutexLock lock(&unique_callstacks_mutex_);
-  unique_callstacks_[a_CallStack.Hash()] =
-      std::make_shared<CallStack>(a_CallStack);
+  auto key = call_stack.Hash();
+  unique_callstacks_[key] = std::make_shared<CallStack>(std::move(call_stack));
 }
 
 const CallStack& SamplingProfiler::GetResolvedCallstack(

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -71,8 +71,8 @@ class SamplingProfiler {
 
   int GetNumSamples() const { return m_NumSamples; }
 
-  void AddCallStack(orbit_client_protos::CallstackEvent& callstack_event);
-  void AddUniqueCallStack(CallStack& a_CallStack);
+  void AddCallStack(orbit_client_protos::CallstackEvent callstack_event);
+  void AddUniqueCallStack(CallStack call_stack);
 
   std::shared_ptr<CallStack> GetCallStack(CallstackID a_ID) {
     absl::MutexLock lock(&unique_callstacks_mutex_);

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -74,7 +74,6 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void StopCapture();
   void ClearCapture();
   void ToggleDrawHelp();
-  void OnCaptureStopped();
   void ToggleCapture();
   void SetCallStack(std::shared_ptr<CallStack> a_CallStack);
   void LoadFileMapping();
@@ -83,6 +82,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void Disassemble(int32_t pid,
                    const orbit_client_protos::FunctionInfo& function);
 
+  void OnCaptureStarted() override;
+  void OnCaptureComplete() override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
   void OnKeyAndString(uint64_t key, std::string str) override;
   void OnCallstack(CallStack callstack) override;
@@ -302,6 +303,10 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   const SymbolHelper symbol_helper_;
 
   std::unique_ptr<FramePointerValidatorClient> frame_pointer_validator_client_;
+
+  // Temporary objects used by CaptureListener implementation
+  std::unordered_map<uint64_t, orbit_client_protos::LinuxAddressInfo>
+      captured_address_infos_;
 };
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/OrbitGl/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -17,6 +17,9 @@ using orbit_client_protos::LinuxAddressInfo;
 using orbit_client_protos::TimerInfo;
 
 class MyCaptureListener : public CaptureListener {
+ private:
+  void OnCaptureStarted() override {}
+  void OnCaptureComplete() override {}
   void OnTimer(const TimerInfo&) override {}
   void OnKeyAndString(uint64_t, std::string) override {}
   void OnCallstack(CallStack) override {}


### PR DESCRIPTION
    For global maps which are currently used from the main thread
    we should make sure that during capturing they are updated on
    the main thread as well, to avoid undefined behavior.
    
    This change moves updates of capture data to the main thread.
    It also introduces OnCaptureStarted and OnCaptureComplete
    callbacks to the listener.
