### PR TITLE
Use shared_ptr to pass Pickable

### DIFF
--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -15,7 +15,7 @@ void Batcher::AddLine(Vec2 from, Vec2 to, float z, const Color& color,
 }
 
 void Batcher::AddLine(Vec2 from, Vec2 to, float z, const Color& color,
-                      std::weak_ptr<Pickable> pickable) {
+                      std::shared_ptr<Pickable> pickable) {
   CHECK(picking_manager_ != nullptr);
 
   Color picking_color = picking_manager_->GetPickableColor(pickable, batcher_id_);
@@ -53,7 +53,7 @@ void Batcher::AddBox(const Box& box, const Color& color,
   AddBox(box, colors, std::move(user_data));
 }
 
-void Batcher::AddBox(const Box& box, const Color& color, std::weak_ptr<Pickable> pickable) {
+void Batcher::AddBox(const Box& box, const Color& color, std::shared_ptr<Pickable> pickable) {
   CHECK(picking_manager_ != nullptr);
 
   Color picking_color = picking_manager_->GetPickableColor(pickable, batcher_id_);
@@ -87,7 +87,7 @@ void Batcher::AddTriangle(const Triangle& triangle, const Color& color,
 }
 
 void Batcher::AddTriangle(const Triangle& triangle, const Color& color,
-                          std::weak_ptr<Pickable> pickable) {
+                          std::shared_ptr<Pickable> pickable) {
   CHECK(picking_manager_ != nullptr);
 
   Color picking_color = picking_manager_->GetPickableColor(pickable, batcher_id_);

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -76,21 +76,22 @@ class Batcher {
                std::unique_ptr<PickingUserData> user_data = nullptr);
   void AddVerticalLine(Vec2 pos, float size, float z, const Color& color,
                        std::unique_ptr<PickingUserData> user_data = nullptr);
-  void AddLine(Vec2 from, Vec2 to, float z, const Color& color, std::weak_ptr<Pickable> pickable);
+  void AddLine(Vec2 from, Vec2 to, float z, const Color& color, std::shared_ptr<Pickable> pickable);
   void AddVerticalLine(Vec2 pos, float size, float z, const Color& color,
-                       std::weak_ptr<Pickable> pickable);
+                       std::shared_ptr<Pickable> pickable);
 
   void AddBox(const Box& box, const std::array<Color, 4>& colors,
               std::unique_ptr<PickingUserData> user_data = nullptr);
   void AddBox(const Box& box, const Color& color,
               std::unique_ptr<PickingUserData> user_data = nullptr);
-  void AddBox(const Box& box, const Color& color, std::weak_ptr<Pickable> pickable);
+  void AddBox(const Box& box, const Color& color, std::shared_ptr<Pickable> pickable);
   void AddShadedBox(Vec2 pos, Vec2 size, float z, const Color& color,
                     std::unique_ptr<PickingUserData> user_data = nullptr);
 
   void AddTriangle(const Triangle& triangle, const Color& color,
                    std::unique_ptr<PickingUserData> user_data = nullptr);
-  void AddTriangle(const Triangle& triangle, const Color& color, std::weak_ptr<Pickable> pickable);
+  void AddTriangle(const Triangle& triangle, const Color& color,
+                   std::shared_ptr<Pickable> pickable);
 
   virtual void Draw(bool picking = false) const;
 

--- a/OrbitGl/BatcherTest.cpp
+++ b/OrbitGl/BatcherTest.cpp
@@ -160,7 +160,7 @@ void ExpectPickableEq(const MockBatcher& batcher, const Color& rendered_color, P
   const PickingUserData* rendered_data = batcher.GetUserData(id);
   EXPECT_EQ(rendered_data, nullptr);
   EXPECT_EQ(id.type, PickingType::kPickable);
-  EXPECT_EQ(pm.GetPickableFromId(id).lock().get(), pickable.get());
+  EXPECT_EQ(pm.GetPickableFromId(id).get(), pickable.get());
 }
 
 TEST(Batcher, PickingPickables) {

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -192,7 +192,7 @@ void CaptureWindow::Hover(int a_X, int a_Y) {
   std::string tooltip = "";
 
   if (pickId.type == PickingType::kPickable) {
-    auto pickable = GetPickingManager().GetPickableFromId(pickId).lock();
+    auto pickable = GetPickingManager().GetPickableFromId(pickId);
     if (pickable) {
       tooltip = pickable->GetTooltip();
     }

--- a/OrbitGl/PickingManager.h
+++ b/OrbitGl/PickingManager.h
@@ -90,7 +90,7 @@ struct PickingId {
 
 class PickingManager {
  public:
-  PickingManager() {}
+  PickingManager() = default;
   PickingManager(PickingManager& rhs) = delete;
 
   void Reset();
@@ -98,16 +98,16 @@ class PickingManager {
   void Pick(PickingId id, int x, int y);
   void Release();
   void Drag(int x, int y);
-  [[nodiscard]] std::weak_ptr<Pickable> GetPicked() const;
-  [[nodiscard]] std::weak_ptr<Pickable> GetPickableFromId(PickingId id) const;
+  [[nodiscard]] std::shared_ptr<Pickable> GetPicked() const;
+  [[nodiscard]] std::shared_ptr<Pickable> GetPickableFromId(PickingId id) const;
   [[nodiscard]] bool IsDragging() const;
 
-  [[nodiscard]] Color GetPickableColor(std::weak_ptr<Pickable> pickable, BatcherId batcher_id);
+  [[nodiscard]] Color GetPickableColor(std::shared_ptr<Pickable> pickable, BatcherId batcher_id);
 
   [[nodiscard]] bool IsThisElementPicked(const Pickable* pickable) const;
 
  private:
-  [[nodiscard]] PickingId GetOrCreatePickableId(std::weak_ptr<Pickable> pickable,
+  [[nodiscard]] PickingId GetOrCreatePickableId(std::shared_ptr<Pickable> pickable,
                                                 BatcherId batcher_id);
   [[nodiscard]] Color ColorFromPickingID(PickingId id) const;
 


### PR DESCRIPTION
Using weak_ptr implies additional cost of having to check
if the value expired on every call in every function. This
is not necessary if we pass shared_ptr instead. In that case
the only place we have to check is when getting Pickable
from the container. After that we can lock it and pass
back to the caller.

Also changed memcpy to absl::bit_cast in ColorFromPickingID

Test: run OrbitGlTests