### PR TITLE
Add base lockfiles to build_and_upload_dependencies.sh

### DIFF
--- a/third_party/conan/configs/linux/profiles/clang7_debug
+++ b/third_party/conan/configs/linux/profiles/clang7_debug
@@ -15,7 +15,7 @@ compiler.fpo=False
 build_type=Debug
 [options]
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CC=$C_COMPILER
 CXX=$CXX_COMPILER

--- a/third_party/conan/configs/linux/profiles/clang7_release
+++ b/third_party/conan/configs/linux/profiles/clang7_release
@@ -15,7 +15,7 @@ compiler.fpo=False
 build_type=Release
 [options]
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CC=$C_COMPILER
 CXX=$CXX_COMPILER

--- a/third_party/conan/configs/linux/profiles/clang7_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/clang7_relwithdebinfo
@@ -15,7 +15,7 @@ compiler.fpo=False
 build_type=RelWithDebInfo
 [options]
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CC=$C_COMPILER
 CXX=$CXX_COMPILER

--- a/third_party/conan/configs/linux/profiles/clang8_debug
+++ b/third_party/conan/configs/linux/profiles/clang8_debug
@@ -15,7 +15,7 @@ compiler.fpo=False
 build_type=Debug
 [options]
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CC=$C_COMPILER
 CXX=$CXX_COMPILER

--- a/third_party/conan/configs/linux/profiles/clang8_release
+++ b/third_party/conan/configs/linux/profiles/clang8_release
@@ -15,7 +15,7 @@ compiler.fpo=False
 build_type=Release
 [options]
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CC=$C_COMPILER
 CXX=$CXX_COMPILER

--- a/third_party/conan/configs/linux/profiles/clang8_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/clang8_relwithdebinfo
@@ -15,7 +15,7 @@ compiler.fpo=False
 build_type=RelWithDebInfo
 [options]
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CC=$C_COMPILER
 CXX=$CXX_COMPILER

--- a/third_party/conan/configs/linux/profiles/clang9_debug
+++ b/third_party/conan/configs/linux/profiles/clang9_debug
@@ -15,7 +15,7 @@ compiler.fpo=False
 build_type=Debug
 [options]
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CC=$C_COMPILER
 CXX=$CXX_COMPILER

--- a/third_party/conan/configs/linux/profiles/clang9_release
+++ b/third_party/conan/configs/linux/profiles/clang9_release
@@ -15,7 +15,7 @@ compiler.fpo=False
 build_type=Release
 [options]
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CC=$C_COMPILER
 CXX=$CXX_COMPILER

--- a/third_party/conan/configs/linux/profiles/clang9_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/clang9_relwithdebinfo
@@ -15,7 +15,7 @@ compiler.fpo=False
 build_type=RelWithDebInfo
 [options]
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CC=$C_COMPILER
 CXX=$CXX_COMPILER

--- a/third_party/conan/configs/linux/profiles/gcc10_debug
+++ b/third_party/conan/configs/linux/profiles/gcc10_debug
@@ -15,7 +15,7 @@ compiler.fpo=False
 build_type=Debug
 [options]
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CC=$C_COMPILER
 CXX=$CXX_COMPILER

--- a/third_party/conan/configs/linux/profiles/gcc10_release
+++ b/third_party/conan/configs/linux/profiles/gcc10_release
@@ -15,7 +15,7 @@ compiler.fpo=False
 build_type=Release
 [options]
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CC=$C_COMPILER
 CXX=$CXX_COMPILER

--- a/third_party/conan/configs/linux/profiles/gcc10_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/gcc10_relwithdebinfo
@@ -15,7 +15,7 @@ compiler.fpo=False
 build_type=RelWithDebInfo
 [options]
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CC=$C_COMPILER
 CXX=$CXX_COMPILER

--- a/third_party/conan/configs/linux/profiles/gcc8_debug
+++ b/third_party/conan/configs/linux/profiles/gcc8_debug
@@ -15,7 +15,7 @@ compiler.fpo=False
 build_type=Debug
 [options]
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CC=$C_COMPILER
 CXX=$CXX_COMPILER

--- a/third_party/conan/configs/linux/profiles/gcc8_release
+++ b/third_party/conan/configs/linux/profiles/gcc8_release
@@ -15,7 +15,7 @@ compiler.fpo=False
 build_type=Release
 [options]
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CC=$C_COMPILER
 CXX=$CXX_COMPILER

--- a/third_party/conan/configs/linux/profiles/gcc8_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/gcc8_relwithdebinfo
@@ -15,7 +15,7 @@ compiler.fpo=False
 build_type=RelWithDebInfo
 [options]
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CC=$C_COMPILER
 CXX=$CXX_COMPILER

--- a/third_party/conan/configs/linux/profiles/gcc9_debug
+++ b/third_party/conan/configs/linux/profiles/gcc9_debug
@@ -15,7 +15,7 @@ compiler.fpo=False
 build_type=Debug
 [options]
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CC=$C_COMPILER
 CXX=$CXX_COMPILER

--- a/third_party/conan/configs/linux/profiles/gcc9_release
+++ b/third_party/conan/configs/linux/profiles/gcc9_release
@@ -15,7 +15,7 @@ compiler.fpo=False
 build_type=Release
 [options]
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CC=$C_COMPILER
 CXX=$CXX_COMPILER

--- a/third_party/conan/configs/linux/profiles/gcc9_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/gcc9_relwithdebinfo
@@ -15,7 +15,7 @@ compiler.fpo=False
 build_type=RelWithDebInfo
 [options]
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CC=$C_COMPILER
 CXX=$CXX_COMPILER

--- a/third_party/conan/configs/linux/profiles/ggp_debug
+++ b/third_party/conan/configs/linux/profiles/ggp_debug
@@ -13,7 +13,7 @@ build_type=Debug
 OrbitProfiler:with_gui=False
 OrbitProfiler:with_orbitgl=False
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 ggp_sdk/1.43.0.14282@orbitdeps/stable
 
 [env]

--- a/third_party/conan/configs/linux/profiles/ggp_release
+++ b/third_party/conan/configs/linux/profiles/ggp_release
@@ -13,7 +13,7 @@ build_type=Release
 OrbitProfiler:with_gui=False
 OrbitProfiler:with_orbitgl=False
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 ggp_sdk/1.43.0.14282@orbitdeps/stable
 
 [env]

--- a/third_party/conan/configs/linux/profiles/ggp_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/ggp_relwithdebinfo
@@ -13,7 +13,7 @@ build_type=RelWithDebInfo
 OrbitProfiler:with_gui=False
 OrbitProfiler:with_orbitgl=False
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 ggp_sdk/1.43.0.14282@orbitdeps/stable
 
 [env]

--- a/third_party/conan/configs/linux/profiles/libfuzzer_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/libfuzzer_relwithdebinfo
@@ -21,7 +21,7 @@ OrbitProfiler:run_tests=False
 llvm_object:allow_undefined_symbols=True
 llvm_symbolize:allow_undefined_symbols=True
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CC=clang-9
 CXX=clang++-9

--- a/third_party/conan/configs/windows/profiles/ggp_debug
+++ b/third_party/conan/configs/windows/profiles/ggp_debug
@@ -16,7 +16,7 @@ build_type=Debug
 OrbitProfiler:with_gui=False
 OrbitProfiler:with_orbitgl=False
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 ggp_sdk/1.43.0.14282@orbitdeps/stable
 ninja/1.9.0@
 

--- a/third_party/conan/configs/windows/profiles/ggp_release
+++ b/third_party/conan/configs/windows/profiles/ggp_release
@@ -16,7 +16,7 @@ build_type=Release
 OrbitProfiler:with_gui=False
 OrbitProfiler:with_orbitgl=False
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 ggp_sdk/1.43.0.14282@orbitdeps/stable
 ninja/1.9.0@
 

--- a/third_party/conan/configs/windows/profiles/ggp_relwithdebinfo
+++ b/third_party/conan/configs/windows/profiles/ggp_relwithdebinfo
@@ -16,7 +16,7 @@ build_type=RelWithDebInfo
 OrbitProfiler:with_gui=False
 OrbitProfiler:with_orbitgl=False
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 ggp_sdk/1.43.0.14282@orbitdeps/stable
 ninja/1.9.0@
 

--- a/third_party/conan/configs/windows/profiles/msvc2017_debug
+++ b/third_party/conan/configs/windows/profiles/msvc2017_debug
@@ -10,7 +10,7 @@ build_type=Debug
 [options]
 OrbitProfiler:system_qt=False
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
 LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2017_debug_x64
+++ b/third_party/conan/configs/windows/profiles/msvc2017_debug_x64
@@ -10,7 +10,7 @@ build_type=Debug
 [options]
 OrbitProfiler:system_qt=False
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
 LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2017_debug_x86
+++ b/third_party/conan/configs/windows/profiles/msvc2017_debug_x86
@@ -12,7 +12,7 @@ OrbitProfiler:system_qt=False
 OrbitProfiler:with_gui=False
 OrbitProfiler:with_orbitgl=False
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
 LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2017_release
+++ b/third_party/conan/configs/windows/profiles/msvc2017_release
@@ -10,7 +10,7 @@ build_type=Release
 [options]
 OrbitProfiler:system_qt=False
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
 LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2017_release_x64
+++ b/third_party/conan/configs/windows/profiles/msvc2017_release_x64
@@ -10,7 +10,7 @@ build_type=Release
 [options]
 OrbitProfiler:system_qt=False
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
 LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2017_release_x86
+++ b/third_party/conan/configs/windows/profiles/msvc2017_release_x86
@@ -12,7 +12,7 @@ OrbitProfiler:system_qt=False
 OrbitProfiler:with_gui=False
 OrbitProfiler:with_orbitgl=False
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
 LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2017_relwithdebinfo
+++ b/third_party/conan/configs/windows/profiles/msvc2017_relwithdebinfo
@@ -10,7 +10,7 @@ build_type=RelWithDebInfo
 [options]
 OrbitProfiler:system_qt=False
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
 LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2017_relwithdebinfo_x64
+++ b/third_party/conan/configs/windows/profiles/msvc2017_relwithdebinfo_x64
@@ -10,7 +10,7 @@ build_type=RelWithDebInfo
 [options]
 OrbitProfiler:system_qt=False
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
 LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2017_relwithdebinfo_x86
+++ b/third_party/conan/configs/windows/profiles/msvc2017_relwithdebinfo_x86
@@ -12,7 +12,7 @@ OrbitProfiler:system_qt=False
 OrbitProfiler:with_gui=False
 OrbitProfiler:with_orbitgl=False
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
 LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2019_debug
+++ b/third_party/conan/configs/windows/profiles/msvc2019_debug
@@ -10,7 +10,7 @@ build_type=Debug
 [options]
 OrbitProfiler:system_qt=False
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
 LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2019_debug_x64
+++ b/third_party/conan/configs/windows/profiles/msvc2019_debug_x64
@@ -10,7 +10,7 @@ build_type=Debug
 [options]
 OrbitProfiler:system_qt=False
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
 LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2019_debug_x86
+++ b/third_party/conan/configs/windows/profiles/msvc2019_debug_x86
@@ -12,7 +12,7 @@ OrbitProfiler:system_qt=False
 OrbitProfiler:with_gui=False
 OrbitProfiler:with_orbitgl=False
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
 LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2019_release
+++ b/third_party/conan/configs/windows/profiles/msvc2019_release
@@ -10,7 +10,7 @@ build_type=Release
 [options]
 OrbitProfiler:system_qt=False
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
 LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2019_release_x64
+++ b/third_party/conan/configs/windows/profiles/msvc2019_release_x64
@@ -10,7 +10,7 @@ build_type=Release
 [options]
 OrbitProfiler:system_qt=False
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
 LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2019_release_x86
+++ b/third_party/conan/configs/windows/profiles/msvc2019_release_x86
@@ -12,7 +12,7 @@ OrbitProfiler:system_qt=False
 OrbitProfiler:with_gui=False
 OrbitProfiler:with_orbitgl=False
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
 LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2019_relwithdebinfo
+++ b/third_party/conan/configs/windows/profiles/msvc2019_relwithdebinfo
@@ -10,7 +10,7 @@ build_type=RelWithDebInfo
 [options]
 OrbitProfiler:system_qt=False
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
 LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2019_relwithdebinfo_x64
+++ b/third_party/conan/configs/windows/profiles/msvc2019_relwithdebinfo_x64
@@ -10,7 +10,7 @@ build_type=RelWithDebInfo
 [options]
 OrbitProfiler:system_qt=False
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
 LDFLAGS=$LINKER_FLAGS

--- a/third_party/conan/configs/windows/profiles/msvc2019_relwithdebinfo_x86
+++ b/third_party/conan/configs/windows/profiles/msvc2019_relwithdebinfo_x86
@@ -12,7 +12,7 @@ OrbitProfiler:system_qt=False
 OrbitProfiler:with_gui=False
 OrbitProfiler:with_orbitgl=False
 [build_requires]
-cmake_installer/3.16.3@conan/stable
+&: cmake_installer/3.16.3@conan/stable
 [env]
 CONAN_CMAKE_SYSTEM_VERSION=8.1
 LDFLAGS=$LINKER_FLAGS


### PR DESCRIPTION
This makes use of base lockfiles in our dependency build script.

Furthermore this fixes a regression in `build.*` which used to build dependencies when not available as binary prebuilts. This is not relevant for the team, but for external contributors using the public remotes which don't have all the prebuilts.