### PR TITLE
[REBASE] Mark empty preset as 'loadable'

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -75,12 +75,13 @@ PresetLoadState GetPresetLoadStateForProcess(
     }
   }
 
-  if (modules_not_found_count == preset->preset_info().path_to_module_size()) {
-    return PresetLoadState::kNotLoadable;
-  }
-
+  // Empty preset is also loadable
   if (modules_not_found_count == 0) {
     return PresetLoadState::kLoadable;
+  }
+
+  if (modules_not_found_count == preset->preset_info().path_to_module_size()) {
+    return PresetLoadState::kNotLoadable;
   }
 
   return PresetLoadState::kPartiallyLoadable;


### PR DESCRIPTION
Test: Start Orbit, save an empty preset, check that the font for this
empty preset is green, and value in Loadable column is 'Yes'.

Reviewed in #1161 