### PR TITLE
Fix 100% crash when capturing instrumented functions.

### DIFF
--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -65,9 +65,10 @@ class CaptureData {
   }
 
   [[nodiscard]] const std::string& GetThreadName(int32_t thread_id) const {
-    static std::string empty_string;
-    return thread_names_.contains(thread_id) ? thread_names_.at(thread_id)
-                                             : empty_string;
+    static const std::string kEmptyString;
+    auto it = thread_names_.find(thread_id);
+    return it != thread_names_.end() ? thread_names_.at(thread_id)
+                                     : kEmptyString;
   }
 
   void set_thread_names(

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -64,8 +64,10 @@ class CaptureData {
     return thread_names_;
   }
 
-  [[nodiscard]] const std::string& GetThreadName(int32_t thread_id) {
-    return thread_names_[thread_id];
+  [[nodiscard]] const std::string& GetThreadName(int32_t thread_id) const {
+    static std::string empty_string;
+    return thread_names_.contains(thread_id) ? thread_names_.at(thread_id)
+                                             : empty_string;
   }
 
   void set_thread_names(

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -64,8 +64,8 @@ class CaptureData {
     return thread_names_;
   }
 
-  [[nodiscard]] const std::string& GetThreadName(int32_t thread_id) const {
-    return thread_names_.at(thread_id);
+  [[nodiscard]] const std::string& GetThreadName(int32_t thread_id) {
+    return thread_names_[thread_id];
   }
 
   void set_thread_names(

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -67,8 +67,7 @@ class CaptureData {
   [[nodiscard]] const std::string& GetThreadName(int32_t thread_id) const {
     static const std::string kEmptyString;
     auto it = thread_names_.find(thread_id);
-    return it != thread_names_.end() ? thread_names_.at(thread_id)
-                                     : kEmptyString;
+    return it != thread_names_.end() ? it->second : kEmptyString;
   }
 
   void set_thread_names(


### PR DESCRIPTION
The code assumed that the hashmap contained the thread name. Use operator[] instead of at() to insert and return an empty string if the thread name is not (yet) present.