### PR TITLE
Store ProcessData by Value (Not as Unique Pointer)

### DIFF
--- a/OrbitCaptureClient/CaptureClient.cpp
+++ b/OrbitCaptureClient/CaptureClient.cpp
@@ -50,7 +50,7 @@ ErrorMessageOr<void> CaptureClient::StartCapture(
 
   state_ = State::kStarting;
 
-  ProcessData process_copy = process.CreateCopy();
+  ProcessData process_copy = process;
 
   // TODO(168797897) Here a copy of the module_map is created. This module_map likely was downloaded
   // when the process was selected, which might be a while back. Between then and now the loaded

--- a/OrbitCaptureClient/CaptureClient.cpp
+++ b/OrbitCaptureClient/CaptureClient.cpp
@@ -50,7 +50,7 @@ ErrorMessageOr<void> CaptureClient::StartCapture(
 
   state_ = State::kStarting;
 
-  std::unique_ptr<ProcessData> process_copy = process.CreateCopy();
+  ProcessData process_copy = process.CreateCopy();
 
   // TODO(168797897) Here a copy of the module_map is created. This module_map likely was downloaded
   // when the process was selected, which might be a while back. Between then and now the loaded
@@ -68,7 +68,7 @@ ErrorMessageOr<void> CaptureClient::StartCapture(
   return outcome::success();
 }
 
-void CaptureClient::Capture(std::unique_ptr<ProcessData> process,
+void CaptureClient::Capture(ProcessData&& process,
                             absl::flat_hash_map<std::string, ModuleData*>&& module_map,
                             absl::flat_hash_map<uint64_t, FunctionInfo> selected_functions,
                             TracepointInfoSet selected_tracepoints) {
@@ -80,7 +80,7 @@ void CaptureClient::Capture(std::unique_ptr<ProcessData> process,
   CaptureRequest request;
   CaptureOptions* capture_options = request.mutable_capture_options();
   capture_options->set_trace_context_switches(true);
-  capture_options->set_pid(process->pid());
+  capture_options->set_pid(process.pid());
   uint16_t sampling_rate = absl::GetFlag(FLAGS_sampling_rate);
   if (sampling_rate == 0) {
     capture_options->set_unwinding_method(CaptureOptions::kUndefined);

--- a/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -25,8 +25,7 @@ using orbit_client_protos::TimerInfo;
 class MyCaptureListener : public CaptureListener {
  private:
   void OnCaptureStarted(
-      std::unique_ptr<ProcessData> /*process*/,
-      absl::flat_hash_map<std::string, ModuleData*>&& /*module_map*/,
+      ProcessData&& /*process*/, absl::flat_hash_map<std::string, ModuleData*>&& /*module_map*/,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> /*selected_functions*/,
       TracepointInfoSet /*selected_tracepoints*/) override {}
   void OnCaptureComplete() override {}

--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
@@ -54,8 +54,7 @@ class CaptureClient {
   }
 
  private:
-  void Capture(std::unique_ptr<ProcessData> process,
-               absl::flat_hash_map<std::string, ModuleData*>&& module_map,
+  void Capture(ProcessData&& process, absl::flat_hash_map<std::string, ModuleData*>&& module_map,
                absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
                TracepointInfoSet selected_tracepoints);
 

--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
@@ -19,8 +19,7 @@ class CaptureListener {
 
   // Called after capture started but before the first event arrived.
   virtual void OnCaptureStarted(
-      std::unique_ptr<ProcessData> process,
-      absl::flat_hash_map<std::string, ModuleData*>&& module_map,
+      ProcessData&& process, absl::flat_hash_map<std::string, ModuleData*>&& module_map,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints) = 0;
   // Called when capture is complete.

--- a/OrbitClientData/ProcessData.cpp
+++ b/OrbitClientData/ProcessData.cpp
@@ -65,30 +65,3 @@ void ProcessData::AddSymbols(ModuleData* module, const ModuleSymbols& module_sym
   uint64_t module_base_address = module_memory_map_.at(module->file_path()).start;
   module->AddSymbols(module_symbols, module_base_address);
 }
-
-ProcessData ProcessData::CreateCopy() const {
-  ProcessInfo info;
-  info.set_pid(pid());
-  info.set_name(name());
-  info.set_full_path(full_path());
-  info.set_command_line(command_line());
-  info.set_cpu_usage(cpu_usage());
-  info.set_is_64_bit(is_64_bit());
-  ProcessData process_copy(info);
-
-  for (const auto& [module_path, memory_space] : module_memory_map_) {
-    uint64_t start = memory_space.start;
-    uint64_t end = memory_space.end;
-    {
-      const auto [it, success] =
-          process_copy.module_memory_map_.try_emplace(module_path, MemorySpace{start, end});
-      CHECK(success);
-    }
-    {
-      const auto [it, success] = process_copy.start_addresses_.try_emplace(start, module_path);
-      CHECK(success);
-    }
-  }
-
-  return process_copy;
-}

--- a/OrbitClientData/ProcessDataTest.cpp
+++ b/OrbitClientData/ProcessDataTest.cpp
@@ -213,7 +213,7 @@ TEST(ProcessData, CreateCopy) {
 
   process.UpdateModuleInfos({module_info});
 
-  ProcessData process_copy = process.CreateCopy();
+  ProcessData process_copy = process;
 
   EXPECT_EQ(process_copy.name(), process_name);
   EXPECT_TRUE(process_copy.IsModuleLoaded(module_path));

--- a/OrbitClientData/include/OrbitClientData/ProcessData.h
+++ b/OrbitClientData/include/OrbitClientData/ProcessData.h
@@ -31,8 +31,8 @@ struct MemorySpace {
 class ProcessData final {
  public:
   ProcessData();
-  ProcessData(const ProcessData&) = delete;
-  ProcessData& operator=(const ProcessData&) = delete;
+  ProcessData(const ProcessData&) = default;
+  ProcessData& operator=(const ProcessData&) = default;
   ProcessData(ProcessData&&) = default;
   ProcessData& operator=(ProcessData&&) = default;
 
@@ -68,8 +68,6 @@ class ProcessData final {
   bool IsModuleLoaded(const std::string& module_path) const {
     return module_memory_map_.contains(module_path);
   }
-
-  ProcessData CreateCopy() const;
 
  private:
   orbit_grpc_protos::ProcessInfo process_info_;

--- a/OrbitClientData/include/OrbitClientData/ProcessData.h
+++ b/OrbitClientData/include/OrbitClientData/ProcessData.h
@@ -30,6 +30,7 @@ struct MemorySpace {
 // Contains current information about process
 class ProcessData final {
  public:
+  ProcessData();
   ProcessData(const ProcessData&) = delete;
   ProcessData& operator=(const ProcessData&) = delete;
   ProcessData(ProcessData&&) = default;
@@ -67,8 +68,8 @@ class ProcessData final {
   bool IsModuleLoaded(const std::string& module_path) const {
     return module_memory_map_.contains(module_path);
   }
-  static std::unique_ptr<ProcessData> Create(orbit_grpc_protos::ProcessInfo process_info);
-  std::unique_ptr<ProcessData> CreateCopy() const;
+
+  ProcessData CreateCopy() const;
 
  private:
   orbit_grpc_protos::ProcessInfo process_info_;

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -256,8 +256,7 @@ void ClientGgp::ProcessTimer(const TimerInfo& timer_info) { timer_infos_.push_ba
 
 // CaptureListener implementation
 void ClientGgp::OnCaptureStarted(
-    std::unique_ptr<ProcessData> process,
-    absl::flat_hash_map<std::string, ModuleData*>&& module_map,
+    ProcessData&& process, absl::flat_hash_map<std::string, ModuleData*>&& module_map,
     absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
     TracepointInfoSet selected_tracepoints) {
   capture_data_ = CaptureData(std::move(process), std::move(module_map),

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -30,7 +30,7 @@ class ClientGgp final : public CaptureListener {
 
   // CaptureListener implementation
   void OnCaptureStarted(
-      ProcessData process, absl::flat_hash_map<std::string, ModuleData*>&& module_map,
+      ProcessData&& process, absl::flat_hash_map<std::string, ModuleData*>&& module_map,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints) override;
   void OnCaptureComplete() override;
@@ -49,7 +49,7 @@ class ClientGgp final : public CaptureListener {
  private:
   ClientGgpOptions options_;
   std::shared_ptr<grpc::Channel> grpc_channel_;
-  std::unique_ptr<ProcessData> target_process_;
+  ProcessData target_process_;
   absl::flat_hash_set<std::unique_ptr<ModuleData>> modules_;
   absl::flat_hash_map<std::string, ModuleData*> module_map_;
   ModuleData* main_module_;
@@ -59,7 +59,7 @@ class ClientGgp final : public CaptureListener {
   CaptureData capture_data_;
   std::vector<orbit_client_protos::TimerInfo> timer_infos_;
 
-  ErrorMessageOr<std::unique_ptr<ProcessData>> GetOrbitProcessByPid(int32_t pid);
+  ErrorMessageOr<ProcessData> GetOrbitProcessByPid(int32_t pid);
   bool InitCapture();
   ErrorMessageOr<void> LoadModuleAndSymbols();
   std::string SelectedFunctionMatch(const orbit_client_protos::FunctionInfo& func);

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -30,8 +30,7 @@ class ClientGgp final : public CaptureListener {
 
   // CaptureListener implementation
   void OnCaptureStarted(
-      std::unique_ptr<ProcessData> process,
-      absl::flat_hash_map<std::string, ModuleData*>&& module_map,
+      ProcessData process, absl::flat_hash_map<std::string, ModuleData*>&& module_map,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints) override;
   void OnCaptureComplete() override;

--- a/OrbitClientModel/CaptureDeserializer.cpp
+++ b/OrbitClientModel/CaptureDeserializer.cpp
@@ -125,7 +125,8 @@ void LoadCaptureInfo(const CaptureInfo& capture_info, CaptureListener* capture_l
   ProcessInfo process_info;
   process_info.set_pid(capture_info.process_id());
   process_info.set_name(capture_info.process_name());
-  std::unique_ptr<ProcessData> process = ProcessData::Create(process_info);
+
+  ProcessData process(process_info);
   capture_listener->OnCaptureStarted(
       std::move(process), absl::flat_hash_map<std::string, ModuleData*>(),
       std::move(selected_functions), std::move(selected_tracepoints));

--- a/OrbitClientModel/CaptureDeserializerTest.cpp
+++ b/OrbitClientModel/CaptureDeserializerTest.cpp
@@ -41,8 +41,7 @@ class MockCaptureListener : public CaptureListener {
  public:
   MOCK_METHOD(
       void, OnCaptureStarted,
-      (std::unique_ptr<ProcessData> /*process*/,
-       (absl::flat_hash_map<std::string, ModuleData*> &&) /*module_map*/,
+      (ProcessData&& /*process*/, (absl::flat_hash_map<std::string, ModuleData*> &&) /*module_map*/,
        (absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>)/*selected_functions*/,
        TracepointInfoSet /*selected_tracepoints*/),
       (override));
@@ -163,13 +162,13 @@ TEST(CaptureDeserializer, LoadCaptureInfoOnCaptureStarted) {
   EXPECT_CALL(listener, OnCaptureStarted(_, _, _, _)).Times(0);
   EXPECT_CALL(listener, OnCaptureStarted(_, _, _, IsEmpty()))
       .Times(1)
-      .WillOnce([selected_function](std::unique_ptr<ProcessData> process, Unused,
+      .WillOnce([selected_function](ProcessData&& process, Unused,
                                     absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>
                                         actual_selected_functions,
                                     Unused) {
         ASSERT_NE(process, nullptr);
-        EXPECT_EQ(process->name(), "process");
-        EXPECT_EQ(process->pid(), 42);
+        EXPECT_EQ(process.name(), "process");
+        EXPECT_EQ(process.pid(), 42);
 
         ASSERT_EQ(actual_selected_functions.size(), 1);
         ASSERT_TRUE(actual_selected_functions.contains(selected_function->address()));

--- a/OrbitClientModel/CaptureDeserializerTest.cpp
+++ b/OrbitClientModel/CaptureDeserializerTest.cpp
@@ -166,7 +166,6 @@ TEST(CaptureDeserializer, LoadCaptureInfoOnCaptureStarted) {
                                     absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>
                                         actual_selected_functions,
                                     Unused) {
-        ASSERT_NE(process, nullptr);
         EXPECT_EQ(process.name(), "process");
         EXPECT_EQ(process.pid(), 42);
 

--- a/OrbitClientModel/CaptureSerializerTest.cpp
+++ b/OrbitClientModel/CaptureSerializerTest.cpp
@@ -69,7 +69,7 @@ TEST(CaptureSerializer, GenerateCaptureInfo) {
   ProcessInfo process_info;
   process_info.set_name(process_name);
   process_info.set_pid(process_id);
-  std::unique_ptr<ProcessData> process = ProcessData::Create(process_info);
+  ProcessData process(process_info);
 
   absl::flat_hash_map<std::string, ModuleData*> empty_module_map;
 

--- a/OrbitCore/CaptureData.cpp
+++ b/OrbitCore/CaptureData.cpp
@@ -109,7 +109,7 @@ const std::string& CaptureData::GetModulePathByAddress(uint64_t absolute_address
 
 const FunctionInfo* CaptureData::FindFunctionByAddress(uint64_t absolute_address,
                                                        bool is_exact) const {
-  const auto result = process_->FindModuleByAddress(absolute_address);
+  const auto result = process_.FindModuleByAddress(absolute_address);
   if (!result) return nullptr;
   const std::string& module_path = result.value().first;
   const uint64_t module_base_address = result.value().second;
@@ -121,19 +121,11 @@ const FunctionInfo* CaptureData::FindFunctionByAddress(uint64_t absolute_address
 }
 
 [[nodiscard]] ModuleData* CaptureData::FindModuleByAddress(uint64_t absolute_address) const {
-  const auto result = process_->FindModuleByAddress(absolute_address);
+  const auto result = process_.FindModuleByAddress(absolute_address);
   if (!result) return nullptr;
   return module_map_.at(result.value().first);
 }
 
-int32_t CaptureData::process_id() const {
-  // TODO(antonrohr) Maybe do a CHECK(process_ != nullptr) here instead of returning -1. Currently
-  // CaptureSerializerTest is the only scenario where this is actually needed.
-  return process_ != nullptr ? process_->pid() : -1;
-}
+int32_t CaptureData::process_id() const { return process_.pid(); }
 
-const std::string CaptureData::process_name() const {
-  // TODO(antonrohr) Maybe do a CHECK(process_ != nullptr) here instead of returning an empty
-  // string. Currently CaptureSerializerTest is the only scenario where this is actually needed.
-  return process_ != nullptr ? process_->name() : "";
-}
+std::string CaptureData::process_name() const { return process_.name(); }

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -21,8 +21,7 @@
 class CaptureData {
  public:
   explicit CaptureData(
-      std::unique_ptr<ProcessData> process,
-      absl::flat_hash_map<std::string, ModuleData*>&& module_map,
+      ProcessData&& process, absl::flat_hash_map<std::string, ModuleData*>&& module_map,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints)
       : process_(std::move(process)),
@@ -32,12 +31,11 @@ class CaptureData {
         callstack_data_(std::make_unique<CallstackData>()),
         selection_callstack_data_(std::make_unique<CallstackData>()),
         tracepoint_info_manager_(std::make_unique<TracepointInfoManager>()),
-        tracepoint_event_buffer_(std::make_unique<TracepointEventBuffer>()) {
-    CHECK(process_ != nullptr);
-  }
+        tracepoint_event_buffer_(std::make_unique<TracepointEventBuffer>()) {}
 
   explicit CaptureData()
-      : callstack_data_(std::make_unique<CallstackData>()),
+      : process_(),
+        callstack_data_(std::make_unique<CallstackData>()),
         selection_callstack_data_(std::make_unique<CallstackData>()),
         tracepoint_info_manager_(std::make_unique<TracepointInfoManager>()),
         tracepoint_event_buffer_(std::make_unique<TracepointEventBuffer>()){};
@@ -59,7 +57,7 @@ class CaptureData {
 
   [[nodiscard]] int32_t process_id() const;
 
-  [[nodiscard]] const std::string process_name() const;
+  [[nodiscard]] std::string process_name() const;
 
   [[nodiscard]] const std::chrono::system_clock::time_point& capture_start_time() const {
     return capture_start_time_;
@@ -165,7 +163,7 @@ class CaptureData {
     selection_callstack_data_ = std::move(selection_callstack_data);
   }
 
-  [[nodiscard]] const ProcessData* process() const { return process_.get(); }
+  [[nodiscard]] const ProcessData* process() const { return &process_; }
 
   [[nodiscard]] const SamplingProfiler& sampling_profiler() const { return sampling_profiler_; }
 
@@ -174,7 +172,7 @@ class CaptureData {
   }
 
  private:
-  std::unique_ptr<ProcessData> process_;
+  ProcessData process_;
   absl::flat_hash_map<std::string, ModuleData*> module_map_;
   absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions_;
 

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -114,7 +114,7 @@ OrbitApp::~OrbitApp() {
 #endif
 }
 
-void OrbitApp::OnCaptureStarted(std::unique_ptr<ProcessData> process,
+void OrbitApp::OnCaptureStarted(ProcessData&& process,
                                 absl::flat_hash_map<std::string, ModuleData*>&& module_map,
                                 absl::flat_hash_map<uint64_t, FunctionInfo> selected_functions,
                                 TracepointInfoSet selected_tracepoints) {

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -97,8 +97,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void Disassemble(int32_t pid, const orbit_client_protos::FunctionInfo& function);
 
   void OnCaptureStarted(
-      std::unique_ptr<ProcessData> process,
-      absl::flat_hash_map<std::string, ModuleData*>&& module_map,
+      ProcessData&& process, absl::flat_hash_map<std::string, ModuleData*>&& module_map,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints) override;
   void OnCaptureComplete() override;

--- a/OrbitGl/DataManager.h
+++ b/OrbitGl/DataManager.h
@@ -63,7 +63,7 @@ class DataManager final {
 
  private:
   const std::thread::id main_thread_id_;
-  absl::flat_hash_map<int32_t, std::unique_ptr<ProcessData>> process_map_;
+  absl::flat_hash_map<int32_t, ProcessData> process_map_;
   absl::flat_hash_map<std::string, std::unique_ptr<ModuleData>> module_map_;
   absl::flat_hash_set<uint64_t> selected_functions_;
   absl::flat_hash_set<uint64_t> visible_functions_;


### PR DESCRIPTION
ProcessData may be stored at two places, first in DataManager and
second in CaptureData. There is no need to store them as unique
pointers here. Moreover, the absense of a concrete process in
CaptureData already led to a crash.

This change ensures, that we always store the process by value,
which among others allow clear default values for empty captures.

Test: Compile