### PR TITLE
Add color support to Orbit API macros in Orbit.h

### DIFF
--- a/Orbit.h
+++ b/Orbit.h
@@ -11,9 +11,11 @@
 
 // Orbit API (header-only)
 //
-// While the main feature of Orbit is its ability to dynamically instrument
-// functions, manual instrumentation is still possible using the macros below.
-// These macros call empty functions that Orbit dynamically instruments.
+// While the main feature of Orbit is its ability to dynamically instrument functions, manual
+// instrumentation is still possible using the macros below. These macros call empty functions that
+// Orbit dynamically instruments.
+//
+// NOTE: We only support string literals for now. This is enforced through the ORBIT_STR() macro.
 
 // To disable manual instrumentation macros, define ORBIT_API_ENABLED as 0.
 #define ORBIT_API_ENABLED 1
@@ -21,23 +23,62 @@
 #if ORBIT_API_ENABLED
 
 // ORBIT_SCOPE: profile current scope.
-#define ORBIT_SCOPE(name) orbit_api::Scope ORBIT_VAR(ORBIT_STR(name))
+#define ORBIT_SCOPE(name) ORBIT_SCOPE_WITH_COLOR(name, orbit::Color::kAuto)
+#define ORBIT_SCOPE_WITH_COLOR(name, col) orbit_api::Scope ORBIT_VAR(ORBIT_STR(name), col)
 
 // ORBIT_START/ORBIT_STOP: profile time span on a single thread.
-#define ORBIT_START(name) orbit_api::Start(ORBIT_STR(name))
+#define ORBIT_START(name) ORBIT_START_WITH_COLOR(name, orbit::Color::kAuto)
+#define ORBIT_START_WITH_COLOR(name, col) orbit_api::Start(ORBIT_STR(name), col)
 #define ORBIT_STOP() orbit_api::Stop()
 
 // ORBIT_START_ASYNC/ORBIT_STOP_ASYNC: profile time span across threads.
-#define ORBIT_START_ASYNC(name, id) orbit_api::StartAsync(ORBIT_STR(name), id)
+#define ORBIT_START_ASYNC(name, id) ORBIT_START_ASYNC_WITH_COLOR(name, id, orbit::Color::kAuto)
+#define ORBIT_START_ASYNC_WITH_COLOR(name, id, col) orbit_api::StartAsync(ORBIT_STR(name), id, col)
 #define ORBIT_STOP_ASYNC(id) orbit_api::StopAsync(id)
 
 // ORBIT_[type]: graph variables.
-#define ORBIT_INT(name, val) orbit_api::TrackInt(ORBIT_STR(name), val)
-#define ORBIT_INT64(name, val) orbit_api::TrackInt64(ORBIT_STR(name), val)
-#define ORBIT_UINT(name, val) orbit_api::TrackUint(ORBIT_STR(name), val)
-#define ORBIT_UINT64(name, val) orbit_api::TrackUint64(ORBIT_STR(name), val)
-#define ORBIT_FLOAT(name, val) orbit_api::TrackFloat(ORBIT_STR(name), val)
-#define ORBIT_DOUBLE(name, val) orbit_api::TrackDouble(ORBIT_STR(name), val)
+#define ORBIT_INT(name, val) ORBIT_INT_WITH_COLOR(name, val, orbit::Color::kAuto)
+#define ORBIT_INT64(name, val) ORBIT_INT64_WITH_COLOR(name, val, orbit::Color::kAuto)
+#define ORBIT_UINT(name, val) ORBIT_UINT_WITH_COLOR(name, val, orbit::Color::kAuto)
+#define ORBIT_UINT64(name, val) ORBIT_UINT64_WITH_COLOR(name, val, orbit::Color::kAuto)
+#define ORBIT_FLOAT(name, val) ORBIT_FLOAT_WITH_COLOR(name, val, orbit::Color::kAuto)
+#define ORBIT_DOUBLE(name, val) ORBIT_DOUBLE_WITH_COLOR(name, val, orbit::Color::kAuto)
+
+// ORBIT_[type]_WITH_COLOR: graph variables with color.
+#define ORBIT_INT_WITH_COLOR(name, val, col) orbit_api::TrackInt(ORBIT_STR(name), val, col)
+#define ORBIT_INT64_WITH_COLOR(name, val, col) orbit_api::TrackInt64(ORBIT_STR(name), val, col)
+#define ORBIT_UINT_WITH_COLOR(name, val, col) orbit_api::TrackUint(ORBIT_STR(name), val, col)
+#define ORBIT_UINT64_WITH_COLOR(name, val, col) orbit_api::TrackUint64(ORBIT_STR(name), val, col)
+#define ORBIT_FLOAT_WITH_COLOR(name, val, col) orbit_api::TrackFloat(ORBIT_STR(name), val, col)
+#define ORBIT_DOUBLE_WITH_COLOR(name, val, col) orbit_api::TrackDouble(ORBIT_STR(name), val, col)
+
+namespace orbit {
+
+// Material Design Colors #500
+enum class Color : uint32_t {
+  kAuto = 0x00000001,
+  kRed = 0xf44336ff,
+  kPink = 0xe91e63ff,
+  kPurple = 0x9c27b0ff,
+  kDeepPurple = 0x673ab7ff,
+  kIndigo = 0x3f51b5ff,
+  kBlue = 0x2196f3ff,
+  kLightBlue = 0x03a9f4ff,
+  kCyan = 0x00bcd4ff,
+  kTeal = 0x009688ff,
+  kGreen = 0x4caf50ff,
+  kLightGreen = 0x8bc34aff,
+  kLime = 0xcddc39ff,
+  kYellow = 0xffeb3bff,
+  kAmber = 0xffc107ff,
+  kOrange = 0xff9800ff,
+  kDeepOrange = 0xff5722ff,
+  kBrown = 0x795548ff,
+  kGrey = 0x9e9e9eff,
+  kBlueGrey = 0x607d8bff
+};
+
+}  // namespace orbit
 
 #else
 
@@ -53,9 +94,20 @@
 #define ORBIT_FLOAT(name, value)
 #define ORBIT_DOUBLE(name, value)
 
+#define ORBIT_SCOPE_WITH_COLOR(name, color)
+#define ORBIT_START_WITH_COLOR(name, color)
+#define ORBIT_START_ASYNC_WITH_COLOR(name, id, color)
+#define ORBIT_INT_WITH_COLOR(name, value, color)
+#define ORBIT_INT64_WITH_COLOR(name, value, color)
+#define ORBIT_UINT_WITH_COLOR(name, value, color)
+#define ORBIT_UINT64_WITH_COLOR(name, value, color)
+#define ORBIT_FLOAT_WITH_COLOR(name, value, color)
+#define ORBIT_DOUBLE_WITH_COLOR(name, value, color)
+
 #endif
 
 // NOTE: Do not use any of the code below directly.
+#if ORBIT_API_ENABLED
 
 // Internal macros.
 #define ORBIT_STR(x) ("" x)
@@ -78,37 +130,40 @@
 namespace orbit_api {
 
 // NOTE: Do not use these directly, use corresponding macros instead.
-ORBIT_STUB void Start(const char*) { ORBIT_NOOP(); }
+ORBIT_STUB void Start(const char*, orbit::Color) { ORBIT_NOOP(); }
 ORBIT_STUB void Stop() { ORBIT_NOOP(); }
-ORBIT_STUB void StartAsync(const char*, uint64_t) { ORBIT_NOOP(); }
+ORBIT_STUB void StartAsync(const char*, uint64_t, orbit::Color) { ORBIT_NOOP(); }
 ORBIT_STUB void StopAsync(uint64_t) { ORBIT_NOOP(); }
-ORBIT_STUB void TrackInt(const char*, int32_t) { ORBIT_NOOP(); }
-ORBIT_STUB void TrackInt64(const char*, int64_t) { ORBIT_NOOP(); }
-ORBIT_STUB void TrackUint(const char*, uint32_t) { ORBIT_NOOP(); }
-ORBIT_STUB void TrackUint64(const char*, uint64_t) { ORBIT_NOOP(); }
-ORBIT_STUB void TrackFloatAsInt(const char*, int32_t) { ORBIT_NOOP(); }
-ORBIT_STUB void TrackDoubleAsInt64(const char*, int64_t) { ORBIT_NOOP(); }
+ORBIT_STUB void TrackInt(const char*, int32_t, orbit::Color) { ORBIT_NOOP(); }
+ORBIT_STUB void TrackInt64(const char*, int64_t, orbit::Color) { ORBIT_NOOP(); }
+ORBIT_STUB void TrackUint(const char*, uint32_t, orbit::Color) { ORBIT_NOOP(); }
+ORBIT_STUB void TrackUint64(const char*, uint64_t, orbit::Color) { ORBIT_NOOP(); }
+ORBIT_STUB void TrackFloatAsInt(const char*, int32_t, orbit::Color) { ORBIT_NOOP(); }
+ORBIT_STUB void TrackDoubleAsInt64(const char*, int64_t, orbit::Color) { ORBIT_NOOP(); }
 
 // Convert floating point arguments to integer arguments as we can't access
 // XMM registers with our current dynamic instrumentation on Linux (uprobes).
-inline void TrackFloat(const char* name, float value) {
+inline void TrackFloat(const char* name, float value, orbit::Color color) {
   int int_value;
   static_assert(sizeof(value) == sizeof(int_value));
   std::memcpy(&int_value, &value, sizeof(value));
-  TrackFloatAsInt(name, int_value);
+  TrackFloatAsInt(name, int_value, color);
 }
-inline void TrackDouble(const char* name, double value) {
+
+inline void TrackDouble(const char* name, double value, orbit::Color color) {
   int64_t int_value;
   static_assert(sizeof(value) == sizeof(int_value));
   std::memcpy(&int_value, &value, sizeof(value));
-  TrackDoubleAsInt64(name, int_value);
+  TrackDoubleAsInt64(name, int_value, color);
 }
 
 struct Scope {
-  Scope(const char* name) { Start(name); }
+  Scope(const char* name, orbit::Color color) { Start(name, color); }
   ~Scope() { Stop(); }
 };
 
 }  // namespace orbit_api
+
+#endif  // ORBIT_API_ENABLED
 
 #endif  // ORBIT_H_

--- a/OrbitTest/OrbitTest.cpp
+++ b/OrbitTest/OrbitTest.cpp
@@ -88,6 +88,8 @@ void NO_INLINE SleepFor1Ms() { std::this_thread::sleep_for(std::chrono::millisec
 
 void NO_INLINE SleepFor2Ms() {
   ORBIT_SCOPE("Sleep for two milliseconds");
+  ORBIT_SCOPE_WITH_COLOR("Sleep for two milliseconds", orbit::Color::kTeal);
+  ORBIT_SCOPE_WITH_COLOR("Sleep for two milliseconds", orbit::Color::kOrange);
   SleepFor1Ms();
   SleepFor1Ms();
 }

--- a/OrbitTest/OrbitTest.cpp
+++ b/OrbitTest/OrbitTest.cpp
@@ -96,13 +96,14 @@ void OrbitTest::ManualInstrumentationApiTest() {
 #if ORBIT_API_ENABLED
   while (!m_ExitRequested) {
     ORBIT_SCOPE("ORBIT_SCOPE_TEST");
+    ORBIT_SCOPE_WITH_COLOR("ORBIT_SCOPE_TEST_WITH_COLOR", orbit::Color(0xff0000ff));
     SleepFor2Ms();
 
-    ORBIT_START("ORBIT_START_TEST");
+    ORBIT_START_WITH_COLOR("ORBIT_START_TEST", orbit::Color::kRed);
     std::this_thread::sleep_for(std::chrono::microseconds(500));
     ORBIT_STOP();
 
-    ORBIT_START_ASYNC("ORBIT_START_ASYNC_TEST", 0);
+    ORBIT_START_ASYNC_WITH_COLOR("ORBIT_START_ASYNC_TEST", 0, orbit::Color::kLightBlue);
     std::this_thread::sleep_for(std::chrono::microseconds(500));
     ORBIT_STOP_ASYNC(0);
 
@@ -120,15 +121,15 @@ void OrbitTest::ManualInstrumentationApiTest() {
 
     static uint64_t uint64_var = 0;
     if (++uint64_var > 100) uint64_var = 0;
-    ORBIT_UINT64("uint64_var", uint64_var);
+    ORBIT_UINT64_WITH_COLOR("uint64_var", uint64_var, orbit::Color::kIndigo);
 
     static float float_var = 0.f;
     static volatile float sinf_coeff = 0.1f;
-    ORBIT_FLOAT("float_var", sinf((++float_var) * sinf_coeff));
+    ORBIT_FLOAT_WITH_COLOR("float_var", sinf((++float_var) * sinf_coeff), orbit::Color::kPink);
 
     static double double_var = 0.0;
     static volatile double cos_coeff = 0.1;
-    ORBIT_DOUBLE("double_var", cos((++double_var) * cos_coeff));
+    ORBIT_DOUBLE_WITH_COLOR("double_var", cos((++double_var) * cos_coeff), orbit::Color::kPurple);
 
     std::this_thread::sleep_for(std::chrono::milliseconds(15));
   }


### PR DESCRIPTION
- User can specify the color of timeslices and tracked variables
- Add a set of predefined colors based on Google's Material Design
- Original macros still work

![image](https://user-images.githubusercontent.com/3687222/90614781-f98d1f80-e1bf-11ea-93e8-35c3e0627e09.png)
