### PR TITLE
Fix default tab on right hand side.

### DIFF
--- a/OrbitQt/orbitmainwindow.ui
+++ b/OrbitQt/orbitmainwindow.ui
@@ -106,7 +106,7 @@
       </widget>
       <widget class="QTabWidget" name="RightTabWidget">
        <property name="currentIndex">
-        <number>7</number>
+        <number>0</number>
        </property>
        <widget class="QWidget" name="FunctionsTab">
         <attribute name="title">


### PR DESCRIPTION
In a previous PR (https://github.com/google/orbit/pull/1104) this was
changed to the right most tab. It should be the left most.

Bug: N/A
Test: Ran the change locally