### PR TITLE
Dynamic string support for manual instrumentation

### DIFF
--- a/Orbit.h
+++ b/Orbit.h
@@ -155,17 +155,18 @@ struct Event {
 union EncodedEvent {
   EncodedEvent(orbit_api::EventType type, const char* name = nullptr, uint64_t value = 0,
                orbit::Color color = orbit::Color::kAuto, uint32_t id = 0) {
-    static_assert(sizeof(EncodedEvent) == 48, "EncodedEvent should be 48 bytes.");
-    memset(this, 0, sizeof(*this));
-    event.id = id;
-    event.color = color;
-    event.value = value;
+    static_assert(sizeof(EncodedEvent) == 48, "orbit_api::EncodedEvent should be 48 bytes.");
+    static_assert(sizeof(Event) == 48, "orbit_api::Event should be 48 bytes.");
     event.version = kVersion;
     event.type = static_cast<uint8_t>(type);
+    memset(event.name, 0, kMaxEventStringSize);
     if (name != nullptr) {
       std::strncpy(event.name, name, kMaxEventStringSize - 1);
       event.name[kMaxEventStringSize - 1] = 0;
     }
+    event.value = value;
+    event.color = color;
+    event.id = id;
   }
 
   EncodedEvent(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3, uint64_t a4, uint64_t a5) {

--- a/Orbit.h
+++ b/Orbit.h
@@ -15,7 +15,8 @@
 // instrumentation is still possible using the macros below. These macros call empty functions that
 // Orbit dynamically instruments.
 //
-// NOTE: We only support string literals for now. This is enforced through the ORBIT_STR() macro.
+// Note: We currently only support strings smaller than 30 characters, longer strings will be
+//       truncated. An upcoming update will allow for arbitrarily long strings.
 
 // To disable manual instrumentation macros, define ORBIT_API_ENABLED as 0.
 #define ORBIT_API_ENABLED 1
@@ -24,16 +25,16 @@
 
 // ORBIT_SCOPE: profile current scope.
 #define ORBIT_SCOPE(name) ORBIT_SCOPE_WITH_COLOR(name, orbit::Color::kAuto)
-#define ORBIT_SCOPE_WITH_COLOR(name, col) orbit_api::Scope ORBIT_VAR(ORBIT_STR(name), col)
+#define ORBIT_SCOPE_WITH_COLOR(name, col) orbit_api::Scope ORBIT_VAR(name, col)
 
 // ORBIT_START/ORBIT_STOP: profile time span on a single thread.
 #define ORBIT_START(name) ORBIT_START_WITH_COLOR(name, orbit::Color::kAuto)
-#define ORBIT_START_WITH_COLOR(name, col) orbit_api::Start(ORBIT_STR(name), 0, col)
+#define ORBIT_START_WITH_COLOR(name, col) orbit_api::Start(name, col)
 #define ORBIT_STOP() orbit_api::Stop()
 
 // ORBIT_START_ASYNC/ORBIT_STOP_ASYNC: profile time span across threads.
 #define ORBIT_START_ASYNC(name, id) ORBIT_START_ASYNC_WITH_COLOR(name, id, orbit::Color::kAuto)
-#define ORBIT_START_ASYNC_WITH_COLOR(name, id, col) orbit_api::StartAsync(ORBIT_STR(name), id, col)
+#define ORBIT_START_ASYNC_WITH_COLOR(name, id, col) orbit_api::StartAsync(name, id, col)
 #define ORBIT_STOP_ASYNC(id) orbit_api::StopAsync(id)
 
 // ORBIT_[type]: graph variables.
@@ -45,12 +46,12 @@
 #define ORBIT_DOUBLE(name, val) ORBIT_DOUBLE_WITH_COLOR(name, val, orbit::Color::kAuto)
 
 // ORBIT_[type]_WITH_COLOR: graph variables with color.
-#define ORBIT_INT_WITH_COLOR(name, val, col) orbit_api::TrackInt(ORBIT_STR(name), val, col)
-#define ORBIT_INT64_WITH_COLOR(name, val, col) orbit_api::TrackInt64(ORBIT_STR(name), val, col)
-#define ORBIT_UINT_WITH_COLOR(name, val, col) orbit_api::TrackUint(ORBIT_STR(name), val, col)
-#define ORBIT_UINT64_WITH_COLOR(name, val, col) orbit_api::TrackUint64(ORBIT_STR(name), val, col)
-#define ORBIT_FLOAT_WITH_COLOR(name, val, col) orbit_api::TrackFloat(ORBIT_STR(name), val, col)
-#define ORBIT_DOUBLE_WITH_COLOR(name, val, col) orbit_api::TrackDouble(ORBIT_STR(name), val, col)
+#define ORBIT_INT_WITH_COLOR(name, val, col) ORBIT_TRACK(orbit_api::kTrackInt, name, val, col)
+#define ORBIT_INT64_WITH_COLOR(name, val, col) ORBIT_TRACK(orbit_api::kTrackInt64, name, val, col)
+#define ORBIT_UINT_WITH_COLOR(name, val, col) ORBIT_TRACK(orbit_api::kTrackUint, name, val, col)
+#define ORBIT_UINT64_WITH_COLOR(name, val, col) ORBIT_TRACK(orbit_api::kTrackUint64, name, val, col)
+#define ORBIT_FLOAT_WITH_COLOR(name, val, col) ORBIT_TRACK(orbit_api::kTrackFloat, name, val, col)
+#define ORBIT_DOUBLE_WITH_COLOR(name, val, col) ORBIT_TRACK(orbit_api::kTrackDouble, name, val, col)
 
 namespace orbit {
 
@@ -110,16 +111,12 @@ enum class Color : uint32_t {
 #if ORBIT_API_ENABLED
 
 // Internal macros.
-#define ORBIT_STR(x) ("" x)
 #define ORBIT_CONCAT_IND(x, y) (x##y)
 #define ORBIT_CONCAT(x, y) ORBIT_CONCAT_IND(x, y)
 #define ORBIT_UNIQUE(x) ORBIT_CONCAT(x, __COUNTER__)
 #define ORBIT_VAR ORBIT_UNIQUE(ORB)
-#define ORBIT_NOOP()       \
-  do {                     \
-    static volatile int x; \
-    x;                     \
-  } while (0)
+#define ORBIT_TRACK(type, name, val, col) \
+  orbit_api::TrackValue(type, name, orbit_api::Encode<uint64_t>(val), col)
 
 #if _WIN32
 #define ORBIT_STUB inline __declspec(noinline)
@@ -129,49 +126,129 @@ enum class Color : uint32_t {
 
 namespace orbit_api {
 
+constexpr uint8_t kVersion = 1;
+
+enum EventType : uint8_t {
+  kNone = 0,
+  kScopeStart = 1,
+  kScopeStop = 2,
+  kScopeStartAsync = 3,
+  kScopeStopAsync = 4,
+  kTrackInt = 5,
+  kTrackInt64 = 6,
+  kTrackUint = 7,
+  kTrackUint64 = 8,
+  kTrackFloat = 9,
+  kTrackDouble = 10,
+};
+
+constexpr size_t kMaxEventStringSize = 30;
+struct Event {
+  uint8_t version;                 // 1
+  uint8_t type;                    // 1
+  char name[kMaxEventStringSize];  // 30
+  uint64_t value;                  // 8
+  orbit::Color color;              // 4
+  uint32_t id;                     // 4
+};
+
+union EncodedEvent {
+  EncodedEvent(orbit_api::EventType type, const char* name = nullptr, uint64_t value = 0,
+               orbit::Color color = orbit::Color::kAuto, uint32_t id = 0) {
+    static_assert(sizeof(EncodedEvent) == 48, "EncodedEvent should be 48 bytes.");
+    memset(this, 0, sizeof(*this));
+    event.id = id;
+    event.color = color;
+    event.value = value;
+    event.version = kVersion;
+    event.type = static_cast<uint8_t>(type);
+    if (name != nullptr) {
+      std::strncpy(event.name, name, kMaxEventStringSize - 1);
+      event.name[kMaxEventStringSize - 1] = 0;
+    }
+  }
+
+  EncodedEvent(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3, uint64_t a4, uint64_t a5) {
+    args[0] = a0;
+    args[1] = a1;
+    args[2] = a2;
+    args[3] = a3;
+    args[4] = a4;
+    args[5] = a5;
+  }
+  Event event;
+  uint64_t args[6];
+};
+
+template <typename Dest, typename Source>
+inline Dest Encode(const Source& source) {
+  static_assert(sizeof(Source) <= sizeof(Dest));
+  Dest dest = 0;
+  std::memcpy(&dest, &source, sizeof(Source));
+  return dest;
+}
+
+template <typename Dest, typename Source>
+inline Dest Decode(const Source& source) {
+  static_assert(sizeof(Dest) <= sizeof(Source));
+  Dest dest = 0;
+  std::memcpy(&dest, &source, sizeof(Dest));
+  return dest;
+}
+
+// Used to prevent compiler from stripping out empty function.
+inline void Noop() {
+  static volatile int x;
+  x;
+}
+
+// The stub functions below are automatically dynamically instrumented.
+ORBIT_STUB void Start(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) { Noop(); }
+ORBIT_STUB void Stop(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) { Noop(); }
+ORBIT_STUB void StartAsync(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) { Noop(); }
+ORBIT_STUB void StopAsync(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) { Noop(); }
+ORBIT_STUB void TrackValue(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) { Noop(); }
+
 // NOTE: Do not use these directly, use corresponding macros instead.
-#ifdef ORBIT_API_INTERNAL_IMPL
-void Start(const char* name, uint8_t dummy, orbit::Color color);
-void Stop();
-void StartAsync(const char* name, uint64_t value, orbit::Color color);
-void StopAsync(uint64_t);
-void TrackInt(const char* name, int32_t value, orbit::Color color);
-void TrackInt64(const char* name, int64_t value, orbit::Color color);
-void TrackUint(const char* name, uint32_t value, orbit::Color color);
-void TrackUint64(const char* name, uint64_t value, orbit::Color color);
-void TrackFloat(const char* name, float value, orbit::Color color);
-void TrackDouble(const char* name, double value, orbit::Color color);
+#ifndef ORBIT_API_INTERNAL_IMPL
+
+inline void Start(const char* name, orbit::Color color) {
+  EncodedEvent e(EventType::kScopeStart, name, 0, color);
+  Start(e.args[0], e.args[1], e.args[2], e.args[3], e.args[4], e.args[5]);
+}
+
+inline void Stop() {
+  EncodedEvent e(EventType::kScopeStop);
+  Stop(e.args[0], e.args[1], e.args[2], e.args[3], e.args[4], e.args[5]);
+}
+
+inline void StartAsync(const char* name, uint64_t id, orbit::Color color) {
+  EncodedEvent e(EventType::kScopeStartAsync, name, id, color);
+  StartAsync(e.args[0], e.args[1], e.args[2], e.args[3], e.args[4], e.args[5]);
+}
+
+inline void StopAsync(uint64_t id) {
+  EncodedEvent e(EventType::kScopeStopAsync, nullptr, id);
+  StopAsync(e.args[0], e.args[1], e.args[2], e.args[3], e.args[4], e.args[5]);
+}
+
+inline void TrackValue(EventType type, const char* name, uint64_t value, orbit::Color color) {
+  EncodedEvent e(type, name, value, color);
+  TrackValue(e.args[0], e.args[1], e.args[2], e.args[3], e.args[4], e.args[5]);
+}
+
 #else
-ORBIT_STUB void Start(const char*, uint8_t, orbit::Color) { ORBIT_NOOP(); }
-ORBIT_STUB void Stop() { ORBIT_NOOP(); }
-ORBIT_STUB void StartAsync(const char*, uint64_t, orbit::Color) { ORBIT_NOOP(); }
-ORBIT_STUB void StopAsync(uint64_t) { ORBIT_NOOP(); }
-ORBIT_STUB void TrackInt(const char*, int32_t, orbit::Color) { ORBIT_NOOP(); }
-ORBIT_STUB void TrackInt64(const char*, int64_t, orbit::Color) { ORBIT_NOOP(); }
-ORBIT_STUB void TrackUint(const char*, uint32_t, orbit::Color) { ORBIT_NOOP(); }
-ORBIT_STUB void TrackUint64(const char*, uint64_t, orbit::Color) { ORBIT_NOOP(); }
-ORBIT_STUB void TrackFloatAsInt(const char*, int32_t, orbit::Color) { ORBIT_NOOP(); }
-ORBIT_STUB void TrackDoubleAsInt64(const char*, int64_t, orbit::Color) { ORBIT_NOOP(); }
 
-// Convert floating point arguments to integer arguments as we can't access
-// XMM registers with our current dynamic instrumentation on Linux (uprobes).
-inline void TrackFloat(const char* name, float value, orbit::Color color) {
-  int int_value;
-  static_assert(sizeof(value) == sizeof(int_value));
-  std::memcpy(&int_value, &value, sizeof(value));
-  TrackFloatAsInt(name, int_value, color);
-}
+void Start(const char* name, orbit::Color color);
+void Stop();
+void StartAsync(const char* name, uint32_t id, orbit::Color color);
+void StopAsync(uint32_t id);
+void TrackValue(EventType type, const char* name, uint64_t value, orbit::Color color);
 
-inline void TrackDouble(const char* name, double value, orbit::Color color) {
-  int64_t int_value;
-  static_assert(sizeof(value) == sizeof(int_value));
-  std::memcpy(&int_value, &value, sizeof(value));
-  TrackDoubleAsInt64(name, int_value, color);
-}
 #endif  // ORBIT_API_INTERNAL_IMPL
 
 struct Scope {
-  Scope(const char* name, orbit::Color color) { Start(name, 0, color); }
+  Scope(const char* name, orbit::Color color) { Start(name, color); }
   ~Scope() { Stop(); }
 };
 

--- a/OrbitBase/CMakeLists.txt
+++ b/OrbitBase/CMakeLists.txt
@@ -45,6 +45,7 @@ target_compile_options(OrbitBaseTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(OrbitBaseTests PRIVATE
     UniqueResourceTest.cpp
+    OrbitApiTest.cpp
     ProfilingTest.cpp
     TracingTest.cpp
 )

--- a/OrbitBase/OrbitApiTest.cpp
+++ b/OrbitBase/OrbitApiTest.cpp
@@ -6,8 +6,8 @@
 
 #include "../Orbit.h"
 
-orbit_api::Event Decode(uint64_t a1, uint64_t a2, uint64_t a3, uint64_t a4, uint64_t a5,
-                        uint64_t a6) {
+static orbit_api::Event Decode(uint64_t a1, uint64_t a2, uint64_t a3, uint64_t a4, uint64_t a5,
+                               uint64_t a6) {
   orbit_api::EncodedEvent encoded_event(a1, a2, a3, a4, a5, a6);
   return encoded_event.event;
 }

--- a/OrbitBase/OrbitApiTest.cpp
+++ b/OrbitBase/OrbitApiTest.cpp
@@ -1,0 +1,33 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "../Orbit.h"
+
+orbit_api::Event Decode(uint64_t a1, uint64_t a2, uint64_t a3, uint64_t a4, uint64_t a5,
+                        uint64_t a6) {
+  orbit_api::EncodedEvent encoded_event(a1, a2, a3, a4, a5, a6);
+  return encoded_event.event;
+}
+
+TEST(OrbitApi, Encoding) {
+  constexpr orbit_api::EventType kType = orbit_api::kTrackInt64;
+  constexpr const char* kName = "The quick brown fox jumps over the lazy dog";
+  constexpr double kValue = 1234567.12345671234567;
+  constexpr orbit::Color kColor = orbit::Color::kAmber;
+  constexpr uint32_t kId = 0xABCDEF01;
+
+  orbit_api::EncodedEvent e(kType, kName, orbit_api::Encode<uint64_t>(kValue), kColor, kId);
+  auto decoded_event = Decode(e.args[0], e.args[1], e.args[2], e.args[3], e.args[4], e.args[5]);
+
+  EXPECT_EQ(decoded_event.type, kType);
+  EXPECT_EQ(orbit_api::Decode<double>(decoded_event.value), kValue);
+  EXPECT_EQ(decoded_event.color, kColor);
+  EXPECT_EQ(decoded_event.id, kId);
+
+  std::string initial_string(kName);
+  EXPECT_EQ(strlen(decoded_event.name), orbit_api::kMaxEventStringSize - 1);
+  EXPECT_TRUE(initial_string.find(decoded_event.name) != std::string::npos);
+}

--- a/OrbitBase/include/OrbitBase/Tracing.h
+++ b/OrbitBase/include/OrbitBase/Tracing.h
@@ -16,20 +16,6 @@
 
 namespace orbit::tracing {
 
-enum ScopeType : int {
-  kNone = 0,
-  kScope = 1,
-  kScopeAsync = 2,
-  kTrackInt = 3,
-  kTrackInt64 = 4,
-  kTrackUint = 5,
-  kTrackUint64 = 6,
-  kTrackFloat = 7,
-  kTrackDouble = 8,
-  kTrackFloatAsInt = 9,
-  kTrackDoubleAsInt64 = 10
-};
-
 struct Scope {
   uint64_t begin = 0;
   uint64_t end = 0;
@@ -38,7 +24,7 @@ struct Scope {
   uint32_t tid = 0;
   orbit::Color color = orbit::Color::kAuto;
   const char* name = nullptr;
-  ScopeType type = kNone;
+  orbit_api::EventType type = orbit_api::kNone;
 };
 
 using TimerCallback = std::function<void(const Scope& scope)>;

--- a/OrbitClientProtos/capture_data.proto
+++ b/OrbitClientProtos/capture_data.proto
@@ -32,14 +32,7 @@ message FunctionInfo {
     kOrbitTimerStop = 2;
     kOrbitTimerStartAsync = 3;
     kOrbitTimerStopAsync = 4;
-    kOrbitTrackInt = 5;
-    kOrbitTrackInt64 = 6;
-    kOrbitTrackUint = 7;
-    kOrbitTrackUint64 = 8;
-    kOrbitTrackFloat = 9;
-    kOrbitTrackDouble = 10;
-    kOrbitTrackFloatAsInt = 11;
-    kOrbitTrackDoubleAsInt64 = 12;
+    kOrbitTrackValue = 5;
   }
   OrbitType type = 10;
 }

--- a/OrbitCore/FunctionUtils.cpp
+++ b/OrbitCore/FunctionUtils.cpp
@@ -52,15 +52,7 @@ const absl::flat_hash_map<const char*, FunctionInfo::OrbitType>& GetFunctionName
       {"Stop(", FunctionInfo::kOrbitTimerStop},
       {"StartAsync(", FunctionInfo::kOrbitTimerStartAsync},
       {"StopAsync(", FunctionInfo::kOrbitTimerStopAsync},
-      {"TrackInt(", FunctionInfo::kOrbitTrackInt},
-      {"TrackInt64(", FunctionInfo::kOrbitTrackInt64},
-      {"TrackUint(", FunctionInfo::kOrbitTrackUint},
-      {"TrackUint64(", FunctionInfo::kOrbitTrackUint64},
-      {"TrackFloat(", FunctionInfo::kOrbitTrackFloat},
-      {"TrackDouble(", FunctionInfo::kOrbitTrackDouble},
-      {"TrackFloatAsInt(", FunctionInfo::kOrbitTrackFloatAsInt},
-      {"TrackDoubleAsInt64(", FunctionInfo::kOrbitTrackDoubleAsInt64},
-  };
+      {"TrackValue(", FunctionInfo::kOrbitTrackValue}};
   return function_name_to_type_map;
 }
 

--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -35,6 +35,7 @@ target_sources(
          ImGuiOrbit.h
          LiveFunctionsController.h
          LiveFunctionsDataView.h
+         ManualInstrumentationManager.h
          ModulesDataView.h
          OpenGl.h
          PickingManager.h
@@ -81,6 +82,7 @@ target_sources(
           GraphTrack.cpp
           ImGuiOrbit.cpp
           LiveFunctionsDataView.cpp
+          ManualInstrumentationManager.cpp
           ModulesDataView.cpp
           PickingManager.cpp
           PresetsDataView.cpp

--- a/OrbitGl/GraphTrack.cpp
+++ b/OrbitGl/GraphTrack.cpp
@@ -6,8 +6,8 @@
 
 #include "GlCanvas.h"
 
-GraphTrack::GraphTrack(TimeGraph* time_graph, uint64_t graph_id)
-    : Track(time_graph), graph_id_(graph_id) {}
+GraphTrack::GraphTrack(TimeGraph* time_graph, std::string name)
+    : Track(time_graph), name_(std::move(name)) {}
 
 void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   Batcher* batcher = canvas->GetBatcher();

--- a/OrbitGl/GraphTrack.h
+++ b/OrbitGl/GraphTrack.h
@@ -14,7 +14,7 @@ class TimeGraph;
 
 class GraphTrack : public Track {
  public:
-  explicit GraphTrack(TimeGraph* time_graph, uint64_t graph_id);
+  explicit GraphTrack(TimeGraph* time_graph, std::string name);
   [[nodiscard]] Type GetType() const override { return kGraphTrack; }
   void Draw(GlCanvas* canvas, PickingMode /*picking_mode*/) override;
   [[nodiscard]] float GetHeight() const override;
@@ -27,7 +27,7 @@ class GraphTrack : public Track {
   double max_ = std::numeric_limits<double>::lowest();
   double value_range_ = 0;
   double inv_value_range_ = 0;
-  uint64_t graph_id_ = 0;
+  std::string name_;
 };
 
 #endif

--- a/OrbitGl/ManualInstrumentationManager.cpp
+++ b/OrbitGl/ManualInstrumentationManager.cpp
@@ -3,7 +3,3 @@
 // found in the LICENSE file.
 
 #include "ManualInstrumentationManager.h"
-
-using orbit_client_protos::TimerInfo;
-
-void ManualInstrumentationManager::OnTimerInfo(const TimerInfo&) {}

--- a/OrbitGl/ManualInstrumentationManager.cpp
+++ b/OrbitGl/ManualInstrumentationManager.cpp
@@ -1,0 +1,9 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ManualInstrumentationManager.h"
+
+using orbit_client_protos::TimerInfo;
+
+void ManualInstrumentationManager::OnTimerInfo(const TimerInfo&) {}

--- a/OrbitGl/ManualInstrumentationManager.h
+++ b/OrbitGl/ManualInstrumentationManager.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_MANUAL_INSTRUMENTATION_MANAGER_H_
+#define ORBIT_GL_MANUAL_INSTRUMENTATION_MANAGER_H_
+
+#include "../Orbit.h"
+#include "OrbitBase/Logging.h"
+#include "capture_data.pb.h"
+
+class ManualInstrumentationManager {
+ public:
+  [[nodiscard]] static orbit_api::Event ApiEventFromTimerInfo(
+      const orbit_client_protos::TimerInfo& timer_info) {
+    // On x64 Linux, 6 registers are used for integer argument passing.
+    // Manual instrumentation uses those registers to encode orbit_api::Event
+    // objects.
+    constexpr size_t kNumIntegerRegisers = 6;
+    CHECK(timer_info.registers_size() == kNumIntegerRegisers);
+    uint64_t arg_0 = timer_info.registers(0);
+    uint64_t arg_1 = timer_info.registers(1);
+    uint64_t arg_2 = timer_info.registers(2);
+    uint64_t arg_3 = timer_info.registers(3);
+    uint64_t arg_4 = timer_info.registers(4);
+    uint64_t arg_5 = timer_info.registers(5);
+    orbit_api::EncodedEvent encoded_event(arg_0, arg_1, arg_2, arg_3, arg_4, arg_5);
+    return encoded_event.event;
+  }
+
+  void OnTimerInfo(const orbit_client_protos::TimerInfo& timer_info);
+};
+
+#endif  // ORBIT_GL_MANUAL_INSTRUMENTATION_MANAGER_H_

--- a/OrbitGl/ManualInstrumentationManager.h
+++ b/OrbitGl/ManualInstrumentationManager.h
@@ -27,8 +27,6 @@ class ManualInstrumentationManager {
     orbit_api::EncodedEvent encoded_event(arg_0, arg_1, arg_2, arg_3, arg_4, arg_5);
     return encoded_event.event;
   }
-
-  void OnTimerInfo(const orbit_client_protos::TimerInfo& timer_info);
 };
 
 #endif  // ORBIT_GL_MANUAL_INSTRUMENTATION_MANAGER_H_

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -87,12 +87,12 @@ bool ThreadTrack::IsTimerActive(const TimerInfo& timer_info) const {
                                                               const FunctionInfo& function_info) {
   FunctionInfo::OrbitType type = function_info.type();
   if (type != FunctionInfo::kOrbitTimerStart && type != FunctionInfo::kOrbitTimerStartAsync) {
-    return std::optional<Color>{};
+    return std::nullopt;
   }
 
   orbit_api::Event event = ManualInstrumentationManager::ApiEventFromTimerInfo(timer_info);
   if (event.color == orbit::Color::kAuto) {
-    return std::optional<Color>{};
+    return std::nullopt;
   }
 
   return ToColor(static_cast<uint64_t>(event.color));

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <utility>
 
+#include "../Orbit.h"
 #include "App.h"
 #include "Batcher.h"
 #include "EventTracer.h"
@@ -20,6 +21,7 @@
 #include "GlCanvas.h"
 #include "GpuTrack.h"
 #include "GraphTrack.h"
+#include "ManualInstrumentationManager.h"
 #include "Params.h"
 #include "PickingManager.h"
 #include "SamplingProfiler.h"
@@ -306,8 +308,9 @@ void TimeGraph::ProcessTimer(const TimerInfo& timer_info, const FunctionInfo* fu
     capture_max_timestamp_ = timer_info.end();
   }
 
-  if (function != nullptr && FunctionUtils::IsOrbitFunc(*function)) {
-    ProcessOrbitFunctionTimer(*function, timer_info);
+  if (function != nullptr && function->type() == FunctionInfo::kOrbitTrackValue) {
+    ProcessValueTrackingTimer(timer_info);
+    return;
   }
 
   if (timer_info.type() == TimerInfo::kGpuActivity) {
@@ -333,89 +336,34 @@ void TimeGraph::ProcessTimer(const TimerInfo& timer_info, const FunctionInfo* fu
   NeedsUpdate();
 }
 
-void TimeGraph::ProcessOrbitFunctionTimer(const FunctionInfo& function,
-                                          const TimerInfo& timer_info) {
-  FunctionInfo::OrbitType type = function.type();
+void TimeGraph::ProcessValueTrackingTimer(const TimerInfo& timer_info) {
+  orbit_api::Event event = ManualInstrumentationManager::ApiEventFromTimerInfo(timer_info);
+  auto track = GetOrCreateGraphTrack(event.name);
   uint64_t time = timer_info.start();
-  CHECK(timer_info.registers_size() > 1);
 
-  // timer_info's "registers" hold a function's integer arguments in the order
-  // specified by the ABI. On x64 Linux, 6 registers are used for integer
-  // argument passing: rdi, rsi, rdx, rcx, r8, r9.
-  //
-  // "OrbitFunctions" are defined in Orbit.h. They are empty stubs that Orbit
-  // dynamically instruments. Manual instrumentation works by monitoring those
-  // function calls and the value of their arguments.
-  uint64_t arg_0 = timer_info.registers(0);  // first argument.
-  uint64_t arg_1 = timer_info.registers(1);  // second argument.
-
-  switch (type) {
-    case FunctionInfo::kOrbitTrackInt: {
-      int32_t value = static_cast<int32_t>(arg_1);
-      auto track = GetOrCreateGraphTrack(/*graph_id*/ arg_0);
-      track->AddValue(value, time);
+  switch (event.type) {
+    case orbit_api::kTrackInt: {
+      track->AddValue(orbit_api::Decode<int32_t>(event.value), time);
     } break;
-    case FunctionInfo::kOrbitTrackInt64: {
-      int64_t value = static_cast<int64_t>(arg_1);
-      auto track = GetOrCreateGraphTrack(/*graph_id*/ arg_0);
-      track->AddValue(value, time);
+    case orbit_api::kTrackInt64: {
+      track->AddValue(orbit_api::Decode<int64_t>(event.value), time);
     } break;
-    case FunctionInfo::kOrbitTrackUint: {
-      uint32_t value = static_cast<uint32_t>(arg_1);
-      auto track = GetOrCreateGraphTrack(/*graph_id*/ arg_0);
-      track->AddValue(value, time);
+    case orbit_api::kTrackUint: {
+      track->AddValue(orbit_api::Decode<uint32_t>(event.value), time);
     } break;
-    case FunctionInfo::kOrbitTrackUint64: {
-      uint64_t value = static_cast<uint64_t>(arg_1);
-      auto track = GetOrCreateGraphTrack(/*graph_id*/ arg_0);
-      track->AddValue(value, time);
+    case orbit_api::kTrackUint64: {
+      track->AddValue(event.value, time);
     } break;
-    case FunctionInfo::kOrbitTrackFloatAsInt: {
-      int32_t int_value = static_cast<int32_t>(arg_1);
-      float value = *(reinterpret_cast<float*>(&int_value));
-      auto track = GetOrCreateGraphTrack(/*graph_id*/ arg_0);
-      track->AddValue(value, time);
+    case orbit_api::kTrackFloat: {
+      track->AddValue(orbit_api::Decode<float>(event.value), time);
     } break;
-    case FunctionInfo::kOrbitTrackDoubleAsInt64: {
-      int64_t int_value = static_cast<int64_t>(arg_1);
-      double value = *(reinterpret_cast<double*>(&int_value));
-      auto track = GetOrCreateGraphTrack(/*graph_id*/ arg_0);
-      track->AddValue(value, time);
+    case orbit_api::kTrackDouble: {
+      track->AddValue(orbit_api::Decode<double>(event.value), time);
     } break;
-    case FunctionInfo::kOrbitTimerStart:
-      ProcessManualIntrumentationTimer(timer_info);
-      break;
     default:
+      ERROR("Unsupported value tracking type [%u]", event.type);
       break;
   }
-}
-
-void TimeGraph::ProcessManualIntrumentationTimer(const TimerInfo& timer_info) {
-  constexpr int kStringArgumentIndex = 0;
-  uint64_t string_address = timer_info.registers(kStringArgumentIndex);
-
-  // Request remote string on first encounter of string_address.
-  if (!manual_instrumentation_string_manager_.Contains(string_address)) {
-    // Prevent redundant string requests while the current request is in flight.
-    manual_instrumentation_string_manager_.AddOrReplace(string_address, "");
-
-    GOrbitApp->GetThreadPool()->Schedule([this, string_address]() {
-      int32_t pid = GOrbitApp->GetCaptureData().process_id();
-      const auto& process_manager = GOrbitApp->GetProcessManager();
-      auto error_or_string = process_manager->LoadNullTerminatedString(pid, string_address);
-
-      if (error_or_string.has_value()) {
-        manual_instrumentation_string_manager_.AddOrReplace(string_address,
-                                                            error_or_string.value());
-      } else {
-        ERROR("Loading remote string %s", error_or_string.error().message());
-      }
-    });
-  }
-}
-
-std::string TimeGraph::GetManualInstrumentationString(uint64_t string_address) const {
-  return manual_instrumentation_string_manager_.Get(string_address).value_or("");
 }
 
 uint32_t TimeGraph::GetNumTimers() const {
@@ -829,32 +777,15 @@ std::shared_ptr<GpuTrack> TimeGraph::GetOrCreateGpuTrack(uint64_t timeline_hash)
   return track;
 }
 
-static void SetTrackNameFromRemoteMemory(std::shared_ptr<Track> track, uint64_t string_address,
-                                         OrbitApp* app) {
-  app->GetThreadPool()->Schedule([track, string_address, app]() {
-    int32_t pid = GOrbitApp->GetCaptureData().process_id();
-    const auto& process_manager = app->GetProcessManager();
-    auto error_or_string = process_manager->LoadNullTerminatedString(pid, string_address);
-
-    if (error_or_string.has_value()) {
-      app->GetMainThreadExecutor()->Schedule([track, error_or_string]() {
-        track->SetName(error_or_string.value());
-        track->SetLabel(error_or_string.value());
-      });
-    } else {
-      ERROR("Setting track name from remote memory: %s", error_or_string.error().message());
-    }
-  });
-}
-
-GraphTrack* TimeGraph::GetOrCreateGraphTrack(uint64_t graph_id) {
+GraphTrack* TimeGraph::GetOrCreateGraphTrack(const std::string& name) {
   ScopeLock lock(m_Mutex);
-  std::shared_ptr<GraphTrack> track = graph_tracks_[graph_id];
+  std::shared_ptr<GraphTrack> track = graph_tracks_[name];
   if (track == nullptr) {
-    track = std::make_shared<GraphTrack>(this, graph_id);
-    SetTrackNameFromRemoteMemory(track, graph_id, GOrbitApp.get());
+    track = std::make_shared<GraphTrack>(this, name);
+    track->SetName(name);
+    track->SetLabel(name);
     tracks_.emplace_back(track);
-    graph_tracks_[graph_id] = track;
+    graph_tracks_[name] = track;
   }
 
   return track.get();
@@ -933,8 +864,8 @@ void TimeGraph::SortTracks() {
     }
 
     // Graph Tracks.
-    for (const auto& timeline_and_track : graph_tracks_) {
-      sorted_tracks_.emplace_back(timeline_and_track.second);
+    for (const auto& graph_track : graph_tracks_) {
+      sorted_tracks_.emplace_back(graph_track.second);
     }
 
     // Process Track.

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -44,8 +44,7 @@ class TimeGraph {
 
   void ProcessTimer(const orbit_client_protos::TimerInfo& timer_info,
                     const orbit_client_protos::FunctionInfo* function);
-  void ProcessOrbitFunctionTimer(const orbit_client_protos::FunctionInfo& function,
-                                 const orbit_client_protos::TimerInfo& timer_info);
+  void ProcessValueTrackingTimer(const orbit_client_protos::TimerInfo& timer_info);
   void UpdateMaxTimeStamp(uint64_t a_Time);
 
   float GetThreadTotalHeight();
@@ -128,7 +127,6 @@ class TimeGraph {
   const TextBox* FindDown(const TextBox* from);
 
   Color GetThreadColor(int32_t tid) const;
-  [[nodiscard]] std::string GetManualInstrumentationString(uint64_t string_address) const;
 
   void SetIteratorOverlayData(
       const absl::flat_hash_map<uint64_t, const TextBox*>& iterator_text_boxes,
@@ -146,10 +144,8 @@ class TimeGraph {
   std::shared_ptr<SchedulerTrack> GetOrCreateSchedulerTrack();
   std::shared_ptr<ThreadTrack> GetOrCreateThreadTrack(int32_t tid);
   std::shared_ptr<GpuTrack> GetOrCreateGpuTrack(uint64_t timeline_hash);
-  GraphTrack* GetOrCreateGraphTrack(uint64_t graph_id);
+  GraphTrack* GetOrCreateGraphTrack(const std::string& name);
 
-  void ProcessOrbitFunctionTimer(const orbit_client_protos::FunctionInfo* function,
-                                 const Timer& timer);
   void ProcessManualIntrumentationTimer(const orbit_client_protos::TimerInfo& timer_info);
 
  private:
@@ -200,7 +196,7 @@ class TimeGraph {
   mutable Mutex m_Mutex;
   std::vector<std::shared_ptr<Track>> tracks_;
   std::unordered_map<int32_t, std::shared_ptr<ThreadTrack>> thread_tracks_;
-  absl::flat_hash_map<uint64_t, std::shared_ptr<GraphTrack>> graph_tracks_;
+  std::map<std::string, std::shared_ptr<GraphTrack>> graph_tracks_;
   // Mapping from timeline hash to GPU tracks.
   std::unordered_map<uint64_t, std::shared_ptr<GpuTrack>> gpu_tracks_;
   std::vector<std::shared_ptr<Track>> sorted_tracks_;

--- a/OrbitTest/CMakeLists.txt
+++ b/OrbitTest/CMakeLists.txt
@@ -12,4 +12,4 @@ target_sources(OrbitTest PRIVATE main.cpp OrbitTest.cpp)
 target_sources(OrbitTest PUBLIC OrbitTest.h)
 
 target_include_directories(OrbitTest PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(OrbitTest PRIVATE Threads::Threads)
+target_link_libraries(OrbitTest PRIVATE Threads::Threads PUBLIC OrbitBase)

--- a/OrbitTest/OrbitTest.cpp
+++ b/OrbitTest/OrbitTest.cpp
@@ -13,6 +13,7 @@
 #include <thread>
 
 #include "../Orbit.h"
+#include "absl/strings/str_format.h"
 
 #if __linux__
 #define NO_INLINE __attribute__((noinline))
@@ -132,6 +133,11 @@ void OrbitTest::ManualInstrumentationApiTest() {
     static double double_var = 0.0;
     static volatile double cos_coeff = 0.1;
     ORBIT_DOUBLE_WITH_COLOR("double_var", cos((++double_var) * cos_coeff), orbit::Color::kPurple);
+
+    for (int i = 0; i < 5; ++i) {
+      std::string track_name = absl::StrFormat("DynamicName_%u", i);
+      ORBIT_DOUBLE(track_name.c_str(), cos(double_var * static_cast<double>(i)));
+    }
 
     std::this_thread::sleep_for(std::chrono::milliseconds(15));
   }


### PR DESCRIPTION
Use the 6 integer registers visible from uprobes to encode
a tightly packed "orbit_api::Event" object. This allows us
to add support for dynamic strings for manual instrumentation
scopes (30 characters max).

Add "orbit_api::Event" class
- Contains the current orbit_api version in the first byte
- Enables dynamic strings support (up to 30 characters for now)
- Fits in exactly 6 integer registers (48 bytes)

Add "orbit_api::EncodedEvent" class
- union of a orbit_api::Event object and 6 uint64_t's
- Used to convert an orbit_api::Event object to and from 6 uint64_t's