### PR TITLE
Split ProcessManager into ProcessManager and ProcessClient

### DIFF
--- a/OrbitClientServices/CMakeLists.txt
+++ b/OrbitClientServices/CMakeLists.txt
@@ -15,11 +15,13 @@ target_include_directories(OrbitClientServices PRIVATE
 
 target_sources(OrbitClientServices PUBLIC 
         include/OrbitClientServices/CrashManager.h
-        include/OrbitClientServices/ProcessManager.h)
+        include/OrbitClientServices/ProcessManager.h
+        include/OrbitClientServices/ProcessClient.h)
 
 target_sources(OrbitClientServices PRIVATE
         CrashManager.cpp
-        ProcessManager.cpp)
+        ProcessManager.cpp
+        ProcessClient.cpp)
 
 target_link_libraries(OrbitClientServices PUBLIC
         OrbitBase

--- a/OrbitClientServices/ProcessClient.cpp
+++ b/OrbitClientServices/ProcessClient.cpp
@@ -30,9 +30,9 @@ using orbit_grpc_protos::TracepointInfo;
 
 constexpr uint64_t kGrpcDefaultTimeoutMilliseconds = 1000;
 
-std::unique_ptr<grpc::ClientContext> CreateContext(uint64_t timeout_milliseconds) {
+std::unique_ptr<grpc::ClientContext> CreateContext(
+    uint64_t timeout_milliseconds = kGrpcDefaultTimeoutMilliseconds) {
   auto context = std::make_unique<grpc::ClientContext>();
-
   std::chrono::time_point deadline =
       std::chrono::system_clock::now() + std::chrono::milliseconds(timeout_milliseconds);
   context->set_deadline(deadline);
@@ -45,7 +45,7 @@ std::unique_ptr<grpc::ClientContext> CreateContext(uint64_t timeout_milliseconds
 ErrorMessageOr<std::vector<orbit_grpc_protos::ProcessInfo>> ProcessClient::GetProcessList() {
   GetProcessListRequest request;
   GetProcessListResponse response;
-  std::unique_ptr<grpc::ClientContext> context = CreateContext(kGrpcDefaultTimeoutMilliseconds);
+  std::unique_ptr<grpc::ClientContext> context = CreateContext();
 
   grpc::Status status = process_service_->GetProcessList(context.get(), request, &response);
   if (!status.ok()) {
@@ -64,7 +64,7 @@ ErrorMessageOr<std::vector<ModuleInfo>> ProcessClient::LoadModuleList(int32_t pi
   GetModuleListResponse response;
   request.set_process_id(pid);
 
-  std::unique_ptr<grpc::ClientContext> context = CreateContext(kGrpcDefaultTimeoutMilliseconds);
+  std::unique_ptr<grpc::ClientContext> context = CreateContext();
   grpc::Status status = process_service_->GetModuleList(context.get(), request, &response);
 
   if (!status.ok()) {
@@ -81,7 +81,7 @@ ErrorMessageOr<std::vector<TracepointInfo>> ProcessClient::LoadTracepointList() 
   GetTracepointListRequest request;
   GetTracepointListResponse response;
 
-  std::unique_ptr<grpc::ClientContext> context = CreateContext(kGrpcDefaultTimeoutMilliseconds);
+  std::unique_ptr<grpc::ClientContext> context = CreateContext();
   grpc::Status status = process_service_->GetTracepointList(context.get(), request, &response);
 
   if (!status.ok()) {
@@ -100,7 +100,7 @@ ErrorMessageOr<std::string> ProcessClient::FindDebugInfoFile(const std::string& 
 
   request.set_module_path(module_path);
 
-  std::unique_ptr<grpc::ClientContext> context = CreateContext(kGrpcDefaultTimeoutMilliseconds);
+  std::unique_ptr<grpc::ClientContext> context = CreateContext();
 
   grpc::Status status = process_service_->GetDebugInfoFile(context.get(), request, &response);
   if (!status.ok()) {
@@ -120,7 +120,7 @@ ErrorMessageOr<std::string> ProcessClient::LoadProcessMemory(int32_t pid, uint64
 
   GetProcessMemoryResponse response;
 
-  std::unique_ptr<grpc::ClientContext> context = CreateContext(kGrpcDefaultTimeoutMilliseconds);
+  std::unique_ptr<grpc::ClientContext> context = CreateContext();
 
   grpc::Status status = process_service_->GetProcessMemory(context.get(), request, &response);
   if (!status.ok()) {

--- a/OrbitClientServices/ProcessClient.cpp
+++ b/OrbitClientServices/ProcessClient.cpp
@@ -4,6 +4,9 @@
 
 #include "OrbitClientServices/ProcessClient.h"
 
+#include <memory>
+#include <vector>
+
 #include "OrbitBase/Logging.h"
 #include "grpcpp/grpcpp.h"
 #include "outcome.hpp"

--- a/OrbitClientServices/ProcessClient.cpp
+++ b/OrbitClientServices/ProcessClient.cpp
@@ -1,0 +1,132 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "OrbitClientServices/ProcessClient.h"
+
+#include "OrbitBase/Logging.h"
+#include "grpcpp/grpcpp.h"
+#include "outcome.hpp"
+#include "services.grpc.pb.h"
+#include "symbol.pb.h"
+#include "tracepoint.pb.h"
+
+namespace {
+
+using orbit_grpc_protos::GetDebugInfoFileRequest;
+using orbit_grpc_protos::GetDebugInfoFileResponse;
+using orbit_grpc_protos::GetModuleListRequest;
+using orbit_grpc_protos::GetModuleListResponse;
+using orbit_grpc_protos::GetProcessListRequest;
+using orbit_grpc_protos::GetProcessListResponse;
+using orbit_grpc_protos::GetProcessMemoryRequest;
+using orbit_grpc_protos::GetProcessMemoryResponse;
+using orbit_grpc_protos::GetTracepointListRequest;
+using orbit_grpc_protos::GetTracepointListResponse;
+using orbit_grpc_protos::ModuleInfo;
+using orbit_grpc_protos::ProcessInfo;
+using orbit_grpc_protos::ProcessService;
+using orbit_grpc_protos::TracepointInfo;
+
+constexpr uint64_t kGrpcDefaultTimeoutMilliseconds = 1000;
+
+std::unique_ptr<grpc::ClientContext> CreateContext(uint64_t timeout_milliseconds) {
+  auto context = std::make_unique<grpc::ClientContext>();
+
+  std::chrono::time_point deadline =
+      std::chrono::system_clock::now() + std::chrono::milliseconds(timeout_milliseconds);
+  context->set_deadline(deadline);
+
+  return context;
+}
+
+}  // namespace
+
+ErrorMessageOr<std::vector<orbit_grpc_protos::ProcessInfo>> ProcessClient::GetProcessList() {
+  GetProcessListRequest request;
+  GetProcessListResponse response;
+  std::unique_ptr<grpc::ClientContext> context = CreateContext(kGrpcDefaultTimeoutMilliseconds);
+
+  grpc::Status status = process_service_->GetProcessList(context.get(), request, &response);
+  if (!status.ok()) {
+    ERROR("gRPC call to GetProcessList failed: %s (error_code=%d)", status.error_message(),
+          status.error_code());
+    return ErrorMessage(status.error_message());
+  }
+
+  const auto& processes = response.processes();
+
+  return std::vector<ProcessInfo>(processes.begin(), processes.end());
+}
+
+ErrorMessageOr<std::vector<ModuleInfo>> ProcessClient::LoadModuleList(int32_t pid) {
+  GetModuleListRequest request;
+  GetModuleListResponse response;
+  request.set_process_id(pid);
+
+  std::unique_ptr<grpc::ClientContext> context = CreateContext(kGrpcDefaultTimeoutMilliseconds);
+  grpc::Status status = process_service_->GetModuleList(context.get(), request, &response);
+
+  if (!status.ok()) {
+    ERROR("Grpc call failed: code=%d, message=%s", status.error_code(), status.error_message());
+    return ErrorMessage(status.error_message());
+  }
+
+  const auto& modules = response.modules();
+
+  return std::vector<ModuleInfo>(modules.begin(), modules.end());
+}
+
+ErrorMessageOr<std::vector<TracepointInfo>> ProcessClient::LoadTracepointList() {
+  GetTracepointListRequest request;
+  GetTracepointListResponse response;
+
+  std::unique_ptr<grpc::ClientContext> context = CreateContext(kGrpcDefaultTimeoutMilliseconds);
+  grpc::Status status = process_service_->GetTracepointList(context.get(), request, &response);
+
+  if (!status.ok()) {
+    ERROR("Grpc call failed: code=%d, message=%s", status.error_code(), status.error_message());
+    return ErrorMessage(status.error_message());
+  }
+
+  const auto& tracepoints = response.tracepoints();
+
+  return std::vector<TracepointInfo>(tracepoints.begin(), tracepoints.end());
+}
+
+ErrorMessageOr<std::string> ProcessClient::FindDebugInfoFile(const std::string& module_path) {
+  GetDebugInfoFileRequest request;
+  GetDebugInfoFileResponse response;
+
+  request.set_module_path(module_path);
+
+  std::unique_ptr<grpc::ClientContext> context = CreateContext(kGrpcDefaultTimeoutMilliseconds);
+
+  grpc::Status status = process_service_->GetDebugInfoFile(context.get(), request, &response);
+  if (!status.ok()) {
+    ERROR("gRPC call to GetDebugInfoFile failed: %s", status.error_message());
+    return ErrorMessage(status.error_message());
+  }
+
+  return response.debug_info_file_path();
+}
+
+ErrorMessageOr<std::string> ProcessClient::LoadProcessMemory(int32_t pid, uint64_t address,
+                                                             uint64_t size) {
+  GetProcessMemoryRequest request;
+  request.set_pid(pid);
+  request.set_address(address);
+  request.set_size(size);
+
+  GetProcessMemoryResponse response;
+
+  std::unique_ptr<grpc::ClientContext> context = CreateContext(kGrpcDefaultTimeoutMilliseconds);
+
+  grpc::Status status = process_service_->GetProcessMemory(context.get(), request, &response);
+  if (!status.ok()) {
+    ERROR("gRPC call to GetProcessMemory failed: %s", status.error_message());
+    return ErrorMessage(status.error_message());
+  }
+
+  return std::move(*response.mutable_memory());
+}

--- a/OrbitClientServices/include/OrbitClientServices/ProcessClient.h
+++ b/OrbitClientServices/include/OrbitClientServices/ProcessClient.h
@@ -5,11 +5,16 @@
 #ifndef ORBIT_CLIENT_SERVICES_PROCESS_CLIENT_H_
 #define ORBIT_CLIENT_SERVICES_PROCESS_CLIENT_H_
 
+#include <chrono>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "OrbitBase/Result.h"
 #include "grpcpp/grpcpp.h"
 #include "services.grpc.pb.h"
+
+// This class handles the client calls related to process service.
 
 class ProcessClient {
  public:

--- a/OrbitClientServices/include/OrbitClientServices/ProcessClient.h
+++ b/OrbitClientServices/include/OrbitClientServices/ProcessClient.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_CLIENT_SERVICES_PROCESS_CLIENT_H_
+#define ORBIT_CLIENT_SERVICES_PROCESS_CLIENT_H_
+
+//#include <chrono>
+//#include <memory>
+#include <string>
+
+#include "OrbitBase/Result.h"
+#include "grpcpp/grpcpp.h"
+//#include "module.pb.h"
+//#include "process.pb.h"
+#include "services.grpc.pb.h"
+//#include "symbol.pb.h"
+//#include "tracepoint.pb.h"
+
+class ProcessClient {
+ public:
+  explicit ProcessClient(const std::shared_ptr<grpc::Channel>& channel)
+      : process_service_(orbit_grpc_protos::ProcessService::NewStub(channel)) {}
+
+  [[nodiscard]] ErrorMessageOr<std::vector<orbit_grpc_protos::ProcessInfo>> GetProcessList();
+
+  [[nodiscard]] ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> LoadModuleList(
+      int32_t pid);
+
+  [[nodiscard]] ErrorMessageOr<std::vector<orbit_grpc_protos::TracepointInfo>> LoadTracepointList();
+
+  [[nodiscard]] ErrorMessageOr<std::string> FindDebugInfoFile(const std::string& module_path);
+
+  [[nodiscard]] ErrorMessageOr<std::string> LoadProcessMemory(int32_t pid, uint64_t address,
+                                                              uint64_t size);
+
+ private:
+  std::unique_ptr<orbit_grpc_protos::ProcessService::Stub> process_service_;
+};
+
+#endif  // ORBIT_CLIENT_SERVICES_PROCESS_CLIENT_H_

--- a/OrbitClientServices/include/OrbitClientServices/ProcessClient.h
+++ b/OrbitClientServices/include/OrbitClientServices/ProcessClient.h
@@ -5,17 +5,11 @@
 #ifndef ORBIT_CLIENT_SERVICES_PROCESS_CLIENT_H_
 #define ORBIT_CLIENT_SERVICES_PROCESS_CLIENT_H_
 
-//#include <chrono>
-//#include <memory>
 #include <string>
 
 #include "OrbitBase/Result.h"
 #include "grpcpp/grpcpp.h"
-//#include "module.pb.h"
-//#include "process.pb.h"
 #include "services.grpc.pb.h"
-//#include "symbol.pb.h"
-//#include "tracepoint.pb.h"
 
 class ProcessClient {
  public:


### PR DESCRIPTION
Split _ProcessManager_  in _ProcessManager_  and _ProcessClient_ so the methods related to the process service client are located in their own class.

_ProcessManager_ contains the implementation of the client methods related to the process service but also creates a worker in the background in charge of updating the list of processes until the manager is shutdown. 

_ProcessManager_ interface does not change to the Orbit App and makes the calls to _ProcessClient_ instead of handling the client calls itself. This refactor also allows using _ProcessClient_ in other clients without having to create a worker if it is not needed.

_ProcessClient_ will be used in the ggp client.