### PR TITLE
Fix `build_and_upload_dependencies.sh`

### DIFF
--- a/third_party/conan/scripts/build_and_upload_dependencies.sh
+++ b/third_party/conan/scripts/build_and_upload_dependencies.sh
@@ -13,6 +13,9 @@ REPO_ROOT_WIN="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../../" >/dev/null 2>&
 SCRIPT="/mnt/third_party/conan/scripts/build_and_upload_dependencies.sh"
 
 if [ "$1" ]; then
+  pip3 install conan==1.27.1
+  export QT_QPA_PLATFORM=offscreen
+
   $REPO_ROOT/third_party/conan/configs/install.sh || exit $?
   conan user -r artifactory $ARTIFACTORY_USERNAME -p $ARTIFACTORY_API_KEY || exit $?
   if [ -n "$BINTRAY_USERNAME" -a -n "$BINTRAY_API_KEY" ]; then


### PR DESCRIPTION
Due to recent changes to the docker containers and due to more tests
some adjustments to the dependency build scripts were neded.

1. Fix the conan version to one exact version since we aren't currently
compatible to the most recent one.
2. Set the `QT_QPA_PLATFORM` variable such that the OrbitQt tests can
run in a headless environment.