### PR TITLE
Ship Orbit.h

### DIFF
--- a/kokoro/builds/build.sh
+++ b/kokoro/builds/build.sh
@@ -200,7 +200,8 @@ if [ -n "$1" ]; then
     cp -v NOTICE Orbit/NOTICE
     test -f NOTICE.Chromium && cp -v NOTICE.Chromium Orbit/NOTICE.Chromium
     cp -v LICENSE Orbit/LICENSE.txt
-    cp -av ../../contrib/automation_tests Orbit
+    cp -av "${REPO_ROOT}/contrib/automation_tests" Orbit
+    cp -v "${REPO_ROOT}/Orbit.h" Orbit/
     zip -r Orbit.zip Orbit/
     rm -rf Orbit/
     popd > /dev/null


### PR DESCRIPTION
This commit changes the CI build script such that the manual
instrumenation API header (Orbit.h) is deployed next to the Orbit
executable.

@danielfenner I hope you don't mind, I also changed the e2e-test copy command to use the `${REPO_ROOT}` variable.