### PR TITLE
Added .clang-tidy file

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,61 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+---
+Checks: >
+  -*,
+  abseil-*,
+  bugprone-*,
+  cert-*,
+  -cert-err58-cpp,
+  cppcoreguidelines-*,
+  -cppcoreguidelines-special-member-functions,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-pro-type-vararg,
+  -cppcoreguidelines-non-private-member-variables-in-classes,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-avoid-non-const-global-variables,
+  misc-*,
+  -misc-non-private-member-variables-in-classes,
+  google-*,
+  -google-default-arguments,
+  -google-runtime-references,
+  modernize-*,
+  -modernize-use-noexcept,
+  -modernize-use-trailing-return-type,
+  performance-*,
+  -performance-noexcept-move-constructor,
+  readability-*,
+  -readability-magic-numbers,
+  -readability-non-const-parameter,
+  -readability-uppercase-literal-suffix,
+
+
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+CheckOptions:
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             readability-identifier-naming.ClassCase
+    value:           'CamelCase'
+  - key:             readability-identifier-naming.ConstexprVariableCase
+    value:           'CamelCase'
+  - key:             readability-identifier-naming.ConstexprVariablePrefix
+    value:           'k'
+  - key:             readability-identifier-naming.EnumCase
+    value:           'CamelCase'
+  - key:             readability-identifier-naming.EnumConstantCase
+    value:           'CamelCase'
+  - key:             readability-identifier-naming.EnumConstantPrefix
+    value:           'k'
+  - key:             readability-identifier-naming.FunctionCase
+    value:           'CamelCase'
+  - key:             readability-identifier-naming.LocalVariableCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.ParameterCase
+    value:           'lower_case'
+  - key:             readability-identifier-naming.StructCase
+    value:           'CamelCase'
+  - key:             readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+...


### PR DESCRIPTION
This is my attempt on producing a clang-tidy file that is helpful for our codebase. I tried to enable as many useful checks as possible without getting too many warning messages for our codebase. 

The naming rules do not work for class/struct member naming since clang-tidy currently does not differentiate between class and struct, but the google style guide does (class: `lower_case_` struct: `lower_case`). Wrong naming of functions, local variables, constants, classes, struct and parameters should get caught with this file. 

This is best used with an IDE, but can also be triggered via the command line (`clang-tidy <filename>`)

* CLion defaults to using its own clang-tidy checks, using this file needs to be enabled in settings.
* VS2019 supports clang-tidy files (needs to be enabled in settings) (VS2017 no support)
* clangd extension for vscode supports clang-tidy files out of the box