### PR TITLE
Fixed small bug in run_clang_format.sh

### DIFF
--- a/run_clang_format.sh
+++ b/run_clang_format.sh
@@ -4,4 +4,4 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-find . \( -name '*.cpp' -o -name '*.h' \) ! -path './third_party/*' ! -path './build/*' ! -path './cmake-*' ! -name 'resource.h' | xargs clang-format -i
+find . \( -name '*.cpp' -o -name '*.h' \) ! -path './third_party/*' ! -path './build*/*' ! -path './cmake-*' ! -name 'resource.h' | xargs clang-format -i


### PR DESCRIPTION
run_clang_format.sh did format files in build_ folders, now it does not
anymore. This is now the same as in the .gitignore file.