### PR TITLE
Remove Samplingprofiler default constructor

### DIFF
--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -64,7 +64,6 @@ struct SortedCallstackReport {
 class SamplingProfiler {
  public:
   explicit SamplingProfiler(std::shared_ptr<Process> a_Process) : process_{std::move(a_Process)} {}
-  SamplingProfiler() : SamplingProfiler{std::make_shared<Process>()} {}
 
   const CallStack& GetResolvedCallstack(CallstackID raw_callstack_id) const;
 


### PR DESCRIPTION
This is not needed anymore and removes one other usage of the OrbitProcess constructor. Unless I missed something.