### PR TITLE
Picking manager / Batcher variable renaming

### DIFF
--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -94,18 +94,18 @@ void Batcher::AddTriangle(Vec3 v0, Vec3 v1, Vec3 v2, Color color,
 }
 
 PickingUserData* Batcher::GetUserData(PickingID a_ID) {
-  CHECK(a_ID.m_Id >= 0);
+  CHECK(a_ID.id_ >= 0);
 
-  switch (a_ID.m_Type) {
+  switch (a_ID.type_) {
     case PickingID::Type::kBox:
-      CHECK(a_ID.m_Id < box_buffer_.m_UserData.size());
-      return box_buffer_.m_UserData[a_ID.m_Id].get();
+      CHECK(a_ID.id_ < box_buffer_.m_UserData.size());
+      return box_buffer_.m_UserData[a_ID.id_].get();
     case PickingID::Type::kLine:
-      CHECK(a_ID.m_Id < line_buffer_.m_UserData.size());
-      return line_buffer_.m_UserData[a_ID.m_Id].get();
+      CHECK(a_ID.id_ < line_buffer_.m_UserData.size());
+      return line_buffer_.m_UserData[a_ID.id_].get();
     case PickingID::Type::kTriangle:
-      CHECK(a_ID.m_Id < triangle_buffer_.user_data_.size());
-      return triangle_buffer_.user_data_[a_ID.m_Id].get();
+      CHECK(a_ID.id_ < triangle_buffer_.user_data_.size());
+      return triangle_buffer_.user_data_[a_ID.id_].get();
   }
 
   return nullptr;

--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -10,7 +10,7 @@
 void Batcher::AddLine(const Line& line, const Color* colors,
                       PickingType picking_type,
                       std::unique_ptr<PickingUserData> user_data) {
-  Color picking_color = PickingID::GetColor(
+  Color picking_color = PickingId::GetColor(
       picking_type, line_buffer_.lines_.size(), batcher_id_);
   line_buffer_.lines_.push_back(line);
   line_buffer_.colors_.push_back(colors, 2);
@@ -51,7 +51,7 @@ void Batcher::AddBox(const Box& box, const Color* colors,
                      PickingType picking_type,
                      std::unique_ptr<PickingUserData> user_data) {
   Color picking_color =
-      PickingID::GetColor(picking_type, box_buffer_.boxes_.size(), batcher_id_);
+      PickingId::GetColor(picking_type, box_buffer_.boxes_.size(), batcher_id_);
   box_buffer_.boxes_.push_back(box);
   box_buffer_.colors_.push_back(colors, 4);
   box_buffer_.picking_colors_.push_back_n(picking_color, 4);
@@ -77,7 +77,7 @@ void Batcher::AddShadedBox(Vec2 pos, Vec2 size, float z, Color color,
 void Batcher::AddTriangle(const Triangle& triangle, Color color,
                           PickingType picking_type,
                           std::unique_ptr<PickingUserData> user_data) {
-  Color picking_color = PickingID::GetColor(
+  Color picking_color = PickingId::GetColor(
       picking_type, triangle_buffer_.triangles_.size(), batcher_id_);
   triangle_buffer_.triangles_.push_back(triangle);
   triangle_buffer_.colors_.push_back_n(color, 3);
@@ -91,7 +91,7 @@ void Batcher::AddTriangle(Vec3 v0, Vec3 v1, Vec3 v2, Color color,
   AddTriangle(Triangle(v0, v1, v2), color, picking_type, std::move(user_data));
 }
 
-PickingUserData* Batcher::GetUserData(PickingID id) {
+PickingUserData* Batcher::GetUserData(PickingId id) {
   CHECK(id.id_ >= 0);
 
   switch (id.type_) {
@@ -113,7 +113,7 @@ PickingUserData* Batcher::GetUserData(PickingID id) {
   return nullptr;
 }
 
-TextBox* Batcher::GetTextBox(PickingID a_ID) {
+TextBox* Batcher::GetTextBox(PickingId a_ID) {
   PickingUserData* data = GetUserData(a_ID);
 
   if (data && data->text_box_) {

--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -97,13 +97,13 @@ PickingUserData* Batcher::GetUserData(PickingID a_ID) {
   CHECK(a_ID.m_Id >= 0);
 
   switch (a_ID.m_Type) {
-    case PickingID::BOX:
+    case PickingID::Type::kBox:
       CHECK(a_ID.m_Id < box_buffer_.m_UserData.size());
       return box_buffer_.m_UserData[a_ID.m_Id].get();
-    case PickingID::LINE:
+    case PickingID::Type::kLine:
       CHECK(a_ID.m_Id < line_buffer_.m_UserData.size());
       return line_buffer_.m_UserData[a_ID.m_Id].get();
-    case PickingID::TRIANGLE:
+    case PickingID::Type::kTriangle:
       CHECK(a_ID.m_Id < triangle_buffer_.user_data_.size());
       return triangle_buffer_.user_data_[a_ID.m_Id].get();
   }

--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -92,20 +92,20 @@ void Batcher::AddTriangle(Vec3 v0, Vec3 v1, Vec3 v2, Color color,
 }
 
 PickingUserData* Batcher::GetUserData(PickingId id) {
-  CHECK(id.id_ >= 0);
+  CHECK(id.id >= 0);
 
-  switch (id.type_) {
+  switch (id.type) {
     case PickingType::kInvalid:
       return nullptr;
     case PickingType::kBox:
-      CHECK(id.id_ < box_buffer_.user_data_.size());
-      return box_buffer_.user_data_[id.id_].get();
+      CHECK(id.id < box_buffer_.user_data_.size());
+      return box_buffer_.user_data_[id.id].get();
     case PickingType::kLine:
-      CHECK(id.id_ < line_buffer_.user_data_.size());
-      return line_buffer_.user_data_[id.id_].get();
+      CHECK(id.id < line_buffer_.user_data_.size());
+      return line_buffer_.user_data_[id.id].get();
     case PickingType::kTriangle:
-      CHECK(id.id_ < triangle_buffer_.user_data_.size());
-      return triangle_buffer_.user_data_[id.id_].get();
+      CHECK(id.id < triangle_buffer_.user_data_.size());
+      return triangle_buffer_.user_data_[id.id].get();
     case PickingType::kPickable:
       return nullptr;
   }

--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -18,8 +18,7 @@ void Batcher::AddLine(const Line& line, const Color* colors,
   line_buffer_.user_data_.push_back(std::move(user_data));
 }
 
-void Batcher::AddLine(const Line& line, Color color,
-                      PickingType picking_type,
+void Batcher::AddLine(const Line& line, Color color, PickingType picking_type,
                       std::unique_ptr<PickingUserData> user_data) {
   Color colors[2];
   Fill(colors, color);
@@ -51,16 +50,15 @@ void Batcher::AddVerticalLine(Vec2 pos, float size, float z, Color color,
 void Batcher::AddBox(const Box& box, const Color* colors,
                      PickingType picking_type,
                      std::unique_ptr<PickingUserData> user_data) {
-  Color picking_color = PickingID::GetColor(
-      picking_type, box_buffer_.boxes_.size(), batcher_id_);
+  Color picking_color =
+      PickingID::GetColor(picking_type, box_buffer_.boxes_.size(), batcher_id_);
   box_buffer_.boxes_.push_back(box);
   box_buffer_.colors_.push_back(colors, 4);
   box_buffer_.picking_colors_.push_back_n(picking_color, 4);
   box_buffer_.user_data_.push_back(std::move(user_data));
 }
 
-void Batcher::AddBox(const Box& box, Color color,
-                     PickingType picking_type,
+void Batcher::AddBox(const Box& box, Color color, PickingType picking_type,
                      std::unique_ptr<PickingUserData> user_data) {
   Color colors[4];
   Fill(colors, color);
@@ -109,14 +107,13 @@ PickingUserData* Batcher::GetUserData(PickingID id) {
   }
 
   return nullptr;
- ;
 }
 
 TextBox* Batcher::GetTextBox(PickingID a_ID) {
   PickingUserData* data = GetUserData(a_ID);
 
   if (data && data->text_box_) {
-    return data->text_box_; 
+    return data->text_box_;
   }
 
   return nullptr;

--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -8,7 +8,7 @@
 #include "Utils.h"
 
 void Batcher::AddLine(const Line& line, const Color* colors,
-                      PickingID::Type picking_type,
+                      PickingType picking_type,
                       std::unique_ptr<PickingUserData> user_data) {
   Color picking_color = PickingID::GetColor(
       picking_type, line_buffer_.m_Lines.size(), batcher_id_);
@@ -19,7 +19,7 @@ void Batcher::AddLine(const Line& line, const Color* colors,
 }
 
 void Batcher::AddLine(const Line& line, Color color,
-                      PickingID::Type picking_type,
+                      PickingType picking_type,
                       std::unique_ptr<PickingUserData> user_data) {
   Color colors[2];
   Fill(colors, color);
@@ -27,7 +27,7 @@ void Batcher::AddLine(const Line& line, Color color,
 }
 
 void Batcher::AddLine(Vec2 from, Vec2 to, float z, Color color,
-                      PickingID::Type picking_type,
+                      PickingType picking_type,
                       std::unique_ptr<PickingUserData> user_data) {
   Line line;
   Color colors[2];
@@ -38,7 +38,7 @@ void Batcher::AddLine(Vec2 from, Vec2 to, float z, Color color,
 }
 
 void Batcher::AddVerticalLine(Vec2 pos, float size, float z, Color color,
-                              PickingID::Type picking_type,
+                              PickingType picking_type,
                               std::unique_ptr<PickingUserData> user_data) {
   Line line;
   Color colors[2];
@@ -49,7 +49,7 @@ void Batcher::AddVerticalLine(Vec2 pos, float size, float z, Color color,
 }
 
 void Batcher::AddBox(const Box& a_Box, const Color* colors,
-                     PickingID::Type picking_type,
+                     PickingType picking_type,
                      std::unique_ptr<PickingUserData> user_data) {
   Color picking_color = PickingID::GetColor(
       picking_type, box_buffer_.m_Boxes.size(), batcher_id_);
@@ -60,7 +60,7 @@ void Batcher::AddBox(const Box& a_Box, const Color* colors,
 }
 
 void Batcher::AddBox(const Box& a_Box, Color color,
-                     PickingID::Type picking_type,
+                     PickingType picking_type,
                      std::unique_ptr<PickingUserData> user_data) {
   Color colors[4];
   Fill(colors, color);
@@ -68,7 +68,7 @@ void Batcher::AddBox(const Box& a_Box, Color color,
 }
 
 void Batcher::AddShadedBox(Vec2 pos, Vec2 size, float z, Color color,
-                           PickingID::Type picking_type,
+                           PickingType picking_type,
                            std::unique_ptr<PickingUserData> user_data) {
   Color colors[4];
   GetBoxGradientColors(color, colors);
@@ -77,7 +77,7 @@ void Batcher::AddShadedBox(Vec2 pos, Vec2 size, float z, Color color,
 }
 
 void Batcher::AddTriangle(const Triangle& triangle, Color color,
-                          PickingID::Type picking_type,
+                          PickingType picking_type,
                           std::unique_ptr<PickingUserData> user_data) {
   Color picking_color = PickingID::GetColor(
       picking_type, triangle_buffer_.triangles_.size(), batcher_id_);
@@ -88,7 +88,7 @@ void Batcher::AddTriangle(const Triangle& triangle, Color color,
 }
 
 void Batcher::AddTriangle(Vec3 v0, Vec3 v1, Vec3 v2, Color color,
-                          PickingID::Type picking_type,
+                          PickingType picking_type,
                           std::unique_ptr<PickingUserData> user_data) {
   AddTriangle(Triangle(v0, v1, v2), color, picking_type, std::move(user_data));
 }
@@ -97,13 +97,13 @@ PickingUserData* Batcher::GetUserData(PickingID a_ID) {
   CHECK(a_ID.id_ >= 0);
 
   switch (a_ID.type_) {
-    case PickingID::Type::kBox:
+    case PickingType::kBox:
       CHECK(a_ID.id_ < box_buffer_.m_UserData.size());
       return box_buffer_.m_UserData[a_ID.id_].get();
-    case PickingID::Type::kLine:
+    case PickingType::kLine:
       CHECK(a_ID.id_ < line_buffer_.m_UserData.size());
       return line_buffer_.m_UserData[a_ID.id_].get();
-    case PickingID::Type::kTriangle:
+    case PickingType::kTriangle:
       CHECK(a_ID.id_ < triangle_buffer_.user_data_.size());
       return triangle_buffer_.user_data_[a_ID.id_].get();
   }

--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -95,6 +95,8 @@ PickingUserData* Batcher::GetUserData(PickingID id) {
   CHECK(id.id_ >= 0);
 
   switch (id.type_) {
+    case PickingType::kInvalid:
+      return nullptr;
     case PickingType::kBox:
       CHECK(id.id_ < box_buffer_.user_data_.size());
       return box_buffer_.user_data_[id.id_].get();
@@ -104,6 +106,8 @@ PickingUserData* Batcher::GetUserData(PickingID id) {
     case PickingType::kTriangle:
       CHECK(id.id_ < triangle_buffer_.user_data_.size());
       return triangle_buffer_.user_data_[id.id_].get();
+    case PickingType::kPickable:
+      return nullptr;
   }
 
   return nullptr;

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -105,11 +105,11 @@ class Batcher {
 
   void Reset();
 
-  PickingUserData* GetUserData(PickingID id);
-  TextBox* GetTextBox(PickingID id);
-  BoxBuffer& GetBoxBuffer() { return box_buffer_; }
-  LineBuffer& GetLineBuffer() { return line_buffer_; }
-  TriangleBuffer& GetTriangleBuffer() { return triangle_buffer_; }
+  [[nodiscard]] PickingUserData* GetUserData(PickingID id);
+  [[nodiscard]] TextBox* GetTextBox(PickingID id);
+  [[nodiscard]] BoxBuffer& GetBoxBuffer() { return box_buffer_; }
+  [[nodiscard]] LineBuffer& GetLineBuffer() { return line_buffer_; }
+  [[nodiscard]] TriangleBuffer& GetTriangleBuffer() { return triangle_buffer_; }
 
  protected:
   void DrawLineBuffer(bool picking);

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -69,35 +69,35 @@ struct TriangleBuffer {
 
 class Batcher {
  public:
-  explicit Batcher(PickingID::BatcherId batcher_id) : batcher_id_(batcher_id) {}
-  Batcher() : batcher_id_(PickingID::BatcherId::kTimeGraph) {}
+  explicit Batcher(BatcherId batcher_id) : batcher_id_(batcher_id) {}
+  Batcher() : batcher_id_(BatcherId::kTimeGraph) {}
 
   void AddLine(const Line& line, const Color* colors,
-               PickingID::Type picking_type, 
+               PickingType picking_type, 
                std::unique_ptr<PickingUserData> user_data = nullptr);
-  void AddLine(const Line& line, Color color, PickingID::Type picking_type,
+  void AddLine(const Line& line, Color color, PickingType picking_type,
                std::unique_ptr<PickingUserData> user_data = nullptr);
   void AddLine(Vec2 from, Vec2 to, float z, Color color,
-               PickingID::Type picking_type,
+               PickingType picking_type,
                std::unique_ptr<PickingUserData> user_data = nullptr);
   void AddVerticalLine(Vec2 pos, float size, float z, Color color,
-                       PickingID::Type picking_type,
+                       PickingType picking_type,
                        std::unique_ptr<PickingUserData> user_data = nullptr);
 
   void AddBox(const Box& a_Box, const Color* colors,
-              PickingID::Type picking_type,
+              PickingType picking_type,
               std::unique_ptr<PickingUserData> user_data = nullptr);
-  void AddBox(const Box& a_Box, Color color, PickingID::Type picking_type,
+  void AddBox(const Box& a_Box, Color color, PickingType picking_type,
               std::unique_ptr<PickingUserData> user_data = nullptr);
   void AddShadedBox(Vec2 pos, Vec2 size, float z, Color color,
-                    PickingID::Type picking_type,
+                    PickingType picking_type,
                     std::unique_ptr<PickingUserData> user_data = nullptr);
 
   void AddTriangle(const Triangle& triangle, Color color,
-                   PickingID::Type picking_type,
+                   PickingType picking_type,
                    std::unique_ptr<PickingUserData> user_data = nullptr);
   void AddTriangle(Vec3 v0, Vec3 v1, Vec3 v2, Color color,
-                   PickingID::Type picking_type,
+                   PickingType picking_type,
                    std::unique_ptr<PickingUserData> user_data = nullptr);
 
   void GetBoxGradientColors(Color color, Color* colors);
@@ -119,5 +119,5 @@ class Batcher {
   LineBuffer line_buffer_;
   BoxBuffer box_buffer_;
   TriangleBuffer triangle_buffer_;
-  PickingID::BatcherId batcher_id_;
+  BatcherId batcher_id_;
 };

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -2,7 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#pragma once
+#ifndef ORBIT_GL_BATCHER_H_
+#define ORBIT_GL_BATCHER_H_
+
 #include <vector>
 
 #include "BlockChain.h"
@@ -16,40 +18,39 @@ struct PickingUserData {
   TooltipCallback generate_tooltip_;
   void* custom_data_ = nullptr;
 
-  PickingUserData(
-    TextBox* text_box = nullptr,
-    TooltipCallback generate_tooltip = nullptr)
-    : text_box_(text_box), generate_tooltip_(generate_tooltip) {}
+  PickingUserData(TextBox* text_box = nullptr,
+                  TooltipCallback generate_tooltip = nullptr)
+      : text_box_(text_box), generate_tooltip_(generate_tooltip) {}
 };
 
 struct LineBuffer {
   void Reset() {
-    m_Lines.Reset();
-    m_Colors.Reset();
-    m_PickingColors.Reset();
-    m_UserData.clear();
+    lines_.Reset();
+    colors_.Reset();
+    picking_colors_.Reset();
+    user_data_.clear();
   }
 
   static const int NUM_LINES_PER_BLOCK = 64 * 1024;
-  BlockChain<Line, NUM_LINES_PER_BLOCK> m_Lines;
-  BlockChain<Color, 2 * NUM_LINES_PER_BLOCK> m_Colors;
-  BlockChain<Color, 2 * NUM_LINES_PER_BLOCK> m_PickingColors;
-  std::vector<std::unique_ptr<PickingUserData>> m_UserData;
+  BlockChain<Line, NUM_LINES_PER_BLOCK> lines_;
+  BlockChain<Color, 2 * NUM_LINES_PER_BLOCK> colors_;
+  BlockChain<Color, 2 * NUM_LINES_PER_BLOCK> picking_colors_;
+  std::vector<std::unique_ptr<PickingUserData>> user_data_;
 };
 
 struct BoxBuffer {
   void Reset() {
-    m_Boxes.Reset();
-    m_Colors.Reset();
-    m_PickingColors.Reset();
-    m_UserData.clear();
+    boxes_.Reset();
+    colors_.Reset();
+    picking_colors_.Reset();
+    user_data_.clear();
   }
 
   static const int NUM_BOXES_PER_BLOCK = 64 * 1024;
-  BlockChain<Box, NUM_BOXES_PER_BLOCK> m_Boxes;
-  BlockChain<Color, 4 * NUM_BOXES_PER_BLOCK> m_Colors;
-  BlockChain<Color, 4 * NUM_BOXES_PER_BLOCK> m_PickingColors;
-  std::vector<std::unique_ptr<PickingUserData>> m_UserData;
+  BlockChain<Box, NUM_BOXES_PER_BLOCK> boxes_;
+  BlockChain<Color, 4 * NUM_BOXES_PER_BLOCK> colors_;
+  BlockChain<Color, 4 * NUM_BOXES_PER_BLOCK> picking_colors_;
+  std::vector<std::unique_ptr<PickingUserData>> user_data_;
 };
 
 struct TriangleBuffer {
@@ -72,8 +73,7 @@ class Batcher {
   explicit Batcher(BatcherId batcher_id) : batcher_id_(batcher_id) {}
   Batcher() : batcher_id_(BatcherId::kTimeGraph) {}
 
-  void AddLine(const Line& line, const Color* colors,
-               PickingType picking_type, 
+  void AddLine(const Line& line, const Color* colors, PickingType picking_type,
                std::unique_ptr<PickingUserData> user_data = nullptr);
   void AddLine(const Line& line, Color color, PickingType picking_type,
                std::unique_ptr<PickingUserData> user_data = nullptr);
@@ -84,10 +84,9 @@ class Batcher {
                        PickingType picking_type,
                        std::unique_ptr<PickingUserData> user_data = nullptr);
 
-  void AddBox(const Box& a_Box, const Color* colors,
-              PickingType picking_type,
+  void AddBox(const Box& box, const Color* colors, PickingType picking_type,
               std::unique_ptr<PickingUserData> user_data = nullptr);
-  void AddBox(const Box& a_Box, Color color, PickingType picking_type,
+  void AddBox(const Box& box, Color color, PickingType picking_type,
               std::unique_ptr<PickingUserData> user_data = nullptr);
   void AddShadedBox(Vec2 pos, Vec2 size, float z, Color color,
                     PickingType picking_type,
@@ -106,8 +105,8 @@ class Batcher {
 
   void Reset();
 
-  PickingUserData* GetUserData(PickingID a_ID);
-  TextBox* GetTextBox(PickingID a_ID);
+  PickingUserData* GetUserData(PickingID id);
+  TextBox* GetTextBox(PickingID id);
   BoxBuffer& GetBoxBuffer() { return box_buffer_; }
   LineBuffer& GetLineBuffer() { return line_buffer_; }
   TriangleBuffer& GetTriangleBuffer() { return triangle_buffer_; }
@@ -121,3 +120,5 @@ class Batcher {
   TriangleBuffer triangle_buffer_;
   BatcherId batcher_id_;
 };
+
+#endif

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -70,7 +70,7 @@ struct TriangleBuffer {
 class Batcher {
  public:
   explicit Batcher(PickingID::BatcherId batcher_id) : batcher_id_(batcher_id) {}
-  Batcher() : batcher_id_(PickingID::BatcherId::TIME_GRAPH) {}
+  Batcher() : batcher_id_(PickingID::BatcherId::kTimeGraph) {}
 
   void AddLine(const Line& line, const Color* colors,
                PickingID::Type picking_type, 

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -11,7 +11,7 @@
 #include "Geometry.h"
 #include "PickingManager.h"
 
-using TooltipCallback = std::function<std::string(PickingID)>;
+using TooltipCallback = std::function<std::string(PickingId)>;
 
 struct PickingUserData {
   TextBox* text_box_;
@@ -105,8 +105,8 @@ class Batcher {
 
   void Reset();
 
-  [[nodiscard]] PickingUserData* GetUserData(PickingID id);
-  [[nodiscard]] TextBox* GetTextBox(PickingID id);
+  [[nodiscard]] PickingUserData* GetUserData(PickingId id);
+  [[nodiscard]] TextBox* GetTextBox(PickingId id);
   [[nodiscard]] BoxBuffer& GetBoxBuffer() { return box_buffer_; }
   [[nodiscard]] LineBuffer& GetLineBuffer() { return line_buffer_; }
   [[nodiscard]] TriangleBuffer& GetTriangleBuffer() { return triangle_buffer_; }

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -160,7 +160,7 @@ void CaptureWindow::Pick(int a_X, int a_Y) {
                &pixels[0]);
   uint32_t value;
   std::memcpy(&value, &pixels[0], sizeof(uint32_t));
-  PickingID pickId = PickingID::Get(value);
+  PickingId pickId = PickingId::Get(value);
 
   Capture::GSelectedTextBox = nullptr;
   Capture::GSelectedThreadId = 0;
@@ -170,7 +170,7 @@ void CaptureWindow::Pick(int a_X, int a_Y) {
   NeedsUpdate();
 }
 
-void CaptureWindow::Pick(PickingID a_PickingID, int a_X, int a_Y) {
+void CaptureWindow::Pick(PickingId a_PickingID, int a_X, int a_Y) {
   PickingType type = a_PickingID.type_;
 
   Batcher& batcher = GetBatcherById(a_PickingID.batcher_id_);
@@ -202,7 +202,7 @@ void CaptureWindow::Hover(int a_X, int a_Y) {
   glReadPixels(a_X, m_MainWindowHeight - a_Y, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE,
                &pixels[0]);
 
-  PickingID pickId = absl::bit_cast<PickingID>(pixels);
+  PickingId pickId = absl::bit_cast<PickingId>(pixels);
   Batcher& batcher = GetBatcherById(pickId.batcher_id_);
 
   std::string tooltip = "";
@@ -635,10 +635,9 @@ Batcher& CaptureWindow::GetBatcherById(BatcherId batcher_id) {
       return time_graph_.GetBatcher();
     case BatcherId::kUi:
       return ui_batcher_;
-    default:
-      CHECK(false);
-      return ui_batcher_;
   }
+
+  UNREACHABLE();
 }
 
 [[nodiscard]] PickingMode CaptureWindow::GetPickingMode() {

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -171,14 +171,14 @@ void CaptureWindow::Pick(int a_X, int a_Y) {
 }
 
 void CaptureWindow::Pick(PickingId a_PickingID, int a_X, int a_Y) {
-  PickingType type = a_PickingID.type_;
+  PickingType type = a_PickingID.type;
 
-  Batcher& batcher = GetBatcherById(a_PickingID.batcher_id_);
+  Batcher& batcher = GetBatcherById(a_PickingID.batcher_id);
   TextBox* text_box = batcher.GetTextBox(a_PickingID);
   if (text_box) {
     SelectTextBox(text_box);
   } else if (type == PickingType::kPickable) {
-    m_PickingManager.Pick(a_PickingID.id_, a_X, a_Y);
+    m_PickingManager.Pick(a_PickingID.id, a_X, a_Y);
   }
 }
 
@@ -203,12 +203,12 @@ void CaptureWindow::Hover(int a_X, int a_Y) {
                &pixels[0]);
 
   PickingId pickId = absl::bit_cast<PickingId>(pixels);
-  Batcher& batcher = GetBatcherById(pickId.batcher_id_);
+  Batcher& batcher = GetBatcherById(pickId.batcher_id);
 
   std::string tooltip = "";
 
-  if (pickId.type_ == PickingType::kPickable) {
-    auto pickable = GetPickingManager().GetPickableFromId(pickId.id_).lock();
+  if (pickId.type == PickingType::kPickable) {
+    auto pickable = GetPickingManager().GetPickableFromId(pickId.id).lock();
     if (pickable) {
       tooltip = pickable->GetTooltip();
     }

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -177,7 +177,7 @@ void CaptureWindow::Pick(PickingID a_PickingID, int a_X, int a_Y) {
   TextBox* text_box = batcher.GetTextBox(a_PickingID);
   if (text_box) {
     SelectTextBox(text_box);
-  } else if (type == PickingID::PICKABLE) {
+  } else if (type == PickingID::Type::kPickable) {
     m_PickingManager.Pick(a_PickingID.m_Id, a_X, a_Y);
   }
 }
@@ -207,7 +207,7 @@ void CaptureWindow::Hover(int a_X, int a_Y) {
 
   std::string tooltip = "";
 
-  if (pickId.m_Type == PickingID::PICKABLE) {
+  if (pickId.m_Type == PickingID::Type::kPickable) {
     auto pickable = GetPickingManager().GetPickableFromId(pickId.m_Id).lock();
     if (pickable) {
       tooltip = pickable->GetTooltip();
@@ -546,7 +546,7 @@ void CaptureWindow::Draw() {
 
     Vec2 pos(m_MouseX, m_WorldTopLeftY);
     ui_batcher_.AddVerticalLine(pos, -m_WorldHeight, Z_VALUE_TEXT,
-                                Color(0, 255, 0, 127), PickingID::LINE);
+                                Color(0, 255, 0, 127), PickingID::Type::kLine);
   }
 }
 
@@ -593,14 +593,14 @@ void CaptureWindow::DrawScreenSpace() {
 
   Box box(Vec2(margin_x0, 0),
           Vec2(margin_x1 - margin_x0, canvasHeight - height), z);
-  ui_batcher_.AddBox(box, kBackgroundColor, PickingID::BOX);
+  ui_batcher_.AddBox(box, kBackgroundColor, PickingID::Type::kBox);
 
   // Time bar background
   if (time_graph_.GetCaptureTimeSpanUs() > 0) {
     Box box(Vec2(0, time_graph_.GetLayout().GetSliderWidth()),
             Vec2(getWidth(), time_graph_.GetLayout().GetTimeBarHeight()),
             GlCanvas::Z_VALUE_TEXT_UI_BG);
-    ui_batcher_.AddBox(box, Color(70, 70, 70, 200), PickingID::BOX);
+    ui_batcher_.AddBox(box, Color(70, 70, 70, 200), PickingID::Type::kBox);
   }
 }
 
@@ -630,8 +630,9 @@ void CaptureWindow::ToggleDrawHelp() {
 }
 
 Batcher& CaptureWindow::GetBatcherById(uint32_t batcher_id) {
-  return batcher_id == PickingID::TIME_GRAPH ? time_graph_.GetBatcher()
-                                             : ui_batcher_;
+  return batcher_id == PickingID::BatcherId::kTimeGraph
+             ? time_graph_.GetBatcher()
+             : ui_batcher_;
 }
 
 [[nodiscard]] PickingMode CaptureWindow::GetPickingMode() {
@@ -844,7 +845,7 @@ void CaptureWindow::RenderTimeBar() {
 
       Vec2 pos(worldX, worldY);
       ui_batcher_.AddVerticalLine(pos, height, GlCanvas::Z_VALUE_UI,
-                                  Color(255, 255, 255, 255), PickingID::LINE);
+                                  Color(255, 255, 255, 255), PickingID::Type::kLine);
     }
   }
 }

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -171,14 +171,14 @@ void CaptureWindow::Pick(int a_X, int a_Y) {
 }
 
 void CaptureWindow::Pick(PickingID a_PickingID, int a_X, int a_Y) {
-  uint32_t type = a_PickingID.m_Type;
+  uint32_t type = a_PickingID.type_;
 
   Batcher& batcher = GetBatcherById(a_PickingID.batcher_id_);
   TextBox* text_box = batcher.GetTextBox(a_PickingID);
   if (text_box) {
     SelectTextBox(text_box);
   } else if (type == PickingID::Type::kPickable) {
-    m_PickingManager.Pick(a_PickingID.m_Id, a_X, a_Y);
+    m_PickingManager.Pick(a_PickingID.id_, a_X, a_Y);
   }
 }
 
@@ -207,8 +207,8 @@ void CaptureWindow::Hover(int a_X, int a_Y) {
 
   std::string tooltip = "";
 
-  if (pickId.m_Type == PickingID::Type::kPickable) {
-    auto pickable = GetPickingManager().GetPickableFromId(pickId.m_Id).lock();
+  if (pickId.type_ == PickingID::Type::kPickable) {
+    auto pickable = GetPickingManager().GetPickableFromId(pickId.id_).lock();
     if (pickable) {
       tooltip = pickable->GetTooltip();
     }

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -64,7 +64,7 @@ class CaptureWindow : public GlCanvas {
   void ToggleDrawHelp();
 
   Batcher& GetBatcherById(BatcherId batcher_id);
- 
+
  private:
   [[nodiscard]] PickingMode GetPickingMode();
 

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -63,7 +63,7 @@ class CaptureWindow : public GlCanvas {
   void UpdateVerticalSlider();
   void ToggleDrawHelp();
 
-  Batcher& GetBatcherById(uint32_t batcher_id);
+  Batcher& GetBatcherById(BatcherId batcher_id);
  
  private:
   [[nodiscard]] PickingMode GetPickingMode();

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -29,7 +29,7 @@ class CaptureWindow : public GlCanvas {
   void LeftUp() override;
   void Pick();
   void Pick(int a_X, int a_Y);
-  void Pick(PickingID a_ID, int a_X, int a_Y);
+  void Pick(PickingId a_ID, int a_X, int a_Y);
   void Hover(int a_X, int a_Y);
   void FindCode(uint64_t address);
   void RightDown(int a_X, int a_Y) override;

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -38,11 +38,11 @@ void EventTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
 
   if (picking) {
     color = picking_manager.GetPickableColor(shared_from_this(),
-                                             PickingID::BatcherId::kUi);
+                                             BatcherId::kUi);
   }
 
   Box box(m_Pos, Vec2(m_Size[0], -m_Size[1]), eventBarZ);
-  batcher->AddBox(box, color, PickingID::Type::kPickable);
+  batcher->AddBox(box, color, PickingType::kPickable);
 
   if (canvas->GetPickingManager().IsThisElementPicked(this)) {
     color = Color(255, 255, 255, 255);
@@ -54,9 +54,9 @@ void EventTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   float y1 = y0 - m_Size[1];
 
   batcher->AddLine(m_Pos, Vec2(x1, y0), GlCanvas::Z_VALUE_EVENT_BAR, color,
-                   PickingID::Type::kPickable);
+                   PickingType::kPickable);
   batcher->AddLine(Vec2(x1, y1), Vec2(x0, y1), GlCanvas::Z_VALUE_EVENT_BAR,
-                   color, PickingID::Type::kPickable);
+                   color, PickingType::kPickable);
 
   if (m_Picked) {
     Vec2& from = m_MousePos[0];
@@ -69,7 +69,7 @@ void EventTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
 
     Color picked_color(0, 128, 255, 128);
     Box box(Vec2(x0, y0), Vec2(x1 - x0, -m_Size[1]), -0.f);
-    batcher->AddBox(box, picked_color, PickingID::Type::kPickable);
+    batcher->AddBox(box, picked_color, PickingType::kPickable);
   }
 
   m_Canvas = canvas;
@@ -97,7 +97,7 @@ void EventTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
       if (time > min_tick && time < max_tick) {
         Vec2 pos(time_graph_->GetWorldFromTick(time), m_Pos[1]);
         batcher->AddVerticalLine(pos, -track_height, z, kWhite,
-                                 PickingID::Type::kLine);
+                                 PickingType::kLine);
       }
     }
 
@@ -108,7 +108,7 @@ void EventTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
          time_graph_->GetSelectedCallstackEvents(m_ThreadId)) {
       Vec2 pos(time_graph_->GetWorldFromTick(event.time()), m_Pos[1]);
       batcher->AddVerticalLine(pos, -track_height, z, kGreenSelection,
-                               PickingID::Type::kLine);
+                               PickingType::kLine);
     }
   } else {
     // Draw boxes instead of lines to make picking easier, even if this may
@@ -126,7 +126,7 @@ void EventTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
             nullptr,
             [&](PickingID id) -> std::string { return GetSampleTooltip(id); });
         user_data->custom_data_ = &pair.second;
-        batcher->AddShadedBox(pos, size, z, kGreenSelection, PickingID::Type::kBox,
+        batcher->AddShadedBox(pos, size, z, kGreenSelection, PickingType::kBox,
                               std::move(user_data));
       }
     }

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -37,8 +37,8 @@ void EventTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   Color color = m_Color;
 
   if (picking) {
-    color = picking_manager.GetPickableColor(shared_from_this(),
-                                             BatcherId::kUi);
+    color =
+        picking_manager.GetPickableColor(shared_from_this(), BatcherId::kUi);
   }
 
   Box box(m_Pos, Vec2(m_Size[0], -m_Size[1]), eventBarZ);

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -124,7 +124,7 @@ void EventTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
         Vec2 size(kPickingBoxWidth, track_height);
         auto user_data = std::make_unique<PickingUserData>(
             nullptr,
-            [&](PickingID id) -> std::string { return GetSampleTooltip(id); });
+            [&](PickingId id) -> std::string { return GetSampleTooltip(id); });
         user_data->custom_data_ = &pair.second;
         batcher->AddShadedBox(pos, size, z, kGreenSelection, PickingType::kBox,
                               std::move(user_data));
@@ -226,7 +226,7 @@ static std::string FormatCallstackForTooltip(
   return result;
 }
 
-std::string EventTrack::GetSampleTooltip(PickingID id) const {
+std::string EventTrack::GetSampleTooltip(PickingId id) const {
   static const std::string unknown_return_text =
       "Function call information missing";
 

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -38,11 +38,11 @@ void EventTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
 
   if (picking) {
     color = picking_manager.GetPickableColor(shared_from_this(),
-                                             PickingID::BatcherId::UI);
+                                             PickingID::BatcherId::kUi);
   }
 
   Box box(m_Pos, Vec2(m_Size[0], -m_Size[1]), eventBarZ);
-  batcher->AddBox(box, color, PickingID::PICKABLE);
+  batcher->AddBox(box, color, PickingID::Type::kPickable);
 
   if (canvas->GetPickingManager().IsThisElementPicked(this)) {
     color = Color(255, 255, 255, 255);
@@ -54,9 +54,9 @@ void EventTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   float y1 = y0 - m_Size[1];
 
   batcher->AddLine(m_Pos, Vec2(x1, y0), GlCanvas::Z_VALUE_EVENT_BAR, color,
-                   PickingID::PICKABLE);
+                   PickingID::Type::kPickable);
   batcher->AddLine(Vec2(x1, y1), Vec2(x0, y1), GlCanvas::Z_VALUE_EVENT_BAR,
-                   color, PickingID::PICKABLE);
+                   color, PickingID::Type::kPickable);
 
   if (m_Picked) {
     Vec2& from = m_MousePos[0];
@@ -69,7 +69,7 @@ void EventTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
 
     Color picked_color(0, 128, 255, 128);
     Box box(Vec2(x0, y0), Vec2(x1 - x0, -m_Size[1]), -0.f);
-    batcher->AddBox(box, picked_color, PickingID::PICKABLE);
+    batcher->AddBox(box, picked_color, PickingID::Type::kPickable);
   }
 
   m_Canvas = canvas;
@@ -97,7 +97,7 @@ void EventTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
       if (time > min_tick && time < max_tick) {
         Vec2 pos(time_graph_->GetWorldFromTick(time), m_Pos[1]);
         batcher->AddVerticalLine(pos, -track_height, z, kWhite,
-                                 PickingID::LINE);
+                                 PickingID::Type::kLine);
       }
     }
 
@@ -108,7 +108,7 @@ void EventTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
          time_graph_->GetSelectedCallstackEvents(m_ThreadId)) {
       Vec2 pos(time_graph_->GetWorldFromTick(event.time()), m_Pos[1]);
       batcher->AddVerticalLine(pos, -track_height, z, kGreenSelection,
-                               PickingID::LINE);
+                               PickingID::Type::kLine);
     }
   } else {
     // Draw boxes instead of lines to make picking easier, even if this may
@@ -126,7 +126,7 @@ void EventTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
             nullptr,
             [&](PickingID id) -> std::string { return GetSampleTooltip(id); });
         user_data->custom_data_ = &pair.second;
-        batcher->AddShadedBox(pos, size, z, kGreenSelection, PickingID::BOX,
+        batcher->AddShadedBox(pos, size, z, kGreenSelection, PickingID::Type::kBox,
                               std::move(user_data));
       }
     }

--- a/OrbitGl/EventTrack.h
+++ b/OrbitGl/EventTrack.h
@@ -37,7 +37,7 @@ class EventTrack : public Track {
 
  protected:
   void SelectEvents();
-  std::string GetSampleTooltip(PickingID id) const;
+  std::string GetSampleTooltip(PickingId id) const;
 
  protected:
   TextBox m_ThreadName;

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -36,7 +36,7 @@ float GlCanvas::Z_VALUE_BOX_INACTIVE = -0.03f;
 float GlCanvas::Z_VALUE_EVENT_BAR = -0.1f;
 float GlCanvas::Z_VALUE_EVENT_BAR_PICKING = 0.1f;
 
-GlCanvas::GlCanvas() : ui_batcher_(PickingID::BatcherId::kUi) {
+GlCanvas::GlCanvas() : ui_batcher_(BatcherId::kUi) {
   m_TextRenderer.SetCanvas(this);
 
   m_Width = 0;

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -36,7 +36,7 @@ float GlCanvas::Z_VALUE_BOX_INACTIVE = -0.03f;
 float GlCanvas::Z_VALUE_EVENT_BAR = -0.1f;
 float GlCanvas::Z_VALUE_EVENT_BAR_PICKING = 0.1f;
 
-GlCanvas::GlCanvas() : ui_batcher_(PickingID::BatcherId::UI) {
+GlCanvas::GlCanvas() : ui_batcher_(PickingID::BatcherId::kUi) {
   m_TextRenderer.SetCanvas(this);
 
   m_Width = 0;

--- a/OrbitGl/GlSlider.cpp
+++ b/OrbitGl/GlSlider.cpp
@@ -115,7 +115,7 @@ void GlSlider::DrawHorizontal(GlCanvas* canvas, PickingMode picking_mode) {
   // Bar
   if (!picking) {
     Box box(Vec2(0, y), Vec2(canvasWidth, GetPixelHeight()), 0.f);
-    batcher->AddBox(box, m_BarColor, PickingID::PICKABLE);
+    batcher->AddBox(box, m_BarColor, PickingID::Type::kPickable);
   }
 
   float start = m_Ratio * nonSliderWidth;
@@ -124,13 +124,13 @@ void GlSlider::DrawHorizontal(GlCanvas* canvas, PickingMode picking_mode) {
   Color color = m_SliderColor;
   if (picking) {
     color = canvas->GetPickingManager().GetPickableColor(
-        shared_from_this(), PickingID::BatcherId::UI);
+        shared_from_this(), PickingID::BatcherId::kUi);
   } else if (canvas->GetPickingManager().IsThisElementPicked(this)) {
     color = m_SelectedColor;
   }
 
   Box box(Vec2(start, y), Vec2(stop - start, GetPixelHeight()), 0.f);
-  batcher->AddBox(box, color, PickingID::PICKABLE);
+  batcher->AddBox(box, color, PickingID::Type::kPickable);
 }
 
 void GlSlider::DrawVertical(GlCanvas* canvas, PickingMode picking_mode) {
@@ -147,7 +147,7 @@ void GlSlider::DrawVertical(GlCanvas* canvas, PickingMode picking_mode) {
   // Bar
   if (!picking) {
     Box box(Vec2(x, 0), Vec2(GetPixelHeight(), canvasHeight), 0.f);
-    batcher->AddBox(box, m_BarColor, PickingID::PICKABLE);
+    batcher->AddBox(box, m_BarColor, PickingID::Type::kPickable);
   }
 
   float start = canvasHeight - m_Ratio * nonSliderHeight;
@@ -156,11 +156,11 @@ void GlSlider::DrawVertical(GlCanvas* canvas, PickingMode picking_mode) {
   Color color = m_SliderColor;
   if (picking) {
     color = canvas->GetPickingManager().GetPickableColor(
-        shared_from_this(), PickingID::BatcherId::UI);
+        shared_from_this(), PickingID::BatcherId::kUi);
   } else if (canvas->GetPickingManager().IsThisElementPicked(this)) {
     color = m_SelectedColor;
   }
 
   Box box(Vec2(x, start), Vec2(GetPixelHeight(), stop - start), 0.f);
-  batcher->AddBox(box, color, PickingID::PICKABLE);
+  batcher->AddBox(box, color, PickingID::Type::kPickable);
 }

--- a/OrbitGl/GlSlider.cpp
+++ b/OrbitGl/GlSlider.cpp
@@ -123,8 +123,8 @@ void GlSlider::DrawHorizontal(GlCanvas* canvas, PickingMode picking_mode) {
 
   Color color = m_SliderColor;
   if (picking) {
-    color = canvas->GetPickingManager().GetPickableColor(
-        shared_from_this(), BatcherId::kUi);
+    color = canvas->GetPickingManager().GetPickableColor(shared_from_this(),
+                                                         BatcherId::kUi);
   } else if (canvas->GetPickingManager().IsThisElementPicked(this)) {
     color = m_SelectedColor;
   }
@@ -155,8 +155,8 @@ void GlSlider::DrawVertical(GlCanvas* canvas, PickingMode picking_mode) {
 
   Color color = m_SliderColor;
   if (picking) {
-    color = canvas->GetPickingManager().GetPickableColor(
-        shared_from_this(), BatcherId::kUi);
+    color = canvas->GetPickingManager().GetPickableColor(shared_from_this(),
+                                                         BatcherId::kUi);
   } else if (canvas->GetPickingManager().IsThisElementPicked(this)) {
     color = m_SelectedColor;
   }

--- a/OrbitGl/GlSlider.cpp
+++ b/OrbitGl/GlSlider.cpp
@@ -115,7 +115,7 @@ void GlSlider::DrawHorizontal(GlCanvas* canvas, PickingMode picking_mode) {
   // Bar
   if (!picking) {
     Box box(Vec2(0, y), Vec2(canvasWidth, GetPixelHeight()), 0.f);
-    batcher->AddBox(box, m_BarColor, PickingID::Type::kPickable);
+    batcher->AddBox(box, m_BarColor, PickingType::kPickable);
   }
 
   float start = m_Ratio * nonSliderWidth;
@@ -124,13 +124,13 @@ void GlSlider::DrawHorizontal(GlCanvas* canvas, PickingMode picking_mode) {
   Color color = m_SliderColor;
   if (picking) {
     color = canvas->GetPickingManager().GetPickableColor(
-        shared_from_this(), PickingID::BatcherId::kUi);
+        shared_from_this(), BatcherId::kUi);
   } else if (canvas->GetPickingManager().IsThisElementPicked(this)) {
     color = m_SelectedColor;
   }
 
   Box box(Vec2(start, y), Vec2(stop - start, GetPixelHeight()), 0.f);
-  batcher->AddBox(box, color, PickingID::Type::kPickable);
+  batcher->AddBox(box, color, PickingType::kPickable);
 }
 
 void GlSlider::DrawVertical(GlCanvas* canvas, PickingMode picking_mode) {
@@ -147,7 +147,7 @@ void GlSlider::DrawVertical(GlCanvas* canvas, PickingMode picking_mode) {
   // Bar
   if (!picking) {
     Box box(Vec2(x, 0), Vec2(GetPixelHeight(), canvasHeight), 0.f);
-    batcher->AddBox(box, m_BarColor, PickingID::Type::kPickable);
+    batcher->AddBox(box, m_BarColor, PickingType::kPickable);
   }
 
   float start = canvasHeight - m_Ratio * nonSliderHeight;
@@ -156,11 +156,11 @@ void GlSlider::DrawVertical(GlCanvas* canvas, PickingMode picking_mode) {
   Color color = m_SliderColor;
   if (picking) {
     color = canvas->GetPickingManager().GetPickableColor(
-        shared_from_this(), PickingID::BatcherId::kUi);
+        shared_from_this(), BatcherId::kUi);
   } else if (canvas->GetPickingManager().IsThisElementPicked(this)) {
     color = m_SelectedColor;
   }
 
   Box box(Vec2(x, start), Vec2(GetPixelHeight(), stop - start), 0.f);
-  batcher->AddBox(box, color, PickingID::Type::kPickable);
+  batcher->AddBox(box, color, PickingType::kPickable);
 }

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -187,7 +187,7 @@ const TextBox* GpuTrack::GetRight(TextBox* text_box) const {
   return nullptr;
 }
 
-std::string GpuTrack::GetBoxTooltip(PickingID id) const {
+std::string GpuTrack::GetBoxTooltip(PickingId id) const {
   TextBox* text_box = time_graph_->GetBatcher().GetTextBox(id);
   if (!text_box ||
       text_box->GetTimerInfo().type() == TimerInfo::kCoreActivity) {

--- a/OrbitGl/GpuTrack.h
+++ b/OrbitGl/GpuTrack.h
@@ -47,7 +47,7 @@ class GpuTrack : public TimerTrack {
   void SetTimesliceText(
       const orbit_client_protos::TimerInfo& timer, double elapsed_us,
       float min_x, TextBox* text_box) override;
-  [[nodiscard]] std::string GetBoxTooltip(PickingID id) const override;
+  [[nodiscard]] std::string GetBoxTooltip(PickingId id) const override;
 
  private:
   uint64_t timeline_hash_;

--- a/OrbitGl/GraphTrack.cpp
+++ b/OrbitGl/GraphTrack.cpp
@@ -35,15 +35,15 @@ void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   float text_z = layout.GetTextZ();
 
   Box box(m_Pos, Vec2(m_Size[0], -m_Size[1]), track_z);
-  batcher->AddBox(box, color, PickingID::PICKABLE);
+  batcher->AddBox(box, color, PickingID::Type::kPickable);
 
   if (canvas->GetPickingManager().IsThisElementPicked(this)) {
     color = Color(255, 255, 255, 255);
   }
 
-  batcher->AddLine(m_Pos, Vec2(x1, y0), track_z, color, PickingID::PICKABLE);
+  batcher->AddLine(m_Pos, Vec2(x1, y0), track_z, color, PickingID::Type::kPickable);
   batcher->AddLine(Vec2(x1, y1), Vec2(x0, y1), track_z, color,
-                   PickingID::PICKABLE);
+                   PickingID::Type::kPickable);
 
   const Color kLineColor(0, 128, 255, 128);
 
@@ -67,7 +67,7 @@ void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
     float y0 = base_y + static_cast<float>(last_normalized_value) * m_Size[1];
     float y1 = base_y + static_cast<float>(normalized_value) * m_Size[1];
     time_graph_->GetBatcher().AddLine(Vec2(x0, y0), Vec2(x1, y1), text_z,
-                                      kLineColor, PickingID::LINE);
+                                      kLineColor, PickingID::Type::kLine);
 
     previous_time = time;
     last_normalized_value = normalized_value;

--- a/OrbitGl/GraphTrack.cpp
+++ b/OrbitGl/GraphTrack.cpp
@@ -35,15 +35,15 @@ void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   float text_z = layout.GetTextZ();
 
   Box box(m_Pos, Vec2(m_Size[0], -m_Size[1]), track_z);
-  batcher->AddBox(box, color, PickingID::Type::kPickable);
+  batcher->AddBox(box, color, PickingType::kPickable);
 
   if (canvas->GetPickingManager().IsThisElementPicked(this)) {
     color = Color(255, 255, 255, 255);
   }
 
-  batcher->AddLine(m_Pos, Vec2(x1, y0), track_z, color, PickingID::Type::kPickable);
+  batcher->AddLine(m_Pos, Vec2(x1, y0), track_z, color, PickingType::kPickable);
   batcher->AddLine(Vec2(x1, y1), Vec2(x0, y1), track_z, color,
-                   PickingID::Type::kPickable);
+                   PickingType::kPickable);
 
   const Color kLineColor(0, 128, 255, 128);
 
@@ -67,7 +67,7 @@ void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
     float y0 = base_y + static_cast<float>(last_normalized_value) * m_Size[1];
     float y1 = base_y + static_cast<float>(normalized_value) * m_Size[1];
     time_graph_->GetBatcher().AddLine(Vec2(x0, y0), Vec2(x1, y1), text_z,
-                                      kLineColor, PickingID::Type::kLine);
+                                      kLineColor, PickingType::kLine);
 
     previous_time = time;
     last_normalized_value = normalized_value;

--- a/OrbitGl/PickingManager.cpp
+++ b/OrbitGl/PickingManager.cpp
@@ -11,7 +11,7 @@ PickingID PickingManager::CreatePickableId(std::weak_ptr<Pickable> a_Pickable,
                                            PickingID::BatcherId batcher_id) {
   absl::MutexLock lock(&mutex_);
   ++m_IdCounter;
-  PickingID id = PickingID::Get(PickingID::PICKABLE, m_IdCounter, batcher_id);
+  PickingID id = PickingID::Get(PickingID::Type::kPickable, m_IdCounter, batcher_id);
   m_IdPickableMap[m_IdCounter] = a_Pickable;
   return id;
 }

--- a/OrbitGl/PickingManager.cpp
+++ b/OrbitGl/PickingManager.cpp
@@ -8,11 +8,11 @@
 #include "OrbitBase/Logging.h"
 
 PickingID PickingManager::CreatePickableId(std::weak_ptr<Pickable> a_Pickable,
-                                           PickingID::BatcherId batcher_id) {
+                                           BatcherId batcher_id) {
   absl::MutexLock lock(&mutex_);
   ++id_counter_;
   PickingID id =
-      PickingID::Get(PickingID::Type::kPickable, id_counter_, batcher_id);
+      PickingID::Get(PickingType::kPickable, id_counter_, batcher_id);
   id_pickable_map_[id_counter_] = a_Pickable;
   return id;
 }
@@ -70,7 +70,7 @@ bool PickingManager::IsDragging() const {
 }
 
 Color PickingManager::GetPickableColor(std::weak_ptr<Pickable> pickable,
-                                       PickingID::BatcherId batcher_id) {
+                                       BatcherId batcher_id) {
   PickingID id = CreatePickableId(pickable, batcher_id);
   return ColorFromPickingID(id);
 }

--- a/OrbitGl/PickingManager.cpp
+++ b/OrbitGl/PickingManager.cpp
@@ -7,12 +7,12 @@
 #include "OpenGl.h"
 #include "OrbitBase/Logging.h"
 
-PickingID PickingManager::CreatePickableId(std::weak_ptr<Pickable> a_Pickable,
+PickingId PickingManager::CreatePickableId(std::weak_ptr<Pickable> a_Pickable,
                                            BatcherId batcher_id) {
   absl::MutexLock lock(&mutex_);
   ++id_counter_;
-  PickingID id =
-      PickingID::Get(PickingType::kPickable, id_counter_, batcher_id);
+  PickingId id =
+      PickingId::Get(PickingType::kPickable, id_counter_, batcher_id);
   id_pickable_map_[id_counter_] = a_Pickable;
   return id;
 }
@@ -71,7 +71,7 @@ bool PickingManager::IsDragging() const {
 
 Color PickingManager::GetPickableColor(std::weak_ptr<Pickable> pickable,
                                        BatcherId batcher_id) {
-  PickingID id = CreatePickableId(pickable, batcher_id);
+  PickingId id = CreatePickableId(pickable, batcher_id);
   return ColorFromPickingID(id);
 }
 
@@ -80,11 +80,11 @@ bool PickingManager::IsThisElementPicked(const Pickable* pickable) const {
   return picked && picked.get() == pickable;
 }
 
-Color PickingManager::ColorFromPickingID(PickingID id) const {
-  static_assert(sizeof(PickingID) == 4 * sizeof(uint8_t),
-                "PickingID should be same size as 4 * uint8_t");
+Color PickingManager::ColorFromPickingID(PickingId id) const {
+  static_assert(sizeof(PickingId) == 4 * sizeof(uint8_t),
+                "PickingId should be same size as 4 * uint8_t");
   std::array<uint8_t, 4> color_values;
-  std::memcpy(&color_values[0], &id, sizeof(PickingID));
+  std::memcpy(&color_values[0], &id, sizeof(PickingId));
   return Color(color_values[0], color_values[1], color_values[2],
                color_values[3]);
 }

--- a/OrbitGl/PickingManager.h
+++ b/OrbitGl/PickingManager.h
@@ -5,11 +5,11 @@
 #pragma once
 
 #include <cstring>
-#include <unordered_map>
-#include <vector>
 #include <memory>
 #include <string>
 #include <type_traits>
+#include <unordered_map>
+#include <vector>
 
 #include "CoreMath.h"
 #include "absl/synchronization/mutex.h"
@@ -32,27 +32,27 @@ class Pickable {
 
 struct PickingID {
   enum Type {
-    INVALID,
-    LINE,
-    BOX,
-    TRIANGLE,
-    PICKABLE,
+    kInvalid,
+    kLine,
+    kBox,
+    kTriangle,
+    kPickable,
   };
 
   // Instances of batchers used to draw must be in 1:1 correspondence with
   // values in the following enum. Currently, two batchers are used, one to draw
   // UI elements (corresponding to BatcherId::UI), and one for drawing events on
-  // the time graph (corresponding to BatcherId::TIME_GRAPH). If you want to add
+  // the time graph (corresponding to BatcherId::kTimeGraph). If you want to add
   // more batchers, this enum must be extended and you need to spend more bits
   // on the batcher_id_ field below. The total number of elements that can be
   // correctly picked is limited to the number of elements that can be encoded
   // in the bits remaining after encoding the batcher id, and the
   // PickingID::Type, so adding more batchers or types has to be carefully
   // considered.
-  enum BatcherId { TIME_GRAPH, UI };
+  enum BatcherId { kTimeGraph, kUi };
 
   static PickingID Get(Type a_Type, uint32_t a_ID,
-                       BatcherId batcher_id = TIME_GRAPH) {
+                       BatcherId batcher_id = BatcherId::kTimeGraph) {
     static_assert(sizeof(PickingID) == 4, "PickingID must be 32 bits");
     PickingID id;
     id.m_Type = a_Type;
@@ -61,7 +61,7 @@ struct PickingID {
     return id;
   }
   static Color GetColor(Type a_Type, uint32_t a_ID,
-                        BatcherId batcher_id = TIME_GRAPH) {
+                        BatcherId batcher_id = BatcherId::kTimeGraph) {
     static_assert(sizeof(PickingID) == sizeof(Color),
                   "PickingId and Color must have the same size");
     static_assert(std::is_trivially_copyable<PickingID>::value,

--- a/OrbitGl/PickingManager.h
+++ b/OrbitGl/PickingManager.h
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#pragma once
+#ifndef ORBIT_GL_PICKING_MANAGER_H
+#define ORBIT_GL_PICKING_MANAGER_H
 
 #include <cstring>
 #include <memory>
@@ -109,3 +110,5 @@ class PickingManager {
   std::weak_ptr<Pickable> currently_picked_;
   mutable absl::Mutex mutex_;
 };
+
+#endif

--- a/OrbitGl/PickingManager.h
+++ b/OrbitGl/PickingManager.h
@@ -94,9 +94,9 @@ class PickingManager {
   PickingManager() {}
   void Reset();
 
-  void Pick(uint32_t a_Id, int a_X, int a_Y);
+  void Pick(uint32_t id, int x, int y);
   void Release();
-  void Drag(int a_X, int a_Y);
+  void Drag(int x, int y);
   std::weak_ptr<Pickable> GetPicked() const;
   std::weak_ptr<Pickable> GetPickableFromId(uint32_t id) const;
   bool IsDragging() const;
@@ -112,9 +112,8 @@ class PickingManager {
   Color ColorFromPickingID(PickingID id) const;
 
  private:
-  std::vector<Pickable*> m_Pickables;
-  uint32_t m_IdCounter = 0;
-  std::unordered_map<uint32_t, std::weak_ptr<Pickable>> m_IdPickableMap;
-  std::weak_ptr<Pickable> m_Picked;
+  uint32_t id_counter_ = 0;
+  std::unordered_map<uint32_t, std::weak_ptr<Pickable>> id_pickable_map_;
+  std::weak_ptr<Pickable> currently_picked_;
   mutable absl::Mutex mutex_;
 };

--- a/OrbitGl/PickingManager.h
+++ b/OrbitGl/PickingManager.h
@@ -25,12 +25,12 @@ class Pickable {
   virtual void OnDrag(int /*a_X*/, int /*a_Y*/) {}
   virtual void OnRelease(){};
   virtual void Draw(GlCanvas* a_Canvas, PickingMode a_PickingMode) = 0;
-  virtual bool Draggable() { return false; }
-  virtual bool Movable() { return false; }
-  virtual std::string GetTooltip() const { return ""; }
+  [[nodiscard]] virtual bool Draggable() { return false; }
+  [[nodiscard]] virtual bool Movable() { return false; }
+  [[nodiscard]] virtual std::string GetTooltip() const { return ""; }
 };
 
-enum class PickingType: uint32_t {
+enum class PickingType : uint32_t {
   kInvalid = 0,
   kLine = 1,
   kBox = 2,
@@ -48,11 +48,12 @@ enum class PickingType: uint32_t {
 // in the bits remaining after encoding the batcher id, and the
 // PickingType, so adding more batchers or types has to be carefully
 // considered.
-enum class BatcherId: uint32_t { kTimeGraph, kUi };
+enum class BatcherId : uint32_t { kTimeGraph, kUi };
 
 struct PickingID {
-  static PickingID Get(PickingType type, uint32_t id,
-                       BatcherId batcher_id = BatcherId::kTimeGraph) {
+  [[nodiscard]] static PickingID Get(
+      PickingType type, uint32_t id,
+      BatcherId batcher_id = BatcherId::kTimeGraph) {
     static_assert(sizeof(PickingID) == 4, "PickingID must be 32 bits");
     PickingID result;
     result.type_ = type;
@@ -60,8 +61,10 @@ struct PickingID {
     result.batcher_id_ = batcher_id;
     return result;
   }
-  static Color GetColor(PickingType type, uint32_t id,
-                        BatcherId batcher_id = BatcherId::kTimeGraph) {
+
+  [[nodiscard]] static Color GetColor(
+      PickingType type, uint32_t id,
+      BatcherId batcher_id = BatcherId::kTimeGraph) {
     static_assert(sizeof(PickingID) == sizeof(Color),
                   "PickingId and Color must have the same size");
     static_assert(std::is_trivially_copyable<PickingID>::value,
@@ -74,7 +77,8 @@ struct PickingID {
     return Color(color_values[0], color_values[1], color_values[2],
                  color_values[3]);
   }
-  static PickingID Get(uint32_t value) {
+
+  [[nodiscard]] static PickingID Get(uint32_t value) {
     static_assert(sizeof(PickingID) == sizeof(uint32_t),
                   "PickingId and uint32_t must have the same size");
     static_assert(std::is_trivially_copyable<PickingID>::value,
@@ -97,19 +101,19 @@ class PickingManager {
   void Pick(uint32_t id, int x, int y);
   void Release();
   void Drag(int x, int y);
-  std::weak_ptr<Pickable> GetPicked() const;
-  std::weak_ptr<Pickable> GetPickableFromId(uint32_t id) const;
-  bool IsDragging() const;
+  [[nodiscard]] std::weak_ptr<Pickable> GetPicked() const;
+  [[nodiscard]] std::weak_ptr<Pickable> GetPickableFromId(uint32_t id) const;
+  [[nodiscard]] bool IsDragging() const;
 
-  Color GetPickableColor(std::weak_ptr<Pickable> pickable,
-                         BatcherId batcher_id);
+  [[nodiscard]] Color GetPickableColor(std::weak_ptr<Pickable> pickable,
+                                       BatcherId batcher_id);
 
-  bool IsThisElementPicked(const Pickable* pickable) const;
+  [[nodiscard]] bool IsThisElementPicked(const Pickable* pickable) const;
 
  private:
-  PickingID CreatePickableId(std::weak_ptr<Pickable> a_Pickable,
-                             BatcherId batcher_id);
-  Color ColorFromPickingID(PickingID id) const;
+  [[nodiscard]] PickingID CreatePickableId(std::weak_ptr<Pickable> a_Pickable,
+                                           BatcherId batcher_id);
+  [[nodiscard]] Color ColorFromPickingID(PickingID id) const;
 
  private:
   uint32_t id_counter_ = 0;

--- a/OrbitGl/PickingManager.h
+++ b/OrbitGl/PickingManager.h
@@ -53,13 +53,13 @@ enum class PickingType : uint32_t {
 enum class BatcherId : uint32_t { kTimeGraph, kUi };
 
 struct PickingId {
-  [[nodiscard]] static PickingId Get(
+  [[nodiscard]] inline static PickingId Get(
       PickingType type, uint32_t id,
       BatcherId batcher_id = BatcherId::kTimeGraph) {
     PickingId result;
-    result.type_ = type;
-    result.id_ = id;
-    result.batcher_id_ = batcher_id;
+    result.type = type;
+    result.id = id;
+    result.batcher_id = batcher_id;
     return result;
   }
 
@@ -73,13 +73,13 @@ struct PickingId {
                  color_values[3]);
   }
 
-  [[nodiscard]] static PickingId Get(uint32_t value) {
+  [[nodiscard]] inline static PickingId Get(uint32_t value) {
     PickingId id = absl::bit_cast<PickingId, uint32_t>(value);
     return id;
   }
-  uint32_t id_ : 28;
-  PickingType type_ : 3;
-  BatcherId batcher_id_ : 1;
+  uint32_t id : 28;
+  PickingType type : 3;
+  BatcherId batcher_id : 1;
 };
 
 class PickingManager {

--- a/OrbitGl/PickingManager.h
+++ b/OrbitGl/PickingManager.h
@@ -51,41 +51,41 @@ struct PickingID {
   // considered.
   enum BatcherId { kTimeGraph, kUi };
 
-  static PickingID Get(Type a_Type, uint32_t a_ID,
+  static PickingID Get(Type type, uint32_t id,
                        BatcherId batcher_id = BatcherId::kTimeGraph) {
     static_assert(sizeof(PickingID) == 4, "PickingID must be 32 bits");
-    PickingID id;
-    id.m_Type = a_Type;
-    id.m_Id = a_ID;
-    id.batcher_id_ = batcher_id;
-    return id;
+    PickingID result;
+    result.type_ = type;
+    result.id_ = id;
+    result.batcher_id_ = batcher_id;
+    return result;
   }
-  static Color GetColor(Type a_Type, uint32_t a_ID,
+  static Color GetColor(Type type, uint32_t id,
                         BatcherId batcher_id = BatcherId::kTimeGraph) {
     static_assert(sizeof(PickingID) == sizeof(Color),
                   "PickingId and Color must have the same size");
     static_assert(std::is_trivially_copyable<PickingID>::value,
                   "PickingID must be trivially copyable");
 
-    PickingID id = Get(a_Type, a_ID, batcher_id);
+    PickingID result_id = Get(type, id, batcher_id);
     std::array<uint8_t, 4> color_values;
-    std::memcpy(&color_values[0], &id, sizeof(PickingID));
+    std::memcpy(&color_values[0], &result_id, sizeof(PickingID));
 
     return Color(color_values[0], color_values[1], color_values[2],
                  color_values[3]);
   }
-  static PickingID Get(uint32_t a_Value) {
+  static PickingID Get(uint32_t value) {
     static_assert(sizeof(PickingID) == sizeof(uint32_t),
                   "PickingId and uint32_t must have the same size");
     static_assert(std::is_trivially_copyable<PickingID>::value,
                   "PickingID must be trivially copyable");
 
     PickingID id;
-    std::memcpy(&id, &a_Value, sizeof(uint32_t));
+    std::memcpy(&id, &value, sizeof(uint32_t));
     return id;
   }
-  uint32_t m_Id : 28;
-  uint32_t m_Type : 3;
+  uint32_t id_ : 28;
+  uint32_t type_ : 3;
   uint32_t batcher_id_ : 1;
 };
 

--- a/OrbitGl/PickingManagerTest.cpp
+++ b/OrbitGl/PickingManagerTest.cpp
@@ -7,6 +7,7 @@
 #include <cstring>
 
 #include "PickingManager.h"
+#include "absl/base/casts.h"
 
 class PickableMock : public Pickable {
  public:
@@ -49,8 +50,7 @@ TEST(PickingManager, PickableMock) {
 
 // Simulate "rendering" the picking color into a uint32_t target
 PickingId MockRenderPickingColor(const Color& col_vec) {
-  uint32_t col;
-  std::memcpy(&col, &col_vec[0], sizeof(uint32_t));
+  uint32_t col = absl::bit_cast<uint32_t, Color>(col_vec);
   PickingId picking_id = PickingId::Get(col);
   return picking_id;
 }
@@ -62,17 +62,17 @@ TEST(PickingManager, BasicFunctionality) {
 
   Color col_vec1 = pm.GetPickableColor(pickable1, BatcherId::kUi);
   Color col_vec2 = pm.GetPickableColor(pickable2, BatcherId::kUi);
-  ASSERT_EQ(pm.GetPickableFromId(MockRenderPickingColor(col_vec1).id_).lock(),
+  ASSERT_EQ(pm.GetPickableFromId(MockRenderPickingColor(col_vec1).id).lock(),
             pickable1);
-  ASSERT_EQ(pm.GetPickableFromId(MockRenderPickingColor(col_vec2).id_).lock(),
+  ASSERT_EQ(pm.GetPickableFromId(MockRenderPickingColor(col_vec2).id).lock(),
             pickable2);
   ASSERT_TRUE(pm.GetPickableFromId(0xdeadbeef).expired());
 
   pm.Reset();
   ASSERT_TRUE(
-      pm.GetPickableFromId(MockRenderPickingColor(col_vec1).id_).expired());
+      pm.GetPickableFromId(MockRenderPickingColor(col_vec1).id).expired());
   ASSERT_TRUE(
-      pm.GetPickableFromId(MockRenderPickingColor(col_vec2).id_).expired());
+      pm.GetPickableFromId(MockRenderPickingColor(col_vec2).id).expired());
 }
 
 TEST(PickingManager, Callbacks) {
@@ -83,7 +83,7 @@ TEST(PickingManager, Callbacks) {
   PickingId id = MockRenderPickingColor(col_vec);
   ASSERT_FALSE(pickable->picked_);
   ASSERT_FALSE(pm.IsThisElementPicked(pickable.get()));
-  pm.Pick(id.id_, 0, 0);
+  pm.Pick(id.id, 0, 0);
   ASSERT_TRUE(pickable->picked_);
   ASSERT_TRUE(pm.IsThisElementPicked(pickable.get()));
 
@@ -92,7 +92,7 @@ TEST(PickingManager, Callbacks) {
   ASSERT_FALSE(pm.IsThisElementPicked(pickable.get()));
 
   ASSERT_FALSE(pm.IsDragging());
-  pm.Pick(id.id_, 0, 0);
+  pm.Pick(id.id, 0, 0);
   ASSERT_TRUE(pm.IsDragging());
   ASSERT_FALSE(pickable->dragging_);
 
@@ -113,7 +113,7 @@ TEST(PickingManager, Undraggable) {
   PickingId id = MockRenderPickingColor(col_vec);
 
   ASSERT_FALSE(pm.IsDragging());
-  pm.Pick(id.id_, 0, 0);
+  pm.Pick(id.id, 0, 0);
   ASSERT_FALSE(pm.IsDragging());
   ASSERT_FALSE(pickable->dragging_);
 
@@ -129,17 +129,17 @@ TEST(PickingManager, RobustnessOnReset) {
   Color col_vec = pm.GetPickableColor(pickable, BatcherId::kUi);
   PickingId id = MockRenderPickingColor(col_vec);
   ASSERT_FALSE(pickable->picked_);
-  pm.Pick(id.id_, 0, 0);
+  pm.Pick(id.id, 0, 0);
   ASSERT_TRUE(pickable->picked_);
   pm.Drag(10, 10);
   ASSERT_TRUE(pickable->dragging_);
 
   pickable.reset();
 
-  ASSERT_EQ(pm.GetPickableFromId(MockRenderPickingColor(col_vec).id_).lock(),
+  ASSERT_EQ(pm.GetPickableFromId(MockRenderPickingColor(col_vec).id).lock(),
             std::shared_ptr<PickableMock>());
   ASSERT_FALSE(pm.IsDragging());
-  pm.Pick(id.id_, 0, 0);
+  pm.Pick(id.id, 0, 0);
   ASSERT_TRUE(pm.GetPicked().expired());
 
   pickable = std::make_shared<PickableMock>();

--- a/OrbitGl/PickingManagerTest.cpp
+++ b/OrbitGl/PickingManagerTest.cpp
@@ -60,8 +60,8 @@ TEST(PickingManager, BasicFunctionality) {
   auto pickable2 = std::make_shared<PickableMock>();
   PickingManager pm;
 
-  Color col_vec1 = pm.GetPickableColor(pickable1, PickingID::BatcherId::kUi);
-  Color col_vec2 = pm.GetPickableColor(pickable2, PickingID::BatcherId::kUi);
+  Color col_vec1 = pm.GetPickableColor(pickable1, BatcherId::kUi);
+  Color col_vec2 = pm.GetPickableColor(pickable2, BatcherId::kUi);
   ASSERT_EQ(pm.GetPickableFromId(MockRenderPickingColor(col_vec1).id_).lock(),
             pickable1);
   ASSERT_EQ(pm.GetPickableFromId(MockRenderPickingColor(col_vec2).id_).lock(),
@@ -79,7 +79,7 @@ TEST(PickingManager, Callbacks) {
   auto pickable = std::make_shared<PickableMock>();
   PickingManager pm;
 
-  Color col_vec = pm.GetPickableColor(pickable, PickingID::BatcherId::kUi);
+  Color col_vec = pm.GetPickableColor(pickable, BatcherId::kUi);
   PickingID id = MockRenderPickingColor(col_vec);
   ASSERT_FALSE(pickable->picked_);
   ASSERT_FALSE(pm.IsThisElementPicked(pickable.get()));
@@ -109,7 +109,7 @@ TEST(PickingManager, Undraggable) {
   auto pickable = std::make_shared<UndraggableMock>();
   PickingManager pm;
 
-  Color col_vec = pm.GetPickableColor(pickable, PickingID::BatcherId::kUi);
+  Color col_vec = pm.GetPickableColor(pickable, BatcherId::kUi);
   PickingID id = MockRenderPickingColor(col_vec);
 
   ASSERT_FALSE(pm.IsDragging());
@@ -126,7 +126,7 @@ TEST(PickingManager, RobustnessOnReset) {
   std::shared_ptr<PickableMock> pickable = std::make_shared<PickableMock>();
   PickingManager pm;
 
-  Color col_vec = pm.GetPickableColor(pickable, PickingID::BatcherId::kUi);
+  Color col_vec = pm.GetPickableColor(pickable, BatcherId::kUi);
   PickingID id = MockRenderPickingColor(col_vec);
   ASSERT_FALSE(pickable->picked_);
   pm.Pick(id.id_, 0, 0);
@@ -143,7 +143,7 @@ TEST(PickingManager, RobustnessOnReset) {
   ASSERT_TRUE(pm.GetPicked().expired());
 
   pickable = std::make_shared<PickableMock>();
-  col_vec = pm.GetPickableColor(pickable, PickingID::BatcherId::kUi);
+  col_vec = pm.GetPickableColor(pickable, BatcherId::kUi);
   id = MockRenderPickingColor(col_vec);
 
   pickable.reset(new PickableMock());

--- a/OrbitGl/PickingManagerTest.cpp
+++ b/OrbitGl/PickingManagerTest.cpp
@@ -61,17 +61,17 @@ TEST(PickingManager, BasicFunctionality) {
 
   Color col_vec1 = pm.GetPickableColor(pickable1, PickingID::BatcherId::kUi);
   Color col_vec2 = pm.GetPickableColor(pickable2, PickingID::BatcherId::kUi);
-  ASSERT_EQ(pm.GetPickableFromId(MockRenderPickingColor(col_vec1).m_Id).lock(),
+  ASSERT_EQ(pm.GetPickableFromId(MockRenderPickingColor(col_vec1).id_).lock(),
             pickable1);
-  ASSERT_EQ(pm.GetPickableFromId(MockRenderPickingColor(col_vec2).m_Id).lock(),
+  ASSERT_EQ(pm.GetPickableFromId(MockRenderPickingColor(col_vec2).id_).lock(),
             pickable2);
   ASSERT_TRUE(pm.GetPickableFromId(0xdeadbeef).expired());
 
   pm.Reset();
   ASSERT_TRUE(
-      pm.GetPickableFromId(MockRenderPickingColor(col_vec1).m_Id).expired());
+      pm.GetPickableFromId(MockRenderPickingColor(col_vec1).id_).expired());
   ASSERT_TRUE(
-      pm.GetPickableFromId(MockRenderPickingColor(col_vec2).m_Id).expired());
+      pm.GetPickableFromId(MockRenderPickingColor(col_vec2).id_).expired());
 }
 
 TEST(PickingManager, Callbacks) {
@@ -82,7 +82,7 @@ TEST(PickingManager, Callbacks) {
   PickingID id = MockRenderPickingColor(col_vec);
   ASSERT_FALSE(pickable->picked_);
   ASSERT_FALSE(pm.IsThisElementPicked(pickable.get()));
-  pm.Pick(id.m_Id, 0, 0);
+  pm.Pick(id.id_, 0, 0);
   ASSERT_TRUE(pickable->picked_);
   ASSERT_TRUE(pm.IsThisElementPicked(pickable.get()));
 
@@ -91,7 +91,7 @@ TEST(PickingManager, Callbacks) {
   ASSERT_FALSE(pm.IsThisElementPicked(pickable.get()));
 
   ASSERT_FALSE(pm.IsDragging());
-  pm.Pick(id.m_Id, 0, 0);
+  pm.Pick(id.id_, 0, 0);
   ASSERT_TRUE(pm.IsDragging());
   ASSERT_FALSE(pickable->dragging_);
 
@@ -112,7 +112,7 @@ TEST(PickingManager, Undraggable) {
   PickingID id = MockRenderPickingColor(col_vec);
 
   ASSERT_FALSE(pm.IsDragging());
-  pm.Pick(id.m_Id, 0, 0);
+  pm.Pick(id.id_, 0, 0);
   ASSERT_FALSE(pm.IsDragging());
   ASSERT_FALSE(pickable->dragging_);
 
@@ -128,17 +128,17 @@ TEST(PickingManager, RobustnessOnReset) {
   Color col_vec = pm.GetPickableColor(pickable, PickingID::BatcherId::kUi);
   PickingID id = MockRenderPickingColor(col_vec);
   ASSERT_FALSE(pickable->picked_);
-  pm.Pick(id.m_Id, 0, 0);
+  pm.Pick(id.id_, 0, 0);
   ASSERT_TRUE(pickable->picked_);
   pm.Drag(10, 10);
   ASSERT_TRUE(pickable->dragging_);
 
   pickable.reset();
 
-  ASSERT_EQ(pm.GetPickableFromId(MockRenderPickingColor(col_vec).m_Id).lock(),
+  ASSERT_EQ(pm.GetPickableFromId(MockRenderPickingColor(col_vec).id_).lock(),
             std::shared_ptr<PickableMock>());
   ASSERT_FALSE(pm.IsDragging());
-  pm.Pick(id.m_Id, 0, 0);
+  pm.Pick(id.id_, 0, 0);
   ASSERT_TRUE(pm.GetPicked().expired());
 
   pickable = std::make_shared<PickableMock>();

--- a/OrbitGl/PickingManagerTest.cpp
+++ b/OrbitGl/PickingManagerTest.cpp
@@ -59,8 +59,8 @@ TEST(PickingManager, BasicFunctionality) {
   auto pickable2 = std::make_shared<PickableMock>();
   PickingManager pm;
 
-  Color col_vec1 = pm.GetPickableColor(pickable1, PickingID::BatcherId::UI);
-  Color col_vec2 = pm.GetPickableColor(pickable2, PickingID::BatcherId::UI);
+  Color col_vec1 = pm.GetPickableColor(pickable1, PickingID::BatcherId::kUi);
+  Color col_vec2 = pm.GetPickableColor(pickable2, PickingID::BatcherId::kUi);
   ASSERT_EQ(pm.GetPickableFromId(MockRenderPickingColor(col_vec1).m_Id).lock(),
             pickable1);
   ASSERT_EQ(pm.GetPickableFromId(MockRenderPickingColor(col_vec2).m_Id).lock(),
@@ -78,7 +78,7 @@ TEST(PickingManager, Callbacks) {
   auto pickable = std::make_shared<PickableMock>();
   PickingManager pm;
 
-  Color col_vec = pm.GetPickableColor(pickable, PickingID::BatcherId::UI);
+  Color col_vec = pm.GetPickableColor(pickable, PickingID::BatcherId::kUi);
   PickingID id = MockRenderPickingColor(col_vec);
   ASSERT_FALSE(pickable->picked_);
   ASSERT_FALSE(pm.IsThisElementPicked(pickable.get()));
@@ -108,7 +108,7 @@ TEST(PickingManager, Undraggable) {
   auto pickable = std::make_shared<UndraggableMock>();
   PickingManager pm;
 
-  Color col_vec = pm.GetPickableColor(pickable, PickingID::BatcherId::UI);
+  Color col_vec = pm.GetPickableColor(pickable, PickingID::BatcherId::kUi);
   PickingID id = MockRenderPickingColor(col_vec);
 
   ASSERT_FALSE(pm.IsDragging());
@@ -125,7 +125,7 @@ TEST(PickingManager, RobustnessOnReset) {
   std::shared_ptr<PickableMock> pickable = std::make_shared<PickableMock>();
   PickingManager pm;
 
-  Color col_vec = pm.GetPickableColor(pickable, PickingID::BatcherId::UI);
+  Color col_vec = pm.GetPickableColor(pickable, PickingID::BatcherId::kUi);
   PickingID id = MockRenderPickingColor(col_vec);
   ASSERT_FALSE(pickable->picked_);
   pm.Pick(id.m_Id, 0, 0);
@@ -142,7 +142,7 @@ TEST(PickingManager, RobustnessOnReset) {
   ASSERT_TRUE(pm.GetPicked().expired());
 
   pickable = std::make_shared<PickableMock>();
-  col_vec = pm.GetPickableColor(pickable, PickingID::BatcherId::UI);
+  col_vec = pm.GetPickableColor(pickable, PickingID::BatcherId::kUi);
   id = MockRenderPickingColor(col_vec);
 
   pickable.reset(new PickableMock());

--- a/OrbitGl/PickingManagerTest.cpp
+++ b/OrbitGl/PickingManagerTest.cpp
@@ -48,10 +48,10 @@ TEST(PickingManager, PickableMock) {
 }
 
 // Simulate "rendering" the picking color into a uint32_t target
-PickingID MockRenderPickingColor(const Color& col_vec) {
+PickingId MockRenderPickingColor(const Color& col_vec) {
   uint32_t col;
   std::memcpy(&col, &col_vec[0], sizeof(uint32_t));
-  PickingID picking_id = PickingID::Get(col);
+  PickingId picking_id = PickingId::Get(col);
   return picking_id;
 }
 
@@ -80,7 +80,7 @@ TEST(PickingManager, Callbacks) {
   PickingManager pm;
 
   Color col_vec = pm.GetPickableColor(pickable, BatcherId::kUi);
-  PickingID id = MockRenderPickingColor(col_vec);
+  PickingId id = MockRenderPickingColor(col_vec);
   ASSERT_FALSE(pickable->picked_);
   ASSERT_FALSE(pm.IsThisElementPicked(pickable.get()));
   pm.Pick(id.id_, 0, 0);
@@ -110,7 +110,7 @@ TEST(PickingManager, Undraggable) {
   PickingManager pm;
 
   Color col_vec = pm.GetPickableColor(pickable, BatcherId::kUi);
-  PickingID id = MockRenderPickingColor(col_vec);
+  PickingId id = MockRenderPickingColor(col_vec);
 
   ASSERT_FALSE(pm.IsDragging());
   pm.Pick(id.id_, 0, 0);
@@ -127,7 +127,7 @@ TEST(PickingManager, RobustnessOnReset) {
   PickingManager pm;
 
   Color col_vec = pm.GetPickableColor(pickable, BatcherId::kUi);
-  PickingID id = MockRenderPickingColor(col_vec);
+  PickingId id = MockRenderPickingColor(col_vec);
   ASSERT_FALSE(pickable->picked_);
   pm.Pick(id.id_, 0, 0);
   ASSERT_TRUE(pickable->picked_);

--- a/OrbitGl/PickingManagerTest.cpp
+++ b/OrbitGl/PickingManagerTest.cpp
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <gtest/gtest.h>
+
 #include <cstring>
 
 #include "PickingManager.h"

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -63,7 +63,7 @@ void SchedulerTrack::UpdateBoxHeight() {
   box_height_ = time_graph_->GetLayout().GetTextCoresHeight();
 }
 
-std::string SchedulerTrack::GetBoxTooltip(PickingID id) const {
+std::string SchedulerTrack::GetBoxTooltip(PickingId id) const {
   TextBox* text_box = time_graph_->GetBatcher().GetTextBox(id);
   if (!text_box) {
     return "";

--- a/OrbitGl/SchedulerTrack.h
+++ b/OrbitGl/SchedulerTrack.h
@@ -27,7 +27,7 @@ class SchedulerTrack : public TimerTrack {
       const orbit_client_protos::TimerInfo& timer_info) const override;
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
                       bool is_selected) const override;
-  [[nodiscard]] std::string GetBoxTooltip(PickingID id) const override;
+  [[nodiscard]] std::string GetBoxTooltip(PickingId id) const override;
 };
 
 #endif  // ORBIT_GL_SCHEDULER_TRACK_H_

--- a/OrbitGl/TextBox.cpp
+++ b/OrbitGl/TextBox.cpp
@@ -104,7 +104,7 @@ void TextBox::Draw(Batcher* batcher, TextRenderer& a_TextRenderer, float a_MinX,
 
   if (a_Visible) {
     Box box(m_Pos, m_Size, z);
-    batcher->AddBox(box, color, PickingID::Type::kPickable);
+    batcher->AddBox(box, color, PickingType::kPickable);
 
     static Color s_Color(255, 255, 255, 255);
 
@@ -128,5 +128,5 @@ void TextBox::Draw(Batcher* batcher, TextRenderer& a_TextRenderer, float a_MinX,
     }
   }
 
-  batcher->AddVerticalLine(m_Pos, m_Size[1], z, grey, PickingID::Type::kPickable);
+  batcher->AddVerticalLine(m_Pos, m_Size[1], z, grey, PickingType::kPickable);
 }

--- a/OrbitGl/TextBox.cpp
+++ b/OrbitGl/TextBox.cpp
@@ -104,7 +104,7 @@ void TextBox::Draw(Batcher* batcher, TextRenderer& a_TextRenderer, float a_MinX,
 
   if (a_Visible) {
     Box box(m_Pos, m_Size, z);
-    batcher->AddBox(box, color, PickingID::PICKABLE);
+    batcher->AddBox(box, color, PickingID::Type::kPickable);
 
     static Color s_Color(255, 255, 255, 255);
 
@@ -128,5 +128,5 @@ void TextBox::Draw(Batcher* batcher, TextRenderer& a_TextRenderer, float a_MinX,
     }
   }
 
-  batcher->AddVerticalLine(m_Pos, m_Size[1], z, grey, PickingID::PICKABLE);
+  batcher->AddVerticalLine(m_Pos, m_Size[1], z, grey, PickingID::Type::kPickable);
 }

--- a/OrbitGl/TextRenderer.cpp
+++ b/OrbitGl/TextRenderer.cpp
@@ -154,11 +154,11 @@ void TextRenderer::DrawOutline(Batcher* batcher, vertex_buffer_t* a_Buffer) {
         *static_cast<const vertex_t*>(vector_get(a_Buffer->vertices, i2));
 
     batcher->AddLine(Vec2(v0.x, v0.y), Vec2(v1.x, v1.y), v0.z, color,
-                     PickingID::Type::kPickable);
+                     PickingType::kPickable);
     batcher->AddLine(Vec2(v1.x, v1.y), Vec2(v2.x, v2.y), v1.z, color,
-                     PickingID::Type::kPickable);
+                     PickingType::kPickable);
     batcher->AddLine(Vec2(v2.x, v2.y), Vec2(v0.x, v0.y), v2.z, color,
-                     PickingID::Type::kPickable);
+                     PickingType::kPickable);
   }
 }
 

--- a/OrbitGl/TextRenderer.cpp
+++ b/OrbitGl/TextRenderer.cpp
@@ -154,11 +154,11 @@ void TextRenderer::DrawOutline(Batcher* batcher, vertex_buffer_t* a_Buffer) {
         *static_cast<const vertex_t*>(vector_get(a_Buffer->vertices, i2));
 
     batcher->AddLine(Vec2(v0.x, v0.y), Vec2(v1.x, v1.y), v0.z, color,
-                     PickingID::PICKABLE);
+                     PickingID::Type::kPickable);
     batcher->AddLine(Vec2(v1.x, v1.y), Vec2(v2.x, v2.y), v1.z, color,
-                     PickingID::PICKABLE);
+                     PickingID::Type::kPickable);
     batcher->AddLine(Vec2(v2.x, v2.y), Vec2(v0.x, v0.y), v2.z, color,
-                     PickingID::PICKABLE);
+                     PickingID::Type::kPickable);
   }
 }
 

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -38,7 +38,7 @@ const TextBox* ThreadTrack::GetRight(TextBox* text_box) const {
   return nullptr;
 }
 
-std::string ThreadTrack::GetBoxTooltip(PickingID id) const {
+std::string ThreadTrack::GetBoxTooltip(PickingId id) const {
   TextBox* text_box = time_graph_->GetBatcher().GetTextBox(id);
   if (!text_box ||
       text_box->GetTimerInfo().type() == TimerInfo::kCoreActivity) {

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -40,7 +40,7 @@ class ThreadTrack : public TimerTrack {
   void SetTimesliceText(const orbit_client_protos::TimerInfo& timer,
                         double elapsed_us, float min_x,
                         TextBox* text_box) override;
-  [[nodiscard]] std::string GetBoxTooltip(PickingID id) const override;
+  [[nodiscard]] std::string GetBoxTooltip(PickingId id) const override;
 
   std::shared_ptr<EventTrack> event_track_;
   int32_t thread_id_;

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -707,7 +707,7 @@ void DrawIteratorBox(GlCanvas* canvas, Vec2 pos, Vec2 size, const Color& color,
                      const std::string& label, const std::string& time,
                      float text_y) {
   Box box(pos, size, GlCanvas::Z_VALUE_OVERLAY);
-  canvas->GetBatcher()->AddBox(box, color, PickingID::BOX);
+  canvas->GetBatcher()->AddBox(box, color, PickingID::Type::kBox);
 
   std::string text = absl::StrFormat("%s: %s", label, time);
 
@@ -724,7 +724,7 @@ void DrawIteratorBox(GlCanvas* canvas, Vec2 pos, Vec2 size, const Color& color,
   Vec2 line_from(pos[0], text_y + kOffsetBelowText);
   Vec2 line_to(pos[0] + size[0], text_y + kOffsetBelowText);
   canvas->GetBatcher()->AddLine(line_from, line_to, GlCanvas::Z_VALUE_OVERLAY,
-                                Color(255, 255, 255, 255), PickingID::LINE);
+                                Color(255, 255, 255, 255), PickingID::Type::kLine);
 }
 
 }  // namespace
@@ -774,7 +774,7 @@ void TimeGraph::DrawOverlay(GlCanvas* canvas, PickingMode picking_mode) {
 
     canvas->GetBatcher()->AddVerticalLine(
         pos, -world_height, GlCanvas::Z_VALUE_OVERLAY,
-        GetThreadColor(timer_info.thread_id()), PickingID::LINE, nullptr);
+        GetThreadColor(timer_info.thread_id()), PickingID::Type::kLine, nullptr);
   }
 
   // Draw boxes with timings between iterators.

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -707,7 +707,7 @@ void DrawIteratorBox(GlCanvas* canvas, Vec2 pos, Vec2 size, const Color& color,
                      const std::string& label, const std::string& time,
                      float text_y) {
   Box box(pos, size, GlCanvas::Z_VALUE_OVERLAY);
-  canvas->GetBatcher()->AddBox(box, color, PickingID::Type::kBox);
+  canvas->GetBatcher()->AddBox(box, color, PickingType::kBox);
 
   std::string text = absl::StrFormat("%s: %s", label, time);
 
@@ -724,7 +724,7 @@ void DrawIteratorBox(GlCanvas* canvas, Vec2 pos, Vec2 size, const Color& color,
   Vec2 line_from(pos[0], text_y + kOffsetBelowText);
   Vec2 line_to(pos[0] + size[0], text_y + kOffsetBelowText);
   canvas->GetBatcher()->AddLine(line_from, line_to, GlCanvas::Z_VALUE_OVERLAY,
-                                Color(255, 255, 255, 255), PickingID::Type::kLine);
+                                Color(255, 255, 255, 255), PickingType::kLine);
 }
 
 }  // namespace
@@ -774,7 +774,7 @@ void TimeGraph::DrawOverlay(GlCanvas* canvas, PickingMode picking_mode) {
 
     canvas->GetBatcher()->AddVerticalLine(
         pos, -world_height, GlCanvas::Z_VALUE_OVERLAY,
-        GetThreadColor(timer_info.thread_id()), PickingID::Type::kLine, nullptr);
+        GetThreadColor(timer_info.thread_id()), PickingType::kLine, nullptr);
   }
 
   // Draw boxes with timings between iterators.

--- a/OrbitGl/TimerTrack.cpp
+++ b/OrbitGl/TimerTrack.cpp
@@ -138,10 +138,10 @@ void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingM
           if (!is_collapsed) {
             SetTimesliceText(timer_info, elapsed_us, min_x, &text_box);
           }
-          batcher->AddShadedBox(pos, size, z, color, PickingID::Type::kBox,
+          batcher->AddShadedBox(pos, size, z, color, PickingType::kBox,
                                 std::move(user_data));
         } else {
-          auto type = PickingID::Type::kLine;
+          auto type = PickingType::kLine;
           batcher->AddVerticalLine(pos, size[1], z, color, type,
                                    std::move(user_data));
           // For lines, we can ignore the entire pixel into which this event

--- a/OrbitGl/TimerTrack.cpp
+++ b/OrbitGl/TimerTrack.cpp
@@ -138,10 +138,10 @@ void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingM
           if (!is_collapsed) {
             SetTimesliceText(timer_info, elapsed_us, min_x, &text_box);
           }
-          batcher->AddShadedBox(pos, size, z, color, PickingID::BOX,
+          batcher->AddShadedBox(pos, size, z, color, PickingID::Type::kBox,
                                 std::move(user_data));
         } else {
-          auto type = PickingID::LINE;
+          auto type = PickingID::Type::kLine;
           batcher->AddVerticalLine(pos, size[1], z, color, type,
                                    std::move(user_data));
           // For lines, we can ignore the entire pixel into which this event

--- a/OrbitGl/TimerTrack.cpp
+++ b/OrbitGl/TimerTrack.cpp
@@ -132,7 +132,7 @@ void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingM
         text_box.SetSize(size);
 
         auto user_data = std::make_unique<PickingUserData>(
-            &text_box, [&](PickingID id) { return this->GetBoxTooltip(id); });
+            &text_box, [&](PickingId id) { return this->GetBoxTooltip(id); });
 
         if (is_visible_width) {
           if (!is_collapsed) {
@@ -270,4 +270,4 @@ std::vector<std::shared_ptr<TimerChain>> TimerTrack::GetAllChains() {
 
 bool TimerTrack::IsEmpty() const { return GetNumTimers() == 0; }
 
-std::string TimerTrack::GetBoxTooltip(PickingID /*id*/) const { return ""; }
+std::string TimerTrack::GetBoxTooltip(PickingId /*id*/) const { return ""; }

--- a/OrbitGl/TimerTrack.h
+++ b/OrbitGl/TimerTrack.h
@@ -100,7 +100,7 @@ class TimerTrack : public Track {
   mutable Mutex mutex_;
   std::map<int, std::shared_ptr<TimerChain>> timers_;
 
-  [[nodiscard]] virtual std::string GetBoxTooltip(PickingID /*id*/) const;
+  [[nodiscard]] virtual std::string GetBoxTooltip(PickingId /*id*/) const;
   float box_height_;
 };
 

--- a/OrbitGl/TimerTrack.h
+++ b/OrbitGl/TimerTrack.h
@@ -100,7 +100,7 @@ class TimerTrack : public Track {
   mutable Mutex mutex_;
   std::map<int, std::shared_ptr<TimerChain>> timers_;
 
-  [[nodiscard]] virtual std::string GetBoxTooltip(PickingId /*id*/) const;
+  [[nodiscard]] virtual std::string GetBoxTooltip(PickingId id) const;
   float box_height_;
 };
 

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -74,7 +74,7 @@ void DrawTriangleFan(Batcher* batcher, const std::vector<Vec2>& points,
     vertices[i % 2] =
         position + Vec3(rotated_points[i + 1][0], rotated_points[i + 1][1], z);
     Triangle triangle(pivot, vertices[i % 2], vertices[(i + 1) % 2]);
-    batcher->AddTriangle(triangle, color, PickingID::PICKABLE);
+    batcher->AddTriangle(triangle, color, PickingID::Type::kPickable);
   }
 }
 
@@ -83,7 +83,7 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
 
   const TimeGraphLayout& layout = time_graph_->GetLayout();
   Color picking_color = canvas->GetPickingManager().GetPickableColor(
-      shared_from_this(), PickingID::BatcherId::UI);
+      shared_from_this(), PickingID::BatcherId::kUi);
   const Color kTabColor(50, 50, 50, 255);
   const bool picking = picking_mode != PickingMode::kNone;
   Color color = picking ? picking_color : kTabColor;
@@ -102,7 +102,7 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
     if (layout.GetDrawTrackBackground()) {
       Box box(Vec2(x0, y0 + top_margin),
               Vec2(m_Size[0], -m_Size[1] - top_margin), track_z);
-      batcher->AddBox(box, color, PickingID::PICKABLE);
+      batcher->AddBox(box, color, PickingID::Type::kPickable);
     }
   }
 
@@ -114,7 +114,7 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   float tab_x0 = x0 + layout.GetTrackTabOffset();
 
   Box box(Vec2(tab_x0, y0), Vec2(label_width, label_height), track_z);
-  batcher->AddBox(box, color, PickingID::PICKABLE);
+  batcher->AddBox(box, color, PickingID::Type::kPickable);
 
   // Draw rounded corners.
   if (!picking) {

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -74,7 +74,7 @@ void DrawTriangleFan(Batcher* batcher, const std::vector<Vec2>& points,
     vertices[i % 2] =
         position + Vec3(rotated_points[i + 1][0], rotated_points[i + 1][1], z);
     Triangle triangle(pivot, vertices[i % 2], vertices[(i + 1) % 2]);
-    batcher->AddTriangle(triangle, color, PickingID::Type::kPickable);
+    batcher->AddTriangle(triangle, color, PickingType::kPickable);
   }
 }
 
@@ -83,7 +83,7 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
 
   const TimeGraphLayout& layout = time_graph_->GetLayout();
   Color picking_color = canvas->GetPickingManager().GetPickableColor(
-      shared_from_this(), PickingID::BatcherId::kUi);
+      shared_from_this(), BatcherId::kUi);
   const Color kTabColor(50, 50, 50, 255);
   const bool picking = picking_mode != PickingMode::kNone;
   Color color = picking ? picking_color : kTabColor;
@@ -102,7 +102,7 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
     if (layout.GetDrawTrackBackground()) {
       Box box(Vec2(x0, y0 + top_margin),
               Vec2(m_Size[0], -m_Size[1] - top_margin), track_z);
-      batcher->AddBox(box, color, PickingID::Type::kPickable);
+      batcher->AddBox(box, color, PickingType::kPickable);
     }
   }
 
@@ -114,7 +114,7 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   float tab_x0 = x0 + layout.GetTrackTabOffset();
 
   Box box(Vec2(tab_x0, y0), Vec2(label_width, label_height), track_z);
-  batcher->AddBox(box, color, PickingID::Type::kPickable);
+  batcher->AddBox(box, color, PickingType::kPickable);
 
   // Draw rounded corners.
   if (!picking) {

--- a/OrbitGl/TriangleToggle.cpp
+++ b/OrbitGl/TriangleToggle.cpp
@@ -25,7 +25,7 @@ void TriangleToggle::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   if (picking) {
     PickingManager& picking_manager = canvas->GetPickingManager();
     color = picking_manager.GetPickableColor(shared_from_this(),
-                                             PickingID::BatcherId::kUi);
+                                             BatcherId::kUi);
   }
 
   // Draw triangle.
@@ -46,14 +46,14 @@ void TriangleToggle::Draw(GlCanvas* canvas, PickingMode picking_mode) {
                           position + Vec3(-half_w, half_h, 0.f),
                           position + Vec3(0.f, -half_w, 0.f));
     }
-    batcher->AddTriangle(triangle, color, PickingID::Type::kPickable);
+    batcher->AddTriangle(triangle, color, PickingType::kPickable);
   } else {
     // When picking, draw a big square for easier picking.
     float original_width = 2 * half_w;
     float large_width = 2 * original_width;
     Box box(Vec2(pos_[0] - original_width, pos_[1] - original_width),
             Vec2(large_width, large_width), 0.f);
-    batcher->AddBox(box, color, PickingID::Type::kPickable);
+    batcher->AddBox(box, color, PickingType::kPickable);
   }
 }
 

--- a/OrbitGl/TriangleToggle.cpp
+++ b/OrbitGl/TriangleToggle.cpp
@@ -25,7 +25,7 @@ void TriangleToggle::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   if (picking) {
     PickingManager& picking_manager = canvas->GetPickingManager();
     color = picking_manager.GetPickableColor(shared_from_this(),
-                                             PickingID::BatcherId::UI);
+                                             PickingID::BatcherId::kUi);
   }
 
   // Draw triangle.
@@ -46,14 +46,14 @@ void TriangleToggle::Draw(GlCanvas* canvas, PickingMode picking_mode) {
                           position + Vec3(-half_w, half_h, 0.f),
                           position + Vec3(0.f, -half_w, 0.f));
     }
-    batcher->AddTriangle(triangle, color, PickingID::PICKABLE);
+    batcher->AddTriangle(triangle, color, PickingID::Type::kPickable);
   } else {
     // When picking, draw a big square for easier picking.
     float original_width = 2 * half_w;
     float large_width = 2 * original_width;
     Box box(Vec2(pos_[0] - original_width, pos_[1] - original_width),
             Vec2(large_width, large_width), 0.f);
-    batcher->AddBox(box, color, PickingID::PICKABLE);
+    batcher->AddBox(box, color, PickingID::Type::kPickable);
   }
 }
 

--- a/OrbitGl/TriangleToggle.cpp
+++ b/OrbitGl/TriangleToggle.cpp
@@ -24,8 +24,8 @@ void TriangleToggle::Draw(GlCanvas* canvas, PickingMode picking_mode) {
 
   if (picking) {
     PickingManager& picking_manager = canvas->GetPickingManager();
-    color = picking_manager.GetPickableColor(shared_from_this(),
-                                             BatcherId::kUi);
+    color =
+        picking_manager.GetPickableColor(shared_from_this(), BatcherId::kUi);
   }
 
   // Draw triangle.


### PR DESCRIPTION
This PR just cleans up coding style for PickingManager and Batcher, and moves the enums out of PickingID. As a next step, a small refactoring would be required to have the user data consistently accessible and avoid incorrect picking id generation, which can easily cause problems currently, but I wanted to submit the cleaning PR before touching the structure for clarity.