### PR TITLE
Fix manual instrumentation serialization for async tracks

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -679,7 +679,7 @@ PresetLoadState OrbitApp::GetPresetLoadState(
 ErrorMessageOr<void> OrbitApp::OnSaveCapture(const std::string& file_name) {
   const auto& key_to_string_map = GCurrentTimeGraph->GetStringManager()->GetKeyToStringMap();
 
-  std::vector<std::shared_ptr<TimerChain>> chains = GCurrentTimeGraph->GetAllTimerChains();
+  std::vector<std::shared_ptr<TimerChain>> chains = GCurrentTimeGraph->GetAllSerializableTimerChains();
 
   TimerInfosIterator timers_it_begin(chains.begin(), chains.end());
   TimerInfosIterator timers_it_end(chains.end(), chains.end());

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -679,7 +679,8 @@ PresetLoadState OrbitApp::GetPresetLoadState(
 ErrorMessageOr<void> OrbitApp::OnSaveCapture(const std::string& file_name) {
   const auto& key_to_string_map = GCurrentTimeGraph->GetStringManager()->GetKeyToStringMap();
 
-  std::vector<std::shared_ptr<TimerChain>> chains = GCurrentTimeGraph->GetAllSerializableTimerChains();
+  std::vector<std::shared_ptr<TimerChain>> chains =
+      GCurrentTimeGraph->GetAllSerializableTimerChains();
 
   TimerInfosIterator timers_it_begin(chains.begin(), chains.end());
   TimerInfosIterator timers_it_end(chains.end(), chains.end());

--- a/OrbitGl/AsyncTrack.cpp
+++ b/OrbitGl/AsyncTrack.cpp
@@ -52,8 +52,8 @@ void AsyncTrack::UpdateBoxHeight() {
 }
 
 std::vector<std::shared_ptr<TimerChain>> AsyncTrack::GetAllSerializableChains() {
-  // For async time slices, the start and stop events are their own individual timers and are 
-  // already serialized on their initial thread tracks. Return an empty vector so that we don't 
+  // For async time slices, the start and stop events are their own individual timers and are
+  // already serialized on their initial thread tracks. Return an empty vector so that we don't
   // serialize the async timer twice.
   return {};
 }

--- a/OrbitGl/AsyncTrack.cpp
+++ b/OrbitGl/AsyncTrack.cpp
@@ -51,10 +51,10 @@ void AsyncTrack::UpdateBoxHeight() {
   }
 }
 
-std::vector<std::shared_ptr<TimerChain>> AsyncTrack::GetAllChains() {
-  // GetAllChains() is used for timer serialization. In the case of async time slices, the start
-  // and stop events are their own individual timers and are already serialized on their initial
-  // thread tracks. Return an empty vector so that we don't serialize the async timer twice.
+std::vector<std::shared_ptr<TimerChain>> AsyncTrack::GetAllSerializableChains() {
+  // For async time slices, the start and stop events are their own individual timers and are 
+  // already serialized on their initial thread tracks. Return an empty vector so that we don't 
+  // serialize the async timer twice.
   return {};
 }
 

--- a/OrbitGl/AsyncTrack.cpp
+++ b/OrbitGl/AsyncTrack.cpp
@@ -51,6 +51,13 @@ void AsyncTrack::UpdateBoxHeight() {
   }
 }
 
+std::vector<std::shared_ptr<TimerChain>> AsyncTrack::GetAllChains() {
+  // GetAllChains() is used for timer serialization. In the case of async time slices, the start
+  // and stop events are their own individual timers and are already serialized on their initial
+  // thread tracks. Return an empty vector so that we don't serialize the async timer twice.
+  return {};
+}
+
 void AsyncTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
   // Find the first row that that can receive the new timeslice with no overlap.
   // If none of the existing rows works, add a new row.

--- a/OrbitGl/AsyncTrack.h
+++ b/OrbitGl/AsyncTrack.h
@@ -16,6 +16,7 @@ class AsyncTrack : public TimerTrack {
 
   [[nodiscard]] Type GetType() const override { return kAsyncTrack; };
   [[nodiscard]] std::string GetBoxTooltip(PickingId id) const override;
+  [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllChains() override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
   void UpdateBoxHeight() override;
 

--- a/OrbitGl/AsyncTrack.h
+++ b/OrbitGl/AsyncTrack.h
@@ -16,7 +16,7 @@ class AsyncTrack : public TimerTrack {
 
   [[nodiscard]] Type GetType() const override { return kAsyncTrack; };
   [[nodiscard]] std::string GetBoxTooltip(PickingId id) const override;
-  [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllChains() override;
+  [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllSerializableChains() override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
   void UpdateBoxHeight() override;
 

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -408,6 +408,14 @@ std::vector<std::shared_ptr<TimerChain>> TimeGraph::GetAllThreadTrackTimerChains
   return chains;
 }
 
+std::vector<std::shared_ptr<TimerChain>> TimeGraph::GetAllSerializableTimerChains() const {
+  std::vector<std::shared_ptr<TimerChain>> chains;
+  for (const auto& track : tracks_) {
+    Append(chains, track->GetAllSerializableChains());
+  }
+  return chains;
+}
+
 void TimeGraph::UpdateMaxTimeStamp(uint64_t time) {
   if (time > capture_max_timestamp_) {
     capture_max_timestamp_ = time;

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -117,6 +117,7 @@ class TimeGraph {
   [[nodiscard]] uint32_t GetNumCores() const;
   [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllTimerChains() const;
   [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllThreadTrackTimerChains() const;
+  [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllSerializableTimerChains() const;
 
   void OnDrag(float ratio);
   [[nodiscard]] double GetMinTimeUs() const { return min_time_us_; }

--- a/OrbitGl/TimerTrack.cpp
+++ b/OrbitGl/TimerTrack.cpp
@@ -249,6 +249,10 @@ std::vector<std::shared_ptr<TimerChain>> TimerTrack::GetAllChains() {
   return chains;
 }
 
+std::vector<std::shared_ptr<TimerChain>> TimerTrack::GetAllSerializableChains() {
+  return GetAllChains();
+}
+
 bool TimerTrack::IsEmpty() const { return GetNumTimers() == 0; }
 
 std::string TimerTrack::GetBoxTooltip(PickingId /*id*/) const { return ""; }

--- a/OrbitGl/TimerTrack.h
+++ b/OrbitGl/TimerTrack.h
@@ -57,6 +57,7 @@ class TimerTrack : public Track {
   [[nodiscard]] virtual const TextBox* GetDown(const TextBox* textbox) const;
 
   [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllChains() override;
+  [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllSerializableChains() override;
   [[nodiscard]] virtual bool IsEmpty() const;
 
   [[nodiscard]] bool IsCollapsable() const override { return depth_ > 1; }

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -59,7 +59,9 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
 
   [[nodiscard]] virtual std::vector<std::shared_ptr<TimerChain>> GetTimers() { return {}; }
   [[nodiscard]] virtual std::vector<std::shared_ptr<TimerChain>> GetAllChains() { return {}; }
-  [[nodiscard]] virtual std::vector<std::shared_ptr<TimerChain>> GetAllSerializableChains() { return {}; }
+  [[nodiscard]] virtual std::vector<std::shared_ptr<TimerChain>> GetAllSerializableChains() {
+    return {};
+  }
 
   [[nodiscard]] bool IsMoving() const { return moving_; }
   [[nodiscard]] Vec2 GetMoveDelta() const {

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -59,6 +59,7 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
 
   [[nodiscard]] virtual std::vector<std::shared_ptr<TimerChain>> GetTimers() { return {}; }
   [[nodiscard]] virtual std::vector<std::shared_ptr<TimerChain>> GetAllChains() { return {}; }
+  [[nodiscard]] virtual std::vector<std::shared_ptr<TimerChain>> GetAllSerializableChains() { return {}; }
 
   [[nodiscard]] bool IsMoving() const { return moving_; }
   [[nodiscard]] Vec2 GetMoveDelta() const {


### PR DESCRIPTION
In the case of async time slices, the start and stop events are their
own individual timers and are already serialized on their initial thread
tracks. Make sure we don't serialize the async timers twice.

This change fixes a bug in the serialization of async timers that would
cause duplication of time slices. The other manual instrumentation
data was already properly serialized (scopes and graphs).

Fixes b/165078963

Test: grab a capture of OrbitTest which uses the manual instrumentation
API, save and reload.