### PR TITLE
Use this->GetCallStack instead of GSamplingProfiler->GetCallStack

### DIFF
--- a/OrbitCore/SamplingProfiler.cpp
+++ b/OrbitCore/SamplingProfiler.cpp
@@ -70,8 +70,7 @@ std::multimap<int, CallstackID> SamplingProfiler::GetCallstacksFromAddress(
 void SamplingProfiler::AddCallStack(CallstackEvent callstack_event) {
   CallstackID hash = callstack_event.callstack_hash();
   if (!HasCallStack(hash)) {
-    std::shared_ptr<CallStack> callstack =
-        Capture::GSamplingProfiler->GetCallStack(hash);
+    std::shared_ptr<CallStack> callstack = GetCallStack(hash);
     AddUniqueCallStack(*callstack);
   }
 


### PR DESCRIPTION
`GSamplingProfiler` is currently a global inside the capture class. Within the `SamplingProfiler` class, this global should not be used, but instead `this`, as it is a usual class.