### PR TITLE
Fixes a crash when selecting a different process

### DIFF
--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -33,8 +33,8 @@ void Capture::Init() { GTargetProcess = std::make_shared<Process>(); }
 
 void Capture::SetTargetProcess(std::shared_ptr<Process> process) {
   if (process != GTargetProcess) {
-    GTargetProcess = std::move(process);
     GSamplingProfiler = std::make_shared<SamplingProfiler>(process);
+    GTargetProcess = std::move(process);
     GSelectedFunctionsMap.clear();
   }
 }

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -31,10 +31,10 @@ std::shared_ptr<PresetFile> Capture::GSessionPresets = nullptr;
 
 void Capture::Init() { GTargetProcess = std::make_shared<Process>(); }
 
-void Capture::SetTargetProcess(const std::shared_ptr<Process>& a_Process) {
-  if (a_Process != GTargetProcess) {
-    GTargetProcess = a_Process;
-    GSamplingProfiler = std::make_shared<SamplingProfiler>(a_Process);
+void Capture::SetTargetProcess(std::shared_ptr<Process> process) {
+  if (process != GTargetProcess) {
+    GTargetProcess = std::move(process);
+    GSamplingProfiler = std::make_shared<SamplingProfiler>(process);
     GSelectedFunctionsMap.clear();
   }
 }

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -23,9 +23,8 @@ class SamplingProfiler;
 
 class Capture {
  public:
-
   static void Init();
-  static void SetTargetProcess(const std::shared_ptr<Process>& a_Process);
+  static void SetTargetProcess(std::shared_ptr<Process> process);
   static ErrorMessageOr<void> StartCapture();
   static void FinalizeCapture();
   static void ClearCaptureData();

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -814,6 +814,7 @@ void OrbitApp::LoadModulesFromPreset(
 }
 
 void OrbitApp::UpdateProcessAndModuleList(int32_t pid) {
+  CHECK(m_ProcessesDataView->GetSelectedProcessId() == pid);
   thread_pool_->Schedule([pid, this] {
     ErrorMessageOr<std::vector<ModuleInfo>> result =
         process_manager_->LoadModuleList(pid);
@@ -875,13 +876,6 @@ void OrbitApp::UpdateProcessAndModuleList(int32_t pid) {
   });
 }
 
-void OrbitApp::OnProcessSelected(int32_t pid) {
-  CHECK(m_ProcessesDataView->GetSelectedProcessId() == pid);
-
-  // Update modules and process together to avoid inconsistent state
-  UpdateProcessAndModuleList(pid);
-}
-
 std::shared_ptr<Process> OrbitApp::FindProcessByPid(int32_t pid) {
   absl::MutexLock lock(&process_map_mutex_);
   auto it = process_map_.find(pid);
@@ -929,7 +923,7 @@ DataView* OrbitApp::GetOrCreateDataView(DataViewType type) {
       if (!m_ProcessesDataView) {
         m_ProcessesDataView = std::make_unique<ProcessesDataView>();
         m_ProcessesDataView->SetSelectionListener(
-            [&](int32_t pid) { OnProcessSelected(pid); });
+            [&](int32_t pid) { UpdateProcessAndModuleList(pid); });
         m_Panels.push_back(m_ProcessesDataView.get());
       }
       return m_ProcessesDataView.get();

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -97,8 +97,6 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
 
   void RegisterCaptureWindow(class CaptureWindow* a_Capture);
 
-  void OnProcessSelected(int32_t pid);
-
   void AddSamplingReport(std::shared_ptr<SamplingProfiler> sampling_profiler);
   void AddSelectionReport(std::shared_ptr<SamplingProfiler> a_SamplingProfiler);
   void AddTopDownView(const SamplingProfiler& sampling_profiler);

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -203,7 +203,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void LoadModulesFromPreset(
       const std::shared_ptr<Process>& process,
       const std::shared_ptr<orbit_client_protos::PresetFile>& preset);
-  void UpdateModuleList(int32_t pid);
+  void UpdateProcessAndModuleList(int32_t pid);
 
   void UpdateSamplingReport();
   void LoadPreset(

--- a/OrbitGl/ModulesDataView.cpp
+++ b/OrbitGl/ModulesDataView.cpp
@@ -186,7 +186,7 @@ void ModulesDataView::SetModules(int32_t process_id,
 }
 
 void ModulesDataView::OnRefreshButtonClicked() {
-  GOrbitApp->UpdateModuleList(Capture::GTargetProcess->GetID());
+  GOrbitApp->UpdateProcessAndModuleList(Capture::GTargetProcess->GetID());
 }
 
 const ModuleData* ModulesDataView::GetModule(uint32_t row) const {


### PR DESCRIPTION
This bug occurred when there were symbols loaded and functions hooked.
In this case the process gets updated internally and the UI tries to
render the function window before its `OnDataChanged` event arrived,
as `UpdateModules` fires the refresh callbacks at the very end initially
spawned from another thread.

This fix pospones the setting of the global variable GTargetProcess
until all data is ready to propagete the UI update (in particular the
modules list). So if the UI redraws before the UpdateModules function
propagates the data update, there will be no inconsistent state and
thus no crash. As UpdateModules now also sets the process, the method
is also renamed.

This also slightly refactors the Capture::SetTargetProcess by making
it non-ref parameter (as it is a sink) and move the process there and
further rename the parameter.

Bug: http://b/163786513
Test: On Linux: Select a process, load some modules and hook functions.
        Then select another process. The previous crash is gone now.