### PR TITLE
Rename SampledFunction::address to absolute_address

### DIFF
--- a/OrbitCore/SamplingProfiler.cpp
+++ b/OrbitCore/SamplingProfiler.cpp
@@ -290,7 +290,7 @@ void SamplingProfiler::FillThreadSampleDataSampleReports(const CaptureData& capt
       if (it != thread_sample_data->exclusive_count.end()) {
         function.exclusive = 100.f * it->second / thread_sample_data->samples_count;
       }
-      function.address = absolute_address;
+      function.absolute_address = absolute_address;
       function.module_path = capture_data.GetModulePathByAddress(absolute_address);
 
       const FunctionInfo* function_info = capture_data.GetFunctionInfoByAddress(absolute_address);

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -32,7 +32,7 @@ struct SampledFunction {
   float exclusive = 0;
   float inclusive = 0;
   int line = 0;
-  uint64_t address = 0;
+  uint64_t absolute_address = 0;
   orbit_client_protos::FunctionInfo* function = nullptr;
 };
 

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -1051,7 +1051,7 @@ void OrbitApp::ClearSelectedFunctions() { data_manager_->ClearSelectedFunctions(
 }
 
 [[nodiscard]] bool OrbitApp::IsFunctionSelected(const SampledFunction& func) const {
-  return data_manager_->IsFunctionSelected(func.address);
+  return data_manager_->IsFunctionSelected(func.absolute_address);
 }
 
 void OrbitApp::SetVisibleFunctions(absl::flat_hash_set<uint64_t> visible_functions) {

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -56,7 +56,7 @@ std::string SamplingReportDataView::GetValue(int row, int column) {
     case kColumnLine:
       return func.line > 0 ? absl::StrFormat("%d", func.line) : "";
     case kColumnAddress:
-      return absl::StrFormat("%#llx", func.address);
+      return absl::StrFormat("%#llx", func.absolute_address);
     default:
       return "";
   }
@@ -107,7 +107,7 @@ void SamplingReportDataView::DoSort() {
       sorter = ORBIT_PROC_SORT(line);
       break;
     case kColumnAddress:
-      sorter = ORBIT_PROC_SORT(address);
+      sorter = ORBIT_PROC_SORT(absolute_address);
       break;
     default:
       break;
@@ -120,7 +120,7 @@ void SamplingReportDataView::DoSort() {
   const auto fallback_sorter = [&](const auto& ind_left, const auto& ind_right) {
     // `SampledFunction::address` is the absolute function address. Hence it is unique and qualifies
     // for total ordering.
-    return functions[ind_left].address < functions[ind_right].address;
+    return functions[ind_left].absolute_address < functions[ind_right].absolute_address;
   };
 
   const auto combined_sorter = [&](const auto& ind_left, const auto& ind_right) {
@@ -146,7 +146,8 @@ std::vector<FunctionInfo*> SamplingReportDataView::GetFunctionsFromIndices(
   for (int index : indices) {
     SampledFunction& sampled_function = GetSampledFunction(index);
     if (sampled_function.function == nullptr) {
-      sampled_function.function = process->GetFunctionFromAddress(sampled_function.address, false);
+      sampled_function.function =
+          process->GetFunctionFromAddress(sampled_function.absolute_address, false);
     }
 
     FunctionInfo* function = sampled_function.function;
@@ -244,7 +245,7 @@ void SamplingReportDataView::OnContextMenu(const std::string& action, int menu_i
 
 void SamplingReportDataView::OnSelect(int index) {
   SampledFunction& func = GetSampledFunction(index);
-  sampling_report_->OnSelectAddress(func.address, tid_);
+  sampling_report_->OnSelectAddress(func.absolute_address, tid_);
 }
 
 void SamplingReportDataView::LinkDataView(DataView* data_view) {


### PR DESCRIPTION
This is a follow-up to the sorting changes in SamplingReportDataView.

SampledFunction::address is an absolute address, so it should also be
called like that since we also have that distinction in the rest of the
code base.

This commit only renames the member variable, no further changes.

Test: Compiles