### PR TITLE
Fix Crash Unselecting Multiple Functions

### DIFF
--- a/OrbitGl/DataManager.cpp
+++ b/OrbitGl/DataManager.cpp
@@ -47,7 +47,6 @@ void DataManager::SelectFunction(uint64_t function_address) {
 
 void DataManager::DeselectFunction(uint64_t function_address) {
   CHECK(std::this_thread::get_id() == main_thread_id_);
-  CHECK(selected_functions_.contains(function_address));
   selected_functions_.erase(function_address);
 }
 


### PR DESCRIPTION
When selecting multiple functions (some of which are hooked, others not),
the UI will allow you to unhook (unselect) all. For simplicity
DeselectFunction will be called for all of them.
Prior to this, there was a CHECK, that would fail then.

Test: Compile
Bug: http://167197303