### PR TITLE
Remove usage of GTargetProcess->GetID()

### DIFF
--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -203,6 +203,9 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   [[nodiscard]] ThreadPool* GetThreadPool() { return thread_pool_.get(); }
   [[nodiscard]] MainThreadExecutor* GetMainThreadExecutor() { return main_thread_executor_.get(); }
   [[nodiscard]] std::shared_ptr<Process> FindProcessByPid(int32_t pid);
+  [[nodiscard]] int32_t GetSelectedProcessID() const {
+    return processes_data_view_->GetSelectedProcessId();
+  }
 
   // TODO(kuebler): Move them to a separate controler at some point
   void SelectFunction(const orbit_client_protos::FunctionInfo& func);

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -112,7 +112,7 @@ void CallStackDataView::OnContextMenu(const std::string& action, int menu_index,
       CallStackDataViewFrame frame = GetFrameFromRow(i);
       std::shared_ptr<Module> module = frame.module;
       if (module != nullptr && module->IsLoadable() && !module->IsLoaded()) {
-        GOrbitApp->LoadModules(Capture::GTargetProcess->GetID(), {module});
+        GOrbitApp->LoadModules(Capture::capture_data_.process_id(), {module});
       }
     }
 
@@ -131,7 +131,7 @@ void CallStackDataView::OnContextMenu(const std::string& action, int menu_index,
     }
 
   } else if (action == kMenuActionDisassembly) {
-    int32_t pid = Capture::GTargetProcess->GetID();
+    int32_t pid = Capture::capture_data_.process_id();
     for (int i : item_indices) {
       GOrbitApp->Disassemble(pid, *GetFrameFromRow(i).function);
     }

--- a/OrbitGl/FunctionsDataView.cpp
+++ b/OrbitGl/FunctionsDataView.cpp
@@ -149,7 +149,7 @@ void FunctionsDataView::OnContextMenu(const std::string& action, int menu_index,
       GOrbitApp->DeselectFunction(GetFunction(i));
     }
   } else if (action == kMenuActionDisassembly) {
-    int32_t pid = Capture::GTargetProcess->GetID();
+    int32_t pid = GOrbitApp->GetSelectedProcessID();
     for (int i : item_indices) {
       GOrbitApp->Disassemble(pid, GetFunction(i));
     }

--- a/OrbitGl/LiveFunctionsDataView.cpp
+++ b/OrbitGl/LiveFunctionsDataView.cpp
@@ -195,7 +195,7 @@ void LiveFunctionsDataView::OnContextMenu(const std::string& action, int menu_in
       GOrbitApp->DeselectFunction(*function);
     }
   } else if (action == kMenuActionDisassembly) {
-    int32_t pid = Capture::GTargetProcess->GetID();
+    int32_t pid = Capture::capture_data_.process_id();
     for (int i : item_indices) {
       const FunctionInfo& function = *GetFunction(i);
       GOrbitApp->Disassemble(pid, function);

--- a/OrbitGl/ModulesDataView.cpp
+++ b/OrbitGl/ModulesDataView.cpp
@@ -121,7 +121,7 @@ void ModulesDataView::OnContextMenu(const std::string& action, int menu_index,
         modules.push_back(Capture::GTargetProcess->GetModuleFromPath(module_data->file_path()));
       }
     }
-    GOrbitApp->LoadModules(Capture::GTargetProcess->GetID(), modules);
+    GOrbitApp->LoadModules(GOrbitApp->GetSelectedProcessID(), modules);
 
   } else if (action == kMenuActionVerifyFramePointers) {
     std::vector<std::shared_ptr<Module>> modules_to_validate;
@@ -179,7 +179,7 @@ void ModulesDataView::SetModules(int32_t process_id, const std::vector<ModuleDat
 }
 
 void ModulesDataView::OnRefreshButtonClicked() {
-  GOrbitApp->UpdateProcessAndModuleList(Capture::GTargetProcess->GetID());
+  GOrbitApp->UpdateProcessAndModuleList(GOrbitApp->GetSelectedProcessID());
 }
 
 const ModuleData* ModulesDataView::GetModule(uint32_t row) const { return modules_[indices_[row]]; }

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -206,9 +206,9 @@ void SamplingReportDataView::OnContextMenu(const std::string& action, int menu_i
         modules.push_back(module);
       }
     }
-    GOrbitApp->LoadModules(Capture::GTargetProcess->GetID(), modules);
+    GOrbitApp->LoadModules(Capture::capture_data_.process_id(), modules);
   } else if (action == kMenuActionDisassembly) {
-    int32_t pid = Capture::GTargetProcess->GetID();
+    int32_t pid = Capture::capture_data_.process_id();
     for (FunctionInfo* function : GetFunctionsFromIndices(item_indices)) {
       GOrbitApp->Disassemble(pid, *function);
     }

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -407,7 +407,7 @@ void TimeGraph::ProcessManualIntrumentationTimer(const TimerInfo& timer_info) {
     manual_instrumentation_string_manager_.AddOrReplace(string_address, "");
 
     GOrbitApp->GetThreadPool()->Schedule([this, string_address]() {
-      int32_t pid = Capture::GTargetProcess->GetID();
+      int32_t pid = Capture::capture_data_.process_id();
       const auto& process_manager = GOrbitApp->GetProcessManager();
       auto error_or_string = process_manager->LoadNullTerminatedString(pid, string_address);
 
@@ -857,7 +857,7 @@ std::shared_ptr<GpuTrack> TimeGraph::GetOrCreateGpuTrack(uint64_t timeline_hash)
 static void SetTrackNameFromRemoteMemory(std::shared_ptr<Track> track, uint64_t string_address,
                                          OrbitApp* app) {
   app->GetThreadPool()->Schedule([track, string_address, app]() {
-    int32_t pid = Capture::GTargetProcess->GetID();
+    int32_t pid = Capture::capture_data_.process_id();
     const auto& process_manager = app->GetProcessManager();
     auto error_or_string = process_manager->LoadNullTerminatedString(pid, string_address);
 


### PR DESCRIPTION
This avoid using Capture::GTargetProcess->GetID and rather use
the id stored in the CaptureData or the one currently selected,
depending on the use case.

Test: Compile