### PR TITLE
Fix failing nullptr CHECK

### DIFF
--- a/OrbitGl/TextBox.cpp
+++ b/OrbitGl/TextBox.cpp
@@ -30,7 +30,7 @@ TextBox::TextBox(const Vec2& a_Pos, const Vec2& a_Size,
                  const std::string& a_Text, const Color& a_Color)
     : m_Pos(a_Pos),
       m_Size(a_Size),
-      m_Text(a_Text),
+      text_(a_Text),
       m_Color(a_Color),
       m_MainFrameCounter(-1),
       m_Selected(false),
@@ -117,10 +117,9 @@ void TextBox::Draw(Batcher* batcher, TextRenderer& a_TextRenderer, float a_MinX,
 
     const FunctionInfo* func = Capture::capture_data_.GetSelectedFunction(
         timer_info_.function_address());
-    CHECK(func != nullptr);
-    std::string text = absl::StrFormat(
-        "%s %s", func ? FunctionUtils::GetDisplayName(*func).c_str() : "",
-        m_Text.c_str());
+    std::string function_name =
+        func != nullptr ? FunctionUtils::GetDisplayName(*func) : "";
+    std::string text = absl::StrFormat("%s %s", function_name, text_.c_str());
 
     if (!a_IsPicking && !isCoreActivity) {
       a_TextRenderer.AddText(

--- a/OrbitGl/TextBox.h
+++ b/OrbitGl/TextBox.h
@@ -69,10 +69,13 @@ class TextBox {
   Vec2 GetMin() const { return m_Min; }
   Vec2 GetMax() const { return m_Max; }
 
-  const std::string& GetText() const { return m_Text; }
-  void SetText(const std::string& a_Text) { m_Text = a_Text; }
+  const std::string& GetText() const { return text_; }
+  void SetText(const std::string& a_Text) { text_ = a_Text; }
 
   void SetTimerInfo(const orbit_client_protos::TimerInfo& timer_info) {
+    if (timer_info.end() == 0 && timer_info.start() == 0) {
+      return;
+    }
     timer_info_ = timer_info;
   }
   const orbit_client_protos::TimerInfo& GetTimerInfo() const {
@@ -113,7 +116,7 @@ class TextBox {
   Vec2 m_Size;
   Vec2 m_Min;
   Vec2 m_Max;
-  std::string m_Text;
+  std::string text_;
   Color m_Color;
   orbit_client_protos::TimerInfo timer_info_;
   int m_MainFrameCounter;


### PR DESCRIPTION
#1026 introduced a nullptr check for the function corresponding to textbox.
However, textbox is used to display also others then function timers.
The following case distinction (based on an implicit null check) uses empty
string for this case.

This makes the case distinction explicit and removed the CHECK, which was failing.
It also renames m_Text to text_.

Test: Hook some functions and while capturing left and right click in the capture
      window.