### PR TITLE
Remove unnecessary code from OrbitModule

### DIFF
--- a/OrbitCore/OrbitModule.cpp
+++ b/OrbitCore/OrbitModule.cpp
@@ -20,28 +20,12 @@ using orbit_client_protos::FunctionInfo;
 using orbit_grpc_protos::ModuleSymbols;
 using orbit_grpc_protos::SymbolInfo;
 
-Module::Module(const std::string& file_name, uint64_t address_start, uint64_t address_end) {
-  if (!std::filesystem::exists(file_name)) {
-    ERROR("Creating Module from path \"%s\": file does not exist", file_name);
-  }
-
-  m_FullName = file_name;
-  m_Name = Path::GetFileName(file_name);
-  m_PdbSize = Path::FileSize(file_name);
-
-  m_AddressStart = address_start;
-  m_AddressEnd = address_end;
-
-  loadable_ = true;  // necessary, because it toggles "Load Symbols" option
-}
-
 void Module::LoadSymbols(const ModuleSymbols& module_symbols) {
   if (m_Pdb != nullptr) {
     LOG("Warning: Module \"%s\" already contained symbols, will override now", m_Name);
   }
 
-  m_Pdb = std::make_shared<Pdb>(m_AddressStart, module_symbols.load_bias(),
-                                module_symbols.symbols_file_path(), m_FullName);
+  m_Pdb = std::make_shared<Pdb>(m_AddressStart, module_symbols.load_bias(), m_FullName);
 
   for (const SymbolInfo& symbol_info : module_symbols.symbol_infos()) {
     std::shared_ptr<FunctionInfo> function = FunctionUtils::CreateFunctionInfo(

--- a/OrbitCore/OrbitModule.h
+++ b/OrbitCore/OrbitModule.h
@@ -14,13 +14,10 @@
 
 struct Module {
   Module() = default;
-  Module(const std::string& file_name, uint64_t address_start, uint64_t address_end);
 
   void LoadSymbols(const orbit_grpc_protos::ModuleSymbols& module_symbols);
 
   void SetLoaded(bool value) { loaded_ = value; }
-  void SetLoadable(bool value) { loadable_ = value; }
-  bool IsLoadable() const { return loadable_; }
   bool IsLoaded() const { return loaded_; }
 
   std::string m_Name;      // name of the file (without path)
@@ -35,7 +32,6 @@ struct Module {
   mutable std::shared_ptr<Pdb> m_Pdb;
 
  private:
-  bool loadable_ = false;
   bool loaded_ = false;
 };
 

--- a/OrbitCore/Pdb.cpp
+++ b/OrbitCore/Pdb.cpp
@@ -14,14 +14,10 @@ using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::PresetFile;
 using orbit_client_protos::PresetModule;
 
-Pdb::Pdb(uint64_t module_address, uint64_t load_bias, std::string file_name,
-         std::string module_file_name)
+Pdb::Pdb(uint64_t module_address, uint64_t load_bias, std::string file_name)
     : m_MainModule(module_address),
       load_bias_(load_bias),
-      m_FileName(std::move(file_name)),
-      m_LoadedModuleName(std::move(module_file_name)) {
-  m_Name = Path::GetFileName(m_FileName);
-}
+      m_LoadedModuleName(std::move(file_name)) {}
 
 void Pdb::AddFunction(const std::shared_ptr<FunctionInfo>& function) {
   functions_.push_back(function);

--- a/OrbitCore/Pdb.h
+++ b/OrbitCore/Pdb.h
@@ -15,13 +15,10 @@
 
 class Pdb {
  public:
-  Pdb(uint64_t module_address, uint64_t load_bias, std::string file_name,
-      std::string module_file_name);
+  Pdb(uint64_t module_address, uint64_t load_bias, std::string file_name);
   Pdb(const Pdb&) = delete;
   Pdb& operator=(const Pdb&) = delete;
 
-  const std::string& GetName() const { return m_Name; }
-  const std::string& GetFileName() const { return m_FileName; }
   const std::string& GetLoadedModuleName() const { return m_LoadedModuleName; }
   const std::vector<std::shared_ptr<orbit_client_protos::FunctionInfo>>& GetFunctions() {
     return functions_;
@@ -43,8 +40,6 @@ class Pdb {
  private:
   uint64_t m_MainModule = 0;
   uint64_t load_bias_ = 0;
-  std::string m_Name;              // name of the file containing the symbols
-  std::string m_FileName;          // full path of file containing the symbols
   std::string m_LoadedModuleName;  // full path of the module
   std::vector<std::shared_ptr<orbit_client_protos::FunctionInfo>> functions_;
   std::map<uint64_t, orbit_client_protos::FunctionInfo*> m_FunctionMap;

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -895,7 +895,6 @@ void OrbitApp::UpdateProcessAndModuleList(
         module->m_AddressStart = info.address_start();
         module->m_AddressEnd = info.address_end();
         module->m_DebugSignature = info.build_id();
-        module->SetLoadable(true);
         process->AddModule(module);
       }
 

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -91,7 +91,7 @@ std::vector<std::string> CallStackDataView::GetContextMenu(
       enable_select |= !GOrbitApp->IsFunctionSelected(*function);
       enable_unselect |= GOrbitApp->IsFunctionSelected(*function);
       enable_disassembly = true;
-    } else if (module != nullptr && module->IsLoadable() && !module->IsLoaded()) {
+    } else if (module != nullptr && !module->IsLoaded()) {
       enable_load = true;
     }
   }
@@ -111,7 +111,7 @@ void CallStackDataView::OnContextMenu(const std::string& action, int menu_index,
     for (int i : item_indices) {
       CallStackDataViewFrame frame = GetFrameFromRow(i);
       std::shared_ptr<Module> module = frame.module;
-      if (module != nullptr && module->IsLoadable() && !module->IsLoaded()) {
+      if (module != nullptr && !module->IsLoaded()) {
         GOrbitApp->LoadModules(Capture::capture_data_.process(),
                                Capture::capture_data_.process_id(), {module});
       }

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -175,7 +175,7 @@ std::vector<std::string> SamplingReportDataView::GetContextMenu(
 
   bool enable_load = false;
   for (const auto& module : GetModulesFromIndices(selected_indices)) {
-    if (module->IsLoadable() && !module->IsLoaded()) {
+    if (!module->IsLoaded()) {
       enable_load = true;
     }
   }
@@ -202,7 +202,7 @@ void SamplingReportDataView::OnContextMenu(const std::string& action, int menu_i
   } else if (action == kMenuActionLoadSymbols) {
     std::vector<std::shared_ptr<Module>> modules;
     for (const auto& module : GetModulesFromIndices(item_indices)) {
-      if (module->IsLoadable() && !module->IsLoaded()) {
+      if (!module->IsLoaded()) {
         modules.push_back(module);
       }
     }


### PR DESCRIPTION
This is constructor that is not used anymore and the loadable flag,
which is did not do anything in the code base.

This is a of course a step to make completely removing OrbitModule easier