### PR TITLE
 Add "Load Symbols" context menu action to the top-down view

### DIFF
--- a/OrbitGl/TopDownView.h
+++ b/OrbitGl/TopDownView.h
@@ -8,6 +8,7 @@
 #include <unordered_map>
 
 #include "CaptureData.h"
+#include "Path.h"
 #include "absl/container/node_hash_map.h"
 
 class TopDownNode {
@@ -44,7 +45,8 @@ class TopDownInternalNode : public TopDownNode {
   [[nodiscard]] TopDownFunction* GetFunctionOrNull(uint64_t function_absolute_address);
 
   [[nodiscard]] TopDownFunction* AddAndGetFunction(uint64_t function_absolute_address,
-                                                   std::string function_name);
+                                                   std::string function_name,
+                                                   std::string module_path);
 
   [[nodiscard]] float GetInclusivePercent(uint64_t total_sample_count) const {
     return 100.0f * sample_count() / total_sample_count;
@@ -63,14 +65,19 @@ class TopDownInternalNode : public TopDownNode {
 class TopDownFunction : public TopDownInternalNode {
  public:
   explicit TopDownFunction(uint64_t function_absolute_address, std::string function_name,
-                           TopDownNode* parent)
+                           std::string module_path, TopDownNode* parent)
       : TopDownInternalNode{parent},
         function_absolute_address_{function_absolute_address},
-        function_name_{std::move(function_name)} {}
+        function_name_{std::move(function_name)},
+        module_path_{std::move(module_path)} {}
 
   [[nodiscard]] uint64_t function_absolute_address() const { return function_absolute_address_; }
 
   [[nodiscard]] const std::string& function_name() const { return function_name_; }
+
+  [[nodiscard]] const std::string& module_path() const { return module_path_; }
+
+  [[nodiscard]] std::string GetModuleName() const { return Path::GetFileName(module_path()); }
 
   [[nodiscard]] uint64_t GetExclusiveSampleCount() const {
     uint64_t children_sample_count = 0;
@@ -97,6 +104,7 @@ class TopDownFunction : public TopDownInternalNode {
  private:
   uint64_t function_absolute_address_;
   std::string function_name_;
+  std::string module_path_;
 };
 
 class TopDownThread : public TopDownInternalNode {

--- a/OrbitQt/TopDownViewItemModel.cpp
+++ b/OrbitQt/TopDownViewItemModel.cpp
@@ -65,6 +65,7 @@ QVariant TopDownViewItemModel::GetEditRoleData(const QModelIndex& index) const {
   if (thread_item != nullptr) {
     switch (index.column()) {
       case kThreadOrFunction:
+        // Threads are sorted by tid, not by name.
         return thread_item->thread_id();
       case kInclusive:
         return static_cast<qulonglong>(thread_item->sample_count());
@@ -90,6 +91,18 @@ QVariant TopDownViewItemModel::GetEditRoleData(const QModelIndex& index) const {
   return QVariant();
 }
 
+QVariant TopDownViewItemModel::GetToolTipRoleData(const QModelIndex& index) const {
+  auto* item = static_cast<TopDownNode*>(index.internalPointer());
+  auto function_item = dynamic_cast<TopDownFunction*>(item);
+  if (function_item != nullptr) {
+    switch (index.column()) {
+      case kModule:
+        return QString::fromStdString(function_item->module_path());
+    }
+  }
+  return QVariant();
+}
+
 QVariant TopDownViewItemModel::data(const QModelIndex& index, int role) const {
   if (!index.isValid()) {
     return QVariant();
@@ -100,6 +113,9 @@ QVariant TopDownViewItemModel::data(const QModelIndex& index, int role) const {
     // The value returned when role == Qt::EditRole is used for sorting.
     case Qt::EditRole:
       return GetEditRoleData(index);
+    // When role == Qt::ToolTipRole more detailed information than it's shown is returned.
+    case Qt::ToolTipRole:
+      return GetToolTipRoleData(index);
   }
   return QVariant();
 }

--- a/OrbitQt/TopDownViewItemModel.cpp
+++ b/OrbitQt/TopDownViewItemModel.cpp
@@ -9,6 +9,7 @@ TopDownViewItemModel::TopDownViewItemModel(std::unique_ptr<TopDownView> top_down
     : QAbstractItemModel{parent}, top_down_view_{std::move(top_down_view)} {}
 
 QVariant TopDownViewItemModel::GetDisplayRoleData(const QModelIndex& index) const {
+  CHECK(index.isValid());
   auto* item = static_cast<TopDownNode*>(index.internalPointer());
   auto thread_item = dynamic_cast<TopDownThread*>(item);
   auto function_item = dynamic_cast<TopDownFunction*>(item);
@@ -59,6 +60,7 @@ QVariant TopDownViewItemModel::GetDisplayRoleData(const QModelIndex& index) cons
 }
 
 QVariant TopDownViewItemModel::GetEditRoleData(const QModelIndex& index) const {
+  CHECK(index.isValid());
   auto* item = static_cast<TopDownNode*>(index.internalPointer());
   auto thread_item = dynamic_cast<TopDownThread*>(item);
   auto function_item = dynamic_cast<TopDownFunction*>(item);
@@ -92,6 +94,7 @@ QVariant TopDownViewItemModel::GetEditRoleData(const QModelIndex& index) const {
 }
 
 QVariant TopDownViewItemModel::GetToolTipRoleData(const QModelIndex& index) const {
+  CHECK(index.isValid());
   auto* item = static_cast<TopDownNode*>(index.internalPointer());
   auto function_item = dynamic_cast<TopDownFunction*>(item);
   if (function_item != nullptr) {

--- a/OrbitQt/TopDownViewItemModel.cpp
+++ b/OrbitQt/TopDownViewItemModel.cpp
@@ -106,6 +106,16 @@ QVariant TopDownViewItemModel::GetToolTipRoleData(const QModelIndex& index) cons
   return QVariant();
 }
 
+QVariant TopDownViewItemModel::GetModulePathRoleData(const QModelIndex& index) const {
+  CHECK(index.isValid());
+  auto* item = static_cast<TopDownNode*>(index.internalPointer());
+  auto function_item = dynamic_cast<TopDownFunction*>(item);
+  if (function_item != nullptr) {
+    return QString::fromStdString(function_item->module_path());
+  }
+  return QVariant();
+}
+
 QVariant TopDownViewItemModel::data(const QModelIndex& index, int role) const {
   if (!index.isValid()) {
     return QVariant();
@@ -119,6 +129,8 @@ QVariant TopDownViewItemModel::data(const QModelIndex& index, int role) const {
     // When role == Qt::ToolTipRole more detailed information than it's shown is returned.
     case Qt::ToolTipRole:
       return GetToolTipRoleData(index);
+    case kModulePathRole:
+      return GetModulePathRoleData(index);
   }
   return QVariant();
 }

--- a/OrbitQt/TopDownViewItemModel.cpp
+++ b/OrbitQt/TopDownViewItemModel.cpp
@@ -48,6 +48,8 @@ QVariant TopDownViewItemModel::GetDisplayRoleData(const QModelIndex& index) cons
       case kOfParent:
         return QString::fromStdString(
             absl::StrFormat("%.2f%%", function_item->GetPercentOfParent()));
+      case kModule:
+        return QString::fromStdString(function_item->GetModuleName());
       case kFunctionAddress:
         return QString::fromStdString(
             absl::StrFormat("%#llx", function_item->function_absolute_address()));
@@ -79,6 +81,8 @@ QVariant TopDownViewItemModel::GetEditRoleData(const QModelIndex& index) const {
         return static_cast<qulonglong>(function_item->GetExclusiveSampleCount());
       case kOfParent:
         return static_cast<qulonglong>(function_item->GetPercentOfParent());
+      case kModule:
+        return QString::fromStdString(function_item->GetModuleName());
       case kFunctionAddress:
         return static_cast<qulonglong>(function_item->function_absolute_address());
     }
@@ -123,6 +127,8 @@ QVariant TopDownViewItemModel::headerData(int section, Qt::Orientation orientati
           return "Exclusive";
         case Columns::kOfParent:
           return "Of parent";
+        case Columns::kModule:
+          return "Module";
         case Columns::kFunctionAddress:
           return "Function address";
       }
@@ -137,6 +143,8 @@ QVariant TopDownViewItemModel::headerData(int section, Qt::Orientation orientati
           return Qt::DescendingOrder;
         case Columns::kOfParent:
           return Qt::DescendingOrder;
+        case Columns::kModule:
+          return Qt::AscendingOrder;
         case Columns::kFunctionAddress:
           return Qt::AscendingOrder;
       }

--- a/OrbitQt/TopDownViewItemModel.h
+++ b/OrbitQt/TopDownViewItemModel.h
@@ -37,10 +37,13 @@ class TopDownViewItemModel : public QAbstractItemModel {
     kColumnCount
   };
 
+  static const int kModulePathRole = Qt::UserRole + 1;
+
  private:
   [[nodiscard]] QVariant GetDisplayRoleData(const QModelIndex& index) const;
   [[nodiscard]] QVariant GetEditRoleData(const QModelIndex& index) const;
   [[nodiscard]] QVariant GetToolTipRoleData(const QModelIndex& index) const;
+  [[nodiscard]] QVariant GetModulePathRoleData(const QModelIndex& index) const;
 
   std::unique_ptr<TopDownView> top_down_view_;
 };

--- a/OrbitQt/TopDownViewItemModel.h
+++ b/OrbitQt/TopDownViewItemModel.h
@@ -40,6 +40,7 @@ class TopDownViewItemModel : public QAbstractItemModel {
  private:
   QVariant GetDisplayRoleData(const QModelIndex& index) const;
   QVariant GetEditRoleData(const QModelIndex& index) const;
+  QVariant GetToolTipRoleData(const QModelIndex& index) const;
 
   std::unique_ptr<TopDownView> top_down_view_;
 };

--- a/OrbitQt/TopDownViewItemModel.h
+++ b/OrbitQt/TopDownViewItemModel.h
@@ -32,6 +32,7 @@ class TopDownViewItemModel : public QAbstractItemModel {
     kInclusive,
     kExclusive,
     kOfParent,
+    kModule,
     kFunctionAddress,
     kColumnCount
   };

--- a/OrbitQt/TopDownViewItemModel.h
+++ b/OrbitQt/TopDownViewItemModel.h
@@ -38,9 +38,9 @@ class TopDownViewItemModel : public QAbstractItemModel {
   };
 
  private:
-  QVariant GetDisplayRoleData(const QModelIndex& index) const;
-  QVariant GetEditRoleData(const QModelIndex& index) const;
-  QVariant GetToolTipRoleData(const QModelIndex& index) const;
+  [[nodiscard]] QVariant GetDisplayRoleData(const QModelIndex& index) const;
+  [[nodiscard]] QVariant GetEditRoleData(const QModelIndex& index) const;
+  [[nodiscard]] QVariant GetToolTipRoleData(const QModelIndex& index) const;
 
   std::unique_ptr<TopDownView> top_down_view_;
 };

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -192,6 +192,8 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App, ApplicationOptions&& optio
   connect(ui->liveFunctions->GetFilterLineEdit(), &QLineEdit::textChanged, this,
           [this](const QString& text) { OnLiveTabFunctionsFilterTextChanged(text); });
 
+  ui->topDownWidget->Initialize(GOrbitApp.get());
+
   SetTitle({});
   std::string iconFileName = Path::JoinPath({Path::GetExecutableDir(), "orbit.ico"});
   this->setWindowIcon(QIcon(iconFileName.c_str()));

--- a/OrbitQt/topdownwidget.cpp
+++ b/OrbitQt/topdownwidget.cpp
@@ -79,7 +79,7 @@ static std::vector<std::shared_ptr<Module>> GetModulesFromIndices(
     std::string module_path =
         index.model()
             ->index(index.row(), TopDownViewItemModel::kModule, index.parent())
-            .data(Qt::ToolTipRole)
+            .data(TopDownViewItemModel::kModulePathRole)
             .toString()
             .toStdString();
     unique_module_paths.insert(module_path);

--- a/OrbitQt/topdownwidget.h
+++ b/OrbitQt/topdownwidget.h
@@ -14,6 +14,8 @@
 #include "TopDownViewItemModel.h"
 #include "ui_topdownwidget.h"
 
+class OrbitApp;
+
 class TopDownWidget : public QWidget {
   Q_OBJECT
 
@@ -24,6 +26,8 @@ class TopDownWidget : public QWidget {
     connect(ui_->topDownTreeView, &QTreeView::customContextMenuRequested, this,
             &TopDownWidget::onCustomContextMenuRequested);
   }
+
+  void Initialize(OrbitApp* app) { app_ = app; }
 
   void SetTopDownView(std::unique_ptr<TopDownView> top_down_view);
 
@@ -37,6 +41,7 @@ class TopDownWidget : public QWidget {
   static const QString kActionCollapseChildrenRecursively;
   static const QString kActionExpandAll;
   static const QString kActionCollapseAll;
+  static const QString kActionLoadSymbols;
 
   class HighlightCustomFilterSortFilterProxyModel : public QSortFilterProxyModel {
    public:
@@ -59,6 +64,7 @@ class TopDownWidget : public QWidget {
   };
 
   std::unique_ptr<Ui::TopDownWidget> ui_;
+  OrbitApp* app_ = nullptr;
   std::unique_ptr<TopDownViewItemModel> model_;
   std::unique_ptr<HighlightCustomFilterSortFilterProxyModel> proxy_model_;
 };


### PR DESCRIPTION
#### Use SamplingProfiler::kAllThreadsFakeTid in TopDownViewItemModel
#### Add "Module" column with module name to the top-down view
#### Add tooltips with module paths to the top-down view
#### Add "Load Symbols" context menu action to top-down view
Bug: http://b/162707037

N.B.: Loading a module's symbols, regardless of whether it's done from the
modules table, the sampling tab, etc., causes the top-down view to be refreshed
(the same happens with the sampling reports, to take the new information into
account, e.g., to group addresses under the same function) and hence to be
collapsed (unless a search string is in place). This is not caused by this
specific change, but it makes it more evident.