### PR TITLE
Include local target process in ClientGgp

### DIFF
--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -60,7 +60,7 @@ bool ClientGgp::RequestStartCapture(ThreadPool* thread_pool) {
     ERROR("Error starting capture: %s", result.error().message());
     return false;
   }
-  int32_t pid = Capture::GTargetProcess->GetID();
+  int32_t pid = target_process->GetID();
   LOG("Capture pid %d", pid);
 
   // TODO: selected_functions available when UploadSymbols is included
@@ -81,9 +81,10 @@ bool ClientGgp::StopCapture() {
 
 void ClientGgp::InitCapture() {
   Capture::Init();
-  std::shared_ptr<Process> process = GetOrbitProcessByPid(options_.capture_pid);
-  CHECK(process != nullptr);
-  Capture::SetTargetProcess(std::move(process));
+  target_process = GetOrbitProcessByPid(options_.capture_pid);
+  CHECK(target_process != nullptr);
+  // TODO: remove this line when GTargetProcess is deprecated in Capture
+  Capture::SetTargetProcess(target_process);
 }
 
 // CaptureListener implementation

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -60,7 +60,7 @@ bool ClientGgp::RequestStartCapture(ThreadPool* thread_pool) {
     ERROR("Error starting capture: %s", result.error().message());
     return false;
   }
-  int32_t pid = target_process->GetID();
+  int32_t pid = target_process_->GetID();
   LOG("Capture pid %d", pid);
 
   // TODO: selected_functions available when UploadSymbols is included
@@ -81,10 +81,10 @@ bool ClientGgp::StopCapture() {
 
 void ClientGgp::InitCapture() {
   Capture::Init();
-  target_process = GetOrbitProcessByPid(options_.capture_pid);
-  CHECK(target_process != nullptr);
+  target_process_ = GetOrbitProcessByPid(options_.capture_pid);
+  CHECK(target_process_ != nullptr);
   // TODO: remove this line when GTargetProcess is deprecated in Capture
-  Capture::SetTargetProcess(target_process);
+  Capture::SetTargetProcess(target_process_);
 }
 
 // CaptureListener implementation

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -38,6 +38,7 @@ class ClientGgp final : public CaptureListener {
  private:
   ClientGgpOptions options_;
   std::shared_ptr<grpc::Channel> grpc_channel_;
+  std::shared_ptr<Process> target_process;
   std::unique_ptr<CaptureClient> capture_client_;
 
   void InitCapture();

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -38,7 +38,7 @@ class ClientGgp final : public CaptureListener {
  private:
   ClientGgpOptions options_;
   std::shared_ptr<grpc::Channel> grpc_channel_;
-  std::shared_ptr<Process> target_process;
+  std::shared_ptr<Process> target_process_;
   std::unique_ptr<CaptureClient> capture_client_;
 
   void InitCapture();


### PR DESCRIPTION
GTargetProcess in Capture is going to dissapear so this code prepares the ggp client to handle the target process itself.