### PR TITLE
Fix: Show source file and line in Sampling Report

### DIFF
--- a/OrbitCore/CaptureData.cpp
+++ b/OrbitCore/CaptureData.cpp
@@ -102,3 +102,7 @@ const std::string& CaptureData::GetModulePathByAddress(uint64_t absolute_address
   }
   return module_path;
 }
+
+const FunctionInfo* CaptureData::GetFunctionInfoByAddress(uint64_t absolute_address) const {
+  return process_->GetFunctionFromAddress(absolute_address, false);
+}

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -86,6 +86,8 @@ class CaptureData {
 
   [[nodiscard]] const std::string& GetFunctionNameByAddress(uint64_t absolute_address) const;
   [[nodiscard]] const std::string& GetModulePathByAddress(uint64_t absolute_address) const;
+  [[nodiscard]] const orbit_client_protos::FunctionInfo* GetFunctionInfoByAddress(
+      uint64_t absolute_address) const;
 
   static const std::string kUnknownFunctionOrModuleName;
 

--- a/OrbitCore/SamplingProfiler.cpp
+++ b/OrbitCore/SamplingProfiler.cpp
@@ -293,6 +293,12 @@ void SamplingProfiler::FillThreadSampleDataSampleReports(const CaptureData& capt
       function.address = absolute_address;
       function.module_path = capture_data.GetModulePathByAddress(absolute_address);
 
+      const FunctionInfo* function_info = capture_data.GetFunctionInfoByAddress(absolute_address);
+      if (function_info != nullptr) {
+        function.line = function_info->line();
+        function.file = function_info->file();
+      }
+
       sampled_functions->push_back(function);
     }
   }


### PR DESCRIPTION
Line number were not shown in sampling reports. This change propagates
information to SampledFunction, which fixes the problem.

Bug: http://b/154580143
Test: Start Orbit load module and see that line number and source file
      get updated in Sampling Report tab.