### PR TITLE
Add Cancellation and Error Handling to CaptureListener

### DIFF
--- a/OrbitCaptureClient/CaptureClient.cpp
+++ b/OrbitCaptureClient/CaptureClient.cpp
@@ -123,7 +123,7 @@ void CaptureClient::Capture(int32_t process_id, std::string process_name,
   if (force_stop_) {
     capture_listener_->OnCaptureFailed(
         ErrorMessage("WritesDone on Capture's gRPC stream failed: unable to finish the "
-                     "capture in orderly manner, initiating emergency stop"));
+                     "capture in orderly manner, performing emergency stop."));
   } else {
     LOG("Finished reading from Capture's gRPC stream: all capture data has been received");
     capture_listener_->OnCaptureComplete();

--- a/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -27,6 +27,8 @@ class MyCaptureListener : public CaptureListener {
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> /*selected_functions*/,
       TracepointInfoSet /*selected_tracepoints*/) override {}
   void OnCaptureComplete() override {}
+  void OnCaptureCanceled() override {}
+  void OnCaptureFailed(std::string /*error_message*/) override {}
   void OnTimer(const TimerInfo&) override {}
   void OnKeyAndString(uint64_t, std::string) override {}
   void OnUniqueCallStack(CallStack) override {}

--- a/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -4,6 +4,7 @@
 
 #include <libfuzzer/libfuzzer_macro.h>
 
+#include "OrbitBase/Result.h"
 #include "OrbitCaptureClient/CaptureEventProcessor.h"
 #include "OrbitCaptureClient/CaptureListener.h"
 #include "TracepointCustom.h"
@@ -27,8 +28,8 @@ class MyCaptureListener : public CaptureListener {
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> /*selected_functions*/,
       TracepointInfoSet /*selected_tracepoints*/) override {}
   void OnCaptureComplete() override {}
-  void OnCaptureCanceled() override {}
-  void OnCaptureFailed(std::string /*error_message*/) override {}
+  void OnCaptureCancelled() override {}
+  void OnCaptureFailed(ErrorMessage /*error_message*/) override {}
   void OnTimer(const TimerInfo&) override {}
   void OnKeyAndString(uint64_t, std::string) override {}
   void OnUniqueCallStack(CallStack) override {}

--- a/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -29,7 +29,7 @@ class MyCaptureListener : public CaptureListener {
       TracepointInfoSet /*selected_tracepoints*/) override {}
   void OnCaptureComplete() override {}
   void OnCaptureCancelled() override {}
-  void OnCaptureFailed(ErrorMessage /*error_message*/) override {}
+  void OnCaptureFailed(ErrorMessage) override {}
   void OnTimer(const TimerInfo&) override {}
   void OnKeyAndString(uint64_t, std::string) override {}
   void OnUniqueCallStack(CallStack) override {}

--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
@@ -23,8 +23,13 @@ class CaptureListener {
       int32_t process_id, std::string process_name, std::shared_ptr<Process> process,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints) = 0;
-  // Called when capture is complete
+  // Called when capture is complete.
   virtual void OnCaptureComplete() = 0;
+
+  // Called when capture is cancelled (not stopped). Mostly relevant for capture loading.
+  virtual void OnCaptureCanceled() = 0;
+  // Called when an internal error occurred that makes the capture invalid.
+  virtual void OnCaptureFailed(std::string error_message) = 0;
 
   virtual void OnTimer(const orbit_client_protos::TimerInfo& timer_info) = 0;
   virtual void OnKeyAndString(uint64_t key, std::string str) = 0;

--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
@@ -7,6 +7,7 @@
 
 #include "Callstack.h"
 #include "EventBuffer.h"
+#include "OrbitBase/Result.h"
 #include "OrbitProcess.h"
 #include "ScopeTimer.h"
 #include "TracepointCustom.h"
@@ -27,9 +28,9 @@ class CaptureListener {
   virtual void OnCaptureComplete() = 0;
 
   // Called when capture is cancelled (not stopped). Mostly relevant for capture loading.
-  virtual void OnCaptureCanceled() = 0;
+  virtual void OnCaptureCancelled() = 0;
   // Called when an internal error occurred that makes the capture invalid.
-  virtual void OnCaptureFailed(std::string error_message) = 0;
+  virtual void OnCaptureFailed(ErrorMessage error_message) = 0;
 
   virtual void OnTimer(const orbit_client_protos::TimerInfo& timer_info) = 0;
   virtual void OnKeyAndString(uint64_t key, std::string str) = 0;

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -249,9 +249,9 @@ void ClientGgp::OnCaptureComplete() {
   capture_data_.set_sampling_profiler(sampling_profiler);
 }
 
-void ClientGgp::OnCaptureCanceled(){};
+void ClientGgp::OnCaptureCancelled() {}
 
-void ClientGgp::OnCaptureFailed(std::string /*error_message*/){};
+void ClientGgp::OnCaptureFailed(ErrorMessage /*error_message*/) {}
 
 void ClientGgp::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
   if (timer_info.function_address() > 0) {

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -249,6 +249,10 @@ void ClientGgp::OnCaptureComplete() {
   capture_data_.set_sampling_profiler(sampling_profiler);
 }
 
+void ClientGgp::OnCaptureCanceled(){};
+
+void ClientGgp::OnCaptureFailed(std::string /*error_message*/){};
+
 void ClientGgp::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
   if (timer_info.function_address() > 0) {
     FunctionInfo* func =

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -34,6 +34,8 @@ class ClientGgp final : public CaptureListener {
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints) override;
   void OnCaptureComplete() override;
+  void OnCaptureCanceled() override;
+  void OnCaptureFailed(std::string error_message) override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
   void OnKeyAndString(uint64_t key, std::string str) override;
   void OnUniqueCallStack(CallStack callstack) override;

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -34,8 +34,8 @@ class ClientGgp final : public CaptureListener {
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints) override;
   void OnCaptureComplete() override;
-  void OnCaptureCanceled() override;
-  void OnCaptureFailed(std::string error_message) override;
+  void OnCaptureCancelled() override;
+  void OnCaptureFailed(ErrorMessage error_message) override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
   void OnKeyAndString(uint64_t key, std::string str) override;
   void OnUniqueCallStack(CallStack callstack) override;

--- a/OrbitClientModel/CaptureDeserializer.cpp
+++ b/OrbitClientModel/CaptureDeserializer.cpp
@@ -34,7 +34,7 @@ void Load(const std::string& file_name, CaptureListener* capture_listener,
   if (file.fail()) {
     ERROR("Loading capture from \"%s\": %s", file_name, "file.fail()");
     capture_listener->OnCaptureFailed(
-        absl::StrFormat("Error opening the file \"%s\"for reading", file_name));
+        ErrorMessage(absl::StrFormat("Error opening file \"%s\"for reading", file_name)));
     return;
   }
 
@@ -55,7 +55,7 @@ void Load(std::istream& stream, const std::string& file_name, CaptureListener* c
   CaptureHeader header;
   if (!internal::ReadMessage(&header, &coded_input) || header.version().empty()) {
     ERROR("%s", error_message);
-    capture_listener->OnCaptureFailed(std::move(error_message));
+    capture_listener->OnCaptureFailed(ErrorMessage(std::move(error_message)));
     return;
   }
   if (header.version() != internal::kRequiredCaptureVersion) {
@@ -64,14 +64,14 @@ void Load(std::istream& stream, const std::string& file_name, CaptureListener* c
         "Orbit version %s.",
         file_name, header.version());
     ERROR("%s", incompatible_version_error_message);
-    capture_listener->OnCaptureFailed(std::move(incompatible_version_error_message));
+    capture_listener->OnCaptureFailed(ErrorMessage(std::move(incompatible_version_error_message)));
     return;
   }
 
   CaptureInfo capture_info;
   if (!internal::ReadMessage(&capture_info, &coded_input)) {
     ERROR("%s", error_message);
-    capture_listener->OnCaptureFailed(std::move(error_message));
+    capture_listener->OnCaptureFailed(ErrorMessage(std::move(error_message)));
     return;
   }
 
@@ -109,7 +109,7 @@ void LoadCaptureInfo(const CaptureInfo& capture_info, CaptureListener* capture_l
   TracepointInfoSet selected_tracepoints;
 
   if (*cancellation_requested) {
-    capture_listener->OnCaptureCanceled();
+    capture_listener->OnCaptureCancelled();
     return;
   }
   capture_listener->OnCaptureStarted(capture_info.process_id(), capture_info.process_name(),
@@ -118,7 +118,7 @@ void LoadCaptureInfo(const CaptureInfo& capture_info, CaptureListener* capture_l
 
   for (const auto& address_info : capture_info.address_infos()) {
     if (*cancellation_requested) {
-      capture_listener->OnCaptureCanceled();
+      capture_listener->OnCaptureCancelled();
       return;
     }
     capture_listener->OnAddressInfo(address_info);
@@ -126,7 +126,7 @@ void LoadCaptureInfo(const CaptureInfo& capture_info, CaptureListener* capture_l
 
   for (const auto& thread_id_and_name : capture_info.thread_names()) {
     if (*cancellation_requested) {
-      capture_listener->OnCaptureCanceled();
+      capture_listener->OnCaptureCancelled();
       return;
     }
     capture_listener->OnThreadName(thread_id_and_name.first, thread_id_and_name.second);
@@ -135,14 +135,14 @@ void LoadCaptureInfo(const CaptureInfo& capture_info, CaptureListener* capture_l
   for (const CallstackInfo& callstack : capture_info.callstacks()) {
     CallStack unique_callstack({callstack.data().begin(), callstack.data().end()});
     if (*cancellation_requested) {
-      capture_listener->OnCaptureCanceled();
+      capture_listener->OnCaptureCancelled();
       return;
     }
     capture_listener->OnUniqueCallStack(std::move(unique_callstack));
   }
   for (CallstackEvent callstack_event : capture_info.callstack_events()) {
     if (*cancellation_requested) {
-      capture_listener->OnCaptureCanceled();
+      capture_listener->OnCaptureCancelled();
       return;
     }
     capture_listener->OnCallstackEvent(std::move(callstack_event));
@@ -150,7 +150,7 @@ void LoadCaptureInfo(const CaptureInfo& capture_info, CaptureListener* capture_l
 
   for (const auto& key_to_string : capture_info.key_to_string()) {
     if (*cancellation_requested) {
-      capture_listener->OnCaptureCanceled();
+      capture_listener->OnCaptureCancelled();
       return;
     }
     capture_listener->OnKeyAndString(key_to_string.first, key_to_string.second);
@@ -160,7 +160,7 @@ void LoadCaptureInfo(const CaptureInfo& capture_info, CaptureListener* capture_l
   TimerInfo timer_info;
   while (internal::ReadMessage(&timer_info, coded_input)) {
     if (*cancellation_requested) {
-      capture_listener->OnCaptureCanceled();
+      capture_listener->OnCaptureCancelled();
       return;
     }
     capture_listener->OnTimer(timer_info);

--- a/OrbitClientModel/CaptureDeserializer.cpp
+++ b/OrbitClientModel/CaptureDeserializer.cpp
@@ -25,53 +25,57 @@ using orbit_client_protos::TimerInfo;
 
 namespace capture_deserializer {
 
-ErrorMessageOr<void> Load(const std::string& filename, CaptureListener* capture_listener,
-                          std::atomic<bool>* cancellation_requested) {
-  SCOPE_TIMER_LOG(absl::StrFormat("Loading capture from \"%s\"", filename));
+void Load(const std::string& file_name, CaptureListener* capture_listener,
+          std::atomic<bool>* cancellation_requested) {
+  SCOPE_TIMER_LOG(absl::StrFormat("Loading capture from \"%s\"", file_name));
 
   // Binary
-  std::ifstream file(filename, std::ios::binary);
+  std::ifstream file(file_name, std::ios::binary);
   if (file.fail()) {
-    ERROR("Loading capture from \"%s\": %s", filename, "file.fail()");
-    return ErrorMessage("Error opening the file for reading");
+    ERROR("Loading capture from \"%s\": %s", file_name, "file.fail()");
+    capture_listener->OnCaptureFailed(
+        absl::StrFormat("Error opening the file \"%s\"for reading", file_name));
+    return;
   }
 
-  return Load(file, capture_listener, cancellation_requested);
+  return Load(file, file_name, capture_listener, cancellation_requested);
 }
 
-ErrorMessageOr<void> Load(std::istream& stream, CaptureListener* capture_listener,
-                          std::atomic<bool>* cancellation_requested) {
+void Load(std::istream& stream, const std::string& file_name, CaptureListener* capture_listener,
+          std::atomic<bool>* cancellation_requested) {
   google::protobuf::io::IstreamInputStream input_stream(&stream);
   google::protobuf::io::CodedInputStream coded_input(&input_stream);
 
-  std::string error_message =
-      "Error parsing the capture.\nNote: If the capture "
+  std::string error_message = absl::StrFormat(
+      "Error parsing the capture from \"%s\".\nNote: If the capture "
       "was taken with a previous Orbit version, it could be incompatible. "
-      "Please check release notes for more information.";
+      "Please check release notes for more information.",
+      file_name);
 
   CaptureHeader header;
   if (!internal::ReadMessage(&header, &coded_input) || header.version().empty()) {
     ERROR("%s", error_message);
-    return ErrorMessage(error_message);
+    capture_listener->OnCaptureFailed(std::move(error_message));
+    return;
   }
   if (header.version() != internal::kRequiredCaptureVersion) {
     std::string incompatible_version_error_message = absl::StrFormat(
-        "This capture format is no longer supported but could be opened with "
+        "The format of capture \"%s\" is no longer supported but could be opened with "
         "Orbit version %s.",
-        header.version());
+        file_name, header.version());
     ERROR("%s", incompatible_version_error_message);
-    return ErrorMessage(incompatible_version_error_message);
+    capture_listener->OnCaptureFailed(std::move(incompatible_version_error_message));
+    return;
   }
 
   CaptureInfo capture_info;
   if (!internal::ReadMessage(&capture_info, &coded_input)) {
     ERROR("%s", error_message);
-    return ErrorMessage(error_message);
+    capture_listener->OnCaptureFailed(std::move(error_message));
+    return;
   }
 
   internal::LoadCaptureInfo(capture_info, capture_listener, &coded_input, cancellation_requested);
-
-  return outcome::success();
 }
 
 namespace internal {
@@ -105,6 +109,7 @@ void LoadCaptureInfo(const CaptureInfo& capture_info, CaptureListener* capture_l
   TracepointInfoSet selected_tracepoints;
 
   if (*cancellation_requested) {
+    capture_listener->OnCaptureCanceled();
     return;
   }
   capture_listener->OnCaptureStarted(capture_info.process_id(), capture_info.process_name(),
@@ -113,6 +118,7 @@ void LoadCaptureInfo(const CaptureInfo& capture_info, CaptureListener* capture_l
 
   for (const auto& address_info : capture_info.address_infos()) {
     if (*cancellation_requested) {
+      capture_listener->OnCaptureCanceled();
       return;
     }
     capture_listener->OnAddressInfo(address_info);
@@ -120,6 +126,7 @@ void LoadCaptureInfo(const CaptureInfo& capture_info, CaptureListener* capture_l
 
   for (const auto& thread_id_and_name : capture_info.thread_names()) {
     if (*cancellation_requested) {
+      capture_listener->OnCaptureCanceled();
       return;
     }
     capture_listener->OnThreadName(thread_id_and_name.first, thread_id_and_name.second);
@@ -128,12 +135,14 @@ void LoadCaptureInfo(const CaptureInfo& capture_info, CaptureListener* capture_l
   for (const CallstackInfo& callstack : capture_info.callstacks()) {
     CallStack unique_callstack({callstack.data().begin(), callstack.data().end()});
     if (*cancellation_requested) {
+      capture_listener->OnCaptureCanceled();
       return;
     }
     capture_listener->OnUniqueCallStack(std::move(unique_callstack));
   }
   for (CallstackEvent callstack_event : capture_info.callstack_events()) {
     if (*cancellation_requested) {
+      capture_listener->OnCaptureCanceled();
       return;
     }
     capture_listener->OnCallstackEvent(std::move(callstack_event));
@@ -141,6 +150,7 @@ void LoadCaptureInfo(const CaptureInfo& capture_info, CaptureListener* capture_l
 
   for (const auto& key_to_string : capture_info.key_to_string()) {
     if (*cancellation_requested) {
+      capture_listener->OnCaptureCanceled();
       return;
     }
     capture_listener->OnKeyAndString(key_to_string.first, key_to_string.second);
@@ -150,14 +160,12 @@ void LoadCaptureInfo(const CaptureInfo& capture_info, CaptureListener* capture_l
   TimerInfo timer_info;
   while (internal::ReadMessage(&timer_info, coded_input)) {
     if (*cancellation_requested) {
+      capture_listener->OnCaptureCanceled();
       return;
     }
     capture_listener->OnTimer(timer_info);
   }
 
-  if (*cancellation_requested) {
-    return;
-  }
   capture_listener->OnCaptureComplete();
 }
 

--- a/OrbitClientModel/include/OrbitClientModel/CaptureDeserializer.h
+++ b/OrbitClientModel/include/OrbitClientModel/CaptureDeserializer.h
@@ -19,10 +19,10 @@
 
 namespace capture_deserializer {
 
-ErrorMessageOr<void> Load(std::istream& stream, CaptureListener* capture_listener,
-                          std::atomic<bool>* cancellation_requested);
-ErrorMessageOr<void> Load(const std::string& filename, CaptureListener* capture_listener,
-                          std::atomic<bool>* cancellation_requested);
+void Load(std::istream& stream, const std::string& file_name, CaptureListener* capture_listener,
+          std::atomic<bool>* cancellation_requested);
+void Load(const std::string& file_name, CaptureListener* capture_listener,
+          std::atomic<bool>* cancellation_requested);
 
 namespace internal {
 

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -81,7 +81,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   ErrorMessageOr<void> OnLoadPreset(const std::string& file_name);
   ErrorMessageOr<void> OnSaveCapture(const std::string& file_name);
   void OnLoadCapture(const std::string& file_name);
-  void OnLoadCatpureCanceled();
+  void OnLoadCaptureCancellationRequest();
   [[nodiscard]] bool IsCapturing() const;
   bool StartCapture();
   void StopCapture();
@@ -100,6 +100,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints) override;
   void OnCaptureComplete() override;
+  void OnCaptureCanceled() override;
+  void OnCaptureFailed(std::string error_message) override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
   void OnKeyAndString(uint64_t key, std::string str) override;
   void OnUniqueCallStack(CallStack callstack) override;

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -81,7 +81,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   ErrorMessageOr<void> OnLoadPreset(const std::string& file_name);
   ErrorMessageOr<void> OnSaveCapture(const std::string& file_name);
   void OnLoadCapture(const std::string& file_name);
-  void OnLoadCaptureCancellationRequest();
+  void OnLoadCaptureCancelRequested();
   [[nodiscard]] bool IsCapturing() const;
   bool StartCapture();
   void StopCapture();
@@ -100,8 +100,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints) override;
   void OnCaptureComplete() override;
-  void OnCaptureCanceled() override;
-  void OnCaptureFailed(std::string error_message) override;
+  void OnCaptureCancelled() override;
+  void OnCaptureFailed(ErrorMessage error_message) override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
   void OnKeyAndString(uint64_t key, std::string str) override;
   void OnUniqueCallStack(CallStack callstack) override;
@@ -141,6 +141,10 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   using CaptureStoppedCallback = std::function<void()>;
   void SetCaptureStoppedCallback(CaptureStoppedCallback callback) {
     capture_stopped_callback_ = std::move(callback);
+  }
+  using CaptureFailedCallback = std::function<void()>;
+  void SetCaptureFailedCallback(CaptureFailedCallback callback) {
+    capture_failed_callback_ = std::move(callback);
   }
 
   using CaptureClearedCallback = std::function<void()>;
@@ -314,6 +318,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   CaptureStartedCallback capture_started_callback_;
   CaptureStopRequestedCallback capture_stop_requested_callback_;
   CaptureStoppedCallback capture_stopped_callback_;
+  CaptureFailedCallback capture_failed_callback_;
   CaptureClearedCallback capture_cleared_callback_;
   OpenCaptureCallback open_capture_callback_;
   OpenCaptureFailedCallback open_capture_failed_callback_;

--- a/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
+++ b/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
@@ -51,7 +51,7 @@ DEFINE_PROTO_FUZZER(const orbit_client_protos::CaptureDeserializerFuzzerInfo& in
   // NOLINTNEXTLINE
   std::istringstream input_stream{std::move(buffer)};
   std::atomic<bool> cancellation_requested = false;
-  (void)capture_deserializer::Load(input_stream, GOrbitApp.get(), &cancellation_requested);
+  capture_deserializer::Load(input_stream, "", GOrbitApp.get(), &cancellation_requested);
 
   GOrbitApp->GetThreadPool()->ShutdownAndWait();
   GOrbitApp.reset();

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -146,7 +146,7 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App, ApplicationOptions&& optio
   loading_capture_cancel_button->setText("Cancel");
   QObject::connect(loading_capture_cancel_button, &QPushButton::clicked, this,
                    [loading_capture_dialog]() {
-                     GOrbitApp->OnLoadCatpureCanceled();
+                     GOrbitApp->OnLoadCaptureCancellationRequest();
                      loading_capture_dialog->close();
                    });
   loading_capture_dialog->setCancelButton(loading_capture_cancel_button);


### PR DESCRIPTION
On capture loading there might be the cases of errors or user cancellation.
Prior to this change, those might not be handled thread-safe. Now, the capture
thread properly calls respective methods on the capture listener.
These callbacks are currently only called on capture loading and not on usual
capturing.

Test: Compile, Loading Captures (also broken ones). Pressed "cancel" during loading.