### PR TITLE
Fix crash on preset loading.

### DIFF
--- a/OrbitGl/DataManager.cpp
+++ b/OrbitGl/DataManager.cpp
@@ -40,8 +40,9 @@ void DataManager::UpdateModuleInfos(int32_t process_id,
 
 void DataManager::SelectFunction(uint64_t function_address) {
   CHECK(std::this_thread::get_id() == main_thread_id_);
-  CHECK(!selected_functions_.contains(function_address));
-  selected_functions_.insert(function_address);
+  if (!selected_functions_.contains(function_address)) {
+    selected_functions_.insert(function_address);
+  }
 }
 
 void DataManager::DeselectFunction(uint64_t function_address) {


### PR DESCRIPTION
Hooking a already hooked function CHECK-fails. I think it is just fine
to ignore any duplicates.

BUG: b/166424640
TEST: Run locally, does not crash anymore.