### PR TITLE
Interactively render the tracepoint tracks

### DIFF
--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -19,7 +19,7 @@ ThreadTrack::ThreadTrack(TimeGraph* time_graph, int32_t thread_id) : TimerTrack(
   event_track_ = std::make_shared<EventTrack>(time_graph);
   event_track_->SetThreadId(thread_id);
 
-  tracepoint_track_ = std::make_shared<TracepointTrack>(time_graph);
+  tracepoint_track_ = std::make_shared<TracepointTrack>(time_graph, thread_id);
   tracepoint_track_->SetThreadId(thread_id);
 }
 
@@ -157,7 +157,6 @@ void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, Picking
   tracepoint_track_->SetPos(pos_[0], pos_[1]);
   tracepoint_track_->UpdatePrimitives(min_tick, max_tick, picking_mode);
 
-  TimerTrack::SetTracepointTrack(tracepoint_track_);
   TimerTrack::UpdatePrimitives(min_tick, max_tick, picking_mode);
 }
 
@@ -230,4 +229,10 @@ float ThreadTrack::GetHeight() const {
   return layout.GetTextBoxHeight() * depth +
          (depth > 0 ? layout.GetSpaceBetweenTracksAndThread() : 0) + layout.GetEventTrackHeight() +
          layout.GetTrackBottomMargin() + tracepoint_track_->GetHeight();
+}
+
+const float ThreadTrack::GetHeaderHeight() const {
+  TimeGraphLayout& layout = time_graph_->GetLayout();
+
+  return layout.GetEventTrackHeight() + tracepoint_track_->GetHeight();
 }

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -159,7 +159,7 @@ void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, Picking
   TimerTrack::UpdatePrimitives(min_tick, max_tick, picking_mode);
 }
 
-void ThreadTrack::SetEventTrackColor(Color color) {
+void ThreadTrack::SetTrackColor(Color color) {
   ScopeLock lock(mutex_);
   event_track_->SetColor(color);
   tracepoint_track_->SetColor(color);
@@ -222,9 +222,9 @@ std::string ThreadTrack::GetTooltip() const {
 
 float ThreadTrack::GetHeight() const {
   TimeGraphLayout& layout = time_graph_->GetLayout();
-  bool is_collapsed = collapse_toggle_->IsCollapsed();
-  uint32_t collapsed_depth = (GetNumTimers() == 0) ? 0 : 1;
-  uint32_t depth = is_collapsed ? collapsed_depth : GetDepth();
+  const bool is_collapsed = collapse_toggle_->IsCollapsed();
+  const uint32_t collapsed_depth = (GetNumTimers() == 0) ? 0 : 1;
+  const uint32_t depth = is_collapsed ? collapsed_depth : GetDepth();
   return layout.GetTextBoxHeight() * depth +
          (depth > 0 ? layout.GetSpaceBetweenTracksAndThread() : 0) + layout.GetEventTrackHeight() +
          layout.GetTrackBottomMargin() + tracepoint_track_->GetHeight();

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -20,7 +20,6 @@ ThreadTrack::ThreadTrack(TimeGraph* time_graph, int32_t thread_id) : TimerTrack(
   event_track_->SetThreadId(thread_id);
 
   tracepoint_track_ = std::make_shared<TracepointTrack>(time_graph, thread_id);
-  tracepoint_track_->SetThreadId(thread_id);
 }
 
 const TextBox* ThreadTrack::GetLeft(const TextBox* text_box) const {

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -230,7 +230,7 @@ float ThreadTrack::GetHeight() const {
          layout.GetTrackBottomMargin() + tracepoint_track_->GetHeight();
 }
 
-const float ThreadTrack::GetHeaderHeight() const {
+float ThreadTrack::GetHeaderHeight() const {
   TimeGraphLayout& layout = time_graph_->GetLayout();
 
   return layout.GetEventTrackHeight() + tracepoint_track_->GetHeight();

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -41,6 +41,8 @@ class ThreadTrack : public TimerTrack {
 
   [[nodiscard]] float GetHeight() const override;
 
+  const float GetHeaderHeight() const override;
+
   std::shared_ptr<EventTrack> event_track_;
   std::shared_ptr<TracepointTrack> tracepoint_track_;
 };

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -39,7 +39,10 @@ class ThreadTrack : public TimerTrack {
                         TextBox* text_box) override;
   [[nodiscard]] std::string GetBoxTooltip(PickingId id) const override;
 
+  [[nodiscard]] float GetHeight() const override;
+
   std::shared_ptr<EventTrack> event_track_;
+  std::shared_ptr<TracepointTrack> tracepoint_track_;
 };
 
 #endif  // ORBIT_GL_THREAD_TRACK_H_

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -26,7 +26,7 @@ class ThreadTrack : public TimerTrack {
   void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
 
   void UpdateBoxHeight() override;
-  void SetEventTrackColor(Color color);
+  void SetTrackColor(Color color);
   [[nodiscard]] bool IsEmpty() const override;
 
   void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode) override;

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -41,7 +41,7 @@ class ThreadTrack : public TimerTrack {
 
   [[nodiscard]] float GetHeight() const override;
 
-  const float GetHeaderHeight() const override;
+  [[nodiscard]] float GetHeaderHeight() const override;
 
   std::shared_ptr<EventTrack> event_track_;
   std::shared_ptr<TracepointTrack> tracepoint_track_;

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -810,7 +810,7 @@ std::shared_ptr<ThreadTrack> TimeGraph::GetOrCreateThreadTrack(int32_t tid) {
     track = std::make_shared<ThreadTrack>(this, tid);
     tracks_.emplace_back(track);
     thread_tracks_[tid] = track;
-    track->SetEventTrackColor(GetThreadColor(tid));
+    track->SetTrackColor(GetThreadColor(tid));
   }
   return track;
 }

--- a/OrbitGl/TimerTrack.cpp
+++ b/OrbitGl/TimerTrack.cpp
@@ -55,8 +55,13 @@ float TimerTrack::GetYFromDepth(uint32_t depth) const {
     box_height /= static_cast<float>(depth_);
   }
 
-  return pos_[1] - layout.GetEventTrackHeight() - layout.GetSpaceBetweenTracksAndThread() -
-         box_height * (depth + 1);
+  float tracepoint_track_space = tracepoint_track_->GetEventTrackHeightAndExtraSpace();
+  float space_between_tracks_and_thread = layout.GetSpaceBetweenTracksAndThread();
+
+  return pos_[1] - layout.GetEventTrackHeight() - space_between_tracks_and_thread -
+         box_height * (depth + 1) -
+         (tracepoint_track_space > 0 ? tracepoint_track_space + space_between_tracks_and_thread
+                                     : 0);
 }
 
 void TimerTrack::UpdateBoxHeight() { box_height_ = time_graph_->GetLayout().GetTextBoxHeight(); }
@@ -172,16 +177,6 @@ void TimerTrack::OnTimer(const TimerInfo& timer_info) {
 std::string TimerTrack::GetTooltip() const {
   return "Shows collected samples and timings from dynamically instrumented "
          "functions";
-}
-
-float TimerTrack::GetHeight() const {
-  TimeGraphLayout& layout = time_graph_->GetLayout();
-  bool is_collapsed = collapse_toggle_->IsCollapsed();
-  uint32_t collapsed_depth = (GetNumTimers() == 0) ? 0 : 1;
-  uint32_t depth = is_collapsed ? collapsed_depth : GetDepth();
-  return layout.GetTextBoxHeight() * depth +
-         (depth > 0 ? layout.GetSpaceBetweenTracksAndThread() : 0) + layout.GetEventTrackHeight() +
-         layout.GetTrackBottomMargin();
 }
 
 std::vector<std::shared_ptr<TimerChain>> TimerTrack::GetTimers() {

--- a/OrbitGl/TimerTrack.cpp
+++ b/OrbitGl/TimerTrack.cpp
@@ -55,13 +55,8 @@ float TimerTrack::GetYFromDepth(uint32_t depth) const {
     box_height /= static_cast<float>(depth_);
   }
 
-  float tracepoint_track_space = tracepoint_track_->GetEventTrackHeightAndExtraSpace();
-  float space_between_tracks_and_thread = layout.GetSpaceBetweenTracksAndThread();
-
-  return pos_[1] - layout.GetEventTrackHeight() - space_between_tracks_and_thread -
-         box_height * (depth + 1) -
-         (tracepoint_track_space > 0 ? tracepoint_track_space + space_between_tracks_and_thread
-                                     : 0);
+  return pos_[1] - GetHeaderHeight() - layout.GetSpaceBetweenTracksAndThread() -
+         box_height * (depth + 1);
 }
 
 void TimerTrack::UpdateBoxHeight() { box_height_ = time_graph_->GetLayout().GetTextBoxHeight(); }
@@ -252,3 +247,8 @@ std::vector<std::shared_ptr<TimerChain>> TimerTrack::GetAllChains() {
 bool TimerTrack::IsEmpty() const { return GetNumTimers() == 0; }
 
 std::string TimerTrack::GetBoxTooltip(PickingId /*id*/) const { return ""; }
+
+const float TimerTrack::GetHeaderHeight() const {
+  const TimeGraphLayout& layout = time_graph_->GetLayout();
+  return layout.GetEventTrackHeight();
+}

--- a/OrbitGl/TimerTrack.cpp
+++ b/OrbitGl/TimerTrack.cpp
@@ -248,7 +248,7 @@ bool TimerTrack::IsEmpty() const { return GetNumTimers() == 0; }
 
 std::string TimerTrack::GetBoxTooltip(PickingId /*id*/) const { return ""; }
 
-const float TimerTrack::GetHeaderHeight() const {
+float TimerTrack::GetHeaderHeight() const {
   const TimeGraphLayout& layout = time_graph_->GetLayout();
   return layout.GetEventTrackHeight();
 }

--- a/OrbitGl/TimerTrack.h
+++ b/OrbitGl/TimerTrack.h
@@ -66,6 +66,8 @@ class TimerTrack : public Track {
   virtual void UpdateBoxHeight();
   [[nodiscard]] virtual float GetYFromDepth(uint32_t depth) const;
 
+  virtual const float GetHeaderHeight() const;
+
  protected:
   [[nodiscard]] virtual bool IsTimerActive(
       const orbit_client_protos::TimerInfo& /*timer_info*/) const {
@@ -92,13 +94,6 @@ class TimerTrack : public Track {
 
   [[nodiscard]] virtual std::string GetBoxTooltip(PickingId id) const;
   float box_height_;
-
-  void SetTracepointTrack(std::shared_ptr<TracepointTrack> tracepoint_track) {
-    this->tracepoint_track_ = tracepoint_track;
-  }
-
- private:
-  std::shared_ptr<TracepointTrack> tracepoint_track_;
 };
 
 #endif  // ORBIT_GL_TIMER_TRACK_H_

--- a/OrbitGl/TimerTrack.h
+++ b/OrbitGl/TimerTrack.h
@@ -14,6 +14,7 @@
 #include "TextBox.h"
 #include "Threading.h"
 #include "TimerChain.h"
+#include "TracepointTrack.h"
 #include "Track.h"
 #include "capture_data.pb.h"
 
@@ -33,7 +34,6 @@ class TimerTrack : public Track {
   void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
                         PickingMode /*picking_mode*/) override;
   [[nodiscard]] Type GetType() const override { return kTimerTrack; }
-  [[nodiscard]] float GetHeight() const override;
 
   [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetTimers() override;
   [[nodiscard]] uint32_t GetDepth() const { return depth_; }
@@ -92,6 +92,13 @@ class TimerTrack : public Track {
 
   [[nodiscard]] virtual std::string GetBoxTooltip(PickingId id) const;
   float box_height_;
+
+  void SetTracepointTrack(std::shared_ptr<TracepointTrack> tracepoint_track) {
+    this->tracepoint_track_ = tracepoint_track;
+  }
+
+ private:
+  std::shared_ptr<TracepointTrack> tracepoint_track_;
 };
 
 #endif  // ORBIT_GL_TIMER_TRACK_H_

--- a/OrbitGl/TimerTrack.h
+++ b/OrbitGl/TimerTrack.h
@@ -66,7 +66,7 @@ class TimerTrack : public Track {
   virtual void UpdateBoxHeight();
   [[nodiscard]] virtual float GetYFromDepth(uint32_t depth) const;
 
-  virtual const float GetHeaderHeight() const;
+  [[nodiscard]] virtual float GetHeaderHeight() const;
 
  protected:
   [[nodiscard]] virtual bool IsTimerActive(

--- a/OrbitGl/TracepointTrack.cpp
+++ b/OrbitGl/TracepointTrack.cpp
@@ -79,6 +79,6 @@ float TracepointTrack::GetHeight() const {
                           : 0;
 }
 
-const bool TracepointTrack::HasTracepoints() const {
+bool TracepointTrack::HasTracepoints() const {
   return !GOrbitApp->GetCaptureData().GetTracepointsOfThread(thread_id_).empty();
 }

--- a/OrbitGl/TracepointTrack.cpp
+++ b/OrbitGl/TracepointTrack.cpp
@@ -8,6 +8,43 @@
 
 TracepointTrack::TracepointTrack(TimeGraph* time_graph) : EventTrack(time_graph) {}
 
+void TracepointTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
+  if (!were_tracepoints_hit_per_thread_) {
+    const std::map<uint64_t, orbit_client_protos::TracepointEventInfo>& tracepoints =
+        GOrbitApp->GetCaptureData().GetTracepointsOfThread(thread_id_);
+
+    if (!tracepoints.empty()) {
+      were_tracepoints_hit_per_thread_ = true;
+    }
+  }
+
+  if (!were_tracepoints_hit_per_thread_) {
+    return;
+  }
+  Batcher* batcher = canvas->GetBatcher();
+
+  const float eventBarZ = picking_mode == PickingMode::kClick ? GlCanvas::kZValueEventBarPicking
+                                                              : GlCanvas::kZValueEventBar;
+  Color color = color_;
+  Box box(pos_, Vec2(size_[0], -size_[1]), eventBarZ);
+  batcher->AddBox(box, color, shared_from_this());
+
+  if (canvas->GetPickingManager().IsThisElementPicked(this)) {
+    color = Color(255, 255, 255, 255);
+  }
+
+  float x0 = pos_[0];
+  float y0 = pos_[1];
+  float x1 = x0 + size_[0];
+  float y1 = y0 - size_[1];
+
+  batcher->AddLine(pos_, Vec2(x1, y0), GlCanvas::kZValueEventBar, color, shared_from_this());
+  batcher->AddLine(Vec2(x1, y1), Vec2(x0, y1), GlCanvas::kZValueEventBar, color,
+                   shared_from_this());
+
+  canvas_ = canvas;
+}
+
 void TracepointTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode) {
   Batcher* batcher = &time_graph_->GetBatcher();
   const TimeGraphLayout& layout = time_graph_->GetLayout();
@@ -30,4 +67,28 @@ void TracepointTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, Pic
       return;
     }
   }
+}
+
+void TracepointTrack::SetPos(float x, float y) {
+  y = y - GetHeight();
+  pos_ = Vec2(x, y);
+
+  thread_name_.SetPos(pos_);
+  thread_name_.SetSize(Vec2(size_[0] * 0.3f, size_[1]));
+}
+
+float TracepointTrack::GetEventTrackHeightAndExtraSpace() const {
+  TimeGraphLayout& layout = time_graph_->GetLayout();
+
+  return were_tracepoints_hit_per_thread_ == true
+             ? layout.GetEventTrackHeight() + layout.GetSpaceBetweenTracksAndThread()
+             : 0;
+}
+
+float TracepointTrack::GetHeight() const {
+  TimeGraphLayout& layout = time_graph_->GetLayout();
+
+  return were_tracepoints_hit_per_thread_ == true
+             ? GetEventTrackHeightAndExtraSpace() + layout.GetTrackBottomMargin()
+             : 0;
 }

--- a/OrbitGl/TracepointTrack.cpp
+++ b/OrbitGl/TracepointTrack.cpp
@@ -12,9 +12,7 @@ TracepointTrack::TracepointTrack(TimeGraph* time_graph, int32_t thread_id)
 }
 
 void TracepointTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
-  HasTracepoints();
-
-  if (!has_tracepoints_) {
+  if (!HasTracepoints()) {
     return;
   }
 
@@ -77,13 +75,10 @@ void TracepointTrack::SetPos(float x, float y) {
 float TracepointTrack::GetHeight() const {
   TimeGraphLayout& layout = time_graph_->GetLayout();
 
-  return has_tracepoints_ == true
-             ? layout.GetEventTrackHeight() + layout.GetSpaceBetweenTracksAndThread()
-             : 0;
+  return HasTracepoints() ? layout.GetEventTrackHeight() + layout.GetSpaceBetweenTracksAndThread()
+                          : 0;
 }
 
-void TracepointTrack::HasTracepoints() {
-  if (!has_tracepoints_) {
-    has_tracepoints_ = !GOrbitApp->GetCaptureData().GetTracepointsOfThread(thread_id_).empty();
-  }
+const bool TracepointTrack::HasTracepoints() const {
+  return !GOrbitApp->GetCaptureData().GetTracepointsOfThread(thread_id_).empty();
 }

--- a/OrbitGl/TracepointTrack.h
+++ b/OrbitGl/TracepointTrack.h
@@ -5,19 +5,25 @@
 #ifndef ORBIT_GL_TRACEPOINT_TRACK_H_
 #define ORBIT_GL_TRACEPOINT_TRACK_H_
 
-#include "GlCanvas.h"
-#include "TimeGraph.h"
-#include "Track.h"
+#include "EventTrack.h"
 
 class TracepointTrack : public EventTrack {
  public:
   explicit TracepointTrack(TimeGraph* time_graph);
 
+  void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
+
   void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode) override;
 
   void SetPos(float x, float y);
 
-  // TODO(msandru): Override Track::Draw, Track::OnPick, Track::OnRelease(), Track::GetBoxTooltip()
+  [[nodiscard]] float GetHeight() const override;
+
+  float GetEventTrackHeightAndExtraSpace() const;
+
+  // TODO(msandru): Track::OnPick, Track::OnRelease(), Track::GetBoxTooltip()
+ private:
+  bool were_tracepoints_hit_per_thread_ = false;
 };
 
 #endif  // ORBIT_GL_TRACEPOINT_TRACK_H_

--- a/OrbitGl/TracepointTrack.h
+++ b/OrbitGl/TracepointTrack.h
@@ -21,7 +21,7 @@ class TracepointTrack : public EventTrack {
 
   // TODO(msandru): Track::OnPick, Track::OnRelease(), Track::GetBoxTooltip()
  private:
-  const bool HasTracepoints() const;
+  [[nodiscard]] bool HasTracepoints() const;
 };
 
 #endif  // ORBIT_GL_TRACEPOINT_TRACK_H_

--- a/OrbitGl/TracepointTrack.h
+++ b/OrbitGl/TracepointTrack.h
@@ -21,8 +21,7 @@ class TracepointTrack : public EventTrack {
 
   // TODO(msandru): Track::OnPick, Track::OnRelease(), Track::GetBoxTooltip()
  private:
-  void HasTracepoints();
-  bool has_tracepoints_ = false;
+  const bool HasTracepoints() const;
 };
 
 #endif  // ORBIT_GL_TRACEPOINT_TRACK_H_

--- a/OrbitGl/TracepointTrack.h
+++ b/OrbitGl/TracepointTrack.h
@@ -9,7 +9,7 @@
 
 class TracepointTrack : public EventTrack {
  public:
-  explicit TracepointTrack(TimeGraph* time_graph);
+  explicit TracepointTrack(TimeGraph* time_graph, int32_t thread_id);
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
 
@@ -19,11 +19,10 @@ class TracepointTrack : public EventTrack {
 
   [[nodiscard]] float GetHeight() const override;
 
-  float GetEventTrackHeightAndExtraSpace() const;
-
   // TODO(msandru): Track::OnPick, Track::OnRelease(), Track::GetBoxTooltip()
  private:
-  bool were_tracepoints_hit_per_thread_ = false;
+  void HasTracepoints();
+  bool has_tracepoints_ = false;
 };
 
 #endif  // ORBIT_GL_TRACEPOINT_TRACK_H_


### PR DESCRIPTION
The thread tracks are rendered every frame according to the event tracks
and the possible instrumented functions and/or activated tracepoints.

If no tracepoints have been hooked or the ones selected have 
not been activated in the profiled program, the tracepoint
track is not shown. If the selected tracepoints are activated
later in the program, the tracepoint track appears only when
 at least one tracepoint on that thread track has been hit. 
Also, the positioning of the instrumented functions depends on 
the existence of tracepoints on the corresponding thread such as 
if there were not until a certain point activated tracepoints, 
the timer track is shown below the event track and, otherwise, 
it is place below the tracepoint track.

The existence of the activated tracepoints is tested
per frame in the TracepointTrack::Draw() call and,
 if the map of tracepoints for a certain thread is empty,
it means that, for that specific thread no tracepoints
 have been hit and we do not need to display the tracepoint track.

The generic order of the tracks per thread:
* event track -> reveals the callstacks
* tracepoint track (optional) -> displaying the hit tracepoints
* timer track (optional) -> showing the instrumented functions 
in an hierarchical way

This pull request also has a refactoring component:
moving TimerTrack::GetHeight() to ThreadTrack because

_ThreadTrack_ is the only subclass of TimerTrack
that does not override the GetHeight function,
 so moving the method does not make any
 difference from the point of view of the functionality
 of the other tracks.

 _TimerTrack::GetHeight()_ used to render
 the whole thread track, including the event track
 and the timer track (instrumented functions) but
 it did not have access to the tracepoint track, and
 therefore, could not resize the thread track to
 include the tracepoint track. Since ThreadTrack
 has a shared pointer to TracepointTrack, then,
 in ThreadTrack::GetHeight() we have direct 
access to the existence or not the of activated
 tracepoints, and, as a consequence, can modify
 the layout of the thread track to support the tracepoint track.

Exemples:

Event Track + Tracepoint Track + Timer Track:
![Screenshot 2020-09-14 at 10 56 08 PM](https://user-images.githubusercontent.com/52468725/93132971-2a894300-f6df-11ea-926a-93444e3cc484.png)

Event Track + Tracepoint Track:
![Screenshot 2020-09-14 at 10 25 10 PM](https://user-images.githubusercontent.com/52468725/93133039-455bb780-f6df-11ea-8c42-382ff2557327.png)

Event Track + Timer Track:
![Screenshot 2020-09-14 at 10 57 21 PM](https://user-images.githubusercontent.com/52468725/93133143-67553a00-f6df-11ea-99df-23885a9aad41.png)
