### PR TITLE
Color adjustment of Capture Window Background

### DIFF
--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -532,7 +532,6 @@ void CaptureWindow::DrawScreenSpace() {
 
   // Right vertical margin.
   time_graph_.SetRightMargin(right_margin);
-  const Color kBackgroundColor(70, 70, 70, 255);
   float margin_x1 = getWidth();
   float margin_x0 = margin_x1 - right_margin;
 
@@ -544,7 +543,8 @@ void CaptureWindow::DrawScreenSpace() {
     Box box(Vec2(0, time_graph_.GetLayout().GetSliderWidth()),
             Vec2(getWidth(), time_graph_.GetLayout().GetTimeBarHeight()),
             GlCanvas::kZValueTimeBarBg);
-    ui_batcher_.AddBox(box, Color(70, 70, 70, 200));
+    ui_batcher_.AddBox(box,
+                       Color(kBackgroundColor[0], kBackgroundColor[1], kBackgroundColor[2], 200));
   }
 }
 

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -33,6 +33,8 @@ float GlCanvas::kZValueBox = -0.03f;
 float GlCanvas::kZValueEventBar = -0.1f;
 float GlCanvas::kZValueTrack = -0.2f;
 
+const Color GlCanvas::kBackgroundColor = Color(67, 67, 67, 255);
+
 GlCanvas::GlCanvas() : ui_batcher_(BatcherId::kUi, &m_PickingManager) {
   m_TextRenderer.SetCanvas(this);
 
@@ -63,7 +65,6 @@ GlCanvas::GlCanvas() : ui_batcher_(BatcherId::kUi, &m_PickingManager) {
   m_MouseRatio = 0.0;
   m_DrawUI = true;
   m_ImguiActive = false;
-  m_BackgroundColor = Vec4(70.f / 255.f, 70.f / 255.f, 70.f / 255.f, 1.0f);
 
   static int counter = 0;
   m_ID = counter++;
@@ -272,8 +273,10 @@ void GlCanvas::prepare3DViewport(int topleft_x, int topleft_y, int bottomrigth_x
 /** Inits the OpenGL viewport for drawing in 2D. */
 void GlCanvas::prepare2DViewport(int topleft_x, int topleft_y, int bottomrigth_x,
                                  int bottomrigth_y) {
-  glClearColor(m_BackgroundColor[0], m_BackgroundColor[1], m_BackgroundColor[2],
-               m_BackgroundColor[3]);
+  glClearColor(static_cast<float>(kBackgroundColor[0]) / 255.0f,
+               static_cast<float>(kBackgroundColor[1]) / 255.0f,
+               static_cast<float>(kBackgroundColor[2]) / 255.0f,
+               static_cast<float>(kBackgroundColor[3]) / 255.0f);
   if (m_Picking) glClearColor(0.f, 0.f, 0.f, 0.f);
 
   // glEnable(GL_DEBUG_OUTPUT);

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -62,7 +62,6 @@ class GlCanvas : public GlPanel {
   void SetWorldTopLeftY(float val) { m_WorldTopLeftY = val; }
 
   TextRenderer& GetTextRenderer() { return m_TextRenderer; }
-  void SetBackgroundColor(const Vec4& a_Color) { m_BackgroundColor = a_Color; }
 
   virtual void UpdateWheelMomentum(float a_DeltaTime);
   virtual void OnTimer();
@@ -113,6 +112,8 @@ class GlCanvas : public GlPanel {
   static float kZValueEventBar;
   static float kZValueTrack;
 
+  static const Color kBackgroundColor;
+
  protected:
   [[nodiscard]] PickingMode GetPickingMode();
 
@@ -146,7 +147,6 @@ class GlCanvas : public GlPanel {
   bool m_DrawUI;
   bool m_ImguiActive;
   int m_ID;
-  Vec4 m_BackgroundColor;
 
   Timer m_HoverTimer;
   int m_HoverDelayMs;

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -108,8 +108,6 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   // Draw rounded corners.
   if (!picking) {
     float right_margin = time_graph_->GetRightMargin();
-    const Color kBackgroundColor(70, 70, 70, 255);
-
     float radius = std::min(layout.GetRoundingRadius(), half_label_height);
     radius = std::min(radius, half_label_width);
     uint32_t sides = static_cast<uint32_t>(layout.GetRoundingNumSides() + 0.5f);
@@ -123,12 +121,12 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
     float z = GlCanvas::kZValueRoundingCorner;
 
     glColor4ubv(&kTabColor[0]);
-    DrawTriangleFan(batcher, rounded_corner, bottom_left, kBackgroundColor, 0, z);
+    DrawTriangleFan(batcher, rounded_corner, bottom_left, GlCanvas::kBackgroundColor, 0, z);
     DrawTriangleFan(batcher, rounded_corner, bottom_right, kTabColor, 0, z);
-    DrawTriangleFan(batcher, rounded_corner, top_right, kBackgroundColor, 180.f, z);
-    DrawTriangleFan(batcher, rounded_corner, top_left, kBackgroundColor, -90.f, z);
-    DrawTriangleFan(batcher, rounded_corner, end_bottom, kBackgroundColor, 90.f, z);
-    DrawTriangleFan(batcher, rounded_corner, end_top, kBackgroundColor, 180.f, z);
+    DrawTriangleFan(batcher, rounded_corner, top_right, GlCanvas::kBackgroundColor, 180.f, z);
+    DrawTriangleFan(batcher, rounded_corner, top_left, GlCanvas::kBackgroundColor, -90.f, z);
+    DrawTriangleFan(batcher, rounded_corner, end_bottom, GlCanvas::kBackgroundColor, 90.f, z);
+    DrawTriangleFan(batcher, rounded_corner, end_top, GlCanvas::kBackgroundColor, 180.f, z);
   }
 
   // Collapse toggle state management.


### PR DESCRIPTION
The background color of the capture window was slightly different than the surrounding frame and the other tabs:

Surroundings: rgb(67, 67, 67)
Background: rgb(70, 70, 70)

Adjusted to make the colors match.

![image](https://user-images.githubusercontent.com/63750742/93743771-eb805380-fbf0-11ea-8af3-db04e675e6be.png)
![image](https://user-images.githubusercontent.com/63750742/93743775-f0450780-fbf0-11ea-82b0-8b2636252b34.png)
