### PR TITLE
Rename right margin

### DIFF
--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -505,7 +505,7 @@ void CaptureWindow::DrawScreenSpace() {
   float canvasHeight = getHeight();
 
   const TimeGraphLayout& layout = time_graph_.GetLayout();
-  float vertical_margin = layout.GetVerticalMargin();
+  float right_margin = layout.GetRightMargin();
 
   const auto picking_mode = GetPickingMode();
 
@@ -526,15 +526,15 @@ void CaptureWindow::DrawScreenSpace() {
       vertical_slider_->SetPixelHeight(slider_width);
       vertical_slider_->SetSliderWidthRatio(verticalRatio);
       vertical_slider_->Draw(this, picking_mode);
-      vertical_margin += slider_width;
+      right_margin += slider_width;
     }
   }
 
   // Right vertical margin.
-  time_graph_.SetVerticalMargin(vertical_margin);
+  time_graph_.SetRightMargin(right_margin);
   const Color kBackgroundColor(70, 70, 70, 255);
   float margin_x1 = getWidth();
-  float margin_x0 = margin_x1 - vertical_margin;
+  float margin_x0 = margin_x1 - right_margin;
 
   Box box(Vec2(margin_x0, 0), Vec2(margin_x1 - margin_x0, canvasHeight), GlCanvas::kZValueMargin);
   ui_batcher_.AddBox(box, kBackgroundColor);

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -119,8 +119,8 @@ class TimeGraph {
   double GetMaxTimeUs() const { return m_MaxTimeUs; }
   const TimeGraphLayout& GetLayout() const { return m_Layout; }
   TimeGraphLayout& GetLayout() { return m_Layout; }
-  float GetVerticalMargin() const { return vertical_margin_; }
-  void SetVerticalMargin(float margin) { vertical_margin_ = margin; }
+  float GetRightMargin() const { return right_margin_; }
+  void SetRightMargin(float margin) { right_margin_ = margin; }
 
   const TextBox* FindPrevious(const TextBox* from);
   const TextBox* FindNext(const TextBox* from);
@@ -173,7 +173,7 @@ class TimeGraph {
   float m_WorldWidth = 0;
   float min_y_ = 0;
   int m_Margin = 0;
-  float vertical_margin_ = 0;
+  float right_margin_ = 0;
 
   double m_ZoomValue = 0;
   double m_MouseRatio = 0;

--- a/OrbitGl/TimeGraphLayout.cpp
+++ b/OrbitGl/TimeGraphLayout.cpp
@@ -27,7 +27,7 @@ TimeGraphLayout::TimeGraphLayout() {
   m_RoundingRadius = 8.f;
   m_RoundingNumSides = 16;
   m_TextOffset = 5.f;
-  m_VerticalMargin = 10.f;
+  right_margin_ = 10.f;
   m_SchedulerTrackOffset = 10.f;
   m_ToolbarIconHeight = 24.f;
   scale_ = 1.f;
@@ -64,7 +64,7 @@ bool TimeGraphLayout::DrawProperties() {
   FLOAT_SLIDER(m_RoundingRadius);
   FLOAT_SLIDER(m_RoundingNumSides);
   FLOAT_SLIDER(m_TextOffset);
-  FLOAT_SLIDER(m_VerticalMargin);
+  FLOAT_SLIDER(right_margin_);
   FLOAT_SLIDER(m_SchedulerTrackOffset);
   FLOAT_SLIDER_MIN_MAX(m_TrackTabWidth, 0, 1000.f);
   FLOAT_SLIDER_MIN_MAX(m_TrackBottomMargin, 0, 20.f);

--- a/OrbitGl/TimeGraphLayout.h
+++ b/OrbitGl/TimeGraphLayout.h
@@ -27,7 +27,7 @@ class TimeGraphLayout {
   float GetTextOffset() const { return m_TextOffset; }
   float GetBottomMargin() const;
   float GetTopMargin() const { return GetSchedulerTrackOffset(); }
-  float GetVerticalMargin() const { return m_VerticalMargin; }
+  float GetRightMargin() const { return right_margin_; }
   float GetSchedulerTrackOffset() const { return m_SchedulerTrackOffset * scale_; }
   float GetSpaceBetweenTracks() const { return m_SpaceBetweenTracks * scale_; }
   float GetSpaceBetweenCores() const { return m_SpaceBetweenCores * scale_; }
@@ -59,7 +59,7 @@ class TimeGraphLayout {
   float m_RoundingRadius;
   float m_RoundingNumSides;
   float m_TextOffset;
-  float m_VerticalMargin;
+  float right_margin_;
   float m_SchedulerTrackOffset;
 
   float m_SpaceBetweenCores;

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -107,7 +107,7 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
 
   // Draw rounded corners.
   if (!picking) {
-    float vertical_margin = time_graph_->GetVerticalMargin();
+    float right_margin = time_graph_->GetRightMargin();
     const Color kBackgroundColor(70, 70, 70, 255);
 
     float radius = std::min(layout.GetRoundingRadius(), half_label_height);
@@ -118,8 +118,8 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
     Vec2 bottom_right(tab_x0 + label_width, y0 + top_margin);
     Vec2 top_right(tab_x0 + label_width, y0 + label_height);
     Vec2 top_left(tab_x0, y0 + label_height);
-    Vec2 end_bottom(x1 - vertical_margin, y1);
-    Vec2 end_top(x1 - vertical_margin, y0 + top_margin);
+    Vec2 end_bottom(x1 - right_margin, y1);
+    Vec2 end_top(x1 - right_margin, y0 + top_margin);
     float z = GlCanvas::kZValueRoundingCorner;
 
     glColor4ubv(&kTabColor[0]);


### PR DESCRIPTION
As VerticalMargin attribute is only being used as right margin, and it is a little confusing, this commit renames it.