### PR TITLE
Add QWebChannelExtractor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,7 @@ if(WITH_GUI)
   add_subdirectory(OrbitSsh)
   add_subdirectory(OrbitSshQt)
   add_subdirectory(OrbitQt)
+  add_subdirectory(WebUI)
 endif()
 
 if(WIN32)

--- a/WebUI/CMakeLists.txt
+++ b/WebUI/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+project(webUI CXX)
+
+add_executable(QWebChannelExtractor QWebChannelExtractor.cpp)
+target_link_libraries(QWebChannelExtractor PUBLIC Qt5::WebChannel)
+set(q_webchannel_js_output "${CMAKE_CURRENT_BINARY_DIR}/qtwebchannel/qwebchannel.js")
+
+add_custom_command(OUTPUT "${q_webchannel_js_output}"
+                   COMMAND "$<TARGET_FILE:QWebChannelExtractor>"
+                   ARGS "${q_webchannel_js_output}"
+                   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                   DEPENDS QWebChannelExtractor
+                   COMMENT "Extracting qwebchannel.js from Qt5::WebChannel library")
+
+add_custom_target(q_webchannel_js ALL DEPENDS ${q_webchannel_js_output})
+
+if(WIN32)
+  get_target_property(_qmake_executable Qt5::qmake IMPORTED_LOCATION)
+  get_filename_component(_qt_bin_dir "${_qmake_executable}" DIRECTORY)
+  find_program(WINDEPLOYQT_EXECUTABLE windeployqt HINTS "${_qt_bin_dir}")
+
+  add_custom_command(
+    TARGET QWebChannelExtractor
+    POST_BUILD
+    COMMAND "${CMAKE_COMMAND}" -E env PATH="${_qt_bin_dir}"
+            "${WINDEPLOYQT_EXECUTABLE}" --pdb "$<TARGET_FILE:QWebChannelExtractor>"
+    COMMENT "Running windeployqt for QWebChannelExtractor...")
+endif()

--- a/WebUI/QWebChannelExtractor.cpp
+++ b/WebUI/QWebChannelExtractor.cpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <QDebug>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QWebChannel>
+#include <cstdio>
+
+int main(int argc, char* argv[]) {
+  // We need to consume a symbol from the QtWebChannel module. Otherwise
+  // the linker won't link against the corresponding library which contains
+  // the embedded resource that we're trying to extract.
+  QWebChannel _{};
+
+  QFile webchannel_js{":/qtwebchannel/qwebchannel.js"};
+
+  if (!webchannel_js.open(QIODevice::ReadOnly)) {
+    qCritical() << "QWebChannelExractor does not come with qwebchannel.js embedded!";
+    return 1;
+  }
+
+  if (argc != 2) {
+    QTextStream stream{stdout};
+    stream << webchannel_js.readAll();
+    return 0;
+  }
+
+  // Create the output directory if it does not exist
+  QFileInfo{argv[1]}.dir().mkpath(".");
+
+  QFile output_file{argv[1]};
+  if (!output_file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+    qCritical() << "Could not open the output file for writing.";
+    return 1;
+  }
+
+  output_file.write(webchannel_js.readAll());
+  return 0;
+}


### PR DESCRIPTION
(This is not targeting 1.53)

The JavaScript client library for Qt's WebChannel module is embedded
into the QtWebChannel shared library. For the development workflow we
need to extract that file. The simplest portable way to do that is to
compile an exectuable link it to QtWebChannel and output the resource.

On Windows where we use Qt from a conan package we could also copy the
library from the source archive, but this won't work on Linux where
we usually rely on system-installed Qt. That's why this extraction
mechanism is the simplest portable way of getting the right version of
that file.

This mechanism has a limitation: It won't work with cross-compilation
setups. But this can be easily added in the future by separating the
extractor into its own conan package and require that package as a build
requirement which means it will be compiled for the build platform and
not for the target platform. Currently we don't need the cross
compilation workflow for the UI.

Bug: http://b/169113529

The next step will be:
- Create a simple webpack config on top of this
- Having webpack run as part of the cmake build
- Automatically generate a qrc-file for all the files that webpack output
- Embed them into OrbitQt.