### PR TITLE
Fix OrbitBase/TracingTest flakiness

### DIFF
--- a/OrbitBase/Tracing.cpp
+++ b/OrbitBase/Tracing.cpp
@@ -54,7 +54,7 @@ void Listener::DeferScopeProcessing(const Scope& scope) {
   // User callback is called from a worker thread to
   // minimize contention on the instrumented threads.
   absl::MutexLock lock(&global_tracing_mutex);
-  if (IsActive() == false) return;
+  if (!IsActive()) return;
   global_tracing_listener->thread_pool_->Schedule([scope]() {
     absl::MutexLock lock(&global_tracing_mutex);
     if (IsActive() == false) return;

--- a/OrbitBase/Tracing.cpp
+++ b/OrbitBase/Tracing.cpp
@@ -40,7 +40,7 @@ Listener::Listener(std::unique_ptr<TimerCallback> callback) {
 
 Listener::~Listener() {
   absl::MutexLock lock(&global_tracing_mutex);
-  CHECK(IsActive() == true);
+  CHECK(IsActive());
   // Purge deferred scopes.
   thread_pool_->Shutdown();
   thread_pool_->Wait();

--- a/OrbitBase/Tracing.cpp
+++ b/OrbitBase/Tracing.cpp
@@ -29,7 +29,7 @@ namespace orbit::tracing {
 Listener::Listener(std::unique_ptr<TimerCallback> callback) {
   absl::MutexLock lock(&global_tracing_mutex);
   // Only one listener is supported.
-  CHECK(IsActive() == false);
+  CHECK(!IsActive());
   constexpr size_t kMinNumThreads = 1;
   constexpr size_t kMaxNumThreads = 1;
   thread_pool_ = ThreadPool::Create(kMinNumThreads, kMaxNumThreads, absl::Milliseconds(500));

--- a/OrbitBase/Tracing.cpp
+++ b/OrbitBase/Tracing.cpp
@@ -57,7 +57,7 @@ void Listener::DeferScopeProcessing(const Scope& scope) {
   if (!IsActive()) return;
   global_tracing_listener->thread_pool_->Schedule([scope]() {
     absl::MutexLock lock(&global_tracing_mutex);
-    if (IsActive() == false) return;
+    if (!IsActive()) return;
     (*global_tracing_listener->user_callback_)(scope);
   });
 }

--- a/OrbitBase/include/OrbitBase/Tracing.h
+++ b/OrbitBase/include/OrbitBase/Tracing.h
@@ -12,6 +12,7 @@
 // NOTE: Orbit.h will be moved to its own
 //       OrbitApi project in a subsequent PR.
 #include "../../../Orbit.h"
+#include "OrbitBase/ThreadPool.h"
 
 namespace orbit::tracing {
 
@@ -46,6 +47,14 @@ class Listener {
  public:
   explicit Listener(std::unique_ptr<TimerCallback> callback);
   ~Listener();
+
+  static void DeferScopeProcessing(const Scope& scope);
+  [[nodiscard]] inline static bool IsActive() { return active_; }
+
+ private:
+  std::unique_ptr<TimerCallback> user_callback_ = {};
+  std::unique_ptr<ThreadPool> thread_pool_ = {};
+  inline static bool active_ = false;
 };
 
 }  // namespace orbit::tracing


### PR DESCRIPTION
- Listener now owns the user callback and thread pool objects
- User callback now valid until thread pool is purged (should fix test)

I was never able to reproduce the failed test, but it must have been caused by the fact that we set the user callback to null *before* remaining in-flight scopes were processed