### PR TITLE
Add and implement StatusListener

### DIFF
--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -44,6 +44,7 @@ target_sources(
          SamplingReport.h
          SamplingReportDataView.h
          SchedulerTrack.h
+         StatusListener.h
          TextBox.h
          TextRenderer.h
          ThreadTrack.h

--- a/OrbitGl/StatusListener.h
+++ b/OrbitGl/StatusListener.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_STATUS_LISTENER_H_
+#define ORBIT_GL_STATUS_LISTENER_H_
+
+/**
+ * This interface is used to communicate status of a background
+ * task to the UI. Since there could be multiple background tasks
+ * working at once the caller should keep track of status ids
+ * and use them to update or clear status messages.
+ *
+ * The implementation of this class is not supposed to be thread-safe
+ * it assumes methods are invoked on the main thread.
+ *
+ * Example usage:
+ *
+ * uint64_t status_id = listener->AddStatus("");
+ */
+class StatusListener {
+ public:
+  virtual ~StatusListener() = default;
+
+  [[nodiscard]] virtual uint64_t AddStatus(std::string message) = 0;
+  virtual void ClearStatus(uint64_t status_id) = 0;
+  virtual void UpdateStatus(uint64_t status_id, std::string message) = 0;
+};
+
+#endif  // ORBIT_GL_STATUS_LISTENER_H_

--- a/OrbitQt/CMakeLists.txt
+++ b/OrbitQt/CMakeLists.txt
@@ -39,6 +39,7 @@ target_sources(
   PRIVATE Error.cpp
           ElidedLabel.cpp
           MainThreadExecutorImpl.cpp
+          StatusListenerImpl.cpp
           deploymentconfigurations.cpp
           main.cpp
           orbitaboutdialog.cpp
@@ -116,3 +117,20 @@ set_target_properties(OrbitQt PROPERTIES OUTPUT_NAME "Orbit")
 set_target_properties(OrbitQt PROPERTIES AUTOMOC ON)
 set_target_properties(OrbitQt PROPERTIES AUTOUIC ON)
 strip_symbols(OrbitQt)
+
+add_executable(OrbitQtTests)
+
+target_compile_options(OrbitQtTests PRIVATE ${STRICT_COMPILE_FLAGS})
+
+target_sources(OrbitQtTests
+        PRIVATE StatusListenerImplTest.cpp
+                StatusListenerImpl.cpp)
+
+target_link_libraries(
+  OrbitQtTests
+  PRIVATE OrbitGl
+          Qt5::Widgets
+          Qt5::Core
+          GTest::Main)
+
+register_test(OrbitGlTests)

--- a/OrbitQt/StatusListenerImpl.cpp
+++ b/OrbitQt/StatusListenerImpl.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "StatusListenerImpl.h"
+
+#include "OrbitBase/Logging.h"
+
+uint64_t StatusListenerImpl::AddStatus(std::string message) {
+  uint64_t id = GetNextId();
+  status_bar_->showMessage(QString::fromStdString(message));
+
+  status_messages_.insert_or_assign(id, std::move(message));
+  status_id_stack_.push_back(id);
+
+  return id;
+}
+
+void StatusListenerImpl::ClearStatus(uint64_t status_id) {
+  CHECK(status_messages_.count(status_id) == 1);
+  status_messages_.erase(status_id);
+  status_id_stack_.erase(std::remove(status_id_stack_.begin(), status_id_stack_.end(), status_id),
+                         status_id_stack_.end());
+  if (status_id_stack_.empty()) {
+    status_bar_->clearMessage();
+    return;
+  }
+
+  uint64_t current_status_id = status_id_stack_.back();
+  status_bar_->showMessage(QString::fromStdString(status_messages_.at(current_status_id)));
+}
+
+void StatusListenerImpl::UpdateStatus(uint64_t status_id, std::string message) {
+  CHECK(status_messages_.count(status_id) == 1);
+  auto it = std::find(status_id_stack_.begin(), status_id_stack_.end(), status_id);
+  CHECK(it != status_id_stack_.end());
+
+  status_id_stack_.erase(it);
+  status_id_stack_.push_back(status_id);
+
+  status_bar_->showMessage(QString::fromStdString(message));
+  status_messages_.insert_or_assign(status_id, std::move(message));
+}
+
+std::unique_ptr<StatusListener> StatusListenerImpl::Create(QStatusBar* status_bar) {
+  return std::unique_ptr<StatusListener>(new StatusListenerImpl(status_bar));
+}
+
+uint64_t StatusListenerImpl::GetNextId() {
+  CHECK(next_id_ < std::numeric_limits<uint64_t>::max());
+  return next_id_++;
+}

--- a/OrbitQt/StatusListenerImpl.h
+++ b/OrbitQt/StatusListenerImpl.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_QT_STATUS_LISTENER_IMPL_H_
+#define ORBIT_QT_STATUS_LISTENER_IMPL_H_
+
+#include <QStatusBar>
+#include <cstdint>
+#include <memory>
+#include <string_view>
+
+#include "StatusListener.h"
+#include "absl/container/flat_hash_map.h"
+
+class StatusListenerImpl : public StatusListener {
+ public:
+  [[nodiscard]] uint64_t AddStatus(std::string message) override;
+  void ClearStatus(uint64_t status_id) override;
+  void UpdateStatus(uint64_t status_id, std::string message) override;
+
+  static std::unique_ptr<StatusListener> Create(QStatusBar* status_bar);
+
+ private:
+  explicit StatusListenerImpl(QStatusBar* status_bar) : next_id_{0}, status_bar_(status_bar) {}
+  uint64_t GetNextId();
+
+  uint64_t next_id_;
+  absl::flat_hash_map<uint64_t, std::string> status_messages_;
+
+  // Container holds recently updated status_id on the top
+  // (at the end of the vector).
+  std::vector<uint64_t> status_id_stack_;
+
+  QStatusBar* status_bar_;
+};
+
+#endif  // ORBIT_QT_STATUS_LISTENER_IMPL_H_

--- a/OrbitQt/StatusListenerImplTest.cpp
+++ b/OrbitQt/StatusListenerImplTest.cpp
@@ -1,0 +1,132 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <QApplication>
+
+#include "StatusListenerImpl.h"
+#include "gtest/gtest.h"
+
+int argc = 0;
+
+TEST(StatusListenerImpl, ShowAndClearOneMessage) {
+  QApplication app(argc, nullptr);
+  auto status_bar = std::make_unique<QStatusBar>(nullptr);
+  auto status_listener = StatusListenerImpl::Create(status_bar.get());
+
+  EXPECT_EQ(status_bar->currentMessage(), "");
+  auto id = status_listener->AddStatus("message 1");
+  EXPECT_EQ(status_bar->currentMessage(), "message 1");
+  status_listener->ClearStatus(id);
+  EXPECT_EQ(status_bar->currentMessage(), "");
+}
+
+TEST(StatusListenerImpl, ShowAndUpdate) {
+  constexpr const char* message1 = "message 1";
+  constexpr const char* message2 = "message 2";
+  constexpr const char* message3 = "message 3";
+  constexpr const char* updated_message = "updated message";
+
+  QApplication app(argc, nullptr);
+  auto status_bar = std::make_unique<QStatusBar>(nullptr);
+  auto status_listener = StatusListenerImpl::Create(status_bar.get());
+
+  EXPECT_EQ(status_bar->currentMessage(), "");
+  auto id1 = status_listener->AddStatus(message1);
+  EXPECT_EQ(status_bar->currentMessage(), message1);
+  auto id2 = status_listener->AddStatus(message2);
+  EXPECT_EQ(status_bar->currentMessage(), message2);
+  auto id3 = status_listener->AddStatus(message3);
+  EXPECT_EQ(status_bar->currentMessage(), message3);
+
+  status_listener->UpdateStatus(id2, updated_message);
+  EXPECT_EQ(status_bar->currentMessage(), updated_message);
+
+  status_listener->ClearStatus(id3);
+  // Check that nothing changes.
+  EXPECT_EQ(status_bar->currentMessage(), updated_message);
+
+  // now we should see 1st message.
+  status_listener->ClearStatus(id2);
+  EXPECT_EQ(status_bar->currentMessage(), message1);
+  status_listener->ClearStatus(id1);
+
+  // Nothing left - status bar is empty.
+  EXPECT_EQ(status_bar->currentMessage(), "");
+}
+
+TEST(StatusListenerImpl, CheckOrder) {
+  constexpr const char* message1 = "message 1";
+  constexpr const char* message2 = "message 2";
+  constexpr const char* message3 = "message 3";
+  constexpr const char* message4 = "message 4";
+  constexpr const char* message5 = "message 5";
+
+  QApplication app(argc, nullptr);
+  auto status_bar = std::make_unique<QStatusBar>(nullptr);
+  auto status_listener = StatusListenerImpl::Create(status_bar.get());
+
+  EXPECT_EQ(status_bar->currentMessage(), "");
+
+  auto id2 = status_listener->AddStatus(message2);
+  EXPECT_EQ(status_bar->currentMessage(), message2);
+  auto id4 = status_listener->AddStatus(message4);
+  EXPECT_EQ(status_bar->currentMessage(), message4);
+  auto id1 = status_listener->AddStatus(message1);
+  EXPECT_EQ(status_bar->currentMessage(), message1);
+  auto id5 = status_listener->AddStatus(message5);
+  EXPECT_EQ(status_bar->currentMessage(), message5);
+  auto id3 = status_listener->AddStatus(message3);
+  EXPECT_EQ(status_bar->currentMessage(), message3);
+
+  // Now update them in order
+  status_listener->UpdateStatus(id1, message1);
+  EXPECT_EQ(status_bar->currentMessage(), message1);
+  status_listener->UpdateStatus(id2, message2);
+  EXPECT_EQ(status_bar->currentMessage(), message2);
+  status_listener->UpdateStatus(id3, message3);
+  EXPECT_EQ(status_bar->currentMessage(), message3);
+  status_listener->UpdateStatus(id4, message4);
+  EXPECT_EQ(status_bar->currentMessage(), message4);
+  status_listener->UpdateStatus(id5, message5);
+  EXPECT_EQ(status_bar->currentMessage(), message5);
+
+  // Remove from last to first - check that most recently
+  // updated message is on the top.
+
+  status_listener->ClearStatus(id5);
+  EXPECT_EQ(status_bar->currentMessage(), message4);
+  status_listener->ClearStatus(id4);
+  EXPECT_EQ(status_bar->currentMessage(), message3);
+  status_listener->ClearStatus(id3);
+  EXPECT_EQ(status_bar->currentMessage(), message2);
+  status_listener->ClearStatus(id2);
+  EXPECT_EQ(status_bar->currentMessage(), message1);
+  status_listener->ClearStatus(id1);
+  // Nothing left - status bar is empty.
+  EXPECT_EQ(status_bar->currentMessage(), "");
+}
+
+TEST(StatusListenerImpl, UpdateStatusInvalidId) {
+  EXPECT_DEATH(
+      {
+        QApplication app(argc, nullptr);
+        auto status_bar = std::make_unique<QStatusBar>(nullptr);
+        auto status_listener = StatusListenerImpl::Create(status_bar.get());
+
+        status_listener->UpdateStatus(10, "no message");
+      },
+      "");
+}
+
+TEST(StatusListenerImpl, ClearStatusInvalidId) {
+  EXPECT_DEATH(
+      {
+        QApplication app(argc, nullptr);
+        auto status_bar = std::make_unique<QStatusBar>(nullptr);
+        auto status_listener = StatusListenerImpl::Create(status_bar.get());
+
+        status_listener->ClearStatus(1);
+      },
+      "");
+}


### PR DESCRIPTION
StatusListener is an interface to be used by controllers
(OrbitApp) to notify user about progress of background tasks

This commit adds the interface and simple Qt implementation using
QStatusBar showMessage/clearMessage.

Test: run OrbitQtTests