### PR TITLE
[On Release] Add already loaded functions after process switch

### DIFF
--- a/OrbitClientData/ModuleData.cpp
+++ b/OrbitClientData/ModuleData.cpp
@@ -75,13 +75,11 @@ void ModuleData::AddSymbols(const orbit_grpc_protos::ModuleSymbols& module_symbo
   is_loaded_ = true;
 }
 
-void ModuleData::ClearSymbols() {
+void ModuleData::UpdateFunctionsModuleBaseAddress(uint64_t module_base_address) {
   absl::MutexLock lock(&mutex_);
-
-  CHECK(is_loaded_);
-  functions_.clear();
-  hash_to_function_map_.clear();
-  is_loaded_ = false;
+  for (auto& [_, function] : functions_) {
+    function->set_module_base_address(module_base_address);
+  }
 }
 
 const orbit_client_protos::FunctionInfo* ModuleData::FindFunctionFromHash(uint64_t hash) const {

--- a/OrbitClientData/ModuleDataTest.cpp
+++ b/OrbitClientData/ModuleDataTest.cpp
@@ -82,16 +82,33 @@ TEST(ModuleData, LoadSymbols) {
   EXPECT_EQ(function->line(), 0);
 }
 
-TEST(ModuleData, ClearSymbols) {
+TEST(ModuleData, UpdateFunctionsModuleBaseAddress) {
   ModuleData module{ModuleInfo{}};
-  module.AddSymbols(ModuleSymbols(), 0);
-  EXPECT_TRUE(module.is_loaded());
-  module.ClearSymbols();
-  EXPECT_FALSE(module.is_loaded());
-  EXPECT_EQ(module.GetFunctions().size(), 0);
 
-  // don't clear when no symbols are loaded
-  EXPECT_DEATH(module.ClearSymbols(), "Check failed");
+  ModuleSymbols symbols{};
+  SymbolInfo* symbol = symbols.add_symbol_infos();
+  symbol->set_name("test name");
+
+  module.AddSymbols(symbols, 0);
+
+  ASSERT_TRUE(module.is_loaded());
+  ASSERT_EQ(module.GetFunctions().size(), 1);
+
+  {
+    const FunctionInfo* function = module.GetFunctions()[0];
+    EXPECT_EQ(function->name(), "test name");
+    EXPECT_EQ(function->module_base_address(), 0);
+  }
+  module.UpdateFunctionsModuleBaseAddress(100);
+
+  ASSERT_TRUE(module.is_loaded());
+  ASSERT_EQ(module.GetFunctions().size(), 1);
+
+  {
+    const FunctionInfo* function = module.GetFunctions()[0];
+    EXPECT_EQ(function->name(), "test name");
+    EXPECT_EQ(function->module_base_address(), 100);
+  }
 }
 
 TEST(ModuleData, FindFunctionByRelativeAddress) {

--- a/OrbitClientData/ProcessDataTest.cpp
+++ b/OrbitClientData/ProcessDataTest.cpp
@@ -136,22 +136,22 @@ TEST(ProcessData, MemorySpace) {
 
 TEST(ProcessData, IsModuleLoaded) {
   const std::string file_path_1 = "filepath1";
-  uint64_t start_address1 = 0;
+  uint64_t start_address_1 = 0;
   uint64_t end_address_1 = 10;
-  ModuleInfo module_info1;
-  module_info1.set_file_path(file_path_1);
-  module_info1.set_address_start(start_address1);
-  module_info1.set_address_end(end_address_1);
+  ModuleInfo module_info_1;
+  module_info_1.set_file_path(file_path_1);
+  module_info_1.set_address_start(start_address_1);
+  module_info_1.set_address_end(end_address_1);
 
   const std::string file_path_2 = "filepath2";
   uint64_t start_address_2 = 100;
   uint64_t end_address_2 = 110;
-  ModuleInfo module_info2;
-  module_info2.set_file_path(file_path_2);
-  module_info2.set_address_start(start_address_2);
-  module_info1.set_address_end(end_address_2);
+  ModuleInfo module_info_2;
+  module_info_2.set_file_path(file_path_2);
+  module_info_2.set_address_start(start_address_2);
+  module_info_1.set_address_end(end_address_2);
 
-  std::vector<ModuleInfo> module_infos{module_info1, module_info2};
+  std::vector<ModuleInfo> module_infos{module_info_1, module_info_2};
 
   std::unique_ptr<ProcessData> process = ProcessData::Create(ProcessInfo{});
   process->UpdateModuleInfos(module_infos);
@@ -159,6 +159,33 @@ TEST(ProcessData, IsModuleLoaded) {
   EXPECT_TRUE(process->IsModuleLoaded(file_path_1));
   EXPECT_TRUE(process->IsModuleLoaded(file_path_2));
   EXPECT_FALSE(process->IsModuleLoaded("not/loaded/module"));
+}
+
+TEST(ProcessData, GetModuleBaseAddress) {
+  const std::string file_path_1 = "filepath1";
+  uint64_t start_address_1 = 0;
+  uint64_t end_address_1 = 10;
+  ModuleInfo module_info_1;
+  module_info_1.set_file_path(file_path_1);
+  module_info_1.set_address_start(start_address_1);
+  module_info_1.set_address_end(end_address_1);
+
+  const std::string file_path_2 = "filepath2";
+  uint64_t start_address_2 = 100;
+  uint64_t end_address_2 = 110;
+  ModuleInfo module_info_2;
+  module_info_2.set_file_path(file_path_2);
+  module_info_2.set_address_start(start_address_2);
+  module_info_1.set_address_end(end_address_2);
+
+  std::vector<ModuleInfo> module_infos{module_info_1, module_info_2};
+
+  std::unique_ptr<ProcessData> process = ProcessData::Create(ProcessInfo{});
+  process->UpdateModuleInfos(module_infos);
+
+  EXPECT_EQ(process->GetModuleBaseAddress(file_path_1), start_address_1);
+  EXPECT_EQ(process->GetModuleBaseAddress(file_path_2), start_address_2);
+  EXPECT_DEATH(process->GetModuleBaseAddress("does/not/exist"), "Check failed");
 }
 
 TEST(ProcessData, CreateCopy) {

--- a/OrbitClientData/include/OrbitClientData/ModuleData.h
+++ b/OrbitClientData/include/OrbitClientData/ModuleData.h
@@ -37,12 +37,14 @@ class ModuleData final {
       uint64_t relative_address, bool is_exact) const;
   [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionByElfAddress(
       uint64_t elf_address, bool is_exact) const;
-  // TODO(antonrohr): The module_base_address parameter should not be needed here, but it is
+  // TODO(169309553): The module_base_address parameter should not be needed here, but it is
   // because FunctionInfo still contains the field module_base_address. As soon as that field is
   // gone, remove the parameter here
   void AddSymbols(const orbit_grpc_protos::ModuleSymbols& module_symbols,
                   uint64_t module_base_address);
-  void ClearSymbols();
+  // TODO(169309553): As soon as FunctionInfo does not contain module_base_address anymore,
+  // completely remove the following method
+  void UpdateFunctionsModuleBaseAddress(uint64_t module_base_address);
   [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionFromHash(uint64_t hash) const;
   [[nodiscard]] const std::vector<const orbit_client_protos::FunctionInfo*> GetFunctions() const;
   [[nodiscard]] const std::vector<const orbit_client_protos::FunctionInfo*> GetOrbitFunctions()

--- a/OrbitClientData/include/OrbitClientData/ProcessData.h
+++ b/OrbitClientData/include/OrbitClientData/ProcessData.h
@@ -54,9 +54,13 @@ class ProcessData final {
   [[nodiscard]] ErrorMessageOr<std::pair<std::string, uint64_t>> FindModuleByAddress(
       uint64_t absolute_address) const;
 
-  // TODO(antonrohr): remove this function and add symbols directly into a module, as soon as the
+  // TODO(169309553): remove this function and add symbols directly into a module, as soon as the
   // module_base_address is not needed anymore (FunctionInfo needs to be changed)
   void AddSymbols(ModuleData* module, const orbit_grpc_protos::ModuleSymbols& module_symbols) const;
+  uint64_t GetModuleBaseAddress(const std::string& module_path) const {
+    CHECK(module_memory_map_.contains(module_path));
+    return module_memory_map_.at(module_path).start;
+  }
   const absl::flat_hash_map<std::string, MemorySpace>& GetMemoryMap() const {
     return module_memory_map_;
   }

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -1032,11 +1032,10 @@ void OrbitApp::UpdateProcessAndModuleList(int32_t pid) {
       return;
     }
 
-    main_thread_executor_->Schedule([pid, result, this] {
+    main_thread_executor_->Schedule([pid, module_infos = std::move(result.value()), this] {
+      data_manager_->UpdateModuleInfos(pid, module_infos);
       // Make sure that pid is actually what user has selected at
       // the moment we arrive here. If not - ignore the result.
-      const std::vector<ModuleInfo>& module_infos = result.value();
-      data_manager_->UpdateModuleInfos(pid, module_infos);
       if (pid != processes_data_view_->GetSelectedProcessId()) {
         return;
       }
@@ -1047,19 +1046,16 @@ void OrbitApp::UpdateProcessAndModuleList(int32_t pid) {
       // propagate the changes to the UI.
 
       // If no process was selected before, or the process changed
-      const ProcessData* selected_process = data_manager_->selected_process();
-      if (selected_process == nullptr || pid != selected_process->pid()) {
+      if (GetSelectedProcess() == nullptr || pid != GetSelectedProcess()->pid()) {
         data_manager_->ClearSelectedFunctions();
         data_manager_->set_selected_process(pid);
-        functions_data_view_->ClearFunctions();
+      }
 
-        for (const auto& [module_path, memory_space] : GetSelectedProcess()->GetMemoryMap()) {
-          ModuleData* module = data_manager_->GetMutableModuleByPath(module_path);
-          if (module->is_loaded()) {
-            // TODO(antonrohr) As soon as FunctionInfo does not contain an absolute address anymore,
-            // do not clear the symbols here, but add them to functions_data_view.
-            module->ClearSymbols();
-          }
+      functions_data_view_->ClearFunctions();
+      for (const auto& [module_path, _] : GetSelectedProcess()->GetMemoryMap()) {
+        ModuleData* module = data_manager_->GetMutableModuleByPath(module_path);
+        if (module->is_loaded()) {
+          functions_data_view_->AddFunctions(module->GetFunctions());
         }
       }
 

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -229,11 +229,11 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void SendErrorToUi(const std::string& title, const std::string& text);
   void NeedsRedraw();
 
-  // TODO(antonrohr) get rid of ProcessData here, the process should not be needed to load a module.
+  // TODO(169309553) get rid of ProcessData here, the process should not be needed to load a module.
   // Also remove shared_ptr from PresetFile. Also consider references instead of pointers
   void LoadModules(const ProcessData* process, const std::vector<ModuleData*>& modules,
                    const std::shared_ptr<orbit_client_protos::PresetFile>& preset = nullptr);
-  // TODO(antonrohr) get rid of Process
+  // TODO(169309553) get rid of Process
   void LoadModulesFromPreset(const ProcessData* process,
                              const std::shared_ptr<orbit_client_protos::PresetFile>& preset);
   void UpdateProcessAndModuleList(int32_t pid);
@@ -293,8 +293,12 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
  private:
   ErrorMessageOr<std::filesystem::path> FindSymbolsLocally(const std::filesystem::path& module_path,
                                                            const std::string& build_id);
+  // TODO(169309553): remove the process here, as soon as module_base_address is removed from
+  // FunctionInfo
   void LoadSymbols(const std::filesystem::path& symbols_path, const ProcessData* process,
                    ModuleData* module_data, const orbit_client_protos::PresetModule* preset_module);
+  // TODO(169309553): remove the process here, as soon as module_base_address is removed from
+  // FunctionInfo
   void LoadModuleOnRemote(const ProcessData* process, ModuleData* module_data,
                           const orbit_client_protos::PresetModule* preset_module);
   ErrorMessageOr<void> SelectFunctionsFromPreset(const ModuleData* module,

--- a/OrbitGl/ModulesDataView.h
+++ b/OrbitGl/ModulesDataView.h
@@ -37,7 +37,7 @@ class ModulesDataView : public DataView {
  private:
   [[nodiscard]] ModuleData* GetModule(uint32_t row) const { return modules_[indices_[row]]; }
 
-  // TODO(antonrohr) Saving this process_ here is currently only necessary because symbol loading
+  // TODO(169309553) Saving this process_ here is currently only necessary because symbol loading
   // involves the process (see GOrbitApp->LoadSymbols). The plan is not involve the process in
   // symbol loading anymore, once this changed, remove this process_ field.
   const ProcessData* process_ = nullptr;


### PR DESCRIPTION
To fix the regression in 1.53. (b/169305654)

Before: When switching the process the symbols in modules were cleared. FunctionsDataView was also cleared. 
Now: symbols in modules are not cleared but updated if necessary. FunctionsDataView is filled with existing functions.

Whenever the list of modules of a process changes, it could be that a module is now loaded at a different memory address than before (module_base_address). If this is actually the case and the module already contained Functions, the field `module_base_address` of these Functions is updated to the new value. 

This also adds/changes the appropriate tests