### PR TITLE
Mini rework and tests for Path utils

### DIFF
--- a/ElfUtils/ElfFileTest.cpp
+++ b/ElfUtils/ElfFileTest.cpp
@@ -18,9 +18,9 @@ using ElfUtils::ElfFile;
 using orbit_grpc_protos::SymbolInfo;
 
 TEST(ElfFile, LoadSymbols) {
-  std::string executable_path = Path::GetExecutablePath();
+  std::string executable_dir = Path::GetExecutableDir();
   std::string executable = "hello_world_elf";
-  std::string file_path = executable_path + "testdata/" + executable;
+  std::string file_path = executable_dir + "testdata/" + executable;
 
   auto elf_file_result = ElfFile::Create(file_path);
   ASSERT_TRUE(elf_file_result) << elf_file_result.error().message();
@@ -55,10 +55,10 @@ TEST(ElfFile, LoadSymbols) {
 }
 
 TEST(ElfFile, CalculateLoadBias) {
-  const std::string executable_path = Path::GetExecutablePath();
+  const std::string executable_dir = Path::GetExecutableDir();
 
   {
-    const std::string test_elf_file_dynamic = executable_path + "/testdata/hello_world_elf";
+    const std::string test_elf_file_dynamic = executable_dir + "/testdata/hello_world_elf";
     auto elf_file_dynamic = ElfFile::Create(test_elf_file_dynamic);
     ASSERT_TRUE(elf_file_dynamic);
     const auto load_bias = elf_file_dynamic.value()->GetLoadBias();
@@ -67,7 +67,7 @@ TEST(ElfFile, CalculateLoadBias) {
   }
 
   {
-    const std::string test_elf_file_static = executable_path + "/testdata/hello_world_static_elf";
+    const std::string test_elf_file_static = executable_dir + "/testdata/hello_world_static_elf";
     auto elf_file_static = ElfFile::Create(test_elf_file_static);
     ASSERT_TRUE(elf_file_static) << elf_file_static.error().message();
     const auto load_bias = elf_file_static.value()->GetLoadBias();
@@ -77,9 +77,8 @@ TEST(ElfFile, CalculateLoadBias) {
 }
 
 TEST(ElfFile, CalculateLoadBiasNoProgramHeaders) {
-  const std::string executable_path = Path::GetExecutablePath();
-  const std::string test_elf_file =
-      executable_path + "/testdata/hello_world_elf_no_program_headers";
+  const std::string executable_dir = Path::GetExecutableDir();
+  const std::string test_elf_file = executable_dir + "/testdata/hello_world_elf_no_program_headers";
   auto elf_file_result = ElfFile::Create(test_elf_file);
 
   ASSERT_TRUE(elf_file_result) << elf_file_result.error().message();
@@ -93,9 +92,9 @@ TEST(ElfFile, CalculateLoadBiasNoProgramHeaders) {
 }
 
 TEST(ElfFile, HasSymtab) {
-  std::string executable_path = Path::GetExecutablePath();
-  std::string elf_with_symbols_path = executable_path + "/testdata/hello_world_elf";
-  std::string elf_without_symbols_path = executable_path + "/testdata/no_symbols_elf";
+  std::string executable_dir = Path::GetExecutableDir();
+  std::string elf_with_symbols_path = executable_dir + "/testdata/hello_world_elf";
+  std::string elf_without_symbols_path = executable_dir + "/testdata/no_symbols_elf";
 
   auto elf_with_symbols = ElfFile::Create(elf_with_symbols_path);
   ASSERT_TRUE(elf_with_symbols) << elf_with_symbols.error().message();
@@ -109,14 +108,14 @@ TEST(ElfFile, HasSymtab) {
 }
 
 TEST(ElfFile, GetBuildId) {
-  std::string executable_path = Path::GetExecutablePath();
-  std::string hello_world_path = executable_path + "/testdata/hello_world_elf";
+  std::string executable_dir = Path::GetExecutableDir();
+  std::string hello_world_path = executable_dir + "/testdata/hello_world_elf";
 
   auto hello_world = ElfFile::Create(hello_world_path);
   ASSERT_TRUE(hello_world) << hello_world.error().message();
   EXPECT_EQ(hello_world.value()->GetBuildId(), "d12d54bc5b72ccce54a408bdeda65e2530740ac8");
 
-  std::string elf_without_build_id_path = executable_path + "/testdata/hello_world_elf_no_build_id";
+  std::string elf_without_build_id_path = executable_dir + "/testdata/hello_world_elf_no_build_id";
 
   auto elf_without_build_id = ElfFile::Create(elf_without_build_id_path);
   ASSERT_TRUE(elf_without_build_id) << elf_without_build_id.error().message();
@@ -124,8 +123,8 @@ TEST(ElfFile, GetBuildId) {
 }
 
 TEST(ElfFile, GetFilePath) {
-  std::string executable_path = Path::GetExecutablePath();
-  std::string hello_world_path = executable_path + "/testdata/hello_world_elf";
+  std::string executable_dir = Path::GetExecutableDir();
+  std::string hello_world_path = executable_dir + "/testdata/hello_world_elf";
 
   auto hello_world = ElfFile::Create(hello_world_path);
   ASSERT_TRUE(hello_world) << hello_world.error().message();
@@ -134,8 +133,8 @@ TEST(ElfFile, GetFilePath) {
 }
 
 TEST(ElfFile, CreateFromBuffer) {
-  std::string executable_path = Path::GetExecutablePath();
-  std::string test_elf_file = executable_path + "/testdata/hello_world_elf";
+  std::string executable_dir = Path::GetExecutableDir();
+  std::string test_elf_file = executable_dir + "/testdata/hello_world_elf";
 
   std::ifstream test_elf_stream{test_elf_file, std::ios::binary};
   const std::string buffer{std::istreambuf_iterator<char>{test_elf_stream},
@@ -148,8 +147,8 @@ TEST(ElfFile, CreateFromBuffer) {
 }
 
 TEST(ElfFile, FileDoesNotExist) {
-  std::string executable_path = Path::GetExecutablePath();
-  std::string file_path = executable_path + "/testdata/does_not_exist";
+  std::string executable_dir = Path::GetExecutableDir();
+  std::string file_path = executable_dir + "/testdata/does_not_exist";
 
   auto elf_file = ElfFile::Create(file_path);
   ASSERT_FALSE(elf_file);

--- a/OrbitCore/CMakeLists.txt
+++ b/OrbitCore/CMakeLists.txt
@@ -106,6 +106,13 @@ target_link_libraries(
           llvm_object::llvm_object
           abseil::abseil)
 
+add_custom_command(TARGET OrbitCoreTests POST_BUILD COMMAND ${CMAKE_COMMAND}
+                   -E remove_directory $<TARGET_FILE_DIR:OrbitCoreTests>/testdata/OrbitCore)
+
+add_custom_command(TARGET OrbitCoreTests POST_BUILD COMMAND ${CMAKE_COMMAND}
+                   -E copy_directory ${CMAKE_SOURCE_DIR}/OrbitCore/testdata/
+                   $<TARGET_FILE_DIR:OrbitCoreTests>/testdata/OrbitCore)
+
 register_test(OrbitCoreTests)
 
 add_fuzzer(ModuleLoadSymbolsFuzzer ModuleLoadSymbolsFuzzer.cpp)

--- a/OrbitCore/OrbitModuleTest.cpp
+++ b/OrbitCore/OrbitModuleTest.cpp
@@ -16,7 +16,7 @@
 #include "capture_data.pb.h"
 #include "symbol.pb.h"
 
-const std::string executable_directory = Path::GetExecutablePath() + "testdata/";
+const std::string executable_directory = Path::GetExecutableDir() + "testdata/";
 
 using ElfUtils::ElfFile;
 using orbit_client_protos::FunctionInfo;

--- a/OrbitCore/Path.cpp
+++ b/OrbitCore/Path.cpp
@@ -134,15 +134,6 @@ std::string Path::GetDirectory(const std::string& any_path) {
   return "";
 }
 
-std::string Path::GetParentDirectory(std::string any_path) {
-  if (any_path.empty()) return "";
-  std::replace(any_path.begin(), any_path.end(), '\\', '/');
-  wchar_t lastChar = any_path.c_str()[any_path.size() - 1];
-  if (lastChar == '/') any_path.erase(any_path.size() - 1);
-
-  return GetDirectory(any_path);
-}
-
 std::string Path::JoinPath(const std::vector<std::string>& parts) {
   if (parts.empty()) {
     return "";

--- a/OrbitCore/Path.h
+++ b/OrbitCore/Path.h
@@ -8,50 +8,28 @@
 #include <string>
 #include <vector>
 
-class Path {
- public:
-  static void Init();
+namespace Path {
+[[nodiscard]] std::string GetExecutablePath();
+[[nodiscard]] std::string GetExecutableDir();
+[[nodiscard]] std::string GetFileMappingFileName();
+[[nodiscard]] std::string GetSymbolsFileName();
+[[nodiscard]] std::string CreateOrGetCacheDir();
+[[nodiscard]] std::string CreateOrGetPresetDir();
+[[nodiscard]] std::string CreateOrGetCaptureDir();
+[[nodiscard]] std::string CreateOrGetDumpDir();
+[[nodiscard]] std::string CreateOrGetOrbitAppDataDir();
+[[nodiscard]] std::string GetLogFilePathAndCreateDir();
+[[nodiscard]] std::string GetIconsPath();
+[[nodiscard]] std::string GetFileName(const std::string& file_path);
+[[nodiscard]] std::string StripExtension(const std::string& file_path);
+[[nodiscard]] std::string GetExtension(const std::string& file_path);
+[[nodiscard]] std::string GetDirectory(const std::string& any_path);
+[[nodiscard]] std::string GetParentDirectory(std::string any_path);
+[[nodiscard]] std::string JoinPath(const std::vector<std::string>& parts);
 
-  static std::string GetExecutableName();
-  static std::string GetExecutablePath();
-  static std::string GetBasePath();
-  static std::string GetDllPath(bool a_Is64Bit);
-  static std::string GetDllName(bool a_Is64Bit);
-  static std::string GetFileMappingFileName();
-  static std::string GetSymbolsFileName();
-  static std::string GetCachePath();
-  static std::string GetPresetPath();
-  static std::string GetPluginPath();
-  static std::string GetCapturePath();
-  static std::string GetDumpPath();
-  static std::string GetAppDataPath();
-  static std::string GetLogFilePath();
-  static std::string GetIconsPath();
-  static void Dump();
-
-#ifdef __linux__
-  static std::string GetHome();
-#endif
-
-  static std::string GetFileName(const std::string& a_FullName);
-  static std::string GetFileNameNoExt(const std::string& a_FullName);
-  static std::string StripExtension(const std::string& a_FullName);
-  static std::string GetExtension(const std::string& a_FullName);
-  static std::string GetDirectory(const std::string& a_FullName);
-  static std::string GetParentDirectory(std::string a_FullName);
-  static std::string JoinPath(const std::vector<std::string>& parts);
-
-  // TODO(159868905): This is only used by OrbitModule. Remove this as soon as
-  //  OrbitModule is removed.
-  static uint64_t FileSize(const std::string& a_File);
-  static bool DirExists(const std::string& a_Dir);
-
-  static std::vector<std::string> ListFiles(
-      const std::string& directory, const std::function<bool(const std::string&)>& filter =
-                                        [](const std::string&) { return true; });
-  static std::vector<std::string> ListFiles(const std::string& directory,
-                                            const std::string& filter);
-
- private:
-  static std::string base_path_;
-};
+[[nodiscard]] std::vector<std::string> ListFiles(
+    const std::string& directory, const std::function<bool(const std::string&)>& filter =
+                                      [](const std::string&) { return true; });
+[[nodiscard]] std::vector<std::string> ListFiles(const std::string& directory,
+                                                 const std::string& filter);
+};  // namespace Path

--- a/OrbitCore/Path.h
+++ b/OrbitCore/Path.h
@@ -24,7 +24,6 @@ namespace Path {
 [[nodiscard]] std::string StripExtension(const std::string& file_path);
 [[nodiscard]] std::string GetExtension(const std::string& file_path);
 [[nodiscard]] std::string GetDirectory(const std::string& any_path);
-[[nodiscard]] std::string GetParentDirectory(std::string any_path);
 [[nodiscard]] std::string JoinPath(const std::vector<std::string>& parts);
 
 [[nodiscard]] std::vector<std::string> ListFiles(

--- a/OrbitCore/PathTest.cpp
+++ b/OrbitCore/PathTest.cpp
@@ -156,38 +156,34 @@ static std::string GetTestDataAbsPath(const std::string& filename = "") {
   }
 }
 
-TEST(Path, GetDirectoryAndParent) {
+TEST(Path, GetDirectory) {
   struct Test {
     std::string input;
     std::string dir;
-    std::string parent_of_input;
-    std::string parent_of_dir;
   };
 
   // The hoops I'm jumping through to have the test declarations below nicely formatted...
   using V = std::vector<Test>;
 #ifdef _WIN32
-  V tests = {{"C:\\dir/With\\fwd_slash.txt.ext", "C:/dir/With/", "C:/dir/With/", "C:/dir/"},
-             {"C:\\no\\ext\\file", "C:/no/ext/", "C:/no/ext/", "C:/no/"},
-             {"C:\\dir\\subdir\\", "C:/dir/subdir/", "C:/dir/", "C:/dir/"},
-             {"C:\\file_in_root", "C:/", "C:/", ""},
-             {"broken_path", "", "", ""},
-             {"C:\\", "C:/", "", ""}};
+  V tests = {{"C:\\dir/With\\fwd_slash.txt.ext", "C:/dir/With/"},
+             {"C:\\no\\ext\\file", "C:/no/ext/"},
+             {"C:\\dir\\subdir\\", "C:/dir/subdir/"},
+             {"C:\\file_in_root", "C:/"},
+             {"broken_path", ""},
+             {"C:\\", "C:/"}};
 #else
-  V tests = {{"/dir/With/mult_ext.txt.ext", "/dir/With/", "/dir/With/", "/dir/"},
-             {"/no/ext/file", "/no/ext/", "/no/ext/", "/no/"},
-             {"/dir/subdir/", "/dir/subdir/", "/dir/", "/dir/"},
-             {"/file_in_root", "/", "/", ""},
-             {"broken_path", "", "", ""},
-             {"/", "/", "", ""}};
+  V tests = {{"/dir/With/mult_ext.txt.ext", "/dir/With/"},
+             {"/no/ext/file", "/no/ext/"},
+             {"/dir/subdir/", "/dir/subdir/"},
+             {"/file_in_root", "/"},
+             {"broken_path", ""},
+             {"/", "/"}};
 #endif
 
   for (auto& test : tests) {
-    LOG("Checking directory and parent of \"%s\"", test.input.c_str());
+    LOG("Checking directory of \"%s\"", test.input.c_str());
     const std::string result_dir = Path::GetDirectory(test.input);
     EXPECT_EQ(result_dir, test.dir);
-    EXPECT_EQ(Path::GetParentDirectory(test.input), test.parent_of_input);
-    EXPECT_EQ(Path::GetParentDirectory(result_dir), test.parent_of_dir);
   }
 }
 

--- a/OrbitCore/PathTest.cpp
+++ b/OrbitCore/PathTest.cpp
@@ -6,6 +6,7 @@
 
 #include <filesystem>
 
+#include "OrbitBase/Logging.h"
 #include "Path.h"
 #include "absl/strings/match.h"
 
@@ -95,4 +96,156 @@ TEST(Path, JoinPathPartsAbsoluteRootBackslash) {
   std::string expected = "C:/dir1\\dir2/dir3\\dir4";
 #endif
   EXPECT_EQ(actual, expected);
+}
+
+TEST(Path, FileNamesAndExtensions) {
+#ifdef _WIN32
+  std::string abs_input[] = {"C:\\some_abs_path\\file.txt", "C:\\dir.with.dots\\file_without_ext"};
+  std::string abs_stripped[] = {"C:/some_abs_path/file", "C:/dir.with.dots/file_without_ext"};
+#else
+  std::string abs_input[] = {"/some_abs_path/file.txt", "/dir.with.dots/file_without_ext"};
+  std::string abs_stripped[] = {"/some_abs_path/file", "/dir.with.dots/file_without_ext"};
+#endif
+  EXPECT_EQ(Path::GetExtension(abs_input[0]), ".txt");
+  EXPECT_EQ(Path::StripExtension(abs_input[0]), abs_stripped[0]);
+  EXPECT_EQ(Path::GetFileName(abs_input[0]), "file.txt");
+
+  EXPECT_EQ(Path::GetExtension(abs_input[1]), "");
+  EXPECT_EQ(Path::StripExtension(abs_input[1]), abs_stripped[1]);
+  EXPECT_EQ(Path::GetFileName(abs_input[1]), "file_without_ext");
+
+  std::string input = "relative\\mixed/path/file.txt";
+  EXPECT_EQ(Path::GetExtension(input), ".txt");
+  EXPECT_EQ(Path::StripExtension(input), "relative/mixed/path/file");
+  EXPECT_EQ(Path::GetFileName(input), "file.txt");
+
+  input = "simple.file";
+  EXPECT_EQ(Path::GetExtension(input), ".file");
+  EXPECT_EQ(Path::StripExtension(input), "simple");
+  EXPECT_EQ(Path::GetFileName(input), "simple.file");
+
+  input = "no/ext";
+  EXPECT_EQ(Path::GetExtension(input), "");
+  EXPECT_EQ(Path::StripExtension(input), "no/ext");
+  EXPECT_EQ(Path::GetFileName(input), "ext");
+
+  input = "double.ext.txt";
+  EXPECT_EQ(Path::GetExtension(input), ".txt");
+  EXPECT_EQ(Path::StripExtension(input), "double.ext");
+  EXPECT_EQ(Path::StripExtension(Path::StripExtension(input)), "double");
+  EXPECT_EQ(Path::GetFileName(input), "double.ext.txt");
+}
+
+// TODO: A test for GetExecutableDir is missing - using this here makes this test
+// kind of invalid, since GetExecutableDir is using GetExecutablePath internally...
+TEST(Path, GetExecutablePath) {
+  std::string actual = Path::GetExecutablePath();
+#ifdef _WIN32
+  std::string expected = Path::JoinPath({Path::GetExecutableDir(), "OrbitCoreTests.exe"});
+#else
+  std::string expected = Path::JoinPath({Path::GetExecutableDir(), "OrbitCoreTests"});
+#endif
+  EXPECT_EQ(actual, expected);
+}
+
+static std::string GetTestDataAbsPath(const std::string& filename = "") {
+  if (filename.empty()) {
+    return Path::JoinPath({Path::GetExecutableDir(), "testdata", "OrbitCore"});
+  } else {
+    return Path::JoinPath({Path::GetExecutableDir(), "testdata", "OrbitCore", filename});
+  }
+}
+
+TEST(Path, GetDirectoryAndParent) {
+  struct Test {
+    std::string input;
+    std::string dir;
+    std::string parent_of_input;
+    std::string parent_of_dir;
+  };
+
+  // The hoops I'm jumping through to have the test declarations below nicely formatted...
+  using V = std::vector<Test>;
+#ifdef _WIN32
+  V tests = {{"C:\\dir/With\\fwd_slash.txt.ext", "C:/dir/With/", "C:/dir/With/", "C:/dir/"},
+             {"C:\\no\\ext\\file", "C:/no/ext/", "C:/no/ext/", "C:/no/"},
+             {"C:\\dir\\subdir\\", "C:/dir/subdir/", "C:/dir/", "C:/dir/"},
+             {"C:\\file_in_root", "C:/", "C:/", ""},
+             {"broken_path", "", "", ""},
+             {"C:\\", "C:/", "", ""}};
+#else
+  V tests = {{"/dir/With/mult_ext.txt.ext", "/dir/With/", "/dir/With/", "/dir/"},
+             {"/no/ext/file", "/no/ext/", "/no/ext/", "/no/"},
+             {"/dir/subdir/", "/dir/subdir/", "/dir/", "/dir/"},
+             {"/file_in_root", "/", "/", ""},
+             {"broken_path", "", "", ""},
+             {"/", "/", "", ""}};
+#endif
+
+  for (auto& test : tests) {
+    LOG("Checking directory and parent of \"%s\"", test.input.c_str());
+    const std::string result_dir = Path::GetDirectory(test.input);
+    EXPECT_EQ(result_dir, test.dir);
+    EXPECT_EQ(Path::GetParentDirectory(test.input), test.parent_of_input);
+    EXPECT_EQ(Path::GetParentDirectory(result_dir), test.parent_of_dir);
+  }
+}
+
+TEST(Path, ListFiles) {
+  using Set = std::set<std::string>;
+
+  auto empty_file_path = GetTestDataAbsPath("empty_file.txt");
+  auto small_file_path = GetTestDataAbsPath("small_file");
+
+  auto files = Path::ListFiles(GetTestDataAbsPath());
+  Set unordered_files(files.begin(), files.end());
+  EXPECT_EQ(unordered_files, Set({empty_file_path, small_file_path}));
+
+  // Filter is NOT a regex...
+  files = Path::ListFiles(GetTestDataAbsPath(), "*.txt");
+  EXPECT_TRUE(files.empty());
+
+  // ... but simply a "contains"
+  files = Path::ListFiles(GetTestDataAbsPath(), ".txt");
+  unordered_files = Set(files.begin(), files.end());
+  EXPECT_EQ(unordered_files, Set({empty_file_path}));
+
+  // Filter lambda gets the absolute file path as a parameter
+  files = Path::ListFiles(GetTestDataAbsPath(), [](const std::string& file) -> bool {
+    return file == GetTestDataAbsPath("small_file");
+  });
+  unordered_files = Set(files.begin(), files.end());
+  EXPECT_EQ(unordered_files, Set({small_file_path}));
+}
+
+TEST(Path, AllAutoCreatedDirsExist) {
+  auto test_fns = {Path::CreateOrGetOrbitAppDataDir, Path::CreateOrGetDumpDir,
+                   Path::CreateOrGetPresetDir, Path::CreateOrGetCacheDir,
+                   Path::CreateOrGetOrbitAppDataDir};
+
+  for (auto fn : test_fns) {
+    std::string path = fn();
+    LOG("Testing existence of \"%s\"", path.c_str());
+    EXPECT_TRUE(std::filesystem::is_directory(path));
+  }
+}
+
+TEST(Path, AllCopiedDirsExist) {
+  auto test_fns = {Path::GetIconsPath};
+
+  for (auto fn : test_fns) {
+    std::string path = fn();
+    LOG("Testing existence of \"%s\"", path.c_str());
+    EXPECT_TRUE(std::filesystem::is_directory(path));
+  }
+}
+
+TEST(Path, AllDirsOfFilesExist) {
+  auto test_fns = {Path::GetLogFilePathAndCreateDir};
+
+  for (auto fn : test_fns) {
+    std::string path = Path::GetDirectory(fn());
+    LOG("Testing existence of \"%s\"", path.c_str());
+    EXPECT_TRUE(std::filesystem::is_directory(path));
+  }
 }

--- a/OrbitCore/PathTest.cpp
+++ b/OrbitCore/PathTest.cpp
@@ -99,22 +99,27 @@ TEST(Path, JoinPathPartsAbsoluteRootBackslash) {
 }
 
 TEST(Path, FileNamesAndExtensions) {
-#ifdef _WIN32
-  std::string abs_input[] = {"C:\\some_abs_path\\file.txt", "C:\\dir.with.dots\\file_without_ext"};
-  std::string abs_stripped[] = {"C:/some_abs_path/file", "C:/dir.with.dots/file_without_ext"};
-#else
-  std::string abs_input[] = {"/some_abs_path/file.txt", "/dir.with.dots/file_without_ext"};
-  std::string abs_stripped[] = {"/some_abs_path/file", "/dir.with.dots/file_without_ext"};
-#endif
-  EXPECT_EQ(Path::GetExtension(abs_input[0]), ".txt");
-  EXPECT_EQ(Path::StripExtension(abs_input[0]), abs_stripped[0]);
-  EXPECT_EQ(Path::GetFileName(abs_input[0]), "file.txt");
+  std::string input = "C:\\win_abs_path\\file.txt";
+  EXPECT_EQ(Path::GetExtension(input), ".txt");
+  EXPECT_EQ(Path::StripExtension(input), "C:/win_abs_path/file");
+  EXPECT_EQ(Path::GetFileName(input), "file.txt");
 
-  EXPECT_EQ(Path::GetExtension(abs_input[1]), "");
-  EXPECT_EQ(Path::StripExtension(abs_input[1]), abs_stripped[1]);
-  EXPECT_EQ(Path::GetFileName(abs_input[1]), "file_without_ext");
+  input = "/unix_abs_path/file.txt";
+  EXPECT_EQ(Path::GetExtension(input), ".txt");
+  EXPECT_EQ(Path::StripExtension(input), "/unix_abs_path/file");
+  EXPECT_EQ(Path::GetFileName(input), "file.txt");
 
-  std::string input = "relative\\mixed/path/file.txt";
+  input = "C:\\windir.with.dots\\file_without_ext";
+  EXPECT_EQ(Path::GetExtension(input), "");
+  EXPECT_EQ(Path::StripExtension(input), "C:/windir.with.dots/file_without_ext");
+  EXPECT_EQ(Path::GetFileName(input), "file_without_ext");
+
+  input = "/unixdir.with.dots/file_without_ext";
+  EXPECT_EQ(Path::GetExtension(input), "");
+  EXPECT_EQ(Path::StripExtension(input), "/unixdir.with.dots/file_without_ext");
+  EXPECT_EQ(Path::GetFileName(input), "file_without_ext");
+
+  input = "relative\\mixed/path/file.txt";
   EXPECT_EQ(Path::GetExtension(input), ".txt");
   EXPECT_EQ(Path::StripExtension(input), "relative/mixed/path/file");
   EXPECT_EQ(Path::GetFileName(input), "file.txt");

--- a/OrbitCore/SymbolHelper.cpp
+++ b/OrbitCore/SymbolHelper.cpp
@@ -52,7 +52,7 @@ std::vector<fs::path> ReadSymbolsFile() {
       if (absl::StartsWith(line, "//") || line.empty()) continue;
 
       const fs::path& dir = line;
-      if (fs::exists(dir)) {
+      if (std::filesystem::is_directory(dir)) {
         directories.push_back(dir);
       } else {
         ERROR("Symbols directory \"%s\" doesn't exist", dir.string());
@@ -84,7 +84,7 @@ ErrorMessageOr<void> VerifySymbolsFile(const fs::path& symbols_path, const std::
 }  // namespace
 
 SymbolHelper::SymbolHelper()
-    : symbols_file_directories_(ReadSymbolsFile()), cache_directory_(Path::GetCachePath()) {}
+    : symbols_file_directories_(ReadSymbolsFile()), cache_directory_(Path::CreateOrGetCacheDir()) {}
 
 ErrorMessageOr<fs::path> SymbolHelper::FindSymbolsWithSymbolsPathFile(
     const fs::path& module_path, const std::string& build_id) const {

--- a/OrbitCore/SymbolHelperTest.cpp
+++ b/OrbitCore/SymbolHelperTest.cpp
@@ -15,7 +15,7 @@
 using orbit_grpc_protos::ModuleSymbols;
 namespace fs = std::filesystem;
 
-const fs::path executable_directory = Path::GetExecutablePath() + "testdata/";
+const std::filesystem::path executable_directory = Path::GetExecutableDir() + "testdata/";
 
 TEST(SymbolHelper, FindSymbolsWithSymbolsPathFile) {
   SymbolHelper symbol_helper({executable_directory}, "");
@@ -125,8 +125,8 @@ TEST(SymbolHelper, LoadFromFile) {
 }
 
 TEST(SymbolHelper, GenerateCachedFileName) {
-  SymbolHelper symbol_helper{{}, Path::GetCachePath()};
+  SymbolHelper symbol_helper{{}, Path::CreateOrGetCacheDir()};
   const std::string file_path = "/var/data/filename.elf";
-  const std::string cache_file_path = Path::GetCachePath() + "/_var_data_filename.elf";
+  const std::string cache_file_path = Path::CreateOrGetCacheDir() + "/_var_data_filename.elf";
   EXPECT_EQ(symbol_helper.GenerateCachedFileName(file_path), cache_file_path);
 }

--- a/OrbitCore/testdata/small_file
+++ b/OrbitCore/testdata/small_file
@@ -1,0 +1,1 @@
+small file content

--- a/OrbitFramePointerValidator/FramePointerValidatorTest.cpp
+++ b/OrbitFramePointerValidator/FramePointerValidatorTest.cpp
@@ -16,8 +16,8 @@ using orbit_grpc_protos::CodeBlock;
 using orbit_grpc_protos::SymbolInfo;
 
 TEST(FramePointerValidator, GetFpoFunctions) {
-  std::string executable_path = Path::GetExecutablePath();
-  std::string test_elf_file = executable_path + "/testdata/hello_world_elf";
+  std::string executable_dir = Path::GetExecutableDir();
+  std::string test_elf_file = executable_dir + "/testdata/hello_world_elf";
 
   auto elf_file = ElfUtils::ElfFile::Create(test_elf_file);
   ASSERT_TRUE(elf_file) << elf_file.error().message();

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -169,8 +169,6 @@ bool OrbitApp::Init(ApplicationOptions&& options,
                     std::unique_ptr<MainThreadExecutor> main_thread_executor) {
   GOrbitApp = std::make_unique<OrbitApp>(std::move(options), std::move(main_thread_executor));
 
-  Path::Init();
-
 #ifdef _WIN32
   oqpi_tk::start_default_scheduler();
 #endif
@@ -319,7 +317,7 @@ void OrbitApp::LoadFileMapping() {
 }
 
 void OrbitApp::ListPresets() {
-  std::vector<std::string> preset_filenames = Path::ListFiles(Path::GetPresetPath(), ".opr");
+  std::vector<std::string> preset_filenames = Path::ListFiles(Path::CreateOrGetPresetDir(), ".opr");
   std::vector<std::shared_ptr<PresetFile>> presets;
   for (std::string& filename : preset_filenames) {
     ErrorMessageOr<PresetInfo> preset_result = ReadPresetFromFile(filename);
@@ -524,7 +522,7 @@ ErrorMessageOr<PresetInfo> OrbitApp::ReadPresetFromFile(const std::string& filen
   std::string file_path = filename;
 
   if (Path::GetDirectory(filename).empty()) {
-    file_path = Path::JoinPath({Path::GetPresetPath(), filename});
+    file_path = Path::JoinPath({Path::CreateOrGetPresetDir(), filename});
   }
 
   std::ifstream file(file_path, std::ios::binary);

--- a/OrbitGl/ImGuiOrbit.cpp
+++ b/OrbitGl/ImGuiOrbit.cpp
@@ -582,8 +582,8 @@ void Orbit_ImGui_RenderDrawLists(ImDrawData* draw_data) {
 }
 
 ImFont* AddOrbitFont(float pixel_size) {
-  const auto exe_path = Path::GetExecutablePath();
-  const auto font_file_name = exe_path + "fonts/Vera.ttf";
+  const auto exe_dir = Path::GetExecutableDir();
+  const auto font_file_name = Path::JoinPath({exe_dir, "fonts", "Vera.ttf"});
   return ImGui::GetIO().Fonts->AddFontFromFileTTF(font_file_name.c_str(), pixel_size);
 }
 

--- a/OrbitGl/TextRenderer.cpp
+++ b/OrbitGl/TextRenderer.cpp
@@ -55,8 +55,8 @@ void TextRenderer::Init() {
   int atlasSize = 2 * 1024;
   m_Atlas = texture_atlas_new(atlasSize, atlasSize, 1);
 
-  const auto exePath = Path::GetExecutablePath();
-  const auto fontFileName = exePath + "fonts/Vera.ttf";
+  const auto exe_dir = Path::GetExecutableDir();
+  const auto fontFileName = exe_dir + "fonts/Vera.ttf";
 
   static float fsize = GParams.font_size;
   m_Buffer = vertex_buffer_new("vertex:3f,tex_coord:2f,color:4f");
@@ -71,8 +71,8 @@ void TextRenderer::Init() {
 
   glGenTextures(1, &m_Atlas->id);
 
-  const auto vertShaderFileName = exePath + "shaders/v3f-t2f-c4f.vert";
-  const auto fragShaderFileName = exePath + "shaders/v3f-t2f-c4f.frag";
+  const auto vertShaderFileName = Path::JoinPath({exe_dir, "shaders", "v3f-t2f-c4f.vert"});
+  const auto fragShaderFileName = Path::JoinPath({exe_dir, "shaders", "v3f-t2f-c4f.frag"});
   m_Shader = shader_load(vertShaderFileName.c_str(), fragShaderFileName.c_str());
 
   mat4_set_identity(&m_Proj);

--- a/OrbitQt/OrbitStartupWindow.cpp
+++ b/OrbitQt/OrbitStartupWindow.cpp
@@ -69,7 +69,7 @@ OrbitStartupWindow::OrbitStartupWindow(QWidget* parent)
 
   QObject::connect(load_capture_button, &QPushButton::clicked, this, [this, button_box]() {
     const QString file = QFileDialog::getOpenFileName(
-        this, "Open capture...", QString::fromStdString(Path::GetCapturePath()), "*.orbit");
+        this, "Open capture...", QString::fromStdString(Path::CreateOrGetCaptureDir()), "*.orbit");
     if (!file.isEmpty()) {
       result_ = file;
       accept();

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -244,7 +244,7 @@ int main(int argc, char* argv[]) {
     absl::SetFlagsUsageConfig(absl::FlagsUsageConfig{{}, {}, {}, &OrbitCore::GetBuildReport, {}});
     absl::ParseCommandLine(argc, argv);
 
-    const std::string log_file_path = Path::GetLogFilePath();
+    const std::string log_file_path = Path::GetLogFilePathAndCreateDir();
     InitLogFile(log_file_path);
     LOG("You are running Orbit Profiler version %s", OrbitCore::GetVersion());
 
@@ -258,7 +258,7 @@ int main(int argc, char* argv[]) {
     path_to_executable = QCoreApplication::applicationFilePath();
 
 #ifdef ORBIT_CRASH_HANDLING
-    const std::string dump_path = Path::GetDumpPath();
+    const std::string dump_path = Path::CreateOrGetDumpDir();
 #ifdef _WIN32
     const char* handler_name = "crashpad_handler.exe";
 #else
@@ -267,7 +267,7 @@ int main(int argc, char* argv[]) {
     const std::string handler_path =
         QDir(QCoreApplication::applicationDirPath()).absoluteFilePath(handler_name).toStdString();
     const std::string crash_server_url = CrashServerOptions::GetUrl();
-    const std::vector<std::string> attachments = {Path::GetLogFilePath()};
+    const std::vector<std::string> attachments = {Path::GetLogFilePathAndCreateDir()};
 
     CrashHandler crash_handler(dump_path, handler_path, crash_server_url, attachments);
 #endif  // ORBIT_CRASH_HANDLING

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -189,7 +189,7 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App, ApplicationOptions&& optio
           [this](const QString& text) { OnLiveTabFunctionsFilterTextChanged(text); });
 
   SetTitle({});
-  std::string iconFileName = Path::GetExecutablePath() + "orbit.ico";
+  std::string iconFileName = Path::JoinPath({Path::GetExecutableDir(), "orbit.ico"});
   this->setWindowIcon(QIcon(iconFileName.c_str()));
 
   GOrbitApp->PostInit();
@@ -429,7 +429,7 @@ void OrbitMainWindow::OnFilterTracksTextChanged(const QString& text) {
 
 void OrbitMainWindow::on_actionOpen_Preset_triggered() {
   QStringList list = QFileDialog::getOpenFileNames(this, "Select a file to open...",
-                                                   Path::GetPresetPath().c_str(), "*.opr");
+                                                   Path::CreateOrGetPresetDir().c_str(), "*.opr");
   for (const auto& file : list) {
     ErrorMessageOr<void> result = GOrbitApp->OnLoadPreset(file.toStdString());
     if (result.has_error()) {
@@ -458,7 +458,7 @@ QPixmap QtGrab(OrbitMainWindow* a_Window) {
 
 void OrbitMainWindow::on_actionSave_Preset_As_triggered() {
   QString file = QFileDialog::getSaveFileName(this, "Specify a file to save...",
-                                              Path::GetPresetPath().c_str(), "*.opr");
+                                              Path::CreateOrGetPresetDir().c_str(), "*.opr");
   if (file.isEmpty()) {
     return;
   }
@@ -505,7 +505,8 @@ void OrbitMainWindow::on_actionSave_Capture_triggered() {
 
   QString file = QFileDialog::getSaveFileName(
       this, "Save capture...",
-      Path::JoinPath({Path::GetCapturePath(), GOrbitApp->GetCaptureFileName()}).c_str(), "*.orbit");
+      Path::JoinPath({Path::CreateOrGetCaptureDir(), GOrbitApp->GetCaptureFileName()}).c_str(),
+      "*.orbit");
   if (file.isEmpty()) {
     return;
   }
@@ -521,7 +522,7 @@ void OrbitMainWindow::on_actionSave_Capture_triggered() {
 
 void OrbitMainWindow::on_actionOpen_Capture_triggered() {
   QString file = QFileDialog::getOpenFileName(
-      this, "Open capture...", QString::fromStdString(Path::GetCapturePath()), "*.orbit");
+      this, "Open capture...", QString::fromStdString(Path::CreateOrGetCaptureDir()), "*.orbit");
   if (file.isEmpty()) {
     return;
   }


### PR DESCRIPTION
This came up for a method that was added to Path.cpp in this PR: https://github.com/google/orbit/pull/1120
I decided to consistently add [[nodiscard]] for all methods, and this lead to some more fixes... which lead to tests to be sure I didn't break the rest of the class.

- Added [[nodiscard]] everywhere
- Changed internal logic for GetBasePath() and Init() due to a warning resulting from [[nodiscard]]
- Renamed some methods to make it more obvious that they are creating directories, and to distinguish between "path" and "dir"
- Added tests for uncovered parts of Path.cpp to make sure I didn't break anything