### PR TITLE
Send the kernel tracepoint events from the service to the client

### DIFF
--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -860,7 +860,8 @@ void TracerThread::ProcessSampleEvent(const perf_event_header& header,
     tracepoint->set_name(it->second.name());
     tracepoint->set_category(it->second.category());
 
-    // TODO: Sending of the event
+    listener_->OnTracepointEvent(std::move(tracepoint_event));
+
   } else if (is_amdgpu_cs_ioctl_event) {
     // TODO: Consider deferring GPU events.
     auto event = ConsumeTracepointPerfEvent<AmdgpuCsIoctlPerfEvent>(ring_buffer, header);

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/TracerListener.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/TracerListener.h
@@ -18,6 +18,7 @@ class TracerListener {
   virtual void OnGpuJob(orbit_grpc_protos::GpuJob gpu_job) = 0;
   virtual void OnThreadName(orbit_grpc_protos::ThreadName thread_name) = 0;
   virtual void OnAddressInfo(orbit_grpc_protos::AddressInfo address_info) = 0;
+  virtual void OnTracepointEvent(orbit_grpc_protos::TracepointEvent tracepoint_event) = 0;
 };
 
 }  // namespace LinuxTracing

--- a/OrbitService/LinuxTracingGrpcHandler.cpp
+++ b/OrbitService/LinuxTracingGrpcHandler.cpp
@@ -125,6 +125,21 @@ void LinuxTracingGrpcHandler::OnAddressInfo(AddressInfo address_info) {
   }
 }
 
+void LinuxTracingGrpcHandler::OnTracepointEvent(
+    orbit_grpc_protos::TracepointEvent tracepoint_event) {
+  CHECK(tracepoint_event.tracepoint_info_or_key_case() ==
+        orbit_grpc_protos::TracepointEvent::kTracepointInfo);
+  tracepoint_event.set_tracepoint_info_key(
+      InternTracepointInfoIfNecessaryAndGetKey(tracepoint_event.tracepoint_info()));
+
+  CaptureEvent event;
+  *event.mutable_tracepoint_event() = std::move(tracepoint_event);
+  {
+    absl::MutexLock lock{&event_buffer_mutex_};
+    event_buffer_.emplace_back(std::move(event));
+  }
+}
+
 uint64_t LinuxTracingGrpcHandler::ComputeCallstackKey(const Callstack& callstack) {
   uint64_t key = 17;
   for (uint64_t pc : callstack.pcs()) {
@@ -170,6 +185,30 @@ uint64_t LinuxTracingGrpcHandler::InternStringIfNecessaryAndGetKey(std::string s
   CaptureEvent event;
   event.mutable_interned_string()->set_key(key);
   event.mutable_interned_string()->set_intern(std::move(str));
+  {
+    absl::MutexLock lock{&event_buffer_mutex_};
+    event_buffer_.emplace_back(std::move(event));
+  }
+  return key;
+}
+
+uint64_t LinuxTracingGrpcHandler::InternTracepointInfoIfNecessaryAndGetKey(
+    orbit_grpc_protos::TracepointInfo tracepoint_info) {
+  uint64_t key =
+      ComputeStringKey(tracepoint_info.category()) * 37 + ComputeStringKey(tracepoint_info.name());
+  {
+    absl::MutexLock lock{&tracepoint_keys_sent_mutex_};
+    if (tracepoint_keys_sent_.contains(key)) {
+      return key;
+    }
+    tracepoint_keys_sent_.emplace(key);
+  }
+
+  CaptureEvent event;
+  event.mutable_interned_tracepoint_info()->set_key(key);
+  event.mutable_interned_tracepoint_info()->mutable_intern()->set_name(tracepoint_info.name());
+  event.mutable_interned_tracepoint_info()->mutable_intern()->set_category(
+      tracepoint_info.category());
   {
     absl::MutexLock lock{&event_buffer_mutex_};
     event_buffer_.emplace_back(std::move(event));

--- a/OrbitService/LinuxTracingGrpcHandler.cpp
+++ b/OrbitService/LinuxTracingGrpcHandler.cpp
@@ -4,6 +4,7 @@
 
 #include "LinuxTracingGrpcHandler.h"
 
+#include "absl/strings/str_join.h"
 #include "llvm/Demangle/Demangle.h"
 
 namespace orbit_service {
@@ -195,7 +196,7 @@ uint64_t LinuxTracingGrpcHandler::InternStringIfNecessaryAndGetKey(std::string s
 uint64_t LinuxTracingGrpcHandler::InternTracepointInfoIfNecessaryAndGetKey(
     orbit_grpc_protos::TracepointInfo tracepoint_info) {
   uint64_t key =
-      ComputeStringKey(tracepoint_info.category()) * 37 + ComputeStringKey(tracepoint_info.name());
+      ComputeStringKey(absl::StrCat(tracepoint_info.category(), ":", tracepoint_info.name()));
   {
     absl::MutexLock lock{&tracepoint_keys_sent_mutex_};
     if (tracepoint_keys_sent_.contains(key)) {

--- a/OrbitService/LinuxTracingGrpcHandler.cpp
+++ b/OrbitService/LinuxTracingGrpcHandler.cpp
@@ -4,7 +4,6 @@
 
 #include "LinuxTracingGrpcHandler.h"
 
-#include "absl/strings/str_join.h"
 #include "llvm/Demangle/Demangle.h"
 
 namespace orbit_service {

--- a/OrbitService/LinuxTracingGrpcHandler.h
+++ b/OrbitService/LinuxTracingGrpcHandler.h
@@ -58,8 +58,8 @@ class LinuxTracingGrpcHandler : public LinuxTracing::TracerListener {
   absl::Mutex callstack_keys_sent_mutex_;
   absl::flat_hash_set<uint64_t> string_keys_sent_;
   absl::Mutex string_keys_sent_mutex_;
-  absl::Mutex tracepoint_keys_sent_mutex_;
   absl::flat_hash_set<uint64_t> tracepoint_keys_sent_;
+  absl::Mutex tracepoint_keys_sent_mutex_;
 
   void SenderThread();
   void SendBufferedEvents(std::vector<orbit_grpc_protos::CaptureEvent>&& buffered_events);

--- a/OrbitService/LinuxTracingGrpcHandler.h
+++ b/OrbitService/LinuxTracingGrpcHandler.h
@@ -37,6 +37,7 @@ class LinuxTracingGrpcHandler : public LinuxTracing::TracerListener {
   void OnGpuJob(orbit_grpc_protos::GpuJob gpu_job) override;
   void OnThreadName(orbit_grpc_protos::ThreadName thread_name) override;
   void OnAddressInfo(orbit_grpc_protos::AddressInfo address_info) override;
+  void OnTracepointEvent(orbit_grpc_protos::TracepointEvent tracepoint_event) override;
 
  private:
   grpc::ServerReaderWriter<orbit_grpc_protos::CaptureResponse, orbit_grpc_protos::CaptureRequest>*
@@ -48,6 +49,8 @@ class LinuxTracingGrpcHandler : public LinuxTracing::TracerListener {
       orbit_grpc_protos::Callstack callstack);
   [[nodiscard]] static uint64_t ComputeStringKey(const std::string& str);
   [[nodiscard]] uint64_t InternStringIfNecessaryAndGetKey(std::string str);
+  [[nodiscard]] uint64_t InternTracepointInfoIfNecessaryAndGetKey(
+      orbit_grpc_protos::TracepointInfo tracepoint_info);
 
   absl::flat_hash_set<uint64_t> addresses_seen_;
   absl::Mutex addresses_seen_mutex_;
@@ -55,6 +58,8 @@ class LinuxTracingGrpcHandler : public LinuxTracing::TracerListener {
   absl::Mutex callstack_keys_sent_mutex_;
   absl::flat_hash_set<uint64_t> string_keys_sent_;
   absl::Mutex string_keys_sent_mutex_;
+  absl::Mutex tracepoint_keys_sent_mutex_;
+  absl::flat_hash_set<uint64_t> tracepoint_keys_sent_;
 
   void SenderThread();
   void SendBufferedEvents(std::vector<orbit_grpc_protos::CaptureEvent>&& buffered_events);


### PR DESCRIPTION
Create a hash mechanism in order to not send the tracepoint's category and name every time an event occurs if it does repet itself.

The only data that will be sent from the service to the client will be the one that differs for every single tracepoint event such as the process and thread id, cpu and timestamp. To distinguish the category and name of the tracepoint, a hash key will be associated to these, such that they are sent only once.

When an event occurs, we verify whether the tracepoint name and category has been seen before. If this is the first time, we compute the key and send the hash key and the tracepoint info separately to the client such that, the next time the client sees the key, it will be able to recognise the event. Then, the whole event is sent to the client with the key computed and without the tracepoint info. Since the client already is able to recognise that key, it is able to correctly identify the name and category of the event. If the key is not seen for the first time, the event is sent to the client with the hash key. The key is not being sent again separately, since the client is already aware of its existence and the associated tracepoint info.