### PR TITLE
Fix Broken Capture Duration for Empty Captures

### DIFF
--- a/OrbitCore/EventBuffer.cpp
+++ b/OrbitCore/EventBuffer.cpp
@@ -13,11 +13,11 @@ using orbit_client_protos::CallstackEvent;
 EventTracer GEventTracer;
 
 std::vector<CallstackEvent> EventBuffer::GetCallstackEvents(
-    uint64_t time_begin, uint64_t time_end, ThreadID thread_id /*= kAllThreadsFakeTid*/) {
+    uint64_t time_begin, uint64_t time_end, int32_t thread_id /*= kAllThreadsFakeTid*/) const {
   std::vector<CallstackEvent> callstack_events;
   for (auto& pair : callstack_events_) {
-    const ThreadID callstack_thread_id = pair.first;
-    std::map<uint64_t, CallstackEvent>& callstacks = pair.second;
+    const int32_t callstack_thread_id = pair.first;
+    const std::map<uint64_t, CallstackEvent>& callstacks = pair.second;
 
     if (thread_id == SamplingProfiler::kAllThreadsFakeTid || callstack_thread_id == thread_id) {
       for (auto it = callstacks.lower_bound(time_begin); it != callstacks.end(); ++it) {
@@ -32,8 +32,8 @@ std::vector<CallstackEvent> EventBuffer::GetCallstackEvents(
   return callstack_events;
 }
 
-void EventBuffer::AddCallstackEvent(uint64_t time, CallstackID cs_hash, ThreadID thread_id) {
-  ScopeLock lock(m_Mutex);
+void EventBuffer::AddCallstackEvent(uint64_t time, CallstackID cs_hash, int32_t thread_id) {
+  ScopeLock lock(mutex_);
   std::map<uint64_t, CallstackEvent>& event_map = callstack_events_[thread_id];
   CallstackEvent event;
   event.set_time(time);
@@ -55,11 +55,11 @@ void EventBuffer::AddCallstackEvent(uint64_t time, CallstackID cs_hash, ThreadID
 
 #ifdef __linux
 size_t EventBuffer::GetNumEvents() const {
-  size_t numEvents = 0;
+  size_t num_events = 0;
   for (auto& pair : callstack_events_) {
-    numEvents += pair.second.size();
+    num_events += pair.second.size();
   }
 
-  return numEvents;
+  return num_events;
 }
 #endif

--- a/OrbitCore/EventBuffer.cpp
+++ b/OrbitCore/EventBuffer.cpp
@@ -32,6 +32,19 @@ std::vector<CallstackEvent> EventBuffer::GetCallstackEvents(
   return callstack_events;
 }
 
+bool EventBuffer::HasEvent() {
+  ScopeLock lock(mutex_);
+  if (callstack_events_.empty()) {
+    return false;
+  }
+  for (const auto& pair : callstack_events_) {
+    if (!pair.second.empty()) {
+      return true;
+    }
+  }
+  return false;
+}
+
 void EventBuffer::AddCallstackEvent(uint64_t time, CallstackID cs_hash, int32_t thread_id) {
   ScopeLock lock(mutex_);
   std::map<uint64_t, CallstackEvent>& event_map = callstack_events_[thread_id];

--- a/OrbitCore/EventBuffer.cpp
+++ b/OrbitCore/EventBuffer.cpp
@@ -53,7 +53,6 @@ void EventBuffer::AddCallstackEvent(uint64_t time, CallstackID cs_hash, int32_t 
   RegisterTime(time);
 }
 
-#ifdef __linux
 size_t EventBuffer::GetNumEvents() const {
   size_t num_events = 0;
   for (auto& pair : callstack_events_) {
@@ -62,4 +61,3 @@ size_t EventBuffer::GetNumEvents() const {
 
   return num_events;
 }
-#endif

--- a/OrbitCore/EventBuffer.h
+++ b/OrbitCore/EventBuffer.h
@@ -50,7 +50,15 @@ class EventBuffer {
 
   [[nodiscard]] bool HasEvent() {
     ScopeLock lock(mutex_);
-    return !callstack_events_.empty();
+    if (callstack_events_.empty()) {
+      return false;
+    }
+    for (const auto& pair : callstack_events_) {
+      if (!pair.second.empty()) {
+        return true;
+      }
+    }
+    return true;
   }
 
   [[nodiscard]] size_t GetNumEvents() const;

--- a/OrbitCore/EventBuffer.h
+++ b/OrbitCore/EventBuffer.h
@@ -48,18 +48,7 @@ class EventBuffer {
 
   [[nodiscard]] uint64_t GetMinTime() const { return min_time_; }
 
-  [[nodiscard]] bool HasEvent() {
-    ScopeLock lock(mutex_);
-    if (callstack_events_.empty()) {
-      return false;
-    }
-    for (const auto& pair : callstack_events_) {
-      if (!pair.second.empty()) {
-        return true;
-      }
-    }
-    return true;
-  }
+  [[nodiscard]] bool HasEvent();
 
   [[nodiscard]] size_t GetNumEvents() const;
 

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -507,7 +507,7 @@ std::string OrbitApp::GetCaptureFileName() {
 }
 
 std::string OrbitApp::GetCaptureTime() {
-  double time = GCurrentTimeGraph != nullptr ? GCurrentTimeGraph->GetCaptureTimeSpanUs() : 0;
+  double time = GCurrentTimeGraph != nullptr ? GCurrentTimeGraph->GetCaptureTimeSpanUs() : 0.0;
   return GetPrettyTime(absl::Microseconds(time));
 }
 

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -18,7 +18,7 @@ using TooltipCallback = std::function<std::string(PickingId)>;
 struct PickingUserData {
   TextBox* text_box_;
   TooltipCallback generate_tooltip_;
-  void* custom_data_ = nullptr;
+  const void* custom_data_ = nullptr;
 
   explicit PickingUserData(TextBox* text_box = nullptr, TooltipCallback generate_tooltip = nullptr)
       : text_box_(text_box), generate_tooltip_(std::move(generate_tooltip)) {}

--- a/OrbitGl/BatcherTest.cpp
+++ b/OrbitGl/BatcherTest.cpp
@@ -125,7 +125,7 @@ void ExpectCustomDataEq(const MockBatcher& batcher, const Color& rendered_color,
   const PickingUserData* rendered_data = batcher.GetUserData(id);
   EXPECT_NE(rendered_data, nullptr);
   EXPECT_NE(rendered_data->custom_data_, nullptr);
-  EXPECT_EQ(*static_cast<T*>(rendered_data->custom_data_), value);
+  EXPECT_EQ(*static_cast<const T*>(rendered_data->custom_data_), value);
 }
 
 TEST(Batcher, PickingSimpleElements) {

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -208,7 +208,7 @@ std::string EventTrack::GetSampleTooltip(PickingId id) const {
   }
 
   const CallstackData* callstack_data = GOrbitApp->GetCaptureData().GetCallstackData();
-  const auto callstack_event = static_cast<const CallstackEvent*>(user_data->custom_data_);
+  const auto* callstack_event = static_cast<const CallstackEvent*>(user_data->custom_data_);
 
   uint64_t callstack_hash = callstack_event->callstack_hash();
   const CallStack* callstack = callstack_data->GetCallStack(callstack_hash);

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -70,8 +70,8 @@ void EventTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingM
   const bool picking = picking_mode != PickingMode::kNone;
 
   ScopeLock lock(GEventTracer.GetEventBuffer().GetMutex());
-  std::map<uint64_t, CallstackEvent>& callstacks =
-      GEventTracer.GetEventBuffer().GetCallstacks()[thread_id_];
+  const std::map<uint64_t, CallstackEvent>& callstacks =
+      GEventTracer.GetEventBuffer().GetCallstacksOfThread(thread_id_);
 
   const Color kWhite(255, 255, 255, 255);
   const Color kGreenSelection(0, 255, 0, 255);
@@ -99,7 +99,7 @@ void EventTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingM
     constexpr const float kPickingBoxWidth = 9.0f;
     constexpr const float kPickingBoxOffset = (kPickingBoxWidth - 1.0f) / 2.0f;
 
-    for (auto& pair : callstacks) {
+    for (const auto& pair : callstacks) {
       uint64_t time = pair.first;
       if (time > min_tick && time < max_tick) {
         Vec2 pos(time_graph_->GetWorldFromTick(time) - kPickingBoxOffset,
@@ -153,7 +153,7 @@ void EventTrack::SelectEvents() {
 bool EventTrack::IsEmpty() const {
   ScopeLock lock(GEventTracer.GetEventBuffer().GetMutex());
   const std::map<uint64_t, CallstackEvent>& callstacks =
-      GEventTracer.GetEventBuffer().GetCallstacks()[thread_id_];
+      GEventTracer.GetEventBuffer().GetCallstacksOfThread(thread_id_);
   return callstacks.empty();
 }
 
@@ -208,7 +208,7 @@ std::string EventTrack::GetSampleTooltip(PickingId id) const {
   }
 
   const CallstackData* callstack_data = GOrbitApp->GetCaptureData().GetCallstackData();
-  CallstackEvent* callstack_event = static_cast<CallstackEvent*>(user_data->custom_data_);
+  const auto callstack_event = static_cast<const CallstackEvent*>(user_data->custom_data_);
 
   uint64_t callstack_hash = callstack_event->callstack_hash();
   const CallStack* callstack = callstack_data->GetCallStack(callstack_hash);

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -157,7 +157,7 @@ double TimeGraph::GetCaptureTimeSpanUs() {
     return TicksToMicroseconds(capture_min_timestamp_, capture_max_timestamp_);
   }
 
-  return 0;
+  return 0.0;
 }
 
 double TimeGraph::GetCurrentTimeSpanUs() { return m_MaxTimeUs - m_MinTimeUs; }

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -872,10 +872,10 @@ void TimeGraph::SortTracks() {
     m_EventCount.clear();
 
     for (auto& pair : GEventTracer.GetEventBuffer().GetCallstacks()) {
-      ThreadID threadID = pair.first;
-      std::map<uint64_t, CallstackEvent>& callstacks = pair.second;
-      m_EventCount[threadID] = callstacks.size();
-      GetOrCreateThreadTrack(threadID);
+      ThreadID thread_id = pair.first;
+      const std::map<uint64_t, CallstackEvent>& callstacks = pair.second;
+      m_EventCount[thread_id] = callstacks.size();
+      GetOrCreateThreadTrack(thread_id);
     }
   }
 

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -39,8 +39,8 @@ class TimeGraph {
   void UpdatePrimitives(PickingMode picking_mode);
   void SortTracks();
   std::vector<orbit_client_protos::CallstackEvent> SelectEvents(float world_start, float world_end,
-                                                                ThreadID thread_id);
-  const std::vector<orbit_client_protos::CallstackEvent>& GetSelectedCallstackEvents(ThreadID tid);
+                                                                int32_t thread_id);
+  const std::vector<orbit_client_protos::CallstackEvent>& GetSelectedCallstackEvents(int32_t tid);
 
   void ProcessTimer(const orbit_client_protos::TimerInfo& timer_info,
                     const orbit_client_protos::FunctionInfo* function);
@@ -127,7 +127,7 @@ class TimeGraph {
   const TextBox* FindTop(const TextBox* from);
   const TextBox* FindDown(const TextBox* from);
 
-  Color GetThreadColor(ThreadID tid) const;
+  Color GetThreadColor(int32_t tid) const;
   [[nodiscard]] std::string GetManualInstrumentationString(uint64_t string_address) const;
 
   void SetIteratorOverlayData(
@@ -144,7 +144,7 @@ class TimeGraph {
 
  protected:
   std::shared_ptr<SchedulerTrack> GetOrCreateSchedulerTrack();
-  std::shared_ptr<ThreadTrack> GetOrCreateThreadTrack(ThreadID a_TID);
+  std::shared_ptr<ThreadTrack> GetOrCreateThreadTrack(int32_t tid);
   std::shared_ptr<GpuTrack> GetOrCreateGpuTrack(uint64_t timeline_hash);
   GraphTrack* GetOrCreateGraphTrack(uint64_t graph_id);
 
@@ -167,7 +167,7 @@ class TimeGraph {
   double m_MaxTimeUs = 0;
   uint64_t capture_min_timestamp_ = 0;
   uint64_t capture_max_timestamp_ = 0;
-  std::map<ThreadID, uint32_t> m_EventCount;
+  std::map<int32_t, uint32_t> m_EventCount;
   double m_TimeWindowUs = 0;
   float m_WorldStartX = 0;
   float m_WorldWidth = 0;
@@ -180,7 +180,7 @@ class TimeGraph {
 
   TimeGraphLayout m_Layout;
 
-  std::map<ThreadID, uint32_t> m_ThreadCountMap;
+  std::map<int32_t, uint32_t> m_ThreadCountMap;
 
   // Be careful when directly changing these members without using the
   // methods NeedsRedraw() or NeedsUpdate():
@@ -199,7 +199,7 @@ class TimeGraph {
 
   mutable Mutex m_Mutex;
   std::vector<std::shared_ptr<Track>> tracks_;
-  std::unordered_map<ThreadID, std::shared_ptr<ThreadTrack>> thread_tracks_;
+  std::unordered_map<int32_t, std::shared_ptr<ThreadTrack>> thread_tracks_;
   absl::flat_hash_map<uint64_t, std::shared_ptr<GraphTrack>> graph_tracks_;
   // Mapping from timeline hash to GPU tracks.
   std::unordered_map<uint64_t, std::shared_ptr<GpuTrack>> gpu_tracks_;
@@ -210,7 +210,7 @@ class TimeGraph {
   std::shared_ptr<SchedulerTrack> scheduler_track_;
   std::shared_ptr<ThreadTrack> process_track_;
 
-  absl::flat_hash_map<ThreadID, std::vector<orbit_client_protos::CallstackEvent>>
+  absl::flat_hash_map<int32_t, std::vector<orbit_client_protos::CallstackEvent>>
       selected_callstack_events_per_thread_;
 
   std::shared_ptr<StringManager> string_manager_;


### PR DESCRIPTION
When opening the capture view for the first time showed "days"
instead of "0". This fixes this issue, by making EventBuffer's
callstacks_ read methods const.
Previousely there was an effective access in EventTrack GEventTracer.GetEventBuffer().GetCallstacks[tid];
which was executed always at the beginning for the all threads track
and added empty callstacks for that thread id. Additionally, the
check for the capture time span asks for EventBuffer::HasEvent, which
just checked whether the map is empty (which it was not).

This also made some minor local cleanup refactorings (nodiscard, naming).

Test: On Empty Capture: Go to Sampling View. Also clear capture.
Bug: http://b/162706447