### PR TITLE
Support for new compilers in conan

### DIFF
--- a/third_party/conan/configs/linux/profiles/gcc10_debug
+++ b/third_party/conan/configs/linux/profiles/gcc10_debug
@@ -1,0 +1,24 @@
+C_COMPILER=gcc-10
+CXX_COMPILER=g++-10
+C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
+[settings]
+os=Linux
+os_build=Linux
+arch=x86_64
+arch_build=x86_64
+compiler=gcc
+compiler.version=10
+compiler.libcxx=libstdc++11
+compiler.fpo=False
+build_type=Debug
+[options]
+[build_requires]
+cmake_installer/3.16.3@conan/stable
+[env]
+CC=$C_COMPILER
+CXX=$CXX_COMPILER
+CFLAGS=$C_FLAGS
+CXXFLAGS=$CXX_FLAGS
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/linux/profiles/gcc10_release
+++ b/third_party/conan/configs/linux/profiles/gcc10_release
@@ -1,0 +1,24 @@
+C_COMPILER=gcc-10
+CXX_COMPILER=g++-10
+C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
+[settings]
+os=Linux
+os_build=Linux
+arch=x86_64
+arch_build=x86_64
+compiler=gcc
+compiler.version=10
+compiler.libcxx=libstdc++11
+compiler.fpo=False
+build_type=Release
+[options]
+[build_requires]
+cmake_installer/3.16.3@conan/stable
+[env]
+CC=$C_COMPILER
+CXX=$CXX_COMPILER
+CFLAGS=$C_FLAGS
+CXXFLAGS=$CXX_FLAGS
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/linux/profiles/gcc10_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/gcc10_relwithdebinfo
@@ -1,0 +1,24 @@
+C_COMPILER=gcc-10
+CXX_COMPILER=g++-10
+C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
+[settings]
+os=Linux
+os_build=Linux
+arch=x86_64
+arch_build=x86_64
+compiler=gcc
+compiler.version=10
+compiler.libcxx=libstdc++11
+compiler.fpo=False
+build_type=RelWithDebInfo
+[options]
+[build_requires]
+cmake_installer/3.16.3@conan/stable
+[env]
+CC=$C_COMPILER
+CXX=$CXX_COMPILER
+CFLAGS=$C_FLAGS
+CXXFLAGS=$CXX_FLAGS
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/linux/settings.yml
+++ b/third_party/conan/configs/linux/settings.yml
@@ -42,15 +42,15 @@ os:
 arch: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64, armv4, armv4i, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, asm.js, wasm, sh4le]
 compiler:
     sun-cc:
-        version: ["5.10", "5.11", "5.12", "5.13", "5.14"]
+        version: ["5.10", "5.11", "5.12", "5.13", "5.14", "5.15"]
         threads: [None, posix]
         libcxx: [libCstd, libstdcxx, libstlport, libstdc++]
     gcc: &gcc
         version: ["4.1", "4.4", "4.5", "4.6", "4.7", "4.8", "4.9",
                   "5", "5.1", "5.2", "5.3", "5.4", "5.5",
-                  "6", "6.1", "6.2", "6.3", "6.4",
-                  "7", "7.1", "7.2", "7.3", "7.4",
-                  "8", "8.1", "8.2", "8.3",
+                  "6", "6.1", "6.2", "6.3", "6.4", "6.5",
+                  "7", "7.1", "7.2", "7.3", "7.4", "7.5",
+                  "8", "8.1", "8.2", "8.3", "8.4",
                   "9", "9.1", "9.2", "9.3",
                   "10", "10.1"]
         libcxx: [libstdc++, libstdc++11]
@@ -69,7 +69,7 @@ compiler:
     clang:
         version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0",
                   "5.0", "6.0", "7.0", "7.1",
-                  "8", "9", "10"]
+                  "8", "9", "10", "11", "12"]
         libcxx: [libstdc++, libstdc++11, libc++, c++_shared, c++_static]
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
         fpo: [None, True, False]
@@ -79,12 +79,12 @@ compiler:
         memory_sanitizer: [None, True]
         fuzzer_sanitizer: [None, True]
 
-    apple-clang:
+    apple-clang: &apple_clang
         version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1", "10.0", "11.0"]
         libcxx: [libstdc++, libc++]
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     intel:
-        version: ["11", "12", "13", "14", "15", "16", "17", "18", "19"]
+        version: ["11", "12", "13", "14", "15", "16", "17", "18", "19", "19.1"]
         base:
             gcc:
                 <<: *gcc
@@ -92,9 +92,13 @@ compiler:
                 exception: [None]
             Visual Studio:
                 <<: *visual_studio
+            apple-clang:
+                <<: *apple_clang
     qcc:
         version: ["4.4", "5.4"]
         libcxx: [cxx, gpp, cpp, cpp-ne, accp, acpp-ne, ecpp, ecpp-ne]
 
 build_type: [None, Debug, Release, RelWithDebInfo, MinSizeRel]
+
+
 cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]  # Deprecated, use compiler.cppstd

--- a/third_party/conan/configs/windows/settings.yml
+++ b/third_party/conan/configs/windows/settings.yml
@@ -42,15 +42,15 @@ os:
 arch: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64, armv4, armv4i, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, asm.js, wasm, sh4le]
 compiler:
     sun-cc:
-        version: ["5.10", "5.11", "5.12", "5.13", "5.14"]
+        version: ["5.10", "5.11", "5.12", "5.13", "5.14", "5.15"]
         threads: [None, posix]
         libcxx: [libCstd, libstdcxx, libstlport, libstdc++]
     gcc: &gcc
         version: ["4.1", "4.4", "4.5", "4.6", "4.7", "4.8", "4.9",
                   "5", "5.1", "5.2", "5.3", "5.4", "5.5",
-                  "6", "6.1", "6.2", "6.3", "6.4",
-                  "7", "7.1", "7.2", "7.3", "7.4",
-                  "8", "8.1", "8.2", "8.3",
+                  "6", "6.1", "6.2", "6.3", "6.4", "6.5",
+                  "7", "7.1", "7.2", "7.3", "7.4", "7.5",
+                  "8", "8.1", "8.2", "8.3", "8.4",
                   "9", "9.1", "9.2", "9.3",
                   "10", "10.1"]
         libcxx: [libstdc++, libstdc++11]
@@ -69,7 +69,7 @@ compiler:
     clang:
         version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0",
                   "5.0", "6.0", "7.0", "7.1",
-                  "8", "9", "10"]
+                  "8", "9", "10", "11", "12"]
         libcxx: [libstdc++, libstdc++11, libc++, c++_shared, c++_static]
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
         fpo: [None, True, False]
@@ -79,12 +79,12 @@ compiler:
         memory_sanitizer: [None, True]
         fuzzer_sanitizer: [None, True]
 
-    apple-clang:
+    apple-clang: &apple_clang
         version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1", "10.0", "11.0"]
         libcxx: [libstdc++, libc++]
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]
     intel:
-        version: ["11", "12", "13", "14", "15", "16", "17", "18", "19"]
+        version: ["11", "12", "13", "14", "15", "16", "17", "18", "19", "19.1"]
         base:
             gcc:
                 <<: *gcc
@@ -92,9 +92,13 @@ compiler:
                 exception: [None]
             Visual Studio:
                 <<: *visual_studio
+            apple-clang:
+                <<: *apple_clang
     qcc:
         version: ["4.4", "5.4"]
         libcxx: [cxx, gpp, cpp, cpp-ne, accp, acpp-ne, ecpp, ecpp-ne]
 
 build_type: [None, Debug, Release, RelWithDebInfo, MinSizeRel]
+
+
 cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20]  # Deprecated, use compiler.cppstd


### PR DESCRIPTION
This adds support for new compiler version to conan.
GCC 10 is needed by the community (see #1105) and for Fuzzing we need clang-12 (trunk) support.

Fixes: #1105
Test: Did a clang10_release build. Went though without problems - at least on my machine.