### PR TITLE
Iterators are now in a QScrollArea

### DIFF
--- a/OrbitQt/orbiteventiterator.ui
+++ b/OrbitQt/orbiteventiterator.ui
@@ -19,6 +19,9 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
+  <property name="autoFillBackground">
+   <bool>false</bool>
+  </property>
   <property name="frameShape">
    <enum>QFrame::StyledPanel</enum>
   </property>

--- a/OrbitQt/orbitlivefunctions.cpp
+++ b/OrbitQt/orbitlivefunctions.cpp
@@ -37,7 +37,8 @@ OrbitLiveFunctions::OrbitLiveFunctions(QWidget* parent)
   all_events_iterator_->SetFunctionName("All functions");
   all_events_iterator_->HideDeleteButton();
   all_events_iterator_->DisableButtons();
-  ui->iteratorLayout->addWidget(all_events_iterator_);
+  dynamic_cast<QBoxLayout*>(ui->iteratorFrame->layout())
+      ->insertWidget(ui->iteratorFrame->layout()->count() - 1, all_events_iterator_);
 }
 
 OrbitLiveFunctions::~OrbitLiveFunctions() { delete ui; }
@@ -72,7 +73,7 @@ void OrbitLiveFunctions::AddIterator(size_t id, FunctionInfo* function) {
   iterator_ui->SetDeleteButtonCallback([this, id]() {
     this->live_functions_.OnDeleteButton(id);
     auto it = this->iterator_uis.find(id);
-    ui->iteratorLayout->removeWidget(it->second);
+    ui->iteratorFrame->layout()->removeWidget(it->second);
     it->second->deleteLater();
     iterator_uis.erase(id);
     if (iterator_uis.empty()) {
@@ -80,7 +81,7 @@ void OrbitLiveFunctions::AddIterator(size_t id, FunctionInfo* function) {
     }
   });
   iterator_ui->SetFunctionName(function->pretty_name());
-
+  
   iterator_ui->SetMinMaxTime(live_functions_.GetCaptureMin(), live_functions_.GetCaptureMax());
   iterator_ui->SetCurrentTime(live_functions_.GetStartTime(id));
 
@@ -88,7 +89,8 @@ void OrbitLiveFunctions::AddIterator(size_t id, FunctionInfo* function) {
 
   all_events_iterator_->EnableButtons();
 
-  ui->iteratorLayout->addWidget(iterator_ui);
+  dynamic_cast<QBoxLayout*>(ui->iteratorFrame->layout())
+      ->insertWidget(ui->iteratorFrame->layout()->count() - 1, iterator_ui);
 }
 
 QLineEdit* OrbitLiveFunctions::GetFilterLineEdit() {
@@ -99,7 +101,7 @@ void OrbitLiveFunctions::Reset() {
   live_functions_.Reset();
 
   for (auto& [_, iterator_ui] : iterator_uis) {
-    ui->iteratorLayout->removeWidget(iterator_ui);
+    ui->iteratorFrame->layout()->removeWidget(iterator_ui);
     delete iterator_ui;
   }
   iterator_uis.clear();

--- a/OrbitQt/orbitlivefunctions.cpp
+++ b/OrbitQt/orbitlivefunctions.cpp
@@ -81,7 +81,7 @@ void OrbitLiveFunctions::AddIterator(size_t id, FunctionInfo* function) {
     }
   });
   iterator_ui->SetFunctionName(function->pretty_name());
-  
+
   iterator_ui->SetMinMaxTime(live_functions_.GetCaptureMin(), live_functions_.GetCaptureMax());
   iterator_ui->SetCurrentTime(live_functions_.GetStartTime(id));
 

--- a/OrbitQt/orbitlivefunctions.ui
+++ b/OrbitQt/orbitlivefunctions.ui
@@ -19,7 +19,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_2">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -32,19 +32,103 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="0" column="0">
-    <widget class="OrbitDataViewPanel" name="data_view_panel_" native="true"/>
-   </item>
-   <item row="1" column="0">
-    <layout class="QVBoxLayout" name="iteratorLayout">
-     <item>
-      <widget class="QLabel" name="instructionsLabel">
-       <property name="text">
-        <string>Select functions above, right-click, and select 'Add iterator(s)' to add iterators for instrumented functions.</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+   <item>
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <widget class="OrbitDataViewPanel" name="data_view_panel_" native="true">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+     </widget>
+     <widget class="QWidget" name="verticalLayoutWidget">
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <widget class="QLabel" name="instructionsLabel">
+         <property name="styleSheet">
+          <string notr="true">margin-top: 5px;</string>
+         </property>
+         <property name="text">
+          <string>Select functions above, right-click, and select 'Add iterator(s)' to add iterators for instrumented functions.</string>
+         </property>
+         <property name="margin">
+          <number>0</number>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QScrollArea" name="iteratorScrollArea">
+         <property name="autoFillBackground">
+          <bool>true</bool>
+         </property>
+         <property name="styleSheet">
+          <string notr="true">QScrollArea {
+	border: 0;
+}</string>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QAbstractScrollArea::AdjustToContents</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="iteratorFrame">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>688</width>
+            <height>187</height>
+           </rect>
+          </property>
+          <property name="autoFillBackground">
+           <bool>false</bool>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">#iteratorFrame {
+	background-color: rgb(67, 67, 67);
+}</string>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout">
+           <property name="spacing">
+            <number>6</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <spacer name="verticalSpacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/OrbitQt/orbitsamplingreport.ui
+++ b/OrbitQt/orbitsamplingreport.ui
@@ -20,6 +20,18 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item row="0" column="1">
     <widget class="QSplitter" name="splitter">
      <property name="orientation">


### PR DESCRIPTION
Fixes the issue that iterators are appended to the live functions panel without displaying a scroll bar - the window just kept growing to fit all iterators.

To test the issue:
1) Capture with hooked functions
2) Add a bunch of iterators -> The window keeps growing and growing.

New behavior: Scrollbar appears when the available space is used up.

Fixed by adding a QScrollArea around the iterators, and some CSS to retain the original look. Also added a splitter to make the size of the Iterator area configurable. Background color of the scrollarea is hardcoded, which is a bit unfortunate, but apparently the color is not part of the palette values.

Result:
![image](https://user-images.githubusercontent.com/63750742/93743451-5da46880-fbf0-11ea-8b93-c78db443ff12.png)


