### PR TITLE
Removed unused GProcessToInject, GInjected and GInjectedProcess

### DIFF
--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -21,8 +21,6 @@ using orbit_client_protos::PresetFile;
 using orbit_client_protos::PresetInfo;
 
 Capture::State Capture::GState = Capture::State::kEmpty;
-bool Capture::GInjected = false;
-std::string Capture::GInjectedProcess;
 uint32_t Capture::GNumInstalledHooks;
 uint64_t Capture::GNumContextSwitches;
 uint64_t Capture::GNumLinuxEvents;
@@ -55,9 +53,6 @@ void Capture::Init() { GTargetProcess = std::make_shared<Process>(); }
 //-----------------------------------------------------------------------------
 void Capture::SetTargetProcess(const std::shared_ptr<Process>& a_Process) {
   if (a_Process != GTargetProcess) {
-    GInjected = false;
-    GInjectedProcess = "";
-
     GTargetProcess = a_Process;
     GSamplingProfiler = std::make_shared<SamplingProfiler>(a_Process);
     GSelectedFunctionsMap.clear();
@@ -78,8 +73,6 @@ ErrorMessageOr<void> Capture::StartCapture() {
   GProcessId = GTargetProcess->GetID();
   GProcessName = GTargetProcess->GetName();
 
-  GInjected = true;
-
   PreFunctionHooks();
 
   Capture::NewSamplingProfiler();
@@ -91,10 +84,6 @@ ErrorMessageOr<void> Capture::StartCapture() {
 
 //-----------------------------------------------------------------------------
 void Capture::StopCapture() {
-  if (!GInjected) {
-    return;
-  }
-
   GState = State::kStopping;
 }
 

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -27,7 +27,6 @@ uint32_t Capture::GNumInstalledHooks;
 uint64_t Capture::GNumContextSwitches;
 uint64_t Capture::GNumLinuxEvents;
 uint64_t Capture::GNumProfileEvents;
-std::string Capture::GProcessToInject;
 
 std::vector<std::shared_ptr<FunctionInfo>> Capture::GSelectedInCaptureFunctions;
 std::map<uint64_t, FunctionInfo*> Capture::GSelectedFunctionsMap;

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -43,8 +43,6 @@ class Capture {
   static void PreSave();
 
   static State GState;
-  static bool GInjected;
-  static std::string GInjectedProcess;
   static uint32_t GNumInstalledHooks;
 
   static uint64_t GNumContextSwitches;

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -45,7 +45,6 @@ class Capture {
   static State GState;
   static bool GInjected;
   static std::string GInjectedProcess;
-  static std::string GProcessToInject;
   static uint32_t GNumInstalledHooks;
 
   static uint64_t GNumContextSwitches;

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -28,7 +28,6 @@ CaptureWindow::CaptureWindow() {
   m_WorldTopLeftX = 0;
   m_WorldTopLeftY = 0;
   m_WorldMaxY = 0;
-  m_ProcessX = 0;
 
   slider_ = std::make_shared<GlSlider>();
   vertical_slider_ = std::make_shared<GlSlider>();
@@ -575,7 +574,6 @@ void CaptureWindow::Draw() {
   }
 
   if (!m_Picking && !m_IsHovering) {
-    DrawStatus();
     RenderTimeBar();
 
     Vec2 pos(m_MouseX, m_WorldTopLeftY);
@@ -694,29 +692,6 @@ void CaptureWindow::NeedsUpdate() {
 float CaptureWindow::GetTopBarTextY() {
   return slider_->GetPixelHeight() * 0.5f +
          m_TextRenderer.GetStringHeight("FpjT_H") * 0.5f;
-}
-
-//-----------------------------------------------------------------------------
-void CaptureWindow::DrawStatus() {
-  int s_PosX = 0;
-  int s_PosY = static_cast<int>(GetTopBarTextY());
-  static int s_IncY = 20;
-
-  static Color s_Color(255, 255, 255, 255);
-
-  int PosX = getWidth() - s_PosX;
-  int PosY = s_PosY;
-  int LeftY = s_PosY;
-
-  LeftY += s_IncY;
-
-  if (Capture::GInjected) {
-    std::string injectStr =
-        absl::StrFormat(" %s", Capture::GInjectedProcess.c_str());
-    m_ProcessX = m_TextRenderer.AddText2D(injectStr.c_str(), PosX, PosY,
-                                          Z_VALUE_TEXT_UI, s_Color, -1, true);
-    PosY += s_IncY;
-  }
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -44,7 +44,6 @@ class CaptureWindow : public GlCanvas {
   void OnTimer() override;
   void Draw() override;
   void DrawScreenSpace() override;
-  void DrawStatus();
   void RenderUI() override;
   void RenderText() override;
   void PreRender() override;
@@ -82,7 +81,6 @@ class CaptureWindow : public GlCanvas {
   bool m_DrawStats;
   std::shared_ptr<GlSlider> slider_;
   std::shared_ptr<GlSlider> vertical_slider_;
-  int m_ProcessX;
 
   static const std::string MENU_ACTION_GO_TO_CALLSTACK;
   static const std::string MENU_ACTION_GO_TO_SOURCE;


### PR DESCRIPTION
This also allowed removing `DrawStatus` and `m_ProcessX` in `CaptureWindow`.