### PR TITLE
Defer the deletion of ui widget when removing iterator from the ui.

### DIFF
--- a/OrbitQt/orbitlivefunctions.cpp
+++ b/OrbitQt/orbitlivefunctions.cpp
@@ -78,7 +78,7 @@ void OrbitLiveFunctions::AddIterator(size_t id, FunctionInfo* function) {
     this->live_functions_.OnDeleteButton(id);
     auto it = this->iterator_uis.find(id);
     ui->iteratorLayout->removeWidget(it->second);
-    delete it->second;
+    it->second->deleteLater();
     iterator_uis.erase(id);
     if (iterator_uis.empty()) {
       this->all_events_iterator_->DisableButtons();


### PR DESCRIPTION
With the previous implementation we were deleting the object that stored the
lambda which was executing the delete. By a (un)lucky coincidence this works
fine in release builds. It crashes in debug reproducibly.