### PR TITLE
Resize top-down view columns to contents only once

### DIFF
--- a/OrbitQt/TopDownWidget.cpp
+++ b/OrbitQt/TopDownWidget.cpp
@@ -26,7 +26,12 @@ void TopDownWidget::SetTopDownView(std::unique_ptr<TopDownView> top_down_view) {
 
   ui_->topDownTreeView->setModel(hooked_proxy_model_.get());
   ui_->topDownTreeView->sortByColumn(TopDownViewItemModel::kInclusive, Qt::DescendingOrder);
-  ui_->topDownTreeView->header()->resizeSections(QHeaderView::ResizeToContents);
+
+  // Resize columns only the first time a non-empty TopDownView is set.
+  if (!columns_already_resized_ && hooked_proxy_model_->rowCount(QModelIndex{}) > 0) {
+    ui_->topDownTreeView->header()->resizeSections(QHeaderView::ResizeToContents);
+    columns_already_resized_ = true;
+  }
 
   onSearchLineEditTextEdited(ui_->searchLineEdit->text());
 }

--- a/OrbitQt/TopDownWidget.h
+++ b/OrbitQt/TopDownWidget.h
@@ -89,6 +89,7 @@ class TopDownWidget : public QWidget {
   std::unique_ptr<TopDownViewItemModel> model_;
   std::unique_ptr<HighlightCustomFilterSortFilterProxyModel> search_proxy_model_;
   std::unique_ptr<HookedIdentityProxyModel> hooked_proxy_model_;
+  bool columns_already_resized_ = false;
 };
 
 #endif  // ORBIT_QT_TOP_DOWN_WIDGET_H_


### PR DESCRIPTION
This prevents the annoying behavior of columns resizing every time the top-down
view is refreshed (new capture/new selection, symbols loaded), invalidating the
width set by the user.