### PR TITLE
OrbitClientGgp: project structure and basic capture flow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,7 @@ if(WIN32)
 else()
   add_subdirectory(OrbitLinuxTracing)
   add_subdirectory(OrbitService)
+  add_subdirectory(OrbitClientGgp)
 endif()
 
 add_subdirectory(ElfUtils)

--- a/OrbitClientGgp/CMakeLists.txt
+++ b/OrbitClientGgp/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+project(OrbitClientGgp)
+
+add_executable(OrbitClientGgp main.cpp)
+
+target_compile_options(OrbitClientGgp PRIVATE
+    ${STRICT_COMPILE_FLAGS})
+
+target_include_directories(OrbitClientGgp PRIVATE 
+    ${CMAKE_CURRENT_LIST_DIR})
+
+target_sources(OrbitClientGgp PRIVATE
+    ClientGgp.cpp
+    ClientGgp.h
+    main.cpp)
+
+target_link_libraries(OrbitClientGgp PUBLIC 
+    OrbitBase
+    OrbitCaptureClient
+    OrbitProtos)
+
+#strip_symbols(OrbitClientGgp)

--- a/OrbitClientGgp/CMakeLists.txt
+++ b/OrbitClientGgp/CMakeLists.txt
@@ -21,5 +21,4 @@ target_link_libraries(OrbitClientGgp PUBLIC
     OrbitBase
     OrbitCaptureClient
     OrbitProtos)
-
-#strip_symbols(OrbitClientGgp)
+    

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -15,6 +15,15 @@
 #include "OrbitBase/Result.h"
 #include "capture_data.pb.h"
 
+namespace {
+std::shared_ptr<Process> GetOrbitProcessByPid(int32_t pid) {
+  std::shared_ptr<Process> process = std::make_shared<Process>();
+  // TODO: study if we need more information. Requires extra steps
+  process->SetID(pid);
+  return process;
+}
+}  // namespace
+
 ClientGgp::ClientGgp(ClientGgpOptions&& options)
     : options_(std::move(options)) {}
 
@@ -75,13 +84,6 @@ void ClientGgp::InitCapture() {
   std::shared_ptr<Process> process = GetOrbitProcessByPid(options_.capture_pid);
   CHECK(process != nullptr);
   Capture::SetTargetProcess(std::move(process));
-}
-
-std::shared_ptr<Process> ClientGgp::GetOrbitProcessByPid(int32_t pid) {
-  std::shared_ptr<Process> process = std::make_shared<Process>();
-  // TODO: study if we need more information. Requires extra steps
-  process->SetID(pid);
-  return process;
 }
 
 // CaptureListener implementation

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -45,7 +45,8 @@ bool ClientGgp::InitClient() {
   return true;
 }
 
-bool ClientGgp::StartCapture() {
+// Prepare the Capture object to be able to request a capture
+bool ClientGgp::PrepareStartCapture() {
   CHECK(!Capture::IsCapturing());
 
   ErrorMessageOr<void> result = Capture::StartCapture();
@@ -54,7 +55,11 @@ bool ClientGgp::StartCapture() {
     return false;
   }
 
-  // Client capture request
+  return true;
+}
+
+// Client requests to start the capture
+void ClientGgp::RequestStartCapture() {
   int32_t pid = Capture::GProcessId;
   LOG("Capture pid %d", pid);
 
@@ -62,19 +67,17 @@ bool ClientGgp::StartCapture() {
   std::vector<std::shared_ptr<orbit_client_protos::FunctionInfo>> selected_functions =
       Capture::GSelectedFunctions;
   capture_client_->Capture(pid, selected_functions);
-  LOG("Capture started");
-
-  return true;
+  
+  LOG("Start capture requested");
 }
 
 void ClientGgp::StopCapture() {
-  LOG("Stop captured requested");
   CHECK(Capture::IsCapturing());
   Capture::StopCapture();
 
   capture_client_->StopCapture();
 
-  LOG("Capture stopped");
+  LOG("Stop capture requested");
 }
 
 void ClientGgp::InitCapture() {

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -1,0 +1,5 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ClientGgp.h"

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -67,8 +67,6 @@ void ClientGgp::RequestStartCapture() {
   std::map<uint64_t, orbit_client_protos::FunctionInfo*> selected_functions =
       Capture::GSelectedFunctionsMap;
   capture_client_->Capture(pid, selected_functions);
-  
-  LOG("Start capture requested");
 }
 
 void ClientGgp::StopCapture() {
@@ -95,9 +93,13 @@ std::shared_ptr<Process> ClientGgp::GetOrbitProcessByPid(int32_t pid) {
 }
 
 // CaptureListener implementation
-void ClientGgp::OnCaptureStarted() {}
+void ClientGgp::OnCaptureStarted() {
+  LOG("Capture started");
+}
 
-void ClientGgp::OnCaptureComplete() {}
+void ClientGgp::OnCaptureComplete() {
+  LOG("Capture completed");
+}
 
 void ClientGgp::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
   (void)timer_info;

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -103,32 +103,26 @@ void ClientGgp::OnCaptureComplete() {
 
 void ClientGgp::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
   (void)timer_info;
-  //LOG("OnTimer called");
 }
 
 void ClientGgp::OnKeyAndString(uint64_t key, std::string str) {
   (void)key;
   (void)str;
-  //LOG("OnKeyAndString called");
 }
 
 void ClientGgp::OnCallstack(CallStack callstack) {
   (void)callstack;
-  //LOG("OnCallstack called");
 }
 
 void ClientGgp::OnCallstackEvent(orbit_client_protos::CallstackEvent callstack_event) {
   (void)callstack_event;
-  //LOG("OnCallstackEvent called");
 }
 
 void ClientGgp::OnThreadName(int32_t thread_id, std::string thread_name) {
   (void)thread_id;
   (void)thread_name;
-  //LOG("OnThreadName called");
 }
 
 void ClientGgp::OnAddressInfo(orbit_client_protos::LinuxAddressInfo address_info) {
   (void)address_info;
-  //LOG("OnAddressInfo called");
 }

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -6,6 +6,12 @@
 
 #include "capture_data.pb.h"
 
+#include <limits>
+#include <memory>
+#include <cstdint>
+#include <map>
+#include <string>
+
 #include "Capture.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -34,20 +34,17 @@ bool ClientGgp::InitClient() {
       options_.grpc_server_address, 
       grpc::InsecureChannelCredentials(), 
       channel_arguments);
-
   if (!grpc_channel_) {
     ERROR("Unable to create GRPC channel to %s",
           options_.grpc_server_address);
     return false;
   }
-  
   LOG("Created GRPC channel to %s", options_.grpc_server_address);
 
   // Initialisations needed for capture to work
   InitCapture();
-  
-  capture_client_ = std::make_unique<CaptureClient>(grpc_channel_, this);
 
+  capture_client_ = std::make_unique<CaptureClient>(grpc_channel_, this);
   return true;
 }
 
@@ -60,7 +57,6 @@ bool ClientGgp::PrepareStartCapture() {
     ERROR("Error starting capture %s", result.error().message());
     return false;
   }
-
   return true;
 }
 
@@ -80,7 +76,6 @@ void ClientGgp::StopCapture() {
   Capture::StopCapture();
 
   capture_client_->StopCapture();
-
   LOG("Stop capture requested");
 }
 

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -64,8 +64,8 @@ void ClientGgp::RequestStartCapture() {
   LOG("Capture pid %d", pid);
 
   // TODO: selected_functions available when UploadSymbols is included
-  std::vector<std::shared_ptr<orbit_client_protos::FunctionInfo>> selected_functions =
-      Capture::GSelectedFunctions;
+  std::map<uint64_t, orbit_client_protos::FunctionInfo*> selected_functions =
+      Capture::GSelectedFunctionsMap;
   capture_client_->Capture(pid, selected_functions);
   
   LOG("Start capture requested");

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -4,8 +4,6 @@
 
 #include "ClientGgp.h"
 
-#include "capture_data.pb.h"
-
 #include <cstdint>
 #include <limits>
 #include <map>
@@ -15,12 +13,14 @@
 #include "Capture.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
+#include "capture_data.pb.h"
 
-ClientGgp::ClientGgp(ClientGgpOptions&& options) 
+
+ClientGgp::ClientGgp(ClientGgpOptions&& options)
     : options_(std::move(options)) {}
 
 bool ClientGgp::InitClient() {
-  if (options_.grpc_server_address.empty()){
+  if (options_.grpc_server_address.empty()) {
     ERROR("gRPC server address not provided");
     return false;
   }
@@ -30,13 +30,11 @@ bool ClientGgp::InitClient() {
   channel_arguments.SetMaxReceiveMessageSize(
       std::numeric_limits<int32_t>::max());
 
-  grpc_channel_ = grpc::CreateCustomChannel(
-      options_.grpc_server_address, 
-      grpc::InsecureChannelCredentials(), 
-      channel_arguments);
+  grpc_channel_ = grpc::CreateCustomChannel(options_.grpc_server_address,
+                                            grpc::InsecureChannelCredentials(),
+                                            channel_arguments);
   if (!grpc_channel_) {
-    ERROR("Unable to create GRPC channel to %s",
-          options_.grpc_server_address);
+    ERROR("Unable to create GRPC channel to %s", options_.grpc_server_address);
     return false;
   }
   LOG("Created GRPC channel to %s", options_.grpc_server_address);
@@ -94,13 +92,9 @@ std::shared_ptr<Process> ClientGgp::GetOrbitProcessByPid(int32_t pid) {
 }
 
 // CaptureListener implementation
-void ClientGgp::OnCaptureStarted() {
-  LOG("Capture started");
-}
+void ClientGgp::OnCaptureStarted() { LOG("Capture started"); }
 
-void ClientGgp::OnCaptureComplete() {
-  LOG("Capture completed");
-}
+void ClientGgp::OnCaptureComplete() { LOG("Capture completed"); }
 
 void ClientGgp::OnTimer(const orbit_client_protos::TimerInfo&) {}
 

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -95,6 +95,10 @@ std::shared_ptr<Process> ClientGgp::GetOrbitProcessByPid(int32_t pid) {
 }
 
 // CaptureListener implementation
+void ClientGgp::OnCaptureStarted() {}
+
+void ClientGgp::OnCaptureComplete() {}
+
 void ClientGgp::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
   (void)timer_info;
   //LOG("OnTimer called");

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -3,3 +3,36 @@
 // found in the LICENSE file.
 
 #include "ClientGgp.h"
+
+ClientGgp::ClientGgp(ClientGgpOptions&& options) 
+    : options_(std::move(options)) {}
+
+bool ClientGgp::InitClient() {
+  if (options_.grpc_server_address.empty()){
+    ERROR("gRPC server address not provided");
+    return false;
+  }
+
+  // Create channel
+  grpc::ChannelArguments channel_arguments;
+  channel_arguments.SetMaxReceiveMessageSize(
+      std::numeric_limits<int32_t>::max());
+
+  grpc_channel_ = grpc::CreateCustomChannel(
+      options_.grpc_server_address, 
+      grpc::InsecureChannelCredentials(), 
+      channel_arguments);
+
+  if (!grpc_channel_) {
+    ERROR("Unable to create GRPC channel to %s",
+          options_.grpc_server_address);
+    return false;
+  }
+  
+  LOG("Created GRPC channel to %s", options_.grpc_server_address);
+
+  // Instantiate CaptureClient
+  //capture_client_ = std::make_unique<CaptureClient>(grpc_channel_, nullptr);
+
+  return true;
+}

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -4,6 +4,12 @@
 
 #include "ClientGgp.h"
 
+#include "capture_data.pb.h"
+
+#include "Capture.h"
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/Result.h"
+
 ClientGgp::ClientGgp(ClientGgpOptions&& options) 
     : options_(std::move(options)) {}
 
@@ -31,41 +37,89 @@ bool ClientGgp::InitClient() {
   
   LOG("Created GRPC channel to %s", options_.grpc_server_address);
 
-  // Instantiate CaptureClient
+  // Initialisations needed for capture to work
+  InitCapture();
+  
   capture_client_ = std::make_unique<CaptureClient>(grpc_channel_, this);
 
   return true;
 }
 
+bool ClientGgp::StartCapture() {
+  CHECK(!Capture::IsCapturing());
+
+  ErrorMessageOr<void> result = Capture::StartCapture();
+  if (result.has_error()) {
+    ERROR("Error starting capture %s", result.error().message());
+    return false;
+  }
+
+  // Client capture request
+  int32_t pid = Capture::GProcessId;
+  LOG("Capture pid %d", pid);
+
+  // TODO: selected_functions available when UploadSymbols is included
+  std::vector<std::shared_ptr<orbit_client_protos::FunctionInfo>> selected_functions =
+      Capture::GSelectedFunctions;
+  capture_client_->Capture(pid, selected_functions);
+  LOG("Capture started");
+
+  return true;
+}
+
+void ClientGgp::StopCapture() {
+  LOG("Stop captured requested");
+  CHECK(Capture::IsCapturing());
+  Capture::StopCapture();
+
+  capture_client_->StopCapture();
+
+  LOG("Capture stopped");
+}
+
+void ClientGgp::InitCapture() {
+  Capture::Init();
+  std::shared_ptr<Process> process = GetOrbitProcessByPid(options_.capture_pid);
+  CHECK(process != nullptr);
+  Capture::SetTargetProcess(std::move(process));
+}
+
+std::shared_ptr<Process> ClientGgp::GetOrbitProcessByPid(int32_t pid) {
+  std::shared_ptr<Process> process = std::make_shared<Process>();
+  // TODO: study if we need more information. Requires extra steps
+  process->SetID(pid);
+  return process;
+}
+
 // CaptureListener implementation
 void ClientGgp::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
   (void)timer_info;
-  LOG("OnTimer called w/ ");
+  //LOG("OnTimer called");
 }
 
 void ClientGgp::OnKeyAndString(uint64_t key, std::string str) {
   (void)key;
   (void)str;
-  LOG("OnKeyAndString called");
+  //LOG("OnKeyAndString called");
 }
 
 void ClientGgp::OnCallstack(CallStack callstack) {
   (void)callstack;
-  LOG("OnCallstack called");
+  //LOG("OnCallstack called");
 }
 
 void ClientGgp::OnCallstackEvent(orbit_client_protos::CallstackEvent callstack_event) {
   (void)callstack_event;
-  LOG("OnCallstackEvent called");
+  //LOG("OnCallstackEvent called");
 }
 
 void ClientGgp::OnThreadName(int32_t thread_id, std::string thread_name) {
   (void)thread_id;
   (void)thread_name;
-  LOG("OnThreadName called");
+  //LOG("OnThreadName called");
 }
 
 void ClientGgp::OnAddressInfo(orbit_client_protos::LinuxAddressInfo address_info) {
   (void)address_info;
-  LOG("OnAddressInfo called");
+  //LOG("OnAddressInfo called");
 }

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -107,28 +107,14 @@ void ClientGgp::OnCaptureComplete() {
   LOG("Capture completed");
 }
 
-void ClientGgp::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
-  (void)timer_info;
-}
+void ClientGgp::OnTimer(const orbit_client_protos::TimerInfo&) {}
 
-void ClientGgp::OnKeyAndString(uint64_t key, std::string str) {
-  (void)key;
-  (void)str;
-}
+void ClientGgp::OnKeyAndString(uint64_t, std::string) {}
 
-void ClientGgp::OnCallstack(CallStack callstack) {
-  (void)callstack;
-}
+void ClientGgp::OnCallstack(CallStack) {}
 
-void ClientGgp::OnCallstackEvent(orbit_client_protos::CallstackEvent callstack_event) {
-  (void)callstack_event;
-}
+void ClientGgp::OnCallstackEvent(orbit_client_protos::CallstackEvent) {}
 
-void ClientGgp::OnThreadName(int32_t thread_id, std::string thread_name) {
-  (void)thread_id;
-  (void)thread_name;
-}
+void ClientGgp::OnThreadName(int32_t, std::string) {}
 
-void ClientGgp::OnAddressInfo(orbit_client_protos::LinuxAddressInfo address_info) {
-  (void)address_info;
-}
+void ClientGgp::OnAddressInfo(orbit_client_protos::LinuxAddressInfo) {}

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -32,7 +32,40 @@ bool ClientGgp::InitClient() {
   LOG("Created GRPC channel to %s", options_.grpc_server_address);
 
   // Instantiate CaptureClient
-  //capture_client_ = std::make_unique<CaptureClient>(grpc_channel_, nullptr);
+  capture_client_ = std::make_unique<CaptureClient>(grpc_channel_, this);
 
   return true;
+}
+
+// CaptureListener implementation
+void ClientGgp::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
+  (void)timer_info;
+  LOG("OnTimer called w/ ");
+}
+
+void ClientGgp::OnKeyAndString(uint64_t key, std::string str) {
+  (void)key;
+  (void)str;
+  LOG("OnKeyAndString called");
+}
+
+void ClientGgp::OnCallstack(CallStack callstack) {
+  (void)callstack;
+  LOG("OnCallstack called");
+}
+
+void ClientGgp::OnCallstackEvent(orbit_client_protos::CallstackEvent callstack_event) {
+  (void)callstack_event;
+  LOG("OnCallstackEvent called");
+}
+
+void ClientGgp::OnThreadName(int32_t thread_id, std::string thread_name) {
+  (void)thread_id;
+  (void)thread_name;
+  LOG("OnThreadName called");
+}
+
+void ClientGgp::OnAddressInfo(orbit_client_protos::LinuxAddressInfo address_info) {
+  (void)address_info;
+  LOG("OnAddressInfo called");
 }

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -6,10 +6,10 @@
 
 #include "capture_data.pb.h"
 
-#include <limits>
-#include <memory>
 #include <cstdint>
+#include <limits>
 #include <map>
+#include <memory>
 #include <string>
 
 #include "Capture.h"

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -12,7 +12,7 @@
 #include "ClientGgpOptions.h"
 #include "OrbitCaptureClient/CaptureClient.h"
 #include "OrbitCaptureClient/CaptureListener.h"
-#include "OrbitProcess.h"  // remove if including Capture.h in here
+#include "OrbitProcess.h"
 #include "grpcpp/grpcpp.h"
 
 class ClientGgp final : public CaptureListener {
@@ -41,7 +41,6 @@ class ClientGgp final : public CaptureListener {
   std::unique_ptr<CaptureClient> capture_client_;
 
   void InitCapture();
-  std::shared_ptr<Process> GetOrbitProcessByPid(int32_t pid);
 };
 
 #endif  // ORBIT_CLIENT_GGP_CLIENT_GGP_H_

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -5,8 +5,6 @@
 #ifndef ORBIT_CLIENT_GGP_CLIENT_GGP_H_
 #define ORBIT_CLIENT_GGP_CLIENT_GGP_H_
 
-#include "grpcpp/grpcpp.h"
-
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -14,36 +12,38 @@
 #include "ClientGgpOptions.h"
 #include "OrbitCaptureClient/CaptureClient.h"
 #include "OrbitCaptureClient/CaptureListener.h"
-#include "OrbitProcess.h" // remove if including Capture.h in here
+#include "OrbitProcess.h"  // remove if including Capture.h in here
+#include "grpcpp/grpcpp.h"
+
 
 class ClientGgp final : public CaptureListener {
-  public:
-    ClientGgp(ClientGgpOptions&& options);
-    bool InitClient();
-    bool PrepareStartCapture();
-    void RequestStartCapture();
-    void StopCapture();
-    void SaveCapture();
+ public:
+  ClientGgp(ClientGgpOptions&& options);
+  bool InitClient();
+  bool PrepareStartCapture();
+  void RequestStartCapture();
+  void StopCapture();
+  void SaveCapture();
 
-    // CaptureListener implementation
-    void OnCaptureStarted() override;
-    void OnCaptureComplete() override;
-    void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
-    void OnKeyAndString(uint64_t key, std::string str) override;
-    void OnCallstack(CallStack callstack) override;
-    void OnCallstackEvent(
+  // CaptureListener implementation
+  void OnCaptureStarted() override;
+  void OnCaptureComplete() override;
+  void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
+  void OnKeyAndString(uint64_t key, std::string str) override;
+  void OnCallstack(CallStack callstack) override;
+  void OnCallstackEvent(
       orbit_client_protos::CallstackEvent callstack_event) override;
-    void OnThreadName(int32_t thread_id, std::string thread_name) override;
-    void OnAddressInfo(
+  void OnThreadName(int32_t thread_id, std::string thread_name) override;
+  void OnAddressInfo(
       orbit_client_protos::LinuxAddressInfo address_info) override;
 
-  private:
-    ClientGgpOptions options_;
-    std::shared_ptr<grpc::Channel> grpc_channel_;
-    std::unique_ptr<CaptureClient> capture_client_;
+ private:
+  ClientGgpOptions options_;
+  std::shared_ptr<grpc::Channel> grpc_channel_;
+  std::unique_ptr<CaptureClient> capture_client_;
 
-    void InitCapture();
-    std::shared_ptr<Process> GetOrbitProcessByPid(int32_t pid);
+  void InitCapture();
+  std::shared_ptr<Process> GetOrbitProcessByPid(int32_t pid);
 };
 
-#endif // ORBIT_CLIENT_GGP_CLIENT_GGP_H_
+#endif  // ORBIT_CLIENT_GGP_CLIENT_GGP_H_

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -7,6 +7,10 @@
 
 #include "grpcpp/grpcpp.h"
 
+#include <cstdint>
+#include <string>
+#include <memory>
+
 #include "ClientGgpOptions.h"
 #include "OrbitCaptureClient/CaptureClient.h"
 #include "OrbitCaptureClient/CaptureListener.h"

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -5,26 +5,26 @@
 #ifndef ORBIT_CLIENT_GGP_CLIENT_GGP_H_
 #define ORBIT_CLIENT_GGP_CLIENT_GGP_H_
 
-#include <string>
+//#include <string>
 
-#include "capture_data.pb.h"
 #include "grpcpp/grpcpp.h"
 
-#include "Callstack.h"
-#include "EventBuffer.h"
-#include "KeyAndString.h"
-#include "ScopeTimer.h"
+//#include "Callstack.h"
+//#include "EventBuffer.h"
+//#include "KeyAndString.h"
+//#include "ScopeTimer.h"
 
 #include "ClientGgpOptions.h"
 #include "OrbitCaptureClient/CaptureClient.h"
 #include "OrbitCaptureClient/CaptureListener.h"
+#include "OrbitProcess.h" // remove if including Capture.h in here
 
 class ClientGgp : public CaptureListener {
   public:
     ClientGgp(ClientGgpOptions&& options);
     bool InitClient();
-    void StartCapture();
-    void EndCapture();
+    bool StartCapture();
+    void StopCapture();
     void SaveCapture();
 
     // CaptureListener implementation
@@ -39,10 +39,11 @@ class ClientGgp : public CaptureListener {
 
   private:
     ClientGgpOptions options_;
-
     std::shared_ptr<grpc::Channel> grpc_channel_;
-    
     std::unique_ptr<CaptureClient> capture_client_;
+
+    void InitCapture();
+    std::shared_ptr<Process> GetOrbitProcessByPid(int32_t pid);
 };
 
 #endif // ORBIT_CLIENT_GGP_CLIENT_GGP_H_

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -5,14 +5,7 @@
 #ifndef ORBIT_CLIENT_GGP_CLIENT_GGP_H_
 #define ORBIT_CLIENT_GGP_CLIENT_GGP_H_
 
-//#include <string>
-
 #include "grpcpp/grpcpp.h"
-
-//#include "Callstack.h"
-//#include "EventBuffer.h"
-//#include "KeyAndString.h"
-//#include "ScopeTimer.h"
 
 #include "ClientGgpOptions.h"
 #include "OrbitCaptureClient/CaptureClient.h"

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -19,11 +19,12 @@
 #include "OrbitCaptureClient/CaptureListener.h"
 #include "OrbitProcess.h" // remove if including Capture.h in here
 
-class ClientGgp : public CaptureListener {
+class ClientGgp final : public CaptureListener {
   public:
     ClientGgp(ClientGgpOptions&& options);
     bool InitClient();
-    bool StartCapture();
+    bool PrepareStartCapture();
+    void RequestStartCapture();
     void StopCapture();
     void SaveCapture();
 

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -5,13 +5,21 @@
 #ifndef ORBIT_CLIENT_GGP_CLIENT_GGP_H_
 #define ORBIT_CLIENT_GGP_CLIENT_GGP_H_
 
+#include <string>
+
+#include "capture_data.pb.h"
 #include "grpcpp/grpcpp.h"
+
+#include "Callstack.h"
+#include "EventBuffer.h"
+#include "KeyAndString.h"
+#include "ScopeTimer.h"
 
 #include "ClientGgpOptions.h"
 #include "OrbitCaptureClient/CaptureClient.h"
 #include "OrbitCaptureClient/CaptureListener.h"
 
-class ClientGgp {
+class ClientGgp : public CaptureListener {
   public:
     ClientGgp(ClientGgpOptions&& options);
     bool InitClient();
@@ -19,12 +27,22 @@ class ClientGgp {
     void EndCapture();
     void SaveCapture();
 
+    // CaptureListener implementation
+    void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
+    void OnKeyAndString(uint64_t key, std::string str) override;
+    void OnCallstack(CallStack callstack) override;
+    void OnCallstackEvent(
+      orbit_client_protos::CallstackEvent callstack_event) override;
+    void OnThreadName(int32_t thread_id, std::string thread_name) override;
+    void OnAddressInfo(
+      orbit_client_protos::LinuxAddressInfo address_info) override;
+
   private:
     ClientGgpOptions options_;
 
     std::shared_ptr<grpc::Channel> grpc_channel_;
-
-    //std::unique_ptr<CaptureClient> capture_client_;
+    
+    std::unique_ptr<CaptureClient> capture_client_;
 };
 
 #endif // ORBIT_CLIENT_GGP_CLIENT_GGP_H_

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -8,8 +8,8 @@
 #include "grpcpp/grpcpp.h"
 
 #include <cstdint>
-#include <string>
 #include <memory>
+#include <string>
 
 #include "ClientGgpOptions.h"
 #include "OrbitCaptureClient/CaptureClient.h"

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -1,0 +1,13 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_CLIENT_GGP_CLIENT_GGP_H_
+#define ORBIT_CLIENT_GGP_CLIENT_GGP_H_
+
+#include "ClientGgpOptions.h"
+#include "OrbitCaptureClient/CaptureListener.h"
+
+class ClientGgp : public CaptureListener {};
+
+#endif // ORBIT_CLIENT_GGP_CLIENT_GGP_H_

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -5,9 +5,26 @@
 #ifndef ORBIT_CLIENT_GGP_CLIENT_GGP_H_
 #define ORBIT_CLIENT_GGP_CLIENT_GGP_H_
 
+#include "grpcpp/grpcpp.h"
+
 #include "ClientGgpOptions.h"
+#include "OrbitCaptureClient/CaptureClient.h"
 #include "OrbitCaptureClient/CaptureListener.h"
 
-class ClientGgp : public CaptureListener {};
+class ClientGgp {
+  public:
+    ClientGgp(ClientGgpOptions&& options);
+    bool InitClient();
+    void StartCapture();
+    void EndCapture();
+    void SaveCapture();
+
+  private:
+    ClientGgpOptions options_;
+
+    std::shared_ptr<grpc::Channel> grpc_channel_;
+
+    //std::unique_ptr<CaptureClient> capture_client_;
+};
 
 #endif // ORBIT_CLIENT_GGP_CLIENT_GGP_H_

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -15,14 +15,12 @@
 #include "OrbitProcess.h"  // remove if including Capture.h in here
 #include "grpcpp/grpcpp.h"
 
-
 class ClientGgp final : public CaptureListener {
  public:
   ClientGgp(ClientGgpOptions&& options);
   bool InitClient();
-  bool PrepareStartCapture();
-  void RequestStartCapture();
-  void StopCapture();
+  bool RequestStartCapture(ThreadPool* thread_pool);
+  bool StopCapture();
   void SaveCapture();
 
   // CaptureListener implementation

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -29,6 +29,8 @@ class ClientGgp final : public CaptureListener {
     void SaveCapture();
 
     // CaptureListener implementation
+    void OnCaptureStarted() override;
+    void OnCaptureComplete() override;
     void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
     void OnKeyAndString(uint64_t key, std::string str) override;
     void OnCallstack(CallStack callstack) override;

--- a/OrbitClientGgp/ClientGgpOptions.h
+++ b/OrbitClientGgp/ClientGgpOptions.h
@@ -15,4 +15,4 @@ struct ClientGgpOptions {
   int32_t capture_pid;
 };
 
-#endif // ORBIT_CLIENT_GGP_CLIENT_GGP_OPTIONS_H_
+#endif  // ORBIT_CLIENT_GGP_CLIENT_GGP_OPTIONS_H_

--- a/OrbitClientGgp/ClientGgpOptions.h
+++ b/OrbitClientGgp/ClientGgpOptions.h
@@ -12,6 +12,7 @@
 struct ClientGgpOptions {
   // gRPC connection string
   std::string grpc_server_address;
+  int32_t capture_pid;
 };
 
 #endif // ORBIT_CLIENT_GGP_CLIENT_GGP_OPTIONS_H_

--- a/OrbitClientGgp/ClientGgpOptions.h
+++ b/OrbitClientGgp/ClientGgpOptions.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_CLIENT_GGP_CLIENT_GGP_OPTIONS_H_
+#define ORBIT_CLIENT_GGP_CLIENT_GGP_OPTIONS_H_
+
+#include <string>
+
+// The struct used to store Orbit Ggp Client options
+// The default values are set by main()
+struct ClientGgpOptions {
+  // gRPC connection string
+  std::string grpc_server_address;
+};
+
+#endif // ORBIT_CLIENT_GGP_CLIENT_GGP_OPTIONS_H_

--- a/OrbitClientGgp/main.cpp
+++ b/OrbitClientGgp/main.cpp
@@ -2,10 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "ClientGgp.h"
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
 
-#include "ClientGgp.h"
 
 ABSL_FLAG(uint64_t, grpc_port, 44765, "Grpc service's port");
 ABSL_FLAG(int32_t, pid, 0, "pid to capture");
@@ -19,7 +19,7 @@ int main(int argc, char** argv) {
   absl::ParseCommandLine(argc, argv);
   uint64_t grpc_port = absl::GetFlag(FLAGS_grpc_port);
   uint32_t capture_length = absl::GetFlag(FLAGS_capture_length);
-  
+
   if (!absl::GetFlag(FLAGS_pid)) {
     FATAL("pid to capture not provided; set using -pid");
   }
@@ -29,20 +29,18 @@ int main(int argc, char** argv) {
   options.capture_pid = absl::GetFlag(FLAGS_pid);
 
   ClientGgp client_ggp(std::move(options));
-  if (!client_ggp.InitClient()){
+  if (!client_ggp.InitClient()) {
     return -1;
   }
 
   LOG("Let's start the capture");
-  if(!client_ggp.PrepareStartCapture()){
+  if (!client_ggp.PrepareStartCapture()) {
     return -1;
   }
 
   // The request is done in a separate thread to avoid blocking main()
   std::thread client_thread;
-  client_thread = std::thread([&]() {
-    client_ggp.RequestStartCapture();
-  });
+  client_thread = std::thread([&]() { client_ggp.RequestStartCapture(); });
 
   // Captures for the period of time requested
   LOG("Go to sleep");
@@ -54,8 +52,8 @@ int main(int argc, char** argv) {
   LOG("Shut down the thread and wait for it to finish");
   client_thread.join();
 
-  //TODO: process/save capture data
-  
+  // TODO: process/save capture data
+
   LOG("All done");
   return 0;
 }

--- a/OrbitClientGgp/main.cpp
+++ b/OrbitClientGgp/main.cpp
@@ -11,15 +11,10 @@
 #include "absl/flags/usage_config.h"
 #include "absl/strings/str_format.h"
 
-#include "grpcpp/grpcpp.h"
-
-#include "ClientGgpOptions.h"
 #include "ClientGgp.h"
 #include "OrbitBase/Logging.h"
-#include "OrbitCaptureClient/CaptureClient.h"
 
 ABSL_FLAG(uint64_t, grpc_port, 44765, "Grpc service's port");
-
 
 int main() {
   // TODO This must be in client class but here in the meantime
@@ -29,27 +24,10 @@ int main() {
   options.grpc_server_address = 
     absl::StrFormat("127.0.0.1:%d", grpc_port_);
 
-  // TODO: move to ClientGgp / delete following line
-  std::string grpc_server_address = options.grpc_server_address;
-
-  // Creating channel
-  grpc::ChannelArguments channel_arguments;
-  channel_arguments.SetMaxReceiveMessageSize(
-      std::numeric_limits<int32_t>::max());
-
-  std::shared_ptr<grpc::Channel> grpc_channel_ = grpc::CreateCustomChannel(
-      grpc_server_address, grpc::InsecureChannelCredentials(),
-      channel_arguments);
-
-  if (!grpc_channel_) {
-    ERROR("Unable to create GRPC channel to %s",
-          grpc_server_address);
-  } else {
-    LOG("Created GRPC channel to %s", grpc_server_address);
-}
-
-  // Stubs and details of the service is done in their classes
+  ClientGgp client_ggp(std::move(options));
+  if (!client_ggp.InitClient()){
+    return -1;
+  }
   
-  std::unique_ptr<CaptureClient> capture_client_ = std::make_unique<CaptureClient>(grpc_channel_, nullptr);
   return 0;
 }

--- a/OrbitClientGgp/main.cpp
+++ b/OrbitClientGgp/main.cpp
@@ -2,32 +2,53 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <iostream>
-#include <string>
+//#include <iostream>
+//#include <string>
 
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
-#include "absl/flags/usage.h"
-#include "absl/flags/usage_config.h"
-#include "absl/strings/str_format.h"
+//#include "absl/flags/usage.h"
+//#include "absl/flags/usage_config.h"
+//#include "absl/strings/str_format.h"
 
 #include "ClientGgp.h"
-#include "OrbitBase/Logging.h"
+//#include "OrbitBase/Logging.h"
 
 ABSL_FLAG(uint64_t, grpc_port, 44765, "Grpc service's port");
+ABSL_FLAG(int32_t, pid, 0, "pid to capture");
+ABSL_FLAG(uint16_t, sampling_rate, 1000,
+          "Frequency of callstack sampling in samples per second");
+ABSL_FLAG(bool, frame_pointer_unwinding, false,
+          "Use frame pointers for unwinding");
 
-int main() {
-  // TODO This must be in client class but here in the meantime
-    uint16_t grpc_port_ = absl::GetFlag(FLAGS_grpc_port);
+int main(int argc, char** argv) {
+  absl::ParseCommandLine(argc, argv);
+  uint64_t grpc_port_ = absl::GetFlag(FLAGS_grpc_port);
+  
+  if (!absl::GetFlag(FLAGS_pid)) {
+    ERROR("pid to capture not provided; set using -pid");
+    return -1;
+  }
 
   ClientGgpOptions options;
   options.grpc_server_address = 
-    absl::StrFormat("127.0.0.1:%d", grpc_port_);
+        absl::StrFormat("127.0.0.1:%d", grpc_port_);
+  options.capture_pid = absl::GetFlag(FLAGS_pid);
 
   ClientGgp client_ggp(std::move(options));
   if (!client_ggp.InitClient()){
     return -1;
   }
-  
+
+  LOG("Lets start the capture");
+
+  if(!client_ggp.StartCapture()){
+    return -1;
+  }
+
+  LOG("Obvs not reaching here");
+
+  client_ggp.StopCapture();
+
   return 0;
 }

--- a/OrbitClientGgp/main.cpp
+++ b/OrbitClientGgp/main.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <iostream>
+#include <string>
+
+#include "absl/flags/flag.h"
+#include "absl/flags/parse.h"
+#include "absl/flags/usage.h"
+#include "absl/flags/usage_config.h"
+#include "absl/strings/str_format.h"
+
+#include "grpcpp/grpcpp.h"
+
+#include "ClientGgpOptions.h"
+#include "ClientGgp.h"
+#include "OrbitBase/Logging.h"
+#include "OrbitCaptureClient/CaptureClient.h"
+
+ABSL_FLAG(uint64_t, grpc_port, 44765, "Grpc service's port");
+
+
+int main() {
+  // TODO This must be in client class but here in the meantime
+    uint16_t grpc_port_ = absl::GetFlag(FLAGS_grpc_port);
+
+  ClientGgpOptions options;
+  options.grpc_server_address = 
+    absl::StrFormat("127.0.0.1:%d", grpc_port_);
+
+  // TODO: move to ClientGgp / delete following line
+  std::string grpc_server_address = options.grpc_server_address;
+
+  // Creating channel
+  grpc::ChannelArguments channel_arguments;
+  channel_arguments.SetMaxReceiveMessageSize(
+      std::numeric_limits<int32_t>::max());
+
+  std::shared_ptr<grpc::Channel> grpc_channel_ = grpc::CreateCustomChannel(
+      grpc_server_address, grpc::InsecureChannelCredentials(),
+      channel_arguments);
+
+  if (!grpc_channel_) {
+    ERROR("Unable to create GRPC channel to %s",
+          grpc_server_address);
+  } else {
+    LOG("Created GRPC channel to %s", grpc_server_address);
+}
+
+  // Stubs and details of the service is done in their classes
+  
+  std::unique_ptr<CaptureClient> capture_client_ = std::make_unique<CaptureClient>(grpc_channel_, nullptr);
+  return 0;
+}

--- a/OrbitClientGgp/main.cpp
+++ b/OrbitClientGgp/main.cpp
@@ -34,25 +34,23 @@ int main(int argc, char** argv) {
   }
 
   LOG("Let's start the capture");
-
   if(!client_ggp.PrepareStartCapture()){
     return -1;
   }
 
-  std::thread client_thread;
-
   // The request is done in a separate thread to avoid blocking main()
+  std::thread client_thread;
   client_thread = std::thread([&]() {
     client_ggp.RequestStartCapture();
   });
 
-  LOG("Go to sleep");
   // Captures for the period of time requested
+  LOG("Go to sleep");
   absl::SleepFor(absl::Seconds(capture_length));
   LOG("Back from sleep");
 
+  // Requests to stop the capture and waits for thread to finish
   client_ggp.StopCapture();
-
   LOG("Shut down the thread and wait for it to finish");
   client_thread.join();
 

--- a/OrbitClientGgp/main.cpp
+++ b/OrbitClientGgp/main.cpp
@@ -2,17 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-//#include <iostream>
-//#include <string>
-
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
-//#include "absl/flags/usage.h"
-//#include "absl/flags/usage_config.h"
-//#include "absl/strings/str_format.h"
 
 #include "ClientGgp.h"
-//#include "OrbitBase/Logging.h"
 #include "OrbitBase/ThreadPool.h"
 
 ABSL_FLAG(uint64_t, grpc_port, 44765, "Grpc service's port");

--- a/OrbitClientGgp/main.cpp
+++ b/OrbitClientGgp/main.cpp
@@ -35,6 +35,7 @@ int main(int argc, char** argv) {
         absl::StrFormat("127.0.0.1:%d", grpc_port_);
   options.capture_pid = absl::GetFlag(FLAGS_pid);
 
+  //  std::unique_ptr<ClientGgp> client_ggp = std::make_unique<ClientGgp>(std::move(options));
   ClientGgp client_ggp(std::move(options));
   if (!client_ggp.InitClient()){
     return -1;
@@ -42,11 +43,15 @@ int main(int argc, char** argv) {
 
   LOG("Lets start the capture");
 
-  if(!client_ggp.StartCapture()){
+  if(!client_ggp.PrepareStartCapture()){
     return -1;
   }
 
-  LOG("Obvs not reaching here");
+  // TODO: Do this in a new thread
+  client_ggp.RequestStartCapture();
+
+  // Captures for a little while
+  sleep(10);
 
   client_ggp.StopCapture();
 

--- a/run_client_ssh.ps1
+++ b/run_client_ssh.ps1
@@ -1,0 +1,59 @@
+# Connects to the instance and starts OrbitClientGgp. To also deploy OrbitClientGgp,
+# invoke with a the argument -deploy and a path to the OrbitClientGgp executable
+# e.g. run_client_ssh.ps1 -deploy build/bin/OrbitClientGgp
+# All other arguments will be passed to OrbitClientGgp.
+
+param (
+    [Parameter(Mandatory=$false)][string]$deploy,
+    [Parameter(ValueFromRemainingArguments = $true)]$remainingArgs
+ )
+
+$ggp_sdk_path = $env:GGP_SDK_PATH
+
+IF(!$ggp_sdk_path) {
+    throw "GGP_SDK_PATH environment variable not found"
+}
+
+$ggp_path = "$($ggp_sdk_path)dev\bin\ggp.exe"
+
+IF($deploy) {
+    $ggp_put_command = "`"$($ggp_path)`" ssh put `"$($deploy)`""
+    Invoke-Expression "& $ggp_put_command"
+    $ggp_chmod_command = "`"$($ggp_path)`" ssh shell -- chmod u+x /mnt/developer/OrbitClientGgp"
+    Invoke-Expression "& $ggp_chmod_command"
+}
+
+$ggp_ssh_init_command = "`"$($ggp_path)`" ssh init"
+
+Invoke-Expression "& $ggp_ssh_init_command" | Tee-Object -Variable ggp_out
+
+$lines = $ggp_out -split "\n"
+
+ForEach ($line in $lines) {
+    if ($line.Contains("User:")) {
+        $ggp_user = $line.Replace("User:", "").Trim()
+    }
+    if ($line.Contains("Host:")) {
+        $ggp_host = $line.Replace("Host:", "").Trim()
+    }
+    if ($line.Contains("Port:")) {
+        $ggp_port = $line.Replace("Port:", "").Trim()
+    }
+    if ($line.Contains("Key Path:")) {
+        $ggp_key_path = $line.Replace("Key Path:", "").Trim()
+    }
+    if ($line.Contains("Known Hosts Path:")) {
+        $ggp_known_hosts_path = $line.Replace("Known Hosts Path:", "").Trim()
+    }
+}
+
+IF (!$ggp_user -Or !$ggp_host -Or !$ggp_port -Or !$ggp_key_path -Or !$ggp_known_hosts_path) {
+  throw "Unable to get all necessary information from ggp ssh init"
+}
+
+$ssh_path = "$($ggp_sdk_path)tools\OpenSSH-Win64\ssh.exe"
+
+$ssh_command = "`"$($ssh_path)`" -t -p`"$($ggp_port)`" -i`"$($ggp_key_path)`" -oStrictHostKeyChecking=yes -oUserKnownHostsFile=`"$($ggp_known_hosts_path)`" -L44766:localhost:44766 -L44765:localhost:44765 $($ggp_user)@$($ggp_host) -- /mnt/developer/OrbitClientGgp $($remainingArgs)"
+
+Invoke-Expression "& $ssh_command"
+

--- a/run_client_ssh.ps1
+++ b/run_client_ssh.ps1
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 # Connects to the instance and starts OrbitClientGgp. To also deploy OrbitClientGgp,
 # invoke with a the argument -deploy and a path to the OrbitClientGgp executable
 # e.g. run_client_ssh.ps1 -deploy build/bin/OrbitClientGgp


### PR DESCRIPTION
### Create OrbitClientGgp to manage a capture request from the ggp instance

Main files and the structure of the project has been created. Basic flow is working: initial set up, starts capture, captures for a period of time and stops the capture.

Capture data is not collected or handled yet; this pull request is intended to include the project in Orbit so there is not a huge list of commits later. Also it avoids being 'silently' broken in updates related to Capture, etc. 

The options related to the capture cycle must be provided as an argument to OrbitClientGgp. Some values are given a default value but others are required to be provided by the user:

* pid. (Mandatory) Id of the process to capture.
* grpc_port. (Optional) Required for gRPC, by default is 44765.
* sampling_rate. (Optional) Required for CaptureClient to work, by default is 1000.
* frame_pointer_unwinding. (Optional) Required for CaptureClient to work.
* capture_length. (Optional) Sets the length of the capture in seconds, by default is 10

The new project contains the following files:

+ main.cpp Contains the linear flow and handles the different classes instantiation and requests
+ ClientGgp.h/cc Contains methods that handle the gRPC client and capture requests. Extends and implements CaptureListener (although it does not handle the calls yet).
+ ClientGgpOptions.h  Struct containing the options needed for the client initialisation.

Also a Run_client_ssh.ps1 script has been created to facilitate the deployment and test of OrbitClientGgp.


