### PR TITLE
[REBASE] Fix "Narrowing conversion from 'double' to 'float'" warning. ()

### DIFF
--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -376,13 +376,11 @@ void CaptureWindow::MouseWheelMoved(int a_X, int a_Y, int a_Delta,
   if (a_Delta == 0) return;
 
   // Normalize and invert sign, so that delta < 0 is zoom in.
-  int delta = a_Delta < 0 ? 1 : -1;
+  const int delta = a_Delta < 0 ? 1 : -1;
+  const auto delta_float = static_cast<float>(delta);
 
   if (delta < m_MinWheelDelta) m_MinWheelDelta = delta;
   if (delta > m_MaxWheelDelta) m_MaxWheelDelta = delta;
-
-  float mousex = a_X;
-  float mousey = a_Y;
 
   float worldx;
   float worldy;
@@ -391,12 +389,14 @@ void CaptureWindow::MouseWheelMoved(int a_X, int a_Y, int a_Delta,
 
   bool zoomWidth = !a_Ctrl;
   if (zoomWidth) {
-    m_MouseRatio = static_cast<double>(mousex) / getWidth();
-    time_graph_.ZoomTime(delta, m_MouseRatio);
-    m_WheelMomentum = delta * m_WheelMomentum < 0 ? 0 : m_WheelMomentum + delta;
+    m_MouseRatio = static_cast<double>(a_X) / getWidth();
+    time_graph_.ZoomTime(delta_float, m_MouseRatio);
+    m_WheelMomentum =
+        delta_float * m_WheelMomentum < 0 ? 0 : m_WheelMomentum + delta_float;
   } else {
-    float mouse_relative_y_position = mousey / getHeight();
-    time_graph_.VerticalZoom(delta, mouse_relative_y_position);
+    float mouse_relative_y_position =
+        static_cast<float>(a_Y) / static_cast<float>(getHeight());
+    time_graph_.VerticalZoom(delta_float, mouse_relative_y_position);
   }
 
   // Use the original sign of a_Delta here.

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -197,15 +197,17 @@ void TimeGraph::ZoomTime(float a_ZoomValue, double a_MouseRatio) {
 }
 
 void TimeGraph::VerticalZoom(float zoom_value, float mouse_relative_position) {
-  static float increment_ratio = 0.1f;
+  constexpr float increment_ratio = 0.1f;
 
-  float ratio = zoom_value > 0 ? 1 + increment_ratio : 1 - increment_ratio;
+  const float ratio =
+      zoom_value > 0 ? 1 + increment_ratio : 1 - increment_ratio;
 
-  float world_height = m_Canvas->GetWorldHeight();
-  float y_mouse_position = m_Canvas->GetWorldTopLeftY() - mouse_relative_position * world_height;
-  float top_distance = m_Canvas->GetWorldTopLeftY() - y_mouse_position;
+  const float world_height = m_Canvas->GetWorldHeight();
+  const float y_mouse_position =
+      m_Canvas->GetWorldTopLeftY() - mouse_relative_position * world_height;
+  const float top_distance = m_Canvas->GetWorldTopLeftY() - y_mouse_position;
 
-  float new_y_mouse_position = y_mouse_position / ratio;
+  const float new_y_mouse_position = y_mouse_position / ratio;
 
   float new_world_top_left_y = new_y_mouse_position + top_distance;
 
@@ -220,7 +222,7 @@ void TimeGraph::VerticalZoom(float zoom_value, float mouse_relative_position) {
   m_Canvas->SetWorldTopLeftY(new_world_top_left_y);
 
   // Finally, we have to scale every item in the layout.
-  float old_scale = m_Layout.GetScale();
+  const float old_scale = m_Layout.GetScale();
   m_Layout.SetScale(old_scale / ratio);
 }
 
@@ -261,7 +263,8 @@ void TimeGraph::HorizontallyMoveIntoView(VisibilityType vis_type, TickType min,
 
   double CurrentTimeWindowUs = m_MaxTimeUs - m_MinTimeUs;
 
-  if (vis_type == VisibilityType::kFullyVisible && CurrentTimeWindowUs < (end - start)) {
+  if (vis_type == VisibilityType::kFullyVisible &&
+      CurrentTimeWindowUs < (end - start)) {
     Zoom(min, max);
     return;
   }
@@ -293,10 +296,12 @@ void TimeGraph::VerticallyMoveIntoView(const TextBox* text_box) {
   auto text_box_y_position = thread_track->GetYFromDepth(timer_info.depth());
 
   float world_top_left_y = m_Canvas->GetWorldTopLeftY();
-  float min_world_top_left_y = 
-      text_box_y_position + m_Layout.GetSpaceBetweenTracks() + m_Layout.GetTopMargin();
-  float max_world_top_left_y = text_box_y_position + m_Canvas->GetWorldHeight() - 
-                              GetTextBoxHeight() - m_Layout.GetBottomMargin();
+  float min_world_top_left_y = text_box_y_position +
+                               m_Layout.GetSpaceBetweenTracks() +
+                               m_Layout.GetTopMargin();
+  float max_world_top_left_y = text_box_y_position +
+                               m_Canvas->GetWorldHeight() - GetTextBoxHeight() -
+                               m_Layout.GetBottomMargin();
   CHECK(min_world_top_left_y <= max_world_top_left_y);
   world_top_left_y = std::min(world_top_left_y, max_world_top_left_y);
   world_top_left_y = std::max(world_top_left_y, min_world_top_left_y);
@@ -626,8 +631,8 @@ void TimeGraph::Draw(GlCanvas* canvas, PickingMode picking_mode) {
 
 namespace {
 
-[[nodiscard]] std::string GetLabelBetweenIterators(const FunctionInfo& function_a,
-                                     const FunctionInfo& function_b) {
+[[nodiscard]] std::string GetLabelBetweenIterators(
+    const FunctionInfo& function_a, const FunctionInfo& function_b) {
   std::string function_from = FunctionUtils::GetDisplayName(function_a);
   std::string function_to = FunctionUtils::GetDisplayName(function_b);
   return absl::StrFormat("%s to %s", function_from, function_to);
@@ -675,15 +680,14 @@ void DrawIteratorBox(GlCanvas* canvas, Vec2 pos, Vec2 size, const Color& color,
 }  // namespace
 
 void TimeGraph::DrawOverlay(GlCanvas* canvas, PickingMode picking_mode) {
-  if (picking_mode != PickingMode::kNone || 
-      iterator_text_boxes_.size() == 0) {
+  if (picking_mode != PickingMode::kNone || iterator_text_boxes_.size() == 0) {
     return;
   }
 
   std::vector<std::pair<uint64_t, const TextBox*>> boxes(
       iterator_text_boxes_.size());
-  std::copy(iterator_text_boxes_.begin(),
-            iterator_text_boxes_.end(), boxes.begin());
+  std::copy(iterator_text_boxes_.begin(), iterator_text_boxes_.end(),
+            boxes.begin());
 
   // Sort boxes by start time.
   std::sort(boxes.begin(), boxes.end(),
@@ -734,8 +738,8 @@ void TimeGraph::DrawOverlay(GlCanvas* canvas, PickingMode picking_mode) {
     uint64_t id_b = boxes[k].first;
     CHECK(iterator_functions_.find(id_a) != iterator_functions_.end());
     CHECK(iterator_functions_.find(id_b) != iterator_functions_.end());
-    const std::string& label =
-        GetLabelBetweenIterators(*(iterator_functions_[id_a]), *(iterator_functions_[id_b]));
+    const std::string& label = GetLabelBetweenIterators(
+        *(iterator_functions_[id_a]), *(iterator_functions_[id_b]));
     const std::string& time =
         GetTimeString(boxes[k - 1].second, boxes[k].second);
 
@@ -746,9 +750,8 @@ void TimeGraph::DrawOverlay(GlCanvas* canvas, PickingMode picking_mode) {
     // at pos[1] + bottom_margin (lowest possible position) and the height of
     // the box showing the overall time (see below) is at pos[1] + (world_height
     // / 2.f), corresponding to the case k == 0 in the formula for 'text_y'.
-    float height_per_text =
-        ((world_height / 2.f) - bottom_margin) /
-        static_cast<float>(iterator_text_boxes_.size() - 1);
+    float height_per_text = ((world_height / 2.f) - bottom_margin) /
+                            static_cast<float>(iterator_text_boxes_.size() - 1);
     float text_y =
         pos[1] + (world_height / 2.f) - static_cast<float>(k) * height_per_text;
 
@@ -1067,7 +1070,8 @@ bool TimeGraph::IsPartlyVisible(TickType min, TickType max) const {
   return true;
 }
 
-bool TimeGraph::IsVisible(VisibilityType vis_type, TickType min, TickType max) const {
+bool TimeGraph::IsVisible(VisibilityType vis_type, TickType min,
+                          TickType max) const {
   switch (vis_type) {
     case VisibilityType::kPartlyVisible:
       return IsPartlyVisible(min, max);


### PR DESCRIPTION
Rebases #915. As the main issue was already solved, this basically adds some `const` and does reformatting. 

Original message:
Fix "Narrowing conversion from 'double' to 'float'" warning, which prevented clang from compilation.
To fix the warning, the doubles were changed to float. The precision lost should be fine, as the actual values (coming in as params) were already floats.
Also applied clang-format to the changed files and added const keyword in touched functions.