### PR TITLE
Hide CaptureWindow's Capture-Stats behind a flag

### DIFF
--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -10,7 +10,8 @@
 
 using orbit_client_protos::TimerInfo;
 
-CaptureWindow::CaptureWindow() : GlCanvas() {
+CaptureWindow::CaptureWindow(CaptureWindow::StatsMode stats_mode)
+    : GlCanvas(), stats_enabled_(stats_mode == StatsMode::kEnabled) {
   GCurrentTimeGraph = &time_graph_;
   time_graph_.SetTextRenderer(&m_TextRenderer);
   time_graph_.SetCanvas(this);
@@ -406,7 +407,7 @@ void CaptureWindow::KeyPressed(unsigned int a_KeyCode, bool a_Ctrl, bool a_Shift
         m_DrawFilter = !m_DrawFilter;
         break;
       case 'I':
-        m_DrawStats = !m_DrawStats;
+        m_DrawStats = !m_DrawStats && stats_enabled_;
         break;
       case 'H':
         draw_help_ = !draw_help_;

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -11,7 +11,7 @@
 
 class CaptureWindow : public GlCanvas {
  public:
-  CaptureWindow();
+  explicit CaptureWindow(StatsMode stats_mode);
   ~CaptureWindow() override;
 
   void Initialize() override;
@@ -67,6 +67,7 @@ class CaptureWindow : public GlCanvas {
   bool m_DrawFilter;
   bool m_FirstHelpDraw;
   bool m_DrawStats;
+  bool stats_enabled_;
   std::shared_ptr<GlSlider> slider_;
   std::shared_ptr<GlSlider> vertical_slider_;
 

--- a/OrbitGl/GlPanel.cpp
+++ b/OrbitGl/GlPanel.cpp
@@ -6,17 +6,8 @@
 
 #include "CaptureWindow.h"
 
-std::unique_ptr<GlPanel> GlPanel::Create(Type a_Type) {
-  // Intended to be a factory method creating different types of
-  // GlPanels, but right now there's only CAPTURE
-  if (a_Type != CAPTURE) {
-    return nullptr;
-  }
-
-  std::unique_ptr<GlPanel> panel = std::make_unique<CaptureWindow>();
-  panel->m_Type = a_Type;
-
-  return panel;
+std::unique_ptr<GlPanel> GlPanel::Create(StatsMode stats_mode) {
+  return std::make_unique<CaptureWindow>(stats_mode);
 }
 
 GlPanel::GlPanel() {

--- a/OrbitGl/GlPanel.h
+++ b/OrbitGl/GlPanel.h
@@ -12,9 +12,10 @@ class GlPanel {
   GlPanel();
   virtual ~GlPanel() = default;
 
-  enum Type { CAPTURE };
-
-  static std::unique_ptr<GlPanel> Create(Type a_Type);
+  // Determines if the panel should show debug statistics when the user requests them.
+  // This is usually only enabled when Orbit runs in developer mode.
+  enum class StatsMode { kEnabled, kDisabled };
+  static std::unique_ptr<GlPanel> Create(StatsMode stats_mode);
 
   virtual void Initialize();
   virtual void Resize(int a_Width, int a_Height);
@@ -53,12 +54,10 @@ class GlPanel {
   bool GetIsMouseOver() const { return is_mouse_over_; }
   void SetIsMouseOver(bool value) { is_mouse_over_ = value; }
 
-  Type GetType() const { return m_Type; }
   virtual bool GetNeedsRedraw() const { return m_NeedsRedraw; }
   void NeedsRedraw() { m_NeedsRedraw = true; }
 
  protected:
-  Type m_Type;
   int m_WindowOffset[2];
   int m_MainWindowWidth;
   int m_MainWindowHeight;

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -238,6 +238,11 @@ static void DisplayErrorToUser(const QString& message) {
   QMessageBox::critical(nullptr, QApplication::applicationName(), message);
 }
 
+static bool DevModeEnabledViaEnvironmentVariable() {
+  const auto env = QProcessEnvironment::systemEnvironment();
+  return env.contains("ORBIT_DEV_MODE") || env.contains("ORBIT_DEVELOPER_MODE");
+}
+
 int main(int argc, char* argv[]) {
   // Will be filled by QApplication once instantiated.
   QString path_to_executable;
@@ -267,6 +272,10 @@ int main(int argc, char* argv[]) {
 
     QApplication app(argc, argv);
     QApplication::setApplicationName("orbitprofiler");
+
+    if (DevModeEnabledViaEnvironmentVariable()) {
+      absl::SetFlag(&FLAGS_devmode, true);
+    }
 
     // The application display name is automatically appended to all window titles when shown in the
     // title bar: <specific window title> - <application display name>

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -280,9 +280,13 @@ int main(int argc, char* argv[]) {
     // The application display name is automatically appended to all window titles when shown in the
     // title bar: <specific window title> - <application display name>
     const auto version_string = QString::fromStdString(OrbitCore::GetVersion());
-    QApplication::setApplicationDisplayName(
-        QString{"Orbit Profiler %1 [BETA]"}.arg(version_string));
+    auto display_name = QString{"Orbit Profiler %1 [BETA]"}.arg(version_string);
 
+    if (absl::GetFlag(FLAGS_devmode)) {
+      display_name.append(" [DEVELOPER MODE]");
+    }
+
+    QApplication::setApplicationDisplayName(display_name);
     QApplication::setApplicationVersion(version_string);
     path_to_executable = QCoreApplication::applicationFilePath();
 

--- a/OrbitQt/orbitglwidget.cpp
+++ b/OrbitQt/orbitglwidget.cpp
@@ -36,8 +36,8 @@ bool OrbitGLWidget::eventFilter(QObject* /*object*/, QEvent* event) {
   return false;
 }
 
-void OrbitGLWidget::Initialize(GlPanel::Type a_Type, OrbitMainWindow* a_MainWindow) {
-  m_OrbitPanel = GlPanel::Create(a_Type);
+void OrbitGLWidget::Initialize(GlPanel::StatsMode stats_mode, OrbitMainWindow* a_MainWindow) {
+  m_OrbitPanel = GlPanel::Create(stats_mode);
 
   if (a_MainWindow) {
     a_MainWindow->RegisterGlWidget(this);

--- a/OrbitQt/orbitglwidget.h
+++ b/OrbitQt/orbitglwidget.h
@@ -8,7 +8,7 @@
 #include <QOpenGLFunctions>
 #include <QOpenGLWidget>
 
-#include "../OrbitGl/GlPanel.h"
+#include "GlPanel.h"
 
 class QOpenGLDebugMessage;
 class QOpenGLDebugLogger;
@@ -18,7 +18,7 @@ class OrbitGLWidget : public QOpenGLWidget, protected QOpenGLFunctions {
 
  public:
   explicit OrbitGLWidget(QWidget* parent = nullptr);
-  void Initialize(GlPanel::Type a_Type, class OrbitMainWindow* a_MainWindow);
+  void Initialize(GlPanel::StatsMode stats_mode, class OrbitMainWindow* a_MainWindow);
   void initializeGL() override;
   void resizeGL(int w, int h) override;
   void paintGL() override;

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -202,7 +202,15 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App,
         return service_deploy_manager->CopyFileToLocal(source, destination);
       });
 
-  ui->CaptureGLWidget->Initialize(GlPanel::CAPTURE, this);
+  auto const capture_window_stats_mode = [&]() {
+    // The capture window will show statistics on request only when then developer mode.
+    if (absl::GetFlag(FLAGS_devmode)) {
+      return GlPanel::StatsMode::kEnabled;
+    } else {
+      return GlPanel::StatsMode::kDisabled;
+    }
+  }();
+  ui->CaptureGLWidget->Initialize(capture_window_stats_mode, this);
 
   ui->ModulesList->Initialize(data_view_factory->GetOrCreateDataView(DataViewType::kModules),
                               SelectionType::kExtended, FontType::kDefault);


### PR DESCRIPTION
Pressing `I` or `i` in the capture window brings up a bunch of debug windows
which are very useful when making changes to the capture window, but not at all
to the users.

We should avoid situations where the user accidentally presses `i` and these windows show up.

This PR is one quickly-made possible solution. Please push back if you prefer a different way.

In this PR I tied the availability of the `i`-hotkey to Orbit's developer mode. Meaning pressing `i` only
brings up the windows when Orbit was started in developer mode.

Starting Orbit in developer mode works with the `--devmode` command line option. When working
on the capture window always specfying `--devmode` might be annoying. For this situation I added a
environment variable (`ORBIT_DEV_MODE` or alternatively `ORBIT_DEVELOPER_MODE`) which can
be set globally or in the IDE and always enables the developer mode.