### PR TITLE
Remove unused GCallstacks from Capture

### DIFF
--- a/OrbitClientProtos/capture_data.proto
+++ b/OrbitClientProtos/capture_data.proto
@@ -92,7 +92,7 @@ message TimerInfo {
   Type type = 6;
 
   int32 processor = 7;
-  uint64 callstack_hash = 8;
+  uint64 callstack_id = 8;
   uint64 function_address = 9;
   uint64 user_data_key = 10;
   uint64 timeline_hash = 11;

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -34,15 +34,12 @@ std::vector<std::shared_ptr<FunctionInfo>> Capture::GSelectedInCaptureFunctions;
 std::map<uint64_t, FunctionInfo*> Capture::GSelectedFunctionsMap;
 std::map<uint64_t, FunctionInfo*> Capture::GVisibleFunctionsMap;
 std::unordered_map<uint64_t, uint64_t> Capture::GFunctionCountMap;
-std::shared_ptr<CallStack> Capture::GSelectedCallstack;
-std::unordered_map<uint64_t, std::shared_ptr<CallStack>> Capture::GCallstacks;
 int32_t Capture::GProcessId = -1;
 std::string Capture::GProcessName;
 std::unordered_map<int32_t, std::string> Capture::GThreadNames;
 std::unordered_map<uint64_t, LinuxAddressInfo> Capture::GAddressInfos;
 std::unordered_map<uint64_t, std::string> Capture::GAddressToFunctionName;
 std::unordered_map<uint64_t, std::string> Capture::GAddressToModuleName;
-Mutex Capture::GCallstackMutex;
 TextBox* Capture::GSelectedTextBox = nullptr;
 ThreadID Capture::GSelectedThreadId;
 std::chrono::system_clock::time_point Capture::GCaptureTimePoint;
@@ -115,7 +112,6 @@ void Capture::FinalizeCapture() {
 //-----------------------------------------------------------------------------
 void Capture::ClearCaptureData() {
   GFunctionCountMap.clear();
-  GCallstacks.clear();
   GProcessId = -1;
   GProcessName = "";
   GThreadNames.clear();
@@ -212,18 +208,6 @@ void Capture::NewSamplingProfiler() {
 
   Capture::GSamplingProfiler =
       std::make_shared<SamplingProfiler>(Capture::GTargetProcess);
-}
-
-//-----------------------------------------------------------------------------
-std::shared_ptr<CallStack> Capture::GetCallstack(CallstackID a_ID) {
-  ScopeLock lock(GCallstackMutex);
-
-  auto it = Capture::GCallstacks.find(a_ID);
-  if (it != Capture::GCallstacks.end()) {
-    return it->second;
-  }
-
-  return nullptr;
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -38,7 +38,6 @@ class Capture {
   static void DisplayStats();
   static ErrorMessageOr<void> SavePreset(const std::string& filename);
   static void NewSamplingProfiler();
-  static std::shared_ptr<CallStack> GetCallstack(CallstackID a_ID);
   static orbit_client_protos::LinuxAddressInfo* GetAddressInfo(
       uint64_t address);
   static void PreSave();
@@ -56,7 +55,6 @@ class Capture {
   static std::shared_ptr<SamplingProfiler> GSamplingProfiler;
   static std::shared_ptr<Process> GTargetProcess;
   static std::shared_ptr<orbit_client_protos::PresetFile> GSessionPresets;
-  static std::shared_ptr<CallStack> GSelectedCallstack;
   static void (*GClearCaptureDataFunc)();
   static std::vector<std::shared_ptr<orbit_client_protos::FunctionInfo>>
       GSelectedInCaptureFunctions;
@@ -65,7 +63,6 @@ class Capture {
   static std::map<uint64_t, orbit_client_protos::FunctionInfo*>
       GVisibleFunctionsMap;
   static std::unordered_map<uint64_t, uint64_t> GFunctionCountMap;
-  static std::unordered_map<uint64_t, std::shared_ptr<CallStack>> GCallstacks;
   static int32_t GProcessId;
   static std::string GProcessName;
   static std::unordered_map<int32_t, std::string> GThreadNames;
@@ -76,7 +73,6 @@ class Capture {
   static class TextBox* GSelectedTextBox;
   static ThreadID GSelectedThreadId;
   static std::chrono::system_clock::time_point GCaptureTimePoint;
-  static Mutex GCallstackMutex;
 };
 
 #endif  // ORBIT_CORE_CAPTURE_H_

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -196,20 +196,17 @@ void CaptureWindow::Pick(PickingID a_PickingID, int a_X, int a_Y) {
 }
 
 //-----------------------------------------------------------------------------
-void CaptureWindow::SelectTextBox(class TextBox* a_TextBox) {
-  if (a_TextBox == nullptr) return;
-  Capture::GSelectedTextBox = a_TextBox;
-  Capture::GSelectedThreadId = a_TextBox->GetTimerInfo().thread_id();
-  Capture::GSelectedCallstack =
-      Capture::GetCallstack(a_TextBox->GetTimerInfo().callstack_hash());
-  GOrbitApp->SetCallStack(Capture::GSelectedCallstack);
+void CaptureWindow::SelectTextBox(class TextBox* text_box) {
+  if (text_box == nullptr) return;
+  Capture::GSelectedTextBox = text_box;
+  Capture::GSelectedThreadId = text_box->GetTimerInfo().thread_id();
 
-  const TimerInfo& timer_info = a_TextBox->GetTimerInfo();
+  const TimerInfo& timer_info = text_box->GetTimerInfo();
   DWORD64 address = timer_info.function_address();
   FindCode(address);
 
-  if (m_DoubleClicking && a_TextBox) {
-    time_graph_.Zoom(a_TextBox);
+  if (m_DoubleClicking) {
+    time_graph_.Zoom(text_box);
   }
 }
 

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -7,6 +7,7 @@
 #include "Batcher.h"
 #include "GlCanvas.h"
 #include "GlSlider.h"
+#include "TextBox.h"
 
 struct ContextSwitch;
 
@@ -52,7 +53,7 @@ class CaptureWindow : public GlCanvas {
   void RenderHelpUi();
   void RenderTimeBar();
   void ResetHoverTimer();
-  void SelectTextBox(class TextBox* a_TextBox);
+  void SelectTextBox(TextBox* text_box);
   void OnDrag(float a_Ratio);
   void OnVerticalDrag(float a_Ratio);
   void NeedsUpdate();


### PR DESCRIPTION
callstack_hash was always 0 because of b/159107241, once
we have callstacks for uprobes we can revisit this.