### PR TITLE
Add LOG_VAR macro

### DIFF
--- a/OrbitBase/include/OrbitBase/Logging.h
+++ b/OrbitBase/include/OrbitBase/Logging.h
@@ -8,6 +8,7 @@
 #include <cstdio>
 #include <filesystem>
 #include <fstream>
+#include <string>
 
 #ifdef _WIN32
 #include <Windows.h>
@@ -33,6 +34,8 @@
         "[%28s] " format "\n", file_and_line__.c_str(), ##__VA_ARGS__);       \
     PLATFORM_LOG(formatted_log__.c_str());                                    \
   } while (0)
+
+#define LOG_VAR(x) LOG("%s = %s", #x, std::to_string(x))
 
 #if defined(_WIN32) && defined(ERROR)
 #undef ERROR


### PR DESCRIPTION
LOG_VAR logs a variable's name and value in the form "name = value".

This was previously implemented in OrbitCore as PRINT_VAR. I use it all the time 
for debugging so I'm re-adding it, in OrbitBase this time.