### PR TITLE
Fix Z-ordering issues + Refactoring

### DIFF
--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -495,7 +495,7 @@ void CaptureWindow::Draw() {
 
     Vec2 pos(m_MouseX, m_WorldTopLeftY);
     // Vertical green line at mouse x position
-    ui_batcher_.AddVerticalLine(pos, -m_WorldHeight, Z_VALUE_TEXT, Color(0, 255, 0, 127));
+    ui_batcher_.AddVerticalLine(pos, -m_WorldHeight, kZValueText, Color(0, 255, 0, 127));
   }
 }
 
@@ -537,14 +537,14 @@ void CaptureWindow::DrawScreenSpace() {
   float margin_x1 = getWidth();
   float margin_x0 = margin_x1 - vertical_margin;
 
-  Box box(Vec2(margin_x0, 0), Vec2(margin_x1 - margin_x0, canvasHeight), GlCanvas::Z_VALUE_MARGIN);
+  Box box(Vec2(margin_x0, 0), Vec2(margin_x1 - margin_x0, canvasHeight), GlCanvas::kZValueMargin);
   ui_batcher_.AddBox(box, kBackgroundColor);
 
   // Time bar background
   if (time_graph_.GetCaptureTimeSpanUs() > 0) {
     Box box(Vec2(0, time_graph_.GetLayout().GetSliderWidth()),
             Vec2(getWidth(), time_graph_.GetLayout().GetTimeBarHeight()),
-            GlCanvas::Z_VALUE_TIME_BAR_BG);
+            GlCanvas::kZValueTimeBarBg);
     ui_batcher_.AddBox(box, Color(70, 70, 70, 200));
   }
 }
@@ -779,11 +779,11 @@ void CaptureWindow::RenderTimeBar() {
 
       std::string text = GetPrettyTime(absl::Microseconds(current_micros));
       float worldX = time_graph_.GetWorldFromUs(current_micros);
-      m_TextRenderer.AddText(text.c_str(), worldX + xMargin, worldY, GlCanvas::Z_VALUE_TEXT_UI,
+      m_TextRenderer.AddText(text.c_str(), worldX + xMargin, worldY, GlCanvas::kZValueTextUi,
                              Color(255, 255, 255, 255));
 
       Vec2 pos(worldX, worldY);
-      ui_batcher_.AddVerticalLine(pos, height, GlCanvas::Z_VALUE_UI, Color(255, 255, 255, 255));
+      ui_batcher_.AddVerticalLine(pos, height, GlCanvas::kZValueUi, Color(255, 255, 255, 255));
     }
   }
 }
@@ -803,18 +803,18 @@ void CaptureWindow::RenderSelectionOverlay() {
     std::string text = GetPrettyTime(TicksToDuration(minTime, maxTime));
     const Color color(0, 128, 0, 128);
 
-    Box box(pos, size, GlCanvas::Z_VALUE_OVERLAY);
+    Box box(pos, size, GlCanvas::kZValueOverlay);
     ui_batcher_.AddBox(box, color);
 
     const Color text_color(255, 255, 255, 255);
     float pos_x = pos[0] + size[0];
 
-    m_TextRenderer.AddText(text.c_str(), pos_x, m_SelectStop[1], GlCanvas::Z_VALUE_TEXT, text_color,
+    m_TextRenderer.AddText(text.c_str(), pos_x, m_SelectStop[1], GlCanvas::kZValueText, text_color,
                            size[0], true);
 
     const unsigned char g = 100;
     Color grey(g, g, g, 255);
-    ui_batcher_.AddVerticalLine(pos, size[1], GlCanvas::Z_VALUE_OVERLAY, grey);
+    ui_batcher_.AddVerticalLine(pos, size[1], GlCanvas::kZValueOverlay, grey);
   }
 }
 

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -494,6 +494,7 @@ void CaptureWindow::Draw() {
     RenderTimeBar();
 
     Vec2 pos(m_MouseX, m_WorldTopLeftY);
+    // Vertical green line at mouse x position
     ui_batcher_.AddVerticalLine(pos, -m_WorldHeight, Z_VALUE_TEXT, Color(0, 255, 0, 127));
   }
 }
@@ -543,7 +544,7 @@ void CaptureWindow::DrawScreenSpace() {
   if (time_graph_.GetCaptureTimeSpanUs() > 0) {
     Box box(Vec2(0, time_graph_.GetLayout().GetSliderWidth()),
             Vec2(getWidth(), time_graph_.GetLayout().GetTimeBarHeight()),
-            GlCanvas::Z_VALUE_TEXT_UI_BG);
+            GlCanvas::Z_VALUE_TIME_BAR_BG);
     ui_batcher_.AddBox(box, Color(70, 70, 70, 200));
   }
 }
@@ -802,7 +803,7 @@ void CaptureWindow::RenderSelectionOverlay() {
     std::string text = GetPrettyTime(TicksToDuration(minTime, maxTime));
     const Color color(0, 128, 0, 128);
 
-    Box box(pos, size, GlCanvas::Z_VALUE_BOX_ACTIVE);
+    Box box(pos, size, GlCanvas::Z_VALUE_OVERLAY);
     ui_batcher_.AddBox(box, color);
 
     const Color text_color(255, 255, 255, 255);
@@ -813,7 +814,7 @@ void CaptureWindow::RenderSelectionOverlay() {
 
     const unsigned char g = 100;
     Color grey(g, g, g, 255);
-    ui_batcher_.AddVerticalLine(pos, size[1], GlCanvas::Z_VALUE_BOX_ACTIVE, grey);
+    ui_batcher_.AddVerticalLine(pos, size[1], GlCanvas::Z_VALUE_OVERLAY, grey);
   }
 }
 

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -28,8 +28,8 @@ void EventTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   // have a tooltip. For picking, we want to draw the event bar over them if
   // handling a click, and underneath otherwise.
   // This simulates "click-through" behavior.
-  const float eventBarZ = picking_mode == PickingMode::kClick ? GlCanvas::Z_VALUE_EVENT_BAR_PICKING
-                                                              : GlCanvas::Z_VALUE_EVENT_BAR;
+  const float eventBarZ = picking_mode == PickingMode::kClick ? GlCanvas::kZValueEventBarPicking
+                                                              : GlCanvas::kZValueEventBar;
   Color color = m_Color;
   Box box(m_Pos, Vec2(m_Size[0], -m_Size[1]), eventBarZ);
   batcher->AddBox(box, color, shared_from_this());
@@ -43,8 +43,8 @@ void EventTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   float x1 = x0 + m_Size[0];
   float y1 = y0 - m_Size[1];
 
-  batcher->AddLine(m_Pos, Vec2(x1, y0), GlCanvas::Z_VALUE_EVENT_BAR, color, shared_from_this());
-  batcher->AddLine(Vec2(x1, y1), Vec2(x0, y1), GlCanvas::Z_VALUE_EVENT_BAR, color,
+  batcher->AddLine(m_Pos, Vec2(x1, y0), GlCanvas::kZValueEventBar, color, shared_from_this());
+  batcher->AddLine(Vec2(x1, y1), Vec2(x0, y1), GlCanvas::kZValueEventBar, color,
                    shared_from_this());
 
   if (m_Picked) {
@@ -57,7 +57,7 @@ void EventTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
     y1 = y0 - m_Size[1];
 
     Color picked_color(0, 128, 255, 128);
-    Box box(Vec2(x0, y0), Vec2(x1 - x0, -m_Size[1]), GlCanvas::Z_VALUE_UI);
+    Box box(Vec2(x0, y0), Vec2(x1 - x0, -m_Size[1]), GlCanvas::kZValueUi);
     batcher->AddBox(box, picked_color, shared_from_this());
   }
 
@@ -67,7 +67,7 @@ void EventTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
 void EventTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode) {
   Batcher* batcher = &time_graph_->GetBatcher();
   const TimeGraphLayout& layout = time_graph_->GetLayout();
-  float z = GlCanvas::Z_VALUE_EVENT;
+  float z = GlCanvas::kZValueEvent;
   float track_height = layout.GetEventTrackHeight();
   const bool picking = picking_mode != PickingMode::kNone;
 

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -57,7 +57,7 @@ void EventTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
     y1 = y0 - m_Size[1];
 
     Color picked_color(0, 128, 255, 128);
-    Box box(Vec2(x0, y0), Vec2(x1 - x0, -m_Size[1]), -0.f);
+    Box box(Vec2(x0, y0), Vec2(x1 - x0, -m_Size[1]), GlCanvas::Z_VALUE_UI);
     batcher->AddBox(box, picked_color, shared_from_this());
   }
 

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -17,21 +17,20 @@
 
 RingBuffer<float, 512> GDeltaTimeBuffer;
 
-float GlCanvas::Z_VALUE_SLIDER = 0.02f;
-float GlCanvas::Z_VALUE_MARGIN = 0.01f;
-float GlCanvas::Z_VALUE_TEXT_UI = 0.0f;
-float GlCanvas::Z_VALUE_UI = 0.0f;
-float GlCanvas::Z_VALUE_TIME_BAR_BG = -0.001f;
-float GlCanvas::Z_VALUE_TEXT = -0.002f;
-float GlCanvas::Z_VALUE_OVERLAY = -0.003f;
-float GlCanvas::Z_VALUE_OVERLAY_BG = -0.004f;
-float GlCanvas::Z_VALUE_ROUNDING_CORNER = -0.01f;
-float GlCanvas::Z_VALUE_EVENT = -0.02f;
-float GlCanvas::Z_VALUE_BOX = -0.03f;
-float GlCanvas::Z_VALUE_EVENT_BAR = -0.1f;
-float GlCanvas::Z_VALUE_TRACK = -0.2f;
-
-float GlCanvas::Z_VALUE_EVENT_BAR_PICKING = 0.1f;
+float GlCanvas::kZValueEventBarPicking = 0.1f;
+float GlCanvas::kZValueSlider = 0.02f;
+float GlCanvas::kZValueMargin = 0.01f;
+float GlCanvas::kZValueTextUi = 0.0f;
+float GlCanvas::kZValueUi = 0.0f;
+float GlCanvas::kZValueTimeBarBg = -0.001f;
+float GlCanvas::kZValueText = -0.002f;
+float GlCanvas::kZValueOverlay = -0.003f;
+float GlCanvas::kZValueOverlayBg = -0.004f;
+float GlCanvas::kZValueRoundingCorner = -0.01f;
+float GlCanvas::kZValueEvent = -0.02f;
+float GlCanvas::kZValueBox = -0.03f;
+float GlCanvas::kZValueEventBar = -0.1f;
+float GlCanvas::kZValueTrack = -0.2f;
 
 GlCanvas::GlCanvas() : ui_batcher_(BatcherId::kUi, &m_PickingManager) {
   m_TextRenderer.SetCanvas(this);

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -17,22 +17,21 @@
 
 RingBuffer<float, 512> GDeltaTimeBuffer;
 
-float GlCanvas::Z_VALUE_UI = 0.00f;
-float GlCanvas::Z_VALUE_TEXT_UI = 0.0f;
-float GlCanvas::Z_VALUE_TEXT_UI_BG = -0.005f;
-float GlCanvas::Z_VALUE_TEXT = -0.01f;
-float GlCanvas::Z_VALUE_OVERLAY = -0.012f;
-float GlCanvas::Z_VALUE_OVERLAY_BG = -0.013f;
-float GlCanvas::Z_VALUE_CONTEXT_SWITCH = -0.015f;
-float GlCanvas::Z_VALUE_EVENT = -0.015f;
-float GlCanvas::Z_VALUE_BOX_ACTIVE = -0.02f;
-float GlCanvas::Z_VALUE_BOX_INACTIVE = -0.03f;
-float GlCanvas::Z_VALUE_EVENT_BAR = -0.1f;
-float GlCanvas::Z_VALUE_EVENT_BAR_PICKING = 0.1f;
+float GlCanvas::Z_VALUE_SLIDER = 0.02f;
 float GlCanvas::Z_VALUE_MARGIN = 0.01f;
-float GlCanvas::Z_VALUE_SLIDER_PICKING = 0.1f;
-float GlCanvas::Z_VALUE_SLIDER = 0.05f;
-float GlCanvas::Z_VALUE_ROUNDING_CORNER = -0.0055f;
+float GlCanvas::Z_VALUE_TEXT_UI = 0.0f;
+float GlCanvas::Z_VALUE_UI = 0.0f;
+float GlCanvas::Z_VALUE_TIME_BAR_BG = -0.001f;
+float GlCanvas::Z_VALUE_TEXT = -0.002f;
+float GlCanvas::Z_VALUE_OVERLAY = -0.003f;
+float GlCanvas::Z_VALUE_OVERLAY_BG = -0.004f;
+float GlCanvas::Z_VALUE_ROUNDING_CORNER = -0.01f;
+float GlCanvas::Z_VALUE_EVENT = -0.02f;
+float GlCanvas::Z_VALUE_BOX = -0.03f;
+float GlCanvas::Z_VALUE_EVENT_BAR = -0.1f;
+float GlCanvas::Z_VALUE_TRACK = -0.2f;
+
+float GlCanvas::Z_VALUE_EVENT_BAR_PICKING = 0.1f;
 
 GlCanvas::GlCanvas() : ui_batcher_(BatcherId::kUi, &m_PickingManager) {
   m_TextRenderer.SetCanvas(this);

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -17,15 +17,15 @@
 
 RingBuffer<float, 512> GDeltaTimeBuffer;
 
-float GlCanvas::kZValueEventBarPicking = 0.1f;
 float GlCanvas::kZValueSlider = 0.02f;
 float GlCanvas::kZValueMargin = 0.01f;
 float GlCanvas::kZValueTextUi = 0.0f;
 float GlCanvas::kZValueUi = 0.0f;
-float GlCanvas::kZValueTimeBarBg = -0.001f;
-float GlCanvas::kZValueText = -0.002f;
-float GlCanvas::kZValueOverlay = -0.003f;
-float GlCanvas::kZValueOverlayBg = -0.004f;
+float GlCanvas::kZValueEventBarPicking = -0.001f;
+float GlCanvas::kZValueTimeBarBg = -0.002f;
+float GlCanvas::kZValueText = -0.003f;
+float GlCanvas::kZValueOverlay = -0.004f;
+float GlCanvas::kZValueOverlayBg = -0.005f;
 float GlCanvas::kZValueRoundingCorner = -0.01f;
 float GlCanvas::kZValueEvent = -0.02f;
 float GlCanvas::kZValueBox = -0.03f;

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -97,11 +97,11 @@ class GlCanvas : public GlPanel {
 
   PickingManager& GetPickingManager() { return m_PickingManager; }
 
-  static float kZValueEventBarPicking;
   static float kZValueSlider;
   static float kZValueMargin;
   static float kZValueTextUi;
   static float kZValueUi;
+  static float kZValueEventBarPicking;
   static float kZValueTimeBarBg;
   static float kZValueText;
   static float kZValueOverlay;

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -97,21 +97,20 @@ class GlCanvas : public GlPanel {
 
   PickingManager& GetPickingManager() { return m_PickingManager; }
 
-  static float Z_VALUE_SLIDER;
-  static float Z_VALUE_MARGIN;
-  static float Z_VALUE_TEXT_UI;
-  static float Z_VALUE_UI;
-  static float Z_VALUE_TIME_BAR_BG;
-  static float Z_VALUE_OVERLAY;
-  static float Z_VALUE_OVERLAY_BG;
-  static float Z_VALUE_ROUNDING_CORNER;
-  static float Z_VALUE_TEXT;
-  static float Z_VALUE_EVENT;
-  static float Z_VALUE_BOX;
-  static float Z_VALUE_EVENT_BAR;
-  static float Z_VALUE_TRACK;
-
-  static float Z_VALUE_EVENT_BAR_PICKING;
+  static float kZValueEventBarPicking;
+  static float kZValueSlider;
+  static float kZValueMargin;
+  static float kZValueTextUi;
+  static float kZValueUi;
+  static float kZValueTimeBarBg;
+  static float kZValueText;
+  static float kZValueOverlay;
+  static float kZValueOverlayBg;
+  static float kZValueRoundingCorner;
+  static float kZValueEvent;
+  static float kZValueBox;
+  static float kZValueEventBar;
+  static float kZValueTrack;
 
  protected:
   [[nodiscard]] PickingMode GetPickingMode();

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -97,23 +97,21 @@ class GlCanvas : public GlPanel {
 
   PickingManager& GetPickingManager() { return m_PickingManager; }
 
-  static float Z_VALUE_UI;
-  static float Z_VALUE_TEXT;
+  static float Z_VALUE_SLIDER;
+  static float Z_VALUE_MARGIN;
   static float Z_VALUE_TEXT_UI;
-  static float Z_VALUE_TEXT_UI_BG;
+  static float Z_VALUE_UI;
+  static float Z_VALUE_TIME_BAR_BG;
   static float Z_VALUE_OVERLAY;
   static float Z_VALUE_OVERLAY_BG;
-  static float Z_VALUE_CONTEXT_SWITCH;
-  static float Z_VALUE_EVENT;
-  static float Z_VALUE_BOX_ACTIVE;
-  static float Z_VALUE_BOX_INACTIVE;
-  static float Z_VALUE_TEXT_BG;
-  static float Z_VALUE_EVENT_BAR;
-  static float Z_VALUE_EVENT_BAR_PICKING;
-  static float Z_VALUE_MARGIN;
-  static float Z_VALUE_SLIDER_PICKING;
-  static float Z_VALUE_SLIDER;
   static float Z_VALUE_ROUNDING_CORNER;
+  static float Z_VALUE_TEXT;
+  static float Z_VALUE_EVENT;
+  static float Z_VALUE_BOX;
+  static float Z_VALUE_EVENT_BAR;
+  static float Z_VALUE_TRACK;
+
+  static float Z_VALUE_EVENT_BAR_PICKING;
 
  protected:
   [[nodiscard]] PickingMode GetPickingMode();

--- a/OrbitGl/GlSlider.cpp
+++ b/OrbitGl/GlSlider.cpp
@@ -112,7 +112,7 @@ void GlSlider::DrawHorizontal(GlCanvas* canvas, PickingMode picking_mode) {
 
   // Bar
   if (!picking) {
-    Box box(Vec2(0, y), Vec2(canvasWidth, GetPixelHeight()), GlCanvas::Z_VALUE_SLIDER);
+    Box box(Vec2(0, y), Vec2(canvasWidth, GetPixelHeight()), GlCanvas::Z_VALUE_MARGIN);
     batcher->AddBox(box, m_BarColor, shared_from_this());
   }
 
@@ -122,7 +122,7 @@ void GlSlider::DrawHorizontal(GlCanvas* canvas, PickingMode picking_mode) {
   Color color =
       canvas->GetPickingManager().IsThisElementPicked(this) ? m_SelectedColor : m_SliderColor;
 
-  Box box(Vec2(start, y), Vec2(stop - start, GetPixelHeight()), GlCanvas::Z_VALUE_SLIDER_PICKING);
+  Box box(Vec2(start, y), Vec2(stop - start, GetPixelHeight()), GlCanvas::Z_VALUE_SLIDER);
   batcher->AddBox(box, color, shared_from_this());
 }
 
@@ -139,7 +139,7 @@ void GlSlider::DrawVertical(GlCanvas* canvas, PickingMode picking_mode) {
 
   // Bar
   if (!picking) {
-    Box box(Vec2(x, 0), Vec2(GetPixelHeight(), canvasHeight), GlCanvas::Z_VALUE_SLIDER);
+    Box box(Vec2(x, 0), Vec2(GetPixelHeight(), canvasHeight), GlCanvas::Z_VALUE_MARGIN);
     batcher->AddBox(box, m_BarColor, shared_from_this());
   }
 
@@ -149,6 +149,6 @@ void GlSlider::DrawVertical(GlCanvas* canvas, PickingMode picking_mode) {
   Color color =
       canvas->GetPickingManager().IsThisElementPicked(this) ? m_SelectedColor : m_SliderColor;
 
-  Box box(Vec2(x, start), Vec2(GetPixelHeight(), stop - start), GlCanvas::Z_VALUE_SLIDER_PICKING);
+  Box box(Vec2(x, start), Vec2(GetPixelHeight(), stop - start), GlCanvas::Z_VALUE_SLIDER);
   batcher->AddBox(box, color, shared_from_this());
 }

--- a/OrbitGl/GlSlider.cpp
+++ b/OrbitGl/GlSlider.cpp
@@ -112,7 +112,7 @@ void GlSlider::DrawHorizontal(GlCanvas* canvas, PickingMode picking_mode) {
 
   // Bar
   if (!picking) {
-    Box box(Vec2(0, y), Vec2(canvasWidth, GetPixelHeight()), GlCanvas::Z_VALUE_MARGIN);
+    Box box(Vec2(0, y), Vec2(canvasWidth, GetPixelHeight()), GlCanvas::kZValueMargin);
     batcher->AddBox(box, m_BarColor, shared_from_this());
   }
 
@@ -122,7 +122,7 @@ void GlSlider::DrawHorizontal(GlCanvas* canvas, PickingMode picking_mode) {
   Color color =
       canvas->GetPickingManager().IsThisElementPicked(this) ? m_SelectedColor : m_SliderColor;
 
-  Box box(Vec2(start, y), Vec2(stop - start, GetPixelHeight()), GlCanvas::Z_VALUE_SLIDER);
+  Box box(Vec2(start, y), Vec2(stop - start, GetPixelHeight()), GlCanvas::kZValueSlider);
   batcher->AddBox(box, color, shared_from_this());
 }
 
@@ -139,7 +139,7 @@ void GlSlider::DrawVertical(GlCanvas* canvas, PickingMode picking_mode) {
 
   // Bar
   if (!picking) {
-    Box box(Vec2(x, 0), Vec2(GetPixelHeight(), canvasHeight), GlCanvas::Z_VALUE_MARGIN);
+    Box box(Vec2(x, 0), Vec2(GetPixelHeight(), canvasHeight), GlCanvas::kZValueMargin);
     batcher->AddBox(box, m_BarColor, shared_from_this());
   }
 
@@ -149,6 +149,6 @@ void GlSlider::DrawVertical(GlCanvas* canvas, PickingMode picking_mode) {
   Color color =
       canvas->GetPickingManager().IsThisElementPicked(this) ? m_SelectedColor : m_SliderColor;
 
-  Box box(Vec2(x, start), Vec2(GetPixelHeight(), stop - start), GlCanvas::Z_VALUE_SLIDER);
+  Box box(Vec2(x, start), Vec2(GetPixelHeight(), stop - start), GlCanvas::kZValueSlider);
   batcher->AddBox(box, color, shared_from_this());
 }

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -144,7 +144,7 @@ void GpuTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_us, 
   float max_size = box_pos[0] + box_size[0] - pos_x;
   text_renderer_->AddTextTrailingCharsPrioritized(
       text_box->GetText().c_str(), pos_x, text_box->GetPos()[1] + layout.GetTextOffset(),
-      GlCanvas::Z_VALUE_TEXT, kTextWhite, text_box->GetElapsedTimeTextLength(), max_size);
+      GlCanvas::kZValueText, kTextWhite, text_box->GetElapsedTimeTextLength(), max_size);
 }
 
 std::string GpuTrack::GetTooltip() const {

--- a/OrbitGl/GraphTrack.cpp
+++ b/OrbitGl/GraphTrack.cpp
@@ -31,8 +31,8 @@ void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
     color = kPickedColor;
   }
 
-  float track_z = GlCanvas::Z_VALUE_TRACK;
-  float text_z = GlCanvas::Z_VALUE_TEXT;
+  float track_z = GlCanvas::kZValueTrack;
+  float text_z = GlCanvas::kZValueText;
 
   Box box(m_Pos, Vec2(m_Size[0], -m_Size[1]), track_z);
   batcher->AddBox(box, color, shared_from_this());

--- a/OrbitGl/GraphTrack.cpp
+++ b/OrbitGl/GraphTrack.cpp
@@ -12,7 +12,6 @@ GraphTrack::GraphTrack(TimeGraph* time_graph, uint64_t graph_id)
 void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   Batcher* batcher = canvas->GetBatcher();
 
-  TimeGraphLayout& layout = time_graph_->GetLayout();
   float trackWidth = canvas->GetWorldWidth();
 
   m_Pos[0] = canvas->GetWorldTopLeftX();
@@ -32,8 +31,8 @@ void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
     color = kPickedColor;
   }
 
-  float track_z = layout.GetTrackZ();
-  float text_z = layout.GetTextZ();
+  float track_z = GlCanvas::Z_VALUE_TRACK;
+  float text_z = GlCanvas::Z_VALUE_TEXT;
 
   Box box(m_Pos, Vec2(m_Size[0], -m_Size[1]), track_z);
   batcher->AddBox(box, color, shared_from_this());

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -200,7 +200,7 @@ void ThreadTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_u
   float max_size = box_pos[0] + box_size[0] - pos_x;
   text_renderer_->AddTextTrailingCharsPrioritized(
       text_box->GetText().c_str(), pos_x, text_box->GetPos()[1] + layout.GetTextOffset(),
-      GlCanvas::Z_VALUE_TEXT, kTextWhite, text_box->GetElapsedTimeTextLength(), max_size);
+      GlCanvas::kZValueText, kTextWhite, text_box->GetElapsedTimeTextLength(), max_size);
 }
 
 std::string ThreadTrack::GetTooltip() const {

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -673,7 +673,7 @@ std::string GetTimeString(const TextBox* box_a, const TextBox* box_b) {
 
 void DrawIteratorBox(GlCanvas* canvas, Vec2 pos, Vec2 size, const Color& color,
                      const std::string& label, const std::string& time, float text_y) {
-  Box box(pos, size, GlCanvas::Z_VALUE_OVERLAY);
+  Box box(pos, size, GlCanvas::kZValueOverlay);
   canvas->GetBatcher()->AddBox(box, color);
 
   std::string text = absl::StrFormat("%s: %s", label, time);
@@ -683,13 +683,13 @@ void DrawIteratorBox(GlCanvas* canvas, Vec2 pos, Vec2 size, const Color& color,
 
   float max_size = size[0];
   canvas->GetTextRenderer().AddTextTrailingCharsPrioritized(
-      text.c_str(), pos[0] + kLeftOffset, text_y + kAdditionalSpaceForLine, GlCanvas::Z_VALUE_TEXT,
+      text.c_str(), pos[0] + kLeftOffset, text_y + kAdditionalSpaceForLine, GlCanvas::kZValueText,
       Color(255, 255, 255, 255), time.length(), max_size);
 
   constexpr const float kOffsetBelowText = kAdditionalSpaceForLine / 2.f;
   Vec2 line_from(pos[0], text_y + kOffsetBelowText);
   Vec2 line_to(pos[0] + size[0], text_y + kOffsetBelowText);
-  canvas->GetBatcher()->AddLine(line_from, line_to, GlCanvas::Z_VALUE_OVERLAY,
+  canvas->GetBatcher()->AddLine(line_from, line_to, GlCanvas::kZValueOverlay,
                                 Color(255, 255, 255, 255));
 }
 
@@ -734,7 +734,7 @@ void TimeGraph::DrawOverlay(GlCanvas* canvas, PickingMode picking_mode) {
     Vec2 pos(world_timer_x, world_start_y);
     x_coords.push_back(pos[0]);
 
-    canvas->GetBatcher()->AddVerticalLine(pos, -world_height, GlCanvas::Z_VALUE_OVERLAY,
+    canvas->GetBatcher()->AddVerticalLine(pos, -world_height, GlCanvas::kZValueOverlay,
                                           GetThreadColor(timer_info.thread_id()));
   }
 

--- a/OrbitGl/TimeGraphLayout.cpp
+++ b/OrbitGl/TimeGraphLayout.cpp
@@ -30,8 +30,6 @@ TimeGraphLayout::TimeGraphLayout() {
   m_TextOffset = 5.f;
   m_VerticalMargin = 10.f;
   m_SchedulerTrackOffset = 10.f;
-  m_TextZ = -0.02f;
-  m_TrackZ = -0.1f;
   m_ToolbarIconHeight = 24.f;
   scale_ = 1.f;
   time_bar_height_ = 15.f;
@@ -72,8 +70,6 @@ bool TimeGraphLayout::DrawProperties() {
   FLOAT_SLIDER_MIN_MAX(m_TrackTabWidth, 0, 1000.f);
   FLOAT_SLIDER_MIN_MAX(m_TrackBottomMargin, 0, 20.f);
   FLOAT_SLIDER_MIN_MAX(m_TrackTopMargin, 0, 20.f);
-  FLOAT_SLIDER_MIN_MAX(m_TextZ, -1.f, 1.f);
-  FLOAT_SLIDER_MIN_MAX(m_TrackZ, -1.f, 1.f);
   FLOAT_SLIDER(m_ToolbarIconHeight);
   FLOAT_SLIDER_MIN_MAX(scale_, 0.05f, 20.f);
   ImGui::Checkbox("DrawTrackBackground", &m_DrawTrackBackground);

--- a/OrbitGl/TimeGraphLayout.h
+++ b/OrbitGl/TimeGraphLayout.h
@@ -32,8 +32,6 @@ class TimeGraphLayout {
   float GetSpaceBetweenTracks() const { return m_SpaceBetweenTracks * scale_; }
   float GetSpaceBetweenCores() const { return m_SpaceBetweenCores * scale_; }
   float GetSpaceBetweenTracksAndThread() const { return m_SpaceBetweenTracksAndThread * scale_; }
-  float GetTextZ() const { return m_TextZ; }
-  float GetTrackZ() const { return m_TrackZ; }
   float GetToolbarIconHeight() const { return m_ToolbarIconHeight; }
   float GetScale() const { return scale_; }
   void SetScale(float value) { scale_ = value; }
@@ -69,8 +67,6 @@ class TimeGraphLayout {
   float m_SpaceBetweenTracksAndThread;
   float m_SpaceBetweenThreadBlocks;
 
-  float m_TextZ;
-  float m_TrackZ;
   float m_ToolbarIconHeight;
   float scale_;
 

--- a/OrbitGl/TimerTrack.cpp
+++ b/OrbitGl/TimerTrack.cpp
@@ -119,7 +119,7 @@ void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
 
         Vec2 pos(world_timer_x, world_timer_y);
         Vec2 size(world_timer_width, box_height_);
-        float z = GlCanvas::Z_VALUE_BOX;
+        float z = GlCanvas::kZValueBox;
         Color color = GetTimerColor(timer_info, is_selected);
         text_box.SetPos(pos);
         text_box.SetSize(size);

--- a/OrbitGl/TimerTrack.cpp
+++ b/OrbitGl/TimerTrack.cpp
@@ -119,7 +119,7 @@ void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
 
         Vec2 pos(world_timer_x, world_timer_y);
         Vec2 size(world_timer_width, box_height_);
-        float z = GlCanvas::Z_VALUE_BOX_ACTIVE;
+        float z = GlCanvas::Z_VALUE_BOX;
         Color color = GetTimerColor(timer_info, is_selected);
         text_box.SetPos(pos);
         text_box.SetSize(size);

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -84,8 +84,8 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   float x1 = x0 + m_Size[0];
   float y0 = m_Pos[1];
   float y1 = y0 - m_Size[1];
-  float track_z = GlCanvas::Z_VALUE_TRACK;
-  float text_z = GlCanvas::Z_VALUE_TEXT;
+  float track_z = GlCanvas::kZValueTrack;
+  float text_z = GlCanvas::kZValueText;
   float top_margin = layout.GetTrackTopMargin();
 
   // Draw track background.
@@ -121,7 +121,7 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
     Vec2 top_left(tab_x0, y0 + label_height);
     Vec2 end_bottom(x1 - vertical_margin, y1);
     Vec2 end_top(x1 - vertical_margin, y0 + top_margin);
-    float z = GlCanvas::Z_VALUE_ROUNDING_CORNER;
+    float z = GlCanvas::kZValueRoundingCorner;
 
     glColor4ubv(&kTabColor[0]);
     DrawTriangleFan(batcher, rounded_corner, bottom_left, kBackgroundColor, 0, z);

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -84,8 +84,8 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   float x1 = x0 + m_Size[0];
   float y0 = m_Pos[1];
   float y1 = y0 - m_Size[1];
-  float track_z = layout.GetTrackZ();
-  float text_z = layout.GetTextZ();
+  float track_z = GlCanvas::Z_VALUE_TRACK;
+  float text_z = GlCanvas::Z_VALUE_TEXT;
   float top_margin = layout.GetTrackTopMargin();
 
   // Draw track background.

--- a/OrbitGl/TriangleToggle.cpp
+++ b/OrbitGl/TriangleToggle.cpp
@@ -46,7 +46,7 @@ void TriangleToggle::Draw(GlCanvas* canvas, PickingMode picking_mode) {
     float original_width = 2 * half_w;
     float large_width = 2 * original_width;
     Box box(Vec2(pos_[0] - original_width, pos_[1] - original_width),
-            Vec2(large_width, large_width), 0.f);
+            Vec2(large_width, large_width), GlCanvas::Z_VALUE_UI);
     batcher->AddBox(box, color, shared_from_this());
   }
 }

--- a/OrbitGl/TriangleToggle.cpp
+++ b/OrbitGl/TriangleToggle.cpp
@@ -46,7 +46,7 @@ void TriangleToggle::Draw(GlCanvas* canvas, PickingMode picking_mode) {
     float original_width = 2 * half_w;
     float large_width = 2 * original_width;
     Box box(Vec2(pos_[0] - original_width, pos_[1] - original_width),
-            Vec2(large_width, large_width), GlCanvas::Z_VALUE_UI);
+            Vec2(large_width, large_width), GlCanvas::kZValueUi);
     batcher->AddBox(box, color, shared_from_this());
   }
 }


### PR DESCRIPTION
There were a few bugs related with Z-ordering.

This PR:
1) Move TextZ and TrackZ from Layout to Canvas.
2) Erase some numeric values and changed them to Canvas' constants.
3) Refactor Canvas a little.
4) Fix wrong Z-values (see images).
5) Fix b/162485723

Before:
Iterators with SelectionOverlay:
![Screen Shot 2020-08-25 at 15 47 29](https://user-images.githubusercontent.com/8610429/91276808-4eadd000-e782-11ea-897d-26927647f9f2.png)

Iterators with Track Titles
![Screen Shot 2020-08-25 at 14 44 16](https://user-images.githubusercontent.com/8610429/91276855-5cfbec00-e782-11ea-8840-272899b67d52.png)

Now:
![Screen Shot 2020-08-26 at 13 18 50](https://user-images.githubusercontent.com/8610429/91297573-d43f7900-e79e-11ea-915f-98666af60240.png)
![Screen Shot 2020-08-26 at 13 19 26](https://user-images.githubusercontent.com/8610429/91297578-d6a1d300-e79e-11ea-86a9-0483064f6ce6.png)


