### PR TITLE
Text rendering fix

### DIFF
--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -159,7 +159,12 @@ void Batcher::StartNewFrame() {
 
 void Batcher::Draw(bool picking) const {
   glPushAttrib(GL_ENABLE_BIT | GL_COLOR_BUFFER_BIT);
-  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+  if (picking) {
+    glDisable(GL_BLEND);
+  } else {
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+  }
   glDisable(GL_CULL_FACE);
   glEnableClientState(GL_VERTEX_ARRAY);
   glEnableClientState(GL_COLOR_ARRAY);

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -769,7 +769,7 @@ void CaptureWindow::RenderTimeBar() {
     float dummy, worldY;
     ScreenToWorld(0, screenY, dummy, worldY);
 
-    float height = ScreenToWorldHeight(static_cast<int>(GParams.font_size) + pixelMargin);
+    float height = time_graph_.GetLayout().GetTimeBarHeight() - pixelMargin;
     float xMargin = ScreenToworldWidth(4);
 
     for (int i = 0; i < numTimePoints; ++i) {
@@ -782,7 +782,7 @@ void CaptureWindow::RenderTimeBar() {
                              Color(255, 255, 255, 255));
 
       Vec2 pos(worldX, worldY);
-      ui_batcher_.AddVerticalLine(pos, height, GlCanvas::kZValueUi, Color(255, 255, 255, 255));
+      ui_batcher_.AddVerticalLine(pos, height, GlCanvas::kZValueTextUi, Color(255, 255, 255, 255));
     }
   }
 }

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -389,12 +389,12 @@ void GlCanvas::Render(int a_Width, int a_Height) {
 
   DrawScreenSpace();
 
+  // Draw remaining elements collected with the batcher.
+  ui_batcher_.Draw(GetPickingMode() != PickingMode::kNone);
+
   m_TextRenderer.Display(&ui_batcher_);
   RenderText();
   RenderUI();
-
-  // Draw remaining elements collected with the batcher.
-  ui_batcher_.Draw(GetPickingMode() != PickingMode::kNone);
 
   glFlush();
   cleanupGlState();

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -26,9 +26,10 @@ class GlCanvas : public GlPanel {
   int getWidth() const;
   int getHeight() const;
 
-  void prepare3DViewport(int topleft_x, int topleft_y, int bottomrigth_x, int bottomrigth_y);
   void prepare2DViewport(int topleft_x, int topleft_y, int bottomrigth_x, int bottomrigth_y);
   void prepareScreenSpaceViewport();
+  void prepareGlState();
+  void cleanupGlState();
   void ScreenToWorld(int x, int y, float& wx, float& wy) const;
   void WorldToScreen(float wx, float wy, int& x, int& y) const;
   int WorldToScreenHeight(float a_Height) const;

--- a/OrbitGl/TextRenderer.cpp
+++ b/OrbitGl/TextRenderer.cpp
@@ -101,7 +101,11 @@ void TextRenderer::Display(Batcher* batcher) {
   if (!m_Initialized) {
     Init();
   }
-
+  
+  glPushAttrib(GL_ENABLE_BIT | GL_COLOR_BUFFER_BIT);
+  glEnable(GL_BLEND);
+  glBlendEquation(GL_FUNC_ADD);
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
   glBindTexture(GL_TEXTURE_2D, m_Atlas->id);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
@@ -134,6 +138,8 @@ void TextRenderer::Display(Batcher* batcher) {
 
   glBindTexture(GL_TEXTURE_2D, 0);
   glUseProgram(0);
+
+  glPopAttrib();
 }
 
 void TextRenderer::DrawOutline(Batcher* batcher, vertex_buffer_t* a_Buffer) {

--- a/OrbitGl/TextRenderer.cpp
+++ b/OrbitGl/TextRenderer.cpp
@@ -101,9 +101,10 @@ void TextRenderer::Display(Batcher* batcher) {
   if (!m_Initialized) {
     Init();
   }
-  
-  glPushAttrib(GL_ENABLE_BIT | GL_COLOR_BUFFER_BIT);
+
+  glPushAttrib(GL_ENABLE_BIT | GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
   glEnable(GL_BLEND);
+  glDepthMask(GL_FALSE);
   glBlendEquation(GL_FUNC_ADD);
   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
   glBindTexture(GL_TEXTURE_2D, m_Atlas->id);

--- a/OrbitGl/TriangleToggle.cpp
+++ b/OrbitGl/TriangleToggle.cpp
@@ -32,13 +32,13 @@ void TriangleToggle::Draw(GlCanvas* canvas, PickingMode picking_mode) {
 
     Triangle triangle;
     if (state_ == State::kCollapsed) {
-      triangle =
-          Triangle(position + Vec3(-half_h, half_w, 0.f), position + Vec3(-half_h, -half_w, 0.f),
-                   position + Vec3(half_w, 0.f, 0.f));
+      triangle = Triangle(position + Vec3(-half_h, half_w, GlCanvas::kZValueUi),
+                          position + Vec3(-half_h, -half_w, GlCanvas::kZValueUi),
+                          position + Vec3(half_w, 0.f, GlCanvas::kZValueUi));
     } else {
-      triangle =
-          Triangle(position + Vec3(half_w, half_h, 0.f), position + Vec3(-half_w, half_h, 0.f),
-                   position + Vec3(0.f, -half_w, 0.f));
+      triangle = Triangle(position + Vec3(half_w, half_h, GlCanvas::kZValueUi),
+                          position + Vec3(-half_w, half_h, GlCanvas::kZValueUi),
+                          position + Vec3(0.f, -half_w, GlCanvas::kZValueUi));
     }
     batcher->AddTriangle(triangle, color, shared_from_this());
   } else {


### PR DESCRIPTION
Fixes the broken text background for the time bar.

To reproduce:
1) Load or take a capture
2) Scroll the capture window downwards to that the time bar is on top of any event bar
-> The event bar color is visible "through" the text of the time bar

Since depth write is enabled, the transparent parts of the text overwrite the existing z-values even though they are fully transparent. Commonly, depth-write is disabled for alpha-blended elements. This PR does exactly that and makes sure the text is rendered after the remaining UI elements so it is always rendered "on top".

In addition, it is taken care that all draw() functions correctly restore the GL states they touch, and this was moved into separate methods for clarity.

Before:
![image](https://user-images.githubusercontent.com/63750742/93769675-70806280-fc1b-11ea-9658-a4fcfa14d499.png)

After:
![image](https://user-images.githubusercontent.com/63750742/93770113-0d430000-fc1c-11ea-9a09-01bb8f3a0644.png)

The transparent time bar hides any text that is drawn underneath, which is imho a welcome side-effect because it improves readability of the time indicators.