### PR TITLE
Add missing header in GlUtils.cpp

### DIFF
--- a/OrbitGl/GlUtils.cpp
+++ b/OrbitGl/GlUtils.cpp
@@ -4,6 +4,7 @@
 
 #include "GlUtils.h"
 
+#include "OpenGl.h"
 #include "OrbitBase/Logging.h"
 #include "absl/strings/str_format.h"
 #include "freetype-gl/freetype-gl.h"


### PR DESCRIPTION
I was sometimes getting a compilation error related to gluErrorString, not sure why it wasn't 100%...