### PR TITLE
Add tutorial basics

### DIFF
--- a/OrbitCore/Path.cpp
+++ b/OrbitCore/Path.cpp
@@ -167,10 +167,6 @@ std::string Path::GetLogFilePathAndCreateDir() {
   return Path::JoinPath({logs_dir, "Orbit.log"});
 }
 
-std::string Path::GetIconsPath() {
-  static std::string icons_path = JoinPath({GetExecutableDir(), "icons"});
-  return icons_path;
-}
 
 std::vector<std::string> Path::ListFiles(const std::string& directory,
                                          const std::function<bool(const std::string&)>& filter) {

--- a/OrbitCore/Path.h
+++ b/OrbitCore/Path.h
@@ -19,7 +19,6 @@ namespace Path {
 [[nodiscard]] std::string CreateOrGetDumpDir();
 [[nodiscard]] std::string CreateOrGetOrbitAppDataDir();
 [[nodiscard]] std::string GetLogFilePathAndCreateDir();
-[[nodiscard]] std::string GetIconsPath();
 [[nodiscard]] std::string GetFileName(const std::string& file_path);
 [[nodiscard]] std::string StripExtension(const std::string& file_path);
 [[nodiscard]] std::string GetExtension(const std::string& file_path);

--- a/OrbitCore/PathTest.cpp
+++ b/OrbitCore/PathTest.cpp
@@ -231,16 +231,6 @@ TEST(Path, AllAutoCreatedDirsExist) {
   }
 }
 
-TEST(Path, AllCopiedDirsExist) {
-  auto test_fns = {Path::GetIconsPath};
-
-  for (auto fn : test_fns) {
-    std::string path = fn();
-    LOG("Testing existence of \"%s\"", path.c_str());
-    EXPECT_TRUE(std::filesystem::is_directory(path));
-  }
-}
-
 TEST(Path, AllDirsOfFilesExist) {
   auto test_fns = {Path::GetLogFilePathAndCreateDir};
 

--- a/OrbitQt/CMakeLists.txt
+++ b/OrbitQt/CMakeLists.txt
@@ -11,6 +11,7 @@ target_compile_options(OrbitQt PRIVATE ${STRICT_COMPILE_FLAGS})
 target_sources(
   OrbitQt
   PRIVATE deploymentconfigurations.h
+          CutoutWidget.h
           ElidedLabel.h
           Error.h
           eventloop.h
@@ -32,6 +33,7 @@ target_sources(
           resource.h
           servicedeploymanager.h
           TopDownViewItemModel.h
+          TutorialOverlay.h
           topdownwidget.h)
 
 target_sources(
@@ -62,7 +64,10 @@ target_sources(
           servicedeploymanager.cpp
           TopDownViewItemModel.cpp
           topdownwidget.cpp
-          ../icons/orbiticons.qrc)
+          TutorialOverlay.cpp
+          TutorialOverlay.ui
+          ../icons/orbiticons.qrc
+          ../images/orbitimages.qrc)
 
 target_include_directories(OrbitQt PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -110,10 +115,6 @@ if(WIN32)
     COMMENT "Running windeployqt...")
 endif()
 
-add_custom_command(TARGET OrbitQt POST_BUILD COMMAND ${CMAKE_COMMAND}
-                   -E copy_directory ${CMAKE_SOURCE_DIR}/icons/
-                   $<TARGET_FILE_DIR:OrbitQt>/icons)
-
 set_target_properties(OrbitQt PROPERTIES OUTPUT_NAME "Orbit")
 set_target_properties(OrbitQt PROPERTIES AUTOMOC ON)
 set_target_properties(OrbitQt PROPERTIES AUTOUIC ON)
@@ -125,15 +126,30 @@ add_executable(OrbitQtTests)
 target_compile_options(OrbitQtTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(OrbitQtTests
+        PRIVATE
+                CutoutWidget.h
+                TutorialOverlay.h)
+target_sources(OrbitQtTests
         PRIVATE StatusListenerImplTest.cpp
-                StatusListenerImpl.cpp)
+                StatusListenerImpl.cpp
+                TutorialOverlayTest.cpp
+                TutorialOverlay.cpp
+                TutorialOverlay.ui
+                ../images/orbitimages.qrc)
+				
+target_include_directories(OrbitQtTests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_link_libraries(
   OrbitQtTests
-  PRIVATE OrbitGl
+  PRIVATE OrbitCore
+          OrbitGl
           Qt5::Widgets
           Qt5::Core
           GTest::Main)
+		  
+set_target_properties(OrbitQtTests PROPERTIES AUTOMOC ON)
+set_target_properties(OrbitQtTests PROPERTIES AUTOUIC ON)
+set_target_properties(OrbitQtTests PROPERTIES AUTORCC ON)
 
 register_test(OrbitQtTests)
 

--- a/OrbitQt/CutoutWidget.h
+++ b/OrbitQt/CutoutWidget.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_QT_CUTOUT_WIDGET_
+#define ORBIT_QT_CUTOUT_WIDGET_
+
+#include <QLabel>
+
+/**
+Used by the TutorialOverlay widget (TutorialOverlay.h).
+
+This widget does not provide any functionality on top of QLabel, so there is no
+reason to use it except in cases explicitely stated in the documentation of
+TutorialOverlay.
+
+CutoutWidget merely provides a semantic difference when placed inside the TutorialOverlay
+widget, as TutorialOverlay is looking for instances of this class to determine
+the "area of interest" in each tutorial step.
+**/
+class CutoutWidget : public QLabel {
+  Q_OBJECT
+
+ public:
+  explicit CutoutWidget(QWidget* parent = nullptr) : QLabel{parent} {
+    setAttribute(Qt::WA_TransparentForMouseEvents, true);
+  }
+};
+
+#endif

--- a/OrbitQt/StatusListenerImplTest.cpp
+++ b/OrbitQt/StatusListenerImplTest.cpp
@@ -7,7 +7,7 @@
 #include "StatusListenerImpl.h"
 #include "gtest/gtest.h"
 
-int argc = 0;
+static int argc = 0;
 
 TEST(StatusListenerImpl, ShowAndClearOneMessage) {
   QApplication app(argc, nullptr);

--- a/OrbitQt/TutorialOverlay.cpp
+++ b/OrbitQt/TutorialOverlay.cpp
@@ -1,0 +1,424 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "TutorialOverlay.h"
+
+#include <QFrame>
+#include <QLabel>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QRegion>
+#include <QTabBar>
+
+#include "OrbitBase/Logging.h"
+#include "Utils.h"
+#include "absl/strings/str_format.h"
+#include "ui_TutorialOverlay.h"
+
+static void RecursiveUpdate(QWidget* widget) {
+  for (auto child : widget->children()) {
+    auto child_widget = dynamic_cast<QWidget*>(child);
+    if (child_widget != nullptr) {
+      RecursiveUpdate(child_widget);
+    }
+  }
+
+  widget->update();
+}
+
+TutorialOverlay::TutorialOverlay(QWidget* parent)
+    : QDialog(parent), ui_(std::make_unique<Ui::TutorialOverlay>()) {
+  ui_->setupUi(this);
+
+  if (parent != nullptr) {
+    setGeometry(QRect(0, 0, parent->rect().width(), parent->rect().height()));
+  }
+  setWindowFlags(Qt::FramelessWindowHint | Qt::WindowSystemMenuHint);
+
+  background_label_ = std::make_unique<QLabel>(this);
+  background_label_->setStyleSheet("background-color: rgba(0, 0, 0, 150);");
+
+  ui_->tabWidget->raise();
+  ui_->titleFrame->raise();
+  ui_->btnClose->raise();
+  QTabBar* tabBar = ui_->tabWidget->findChild<QTabBar*>();
+  tabBar->hide();
+
+  InitAllStepsFromUi();
+}
+
+TutorialOverlay::Step TutorialOverlay::InitializeStep(int tab_index) {
+  QWidget* tab = ui_->tabWidget->widget(tab_index);
+
+  Step step;
+  step.tab_index = tab_index;
+  step.name = tab->objectName().toStdString();
+  step.cutout_widget = tab->findChild<CutoutWidget*>();
+
+  if (step.cutout_widget) {
+    QRect cutout_rect = step.cutout_widget->geometry();
+    for (auto child : tab->findChildren<QWidget*>()) {
+      if (child != step.cutout_widget && child->parent() == tab) {
+        step.hints.push_back(DeriveHintDescription(cutout_rect, child));
+      }
+    }
+  }
+
+  return step;
+}
+
+void TutorialOverlay::InitAllStepsFromUi() {
+  steps_.clear();
+  for (int i = 0; i < ui_->tabWidget->count(); ++i) {
+    const std::string tab_name = ui_->tabWidget->widget(i)->objectName().toStdString();
+    CHECK(steps_.find(tab_name) == steps_.end());
+    steps_[tab_name] = InitializeStep(i);
+  }
+}
+
+QRect TutorialOverlay::AbsoluteGeometry(QWidget* widget) const {
+  if (widget->parentWidget() == nullptr || widget->parentWidget() == parentWidget()) {
+    return widget->geometry();
+  }
+
+  QWidget* parent_widget = widget->parentWidget();
+  QRect result = widget->geometry();
+  QRect parent_geo = AbsoluteGeometry(parent_widget);
+
+  result.moveTo(parent_geo.topLeft());
+
+  return result;
+}
+
+TutorialOverlay::~TutorialOverlay() {}
+
+void TutorialOverlay::StartActiveStep() {
+  const Step& step = GetActiveStep();
+  ui_->tabWidget->setCurrentIndex(step.tab_index);
+
+  if (step.setup.callback_init) {
+    step.setup.callback_init(this, step.name);
+  }
+
+  ui_->btnPrev->setEnabled(!ActiveStepIsFirstInSection());
+  const Section& section = GetActiveSection();
+  const std::string text = absl::StrFormat(
+      "%s: %d/%d", section.title, section.active_step_index + 1, section.step_names.size());
+  ui_->labelStep->setText(QString::fromStdString(text));
+
+  if (step.setup.anchor_widget) {
+    step.setup.anchor_widget->installEventFilter(this);
+  }
+  showMaximized();
+  UpdateOverlayLayout();
+}
+
+bool TutorialOverlay::EndActiveStep() {
+  if (!HasActiveStep()) {
+    return true;
+  }
+
+  UnhookActiveStep();
+
+  return true;
+}
+
+void TutorialOverlay::StartSection(const std::string& section) {
+  if (!EndActiveStep()) {
+    return;
+  }
+
+  auto it = sections_.find(section);
+  CHECK(it != sections_.end());
+
+  active_section_ = it;
+  it->second.active_step_index = it->second.step_names.empty() ? -1 : 0;
+  StartActiveStep();
+}
+
+void TutorialOverlay::AddSection(std::string section_name, std::string title,
+                                 std::vector<std::string> step_names) {
+  Section section;
+  for (auto& name : step_names) {
+    CHECK(StepExists(name));
+  }
+  section.step_names = std::move(step_names);
+  section.title = std::move(title);
+  sections_[std::move(section_name)] = std::move(section);
+}
+
+void TutorialOverlay::NextStep() {
+  if (!HasActiveStep()) {
+    return;
+  }
+  if (!VerifyActiveStep()) {
+    return;
+  }
+  if (!EndActiveStep()) {
+    return;
+  }
+
+  auto& section = GetActiveSection();
+  section.active_step_index++;
+  if (static_cast<size_t>(section.active_step_index) >= section.step_names.size()) {
+    section.active_step_index = -1;
+  }
+
+  if (!HasActiveStep()) {
+    emit SectionCompleted(active_section_->first);
+    active_section_ = sections_.end();
+    close();
+  } else {
+    StartActiveStep();
+  }
+}
+
+void TutorialOverlay::PrevStep() {
+  if (!HasActiveStep()) {
+    return;
+  }
+  if (ActiveStepIsFirstInSection()) {
+    return;
+  }
+  if (!EndActiveStep()) {
+    return;
+  }
+  GetActiveSection().active_step_index--;
+  StartActiveStep();
+}
+
+void TutorialOverlay::closeEvent(QCloseEvent* event) {
+  UnhookActiveStep();
+  QDialog::closeEvent(event);
+
+  if (parentWidget() != nullptr) {
+    RecursiveUpdate(parentWidget());
+    parentWidget()->removeEventFilter(this);
+  }
+}
+
+void TutorialOverlay::showEvent(QShowEvent* event) {
+  QDialog::showEvent(event);
+  if (parentWidget() != nullptr) {
+    parentWidget()->installEventFilter(this);
+  }
+}
+
+bool TutorialOverlay::eventFilter(QObject*, QEvent* event) {
+  if (event->type() == QEvent::Resize) {
+    UpdateOverlayLayout();
+  }
+
+  return false;
+}
+
+void TutorialOverlay::SetupStep(const std::string& ui_tab_name, StepSetup step_setup) {
+  auto it = steps_.find(ui_tab_name);
+  CHECK(it != steps_.end());
+  it->second.setup = step_setup;
+}
+
+const TutorialOverlay::StepSetup& TutorialOverlay::GetStep(const std::string& name) const {
+  CHECK(StepExists(name));
+  auto it = steps_.find(name);
+  return it->second.setup;
+}
+
+bool TutorialOverlay::StepExists(const std::string& name) const {
+  auto it = steps_.find(name);
+  return it != steps_.end();
+}
+
+static const auto margin = QPoint(20, 20);
+
+void TutorialOverlay::UpdateOverlayLayout() {
+  if (parentWidget() != nullptr) {
+    const QRect parent_rect = parentWidget()->rect();
+    setGeometry(parent_rect);
+    ui_->tabWidget->setGeometry(parent_rect);
+  }
+  UpdateButtons();
+  background_label_->setGeometry(rect());
+
+  Step& step = GetActiveStep();
+
+  if (step.setup.anchor_widget != nullptr && step.cutout_widget != nullptr) {
+    auto target_rect = AbsoluteGeometry(step.setup.anchor_widget);
+    auto outer_rect = target_rect;
+    outer_rect.setTopLeft(outer_rect.topLeft() - margin);
+    outer_rect.setBottomRight(outer_rect.bottomRight() + margin);
+
+    QRegion maskedRegion(QRegion(QRect(rect())).subtracted(QRegion(target_rect)));
+    setMask(maskedRegion);
+
+    step.cutout_widget->setGeometry(outer_rect);
+
+    for (auto& hint : step.hints) {
+      UpdateHintWidgetPosition(outer_rect, hint);
+    }
+
+    background_label_->show();
+  } else {
+    background_label_->hide();
+  }
+
+  if (parentWidget() != nullptr) {
+    RecursiveUpdate(parentWidget());
+  }
+}
+
+void TutorialOverlay::UpdateButtons() {
+  if (parentWidget() == nullptr) {
+    return;
+  }
+
+  const int kMargin[] = {20, 20};
+
+  const QRect parent_rect = parentWidget()->rect();
+
+  QRect rect = ui_->btnClose->geometry();
+  ui_->btnClose->setGeometry(QRect(parent_rect.width() - rect.width() - kMargin[0], kMargin[1],
+                                   rect.width(), rect.height()));
+
+  rect = ui_->titleFrame->geometry();
+  ui_->titleFrame->setGeometry(QRect((parent_rect.width() - rect.width()) / 2,
+                                     parent_rect.height() - rect.height() - kMargin[1],
+                                     rect.width(), rect.height()));
+}
+
+bool TutorialOverlay::VerifyActiveStep() {
+  const Step& step = GetActiveStep();
+
+  if (step.setup.callback_verify) {
+    auto verify_complete = step.setup.callback_verify(this, step.name);
+    if (verify_complete.has_value()) {
+      // This is mostly to allow unit testing...
+      if (parentWidget() != nullptr && parentWidget()->isVisible()) {
+        QMessageBox::critical(this, "Wizard Error",
+                              QString::fromStdString(verify_complete.value()));
+      }
+      return false;
+    }
+  }
+
+  return true;
+}
+
+TutorialOverlay::Hint TutorialOverlay::DeriveHintDescription(const QRect& anchor_rect,
+                                                             QWidget* hint_widget) const {
+  QRect hint_rect = hint_widget->geometry();
+
+  // The anchor position is determined by the quadrant of anchor_rect in which the top
+  // left corner of hint_rect is placed initially.
+  Hint result;
+  result.widget = hint_widget;
+
+  if (hint_rect.x() < anchor_rect.x() + anchor_rect.width() / 2) {
+    if (hint_rect.y() < anchor_rect.y() + anchor_rect.height() / 2) {
+      result.anchor = HintAnchor::kTopLeft;
+    } else {
+      result.anchor = HintAnchor::kBottomLeft;
+    }
+  } else {
+    if (hint_rect.y() < anchor_rect.y() + anchor_rect.height() / 2) {
+      result.anchor = HintAnchor::kTopRight;
+    } else {
+      result.anchor = HintAnchor::kBottomRight;
+    }
+  }
+
+  switch (result.anchor) {
+    case HintAnchor::kTopLeft:
+      result.offset = hint_rect.topLeft() - anchor_rect.topLeft();
+      break;
+    case HintAnchor::kTopRight:
+      result.offset = hint_rect.topLeft() - anchor_rect.topRight();
+      break;
+    case HintAnchor::kBottomRight:
+      result.offset = hint_rect.topLeft() - anchor_rect.bottomRight();
+      break;
+    case HintAnchor::kBottomLeft:
+      result.offset = hint_rect.topLeft() - anchor_rect.bottomLeft();
+      break;
+  }
+
+  return result;
+}
+
+void TutorialOverlay::UpdateHintWidgetPosition(const QRect& anchor_rect, Hint& hint) {
+  const QPoint size(hint.widget->rect().width(), hint.widget->rect().height());
+  QPoint tl, br;
+
+  // See comments in DeriveHintDescription() on how offsets and anchors
+  // are calculated
+  switch (hint.anchor) {
+    case HintAnchor::kTopLeft:
+      tl = anchor_rect.topLeft() + hint.offset;
+      break;
+    case HintAnchor::kTopRight:
+      tl = anchor_rect.topRight() + hint.offset;
+      break;
+    case HintAnchor::kBottomRight:
+      tl = anchor_rect.bottomRight() + hint.offset;
+      break;
+    case HintAnchor::kBottomLeft:
+      tl = anchor_rect.bottomLeft() + hint.offset;
+      break;
+  }
+
+  br = tl + size;
+  hint.widget->setGeometry(QRect(tl, br));
+}
+
+bool TutorialOverlay::HasActiveStep() const {
+  if (!HasActiveSection()) {
+    return false;
+  }
+
+  auto& section = GetActiveSection();
+  return section.active_step_index >= 0 &&
+         static_cast<size_t>(section.active_step_index) < section.step_names.size();
+}
+
+const TutorialOverlay::Step& TutorialOverlay::GetActiveStep() const {
+  CHECK(HasActiveStep());
+  auto& section = GetActiveSection();
+  auto it = steps_.find(section.step_names[section.active_step_index]);
+  CHECK(it != steps_.end());
+
+  return it->second;
+}
+
+TutorialOverlay::Step& TutorialOverlay::GetActiveStep() {
+  return const_cast<TutorialOverlay::Step&>(
+      static_cast<const TutorialOverlay*>(this)->GetActiveStep());
+}
+
+const TutorialOverlay::Section& TutorialOverlay::GetActiveSection() const {
+  CHECK(HasActiveSection());
+  return active_section_->second;
+}
+
+TutorialOverlay::Section& TutorialOverlay::GetActiveSection() {
+  return const_cast<TutorialOverlay::Section&>(
+      static_cast<const TutorialOverlay*>(this)->GetActiveSection());
+}
+
+bool TutorialOverlay::ActiveStepIsFirstInSection() const {
+  CHECK(HasActiveSection());
+  return GetActiveSection().active_step_index == 0;
+}
+
+void TutorialOverlay::UnhookActiveStep() {
+  if (HasActiveStep()) {
+    Step& active_step = GetActiveStep();
+
+    if (active_step.setup.anchor_widget != nullptr) {
+      active_step.setup.anchor_widget->removeEventFilter(this);
+    }
+    if (active_step.setup.callback_teardown != nullptr) {
+      active_step.setup.callback_teardown(this, active_step.name);
+    }
+  }
+}

--- a/OrbitQt/TutorialOverlay.h
+++ b/OrbitQt/TutorialOverlay.h
@@ -1,0 +1,167 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_QT_TUTORIAL_OVERLAY_
+#define ORBIT_QT_TUTORIAL_OVERLAY_
+
+#include <QDialog>
+#include <QLabel>
+#include <QPoint>
+#include <memory>
+#include <optional>
+#include <unordered_map>
+
+#include "CutoutWidget.h"
+
+namespace Ui {
+class TutorialOverlay;
+}
+
+/**
+Provides interactive tutorials as fullscreen overlays.
+
+This Dialog relies on tutorial content defined in TutorialOverlay.ui. Open the UI file
+in Qt Designer for a description on how to create new tutorial steps (check the README tab).
+
+The Orbit tutorial consists of multiple "Sections". A section takes you through a single
+workflow in Orbit (e.g. taking a capture). Each section consist of multiple "Steps",
+where each step is a fullscreen overlay displaying instructions to the user. A section is
+defined by a freely given name and a list of step names that will be executed
+one after another.
+
+All UI elements of a step are defined by a single tab in the main tabWidget of the tutorial UI
+(again, check the UI file), where the tab objectName equals the step name. If no further
+setup is done, the step will simply display this tab and wait for the user to click "next".
+
+Usually, additional programmatical setup of a step will be performed through
+TutorialOverlay::SetupStep(). Each step can receive:
+
+* An anchor widget: This is the widget onto which you want to focus the user's attention.
+  This widget will receive a prominent border, and the rest of Orbit will receive a
+  dimming overlay and cannot be interacted with
+* An init callback: A callback method that is executed when the step is started. This can
+  be used to e.g. connect signals to the TutorialOverlay::NextStep() method to
+  automatically advance
+* A teardown callback: A callback method that is executed when the step ends. Use this to
+  cleanup everything you set up in the init callback
+* A verify callback: A callback method that is executed before a step is finished. If this
+  callback returns a string, this is interpreted as an error message to be displayed to
+  the user, and the tutorial will not advance to the next step.
+
+Check the unit tests on how to use.
+A very brief summary:
+1) Add your step's UI to TutorialOverlay.ui
+2) (optional) Setup your step with SetupStep() in code
+3) Create a section that contains one or more steps with AddSection()
+4) Create this dialog with the main window as a parent
+5) Execute the tutorial by StartSection()
+**/
+class TutorialOverlay : public QDialog {
+  Q_OBJECT
+
+ public:
+  using StepCallback = std::function<void(TutorialOverlay* overlay, const std::string& step_name)>;
+  using VerifyStepCompleted = std::function<std::optional<std::string>(
+      TutorialOverlay* overlay, const std::string& step_completed)>;
+
+  struct StepSetup {
+    QWidget* anchor_widget = nullptr;
+    StepCallback callback_init = nullptr;
+    StepCallback callback_teardown = nullptr;
+    VerifyStepCompleted callback_verify = nullptr;
+  };
+
+  explicit TutorialOverlay(QWidget* parent = nullptr);
+  ~TutorialOverlay() override;
+
+  bool eventFilter(QObject* object, QEvent* event) override;
+
+  void SetupStep(const std::string& ui_tab_name, StepSetup step_setup);
+  [[nodiscard]] const StepSetup& GetStep(const std::string& name) const;
+  [[nodiscard]] bool StepExists(const std::string& name) const;
+
+  [[nodiscard]] std::string GetActiveStepName() const {
+    return HasActiveStep() ? GetActiveStep().name : "";
+  }
+
+  [[nodiscard]] std::string GetActiveSectionName() const {
+    return HasActiveSection() ? active_section_->first : "";
+  }
+
+  void AddSection(const std::string section_name, std::string title,
+                  std::vector<std::string> step_names);
+
+ public Q_SLOTS:
+  void StartSection(const std::string& section_name);
+  void NextStep();
+  void PrevStep();
+
+ Q_SIGNALS:
+  void SectionCompleted(const std::string& section_name);
+
+ protected:
+  void closeEvent(QCloseEvent* event) override;
+  void showEvent(QShowEvent* event) override;
+
+ private:
+  enum class HintAnchor { kTopLeft, kTopRight, kBottomRight, kBottomLeft };
+  struct Hint {
+    QWidget* widget = nullptr;
+    HintAnchor anchor = HintAnchor::kTopLeft;
+    QPoint offset = QPoint(0, 0);
+  };
+
+  struct Step {
+    StepSetup setup;
+    std::vector<Hint> hints;
+    QWidget* cutout_widget = nullptr;
+    int tab_index = -1;
+    std::string name;
+  };
+
+  struct Section {
+    std::string title;
+    std::vector<std::string> step_names;
+    int active_step_index = -1;
+  };
+
+  using SectionMap = std::unordered_map<std::string, Section>;
+
+  std::unique_ptr<Ui::TutorialOverlay> ui_;
+  std::unique_ptr<QWidget> background_label_;
+  std::unordered_map<std::string, Step> steps_;
+  SectionMap sections_ = SectionMap();
+
+  SectionMap::iterator active_section_ = sections_.end();
+
+ private:
+  [[nodiscard]] Step InitializeStep(int tab_index);
+  void InitAllStepsFromUi();
+
+  void UpdateButtons();
+
+  [[nodiscard]] bool HasActiveStep() const;
+  [[nodiscard]] Step& GetActiveStep();
+  [[nodiscard]] Section& GetActiveSection();
+  [[nodiscard]] const Step& GetActiveStep() const;
+  [[nodiscard]] const Section& GetActiveSection() const;
+  [[nodiscard]] bool HasActiveSection() const { return active_section_ != sections_.end(); }
+  [[nodiscard]] bool ActiveStepIsFirstInSection() const;
+
+  void UnhookActiveStep();
+  [[nodiscard]] bool VerifyActiveStep();
+
+  void StartActiveStep();
+  [[nodiscard]] bool EndActiveStep();
+
+  [[nodiscard]] Hint DeriveHintDescription(const QRect& anchor_rect, QWidget* hint_widget) const;
+  void UpdateHintWidgetPosition(const QRect& anchor_rect, Hint& hint);
+
+  [[nodiscard]] QRect AbsoluteGeometry(QWidget* widget) const;
+
+ private Q_SLOTS:
+  void UpdateOverlayLayout();
+};
+
+#endif

--- a/OrbitQt/TutorialOverlay.ui
+++ b/OrbitQt/TutorialOverlay.ui
@@ -1,0 +1,914 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TutorialOverlay</class>
+ <widget class="QDialog" name="TutorialOverlay">
+  <property name="windowModality">
+   <enum>Qt::WindowModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>939</width>
+    <height>845</height>
+   </rect>
+  </property>
+  <property name="contextMenuPolicy">
+   <enum>Qt::NoContextMenu</enum>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <property name="windowOpacity">
+   <double>1.000000000000000</double>
+  </property>
+  <property name="styleSheet">
+   <string notr="true">QPushButton {
+	font-weight: bold;
+	font-family: Calibri;
+	font-size: 12pt;
+}
+
+QTabWidget::pane { 
+	border: 0;
+    margin: 0;
+    padding: 0;
+}
+
+QFrame {
+	border: 0;
+}
+
+QDialog {
+	padding: 0;
+	margin: 0;
+}
+
+QLabel[accessibleName=&quot;cutout&quot;] {
+	border: 10px solid #2196F3;
+}
+
+QLabel[accessibleName=&quot;hint&quot;] {
+	background: #757575;
+	color: #FFFFFF;
+	padding: 5px;
+	font-family: sans;
+	font-size: 12px;
+}
+
+QLabel[accessibleName=&quot;main&quot;] {
+	background: #2196F3;
+	color: #FFFFFF;
+	padding: 10px;
+	font-size: 12px;
+	font-family: sans;
+}</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <widget class="QTabWidget" name="tabWidget">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>881</width>
+     <height>711</height>
+    </rect>
+   </property>
+   <property name="styleSheet">
+    <string notr="true"/>
+   </property>
+   <property name="currentIndex">
+    <number>0</number>
+   </property>
+   <widget class="QWidget" name="readme">
+    <attribute name="title">
+     <string>README</string>
+    </attribute>
+    <widget class="CutoutWidget" name="borderLabel_5">
+     <property name="geometry">
+      <rect>
+       <x>60</x>
+       <y>70</y>
+       <width>171</width>
+       <height>51</height>
+      </rect>
+     </property>
+     <property name="accessibleName">
+      <string>cutout</string>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="scaledContents">
+      <bool>true</bool>
+     </property>
+    </widget>
+    <widget class="QFrame" name="frame_7">
+     <property name="geometry">
+      <rect>
+       <x>150</x>
+       <y>10</y>
+       <width>341</width>
+       <height>61</height>
+      </rect>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <widget class="QLabel" name="label_16">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>10</y>
+        <width>331</width>
+        <height>31</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="accessibleName">
+       <string>hint</string>
+      </property>
+      <property name="styleSheet">
+       <string notr="true"/>
+      </property>
+      <property name="text">
+       <string>I am a hint!</string>
+      </property>
+      <property name="scaledContents">
+       <bool>false</bool>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+      <property name="wordWrap">
+       <bool>false</bool>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_17">
+      <property name="geometry">
+       <rect>
+        <x>30</x>
+        <y>30</y>
+        <width>41</width>
+        <height>31</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string/>
+      </property>
+      <property name="pixmap">
+       <pixmap resource="../images/orbitimages.qrc">:/images/tutorial/grey_arrow_down.svg</pixmap>
+      </property>
+      <property name="scaledContents">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </widget>
+    <widget class="QFrame" name="frame_8">
+     <property name="geometry">
+      <rect>
+       <x>70</x>
+       <y>120</y>
+       <width>781</width>
+       <height>561</height>
+      </rect>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <widget class="QLabel" name="label_18">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>20</y>
+        <width>761</width>
+        <height>541</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="font">
+       <font>
+        <family>sans</family>
+        <pointsize>-1</pointsize>
+        <weight>50</weight>
+        <italic>false</italic>
+        <bold>false</bold>
+       </font>
+      </property>
+      <property name="accessibleName">
+       <string>main</string>
+      </property>
+      <property name="styleSheet">
+       <string notr="true"/>
+      </property>
+      <property name="text">
+       <string>&lt;h1&gt;Main step!&lt;/h1&gt;
+&lt;b&gt;How to create new steps&lt;/b&gt;&lt;br/&gt;
+To create a new Tutorial step, create a new tab in this TabWidget. The new step will be identified by tab name and will need to be added to a tutorial section programmatically (check tutorialoverlay.h).&lt;br/&gt;&lt;br/&gt;
+&lt;b&gt;Step contents&lt;/b&gt;&lt;br/&gt;
+On each UI tab, you can (but don't have to) place - just copy &amp;amp; paste an existing tab:
+&lt;ul&gt;
+&lt;li&gt;&lt;b&gt;ONE&lt;/b&gt;&lt;/il&gt; instance of the custom CutoutWidget.&lt;li/&gt;
+&lt;li&gt;As many additional widgets as you like&lt;/li&gt;
+&lt;/ul&gt;
+&lt;b&gt;Styling&lt;/b&gt;&lt;br/&gt;
+The main window's stylesheet uses the &lt;b&gt;accessibleName&lt;/b&gt; property of QLabels to determine styling. Check the main window's stylesheet for more info.&lt;br/&gt;&lt;br/&gt;
+&lt;b&gt;Positioning &amp;amp; anchoring&lt;/b&gt;&lt;br/&gt;
+If you do not place a CutoutWidget, feel free to position elements using a layout (the tab widget will always be 100% width/height when executed), but if you do place a CutoutWidget, positioning of all widgets is done automcatically in code as follows:
+&lt;ul&gt;&lt;li&gt;The CutoutWidget will always be moved / sized to act as a border around the AnchorWidget (which is defined in code, check the documentation). Think of the Anchor Widget as the area in Orbit that you want the user to explore in this tutorial step.&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;All&lt;/b&gt; other widgets which are &lt;b&gt;direct children&lt;/b&gt; of the tab will be moved relative to the cutout widget. In the initial placement, the corner of the cutout widget that is closest to the &lt;b&gt;top left corner&lt;/b&gt; of each widget is used as reference, and the widget will be positioned to keep it's relative distance to this reference.&lt;/li&gt;&lt;/ul&gt;
+&lt;b&gt;Example&lt;/b&gt;&lt;br/&gt;
+On this page, the hint panel will use the &lt;b&gt;top right corner&lt;/b&gt; of the cutout widget as reference. When the layout changes, the arrow will thus always point a little to the left of the cutout.&lt;br/&gt;
+The main step panel will use the &lt;b&gt;bottom left corner&lt;/b&gt; as reference, and the arrow will always point at it after layout changes.&lt;br/&gt;&lt;br/&gt;
+&lt;b&gt;Hints&lt;/b&gt;&lt;br/&gt;
+The inside of the cutout widget will be cut from the final window, so any UI elements inside it will be cut as well. Do not let your arrows point to far into the contents.&lt;br/&gt;</string>
+      </property>
+      <property name="scaledContents">
+       <bool>false</bool>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_19">
+      <property name="geometry">
+       <rect>
+        <x>20</x>
+        <y>0</y>
+        <width>41</width>
+        <height>31</height>
+       </rect>
+      </property>
+      <property name="accessibleName">
+       <string/>
+      </property>
+      <property name="text">
+       <string/>
+      </property>
+      <property name="pixmap">
+       <pixmap resource="../images/orbitimages.qrc">:/images/tutorial/blue_arrow_up.svg</pixmap>
+      </property>
+      <property name="scaledContents">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </widget>
+    <widget class="QFrame" name="frame_9">
+     <property name="geometry">
+      <rect>
+       <x>370</x>
+       <y>70</y>
+       <width>431</width>
+       <height>51</height>
+      </rect>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <property name="spacing">
+       <number>10</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="label_23">
+        <property name="accessibleName">
+         <string/>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="pixmap">
+         <pixmap resource="../images/orbitimages.qrc">:/images/tutorial/blue_arrow_up.svg</pixmap>
+        </property>
+        <property name="scaledContents">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_24">
+        <property name="accessibleName">
+         <string/>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="pixmap">
+         <pixmap resource="../images/orbitimages.qrc">:/images/tutorial/blue_arrow_down.svg</pixmap>
+        </property>
+        <property name="scaledContents">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_25">
+        <property name="accessibleName">
+         <string/>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="pixmap">
+         <pixmap resource="../images/orbitimages.qrc">:/images/tutorial/blue_arrow_left.svg</pixmap>
+        </property>
+        <property name="scaledContents">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_26">
+        <property name="accessibleName">
+         <string/>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="pixmap">
+         <pixmap resource="../images/orbitimages.qrc">:/images/tutorial/blue_arrow_right.svg</pixmap>
+        </property>
+        <property name="scaledContents">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_27">
+        <property name="accessibleName">
+         <string/>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="pixmap">
+         <pixmap resource="../images/orbitimages.qrc">:/images/tutorial/grey_arrow_up.svg</pixmap>
+        </property>
+        <property name="scaledContents">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_28">
+        <property name="accessibleName">
+         <string/>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="pixmap">
+         <pixmap resource="../images/orbitimages.qrc">:/images/tutorial/grey_arrow_down.svg</pixmap>
+        </property>
+        <property name="scaledContents">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_29">
+        <property name="accessibleName">
+         <string/>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="pixmap">
+         <pixmap resource="../images/orbitimages.qrc">:/images/tutorial/grey_arrow_left.svg</pixmap>
+        </property>
+        <property name="scaledContents">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_30">
+        <property name="accessibleName">
+         <string/>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="pixmap">
+         <pixmap resource="../images/orbitimages.qrc">:/images/tutorial/grey_arrow_right.svg</pixmap>
+        </property>
+        <property name="scaledContents">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </widget>
+   <widget class="QWidget" name="unitTest1">
+    <attribute name="title">
+     <string>Unit Testing - DO NOT CHANGE</string>
+    </attribute>
+    <widget class="QFrame" name="frame_5">
+     <property name="geometry">
+      <rect>
+       <x>200</x>
+       <y>110</y>
+       <width>441</width>
+       <height>111</height>
+      </rect>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <widget class="QLabel" name="label_12">
+      <property name="geometry">
+       <rect>
+        <x>20</x>
+        <y>20</y>
+        <width>401</width>
+        <height>71</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="font">
+       <font>
+        <family>sans</family>
+        <pointsize>-1</pointsize>
+        <weight>50</weight>
+        <italic>false</italic>
+        <bold>false</bold>
+       </font>
+      </property>
+      <property name="accessibleName">
+       <string>main</string>
+      </property>
+      <property name="styleSheet">
+       <string notr="true"/>
+      </property>
+      <property name="text">
+       <string>&lt;h1&gt;Test&lt;/h1&gt;</string>
+      </property>
+      <property name="scaledContents">
+       <bool>false</bool>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+      <property name="wordWrap">
+       <bool>false</bool>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_31">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>30</y>
+        <width>45</width>
+        <height>51</height>
+       </rect>
+      </property>
+      <property name="accessibleName">
+       <string/>
+      </property>
+      <property name="text">
+       <string/>
+      </property>
+      <property name="pixmap">
+       <pixmap resource="../images/orbitimages.qrc">:/images/tutorial/blue_arrow_left.svg</pixmap>
+      </property>
+      <property name="scaledContents">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </widget>
+    <widget class="CutoutWidget" name="borderLabel_3">
+     <property name="geometry">
+      <rect>
+       <x>50</x>
+       <y>40</y>
+       <width>151</width>
+       <height>131</height>
+      </rect>
+     </property>
+     <property name="accessibleName">
+      <string>cutout</string>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="scaledContents">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </widget>
+   <widget class="QWidget" name="unitTest2">
+    <attribute name="title">
+     <string>Unit Testing - DO NOT CHANGE</string>
+    </attribute>
+    <widget class="QFrame" name="frame_6">
+     <property name="geometry">
+      <rect>
+       <x>210</x>
+       <y>40</y>
+       <width>431</width>
+       <height>111</height>
+      </rect>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <widget class="QLabel" name="label_14">
+      <property name="geometry">
+       <rect>
+        <x>20</x>
+        <y>30</y>
+        <width>401</width>
+        <height>71</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="font">
+       <font>
+        <family>sans</family>
+        <pointsize>-1</pointsize>
+        <weight>50</weight>
+        <italic>false</italic>
+        <bold>false</bold>
+       </font>
+      </property>
+      <property name="accessibleName">
+       <string>main</string>
+      </property>
+      <property name="styleSheet">
+       <string notr="true"/>
+      </property>
+      <property name="text">
+       <string>&lt;h1&gt;Test&lt;/h1&gt;</string>
+      </property>
+      <property name="scaledContents">
+       <bool>false</bool>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+      <property name="wordWrap">
+       <bool>false</bool>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_32">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>50</y>
+        <width>45</width>
+        <height>51</height>
+       </rect>
+      </property>
+      <property name="accessibleName">
+       <string/>
+      </property>
+      <property name="text">
+       <string/>
+      </property>
+      <property name="pixmap">
+       <pixmap resource="../images/orbitimages.qrc">:/images/tutorial/blue_arrow_left.svg</pixmap>
+      </property>
+      <property name="scaledContents">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </widget>
+    <widget class="CutoutWidget" name="borderLabel_4">
+     <property name="geometry">
+      <rect>
+       <x>60</x>
+       <y>110</y>
+       <width>151</width>
+       <height>131</height>
+      </rect>
+     </property>
+     <property name="accessibleName">
+      <string>cutout</string>
+     </property>
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="scaledContents">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </widget>
+  </widget>
+  <widget class="QPushButton" name="btnClose">
+   <property name="geometry">
+    <rect>
+     <x>880</x>
+     <y>20</y>
+     <width>51</width>
+     <height>51</height>
+    </rect>
+   </property>
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
+   <property name="minimumSize">
+    <size>
+     <width>0</width>
+     <height>0</height>
+    </size>
+   </property>
+   <property name="styleSheet">
+    <string notr="true"/>
+   </property>
+   <property name="text">
+    <string/>
+   </property>
+   <property name="icon">
+    <iconset resource="../icons/orbiticons.qrc">
+     <normaloff>:/actions/clear</normaloff>:/actions/clear</iconset>
+   </property>
+   <property name="flat">
+    <bool>false</bool>
+   </property>
+  </widget>
+  <widget class="QFrame" name="titleFrame">
+   <property name="geometry">
+    <rect>
+     <x>150</x>
+     <y>760</y>
+     <width>661</width>
+     <height>73</height>
+    </rect>
+   </property>
+   <property name="styleSheet">
+    <string notr="true">QFrame {
+	border: 0;
+}</string>
+   </property>
+   <property name="frameShape">
+    <enum>QFrame::StyledPanel</enum>
+   </property>
+   <property name="frameShadow">
+    <enum>QFrame::Raised</enum>
+   </property>
+   <layout class="QHBoxLayout" name="horizontalLayout">
+    <item>
+     <spacer name="horizontalSpacer">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>40</width>
+        <height>20</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+    <item>
+     <widget class="QPushButton" name="btnPrev">
+      <property name="minimumSize">
+       <size>
+        <width>50</width>
+        <height>50</height>
+       </size>
+      </property>
+      <property name="font">
+       <font>
+        <family>Calibri</family>
+        <pointsize>12</pointsize>
+        <weight>75</weight>
+        <bold>true</bold>
+       </font>
+      </property>
+      <property name="styleSheet">
+       <string notr="true"/>
+      </property>
+      <property name="text">
+       <string/>
+      </property>
+      <property name="icon">
+       <iconset resource="../icons/orbiticons.qrc">
+        <normaloff>:/actions/keyboard_arrow_left</normaloff>:/actions/keyboard_arrow_left</iconset>
+      </property>
+      <property name="flat">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QLabel" name="labelStep">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>50</height>
+       </size>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">background: #43a047;
+font: 24pt 'Caveat';
+color: #000000;
+padding: 5px 15px 5px 15px;</string>
+      </property>
+      <property name="text">
+       <string>Taking a Capture: 1/3</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QPushButton" name="btnNext">
+      <property name="minimumSize">
+       <size>
+        <width>50</width>
+        <height>50</height>
+       </size>
+      </property>
+      <property name="font">
+       <font>
+        <family>Calibri</family>
+        <pointsize>12</pointsize>
+        <weight>75</weight>
+        <bold>true</bold>
+       </font>
+      </property>
+      <property name="styleSheet">
+       <string notr="true"/>
+      </property>
+      <property name="text">
+       <string/>
+      </property>
+      <property name="icon">
+       <iconset resource="../icons/orbiticons.qrc">
+        <normaloff>:/actions/keyboard_arrow_right</normaloff>:/actions/keyboard_arrow_right</iconset>
+      </property>
+      <property name="flat">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <spacer name="horizontalSpacer_2">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>40</width>
+        <height>20</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>CutoutWidget</class>
+   <extends>QLabel</extends>
+   <header>CutoutWidget.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources>
+  <include location="../images/orbitimages.qrc"/>
+  <include location="../icons/orbiticons.qrc"/>
+ </resources>
+ <connections>
+  <connection>
+   <sender>btnClose</sender>
+   <signal>clicked()</signal>
+   <receiver>TutorialOverlay</receiver>
+   <slot>close()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>970</x>
+     <y>880</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>506</x>
+     <y>457</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>btnNext</sender>
+   <signal>clicked()</signal>
+   <receiver>TutorialOverlay</receiver>
+   <slot>NextStep()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>896</x>
+     <y>880</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>506</x>
+     <y>457</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>btnPrev</sender>
+   <signal>clicked()</signal>
+   <receiver>TutorialOverlay</receiver>
+   <slot>PrevStep()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>272</x>
+     <y>796</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>444</x>
+     <y>422</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+ <slots>
+  <slot>NextStep()</slot>
+  <slot>PrevStep()</slot>
+ </slots>
+</ui>

--- a/OrbitQt/TutorialOverlayTest.cpp
+++ b/OrbitQt/TutorialOverlayTest.cpp
@@ -1,0 +1,155 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <QApplication>
+#include <QPushButton>
+
+#include "TutorialOverlay.h"
+#include "gtest/gtest.h"
+
+static int argc = 0;
+
+// TODO: These tests use the actual Tutorial UI and can be broken
+// by updating this UI... it should use a dedicated unit testing UI
+
+TEST(TutorialOverlay, StepExists) {
+  QApplication app(argc, nullptr);
+  auto overlay = std::make_unique<TutorialOverlay>(nullptr);
+
+  // Check if StepExists works, and implicitely check if the UI file
+  // is correctly setup for unit tests. If this failes, a lot of other
+  // tests will also fail!
+  EXPECT_TRUE(overlay->StepExists("unitTest1"));
+  EXPECT_TRUE(overlay->StepExists("unitTest2"));
+  EXPECT_FALSE(overlay->StepExists("unitTest3"));
+}
+
+TEST(TutorialOverlay, SetupSections) {
+  QApplication app(argc, nullptr);
+  auto overlay = std::make_unique<TutorialOverlay>(nullptr);
+
+  overlay->AddSection("unitTest", "Unit Testing", {"unitTest1", "unitTest2"});
+  overlay->StartSection("unitTest");
+  EXPECT_EQ(overlay->GetActiveSectionName(), "unitTest");
+  EXPECT_EQ(overlay->GetActiveStepName(), "unitTest1");
+}
+
+TEST(TutorialOverlay, callbackSuccess) {
+  QApplication app(argc, nullptr);
+  auto overlay = std::make_unique<TutorialOverlay>(nullptr);
+
+  std::map<std::string, int> init_count{std::make_pair<std::string, int>("unitTest1", 0),
+                                        std::make_pair<std::string, int>("unitTest2", 0)};
+  std::map<std::string, int> verify_count = init_count;
+  std::map<std::string, int> teardown_count = init_count;
+
+  TutorialOverlay::StepSetup setup;
+  setup.callback_init = [&](TutorialOverlay*, const std::string& step) { init_count[step]++; };
+  setup.callback_verify = [&](TutorialOverlay*,
+                              const std::string& step) -> std::optional<std::string> {
+    verify_count[step]++;
+    return std::nullopt;
+  };
+  setup.callback_teardown = [&](TutorialOverlay*, const std::string& step) {
+    teardown_count[step]++;
+  };
+
+  overlay->SetupStep("unitTest1", setup);
+  overlay->SetupStep("unitTest2", setup);
+
+  overlay->AddSection("unitTest", "Unit Testing", {"unitTest1", "unitTest2"});
+  overlay->StartSection("unitTest");
+
+  EXPECT_EQ(overlay->GetActiveStepName(), "unitTest1");
+  EXPECT_EQ(init_count["unitTest1"], 1);
+  EXPECT_EQ(verify_count["unitTest1"], 0);
+
+  overlay->NextStep();
+
+  EXPECT_EQ(overlay->GetActiveStepName(), "unitTest2");
+  EXPECT_EQ(init_count["unitTest2"], 1);
+  EXPECT_EQ(verify_count["unitTest1"], 1);
+  EXPECT_EQ(teardown_count["unitTest1"], 1);
+
+  overlay->PrevStep();
+
+  EXPECT_EQ(overlay->GetActiveStepName(), "unitTest1");
+  EXPECT_EQ(init_count["unitTest2"], 1);
+  EXPECT_EQ(teardown_count["unitTest2"], 1);
+  EXPECT_EQ(init_count["unitTest1"], 2);
+
+  overlay->close();
+  EXPECT_EQ(teardown_count["unitTest1"], 2);
+}
+
+TEST(TutorialOverlay, CallbackFail) {
+  QApplication app(argc, nullptr);
+  auto overlay = std::make_unique<TutorialOverlay>(nullptr);
+
+  TutorialOverlay::StepSetup setup{
+      nullptr, nullptr, nullptr,
+      [&](TutorialOverlay*, const std::string&) -> std::optional<std::string> {
+        return "You did not complete this step correctly.";
+      }};
+  overlay->SetupStep("unitTest1", setup);
+
+  overlay->AddSection("unitTest", "Unit Testing", {"unitTest1", "unitTest2"});
+  overlay->StartSection("unitTest");
+  EXPECT_EQ(overlay->GetActiveStepName(), "unitTest1");
+  overlay->NextStep();
+  EXPECT_EQ(overlay->GetActiveStepName(), "unitTest1");
+}
+
+TEST(TutorialOverlay, SignalsAndSlots) {
+  QApplication app(argc, nullptr);
+  auto overlay = std::make_unique<TutorialOverlay>(nullptr);
+
+  auto button = std::make_unique<QPushButton>();
+
+  TutorialOverlay::StepSetup setup;
+  setup.callback_init = [&button](TutorialOverlay* overlay, const std::string&) {
+    QObject::connect(button.get(), &QPushButton::clicked, overlay, &TutorialOverlay::NextStep);
+  };
+  setup.callback_teardown = [&button](TutorialOverlay* overlay, const std::string&) {
+    QObject::disconnect(button.get(), &QPushButton::clicked, overlay, &TutorialOverlay::NextStep);
+  };
+  overlay->SetupStep("unitTest1", setup);
+
+  // Clicking the button initially should not do anything - connect() happens on
+  // initialization of step 0
+  emit button->clicked();
+  EXPECT_EQ(overlay->GetActiveStepName(), "");
+
+  overlay->AddSection("unitTest", "Unit Testing", {"unitTest1", "unitTest2"});
+  overlay->StartSection("unitTest");
+  EXPECT_EQ(overlay->GetActiveStepName(), "unitTest1");
+
+  emit button->clicked();
+  EXPECT_EQ(overlay->GetActiveStepName(), "unitTest2");
+
+  // Clicking the button again should not do anything - the slot is disconnected
+  // on teardown of step 0
+  emit button->clicked();
+  EXPECT_EQ(overlay->GetActiveStepName(), "unitTest2");
+
+  bool completed = false;
+  QObject::connect(overlay.get(), &TutorialOverlay::SectionCompleted,
+                   [&completed] { completed = true; });
+  overlay->NextStep();
+  EXPECT_TRUE(completed);
+}
+
+TEST(TutorialOverlay, FailTests) {
+  QApplication app(argc, nullptr);
+  auto overlay = std::make_unique<TutorialOverlay>(nullptr);
+  EXPECT_DEATH({ overlay->SetupStep("xx_invalid_step_name_xx", {}); }, "Check failed");
+  EXPECT_DEATH({ overlay->AddSection("test", "Unit Testing", {"xx_invalid_step_name_xx"}); },
+               "Check failed");
+  EXPECT_DEATH({ overlay->StartSection("invalid_section"); }, "Check failed");
+
+  overlay->NextStep();
+  EXPECT_EQ(overlay->GetActiveStepName(), "");
+  overlay->PrevStep();
+  EXPECT_EQ(overlay->GetActiveStepName(), "");
+}

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -27,6 +27,7 @@
 #include "SamplingReport.h"
 #include "StatusListenerImpl.h"
 #include "TopDownViewItemModel.h"
+#include "TutorialOverlay.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_format.h"
 #include "orbitaboutdialog.h"
@@ -205,17 +206,13 @@ static QWidget* CreateSpacer(QWidget* parent) {
   return spacer;
 }
 
-[[nodiscard]] static QIcon GetIcon(const std::string& icon_name) {
-  return QIcon(Path::JoinPath({Path::GetIconsPath(), icon_name}).c_str());
-}
-
 void OrbitMainWindow::SetupCaptureToolbar() {
   // Sizes.
   QToolBar* toolbar = ui->capture_toolbar;
 
   // Create missing icons
-  icon_start_capture_ = GetIcon("outline_play_arrow_white_48dp.png");
-  icon_stop_capture_ = GetIcon("outline_stop_white_48dp.png");
+  icon_start_capture_ = QIcon(":/actions/outline_play_arrow_white_48dp.png");
+  icon_stop_capture_ = QIcon(":/actions/outline_stop_white_48dp.png");
 
   // Attach the filter panel to the toolbar
   toolbar->addWidget(CreateSpacer(toolbar));

--- a/OrbitQt/orbitmainwindow.ui
+++ b/OrbitQt/orbitmainwindow.ui
@@ -614,6 +614,7 @@ QPushButton:disabled {
  </customwidgets>
  <resources>
   <include location="../icons/orbiticons.qrc"/>
+  <include location="../fonts/orbitfonts.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/images/orbitimages.qrc
+++ b/images/orbitimages.qrc
@@ -1,0 +1,12 @@
+<RCC>
+  <qresource prefix="/images">
+    <file>tutorial/blue_arrow_down.svg</file>
+    <file>tutorial/blue_arrow_left.svg</file>
+    <file>tutorial/blue_arrow_right.svg</file>
+    <file>tutorial/grey_arrow_down.svg</file>
+    <file>tutorial/grey_arrow_left.svg</file>
+    <file>tutorial/grey_arrow_right.svg</file>
+    <file>tutorial/grey_arrow_up.svg</file>
+    <file>tutorial/blue_arrow_up.svg</file>
+  </qresource>
+</RCC>

--- a/images/tutorial/blue_arrow_down.svg
+++ b/images/tutorial/blue_arrow_down.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="blue_arrow_down.svg"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   id="svg845"
+   version="1.1"
+   viewBox="0 0 11.339286 7.9375001"
+   height="7.9375mm"
+   width="11.339286mm">
+  <defs
+     id="defs839">
+    <inkscape:path-effect
+       end_linecap_type="zerowidth"
+       scale_width="1"
+       miter_limit="4"
+       linejoin_type="extrp_arc"
+       start_linecap_type="zerowidth"
+       interpolator_beta="0.2"
+       interpolator_type="CubicBezierJohan"
+       sort_points="true"
+       offset_points="0,0.028348175"
+       lpeversion="1"
+       is_visible="true"
+       id="path-effect1412"
+       effect="powerstroke" />
+  </defs>
+  <sodipodi:namedview
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     showgrid="true"
+     inkscape:document-rotation="0"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="mm"
+     inkscape:cy="14.68724"
+     inkscape:cx="25.852831"
+     inkscape:zoom="5.6"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base">
+    <inkscape:grid
+       originy="0"
+       originx="-9.4000001e-06"
+       id="grid1408"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata842">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:original-d="M 11.339288,2.1e-6 5.6696463,7.9375 2.4e-6,0 Z"
+       inkscape:path-effect="#path-effect1412"
+       id="path1410"
+       d="M 11.339288,2.1e-6 5.6696463,7.9375 2.4e-6,0 Z"
+       style="fill:#2196f3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.0566963px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+</svg>

--- a/images/tutorial/blue_arrow_left.svg
+++ b/images/tutorial/blue_arrow_left.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="blue_arrow_left.svg"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   id="svg845"
+   version="1.1"
+   viewBox="0 0 7.9375001 11.339286"
+   height="11.339286mm"
+   width="7.9375mm">
+  <defs
+     id="defs839">
+    <inkscape:path-effect
+       end_linecap_type="zerowidth"
+       scale_width="1"
+       miter_limit="4"
+       linejoin_type="extrp_arc"
+       start_linecap_type="zerowidth"
+       interpolator_beta="0.2"
+       interpolator_type="CubicBezierJohan"
+       sort_points="true"
+       offset_points="0,0.028348175"
+       lpeversion="1"
+       is_visible="true"
+       id="path-effect1412"
+       effect="powerstroke" />
+  </defs>
+  <sodipodi:namedview
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     showgrid="true"
+     inkscape:document-rotation="0"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="mm"
+     inkscape:cy="21.115811"
+     inkscape:cx="19.424251"
+     inkscape:zoom="5.6"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base">
+    <inkscape:grid
+       originy="1.7008928"
+       originx="-1.7009046"
+       id="grid1408"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata842">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-1.7008952,1.7008928)"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:original-d="m 9.6383931,9.6383928 -7.9374979,-5.6696417 7.9375,-5.6696439 z"
+       inkscape:path-effect="#path-effect1412"
+       id="path1410"
+       d="m 9.6383931,9.6383928 -7.9374979,-5.6696417 7.9375,-5.6696439 z"
+       style="fill:#2196f3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.0566963px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+</svg>

--- a/images/tutorial/blue_arrow_right.svg
+++ b/images/tutorial/blue_arrow_right.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="blue_arrow_right.svg"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   id="svg845"
+   version="1.1"
+   viewBox="0 0 7.9375001 11.339286"
+   height="11.339286mm"
+   width="7.9375mm">
+  <defs
+     id="defs839">
+    <inkscape:path-effect
+       end_linecap_type="zerowidth"
+       scale_width="1"
+       miter_limit="4"
+       linejoin_type="extrp_arc"
+       start_linecap_type="zerowidth"
+       interpolator_beta="0.2"
+       interpolator_type="CubicBezierJohan"
+       sort_points="true"
+       offset_points="0,0.028348175"
+       lpeversion="1"
+       is_visible="true"
+       id="path-effect1412"
+       effect="powerstroke" />
+  </defs>
+  <sodipodi:namedview
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     showgrid="true"
+     inkscape:document-rotation="0"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="mm"
+     inkscape:cy="21.115811"
+     inkscape:cx="19.42426"
+     inkscape:zoom="5.6"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base">
+    <inkscape:grid
+       originy="1.7008928"
+       originx="-1.7009022"
+       id="grid1408"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata842">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-1.7008952,1.7008928)"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:original-d="m 1.7008973,-1.7008928 7.9374979,5.6696417 -7.9375,5.6696439 z"
+       inkscape:path-effect="#path-effect1412"
+       id="path1410"
+       d="m 1.7008973,-1.7008928 7.9374979,5.6696417 -7.9375,5.6696439 z"
+       style="fill:#2196f3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.0566963px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+</svg>

--- a/images/tutorial/blue_arrow_up.svg
+++ b/images/tutorial/blue_arrow_up.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="blue_arrow_up.svg"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   id="svg845"
+   version="1.1"
+   viewBox="0 0 11.339286 7.9374998"
+   height="7.9375mm"
+   width="11.339286mm">
+  <defs
+     id="defs839">
+    <inkscape:path-effect
+       end_linecap_type="zerowidth"
+       scale_width="1"
+       miter_limit="4"
+       linejoin_type="extrp_arc"
+       start_linecap_type="zerowidth"
+       interpolator_beta="0.2"
+       interpolator_type="CubicBezierJohan"
+       sort_points="true"
+       offset_points="0,0.028348175"
+       lpeversion="1"
+       is_visible="true"
+       id="path-effect1412"
+       effect="powerstroke" />
+  </defs>
+  <sodipodi:namedview
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     showgrid="true"
+     inkscape:document-rotation="0"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="mm"
+     inkscape:cy="14.68724"
+     inkscape:cx="25.852841"
+     inkscape:zoom="5.6"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base">
+    <inkscape:grid
+       originy="0"
+       originx="-7.0000001e-06"
+       id="grid1408"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata842">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:original-d="M 2.3333333e-6,7.9374979 5.6696441,0 11.339288,7.9375 Z"
+       inkscape:path-effect="#path-effect1412"
+       id="path1410"
+       d="M 2.3333333e-6,7.9374979 5.6696441,0 11.339288,7.9375 Z"
+       style="fill:#2196f3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.0566963px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+</svg>

--- a/images/tutorial/grey_arrow_down.svg
+++ b/images/tutorial/grey_arrow_down.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="grey_arrow_down.svg"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   id="svg845"
+   version="1.1"
+   viewBox="0 0 11.339286 7.9375001"
+   height="7.9375mm"
+   width="11.339286mm">
+  <defs
+     id="defs839">
+    <inkscape:path-effect
+       end_linecap_type="zerowidth"
+       scale_width="1"
+       miter_limit="4"
+       linejoin_type="extrp_arc"
+       start_linecap_type="zerowidth"
+       interpolator_beta="0.2"
+       interpolator_type="CubicBezierJohan"
+       sort_points="true"
+       offset_points="0,0.028348175"
+       lpeversion="1"
+       is_visible="true"
+       id="path-effect1412"
+       effect="powerstroke" />
+  </defs>
+  <sodipodi:namedview
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     showgrid="true"
+     inkscape:document-rotation="0"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="mm"
+     inkscape:cy="14.68724"
+     inkscape:cx="25.852822"
+     inkscape:zoom="5.6"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base">
+    <inkscape:grid
+       originy="0"
+       originx="-1.18e-05"
+       id="grid1408"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata842">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:original-d="M 11.339288,2.1e-6 5.6696463,7.9375 2.4e-6,0 Z"
+       inkscape:path-effect="#path-effect1412"
+       id="path1410"
+       d="M 11.339288,2.1e-6 5.6696463,7.9375 2.4e-6,0 Z"
+       style="fill:#757575;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.0566963px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+</svg>

--- a/images/tutorial/grey_arrow_left.svg
+++ b/images/tutorial/grey_arrow_left.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="grey_arrow_left.svg"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   id="svg845"
+   version="1.1"
+   viewBox="0 0 7.9375001 11.339286"
+   height="11.339286mm"
+   width="7.9375mm">
+  <defs
+     id="defs839">
+    <inkscape:path-effect
+       end_linecap_type="zerowidth"
+       scale_width="1"
+       miter_limit="4"
+       linejoin_type="extrp_arc"
+       start_linecap_type="zerowidth"
+       interpolator_beta="0.2"
+       interpolator_type="CubicBezierJohan"
+       sort_points="true"
+       offset_points="0,0.028348175"
+       lpeversion="1"
+       is_visible="true"
+       id="path-effect1412"
+       effect="powerstroke" />
+  </defs>
+  <sodipodi:namedview
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     showgrid="true"
+     inkscape:document-rotation="0"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="mm"
+     inkscape:cy="21.115811"
+     inkscape:cx="19.424251"
+     inkscape:zoom="5.6"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base">
+    <inkscape:grid
+       originy="1.7008928"
+       originx="-1.7009046"
+       id="grid1408"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata842">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-1.7008952,1.7008928)"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:original-d="m 9.6383931,9.6383928 -7.9374979,-5.6696417 7.9375,-5.6696439 z"
+       inkscape:path-effect="#path-effect1412"
+       id="path1410"
+       d="m 9.6383931,9.6383928 -7.9374979,-5.6696417 7.9375,-5.6696439 z"
+       style="fill:#757575;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.0566963px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+</svg>

--- a/images/tutorial/grey_arrow_right.svg
+++ b/images/tutorial/grey_arrow_right.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="grey_arrow_right.svg"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   id="svg845"
+   version="1.1"
+   viewBox="0 0 7.9375001 11.339286"
+   height="11.339286mm"
+   width="7.9375mm">
+  <defs
+     id="defs839">
+    <inkscape:path-effect
+       end_linecap_type="zerowidth"
+       scale_width="1"
+       miter_limit="4"
+       linejoin_type="extrp_arc"
+       start_linecap_type="zerowidth"
+       interpolator_beta="0.2"
+       interpolator_type="CubicBezierJohan"
+       sort_points="true"
+       offset_points="0,0.028348175"
+       lpeversion="1"
+       is_visible="true"
+       id="path-effect1412"
+       effect="powerstroke" />
+  </defs>
+  <sodipodi:namedview
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     showgrid="true"
+     inkscape:document-rotation="0"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="mm"
+     inkscape:cy="21.115811"
+     inkscape:cx="19.424242"
+     inkscape:zoom="5.6"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base">
+    <inkscape:grid
+       originy="1.7008928"
+       originx="-1.700907"
+       id="grid1408"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata842">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-1.7008952,1.7008928)"
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:original-d="m 1.7008973,-1.7008928 7.9374979,5.6696417 -7.9375,5.6696439 z"
+       inkscape:path-effect="#path-effect1412"
+       id="path1410"
+       d="m 1.7008973,-1.7008928 7.9374979,5.6696417 -7.9375,5.6696439 z"
+       style="fill:#757575;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.0566963px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+</svg>

--- a/images/tutorial/grey_arrow_up.svg
+++ b/images/tutorial/grey_arrow_up.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="grey_arrow_up.svg"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   id="svg845"
+   version="1.1"
+   viewBox="0 0 11.339286 7.9375001"
+   height="7.9375mm"
+   width="11.339286mm">
+  <defs
+     id="defs839">
+    <inkscape:path-effect
+       end_linecap_type="zerowidth"
+       scale_width="1"
+       miter_limit="4"
+       linejoin_type="extrp_arc"
+       start_linecap_type="zerowidth"
+       interpolator_beta="0.2"
+       interpolator_type="CubicBezierJohan"
+       sort_points="true"
+       offset_points="0,0.028348175"
+       lpeversion="1"
+       is_visible="true"
+       id="path-effect1412"
+       effect="powerstroke" />
+  </defs>
+  <sodipodi:namedview
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     showgrid="true"
+     inkscape:document-rotation="0"
+     inkscape:current-layer="layer1"
+     inkscape:document-units="mm"
+     inkscape:cy="14.68724"
+     inkscape:cx="25.852813"
+     inkscape:zoom="5.6"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base">
+    <inkscape:grid
+       originy="0"
+       originx="-1.42e-05"
+       id="grid1408"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata842">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1">
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:original-d="M 2.4e-6,7.9374979 5.6696441,0 11.339288,7.9375 Z"
+       inkscape:path-effect="#path-effect1412"
+       id="path1410"
+       d="M 2.4e-6,7.9374979 5.6696441,0 11.339288,7.9375 Z"
+       style="fill:#757575;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.0566963px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+</svg>


### PR DESCRIPTION
**Tutorial basics and resources**

_Note: Do not review this commit-by-commit, it contains a final "cleanup" commit that removes all intermediate changes done to the application._

Added a framework to create interactive tutorials (tutorialoverlay.h). Documentation on how to create new tutorials can be found there, and in the accompanying UI file (tutorialoverlay.ui).

Also added a bunch of resources used by the tutorial system, as well as some yet unused but potentially usefull.

Note that the design is still preliminary, we probably want to change that in the future - especially the border around the highlighted widget isn't perfect.

**Examples**

How it looks in Orbit:
![image](https://user-images.githubusercontent.com/63750742/91281849-d7c80580-e788-11ea-8b8b-6321df86d8ce.png)

Creating new steps in the QT Designer:
![image](https://user-images.githubusercontent.com/63750742/91281903-e4e4f480-e788-11ea-814b-c7da86baf5a0.png)
