### PR TITLE
Remove unused code using Log.h

### DIFF
--- a/OrbitCore/CMakeLists.txt
+++ b/OrbitCore/CMakeLists.txt
@@ -47,7 +47,6 @@ target_sources(
           FunctionUtils.cpp
           Introspection.cpp
           LinuxTracingBuffer.cpp
-          Log.cpp
           OrbitModule.cpp
           OrbitProcess.cpp
           Params.cpp

--- a/OrbitCore/FunctionUtils.cpp
+++ b/OrbitCore/FunctionUtils.cpp
@@ -70,13 +70,6 @@ bool IsSelected(const FunctionInfo& func) {
   return Capture::GSelectedFunctionsMap.count(GetAbsoluteAddress(func)) > 0;
 }
 
-void Print(const FunctionInfo& func) {
-  ORBIT_VIZV(func.address());
-  ORBIT_VIZV(func.file());
-  ORBIT_VIZV(func.line());
-  ORBIT_VIZV(IsSelected(func));
-}
-
 const absl::flat_hash_map<const char*, FunctionInfo::OrbitType>&
 GetFunctionNameToOrbitTypeMap() {
   static absl::flat_hash_map<const char*, FunctionInfo::OrbitType>

--- a/OrbitCore/Log.cpp
+++ b/OrbitCore/Log.cpp
@@ -1,7 +1,0 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
-#include "Log.h"
-
-Logger GLogger;

--- a/OrbitCore/Log.h
+++ b/OrbitCore/Log.h
@@ -10,10 +10,6 @@
 
 #include "Threading.h"
 
-#define ORBIT_LOG(msg) GLogger.Log(OrbitLog::Global, msg)
-#define ORBIT_LOGV(var) GLogger.Log(OrbitLog::Global, #var, var)
-#define ORBIT_VIZV(var) GLogger.Log(OrbitLog::Viz, #var, var)
-
 class OrbitLog {
  public:
   enum Type { Global, Debug, Pdb, Viz, NumLogTypes };
@@ -68,5 +64,3 @@ class Logger {
   OrbitLog m_Logs[OrbitLog::NumLogTypes];
   Mutex m_Mutexes[OrbitLog::NumLogTypes];
 };
-
-extern Logger GLogger;

--- a/OrbitCore/SamplingProfiler.cpp
+++ b/OrbitCore/SamplingProfiler.cpp
@@ -347,13 +347,9 @@ void SamplingProfiler::UpdateAddressInfo(uint64_t address) {
 
 void SamplingProfiler::FillThreadSampleDataSampleReports() {
   for (auto& data : thread_id_to_sample_data_) {
-    ThreadID thread_id = data.first;
     ThreadSampleData* thread_sample_data = &data.second;
     std::vector<SampledFunction>* sampled_functions =
         &thread_sample_data->sampled_function;
-
-    ORBIT_LOGV(thread_id);
-    ORBIT_LOGV(thread_sample_data->samples_count);
 
     for (auto sortedIt = thread_sample_data->address_count_sorted.rbegin();
          sortedIt != thread_sample_data->address_count_sorted.rend();

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -93,10 +93,10 @@ void GlCanvas::Initialize() {
     // glewExperimental = GL_TRUE;
     GLenum err = glewInit();
     CheckGlError();
-    if (GLEW_OK != err) {
+    if (err != GLEW_OK) {
       /* Problem: glewInit failed, something is seriously wrong. */
-      ORBIT_LOGV(glewGetErrorString(err));
-      exit(EXIT_FAILURE);
+      FATAL("Problem: glewInit failed, something is seriously wrong: %s",
+            reinterpret_cast<const char*>(glewGetErrorString(err)));
     }
     std::string glew = absl::StrFormat(
         "Using GLEW %s",

--- a/OrbitGl/GlUtils.cpp
+++ b/OrbitGl/GlUtils.cpp
@@ -4,10 +4,7 @@
 
 #include "GlUtils.h"
 
-#include "Log.h"
-#include "OpenGl.h"
 #include "OrbitBase/Logging.h"
-#include "PrintVar.h"
 #include "absl/strings/str_format.h"
 #include "freetype-gl/freetype-gl.h"
 
@@ -18,45 +15,4 @@ void CheckGlError() {
     errString = reinterpret_cast<const char*>(gluErrorString(errCode));
     LOG("OpenGL ERROR : %s", errString);
   }
-}
-
-void OutputGlMatrices() {
-  int i;
-  glGetIntegerv(GL_MATRIX_MODE, &i);
-  /*
-  #define GL_MODELVIEW                      0x1700
-  #define GL_PROJECTION                     0x1701
-  #define GL_TEXTURE                        0x1702
-  */
-
-  ORBIT_LOG("Current matrix mode is : ");
-  switch (i) {
-    case GL_MODELVIEW:
-      ORBIT_LOG("GL_MODELVIEW");
-      break;
-    case GL_PROJECTION:
-      ORBIT_LOG("GL_PROJECTION");
-      break;
-    case GL_TEXTURE:
-      ORBIT_LOG("GL_TEXTURE");
-      break;
-  }
-
-  ORBIT_LOG("\n\nMatrices are: \n");
-
-  // ModelView
-  GLfloat matrix[16];
-  glGetFloatv(GL_MODELVIEW_MATRIX, matrix);
-  mat4* modelView = reinterpret_cast<mat4*>(&matrix[0]);
-  PRINT_VAR(*modelView);
-
-  // Projection
-  glGetFloatv(GL_PROJECTION_MATRIX, matrix);
-  mat4* projection = reinterpret_cast<mat4*>(&matrix[0]);
-  PRINT_VAR(*projection);
-
-  // Texture
-  glGetFloatv(GL_TEXTURE_MATRIX, matrix);
-  mat4* texture = reinterpret_cast<mat4*>(&matrix[0]);
-  PRINT_VAR(*texture);
 }

--- a/OrbitGl/GlUtils.h
+++ b/OrbitGl/GlUtils.h
@@ -9,7 +9,6 @@
 #include <iostream>
 
 void CheckGlError();
-void OutputGlMatrices();
 
 inline std::ostream& operator<<(std::ostream& os, const ftgl::mat4& mat) {
   os << std::endl;


### PR DESCRIPTION
Remove unused code using Log.h macros
and move the rest of the code to use
OrbitBase/Logging.h.

Test: builds