### PR TITLE
use SelectedInCaptureFunctions in Live tab and when saving the capture

### DIFF
--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
@@ -23,10 +23,9 @@ class CaptureClient {
     CHECK(capture_listener_ != nullptr);
   }
 
-  void Capture(
-      int32_t pid,
-      const std::vector<std::shared_ptr<orbit_client_protos::FunctionInfo>>&
-          selected_functions);
+  void Capture(int32_t pid,
+               const std::map<uint64_t, orbit_client_protos::FunctionInfo*>&
+                   selected_functions);
   void StopCapture();
 
  private:

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -43,7 +43,7 @@ std::string Capture::GPresetToLoad;
 std::string Capture::GProcessToInject;
 std::string Capture::GFunctionFilter;
 
-std::vector<std::shared_ptr<FunctionInfo>> Capture::GSelectedFunctions;
+std::vector<std::shared_ptr<FunctionInfo>> Capture::GSelectedInCaptureFunctions;
 std::map<uint64_t, FunctionInfo*> Capture::GSelectedFunctionsMap;
 std::map<uint64_t, FunctionInfo*> Capture::GVisibleFunctionsMap;
 std::unordered_map<uint64_t, uint64_t> Capture::GFunctionCountMap;
@@ -148,9 +148,9 @@ void Capture::ClearCaptureData() {
 
 //-----------------------------------------------------------------------------
 void Capture::PreFunctionHooks() {
-  GSelectedFunctions = GetSelectedFunctions();
+  GSelectedInCaptureFunctions = GetSelectedFunctions();
 
-  for (auto& func : GSelectedFunctions) {
+  for (auto& func : GSelectedInCaptureFunctions) {
     uint64_t address = FunctionUtils::GetAbsoluteAddress(*func);
     GSelectedFunctionsMap[address] = func.get();
     func->clear_stats();

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -67,7 +67,7 @@ class Capture {
   static std::shared_ptr<CallStack> GSelectedCallstack;
   static void (*GClearCaptureDataFunc)();
   static std::vector<std::shared_ptr<orbit_client_protos::FunctionInfo>>
-      GSelectedFunctions;
+      GSelectedInCaptureFunctions;
   static std::map<uint64_t, orbit_client_protos::FunctionInfo*>
       GSelectedFunctionsMap;
   static std::map<uint64_t, orbit_client_protos::FunctionInfo*>

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -584,8 +584,8 @@ bool OrbitApp::StartCapture() {
   }
 
   int32_t pid = Capture::GProcessId;
-  std::vector<std::shared_ptr<FunctionInfo>> selected_functions =
-      Capture::GSelectedFunctions;
+  std::map<uint64_t, FunctionInfo*> selected_functions =
+      Capture::GSelectedFunctionsMap;
   thread_pool_->Schedule([this, pid, selected_functions] {
     capture_client_->Capture(pid, selected_functions);
     main_thread_executor_->Schedule([this] { OnCaptureStopped(); });

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -185,15 +185,15 @@ void CallStackDataView::DoFilter() {
     }
   }
 
-  m_Indices = indices;
+  indices_ = indices;
 }
 
 //-----------------------------------------------------------------------------
 void CallStackDataView::OnDataChanged() {
   size_t numFunctions = m_CallStack ? m_CallStack->m_Data.size() : 0;
-  m_Indices.resize(numFunctions);
+  indices_.resize(numFunctions);
   for (size_t i = 0; i < numFunctions; ++i) {
-    m_Indices[i] = i;
+    indices_[i] = i;
   }
 
   DataView::OnDataChanged();
@@ -202,7 +202,7 @@ void CallStackDataView::OnDataChanged() {
 //-----------------------------------------------------------------------------
 CallStackDataView::CallStackDataViewFrame CallStackDataView::GetFrameFromRow(
     int row) {
-  return GetFrameFromIndex(m_Indices[row]);
+  return GetFrameFromIndex(indices_[row]);
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -61,10 +61,9 @@ void WriteMessage(const google::protobuf::Message* message,
 }
 
 void CaptureSerializer::FillCaptureData(CaptureInfo* capture_info) {
-  for (auto& pair : Capture::GSelectedFunctionsMap) {
-    FunctionInfo* func = pair.second;
-    if (func != nullptr) {
-      capture_info->add_selected_functions()->CopyFrom(*func);
+  for (const auto& function : Capture::GSelectedInCaptureFunctions) {
+    if (function != nullptr) {
+      capture_info->add_selected_functions()->CopyFrom(*function);
     }
   }
 
@@ -183,12 +182,12 @@ void FillEventBuffer() {
 
 void CaptureSerializer::ProcessCaptureData(const CaptureInfo& capture_info) {
   // Functions
-  Capture::GSelectedFunctions.clear();
+  Capture::GSelectedInCaptureFunctions.clear();
   Capture::GSelectedFunctionsMap.clear();
   for (const auto& function : capture_info.selected_functions()) {
     std::shared_ptr<FunctionInfo> function_ptr =
         std::make_shared<FunctionInfo>(function);
-    Capture::GSelectedFunctions.push_back(function_ptr);
+    Capture::GSelectedInCaptureFunctions.push_back(function_ptr);
     Capture::GSelectedFunctionsMap[FunctionUtils::GetAbsoluteAddress(
         *function_ptr)] = function_ptr.get();
   }

--- a/OrbitGl/DataView.h
+++ b/OrbitGl/DataView.h
@@ -44,7 +44,7 @@ class DataView {
   virtual int GetDefaultSortingColumn() { return 0; }
   virtual std::vector<std::string> GetContextMenu(
       int a_ClickedIndex, const std::vector<int>& a_SelectedIndices);
-  virtual size_t GetNumElements() { return m_Indices.size(); }
+  virtual size_t GetNumElements() { return indices_.size(); }
   virtual std::string GetValue(int /*a_Row*/, int /*a_Column*/) { return ""; }
   virtual std::string GetToolTip(int /*a_Row*/, int /*a_Column*/) { return ""; }
 
@@ -91,7 +91,7 @@ class DataView {
   virtual void DoFilter() {}
   FilterCallback filter_callback_;
 
-  std::vector<uint32_t> m_Indices;
+  std::vector<uint32_t> indices_;
   std::vector<SortingOrder> m_SortingOrders;
   int m_SortingColumn = 0;
   std::string m_Filter;

--- a/OrbitGl/FunctionsDataView.cpp
+++ b/OrbitGl/FunctionsDataView.cpp
@@ -122,7 +122,7 @@ void FunctionsDataView::DoSort() {
   }
 
   if (sorter) {
-    std::stable_sort(m_Indices.begin(), m_Indices.end(), sorter);
+    std::stable_sort(indices_.begin(), indices_.end(), sorter);
   }
 }
 
@@ -210,7 +210,7 @@ void FunctionsDataView::DoFilter() {
     }
   }
 
-  m_Indices = indices;
+  indices_ = indices;
 
   OnSort(m_SortingColumn, {});
 #endif
@@ -252,9 +252,9 @@ void FunctionsDataView::ParallelFilter() {
     }
   }
 
-  m_Indices.clear();
+  indices_.clear();
   for (int i : indicesSet) {
-    m_Indices.push_back(i);
+    indices_.push_back(i);
   }
 #endif
 }
@@ -264,9 +264,9 @@ void FunctionsDataView::OnDataChanged() {
   ScopeLock lock(Capture::GTargetProcess->GetDataMutex());
 
   size_t numFunctions = Capture::GTargetProcess->GetFunctions().size();
-  m_Indices.resize(numFunctions);
+  indices_.resize(numFunctions);
   for (size_t i = 0; i < numFunctions; ++i) {
-    m_Indices[i] = i;
+    indices_[i] = i;
   }
 
   DataView::OnDataChanged();
@@ -277,5 +277,5 @@ FunctionInfo& FunctionsDataView::GetFunction(int a_Row) const {
   ScopeLock lock(Capture::GTargetProcess->GetDataMutex());
   const std::vector<std::shared_ptr<FunctionInfo>>& functions =
       Capture::GTargetProcess->GetFunctions();
-  return *functions[m_Indices[a_Row]];
+  return *functions[indices_[a_Row]];
 }

--- a/OrbitGl/LiveFunctionsDataView.h
+++ b/OrbitGl/LiveFunctionsDataView.h
@@ -34,7 +34,7 @@ class LiveFunctionsDataView : public DataView {
   std::pair<TextBox*, TextBox*> GetMinMax(
       const orbit_client_protos::FunctionInfo& function) const;
 
-  std::vector<orbit_client_protos::FunctionInfo*> m_Functions;
+  std::vector<std::shared_ptr<orbit_client_protos::FunctionInfo>> functions_;
 
   LiveFunctionsController* live_functions_;
 

--- a/OrbitGl/ModulesDataView.cpp
+++ b/OrbitGl/ModulesDataView.cpp
@@ -81,7 +81,7 @@ void ModulesDataView::DoSort() {
   }
 
   if (sorter) {
-    std::stable_sort(m_Indices.begin(), m_Indices.end(), sorter);
+    std::stable_sort(indices_.begin(), indices_.end(), sorter);
   }
 }
 
@@ -168,7 +168,7 @@ void ModulesDataView::DoFilter() {
     }
   }
 
-  m_Indices = indices;
+  indices_ = indices;
 
   OnSort(m_SortingColumn, {});
 }
@@ -178,9 +178,9 @@ void ModulesDataView::SetModules(int32_t process_id,
   process_id_ = process_id;
   modules_ = modules;
 
-  m_Indices.resize(modules_.size());
-  for (size_t i = 0; i < m_Indices.size(); ++i) {
-    m_Indices[i] = i;
+  indices_.resize(modules_.size());
+  for (size_t i = 0; i < indices_.size(); ++i) {
+    indices_[i] = i;
   }
 
   OnDataChanged();
@@ -191,7 +191,7 @@ void ModulesDataView::OnRefreshButtonClicked() {
 }
 
 const ModuleData* ModulesDataView::GetModule(uint32_t row) const {
-  return modules_[m_Indices[row]];
+  return modules_[indices_[row]];
 }
 
 bool ModulesDataView::GetDisplayColor(int row, int /*column*/,

--- a/OrbitGl/PresetsDataView.cpp
+++ b/OrbitGl/PresetsDataView.cpp
@@ -78,7 +78,7 @@ void PresetsDataView::DoSort() {
   }
 
   if (sorter) {
-    std::stable_sort(m_Indices.begin(), m_Indices.end(), sorter);
+    std::stable_sort(indices_.begin(), indices_.end(), sorter);
   }
 }
 
@@ -119,7 +119,7 @@ void PresetsDataView::OnContextMenu(const std::string& a_Action,
     const std::string& filename = preset->file_name();
     int ret = remove(filename.c_str());
     if (ret == 0) {
-      presets_.erase(presets_.begin() + m_Indices[row]);
+      presets_.erase(presets_.begin() + indices_[row]);
       OnDataChanged();
     } else {
       ERROR("Deleting preset \"%s\": %s", filename, SafeStrerror(errno));
@@ -159,16 +159,16 @@ void PresetsDataView::DoFilter() {
     }
   }
 
-  m_Indices = indices;
+  indices_ = indices;
 
   OnSort(m_SortingColumn, {});
 }
 
 //-----------------------------------------------------------------------------
 void PresetsDataView::OnDataChanged() {
-  m_Indices.resize(presets_.size());
+  indices_.resize(presets_.size());
   for (size_t i = 0; i < presets_.size(); ++i) {
-    m_Indices[i] = i;
+    indices_[i] = i;
   }
 
   DataView::OnDataChanged();
@@ -184,5 +184,5 @@ void PresetsDataView::SetPresets(
 //-----------------------------------------------------------------------------
 const std::shared_ptr<PresetFile>& PresetsDataView::GetPreset(
     unsigned int a_Row) const {
-  return presets_[m_Indices[a_Row]];
+  return presets_[indices_[a_Row]];
 }

--- a/OrbitGl/ProcessesDataView.cpp
+++ b/OrbitGl/ProcessesDataView.cpp
@@ -74,7 +74,7 @@ void ProcessesDataView::DoSort() {
   }
 
   if (sorter) {
-    std::stable_sort(m_Indices.begin(), m_Indices.end(), sorter);
+    std::stable_sort(indices_.begin(), indices_.end(), sorter);
   }
 
   SetSelectedItem();
@@ -98,10 +98,10 @@ int32_t ProcessesDataView::GetSelectedProcessId() const {
 }
 
 int32_t ProcessesDataView::GetFirstProcessId() const {
-  if (m_Indices.empty()) {
+  if (indices_.empty()) {
     return -1;
   }
-  return process_list_[m_Indices[0]].pid();
+  return process_list_[indices_[0]].pid();
 }
 
 //-----------------------------------------------------------------------------
@@ -172,7 +172,7 @@ void ProcessesDataView::DoFilter() {
     }
   }
 
-  m_Indices = indices;
+  indices_ = indices;
 
   OnSort(m_SortingColumn, {});
 }
@@ -180,9 +180,9 @@ void ProcessesDataView::DoFilter() {
 //-----------------------------------------------------------------------------
 void ProcessesDataView::UpdateProcessList() {
   size_t numProcesses = process_list_.size();
-  m_Indices.resize(numProcesses);
+  indices_.resize(numProcesses);
   for (size_t i = 0; i < numProcesses; ++i) {
-    m_Indices[i] = i;
+    indices_[i] = i;
   }
 }
 
@@ -197,7 +197,7 @@ void ProcessesDataView::SetProcessList(
 }
 
 const ProcessInfo& ProcessesDataView::GetProcess(uint32_t row) const {
-  return process_list_[m_Indices[row]];
+  return process_list_[indices_[row]];
 }
 
 void ProcessesDataView::SetSelectionListener(

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -117,7 +117,7 @@ void SamplingReportDataView::DoSort() {
   }
 
   if (sorter) {
-    std::stable_sort(m_Indices.begin(), m_Indices.end(), sorter);
+    std::stable_sort(indices_.begin(), indices_.end(), sorter);
   }
 }
 
@@ -257,9 +257,9 @@ void SamplingReportDataView::SetSampledFunctions(
   m_Functions = a_Functions;
 
   size_t numFunctions = m_Functions.size();
-  m_Indices.resize(numFunctions);
+  indices_.resize(numFunctions);
   for (size_t i = 0; i < numFunctions; ++i) {
-    m_Indices[i] = i;
+    indices_[i] = i;
   }
 
   OnDataChanged();
@@ -301,7 +301,7 @@ void SamplingReportDataView::DoFilter() {
     }
   }
 
-  m_Indices = indices;
+  indices_ = indices;
 
   OnSort(m_SortingColumn, {});
 }
@@ -309,11 +309,11 @@ void SamplingReportDataView::DoFilter() {
 //-----------------------------------------------------------------------------
 const SampledFunction& SamplingReportDataView::GetSampledFunction(
     unsigned int a_Row) const {
-  return m_Functions[m_Indices[a_Row]];
+  return m_Functions[indices_[a_Row]];
 }
 
 //-----------------------------------------------------------------------------
 SampledFunction& SamplingReportDataView::GetSampledFunction(
     unsigned int a_Row) {
-  return m_Functions[m_Indices[a_Row]];
+  return m_Functions[indices_[a_Row]];
 }


### PR DESCRIPTION
Fix for http://b/163014195

Introduce `Capture::GSelectedInCaptureFunctions` to store the functions that were hooked in the capture, and show these functions on the "live" tab and when saving capture.

If we want to refer to currently hooked functions we should use `GSelectedFunctionsMap`.