### PR TITLE
Make manual instrumentation event "id" 64 bits instead of 32

### DIFF
--- a/OrbitBase/OrbitApiTest.cpp
+++ b/OrbitBase/OrbitApiTest.cpp
@@ -15,17 +15,15 @@ static orbit_api::Event Decode(uint64_t a1, uint64_t a2, uint64_t a3, uint64_t a
 TEST(OrbitApi, Encoding) {
   constexpr orbit_api::EventType kType = orbit_api::kTrackInt64;
   constexpr const char* kName = "The quick brown fox jumps over the lazy dog";
-  constexpr double kValue = 1234567.12345671234567;
+  constexpr double kData = 1234567.12345671234567;
   constexpr orbit::Color kColor = orbit::Color::kAmber;
-  constexpr uint32_t kId = 0xABCDEF01;
 
-  orbit_api::EncodedEvent e(kType, kName, orbit_api::Encode<uint64_t>(kValue), kColor, kId);
+  orbit_api::EncodedEvent e(kType, kName, orbit_api::Encode<uint64_t>(kData), kColor);
   auto decoded_event = Decode(e.args[0], e.args[1], e.args[2], e.args[3], e.args[4], e.args[5]);
 
   EXPECT_EQ(decoded_event.type, kType);
-  EXPECT_EQ(orbit_api::Decode<double>(decoded_event.value), kValue);
+  EXPECT_EQ(orbit_api::Decode<double>(decoded_event.data), kData);
   EXPECT_EQ(decoded_event.color, kColor);
-  EXPECT_EQ(decoded_event.id, kId);
 
   std::string initial_string(kName);
   EXPECT_EQ(strlen(decoded_event.name), orbit_api::kMaxEventStringSize - 1);

--- a/OrbitGl/AsyncTrack.cpp
+++ b/OrbitGl/AsyncTrack.cpp
@@ -30,7 +30,8 @@ AsyncTrack::AsyncTrack(TimeGraph* time_graph, const std::string& name) : TimerTr
   const FunctionInfo* func =
       GOrbitApp->GetCaptureData().GetSelectedFunction(text_box->GetTimerInfo().function_address());
   std::string module_name = FunctionUtils::GetLoadedModuleName(*func);
-  std::string function_name = manual_inst_manager->GetString(event.id);
+  const uint64_t event_id = event.data;
+  std::string function_name = manual_inst_manager->GetString(event_id);
 
   return absl::StrFormat(
       "<b>%s</b><br/>"
@@ -69,7 +70,8 @@ void AsyncTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_us
   text_box->SetElapsedTimeTextLength(time.length());
 
   orbit_api::Event event = ManualInstrumentationManager::ApiEventFromTimerInfo(timer_info);
-  std::string name = GOrbitApp->GetManualInstrumentationManager()->GetString(event.id);
+  const uint64_t event_id = event.data;
+  std::string name = GOrbitApp->GetManualInstrumentationManager()->GetString(event_id);
   std::string text = absl::StrFormat("%s %s", name, time.c_str());
   text_box->SetText(text);
 
@@ -93,7 +95,8 @@ Color AsyncTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected) c
   }
 
   orbit_api::Event event = ManualInstrumentationManager::ApiEventFromTimerInfo(timer_info);
-  std::string name = GOrbitApp->GetManualInstrumentationManager()->GetString(event.id);
+  const uint64_t event_id = event.data;
+  std::string name = GOrbitApp->GetManualInstrumentationManager()->GetString(event_id);
   Color color = time_graph_->GetColor(name);
 
   constexpr uint8_t kOddAlpha = 210;

--- a/OrbitGl/ManualInstrumentationManager.cpp
+++ b/OrbitGl/ManualInstrumentationManager.cpp
@@ -36,10 +36,11 @@ orbit_api::Event ManualInstrumentationManager::ApiEventFromTimerInfo(
 void ManualInstrumentationManager::ProcessAsyncTimer(
     const orbit_client_protos::TimerInfo& timer_info) {
   orbit_api::Event event = ApiEventFromTimerInfo(timer_info);
+  const uint64_t event_id = event.data;
   if (event.type == orbit_api::kScopeStartAsync) {
-    async_timer_info_start_by_id_[event.id] = timer_info;
+    async_timer_info_start_by_id_[event_id] = timer_info;
   } else if (event.type == orbit_api::kScopeStopAsync) {
-    auto it = async_timer_info_start_by_id_.find(event.id);
+    auto it = async_timer_info_start_by_id_.find(event_id);
     if (it != async_timer_info_start_by_id_.end()) {
       const TimerInfo& start_timer_info = it->second;
       orbit_api::Event start_event = ApiEventFromTimerInfo(start_timer_info);
@@ -54,10 +55,11 @@ void ManualInstrumentationManager::ProcessAsyncTimer(
 
 void ManualInstrumentationManager::ProcessStringEvent(const orbit_api::Event& event) {
   // A string can be sent in chunks so we append the current value to any existing one.
-  auto result = string_manager_.Get(event.id);
+  const uint64_t event_id = event.data;
+  auto result = string_manager_.Get(event_id);
   if (result.has_value()) {
-    string_manager_.AddOrReplace(event.id, result.value() + event.name);
+    string_manager_.AddOrReplace(event_id, result.value() + event.name);
   } else {
-    string_manager_.AddOrReplace(event.id, event.name);
+    string_manager_.AddOrReplace(event_id, event.name);
   }
 }

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -382,22 +382,22 @@ void TimeGraph::ProcessValueTrackingTimer(const TimerInfo& timer_info) {
 
   switch (event.type) {
     case orbit_api::kTrackInt: {
-      track->AddValue(orbit_api::Decode<int32_t>(event.value), time);
+      track->AddValue(orbit_api::Decode<int32_t>(event.data), time);
     } break;
     case orbit_api::kTrackInt64: {
-      track->AddValue(orbit_api::Decode<int64_t>(event.value), time);
+      track->AddValue(orbit_api::Decode<int64_t>(event.data), time);
     } break;
     case orbit_api::kTrackUint: {
-      track->AddValue(orbit_api::Decode<uint32_t>(event.value), time);
+      track->AddValue(orbit_api::Decode<uint32_t>(event.data), time);
     } break;
     case orbit_api::kTrackUint64: {
-      track->AddValue(event.value, time);
+      track->AddValue(event.data, time);
     } break;
     case orbit_api::kTrackFloat: {
-      track->AddValue(orbit_api::Decode<float>(event.value), time);
+      track->AddValue(orbit_api::Decode<float>(event.data), time);
     } break;
     case orbit_api::kTrackDouble: {
-      track->AddValue(orbit_api::Decode<double>(event.value), time);
+      track->AddValue(orbit_api::Decode<double>(event.data), time);
     } break;
     default:
       ERROR("Unsupported value tracking type [%u]", event.type);


### PR DESCRIPTION
A 64 bits member makes more sense for an async event id as a user can
now use a pointer as unique id. "value" (uint64_t) and "id" (uint32_t)
were merged into a single uint64_t, "data", leaving room to increase
kMaxEventStringSize from 30 to 34 characters.