### PR TITLE
Fix "read access violation" error in CaptureSerializer::Save

### DIFF
--- a/OrbitGl/CaptureSerializer.h
+++ b/OrbitGl/CaptureSerializer.h
@@ -71,7 +71,7 @@ void CaptureSerializer::Save(std::ostream& stream, const CaptureData& capture_da
   WriteMessage(&capture_info, &coded_output);
 
   // Timers
-  for (auto it = timers_iterator_begin; timers_iterator_begin != timers_iterator_end; ++it) {
+  for (auto it = timers_iterator_begin; it != timers_iterator_end; ++it) {
     WriteMessage(&(*it), &coded_output);
   }
 }


### PR DESCRIPTION
When saving a capture, an exception is thrown. Updated the code to fix it.
The error comes from a small typo in the stop condition in the loop that makes the call to _CaptureSerializer::Write_