### PR TITLE
Fix symbol loading with --local flag

### DIFF
--- a/OrbitCore/SymbolHelper.cpp
+++ b/OrbitCore/SymbolHelper.cpp
@@ -63,7 +63,10 @@ std::vector<fs::path> ReadSymbolsFile() {
   return directories;
 }
 
-ErrorMessageOr<void> VerifySymbolsFile(const fs::path& symbols_path, const std::string& build_id) {
+}  // namespace
+
+ErrorMessageOr<void> SymbolHelper::VerifySymbolsFile(const fs::path& symbols_path,
+                                                     const std::string& build_id) {
   OUTCOME_TRY(symbols_file, ElfFile::Create(symbols_path.string()));
 
   if (!symbols_file->HasSymtab()) {
@@ -82,7 +85,6 @@ ErrorMessageOr<void> VerifySymbolsFile(const fs::path& symbols_path, const std::
   }
   return outcome::success();
 }
-}  // namespace
 
 SymbolHelper::SymbolHelper()
     : symbols_file_directories_(ReadSymbolsFile()), cache_directory_(Path::CreateOrGetCacheDir()) {}

--- a/OrbitCore/SymbolHelper.h
+++ b/OrbitCore/SymbolHelper.h
@@ -27,6 +27,8 @@ class SymbolHelper {
                                                             const std::string& build_id) const;
   [[nodiscard]] static ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> LoadSymbolsFromFile(
       const fs::path& file_path);
+  [[nodiscard]] static ErrorMessageOr<void> VerifySymbolsFile(const fs::path& symbols_path,
+                                                              const std::string& build_id);
 
   [[nodiscard]] fs::path GenerateCachedFileName(const fs::path& file_path) const;
 

--- a/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
+++ b/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
@@ -22,6 +22,7 @@ ABSL_FLAG(bool, enable_stale_features, false,
           "Enable obsolete features that are not working or are not "
           "implemented in the client's UI");
 ABSL_FLAG(bool, devmode, false, "Enable developer mode in the client's UI");
+ABSL_FLAG(bool, local, false, "Connects to local instance of OrbitService");
 ABSL_FLAG(uint16_t, sampling_rate, 1000, "Frequency of callstack sampling in samples per second");
 ABSL_FLAG(bool, frame_pointer_unwinding, false, "Use frame pointers for unwinding");
 

--- a/OrbitGl/DataManagerUpdateModuleInfosFuzzer.cpp
+++ b/OrbitGl/DataManagerUpdateModuleInfosFuzzer.cpp
@@ -17,6 +17,7 @@ ABSL_FLAG(bool, enable_stale_features, false,
           "Enable obsolete features that are not working or are not "
           "implemented in the client's UI");
 ABSL_FLAG(bool, devmode, false, "Enable developer mode in the client's UI");
+ABSL_FLAG(bool, local, false, "Connects to local instance of OrbitService");
 ABSL_FLAG(uint16_t, sampling_rate, 1000, "Frequency of callstack sampling in samples per second");
 ABSL_FLAG(bool, frame_pointer_unwinding, false, "Use frame pointers for unwinding");
 


### PR DESCRIPTION
This moves some things around to not attempt symbol loading from remote when not connected to a remote. 

While I was at it, I also added some more tests and changed the error message appropriately (they are on the rather verbose side).