### PR TITLE
Fix Function Offset in Serialization

### DIFF
--- a/OrbitClientModel/CaptureSerializer.cpp
+++ b/OrbitClientModel/CaptureSerializer.cpp
@@ -66,14 +66,16 @@ CaptureInfo GenerateCaptureInfo(
   for (const auto& address_info : capture_data.address_infos()) {
     orbit_client_protos::LinuxAddressInfo* added_address_info = capture_info.add_address_infos();
     added_address_info->CopyFrom(address_info.second);
+    const uint64_t absolute_address = added_address_info->absolute_address();
     const orbit_client_protos::FunctionInfo* function =
-        capture_data.FindFunctionByAddress(added_address_info->absolute_address(), false);
+        capture_data.FindFunctionByAddress(absolute_address, false);
     if (function == nullptr) {
       continue;
     }
     // Fix names/offset/module in address infos (some might only be in process):
     added_address_info->set_function_name(FunctionUtils::GetDisplayName(*function));
-    added_address_info->set_offset_in_function(FunctionUtils::Offset(*function));
+    const uint64_t offset = absolute_address - FunctionUtils::GetAbsoluteAddress(*function);
+    added_address_info->set_offset_in_function(offset);
     added_address_info->set_module_path(function->loaded_module_path());
   }
 


### PR DESCRIPTION
Sampling information just contains raw absolute addresses.
Mapping those to functions (via offsets) and function names
is done via two mechanisms:
1. If available, the loaded symbols on the UI are used.
2. Otherwise, it will be checked if there are address informations
   from unwinding (the service).
On serialization, we do not store the complete information of loaded symbols (yet?),
but only save the address information, received from the service.

As we do not want to modify this information (potentially during capturing,
as loading symbols is possible while capturing), we already patch the serialized
version of the address information. However, that was limited to
writing the function name. In particular the offset was missing.

This adds this information.

Bug: https://169391773
Test: Take a capture, load symbols, save the capture, restart orbit, load capture -> symbols are correct