### PR TITLE
Added missing license/copyright headers to fuzzer files

### DIFF
--- a/OrbitCore/ModuleLoadSymbolsFuzzer.cpp
+++ b/OrbitCore/ModuleLoadSymbolsFuzzer.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <libfuzzer/libfuzzer_macro.h>
 
 #include "OrbitModule.h"

--- a/OrbitCore/SymbolHelperLoadSymbolsCollectorFuzzer.cpp
+++ b/OrbitCore/SymbolHelperLoadSymbolsCollectorFuzzer.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <string>
 
 #include "SymbolHelper.h"

--- a/OrbitGl/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/OrbitGl/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #include <libfuzzer/libfuzzer_macro.h>
 

--- a/OrbitGl/CaptureSerializerLoadFuzzer.cpp
+++ b/OrbitGl/CaptureSerializerLoadFuzzer.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <absl/flags/flag.h>
 
 #include <cstdio>

--- a/OrbitGl/DataManagerUpdateModuleInfosFuzzer.cpp
+++ b/OrbitGl/DataManagerUpdateModuleInfosFuzzer.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <libfuzzer/libfuzzer_macro.h>
 
 #include "DataManager.h"


### PR DESCRIPTION
I missed adding license headers to the fuzz-test-cpp-files. This commit
is fixing that.