### PR TITLE
[CHERRYPICK] Listen on local interfaces only in SSH tunnel

### DIFF
--- a/OrbitSshQt/Tunnel.cpp
+++ b/OrbitSshQt/Tunnel.cpp
@@ -4,6 +4,7 @@
 
 #include "OrbitSshQt/Tunnel.h"
 
+#include <QHostAddress>
 #include <QTimer>
 
 #include "OrbitBase/Logging.h"
@@ -76,7 +77,7 @@ outcome::result<void> Tunnel::startup() {
     }
     case State::kChannelInitialized: {
       local_server_.emplace();
-      const auto result = local_server_->listen();
+      const auto result = local_server_->listen(QHostAddress{QHostAddress::LocalHost});
 
       if (!result) {
         return Error::kCouldNotListen;


### PR DESCRIPTION
Dimitry suggested to cherry pick that bug fix. Please push back if you think that it's too late for proper testing.

By default QTcpServer listens on all available interfaces. We should
only listen on the local interface avoiding any security complications
and also the firewall dialog popping up.

Tests: Manual test of Orbit