### PR TITLE
Capture Toolbar Cleanup.

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -560,6 +560,8 @@ void OrbitApp::FireRefreshCallbacks(DataViewType type) {
   }
 }
 
+bool OrbitApp::IsCapturing() const { return Capture::IsCapturing(); }
+
 bool OrbitApp::StartCapture() {
   CHECK(!Capture::IsCapturing());
 

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -68,6 +68,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   ErrorMessageOr<void> OnLoadPreset(const std::string& file_name);
   ErrorMessageOr<void> OnSaveCapture(const std::string& file_name);
   ErrorMessageOr<void> OnLoadCapture(const std::string& file_name);
+  bool IsCapturing() const;
   bool StartCapture();
   void StopCapture();
   void ClearCapture();

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -154,11 +154,6 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void SetTooltipCallback(TooltipCallback callback) {
     tooltip_callback_ = std::move(callback);
   }
-  using FeedbackDialogCallback = std::function<void()>;
-  void SetFeedbackDialogCallback(FeedbackDialogCallback callback) {
-    feedback_dialog_callback_ = std::move(callback);
-  }
-
   using RefreshCallback = std::function<void(DataViewType type)>;
   void SetRefreshCallback(RefreshCallback callback) {
     refresh_callback_ = std::move(callback);
@@ -254,7 +249,6 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   ErrorMessageCallback error_message_callback_;
   InfoMessageCallback info_message_callback_;
   TooltipCallback tooltip_callback_;
-  FeedbackDialogCallback feedback_dialog_callback_;
   RefreshCallback refresh_callback_;
   SamplingReportCallback sampling_reports_callback_;
   SamplingReportCallback selection_report_callback_;

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -147,7 +147,6 @@ OrbitMainWindow::OrbitMainWindow(
   GOrbitApp->SetTooltipCallback([this](const std::string& tooltip) {
     QToolTip::showText(QCursor::pos(), QString::fromStdString(tooltip), this);
   });
-  GOrbitApp->SetFeedbackDialogCallback([this] { ShowFeedbackDialog(); });
   GOrbitApp->SetSaveFileCallback([this](const std::string& extension) {
     return this->OnGetSaveFileName(extension);
   });
@@ -305,44 +304,6 @@ void OrbitMainWindow::SetupCodeView() {
   ui->CodeTextEdit->SetFindLineEdit(ui->lineEdit);
   ui->FileMappingWidget->hide();
   OrbitCodeEditor::setFileMappingWidget(ui->FileMappingWidget);
-}
-
-void OrbitMainWindow::ShowFeedbackDialog() {
-  QDialog feedback_dialog{nullptr,
-                          Qt::WindowTitleHint | Qt::WindowCloseButtonHint};
-
-  const auto layout = QPointer{new QGridLayout{&feedback_dialog}};
-  const auto button_box =
-      QPointer{new QDialogButtonBox{QDialogButtonBox::StandardButton::Close}};
-
-  const QPointer<QPushButton> report_missing_feature_button =
-      QPointer{new QPushButton{&feedback_dialog}};
-  button_box->addButton(report_missing_feature_button,
-                        QDialogButtonBox::AcceptRole);
-  report_missing_feature_button->setText("Report Missing Feature");
-  const QPointer<QPushButton> report_bug_button =
-      QPointer{new QPushButton{&feedback_dialog}};
-  button_box->addButton(report_bug_button, QDialogButtonBox::AcceptRole);
-  report_bug_button->setText("Report Bug");
-
-  layout->addWidget(button_box, 0, 0);
-
-  QObject::connect(report_missing_feature_button, &QPushButton::clicked,
-                   &feedback_dialog, [this, &feedback_dialog]() {
-                     on_actionReport_Missing_Feature_triggered();
-                     feedback_dialog.accept();
-                   });
-
-  QObject::connect(report_bug_button, &QPushButton::clicked, &feedback_dialog,
-                   [this, &feedback_dialog]() {
-                     on_actionReport_Bug_triggered();
-                     feedback_dialog.accept();
-                   });
-
-  QObject::connect(button_box, &QDialogButtonBox::rejected, &feedback_dialog,
-                   &QDialog::reject);
-
-  feedback_dialog.exec();
 }
 
 OrbitMainWindow::~OrbitMainWindow() { delete ui; }
@@ -590,8 +551,6 @@ void OrbitMainWindow::on_actionClear_Capture_triggered() {
 }
 
 void OrbitMainWindow::on_actionHelp_triggered() { GOrbitApp->ToggleDrawHelp(); }
-
-void OrbitMainWindow::on_actionFeedback_triggered() { ShowFeedbackDialog(); }
 
 void OrbitMainWindow::ShowCaptureOnSaveWarningIfNeeded() {
   QSettings settings("The Orbit Authors", "Orbit Profiler");

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -77,7 +77,6 @@ class OrbitMainWindow : public QMainWindow {
   void on_actionOpen_Capture_triggered();
   void on_actionClear_Capture_triggered();
   void on_actionHelp_triggered();
-  void on_actionFeedback_triggered();
 
   void on_actionCheckFalse_triggered();
   void on_actionNullPointerDereference_triggered();

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -72,8 +72,7 @@ class OrbitMainWindow : public QMainWindow {
   void on_actionToogleDevMode_toggled(bool arg1);
   void on_actionSave_Preset_As_triggered();
 
-  void on_actionStart_Capture_triggered();
-  void on_actionStop_Capture_triggered();
+  void on_actionToggle_Capture_triggered();
   void on_actionSave_Capture_triggered();
   void on_actionOpen_Capture_triggered();
   void on_actionClear_Capture_triggered();
@@ -105,6 +104,8 @@ class OrbitMainWindow : public QMainWindow {
   QLabel* timer_label_ = nullptr;
   QLineEdit* filter_functions_line_edit_ = nullptr;
   QLineEdit* filter_tracks_line_edit_ = nullptr;
+  QIcon icon_start_capture_;
+  QIcon icon_stop_capture_;
 
   std::string m_CurrentPdbName;
 };

--- a/OrbitQt/orbitmainwindow.ui
+++ b/OrbitQt/orbitmainwindow.ui
@@ -330,14 +330,6 @@
     <string>Search</string>
    </property>
   </action>
-  <action name="actionFeedback">
-   <property name="text">
-    <string>Feedback</string>
-   </property>
-   <property name="toolTip">
-    <string>Feedback</string>
-   </property>
-  </action>
   <action name="actionHelp">
    <property name="text">
     <string>Help</string>

--- a/OrbitQt/orbitmainwindow.ui
+++ b/OrbitQt/orbitmainwindow.ui
@@ -298,17 +298,12 @@
     <string>Open Preset</string>
    </property>
   </action>
-  <action name="actionStart_Capture">
+  <action name="actionToggle_Capture">
    <property name="text">
-    <string>Start Capture</string>
+    <string>Toggle Capture</string>
    </property>
    <property name="toolTip">
-    <string>Start Capture</string>
-   </property>
-  </action>
-  <action name="actionStop_Capture">
-   <property name="text">
-    <string>Stop Capture</string>
+    <string>Toggle Capture</string>
    </property>
   </action>
   <action name="actionClear_Capture">


### PR DESCRIPTION
- Fuse start and stop into a single toggle button.
- Toggle button icon changes based on capture state.
- Remove redundant feedback button.
- Remove feedback dialog.