### PR TITLE
Reorder some fields/variables in OrbitLinuxTracing

### DIFF
--- a/OrbitLinuxTracing/PerfEvent.cpp
+++ b/OrbitLinuxTracing/PerfEvent.cpp
@@ -36,12 +36,12 @@ void TaskNewtaskPerfEvent::Accept(PerfEventVisitor* visitor) { visitor->visit(th
 
 void TaskRenamePerfEvent::Accept(PerfEventVisitor* visitor) { visitor->visit(this); }
 
-void GenericTracepointPerfEvent::Accept(PerfEventVisitor* visitor) { visitor->visit(this); }
-
 void AmdgpuCsIoctlPerfEvent::Accept(PerfEventVisitor* visitor) { visitor->visit(this); }
 
 void AmdgpuSchedRunJobPerfEvent::Accept(PerfEventVisitor* visitor) { visitor->visit(this); }
 
 void DmaFenceSignaledPerfEvent::Accept(PerfEventVisitor* visitor) { visitor->visit(this); }
+
+void GenericTracepointPerfEvent::Accept(PerfEventVisitor* visitor) { visitor->visit(this); }
 
 }  // namespace LinuxTracing

--- a/OrbitLinuxTracing/PerfEventVisitor.h
+++ b/OrbitLinuxTracing/PerfEventVisitor.h
@@ -25,10 +25,10 @@ class PerfEventVisitor {
   virtual void visit(MapsPerfEvent*) {}
   virtual void visit(TaskNewtaskPerfEvent*) {}
   virtual void visit(TaskRenamePerfEvent*) {}
-  virtual void visit(GenericTracepointPerfEvent*) {}
   virtual void visit(AmdgpuCsIoctlPerfEvent*) {}
   virtual void visit(AmdgpuSchedRunJobPerfEvent*) {}
   virtual void visit(DmaFenceSignaledPerfEvent*) {}
+  virtual void visit(GenericTracepointPerfEvent*) {}
 };
 
 }  // namespace LinuxTracing

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -144,12 +144,12 @@ class TracerThread {
   absl::flat_hash_set<uint64_t> uprobes_ids_;
   absl::flat_hash_set<uint64_t> uretprobes_ids_;
   absl::flat_hash_set<uint64_t> stack_sampling_ids_;
+  absl::flat_hash_set<uint64_t> callchain_sampling_ids_;
   absl::flat_hash_set<uint64_t> task_newtask_ids_;
   absl::flat_hash_set<uint64_t> task_rename_ids_;
   absl::flat_hash_set<uint64_t> amdgpu_cs_ioctl_ids_;
   absl::flat_hash_set<uint64_t> amdgpu_sched_run_job_ids_;
   absl::flat_hash_set<uint64_t> dma_fence_signaled_ids_;
-  absl::flat_hash_set<uint64_t> callchain_sampling_ids_;
   absl::flat_hash_map<uint64_t, orbit_grpc_protos::TracepointInfo> ids_to_tracepoint_info_;
 
   std::atomic<bool> stop_deferred_thread_ = false;


### PR DESCRIPTION
Don't split specific tracepoints, bring stack and callchain sampling together.
This is just for consistency reasons.