### PR TITLE
Fix clang-12's unnecessary-copy-warning

### DIFF
--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -45,7 +45,7 @@ std::vector<Vec2> RotatePoints(const std::vector<Vec2>& points, float rotation) 
   float cos_r = cosf(kPiFloat * rotation / 180.f);
   float sin_r = sinf(kPiFloat * rotation / 180.f);
   std::vector<Vec2> result;
-  for (const Vec2 point : points) {
+  for (const Vec2& point : points) {
     float x_rotated = cos_r * point[0] - sin_r * point[1];
     float y_rotated = sin_r * point[0] + cos_r * point[1];
     result.push_back(Vec2(x_rotated, y_rotated));


### PR DESCRIPTION
clang-12's range-loop-construct warning complains about copied const
arguments in range-based for-loop. Apparently we have that enabled as an
error. This commit fixes the complaint. That was necessary for oss-fuzz
which uses clang-trunk.