### PR TITLE
Move most feature flags to main.cpp

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -51,8 +51,7 @@
 
 ABSL_DECLARE_FLAG(bool, devmode);
 ABSL_DECLARE_FLAG(bool, local);
-ABSL_FLAG(bool, enable_tracepoint_feature, false,
-          "Enable the setting of the panel of kernel tracepoints");
+ABSL_DECLARE_FLAG(bool, enable_tracepoint_feature);
 
 using orbit_client_protos::CallstackEvent;
 using orbit_client_protos::FunctionInfo;

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -60,8 +60,6 @@
 #include "services.pb.h"
 #include "symbol.pb.h"
 
-ABSL_DECLARE_FLAG(bool, enable_tracepoint_feature);
-
 class Process;
 
 class OrbitApp final : public DataViewFactory, public CaptureListener {

--- a/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
+++ b/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
@@ -25,6 +25,10 @@ ABSL_FLAG(bool, devmode, false, "Enable developer mode in the client's UI");
 ABSL_FLAG(bool, local, false, "Connects to local instance of OrbitService");
 ABSL_FLAG(uint16_t, sampling_rate, 1000, "Frequency of callstack sampling in samples per second");
 ABSL_FLAG(bool, frame_pointer_unwinding, false, "Use frame pointers for unwinding");
+ABSL_FLAG(bool, enable_frame_pointer_validator, false, "Enable validation of frame pointers");
+ABSL_FLAG(bool, show_return_values, false, "Show return values on time slices");
+ABSL_FLAG(bool, enable_tracepoint_feature, false,
+          "Enable the setting of the panel of kernel tracepoints");
 
 DEFINE_PROTO_FUZZER(const orbit_client_protos::CaptureDeserializerFuzzerInfo& info) {
   std::string buffer{};

--- a/OrbitGl/DataManagerUpdateModuleInfosFuzzer.cpp
+++ b/OrbitGl/DataManagerUpdateModuleInfosFuzzer.cpp
@@ -20,6 +20,10 @@ ABSL_FLAG(bool, devmode, false, "Enable developer mode in the client's UI");
 ABSL_FLAG(bool, local, false, "Connects to local instance of OrbitService");
 ABSL_FLAG(uint16_t, sampling_rate, 1000, "Frequency of callstack sampling in samples per second");
 ABSL_FLAG(bool, frame_pointer_unwinding, false, "Use frame pointers for unwinding");
+ABSL_FLAG(bool, enable_frame_pointer_validator, false, "Enable validation of frame pointers");
+ABSL_FLAG(bool, show_return_values, false, "Show return values on time slices");
+ABSL_FLAG(bool, enable_tracepoint_feature, false,
+          "Enable the setting of the panel of kernel tracepoints");
 
 using orbit_grpc_protos::GetModuleListResponse;
 using orbit_grpc_protos::ModuleInfo;

--- a/OrbitGl/ModulesDataView.cpp
+++ b/OrbitGl/ModulesDataView.cpp
@@ -8,8 +8,7 @@
 #include "OrbitClientData/ProcessData.h"
 #include "absl/flags/flag.h"
 
-// TODO(kuebler): remove this once we have the validator complete
-ABSL_FLAG(bool, enable_frame_pointer_validator, false, "Enable validation of frame pointers");
+ABSL_DECLARE_FLAG(bool, enable_frame_pointer_validator);
 
 ModulesDataView::ModulesDataView() : DataView(DataViewType::kModules) {}
 

--- a/OrbitGl/TimerTrack.cpp
+++ b/OrbitGl/TimerTrack.cpp
@@ -18,8 +18,7 @@
 using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::TimerInfo;
 
-// TODO: Remove this flag once we have a way to toggle the display return values
-ABSL_FLAG(bool, show_return_values, false, "Show return values on time slices");
+ABSL_DECLARE_FLAG(bool, show_return_values);
 
 TimerTrack::TimerTrack(TimeGraph* time_graph) : Track(time_graph) {
   text_renderer_ = time_graph->GetTextRenderer();

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -59,6 +59,15 @@ ABSL_FLAG(uint16_t, sampling_rate, 1000, "Frequency of callstack sampling in sam
 // TODO(b/160549506): Remove this flag once it can be specified in the ui.
 ABSL_FLAG(bool, frame_pointer_unwinding, false, "Use frame pointers for unwinding");
 
+// TODO(kuebler): remove this once we have the validator complete
+ABSL_FLAG(bool, enable_frame_pointer_validator, false, "Enable validation of frame pointers");
+
+// TODO: Remove this flag once we have a way to toggle the display return values
+ABSL_FLAG(bool, show_return_values, false, "Show return values on time slices");
+
+ABSL_FLAG(bool, enable_tracepoint_feature, false,
+          "Enable the setting of the panel of kernel tracepoints");
+
 using ServiceDeployManager = OrbitQt::ServiceDeployManager;
 using DeploymentConfiguration = OrbitQt::DeploymentConfiguration;
 using OrbitStartupWindow = OrbitQt::OrbitStartupWindow;

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -40,6 +40,7 @@
 
 ABSL_DECLARE_FLAG(bool, enable_stale_features);
 ABSL_DECLARE_FLAG(bool, devmode);
+ABSL_DECLARE_FLAG(bool, enable_tracepoint_feature);
 
 using orbit_grpc_protos::CrashOrbitServiceRequest_CrashType;
 using orbit_grpc_protos::CrashOrbitServiceRequest_CrashType_CHECK_FALSE;


### PR DESCRIPTION
This way they are all in the same place, they are listed together with the
`-helpfull` flag, and we have consistency with the majority of the flags.