### PR TITLE
Filter events

### DIFF
--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -292,5 +292,5 @@ void ClientGgp::OnTracepointEvent(orbit_client_protos::TracepointEventInfo trace
 
   capture_data_.AddTracepointEventAndMapToThreads(
       tracepoint_event_info.time(), tracepoint_event_info.tracepoint_info_key(),
-      tracepoint_event_info.tid(), tracepoint_event_info.pid(), is_same_pid_as_target);
+      tracepoint_event_info.pid(), tracepoint_event_info.tid(), is_same_pid_as_target);
 }

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -287,7 +287,11 @@ void ClientGgp::OnUniqueTracepointInfo(uint64_t key,
 }
 
 void ClientGgp::OnTracepointEvent(orbit_client_protos::TracepointEventInfo tracepoint_event_info) {
-  capture_data_.AddTracepointEventAndMapToThreads(tracepoint_event_info.time(),
-                                                  tracepoint_event_info.tracepoint_info_key(),
-                                                  tracepoint_event_info.tid());
+  int32_t capture_process_id = capture_data_.process_id();
+  bool is_same_pid_as_target =
+      capture_process_id == 0 || capture_process_id == tracepoint_event_info.pid();
+
+  capture_data_.AddTracepointEventAndMapToThreads(
+      tracepoint_event_info.time(), tracepoint_event_info.tracepoint_info_key(),
+      tracepoint_event_info.tid(), is_same_pid_as_target);
 }

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -288,10 +288,9 @@ void ClientGgp::OnUniqueTracepointInfo(uint64_t key,
 
 void ClientGgp::OnTracepointEvent(orbit_client_protos::TracepointEventInfo tracepoint_event_info) {
   int32_t capture_process_id = capture_data_.process_id();
-  bool is_same_pid_as_target =
-      capture_process_id == 0 || capture_process_id == tracepoint_event_info.pid();
+  bool is_same_pid_as_target = capture_process_id == tracepoint_event_info.pid();
 
   capture_data_.AddTracepointEventAndMapToThreads(
       tracepoint_event_info.time(), tracepoint_event_info.tracepoint_info_key(),
-      tracepoint_event_info.tid(), is_same_pid_as_target);
+      tracepoint_event_info.tid(), tracepoint_event_info.pid(), is_same_pid_as_target);
 }

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -139,10 +139,11 @@ class CaptureData {
     tracepoint_info_manager_->AddUniqueTracepointEventInfo(key, std::move(tracepoint_info));
   }
 
-  void AddTracepointEventAndMapToThreads(uint64_t time, uint64_t tracepoint_hash, int32_t thread_id,
-                                         int32_t process_id, bool is_same_pid_as_target) {
-    tracepoint_event_buffer_->AddTracepointEventAndMapToThreads(time, tracepoint_hash, thread_id,
-                                                                process_id, is_same_pid_as_target);
+  void AddTracepointEventAndMapToThreads(uint64_t time, uint64_t tracepoint_hash,
+                                         int32_t process_id, int32_t thread_id,
+                                         bool is_same_pid_as_target) {
+    tracepoint_event_buffer_->AddTracepointEventAndMapToThreads(time, tracepoint_hash, process_id,
+                                                                thread_id, is_same_pid_as_target);
   }
 
   [[nodiscard]] const CallstackData* GetSelectionCallstackData() const {

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -139,9 +139,10 @@ class CaptureData {
     tracepoint_info_manager_->AddUniqueTracepointEventInfo(key, std::move(tracepoint_info));
   }
 
-  void AddTracepointEventAndMapToThreads(uint64_t time, uint64_t tracepoint_hash,
-                                         int32_t thread_id) {
-    tracepoint_event_buffer_->AddTracepointEventAndMapToThreads(time, tracepoint_hash, thread_id);
+  void AddTracepointEventAndMapToThreads(uint64_t time, uint64_t tracepoint_hash, int32_t thread_id,
+                                         bool is_same_pid_as_target) {
+    tracepoint_event_buffer_->AddTracepointEventAndMapToThreads(time, tracepoint_hash, thread_id,
+                                                                is_same_pid_as_target);
   }
 
   [[nodiscard]] const CallstackData* GetSelectionCallstackData() const {

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -140,9 +140,9 @@ class CaptureData {
   }
 
   void AddTracepointEventAndMapToThreads(uint64_t time, uint64_t tracepoint_hash, int32_t thread_id,
-                                         bool is_same_pid_as_target) {
+                                         int32_t process_id, bool is_same_pid_as_target) {
     tracepoint_event_buffer_->AddTracepointEventAndMapToThreads(time, tracepoint_hash, thread_id,
-                                                                is_same_pid_as_target);
+                                                                process_id, is_same_pid_as_target);
   }
 
   [[nodiscard]] const CallstackData* GetSelectionCallstackData() const {

--- a/OrbitCore/TracepointEventBuffer.cpp
+++ b/OrbitCore/TracepointEventBuffer.cpp
@@ -8,11 +8,14 @@ using orbit_client_protos::TracepointEventInfo;
 
 void TracepointEventBuffer::AddTracepointEventAndMapToThreads(uint64_t time,
                                                               uint64_t tracepoint_hash,
-                                                              int32_t thread_id, int32_t process_id,
+                                                              int32_t process_id, int32_t thread_id,
                                                               bool is_same_pid_as_target) {
   if (!is_same_pid_as_target) {
     return;
   }
+
+  /*TODO: tracepoint events with !is_same_pid_as_target will also have to be
+   * stored when implementing the track showing tracepoint events from all processes in the system*/
 
   ScopeLock lock(mutex_);
   std::map<uint64_t, orbit_client_protos::TracepointEventInfo>& event_map =

--- a/OrbitCore/TracepointEventBuffer.cpp
+++ b/OrbitCore/TracepointEventBuffer.cpp
@@ -8,7 +8,8 @@ using orbit_client_protos::TracepointEventInfo;
 
 void TracepointEventBuffer::AddTracepointEventAndMapToThreads(uint64_t time,
                                                               uint64_t tracepoint_hash,
-                                                              int32_t thread_id) {
+                                                              int32_t thread_id,
+                                                              bool is_same_pid_as_target) {
   ScopeLock lock(mutex_);
   std::map<uint64_t, orbit_client_protos::TracepointEventInfo>& event_map =
       tracepoint_events_[thread_id];
@@ -18,15 +19,16 @@ void TracepointEventBuffer::AddTracepointEventAndMapToThreads(uint64_t time,
   event.set_tid(thread_id);
   event_map[time] = std::move(event);
 
-  // Add all tracepoint events to "all threads".
-  std::map<uint64_t, orbit_client_protos::TracepointEventInfo>& event_map_all_threads =
-      tracepoint_events_[SamplingProfiler::kAllThreadsFakeTid];
-  orbit_client_protos::TracepointEventInfo event_all_threads;
-  event_all_threads.set_time(time);
-  event_all_threads.set_tracepoint_info_key(tracepoint_hash);
-  event_all_threads.set_tid(SamplingProfiler::kAllThreadsFakeTid);
-  event_map_all_threads[time] = std::move(event);
-
+  if (is_same_pid_as_target) {
+    // Add all tracepoint events to "all threads".
+    std::map<uint64_t, orbit_client_protos::TracepointEventInfo>& event_map_all_threads =
+        tracepoint_events_[SamplingProfiler::kAllThreadsFakeTid];
+    orbit_client_protos::TracepointEventInfo event_all_threads;
+    event_all_threads.set_time(time);
+    event_all_threads.set_tracepoint_info_key(tracepoint_hash);
+    event_all_threads.set_tid(SamplingProfiler::kAllThreadsFakeTid);
+    event_map_all_threads[time] = std::move(event);
+  }
   RegisterTime(time);
 }
 

--- a/OrbitCore/TracepointEventBuffer.h
+++ b/OrbitCore/TracepointEventBuffer.h
@@ -17,8 +17,9 @@ class TracepointEventBuffer {
  public:
   TracepointEventBuffer() : max_time_(0), min_time_(std::numeric_limits<uint64_t>::max()) {}
 
-  void AddTracepointEventAndMapToThreads(uint64_t time, uint64_t tracepoint_hash, int32_t thread_id,
-                                         int32_t process_id, bool is_same_pid_as_target);
+  void AddTracepointEventAndMapToThreads(uint64_t time, uint64_t tracepoint_hash,
+                                         int32_t process_id, int32_t thread_id,
+                                         bool is_same_pid_as_target);
 
   [[nodiscard]] const std::map<uint64_t, orbit_client_protos::TracepointEventInfo>&
   GetTracepointsOfThread(int32_t thread_id) const;

--- a/OrbitCore/TracepointEventBuffer.h
+++ b/OrbitCore/TracepointEventBuffer.h
@@ -17,8 +17,8 @@ class TracepointEventBuffer {
  public:
   TracepointEventBuffer() : max_time_(0), min_time_(std::numeric_limits<uint64_t>::max()) {}
 
-  void AddTracepointEventAndMapToThreads(uint64_t time, uint64_t tracepoint_hash,
-                                         int32_t thread_id);
+  void AddTracepointEventAndMapToThreads(uint64_t time, uint64_t tracepoint_hash, int32_t thread_id,
+                                         bool is_same_pid_as_target);
 
   [[nodiscard]] const std::map<uint64_t, orbit_client_protos::TracepointEventInfo>&
   GetTracepointsOfThread(int32_t thread_id) const;

--- a/OrbitCore/TracepointEventBuffer.h
+++ b/OrbitCore/TracepointEventBuffer.h
@@ -18,7 +18,7 @@ class TracepointEventBuffer {
   TracepointEventBuffer() : max_time_(0), min_time_(std::numeric_limits<uint64_t>::max()) {}
 
   void AddTracepointEventAndMapToThreads(uint64_t time, uint64_t tracepoint_hash, int32_t thread_id,
-                                         bool is_same_pid_as_target);
+                                         int32_t process_id, bool is_same_pid_as_target);
 
   [[nodiscard]] const std::map<uint64_t, orbit_client_protos::TracepointEventInfo>&
   GetTracepointsOfThread(int32_t thread_id) const;

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -213,7 +213,7 @@ void OrbitApp::OnTracepointEvent(orbit_client_protos::TracepointEventInfo tracep
 
   capture_data_.AddTracepointEventAndMapToThreads(
       tracepoint_event_info.time(), tracepoint_event_info.tracepoint_info_key(),
-      tracepoint_event_info.tid(), tracepoint_event_info.pid(), is_same_pid_as_target);
+      tracepoint_event_info.pid(), tracepoint_event_info.tid(), is_same_pid_as_target);
 }
 
 void OrbitApp::OnValidateFramePointers(std::vector<std::shared_ptr<Module>> modules_to_validate) {

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -208,9 +208,13 @@ void OrbitApp::OnUniqueTracepointInfo(uint64_t key,
 }
 
 void OrbitApp::OnTracepointEvent(orbit_client_protos::TracepointEventInfo tracepoint_event_info) {
-  capture_data_.AddTracepointEventAndMapToThreads(tracepoint_event_info.time(),
-                                                  tracepoint_event_info.tracepoint_info_key(),
-                                                  tracepoint_event_info.tid());
+  int32_t capture_process_id = capture_data_.process_id();
+  bool is_same_pid_as_target =
+      capture_process_id == 0 || capture_process_id == tracepoint_event_info.pid();
+
+  capture_data_.AddTracepointEventAndMapToThreads(
+      tracepoint_event_info.time(), tracepoint_event_info.tracepoint_info_key(),
+      tracepoint_event_info.tid(), is_same_pid_as_target);
 }
 
 void OrbitApp::OnValidateFramePointers(std::vector<std::shared_ptr<Module>> modules_to_validate) {

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -209,12 +209,11 @@ void OrbitApp::OnUniqueTracepointInfo(uint64_t key,
 
 void OrbitApp::OnTracepointEvent(orbit_client_protos::TracepointEventInfo tracepoint_event_info) {
   int32_t capture_process_id = capture_data_.process_id();
-  bool is_same_pid_as_target =
-      capture_process_id == 0 || capture_process_id == tracepoint_event_info.pid();
+  bool is_same_pid_as_target = capture_process_id == tracepoint_event_info.pid();
 
   capture_data_.AddTracepointEventAndMapToThreads(
       tracepoint_event_info.time(), tracepoint_event_info.tracepoint_info_key(),
-      tracepoint_event_info.tid(), is_same_pid_as_target);
+      tracepoint_event_info.tid(), tracepoint_event_info.pid(), is_same_pid_as_target);
 }
 
 void OrbitApp::OnValidateFramePointers(std::vector<std::shared_ptr<Module>> modules_to_validate) {


### PR DESCRIPTION
In the tracepoint track responsible for all the threads running on the process being profiled (such as OrbitALL) , filter the tracepoint events based on process id. This is necessary since the events are collected system-wide not process specific. Without this filtering, on that track would be displayed all the tracepoints in the whole system instead of for the process being profiled. 