### PR TITLE
Move GAddressToFunctionName and GAddressToModuleName from Capture to SamplingProfiler

### DIFF
--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -28,7 +28,6 @@ int32_t Capture::GProcessId = -1;
 std::string Capture::GProcessName;
 std::unordered_map<int32_t, std::string> Capture::GThreadNames;
 std::unordered_map<uint64_t, LinuxAddressInfo> Capture::GAddressInfos;
-std::unordered_map<uint64_t, std::string> Capture::GAddressToModuleName;
 TextBox* Capture::GSelectedTextBox = nullptr;
 ThreadID Capture::GSelectedThreadId;
 std::chrono::system_clock::time_point Capture::GCaptureTimePoint =
@@ -85,7 +84,6 @@ void Capture::ClearCaptureData() {
   GProcessName = "";
   GThreadNames.clear();
   GAddressInfos.clear();
-  GAddressToModuleName.clear();
   GSelectedTextBox = nullptr;
   GSelectedThreadId = 0;
 }

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -28,7 +28,6 @@ int32_t Capture::GProcessId = -1;
 std::string Capture::GProcessName;
 std::unordered_map<int32_t, std::string> Capture::GThreadNames;
 std::unordered_map<uint64_t, LinuxAddressInfo> Capture::GAddressInfos;
-std::unordered_map<uint64_t, std::string> Capture::GAddressToFunctionName;
 std::unordered_map<uint64_t, std::string> Capture::GAddressToModuleName;
 TextBox* Capture::GSelectedTextBox = nullptr;
 ThreadID Capture::GSelectedThreadId;
@@ -86,7 +85,6 @@ void Capture::ClearCaptureData() {
   GProcessName = "";
   GThreadNames.clear();
   GAddressInfos.clear();
-  GAddressToFunctionName.clear();
   GAddressToModuleName.clear();
   GSelectedTextBox = nullptr;
   GSelectedThreadId = 0;

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -56,7 +56,6 @@ class Capture {
   static std::unordered_map<int32_t, std::string> GThreadNames;
   static std::unordered_map<uint64_t, orbit_client_protos::LinuxAddressInfo>
       GAddressInfos;
-  static std::unordered_map<uint64_t, std::string> GAddressToModuleName;
   static class TextBox* GSelectedTextBox;
   static ThreadID GSelectedThreadId;
   static std::chrono::system_clock::time_point GCaptureTimePoint;

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -56,7 +56,6 @@ class Capture {
   static std::unordered_map<int32_t, std::string> GThreadNames;
   static std::unordered_map<uint64_t, orbit_client_protos::LinuxAddressInfo>
       GAddressInfos;
-  static std::unordered_map<uint64_t, std::string> GAddressToFunctionName;
   static std::unordered_map<uint64_t, std::string> GAddressToModuleName;
   static class TextBox* GSelectedTextBox;
   static ThreadID GSelectedThreadId;

--- a/OrbitCore/SamplingProfiler.cpp
+++ b/OrbitCore/SamplingProfiler.cpp
@@ -147,6 +147,7 @@ void SamplingProfiler::ProcessSamples() {
   m_FunctionAddressToExactAddresses.clear();
   m_SortedThreadSampleData.clear();
   address_to_function_name_.clear();
+  address_to_module_name_.clear();
 
   // Unique call stacks and per thread data
   for (const CallstackEvent& callstack : m_Callstacks) {
@@ -340,8 +341,8 @@ void SamplingProfiler::UpdateAddressInfo(uint64_t address) {
   } else if (address_info != nullptr) {
     module_name = Path::GetFileName(address_info->module_name());
   }
-  Capture::GAddressToModuleName[address] = module_name;
-  Capture::GAddressToModuleName[function_address] = module_name;
+  address_to_module_name_[address] = module_name;
+  address_to_module_name_[function_address] = module_name;
 }
 
 void SamplingProfiler::FillThreadSampleDataSampleReports() {
@@ -374,8 +375,8 @@ void SamplingProfiler::FillThreadSampleDataSampleReports() {
             100.f * it->second / threadSampleData.m_NumSamples;
       }
       function.m_Address = address;
-      CHECK(Capture::GAddressToModuleName.count(address) > 0);
-      function.m_Module = Capture::GAddressToModuleName.at(address);
+      CHECK(address_to_module_name_.count(address) > 0);
+      function.m_Module = address_to_module_name_.at(address);
 
       sampleReport.push_back(function);
     }
@@ -386,6 +387,15 @@ const std::string& SamplingProfiler::GetFunctionNameByAddress(
     uint64_t address) const {
   auto it = address_to_function_name_.find(address);
   if (it != address_to_function_name_.end()) {
+    return it->second;
+  }
+  return kUnknownFunctionOrModuleName;
+}
+
+const std::string& SamplingProfiler::GetModuleNameByAddress(
+    uint64_t address) const {
+  auto it = address_to_module_name_.find(address);
+  if (it != address_to_module_name_.end()) {
     return it->second;
   }
   return kUnknownFunctionOrModuleName;

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -122,6 +122,9 @@ class SamplingProfiler {
     m_Callstacks.clear();
   }
 
+  [[nodiscard]] const std::string& GetFunctionNameByAddress(
+      uint64_t address) const;
+
   static const int32_t kAllThreadsFakeTid;
   static const std::string kUnknownFunctionOrModuleName;
 
@@ -151,6 +154,8 @@ class SamplingProfiler {
   std::unordered_map<uint64_t, std::unordered_set<uint64_t>>
       m_FunctionAddressToExactAddresses;
   std::vector<ThreadSampleData*> m_SortedThreadSampleData;
+
+  absl::flat_hash_map<uint64_t, std::string> address_to_function_name_;
 };
 
 #endif  // ORBIT_CORE_SAMPLING_PROFILER_H_

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -124,6 +124,8 @@ class SamplingProfiler {
 
   [[nodiscard]] const std::string& GetFunctionNameByAddress(
       uint64_t address) const;
+  [[nodiscard]] const std::string& GetModuleNameByAddress(
+      uint64_t address) const;
 
   static const int32_t kAllThreadsFakeTid;
   static const std::string kUnknownFunctionOrModuleName;
@@ -156,6 +158,7 @@ class SamplingProfiler {
   std::vector<ThreadSampleData*> m_SortedThreadSampleData;
 
   absl::flat_hash_map<uint64_t, std::string> address_to_function_name_;
+  absl::flat_hash_map<uint64_t, std::string> address_to_module_name_;
 };
 
 #endif  // ORBIT_CORE_SAMPLING_PROFILER_H_

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -438,8 +438,7 @@ void OrbitApp::AddTopDownView(const SamplingProfiler& sampling_profiler) {
   }
   std::unique_ptr<TopDownView> top_down_view =
       TopDownView::CreateFromSamplingProfiler(
-          sampling_profiler, Capture::GProcessName, Capture::GThreadNames,
-          Capture::GAddressToFunctionName);
+          sampling_profiler, Capture::GProcessName, Capture::GThreadNames);
   top_down_view_callback_(std::move(top_down_view));
 }
 

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -217,7 +217,8 @@ CallStackDataView::CallStackDataViewFrame CallStackDataView::GetFrameFromIndex(
   } else {
     std::string fallback_name;
     if (Capture::GSamplingProfiler != nullptr) {
-      fallback_name = Capture::GAddressToFunctionName[address];
+      fallback_name =
+          Capture::GSamplingProfiler->GetFunctionNameByAddress(address);
     }
     return CallStackDataViewFrame(address, fallback_name, module);
   }

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -68,7 +68,8 @@ std::string CallStackDataView::GetValue(int a_Row, int a_Column) {
         return module->m_Name;
       }
       if (Capture::GSamplingProfiler != nullptr) {
-        return Capture::GAddressToModuleName[frame.address];
+        return Capture::GSamplingProfiler->GetModuleNameByAddress(
+            frame.address);
       }
       return "";
     case COLUMN_ADDRESS:

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -180,16 +180,17 @@ bool EventTrack::IsEmpty() const {
 
 static std::string SafeGetFormattedFunctionName(uint64_t addr,
                                                 int max_line_length) {
-  auto it = Capture::GAddressToFunctionName.find(addr);
-  if (it == Capture::GAddressToFunctionName.end()) {
-    return std::string("<i>") + "???" + "</i>";
+  const std::string& function_name =
+      Capture::GSamplingProfiler->GetFunctionNameByAddress(addr);
+  if (function_name == SamplingProfiler::kUnknownFunctionOrModuleName) {
+    return std::string("<i>") + function_name + "</i>";
   }
 
   std::string fn_name =
       max_line_length >= 0
-          ? ShortenStringWithEllipsis(it->second,
+          ? ShortenStringWithEllipsis(function_name,
                                       static_cast<size_t>(max_line_length))
-          : it->second;
+          : function_name;
   // Simple HTML escaping
   fn_name = Replace(fn_name, "&", "&amp;");
   fn_name = Replace(fn_name, "<", "&lt;");

--- a/OrbitGl/TopDownView.h
+++ b/OrbitGl/TopDownView.h
@@ -140,8 +140,7 @@ class [[nodiscard]] TopDownView : public TopDownNode {
   [[nodiscard]] static std::unique_ptr<TopDownView> CreateFromSamplingProfiler(
       const SamplingProfiler& sampling_profiler,
       const std::string& process_name,
-      const std::unordered_map<int32_t, std::string>& thread_names,
-      const std::unordered_map<uint64_t, std::string>& function_names);
+      const std::unordered_map<int32_t, std::string>& thread_names);
 
   TopDownView() : TopDownNode{nullptr} {}
 


### PR DESCRIPTION
Address review comment in https://github.com/google/orbit/pull/864#discussion_r462113581

Move `GAddressToFunctionName` and `GAddressToModuleName` from Capture to SamplingProfiler.