### PR TITLE
Scale track text when making a vertical zoom

### DIFF
--- a/OrbitCore/Params.h
+++ b/OrbitCore/Params.h
@@ -5,8 +5,10 @@
 #ifndef ORBIT_CORE_PARAMS_H_
 #define ORBIT_CORE_PARAMS_H_
 
+#include <stdint.h>
+
 struct Params {
-  const float font_size = 14.f;
+  const uint32_t font_size = 14;
 };
 
 extern Params GParams;

--- a/OrbitGl/AsyncTrack.cpp
+++ b/OrbitGl/AsyncTrack.cpp
@@ -82,7 +82,8 @@ void AsyncTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_us
   float max_size = box_pos[0] + box_size[0] - pos_x;
   text_renderer_->AddTextTrailingCharsPrioritized(
       text_box->GetText().c_str(), pos_x, text_box->GetPos()[1] + layout.GetTextOffset(),
-      GlCanvas::kZValueText, kTextWhite, text_box->GetElapsedTimeTextLength(), max_size);
+      GlCanvas::kZValueText, kTextWhite, text_box->GetElapsedTimeTextLength(),
+      time_graph_->CalculateZoomedFontSize(), max_size);
 }
 
 Color AsyncTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected) const {

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -768,7 +768,7 @@ void CaptureWindow::RenderTimeBar() {
       std::string text = GetPrettyTime(absl::Microseconds(current_micros));
       float world_x = time_graph_.GetWorldFromUs(current_micros);
       m_TextRenderer.AddText(text.c_str(), world_x + x_margin, world_y, GlCanvas::kZValueTextUi,
-                             Color(255, 255, 255, 255));
+                             Color(255, 255, 255, 255), GParams.font_size);
 
       Vec2 pos(world_x, world_y);
       ui_batcher_.AddVerticalLine(pos, height, GlCanvas::kZValueTextUi, Color(255, 255, 255, 255));
@@ -798,7 +798,7 @@ void CaptureWindow::RenderSelectionOverlay() {
     float pos_x = pos[0] + size[0];
 
     m_TextRenderer.AddText(text.c_str(), pos_x, select_stop_[1], GlCanvas::kZValueText, text_color,
-                           size[0], true);
+                           GParams.font_size, size[0], true);
 
     const unsigned char g = 100;
     Color grey(g, g, g, 255);

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -430,17 +430,6 @@ Vec2 GlCanvas::ToWorldSpace(const Vec2& a_Point) {
   return Vec2(x, y);
 }
 
-void GlCanvas::AddText(const char* a_Text, float a_X, float a_Y, float a_Z, const Color& a_Color,
-                       float a_MaxSize, bool a_RightJustified) {
-  m_TextRenderer.AddText(a_Text, a_X, a_Y, a_Z, a_Color, a_MaxSize, a_RightJustified);
-}
-
-int GlCanvas::AddText2D(const char* a_Text, int a_X, int a_Y, float a_Z, const Color& a_Color,
-                        float a_MaxSize, bool a_RightJustified, bool a_InvertY) {
-  return m_TextRenderer.AddText2D(a_Text, a_X, a_Y, a_Z, a_Color, a_MaxSize, a_RightJustified,
-                                  a_InvertY);
-}
-
 void GlCanvas::ResetHoverTimer() {
   m_HoverTimer.Reset();
   m_CanHover = true;

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -8,7 +8,6 @@
 #include "GlPanel.h"
 #include "GlUtils.h"
 #include "ImGuiOrbit.h"
-#include "Params.h"
 #include "PickingManager.h"
 #include "ScopeTimer.h"
 #include "TextRenderer.h"

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -8,6 +8,7 @@
 #include "GlPanel.h"
 #include "GlUtils.h"
 #include "ImGuiOrbit.h"
+#include "Params.h"
 #include "PickingManager.h"
 #include "ScopeTimer.h"
 #include "TextRenderer.h"
@@ -75,11 +76,6 @@ class GlCanvas : public GlPanel {
 
   Vec2 ToScreenSpace(const Vec2& a_Point);
   Vec2 ToWorldSpace(const Vec2& a_Point);
-
-  void AddText(const char* a_Text, float a_X, float a_Y, float a_Z, const Color& a_Color,
-               float a_MaxSize = -1.f, bool a_RightJustified = false);
-  int AddText2D(const char* a_Text, int a_X, int a_Y, float a_Z, const Color& a_Color,
-                float a_MaxSize = -1.f, bool a_RightJustified = false, bool a_InvertY = true);
 
   void ResetHoverTimer();
 

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -140,7 +140,8 @@ void GpuTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_us, 
   float max_size = box_pos[0] + box_size[0] - pos_x;
   text_renderer_->AddTextTrailingCharsPrioritized(
       text_box->GetText().c_str(), pos_x, text_box->GetPos()[1] + layout.GetTextOffset(),
-      GlCanvas::kZValueText, kTextWhite, text_box->GetElapsedTimeTextLength(), max_size);
+      GlCanvas::kZValueText, kTextWhite, text_box->GetElapsedTimeTextLength(),
+      time_graph_->CalculateZoomedFontSize(), max_size);
 }
 
 std::string GpuTrack::GetTooltip() const {

--- a/OrbitGl/GraphTrack.cpp
+++ b/OrbitGl/GraphTrack.cpp
@@ -55,7 +55,8 @@ void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
 
   canvas->GetTextRenderer().AddText(std::to_string(graph_value).c_str(), white_text_box_position[0],
                                     white_text_box_position[1] + layout.GetTextOffset(),
-                                    GlCanvas::kZValueTextUi, kBlackColor, white_text_box_size[0]);
+                                    GlCanvas::kZValueTextUi, kBlackColor,
+                                    time_graph_->CalculateZoomedFontSize(), white_text_box_size[0]);
   Box white_text_box(white_text_box_position, white_text_box_size, GlCanvas::kZValueUi);
   batcher->AddBox(white_text_box, kWhiteColor, shared_from_this());
 

--- a/OrbitGl/TextRenderer.h
+++ b/OrbitGl/TextRenderer.h
@@ -25,10 +25,10 @@ class TextRenderer {
   void Init();
   void Display(Batcher* batcher);
   void AddText(const char* a_Text, float a_X, float a_Y, float a_Z, const Color& a_Color,
-               float a_MaxSize = -1.f, bool a_RightJustified = false);
+               uint32_t font_size, float a_MaxSize = -1.f, bool a_RightJustified = false);
   void AddTextTrailingCharsPrioritized(const char* a_Text, float a_X, float a_Y, float a_Z,
                                        const Color& a_Color, size_t a_TrailingCharsLength,
-                                       float a_MaxSize);
+                                       uint32_t font_size, float a_MaxSize);
   int AddText2D(const char* a_Text, int a_X, int a_Y, float a_Z, const Color& a_Color,
                 float a_MaxSize = -1.f, bool a_RightJustified = false, bool a_InvertY = true);
 
@@ -39,8 +39,8 @@ class TextRenderer {
   GlCanvas* GetCanvas() { return m_Canvas; }
   int GetNumCharacters() const;
   void ToggleDrawOutline() { m_DrawOutline = !m_DrawOutline; }
-  void SetFontSize(int a_Size);
-  int GetFontSize();
+  void SetFontSize(uint32_t a_Size);
+  uint32_t GetFontSize() const;
 
  protected:
   void AddTextInternal(texture_font_t* font, const char* text, const vec4& color, vec2* pen,
@@ -54,7 +54,7 @@ class TextRenderer {
   vertex_buffer_t* m_Buffer;
   texture_font_t* m_Font;
   std::map<int, texture_font_t*> m_FontsBySize;
-  int current_font_size_;
+  uint32_t current_font_size_;
   GlCanvas* m_Canvas;
   GLuint m_Shader;
   mat4 m_Model;

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -216,7 +216,8 @@ void ThreadTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_u
   float max_size = box_pos[0] + box_size[0] - pos_x;
   text_renderer_->AddTextTrailingCharsPrioritized(
       text_box->GetText().c_str(), pos_x, text_box->GetPos()[1] + layout.GetTextOffset(),
-      GlCanvas::kZValueText, kTextWhite, text_box->GetElapsedTimeTextLength(), max_size);
+      GlCanvas::kZValueText, kTextWhite, text_box->GetElapsedTimeTextLength(),
+      time_graph_->CalculateZoomedFontSize(), max_size);
 }
 
 std::string ThreadTrack::GetTooltip() const {

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -68,7 +68,7 @@ void TimeGraph::SetCanvas(GlCanvas* canvas) {
   batcher_.SetPickingManager(&canvas->GetPickingManager());
 }
 
-void TimeGraph::SetFontSize(int font_size) {
+void TimeGraph::SetFontSize(uint32_t font_size) {
   text_renderer_->SetFontSize(font_size);
   text_renderer_static_.SetFontSize(font_size);
 }
@@ -622,7 +622,7 @@ void DrawIteratorBox(GlCanvas* canvas, Vec2 pos, Vec2 size, const Color& color,
   float max_size = size[0];
   canvas->GetTextRenderer().AddTextTrailingCharsPrioritized(
       text.c_str(), pos[0] + kLeftOffset, text_y + kAdditionalSpaceForLine, GlCanvas::kZValueText,
-      Color(255, 255, 255, 255), time.length(), max_size);
+      Color(255, 255, 255, 255), time.length(), GParams.font_size, max_size);
 
   constexpr const float kOffsetBelowText = kAdditionalSpaceForLine / 2.f;
   Vec2 line_from(pos[0], text_y + kOffsetBelowText);

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -17,6 +17,7 @@
 #include "GraphTrack.h"
 #include "ManualInstrumentationManager.h"
 #include "OrbitBase/Profiling.h"
+#include "Params.h"
 #include "SchedulerTrack.h"
 #include "ScopeTimer.h"
 #include "StringManager.h"
@@ -106,8 +107,11 @@ class TimeGraph {
   [[nodiscard]] StringManager* GetStringManager() { return string_manager_.get(); }
   void SetCanvas(GlCanvas* canvas);
   [[nodiscard]] GlCanvas* GetCanvas() { return canvas_; }
-  void SetFontSize(int font_size);
-  [[nodiscard]] int GetFontSize() { return GetTextRenderer()->GetFontSize(); }
+  void SetFontSize(uint32_t font_size);
+  [[nodiscard]] uint32_t GetFontSize() const { return text_renderer_static_.GetFontSize(); }
+  [[nodiscard]] uint32_t CalculateZoomedFontSize() const {
+    return lround((GParams.font_size) * layout_.GetScale());
+  }
   [[nodiscard]] Batcher& GetBatcher() { return batcher_; }
   [[nodiscard]] uint32_t GetNumTimers() const;
   [[nodiscard]] uint32_t GetNumCores() const;

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -151,9 +151,9 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
     float label_offset_y = GCurrentTimeGraph->GetFontSize() / 3.f;
     const Color kColor =
         IsTrackSelected() ? GlCanvas::kTabTextColorSelected : Color(255, 255, 255, 255);
-    canvas->GetTextRenderer().AddText(label_.c_str(), tab_x0 + label_offset_x,
-                                      toggle_y_pos - label_offset_y, text_z, kColor,
-                                      label_width - label_offset_x);
+    canvas->GetTextRenderer().AddText(
+        label_.c_str(), tab_x0 + label_offset_x, toggle_y_pos - label_offset_y, text_z, kColor,
+        time_graph_->CalculateZoomedFontSize(), label_width - label_offset_x);
   }
 
   canvas_ = canvas;

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -151,8 +151,9 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
     float label_offset_y = GCurrentTimeGraph->GetFontSize() / 3.f;
     const Color kColor =
         IsTrackSelected() ? GlCanvas::kTabTextColorSelected : Color(255, 255, 255, 255);
-    canvas->AddText(label_.c_str(), tab_x0 + label_offset_x, toggle_y_pos - label_offset_y, text_z,
-                    kColor, label_width - label_offset_x);
+    canvas->GetTextRenderer().AddText(label_.c_str(), tab_x0 + label_offset_x,
+                                      toggle_y_pos - label_offset_y, text_z, kColor,
+                                      label_width - label_offset_x);
   }
 
   canvas_ = canvas;


### PR DESCRIPTION
The text inside OrbitGl always had the same font size, so it was impossible to scale track related text and not scale overlay text.
Now, we can have different font sizes and scale the text within the track in the same way as other objects.

Related to b/162797051.

Screenshots:
![Screen Shot 2020-09-24 at 17 40 15](https://user-images.githubusercontent.com/8610429/94167876-4cc45300-fe8d-11ea-94c6-7d77b84a097b.png)
![Screen Shot 2020-09-24 at 17 40 46](https://user-images.githubusercontent.com/8610429/94167889-4f26ad00-fe8d-11ea-8a2c-46f430fe79e4.png)
