### PR TITLE
Selection in the Capture Window is no longer cleared when scrolling up

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -757,7 +757,7 @@ void OrbitApp::StopCapture() {
 
 void OrbitApp::ClearCapture() {
   capture_data_ = CaptureData();
-  set_selected_thread_id(-1);
+  set_selected_thread_id(SamplingProfiler::kAllThreadsFakeTid);
   SelectTextBox(nullptr);
 
   UpdateAfterCaptureCleared();

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -129,7 +129,7 @@ void CaptureWindow::LeftUp() {
 
   if (!click_was_drag_ && background_clicked_) {
     GOrbitApp->SelectTextBox(nullptr);
-    GOrbitApp->set_selected_thread_id(-1);
+    GOrbitApp->set_selected_thread_id(SamplingProfiler::kAllThreadsFakeTid);
     NeedsUpdate();
   }
 }

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -70,6 +70,9 @@ class CaptureWindow : public GlCanvas {
   std::shared_ptr<GlSlider> slider_;
   std::shared_ptr<GlSlider> vertical_slider_;
 
+  bool click_was_drag_ = false;
+  bool background_clicked_ = false;
+
   static const std::string MENU_ACTION_GO_TO_CALLSTACK;
   static const std::string MENU_ACTION_GO_TO_SOURCE;
 };

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -34,6 +34,8 @@ float GlCanvas::kZValueEventBar = -0.1f;
 float GlCanvas::kZValueTrack = -0.2f;
 
 const Color GlCanvas::kBackgroundColor = Color(67, 67, 67, 255);
+const Color GlCanvas::kTabColor = Color(50, 50, 50, 255);
+const Color GlCanvas::kTabTextColorSelected = Color(100, 181, 246, 255);
 
 GlCanvas::GlCanvas() : ui_batcher_(BatcherId::kUi, &m_PickingManager) {
   m_TextRenderer.SetCanvas(this);

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -114,6 +114,8 @@ class GlCanvas : public GlPanel {
   static float kZValueTrack;
 
   static const Color kBackgroundColor;
+  static const Color kTabColor;
+  static const Color kTabTextColorSelected;
 
  protected:
   [[nodiscard]] PickingMode GetPickingMode();

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -54,7 +54,7 @@ bool GpuTrack::IsTimerActive(const TimerInfo& timer_info) const {
   // We do not properly track the PID for GPU jobs and we still want to show
   // all jobs as active when no thread is selected, so this logic is a bit
   // different than SchedulerTrack::IsTimerActive.
-  bool no_thread_selected = GOrbitApp->selected_thread_id() == -1;
+  bool no_thread_selected = GOrbitApp->selected_thread_id() == SamplingProfiler::kAllThreadsFakeTid;
 
   return is_same_tid_as_selected || no_thread_selected;
 }

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -81,6 +81,11 @@ bool ThreadTrack::IsTimerActive(const TimerInfo& timer_info) const {
   return GOrbitApp->IsFunctionVisible(timer_info.function_address());
 }
 
+bool ThreadTrack::IsTrackSelected() const {
+  return thread_id_ != SamplingProfiler::kAllThreadsFakeTid &&
+         GOrbitApp->selected_thread_id() == thread_id_;
+}
+
 [[nodiscard]] static inline Color ToColor(uint64_t val) {
   return Color((val >> 24) & 0xFF, (val >> 16) & 0xFF, (val >> 8) & 0xFF, val & 0xFF);
 }
@@ -148,6 +153,8 @@ void ThreadTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   tracepoint_track_->SetSize(canvas->GetWorldWidth(), event_track_height);
   tracepoint_track_->Draw(canvas, picking_mode);
 }
+
+void ThreadTrack::OnPick(int /*x*/, int /*y*/) { GOrbitApp->set_selected_thread_id(thread_id_); }
 
 void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode) {
   event_track_->SetPos(pos_[0], pos_[1]);

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -25,6 +25,8 @@ class ThreadTrack : public TimerTrack {
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
 
+  void OnPick(int x, int y) override;
+
   void UpdateBoxHeight() override;
   void SetTrackColor(Color color);
   [[nodiscard]] bool IsEmpty() const override;
@@ -33,6 +35,8 @@ class ThreadTrack : public TimerTrack {
 
  protected:
   [[nodiscard]] bool IsTimerActive(const orbit_client_protos::TimerInfo& timer) const override;
+  [[nodiscard]] virtual bool IsTrackSelected() const override;
+
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer,
                                     bool is_selected) const override;
   void SetTimesliceText(const orbit_client_protos::TimerInfo& timer, double elapsed_us, float min_x,

--- a/OrbitGl/TimerTrack.h
+++ b/OrbitGl/TimerTrack.h
@@ -61,8 +61,6 @@ class TimerTrack : public Track {
 
   [[nodiscard]] bool IsCollapsable() const override { return depth_ > 1; }
 
-  [[nodiscard]] float GetTextBoxHeight() const;
-
   virtual void UpdateBoxHeight();
   [[nodiscard]] virtual float GetYFromDepth(uint32_t depth) const;
 

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -79,7 +79,6 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   Batcher* batcher = canvas->GetBatcher();
 
   const TimeGraphLayout& layout = time_graph_->GetLayout();
-  const Color kTabColor(50, 50, 50, 255);
   const bool picking = picking_mode != PickingMode::kNone;
 
   float x0 = pos_[0];
@@ -94,7 +93,7 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   if (!picking) {
     if (layout.GetDrawTrackBackground()) {
       Box box(Vec2(x0, y0 + top_margin), Vec2(size_[0], -size_[1] - top_margin), track_z);
-      batcher->AddBox(box, kTabColor, shared_from_this());
+      batcher->AddBox(box, GlCanvas::kTabColor, shared_from_this());
     }
   }
 
@@ -106,7 +105,7 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   float tab_x0 = x0 + layout.GetTrackTabOffset();
 
   Box box(Vec2(tab_x0, y0), Vec2(label_width, label_height), track_z);
-  batcher->AddBox(box, kTabColor, shared_from_this());
+  batcher->AddBox(box, GlCanvas::kTabColor, shared_from_this());
 
   // Draw rounded corners.
   if (!picking) {
@@ -123,9 +122,8 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
     Vec2 end_top(x1 - right_margin, y0 + top_margin);
     float z = GlCanvas::kZValueRoundingCorner;
 
-    glColor4ubv(&kTabColor[0]);
     DrawTriangleFan(batcher, rounded_corner, bottom_left, GlCanvas::kBackgroundColor, 0, z);
-    DrawTriangleFan(batcher, rounded_corner, bottom_right, kTabColor, 0, z);
+    DrawTriangleFan(batcher, rounded_corner, bottom_right, GlCanvas::kTabColor, 0, z);
     DrawTriangleFan(batcher, rounded_corner, top_right, GlCanvas::kBackgroundColor, 180.f, z);
     DrawTriangleFan(batcher, rounded_corner, top_left, GlCanvas::kBackgroundColor, -90.f, z);
     DrawTriangleFan(batcher, rounded_corner, end_bottom, GlCanvas::kBackgroundColor, 90.f, z);
@@ -151,9 +149,10 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
     float label_offset_x = layout.GetTrackLabelOffsetX();
     // Vertical offset for the text to be aligned to the center of the triangle.
     float label_offset_y = GCurrentTimeGraph->GetFontSize() / 3.f;
-    const Color kTextWhite(255, 255, 255, 255);
+    const Color kColor =
+        IsTrackSelected() ? GlCanvas::kTabTextColorSelected : Color(255, 255, 255, 255);
     canvas->AddText(label_.c_str(), tab_x0 + label_offset_x, toggle_y_pos - label_offset_y, text_z,
-                    kTextWhite, label_width - label_offset_x);
+                    kColor, label_width - label_offset_x);
   }
 
   canvas_ = canvas;

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -84,6 +84,8 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
   void DrawTriangleFan(Batcher* batcher, const std::vector<Vec2>& points, const Vec2& pos,
                        const Color& color, float rotation, float z);
 
+  [[nodiscard]] virtual bool IsTrackSelected() const { return false; }
+
   GlCanvas* canvas_;
   TimeGraph* time_graph_;
   Vec2 pos_;


### PR DESCRIPTION
The selected thread was cleared as soon as anything else was clicked
inside the capture window. This also happened when the user tried
to scroll up to see the scheduler view.

To reproduce:
1) Select a thread
2) Scroll in the capture view
-> Thread is no longer selected.

Fix:
1) Threads are not deselected if any pickable is clicked
2) Threads are not deselected if the capture window background is clicked **and** dragged

In addition, thread selection was improved:
- Threads can be selected by clicking on the tab title
- Titles of selected threads are shown in blue

3 commits:
1) Fix the selection issue
2) Cleanup the use of "-1" as fake thread id
3) Highlight currently selected thread

![image](https://user-images.githubusercontent.com/63750742/94158165-598f7980-fe82-11ea-85cd-19802d950fdc.png)
