### PR TITLE
Fix symbol uploading

### DIFF
--- a/kokoro/builds/upload_symbols.sh
+++ b/kokoro/builds/upload_symbols.sh
@@ -64,7 +64,7 @@ function upload_symbol_file {
     breakpad/bin/symupload -p sym-upload-v2 -k $api_key $sym_file_path \
       https://prod-crashsymbolcollector-pa.googleapis.com
   else
-    breakpad/bin/symupload -p $symbol_file_path \
+    PATH="/c/BuildTools/DIA SDK/bin/amd64:$PATH" breakpad/bin/symupload -p $symbol_file_path \
       https://prod-crashsymbolcollector-pa.googleapis.com $api_key
   fi
 }


### PR DESCRIPTION
breakpad's upload tool needs to find `msdia140.dll` from the DIA SDK which comes with Visual Studio.

Apparently this does not work automatically when Visual Studio is installed in the BuildTools version.

This change adds the DIA SDK-path to $PATH to fix that problem.