### PR TITLE
Move GVisibleFunctionMap to DataManager

### DIFF
--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -15,12 +15,9 @@
 #include "absl/strings/str_format.h"
 
 using orbit_client_protos::FunctionInfo;
-using orbit_client_protos::LinuxAddressInfo;
 using orbit_client_protos::PresetFile;
-using orbit_client_protos::PresetInfo;
 
 CaptureData Capture::capture_data_;
-absl::flat_hash_map<uint64_t, FunctionInfo> Capture::GVisibleFunctionsMap;
 TextBox* Capture::GSelectedTextBox = nullptr;
 ThreadID Capture::GSelectedThreadId;
 

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -37,7 +37,6 @@ class Capture {
   static std::shared_ptr<SamplingProfiler> GSamplingProfiler;
   static std::shared_ptr<Process> GTargetProcess;
   static std::shared_ptr<orbit_client_protos::PresetFile> GSessionPresets;
-  static absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> GVisibleFunctionsMap;
   static class TextBox* GSelectedTextBox;
   static ThreadID GSelectedThreadId;
 };

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -898,6 +898,15 @@ void OrbitApp::ClearSelectedFunctions() { data_manager_->ClearSelectedFunctions(
   return data_manager_->IsFunctionSelected(func.address);
 }
 
+void OrbitApp::SetVisibleFunctions(absl::flat_hash_set<uint64_t> visible_functions) {
+  data_manager_->set_visible_functions(std::move(visible_functions));
+  NeedsRedraw();
+}
+
+[[nodiscard]] bool OrbitApp::IsFunctionVisible(uint64_t function_address) {
+  return data_manager_->IsFunctionVisible(function_address);
+}
+
 void OrbitApp::UpdateSamplingReport() {
   if (sampling_report_ != nullptr) {
     sampling_report_->UpdateReport();

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -203,6 +203,9 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   [[nodiscard]] bool IsFunctionSelected(const orbit_client_protos::FunctionInfo& func) const;
   [[nodiscard]] bool IsFunctionSelected(const SampledFunction& func) const;
 
+  void SetVisibleFunctions(absl::flat_hash_set<uint64_t> visible_functions);
+  [[nodiscard]] bool IsFunctionVisible(uint64_t function_address);
+
  private:
   void LoadModuleOnRemote(int32_t process_id, const std::shared_ptr<Module>& module,
                           const std::shared_ptr<orbit_client_protos::PresetFile>& preset);

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -169,11 +169,13 @@ void CaptureSerializer::ProcessCaptureData(const CaptureInfo& capture_info) {
   // Clear the old capture
   GOrbitApp->ClearSelectedFunctions();
   absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions;
+  absl::flat_hash_set<uint64_t> visible_functions;
   for (const auto& function : capture_info.selected_functions()) {
     uint64_t address = FunctionUtils::GetAbsoluteAddress(function);
     selected_functions[address] = function;
+    visible_functions.insert(address);
   }
-  Capture::GVisibleFunctionsMap = selected_functions;
+  GOrbitApp->SetVisibleFunctions(std::move(visible_functions));
 
   absl::flat_hash_map<uint64_t, FunctionStats> functions_stats{
       capture_info.function_stats().begin(), capture_info.function_stats().end()};

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -641,7 +641,6 @@ void CaptureWindow::RenderUI() {
     m_StatsWindow.AddLine(VAR_TO_STR(m_WorldMinWidth));
     m_StatsWindow.AddLine(VAR_TO_STR(m_MouseX));
     m_StatsWindow.AddLine(VAR_TO_STR(m_MouseY));
-    m_StatsWindow.AddLine(VAR_TO_STR(Capture::GVisibleFunctionsMap.size()));
     m_StatsWindow.AddLine(VAR_TO_STR(time_graph_.GetNumDrawnTextBoxes()));
     m_StatsWindow.AddLine(VAR_TO_STR(time_graph_.GetNumTimers()));
     m_StatsWindow.AddLine(VAR_TO_STR(time_graph_.GetThreadTotalHeight()));

--- a/OrbitGl/DataManager.cpp
+++ b/OrbitGl/DataManager.cpp
@@ -55,6 +55,16 @@ void DataManager::set_selected_functions(absl::flat_hash_set<uint64_t> selected_
   selected_functions_ = std::move(selected_functions);
 }
 
+void DataManager::set_visible_functions(absl::flat_hash_set<uint64_t> visible_functions) {
+  CHECK(std::this_thread::get_id() == main_thread_id_);
+  visible_functions_ = std::move(visible_functions);
+}
+
+bool DataManager::IsFunctionVisible(uint64_t function_address) const {
+  CHECK(std::this_thread::get_id() == main_thread_id_);
+  return visible_functions_.contains(function_address);
+}
+
 void DataManager::ClearSelectedFunctions() {
   CHECK(std::this_thread::get_id() == main_thread_id_);
   selected_functions_ = absl::flat_hash_set<uint64_t>();

--- a/OrbitGl/DataManager.h
+++ b/OrbitGl/DataManager.h
@@ -28,6 +28,7 @@ class DataManager final {
   void DeselectFunction(uint64_t function_address);
   void ClearSelectedFunctions();
   void set_selected_functions(absl::flat_hash_set<uint64_t> selected_functions);
+  void set_visible_functions(absl::flat_hash_set<uint64_t> visible_functions);
 
   [[nodiscard]] ProcessData* GetProcessByPid(int32_t process_id) const;
   [[nodiscard]] const std::vector<ModuleData*>& GetModules(int32_t process_id) const;
@@ -35,11 +36,13 @@ class DataManager final {
                                                      uint64_t address_start) const;
   [[nodiscard]] bool IsFunctionSelected(uint64_t function_address) const;
   [[nodiscard]] const absl::flat_hash_set<uint64_t>& selected_functions() const;
+  [[nodiscard]] bool IsFunctionVisible(uint64_t function_address) const;
 
  private:
   const std::thread::id main_thread_id_;
   absl::flat_hash_map<int32_t, std::unique_ptr<ProcessData>> process_map_;
   absl::flat_hash_set<uint64_t> selected_functions_;
+  absl::flat_hash_set<uint64_t> visible_functions_;
 };
 
 #endif  // ORBIT_GL_DATA_MANAGER_H_

--- a/OrbitGl/LiveFunctionsDataView.cpp
+++ b/OrbitGl/LiveFunctionsDataView.cpp
@@ -272,13 +272,12 @@ void LiveFunctionsDataView::DoFilter() {
   OnSort(sorting_column_, {});
 
   // Filter drawn textboxes
-  Capture::GVisibleFunctionsMap.clear();
+  absl::flat_hash_set<uint64_t> visible_functions;
   for (size_t i = 0; i < indices_.size(); ++i) {
     FunctionInfo* func = GetFunction(i);
-    Capture::GVisibleFunctionsMap[FunctionUtils::GetAbsoluteAddress(*func)] = *func;
+    visible_functions.insert(FunctionUtils::GetAbsoluteAddress(*func));
   }
-
-  GOrbitApp->NeedsRedraw();
+  GOrbitApp->SetVisibleFunctions(std::move(visible_functions));
 }
 
 void LiveFunctionsDataView::OnDataChanged() {

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -65,8 +65,7 @@ std::string ThreadTrack::GetBoxTooltip(PickingId id) const {
 }
 
 bool ThreadTrack::IsTimerActive(const TimerInfo& timer_info) const {
-  return Capture::GVisibleFunctionsMap.find(timer_info.function_address()) !=
-         Capture::GVisibleFunctionsMap.end();
+  return GOrbitApp->IsFunctionVisible(timer_info.function_address());
 }
 
 Color ThreadTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected) const {


### PR DESCRIPTION
In order to reduce the number of globals, this PR moves the
Capture::GVisibleFunctionsMap to App's data manager. This map
was also only used in OrbitGl, so it is now also closer to
the users.

Bug: http://b/163020637
Test: Compile