### PR TITLE
[REBASE] Add Orbit.h to the installer ZIP

### DIFF
--- a/kokoro/builds/build.sh
+++ b/kokoro/builds/build.sh
@@ -202,7 +202,8 @@ if [ -n "$1" ]; then
     cp -v NOTICE Orbit/NOTICE
     test -f NOTICE.Chromium && cp -v NOTICE.Chromium Orbit/NOTICE.Chromium
     cp -v LICENSE Orbit/LICENSE.txt
-    cp -av ../../contrib/automation_tests Orbit
+    cp -av "${REPO_ROOT}/contrib/automation_tests" Orbit
+    cp -v "${REPO_ROOT}/Orbit.h" Orbit/
     zip -r Orbit.zip Orbit/
     rm -rf Orbit/
     popd > /dev/null


### PR DESCRIPTION
This commit changes the CI build script such that the manual
instrumenation API header (Orbit.h) is deployed next to the Orbit
executable.