### PR TITLE
Disable selection tabs on empty selections & tweak tab-switching logic

### DIFF
--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -309,7 +309,14 @@ void OrbitMainWindow::OnNewSelectionReport(DataView* callstack_data_view,
                                            std::shared_ptr<SamplingReport> sampling_report) {
   if (sampling_report->HasSamples()) {
     ui->RightTabWidget->setTabEnabled(ui->RightTabWidget->indexOf(ui->selectionTab), true);
-    ui->RightTabWidget->setCurrentWidget(ui->selectionTab);
+    // This condition and the corresponding one in OnNewSelectionTopDownView need to be
+    // complementary, such that one doesn't cause switching away from or to a tab that the other
+    // method would switch from when such a tab is selected. Otherwise, which tab ends up being
+    // selected would depend on the order in which these two methods are called.
+    if (ui->RightTabWidget->currentWidget() != ui->topDownTab &&
+        ui->RightTabWidget->currentWidget() != ui->selectionTopDownTab) {
+      ui->RightTabWidget->setCurrentWidget(ui->selectionTab);
+    }
   } else {
     // If the selection is empty, if this tab is currently selected switch to the corresponding tab
     // for the entire capture...
@@ -336,6 +343,13 @@ void OrbitMainWindow::OnNewSelectionTopDownView(
     std::unique_ptr<TopDownView> selection_top_down_view) {
   if (selection_top_down_view->child_count() > 0) {
     ui->RightTabWidget->setTabEnabled(ui->RightTabWidget->indexOf(ui->selectionTopDownTab), true);
+    // This condition and the corresponding one in OnNewSelectionReport need to be complementary,
+    // such that one doesn't cause switching away from or to a tab that the other method would
+    // switch from when such a tab is selected. Otherwise, which tab ends up being selected would
+    // depend on the order in which these two methods are called.
+    if (ui->RightTabWidget->currentWidget() == ui->topDownTab) {
+      ui->RightTabWidget->setCurrentWidget(ui->selectionTopDownTab);
+    }
   } else {
     // If the selection is empty, if this tab is currently selected switch to the corresponding tab
     // for the entire capture...

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -117,7 +117,7 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App, ApplicationOptions&& optio
         this->OnNewSamplingReport(callstack_data_view, std::move(report));
       });
 
-  ui->RightTabWidget->setTabEnabled(ui->RightTabWidget->indexOf(ui->selectionTab), false);
+  ui->RightTabWidget->setTabEnabled(ui->RightTabWidget->indexOf(ui->selectionSamplingTab), false);
   GOrbitApp->SetSelectionReportCallback(
       [this](DataView* callstack_data_view, std::shared_ptr<SamplingReport> report) {
         this->OnNewSelectionReport(callstack_data_view, std::move(report));
@@ -308,29 +308,29 @@ void OrbitMainWindow::OnNewSamplingReport(DataView* callstack_data_view,
 void OrbitMainWindow::OnNewSelectionReport(DataView* callstack_data_view,
                                            std::shared_ptr<SamplingReport> sampling_report) {
   if (sampling_report->HasSamples()) {
-    ui->RightTabWidget->setTabEnabled(ui->RightTabWidget->indexOf(ui->selectionTab), true);
+    ui->RightTabWidget->setTabEnabled(ui->RightTabWidget->indexOf(ui->selectionSamplingTab), true);
     // This condition and the corresponding one in OnNewSelectionTopDownView need to be
     // complementary, such that one doesn't cause switching away from or to a tab that the other
     // method would switch from when such a tab is selected. Otherwise, which tab ends up being
     // selected would depend on the order in which these two methods are called.
     if (ui->RightTabWidget->currentWidget() != ui->topDownTab &&
         ui->RightTabWidget->currentWidget() != ui->selectionTopDownTab) {
-      ui->RightTabWidget->setCurrentWidget(ui->selectionTab);
+      ui->RightTabWidget->setCurrentWidget(ui->selectionSamplingTab);
     }
   } else {
     // If the selection is empty, if this tab is currently selected switch to the corresponding tab
     // for the entire capture...
-    if (ui->RightTabWidget->currentWidget() == ui->selectionTab) {
+    if (ui->RightTabWidget->currentWidget() == ui->selectionSamplingTab) {
       ui->RightTabWidget->setCurrentWidget(ui->samplingTab);
     }
     // ...and then disable this tab.
-    ui->RightTabWidget->setTabEnabled(ui->RightTabWidget->indexOf(ui->selectionTab), false);
+    ui->RightTabWidget->setTabEnabled(ui->RightTabWidget->indexOf(ui->selectionSamplingTab), false);
   }
 
   ui->selectionGridLayout->removeWidget(ui->selectionReport);
   delete ui->selectionReport;
 
-  ui->selectionReport = new OrbitSamplingReport(ui->selectionTab);
+  ui->selectionReport = new OrbitSamplingReport(ui->selectionSamplingTab);
   ui->selectionReport->Initialize(callstack_data_view, std::move(sampling_report));
   ui->selectionGridLayout->addWidget(ui->selectionReport, 0, 0, 1, 1);
 }

--- a/OrbitQt/orbitmainwindow.ui
+++ b/OrbitQt/orbitmainwindow.ui
@@ -271,7 +271,7 @@ QPushButton:disabled {
          </item>
         </layout>
        </widget>
-       <widget class="QWidget" name="selectionTab">
+       <widget class="QWidget" name="selectionSamplingTab">
         <attribute name="title">
          <string>Sampling (selection)</string>
         </attribute>


### PR DESCRIPTION
#### Disable selection-related tabs when the selection is empty
Also, if the "Sampling (selection)" tab was the current tab, switch to the
global "Sampling" tab. If the "Top-Down (selection)" tab was the current tab,
switch to the global "Top-Down" tab.

Bug: http://b/168098607
#### Tweak tab-switching logic on selection
When making a (new) selection, don't switch to the "Sampling (selection)" tab if
one of the two top-down tabs is currently active (this was annoying). Also, if
the "Top-Down" tab is the current one, switch to the "Top-Down (selection)" tab
instead.