### PR TITLE
Scrollbar colors

### DIFF
--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -179,34 +179,32 @@ void Batcher::GetBoxGradientColors(const Color& color, std::array<Color, 4>* col
                                    ShadingDirection shading_direction) {
   const float kGradientCoeff = 0.94f;
   Vec3 dark = Vec3(color[0], color[1], color[2]) * kGradientCoeff;
+  Color dark_color = Color(static_cast<uint8_t>(dark[0]), static_cast<uint8_t>(dark[1]),
+                           static_cast<uint8_t>(dark[2]), color[3]);
 
   switch (shading_direction) {
     case ShadingDirection::kLeftToRight:
-      (*colors)[0] = Color(static_cast<uint8_t>(dark[0]), static_cast<uint8_t>(dark[1]),
-                           static_cast<uint8_t>(dark[2]), color[3]);
-      (*colors)[1] = (*colors)[0];
+      (*colors)[0] = dark_color;
+      (*colors)[1] = dark_color;
       (*colors)[2] = color;
       (*colors)[3] = color;
       break;
     case ShadingDirection::kRightToLeft:
-      (*colors)[2] = Color(static_cast<uint8_t>(dark[0]), static_cast<uint8_t>(dark[1]),
-                           static_cast<uint8_t>(dark[2]), color[3]);
-      (*colors)[3] = (*colors)[2];
       (*colors)[0] = color;
       (*colors)[1] = color;
+      (*colors)[2] = dark_color;
+      (*colors)[3] = dark_color;
       break;
     case ShadingDirection::kTopToBottom:
-      (*colors)[0] = Color(static_cast<uint8_t>(dark[0]), static_cast<uint8_t>(dark[1]),
-                           static_cast<uint8_t>(dark[2]), color[3]);
-      (*colors)[3] = (*colors)[0];
+      (*colors)[0] = dark_color;
       (*colors)[1] = color;
       (*colors)[2] = color;
+      (*colors)[3] = dark_color;
       break;
     case ShadingDirection::kBottomToTop:
-      (*colors)[1] = Color(static_cast<uint8_t>(dark[0]), static_cast<uint8_t>(dark[1]),
-                           static_cast<uint8_t>(dark[2]), color[3]);
-      (*colors)[2] = (*colors)[1];
       (*colors)[0] = color;
+      (*colors)[1] = dark_color;
+      (*colors)[2] = dark_color;
       (*colors)[3] = color;
       break;
   }

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -63,6 +63,8 @@ struct TriangleBuffer {
   BlockChain<Color, 3 * NUM_TRIANGLES_PER_BLOCK> picking_colors_;
 };
 
+enum class ShadingDirection { kLeftToRight, kRightToLeft, kTopToBottom, kBottomToTop };
+
 class Batcher {
  public:
   explicit Batcher(BatcherId batcher_id, PickingManager* picking_manager = nullptr)
@@ -93,8 +95,16 @@ class Batcher {
   void AddBox(const Box& box, const Color& color,
               std::unique_ptr<PickingUserData> user_data = nullptr);
   void AddBox(const Box& box, const Color& color, std::shared_ptr<Pickable> pickable);
+
+  void AddShadedBox(Vec2 pos, Vec2 size, float z, const Color& color);
   void AddShadedBox(Vec2 pos, Vec2 size, float z, const Color& color,
-                    std::unique_ptr<PickingUserData> user_data = nullptr);
+                    ShadingDirection shading_direction);
+  void AddShadedBox(Vec2 pos, Vec2 size, float z, const Color& color,
+                    std::unique_ptr<PickingUserData> user_data,
+                    ShadingDirection shading_direction = ShadingDirection::kLeftToRight);
+  void AddShadedBox(Vec2 pos, Vec2 size, float z, const Color& color,
+                    std::shared_ptr<Pickable> pickable,
+                    ShadingDirection shading_direction = ShadingDirection::kLeftToRight);
 
   void AddTriangle(const Triangle& triangle, const Color& color,
                    std::unique_ptr<PickingUserData> user_data = nullptr);
@@ -120,7 +130,8 @@ class Batcher {
   void DrawBoxBuffer(bool picking) const;
   void DrawTriangleBuffer(bool picking) const;
 
-  void GetBoxGradientColors(const Color& color, std::array<Color, 4>* colors);
+  void GetBoxGradientColors(const Color& color, std::array<Color, 4>* colors,
+                            ShadingDirection shading_direction = ShadingDirection::kLeftToRight);
 
   void AddLine(Vec2 from, Vec2 to, float z, const Color& color, const Color& picking_color,
                std::unique_ptr<PickingUserData> user_data = nullptr);

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -24,15 +24,17 @@ CaptureWindow::CaptureWindow(CaptureWindow::StatsMode stats_mode)
   world_top_left_y_ = 0;
   world_max_y_ = 0;
 
-  slider_ = std::make_shared<GlSlider>();
-  vertical_slider_ = std::make_shared<GlSlider>();
+  slider_ = std::make_shared<GlHorizontalSlider>();
+  vertical_slider_ = std::make_shared<GlVerticalSlider>();
 
   slider_->SetCanvas(this);
   slider_->SetDragCallback([&](float ratio) { this->OnDrag(ratio); });
 
   vertical_slider_->SetCanvas(this);
-  vertical_slider_->SetVertical();
   vertical_slider_->SetDragCallback([&](float ratio) { this->OnVerticalDrag(ratio); });
+
+  vertical_slider_->SetOrthogonalSliderSize(slider_->GetPixelHeight());
+  slider_->SetOrthogonalSliderSize(vertical_slider_->GetPixelHeight());
 
   GOrbitApp->RegisterCaptureWindow(this);
 }
@@ -534,6 +536,9 @@ void CaptureWindow::DrawScreenSpace() {
       vertical_slider_->Draw(this, picking_mode);
       right_margin += slider_width;
     }
+
+    vertical_slider_->SetOrthogonalSliderSize(slider_->GetPixelHeight());
+    slider_->SetOrthogonalSliderSize(vertical_slider_->GetPixelHeight());
   }
 
   // Right vertical margin.

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -27,11 +27,11 @@ CaptureWindow::CaptureWindow(CaptureWindow::StatsMode stats_mode)
   slider_ = std::make_shared<GlHorizontalSlider>();
   vertical_slider_ = std::make_shared<GlVerticalSlider>();
 
-  slider_->SetCanvas(this);
   slider_->SetDragCallback([&](float ratio) { this->OnDrag(ratio); });
+  slider_->SetCanvas(this);
 
-  vertical_slider_->SetCanvas(this);
   vertical_slider_->SetDragCallback([&](float ratio) { this->OnVerticalDrag(ratio); });
+  vertical_slider_->SetCanvas(this);
 
   vertical_slider_->SetOrthogonalSliderSize(slider_->GetPixelHeight());
   slider_->SetOrthogonalSliderSize(vertical_slider_->GetPixelHeight());

--- a/OrbitGl/GlSlider.cpp
+++ b/OrbitGl/GlSlider.cpp
@@ -10,26 +10,26 @@
 #include "PickingManager.h"
 
 GlSlider::GlSlider()
-    : m_Canvas(nullptr),
-      m_Ratio(0),
-      m_Length(0),
-      m_PickingRatio(0),
-      m_SelectedColor(75, 75, 75, 255),
-      m_SliderColor(68, 68, 68, 255),
-      m_BarColor(61, 61, 61, 255),
-      m_MinSliderPixelWidth(20),
-      m_PixelHeight(20),
+    : canvas_(nullptr),
+      ratio_(0),
+      length_(0),
+      picking_ratio_(0),
+      selected_color_(75, 75, 75, 255),
+      slider_color_(68, 68, 68, 255),
+      bar_color_(61, 61, 61, 255),
+      min_slider_pixel_width_(20),
+      pixel_height_(20),
       orthogonal_slider_size_(20) {}
 
-void GlSlider::SetSliderRatio(float a_Ratio)  // [0,1]
+void GlSlider::SetSliderRatio(float ratio)  // [0,1]
 {
-  m_Ratio = a_Ratio;
+  ratio_ = ratio;
 }
 
-void GlSlider::SetSliderWidthRatio(float a_WidthRatio)  // [0,1]
+void GlSlider::SetSliderWidthRatio(float width_radio)  // [0,1]
 {
-  float minWidth = m_MinSliderPixelWidth / static_cast<float>(m_Canvas->getWidth());
-  m_Length = std::max(a_WidthRatio, minWidth);
+  float minWidth = min_slider_pixel_width_ / static_cast<float>(canvas_->getWidth());
+  length_ = std::max(width_radio, minWidth);
 }
 
 Color GlSlider::GetLighterColor(const Color& color) {
@@ -46,7 +46,7 @@ Color GlSlider::GetDarkerColor(const Color& color) {
 
 void GlSlider::DrawBackground(GlCanvas* canvas, float x, float y, float width, float height) {
   Batcher* batcher = canvas->GetBatcher();
-  const Color dark_border_color = GetDarkerColor(m_BarColor);
+  const Color dark_border_color = GetDarkerColor(bar_color_);
 
   // Dark border
   {
@@ -56,16 +56,16 @@ void GlSlider::DrawBackground(GlCanvas* canvas, float x, float y, float width, f
   // Background itself
   {
     Box box(Vec2(x + 1, y + 1), Vec2(width - 2, height - 2), GlCanvas::kZValueSliderBg);
-    batcher->AddBox(box, m_BarColor, shared_from_this());
+    batcher->AddBox(box, bar_color_, shared_from_this());
   }
 }
 
 void GlSlider::DrawSlider(GlCanvas* canvas, float x, float y, float width, float height,
-                          bool picking, ShadingDirection shading_direction) {
+                          ShadingDirection shading_direction) {
   Batcher* batcher = canvas->GetBatcher();
   Color color =
-      canvas->GetPickingManager().IsThisElementPicked(this) ? m_SelectedColor : m_SliderColor;
-  const Color dark_border_color = GetDarkerColor(m_BarColor);
+      canvas->GetPickingManager().IsThisElementPicked(this) ? selected_color_ : slider_color_;
+  const Color dark_border_color = GetDarkerColor(bar_color_);
   const Color light_border_color = GetLighterColor(color);
 
   // Slider
@@ -87,103 +87,98 @@ void GlSlider::DrawSlider(GlCanvas* canvas, float x, float y, float width, float
 }
 
 void GlVerticalSlider::OnPick(int /*x*/, int y) {
-  float canvasHeight = m_Canvas->getHeight();
-  float sliderHeight = m_Length * canvasHeight;
+  float canvasHeight = canvas_->getHeight();
+  float sliderHeight = length_ * canvasHeight;
   float nonSliderHeight = canvasHeight - sliderHeight;
 
-  float sliderY = m_Ratio * nonSliderHeight;
-  m_PickingRatio = (static_cast<float>(y) - sliderY) / sliderHeight;
+  float sliderY = ratio_ * nonSliderHeight;
+  picking_ratio_ = (static_cast<float>(y) - sliderY) / sliderHeight;
 }
 
 void GlVerticalSlider::OnDrag(int /*x*/, int y) {
-  float canvasHeight = m_Canvas->getHeight();
-  float sliderHeight = m_Length * canvasHeight;
+  float canvasHeight = canvas_->getHeight();
+  float sliderHeight = length_ * canvasHeight;
   float nonSliderHeight = canvasHeight - sliderHeight;
 
-  float sliderTopHeight = m_PickingRatio * m_Length * canvasHeight;
+  float sliderTopHeight = picking_ratio_ * length_ * canvasHeight;
   float newY = static_cast<float>(y) - sliderTopHeight;
   float ratio = newY / nonSliderHeight;
 
-  m_Ratio = clamp(ratio, 0.f, 1.f);
+  ratio_ = clamp(ratio, 0.f, 1.f);
 
-  if (m_DragCallback) {
-    m_DragCallback(m_Ratio);
+  if (drag_callback_) {
+    drag_callback_(ratio_);
   }
 }
 
 void GlVerticalSlider::Draw(GlCanvas* canvas, PickingMode picking_mode) {
+  CHECK(canvas == canvas_);
+
   const bool picking = picking_mode != PickingMode::kNone;
-  m_Canvas = canvas;
-  Batcher* batcher = canvas->GetBatcher();
+  float x = canvas_->getWidth() - GetPixelHeight();
 
-  float x = m_Canvas->getWidth() - GetPixelHeight();
-
-  float canvasHeight = m_Canvas->getHeight() - GetOrthogonalSliderSize();
-  float sliderHeight = m_Length * canvasHeight;
+  float canvasHeight = canvas_->getHeight() - GetOrthogonalSliderSize();
+  float sliderHeight = length_ * canvasHeight;
   float nonSliderHeight = canvasHeight - sliderHeight;
 
-  const Color dark_border_color = GetDarkerColor(m_BarColor);
+  const Color dark_border_color = GetDarkerColor(bar_color_);
 
   // Background
   if (!picking) {
     DrawBackground(canvas, x, GetOrthogonalSliderSize(), GetPixelHeight(), canvasHeight);
   }
 
-  float start = (1.0f - m_Ratio) * nonSliderHeight + GetOrthogonalSliderSize();
+  float start = (1.0f - ratio_) * nonSliderHeight + GetOrthogonalSliderSize();
 
-  DrawSlider(canvas, x, start, GetPixelHeight(), sliderHeight, picking,
-             ShadingDirection::kRightToLeft);
+  DrawSlider(canvas, x, start, GetPixelHeight(), sliderHeight, ShadingDirection::kRightToLeft);
 }
 
 void GlHorizontalSlider::OnPick(int x, int /*y*/) {
-  float canvasWidth = m_Canvas->getWidth();
-  float sliderWidth = m_Length * canvasWidth;
+  float canvasWidth = canvas_->getWidth();
+  float sliderWidth = length_ * canvasWidth;
   float nonSliderWidth = canvasWidth - sliderWidth;
 
-  float sliderX = m_Ratio * nonSliderWidth;
-  m_PickingRatio = (static_cast<float>(x) - sliderX) / sliderWidth;
+  float sliderX = ratio_ * nonSliderWidth;
+  picking_ratio_ = (static_cast<float>(x) - sliderX) / sliderWidth;
 }
 
 void GlHorizontalSlider::OnDrag(int x, int /*y*/) {
-  float canvasWidth = m_Canvas->getWidth();
-  float sliderWidth = m_Length * canvasWidth;
+  float canvasWidth = canvas_->getWidth();
+  float sliderWidth = length_ * canvasWidth;
   float nonSliderWidth = canvasWidth - sliderWidth;
 
-  float sliderLeftWidth = m_PickingRatio * m_Length * canvasWidth;
+  float sliderLeftWidth = picking_ratio_ * length_ * canvasWidth;
   float newX = static_cast<float>(x) - sliderLeftWidth;
   float ratio = newX / nonSliderWidth;
 
-  m_Ratio = clamp(ratio, 0.f, 1.f);
+  ratio_ = clamp(ratio, 0.f, 1.f);
 
-  if (m_DragCallback) {
-    m_DragCallback(m_Ratio);
+  if (drag_callback_) {
+    drag_callback_(ratio_);
   }
 }
 
 void GlHorizontalSlider::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   const bool picking = picking_mode != PickingMode::kNone;
 
-  m_Canvas = canvas;
-  Batcher* batcher = canvas->GetBatcher();
-
+  canvas_ = canvas;
   static float y = 0;
 
-  float canvasWidth = m_Canvas->getWidth() - GetOrthogonalSliderSize();
-  float sliderWidth = m_Length * canvasWidth;
+  float canvasWidth = canvas_->getWidth() - GetOrthogonalSliderSize();
+  float sliderWidth = length_ * canvasWidth;
   float nonSliderWidth = canvasWidth - sliderWidth;
 
-  const Color dark_border_color = GetDarkerColor(m_BarColor);
+  const Color dark_border_color = GetDarkerColor(bar_color_);
 
   Color color =
-      canvas->GetPickingManager().IsThisElementPicked(this) ? m_SelectedColor : m_SliderColor;
+      canvas->GetPickingManager().IsThisElementPicked(this) ? selected_color_ : slider_color_;
   const Color light_border_color = GetLighterColor(color);
 
   if (!picking) {
     DrawBackground(canvas, 0, y, canvasWidth, GetPixelHeight());
   }
 
-  float start = m_Ratio * nonSliderWidth;
+  float start = ratio_ * nonSliderWidth;
 
-  DrawSlider(canvas, start, y, sliderWidth, GetPixelHeight(), picking,
-             ShadingDirection::kTopToBottom);
+  DrawSlider(canvas, start, y, sliderWidth, GetPixelHeight(), ShadingDirection::kTopToBottom);
 }

--- a/OrbitGl/GlSlider.h
+++ b/OrbitGl/GlSlider.h
@@ -18,41 +18,41 @@ class GlSlider : public Pickable, public std::enable_shared_from_this<GlSlider> 
   GlSlider();
   ~GlSlider(){};
 
-  bool Draggable() override { return true; }
-  void SetSliderRatio(float a_Start);       // [0,1]
-  void SetSliderWidthRatio(float a_Ratio);  // [0,1]
-  void SetCanvas(GlCanvas* a_Canvas) { m_Canvas = a_Canvas; }
-  Color GetBarColor() const { return m_SliderColor; }
-  void SetPixelHeight(float height) { m_PixelHeight = height; }
-  float GetPixelHeight() const { return m_PixelHeight; }
+  [[nodiscard]] bool Draggable() override { return true; }
+
+  void SetCanvas(GlCanvas* canvas) { canvas_ = canvas; }
+  void SetSliderRatio(float start);  // [0,1]
+
+  void SetSliderWidthRatio(float ratio);  // [0,1]
+  [[nodiscard]] Color GetBarColor() const { return slider_color_; }
+  void SetPixelHeight(float height) { pixel_height_ = height; }
+  [[nodiscard]] float GetPixelHeight() const { return pixel_height_; }
 
   void SetOrthogonalSliderSize(float size) { orthogonal_slider_size_ = size; }
-  float GetOrthogonalSliderSize() { return orthogonal_slider_size_; }
+  [[nodiscard]] float GetOrthogonalSliderSize() { return orthogonal_slider_size_; }
 
   typedef std::function<void(float)> DragCallback;
-  void SetDragCallback(DragCallback a_Callback) { m_DragCallback = a_Callback; }
+  void SetDragCallback(DragCallback callback) { drag_callback_ = callback; }
 
  protected:
   static Color GetLighterColor(const Color& color);
   static Color GetDarkerColor(const Color& color);
 
   void DrawBackground(GlCanvas* canvas, float x, float y, float width, float height);
-  void DrawSlider(GlCanvas* canvas, float x, float y, float width, float height, bool picking,
+  void DrawSlider(GlCanvas* canvas, float x, float y, float width, float height,
                   ShadingDirection shading_direction);
 
  protected:
-  TextBox m_Slider;
-  TextBox m_Bar;
-  GlCanvas* m_Canvas;
-  float m_Ratio;
-  float m_Length;
-  float m_PickingRatio;
-  DragCallback m_DragCallback;
-  Color m_SelectedColor;
-  Color m_SliderColor;
-  Color m_BarColor;
-  float m_MinSliderPixelWidth;
-  float m_PixelHeight;
+  GlCanvas* canvas_;
+  float ratio_;
+  float length_;
+  float picking_ratio_;
+  DragCallback drag_callback_;
+  Color selected_color_;
+  Color slider_color_;
+  Color bar_color_;
+  float min_slider_pixel_width_;
+  float pixel_height_;
   float orthogonal_slider_size_;
 };
 
@@ -63,7 +63,7 @@ class GlVerticalSlider : public GlSlider {
 
   void OnPick(int x, int y) override;
   void OnDrag(int x, int y) override;
-  void Draw(GlCanvas* a_Canvas, PickingMode picking_mode) override;
+  void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
 };
 
 class GlHorizontalSlider : public GlSlider {
@@ -73,5 +73,5 @@ class GlHorizontalSlider : public GlSlider {
 
   void OnPick(int x, int y) override;
   void OnDrag(int x, int y) override;
-  void Draw(GlCanvas* a_Canvas, PickingMode picking_mode) override;
+  void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
 };

--- a/OrbitGl/GlSlider.h
+++ b/OrbitGl/GlSlider.h
@@ -43,6 +43,8 @@ class GlSlider : public Pickable, public std::enable_shared_from_this<GlSlider> 
                   ShadingDirection shading_direction);
 
  protected:
+  static const float kGradientFactor;
+
   GlCanvas* canvas_;
   float ratio_;
   float length_;

--- a/OrbitGl/GlSlider.h
+++ b/OrbitGl/GlSlider.h
@@ -6,6 +6,7 @@
 
 #include <functional>
 
+#include "Batcher.h"
 #include "Params.h"
 #include "PickingManager.h"
 #include "TextBox.h"
@@ -17,9 +18,6 @@ class GlSlider : public Pickable, public std::enable_shared_from_this<GlSlider> 
   GlSlider();
   ~GlSlider(){};
 
-  void OnPick(int a_X, int a_Y) override;
-  void OnDrag(int a_X, int a_Y) override;
-  void Draw(GlCanvas* a_Canvas, PickingMode picking_mode) override;
   bool Draggable() override { return true; }
   void SetSliderRatio(float a_Start);       // [0,1]
   void SetSliderWidthRatio(float a_Ratio);  // [0,1]
@@ -27,18 +25,20 @@ class GlSlider : public Pickable, public std::enable_shared_from_this<GlSlider> 
   Color GetBarColor() const { return m_SliderColor; }
   void SetPixelHeight(float height) { m_PixelHeight = height; }
   float GetPixelHeight() const { return m_PixelHeight; }
-  void SetVertical() { m_Vertical = true; }
+
+  void SetOrthogonalSliderSize(float size) { orthogonal_slider_size_ = size; }
+  float GetOrthogonalSliderSize() { return orthogonal_slider_size_; }
 
   typedef std::function<void(float)> DragCallback;
   void SetDragCallback(DragCallback a_Callback) { m_DragCallback = a_Callback; }
 
  protected:
-  void DrawHorizontal(GlCanvas* a_Canvas, PickingMode picking_mode);
-  void DrawVertical(GlCanvas* a_Canvas, PickingMode picking_mode);
-  void OnDragHorizontal(int a_X, int a_Y);
-  void OnDragVertical(int a_X, int a_Y);
-  void OnPickHorizontal(int a_X, int a_Y);
-  void OnPickVertical(int a_X, int a_Y);
+  static Color GetLighterColor(const Color& color);
+  static Color GetDarkerColor(const Color& color);
+
+  void DrawBackground(GlCanvas* canvas, float x, float y, float width, float height);
+  void DrawSlider(GlCanvas* canvas, float x, float y, float width, float height, bool picking,
+                  ShadingDirection shading_direction);
 
  protected:
   TextBox m_Slider;
@@ -53,5 +53,25 @@ class GlSlider : public Pickable, public std::enable_shared_from_this<GlSlider> 
   Color m_BarColor;
   float m_MinSliderPixelWidth;
   float m_PixelHeight;
-  bool m_Vertical;
+  float orthogonal_slider_size_;
+};
+
+class GlVerticalSlider : public GlSlider {
+ public:
+  GlVerticalSlider() : GlSlider(){};
+  ~GlVerticalSlider(){};
+
+  void OnPick(int x, int y) override;
+  void OnDrag(int x, int y) override;
+  void Draw(GlCanvas* a_Canvas, PickingMode picking_mode) override;
+};
+
+class GlHorizontalSlider : public GlSlider {
+ public:
+  GlHorizontalSlider() : GlSlider(){};
+  ~GlHorizontalSlider(){};
+
+  void OnPick(int x, int y) override;
+  void OnDrag(int x, int y) override;
+  void Draw(GlCanvas* a_Canvas, PickingMode picking_mode) override;
 };


### PR DESCRIPTION
**Adjust the colors of scrollbars in the Capture Window**

The capture window scrollbars are drawn in OpenGl, and their Style
does not match the other scrollbars in Orbit. For users, it was not evident
which part of the scrollbar is the bar background and which part it the
slider, especially when the slider occupied about 50% of the bar.

Confusingly, our color choice (dark slider on lighter bar) was the opposite
of our QT bars (light, "paneled" slider on dark bar).

This PR fixes the look of the sliders to have them closer to the QT UI.

**Before**
![image](https://user-images.githubusercontent.com/63750742/94268514-92d8ef80-ff3d-11ea-9e56-62d88bc8af53.png)

**After**
![image](https://user-images.githubusercontent.com/63750742/94268060-e4cd4580-ff3c-11ea-8306-36dc5059ffe2.png)

(Vertical slider is drawn regularly, horizontal slider is the "on click" version
during drag)

To simplify the code and to prepare for a potential future extension of the
horizontal slider (e.g. showing frame tracks in the background), this PR 
splits the GlSlider into GlVerticalSlider and GlHorizontal slider.

First commit is the actual changes, second commit the cleanup and renaming
of existing variables.