### PR TITLE
Implement ScopedStatus class

### DIFF
--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -131,8 +131,9 @@ target_sources(OrbitGlTests PRIVATE
                PickingManagerTest.h)
 
 target_sources(OrbitGlTests PRIVATE
+               BatcherTest.cpp
                PickingManagerTest.cpp
-               BatcherTest.cpp)
+               ScopedStatusTest.cpp)
 
 target_link_libraries(
   OrbitGlTests

--- a/OrbitGl/ScopedStatus.h
+++ b/OrbitGl/ScopedStatus.h
@@ -1,0 +1,108 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_SCOPED_STATUS_H_
+#define ORBIT_GL_SCOPED_STATUS_H_
+
+#include <string>
+#include <thread>
+
+#include "MainThreadExecutor.h"
+#include "OrbitBase/Logging.h"
+#include "StatusListener.h"
+
+/**
+ * This class holds scope for status. It also takes care
+ * of updating status on the main thread even if Update
+ * is called from a different thread.
+ *
+ * Usage example:
+ *
+ * {
+ *   ScopedStatus scoped_status(main_thread_executor, status_listener_, "Waiting for fish");
+ *
+ *   ...
+ *
+ *   scoped_status.Update("Still waiting for fish!");
+ *
+ *   ...
+ *
+ *   // Once out of scope it will clear the message.
+ * }
+ *
+ * See also StatusListener class.
+ */
+class ScopedStatus final {
+ public:
+  ScopedStatus() = default;
+  explicit ScopedStatus(MainThreadExecutor* main_thread_executor, StatusListener* status_listener,
+                        const std::string& status_message,
+                        std::thread::id main_thread_id = std::this_thread::get_id()) {
+    data_ = std::make_unique<Data>();
+    data_->main_thread_executor = main_thread_executor;
+    data_->status_listener = status_listener;
+    data_->main_thread_id = main_thread_id;
+    data_->status_id = status_listener->AddStatus(status_message);
+  }
+
+  ScopedStatus(const ScopedStatus& that) = delete;
+  ScopedStatus& operator=(const ScopedStatus& that) = delete;
+
+  ScopedStatus(ScopedStatus&& that) = default;
+
+  ScopedStatus& operator=(ScopedStatus&& that) noexcept {
+    if (this == &that) {
+      return *this;
+    }
+
+    reset();
+    data_ = std::move(that.data_);
+    return *this;
+  }
+
+  ~ScopedStatus() { reset(); }
+
+  void UpdateMessage(const std::string& message) {
+    CHECK(data_ != nullptr);
+    if (std::this_thread::get_id() == data_->main_thread_id) {
+      data_->status_listener->UpdateStatus(data_->status_id, message);
+    } else {
+      data_->main_thread_executor->Schedule(
+          [status_id = data_->status_id, status_listener = data_->status_listener, message] {
+            status_listener->UpdateStatus(status_id, message);
+          });
+    }
+  }
+
+ private:
+  void reset() noexcept {
+    if (!data_) {
+      return;
+    }
+
+    if (std::this_thread::get_id() == data_->main_thread_id) {
+      data_->status_listener->ClearStatus(data_->status_id);
+    } else {
+      data_->main_thread_executor->Schedule(
+          [status_listener = data_->status_listener, status_id = data_->status_id] {
+            status_listener->ClearStatus(status_id);
+          });
+    }
+
+    data_.reset();
+  }
+
+  // Instances fo this class are going to be moved a lot so we want data to be
+  // stored in easily movable form.
+  struct Data {
+    MainThreadExecutor* main_thread_executor = nullptr;
+    StatusListener* status_listener = nullptr;
+    std::thread::id main_thread_id;
+    uint64_t status_id = 0;
+  };
+
+  std::unique_ptr<Data> data_;
+};
+
+#endif  // ORBIT_GL_SCOPED_STATUS_H_

--- a/OrbitGl/ScopedStatusTest.cpp
+++ b/OrbitGl/ScopedStatusTest.cpp
@@ -1,0 +1,99 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "MainThreadExecutor.h"
+#include "ScopedStatus.h"
+
+namespace {
+
+class MockStatusListener : public StatusListener {
+ public:
+  MOCK_METHOD(uint64_t, AddStatus, (std::string message), (override));
+  MOCK_METHOD(void, UpdateStatus, (uint64_t status_id, std::string message), (override));
+  MOCK_METHOD(void, ClearStatus, (uint64_t status_id), (override));
+};
+
+class MockMainThreadExecutor : public MainThreadExecutor {
+ public:
+  MOCK_METHOD(void, Schedule, (std::unique_ptr<Action> action), (override));
+};
+
+}  // namespace
+
+using ::testing::_;
+
+TEST(ScopedStatus, Smoke) {
+  MockStatusListener status_listener{};
+  MockMainThreadExecutor main_thread_executor{};
+  EXPECT_CALL(status_listener, AddStatus("Initial message")).Times(1);
+  EXPECT_CALL(status_listener, UpdateStatus(_, "Updated message")).Times(1);
+  EXPECT_CALL(status_listener, ClearStatus).Times(1);
+  EXPECT_CALL(main_thread_executor, Schedule).Times(0);
+
+  {
+    ScopedStatus status(&main_thread_executor, &status_listener, "Initial message");
+    status.UpdateMessage("Updated message");
+  }
+}
+
+TEST(ScopedStatus, UpdateInAnotherThread) {
+  MockStatusListener status_listener{};
+  MockMainThreadExecutor main_thread_executor{};
+  EXPECT_CALL(status_listener, AddStatus("Initial message")).Times(1);
+  EXPECT_CALL(status_listener, ClearStatus).Times(1);
+  EXPECT_CALL(main_thread_executor, Schedule).Times(1);
+
+  {
+    ScopedStatus status(&main_thread_executor, &status_listener, "Initial message");
+    std::thread thread([&status] { status.UpdateMessage("Updated message"); });
+
+    thread.join();
+  }
+}
+
+TEST(ScopedStatus, DestroyInAnotherThread) {
+  MockStatusListener status_listener{};
+  MockMainThreadExecutor main_thread_executor{};
+  EXPECT_CALL(status_listener, AddStatus("Initial message")).Times(1);
+  EXPECT_CALL(status_listener, UpdateStatus(_, "Updated message")).Times(1);
+  EXPECT_CALL(main_thread_executor, Schedule).Times(1);
+
+  {
+    ScopedStatus status(&main_thread_executor, &status_listener, "Initial message");
+    status.UpdateMessage("Updated message");
+    std::thread thread([status = std::move(status)]() {
+      // Do nothing
+    });
+
+    thread.join();
+  }
+}
+
+TEST(ScopedStatus, MoveAssignment) {
+  MockStatusListener status_listener{};
+  MockMainThreadExecutor main_thread_executor{};
+  EXPECT_CALL(status_listener, AddStatus("Initial message 1")).Times(1);
+  EXPECT_CALL(status_listener, AddStatus("Initial message 2")).Times(1);
+  EXPECT_CALL(status_listener, UpdateStatus(_, "Updated message")).Times(1);
+  EXPECT_CALL(status_listener, ClearStatus).Times(2);
+
+  {
+    ScopedStatus status1(&main_thread_executor, &status_listener, "Initial message 1");
+    ScopedStatus status2(&main_thread_executor, &status_listener, "Initial message 2");
+    status1.UpdateMessage("Updated message");
+    status1 = std::move(status2);
+  }
+}
+
+TEST(ScopedStatus, Unitialized) { ScopedStatus status{}; }
+
+TEST(ScopedStatus, UpdateUnutialized) {
+  ScopedStatus status{};
+  EXPECT_DEATH(status.UpdateMessage("Updated message"), "");
+}


### PR DESCRIPTION
Instance of this class can easily be moved between threads
and called from any thread. It automatically lands calls
to the main_thread when necessary.

Test: run OrbitGlTests
Bug: http://b/162705265