### PR TITLE
[On Release] Reenable Context Menus for Loaded Captures if Still Connected

### DIFF
--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -238,6 +238,16 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
                              const std::shared_ptr<orbit_client_protos::PresetFile>& preset);
   void UpdateProcessAndModuleList(int32_t pid);
 
+  [[nodiscard]] ModuleData* FindMutableModuleByAddress(int32_t process_id,
+                                                       uint64_t absolute_address) {
+    return data_manager_->FindMutableModuleByAddress(process_id, absolute_address);
+  }
+
+  [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionByAddress(
+      int32_t process_id, uint64_t absolute_address, bool is_exact) const {
+    return data_manager_->FindFunctionByAddress(process_id, absolute_address, is_exact);
+  }
+
   void UpdateAfterSymbolLoading();
   void UpdateAfterCaptureCleared();
 

--- a/OrbitGl/DataManager.cpp
+++ b/OrbitGl/DataManager.cpp
@@ -189,7 +189,8 @@ bool DataManager::IsTracepointSelected(const TracepointInfo& info) const {
 
 const TracepointInfoSet& DataManager::selected_tracepoints() const { return selected_tracepoints_; }
 
-const ModuleData* DataManager::FindModuleByAddress(int32_t process_id, uint64_t absolute_address) {
+ModuleData* DataManager::FindMutableModuleByAddress(int32_t process_id,
+                                                    uint64_t absolute_address) const {
   CHECK(std::this_thread::get_id() == main_thread_id_);
 
   const ProcessData* process = GetProcessByPid(process_id);

--- a/OrbitGl/DataManager.h
+++ b/OrbitGl/DataManager.h
@@ -39,8 +39,8 @@ class DataManager final {
   [[nodiscard]] const ProcessData* GetProcessByPid(int32_t process_id) const;
   [[nodiscard]] const ModuleData* GetModuleByPath(const std::string& path) const;
   [[nodiscard]] ModuleData* GetMutableModuleByPath(const std::string& path) const;
-  [[nodiscard]] const ModuleData* FindModuleByAddress(int32_t process_id,
-                                                      uint64_t absolute_address);
+  [[nodiscard]] ModuleData* FindMutableModuleByAddress(int32_t process_id,
+                                                       uint64_t absolute_address) const;
   [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionByAddress(
       int32_t process_id, uint64_t absolute_address, bool is_exact) const;
   [[nodiscard]] absl::flat_hash_map<std::string, ModuleData*> GetModulesLoadedByProcess(


### PR DESCRIPTION
Recent changes (#1252 and #1208) disabled some context menus on
loaded captures based on function/module pointers taken from
capture data.
However, if we just save a capture and load it again (without
switching to another process), these actions are possible with
1.52.

Bug: http://b/169305792
Test: 1. Take capture, load it directly -> context menus are there
      2. Take capture, switch process, load capture -> no context menu
      3. Load a capture -> no context menus