### PR TITLE
Fix BlockChain for empty instance iteration

### DIFF
--- a/OrbitCore/BlockChain.h
+++ b/OrbitCore/BlockChain.h
@@ -176,7 +176,7 @@ class BlockChain final {
   [[nodiscard]] uint32_t size() const { return size_; }
 
   [[nodiscard]] BlockIterator<T, BlockSize> begin() const {
-    return BlockIterator<T, BlockSize>(root_);
+    return size() > 0 ? BlockIterator<T, BlockSize>(root_) : end();
   }
 
   [[nodiscard]] BlockIterator<T, BlockSize> end() const {

--- a/OrbitCore/BlockChainTest.cpp
+++ b/OrbitCore/BlockChainTest.cpp
@@ -94,6 +94,7 @@ TEST(BlockChain, ElementIteration) {
   constexpr const int v3 = 15;
 
   BlockChain<int, 1024> chain;
+
   chain.push_back(v1);
   chain.push_back(v2);
   chain.push_back(v3);
@@ -137,6 +138,12 @@ TEST(BlockChain, ElementIteration) {
   }
 
   EXPECT_EQ(it_count, 2000);
+}
+
+TEST(BlockChain, EmptyIteration) {
+  BlockChain<std::string, 1024> chain;
+  auto it = chain.begin();
+  ASSERT_FALSE(it != chain.end());
 }
 
 TEST(BlockChain, AddCopyableTypesN) {


### PR DESCRIPTION
BlockChain iteration is broken for an empty chain: Without calling BlockChainIterator++, `begin() != end()` will always be true, even for an empty chain. Added a new test to detect the behavior.

Test: run OrbitCore Tests