### PR TITLE
Add MESA's opengl32.dll to Win32 Docker containers

### DIFF
--- a/third_party/conan/docker/Dockerfile.msvc2017
+++ b/third_party/conan/docker/Dockerfile.msvc2017
@@ -38,5 +38,13 @@ RUN C:\TEMP\Install.cmd C:\TEMP\vs_buildtools.exe --quiet --wait --norestart --n
     --add Microsoft.VisualStudio.Component.Windows10SDK.17763 `
     --installPath C:\BuildTools
 
+ADD https://downloads.fdossena.com/Projects/Mesa3D/Builds/MesaForWindows-x64-20.1.5.7z C:\TEMP\MesaForWindows.7z
+
+RUN choco install --no-progress --yes --ignorepackagecodes 7zip.commandline --version=16.02.0.20170209; `
+    7z x -oC:\TEMP\ C:\TEMP\MesaForWindows.7z opengl32.dll; `
+    Copy-Item -Path C:\TEMP\opengl32.dll -Destination C:\Windows\system32\opengl32.dll; `
+    Remove-Item -Path C:\TEMP\MesaForWindows.7z; `
+    Remove-Item -Path C:\TEMP\opengl32.dll
+
 
 CMD ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]

--- a/third_party/conan/docker/Dockerfile.msvc2019
+++ b/third_party/conan/docker/Dockerfile.msvc2019
@@ -38,5 +38,13 @@ RUN C:\TEMP\Install.cmd C:\TEMP\vs_buildtools.exe --quiet --wait --norestart --n
     --add Microsoft.VisualStudio.Component.Windows10SDK.17763 `
     --installPath C:\BuildTools
 
+ADD https://downloads.fdossena.com/Projects/Mesa3D/Builds/MesaForWindows-x64-20.1.5.7z C:\TEMP\MesaForWindows.7z
+
+RUN choco install --no-progress --yes --ignorepackagecodes 7zip.commandline --version=16.02.0.20170209; `
+    7z x -oC:\TEMP\ C:\TEMP\MesaForWindows.7z opengl32.dll; `
+    Copy-Item -Path C:\TEMP\opengl32.dll -Destination C:\Windows\system32\opengl32.dll; `
+    Remove-Item -Path C:\TEMP\MesaForWindows.7z; `
+    Remove-Item -Path C:\TEMP\opengl32.dll
+
 
 CMD ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]


### PR DESCRIPTION
This is necessary since the new OrbitGl-tests require OpenGL to be available.

The MESA software renderer is the best way to fulfill that requirement. So this PR changes the Dockerfiles such that MESA's opengl32.dll will be installed in the containers.