### PR TITLE
Fix callstack view when switch between sampling and selection tabs

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -551,7 +551,7 @@ ErrorMessageOr<void> OrbitApp::OnLoadCapture(const std::string& file_name) {
 }
 
 void OrbitApp::FireRefreshCallbacks(DataViewType type) {
-  for (DataView* panel : m_Panels) {
+  for (DataView* panel : panels_) {
     if (type == DataViewType::kAll || type == panel->GetType()) {
       panel->OnDataChanged();
     }
@@ -990,21 +990,21 @@ DataView* OrbitApp::GetOrCreateDataView(DataViewType type) {
     case DataViewType::kFunctions:
       if (!functions_data_view_) {
         functions_data_view_ = std::make_unique<FunctionsDataView>();
-        m_Panels.push_back(functions_data_view_.get());
+        panels_.push_back(functions_data_view_.get());
       }
       return functions_data_view_.get();
 
     case DataViewType::kCallstack:
       if (!callstack_data_view_) {
         callstack_data_view_ = std::make_unique<CallStackDataView>();
-        m_Panels.push_back(callstack_data_view_.get());
+        panels_.push_back(callstack_data_view_.get());
       }
       return callstack_data_view_.get();
 
     case DataViewType::kModules:
       if (!modules_data_view_) {
         modules_data_view_ = std::make_unique<ModulesDataView>();
-        m_Panels.push_back(modules_data_view_.get());
+        panels_.push_back(modules_data_view_.get());
       }
       return modules_data_view_.get();
 
@@ -1015,14 +1015,14 @@ DataView* OrbitApp::GetOrCreateDataView(DataViewType type) {
             [&](int32_t pid, const std::shared_ptr<orbit_client_protos::PresetFile>& preset) {
               UpdateProcessAndModuleList(pid, preset);
             });
-        m_Panels.push_back(processes_data_view_.get());
+        panels_.push_back(processes_data_view_.get());
       }
       return processes_data_view_.get();
 
     case DataViewType::kPresets:
       if (!presets_data_view_) {
         presets_data_view_ = std::make_unique<PresetsDataView>();
-        m_Panels.push_back(presets_data_view_.get());
+        panels_.push_back(presets_data_view_.get());
       }
       return presets_data_view_.get();
 
@@ -1046,7 +1046,7 @@ DataView* OrbitApp::GetOrCreateDataView(DataViewType type) {
 DataView* OrbitApp::GetOrCreateSelectionCallstackDataView() {
   if (selection_callstack_data_view_ == nullptr) {
     selection_callstack_data_view_ = std::make_unique<CallStackDataView>();
-    m_Panels.push_back(selection_callstack_data_view_.get());
+    panels_.push_back(selection_callstack_data_view_.get());
   }
   return selection_callstack_data_view_.get();
 }

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -395,7 +395,7 @@ void OrbitApp::AddSelectionReport(std::shared_ptr<SamplingProfiler> sampling_pro
   auto report = std::make_shared<SamplingReport>(std::move(sampling_profiler), callstack_data);
 
   if (selection_report_callback_) {
-    DataView* callstack_data_view = GetOrCreateDataView(DataViewType::kCallstack);
+    DataView* callstack_data_view = GetOrCreateSelectionCallstackDataView();
     selection_report_callback_(callstack_data_view, report);
   }
 
@@ -404,6 +404,7 @@ void OrbitApp::AddSelectionReport(std::shared_ptr<SamplingProfiler> sampling_pro
     selection_report_->ClearReport();
   }
   selection_report_ = report;
+  FireRefreshCallbacks();
 }
 
 void OrbitApp::AddTopDownView(const SamplingProfiler& sampling_profiler) {
@@ -1040,6 +1041,14 @@ DataView* OrbitApp::GetOrCreateDataView(DataViewType type) {
   }
 
   FATAL("Unreachable");
+}
+
+DataView* OrbitApp::GetOrCreateSelectionCallstackDataView() {
+  if (selection_callstack_data_view_ == nullptr) {
+    selection_callstack_data_view_ = std::make_unique<CallStackDataView>();
+    m_Panels.push_back(selection_callstack_data_view_.get());
+  }
+  return selection_callstack_data_view_.get();
 }
 
 void OrbitApp::FilterTracks(const std::string& filter) {

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -200,7 +200,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
 
   void CrashOrbitService(orbit_grpc_protos::CrashOrbitServiceRequest_CrashType crash_type);
 
-  DataView* GetOrCreateDataView(DataViewType type) override;
+  [[nodiscard]] DataView* GetOrCreateDataView(DataViewType type) override;
+  [[nodiscard]] DataView* GetOrCreateSelectionCallstackDataView();
 
   [[nodiscard]] ProcessManager* GetProcessManager() { return process_manager_.get(); }
   [[nodiscard]] ThreadPool* GetThreadPool() { return thread_pool_.get(); }
@@ -273,6 +274,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   std::unique_ptr<FunctionsDataView> functions_data_view_;
   std::unique_ptr<LiveFunctionsDataView> live_functions_data_view_;
   std::unique_ptr<CallStackDataView> callstack_data_view_;
+  std::unique_ptr<CallStackDataView> selection_callstack_data_view_;
   std::unique_ptr<PresetsDataView> presets_data_view_;
 
   CaptureWindow* capture_window_ = nullptr;

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -19,6 +19,7 @@
 #include "CallstackData.h"
 #include "CaptureWindow.h"
 #include "DataManager.h"
+#include "DataView.h"
 #include "DataViewFactory.h"
 #include "DataViewTypes.h"
 #include "DisassemblyReport.h"
@@ -264,7 +265,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   SamplingReportCallback sampling_reports_callback_;
   SamplingReportCallback selection_report_callback_;
   TopDownViewCallback top_down_view_callback_;
-  std::vector<class DataView*> m_Panels;
+  std::vector<DataView*> panels_;
   SaveFileCallback save_file_callback_;
   ClipboardCallback clipboard_callback_;
   SecureCopyCallback secure_copy_callback_;

--- a/OrbitGl/SamplingReport.cpp
+++ b/OrbitGl/SamplingReport.cpp
@@ -43,6 +43,16 @@ void SamplingReport::FillReport() {
   }
 }
 
+void SamplingReport::UpdateDisplayedCallstack() {
+  selected_sorted_callstack_report_ =
+      profiler_->GetSortedCallstacksFromAddress(selected_address_, selected_thread_id_);
+  if (selected_sorted_callstack_report_->callstacks_count.empty()) {
+    ClearReport();
+  } else {
+    OnCallstackIndexChanged(selected_callstack_index_);
+  }
+}
+
 void SamplingReport::UpdateReport() {
   if (callstack_data_ == nullptr) {
     return;
@@ -62,27 +72,15 @@ void SamplingReport::UpdateReport() {
   // for example the number of occurrences or of total callstacks might have
   // changed (OrbitSamplingReport::RefreshCallstackView will do the actual
   // update once OrbitApp::FireRefreshCallbacks is called).
-  selected_sorted_callstack_report_ =
-      profiler_->GetSortedCallstacksFromAddress(selected_address_, selected_thread_id_);
-  if (selected_sorted_callstack_report_->callstacks_count.empty()) {
-    ClearReport();
-  } else {
-    OnCallstackIndexChanged(selected_callstack_index_);
-  }
+  UpdateDisplayedCallstack();
 }
 
 void SamplingReport::OnSelectAddress(uint64_t address, ThreadID thread_id) {
   if (callstack_data_view_) {
     if (selected_address_ != address || selected_thread_id_ != thread_id) {
-      selected_sorted_callstack_report_ =
-          profiler_->GetSortedCallstacksFromAddress(address, thread_id);
       selected_address_ = address;
       selected_thread_id_ = thread_id;
-      if (selected_sorted_callstack_report_->callstacks_count.empty()) {
-        callstack_data_view_->ClearCallstack();
-      } else {
-        OnCallstackIndexChanged(0);
-      }
+      UpdateDisplayedCallstack();
     }
   }
 

--- a/OrbitGl/SamplingReport.h
+++ b/OrbitGl/SamplingReport.h
@@ -39,6 +39,7 @@ class SamplingReport {
  protected:
   void FillReport();
   void OnCallstackIndexChanged(size_t index);
+  void UpdateDisplayedCallstack();
 
  protected:
   std::shared_ptr<SamplingProfiler> profiler_;


### PR DESCRIPTION
CallstackDataView was common for both `sampling` and `selection` tabs,
and after switching the tabs CallstackDataView showed the callstack from
the previously selected tab. This commit introduces new DataViewType for
`selection` callstack, and adds corresponding view for it.

Test: take a capture, make a selection, switch from selection to samping
tab and vice versa.

Bug: http://b/165613158