### PR TITLE
Clear selection before adding a new samples

### DIFF
--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -110,16 +110,8 @@ class CaptureData {
     return selection_callstack_data_.get();
   };
 
-  void AddSelectionCallStack(CallStack call_stack) {
-    selection_callstack_data_->AddUniqueCallStack(std::move(call_stack));
-  }
-
-  void AddSelectionCallstackEvent(orbit_client_protos::CallstackEvent callstack_event) {
-    selection_callstack_data_->AddCallstackEvent(std::move(callstack_event));
-  }
-
-  void AddSelectionCallstackFromCallstackData(const orbit_client_protos::CallstackEvent& event) {
-    selection_callstack_data_->AddCallStackFromKnownCallstackData(event, *callstack_data_);
+  void SetSelectionCallstackData(std::unique_ptr<CallstackData> selection_callstack_data) {
+    selection_callstack_data_ = std::move(selection_callstack_data);
   }
 
  private:

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -613,18 +613,16 @@ std::vector<CallstackEvent> TimeGraph::SelectEvents(float a_WorldStart, float a_
 
   sampling_profiler->SetGenerateSummary(a_TID == 0);
 
+  const CallstackData* callstack_data = Capture::capture_data_.GetCallstackData();
+  std::unique_ptr<CallstackData> selection_callstack_data = std::make_unique<CallstackData>();
   for (const CallstackEvent& event : selected_callstack_events) {
-    Capture::capture_data_.AddSelectionCallstackFromCallstackData(event);
+    selection_callstack_data->AddCallStackFromKnownCallstackData(event, *callstack_data);
   }
 
-  const CallstackData* selection_callstack_data =
-      Capture::capture_data_.GetSelectionCallstackData();
   sampling_profiler->ProcessSamples(*selection_callstack_data);
 
-  int samples_count = selection_callstack_data->GetCallstackEventsSize();
-  if (samples_count > 0) {
-    GOrbitApp->AddSelectionReport(sampling_profiler, selection_callstack_data);
-  }
+  GOrbitApp->AddSelectionReport(sampling_profiler, selection_callstack_data.get());
+  Capture::capture_data_.SetSelectionCallstackData(std::move(selection_callstack_data));
 
   NeedsUpdate();
 


### PR DESCRIPTION
Clear selection tab when selection is cleared and fix the issue that the
selection isn't cleared when started a new selection.

Test: start capture, make several selections, check that new selection
doesn't contain data of the previous one.

Bug: https://b/156694740