### PR TITLE
Call Initialize() on DataViewPanels for thread sampling reports

### DIFF
--- a/OrbitQt/orbitdataviewpanel.cpp
+++ b/OrbitQt/orbitdataviewpanel.cpp
@@ -30,8 +30,8 @@ void OrbitDataViewPanel::Initialize(DataView* data_view, SelectionType selection
     this->ui->label->show();
   }
 
+  ui->refreshButton->setIcon(QApplication::style()->standardIcon(QStyle::SP_BrowserReload));
   if (ui->treeView->HasRefreshButton()) {
-    ui->refreshButton->setIcon(QApplication::style()->standardIcon(QStyle::SP_BrowserReload));
     ui->refreshButton->show();
   } else {
     ui->refreshButton->hide();

--- a/OrbitQt/orbitsamplingreport.cpp
+++ b/OrbitQt/orbitsamplingreport.cpp
@@ -63,9 +63,8 @@ void OrbitSamplingReport::Initialize(DataView* callstack_data_view,
 
     treeView->setObjectName(QStringLiteral("treeView"));
     gridLayout_2->addWidget(treeView, 0, 0, 1, 1);
-    treeView->GetTreeView()->setSelectionMode(OrbitTreeView::ExtendedSelection);
+    treeView->Initialize(&report_data_view, SelectionType::kExtended, FontType::kDefault);
     treeView->GetTreeView()->header()->resizeSections(QHeaderView::ResizeToContents);
-    treeView->GetTreeView()->setAlternatingRowColors(true);
 
     treeView->Link(ui->CallstackTreeView);
 


### PR DESCRIPTION
This fixes the missing intialization of the "Refresh" buttons: https://b.corp.google.com/issues/165000881

Tests: Run Orbit, check that the refresh buttons are correctly hidden for the main sampling report and in the selection.