### PR TITLE
Add a white rectangle near the variable values

### DIFF
--- a/OrbitGl/TextRenderer.cpp
+++ b/OrbitGl/TextRenderer.cpp
@@ -220,8 +220,7 @@ void TextRenderer::AddText(const char* a_Text, float a_X, float a_Y, float a_Z,
 
   if (a_RightJustified) {
     a_MaxSize = FLT_MAX;
-    int stringWidth, stringHeight;
-    GetStringSize(a_Text, stringWidth, stringHeight);
+    int stringWidth = GetStringWidth(a_Text);
     m_Pen.x -= stringWidth;
   }
 
@@ -302,8 +301,7 @@ void TextRenderer::AddTextTrailingCharsPrioritized(const char* a_Text, float a_X
 int TextRenderer::AddText2D(const char* a_Text, int a_X, int a_Y, float a_Z, const Color& a_Color,
                             float a_MaxSize, bool a_RightJustified, bool a_InvertY) {
   if (a_RightJustified) {
-    int stringWidth, stringHeight;
-    GetStringSize(a_Text, stringWidth, stringHeight);
+    int stringWidth = GetStringWidth(a_Text);
     a_X -= stringWidth;
   }
 
@@ -315,9 +313,8 @@ int TextRenderer::AddText2D(const char* a_Text, int a_X, int a_Y, float a_Z, con
   return a_X;
 }
 
-void TextRenderer::GetStringSize(const char* a_Text, int& a_Width, int& a_Height) {
+int TextRenderer::GetStringWidth(const char* a_Text) const {
   float stringWidth = 0;
-  float stringHeight = 0;
 
   std::size_t len = strlen(a_Text);
   for (std::size_t i = 0; i < len; ++i) {
@@ -330,19 +327,10 @@ void TextRenderer::GetStringSize(const char* a_Text, int& a_Width, int& a_Height
 
       stringWidth += kerning;
       stringWidth += glyph->advance_x;
-
-      if (glyph->height > stringHeight) stringHeight = glyph->height;
     }
   }
 
-  a_Width = static_cast<int>(stringWidth);
-  a_Height = static_cast<int>(stringHeight);
-}
-
-int TextRenderer::GetStringHeight(const char* a_Text) {
-  int w, h;
-  GetStringSize(a_Text, w, h);
-  return h;
+  return static_cast<int>(ceil(stringWidth));
 }
 
 void TextRenderer::ToScreenSpace(float a_X, float a_Y, float& o_X, float& o_Y) {

--- a/OrbitGl/TextRenderer.h
+++ b/OrbitGl/TextRenderer.h
@@ -32,8 +32,7 @@ class TextRenderer {
   int AddText2D(const char* a_Text, int a_X, int a_Y, float a_Z, const Color& a_Color,
                 float a_MaxSize = -1.f, bool a_RightJustified = false, bool a_InvertY = true);
 
-  void GetStringSize(const char* a_Text, int& a_Width, int& a_Height);
-  int GetStringHeight(const char* a_Text);
+  int GetStringWidth(const char* a_Text) const;
   void Clear();
   void SetCanvas(class GlCanvas* a_Canvas) { m_Canvas = a_Canvas; }
   const GlCanvas* GetCanvas() const { return m_Canvas; }


### PR DESCRIPTION
Previously, in manual instrumentation we wrote the value of each variable on the top of their track. Now, we draw a white rectangle closer to the corresponding value.

Related to b\169310201.

Before:
![Screen Shot 2020-09-24 at 14 04 16](https://user-images.githubusercontent.com/8610429/94151073-411b6100-fe7a-11ea-9406-84b212db0f8f.png)

After
![Screen Shot 2020-09-24 at 14 20 53](https://user-images.githubusercontent.com/8610429/94150942-116c5900-fe7a-11ea-8e95-6f87efee271a.png)
