### PR TITLE
Add "Go to Disassembly" context menu action to top-down view

### DIFF
--- a/OrbitQt/TopDownViewItemModel.cpp
+++ b/OrbitQt/TopDownViewItemModel.cpp
@@ -99,6 +99,8 @@ QVariant TopDownViewItemModel::GetToolTipRoleData(const QModelIndex& index) cons
   auto function_item = dynamic_cast<TopDownFunction*>(item);
   if (function_item != nullptr) {
     switch (index.column()) {
+      case kThreadOrFunction:
+        return QString::fromStdString(function_item->function_name());
       case kModule:
         return QString::fromStdString(function_item->module_path());
     }

--- a/OrbitQt/topdownwidget.h
+++ b/OrbitQt/topdownwidget.h
@@ -42,6 +42,7 @@ class TopDownWidget : public QWidget {
   static const QString kActionExpandAll;
   static const QString kActionCollapseAll;
   static const QString kActionLoadSymbols;
+  static const QString kActionDisassembly;
 
   class HighlightCustomFilterSortFilterProxyModel : public QSortFilterProxyModel {
    public:


### PR DESCRIPTION
#### Add "Go to Disassembly" context menu action to top-down view
Bug: http://b/162707037
#### Add tooltips for function names to top-down view
Can be useful when the function name is particularly long and doesn't fit in the
column width.