### PR TITLE
Move OrbitApp and ImGui scope to RunUiInstance

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -452,7 +452,6 @@ void OrbitApp::OnExit() {
   thread_pool_->ShutdownAndWait();
 
   GOrbitApp = nullptr;
-  Orbit_ImGui_Shutdown();
 }
 
 Timer GMainTimer;

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -80,7 +80,6 @@ GlCanvas::GlCanvas() : ui_batcher_(BatcherId::kUi, &m_PickingManager) {
 
   m_ImGuiContext = ImGui::CreateContext();
   ScopeImguiContext state(m_ImGuiContext);
-  Orbit_ImGui_Init();
 }
 
 GlCanvas::~GlCanvas() {

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -21,7 +21,6 @@
 #include <utility>
 
 #include "App.h"
-#include "MainThreadExecutorImpl.h"
 #include "OrbitClientModel/CaptureSerializer.h"
 #include "OrbitVersion/OrbitVersion.h"
 #include "Path.h"
@@ -49,11 +48,9 @@ using orbit_grpc_protos::CrashOrbitServiceRequest_CrashType_STACK_OVERFLOW;
 
 extern QMenu* GContextMenu;
 
-OrbitMainWindow::OrbitMainWindow(QApplication* a_App, ApplicationOptions&& options,
+OrbitMainWindow::OrbitMainWindow(QApplication* a_App,
                                  OrbitQt::ServiceDeployManager* service_deploy_manager)
     : QMainWindow(nullptr), m_App(a_App), ui(new Ui::OrbitMainWindow) {
-  OrbitApp::Init(std::move(options), CreateMainThreadExecutor());
-
   DataViewFactory* data_view_factory = GOrbitApp.get();
 
   ui->setupUi(this);

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -18,7 +18,6 @@
 #include <string>
 #include <vector>
 
-#include "ApplicationOptions.h"
 #include "CallStackDataView.h"
 #include "StatusListener.h"
 #include "TopDownView.h"
@@ -32,8 +31,7 @@ class OrbitMainWindow : public QMainWindow {
   Q_OBJECT
 
  public:
-  OrbitMainWindow(QApplication* a_App, ApplicationOptions&& options,
-                  OrbitQt::ServiceDeployManager* service_deploy_manager);
+  OrbitMainWindow(QApplication* a_App, OrbitQt::ServiceDeployManager* service_deploy_manager);
   ~OrbitMainWindow() override;
 
   void RegisterGlWidget(class OrbitGLWidget* a_GlWidget) { m_GlWidgets.push_back(a_GlWidget); }


### PR DESCRIPTION
**Targets release 1.53**

When Orbit's main window is closed, the process does not exit.

Reason: 
Destruction of `TimeGraph` accesses `GOrbitApp::manual_instrumentation_manager_`, but GOrbitApp is destroyed before TimeGraph.

Current Initialization:
OrbitMainWindow is initialized on the Stack by main.cpp::RunUiInstance()
OrbitMainWindow calls GOrbitApp::Init()

Current Deinitialization:
main.cpp::RunUiInstance() calls GOrbitApp::Deinit() after the main window is closed
OrbitMainWindow is deleted when it runs out of scope (when main.cpp::RunUiInstance() returns)

In addition, ImGui is initialized by GLCanvas (which is initialized by OrbitMainWindow), deleted by GOrbitApp, which introduced another bug after fixing this one.

Fix:
main.cpp::RunUiInstance() manages scope of GOrbitApp, ImGui and OrbitMainWindow directly, no more hidden initialization of GOrbitApp and ImGui.

Adding a bunch of reviewers since it's a hotfix for the release.
@pierricgimmig Please take a careful look if this could interfere with anything else regarding manual instrumentation.