### PR TITLE
[Rebase; already on release] Fix Path::FileExist bug

### DIFF
--- a/OrbitCore/LinuxUtils.cpp
+++ b/OrbitCore/LinuxUtils.cpp
@@ -118,7 +118,7 @@ ErrorMessageOr<std::vector<ModuleInfo>> ListModules(int32_t pid) {
   for (const auto& [module_path, address_range] : address_map) {
     // Filter out entries which are not executable
     if (!address_range.is_executable) continue;
-    if (!Path::FileExists(module_path)) continue;
+    if (!std::filesystem::exists(module_path)) continue;
     uint64_t file_size = Path::FileSize(module_path);
     if (file_size == 0) continue;
 

--- a/OrbitCore/OrbitModule.cpp
+++ b/OrbitCore/OrbitModule.cpp
@@ -28,7 +28,7 @@ using orbit_client_protos::FunctionInfo;
 //-----------------------------------------------------------------------------
 Module::Module(const std::string& file_name, uint64_t address_start,
                uint64_t address_end) {
-  if (!Path::FileExists(file_name)) {
+  if (!std::filesystem::exists(file_name)) {
     ERROR("Creating Module from path \"%s\": file does not exist",
           file_name.c_str());
   }

--- a/OrbitCore/Path.cpp
+++ b/OrbitCore/Path.cpp
@@ -68,12 +68,6 @@ std::string Path::GetExecutablePath() {
   return path;
 }
 
-bool Path::FileExists(const std::string& file) {
-  struct stat statbuf;
-  int ret = stat(file.c_str(), &statbuf);
-  return ret == 0;
-}
-
 uint64_t Path::FileSize(const std::string& file) {
   struct stat stat_buf;
   int ret = stat(file.c_str(), &stat_buf);

--- a/OrbitCore/Path.h
+++ b/OrbitCore/Path.h
@@ -42,7 +42,6 @@ class Path {
   static std::string GetParentDirectory(std::string a_FullName);
   static std::string JoinPath(const std::vector<std::string>& parts);
 
-  static bool FileExists(const std::string& a_File);
   static uint64_t FileSize(const std::string& a_File);
   static bool DirExists(const std::string& a_Dir);
   static bool IsPackaged() { return is_packaged_; }

--- a/OrbitCore/PathTest.cpp
+++ b/OrbitCore/PathTest.cpp
@@ -4,12 +4,14 @@
 
 #include <gtest/gtest.h>
 
+#include <filesystem>
+
 #include "Path.h"
 #include "absl/strings/match.h"
 
 TEST(Path, FileExistsEmptyFilename) {
   std::string filename{};
-  EXPECT_FALSE(Path::FileExists(filename));
+  EXPECT_FALSE(std::filesystem::exists(filename));
 }
 
 TEST(Path, FileExistsRootDir) {
@@ -19,13 +21,13 @@ TEST(Path, FileExistsRootDir) {
 #else
   filename = "/";
 #endif
-  EXPECT_TRUE(Path::FileExists(filename));
+  EXPECT_TRUE(std::filesystem::exists(filename));
 }
 
 #ifndef _WIN32
 TEST(Path, FileExistsDevNull) {
   std::string filename = "/dev/null";
-  EXPECT_TRUE(Path::FileExists(filename));
+  EXPECT_TRUE(std::filesystem::exists(filename));
 }
 #endif
 

--- a/OrbitCore/SymbolHelper.cpp
+++ b/OrbitCore/SymbolHelper.cpp
@@ -20,7 +20,7 @@ using ::ElfUtils::ElfFile;
 
 std::vector<std::string> ReadSymbolsFile() {
   std::string file_name = Path::GetSymbolsFileName();
-  if (!Path::FileExists(file_name)) {
+  if (!std::filesystem::exists(file_name)) {
     std::ofstream outfile(file_name);
     outfile << "//-------------------" << std::endl
             << "// Orbit Symbol Locations" << std::endl
@@ -77,7 +77,7 @@ ErrorMessageOr<std::string> FindSymbolsFile(
 
   LOG("Trying to find symbols for module: \"%s\"", module_path);
   for (const auto& symbols_file_path : search_file_paths) {
-    if (!Path::FileExists(symbols_file_path)) continue;
+    if (!std::filesystem::exists(symbols_file_path)) continue;
 
     ErrorMessageOr<std::unique_ptr<ElfFile>> symbols_file =
         ElfFile::Create(symbols_file_path);

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -282,7 +282,7 @@ void OrbitApp::PostInit() {
 void OrbitApp::LoadFileMapping() {
   m_FileMapping.clear();
   std::string fileName = Path::GetFileMappingFileName();
-  if (!Path::FileExists(fileName)) {
+  if (!std::filesystem::exists(fileName)) {
     std::ofstream outfile(fileName);
     outfile << "//-------------------" << std::endl
             << "// Orbit File Mapping" << std::endl


### PR DESCRIPTION
Path::FileExists used stat to determine if a file exists. This did not
work on Windows when the filename contained a dash (-).
Path::FileExists is now not used anymore, but std::filesystem::exists()
is used instead.