### PR TITLE
Add TimerInfosIterator for Usage in Serializer

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -582,14 +582,15 @@ void OrbitApp::LoadPreset(const std::shared_ptr<PresetFile>& preset) {
 }
 
 ErrorMessageOr<void> OrbitApp::OnSaveCapture(const std::string& file_name) {
-  CaptureSerializer ar;
-  ar.time_graph_ = GCurrentTimeGraph;
+  const auto& key_to_string_map = GCurrentTimeGraph->GetStringManager()->GetKeyToStringMap();
 
   std::vector<std::shared_ptr<TimerChain>> chains = GCurrentTimeGraph->GetAllTimerChains();
 
   TimerInfosIterator timers_it_begin(chains.begin(), chains.end());
   TimerInfosIterator timers_it_end(chains.end(), chains.end());
-  return ar.Save(file_name, GetCaptureData(), timers_it_begin, timers_it_end);
+
+  return CaptureSerializer::Save(file_name, GetCaptureData(), key_to_string_map, timers_it_begin,
+                                 timers_it_end);
 }
 
 ErrorMessageOr<void> OrbitApp::OnLoadCapture(const std::string& file_name) {

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -39,6 +39,7 @@
 #include "ScopeTimer.h"
 #include "StringManager.h"
 #include "SymbolHelper.h"
+#include "TimerInfosIterator.h"
 #include "Utils.h"
 #include "symbol.pb.h"
 
@@ -583,7 +584,12 @@ void OrbitApp::LoadPreset(const std::shared_ptr<PresetFile>& preset) {
 ErrorMessageOr<void> OrbitApp::OnSaveCapture(const std::string& file_name) {
   CaptureSerializer ar;
   ar.time_graph_ = GCurrentTimeGraph;
-  return ar.Save(file_name, GetCaptureData());
+
+  std::vector<std::shared_ptr<TimerChain>> chains = GCurrentTimeGraph->GetAllTimerChains();
+
+  TimerInfosIterator timers_it_begin(chains.begin(), chains.end());
+  TimerInfosIterator timers_it_end(chains.end(), chains.end());
+  return ar.Save(file_name, GetCaptureData(), timers_it_begin, timers_it_end);
 }
 
 ErrorMessageOr<void> OrbitApp::OnLoadCapture(const std::string& file_name) {

--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -51,6 +51,7 @@ target_sources(
          TimeGraph.h
          TimeGraphLayout.h
          TimerChain.h
+         TimerInfosIterator.h
          TopDownView.h
          TimerTrack.h
          Track.h
@@ -91,6 +92,7 @@ target_sources(
           TimeGraph.cpp
           TimeGraphLayout.cpp
           TimerChain.cpp
+          TimerInfosIterator.cpp
           TimerTrack.cpp
           ThreadTrack.cpp
           TopDownView.cpp
@@ -130,7 +132,8 @@ target_sources(OrbitGlTests PRIVATE
 target_sources(OrbitGlTests PRIVATE
                BatcherTest.cpp
                PickingManagerTest.cpp
-               ScopedStatusTest.cpp)
+               ScopedStatusTest.cpp
+               TimerInfosIteratorTest.cpp)
 
 target_link_libraries(
   OrbitGlTests

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -16,12 +16,9 @@
 #include "EventTracer.h"
 #include "FunctionUtils.h"
 #include "OrbitBase/MakeUniqueForOverwrite.h"
-#include "OrbitModule.h"
 #include "OrbitProcess.h"
 #include "SamplingProfiler.h"
-#include "TextBox.h"
 #include "TimeGraph.h"
-#include "TimerChain.h"
 #include "absl/strings/str_format.h"
 #include "capture_data.pb.h"
 
@@ -31,24 +28,6 @@ using orbit_client_protos::CaptureInfo;
 using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::FunctionStats;
 using orbit_client_protos::TimerInfo;
-
-ErrorMessageOr<void> CaptureSerializer::Save(const std::string& filename,
-                                             const CaptureData& capture_data) {
-  header.set_version(kRequiredCaptureVersion);
-
-  std::ofstream file(filename, std::ios::binary);
-  if (file.fail()) {
-    ERROR("Saving capture in \"%s\": %s", filename, "file.fail()");
-    return ErrorMessage("Error opening the file for writing");
-  }
-
-  {
-    SCOPE_TIMER_LOG(absl::StrFormat("Saving capture in \"%s\"", filename));
-    Save(file, capture_data);
-  }
-
-  return outcome::success();
-}
 
 void CaptureSerializer::WriteMessage(const google::protobuf::Message* message,
                                      google::protobuf::io::CodedOutputStream* output) {
@@ -102,35 +81,6 @@ CaptureInfo CaptureSerializer::GenerateCaptureInfo(const CaptureData& capture_da
   capture_info.mutable_key_to_string()->insert(key_to_string_map.begin(), key_to_string_map.end());
 
   return capture_info;
-}
-
-void CaptureSerializer::Save(std::ostream& stream, const CaptureData& capture_data) {
-  google::protobuf::io::OstreamOutputStream out_stream(&stream);
-  google::protobuf::io::CodedOutputStream coded_output(&out_stream);
-
-  CHECK(time_graph_ != nullptr);
-  int timers_count = time_graph_->GetNumTimers();
-
-  WriteMessage(&header, &coded_output);
-
-  CaptureInfo capture_info = GenerateCaptureInfo(capture_data);
-  WriteMessage(&capture_info, &coded_output);
-
-  // Timers
-  int writes_count = 0;
-  std::vector<std::shared_ptr<TimerChain>> chains = time_graph_->GetAllTimerChains();
-  for (auto& chain : chains) {
-    if (!chain) continue;
-    for (TimerChainIterator it = chain->begin(); it != chain->end(); ++it) {
-      TimerBlock& block = *it;
-      for (uint32_t k = 0; k < block.size(); ++k) {
-        WriteMessage(&block[k].GetTimerInfo(), &coded_output);
-        if (++writes_count > timers_count) {
-          return;
-        }
-      }
-    }
-  }
 }
 
 ErrorMessageOr<void> CaptureSerializer::Load(const std::string& filename) {

--- a/OrbitGl/CaptureSerializer.h
+++ b/OrbitGl/CaptureSerializer.h
@@ -38,8 +38,7 @@ class CaptureSerializer {
 
  private:
   template <class TimersIterator>
-  static void Save(std::ostream& stream, const orbit_client_protos::CaptureHeader& header,
-                   const CaptureData& capture_data,
+  static void Save(std::ostream& stream, const CaptureData& capture_data,
                    const absl::flat_hash_map<uint64_t, std::string>& key_to_string_map,
                    TimersIterator timers_iterator_begin, TimersIterator timers_iterator_end);
 
@@ -56,13 +55,14 @@ class CaptureSerializer {
 };
 
 template <class TimersIterator>
-void CaptureSerializer::Save(std::ostream& stream, const orbit_client_protos::CaptureHeader& header,
-                             const CaptureData& capture_data,
+void CaptureSerializer::Save(std::ostream& stream, const CaptureData& capture_data,
                              const absl::flat_hash_map<uint64_t, std::string>& key_to_string_map,
                              TimersIterator begin, TimersIterator end) {
   google::protobuf::io::OstreamOutputStream out_stream(&stream);
   google::protobuf::io::CodedOutputStream coded_output(&out_stream);
 
+  orbit_client_protos::CaptureHeader header;
+  header.set_version(kRequiredCaptureVersion);
   WriteMessage(&header, &coded_output);
 
   orbit_client_protos::CaptureInfo capture_info =
@@ -80,9 +80,6 @@ ErrorMessageOr<void> CaptureSerializer::Save(
     const std::string& filename, const CaptureData& capture_data,
     const absl::flat_hash_map<uint64_t, std::string>& key_to_string_map,
     TimersIterator timers_iterator_begin, TimersIterator timers_iterator_end) {
-  orbit_client_protos::CaptureHeader header;
-  header.set_version(kRequiredCaptureVersion);
-
   std::ofstream file(filename, std::ios::binary);
   if (file.fail()) {
     ERROR("Saving capture in \"%s\": %s", filename, "file.fail()");
@@ -91,8 +88,7 @@ ErrorMessageOr<void> CaptureSerializer::Save(
 
   {
     SCOPE_TIMER_LOG(absl::StrFormat("Saving capture in \"%s\"", filename));
-
-    Save(file, header, capture_data, key_to_string_map, std::move(timers_iterator_begin),
+    Save(file, capture_data, key_to_string_map, std::move(timers_iterator_begin),
          std::move(timers_iterator_end));
   }
 

--- a/OrbitGl/CaptureSerializer.h
+++ b/OrbitGl/CaptureSerializer.h
@@ -57,7 +57,8 @@ class CaptureSerializer {
 template <class TimersIterator>
 void CaptureSerializer::Save(std::ostream& stream, const CaptureData& capture_data,
                              const absl::flat_hash_map<uint64_t, std::string>& key_to_string_map,
-                             TimersIterator begin, TimersIterator end) {
+                             TimersIterator timers_iterator_begin,
+                             TimersIterator timers_iterator_end) {
   google::protobuf::io::OstreamOutputStream out_stream(&stream);
   google::protobuf::io::CodedOutputStream coded_output(&out_stream);
 
@@ -70,8 +71,8 @@ void CaptureSerializer::Save(std::ostream& stream, const CaptureData& capture_da
   WriteMessage(&capture_info, &coded_output);
 
   // Timers
-  for (; begin != end; ++begin) {
-    WriteMessage(&(*begin), &coded_output);
+  for (auto it = timers_iterator_begin; timers_iterator_begin != timers_iterator_end; ++it) {
+    WriteMessage(&(*it), &coded_output);
   }
 }
 

--- a/OrbitGl/CaptureSerializer.h
+++ b/OrbitGl/CaptureSerializer.h
@@ -6,6 +6,7 @@
 #define ORBIT_GL_CAPTURE_SERIALIZER_H_
 
 #include <google/protobuf/io/coded_stream.h>
+#include <google/protobuf/io/zero_copy_stream_impl.h>
 #include <google/protobuf/message.h>
 
 #include <iosfwd>
@@ -14,17 +15,24 @@
 
 #include "CaptureData.h"
 #include "OrbitBase/Result.h"
+#include "TimeGraph.h"
 #include "capture_data.pb.h"
 
 class CaptureSerializer {
  public:
-  void Save(std::ostream& stream, const CaptureData& capture_data);
-  ErrorMessageOr<void> Save(const std::string& filename, const CaptureData& capture_data);
+  template <class TimersIterator>
+  void Save(std::ostream& stream, const CaptureData& capture_data,
+            TimersIterator timers_iterator_begin, TimersIterator timers_iterator_end);
+
+  template <class TimersIterator>
+  ErrorMessageOr<void> Save(const std::string& filename, const CaptureData& capture_data,
+                            TimersIterator timers_iterator_begin,
+                            TimersIterator timers_iterator_end);
 
   ErrorMessageOr<void> Load(std::istream& stream);
   ErrorMessageOr<void> Load(const std::string& filename);
 
-  class TimeGraph* time_graph_;
+  TimeGraph* time_graph_;
 
   static bool ReadMessage(google::protobuf::Message* message,
                           google::protobuf::io::CodedInputStream* input);
@@ -40,5 +48,51 @@ class CaptureSerializer {
 
   const std::string kRequiredCaptureVersion = "1.52";
 };
+
+template <class TimersIterator>
+void CaptureSerializer::Save(std::ostream& stream, const CaptureData& capture_data,
+                             TimersIterator begin, TimersIterator end) {
+  google::protobuf::io::OstreamOutputStream out_stream(&stream);
+  google::protobuf::io::CodedOutputStream coded_output(&out_stream);
+
+  CHECK(time_graph_ != nullptr);
+
+  WriteMessage(&header, &coded_output);
+
+  orbit_client_protos::CaptureInfo capture_info = GenerateCaptureInfo(capture_data);
+  WriteMessage(&capture_info, &coded_output);
+
+  // Timers
+  int timers_count = time_graph_->GetNumTimers();
+  int writes_count = 0;
+  for (; begin != end; ++begin) {
+    WriteMessage(&(*begin), &coded_output);
+    if (++writes_count > timers_count) {
+      return;
+    }
+  }
+}
+
+template <class TimersIterator>
+ErrorMessageOr<void> CaptureSerializer::Save(const std::string& filename,
+                                             const CaptureData& capture_data,
+                                             TimersIterator timers_iterator_begin,
+                                             TimersIterator timers_iterator_end) {
+  header.set_version(kRequiredCaptureVersion);
+
+  std::ofstream file(filename, std::ios::binary);
+  if (file.fail()) {
+    ERROR("Saving capture in \"%s\": %s", filename, "file.fail()");
+    return ErrorMessage("Error opening the file for writing");
+  }
+
+  {
+    SCOPE_TIMER_LOG(absl::StrFormat("Saving capture in \"%s\"", filename));
+
+    Save(file, capture_data, std::move(timers_iterator_begin), std::move(timers_iterator_end));
+  }
+
+  return outcome::success();
+}
 
 #endif  // ORBIT_GL_CAPTURE_SERIALIZER_H_

--- a/OrbitGl/TimerChain.h
+++ b/OrbitGl/TimerChain.h
@@ -66,17 +66,24 @@ class TimerBlock {
 class TimerChainIterator {
  public:
   explicit TimerChainIterator(TimerBlock* block) : block_(block) {}
+  TimerChainIterator& operator=(const TimerChainIterator& other) = default;
+  TimerChainIterator(const TimerChainIterator& other) = default;
+  TimerChainIterator(TimerChainIterator&& other) = default;
+  TimerChainIterator& operator=(TimerChainIterator&& other) = default;
 
-  TimerBlock& operator*() { return *block_; }
+  bool operator!=(const TimerChainIterator& other) const { return !(*this == other); }
 
-  bool operator!=(const TimerChainIterator& other) const { return block_ != other.block_; }
-
+  bool operator==(const TimerChainIterator& other) const { return block_ == other.block_; }
   TimerChainIterator& operator++() {
     block_ = block_->next_;
     return *this;
   }
 
+  const TimerBlock& operator*() const { return *block_; }
+  TimerBlock& operator*() { return *block_; }
+
   TimerBlock* operator->() { return block_; }
+  const TimerBlock* operator->() const { return block_; }
 
  private:
   TimerBlock* block_;

--- a/OrbitGl/TimerInfosIterator.cpp
+++ b/OrbitGl/TimerInfosIterator.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+#include "TimerInfosIterator.h"
+
+TimerInfosIterator& TimerInfosIterator::operator++() {
+  // Next timer in block:
+  ++timer_index_;
+  // Still inside block?
+  if (timer_index_ < blocks_it_->size()) {
+    return *this;
+  }
+
+  // Next block:
+  timer_index_ = 0;
+  ++blocks_it_;
+  // Still inside the chain?
+  if (blocks_it_ != (*chains_it_)->end()) {
+    return *this;
+  }
+
+  // Next chain:
+  ++chains_it_;
+  // Still inside chains?
+  if (chains_it_ != chains_end_it_) {
+    blocks_it_ = (*chains_it_)->begin();
+    return *this;
+  }
+
+  return *this;
+}

--- a/OrbitGl/TimerInfosIterator.h
+++ b/OrbitGl/TimerInfosIterator.h
@@ -1,0 +1,52 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBITGL_TIMER_INFOS_ITERATOR_H_
+#define ORBITGL_TIMER_INFOS_ITERATOR_H_
+
+#include <memory>
+#include <vector>
+
+#include "TimerChain.h"
+#include "capture_data.pb.h"
+
+class TimerInfosIterator {
+ public:
+  explicit TimerInfosIterator(std::vector<std::shared_ptr<TimerChain>>::const_iterator begin,
+                              std::vector<std::shared_ptr<TimerChain>>::const_iterator end)
+      : chains_it_(begin),
+        chains_end_it_(end),
+        blocks_it_((chains_it_ != chains_end_it_) ? (*chains_it_)->begin()
+                                                  : TimerChainIterator(nullptr)),
+        timer_index_(0) {}
+
+  TimerInfosIterator& operator=(const TimerInfosIterator& other) = default;
+  TimerInfosIterator(const TimerInfosIterator& other) = default;
+  TimerInfosIterator(TimerInfosIterator&& other) = default;
+  TimerInfosIterator& operator=(TimerInfosIterator&& other) = default;
+
+  TimerInfosIterator& operator++();
+
+  const orbit_client_protos::TimerInfo& operator*() const {
+    return (*blocks_it_)[timer_index_].GetTimerInfo();
+  }
+
+  const orbit_client_protos::TimerInfo* operator->() const {
+    return &(*blocks_it_)[timer_index_].GetTimerInfo();
+  }
+
+  bool operator==(const TimerInfosIterator& other) const {
+    return chains_it_ == other.chains_it_ && blocks_it_ == other.blocks_it_ &&
+           timer_index_ == other.timer_index_;
+  }
+  bool operator!=(const TimerInfosIterator& other) const { return !(other == *this); }
+
+ private:
+  std::vector<std::shared_ptr<TimerChain>>::const_iterator chains_it_;
+  std::vector<std::shared_ptr<TimerChain>>::const_iterator chains_end_it_;
+  TimerChainIterator blocks_it_;
+  uint32_t timer_index_;
+};
+
+#endif  // ORBITGL_TIMER_INFOS_ITERATOR_H_

--- a/OrbitGl/TimerInfosIteratorTest.cpp
+++ b/OrbitGl/TimerInfosIteratorTest.cpp
@@ -1,0 +1,171 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include "TextBox.h"
+#include "TimerChain.h"
+#include "TimerInfosIterator.h"
+#include "capture_data.pb.h"
+
+using orbit_client_protos::TimerInfo;
+
+TEST(TimerInfosIterator, Access) {
+  std::vector<std::shared_ptr<TimerChain>> chains;
+  std::shared_ptr<TimerChain> chain = std::make_shared<TimerChain>();
+  TextBox box;
+  TimerInfo timer;
+  timer.set_function_address(1);
+  // Need to set the end, as SetTimerInfo will refuse that timer otherwise.
+  timer.set_end(1);
+  box.SetTimerInfo(timer);
+  chain->push_back(box);
+  chains.push_back(chain);
+
+  // Just validate setting worked as expected
+  EXPECT_EQ(1, timer.function_address());
+  EXPECT_EQ(1, box.GetTimerInfo().function_address());
+
+  // Now create an iterator and test to access it
+  TimerInfosIterator it(chains.begin(), chains.end());
+  EXPECT_EQ(1, it->function_address());
+  EXPECT_EQ(1, (*it).function_address());
+}
+
+TEST(TimerInfosIterator, Copy) {
+  std::vector<std::shared_ptr<TimerChain>> chains;
+  std::shared_ptr<TimerChain> chain = std::make_shared<TimerChain>();
+  TextBox box;
+  TimerInfo timer;
+  timer.set_function_address(1);
+  // Need to set the end, as SetTimerInfo will refuse that timer otherwise.
+  timer.set_end(1);
+  box.SetTimerInfo(timer);
+  chain->push_back(box);
+  chains.push_back(chain);
+
+  // Now create an iterator and test to access it
+  TimerInfosIterator it(chains.begin(), chains.end());
+  EXPECT_EQ(1, it->function_address());
+
+  // Now create a Copy
+  TimerInfosIterator it_copy1 = it;
+  EXPECT_EQ(1, it_copy1->function_address());
+
+  // Increase the original and check that the copy does not modify
+  ++it;
+  EXPECT_EQ(1, it_copy1->function_address());
+
+  // Create a copy using the copy-constructor
+  TimerInfosIterator it_copy2(it_copy1);
+  EXPECT_EQ(1, it_copy2->function_address());
+
+  // Increase the original and check that the copy does not modify
+  ++it_copy1;
+  EXPECT_EQ(1, it_copy2->function_address());
+}
+
+TEST(TimerInfosIterator, Move) {
+  std::vector<std::shared_ptr<TimerChain>> chains;
+  std::shared_ptr<TimerChain> chain = std::make_shared<TimerChain>();
+  TextBox box;
+  TimerInfo timer;
+  timer.set_function_address(1);
+  // Need to set the end, as SetTimerInfo will refuse that timer otherwise.
+  timer.set_end(1);
+  box.SetTimerInfo(timer);
+  chain->push_back(box);
+  chains.push_back(chain);
+
+  // Now create an iterator and test to access it
+  TimerInfosIterator it(chains.begin(), chains.end());
+  EXPECT_EQ(1, it->function_address());
+
+  // Now create a Copy
+  TimerInfosIterator it_copy1 = std::move(it);
+  EXPECT_EQ(1, it_copy1->function_address());
+
+  // Create a copy using the copy-constructor
+  TimerInfosIterator it_copy2(std::move(it_copy1));
+  EXPECT_EQ(1, it_copy2->function_address());
+}
+
+TEST(TimerInfosIterator, Equality) {
+  std::vector<std::shared_ptr<TimerChain>> chains;
+  std::shared_ptr<TimerChain> chain = std::make_shared<TimerChain>();
+  TextBox box;
+  TimerInfo timer;
+  timer.set_function_address(1);
+  timer.set_end(1);
+  box.SetTimerInfo(timer);
+  chain->push_back(box);
+  chains.push_back(chain);
+
+  // Now create an iterators and test equality
+  TimerInfosIterator it1(chains.begin(), chains.end());
+  TimerInfosIterator it2(chains.begin(), chains.end());
+  TimerInfosIterator it_end(chains.end(), chains.end());
+
+  EXPECT_TRUE(it1 == it2);
+  EXPECT_FALSE(it1 != it2);
+
+  EXPECT_FALSE(it1 == it_end);
+  EXPECT_TRUE(it1 != it_end);
+
+  ++it1;
+  EXPECT_TRUE(it1 == it_end);
+  EXPECT_FALSE(it1 != it_end);
+  EXPECT_FALSE(it1 == it2);
+  EXPECT_TRUE(it1 != it2);
+}
+
+TEST(TimerInfosIterator, ForEachEmpty) {
+  std::vector<std::shared_ptr<TimerChain>> chains;
+
+  TimerInfosIterator it_begin(chains.begin(), chains.end());
+  TimerInfosIterator it_end(chains.begin(), chains.end());
+
+  std::vector<uint64_t> result;
+  for (auto it = it_begin; it != it_end; ++it) {
+    result.push_back(it->function_address());
+  }
+  EXPECT_THAT(result, testing::ElementsAre());
+}
+
+TEST(TimerInfosIterator, ForEachLarge) {
+  std::vector<std::shared_ptr<TimerChain>> chains;
+  std::vector<uint64_t> expected;
+
+  size_t count = 0;
+  size_t max_timers = 32;
+  // Add twelve chains, with the size 2⁴, 2⁵, 2⁶, ...
+  //  such that there are blocks inside the chains that are full (1024 elements),
+  //  as well as blocks that are not full.
+  for (size_t chain_count = 0; chain_count < 12; ++chain_count) {
+    std::shared_ptr<TimerChain> chain = std::make_shared<TimerChain>();
+    for (size_t box_count = 0; box_count < max_timers; ++box_count) {
+      TextBox box;
+      TimerInfo timer;
+      timer.set_function_address(count);
+      timer.set_start(count);
+      timer.set_end(count + 1);
+      box.SetTimerInfo(timer);
+      chain->push_back(box);
+      expected.push_back(count);
+      ++count;
+    }
+    max_timers *= 2;
+    chains.push_back(chain);
+  }
+
+  TimerInfosIterator it_begin(chains.begin(), chains.end());
+  TimerInfosIterator it_end(chains.end(), chains.end());
+
+  std::vector<uint64_t> result;
+  for (auto it = it_begin; it != it_end; ++it) {
+    result.push_back(it->function_address());
+  }
+  EXPECT_THAT(result, testing::ElementsAreArray(expected));
+}


### PR DESCRIPTION
Add an interator for the TimerChains and use it in Serializer.
This is the first step of removing dependencies of OrbitGl from
CaptureSerializer, such that it can be used also by other clients.

Test: Compile, Save/Load capture.