### PR TITLE
Align track titles with their respective triangles

### DIFF
--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -105,6 +105,7 @@ class TimeGraph {
   void SetCanvas(GlCanvas* a_Canvas);
   GlCanvas* GetCanvas() { return m_Canvas; }
   void SetFontSize(int a_FontSize);
+  int GetFontSize() { return GetTextRenderer()->GetFontSize(); }
   Batcher& GetBatcher() { return m_Batcher; }
   uint32_t GetNumTimers() const;
   uint32_t GetNumCores() const;

--- a/OrbitGl/TimeGraphLayout.cpp
+++ b/OrbitGl/TimeGraphLayout.cpp
@@ -20,7 +20,6 @@ TimeGraphLayout::TimeGraphLayout() {
   m_SpaceBetweenTracksAndThread = 5.f;
   m_SpaceBetweenThreadBlocks = 35.f;
   m_TrackLabelOffsetX = 30.f;
-  m_TrackLabelOffsetY = 10.f;
   m_SliderWidth = 15.f;
   m_TrackTabWidth = 350.f;
   m_TrackTabHeight = 30.f;
@@ -52,7 +51,6 @@ bool TimeGraphLayout::DrawProperties() {
   ImGui::Begin("Layout Properties", &m_DrawProperties, size, 1.f, 0);
   bool needs_redraw = false;
   FLOAT_SLIDER(m_TrackLabelOffsetX);
-  FLOAT_SLIDER(m_TrackLabelOffsetY);
   FLOAT_SLIDER(m_TextBoxHeight);
   FLOAT_SLIDER(m_CoresHeight);
   FLOAT_SLIDER(m_EventTrackHeight);

--- a/OrbitGl/TimeGraphLayout.h
+++ b/OrbitGl/TimeGraphLayout.h
@@ -16,7 +16,6 @@ class TimeGraphLayout {
   float GetTrackBottomMargin() const { return m_TrackBottomMargin * scale_; }
   float GetTrackTopMargin() const { return m_TrackTopMargin * scale_; }
   float GetTrackLabelOffsetX() const { return m_TrackLabelOffsetX; }
-  float GetTrackLabelOffsetY() const { return m_TrackLabelOffsetY; }
   float GetSliderWidth() const { return m_SliderWidth; }
   float GetTimeBarHeight() const { return time_bar_height_; }
   float GetTrackTabWidth() const { return m_TrackTabWidth; }
@@ -53,7 +52,6 @@ class TimeGraphLayout {
   float m_TrackBottomMargin;
   float m_TrackTopMargin;
   float m_TrackLabelOffsetX;
-  float m_TrackLabelOffsetY;
   float m_SliderWidth;
   float time_bar_height_;
   float m_TrackTabWidth;

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -141,17 +141,19 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
 
   // Draw collapsing triangle.
   float button_offset = layout.GetCollapseButtonOffset();
-  Vec2 toggle_pos = Vec2(tab_x0 + button_offset, m_Pos[1] + half_label_height);
+  float toggle_y_pos = m_Pos[1] + half_label_height;
+  Vec2 toggle_pos = Vec2(tab_x0 + button_offset, toggle_y_pos);
   collapse_toggle_->SetPos(toggle_pos);
   collapse_toggle_->Draw(canvas, picking_mode);
 
   if (!picking) {
     // Draw label.
     float label_offset_x = layout.GetTrackLabelOffsetX();
-    float label_offset_y = layout.GetTrackLabelOffsetY();
+    // Vertical offset for the text to be aligned to the center of the triangle.
+    float label_offset_y = GCurrentTimeGraph->GetFontSize() / 3.f;
     const Color kTextWhite(255, 255, 255, 255);
-    canvas->AddText(label_.c_str(), tab_x0 + label_offset_x, y1 + label_offset_y + m_Size[1],
-                    text_z, kTextWhite, label_width - label_offset_x);
+    canvas->AddText(label_.c_str(), tab_x0 + label_offset_x, toggle_y_pos - label_offset_y, text_z,
+                    kTextWhite, label_width - label_offset_x);
   }
 
   m_Canvas = canvas;


### PR DESCRIPTION
Related to[ b/164961039](url).
Track titles y-coordinates were drawn independently of those of the
triangles. After vertical zoom, this difference meant that they weren't
aligned. This PR solved that, causing both to draw similarly.

Florian's image:
![Mon Aug 17 2020 10_49_30 GMT+0200 (Central European Summer Time)](https://user-images.githubusercontent.com/8610429/91047271-12f7f680-e61a-11ea-9f55-ff7092699d5c.png)

Now:
![Screen Shot 2020-08-24 at 13 50 31](https://user-images.githubusercontent.com/8610429/91047284-18edd780-e61a-11ea-9ba3-3a0e7953947f.png)
![Screen Shot 2020-08-24 at 13 50 11](https://user-images.githubusercontent.com/8610429/91047290-1ab79b00-e61a-11ea-8714-b23c5b8a3ec2.png)
