### PR TITLE
Remove tr-tool from docker call in Kokoro

### DIFF
--- a/kokoro/builds/build.sh
+++ b/kokoro/builds/build.sh
@@ -199,5 +199,5 @@ else
     --isolation=process --storage-opt 'size=50GB' \
     ${CONTAINER} \
     'C:/Program Files/Git/bin/bash.exe' -c \
-    "/c/mnt/github/orbitprofiler/kokoro/builds/build.sh in_docker" | tr -d '\r'
+    "/c/mnt/github/orbitprofiler/kokoro/builds/build.sh in_docker"
 fi


### PR DESCRIPTION
Windows docker-run-calls were piped to tr to substitute Windows
line-endings `\r\n` by Unix-style line endings `\n`.

But this means the exit code does not properly propagate to Kokoro. This
commit fixes that by removing `tr` for now.