### PR TITLE
Fixed loading symbols again after fail

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -754,6 +754,9 @@ void OrbitApp::LoadModuleOnRemote(int32_t process_id,
               "Trying to load symbols from remote resulted in error "
               "message: %s",
               module->m_Name, remote_symbols_result.error().message()));
+      main_thread_executor_->Schedule([this, module]() {
+        modules_currently_loading_.erase(module->m_FullName);
+      });
       return;
     }
 


### PR DESCRIPTION
Before this was fixed, clicking the load modules button after a
symbol loading error occured would not do anything. With this fix
subsequent loading attempts are possible.