### PR TITLE
Use rvalue refererce to pass CallstackEvent

### DIFF
--- a/OrbitCore/SamplingProfiler.cpp
+++ b/OrbitCore/SamplingProfiler.cpp
@@ -67,7 +67,7 @@ std::multimap<int, CallstackID> SamplingProfiler::GetCallstacksFromAddress(
   return SortCallstacks(m_ThreadSampleData[a_TID], callstacks, o_NumCallstacks);
 }
 
-void SamplingProfiler::AddCallStack(CallstackEvent callstack_event) {
+void SamplingProfiler::AddCallStack(CallstackEvent&& callstack_event) {
   CallstackID hash = callstack_event.callstack_hash();
   if (!HasCallStack(hash)) {
     std::shared_ptr<CallStack> callstack =

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -65,7 +65,7 @@ class SamplingProfiler {
 
   int GetNumSamples() const { return m_NumSamples; }
 
-  void AddCallStack(orbit_client_protos::CallstackEvent callstack_event);
+  void AddCallStack(orbit_client_protos::CallstackEvent&& callstack_event);
   void AddUniqueCallStack(CallStack call_stack);
 
   std::shared_ptr<CallStack> GetCallStack(CallstackID a_ID) {

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -205,7 +205,7 @@ void CaptureSerializer::ProcessCaptureData(const CaptureInfo& capture_info) {
     Capture::GSamplingProfiler->AddUniqueCallStack(unique_callstack);
   }
   for (CallstackEvent callstack_event : capture_info.callstack_events()) {
-    Capture::GSamplingProfiler->AddCallStack(callstack_event);
+    Capture::GSamplingProfiler->AddCallStack(std::move(callstack_event));
   }
   Capture::GSamplingProfiler->ProcessSamples();
 

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -546,20 +546,20 @@ std::vector<CallstackEvent> TimeGraph::SelectEvents(float a_WorldStart,
   }
 
   // Generate selection report.
-  std::shared_ptr<SamplingProfiler> samplingProfiler =
+  std::shared_ptr<SamplingProfiler> sampling_profiler =
       std::make_shared<SamplingProfiler>(Capture::GTargetProcess);
 
-  samplingProfiler->SetGenerateSummary(a_TID == 0);
+  sampling_profiler->SetGenerateSummary(a_TID == 0);
 
-  for (CallstackEvent& event : selected_callstack_events) {
+  for (CallstackEvent event : selected_callstack_events) {
     if (Capture::GSamplingProfiler->GetCallStack(event.callstack_hash())) {
-      samplingProfiler->AddCallStack(event);
+      sampling_profiler->AddCallStack(std::move(event));
     }
   }
-  samplingProfiler->ProcessSamples();
+  sampling_profiler->ProcessSamples();
 
-  if (samplingProfiler->GetNumSamples() > 0) {
-    GOrbitApp->AddSelectionReport(samplingProfiler);
+  if (sampling_profiler->GetNumSamples() > 0) {
+    GOrbitApp->AddSelectionReport(sampling_profiler);
   }
 
   NeedsUpdate();


### PR DESCRIPTION
Change SamplingProfiler::AddCallStack parameter to rvalue reference.