### PR TITLE
Save capture in Ggp client

### DIFF
--- a/OrbitClientGgp/CMakeLists.txt
+++ b/OrbitClientGgp/CMakeLists.txt
@@ -20,5 +20,6 @@ target_sources(OrbitClientGgp PRIVATE
 target_link_libraries(OrbitClientGgp PUBLIC
     OrbitBase
     OrbitCaptureClient
+    OrbitClientModel
     OrbitClientServices
     OrbitProtos)

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -112,10 +112,10 @@ bool ClientGgp::SaveCapture() {
   const auto& key_to_string_map = string_manager_->GetKeyToStringMap();
   std::string file_name = options_.capture_file_name;
   if (file_name.empty()) {
-    file_name = capture_serializer::file_management::GetCaptureFileName(capture_data_);
+    file_name = capture_serializer::GetCaptureFileName(capture_data_);
   } else {
     // Make sure the file is saved with orbit extension
-    capture_serializer::file_management::IncludeOrbitExtensionInFile(file_name);
+    capture_serializer::IncludeOrbitExtensionInFile(file_name);
   }
 
   ErrorMessageOr<void> result = capture_serializer::Save(

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -26,7 +26,7 @@ class ClientGgp final : public CaptureListener {
   bool InitClient();
   bool RequestStartCapture(ThreadPool* thread_pool);
   bool StopCapture();
-  void SaveCapture();
+  bool SaveCapture();
 
   // CaptureListener implementation
   void OnCaptureStarted(

--- a/OrbitClientGgp/ClientGgpOptions.h
+++ b/OrbitClientGgp/ClientGgpOptions.h
@@ -15,6 +15,7 @@ struct ClientGgpOptions {
   std::string grpc_server_address;
   int32_t capture_pid;
   std::vector<std::string> capture_functions;
+  std::string capture_file_name;
 };
 
 #endif  // ORBIT_CLIENT_GGP_CLIENT_GGP_OPTIONS_H_

--- a/OrbitClientGgp/main.cpp
+++ b/OrbitClientGgp/main.cpp
@@ -14,6 +14,7 @@ ABSL_FLAG(int32_t, pid, 0, "pid to capture");
 ABSL_FLAG(uint32_t, capture_length, 10, "duration of capture in seconds");
 ABSL_FLAG(std::vector<std::string>, functions, {},
           "Comma-separated list of functions to hook to the capture");
+ABSL_FLAG(std::string, file_name, "", "Set file name for saving the capture.");
 ABSL_FLAG(uint16_t, sampling_rate, 1000, "Frequency of callstack sampling in samples per second");
 ABSL_FLAG(bool, frame_pointer_unwinding, false, "Use frame pointers for unwinding");
 
@@ -29,6 +30,7 @@ int main(int argc, char** argv) {
   options.grpc_server_address = absl::StrFormat("127.0.0.1:%d", grpc_port);
   options.capture_pid = absl::GetFlag(FLAGS_pid);
   options.capture_functions = absl::GetFlag(FLAGS_functions);
+  options.capture_file_name = absl::GetFlag(FLAGS_file_name);
 
   ClientGgp client_ggp(std::move(options));
   if (!client_ggp.InitClient()) {
@@ -57,7 +59,9 @@ int main(int argc, char** argv) {
   LOG("Shut down the thread and wait for it to finish");
   thread_pool->ShutdownAndWait();
 
-  // TODO: process/save capture data
+  if (!client_ggp.SaveCapture()) {
+    return -1;
+  }
 
   LOG("All done");
   return 0;

--- a/OrbitClientGgp/main.cpp
+++ b/OrbitClientGgp/main.cpp
@@ -14,7 +14,7 @@ ABSL_FLAG(int32_t, pid, 0, "pid to capture");
 ABSL_FLAG(uint32_t, capture_length, 10, "duration of capture in seconds");
 ABSL_FLAG(std::vector<std::string>, functions, {},
           "Comma-separated list of functions to hook to the capture");
-ABSL_FLAG(std::string, file_name, "", "Set file name for saving the capture.");
+ABSL_FLAG(std::string, file_name, "", "File name used for saving the capture");
 ABSL_FLAG(uint16_t, sampling_rate, 1000, "Frequency of callstack sampling in samples per second");
 ABSL_FLAG(bool, frame_pointer_unwinding, false, "Use frame pointers for unwinding");
 

--- a/OrbitClientModel/CaptureSerializer.cpp
+++ b/OrbitClientModel/CaptureSerializer.cpp
@@ -39,8 +39,6 @@ void WriteMessage(const google::protobuf::Message* message,
   message->SerializeToCodedStream(output);
 }
 
-namespace file_management {
-
 std::string GetCaptureFileName(const CaptureData& capture_data) {
   time_t timestamp = std::chrono::system_clock::to_time_t(capture_data.capture_start_time());
   std::string result;
@@ -57,8 +55,6 @@ void IncludeOrbitExtensionInFile(std::string& file_name) {
     file_name.append(kFileOrbitExtension);
   }
 }
-
-}  // namespace file_management
 
 namespace internal {
 

--- a/OrbitClientModel/CaptureSerializer.cpp
+++ b/OrbitClientModel/CaptureSerializer.cpp
@@ -12,6 +12,7 @@
 #include "FunctionUtils.h"
 #include "OrbitBase/MakeUniqueForOverwrite.h"
 #include "OrbitProcess.h"
+#include "Path.h"
 #include "absl/strings/str_format.h"
 #include "capture_data.pb.h"
 #include "google/protobuf/io/coded_stream.h"
@@ -33,6 +34,27 @@ void WriteMessage(const google::protobuf::Message* message,
   output->WriteLittleEndian32(message_size);
   message->SerializeToCodedStream(output);
 }
+
+namespace file_management {
+
+std::string GetCaptureFileName(const CaptureData& capture_data) {
+  time_t timestamp = std::chrono::system_clock::to_time_t(capture_data.capture_start_time());
+  std::string result;
+  result.append(Path::StripExtension(capture_data.process_name()));
+  result.append("_");
+  result.append(OrbitUtils::FormatTime(timestamp));
+  IncludeOrbitExtensionInFile(result);
+  return result;
+}
+
+void IncludeOrbitExtensionInFile(std::string& file_name) {
+  const std::string extension = Path::GetExtension(file_name);
+  if (extension != internal::kFileOrbitExtension) {
+    file_name.append(internal::kFileOrbitExtension);
+  }
+}
+
+}  // namespace file_management
 
 namespace internal {
 

--- a/OrbitClientModel/CaptureSerializer.cpp
+++ b/OrbitClientModel/CaptureSerializer.cpp
@@ -27,7 +27,7 @@ using orbit_client_protos::FunctionStats;
 using orbit_client_protos::TimerInfo;
 
 namespace {
-inline const std::string kFileOrbitExtension = ".orbit";
+inline constexpr std::string_view kFileOrbitExtension = ".orbit";
 }
 
 namespace capture_serializer {
@@ -41,10 +41,8 @@ void WriteMessage(const google::protobuf::Message* message,
 
 std::string GetCaptureFileName(const CaptureData& capture_data) {
   time_t timestamp = std::chrono::system_clock::to_time_t(capture_data.capture_start_time());
-  std::string result;
-  result.append(Path::StripExtension(capture_data.process_name()));
-  result.append("_");
-  result.append(OrbitUtils::FormatTime(timestamp));
+  std::string result = absl::StrCat(Path::StripExtension(capture_data.process_name()), "_",
+                                    OrbitUtils::FormatTime(timestamp));
   IncludeOrbitExtensionInFile(result);
   return result;
 }

--- a/OrbitClientModel/CaptureSerializer.cpp
+++ b/OrbitClientModel/CaptureSerializer.cpp
@@ -29,6 +29,7 @@ using orbit_client_protos::TimerInfo;
 namespace {
 inline const std::string kFileOrbitExtension = ".orbit";
 }
+
 namespace capture_serializer {
 
 void WriteMessage(const google::protobuf::Message* message,

--- a/OrbitClientModel/CaptureSerializer.cpp
+++ b/OrbitClientModel/CaptureSerializer.cpp
@@ -26,6 +26,9 @@ using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::FunctionStats;
 using orbit_client_protos::TimerInfo;
 
+namespace {
+inline const std::string kFileOrbitExtension = ".orbit";
+}
 namespace capture_serializer {
 
 void WriteMessage(const google::protobuf::Message* message,
@@ -49,8 +52,8 @@ std::string GetCaptureFileName(const CaptureData& capture_data) {
 
 void IncludeOrbitExtensionInFile(std::string& file_name) {
   const std::string extension = Path::GetExtension(file_name);
-  if (extension != internal::kFileOrbitExtension) {
-    file_name.append(internal::kFileOrbitExtension);
+  if (extension != kFileOrbitExtension) {
+    file_name.append(kFileOrbitExtension);
   }
 }
 

--- a/OrbitClientModel/include/OrbitClientModel/CaptureSerializer.h
+++ b/OrbitClientModel/include/OrbitClientModel/CaptureSerializer.h
@@ -37,7 +37,6 @@ void IncludeOrbitExtensionInFile(std::string& file_name);
 namespace internal {
 
 inline const std::string kRequiredCaptureVersion = "1.52";
-inline const std::string kFileOrbitExtension = ".orbit";
 
 orbit_client_protos::CaptureInfo GenerateCaptureInfo(
     const CaptureData& capture_data,

--- a/OrbitClientModel/include/OrbitClientModel/CaptureSerializer.h
+++ b/OrbitClientModel/include/OrbitClientModel/CaptureSerializer.h
@@ -26,13 +26,9 @@ ErrorMessageOr<void> Save(const std::string& filename, const CaptureData& captur
 void WriteMessage(const google::protobuf::Message* message,
                   google::protobuf::io::CodedOutputStream* output);
 
-namespace file_management {
-
 std::string GetCaptureFileName(const CaptureData& capture_data);
 
 void IncludeOrbitExtensionInFile(std::string& file_name);
-
-}  // namespace file_management
 
 namespace internal {
 

--- a/OrbitClientModel/include/OrbitClientModel/CaptureSerializer.h
+++ b/OrbitClientModel/include/OrbitClientModel/CaptureSerializer.h
@@ -26,9 +26,18 @@ ErrorMessageOr<void> Save(const std::string& filename, const CaptureData& captur
 void WriteMessage(const google::protobuf::Message* message,
                   google::protobuf::io::CodedOutputStream* output);
 
+namespace file_management {
+
+std::string GetCaptureFileName(const CaptureData& capture_data);
+
+void IncludeOrbitExtensionInFile(std::string& file_name);
+
+}  // namespace file_management
+
 namespace internal {
 
 inline const std::string kRequiredCaptureVersion = "1.52";
+inline const std::string kFileOrbitExtension = ".orbit";
 
 orbit_client_protos::CaptureInfo GenerateCaptureInfo(
     const CaptureData& capture_data,

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -513,17 +513,6 @@ void OrbitApp::SetSelectionTopDownView(const SamplingProfiler& selection_samplin
   selection_top_down_view_callback_(std::move(selection_top_down_view));
 }
 
-std::string OrbitApp::GetCaptureFileName() {
-  const CaptureData& capture_data = GetCaptureData();
-  time_t timestamp = std::chrono::system_clock::to_time_t(capture_data.capture_start_time());
-  std::string result;
-  result.append(Path::StripExtension(capture_data.process_name()));
-  result.append("_");
-  result.append(OrbitUtils::FormatTime(timestamp));
-  result.append(".orbit");
-  return result;
-}
-
 std::string OrbitApp::GetCaptureTime() {
   double time = GCurrentTimeGraph != nullptr ? GCurrentTimeGraph->GetCaptureTimeSpanUs() : 0.0;
   return GetPrettyTime(absl::Microseconds(time));

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -73,7 +73,6 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void OnExit();
   static void MainTick();
 
-  std::string GetCaptureFileName();
   std::string GetCaptureTime();
   std::string GetSaveFile(const std::string& extension);
   void SetClipboard(const std::string& text);

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -22,6 +22,7 @@
 
 #include "App.h"
 #include "MainThreadExecutorImpl.h"
+#include "OrbitClientModel/CaptureSerializer.h"
 #include "OrbitVersion/OrbitVersion.h"
 #include "Path.h"
 #include "SamplingReport.h"
@@ -561,9 +562,12 @@ void OrbitMainWindow::ShowCaptureOnSaveWarningIfNeeded() {
 void OrbitMainWindow::on_actionSave_Capture_triggered() {
   ShowCaptureOnSaveWarningIfNeeded();
 
+  const CaptureData& capture_data = GOrbitApp->GetCaptureData();
   QString file = QFileDialog::getSaveFileName(
       this, "Save capture...",
-      Path::JoinPath({Path::CreateOrGetCaptureDir(), GOrbitApp->GetCaptureFileName()}).c_str(),
+      Path::JoinPath({Path::CreateOrGetCaptureDir(),
+                      capture_serializer::file_management::GetCaptureFileName(capture_data)})
+          .c_str(),
       "*.orbit");
   if (file.isEmpty()) {
     return;

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -565,8 +565,8 @@ void OrbitMainWindow::on_actionSave_Capture_triggered() {
   const CaptureData& capture_data = GOrbitApp->GetCaptureData();
   QString file = QFileDialog::getSaveFileName(
       this, "Save capture...",
-      Path::JoinPath({Path::CreateOrGetCaptureDir(),
-                      capture_serializer::file_management::GetCaptureFileName(capture_data)})
+      Path::JoinPath(
+          {Path::CreateOrGetCaptureDir(), capture_serializer::GetCaptureFileName(capture_data)})
           .c_str(),
       "*.orbit");
   if (file.isEmpty()) {


### PR DESCRIPTION
Include _GgpClient::SaveCapture_ implementation so the capture is saved in disk. The file name can be provided by the user as an argument and, if not provided, a default name is given. A series of changes were needed for this:

* **Move _OrbitApp::GetCaptureFileName_ to _CaptureSerializer_** This change allows giving the capture file the same default name as the one given in the Orbit App. The method has been moved to the _CaptureSerializer_, in a new namespace called _file_management_. A new method has also been created to include the orbit extension to a file name if this has not been provided.

* **_GgpClient::SaveCapture_ implementation** Serialise and save the data collected while the capture was running. Added logic to determine the name of the file: either the one provided by the user (making sure the orbit extension is included) or the default one. Makes use of the _CaptureSerializer_ methods.

* **_OrbitGgpClient/main_ update** To be able to provide the _file_name_ as an argument when executing the program, include it in the options of the client and make the call to save the capture once it has finished.

Tests: 
* Save a capture in the Orbit app to make sure the name generated for the capture still works. 
* Run _OrbitGgpClient_ with different arguments making sure the capture is saved with the name provided or the default name
* Load the capture generated by the _OrbitGgpClient_ in the Orbit app and make sure the information is there