### PR TITLE
Sort CallstackReports by Sample Count

### DIFF
--- a/OrbitCore/SamplingProfiler.cpp
+++ b/OrbitCore/SamplingProfiler.cpp
@@ -28,18 +28,6 @@ std::multimap<int, CallstackID> SortCallstacks(const ThreadSampleData& data,
   return sorted_callstacks;
 }
 
-void ComputeAverageThreadUsage(ThreadSampleData* data) {
-  data->average_thread_usage = 0.f;
-
-  if (!data->thread_usage.empty()) {
-    for (float thread_usage : data->thread_usage) {
-      data->average_thread_usage += thread_usage;
-    }
-
-    data->average_thread_usage /= data->thread_usage.size();
-  }
-}
-
 }  // namespace
 
 uint32_t ThreadSampleData::GetCountForAddress(uint64_t address) const {
@@ -69,7 +57,7 @@ const CallStack& SamplingProfiler::GetResolvedCallstack(CallstackID raw_callstac
   return *resolved_callstack_it->second;
 }
 
-std::unique_ptr<SortedCallstackReport> SamplingProfiler::GetSortedCallstacksFromAddress(
+std::unique_ptr<SortedCallstackReport> SamplingProfiler::GetSortedCallstackReportFromAddress(
     uint64_t address, ThreadID thread_id) const {
   std::unique_ptr<SortedCallstackReport> report = std::make_unique<SortedCallstackReport>();
   std::multimap<int, CallstackID> multi_map = GetCallstacksFromAddress(address, thread_id);
@@ -90,14 +78,7 @@ std::unique_ptr<SortedCallstackReport> SamplingProfiler::GetSortedCallstacksFrom
 const int32_t SamplingProfiler::kAllThreadsFakeTid = -1;
 
 void SamplingProfiler::SortByThreadUsage() {
-  sorted_thread_sample_data_.clear();
   sorted_thread_sample_data_.reserve(thread_id_to_sample_data_.size());
-
-  // If "All" exists, set to 100% usage
-  auto all_threads_it = thread_id_to_sample_data_.find(kAllThreadsFakeTid);
-  if (all_threads_it != thread_id_to_sample_data_.end()) {
-    all_threads_it->second.average_thread_usage = 100.f;
-  }
 
   for (auto& pair : thread_id_to_sample_data_) {
     ThreadSampleData& data = pair.second;
@@ -107,7 +88,7 @@ void SamplingProfiler::SortByThreadUsage() {
 
   sort(sorted_thread_sample_data_.begin(), sorted_thread_sample_data_.end(),
        [](const ThreadSampleData& a, const ThreadSampleData& b) {
-         return a.average_thread_usage > b.average_thread_usage;
+         return a.samples_count > b.samples_count;
        });
 }
 
@@ -141,8 +122,6 @@ void SamplingProfiler::ProcessSamples(const CallstackData& callstack_data,
 
   for (auto& sample_data_it : thread_id_to_sample_data_) {
     ThreadSampleData* thread_sample_data = &sample_data_it.second;
-
-    ComputeAverageThreadUsage(thread_sample_data);
 
     // Address count per sample per thread
     for (const auto& callstack_count_it : thread_sample_data->callstack_count) {
@@ -270,11 +249,11 @@ void SamplingProfiler::FillThreadSampleDataSampleReports(const CaptureData& capt
     ThreadSampleData* thread_sample_data = &data.second;
     std::vector<SampledFunction>* sampled_functions = &thread_sample_data->sampled_function;
 
-    for (auto sortedIt = thread_sample_data->address_count_sorted.rbegin();
-         sortedIt != thread_sample_data->address_count_sorted.rend(); ++sortedIt) {
-      uint32_t numOccurences = sortedIt->first;
-      uint64_t absolute_address = sortedIt->second;
-      float inclusive_percent = 100.f * numOccurences / thread_sample_data->samples_count;
+    for (auto sorted_it = thread_sample_data->address_count_sorted.rbegin();
+         sorted_it != thread_sample_data->address_count_sorted.rend(); ++sorted_it) {
+      uint32_t num_occurences = sorted_it->first;
+      uint64_t absolute_address = sorted_it->second;
+      float inclusive_percent = 100.f * num_occurences / thread_sample_data->samples_count;
 
       SampledFunction function;
       function.name = capture_data.GetFunctionNameByAddress(absolute_address);

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -37,7 +37,7 @@ struct SampledFunction {
 };
 
 struct ThreadSampleData {
-  ThreadSampleData() { thread_usage.push_back(0); }
+  ThreadSampleData() = default;
   [[nodiscard]] uint32_t GetCountForAddress(uint64_t address) const;
   absl::flat_hash_map<CallstackID, uint32_t> callstack_count;
   absl::flat_hash_map<uint64_t, uint32_t> address_count;
@@ -46,8 +46,6 @@ struct ThreadSampleData {
   std::multimap<uint32_t, uint64_t> address_count_sorted;
   uint32_t samples_count = 0;
   std::vector<SampledFunction> sampled_function;
-  std::vector<float> thread_usage;
-  float average_thread_usage = 0;
   ThreadID thread_id = 0;
 };
 
@@ -81,7 +79,7 @@ class SamplingProfiler {
 
   [[nodiscard]] std::multimap<int, CallstackID> GetCallstacksFromAddress(uint64_t address,
                                                                          ThreadID thread_id) const;
-  [[nodiscard]] std::unique_ptr<SortedCallstackReport> GetSortedCallstacksFromAddress(
+  [[nodiscard]] std::unique_ptr<SortedCallstackReport> GetSortedCallstackReportFromAddress(
       uint64_t address, ThreadID thread_id) const;
 
   [[nodiscard]] const std::vector<ThreadSampleData>& GetThreadSampleData() const {
@@ -96,10 +94,8 @@ class SamplingProfiler {
     return &it->second;
   }
 
-  void SortByThreadUsage();
   [[nodiscard]] const ThreadSampleData* GetSummary() const;
   [[nodiscard]] uint32_t GetCountOfFunction(uint64_t function_address) const;
-
   static const int32_t kAllThreadsFakeTid;
 
  private:
@@ -108,6 +104,7 @@ class SamplingProfiler {
   void ResolveCallstacks(const CallstackData& callstack_data, const CaptureData& capture_data);
   void MapAddressToFunctionAddress(uint64_t absolute_address, const CaptureData& capture_data);
   void FillThreadSampleDataSampleReports(const CaptureData& capture_data);
+  void SortByThreadUsage();
 
   // Filled by ProcessSamples.
   absl::flat_hash_map<ThreadID, ThreadSampleData> thread_id_to_sample_data_;

--- a/OrbitGl/SamplingReport.cpp
+++ b/OrbitGl/SamplingReport.cpp
@@ -44,7 +44,7 @@ void SamplingReport::FillReport() {
 
 void SamplingReport::UpdateDisplayedCallstack() {
   selected_sorted_callstack_report_ =
-      profiler_.GetSortedCallstacksFromAddress(selected_address_, selected_thread_id_);
+      profiler_.GetSortedCallstackReportFromAddress(selected_address_, selected_thread_id_);
   if (selected_sorted_callstack_report_->callstacks_count.empty()) {
     ClearReport();
   } else {


### PR DESCRIPTION
Prior to this, callstack reports were attempted to be sorted by thread usage.
However, this was basically never set (except for the all thread case).

As the thread usage is also not used anywhere else, this removes this
information and uses the sample count for sorting (as already implicitly
doe in top down view).
This also simplifies the code.

Bug: http://b/169135142
Test: Take a Capture and see that the thread taps in the sampling
report are now actually sorted by number of samples.