### PR TITLE
Disable flaky tests.

### DIFF
--- a/OrbitBase/CMakeLists.txt
+++ b/OrbitBase/CMakeLists.txt
@@ -41,9 +41,16 @@ add_executable(OrbitBaseTests)
 target_compile_options(OrbitBaseTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(OrbitBaseTests PRIVATE
-    ThreadPoolTest.cpp
     UniqueResourceTest.cpp
 )
+
+# Threadpool test contains some sleeps we couldn't work around - disable them on the CI
+# since they are flaky there (but they work fine on local workstations).
+if (NOT (WIN32 AND "$ENV{QT_QPA_PLATFORM}" STREQUAL "offscreen"))
+target_sources(OrbitBaseTests PRIVATE
+    ThreadPoolTest.cpp
+)
+endif()
 
 target_link_libraries(OrbitBaseTests PRIVATE
         OrbitBase


### PR DESCRIPTION
Threadpool test contains some sleeps we couldn't work around - disable them on
the CI since they are flaky there (but they work fine on local workstations).

Bug: b/165598808
Test: Check that the disabled test doesn't run on CI.