### PR TITLE
Show thread names in sampling reports ("Sampling" tab)

### DIFF
--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -265,9 +265,9 @@ void SamplingReportDataView::SetSampledFunctions(const std::vector<SampledFuncti
 void SamplingReportDataView::SetThreadID(ThreadID tid) {
   tid_ = tid;
   if (tid == SamplingProfiler::kAllThreadsFakeTid) {
-    name_ = "All";
+    name_ = absl::StrFormat("%s\n(all threads)", GOrbitApp->GetCaptureData().process_name());
   } else {
-    name_ = absl::StrFormat("%d", tid_);
+    name_ = absl::StrFormat("%s\n[%d]", GOrbitApp->GetCaptureData().GetThreadName(tid_), tid_);
   }
 }
 

--- a/OrbitQt/orbitsamplingreport.ui
+++ b/OrbitQt/orbitsamplingreport.ui
@@ -44,6 +44,9 @@
         <verstretch>0</verstretch>
        </sizepolicy>
       </property>
+      <property name="styleSheet">
+       <string notr="true">QTabBar::tab { height: 40px; }</string>
+      </property>
       <property name="currentIndex">
        <number>-1</number>
       </property>


### PR DESCRIPTION
The tabs get wider but I think the gain compensates. Threads names are limited
to 15 characters anyway.

Bug: http://b/159313842

---

<img width="785" alt="Capture" src="https://user-images.githubusercontent.com/58685940/94136226-e88d9900-fe64-11ea-987f-c46c6450433b.PNG">

This might be a bit controversial as tabs take more space now, but they also become much more usable (ok, Trata doesn't really rename most of its threads...). Let me know what you think.