### PR TITLE
License header presubmit check

### DIFF
--- a/kokoro/checks/license_headers/check.sh
+++ b/kokoro/checks/license_headers/check.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Fail on any error.
+readonly DIR="/mnt/github/orbitprofiler"
+readonly SCRIPT="${DIR}/kokoro/checks/license_headers/check.sh"
+
+if [ "$0" == "$SCRIPT" ]; then
+  # We are inside the docker container
+
+  cd "$DIR"
+  REFERENCE="origin/master"
+  MERGE_BASE="$(git merge-base $REFERENCE HEAD)" # Merge base is the commit on master this PR was branched from.
+  LICENSE_HEADER_MISSED=""
+
+  echo -e "The following files are missing a license/copyright header:\n"
+  while read file; do
+    if [ ! -f "$file" ]; then
+      continue
+    fi
+
+    if ! grep -E 'Copyright \(c\) [0-9]{4} The Orbit Authors\. All rights reserved\.' "$file" > /dev/null; then
+      LICENSE_HEADER_MISSED="yes"
+      echo "$file"
+    fi
+
+  done <<< $(git diff -U0 --no-color --relative --name-only $MERGE_BASE \
+  | grep -v third_party/ \
+  | grep -v /build \
+  | egrep '\.cpp$|\.h$|CMakeLists\.txt$')
+
+  if [ -n "$LICENSE_HEADER_MISSED" ]; then
+    exit 1
+  fi
+
+else
+  gcloud auth configure-docker --quiet
+  docker run --rm --network host -v ${KOKORO_ARTIFACTS_DIR}:/mnt gcr.io/orbitprofiler/license_headers:latest $SCRIPT
+fi

--- a/kokoro/checks/license_headers/presubmit.cfg
+++ b/kokoro/checks/license_headers/presubmit.cfg
@@ -1,0 +1,10 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+#
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+
+# Location of the bash script. Should have value <github_scm.name>/<path_from_repository_root>.
+# github_scm.name is specified in the job configuration (next section).
+build_file: "orbitprofiler/kokoro/checks/license_headers/check.sh"

--- a/third_party/conan/docker/Dockerfile.license_headers
+++ b/third_party/conan/docker/Dockerfile.license_headers
@@ -1,0 +1,8 @@
+FROM conanio/clang9:latest
+
+RUN sudo apt-get -qq update \
+    && sudo apt-get install -y --no-install-recommends \
+    jq \
+    python2.7 \
+    zip \
+    && sudo rm -rf /var/lib/apt/lists/*

--- a/third_party/conan/docker/build_containers.sh
+++ b/third_party/conan/docker/build_containers.sh
@@ -33,10 +33,11 @@ declare -A profile_to_dockerfile=( \
   ["msvc2019_release_x86"]="msvc2019" \
   ["msvc2019_relwithdebinfo_x86"]="msvc2019" \
   ["msvc2019_debug_x86"]="msvc2019" \
-  ["clang_format"]="clang_format" )
+  ["clang_format"]="clang_format" \
+  ["license_headers"]="license_headers" )
 
 if [ "$(uname -s)" == "Linux" ]; then
-  for profile in {clang{7,8,9},gcc{8,9},ggp}_{release,relwithdebinfo,debug} clang_format; do
+  for profile in {clang{7,8,9},gcc{8,9},ggp}_{release,relwithdebinfo,debug} clang_format license_headers; do
     docker build "${DIR}" -f "${DIR}/Dockerfile.${profile_to_dockerfile[$profile]}" -t gcr.io/orbitprofiler/$profile:latest || exit $?
   done
 else

--- a/third_party/conan/docker/upload_containers.sh
+++ b/third_party/conan/docker/upload_containers.sh
@@ -3,7 +3,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 if [ "$(uname -s)" == "Linux" ]; then
-  for profile in {clang{7,8,9},gcc{8,9},ggp}_{release,relwithdebinfo,debug} clang_format; do
+  for profile in {clang{7,8,9},gcc{8,9},ggp}_{release,relwithdebinfo,debug} clang_format license_headers; do
     docker push gcr.io/orbitprofiler/$profile:latest || exit $?
   done
 else


### PR DESCRIPTION
This PR adds a presubmit for license headers in cpp-, header- and CMakeLists.txt files. It will fail if our typical copyright notice is missing.

The check only tests the file which have been touched by the current PR. Everything else will not be examined.