### PR TITLE
Fix potential crash in OrbitGgp

### DIFF
--- a/OrbitGgp/Client.cpp
+++ b/OrbitGgp/Client.cpp
@@ -29,12 +29,14 @@ void RunProcessWithTimeout(const QString& program, const QStringList& arguments,
   const auto timeout_timer = QPointer{new QTimer{parent}};
 
   QObject::connect(timeout_timer, &QTimer::timeout, parent, [process, timeout_timer, callback]() {
-    if (!process->waitForFinished(10)) {
+    if (process && !process->waitForFinished(10)) {
       ERROR("Process request timed out after %dms", kDefaultTimeoutInMs);
       callback(Error::kRequestTimedOut);
-      process->terminate();
-      process->waitForFinished();
-      process->deleteLater();
+      if (process) {
+        process->terminate();
+        process->waitForFinished();
+        process->deleteLater();
+      }
     }
 
     timeout_timer->deleteLater();


### PR DESCRIPTION
This change prevents an asynchronously executed callback from accessing
a potentially already deleted object of type QProcess.

There are two checks in this commit since we have to check before and
after custom user code is executed which could potentially delete the
QProcess object.

I hope this will fix a crash reported in http://b/166385260, but due to
the asynchronous nature of that problem we can't say for sure.

Tested manually. The timeout works fine.