### PR TITLE
Refactor client symbol loading

### DIFF
--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -15,6 +15,7 @@
 #include "OrbitBase/Result.h"
 #include "OrbitCaptureClient/CaptureClient.h"
 #include "OrbitClientServices/ProcessManager.h"
+#include "SymbolHelper.h"
 #include "capture_data.pb.h"
 
 using orbit_grpc_protos::ModuleInfo;
@@ -140,8 +141,7 @@ ErrorMessageOr<void> ClientGgp::LoadModuleAndSymbols() {
   OUTCOME_TRY(main_executable_debug_file, process_client_->FindDebugInfoFile(module_path));
   LOG("Found file: %s", main_executable_debug_file);
   LOG("Loading symbols");
-  OUTCOME_TRY(symbols, symbol_helper_.LoadSymbolsFromFile(main_executable_debug_file,
-                                                          module->m_DebugSignature));
+  OUTCOME_TRY(symbols, SymbolHelper::LoadSymbolsFromFile(main_executable_debug_file));
   module->LoadSymbols(symbols);
   target_process_->AddFunctions(module->m_Pdb->GetFunctions());
   return outcome::success();

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -15,7 +15,6 @@
 #include "OrbitCaptureClient/CaptureListener.h"
 #include "OrbitClientServices/ProcessClient.h"
 #include "OrbitProcess.h"
-#include "SymbolHelper.h"
 #include "grpcpp/grpcpp.h"
 
 class ClientGgp final : public CaptureListener {
@@ -44,8 +43,6 @@ class ClientGgp final : public CaptureListener {
   std::shared_ptr<Process> target_process_;
   std::unique_ptr<CaptureClient> capture_client_;
   std::unique_ptr<ProcessClient> process_client_;
-
-  const SymbolHelper symbol_helper_;
 
   ErrorMessageOr<std::shared_ptr<Process>> GetOrbitProcessByPid(int32_t pid);
   bool InitCapture();

--- a/OrbitCore/OrbitModuleTest.cpp
+++ b/OrbitCore/OrbitModuleTest.cpp
@@ -135,7 +135,7 @@ TEST(OrbitModule, GetFunctionFromProgramCounter) {
   EXPECT_EQ(function->name(), "__free");
 }
 
-TEST(SymbolHelper, LoadSymbols) {
+TEST(OrbitModule, LoadSymbols) {
   ModuleSymbols module_symbols;
   module_symbols.set_symbols_file_path("path/symbols_file_name");
   module_symbols.set_load_bias(0x400);

--- a/OrbitCore/SymbolHelper.cpp
+++ b/OrbitCore/SymbolHelper.cpp
@@ -8,21 +8,24 @@
 #include <absl/strings/str_format.h>
 #include <absl/strings/str_replace.h>
 
+#include <filesystem>
 #include <fstream>
 
 #include "ElfUtils/ElfFile.h"
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/Result.h"
 #include "Path.h"
 
 using orbit_grpc_protos::ModuleSymbols;
 
-namespace {
-
+namespace fs = std::filesystem;
 using ::ElfUtils::ElfFile;
 
-std::vector<std::string> ReadSymbolsFile() {
+namespace {
+
+std::vector<fs::path> ReadSymbolsFile() {
   std::string file_name = Path::GetSymbolsFileName();
-  if (!std::filesystem::exists(file_name)) {
+  if (!fs::exists(file_name)) {
     std::ofstream outfile(file_name);
     outfile << "//-------------------" << std::endl
             << "// Orbit Symbol Locations" << std::endl
@@ -41,118 +44,112 @@ std::vector<std::string> ReadSymbolsFile() {
     outfile.close();
   }
 
-  std::vector<std::string> directories;
+  std::vector<fs::path> directories;
   std::fstream infile(file_name);
   if (!infile.fail()) {
     std::string line;
     while (std::getline(infile, line)) {
       if (absl::StartsWith(line, "//") || line.empty()) continue;
 
-      const std::string& dir = line;
-      if (Path::DirExists(dir)) {
+      const fs::path& dir = line;
+      if (fs::exists(dir)) {
         directories.push_back(dir);
       } else {
-        ERROR("Symbols directory \"%s\" doesn't exist", dir);
+        ERROR("Symbols directory \"%s\" doesn't exist", dir.string());
       }
     }
   }
   return directories;
 }
 
-ErrorMessageOr<std::string> FindSymbolsFile(const std::string& module_path,
-                                            const std::vector<std::string>& search_paths,
-                                            const std::string& build_id) {
-  std::string filename = Path::GetFileName(module_path);
-  std::string filename_without_extension = Path::StripExtension(filename);
+ErrorMessageOr<void> VerifySymbolsFile(const fs::path& symbols_path, const std::string& build_id) {
+  OUTCOME_TRY(symbols_file, ElfFile::Create(symbols_path.string()));
 
-  std::vector<std::string> search_file_paths;
-  search_file_paths.push_back(module_path);
-
-  for (const auto& directory : search_paths) {
-    search_file_paths.emplace_back(
-        Path::JoinPath({directory, filename_without_extension + ".debug"}));
-    search_file_paths.emplace_back(Path::JoinPath({directory, filename + ".debug"}));
-    search_file_paths.emplace_back(Path::JoinPath({directory, filename}));
+  if (!symbols_file->HasSymtab()) {
+    return ErrorMessage(
+        absl::StrFormat("Elf file \"%s\" does not contain symbols.", symbols_path.string()));
   }
-
-  LOG("Trying to find symbols for module: \"%s\"", module_path);
-  for (const auto& symbols_file_path : search_file_paths) {
-    if (!std::filesystem::exists(symbols_file_path)) continue;
-
-    ErrorMessageOr<std::unique_ptr<ElfFile>> symbols_file = ElfFile::Create(symbols_file_path);
-    if (!symbols_file) continue;
-    if (!symbols_file.value()->HasSymtab()) continue;
-
-    // don't check build_id of module_path itself has symbols
-    // and requested build_id is empty.
-    if (build_id.empty() && symbols_file_path == module_path) {
-      return symbols_file_path;
-    }
-
-    // Otherwise check that build_id is not empty and correct.
-    if (symbols_file.value()->GetBuildId().empty()) continue;
-    if (symbols_file.value()->GetBuildId() != build_id) continue;
-
-    LOG("Found debug info for module \"%s\" -> \"%s\"", module_path, symbols_file_path);
-    return symbols_file_path;
+  if (symbols_file->GetBuildId().empty()) {
+    return ErrorMessage(
+        absl::StrFormat("Symbols file \"%s\" does not have a build id", symbols_path.string()));
   }
-
-  return ErrorMessage(
-      absl::StrFormat("Could not find a file with debug symbols for module \"%s\"", module_path));
+  const std::string& file_build_id = symbols_file->GetBuildId();
+  if (build_id != file_build_id) {
+    return ErrorMessage(
+        absl::StrFormat(R"(Symbols file "%s" has a different build id: "%s" != "%s")",
+                        symbols_path.string(), build_id, file_build_id));
+  }
+  return outcome::success();
 }
-
-ErrorMessageOr<ModuleSymbols> FindSymbols(const std::string& module_path,
-                                          const std::string& build_id,
-                                          const std::vector<std::string>& search_paths) {
-  ErrorMessageOr<std::string> debug_info_file_path =
-      FindSymbolsFile(module_path, search_paths, build_id);
-
-  if (!debug_info_file_path) {
-    return debug_info_file_path.error();
-  }
-
-  ErrorMessageOr<std::unique_ptr<ElfFile>> elf_file_result =
-      ElfFile::Create(debug_info_file_path.value());
-
-  if (!elf_file_result) {
-    return ErrorMessage(absl::StrFormat("Failed to load debug symbols for \"%s\" from \"%s\": %s",
-                                        module_path, debug_info_file_path.value(),
-                                        elf_file_result.error().message()));
-  }
-
-  return elf_file_result.value()->LoadSymbols();
-}
-
 }  // namespace
 
-SymbolHelper::SymbolHelper() : symbols_file_directories_(ReadSymbolsFile()) {}
+SymbolHelper::SymbolHelper()
+    : symbols_file_directories_(ReadSymbolsFile()), cache_directory_(Path::GetCachePath()) {}
 
-ErrorMessageOr<ModuleSymbols> SymbolHelper::LoadUsingSymbolsPathFile(
-    const std::string& module_path, const std::string& build_id) const {
-  return FindSymbols(module_path, build_id, symbols_file_directories_);
-}
-
-ErrorMessageOr<ModuleSymbols> SymbolHelper::LoadSymbolsFromFile(const std::string& file_path,
-                                                                const std::string& build_id) const {
-  ErrorMessageOr<std::unique_ptr<ElfFile>> elf_file_result = ElfFile::Create(file_path);
-
-  if (!elf_file_result) {
-    return ErrorMessage(absl::StrFormat("Failed to load debug symbols from \"%s\": %s", file_path,
-                                        elf_file_result.error().message()));
+ErrorMessageOr<fs::path> SymbolHelper::FindSymbolsWithSymbolsPathFile(
+    const fs::path& module_path, const std::string& build_id) const {
+  if (build_id.empty()) {
+    return ErrorMessage(absl::StrFormat(
+        "Could not find symbols file for module \"%s\", because it does not contain a build id",
+        module_path.string()));
   }
 
-  const std::string& target_build_id = elf_file_result.value()->GetBuildId();
-  if (target_build_id != build_id) {
+  const fs::path& filename = module_path.filename();
+  fs::path filename_dot_debug = filename;
+  filename_dot_debug.replace_extension(".debug");
+  fs::path filename_plus_debug = filename;
+  filename_plus_debug.replace_extension(filename.extension().string() + ".debug");
+
+  std::set<fs::path> search_paths;
+  for (const auto& directory : symbols_file_directories_) {
+    search_paths.insert(directory / filename_dot_debug);
+    search_paths.insert(directory / filename_plus_debug);
+    search_paths.insert(directory / filename);
+  }
+
+  LOG("Trying to find symbols for module: \"%s\"", module_path.string());
+  for (const auto& symbols_path : search_paths) {
+    if (!fs::exists(symbols_path)) continue;
+
+    const auto verification_result = VerifySymbolsFile(symbols_path, build_id);
+    if (!verification_result) {
+      LOG("Existing file \"%s\" is not the symbols file for module \"%s\", error: %s",
+          symbols_path.string(), module_path.string(), verification_result.error().message());
+      continue;
+    }
+
+    LOG("Found debug info for module \"%s\" -> \"%s\"", module_path.string(),
+        symbols_path.string());
+    return symbols_path;
+  }
+
+  return ErrorMessage(absl::StrFormat("Could not find a file with debug symbols for module \"%s\"",
+                                      module_path.string()));
+}
+
+[[nodiscard]] ErrorMessageOr<fs::path> SymbolHelper::FindSymbolsInCache(
+    const fs::path& module_path, const std::string& build_id) const {
+  fs::path cache_file_path = GenerateCachedFileName(module_path);
+  if (!fs::exists(cache_file_path)) {
     return ErrorMessage(
-        absl::StrFormat("Failed to load debug symbols from \"%s\": invalid "
-                        "build id \"%s\", expected: \"%s\"",
-                        file_path, target_build_id, build_id));
+        absl::StrFormat("Unable to find symbols in cache for module \"%s\"", module_path.string()));
+  }
+  OUTCOME_TRY(VerifySymbolsFile(cache_file_path, build_id));
+  return cache_file_path;
+}
+
+ErrorMessageOr<ModuleSymbols> SymbolHelper::LoadSymbolsFromFile(const fs::path& file_path) {
+  ErrorMessageOr<std::unique_ptr<ElfFile>> elf_file_result = ElfFile::Create(file_path.string());
+
+  if (!elf_file_result) {
+    return ErrorMessage(absl::StrFormat("Failed to load debug symbols from \"%s\": %s",
+                                        file_path.string(), elf_file_result.error().message()));
   }
 
   return elf_file_result.value()->LoadSymbols();
 }
 
-std::string SymbolHelper::GenerateCachedFileName(const std::string& file_path) const {
-  auto file_name = absl::StrReplaceAll(file_path, {{"/", "_"}});
-  return Path::JoinPath({Path::GetCachePath(), file_name});
+fs::path SymbolHelper::GenerateCachedFileName(const fs::path& file_path) const {
+  auto file_name = absl::StrReplaceAll(file_path.string(), {{"/", "_"}});
+  return cache_directory_ / file_name;
 }

--- a/OrbitCore/SymbolHelper.h
+++ b/OrbitCore/SymbolHelper.h
@@ -5,27 +5,34 @@
 #ifndef SYMBOL_HELPER_H_
 #define SYMBOL_HELPER_H_
 
+#include <filesystem>
 #include <string>
 #include <vector>
 
 #include "OrbitBase/Result.h"
 #include "symbol.pb.h"
 
+namespace fs = std::filesystem;
+
 class SymbolHelper {
  public:
   SymbolHelper();
-  explicit SymbolHelper(std::vector<std::string> symbols_file_directories)
-      : symbols_file_directories_(std::move(symbols_file_directories)){};
+  explicit SymbolHelper(std::vector<fs::path> symbols_file_directories, fs::path cache_directory)
+      : symbols_file_directories_(std::move(symbols_file_directories)),
+        cache_directory_(std::move(cache_directory)){};
 
-  [[nodiscard]] ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> LoadUsingSymbolsPathFile(
-      const std::string& module_path, const std::string& build_id) const;
-  [[nodiscard]] ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> LoadSymbolsFromFile(
-      const std::string& file_path, const std::string& build_id) const;
+  [[nodiscard]] ErrorMessageOr<fs::path> FindSymbolsWithSymbolsPathFile(
+      const fs::path& module_path, const std::string& build_id) const;
+  [[nodiscard]] ErrorMessageOr<fs::path> FindSymbolsInCache(const fs::path& module_path,
+                                                            const std::string& build_id) const;
+  [[nodiscard]] static ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> LoadSymbolsFromFile(
+      const fs::path& file_path);
 
-  [[nodiscard]] std::string GenerateCachedFileName(const std::string& file_path) const;
+  [[nodiscard]] fs::path GenerateCachedFileName(const fs::path& file_path) const;
 
  private:
-  const std::vector<std::string> symbols_file_directories_;
+  const std::vector<fs::path> symbols_file_directories_;
+  const fs::path cache_directory_;
 };
 
 #endif  // SYMBOL_HELPER_H_

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -54,6 +54,7 @@
 #include "preset.pb.h"
 #include "services.grpc.pb.h"
 #include "services.pb.h"
+#include "symbol.pb.h"
 #include "tracepoint.pb.h"
 
 ABSL_DECLARE_FLAG(bool, enable_tracepoint_feature);
@@ -193,7 +194,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void SendErrorToUi(const std::string& title, const std::string& text);
   void NeedsRedraw();
 
-  void LoadModules(const std::shared_ptr<Process>& process, int32_t process_id,
+  void LoadModules(const std::shared_ptr<Process>& process,
                    const std::vector<std::shared_ptr<Module>>& modules,
                    const std::shared_ptr<orbit_client_protos::PresetFile>& preset = nullptr);
   void LoadModulesFromPreset(const std::shared_ptr<Process>& process,
@@ -238,11 +239,14 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void SelectTextBox(const TextBox* text_box);
 
  private:
-  void LoadModuleOnRemote(const std::shared_ptr<Process>& process, int32_t process_id,
+  ErrorMessageOr<std::filesystem::path> FindSymbolsLocally(const std::filesystem::path& module_path,
+                                                           const std::string& build_id);
+  void LoadSymbols(const std::filesystem::path& symbols_path,
+                   const std::shared_ptr<Process>& process, const std::shared_ptr<Module>& module,
+                   const std::shared_ptr<orbit_client_protos::PresetFile>& preset);
+  void LoadModuleOnRemote(const std::shared_ptr<Process>& process,
                           const std::shared_ptr<Module>& module,
                           const std::shared_ptr<orbit_client_protos::PresetFile>& preset);
-  void SymbolLoadingFinished(uint32_t process_id, const std::shared_ptr<Module>& module,
-                             const std::shared_ptr<orbit_client_protos::PresetFile>& preset);
 
   ErrorMessageOr<orbit_client_protos::PresetInfo> ReadPresetFromFile(const std::string& filename);
 

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -111,8 +111,7 @@ void CallStackDataView::OnContextMenu(const std::string& action, int menu_index,
       CallStackDataViewFrame frame = GetFrameFromRow(i);
       std::shared_ptr<Module> module = frame.module;
       if (module != nullptr && !module->IsLoaded()) {
-        GOrbitApp->LoadModules(Capture::capture_data_.process(),
-                               Capture::capture_data_.process_id(), {module});
+        GOrbitApp->LoadModules(Capture::capture_data_.process(), {module});
       }
     }
 

--- a/OrbitGl/ModulesDataView.cpp
+++ b/OrbitGl/ModulesDataView.cpp
@@ -122,7 +122,7 @@ void ModulesDataView::OnContextMenu(const std::string& action, int menu_index,
         modules.push_back(process->GetModuleFromPath(module_data->file_path()));
       }
     }
-    GOrbitApp->LoadModules(process, GOrbitApp->GetSelectedProcessId(), modules);
+    GOrbitApp->LoadModules(process, modules);
 
   } else if (action == kMenuActionVerifyFramePointers) {
     std::vector<std::shared_ptr<Module>> modules_to_validate;

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -212,8 +212,7 @@ void SamplingReportDataView::OnContextMenu(const std::string& action, int menu_i
         modules.push_back(module);
       }
     }
-    GOrbitApp->LoadModules(Capture::capture_data_.process(), Capture::capture_data_.process_id(),
-                           modules);
+    GOrbitApp->LoadModules(Capture::capture_data_.process(), modules);
   } else if (action == kMenuActionDisassembly) {
     int32_t pid = Capture::capture_data_.process_id();
     for (FunctionInfo* function : GetFunctionsFromIndices(item_indices)) {


### PR DESCRIPTION
This simplifies the symbol loading flow a little bit and adds more tests. 

Since Orbit downloads and caches the symbols file, the flow was a little broken. Now it should be:
LoadModules:
1. Check local from SymbolsPaths.txt -> iff found -> LoadSymbols()
2. Check local in cache -> iff found -> LoadSymbols()
3. Load from Remote -> if found on remote, download into cache -> LoadSymbols

