### PR TITLE
ScopedState is always constructed on the main thread

### DIFF
--- a/OrbitGl/ScopedStatus.h
+++ b/OrbitGl/ScopedStatus.h
@@ -37,12 +37,11 @@ class ScopedStatus final {
  public:
   ScopedStatus() = default;
   explicit ScopedStatus(MainThreadExecutor* main_thread_executor, StatusListener* status_listener,
-                        const std::string& status_message,
-                        std::thread::id main_thread_id = std::this_thread::get_id()) {
+                        const std::string& status_message) {
     data_ = std::make_unique<Data>();
     data_->main_thread_executor = main_thread_executor;
     data_->status_listener = status_listener;
-    data_->main_thread_id = main_thread_id;
+    data_->main_thread_id = std::this_thread::get_id();
     data_->status_id = status_listener->AddStatus(status_message);
   }
 

--- a/OrbitGl/ScopedStatusTest.cpp
+++ b/OrbitGl/ScopedStatusTest.cpp
@@ -91,6 +91,23 @@ TEST(ScopedStatus, MoveAssignment) {
   }
 }
 
+TEST(ScopedStatus, SelfMoveAssign) {
+  MockStatusListener status_listener{};
+  MockMainThreadExecutor main_thread_executor{};
+  EXPECT_CALL(status_listener, AddStatus("Initial message")).Times(1);
+  EXPECT_CALL(status_listener, UpdateStatus(_, "Updated message")).Times(1);
+  EXPECT_CALL(status_listener, ClearStatus).Times(1);
+
+  {
+    ScopedStatus status1(&main_thread_executor, &status_listener, "Initial message");
+    status1.UpdateMessage("Updated message");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wself-move"
+    status1 = std::move(status1);
+#pragma GCC diagnostic pop
+  }
+}
+
 TEST(ScopedStatus, Unitialized) { ScopedStatus status{}; }
 
 TEST(ScopedStatus, UpdateUnutialized) {


### PR DESCRIPTION
ScopedState should always be constructed on the main thread,
because I am too lazy to handle the case when it is constructed
in another thread.

Also this adds missing test for self-move-assign.

Test: run OrbitGlTests