### PR TITLE
Change EventBuffer::GetCallstackEvents to ...InTimeRangeForThreadId

### DIFF
--- a/OrbitCore/EventBuffer.cpp
+++ b/OrbitCore/EventBuffer.cpp
@@ -12,11 +12,14 @@ using orbit_client_protos::CallstackEvent;
 
 EventTracer GEventTracer;
 
-std::vector<CallstackEvent> EventBuffer::GetCallstackEvents(
+std::vector<CallstackEvent> EventBuffer::GetCallstackEventsInTimeRangeForThreadId(
     uint64_t time_begin, uint64_t time_end, int32_t thread_id /*= kAllThreadsFakeTid*/) const {
   std::vector<CallstackEvent> callstack_events;
-  for (auto& pair : callstack_events_) {
+  for (const auto& pair : callstack_events_) {
     const int32_t callstack_thread_id = pair.first;
+    if (callstack_thread_id == SamplingProfiler::kAllThreadsFakeTid) {
+      continue;
+    }
     const std::map<uint64_t, CallstackEvent>& callstacks = pair.second;
 
     if (thread_id == SamplingProfiler::kAllThreadsFakeTid || callstack_thread_id == thread_id) {

--- a/OrbitCore/EventBuffer.h
+++ b/OrbitCore/EventBuffer.h
@@ -40,7 +40,7 @@ class EventBuffer {
 
   Mutex& GetMutex() { return mutex_; }
 
-  [[nodiscard]] std::vector<orbit_client_protos::CallstackEvent> GetCallstackEvents(
+  std::vector<orbit_client_protos::CallstackEvent> GetCallstackEventsInTimeRangeForThreadId(
       uint64_t time_begin, uint64_t time_end,
       int32_t thread_id = SamplingProfiler::kAllThreadsFakeTid) const;
 

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -592,7 +592,7 @@ std::vector<CallstackEvent> TimeGraph::SelectEvents(float world_start, float wor
   uint64_t t1 = GetTickFromWorld(world_end);
 
   std::vector<CallstackEvent> selected_callstack_events =
-      GEventTracer.GetEventBuffer().GetCallstackEvents(t0, t1, thread_id);
+      GEventTracer.GetEventBuffer().GetCallstackEventsInTimeRangeForThreadId(t0, t1, thread_id);
 
   selected_callstack_events_per_thread_.clear();
   for (CallstackEvent& event : selected_callstack_events) {


### PR DESCRIPTION
Fixes a bug caused by the fact that when
`SamplingProfiler::ProcessSamples` is called for a selection, the
`CallstackData` passed to it contains each CallstackEvent twice, once
for its thread and once for the fake -1 thread. But
`SamplingProfiler::ProcessSamples` assumes the opposite.

Bug: http://b/167672728

The original version is not needed as this method is only used in one place.