### PR TITLE
Make sure Context is created when creating session

### DIFF
--- a/OrbitSsh/ContextTests.cpp
+++ b/OrbitSsh/ContextTests.cpp
@@ -13,10 +13,10 @@ namespace OrbitSsh {
 TEST(Context, Create) {
   auto context = Context::Create();
   ASSERT_TRUE(context.has_value());
-  ASSERT_TRUE(context.value().isActiveContext());
+  ASSERT_TRUE(context.value().active());
 
   auto context2 = std::move(context.value());
-  ASSERT_FALSE(context.value().isActiveContext());
-  ASSERT_TRUE(context2.isActiveContext());
+  ASSERT_FALSE(context.value().active());
+  ASSERT_TRUE(context2.active());
 }
 }  // namespace OrbitSsh

--- a/OrbitSsh/Session.cpp
+++ b/OrbitSsh/Session.cpp
@@ -19,7 +19,8 @@ namespace OrbitSsh {
 Session::Session(LIBSSH2_SESSION* raw_session_ptr)
     : raw_session_ptr_(raw_session_ptr, &libssh2_session_free) {}
 
-outcome::result<Session> Session::Create(Context*) {
+outcome::result<Session> Session::Create(Context* context) {
+  CHECK(context->active());
   LIBSSH2_SESSION* raw_session_ptr = libssh2_session_init();
 
   if (raw_session_ptr == nullptr) {

--- a/OrbitSsh/include/OrbitSsh/Context.h
+++ b/OrbitSsh/include/OrbitSsh/Context.h
@@ -21,7 +21,7 @@ class Context {
 
   ~Context() noexcept;
 
-  bool isActiveContext() const { return active_; }
+  [[nodiscard]] bool active() const { return active_; }
 
  private:
   explicit Context() = default;

--- a/OrbitSsh/include/OrbitSsh/Session.h
+++ b/OrbitSsh/include/OrbitSsh/Session.h
@@ -18,7 +18,7 @@ namespace OrbitSsh {
 
 class Session {
  public:
-  static outcome::result<Session> Create(Context*);
+  static outcome::result<Session> Create(Context* context);
 
   outcome::result<void> Handshake(Socket* socket_ptr);
   outcome::result<void> MatchKnownHosts(std::string host, int port,


### PR DESCRIPTION
It is currently implied but not really checked. This
commit adds explicit check for it and fixes some
clang-tidy warnings.