### PR TITLE
Use progress bars in the "Inclusive" column of the top-down view

### DIFF
--- a/OrbitQt/TopDownViewItemModel.cpp
+++ b/OrbitQt/TopDownViewItemModel.cpp
@@ -70,20 +70,20 @@ QVariant TopDownViewItemModel::GetEditRoleData(const QModelIndex& index) const {
         // Threads are sorted by tid, not by name.
         return thread_item->thread_id();
       case kInclusive:
-        return static_cast<qulonglong>(thread_item->sample_count());
+        return thread_item->GetInclusivePercent(top_down_view_->sample_count());
       case kOfParent:
-        return static_cast<qulonglong>(thread_item->GetPercentOfParent());
+        return thread_item->GetPercentOfParent();
     }
   } else if (function_item != nullptr) {
     switch (index.column()) {
       case kThreadOrFunction:
         return QString::fromStdString(function_item->function_name());
       case kInclusive:
-        return static_cast<qulonglong>(function_item->sample_count());
+        return function_item->GetInclusivePercent(top_down_view_->sample_count());
       case kExclusive:
-        return static_cast<qulonglong>(function_item->GetExclusiveSampleCount());
+        return function_item->GetExclusivePercent(top_down_view_->sample_count());
       case kOfParent:
-        return static_cast<qulonglong>(function_item->GetPercentOfParent());
+        return function_item->GetPercentOfParent();
       case kModule:
         return QString::fromStdString(function_item->GetModuleName());
       case kFunctionAddress:

--- a/OrbitQt/TopDownWidget.cpp
+++ b/OrbitQt/TopDownWidget.cpp
@@ -418,6 +418,7 @@ void TopDownWidget::ProgressBarItemDelegate::paint(QPainter* painter,
 
   QStyleOptionProgressBar option_progress_bar;
   option_progress_bar.rect = option.rect;
+  option_progress_bar.palette = option.palette;
   option_progress_bar.minimum = 0;
   option_progress_bar.maximum = 100;
   option_progress_bar.progress = static_cast<int>(round(inclusive_percent));
@@ -432,16 +433,15 @@ void TopDownWidget::ProgressBarItemDelegate::paint(QPainter* painter,
       static_cast<int>(round(palette_highlight_color.value() * kBarColorValueReductionFactor)));
   option_progress_bar.palette.setColor(QPalette::Highlight, bar_foreground_color);
 
-  if (!highlight) {
-    option_progress_bar.text = index.data(Qt::DisplayRole).toString();
-    option_progress_bar.textVisible = true;
-  }
-  option.widget->style()->drawControl(QStyle::CE_ProgressBar, &option_progress_bar, painter);
+  option_progress_bar.text = index.data(Qt::DisplayRole).toString();
+  option_progress_bar.textVisible = true;
 
   if (highlight) {
-    QTextOption text_option;
-    text_option.setAlignment(Qt::AlignCenter);
-    painter->setPen(HighlightCustomFilterSortFilterProxyModel::kHighlightColor);
-    painter->drawText(option.rect, index.data(Qt::DisplayRole).toString(), text_option);
+    option_progress_bar.palette.setColor(
+        QPalette::Text, HighlightCustomFilterSortFilterProxyModel::kHighlightColor);
+    option_progress_bar.palette.setColor(
+        QPalette::HighlightedText, HighlightCustomFilterSortFilterProxyModel::kHighlightColor);
   }
+
+  option.widget->style()->drawControl(QStyle::CE_ProgressBar, &option_progress_bar, painter);
 }

--- a/OrbitQt/TopDownWidget.h
+++ b/OrbitQt/TopDownWidget.h
@@ -8,6 +8,7 @@
 #include <QIdentityProxyModel>
 #include <QSortFilterProxyModel>
 #include <QString>
+#include <QStyledItemDelegate>
 #include <QWidget>
 #include <memory>
 
@@ -21,16 +22,7 @@ class TopDownWidget : public QWidget {
   Q_OBJECT
 
  public:
-  explicit TopDownWidget(QWidget* parent = nullptr)
-      : QWidget{parent}, ui_{std::make_unique<Ui::TopDownWidget>()} {
-    ui_->setupUi(this);
-    connect(ui_->topDownTreeView, &CopyKeySequenceEnabledTreeView::copyKeySequencePressed, this,
-            &TopDownWidget::onCopyKeySequencePressed);
-    connect(ui_->topDownTreeView, &QTreeView::customContextMenuRequested, this,
-            &TopDownWidget::onCustomContextMenuRequested);
-    connect(ui_->searchLineEdit, &QLineEdit::textEdited, this,
-            &TopDownWidget::onSearchLineEditTextEdited);
-  }
+  explicit TopDownWidget(QWidget* parent = nullptr);
 
   void Initialize(OrbitApp* app) { app_ = app; }
 
@@ -64,6 +56,7 @@ class TopDownWidget : public QWidget {
     }
 
     static const int kMatchesCustomFilterRole = Qt::UserRole;
+    static const QColor kHighlightColor;
 
     QVariant data(const QModelIndex& index, int role) const override;
 
@@ -82,6 +75,16 @@ class TopDownWidget : public QWidget {
 
    private:
     OrbitApp* app_;
+  };
+
+  // Displays progress bars in the "Inclusive" column as a means to better visualize the percentage
+  // in each cell and the distribution of samples in the tree.
+  class ProgressBarItemDelegate : public QStyledItemDelegate {
+   public:
+    explicit ProgressBarItemDelegate(QObject* parent) : QStyledItemDelegate(parent) {}
+
+    void paint(QPainter* painter, const QStyleOptionViewItem& option,
+               const QModelIndex& index) const override;
   };
 
   std::unique_ptr<Ui::TopDownWidget> ui_;


### PR DESCRIPTION
This makes the distribution of samples in the tree much more immediate to see.