### PR TITLE
Run OrbitQt tests always with offscreen rendering

### DIFF
--- a/OrbitQt/CMakeLists.txt
+++ b/OrbitQt/CMakeLists.txt
@@ -162,3 +162,9 @@ if (WIN32 AND "$ENV{QT_QPA_PLATFORM}" STREQUAL "offscreen")
   message(STATUS "Disabling OrbitQt-tests since they don't work in a headless setup")
   set_tests_properties(OrbitQt PROPERTIES DISABLED TRUE)
 endif()
+
+if (NOT WIN32)
+  # On Linux we can always run the tests with offscreen rendering. That won't do any harm
+  # and it avoid test failures in headless environments like SSH-sessions.
+  set_tests_properties(OrbitQt PROPERTIES ENVIRONMENT QT_QPA_PLATFORM=offscreen)
+endif()


### PR DESCRIPTION
The OrbitQt tests instantiate widgets and need a drawing context for
that. Usually that's the screen of the calling instance. In a CI context
there is no screen and we use offscreen rendering to run the tests.

This change enables the same for the developer workflow. Offscreen
rendering gets the default when available. And it's currently only
available on Linux.

This has the advantage that the OrbitQt tests don't fail anymore when
manually run from a headless context like a SSH session. Before a SSH
session with X11 forwarding was needed for a successful test. But this
also increased test times by roughly a factor of 50 to 100.

@reichlfl @dimitry- You both have written OrbitQt tests that do rendering. Please let me know if you think this might break something.