### PR TITLE
Don't show percentage "Of parent" for a thread in the top-down view

### DIFF
--- a/OrbitQt/TopDownViewItemModel.cpp
+++ b/OrbitQt/TopDownViewItemModel.cpp
@@ -31,8 +31,6 @@ QVariant TopDownViewItemModel::GetDisplayRoleData(const QModelIndex& index) cons
         return QString::fromStdString(absl::StrFormat(
             "%.2f%% (%llu)", thread_item->GetInclusivePercent(top_down_view_->sample_count()),
             thread_item->sample_count()));
-      case kOfParent:
-        return QString::fromStdString(absl::StrFormat("%.2f%%", thread_item->GetPercentOfParent()));
     }
   } else if (function_item != nullptr) {
     switch (index.column()) {
@@ -71,8 +69,6 @@ QVariant TopDownViewItemModel::GetEditRoleData(const QModelIndex& index) const {
         return thread_item->thread_id();
       case kInclusive:
         return thread_item->GetInclusivePercent(top_down_view_->sample_count());
-      case kOfParent:
-        return thread_item->GetPercentOfParent();
     }
   } else if (function_item != nullptr) {
     switch (index.column()) {


### PR DESCRIPTION
For a thread, this is the same as the "Inclusive" percentage, i.e. the number of
samples collected from this thread over the total number of samples. It's
confusing to have the value twice.