### PR TITLE
Introduce frame tracks to visualize frame markers

### DIFF
--- a/OrbitClientProtos/capture_data.proto
+++ b/OrbitClientProtos/capture_data.proto
@@ -99,6 +99,7 @@ message TimerInfo {
     kCoreActivity = 1;
     kIntrospection = 2;
     kGpuActivity = 3;
+    kFrame = 4;
   }
   Type type = 6;
 

--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -25,6 +25,7 @@ target_sources(
          DisassemblyReport.h
          EventTrack.h
          FramePointerValidatorClient.h
+         FrameTrack.h
          FunctionsDataView.h
          Geometry.h
          GlCanvas.h
@@ -75,6 +76,7 @@ target_sources(
           DisassemblyReport.cc
           EventTrack.cpp
           FramePointerValidatorClient.cpp
+          FrameTrack.cpp
           LiveFunctionsController.cpp
           FunctionsDataView.cpp
           GlCanvas.cpp

--- a/OrbitGl/FrameTrack.cpp
+++ b/OrbitGl/FrameTrack.cpp
@@ -1,0 +1,240 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "FrameTrack.h"
+
+#include "App.h"
+#include "OrbitClientData/FunctionUtils.h"
+#include "TimeGraph.h"
+#include "TimeGraphLayout.h"
+
+using orbit_client_protos::FunctionInfo;
+using orbit_client_protos::TimerInfo;
+
+namespace {
+constexpr const double kHeightCapAverageMultipleDouble = 6.0;
+constexpr const uint64_t kHeightCapAverageMultipleUint64 = 6;
+constexpr const float kBoxHeightMultiplier = 3.f;
+}  // namespace
+
+float FrameTrack::GetMaximumBoxHeight() const {
+  const bool is_collapsed = collapse_toggle_->IsCollapsed();
+  const float box_height_normalizer = is_collapsed ? maximum_box_ratio_ : 1.f;
+  if (maximum_box_ratio_ == 0.f) {
+    return 0.f;
+  } else {
+    return maximum_box_ratio_ * box_height_ / box_height_normalizer;
+  }
+}
+
+float FrameTrack::GetAverageBoxHeight() const {
+  const bool is_collapsed = collapse_toggle_->IsCollapsed();
+  const float box_height_normalizer = is_collapsed ? maximum_box_ratio_ : 1.f;
+  if (maximum_box_ratio_ == 0.f) {
+    return 0.f;
+  } else {
+    return box_height_ / box_height_normalizer;
+  }
+}
+
+FrameTrack::FrameTrack(TimeGraph* time_graph, const FunctionInfo& function)
+    : TimerTrack(time_graph), function_(function) {
+  // TODO(b/169554463): Support manual instrumentation.
+  std::string function_name = FunctionUtils::GetDisplayName(function_);
+  std::string name = absl::StrFormat("Frame track based on %s", function_name);
+  SetName(name);
+  SetLabel(name);
+
+  // Frame tracks are collapsed by default.
+  collapse_toggle_->SetState(TriangleToggle::State::kCollapsed,
+                             TriangleToggle::InitialStateUpdate::kReplaceInitialState);
+}
+
+float FrameTrack::GetHeaderHeight() const { return 0.f; }
+
+float FrameTrack::GetHeight() const {
+  TimeGraphLayout& layout = time_graph_->GetLayout();
+  return GetMaximumBoxHeight() + layout.GetTrackBottomMargin();
+}
+
+float FrameTrack::GetYFromDepth(uint32_t /*depth*/) const {
+  return pos_[1] - GetMaximumBoxHeight();
+}
+
+float FrameTrack::GetTextBoxHeight(const TimerInfo& timer_info) const {
+  uint64_t timer_duration_ns = timer_info.end() - timer_info.start();
+  if (stats_.average_time_ns() == 0) {
+    return 0.f;
+  }
+  double ratio =
+      static_cast<double>(timer_duration_ns) / static_cast<double>(stats_.average_time_ns());
+  ratio = std::min(ratio, kHeightCapAverageMultipleDouble);
+  return static_cast<float>(ratio) * GetAverageBoxHeight();
+}
+
+Color FrameTrack::GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
+                                bool /*is_selected*/) const {
+  Vec4 min_color(76.f, 175.f, 80.f, 255.f);
+  Vec4 max_color(63.f, 81.f, 181.f, 255.f);
+  Vec4 warn_color(244.f, 67.f, 54.f, 255.f);
+
+  Vec4 color;
+  uint64_t timer_duration_ns = timer_info.end() - timer_info.start();
+
+  if (timer_duration_ns >= kHeightCapAverageMultipleUint64 * stats_.average_time_ns()) {
+    color = warn_color;
+  } else {
+    uint64_t lower_bound = stats_.min_ns();
+    uint64_t upper_bound =
+        std::min(kHeightCapAverageMultipleUint64 * stats_.average_time_ns(), stats_.max_ns());
+    if (upper_bound == lower_bound) {
+      // This implies that min_ns == max_ns and thus all times are the same. We can just render
+      // everything using min_color.
+      color = min_color;
+    }
+    timer_duration_ns = std::min(timer_duration_ns, upper_bound);
+    float fraction = static_cast<float>(timer_duration_ns - lower_bound) /
+                     static_cast<float>(upper_bound - lower_bound);
+    color = fraction * max_color + (1.f - fraction) * min_color;
+  }
+
+  if (timer_info.user_data_key() % 2 == 0) {
+    color = 0.8f * color;
+  }
+  return Color(static_cast<uint8_t>(color[0]), static_cast<uint8_t>(color[1]),
+               static_cast<uint8_t>(color[2]), static_cast<uint8_t>(color[3]));
+}
+
+void FrameTrack::OnTimer(const TimerInfo& timer_info) {
+  uint64_t duration_ns = timer_info.end() - timer_info.start();
+  stats_.set_count(stats_.count() + 1);
+  stats_.set_total_time_ns(stats_.total_time_ns() + duration_ns);
+  stats_.set_average_time_ns(stats_.total_time_ns() / stats_.count());
+
+  if (duration_ns > stats_.max_ns()) {
+    stats_.set_max_ns(duration_ns);
+  }
+  if (stats_.min_ns() == 0 || duration_ns < stats_.min_ns()) {
+    stats_.set_min_ns(duration_ns);
+  }
+
+  double ratio = 0.0;
+  if (stats_.average_time_ns() != 0) {
+    ratio = static_cast<double>(duration_ns) / static_cast<double>(stats_.average_time_ns());
+  }
+
+  maximum_box_ratio_ = std::max(maximum_box_ratio_, static_cast<float>(ratio));
+  maximum_box_ratio_ =
+      std::min(maximum_box_ratio_, static_cast<float>(kHeightCapAverageMultipleDouble));
+
+  TimerTrack::OnTimer(timer_info);
+}
+
+void FrameTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_us, float min_x,
+                                  TextBox* text_box) {
+  TimeGraphLayout layout = time_graph_->GetLayout();
+  if (text_box->GetText().empty()) {
+    std::string time = GetPrettyTime(absl::Microseconds(elapsed_us));
+    text_box->SetElapsedTimeTextLength(time.length());
+
+    std::string text = absl::StrFormat("Frame #%u: %s", timer_info.user_data_key(), time.c_str());
+    text_box->SetText(text);
+  }
+
+  const Color kTextWhite(255, 255, 255, 255);
+  const Vec2& box_pos = text_box->GetPos();
+  const Vec2& box_size = text_box->GetSize();
+  float pos_x = std::max(box_pos[0], min_x);
+  float max_size = box_pos[0] + box_size[0] - pos_x;
+  text_renderer_->AddTextTrailingCharsPrioritized(
+      text_box->GetText().c_str(), pos_x, text_box->GetPos()[1] + layout.GetTextOffset(),
+      GlCanvas::kZValueText, kTextWhite, text_box->GetElapsedTimeTextLength(),
+      time_graph_->CalculateZoomedFontSize(), max_size);
+}
+
+std::string FrameTrack::GetTooltip() const {
+  std::string function_name = FunctionUtils::GetDisplayName(function_);
+  return absl::StrFormat(
+      "<b>Frame track</b><br/>"
+      "<i>Shows frame timings based on subsequent callst to %s. "
+      "<br/><br/>"
+      "<b>Coloring</b>: Colors are interpolated between green (minimum frame time) and blue "
+      "(maximum frame time). The height of frames that strongly exceed average time are capped at "
+      "%u times the average frame time for drawing purposes. These are drawn in red."
+      "<br/><br/>"
+      "<b>Note</b>: Timings are not the runtime of the function, but the difference "
+      "between start timestamps of subsequent calls."
+      "<br/><br/>"
+      "<b>Frame marker function:</b> %s<br/>"
+      "<b>Module:</b> %s<br/>"
+      "<b>Frame count:</b> %u<br/>"
+      "<b>Maximum frame time:</b> %s<br/>"
+      "<b>Minimum frame time:</b> %s<br/>"
+      "<b>Average frame time:</b> %s<br/>",
+      function_name, kHeightCapAverageMultipleUint64, function_name,
+      FunctionUtils::GetLoadedModuleName(function_), stats_.count(),
+      GetPrettyTime(absl::Nanoseconds(stats_.max_ns())),
+      GetPrettyTime(absl::Nanoseconds(stats_.min_ns())),
+      GetPrettyTime(absl::Nanoseconds(stats_.average_time_ns())));
+}
+
+std::string FrameTrack::GetBoxTooltip(PickingId id) const {
+  const TextBox* text_box = time_graph_->GetBatcher().GetTextBox(id);
+  if (!text_box) {
+    return "";
+  }
+  // TODO(b/169554463): Support manual instrumentation.
+  std::string function_name = FunctionUtils::GetDisplayName(function_);
+
+  return absl::StrFormat(
+      "<b>Frame time</b><br/>"
+      "<i>Frame time based on two subsequent calls to %s. Height and width of the box are "
+      "proportional to time where height is capped at %u times the average time. Timeslices with "
+      "capped height are shown in red.</i>"
+      "<br/><br/>"
+      "<b>Frame marker function:</b> %s<br/>"
+      "<b>Module:</b> %s<br/>"
+      "<b>Frame:</b> #%u<br/>"
+      "<b>Frame time:</b> %s",
+      function_name, kHeightCapAverageMultipleUint64, function_name,
+      FunctionUtils::GetLoadedModuleName(function_), text_box->GetTimerInfo().user_data_key(),
+      GetPrettyTime(
+          TicksToDuration(text_box->GetTimerInfo().start(), text_box->GetTimerInfo().end())));
+}
+
+void FrameTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
+  TimerTrack::Draw(canvas, picking_mode);
+
+  const Color kWhiteColor(255, 255, 255, 255);
+  const Color kBlackColor(0, 0, 0, 255);
+
+  Batcher* batcher = &time_graph_->GetBatcher();
+  float y = pos_[1] - GetMaximumBoxHeight() + GetAverageBoxHeight();
+  float x = pos_[0];
+  Vec2 from(x, y);
+  Vec2 to(x + size_[0], y);
+  float ui_z = GlCanvas::kZValueUi;
+
+  const TimeGraphLayout& layout = time_graph_->GetLayout();
+  std::string avg_time = GetPrettyTime(absl::Nanoseconds(stats_.average_time_ns()));
+  std::string label = absl::StrFormat("Avg: %s", avg_time);
+
+  int string_width = canvas->GetTextRenderer().GetStringWidth(label.c_str());
+  Vec2 white_text_box_size(static_cast<float>(string_width), layout.GetTextBoxHeight());
+  Vec2 white_text_box_position(pos_[0] + layout.GetRightMargin(),
+                               y - layout.GetTextBoxHeight() / 2.f);
+
+  batcher->AddLine(from, from + Vec2(layout.GetRightMargin() / 2.f, 0), ui_z, kWhiteColor);
+  batcher->AddLine(Vec2(white_text_box_position[0] + white_text_box_size[0], y), to, ui_z,
+                   kWhiteColor);
+
+  canvas->GetTextRenderer().AddText(label.c_str(), white_text_box_position[0],
+                                    white_text_box_position[1] + layout.GetTextOffset(),
+                                    GlCanvas::kZValueTextUi, kWhiteColor,
+                                    time_graph_->CalculateZoomedFontSize(), white_text_box_size[0]);
+}
+
+void FrameTrack::UpdateBoxHeight() {
+  box_height_ = kBoxHeightMultiplier * time_graph_->GetLayout().GetTextBoxHeight();
+}

--- a/OrbitGl/FrameTrack.h
+++ b/OrbitGl/FrameTrack.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_DELTA_TRACK_H_
+#define ORBIT_GL_DELTA_TRACK_H_
+
+#include "TimerTrack.h"
+
+class FrameTrack : public TimerTrack {
+ public:
+  explicit FrameTrack(TimeGraph* time_graph, const orbit_client_protos::FunctionInfo& function);
+  [[nodiscard]] Type GetType() const override { return kFrameTrack; }
+  [[nodiscard]] bool IsCollapsable() const override { return maximum_box_ratio_ > 0.f; }
+
+  [[nodiscard]] virtual float GetYFromDepth(uint32_t depth) const override;
+  void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
+
+  [[nodiscard]] float GetTextBoxHeight(
+      const orbit_client_protos::TimerInfo& timer_info) const override;
+  [[nodiscard]] float GetHeaderHeight() const override;
+
+  void SetTimesliceText(const orbit_client_protos::TimerInfo& timer, double elapsed_us, float min_x,
+                        TextBox* text_box) override;
+  [[nodiscard]] std::string GetTooltip() const override;
+  [[nodiscard]] std::string GetBoxTooltip(PickingId id) const override;
+
+  void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
+
+  void UpdateBoxHeight() override;
+
+ protected:
+  [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
+                                    bool is_selected) const override;
+  [[nodiscard]] float GetHeight() const override;
+
+ private:
+  [[nodiscard]] float GetMaximumBoxHeight() const;
+  [[nodiscard]] float GetAverageBoxHeight() const;
+
+  orbit_client_protos::FunctionInfo function_;
+  orbit_client_protos::FunctionStats stats_;
+
+  float maximum_box_ratio_ = 0.f;
+};
+
+#endif  // ORBIT_GL_THREAD_TRACK_H_

--- a/OrbitGl/LiveFunctionsController.h
+++ b/OrbitGl/LiveFunctionsController.h
@@ -39,6 +39,8 @@ class LiveFunctionsController {
   uint64_t GetStartTime(uint64_t index);
 
   void AddIterator(orbit_client_protos::FunctionInfo* function);
+  void AddFrameTrack(const orbit_client_protos::FunctionInfo& function);
+  void RemoveFrameTrack(const orbit_client_protos::FunctionInfo& function);
 
  private:
   void Move();

--- a/OrbitGl/LiveFunctionsDataView.h
+++ b/OrbitGl/LiveFunctionsDataView.h
@@ -34,6 +34,7 @@ class LiveFunctionsDataView : public DataView {
       const orbit_client_protos::FunctionInfo& function) const;
 
   std::vector<orbit_client_protos::FunctionInfo> functions_;
+  std::set<uint64_t> added_frame_tracks_;
 
   LiveFunctionsController* live_functions_;
 
@@ -58,6 +59,8 @@ class LiveFunctionsDataView : public DataView {
   static const std::string kMenuActionJumpToMax;
   static const std::string kMenuActionDisassembly;
   static const std::string kMenuActionIterate;
+  static const std::string kMenuActionFrameTrack;
+  static const std::string kMenuActionRemoveFrameTrack;
 };
 
 #endif  // ORBIT_GL_LIVE_FUNCTIONS_DATA_VIEW_H_

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -12,6 +12,7 @@
 #include "AsyncTrack.h"
 #include "Batcher.h"
 #include "BlockChain.h"
+#include "FrameTrack.h"
 #include "Geometry.h"
 #include "GpuTrack.h"
 #include "GraphTrack.h"
@@ -162,12 +163,16 @@ class TimeGraph {
   [[nodiscard]] uint64_t GetCaptureMax() const { return capture_max_timestamp_; }
   [[nodiscard]] uint64_t GetCurrentMouseTimeNs() const { return current_mouse_time_ns_; }
 
+  void RemoveFrameTrack(const orbit_client_protos::FunctionInfo& function);
+
  protected:
   std::shared_ptr<SchedulerTrack> GetOrCreateSchedulerTrack();
   std::shared_ptr<ThreadTrack> GetOrCreateThreadTrack(int32_t tid);
   std::shared_ptr<GpuTrack> GetOrCreateGpuTrack(uint64_t timeline_hash);
   GraphTrack* GetOrCreateGraphTrack(const std::string& name);
   AsyncTrack* GetOrCreateAsyncTrack(const std::string& name);
+  std::shared_ptr<FrameTrack> GetOrCreateFrameTrack(
+      const orbit_client_protos::FunctionInfo& function);
 
   void ProcessOrbitFunctionTimer(orbit_client_protos::FunctionInfo::OrbitType type,
                                  const orbit_client_protos::TimerInfo& timer_info);
@@ -224,6 +229,9 @@ class TimeGraph {
   std::map<std::string, std::shared_ptr<GraphTrack>> graph_tracks_;
   // Mapping from timeline hash to GPU tracks.
   std::unordered_map<uint64_t, std::shared_ptr<GpuTrack>> gpu_tracks_;
+  // Mapping from function address to frame tracks.
+  std::unordered_map<uint64_t, std::shared_ptr<FrameTrack>> frame_tracks_;
+
   std::vector<std::shared_ptr<Track>> sorted_tracks_;
   std::string thread_filter_;
 

--- a/OrbitGl/TimerTrack.cpp
+++ b/OrbitGl/TimerTrack.cpp
@@ -45,7 +45,7 @@ std::string TimerTrack::GetExtraInfo(const TimerInfo& timer_info) {
 
 float TimerTrack::GetYFromDepth(uint32_t depth) const {
   const TimeGraphLayout& layout = time_graph_->GetLayout();
-  float box_height = layout.GetTextBoxHeight();
+  float box_height = box_height_;
   if (collapse_toggle_->IsCollapsed() && depth_ > 0) {
     box_height /= static_cast<float>(depth_);
   }
@@ -55,6 +55,8 @@ float TimerTrack::GetYFromDepth(uint32_t depth) const {
 }
 
 void TimerTrack::UpdateBoxHeight() { box_height_ = time_graph_->GetLayout().GetTextBoxHeight(); }
+
+float TimerTrack::GetTextBoxHeight(const TimerInfo& /*timer_info*/) const { return box_height_; }
 
 void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
                                   PickingMode /*picking_mode*/) {
@@ -112,7 +114,7 @@ void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
         bool is_selected = &text_box == GOrbitApp->selected_text_box();
 
         Vec2 pos(world_timer_x, world_timer_y);
-        Vec2 size(world_timer_width, box_height_);
+        Vec2 size(world_timer_width, GetTextBoxHeight(timer_info));
         float z = GlCanvas::kZValueBox;
         Color color = GetTimerColor(timer_info, is_selected);
         text_box.SetPos(pos);

--- a/OrbitGl/TimerTrack.h
+++ b/OrbitGl/TimerTrack.h
@@ -62,6 +62,8 @@ class TimerTrack : public Track {
   [[nodiscard]] bool IsCollapsable() const override { return depth_ > 1; }
 
   virtual void UpdateBoxHeight();
+  [[nodiscard]] virtual float GetTextBoxHeight(
+      const orbit_client_protos::TimerInfo& /*timer_info*/) const;
   [[nodiscard]] virtual float GetYFromDepth(uint32_t depth) const;
 
   [[nodiscard]] virtual float GetHeaderHeight() const;

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -28,6 +28,7 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
     kTimerTrack,
     kThreadTrack,
     kEventTrack,
+    kFrameTrack,
     kGraphTrack,
     kGpuTrack,
     kSchedulerTrack,


### PR DESCRIPTION
Users can now choose functions to use as frame markers. A good
example for a frame marker is vkQueuePresent, but any function that
meaningfully represents a "frame" can be used. Choosing multiple frame
markers is possible and meaninful for games that have subsystems
running at different frequencies (e.g. a physics system running at 30Hz,
while rendering runs at 60Hz).

The following improvements are planned for later (not done in this PR):
- Frame tracks should be stored in presets and captures.
- Frame tracks should persist and be populated when starting a new capture.
- Frame tracks could be used to change track backgrounds to indicate
frame boundaries on any track.
- Manual instrumentation markers as frame markers should be supported.
- GPU events as frame markers should be supported.