### PR TITLE
Make CaptureDeserializer independed from OrbitGl

### DIFF
--- a/OrbitClientModel/CMakeLists.txt
+++ b/OrbitClientModel/CMakeLists.txt
@@ -13,12 +13,15 @@ target_include_directories(OrbitClientModel PUBLIC
 target_include_directories(OrbitClientModel PRIVATE 
         ${CMAKE_CURRENT_LIST_DIR})
 
-target_sources(OrbitClientModel PUBLIC 
+target_sources(OrbitClientModel PUBLIC
+        include/OrbitClientModel/CaptureDeserializer.h
         include/OrbitClientModel/CaptureSerializer.h)
 
 target_sources(OrbitClientModel PRIVATE
+        CaptureDeserializer.cpp
         CaptureSerializer.cpp)
 
-target_link_libraries(OrbitClientModel PUBLIC 
+target_link_libraries(OrbitClientModel PUBLIC
+        OrbitCaptureClient
         OrbitCore
         OrbitProtos)

--- a/OrbitClientModel/CaptureDeserializer.cpp
+++ b/OrbitClientModel/CaptureDeserializer.cpp
@@ -26,7 +26,7 @@ using orbit_client_protos::TimerInfo;
 namespace capture_deserializer {
 
 ErrorMessageOr<void> Load(const std::string& filename, CaptureListener* capture_listener,
-                          bool* cancelation_requested) {
+                          std::atomic<bool>* cancellation_requested) {
   SCOPE_TIMER_LOG(absl::StrFormat("Loading capture from \"%s\"", filename));
 
   // Binary
@@ -36,11 +36,11 @@ ErrorMessageOr<void> Load(const std::string& filename, CaptureListener* capture_
     return ErrorMessage("Error opening the file for reading");
   }
 
-  return Load(file, capture_listener, cancelation_requested);
+  return Load(file, capture_listener, cancellation_requested);
 }
 
 ErrorMessageOr<void> Load(std::istream& stream, CaptureListener* capture_listener,
-                          bool* cancelation_requested) {
+                          std::atomic<bool>* cancellation_requested) {
   google::protobuf::io::IstreamInputStream input_stream(&stream);
   google::protobuf::io::CodedInputStream coded_input(&input_stream);
 
@@ -69,7 +69,7 @@ ErrorMessageOr<void> Load(std::istream& stream, CaptureListener* capture_listene
     return ErrorMessage(error_message);
   }
 
-  internal::LoadCaptureInfo(capture_info, capture_listener, &coded_input, cancelation_requested);
+  internal::LoadCaptureInfo(capture_info, capture_listener, &coded_input, cancellation_requested);
 
   return outcome::success();
 }
@@ -94,7 +94,7 @@ bool ReadMessage(google::protobuf::Message* message,
 
 void LoadCaptureInfo(const CaptureInfo& capture_info, CaptureListener* capture_listener,
                      google::protobuf::io::CodedInputStream* coded_input,
-                     bool* cancelation_requested) {
+                     std::atomic<bool>* cancellation_requested) {
   CHECK(capture_listener != nullptr);
 
   absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions;
@@ -104,7 +104,7 @@ void LoadCaptureInfo(const CaptureInfo& capture_info, CaptureListener* capture_l
   }
   TracepointInfoSet selected_tracepoints;
 
-  if (*cancelation_requested) {
+  if (*cancellation_requested) {
     return;
   }
   capture_listener->OnCaptureStarted(capture_info.process_id(), capture_info.process_name(),
@@ -112,14 +112,14 @@ void LoadCaptureInfo(const CaptureInfo& capture_info, CaptureListener* capture_l
                                      std::move(selected_tracepoints));
 
   for (const auto& address_info : capture_info.address_infos()) {
-    if (*cancelation_requested) {
+    if (*cancellation_requested) {
       return;
     }
     capture_listener->OnAddressInfo(address_info);
   }
 
   for (const auto& thread_id_and_name : capture_info.thread_names()) {
-    if (*cancelation_requested) {
+    if (*cancellation_requested) {
       return;
     }
     capture_listener->OnThreadName(thread_id_and_name.first, thread_id_and_name.second);
@@ -127,20 +127,20 @@ void LoadCaptureInfo(const CaptureInfo& capture_info, CaptureListener* capture_l
 
   for (const CallstackInfo& callstack : capture_info.callstacks()) {
     CallStack unique_callstack({callstack.data().begin(), callstack.data().end()});
-    if (*cancelation_requested) {
+    if (*cancellation_requested) {
       return;
     }
     capture_listener->OnUniqueCallStack(std::move(unique_callstack));
   }
   for (CallstackEvent callstack_event : capture_info.callstack_events()) {
-    if (*cancelation_requested) {
+    if (*cancellation_requested) {
       return;
     }
     capture_listener->OnCallstackEvent(std::move(callstack_event));
   }
 
   for (const auto& key_to_string : capture_info.key_to_string()) {
-    if (*cancelation_requested) {
+    if (*cancellation_requested) {
       return;
     }
     capture_listener->OnKeyAndString(key_to_string.first, key_to_string.second);
@@ -149,13 +149,13 @@ void LoadCaptureInfo(const CaptureInfo& capture_info, CaptureListener* capture_l
   // Timers
   TimerInfo timer_info;
   while (internal::ReadMessage(&timer_info, coded_input)) {
-    if (*cancelation_requested) {
+    if (*cancellation_requested) {
       return;
     }
     capture_listener->OnTimer(timer_info);
   }
 
-  if (*cancelation_requested) {
+  if (*cancellation_requested) {
     return;
   }
   capture_listener->OnCaptureComplete();

--- a/OrbitClientModel/CaptureDeserializer.cpp
+++ b/OrbitClientModel/CaptureDeserializer.cpp
@@ -67,7 +67,7 @@ ErrorMessageOr<void> Load(std::istream& stream, CaptureListener* capture_listene
     return ErrorMessage(error_message);
   }
 
-  internal::DoLoadCaptureInfo(capture_info, capture_listener, &coded_input);
+  internal::LoadCaptureInfo(capture_info, capture_listener, &coded_input);
 
   return outcome::success();
 }
@@ -90,8 +90,8 @@ bool ReadMessage(google::protobuf::Message* message,
   return true;
 }
 
-void DoLoadCaptureInfo(const CaptureInfo& capture_info, CaptureListener* capture_listener,
-                       google::protobuf::io::CodedInputStream* coded_input) {
+void LoadCaptureInfo(const CaptureInfo& capture_info, CaptureListener* capture_listener,
+                     google::protobuf::io::CodedInputStream* coded_input) {
   CHECK(capture_listener != nullptr);
   absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions;
   for (const auto& function : capture_info.selected_functions()) {

--- a/OrbitClientModel/CaptureDeserializer.cpp
+++ b/OrbitClientModel/CaptureDeserializer.cpp
@@ -2,19 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "CaptureDeserializer.h"
+#include "OrbitClientModel/CaptureDeserializer.h"
 
 #include <fstream>
 #include <memory>
 
-#include "App.h"
 #include "Callstack.h"
-#include "EventTracer.h"
 #include "FunctionUtils.h"
 #include "OrbitBase/MakeUniqueForOverwrite.h"
-#include "OrbitProcess.h"
-#include "SamplingProfiler.h"
-#include "TimeGraph.h"
 #include "absl/strings/str_format.h"
 #include "capture_data.pb.h"
 #include "google/protobuf/io/coded_stream.h"
@@ -26,25 +21,11 @@ using orbit_client_protos::CallstackInfo;
 using orbit_client_protos::CaptureHeader;
 using orbit_client_protos::CaptureInfo;
 using orbit_client_protos::FunctionInfo;
-using orbit_client_protos::FunctionStats;
 using orbit_client_protos::TimerInfo;
-
-namespace {
-
-static void FillEventBuffer(const CaptureData& capture_data) {
-  GEventTracer.GetEventBuffer().Reset();
-  for (const CallstackEvent& callstack_event :
-       capture_data.GetCallstackData()->callstack_events()) {
-    GEventTracer.GetEventBuffer().AddCallstackEvent(
-        callstack_event.time(), callstack_event.callstack_hash(), callstack_event.thread_id());
-  }
-}
-
-}  // namespace
 
 namespace capture_deserializer {
 
-ErrorMessageOr<void> Load(const std::string& filename, TimeGraph* time_graph) {
+ErrorMessageOr<void> Load(const std::string& filename, CaptureListener* capture_listener) {
   SCOPE_TIMER_LOG(absl::StrFormat("Loading capture from \"%s\"", filename));
 
   // Binary
@@ -54,10 +35,10 @@ ErrorMessageOr<void> Load(const std::string& filename, TimeGraph* time_graph) {
     return ErrorMessage("Error opening the file for reading");
   }
 
-  return Load(file, time_graph);
+  return Load(file, capture_listener);
 }
 
-ErrorMessageOr<void> Load(std::istream& stream, TimeGraph* time_graph) {
+ErrorMessageOr<void> Load(std::istream& stream, CaptureListener* capture_listener) {
   google::protobuf::io::IstreamInputStream input_stream(&stream);
   google::protobuf::io::CodedInputStream coded_input(&input_stream);
 
@@ -85,34 +66,9 @@ ErrorMessageOr<void> Load(std::istream& stream, TimeGraph* time_graph) {
     ERROR("%s", error_message);
     return ErrorMessage(error_message);
   }
-  time_graph->Clear();
-  StringManager* string_manager = time_graph->GetStringManager();
-  CaptureData capture_data = internal::GenerateCaptureData(capture_info, string_manager);
 
-  // Timers
-  TimerInfo timer_info;
-  while (internal::ReadMessage(&timer_info, &coded_input)) {
-    if (timer_info.function_address() > 0) {
-      const FunctionInfo& func =
-          capture_data.selected_functions().at(timer_info.function_address());
-      time_graph->ProcessTimer(timer_info, &func);
-    } else {
-      time_graph->ProcessTimer(timer_info, nullptr);
-    }
-  }
+  internal::DoLoadCaptureInfo(capture_info, capture_listener, &coded_input);
 
-  // Clear the old capture and set the new one
-  GOrbitApp->ClearSelectedFunctions();
-  absl::flat_hash_set<uint64_t> visible_functions;
-  for (auto const& [address, selected_function] : capture_data.selected_functions()) {
-    visible_functions.insert(address);
-  }
-  GOrbitApp->SetVisibleFunctions(std::move(visible_functions));
-  GOrbitApp->SetSamplingReport(capture_data.sampling_profiler(),
-                               capture_data.GetCallstackData()->GetUniqueCallstacksCopy());
-  GOrbitApp->SetTopDownView(capture_data);
-  GOrbitApp->SetCaptureData(std::move(capture_data));
-  GOrbitApp->FireRefreshCallbacks();
   return outcome::success();
 }
 
@@ -134,45 +90,47 @@ bool ReadMessage(google::protobuf::Message* message,
   return true;
 }
 
-CaptureData GenerateCaptureData(const CaptureInfo& capture_info, StringManager* string_manager) {
+void DoLoadCaptureInfo(const CaptureInfo& capture_info, CaptureListener* capture_listener,
+                       google::protobuf::io::CodedInputStream* coded_input) {
+  CHECK(capture_listener != nullptr);
   absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions;
   for (const auto& function : capture_info.selected_functions()) {
     uint64_t address = FunctionUtils::GetAbsoluteAddress(function);
     selected_functions[address] = function;
   }
+  TracepointInfoSet selected_tracepoints;
 
-  absl::flat_hash_map<uint64_t, FunctionStats> functions_stats{
-      capture_info.function_stats().begin(), capture_info.function_stats().end()};
-  CaptureData capture_data(capture_info.process_id(), capture_info.process_name(),
-                           std::make_shared<Process>(), std::move(selected_functions),
-                           std::move(functions_stats));
+  capture_listener->OnCaptureStarted(capture_info.process_id(), capture_info.process_name(),
+                                     std::make_shared<Process>(), std::move(selected_functions),
+                                     std::move(selected_tracepoints));
 
   for (const auto& address_info : capture_info.address_infos()) {
-    capture_data.InsertAddressInfo(address_info);
+    capture_listener->OnAddressInfo(address_info);
   }
 
-  absl::flat_hash_map<int32_t, std::string> thread_names{capture_info.thread_names().begin(),
-                                                         capture_info.thread_names().end()};
-  capture_data.set_thread_names(thread_names);
+  for (const auto& thread_id_and_name : capture_info.thread_names()) {
+    capture_listener->OnThreadName(thread_id_and_name.first, thread_id_and_name.second);
+  }
 
   for (const CallstackInfo& callstack : capture_info.callstacks()) {
     CallStack unique_callstack({callstack.data().begin(), callstack.data().end()});
-    capture_data.AddUniqueCallStack(std::move(unique_callstack));
+    capture_listener->OnUniqueCallStack(std::move(unique_callstack));
   }
   for (CallstackEvent callstack_event : capture_info.callstack_events()) {
-    capture_data.AddCallstackEvent(std::move(callstack_event));
-  }
-  SamplingProfiler sampling_profiler(*capture_data.GetCallstackData(), capture_data);
-  capture_data.set_sampling_profiler(sampling_profiler);
-
-  string_manager->Clear();
-  for (const auto& entry : capture_info.key_to_string()) {
-    string_manager->AddIfNotPresent(entry.first, entry.second);
+    capture_listener->OnCallstackEvent(std::move(callstack_event));
   }
 
-  FillEventBuffer(capture_data);
+  for (const auto& key_to_string : capture_info.key_to_string()) {
+    capture_listener->OnKeyAndString(key_to_string.first, key_to_string.second);
+  }
 
-  return capture_data;
+  // Timers
+  TimerInfo timer_info;
+  while (internal::ReadMessage(&timer_info, coded_input)) {
+    capture_listener->OnTimer(timer_info);
+  }
+
+  capture_listener->OnCaptureComplete();
 }
 
 }  // namespace internal

--- a/OrbitClientModel/include/OrbitClientModel/CaptureDeserializer.h
+++ b/OrbitClientModel/include/OrbitClientModel/CaptureDeserializer.h
@@ -11,7 +11,7 @@
 
 #include "CaptureData.h"
 #include "OrbitBase/Result.h"
-#include "TimeGraph.h"
+#include "OrbitCaptureClient/CaptureListener.h"
 #include "capture_data.pb.h"
 #include "google/protobuf/io/coded_stream.h"
 #include "google/protobuf/io/zero_copy_stream_impl.h"
@@ -19,15 +19,16 @@
 
 namespace capture_deserializer {
 
-ErrorMessageOr<void> Load(std::istream& stream, TimeGraph* time_graph);
-ErrorMessageOr<void> Load(const std::string& filename, TimeGraph* time_graph);
+ErrorMessageOr<void> Load(std::istream& stream, CaptureListener* capture_listener);
+ErrorMessageOr<void> Load(const std::string& filename, CaptureListener* capture_listener);
 
 namespace internal {
 
 bool ReadMessage(google::protobuf::Message* message, google::protobuf::io::CodedInputStream* input);
 
-[[nodiscard]] CaptureData GenerateCaptureData(const orbit_client_protos::CaptureInfo& capture_info,
-                                              StringManager* string_manager);
+void DoLoadCaptureInfo(const orbit_client_protos::CaptureInfo& capture_info,
+                       CaptureListener* capture_listener,
+                       google::protobuf::io::CodedInputStream* coded_input);
 
 inline const std::string kRequiredCaptureVersion = "1.52";
 

--- a/OrbitClientModel/include/OrbitClientModel/CaptureDeserializer.h
+++ b/OrbitClientModel/include/OrbitClientModel/CaptureDeserializer.h
@@ -26,9 +26,9 @@ namespace internal {
 
 bool ReadMessage(google::protobuf::Message* message, google::protobuf::io::CodedInputStream* input);
 
-void DoLoadCaptureInfo(const orbit_client_protos::CaptureInfo& capture_info,
-                       CaptureListener* capture_listener,
-                       google::protobuf::io::CodedInputStream* coded_input);
+void LoadCaptureInfo(const orbit_client_protos::CaptureInfo& capture_info,
+                     CaptureListener* capture_listener,
+                     google::protobuf::io::CodedInputStream* coded_input);
 
 inline const std::string kRequiredCaptureVersion = "1.52";
 

--- a/OrbitClientModel/include/OrbitClientModel/CaptureDeserializer.h
+++ b/OrbitClientModel/include/OrbitClientModel/CaptureDeserializer.h
@@ -19,8 +19,10 @@
 
 namespace capture_deserializer {
 
-ErrorMessageOr<void> Load(std::istream& stream, CaptureListener* capture_listener);
-ErrorMessageOr<void> Load(const std::string& filename, CaptureListener* capture_listener);
+ErrorMessageOr<void> Load(std::istream& stream, CaptureListener* capture_listener,
+                          bool* cancelation_requested);
+ErrorMessageOr<void> Load(const std::string& filename, CaptureListener* capture_listener,
+                          bool* cancelation_requested);
 
 namespace internal {
 
@@ -28,7 +30,8 @@ bool ReadMessage(google::protobuf::Message* message, google::protobuf::io::Coded
 
 void LoadCaptureInfo(const orbit_client_protos::CaptureInfo& capture_info,
                      CaptureListener* capture_listener,
-                     google::protobuf::io::CodedInputStream* coded_input);
+                     google::protobuf::io::CodedInputStream* coded_input,
+                     bool* cancelation_requested);
 
 inline const std::string kRequiredCaptureVersion = "1.52";
 

--- a/OrbitClientModel/include/OrbitClientModel/CaptureDeserializer.h
+++ b/OrbitClientModel/include/OrbitClientModel/CaptureDeserializer.h
@@ -20,9 +20,9 @@
 namespace capture_deserializer {
 
 ErrorMessageOr<void> Load(std::istream& stream, CaptureListener* capture_listener,
-                          bool* cancelation_requested);
+                          std::atomic<bool>* cancellation_requested);
 ErrorMessageOr<void> Load(const std::string& filename, CaptureListener* capture_listener,
-                          bool* cancelation_requested);
+                          std::atomic<bool>* cancellation_requested);
 
 namespace internal {
 
@@ -31,7 +31,7 @@ bool ReadMessage(google::protobuf::Message* message, google::protobuf::io::Coded
 void LoadCaptureInfo(const orbit_client_protos::CaptureInfo& capture_info,
                      CaptureListener* capture_listener,
                      google::protobuf::io::CodedInputStream* coded_input,
-                     bool* cancelation_requested);
+                     std::atomic<bool>* cancellation_requested);
 
 inline const std::string kRequiredCaptureVersion = "1.52";
 

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -34,21 +34,6 @@ class CaptureData {
         tracepoint_event_buffer_(std::make_unique<TracepointEventBuffer>()) {
     CHECK(process_ != nullptr);
   }
-  explicit CaptureData(
-      int32_t process_id, std::string process_name, std::shared_ptr<Process> process,
-      absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
-      absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionStats> functions_stats)
-      : process_id_{process_id},
-        process_name_{std::move(process_name)},
-        process_{std::move(process)},
-        selected_functions_{std::move(selected_functions)},
-        callstack_data_(std::make_unique<CallstackData>()),
-        selection_callstack_data_(std::make_unique<CallstackData>()),
-        tracepoint_info_manager_(std::make_unique<TracepointInfoManager>()),
-        tracepoint_event_buffer_(std::make_unique<TracepointEventBuffer>()),
-        functions_stats_{std::move(functions_stats)} {
-    CHECK(process_ != nullptr);
-  }
 
   explicit CaptureData()
       : process_{std::make_shared<Process>()},

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -642,7 +642,7 @@ void OrbitApp::OnLoadCapture(const std::string& file_name) {
     open_capture_callback_();
   }
   ClearCapture();
-  GCurrentTimeGraph->GetStringManager()->Clear();
+  string_manager_->Clear();
   thread_pool_->Schedule([this, file_name]() mutable {
     capture_loading_cancalation_requested_ = false;
     ErrorMessageOr<void> result =

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -644,9 +644,9 @@ void OrbitApp::OnLoadCapture(const std::string& file_name) {
   ClearCapture();
   string_manager_->Clear();
   thread_pool_->Schedule([this, file_name]() mutable {
-    capture_loading_cancalation_requested_ = false;
+    capture_loading_cancellation_requested_ = false;
     ErrorMessageOr<void> result =
-        capture_deserializer::Load(file_name, this, &capture_loading_cancalation_requested_);
+        capture_deserializer::Load(file_name, this, &capture_loading_cancellation_requested_);
 
     if (result.has_error()) {
       if (open_capture_failed_callback_) {
@@ -666,7 +666,7 @@ void OrbitApp::OnLoadCapture(const std::string& file_name) {
 }
 
 void OrbitApp::OnLoadCatpureCanceled() {
-  capture_loading_cancalation_requested_ = true;
+  capture_loading_cancellation_requested_ = true;
   if (open_capture_failed_callback_) {
     open_capture_failed_callback_();
   }

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -17,7 +17,6 @@
 
 #include "CallStackDataView.h"
 #include "Callstack.h"
-#include "CaptureDeserializer.h"
 #include "CaptureWindow.h"
 #include "Disassembler.h"
 #include "DisassemblyReport.h"
@@ -30,6 +29,7 @@
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
 #include "OrbitBase/Tracing.h"
+#include "OrbitClientModel/CaptureDeserializer.h"
 #include "OrbitClientModel/CaptureSerializer.h"
 #include "Path.h"
 #include "Pdb.h"
@@ -170,12 +170,11 @@ void OrbitApp::OnCaptureComplete() {
 
 void OrbitApp::OnTimer(const TimerInfo& timer_info) {
   if (timer_info.function_address() > 0) {
-    FunctionInfo* func =
-        GetCaptureData().process()->GetFunctionFromAddress(timer_info.function_address());
-    CHECK(func != nullptr);
+    const FunctionInfo func =
+        GetCaptureData().selected_functions().at(timer_info.function_address());
     uint64_t elapsed_nanos = timer_info.end() - timer_info.start();
-    capture_data_.UpdateFunctionStats(*func, elapsed_nanos);
-    GCurrentTimeGraph->ProcessTimer(timer_info, func);
+    capture_data_.UpdateFunctionStats(func, elapsed_nanos);
+    GCurrentTimeGraph->ProcessTimer(timer_info, &func);
   } else {
     GCurrentTimeGraph->ProcessTimer(timer_info, nullptr);
   }
@@ -638,13 +637,20 @@ ErrorMessageOr<void> OrbitApp::OnSaveCapture(const std::string& file_name) {
                                   timers_it_end);
 }
 
-ErrorMessageOr<void> OrbitApp::OnLoadCapture(const std::string& file_name) {
+void OrbitApp::OnLoadCapture(const std::string& file_name) {
   ClearCapture();
+  GCurrentTimeGraph->GetStringManager()->Clear();
+  thread_pool_->Schedule([this, file_name]() mutable {
+    ErrorMessageOr<void> result = capture_deserializer::Load(file_name, this);
 
-  OUTCOME_TRY(capture_deserializer::Load(file_name, GCurrentTimeGraph));
+    if (result.has_error()) {
+      SendErrorToUi("Error loading capture",
+                    absl::StrFormat("Could not load capture from \"%s\":\n%s", file_name,
+                                    result.error().message()));
+    }
+  });
 
   DoZoom = true;  // TODO: remove global, review logic
-  return outcome::success();
 }
 
 void OrbitApp::FireRefreshCallbacks(DataViewType type) {

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -81,6 +81,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   ErrorMessageOr<void> OnLoadPreset(const std::string& file_name);
   ErrorMessageOr<void> OnSaveCapture(const std::string& file_name);
   void OnLoadCapture(const std::string& file_name);
+  void OnLoadCatpureCanceled();
   [[nodiscard]] bool IsCapturing() const;
   bool StartCapture();
   void StopCapture();
@@ -152,6 +153,10 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   using OpenCaptureFailedCallback = std::function<void()>;
   void SetOpenCaptureFailedCallback(OpenCaptureFailedCallback callback) {
     open_capture_failed_callback_ = std::move(callback);
+  }
+  using OpenCaptureFinishedCallback = std::function<void()>;
+  void SetOpenCaptureFinishedCallback(OpenCaptureFinishedCallback callback) {
+    open_capture_finished_callback_ = std::move(callback);
   }
   using SaveCaptureCallback = std::function<void()>;
   void SetSaveCaptureCallback(SaveCaptureCallback callback) {
@@ -302,12 +307,15 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   absl::Mutex process_map_mutex_;
   absl::flat_hash_map<uint32_t, std::shared_ptr<Process>> process_map_;
 
+  bool capture_loading_cancalation_requested_ = false;
+
   CaptureStartedCallback capture_started_callback_;
   CaptureStopRequestedCallback capture_stop_requested_callback_;
   CaptureStoppedCallback capture_stopped_callback_;
   CaptureClearedCallback capture_cleared_callback_;
   OpenCaptureCallback open_capture_callback_;
   OpenCaptureFailedCallback open_capture_failed_callback_;
+  OpenCaptureFinishedCallback open_capture_finished_callback_;
   SaveCaptureCallback save_capture_callback_;
   SelectLiveTabCallback select_live_tab_callback_;
   DisassemblyCallback disassembly_callback_;

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -149,6 +149,10 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void SetOpenCaptureCallback(OpenCaptureCallback callback) {
     open_capture_callback_ = std::move(callback);
   }
+  using OpenCaptureFailedCallback = std::function<void()>;
+  void SetOpenCaptureFailedCallback(OpenCaptureFailedCallback callback) {
+    open_capture_failed_callback_ = std::move(callback);
+  }
   using SaveCaptureCallback = std::function<void()>;
   void SetSaveCaptureCallback(SaveCaptureCallback callback) {
     save_capture_callback_ = std::move(callback);
@@ -303,6 +307,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   CaptureStoppedCallback capture_stopped_callback_;
   CaptureClearedCallback capture_cleared_callback_;
   OpenCaptureCallback open_capture_callback_;
+  OpenCaptureFailedCallback open_capture_failed_callback_;
   SaveCaptureCallback save_capture_callback_;
   SelectLiveTabCallback select_live_tab_callback_;
   DisassemblyCallback disassembly_callback_;

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -307,7 +307,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   absl::Mutex process_map_mutex_;
   absl::flat_hash_map<uint32_t, std::shared_ptr<Process>> process_map_;
 
-  bool capture_loading_cancalation_requested_ = false;
+  std::atomic<bool> capture_loading_cancellation_requested_ = false;
 
   CaptureStartedCallback capture_started_callback_;
   CaptureStopRequestedCallback capture_stop_requested_callback_;

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -80,7 +80,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   ErrorMessageOr<void> OnSavePreset(const std::string& file_name);
   ErrorMessageOr<void> OnLoadPreset(const std::string& file_name);
   ErrorMessageOr<void> OnSaveCapture(const std::string& file_name);
-  ErrorMessageOr<void> OnLoadCapture(const std::string& file_name);
+  void OnLoadCapture(const std::string& file_name);
   [[nodiscard]] bool IsCapturing() const;
   bool StartCapture();
   void StopCapture();

--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -14,7 +14,6 @@ target_sources(
   PUBLIC App.h
          Batcher.h
          CallStackDataView.h
-         CaptureDeserializer.h
          CaptureWindow.h
          CodeReport.h
          CoreMath.h
@@ -64,7 +63,6 @@ target_sources(
   PRIVATE App.cpp
           Batcher.cpp
           CallStackDataView.cpp
-          CaptureDeserializer.cpp
           CaptureWindow.cpp
           DataManager.cpp
           DataView.cpp

--- a/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
+++ b/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
@@ -50,7 +50,8 @@ DEFINE_PROTO_FUZZER(const orbit_client_protos::CaptureDeserializerFuzzerInfo& in
 
   // NOLINTNEXTLINE
   std::istringstream input_stream{std::move(buffer)};
-  (void)capture_deserializer::Load(input_stream, GOrbitApp.get());
+  bool cancelation_requested = false;
+  (void)capture_deserializer::Load(input_stream, GOrbitApp.get(), &cancelation_requested);
 
   GOrbitApp->GetThreadPool()->ShutdownAndWait();
   GOrbitApp.reset();

--- a/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
+++ b/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
@@ -8,7 +8,7 @@
 #include <filesystem>
 
 #include "App.h"
-#include "CaptureDeserializer.h"
+#include "OrbitClientModel/CaptureDeserializer.h"
 #include "OrbitClientModel/CaptureSerializer.h"
 #include "SamplingProfiler.h"
 #include "TimeGraph.h"
@@ -50,7 +50,7 @@ DEFINE_PROTO_FUZZER(const orbit_client_protos::CaptureDeserializerFuzzerInfo& in
 
   // NOLINTNEXTLINE
   std::istringstream input_stream{std::move(buffer)};
-  (void)capture_deserializer::Load(input_stream, GCurrentTimeGraph);
+  (void)capture_deserializer::Load(input_stream, GOrbitApp.get());
 
   GOrbitApp->GetThreadPool()->ShutdownAndWait();
   GOrbitApp.reset();

--- a/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
+++ b/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
@@ -50,8 +50,8 @@ DEFINE_PROTO_FUZZER(const orbit_client_protos::CaptureDeserializerFuzzerInfo& in
 
   // NOLINTNEXTLINE
   std::istringstream input_stream{std::move(buffer)};
-  bool cancelation_requested = false;
-  (void)capture_deserializer::Load(input_stream, GOrbitApp.get(), &cancelation_requested);
+  std::atomic<bool> cancellation_requested = false;
+  (void)capture_deserializer::Load(input_stream, GOrbitApp.get(), &cancellation_requested);
 
   GOrbitApp->GetThreadPool()->ShutdownAndWait();
   GOrbitApp.reset();

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -143,7 +143,7 @@ static outcome::result<void> RunUiInstance(
   }();
 
   if (!capture_path.isEmpty()) {
-    OUTCOME_TRY(w.OpenCapture(capture_path.toStdString()));
+    w.OpenCapture(capture_path.toStdString());
   }
 
   QApplication::exec();

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -133,7 +133,27 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App, ApplicationOptions&& optio
         this->OnNewSelectionTopDownView(std::move(selection_top_down_view));
       });
 
-  GOrbitApp->SetOpenCaptureCallback([this] {
+  auto loading_capture_dialog =
+      new QProgressDialog("Waiting for the capture to be loaded...", nullptr, 0, 0, this, Qt::Tool);
+  loading_capture_dialog->setWindowTitle("Loading capture");
+  loading_capture_dialog->setModal(true);
+  loading_capture_dialog->setWindowFlags(
+      (loading_capture_dialog->windowFlags() | Qt::CustomizeWindowHint) &
+      ~Qt::WindowCloseButtonHint & ~Qt::WindowSystemMenuHint);
+  loading_capture_dialog->setFixedSize(loading_capture_dialog->size());
+
+  auto loading_capture_cancel_button = QPointer{new QPushButton{this}};
+  loading_capture_cancel_button->setText("Cancel");
+  QObject::connect(loading_capture_cancel_button, &QPushButton::clicked, this,
+                   [loading_capture_dialog]() {
+                     GOrbitApp->OnLoadCatpureCanceled();
+                     loading_capture_dialog->close();
+                   });
+  loading_capture_dialog->setCancelButton(loading_capture_cancel_button);
+
+  loading_capture_dialog->close();
+
+  GOrbitApp->SetOpenCaptureCallback([this, loading_capture_dialog] {
     ui->actionToggle_Capture->setIcon(icon_stop_capture_);
     ui->actionToggle_Capture->setDisabled(true);
     ui->actionClear_Capture->setDisabled(true);
@@ -143,8 +163,9 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App, ApplicationOptions&& optio
     ui->actionSave_Preset_As->setDisabled(true);
     ui->HomeTab->setDisabled(true);
     setWindowTitle({});
+    loading_capture_dialog->show();
   });
-  GOrbitApp->SetOpenCaptureFailedCallback([this] {
+  GOrbitApp->SetOpenCaptureFailedCallback([this, loading_capture_dialog] {
     ui->actionToggle_Capture->setIcon(icon_start_capture_);
     ui->actionToggle_Capture->setDisabled(false);
     ui->actionClear_Capture->setDisabled(false);
@@ -154,7 +175,10 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App, ApplicationOptions&& optio
     ui->actionSave_Preset_As->setDisabled(false);
     ui->HomeTab->setDisabled(false);
     setWindowTitle({});
+    loading_capture_dialog->close();
   });
+  GOrbitApp->SetOpenCaptureFinishedCallback(
+      [loading_capture_dialog] { loading_capture_dialog->close(); });
   GOrbitApp->SetSaveCaptureCallback([this] { on_actionSave_Capture_triggered(); });
   GOrbitApp->SetSelectLiveTabCallback(
       [this] { ui->RightTabWidget->setCurrentWidget(ui->liveTab); });

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -540,23 +540,13 @@ void OrbitMainWindow::on_actionOpen_Capture_triggered() {
     return;
   }
 
-  (void)OpenCapture(file.toStdString());
+  OpenCapture(file.toStdString());
 }
 
-outcome::result<void> OrbitMainWindow::OpenCapture(const std::string& filepath) {
-  ErrorMessageOr<void> result = GOrbitApp->OnLoadCapture(filepath);
-
-  if (result.has_error()) {
-    setWindowTitle({});
-    QMessageBox::critical(
-        this, "Error loading capture",
-        QString::fromStdString(absl::StrFormat("Could not load capture from \"%s\":\n%s", filepath,
-                                               result.error().message())));
-    return std::errc::no_such_file_or_directory;
-  }
+void OrbitMainWindow::OpenCapture(const std::string& filepath) {
+  GOrbitApp->OnLoadCapture(filepath);
   setWindowTitle(QString::fromStdString(filepath));
   ui->MainTabWidget->setCurrentWidget(ui->CaptureTab);
-  return outcome::success();
 }
 
 void OrbitMainWindow::OpenDisassembly(std::string a_String, DisassemblyReport report) {

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -133,7 +133,28 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App, ApplicationOptions&& optio
         this->OnNewSelectionTopDownView(std::move(selection_top_down_view));
       });
 
-  GOrbitApp->SetOpenCaptureCallback([this] { on_actionOpen_Capture_triggered(); });
+  GOrbitApp->SetOpenCaptureCallback([this] {
+    ui->actionToggle_Capture->setIcon(icon_stop_capture_);
+    ui->actionToggle_Capture->setDisabled(true);
+    ui->actionClear_Capture->setDisabled(true);
+    ui->actionOpen_Capture->setDisabled(true);
+    ui->actionSave_Capture->setDisabled(true);
+    ui->actionOpen_Preset->setDisabled(true);
+    ui->actionSave_Preset_As->setDisabled(true);
+    ui->HomeTab->setDisabled(true);
+    setWindowTitle({});
+  });
+  GOrbitApp->SetOpenCaptureFailedCallback([this] {
+    ui->actionToggle_Capture->setIcon(icon_start_capture_);
+    ui->actionToggle_Capture->setDisabled(false);
+    ui->actionClear_Capture->setDisabled(false);
+    ui->actionOpen_Capture->setDisabled(false);
+    ui->actionSave_Capture->setDisabled(false);
+    ui->actionOpen_Preset->setDisabled(false);
+    ui->actionSave_Preset_As->setDisabled(false);
+    ui->HomeTab->setDisabled(false);
+    setWindowTitle({});
+  });
   GOrbitApp->SetSaveCaptureCallback([this] { on_actionSave_Capture_triggered(); });
   GOrbitApp->SetSelectLiveTabCallback(
       [this] { ui->RightTabWidget->setCurrentWidget(ui->liveTab); });

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -48,7 +48,7 @@ class OrbitMainWindow : public QMainWindow {
   std::string OnGetSaveFileName(const std::string& extension);
   void OnSetClipboard(const std::string& text);
   void OpenDisassembly(std::string a_String, DisassemblyReport report);
-  outcome::result<void> OpenCapture(const std::string& filepath);
+  void OpenCapture(const std::string& filepath);
   void OnCaptureCleared();
 
  protected:


### PR DESCRIPTION
CaptureDesirializer now uses CaptureListener methods in order
to process the data from the capture to be loaded instead.
Prior to this, capture data was loaded and directly set at once to the App.
Also, the timers were stored directly on the time graph.

The calls to capture listener must not be done on the main thread.
Therefor, as a side-effect, deserialization does not block the UI
anymore and is somewhat "interactive", i.e. you see events poping
 up on loading.

Follow up: Make the events not appearing in blocks, which requires
 rethinking of the way we store timers.

Known Issue:
When loading a "broken" capture from the startup window
 the following happend before:
 1. An error msg. appears, that and why loading failed. In the background
    Orbit's main UI is already spawned.
 2. After clicking okay on this, the UI closes, and there is another error
    msg. saying "no such file".
 3. After clicking onkay on this, the startup windows shows up again.
Now:
 1. As before.
 2. On click of okay, you are in an empty Orbit and can try to load another
    capture from the capture view, but in order to connect to a gamelet,
    you need to restart Orbit manually.

Bug: http://b/167200870 and http://b/166094073
Test: Compile, Load Capture (also a broken one) from UI and start-up window.