### PR TITLE
Fix symbol uploading for OrbitService

### DIFF
--- a/kokoro/gcp_ubuntu_ggp/upload_symbols.sh
+++ b/kokoro/gcp_ubuntu_ggp/upload_symbols.sh
@@ -77,7 +77,7 @@ function upload_debug_symbols {
     mkdir breakpad/symbols
   fi
 
-  upload_symbol_file $bin_folder/OrbitService.debug OrbitService
+  upload_symbol_file $bin_folder/OrbitService OrbitService
 }
 
 upload_debug_symbols $1


### PR DESCRIPTION
We should pass OrbitService to dump_syms tool instead of OrbitService.debug (we use dump_syms to create symbol file in breakpad format).