### PR TITLE
Refactor TextBox

### DIFF
--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -5,6 +5,7 @@
 #include "Batcher.h"
 
 #include "OpenGl.h"
+#include "TextBox.h"
 #include "Utils.h"
 
 void Batcher::AddLine(Vec2 from, Vec2 to, float z, const Color& color,
@@ -31,8 +32,8 @@ void Batcher::AddVerticalLine(Vec2 pos, float size, float z, const Color& color,
 void Batcher::AddLine(Vec2 from, Vec2 to, float z, const Color& color, const Color& picking_color,
                       std::unique_ptr<PickingUserData> user_data) {
   Line line;
-  line.m_Beg = Vec3(from[0], from[1], z);
-  line.m_End = Vec3(to[0], to[1], z);
+  line.start_point = Vec3(from[0], from[1], z);
+  line.end_point = Vec3(to[0], to[1], z);
 
   line_buffer_.lines_.push_back(line);
   line_buffer_.colors_.push_back_n(color, 2);

--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -5,7 +5,6 @@
 #include "Batcher.h"
 
 #include "OpenGl.h"
-#include "TextBox.h"
 #include "Utils.h"
 
 void Batcher::AddLine(Vec2 from, Vec2 to, float z, const Color& color,

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -12,6 +12,9 @@
 #include "Geometry.h"
 #include "PickingManager.h"
 
+// TODO: Remove cyclic reference
+class TextBox;
+
 using TooltipCallback = std::function<std::string(PickingId)>;
 
 struct PickingUserData {

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -11,9 +11,7 @@
 #include "BlockChain.h"
 #include "Geometry.h"
 #include "PickingManager.h"
-
-// TODO: Remove cyclic reference
-class TextBox;
+#include "TextBox.h"
 
 using TooltipCallback = std::function<std::string(PickingId)>;
 

--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -86,7 +86,6 @@ target_sources(
           SamplingReport.cpp
           SamplingReportDataView.cpp
           SchedulerTrack.cpp
-          TextBox.cpp
           TextRenderer.cpp
           TimeGraph.cpp
           TimeGraphLayout.cpp

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -93,6 +93,7 @@ void CaptureWindow::MouseMoved(int a_X, int a_Y, bool a_Left, bool /*a_Right*/, 
   }
 
   if (m_IsSelecting) {
+    ScreenToWorld(std::max(a_X, 0), std::max(a_Y, 0), worldx, worldy);
     m_SelectStop = Vec2(worldx, worldy);
     m_TimeStop = time_graph_.GetTickFromWorld(worldx);
   }

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -86,7 +86,6 @@ void CaptureWindow::MouseMoved(int a_X, int a_Y, bool a_Left, bool /*a_Right*/, 
     m_WorldTopLeftX = clamp(m_WorldTopLeftX, worldMin, worldMax - m_WorldWidth);
     m_WorldTopLeftY =
         clamp(m_WorldTopLeftY, m_WorldHeight - time_graph_.GetThreadTotalHeight(), m_WorldMaxY);
-    UpdateSceneBox();
 
     time_graph_.PanTime(m_ScreenClickX, a_X, getWidth(), static_cast<double>(m_RefTimeClick));
     UpdateVerticalSlider();
@@ -316,7 +315,6 @@ void CaptureWindow::Pan(float a_Ratio) {
   double refTime = time_graph_.GetTime(static_cast<double>(m_MousePosX) / getWidth());
   time_graph_.PanTime(m_MousePosX, m_MousePosX + static_cast<int>(a_Ratio * getWidth()), getWidth(),
                       refTime);
-  UpdateSceneBox();
   NeedsUpdate();
 }
 

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -807,13 +807,13 @@ void CaptureWindow::RenderSelectionOverlay() {
     Box box(pos, size, GlCanvas::Z_VALUE_BOX_ACTIVE);
     ui_batcher_.AddBox(box, color);
 
-    static Color text_color(255, 255, 255, 255);
+    const Color text_color(255, 255, 255, 255);
     float pos_x = pos[0] + size[0];
 
     m_TextRenderer.AddText(text.c_str(), pos_x, m_SelectStop[1], GlCanvas::Z_VALUE_TEXT, text_color,
                            size[0], true);
 
-    static unsigned char g = 100;
+    const unsigned char g = 100;
     Color grey(g, g, g, 255);
     ui_batcher_.AddVerticalLine(pos, size[1], GlCanvas::Z_VALUE_BOX_ACTIVE, grey);
   }

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -487,22 +487,7 @@ void CaptureWindow::Draw() {
 
   time_graph_.Draw(this, GetPickingMode());
 
-  if (!m_Picking && m_SelectStart[0] != m_SelectStop[0]) {
-    TickType minTime = std::min(m_TimeStart, m_TimeStop);
-    TickType maxTime = std::max(m_TimeStart, m_TimeStop);
-
-    float from = time_graph_.GetWorldFromTick(minTime);
-    float to = time_graph_.GetWorldFromTick(maxTime);
-
-    float sizex = to - from;
-    Vec2 pos(from, m_WorldTopLeftY - m_WorldHeight);
-    Vec2 size(sizex, m_WorldHeight);
-
-    std::string time = GetPrettyTime(TicksToDuration(minTime, maxTime));
-    TextBox box(pos, size, time, Color(0, 128, 0, 128));
-    box.SetTextY(m_SelectStop[1]);
-    box.Draw(&ui_batcher_, m_TextRenderer, -FLT_MAX, true, true);
-  }
+  RenderSelectionOverlay();
 
   if (GetPickingMode() == PickingMode::kNone) {
     RenderTimeBar();
@@ -800,6 +785,36 @@ void CaptureWindow::RenderTimeBar() {
       Vec2 pos(worldX, worldY);
       ui_batcher_.AddVerticalLine(pos, height, GlCanvas::Z_VALUE_UI, Color(255, 255, 255, 255));
     }
+  }
+}
+
+void CaptureWindow::RenderSelectionOverlay() {
+  if (!m_Picking && m_SelectStart[0] != m_SelectStop[0]) {
+    TickType minTime = std::min(m_TimeStart, m_TimeStop);
+    TickType maxTime = std::max(m_TimeStart, m_TimeStop);
+
+    float from = time_graph_.GetWorldFromTick(minTime);
+    float to = time_graph_.GetWorldFromTick(maxTime);
+
+    float sizex = to - from;
+    Vec2 pos(from, m_WorldTopLeftY - m_WorldHeight);
+    Vec2 size(sizex, m_WorldHeight);
+
+    std::string text = GetPrettyTime(TicksToDuration(minTime, maxTime));
+    const Color color(0, 128, 0, 128);
+
+    Box box(pos, size, GlCanvas::Z_VALUE_BOX_ACTIVE);
+    ui_batcher_.AddBox(box, color);
+
+    static Color text_color(255, 255, 255, 255);
+    float pos_x = pos[0] + size[0];
+
+    m_TextRenderer.AddText(text.c_str(), pos_x, m_SelectStop[1], GlCanvas::Z_VALUE_TEXT, text_color,
+                           size[0], true);
+
+    static unsigned char g = 100;
+    Color grey(g, g, g, 255);
+    ui_batcher_.AddVerticalLine(pos, size[1], GlCanvas::Z_VALUE_BOX_ACTIVE, grey);
   }
 }
 

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -46,6 +46,7 @@ class CaptureWindow : public GlCanvas {
   void Resize(int a_Width, int a_Height) override;
   void RenderHelpUi();
   void RenderTimeBar();
+  void RenderSelectionOverlay();
   void SelectTextBox(const TextBox* text_box);
   void OnDrag(float a_Ratio);
   void OnVerticalDrag(float a_Ratio);

--- a/OrbitGl/Geometry.h
+++ b/OrbitGl/Geometry.h
@@ -2,34 +2,35 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#pragma once
-#include "BlockChain.h"
+#ifndef ORBIT_GL_GEOMETRY_H_
+#define ORBIT_GL_GEOMETRY_H_
+
 #include "CoreMath.h"
 
-class TextBox;
-
 struct Line {
-  Vec3 m_Beg;
-  Vec3 m_End;
+  Vec3 start_point;
+  Vec3 end_point;
 };
 
 struct Box {
   Box() = default;
   Box(Vec2 pos, Vec2 size, float z) {
-    vertices_[0] = Vec3(pos[0], pos[1], z);
-    vertices_[1] = Vec3(pos[0], pos[1] + size[1], z);
-    vertices_[2] = Vec3(pos[0] + size[0], pos[1] + size[1], z);
-    vertices_[3] = Vec3(pos[0] + size[0], pos[1], z);
+    vertices[0] = Vec3(pos[0], pos[1], z);
+    vertices[1] = Vec3(pos[0], pos[1] + size[1], z);
+    vertices[2] = Vec3(pos[0] + size[0], pos[1] + size[1], z);
+    vertices[3] = Vec3(pos[0] + size[0], pos[1], z);
   }
-  Vec3 vertices_[4];
+  Vec3 vertices[4];
 };
 
 struct Triangle {
   Triangle() = default;
   Triangle(Vec3 v0, Vec3 v1, Vec3 v2) {
-    vertices_[0] = v0;
-    vertices_[1] = v1;
-    vertices_[2] = v2;
+    vertices[0] = v0;
+    vertices[1] = v1;
+    vertices[2] = v2;
   }
-  Vec3 vertices_[3];
+  Vec3 vertices[3];
 };
+
+#endif

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -74,8 +74,6 @@ GlCanvas::GlCanvas() : ui_batcher_(BatcherId::kUi, &m_PickingManager) {
   m_IsHovering = false;
   ResetHoverTimer();
 
-  UpdateSceneBox();
-
   m_ImGuiContext = ImGui::CreateContext();
   ScopeImguiContext state(m_ImGuiContext);
   Orbit_ImGui_Init();
@@ -118,7 +116,6 @@ void GlCanvas::MouseMoved(int a_X, int a_Y, bool a_Left, bool /*a_Right*/, bool 
   if (a_Left && !m_ImguiActive) {
     m_WorldTopLeftX = m_WorldClickX - static_cast<float>(mousex) / getWidth() * m_WorldWidth;
     m_WorldTopLeftY = m_WorldClickY + static_cast<float>(mousey) / getHeight() * m_WorldHeight;
-    UpdateSceneBox();
   }
 
   if (m_IsSelecting) {
@@ -298,8 +295,6 @@ void GlCanvas::prepare2DViewport(int topleft_x, int topleft_y, int bottomrigth_x
   m_WorldWidth = m_Width;
   m_WorldHeight = m_Height;
 
-  UpdateSceneBox();
-
   // TRACE_VAR( m_ScreenClickY );
   // TRACE_VAR( GPdbDbg->GetFunctions().size() );
   // TRACE_VAR( GPdbDbg->GetTypes().size() );
@@ -427,16 +422,6 @@ void GlCanvas::Resize(int a_Width, int a_Height) {
   m_Width = a_Width;
   m_Height = a_Height;
   NeedsRedraw();
-}
-
-void GlCanvas::UpdateSceneBox() {
-  Vec2 pos;
-  pos[0] = m_WorldTopLeftX;
-  pos[1] = m_WorldTopLeftY - m_WorldHeight;
-
-  Vec2 size(m_WorldWidth, m_WorldHeight);
-
-  m_SceneBox = TextBox(pos, size);
 }
 
 Vec2 GlCanvas::ToScreenSpace(const Vec2& a_Point) {

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -62,12 +62,9 @@ class GlCanvas : public GlPanel {
   void SetWorldTopLeftY(float val) { m_WorldTopLeftY = val; }
 
   TextRenderer& GetTextRenderer() { return m_TextRenderer; }
-  const TextBox& GetSceneBox() { return m_SceneBox; }
-  void SetSceneBox(const TextBox& a_TextBox) { m_SceneBox = a_TextBox; }
   void SetBackgroundColor(const Vec4& a_Color) { m_BackgroundColor = a_Color; }
 
   virtual void UpdateWheelMomentum(float a_DeltaTime);
-  void UpdateSceneBox();
   virtual void OnTimer();
 
   float GetMouseX() const { return m_MouseX; }
@@ -158,7 +155,6 @@ class GlCanvas : public GlPanel {
   TickType m_RefTimeClick;
   TickType m_SelectedInterval;
   TextRenderer m_TextRenderer;
-  TextBox m_SceneBox;
   Timer m_UpdateTimer;
   PickingManager m_PickingManager;
   bool m_Picking;

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -143,7 +143,7 @@ void GpuTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_us, 
   float pos_x = std::max(box_pos[0], min_x);
   float max_size = box_pos[0] + box_size[0] - pos_x;
   text_renderer_->AddTextTrailingCharsPrioritized(
-      text_box->GetText().c_str(), pos_x, text_box->GetPosY() + layout.GetTextOffset(),
+      text_box->GetText().c_str(), pos_x, text_box->GetPos()[1] + layout.GetTextOffset(),
       GlCanvas::Z_VALUE_TEXT, kTextWhite, text_box->GetElapsedTimeTextLength(), max_size);
 }
 

--- a/OrbitGl/TextBox.cpp
+++ b/OrbitGl/TextBox.cpp
@@ -17,57 +17,30 @@ using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::TimerInfo;
 
 TextBox::TextBox()
-    : m_Pos(Vec2::Zero()),
-      m_Size(Vec2(100.f, 10.f)),
-      m_MainFrameCounter(-1),
-      m_Selected(false),
-      m_TextY(FLT_MAX),
-      m_ElapsedTimeTextLength(0) {
-  Update();
-}
+    : pos_(Vec2::Zero()),
+      size_(Vec2(100.f, 10.f)),
+      main_frame_counter_(-1),
+      text_y_(FLT_MAX),
+      elapsed_time_text_length_(0) {}
 
 TextBox::TextBox(const Vec2& a_Pos, const Vec2& a_Size, const std::string& a_Text,
                  const Color& a_Color)
-    : m_Pos(a_Pos),
-      m_Size(a_Size),
+    : pos_(a_Pos),
+      size_(a_Size),
       text_(a_Text),
-      m_Color(a_Color),
-      m_MainFrameCounter(-1),
-      m_Selected(false),
-      m_ElapsedTimeTextLength(0) {
-  Update();
-}
+      color_(a_Color),
+      main_frame_counter_(-1),
+      elapsed_time_text_length_(0) {}
 
 TextBox::TextBox(const Vec2& a_Pos, const Vec2& a_Size, const Color& a_Color)
-    : m_Pos(a_Pos),
-      m_Size(a_Size),
-      m_Color(a_Color),
-      m_MainFrameCounter(-1),
-      m_Selected(false),
-      m_ElapsedTimeTextLength(0) {
-  Update();
-}
+    : pos_(a_Pos),
+      size_(a_Size),
+      color_(a_Color),
+      main_frame_counter_(-1),
+      elapsed_time_text_length_(0) {}
 
 TextBox::TextBox(const Vec2& a_Pos, const Vec2& a_Size)
-    : m_Pos(a_Pos),
-      m_Size(a_Size),
-      m_MainFrameCounter(-1),
-      m_Selected(false),
-      m_ElapsedTimeTextLength(0) {
-  Update();
-}
-
-void TextBox::Update() {
-  m_Min = m_Pos;
-  m_Max = m_Pos + Vec2(std::abs(m_Size[0]), std::abs(m_Size[1]));
-}
-
-float TextBox::GetScreenSize(const TextRenderer& a_TextRenderer) {
-  float worldWidth = a_TextRenderer.GetSceneBox().m_Size[0];
-  float screenSize = a_TextRenderer.GetCanvas()->getWidth();
-
-  return (m_Size[0] / worldWidth) * screenSize;
-}
+    : pos_(a_Pos), size_(a_Size), main_frame_counter_(-1), elapsed_time_text_length_(0) {}
 
 void TextBox::Draw(Batcher* batcher, TextRenderer& text_renderer, float min_x, bool visible,
                    bool right_justify, bool is_inactive, unsigned int id, bool is_picking,
@@ -101,7 +74,7 @@ void TextBox::Draw(Batcher* batcher, TextRenderer& text_renderer, float min_x, b
   }
 
   if (visible) {
-    Box box(m_Pos, m_Size, z);
+    Box box(pos_, size_, z);
     // TODO: This should be pickable??
     batcher->AddBox(box, color);
 
@@ -126,5 +99,5 @@ void TextBox::Draw(Batcher* batcher, TextRenderer& text_renderer, float min_x, b
   }
 
   // TODO: This should be pickable??
-  batcher->AddVerticalLine(m_Pos, m_Size[1], z, grey);
+  batcher->AddVerticalLine(pos_, size_[1], z, grey);
 }

--- a/OrbitGl/TextBox.cpp
+++ b/OrbitGl/TextBox.cpp
@@ -29,6 +29,7 @@ TextBox::TextBox(const Vec2& a_Pos, const Vec2& a_Size, const std::string& a_Tex
       size_(a_Size),
       text_(a_Text),
       color_(a_Color),
+      text_y_(FLT_MAX),
       main_frame_counter_(-1),
       elapsed_time_text_length_(0) {}
 
@@ -36,68 +37,13 @@ TextBox::TextBox(const Vec2& a_Pos, const Vec2& a_Size, const Color& a_Color)
     : pos_(a_Pos),
       size_(a_Size),
       color_(a_Color),
+      text_y_(FLT_MAX),
       main_frame_counter_(-1),
       elapsed_time_text_length_(0) {}
 
 TextBox::TextBox(const Vec2& a_Pos, const Vec2& a_Size)
-    : pos_(a_Pos), size_(a_Size), main_frame_counter_(-1), elapsed_time_text_length_(0) {}
-
-void TextBox::Draw(Batcher* batcher, TextRenderer& text_renderer, float min_x, bool visible,
-                   bool right_justify, bool is_inactive, unsigned int id, bool is_picking,
-                   bool is_highlighted) {
-  bool is_core_activity = timer_info_.type() == TimerInfo::kCoreActivity;
-  bool is_same_thread_id_as_selected =
-      is_core_activity && timer_info_.thread_id() == GOrbitApp->selected_thread_id();
-
-  if (GOrbitApp->selected_thread_id() != -1 && is_core_activity && !is_same_thread_id_as_selected) {
-    is_inactive = true;
-  }
-
-  static unsigned char g = 100;
-  Color grey(g, g, g, 255);
-  static Color selection_color(0, 128, 255, 255);
-
-  Color col = is_same_thread_id_as_selected ? m_Color : is_inactive ? grey : m_Color;
-
-  if (this == GOrbitApp->selected_text_box()) {
-    col = selection_color;
-  }
-
-  float z = is_highlighted
-                ? GlCanvas::Z_VALUE_CONTEXT_SWITCH
-                : is_inactive ? GlCanvas::Z_VALUE_BOX_INACTIVE : GlCanvas::Z_VALUE_BOX_ACTIVE;
-
-  Color color = col;
-  if (is_picking) {
-    memcpy(&color[0], &id, sizeof(unsigned int));
-    color[3] = 255;
-  }
-
-  if (visible) {
-    Box box(pos_, size_, z);
-    // TODO: This should be pickable??
-    batcher->AddBox(box, color);
-
-    static Color a_color(255, 255, 255, 255);
-
-    float pos_x = std::max(m_Pos[0], min_x);
-    if (right_justify) {
-      pos_x += m_Size[0];
-    }
-
-    float max_size = m_Pos[0] + m_Size[0] - pos_x;
-
-    const FunctionInfo* func =
-        Capture::capture_data_.GetSelectedFunction(timer_info_.function_address());
-    std::string function_name = func != nullptr ? FunctionUtils::GetDisplayName(*func) : "";
-    std::string text = absl::StrFormat("%s %s", function_name, text_.c_str());
-
-    if (!is_picking && !is_core_activity) {
-      text_renderer.AddText(text.c_str(), pos_x, m_TextY == FLT_MAX ? m_Pos[1] + 1.f : m_TextY,
-                            GlCanvas::Z_VALUE_TEXT, a_color, max_size, right_justify);
-    }
-  }
-
-  // TODO: This should be pickable??
-  batcher->AddVerticalLine(pos_, size_[1], z, grey);
-}
+    : pos_(a_Pos),
+      size_(a_Size),
+      main_frame_counter_(-1),
+      elapsed_time_text_length_(0),
+      text_y_(FLT_MAX) {}

--- a/OrbitGl/TextBox.cpp
+++ b/OrbitGl/TextBox.cpp
@@ -4,46 +4,7 @@
 
 #include "TextBox.h"
 
-#include "App.h"
-#include "Capture.h"
-#include "FunctionUtils.h"
-#include "GlCanvas.h"
-#include "OpenGl.h"
-#include "Params.h"
-#include "TextRenderer.h"
-#include "absl/strings/str_format.h"
+TextBox::TextBox() : pos_(Vec2::Zero()), size_(Vec2(100.f, 10.f)), elapsed_time_text_length_(0) {}
 
-using orbit_client_protos::FunctionInfo;
-using orbit_client_protos::TimerInfo;
-
-TextBox::TextBox()
-    : pos_(Vec2::Zero()),
-      size_(Vec2(100.f, 10.f)),
-      main_frame_counter_(-1),
-      text_y_(FLT_MAX),
-      elapsed_time_text_length_(0) {}
-
-TextBox::TextBox(const Vec2& a_Pos, const Vec2& a_Size, const std::string& a_Text,
-                 const Color& a_Color)
-    : pos_(a_Pos),
-      size_(a_Size),
-      text_(a_Text),
-      color_(a_Color),
-      text_y_(FLT_MAX),
-      main_frame_counter_(-1),
-      elapsed_time_text_length_(0) {}
-
-TextBox::TextBox(const Vec2& a_Pos, const Vec2& a_Size, const Color& a_Color)
-    : pos_(a_Pos),
-      size_(a_Size),
-      color_(a_Color),
-      text_y_(FLT_MAX),
-      main_frame_counter_(-1),
-      elapsed_time_text_length_(0) {}
-
-TextBox::TextBox(const Vec2& a_Pos, const Vec2& a_Size)
-    : pos_(a_Pos),
-      size_(a_Size),
-      main_frame_counter_(-1),
-      elapsed_time_text_length_(0),
-      text_y_(FLT_MAX) {}
+TextBox::TextBox(const Vec2& pos, const Vec2& size, const std::string& text)
+    : pos_(pos), size_(size), text_(text), elapsed_time_text_length_(0) {}

--- a/OrbitGl/TextBox.h
+++ b/OrbitGl/TextBox.h
@@ -23,10 +23,6 @@ class TextBox {
   TextBox(const Vec2& a_Pos, const Vec2& a_Size, const Color& a_Color);
   TextBox(const Vec2& a_Pos, const Vec2& a_Size);
 
-  void Draw(Batcher* batcher, TextRenderer& text_renderer, float min_x = -FLT_MAX,
-            bool visible = true, bool right_justify = false, bool is_inactive = false,
-            unsigned int id = 0xFFFFFFFF, bool is_picking = false, bool is_highlighted = false);
-
   void SetSize(const Vec2& a_Size) { size_ = a_Size; }
 
   void SetPos(const Vec2& a_Pos) { pos_ = a_Pos; }
@@ -45,18 +41,8 @@ class TextBox {
   }
   const orbit_client_protos::TimerInfo& GetTimerInfo() const { return timer_info_; }
 
-  void SetTextY(float a_Y) { text_y_ = a_Y; }
-
   void SetElapsedTimeTextLength(size_t length) { elapsed_time_text_length_ = length; }
   size_t GetElapsedTimeTextLength() const { return elapsed_time_text_length_; }
-
-  inline void SetColor(Color& color) { color_ = color; }
-  inline void SetColor(uint8_t r, uint8_t g, uint8_t b) {
-    color_[0] = r;
-    color_[1] = g;
-    color_[2] = b;
-  }
-  inline Color GetColor() { return color_; }
 
  protected:
   Vec2 pos_;

--- a/OrbitGl/TextBox.h
+++ b/OrbitGl/TextBox.h
@@ -23,7 +23,7 @@ class TextBox {
   const Vec2& GetPos() const { return pos_; }
 
   const std::string& GetText() const { return text_; }
-  void SetText(std::string_view text) { text_ = text; }
+  void SetText(std::string text) { text_ = std::move(text); }
 
   void SetTimerInfo(const orbit_client_protos::TimerInfo& timer_info) {
     if (timer_info.end() == 0 && timer_info.start() == 0) {

--- a/OrbitGl/TextBox.h
+++ b/OrbitGl/TextBox.h
@@ -5,10 +5,6 @@
 #ifndef ORBIT_GL_TEXT_BOX_H_
 #define ORBIT_GL_TEXT_BOX_H_
 
-#include <cfloat>
-#include <cstdint>
-
-#include "Batcher.h"
 #include "CoreMath.h"
 #include "capture_data.pb.h"
 
@@ -16,16 +12,12 @@ class TextRenderer;
 
 class TextBox {
  public:
-  TextBox();
-  TextBox(const Vec2& a_Pos, const Vec2& a_Size, const std::string& a_Text,
-          const Color& a_Color = Color(128, 128, 128, 128));
+  TextBox() : pos_(Vec2::Zero()), size_(Vec2(100.f, 10.f)), elapsed_time_text_length_(0){};
+  TextBox(const Vec2& pos, const Vec2& size, const std::string& text = "")
+      : pos_(pos), size_(size), text_(text), elapsed_time_text_length_(0) {}
 
-  TextBox(const Vec2& a_Pos, const Vec2& a_Size, const Color& a_Color);
-  TextBox(const Vec2& a_Pos, const Vec2& a_Size);
-
-  void SetSize(const Vec2& a_Size) { size_ = a_Size; }
-
-  void SetPos(const Vec2& a_Pos) { pos_ = a_Pos; }
+  void SetSize(const Vec2& size) { size_ = size; }
+  void SetPos(const Vec2& pos) { pos_ = pos; }
 
   const Vec2& GetSize() const { return size_; }
   const Vec2& GetPos() const { return pos_; }
@@ -48,10 +40,7 @@ class TextBox {
   Vec2 pos_;
   Vec2 size_;
   std::string text_;
-  Color color_;
   orbit_client_protos::TimerInfo timer_info_;
-  int main_frame_counter_;
-  float text_y_;
   size_t elapsed_time_text_length_;
 };
 

--- a/OrbitGl/TextBox.h
+++ b/OrbitGl/TextBox.h
@@ -27,48 +27,15 @@ class TextBox {
             bool visible = true, bool right_justify = false, bool is_inactive = false,
             unsigned int id = 0xFFFFFFFF, bool is_picking = false, bool is_highlighted = false);
 
-  void SetSize(const Vec2& a_Size) {
-    m_Size = a_Size;
-    Update();
-  }
-  void SetSizeX(float X) {
-    m_Size[0] = X;
-    Update();
-  }
-  void SetSizeY(float Y) {
-    m_Size[1] = Y;
-    Update();
-  }
+  void SetSize(const Vec2& a_Size) { size_ = a_Size; }
 
-  void SetPos(const Vec2& a_Pos) {
-    m_Pos = a_Pos;
-    Update();
-  }
-  void SetPosX(float X) {
-    m_Pos[0] = X;
-    Update();
-  }
-  void SetPosY(float Y) {
-    m_Pos[1] = Y;
-    Update();
-  }
+  void SetPos(const Vec2& a_Pos) { pos_ = a_Pos; }
 
-  const Vec2& GetSize() const { return m_Size; }
-  float GetSizeX() const { return m_Size[0]; }
-  float GetSizeY() const { return m_Size[1]; }
-
-  const Vec2& GetPos() const { return m_Pos; }
-  float GetPosX() const { return m_Pos[0]; }
-  float GetPosY() const { return m_Pos[1]; }
-
-  float GetMaxX() const { return m_Max[0]; }
-  float GetMaxY() const { return m_Max[1]; }
-
-  Vec2 GetMin() const { return m_Min; }
-  Vec2 GetMax() const { return m_Max; }
+  const Vec2& GetSize() const { return size_; }
+  const Vec2& GetPos() const { return pos_; }
 
   const std::string& GetText() const { return text_; }
-  void SetText(const std::string& a_Text) { text_ = a_Text; }
+  void SetText(std::string_view text) { text_ = text; }
 
   void SetTimerInfo(const orbit_client_protos::TimerInfo& timer_info) {
     if (timer_info.end() == 0 && timer_info.start() == 0) {
@@ -78,67 +45,28 @@ class TextBox {
   }
   const orbit_client_protos::TimerInfo& GetTimerInfo() const { return timer_info_; }
 
-  void SetTextY(float a_Y) { m_TextY = a_Y; }
+  void SetTextY(float a_Y) { text_y_ = a_Y; }
 
-  void SetElapsedTimeTextLength(size_t a_Length) { m_ElapsedTimeTextLength = a_Length; }
-  size_t GetElapsedTimeTextLength() const { return m_ElapsedTimeTextLength; }
+  void SetElapsedTimeTextLength(size_t length) { elapsed_time_text_length_ = length; }
+  size_t GetElapsedTimeTextLength() const { return elapsed_time_text_length_; }
 
-  inline void SetColor(Color& a_Color) { m_Color = a_Color; }
-  inline void SetColor(uint8_t a_R, uint8_t a_G, uint8_t a_B) {
-    m_Color[0] = a_R;
-    m_Color[1] = a_G;
-    m_Color[2] = a_B;
+  inline void SetColor(Color& color) { color_ = color; }
+  inline void SetColor(uint8_t r, uint8_t g, uint8_t b) {
+    color_[0] = r;
+    color_[1] = g;
+    color_[2] = b;
   }
-  inline Color GetColor() { return m_Color; }
-
-  float GetScreenSize(const TextRenderer& a_TextRenderer);
-
-  inline bool Intersects(const TextBox& a_Box);
-  inline void Expand(const TextBox& a_Box);
-
-  int GetMainFrameCounter() const { return m_MainFrameCounter; }
-  void SetMainFrameCounter(int a_Counter) { m_MainFrameCounter = a_Counter; }
-
-  void ToggleSelect() { m_Selected = !m_Selected; }
-  void SetSelected(bool a_Select) { m_Selected = a_Select; }
+  inline Color GetColor() { return color_; }
 
  protected:
-  void Update();
-
- protected:
-  Vec2 m_Pos;
-  Vec2 m_Size;
-  Vec2 m_Min;
-  Vec2 m_Max;
+  Vec2 pos_;
+  Vec2 size_;
   std::string text_;
-  Color m_Color;
+  Color color_;
   orbit_client_protos::TimerInfo timer_info_;
-  int m_MainFrameCounter;
-  bool m_Selected;
-  float m_TextY;
-  size_t m_ElapsedTimeTextLength;
+  int main_frame_counter_;
+  float text_y_;
+  size_t elapsed_time_text_length_;
 };
-
-inline bool TextBox::Intersects(const TextBox& a_Box) {
-  for (int i = 0; i < 2; i++) {
-    if (m_Max[i] < a_Box.m_Min[i] || m_Min[i] > a_Box.m_Max[i]) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-inline void TextBox::Expand(const TextBox& a_Box) {
-  for (int i = 0; i < 2; i++) {
-    if (a_Box.m_Min[i] < m_Min[i]) {
-      m_Min[i] = a_Box.m_Min[i];
-    }
-
-    if (a_Box.m_Max[i] > m_Max[i]) {
-      m_Max[i] = a_Box.m_Max[i];
-    }
-  }
-}
 
 #endif  // ORBIT_GL_TEXT_BOX_H_

--- a/OrbitGl/TextRenderer.cpp
+++ b/OrbitGl/TextRenderer.cpp
@@ -360,6 +360,4 @@ void TextRenderer::Clear() {
   }
 }
 
-const TextBox& TextRenderer::GetSceneBox() const { return m_Canvas->GetSceneBox(); }
-
 int TextRenderer::GetNumCharacters() const { return int(m_Buffer->vertices->size) / 4; }

--- a/OrbitGl/TextRenderer.h
+++ b/OrbitGl/TextRenderer.h
@@ -38,7 +38,6 @@ class TextRenderer {
   void SetCanvas(class GlCanvas* a_Canvas) { m_Canvas = a_Canvas; }
   const GlCanvas* GetCanvas() const { return m_Canvas; }
   GlCanvas* GetCanvas() { return m_Canvas; }
-  const TextBox& GetSceneBox() const;
   int GetNumCharacters() const;
   void ToggleDrawOutline() { m_DrawOutline = !m_DrawOutline; }
   void SetFontSize(int a_Size);

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -174,7 +174,7 @@ void ThreadTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_u
   float pos_x = std::max(box_pos[0], min_x);
   float max_size = box_pos[0] + box_size[0] - pos_x;
   text_renderer_->AddTextTrailingCharsPrioritized(
-      text_box->GetText().c_str(), pos_x, text_box->GetPosY() + layout.GetTextOffset(),
+      text_box->GetText().c_str(), pos_x, text_box->GetPos()[1] + layout.GetTextOffset(),
       GlCanvas::Z_VALUE_TEXT, kTextWhite, text_box->GetElapsedTimeTextLength(), max_size);
 }
 

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -569,7 +569,6 @@ void TimeGraph::UpdatePrimitives(PickingMode picking_mode) {
 
   UpdateMaxTimeStamp(GEventTracer.GetEventBuffer().GetMaxTime());
 
-  m_SceneBox = m_Canvas->GetSceneBox();
   m_TimeWindowUs = m_MaxTimeUs - m_MinTimeUs;
   m_WorldStartX = m_Canvas->GetWorldTopLeftX();
   m_WorldWidth = m_Canvas->GetWorldWidth();

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -153,7 +153,6 @@ class TimeGraph {
   TextRenderer m_TextRendererStatic;
   TextRenderer* m_TextRenderer = nullptr;
   GlCanvas* m_Canvas = nullptr;
-  TextBox m_SceneBox;
   int m_NumDrawnTextBoxes = 0;
 
   // First member is id.

--- a/OrbitGl/TimerChain.cpp
+++ b/OrbitGl/TimerChain.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "TimerChain.h"
 
 #include <algorithm>

--- a/OrbitGl/TimerChain.cpp
+++ b/OrbitGl/TimerChain.cpp
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 
+#include "OrbitBase/Logging.h"
+
 void TimerBlock::Add(const TextBox& item) {
   if (size_ == kBlockSize) {
     if (next_ == nullptr) {

--- a/OrbitGl/TimerTrack.cpp
+++ b/OrbitGl/TimerTrack.cpp
@@ -68,9 +68,7 @@ void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
 
   Batcher* batcher = &time_graph_->GetBatcher();
   GlCanvas* canvas = time_graph_->GetCanvas();
-  const TextBox& scene_box = canvas->GetSceneBox();
 
-  float min_x = scene_box.GetPosX();
   float world_start_x = canvas->GetWorldTopLeftX();
   float world_width = canvas->GetWorldWidth();
   double inv_time_window = 1.0 / time_graph_->GetTimeWindowUs();
@@ -133,7 +131,7 @@ void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
 
         if (is_visible_width) {
           if (!is_collapsed) {
-            SetTimesliceText(timer_info, elapsed_us, min_x, &text_box);
+            SetTimesliceText(timer_info, elapsed_us, world_start_x, &text_box);
           }
           batcher->AddShadedBox(pos, size, z, color, std::move(user_data));
         } else {

--- a/OrbitGl/TimerTrack.cpp
+++ b/OrbitGl/TimerTrack.cpp
@@ -158,7 +158,7 @@ void TimerTrack::OnTimer(const TimerInfo& timer_info) {
     UpdateDepth(timer_info.depth() + 1);
   }
 
-  TextBox text_box(Vec2(0, 0), Vec2(0, 0), "", Color(255, 0, 0, 255));
+  TextBox text_box(Vec2(0, 0), Vec2(0, 0), "");
   text_box.SetTimerInfo(timer_info);
 
   std::shared_ptr<TimerChain> timer_chain = timers_[timer_info.depth()];


### PR DESCRIPTION
This PR removes most functionality from TextBox.

We create a TextBox for every Timer, but it is only used as a storage class for the related text and potentially for measurements. The Draw() method was never called when rendering timers, and in nearly all cases, the TextBox is only used to access the linked timer.

The only place where TextBox::Draw() was really used is to draw the overlay when selecting a timeslice in the capture window, and this functionality abused TextBox by not passing any valid timer at all, it only required drawing of the green rectangle and some text.

Refactor:
* All rendering-related functionality of TextBox was removed, it is purely used to store a pointer to a timer and some additional layouting information
* Drawing of the selection rectangle has been implemented in the CaptureWindow without use of TextBox

Maybe we could remove TextBox completely in the future and work with the timer pointers directly.