### PR TITLE
Add bottom-up view

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -166,6 +166,7 @@ void OrbitApp::OnCaptureComplete() {
         SetSamplingReport(std::move(sampling_profiler),
                           GetCaptureData().GetCallstackData()->GetUniqueCallstacksCopy());
         SetTopDownView(GetCaptureData());
+        SetBottomUpView(GetCaptureData());
 
         CHECK(capture_stopped_callback_);
         capture_stopped_callback_();
@@ -539,6 +540,33 @@ void OrbitApp::SetSelectionTopDownView(const SamplingProfiler& selection_samplin
 void OrbitApp::ClearSelectionTopDownView() {
   CHECK(selection_top_down_view_callback_);
   selection_top_down_view_callback_(std::make_unique<CallTreeView>());
+}
+
+void OrbitApp::SetBottomUpView(const CaptureData& capture_data) {
+  CHECK(bottom_up_view_callback_);
+  std::unique_ptr<CallTreeView> bottom_up_view =
+      CallTreeView::CreateBottomUpViewFromSamplingProfiler(capture_data.sampling_profiler(),
+                                                           capture_data);
+  bottom_up_view_callback_(std::move(bottom_up_view));
+}
+
+void OrbitApp::ClearBottomUpView() {
+  CHECK(bottom_up_view_callback_);
+  bottom_up_view_callback_(std::make_unique<CallTreeView>());
+}
+
+void OrbitApp::SetSelectionBottomUpView(const SamplingProfiler& selection_sampling_profiler,
+                                        const CaptureData& capture_data) {
+  CHECK(selection_bottom_up_view_callback_);
+  std::unique_ptr<CallTreeView> selection_bottom_up_view =
+      CallTreeView::CreateBottomUpViewFromSamplingProfiler(selection_sampling_profiler,
+                                                           capture_data);
+  selection_bottom_up_view_callback_(std::move(selection_bottom_up_view));
+}
+
+void OrbitApp::ClearSelectionBottomUpView() {
+  CHECK(selection_bottom_up_view_callback_);
+  selection_bottom_up_view_callback_(std::make_unique<CallTreeView>());
 }
 
 // std::string OrbitApp::GetCaptureFileName() {
@@ -1135,6 +1163,7 @@ void OrbitApp::SelectCallstackEvents(const std::vector<CallstackEvent>& selected
                                      generate_summary);
 
   SetSelectionTopDownView(sampling_profiler, GetCaptureData());
+  SetSelectionBottomUpView(sampling_profiler, GetCaptureData());
 
   SetSelectionReport(std::move(sampling_profiler),
                      capture_data_.GetSelectionCallstackData()->GetUniqueCallstacksCopy(),
@@ -1150,6 +1179,7 @@ void OrbitApp::UpdateAfterSymbolLoading() {
                                    capture_data.GetCallstackData()->GetUniqueCallstacksCopy());
     capture_data_.set_sampling_profiler(sampling_profiler);
     SetTopDownView(capture_data);
+    SetBottomUpView(capture_data);
   }
 
   if (selection_report_ == nullptr) {
@@ -1161,6 +1191,7 @@ void OrbitApp::UpdateAfterSymbolLoading() {
                                       selection_report_->has_summary());
 
   SetSelectionTopDownView(selection_profiler, GetCaptureData());
+  SetSelectionBottomUpView(selection_profiler, GetCaptureData());
   selection_report_->UpdateReport(
       std::move(selection_profiler),
       capture_data.GetSelectionCallstackData()->GetUniqueCallstacksCopy());
@@ -1174,6 +1205,8 @@ void OrbitApp::UpdateAfterCaptureCleared() {
   SetSamplingReport(empty_profiler, empty_unique_callstacks);
   ClearTopDownView();
   ClearSelectionTopDownView();
+  ClearBottomUpView();
+  ClearSelectionBottomUpView();
   if (selection_report_) {
     SetSelectionReport(std::move(empty_profiler), empty_unique_callstacks, false);
   }

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -517,27 +517,28 @@ void OrbitApp::SetSelectionReport(
 
 void OrbitApp::SetTopDownView(const CaptureData& capture_data) {
   CHECK(top_down_view_callback_);
-  std::unique_ptr<TopDownView> top_down_view =
-      TopDownView::CreateFromSamplingProfiler(capture_data.sampling_profiler(), capture_data);
+  std::unique_ptr<CallTreeView> top_down_view = CallTreeView::CreateTopDownViewFromSamplingProfiler(
+      capture_data.sampling_profiler(), capture_data);
   top_down_view_callback_(std::move(top_down_view));
 }
 
 void OrbitApp::ClearTopDownView() {
   CHECK(top_down_view_callback_);
-  top_down_view_callback_(std::make_unique<TopDownView>());
+  top_down_view_callback_(std::make_unique<CallTreeView>());
 }
 
 void OrbitApp::SetSelectionTopDownView(const SamplingProfiler& selection_sampling_profiler,
                                        const CaptureData& capture_data) {
   CHECK(selection_top_down_view_callback_);
-  std::unique_ptr<TopDownView> selection_top_down_view =
-      TopDownView::CreateFromSamplingProfiler(selection_sampling_profiler, capture_data);
+  std::unique_ptr<CallTreeView> selection_top_down_view =
+      CallTreeView::CreateTopDownViewFromSamplingProfiler(selection_sampling_profiler,
+                                                          capture_data);
   selection_top_down_view_callback_(std::move(selection_top_down_view));
 }
 
 void OrbitApp::ClearSelectionTopDownView() {
   CHECK(selection_top_down_view_callback_);
-  selection_top_down_view_callback_(std::make_unique<TopDownView>());
+  selection_top_down_view_callback_(std::make_unique<CallTreeView>());
 }
 
 // std::string OrbitApp::GetCaptureFileName() {

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -15,6 +15,7 @@
 
 #include "ApplicationOptions.h"
 #include "CallStackDataView.h"
+#include "CallTreeView.h"
 #include "Callstack.h"
 #include "CallstackData.h"
 #include "CaptureWindow.h"
@@ -47,7 +48,6 @@
 #include "StringManager.h"
 #include "SymbolHelper.h"
 #include "Threading.h"
-#include "TopDownView.h"
 #include "TracepointCustom.h"
 #include "TracepointsDataView.h"
 #include "absl/container/flat_hash_map.h"
@@ -199,11 +199,11 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void SetSelectionReportCallback(SamplingReportCallback callback) {
     selection_report_callback_ = std::move(callback);
   }
-  using TopDownViewCallback = std::function<void(std::unique_ptr<TopDownView>)>;
-  void SetTopDownViewCallback(TopDownViewCallback callback) {
+  using CallTreeViewCallback = std::function<void(std::unique_ptr<CallTreeView>)>;
+  void SetTopDownViewCallback(CallTreeViewCallback callback) {
     top_down_view_callback_ = std::move(callback);
   }
-  void SetSelectionTopDownViewCallback(TopDownViewCallback callback) {
+  void SetSelectionTopDownViewCallback(CallTreeViewCallback callback) {
     selection_top_down_view_callback_ = std::move(callback);
   }
   using SaveFileCallback = std::function<std::string(const std::string& extension)>;
@@ -326,8 +326,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   RefreshCallback refresh_callback_;
   SamplingReportCallback sampling_reports_callback_;
   SamplingReportCallback selection_report_callback_;
-  TopDownViewCallback top_down_view_callback_;
-  TopDownViewCallback selection_top_down_view_callback_;
+  CallTreeViewCallback top_down_view_callback_;
+  CallTreeViewCallback selection_top_down_view_callback_;
   SaveFileCallback save_file_callback_;
   ClipboardCallback clipboard_callback_;
   SecureCopyCallback secure_copy_callback_;

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -131,6 +131,12 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
                                const CaptureData& capture_data);
   void ClearSelectionTopDownView();
 
+  void SetBottomUpView(const CaptureData& capture_data);
+  void ClearBottomUpView();
+  void SetSelectionBottomUpView(const SamplingProfiler& selection_sampling_profiler,
+                                const CaptureData& capture_data);
+  void ClearSelectionBottomUpView();
+
   bool SelectProcess(const std::string& process);
 
   // Callbacks
@@ -192,6 +198,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void SetTooltipCallback(TooltipCallback callback) { tooltip_callback_ = std::move(callback); }
   using RefreshCallback = std::function<void(DataViewType type)>;
   void SetRefreshCallback(RefreshCallback callback) { refresh_callback_ = std::move(callback); }
+
   using SamplingReportCallback = std::function<void(DataView*, std::shared_ptr<SamplingReport>)>;
   void SetSamplingReportCallback(SamplingReportCallback callback) {
     sampling_reports_callback_ = std::move(callback);
@@ -199,6 +206,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void SetSelectionReportCallback(SamplingReportCallback callback) {
     selection_report_callback_ = std::move(callback);
   }
+
   using CallTreeViewCallback = std::function<void(std::unique_ptr<CallTreeView>)>;
   void SetTopDownViewCallback(CallTreeViewCallback callback) {
     top_down_view_callback_ = std::move(callback);
@@ -206,6 +214,13 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void SetSelectionTopDownViewCallback(CallTreeViewCallback callback) {
     selection_top_down_view_callback_ = std::move(callback);
   }
+  void SetBottomUpViewCallback(CallTreeViewCallback callback) {
+    bottom_up_view_callback_ = std::move(callback);
+  }
+  void SetSelectionBottomUpViewCallback(CallTreeViewCallback callback) {
+    selection_bottom_up_view_callback_ = std::move(callback);
+  }
+
   using SaveFileCallback = std::function<std::string(const std::string& extension)>;
   void SetSaveFileCallback(SaveFileCallback callback) { save_file_callback_ = std::move(callback); }
   void FireRefreshCallbacks(DataViewType type = DataViewType::kAll);
@@ -328,6 +343,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   SamplingReportCallback selection_report_callback_;
   CallTreeViewCallback top_down_view_callback_;
   CallTreeViewCallback selection_top_down_view_callback_;
+  CallTreeViewCallback bottom_up_view_callback_;
+  CallTreeViewCallback selection_bottom_up_view_callback_;
   SaveFileCallback save_file_callback_;
   ClipboardCallback clipboard_callback_;
   SecureCopyCallback secure_copy_callback_;

--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(
          AsyncTrack.h
          Batcher.h
          CallStackDataView.h
+         CallTreeView.h
          CaptureWindow.h
          CodeReport.h
          CoreMath.h
@@ -54,7 +55,6 @@ target_sources(
          TimeGraphLayout.h
          TimerChain.h
          TimerInfosIterator.h
-         TopDownView.h
          TimerTrack.h
          Track.h
          TriangleToggle.h
@@ -67,6 +67,7 @@ target_sources(
           AsyncTrack.cpp
           Batcher.cpp
           CallStackDataView.cpp
+          CallTreeView.cpp
           CaptureWindow.cpp
           DataManager.cpp
           DataView.cpp
@@ -99,7 +100,6 @@ target_sources(
           TimerInfosIterator.cpp
           TimerTrack.cpp
           ThreadTrack.cpp
-          TopDownView.cpp
           Track.cpp
           TriangleToggle.cpp
           TracepointsDataView.cpp

--- a/OrbitGl/CallTreeView.cpp
+++ b/OrbitGl/CallTreeView.cpp
@@ -134,3 +134,9 @@ std::unique_ptr<CallTreeView> CallTreeView::CreateTopDownViewFromSamplingProfile
   }
   return top_down_view;
 }
+
+std::unique_ptr<CallTreeView> CallTreeView::CreateBottomUpViewFromSamplingProfiler(
+    const SamplingProfiler& /*sampling_profiler*/, const CaptureData& /*capture_data*/) {
+  // TODO: Implement.
+  return std::unique_ptr<CallTreeView>();
+}

--- a/OrbitGl/CallTreeView.h
+++ b/OrbitGl/CallTreeView.h
@@ -112,6 +112,9 @@ class CallTreeView : public CallTreeNode {
   [[nodiscard]] static std::unique_ptr<CallTreeView> CreateTopDownViewFromSamplingProfiler(
       const SamplingProfiler& sampling_profiler, const CaptureData& capture_data);
 
+  [[nodiscard]] static std::unique_ptr<CallTreeView> CreateBottomUpViewFromSamplingProfiler(
+      const SamplingProfiler& sampling_profiler, const CaptureData& capture_data);
+
   CallTreeView() : CallTreeNode{nullptr} {}
 };
 

--- a/OrbitGl/CallTreeView.h
+++ b/OrbitGl/CallTreeView.h
@@ -2,39 +2,39 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef ORBIT_GL_TOP_DOWN_VIEW_H_
-#define ORBIT_GL_TOP_DOWN_VIEW_H_
+#ifndef ORBIT_GL_CALL_TREE_VIEW_H_
+#define ORBIT_GL_CALL_TREE_VIEW_H_
 
 #include "CaptureData.h"
 #include "Path.h"
 #include "absl/container/node_hash_map.h"
 
-class TopDownThread;
-class TopDownFunction;
+class CallTreeThread;
+class CallTreeFunction;
 
-class TopDownNode {
+class CallTreeNode {
  public:
-  explicit TopDownNode(TopDownNode* parent) : parent_{parent} {}
-  virtual ~TopDownNode() = default;
+  explicit CallTreeNode(CallTreeNode* parent) : parent_{parent} {}
+  virtual ~CallTreeNode() = default;
 
-  // parent(), child_count(), children() are needed by TopDownViewItemModel.
-  [[nodiscard]] const TopDownNode* parent() const { return parent_; }
+  // parent(), child_count(), children() are needed by CallTreeViewItemModel.
+  [[nodiscard]] const CallTreeNode* parent() const { return parent_; }
 
   [[nodiscard]] uint64_t child_count() const {
     return thread_children_.size() + function_children_.size();
   }
 
-  [[nodiscard]] std::vector<const TopDownNode*> children() const;
+  [[nodiscard]] std::vector<const CallTreeNode*> children() const;
 
-  [[nodiscard]] TopDownThread* GetThreadOrNull(int32_t thread_id);
+  [[nodiscard]] CallTreeThread* GetThreadOrNull(int32_t thread_id);
 
-  [[nodiscard]] TopDownThread* AddAndGetThread(int32_t thread_id, std::string thread_name);
+  [[nodiscard]] CallTreeThread* AddAndGetThread(int32_t thread_id, std::string thread_name);
 
-  [[nodiscard]] TopDownFunction* GetFunctionOrNull(uint64_t function_absolute_address);
+  [[nodiscard]] CallTreeFunction* GetFunctionOrNull(uint64_t function_absolute_address);
 
-  [[nodiscard]] TopDownFunction* AddAndGetFunction(uint64_t function_absolute_address,
-                                                   std::string function_name,
-                                                   std::string module_path);
+  [[nodiscard]] CallTreeFunction* AddAndGetFunction(uint64_t function_absolute_address,
+                                                    std::string function_name,
+                                                    std::string module_path);
 
   [[nodiscard]] uint64_t sample_count() const { return sample_count_; }
 
@@ -61,20 +61,20 @@ class TopDownNode {
 
  protected:
   // node_hash_map instead of flat_hash_map as pointer stability is needed for
-  // the TopDownNode::parent_ field.
-  absl::node_hash_map<int32_t, TopDownThread> thread_children_;
-  absl::node_hash_map<uint64_t, TopDownFunction> function_children_;
+  // the CallTreeNode::parent_ field.
+  absl::node_hash_map<int32_t, CallTreeThread> thread_children_;
+  absl::node_hash_map<uint64_t, CallTreeFunction> function_children_;
 
  private:
-  TopDownNode* parent_;
+  CallTreeNode* parent_;
   uint64_t sample_count_ = 0;
 };
 
-class TopDownFunction : public TopDownNode {
+class CallTreeFunction : public CallTreeNode {
  public:
-  explicit TopDownFunction(uint64_t function_absolute_address, std::string function_name,
-                           std::string module_path, TopDownNode* parent)
-      : TopDownNode{parent},
+  explicit CallTreeFunction(uint64_t function_absolute_address, std::string function_name,
+                            std::string module_path, CallTreeNode* parent)
+      : CallTreeNode{parent},
         function_absolute_address_{function_absolute_address},
         function_name_{std::move(function_name)},
         module_path_{std::move(module_path)} {}
@@ -93,10 +93,10 @@ class TopDownFunction : public TopDownNode {
   std::string module_path_;
 };
 
-class TopDownThread : public TopDownNode {
+class CallTreeThread : public CallTreeNode {
  public:
-  explicit TopDownThread(int32_t thread_id, std::string thread_name, TopDownNode* parent)
-      : TopDownNode{parent}, thread_id_{thread_id}, thread_name_{std::move(thread_name)} {}
+  explicit CallTreeThread(int32_t thread_id, std::string thread_name, CallTreeNode* parent)
+      : CallTreeNode{parent}, thread_id_{thread_id}, thread_name_{std::move(thread_name)} {}
 
   [[nodiscard]] int32_t thread_id() const { return thread_id_; }
 
@@ -107,12 +107,12 @@ class TopDownThread : public TopDownNode {
   std::string thread_name_;
 };
 
-class TopDownView : public TopDownNode {
+class CallTreeView : public CallTreeNode {
  public:
-  [[nodiscard]] static std::unique_ptr<TopDownView> CreateFromSamplingProfiler(
+  [[nodiscard]] static std::unique_ptr<CallTreeView> CreateTopDownViewFromSamplingProfiler(
       const SamplingProfiler& sampling_profiler, const CaptureData& capture_data);
 
-  TopDownView() : TopDownNode{nullptr} {}
+  CallTreeView() : CallTreeNode{nullptr} {}
 };
 
-#endif  // ORBIT_GL_TOP_DOWN_VIEW_H_
+#endif  // ORBIT_GL_CALL_TREE_VIEW_H_

--- a/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
+++ b/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
@@ -56,7 +56,7 @@ DEFINE_PROTO_FUZZER(const orbit_client_protos::CaptureDeserializerFuzzerInfo& in
   GOrbitApp->SetRefreshCallback([](DataViewType /*type*/) {});
   GOrbitApp->SetSamplingReportCallback(
       [](DataView* /*view*/, std::shared_ptr<SamplingReport> /*report*/) {});
-  GOrbitApp->SetTopDownViewCallback([](std::unique_ptr<TopDownView> /*view*/) {});
+  GOrbitApp->SetTopDownViewCallback([](std::unique_ptr<CallTreeView> /*view*/) {});
 
   TimeGraph time_graph{};
   GCurrentTimeGraph = &time_graph;

--- a/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
+++ b/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
@@ -57,6 +57,7 @@ DEFINE_PROTO_FUZZER(const orbit_client_protos::CaptureDeserializerFuzzerInfo& in
   GOrbitApp->SetSamplingReportCallback(
       [](DataView* /*view*/, std::shared_ptr<SamplingReport> /*report*/) {});
   GOrbitApp->SetTopDownViewCallback([](std::unique_ptr<CallTreeView> /*view*/) {});
+  GOrbitApp->SetBottomUpViewCallback([](std::unique_ptr<CallTreeView> /*view*/) {});
 
   TimeGraph time_graph{};
   GCurrentTimeGraph = &time_graph;

--- a/OrbitGl/TopDownView.cpp
+++ b/OrbitGl/TopDownView.cpp
@@ -4,40 +4,63 @@
 
 #include "TopDownView.h"
 
-TopDownFunction* TopDownInternalNode::GetFunctionOrNull(uint64_t function_absolute_address) {
-  auto top_down_function_it = function_nodes_.find(function_absolute_address);
-  if (top_down_function_it == function_nodes_.end()) {
-    return nullptr;
+std::vector<const TopDownNode*> TopDownNode::children() const {
+  std::vector<const TopDownNode*> ret;
+  for (const auto& tid_and_thread : thread_children_) {
+    ret.push_back(&tid_and_thread.second);
   }
-  return &top_down_function_it->second;
+  for (auto& address_and_functions : function_children_) {
+    ret.push_back(&address_and_functions.second);
+  }
+  return ret;
 }
 
-TopDownFunction* TopDownInternalNode::AddAndGetFunction(uint64_t function_absolute_address,
-                                                        std::string function_name,
-                                                        std::string module_path) {
-  function_nodes_.insert_or_assign(
-      function_absolute_address,
-      TopDownFunction{function_absolute_address, std::move(function_name), std::move(module_path),
-                      this});
-  return &function_nodes_.at(function_absolute_address);
-}
-
-TopDownThread* TopDownView::GetThreadOrNull(int32_t thread_id) {
-  auto top_down_thread_it = thread_nodes_.find(thread_id);
-  if (top_down_thread_it == thread_nodes_.end()) {
+TopDownThread* TopDownNode::GetThreadOrNull(int32_t thread_id) {
+  auto top_down_thread_it = thread_children_.find(thread_id);
+  if (top_down_thread_it == thread_children_.end()) {
     return nullptr;
   }
   return &top_down_thread_it->second;
 }
 
-TopDownThread* TopDownView::AddAndGetThread(int32_t thread_id, std::string thread_name) {
-  thread_nodes_.insert_or_assign(thread_id, TopDownThread{thread_id, std::move(thread_name), this});
-  return &thread_nodes_.at(thread_id);
+TopDownThread* TopDownNode::AddAndGetThread(int32_t thread_id, std::string thread_name) {
+  thread_children_.insert_or_assign(thread_id,
+                                    TopDownThread{thread_id, std::move(thread_name), this});
+  return &thread_children_.at(thread_id);
+}
+
+TopDownFunction* TopDownNode::GetFunctionOrNull(uint64_t function_absolute_address) {
+  auto top_down_function_it = function_children_.find(function_absolute_address);
+  if (top_down_function_it == function_children_.end()) {
+    return nullptr;
+  }
+  return &top_down_function_it->second;
+}
+
+TopDownFunction* TopDownNode::AddAndGetFunction(uint64_t function_absolute_address,
+                                                std::string function_name,
+                                                std::string module_path) {
+  function_children_.insert_or_assign(
+      function_absolute_address,
+      TopDownFunction{function_absolute_address, std::move(function_name), std::move(module_path),
+                      this});
+  return &function_children_.at(function_absolute_address);
+}
+
+uint64_t TopDownNode::GetExclusiveSampleCount() const {
+  uint64_t children_sample_count = 0;
+  for (const auto& address_and_function : function_children_) {
+    children_sample_count += address_and_function.second.sample_count();
+  }
+  for (const auto& tid_and_thread : thread_children_) {
+    children_sample_count += tid_and_thread.second.sample_count();
+  }
+  return sample_count() - children_sample_count;
 }
 
 [[nodiscard]] static TopDownFunction* GetOrCreateFunctionNode(
-    TopDownInternalNode* current_thread_or_function, uint64_t frame,
-    const std::string& function_name, const std::string& module_path) {
+    TopDownNode* current_thread_or_function, uint64_t frame, const std::string& function_name,
+    const std::string& module_path) {
   TopDownFunction* function_node = current_thread_or_function->GetFunctionOrNull(frame);
   if (function_node == nullptr) {
     std::string formatted_function_name;
@@ -56,7 +79,7 @@ static void AddCallstackToTopDownThread(TopDownThread* thread_node,
                                         const CallStack& resolved_callstack,
                                         uint64_t callstack_sample_count,
                                         const CaptureData& capture_data) {
-  TopDownInternalNode* current_thread_or_function = thread_node;
+  TopDownNode* current_thread_or_function = thread_node;
   for (auto frame_it = resolved_callstack.GetFrames().crbegin();
        frame_it != resolved_callstack.GetFrames().crend(); ++frame_it) {
     uint64_t frame = *frame_it;
@@ -90,6 +113,7 @@ std::unique_ptr<TopDownView> TopDownView::CreateFromSamplingProfiler(
   auto top_down_view = std::make_unique<TopDownView>();
   const std::string& process_name = capture_data.process_name();
   const absl::flat_hash_map<int32_t, std::string>& thread_names = capture_data.thread_names();
+
   for (const ThreadSampleData& thread_sample_data : sampling_profiler.GetThreadSampleData()) {
     const int32_t tid = thread_sample_data.thread_id;
     TopDownThread* thread_node =

--- a/OrbitGl/TopDownView.h
+++ b/OrbitGl/TopDownView.h
@@ -5,42 +5,30 @@
 #ifndef ORBIT_GL_TOP_DOWN_VIEW_H_
 #define ORBIT_GL_TOP_DOWN_VIEW_H_
 
-#include <unordered_map>
-
 #include "CaptureData.h"
 #include "Path.h"
 #include "absl/container/node_hash_map.h"
+
+class TopDownThread;
+class TopDownFunction;
 
 class TopDownNode {
  public:
   explicit TopDownNode(TopDownNode* parent) : parent_{parent} {}
   virtual ~TopDownNode() = default;
 
-  [[nodiscard]] uint64_t sample_count() const { return sample_count_; }
-
-  void IncreaseSampleCount(uint64_t sample_count_increase) {
-    sample_count_ += sample_count_increase;
-  }
-
   // parent(), child_count(), children() are needed by TopDownViewItemModel.
   [[nodiscard]] const TopDownNode* parent() const { return parent_; }
 
-  [[nodiscard]] virtual uint64_t child_count() const = 0;
-
-  [[nodiscard]] virtual std::vector<const TopDownNode*> children() const = 0;
-
- private:
-  TopDownNode* parent_;
-  uint64_t sample_count_ = 0;
-};
-
-class TopDownFunction;
-
-class TopDownInternalNode : public TopDownNode {
- public:
-  explicit TopDownInternalNode(TopDownNode* parent) : TopDownNode{parent} {
-    CHECK(parent != nullptr);
+  [[nodiscard]] uint64_t child_count() const {
+    return thread_children_.size() + function_children_.size();
   }
+
+  [[nodiscard]] std::vector<const TopDownNode*> children() const;
+
+  [[nodiscard]] TopDownThread* GetThreadOrNull(int32_t thread_id);
+
+  [[nodiscard]] TopDownThread* AddAndGetThread(int32_t thread_id, std::string thread_name);
 
   [[nodiscard]] TopDownFunction* GetFunctionOrNull(uint64_t function_absolute_address);
 
@@ -48,25 +36,45 @@ class TopDownInternalNode : public TopDownNode {
                                                    std::string function_name,
                                                    std::string module_path);
 
+  [[nodiscard]] uint64_t sample_count() const { return sample_count_; }
+
+  void IncreaseSampleCount(uint64_t sample_count_increase) {
+    sample_count_ += sample_count_increase;
+  }
+
   [[nodiscard]] float GetInclusivePercent(uint64_t total_sample_count) const {
     return 100.0f * sample_count() / total_sample_count;
   }
 
   [[nodiscard]] float GetPercentOfParent() const {
-    return 100.0f * sample_count() / parent()->sample_count();
+    if (parent_ == nullptr) {
+      return 100.0f;
+    }
+    return 100.0f * sample_count() / parent_->sample_count();
+  }
+
+  [[nodiscard]] uint64_t GetExclusiveSampleCount() const;
+
+  [[nodiscard]] float GetExclusivePercent(uint64_t total_sample_count) const {
+    return 100.0f * GetExclusiveSampleCount() / total_sample_count;
   }
 
  protected:
   // node_hash_map instead of flat_hash_map as pointer stability is needed for
   // the TopDownNode::parent_ field.
-  absl::node_hash_map<uint64_t, TopDownFunction> function_nodes_;
+  absl::node_hash_map<int32_t, TopDownThread> thread_children_;
+  absl::node_hash_map<uint64_t, TopDownFunction> function_children_;
+
+ private:
+  TopDownNode* parent_;
+  uint64_t sample_count_ = 0;
 };
 
-class TopDownFunction : public TopDownInternalNode {
+class TopDownFunction : public TopDownNode {
  public:
   explicit TopDownFunction(uint64_t function_absolute_address, std::string function_name,
                            std::string module_path, TopDownNode* parent)
-      : TopDownInternalNode{parent},
+      : TopDownNode{parent},
         function_absolute_address_{function_absolute_address},
         function_name_{std::move(function_name)},
         module_path_{std::move(module_path)} {}
@@ -79,52 +87,20 @@ class TopDownFunction : public TopDownInternalNode {
 
   [[nodiscard]] std::string GetModuleName() const { return Path::GetFileName(module_path()); }
 
-  [[nodiscard]] uint64_t GetExclusiveSampleCount() const {
-    uint64_t children_sample_count = 0;
-    for (const auto& child_address_and_node : function_nodes_) {
-      children_sample_count += child_address_and_node.second.sample_count();
-    }
-    return sample_count() - children_sample_count;
-  }
-
-  [[nodiscard]] float GetExclusivePercent(uint64_t total_sample_count) const {
-    return 100.0f * GetExclusiveSampleCount() / total_sample_count;
-  }
-
-  [[nodiscard]] uint64_t child_count() const override { return function_nodes_.size(); }
-
-  [[nodiscard]] std::vector<const TopDownNode*> children() const override {
-    std::vector<const TopDownNode*> ret;
-    for (auto& address_and_node : function_nodes_) {
-      ret.push_back(&address_and_node.second);
-    }
-    return ret;
-  }
-
  private:
   uint64_t function_absolute_address_;
   std::string function_name_;
   std::string module_path_;
 };
 
-class TopDownThread : public TopDownInternalNode {
+class TopDownThread : public TopDownNode {
  public:
   explicit TopDownThread(int32_t thread_id, std::string thread_name, TopDownNode* parent)
-      : TopDownInternalNode{parent}, thread_id_{thread_id}, thread_name_{std::move(thread_name)} {}
+      : TopDownNode{parent}, thread_id_{thread_id}, thread_name_{std::move(thread_name)} {}
 
   [[nodiscard]] int32_t thread_id() const { return thread_id_; }
 
   [[nodiscard]] const std::string& thread_name() const { return thread_name_; }
-
-  [[nodiscard]] uint64_t child_count() const override { return function_nodes_.size(); }
-
-  [[nodiscard]] std::vector<const TopDownNode*> children() const override {
-    std::vector<const TopDownNode*> ret;
-    for (auto& address_and_node : function_nodes_) {
-      ret.push_back(&address_and_node.second);
-    }
-    return ret;
-  }
 
  private:
   int32_t thread_id_;
@@ -137,23 +113,6 @@ class TopDownView : public TopDownNode {
       const SamplingProfiler& sampling_profiler, const CaptureData& capture_data);
 
   TopDownView() : TopDownNode{nullptr} {}
-
-  [[nodiscard]] TopDownThread* GetThreadOrNull(int32_t thread_id);
-
-  [[nodiscard]] TopDownThread* AddAndGetThread(int32_t thread_id, std::string thread_name);
-
-  [[nodiscard]] uint64_t child_count() const override { return thread_nodes_.size(); }
-
-  [[nodiscard]] std::vector<const TopDownNode*> children() const override {
-    std::vector<const TopDownNode*> ret;
-    for (const auto& tid_and_node : thread_nodes_) {
-      ret.push_back(&tid_and_node.second);
-    }
-    return ret;
-  }
-
- private:
-  absl::node_hash_map<int32_t, TopDownThread> thread_nodes_;
 };
 
 #endif  // ORBIT_GL_TOP_DOWN_VIEW_H_

--- a/OrbitQt/CMakeLists.txt
+++ b/OrbitQt/CMakeLists.txt
@@ -10,9 +10,11 @@ target_compile_options(OrbitQt PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(
   OrbitQt
-  PRIVATE deploymentconfigurations.h
+  PRIVATE CallTreeViewItemModel.h
+          CallTreeWidget.h
           CopyKeySequenceEnabledTreeView.h
           CutoutWidget.h
+          deploymentconfigurations.h
           ElidedLabel.h
           Error.h
           eventloop.h
@@ -33,13 +35,14 @@ target_sources(
           processlauncherwidget.h
           resource.h
           servicedeploymanager.h
-          TopDownViewItemModel.h
-          TutorialOverlay.h
-          TopDownWidget.h)
+          TutorialOverlay.h)
 
 target_sources(
   OrbitQt
-  PRIVATE Error.cpp
+  PRIVATE CallTreeViewItemModel.cpp
+          CallTreeWidget.cpp
+          CallTreeWidget.ui
+          Error.cpp
           ElidedLabel.cpp
           MainThreadExecutorImpl.cpp
           StatusListenerImpl.cpp
@@ -63,9 +66,6 @@ target_sources(
           opengldetect.cpp
           processlauncherwidget.cpp
           servicedeploymanager.cpp
-          TopDownViewItemModel.cpp
-          TopDownWidget.cpp
-          TopDownWidget.ui
           TutorialOverlay.cpp
           TutorialOverlay.ui
           ../icons/orbiticons.qrc
@@ -138,7 +138,7 @@ target_sources(OrbitQtTests
                 TutorialOverlay.cpp
                 TutorialOverlay.ui
                 ../images/orbitimages.qrc)
-				
+
 target_include_directories(OrbitQtTests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_link_libraries(
@@ -148,7 +148,7 @@ target_link_libraries(
           Qt5::Widgets
           Qt5::Core
           GTest::Main)
-		  
+
 set_target_properties(OrbitQtTests PROPERTIES AUTOMOC ON)
 set_target_properties(OrbitQtTests PROPERTIES AUTOUIC ON)
 set_target_properties(OrbitQtTests PROPERTIES AUTORCC ON)

--- a/OrbitQt/CallTreeViewItemModel.cpp
+++ b/OrbitQt/CallTreeViewItemModel.cpp
@@ -31,6 +31,12 @@ QVariant CallTreeViewItemModel::GetDisplayRoleData(const QModelIndex& index) con
         return QString::fromStdString(absl::StrFormat(
             "%.2f%% (%llu)", thread_item->GetInclusivePercent(call_tree_view_->sample_count()),
             thread_item->sample_count()));
+      case kExclusive:
+        return QString::fromStdString(absl::StrFormat(
+            "%.2f%% (%llu)", thread_item->GetExclusivePercent(call_tree_view_->sample_count()),
+            thread_item->GetExclusiveSampleCount()));
+      case kOfParent:
+        return QString::fromStdString(absl::StrFormat("%.2f%%", thread_item->GetPercentOfParent()));
     }
   } else if (function_item != nullptr) {
     switch (index.column()) {
@@ -69,6 +75,10 @@ QVariant CallTreeViewItemModel::GetEditRoleData(const QModelIndex& index) const 
         return thread_item->thread_id();
       case kInclusive:
         return thread_item->GetInclusivePercent(call_tree_view_->sample_count());
+      case kExclusive:
+        return thread_item->GetExclusivePercent(call_tree_view_->sample_count());
+      case kOfParent:
+        return thread_item->GetPercentOfParent();
     }
   } else if (function_item != nullptr) {
     switch (index.column()) {

--- a/OrbitQt/CallTreeViewItemModel.h
+++ b/OrbitQt/CallTreeViewItemModel.h
@@ -2,22 +2,22 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef ORBIT_QT_TOP_DOWN_VIEW_ITEM_MODEL_H_
-#define ORBIT_QT_TOP_DOWN_VIEW_ITEM_MODEL_H_
+#ifndef ORBIT_QT_CALL_TREE_VIEW_ITEM_MODEL_H_
+#define ORBIT_QT_CALL_TREE_VIEW_ITEM_MODEL_H_
 
 #include <QAbstractItemModel>
 #include <QModelIndex>
 #include <QVariant>
 #include <memory>
 
-#include "TopDownView.h"
+#include "CallTreeView.h"
 
-class TopDownViewItemModel : public QAbstractItemModel {
+class CallTreeViewItemModel : public QAbstractItemModel {
   Q_OBJECT
 
  public:
-  explicit TopDownViewItemModel(std::unique_ptr<TopDownView> top_down_view,
-                                QObject* parent = nullptr);
+  explicit CallTreeViewItemModel(std::unique_ptr<CallTreeView> call_tree_view,
+                                 QObject* parent = nullptr);
 
   QVariant data(const QModelIndex& index, int role) const override;
   Qt::ItemFlags flags(const QModelIndex& index) const override;
@@ -45,7 +45,7 @@ class TopDownViewItemModel : public QAbstractItemModel {
   [[nodiscard]] QVariant GetToolTipRoleData(const QModelIndex& index) const;
   [[nodiscard]] QVariant GetModulePathRoleData(const QModelIndex& index) const;
 
-  std::unique_ptr<TopDownView> top_down_view_;
+  std::unique_ptr<CallTreeView> call_tree_view_;
 };
 
-#endif  // ORBIT_QT_TOP_DOWN_VIEW_ITEM_MODEL_H_
+#endif  // ORBIT_QT_CALL_TREE_VIEW_ITEM_MODEL_H_

--- a/OrbitQt/CallTreeWidget.cpp
+++ b/OrbitQt/CallTreeWidget.cpp
@@ -53,6 +53,11 @@ void CallTreeWidget::SetTopDownView(std::unique_ptr<CallTreeView> top_down_view)
   onSearchLineEditTextEdited(ui_->searchLineEdit->text());
 }
 
+void CallTreeWidget::SetBottomUpView(std::unique_ptr<CallTreeView> bottom_up_view) {
+  SetTopDownView(std::move(bottom_up_view));
+  // TODO: Hide the "Exclusive" column.
+}
+
 static std::string BuildStringFromIndices(const QModelIndexList& indices) {
   std::string buffer;
   std::optional<QModelIndex> prev_index;

--- a/OrbitQt/CallTreeWidget.h
+++ b/OrbitQt/CallTreeWidget.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef ORBIT_QT_TOP_DOWN_WIDGET_H_
-#define ORBIT_QT_TOP_DOWN_WIDGET_H_
+#ifndef ORBIT_QT_CALL_TREE_WIDGET_H_
+#define ORBIT_QT_CALL_TREE_WIDGET_H_
 
 #include <QIdentityProxyModel>
 #include <QSortFilterProxyModel>
@@ -12,22 +12,22 @@
 #include <QWidget>
 #include <memory>
 
-#include "TopDownView.h"
-#include "TopDownViewItemModel.h"
+#include "CallTreeView.h"
+#include "CallTreeViewItemModel.h"
 #include "absl/strings/str_split.h"
-#include "ui_TopDownWidget.h"
+#include "ui_CallTreeWidget.h"
 
 class OrbitApp;
 
-class TopDownWidget : public QWidget {
+class CallTreeWidget : public QWidget {
   Q_OBJECT
 
  public:
-  explicit TopDownWidget(QWidget* parent = nullptr);
+  explicit CallTreeWidget(QWidget* parent = nullptr);
 
   void Initialize(OrbitApp* app) { app_ = app; }
 
-  void SetTopDownView(std::unique_ptr<TopDownView> top_down_view);
+  void SetTopDownView(std::unique_ptr<CallTreeView> top_down_view);
 
  private slots:
   void onCopyKeySequencePressed();
@@ -88,12 +88,12 @@ class TopDownWidget : public QWidget {
                const QModelIndex& index) const override;
   };
 
-  std::unique_ptr<Ui::TopDownWidget> ui_;
+  std::unique_ptr<Ui::CallTreeWidget> ui_;
   OrbitApp* app_ = nullptr;
-  std::unique_ptr<TopDownViewItemModel> model_;
+  std::unique_ptr<CallTreeViewItemModel> model_;
   std::unique_ptr<HighlightCustomFilterSortFilterProxyModel> search_proxy_model_;
   std::unique_ptr<HookedIdentityProxyModel> hooked_proxy_model_;
   bool columns_already_resized_ = false;
 };
 
-#endif  // ORBIT_QT_TOP_DOWN_WIDGET_H_
+#endif  // ORBIT_QT_CALL_TREE_WIDGET_H_

--- a/OrbitQt/CallTreeWidget.h
+++ b/OrbitQt/CallTreeWidget.h
@@ -89,9 +89,13 @@ class CallTreeWidget : public QWidget {
                const QModelIndex& index) const override;
   };
 
+  void SetCallTreeView(std::unique_ptr<CallTreeView> call_tree_view,
+                       std::unique_ptr<QIdentityProxyModel> hide_values_proxy_model);
+
   std::unique_ptr<Ui::CallTreeWidget> ui_;
   OrbitApp* app_ = nullptr;
   std::unique_ptr<CallTreeViewItemModel> model_;
+  std::unique_ptr<QIdentityProxyModel> hide_values_proxy_model_;
   std::unique_ptr<HighlightCustomFilterSortFilterProxyModel> search_proxy_model_;
   std::unique_ptr<HookedIdentityProxyModel> hooked_proxy_model_;
   bool columns_already_resized_ = false;

--- a/OrbitQt/CallTreeWidget.h
+++ b/OrbitQt/CallTreeWidget.h
@@ -28,6 +28,7 @@ class CallTreeWidget : public QWidget {
   void Initialize(OrbitApp* app) { app_ = app; }
 
   void SetTopDownView(std::unique_ptr<CallTreeView> top_down_view);
+  void SetBottomUpView(std::unique_ptr<CallTreeView> bottom_up_view);
 
  private slots:
   void onCopyKeySequencePressed();

--- a/OrbitQt/CallTreeWidget.ui
+++ b/OrbitQt/CallTreeWidget.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>TopDownWidget</class>
- <widget class="QWidget" name="TopDownWidget">
+ <class>CallTreeWidget</class>
+ <widget class="QWidget" name="CallTreeWidget">
   <layout class="QGridLayout">
    <property name="leftMargin">
     <number>0</number>
@@ -29,7 +29,7 @@
     </widget>
    </item>
    <item row="1" column="0">
-    <widget class="CopyKeySequenceEnabledTreeView" name="topDownTreeView">
+    <widget class="CopyKeySequenceEnabledTreeView" name="callTreeTreeView">
      <property name="contextMenuPolicy">
       <enum>Qt::CustomContextMenu</enum>
      </property>

--- a/OrbitQt/TopDownViewItemModel.cpp
+++ b/OrbitQt/TopDownViewItemModel.cpp
@@ -191,7 +191,7 @@ QModelIndex TopDownViewItemModel::index(int row, int column, const QModelIndex& 
   if (!parent.isValid()) {
     parent_item = top_down_view_.get();
   } else {
-    parent_item = static_cast<TopDownInternalNode*>(parent.internalPointer());
+    parent_item = static_cast<TopDownNode*>(parent.internalPointer());
   }
 
   const std::vector<const TopDownNode*>& siblings = parent_item->children();

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -21,13 +21,13 @@
 #include <utility>
 
 #include "App.h"
+#include "CallTreeViewItemModel.h"
 #include "MainThreadExecutorImpl.h"
 #include "OrbitClientModel/CaptureSerializer.h"
 #include "OrbitVersion/OrbitVersion.h"
 #include "Path.h"
 #include "SamplingReport.h"
 #include "StatusListenerImpl.h"
-#include "TopDownViewItemModel.h"
 #include "TutorialOverlay.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_format.h"
@@ -157,13 +157,13 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App, ApplicationOptions&& optio
         this->OnNewSelectionReport(callstack_data_view, std::move(report));
       });
 
-  GOrbitApp->SetTopDownViewCallback([this](std::unique_ptr<TopDownView> top_down_view) {
+  GOrbitApp->SetTopDownViewCallback([this](std::unique_ptr<CallTreeView> top_down_view) {
     this->OnNewTopDownView(std::move(top_down_view));
   });
 
   ui->RightTabWidget->setTabEnabled(ui->RightTabWidget->indexOf(ui->selectionTopDownTab), false);
   GOrbitApp->SetSelectionTopDownViewCallback(
-      [this](std::unique_ptr<TopDownView> selection_top_down_view) {
+      [this](std::unique_ptr<CallTreeView> selection_top_down_view) {
         this->OnNewSelectionTopDownView(std::move(selection_top_down_view));
       });
 
@@ -367,12 +367,12 @@ void OrbitMainWindow::OnNewSelectionReport(DataView* callstack_data_view,
   ui->selectionGridLayout->addWidget(ui->selectionReport, 0, 0, 1, 1);
 }
 
-void OrbitMainWindow::OnNewTopDownView(std::unique_ptr<TopDownView> top_down_view) {
+void OrbitMainWindow::OnNewTopDownView(std::unique_ptr<CallTreeView> top_down_view) {
   ui->topDownWidget->SetTopDownView(std::move(top_down_view));
 }
 
 void OrbitMainWindow::OnNewSelectionTopDownView(
-    std::unique_ptr<TopDownView> selection_top_down_view) {
+    std::unique_ptr<CallTreeView> selection_top_down_view) {
   if (selection_top_down_view->child_count() > 0) {
     ui->RightTabWidget->setTabEnabled(ui->RightTabWidget->indexOf(ui->selectionTopDownTab), true);
     // This condition and the corresponding one in OnNewSelectionReport need to be complementary,

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -39,12 +39,18 @@ class OrbitMainWindow : public QMainWindow {
   void RegisterGlWidget(class OrbitGLWidget* a_GlWidget) { m_GlWidgets.push_back(a_GlWidget); }
   void OnRefreshDataViewPanels(DataViewType a_Type);
   void UpdatePanel(DataViewType a_Type);
+
   void OnNewSamplingReport(DataView* callstack_data_view,
                            std::shared_ptr<class SamplingReport> sampling_report);
   void OnNewSelectionReport(DataView* callstack_data_view,
                             std::shared_ptr<class SamplingReport> sampling_report);
+
   void OnNewTopDownView(std::unique_ptr<CallTreeView> top_down_view);
   void OnNewSelectionTopDownView(std::unique_ptr<CallTreeView> selection_top_down_view);
+
+  void OnNewBottomUpView(std::unique_ptr<CallTreeView> bottom_up_view);
+  void OnNewSelectionBottomUpView(std::unique_ptr<CallTreeView> selection_bottom_up_view);
+
   std::string OnGetSaveFileName(const std::string& extension);
   void OnSetClipboard(const std::string& text);
   void OpenDisassembly(std::string a_String, DisassemblyReport report);

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -20,8 +20,8 @@
 
 #include "ApplicationOptions.h"
 #include "CallStackDataView.h"
+#include "CallTreeView.h"
 #include "StatusListener.h"
-#include "TopDownView.h"
 #include "servicedeploymanager.h"
 
 namespace Ui {
@@ -43,8 +43,8 @@ class OrbitMainWindow : public QMainWindow {
                            std::shared_ptr<class SamplingReport> sampling_report);
   void OnNewSelectionReport(DataView* callstack_data_view,
                             std::shared_ptr<class SamplingReport> sampling_report);
-  void OnNewTopDownView(std::unique_ptr<TopDownView> top_down_view);
-  void OnNewSelectionTopDownView(std::unique_ptr<TopDownView> selection_top_down_view);
+  void OnNewTopDownView(std::unique_ptr<CallTreeView> top_down_view);
+  void OnNewSelectionTopDownView(std::unique_ptr<CallTreeView> selection_top_down_view);
   std::string OnGetSaveFileName(const std::string& extension);
   void OnSetClipboard(const std::string& text);
   void OpenDisassembly(std::string a_String, DisassemblyReport report);

--- a/OrbitQt/orbitmainwindow.ui
+++ b/OrbitQt/orbitmainwindow.ui
@@ -267,7 +267,7 @@ QPushButton:disabled {
         </attribute>
         <layout class="QGridLayout" name="topDownGridLayout">
          <item row="0" column="0">
-          <widget class="TopDownWidget" name="topDownWidget" native="true"/>
+          <widget class="CallTreeWidget" name="topDownWidget" native="true"/>
          </item>
         </layout>
        </widget>
@@ -287,7 +287,7 @@ QPushButton:disabled {
         </attribute>
         <layout class="QGridLayout" name="selectionTopDownGridLayout">
          <item row="0" column="0">
-          <widget class="TopDownWidget" name="selectionTopDownWidget" native="true"/>
+          <widget class="CallTreeWidget" name="selectionTopDownWidget" native="true"/>
          </item>
         </layout>
        </widget>
@@ -617,9 +617,9 @@ QPushButton:disabled {
    <header>orbitsamplingreport.h</header>
   </customwidget>
   <customwidget>
-   <class>TopDownWidget</class>
+   <class>CallTreeWidget</class>
    <extends>QWidget</extends>
-   <header>TopDownWidget.h</header>
+   <header>CallTreeWidget.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/OrbitQt/orbitmainwindow.ui
+++ b/OrbitQt/orbitmainwindow.ui
@@ -271,6 +271,16 @@ QPushButton:disabled {
          </item>
         </layout>
        </widget>
+       <widget class="QWidget" name="bottomUpTab">
+        <attribute name="title">
+         <string>Bottom-Up</string>
+        </attribute>
+        <layout class="QGridLayout" name="bottomUpGridLayout">
+         <item row="0" column="0">
+          <widget class="CallTreeWidget" name="bottomUpWidget" native="true"/>
+         </item>
+        </layout>
+       </widget>
        <widget class="QWidget" name="selectionSamplingTab">
         <attribute name="title">
          <string>Sampling (selection)</string>
@@ -288,6 +298,16 @@ QPushButton:disabled {
         <layout class="QGridLayout" name="selectionTopDownGridLayout">
          <item row="0" column="0">
           <widget class="CallTreeWidget" name="selectionTopDownWidget" native="true"/>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="selectionBottomUpTab">
+        <attribute name="title">
+         <string>Bottom-Up (selection)</string>
+        </attribute>
+        <layout class="QGridLayout" name="selectionBottomUpGridLayout">
+         <item row="0" column="0">
+          <widget class="CallTreeWidget" name="selectionBottomUpWidget" native="true"/>
          </item>
         </layout>
        </widget>


### PR DESCRIPTION
#### Simplify and generalize TopDownNode hierarchy
#### Change "TopDown" to "CallTree" in many places
#### Prepare OrbitApp, OrbitMainWindow for bottom-up view
Bug: http://b/168018191
#### Implement CallTreeView::CreateBottomUpViewFromSamplingProfiler
Bug: http://b/168018191
#### Hide "Exclusive" in bottom-up view, hide "Of parent" for first level
`CallTreeViewItemModel` handles `kExclusive`, `kOfParent` for threads too.
These values are now hidden by `CallTreeWidget` based on different logics in
case of a top-down or a bottom-up view.
- Top-down view: for the elements at the first level (i.e., the threads),
  "Exclusive" and "Of parent" are hidden.
- Bottom-up view: the "Exclusive" column is hidden entirely; for elements at the
  first level (i.e., the innermost functions), "Of parent" is also hidden.

---

Screenshot from Trata:

<img width="758" alt="Capture" src="https://user-images.githubusercontent.com/58685940/93896426-2ec1eb80-fcf1-11ea-89be-6062a391896a.PNG">

The number of tabs is not getting any lower...