### PR TITLE
Move callstacks from SamplingProfiler to CaptureData

### DIFF
--- a/OrbitCaptureClient/CaptureEventProcessor.cpp
+++ b/OrbitCaptureClient/CaptureEventProcessor.cpp
@@ -202,7 +202,7 @@ uint64_t CaptureEventProcessor::GetCallstackHashAndSendToListenerIfNecessary(
 
   if (!callstack_hashes_seen_.contains(hash)) {
     callstack_hashes_seen_.emplace(hash);
-    capture_listener_->OnCallstack(cs);
+    capture_listener_->OnUniqueCallStack(cs);
   }
   return hash;
 }

--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
@@ -21,7 +21,7 @@ class CaptureListener {
 
   virtual void OnTimer(const orbit_client_protos::TimerInfo& timer_info) = 0;
   virtual void OnKeyAndString(uint64_t key, std::string str) = 0;
-  virtual void OnCallstack(CallStack callstack) = 0;
+  virtual void OnUniqueCallStack(CallStack callstack) = 0;
   virtual void OnCallstackEvent(orbit_client_protos::CallstackEvent callstack_event) = 0;
   virtual void OnThreadName(int32_t thread_id, std::string thread_name) = 0;
   virtual void OnAddressInfo(orbit_client_protos::LinuxAddressInfo address_info) = 0;

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -95,7 +95,7 @@ void ClientGgp::OnTimer(const orbit_client_protos::TimerInfo&) {}
 
 void ClientGgp::OnKeyAndString(uint64_t, std::string) {}
 
-void ClientGgp::OnCallstack(CallStack) {}
+void ClientGgp::OnUniqueCallStack(CallStack) {}
 
 void ClientGgp::OnCallstackEvent(orbit_client_protos::CallstackEvent) {}
 

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -28,7 +28,7 @@ class ClientGgp final : public CaptureListener {
   void OnCaptureComplete() override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
   void OnKeyAndString(uint64_t key, std::string str) override;
-  void OnCallstack(CallStack callstack) override;
+  void OnUniqueCallStack(CallStack callstack) override;
   void OnCallstackEvent(orbit_client_protos::CallstackEvent callstack_event) override;
   void OnThreadName(int32_t thread_id, std::string thread_name) override;
   void OnAddressInfo(orbit_client_protos::LinuxAddressInfo address_info) override;

--- a/OrbitCore/CMakeLists.txt
+++ b/OrbitCore/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(
   OrbitCore
   PUBLIC BlockChain.h
          Callstack.h
+         CallstackData.h
          CallstackTypes.h
          Capture.h
          CaptureData.h
@@ -35,7 +36,8 @@ target_sources(
 
 target_sources(
   OrbitCore
-  PRIVATE Capture.cpp
+  PRIVATE CallstackData.cpp
+          Capture.cpp
           CaptureData.cpp
           EventBuffer.cpp
           FunctionUtils.cpp

--- a/OrbitCore/CallstackData.cpp
+++ b/OrbitCore/CallstackData.cpp
@@ -1,0 +1,38 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "CallstackData.h"
+
+#include "Callstack.h"
+#include "Capture.h"
+#include "SamplingProfiler.h"
+
+using orbit_client_protos::CallstackEvent;
+
+void CallstackData::AddCallstackEvent(CallstackEvent callstack_event) {
+  CallstackID hash = callstack_event.callstack_hash();
+  CHECK(HasCallStack(hash));
+  callstack_events_.push_back(std::move(callstack_event));
+}
+
+void CallstackData::AddUniqueCallStack(CallStack call_stack) {
+  absl::MutexLock lock(&unique_callstacks_mutex_);
+  CallstackID hash = call_stack.GetHash();
+  unique_callstacks_[hash] = std::make_shared<CallStack>(std::move(call_stack));
+}
+
+void CallstackData::AddCallStackFromKnownCallstackData(
+    const orbit_client_protos::CallstackEvent& event, const CallstackData& known_callstack_data) {
+  uint64_t hash = event.callstack_hash();
+  std::shared_ptr<CallStack> unique_callstack = known_callstack_data.GetCallstackPtr(hash);
+  if (unique_callstack == nullptr) {
+    return;
+  }
+
+  if (!HasCallStack(hash)) {
+    absl::MutexLock lock(&unique_callstacks_mutex_);
+    unique_callstacks_[hash] = std::move(unique_callstack);
+  }
+  callstack_events_.push_back(CallstackEvent(event));
+}

--- a/OrbitCore/CallstackData.h
+++ b/OrbitCore/CallstackData.h
@@ -1,0 +1,81 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_CORE_CALLSTACK_DATA_H_
+#define ORBIT_CORE_CALLSTACK_DATA_H_
+
+#include <memory>
+
+#include "BlockChain.h"
+#include "Callstack.h"
+#include "CallstackTypes.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/synchronization/mutex.h"
+#include "capture_data.pb.h"
+
+class CallstackData {
+ public:
+  explicit CallstackData() = default;
+
+  // Assume that callstack_event.callstack_hash is filled correctly and the
+  // CallStack with corresponding hash is already in unique_callstacks_
+  void AddCallstackEvent(orbit_client_protos::CallstackEvent callstack_event);
+  void AddUniqueCallStack(CallStack call_stack);
+  void AddCallStackFromKnownCallstackData(const orbit_client_protos::CallstackEvent& event,
+                                          const CallstackData& known_callstack_data);
+
+  [[nodiscard]] const BlockChain<orbit_client_protos::CallstackEvent, 16 * 1024>& callstack_events()
+      const {
+    return callstack_events_;
+  };
+
+  [[nodiscard]] uint32_t GetCallstackEventsSize() const { return callstack_events_.size(); };
+
+  [[nodiscard]] const CallStack* GetCallStack(CallstackID callstack_id) const {
+    absl::MutexLock lock(&unique_callstacks_mutex_);
+    auto it = unique_callstacks_.find(callstack_id);
+    if (it != unique_callstacks_.end()) {
+      return unique_callstacks_.at(callstack_id).get();
+    }
+    return nullptr;
+  };
+
+  [[nodiscard]] bool HasCallStack(CallstackID callstack_id) const {
+    absl::MutexLock lock(&unique_callstacks_mutex_);
+    return unique_callstacks_.count(callstack_id) > 0;
+  }
+
+  void ForEachUniqueCallstack(const std::function<void(const CallStack&)>& action) const {
+    absl::MutexLock lock(&unique_callstacks_mutex_);
+    for (const auto& it : unique_callstacks_) {
+      action(*it.second);
+    }
+  }
+
+  void ForEachFrameInCallstack(uint64_t callstack_id,
+                               const std::function<void(uint64_t)>& action) const {
+    absl::MutexLock lock(&unique_callstacks_mutex_);
+    for (uint64_t frame : unique_callstacks_.at(callstack_id)->GetFrames()) {
+      action(frame);
+    }
+  }
+
+ private:
+  [[nodiscard]] std::shared_ptr<CallStack> GetCallstackPtr(CallstackID callstack_id) const {
+    absl::MutexLock lock(&unique_callstacks_mutex_);
+    auto it = unique_callstacks_.find(callstack_id);
+    if (it != unique_callstacks_.end()) {
+      return unique_callstacks_.at(callstack_id);
+    }
+    return nullptr;
+  };
+
+ private:
+  BlockChain<orbit_client_protos::CallstackEvent, 16 * 1024> callstack_events_;
+
+  mutable absl::Mutex unique_callstacks_mutex_;
+  absl::flat_hash_map<CallstackID, std::shared_ptr<CallStack>> unique_callstacks_;
+};
+
+#endif  // ORBIT_CORE_CALLSTACK_DATA_H_

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -45,7 +45,7 @@ ErrorMessageOr<void> Capture::StartCapture(
 
 void Capture::FinalizeCapture() {
   if (Capture::GSamplingProfiler != nullptr) {
-    Capture::GSamplingProfiler->ProcessSamples();
+    Capture::GSamplingProfiler->ProcessSamples(*Capture::capture_data_.GetCallstackData());
   }
 }
 

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -16,6 +16,7 @@
 #include "ApplicationOptions.h"
 #include "CallStackDataView.h"
 #include "Callstack.h"
+#include "CallstackData.h"
 #include "CaptureWindow.h"
 #include "DataManager.h"
 #include "DataViewFactory.h"
@@ -34,6 +35,7 @@
 #include "OrbitClientServices/ProcessManager.h"
 #include "PresetsDataView.h"
 #include "ProcessesDataView.h"
+#include "SamplingReport.h"
 #include "SamplingReportDataView.h"
 #include "ScopedStatus.h"
 #include "StatusListener.h"
@@ -85,7 +87,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void OnCaptureComplete() override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
   void OnKeyAndString(uint64_t key, std::string str) override;
-  void OnCallstack(CallStack callstack) override;
+  void OnUniqueCallStack(CallStack callstack) override;
   void OnCallstackEvent(orbit_client_protos::CallstackEvent callstack_event) override;
   void OnThreadName(int32_t thread_id, std::string thread_name) override;
   void OnAddressInfo(orbit_client_protos::LinuxAddressInfo address_info) override;
@@ -94,8 +96,10 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
 
   void RegisterCaptureWindow(CaptureWindow* capture);
 
-  void AddSamplingReport(std::shared_ptr<SamplingProfiler> sampling_profiler);
-  void AddSelectionReport(std::shared_ptr<SamplingProfiler> sampling_profiler);
+  void AddSamplingReport(std::shared_ptr<SamplingProfiler> sampling_profiler,
+                         const CallstackData* callstack_data);
+  void AddSelectionReport(std::shared_ptr<SamplingProfiler> sampling_profiler,
+                          const CallstackData* callstack_data);
   void AddTopDownView(const SamplingProfiler& sampling_profiler);
 
   bool SelectProcess(const std::string& process);

--- a/OrbitGl/CallStackDataView.h
+++ b/OrbitGl/CallStackDataView.h
@@ -27,15 +27,17 @@ class CallStackDataView : public DataView {
   void OnContextMenu(const std::string& action, int menu_index,
                      const std::vector<int>& item_indices) override;
   void OnDataChanged() override;
-  void SetCallStack(std::shared_ptr<CallStack> callstack) {
-    callstack_ = std::move(callstack);
+  void SetCallStack(const CallStack& callstack) {
+    callstack_ = std::make_unique<CallStack>(callstack);
     OnDataChanged();
   }
+
+  void ClearCallstack() { callstack_ = nullptr; }
 
  protected:
   void DoFilter() override;
 
-  std::shared_ptr<CallStack> callstack_;
+  std::unique_ptr<CallStack> callstack_;
 
   struct CallStackDataViewFrame {
     CallStackDataViewFrame() = default;

--- a/OrbitGl/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/OrbitGl/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -25,7 +25,7 @@ class MyCaptureListener : public CaptureListener {
   void OnCaptureComplete() override {}
   void OnTimer(const TimerInfo&) override {}
   void OnKeyAndString(uint64_t, std::string) override {}
-  void OnCallstack(CallStack) override {}
+  void OnUniqueCallStack(CallStack) override {}
   void OnCallstackEvent(CallstackEvent) override {}
   void OnThreadName(int32_t, std::string) override {}
   void OnAddressInfo(LinuxAddressInfo) override {}

--- a/OrbitGl/DisassemblyReport.h
+++ b/OrbitGl/DisassemblyReport.h
@@ -14,28 +14,25 @@
 class DisassemblyReport : public CodeReport {
  public:
   DisassemblyReport(Disassembler disasm, uint64_t function_address,
-                    std::shared_ptr<SamplingProfiler> profiler)
+                    std::shared_ptr<SamplingProfiler> profiler, uint32_t samples_count)
       : disasm_{std::move(disasm)},
         profiler_{std::move(profiler)},
         function_count_{(profiler_ == nullptr) ? 0
-                                               : profiler_->GetCountOfFunction(function_address)} {}
+                                               : profiler_->GetCountOfFunction(function_address)},
+        samples_count_(samples_count) {}
 
   explicit DisassemblyReport(Disassembler disasm)
-      : disasm_{std::move(disasm)}, profiler_{nullptr}, function_count_{0} {};
+      : disasm_{std::move(disasm)}, profiler_{nullptr}, function_count_{0}, samples_count_{0} {};
 
   [[nodiscard]] uint32_t GetNumSamplesInFunction() const override { return function_count_; }
-  [[nodiscard]] uint32_t GetNumSamples() const override {
-    if (profiler_ == nullptr) {
-      return 0;
-    }
-    return profiler_->GetNumSamples();
-  }
+  [[nodiscard]] uint32_t GetNumSamples() const override { return samples_count_; }
   [[nodiscard]] uint32_t GetNumSamplesAtLine(size_t line) const override;
 
  private:
   const Disassembler disasm_;
   const std::shared_ptr<SamplingProfiler> profiler_;
   const uint32_t function_count_;
+  const uint32_t samples_count_;
 };
 
 #endif  // ORBIT_GL_DISASSEMBLY_REPORT_H_

--- a/OrbitGl/SamplingReport.h
+++ b/OrbitGl/SamplingReport.h
@@ -11,13 +11,15 @@
 #include <string>
 #include <vector>
 
+#include "CallstackData.h"
 #include "CallstackTypes.h"
 #include "SamplingProfiler.h"
 #include "SamplingReportDataView.h"
 
 class SamplingReport {
  public:
-  explicit SamplingReport(std::shared_ptr<SamplingProfiler> sampling_profiler);
+  explicit SamplingReport(std::shared_ptr<SamplingProfiler> sampling_profiler,
+                          const CallstackData* callstack_data);
 
   void UpdateReport();
   [[nodiscard]] std::shared_ptr<SamplingProfiler> GetProfiler() const { return profiler_; };
@@ -29,7 +31,9 @@ class SamplingReport {
   [[nodiscard]] std::string GetSelectedCallstackString() const;
   void SetUiRefreshFunc(std::function<void()> func) { ui_refresh_func_ = std::move(func); };
   [[nodiscard]] bool HasCallstacks() const { return selected_sorted_callstack_report_ != nullptr; };
-  [[nodiscard]] bool HasSamples() const { return profiler_->GetNumSamples() > 0; }
+  [[nodiscard]] bool HasSamples() const {
+    return callstack_data_ != nullptr && callstack_data_->GetCallstackEventsSize() > 0;
+  }
 
  protected:
   void FillReport();
@@ -37,6 +41,7 @@ class SamplingReport {
 
  protected:
   std::shared_ptr<SamplingProfiler> profiler_;
+  const CallstackData* callstack_data_;
   std::vector<SamplingReportDataView> thread_reports_;
   CallStackDataView* callstack_data_view_;
 

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -615,14 +615,16 @@ std::vector<CallstackEvent> TimeGraph::SelectEvents(float a_WorldStart, float a_
   sampling_profiler->SetGenerateSummary(a_TID == 0);
 
   for (const CallstackEvent& event : selected_callstack_events) {
-    if (Capture::GSamplingProfiler->GetCallStack(event.callstack_hash())) {
-      sampling_profiler->AddCallStack(CallstackEvent(event));
-    }
+    Capture::capture_data_.AddSelectionCallstackFromCallstackData(event);
   }
-  sampling_profiler->ProcessSamples();
 
-  if (sampling_profiler->GetNumSamples() > 0) {
-    GOrbitApp->AddSelectionReport(sampling_profiler);
+  const CallstackData* selection_callstack_data =
+      Capture::capture_data_.GetSelectionCallstackData();
+  sampling_profiler->ProcessSamples(*selection_callstack_data);
+
+  int samples_count = selection_callstack_data->GetCallstackEventsSize();
+  if (samples_count > 0) {
+    GOrbitApp->AddSelectionReport(sampling_profiler, selection_callstack_data);
   }
 
   NeedsUpdate();


### PR DESCRIPTION
Callstacks are the "raw" data that we get during the capture, so it
should be part of CaptureData. After this change SamplingProfiler
stores only post-processed data.