### PR TITLE
Remove extra function calls from capture

### DIFF
--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -39,8 +39,6 @@ std::shared_ptr<SamplingProfiler> Capture::GSamplingProfiler = nullptr;
 std::shared_ptr<Process> Capture::GTargetProcess = nullptr;
 std::shared_ptr<PresetFile> Capture::GSessionPresets = nullptr;
 
-void (*Capture::GClearCaptureDataFunc)();
-
 void Capture::Init() { GTargetProcess = std::make_shared<Process>(); }
 
 void Capture::SetTargetProcess(const std::shared_ptr<Process>& a_Process) {
@@ -107,10 +105,6 @@ void Capture::PreFunctionHooks() {
   }
 
   GVisibleFunctionsMap = GSelectedFunctionsMap;
-
-  if (GClearCaptureDataFunc) {
-    GClearCaptureDataFunc();
-  }
 }
 
 std::vector<std::shared_ptr<FunctionInfo>> Capture::GetSelectedFunctions() {

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -55,8 +55,6 @@ ErrorMessageOr<void> Capture::StartCapture() {
         "No process selected. Please choose a target process for the capture.");
   }
 
-  ClearCaptureData();
-
   GCaptureTimePoint = std::chrono::system_clock::now();
   GProcessId = GTargetProcess->GetID();
   GProcessName = GTargetProcess->GetName();

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -45,7 +45,6 @@ class Capture {
   static std::shared_ptr<SamplingProfiler> GSamplingProfiler;
   static std::shared_ptr<Process> GTargetProcess;
   static std::shared_ptr<orbit_client_protos::PresetFile> GSessionPresets;
-  static void (*GClearCaptureDataFunc)();
   static std::vector<std::shared_ptr<orbit_client_protos::FunctionInfo>>
       GSelectedInCaptureFunctions;
   static std::map<uint64_t, orbit_client_protos::FunctionInfo*>

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -592,8 +592,12 @@ void OrbitApp::StopCapture() {
 
 void OrbitApp::ClearCapture() {
   Capture::ClearCaptureData();
-  Capture::GClearCaptureDataFunc();
-  GCurrentTimeGraph->Clear();
+
+  if (GCurrentTimeGraph) {
+    GCurrentTimeGraph->Clear();
+  }
+  GOrbitApp->FireRefreshCallbacks(DataViewType::LIVE_FUNCTIONS);
+
   if (capture_cleared_callback_) {
     capture_cleared_callback_();
   }
@@ -639,7 +643,6 @@ void OrbitApp::SendTooltipToUi(const std::string& tooltip) {
     }
   });
 }
-
 
 void OrbitApp::SendInfoToUi(const std::string& title, const std::string& text) {
   main_thread_executor_->Schedule([this, title, text] {

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -36,14 +36,6 @@ float GlCanvas::Z_VALUE_BOX_INACTIVE = -0.03f;
 float GlCanvas::Z_VALUE_EVENT_BAR = -0.1f;
 float GlCanvas::Z_VALUE_EVENT_BAR_PICKING = 0.1f;
 
-void ClearCaptureData() {
-  if (GCurrentTimeGraph) {
-    GCurrentTimeGraph->Clear();
-  }
-
-  GOrbitApp->FireRefreshCallbacks(DataViewType::LIVE_FUNCTIONS);
-}
-
 GlCanvas::GlCanvas() : ui_batcher_(PickingID::BatcherId::UI) {
   m_TextRenderer.SetCanvas(this);
 
@@ -80,8 +72,6 @@ GlCanvas::GlCanvas() : ui_batcher_(PickingID::BatcherId::UI) {
   m_ID = counter++;
 
   m_UpdateTimer.Start();
-
-  Capture::GClearCaptureDataFunc = ClearCaptureData;
 
   // SetCursor(wxCURSOR_BLANK);
 


### PR DESCRIPTION
A small clean up before the global capture changes by @florian-kuebler : remove extra function calls.