### PR TITLE
Select tracepoints to show up in the capture

### DIFF
--- a/OrbitCaptureClient/CaptureClient.cpp
+++ b/OrbitCaptureClient/CaptureClient.cpp
@@ -33,7 +33,10 @@ static CaptureOptions::InstrumentedFunction::FunctionType IntrumentedFunctionTyp
 ErrorMessageOr<void> CaptureClient::StartCapture(
     ThreadPool* thread_pool, int32_t process_id, std::string process_name,
     std::shared_ptr<Process> process,
-    absl::flat_hash_map<uint64_t, FunctionInfo> selected_functions) {
+    absl::flat_hash_map<uint64_t, FunctionInfo> selected_functions,
+    absl::flat_hash_set<orbit_grpc_protos::TracepointInfo, internal::HashTracepointInfo,
+                        internal::EqualTracepointInfo>
+        selected_tracepoints) {
   absl::MutexLock lock(&state_mutex_);
   if (state_ != State::kStopped) {
     return ErrorMessage(
@@ -42,16 +45,20 @@ ErrorMessageOr<void> CaptureClient::StartCapture(
   }
 
   state_ = State::kStarting;
-  thread_pool->Schedule([this, process_id, process_name, process, selected_functions]() {
-    Capture(process_id, process_name, process, selected_functions);
-  });
+  thread_pool->Schedule(
+      [this, process_id, process_name, process, selected_functions, selected_tracepoints]() {
+        Capture(process_id, process_name, process, selected_functions, selected_tracepoints);
+      });
 
   return outcome::success();
 }
 
-void CaptureClient::Capture(int32_t process_id, std::string process_name,
-                            std::shared_ptr<Process> process,
-                            absl::flat_hash_map<uint64_t, FunctionInfo> selected_functions) {
+void CaptureClient::Capture(
+    int32_t process_id, std::string process_name, std::shared_ptr<Process> process,
+    absl::flat_hash_map<uint64_t, FunctionInfo> selected_functions,
+    absl::flat_hash_set<orbit_grpc_protos::TracepointInfo, internal::HashTracepointInfo,
+                        internal::EqualTracepointInfo>
+        selected_tracepoints) {
   CHECK(reader_writer_ == nullptr);
 
   grpc::ClientContext context;
@@ -84,6 +91,13 @@ void CaptureClient::Capture(int32_t process_id, std::string process_name,
     instrumented_function->set_function_type(IntrumentedFunctionTypeFromOrbitType(function.type()));
   }
 
+  for (const auto& tracepoint : selected_tracepoints) {
+    CaptureOptions::InstrumentedTracepoint* instrumented_tracepoint =
+        capture_options->add_instrumented_tracepoint();
+    instrumented_tracepoint->set_category(tracepoint.category());
+    instrumented_tracepoint->set_name(tracepoint.name());
+  }
+
   if (!reader_writer_->Write(request)) {
     ERROR("Sending CaptureRequest on Capture's gRPC stream");
     reader_writer_->WritesDone();
@@ -100,7 +114,8 @@ void CaptureClient::Capture(int32_t process_id, std::string process_name,
   CaptureEventProcessor event_processor(capture_listener_);
 
   capture_listener_->OnCaptureStarted(process_id, std::move(process_name), std::move(process),
-                                      std::move(selected_functions));
+                                      std::move(selected_functions),
+                                      std::move(selected_tracepoints));
 
   CaptureResponse response;
   while (!force_stop_ && reader_writer_->Read(&response)) {

--- a/OrbitCaptureClient/CaptureEventProcessor.cpp
+++ b/OrbitCaptureClient/CaptureEventProcessor.cpp
@@ -47,6 +47,9 @@ void CaptureEventProcessor::ProcessEvent(const CaptureEvent& event) {
     case CaptureEvent::kAddressInfo:
       ProcessAddressInfo(event.address_info());
       break;
+    case CaptureEvent::kTracepointServerResponse:
+      ProcessTracepointServerResponse(event.tracepoint_server_response());
+      break;
     case CaptureEvent::EVENT_NOT_SET:
       ERROR("CaptureEvent::EVENT_NOT_SET read from Capture's gRPC stream");
       break;
@@ -192,6 +195,17 @@ void CaptureEventProcessor::ProcessAddressInfo(const AddressInfo& address_info) 
   linux_address_info.set_function_name(function_name);
   linux_address_info.set_offset_in_function(address_info.offset_in_function());
   capture_listener_->OnAddressInfo(linux_address_info);
+}
+
+void CaptureEventProcessor::ProcessTracepointServerResponse(
+    const orbit_grpc_protos::TracepointServerResponse tracepoint_server_response) {
+  orbit_grpc_protos::TracepointInfo tracepoint_info;
+  tracepoint_info.set_category(tracepoint_server_response.category());
+  tracepoint_info.set_name(tracepoint_server_response.name());
+  capture_listener_->OnTracepointServiceResponse(
+      tracepoint_server_response.pid(), tracepoint_server_response.tid(),
+      tracepoint_server_response.time(), tracepoint_server_response.stream_id(),
+      tracepoint_server_response.cpu(), tracepoint_info);
 }
 
 uint64_t CaptureEventProcessor::GetCallstackHashAndSendToListenerIfNecessary(

--- a/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -8,11 +8,13 @@
 #include "OrbitCaptureClient/CaptureListener.h"
 #include "absl/flags/flag.h"
 #include "services.pb.h"
+#include "tracepoint.pb.h"
 
 ABSL_FLAG(uint16_t, sampling_rate, 1000, "Frequency of callstack sampling in samples per second");
 ABSL_FLAG(bool, frame_pointer_unwinding, false, "Use frame pointers for unwinding");
 
 using orbit_grpc_protos::CaptureResponse;
+using orbit_grpc_protos::TracepointInfo;
 
 namespace {
 using orbit_client_protos::CallstackEvent;
@@ -23,8 +25,9 @@ class MyCaptureListener : public CaptureListener {
  private:
   void OnCaptureStarted(
       int32_t /*process_id*/, std::string /*process_name*/, std::shared_ptr<Process> /*process*/,
-      absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> /*selected_functions*/)
-      override {}
+      absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> /*selected_functions*/,
+      absl::flat_hash_set<orbit_grpc_protos::TracepointInfo, internal::HashTracepointInfo,
+                          internal::EqualTracepointInfo> /*selected_tracepoints*/) override {}
   void OnCaptureComplete() override {}
   void OnTimer(const TimerInfo&) override {}
   void OnKeyAndString(uint64_t, std::string) override {}
@@ -32,6 +35,8 @@ class MyCaptureListener : public CaptureListener {
   void OnCallstackEvent(CallstackEvent) override {}
   void OnThreadName(int32_t, std::string) override {}
   void OnAddressInfo(LinuxAddressInfo) override {}
+  void OnTracepointServiceResponse(int32_t, int32_t, int64_t, int64_t, int32_t,
+                                   TracepointInfo) override {}
 };
 }  // namespace
 

--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
@@ -7,6 +7,7 @@
 
 #include <optional>
 
+#include "../../OrbitGl/TracepointCustom.h"
 #include "CaptureListener.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
@@ -32,7 +33,10 @@ class CaptureClient {
   [[nodiscard]] ErrorMessageOr<void> StartCapture(
       ThreadPool* thread_pool, int32_t process_id, std::string process_name,
       std::shared_ptr<Process> process,
-      absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions);
+      absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
+      absl::flat_hash_set<orbit_grpc_protos::TracepointInfo, internal::HashTracepointInfo,
+                          internal::EqualTracepointInfo>
+          selected_tracepoints);
 
   // Returns true if stop was initiated and false otherwise.
   // The latter can happen if for example the stop was already
@@ -54,7 +58,10 @@ class CaptureClient {
 
  private:
   void Capture(int32_t process_id, std::string process_name, std::shared_ptr<Process> process,
-               absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions);
+               absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
+               absl::flat_hash_set<orbit_grpc_protos::TracepointInfo, internal::HashTracepointInfo,
+                                   internal::EqualTracepointInfo>
+                   selected_tracepoints);
 
   void FinishCapture();
 

--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
@@ -33,6 +33,8 @@ class CaptureEventProcessor {
   void ProcessGpuJob(const orbit_grpc_protos::GpuJob& gpu_job);
   void ProcessThreadName(const orbit_grpc_protos::ThreadName& thread_name);
   void ProcessAddressInfo(const orbit_grpc_protos::AddressInfo& address_info);
+  void ProcessTracepointServerResponse(
+      const orbit_grpc_protos::TracepointServerResponse tracepoint_server_response);
 
   absl::flat_hash_map<uint64_t, orbit_grpc_protos::Callstack> callstack_intern_pool;
   absl::flat_hash_map<uint64_t, std::string> string_intern_pool;

--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
@@ -5,12 +5,15 @@
 #ifndef ORBIT_CAPTURE_CLIENT_CAPTURE_LISTENER_H_
 #define ORBIT_CAPTURE_CLIENT_CAPTURE_LISTENER_H_
 
+#include "../../OrbitGl/TracepointCustom.h"
 #include "Callstack.h"
 #include "EventBuffer.h"
 #include "OrbitProcess.h"
 #include "ScopeTimer.h"
 #include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
 #include "capture_data.pb.h"
+#include "tracepoint.pb.h"
 
 class CaptureListener {
  public:
@@ -19,7 +22,10 @@ class CaptureListener {
   // Called after capture started but before the first event arrived.
   virtual void OnCaptureStarted(
       int32_t process_id, std::string process_name, std::shared_ptr<Process> process,
-      absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions) = 0;
+      absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
+      absl::flat_hash_set<orbit_grpc_protos::TracepointInfo, internal::HashTracepointInfo,
+                          internal::EqualTracepointInfo>
+          selected_tracepoints) = 0;
   // Called when capture is complete
   virtual void OnCaptureComplete() = 0;
 
@@ -29,6 +35,9 @@ class CaptureListener {
   virtual void OnCallstackEvent(orbit_client_protos::CallstackEvent callstack_event) = 0;
   virtual void OnThreadName(int32_t thread_id, std::string thread_name) = 0;
   virtual void OnAddressInfo(orbit_client_protos::LinuxAddressInfo address_info) = 0;
+  virtual void OnTracepointServiceResponse(int32_t pid, int32_t tid, int64_t time,
+                                           int64_t stream_id, int32_t cpu,
+                                           orbit_grpc_protos::TracepointInfo tracepoint_info) = 0;
 };
 
 #endif  // ORBIT_GL_CAPTURE_LISTENER_H_

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -17,6 +17,7 @@
 #include "OrbitClientServices/ProcessClient.h"
 #include "OrbitProcess.h"
 #include "grpcpp/grpcpp.h"
+#include "tracepoint.pb.h"
 
 class ClientGgp final : public CaptureListener {
  public:
@@ -29,7 +30,10 @@ class ClientGgp final : public CaptureListener {
   // CaptureListener implementation
   void OnCaptureStarted(
       int32_t process_id, std::string process_name, std::shared_ptr<Process> process,
-      absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions) override;
+      absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
+      absl::flat_hash_set<orbit_grpc_protos::TracepointInfo, internal::HashTracepointInfo,
+                          internal::EqualTracepointInfo>
+          selected_tracepoints) override;
   void OnCaptureComplete() override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
   void OnKeyAndString(uint64_t key, std::string str) override;
@@ -37,6 +41,9 @@ class ClientGgp final : public CaptureListener {
   void OnCallstackEvent(orbit_client_protos::CallstackEvent callstack_event) override;
   void OnThreadName(int32_t thread_id, std::string thread_name) override;
   void OnAddressInfo(orbit_client_protos::LinuxAddressInfo address_info) override;
+  void OnTracepointServiceResponse(int32_t pid, int32_t tid, int64_t time, int64_t stream_id,
+                                   int32_t cpu,
+                                   orbit_grpc_protos::TracepointInfo tracepoint_info) override;
 
  private:
   ClientGgpOptions options_;

--- a/OrbitCore/CMakeLists.txt
+++ b/OrbitCore/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.15)
 
 project(OrbitCore)
-add_library(OrbitCore STATIC)
+add_library(OrbitCore STATIC TracepointCollection.h)
 
 target_compile_options(OrbitCore PRIVATE ${STRICT_COMPILE_FLAGS})
 

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -8,21 +8,28 @@
 #include <memory>
 #include <vector>
 
+#include "../../OrbitGl/TracepointCustom.h"
 #include "CallstackData.h"
 #include "OrbitProcess.h"
 #include "SamplingProfiler.h"
+#include "TracepointCollection.h"
 #include "absl/container/flat_hash_map.h"
 #include "capture_data.pb.h"
+#include "tracepoint.pb.h"
 
 class CaptureData {
  public:
   explicit CaptureData(
       int32_t process_id, std::string process_name, std::shared_ptr<Process> process,
-      absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions)
+      absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
+      absl::flat_hash_set<orbit_grpc_protos::TracepointInfo, internal::HashTracepointInfo,
+                          internal::EqualTracepointInfo>
+          selected_tracepoints)
       : process_id_{process_id},
         process_name_{std::move(process_name)},
         process_{std::move(process)},
         selected_functions_{std::move(selected_functions)},
+        selected_tracepoints_{std::move(selected_tracepoints)},
         callstack_data_(std::make_unique<CallstackData>()),
         selection_callstack_data_(std::make_unique<CallstackData>()) {
     CHECK(process_ != nullptr);
@@ -143,11 +150,22 @@ class CaptureData {
     sampling_profiler_ = std::move(sampling_profiler);
   }
 
+  void AddOrAssignTracepointServiceResponse(int32_t pid, int32_t tid, int64_t time,
+                                            int64_t stream_id, int32_t cpu,
+                                            orbit_grpc_protos::TracepointInfo tracepoint_info) {
+    TracepointCollection tracepoint_collection(pid, tid, time, stream_id, cpu, tracepoint_info);
+    server_response_tracepoints_.emplace_back(tracepoint_collection);
+  }
+
  private:
   int32_t process_id_ = -1;
   std::string process_name_;
   std::shared_ptr<Process> process_;
   absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions_;
+
+  absl::flat_hash_set<orbit_grpc_protos::TracepointInfo, internal::HashTracepointInfo,
+                      internal::EqualTracepointInfo>
+      selected_tracepoints_;
   // std::unique_ptr<> allows to move and copy CallstackData easier
   // (as CallstackData stores an absl::Mutex inside)
   std::unique_ptr<CallstackData> callstack_data_;
@@ -161,6 +179,8 @@ class CaptureData {
   absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionStats> functions_stats_;
 
   absl::flat_hash_map<int32_t, std::string> thread_names_;
+
+  std::deque<TracepointCollection> server_response_tracepoints_;
 
   std::chrono::system_clock::time_point capture_start_time_ = std::chrono::system_clock::now();
 };

--- a/OrbitCore/TracepointCollection.h
+++ b/OrbitCore/TracepointCollection.h
@@ -1,0 +1,33 @@
+//
+// Created by msandru on 8/29/20.
+//
+
+#ifndef ORBIT_TRACEPOINTCOLLECTION_H
+#define ORBIT_TRACEPOINTCOLLECTION_H
+
+#include <string>
+#include <utility>
+
+#include "tracepoint.pb.h"
+
+using orbit_grpc_protos::TracepointInfo;
+
+struct TracepointCollection {
+  TracepointCollection();
+  TracepointCollection(int32_t pid, int32_t tid, int64_t time, int64_t stream_id, int32_t cpu,
+                       TracepointInfo tracepoint_info)
+      : pid{pid},
+        tid{tid},
+        time{time},
+        stream_id{stream_id},
+        cpu{cpu},
+        tracepoint_info{tracepoint_info} {}
+
+  int32_t pid, tid;  /* if PERF_SAMPLE_TID */
+  int64_t time;      /* if PERF_SAMPLE_TIME */
+  int64_t stream_id; /* if PERF_SAMPLE_STREAM_ID */
+  int32_t cpu;       /* if PERF_SAMPLE_CPU */
+  TracepointInfo tracepoint_info;
+};
+
+#endif  // ORBIT_TRACEPOINTCOLLECTION_H

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -95,7 +95,10 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
 
   void OnCaptureStarted(
       int32_t process_id, std::string process_name, std::shared_ptr<Process> process,
-      absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions) override;
+      absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
+      absl::flat_hash_set<orbit_grpc_protos::TracepointInfo, internal::HashTracepointInfo,
+                          internal::EqualTracepointInfo>
+          selected_tracepoints) override;
   void OnCaptureComplete() override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
   void OnKeyAndString(uint64_t key, std::string str) override;
@@ -103,6 +106,9 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void OnCallstackEvent(orbit_client_protos::CallstackEvent callstack_event) override;
   void OnThreadName(int32_t thread_id, std::string thread_name) override;
   void OnAddressInfo(orbit_client_protos::LinuxAddressInfo address_info) override;
+  void OnTracepointServiceResponse(int32_t pid, int32_t tid, int64_t time, int64_t stream_id,
+                                   int32_t cpu,
+                                   orbit_grpc_protos::TracepointInfo tracepoint_info) override;
 
   void OnValidateFramePointers(std::vector<std::shared_ptr<Module>> modules_to_validate);
 
@@ -253,6 +259,12 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void DeselectTracepoint(const TracepointInfo& tracepoint);
 
   [[nodiscard]] bool IsTracepointSelected(const TracepointInfo& info) const;
+
+  [[nodiscard]] const absl::flat_hash_set<TracepointInfo, internal::HashTracepointInfo,
+                                          internal::EqualTracepointInfo>&
+  GetSelectedTracepoints() const {
+    return data_manager_->selected_tracepoints();
+  }
 
  private:
   ErrorMessageOr<std::filesystem::path> FindSymbolsLocally(const std::filesystem::path& module_path,

--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -55,7 +55,8 @@ target_sources(
          TimerTrack.h
          Track.h
          TriangleToggle.h
-         TracepointsDataView.h )
+         TracepointsDataView.h
+         TracepointCustom.h)
 
 target_sources(
   OrbitGl

--- a/OrbitGl/DataManager.cpp
+++ b/OrbitGl/DataManager.cpp
@@ -154,3 +154,9 @@ void DataManager::DeselectTracepoint(const TracepointInfo& info) {
 bool DataManager::IsTracepointSelected(const TracepointInfo& info) const {
   return selected_tracepoints_.contains(info);
 }
+
+const absl::flat_hash_set<TracepointInfo, internal::HashTracepointInfo,
+                          internal::EqualTracepointInfo>&
+DataManager::selected_tracepoints() const {
+  return selected_tracepoints_;
+}

--- a/OrbitGl/DataManager.h
+++ b/OrbitGl/DataManager.h
@@ -11,6 +11,7 @@
 
 #include "ProcessData.h"
 #include "TextBox.h"
+#include "TracepointCustom.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "tracepoint.pb.h"
@@ -21,20 +22,6 @@
 // on the main thread.
 
 using orbit_grpc_protos::TracepointInfo;
-
-namespace internal {
-struct HashTracepointInfo {
-  size_t operator()(const TracepointInfo& info) const {
-    return std::hash<std::string>{}(info.category()) * 37 + std::hash<std::string>{}(info.name());
-  }
-};
-
-struct EqualTracepointInfo {
-  bool operator()(const TracepointInfo& left, const TracepointInfo& right) const {
-    return left.category().compare(right.category()) == 0 && left.name().compare(right.name()) == 0;
-  }
-};
-}  // namespace internal
 
 class DataManager final {
  public:
@@ -64,6 +51,10 @@ class DataManager final {
   [[nodiscard]] int32_t selected_thread_id() const;
   [[nodiscard]] const TextBox* selected_text_box() const;
   [[nodiscard]] const std::shared_ptr<Process>& selected_process() const;
+
+  [[nodiscard]] const absl::flat_hash_set<TracepointInfo, internal::HashTracepointInfo,
+                                          internal::EqualTracepointInfo>&
+  selected_tracepoints() const;
 
   void SelectTracepoint(const TracepointInfo& info);
   void DeselectTracepoint(const TracepointInfo& info);

--- a/OrbitGl/TracepointCustom.h
+++ b/OrbitGl/TracepointCustom.h
@@ -1,0 +1,25 @@
+//
+// Created by msandru on 8/28/20.
+//
+
+#ifndef ORBIT_TRACEPOINTCUSTOM_H
+#define ORBIT_TRACEPOINTCUSTOM_H
+
+#include "tracepoint.pb.h"
+
+namespace internal {
+struct HashTracepointInfo {
+  size_t operator()(const orbit_grpc_protos::TracepointInfo& info) const {
+    return std::hash<std::string>{}(info.category()) * 37 + std::hash<std::string>{}(info.name());
+  }
+};
+
+struct EqualTracepointInfo {
+  bool operator()(const orbit_grpc_protos::TracepointInfo& left,
+                  const orbit_grpc_protos::TracepointInfo& right) const {
+    return left.category().compare(right.category()) == 0 && left.name().compare(right.name()) == 0;
+  }
+};
+}  // namespace internal
+
+#endif  // ORBIT_TRACEPOINTCUSTOM_H

--- a/OrbitGrpcProtos/capture.proto
+++ b/OrbitGrpcProtos/capture.proto
@@ -30,9 +30,17 @@ message CaptureOptions {
     }
     FunctionType function_type = 4;
   }
+
+  message InstrumentedTracepoint {
+    string category = 1;
+    string name = 2;
+  }
+
   repeated InstrumentedFunction instrumented_functions = 5;
 
   bool trace_gpu_driver = 6;
+
+  repeated InstrumentedTracepoint instrumented_tracepoint = 7;
 }
 
 message SchedulingSlice {
@@ -114,6 +122,16 @@ message AddressInfo {
   }
 }
 
+message TracepointServerResponse {
+  int32 pid = 1;
+  int32 tid = 2;
+  int64 time = 3;
+  int64 stream_id = 4;
+  int32 cpu = 5;
+  string category = 7;
+  string name = 8;
+}
+
 message CaptureEvent {
   oneof event {
     SchedulingSlice scheduling_slice = 1;
@@ -124,5 +142,6 @@ message CaptureEvent {
     GpuJob gpu_job = 6;
     ThreadName thread_name = 7;
     AddressInfo address_info = 8;
+    TracepointServerResponse tracepoint_server_response = 9;
   }
 }

--- a/OrbitLinuxTracing/PerfEvent.cpp
+++ b/OrbitLinuxTracing/PerfEvent.cpp
@@ -42,6 +42,6 @@ void AmdgpuSchedRunJobPerfEvent::Accept(PerfEventVisitor* visitor) { visitor->vi
 
 void DmaFenceSignaledPerfEvent::Accept(PerfEventVisitor* visitor) { visitor->visit(this); }
 
-void SchedSwitchPerfEvent::Accept(PerfEventVisitor*) {}
+void TracepointServerResponse::Accept(PerfEventVisitor*) {}
 
 }  // namespace LinuxTracing

--- a/OrbitLinuxTracing/PerfEvent.h
+++ b/OrbitLinuxTracing/PerfEvent.h
@@ -369,27 +369,16 @@ class TaskRenamePerfEvent : public TracepointPerfEvent {
   }
 };
 
-class SchedSwitchPerfEvent : public TracepointPerfEvent {
+class TracepointServerResponse : public TracepointPerfEvent {
  public:
-  explicit SchedSwitchPerfEvent(uint32_t tracepoint_size) : TracepointPerfEvent(tracepoint_size) {}
+  explicit TracepointServerResponse(uint32_t tracepoint_size)
+      : TracepointPerfEvent(tracepoint_size) {}
 
   void Accept(PerfEventVisitor* visitor) override;
 
-  pid_t GetPrevPid() const { return GetTypedTracepointData<sched_switch_tracepoint>().prev_pid; }
+  int32_t GetPid() const { return ring_buffer_record.sample_id.pid; }
 
-  pid_t GetNextPid() const { return GetTypedTracepointData<sched_switch_tracepoint>().next_pid; }
-
-  const char* GetPrevComm() const {
-    return GetTypedTracepointData<sched_switch_tracepoint>().prev_comm;
-  }
-
-  const char* GetNextComm() const {
-    return GetTypedTracepointData<sched_switch_tracepoint>().next_comm;
-  }
-
-  pid_t GetPrevPrio() const { return GetTypedTracepointData<sched_switch_tracepoint>().prev_prio; }
-
-  pid_t GetNextPrio() const { return GetTypedTracepointData<sched_switch_tracepoint>().next_prio; }
+  int32_t GetTid() const { return ring_buffer_record.sample_id.tid; }
 };
 class GpuPerfEvent : public TracepointPerfEvent {
  public:

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -8,6 +8,7 @@
 #include <Function.h>
 #include <OrbitLinuxTracing/TracerListener.h>
 #include <linux/perf_event.h>
+#include <tracepoint.pb.h>
 
 #include <atomic>
 #include <memory>
@@ -16,6 +17,7 @@
 #include <regex>
 #include <vector>
 
+#include "../../OrbitGl/TracepointCustom.h"
 #include "ContextSwitchManager.h"
 #include "GpuTracepointEventProcessor.h"
 #include "ManualInstrumentationConfig.h"
@@ -129,6 +131,7 @@ class TracerThread {
   uint64_t sampling_period_ns_;
   orbit_grpc_protos::CaptureOptions::UnwindingMethod unwinding_method_;
   std::vector<Function> instrumented_functions_;
+  std::deque<orbit_grpc_protos::TracepointInfo> instrumented_tracepoints_;
   bool trace_gpu_driver_;
 
   TracerListener* listener_ = nullptr;
@@ -142,7 +145,9 @@ class TracerThread {
   absl::flat_hash_set<uint64_t> uretprobes_ids_;
   absl::flat_hash_set<uint64_t> stack_sampling_ids_;
   absl::flat_hash_set<uint64_t> task_newtask_ids_;
-  absl::flat_hash_set<uint64_t> sched_switch_ids_;
+  absl::flat_hash_map<orbit_grpc_protos::TracepointInfo, absl::flat_hash_set<uint64_t>,
+                      internal::HashTracepointInfo, internal::EqualTracepointInfo>
+      instrumented_tracepoints_ids_;
   absl::flat_hash_set<uint64_t> task_rename_ids_;
   absl::flat_hash_set<uint64_t> amdgpu_cs_ioctl_ids_;
   absl::flat_hash_set<uint64_t> amdgpu_sched_run_job_ids_;

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/TracerListener.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/TracerListener.h
@@ -18,6 +18,8 @@ class TracerListener {
   virtual void OnGpuJob(orbit_grpc_protos::GpuJob gpu_job) = 0;
   virtual void OnThreadName(orbit_grpc_protos::ThreadName thread_name) = 0;
   virtual void OnAddressInfo(orbit_grpc_protos::AddressInfo address_info) = 0;
+  virtual void OnTracepointServiceResponse(
+      orbit_grpc_protos::TracepointServerResponse tracepoint_server_response) = 0;
 };
 
 }  // namespace LinuxTracing

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -171,9 +171,9 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App, ApplicationOptions&& optio
     ui->RightTabWidget->removeTab(ui->RightTabWidget->indexOf(ui->CodeTab));
   }
 
-  if (!absl::GetFlag(FLAGS_enable_tracepoint_feature)) {
+  /*if (!absl::GetFlag(FLAGS_enable_tracepoint_feature)) {
     ui->RightTabWidget->removeTab(ui->RightTabWidget->indexOf(ui->tracepointsTab));
-  }
+  }*/
 
   if (!absl::GetFlag(FLAGS_devmode)) {
     ui->menuDebug->menuAction()->setVisible(false);

--- a/OrbitService/LinuxTracingGrpcHandler.cpp
+++ b/OrbitService/LinuxTracingGrpcHandler.cpp
@@ -125,6 +125,16 @@ void LinuxTracingGrpcHandler::OnAddressInfo(AddressInfo address_info) {
   }
 }
 
+void LinuxTracingGrpcHandler::OnTracepointServiceResponse(
+    orbit_grpc_protos::TracepointServerResponse tracepoint_server_response) {
+  CaptureEvent event;
+  *event.mutable_tracepoint_server_response() = std::move(tracepoint_server_response);
+  {
+    absl::MutexLock lock{&event_buffer_mutex_};
+    event_buffer_.emplace_back(std::move(event));
+  }
+}
+
 uint64_t LinuxTracingGrpcHandler::ComputeCallstackKey(const Callstack& callstack) {
   uint64_t key = 17;
   for (uint64_t pc : callstack.pcs()) {

--- a/OrbitService/LinuxTracingGrpcHandler.h
+++ b/OrbitService/LinuxTracingGrpcHandler.h
@@ -37,6 +37,8 @@ class LinuxTracingGrpcHandler : public LinuxTracing::TracerListener {
   void OnGpuJob(orbit_grpc_protos::GpuJob gpu_job) override;
   void OnThreadName(orbit_grpc_protos::ThreadName thread_name) override;
   void OnAddressInfo(orbit_grpc_protos::AddressInfo address_info) override;
+  void OnTracepointServiceResponse(
+      orbit_grpc_protos::TracepointServerResponse tracepoint_server_response) override;
 
  private:
   grpc::ServerReaderWriter<orbit_grpc_protos::CaptureResponse, orbit_grpc_protos::CaptureRequest>*


### PR DESCRIPTION
Get list of selected kenel tracepoints into the capture
Generate proto for generic tracepoint event
Perf_event_open is called for all the tracepoints hooked
Events are emitted when the tracepoints are hit, they arrive in the ui,
for now log