### PR TITLE
Added clang_format CI presubmit check

### DIFF
--- a/kokoro/checks/clang_format/check.sh
+++ b/kokoro/checks/clang_format/check.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Fail on any error.
+DIR="/mnt/github/orbitprofiler"
+SCRIPT="${DIR}/kokoro/checks/clang_format/check.sh"
+
+if [ "$0" == "$SCRIPT" ]; then
+  # We are inside the docker container
+
+  echo -e "\n\nThe following files don't match our code-formatting standard:"
+  echo -e "> This list includes all files in the repo that need formatting,"
+  echo -e "> but changes outside of the scope of your PR won't affect the outcome"
+  echo -e "> of this presubmit check.\n"
+  while read line; do
+    clang-format --output-replacements-xml $line | grep '<replacement ' > /dev/null
+    if [ $? -eq 0 ]; then
+      echo $line
+    fi
+  done <<< $(find "$DIR" -name '*.cpp' -o -name '*.h' \
+        | grep -v "third_party/" \
+        | grep -v "/build" )
+  echo -e "--\n"
+
+  cd "$DIR"
+  REFERENCE="origin/master"
+  MERGE_BASE="$(git merge-base $REFERENCE HEAD)" # Merge base is the commit on master this PR was branched from.
+  FORMATTING_DIFF="$(git diff -U0 --no-color --relative $MERGE_BASE | clang-format-diff-9 -p1)"
+
+  if [ -n "$FORMATTING_DIFF" ]; then
+    echo "clang-format determined the following necessary changes to your PR:"
+    echo "$FORMATTING_DIFF"
+    echo -e "\n\nHere is the list of files that need formatting:"
+    echo "$(echo "$FORMATTING_DIFF" | egrep '^\+\+\+' | cut -d' ' -f2 | cut -f1 )"
+    echo -e "--\n\nNote: We recommend you to use git clang-format to format your changes!"
+    exit 1
+  else
+    echo "All your changes fulfill our code formatting requirements!"
+    exit 0
+  fi
+
+else
+  gcloud auth configure-docker --quiet
+  docker run --rm --network host -v ${KOKORO_ARTIFACTS_DIR}:/mnt gcr.io/orbitprofiler/clang_format:latest $SCRIPT
+fi
+

--- a/kokoro/checks/clang_format/presubmit.cfg
+++ b/kokoro/checks/clang_format/presubmit.cfg
@@ -1,0 +1,10 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+#
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+
+# Location of the bash script. Should have value <github_scm.name>/<path_from_repository_root>.
+# github_scm.name is specified in the job configuration (next section).
+build_file: "orbitprofiler/kokoro/checks/clang_format/check.sh"

--- a/third_party/conan/docker/Dockerfile.clang_format
+++ b/third_party/conan/docker/Dockerfile.clang_format
@@ -1,0 +1,9 @@
+FROM conanio/clang9:latest
+
+RUN sudo apt-get -qq update \
+    && sudo apt-get install -y --no-install-recommends \
+    clang-format \
+    jq \
+    python2.7 \
+    zip \
+    && sudo rm -rf /var/lib/apt/lists/*

--- a/third_party/conan/docker/build_containers.sh
+++ b/third_party/conan/docker/build_containers.sh
@@ -32,10 +32,11 @@ declare -A profile_to_dockerfile=( \
   ["msvc2019_debug"]="msvc2019" \
   ["msvc2019_release_x86"]="msvc2019" \
   ["msvc2019_relwithdebinfo_x86"]="msvc2019" \
-  ["msvc2019_debug_x86"]="msvc2019" )
+  ["msvc2019_debug_x86"]="msvc2019" \
+  ["clang_format"]="clang_format" )
 
 if [ "$(uname -s)" == "Linux" ]; then
-  for profile in {clang{7,8,9},gcc{8,9},ggp}_{release,relwithdebinfo,debug}; do
+  for profile in {clang{7,8,9},gcc{8,9},ggp}_{release,relwithdebinfo,debug} clang_format; do
     docker build "${DIR}" -f "${DIR}/Dockerfile.${profile_to_dockerfile[$profile]}" -t gcr.io/orbitprofiler/$profile:latest || exit $?
   done
 else

--- a/third_party/conan/docker/upload_containers.sh
+++ b/third_party/conan/docker/upload_containers.sh
@@ -3,7 +3,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 if [ "$(uname -s)" == "Linux" ]; then
-  for profile in {clang{7,8,9},gcc{8,9},ggp}_{release,relwithdebinfo,debug}; do
+  for profile in {clang{7,8,9},gcc{8,9},ggp}_{release,relwithdebinfo,debug} clang_format; do
     docker push gcr.io/orbitprofiler/$profile:latest || exit $?
   done
 else


### PR DESCRIPTION
This PR adds a clang_format presubmit check.

This check evaluates whether all your made changes fulfill our code formatting standard by calling `clang-format-diff` on them.
Only changed lines are taken into account for the result of the presubmit change.

However the script always checks all *.cpp/*.h file in the repository (and not under third_party/) for compliance. This result will only be shown in the logfile.