### PR TITLE
Add missing lock to TimeGraph::SortTracks

### DIFF
--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -912,6 +912,7 @@ void TimeGraph::SortTracks() {
       sortedThreadIds = filteredThreadIds;
     }
 
+    ScopeLock lock(mutex_);
     sorted_tracks_.clear();
 
     // Scheduler Track.


### PR DESCRIPTION
`TimeGraph::thread_tracks_` and `TimeGraph::gpu_tracks_` are accessed
from different threads and usually guarded by a mutex. In
`TimeGraph::SortTracks` a lock of this mutex is missing and might have
lead to the crash in the mentioned bug.

Test: Manual test of Orbit UI - Basic tests, Capturing works, Manual instrumentation works
Bug: http://b/169124700