### PR TITLE
Clear callstack and selection views

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -89,6 +89,8 @@ void OrbitApp::OnCaptureStarted() {
       select_live_tab_callback_();
     }
 
+    FireRefreshCallbacks();
+
     absl::MutexLock lock(&mutex);
     initialization_complete = true;
   });
@@ -593,8 +595,6 @@ void OrbitApp::StopCapture() {
   if (capture_stop_requested_callback_) {
     capture_stop_requested_callback_();
   }
-
-  FireRefreshCallbacks();
 }
 
 void OrbitApp::ClearCapture() {
@@ -607,14 +607,19 @@ void OrbitApp::ClearCapture() {
   AddTopDownView(*empty_sampling_profiler);
   Capture::GSamplingProfiler = empty_sampling_profiler;
 
+  if (selection_report_) {
+    auto empty_selection_profiler = std::make_shared<SamplingProfiler>(Capture::GTargetProcess);
+    AddSelectionReport(empty_selection_profiler, nullptr);
+  }
+
   if (GCurrentTimeGraph != nullptr) {
     GCurrentTimeGraph->Clear();
   }
-  GOrbitApp->FireRefreshCallbacks(DataViewType::kLiveFunctions);
 
   if (capture_cleared_callback_) {
     capture_cleared_callback_();
   }
+  FireRefreshCallbacks();
 }
 
 void OrbitApp::ToggleDrawHelp() {

--- a/OrbitGl/CallStackDataView.h
+++ b/OrbitGl/CallStackDataView.h
@@ -28,16 +28,16 @@ class CallStackDataView : public DataView {
                      const std::vector<int>& item_indices) override;
   void OnDataChanged() override;
   void SetCallStack(const CallStack& callstack) {
-    callstack_ = std::make_unique<CallStack>(callstack);
+    callstack_ = CallStack(callstack);
     OnDataChanged();
   }
 
-  void ClearCallstack() { callstack_ = nullptr; }
+  void ClearCallstack() { callstack_ = CallStack(); }
 
  protected:
   void DoFilter() override;
 
-  std::unique_ptr<CallStack> callstack_;
+  CallStack callstack_;
 
   struct CallStackDataViewFrame {
     CallStackDataViewFrame() = default;

--- a/OrbitGl/SamplingReport.cpp
+++ b/OrbitGl/SamplingReport.cpp
@@ -19,6 +19,16 @@ SamplingReport::SamplingReport(std::shared_ptr<SamplingProfiler> sampling_profil
   FillReport();
 }
 
+SamplingReport::~SamplingReport() { ClearReport(); }
+
+void SamplingReport::ClearReport() {
+  selected_sorted_callstack_report_ = nullptr;
+  selected_callstack_index_ = 0;
+  if (callstack_data_view_ != nullptr) {
+    callstack_data_view_->ClearCallstack();
+  }
+}
+
 void SamplingReport::FillReport() {
   const auto& sample_data = profiler_->GetThreadSampleData();
 
@@ -57,9 +67,7 @@ void SamplingReport::UpdateReport() {
   selected_sorted_callstack_report_ =
       profiler_->GetSortedCallstacksFromAddress(selected_address_, selected_thread_id_);
   if (selected_sorted_callstack_report_->callstacks_count.empty()) {
-    selected_sorted_callstack_report_ = nullptr;
-    selected_callstack_index_ = 0;
-    callstack_data_view_->ClearCallstack();
+    ClearReport();
   } else {
     OnCallstackIndexChanged(selected_callstack_index_);
   }

--- a/OrbitGl/SamplingReport.h
+++ b/OrbitGl/SamplingReport.h
@@ -20,6 +20,7 @@ class SamplingReport {
  public:
   explicit SamplingReport(std::shared_ptr<SamplingProfiler> sampling_profiler,
                           const CallstackData* callstack_data);
+  ~SamplingReport();
 
   void UpdateReport();
   [[nodiscard]] std::shared_ptr<SamplingProfiler> GetProfiler() const { return profiler_; };
@@ -38,6 +39,7 @@ class SamplingReport {
  protected:
   void FillReport();
   void OnCallstackIndexChanged(size_t index);
+  void ClearReport();
 
  protected:
   std::shared_ptr<SamplingProfiler> profiler_;


### PR DESCRIPTION
Use pointer to the CallStack in the CallStackDataView instead of
creating a copy, remove extra FireRefreshCallbacks call in StopCapture
and clear CallStack and Selection views when clear capture or start a
new one.

Test: Take a capture, make a selection, clear capture and check the
content of the sampling, selection and callstack views; take a capture,
make a selection, start a new capture and check the content of the
sampling, selection and callstack views while capture in process.

Bug: http://b/164971132