### PR TITLE
Disable ImGui ini file writing 

### DIFF
--- a/OrbitGl/ImGuiOrbit.cpp
+++ b/OrbitGl/ImGuiOrbit.cpp
@@ -629,6 +629,7 @@ uint32_t LoadTextureFromFile(const char* file_name) {
 
 bool Orbit_ImGui_Init() {
   ImGuiIO& io = ImGui::GetIO();
+  io.IniFilename = nullptr;
 
   // http://doc.qt.io/qt-4.8/qt.html#Key-enum
 


### PR DESCRIPTION
This disables the ImGui configuration file which we don't use anyway.

I haven't found any official documentation about that because the ImGui author says [here](https://github.com/ocornut/imgui/issues/923) and [here](https://www.reddit.com/r/imgui/comments/4xstmx/no_imguiini/) that setting the filename to nullptr will disable the mechanism.