### PR TITLE
Moved FunctionStats from FunctionInfo to CaptureData. 

### DIFF
--- a/OrbitClientProtos/capture_data.proto
+++ b/OrbitClientProtos/capture_data.proto
@@ -15,6 +15,7 @@ message FunctionStats {
 }
 
 message FunctionInfo {
+  reserved 11;
   string name = 1;
   string pretty_name = 2;
   string loaded_module_path = 3;
@@ -41,7 +42,6 @@ message FunctionInfo {
     kOrbitTrackDoubleAsInt64 = 12;
   }
   OrbitType type = 10;
-  FunctionStats stats = 11;
 }
 
 message CallstackEvent {
@@ -74,6 +74,8 @@ message CaptureInfo {
   repeated CallstackInfo callstacks = 6;
   repeated CallstackEvent callstack_events = 7;
   map<uint64, string> key_to_string = 8;
+  // TODO(kuebler): consider removing this field completely.
+  map<uint64, FunctionStats> function_stats = 9;
 }
 
 message TimerInfo {

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -73,7 +73,6 @@ void Capture::PreFunctionHooks() {
   for (auto& func : capture_data_.selected_functions()) {
     uint64_t address = FunctionUtils::GetAbsoluteAddress(*func);
     GSelectedFunctionsMap[address] = func.get();
-    func->clear_stats();
   }
 
   GVisibleFunctionsMap = GSelectedFunctionsMap;

--- a/OrbitCore/CaptureData.cpp
+++ b/OrbitCore/CaptureData.cpp
@@ -4,6 +4,10 @@
 
 #include "CaptureData.h"
 
+#include "Profiling.h"
+
+using orbit_client_protos::FunctionStats;
+
 orbit_client_protos::LinuxAddressInfo* CaptureData::GetAddressInfo(
     uint64_t address) {
   auto address_info_it = address_infos_.find(address);
@@ -11,4 +15,34 @@ orbit_client_protos::LinuxAddressInfo* CaptureData::GetAddressInfo(
     return nullptr;
   }
   return &address_info_it->second;
+}
+
+const FunctionStats& CaptureData::GetFunctionStatsOrDefault(
+    uint64_t function_address) {
+  static const FunctionStats kDefaultFunctionStats;
+  auto function_stats_it = functions_stats_.find(function_address);
+  if (function_stats_it == functions_stats_.end()) {
+    return kDefaultFunctionStats;
+  }
+  return function_stats_it->second;
+}
+
+void CaptureData::UpdateFunctionStats(
+    orbit_client_protos::FunctionInfo* func,
+    const orbit_client_protos::TimerInfo& timer_info) {
+  const uint64_t function_address = func->address();
+  FunctionStats& stats = functions_stats_[function_address];
+  stats.set_count(stats.count() + 1);
+  uint64_t elapsed_nanos =
+      TicksToNanoseconds(timer_info.start(), timer_info.end());
+  stats.set_total_time_ns(stats.total_time_ns() + elapsed_nanos);
+  stats.set_average_time_ns(stats.total_time_ns() / stats.count());
+
+  if (elapsed_nanos > stats.max_ns()) {
+    stats.set_max_ns(elapsed_nanos);
+  }
+
+  if (stats.min_ns() == 0 || elapsed_nanos < stats.min_ns()) {
+    stats.set_min_ns(elapsed_nanos);
+  }
 }

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -20,6 +20,16 @@ class CaptureData {
       : process_id_{process_id},
         process_name_{std::move(process_name)},
         selected_functions_{std::move(selected_functions)} {}
+  explicit CaptureData(
+      int32_t process_id, std::string process_name,
+      std::vector<std::shared_ptr<orbit_client_protos::FunctionInfo>>
+          selected_functions,
+      absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionStats>
+          functions_stats)
+      : process_id_{process_id},
+        process_name_{std::move(process_name)},
+        selected_functions_{std::move(selected_functions)},
+        functions_stats_{std::move(functions_stats)} {}
 
   explicit CaptureData() = default;
   CaptureData(const CaptureData& other) = default;
@@ -79,6 +89,17 @@ class CaptureData {
     thread_names_.insert_or_assign(thread_id, std::move(thread_name));
   }
 
+  const absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionStats>&
+  functions_stats() {
+    return functions_stats_;
+  }
+
+  const orbit_client_protos::FunctionStats& GetFunctionStatsOrDefault(
+      uint64_t function_address);
+
+  void UpdateFunctionStats(orbit_client_protos::FunctionInfo* func,
+                           const orbit_client_protos::TimerInfo& timer_info);
+
  private:
   absl::flat_hash_map<uint64_t, orbit_client_protos::LinuxAddressInfo>
       address_infos_;
@@ -92,6 +113,9 @@ class CaptureData {
 
   std::chrono::system_clock::time_point capture_start_time_ =
       std::chrono::system_clock::now();
+
+  absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionStats>
+      functions_stats_;
 };
 
 #endif  // ORBIT_CORE_CAPTURE_DATA_H_

--- a/OrbitCore/FunctionUtils.cpp
+++ b/OrbitCore/FunctionUtils.cpp
@@ -10,7 +10,6 @@
 #include "Log.h"
 #include "OrbitBase/Logging.h"
 #include "Path.h"
-#include "Profiling.h"
 #include "Utils.h"
 
 namespace FunctionUtils {
@@ -111,23 +110,6 @@ bool SetOrbitTypeFromName(FunctionInfo* func) {
     }
   }
   return false;
-}
-
-void UpdateStats(FunctionInfo* func, const TimerInfo& timer_info) {
-  FunctionStats* stats = func->mutable_stats();
-  stats->set_count(stats->count() + 1);
-  uint64_t elapsed_nanos =
-      TicksToNanoseconds(timer_info.start(), timer_info.end());
-  stats->set_total_time_ns(stats->total_time_ns() + elapsed_nanos);
-  stats->set_average_time_ns(stats->total_time_ns() / stats->count());
-
-  if (elapsed_nanos > stats->max_ns()) {
-    stats->set_max_ns(elapsed_nanos);
-  }
-
-  if (stats->min_ns() == 0 || elapsed_nanos < stats->min_ns()) {
-    stats->set_min_ns(elapsed_nanos);
-  }
 }
 
 bool IsSelected(const SampledFunction& func) {

--- a/OrbitCore/FunctionUtils.h
+++ b/OrbitCore/FunctionUtils.h
@@ -43,8 +43,6 @@ bool IsSelected(const orbit_client_protos::FunctionInfo& func);
 void Print(const orbit_client_protos::FunctionInfo& func);
 
 bool SetOrbitTypeFromName(orbit_client_protos::FunctionInfo* func);
-void UpdateStats(orbit_client_protos::FunctionInfo* func,
-                 const orbit_client_protos::TimerInfo& timer_info);
 
 bool IsSelected(const SampledFunction& func);
 

--- a/OrbitGl/CaptureSerializer.h
+++ b/OrbitGl/CaptureSerializer.h
@@ -28,7 +28,7 @@ class CaptureSerializer {
 
   orbit_client_protos::CaptureHeader header;
 
-  const std::string kRequiredCaptureVersion = "1.51";
+  const std::string kRequiredCaptureVersion = "1.52";
 };
 
 #endif  // ORBIT_GL_CAPTURE_SERIALIZER_H_

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -324,7 +324,7 @@ void TimeGraph::ProcessTimer(const TimerInfo& timer_info) {
         timer_info.function_address());
 
     if (func != nullptr) {
-      FunctionUtils::UpdateStats(func, timer_info);
+      Capture::capture_data_.UpdateFunctionStats(func, timer_info);
       if (FunctionUtils::IsOrbitFunc(*func)) {
         ProcessOrbitFunctionTimer(func, timer_info);
       }


### PR DESCRIPTION
This will break compatibility to old captures, but the decoupling of those helps to reduce code complexity (e.g. on cleaning). It will also allow a history of captures at some point.