### PR TITLE
Fix memory leaks when loading and clearing captures

### DIFF
--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -15,10 +15,14 @@
 #include "absl/strings/str_format.h"
 
 using orbit_client_protos::FunctionInfo;
+using orbit_client_protos::LinuxAddressInfo;
 using orbit_client_protos::PresetFile;
+using orbit_client_protos::PresetInfo;
 
 CaptureData Capture::capture_data_;
+absl::flat_hash_map<uint64_t, FunctionInfo> Capture::GVisibleFunctionsMap;
 TextBox* Capture::GSelectedTextBox = nullptr;
+ThreadID Capture::GSelectedThreadId;
 
 std::shared_ptr<SamplingProfiler> Capture::GSamplingProfiler = nullptr;
 std::shared_ptr<Process> Capture::GTargetProcess = nullptr;
@@ -53,7 +57,11 @@ void Capture::FinalizeCapture() {
   }
 }
 
-void Capture::ClearCaptureData() { GSelectedTextBox = nullptr; }
+void Capture::ClearCaptureData() {
+  GSelectedTextBox = nullptr;
+  GSelectedThreadId = 0;
+  capture_data_ = CaptureData();
+}
 
 void Capture::PreSave() {
   // Add selected functions' exact address to sampling profiler

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -60,7 +60,6 @@ void Capture::FinalizeCapture() {
 void Capture::ClearCaptureData() {
   GSelectedTextBox = nullptr;
   GSelectedThreadId = 0;
-  capture_data_ = CaptureData();
 }
 
 void Capture::PreSave() {

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -45,9 +45,6 @@ ErrorMessageOr<void> Capture::StartCapture(
   }
 
   capture_data_ = CaptureData(process_id, std::move(process_name), std::move(selected_functions));
-
-  Capture::GSamplingProfiler = std::make_shared<SamplingProfiler>(Capture::GTargetProcess);
-
   return outcome::success();
 }
 

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -15,14 +15,10 @@
 #include "absl/strings/str_format.h"
 
 using orbit_client_protos::FunctionInfo;
-using orbit_client_protos::LinuxAddressInfo;
 using orbit_client_protos::PresetFile;
-using orbit_client_protos::PresetInfo;
 
 CaptureData Capture::capture_data_;
-absl::flat_hash_map<uint64_t, FunctionInfo> Capture::GVisibleFunctionsMap;
 TextBox* Capture::GSelectedTextBox = nullptr;
-ThreadID Capture::GSelectedThreadId;
 
 std::shared_ptr<SamplingProfiler> Capture::GSamplingProfiler = nullptr;
 std::shared_ptr<Process> Capture::GTargetProcess = nullptr;
@@ -54,10 +50,7 @@ void Capture::FinalizeCapture() {
   }
 }
 
-void Capture::ClearCaptureData() {
-  GSelectedTextBox = nullptr;
-  GSelectedThreadId = 0;
-}
+void Capture::ClearCaptureData() { GSelectedTextBox = nullptr; }
 
 void Capture::PreSave() {
   // Add selected functions' exact address to sampling profiler

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -602,7 +602,6 @@ void OrbitApp::ClearCapture() {
   // Trigger deallocation of previous sampling related data.
   sampling_report_ = nullptr;
   auto empty_sampling_profiler = std::make_shared<SamplingProfiler>();
-  Capture::GSamplingProfiler = empty_sampling_profiler;
   AddSamplingReport(empty_sampling_profiler);
   AddTopDownView(*empty_sampling_profiler);
 

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -599,6 +599,13 @@ void OrbitApp::ClearCapture() {
   set_selected_thread_id(-1);
   Capture::ClearCaptureData();
 
+  // Trigger deallocation of previous sampling related data.
+  sampling_report_ = nullptr;
+  auto empty_sampling_profiler = std::make_shared<SamplingProfiler>();
+  Capture::GSamplingProfiler = empty_sampling_profiler;
+  AddSamplingReport(empty_sampling_profiler);
+  AddTopDownView(*empty_sampling_profiler);
+
   if (GCurrentTimeGraph != nullptr) {
     GCurrentTimeGraph->Clear();
   }

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -600,10 +600,10 @@ void OrbitApp::ClearCapture() {
   Capture::ClearCaptureData();
 
   // Trigger deallocation of previous sampling related data.
-  sampling_report_ = nullptr;
-  auto empty_sampling_profiler = std::make_shared<SamplingProfiler>();
+  auto empty_sampling_profiler = std::make_shared<SamplingProfiler>(Capture::GTargetProcess);
   AddSamplingReport(empty_sampling_profiler);
   AddTopDownView(*empty_sampling_profiler);
+  Capture::GSamplingProfiler = empty_sampling_profiler;
 
   if (GCurrentTimeGraph != nullptr) {
     GCurrentTimeGraph->Clear();

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -260,8 +260,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
 
   CaptureWindow* capture_window_ = nullptr;
 
-  std::shared_ptr<class SamplingReport> sampling_report_;
-  std::shared_ptr<class SamplingReport> selection_report_;
+  std::shared_ptr<SamplingReport> sampling_report_;
+  std::shared_ptr<SamplingReport> selection_report_;
   std::map<std::string, std::string> file_mapping_;
 
   absl::flat_hash_set<std::string> modules_currently_loading_;

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -193,10 +193,6 @@ void CaptureSerializer::ProcessCaptureData(const CaptureInfo& capture_info) {
   capture_data.set_thread_names(thread_names);
   Capture::capture_data_ = std::move(capture_data);
 
-  if (Capture::GSamplingProfiler == nullptr) {
-    Capture::GSamplingProfiler = std::make_shared<SamplingProfiler>();
-  }
-  Capture::GSamplingProfiler->ClearCallstacks();
   for (CallstackInfo callstack : capture_info.callstacks()) {
     CallStack unique_callstack({callstack.data().begin(), callstack.data().end()});
     Capture::GSamplingProfiler->AddUniqueCallStack(unique_callstack);

--- a/OrbitGl/SamplingReport.h
+++ b/OrbitGl/SamplingReport.h
@@ -29,6 +29,7 @@ class SamplingReport {
   [[nodiscard]] std::string GetSelectedCallstackString() const;
   void SetUiRefreshFunc(std::function<void()> func) { ui_refresh_func_ = std::move(func); };
   [[nodiscard]] bool HasCallstacks() const { return selected_sorted_callstack_report_ != nullptr; };
+  [[nodiscard]] bool HasSamples() const { return profiler_->GetNumSamples() > 0; }
 
  protected:
   void FillReport();

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -99,6 +99,8 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App, ApplicationOptions&& optio
     finalizing_capture_dialog->close();
     ui->actionToggle_Capture->setDisabled(false);
     ui->actionToggle_Capture->setIcon(icon_start_capture_);
+    ui->actionClear_Capture->setDisabled(false);
+    ui->actionOpen_Capture->setDisabled(false);
     ui->actionSave_Capture->setDisabled(false);
     ui->actionOpen_Preset->setDisabled(false);
     ui->actionSave_Preset_As->setDisabled(false);

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -338,8 +338,9 @@ void OrbitMainWindow::OnNewSamplingReport(DataView* callstack_data_view,
   ui->samplingReport->Initialize(callstack_data_view, std::move(sampling_report));
   ui->samplingGridLayout->addWidget(ui->samplingReport, 0, 0, 1, 1);
 
-  // Automatically switch to sampling tab if not already in live tab.
-  if (ui->RightTabWidget->currentWidget() != ui->liveTab) {
+  // Switch to sampling tab if sampling report is not empty and if not already in live tab.
+  bool has_samples = sampling_report->HasSamples();
+  if (has_samples && (ui->RightTabWidget->currentWidget() != ui->liveTab)) {
     ui->RightTabWidget->setCurrentWidget(ui->samplingTab);
   }
 }

--- a/OrbitQt/topdownwidget.cpp
+++ b/OrbitQt/topdownwidget.cpp
@@ -10,12 +10,12 @@
 #include "TopDownViewItemModel.h"
 
 void TopDownWidget::SetTopDownView(std::unique_ptr<TopDownView> top_down_view) {
-  auto* model = new TopDownViewItemModel{std::move(top_down_view), ui_->topDownTreeView};
-  proxy_model_ = new HighlightCustomFilterSortFilterProxyModel{ui_->topDownTreeView};
-  proxy_model_->setSourceModel(model);
+  model_ = std::make_unique<TopDownViewItemModel>(std::move(top_down_view));
+  proxy_model_ = std::make_unique<HighlightCustomFilterSortFilterProxyModel>(nullptr);
+  proxy_model_->setSourceModel(model_.get());
   proxy_model_->setSortRole(Qt::EditRole);
 
-  ui_->topDownTreeView->setModel(proxy_model_);
+  ui_->topDownTreeView->setModel(proxy_model_.get());
   ui_->topDownTreeView->sortByColumn(TopDownViewItemModel::kInclusive, Qt::DescendingOrder);
   ui_->topDownTreeView->header()->resizeSections(QHeaderView::ResizeToContents);
 

--- a/OrbitQt/topdownwidget.h
+++ b/OrbitQt/topdownwidget.h
@@ -11,6 +11,7 @@
 #include <memory>
 
 #include "TopDownView.h"
+#include "TopDownViewItemModel.h"
 #include "ui_topdownwidget.h"
 
 class TopDownWidget : public QWidget {
@@ -55,7 +56,8 @@ class TopDownWidget : public QWidget {
   };
 
   std::unique_ptr<Ui::TopDownWidget> ui_;
-  HighlightCustomFilterSortFilterProxyModel* proxy_model_ = nullptr;
+  std::unique_ptr<TopDownViewItemModel> model_;
+  std::unique_ptr<HighlightCustomFilterSortFilterProxyModel> proxy_model_;
 };
 
 #endif  // ORBIT_QT_TOP_DOWN_WIDGET_H_


### PR DESCRIPTION
- Clear CaptureData when clearing capture
- Set empty sampling profiler when clearing capture to trigger deallocation of previous sampling related data
- Make TopDownView own its Model and ProxyModel instead relying on Qt for memory management

When loading a capture and clearing it, we held on to a lot of memory. See before and after comparison below where we load and clear the same capture file twice. Before the change, we start off with 83MB and end with 106MB of memory usage whereas after the change, we get back to 83MB after the loading/clearing operations.

In the graphs below, the green curve represents the number of live allocations and the blue curve represents the number of bytes allocated.

![image](https://user-images.githubusercontent.com/3687222/90350495-360b2080-dff2-11ea-9799-0fbc37c23a93.png)


