### PR TITLE
Move GSelectedTextBox to DataManager and make it const pointer

### DIFF
--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -18,7 +18,6 @@ using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::PresetFile;
 
 CaptureData Capture::capture_data_;
-TextBox* Capture::GSelectedTextBox = nullptr;
 
 std::shared_ptr<SamplingProfiler> Capture::GSamplingProfiler = nullptr;
 std::shared_ptr<Process> Capture::GTargetProcess = nullptr;
@@ -52,8 +51,6 @@ void Capture::FinalizeCapture() {
     Capture::GSamplingProfiler->ProcessSamples();
   }
 }
-
-void Capture::ClearCaptureData() { GSelectedTextBox = nullptr; }
 
 void Capture::PreSave() {
   // Add selected functions' exact address to sampling profiler

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -29,7 +29,6 @@ class Capture {
       uint64_t process_id, std::string process_name,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions);
   static void FinalizeCapture();
-  static void ClearCaptureData();
   static void PreSave();
 
   static CaptureData capture_data_;
@@ -37,7 +36,6 @@ class Capture {
   static std::shared_ptr<SamplingProfiler> GSamplingProfiler;
   static std::shared_ptr<Process> GTargetProcess;
   static std::shared_ptr<orbit_client_protos::PresetFile> GSessionPresets;
-  static class TextBox* GSelectedTextBox;
 };
 
 #endif  // ORBIT_CORE_CAPTURE_H_

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -596,7 +596,7 @@ void OrbitApp::StopCapture() {
 
 void OrbitApp::ClearCapture() {
   set_selected_thread_id(-1);
-  Capture::ClearCaptureData();
+  SelectTextBox(nullptr);
 
   if (GCurrentTimeGraph != nullptr) {
     GCurrentTimeGraph->Clear();
@@ -912,6 +912,11 @@ ThreadID OrbitApp::selected_thread_id() const { return data_manager_->selected_t
 
 void OrbitApp::set_selected_thread_id(ThreadID thread_id) {
   return data_manager_->set_selected_thread_id(thread_id);
+}
+
+const TextBox* OrbitApp::selected_text_box() const { return data_manager_->selected_text_box(); }
+void OrbitApp::SelectTextBox(const TextBox* text_box) {
+  data_manager_->set_selected_text_box(text_box);
 }
 
 void OrbitApp::UpdateSamplingReport() {

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -209,6 +209,9 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   [[nodiscard]] ThreadID selected_thread_id() const;
   void set_selected_thread_id(ThreadID thread_id);
 
+  [[nodiscard]] const TextBox* selected_text_box() const;
+  void SelectTextBox(const TextBox* text_box);
+
  private:
   void LoadModuleOnRemote(int32_t process_id, const std::shared_ptr<Module>& module,
                           const std::shared_ptr<orbit_client_protos::PresetFile>& preset);

--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -133,7 +133,7 @@ PickingUserData* Batcher::GetUserData(PickingId id) {
   return const_cast<PickingUserData*>(static_cast<const Batcher*>(this)->GetUserData(id));
 }
 
-TextBox* Batcher::GetTextBox(PickingId id) {
+const TextBox* Batcher::GetTextBox(PickingId id) {
   PickingUserData* data = GetUserData(id);
 
   if (data && data->text_box_) {

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -107,7 +107,7 @@ class Batcher {
   [[nodiscard]] const PickingUserData* GetUserData(PickingId id) const;
   [[nodiscard]] PickingUserData* GetUserData(PickingId id);
 
-  [[nodiscard]] TextBox* GetTextBox(PickingId id);
+  [[nodiscard]] const TextBox* GetTextBox(PickingId id);
 
  protected:
   void DrawLineBuffer(bool picking) const;

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -147,7 +147,7 @@ void CaptureWindow::Pick(int a_X, int a_Y) {
   std::memcpy(&value, &pixels[0], sizeof(uint32_t));
   PickingId pickId = PickingId::FromPixelValue(value);
 
-  Capture::GSelectedTextBox = nullptr;
+  GOrbitApp->SelectTextBox(nullptr);
   GOrbitApp->set_selected_thread_id(-1);
 
   Pick(pickId, a_X, a_Y);
@@ -159,7 +159,7 @@ void CaptureWindow::Pick(PickingId a_PickingID, int a_X, int a_Y) {
   PickingType type = a_PickingID.type;
 
   Batcher& batcher = GetBatcherById(a_PickingID.batcher_id);
-  TextBox* text_box = batcher.GetTextBox(a_PickingID);
+  const TextBox* text_box = batcher.GetTextBox(a_PickingID);
   if (text_box) {
     SelectTextBox(text_box);
   } else if (type == PickingType::kPickable) {
@@ -167,9 +167,9 @@ void CaptureWindow::Pick(PickingId a_PickingID, int a_X, int a_Y) {
   }
 }
 
-void CaptureWindow::SelectTextBox(class TextBox* text_box) {
+void CaptureWindow::SelectTextBox(const TextBox* text_box) {
   if (text_box == nullptr) return;
-  Capture::GSelectedTextBox = text_box;
+  GOrbitApp->SelectTextBox(text_box);
   GOrbitApp->set_selected_thread_id(text_box->GetTimerInfo().thread_id());
 
   const TimerInfo& timer_info = text_box->GetTimerInfo();
@@ -417,37 +417,42 @@ void CaptureWindow::KeyPressed(unsigned int a_KeyCode, bool a_Ctrl, bool a_Shift
         break;
       case 18:  // Left
         if (a_Shift) {
-          time_graph_.JumpToNeighborBox(Capture::GSelectedTextBox,
+          time_graph_.JumpToNeighborBox(GOrbitApp->selected_text_box(),
                                         TimeGraph::JumpDirection::kPrevious,
                                         TimeGraph::JumpScope::kSameFunction);
         } else if (a_Alt) {
-          time_graph_.JumpToNeighborBox(Capture::GSelectedTextBox,
+          time_graph_.JumpToNeighborBox(GOrbitApp->selected_text_box(),
                                         TimeGraph::JumpDirection::kPrevious,
                                         TimeGraph::JumpScope::kSameThreadSameFunction);
         } else {
-          time_graph_.JumpToNeighborBox(Capture::GSelectedTextBox,
+          time_graph_.JumpToNeighborBox(GOrbitApp->selected_text_box(),
                                         TimeGraph::JumpDirection::kPrevious,
                                         TimeGraph::JumpScope::kSameDepth);
         }
         break;
       case 20:  // Right
         if (a_Shift) {
-          time_graph_.JumpToNeighborBox(Capture::GSelectedTextBox, TimeGraph::JumpDirection::kNext,
+          time_graph_.JumpToNeighborBox(GOrbitApp->selected_text_box(),
+                                        TimeGraph::JumpDirection::kNext,
                                         TimeGraph::JumpScope::kSameFunction);
         } else if (a_Alt) {
-          time_graph_.JumpToNeighborBox(Capture::GSelectedTextBox, TimeGraph::JumpDirection::kNext,
+          time_graph_.JumpToNeighborBox(GOrbitApp->selected_text_box(),
+                                        TimeGraph::JumpDirection::kNext,
                                         TimeGraph::JumpScope::kSameThreadSameFunction);
         } else {
-          time_graph_.JumpToNeighborBox(Capture::GSelectedTextBox, TimeGraph::JumpDirection::kNext,
+          time_graph_.JumpToNeighborBox(GOrbitApp->selected_text_box(),
+                                        TimeGraph::JumpDirection::kNext,
                                         TimeGraph::JumpScope::kSameDepth);
         }
         break;
       case 19:  // Up
-        time_graph_.JumpToNeighborBox(Capture::GSelectedTextBox, TimeGraph::JumpDirection::kTop,
+        time_graph_.JumpToNeighborBox(GOrbitApp->selected_text_box(),
+                                      TimeGraph::JumpDirection::kTop,
                                       TimeGraph::JumpScope::kSameThread);
         break;
       case 21:  // Down
-        time_graph_.JumpToNeighborBox(Capture::GSelectedTextBox, TimeGraph::JumpDirection::kDown,
+        time_graph_.JumpToNeighborBox(GOrbitApp->selected_text_box(),
+                                      TimeGraph::JumpDirection::kDown,
                                       TimeGraph::JumpScope::kSameThread);
         break;
     }

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -46,7 +46,7 @@ class CaptureWindow : public GlCanvas {
   void Resize(int a_Width, int a_Height) override;
   void RenderHelpUi();
   void RenderTimeBar();
-  void SelectTextBox(TextBox* text_box);
+  void SelectTextBox(const TextBox* text_box);
   void OnDrag(float a_Ratio);
   void OnVerticalDrag(float a_Ratio);
   void NeedsUpdate();

--- a/OrbitGl/DataManager.cpp
+++ b/OrbitGl/DataManager.cpp
@@ -75,6 +75,16 @@ int32_t DataManager::selected_thread_id() const {
   return selected_thread_id_;
 }
 
+const TextBox* DataManager::selected_text_box() const {
+  CHECK(std::this_thread::get_id() == main_thread_id_);
+  return selected_text_box_;
+}
+
+void DataManager::set_selected_text_box(const TextBox* text_box) {
+  CHECK(std::this_thread::get_id() == main_thread_id_);
+  selected_text_box_ = text_box;
+}
+
 void DataManager::ClearSelectedFunctions() {
   CHECK(std::this_thread::get_id() == main_thread_id_);
   selected_functions_ = absl::flat_hash_set<uint64_t>();

--- a/OrbitGl/DataManager.h
+++ b/OrbitGl/DataManager.h
@@ -8,6 +8,7 @@
 #include <thread>
 
 #include "ProcessData.h"
+#include "TextBox.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 
@@ -30,6 +31,7 @@ class DataManager final {
   void set_selected_functions(absl::flat_hash_set<uint64_t> selected_functions);
   void set_visible_functions(absl::flat_hash_set<uint64_t> visible_functions);
   void set_selected_thread_id(int32_t thread_id);
+  void set_selected_text_box(const TextBox* text_box);
 
   [[nodiscard]] ProcessData* GetProcessByPid(int32_t process_id) const;
   [[nodiscard]] const std::vector<ModuleData*>& GetModules(int32_t process_id) const;
@@ -39,6 +41,7 @@ class DataManager final {
   [[nodiscard]] const absl::flat_hash_set<uint64_t>& selected_functions() const;
   [[nodiscard]] bool IsFunctionVisible(uint64_t function_address) const;
   [[nodiscard]] int32_t selected_thread_id() const;
+  [[nodiscard]] const TextBox* selected_text_box() const;
 
  private:
   const std::thread::id main_thread_id_;
@@ -46,6 +49,7 @@ class DataManager final {
   absl::flat_hash_set<uint64_t> selected_functions_;
   absl::flat_hash_set<uint64_t> visible_functions_;
   int32_t selected_thread_id_ = -1;
+  const TextBox* selected_text_box_ = nullptr;
 };
 
 #endif  // ORBIT_GL_DATA_MANAGER_H_

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -159,7 +159,7 @@ float GpuTrack::GetHeight() const {
   return layout.GetTextBoxHeight() * depth + layout.GetTrackBottomMargin();
 }
 
-const TextBox* GpuTrack::GetLeft(TextBox* text_box) const {
+const TextBox* GpuTrack::GetLeft(const TextBox* text_box) const {
   const TimerInfo& timer_info = text_box->GetTimerInfo();
   uint64_t timeline_hash = timer_info.user_data_key();
   if (timeline_hash == timeline_hash_) {
@@ -169,7 +169,7 @@ const TextBox* GpuTrack::GetLeft(TextBox* text_box) const {
   return nullptr;
 }
 
-const TextBox* GpuTrack::GetRight(TextBox* text_box) const {
+const TextBox* GpuTrack::GetRight(const TextBox* text_box) const {
   const TimerInfo& timer_info = text_box->GetTimerInfo();
   uint64_t timeline_hash = timer_info.user_data_key();
   if (timeline_hash == timeline_hash_) {
@@ -180,7 +180,7 @@ const TextBox* GpuTrack::GetRight(TextBox* text_box) const {
 }
 
 std::string GpuTrack::GetBoxTooltip(PickingId id) const {
-  TextBox* text_box = time_graph_->GetBatcher().GetTextBox(id);
+  const TextBox* text_box = time_graph_->GetBatcher().GetTextBox(id);
   if (!text_box || text_box->GetTimerInfo().type() == TimerInfo::kCoreActivity) {
     return "";
   }

--- a/OrbitGl/GpuTrack.h
+++ b/OrbitGl/GpuTrack.h
@@ -32,8 +32,8 @@ class GpuTrack : public TimerTrack {
   [[nodiscard]] Type GetType() const override { return kGpuTrack; }
   [[nodiscard]] float GetHeight() const override;
 
-  [[nodiscard]] const TextBox* GetLeft(TextBox* text_box) const override;
-  [[nodiscard]] const TextBox* GetRight(TextBox* text_box) const override;
+  [[nodiscard]] const TextBox* GetLeft(const TextBox* text_box) const override;
+  [[nodiscard]] const TextBox* GetRight(const TextBox* text_box) const override;
 
   [[nodiscard]] float GetYFromDepth(uint32_t depth) const override;
 

--- a/OrbitGl/LiveFunctionsController.cpp
+++ b/OrbitGl/LiveFunctionsController.cpp
@@ -6,6 +6,7 @@
 
 #include <utility>
 
+#include "App.h"
 #include "Capture.h"
 #include "FunctionUtils.h"
 #include "TimeGraph.h"
@@ -190,7 +191,7 @@ void LiveFunctionsController::AddIterator(FunctionInfo* function) {
   ++next_iterator_id_;
 
   auto function_address = FunctionUtils::GetAbsoluteAddress(*function);
-  const TextBox* box = Capture::GSelectedTextBox;
+  const TextBox* box = GOrbitApp->selected_text_box();
   // If no box is currently selected or the selected box is a different
   // function, we search for the closest box to the current center of the
   // screen.

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -61,7 +61,7 @@ void SchedulerTrack::UpdateBoxHeight() {
 }
 
 std::string SchedulerTrack::GetBoxTooltip(PickingId id) const {
-  TextBox* text_box = time_graph_->GetBatcher().GetTextBox(id);
+  const TextBox* text_box = time_graph_->GetBatcher().GetTextBox(id);
   if (!text_box) {
     return "";
   }

--- a/OrbitGl/TextBox.cpp
+++ b/OrbitGl/TextBox.cpp
@@ -86,7 +86,7 @@ void TextBox::Draw(Batcher* batcher, TextRenderer& text_renderer, float min_x, b
 
   Color col = is_same_thread_id_as_selected ? m_Color : is_inactive ? grey : m_Color;
 
-  if (this == Capture::GSelectedTextBox) {
+  if (this == GOrbitApp->selected_text_box()) {
     col = selection_color;
   }
 

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -21,7 +21,7 @@ ThreadTrack::ThreadTrack(TimeGraph* time_graph, int32_t thread_id)
   event_track_->SetThreadId(thread_id);
 }
 
-const TextBox* ThreadTrack::GetLeft(TextBox* text_box) const {
+const TextBox* ThreadTrack::GetLeft(const TextBox* text_box) const {
   const TimerInfo& timer_info = text_box->GetTimerInfo();
   if (timer_info.thread_id() == thread_id_) {
     std::shared_ptr<TimerChain> timers = GetTimers(timer_info.depth());
@@ -30,7 +30,7 @@ const TextBox* ThreadTrack::GetLeft(TextBox* text_box) const {
   return nullptr;
 }
 
-const TextBox* ThreadTrack::GetRight(TextBox* text_box) const {
+const TextBox* ThreadTrack::GetRight(const TextBox* text_box) const {
   const TimerInfo& timer_info = text_box->GetTimerInfo();
   if (timer_info.thread_id() == thread_id_) {
     std::shared_ptr<TimerChain> timers = GetTimers(timer_info.depth());
@@ -40,7 +40,7 @@ const TextBox* ThreadTrack::GetRight(TextBox* text_box) const {
 }
 
 std::string ThreadTrack::GetBoxTooltip(PickingId id) const {
-  TextBox* text_box = time_graph_->GetBatcher().GetTextBox(id);
+  const TextBox* text_box = time_graph_->GetBatcher().GetTextBox(id);
   if (!text_box || text_box->GetTimerInfo().type() == TimerInfo::kCoreActivity) {
     return "";
   }

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -20,8 +20,8 @@ class ThreadTrack : public TimerTrack {
   [[nodiscard]] Type GetType() const override { return kThreadTrack; }
   [[nodiscard]] std::string GetTooltip() const override;
 
-  [[nodiscard]] const TextBox* GetLeft(TextBox* textbox) const override;
-  [[nodiscard]] const TextBox* GetRight(TextBox* textbox) const override;
+  [[nodiscard]] const TextBox* GetLeft(const TextBox* textbox) const override;
+  [[nodiscard]] const TextBox* GetRight(const TextBox* textbox) const override;
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
 

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -499,11 +499,10 @@ void TimeGraph::GetWorldMinMax(float& a_Min, float& a_Max) const {
   a_Max = GetWorldFromTick(capture_max_timestamp_);
 }
 
-void TimeGraph::Select(const TextBox* a_TextBox) {
-  TextBox* text_box = const_cast<TextBox*>(a_TextBox);
-  Capture::GSelectedTextBox = text_box;
-  HorizontallyMoveIntoView(VisibilityType::kPartlyVisible, a_TextBox);
-  VerticallyMoveIntoView(a_TextBox);
+void TimeGraph::Select(const TextBox* text_box) {
+  GOrbitApp->SelectTextBox(text_box);
+  HorizontallyMoveIntoView(VisibilityType::kPartlyVisible, text_box);
+  VerticallyMoveIntoView(text_box);
 }
 
 const TextBox* TimeGraph::FindPreviousFunctionCall(uint64_t function_address, TickType current_time,
@@ -984,7 +983,7 @@ void TimeGraph::SelectAndZoom(const TextBox* text_box) {
   Select(text_box);
 }
 
-void TimeGraph::JumpToNeighborBox(TextBox* from, JumpDirection jump_direction,
+void TimeGraph::JumpToNeighborBox(const TextBox* from, JumpDirection jump_direction,
                                   JumpScope jump_scope) {
   const TextBox* goal = nullptr;
   if (!from) {
@@ -1037,7 +1036,7 @@ void TimeGraph::JumpToNeighborBox(TextBox* from, JumpDirection jump_direction,
   }
 }
 
-const TextBox* TimeGraph::FindPrevious(TextBox* from) {
+const TextBox* TimeGraph::FindPrevious(const TextBox* from) {
   CHECK(from);
   const TimerInfo& timer_info = from->GetTimerInfo();
   if (timer_info.type() == TimerInfo::kGpuActivity) {
@@ -1048,7 +1047,7 @@ const TextBox* TimeGraph::FindPrevious(TextBox* from) {
   return nullptr;
 }
 
-const TextBox* TimeGraph::FindNext(TextBox* from) {
+const TextBox* TimeGraph::FindNext(const TextBox* from) {
   CHECK(from);
   const TimerInfo& timer_info = from->GetTimerInfo();
   if (timer_info.type() == TimerInfo::kGpuActivity) {
@@ -1059,7 +1058,7 @@ const TextBox* TimeGraph::FindNext(TextBox* from) {
   return nullptr;
 }
 
-const TextBox* TimeGraph::FindTop(TextBox* from) {
+const TextBox* TimeGraph::FindTop(const TextBox* from) {
   CHECK(from);
   const TimerInfo& timer_info = from->GetTimerInfo();
   if (timer_info.type() == TimerInfo::kGpuActivity) {
@@ -1070,7 +1069,7 @@ const TextBox* TimeGraph::FindTop(TextBox* from) {
   return nullptr;
 }
 
-const TextBox* TimeGraph::FindDown(TextBox* from) {
+const TextBox* TimeGraph::FindDown(const TextBox* from) {
   CHECK(from);
   const TimerInfo& timer_info = from->GetTimerInfo();
   if (timer_info.type() == TimerInfo::kGpuActivity) {

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -77,10 +77,10 @@ class TimeGraph {
   void VerticallyMoveIntoView(const TextBox* text_box);
   double GetTime(double a_Ratio);
   double GetTimeIntervalMicro(double a_Ratio);
-  void Select(const TextBox* a_TextBox);
+  void Select(const TextBox* text_box);
   enum class JumpScope { kGlobal, kSameDepth, kSameThread, kSameFunction, kSameThreadSameFunction };
   enum class JumpDirection { kPrevious, kNext, kTop, kDown };
-  void JumpToNeighborBox(TextBox* from, JumpDirection jump_direction, JumpScope jump_scope);
+  void JumpToNeighborBox(const TextBox* from, JumpDirection jump_direction, JumpScope jump_scope);
   const TextBox* FindPreviousFunctionCall(uint64_t function_address, TickType current_time,
                                           std::optional<int32_t> thread_ID = std::nullopt) const;
   const TextBox* FindNextFunctionCall(uint64_t function_address, TickType current_time,
@@ -119,10 +119,10 @@ class TimeGraph {
   float GetVerticalMargin() const { return vertical_margin_; }
   void SetVerticalMargin(float margin) { vertical_margin_ = margin; }
 
-  const TextBox* FindPrevious(TextBox* from);
-  const TextBox* FindNext(TextBox* from);
-  const TextBox* FindTop(TextBox* from);
-  const TextBox* FindDown(TextBox* from);
+  const TextBox* FindPrevious(const TextBox* from);
+  const TextBox* FindNext(const TextBox* from);
+  const TextBox* FindTop(const TextBox* from);
+  const TextBox* FindDown(const TextBox* from);
 
   Color GetThreadColor(ThreadID tid) const;
   [[nodiscard]] std::string GetManualInstrumentationString(uint64_t string_address) const;

--- a/OrbitGl/TimerTrack.cpp
+++ b/OrbitGl/TimerTrack.cpp
@@ -6,6 +6,7 @@
 
 #include <limits>
 
+#include "App.h"
 #include "Capture.h"
 #include "EventTrack.h"
 #include "FunctionUtils.h"
@@ -118,7 +119,7 @@ void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
         float world_timer_y = GetYFromDepth(timer_info.depth());
 
         bool is_visible_width = normalized_length * canvas->getWidth() > 1;
-        bool is_selected = &text_box == Capture::GSelectedTextBox;
+        bool is_selected = &text_box == GOrbitApp->selected_text_box();
 
         Vec2 pos(world_timer_x, world_timer_y);
         Vec2 size(world_timer_width, box_height_);
@@ -240,12 +241,12 @@ std::shared_ptr<TimerChain> TimerTrack::GetTimers(uint32_t depth) const {
   return nullptr;
 }
 
-const TextBox* TimerTrack::GetUp(TextBox* text_box) const {
+const TextBox* TimerTrack::GetUp(const TextBox* text_box) const {
   const TimerInfo& timer_info = text_box->GetTimerInfo();
   return GetFirstBeforeTime(timer_info.start(), timer_info.depth() - 1);
 }
 
-const TextBox* TimerTrack::GetDown(TextBox* text_box) const {
+const TextBox* TimerTrack::GetDown(const TextBox* text_box) const {
   const TimerInfo& timer_info = text_box->GetTimerInfo();
   return GetFirstAfterTime(timer_info.start(), timer_info.depth() + 1);
 }

--- a/OrbitGl/TimerTrack.h
+++ b/OrbitGl/TimerTrack.h
@@ -49,12 +49,12 @@ class TimerTrack : public Track {
   [[nodiscard]] const TextBox* GetFirstBeforeTime(TickType time, uint32_t depth) const;
 
   // Must be overriden by child class for sensible behavior.
-  [[nodiscard]] virtual const TextBox* GetLeft(TextBox* textbox) const { return textbox; };
+  [[nodiscard]] virtual const TextBox* GetLeft(const TextBox* textbox) const { return textbox; };
   // Must be overriden by child class for sensible behavior.
-  [[nodiscard]] virtual const TextBox* GetRight(TextBox* textbox) const { return textbox; };
+  [[nodiscard]] virtual const TextBox* GetRight(const TextBox* textbox) const { return textbox; };
 
-  [[nodiscard]] virtual const TextBox* GetUp(TextBox* textbox) const;
-  [[nodiscard]] virtual const TextBox* GetDown(TextBox* textbox) const;
+  [[nodiscard]] virtual const TextBox* GetUp(const TextBox* textbox) const;
+  [[nodiscard]] virtual const TextBox* GetDown(const TextBox* textbox) const;
 
   [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllChains() override;
   [[nodiscard]] virtual bool IsEmpty() const;


### PR DESCRIPTION
Move GSelectedTextBox from Capture global to DataManager and
made it always a const pointer (rather then a raw pointer).
This touches a couple of functions, where it was passed as an
argument.

Test: Compile, do a capture, move arround text boxes.
Bug: https://b/163020637