### PR TITLE
Match exact version when deploying Orbit

### DIFF
--- a/OrbitQt/servicedeploymanager.cpp
+++ b/OrbitQt/servicedeploymanager.cpp
@@ -84,8 +84,8 @@ outcome::result<bool> ServiceDeployManager::CheckIfInstalled() {
     // packages. So we have to remove it.
     version = version.substr(1);
   }
-  const auto command =
-      absl::StrFormat("/usr/bin/dpkg-query -W -f '${Version}' orbitprofiler 2>/dev/null | grep -xF '%s'", version);
+  const auto command = absl::StrFormat(
+      "/usr/bin/dpkg-query -W -f '${Version}' orbitprofiler 2>/dev/null | grep -xF '%s'", version);
 
   OrbitSshQt::Task check_if_installed_task{&session_.value(), command};
 

--- a/OrbitQt/servicedeploymanager.cpp
+++ b/OrbitQt/servicedeploymanager.cpp
@@ -85,7 +85,7 @@ outcome::result<bool> ServiceDeployManager::CheckIfInstalled() {
     version = version.substr(1);
   }
   const auto command =
-      absl::StrFormat("/usr/bin/dpkg-query -W orbitprofiler 2>/dev/null | grep -E '%s$'", version);
+      absl::StrFormat("/usr/bin/dpkg-query -W -f '${Version}' orbitprofiler 2>/dev/null | grep -xF '%s'", version);
 
   OrbitSshQt::Task check_if_installed_task{&session_.value(), command};
 

--- a/OrbitQt/servicedeploymanager.cpp
+++ b/OrbitQt/servicedeploymanager.cpp
@@ -85,7 +85,7 @@ outcome::result<bool> ServiceDeployManager::CheckIfInstalled() {
     version = version.substr(1);
   }
   const auto command =
-      absl::StrFormat("/usr/bin/dpkg-query -W orbitprofiler 2>/dev/null | grep %s", version);
+      absl::StrFormat("/usr/bin/dpkg-query -W orbitprofiler 2>/dev/null | grep -E '%s$'", version);
 
   OrbitSshQt::Task check_if_installed_task{&session_.value(), command};
 


### PR DESCRIPTION
Checking the version that's installed on the gamelet is currently
checked with a simple `grep` which leads to `1.51` matches `1.51-333-xxxxxx`.

This should not be the case, so this commit changes the matching such
that always the full version number is matched.

This is only an issue when using developement versions of Orbit, so not
a customer-facing issue.