### PR TITLE
Made SamplingProfiler a value member of CaptureData

### DIFF
--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -25,7 +25,7 @@ class CaptureData {
         selected_functions_{std::move(selected_functions)},
         callstack_data_(std::make_unique<CallstackData>()),
         selection_callstack_data_(std::make_unique<CallstackData>()),
-        sampling_profiler_{std::make_shared<SamplingProfiler>(process_)} {
+        sampling_profiler_{process_} {
     CHECK(process_ != nullptr);
   }
   explicit CaptureData(
@@ -38,7 +38,7 @@ class CaptureData {
         selected_functions_{std::move(selected_functions)},
         callstack_data_(std::make_unique<CallstackData>()),
         selection_callstack_data_(std::make_unique<CallstackData>()),
-        sampling_profiler_{std::make_shared<SamplingProfiler>(process_)},
+        sampling_profiler_{process_},
         functions_stats_{std::move(functions_stats)} {
     CHECK(process_ != nullptr);
   }
@@ -47,7 +47,7 @@ class CaptureData {
       : process_{std::make_shared<Process>()},
         callstack_data_(std::make_unique<CallstackData>()),
         selection_callstack_data_(std::make_unique<CallstackData>()),
-        sampling_profiler_{std::make_shared<SamplingProfiler>(process_)} {};
+        sampling_profiler_{process_} {};
   CaptureData(const CaptureData& other) = delete;
   // We can not copy the unique_ptr, so we can not copy this object.
   CaptureData& operator=(const CaptureData& other) = delete;
@@ -129,11 +129,9 @@ class CaptureData {
 
   [[nodiscard]] const std::shared_ptr<Process>& process() const { return process_; }
 
-  [[nodiscard]] std::shared_ptr<SamplingProfiler> sampling_profiler() { return sampling_profiler_; }
+  [[nodiscard]] const SamplingProfiler& GetSamplingProfiler() const { return sampling_profiler_; }
 
-  [[nodiscard]] const SamplingProfiler& GetSamplingProfiler() const { return *sampling_profiler_; }
-
-  void UpdateSamplingProfiler() { sampling_profiler_->ProcessSamples(*callstack_data_); }
+  void UpdateSamplingProfiler() { sampling_profiler_.ProcessSamples(*callstack_data_); }
 
  private:
   int32_t process_id_ = -1;
@@ -146,9 +144,7 @@ class CaptureData {
   // selection_callstack_data_ is subset of callstack_data_
   std::unique_ptr<CallstackData> selection_callstack_data_;
 
-  // TODO(kuebler): Make this value type as soon as UI/SamplingReport does not need to modify it
-  //  anymore.
-  std::shared_ptr<SamplingProfiler> sampling_profiler_;
+  SamplingProfiler sampling_profiler_;
 
   absl::flat_hash_map<uint64_t, orbit_client_protos::LinuxAddressInfo> address_infos_;
 

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -133,6 +133,8 @@ class CaptureData {
 
   [[nodiscard]] const SamplingProfiler& GetSamplingProfiler() const { return *sampling_profiler_; }
 
+  void UpdateSamplingProfiler() { sampling_profiler_->ProcessSamples(*callstack_data_); }
+
  private:
   int32_t process_id_ = -1;
   std::string process_name_;

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -68,9 +68,9 @@ class SamplingProfiler {
   const CallStack& GetResolvedCallstack(CallstackID raw_callstack_id) const;
 
   std::multimap<int, CallstackID> GetCallstacksFromAddress(uint64_t address, ThreadID thread_id,
-                                                           int* callstacks_count);
+                                                           int* callstacks_count) const;
   std::shared_ptr<SortedCallstackReport> GetSortedCallstacksFromAddress(uint64_t address,
-                                                                        ThreadID thread_id);
+                                                                        ThreadID thread_id) const;
 
   const std::vector<ThreadSampleData*>& GetThreadSampleData() const {
     return sorted_thread_sample_data_;

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -980,7 +980,7 @@ void OrbitApp::UpdateSamplingReport() {
   }
 
   if (selection_report_ != nullptr) {
-    SamplingProfiler selection_profiler = selection_report_->profiler();
+    SamplingProfiler selection_profiler(Capture::capture_data_.process());
     selection_profiler.ProcessSamples(*Capture::capture_data_.GetSelectionCallstackData());
     selection_report_->UpdateReport(std::move(selection_profiler),
                                     Capture::capture_data_.GetSelectionCallstackData());

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -109,12 +109,11 @@ void OrbitApp::OnCaptureStarted(
 void OrbitApp::OnCaptureComplete() {
   main_thread_executor_->Schedule([this] {
     Capture::capture_data_.set_address_infos(std::move(captured_address_infos_));
-    Capture::capture_data_.sampling_profiler()->ProcessSamples(
-        *Capture::capture_data_.GetCallstackData());
+    Capture::capture_data_.UpdateSamplingProfiler();
 
     RefreshCaptureView();
 
-    AddSamplingReport(Capture::capture_data_.sampling_profiler(),
+    AddSamplingReport(Capture::capture_data_.GetSamplingProfiler(),
                       Capture::capture_data_.GetCallstackData());
     AddTopDownView(Capture::capture_data_.GetSamplingProfiler());
 
@@ -330,12 +329,12 @@ void OrbitApp::Disassemble(int32_t pid, const FunctionInfo& function) {
     disasm.AddLine(absl::StrFormat("asm: /* %s */", FunctionUtils::GetDisplayName(function)));
     disasm.Disassemble(memory.data(), memory.size(), FunctionUtils::GetAbsoluteAddress(function),
                        is_64_bit);
-    if (!sampling_report_ || !sampling_report_->GetProfiler()) {
+    if (!sampling_report_) {
       DisassemblyReport empty_report(disasm);
       SendDisassemblyToUi(disasm.GetResult(), std::move(empty_report));
       return;
     }
-    std::shared_ptr<SamplingProfiler> profiler = sampling_report_->GetProfiler();
+    const SamplingProfiler& profiler = Capture::capture_data_.GetSamplingProfiler();
 
     DisassemblyReport report(disasm, FunctionUtils::GetAbsoluteAddress(function), profiler,
                              Capture::capture_data_.GetCallstackData()->GetCallstackEventsSize());
@@ -380,7 +379,7 @@ void OrbitApp::NeedsRedraw() {
   }
 }
 
-void OrbitApp::AddSamplingReport(std::shared_ptr<SamplingProfiler> sampling_profiler,
+void OrbitApp::AddSamplingReport(SamplingProfiler sampling_profiler,
                                  const CallstackData* callstack_data) {
   auto report = std::make_shared<SamplingReport>(std::move(sampling_profiler), callstack_data);
   if (sampling_reports_callback_) {
@@ -395,7 +394,7 @@ void OrbitApp::AddSamplingReport(std::shared_ptr<SamplingProfiler> sampling_prof
   sampling_report_ = report;
 }
 
-void OrbitApp::AddSelectionReport(std::shared_ptr<SamplingProfiler> sampling_profiler,
+void OrbitApp::AddSelectionReport(SamplingProfiler sampling_profiler,
                                   const CallstackData* callstack_data) {
   auto report = std::make_shared<SamplingReport>(std::move(sampling_profiler), callstack_data);
 
@@ -616,13 +615,13 @@ void OrbitApp::ClearCapture() {
   set_selected_thread_id(-1);
   SelectTextBox(nullptr);
 
-  AddSamplingReport(Capture::capture_data_.sampling_profiler(), nullptr);
+  AddSamplingReport(Capture::capture_data_.GetSamplingProfiler(), nullptr);
   // TODO(kuebler): This seems fishy. Probably, TopDownView does not update on new symbols.
   AddTopDownView(Capture::capture_data_.GetSamplingProfiler());
 
   if (selection_report_) {
-    auto empty_selection_profiler = std::make_shared<SamplingProfiler>(GetSelectedProcess());
-    AddSelectionReport(empty_selection_profiler, nullptr);
+    SamplingProfiler empty_selection_profiler(GetSelectedProcess());
+    AddSelectionReport(std::move(empty_selection_profiler), nullptr);
   }
 
   if (GCurrentTimeGraph != nullptr) {
@@ -975,11 +974,16 @@ void OrbitApp::SelectTextBox(const TextBox* text_box) {
 
 void OrbitApp::UpdateSamplingReport() {
   if (sampling_report_ != nullptr) {
-    sampling_report_->UpdateReport();
+    Capture::capture_data_.UpdateSamplingProfiler();
+    sampling_report_->UpdateReport(Capture::capture_data_.GetSamplingProfiler(),
+                                   Capture::capture_data_.GetCallstackData());
   }
 
   if (selection_report_ != nullptr) {
-    selection_report_->UpdateReport();
+    SamplingProfiler selection_profiler = selection_report_->profiler();
+    selection_profiler.ProcessSamples(*Capture::capture_data_.GetCallstackData());
+    selection_report_->UpdateReport(std::move(selection_profiler),
+                                    Capture::capture_data_.GetCallstackData());
   }
 }
 

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -981,9 +981,9 @@ void OrbitApp::UpdateSamplingReport() {
 
   if (selection_report_ != nullptr) {
     SamplingProfiler selection_profiler = selection_report_->profiler();
-    selection_profiler.ProcessSamples(*Capture::capture_data_.GetCallstackData());
+    selection_profiler.ProcessSamples(*Capture::capture_data_.GetSelectionCallstackData());
     selection_report_->UpdateReport(std::move(selection_profiler),
-                                    Capture::capture_data_.GetCallstackData());
+                                    Capture::capture_data_.GetSelectionCallstackData());
   }
 }
 

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -99,10 +99,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
 
   void RegisterCaptureWindow(CaptureWindow* capture);
 
-  void AddSamplingReport(std::shared_ptr<SamplingProfiler> sampling_profiler,
-                         const CallstackData* callstack_data);
-  void AddSelectionReport(std::shared_ptr<SamplingProfiler> sampling_profiler,
-                          const CallstackData* callstack_data);
+  void AddSamplingReport(SamplingProfiler sampling_profiler, const CallstackData* callstack_data);
+  void AddSelectionReport(SamplingProfiler sampling_profiler, const CallstackData* callstack_data);
   void AddTopDownView(const SamplingProfiler& sampling_profiler);
 
   bool SelectProcess(const std::string& process,

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -35,9 +35,9 @@ using orbit_client_protos::TimerInfo;
 
 ErrorMessageOr<void> CaptureSerializer::Save(const std::string& filename) {
   // Add selected functions' exact address to sampling profiler
-  const std::shared_ptr<SamplingProfiler>& profiler = Capture::capture_data_.sampling_profiler();
+  SamplingProfiler profiler = Capture::capture_data_.GetSamplingProfiler();
   for (auto& pair : Capture::capture_data_.selected_functions()) {
-    profiler->UpdateAddressInfo(pair.first);
+    profiler.UpdateAddressInfo(pair.first);
   }
 
   header.set_version(kRequiredCaptureVersion);
@@ -207,8 +207,7 @@ void CaptureSerializer::ProcessCaptureData(const CaptureInfo& capture_info) {
   for (CallstackEvent callstack_event : capture_info.callstack_events()) {
     Capture::capture_data_.AddCallstackEvent(std::move(callstack_event));
   }
-  Capture::capture_data_.sampling_profiler()->ProcessSamples(
-      *Capture::capture_data_.GetCallstackData());
+  Capture::capture_data_.UpdateSamplingProfiler();
 
   time_graph_->Clear();
   StringManager* string_manager = time_graph_->GetStringManager();
@@ -255,7 +254,7 @@ ErrorMessageOr<void> CaptureSerializer::Load(std::istream& stream) {
     time_graph_->ProcessTimer(timer_info);
   }
 
-  GOrbitApp->AddSamplingReport(Capture::capture_data_.sampling_profiler(),
+  GOrbitApp->AddSamplingReport(Capture::capture_data_.GetSamplingProfiler(),
                                Capture::capture_data_.GetCallstackData());
   GOrbitApp->AddTopDownView(Capture::capture_data_.GetSamplingProfiler());
   GOrbitApp->FireRefreshCallbacks();

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -34,12 +34,6 @@ using orbit_client_protos::FunctionStats;
 using orbit_client_protos::TimerInfo;
 
 ErrorMessageOr<void> CaptureSerializer::Save(const std::string& filename) {
-  // Add selected functions' exact address to sampling profiler
-  SamplingProfiler profiler = Capture::capture_data_.GetSamplingProfiler();
-  for (auto& pair : Capture::capture_data_.selected_functions()) {
-    profiler.UpdateAddressInfo(pair.first);
-  }
-
   header.set_version(kRequiredCaptureVersion);
 
   std::ofstream file(filename, std::ios::binary);

--- a/OrbitGl/DisassemblyReport.cc
+++ b/OrbitGl/DisassemblyReport.cc
@@ -1,7 +1,7 @@
 #include "DisassemblyReport.h"
 
 uint32_t DisassemblyReport::GetNumSamplesAtLine(size_t line) const {
-  if (function_count_ == 0 || profiler_ == nullptr) {
+  if (function_count_ == 0) {
     return 0;
   }
   uint64_t address = disasm_.GetAddressAtLine(line);
@@ -19,7 +19,7 @@ uint32_t DisassemblyReport::GetNumSamplesAtLine(size_t line) const {
   if (next_address == 0) {
     next_address = address + 1;
   }
-  const ThreadSampleData* data = profiler_->GetSummary();
+  const ThreadSampleData* data = profiler_.GetSummary();
   if (data == nullptr) {
     return 0.0;
   }

--- a/OrbitGl/DisassemblyReport.h
+++ b/OrbitGl/DisassemblyReport.h
@@ -13,16 +13,18 @@
 
 class DisassemblyReport : public CodeReport {
  public:
-  DisassemblyReport(Disassembler disasm, uint64_t function_address,
-                    std::shared_ptr<SamplingProfiler> profiler, uint32_t samples_count)
+  DisassemblyReport(Disassembler disasm, uint64_t function_address, SamplingProfiler profiler,
+                    uint32_t samples_count)
       : disasm_{std::move(disasm)},
         profiler_{std::move(profiler)},
-        function_count_{(profiler_ == nullptr) ? 0
-                                               : profiler_->GetCountOfFunction(function_address)},
+        function_count_{profiler_.GetCountOfFunction(function_address)},
         samples_count_(samples_count) {}
 
   explicit DisassemblyReport(Disassembler disasm)
-      : disasm_{std::move(disasm)}, profiler_{nullptr}, function_count_{0}, samples_count_{0} {};
+      : disasm_{std::move(disasm)},
+        profiler_{std::make_shared<Process>()},
+        function_count_{0},
+        samples_count_{0} {};
 
   [[nodiscard]] uint32_t GetNumSamplesInFunction() const override { return function_count_; }
   [[nodiscard]] uint32_t GetNumSamples() const override { return samples_count_; }
@@ -30,7 +32,7 @@ class DisassemblyReport : public CodeReport {
 
  private:
   const Disassembler disasm_;
-  const std::shared_ptr<SamplingProfiler> profiler_;
+  const SamplingProfiler profiler_;
   const uint32_t function_count_;
   const uint32_t samples_count_;
 };

--- a/OrbitGl/SamplingReport.cpp
+++ b/OrbitGl/SamplingReport.cpp
@@ -41,12 +41,6 @@ void SamplingReport::FillReport() {
     thread_report.SetSamplingReport(this);
     thread_reports_.push_back(std::move(thread_report));
   }
-
-  // Refresh the displayed callstacks as they might not be up to date anymore,
-  // for example the number of occurrences or of total callstacks might have
-  // changed (OrbitSamplingReport::RefreshCallstackView will do the actual
-  // update once OrbitApp::FireRefreshCallbacks is called).
-  UpdateDisplayedCallstack();
 }
 
 void SamplingReport::UpdateDisplayedCallstack() {

--- a/OrbitGl/SamplingReport.h
+++ b/OrbitGl/SamplingReport.h
@@ -18,11 +18,9 @@
 
 class SamplingReport {
  public:
-  explicit SamplingReport(std::shared_ptr<SamplingProfiler> sampling_profiler,
-                          const CallstackData* callstack_data);
-
-  void UpdateReport();
-  [[nodiscard]] std::shared_ptr<SamplingProfiler> GetProfiler() const { return profiler_; };
+  explicit SamplingReport(SamplingProfiler sampling_profiler, const CallstackData* callstack_data);
+  void UpdateReport(SamplingProfiler profiler, const CallstackData* callstack_data);
+  [[nodiscard]] const SamplingProfiler& profiler() const { return profiler_; };
   [[nodiscard]] std::vector<SamplingReportDataView>& GetThreadReports() { return thread_reports_; };
   void SetCallstackDataView(CallStackDataView* data_view) { callstack_data_view_ = data_view; };
   void OnSelectAddress(uint64_t address, ThreadID thread_id);
@@ -42,7 +40,7 @@ class SamplingReport {
   void UpdateDisplayedCallstack();
 
  protected:
-  std::shared_ptr<SamplingProfiler> profiler_;
+  SamplingProfiler profiler_;
   const CallstackData* callstack_data_;
   std::vector<SamplingReportDataView> thread_reports_;
   CallStackDataView* callstack_data_view_;

--- a/OrbitGl/SamplingReport.h
+++ b/OrbitGl/SamplingReport.h
@@ -20,7 +20,6 @@ class SamplingReport {
  public:
   explicit SamplingReport(SamplingProfiler sampling_profiler, const CallstackData* callstack_data);
   void UpdateReport(SamplingProfiler profiler, const CallstackData* callstack_data);
-  [[nodiscard]] const SamplingProfiler& profiler() const { return profiler_; };
   [[nodiscard]] std::vector<SamplingReportDataView>& GetThreadReports() { return thread_reports_; };
   void SetCallstackDataView(CallStackDataView* data_view) { callstack_data_view_ = data_view; };
   void OnSelectAddress(uint64_t address, ThreadID thread_id);

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -608,10 +608,9 @@ std::vector<CallstackEvent> TimeGraph::SelectEvents(float a_WorldStart, float a_
   }
 
   // Generate selection report.
-  std::shared_ptr<SamplingProfiler> sampling_profiler =
-      std::make_shared<SamplingProfiler>(Capture::capture_data_.process());
+  SamplingProfiler sampling_profiler(Capture::capture_data_.process());
 
-  sampling_profiler->SetGenerateSummary(a_TID == 0);
+  sampling_profiler.SetGenerateSummary(a_TID == 0);
 
   const CallstackData* callstack_data = Capture::capture_data_.GetCallstackData();
   std::unique_ptr<CallstackData> selection_callstack_data = std::make_unique<CallstackData>();
@@ -619,9 +618,9 @@ std::vector<CallstackEvent> TimeGraph::SelectEvents(float a_WorldStart, float a_
     selection_callstack_data->AddCallStackFromKnownCallstackData(event, *callstack_data);
   }
 
-  sampling_profiler->ProcessSamples(*selection_callstack_data);
+  sampling_profiler.ProcessSamples(*selection_callstack_data);
 
-  GOrbitApp->AddSelectionReport(sampling_profiler, selection_callstack_data.get());
+  GOrbitApp->AddSelectionReport(std::move(sampling_profiler), selection_callstack_data.get());
   Capture::capture_data_.SetSelectionCallstackData(std::move(selection_callstack_data));
 
   NeedsUpdate();


### PR DESCRIPTION
Prior to this change, SamplingProfiler was a shared_ptr that was
hold by CaptureData, but also passed and stored by the
SamplingReport view.
With this change, ownership is send to CaptureData and passed as
a copy to SamplingReport.

Test: Compile, Capture, Load Symbols,  Select Samples