### PR TITLE
Remove process from preset

### DIFF
--- a/OrbitClientProtos/preset.proto
+++ b/OrbitClientProtos/preset.proto
@@ -11,7 +11,7 @@ message PresetModule {
 }
 
 message PresetInfo {
-  string process_full_path = 1;
+  reserved 1;
   map<string, PresetModule> path_to_module = 2;
 }
 

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -60,6 +60,34 @@ using orbit_grpc_protos::ModuleSymbols;
 using orbit_grpc_protos::ProcessInfo;
 using orbit_grpc_protos::TracepointInfo;
 
+namespace {
+PresetLoadState GetPresetLoadStateForProcess(
+    const std::shared_ptr<orbit_client_protos::PresetFile>& preset,
+    const std::shared_ptr<Process>& process) {
+  if (process == nullptr) {
+    return PresetLoadState::kNotLoadable;
+  }
+
+  int modules_not_found_count = 0;
+  for (const auto& pair : preset->preset_info().path_to_module()) {
+    const std::string& module_path = pair.first;
+    if (process->GetModuleFromPath(module_path) == nullptr) {
+      modules_not_found_count++;
+    }
+  }
+
+  if (modules_not_found_count == preset->preset_info().path_to_module_size()) {
+    return PresetLoadState::kNotLoadable;
+  }
+
+  if (modules_not_found_count == 0) {
+    return PresetLoadState::kLoadable;
+  }
+
+  return PresetLoadState::kPartiallyLoadable;
+}
+}  // namespace
+
 std::unique_ptr<OrbitApp> GOrbitApp;
 bool DoZoom = false;
 
@@ -556,6 +584,12 @@ void OrbitApp::LoadPreset(const std::shared_ptr<PresetFile>& preset) {
   } else {
     SendErrorToUi("Preset loading failed", "Process is not selected");
   }
+}
+
+PresetLoadState OrbitApp::GetPresetLoadState(
+    const std::shared_ptr<orbit_client_protos::PresetFile>& preset) const {
+  const std::shared_ptr<Process> selected_process = GetSelectedProcess();
+  return GetPresetLoadStateForProcess(preset, selected_process);
 }
 
 ErrorMessageOr<void> OrbitApp::OnSaveCapture(const std::string& file_name) {

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -552,7 +552,7 @@ void OrbitApp::LoadPreset(const std::shared_ptr<PresetFile>& preset) {
   const int32_t selected_process_id = GetSelectedProcessId();
   const ProcessData* selected_process = data_manager_->GetProcessByPid(selected_process_id);
   if (selected_process != nullptr) {
-    GOrbitApp->LoadModulesFromPreset(GetSelectedProcess(), preset);
+    LoadModulesFromPreset(GetSelectedProcess(), preset);
   } else {
     SendErrorToUi("Preset loading failed", "Process is not selected");
   }
@@ -698,6 +698,14 @@ void OrbitApp::SendInfoToUi(const std::string& title, const std::string& text) {
   main_thread_executor_->Schedule([this, title, text] {
     if (info_message_callback_) {
       info_message_callback_(title, text);
+    }
+  });
+}
+
+void OrbitApp::SendWarningToUi(const std::string& title, const std::string& text) {
+  main_thread_executor_->Schedule([this, title, text] {
+    if (warning_message_callback_) {
+      warning_message_callback_(title, text);
     }
   });
 }
@@ -872,11 +880,18 @@ void OrbitApp::LoadModulesFromPreset(const std::shared_ptr<Process>& process,
     modules_to_load.emplace_back(std::move(module));
   }
   if (!modules_not_found.empty()) {
-    SendErrorToUi(
-        "Preset loading incomplete",
-        absl::StrFormat("Unable to load the preset for the following modules:\n\"%s\"\nThe "
-                        "modules are not loaded by process \"%s\".",
-                        absl::StrJoin(modules_not_found, "\"\n\""), process->GetName()));
+    if (static_cast<int>(modules_not_found.size()) == preset->preset_info().path_to_module_size()) {
+      // no modules were loaded
+      SendErrorToUi(
+          "Preset loading failed",
+          absl::StrFormat("None of the modules in the preset are loaded by the process \"%s\".",
+                          process->GetName()));
+    } else {
+      SendWarningToUi(
+          "Preset only partially loaded",
+          absl::StrFormat("The following modules are not loaded by the process \"%s\":\n\"%s\"",
+                          process->GetName(), absl::StrJoin(modules_not_found, "\"\n\"")));
+    }
   }
   if (!modules_to_load.empty()) {
     LoadModules(process, modules_to_load, preset);

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -489,7 +489,6 @@ ErrorMessageOr<void> OrbitApp::SavePreset(const std::string& filename) {
   PresetInfo preset;
   const int32_t pid = GetSelectedProcessId();
   const std::shared_ptr<Process>& process = FindProcessByPid(pid);
-  preset.set_process_full_path(data_manager_->GetProcessByPid(pid)->full_path());
 
   for (uint64_t function_address : data_manager_->selected_functions()) {
     FunctionInfo* func = process->GetFunctionFromAddress(function_address);
@@ -552,16 +551,10 @@ ErrorMessageOr<void> OrbitApp::OnLoadPreset(const std::string& filename) {
 void OrbitApp::LoadPreset(const std::shared_ptr<PresetFile>& preset) {
   const int32_t selected_process_id = GetSelectedProcessId();
   const ProcessData* selected_process = data_manager_->GetProcessByPid(selected_process_id);
-  const std::string& process_full_path = preset->preset_info().process_full_path();
-  if (selected_process != nullptr && selected_process->full_path() == process_full_path) {
-    // In case we already have the correct process selected
+  if (selected_process != nullptr) {
     GOrbitApp->LoadModulesFromPreset(GetSelectedProcess(), preset);
-    return;
-  }
-  if (!SelectProcess(Path::GetFileName(process_full_path), preset)) {
-    SendErrorToUi("Preset loading failed",
-                  absl::StrFormat("The process \"%s\" is not running.", process_full_path));
-    return;
+  } else {
+    SendErrorToUi("Preset loading failed", "Process is not selected");
   }
 }
 

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -669,10 +669,9 @@ void OrbitApp::ToggleCapture() {
   }
 }
 
-bool OrbitApp::SelectProcess(const std::string& process,
-                             const std::shared_ptr<PresetFile>& preset) {
+bool OrbitApp::SelectProcess(const std::string& process) {
   if (processes_data_view_) {
-    return processes_data_view_->SelectProcess(process, preset);
+    return processes_data_view_->SelectProcess(process);
   }
 
   return false;
@@ -885,10 +884,9 @@ void OrbitApp::LoadModulesFromPreset(const std::shared_ptr<Process>& process,
   FireRefreshCallbacks();
 }
 
-void OrbitApp::UpdateProcessAndModuleList(
-    int32_t pid, const std::shared_ptr<orbit_client_protos::PresetFile>& preset) {
+void OrbitApp::UpdateProcessAndModuleList(int32_t pid) {
   CHECK(processes_data_view_->GetSelectedProcessId() == pid);
-  thread_pool_->Schedule([pid, preset, this] {
+  thread_pool_->Schedule([pid, this] {
     ErrorMessageOr<std::vector<ModuleInfo>> result = process_manager_->LoadModuleList(pid);
 
     if (result.has_error()) {
@@ -897,7 +895,7 @@ void OrbitApp::UpdateProcessAndModuleList(
       return;
     }
 
-    main_thread_executor_->Schedule([pid, result, preset, this] {
+    main_thread_executor_->Schedule([pid, result, this] {
       // Make sure that pid is actually what user has selected at
       // the moment we arrive here. If not - ignore the result.
       const std::vector<ModuleInfo>& module_infos = result.value();
@@ -928,10 +926,6 @@ void OrbitApp::UpdateProcessAndModuleList(
         process->AddModule(module);
       }
 
-      if (preset) {
-        LoadModulesFromPreset(process, preset);
-        data_manager_->set_selected_process(process);
-      }
       // To this point ----------------------------------
 
       // To this point all data is ready. We can set the Process and then
@@ -1045,9 +1039,7 @@ DataView* OrbitApp::GetOrCreateDataView(DataViewType type) {
       if (!processes_data_view_) {
         processes_data_view_ = std::make_unique<ProcessesDataView>();
         processes_data_view_->SetSelectionListener(
-            [&](int32_t pid, const std::shared_ptr<orbit_client_protos::PresetFile>& preset) {
-              UpdateProcessAndModuleList(pid, preset);
-            });
+            [&](int32_t pid) { UpdateProcessAndModuleList(pid); });
         panels_.push_back(processes_data_view_.get());
       }
       return processes_data_view_.get();

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -110,8 +110,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void AddSelectionReport(SamplingProfiler sampling_profiler, const CallstackData* callstack_data);
   void AddTopDownView(const SamplingProfiler& sampling_profiler);
 
-  bool SelectProcess(const std::string& process,
-                     const std::shared_ptr<orbit_client_protos::PresetFile>& preset);
+  bool SelectProcess(const std::string& process);
 
   // Callbacks
   using CaptureStartedCallback = std::function<void()>;
@@ -199,8 +198,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
                    const std::shared_ptr<orbit_client_protos::PresetFile>& preset = nullptr);
   void LoadModulesFromPreset(const std::shared_ptr<Process>& process,
                              const std::shared_ptr<orbit_client_protos::PresetFile>& preset);
-  void UpdateProcessAndModuleList(int32_t pid,
-                                  const std::shared_ptr<orbit_client_protos::PresetFile>& preset);
+  void UpdateProcessAndModuleList(int32_t pid);
 
   void UpdateSamplingReport();
   void LoadPreset(const std::shared_ptr<orbit_client_protos::PresetFile>& session);

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -35,6 +35,7 @@
 #include "OrbitClientServices/CrashManager.h"
 #include "OrbitClientServices/ProcessManager.h"
 #include "OrbitClientServices/TracepointServiceClient.h"
+#include "PresetLoadState.h"
 #include "PresetsDataView.h"
 #include "ProcessesDataView.h"
 #include "SamplingReport.h"
@@ -206,7 +207,9 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void UpdateProcessAndModuleList(int32_t pid);
 
   void UpdateSamplingReport();
-  void LoadPreset(const std::shared_ptr<orbit_client_protos::PresetFile>& session);
+  void LoadPreset(const std::shared_ptr<orbit_client_protos::PresetFile>& preset);
+  PresetLoadState GetPresetLoadState(
+      const std::shared_ptr<orbit_client_protos::PresetFile>& preset) const;
   void FilterTracks(const std::string& filter);
 
   void CrashOrbitService(orbit_grpc_protos::CrashOrbitServiceRequest_CrashType crash_type);

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -151,6 +151,10 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void SetErrorMessageCallback(ErrorMessageCallback callback) {
     error_message_callback_ = std::move(callback);
   }
+  using WarningMessageCallback = std::function<void(const std::string&, const std::string&)>;
+  void SetWarningMessageCallback(WarningMessageCallback callback) {
+    warning_message_callback_ = std::move(callback);
+  }
   using InfoMessageCallback = std::function<void(const std::string&, const std::string&)>;
   void SetInfoMessageCallback(InfoMessageCallback callback) {
     info_message_callback_ = std::move(callback);
@@ -190,6 +194,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void SendDisassemblyToUi(std::string disassembly, DisassemblyReport report);
   void SendTooltipToUi(const std::string& tooltip);
   void SendInfoToUi(const std::string& title, const std::string& text);
+  void SendWarningToUi(const std::string& title, const std::string& text);
   void SendErrorToUi(const std::string& title, const std::string& text);
   void NeedsRedraw();
 
@@ -267,6 +272,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   SelectLiveTabCallback select_live_tab_callback_;
   DisassemblyCallback disassembly_callback_;
   ErrorMessageCallback error_message_callback_;
+  WarningMessageCallback warning_message_callback_;
   InfoMessageCallback info_message_callback_;
   TooltipCallback tooltip_callback_;
   RefreshCallback refresh_callback_;

--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -39,6 +39,7 @@ target_sources(
          ModulesDataView.h
          OpenGl.h
          PickingManager.h
+         PresetLoadState.h
          PresetsDataView.h
          ProcessesDataView.h
          SamplingReport.h

--- a/OrbitGl/DataView.h
+++ b/OrbitGl/DataView.h
@@ -61,6 +61,7 @@ class DataView {
   virtual void OnDataChanged();
   virtual void OnTimer() {}
   virtual bool WantsDisplayColor() { return false; }
+  // TODO(irinashkviro): return a Color instead of using out-parameters
   virtual bool GetDisplayColor(int /*row*/, int /*column*/, unsigned char& /*red*/,
                                unsigned char& /*green*/, unsigned char& /*blue*/) {
     return false;

--- a/OrbitGl/ModulesDataView.cpp
+++ b/OrbitGl/ModulesDataView.cpp
@@ -180,7 +180,7 @@ void ModulesDataView::SetModules(int32_t process_id, const std::vector<ModuleDat
 }
 
 void ModulesDataView::OnRefreshButtonClicked() {
-  GOrbitApp->UpdateProcessAndModuleList(GOrbitApp->GetSelectedProcessId(), nullptr);
+  GOrbitApp->UpdateProcessAndModuleList(GOrbitApp->GetSelectedProcessId());
 }
 
 const ModuleData* ModulesDataView::GetModule(uint32_t row) const { return modules_[indices_[row]]; }

--- a/OrbitGl/PresetLoadState.h
+++ b/OrbitGl/PresetLoadState.h
@@ -20,6 +20,26 @@ struct PresetLoadState {
     }
     return "";
   }
+
+  inline void GetDisplayColor(unsigned char& red, unsigned char& green, unsigned char& blue) const {
+    switch (state) {
+      case PresetLoadState::kLoadable:
+        red = 200;
+        green = 240;
+        blue = 200;
+        break;
+      case PresetLoadState::kPartiallyLoadable:
+        red = 240;
+        green = 240;
+        blue = 200;
+        break;
+      case PresetLoadState::kNotLoadable:
+        red = 230;
+        green = 190;
+        blue = 190;
+        break;
+    }
+  }
 };
 
 #endif  // ORBIT_GL_PRESET_LOAD_STATE_H_

--- a/OrbitGl/PresetLoadState.h
+++ b/OrbitGl/PresetLoadState.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_PRESET_LOAD_STATE_H_
+#define ORBIT_GL_PRESET_LOAD_STATE_H_
+
+struct PresetLoadState {
+  enum State { kLoadable, kPartiallyLoadable, kNotLoadable } state;
+  PresetLoadState(State initial_state) : state(initial_state){};
+
+  [[nodiscard]] inline std::string GetName() const {
+    switch (state) {
+      case PresetLoadState::kLoadable:
+        return "Yes";
+      case PresetLoadState::kPartiallyLoadable:
+        return "Partially";
+      case PresetLoadState::kNotLoadable:
+        return "No";
+    }
+    return "";
+  }
+};
+
+#endif  // ORBIT_GL_PRESET_LOAD_STATE_H_

--- a/OrbitGl/PresetsDataView.cpp
+++ b/OrbitGl/PresetsDataView.cpp
@@ -15,11 +15,29 @@
 #include "ModulesDataView.h"
 #include "Path.h"
 #include "Pdb.h"
+#include "PresetLoadState.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
 
 using orbit_client_protos::PresetFile;
 using orbit_client_protos::PresetInfo;
+
+constexpr const char* kLoadableColumnName = "Loadable";
+constexpr const char* kPresetColumnName = "Preset";
+constexpr const char* kModulesColumnName = "Modules";
+constexpr const char* kHookedFunctionsColumnName = "Hooked Functions";
+
+constexpr const float kLoadableColumnWidth = 0.14f;
+constexpr const float kPresetColumnWidth = 0.34f;
+constexpr const float kModulesColumnWidth = 0.34f;
+constexpr const float kHookedFunctionsColumnWidth = 0.16f;
+
+namespace {
+std::string GetLoadStateString(std::shared_ptr<orbit_client_protos::PresetFile> preset) {
+  PresetLoadState load_state = GOrbitApp->GetPresetLoadState(preset);
+  return load_state.GetName();
+}
+}  // namespace
 
 PresetsDataView::PresetsDataView() : DataView(DataViewType::kPresets) {}
 
@@ -39,9 +57,12 @@ const std::vector<DataView::Column>& PresetsDataView::GetColumns() {
   static const std::vector<Column> columns = [] {
     std::vector<Column> columns;
     columns.resize(kNumColumns);
-    columns[kColumnSessionName] = {"Preset", .39f, SortingOrder::kAscending};
-    columns[kColumnModules] = {"Modules", .39f, SortingOrder::kAscending};
-    columns[kColumnFunctionCount] = {"Hooked Functions", .19f, SortingOrder::kAscending};
+    columns[kColumnLoadState] = {kLoadableColumnName, kLoadableColumnWidth,
+                                 SortingOrder::kAscending};
+    columns[kColumnSessionName] = {kPresetColumnName, kPresetColumnWidth, SortingOrder::kAscending};
+    columns[kColumnModules] = {kModulesColumnName, kModulesColumnWidth, SortingOrder::kAscending};
+    columns[kColumnFunctionCount] = {kHookedFunctionsColumnName, kHookedFunctionsColumnWidth,
+                                     SortingOrder::kAscending};
     return columns;
   }();
   return columns;
@@ -51,6 +72,8 @@ std::string PresetsDataView::GetValue(int row, int column) {
   const std::shared_ptr<PresetFile>& preset = GetPreset(row);
 
   switch (column) {
+    case kColumnLoadState:
+      return GetLoadStateString(preset);
     case kColumnSessionName:
       return Path::GetFileName(preset->file_name());
     case kColumnModules:
@@ -67,18 +90,21 @@ std::string PresetsDataView::GetToolTip(int row, int /*column*/) {
   return preset.file_name();
 }
 
-#define ORBIT_PRESET_SORT(Member)                                                    \
-  [&](int a, int b) {                                                                \
-    return OrbitUtils::Compare(presets_[a]->Member, presets_[b]->Member, ascending); \
-  }
-
 void PresetsDataView::DoSort() {
   bool ascending = sorting_orders_[sorting_column_] == SortingOrder::kAscending;
   std::function<bool(int a, int b)> sorter = nullptr;
 
   switch (sorting_column_) {
+    case kColumnLoadState:
+      sorter = [&](int a, int b) {
+        return OrbitUtils::Compare(GOrbitApp->GetPresetLoadState(presets_[a]).state,
+                                   GOrbitApp->GetPresetLoadState(presets_[b]).state, ascending);
+      };
+      break;
     case kColumnSessionName:
-      sorter = ORBIT_PRESET_SORT(file_name());
+      sorter = [&](int a, int b) {
+        return OrbitUtils::Compare(presets_[a]->file_name(), presets_[b]->file_name(), ascending);
+      };
       break;
     default:
       break;

--- a/OrbitGl/PresetsDataView.cpp
+++ b/OrbitGl/PresetsDataView.cpp
@@ -25,8 +25,7 @@ const std::vector<DataView::Column>& PresetsDataView::GetColumns() {
   static const std::vector<Column> columns = [] {
     std::vector<Column> columns;
     columns.resize(kNumColumns);
-    columns[kColumnSessionName] = {"Preset", .49f, SortingOrder::kAscending};
-    columns[kColumnProcessName] = {"Process", .49f, SortingOrder::kAscending};
+    columns[kColumnSessionName] = {"Preset", .99f, SortingOrder::kAscending};
     return columns;
   }();
   return columns;
@@ -38,8 +37,6 @@ std::string PresetsDataView::GetValue(int row, int column) {
   switch (column) {
     case kColumnSessionName:
       return Path::GetFileName(preset->file_name());
-    case kColumnProcessName:
-      return Path::GetFileName(preset->preset_info().process_full_path());
     default:
       return "";
   }
@@ -62,9 +59,6 @@ void PresetsDataView::DoSort() {
   switch (sorting_column_) {
     case kColumnSessionName:
       sorter = ORBIT_PRESET_SORT(file_name());
-      break;
-    case kColumnProcessName:
-      sorter = ORBIT_PRESET_SORT(preset_info().process_full_path());
       break;
     default:
       break;
@@ -129,13 +123,11 @@ void PresetsDataView::DoFilter() {
   for (size_t i = 0; i < presets_.size(); ++i) {
     const PresetFile& preset = *presets_[i];
     std::string name = Path::GetFileName(ToLower(preset.file_name()));
-    std::string path = ToLower(preset.preset_info().process_full_path());
 
     bool match = true;
 
     for (std::string& filter_token : tokens) {
-      if (!(name.find(filter_token) != std::string::npos ||
-            path.find(filter_token) != std::string::npos)) {
+      if (!(name.find(filter_token) != std::string::npos)) {
         match = false;
         break;
       }

--- a/OrbitGl/PresetsDataView.cpp
+++ b/OrbitGl/PresetsDataView.cpp
@@ -204,6 +204,14 @@ void PresetsDataView::OnDataChanged() {
   DataView::OnDataChanged();
 }
 
+bool PresetsDataView::GetDisplayColor(int row, int /*column*/, unsigned char& red,
+                                      unsigned char& green, unsigned char& blue) {
+  const std::shared_ptr<PresetFile> preset = GetPreset(row);
+  PresetLoadState load_state = GOrbitApp->GetPresetLoadState(preset);
+  load_state.GetDisplayColor(red, green, blue);
+  return true;
+}
+
 void PresetsDataView::SetPresets(const std::vector<std::shared_ptr<PresetFile> >& presets) {
   presets_ = presets;
   OnDataChanged();

--- a/OrbitGl/PresetsDataView.h
+++ b/OrbitGl/PresetsDataView.h
@@ -29,13 +29,24 @@ class PresetsDataView : public DataView {
   void SetPresets(const std::vector<std::shared_ptr<orbit_client_protos::PresetFile>>& presets);
 
  protected:
+  struct ModuleView {
+    ModuleView(std::string name, uint32_t count)
+        : module_name(std::move(name)), function_count(count){};
+    std::string module_name;
+    uint32_t function_count;
+  };
+
   void DoSort() override;
   void DoFilter() override;
+  std::string GetModulesList(const std::vector<ModuleView>& modules) const;
+  std::string GetFunctionCountList(const std::vector<ModuleView>& modules) const;
   const std::shared_ptr<orbit_client_protos::PresetFile>& GetPreset(unsigned int row) const;
+  const std::vector<ModuleView>& GetModules(uint32_t row) const;
 
   std::vector<std::shared_ptr<orbit_client_protos::PresetFile>> presets_;
+  std::vector<std::vector<ModuleView>> modules_;
 
-  enum ColumnIndex { kColumnSessionName, kNumColumns };
+  enum ColumnIndex { kColumnSessionName, kColumnModules, kColumnFunctionCount, kNumColumns };
 
   static const std::string kMenuActionLoad;
   static const std::string kMenuActionDelete;

--- a/OrbitGl/PresetsDataView.h
+++ b/OrbitGl/PresetsDataView.h
@@ -46,7 +46,13 @@ class PresetsDataView : public DataView {
   std::vector<std::shared_ptr<orbit_client_protos::PresetFile>> presets_;
   std::vector<std::vector<ModuleView>> modules_;
 
-  enum ColumnIndex { kColumnSessionName, kColumnModules, kColumnFunctionCount, kNumColumns };
+  enum ColumnIndex {
+    kColumnLoadState,
+    kColumnSessionName,
+    kColumnModules,
+    kColumnFunctionCount,
+    kNumColumns
+  };
 
   static const std::string kMenuActionLoad;
   static const std::string kMenuActionDelete;

--- a/OrbitGl/PresetsDataView.h
+++ b/OrbitGl/PresetsDataView.h
@@ -35,7 +35,7 @@ class PresetsDataView : public DataView {
 
   std::vector<std::shared_ptr<orbit_client_protos::PresetFile>> presets_;
 
-  enum ColumnIndex { kColumnSessionName, kColumnProcessName, kNumColumns };
+  enum ColumnIndex { kColumnSessionName, kNumColumns };
 
   static const std::string kMenuActionLoad;
   static const std::string kMenuActionDelete;

--- a/OrbitGl/PresetsDataView.h
+++ b/OrbitGl/PresetsDataView.h
@@ -26,6 +26,10 @@ class PresetsDataView : public DataView {
   void OnContextMenu(const std::string& action, int menu_index,
                      const std::vector<int>& item_indices) override;
 
+  bool WantsDisplayColor() override { return true; }
+  bool GetDisplayColor(int /*row*/, int /*column*/, unsigned char& /*red*/,
+                       unsigned char& /*green*/, unsigned char& /*blue*/) override;
+
   void SetPresets(const std::vector<std::shared_ptr<orbit_client_protos::PresetFile>>& presets);
 
  protected:

--- a/OrbitGl/ProcessesDataView.cpp
+++ b/OrbitGl/ProcessesDataView.cpp
@@ -13,7 +13,6 @@
 #include "Params.h"
 #include "absl/strings/str_format.h"
 
-using orbit_client_protos::PresetFile;
 using orbit_grpc_protos::ProcessInfo;
 
 ProcessesDataView::ProcessesDataView()
@@ -91,18 +90,7 @@ void ProcessesDataView::OnSelect(int index) {
   SetSelectedItem();
 
   if (selection_listener_) {
-    selection_listener_(selected_process_id_, nullptr);
-  }
-}
-
-void ProcessesDataView::OnSelect(int index, const std::shared_ptr<PresetFile>& preset) {
-  const ProcessInfo& selected_process = GetProcess(index);
-  selected_process_id_ = selected_process.pid();
-
-  SetSelectedItem();
-
-  if (selection_listener_) {
-    selection_listener_(selected_process_id_, preset);
+    selection_listener_(selected_process_id_);
   }
 }
 
@@ -127,13 +115,12 @@ void ProcessesDataView::SetSelectedItem() {
   selected_index_ = -1;
 }
 
-bool ProcessesDataView::SelectProcess(const std::string& process_name,
-                                      const std::shared_ptr<PresetFile>& preset) {
+bool ProcessesDataView::SelectProcess(const std::string& process_name) {
   for (size_t i = 0; i < GetNumElements(); ++i) {
     const ProcessInfo& process = GetProcess(i);
     // TODO: What if there are multiple processes with the same substring?
     if (process.full_path().find(process_name) != std::string::npos) {
-      OnSelect(i, preset);
+      OnSelect(i);
       return true;
     }
   }
@@ -205,7 +192,6 @@ const ProcessInfo& ProcessesDataView::GetProcess(uint32_t row) const {
 }
 
 void ProcessesDataView::SetSelectionListener(
-    const std::function<void(int32_t, const std::shared_ptr<PresetFile>& preset)>&
-        selection_listener) {
+    const std::function<void(int32_t)>& selection_listener) {
   selection_listener_ = selection_listener;
 }

--- a/OrbitGl/ProcessesDataView.h
+++ b/OrbitGl/ProcessesDataView.h
@@ -13,9 +13,7 @@ class ProcessesDataView final : public DataView {
  public:
   ProcessesDataView();
 
-  void SetSelectionListener(
-      const std::function<void(int32_t, const std::shared_ptr<orbit_client_protos::PresetFile>&
-                                            preset)>& selection_listener);
+  void SetSelectionListener(const std::function<void(int32_t)>& selection_listener);
   const std::vector<Column>& GetColumns() override;
   int GetDefaultSortingColumn() override { return kColumnCpu; }
   std::string GetValue(int row, int column) override;
@@ -23,9 +21,7 @@ class ProcessesDataView final : public DataView {
   std::string GetLabel() override { return "Processes"; }
 
   void OnSelect(int index) override;
-  void OnSelect(int index, const std::shared_ptr<orbit_client_protos::PresetFile>& preset);
-  bool SelectProcess(const std::string& process_name,
-                     const std::shared_ptr<orbit_client_protos::PresetFile>& preset);
+  bool SelectProcess(const std::string& process_name);
   bool SelectProcess(int32_t process_id);
   void SetProcessList(const std::vector<orbit_grpc_protos::ProcessInfo>& process_list);
   int32_t GetSelectedProcessId() const;
@@ -43,8 +39,7 @@ class ProcessesDataView final : public DataView {
 
   std::vector<orbit_grpc_protos::ProcessInfo> process_list_;
   int32_t selected_process_id_;
-  std::function<void(int32_t, const std::shared_ptr<orbit_client_protos::PresetFile>& preset)>
-      selection_listener_;
+  std::function<void(int32_t)> selection_listener_;
 
   enum ColumnIndex { kColumnPid, kColumnName, kColumnCpu, kNumColumns };
 };

--- a/OrbitQt/orbitdataviewpanel.cpp
+++ b/OrbitQt/orbitdataviewpanel.cpp
@@ -18,8 +18,10 @@ OrbitDataViewPanel::~OrbitDataViewPanel() { delete ui; }
 
 void OrbitDataViewPanel::Initialize(DataView* data_view, SelectionType selection_type,
                                     FontType font_type, bool is_main_instance,
-                                    bool uniform_row_height) {
-  ui->treeView->Initialize(data_view, selection_type, font_type, uniform_row_height);
+                                    bool uniform_row_height,
+                                    QFlags<Qt::AlignmentFlag> text_alignment) {
+  ui->treeView->Initialize(data_view, selection_type, font_type, uniform_row_height,
+                           text_alignment);
 
   if (is_main_instance) {
     ui->treeView->GetModel()->GetDataView()->SetAsMainInstance();

--- a/OrbitQt/orbitdataviewpanel.cpp
+++ b/OrbitQt/orbitdataviewpanel.cpp
@@ -17,8 +17,9 @@ OrbitDataViewPanel::OrbitDataViewPanel(QWidget* parent)
 OrbitDataViewPanel::~OrbitDataViewPanel() { delete ui; }
 
 void OrbitDataViewPanel::Initialize(DataView* data_view, SelectionType selection_type,
-                                    FontType font_type, bool is_main_instance) {
-  ui->treeView->Initialize(data_view, selection_type, font_type);
+                                    FontType font_type, bool is_main_instance,
+                                    bool uniform_row_height) {
+  ui->treeView->Initialize(data_view, selection_type, font_type, uniform_row_height);
 
   if (is_main_instance) {
     ui->treeView->GetModel()->GetDataView()->SetAsMainInstance();

--- a/OrbitQt/orbitdataviewpanel.h
+++ b/OrbitQt/orbitdataviewpanel.h
@@ -24,7 +24,7 @@ class OrbitDataViewPanel : public QWidget {
   ~OrbitDataViewPanel() override;
 
   void Initialize(DataView* data_view, SelectionType selection_type, FontType font_type,
-                  bool is_main_instance = true);
+                  bool is_main_instance = true, bool uniform_row_height = true);
   void Link(OrbitDataViewPanel* a_Panel);
   void Refresh();
   void SetDataModel(DataView* model);

--- a/OrbitQt/orbitdataviewpanel.h
+++ b/OrbitQt/orbitdataviewpanel.h
@@ -24,7 +24,8 @@ class OrbitDataViewPanel : public QWidget {
   ~OrbitDataViewPanel() override;
 
   void Initialize(DataView* data_view, SelectionType selection_type, FontType font_type,
-                  bool is_main_instance = true, bool uniform_row_height = true);
+                  bool is_main_instance = true, bool uniform_row_height = true,
+                  QFlags<Qt::AlignmentFlag> text_alignment = Qt::AlignVCenter | Qt::AlignLeft);
   void Link(OrbitDataViewPanel* a_Panel);
   void Refresh();
   void SetDataModel(DataView* model);

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -162,7 +162,8 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App, ApplicationOptions&& optio
   ui->CallStackView->Initialize(data_view_factory->GetOrCreateDataView(DataViewType::kCallstack),
                                 SelectionType::kExtended, FontType::kDefault);
   ui->SessionList->Initialize(data_view_factory->GetOrCreateDataView(DataViewType::kPresets),
-                              SelectionType::kDefault, FontType::kDefault);
+                              SelectionType::kDefault, FontType::kDefault,
+                              /*is_main_instance=*/true, /*uniform_row_height=*/false);
   ui->TracepointsList->Initialize(
       data_view_factory->GetOrCreateDataView(DataViewType::kTracepoints), SelectionType::kExtended,
       FontType::kDefault);

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -163,7 +163,8 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App, ApplicationOptions&& optio
                                 SelectionType::kExtended, FontType::kDefault);
   ui->SessionList->Initialize(data_view_factory->GetOrCreateDataView(DataViewType::kPresets),
                               SelectionType::kDefault, FontType::kDefault,
-                              /*is_main_instance=*/true, /*uniform_row_height=*/false);
+                              /*is_main_instance=*/true, /*uniform_row_height=*/false,
+                              /*text_alignment=*/Qt::AlignTop | Qt::AlignLeft);
   ui->TracepointsList->Initialize(
       data_view_factory->GetOrCreateDataView(DataViewType::kTracepoints), SelectionType::kExtended,
       FontType::kDefault);

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -134,6 +134,9 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App, ApplicationOptions&& optio
   GOrbitApp->SetErrorMessageCallback([this](const std::string& title, const std::string& text) {
     QMessageBox::critical(this, QString::fromStdString(title), QString::fromStdString(text));
   });
+  GOrbitApp->SetWarningMessageCallback([this](const std::string& title, const std::string& text) {
+    QMessageBox::warning(this, QString::fromStdString(title), QString::fromStdString(text));
+  });
   GOrbitApp->SetInfoMessageCallback([this](const std::string& title, const std::string& text) {
     QMessageBox::information(this, QString::fromStdString(title), QString::fromStdString(text));
   });

--- a/OrbitQt/orbittablemodel.h
+++ b/OrbitQt/orbittablemodel.h
@@ -14,7 +14,9 @@
 class OrbitTableModel : public QAbstractTableModel {
   Q_OBJECT
  public:
-  explicit OrbitTableModel(DataView* data_view, QObject* parent = nullptr);
+  explicit OrbitTableModel(DataView* data_view, QObject* parent = nullptr,
+                           QFlags<Qt::AlignmentFlag> text_alignment = Qt::AlignVCenter |
+                                                                      Qt::AlignLeft);
   explicit OrbitTableModel(QObject* parent = nullptr);
 
   int columnCount(const QModelIndex& parent = QModelIndex()) const override;
@@ -24,20 +26,21 @@ class OrbitTableModel : public QAbstractTableModel {
   QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
   void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) override;
 
-  int GetUpdatePeriodMs() { return m_DataView->GetUpdatePeriodMs(); }
-  int GetSelectedIndex() { return m_DataView->GetSelectedIndex(); }
-  QModelIndex CreateIndex(int a_Row, int a_Column) { return createIndex(a_Row, a_Column); }
-  DataView* GetDataView() { return m_DataView; }
-  void SetDataView(DataView* model) { m_DataView = model; }
+  int GetUpdatePeriodMs() { return data_view_->GetUpdatePeriodMs(); }
+  int GetSelectedIndex() { return data_view_->GetSelectedIndex(); }
+  QModelIndex CreateIndex(int row, int column) { return createIndex(row, column); }
+  DataView* GetDataView() { return data_view_; }
+  void SetDataView(DataView* model) { data_view_ = model; }
   bool IsSortingAllowed() { return GetDataView()->IsSortingAllowed(); }
   std::pair<int, Qt::SortOrder> GetDefaultSortingColumnAndOrder();
 
   void OnTimer();
-  void OnFilter(const QString& a_Filter);
+  void OnFilter(const QString& filter);
   void OnRowSelected(int row);
 
  protected:
-  DataView* m_DataView;
+  DataView* data_view_;
+  QFlags<Qt::AlignmentFlag> text_alignment_;
 };
 
 #endif  // ORBIT_QT_ORBIT_TABLE_MODEL_H_

--- a/OrbitQt/orbittreeview.cpp
+++ b/OrbitQt/orbittreeview.cpp
@@ -49,10 +49,11 @@ OrbitTreeView::OrbitTreeView(QWidget* parent) : QTreeView(parent), auto_resize_(
 }
 
 void OrbitTreeView::Initialize(DataView* data_view, SelectionType selection_type,
-                               FontType font_type, bool uniform_row_height) {
+                               FontType font_type, bool uniform_row_height,
+                               QFlags<Qt::AlignmentFlag> text_alignment) {
   setUniformRowHeights(uniform_row_height);
 
-  model_ = std::make_unique<OrbitTableModel>(data_view);
+  model_ = std::make_unique<OrbitTableModel>(data_view, /*parent=*/nullptr, text_alignment);
   setModel(model_.get());
   header()->resizeSections(QHeaderView::ResizeToContents);
 

--- a/OrbitQt/orbittreeview.cpp
+++ b/OrbitQt/orbittreeview.cpp
@@ -33,7 +33,6 @@ OrbitTreeView::OrbitTreeView(QWidget* parent) : QTreeView(parent), auto_resize_(
   setItemsExpandable(false);
   setContextMenuPolicy(Qt::CustomContextMenu);
   setSelectionBehavior(QTreeView::SelectRows);
-  setUniformRowHeights(true);
   setTextElideMode(Qt::ElideMiddle);
 
   connect(header(), SIGNAL(sortIndicatorChanged(int, Qt::SortOrder)), this,
@@ -50,7 +49,9 @@ OrbitTreeView::OrbitTreeView(QWidget* parent) : QTreeView(parent), auto_resize_(
 }
 
 void OrbitTreeView::Initialize(DataView* data_view, SelectionType selection_type,
-                               FontType font_type) {
+                               FontType font_type, bool uniform_row_height) {
+  setUniformRowHeights(uniform_row_height);
+
   model_ = std::make_unique<OrbitTableModel>(data_view);
   setModel(model_.get());
   header()->resizeSections(QHeaderView::ResizeToContents);

--- a/OrbitQt/orbittreeview.h
+++ b/OrbitQt/orbittreeview.h
@@ -19,7 +19,8 @@ class OrbitTreeView : public QTreeView {
  public:
   explicit OrbitTreeView(QWidget* parent = nullptr);
   void Initialize(DataView* data_view, SelectionType selection_type, FontType font_type,
-                  bool uniform_row_height = true);
+                  bool uniform_row_height = true,
+                  QFlags<Qt::AlignmentFlag> text_alignment = Qt::AlignVCenter | Qt::AlignLeft);
   void SetDataModel(DataView* model);
   void OnFilter(const QString& a_Filter);
   void Refresh();

--- a/OrbitQt/orbittreeview.h
+++ b/OrbitQt/orbittreeview.h
@@ -18,7 +18,8 @@ class OrbitTreeView : public QTreeView {
   Q_OBJECT
  public:
   explicit OrbitTreeView(QWidget* parent = nullptr);
-  void Initialize(DataView* data_view, SelectionType selection_type, FontType font_type);
+  void Initialize(DataView* data_view, SelectionType selection_type, FontType font_type,
+                  bool uniform_row_height = true);
   void SetDataModel(DataView* model);
   void OnFilter(const QString& a_Filter);
   void Refresh();


### PR DESCRIPTION
- Removed information about process from the Preset.
- Presets could be applied partially from now (the user will see the warning if preset was applied partially, and error if it can't be applied).
- Updated PresetDataView: add information about modules, hooked functions count, and if preset could be load for the selected process or not (also font color different depending on this parameter).

![Presets new](https://user-images.githubusercontent.com/4594294/91762901-cb530b00-ebd5-11ea-871c-08fbd71e1116.png)

Test: Start Orbit, save several presets, changed process (check that `loadable` changed), apply preset partially (get a warning, some modules loaded), apply not-loadable preset (get an error, nothing changed).
Bug: http://b/160282419
