### PR TITLE
Fix bug in libprotobuf-mutator package

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -70,7 +70,7 @@ class OrbitConan(ConanFile):
         self.requires("openssl/1.1.1d@{}#0".format(self._orbit_channel))
         self.requires("Outcome/3dae433e@orbitdeps/stable#0")
         self.requires(
-            "libprotobuf-mutator/20200506@{}#4ed8fc67624c9a35b7b0227e93c9d3c4".format(self._orbit_channel))
+            "libprotobuf-mutator/20200506@{}#90ce749ca62b40e9c061d20fae4410e0".format(self._orbit_channel))
         if self.settings.os != "Windows":
             self.requires(
                 "libunwindstack/80a734f14@{}#0".format(self._orbit_channel))

--- a/third_party/conan/lockfiles/linux/clang7_debug/conan.lock
+++ b/third_party/conan/lockfiles/linux/clang7_debug/conan.lock
@@ -347,7 +347,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:2474ccfb55b6f28c84d8c0918e11c6c8968814ab",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:2474ccfb55b6f28c84d8c0918e11c6c8968814ab",
     "options": "fPIC=True\nlzma_sdk:fPIC=True\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/linux/clang7_release/conan.lock
+++ b/third_party/conan/lockfiles/linux/clang7_release/conan.lock
@@ -347,7 +347,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:caee127e224c759fcd21ce8c6e0afebadfc3a15f",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:caee127e224c759fcd21ce8c6e0afebadfc3a15f",
     "options": "fPIC=True\nlzma_sdk:fPIC=True\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/linux/clang7_relwithdebinfo/conan.lock
+++ b/third_party/conan/lockfiles/linux/clang7_relwithdebinfo/conan.lock
@@ -347,7 +347,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:eff4582ee47443910c2c274e51b0c762940ee027",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:eff4582ee47443910c2c274e51b0c762940ee027",
     "options": "fPIC=True\nlzma_sdk:fPIC=True\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/linux/clang8_debug/conan.lock
+++ b/third_party/conan/lockfiles/linux/clang8_debug/conan.lock
@@ -347,7 +347,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:d30023d5766549a3e2a2bc6edfb29f20d5dc6b62",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:d30023d5766549a3e2a2bc6edfb29f20d5dc6b62",
     "options": "fPIC=True\nlzma_sdk:fPIC=True\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/linux/clang8_release/conan.lock
+++ b/third_party/conan/lockfiles/linux/clang8_release/conan.lock
@@ -347,7 +347,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:89694bbb0a38acd884ace45b68250ea8fe4e6588",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:89694bbb0a38acd884ace45b68250ea8fe4e6588",
     "options": "fPIC=True\nlzma_sdk:fPIC=True\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/linux/clang8_relwithdebinfo/conan.lock
+++ b/third_party/conan/lockfiles/linux/clang8_relwithdebinfo/conan.lock
@@ -347,7 +347,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:02f9b4a9c1ea6d79ea003782375ddde5775394d8",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:02f9b4a9c1ea6d79ea003782375ddde5775394d8",
     "options": "fPIC=True\nlzma_sdk:fPIC=True\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/linux/clang9_debug/conan.lock
+++ b/third_party/conan/lockfiles/linux/clang9_debug/conan.lock
@@ -347,7 +347,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:245b341cd1ff7bc7683269926f3d6671a24e0084",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:245b341cd1ff7bc7683269926f3d6671a24e0084",
     "options": "fPIC=True\nlzma_sdk:fPIC=True\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/linux/clang9_release/conan.lock
+++ b/third_party/conan/lockfiles/linux/clang9_release/conan.lock
@@ -347,7 +347,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:529bd45bc40ec7142fc06c10f24a0128285678a0",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:529bd45bc40ec7142fc06c10f24a0128285678a0",
     "options": "fPIC=True\nlzma_sdk:fPIC=True\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/linux/clang9_relwithdebinfo/conan.lock
+++ b/third_party/conan/lockfiles/linux/clang9_relwithdebinfo/conan.lock
@@ -347,7 +347,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:540231ce632b6c70de13017063d1ef01e4f62bfb",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:540231ce632b6c70de13017063d1ef01e4f62bfb",
     "options": "fPIC=True\nlzma_sdk:fPIC=True\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/linux/gcc8_debug/conan.lock
+++ b/third_party/conan/lockfiles/linux/gcc8_debug/conan.lock
@@ -347,7 +347,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:bafd17b0dfeacafddea75bcdd8693c9e810b6e50",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:bafd17b0dfeacafddea75bcdd8693c9e810b6e50",
     "options": "fPIC=True\nlzma_sdk:fPIC=True\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/linux/gcc8_release/conan.lock
+++ b/third_party/conan/lockfiles/linux/gcc8_release/conan.lock
@@ -347,7 +347,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:6d3aea0500012a68f86e1df47cd5b9df6f987f5b",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:6d3aea0500012a68f86e1df47cd5b9df6f987f5b",
     "options": "fPIC=True\nlzma_sdk:fPIC=True\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/linux/gcc8_relwithdebinfo/conan.lock
+++ b/third_party/conan/lockfiles/linux/gcc8_relwithdebinfo/conan.lock
@@ -347,7 +347,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:9f442fd92fc9ee5c2f62aa9201b9ad22b01d2e1c",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:9f442fd92fc9ee5c2f62aa9201b9ad22b01d2e1c",
     "options": "fPIC=True\nlzma_sdk:fPIC=True\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/linux/gcc9_debug/conan.lock
+++ b/third_party/conan/lockfiles/linux/gcc9_debug/conan.lock
@@ -347,7 +347,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:818ea98f74f668df3575a2cdae5cb52f1244e3be",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:818ea98f74f668df3575a2cdae5cb52f1244e3be",
     "options": "fPIC=True\nlzma_sdk:fPIC=True\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/linux/gcc9_release/conan.lock
+++ b/third_party/conan/lockfiles/linux/gcc9_release/conan.lock
@@ -347,7 +347,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:36201f30d08307938d25355ed53003ed11d1a0ee",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:36201f30d08307938d25355ed53003ed11d1a0ee",
     "options": "fPIC=True\nlzma_sdk:fPIC=True\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/linux/gcc9_relwithdebinfo/conan.lock
+++ b/third_party/conan/lockfiles/linux/gcc9_relwithdebinfo/conan.lock
@@ -347,7 +347,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:16655cbc4c3d8d5c9975b4ee4e60e8c65a1f4447",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:16655cbc4c3d8d5c9975b4ee4e60e8c65a1f4447",
     "options": "fPIC=True\nlzma_sdk:fPIC=True\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/linux/ggp_debug/conan.lock
+++ b/third_party/conan/lockfiles/linux/ggp_debug/conan.lock
@@ -366,7 +366,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:f75c9a9ba04d575be69fc0671e91e053b7dd4d1b",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:f75c9a9ba04d575be69fc0671e91e053b7dd4d1b",
     "options": "fPIC=True\nlzma_sdk:fPIC=True\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/linux/ggp_release/conan.lock
+++ b/third_party/conan/lockfiles/linux/ggp_release/conan.lock
@@ -366,7 +366,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:c1a09e388ecf61926dc7b5eb8484c25a1fc3f367",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:c1a09e388ecf61926dc7b5eb8484c25a1fc3f367",
     "options": "fPIC=True\nlzma_sdk:fPIC=True\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/linux/ggp_relwithdebinfo/conan.lock
+++ b/third_party/conan/lockfiles/linux/ggp_relwithdebinfo/conan.lock
@@ -366,7 +366,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:8c8f5d4cdfbfe9467e8d1a6aa7269e5c6b2d1c0b",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:8c8f5d4cdfbfe9467e8d1a6aa7269e5c6b2d1c0b",
     "options": "fPIC=True\nlzma_sdk:fPIC=True\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/windows/ggp_debug/conan.lock
+++ b/third_party/conan/lockfiles/windows/ggp_debug/conan.lock
@@ -393,7 +393,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:f75c9a9ba04d575be69fc0671e91e053b7dd4d1b",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:f75c9a9ba04d575be69fc0671e91e053b7dd4d1b",
     "options": "fPIC=True\nlzma_sdk:fPIC=True\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/windows/ggp_release/conan.lock
+++ b/third_party/conan/lockfiles/windows/ggp_release/conan.lock
@@ -393,7 +393,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:c1a09e388ecf61926dc7b5eb8484c25a1fc3f367",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:c1a09e388ecf61926dc7b5eb8484c25a1fc3f367",
     "options": "fPIC=True\nlzma_sdk:fPIC=True\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/windows/ggp_relwithdebinfo/conan.lock
+++ b/third_party/conan/lockfiles/windows/ggp_relwithdebinfo/conan.lock
@@ -393,7 +393,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:8c8f5d4cdfbfe9467e8d1a6aa7269e5c6b2d1c0b",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:8c8f5d4cdfbfe9467e8d1a6aa7269e5c6b2d1c0b",
     "options": "fPIC=True\nlzma_sdk:fPIC=True\nprotobuf:fPIC=True\nprotobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:fPIC=True\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/windows/msvc2017_debug/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2017_debug/conan.lock
@@ -349,7 +349,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:709e345ce7ac46e4287c2d91296f30286149f06a",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:709e345ce7ac46e4287c2d91296f30286149f06a",
     "options": "protobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/windows/msvc2017_debug_x86/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2017_debug_x86/conan.lock
@@ -341,7 +341,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:a979577ceb18f47b447eae113edd0de7f6016764",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:a979577ceb18f47b447eae113edd0de7f6016764",
     "options": "protobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/windows/msvc2017_release/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2017_release/conan.lock
@@ -349,7 +349,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:80eeade8abb1c9bebc20328e8e1b630ce60e8ef8",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:80eeade8abb1c9bebc20328e8e1b630ce60e8ef8",
     "options": "protobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/windows/msvc2017_release_x86/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2017_release_x86/conan.lock
@@ -341,7 +341,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:bb69217111da7b869244f23ada982ad73a343015",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:bb69217111da7b869244f23ada982ad73a343015",
     "options": "protobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/windows/msvc2017_relwithdebinfo/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2017_relwithdebinfo/conan.lock
@@ -349,7 +349,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:33d6e5a3663f8312f17e637ef04b00ea55fb56d2",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:33d6e5a3663f8312f17e637ef04b00ea55fb56d2",
     "options": "protobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/windows/msvc2017_relwithdebinfo_x86/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2017_relwithdebinfo_x86/conan.lock
@@ -341,7 +341,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:7a4b147ed48700cd2a848a06c529684b726a1dfc",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:7a4b147ed48700cd2a848a06c529684b726a1dfc",
     "options": "protobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/windows/msvc2019_debug/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2019_debug/conan.lock
@@ -349,7 +349,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:28d01a1a413bede88de55c436c1cd84b5b456483",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:28d01a1a413bede88de55c436c1cd84b5b456483",
     "options": "protobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/windows/msvc2019_debug_x86/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2019_debug_x86/conan.lock
@@ -341,7 +341,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:f76e83ca2466ef125ce359133d0ce5cad77b6e68",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:f76e83ca2466ef125ce359133d0ce5cad77b6e68",
     "options": "protobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/windows/msvc2019_release/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2019_release/conan.lock
@@ -349,7 +349,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:59a54a6ecf768c660e842b5dbefdd33bbdfbef20",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:59a54a6ecf768c660e842b5dbefdd33bbdfbef20",
     "options": "protobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/windows/msvc2019_release_x86/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2019_release_x86/conan.lock
@@ -341,7 +341,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:0b86ea94f669c0a013b7071272f3b88b6e4fbcf0",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:0b86ea94f669c0a013b7071272f3b88b6e4fbcf0",
     "options": "protobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/windows/msvc2019_relwithdebinfo/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2019_relwithdebinfo/conan.lock
@@ -349,7 +349,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:92c665e5019a2f4456cd9b8274affc75dd3deecf",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:92c665e5019a2f4456cd9b8274affc75dd3deecf",
     "options": "protobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/lockfiles/windows/msvc2019_relwithdebinfo_x86/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2019_relwithdebinfo_x86/conan.lock
@@ -341,7 +341,7 @@
     ]
    },
    "26": {
-    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#4ed8fc67624c9a35b7b0227e93c9d3c4:6f0e6f7d67cb225ba5eed1400e8772ea4a2eea93",
+    "pref": "libprotobuf-mutator/20200506@orbitdeps/stable#90ce749ca62b40e9c061d20fae4410e0:6f0e6f7d67cb225ba5eed1400e8772ea4a2eea93",
     "options": "protobuf:lite=False\nprotobuf:shared=False\nprotobuf:with_zlib=False\nzlib:minizip=False\nzlib:shared=False",
     "requires": [
      "24",

--- a/third_party/conan/recipes/libprotobuf-mutator/patches/001-conanbuildinfo.diff
+++ b/third_party/conan/recipes/libprotobuf-mutator/patches/001-conanbuildinfo.diff
@@ -2,11 +2,12 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index d9be154..46c7f52 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -14,6 +14,7 @@
+@@ -14,6 +14,8 @@
  
  cmake_minimum_required(VERSION 3.5)
  project(LibProtobufMutator CXX)
 +include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
++conan_basic_setup()
  
  enable_language(C)
  enable_language(CXX)


### PR DESCRIPTION
Without calling `conan_basic_setup()` in libprotobuf-mutator's
`CMakeLists.txt`-file, the package won't pick up compiler flags set via
environment variables like `CFLAGS` or `CXXFLAGS`. This fixes that.