### PR TITLE
Make CaptureDeserialization a namespace

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -628,9 +628,7 @@ ErrorMessageOr<void> OrbitApp::OnSaveCapture(const std::string& file_name) {
 ErrorMessageOr<void> OrbitApp::OnLoadCapture(const std::string& file_name) {
   ClearCapture();
 
-  CaptureDeserializer ar;
-  ar.time_graph_ = GCurrentTimeGraph;
-  OUTCOME_TRY(ar.Load(file_name));
+  OUTCOME_TRY(CaptureDeserializer::Load(file_name, GCurrentTimeGraph));
 
   DoZoom = true;  // TODO: remove global, review logic
   return outcome::success();

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -628,7 +628,7 @@ ErrorMessageOr<void> OrbitApp::OnSaveCapture(const std::string& file_name) {
 ErrorMessageOr<void> OrbitApp::OnLoadCapture(const std::string& file_name) {
   ClearCapture();
 
-  OUTCOME_TRY(CaptureDeserializer::Load(file_name, GCurrentTimeGraph));
+  OUTCOME_TRY(capture_deserializer::Load(file_name, GCurrentTimeGraph));
 
   DoZoom = true;  // TODO: remove global, review logic
   return outcome::success();

--- a/OrbitGl/CaptureDeserializer.cpp
+++ b/OrbitGl/CaptureDeserializer.cpp
@@ -41,6 +41,7 @@ static void FillEventBuffer(const CaptureData& capture_data) {
 }
 
 }  // namespace
+
 namespace capture_deserializer {
 
 ErrorMessageOr<void> Load(const std::string& filename, TimeGraph* time_graph) {

--- a/OrbitGl/CaptureDeserializer.cpp
+++ b/OrbitGl/CaptureDeserializer.cpp
@@ -69,16 +69,11 @@ static void FillEventBuffer(const CaptureData& capture_data) {
 
 CaptureData CaptureDeserializer::internal::GenerateCaptureData(const CaptureInfo& capture_info,
                                                                StringManager* string_manager) {
-  // Clear the old capture
-  GOrbitApp->ClearSelectedFunctions();
   absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions;
-  absl::flat_hash_set<uint64_t> visible_functions;
   for (const auto& function : capture_info.selected_functions()) {
     uint64_t address = FunctionUtils::GetAbsoluteAddress(function);
     selected_functions[address] = function;
-    visible_functions.insert(address);
   }
-  GOrbitApp->SetVisibleFunctions(std::move(visible_functions));
 
   absl::flat_hash_map<uint64_t, FunctionStats> functions_stats{
       capture_info.function_stats().begin(), capture_info.function_stats().end()};
@@ -158,6 +153,13 @@ ErrorMessageOr<void> CaptureDeserializer::Load(std::istream& stream, TimeGraph* 
     }
   }
 
+  // Clear the old capture and set the new one
+  GOrbitApp->ClearSelectedFunctions();
+  absl::flat_hash_set<uint64_t> visible_functions;
+  for (auto const& [address, selected_function] : capture_data.selected_functions()) {
+    visible_functions.insert(address);
+  }
+  GOrbitApp->SetVisibleFunctions(std::move(visible_functions));
   GOrbitApp->SetSamplingReport(capture_data.sampling_profiler(),
                                capture_data.GetCallstackData()->GetUniqueCallstacksCopy());
   GOrbitApp->SetTopDownView(capture_data);

--- a/OrbitGl/CaptureDeserializer.h
+++ b/OrbitGl/CaptureDeserializer.h
@@ -17,21 +17,22 @@
 #include "google/protobuf/io/zero_copy_stream_impl.h"
 #include "google/protobuf/message.h"
 
-class CaptureDeserializer {
- public:
-  ErrorMessageOr<void> Load(std::istream& stream);
-  ErrorMessageOr<void> Load(const std::string& filename);
+namespace CaptureDeserializer {
 
-  TimeGraph* time_graph_;
+ErrorMessageOr<void> Load(std::istream& stream, TimeGraph* time_graph);
+ErrorMessageOr<void> Load(const std::string& filename, TimeGraph* time_graph);
 
-  static bool ReadMessage(google::protobuf::Message* message,
-                          google::protobuf::io::CodedInputStream* input);
+bool ReadMessage(google::protobuf::Message* message, google::protobuf::io::CodedInputStream* input);
 
- private:
-  [[nodiscard]] CaptureData GenerateCaptureData(
-      const orbit_client_protos::CaptureInfo& capture_info);
+namespace internal {
 
-  static inline const std::string kRequiredCaptureVersion = "1.52";
-};
+[[nodiscard]] CaptureData GenerateCaptureData(const orbit_client_protos::CaptureInfo& capture_info,
+                                              StringManager* string_manager);
+
+inline const std::string kRequiredCaptureVersion = "1.52";
+
+}  // namespace internal
+
+}  // namespace CaptureDeserializer
 
 #endif  // ORBIT_GL_CAPTURE_DESERIALIZER_H_

--- a/OrbitGl/CaptureDeserializer.h
+++ b/OrbitGl/CaptureDeserializer.h
@@ -17,7 +17,7 @@
 #include "google/protobuf/io/zero_copy_stream_impl.h"
 #include "google/protobuf/message.h"
 
-namespace CaptureDeserializer {
+namespace capture_deserializer {
 
 ErrorMessageOr<void> Load(std::istream& stream, TimeGraph* time_graph);
 ErrorMessageOr<void> Load(const std::string& filename, TimeGraph* time_graph);
@@ -33,6 +33,6 @@ inline const std::string kRequiredCaptureVersion = "1.52";
 
 }  // namespace internal
 
-}  // namespace CaptureDeserializer
+}  // namespace capture_deserializer
 
 #endif  // ORBIT_GL_CAPTURE_DESERIALIZER_H_

--- a/OrbitGl/CaptureDeserializer.h
+++ b/OrbitGl/CaptureDeserializer.h
@@ -22,9 +22,9 @@ namespace capture_deserializer {
 ErrorMessageOr<void> Load(std::istream& stream, TimeGraph* time_graph);
 ErrorMessageOr<void> Load(const std::string& filename, TimeGraph* time_graph);
 
-bool ReadMessage(google::protobuf::Message* message, google::protobuf::io::CodedInputStream* input);
-
 namespace internal {
+
+bool ReadMessage(google::protobuf::Message* message, google::protobuf::io::CodedInputStream* input);
 
 [[nodiscard]] CaptureData GenerateCaptureData(const orbit_client_protos::CaptureInfo& capture_info,
                                               StringManager* string_manager);

--- a/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
+++ b/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
@@ -47,12 +47,9 @@ DEFINE_PROTO_FUZZER(const orbit_client_protos::CaptureDeserializerFuzzerInfo& in
   time_graph.SetStringManager(string_manager);
   GOrbitApp->ClearCapture();
 
-  CaptureDeserializer deserializer{};
-  deserializer.time_graph_ = GCurrentTimeGraph;
-
   // NOLINTNEXTLINE
   std::istringstream input_stream{std::move(buffer)};
-  (void)deserializer.Load(input_stream);
+  (void)CaptureDeserializer::Load(input_stream, GCurrentTimeGraph);
 
   GOrbitApp->GetThreadPool()->ShutdownAndWait();
   GOrbitApp.reset();

--- a/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
+++ b/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
@@ -49,7 +49,7 @@ DEFINE_PROTO_FUZZER(const orbit_client_protos::CaptureDeserializerFuzzerInfo& in
 
   // NOLINTNEXTLINE
   std::istringstream input_stream{std::move(buffer)};
-  (void)CaptureDeserializer::Load(input_stream, GCurrentTimeGraph);
+  (void)capture_deserializer::Load(input_stream, GCurrentTimeGraph);
 
   GOrbitApp->GetThreadPool()->ShutdownAndWait();
   GOrbitApp.reset();


### PR DESCRIPTION
 First step to make _CaptureDeserializer_ the most independent from _OrbitGl_ as possible

- Remove class to use _capture_deserializer_ namespace instead
- Move private methods to internal namespace
- Provide _TimeGraph_ as an argument
- Make _GenerateCaptureData_ completely independent from _OrbitGl_
    - Remove _TimeGraph_ dependency by providing the _StringManager_ directly as an argument
    - Move code referencing _GOrbitApp_ outside of the method: calls that clean _GOrbitApp_ and sets the visible functions; for which the _CaptureData_ generated after _GenerateCaptureData_ is used.

Test: loading a capture seems to work as before.

Bug: http://b/167200870