### PR TITLE
Remove X11 linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,10 +73,6 @@ list(PREPEND CMAKE_FIND_ROOT_PATH "${CMAKE_BINARY_DIR}")
 # scripts in a cross compilation environment.
 list(APPEND CMAKE_FIND_ROOT_PATH "${CONAN_CMAKE_MODULE_PATH}")
 
-if(NOT WIN32 AND WITH_GUI)
-  find_package(X11 REQUIRED)
-endif()
-
 find_package(OpenSSL CONFIG REQUIRED)
 find_package(Threads REQUIRED)
 find_package(xxHash REQUIRED)

--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -118,10 +118,6 @@ if(TARGET OpenGL::GLX AND TARGET OpenGL::OpenGL)
   target_link_libraries(OrbitGl PUBLIC OpenGL::GLX)
 endif()
 
-if(NOT WIN32)
-  target_link_libraries(OrbitGl PRIVATE X11::X11 X11::Xi X11::Xxf86vm)
-endif()
-
 add_executable(OrbitGlTests)
 
 target_compile_options(OrbitGlTests PRIVATE ${STRICT_COMPILE_FLAGS})


### PR DESCRIPTION
It seems that we don't need to link to X11 anymore. Probably the code that needed that was removed before.

I tested that on Ubuntu 20.04 and on my corporate Linux workstation.