### PR TITLE
Ignore Missing-PDB-File Linker warning on Windows

### DIFF
--- a/third_party/conan/configs/windows/profiles/msvc2017_debug
+++ b/third_party/conan/configs/windows/profiles/msvc2017_debug
@@ -1,4 +1,4 @@
-LINKER_FLAGS=/FIXED:NO
+LINKER_FLAGS=/FIXED:NO /ignore:4099
 [settings]
 os=Windows
 os_build=Windows

--- a/third_party/conan/configs/windows/profiles/msvc2017_debug_x64
+++ b/third_party/conan/configs/windows/profiles/msvc2017_debug_x64
@@ -1,3 +1,4 @@
+LINKER_FLAGS=/FIXED:NO /ignore:4099
 [settings]
 os=Windows
 os_build=Windows
@@ -12,3 +13,4 @@ OrbitProfiler:system_qt=False
 cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2017_debug_x86
+++ b/third_party/conan/configs/windows/profiles/msvc2017_debug_x86
@@ -1,4 +1,4 @@
-LINKER_FLAGS=/FIXED:NO
+LINKER_FLAGS=/FIXED:NO /ignore:4099
 [settings]
 os=Windows
 os_build=Windows

--- a/third_party/conan/configs/windows/profiles/msvc2017_release
+++ b/third_party/conan/configs/windows/profiles/msvc2017_release
@@ -1,4 +1,4 @@
-LINKER_FLAGS=/FIXED:NO
+LINKER_FLAGS=/FIXED:NO /ignore:4099
 [settings]
 os=Windows
 os_build=Windows

--- a/third_party/conan/configs/windows/profiles/msvc2017_release_x64
+++ b/third_party/conan/configs/windows/profiles/msvc2017_release_x64
@@ -1,3 +1,4 @@
+LINKER_FLAGS=/FIXED:NO /ignore:4099
 [settings]
 os=Windows
 os_build=Windows
@@ -12,3 +13,4 @@ OrbitProfiler:system_qt=False
 cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2017_release_x86
+++ b/third_party/conan/configs/windows/profiles/msvc2017_release_x86
@@ -1,4 +1,4 @@
-LINKER_FLAGS=/FIXED:NO
+LINKER_FLAGS=/FIXED:NO /ignore:4099
 [settings]
 os=Windows
 os_build=Windows

--- a/third_party/conan/configs/windows/profiles/msvc2017_relwithdebinfo
+++ b/third_party/conan/configs/windows/profiles/msvc2017_relwithdebinfo
@@ -1,4 +1,4 @@
-LINKER_FLAGS=/FIXED:NO
+LINKER_FLAGS=/FIXED:NO /ignore:4099
 [settings]
 os=Windows
 os_build=Windows

--- a/third_party/conan/configs/windows/profiles/msvc2017_relwithdebinfo_x64
+++ b/third_party/conan/configs/windows/profiles/msvc2017_relwithdebinfo_x64
@@ -1,3 +1,4 @@
+LINKER_FLAGS=/FIXED:NO /ignore:4099
 [settings]
 os=Windows
 os_build=Windows
@@ -12,3 +13,4 @@ OrbitProfiler:system_qt=False
 cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2017_relwithdebinfo_x86
+++ b/third_party/conan/configs/windows/profiles/msvc2017_relwithdebinfo_x86
@@ -1,4 +1,4 @@
-LINKER_FLAGS=/FIXED:NO
+LINKER_FLAGS=/FIXED:NO /ignore:4099
 [settings]
 os=Windows
 os_build=Windows

--- a/third_party/conan/configs/windows/profiles/msvc2019_debug
+++ b/third_party/conan/configs/windows/profiles/msvc2019_debug
@@ -1,4 +1,4 @@
-LINKER_FLAGS=/FIXED:NO
+LINKER_FLAGS=/FIXED:NO /ignore:4099
 [settings]
 os=Windows
 os_build=Windows

--- a/third_party/conan/configs/windows/profiles/msvc2019_debug_x64
+++ b/third_party/conan/configs/windows/profiles/msvc2019_debug_x64
@@ -1,3 +1,4 @@
+LINKER_FLAGS=/FIXED:NO /ignore:4099
 [settings]
 os=Windows
 os_build=Windows
@@ -12,3 +13,4 @@ OrbitProfiler:system_qt=False
 cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2019_debug_x86
+++ b/third_party/conan/configs/windows/profiles/msvc2019_debug_x86
@@ -1,4 +1,4 @@
-LINKER_FLAGS=/FIXED:NO
+LINKER_FLAGS=/FIXED:NO /ignore:4099
 [settings]
 os=Windows
 os_build=Windows

--- a/third_party/conan/configs/windows/profiles/msvc2019_release
+++ b/third_party/conan/configs/windows/profiles/msvc2019_release
@@ -1,4 +1,4 @@
-LINKER_FLAGS=/FIXED:NO
+LINKER_FLAGS=/FIXED:NO /ignore:4099
 [settings]
 os=Windows
 os_build=Windows

--- a/third_party/conan/configs/windows/profiles/msvc2019_release_x64
+++ b/third_party/conan/configs/windows/profiles/msvc2019_release_x64
@@ -1,3 +1,4 @@
+LINKER_FLAGS=/FIXED:NO /ignore:4099
 [settings]
 os=Windows
 os_build=Windows
@@ -12,3 +13,4 @@ OrbitProfiler:system_qt=False
 cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2019_release_x86
+++ b/third_party/conan/configs/windows/profiles/msvc2019_release_x86
@@ -1,4 +1,4 @@
-LINKER_FLAGS=/FIXED:NO
+LINKER_FLAGS=/FIXED:NO /ignore:4099
 [settings]
 os=Windows
 os_build=Windows

--- a/third_party/conan/configs/windows/profiles/msvc2019_relwithdebinfo
+++ b/third_party/conan/configs/windows/profiles/msvc2019_relwithdebinfo
@@ -1,4 +1,4 @@
-LINKER_FLAGS=/FIXED:NO
+LINKER_FLAGS=/FIXED:NO /ignore:4099
 [settings]
 os=Windows
 os_build=Windows

--- a/third_party/conan/configs/windows/profiles/msvc2019_relwithdebinfo_x64
+++ b/third_party/conan/configs/windows/profiles/msvc2019_relwithdebinfo_x64
@@ -1,3 +1,4 @@
+LINKER_FLAGS=/FIXED:NO /ignore:4099
 [settings]
 os=Windows
 os_build=Windows
@@ -12,3 +13,4 @@ OrbitProfiler:system_qt=False
 cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
+LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2019_relwithdebinfo_x86
+++ b/third_party/conan/configs/windows/profiles/msvc2019_relwithdebinfo_x86
@@ -1,4 +1,4 @@
-LINKER_FLAGS=/FIXED:NO
+LINKER_FLAGS=/FIXED:NO /ignore:4099
 [settings]
 os=Windows
 os_build=Windows

--- a/third_party/conan/lockfiles/windows/msvc2017_debug/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2017_debug/conan.lock
@@ -1,5 +1,5 @@
 {
- "profile_host": "[settings]\narch=x86_64\narch_build=x86_64\nbuild_type=Debug\ncompiler=Visual Studio\ncompiler.runtime=MDd\ncompiler.version=15\nos=Windows\nos_build=Windows\n[options]\nOrbitProfiler:system_qt=False\n[build_requires]\n*: cmake_installer/3.16.3@conan/stable\n[env]\nCONAN_CMAKE_SYSTEM_VERSION=8.1\nLDFLAGS=/FIXED:NO",
+ "profile_host": "[settings]\narch=x86_64\narch_build=x86_64\nbuild_type=Debug\ncompiler=Visual Studio\ncompiler.runtime=MDd\ncompiler.version=15\nos=Windows\nos_build=Windows\n[options]\nOrbitProfiler:system_qt=False\n[build_requires]\n*: cmake_installer/3.16.3@conan/stable\n[env]\nCONAN_CMAKE_SYSTEM_VERSION=8.1\nLDFLAGS=/FIXED:NO /ignore:4099",
  "graph_lock": {
   "nodes": {
    "0": {

--- a/third_party/conan/lockfiles/windows/msvc2017_debug_x86/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2017_debug_x86/conan.lock
@@ -1,5 +1,5 @@
 {
- "profile_host": "[settings]\narch=x86\narch_build=x86_64\nbuild_type=Debug\ncompiler=Visual Studio\ncompiler.runtime=MDd\ncompiler.version=15\nos=Windows\nos_build=Windows\n[options]\nOrbitProfiler:system_qt=False\nOrbitProfiler:with_gui=False\nOrbitProfiler:with_orbitgl=False\n[build_requires]\n*: cmake_installer/3.16.3@conan/stable\n[env]\nCONAN_CMAKE_SYSTEM_VERSION=8.1\nLDFLAGS=/FIXED:NO",
+ "profile_host": "[settings]\narch=x86\narch_build=x86_64\nbuild_type=Debug\ncompiler=Visual Studio\ncompiler.runtime=MDd\ncompiler.version=15\nos=Windows\nos_build=Windows\n[options]\nOrbitProfiler:system_qt=False\nOrbitProfiler:with_gui=False\nOrbitProfiler:with_orbitgl=False\n[build_requires]\n*: cmake_installer/3.16.3@conan/stable\n[env]\nCONAN_CMAKE_SYSTEM_VERSION=8.1\nLDFLAGS=/FIXED:NO /ignore:4099",
  "graph_lock": {
   "nodes": {
    "0": {

--- a/third_party/conan/lockfiles/windows/msvc2017_release/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2017_release/conan.lock
@@ -1,5 +1,5 @@
 {
- "profile_host": "[settings]\narch=x86_64\narch_build=x86_64\nbuild_type=Release\ncompiler=Visual Studio\ncompiler.runtime=MD\ncompiler.version=15\nos=Windows\nos_build=Windows\n[options]\nOrbitProfiler:system_qt=False\n[build_requires]\n*: cmake_installer/3.16.3@conan/stable\n[env]\nCONAN_CMAKE_SYSTEM_VERSION=8.1\nLDFLAGS=/FIXED:NO",
+ "profile_host": "[settings]\narch=x86_64\narch_build=x86_64\nbuild_type=Release\ncompiler=Visual Studio\ncompiler.runtime=MD\ncompiler.version=15\nos=Windows\nos_build=Windows\n[options]\nOrbitProfiler:system_qt=False\n[build_requires]\n*: cmake_installer/3.16.3@conan/stable\n[env]\nCONAN_CMAKE_SYSTEM_VERSION=8.1\nLDFLAGS=/FIXED:NO /ignore:4099",
  "graph_lock": {
   "nodes": {
    "0": {

--- a/third_party/conan/lockfiles/windows/msvc2017_release_x86/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2017_release_x86/conan.lock
@@ -1,5 +1,5 @@
 {
- "profile_host": "[settings]\narch=x86\narch_build=x86_64\nbuild_type=Release\ncompiler=Visual Studio\ncompiler.runtime=MD\ncompiler.version=15\nos=Windows\nos_build=Windows\n[options]\nOrbitProfiler:system_qt=False\nOrbitProfiler:with_gui=False\nOrbitProfiler:with_orbitgl=False\n[build_requires]\n*: cmake_installer/3.16.3@conan/stable\n[env]\nCONAN_CMAKE_SYSTEM_VERSION=8.1\nLDFLAGS=/FIXED:NO",
+ "profile_host": "[settings]\narch=x86\narch_build=x86_64\nbuild_type=Release\ncompiler=Visual Studio\ncompiler.runtime=MD\ncompiler.version=15\nos=Windows\nos_build=Windows\n[options]\nOrbitProfiler:system_qt=False\nOrbitProfiler:with_gui=False\nOrbitProfiler:with_orbitgl=False\n[build_requires]\n*: cmake_installer/3.16.3@conan/stable\n[env]\nCONAN_CMAKE_SYSTEM_VERSION=8.1\nLDFLAGS=/FIXED:NO /ignore:4099",
  "graph_lock": {
   "nodes": {
    "0": {

--- a/third_party/conan/lockfiles/windows/msvc2017_relwithdebinfo/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2017_relwithdebinfo/conan.lock
@@ -1,5 +1,5 @@
 {
- "profile_host": "[settings]\narch=x86_64\narch_build=x86_64\nbuild_type=RelWithDebInfo\ncompiler=Visual Studio\ncompiler.runtime=MD\ncompiler.version=15\nos=Windows\nos_build=Windows\n[options]\nOrbitProfiler:system_qt=False\n[build_requires]\n*: cmake_installer/3.16.3@conan/stable\n[env]\nCONAN_CMAKE_SYSTEM_VERSION=8.1\nLDFLAGS=/FIXED:NO",
+ "profile_host": "[settings]\narch=x86_64\narch_build=x86_64\nbuild_type=RelWithDebInfo\ncompiler=Visual Studio\ncompiler.runtime=MD\ncompiler.version=15\nos=Windows\nos_build=Windows\n[options]\nOrbitProfiler:system_qt=False\n[build_requires]\n*: cmake_installer/3.16.3@conan/stable\n[env]\nCONAN_CMAKE_SYSTEM_VERSION=8.1\nLDFLAGS=/FIXED:NO /ignore:4099",
  "graph_lock": {
   "nodes": {
    "0": {

--- a/third_party/conan/lockfiles/windows/msvc2017_relwithdebinfo_x86/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2017_relwithdebinfo_x86/conan.lock
@@ -1,5 +1,5 @@
 {
- "profile_host": "[settings]\narch=x86\narch_build=x86_64\nbuild_type=RelWithDebInfo\ncompiler=Visual Studio\ncompiler.runtime=MD\ncompiler.version=15\nos=Windows\nos_build=Windows\n[options]\nOrbitProfiler:system_qt=False\nOrbitProfiler:with_gui=False\nOrbitProfiler:with_orbitgl=False\n[build_requires]\n*: cmake_installer/3.16.3@conan/stable\n[env]\nCONAN_CMAKE_SYSTEM_VERSION=8.1\nLDFLAGS=/FIXED:NO",
+ "profile_host": "[settings]\narch=x86\narch_build=x86_64\nbuild_type=RelWithDebInfo\ncompiler=Visual Studio\ncompiler.runtime=MD\ncompiler.version=15\nos=Windows\nos_build=Windows\n[options]\nOrbitProfiler:system_qt=False\nOrbitProfiler:with_gui=False\nOrbitProfiler:with_orbitgl=False\n[build_requires]\n*: cmake_installer/3.16.3@conan/stable\n[env]\nCONAN_CMAKE_SYSTEM_VERSION=8.1\nLDFLAGS=/FIXED:NO /ignore:4099",
  "graph_lock": {
   "nodes": {
    "0": {

--- a/third_party/conan/lockfiles/windows/msvc2019_debug/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2019_debug/conan.lock
@@ -1,5 +1,5 @@
 {
- "profile_host": "[settings]\narch=x86_64\narch_build=x86_64\nbuild_type=Debug\ncompiler=Visual Studio\ncompiler.runtime=MDd\ncompiler.version=16\nos=Windows\nos_build=Windows\n[options]\nOrbitProfiler:system_qt=False\n[build_requires]\n*: cmake_installer/3.16.3@conan/stable\n[env]\nCONAN_CMAKE_SYSTEM_VERSION=8.1\nLDFLAGS=/FIXED:NO",
+ "profile_host": "[settings]\narch=x86_64\narch_build=x86_64\nbuild_type=Debug\ncompiler=Visual Studio\ncompiler.runtime=MDd\ncompiler.version=16\nos=Windows\nos_build=Windows\n[options]\nOrbitProfiler:system_qt=False\n[build_requires]\n*: cmake_installer/3.16.3@conan/stable\n[env]\nCONAN_CMAKE_SYSTEM_VERSION=8.1\nLDFLAGS=/FIXED:NO /ignore:4099",
  "graph_lock": {
   "nodes": {
    "0": {

--- a/third_party/conan/lockfiles/windows/msvc2019_debug_x86/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2019_debug_x86/conan.lock
@@ -1,5 +1,5 @@
 {
- "profile_host": "[settings]\narch=x86\narch_build=x86_64\nbuild_type=Debug\ncompiler=Visual Studio\ncompiler.runtime=MDd\ncompiler.version=16\nos=Windows\nos_build=Windows\n[options]\nOrbitProfiler:system_qt=False\nOrbitProfiler:with_gui=False\nOrbitProfiler:with_orbitgl=False\n[build_requires]\n*: cmake_installer/3.16.3@conan/stable\n[env]\nCONAN_CMAKE_SYSTEM_VERSION=8.1\nLDFLAGS=/FIXED:NO",
+ "profile_host": "[settings]\narch=x86\narch_build=x86_64\nbuild_type=Debug\ncompiler=Visual Studio\ncompiler.runtime=MDd\ncompiler.version=16\nos=Windows\nos_build=Windows\n[options]\nOrbitProfiler:system_qt=False\nOrbitProfiler:with_gui=False\nOrbitProfiler:with_orbitgl=False\n[build_requires]\n*: cmake_installer/3.16.3@conan/stable\n[env]\nCONAN_CMAKE_SYSTEM_VERSION=8.1\nLDFLAGS=/FIXED:NO /ignore:4099",
  "graph_lock": {
   "nodes": {
    "0": {

--- a/third_party/conan/lockfiles/windows/msvc2019_release/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2019_release/conan.lock
@@ -1,5 +1,5 @@
 {
- "profile_host": "[settings]\narch=x86_64\narch_build=x86_64\nbuild_type=Release\ncompiler=Visual Studio\ncompiler.runtime=MD\ncompiler.version=16\nos=Windows\nos_build=Windows\n[options]\nOrbitProfiler:system_qt=False\n[build_requires]\n*: cmake_installer/3.16.3@conan/stable\n[env]\nCONAN_CMAKE_SYSTEM_VERSION=8.1\nLDFLAGS=/FIXED:NO",
+ "profile_host": "[settings]\narch=x86_64\narch_build=x86_64\nbuild_type=Release\ncompiler=Visual Studio\ncompiler.runtime=MD\ncompiler.version=16\nos=Windows\nos_build=Windows\n[options]\nOrbitProfiler:system_qt=False\n[build_requires]\n*: cmake_installer/3.16.3@conan/stable\n[env]\nCONAN_CMAKE_SYSTEM_VERSION=8.1\nLDFLAGS=/FIXED:NO /ignore:4099",
  "graph_lock": {
   "nodes": {
    "0": {

--- a/third_party/conan/lockfiles/windows/msvc2019_release_x86/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2019_release_x86/conan.lock
@@ -1,5 +1,5 @@
 {
- "profile_host": "[settings]\narch=x86\narch_build=x86_64\nbuild_type=Release\ncompiler=Visual Studio\ncompiler.runtime=MD\ncompiler.version=16\nos=Windows\nos_build=Windows\n[options]\nOrbitProfiler:system_qt=False\nOrbitProfiler:with_gui=False\nOrbitProfiler:with_orbitgl=False\n[build_requires]\n*: cmake_installer/3.16.3@conan/stable\n[env]\nCONAN_CMAKE_SYSTEM_VERSION=8.1\nLDFLAGS=/FIXED:NO",
+ "profile_host": "[settings]\narch=x86\narch_build=x86_64\nbuild_type=Release\ncompiler=Visual Studio\ncompiler.runtime=MD\ncompiler.version=16\nos=Windows\nos_build=Windows\n[options]\nOrbitProfiler:system_qt=False\nOrbitProfiler:with_gui=False\nOrbitProfiler:with_orbitgl=False\n[build_requires]\n*: cmake_installer/3.16.3@conan/stable\n[env]\nCONAN_CMAKE_SYSTEM_VERSION=8.1\nLDFLAGS=/FIXED:NO /ignore:4099",
  "graph_lock": {
   "nodes": {
    "0": {

--- a/third_party/conan/lockfiles/windows/msvc2019_relwithdebinfo/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2019_relwithdebinfo/conan.lock
@@ -1,5 +1,5 @@
 {
- "profile_host": "[settings]\narch=x86_64\narch_build=x86_64\nbuild_type=RelWithDebInfo\ncompiler=Visual Studio\ncompiler.runtime=MD\ncompiler.version=16\nos=Windows\nos_build=Windows\n[options]\nOrbitProfiler:system_qt=False\n[build_requires]\n*: cmake_installer/3.16.3@conan/stable\n[env]\nCONAN_CMAKE_SYSTEM_VERSION=8.1\nLDFLAGS=/FIXED:NO",
+ "profile_host": "[settings]\narch=x86_64\narch_build=x86_64\nbuild_type=RelWithDebInfo\ncompiler=Visual Studio\ncompiler.runtime=MD\ncompiler.version=16\nos=Windows\nos_build=Windows\n[options]\nOrbitProfiler:system_qt=False\n[build_requires]\n*: cmake_installer/3.16.3@conan/stable\n[env]\nCONAN_CMAKE_SYSTEM_VERSION=8.1\nLDFLAGS=/FIXED:NO /ignore:4099",
  "graph_lock": {
   "nodes": {
    "0": {

--- a/third_party/conan/lockfiles/windows/msvc2019_relwithdebinfo_x86/conan.lock
+++ b/third_party/conan/lockfiles/windows/msvc2019_relwithdebinfo_x86/conan.lock
@@ -1,5 +1,5 @@
 {
- "profile_host": "[settings]\narch=x86\narch_build=x86_64\nbuild_type=RelWithDebInfo\ncompiler=Visual Studio\ncompiler.runtime=MD\ncompiler.version=16\nos=Windows\nos_build=Windows\n[options]\nOrbitProfiler:system_qt=False\nOrbitProfiler:with_gui=False\nOrbitProfiler:with_orbitgl=False\n[build_requires]\n*: cmake_installer/3.16.3@conan/stable\n[env]\nCONAN_CMAKE_SYSTEM_VERSION=8.1\nLDFLAGS=/FIXED:NO",
+ "profile_host": "[settings]\narch=x86\narch_build=x86_64\nbuild_type=RelWithDebInfo\ncompiler=Visual Studio\ncompiler.runtime=MD\ncompiler.version=16\nos=Windows\nos_build=Windows\n[options]\nOrbitProfiler:system_qt=False\nOrbitProfiler:with_gui=False\nOrbitProfiler:with_orbitgl=False\n[build_requires]\n*: cmake_installer/3.16.3@conan/stable\n[env]\nCONAN_CMAKE_SYSTEM_VERSION=8.1\nLDFLAGS=/FIXED:NO /ignore:4099",
  "graph_lock": {
   "nodes": {
    "0": {


### PR DESCRIPTION
This commit changes the conan profiles such that missing PDB files are
ignored. We have a bunch of missing PDB files from dependencies. This
could be fixed by adding them to the upstream packages which is a lot of
work and will take some time to do.

In the meantime this warning hurts readability of the compiler log quite
a bit. So disabling this warning will help with that, especially on the
CI.