### PR TITLE
Don't set system_qt option in build script

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -47,7 +47,7 @@ foreach ($profile in $profiles) {
   
   Write-Host "Building Orbit in build_$profile/ with conan profile $profile"
 
-  $process = Start-Process $conan.Path -Wait -NoNewWindow -ErrorAction Stop -PassThru -ArgumentList "install","--update","-pr",$profile,"-o","system_qt=False","-if","build_$profile/","--build","outdated",$PSScriptRoot
+  $process = Start-Process $conan.Path -Wait -NoNewWindow -ErrorAction Stop -PassThru -ArgumentList "install","--update","-pr",$profile,"-if","build_$profile/","--build","outdated",$PSScriptRoot
   if ($process.ExitCode -ne 0) {
     Throw "Error while running conan install."
   }


### PR DESCRIPTION
The build.ps1 script used to set the `system_qt` setting when calling
`conan install`. That's wrong because this settings should be set by
the conan profiles.

This change removes the settings which solves a problem when building
for Stadia on Windows.

@pierricgimmig : FYI, that's the fix to the problem you had as well.