### PR TITLE
Fix Selecting "All Threads" and Display That Track on Linux

### DIFF
--- a/OrbitCore/EventBuffer.cpp
+++ b/OrbitCore/EventBuffer.cpp
@@ -42,13 +42,13 @@ void EventBuffer::AddCallstackEvent(uint64_t time, CallstackID cs_hash, ThreadID
   event_map[time] = event;
 
   // Add all callstack events to "all threads".
-  std::map<uint64_t, CallstackEvent>& event_map_0 =
+  std::map<uint64_t, CallstackEvent>& event_map_all_threads =
       callstack_events_[SamplingProfiler::kAllThreadsFakeTid];
-  CallstackEvent event0;
-  event0.set_time(time);
-  event0.set_callstack_hash(cs_hash);
-  event0.set_thread_id(SamplingProfiler::kAllThreadsFakeTid);
-  event_map_0[time] = event0;
+  CallstackEvent event_all_threads;
+  event_all_threads.set_time(time);
+  event_all_threads.set_callstack_hash(cs_hash);
+  event_all_threads.set_thread_id(SamplingProfiler::kAllThreadsFakeTid);
+  event_map_all_threads[time] = event_all_threads;
 
   RegisterTime(time);
 }

--- a/OrbitCore/SamplingProfiler.cpp
+++ b/OrbitCore/SamplingProfiler.cpp
@@ -93,7 +93,7 @@ std::shared_ptr<SortedCallstackReport> SamplingProfiler::GetSortedCallstacksFrom
   return report;
 }
 
-const int32_t SamplingProfiler::kAllThreadsFakeTid = 0;
+const int32_t SamplingProfiler::kAllThreadsFakeTid = -1;
 
 void SamplingProfiler::SortByThreadUsage() {
   sorted_thread_sample_data_.clear();

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -248,7 +248,7 @@ void SamplingReportDataView::SetSampledFunctions(const std::vector<SampledFuncti
 
 void SamplingReportDataView::SetThreadID(ThreadID tid) {
   tid_ = tid;
-  if (tid == 0) {
+  if (tid == SamplingProfiler::kAllThreadsFakeTid) {
     name_ = "All";
   } else {
     name_ = absl::StrFormat("%d", tid_);

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -42,7 +42,7 @@ TimeGraph::TimeGraph() : m_Batcher(BatcherId::kTimeGraph) {
   m_LastThreadReorder.Start();
   scheduler_track_ = GetOrCreateSchedulerTrack();
 
-  // The process track is a special ThreadTrack of id "0".
+  // The process track is a special ThreadTrack of id "kAllThreadsFakeTid".
   process_track_ = GetOrCreateThreadTrack(SamplingProfiler::kAllThreadsFakeTid);
 }
 
@@ -93,7 +93,7 @@ void TimeGraph::Clear() {
   cores_seen_.clear();
   scheduler_track_ = GetOrCreateSchedulerTrack();
 
-  // The process track is a special ThreadTrack of id "0".
+  // The process track is a special ThreadTrack of id "kAllThreadsFakeTid".
   process_track_ = GetOrCreateThreadTrack(SamplingProfiler::kAllThreadsFakeTid);
 
   SetIteratorOverlayData({}, {});
@@ -773,7 +773,7 @@ void TimeGraph::DrawTracks(GlCanvas* canvas, PickingMode picking_mode) {
     if (track->GetType() == Track::kThreadTrack) {
       auto thread_track = std::static_pointer_cast<ThreadTrack>(track);
       int32_t tid = thread_track->GetThreadId();
-      if (tid == 0) {
+      if (tid == SamplingProfiler::kAllThreadsFakeTid) {
         // This is the process_track_.
         std::string process_name = GOrbitApp->GetCaptureData().process_name();
         thread_track->SetName(process_name);
@@ -887,18 +887,18 @@ void TimeGraph::SortTracks() {
     std::vector<std::pair<ThreadID, uint32_t>> sortedThreads =
         OrbitUtils::ReverseValueSort(m_ThreadCountMap);
     for (auto& pair : sortedThreads) {
-      // Track "0" holds all target process sampling info, it is handled
+      // Track "kAllThreadsFakeTid" holds all target process sampling info, it is handled
       // separately.
-      if (pair.first != 0) sortedThreadIds.push_back(pair.first);
+      if (pair.first != SamplingProfiler::kAllThreadsFakeTid) sortedThreadIds.push_back(pair.first);
     }
 
     // Then show threads sorted by number of events
     std::vector<std::pair<ThreadID, uint32_t>> sortedByEvents =
         OrbitUtils::ReverseValueSort(m_EventCount);
     for (auto& pair : sortedByEvents) {
-      // Track "0" holds all target process sampling info, it is handled
+      // Track "kAllThreadsFakeTid" holds all target process sampling info, it is handled
       // separately.
-      if (pair.first == 0) continue;
+      if (pair.first == SamplingProfiler::kAllThreadsFakeTid) continue;
       if (m_ThreadCountMap.find(pair.first) == m_ThreadCountMap.end()) {
         sortedThreadIds.push_back(pair.first);
       }

--- a/OrbitQt/TopDownViewItemModel.cpp
+++ b/OrbitQt/TopDownViewItemModel.cpp
@@ -15,7 +15,7 @@ QVariant TopDownViewItemModel::GetDisplayRoleData(const QModelIndex& index) cons
   if (thread_item != nullptr) {
     switch (index.column()) {
       case kThreadOrFunction:
-        if (thread_item->thread_id() == 0) {
+        if (thread_item->thread_id() == SamplingProfiler::kAllThreadsFakeTid) {
           return QString::fromStdString(
               thread_item->thread_name().empty()
                   ? "(all threads)"


### PR DESCRIPTION
With recent changes, we started using "-1" instead of "0" for special
purpose thread/process ids (no selection and all threads). By these
changes, we missed a couple of places.

This change uses SamplingProfiler::kAllThreadsFakeTid on all these
places and thus fixes the issue that scheduler track was not highlighting
anything, when clicking on the "all threads" track and also displays that
track on Linux at all.

Bug: http://167391339 http://167393367
Test: In capture, select different tracks (including all threads), and
      click on the background (to reset). Also check the lable in
      TopDownView and the SamplingViews.