### PR TITLE
Make sliders smaller to avoid intersections

### DIFF
--- a/OrbitGl/GlSlider.cpp
+++ b/OrbitGl/GlSlider.cpp
@@ -117,7 +117,7 @@ void GlSlider::DrawHorizontal(GlCanvas* canvas, PickingMode picking_mode) {
   }
 
   float start = m_Ratio * nonSliderWidth;
-  float stop = start + sliderWidth;
+  float stop = start + sliderWidth - GetPixelHeight();
 
   Color color =
       canvas->GetPickingManager().IsThisElementPicked(this) ? m_SelectedColor : m_SliderColor;
@@ -144,7 +144,7 @@ void GlSlider::DrawVertical(GlCanvas* canvas, PickingMode picking_mode) {
   }
 
   float start = canvasHeight - m_Ratio * nonSliderHeight;
-  float stop = start - sliderHeight;
+  float stop = start - sliderHeight + GetPixelHeight();
 
   Color color =
       canvas->GetPickingManager().IsThisElementPicked(this) ? m_SelectedColor : m_SliderColor;


### PR DESCRIPTION
Sliders could intercept each other, so we limit the range where they can move.

Past:
![Screen Shot 2020-08-21 at 14 17 05](https://user-images.githubusercontent.com/8610429/90891142-8c45de00-e3bb-11ea-88e5-ab907a3e00eb.png)

Now:
![Screen Shot 2020-08-21 at 14 41 49](https://user-images.githubusercontent.com/8610429/90891740-7ab10600-e3bc-11ea-84dc-f2994d14f8c9.png)
