### PR TITLE
Remove top from obtaining CPU usage information

### DIFF
--- a/OrbitService/CMakeLists.txt
+++ b/OrbitService/CMakeLists.txt
@@ -21,6 +21,8 @@ target_sources(OrbitServiceLib PRIVATE
         OrbitGrpcServer.h
         OrbitService.cpp
         OrbitService.h
+        Process.cpp
+        Process.h
         ProcessList.cpp
         ProcessList.h
         ProcessServiceImpl.cpp
@@ -67,7 +69,8 @@ strip_symbols(OrbitService)
 add_executable(OrbitServiceTests)
 target_compile_options(OrbitServiceTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
-target_sources(OrbitServiceTests PRIVATE UtilsTest.cpp Utils.cpp)
+target_sources(OrbitServiceTests PRIVATE UtilsTest.cpp
+                                         ProcessTest.cpp)
 
 target_link_libraries(OrbitServiceTests PRIVATE 
         OrbitServiceLib
@@ -78,6 +81,7 @@ add_custom_command(TARGET OrbitServiceTests POST_BUILD
         $<TARGET_FILE_DIR:OrbitServiceTests>/testdata)
 
 register_test(OrbitServiceTests)
+set_tests_properties(OrbitService PROPERTIES TIMEOUT 10)
 
 add_fuzzer(OrbitServiceUtilsFindSymbolsFilePathFuzzer
            OrbitServiceUtilsFindSymbolsFilePathFuzzer.cpp)

--- a/OrbitService/CMakeLists.txt
+++ b/OrbitService/CMakeLists.txt
@@ -70,6 +70,7 @@ add_executable(OrbitServiceTests)
 target_compile_options(OrbitServiceTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(OrbitServiceTests PRIVATE UtilsTest.cpp
+                                         ProcessListTest.cpp
                                          ProcessTest.cpp)
 
 target_link_libraries(OrbitServiceTests PRIVATE 

--- a/OrbitService/Process.cpp
+++ b/OrbitService/Process.cpp
@@ -19,7 +19,26 @@
 
 namespace orbit_service {
 
-ErrorMessageOr<Process> Process::FromPidAndCpuUsage(pid_t pid, double cpu_usage) {
+void Process::UpdateCpuUsage(utils::Jiffies process_cpu_time, utils::Jiffies total_cpu_time) {
+  const auto diff_process_cpu_time =
+      static_cast<double>(process_cpu_time.value - previous_process_cpu_time_.value);
+  const auto diff_total_cpu_time =
+      static_cast<double>(total_cpu_time.value - previous_total_cpu_time_.value);
+
+  // When the counters wrap, `cpu_usage` might be smaller than 0.0 or larger than 1.0,
+  // depending on the signedness of `Jiffies`. Reference implementations like top and htop usually
+  // clamp in this case. So that's what we're also doing here.
+  const auto cpu_usage = std::clamp(diff_process_cpu_time / diff_total_cpu_time, 0.0, 1.0);
+
+  // TODO(hebecker): Rename cpu_usage to cpu_usage_rate and normalize. Being in percent was
+  // surprising
+  set_cpu_usage(cpu_usage * 100.0);
+
+  previous_process_cpu_time_ = process_cpu_time;
+  previous_total_cpu_time_ = total_cpu_time;
+}
+
+ErrorMessageOr<Process> Process::FromPid(pid_t pid) {
   const auto path = std::filesystem::path{"/proc"} / std::to_string(pid);
 
   if (!std::filesystem::is_directory(path)) {
@@ -43,7 +62,14 @@ ErrorMessageOr<Process> Process::FromPidAndCpuUsage(pid_t pid, double cpu_usage)
   Process process{};
   process.set_pid(pid);
   process.set_name(name);
-  process.set_cpu_usage(cpu_usage);
+
+  const auto total_cpu_time = utils::GetCumulativeTotalCpuTime();
+  const auto cpu_time = utils::GetCumulativeCpuTimeFromProcess(process.pid());
+  if (cpu_time && total_cpu_time) {
+    process.UpdateCpuUsage(cpu_time.value(), total_cpu_time.value());
+  } else {
+    LOG("Could not update the CPU usage of process %d", process.pid());
+  }
 
   // "The command-line arguments appear [...] as a set of strings
   // separated by null bytes ('\0')".

--- a/OrbitService/Process.cpp
+++ b/OrbitService/Process.cpp
@@ -1,0 +1,77 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "Process.h"
+
+#include <absl/strings/ascii.h>
+#include <absl/strings/str_format.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+
+#include "ElfUtils/ElfFile.h"
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/Result.h"
+#include "Utils.h"
+
+namespace orbit_service {
+
+ErrorMessageOr<Process> Process::FromPidAndCpuUsage(pid_t pid, double cpu_usage) {
+  const auto path = std::filesystem::path{"/proc"} / std::to_string(pid);
+
+  if (!std::filesystem::is_directory(path)) {
+    return ErrorMessage{absl::StrFormat("PID %d does not exist", pid)};
+  }
+
+  const std::filesystem::path name_file_path = path / "comm";
+  auto name_file_result = utils::ReadFileToString(name_file_path);
+  if (!name_file_result) {
+    return ErrorMessage{absl::StrFormat("Failed to read %s: %s", name_file_path.string(),
+                                        name_file_result.error().message())};
+  }
+
+  std::string name = std::move(name_file_result.value());
+  // Remove new line character.
+  absl::StripTrailingAsciiWhitespace(&name);
+  if (name.empty()) {
+    return ErrorMessage{absl::StrFormat("Could not determine the process name of process %d", pid)};
+  }
+
+  Process process{};
+  process.set_pid(pid);
+  process.set_name(name);
+  process.set_cpu_usage(cpu_usage);
+
+  // "The command-line arguments appear [...] as a set of strings
+  // separated by null bytes ('\0')".
+  const std::filesystem::path cmdline_file_path = path / "cmdline";
+  auto cmdline_file_result = utils::ReadFileToString(cmdline_file_path);
+  if (!cmdline_file_result) {
+    return ErrorMessage{absl::StrFormat("Failed to read %s: %s", cmdline_file_path.string(),
+                                        name_file_result.error().message())};
+  }
+
+  std::string cmdline = std::move(cmdline_file_result.value());
+  std::replace(cmdline.begin(), cmdline.end(), '\0', ' ');
+  process.set_command_line(cmdline);
+
+  auto file_path_result = utils::GetExecutablePath(pid);
+  if (file_path_result) {
+    process.set_full_path(std::move(file_path_result.value()));
+
+    const auto& elf_file = ElfUtils::ElfFile::Create(file_path_result.value().string());
+    if (elf_file) {
+      process.set_is_64_bit(elf_file.value()->Is64Bit());
+    } else {
+      LOG("Warning: Unable to parse the executable \"%s\" as elf file. (pid: %d)",
+          file_path_result.value(), pid);
+    }
+  }
+
+  return process;
+}
+
+}  // namespace orbit_service

--- a/OrbitService/Process.h
+++ b/OrbitService/Process.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_SERVICE_PROCESS_H_
+#define ORBIT_SERVICE_PROCESS_H_
+
+#include "OrbitBase/Result.h"
+#include "process.pb.h"
+
+namespace orbit_service {
+
+class Process : public orbit_grpc_protos::ProcessInfo {
+ public:
+  using orbit_grpc_protos::ProcessInfo::ProcessInfo;
+
+  // Creates a `Process` by reading details from the `/proc` filesystem.
+  // This might fail due to a non existing pid or due to permission problems.
+  static ErrorMessageOr<Process> FromPidAndCpuUsage(pid_t pid, double cpu_usage);
+};
+
+}  // namespace orbit_service
+
+#endif  // ORBIT_SERVICE_PROCESS_H_

--- a/OrbitService/Process.h
+++ b/OrbitService/Process.h
@@ -6,6 +6,7 @@
 #define ORBIT_SERVICE_PROCESS_H_
 
 #include "OrbitBase/Result.h"
+#include "Utils.h"
 #include "process.pb.h"
 
 namespace orbit_service {
@@ -14,9 +15,15 @@ class Process : public orbit_grpc_protos::ProcessInfo {
  public:
   using orbit_grpc_protos::ProcessInfo::ProcessInfo;
 
+  void UpdateCpuUsage(utils::Jiffies process_cpu_time, utils::Jiffies total_cpu_time);
+
   // Creates a `Process` by reading details from the `/proc` filesystem.
   // This might fail due to a non existing pid or due to permission problems.
-  static ErrorMessageOr<Process> FromPidAndCpuUsage(pid_t pid, double cpu_usage);
+  static ErrorMessageOr<Process> FromPid(pid_t pid);
+
+ private:
+  utils::Jiffies previous_process_cpu_time_ = {};
+  utils::Jiffies previous_total_cpu_time_ = {};
 };
 
 }  // namespace orbit_service

--- a/OrbitService/ProcessList.cpp
+++ b/OrbitService/ProcessList.cpp
@@ -17,8 +17,6 @@
 
 namespace orbit_service {
 
-using orbit_grpc_protos::ProcessInfo;
-
 ErrorMessageOr<void> ProcessList::Refresh() {
   auto cpu_result = utils::GetCpuUtilization();
   if (!cpu_result) {
@@ -27,7 +25,7 @@ ErrorMessageOr<void> ProcessList::Refresh() {
   }
   std::unordered_map<int32_t, double> cpu_usage_map = std::move(cpu_result.value());
 
-  std::vector<ProcessInfo> updated_processes;
+  std::vector<Process> updated_processes;
 
   // TODO(b/161423785): This for loop should be refactored. For example, when
   //  parts are in a separate function, OUTCOME_TRY could be used to simplify
@@ -43,55 +41,20 @@ ErrorMessageOr<void> ProcessList::Refresh() {
 
     auto iter = processes_map_.find(pid);
     if (iter != processes_map_.end()) {
-      ProcessInfo& process(*(iter->second));
+      Process& process = *(iter->second);
       process.set_cpu_usage(cpu_usage_map[process.pid()]);
       updated_processes.push_back(process);
       continue;
     }
 
-    const std::filesystem::path name_file_path = path / "comm";
-    auto name_file_result = utils::ReadFileToString(name_file_path);
-    if (!name_file_result) {
-      ERROR("Failed to read %s: %s", name_file_path.string(), name_file_result.error().message());
-      continue;
+    auto process = Process::FromPidAndCpuUsage(pid, cpu_usage_map[pid]);
+    if (process) {
+      updated_processes.emplace_back(std::move(process.value()));
+    } else {
+      // We don't fail in this case. This could be a permission problem which is restricted to a
+      // small amount of processes.
+      ERROR("Could not create process list entry for pid %d: %s", pid, process.error().message());
     }
-    std::string name = std::move(name_file_result.value());
-    // Remove new line character.
-    absl::StripTrailingAsciiWhitespace(&name);
-    if (name.empty()) continue;
-
-    ProcessInfo process;
-    process.set_pid(pid);
-    process.set_name(name);
-    process.set_cpu_usage(cpu_usage_map[pid]);
-
-    // "The command-line arguments appear [...] as a set of strings
-    // separated by null bytes ('\0')".
-    const std::filesystem::path cmdline_file_path = directory_entry.path() / "cmdline";
-    auto cmdline_file_result = utils::ReadFileToString(cmdline_file_path);
-    if (!cmdline_file_result) {
-      ERROR("Failed to read %s: %s", cmdline_file_path.string(),
-            name_file_result.error().message());
-      continue;
-    }
-    std::string cmdline = std::move(cmdline_file_result.value());
-    std::replace(cmdline.begin(), cmdline.end(), '\0', ' ');
-    process.set_command_line(cmdline);
-
-    auto file_path_result = utils::GetExecutablePath(pid);
-    if (file_path_result) {
-      process.set_full_path(std::move(file_path_result.value()));
-
-      const auto& elf_file = ElfUtils::ElfFile::Create(file_path_result.value().string());
-      if (elf_file) {
-        process.set_is_64_bit(elf_file.value()->Is64Bit());
-      } else {
-        LOG("Warning: Unable to parse the executable \"%s\" as elf file. (pid: %d)",
-            file_path_result.value(), pid);
-      }
-    }
-
-    updated_processes.push_back(process);
   }
 
   processes_ = std::move(updated_processes);

--- a/OrbitService/ProcessList.h
+++ b/OrbitService/ProcessList.h
@@ -9,20 +9,24 @@
 #include <vector>
 
 #include "OrbitBase/Result.h"
-#include "process.pb.h"
+#include "Process.h"
 
 namespace orbit_service {
 
 class ProcessList {
  public:
   [[nodiscard]] ErrorMessageOr<void> Refresh();
-  [[nodiscard]] const std::vector<orbit_grpc_protos::ProcessInfo>& GetProcesses() {
-    return processes_;
+  [[nodiscard]] std::vector<orbit_grpc_protos::ProcessInfo> GetProcesses() const {
+    std::vector<orbit_grpc_protos::ProcessInfo> processes;
+    processes.reserve(processes_.size());
+    std::copy(processes_.begin(), processes_.end(), std::back_inserter(processes));
+
+    return processes;
   }
 
  private:
-  std::vector<orbit_grpc_protos::ProcessInfo> processes_;
-  std::unordered_map<int32_t, orbit_grpc_protos::ProcessInfo*> processes_map_;
+  std::vector<Process> processes_;
+  std::unordered_map<int32_t, Process*> processes_map_;
 };
 
 }  // namespace orbit_service

--- a/OrbitService/ProcessListTest.cpp
+++ b/OrbitService/ProcessListTest.cpp
@@ -1,0 +1,37 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
+
+#include <unistd.h>
+
+#include "OrbitBase/Logging.h"
+#include "ProcessList.h"
+#include "gtest/gtest.h"
+
+namespace orbit_service {
+
+TEST(ProcessList, ProcessList) {
+  ProcessList process_list;
+  const auto result1 = process_list.Refresh();
+  ASSERT_TRUE(result1) << result1.error().message();
+
+  const auto process1 = process_list.GetProcessByPid(getpid());
+  EXPECT_TRUE(process1);
+
+  const auto total_cpu_cycles = utils::GetCumulativeTotalCpuTime().value();
+
+  // We wait until the stats have been updated
+  while (utils::GetCumulativeTotalCpuTime().value().value == total_cpu_cycles.value) {
+    // If this loop never ends it will be caught by the automatic timeout feature
+    usleep(10'000);
+  }
+
+  const auto result2 = process_list.Refresh();
+  ASSERT_TRUE(result2) << result2.error().message();
+
+  const auto process2 = process_list.GetProcessByPid(getpid());
+  EXPECT_TRUE(process2);
+}
+
+}  // namespace orbit_service

--- a/OrbitService/ProcessTest.cpp
+++ b/OrbitService/ProcessTest.cpp
@@ -12,7 +12,7 @@ constexpr int kTaskCommLength = 16;
 namespace orbit_service {
 
 TEST(Process, FromPid) {
-  auto potential_process = Process::FromPidAndCpuUsage(getpid(), 0.0);
+  auto potential_process = Process::FromPid(getpid());
   ASSERT_TRUE(potential_process);
 
   auto& process = potential_process.value();

--- a/OrbitService/ProcessTest.cpp
+++ b/OrbitService/ProcessTest.cpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <unistd.h>
+
+#include "ProcessList.h"
+#include "gtest/gtest.h"
+
+constexpr int kTaskCommLength = 16;
+
+namespace orbit_service {
+
+TEST(Process, FromPid) {
+  auto potential_process = Process::FromPidAndCpuUsage(getpid(), 0.0);
+  ASSERT_TRUE(potential_process);
+
+  auto& process = potential_process.value();
+
+  EXPECT_EQ(process.pid(), getpid());
+  EXPECT_EQ(process.name(), std::string_view{"OrbitServiceTests"}.substr(0, kTaskCommLength - 1));
+}
+
+}  // namespace orbit_service

--- a/OrbitService/Utils.h
+++ b/OrbitService/Utils.h
@@ -24,8 +24,18 @@ ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> ReadModules(int32_t p
 ErrorMessageOr<std::vector<orbit_grpc_protos::TracepointInfo>> ReadTracepoints();
 ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> ParseMaps(
     std::string_view proc_maps_data);
-ErrorMessageOr<std::unordered_map<pid_t, double>> GetCpuUtilization();
-ErrorMessageOr<std::unordered_map<pid_t, double>> GetCpuUtilization(std::string_view top_data);
+std::vector<pid_t> GetAllPids();
+
+// In the linux world, Jiffies is a global counter which increments on tick (caused by a CPU timer
+// interrupt). This struct is a poor man's strong type to ensure that this measure is not mistakenly
+// interpreted as nanoseconds.
+struct Jiffies {
+  uint64_t value;
+};
+
+std::optional<Jiffies> GetCumulativeTotalCpuTime();
+std::optional<Jiffies> GetCumulativeCpuTimeFromProcess(pid_t pid);
+
 ErrorMessageOr<Path> GetExecutablePath(int32_t pid);
 ErrorMessageOr<std::string> ReadFileToString(const Path& file_name);
 ErrorMessageOr<Path> FindSymbolsFilePath(const Path& module_path,


### PR DESCRIPTION
Up to now we use top for getting CPU usage information per process.
This requires a fixed output format of top and is slow since top has to
run a certain time interval for averaging CPU usage.

We can do the same internally by reading /proc/stat and
/proc/[pid]/stat. This commit adds this logic to
orbit_service::ProcessList.

The routines reading from `/proc` live in orbit_service::utils and are
unit-tested.

The CPU usage is averaged between two consecutive calls of
ProcessList::Refresh. This means the averaging time period is not always
constant and depends on when Refresh is called. But I believe it's good
enough for our use case.

Test: Manual test, compared process list cpu output to top running in
shell
Bug: http://b/165823980
Fixes #1157