### PR TITLE
Add .git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,7 @@
+# This list contains commits for git blame to ignore
+# These are usually commits with bulk changes like
+# clang-format.
+
+7e1ae51539672920f3cb2441bce184658dae4e1e  # Initial clang-format
+cea9ffd533106b59e79cc9a2e80c595691b24576  # Bulk clang-format after ColumnLimit change
+748d5b126b19690a5d20d8e1aff375e4d4e35564  # Bulk clang-format after ColumnLimit change


### PR DESCRIPTION
This file contains list of commits doing
bulk changes to repository. Commits listed
in this file are ignored by git blame.

Run following command to enable it:
git config blame.ignoreRevsFile .git-blame-ignore-revs