### PR TITLE
Add a top-down view for the selection

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -453,10 +453,9 @@ void OrbitApp::SetSamplingReport(
     absl::flat_hash_map<CallstackID, std::shared_ptr<CallStack>> unique_callstacks) {
   auto report =
       std::make_shared<SamplingReport>(std::move(sampling_profiler), std::move(unique_callstacks));
-  if (sampling_reports_callback_) {
-    DataView* callstack_data_view = GetOrCreateDataView(DataViewType::kCallstack);
-    sampling_reports_callback_(callstack_data_view, report);
-  }
+  CHECK(sampling_reports_callback_);
+  DataView* callstack_data_view = GetOrCreateDataView(DataViewType::kCallstack);
+  sampling_reports_callback_(callstack_data_view, report);
 
   // clear old sampling report
   if (sampling_report_ != nullptr) {
@@ -469,13 +468,11 @@ void OrbitApp::SetSelectionReport(
     SamplingProfiler sampling_profiler,
     absl::flat_hash_map<CallstackID, std::shared_ptr<CallStack>> unique_callstacks,
     bool has_summary) {
+  CHECK(selection_report_callback_);
   auto report = std::make_shared<SamplingReport>(std::move(sampling_profiler),
                                                  std::move(unique_callstacks), has_summary);
-
-  if (selection_report_callback_) {
-    DataView* callstack_data_view = GetOrCreateSelectionCallstackDataView();
-    selection_report_callback_(callstack_data_view, report);
-  }
+  DataView* callstack_data_view = GetOrCreateSelectionCallstackDataView();
+  selection_report_callback_(callstack_data_view, report);
 
   // clear old selection report
   if (selection_report_ != nullptr) {
@@ -486,10 +483,7 @@ void OrbitApp::SetSelectionReport(
 }
 
 void OrbitApp::SetTopDownView(const CaptureData& capture_data) {
-  if (!top_down_view_callback_) {
-    return;
-  }
-
+  CHECK(top_down_view_callback_);
   std::unique_ptr<TopDownView> top_down_view =
       TopDownView::CreateFromSamplingProfiler(capture_data.sampling_profiler(), capture_data);
   top_down_view_callback_(std::move(top_down_view));
@@ -497,10 +491,7 @@ void OrbitApp::SetTopDownView(const CaptureData& capture_data) {
 
 void OrbitApp::SetSelectionTopDownView(const SamplingProfiler& selection_sampling_profiler,
                                        const CaptureData& capture_data) {
-  if (!selection_top_down_view_callback_) {
-    return;
-  }
-
+  CHECK(selection_top_down_view_callback_);
   std::unique_ptr<TopDownView> selection_top_down_view =
       TopDownView::CreateFromSamplingProfiler(selection_sampling_profiler, capture_data);
   selection_top_down_view_callback_(std::move(selection_top_down_view));

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -702,16 +702,7 @@ void OrbitApp::ClearCapture() {
   set_selected_thread_id(-1);
   SelectTextBox(nullptr);
 
-  SamplingProfiler empty_profiler;
-  absl::flat_hash_map<CallstackID, std::shared_ptr<CallStack>> empty_unique_callstacks;
-
-  SetSamplingReport(empty_profiler, empty_unique_callstacks);
-  SetTopDownView(GetCaptureData());
-  SetSelectionTopDownView(empty_profiler, GetCaptureData());
-
-  if (selection_report_) {
-    SetSelectionReport(std::move(empty_profiler), empty_unique_callstacks, false);
-  }
+  UpdateAfterCaptureCleared();
 
   if (GCurrentTimeGraph != nullptr) {
     GCurrentTimeGraph->Clear();
@@ -1130,6 +1121,18 @@ void OrbitApp::UpdateAfterSymbolLoading() {
     selection_report_->UpdateReport(
         std::move(selection_profiler),
         capture_data.GetSelectionCallstackData()->GetUniqueCallstacksCopy());
+  }
+}
+
+void OrbitApp::UpdateAfterCaptureCleared() {
+  SamplingProfiler empty_profiler;
+  absl::flat_hash_map<CallstackID, std::shared_ptr<CallStack>> empty_unique_callstacks;
+
+  SetSamplingReport(empty_profiler, empty_unique_callstacks);
+  SetTopDownView(GetCaptureData());
+  SetSelectionTopDownView(empty_profiler, GetCaptureData());
+  if (selection_report_) {
+    SetSelectionReport(std::move(empty_profiler), empty_unique_callstacks, false);
   }
 }
 

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -118,6 +118,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
       absl::flat_hash_map<CallstackID, std::shared_ptr<CallStack>> unique_callstacks,
       bool has_summary);
   void SetTopDownView(const CaptureData& capture_data);
+  void SetSelectionTopDownView(const SamplingProfiler& selection_sampling_profiler,
+                               const CaptureData& capture_data);
 
   bool SelectProcess(const std::string& process);
 
@@ -183,6 +185,9 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void SetTopDownViewCallback(TopDownViewCallback callback) {
     top_down_view_callback_ = std::move(callback);
   }
+  void SetSelectionTopDownViewCallback(TopDownViewCallback callback) {
+    selection_top_down_view_callback_ = std::move(callback);
+  }
   using SaveFileCallback = std::function<std::string(const std::string& extension)>;
   void SetSaveFileCallback(SaveFileCallback callback) { save_file_callback_ = std::move(callback); }
   void FireRefreshCallbacks(DataViewType type = DataViewType::kAll);
@@ -214,7 +219,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
                              const std::shared_ptr<orbit_client_protos::PresetFile>& preset);
   void UpdateProcessAndModuleList(int32_t pid);
 
-  void UpdateSamplingReport();
+  void UpdateAfterSymbolLoading();
   void LoadPreset(const std::shared_ptr<orbit_client_protos::PresetFile>& preset);
   PresetLoadState GetPresetLoadState(
       const std::shared_ptr<orbit_client_protos::PresetFile>& preset) const;
@@ -304,6 +309,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   SamplingReportCallback sampling_reports_callback_;
   SamplingReportCallback selection_report_callback_;
   TopDownViewCallback top_down_view_callback_;
+  TopDownViewCallback selection_top_down_view_callback_;
   std::vector<DataView*> panels_;
   SaveFileCallback save_file_callback_;
   ClipboardCallback clipboard_callback_;

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -220,6 +220,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void UpdateProcessAndModuleList(int32_t pid);
 
   void UpdateAfterSymbolLoading();
+  void UpdateAfterCaptureCleared();
+
   void LoadPreset(const std::shared_ptr<orbit_client_protos::PresetFile>& preset);
   PresetLoadState GetPresetLoadState(
       const std::shared_ptr<orbit_client_protos::PresetFile>& preset) const;

--- a/OrbitGl/TopDownView.cpp
+++ b/OrbitGl/TopDownView.cpp
@@ -85,11 +85,11 @@ static void AddCallstackToTopDownThread(TopDownThread* thread_node,
   return thread_node;
 }
 
-std::unique_ptr<TopDownView> TopDownView::CreateFromCaptureData(const CaptureData& capture_data) {
+std::unique_ptr<TopDownView> TopDownView::CreateFromSamplingProfiler(
+    const SamplingProfiler& sampling_profiler, const CaptureData& capture_data) {
   auto top_down_view = std::make_unique<TopDownView>();
   const std::string& process_name = capture_data.process_name();
   const absl::flat_hash_map<int32_t, std::string>& thread_names = capture_data.thread_names();
-  const SamplingProfiler& sampling_profiler = capture_data.sampling_profiler();
   for (const ThreadSampleData& thread_sample_data : sampling_profiler.GetThreadSampleData()) {
     const int32_t tid = thread_sample_data.thread_id;
     TopDownThread* thread_node =

--- a/OrbitGl/TopDownView.h
+++ b/OrbitGl/TopDownView.h
@@ -133,8 +133,8 @@ class TopDownThread : public TopDownInternalNode {
 
 class TopDownView : public TopDownNode {
  public:
-  [[nodiscard]] static std::unique_ptr<TopDownView> CreateFromCaptureData(
-      const CaptureData& capture_data);
+  [[nodiscard]] static std::unique_ptr<TopDownView> CreateFromSamplingProfiler(
+      const SamplingProfiler& sampling_profiler, const CaptureData& capture_data);
 
   TopDownView() : TopDownNode{nullptr} {}
 

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -123,6 +123,10 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App, ApplicationOptions&& optio
   GOrbitApp->SetTopDownViewCallback([this](std::unique_ptr<TopDownView> top_down_view) {
     this->OnNewTopDownView(std::move(top_down_view));
   });
+  GOrbitApp->SetSelectionTopDownViewCallback(
+      [this](std::unique_ptr<TopDownView> selection_top_down_view) {
+        this->OnNewSelectionTopDownView(std::move(selection_top_down_view));
+      });
 
   GOrbitApp->SetOpenCaptureCallback([this] { on_actionOpen_Capture_triggered(); });
   GOrbitApp->SetSaveCaptureCallback([this] { on_actionSave_Capture_triggered(); });
@@ -194,6 +198,7 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App, ApplicationOptions&& optio
           [this](const QString& text) { OnLiveTabFunctionsFilterTextChanged(text); });
 
   ui->topDownWidget->Initialize(GOrbitApp.get());
+  ui->selectionTopDownWidget->Initialize(GOrbitApp.get());
 
   SetTitle({});
   std::string iconFileName = Path::JoinPath({Path::GetExecutableDir(), "orbit.ico"});
@@ -309,6 +314,11 @@ void OrbitMainWindow::OnNewSelectionReport(DataView* callstack_data_view,
 
 void OrbitMainWindow::OnNewTopDownView(std::unique_ptr<TopDownView> top_down_view) {
   ui->topDownWidget->SetTopDownView(std::move(top_down_view));
+}
+
+void OrbitMainWindow::OnNewSelectionTopDownView(
+    std::unique_ptr<TopDownView> selection_top_down_view) {
+  ui->selectionTopDownWidget->SetTopDownView(std::move(selection_top_down_view));
 }
 
 std::string OrbitMainWindow::OnGetSaveFileName(const std::string& extension) {

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -44,6 +44,7 @@ class OrbitMainWindow : public QMainWindow {
   void OnNewSelectionReport(DataView* callstack_data_view,
                             std::shared_ptr<class SamplingReport> sampling_report);
   void OnNewTopDownView(std::unique_ptr<TopDownView> top_down_view);
+  void OnNewSelectionTopDownView(std::unique_ptr<TopDownView> selection_top_down_view);
   std::string OnGetSaveFileName(const std::string& extension);
   void OnSetClipboard(const std::string& text);
   void OpenDisassembly(std::string a_String, DisassemblyReport report);

--- a/OrbitQt/orbitmainwindow.ui
+++ b/OrbitQt/orbitmainwindow.ui
@@ -273,11 +273,21 @@ QPushButton:disabled {
        </widget>
        <widget class="QWidget" name="selectionTab">
         <attribute name="title">
-         <string>Selection</string>
+         <string>Sampling (selection)</string>
         </attribute>
         <layout class="QGridLayout" name="selectionGridLayout">
          <item row="0" column="0">
           <widget class="OrbitSamplingReport" name="selectionReport" native="true"/>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="selectionTopDownTab">
+        <attribute name="title">
+         <string>Top-Down (selection)</string>
+        </attribute>
+        <layout class="QGridLayout" name="selectionTopDownGridLayout">
+         <item row="0" column="0">
+          <widget class="TopDownWidget" name="selectionTopDownWidget" native="true"/>
          </item>
         </layout>
        </widget>


### PR DESCRIPTION
Adds a "Top-Down (selection)" tab whose top-down view is constructed from the
selected callstacks only.
Also renames the "selection" tab to "Sampling (selection)" for clarity.

Bug: http://b/162706739