### PR TITLE
Bugfix: Icon names and resource link broke during merging

### DIFF
--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -213,8 +213,8 @@ void OrbitMainWindow::SetupCaptureToolbar() {
   QToolBar* toolbar = ui->capture_toolbar;
 
   // Create missing icons
-  icon_start_capture_ = QIcon(":/actions/outline_play_arrow_white_48dp.png");
-  icon_stop_capture_ = QIcon(":/actions/outline_stop_white_48dp.png");
+  icon_start_capture_ = QIcon(":/actions/play_arrow");
+  icon_stop_capture_ = QIcon(":/actions/stop");
 
   // Attach the filter panel to the toolbar
   toolbar->addWidget(CreateSpacer(toolbar));

--- a/OrbitQt/orbitmainwindow.ui
+++ b/OrbitQt/orbitmainwindow.ui
@@ -614,7 +614,7 @@ QPushButton:disabled {
  </customwidgets>
  <resources>
   <include location="../icons/orbiticons.qrc"/>
-  <include location="../fonts/orbitfonts.qrc"/>
+  <include location="../images/orbitimages.qrc"/>
  </resources>
  <connections>
   <connection>


### PR DESCRIPTION
During rebase of the tutorial resource branch, apparently the resource name of the start / stop icon was merged incorrectly.

Bug in current master:
Start a capture -> Icon on the button disappears.

To test:
Start a capture -> Icon on the button correctly changes to stop
Stop the capture -> Changes back to play button