### PR TITLE
Clean up disassembler

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -340,7 +340,7 @@ void OrbitApp::Disassemble(int32_t pid, const FunctionInfo& function) {
 
     const std::string& memory = result.value();
     Disassembler disasm;
-    disasm.LogLine(absl::StrFormat("asm: /* %s */",
+    disasm.AddLine(absl::StrFormat("asm: /* %s */",
                                    FunctionUtils::GetDisplayName(function)));
     disasm.Disassemble(memory.data(), memory.size(),
                        FunctionUtils::GetAbsoluteAddress(function),

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -340,8 +340,8 @@ void OrbitApp::Disassemble(int32_t pid, const FunctionInfo& function) {
 
     const std::string& memory = result.value();
     Disassembler disasm;
-    disasm.LOGF(absl::StrFormat("asm: /* %s */\n",
-                                FunctionUtils::GetDisplayName(function)));
+    disasm.LogLine(absl::StrFormat("asm: /* %s */",
+                                   FunctionUtils::GetDisplayName(function)));
     disasm.Disassemble(memory.data(), memory.size(),
                        FunctionUtils::GetAbsoluteAddress(function),
                        Capture::GTargetProcess->GetIs64Bit());

--- a/OrbitGl/Disassembler.cpp
+++ b/OrbitGl/Disassembler.cpp
@@ -4,27 +4,9 @@
 
 #include "Disassembler.h"
 
+#include <absl/strings/str_replace.h>
 #include <capstone/capstone.h>
 #include <capstone/platform.h>
-
-#define LOGF(format, ...)                                   \
-  {                                                         \
-    std::string log = absl::StrFormat(format, __VA_ARGS__); \
-    result_ += log;                                         \
-  }
-
-#define LOG(str) \
-  { result_ += str; }
-
-void Disassembler::LogHex(const uint8_t* str, size_t len) {
-  const unsigned char* c;
-
-  LOGF("%s", "Code: ");
-  for (c = str; c < str + len; c++) {
-    LOGF("0x%02x ", *c & 0xff);
-  }
-  LOGF("%s", "\n");
-}
 
 void Disassembler::Disassemble(const void* machine_code, size_t size,
                                uint64_t address, bool is_64bit) {
@@ -35,14 +17,12 @@ void Disassembler::Disassemble(const void* machine_code, size_t size,
   cs_err err;
   cs_mode mode = is_64bit ? CS_MODE_64 : CS_MODE_32;
 
-  LOG("\n");
-  line_to_address_.push_back(0);
-  LOGF("Platform: %s\n",
-       is_64bit ? "X86 64 (Intel syntax)" : "X86 32 (Intel syntax)");
-  line_to_address_.push_back(0);
+  LogLine(absl::StrFormat("Platform: %s", is_64bit ? "X86 64 (Intel syntax)"
+                                                   : "X86 32 (Intel syntax)"));
   err = cs_open(arch, mode, &handle);
   if (err) {
-    LOGF("Failed on cs_open() with error returned: %u\n", err);
+    LogLine(
+        absl::StrFormat("Failed on cs_open() with error returned: %u", err));
     return;
   }
 
@@ -53,27 +33,33 @@ void Disassembler::Disassemble(const void* machine_code, size_t size,
     size_t j;
 
     for (j = 0; j < count; j++) {
-      LOGF("0x%" PRIx64 ":\t%-12s %s\n", insn[j].address, insn[j].mnemonic,
-           insn[j].op_str);
-      line_to_address_.push_back(insn[j].address);
+      LogLine(absl::StrFormat("0x%llx:\t%-12s %s", insn[j].address,
+                              insn[j].mnemonic, insn[j].op_str),
+              insn[j].address);
     }
 
-    // print out the next offset, after the last insn
-    LOGF("0x%" PRIx64 ":\n", insn[j - 1].address + insn[j - 1].size);
+    // Print out the next offset, after the last instruction.
+    LogLine(absl::StrFormat("0x%llx:", insn[j - 1].address + insn[j - 1].size));
 
-    // free memory allocated by cs_disasm()
+    // Free memory allocated by cs_disasm().
     cs_free(insn, count);
   } else {
-    LOG("****************\n");
-    LOG("ERROR: Failed to disasm given code!\n");
+    LogLine("****************");
+    LogLine("ERROR: Failed to disasm given code!");
   }
 
-  LOG("\n");
-
+  LogLine("");
   cs_close(&handle);
 }
 
 uint64_t Disassembler::GetAddressAtLine(size_t line) const {
   if (line >= line_to_address_.size()) return 0;
   return line_to_address_[line];
+}
+
+void Disassembler::LogLine(std::string line, uint64_t address) {
+  // Remove any new line character.
+  line = absl::StrReplaceAll(line, {{"\n", ""}});
+  line_to_address_.push_back(address);
+  result_ += absl::StrFormat("%s\n", line);
 }

--- a/OrbitGl/Disassembler.cpp
+++ b/OrbitGl/Disassembler.cpp
@@ -17,11 +17,11 @@ void Disassembler::Disassemble(const void* machine_code, size_t size,
   cs_err err;
   cs_mode mode = is_64bit ? CS_MODE_64 : CS_MODE_32;
 
-  LogLine(absl::StrFormat("Platform: %s", is_64bit ? "X86 64 (Intel syntax)"
+  AddLine(absl::StrFormat("Platform: %s", is_64bit ? "X86 64 (Intel syntax)"
                                                    : "X86 32 (Intel syntax)"));
   err = cs_open(arch, mode, &handle);
   if (err) {
-    LogLine(
+    AddLine(
         absl::StrFormat("Failed on cs_open() with error returned: %u", err));
     return;
   }
@@ -33,22 +33,22 @@ void Disassembler::Disassemble(const void* machine_code, size_t size,
     size_t j;
 
     for (j = 0; j < count; j++) {
-      LogLine(absl::StrFormat("0x%llx:\t%-12s %s", insn[j].address,
+      AddLine(absl::StrFormat("0x%llx:\t%-12s %s", insn[j].address,
                               insn[j].mnemonic, insn[j].op_str),
               insn[j].address);
     }
 
     // Print out the next offset, after the last instruction.
-    LogLine(absl::StrFormat("0x%llx:", insn[j - 1].address + insn[j - 1].size));
+    AddLine(absl::StrFormat("0x%llx:", insn[j - 1].address + insn[j - 1].size));
 
     // Free memory allocated by cs_disasm().
     cs_free(insn, count);
   } else {
-    LogLine("****************");
-    LogLine("ERROR: Failed to disasm given code!");
+    AddLine("****************");
+    AddLine("ERROR: Failed to disasm given code!");
   }
 
-  LogLine("");
+  AddLine("");
   cs_close(&handle);
 }
 
@@ -57,7 +57,7 @@ uint64_t Disassembler::GetAddressAtLine(size_t line) const {
   return line_to_address_[line];
 }
 
-void Disassembler::LogLine(std::string line, uint64_t address) {
+void Disassembler::AddLine(std::string line, uint64_t address) {
   // Remove any new line character.
   line = absl::StrReplaceAll(line, {{"\n", ""}});
   line_to_address_.push_back(address);

--- a/OrbitGl/Disassembler.h
+++ b/OrbitGl/Disassembler.h
@@ -13,7 +13,7 @@ class Disassembler {
  public:
   void Disassemble(const void* machine_code, size_t size, uint64_t address,
                    bool is_64bit);
-  void LogLine(std::string, uint64_t address = 0);
+  void AddLine(std::string, uint64_t address = 0);
   [[nodiscard]] const std::string& GetResult() const { return result_; }
   [[nodiscard]] uint64_t GetAddressAtLine(size_t line) const;
 

--- a/OrbitGl/Disassembler.h
+++ b/OrbitGl/Disassembler.h
@@ -13,15 +13,10 @@ class Disassembler {
  public:
   void Disassemble(const void* machine_code, size_t size, uint64_t address,
                    bool is_64bit);
-  [[nodiscard]] const std::string& GetResult() const { return result_; }
-  [[nodiscard]] uint64_t GetAddressAtLine(size_t line) const;
-
-  void LOGF(const std::string& format) {
-    result_ += format;
-    line_to_address_.push_back(0);
-  }
-
-  void LogHex(const uint8_t* str, size_t len);
+  void LogLine(std::string, uint64_t address = 0);
+  [[nodiscard]] const std::string& GetResult() const {
+    return result_;
+  }[[nodiscard]] uint64_t GetAddressAtLine(size_t line) const;
 
  private:
   std::string result_;

--- a/OrbitGl/Disassembler.h
+++ b/OrbitGl/Disassembler.h
@@ -14,9 +14,8 @@ class Disassembler {
   void Disassemble(const void* machine_code, size_t size, uint64_t address,
                    bool is_64bit);
   void LogLine(std::string, uint64_t address = 0);
-  [[nodiscard]] const std::string& GetResult() const {
-    return result_;
-  }[[nodiscard]] uint64_t GetAddressAtLine(size_t line) const;
+  [[nodiscard]] const std::string& GetResult() const { return result_; }
+  [[nodiscard]] uint64_t GetAddressAtLine(size_t line) const;
 
  private:
   std::string result_;


### PR DESCRIPTION
Remove LOG and LOGF macros in Disassembler.cpp. @florian-kuebler, I tried to make the the line_to_address_ code more robust, please let me know if there is any functional difference. I might have introduced an off-by-one here, not sure.