### PR TITLE
Have cmake always create compile_commands.json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,8 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
                            -Werror=sign-compare)
 endif()
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 option(WITH_ORBITGL "Setting this option will enable the OrbitGL component." ON)
 option(WITH_GUI "Setting this option will enable the Qt-based UI client." ON)
 option(WITH_CRASH_HANDLING "Setting this option will enable crash handling based on crashpad." ON)


### PR DESCRIPTION
This enables the generation of a compile_commands.json file in CMake
whenever the used generator allows it (No msbuild support though).

Always having a compile_commands.json is convenient for developers using
clangd and is a requirement for the integration of include_what_you_use.