### PR TITLE
Move GTargetProcess to DataManager and CaptureData

### DIFF
--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -84,8 +84,6 @@ bool ClientGgp::StopCapture() {
 void ClientGgp::InitCapture() {
   target_process_ = GetOrbitProcessByPid(options_.capture_pid);
   CHECK(target_process_ != nullptr);
-  // TODO: remove this line when GTargetProcess is deprecated in Capture
-  Capture::SetTargetProcess(target_process_);
 }
 
 // CaptureListener implementation

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -52,7 +52,7 @@ bool ClientGgp::InitClient() {
 
 // Client requests to start the capture
 bool ClientGgp::RequestStartCapture(ThreadPool* thread_pool) {
-  int32_t pid = target_process_->GetID();
+  int32_t pid = target_process_->GetId();
   if (pid == -1) {
     ERROR(
         "Error starting capture: "

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -65,7 +65,8 @@ bool ClientGgp::RequestStartCapture(ThreadPool* thread_pool) {
   // TODO(kuebler): right now selected_functions is only an empty placeholder,
   //  it needs to be filled separately in each client and then passed.
   absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions;
-  Capture::capture_data_ = CaptureData(pid, target_process_->GetName(), selected_functions);
+  Capture::capture_data_ =
+      CaptureData(pid, target_process_->GetName(), target_process_, selected_functions);
 
   ErrorMessageOr<void> result = capture_client_->StartCapture(thread_pool, pid, selected_functions);
   if (result.has_error()) {
@@ -81,7 +82,6 @@ bool ClientGgp::StopCapture() {
 }
 
 void ClientGgp::InitCapture() {
-  Capture::Init();
   target_process_ = GetOrbitProcessByPid(options_.capture_pid);
   CHECK(target_process_ != nullptr);
   // TODO: remove this line when GTargetProcess is deprecated in Capture

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -6,15 +6,8 @@
 
 #include <ostream>
 
-#include "EventBuffer.h"
-#include "FunctionUtils.h"
-#include "OrbitBase/Logging.h"
-#include "Path.h"
-#include "Pdb.h"
 #include "SamplingProfiler.h"
 #include "absl/strings/str_format.h"
-
-using orbit_client_protos::FunctionInfo;
 
 CaptureData Capture::capture_data_;
 

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -19,15 +19,9 @@ using orbit_client_protos::FunctionInfo;
 CaptureData Capture::capture_data_;
 
 std::shared_ptr<SamplingProfiler> Capture::GSamplingProfiler = nullptr;
-std::shared_ptr<Process> Capture::GTargetProcess = nullptr;
-
-void Capture::Init() { GTargetProcess = std::make_shared<Process>(); }
 
 void Capture::SetTargetProcess(std::shared_ptr<Process> process) {
-  if (process != GTargetProcess) {
-    GSamplingProfiler = std::make_shared<SamplingProfiler>(process);
-    GTargetProcess = std::move(process);
-  }
+  GSamplingProfiler = std::make_shared<SamplingProfiler>(std::move(process));
 }
 
 void Capture::FinalizeCapture() {

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -23,7 +23,6 @@ class SamplingProfiler;
 
 class Capture {
  public:
-  static void Init();
   static void SetTargetProcess(std::shared_ptr<Process> process);
   static void FinalizeCapture();
   static void PreSave();
@@ -31,7 +30,6 @@ class Capture {
   static CaptureData capture_data_;
 
   static std::shared_ptr<SamplingProfiler> GSamplingProfiler;
-  static std::shared_ptr<Process> GTargetProcess;
 };
 
 #endif  // ORBIT_CORE_CAPTURE_H_

--- a/OrbitCore/OrbitProcess.cpp
+++ b/OrbitCore/OrbitProcess.cpp
@@ -14,8 +14,8 @@
 using orbit_client_protos::FunctionInfo;
 
 Process::Process() {
-  process_id_ = 0;
-  m_Is64Bit = false;
+  id_ = -1;
+  is_64_bit_ = false;
 }
 
 FunctionInfo* Process::GetFunctionFromAddress(uint64_t address, bool a_IsExact) {

--- a/OrbitCore/OrbitProcess.cpp
+++ b/OrbitCore/OrbitProcess.cpp
@@ -14,7 +14,7 @@
 using orbit_client_protos::FunctionInfo;
 
 Process::Process() {
-  m_ID = 0;
+  process_id_ = 0;
   m_Is64Bit = false;
 }
 

--- a/OrbitCore/OrbitProcess.h
+++ b/OrbitCore/OrbitProcess.h
@@ -32,8 +32,8 @@ class Process {
   const std::string& GetName() const { return m_Name; }
   void SetFullPath(std::string_view full_path) { m_FullPath = full_path; }
   const std::string& GetFullPath() const { return m_FullPath; }
-  void SetID(int32_t id) { m_ID = id; }
-  int32_t GetID() const { return m_ID; }
+  void SetID(int32_t id) { process_id_ = id; }
+  [[nodiscard]] int32_t GetID() const { return process_id_; }
   void SetIs64Bit(bool value) { m_Is64Bit = value; }
   bool GetIs64Bit() const { return m_Is64Bit; }
 
@@ -57,7 +57,7 @@ class Process {
   Mutex& GetDataMutex() { return data_mutex_; }
 
  private:
-  int32_t m_ID;
+  int32_t process_id_ = -1;
 
   std::string m_Name;
   std::string m_FullPath;

--- a/OrbitCore/OrbitProcess.h
+++ b/OrbitCore/OrbitProcess.h
@@ -33,7 +33,7 @@ class Process {
   void SetFullPath(std::string_view full_path) { m_FullPath = full_path; }
   const std::string& GetFullPath() const { return m_FullPath; }
   void SetID(int32_t id) { process_id_ = id; }
-  [[nodiscard]] int32_t GetID() const { return process_id_; }
+  [[nodiscard]] int32_t GetId() const { return process_id_; }
   void SetIs64Bit(bool value) { m_Is64Bit = value; }
   bool GetIs64Bit() const { return m_Is64Bit; }
 

--- a/OrbitCore/OrbitProcess.h
+++ b/OrbitCore/OrbitProcess.h
@@ -32,10 +32,10 @@ class Process {
   const std::string& GetName() const { return m_Name; }
   void SetFullPath(std::string_view full_path) { m_FullPath = full_path; }
   const std::string& GetFullPath() const { return m_FullPath; }
-  void SetID(int32_t id) { process_id_ = id; }
-  [[nodiscard]] int32_t GetId() const { return process_id_; }
-  void SetIs64Bit(bool value) { m_Is64Bit = value; }
-  bool GetIs64Bit() const { return m_Is64Bit; }
+  void SetID(int32_t id) { id_ = id; }
+  [[nodiscard]] int32_t GetId() const { return id_; }
+  void SetIs64Bit(bool value) { is_64_bit_ = value; }
+  bool GetIs64Bit() const { return is_64_bit_; }
 
   orbit_client_protos::FunctionInfo* GetFunctionFromAddress(uint64_t address,
                                                             bool a_IsExact = true);
@@ -57,12 +57,12 @@ class Process {
   Mutex& GetDataMutex() { return data_mutex_; }
 
  private:
-  int32_t process_id_ = -1;
+  int32_t id_ = -1;
 
   std::string m_Name;
   std::string m_FullPath;
 
-  bool m_Is64Bit;
+  bool is_64_bit_;
   Mutex data_mutex_;
 
   std::map<uint64_t, std::shared_ptr<Module>> m_Modules;

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -906,7 +906,7 @@ void OrbitApp::UpdateProcessAndModuleList(
       // To this point all data is ready. We can set the Process and then
       // propagate the changes to the UI.
 
-      if (pid != GetSelectedProcessID()) {
+      if (pid != GetSelectedProcess()->GetID()) {
         data_manager_->ClearSelectedFunctions();
         // TODO(kuebler): Move as soon as Capture is gone.
         data_manager_->set_selected_process(process);

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -613,7 +613,8 @@ void OrbitApp::ClearCapture() {
   SelectTextBox(nullptr);
 
   // Trigger deallocation of previous sampling related data.
-  auto empty_sampling_profiler = std::make_shared<SamplingProfiler>(std::make_shared<Process>());
+  // TODO(kuebler): Investigate why selected process needs to be passed here.
+  auto empty_sampling_profiler = std::make_shared<SamplingProfiler>(GetSelectedProcess());
   AddSamplingReport(empty_sampling_profiler, nullptr);
   AddTopDownView(*empty_sampling_profiler);
   Capture::GSamplingProfiler = empty_sampling_profiler;

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -620,7 +620,7 @@ void OrbitApp::ClearCapture() {
   Capture::GSamplingProfiler = empty_sampling_profiler;
 
   if (selection_report_) {
-    auto empty_selection_profiler = std::make_shared<SamplingProfiler>(Capture::GTargetProcess);
+    auto empty_selection_profiler = std::make_shared<SamplingProfiler>(GetSelectedProcess());
     AddSelectionReport(empty_selection_profiler, nullptr);
   }
 

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -210,11 +210,11 @@ void OrbitApp::PostInit() {
             process->SetIs64Bit(info.is_64_bit());
             // The other fields do not appear to be used at the moment.
 
-            process_map_.insert_or_assign(process->GetID(), process);
+            process_map_.insert_or_assign(process->GetId(), process);
           }
         }
 
-        if (GetSelectedProcessID() == -1 && processes_data_view_->GetFirstProcessId() != -1) {
+        if (GetSelectedProcessId() == -1 && processes_data_view_->GetFirstProcessId() != -1) {
           processes_data_view_->SelectProcess(processes_data_view_->GetFirstProcessId());
         }
         FireRefreshCallbacks(DataViewType::kProcesses);
@@ -454,7 +454,7 @@ ErrorMessageOr<void> OrbitApp::OnSavePreset(const std::string& filename) {
 
 ErrorMessageOr<void> OrbitApp::SavePreset(const std::string& filename) {
   PresetInfo preset;
-  const int32_t pid = GetSelectedProcessID();
+  const int32_t pid = GetSelectedProcessId();
   const std::shared_ptr<Process>& process = FindProcessByPid(pid);
   preset.set_process_full_path(data_manager_->GetProcessByPid(pid)->full_path());
 
@@ -517,7 +517,7 @@ ErrorMessageOr<void> OrbitApp::OnLoadPreset(const std::string& filename) {
 }
 
 void OrbitApp::LoadPreset(const std::shared_ptr<PresetFile>& preset) {
-  const int32_t selected_process_id = GetSelectedProcessID();
+  const int32_t selected_process_id = GetSelectedProcessId();
   const ProcessData* selected_process = data_manager_->GetProcessByPid(selected_process_id);
   const std::string& process_full_path = preset->preset_info().process_full_path();
   if (selected_process != nullptr && selected_process->full_path() == process_full_path) {
@@ -562,7 +562,7 @@ void OrbitApp::FireRefreshCallbacks(DataViewType type) {
 }
 
 bool OrbitApp::StartCapture() {
-  int32_t pid = GetSelectedProcessID();
+  int32_t pid = GetSelectedProcessId();
   if (pid == -1) {
     SendErrorToUi("Error starting capture",
                   "No process selected. Please choose a target process for the capture.");
@@ -850,13 +850,13 @@ void OrbitApp::LoadModulesFromPreset(const std::shared_ptr<Process>& process,
                         absl::StrJoin(modules_not_found, "\"\n\""), process->GetName()));
   }
   if (!modules_to_load.empty()) {
-    LoadModules(process, process->GetID(), modules_to_load, preset);
+    LoadModules(process, process->GetId(), modules_to_load, preset);
   }
 }
 
 void OrbitApp::UpdateProcessAndModuleList(
     int32_t pid, const std::shared_ptr<orbit_client_protos::PresetFile>& preset) {
-  CHECK(GetSelectedProcessID() == pid);
+  CHECK(processes_data_view_->GetSelectedProcessId() == pid);
   thread_pool_->Schedule([pid, preset, this] {
     ErrorMessageOr<std::vector<ModuleInfo>> result = process_manager_->LoadModuleList(pid);
 
@@ -871,7 +871,7 @@ void OrbitApp::UpdateProcessAndModuleList(
       // the moment we arrive here. If not - ignore the result.
       const std::vector<ModuleInfo>& module_infos = result.value();
       data_manager_->UpdateModuleInfos(pid, module_infos);
-      if (pid != GetSelectedProcessID()) {
+      if (pid != processes_data_view_->GetSelectedProcessId()) {
         return;
       }
 
@@ -906,7 +906,7 @@ void OrbitApp::UpdateProcessAndModuleList(
       // To this point all data is ready. We can set the Process and then
       // propagate the changes to the UI.
 
-      if (pid != GetSelectedProcess()->GetID()) {
+      if (pid != GetSelectedProcessId()) {
         data_manager_->ClearSelectedFunctions();
         // TODO(kuebler): Move as soon as Capture is gone.
         data_manager_->set_selected_process(process);

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -206,8 +206,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   [[nodiscard]] ThreadPool* GetThreadPool() { return thread_pool_.get(); }
   [[nodiscard]] MainThreadExecutor* GetMainThreadExecutor() { return main_thread_executor_.get(); }
   [[nodiscard]] std::shared_ptr<Process> FindProcessByPid(int32_t pid);
-  [[nodiscard]] int32_t GetSelectedProcessID() const {
-    return processes_data_view_->GetSelectedProcessId();
+  [[nodiscard]] int32_t GetSelectedProcessId() const {
+    return data_manager_->selected_process()->GetId();
   }
   [[nodiscard]] const std::shared_ptr<Process>& GetSelectedProcess() const {
     return data_manager_->selected_process();

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -186,7 +186,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void SendErrorToUi(const std::string& title, const std::string& text);
   void NeedsRedraw();
 
-  void LoadModules(int32_t process_id, const std::vector<std::shared_ptr<Module>>& modules,
+  void LoadModules(const std::shared_ptr<Process>& process, int32_t process_id,
+                   const std::vector<std::shared_ptr<Module>>& modules,
                    const std::shared_ptr<orbit_client_protos::PresetFile>& preset = nullptr);
   void LoadModulesFromPreset(const std::shared_ptr<Process>& process,
                              const std::shared_ptr<orbit_client_protos::PresetFile>& preset);
@@ -208,6 +209,9 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   [[nodiscard]] int32_t GetSelectedProcessID() const {
     return processes_data_view_->GetSelectedProcessId();
   }
+  [[nodiscard]] const std::shared_ptr<Process>& GetSelectedProcess() const {
+    return data_manager_->selected_process();
+  }
 
   // TODO(kuebler): Move them to a separate controler at some point
   void SelectFunction(const orbit_client_protos::FunctionInfo& func);
@@ -226,7 +230,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void SelectTextBox(const TextBox* text_box);
 
  private:
-  void LoadModuleOnRemote(int32_t process_id, const std::shared_ptr<Module>& module,
+  void LoadModuleOnRemote(const std::shared_ptr<Process>& process, int32_t process_id,
+                          const std::shared_ptr<Module>& module,
                           const std::shared_ptr<orbit_client_protos::PresetFile>& preset);
   void SymbolLoadingFinished(uint32_t process_id, const std::shared_ptr<Module>& module,
                              const std::shared_ptr<orbit_client_protos::PresetFile>& preset);

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -182,7 +182,8 @@ void CaptureSerializer::ProcessCaptureData(const CaptureInfo& capture_info) {
   absl::flat_hash_map<uint64_t, FunctionStats> functions_stats{
       capture_info.function_stats().begin(), capture_info.function_stats().end()};
   CaptureData capture_data(capture_info.process_id(), capture_info.process_name(),
-                           std::move(selected_functions), std::move(functions_stats));
+                           std::make_shared<Process>(), std::move(selected_functions),
+                           std::move(functions_stats));
 
   absl::flat_hash_map<uint64_t, orbit_client_protos::LinuxAddressInfo> address_infos;
   address_infos.reserve(capture_info.address_infos_size());

--- a/OrbitGl/DataManager.cpp
+++ b/OrbitGl/DataManager.cpp
@@ -129,3 +129,14 @@ const absl::flat_hash_set<uint64_t>& DataManager::selected_functions() const {
   CHECK(std::this_thread::get_id() == main_thread_id_);
   return selected_functions_;
 }
+
+void DataManager::set_selected_process(std::shared_ptr<Process> process) {
+  CHECK(std::this_thread::get_id() == main_thread_id_);
+  CHECK(process != nullptr);
+  selected_process_ = std::move(process);
+}
+
+const std::shared_ptr<Process>& DataManager::selected_process() const {
+  CHECK(std::this_thread::get_id() == main_thread_id_);
+  return selected_process_;
+}

--- a/OrbitGl/DataManager.h
+++ b/OrbitGl/DataManager.h
@@ -54,6 +54,7 @@ class DataManager final {
   absl::flat_hash_set<uint64_t> visible_functions_;
   int32_t selected_thread_id_ = -1;
   const TextBox* selected_text_box_ = nullptr;
+  // TODO(kuebler): Remove OrbitProcess class and this member soon.
   std::shared_ptr<Process> selected_process_ = std::make_shared<Process>();
 };
 

--- a/OrbitGl/DataManager.h
+++ b/OrbitGl/DataManager.h
@@ -5,6 +5,8 @@
 #ifndef ORBIT_GL_DATA_MANAGER_H_
 #define ORBIT_GL_DATA_MANAGER_H_
 
+#include <OrbitProcess.h>
+
 #include <thread>
 
 #include "ProcessData.h"
@@ -32,6 +34,7 @@ class DataManager final {
   void set_visible_functions(absl::flat_hash_set<uint64_t> visible_functions);
   void set_selected_thread_id(int32_t thread_id);
   void set_selected_text_box(const TextBox* text_box);
+  void set_selected_process(std::shared_ptr<Process> process);
 
   [[nodiscard]] ProcessData* GetProcessByPid(int32_t process_id) const;
   [[nodiscard]] const std::vector<ModuleData*>& GetModules(int32_t process_id) const;
@@ -42,6 +45,7 @@ class DataManager final {
   [[nodiscard]] bool IsFunctionVisible(uint64_t function_address) const;
   [[nodiscard]] int32_t selected_thread_id() const;
   [[nodiscard]] const TextBox* selected_text_box() const;
+  [[nodiscard]] const std::shared_ptr<Process>& selected_process() const;
 
  private:
   const std::thread::id main_thread_id_;
@@ -50,6 +54,7 @@ class DataManager final {
   absl::flat_hash_set<uint64_t> visible_functions_;
   int32_t selected_thread_id_ = -1;
   const TextBox* selected_text_box_ = nullptr;
+  std::shared_ptr<Process> selected_process_ = std::make_shared<Process>();
 };
 
 #endif  // ORBIT_GL_DATA_MANAGER_H_

--- a/OrbitGl/FunctionsDataView.cpp
+++ b/OrbitGl/FunctionsDataView.cpp
@@ -5,7 +5,6 @@
 #include "FunctionsDataView.h"
 
 #include "App.h"
-#include "Capture.h"
 #include "FunctionUtils.h"
 #include "OrbitProcess.h"
 #include "Pdb.h"
@@ -203,7 +202,7 @@ void FunctionsDataView::DoFilter() {
 void FunctionsDataView::ParallelFilter() {
 #ifdef _WIN32
   const std::vector<std::shared_ptr<FunctionInfo>>& functions =
-      Capture::GTargetProcess->GetFunctions();
+      GOrbitApp->GetSelectedProcess()->GetFunctions();
   const auto prio = oqpi::task_priority::normal;
   auto numWorkers = oqpi_tk::scheduler().workersCount(prio);
   // int numWorkers = oqpi::thread::hardware_concurrency();

--- a/OrbitGl/FunctionsDataView.cpp
+++ b/OrbitGl/FunctionsDataView.cpp
@@ -148,7 +148,7 @@ void FunctionsDataView::OnContextMenu(const std::string& action, int menu_index,
       GOrbitApp->DeselectFunction(GetFunction(i));
     }
   } else if (action == kMenuActionDisassembly) {
-    int32_t pid = GOrbitApp->GetSelectedProcessID();
+    int32_t pid = GOrbitApp->GetSelectedProcessId();
     for (int i : item_indices) {
       GOrbitApp->Disassemble(pid, GetFunction(i));
     }

--- a/OrbitGl/FunctionsDataView.cpp
+++ b/OrbitGl/FunctionsDataView.cpp
@@ -33,7 +33,7 @@ const std::vector<DataView::Column>& FunctionsDataView::GetColumns() {
 }
 
 std::string FunctionsDataView::GetValue(int row, int column) {
-  ScopeLock lock(Capture::GTargetProcess->GetDataMutex());
+  ScopeLock lock(GOrbitApp->GetSelectedProcess()->GetDataMutex());
 
   if (row >= static_cast<int>(GetNumElements())) {
     return "";
@@ -83,7 +83,7 @@ void FunctionsDataView::DoSort() {
   std::function<bool(int a, int b)> sorter = nullptr;
 
   const std::vector<std::shared_ptr<FunctionInfo>>& functions =
-      Capture::GTargetProcess->GetFunctions();
+      GOrbitApp->GetSelectedProcess()->GetFunctions();
 
   switch (sorting_column_) {
     case kColumnSelected:
@@ -174,7 +174,7 @@ void FunctionsDataView::DoFilter() {
   // TODO: port parallel filtering
   std::vector<uint32_t> indices;
   const std::vector<std::shared_ptr<FunctionInfo>>& functions =
-      Capture::GTargetProcess->GetFunctions();
+      GOrbitApp->GetSelectedProcess()->GetFunctions();
   for (size_t i = 0; i < functions.size(); ++i) {
     auto& function = functions[i];
     std::string name = ToLower(FunctionUtils::GetDisplayName(*function)) +
@@ -242,9 +242,9 @@ void FunctionsDataView::ParallelFilter() {
 }
 
 void FunctionsDataView::OnDataChanged() {
-  ScopeLock lock(Capture::GTargetProcess->GetDataMutex());
+  ScopeLock lock(GOrbitApp->GetSelectedProcess()->GetDataMutex());
 
-  size_t num_functions = Capture::GTargetProcess->GetFunctions().size();
+  size_t num_functions = GOrbitApp->GetSelectedProcess()->GetFunctions().size();
   indices_.resize(num_functions);
   for (size_t i = 0; i < num_functions; ++i) {
     indices_[i] = i;
@@ -254,8 +254,8 @@ void FunctionsDataView::OnDataChanged() {
 }
 
 FunctionInfo& FunctionsDataView::GetFunction(int row) const {
-  ScopeLock lock(Capture::GTargetProcess->GetDataMutex());
+  ScopeLock lock(GOrbitApp->GetSelectedProcess()->GetDataMutex());
   const std::vector<std::shared_ptr<FunctionInfo>>& functions =
-      Capture::GTargetProcess->GetFunctions();
+      GOrbitApp->GetSelectedProcess()->GetFunctions();
   return *functions[indices_[row]];
 }

--- a/OrbitGl/ModulesDataView.cpp
+++ b/OrbitGl/ModulesDataView.cpp
@@ -113,21 +113,22 @@ std::vector<std::string> ModulesDataView::GetContextMenu(int clicked_index,
 
 void ModulesDataView::OnContextMenu(const std::string& action, int menu_index,
                                     const std::vector<int>& item_indices) {
+  const std::shared_ptr<Process>& process = GOrbitApp->GetSelectedProcess();
   if (action == kMenuActionLoadSymbols) {
     std::vector<std::shared_ptr<Module>> modules;
     for (int index : item_indices) {
       const ModuleData* module_data = GetModule(index);
       if (!module_data->is_loaded()) {
-        modules.push_back(Capture::GTargetProcess->GetModuleFromPath(module_data->file_path()));
+        modules.push_back(process->GetModuleFromPath(module_data->file_path()));
       }
     }
-    GOrbitApp->LoadModules(GOrbitApp->GetSelectedProcessID(), modules);
+    GOrbitApp->LoadModules(process, GOrbitApp->GetSelectedProcessID(), modules);
 
   } else if (action == kMenuActionVerifyFramePointers) {
     std::vector<std::shared_ptr<Module>> modules_to_validate;
     for (int index : item_indices) {
       const ModuleData* module = GetModule(index);
-      modules_to_validate.push_back(Capture::GTargetProcess->GetModuleFromName(module->name()));
+      modules_to_validate.push_back(process->GetModuleFromName(module->name()));
     }
 
     if (!modules_to_validate.empty()) {

--- a/OrbitGl/ModulesDataView.cpp
+++ b/OrbitGl/ModulesDataView.cpp
@@ -122,7 +122,7 @@ void ModulesDataView::OnContextMenu(const std::string& action, int menu_index,
         modules.push_back(process->GetModuleFromPath(module_data->file_path()));
       }
     }
-    GOrbitApp->LoadModules(process, GOrbitApp->GetSelectedProcessID(), modules);
+    GOrbitApp->LoadModules(process, GOrbitApp->GetSelectedProcessId(), modules);
 
   } else if (action == kMenuActionVerifyFramePointers) {
     std::vector<std::shared_ptr<Module>> modules_to_validate;
@@ -180,7 +180,7 @@ void ModulesDataView::SetModules(int32_t process_id, const std::vector<ModuleDat
 }
 
 void ModulesDataView::OnRefreshButtonClicked() {
-  GOrbitApp->UpdateProcessAndModuleList(GOrbitApp->GetSelectedProcessID(), nullptr);
+  GOrbitApp->UpdateProcessAndModuleList(GOrbitApp->GetSelectedProcessId(), nullptr);
 }
 
 const ModuleData* ModulesDataView::GetModule(uint32_t row) const { return modules_[indices_[row]]; }

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -307,7 +307,7 @@ void TimeGraph::ProcessTimer(const TimerInfo& timer_info) {
 
   if (timer_info.function_address() > 0) {
     FunctionInfo* func =
-        Capture::GTargetProcess->GetFunctionFromAddress(timer_info.function_address());
+        Capture::capture_data_.process()->GetFunctionFromAddress(timer_info.function_address());
 
     if (func != nullptr) {
       Capture::capture_data_.UpdateFunctionStats(func, timer_info);
@@ -609,7 +609,7 @@ std::vector<CallstackEvent> TimeGraph::SelectEvents(float a_WorldStart, float a_
 
   // Generate selection report.
   std::shared_ptr<SamplingProfiler> sampling_profiler =
-      std::make_shared<SamplingProfiler>(Capture::GTargetProcess);
+      std::make_shared<SamplingProfiler>(Capture::capture_data_.process());
 
   sampling_profiler->SetGenerateSummary(a_TID == 0);
 


### PR DESCRIPTION
The global Capture::GTargetProcess was used for two purposes:
1. Get/Add Functions/Modules for the currently selected process.
2. Get/add Functions/Modules for the process from the previous capture.

This explicitly distinguishes these cases by moving the selected
process to the DataManager and when starting a capture, store the
selected process in capture data.
This will also fix symbol loading.

Follow Up: Remove outside usage of the Mutex inside Process. And
  later completely remove Process (replace by ProcessInfo).

Test: Compile
Bug: http://b/163020637 and http://b/165562622