### PR TITLE
Check std::error_code set by directory_iterator in GetTidsOfProcess

### DIFF
--- a/OrbitLinuxTracing/LinuxTracingUtils.cpp
+++ b/OrbitLinuxTracing/LinuxTracingUtils.cpp
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef ORBIT_LINUX_TRACING_UTILS_H_
-#define ORBIT_LINUX_TRACING_UTILS_H_
-
 #include <OrbitBase/Logging.h>
 #include <OrbitBase/SafeStrerror.h>
 #include <sys/resource.h>
@@ -255,5 +252,3 @@ bool SetMaxOpenFilesSoftLimit(uint64_t soft_limit) {
 }
 
 }  // namespace LinuxTracing
-
-#endif  // ORBIT_LINUX_TRACING_UTILS_H_


### PR DESCRIPTION
Bug: http://b/169727599

Test: Automatically run `LinuxTracingUtilsTest` thousands of times, verify that
the times when the problem occurs and the error is printed the test still
succeeds.