### PR TITLE
Multi-pass capabilities for the batcher

### DIFF
--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -9,8 +9,7 @@
 
 void Batcher::AddLine(Vec2 from, Vec2 to, float z, const Color& color,
                       std::unique_ptr<PickingUserData> user_data) {
-  Color picking_color =
-      PickingId::ToColor(PickingType::kLine, user_data_.size(), batcher_id_);
+  Color picking_color = PickingId::ToColor(PickingType::kLine, user_data_.size(), batcher_id_);
 
   AddLine(from, to, z, color, picking_color, std::move(user_data));
 }
@@ -43,8 +42,7 @@ void Batcher::AddLine(Vec2 from, Vec2 to, float z, const Color& color, const Col
 
 void Batcher::AddBox(const Box& box, const std::array<Color, 4>& colors,
                      std::unique_ptr<PickingUserData> user_data) {
-  Color picking_color =
-      PickingId::ToColor(PickingType::kBox, user_data_.size(), batcher_id_);
+  Color picking_color = PickingId::ToColor(PickingType::kBox, user_data_.size(), batcher_id_);
   AddBox(box, colors, picking_color, std::move(user_data));
 }
 
@@ -83,8 +81,7 @@ void Batcher::AddBox(const Box& box, const std::array<Color, 4>& colors, const C
 
 void Batcher::AddTriangle(const Triangle& triangle, const Color& color,
                           std::unique_ptr<PickingUserData> user_data) {
-  Color picking_color = PickingId::ToColor(PickingType::kTriangle,
-                                           user_data_.size(), batcher_id_);
+  Color picking_color = PickingId::ToColor(PickingType::kTriangle, user_data_.size(), batcher_id_);
 
   AddTriangle(triangle, color, picking_color, std::move(user_data));
 }

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -28,14 +28,12 @@ struct LineBuffer {
     lines_.Reset();
     colors_.Reset();
     picking_colors_.Reset();
-    user_data_.clear();
   }
 
   static const int NUM_LINES_PER_BLOCK = 64 * 1024;
   BlockChain<Line, NUM_LINES_PER_BLOCK> lines_;
   BlockChain<Color, 2 * NUM_LINES_PER_BLOCK> colors_;
   BlockChain<Color, 2 * NUM_LINES_PER_BLOCK> picking_colors_;
-  std::vector<std::unique_ptr<PickingUserData>> user_data_;
 };
 
 struct BoxBuffer {
@@ -43,14 +41,12 @@ struct BoxBuffer {
     boxes_.Reset();
     colors_.Reset();
     picking_colors_.Reset();
-    user_data_.clear();
   }
 
   static const int NUM_BOXES_PER_BLOCK = 64 * 1024;
   BlockChain<Box, NUM_BOXES_PER_BLOCK> boxes_;
   BlockChain<Color, 4 * NUM_BOXES_PER_BLOCK> colors_;
   BlockChain<Color, 4 * NUM_BOXES_PER_BLOCK> picking_colors_;
-  std::vector<std::unique_ptr<PickingUserData>> user_data_;
 };
 
 struct TriangleBuffer {
@@ -58,14 +54,12 @@ struct TriangleBuffer {
     triangles_.Reset();
     colors_.Reset();
     picking_colors_.Reset();
-    user_data_.clear();
   }
 
   static const int NUM_TRIANGLES_PER_BLOCK = 64 * 1024;
   BlockChain<Triangle, NUM_TRIANGLES_PER_BLOCK> triangles_;
   BlockChain<Color, 3 * NUM_TRIANGLES_PER_BLOCK> colors_;
   BlockChain<Color, 3 * NUM_TRIANGLES_PER_BLOCK> picking_colors_;
-  std::vector<std::unique_ptr<PickingUserData>> user_data_;
 };
 
 class Batcher {
@@ -99,7 +93,8 @@ class Batcher {
 
   virtual void Draw(bool picking = false) const;
 
-  void Reset();
+  void ResetElements();
+  void StartNewFrame();
 
   [[nodiscard]] PickingManager* GetPickingManager() { return picking_manager_; }
   void SetPickingManager(PickingManager* picking_manager) { picking_manager_ = picking_manager; }
@@ -128,6 +123,8 @@ class Batcher {
   LineBuffer line_buffer_;
   BoxBuffer box_buffer_;
   TriangleBuffer triangle_buffer_;
+
+  std::vector<std::unique_ptr<PickingUserData>> user_data_;
 };
 
 #endif

--- a/OrbitGl/BatcherTest.cpp
+++ b/OrbitGl/BatcherTest.cpp
@@ -196,12 +196,10 @@ TEST(Batcher, MultipleDrawCalls) {
   auto box_user_data = std::make_unique<PickingUserData>();
   box_user_data->custom_data_ = &box_custom_data;
 
-  batcher.AddLine(Vec2(0, 0), Vec2(1, 0), 0, Color(255, 255, 255, 255),
-                  std::move(line_user_data));
-  batcher.AddTriangle(Triangle(Vec3(0, 0, 0), Vec3(0, 1, 0), Vec3(1, 0, 0)),
-                      Color(0, 255, 0, 255), std::move(triangle_user_data));
-  batcher.AddBox(Box(Vec2(0, 0), Vec2(1, 1), 0), Color(255, 0, 0, 255),
-                 std::move(box_user_data));
+  batcher.AddLine(Vec2(0, 0), Vec2(1, 0), 0, Color(255, 255, 255, 255), std::move(line_user_data));
+  batcher.AddTriangle(Triangle(Vec3(0, 0, 0), Vec3(0, 1, 0), Vec3(1, 0, 0)), Color(0, 255, 0, 255),
+                      std::move(triangle_user_data));
+  batcher.AddBox(Box(Vec2(0, 0), Vec2(1, 1), 0), Color(255, 0, 0, 255), std::move(box_user_data));
 
   batcher.Draw(true);
 

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -374,7 +374,7 @@ void GlCanvas::Render(int a_Width, int a_Height) {
   }
 
   m_NeedsRedraw = false;
-  ui_batcher_.Reset();
+  ui_batcher_.StartNewFrame();
 
   ScopeImguiContext state(m_ImGuiContext);
 
@@ -398,7 +398,7 @@ void GlCanvas::Render(int a_Width, int a_Height) {
   // We have to draw everything collected in the batcher at this point,
   // as prepareScreenSpaceViewport() changes the coordinate system.
   ui_batcher_.Draw(GetPickingMode() != PickingMode::kNone);
-  ui_batcher_.Reset();
+  ui_batcher_.ResetElements();
 
   prepareScreenSpaceViewport();
 
@@ -410,7 +410,6 @@ void GlCanvas::Render(int a_Width, int a_Height) {
 
   // Draw remaining elements collected with the batcher.
   ui_batcher_.Draw(GetPickingMode() != PickingMode::kNone);
-  ui_batcher_.Reset();
 
   glFlush();
 

--- a/OrbitGl/PickingManager.h
+++ b/OrbitGl/PickingManager.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "CoreMath.h"
+#include "OrbitBase/Logging.h"
 #include "absl/base/casts.h"
 #include "absl/synchronization/mutex.h"
 
@@ -61,6 +62,7 @@ struct PickingId {
 
   [[nodiscard]] inline static PickingId Create(PickingType type, uint32_t element_id,
                                                BatcherId batcher_id = BatcherId::kTimeGraph) {
+    CHECK(element_id >> kElementIDBitSize == 0);
     PickingId result;
     result.type = type;
     result.element_id = element_id;

--- a/OrbitGl/PickingManagerTest.cpp
+++ b/OrbitGl/PickingManagerTest.cpp
@@ -38,7 +38,7 @@ TEST(PickingManager, BasicFunctionality) {
 
   PickingId invalid_id;
   invalid_id.type = PickingType::kPickable;
-  invalid_id.element_id = 0xdeadbeef;
+  invalid_id.element_id = 0xdead;
   ASSERT_TRUE(pm.GetPickableFromId(invalid_id).expired());
 
   invalid_id.type = PickingType::kLine;
@@ -121,4 +121,12 @@ TEST(PickingManager, RobustnessOnReset) {
   id = MockRenderPickingColor(col_vec);
 
   pickable.reset(new PickableMock());
+}
+
+TEST(PickingManager, Overflow) {
+  PickingId id;
+  ASSERT_DEATH(id = PickingId::Create(PickingType::kLine,
+                                      1 << PickingId::kElementIDBitSize),
+               "kElementIDBitSize");
+  UNUSED(id);
 }

--- a/OrbitGl/PickingManagerTest.cpp
+++ b/OrbitGl/PickingManagerTest.cpp
@@ -125,8 +125,7 @@ TEST(PickingManager, RobustnessOnReset) {
 
 TEST(PickingManager, Overflow) {
   PickingId id;
-  ASSERT_DEATH(id = PickingId::Create(PickingType::kLine,
-                                      1 << PickingId::kElementIDBitSize),
+  ASSERT_DEATH(id = PickingId::Create(PickingType::kLine, 1 << PickingId::kElementIDBitSize),
                "kElementIDBitSize");
   UNUSED(id);
 }

--- a/OrbitGl/PickingManagerTest.h
+++ b/OrbitGl/PickingManagerTest.h
@@ -32,7 +32,9 @@ class PickableMock : public Pickable {
 
 // Simulate "rendering" the picking color into a uint32_t target
 inline PickingId MockRenderPickingColor(const Color& col_vec) {
-  uint32_t col = absl::bit_cast<uint32_t, Color>(col_vec);
+  std::array<uint8_t, 4> color_values{col_vec[0], col_vec[1], col_vec[2],
+                                      col_vec[3]};
+  uint32_t col = absl::bit_cast<uint32_t>(color_values);
   PickingId picking_id = PickingId::FromPixelValue(col);
   return picking_id;
 }

--- a/OrbitGl/PickingManagerTest.h
+++ b/OrbitGl/PickingManagerTest.h
@@ -32,8 +32,7 @@ class PickableMock : public Pickable {
 
 // Simulate "rendering" the picking color into a uint32_t target
 inline PickingId MockRenderPickingColor(const Color& col_vec) {
-  std::array<uint8_t, 4> color_values{col_vec[0], col_vec[1], col_vec[2],
-                                      col_vec[3]};
+  std::array<uint8_t, 4> color_values{col_vec[0], col_vec[1], col_vec[2], col_vec[3]};
   uint32_t col = absl::bit_cast<uint32_t>(color_values);
   PickingId picking_id = PickingId::FromPixelValue(col);
   return picking_id;

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -77,7 +77,7 @@ void TimeGraph::SetFontSize(int a_FontSize) {
 void TimeGraph::Clear() {
   ScopeLock lock(m_Mutex);
 
-  m_Batcher.Reset();
+  m_Batcher.StartNewFrame();
   capture_min_timestamp_ = std::numeric_limits<TickType>::max();
   capture_max_timestamp_ = 0;
   m_ThreadCountMap.clear();
@@ -564,7 +564,7 @@ void TimeGraph::NeedsUpdate() {
 void TimeGraph::UpdatePrimitives(PickingMode picking_mode) {
   CHECK(string_manager_);
 
-  m_Batcher.Reset();
+  m_Batcher.StartNewFrame();
   m_TextRendererStatic.Clear();
 
   UpdateMaxTimeStamp(GEventTracer.GetEventBuffer().GetMaxTime());


### PR DESCRIPTION
Multiple calls to Batcher.Reset() in GlCanvas caused problems with 
accessing user_data that has been rendered in a previous pass.
This is now fixed as follows:

Each batcher stores it's user_data now independent of the actual
rendering primitives. Reset() accepts an additional parameter to
indicate that a new frame has started.

This way, a batcher can perform rendering multiple times during a frame
without loosing the user_data of primitives rendered in a previous
renderpass. Only one Reset(true) must be called each frame.

Added tests to reproduce the previous behavior and check for correct
behavior. Also added checks to the PickingId to discover potential overflows.