### PR TITLE
Change the text of the top-down view's search field back to "search"

### DIFF
--- a/OrbitQt/topdownwidget.ui
+++ b/OrbitQt/topdownwidget.ui
@@ -21,7 +21,7 @@
       <string>filter</string>
      </property>
      <property name="placeholderText">
-      <string>Filter (invalidates the expanded/collapsed state of all nodes in the tree)</string>
+      <string>Search (invalidates the expanded/collapsed state of all nodes in the tree)</string>
      </property>
      <property name="clearButtonEnabled">
       <bool>true</bool>


### PR DESCRIPTION
No filtering is actually done, i.e., no node is hidden: the matching nodes are
highlighted and all their ancestors expanded. I think "search" is more accurate
for this.