### PR TITLE
Move GSamplingProfiler to CaptureData

### DIFF
--- a/OrbitCaptureClient/CaptureClient.cpp
+++ b/OrbitCaptureClient/CaptureClient.cpp
@@ -94,7 +94,7 @@ void CaptureClient::Capture(int32_t pid,
   state_ = State::kStarted;
   state_mutex_.Unlock();
 
-  capture_listener_->OnCaptureStarted();
+  capture_listener_->OnCaptureStarted(pid, selected_functions);
 
   CaptureResponse response;
   while (!force_stop_ && reader_writer_->Read(&response)) {

--- a/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -21,7 +21,8 @@ using orbit_client_protos::TimerInfo;
 
 class MyCaptureListener : public CaptureListener {
  private:
-  void OnCaptureStarted() override {}
+  void OnCaptureStarted(
+      int32_t, const absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>&) override {}
   void OnCaptureComplete() override {}
   void OnTimer(const TimerInfo&) override {}
   void OnKeyAndString(uint64_t, std::string) override {}

--- a/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -22,7 +22,9 @@ using orbit_client_protos::TimerInfo;
 class MyCaptureListener : public CaptureListener {
  private:
   void OnCaptureStarted(
-      int32_t, const absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>&) override {}
+      int32_t /*process_id*/,
+      const absl::flat_hash_map<
+          uint64_t, orbit_client_protos::FunctionInfo>& /*selected_functions*/) override {}
   void OnCaptureComplete() override {}
   void OnTimer(const TimerInfo&) override {}
   void OnKeyAndString(uint64_t, std::string) override {}

--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
@@ -8,6 +8,7 @@
 #include "Callstack.h"
 #include "EventBuffer.h"
 #include "ScopeTimer.h"
+#include "absl/container/flat_hash_map.h"
 #include "capture_data.pb.h"
 
 class CaptureListener {
@@ -15,7 +16,9 @@ class CaptureListener {
   virtual ~CaptureListener() = default;
 
   // Called after capture started but before the first event arrived.
-  virtual void OnCaptureStarted() = 0;
+  virtual void OnCaptureStarted(
+      int32_t process_id, const absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>&
+                              selected_functions) = 0;
   // Called when capture is complete
   virtual void OnCaptureComplete() = 0;
 

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -65,8 +65,6 @@ bool ClientGgp::RequestStartCapture(ThreadPool* thread_pool) {
   // TODO(kuebler): right now selected_functions is only an empty placeholder,
   //  it needs to be filled separately in each client and then passed.
   absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions;
-  Capture::capture_data_ =
-      CaptureData(pid, target_process_->GetName(), target_process_, selected_functions);
 
   ErrorMessageOr<void> result = capture_client_->StartCapture(thread_pool, pid, selected_functions);
   if (result.has_error()) {
@@ -87,7 +85,13 @@ void ClientGgp::InitCapture() {
 }
 
 // CaptureListener implementation
-void ClientGgp::OnCaptureStarted() { LOG("Capture started"); }
+void ClientGgp::OnCaptureStarted(
+    int32_t process_id,
+    const absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>& selected_functions) {
+  Capture::capture_data_ =
+      CaptureData(process_id, target_process_->GetName(), target_process_, selected_functions);
+  LOG("Capture started");
+}
 
 void ClientGgp::OnCaptureComplete() { LOG("Capture completed"); }
 

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -24,7 +24,9 @@ class ClientGgp final : public CaptureListener {
   void SaveCapture();
 
   // CaptureListener implementation
-  void OnCaptureStarted() override;
+  void OnCaptureStarted(int32_t process_id,
+                        const absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>&
+                            selected_functions) override;
   void OnCaptureComplete() override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
   void OnKeyAndString(uint64_t key, std::string str) override;

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -4,28 +4,4 @@
 
 #include "Capture.h"
 
-#include <ostream>
-
-#include "SamplingProfiler.h"
-#include "absl/strings/str_format.h"
-
 CaptureData Capture::capture_data_;
-
-std::shared_ptr<SamplingProfiler> Capture::GSamplingProfiler = nullptr;
-
-void Capture::SetTargetProcess(std::shared_ptr<Process> process) {
-  GSamplingProfiler = std::make_shared<SamplingProfiler>(std::move(process));
-}
-
-void Capture::FinalizeCapture() {
-  if (Capture::GSamplingProfiler != nullptr) {
-    Capture::GSamplingProfiler->ProcessSamples(*Capture::capture_data_.GetCallstackData());
-  }
-}
-
-void Capture::PreSave() {
-  // Add selected functions' exact address to sampling profiler
-  for (auto& pair : capture_data_.selected_functions()) {
-    GSamplingProfiler->UpdateAddressInfo(pair.first);
-  }
-}

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -9,27 +9,11 @@
 #include <outcome.hpp>
 #include <string>
 
-#include "CallstackTypes.h"
 #include "CaptureData.h"
-#include "OrbitBase/Result.h"
-#include "OrbitProcess.h"
-#include "Threading.h"
-#include "absl/container/flat_hash_map.h"
-#include "capture_data.pb.h"
-#include "preset.pb.h"
-
-class Process;
-class SamplingProfiler;
 
 class Capture {
  public:
-  static void SetTargetProcess(std::shared_ptr<Process> process);
-  static void FinalizeCapture();
-  static void PreSave();
-
   static CaptureData capture_data_;
-
-  static std::shared_ptr<SamplingProfiler> GSamplingProfiler;
 };
 
 #endif  // ORBIT_CORE_CAPTURE_H_

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -129,9 +129,7 @@ class CaptureData {
 
   [[nodiscard]] const std::shared_ptr<Process>& process() const { return process_; }
 
-  [[nodiscard]] std::shared_ptr<SamplingProfiler> sampling_profiler() const {
-    return sampling_profiler_;
-  }
+  [[nodiscard]] std::shared_ptr<SamplingProfiler> sampling_profiler() { return sampling_profiler_; }
 
   [[nodiscard]] const SamplingProfiler& GetSamplingProfiler() const { return *sampling_profiler_; }
 

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -129,7 +129,7 @@ class CaptureData {
 
   [[nodiscard]] const std::shared_ptr<Process>& process() const { return process_; }
 
-  [[nodiscard]] const std::shared_ptr<SamplingProfiler>& sampling_profiler() const {
+  [[nodiscard]] std::shared_ptr<SamplingProfiler> sampling_profiler() const {
     return sampling_profiler_;
   }
 

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -133,6 +133,8 @@ class CaptureData {
     return sampling_profiler_;
   }
 
+  [[nodiscard]] const SamplingProfiler& GetSamplingProfiler() const { return *sampling_profiler_; }
+
  private:
   int32_t process_id_ = -1;
   std::string process_name_;

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -10,6 +10,7 @@
 
 #include "CallstackData.h"
 #include "OrbitProcess.h"
+#include "SamplingProfiler.h"
 #include "absl/container/flat_hash_map.h"
 #include "capture_data.pb.h"
 
@@ -23,7 +24,8 @@ class CaptureData {
         process_{std::move(process)},
         selected_functions_{std::move(selected_functions)},
         callstack_data_(std::make_unique<CallstackData>()),
-        selection_callstack_data_(std::make_unique<CallstackData>()) {
+        selection_callstack_data_(std::make_unique<CallstackData>()),
+        sampling_profiler_{std::make_shared<SamplingProfiler>(process_)} {
     CHECK(process_ != nullptr);
   }
   explicit CaptureData(
@@ -36,6 +38,7 @@ class CaptureData {
         selected_functions_{std::move(selected_functions)},
         callstack_data_(std::make_unique<CallstackData>()),
         selection_callstack_data_(std::make_unique<CallstackData>()),
+        sampling_profiler_{std::make_shared<SamplingProfiler>(process_)},
         functions_stats_{std::move(functions_stats)} {
     CHECK(process_ != nullptr);
   }
@@ -43,7 +46,8 @@ class CaptureData {
   explicit CaptureData()
       : process_{std::make_shared<Process>()},
         callstack_data_(std::make_unique<CallstackData>()),
-        selection_callstack_data_(std::make_unique<CallstackData>()){};
+        selection_callstack_data_(std::make_unique<CallstackData>()),
+        sampling_profiler_{std::make_shared<SamplingProfiler>(process_)} {};
   CaptureData(const CaptureData& other) = delete;
   // We can not copy the unique_ptr, so we can not copy this object.
   CaptureData& operator=(const CaptureData& other) = delete;
@@ -125,6 +129,10 @@ class CaptureData {
 
   [[nodiscard]] const std::shared_ptr<Process>& process() const { return process_; }
 
+  [[nodiscard]] const std::shared_ptr<SamplingProfiler>& sampling_profiler() const {
+    return sampling_profiler_;
+  }
+
  private:
   int32_t process_id_ = -1;
   std::string process_name_;
@@ -135,6 +143,10 @@ class CaptureData {
   std::unique_ptr<CallstackData> callstack_data_;
   // selection_callstack_data_ is subset of callstack_data_
   std::unique_ptr<CallstackData> selection_callstack_data_;
+
+  // TODO(kuebler): Make this value type as soon as UI/SamplingReport does not need to modify it
+  //  anymore.
+  std::shared_ptr<SamplingProfiler> sampling_profiler_;
 
   absl::flat_hash_map<uint64_t, orbit_client_protos::LinuxAddressInfo> address_infos_;
 

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -109,7 +109,7 @@ void OrbitApp::OnCaptureComplete() {
 
     AddSamplingReport(Capture::capture_data_.sampling_profiler(),
                       Capture::capture_data_.GetCallstackData());
-    AddTopDownView(*Capture::capture_data_.sampling_profiler());
+    AddTopDownView(Capture::capture_data_.GetSamplingProfiler().);
 
     if (capture_stopped_callback_) {
       capture_stopped_callback_();
@@ -612,7 +612,7 @@ void OrbitApp::ClearCapture() {
 
   AddSamplingReport(Capture::capture_data_.sampling_profiler(), nullptr);
   // TODO(kuebler): This seems fishy. Probably, TopDownView does not update on new symbols.
-  AddTopDownView(*Capture::capture_data_.sampling_profiler());
+  AddTopDownView(Capture::capture_data_.GetSamplingProfiler());
 
   if (selection_report_) {
     auto empty_selection_profiler = std::make_shared<SamplingProfiler>(GetSelectedProcess());
@@ -769,7 +769,7 @@ void OrbitApp::SymbolLoadingFinished(uint32_t process_id, const std::shared_ptr<
   modules_currently_loading_.erase(module->m_FullName);
 
   UpdateSamplingReport();
-  AddTopDownView(*Capture::capture_data_.sampling_profiler());
+  AddTopDownView(Capture::capture_data_.GetSamplingProfiler());
   GOrbitApp->FireRefreshCallbacks();
 }
 

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -102,12 +102,14 @@ void OrbitApp::OnCaptureStarted() {
 void OrbitApp::OnCaptureComplete() {
   main_thread_executor_->Schedule([this] {
     Capture::capture_data_.set_address_infos(std::move(captured_address_infos_));
-    Capture::FinalizeCapture();
+    Capture::capture_data_.sampling_profiler()->ProcessSamples(
+        *Capture::capture_data_.GetCallstackData());
 
     RefreshCaptureView();
 
-    AddSamplingReport(Capture::GSamplingProfiler, Capture::capture_data_.GetCallstackData());
-    AddTopDownView(*Capture::GSamplingProfiler);
+    AddSamplingReport(Capture::capture_data_.sampling_profiler(),
+                      Capture::capture_data_.GetCallstackData());
+    AddTopDownView(*Capture::capture_data_.sampling_profiler());
 
     if (capture_stopped_callback_) {
       capture_stopped_callback_();
@@ -128,10 +130,6 @@ void OrbitApp::OnUniqueCallStack(CallStack callstack) {
 }
 
 void OrbitApp::OnCallstackEvent(CallstackEvent callstack_event) {
-  if (Capture::GSamplingProfiler == nullptr) {
-    ERROR("GSamplingProfiler is null, ignoring callstack event.");
-    return;
-  }
   GEventTracer.GetEventBuffer().AddCallstackEvent(
       callstack_event.time(), callstack_event.callstack_hash(), callstack_event.thread_id());
   Capture::capture_data_.AddCallstackEvent(std::move(callstack_event));
@@ -612,12 +610,9 @@ void OrbitApp::ClearCapture() {
   set_selected_thread_id(-1);
   SelectTextBox(nullptr);
 
-  // Trigger deallocation of previous sampling related data.
-  // TODO(kuebler): Investigate why selected process needs to be passed here.
-  auto empty_sampling_profiler = std::make_shared<SamplingProfiler>(GetSelectedProcess());
-  AddSamplingReport(empty_sampling_profiler, nullptr);
-  AddTopDownView(*empty_sampling_profiler);
-  Capture::GSamplingProfiler = empty_sampling_profiler;
+  AddSamplingReport(Capture::capture_data_.sampling_profiler(), nullptr);
+  // TODO(kuebler): This seems fishy. Probably, TopDownView does not update on new symbols.
+  AddTopDownView(*Capture::capture_data_.sampling_profiler());
 
   if (selection_report_) {
     auto empty_selection_profiler = std::make_shared<SamplingProfiler>(GetSelectedProcess());
@@ -774,7 +769,7 @@ void OrbitApp::SymbolLoadingFinished(uint32_t process_id, const std::shared_ptr<
   modules_currently_loading_.erase(module->m_FullName);
 
   UpdateSamplingReport();
-  AddTopDownView(*Capture::GSamplingProfiler);
+  AddTopDownView(*Capture::capture_data_.sampling_profiler());
   GOrbitApp->FireRefreshCallbacks();
 }
 
@@ -909,9 +904,7 @@ void OrbitApp::UpdateProcessAndModuleList(
 
       if (pid != GetSelectedProcessId()) {
         data_manager_->ClearSelectedFunctions();
-        // TODO(kuebler): Move as soon as Capture is gone.
         data_manager_->set_selected_process(process);
-        Capture::SetTargetProcess(std::move(process));
       }
 
       FireRefreshCallbacks();

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -83,7 +83,9 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void RefreshCaptureView();
   void Disassemble(int32_t pid, const orbit_client_protos::FunctionInfo& function);
 
-  void OnCaptureStarted() override;
+  void OnCaptureStarted(int32_t process_id,
+                        const absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>&
+                            selected_functions) override;
   void OnCaptureComplete() override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
   void OnKeyAndString(uint64_t key, std::string str) override;

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -60,10 +60,7 @@ std::string CallStackDataView::GetValue(int row, int column) {
       if (module != nullptr) {
         return module->m_Name;
       }
-      if (Capture::GSamplingProfiler != nullptr) {
-        return Capture::GSamplingProfiler->GetModuleNameByAddress(frame.address);
-      }
-      return "";
+      return Capture::capture_data_.sampling_profiler()->GetModuleNameByAddress(frame.address);
     case kColumnAddress:
       return absl::StrFormat("%#llx", frame.address);
     default:
@@ -207,9 +204,7 @@ CallStackDataView::CallStackDataViewFrame CallStackDataView::GetFrameFromIndex(
     return CallStackDataViewFrame(address, function, module);
   } else {
     std::string fallback_name;
-    if (Capture::GSamplingProfiler != nullptr) {
-      fallback_name = Capture::GSamplingProfiler->GetFunctionNameByAddress(address);
-    }
+    fallback_name = Capture::capture_data_.sampling_profiler()->GetFunctionNameByAddress(address);
     return CallStackDataViewFrame(address, fallback_name, module);
   }
 }

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -60,7 +60,7 @@ std::string CallStackDataView::GetValue(int row, int column) {
       if (module != nullptr) {
         return module->m_Name;
       }
-      return Capture::capture_data_.sampling_profiler()->GetModuleNameByAddress(frame.address);
+      return Capture::capture_data_.GetSamplingProfiler().GetModuleNameByAddress(frame.address);
     case kColumnAddress:
       return absl::StrFormat("%#llx", frame.address);
     default:
@@ -204,7 +204,7 @@ CallStackDataView::CallStackDataViewFrame CallStackDataView::GetFrameFromIndex(
     return CallStackDataViewFrame(address, function, module);
   } else {
     std::string fallback_name;
-    fallback_name = Capture::capture_data_.sampling_profiler()->GetFunctionNameByAddress(address);
+    fallback_name = Capture::capture_data_.GetSamplingProfiler().GetFunctionNameByAddress(address);
     return CallStackDataViewFrame(address, fallback_name, module);
   }
 }

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -35,7 +35,7 @@ using orbit_client_protos::TimerInfo;
 
 ErrorMessageOr<void> CaptureSerializer::Save(const std::string& filename) {
   // Add selected functions' exact address to sampling profiler
-  const std::shared_ptr<SamplingProfiler> profiler = Capture::capture_data_.sampling_profiler();
+  const std::shared_ptr<SamplingProfiler>& profiler = Capture::capture_data_.sampling_profiler();
   for (auto& pair : Capture::capture_data_.selected_functions()) {
     profiler->UpdateAddressInfo(pair.first);
   }
@@ -257,7 +257,7 @@ ErrorMessageOr<void> CaptureSerializer::Load(std::istream& stream) {
 
   GOrbitApp->AddSamplingReport(Capture::capture_data_.sampling_profiler(),
                                Capture::capture_data_.GetCallstackData());
-  GOrbitApp->AddTopDownView(*Capture::capture_data_.sampling_profiler());
+  GOrbitApp->AddTopDownView(Capture::capture_data_.GetSamplingProfiler());
   GOrbitApp->FireRefreshCallbacks();
   return outcome::success();
 }

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -160,7 +160,8 @@ bool EventTrack::IsEmpty() const {
 }
 
 static std::string SafeGetFormattedFunctionName(uint64_t addr, int max_line_length) {
-  const std::string& function_name = Capture::GSamplingProfiler->GetFunctionNameByAddress(addr);
+  const std::string& function_name =
+      Capture::capture_data_.sampling_profiler()->GetFunctionNameByAddress(addr);
   if (function_name == SamplingProfiler::kUnknownFunctionOrModuleName) {
     return std::string("<i>") + function_name + "</i>";
   }

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -161,7 +161,7 @@ bool EventTrack::IsEmpty() const {
 
 static std::string SafeGetFormattedFunctionName(uint64_t addr, int max_line_length) {
   const std::string& function_name =
-      Capture::capture_data_.sampling_profiler()->GetFunctionNameByAddress(addr);
+      Capture::capture_data_.GetSamplingProfiler().GetFunctionNameByAddress(addr);
   if (function_name == SamplingProfiler::kUnknownFunctionOrModuleName) {
     return std::string("<i>") + function_name + "</i>";
   }


### PR DESCRIPTION
This moves the global Capture::GSamplingProfiler to CaptureData.
By being tight to the CaptureData (of the previous capture), lifetime
is more explicit.

Follow Up:
1. Make the shared_ptr in CaptureData a value type.
2. Move CaptureData to DataManager.
3. Make SamplingProfiler stateless (requires updates of SamplingReport).

Test: Compile, Take Capture, Load Symbols (before and after). Check all
 views. Load a Capture.
Bug: http://b/163020637