### PR TITLE
Add recipes for llvm_symbolizer and dependencies

### DIFF
--- a/third_party/conan/recipes/llvm_debuginfo_dwarf/LICENSE
+++ b/third_party/conan/recipes/llvm_debuginfo_dwarf/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 ポリ平方 POLYSQUARE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third_party/conan/recipes/llvm_debuginfo_dwarf/conanfile.py
+++ b/third_party/conan/recipes/llvm_debuginfo_dwarf/conanfile.py
@@ -1,0 +1,12 @@
+from conans import python_requires
+import os
+
+common = python_requires('llvm-common/0.0.2@orbitdeps/stable')
+
+class LLVMDebugInfoDWARF(common.LLVMModulePackage):
+    version = common.LLVMModulePackage.version
+    name = 'llvm_debuginfo_dwarf'
+    llvm_component = 'llvm'
+    llvm_module = 'DebugInfoDWARF'
+    llvm_requires = ['llvm_headers', 'llvm_object', 'llvm_support',
+                     'llvm_binary_format', 'llvm_mc']

--- a/third_party/conan/recipes/llvm_debuginfo_pdb/LICENSE
+++ b/third_party/conan/recipes/llvm_debuginfo_pdb/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 ポリ平方 POLYSQUARE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third_party/conan/recipes/llvm_debuginfo_pdb/conanfile.py
+++ b/third_party/conan/recipes/llvm_debuginfo_pdb/conanfile.py
@@ -1,0 +1,12 @@
+from conans import python_requires
+import os
+
+common = python_requires('llvm-common/0.0.2@orbitdeps/stable')
+
+class LLVMDebugInfoPDB(common.LLVMModulePackage):
+    version = common.LLVMModulePackage.version
+    name = 'llvm_debuginfo_pdb'
+    llvm_component = 'llvm'
+    llvm_module = 'DebugInfoPDB'
+    llvm_requires = ['llvm_headers', 'llvm_support', 'llvm_debuginfo_msf',
+                     'llvm_debuginfo_codeview']

--- a/third_party/conan/recipes/llvm_symbolize/LICENSE
+++ b/third_party/conan/recipes/llvm_symbolize/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 ポリ平方 POLYSQUARE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third_party/conan/recipes/llvm_symbolize/conanfile.py
+++ b/third_party/conan/recipes/llvm_symbolize/conanfile.py
@@ -1,0 +1,14 @@
+from conans import python_requires
+import os
+
+common = python_requires('llvm-common/0.0.2@orbitdeps/stable')
+
+class LLVMSymbolize(common.LLVMModulePackage):
+    version = common.LLVMModulePackage.version
+    name = 'llvm_symbolize'
+    llvm_component = 'llvm'
+    llvm_module = 'Symbolize'
+    llvm_requires = ['llvm_headers', 'llvm_binary_format', 'llvm_bit_reader',
+                     'llvm_core', 'llvm_mc', 'llvm_mc_parser', 'llvm_support',
+                     'llvm_textapi', 'llvm_object', 'llvm_debuginfo_pdb',
+                     'llvm_debuginfo_dwarf']


### PR DESCRIPTION
These components are going to be used for line and debug info
extraction functionality.