### PR TITLE
Add selected_functions to capture in OrbitClientGgp

### DIFF
--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -9,6 +9,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -181,9 +181,9 @@ bool ClientGgp::InitCapture() {
 }
 
 void ClientGgp::InformUsedSelectedCaptureFunctions(
-    absl::flat_hash_set<std::string> capture_functions_used) {
+    const absl::flat_hash_set<std::string>& capture_functions_used) {
   if (capture_functions_used.size() != options_.capture_functions.size()) {
-    for (const std::string selected_function : options_.capture_functions) {
+    for (const std::string& selected_function : options_.capture_functions) {
       if (!capture_functions_used.contains(selected_function)) {
         ERROR("Function matching %s not found; will not be hooked in the capture",
               selected_function);
@@ -195,7 +195,7 @@ void ClientGgp::InformUsedSelectedCaptureFunctions(
 }
 
 std::string ClientGgp::SelectedFunctionMatch(const FunctionInfo& func) {
-  for (const std::string selected_function : options_.capture_functions) {
+  for (const std::string& selected_function : options_.capture_functions) {
     if (func.pretty_name().find(selected_function) != std::string::npos) {
       return selected_function;
     }
@@ -207,7 +207,7 @@ absl::flat_hash_map<uint64_t, FunctionInfo> ClientGgp::GetSelectedFunctions() {
   absl::flat_hash_map<uint64_t, FunctionInfo> selected_functions;
   absl::flat_hash_set<std::string> capture_functions_used;
   for (const auto& func : target_process_->GetFunctions()) {
-    const std::string selected_function_match = SelectedFunctionMatch(*func);
+    const std::string& selected_function_match = SelectedFunctionMatch(*func);
     if (!selected_function_match.empty()) {
       uint64_t address = FunctionUtils::GetAbsoluteAddress(*func);
       selected_functions[address] = *func;

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -17,6 +17,7 @@
 #include "OrbitCaptureClient/CaptureListener.h"
 #include "OrbitClientServices/ProcessClient.h"
 #include "OrbitProcess.h"
+#include "SymbolHelper.h"
 #include "grpcpp/grpcpp.h"
 
 class ClientGgp final : public CaptureListener {
@@ -46,10 +47,14 @@ class ClientGgp final : public CaptureListener {
   std::unique_ptr<CaptureClient> capture_client_;
   std::unique_ptr<ProcessClient> process_client_;
   CaptureData capture_data_;
+  absl::flat_hash_set<std::string> capture_functions_used_;
 
   ErrorMessageOr<std::shared_ptr<Process>> GetOrbitProcessByPid(int32_t pid);
   bool InitCapture();
   ErrorMessageOr<void> LoadModuleAndSymbols();
+  bool IsSelectedFunction(const orbit_client_protos::FunctionInfo& func);
+  absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> GetSelectedFunctions();
+  void InformUsedSelectedCaptureFunctions();
 };
 
 #endif  // ORBIT_CLIENT_GGP_CLIENT_GGP_H_

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "CaptureData.h"
 #include "ClientGgpOptions.h"

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -8,7 +8,6 @@
 #include <cstdint>
 #include <memory>
 #include <string>
-#include <vector>
 
 #include "CaptureData.h"
 #include "ClientGgpOptions.h"
@@ -53,7 +52,8 @@ class ClientGgp final : public CaptureListener {
   ErrorMessageOr<void> LoadModuleAndSymbols();
   std::string SelectedFunctionMatch(const orbit_client_protos::FunctionInfo& func);
   absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> GetSelectedFunctions();
-  void InformUsedSelectedCaptureFunctions(absl::flat_hash_set<std::string> capture_functions_used);
+  void InformUsedSelectedCaptureFunctions(
+      const absl::flat_hash_set<std::string>& capture_functions_used);
 };
 
 #endif  // ORBIT_CLIENT_GGP_CLIENT_GGP_H_

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -47,14 +47,13 @@ class ClientGgp final : public CaptureListener {
   std::unique_ptr<CaptureClient> capture_client_;
   std::unique_ptr<ProcessClient> process_client_;
   CaptureData capture_data_;
-  absl::flat_hash_set<std::string> capture_functions_used_;
 
   ErrorMessageOr<std::shared_ptr<Process>> GetOrbitProcessByPid(int32_t pid);
   bool InitCapture();
   ErrorMessageOr<void> LoadModuleAndSymbols();
-  bool IsSelectedFunction(const orbit_client_protos::FunctionInfo& func);
+  std::string SelectedFunctionMatch(const orbit_client_protos::FunctionInfo& func);
   absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> GetSelectedFunctions();
-  void InformUsedSelectedCaptureFunctions();
+  void InformUsedSelectedCaptureFunctions(absl::flat_hash_set<std::string> capture_functions_used);
 };
 
 #endif  // ORBIT_CLIENT_GGP_CLIENT_GGP_H_

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -16,7 +16,6 @@
 #include "OrbitCaptureClient/CaptureListener.h"
 #include "OrbitClientServices/ProcessClient.h"
 #include "OrbitProcess.h"
-#include "SymbolHelper.h"
 #include "grpcpp/grpcpp.h"
 
 class ClientGgp final : public CaptureListener {

--- a/OrbitClientGgp/ClientGgpOptions.h
+++ b/OrbitClientGgp/ClientGgpOptions.h
@@ -6,6 +6,7 @@
 #define ORBIT_CLIENT_GGP_CLIENT_GGP_OPTIONS_H_
 
 #include <string>
+#include <vector>
 
 // The struct used to store Orbit Ggp Client options
 // The default values are set by main()
@@ -13,6 +14,7 @@ struct ClientGgpOptions {
   // gRPC connection string
   std::string grpc_server_address;
   int32_t capture_pid;
+  std::vector<std::string> capture_functions;
 };
 
 #endif  // ORBIT_CLIENT_GGP_CLIENT_GGP_OPTIONS_H_

--- a/OrbitClientGgp/main.cpp
+++ b/OrbitClientGgp/main.cpp
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <vector>
+
 #include "ClientGgp.h"
 #include "OrbitBase/ThreadPool.h"
 #include "absl/flags/flag.h"
@@ -10,21 +12,23 @@
 ABSL_FLAG(uint64_t, grpc_port, 44765, "Grpc service's port");
 ABSL_FLAG(int32_t, pid, 0, "pid to capture");
 ABSL_FLAG(uint32_t, capture_length, 10, "duration of capture in seconds");
+ABSL_FLAG(std::vector<std::string>, functions, {},
+          "Comma-separated list of functions to hook to the capture");
 ABSL_FLAG(uint16_t, sampling_rate, 1000, "Frequency of callstack sampling in samples per second");
 ABSL_FLAG(bool, frame_pointer_unwinding, false, "Use frame pointers for unwinding");
 
 int main(int argc, char** argv) {
   absl::ParseCommandLine(argc, argv);
-  uint64_t grpc_port = absl::GetFlag(FLAGS_grpc_port);
-  uint32_t capture_length = absl::GetFlag(FLAGS_capture_length);
 
   if (!absl::GetFlag(FLAGS_pid)) {
     FATAL("pid to capture not provided; set using -pid");
   }
 
   ClientGgpOptions options;
+  uint64_t grpc_port = absl::GetFlag(FLAGS_grpc_port);
   options.grpc_server_address = absl::StrFormat("127.0.0.1:%d", grpc_port);
   options.capture_pid = absl::GetFlag(FLAGS_pid);
+  options.capture_functions = absl::GetFlag(FLAGS_functions);
 
   ClientGgp client_ggp(std::move(options));
   if (!client_ggp.InitClient()) {
@@ -40,6 +44,7 @@ int main(int argc, char** argv) {
   }
 
   // Captures for the period of time requested
+  uint32_t capture_length = absl::GetFlag(FLAGS_capture_length);
   LOG("Go to sleep for %d seconds", capture_length);
   absl::SleepFor(absl::Seconds(capture_length));
   LOG("Back from sleep");


### PR DESCRIPTION
Populate _selected_functions_ to be provided to _CaptureClient_ when requesting to start a capture. Each of the functions provided as argument acts as a filter to find one or more functions loaded in _target_process__ that matches its string.

**Add optional -functions parameter** It is possible to provide the list of functions to hook when capturing so we create a new "functions" argument, which accepts a list of strings separated by comma: `.\OrbitClientGgp -functions "function1,function2"`

**Populate selected_functions based on the list provided** The list of selected functions acts as a "filter" so all the functions existent in _target_process__ that matches any of the strings provided will be included in selected_functions. Three methods has been created:  

1. _ClientGgp::GetSelectedFunctions_ Returns selected_functions
2. _ClientGgp::SelectedFunctionMatch_ Checks if a function matches any of the "filters" in the list and returns the matching string if it does.
3. _ClientGgp::InformUsedSelectedCaptureFunctions_ Go through the filters provided if not all of them got a match when looking for the selected functions. Informs the user by logs that any functions related to them will be included in the capture.





