### PR TITLE
GlPanel is destroyed correctly on destruction of OrbitGLWidget

### DIFF
--- a/OrbitGl/GlPanel.cpp
+++ b/OrbitGl/GlPanel.cpp
@@ -7,14 +7,13 @@
 #include "CaptureWindow.h"
 
 std::unique_ptr<GlPanel> GlPanel::Create(Type a_Type) {
-  std::unique_ptr<GlPanel> panel = nullptr;
-
-  switch (a_Type) {
-    case CAPTURE:
-      panel = std::make_unique<CaptureWindow>();
-      break;
+  // Intended to be a factory method creating different types of
+  // GlPanels, but right now there's only CAPTURE
+  if (a_Type != CAPTURE) {
+    return nullptr;
   }
 
+  std::unique_ptr<GlPanel> panel = std::make_unique<CaptureWindow>();
   panel->m_Type = a_Type;
 
   return panel;

--- a/OrbitGl/GlPanel.cpp
+++ b/OrbitGl/GlPanel.cpp
@@ -21,6 +21,8 @@ GlPanel* GlPanel::Create(Type a_Type) {
   return panel;
 }
 
+void GlPanel::Destroy(GlPanel* panel) { delete panel; }
+
 GlPanel::GlPanel() {
   m_WindowOffset[0] = 0;
   m_WindowOffset[1] = 0;

--- a/OrbitGl/GlPanel.cpp
+++ b/OrbitGl/GlPanel.cpp
@@ -6,22 +6,19 @@
 
 #include "CaptureWindow.h"
 
-GlPanel* GlPanel::Create(Type a_Type) {
-  GlPanel* panel = nullptr;
+std::unique_ptr<GlPanel> GlPanel::Create(Type a_Type) {
+  std::unique_ptr<GlPanel> panel = nullptr;
 
   switch (a_Type) {
     case CAPTURE:
-      panel = new CaptureWindow();
+      panel = std::make_unique<CaptureWindow>();
       break;
   }
 
   panel->m_Type = a_Type;
 
-  // Todo: fix leak...
   return panel;
 }
-
-void GlPanel::Destroy(GlPanel* panel) { delete panel; }
 
 GlPanel::GlPanel() {
   m_WindowOffset[0] = 0;

--- a/OrbitGl/GlPanel.h
+++ b/OrbitGl/GlPanel.h
@@ -14,6 +14,7 @@ class GlPanel {
   enum Type { CAPTURE };
 
   static GlPanel* Create(Type a_Type);
+  static void Destroy(GlPanel* panel);
 
   virtual void Initialize();
   virtual void Resize(int a_Width, int a_Height);

--- a/OrbitGl/GlPanel.h
+++ b/OrbitGl/GlPanel.h
@@ -3,9 +3,9 @@
 // found in the LICENSE file.
 
 #pragma once
+#include <memory>
 #include <string>
 #include <vector>
-#include <memory>
 
 class GlPanel {
  public:

--- a/OrbitGl/GlPanel.h
+++ b/OrbitGl/GlPanel.h
@@ -5,6 +5,7 @@
 #pragma once
 #include <string>
 #include <vector>
+#include <memory>
 
 class GlPanel {
  public:
@@ -13,8 +14,7 @@ class GlPanel {
 
   enum Type { CAPTURE };
 
-  static GlPanel* Create(Type a_Type);
-  static void Destroy(GlPanel* panel);
+  static std::unique_ptr<GlPanel> Create(Type a_Type);
 
   virtual void Initialize();
   virtual void Resize(int a_Width, int a_Height);

--- a/OrbitQt/orbitglwidget.cpp
+++ b/OrbitQt/orbitglwidget.cpp
@@ -48,8 +48,6 @@ void OrbitGLWidget::Initialize(GlPanel::Type a_Type,
   }
 }
 
-OrbitGLWidget::~OrbitGLWidget() { GlPanel::Destroy(m_OrbitPanel); }
-
 void OrbitGLWidget::initializeGL() {
 #if ORBIT_DEBUG_OPEN_GL
   m_DebugLogger = new QOpenGLDebugLogger(this);

--- a/OrbitQt/orbitglwidget.cpp
+++ b/OrbitQt/orbitglwidget.cpp
@@ -41,15 +41,14 @@ bool OrbitGLWidget::eventFilter(QObject* /*object*/, QEvent* event) {
 
 void OrbitGLWidget::Initialize(GlPanel::Type a_Type,
                                OrbitMainWindow* a_MainWindow) {
-  UNUSED(a_Type);
-  UNUSED(a_MainWindow);
-
   m_OrbitPanel = GlPanel::Create(a_Type);
 
   if (a_MainWindow) {
     a_MainWindow->RegisterGlWidget(this);
   }
 }
+
+OrbitGLWidget::~OrbitGLWidget() { GlPanel::Destroy(m_OrbitPanel); }
 
 void OrbitGLWidget::initializeGL() {
 #if ORBIT_DEBUG_OPEN_GL

--- a/OrbitQt/orbitglwidget.h
+++ b/OrbitQt/orbitglwidget.h
@@ -17,14 +17,13 @@ class OrbitGLWidget : public QOpenGLWidget, protected QOpenGLFunctions {
 
  public:
   explicit OrbitGLWidget(QWidget* parent = nullptr);
-  ~OrbitGLWidget() override;
   void Initialize(GlPanel::Type a_Type, class OrbitMainWindow* a_MainWindow);
   void initializeGL() override;
   void resizeGL(int w, int h) override;
   void paintGL() override;
   bool eventFilter(QObject* object, QEvent* event) override;
   void TakeScreenShot();
-  GlPanel* GetPanel() { return m_OrbitPanel; }
+  GlPanel* GetPanel() { return m_OrbitPanel.get(); }
   void PrintContextInformation();
 
   void mousePressEvent(QMouseEvent* event) override;
@@ -43,6 +42,6 @@ class OrbitGLWidget : public QOpenGLWidget, protected QOpenGLFunctions {
   void OnMenuClicked(int a_Index);
 
  private:
-  GlPanel* m_OrbitPanel;
+  std::unique_ptr<GlPanel> m_OrbitPanel;
   QOpenGLDebugLogger* m_DebugLogger;
 };

--- a/OrbitQt/orbitglwidget.h
+++ b/OrbitQt/orbitglwidget.h
@@ -17,6 +17,7 @@ class OrbitGLWidget : public QOpenGLWidget, protected QOpenGLFunctions {
 
  public:
   explicit OrbitGLWidget(QWidget* parent = nullptr);
+  ~OrbitGLWidget() override;
   void Initialize(GlPanel::Type a_Type, class OrbitMainWindow* a_MainWindow);
   void initializeGL() override;
   void resizeGL(int w, int h) override;


### PR DESCRIPTION
Small fix to have GlPanel consistently destroyed when the OrbitGLWidget is destroyed. This *probably* doesn't happen during runtime, but won't hurt nevertheless.