### PR TITLE
Manual instrumentation "async" operation tracking

### DIFF
--- a/Orbit.h
+++ b/Orbit.h
@@ -218,6 +218,12 @@ ORBIT_STUB void TrackValue(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uin
 // NOTE: Do not use these directly, use corresponding macros instead.
 #ifndef ORBIT_API_INTERNAL_IMPL
 
+// Default values.
+constexpr const char* kNameNullPtr = nullptr;
+constexpr uint32_t kIdZero = 0;
+constexpr uint64_t kValueZero = 0;
+constexpr orbit::Color kColorAuto = orbit::Color::kAuto;
+
 inline void Start(const char* name, orbit::Color color) {
   EncodedEvent e(EventType::kScopeStart, name, 0, color);
   Start(e.args[0], e.args[1], e.args[2], e.args[3], e.args[4], e.args[5]);
@@ -228,14 +234,13 @@ inline void Stop() {
   Stop(e.args[0], e.args[1], e.args[2], e.args[3], e.args[4], e.args[5]);
 }
 
-inline void StartAsync(const char* name, uint64_t id, orbit::Color color) {
-  EncodedEvent e(EventType::kScopeStartAsync, name, /*value*/ 0, color, id);
+inline void StartAsync(const char* name, uint32_t id, orbit::Color color) {
+  EncodedEvent e(EventType::kScopeStartAsync, name, kValueZero, color, id);
   StartAsync(e.args[0], e.args[1], e.args[2], e.args[3], e.args[4], e.args[5]);
 }
 
-inline void StopAsync(uint64_t id) {
-  EncodedEvent e(EventType::kScopeStopAsync, /*name*/ nullptr, /*value*/ 0, orbit::Color::kAuto,
-                 id);
+inline void StopAsync(uint32_t id) {
+  EncodedEvent e(EventType::kScopeStopAsync, kNameNullPtr, kValueZero, kColorAuto, id);
   StopAsync(e.args[0], e.args[1], e.args[2], e.args[3], e.args[4], e.args[5]);
 }
 
@@ -244,7 +249,7 @@ inline void AsyncString(const char* str, uint32_t id, orbit::Color color) {
   constexpr size_t chunk_size = kMaxEventStringSize - 1;
   const char* end = str + strlen(str);
   while (str < end) {
-    EncodedEvent e(EventType::kString, /*name*/ nullptr, /*value*/ 0, color, id);
+    EncodedEvent e(EventType::kString, kNameNullPtr, kValueZero, color, id);
     std::strncpy(e.event.name, str, chunk_size);
     e.event.name[chunk_size] = 0;
     TrackValue(e.args[0], e.args[1], e.args[2], e.args[3], e.args[4], e.args[5]);

--- a/OrbitCaptureClient/CaptureClient.cpp
+++ b/OrbitCaptureClient/CaptureClient.cpp
@@ -87,7 +87,8 @@ void CaptureClient::Capture(int32_t process_id, std::string process_name,
     instrumented_function->set_file_path(function.loaded_module_path());
     instrumented_function->set_file_offset(FunctionUtils::Offset(function));
     instrumented_function->set_absolute_address(FunctionUtils::GetAbsoluteAddress(function));
-    instrumented_function->set_function_type(IntrumentedFunctionTypeFromOrbitType(function.type()));
+    instrumented_function->set_function_type(
+        IntrumentedFunctionTypeFromOrbitType(function.orbit_type()));
   }
 
   for (const auto& tracepoint : selected_tracepoints) {

--- a/OrbitClientProtos/capture_data.proto
+++ b/OrbitClientProtos/capture_data.proto
@@ -34,7 +34,7 @@ message FunctionInfo {
     kOrbitTimerStopAsync = 4;
     kOrbitTrackValue = 5;
   }
-  OrbitType type = 10;
+  OrbitType orbit_type = 10;
 }
 
 message CallstackEvent {

--- a/OrbitCore/FunctionUtils.cpp
+++ b/OrbitCore/FunctionUtils.cpp
@@ -24,7 +24,7 @@ uint64_t GetHash(const FunctionInfo& func) { return StringHash(func.pretty_name(
 
 uint64_t Offset(const FunctionInfo& func) { return func.address() - func.load_bias(); }
 
-bool IsOrbitFunc(const FunctionInfo& func) { return func.type() != FunctionInfo::kNone; }
+bool IsOrbitFunc(const FunctionInfo& func) { return func.orbit_type() != FunctionInfo::kNone; }
 
 std::shared_ptr<FunctionInfo> CreateFunctionInfo(std::string name, std::string pretty_name,
                                                  uint64_t address, uint64_t load_bias,
@@ -63,7 +63,7 @@ bool SetOrbitTypeFromName(FunctionInfo* func) {
   if (absl::StartsWith(name, "orbit_api::")) {
     for (auto& pair : GetFunctionNameToOrbitTypeMap()) {
       if (absl::StrContains(name, pair.first)) {
-        func->set_type(pair.second);
+        func->set_orbit_type(pair.second);
         return true;
       }
     }

--- a/OrbitCore/Utils.h
+++ b/OrbitCore/Utils.h
@@ -74,8 +74,8 @@ inline std::string GetEnvVar(const char* a_Var) {
   return var;
 }
 
-inline uint64_t StringHash(const std::string& string) {
-  return XXH64(string.data(), string.size(), 0xBADDCAFEDEAD10CC);
+inline uint64_t StringHash(std::string_view str) {
+  return XXH64(str.data(), str.size(), 0xBADDCAFEDEAD10CC);
 }
 
 template <typename T, typename U>

--- a/OrbitCore/Utils.h
+++ b/OrbitCore/Utils.h
@@ -74,8 +74,8 @@ inline std::string GetEnvVar(const char* a_Var) {
   return var;
 }
 
-inline unsigned long long StringHash(const std::string& a_String) {
-  return XXH64(a_String.data(), a_String.size(), 0xBADDCAFEDEAD10CC);
+inline uint64_t StringHash(const std::string& string) {
+  return XXH64(string.data(), string.size(), 0xBADDCAFEDEAD10CC);
 }
 
 template <typename T, typename U>

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -100,6 +100,7 @@ OrbitApp::OrbitApp(ApplicationOptions&& options,
   thread_pool_ = ThreadPool::Create(4 /*min_size*/, 256 /*max_size*/, absl::Seconds(1));
   main_thread_id_ = std::this_thread::get_id();
   data_manager_ = std::make_unique<DataManager>(main_thread_id_);
+  manual_instrumentation_manager_ = std::make_unique<ManualInstrumentationManager>();
 }
 
 OrbitApp::~OrbitApp() {

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -27,6 +27,7 @@
 #include "FunctionsDataView.h"
 #include "LiveFunctionsDataView.h"
 #include "MainThreadExecutor.h"
+#include "ManualInstrumentationManager.h"
 #include "ModulesDataView.h"
 #include "OrbitBase/Result.h"
 #include "OrbitBase/ThreadPool.h"
@@ -254,6 +255,9 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   [[nodiscard]] const std::shared_ptr<Process>& GetSelectedProcess() const {
     return data_manager_->selected_process();
   }
+  [[nodiscard]] ManualInstrumentationManager* GetManualInstrumentationManager() {
+    return manual_instrumentation_manager_.get();
+  }
 
   // TODO(kuebler): Move them to a separate controler at some point
   void SelectFunction(const orbit_client_protos::FunctionInfo& func);
@@ -361,6 +365,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   std::unique_ptr<ProcessManager> process_manager_;
   std::unique_ptr<DataManager> data_manager_;
   std::unique_ptr<CrashManager> crash_manager_;
+  std::unique_ptr<ManualInstrumentationManager> manual_instrumentation_manager_;
 
   const SymbolHelper symbol_helper_;
 

--- a/OrbitGl/AsyncTrack.cpp
+++ b/OrbitGl/AsyncTrack.cpp
@@ -52,7 +52,7 @@ void AsyncTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
   // Find the first row that that can receive the new timeslice with no overlap.
   // If none of the existing rows works, add a new row.
   uint32_t depth = 0;
-  while (max_span_time_by_depth_[depth] >= timer_info.start()) ++depth;
+  while (max_span_time_by_depth_[depth] > timer_info.start()) ++depth;
   max_span_time_by_depth_[depth] = timer_info.end();
 
   orbit_client_protos::TimerInfo new_timer_info = timer_info;

--- a/OrbitGl/AsyncTrack.cpp
+++ b/OrbitGl/AsyncTrack.cpp
@@ -1,0 +1,103 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "AsyncTrack.h"
+
+#include "App.h"
+#include "FunctionUtils.h"
+#include "GlCanvas.h"
+#include "ManualInstrumentationManager.h"
+#include "TimeGraph.h"
+#include "capture_data.pb.h"
+
+using orbit_client_protos::FunctionInfo;
+using orbit_client_protos::TimerInfo;
+
+AsyncTrack::AsyncTrack(TimeGraph* time_graph, const std::string& name) : TimerTrack(time_graph) {
+  SetName(name);
+  SetLabel(name);
+}
+
+[[nodiscard]] std::string AsyncTrack::GetBoxTooltip(PickingId id) const {
+  const TextBox* text_box = time_graph_->GetBatcher().GetTextBox(id);
+  if (text_box == nullptr) return "";
+  ManualInstrumentationManager* manager = time_graph_->GetManualInstrumentationManager();
+  orbit_api::Event event = manager->ApiEventFromTimerInfo(text_box->GetTimerInfo());
+
+  const FunctionInfo* func =
+      GOrbitApp->GetCaptureData().GetSelectedFunction(text_box->GetTimerInfo().function_address());
+
+  std::string function_name = manager->GetString(event.id);
+
+  return absl::StrFormat(
+      "<b>%s</b><br/>"
+      "<i>Timing measured through manual instrumentation</i>"
+      "<br/><br/>"
+      "<b>Module:</b> %s<br/>"
+      "<b>Time:</b> %s",
+      function_name, FunctionUtils::GetLoadedModuleName(*func),
+      GetPrettyTime(
+          TicksToDuration(text_box->GetTimerInfo().start(), text_box->GetTimerInfo().end())));
+}
+
+void AsyncTrack::UpdateBoxHeight() {
+  box_height_ = time_graph_->GetLayout().GetTextBoxHeight();
+  if (collapse_toggle_->IsCollapsed() && depth_ > 0) {
+    box_height_ /= static_cast<float>(depth_);
+  }
+}
+
+void AsyncTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
+  // Find the first row that that can receive the new timeslice with no overlap.
+  // If none of the existing rows works, add a new row.
+  uint32_t depth = 0;
+  while (max_span_time_by_depth_[depth] >= timer_info.start()) ++depth;
+  max_span_time_by_depth_[depth] = timer_info.end();
+
+  orbit_client_protos::TimerInfo new_timer_info = timer_info;
+  new_timer_info.set_depth(depth);
+  TimerTrack::OnTimer(new_timer_info);
+}
+
+void AsyncTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_us, float min_x,
+                                  TextBox* text_box) {
+  TimeGraphLayout layout = time_graph_->GetLayout();
+  std::string time = GetPrettyTime(absl::Microseconds(elapsed_us));
+  text_box->SetElapsedTimeTextLength(time.length());
+
+  orbit_api::Event event = ManualInstrumentationManager::ApiEventFromTimerInfo(timer_info);
+  std::string name = time_graph_->GetManualInstrumentationManager()->GetString(event.id);
+  std::string text = absl::StrFormat("%s %s", name, time.c_str());
+  text_box->SetText(text);
+
+  const Color kTextWhite(255, 255, 255, 255);
+  const Vec2& box_pos = text_box->GetPos();
+  const Vec2& box_size = text_box->GetSize();
+  float pos_x = std::max(box_pos[0], min_x);
+  float max_size = box_pos[0] + box_size[0] - pos_x;
+  text_renderer_->AddTextTrailingCharsPrioritized(
+      text_box->GetText().c_str(), pos_x, text_box->GetPos()[1] + layout.GetTextOffset(),
+      GlCanvas::kZValueText, kTextWhite, text_box->GetElapsedTimeTextLength(), max_size);
+}
+
+Color AsyncTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected) const {
+  const Color kInactiveColor(100, 100, 100, 255);
+  const Color kSelectionColor(0, 128, 255, 255);
+  if (is_selected) {
+    return kSelectionColor;
+  } else if (!IsTimerActive(timer_info)) {
+    return kInactiveColor;
+  }
+
+  orbit_api::Event event = ManualInstrumentationManager::ApiEventFromTimerInfo(timer_info);
+  std::string name = time_graph_->GetManualInstrumentationManager()->GetString(event.id);
+  Color color = time_graph_->GetColor(name);
+
+  constexpr uint8_t kOddAlpha = 210;
+  if (!(timer_info.depth() & 0x1)) {
+    color[3] = kOddAlpha;
+  }
+
+  return color;
+}

--- a/OrbitGl/AsyncTrack.cpp
+++ b/OrbitGl/AsyncTrack.cpp
@@ -22,13 +22,13 @@ AsyncTrack::AsyncTrack(TimeGraph* time_graph, const std::string& name) : TimerTr
 [[nodiscard]] std::string AsyncTrack::GetBoxTooltip(PickingId id) const {
   const TextBox* text_box = time_graph_->GetBatcher().GetTextBox(id);
   if (text_box == nullptr) return "";
-  ManualInstrumentationManager* manager = time_graph_->GetManualInstrumentationManager();
-  orbit_api::Event event = manager->ApiEventFromTimerInfo(text_box->GetTimerInfo());
+  auto* manual_inst_manager = GOrbitApp->GetManualInstrumentationManager();
+  orbit_api::Event event = manual_inst_manager->ApiEventFromTimerInfo(text_box->GetTimerInfo());
 
   const FunctionInfo* func =
       GOrbitApp->GetCaptureData().GetSelectedFunction(text_box->GetTimerInfo().function_address());
 
-  std::string function_name = manager->GetString(event.id);
+  std::string function_name = manual_inst_manager->GetString(event.id);
 
   return absl::StrFormat(
       "<b>%s</b><br/>"
@@ -67,7 +67,7 @@ void AsyncTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_us
   text_box->SetElapsedTimeTextLength(time.length());
 
   orbit_api::Event event = ManualInstrumentationManager::ApiEventFromTimerInfo(timer_info);
-  std::string name = time_graph_->GetManualInstrumentationManager()->GetString(event.id);
+  std::string name = GOrbitApp->GetManualInstrumentationManager()->GetString(event.id);
   std::string text = absl::StrFormat("%s %s", name, time.c_str());
   text_box->SetText(text);
 
@@ -91,7 +91,7 @@ Color AsyncTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected) c
   }
 
   orbit_api::Event event = ManualInstrumentationManager::ApiEventFromTimerInfo(timer_info);
-  std::string name = time_graph_->GetManualInstrumentationManager()->GetString(event.id);
+  std::string name = GOrbitApp->GetManualInstrumentationManager()->GetString(event.id);
   Color color = time_graph_->GetColor(name);
 
   constexpr uint8_t kOddAlpha = 210;

--- a/OrbitGl/AsyncTrack.cpp
+++ b/OrbitGl/AsyncTrack.cpp
@@ -25,6 +25,8 @@ AsyncTrack::AsyncTrack(TimeGraph* time_graph, const std::string& name) : TimerTr
   auto* manual_inst_manager = GOrbitApp->GetManualInstrumentationManager();
   orbit_api::Event event = manual_inst_manager->ApiEventFromTimerInfo(text_box->GetTimerInfo());
 
+  // The FunctionInfo here corresponds to one of the automatically instrumented empty stubs from
+  // Orbit.h. Use it to retrieve the module from which the manually instrumented scope originated.
   const FunctionInfo* func =
       GOrbitApp->GetCaptureData().GetSelectedFunction(text_box->GetTimerInfo().function_address());
   std::string module_name = FunctionUtils::GetLoadedModuleName(*func);

--- a/OrbitGl/AsyncTrack.cpp
+++ b/OrbitGl/AsyncTrack.cpp
@@ -27,7 +27,7 @@ AsyncTrack::AsyncTrack(TimeGraph* time_graph, const std::string& name) : TimerTr
 
   const FunctionInfo* func =
       GOrbitApp->GetCaptureData().GetSelectedFunction(text_box->GetTimerInfo().function_address());
-
+  std::string module_name = FunctionUtils::GetLoadedModuleName(*func);
   std::string function_name = manual_inst_manager->GetString(event.id);
 
   return absl::StrFormat(
@@ -36,7 +36,7 @@ AsyncTrack::AsyncTrack(TimeGraph* time_graph, const std::string& name) : TimerTr
       "<br/><br/>"
       "<b>Module:</b> %s<br/>"
       "<b>Time:</b> %s",
-      function_name, FunctionUtils::GetLoadedModuleName(*func),
+      function_name, module_name,
       GetPrettyTime(
           TicksToDuration(text_box->GetTimerInfo().start(), text_box->GetTimerInfo().end())));
 }

--- a/OrbitGl/AsyncTrack.h
+++ b/OrbitGl/AsyncTrack.h
@@ -7,7 +7,7 @@
 
 #include <string>
 
-#include "ThreadTrack.h"
+#include "TimerTrack.h"
 
 class AsyncTrack : public TimerTrack {
  public:
@@ -24,6 +24,7 @@ class AsyncTrack : public TimerTrack {
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
                                     bool is_selected) const override;
 
+  // Used for determining what row can receive a new timer with no overlap.
   absl::flat_hash_map<uint32_t, uint64_t> max_span_time_by_depth_;
 };
 

--- a/OrbitGl/AsyncTrack.h
+++ b/OrbitGl/AsyncTrack.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_ASYNC_TRACK_H_
+#define ORBIT_GL_ASYNC_TRACK_H_
+
+#include <string>
+
+#include "ThreadTrack.h"
+
+class AsyncTrack : public TimerTrack {
+ public:
+  AsyncTrack(TimeGraph* time_graph, const std::string& name);
+
+  [[nodiscard]] Type GetType() const override { return kAsyncTrack; };
+  [[nodiscard]] std::string GetBoxTooltip(PickingId id) const override;
+  void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
+  void UpdateBoxHeight() override;
+
+ protected:
+  void SetTimesliceText(const orbit_client_protos::TimerInfo& timer, double elapsed_us, float min_x,
+                        TextBox* text_box) override;
+  [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
+                                    bool is_selected) const override;
+
+  absl::flat_hash_map<uint32_t, uint64_t> max_span_time_by_depth_;
+};
+
+#endif  // ORBIT_GL_ASYNC_TRACK_H_

--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -12,6 +12,7 @@ target_compile_options(OrbitGl PRIVATE ${STRICT_COMPILE_FLAGS})
 target_sources(
   OrbitGl
   PUBLIC App.h
+         AsyncTrack.h
          Batcher.h
          CallStackDataView.h
          CaptureWindow.h
@@ -63,6 +64,7 @@ target_sources(
 target_sources(
   OrbitGl
   PRIVATE App.cpp
+          AsyncTrack.cpp
           Batcher.cpp
           CallStackDataView.cpp
           CaptureWindow.cpp

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -42,11 +42,6 @@ GpuTrack::GpuTrack(TimeGraph* time_graph, std::shared_ptr<StringManager> string_
     : TimerTrack(time_graph) {
   text_renderer_ = time_graph->GetTextRenderer();
   timeline_hash_ = timeline_hash;
-
-  num_timers_ = 0;
-  min_time_ = std::numeric_limits<uint64_t>::max();
-  max_time_ = std::numeric_limits<uint64_t>::min();
-
   string_manager_ = string_manager;
 
   // Gpu tracks are collapsed by default.

--- a/OrbitGl/ManualInstrumentationManager.cpp
+++ b/OrbitGl/ManualInstrumentationManager.cpp
@@ -3,3 +3,54 @@
 // found in the LICENSE file.
 
 #include "ManualInstrumentationManager.h"
+
+using orbit_client_protos::TimerInfo;
+
+ManualInstrumentationManager::ManualInstrumentationManager(TimerInfoCallback callback) {
+  timer_info_callback_ = callback;
+}
+
+orbit_api::Event ManualInstrumentationManager::ApiEventFromTimerInfo(
+    const orbit_client_protos::TimerInfo& timer_info) {
+  // On x64 Linux, 6 registers are used for integer argument passing.
+  // Manual instrumentation uses those registers to encode orbit_api::Event
+  // objects.
+  constexpr size_t kNumIntegerRegisers = 6;
+  CHECK(timer_info.registers_size() == kNumIntegerRegisers);
+  uint64_t arg_0 = timer_info.registers(0);
+  uint64_t arg_1 = timer_info.registers(1);
+  uint64_t arg_2 = timer_info.registers(2);
+  uint64_t arg_3 = timer_info.registers(3);
+  uint64_t arg_4 = timer_info.registers(4);
+  uint64_t arg_5 = timer_info.registers(5);
+  orbit_api::EncodedEvent encoded_event(arg_0, arg_1, arg_2, arg_3, arg_4, arg_5);
+  return encoded_event.event;
+}
+
+void ManualInstrumentationManager::ProcessAsyncTimer(
+    const orbit_client_protos::TimerInfo& timer_info) {
+  orbit_api::Event event = ApiEventFromTimerInfo(timer_info);
+  if (event.type == orbit_api::kScopeStartAsync) {
+    async_timer_info_start_by_id_[event.id] = timer_info;
+  } else if (event.type == orbit_api::kScopeStopAsync) {
+    auto it = async_timer_info_start_by_id_.find(event.id);
+    if (it != async_timer_info_start_by_id_.end()) {
+      const TimerInfo& start_timer_info = it->second;
+      orbit_api::Event start_event = ApiEventFromTimerInfo(start_timer_info);
+
+      TimerInfo async_span = start_timer_info;
+      async_span.set_end(timer_info.end());
+      timer_info_callback_(start_event.name, async_span);
+    }
+  }
+}
+
+void ManualInstrumentationManager::ProcessStringEvent(const orbit_api::Event& event) {
+  // A string can be sent in chunks so we append the current value to any existing one.
+  auto result = string_manager_.Get(event.id);
+  if (result.has_value()) {
+    string_manager_.AddOrReplace(event.id, result.value() + event.name);
+  } else {
+    string_manager_.AddOrReplace(event.id, event.name);
+  }
+}

--- a/OrbitGl/ManualInstrumentationManager.h
+++ b/OrbitGl/ManualInstrumentationManager.h
@@ -7,26 +7,26 @@
 
 #include "../Orbit.h"
 #include "OrbitBase/Logging.h"
+#include "StringManager.h"
+#include "absl/container/flat_hash_map.h"
 #include "capture_data.pb.h"
 
 class ManualInstrumentationManager {
  public:
+  using TimerInfoCallback = std::function<void(const std::string& name,
+                                               const orbit_client_protos::TimerInfo& timer_info)>;
+  ManualInstrumentationManager(TimerInfoCallback callback);
+
+  void ProcessAsyncTimer(const orbit_client_protos::TimerInfo& timer_info);
+  void ProcessStringEvent(const orbit_api::Event& event);
+  [[nodiscard]] std::string GetString(uint32_t id) { return string_manager_.Get(id).value_or(""); }
   [[nodiscard]] static orbit_api::Event ApiEventFromTimerInfo(
-      const orbit_client_protos::TimerInfo& timer_info) {
-    // On x64 Linux, 6 registers are used for integer argument passing.
-    // Manual instrumentation uses those registers to encode orbit_api::Event
-    // objects.
-    constexpr size_t kNumIntegerRegisers = 6;
-    CHECK(timer_info.registers_size() == kNumIntegerRegisers);
-    uint64_t arg_0 = timer_info.registers(0);
-    uint64_t arg_1 = timer_info.registers(1);
-    uint64_t arg_2 = timer_info.registers(2);
-    uint64_t arg_3 = timer_info.registers(3);
-    uint64_t arg_4 = timer_info.registers(4);
-    uint64_t arg_5 = timer_info.registers(5);
-    orbit_api::EncodedEvent encoded_event(arg_0, arg_1, arg_2, arg_3, arg_4, arg_5);
-    return encoded_event.event;
-  }
+      const orbit_client_protos::TimerInfo& timer_info);
+
+ private:
+  TimerInfoCallback timer_info_callback_;
+  absl::flat_hash_map<uint32_t, orbit_client_protos::TimerInfo> async_timer_info_start_by_id_;
+  StringManager string_manager_;
 };
 
 #endif  // ORBIT_GL_MANUAL_INSTRUMENTATION_MANAGER_H_

--- a/OrbitGl/ManualInstrumentationManager.h
+++ b/OrbitGl/ManualInstrumentationManager.h
@@ -9,24 +9,32 @@
 #include "OrbitBase/Logging.h"
 #include "StringManager.h"
 #include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/synchronization/mutex.h"
 #include "capture_data.pb.h"
 
 class ManualInstrumentationManager {
  public:
-  using TimerInfoCallback = std::function<void(const std::string& name,
-                                               const orbit_client_protos::TimerInfo& timer_info)>;
-  ManualInstrumentationManager(TimerInfoCallback callback);
+  ManualInstrumentationManager() = default;
 
+  using AsyncTimerInfoListener = std::function<void(
+      const std::string& name, const orbit_client_protos::TimerInfo& timer_info)>;
+
+  void AddAsyncTimerListener(AsyncTimerInfoListener* listener);
+  void RemoveAsyncTimerListener(AsyncTimerInfoListener* listener);
   void ProcessAsyncTimer(const orbit_client_protos::TimerInfo& timer_info);
   void ProcessStringEvent(const orbit_api::Event& event);
-  [[nodiscard]] std::string GetString(uint32_t id) { return string_manager_.Get(id).value_or(""); }
+  [[nodiscard]] std::string GetString(uint32_t id) const {
+    return string_manager_.Get(id).value_or("");
+  }
   [[nodiscard]] static orbit_api::Event ApiEventFromTimerInfo(
       const orbit_client_protos::TimerInfo& timer_info);
 
  private:
-  TimerInfoCallback timer_info_callback_;
+  absl::flat_hash_set<AsyncTimerInfoListener*> async_timer_info_listeners_;
   absl::flat_hash_map<uint32_t, orbit_client_protos::TimerInfo> async_timer_info_start_by_id_;
   StringManager string_manager_;
+  absl::Mutex mutex_;
 };
 
 #endif  // ORBIT_GL_MANUAL_INSTRUMENTATION_MANAGER_H_

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -57,7 +57,7 @@ std::string ThreadTrack::GetBoxTooltip(PickingId id) const {
   }
 
   std::string function_name;
-  bool is_manual = func->type() == orbit_client_protos::FunctionInfo::kOrbitTimerStart;
+  bool is_manual = func->orbit_type() == orbit_client_protos::FunctionInfo::kOrbitTimerStart;
   if (is_manual) {
     const TimerInfo& timer_info = text_box->GetTimerInfo();
     auto api_event = ManualInstrumentationManager::ApiEventFromTimerInfo(timer_info);
@@ -87,7 +87,7 @@ bool ThreadTrack::IsTimerActive(const TimerInfo& timer_info) const {
 
 [[nodiscard]] static inline std::optional<Color> GetUserColor(const TimerInfo& timer_info,
                                                               const FunctionInfo& function_info) {
-  FunctionInfo::OrbitType type = function_info.type();
+  FunctionInfo::OrbitType type = function_info.orbit_type();
   if (type != FunctionInfo::kOrbitTimerStart && type != FunctionInfo::kOrbitTimerStartAsync) {
     return std::nullopt;
   }
@@ -178,7 +178,7 @@ void ThreadTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_u
     if (func) {
       std::string extra_info = GetExtraInfo(timer_info);
       std::string name;
-      if (func->type() == FunctionInfo::kOrbitTimerStart) {
+      if (func->orbit_type() == FunctionInfo::kOrbitTimerStart) {
         auto api_event = ManualInstrumentationManager::ApiEventFromTimerInfo(timer_info);
         name = api_event.name;
       } else {

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -354,6 +354,7 @@ void TimeGraph::ProcessOrbitFunctionTimer(FunctionInfo::OrbitType type,
       ProcessValueTrackingTimer(timer_info);
       break;
     case FunctionInfo::kOrbitTimerStartAsync:
+      [[fallthrough]];
     case FunctionInfo::kOrbitTimerStopAsync:
       manual_instrumentation_manager_->ProcessAsyncTimer(timer_info);
       break;

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -320,8 +320,8 @@ void TimeGraph::ProcessTimer(const TimerInfo& timer_info, const FunctionInfo* fu
     capture_max_timestamp_ = timer_info.end();
   }
 
-  if (function != nullptr && function->type() != FunctionInfo::kNone) {
-    ProcessOrbitFunctionTimer(function->type(), timer_info);
+  if (function != nullptr && function->orbit_type() != FunctionInfo::kNone) {
+    ProcessOrbitFunctionTimer(function->orbit_type(), timer_info);
   }
 
   if (timer_info.type() == TimerInfo::kGpuActivity) {

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -32,6 +32,7 @@
 class TimeGraph {
  public:
   TimeGraph();
+  ~TimeGraph();
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode = PickingMode::kNone);
   void DrawTracks(GlCanvas* canvas, PickingMode picking_mode = PickingMode::kNone);
@@ -146,10 +147,6 @@ class TimeGraph {
   uint64_t GetCaptureMax() const { return capture_max_timestamp_; }
   uint64_t GetCurrentMouseTimeNs() const { return current_mouse_time_ns_; }
 
-  ManualInstrumentationManager* GetManualInstrumentationManager() {
-    return manual_instrumentation_manager_.get();
-  }
-
  protected:
   std::shared_ptr<SchedulerTrack> GetOrCreateSchedulerTrack();
   std::shared_ptr<ThreadTrack> GetOrCreateThreadTrack(int32_t tid);
@@ -228,8 +225,8 @@ class TimeGraph {
       selected_callstack_events_per_thread_;
 
   std::shared_ptr<StringManager> string_manager_;
-  StringManager manual_instrumentation_string_manager_;
-  std::unique_ptr<ManualInstrumentationManager> manual_instrumentation_manager_;
+  ManualInstrumentationManager* manual_instrumentation_manager_;
+  std::unique_ptr<ManualInstrumentationManager::AsyncTimerInfoListener> async_timer_info_listener_;
 };
 
 extern TimeGraph* GCurrentTimeGraph;

--- a/OrbitGl/TimerTrack.cpp
+++ b/OrbitGl/TimerTrack.cpp
@@ -23,10 +23,6 @@ ABSL_FLAG(bool, show_return_values, false, "Show return values on time slices");
 
 TimerTrack::TimerTrack(TimeGraph* time_graph) : Track(time_graph) {
   text_renderer_ = time_graph->GetTextRenderer();
-
-  num_timers_ = 0;
-  min_time_ = std::numeric_limits<uint64_t>::max();
-  max_time_ = std::numeric_limits<uint64_t>::min();
 }
 
 void TimerTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
@@ -167,6 +163,16 @@ void TimerTrack::OnTimer(const TimerInfo& timer_info) {
   ++num_timers_;
   if (timer_info.start() < min_time_) min_time_ = timer_info.start();
   if (timer_info.end() > max_time_) max_time_ = timer_info.end();
+}
+
+float TimerTrack::GetHeight() const {
+  TimeGraphLayout& layout = time_graph_->GetLayout();
+  bool is_collapsed = collapse_toggle_->IsCollapsed();
+  uint32_t collapsed_depth = (GetNumTimers() == 0) ? 0 : 1;
+  uint32_t depth = is_collapsed ? collapsed_depth : GetDepth();
+  return layout.GetTextBoxHeight() * depth +
+         (depth > 0 ? layout.GetSpaceBetweenTracksAndThread() : 0) + layout.GetEventTrackHeight() +
+         layout.GetTrackBottomMargin();
 }
 
 std::string TimerTrack::GetTooltip() const {

--- a/OrbitGl/TimerTrack.h
+++ b/OrbitGl/TimerTrack.h
@@ -27,7 +27,7 @@ class TimerTrack : public Track {
 
   // Pickable
   void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
-  void OnTimer(const orbit_client_protos::TimerInfo& timer_info);
+  virtual void OnTimer(const orbit_client_protos::TimerInfo& timer_info);
   [[nodiscard]] std::string GetTooltip() const override;
 
   // Track
@@ -93,6 +93,7 @@ class TimerTrack : public Track {
   std::map<int, std::shared_ptr<TimerChain>> timers_;
 
   [[nodiscard]] virtual std::string GetBoxTooltip(PickingId id) const;
+  float GetHeight() const override;
   float box_height_;
 };
 

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -23,6 +23,9 @@ Track::Track(TimeGraph* time_graph)
   canvas_ = nullptr;
   const Color kDarkGrey(50, 50, 50, 255);
   color_ = kDarkGrey;
+  num_timers_ = 0;
+  min_time_ = std::numeric_limits<uint64_t>::max();
+  max_time_ = std::numeric_limits<uint64_t>::min();
 }
 
 std::vector<Vec2> GetRoundedCornerMask(float radius, uint32_t num_sides) {

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -31,6 +31,7 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
     kGraphTrack,
     kGpuTrack,
     kSchedulerTrack,
+    kAsyncTrack,
     kUnknown,
   };
 

--- a/OrbitTest/OrbitTest.cpp
+++ b/OrbitTest/OrbitTest.cpp
@@ -162,7 +162,7 @@ void OrbitTest::ManualInstrumentationApiTest() {
       ORBIT_DOUBLE(track_name.c_str(), cos(double_var * static_cast<double>(i)));
     }
 
-    // Asyn spans.
+    // Async spans.
     static uint32_t task_id = 0;
     size_t kNumTasksToSchedule = 10;
     for (size_t i = 0; i < kNumTasksToSchedule; ++i) {

--- a/OrbitTest/OrbitTest.cpp
+++ b/OrbitTest/OrbitTest.cpp
@@ -33,8 +33,17 @@ void SetThreadName(const std::string& a_Name) {
 #endif
 }
 
+OrbitTest::OrbitTest() { Init(); }
+
 OrbitTest::OrbitTest(uint32_t num_threads, uint32_t recurse_depth, uint32_t sleep_us)
-    : num_threads_(num_threads), recurse_depth_(recurse_depth), sleep_us_(sleep_us) {}
+    : num_threads_(num_threads), recurse_depth_(recurse_depth), sleep_us_(sleep_us) {
+  Init();
+}
+
+void OrbitTest::Init() {
+  const size_t kNumWorkers = 10;
+  thread_pool_ = ThreadPool::Create(kNumWorkers, kNumWorkers, absl::Milliseconds(500));
+}
 
 OrbitTest::~OrbitTest() {
   m_ExitRequested = true;
@@ -85,14 +94,28 @@ void NO_INLINE OrbitTest::BusyWork(uint64_t microseconds) {
   }
 }
 
-void NO_INLINE SleepFor1Ms() { std::this_thread::sleep_for(std::chrono::milliseconds(1)); }
+static void NO_INLINE SleepFor1Ms() { std::this_thread::sleep_for(std::chrono::milliseconds(1)); }
 
-void NO_INLINE SleepFor2Ms() {
+static void NO_INLINE SleepFor2Ms() {
   ORBIT_SCOPE("Sleep for two milliseconds");
   ORBIT_SCOPE_WITH_COLOR("Sleep for two milliseconds", orbit::Color::kTeal);
   ORBIT_SCOPE_WITH_COLOR("Sleep for two milliseconds", orbit::Color::kOrange);
   SleepFor1Ms();
   SleepFor1Ms();
+}
+
+static void ExecuteTask(uint32_t id) {
+  static const std::vector<uint32_t> sleep_times_ms = {10, 200, 20,  300, 60,  100, 150,
+                                                       20, 30,  320, 380, 400, 450, 500};
+  uint32_t sleep_time = sleep_times_ms[id % sleep_times_ms.size()];
+  ORBIT_START_ASYNC("ORBIT_ASYNC_TASKS", id);
+  std::this_thread::sleep_for(std::chrono::milliseconds(sleep_time));
+  std::string str = absl::StrFormat(
+      "This is a very long dynamic string: The quick brown fox jumps over the lazy dog. This "
+      "string is associated with task id %u. We slept for %u ms.",
+      id, sleep_time);
+  ORBIT_ASYNC_STRING(str.c_str(), id);
+  ORBIT_STOP_ASYNC(id);
 }
 
 void OrbitTest::ManualInstrumentationApiTest() {
@@ -139,7 +162,14 @@ void OrbitTest::ManualInstrumentationApiTest() {
       ORBIT_DOUBLE(track_name.c_str(), cos(double_var * static_cast<double>(i)));
     }
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(15));
+    // Asyn spans.
+    static uint32_t task_id = 0;
+    size_t kNumTasksToSchedule = 10;
+    for (size_t i = 0; i < kNumTasksToSchedule; ++i) {
+      uint32_t id = ++task_id;
+      thread_pool_->Schedule([id]() { ExecuteTask(id); });
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
   }
 #endif
 }

--- a/OrbitTest/OrbitTest.cpp
+++ b/OrbitTest/OrbitTest.cpp
@@ -41,8 +41,9 @@ OrbitTest::OrbitTest(uint32_t num_threads, uint32_t recurse_depth, uint32_t slee
 }
 
 void OrbitTest::Init() {
-  const size_t kNumWorkers = 100;
-  thread_pool_ = ThreadPool::Create(kNumWorkers, kNumWorkers, absl::Milliseconds(500));
+  const size_t kMinNumWorkers = 10;
+  const size_t kMaxNumWorkers = 100;
+  thread_pool_ = ThreadPool::Create(kMinNumWorkers, kMaxNumWorkers, absl::Milliseconds(500));
 }
 
 OrbitTest::~OrbitTest() {

--- a/OrbitTest/OrbitTest.cpp
+++ b/OrbitTest/OrbitTest.cpp
@@ -41,7 +41,7 @@ OrbitTest::OrbitTest(uint32_t num_threads, uint32_t recurse_depth, uint32_t slee
 }
 
 void OrbitTest::Init() {
-  const size_t kNumWorkers = 10;
+  const size_t kNumWorkers = 100;
   thread_pool_ = ThreadPool::Create(kNumWorkers, kNumWorkers, absl::Milliseconds(500));
 }
 
@@ -108,7 +108,6 @@ static void ExecuteTask(uint32_t id) {
   static const std::vector<uint32_t> sleep_times_ms = {10, 200, 20,  300, 60,  100, 150,
                                                        20, 30,  320, 380, 400, 450, 500};
   uint32_t sleep_time = sleep_times_ms[id % sleep_times_ms.size()];
-  ORBIT_START_ASYNC("ORBIT_ASYNC_TASKS", id);
   std::this_thread::sleep_for(std::chrono::milliseconds(sleep_time));
   std::string str = absl::StrFormat(
       "This is a very long dynamic string: The quick brown fox jumps over the lazy dog. This "
@@ -167,6 +166,7 @@ void OrbitTest::ManualInstrumentationApiTest() {
     size_t kNumTasksToSchedule = 10;
     for (size_t i = 0; i < kNumTasksToSchedule; ++i) {
       uint32_t id = ++task_id;
+      ORBIT_START_ASYNC("ORBIT_ASYNC_TASKS", id);
       thread_pool_->Schedule([id]() { ExecuteTask(id); });
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }

--- a/OrbitTest/OrbitTest.h
+++ b/OrbitTest/OrbitTest.h
@@ -7,15 +7,18 @@
 #include <thread>
 #include <vector>
 
+#include "OrbitBase/ThreadPool.h"
+
 class OrbitTest {
  public:
-  OrbitTest() = default;
+  OrbitTest();
   OrbitTest(uint32_t num_threads, uint32_t recurse_depth, uint32_t sleep_us);
   ~OrbitTest();
 
   void Start();
 
  private:
+  void Init();
   void Loop();
   void TestFunc(uint32_t a_Depth = 0);
   void TestFunc2(uint32_t a_Depth = 0);
@@ -28,4 +31,5 @@ class OrbitTest {
   uint32_t num_threads_ = 10;
   uint32_t recurse_depth_ = 10;
   uint32_t sleep_us_ = 100'000;
+  std::unique_ptr<ThreadPool> thread_pool_;
 };


### PR DESCRIPTION
An async operation can start in one scope and end in another,
possibly on a different thread altogether. Start and stop pairs are
matched using a user provided "id". See ASYNC_START and ASYNC_STOP
macros in Orbit.h. A new ASYNC_STRING macro allows to associate an
arbitrarily long string to an async event by specifying the event "id".

On the UI side, a new AsyncTrack takes care of displaying the async
spans in the capture view in a compact way.

See OrbitTest.cpp for example usage.

Notes:
- the async track rendering will be modified to insert a vertical gap between rows of timeslices in a subsequent PR to make it clear that the async tracks are not flame graphs.
- The color of the timeslices is chosen using the hash of their labels.

![image](https://user-images.githubusercontent.com/3687222/93529494-d5bd1680-f8f0-11ea-8048-2596ab825fef.png)
