### PR TITLE
Fix Potential Pointer Stability Issue in DataManager

### DIFF
--- a/OrbitGl/DataManager.h
+++ b/OrbitGl/DataManager.h
@@ -13,6 +13,7 @@
 #include "TracepointCustom.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
+#include "absl/container/node_hash_map.h"
 
 // This class is responsible for storing and
 // navigating data on the client side. Note that
@@ -63,7 +64,8 @@ class DataManager final {
 
  private:
   const std::thread::id main_thread_id_;
-  absl::flat_hash_map<int32_t, ProcessData> process_map_;
+  // We are sharing pointers to that entries and ensure reference stability by using node_hash_map
+  absl::node_hash_map<int32_t, ProcessData> process_map_;
   absl::flat_hash_map<std::string, std::unique_ptr<ModuleData>> module_map_;
   absl::flat_hash_set<uint64_t> selected_functions_;
   absl::flat_hash_set<uint64_t> visible_functions_;


### PR DESCRIPTION
Recent changes stores processes by value, rather then by unique_ptr
in DataManager. As we allow access to the actualy pointer of the
underlying process (in the container), we should be sure to have
pointer stability in that container.

absl::node_hash_map provides this stability.

Test: Compile