### PR TITLE
Fix Not Clearing LiveFunctions and TopDownView

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -657,6 +657,7 @@ void OrbitApp::StopCapture() {
 }
 
 void OrbitApp::ClearCapture() {
+  capture_data_ = CaptureData();
   set_selected_thread_id(-1);
   SelectTextBox(nullptr);
 

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -103,7 +103,6 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App, ApplicationOptions&& optio
     ui->actionSave_Capture->setDisabled(false);
     ui->actionOpen_Preset->setDisabled(false);
     ui->actionSave_Preset_As->setDisabled(false);
-    ui->actionClear_Capture->setDisabled(false);
     ui->HomeTab->setDisabled(false);
   });
   GOrbitApp->SetCaptureClearedCallback([this] { OnCaptureCleared(); });


### PR DESCRIPTION
LiveFunctionsView and TopDownView use the current capture data
to display their information. Previously, clear capture was not
setting the capture data, such that these views kept the old data.
Clearing a capture, did not effect them.

This also removes dublicate setting of disabling the clear capture
button.

Test: Compile, Select Functions, Start Capture, Clear Capture,
      Try Clear Capture while Capturing.