### PR TITLE
Store Selected Functions as Values

### DIFF
--- a/OrbitClientData/CMakeLists.txt
+++ b/OrbitClientData/CMakeLists.txt
@@ -13,7 +13,8 @@ target_include_directories(OrbitClientData PUBLIC
 target_include_directories(OrbitClientData PRIVATE 
         ${CMAKE_CURRENT_LIST_DIR})
 
-target_sources(OrbitClientData PUBLIC 
+target_sources(OrbitClientData PUBLIC
+        include/OrbitClientData/FunctionInfoSet.h
         include/OrbitClientData/FunctionUtils.h
         include/OrbitClientData/ModuleData.h
         include/OrbitClientData/ProcessData.h)
@@ -33,7 +34,8 @@ target_link_libraries(OrbitClientData PUBLIC
 add_executable(OrbitClientDataTests)
 target_compile_options(OrbitClientDataTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
-target_sources(OrbitClientDataTests PRIVATE 
+target_sources(OrbitClientDataTests PRIVATE
+        FunctionInfoSetTest.cpp
         ModuleDataTest.cpp
         ProcessDataTest.cpp)
 

--- a/OrbitClientData/FunctionInfoSetTest.cpp
+++ b/OrbitClientData/FunctionInfoSetTest.cpp
@@ -1,0 +1,274 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "OrbitClientData/FunctionInfoSet.h"
+#include "capture_data.pb.h"
+
+using orbit_client_protos::FunctionInfo;
+
+TEST(FunctionInfoSet, EqualFunctions) {
+  FunctionInfo left;
+  left.set_name("foo");
+  left.set_pretty_name("void foo()");
+  left.set_loaded_module_path("/path/to/module");
+  left.set_module_base_address(42);
+  left.set_address(12);
+  left.set_load_bias(4);
+  left.set_size(16);
+  left.set_file("file.cpp");
+  left.set_line(13);
+
+  FunctionInfo right;
+  right.CopyFrom(left);
+
+  internal::EqualFunctionInfo eq;
+  EXPECT_TRUE(eq(left, right));
+  internal::HashFunctionInfo hash;
+  EXPECT_EQ(hash(left), hash(right));
+}
+
+TEST(FunctionInfoSet, DifferentName) {
+  FunctionInfo left;
+  left.set_name("foo");
+  left.set_pretty_name("void foo()");
+  left.set_loaded_module_path("/path/to/module");
+  left.set_module_base_address(42);
+  left.set_address(12);
+  left.set_load_bias(4);
+  left.set_size(16);
+  left.set_file("file.cpp");
+  left.set_line(13);
+
+  FunctionInfo right;
+  right.CopyFrom(left);
+  right.set_name("bar");
+
+  internal::EqualFunctionInfo eq;
+  EXPECT_FALSE(eq(left, right));
+  internal::HashFunctionInfo hash;
+  EXPECT_NE(hash(left), hash(right));
+}
+TEST(FunctionInfoSet, DifferentPrettyName) {
+  FunctionInfo left;
+  left.set_name("foo");
+  left.set_pretty_name("void foo()");
+  left.set_loaded_module_path("/path/to/module");
+  left.set_module_base_address(42);
+  left.set_address(12);
+  left.set_load_bias(4);
+  left.set_size(16);
+  left.set_file("file.cpp");
+  left.set_line(13);
+
+  FunctionInfo right;
+  right.CopyFrom(left);
+  right.set_pretty_name("void bar()");
+
+  internal::EqualFunctionInfo eq;
+  EXPECT_FALSE(eq(left, right));
+  internal::HashFunctionInfo hash;
+  EXPECT_NE(hash(left), hash(right));
+}
+TEST(FunctionInfoSet, DifferentLoadedModulePath) {
+  FunctionInfo left;
+  left.set_name("foo");
+  left.set_pretty_name("void foo()");
+  left.set_loaded_module_path("/path/to/module");
+  left.set_module_base_address(42);
+  left.set_address(12);
+  left.set_load_bias(4);
+  left.set_size(16);
+  left.set_file("file.cpp");
+  left.set_line(13);
+
+  FunctionInfo right;
+  right.CopyFrom(left);
+  right.set_loaded_module_path("/path/to/other");
+
+  internal::EqualFunctionInfo eq;
+  EXPECT_FALSE(eq(left, right));
+  internal::HashFunctionInfo hash;
+  EXPECT_NE(hash(left), hash(right));
+}
+
+TEST(FunctionInfoSet, DifferentModuleBaseAddress) {
+  FunctionInfo left;
+  left.set_name("foo");
+  left.set_pretty_name("void foo()");
+  left.set_loaded_module_path("/path/to/module");
+  left.set_module_base_address(42);
+  left.set_address(12);
+  left.set_load_bias(4);
+  left.set_size(16);
+  left.set_file("file.cpp");
+  left.set_line(13);
+
+  FunctionInfo right;
+  right.CopyFrom(left);
+  right.set_module_base_address(43);
+
+  internal::EqualFunctionInfo eq;
+  EXPECT_FALSE(eq(left, right));
+  internal::HashFunctionInfo hash;
+  EXPECT_NE(hash(left), hash(right));
+}
+
+TEST(FunctionInfoSet, DifferentAddress) {
+  FunctionInfo left;
+  left.set_name("foo");
+  left.set_pretty_name("void foo()");
+  left.set_loaded_module_path("/path/to/module");
+  left.set_module_base_address(42);
+  left.set_address(12);
+  left.set_load_bias(4);
+  left.set_size(16);
+  left.set_file("file.cpp");
+  left.set_line(13);
+
+  FunctionInfo right;
+  right.CopyFrom(left);
+  right.set_address(14);
+
+  internal::EqualFunctionInfo eq;
+  EXPECT_FALSE(eq(left, right));
+  internal::HashFunctionInfo hash;
+  EXPECT_NE(hash(left), hash(right));
+}
+
+TEST(FunctionInfoSet, DifferentLoadBias) {
+  FunctionInfo left;
+  left.set_name("foo");
+  left.set_pretty_name("void foo()");
+  left.set_loaded_module_path("/path/to/module");
+  left.set_module_base_address(42);
+  left.set_address(12);
+  left.set_load_bias(4);
+  left.set_size(16);
+  left.set_file("file.cpp");
+  left.set_line(13);
+
+  FunctionInfo right;
+  right.CopyFrom(left);
+  right.set_load_bias(3);
+
+  internal::EqualFunctionInfo eq;
+  EXPECT_FALSE(eq(left, right));
+  internal::HashFunctionInfo hash;
+  EXPECT_NE(hash(left), hash(right));
+}
+TEST(FunctionInfoSet, DifferentSize) {
+  FunctionInfo left;
+  left.set_name("foo");
+  left.set_pretty_name("void foo()");
+  left.set_loaded_module_path("/path/to/module");
+  left.set_module_base_address(42);
+  left.set_address(12);
+  left.set_load_bias(4);
+  left.set_size(16);
+  left.set_file("file.cpp");
+  left.set_line(13);
+
+  FunctionInfo right;
+  right.CopyFrom(left);
+  right.set_size(15);
+
+  internal::EqualFunctionInfo eq;
+  EXPECT_FALSE(eq(left, right));
+  internal::HashFunctionInfo hash;
+  EXPECT_NE(hash(left), hash(right));
+}
+TEST(FunctionInfoSet, DifferentFile) {
+  FunctionInfo left;
+  left.set_name("foo");
+  left.set_pretty_name("void foo()");
+  left.set_loaded_module_path("/path/to/module");
+  left.set_module_base_address(42);
+  left.set_address(12);
+  left.set_load_bias(4);
+  left.set_size(16);
+  left.set_file("file.cpp");
+  left.set_line(13);
+
+  FunctionInfo right;
+  right.CopyFrom(left);
+  right.set_file("other.cpp");
+
+  internal::EqualFunctionInfo eq;
+  EXPECT_FALSE(eq(left, right));
+  internal::HashFunctionInfo hash;
+  EXPECT_NE(hash(left), hash(right));
+}
+TEST(FunctionInfoSet, DifferentLine) {
+  FunctionInfo left;
+  left.set_name("foo");
+  left.set_pretty_name("void foo()");
+  left.set_loaded_module_path("/path/to/module");
+  left.set_module_base_address(42);
+  left.set_address(12);
+  left.set_load_bias(4);
+  left.set_size(16);
+  left.set_file("file.cpp");
+  left.set_line(13);
+
+  FunctionInfo right;
+  right.CopyFrom(left);
+  right.set_line(12);
+
+  internal::EqualFunctionInfo eq;
+  EXPECT_FALSE(eq(left, right));
+  internal::HashFunctionInfo hash;
+  EXPECT_NE(hash(left), hash(right));
+}
+
+TEST(FunctionInfoSet, Insertion) {
+  FunctionInfo function;
+  function.set_name("foo");
+  function.set_pretty_name("void foo()");
+  function.set_loaded_module_path("/path/to/module");
+  function.set_module_base_address(42);
+  function.set_address(12);
+  function.set_load_bias(4);
+  function.set_size(16);
+  function.set_file("file.cpp");
+  function.set_line(13);
+
+  FunctionInfoSet functions;
+  EXPECT_FALSE(functions.contains(function));
+  functions.insert(function);
+  EXPECT_TRUE(functions.contains(function));
+  EXPECT_EQ(functions.size(), 1);
+
+  FunctionInfo other;
+  EXPECT_FALSE(functions.contains(other));
+}
+
+TEST(FunctionInfoSet, Deletion) {
+  FunctionInfo function;
+  function.set_name("foo");
+  function.set_pretty_name("void foo()");
+  function.set_loaded_module_path("/path/to/module");
+  function.set_module_base_address(42);
+  function.set_address(12);
+  function.set_load_bias(4);
+  function.set_size(16);
+  function.set_file("file.cpp");
+  function.set_line(13);
+
+  FunctionInfoSet functions;
+  functions.insert(function);
+  EXPECT_TRUE(functions.contains(function));
+  EXPECT_EQ(functions.size(), 1);
+
+  FunctionInfo other;
+  EXPECT_FALSE(functions.contains(other));
+  functions.erase(other);
+  EXPECT_FALSE(functions.contains(other));
+  EXPECT_EQ(functions.size(), 1);
+
+  functions.erase(function);
+  EXPECT_FALSE(functions.contains(function));
+  EXPECT_EQ(functions.size(), 0);
+}

--- a/OrbitClientData/FunctionInfoSetTest.cpp
+++ b/OrbitClientData/FunctionInfoSetTest.cpp
@@ -22,7 +22,15 @@ TEST(FunctionInfoSet, EqualFunctions) {
   left.set_line(13);
 
   FunctionInfo right;
-  right.CopyFrom(left);
+  right.set_name("foo");
+  right.set_pretty_name("void foo()");
+  right.set_loaded_module_path("/path/to/module");
+  right.set_module_base_address(42);
+  right.set_address(12);
+  right.set_load_bias(4);
+  right.set_size(16);
+  right.set_file("file.cpp");
+  right.set_line(13);
 
   internal::EqualFunctionInfo eq;
   EXPECT_TRUE(eq(left, right));
@@ -51,6 +59,7 @@ TEST(FunctionInfoSet, DifferentName) {
   internal::HashFunctionInfo hash;
   EXPECT_NE(hash(left), hash(right));
 }
+
 TEST(FunctionInfoSet, DifferentPrettyName) {
   FunctionInfo left;
   left.set_name("foo");
@@ -72,6 +81,7 @@ TEST(FunctionInfoSet, DifferentPrettyName) {
   internal::HashFunctionInfo hash;
   EXPECT_NE(hash(left), hash(right));
 }
+
 TEST(FunctionInfoSet, DifferentLoadedModulePath) {
   FunctionInfo left;
   left.set_name("foo");
@@ -159,6 +169,7 @@ TEST(FunctionInfoSet, DifferentLoadBias) {
   internal::HashFunctionInfo hash;
   EXPECT_NE(hash(left), hash(right));
 }
+
 TEST(FunctionInfoSet, DifferentSize) {
   FunctionInfo left;
   left.set_name("foo");
@@ -180,6 +191,7 @@ TEST(FunctionInfoSet, DifferentSize) {
   internal::HashFunctionInfo hash;
   EXPECT_NE(hash(left), hash(right));
 }
+
 TEST(FunctionInfoSet, DifferentFile) {
   FunctionInfo left;
   left.set_name("foo");
@@ -201,6 +213,7 @@ TEST(FunctionInfoSet, DifferentFile) {
   internal::HashFunctionInfo hash;
   EXPECT_NE(hash(left), hash(right));
 }
+
 TEST(FunctionInfoSet, DifferentLine) {
   FunctionInfo left;
   left.set_name("foo");

--- a/OrbitClientData/ModuleData.cpp
+++ b/OrbitClientData/ModuleData.cpp
@@ -97,14 +97,14 @@ const std::vector<const FunctionInfo*> ModuleData::GetFunctions() const {
   return result;
 }
 
-const std::vector<const FunctionInfo*> ModuleData::GetOrbitFunctions() const {
+std::vector<FunctionInfo> ModuleData::GetOrbitFunctions() const {
   absl::MutexLock lock(&mutex_);
   CHECK(is_loaded_);
-  std::vector<const FunctionInfo*> result;
+  std::vector<FunctionInfo> result;
   for (const auto& pair : functions_) {
-    const FunctionInfo* function = pair.second.get();
-    if (FunctionUtils::IsOrbitFunc(*function)) {
-      result.push_back(function);
+    FunctionInfo function = *pair.second;
+    if (FunctionUtils::IsOrbitFunc(function)) {
+      result.emplace_back(std::move(function));
     }
   }
   return result;

--- a/OrbitClientData/include/OrbitClientData/FunctionInfoSet.h
+++ b/OrbitClientData/include/OrbitClientData/FunctionInfoSet.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_CLIENT_DATA_FUNCTION_INFO_SET_H_
+#define ORBIT_CLIENT_DATA_FUNCTION_INFO_SET_H_
+
+#include <absl/container/flat_hash_set.h>
+
+#include "capture_data.pb.h"
+
+namespace internal {
+struct HashFunctionInfo {
+  size_t operator()(const orbit_client_protos::FunctionInfo& function) const {
+    return std::hash<std::string>{}(function.name()) * 37 +
+           std::hash<std::string>{}(function.pretty_name()) * 37 +
+           std::hash<std::string>{}(function.loaded_module_path()) * 37 +
+           std::hash<uint64_t>{}(function.module_base_address()) * 37 +
+           std::hash<uint64_t>{}(function.address()) * 37 +
+           std::hash<uint64_t>{}(function.load_bias()) * 37 +
+           std::hash<uint64_t>{}(function.size()) * 37 +
+           std::hash<std::string>{}(function.file()) * 37 + std::hash<uint32_t>{}(function.line());
+  }
+};
+
+struct EqualFunctionInfo {
+  bool operator()(const orbit_client_protos::FunctionInfo& left,
+                  const orbit_client_protos::FunctionInfo& right) const {
+    return left.name().compare(right.name()) == 0 &&
+           left.pretty_name().compare(right.pretty_name()) == 0 &&
+           left.loaded_module_path().compare(right.loaded_module_path()) == 0 &&
+           left.module_base_address() == right.module_base_address() &&
+           left.address() == right.address() && left.load_bias() == right.load_bias() &&
+           left.size() == right.size() && left.file().compare(right.file()) == 0 &&
+           left.line() == right.line();
+  }
+};
+
+}  // namespace internal
+
+using FunctionInfoSet =
+    absl::flat_hash_set<orbit_client_protos::FunctionInfo, internal::HashFunctionInfo,
+                        internal::EqualFunctionInfo>;
+
+#endif  // ORBIT_CLIENT_DATA_FUNCTION_INFO_SET_H_

--- a/OrbitClientData/include/OrbitClientData/ModuleData.h
+++ b/OrbitClientData/include/OrbitClientData/ModuleData.h
@@ -47,8 +47,7 @@ class ModuleData final {
   void UpdateFunctionsModuleBaseAddress(uint64_t module_base_address);
   [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionFromHash(uint64_t hash) const;
   [[nodiscard]] const std::vector<const orbit_client_protos::FunctionInfo*> GetFunctions() const;
-  [[nodiscard]] const std::vector<const orbit_client_protos::FunctionInfo*> GetOrbitFunctions()
-      const;
+  [[nodiscard]] std::vector<orbit_client_protos::FunctionInfo> GetOrbitFunctions() const;
 
  private:
   mutable absl::Mutex mutex_;

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -605,12 +605,12 @@ ErrorMessageOr<void> OrbitApp::OnSavePreset(const std::string& filename) {
 ErrorMessageOr<void> OrbitApp::SavePreset(const std::string& filename) {
   PresetInfo preset;
 
-  for (const auto* function : data_manager_->GetSelectedFunctions()) {
+  for (const auto& function : data_manager_->GetSelectedFunctions()) {
     // GetSelectedFunctions should not contain orbit functions
-    CHECK(!FunctionUtils::IsOrbitFunc(*function));
+    CHECK(!FunctionUtils::IsOrbitFunc(function));
 
-    uint64_t hash = FunctionUtils::GetHash(*function);
-    (*preset.mutable_path_to_module())[function->loaded_module_path()].add_function_hashes(hash);
+    uint64_t hash = FunctionUtils::GetHash(function);
+    (*preset.mutable_path_to_module())[function.loaded_module_path()].add_function_hashes(hash);
   }
 
   std::string filename_with_ext = filename;
@@ -727,9 +727,9 @@ bool OrbitApp::StartCapture() {
   }
 
   absl::flat_hash_map<uint64_t, FunctionInfo> selected_functions;
-  for (const auto* function : data_manager_->GetSelectedAndOrbitFunctions()) {
-    uint64_t absolute_address = FunctionUtils::GetAbsoluteAddress(*function);
-    selected_functions[absolute_address] = FunctionInfo(*function);
+  for (const auto& function : data_manager_->GetSelectedAndOrbitFunctions()) {
+    uint64_t absolute_address = FunctionUtils::GetAbsoluteAddress(function);
+    selected_functions[absolute_address] = FunctionInfo(function);
   }
 
   TracepointInfoSet selected_tracepoints = data_manager_->selected_tracepoints();
@@ -1102,28 +1102,26 @@ void OrbitApp::SelectFunction(const orbit_client_protos::FunctionInfo& func) {
       ", base_address=0x%" PRIx64 ")",
       func.pretty_name(), absolute_address, func.address(), func.load_bias(),
       func.module_base_address());
-  data_manager_->SelectFunction(absolute_address);
+  data_manager_->SelectFunction(func);
 }
 
 void OrbitApp::DeselectFunction(const orbit_client_protos::FunctionInfo& func) {
-  uint64_t absolute_address = FunctionUtils::GetAbsoluteAddress(func);
-  data_manager_->DeselectFunction(absolute_address);
+  data_manager_->DeselectFunction(func);
 }
-
-void OrbitApp::ClearSelectedFunctions() { data_manager_->ClearSelectedFunctions(); }
 
 [[nodiscard]] bool OrbitApp::IsFunctionSelected(
     const orbit_client_protos::FunctionInfo& func) const {
-  uint64_t absolute_address = FunctionUtils::GetAbsoluteAddress(func);
-  return data_manager_->IsFunctionSelected(absolute_address);
+  return data_manager_->IsFunctionSelected(func);
 }
 
 [[nodiscard]] bool OrbitApp::IsFunctionSelected(const SampledFunction& func) const {
-  return data_manager_->IsFunctionSelected(func.absolute_address);
+  return IsFunctionSelected(func.absolute_address);
 }
 
 [[nodiscard]] bool OrbitApp::IsFunctionSelected(uint64_t absolute_address) const {
-  return data_manager_->IsFunctionSelected(absolute_address);
+  int32_t pid = data_manager_->selected_process()->pid();
+  const FunctionInfo* function = data_manager_->FindFunctionByAddress(pid, absolute_address, false);
+  return data_manager_->IsFunctionSelected(*function);
 }
 
 void OrbitApp::SetVisibleFunctions(absl::flat_hash_set<uint64_t> visible_functions) {

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -281,7 +281,6 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   // TODO(kuebler): Move them to a separate controler at some point
   void SelectFunction(const orbit_client_protos::FunctionInfo& func);
   void DeselectFunction(const orbit_client_protos::FunctionInfo& func);
-  void ClearSelectedFunctions();
   [[nodiscard]] bool IsFunctionSelected(const orbit_client_protos::FunctionInfo& func) const;
   [[nodiscard]] bool IsFunctionSelected(const SampledFunction& func) const;
   [[nodiscard]] bool IsFunctionSelected(uint64_t absolute_address) const;

--- a/OrbitGl/DataManager.h
+++ b/OrbitGl/DataManager.h
@@ -7,6 +7,7 @@
 
 #include <thread>
 
+#include "OrbitClientData/FunctionInfoSet.h"
 #include "OrbitClientData/ModuleData.h"
 #include "OrbitClientData/ProcessData.h"
 #include "TextBox.h"
@@ -28,8 +29,8 @@ class DataManager final {
   void UpdateModuleInfos(int32_t process_id,
                          const std::vector<orbit_grpc_protos::ModuleInfo>& module_infos);
 
-  void SelectFunction(uint64_t function_address);
-  void DeselectFunction(uint64_t function_address);
+  void SelectFunction(const orbit_client_protos::FunctionInfo& function);
+  void DeselectFunction(const orbit_client_protos::FunctionInfo& function);
   void ClearSelectedFunctions();
   void set_visible_functions(absl::flat_hash_set<uint64_t> visible_functions);
   void set_selected_thread_id(int32_t thread_id);
@@ -45,10 +46,9 @@ class DataManager final {
       int32_t process_id, uint64_t absolute_address, bool is_exact) const;
   [[nodiscard]] absl::flat_hash_map<std::string, ModuleData*> GetModulesLoadedByProcess(
       const ProcessData* process) const;
-  [[nodiscard]] bool IsFunctionSelected(uint64_t function_address) const;
-  [[nodiscard]] std::vector<const orbit_client_protos::FunctionInfo*> GetSelectedFunctions() const;
-  [[nodiscard]] std::vector<const orbit_client_protos::FunctionInfo*> GetSelectedAndOrbitFunctions()
-      const;
+  [[nodiscard]] bool IsFunctionSelected(const orbit_client_protos::FunctionInfo& function) const;
+  [[nodiscard]] std::vector<orbit_client_protos::FunctionInfo> GetSelectedFunctions() const;
+  [[nodiscard]] std::vector<orbit_client_protos::FunctionInfo> GetSelectedAndOrbitFunctions() const;
   [[nodiscard]] bool IsFunctionVisible(uint64_t function_address) const;
   [[nodiscard]] int32_t selected_thread_id() const;
   [[nodiscard]] const TextBox* selected_text_box() const;
@@ -65,7 +65,7 @@ class DataManager final {
   const std::thread::id main_thread_id_;
   absl::flat_hash_map<int32_t, ProcessData> process_map_;
   absl::flat_hash_map<std::string, std::unique_ptr<ModuleData>> module_map_;
-  absl::flat_hash_set<uint64_t> selected_functions_;
+  FunctionInfoSet selected_functions_;
   absl::flat_hash_set<uint64_t> visible_functions_;
 
   TracepointInfoSet selected_tracepoints_;


### PR DESCRIPTION
This is the first part of a series of moving away from representing
functions by absolute addresses in order to make them independent
of the loaded process.

Prior to this, DataManager stored the selected functions as
as set of their absolute addresses.
This changes this, and stores them by value.
As protos have no hash/equals implementation, FunctionInfoSet
was added.

Test: Compile
Bug: http://b/169309553