### PR TITLE
use sync call with deadline in CrashManager instead of async

### DIFF
--- a/OrbitClientServices/CrashManager.cpp
+++ b/OrbitClientServices/CrashManager.cpp
@@ -40,9 +40,7 @@ void CrashManagerImpl::CrashOrbitService(
   grpc::Status status =
       crash_service_->CrashOrbitService(&context, request, &response);
 
-  if (!status.ok()) {
-    ERROR("Grpc call failed: %s", status.error_message());
-  }
+  CHECK(status.error_code() == grpc::StatusCode::DEADLINE_EXCEEDED);
 }
 
 }  // namespace

--- a/OrbitClientServices/CrashManager.cpp
+++ b/OrbitClientServices/CrashManager.cpp
@@ -9,7 +9,7 @@
 
 namespace {
 
-constexpr uint64_t kTimeoutMilliseconds = 10;
+constexpr uint64_t kTimeoutMilliseconds = 100;
 
 class CrashManagerImpl final : public CrashManager {
  public:

--- a/OrbitClientServices/CrashManager.cpp
+++ b/OrbitClientServices/CrashManager.cpp
@@ -40,7 +40,10 @@ void CrashManagerImpl::CrashOrbitService(
   grpc::Status status =
       crash_service_->CrashOrbitService(&context, request, &response);
 
-  CHECK(status.error_code() == grpc::StatusCode::DEADLINE_EXCEEDED);
+  if (status.error_code() != grpc::StatusCode::DEADLINE_EXCEEDED) {
+    ERROR("CrashOrbitService returned code %i with error message %s",
+          status.error_code(), status.error_message());
+  }
 }
 
 }  // namespace

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -1004,6 +1004,7 @@ void OrbitApp::FilterTracks(const std::string& filter) {
 void OrbitApp::CrashOrbitService(
     CrashOrbitServiceRequest_CrashType crash_type) {
   if (absl::GetFlag(FLAGS_devmode)) {
-    crash_manager_->CrashOrbitService(crash_type);
+    thread_pool_->Schedule(
+        [crash_type, this] { crash_manager_->CrashOrbitService(crash_type); });
   }
 }


### PR DESCRIPTION
Fix for http://b/163018728

Replace asynchronous call with synchronous one (with deadline) for CrashManager