### PR TITLE
Fix nightly and release builds

### DIFF
--- a/kokoro/builds/build.sh
+++ b/kokoro/builds/build.sh
@@ -128,12 +128,12 @@ if [ -n "$1" ]; then
   conan lock create "${REPO_ROOT}/conanfile.py" --user=orbitdeps --channel=stable \
     --lockfile="${REPO_ROOT}/third_party/conan/lockfiles/base.lock" -u -pr ${CONAN_PROFILE} \
     -o crashdump_server="$CRASHDUMP_SERVER" $PACKAGING_OPTION \
-    --lockfile-out="${REPO_ROOT}/build/conan.lock" || exit $?
+    --lockfile-out="${REPO_ROOT}/build/conan.lock"
 
   conan install -if "${REPO_ROOT}/build/" \
           --build outdated \
           --lockfile="${REPO_ROOT}/build/conan.lock" \
-          "${REPO_ROOT}"
+          "${REPO_ROOT}" | sed 's/^crashdump_server=.*$/crashump_server=<<hidden>>/'
   conan build -bf "${REPO_ROOT}/build/" "${REPO_ROOT}"
   conan package -bf "${REPO_ROOT}/build/" "${REPO_ROOT}"
 


### PR DESCRIPTION
The new version of conan logs all options to the standard output, which
was not the case before. One of the options logged is `crashdump_server`
which is filled from a secret from Keystore even though it's not so
secret.

Kokoro has a script which aborts the build when something logs a
keystore-secret and that breaks the build.

This commit fixes that be adjusting conan's output with sed.

Test: I created a nightly build from my branch and it seems to work. The output now looks like so:

```
...
[options]
crashump_server=<<hidden>>
OrbitProfiler:system_qt=False
...
```