### PR TITLE
Fix float/double conversions breaking GCC compilation.

### DIFF
--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -395,7 +395,7 @@ void CaptureWindow::MouseWheelMoved(int a_X, int a_Y, int a_Delta,
     time_graph_.ZoomTime(delta, m_MouseRatio);
     m_WheelMomentum = delta * m_WheelMomentum < 0 ? 0 : m_WheelMomentum + delta;
   } else {
-    double mouse_relative_y_position = static_cast<double>(mousey) / getHeight();
+    float mouse_relative_y_position = mousey / getHeight();
     time_graph_.VerticalZoom(delta, mouse_relative_y_position);
   }
 

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -196,16 +196,16 @@ void TimeGraph::ZoomTime(float a_ZoomValue, double a_MouseRatio) {
   SetMinMax(minTimeUs, maxTimeUs);
 }
 
-void TimeGraph::VerticalZoom(float zoom_value, double mouse_relative_position) {
-  static double increment_ratio = 0.1;
+void TimeGraph::VerticalZoom(float zoom_value, float mouse_relative_position) {
+  static float increment_ratio = 0.1f;
 
-  double ratio = zoom_value > 0 ? 1 + increment_ratio : 1 - increment_ratio;
+  float ratio = zoom_value > 0 ? 1 + increment_ratio : 1 - increment_ratio;
 
   float world_height = m_Canvas->GetWorldHeight();
-  double y_mouse_position = m_Canvas->GetWorldTopLeftY() - mouse_relative_position * world_height;
-  double top_distance = m_Canvas->GetWorldTopLeftY() - y_mouse_position;
+  float y_mouse_position = m_Canvas->GetWorldTopLeftY() - mouse_relative_position * world_height;
+  float top_distance = m_Canvas->GetWorldTopLeftY() - y_mouse_position;
 
-  double new_y_mouse_position = y_mouse_position / ratio;
+  float new_y_mouse_position = y_mouse_position / ratio;
 
   float new_world_top_left_y = new_y_mouse_position + top_distance;
 

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -64,7 +64,7 @@ class TimeGraph {
   void Zoom(const TextBox* a_TextBox);
   void Zoom(TickType min, TickType max);
   void ZoomTime(float a_ZoomValue, double a_MouseRatio);
-  void VerticalZoom(float a_ZoomValue, double a_MouseRatio);
+  void VerticalZoom(float a_ZoomValue, float a_MouseRatio);
   void SetMinMax(double a_MinTimeUs, double a_MaxTimeUs);
   void PanTime(int a_InitialX, int a_CurrentX, int a_Width,
                double a_InitialTime);


### PR DESCRIPTION
Build was broken with GCC:

/home/pierric/git/orbit/OrbitGl/CaptureWindow.cpp: In member function ‘virtual void CaptureWindow::MouseWheelMoved(int, int, int, bool)’:
/home/pierric/git/orbit/OrbitGl/CaptureWindow.cpp:399:37: error: conversion from ‘double’ to ‘float’ may change value [-Werror=float-conversion]
  399 |     time_graph_.VerticalZoom(delta, mouse_relative_y_position);
      |                                     ^~~~~~~~~~~~~~~~~~~~~~~~~
