### PR TITLE
OrbitLinuxTracing: Reduce number of reinterpret_casts

### DIFF
--- a/OrbitLinuxTracing/LibunwindstackUnwinder.cpp
+++ b/OrbitLinuxTracing/LibunwindstackUnwinder.cpp
@@ -31,7 +31,7 @@ const std::array<size_t, unwindstack::X86_64_REG_LAST>
 std::vector<unwindstack::FrameData> LibunwindstackUnwinder::Unwind(
     unwindstack::Maps* maps,
     const std::array<uint64_t, PERF_REG_X86_64_MAX>& perf_regs,
-    const char* stack_dump, uint64_t stack_dump_size) {
+    const void* stack_dump, uint64_t stack_dump_size) {
   unwindstack::RegsX86_64 regs{};
   for (size_t perf_reg = 0; perf_reg < unwindstack::X86_64_REG_LAST;
        ++perf_reg) {
@@ -40,7 +40,7 @@ std::vector<unwindstack::FrameData> LibunwindstackUnwinder::Unwind(
 
   std::shared_ptr<unwindstack::Memory> memory =
       unwindstack::Memory::CreateOfflineMemory(
-          reinterpret_cast<const uint8_t*>(stack_dump),
+          static_cast<const uint8_t*>(stack_dump),
           regs[unwindstack::X86_64_REG_RSP],
           regs[unwindstack::X86_64_REG_RSP] + stack_dump_size);
 
@@ -64,19 +64,6 @@ std::vector<unwindstack::FrameData> LibunwindstackUnwinder::Unwind(
   }
 
   return unwinder.frames();
-}
-
-std::vector<unwindstack::FrameData> LibunwindstackUnwinder::Unwind(
-    const std::string& maps_buffer,
-    const std::array<uint64_t, PERF_REG_X86_64_MAX>& perf_regs,
-    const char* stack_dump, uint64_t stack_dump_size) {
-  std::unique_ptr<unwindstack::BufferMaps> maps = ParseMaps(maps_buffer);
-  if (maps == nullptr) {
-    ERROR("Failed to parse maps");
-    return {};
-  }
-
-  return Unwind(maps.get(), perf_regs, stack_dump, stack_dump_size);
 }
 
 }  // namespace LinuxTracing

--- a/OrbitLinuxTracing/LibunwindstackUnwinder.h
+++ b/OrbitLinuxTracing/LibunwindstackUnwinder.h
@@ -23,12 +23,7 @@ class LibunwindstackUnwinder {
   std::vector<unwindstack::FrameData> Unwind(
       unwindstack::Maps* maps,
       const std::array<uint64_t, PERF_REG_X86_64_MAX>& perf_regs,
-      const char* stack_dump, uint64_t stack_dump_size);
-
-  std::vector<unwindstack::FrameData> Unwind(
-      const std::string& maps_buffer,
-      const std::array<uint64_t, PERF_REG_X86_64_MAX>& perf_regs,
-      const char* stack_dump, uint64_t stack_dump_size);
+      const void* stack_dump, uint64_t stack_dump_size);
 
  private:
   static constexpr size_t MAX_FRAMES = 1024;  // This is arbitrary.

--- a/OrbitLinuxTracing/PerfEventReaders.cpp
+++ b/OrbitLinuxTracing/PerfEventReaders.cpp
@@ -86,7 +86,7 @@ std::unique_ptr<CallchainSamplePerfEvent> ConsumeCallchainSamplePerfEvent(
   // TODO(kuebler): we should have templated read methods
   uint64_t size_in_bytes = nr * sizeof(uint64_t) / sizeof(char);
   ring_buffer->ReadRawAtOffset(
-      reinterpret_cast<char*>(event->ips.data()),
+      event->ips.data(),
       offsetof(perf_event_callchain_sample_fixed, nr) +
           sizeof(perf_event_callchain_sample_fixed::nr),
       size_in_bytes);

--- a/OrbitLinuxTracing/PerfEventReaders.h
+++ b/OrbitLinuxTracing/PerfEventReaders.h
@@ -32,9 +32,8 @@ std::unique_ptr<T> ConsumeTracepointPerfEvent(PerfEventRingBuffer* ring_buffer,
   ring_buffer->ReadValueAtOffset(&tracepoint_size,
                                  offsetof(perf_event_raw_sample_fixed, size));
   auto event = std::make_unique<T>(tracepoint_size);
-  ring_buffer->ReadRawAtOffset(
-      reinterpret_cast<uint8_t*>(&event->ring_buffer_record), 0,
-      sizeof(perf_event_raw_sample_fixed));
+  ring_buffer->ReadRawAtOffset(&event->ring_buffer_record, 0,
+                               sizeof(perf_event_raw_sample_fixed));
   ring_buffer->ReadRawAtOffset(
       &event->tracepoint_data[0],
       offsetof(perf_event_raw_sample_fixed, size) + sizeof(uint32_t),

--- a/OrbitLinuxTracing/PerfEventRingBuffer.h
+++ b/OrbitLinuxTracing/PerfEventRingBuffer.h
@@ -36,15 +36,11 @@ class PerfEventRingBuffer {
 
   template <typename T>
   void ReadValueAtOffset(T* value, uint64_t offset) {
-    ReadAtOffsetFromTail(reinterpret_cast<uint8_t*>(value), offset, sizeof(T));
+    ReadAtOffsetFromTail(value, offset, sizeof(T));
   }
 
-  void ReadRawAtOffset(uint8_t* dest, uint64_t offset, uint64_t count) {
+  void ReadRawAtOffset(void* dest, uint64_t offset, uint64_t count) {
     ReadAtOffsetFromTail(dest, offset, count);
-  }
-
-  void ReadRawAtOffset(char* dest, uint64_t offset, uint64_t count) {
-    ReadAtOffsetFromTail(reinterpret_cast<uint8_t*>(dest), offset, count);
   }
 
  private:
@@ -58,11 +54,11 @@ class PerfEventRingBuffer {
   int file_descriptor_ = -1;
   std::string name_;
 
-  void ReadAtTail(uint8_t* dest, uint64_t count) {
+  void ReadAtTail(void* dest, uint64_t count) {
     return ReadAtOffsetFromTail(dest, 0, count);
   }
 
-  void ReadAtOffsetFromTail(uint8_t* dest, uint64_t offset_from_tail,
+  void ReadAtOffsetFromTail(void* dest, uint64_t offset_from_tail,
                             uint64_t count);
 };
 

--- a/OrbitLinuxTracing/UprobesReturnAddressManager.h
+++ b/OrbitLinuxTracing/UprobesReturnAddressManager.h
@@ -37,7 +37,7 @@ class UprobesReturnAddressManager {
     tid_uprobes_stack.emplace_back(stack_pointer, return_address);
   }
 
-  void PatchSample(pid_t tid, uint64_t stack_pointer, char* stack_data,
+  void PatchSample(pid_t tid, uint64_t stack_pointer, void* stack_data,
                    uint64_t stack_size) {
     if (!tid_uprobes_stacks_.contains(tid)) {
       return;
@@ -61,8 +61,8 @@ class UprobesReturnAddressManager {
         continue;
       }
 
-      *reinterpret_cast<uint64_t*>(&stack_data[offset]) =
-          uprobes.return_address;
+      memcpy(static_cast<uint8_t*>(stack_data) + offset,
+             &uprobes.return_address, sizeof(uprobes.return_address));
     }
   }
 

--- a/OrbitLinuxTracing/UprobesReturnAddressManagerTest.cpp
+++ b/OrbitLinuxTracing/UprobesReturnAddressManagerTest.cpp
@@ -54,11 +54,7 @@ class TestStack {
 
   uint64_t GetTop() const { return data_[0]; }
 
-  char* GetData() { return reinterpret_cast<char*>(data_.data()); }
-
-  const char* GetData() const {
-    return reinterpret_cast<const char*>(data_.data());
-  }
+  [[nodiscard]] void* GetData() { return data_.data(); }
 
   uint64_t GetSize() const { return data_.size() * sizeof(uint64_t); }
 


### PR DESCRIPTION
When functions expects a chunk of memory
pass void* instead of uint8_t*, then we can
remove unnecessary reinterpret_casts to uint8_t

Also replace casts from void* to T* with static_casts.

There is one place where reinterpret_cast was
used to memcopy - it was replaced with explicit memcpy.