### PR TITLE
Remove GSessionPreset global

### DIFF
--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -15,13 +15,11 @@
 #include "absl/strings/str_format.h"
 
 using orbit_client_protos::FunctionInfo;
-using orbit_client_protos::PresetFile;
 
 CaptureData Capture::capture_data_;
 
 std::shared_ptr<SamplingProfiler> Capture::GSamplingProfiler = nullptr;
 std::shared_ptr<Process> Capture::GTargetProcess = nullptr;
-std::shared_ptr<PresetFile> Capture::GSessionPresets = nullptr;
 
 void Capture::Init() { GTargetProcess = std::make_shared<Process>(); }
 

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -32,7 +32,6 @@ class Capture {
 
   static std::shared_ptr<SamplingProfiler> GSamplingProfiler;
   static std::shared_ptr<Process> GTargetProcess;
-  static std::shared_ptr<orbit_client_protos::PresetFile> GSessionPresets;
 };
 
 #endif  // ORBIT_CORE_CAPTURE_H_

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -102,7 +102,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
                           const CallstackData* callstack_data);
   void AddTopDownView(const SamplingProfiler& sampling_profiler);
 
-  bool SelectProcess(const std::string& process);
+  bool SelectProcess(const std::string& process,
+                     const std::shared_ptr<orbit_client_protos::PresetFile>& preset);
 
   // Callbacks
   using CaptureStartedCallback = std::function<void()>;
@@ -189,7 +190,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
                    const std::shared_ptr<orbit_client_protos::PresetFile>& preset = nullptr);
   void LoadModulesFromPreset(const std::shared_ptr<Process>& process,
                              const std::shared_ptr<orbit_client_protos::PresetFile>& preset);
-  void UpdateProcessAndModuleList(int32_t pid);
+  void UpdateProcessAndModuleList(int32_t pid,
+                                  const std::shared_ptr<orbit_client_protos::PresetFile>& preset);
 
   void UpdateSamplingReport();
   void LoadPreset(const std::shared_ptr<orbit_client_protos::PresetFile>& session);

--- a/OrbitGl/ModulesDataView.cpp
+++ b/OrbitGl/ModulesDataView.cpp
@@ -179,7 +179,7 @@ void ModulesDataView::SetModules(int32_t process_id, const std::vector<ModuleDat
 }
 
 void ModulesDataView::OnRefreshButtonClicked() {
-  GOrbitApp->UpdateProcessAndModuleList(GOrbitApp->GetSelectedProcessID());
+  GOrbitApp->UpdateProcessAndModuleList(GOrbitApp->GetSelectedProcessID(), nullptr);
 }
 
 const ModuleData* ModulesDataView::GetModule(uint32_t row) const { return modules_[indices_[row]]; }

--- a/OrbitGl/ProcessesDataView.h
+++ b/OrbitGl/ProcessesDataView.h
@@ -13,7 +13,9 @@ class ProcessesDataView final : public DataView {
  public:
   ProcessesDataView();
 
-  void SetSelectionListener(const std::function<void(int32_t)>& selection_listener);
+  void SetSelectionListener(
+      const std::function<void(int32_t, const std::shared_ptr<orbit_client_protos::PresetFile>&
+                                            preset)>& selection_listener);
   const std::vector<Column>& GetColumns() override;
   int GetDefaultSortingColumn() override { return kColumnCpu; }
   std::string GetValue(int row, int column) override;
@@ -21,7 +23,9 @@ class ProcessesDataView final : public DataView {
   std::string GetLabel() override { return "Processes"; }
 
   void OnSelect(int index) override;
-  bool SelectProcess(const std::string& process_name);
+  void OnSelect(int index, const std::shared_ptr<orbit_client_protos::PresetFile>& preset);
+  bool SelectProcess(const std::string& process_name,
+                     const std::shared_ptr<orbit_client_protos::PresetFile>& preset);
   bool SelectProcess(int32_t process_id);
   void SetProcessList(const std::vector<orbit_grpc_protos::ProcessInfo>& process_list);
   int32_t GetSelectedProcessId() const;
@@ -39,7 +43,8 @@ class ProcessesDataView final : public DataView {
 
   std::vector<orbit_grpc_protos::ProcessInfo> process_list_;
   int32_t selected_process_id_;
-  std::function<void(int32_t)> selection_listener_;
+  std::function<void(int32_t, const std::shared_ptr<orbit_client_protos::PresetFile>& preset)>
+      selection_listener_;
 
   enum ColumnIndex { kColumnPid, kColumnName, kColumnCpu, kNumColumns };
 };


### PR DESCRIPTION
Capture::GSessionPreset was used to support the following scenario:
1. Load a preset, whose associated process is running but not selected.
2. Loading the preset was asynch. selecting the process and then
  applying the preset.

If the process was not running at all, an error was shown to the user.

This required keeping track of the preset variable through not
straightforward control-flow.
This change will ask the user to select the process by herself, which
allows to remove the global and makes the control-flow explicit.

Bug: http://b/163020637
Test: Compile, Select preset when
      (1) process is runnig and selected,
      (2) process is running but not selected,
      (3) process is not running.