### PR TITLE
Simplified interaction of Batcher and PickingManager

### DIFF
--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -113,7 +113,7 @@ void Batcher::AddTriangle(const Triangle& triangle, const Color& color,
   triangle_buffer_.user_data_.push_back(std::move(user_data));
 }
 
-PickingUserData* Batcher::GetUserData(PickingId id) {
+const PickingUserData* Batcher::GetUserData(PickingId id) const {
   CHECK(id.element_id >= 0);
   CHECK(id.batcher_id == batcher_id_);
 
@@ -134,6 +134,11 @@ PickingUserData* Batcher::GetUserData(PickingId id) {
   }
 
   UNREACHABLE();
+}
+
+PickingUserData* Batcher::GetUserData(PickingId id) {
+  return const_cast<PickingUserData*>(
+      static_cast<const Batcher*>(this)->GetUserData(id));
 }
 
 TextBox* Batcher::GetTextBox(PickingId id) {
@@ -223,7 +228,7 @@ void Batcher::DrawLineBuffer(bool picking) const {
 
 void Batcher::DrawTriangleBuffer(bool picking) const {
   const Block<Triangle, TriangleBuffer::NUM_TRIANGLES_PER_BLOCK>*
-      triangle_buffer_.triangles_.root();
+      triangle_block = triangle_buffer_.triangles_.root();
   const Block<Color, TriangleBuffer::NUM_TRIANGLES_PER_BLOCK * 3>* color_block;
 
   color_block = !picking ? triangle_buffer_.colors_.root()

--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -10,7 +10,7 @@
 void Batcher::AddLine(const Line& line, const std::array<Color, 2>& colors,
                       PickingType picking_type,
                       std::unique_ptr<PickingUserData> user_data) {
-  Color picking_color = PickingId::GetColor(
+  Color picking_color = PickingId::ToColor(
       picking_type, line_buffer_.lines_.size(), batcher_id_);
   line_buffer_.lines_.push_back(line);
   line_buffer_.colors_.push_back(colors);
@@ -51,7 +51,7 @@ void Batcher::AddBox(const Box& box, const std::array<Color, 4>& colors,
                      PickingType picking_type,
                      std::unique_ptr<PickingUserData> user_data) {
   Color picking_color =
-      PickingId::GetColor(picking_type, box_buffer_.boxes_.size(), batcher_id_);
+      PickingId::ToColor(picking_type, box_buffer_.boxes_.size(), batcher_id_);
   box_buffer_.boxes_.push_back(box);
   box_buffer_.colors_.push_back(colors);
   box_buffer_.picking_colors_.push_back_n(picking_color, 4);
@@ -77,7 +77,7 @@ void Batcher::AddShadedBox(const Vec2& pos, const Vec2& size, float z,
 void Batcher::AddTriangle(const Triangle& triangle, const Color& color,
                           PickingType picking_type,
                           std::unique_ptr<PickingUserData> user_data) {
-  Color picking_color = PickingId::GetColor(
+  Color picking_color = PickingId::ToColor(
       picking_type, triangle_buffer_.triangles_.size(), batcher_id_);
   triangle_buffer_.triangles_.push_back(triangle);
   triangle_buffer_.colors_.push_back_n(color, 3);
@@ -92,20 +92,20 @@ void Batcher::AddTriangle(const Vec3& v0, const Vec3& v1, const Vec3& v2,
 }
 
 PickingUserData* Batcher::GetUserData(PickingId id) {
-  CHECK(id.id >= 0);
+  CHECK(id.element_id >= 0);
 
   switch (id.type) {
     case PickingType::kInvalid:
       return nullptr;
     case PickingType::kBox:
-      CHECK(id.id < box_buffer_.user_data_.size());
-      return box_buffer_.user_data_[id.id].get();
+      CHECK(id.element_id < box_buffer_.user_data_.size());
+      return box_buffer_.user_data_[id.element_id].get();
     case PickingType::kLine:
-      CHECK(id.id < line_buffer_.user_data_.size());
-      return line_buffer_.user_data_[id.id].get();
+      CHECK(id.element_id < line_buffer_.user_data_.size());
+      return line_buffer_.user_data_[id.element_id].get();
     case PickingType::kTriangle:
-      CHECK(id.id < triangle_buffer_.user_data_.size());
-      return triangle_buffer_.user_data_[id.id].get();
+      CHECK(id.element_id < triangle_buffer_.user_data_.size());
+      return triangle_buffer_.user_data_[id.element_id].get();
     case PickingType::kPickable:
       return nullptr;
   }

--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -7,92 +7,114 @@
 #include "OpenGl.h"
 #include "Utils.h"
 
-void Batcher::AddLine(const Line& line, const std::array<Color, 2>& colors,
-                      PickingType picking_type,
+void Batcher::AddLine(Vec2 from, Vec2 to, float z, Color color,
                       std::unique_ptr<PickingUserData> user_data) {
   Color picking_color = PickingId::ToColor(
-      picking_type, line_buffer_.lines_.size(), batcher_id_);
+      PickingType::kLine, line_buffer_.lines_.size(), batcher_id_);
+
+  AddLine(from, to, z, color, picking_color, std::move(user_data));
+}
+
+void Batcher::AddLine(Vec2 from, Vec2 to, float z, Color color,
+                      std::weak_ptr<Pickable> pickable) {
+  CHECK(picking_manager_ != nullptr);
+
+  Color picking_color =
+      picking_manager_->GetPickableColor(pickable, batcher_id_);
+
+  AddLine(from, to, z, color, picking_color, nullptr);
+}
+
+void Batcher::AddVerticalLine(Vec2 pos, float size, float z, Color color,
+                              std::unique_ptr<PickingUserData> user_data) {
+  AddLine(pos, pos + Vec2(0, size), z, color, std::move(user_data));
+}
+
+void Batcher::AddLine(Vec2 from, Vec2 to, float z, Color color,
+                      Color picking_color,
+                      std::unique_ptr<PickingUserData> user_data) {
+  Line line;
+  line.m_Beg = Vec3(from[0], from[1], z);
+  line.m_End = Vec3(to[0], to[1], z);
+
   line_buffer_.lines_.push_back(line);
-  line_buffer_.colors_.push_back(colors);
+  line_buffer_.colors_.push_back_n(color, 2);
   line_buffer_.picking_colors_.push_back_n(picking_color, 2);
   line_buffer_.user_data_.push_back(std::move(user_data));
 }
 
-void Batcher::AddLine(const Line& line, Color color, PickingType picking_type,
-                      std::unique_ptr<PickingUserData> user_data) {
-  std::array<Color, 2> colors;
-  Fill(colors, color);
-  AddLine(line, colors, picking_type, std::move(user_data));
-}
-
-void Batcher::AddLine(Vec2 from, Vec2 to, float z, Color color,
-                      PickingType picking_type,
-                      std::unique_ptr<PickingUserData> user_data) {
-  Line line;
-  std::array<Color, 2> colors;
-  Fill(colors, color);
-  line.m_Beg = Vec3(from[0], from[1], z);
-  line.m_End = Vec3(to[0], to[1], z);
-  AddLine(line, colors, picking_type, std::move(user_data));
-}
-
-void Batcher::AddVerticalLine(Vec2 pos, float size, float z, Color color,
-                              PickingType picking_type,
-                              std::unique_ptr<PickingUserData> user_data) {
-  Line line;
-  std::array<Color, 2> colors;
-  Fill(colors, color);
-  line.m_Beg = Vec3(pos[0], pos[1], z);
-  line.m_End = Vec3(pos[0], pos[1] + size, z);
-  AddLine(line, colors, picking_type, std::move(user_data));
-}
-
-void Batcher::AddBox(const Box& box, const std::array<Color, 4>& colors,
-                     PickingType picking_type,
+void Batcher::AddBox(const Box& box, const Color* colors,
                      std::unique_ptr<PickingUserData> user_data) {
+  Color picking_color = PickingId::ToColor(
+      PickingType::kBox, box_buffer_.boxes_.size(), batcher_id_);
+  AddBox(box, colors, picking_color, std::move(user_data));
+}
+
+void Batcher::AddBox(const Box& box, Color color,
+                     std::unique_ptr<PickingUserData> user_data) {
+  Color colors[4];
+  Fill(colors, color);
+  AddBox(box, colors, std::move(user_data));
+}
+
+void Batcher::AddBox(const Box& box, Color color,
+                     std::weak_ptr<Pickable> pickable) {
+  CHECK(picking_manager_ != nullptr);
+
   Color picking_color =
-      PickingId::ToColor(picking_type, box_buffer_.boxes_.size(), batcher_id_);
+      picking_manager_->GetPickableColor(pickable, batcher_id_);
+  Color colors[4];
+  Fill(colors, color);
+
+  AddBox(box, colors, picking_color, nullptr);
+}
+
+void Batcher::AddShadedBox(Vec2 pos, Vec2 size, float z, Color color,
+                           std::unique_ptr<PickingUserData> user_data) {
+  Color colors[4];
+  GetBoxGradientColors(color, colors);
+  Box box(pos, size, z);
+  AddBox(box, colors, std::move(user_data));
+}
+
+void Batcher::AddBox(const Box& box, const Color* colors, Color picking_color,
+                     std::unique_ptr<PickingUserData> user_data) {
   box_buffer_.boxes_.push_back(box);
-  box_buffer_.colors_.push_back(colors);
+  box_buffer_.colors_.push_back(colors, 4);
   box_buffer_.picking_colors_.push_back_n(picking_color, 4);
   box_buffer_.user_data_.push_back(std::move(user_data));
 }
 
-void Batcher::AddBox(const Box& box, Color color, PickingType picking_type,
-                     std::unique_ptr<PickingUserData> user_data) {
-  std::array<Color, 4> colors;
-  Fill(colors, color);
-  AddBox(box, colors, picking_type, std::move(user_data));
-}
-
-void Batcher::AddShadedBox(const Vec2& pos, const Vec2& size, float z,
-                           const Color& color, PickingType picking_type,
-                           std::unique_ptr<PickingUserData> user_data) {
-  std::array<Color, 4> colors;
-  GetBoxGradientColors(color, &colors);
-  Box box(pos, size, z);
-  AddBox(box, colors, picking_type, std::move(user_data));
-}
-
-void Batcher::AddTriangle(const Triangle& triangle, const Color& color,
-                          PickingType picking_type,
+void Batcher::AddTriangle(const Triangle& triangle, Color color,
                           std::unique_ptr<PickingUserData> user_data) {
   Color picking_color = PickingId::ToColor(
-      picking_type, triangle_buffer_.triangles_.size(), batcher_id_);
+      PickingType::kTriangle, triangle_buffer_.triangles_.size(), batcher_id_);
+
+  AddTriangle(triangle, color, picking_color, std::move(user_data));
+}
+
+void Batcher::AddTriangle(const Triangle& triangle, Color color,
+                          std::weak_ptr<Pickable> pickable) {
+  CHECK(picking_manager_ != nullptr);
+
+  Color picking_color =
+      picking_manager_->GetPickableColor(pickable, batcher_id_);
+
+  AddTriangle(triangle, color, picking_color, nullptr);
+}
+
+void Batcher::AddTriangle(const Triangle& triangle, Color color,
+                          Color picking_color,
+                          std::unique_ptr<PickingUserData> user_data) {
   triangle_buffer_.triangles_.push_back(triangle);
   triangle_buffer_.colors_.push_back_n(color, 3);
   triangle_buffer_.picking_colors_.push_back_n(picking_color, 3);
   triangle_buffer_.user_data_.push_back(std::move(user_data));
 }
 
-void Batcher::AddTriangle(const Vec3& v0, const Vec3& v1, const Vec3& v2,
-                          const Color& color, PickingType picking_type,
-                          std::unique_ptr<PickingUserData> user_data) {
-  AddTriangle(Triangle(v0, v1, v2), color, picking_type, std::move(user_data));
-}
-
 PickingUserData* Batcher::GetUserData(PickingId id) {
   CHECK(id.element_id >= 0);
+  CHECK(id.batcher_id == batcher_id_);
 
   switch (id.type) {
     case PickingType::kInvalid:
@@ -109,28 +131,29 @@ PickingUserData* Batcher::GetUserData(PickingId id) {
     case PickingType::kPickable:
       return nullptr;
   }
-  UNREACHABLE();
+
+  return nullptr;
 }
 
 TextBox* Batcher::GetTextBox(PickingId id) {
   PickingUserData* data = GetUserData(id);
 
-  if (data != nullptr && data->text_box_ != nullptr) {
+  if (data && data->text_box_) {
     return data->text_box_;
   }
 
   return nullptr;
 }
 
-void Batcher::GetBoxGradientColors(Color color, std::array<Color, 4>* colors) {
+void Batcher::GetBoxGradientColors(Color color, Color* colors) {
   const float kGradientCoeff = 0.94f;
   Vec3 dark = Vec3(color[0], color[1], color[2]) * kGradientCoeff;
-  (*colors)[0] =
+  colors[0] =
       Color(static_cast<uint8_t>(dark[0]), static_cast<uint8_t>(dark[1]),
             static_cast<uint8_t>(dark[2]), color[3]);
-  (*colors)[1] = (*colors)[0];
-  (*colors)[2] = color;
-  (*colors)[3] = color;
+  colors[1] = colors[0];
+  colors[2] = color;
+  colors[3] = color;
 }
 
 void Batcher::Reset() {
@@ -139,7 +162,7 @@ void Batcher::Reset() {
   triangle_buffer_.Reset();
 }
 
-void Batcher::Draw(bool picking) {
+void Batcher::Draw(bool picking) const {
   glPushAttrib(GL_ENABLE_BIT | GL_COLOR_BUFFER_BIT);
   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
   glDisable(GL_CULL_FACE);
@@ -156,15 +179,15 @@ void Batcher::Draw(bool picking) {
   glPopAttrib();
 }
 
-void Batcher::DrawBoxBuffer(bool picking) {
+void Batcher::DrawBoxBuffer(bool picking) const {
   const Block<Box, BoxBuffer::NUM_BOXES_PER_BLOCK>* box_block =
-      GetBoxBuffer().boxes_.root();
+      box_buffer_.boxes_.root();
   const Block<Color, BoxBuffer::NUM_BOXES_PER_BLOCK * 4>* color_block;
 
-  color_block = !picking ? GetBoxBuffer().colors_.root()
-                         : GetBoxBuffer().picking_colors_.root();
+  color_block = !picking ? box_buffer_.colors_.root()
+                         : box_buffer_.picking_colors_.root();
 
-  while (box_block != nullptr) {
+  while (box_block) {
     if (auto num_elems = box_block->size()) {
       glVertexPointer(3, GL_FLOAT, sizeof(Vec3), box_block->data());
       glColorPointer(4, GL_UNSIGNED_BYTE, sizeof(Color), color_block->data());
@@ -176,15 +199,15 @@ void Batcher::DrawBoxBuffer(bool picking) {
   }
 }
 
-void Batcher::DrawLineBuffer(bool picking) {
+void Batcher::DrawLineBuffer(bool picking) const {
   const Block<Line, LineBuffer::NUM_LINES_PER_BLOCK>* line_block =
-      GetLineBuffer().lines_.root();
+      line_buffer_.lines_.root();
   const Block<Color, LineBuffer::NUM_LINES_PER_BLOCK * 2>* color_block;
 
-  color_block = !picking ? GetLineBuffer().colors_.root()
-                         : GetLineBuffer().picking_colors_.root();
+  color_block = !picking ? line_buffer_.colors_.root()
+                         : line_buffer_.picking_colors_.root();
 
-  while (line_block != nullptr) {
+  while (line_block) {
     if (auto num_elems = line_block->size()) {
       glVertexPointer(3, GL_FLOAT, sizeof(Vec3), line_block->data());
       glColorPointer(4, GL_UNSIGNED_BYTE, sizeof(Color), color_block->data());
@@ -196,15 +219,15 @@ void Batcher::DrawLineBuffer(bool picking) {
   }
 }
 
-void Batcher::DrawTriangleBuffer(bool picking) {
+void Batcher::DrawTriangleBuffer(bool picking) const {
   const Block<Triangle, TriangleBuffer::NUM_TRIANGLES_PER_BLOCK>*
-      triangle_block = GetTriangleBuffer().triangles_.root();
+      triangle_buffer_.triangles_.root();
   const Block<Color, TriangleBuffer::NUM_TRIANGLES_PER_BLOCK * 3>* color_block;
 
-  color_block = !picking ? GetTriangleBuffer().colors_.root()
-                         : GetTriangleBuffer().picking_colors_.root();
+  color_block = !picking ? triangle_buffer_.colors_.root()
+                         : triangle_buffer_.picking_colors_.root();
 
-  while (triangle_block != nullptr) {
+  while (triangle_block) {
     if (int num_elems = triangle_block->size()) {
       glVertexPointer(3, GL_FLOAT, sizeof(Vec3), triangle_block->data());
       glColorPointer(4, GL_UNSIGNED_BYTE, sizeof(Color), color_block->data());

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -5,6 +5,7 @@
 #ifndef ORBIT_GL_BATCHER_H_
 #define ORBIT_GL_BATCHER_H_
 
+#include <utility>
 #include <vector>
 
 #include "BlockChain.h"
@@ -18,9 +19,9 @@ struct PickingUserData {
   TooltipCallback generate_tooltip_;
   void* custom_data_ = nullptr;
 
-  PickingUserData(TextBox* text_box = nullptr,
-                  TooltipCallback generate_tooltip = nullptr)
-      : text_box_(text_box), generate_tooltip_(generate_tooltip) {}
+  explicit PickingUserData(TextBox* text_box = nullptr,
+                           TooltipCallback generate_tooltip = nullptr)
+      : text_box_(text_box), generate_tooltip_(std::move(generate_tooltip)) {}
 };
 
 struct LineBuffer {
@@ -78,26 +79,27 @@ class Batcher {
   Batcher(const Batcher&) = delete;
   Batcher(Batcher&&) = delete;
 
-  void AddLine(Vec2 from, Vec2 to, float z, Color color,
+  void AddLine(Vec2 from, Vec2 to, float z, const Color& color,
                std::unique_ptr<PickingUserData> user_data = nullptr);
-  void AddVerticalLine(Vec2 pos, float size, float z, Color color,
+  void AddVerticalLine(Vec2 pos, float size, float z, const Color& color,
                        std::unique_ptr<PickingUserData> user_data = nullptr);
-  void AddLine(Vec2 from, Vec2 to, float z, Color color,
+  void AddLine(Vec2 from, Vec2 to, float z, const Color& color,
                std::weak_ptr<Pickable> pickable);
-  void AddVerticalLine(Vec2 pos, float size, float z, Color color,
+  void AddVerticalLine(Vec2 pos, float size, float z, const Color& color,
                        std::weak_ptr<Pickable> pickable);
 
-  void AddBox(const Box& box, const Color* colors,
+  void AddBox(const Box& box, const std::array<Color, 4>& colors,
               std::unique_ptr<PickingUserData> user_data = nullptr);
-  void AddBox(const Box& box, Color color,
+  void AddBox(const Box& box, const Color& color,
               std::unique_ptr<PickingUserData> user_data = nullptr);
-  void AddBox(const Box& box, Color color, std::weak_ptr<Pickable> pickable);
-  void AddShadedBox(Vec2 pos, Vec2 size, float z, Color color,
+  void AddBox(const Box& box, const Color& color,
+              std::weak_ptr<Pickable> pickable);
+  void AddShadedBox(Vec2 pos, Vec2 size, float z, const Color& color,
                     std::unique_ptr<PickingUserData> user_data = nullptr);
 
-  void AddTriangle(const Triangle& triangle, Color color,
+  void AddTriangle(const Triangle& triangle, const Color& color,
                    std::unique_ptr<PickingUserData> user_data = nullptr);
-  void AddTriangle(const Triangle& triangle, Color color,
+  void AddTriangle(const Triangle& triangle, const Color& color,
                    std::weak_ptr<Pickable> pickable);
 
   virtual void Draw(bool picking = false) const;
@@ -117,13 +119,16 @@ class Batcher {
   void DrawBoxBuffer(bool picking) const;
   void DrawTriangleBuffer(bool picking) const;
 
-  void GetBoxGradientColors(Color color, Color* colors);
+  void GetBoxGradientColors(const Color& color, std::array<Color, 4>* colors);
 
-  void AddLine(Vec2 from, Vec2 to, float z, Color color, Color picking_color,
+  void AddLine(Vec2 from, Vec2 to, float z, const Color& color,
+               const Color& picking_color,
                std::unique_ptr<PickingUserData> user_data = nullptr);
-  void AddBox(const Box& box, const Color* colors, Color picking_color,
+  void AddBox(const Box& box, const std::array<Color, 4>& colors,
+              const Color& picking_color,
               std::unique_ptr<PickingUserData> user_data = nullptr);
-  void AddTriangle(const Triangle& triangle, Color color, Color picking_color,
+  void AddTriangle(const Triangle& triangle, const Color& color,
+                   const Color& picking_color,
                    std::unique_ptr<PickingUserData> user_data = nullptr);
 
   BatcherId batcher_id_;

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -111,7 +111,9 @@ class Batcher {
     picking_manager_ = picking_manager;
   }
 
+  [[nodiscard]] const PickingUserData* GetUserData(PickingId id) const;
   [[nodiscard]] PickingUserData* GetUserData(PickingId id);
+
   [[nodiscard]] TextBox* GetTextBox(PickingId id);
 
  protected:

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -5,7 +5,6 @@
 #ifndef ORBIT_GL_BATCHER_H_
 #define ORBIT_GL_BATCHER_H_
 
-#include <utility>
 #include <vector>
 
 #include "BlockChain.h"
@@ -19,9 +18,9 @@ struct PickingUserData {
   TooltipCallback generate_tooltip_;
   void* custom_data_ = nullptr;
 
-  explicit PickingUserData(TextBox* text_box = nullptr,
-                           TooltipCallback generate_tooltip = nullptr)
-      : text_box_(text_box), generate_tooltip_(std::move(generate_tooltip)) {}
+  PickingUserData(TextBox* text_box = nullptr,
+                  TooltipCallback generate_tooltip = nullptr)
+      : text_box_(text_box), generate_tooltip_(generate_tooltip) {}
 };
 
 struct LineBuffer {
@@ -71,57 +70,67 @@ struct TriangleBuffer {
 
 class Batcher {
  public:
-  explicit Batcher(BatcherId batcher_id) : batcher_id_(batcher_id) {}
-  Batcher() : batcher_id_(BatcherId::kTimeGraph) {}
+  explicit Batcher(BatcherId batcher_id,
+                   PickingManager* picking_manager = nullptr)
+      : batcher_id_(batcher_id), picking_manager_(picking_manager) {}
 
-  void AddLine(const Line& line, const std::array<Color, 2>& colors,
-               PickingType picking_type,
-               std::unique_ptr<PickingUserData> user_data = nullptr);
-  void AddLine(const Line& line, Color color, PickingType picking_type,
-               std::unique_ptr<PickingUserData> user_data = nullptr);
+  Batcher() = delete;
+  Batcher(const Batcher&) = delete;
+  Batcher(Batcher&&) = delete;
+
   void AddLine(Vec2 from, Vec2 to, float z, Color color,
-               PickingType picking_type,
                std::unique_ptr<PickingUserData> user_data = nullptr);
   void AddVerticalLine(Vec2 pos, float size, float z, Color color,
-                       PickingType picking_type,
                        std::unique_ptr<PickingUserData> user_data = nullptr);
+  void AddLine(Vec2 from, Vec2 to, float z, Color color,
+               std::weak_ptr<Pickable> pickable);
+  void AddVerticalLine(Vec2 pos, float size, float z, Color color,
+                       std::weak_ptr<Pickable> pickable);
 
-  void AddBox(const Box& box, const std::array<Color, 4>& colors,
-              PickingType picking_type,
+  void AddBox(const Box& box, const Color* colors,
               std::unique_ptr<PickingUserData> user_data = nullptr);
-  void AddBox(const Box& box, Color color, PickingType picking_type,
+  void AddBox(const Box& box, Color color,
               std::unique_ptr<PickingUserData> user_data = nullptr);
-  void AddShadedBox(const Vec2& pos, const Vec2& size, float z,
-                    const Color& color, PickingType picking_type,
+  void AddBox(const Box& box, Color color, std::weak_ptr<Pickable> pickable);
+  void AddShadedBox(Vec2 pos, Vec2 size, float z, Color color,
                     std::unique_ptr<PickingUserData> user_data = nullptr);
 
-  void AddTriangle(const Triangle& triangle, const Color& color,
-                   PickingType picking_type,
+  void AddTriangle(const Triangle& triangle, Color color,
                    std::unique_ptr<PickingUserData> user_data = nullptr);
-  void AddTriangle(const Vec3& v0, const Vec3& v1, const Vec3& v2,
-                   const Color& color, PickingType picking_type,
-                   std::unique_ptr<PickingUserData> user_data = nullptr);
+  void AddTriangle(const Triangle& triangle, Color color,
+                   std::weak_ptr<Pickable> pickable);
 
-  void GetBoxGradientColors(Color color, std::array<Color, 4>* colors);
-
-  void Draw(bool picking = false);
+  virtual void Draw(bool picking = false) const;
 
   void Reset();
 
+  [[nodiscard]] PickingManager* GetPickingManager() { return picking_manager_; }
+  void SetPickingManager(PickingManager* picking_manager) {
+    picking_manager_ = picking_manager;
+  }
+
   [[nodiscard]] PickingUserData* GetUserData(PickingId id);
   [[nodiscard]] TextBox* GetTextBox(PickingId id);
-  [[nodiscard]] BoxBuffer& GetBoxBuffer() { return box_buffer_; }
-  [[nodiscard]] LineBuffer& GetLineBuffer() { return line_buffer_; }
-  [[nodiscard]] TriangleBuffer& GetTriangleBuffer() { return triangle_buffer_; }
 
  protected:
-  void DrawLineBuffer(bool picking);
-  void DrawBoxBuffer(bool picking);
-  void DrawTriangleBuffer(bool picking);
+  void DrawLineBuffer(bool picking) const;
+  void DrawBoxBuffer(bool picking) const;
+  void DrawTriangleBuffer(bool picking) const;
+
+  void GetBoxGradientColors(Color color, Color* colors);
+
+  void AddLine(Vec2 from, Vec2 to, float z, Color color, Color picking_color,
+               std::unique_ptr<PickingUserData> user_data = nullptr);
+  void AddBox(const Box& box, const Color* colors, Color picking_color,
+              std::unique_ptr<PickingUserData> user_data = nullptr);
+  void AddTriangle(const Triangle& triangle, Color color, Color picking_color,
+                   std::unique_ptr<PickingUserData> user_data = nullptr);
+
+  BatcherId batcher_id_;
+  PickingManager* picking_manager_;
   LineBuffer line_buffer_;
   BoxBuffer box_buffer_;
   TriangleBuffer triangle_buffer_;
-  BatcherId batcher_id_;
 };
 
 #endif

--- a/OrbitGl/BatcherTest.cpp
+++ b/OrbitGl/BatcherTest.cpp
@@ -1,0 +1,207 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "Batcher.h"
+#include "PickingManagerTest.h"
+
+namespace {
+
+class MockBatcher : public Batcher {
+ public:
+  MockBatcher(BatcherId id, PickingManager* picking_manager = nullptr)
+      : Batcher(id, picking_manager) {}
+
+  void ResetMockDrawCounts() {
+    drawn_line_colors_.clear();
+    drawn_triangle_colors_.clear();
+    drawn_box_colors_.clear();
+  }
+
+  const std::vector<Color>& GetDrawnLineColors() const {
+    return drawn_line_colors_;
+  }
+  const std::vector<Color>& GetDrawnTriangleColors() const {
+    return drawn_triangle_colors_;
+  }
+  const std::vector<Color>& GetDrawnBoxColors() const {
+    return drawn_box_colors_;
+  }
+
+  // Simulate drawing by simple appending all colors to internal
+  // buffers. Only a single color per element will be appended
+  // (start point for line, first vertex for triangle and box)
+  void Draw(bool picking = false) const override {
+    if (picking) {
+      for (auto it = line_buffer_.picking_colors_.begin();
+           it != line_buffer_.picking_colors_.end();) {
+        drawn_line_colors_.push_back(*it);
+        ++it;
+        ++it;
+      }
+      for (auto it = triangle_buffer_.picking_colors_.begin();
+           it != triangle_buffer_.picking_colors_.end();) {
+        drawn_triangle_colors_.push_back(*it);
+        ++it;
+        ++it;
+        ++it;
+      }
+      for (auto it = box_buffer_.picking_colors_.begin();
+           it != box_buffer_.picking_colors_.end();) {
+        drawn_box_colors_.push_back(*it);
+        ++it;
+        ++it;
+        ++it;
+        ++it;
+      }
+    } else {
+      for (auto it = line_buffer_.colors_.begin();
+           it != line_buffer_.colors_.end();) {
+        drawn_line_colors_.push_back(*it);
+        ++it;
+        ++it;
+      }
+      for (auto it = triangle_buffer_.colors_.begin();
+           it != triangle_buffer_.colors_.end();) {
+        drawn_triangle_colors_.push_back(*it);
+        ++it;
+        ++it;
+        ++it;
+      }
+      for (auto it = box_buffer_.colors_.begin();
+           it != box_buffer_.colors_.end();) {
+        drawn_box_colors_.push_back(*it);
+        ++it;
+        ++it;
+        ++it;
+        ++it;
+      }
+    }
+  }
+
+ private:
+  mutable std::vector<Color> drawn_line_colors_;
+  mutable std::vector<Color> drawn_triangle_colors_;
+  mutable std::vector<Color> drawn_box_colors_;
+};
+
+void ExpectDraw(MockBatcher& batcher, uint32_t line_count,
+                uint32_t triangle_count, uint32_t box_count) {
+  batcher.ResetMockDrawCounts();
+  batcher.Draw();
+  EXPECT_EQ(batcher.GetDrawnLineColors().size(), line_count);
+  EXPECT_EQ(batcher.GetDrawnTriangleColors().size(), triangle_count);
+  EXPECT_EQ(batcher.GetDrawnBoxColors().size(), box_count);
+}
+
+TEST(Batcher, SimpleElementsDrawing) {
+  MockBatcher batcher(BatcherId::kUi);
+
+  ExpectDraw(batcher, 0, 0, 0);
+  batcher.AddLine(Vec2(0, 0), Vec2(1, 0), 0, Color(255, 255, 255, 255));
+  ExpectDraw(batcher, 1, 0, 0);
+  EXPECT_EQ(batcher.GetDrawnLineColors()[0], Color(255, 255, 255, 255));
+  batcher.AddTriangle(Triangle(Vec3(0, 0, 0), Vec3(0, 1, 0), Vec3(1, 0, 0)),
+                      Color(0, 255, 0, 255));
+  ExpectDraw(batcher, 1, 1, 0);
+  EXPECT_EQ(batcher.GetDrawnTriangleColors()[0], Color(0, 255, 0, 255));
+  batcher.AddBox(Box(Vec2(0, 0), Vec2(1, 1), 0), Color(255, 0, 0, 255));
+  ExpectDraw(batcher, 1, 1, 1);
+  EXPECT_EQ(batcher.GetDrawnBoxColors()[0], Color(255, 0, 0, 255));
+  batcher.Reset();
+  ExpectDraw(batcher, 0, 0, 0);
+}
+
+TEST(Batcher, PickingElementsDrawing) {
+  MockBatcher batcher(BatcherId::kUi);
+  std::shared_ptr<PickableMock> pickable = std::make_shared<PickableMock>();
+  PickingManager pm;
+
+  ExpectDraw(batcher, 0, 0, 0);
+  EXPECT_DEATH(batcher.AddLine(Vec2(0, 0), Vec2(1, 0), 0,
+                               Color(255, 255, 255, 255), pickable),
+               "nullptr");
+  batcher.SetPickingManager(&pm);
+  batcher.AddLine(Vec2(0, 0), Vec2(1, 0), 0, Color(255, 255, 255, 255),
+                  pickable);
+  ExpectDraw(batcher, 1, 0, 0);
+  batcher.Reset();
+  ExpectDraw(batcher, 0, 0, 0);
+}
+
+template <typename T>
+void ExpectCustomDataEq(const MockBatcher& batcher, const Color& rendered_color,
+                        const T& value) {
+  PickingId id = MockRenderPickingColor(rendered_color);
+  const PickingUserData* rendered_data = batcher.GetUserData(id);
+  EXPECT_NE(rendered_data, nullptr);
+  EXPECT_NE(rendered_data->custom_data_, nullptr);
+  EXPECT_EQ(*static_cast<T*>(rendered_data->custom_data_), value);
+}
+
+TEST(Batcher, PickingSimpleElements) {
+  MockBatcher batcher(BatcherId::kUi);
+
+  std::string line_custom_data = "line custom data";
+  auto line_user_data = std::make_unique<PickingUserData>();
+  line_user_data->custom_data_ = &line_custom_data;
+
+  std::string triangle_custom_data = "triangle custom data";
+  auto triangle_user_data = std::make_unique<PickingUserData>();
+  triangle_user_data->custom_data_ = &triangle_custom_data;
+
+  std::string box_custom_data = "box custom data";
+  auto box_user_data = std::make_unique<PickingUserData>();
+  box_user_data->custom_data_ = &box_custom_data;
+
+  batcher.AddLine(Vec2(0, 0), Vec2(1, 0), 0, Color(255, 255, 255, 255),
+                  std::move(line_user_data));
+  batcher.AddTriangle(Triangle(Vec3(0, 0, 0), Vec3(0, 1, 0), Vec3(1, 0, 0)),
+                      Color(0, 255, 0, 255), std::move(triangle_user_data));
+  batcher.AddBox(Box(Vec2(0, 0), Vec2(1, 1), 0), Color(255, 0, 0, 255),
+                 std::move(box_user_data));
+
+  batcher.Draw(true);
+  ExpectCustomDataEq(batcher, batcher.GetDrawnLineColors()[0],
+                     line_custom_data);
+  ExpectCustomDataEq(batcher, batcher.GetDrawnTriangleColors()[0],
+                     triangle_custom_data);
+  ExpectCustomDataEq(batcher, batcher.GetDrawnBoxColors()[0], box_custom_data);
+}
+
+void ExpectPickableEq(const MockBatcher& batcher, const Color& rendered_color,
+                      PickingManager& pm,
+                      std::shared_ptr<const Pickable> pickable) {
+  PickingId id = MockRenderPickingColor(rendered_color);
+  const PickingUserData* rendered_data = batcher.GetUserData(id);
+  EXPECT_EQ(rendered_data, nullptr);
+  EXPECT_EQ(id.type, PickingType::kPickable);
+  EXPECT_EQ(pm.GetPickableFromId(id).lock().get(), pickable.get());
+}
+
+TEST(Batcher, PickingPickables) {
+  PickingManager pm;
+  MockBatcher batcher(BatcherId::kUi, &pm);
+  std::shared_ptr<PickableMock> line_pickable =
+      std::make_shared<PickableMock>();
+  std::shared_ptr<PickableMock> triangle_pickable =
+      std::make_shared<PickableMock>();
+  std::shared_ptr<PickableMock> box_pickable = std::make_shared<PickableMock>();
+
+  batcher.AddLine(Vec2(0, 0), Vec2(1, 0), 0, Color(255, 255, 255, 255),
+                  line_pickable);
+  batcher.AddTriangle(Triangle(Vec3(0, 0, 0), Vec3(0, 1, 0), Vec3(1, 0, 0)),
+                      Color(0, 255, 0, 255), triangle_pickable);
+  batcher.AddBox(Box(Vec2(0, 0), Vec2(1, 1), 0), Color(255, 0, 0, 255),
+                 box_pickable);
+
+  batcher.Draw(true);
+  ExpectPickableEq(batcher, batcher.GetDrawnLineColors()[0], pm, line_pickable);
+  ExpectPickableEq(batcher, batcher.GetDrawnTriangleColors()[0], pm,
+                   triangle_pickable);
+  ExpectPickableEq(batcher, batcher.GetDrawnBoxColors()[0], pm, box_pickable);
+}
+
+}  // namespace

--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -127,7 +127,11 @@ add_executable(OrbitGlTests)
 target_compile_options(OrbitGlTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(OrbitGlTests PRIVATE
-    PickingManagerTest.cpp)
+               PickingManagerTest.h)
+
+target_sources(OrbitGlTests PRIVATE
+               PickingManagerTest.cpp
+               BatcherTest.cpp)
 
 target_link_libraries(
   OrbitGlTests

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -159,7 +159,7 @@ void CaptureWindow::Pick(int a_X, int a_Y) {
                &pixels[0]);
   uint32_t value;
   std::memcpy(&value, &pixels[0], sizeof(uint32_t));
-  PickingId pickId = PickingId::Get(value);
+  PickingId pickId = PickingId::FromPixelValue(value);
 
   Capture::GSelectedTextBox = nullptr;
   Capture::GSelectedThreadId = 0;
@@ -177,7 +177,7 @@ void CaptureWindow::Pick(PickingId a_PickingID, int a_X, int a_Y) {
   if (text_box) {
     SelectTextBox(text_box);
   } else if (type == PickingType::kPickable) {
-    m_PickingManager.Pick(a_PickingID.id, a_X, a_Y);
+    m_PickingManager.Pick(a_PickingID, a_X, a_Y);
   }
 }
 
@@ -207,7 +207,7 @@ void CaptureWindow::Hover(int a_X, int a_Y) {
   std::string tooltip = "";
 
   if (pickId.type == PickingType::kPickable) {
-    auto pickable = GetPickingManager().GetPickableFromId(pickId.id).lock();
+    auto pickable = GetPickingManager().GetPickableFromId(pickId).lock();
     if (pickable) {
       tooltip = pickable->GetTooltip();
     }

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -28,7 +28,7 @@ class CaptureWindow : public GlCanvas {
   void Pick();
   void Pick(int a_X, int a_Y);
   void Pick(PickingId a_ID, int a_X, int a_Y);
-  void Hover(int a_X, int a_Y);
+  void Hover(int a_X, int a_Y) override;
   void FindCode(uint64_t address);
   void RightDown(int a_X, int a_Y) override;
   bool RightUp() override;
@@ -49,7 +49,6 @@ class CaptureWindow : public GlCanvas {
   void Resize(int a_Width, int a_Height) override;
   void RenderHelpUi();
   void RenderTimeBar();
-  void ResetHoverTimer();
   void SelectTextBox(TextBox* text_box);
   void OnDrag(float a_Ratio);
   void OnVerticalDrag(float a_Ratio);
@@ -64,15 +63,8 @@ class CaptureWindow : public GlCanvas {
   Batcher& GetBatcherById(BatcherId batcher_id);
 
  private:
-  [[nodiscard]] PickingMode GetPickingMode();
-
- private:
   TimeGraph time_graph_;
   OutputWindow m_StatsWindow;
-  Timer m_HoverTimer;
-  int m_HoverDelayMs;
-  bool m_IsHovering;
-  bool m_CanHover;
   bool m_DrawHelp;
   bool m_DrawFilter;
   bool m_FirstHelpDraw;

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -24,9 +24,7 @@ std::string EventTrack::GetTooltip() const {
 
 void EventTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   Batcher* batcher = canvas->GetBatcher();
-  PickingManager& picking_manager = canvas->GetPickingManager();
 
-  const bool picking = picking_mode != PickingMode::kNone;
   // The sample indicators are at z == 0 and do not respond to clicks, but
   // have a tooltip. For picking, we want to draw the event bar over them if
   // handling a click, and underneath otherwise.
@@ -35,14 +33,8 @@ void EventTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
                               ? GlCanvas::Z_VALUE_EVENT_BAR_PICKING
                               : GlCanvas::Z_VALUE_EVENT_BAR;
   Color color = m_Color;
-
-  if (picking) {
-    color =
-        picking_manager.GetPickableColor(shared_from_this(), BatcherId::kUi);
-  }
-
   Box box(m_Pos, Vec2(m_Size[0], -m_Size[1]), eventBarZ);
-  batcher->AddBox(box, color, PickingType::kPickable);
+  batcher->AddBox(box, color, shared_from_this());
 
   if (canvas->GetPickingManager().IsThisElementPicked(this)) {
     color = Color(255, 255, 255, 255);
@@ -54,9 +46,9 @@ void EventTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   float y1 = y0 - m_Size[1];
 
   batcher->AddLine(m_Pos, Vec2(x1, y0), GlCanvas::Z_VALUE_EVENT_BAR, color,
-                   PickingType::kPickable);
+                   shared_from_this());
   batcher->AddLine(Vec2(x1, y1), Vec2(x0, y1), GlCanvas::Z_VALUE_EVENT_BAR,
-                   color, PickingType::kPickable);
+                   color, shared_from_this());
 
   if (m_Picked) {
     Vec2& from = m_MousePos[0];
@@ -69,7 +61,7 @@ void EventTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
 
     Color picked_color(0, 128, 255, 128);
     Box box(Vec2(x0, y0), Vec2(x1 - x0, -m_Size[1]), -0.f);
-    batcher->AddBox(box, picked_color, PickingType::kPickable);
+    batcher->AddBox(box, picked_color, shared_from_this());
   }
 
   m_Canvas = canvas;
@@ -96,8 +88,7 @@ void EventTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
       uint64_t time = pair.first;
       if (time > min_tick && time < max_tick) {
         Vec2 pos(time_graph_->GetWorldFromTick(time), m_Pos[1]);
-        batcher->AddVerticalLine(pos, -track_height, z, kWhite,
-                                 PickingType::kLine);
+        batcher->AddVerticalLine(pos, -track_height, z, kWhite);
       }
     }
 
@@ -107,8 +98,7 @@ void EventTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
     for (const CallstackEvent& event :
          time_graph_->GetSelectedCallstackEvents(m_ThreadId)) {
       Vec2 pos(time_graph_->GetWorldFromTick(event.time()), m_Pos[1]);
-      batcher->AddVerticalLine(pos, -track_height, z, kGreenSelection,
-                               PickingType::kLine);
+      batcher->AddVerticalLine(pos, -track_height, z, kGreenSelection);
     }
   } else {
     // Draw boxes instead of lines to make picking easier, even if this may
@@ -126,7 +116,7 @@ void EventTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
             nullptr,
             [&](PickingId id) -> std::string { return GetSampleTooltip(id); });
         user_data->custom_data_ = &pair.second;
-        batcher->AddShadedBox(pos, size, z, kGreenSelection, PickingType::kBox,
+        batcher->AddShadedBox(pos, size, z, kGreenSelection,
                               std::move(user_data));
       }
     }

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -487,7 +487,7 @@ void GlCanvas::ResetHoverTimer() {
 }
 
 [[nodiscard]] PickingMode GlCanvas::GetPickingMode() {
-  if (m_Picking) {
+  if (m_Picking && !m_IsHovering) {
     return PickingMode::kClick;
   }
   if (m_IsHovering) {

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -91,12 +91,16 @@ class GlCanvas : public GlPanel {
                 const Color& a_Color, float a_MaxSize = -1.f,
                 bool a_RightJustified = false, bool a_InvertY = true);
 
+  void ResetHoverTimer();
+
   float GetDeltaTimeSeconds() const { return m_DeltaTime; }
 
   virtual void Draw() {}
   virtual void DrawScreenSpace() {}
   virtual void RenderUI() {}
   virtual void RenderText() {}
+
+  virtual void Hover(int /*a_X*/, int /*a_Y*/) {}
 
   ImGuiContext* GetImGuiContext() { return m_ImGuiContext; }
   Batcher* GetBatcher() { return &ui_batcher_; }
@@ -118,6 +122,8 @@ class GlCanvas : public GlPanel {
   static float Z_VALUE_EVENT_BAR_PICKING;
 
  protected:
+  [[nodiscard]] PickingMode GetPickingMode();
+
   int m_Width;
   int m_Height;
   float m_WorldWidth;
@@ -149,6 +155,11 @@ class GlCanvas : public GlPanel {
   bool m_ImguiActive;
   int m_ID;
   Vec4 m_BackgroundColor;
+
+  Timer m_HoverTimer;
+  int m_HoverDelayMs;
+  bool m_IsHovering;
+  bool m_CanHover;
 
   ImGuiContext* m_ImGuiContext;
   TickType m_RefTimeClick;

--- a/OrbitGl/GlSlider.cpp
+++ b/OrbitGl/GlSlider.cpp
@@ -115,22 +115,18 @@ void GlSlider::DrawHorizontal(GlCanvas* canvas, PickingMode picking_mode) {
   // Bar
   if (!picking) {
     Box box(Vec2(0, y), Vec2(canvasWidth, GetPixelHeight()), 0.f);
-    batcher->AddBox(box, m_BarColor, PickingType::kPickable);
+    batcher->AddBox(box, m_BarColor, shared_from_this());
   }
 
   float start = m_Ratio * nonSliderWidth;
   float stop = start + sliderWidth;
 
-  Color color = m_SliderColor;
-  if (picking) {
-    color = canvas->GetPickingManager().GetPickableColor(shared_from_this(),
-                                                         BatcherId::kUi);
-  } else if (canvas->GetPickingManager().IsThisElementPicked(this)) {
-    color = m_SelectedColor;
-  }
+  Color color = canvas->GetPickingManager().IsThisElementPicked(this)
+                    ? m_SelectedColor
+                    : m_SliderColor;
 
   Box box(Vec2(start, y), Vec2(stop - start, GetPixelHeight()), 0.f);
-  batcher->AddBox(box, color, PickingType::kPickable);
+  batcher->AddBox(box, color, shared_from_this());
 }
 
 void GlSlider::DrawVertical(GlCanvas* canvas, PickingMode picking_mode) {
@@ -147,20 +143,16 @@ void GlSlider::DrawVertical(GlCanvas* canvas, PickingMode picking_mode) {
   // Bar
   if (!picking) {
     Box box(Vec2(x, 0), Vec2(GetPixelHeight(), canvasHeight), 0.f);
-    batcher->AddBox(box, m_BarColor, PickingType::kPickable);
+    batcher->AddBox(box, m_BarColor, shared_from_this());
   }
 
   float start = canvasHeight - m_Ratio * nonSliderHeight;
   float stop = start - sliderHeight;
 
-  Color color = m_SliderColor;
-  if (picking) {
-    color = canvas->GetPickingManager().GetPickableColor(shared_from_this(),
-                                                         BatcherId::kUi);
-  } else if (canvas->GetPickingManager().IsThisElementPicked(this)) {
-    color = m_SelectedColor;
-  }
+  Color color = canvas->GetPickingManager().IsThisElementPicked(this)
+                    ? m_SelectedColor
+                    : m_SliderColor;
 
   Box box(Vec2(x, start), Vec2(GetPixelHeight(), stop - start), 0.f);
-  batcher->AddBox(box, color, PickingType::kPickable);
+  batcher->AddBox(box, color, shared_from_this());
 }

--- a/OrbitGl/GraphTrack.cpp
+++ b/OrbitGl/GraphTrack.cpp
@@ -28,6 +28,7 @@ void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   const Color kPickedColor(0, 128, 255, 128);
   Color color = m_Color;
   if (m_Picked) {
+    // TODO: Is this really used? Is m_Picked even a thing?
     color = kPickedColor;
   }
 
@@ -35,15 +36,15 @@ void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   float text_z = layout.GetTextZ();
 
   Box box(m_Pos, Vec2(m_Size[0], -m_Size[1]), track_z);
-  batcher->AddBox(box, color, PickingType::kPickable);
+  batcher->AddBox(box, color, shared_from_this());
 
   if (canvas->GetPickingManager().IsThisElementPicked(this)) {
     color = Color(255, 255, 255, 255);
   }
 
-  batcher->AddLine(m_Pos, Vec2(x1, y0), track_z, color, PickingType::kPickable);
+  batcher->AddLine(m_Pos, Vec2(x1, y0), track_z, color, shared_from_this());
   batcher->AddLine(Vec2(x1, y1), Vec2(x0, y1), track_z, color,
-                   PickingType::kPickable);
+                   shared_from_this());
 
   const Color kLineColor(0, 128, 255, 128);
 
@@ -67,7 +68,7 @@ void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
     float y0 = base_y + static_cast<float>(last_normalized_value) * m_Size[1];
     float y1 = base_y + static_cast<float>(normalized_value) * m_Size[1];
     time_graph_->GetBatcher().AddLine(Vec2(x0, y0), Vec2(x1, y1), text_z,
-                                      kLineColor, PickingType::kLine);
+                                      kLineColor);
 
     previous_time = time;
     last_normalized_value = normalized_value;

--- a/OrbitGl/PickingManager.cpp
+++ b/OrbitGl/PickingManager.cpp
@@ -12,7 +12,7 @@ PickingId PickingManager::CreatePickableId(std::weak_ptr<Pickable> a_Pickable,
   absl::MutexLock lock(&mutex_);
   ++id_counter_;
   PickingId id =
-      PickingId::Get(PickingType::kPickable, id_counter_, batcher_id);
+      PickingId::Create(PickingType::kPickable, id_counter_, batcher_id);
   id_pickable_map_[id_counter_] = a_Pickable;
   return id;
 }
@@ -23,9 +23,11 @@ void PickingManager::Reset() {
   id_counter_ = 0;
 }
 
-std::weak_ptr<Pickable> PickingManager::GetPickableFromId(uint32_t id) const {
+std::weak_ptr<Pickable> PickingManager::GetPickableFromId(PickingId id) const {
+  CHECK(id.type == PickingType::kPickable);
+
   absl::MutexLock lock(&mutex_);
-  auto it = id_pickable_map_.find(id);
+  auto it = id_pickable_map_.find(id.element_id);
   if (it == id_pickable_map_.end()) {
     return std::weak_ptr<Pickable>();
   }
@@ -37,7 +39,7 @@ std::weak_ptr<Pickable> PickingManager::GetPicked() const {
   return currently_picked_;
 }
 
-void PickingManager::Pick(uint32_t id, int x, int y) {
+void PickingManager::Pick(PickingId id, int x, int y) {
   auto picked = GetPickableFromId(id).lock();
   if (picked) {
     picked->OnPick(x, y);

--- a/OrbitGl/PickingManager.h
+++ b/OrbitGl/PickingManager.h
@@ -53,38 +53,38 @@ enum class PickingType : uint32_t {
 enum class BatcherId : uint32_t { kTimeGraph, kUi };
 
 struct PickingId {
-  static constexpr const uint32_t kIDBitSize = 28;
+  static constexpr const uint32_t kElementIDBitSize = 28;
   static constexpr const uint32_t kPickingTypeBitSize = 3;
   static constexpr const uint32_t kBatcherIDBitSize = 1;
 
-  [[nodiscard]] inline static PickingId Get(
-      PickingType type, uint32_t id,
+  [[nodiscard]] inline static PickingId Create(
+      PickingType type, uint32_t element_id,
       BatcherId batcher_id = BatcherId::kTimeGraph) {
     PickingId result;
     result.type = type;
-    result.id = id;
+    result.element_id = element_id;
     result.batcher_id = batcher_id;
     return result;
   }
 
-  [[nodiscard]] static Color GetColor(
-      PickingType type, uint32_t id,
+  [[nodiscard]] inline static PickingId FromPixelValue(uint32_t value) {
+    PickingId id = absl::bit_cast<PickingId, uint32_t>(value);
+    return id;
+  }
+
+  [[nodiscard]] static Color ToColor(
+      PickingType type, uint32_t element_id,
       BatcherId batcher_id = BatcherId::kTimeGraph) {
-    PickingId result_id = Get(type, id, batcher_id);
+    PickingId result_id = Create(type, element_id, batcher_id);
     std::array<uint8_t, 4> color_values;
     color_values = absl::bit_cast<std::array<uint8_t, 4>, PickingId>(result_id);
     return Color(color_values[0], color_values[1], color_values[2],
                  color_values[3]);
   }
 
-  [[nodiscard]] inline static PickingId Get(uint32_t value) {
-    PickingId id = absl::bit_cast<PickingId, uint32_t>(value);
-    return id;
-  }
-  
-  uint32_t id_ : kIDBitSize;
-  PickingType type_ : kPickingTypeBitSize;
-  BatcherId batcher_id_ : kBatcherIDBitSize;
+  uint32_t element_id : kElementIDBitSize;
+  PickingType type : kPickingTypeBitSize;
+  BatcherId batcher_id : kBatcherIDBitSize;
 };
 
 class PickingManager {
@@ -92,11 +92,11 @@ class PickingManager {
   PickingManager() {}
   void Reset();
 
-  void Pick(uint32_t id, int x, int y);
+  void Pick(PickingId id, int x, int y);
   void Release();
   void Drag(int x, int y);
   [[nodiscard]] std::weak_ptr<Pickable> GetPicked() const;
-  [[nodiscard]] std::weak_ptr<Pickable> GetPickableFromId(uint32_t id) const;
+  [[nodiscard]] std::weak_ptr<Pickable> GetPickableFromId(PickingId id) const;
   [[nodiscard]] bool IsDragging() const;
 
   [[nodiscard]] Color GetPickableColor(std::weak_ptr<Pickable> pickable,

--- a/OrbitGl/PickingManager.h
+++ b/OrbitGl/PickingManager.h
@@ -53,6 +53,10 @@ enum class PickingType : uint32_t {
 enum class BatcherId : uint32_t { kTimeGraph, kUi };
 
 struct PickingId {
+  static constexpr const uint32_t kIDBitSize = 28;
+  static constexpr const uint32_t kPickingTypeBitSize = 3;
+  static constexpr const uint32_t kBatcherIDBitSize = 1;
+
   [[nodiscard]] inline static PickingId Get(
       PickingType type, uint32_t id,
       BatcherId batcher_id = BatcherId::kTimeGraph) {
@@ -77,9 +81,10 @@ struct PickingId {
     PickingId id = absl::bit_cast<PickingId, uint32_t>(value);
     return id;
   }
-  uint32_t id : 28;
-  PickingType type : 3;
-  BatcherId batcher_id : 1;
+  
+  uint32_t id_ : kIDBitSize;
+  PickingType type_ : kPickingTypeBitSize;
+  BatcherId batcher_id_ : kBatcherIDBitSize;
 };
 
 class PickingManager {

--- a/OrbitGl/PickingManager.h
+++ b/OrbitGl/PickingManager.h
@@ -90,6 +90,8 @@ struct PickingId {
 class PickingManager {
  public:
   PickingManager() {}
+  PickingManager(PickingManager& rhs) = delete;
+
   void Reset();
 
   void Pick(PickingId id, int x, int y);
@@ -105,13 +107,14 @@ class PickingManager {
   [[nodiscard]] bool IsThisElementPicked(const Pickable* pickable) const;
 
  private:
-  [[nodiscard]] PickingId CreatePickableId(std::weak_ptr<Pickable> a_Pickable,
-                                           BatcherId batcher_id);
+  [[nodiscard]] PickingId CreateOrGetPickableId(
+      std::weak_ptr<Pickable> pickable, BatcherId batcher_id);
   [[nodiscard]] Color ColorFromPickingID(PickingId id) const;
 
  private:
-  uint32_t id_counter_ = 0;
-  std::unordered_map<uint32_t, std::weak_ptr<Pickable>> id_pickable_map_;
+  uint32_t pickable_id_counter_ = 0;
+  std::unordered_map<uint32_t, std::weak_ptr<Pickable>> pid_pickable_map_;
+  std::unordered_map<Pickable*, uint32_t> pickable_pid_map_;
   std::weak_ptr<Pickable> currently_picked_;
   mutable absl::Mutex mutex_;
 };

--- a/OrbitGl/PickingManager.h
+++ b/OrbitGl/PickingManager.h
@@ -53,9 +53,12 @@ enum class PickingType : uint32_t {
 enum class BatcherId : uint32_t { kTimeGraph, kUi };
 
 struct PickingId {
-  static constexpr const uint32_t kElementIDBitSize = 28;
-  static constexpr const uint32_t kPickingTypeBitSize = 3;
-  static constexpr const uint32_t kBatcherIDBitSize = 1;
+  static constexpr uint32_t kElementIDBitSize = 28;
+  static constexpr uint32_t kPickingTypeBitSize = 3;
+  static constexpr uint32_t kBatcherIDBitSize = 1;
+
+  static_assert(kElementIDBitSize + kPickingTypeBitSize + kBatcherIDBitSize ==
+                32);
 
   [[nodiscard]] inline static PickingId Create(
       PickingType type, uint32_t element_id,
@@ -107,7 +110,7 @@ class PickingManager {
   [[nodiscard]] bool IsThisElementPicked(const Pickable* pickable) const;
 
  private:
-  [[nodiscard]] PickingId CreateOrGetPickableId(
+  [[nodiscard]] PickingId GetOrCreatePickableId(
       std::weak_ptr<Pickable> pickable, BatcherId batcher_id);
   [[nodiscard]] Color ColorFromPickingID(PickingId id) const;
 

--- a/OrbitGl/PickingManagerTest.cpp
+++ b/OrbitGl/PickingManagerTest.cpp
@@ -2,33 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "PickingManagerTest.h"
+
 #include <gtest/gtest.h>
 
 #include <cstring>
-
-#include "PickingManager.h"
-#include "absl/base/casts.h"
-
-class PickableMock : public Pickable {
- public:
-  void OnPick(int, int) override { picked_ = true; }
-  void OnDrag(int, int) override { dragging_ = true; }
-  void OnRelease() override {
-    dragging_ = false;
-    picked_ = false;
-  }
-  void Draw(GlCanvas*, PickingMode) override {}
-
-  bool Draggable() override { return true; }
-
-  bool picked_ = false;
-  bool dragging_ = false;
-
-  void Reset() {
-    picked_ = false;
-    dragging_ = false;
-  }
-};
 
 class UndraggableMock : public PickableMock {
   bool Draggable() override { return false; }
@@ -46,13 +24,6 @@ TEST(PickingManager, PickableMock) {
   ASSERT_FALSE(pickable.dragging_);
   pickable.Reset();
   ASSERT_FALSE(pickable.picked_);
-}
-
-// Simulate "rendering" the picking color into a uint32_t target
-PickingId MockRenderPickingColor(const Color& col_vec) {
-  uint32_t col = absl::bit_cast<uint32_t, Color>(col_vec);
-  PickingId picking_id = PickingId::FromPixelValue(col);
-  return picking_id;
 }
 
 TEST(PickingManager, BasicFunctionality) {

--- a/OrbitGl/PickingManagerTest.h
+++ b/OrbitGl/PickingManagerTest.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_TESTS_PICKING_MANAGER_TEST_H_
+#define ORBIT_GL_TESTS_PICKING_MANAGER_TEST_H_
+
+#include "GlCanvas.h"
+#include "PickingManager.h"
+#include "absl/base/casts.h"
+
+class PickableMock : public Pickable {
+ public:
+  void OnPick(int /*x*/, int /*y*/) override { picked_ = true; }
+  void OnDrag(int /*x*/, int /*y*/) override { dragging_ = true; }
+  void OnRelease() override {
+    dragging_ = false;
+    picked_ = false;
+  }
+  void Draw(GlCanvas*, PickingMode) override {}
+
+  bool Draggable() override { return true; }
+
+  bool picked_ = false;
+  bool dragging_ = false;
+
+  void Reset() {
+    picked_ = false;
+    dragging_ = false;
+  }
+};
+
+// Simulate "rendering" the picking color into a uint32_t target
+inline PickingId MockRenderPickingColor(const Color& col_vec) {
+  uint32_t col = absl::bit_cast<uint32_t, Color>(col_vec);
+  PickingId picking_id = PickingId::FromPixelValue(col);
+  return picking_id;
+}
+
+#endif

--- a/OrbitGl/TextBox.cpp
+++ b/OrbitGl/TextBox.cpp
@@ -102,7 +102,8 @@ void TextBox::Draw(Batcher* batcher, TextRenderer& a_TextRenderer, float a_MinX,
 
   if (a_Visible) {
     Box box(m_Pos, m_Size, z);
-    batcher->AddBox(box, color, PickingType::kPickable);
+    // TODO: This should be pickable??
+    batcher->AddBox(box, color);
 
     static Color s_Color(255, 255, 255, 255);
 
@@ -126,5 +127,6 @@ void TextBox::Draw(Batcher* batcher, TextRenderer& a_TextRenderer, float a_MinX,
     }
   }
 
-  batcher->AddVerticalLine(m_Pos, m_Size[1], z, grey, PickingType::kPickable);
+  // TODO: This should be pickable??
+  batcher->AddVerticalLine(m_Pos, m_Size[1], z, grey);
 }

--- a/OrbitGl/TextRenderer.cpp
+++ b/OrbitGl/TextRenderer.cpp
@@ -162,12 +162,10 @@ void TextRenderer::DrawOutline(Batcher* batcher, vertex_buffer_t* a_Buffer) {
     vertex_t v2 =
         *static_cast<const vertex_t*>(vector_get(a_Buffer->vertices, i2));
 
-    batcher->AddLine(Vec2(v0.x, v0.y), Vec2(v1.x, v1.y), v0.z, color,
-                     PickingType::kPickable);
-    batcher->AddLine(Vec2(v1.x, v1.y), Vec2(v2.x, v2.y), v1.z, color,
-                     PickingType::kPickable);
-    batcher->AddLine(Vec2(v2.x, v2.y), Vec2(v0.x, v0.y), v2.z, color,
-                     PickingType::kPickable);
+    // TODO: This should be pickable??
+    batcher->AddLine(Vec2(v0.x, v0.y), Vec2(v1.x, v1.y), v0.z, color);
+    batcher->AddLine(Vec2(v1.x, v1.y), Vec2(v2.x, v2.y), v1.z, color);
+    batcher->AddLine(Vec2(v2.x, v2.y), Vec2(v0.x, v0.y), v2.z, color);
   }
 }
 

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -37,7 +37,7 @@ using orbit_client_protos::TimerInfo;
 
 TimeGraph* GCurrentTimeGraph = nullptr;
 
-TimeGraph::TimeGraph() {
+TimeGraph::TimeGraph() : m_Batcher(BatcherId::kTimeGraph) {
   m_LastThreadReorder.Start();
   scheduler_track_ = GetOrCreateSchedulerTrack();
 
@@ -66,6 +66,7 @@ void TimeGraph::SetCanvas(GlCanvas* a_Canvas) {
   m_Canvas = a_Canvas;
   m_TextRenderer->SetCanvas(a_Canvas);
   m_TextRendererStatic.SetCanvas(a_Canvas);
+  m_Batcher.SetPickingManager(&a_Canvas->GetPickingManager());
 }
 
 void TimeGraph::SetFontSize(int a_FontSize) {
@@ -706,7 +707,7 @@ void DrawIteratorBox(GlCanvas* canvas, Vec2 pos, Vec2 size, const Color& color,
                      const std::string& label, const std::string& time,
                      float text_y) {
   Box box(pos, size, GlCanvas::Z_VALUE_OVERLAY);
-  canvas->GetBatcher()->AddBox(box, color, PickingType::kBox);
+  canvas->GetBatcher()->AddBox(box, color);
 
   std::string text = absl::StrFormat("%s: %s", label, time);
 
@@ -723,7 +724,7 @@ void DrawIteratorBox(GlCanvas* canvas, Vec2 pos, Vec2 size, const Color& color,
   Vec2 line_from(pos[0], text_y + kOffsetBelowText);
   Vec2 line_to(pos[0] + size[0], text_y + kOffsetBelowText);
   canvas->GetBatcher()->AddLine(line_from, line_to, GlCanvas::Z_VALUE_OVERLAY,
-                                Color(255, 255, 255, 255), PickingType::kLine);
+                                Color(255, 255, 255, 255));
 }
 
 }  // namespace
@@ -773,7 +774,7 @@ void TimeGraph::DrawOverlay(GlCanvas* canvas, PickingMode picking_mode) {
 
     canvas->GetBatcher()->AddVerticalLine(
         pos, -world_height, GlCanvas::Z_VALUE_OVERLAY,
-        GetThreadColor(timer_info.thread_id()), PickingType::kLine, nullptr);
+        GetThreadColor(timer_info.thread_id()));
   }
 
   // Draw boxes with timings between iterators.

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -111,9 +111,6 @@ class TimeGraph {
   bool IsVisible(VisibilityType vis_type, TickType min, TickType max) const;
 
   int GetNumDrawnTextBoxes() { return m_NumDrawnTextBoxes; }
-  void SetPickingManager(class PickingManager* a_Manager) {
-    m_PickingManager = a_Manager;
-  }
   void SetTextRenderer(TextRenderer* a_TextRenderer) {
     m_TextRenderer = a_TextRenderer;
   }
@@ -148,7 +145,9 @@ class TimeGraph {
 
   void SetIteratorOverlayData(
       const absl::flat_hash_map<uint64_t, const TextBox*>& iterator_text_boxes,
-      const absl::flat_hash_map<uint64_t, const orbit_client_protos::FunctionInfo*>& iterator_functions) {
+      const absl::flat_hash_map<uint64_t,
+                                const orbit_client_protos::FunctionInfo*>&
+          iterator_functions) {
     iterator_text_boxes_ = iterator_text_boxes;
     iterator_functions_ = iterator_functions;
     NeedsRedraw();
@@ -177,7 +176,8 @@ class TimeGraph {
 
   // First member is id.
   absl::flat_hash_map<uint64_t, const TextBox*> iterator_text_boxes_;
-  absl::flat_hash_map<uint64_t, const orbit_client_protos::FunctionInfo*> iterator_functions_;
+  absl::flat_hash_map<uint64_t, const orbit_client_protos::FunctionInfo*>
+      iterator_functions_;
 
   double m_RefTimeUs = 0;
   double m_MinTimeUs = 0;
@@ -212,7 +212,6 @@ class TimeGraph {
   bool m_DrawText = true;
 
   Batcher m_Batcher;
-  PickingManager* m_PickingManager = nullptr;
   Timer m_LastThreadReorder;
 
   mutable Mutex m_Mutex;

--- a/OrbitGl/TimerTrack.cpp
+++ b/OrbitGl/TimerTrack.cpp
@@ -63,7 +63,8 @@ void TimerTrack::UpdateBoxHeight() {
   box_height_ = time_graph_->GetLayout().GetTextBoxHeight();
 }
 
-void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode /*picking_mode*/) {
+void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
+                                  PickingMode /*picking_mode*/) {
   UpdateBoxHeight();
 
   Batcher* batcher = &time_graph_->GetBatcher();
@@ -105,8 +106,10 @@ void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingM
       for (size_t k = 0; k < block.size(); ++k) {
         TextBox& text_box = block[k];
         const TimerInfo& timer_info = text_box.GetTimerInfo();
-        if (min_tick > timer_info.end() || max_tick < timer_info.start()) continue;
-        if (timer_info.start() >= min_ignore && timer_info.end() <= max_ignore) continue;
+        if (min_tick > timer_info.end() || max_tick < timer_info.start())
+          continue;
+        if (timer_info.start() >= min_ignore && timer_info.end() <= max_ignore)
+          continue;
         if (!TimerFilter(timer_info)) continue;
 
         UpdateDepth(timer_info.depth() + 1);
@@ -138,11 +141,9 @@ void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingM
           if (!is_collapsed) {
             SetTimesliceText(timer_info, elapsed_us, min_x, &text_box);
           }
-          batcher->AddShadedBox(pos, size, z, color, PickingType::kBox,
-                                std::move(user_data));
+          batcher->AddShadedBox(pos, size, z, color, std::move(user_data));
         } else {
-          auto type = PickingType::kLine;
-          batcher->AddVerticalLine(pos, size[1], z, color, type,
+          batcher->AddVerticalLine(pos, size[1], z, color,
                                    std::move(user_data));
           // For lines, we can ignore the entire pixel into which this event
           // falls. We align this precisely on the pixel x-coordinate of the
@@ -150,10 +151,10 @@ void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingM
           // zero, we need to avoid dividing by zero, but we also wouldn't
           // gain anything here.
           if (pixel_delta_in_ticks != 0) {
-            min_ignore =
-                min_timegraph_tick +
-                ((timer_info.start() - min_timegraph_tick) / pixel_delta_in_ticks) *
-                    pixel_delta_in_ticks;
+            min_ignore = min_timegraph_tick +
+                         ((timer_info.start() - min_timegraph_tick) /
+                          pixel_delta_in_ticks) *
+                             pixel_delta_in_ticks;
             max_ignore = min_ignore + pixel_delta_in_ticks;
           }
         }
@@ -206,7 +207,7 @@ std::vector<std::shared_ptr<TimerChain>> TimerTrack::GetTimers() {
 }
 
 const TextBox* TimerTrack::GetFirstAfterTime(TickType time,
-                                              uint32_t depth) const {
+                                             uint32_t depth) const {
   std::shared_ptr<TimerChain> chain = GetTimers(depth);
   if (chain == nullptr) return nullptr;
 
@@ -223,7 +224,7 @@ const TextBox* TimerTrack::GetFirstAfterTime(TickType time,
 }
 
 const TextBox* TimerTrack::GetFirstBeforeTime(TickType time,
-                                               uint32_t depth) const {
+                                              uint32_t depth) const {
   std::shared_ptr<TimerChain> chain = GetTimers(depth);
   if (chain == nullptr) return nullptr;
 

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -56,9 +56,9 @@ std::vector<Vec2> RotatePoints(const std::vector<Vec2>& points,
   return result;
 }
 
-void DrawTriangleFan(Batcher* batcher, const std::vector<Vec2>& points,
-                     const Vec2& pos, const Color& color, float rotation,
-                     float z) {
+void Track::DrawTriangleFan(Batcher* batcher, const std::vector<Vec2>& points,
+                            const Vec2& pos, const Color& color, float rotation,
+                            float z) {
   if (points.size() < 3) {
     return;
   }
@@ -74,7 +74,7 @@ void DrawTriangleFan(Batcher* batcher, const std::vector<Vec2>& points,
     vertices[i % 2] =
         position + Vec3(rotated_points[i + 1][0], rotated_points[i + 1][1], z);
     Triangle triangle(pivot, vertices[i % 2], vertices[(i + 1) % 2]);
-    batcher->AddTriangle(triangle, color, PickingType::kPickable);
+    batcher->AddTriangle(triangle, color, shared_from_this());
   }
 }
 
@@ -82,12 +82,8 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   Batcher* batcher = canvas->GetBatcher();
 
   const TimeGraphLayout& layout = time_graph_->GetLayout();
-  Color picking_color = canvas->GetPickingManager().GetPickableColor(
-      shared_from_this(), BatcherId::kUi);
   const Color kTabColor(50, 50, 50, 255);
   const bool picking = picking_mode != PickingMode::kNone;
-  Color color = picking ? picking_color : kTabColor;
-  glColor4ubv(&color[0]);
 
   float x0 = m_Pos[0];
   float x1 = x0 + m_Size[0];
@@ -102,7 +98,7 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
     if (layout.GetDrawTrackBackground()) {
       Box box(Vec2(x0, y0 + top_margin),
               Vec2(m_Size[0], -m_Size[1] - top_margin), track_z);
-      batcher->AddBox(box, color, PickingType::kPickable);
+      batcher->AddBox(box, kTabColor, shared_from_this());
     }
   }
 
@@ -114,7 +110,7 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   float tab_x0 = x0 + layout.GetTrackTabOffset();
 
   Box box(Vec2(tab_x0, y0), Vec2(label_width, label_height), track_z);
-  batcher->AddBox(box, color, PickingType::kPickable);
+  batcher->AddBox(box, kTabColor, shared_from_this());
 
   // Draw rounded corners.
   if (!picking) {
@@ -132,9 +128,11 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
     Vec2 end_bottom(x1 - vertical_margin, y1);
     Vec2 end_top(x1 - vertical_margin, y0 + top_margin);
     float z = GlCanvas::Z_VALUE_BOX_ACTIVE + 0.001f;
+
+    glColor4ubv(&kTabColor[0]);
     DrawTriangleFan(batcher, rounded_corner, bottom_left, kBackgroundColor, 0,
                     z);
-    DrawTriangleFan(batcher, rounded_corner, bottom_right, color, 0, z);
+    DrawTriangleFan(batcher, rounded_corner, bottom_right, kTabColor, 0, z);
     DrawTriangleFan(batcher, rounded_corner, top_right, kBackgroundColor, 180.f,
                     z);
     DrawTriangleFan(batcher, rounded_corner, top_left, kBackgroundColor, -90.f,

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -86,6 +86,10 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
   [[nodiscard]] virtual bool IsCollapsable() const { return false; }
 
  protected:
+  void DrawTriangleFan(Batcher* batcher, const std::vector<Vec2>& points,
+                       const Vec2& pos, const Color& color, float rotation,
+                       float z);
+
   GlCanvas* m_Canvas;
   TimeGraph* time_graph_;
   Vec2 m_Pos;

--- a/OrbitGl/TriangleToggle.cpp
+++ b/OrbitGl/TriangleToggle.cpp
@@ -22,12 +22,6 @@ void TriangleToggle::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   const Color kGrey(100, 100, 100, 255);
   Color color = state_ == State::kInactive ? kGrey : kWhite;
 
-  if (picking) {
-    PickingManager& picking_manager = canvas->GetPickingManager();
-    color =
-        picking_manager.GetPickableColor(shared_from_this(), BatcherId::kUi);
-  }
-
   // Draw triangle.
   static float half_sqrt_three = 0.5f * sqrtf(3.f);
   float half_w = 0.5f * size_;
@@ -46,14 +40,14 @@ void TriangleToggle::Draw(GlCanvas* canvas, PickingMode picking_mode) {
                           position + Vec3(-half_w, half_h, 0.f),
                           position + Vec3(0.f, -half_w, 0.f));
     }
-    batcher->AddTriangle(triangle, color, PickingType::kPickable);
+    batcher->AddTriangle(triangle, color, shared_from_this());
   } else {
     // When picking, draw a big square for easier picking.
     float original_width = 2 * half_w;
     float large_width = 2 * original_width;
     Box box(Vec2(pos_[0] - original_width, pos_[1] - original_width),
             Vec2(large_width, large_width), 0.f);
-    batcher->AddBox(box, color, PickingType::kPickable);
+    batcher->AddBox(box, color, shared_from_this());
   }
 }
 


### PR DESCRIPTION
This fix make the interaction between the Batcher and PickingManager less error-prone and easier to use. Before, `Pickable` elements used a hack in drawing to work correctly - they calculated their picking color as "regular" color and ignored the picking color set by the batcher. It was also possible to add user_data to pickables which could never be retrieved lateron.

The batcher now handles the picking color generation for pickables, and all batchers are drawn with the correct picking flag instead of hacking the picking in as before.

This required moving some parts of CaptureWindow into the parent GlCanvas. These classes require a seperate cleanup in a subsequent PR.

Note that there's two TODOs for text rendering. The commented lines seem like a previously existing bug (passing picking type kPickable, but there is no Pickable element or correctly calculated color), so these changes should not influence anything. THis should also be tackled in a subsequent cleanup.