### PR TITLE
Display graph track value at current x mouse position

### DIFF
--- a/OrbitGl/GraphTrack.cpp
+++ b/OrbitGl/GraphTrack.cpp
@@ -35,6 +35,13 @@ void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   float text_z = GlCanvas::kZValueText;
 
   Box box(pos_, Vec2(size_[0], -size_[1]), track_z);
+
+  // Draw label with graph value at current mouse position.
+  const Color kLabelTextColor(255, 255, 255, 255);
+  double graph_value = GetValueAtTime(time_graph_->GetCurrentMouseTimeNs());
+  canvas->GetTextRenderer().AddText(std::to_string(graph_value).c_str(), canvas->GetMouseX(), y0,
+                                    text_z, kLabelTextColor);
+
   batcher->AddBox(box, color, shared_from_this());
 
   if (canvas->GetPickingManager().IsThisElementPicked(this)) {

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -290,7 +290,7 @@ void TimeGraph::OnDrag(float a_Ratio) {
   m_MaxTimeUs = m_MinTimeUs + timeWindow;
 }
 
-double TimeGraph::GetTime(double a_Ratio) {
+double TimeGraph::GetTime(double a_Ratio) const {
   double CurrentWidth = m_MaxTimeUs - m_MinTimeUs;
   double Delta = a_Ratio * CurrentWidth;
   return m_MinTimeUs + Delta;
@@ -475,7 +475,7 @@ double TimeGraph::GetUsFromTick(uint64_t time) const {
   return TicksToMicroseconds(capture_min_timestamp_, time) - m_MinTimeUs;
 }
 
-uint64_t TimeGraph::GetTickFromWorld(float world_x) {
+uint64_t TimeGraph::GetTickFromWorld(float world_x) const {
   double ratio =
       m_WorldWidth != 0 ? static_cast<double>((world_x - m_WorldStartX) / m_WorldWidth) : 0;
   uint64_t time_span_ns = static_cast<uint64_t>(1000 * GetTime(ratio));
@@ -612,6 +612,8 @@ const std::vector<CallstackEvent>& TimeGraph::GetSelectedCallstackEvents(int32_t
 }
 
 void TimeGraph::Draw(GlCanvas* canvas, PickingMode picking_mode) {
+  current_mouse_time_ns_ = GetTickFromWorld(m_Canvas->GetMouseX());
+
   const bool picking = picking_mode != PickingMode::kNone;
   if ((!picking && m_NeedsUpdatePrimitives) || picking) {
     UpdatePrimitives(picking_mode);

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -53,7 +53,7 @@ class TimeGraph {
   int GetMarginInPixels() const { return m_Margin; }
   float GetWorldFromTick(uint64_t a_Time) const;
   float GetWorldFromUs(double a_Micros) const;
-  uint64_t GetTickFromWorld(float a_WorldX);
+  uint64_t GetTickFromWorld(float a_WorldX) const;
   uint64_t GetTickFromUs(double a_MicroSeconds) const;
   double GetUsFromTick(uint64_t time) const;
   double GetTimeWindowUs() const { return m_TimeWindowUs; }
@@ -77,7 +77,7 @@ class TimeGraph {
   void HorizontallyMoveIntoView(VisibilityType vis_type, const TextBox* text_box,
                                 double distance = 0.3);
   void VerticallyMoveIntoView(const TextBox* text_box);
-  double GetTime(double a_Ratio);
+  double GetTime(double a_Ratio) const;
   double GetTimeIntervalMicro(double a_Ratio);
   void Select(const TextBox* text_box);
   enum class JumpScope { kGlobal, kSameDepth, kSameThread, kSameFunction, kSameThreadSameFunction };
@@ -139,8 +139,9 @@ class TimeGraph {
     NeedsRedraw();
   }
 
-  uint64_t GetCaptureMin() { return capture_min_timestamp_; }
-  uint64_t GetCaptureMax() { return capture_max_timestamp_; }
+  uint64_t GetCaptureMin() const { return capture_min_timestamp_; }
+  uint64_t GetCaptureMax() const { return capture_max_timestamp_; }
+  uint64_t GetCurrentMouseTimeNs() const { return current_mouse_time_ns_; }
 
  protected:
   std::shared_ptr<SchedulerTrack> GetOrCreateSchedulerTrack();
@@ -167,6 +168,7 @@ class TimeGraph {
   double m_MaxTimeUs = 0;
   uint64_t capture_min_timestamp_ = 0;
   uint64_t capture_max_timestamp_ = 0;
+  uint64_t current_mouse_time_ns_ = 0;
   std::map<int32_t, uint32_t> m_EventCount;
   double m_TimeWindowUs = 0;
   float m_WorldStartX = 0;


### PR DESCRIPTION
With the manual instrumentation API, a user can track the values of interesting variables which Orbit will plot in graph tracks. This PR adds basic support for displaying the graph value at the current X mouse position (See picture below). This should eventually be  polished a little bit. I might need your help Pablo if you have some time.

![image](https://user-images.githubusercontent.com/3687222/93165445-f018a980-f6d0-11ea-9172-16d2c9ddda6d.png)
