### PR TITLE
Fix drawing problem in rounding corners

### DIFF
--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -32,6 +32,7 @@ float GlCanvas::Z_VALUE_EVENT_BAR_PICKING = 0.1f;
 float GlCanvas::Z_VALUE_MARGIN = 0.01f;
 float GlCanvas::Z_VALUE_SLIDER_PICKING = 0.1f;
 float GlCanvas::Z_VALUE_SLIDER = 0.05f;
+float GlCanvas::Z_VALUE_ROUNDING_CORNER = -0.0055f;
 
 GlCanvas::GlCanvas() : ui_batcher_(BatcherId::kUi, &m_PickingManager) {
   m_TextRenderer.SetCanvas(this);

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -113,6 +113,7 @@ class GlCanvas : public GlPanel {
   static float Z_VALUE_MARGIN;
   static float Z_VALUE_SLIDER_PICKING;
   static float Z_VALUE_SLIDER;
+  static float Z_VALUE_ROUNDING_CORNER;
 
  protected:
   [[nodiscard]] PickingMode GetPickingMode();

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -121,7 +121,7 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
     Vec2 top_left(tab_x0, y0 + label_height);
     Vec2 end_bottom(x1 - vertical_margin, y1);
     Vec2 end_top(x1 - vertical_margin, y0 + top_margin);
-    float z = GlCanvas::Z_VALUE_BOX_ACTIVE + 0.001f;
+    float z = GlCanvas::Z_VALUE_ROUNDING_CORNER;
 
     glColor4ubv(&kTabColor[0]);
     DrawTriangleFan(batcher, rounded_corner, bottom_left, kBackgroundColor, 0, z);


### PR DESCRIPTION
Related with [b/162754926](url).

Before this commit, tracks were drawn outside of the rounded corners.


Before: 
![Screen Shot 2020-08-24 at 12 44 03](https://user-images.githubusercontent.com/8610429/91036908-6eb98400-e608-11ea-9273-603c552471f9.png)
![before-1](https://user-images.githubusercontent.com/8610429/91036917-7416ce80-e608-11ea-9f21-16b8410741b8.png)

After:
![Screen Shot 2020-08-24 at 12 55 05](https://user-images.githubusercontent.com/8610429/91037300-0f0fa880-e609-11ea-9948-8a60d2149ef3.png)
![Screen Shot 2020-08-24 at 12 53 41](https://user-images.githubusercontent.com/8610429/91037310-120a9900-e609-11ea-8a98-2542ac8783e6.png)
