### PR TITLE
Remove Process::GetModuleFromName

### DIFF
--- a/OrbitCaptureClient/CaptureEventProcessor.cpp
+++ b/OrbitCaptureClient/CaptureEventProcessor.cpp
@@ -188,7 +188,7 @@ void CaptureEventProcessor::ProcessAddressInfo(const AddressInfo& address_info) 
 
   LinuxAddressInfo linux_address_info;
   linux_address_info.set_absolute_address(address_info.absolute_address());
-  linux_address_info.set_module_name(map_name);
+  linux_address_info.set_module_path(map_name);
   linux_address_info.set_function_name(function_name);
   linux_address_info.set_offset_in_function(address_info.offset_in_function());
   capture_listener_->OnAddressInfo(linux_address_info);

--- a/OrbitClientProtos/capture_data.proto
+++ b/OrbitClientProtos/capture_data.proto
@@ -56,7 +56,7 @@ message CallstackInfo {
 
 message LinuxAddressInfo {
   uint64 absolute_address = 1;
-  string module_name = 2;
+  string module_path = 2;
   string function_name = 3;
   uint64 offset_in_function = 4;
 }

--- a/OrbitCore/OrbitProcess.cpp
+++ b/OrbitCore/OrbitProcess.cpp
@@ -65,15 +65,6 @@ std::shared_ptr<Module> Process::GetModuleFromAddress(uint64_t a_Address) {
   return module;
 }
 
-std::shared_ptr<Module> Process::GetModuleFromName(const std::string& a_Name) {
-  auto iter = m_NameToModuleMap.find(absl::AsciiStrToLower(a_Name));
-  if (iter != m_NameToModuleMap.end()) {
-    return iter->second;
-  }
-
-  return nullptr;
-}
-
 std::shared_ptr<Module> Process::GetModuleFromPath(const std::string& module_path) {
   auto iter = path_to_module_map_.find(module_path);
   if (iter != path_to_module_map_.end()) {
@@ -93,6 +84,5 @@ void Process::AddFunctions(
 
 void Process::AddModule(std::shared_ptr<Module>& a_Module) {
   m_Modules[a_Module->m_AddressStart] = a_Module;
-  m_NameToModuleMap[absl::AsciiStrToLower(a_Module->m_Name)] = a_Module;
   path_to_module_map_[a_Module->m_FullName] = a_Module;
 }

--- a/OrbitCore/OrbitProcess.h
+++ b/OrbitCore/OrbitProcess.h
@@ -24,10 +24,6 @@ class Process {
 
   void AddModule(std::shared_ptr<Module>& a_Module);
 
-  std::map<std::string, std::shared_ptr<Module>>& GetNameToModulesMap() {
-    return m_NameToModuleMap;
-  }
-
   void SetName(std::string_view name) { m_Name = name; }
   const std::string& GetName() const { return m_Name; }
   void SetFullPath(std::string_view full_path) { m_FullPath = full_path; }
@@ -40,7 +36,6 @@ class Process {
   orbit_client_protos::FunctionInfo* GetFunctionFromAddress(uint64_t address,
                                                             bool a_IsExact = true);
   std::shared_ptr<Module> GetModuleFromAddress(uint64_t a_Address);
-  std::shared_ptr<Module> GetModuleFromName(const std::string& a_Name);
   std::shared_ptr<Module> GetModuleFromPath(const std::string& module_path);
 
   void AddFunction(const std::shared_ptr<orbit_client_protos::FunctionInfo>& function) {
@@ -66,10 +61,6 @@ class Process {
   Mutex data_mutex_;
 
   std::map<uint64_t, std::shared_ptr<Module>> m_Modules;
-  // TODO(antonrohr): Change the usage of m_NameToModuleMap to
-  //  path_to_module_map_, since the name of a module is not unique
-  //  (/usr/lib/libbase.so and /opt/somedir/libbase.so)
-  std::map<std::string, std::shared_ptr<Module>> m_NameToModuleMap;
   std::map<std::string, std::shared_ptr<Module>> path_to_module_map_;
 
   // Transients

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -24,7 +24,7 @@ struct SampledFunction {
   SampledFunction() = default;
 
   std::string name;
-  std::string module;
+  std::string module_path;
   std::string file;
   float exclusive = 0;
   float inclusive = 0;
@@ -93,7 +93,7 @@ class SamplingProfiler {
   [[nodiscard]] uint32_t GetCountOfFunction(uint64_t function_address) const;
 
   [[nodiscard]] const std::string& GetFunctionNameByAddress(uint64_t address) const;
-  [[nodiscard]] const std::string& GetModuleNameByAddress(uint64_t address) const;
+  [[nodiscard]] const std::string& GetModulePathByAddress(uint64_t address) const;
 
   static const int32_t kAllThreadsFakeTid;
   static const std::string kUnknownFunctionOrModuleName;
@@ -116,7 +116,7 @@ class SamplingProfiler {
   std::vector<ThreadSampleData*> sorted_thread_sample_data_;
 
   absl::flat_hash_map<uint64_t, std::string> address_to_function_name_;
-  absl::flat_hash_map<uint64_t, std::string> address_to_module_name_;
+  absl::flat_hash_map<uint64_t, std::string> address_to_module_path_;
 };
 
 #endif  // ORBIT_CORE_SAMPLING_PROFILER_H_

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -8,6 +8,7 @@
 #include "Callstack.h"
 #include "Capture.h"
 #include "FunctionUtils.h"
+#include "Path.h"
 #include "absl/flags/flag.h"
 #include "absl/strings/str_format.h"
 
@@ -60,7 +61,8 @@ std::string CallStackDataView::GetValue(int row, int column) {
       if (module != nullptr) {
         return module->m_Name;
       }
-      return Capture::capture_data_.GetSamplingProfiler().GetModuleNameByAddress(frame.address);
+      return Path::GetFileName(
+          Capture::capture_data_.GetSamplingProfiler().GetModulePathByAddress(frame.address));
     case kColumnAddress:
       return absl::StrFormat("%#llx", frame.address);
     default:

--- a/OrbitGl/ModulesDataView.cpp
+++ b/OrbitGl/ModulesDataView.cpp
@@ -128,7 +128,7 @@ void ModulesDataView::OnContextMenu(const std::string& action, int menu_index,
     std::vector<std::shared_ptr<Module>> modules_to_validate;
     for (int index : item_indices) {
       const ModuleData* module = GetModule(index);
-      modules_to_validate.push_back(process->GetModuleFromName(module->name()));
+      modules_to_validate.push_back(process->GetModuleFromPath(module->file_path()));
     }
 
     if (!modules_to_validate.empty()) {


### PR DESCRIPTION
GetModuleFromPath is now used everywhere.

This is a step towards removing OrbitProcess. In the future modules will be identified always by their path not name, because the name can be ambiguous.