### PR TITLE
Add "searching" to the top-down view

### DIFF
--- a/OrbitQt/topdownwidget.cpp
+++ b/OrbitQt/topdownwidget.cpp
@@ -15,10 +15,18 @@ void TopDownWidget::SetTopDownView(std::unique_ptr<TopDownView> top_down_view) {
   auto* proxy_model = new QSortFilterProxyModel{ui_->topDownTreeView};
   proxy_model->setSourceModel(model);
   proxy_model->setSortRole(Qt::EditRole);
+
+  proxy_model->setFilterRole(Qt::DisplayRole);
+  proxy_model->setFilterKeyColumn(TopDownViewItemModel::kThreadOrFunction);
+  proxy_model->setFilterCaseSensitivity(Qt::CaseInsensitive);
+  proxy_model->setRecursiveFilteringEnabled(true);
+
   ui_->topDownTreeView->setModel(proxy_model);
   ui_->topDownTreeView->sortByColumn(TopDownViewItemModel::kInclusive,
                                      Qt::DescendingOrder);
   ui_->topDownTreeView->header()->resizeSections(QHeaderView::ResizeToContents);
+
+  on_searchLineEdit_textEdited(ui_->searchLineEdit->text());
 }
 
 const QString TopDownWidget::kActionExpandRecursively =
@@ -66,6 +74,31 @@ static void CollapseChildrenRecursively(QTreeView* tree_view,
   for (int i = 0; i < index.model()->rowCount(index); ++i) {
     const QModelIndex& child = index.child(i, 0);
     CollapseRecursively(tree_view, child);
+  }
+}
+
+static void ExpandRecursivelyButCollapseLeaves(QTreeView* tree_view,
+                                               const QModelIndex& index) {
+  if (!index.isValid()) {
+    return;
+  }
+  if (index.model()->rowCount(index) == 0) {
+    tree_view->collapse(index);
+    return;
+  }
+  for (int i = 0; i < index.model()->rowCount(index); ++i) {
+    const QModelIndex& child = index.child(i, 0);
+    ExpandRecursivelyButCollapseLeaves(tree_view, child);
+  }
+  if (!tree_view->isExpanded(index)) {
+    tree_view->expand(index);
+  }
+}
+
+static void ExpandAllButCollapseLeaves(QTreeView* tree_view) {
+  for (int i = 0; i < tree_view->model()->rowCount(); ++i) {
+    const QModelIndex& child = tree_view->model()->index(i, 0);
+    ExpandRecursivelyButCollapseLeaves(tree_view, child);
   }
 }
 
@@ -135,4 +168,27 @@ void TopDownWidget::onCustomContextMenuRequested(const QPoint& point) {
   } else if (action->text() == kActionCollapseAll) {
     ui_->topDownTreeView->collapseAll();
   }
+}
+
+void TopDownWidget::on_searchLineEdit_textEdited(const QString& text) {
+  if (text.isEmpty()) {
+    return;
+  }
+  auto* proxy_model =
+      dynamic_cast<QSortFilterProxyModel*>(ui_->topDownTreeView->model());
+  if (proxy_model == nullptr) {
+    return;
+  }
+  // Don't actually hide any node, but expand up to the parents of the matching
+  // nodes (so that the matching nodes are shown) and collapse everything else.
+  // To do this easily, set a filter on the QTreeView, which actually hides and
+  // as a result collapses all the non-matching nodes. Then expand everything
+  // that is still visible, but collapse leaves (note that a leaf being expanded
+  // has no visual effect while the filter is in place, but those nodes would
+  // retain the expanded state when the filter is removed). Finally, remove the
+  // filter. The initial collapseAll greatly helps filtering performance.
+  ui_->topDownTreeView->collapseAll();
+  proxy_model->setFilterFixedString(text);
+  ExpandAllButCollapseLeaves(ui_->topDownTreeView);
+  proxy_model->setFilterFixedString(QStringLiteral(""));
 }

--- a/OrbitQt/topdownwidget.h
+++ b/OrbitQt/topdownwidget.h
@@ -27,6 +27,7 @@ class TopDownWidget : public QWidget {
 
  private slots:
   void onCustomContextMenuRequested(const QPoint& point);
+  void on_searchLineEdit_textEdited(const QString& text);
 
  private:
   static const QString kActionExpandRecursively;

--- a/OrbitQt/topdownwidget.h
+++ b/OrbitQt/topdownwidget.h
@@ -5,11 +5,13 @@
 #ifndef ORBIT_QT_TOP_DOWN_WIDGET_H_
 #define ORBIT_QT_TOP_DOWN_WIDGET_H_
 
+#include <QSortFilterProxyModel>
 #include <QString>
 #include <QWidget>
 #include <memory>
 
 #include "TopDownView.h"
+#include "absl/container/flat_hash_set.h"
 #include "ui_topdownwidget.h"
 
 class TopDownWidget : public QWidget {
@@ -36,7 +38,34 @@ class TopDownWidget : public QWidget {
   static const QString kActionExpandAll;
   static const QString kActionCollapseAll;
 
+  class HighlightingSortFilterProxyModel : public QSortFilterProxyModel {
+   public:
+    explicit HighlightingSortFilterProxyModel(QObject* parent)
+        : QSortFilterProxyModel{parent} {}
+
+    // Specify a set where this ProxyModel should put internalPointers of
+    // indices that match the current filter.
+    void SetFilterAcceptedNodeCollectorSet(
+        absl::flat_hash_set<void*>* filter_accepted_nodes_collector);
+
+    // Specify a set of internalPointers whose indices should be highlighted.
+    void SetNodesToHighlightSet(
+        std::unique_ptr<absl::flat_hash_set<void*>> nodes_to_highlight);
+
+    QVariant data(const QModelIndex& index, int role) const override;
+
+   protected:
+    bool filterAcceptsRow(int source_row,
+                          const QModelIndex& source_parent) const override;
+
+   private:
+    mutable absl::flat_hash_set<void*>* filter_accepted_nodes_collector_ =
+        nullptr;
+    std::unique_ptr<absl::flat_hash_set<void*>> nodes_to_highlight_ = nullptr;
+  };
+
   std::unique_ptr<Ui::TopDownWidget> ui_;
+  HighlightingSortFilterProxyModel* proxy_model_ = nullptr;
 };
 
 #endif  // ORBIT_QT_TOP_DOWN_WIDGET_H_

--- a/OrbitQt/topdownwidget.ui
+++ b/OrbitQt/topdownwidget.ui
@@ -18,7 +18,7 @@
    <item row="0" column="0">
     <widget class="QLineEdit" name="searchLineEdit">
      <property name="placeholderText">
-      <string>search</string>
+      <string>search  (invalidates changes made to the top-down tree)</string>
      </property>
     </widget>
    </item>

--- a/OrbitQt/topdownwidget.ui
+++ b/OrbitQt/topdownwidget.ui
@@ -18,7 +18,7 @@
    <item row="0" column="0">
     <widget class="QLineEdit" name="searchLineEdit">
      <property name="placeholderText">
-      <string>search  (invalidates changes made to the top-down tree)</string>
+      <string>search  (invalidates the expanded/collapsed state of all nodes in the tree)</string>
      </property>
     </widget>
    </item>

--- a/OrbitQt/topdownwidget.ui
+++ b/OrbitQt/topdownwidget.ui
@@ -16,6 +16,13 @@
     <number>0</number>
    </property>
    <item row="0" column="0">
+    <widget class="QLineEdit" name="searchLineEdit">
+     <property name="placeholderText">
+      <string>search</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
     <widget class="QTreeView" name="topDownTreeView">
      <property name="contextMenuPolicy">
       <enum>Qt::CustomContextMenu</enum>


### PR DESCRIPTION
This builds on the assumption that I don't want to actually hide (i.e., filter
out) entire subtrees if the filter is not matched—I find that confusing.
Instead, I want to expand enough so that the matching nodes are visible, but
collapse everything else. See this as a search functionality rather than a
filter functionality.

---

Let me know it this can make sense.