### PR TITLE
Change docker container names in the CI's build script

### DIFF
--- a/kokoro/gcp_ubuntu/kokoro_build.sh
+++ b/kokoro/gcp_ubuntu/kokoro_build.sh
@@ -7,8 +7,9 @@
 # Fail on any error.
 set -e
 
-DIR="/mnt/github/orbitprofiler"
-SCRIPT="${DIR}/kokoro/gcp_ubuntu/kokoro_build.sh"
+readonly DIR="/mnt/github/orbitprofiler"
+readonly SCRIPT="${DIR}/kokoro/gcp_ubuntu/kokoro_build.sh"
+readonly CONAN_PROFILE="clang7_relwithdebinfo"
 
 if [ "$0" == "$SCRIPT" ]; then
   # We are inside the docker container
@@ -18,7 +19,6 @@ if [ "$0" == "$SCRIPT" ]; then
   echo "Installing conan configuration (profiles, settings, etc.)..."
   ${DIR}/third_party/conan/configs/install.sh || exit $?
 
-  CONAN_PROFILE="clang7_relwithdebinfo"
   CRASHDUMP_SERVER="$(cat /mnt/keystore/74938_orbitprofiler_crashdump_collection_server | tr -d '\n')"
 
   # Building Orbit
@@ -56,6 +56,6 @@ if [ "$0" == "$SCRIPT" ]; then
 
 else
   gcloud auth configure-docker --quiet
-  docker run --rm --network host -v ${KOKORO_ARTIFACTS_DIR}:/mnt gcr.io/orbitprofiler/clang7_opengl_qt:latest $SCRIPT
+  docker run --rm --network host -v ${KOKORO_ARTIFACTS_DIR}:/mnt gcr.io/orbitprofiler/${CONAN_PROFILE}:latest $SCRIPT
 fi
 

--- a/kokoro/gcp_ubuntu_ggp/kokoro_build.sh
+++ b/kokoro/gcp_ubuntu_ggp/kokoro_build.sh
@@ -7,8 +7,9 @@
 # Fail on any error.
 set -e
 
-DIR="/mnt/github/orbitprofiler"
-SCRIPT="${DIR}/kokoro/gcp_ubuntu_ggp/kokoro_build.sh"
+readonly DIR="/mnt/github/orbitprofiler"
+readonly SCRIPT="${DIR}/kokoro/gcp_ubuntu_ggp/kokoro_build.sh"
+readonly CONAN_PROFILE="ggp_relwithdebinfo"
 
 if [ "$0" == "$SCRIPT" ]; then
   # We are inside the docker container
@@ -18,7 +19,6 @@ if [ "$0" == "$SCRIPT" ]; then
   echo "Installing conan configuration (profiles, settings, etc.)..."
   ${DIR}/third_party/conan/configs/install.sh || exit $?
 
-  CONAN_PROFILE="ggp_relwithdebinfo"
 
   # Building Orbit
   mkdir -p "${DIR}/build/"
@@ -88,6 +88,6 @@ if [ "$0" == "$SCRIPT" ]; then
 
 else
   gcloud auth configure-docker --quiet
-  docker run -e KOKORO_JOB_NAME --rm --network host -v ${KOKORO_ARTIFACTS_DIR}:/mnt gcr.io/orbitprofiler/clang7_gpg:latest $SCRIPT
+  docker run -e KOKORO_JOB_NAME --rm --network host -v ${KOKORO_ARTIFACTS_DIR}:/mnt gcr.io/orbitprofiler/${CONAN_PROFILE}:latest $SCRIPT
 fi
 


### PR DESCRIPTION
`build_containers.sh` is used to build docker containers. These docker
containers are named by the conan profile they should be used for.

But the CI hasn't used that naming scheme yet. This change makes the CI
use the docker containers named by their corresponding conan profile.