### PR TITLE
Add load bias to ModuleInfo proto

### DIFF
--- a/OrbitGl/ModuleData.h
+++ b/OrbitGl/ModuleData.h
@@ -25,6 +25,7 @@ class ModuleData final {
   const std::string& file_path() const { return module_info_.file_path(); }
   uint64_t file_size() const { return module_info_.file_size(); }
   uint64_t address_start() const { return module_info_.address_start(); }
+  uint64_t load_bias() const { return module_info_.load_bias(); }
 
   std::string address_range() const {
     return absl::StrFormat("[%016" PRIx64 " - %016" PRIx64 "]", module_info_.address_start(),

--- a/OrbitGrpcProtos/module.proto
+++ b/OrbitGrpcProtos/module.proto
@@ -13,4 +13,5 @@ message ModuleInfo {
   uint64 address_start = 4;
   uint64 address_end = 5;
   string build_id = 6;
+  uint64 load_bias = 7;
 }

--- a/OrbitService/Utils.cpp
+++ b/OrbitService/Utils.cpp
@@ -122,6 +122,13 @@ ErrorMessageOr<std::vector<ModuleInfo>> ParseMaps(std::string_view proc_maps_dat
       continue;
     }
 
+    ErrorMessageOr<uint64_t> load_bias = elf_file.value()->GetLoadBias();
+    // Every loadable module contains a load bias.
+    if (!load_bias) {
+      ERROR("No load bias found for module %s", module_path.c_str());
+      continue;
+    }
+
     ModuleInfo module_info;
     module_info.set_name(std::filesystem::path{module_path}.filename());
     module_info.set_file_path(module_path);
@@ -129,6 +136,7 @@ ErrorMessageOr<std::vector<ModuleInfo>> ParseMaps(std::string_view proc_maps_dat
     module_info.set_address_start(address_range.start_address);
     module_info.set_address_end(address_range.end_address);
     module_info.set_build_id(elf_file.value()->GetBuildId());
+    module_info.set_load_bias(load_bias.value());
 
     result.push_back(module_info);
   }

--- a/OrbitService/UtilsTest.cpp
+++ b/OrbitService/UtilsTest.cpp
@@ -81,6 +81,7 @@ TEST(Utils, ParseMaps) {
     EXPECT_EQ(hello_module_info->address_start(), 0x7f6874285000);
     EXPECT_EQ(hello_module_info->address_end(), 0x7f6874290000);
     EXPECT_EQ(hello_module_info->build_id(), "d12d54bc5b72ccce54a408bdeda65e2530740ac8");
+    EXPECT_EQ(hello_module_info->load_bias(), 0x0);
 
     EXPECT_EQ(no_symbols_module_info->name(), "no_symbols_elf");
     EXPECT_EQ(no_symbols_module_info->file_path(), no_symbols_path);
@@ -88,9 +89,9 @@ TEST(Utils, ParseMaps) {
     EXPECT_EQ(no_symbols_module_info->address_start(), 0x0);
     EXPECT_EQ(no_symbols_module_info->address_end(), 0x1000);
     EXPECT_EQ(no_symbols_module_info->build_id(), "b5413574bbacec6eacb3b89b1012d0e2cd92ec6b");
+    EXPECT_EQ(no_symbols_module_info->load_bias(), 0x400000);
   }
 
-  // Is this actually going to work?
 }  // namespace orbit_service::utils
 
 TEST(Utils, GetCpuUtilization) {


### PR DESCRIPTION
Load bias can be determined easily for every module since the elf file
is read anyways for the build id. This removes the need for the load
bias to be part of symbol loading in the future.