### PR TITLE
Refactor Capture to move GSelectedFunctionsMap to DataManager

### DIFF
--- a/OrbitCaptureClient/CaptureClient.cpp
+++ b/OrbitCaptureClient/CaptureClient.cpp
@@ -27,7 +27,7 @@ IntrumentedFunctionTypeFromOrbitType(FunctionInfo::OrbitType orbit_type) {
 
 ErrorMessageOr<void> CaptureClient::StartCapture(
     ThreadPool* thread_pool, int32_t pid,
-    const std::map<uint64_t, FunctionInfo*>& selected_functions) {
+    const absl::flat_hash_map<uint64_t, FunctionInfo>& selected_functions) {
   absl::MutexLock lock(&state_mutex_);
   if (state_ != State::kStopped) {
     return ErrorMessage(
@@ -43,7 +43,8 @@ ErrorMessageOr<void> CaptureClient::StartCapture(
 }
 
 void CaptureClient::Capture(
-    int32_t pid, const std::map<uint64_t, FunctionInfo*>& selected_functions) {
+    int32_t pid,
+    const absl::flat_hash_map<uint64_t, FunctionInfo>& selected_functions) {
   CHECK(reader_writer_ == nullptr);
 
   event_processor_.emplace(capture_listener_);
@@ -69,7 +70,7 @@ void CaptureClient::Capture(
 
   capture_options->set_trace_gpu_driver(true);
   for (const auto& pair : selected_functions) {
-    const FunctionInfo& function = *pair.second;
+    const FunctionInfo& function = pair.second;
     CaptureOptions::InstrumentedFunction* instrumented_function =
         capture_options->add_instrumented_functions();
     instrumented_function->set_file_path(function.loaded_module_path());

--- a/OrbitCaptureClient/CaptureClient.cpp
+++ b/OrbitCaptureClient/CaptureClient.cpp
@@ -27,7 +27,7 @@ IntrumentedFunctionTypeFromOrbitType(FunctionInfo::OrbitType orbit_type) {
 
 ErrorMessageOr<void> CaptureClient::StartCapture(
     ThreadPool* thread_pool, int32_t pid,
-    const absl::flat_hash_map<uint64_t, FunctionInfo>& selected_functions) {
+    absl::flat_hash_map<uint64_t, FunctionInfo> selected_functions) {
   absl::MutexLock lock(&state_mutex_);
   if (state_ != State::kStopped) {
     return ErrorMessage(
@@ -37,14 +37,16 @@ ErrorMessageOr<void> CaptureClient::StartCapture(
 
   state_ = State::kStarting;
   thread_pool->Schedule(
-      [this, pid, selected_functions]() { Capture(pid, selected_functions); });
+      [this, pid, selected_functions{std::move(selected_functions)}]() {
+        Capture(pid, selected_functions);
+      });
 
   return outcome::success();
 }
 
 void CaptureClient::Capture(
     int32_t pid,
-    const absl::flat_hash_map<uint64_t, FunctionInfo>& selected_functions) {
+    absl::flat_hash_map<uint64_t, FunctionInfo> selected_functions) {
   CHECK(reader_writer_ == nullptr);
 
   event_processor_.emplace(capture_listener_);

--- a/OrbitCaptureClient/CaptureClient.cpp
+++ b/OrbitCaptureClient/CaptureClient.cpp
@@ -37,16 +37,14 @@ ErrorMessageOr<void> CaptureClient::StartCapture(
 
   state_ = State::kStarting;
   thread_pool->Schedule(
-      [this, pid, selected_functions{std::move(selected_functions)}]() {
-        Capture(pid, selected_functions);
-      });
+      [this, pid, selected_functions]() { Capture(pid, selected_functions); });
 
   return outcome::success();
 }
 
 void CaptureClient::Capture(
     int32_t pid,
-    absl::flat_hash_map<uint64_t, FunctionInfo> selected_functions) {
+    const absl::flat_hash_map<uint64_t, FunctionInfo>& selected_functions) {
   CHECK(reader_writer_ == nullptr);
 
   event_processor_.emplace(capture_listener_);

--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
@@ -31,7 +31,7 @@ class CaptureClient {
 
   [[nodiscard]] ErrorMessageOr<void> StartCapture(
       ThreadPool* thread_pool, int32_t pid,
-      const absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>&
+      absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>
           selected_functions);
 
   // Returns true if stop was initiated and false otherwise.
@@ -53,10 +53,9 @@ class CaptureClient {
   }
 
  private:
-  void Capture(
-      int32_t pid,
-      const absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>&
-          selected_functions);
+  void Capture(int32_t pid,
+               absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>
+                   selected_functions);
 
   void FinishCapture();
 

--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
@@ -31,7 +31,7 @@ class CaptureClient {
 
   [[nodiscard]] ErrorMessageOr<void> StartCapture(
       ThreadPool* thread_pool, int32_t pid,
-      const std::map<uint64_t, orbit_client_protos::FunctionInfo*>&
+      const absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>&
           selected_functions);
 
   // Returns true if stop was initiated and false otherwise.
@@ -53,9 +53,10 @@ class CaptureClient {
   }
 
  private:
-  void Capture(int32_t pid,
-               const std::map<uint64_t, orbit_client_protos::FunctionInfo*>&
-                   selected_functions);
+  void Capture(
+      int32_t pid,
+      const absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>&
+          selected_functions);
 
   void FinishCapture();
 

--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
@@ -53,9 +53,10 @@ class CaptureClient {
   }
 
  private:
-  void Capture(int32_t pid,
-               absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>
-                   selected_functions);
+  void Capture(
+      int32_t pid,
+      const absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>&
+          selected_functions);
 
   void FinishCapture();
 

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -55,17 +55,20 @@ bool ClientGgp::InitClient() {
 
 // Client requests to start the capture
 bool ClientGgp::RequestStartCapture(ThreadPool* thread_pool) {
-  ErrorMessageOr<void> result = Capture::StartCapture();
-  if (result.has_error()) {
-    ERROR("Error starting capture: %s", result.error().message());
-    return false;
-  }
   int32_t pid = target_process_->GetID();
   LOG("Capture pid %d", pid);
 
   // TODO: selected_functions available when UploadSymbols is included
-  std::map<uint64_t, orbit_client_protos::FunctionInfo*> selected_functions =
-      Capture::GSelectedFunctionsMap;
+  // TODO(kuebler): function selection should be handled separately by each
+  //  client.
+  absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>
+      selected_functions;
+  ErrorMessageOr<void> result = Capture::StartCapture(
+      pid, target_process_->GetName(), selected_functions);
+  if (result.has_error()) {
+    ERROR("Error starting capture: %s", result.error().message());
+    return false;
+  }
   result = capture_client_->StartCapture(thread_pool, pid, selected_functions);
   if (result.has_error()) {
     ERROR("Error starting capture: %s", result.error().message());

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -59,8 +59,8 @@ bool ClientGgp::RequestStartCapture(ThreadPool* thread_pool) {
   LOG("Capture pid %d", pid);
 
   // TODO: selected_functions available when UploadSymbols is included
-  // TODO(kuebler): function selection should be handled separately by each
-  //  client.
+  // TODO(kuebler): right now selected_functions is only an empty placeholder,
+  //  it needs to be filled separately in each client and then passed.
   absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>
       selected_functions;
   ErrorMessageOr<void> result = Capture::StartCapture(

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -20,8 +20,7 @@ using orbit_client_protos::PresetFile;
 using orbit_client_protos::PresetInfo;
 
 CaptureData Capture::capture_data_;
-std::map<uint64_t, FunctionInfo*> Capture::GSelectedFunctionsMap;
-std::map<uint64_t, FunctionInfo*> Capture::GVisibleFunctionsMap;
+absl::flat_hash_map<uint64_t, FunctionInfo> Capture::GVisibleFunctionsMap;
 TextBox* Capture::GSelectedTextBox = nullptr;
 ThreadID Capture::GSelectedThreadId;
 
@@ -35,21 +34,19 @@ void Capture::SetTargetProcess(std::shared_ptr<Process> process) {
   if (process != GTargetProcess) {
     GSamplingProfiler = std::make_shared<SamplingProfiler>(process);
     GTargetProcess = std::move(process);
-    GSelectedFunctionsMap.clear();
   }
 }
 
-ErrorMessageOr<void> Capture::StartCapture() {
+ErrorMessageOr<void> Capture::StartCapture(
+    uint64_t process_id, std::string process_name,
+    absl::flat_hash_map<uint64_t, FunctionInfo> selectedFunctions) {
   if (GTargetProcess->GetID() == 0) {
     return ErrorMessage(
         "No process selected. Please choose a target process for the capture.");
   }
 
-  capture_data_ =
-      CaptureData(GTargetProcess->GetID(), GTargetProcess->GetName(),
-                  GetSelectedFunctions());
-
-  PreFunctionHooks();
+  capture_data_ = CaptureData(process_id, std::move(process_name),
+                              std::move(selectedFunctions));
 
   Capture::GSamplingProfiler =
       std::make_shared<SamplingProfiler>(Capture::GTargetProcess);
@@ -68,61 +65,9 @@ void Capture::ClearCaptureData() {
   GSelectedThreadId = 0;
 }
 
-void Capture::PreFunctionHooks() {
-  GSelectedFunctionsMap.clear();
-  for (auto& func : capture_data_.selected_functions()) {
-    uint64_t address = FunctionUtils::GetAbsoluteAddress(*func);
-    GSelectedFunctionsMap[address] = func.get();
-  }
-
-  GVisibleFunctionsMap = GSelectedFunctionsMap;
-}
-
-std::vector<std::shared_ptr<FunctionInfo>> Capture::GetSelectedFunctions() {
-  std::vector<std::shared_ptr<FunctionInfo>> selected_functions;
-  for (auto& func : GTargetProcess->GetFunctions()) {
-    if (FunctionUtils::IsSelected(*func) || FunctionUtils::IsOrbitFunc(*func)) {
-      selected_functions.push_back(func);
-    }
-  }
-  return selected_functions;
-}
-
-ErrorMessageOr<void> Capture::SavePreset(const std::string& filename) {
-  PresetInfo preset;
-  preset.set_process_full_path(GTargetProcess->GetFullPath());
-
-  for (auto& func : GTargetProcess->GetFunctions()) {
-    if (FunctionUtils::IsSelected(*func)) {
-      uint64_t hash = FunctionUtils::GetHash(*func);
-      (*preset.mutable_path_to_module())[func->loaded_module_path()]
-          .add_function_hashes(hash);
-    }
-  }
-
-  std::string filename_with_ext = filename;
-  if (!absl::EndsWith(filename, ".opr")) {
-    filename_with_ext += ".opr";
-  }
-
-  std::ofstream file(filename_with_ext, std::ios::binary);
-  if (file.fail()) {
-    ERROR("Saving preset in \"%s\": %s", filename_with_ext, "file.fail()");
-    return ErrorMessage("Error opening the file for writing");
-  }
-
-  {
-    SCOPE_TIMER_LOG(
-        absl::StrFormat("Saving preset in \"%s\"", filename_with_ext));
-    preset.SerializeToOstream(&file);
-  }
-
-  return outcome::success();
-}
-
 void Capture::PreSave() {
   // Add selected functions' exact address to sampling profiler
-  for (auto& pair : GSelectedFunctionsMap) {
+  for (auto& pair : capture_data_.selected_functions()) {
     GSamplingProfiler->UpdateAddressInfo(pair.first);
   }
 }

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -39,14 +39,14 @@ void Capture::SetTargetProcess(std::shared_ptr<Process> process) {
 
 ErrorMessageOr<void> Capture::StartCapture(
     uint64_t process_id, std::string process_name,
-    absl::flat_hash_map<uint64_t, FunctionInfo> selectedFunctions) {
+    absl::flat_hash_map<uint64_t, FunctionInfo> selected_functions) {
   if (GTargetProcess->GetID() == 0) {
     return ErrorMessage(
         "No process selected. Please choose a target process for the capture.");
   }
 
   capture_data_ = CaptureData(process_id, std::move(process_name),
-                              std::move(selectedFunctions));
+                              std::move(selected_functions));
 
   Capture::GSamplingProfiler =
       std::make_shared<SamplingProfiler>(Capture::GTargetProcess);

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -28,7 +28,7 @@ class Capture {
   static ErrorMessageOr<void> StartCapture(
       uint64_t process_id, std::string process_name,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>
-          selectedFunctions);
+          selected_functions);
   static void FinalizeCapture();
   static void ClearCaptureData();
   static void PreSave();

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -25,13 +25,12 @@ class Capture {
  public:
   static void Init();
   static void SetTargetProcess(std::shared_ptr<Process> process);
-  static ErrorMessageOr<void> StartCapture();
+  static ErrorMessageOr<void> StartCapture(
+      uint64_t process_id, std::string process_name,
+      absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>
+          selectedFunctions);
   static void FinalizeCapture();
   static void ClearCaptureData();
-  static std::vector<std::shared_ptr<orbit_client_protos::FunctionInfo>>
-  GetSelectedFunctions();
-  static void PreFunctionHooks();
-  static ErrorMessageOr<void> SavePreset(const std::string& filename);
   static void PreSave();
 
   static CaptureData capture_data_;
@@ -39,9 +38,7 @@ class Capture {
   static std::shared_ptr<SamplingProfiler> GSamplingProfiler;
   static std::shared_ptr<Process> GTargetProcess;
   static std::shared_ptr<orbit_client_protos::PresetFile> GSessionPresets;
-  static std::map<uint64_t, orbit_client_protos::FunctionInfo*>
-      GSelectedFunctionsMap;
-  static std::map<uint64_t, orbit_client_protos::FunctionInfo*>
+  static absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>
       GVisibleFunctionsMap;
   static class TextBox* GSelectedTextBox;
   static ThreadID GSelectedThreadId;

--- a/OrbitCore/CaptureData.cpp
+++ b/OrbitCore/CaptureData.cpp
@@ -6,7 +6,9 @@
 
 #include "Profiling.h"
 
+using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::FunctionStats;
+using orbit_client_protos::TimerInfo;
 
 orbit_client_protos::LinuxAddressInfo* CaptureData::GetAddressInfo(
     uint64_t address) {
@@ -27,9 +29,8 @@ const FunctionStats& CaptureData::GetFunctionStatsOrDefault(
   return function_stats_it->second;
 }
 
-void CaptureData::UpdateFunctionStats(
-    orbit_client_protos::FunctionInfo* func,
-    const orbit_client_protos::TimerInfo& timer_info) {
+void CaptureData::UpdateFunctionStats(FunctionInfo* func,
+                                      const TimerInfo& timer_info) {
   const uint64_t function_address = func->address();
   FunctionStats& stats = functions_stats_[function_address];
   stats.set_count(stats.count() + 1);
@@ -45,4 +46,13 @@ void CaptureData::UpdateFunctionStats(
   if (stats.min_ns() == 0 || elapsed_nanos < stats.min_ns()) {
     stats.set_min_ns(elapsed_nanos);
   }
+}
+
+const FunctionInfo* CaptureData::GetSelectedFunction(
+    uint64_t function_address) const {
+  auto selected_functions_it = selected_functions_.find(function_address);
+  if (selected_functions_it == selected_functions_.end()) {
+    return nullptr;
+  }
+  return &selected_functions_it->second;
 }

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -15,14 +15,14 @@ class CaptureData {
  public:
   explicit CaptureData(
       int32_t process_id, std::string process_name,
-      std::vector<std::shared_ptr<orbit_client_protos::FunctionInfo>>
+      absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>
           selected_functions)
       : process_id_{process_id},
         process_name_{std::move(process_name)},
         selected_functions_{std::move(selected_functions)} {}
   explicit CaptureData(
       int32_t process_id, std::string process_name,
-      std::vector<std::shared_ptr<orbit_client_protos::FunctionInfo>>
+      absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>
           selected_functions,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionStats>
           functions_stats)
@@ -37,11 +37,14 @@ class CaptureData {
   CaptureData(CaptureData&& other) = default;
   CaptureData& operator=(CaptureData&& other) = default;
 
-  [[nodiscard]] const std::vector<
-      std::shared_ptr<orbit_client_protos::FunctionInfo>>&
+  [[nodiscard]] const absl::flat_hash_map<uint64_t,
+                                          orbit_client_protos::FunctionInfo>&
   selected_functions() const {
     return selected_functions_;
   }
+
+  [[nodiscard]] const orbit_client_protos::FunctionInfo* GetSelectedFunction(
+      uint64_t function_address) const;
 
   [[nodiscard]] int32_t process_id() const { return process_id_; }
 
@@ -105,8 +108,7 @@ class CaptureData {
       address_infos_;
   int32_t process_id_ = -1;
   std::string process_name_;
-  // TODO(kuebler): make them raw pointers at some point
-  std::vector<std::shared_ptr<orbit_client_protos::FunctionInfo>>
+  absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>
       selected_functions_;
 
   absl::flat_hash_map<int32_t, std::string> thread_names_;

--- a/OrbitCore/FunctionUtils.cpp
+++ b/OrbitCore/FunctionUtils.cpp
@@ -53,22 +53,6 @@ std::shared_ptr<FunctionInfo> CreateFunctionInfo(
   return function_info;
 }
 
-void Select(FunctionInfo* func) {
-  LOG("Selected %s at 0x%" PRIx64 " (address_=0x%" PRIx64
-      ", load_bias_= 0x%" PRIx64 ", base_address=0x%" PRIx64 ")",
-      func->pretty_name(), GetAbsoluteAddress(*func), func->address(),
-      func->load_bias(), func->module_base_address());
-  Capture::GSelectedFunctionsMap[GetAbsoluteAddress(*func)] = func;
-}
-
-void UnSelect(FunctionInfo* func) {
-  Capture::GSelectedFunctionsMap.erase(GetAbsoluteAddress(*func));
-}
-
-bool IsSelected(const FunctionInfo& func) {
-  return Capture::GSelectedFunctionsMap.count(GetAbsoluteAddress(func)) > 0;
-}
-
 const absl::flat_hash_map<const char*, FunctionInfo::OrbitType>&
 GetFunctionNameToOrbitTypeMap() {
   static absl::flat_hash_map<const char*, FunctionInfo::OrbitType>
@@ -102,10 +86,6 @@ bool SetOrbitTypeFromName(FunctionInfo* func) {
     }
   }
   return false;
-}
-
-bool IsSelected(const SampledFunction& func) {
-  return Capture::GSelectedFunctionsMap.count(func.address) > 0;
 }
 
 }  // namespace FunctionUtils

--- a/OrbitCore/FunctionUtils.h
+++ b/OrbitCore/FunctionUtils.h
@@ -36,13 +36,7 @@ std::shared_ptr<orbit_client_protos::FunctionInfo> CreateFunctionInfo(
     uint64_t load_bias, uint64_t size, std::string file, uint32_t line,
     std::string loaded_module_path, uint64_t module_base_address);
 
-void Select(orbit_client_protos::FunctionInfo* func);
-void UnSelect(orbit_client_protos::FunctionInfo* func);
-bool IsSelected(const orbit_client_protos::FunctionInfo& func);
-
 bool SetOrbitTypeFromName(orbit_client_protos::FunctionInfo* func);
-
-bool IsSelected(const SampledFunction& func);
 
 }  // namespace FunctionUtils
 

--- a/OrbitCore/Pdb.cpp
+++ b/OrbitCore/Pdb.cpp
@@ -79,11 +79,8 @@ FunctionInfo* Pdb::GetFunctionFromProgramCounter(uint64_t a_Address) {
   return it->second;
 }
 
-std::vector<FunctionInfo*> Pdb::FunctionsToSelect(
+std::vector<FunctionInfo*> Pdb::GetSelectedFunctionsFromPreset(
     const PresetFile& preset) const {
-  SCOPE_TIMER_LOG(
-      absl::StrFormat("Pdb::FunctionsToSelect - %s", m_Name.c_str()));
-
   std::vector<FunctionInfo*> functions_to_select;
 
   std::string module_name = m_LoadedModuleName;

--- a/OrbitCore/Pdb.cpp
+++ b/OrbitCore/Pdb.cpp
@@ -79,8 +79,12 @@ FunctionInfo* Pdb::GetFunctionFromProgramCounter(uint64_t a_Address) {
   return it->second;
 }
 
-void Pdb::ApplyPreset(const PresetFile& preset) {
-  SCOPE_TIMER_LOG(absl::StrFormat("Pdb::ApplyPreset - %s", m_Name.c_str()));
+std::vector<FunctionInfo*> Pdb::FunctionsToSelect(
+    const PresetFile& preset) const {
+  SCOPE_TIMER_LOG(
+      absl::StrFormat("Pdb::FunctionsToSelect - %s", m_Name.c_str()));
+
+  std::vector<FunctionInfo*> functions_to_select;
 
   std::string module_name = m_LoadedModuleName;
   auto it = preset.preset_info().path_to_module().find(module_name);
@@ -90,9 +94,9 @@ void Pdb::ApplyPreset(const PresetFile& preset) {
     for (uint64_t hash : preset_module.function_hashes()) {
       auto fit = m_StringFunctionMap.find(hash);
       if (fit != m_StringFunctionMap.end()) {
-        FunctionInfo* function = fit->second;
-        FunctionUtils::Select(function);
+        functions_to_select.push_back(fit->second);
       }
     }
   }
+  return functions_to_select;
 }

--- a/OrbitCore/Pdb.h
+++ b/OrbitCore/Pdb.h
@@ -34,7 +34,8 @@ class Pdb {
 
   void PopulateFunctionMap();
   void PopulateStringFunctionMap();
-  void ApplyPreset(const orbit_client_protos::PresetFile& preset);
+  [[nodiscard]] std::vector<orbit_client_protos::FunctionInfo*>
+  FunctionsToSelect(const orbit_client_protos::PresetFile& preset) const;
 
   orbit_client_protos::FunctionInfo* GetFunctionFromExactAddress(
       uint64_t a_Address);

--- a/OrbitCore/Pdb.h
+++ b/OrbitCore/Pdb.h
@@ -35,7 +35,8 @@ class Pdb {
   void PopulateFunctionMap();
   void PopulateStringFunctionMap();
   [[nodiscard]] std::vector<orbit_client_protos::FunctionInfo*>
-  FunctionsToSelect(const orbit_client_protos::PresetFile& preset) const;
+  GetSelectedFunctionsFromPreset(
+      const orbit_client_protos::PresetFile& preset) const;
 
   orbit_client_protos::FunctionInfo* GetFunctionFromExactAddress(
       uint64_t a_Address);

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -474,7 +474,7 @@ ErrorMessageOr<void> OrbitApp::OnSavePreset(const std::string& filename) {
 
 ErrorMessageOr<void> OrbitApp::SavePreset(const std::string& filename) {
   PresetInfo preset;
-  const int32_t pid = m_ProcessesDataView->GetSelectedProcessId();
+  const int32_t pid = processes_data_view_->GetSelectedProcessId();
   const std::shared_ptr<Process>& process = FindProcessByPid(pid);
   preset.set_process_full_path(
       data_manager_->GetProcessByPid(pid)->full_path());
@@ -586,7 +586,7 @@ void OrbitApp::FireRefreshCallbacks(DataViewType type) {
 }
 
 bool OrbitApp::StartCapture() {
-  int32_t pid = m_ProcessesDataView->GetSelectedProcessId();
+  int32_t pid = processes_data_view_->GetSelectedProcessId();
   std::string process_name = data_manager_->GetProcessByPid(pid)->name();
   absl::flat_hash_map<uint64_t, FunctionInfo> selected_functions =
       GetSelectedFunctionsAndOrbitFunctions();

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -497,14 +497,12 @@ ErrorMessageOr<void> OrbitApp::SavePreset(const std::string& filename) {
   std::ofstream file(filename_with_ext, std::ios::binary);
   if (file.fail()) {
     ERROR("Saving preset in \"%s\": %s", filename_with_ext, "file.fail()");
-    return ErrorMessage(absl::StrFormat("Error opening the file %s for writing",
-                                        filename_with_ext));
+    return ErrorMessage(absl::StrFormat(
+        "Error opening the file \"%s\" for writing", filename_with_ext));
   }
 
-  {
-    LOG("Saving preset in \"%s\"", filename_with_ext);
-    preset.SerializeToOstream(&file);
-  }
+  LOG("Saving preset in \"%s\"", filename_with_ext);
+  preset.SerializeToOstream(&file);
 
   return outcome::success();
 }
@@ -616,7 +614,7 @@ OrbitApp::GetSelectedFunctionsAndOrbitFunctions() const {
   for (const auto& func : Capture::GTargetProcess->GetFunctions()) {
     if (IsFunctionSelected(*func) || FunctionUtils::IsOrbitFunc(*func)) {
       uint64_t address = FunctionUtils::GetAbsoluteAddress(*func);
-      selected_functions[address] = *(func.get());
+      selected_functions[address] = *func;
     }
   }
   return selected_functions;

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -220,6 +220,15 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   [[nodiscard]] MainThreadExecutor* GetMainThreadExecutor() {
     return main_thread_executor_.get();
   }
+  [[nodiscard]] std::shared_ptr<Process> FindProcessByPid(int32_t pid);
+
+  // TODO(kuebler): Move them to a separate controler at some point
+  void SelectFunction(const orbit_client_protos::FunctionInfo& func);
+  void UnSelectFunction(const orbit_client_protos::FunctionInfo& func);
+  void ClearSelectedFunctions();
+  [[nodiscard]] bool IsFunctionSelected(
+      const orbit_client_protos::FunctionInfo& func) const;
+  [[nodiscard]] bool IsFunctionSelected(const SampledFunction& func) const;
 
  private:
   void LoadModuleOnRemote(
@@ -228,10 +237,13 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void SymbolLoadingFinished(
       uint32_t process_id, const std::shared_ptr<Module>& module,
       const std::shared_ptr<orbit_client_protos::PresetFile>& preset);
-  std::shared_ptr<Process> FindProcessByPid(int32_t pid);
 
   ErrorMessageOr<orbit_client_protos::PresetInfo> ReadPresetFromFile(
       const std::string& filename);
+
+  [[nodiscard]] absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>
+  GetSelectedFunctionsAndOrbitFunctions() const;
+  ErrorMessageOr<void> SavePreset(const std::string& filename);
 
   ApplicationOptions options_;
 

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -224,7 +224,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
 
   // TODO(kuebler): Move them to a separate controler at some point
   void SelectFunction(const orbit_client_protos::FunctionInfo& func);
-  void UnSelectFunction(const orbit_client_protos::FunctionInfo& func);
+  void DeselectFunction(const orbit_client_protos::FunctionInfo& func);
   void ClearSelectedFunctions();
   [[nodiscard]] bool IsFunctionSelected(
       const orbit_client_protos::FunctionInfo& func) const;

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -137,7 +137,7 @@ void CallStackDataView::OnContextMenu(const std::string& action, int menu_index,
     for (int i : item_indices) {
       CallStackDataViewFrame frame = GetFrameFromRow(i);
       FunctionInfo* function = frame.function;
-      GOrbitApp->UnSelectFunction(*function);
+      GOrbitApp->DeselectFunction(*function);
     }
 
   } else if (action == kMenuActionDisassembly) {

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -46,7 +46,7 @@ std::string CallStackDataView::GetValue(int row, int column) {
 
   switch (column) {
     case kColumnSelected:
-      return (function != nullptr && FunctionUtils::IsSelected(*function))
+      return (function != nullptr && GOrbitApp->IsFunctionSelected(*function))
                  ? "X"
                  : "-";
     case kColumnName:
@@ -97,8 +97,8 @@ std::vector<std::string> CallStackDataView::GetContextMenu(
     Module* module = frame.module.get();
 
     if (frame.function != nullptr) {
-      enable_select |= !FunctionUtils::IsSelected(*function);
-      enable_unselect |= FunctionUtils::IsSelected(*function);
+      enable_select |= !GOrbitApp->IsFunctionSelected(*function);
+      enable_unselect |= GOrbitApp->IsFunctionSelected(*function);
       enable_disassembly = true;
     } else if (module != nullptr && module->IsLoadable() &&
                !module->IsLoaded()) {
@@ -130,14 +130,14 @@ void CallStackDataView::OnContextMenu(const std::string& action, int menu_index,
     for (int i : item_indices) {
       CallStackDataViewFrame frame = GetFrameFromRow(i);
       FunctionInfo* function = frame.function;
-      FunctionUtils::Select(function);
+      GOrbitApp->SelectFunction(*function);
     }
 
   } else if (action == kMenuActionUnselect) {
     for (int i : item_indices) {
       CallStackDataViewFrame frame = GetFrameFromRow(i);
       FunctionInfo* function = frame.function;
-      FunctionUtils::UnSelect(function);
+      GOrbitApp->UnSelectFunction(*function);
     }
 
   } else if (action == kMenuActionDisassembly) {

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -696,7 +696,6 @@ void CaptureWindow::RenderUI() {
     m_StatsWindow.AddLine(VAR_TO_STR(m_WorldMinWidth));
     m_StatsWindow.AddLine(VAR_TO_STR(m_MouseX));
     m_StatsWindow.AddLine(VAR_TO_STR(m_MouseY));
-    m_StatsWindow.AddLine(VAR_TO_STR(Capture::GSelectedFunctionsMap.size()));
     m_StatsWindow.AddLine(VAR_TO_STR(Capture::GVisibleFunctionsMap.size()));
     m_StatsWindow.AddLine(VAR_TO_STR(time_graph_.GetNumDrawnTextBoxes()));
     m_StatsWindow.AddLine(VAR_TO_STR(time_graph_.GetNumTimers()));

--- a/OrbitGl/DataManager.cpp
+++ b/OrbitGl/DataManager.cpp
@@ -42,7 +42,7 @@ void DataManager::SelectFunction(uint64_t function_address) {
   selected_functions_.insert(function_address);
 }
 
-void DataManager::UnSelectFunction(uint64_t function_address) {
+void DataManager::DeselectFunction(uint64_t function_address) {
   CHECK(std::this_thread::get_id() == main_thread_id_);
   CHECK(selected_functions_.contains(function_address));
   selected_functions_.erase(function_address);

--- a/OrbitGl/DataManager.h
+++ b/OrbitGl/DataManager.h
@@ -25,7 +25,7 @@ class DataManager final {
                          const std::vector<ModuleInfo>& module_infos);
 
   void SelectFunction(uint64_t function_address);
-  void UnSelectFunction(uint64_t function_address);
+  void DeselectFunction(uint64_t function_address);
   void ClearSelectedFunctions();
   void set_selected_functions(absl::flat_hash_set<uint64_t> selected_functions);
 

--- a/OrbitGl/DataManager.h
+++ b/OrbitGl/DataManager.h
@@ -9,6 +9,7 @@
 
 #include "ProcessData.h"
 #include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
 
 // This class is responsible for storing and
 // navigating data on the client side. Note that
@@ -23,14 +24,23 @@ class DataManager final {
   void UpdateModuleInfos(int32_t process_id,
                          const std::vector<ModuleInfo>& module_infos);
 
-  ProcessData* GetProcessByPid(int32_t process_id);
-  const std::vector<ModuleData*>& GetModules(int32_t process_id);
-  ModuleData* FindModuleByAddressStart(int32_t process_id,
-                                       uint64_t address_start);
+  void SelectFunction(uint64_t function_address);
+  void UnSelectFunction(uint64_t function_address);
+  void ClearSelectedFunctions();
+  void set_selected_functions(absl::flat_hash_set<uint64_t> selected_functions);
+
+  [[nodiscard]] ProcessData* GetProcessByPid(int32_t process_id) const;
+  [[nodiscard]] const std::vector<ModuleData*>& GetModules(
+      int32_t process_id) const;
+  [[nodiscard]] ModuleData* FindModuleByAddressStart(
+      int32_t process_id, uint64_t address_start) const;
+  [[nodiscard]] bool IsFunctionSelected(uint64_t function_address) const;
+  [[nodiscard]] const absl::flat_hash_set<uint64_t>& selected_functions() const;
 
  private:
   const std::thread::id main_thread_id_;
   absl::flat_hash_map<int32_t, std::unique_ptr<ProcessData>> process_map_;
+  absl::flat_hash_set<uint64_t> selected_functions_;
 };
 
 #endif  // ORBIT_GL_DATA_MANAGER_H_

--- a/OrbitGl/FunctionsDataView.cpp
+++ b/OrbitGl/FunctionsDataView.cpp
@@ -150,7 +150,7 @@ void FunctionsDataView::OnContextMenu(const std::string& action, int menu_index,
     }
   } else if (action == kMenuActionUnselect) {
     for (int i : item_indices) {
-      GOrbitApp->UnSelectFunction(GetFunction(i));
+      GOrbitApp->DeselectFunction(GetFunction(i));
     }
   } else if (action == kMenuActionDisassembly) {
     int32_t pid = Capture::GTargetProcess->GetID();

--- a/OrbitGl/FunctionsDataView.cpp
+++ b/OrbitGl/FunctionsDataView.cpp
@@ -39,11 +39,11 @@ std::string FunctionsDataView::GetValue(int row, int column) {
     return "";
   }
 
-  FunctionInfo& function = GetFunction(row);
+  const FunctionInfo& function = GetFunction(row);
 
   switch (column) {
     case kColumnSelected:
-      return FunctionUtils::IsSelected(function) ? "X" : "-";
+      return GOrbitApp->IsFunctionSelected(function) ? "X" : "-";
     case kColumnName:
       return FunctionUtils::GetDisplayName(function);
     case kColumnSize:
@@ -90,7 +90,7 @@ void FunctionsDataView::DoSort() {
 
   switch (sorting_column_) {
     case kColumnSelected:
-      sorter = ORBIT_CUSTOM_FUNC_SORT(FunctionUtils::IsSelected);
+      sorter = ORBIT_CUSTOM_FUNC_SORT(GOrbitApp->IsFunctionSelected);
       break;
     case kColumnName:
       sorter = ORBIT_CUSTOM_FUNC_SORT(FunctionUtils::GetDisplayName);
@@ -130,8 +130,8 @@ std::vector<std::string> FunctionsDataView::GetContextMenu(
   bool enable_unselect = false;
   for (int index : selected_indices) {
     const FunctionInfo& function = GetFunction(index);
-    enable_select |= !FunctionUtils::IsSelected(function);
-    enable_unselect |= FunctionUtils::IsSelected(function);
+    enable_select |= !GOrbitApp->IsFunctionSelected(function);
+    enable_unselect |= GOrbitApp->IsFunctionSelected(function);
   }
 
   std::vector<std::string> menu;
@@ -146,11 +146,11 @@ void FunctionsDataView::OnContextMenu(const std::string& action, int menu_index,
                                       const std::vector<int>& item_indices) {
   if (action == kMenuActionSelect) {
     for (int i : item_indices) {
-      FunctionUtils::Select(&GetFunction(i));
+      GOrbitApp->SelectFunction(GetFunction(i));
     }
   } else if (action == kMenuActionUnselect) {
     for (int i : item_indices) {
-      FunctionUtils::UnSelect(&GetFunction(i));
+      GOrbitApp->UnSelectFunction(GetFunction(i));
     }
   } else if (action == kMenuActionDisassembly) {
     int32_t pid = Capture::GTargetProcess->GetID();

--- a/OrbitGl/LiveFunctionsDataView.cpp
+++ b/OrbitGl/LiveFunctionsDataView.cpp
@@ -202,7 +202,7 @@ void LiveFunctionsDataView::OnContextMenu(
   } else if (action == kMenuActionUnselect) {
     for (int i : item_indices) {
       FunctionInfo* function = GetFunction(i);
-      GOrbitApp->UnSelectFunction(*function);
+      GOrbitApp->DeselectFunction(*function);
     }
   } else if (action == kMenuActionDisassembly) {
     int32_t pid = Capture::GTargetProcess->GetID();
@@ -304,7 +304,7 @@ void LiveFunctionsDataView::OnDataChanged() {
   for (const auto& pair : selected_functions) {
     functions_.push_back(pair.second);
     indices_[i] = i;
-    i++;
+    ++i;
   }
 
   DataView::OnDataChanged();

--- a/OrbitGl/LiveFunctionsDataView.cpp
+++ b/OrbitGl/LiveFunctionsDataView.cpp
@@ -54,7 +54,7 @@ std::string LiveFunctionsDataView::GetValue(int row, int column) {
 
   switch (column) {
     case kColumnSelected:
-      return FunctionUtils::IsSelected(function) ? "X" : "-";
+      return GOrbitApp->IsFunctionSelected(function) ? "X" : "-";
     case kColumnName:
       return FunctionUtils::GetDisplayName(function);
     case kColumnCount:
@@ -77,36 +77,36 @@ std::string LiveFunctionsDataView::GetValue(int row, int column) {
   }
 }
 
-#define ORBIT_FUNC_SORT(Member)                                            \
-  [&](int a, int b) {                                                      \
-    return OrbitUtils::Compare(functions[a]->Member, functions[b]->Member, \
-                               ascending);                                 \
+#define ORBIT_FUNC_SORT(Member)                                          \
+  [&](int a, int b) {                                                    \
+    return OrbitUtils::Compare(functions[a].Member, functions[b].Member, \
+                               ascending);                               \
   }
 #define ORBIT_STAT_SORT(Member)                                            \
   [&](int a, int b) {                                                      \
     const FunctionStats& stats_a =                                         \
         Capture::capture_data_.GetFunctionStatsOrDefault(                  \
-            functions[a]->address());                                      \
+            functions[a].address());                                       \
     const FunctionStats& stats_b =                                         \
         Capture::capture_data_.GetFunctionStatsOrDefault(                  \
-            functions[b]->address());                                      \
+            functions[b].address());                                       \
     return OrbitUtils::Compare(stats_a.Member, stats_b.Member, ascending); \
   }
-#define ORBIT_CUSTOM_FUNC_SORT(Func)                                     \
-  [&](int a, int b) {                                                    \
-    return OrbitUtils::Compare(Func(*functions[a]), Func(*functions[b]), \
-                               ascending);                               \
+#define ORBIT_CUSTOM_FUNC_SORT(Func)                                   \
+  [&](int a, int b) {                                                  \
+    return OrbitUtils::Compare(Func(functions[a]), Func(functions[b]), \
+                               ascending);                             \
   }
 
 void LiveFunctionsDataView::DoSort() {
   bool ascending = sorting_orders_[sorting_column_] == SortingOrder::kAscending;
   std::function<bool(int a, int b)> sorter = nullptr;
 
-  const std::vector<std::shared_ptr<FunctionInfo>>& functions = functions_;
+  const std::vector<FunctionInfo>& functions = functions_;
 
   switch (sorting_column_) {
     case kColumnSelected:
-      sorter = ORBIT_CUSTOM_FUNC_SORT(FunctionUtils::IsSelected);
+      sorter = ORBIT_CUSTOM_FUNC_SORT(GOrbitApp->IsFunctionSelected);
       break;
     case kColumnName:
       sorter = ORBIT_CUSTOM_FUNC_SORT(FunctionUtils::GetDisplayName);
@@ -162,8 +162,8 @@ std::vector<std::string> LiveFunctionsDataView::GetContextMenu(
     const FunctionInfo& function = *GetFunction(index);
     const FunctionStats& stats =
         Capture::capture_data_.GetFunctionStatsOrDefault(function.address());
-    enable_select |= !FunctionUtils::IsSelected(function);
-    enable_unselect |= FunctionUtils::IsSelected(function);
+    enable_select |= !GOrbitApp->IsFunctionSelected(function);
+    enable_unselect |= GOrbitApp->IsFunctionSelected(function);
     enable_iterator |= stats.count() > 0;
   }
 
@@ -197,12 +197,12 @@ void LiveFunctionsDataView::OnContextMenu(
   if (action == kMenuActionSelect) {
     for (int i : item_indices) {
       FunctionInfo* function = GetFunction(i);
-      FunctionUtils::Select(function);
+      GOrbitApp->SelectFunction(*function);
     }
   } else if (action == kMenuActionUnselect) {
     for (int i : item_indices) {
       FunctionInfo* function = GetFunction(i);
-      FunctionUtils::UnSelect(function);
+      GOrbitApp->UnSelectFunction(*function);
     }
   } else if (action == kMenuActionDisassembly) {
     int32_t pid = Capture::GTargetProcess->GetID();
@@ -262,22 +262,20 @@ void LiveFunctionsDataView::DoFilter() {
   std::vector<std::string> tokens = absl::StrSplit(ToLower(filter_), ' ');
 
   for (size_t i = 0; i < functions_.size(); ++i) {
-    const std::shared_ptr<FunctionInfo> function = functions_[i];
-    if (function != nullptr) {
-      std::string name = ToLower(FunctionUtils::GetDisplayName(*function));
+    const FunctionInfo& function = functions_[i];
+    std::string name = ToLower(FunctionUtils::GetDisplayName(function));
 
-      bool match = true;
+    bool match = true;
 
-      for (std::string& filter_token : tokens) {
-        if (name.find(filter_token) == std::string::npos) {
-          match = false;
-          break;
-        }
+    for (std::string& filter_token : tokens) {
+      if (name.find(filter_token) == std::string::npos) {
+        match = false;
+        break;
       }
+    }
 
-      if (match) {
-        indices.push_back(i);
-      }
+    if (match) {
+      indices.push_back(i);
     }
   }
 
@@ -290,7 +288,7 @@ void LiveFunctionsDataView::DoFilter() {
   for (size_t i = 0; i < indices_.size(); ++i) {
     FunctionInfo* func = GetFunction(i);
     Capture::GVisibleFunctionsMap[FunctionUtils::GetAbsoluteAddress(*func)] =
-        func;
+        *func;
   }
 
   GOrbitApp->NeedsRedraw();
@@ -298,13 +296,15 @@ void LiveFunctionsDataView::DoFilter() {
 
 void LiveFunctionsDataView::OnDataChanged() {
   functions_.clear();
-  const std::vector<std::shared_ptr<orbit_client_protos::FunctionInfo>>&
+  const absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>&
       selected_functions = Capture::capture_data_.selected_functions();
   size_t functions_count = selected_functions.size();
   indices_.resize(functions_count);
-  for (size_t i = 0; i < functions_count; ++i) {
+  size_t i = 0;
+  for (const auto& pair : selected_functions) {
+    functions_.push_back(pair.second);
     indices_[i] = i;
-    functions_.push_back(selected_functions[i]);
+    i++;
   }
 
   DataView::OnDataChanged();
@@ -316,10 +316,9 @@ void LiveFunctionsDataView::OnTimer() {
   }
 }
 
-FunctionInfo* LiveFunctionsDataView::GetFunction(unsigned int row) const {
+FunctionInfo* LiveFunctionsDataView::GetFunction(unsigned int row) {
   CHECK(row < functions_.size());
-  CHECK(functions_[indices_[row]]);
-  return functions_[indices_[row]].get();
+  return &(functions_[indices_[row]]);
 }
 
 std::pair<TextBox*, TextBox*> LiveFunctionsDataView::GetMinMax(

--- a/OrbitGl/LiveFunctionsDataView.h
+++ b/OrbitGl/LiveFunctionsDataView.h
@@ -29,11 +29,11 @@ class LiveFunctionsDataView : public DataView {
  protected:
   void DoFilter() override;
   void DoSort() override;
-  orbit_client_protos::FunctionInfo* GetFunction(unsigned int row) const;
-  std::pair<TextBox*, TextBox*> GetMinMax(
+  [[nodiscard]] orbit_client_protos::FunctionInfo* GetFunction(unsigned int row);
+  [[nodiscard]] std::pair<TextBox*, TextBox*> GetMinMax(
       const orbit_client_protos::FunctionInfo& function) const;
 
-  std::vector<std::shared_ptr<orbit_client_protos::FunctionInfo>> functions_;
+  std::vector<orbit_client_protos::FunctionInfo> functions_;
 
   LiveFunctionsController* live_functions_;
 

--- a/OrbitGl/LiveFunctionsDataView.h
+++ b/OrbitGl/LiveFunctionsDataView.h
@@ -29,7 +29,8 @@ class LiveFunctionsDataView : public DataView {
  protected:
   void DoFilter() override;
   void DoSort() override;
-  [[nodiscard]] orbit_client_protos::FunctionInfo* GetFunction(unsigned int row);
+  [[nodiscard]] orbit_client_protos::FunctionInfo* GetFunction(
+      unsigned int row);
   [[nodiscard]] std::pair<TextBox*, TextBox*> GetMinMax(
       const orbit_client_protos::FunctionInfo& function) const;
 

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -204,7 +204,7 @@ void SamplingReportDataView::OnContextMenu(
     }
   } else if (action == kMenuActionUnselect) {
     for (FunctionInfo* function : GetFunctionsFromIndices(item_indices)) {
-      GOrbitApp->UnSelectFunction(*function);
+      GOrbitApp->DeselectFunction(*function);
     }
   } else if (action == kMenuActionLoadSymbols) {
     std::vector<std::shared_ptr<Module>> modules;

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -38,11 +38,11 @@ const std::vector<DataView::Column>& SamplingReportDataView::GetColumns() {
 }
 
 std::string SamplingReportDataView::GetValue(int row, int column) {
-  SampledFunction& func = GetSampledFunction(row);
+  const SampledFunction& func = GetSampledFunction(row);
 
   switch (column) {
     case kColumnSelected:
-      return FunctionUtils::IsSelected(func) ? "X" : "-";
+      return GOrbitApp->IsFunctionSelected(func) ? "X" : "-";
     case kColumnFunctionName:
       return func.name;
     case kColumnExclusive:
@@ -82,7 +82,7 @@ void SamplingReportDataView::DoSort() {
 
   switch (sorting_column_) {
     case kColumnSelected:
-      sorter = ORBIT_CUSTOM_FUNC_SORT(FunctionUtils::IsSelected);
+      sorter = ORBIT_CUSTOM_FUNC_SORT(GOrbitApp->IsFunctionSelected);
       break;
     case kColumnFunctionName:
       sorter = ORBIT_PROC_SORT(name);
@@ -175,8 +175,8 @@ std::vector<std::string> SamplingReportDataView::GetContextMenu(
   bool enable_disassembly = !selected_functions.empty();
 
   for (const FunctionInfo* function : selected_functions) {
-    enable_select |= !FunctionUtils::IsSelected(*function);
-    enable_unselect |= FunctionUtils::IsSelected(*function);
+    enable_select |= !GOrbitApp->IsFunctionSelected(*function);
+    enable_unselect |= GOrbitApp->IsFunctionSelected(*function);
   }
 
   bool enable_load = false;
@@ -200,11 +200,11 @@ void SamplingReportDataView::OnContextMenu(
     const std::vector<int>& item_indices) {
   if (action == kMenuActionSelect) {
     for (FunctionInfo* function : GetFunctionsFromIndices(item_indices)) {
-      FunctionUtils::Select(function);
+      GOrbitApp->SelectFunction(*function);
     }
   } else if (action == kMenuActionUnselect) {
     for (FunctionInfo* function : GetFunctionsFromIndices(item_indices)) {
-      FunctionUtils::UnSelect(function);
+      GOrbitApp->UnSelectFunction(*function);
     }
   } else if (action == kMenuActionLoadSymbols) {
     std::vector<std::shared_ptr<Module>> modules;

--- a/OrbitGl/TextBox.cpp
+++ b/OrbitGl/TextBox.cpp
@@ -117,7 +117,6 @@ void TextBox::Draw(Batcher* batcher, TextRenderer& a_TextRenderer, float a_MinX,
     const FunctionInfo* func = Capture::capture_data_.GetSelectedFunction(
         timer_info_.function_address());
     CHECK(func != nullptr);
-    CHECK(func != nullptr);
     std::string text = absl::StrFormat(
         "%s %s", func ? FunctionUtils::GetDisplayName(*func).c_str() : "",
         m_Text.c_str());

--- a/OrbitGl/TextBox.cpp
+++ b/OrbitGl/TextBox.cpp
@@ -4,6 +4,7 @@
 
 #include "TextBox.h"
 
+#include "App.h"
 #include "Capture.h"
 #include "FunctionUtils.h"
 #include "GlCanvas.h"
@@ -91,8 +92,8 @@ void TextBox::Draw(Batcher* batcher, TextRenderer& a_TextRenderer, float a_MinX,
   }
 
   float z = a_IsHighlighted ? GlCanvas::Z_VALUE_CONTEXT_SWITCH
-                            : isInactive ? GlCanvas::Z_VALUE_BOX_INACTIVE
-                                         : GlCanvas::Z_VALUE_BOX_ACTIVE;
+            : isInactive    ? GlCanvas::Z_VALUE_BOX_INACTIVE
+                            : GlCanvas::Z_VALUE_BOX_ACTIVE;
 
   Color color = col;
   if (a_IsPicking) {
@@ -113,8 +114,10 @@ void TextBox::Draw(Batcher* batcher, TextRenderer& a_TextRenderer, float a_MinX,
 
     float maxSize = m_Pos[0] + m_Size[0] - posX;
 
-    FunctionInfo* func =
-        Capture::GSelectedFunctionsMap[timer_info_.function_address()];
+    const FunctionInfo* func = Capture::capture_data_.GetSelectedFunction(
+        timer_info_.function_address());
+    CHECK(func != nullptr);
+    CHECK(func != nullptr);
     std::string text = absl::StrFormat(
         "%s %s", func ? FunctionUtils::GetDisplayName(*func).c_str() : "",
         m_Text.c_str());

--- a/OrbitGl/TextBox.cpp
+++ b/OrbitGl/TextBox.cpp
@@ -92,8 +92,8 @@ void TextBox::Draw(Batcher* batcher, TextRenderer& a_TextRenderer, float a_MinX,
   }
 
   float z = a_IsHighlighted ? GlCanvas::Z_VALUE_CONTEXT_SWITCH
-            : isInactive    ? GlCanvas::Z_VALUE_BOX_INACTIVE
-                            : GlCanvas::Z_VALUE_BOX_ACTIVE;
+                            : isInactive ? GlCanvas::Z_VALUE_BOX_INACTIVE
+                                         : GlCanvas::Z_VALUE_BOX_ACTIVE;
 
   Color color = col;
   if (a_IsPicking) {

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -4,6 +4,7 @@
 
 #include "ThreadTrack.h"
 
+#include "App.h"
 #include "Capture.h"
 #include "FunctionUtils.h"
 #include "GlCanvas.h"
@@ -45,23 +46,24 @@ std::string ThreadTrack::GetBoxTooltip(PickingId id) const {
     return "";
   }
 
-  FunctionInfo* func = Capture::GSelectedFunctionsMap[text_box->GetTimerInfo()
-                                                          .function_address()];
+  const FunctionInfo* func = Capture::capture_data_.GetSelectedFunction(
+      text_box->GetTimerInfo().function_address());
+  CHECK(func != nullptr);
+
   if (!func) {
     return text_box->GetText();
   }
 
   return absl::StrFormat(
-    "<b>%s</b><br/>"
-    "<i>Timing measured through dynamic instrumentation</i>"
-    "<br/><br/>"
-    "<b>Module:</b> %s<br/>"
-    "<b>Time:</b> %s",
-    FunctionUtils::GetDisplayName(*func),
-    FunctionUtils::GetLoadedModuleName(*func),
-    GetPrettyTime(TicksToDuration(text_box->GetTimerInfo().start(),
-                                  text_box->GetTimerInfo().end()))
-  );
+      "<b>%s</b><br/>"
+      "<i>Timing measured through dynamic instrumentation</i>"
+      "<br/><br/>"
+      "<b>Module:</b> %s<br/>"
+      "<b>Time:</b> %s",
+      FunctionUtils::GetDisplayName(*func),
+      FunctionUtils::GetLoadedModuleName(*func),
+      GetPrettyTime(TicksToDuration(text_box->GetTimerInfo().start(),
+                                    text_box->GetTimerInfo().end())));
 }
 
 bool ThreadTrack::IsTimerActive(const TimerInfo& timer_info) const {
@@ -69,7 +71,8 @@ bool ThreadTrack::IsTimerActive(const TimerInfo& timer_info) const {
          Capture::GVisibleFunctionsMap.end();
 }
 
-Color ThreadTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected) const {
+Color ThreadTrack::GetTimerColor(const TimerInfo& timer_info,
+                                 bool is_selected) const {
   const Color kInactiveColor(100, 100, 100, 255);
   const Color kSelectionColor(0, 128, 255, 255);
   if (is_selected) {
@@ -126,8 +129,9 @@ void ThreadTrack::SetTimesliceText(const TimerInfo& timer_info,
   TimeGraphLayout layout = time_graph_->GetLayout();
   if (text_box->GetText().empty()) {
     std::string time = GetPrettyTime(absl::Microseconds(elapsed_us));
-    FunctionInfo* func =
-        Capture::GSelectedFunctionsMap[timer_info.function_address()];
+    const FunctionInfo* func = Capture::capture_data_.GetSelectedFunction(
+        timer_info.function_address());
+    CHECK(func != nullptr);
 
     text_box->SetElapsedTimeTextLength(time.length());
 

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -131,7 +131,6 @@ void ThreadTrack::SetTimesliceText(const TimerInfo& timer_info,
     std::string time = GetPrettyTime(absl::Microseconds(elapsed_us));
     const FunctionInfo* func = Capture::capture_data_.GetSelectedFunction(
         timer_info.function_address());
-    CHECK(func != nullptr);
 
     text_box->SetElapsedTimeTextLength(time.length());
 


### PR DESCRIPTION
The GSelectedFunctionsMap global was previously used from various
places assuming different semantics, which already lead to bugs.
In order to get rid of the globals in Capture and make accesses
to the data stored there more explicit, this change moves the map
to OrbitGl/DataManager and passes it explicitly as input to OrbitCore.

This map represents the current state of the running application,
i.e. wich functions are currently hooked and is not related to the
functions hooked in the previous/loaded capture.
Now this map also stores a copy of the FunctionInfo content, to
avoid nullptrs. Making all maps to store raw pointers is unfeasable,
as there is no dedicated owner of these functions, when loading a
capture (otherwise it would be the process's module).
All accessor methods (in particual to select/unselect/check functions)
are moved to App.

Some usages were replaced with the intended selected functions from the
previous capture (i.e. in CaptureData).

Added [[nodiscard]] and const on various places.

Bug: http://b/163020637
Test: Load Modules, Hook/Unhook functions, do captures, load/store captures,
      load/store presets, repeat captures while/after hooking/unhooking function,
      filter functions.