### PR TITLE
Minor Improvements in SamplingProfiler

### DIFF
--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -79,9 +79,9 @@ class SamplingProfiler {
 
   [[nodiscard]] const CallStack& GetResolvedCallstack(CallstackID raw_callstack_id) const;
 
-  [[nodiscard]] std::multimap<int, CallstackID> GetCallstacksFromAddress(
-      uint64_t address, ThreadID thread_id, int* callstacks_count) const;
-  [[nodiscard]] std::shared_ptr<SortedCallstackReport> GetSortedCallstacksFromAddress(
+  [[nodiscard]] std::multimap<int, CallstackID> GetCallstacksFromAddress(uint64_t address,
+                                                                         ThreadID thread_id) const;
+  [[nodiscard]] std::unique_ptr<SortedCallstackReport> GetSortedCallstacksFromAddress(
       uint64_t address, ThreadID thread_id) const;
 
   [[nodiscard]] const std::vector<ThreadSampleData>& GetThreadSampleData() const {

--- a/OrbitGl/SamplingReport.h
+++ b/OrbitGl/SamplingReport.h
@@ -49,7 +49,7 @@ class SamplingReport {
 
   uint64_t selected_address_;
   ThreadID selected_thread_id_;
-  std::shared_ptr<SortedCallstackReport> selected_sorted_callstack_report_;
+  std::unique_ptr<SortedCallstackReport> selected_sorted_callstack_report_;
   size_t selected_callstack_index_;
   std::function<void()> ui_refresh_func_;
   bool has_summary_;


### PR DESCRIPTION
Prior to this, GetCallstacksFromAddress was modifying the total
callstack count, which would not be expected from a getter.
Now the caller takes care of that (same runtime costs).

Also GetSortedCallstacksFromAddress was returning a shared_ptr,
which was only stored in the SamplingReport. So unique_ptr makes
the owner ship more clearer.

Bug: http://b/166238019