### PR TITLE
Capture in progress is cleaned up before exiting Orbit

### DIFF
--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -560,3 +560,19 @@ void OrbitMainWindow::on_actionServiceStackOverflow_triggered() {
 }
 
 void OrbitMainWindow::OnCaptureCleared() { ui->liveFunctions->Reset(); }
+
+void OrbitMainWindow::closeEvent(QCloseEvent* event) {
+  if (GOrbitApp->IsCapturing()) {
+    event->ignore();
+
+    if (QMessageBox::question(this, "Capture in progress",
+                              "A capture is currently in progress. Do you want to abort the "
+                              "capture and exit Orbit?") == QMessageBox::Yes) {
+      // We need for the capture to clean up - close as soon as this is done
+      GOrbitApp->SetCaptureStoppedCallback([&] { close(); });
+      GOrbitApp->StopCapture();
+    }
+  } else {
+    QMainWindow::closeEvent(event);
+  }
+}

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -51,6 +51,9 @@ class OrbitMainWindow : public QMainWindow {
   outcome::result<void> OpenCapture(const std::string& filepath);
   void OnCaptureCleared();
 
+ protected:
+  virtual void closeEvent(QCloseEvent* event) override;
+
  private slots:
   void on_actionAbout_triggered();
 


### PR DESCRIPTION
Bugfix: When Orbit was closed while a capture was in progress, the process never exited correctly. This is now fixed, and the user is asked if the running capture should be aborted when closing.

To test:
Start a capture, close Orbit's main window. Choose Yes: Orbit closes after capture processing has finished. Choose No: Orbit does not close, capturing continues.

![image](https://user-images.githubusercontent.com/63750742/92119488-25cbb180-edf8-11ea-813b-1ec414fcef82.png)

