### PR TITLE
Remove PRINT_VAR logging

### DIFF
--- a/OrbitCore/Path.cpp
+++ b/OrbitCore/Path.cpp
@@ -262,24 +262,6 @@ std::string Path::GetServiceLogFilePath() {
 }
 #endif
 
-void Path::Dump() {
-  PRINT_VAR(GetExecutableName());
-  PRINT_VAR(GetExecutablePath());
-  PRINT_VAR(GetBasePath());
-  PRINT_VAR(GetDllPath(true));
-  PRINT_VAR(GetDllName(true));
-  PRINT_VAR(GetDllPath(false));
-  PRINT_VAR(GetDllName(false));
-  PRINT_VAR(GetFileMappingFileName());
-  PRINT_VAR(GetSymbolsFileName());
-  PRINT_VAR(GetCachePath());
-  PRINT_VAR(GetPresetPath());
-  PRINT_VAR(GetPluginPath());
-  PRINT_VAR(GetCapturePath());
-  PRINT_VAR(GetDumpPath());
-  PRINT_VAR(GetAppDataPath());
-}
-
 std::vector<std::string> Path::ListFiles(
     const std::string& directory,
     std::function<bool(const std::string&)> filter) {

--- a/OrbitCore/PrintVar.h
+++ b/OrbitCore/PrintVar.h
@@ -7,11 +7,6 @@
 
 #include <sstream>
 
-#include "OrbitBase/Logging.h"
-#include "Utils.h"
-#include "absl/strings/str_format.h"
-
-#define PRINT_VAR(var) LOG("%s", VAR_TO_STR(var).c_str())
 #define VAR_TO_STR(var) VariableToString(#var, var)
 
 template <class T>
@@ -20,7 +15,5 @@ inline std::string VariableToString(const char* name, const T& value) {
   string_stream << name << " = " << value;
   return string_stream.str();
 }
-
-inline void PrintLastError() { PRINT_VAR(GetLastErrorAsString()); }
 
 #endif  // ORBIT_CORE_PRINT_VAR_H_

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -93,10 +93,8 @@ void GlCanvas::Initialize() {
       FATAL("Problem: glewInit failed, something is seriously wrong: %s",
             reinterpret_cast<const char*>(glewGetErrorString(err)));
     }
-    std::string glew = absl::StrFormat(
-        "Using GLEW %s",
+    LOG("Using GLEW %s",
         reinterpret_cast<const char*>(glewGetString(GLEW_VERSION)));
-    PRINT_VAR(glew);
     firstInit = false;
   }
 }

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -159,9 +159,10 @@ void ThreadTrack::SetTimesliceText(const TimerInfo& timer_info,
                                          time.c_str());
       text_box->SetText(text);
     } else {
-      ERROR("Unexpected case in ThreadTrack::SetTimesliceText");
-      PRINT_VAR(timer_info.type());
-      PRINT_VAR(func);
+      ERROR(
+          "Unexpected case in ThreadTrack::SetTimesliceText, function=\"%s\", "
+          "type=%d",
+          func->name(), static_cast<int>(timer_info.type()));
     }
   }
 

--- a/OrbitQt/orbitcodeeditor.cpp
+++ b/OrbitQt/orbitcodeeditor.cpp
@@ -144,7 +144,6 @@ void OrbitCodeEditor::OnSaveMapFile() {
 
 void OrbitCodeEditor::OnFindTextEntered(const QString&) {
   // setFocus();
-  PRINT_VAR(m_FindLineEdit->text().toStdString());
   QTextCursor cursor(textCursor());
   cursor.movePosition(QTextCursor::EndOfWord);
   setTextCursor(cursor);

--- a/OrbitQt/orbitglwidget.cpp
+++ b/OrbitQt/orbitglwidget.cpp
@@ -70,9 +70,9 @@ void OrbitGLWidget::initializeGL() {
 }
 
 void OrbitGLWidget::PrintContextInformation() {
-  QString glType;
-  QString glVersion;
-  QString glProfile;
+  std::string glType;
+  std::string glVersion;
+  std::string glProfile;
 
   // Get Version Information
   glType = (context()->isOpenGLES()) ? "OpenGL ES" : "OpenGL";
@@ -89,10 +89,8 @@ void OrbitGLWidget::PrintContextInformation() {
     CASE(CompatibilityProfile);
   }
 #undef CASE
-
-  PRINT_VAR(qPrintable(glType));
-  PRINT_VAR(qPrintable(glVersion));
-  PRINT_VAR(qPrintable(glProfile));
+  LOG(R"(glType="%s", glVersion="%s", glProfile="%s")", glType, glVersion,
+      glProfile);
 }
 
 void OrbitGLWidget::messageLogged(const QOpenGLDebugMessage& msg) {


### PR DESCRIPTION
There are not so many usages of it
and they are better of having some additional
information in the log message anyways.

Test: builds