### PR TITLE
Add small vertical gap between GPU events

### DIFF
--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -102,11 +102,13 @@ Color GpuTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected) con
 }
 
 float GpuTrack::GetYFromDepth(uint32_t depth) const {
+  const TimeGraphLayout& layout = time_graph_->GetLayout();
   float adjusted_depth = static_cast<float>(depth);
   if (collapse_toggle_->IsCollapsed()) {
     adjusted_depth = 0.f;
   }
-  return pos_[1] - time_graph_->GetLayout().GetTextBoxHeight() * (adjusted_depth + 1.f);
+  return pos_[1] - layout.GetTextBoxHeight() * (adjusted_depth + 1.f) -
+         adjusted_depth * layout.GetSpaceBetweenGpuDepths();
 }
 
 // When track is collapsed, only draw "hardware execution" timers.
@@ -155,7 +157,9 @@ float GpuTrack::GetHeight() const {
   TimeGraphLayout& layout = time_graph_->GetLayout();
   bool collapsed = collapse_toggle_->IsCollapsed();
   uint32_t depth = collapsed ? 1 : GetDepth();
-  return layout.GetTextBoxHeight() * depth + layout.GetTrackBottomMargin();
+  uint32_t num_gaps = depth > 0 ? depth - 1 : 0;
+  return layout.GetTextBoxHeight() * depth + (num_gaps * layout.GetSpaceBetweenGpuDepths()) +
+         layout.GetTrackBottomMargin();
 }
 
 const TextBox* GpuTrack::GetLeft(const TextBox* text_box) const {

--- a/OrbitGl/TimeGraphLayout.cpp
+++ b/OrbitGl/TimeGraphLayout.cpp
@@ -15,6 +15,7 @@ TimeGraphLayout::TimeGraphLayout() {
   m_TrackBottomMargin = 5.f;
   m_TrackTopMargin = 5.f;
   m_SpaceBetweenCores = 2.f;
+  space_between_gpu_depths_ = 2.f;
   m_SpaceBetweenTracks = 40.f;
   m_SpaceBetweenTracksAndThread = 5.f;
   m_SpaceBetweenThreadBlocks = 35.f;
@@ -53,6 +54,7 @@ bool TimeGraphLayout::DrawProperties() {
   FLOAT_SLIDER(m_EventTrackHeight);
   FLOAT_SLIDER(m_GraphTrackHeight);
   FLOAT_SLIDER(m_SpaceBetweenCores);
+  FLOAT_SLIDER(space_between_gpu_depths_);
   FLOAT_SLIDER(m_SpaceBetweenTracks);
   FLOAT_SLIDER(m_SpaceBetweenTracksAndThread);
   FLOAT_SLIDER(m_SpaceBetweenThreadBlocks);

--- a/OrbitGl/TimeGraphLayout.h
+++ b/OrbitGl/TimeGraphLayout.h
@@ -31,6 +31,7 @@ class TimeGraphLayout {
   float GetSchedulerTrackOffset() const { return m_SchedulerTrackOffset * scale_; }
   float GetSpaceBetweenTracks() const { return m_SpaceBetweenTracks * scale_; }
   float GetSpaceBetweenCores() const { return m_SpaceBetweenCores * scale_; }
+  float GetSpaceBetweenGpuDepths() const { return space_between_gpu_depths_ * scale_; }
   float GetSpaceBetweenTracksAndThread() const { return m_SpaceBetweenTracksAndThread * scale_; }
   float GetToolbarIconHeight() const { return m_ToolbarIconHeight; }
   float GetScale() const { return scale_; }
@@ -63,6 +64,7 @@ class TimeGraphLayout {
   float m_SchedulerTrackOffset;
 
   float m_SpaceBetweenCores;
+  float space_between_gpu_depths_;
   float m_SpaceBetweenTracks;
   float m_SpaceBetweenTracksAndThread;
   float m_SpaceBetweenThreadBlocks;


### PR DESCRIPTION
Although GPU events are not related, they look like a flamechart and an
user could think that an event below another could have some kind of
relationship. So, we add a small gap similar to the one in Scheduler tracks.
Related to b/168684948.

Currently:
![Screen Shot 2020-09-17 at 12 18 18](https://user-images.githubusercontent.com/8610429/93460874-342fc800-f8e4-11ea-8b0c-ec9f2d7329b5.png)

Now (distance 2 between gpu depths):
![Screen Shot 2020-09-17 at 12 19 10](https://user-images.githubusercontent.com/8610429/93460864-31cd6e00-f8e4-11ea-8974-d57b39712831.png)

Another possibility (distance 1):
![Screen Shot 2020-09-17 at 12 17 48](https://user-images.githubusercontent.com/8610429/93460878-372ab880-f8e4-11ea-99ed-31be11d1b370.png)
