### PR TITLE
Enforce warnings as errors in tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
                            -Werror=float-conversion
                            -Werror=format=2
                            -Werror=ignored-attributes
+                           -Werror=implicit-fallthrough
                            -Werror=inconsistent-missing-override
                            -Werror=old-style-cast
                            -Werror=unused-parameter

--- a/OrbitBase/CMakeLists.txt
+++ b/OrbitBase/CMakeLists.txt
@@ -37,6 +37,8 @@ target_link_libraries(OrbitBase PUBLIC
 
 add_executable(OrbitBaseTests)
 
+target_compile_options(OrbitBaseTests PRIVATE ${STRICT_COMPILE_FLAGS})
+
 target_sources(OrbitBaseTests PRIVATE
     ThreadPoolTest.cpp
     UniqueResourceTest.cpp

--- a/OrbitCore/BlockChainTest.cpp
+++ b/OrbitCore/BlockChainTest.cpp
@@ -182,7 +182,7 @@ TEST(BlockChain, keep) {
   EXPECT_EQ(chain.size(), 2000);
   chain.keep(10);
   EXPECT_EQ(chain.size(), 2000 - 1024);
-  for (int i = 0; i < chain.size(); ++i) {
+  for (size_t i = 0; i < chain.size(); ++i) {
     EXPECT_EQ(*chain.SlowAt(i), i + 1024);
   }
 }

--- a/OrbitCore/CMakeLists.txt
+++ b/OrbitCore/CMakeLists.txt
@@ -123,6 +123,8 @@ target_sources(OrbitCore PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/OrbitVersion.cpp")
 
 add_executable(OrbitCoreTests)
 
+target_compile_options(OrbitCoreTests PRIVATE ${STRICT_COMPILE_FLAGS})
+
 target_sources(OrbitCoreTests PRIVATE
     BlockChainTest.cpp
     LinuxTracingBufferTest.cpp

--- a/OrbitFramePointerValidator/CMakeLists.txt
+++ b/OrbitFramePointerValidator/CMakeLists.txt
@@ -31,6 +31,8 @@ target_link_libraries(OrbitFramePointerValidator PUBLIC
 
 add_executable(OrbitFramePointerValidatorTests)
 
+target_compile_options(OrbitFramePointerValidatorTests PRIVATE ${STRICT_COMPILE_FLAGS})
+
 target_sources(OrbitFramePointerValidatorTests PRIVATE
         FramePointerValidatorTest.cpp
         FunctionFramePointerValidatorTest.cpp)

--- a/OrbitGgp/CMakeLists.txt
+++ b/OrbitGgp/CMakeLists.txt
@@ -39,6 +39,8 @@ set_target_properties(OrbitGgp PROPERTIES AUTOUIC ON)
 # Tests
 add_executable(OrbitGgpTests)
 
+target_compile_options(OrbitGgpTests PRIVATE ${STRICT_COMPILE_FLAGS})
+
 target_sources(OrbitGgpTests PRIVATE 
           InstanceTests.cpp
           InstanceItemModelTests.cpp

--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -126,6 +126,8 @@ endif()
 
 add_executable(OrbitGlTests)
 
+target_compile_options(OrbitGlTests PRIVATE ${STRICT_COMPILE_FLAGS})
+
 target_sources(OrbitGlTests PRIVATE
     PickingManagerTest.cpp)
 

--- a/OrbitLinuxTracing/CMakeLists.txt
+++ b/OrbitLinuxTracing/CMakeLists.txt
@@ -64,6 +64,8 @@ target_link_libraries(OrbitLinuxTracing PUBLIC
 
 add_executable(OrbitLinuxTracingTests)
 
+target_compile_options(OrbitLinuxTracingTests PRIVATE ${STRICT_COMPILE_FLAGS})
+
 if (NOT WIN32)
     target_sources(OrbitLinuxTracingTests PRIVATE
             ContextSwitchManagerTest.cpp

--- a/OrbitLinuxTracing/PerfEventProcessorTest.cpp
+++ b/OrbitLinuxTracing/PerfEventProcessorTest.cpp
@@ -15,7 +15,7 @@ class TestEvent : public PerfEvent {
 
   uint64_t GetTimestamp() const override { return timestamp_; }
 
-  void Accept(PerfEventVisitor* visitor) override {}
+  void Accept(PerfEventVisitor*) override {}
 
  private:
   uint64_t timestamp_;

--- a/OrbitSsh/CMakeLists.txt
+++ b/OrbitSsh/CMakeLists.txt
@@ -55,6 +55,7 @@ endif()
 
 # tests
 add_executable(OrbitSshTests)
+target_compile_options(OrbitSshTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(OrbitSshTests PRIVATE SocketTests.cpp ContextTests.cpp)
 

--- a/OrbitSshQt/CMakeLists.txt
+++ b/OrbitSshQt/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(OrbitSshQtIntegrationTests PUBLIC OrbitSshQt GTest::GTest)
 
 # tests
 #add_executable(OrbitSshQtTests)
+#target_compile_options(OrbitSshQtTests PRIVATE ${STRICT_COMPILE_FLAGS})
 #target_sources(OrbitSshQtTests PRIVATE SocketTests.cpp ContextTests.cpp)
 #target_link_libraries(OrbitSshQtTests PRIVATE OrbitSshQt GTest::Main)
 


### PR DESCRIPTION
And fix them. Also enforce -Werror=implicit-fallthrough