### PR TITLE
Remove duplicate events in TracepointEventBuffer

### DIFF
--- a/OrbitClientModel/CaptureSerializerTest.cpp
+++ b/OrbitClientModel/CaptureSerializerTest.cpp
@@ -163,10 +163,7 @@ TEST(CaptureSerializer, GenerateCaptureInfo) {
   ASSERT_EQ(actual_tracepoint_info.name(), selected_tracepoint_info.name());
   ASSERT_EQ(actual_tracepoint_info.tracepoint_info_key(), 0);
 
-  /*Note: capture_info.tracepoint_event_infos_size() is 2 and not 1 because for every call adding
-   * TracepointEventInfo, a tracepoint event is created and added twice (once for the corresponding
-   * thread and another time for all threads).*/
-  EXPECT_EQ(2, capture_info.tracepoint_event_infos_size());
+  EXPECT_EQ(1, capture_info.tracepoint_event_infos_size());
   const orbit_client_protos::TracepointEventInfo& actual_tracepoint_event =
       capture_info.tracepoint_event_infos(0);
   EXPECT_EQ(tracepoint_event.tid(), actual_tracepoint_event.tid());

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -111,10 +111,6 @@ class CaptureData {
 
   [[nodiscard]] const CallstackData* GetCallstackData() const { return callstack_data_.get(); };
 
-  [[nodiscard]] Mutex& GetTracepointEventBufferMutex() const {
-    return tracepoint_event_buffer_->mutex();
-  }
-
   [[nodiscard]] orbit_grpc_protos::TracepointInfo GetTracepointInfo(uint64_t key) const {
     return tracepoint_info_manager_->Get(key);
   }
@@ -125,6 +121,13 @@ class CaptureData {
 
   [[nodiscard]] const TracepointEventBuffer* GetTracepointEventBuffer() const {
     return tracepoint_event_buffer_.get();
+  }
+
+  void ForEachTracepointEventPerThread(
+      int32_t thread_id,
+      const std::function<void(
+          const std::map<uint64_t, orbit_client_protos::TracepointEventInfo>&)>& action) const {
+    return tracepoint_event_buffer_->ForEachTracepointEventPerThread(thread_id, action);
   }
 
   [[nodiscard]] const std::map<uint64_t, orbit_client_protos::TracepointEventInfo>&

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -123,11 +123,11 @@ class CaptureData {
     return tracepoint_event_buffer_.get();
   }
 
-  void ForEachTracepointEventPerThread(
-      int32_t thread_id,
-      const std::function<void(
-          const std::map<uint64_t, orbit_client_protos::TracepointEventInfo>&)>& action) const {
-    return tracepoint_event_buffer_->ForEachTracepointEventPerThread(thread_id, action);
+  void ForEachTracepointEventOfThread(
+      int32_t thread_id, uint64_t min_tick, uint64_t max_tick,
+      const std::function<void(const orbit_client_protos::TracepointEventInfo&)>& action) const {
+    return tracepoint_event_buffer_->ForEachTracepointEventOfThread(thread_id, min_tick, max_tick,
+                                                                    action);
   }
 
   [[nodiscard]] const std::map<uint64_t, orbit_client_protos::TracepointEventInfo>&

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -123,11 +123,11 @@ class CaptureData {
     return tracepoint_event_buffer_.get();
   }
 
-  void ForEachTracepointEventOfThread(
+  void ForEachTracepointEventOfThreadInTimeRange(
       int32_t thread_id, uint64_t min_tick, uint64_t max_tick,
       const std::function<void(const orbit_client_protos::TracepointEventInfo&)>& action) const {
-    return tracepoint_event_buffer_->ForEachTracepointEventOfThread(thread_id, min_tick, max_tick,
-                                                                    action);
+    return tracepoint_event_buffer_->ForEachTracepointEventOfThreadInTimeRange(thread_id, min_tick,
+                                                                               max_tick, action);
   }
 
   [[nodiscard]] const std::map<uint64_t, orbit_client_protos::TracepointEventInfo>&

--- a/OrbitCore/TracepointEventBuffer.cpp
+++ b/OrbitCore/TracepointEventBuffer.cpp
@@ -11,14 +11,21 @@ void TracepointEventBuffer::AddTracepointEventAndMapToThreads(uint64_t time,
                                                               int32_t process_id, int32_t thread_id,
                                                               int32_t cpu,
                                                               bool is_same_pid_as_target) {
+  ScopeLock lock(mutex_);
   if (!is_same_pid_as_target) {
+    std::map<uint64_t, orbit_client_protos::TracepointEventInfo>&
+        event_map_tracepoints_not_in_target_process =
+            tracepoint_events_[kAllTracepointsNotInTargetProcessFakeTid];
+    orbit_client_protos::TracepointEventInfo event;
+    event.set_time(time);
+    event.set_tracepoint_info_key(tracepoint_hash);
+    event.set_tid(thread_id);
+    event.set_pid(process_id);
+    event.set_cpu(cpu);
+    event_map_tracepoints_not_in_target_process[time] = std::move(event);
     return;
   }
 
-  /*TODO: tracepoint events with !is_same_pid_as_target will also have to be
-   * stored when implementing the track showing tracepoint events from all processes in the system*/
-
-  ScopeLock lock(mutex_);
   std::map<uint64_t, orbit_client_protos::TracepointEventInfo>& event_map =
       tracepoint_events_[thread_id];
   orbit_client_protos::TracepointEventInfo event;
@@ -28,17 +35,6 @@ void TracepointEventBuffer::AddTracepointEventAndMapToThreads(uint64_t time,
   event.set_pid(process_id);
   event.set_cpu(cpu);
   event_map[time] = std::move(event);
-
-  std::map<uint64_t, orbit_client_protos::TracepointEventInfo>& event_map_all_threads =
-      tracepoint_events_[SamplingProfiler::kAllThreadsFakeTid];
-  orbit_client_protos::TracepointEventInfo event_all_threads;
-  event_all_threads.set_time(time);
-  event_all_threads.set_tracepoint_info_key(tracepoint_hash);
-  event_all_threads.set_tid(thread_id);
-  event_all_threads.set_pid(process_id);
-  event_all_threads.set_cpu(cpu);
-  event_map_all_threads[time] = std::move(event_all_threads);
-
 }
 
 [[nodiscard]] const std::map<uint64_t, orbit_client_protos::TracepointEventInfo>&
@@ -51,4 +47,18 @@ TracepointEventBuffer::GetTracepointsOfThread(int32_t thread_id) const {
   return it->second;
 }
 
-Mutex& TracepointEventBuffer::mutex() { return mutex_; }
+void TracepointEventBuffer::ForEachTracepointEventPerThread(
+    int32_t thread_id,
+    const std::function<void(const std::map<uint64_t, orbit_client_protos::TracepointEventInfo>&)>&
+        action) const {
+  ScopeLock lock(mutex_);
+  if (thread_id == SamplingProfiler::kAllThreadsFakeTid) {
+    for (const auto& it : tracepoint_events_) {
+      if (it.first != kAllTracepointsNotInTargetProcessFakeTid) {
+        action(it.second);
+      }
+    }
+    return;
+  }
+  action(GetTracepointsOfThread(thread_id));
+}

--- a/OrbitCore/TracepointEventBuffer.cpp
+++ b/OrbitCore/TracepointEventBuffer.cpp
@@ -14,8 +14,7 @@ void TracepointEventBuffer::AddTracepointEventAndMapToThreads(uint64_t time,
   ScopeLock lock(mutex_);
   if (!is_same_pid_as_target) {
     std::map<uint64_t, orbit_client_protos::TracepointEventInfo>&
-        event_map_tracepoints_not_in_target_process =
-            tracepoint_events_[kAllTracepointsNotInTargetProcessFakeTid];
+        event_map_tracepoints_not_in_target_process = tracepoint_events_[kNotTargetProcessThreadId];
     orbit_client_protos::TracepointEventInfo event;
     event.set_time(time);
     event.set_tracepoint_info_key(tracepoint_hash);
@@ -63,7 +62,7 @@ void TracepointEventBuffer::ForEachTracepointEventOfThread(
   ScopeLock lock(mutex_);
   if (thread_id == SamplingProfiler::kAllThreadsFakeTid) {
     for (const auto& entry : tracepoint_events_) {
-      if (entry.first != kAllTracepointsNotInTargetProcessFakeTid) {
+      if (entry.first != kNotTargetProcessThreadId) {
         ForEachTracepointEventOfThreadInTimeRange(min_tick, max_tick, entry.second, action);
       }
     }

--- a/OrbitCore/TracepointEventBuffer.cpp
+++ b/OrbitCore/TracepointEventBuffer.cpp
@@ -56,6 +56,7 @@ static void ForEachTracepointEventInEventMapInTimeRange(
     action(time_to_tracepoint_event->second);
   }
 }
+
 void TracepointEventBuffer::ForEachTracepointEventOfThreadInTimeRange(
     int32_t thread_id, uint64_t min_tick, uint64_t max_tick,
     const std::function<void(const orbit_client_protos::TracepointEventInfo&)>& action) const {

--- a/OrbitCore/TracepointEventBuffer.h
+++ b/OrbitCore/TracepointEventBuffer.h
@@ -24,6 +24,11 @@ class TracepointEventBuffer {
   [[nodiscard]] const std::map<uint64_t, orbit_client_protos::TracepointEventInfo>&
   GetTracepointsOfThread(int32_t thread_id) const;
 
+  void ForEachTracepointEventPerThread(
+      int32_t thread_id,
+      const std::function<
+          void(const std::map<uint64_t, orbit_client_protos::TracepointEventInfo>&)>& action) const;
+
   void ForEachTracepointEvent(
       const std::function<void(const orbit_client_protos::TracepointEventInfo&)>& action) const {
     ScopeLock lock(mutex_);
@@ -34,9 +39,8 @@ class TracepointEventBuffer {
     }
   }
 
-  Mutex& mutex();
-
  private:
+  int32_t kAllTracepointsNotInTargetProcessFakeTid = -1;
 
   mutable Mutex mutex_;
   std::map<int32_t, std::map<uint64_t, orbit_client_protos::TracepointEventInfo> >

--- a/OrbitCore/TracepointEventBuffer.h
+++ b/OrbitCore/TracepointEventBuffer.h
@@ -16,7 +16,6 @@
 
 class TracepointEventBuffer {
  public:
-
   void AddTracepointEventAndMapToThreads(uint64_t time, uint64_t tracepoint_hash,
                                          int32_t process_id, int32_t thread_id, int32_t cpu,
                                          bool is_same_pid_as_target);
@@ -24,10 +23,14 @@ class TracepointEventBuffer {
   [[nodiscard]] const std::map<uint64_t, orbit_client_protos::TracepointEventInfo>&
   GetTracepointsOfThread(int32_t thread_id) const;
 
-  void ForEachTracepointEventPerThread(
-      int32_t thread_id,
-      const std::function<
-          void(const std::map<uint64_t, orbit_client_protos::TracepointEventInfo>&)>& action) const;
+  void ForEachTracepointEventOfThread(
+      int32_t thread_id, uint64_t min_tick, uint64_t max_tick,
+      const std::function<void(const orbit_client_protos::TracepointEventInfo&)>& action) const;
+
+  void ForEachTracepointEventOfThreadInTimeRange(
+      uint64_t min_tick, uint64_t max_tick,
+      const std::map<uint64_t, orbit_client_protos::TracepointEventInfo>& time_to_tracepoint_events,
+      const std::function<void(const orbit_client_protos::TracepointEventInfo&)>& action) const;
 
   void ForEachTracepointEvent(
       const std::function<void(const orbit_client_protos::TracepointEventInfo&)>& action) const {

--- a/OrbitCore/TracepointEventBuffer.h
+++ b/OrbitCore/TracepointEventBuffer.h
@@ -43,7 +43,7 @@ class TracepointEventBuffer {
   }
 
  private:
-  int32_t kAllTracepointsNotInTargetProcessFakeTid = -1;
+  int32_t kNotTargetProcessThreadId = -2;
 
   mutable Mutex mutex_;
   std::map<int32_t, std::map<uint64_t, orbit_client_protos::TracepointEventInfo> >

--- a/OrbitCore/TracepointEventBuffer.h
+++ b/OrbitCore/TracepointEventBuffer.h
@@ -23,13 +23,8 @@ class TracepointEventBuffer {
   [[nodiscard]] const std::map<uint64_t, orbit_client_protos::TracepointEventInfo>&
   GetTracepointsOfThread(int32_t thread_id) const;
 
-  void ForEachTracepointEventOfThread(
-      int32_t thread_id, uint64_t min_tick, uint64_t max_tick,
-      const std::function<void(const orbit_client_protos::TracepointEventInfo&)>& action) const;
-
   void ForEachTracepointEventOfThreadInTimeRange(
-      uint64_t min_tick, uint64_t max_tick,
-      const std::map<uint64_t, orbit_client_protos::TracepointEventInfo>& time_to_tracepoint_events,
+      int32_t thread_id, uint64_t min_tick, uint64_t max_tick,
       const std::function<void(const orbit_client_protos::TracepointEventInfo&)>& action) const;
 
   void ForEachTracepointEvent(

--- a/OrbitCore/TracepointEventBufferTest.cpp
+++ b/OrbitCore/TracepointEventBufferTest.cpp
@@ -23,11 +23,4 @@ TEST(TracepointEventBuffer, AddAndGetTracepointEvents) {
   ASSERT_TRUE(it->second.time() == 0 && it->second.tracepoint_info_key() == 1 &&
               it->second.pid() == 2 && it->second.cpu() == 3);
 
-  const std::map<uint64_t, orbit_client_protos::TracepointEventInfo>& tracepoints_all_threads =
-      tracepoint_event_buffer.GetTracepointsOfThread(SamplingProfiler::kAllThreadsFakeTid);
-
-  it = tracepoints_all_threads.end();
-  --it;
-  ASSERT_TRUE(it->first == 2 && it->second.time() == 2 && it->second.tracepoint_info_key() == 3 &&
-              it->second.pid() == 2 && it->second.cpu() == 1);
 }

--- a/OrbitGl/TracepointTrack.cpp
+++ b/OrbitGl/TracepointTrack.cpp
@@ -61,9 +61,7 @@ void TracepointTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
   float z = GlCanvas::kZValueEvent;
   float track_height = layout.GetEventTrackHeight();
   const bool picking = picking_mode != PickingMode::kNone;
-
-  ScopeLock lock(GOrbitApp->GetCaptureData().GetTracepointEventBufferMutex());
-
+  
   const std::map<uint64_t, orbit_client_protos::TracepointEventInfo>& tracepoints =
       GOrbitApp->GetCaptureData().GetTracepointsOfThread(thread_id_);
 

--- a/OrbitGl/TracepointTrack.cpp
+++ b/OrbitGl/TracepointTrack.cpp
@@ -61,7 +61,7 @@ void TracepointTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
   float z = GlCanvas::kZValueEvent;
   float track_height = layout.GetEventTrackHeight();
   const bool picking = picking_mode != PickingMode::kNone;
-  
+
   const Color kWhite(255, 255, 255, 255);
 
   const Color kWhiteTransparent(255, 255, 255, 190);
@@ -69,7 +69,7 @@ void TracepointTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
   const Color kGreenSelection(0, 255, 0, 255);
 
   if (!picking) {
-    GOrbitApp->GetCaptureData().ForEachTracepointEventOfThread(
+    GOrbitApp->GetCaptureData().ForEachTracepointEventOfThreadInTimeRange(
         thread_id_, min_tick, max_tick,
         [&](const orbit_client_protos::TracepointEventInfo& tracepoint) {
           uint64_t time = tracepoint.time();
@@ -85,7 +85,7 @@ void TracepointTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
     constexpr float kPickingBoxWidth = 9.0f;
     constexpr float kPickingBoxOffset = kPickingBoxWidth / 2.0f;
 
-    GOrbitApp->GetCaptureData().ForEachTracepointEventOfThread(
+    GOrbitApp->GetCaptureData().ForEachTracepointEventOfThreadInTimeRange(
         thread_id_, min_tick, max_tick,
         [&](const orbit_client_protos::TracepointEventInfo& tracepoint) {
           uint64_t time = tracepoint.time();

--- a/OrbitGl/TracepointTrack.cpp
+++ b/OrbitGl/TracepointTrack.cpp
@@ -62,9 +62,6 @@ void TracepointTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
   float track_height = layout.GetEventTrackHeight();
   const bool picking = picking_mode != PickingMode::kNone;
   
-  const std::map<uint64_t, orbit_client_protos::TracepointEventInfo>& tracepoints =
-      GOrbitApp->GetCaptureData().GetTracepointsOfThread(thread_id_);
-
   const Color kWhite(255, 255, 255, 255);
 
   const Color kWhiteTransparent(255, 255, 255, 190);
@@ -72,31 +69,34 @@ void TracepointTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
   const Color kGreenSelection(0, 255, 0, 255);
 
   if (!picking) {
-    for (auto it = tracepoints.lower_bound(min_tick); it != tracepoints.upper_bound(max_tick);
-         ++it) {
-      uint64_t time = it->first;
-      float radius = track_height / 4;
+    GOrbitApp->GetCaptureData().ForEachTracepointEventOfThread(
+        thread_id_, min_tick, max_tick,
+        [&](const orbit_client_protos::TracepointEventInfo& tracepoint) {
+          uint64_t time = tracepoint.time();
+          float radius = track_height / 4;
+          Vec2 pos(time_graph_->GetWorldFromTick(time), pos_[1]);
+          batcher->AddVerticalLine(pos, -radius, z, kWhiteTransparent);
+          batcher->AddVerticalLine(Vec2(pos[0], pos[1] - track_height), radius, z,
+                                   kWhiteTransparent);
+          batcher->AddCircle(Vec2(pos[0], pos[1] - track_height / 2), radius, z, kWhiteTransparent);
+        });
 
-      Vec2 pos(time_graph_->GetWorldFromTick(time), pos_[1]);
-      batcher->AddVerticalLine(pos, -radius, z, kWhiteTransparent);
-      batcher->AddVerticalLine(Vec2(pos[0], pos[1] - track_height), radius, z, kWhiteTransparent);
-      batcher->AddCircle(Vec2(pos[0], pos[1] - track_height / 2), radius, z, kWhiteTransparent);
-    }
   } else {
     constexpr float kPickingBoxWidth = 9.0f;
     constexpr float kPickingBoxOffset = kPickingBoxWidth / 2.0f;
 
-    for (auto it = tracepoints.lower_bound(min_tick); it != tracepoints.upper_bound(max_tick);
-         ++it) {
-      uint64_t time = it->first;
-
-      Vec2 pos(time_graph_->GetWorldFromTick(time) - kPickingBoxOffset, pos_[1] - track_height + 1);
-      Vec2 size(kPickingBoxWidth, track_height);
-      auto user_data = std::make_unique<PickingUserData>(
-          nullptr, [&](PickingId id) -> std::string { return GetSampleTooltip(id); });
-      user_data->custom_data_ = &it->second;
-      batcher->AddShadedBox(pos, size, z, kGreenSelection, std::move(user_data));
-    }
+    GOrbitApp->GetCaptureData().ForEachTracepointEventOfThread(
+        thread_id_, min_tick, max_tick,
+        [&](const orbit_client_protos::TracepointEventInfo& tracepoint) {
+          uint64_t time = tracepoint.time();
+          Vec2 pos(time_graph_->GetWorldFromTick(time) - kPickingBoxOffset,
+                   pos_[1] - track_height + 1);
+          Vec2 size(kPickingBoxWidth, track_height);
+          auto user_data = std::make_unique<PickingUserData>(
+              nullptr, [&](PickingId id) -> std::string { return GetSampleTooltip(id); });
+          user_data->custom_data_ = &tracepoint;
+          batcher->AddShadedBox(pos, size, z, kGreenSelection, std::move(user_data));
+        });
   }
 }
 


### PR DESCRIPTION
Before, the events were stored in the corresponding entry 
for the thread on which they were activated and also in 
another entry corresponding to all the tracepoint events
triggered on all the threads in the target process. 

To store every tracepoint event in an entry for all the threads
was necessary for the thread track corresponding to 'all threads'.

However, this meant duplicating events so, a solution was to only
store the events in an entry corresponding to the thread on which
they were activated. When we are interested in all the tracepoints
triggered in the current process we iterate though the map that stores
the tracepoints by threads.

Also, we store in a separate map all the tracepoints that have
not been triggered in the target process. 
When the visualization for the system-wide tracepoints
will be enabled, we will just use all the entries in this map and in
the map  of the tracepoints linked to the threads.