### PR TITLE
Receive the events in the client-side and store them

### DIFF
--- a/OrbitCaptureClient/CaptureEventProcessor.cpp
+++ b/OrbitCaptureClient/CaptureEventProcessor.cpp
@@ -36,7 +36,7 @@ void CaptureEventProcessor::ProcessEvent(const CaptureEvent& event) {
       ProcessInternedTracepointInfo(event.interned_tracepoint_info());
       break;
     case CaptureEvent::kTracepointEvent:
-      ProcessTracepointEventInfo(event.tracepoint_event());
+      ProcessTracepointEvent(event.tracepoint_event());
       break;
     case CaptureEvent::kFunctionCall:
       ProcessFunctionCall(event.function_call());
@@ -216,12 +216,12 @@ uint64_t CaptureEventProcessor::GetCallstackHashAndSendToListenerIfNecessary(
 void CaptureEventProcessor::ProcessInternedTracepointInfo(
     orbit_grpc_protos::InternedTracepointInfo interned_tracepoint_info) {
   if (tracepoint_intern_pool_.contains(interned_tracepoint_info.key())) {
-    ERROR("Overwriting InternedTracepointInfo  with key %llu", interned_tracepoint_info.key());
+    ERROR("Overwriting InternedTracepointInfo with key %llu", interned_tracepoint_info.key());
   }
   tracepoint_intern_pool_.emplace(interned_tracepoint_info.key(),
                                   std::move(*interned_tracepoint_info.mutable_intern()));
 }
-void CaptureEventProcessor::ProcessTracepointEventInfo(
+void CaptureEventProcessor::ProcessTracepointEvent(
     const orbit_grpc_protos::TracepointEvent& tracepoint_event) {
   orbit_grpc_protos::TracepointInfo tracepoint_info;
 
@@ -237,7 +237,7 @@ void CaptureEventProcessor::ProcessTracepointEventInfo(
   tracepoint_event_info.set_cpu(tracepoint_event.cpu());
   tracepoint_event_info.set_tracepoint_info_key(hash);
 
-  // TODO: Set the capture listener to the tracepoint event
+  // TODO: Store the tracepoint event in a unordered map that has as the key the hash computed
 }
 
 uint64_t CaptureEventProcessor::GetStringHashAndSendToListenerIfNecessary(const std::string& str) {

--- a/OrbitCaptureClient/CaptureEventProcessor.cpp
+++ b/OrbitCaptureClient/CaptureEventProcessor.cpp
@@ -223,7 +223,6 @@ void CaptureEventProcessor::ProcessInternedTracepointInfo(
 }
 void CaptureEventProcessor::ProcessTracepointEvent(
     const orbit_grpc_protos::TracepointEvent& tracepoint_event) {
-
   CHECK(tracepoint_event.tracepoint_info_or_key_case() ==
         orbit_grpc_protos::TracepointEvent::kTracepointInfoKey);
 

--- a/OrbitCaptureClient/CaptureEventProcessor.cpp
+++ b/OrbitCaptureClient/CaptureEventProcessor.cpp
@@ -237,7 +237,7 @@ void CaptureEventProcessor::ProcessTracepointEvent(
   tracepoint_event_info.set_cpu(tracepoint_event.cpu());
   tracepoint_event_info.set_tracepoint_info_key(hash);
 
-  // TODO: Store the tracepoint event in a unordered map that has as the key the hash computed
+  // TODO: Store the tracepoint event in a unordered set
 }
 
 uint64_t CaptureEventProcessor::GetStringHashAndSendToListenerIfNecessary(const std::string& str) {
@@ -256,7 +256,9 @@ uint64_t CaptureEventProcessor::GetTracepointInfoHashAndSendToListenerIfNecessar
   if (!tracepoint_hashes_seen_.contains(hash)) {
     tracepoint_hashes_seen_.emplace(hash);
 
-    // TODO: Set the capture listener to the hash
+    /* TODO: Store the hash as a key to the tracepoint info in an unordered map such that the
+     * tracepoints events recognise the tracepoint's name and category according to the hash
+     * */
   }
   return hash;
 }

--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
@@ -48,8 +48,8 @@ class CaptureEventProcessor {
   absl::flat_hash_set<uint64_t> string_hashes_seen_;
   uint64_t GetStringHashAndSendToListenerIfNecessary(const std::string& str);
   absl::flat_hash_set<uint64_t> tracepoint_hashes_seen_;
-  uint64_t GetTracepointInfoHashAndSendToListenerIfNecessary(
-      const orbit_grpc_protos::TracepointInfo& tracepoint_info);
+  void SendTracepointInfoToListenerIfNecessary(
+      const orbit_grpc_protos::TracepointInfo& tracepoint_info, const uint64_t& hash);
 };
 
 #endif  // ORBIT_GL_CAPTURE_EVENT_PROCESSOR_H_

--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
@@ -32,10 +32,14 @@ class CaptureEventProcessor {
   void ProcessInternedString(orbit_grpc_protos::InternedString interned_string);
   void ProcessGpuJob(const orbit_grpc_protos::GpuJob& gpu_job);
   void ProcessThreadName(const orbit_grpc_protos::ThreadName& thread_name);
+  void ProcessInternedTracepointInfo(
+      orbit_grpc_protos::InternedTracepointInfo interned_tracepoint_info);
+  void ProcessTracepointEventInfo(const orbit_grpc_protos::TracepointEvent& tracepoint_event);
   void ProcessAddressInfo(const orbit_grpc_protos::AddressInfo& address_info);
 
   absl::flat_hash_map<uint64_t, orbit_grpc_protos::Callstack> callstack_intern_pool;
   absl::flat_hash_map<uint64_t, std::string> string_intern_pool;
+  absl::flat_hash_map<uint64_t, orbit_grpc_protos::TracepointInfo> tracepoint_intern_pool_;
   CaptureListener* capture_listener_ = nullptr;
 
   absl::flat_hash_set<uint64_t> callstack_hashes_seen_;
@@ -43,6 +47,9 @@ class CaptureEventProcessor {
       const orbit_grpc_protos::Callstack& callstack);
   absl::flat_hash_set<uint64_t> string_hashes_seen_;
   uint64_t GetStringHashAndSendToListenerIfNecessary(const std::string& str);
+  absl::flat_hash_set<uint64_t> tracepoint_hashes_seen_;
+  uint64_t GetTracepointInfoHashAndSendToListenerIfNecessary(
+      const orbit_grpc_protos::TracepointInfo& tracepoint_info);
 };
 
 #endif  // ORBIT_GL_CAPTURE_EVENT_PROCESSOR_H_

--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
@@ -34,7 +34,7 @@ class CaptureEventProcessor {
   void ProcessThreadName(const orbit_grpc_protos::ThreadName& thread_name);
   void ProcessInternedTracepointInfo(
       orbit_grpc_protos::InternedTracepointInfo interned_tracepoint_info);
-  void ProcessTracepointEventInfo(const orbit_grpc_protos::TracepointEvent& tracepoint_event);
+  void ProcessTracepointEvent(const orbit_grpc_protos::TracepointEvent& tracepoint_event);
   void ProcessAddressInfo(const orbit_grpc_protos::AddressInfo& address_info);
 
   absl::flat_hash_map<uint64_t, orbit_grpc_protos::Callstack> callstack_intern_pool;

--- a/OrbitClientProtos/capture_data.proto
+++ b/OrbitClientProtos/capture_data.proto
@@ -54,6 +54,14 @@ message CallstackInfo {
   repeated uint64 data = 1;
 }
 
+message TracepointEventInfo {
+  int32 pid = 1;
+  int32 tid = 2;
+  int64 time = 3;
+  int32 cpu = 4;
+  uint64 tracepoint_info_key = 5;
+}
+
 message LinuxAddressInfo {
   uint64 absolute_address = 1;
   string module_path = 2;


### PR DESCRIPTION
Receive the events in the client-side and store them in a proto for later serialization.
There are two types of events that can be received from the server-side regarding a generic tracepoint. If the first type of event is being processed (consisting of a key and the corresponding tracepoint's name
and category), the hash is used as a key in a unordered map and is associated to the corresponding tracepoint info. This is done such that, when the second type of event is being processed (the one that does not have the tracepoint info and only the hash key), the client to be able to recognise the tracepoint info using the map filled by processing the first type of event. 
The second type of event also has additional information such as the process id, thread id, cpu and time.
A new type of hash is being created that corresponds to the tracepoint event. The difference between this and the hash in the server-side is that, this one recognises the tracepoint event and not the tracepoint info (name and category). It will later be used for capture drawing such that we will store all the tracepoints events mapped by this hash key.