### PR TITLE
Move state to CaptureClient

### DIFF
--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -19,8 +19,6 @@ using orbit_client_protos::LinuxAddressInfo;
 using orbit_client_protos::PresetFile;
 using orbit_client_protos::PresetInfo;
 
-Capture::State Capture::GState = Capture::State::kEmpty;
-
 CaptureData Capture::capture_data_;
 std::map<uint64_t, FunctionInfo*> Capture::GSelectedFunctionsMap;
 std::map<uint64_t, FunctionInfo*> Capture::GVisibleFunctionsMap;
@@ -56,19 +54,13 @@ ErrorMessageOr<void> Capture::StartCapture() {
   Capture::GSamplingProfiler =
       std::make_shared<SamplingProfiler>(Capture::GTargetProcess);
 
-  GState = State::kStarted;
-
   return outcome::success();
 }
-
-void Capture::StopCapture() { GState = State::kStopping; }
 
 void Capture::FinalizeCapture() {
   if (Capture::GSamplingProfiler != nullptr) {
     Capture::GSamplingProfiler->ProcessSamples();
   }
-
-  GState = State::kDone;
 }
 
 void Capture::ClearCaptureData() {
@@ -95,10 +87,6 @@ std::vector<std::shared_ptr<FunctionInfo>> Capture::GetSelectedFunctions() {
     }
   }
   return selected_functions;
-}
-
-bool Capture::IsCapturing() {
-  return GState == State::kStarted || GState == State::kStopping;
 }
 
 ErrorMessageOr<void> Capture::SavePreset(const std::string& filename) {

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -24,24 +24,19 @@ struct CallStack;
 
 class Capture {
  public:
-  enum class State { kEmpty = 0, kStarted, kStopping, kDone };
 
   static void Init();
   static void SetTargetProcess(const std::shared_ptr<Process>& a_Process);
   static ErrorMessageOr<void> StartCapture();
-  static void StopCapture();
   static void FinalizeCapture();
   static void ClearCaptureData();
   static std::vector<std::shared_ptr<orbit_client_protos::FunctionInfo>>
   GetSelectedFunctions();
   static void PreFunctionHooks();
-  static bool IsCapturing();
   static ErrorMessageOr<void> SavePreset(const std::string& filename);
   static void PreSave();
 
   static CaptureData capture_data_;
-
-  static State GState;
 
   static std::shared_ptr<SamplingProfiler> GSamplingProfiler;
   static std::shared_ptr<Process> GTargetProcess;

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -262,8 +262,6 @@ ErrorMessageOr<void> CaptureSerializer::Load(std::istream& stream) {
     time_graph_->ProcessTimer(timer_info);
   }
 
-  Capture::GState = Capture::State::kDone;
-
   GOrbitApp->AddSamplingReport(Capture::GSamplingProfiler);
   GOrbitApp->AddTopDownView(*Capture::GSamplingProfiler);
   GOrbitApp->FireRefreshCallbacks();

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -84,7 +84,7 @@ void CaptureWindow::MouseMoved(int a_X, int a_Y, bool a_Left, bool /*a_Right*/,
 
   // Pan
   if (a_Left && !m_ImguiActive && !m_PickingManager.IsDragging() &&
-      !Capture::IsCapturing()) {
+      !GOrbitApp->IsCapturing()) {
     float worldMin;
     float worldMax;
 
@@ -515,7 +515,7 @@ void CaptureWindow::Draw() {
   m_WorldMaxY =
       1.5f * ScreenToWorldHeight(static_cast<int>(slider_->GetPixelHeight()));
 
-  if (Capture::IsCapturing()) {
+  if (GOrbitApp->IsCapturing()) {
     ZoomAll();
   }
 
@@ -569,7 +569,7 @@ void CaptureWindow::DrawScreenSpace() {
     double width = stop - start;
     double maxStart = timeSpan - width;
     double ratio =
-        Capture::IsCapturing() ? 1 : (maxStart != 0 ? start / maxStart : 0);
+        GOrbitApp->IsCapturing() ? 1 : (maxStart != 0 ? start / maxStart : 0);
     float slider_width = layout.GetSliderWidth();
     slider_->SetPixelHeight(slider_width);
     slider_->SetSliderRatio(static_cast<float>(ratio));

--- a/OrbitGl/LiveFunctionsDataView.cpp
+++ b/OrbitGl/LiveFunctionsDataView.cpp
@@ -305,7 +305,7 @@ void LiveFunctionsDataView::OnDataChanged() {
 }
 
 void LiveFunctionsDataView::OnTimer() {
-  if (Capture::IsCapturing()) {
+  if (GOrbitApp->IsCapturing()) {
     OnSort(m_SortingColumn, {});
   }
 }

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -951,7 +951,7 @@ void TimeGraph::SortTracks() {
   }
 
   // Reorder threads once every second when capturing
-  if (!Capture::IsCapturing() || m_LastThreadReorder.QueryMillis() > 1000.0) {
+  if (!GOrbitApp->IsCapturing() || m_LastThreadReorder.QueryMillis() > 1000.0) {
     std::vector<ThreadID> sortedThreadIds;
 
     // Show threads with instrumented functions first


### PR DESCRIPTION
This change moves capture state from a global
to CaptureClient and syncronizes access to it
it is now thread-safe and consistent.

This also introduces kStarting state which indicates
that start is initiated but is not yet in the correct
state for stopping.  StopCapture waits until the state
becomes something other that kStarting before either
initiating a stop or in the case Start has failed -
ignoring user request.

Bug: http://b/161968742