### PR TITLE
Fix bug occuring when applying preset.

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -879,6 +879,7 @@ void OrbitApp::LoadModulesFromPreset(const std::shared_ptr<Process>& process,
   if (!modules_to_load.empty()) {
     LoadModules(process, process->GetId(), modules_to_load, preset);
   }
+  FireRefreshCallbacks();
 }
 
 void OrbitApp::UpdateProcessAndModuleList(
@@ -926,6 +927,7 @@ void OrbitApp::UpdateProcessAndModuleList(
 
       if (preset) {
         LoadModulesFromPreset(process, preset);
+        data_manager_->set_selected_process(process);
       }
       // To this point ----------------------------------
 


### PR DESCRIPTION
This fixes two issues:

When applying a preset and the process was already selected there was a redraw
missing.

When applying a preset and a different process was selected the hooked
functions were cleared after the preset was applied.

Bug: b/166450212
Test: Ran locally, works fine now.