### PR TITLE
Renaming variables 

### DIFF
--- a/OrbitGl/EventTrack.h
+++ b/OrbitGl/EventTrack.h
@@ -25,26 +25,17 @@ class EventTrack : public Track {
   void OnRelease() override;
   void OnDrag(int a_X, int a_Y) override;
   bool Draggable() override { return true; }
-  float GetHeight() const override { return m_Size[1]; }
+  float GetHeight() const override { return size_[1]; }
 
   void SetThreadId(ThreadID thread_id) { thread_id_ = thread_id; }
   void SetTimeGraph(TimeGraph* a_TimeGraph) { time_graph_ = a_TimeGraph; }
   void SetPos(float a_X, float a_Y);
   void SetSize(float a_SizeX, float a_SizeY);
-  void SetColor(Color color) { m_Color = color; }
+  void SetColor(Color color) { color_ = color; }
   bool IsEmpty() const;
 
  protected:
   void SelectEvents();
   std::string GetSampleTooltip(PickingId id) const;
 
- protected:
-  TextBox m_ThreadName;
-  GlCanvas* m_Canvas;
-  int32_t thread_id_;
-  Vec2 m_Pos;
-  Vec2 m_Size;
-  Vec2 m_MousePos[2];
-  bool m_Picked;
-  Color m_Color;
 };

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -106,7 +106,7 @@ float GpuTrack::GetYFromDepth(uint32_t depth) const {
   if (collapse_toggle_->IsCollapsed()) {
     adjusted_depth = 0.f;
   }
-  return m_Pos[1] - time_graph_->GetLayout().GetTextBoxHeight() * (adjusted_depth + 1.f);
+  return pos_[1] - time_graph_->GetLayout().GetTextBoxHeight() * (adjusted_depth + 1.f);
 }
 
 // When track is collapsed, only draw "hardware execution" timers.

--- a/OrbitGl/GraphTrack.cpp
+++ b/OrbitGl/GraphTrack.cpp
@@ -14,34 +14,34 @@ void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
 
   float trackWidth = canvas->GetWorldWidth();
 
-  m_Pos[0] = canvas->GetWorldTopLeftX();
+  pos_[0] = canvas->GetWorldTopLeftX();
   SetSize(trackWidth, GetHeight());
   Track::Draw(canvas, picking_mode);
 
-  float x0 = m_Pos[0];
-  float x1 = x0 + m_Size[0];
+  float x0 = pos_[0];
+  float x1 = x0 + size_[0];
 
-  float y0 = m_Pos[1];
-  float y1 = y0 - m_Size[1];
+  float y0 = pos_[1];
+  float y1 = y0 - size_[1];
 
   const Color kPickedColor(0, 128, 255, 128);
-  Color color = m_Color;
-  if (m_Picked) {
-    // TODO: Is this really used? Is m_Picked even a thing?
+  Color color = color_;
+  if (picked_) {
+    // TODO: Is this really used? Is picked_ even a thing?
     color = kPickedColor;
   }
 
   float track_z = GlCanvas::kZValueTrack;
   float text_z = GlCanvas::kZValueText;
 
-  Box box(m_Pos, Vec2(m_Size[0], -m_Size[1]), track_z);
+  Box box(pos_, Vec2(size_[0], -size_[1]), track_z);
   batcher->AddBox(box, color, shared_from_this());
 
   if (canvas->GetPickingManager().IsThisElementPicked(this)) {
     color = Color(255, 255, 255, 255);
   }
 
-  batcher->AddLine(m_Pos, Vec2(x1, y0), track_z, color, shared_from_this());
+  batcher->AddLine(pos_, Vec2(x1, y0), track_z, color, shared_from_this());
   batcher->AddLine(Vec2(x1, y1), Vec2(x0, y1), track_z, color, shared_from_this());
 
   const Color kLineColor(0, 128, 255, 128);
@@ -61,11 +61,11 @@ void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
     if (previous_time > max_ns) break;
     uint64_t time = it->first;
     double normalized_value = (it->second - min_) * inv_value_range_;
-    float base_y = m_Pos[1] - m_Size[1];
+    float base_y = pos_[1] - size_[1];
     float x0 = time_graph_->GetWorldFromTick(previous_time);
     float x1 = time_graph_->GetWorldFromTick(time);
-    float y0 = base_y + static_cast<float>(last_normalized_value) * m_Size[1];
-    float y1 = base_y + static_cast<float>(normalized_value) * m_Size[1];
+    float y0 = base_y + static_cast<float>(last_normalized_value) * size_[1];
+    float y1 = base_y + static_cast<float>(normalized_value) * size_[1];
     time_graph_->GetBatcher().AddLine(Vec2(x0, y0), Vec2(x1, y1), text_z, kLineColor);
 
     previous_time = time;

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -47,7 +47,7 @@ Color SchedulerTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selecte
 float SchedulerTrack::GetYFromDepth(uint32_t depth) const {
   const TimeGraphLayout& layout = time_graph_->GetLayout();
   uint32_t num_gaps = depth;
-  return m_Pos[1] - (layout.GetTextCoresHeight() * (depth + 1)) -
+  return pos_[1] - (layout.GetTextCoresHeight() * (depth + 1)) -
          num_gaps * layout.GetSpaceBetweenCores();
 }
 

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -14,8 +14,8 @@
 using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::TimerInfo;
 
-ThreadTrack::ThreadTrack(TimeGraph* time_graph, int32_t thread_id)
-    : TimerTrack(time_graph), thread_id_(thread_id) {
+ThreadTrack::ThreadTrack(TimeGraph* time_graph, int32_t thread_id) : TimerTrack(time_graph) {
+  thread_id_ = thread_id;
   event_track_ = std::make_shared<EventTrack>(time_graph);
   event_track_->SetThreadId(thread_id);
 }
@@ -136,13 +136,13 @@ void ThreadTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   TimerTrack::Draw(canvas, picking_mode);
 
   float event_track_height = time_graph_->GetLayout().GetEventTrackHeight();
-  event_track_->SetPos(m_Pos[0], m_Pos[1]);
+  event_track_->SetPos(pos_[0], pos_[1]);
   event_track_->SetSize(canvas->GetWorldWidth(), event_track_height);
   event_track_->Draw(canvas, picking_mode);
 }
 
 void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode) {
-  event_track_->SetPos(m_Pos[0], m_Pos[1]);
+  event_track_->SetPos(pos_[0], pos_[1]);
   event_track_->UpdatePrimitives(min_tick, max_tick, picking_mode);
   TimerTrack::UpdatePrimitives(min_tick, max_tick, picking_mode);
 }

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -40,7 +40,6 @@ class ThreadTrack : public TimerTrack {
   [[nodiscard]] std::string GetBoxTooltip(PickingId id) const override;
 
   std::shared_ptr<EventTrack> event_track_;
-  int32_t thread_id_;
 };
 
 #endif  // ORBIT_GL_THREAD_TRACK_H_

--- a/OrbitGl/TimerTrack.cpp
+++ b/OrbitGl/TimerTrack.cpp
@@ -33,7 +33,7 @@ void TimerTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   float track_height = GetHeight();
   float track_width = canvas->GetWorldWidth();
 
-  SetPos(canvas->GetWorldTopLeftX(), m_Pos[1]);
+  SetPos(canvas->GetWorldTopLeftX(), pos_[1]);
   SetSize(track_width, track_height);
 
   Track::Draw(canvas, picking_mode);
@@ -55,7 +55,7 @@ float TimerTrack::GetYFromDepth(uint32_t depth) const {
     box_height /= static_cast<float>(depth_);
   }
 
-  return m_Pos[1] - layout.GetEventTrackHeight() - layout.GetSpaceBetweenTracksAndThread() -
+  return pos_[1] - layout.GetEventTrackHeight() - layout.GetSpaceBetweenTracksAndThread() -
          box_height * (depth + 1);
 }
 

--- a/OrbitGl/TracepointTrack.cpp
+++ b/OrbitGl/TracepointTrack.cpp
@@ -6,9 +6,7 @@
 
 #include "App.h"
 
-TracepointTrack::TracepointTrack(TimeGraph* time_graph) : Track(time_graph) {
-  color_ = Color(0, 255, 0, 255);
-}
+TracepointTrack::TracepointTrack(TimeGraph* time_graph) : EventTrack(time_graph) {}
 
 void TracepointTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode) {
   Batcher* batcher = &time_graph_->GetBatcher();

--- a/OrbitGl/TracepointTrack.cpp
+++ b/OrbitGl/TracepointTrack.cpp
@@ -26,16 +26,10 @@ void TracepointTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, Pic
   for (auto it = tracepoints.lower_bound(min_tick); it != tracepoints.upper_bound(max_tick); ++it) {
     uint64_t time = it->first;
     if (time < max_tick) {
-      Vec2 pos(time_graph_->GetWorldFromTick(time), position_[1]);
+      Vec2 pos(time_graph_->GetWorldFromTick(time), pos_[1]);
       batcher->AddVerticalLine(pos, -track_height, z, kWhite);
     } else {
       return;
     }
   }
-}
-
-void TracepointTrack::SetPos(float x, float y) {
-  position_ = Vec2(x, y);
-  thread_name_.SetPos(Vec2(x, y));
-  thread_name_.SetSize(Vec2(size_[0] * 0.3f, size_[1]));
 }

--- a/OrbitGl/TracepointTrack.h
+++ b/OrbitGl/TracepointTrack.h
@@ -20,12 +20,6 @@ class TracepointTrack : public Track {
 
   // TODO(msandru): Override Track::Draw, Track::OnPick, Track::OnRelease(), Track::GetBoxTooltip()
 
- protected:
-  int32_t thread_id_;
-  Vec2 position_;
-  TextBox thread_name_;
-  Vec2 size_;
-  Color color_;
 };
 
 #endif  // ORBIT_GL_TRACEPOINT_TRACK_H_

--- a/OrbitGl/TracepointTrack.h
+++ b/OrbitGl/TracepointTrack.h
@@ -9,17 +9,15 @@
 #include "TimeGraph.h"
 #include "Track.h"
 
-class TracepointTrack : public Track {
+class TracepointTrack : public EventTrack {
  public:
   explicit TracepointTrack(TimeGraph* time_graph);
 
-  void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
   void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode) override;
 
   void SetPos(float x, float y);
 
   // TODO(msandru): Override Track::Draw, Track::OnPick, Track::OnRelease(), Track::GetBoxTooltip()
-
 };
 
 #endif  // ORBIT_GL_TRACEPOINT_TRACK_H_

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -49,8 +49,8 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
   [[nodiscard]] virtual Type GetType() const = 0;
 
   [[nodiscard]] virtual float GetHeight() const { return 0.f; };
-  [[nodiscard]] bool GetVisible() const { return m_Visible; }
-  void SetVisible(bool value) { m_Visible = value; }
+  [[nodiscard]] bool GetVisible() const { return visible_; }
+  void SetVisible(bool value) { visible_ = value; }
 
   [[nodiscard]] uint32_t GetNumTimers() const { return num_timers_; }
   [[nodiscard]] uint64_t GetMinTime() const { return min_time_; }
@@ -59,9 +59,9 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
   [[nodiscard]] virtual std::vector<std::shared_ptr<TimerChain>> GetTimers() { return {}; }
   [[nodiscard]] virtual std::vector<std::shared_ptr<TimerChain>> GetAllChains() { return {}; }
 
-  [[nodiscard]] bool IsMoving() const { return m_Moving; }
+  [[nodiscard]] bool IsMoving() const { return moving_; }
   [[nodiscard]] Vec2 GetMoveDelta() const {
-    return m_Moving ? m_MousePos[1] - m_MousePos[0] : Vec2(0, 0);
+    return moving_ ? mouse_pos_[1] - mouse_pos_[0] : Vec2(0, 0);
   }
   void SetName(const std::string& name) { name_ = name; }
   [[nodiscard]] const std::string& GetName() const { return name_; }
@@ -71,9 +71,9 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
   void SetTimeGraph(TimeGraph* timegraph) { time_graph_ = timegraph; }
   void SetPos(float a_X, float a_Y);
   void SetY(float y);
-  [[nodiscard]] Vec2 GetPos() const { return m_Pos; }
+  [[nodiscard]] Vec2 GetPos() const { return pos_; }
   void SetSize(float a_SizeX, float a_SizeY);
-  void SetColor(Color a_Color) { m_Color = a_Color; }
+  void SetColor(Color a_Color) { color_ = a_Color; }
 
   void AddChild(std::shared_ptr<Track> track) { children_.emplace_back(track); }
   virtual void OnCollapseToggle(TriangleToggle::State state);
@@ -83,22 +83,24 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
   void DrawTriangleFan(Batcher* batcher, const std::vector<Vec2>& points, const Vec2& pos,
                        const Color& color, float rotation, float z);
 
-  GlCanvas* m_Canvas;
+  GlCanvas* canvas_;
   TimeGraph* time_graph_;
-  Vec2 m_Pos;
-  Vec2 m_Size;
-  Vec2 m_MousePos[2];
-  Vec2 m_PickingOffset;
-  bool m_Picked;
-  bool m_Moving;
+  Vec2 pos_;
+  Vec2 size_;
+  Vec2 mouse_pos_[2];
+  Vec2 picking_offset_;
+  bool picked_;
+  bool moving_;
   std::string name_;
   std::string label_;
-  Color m_Color;
-  bool m_Visible = true;
+  TextBox thread_name_;
+  int32_t thread_id_;
+  Color color_;
+  bool visible_ = true;
   std::atomic<uint32_t> num_timers_;
   std::atomic<uint64_t> min_time_;
   std::atomic<uint64_t> max_time_;
-  bool m_PickingEnabled = false;
+  bool picking_enabled_ = false;
   Type type_ = kUnknown;
   std::vector<std::shared_ptr<Track>> children_;
   std::shared_ptr<TriangleToggle> collapse_toggle_;


### PR DESCRIPTION
Rename some variables to follow google3 C++ style 

The main reason for doing this, was to move the EventTrack's member variables to Track and help TracepointTrack inherit EventTrack. The Draw call for the TracepointTrack should be identical to the one in EventTrack so, TracepointTrack should inherit from EventTrack. The variables used in EventTrack::Draw were member variables of EventTrack that followed 'old' C++ standard. 

One solution for the TracepointTrack to use EventTrack::Draw via inheritance, would have been to also have the variables used in EventTrack::Draw as members of TracepointTrack. In order for TracepointTrack to be able to use EventTrack::Draw, the names of the member variable should have been identical to the ones in EventTrack, using 'old' C++.

Creating extra variables in C++ using 'old' style is not desirable, so instead refactoring was chosen. The variables used in EventTrack::Draw were moved to Track and renamed to follow google3 C++ style. Then, TracepointTrack was set to inherit EventTrack. Since the variables used in EventTrack were moved to one level higher, when TracepointTrack::Draw is called, the function EventTrack::Draw is called but with the variables specific to TracepointTrack.

A reason for renaming was that the variables in TracepointTrack::UpdatePrimitives use google3 C++ style. All those variables were moved in Track such that the variables used in TracepointTrack::UpdatePrimitives and Tracepoint::Draw are the same.