### PR TITLE
Remove Module Base Address and Load Bias from FunctionInfo

### DIFF
--- a/OrbitCaptureClient/CaptureClient.cpp
+++ b/OrbitCaptureClient/CaptureClient.cpp
@@ -100,7 +100,8 @@ void CaptureClient::Capture(ProcessData&& process,
         capture_options->add_instrumented_functions();
     instrumented_function->set_file_path(function.loaded_module_path());
     instrumented_function->set_file_offset(FunctionUtils::Offset(function));
-    instrumented_function->set_absolute_address(FunctionUtils::GetAbsoluteAddress(function));
+    instrumented_function->set_absolute_address(FunctionUtils::GetAbsoluteAddress(
+        function, process, *module_map.at(function.loaded_module_path())));
     instrumented_function->set_function_type(
         IntrumentedFunctionTypeFromOrbitType(function.orbit_type()));
   }

--- a/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -25,7 +25,7 @@ using orbit_client_protos::TimerInfo;
 class MyCaptureListener : public CaptureListener {
  private:
   void OnCaptureStarted(
-      ProcessData&& /*process*/, absl::flat_hash_map<std::string, ModuleData*>&& /*module_map*/,
+      ProcessData&& /*process*/,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> /*selected_functions*/,
       TracepointInfoSet /*selected_tracepoints*/) override {}
   void OnCaptureComplete() override {}

--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
@@ -31,7 +31,6 @@ class CaptureClient {
 
   [[nodiscard]] ErrorMessageOr<void> StartCapture(
       ThreadPool* thread_pool, const ProcessData& process,
-      const absl::flat_hash_map<std::string, ModuleData*>& module_map,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints);
 
@@ -54,7 +53,7 @@ class CaptureClient {
   }
 
  private:
-  void Capture(ProcessData&& process, absl::flat_hash_map<std::string, ModuleData*>&& module_map,
+  void Capture(ProcessData&& process,
                absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
                TracepointInfoSet selected_tracepoints);
 

--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
@@ -31,6 +31,7 @@ class CaptureClient {
 
   [[nodiscard]] ErrorMessageOr<void> StartCapture(
       ThreadPool* thread_pool, const ProcessData& process,
+      absl::flat_hash_map<std::string, ModuleData*> module_map,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints);
 
@@ -53,7 +54,7 @@ class CaptureClient {
   }
 
  private:
-  void Capture(ProcessData&& process,
+  void Capture(ProcessData&& process, absl::flat_hash_map<std::string, ModuleData*> module_map,
                absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
                TracepointInfoSet selected_tracepoints);
 

--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
@@ -19,7 +19,7 @@ class CaptureListener {
 
   // Called after capture started but before the first event arrived.
   virtual void OnCaptureStarted(
-      ProcessData&& process, absl::flat_hash_map<std::string, ModuleData*>&& module_map,
+      ProcessData&& process,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints) = 0;
   // Called when capture is complete.

--- a/OrbitClientData/FunctionInfoSetTest.cpp
+++ b/OrbitClientData/FunctionInfoSetTest.cpp
@@ -14,9 +14,7 @@ TEST(FunctionInfoSet, EqualFunctions) {
   left.set_name("foo");
   left.set_pretty_name("void foo()");
   left.set_loaded_module_path("/path/to/module");
-  left.set_module_base_address(42);
   left.set_address(12);
-  left.set_load_bias(4);
   left.set_size(16);
   left.set_file("file.cpp");
   left.set_line(13);
@@ -25,9 +23,7 @@ TEST(FunctionInfoSet, EqualFunctions) {
   right.set_name("foo");
   right.set_pretty_name("void foo()");
   right.set_loaded_module_path("/path/to/module");
-  right.set_module_base_address(42);
   right.set_address(12);
-  right.set_load_bias(4);
   right.set_size(16);
   right.set_file("file.cpp");
   right.set_line(13);
@@ -43,9 +39,7 @@ TEST(FunctionInfoSet, DifferentName) {
   left.set_name("foo");
   left.set_pretty_name("void foo()");
   left.set_loaded_module_path("/path/to/module");
-  left.set_module_base_address(42);
   left.set_address(12);
-  left.set_load_bias(4);
   left.set_size(16);
   left.set_file("file.cpp");
   left.set_line(13);
@@ -65,9 +59,7 @@ TEST(FunctionInfoSet, DifferentPrettyName) {
   left.set_name("foo");
   left.set_pretty_name("void foo()");
   left.set_loaded_module_path("/path/to/module");
-  left.set_module_base_address(42);
   left.set_address(12);
-  left.set_load_bias(4);
   left.set_size(16);
   left.set_file("file.cpp");
   left.set_line(13);
@@ -87,9 +79,7 @@ TEST(FunctionInfoSet, DifferentLoadedModulePath) {
   left.set_name("foo");
   left.set_pretty_name("void foo()");
   left.set_loaded_module_path("/path/to/module");
-  left.set_module_base_address(42);
   left.set_address(12);
-  left.set_load_bias(4);
   left.set_size(16);
   left.set_file("file.cpp");
   left.set_line(13);
@@ -104,36 +94,12 @@ TEST(FunctionInfoSet, DifferentLoadedModulePath) {
   EXPECT_NE(hash(left), hash(right));
 }
 
-TEST(FunctionInfoSet, DifferentModuleBaseAddress) {
-  FunctionInfo left;
-  left.set_name("foo");
-  left.set_pretty_name("void foo()");
-  left.set_loaded_module_path("/path/to/module");
-  left.set_module_base_address(42);
-  left.set_address(12);
-  left.set_load_bias(4);
-  left.set_size(16);
-  left.set_file("file.cpp");
-  left.set_line(13);
-
-  FunctionInfo right;
-  right.CopyFrom(left);
-  right.set_module_base_address(43);
-
-  internal::EqualFunctionInfo eq;
-  EXPECT_FALSE(eq(left, right));
-  internal::HashFunctionInfo hash;
-  EXPECT_NE(hash(left), hash(right));
-}
-
 TEST(FunctionInfoSet, DifferentAddress) {
   FunctionInfo left;
   left.set_name("foo");
   left.set_pretty_name("void foo()");
   left.set_loaded_module_path("/path/to/module");
-  left.set_module_base_address(42);
   left.set_address(12);
-  left.set_load_bias(4);
   left.set_size(16);
   left.set_file("file.cpp");
   left.set_line(13);
@@ -148,36 +114,12 @@ TEST(FunctionInfoSet, DifferentAddress) {
   EXPECT_NE(hash(left), hash(right));
 }
 
-TEST(FunctionInfoSet, DifferentLoadBias) {
-  FunctionInfo left;
-  left.set_name("foo");
-  left.set_pretty_name("void foo()");
-  left.set_loaded_module_path("/path/to/module");
-  left.set_module_base_address(42);
-  left.set_address(12);
-  left.set_load_bias(4);
-  left.set_size(16);
-  left.set_file("file.cpp");
-  left.set_line(13);
-
-  FunctionInfo right;
-  right.CopyFrom(left);
-  right.set_load_bias(3);
-
-  internal::EqualFunctionInfo eq;
-  EXPECT_FALSE(eq(left, right));
-  internal::HashFunctionInfo hash;
-  EXPECT_NE(hash(left), hash(right));
-}
-
 TEST(FunctionInfoSet, DifferentSize) {
   FunctionInfo left;
   left.set_name("foo");
   left.set_pretty_name("void foo()");
   left.set_loaded_module_path("/path/to/module");
-  left.set_module_base_address(42);
   left.set_address(12);
-  left.set_load_bias(4);
   left.set_size(16);
   left.set_file("file.cpp");
   left.set_line(13);
@@ -197,9 +139,7 @@ TEST(FunctionInfoSet, DifferentFile) {
   left.set_name("foo");
   left.set_pretty_name("void foo()");
   left.set_loaded_module_path("/path/to/module");
-  left.set_module_base_address(42);
   left.set_address(12);
-  left.set_load_bias(4);
   left.set_size(16);
   left.set_file("file.cpp");
   left.set_line(13);
@@ -219,9 +159,7 @@ TEST(FunctionInfoSet, DifferentLine) {
   left.set_name("foo");
   left.set_pretty_name("void foo()");
   left.set_loaded_module_path("/path/to/module");
-  left.set_module_base_address(42);
   left.set_address(12);
-  left.set_load_bias(4);
   left.set_size(16);
   left.set_file("file.cpp");
   left.set_line(13);
@@ -241,9 +179,7 @@ TEST(FunctionInfoSet, Insertion) {
   function.set_name("foo");
   function.set_pretty_name("void foo()");
   function.set_loaded_module_path("/path/to/module");
-  function.set_module_base_address(42);
   function.set_address(12);
-  function.set_load_bias(4);
   function.set_size(16);
   function.set_file("file.cpp");
   function.set_line(13);
@@ -263,9 +199,7 @@ TEST(FunctionInfoSet, Deletion) {
   function.set_name("foo");
   function.set_pretty_name("void foo()");
   function.set_loaded_module_path("/path/to/module");
-  function.set_module_base_address(42);
   function.set_address(12);
-  function.set_load_bias(4);
   function.set_size(16);
   function.set_file("file.cpp");
   function.set_line(13);

--- a/OrbitClientData/FunctionUtils.cpp
+++ b/OrbitClientData/FunctionUtils.cpp
@@ -28,24 +28,23 @@ std::string GetLoadedModuleName(const FunctionInfo& func) {
 
 uint64_t GetHash(const FunctionInfo& func) { return StringHash(func.pretty_name()); }
 
-uint64_t Offset(const FunctionInfo& func) { return func.address() - func.load_bias(); }
+uint64_t Offset(const FunctionInfo& func, const ModuleData& module) {
+  return func.address() - module.load_bias();
+}
 
 bool IsOrbitFunc(const FunctionInfo& func) { return func.orbit_type() != FunctionInfo::kNone; }
 
-std::unique_ptr<FunctionInfo> CreateFunctionInfo(const SymbolInfo& symbol_info, uint64_t load_bias,
-                                                 const std::string& module_path,
-                                                 uint64_t module_base_address) {
+std::unique_ptr<FunctionInfo> CreateFunctionInfo(const SymbolInfo& symbol_info,
+                                                 const std::string& module_path) {
   auto function_info = std::make_unique<FunctionInfo>();
 
   function_info->set_name(symbol_info.name());
   function_info->set_pretty_name(symbol_info.demangled_name());
   function_info->set_address(symbol_info.address());
-  function_info->set_load_bias(load_bias);
   function_info->set_size(symbol_info.size());
   function_info->set_file("");
   function_info->set_line(0);
   function_info->set_loaded_module_path(module_path);
-  function_info->set_module_base_address(module_base_address);
 
   SetOrbitTypeFromName(function_info.get());
   return function_info;

--- a/OrbitClientData/ModuleDataTest.cpp
+++ b/OrbitClientData/ModuleDataTest.cpp
@@ -44,7 +44,6 @@ TEST(ModuleData, Constructor) {
 TEST(ModuleData, LoadSymbols) {
   // Setup ModuleData
   std::string module_file_path = "/test/file/path";
-  uint64_t module_base_start = 0x40;
   uint64_t module_load_bias = 0x400;
   ModuleInfo module_info{};
   module_info.set_file_path(module_file_path);
@@ -65,7 +64,7 @@ TEST(ModuleData, LoadSymbols) {
   symbol_info->set_size(symbol_size);
 
   // Test
-  module.AddSymbols(module_symbols, module_base_start);
+  module.AddSymbols(module_symbols);
   EXPECT_TRUE(module.is_loaded());
 
   ASSERT_EQ(module.GetFunctions().size(), 1);
@@ -74,41 +73,10 @@ TEST(ModuleData, LoadSymbols) {
   EXPECT_EQ(function->name(), symbol_name);
   EXPECT_EQ(function->pretty_name(), symbol_pretty_name);
   EXPECT_EQ(function->loaded_module_path(), module_file_path);
-  EXPECT_EQ(function->module_base_address(), module_base_start);
   EXPECT_EQ(function->address(), symbol_address);
-  EXPECT_EQ(function->load_bias(), module_load_bias);
   EXPECT_EQ(function->size(), symbol_size);
   EXPECT_EQ(function->file(), "");
   EXPECT_EQ(function->line(), 0);
-}
-
-TEST(ModuleData, UpdateFunctionsModuleBaseAddress) {
-  ModuleData module{ModuleInfo{}};
-
-  ModuleSymbols symbols{};
-  SymbolInfo* symbol = symbols.add_symbol_infos();
-  symbol->set_name("test name");
-
-  module.AddSymbols(symbols, 0);
-
-  ASSERT_TRUE(module.is_loaded());
-  ASSERT_EQ(module.GetFunctions().size(), 1);
-
-  {
-    const FunctionInfo* function = module.GetFunctions()[0];
-    EXPECT_EQ(function->name(), "test name");
-    EXPECT_EQ(function->module_base_address(), 0);
-  }
-  module.UpdateFunctionsModuleBaseAddress(100);
-
-  ASSERT_TRUE(module.is_loaded());
-  ASSERT_EQ(module.GetFunctions().size(), 1);
-
-  {
-    const FunctionInfo* function = module.GetFunctions()[0];
-    EXPECT_EQ(function->name(), "test name");
-    EXPECT_EQ(function->module_base_address(), 100);
-  }
 }
 
 TEST(ModuleData, FindFunctionByRelativeAddress) {
@@ -130,7 +98,7 @@ TEST(ModuleData, FindFunctionByRelativeAddress) {
 
   ModuleData module{ModuleInfo{}};
 
-  module.AddSymbols(symbols, 1000);
+  module.AddSymbols(symbols);
   EXPECT_TRUE(module.is_loaded());
 
   // Find exact
@@ -192,7 +160,7 @@ TEST(ModuleData, FindFunctionFromHash) {
   symbol->set_name("Symbol Name");
 
   ModuleData module{ModuleInfo{}};
-  module.AddSymbols(symbols, 0);
+  module.AddSymbols(symbols);
 
   ASSERT_TRUE(module.is_loaded());
   ASSERT_FALSE(module.GetFunctions().empty());

--- a/OrbitClientData/ProcessData.cpp
+++ b/OrbitClientData/ProcessData.cpp
@@ -60,8 +60,3 @@ ErrorMessageOr<std::pair<std::string, uint64_t>> ProcessData::FindModuleByAddres
 
   return std::make_pair(module_path, memory_space.start);
 }
-
-void ProcessData::AddSymbols(ModuleData* module, const ModuleSymbols& module_symbols) const {
-  uint64_t module_base_address = module_memory_map_.at(module->file_path()).start;
-  module->AddSymbols(module_symbols, module_base_address);
-}

--- a/OrbitClientData/include/OrbitClientData/FunctionInfoSet.h
+++ b/OrbitClientData/include/OrbitClientData/FunctionInfoSet.h
@@ -15,9 +15,7 @@ struct HashFunctionInfo {
     return std::hash<std::string>{}(function.name()) * 37 +
            std::hash<std::string>{}(function.pretty_name()) * 37 +
            std::hash<std::string>{}(function.loaded_module_path()) * 37 +
-           std::hash<uint64_t>{}(function.module_base_address()) * 37 +
            std::hash<uint64_t>{}(function.address()) * 37 +
-           std::hash<uint64_t>{}(function.load_bias()) * 37 +
            std::hash<uint64_t>{}(function.size()) * 37 +
            std::hash<std::string>{}(function.file()) * 37 + std::hash<uint32_t>{}(function.line());
   }
@@ -26,11 +24,9 @@ struct HashFunctionInfo {
 struct EqualFunctionInfo {
   bool operator()(const orbit_client_protos::FunctionInfo& left,
                   const orbit_client_protos::FunctionInfo& right) const {
-    return left.name().compare(right.name()) == 0 &&
+    return left.address() == right.address() && left.name().compare(right.name()) == 0 &&
            left.pretty_name().compare(right.pretty_name()) == 0 &&
            left.loaded_module_path().compare(right.loaded_module_path()) == 0 &&
-           left.module_base_address() == right.module_base_address() &&
-           left.address() == right.address() && left.load_bias() == right.load_bias() &&
            left.size() == right.size() && left.file().compare(right.file()) == 0 &&
            left.line() == right.line();
   }

--- a/OrbitClientData/include/OrbitClientData/FunctionInfoSet.h
+++ b/OrbitClientData/include/OrbitClientData/FunctionInfoSet.h
@@ -5,8 +5,8 @@
 #ifndef ORBIT_CLIENT_DATA_FUNCTION_INFO_SET_H_
 #define ORBIT_CLIENT_DATA_FUNCTION_INFO_SET_H_
 
-#include <absl/container/flat_hash_set.h>
-
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
 #include "capture_data.pb.h"
 
 namespace internal {
@@ -40,6 +40,11 @@ struct EqualFunctionInfo {
 
 using FunctionInfoSet =
     absl::flat_hash_set<orbit_client_protos::FunctionInfo, internal::HashFunctionInfo,
+                        internal::EqualFunctionInfo>;
+
+template <class V>
+using FunctionInfoMap =
+    absl::flat_hash_map<orbit_client_protos::FunctionInfo, V, internal::HashFunctionInfo,
                         internal::EqualFunctionInfo>;
 
 #endif  // ORBIT_CLIENT_DATA_FUNCTION_INFO_SET_H_

--- a/OrbitClientData/include/OrbitClientData/FunctionUtils.h
+++ b/OrbitClientData/include/OrbitClientData/FunctionUtils.h
@@ -23,10 +23,8 @@ namespace FunctionUtils {
 [[nodiscard]] uint64_t GetHash(const orbit_client_protos::FunctionInfo& func);
 
 // Calculates and returns the absolute address of the function.
-[[nodiscard]] uint64_t Offset(const orbit_client_protos::FunctionInfo& func);
-[[nodiscard]] inline uint64_t GetAbsoluteAddress(const orbit_client_protos::FunctionInfo& func) {
-  return func.address() + func.module_base_address() - func.load_bias();
-}
+[[nodiscard]] uint64_t Offset(const orbit_client_protos::FunctionInfo& func,
+                              const ModuleData& module);
 [[nodiscard]] inline uint64_t GetAbsoluteAddress(const orbit_client_protos::FunctionInfo& func,
                                                  const ProcessData& process,
                                                  const ModuleData& module) {
@@ -37,8 +35,7 @@ namespace FunctionUtils {
 [[nodiscard]] bool IsOrbitFunc(const orbit_client_protos::FunctionInfo& func);
 
 [[nodiscard]] std::unique_ptr<orbit_client_protos::FunctionInfo> CreateFunctionInfo(
-    const orbit_grpc_protos::SymbolInfo& symbol_info, uint64_t load_bias,
-    const std::string& module_path, uint64_t module_base_address);
+    const orbit_grpc_protos::SymbolInfo& symbol_info, const std::string& module_path);
 
 bool SetOrbitTypeFromName(orbit_client_protos::FunctionInfo* func);
 

--- a/OrbitClientData/include/OrbitClientData/FunctionUtils.h
+++ b/OrbitClientData/include/OrbitClientData/FunctionUtils.h
@@ -13,22 +13,23 @@
 
 namespace FunctionUtils {
 
-inline const std::string& GetDisplayName(const orbit_client_protos::FunctionInfo& func) {
+[[nodiscard]] inline const std::string& GetDisplayName(
+    const orbit_client_protos::FunctionInfo& func) {
   return func.pretty_name().empty() ? func.name() : func.pretty_name();
 }
 
-std::string GetLoadedModuleName(const orbit_client_protos::FunctionInfo& func);
-uint64_t GetHash(const orbit_client_protos::FunctionInfo& func);
+[[nodiscard]] std::string GetLoadedModuleName(const orbit_client_protos::FunctionInfo& func);
+[[nodiscard]] uint64_t GetHash(const orbit_client_protos::FunctionInfo& func);
 
 // Calculates and returns the absolute address of the function.
-uint64_t Offset(const orbit_client_protos::FunctionInfo& func);
-inline uint64_t GetAbsoluteAddress(const orbit_client_protos::FunctionInfo& func) {
+[[nodiscard]] uint64_t Offset(const orbit_client_protos::FunctionInfo& func);
+[[nodiscard]] inline uint64_t GetAbsoluteAddress(const orbit_client_protos::FunctionInfo& func) {
   return func.address() + func.module_base_address() - func.load_bias();
 }
 
-bool IsOrbitFunc(const orbit_client_protos::FunctionInfo& func);
+[[nodiscard]] bool IsOrbitFunc(const orbit_client_protos::FunctionInfo& func);
 
-std::unique_ptr<orbit_client_protos::FunctionInfo> CreateFunctionInfo(
+[[nodiscard]] std::unique_ptr<orbit_client_protos::FunctionInfo> CreateFunctionInfo(
     const orbit_grpc_protos::SymbolInfo& symbol_info, uint64_t load_bias,
     const std::string& module_path, uint64_t module_base_address);
 

--- a/OrbitClientData/include/OrbitClientData/FunctionUtils.h
+++ b/OrbitClientData/include/OrbitClientData/FunctionUtils.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <string>
 
+#include "ProcessData.h"
 #include "capture_data.pb.h"
 #include "symbol.pb.h"
 
@@ -25,6 +26,12 @@ namespace FunctionUtils {
 [[nodiscard]] uint64_t Offset(const orbit_client_protos::FunctionInfo& func);
 [[nodiscard]] inline uint64_t GetAbsoluteAddress(const orbit_client_protos::FunctionInfo& func) {
   return func.address() + func.module_base_address() - func.load_bias();
+}
+[[nodiscard]] inline uint64_t GetAbsoluteAddress(const orbit_client_protos::FunctionInfo& func,
+                                                 const ProcessData& process,
+                                                 const ModuleData& module) {
+  return func.address() + process.GetModuleBaseAddress(func.loaded_module_path()) -
+         module.load_bias();
 }
 
 [[nodiscard]] bool IsOrbitFunc(const orbit_client_protos::FunctionInfo& func);

--- a/OrbitClientData/include/OrbitClientData/ModuleData.h
+++ b/OrbitClientData/include/OrbitClientData/ModuleData.h
@@ -40,11 +40,7 @@ class ModuleData final {
   // TODO(169309553): The module_base_address parameter should not be needed here, but it is
   // because FunctionInfo still contains the field module_base_address. As soon as that field is
   // gone, remove the parameter here
-  void AddSymbols(const orbit_grpc_protos::ModuleSymbols& module_symbols,
-                  uint64_t module_base_address);
-  // TODO(169309553): As soon as FunctionInfo does not contain module_base_address anymore,
-  // completely remove the following method
-  void UpdateFunctionsModuleBaseAddress(uint64_t module_base_address);
+  void AddSymbols(const orbit_grpc_protos::ModuleSymbols& module_symbols);
   [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionFromHash(uint64_t hash) const;
   [[nodiscard]] const std::vector<const orbit_client_protos::FunctionInfo*> GetFunctions() const;
   [[nodiscard]] std::vector<orbit_client_protos::FunctionInfo> GetOrbitFunctions() const;

--- a/OrbitClientData/include/OrbitClientData/ModuleData.h
+++ b/OrbitClientData/include/OrbitClientData/ModuleData.h
@@ -30,7 +30,7 @@ class ModuleData final {
   [[nodiscard]] const std::string& build_id() const { return module_info_.build_id(); }
   [[nodiscard]] uint64_t load_bias() const { return module_info_.load_bias(); }
   [[nodiscard]] bool is_loaded() const;
-
+  [[nodiscard]] const orbit_grpc_protos::ModuleInfo& module_info() const { return module_info_; }
   // relative_address here is the absolute address minus the address this module was loaded at by
   // the process (module base address)
   [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionByRelativeAddress(

--- a/OrbitClientData/include/OrbitClientData/ProcessData.h
+++ b/OrbitClientData/include/OrbitClientData/ProcessData.h
@@ -55,9 +55,6 @@ class ProcessData final {
   [[nodiscard]] ErrorMessageOr<std::pair<std::string, uint64_t>> FindModuleByAddress(
       uint64_t absolute_address) const;
 
-  // TODO(169309553): remove this function and add symbols directly into a module, as soon as the
-  // module_base_address is not needed anymore (FunctionInfo needs to be changed)
-  void AddSymbols(ModuleData* module, const orbit_grpc_protos::ModuleSymbols& module_symbols) const;
   uint64_t GetModuleBaseAddress(const std::string& module_path) const {
     CHECK(module_memory_map_.contains(module_path));
     return module_memory_map_.at(module_path).start;

--- a/OrbitClientData/include/OrbitClientData/ProcessData.h
+++ b/OrbitClientData/include/OrbitClientData/ProcessData.h
@@ -69,8 +69,6 @@ class ProcessData final {
     return module_memory_map_.contains(module_path);
   }
 
-  [[nodiscard]] const orbit_grpc_protos::ProcessInfo& process_info() const { return process_info_; }
-
  private:
   orbit_grpc_protos::ProcessInfo process_info_;
 

--- a/OrbitClientData/include/OrbitClientData/ProcessData.h
+++ b/OrbitClientData/include/OrbitClientData/ProcessData.h
@@ -69,6 +69,8 @@ class ProcessData final {
     return module_memory_map_.contains(module_path);
   }
 
+  [[nodiscard]] const orbit_grpc_protos::ProcessInfo& process_info() const { return process_info_; }
+
  private:
   orbit_grpc_protos::ProcessInfo process_info_;
 

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -96,7 +96,7 @@ bool ClientGgp::RequestStartCapture(ThreadPool* thread_pool) {
   TracepointInfoSet selected_tracepoints;
 
   ErrorMessageOr<void> result = capture_client_->StartCapture(
-      thread_pool, target_process_, selected_functions, selected_tracepoints);
+      thread_pool, target_process_, module_map_, selected_functions, selected_tracepoints);
 
   if (result.has_error()) {
     ERROR("Error starting capture: %s", result.error().message());
@@ -192,7 +192,7 @@ ErrorMessageOr<void> ClientGgp::LoadModuleAndSymbols() {
   LOG("Found file: %s", main_executable_debug_file);
   LOG("Loading symbols");
   OUTCOME_TRY(symbols, SymbolHelper::LoadSymbolsFromFile(main_executable_debug_file));
-  target_process_.AddSymbols(main_module_, symbols);
+  main_module_->AddSymbols(symbols);
   return outcome::success();
 }
 

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -240,7 +240,7 @@ absl::flat_hash_map<uint64_t, FunctionInfo> ClientGgp::GetSelectedFunctions() {
   for (const FunctionInfo* func : main_module_->GetFunctions()) {
     const std::string& selected_function_match = SelectedFunctionMatch(*func);
     if (!selected_function_match.empty()) {
-      uint64_t address = FunctionUtils::GetAbsoluteAddress(*func);
+      uint64_t address = FunctionUtils::GetAbsoluteAddress(*func, target_process_, *main_module_);
       selected_functions[address] = *func;
       if (!capture_functions_used.contains(selected_function_match)) {
         capture_functions_used.insert(selected_function_match);

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -30,7 +30,7 @@ class ClientGgp final : public CaptureListener {
 
   // CaptureListener implementation
   void OnCaptureStarted(
-      ProcessData&& process, absl::flat_hash_map<std::string, ModuleData*>&& module_map,
+      ProcessData&& process,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints) override;
   void OnCaptureComplete() override;

--- a/OrbitClientModel/CaptureDeserializer.cpp
+++ b/OrbitClientModel/CaptureDeserializer.cpp
@@ -156,9 +156,8 @@ void LoadCaptureInfo(
   process.UpdateModuleInfos(modules);
   modules_callback(process_info, modules);
 
-  capture_listener->OnCaptureStarted(
-      std::move(process), absl::flat_hash_map<std::string, ModuleData*>(),
-      std::move(selected_functions), std::move(selected_tracepoints));
+  capture_listener->OnCaptureStarted(std::move(process), std::move(selected_functions),
+                                     std::move(selected_tracepoints));
 
   for (const auto& address_info : capture_info.address_infos()) {
     if (*cancellation_requested) {

--- a/OrbitClientModel/CaptureDeserializerTest.cpp
+++ b/OrbitClientModel/CaptureDeserializerTest.cpp
@@ -42,7 +42,7 @@ class MockCaptureListener : public CaptureListener {
  public:
   MOCK_METHOD(
       void, OnCaptureStarted,
-      (ProcessData&& /*process*/, (absl::flat_hash_map<std::string, ModuleData*> &&) /*module_map*/,
+      (ProcessData&& /*process*/,
        (absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>)/*selected_functions*/,
        TracepointInfoSet /*selected_tracepoints*/),
       (override));
@@ -186,10 +186,10 @@ TEST(CaptureDeserializer, LoadCaptureInfoOnCaptureStarted) {
   google::protobuf::io::CodedInputStream empty_stream(&empty_data, 0);
 
   // There will be no call to OnCaptureStarted other then the one specified next.
-  EXPECT_CALL(listener, OnCaptureStarted(_, _, _, _)).Times(0);
-  EXPECT_CALL(listener, OnCaptureStarted(_, _, _, IsEmpty()))
+  EXPECT_CALL(listener, OnCaptureStarted(_, _, _)).Times(0);
+  EXPECT_CALL(listener, OnCaptureStarted(_, _, IsEmpty()))
       .Times(1)
-      .WillOnce([selected_function](ProcessData&& process, Unused,
+      .WillOnce([selected_function](ProcessData&& process,
                                     absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>
                                         actual_selected_functions,
                                     Unused) {
@@ -239,7 +239,7 @@ TEST(CaptureDeserializer, LoadCaptureInfoModulesCallback) {
   google::protobuf::io::CodedInputStream empty_stream(&empty_data, 0);
 
   // There will be no call to OnCaptureStarted other then the one specified next.
-  EXPECT_CALL(listener, OnCaptureStarted(_, _, _, _)).Times(1);
+  EXPECT_CALL(listener, OnCaptureStarted).Times(1);
   EXPECT_CALL(listener, OnCaptureComplete).Times(1);
   EXPECT_CALL(listener, OnCaptureFailed).Times(0);
   EXPECT_CALL(listener, OnCaptureCancelled).Times(0);

--- a/OrbitClientModel/CaptureSerializer.cpp
+++ b/OrbitClientModel/CaptureSerializer.cpp
@@ -18,6 +18,8 @@ using orbit_client_protos::CallstackInfo;
 using orbit_client_protos::CaptureInfo;
 using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::FunctionStats;
+using orbit_client_protos::ModuleInfo;
+using orbit_client_protos::ProcessInfo;
 
 namespace {
 inline constexpr std::string_view kFileOrbitExtension = ".orbit";
@@ -57,8 +59,24 @@ CaptureInfo GenerateCaptureInfo(
     capture_info.add_selected_functions()->CopyFrom(pair.second);
   }
 
-  capture_info.set_process_id(capture_data.process_id());
-  capture_info.set_process_name(capture_data.process_name());
+  ProcessInfo* process = capture_info.mutable_process();
+  process->set_pid(capture_data.process()->pid());
+  process->set_name(capture_data.process()->name());
+  process->set_cpu_usage(capture_data.process()->cpu_usage());
+  process->set_full_path(capture_data.process()->full_path());
+  process->set_command_line(capture_data.process()->command_line());
+  process->set_is_64_bit(capture_data.process()->is_64_bit());
+
+  for (const auto& [_, module] : capture_data.module_map()) {
+    ModuleInfo* module_info = capture_info.add_modules();
+    module_info->set_name(module->name());
+    module_info->set_file_path(module->file_path());
+    module_info->set_file_size(module->file_size());
+    module_info->set_address_start(module->module_info().address_start());
+    module_info->set_address_end(module->module_info().address_end());
+    module_info->set_build_id(module->build_id());
+    module_info->set_load_bias(module->load_bias());
+  }
 
   capture_info.mutable_thread_names()->insert(capture_data.thread_names().begin(),
                                               capture_data.thread_names().end());

--- a/OrbitClientModel/CaptureSerializer.cpp
+++ b/OrbitClientModel/CaptureSerializer.cpp
@@ -100,10 +100,9 @@ CaptureInfo GenerateCaptureInfo(
   }
 
   const FunctionInfoMap<FunctionStats>& functions_stats = capture_data.functions_stats();
-  for (const auto& function_to_stats : functions_stats) {
-    const FunctionInfo& function = function_to_stats.first;
+  for (const auto& [function, stats] : functions_stats) {
     uint64_t absolute_address = capture_data.GetAbsoluteAddress(function);
-    capture_info.mutable_function_stats()->operator[](absolute_address) = function_to_stats.second;
+    capture_info.mutable_function_stats()->operator[](absolute_address) = stats;
   }
 
   // TODO: this is not really synchronized, since GetCallstackData processing below is not under the

--- a/OrbitClientModel/CaptureSerializer.cpp
+++ b/OrbitClientModel/CaptureSerializer.cpp
@@ -16,6 +16,7 @@
 
 using orbit_client_protos::CallstackInfo;
 using orbit_client_protos::CaptureInfo;
+using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::FunctionStats;
 
 namespace {
@@ -74,14 +75,18 @@ CaptureInfo GenerateCaptureInfo(
     }
     // Fix names/offset/module in address infos (some might only be in process):
     added_address_info->set_function_name(FunctionUtils::GetDisplayName(*function));
-    const uint64_t offset = absolute_address - FunctionUtils::GetAbsoluteAddress(*function);
+    uint64_t absolute_function_address = capture_data.GetAbsoluteAddress(*function);
+    const uint64_t offset = absolute_address - absolute_function_address;
     added_address_info->set_offset_in_function(offset);
     added_address_info->set_module_path(function->loaded_module_path());
   }
 
-  const absl::flat_hash_map<uint64_t, FunctionStats>& functions_stats =
-      capture_data.functions_stats();
-  capture_info.mutable_function_stats()->insert(functions_stats.begin(), functions_stats.end());
+  const FunctionInfoMap<FunctionStats>& functions_stats = capture_data.functions_stats();
+  for (const auto& function_to_stats : functions_stats) {
+    const FunctionInfo& function = function_to_stats.first;
+    uint64_t absolute_address = capture_data.GetAbsoluteAddress(function);
+    capture_info.mutable_function_stats()->operator[](absolute_address) = function_to_stats.second;
+  }
 
   // TODO: this is not really synchronized, since GetCallstackData processing below is not under the
   // same mutex lock we could end up having list of callstacks inconsistent with unique_callstacks.

--- a/OrbitClientModel/CaptureSerializerTest.cpp
+++ b/OrbitClientModel/CaptureSerializerTest.cpp
@@ -49,10 +49,11 @@ TEST(CaptureSerializer, IncludeOrbitExtensionInFile) {
 
 TEST(CaptureSerializer, GenerateCaptureInfoEmpty) {
   CaptureData capture_data;
+  absl::flat_hash_map<std::string, ModuleData*> module_map;
   absl::flat_hash_map<uint64_t, std::string> key_to_string_map;
 
-  CaptureInfo capture_info =
-      capture_serializer::internal::GenerateCaptureInfo(capture_data, key_to_string_map);
+  CaptureInfo capture_info = capture_serializer::internal::GenerateCaptureInfo(
+      capture_data, module_map, key_to_string_map);
   EXPECT_EQ(0, capture_info.selected_functions_size());
   EXPECT_EQ(-1, capture_info.process().pid());
   EXPECT_EQ("", capture_info.process().name());
@@ -97,8 +98,7 @@ TEST(CaptureSerializer, GenerateCaptureInfo) {
   selected_tracepoint_info.set_name("sched_switch");
   selected_tracepoints.insert(selected_tracepoint_info);
 
-  CaptureData capture_data{std::move(process), std::move(module_map), selected_functions,
-                           selected_tracepoints};
+  CaptureData capture_data{std::move(process), selected_functions, selected_tracepoints};
 
   LinuxAddressInfo address_info;
   address_info.set_absolute_address(987);
@@ -139,8 +139,8 @@ TEST(CaptureSerializer, GenerateCaptureInfo) {
   key_to_string_map[1] = "b";
   key_to_string_map[2] = "c";
 
-  CaptureInfo capture_info =
-      capture_serializer::internal::GenerateCaptureInfo(capture_data, key_to_string_map);
+  CaptureInfo capture_info = capture_serializer::internal::GenerateCaptureInfo(
+      capture_data, module_map, key_to_string_map);
 
   ASSERT_EQ(1, capture_info.selected_functions_size());
   const FunctionInfo& actual_selected_function = capture_info.selected_functions(0);

--- a/OrbitClientModel/CaptureSerializerTest.cpp
+++ b/OrbitClientModel/CaptureSerializerTest.cpp
@@ -54,8 +54,8 @@ TEST(CaptureSerializer, GenerateCaptureInfoEmpty) {
   CaptureInfo capture_info =
       capture_serializer::internal::GenerateCaptureInfo(capture_data, key_to_string_map);
   EXPECT_EQ(0, capture_info.selected_functions_size());
-  EXPECT_EQ(-1, capture_info.process_id());
-  EXPECT_EQ("", capture_info.process_name());
+  EXPECT_EQ(-1, capture_info.process().pid());
+  EXPECT_EQ("", capture_info.process().name());
   EXPECT_EQ(0, capture_info.address_infos_size());
   EXPECT_EQ(0, capture_info.callstacks_size());
   EXPECT_EQ(0, capture_info.callstack_events_size());
@@ -147,8 +147,16 @@ TEST(CaptureSerializer, GenerateCaptureInfo) {
   EXPECT_EQ(selected_function.address(), actual_selected_function.address());
   EXPECT_EQ(selected_function.name(), actual_selected_function.name());
 
-  EXPECT_EQ(process_id, capture_info.process_id());
-  EXPECT_EQ(process_name, capture_info.process_name());
+  EXPECT_EQ(process_id, capture_info.process().pid());
+  EXPECT_EQ(process_name, capture_info.process().name());
+
+  ASSERT_EQ(1, capture_info.modules_size());
+  const orbit_client_protos::ModuleInfo& actual_module = capture_info.modules(0);
+  EXPECT_EQ(module_info.name(), actual_module.name());
+  EXPECT_EQ(module_info.file_path(), actual_module.file_path());
+  EXPECT_EQ(module_info.load_bias(), actual_module.load_bias());
+  EXPECT_EQ(module_info.address_start(), actual_module.address_start());
+  EXPECT_EQ(module_info.address_end(), actual_module.address_end());
 
   ASSERT_EQ(1, capture_info.address_infos_size());
   const LinuxAddressInfo& actual_address_info = capture_info.address_infos(0);

--- a/OrbitClientModel/CaptureSerializerTest.cpp
+++ b/OrbitClientModel/CaptureSerializerTest.cpp
@@ -88,9 +88,9 @@ TEST(CaptureSerializer, GenerateCaptureInfo) {
   FunctionInfo selected_function;
   selected_function.set_name("foo");
   selected_function.set_address(123);
-  selected_function.set_module_base_address(15);
   selected_function.set_loaded_module_path("path/to/module");
-  selected_functions[FunctionUtils::GetAbsoluteAddress(selected_function)] = selected_function;
+  uint64_t selected_function_absolute_address = 123 + 15 - 0;
+  selected_functions[selected_function_absolute_address] = selected_function;
 
   TracepointInfoSet selected_tracepoints;
   TracepointInfo selected_tracepoint_info;
@@ -190,10 +190,9 @@ TEST(CaptureSerializer, GenerateCaptureInfo) {
   EXPECT_EQ(tracepoint_event.tracepoint_info_key(), actual_tracepoint_event.tracepoint_info_key());
 
   ASSERT_EQ(1, capture_info.function_stats_size());
-  ASSERT_TRUE(
-      capture_info.function_stats().contains(FunctionUtils::GetAbsoluteAddress(selected_function)));
+  ASSERT_TRUE(capture_info.function_stats().contains(selected_function_absolute_address));
   const FunctionStats& actual_function_stats =
-      capture_info.function_stats().at(FunctionUtils::GetAbsoluteAddress(selected_function));
+      capture_info.function_stats().at(selected_function_absolute_address);
   const FunctionStats& expected_function_stats =
       capture_data.GetFunctionStatsOrDefault(selected_function);
   EXPECT_EQ(expected_function_stats.count(), actual_function_stats.count());

--- a/OrbitClientModel/CaptureSerializerTest.cpp
+++ b/OrbitClientModel/CaptureSerializerTest.cpp
@@ -71,13 +71,24 @@ TEST(CaptureSerializer, GenerateCaptureInfo) {
   process_info.set_pid(process_id);
   ProcessData process(process_info);
 
-  absl::flat_hash_map<std::string, ModuleData*> empty_module_map;
+  absl::flat_hash_map<std::string, ModuleData*> module_map;
+  orbit_grpc_protos::ModuleInfo module_info;
+  module_info.set_load_bias(0);
+  module_info.set_file_path("path/to/module");
+  module_info.set_address_start(15);
+  module_info.set_address_end(1000);
+  std::vector<orbit_grpc_protos::ModuleInfo> module_infos;
+  module_infos.push_back(module_info);
+  ModuleData module(module_info);
+  module_map["path/to/module"] = &module;
+  process.UpdateModuleInfos(module_infos);
 
   absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions;
   FunctionInfo selected_function;
   selected_function.set_name("foo");
   selected_function.set_address(123);
   selected_function.set_module_base_address(15);
+  selected_function.set_loaded_module_path("path/to/module");
   selected_functions[FunctionUtils::GetAbsoluteAddress(selected_function)] = selected_function;
 
   TracepointInfoSet selected_tracepoints;
@@ -86,7 +97,7 @@ TEST(CaptureSerializer, GenerateCaptureInfo) {
   selected_tracepoint_info.set_name("sched_switch");
   selected_tracepoints.insert(selected_tracepoint_info);
 
-  CaptureData capture_data{std::move(process), std::move(empty_module_map), selected_functions,
+  CaptureData capture_data{std::move(process), std::move(module_map), selected_functions,
                            selected_tracepoints};
 
   LinuxAddressInfo address_info;

--- a/OrbitClientModel/include/OrbitClientModel/CaptureDeserializer.h
+++ b/OrbitClientModel/include/OrbitClientModel/CaptureDeserializer.h
@@ -19,21 +19,28 @@
 
 namespace capture_deserializer {
 
-void Load(std::istream& stream, const std::string& file_name, CaptureListener* capture_listener,
-          std::atomic<bool>* cancellation_requested);
-void Load(const std::string& file_name, CaptureListener* capture_listener,
-          std::atomic<bool>* cancellation_requested);
+void Load(
+    std::istream& stream, const std::string& file_name, CaptureListener* capture_listener,
+    const std::function<void(const orbit_grpc_protos::ProcessInfo&,
+                             const std::vector<orbit_grpc_protos::ModuleInfo>&)>& modules_callback,
+    std::atomic<bool>* cancellation_requested);
+void Load(
+    const std::string& file_name, CaptureListener* capture_listener,
+    const std::function<void(const orbit_grpc_protos::ProcessInfo&,
+                             const std::vector<orbit_grpc_protos::ModuleInfo>&)>& modules_callback,
+    std::atomic<bool>* cancellation_requested);
 
 namespace internal {
 
 bool ReadMessage(google::protobuf::Message* message, google::protobuf::io::CodedInputStream* input);
 
-void LoadCaptureInfo(const orbit_client_protos::CaptureInfo& capture_info,
-                     CaptureListener* capture_listener,
-                     google::protobuf::io::CodedInputStream* coded_input,
-                     std::atomic<bool>* cancellation_requested);
+void LoadCaptureInfo(
+    const orbit_client_protos::CaptureInfo& capture_info, CaptureListener* capture_listener,
+    const std::function<void(const orbit_grpc_protos::ProcessInfo&,
+                             const std::vector<orbit_grpc_protos::ModuleInfo>&)>& modules_callback,
+    google::protobuf::io::CodedInputStream* coded_input, std::atomic<bool>* cancellation_requested);
 
-inline const std::string kRequiredCaptureVersion = "1.52";
+inline const std::string kRequiredCaptureVersion = "1.54";
 
 }  // namespace internal
 

--- a/OrbitClientModel/include/OrbitClientModel/CaptureSerializer.h
+++ b/OrbitClientModel/include/OrbitClientModel/CaptureSerializer.h
@@ -33,7 +33,7 @@ void IncludeOrbitExtensionInFile(std::string& file_name);
 
 namespace internal {
 
-inline const std::string kRequiredCaptureVersion = "1.52";
+inline const std::string kRequiredCaptureVersion = "1.54";
 
 orbit_client_protos::CaptureInfo GenerateCaptureInfo(
     const CaptureData& capture_data,

--- a/OrbitClientModel/include/OrbitClientModel/CaptureSerializer.h
+++ b/OrbitClientModel/include/OrbitClientModel/CaptureSerializer.h
@@ -37,10 +37,12 @@ inline const std::string kRequiredCaptureVersion = "1.54";
 
 orbit_client_protos::CaptureInfo GenerateCaptureInfo(
     const CaptureData& capture_data,
+    const absl::flat_hash_map<std::string, ModuleData*>& module_map,
     const absl::flat_hash_map<uint64_t, std::string>& key_to_string_map);
 
 template <class TimersIterator>
 void Save(std::ostream& stream, const CaptureData& capture_data,
+          const absl::flat_hash_map<std::string, ModuleData*>& module_map,
           const absl::flat_hash_map<uint64_t, std::string>& key_to_string_map,
           TimersIterator timers_iterator_begin, TimersIterator timers_iterator_end) {
   google::protobuf::io::OstreamOutputStream out_stream(&stream);
@@ -51,7 +53,7 @@ void Save(std::ostream& stream, const CaptureData& capture_data,
   WriteMessage(&header, &coded_output);
 
   orbit_client_protos::CaptureInfo capture_info =
-      GenerateCaptureInfo(capture_data, key_to_string_map);
+      GenerateCaptureInfo(capture_data, module_map, key_to_string_map);
   WriteMessage(&capture_info, &coded_output);
 
   // Timers
@@ -64,6 +66,7 @@ void Save(std::ostream& stream, const CaptureData& capture_data,
 
 template <class TimersIterator>
 ErrorMessageOr<void> Save(const std::string& filename, const CaptureData& capture_data,
+                          const absl::flat_hash_map<std::string, ModuleData*>& module_map,
                           const absl::flat_hash_map<uint64_t, std::string>& key_to_string_map,
                           TimersIterator timers_iterator_begin,
                           TimersIterator timers_iterator_end) {
@@ -75,8 +78,8 @@ ErrorMessageOr<void> Save(const std::string& filename, const CaptureData& captur
 
   {
     SCOPE_TIMER_LOG(absl::StrFormat("Saving capture in \"%s\"", filename));
-    internal::Save(file, capture_data, key_to_string_map, std::move(timers_iterator_begin),
-                   std::move(timers_iterator_end));
+    internal::Save(file, capture_data, module_map, key_to_string_map,
+                   std::move(timers_iterator_begin), std::move(timers_iterator_end));
   }
 
   return outcome::success();

--- a/OrbitClientProtos/capture_data.proto
+++ b/OrbitClientProtos/capture_data.proto
@@ -14,6 +14,25 @@ message FunctionStats {
   uint64 max_ns = 5;
 }
 
+message ProcessInfo {
+  int32 pid = 1;
+  string name = 2;
+  double cpu_usage = 3;
+  string full_path = 4;
+  string command_line = 5;
+  bool is_64_bit = 6;
+}
+
+message ModuleInfo {
+  string name = 1;
+  string file_path = 2;
+  uint64 file_size = 3;
+  uint64 address_start = 4;
+  uint64 address_end = 5;
+  string build_id = 6;
+  uint64 load_bias = 7;
+}
+
 message FunctionInfo {
   reserved 11;
   string name = 1;
@@ -73,9 +92,8 @@ message CaptureHeader {
 }
 
 message CaptureInfo {
+  reserved 2, 3;
   repeated FunctionInfo selected_functions = 1;
-  int32 process_id = 2;
-  string process_name = 3;
   map<int32, string> thread_names = 4;
   repeated LinuxAddressInfo address_infos = 5;
   repeated CallstackInfo callstacks = 6;
@@ -85,6 +103,8 @@ message CaptureInfo {
   map<uint64, FunctionStats> function_stats = 9;
   repeated TracepointInfo tracepoint_infos = 10;
   repeated TracepointEventInfo tracepoint_event_infos = 11;
+  ProcessInfo process = 12;
+  repeated ModuleInfo modules = 14;
 }
 
 message TimerInfo {

--- a/OrbitClientProtos/capture_data.proto
+++ b/OrbitClientProtos/capture_data.proto
@@ -34,13 +34,11 @@ message ModuleInfo {
 }
 
 message FunctionInfo {
-  reserved 11;
+  reserved 4, 6, 11;
   string name = 1;
   string pretty_name = 2;
   string loaded_module_path = 3;
-  uint64 module_base_address = 4;
   uint64 address = 5;
-  uint64 load_bias = 6;
   uint64 size = 7;
   string file = 8;
   uint32 line = 9;

--- a/OrbitCore/CaptureData.cpp
+++ b/OrbitCore/CaptureData.cpp
@@ -17,8 +17,7 @@ using orbit_client_protos::LinuxAddressInfo;
 
 const FunctionStats& CaptureData::GetFunctionStatsOrDefault(const FunctionInfo& function) const {
   static const FunctionStats kDefaultFunctionStats;
-  uint64_t absolute_address = FunctionUtils::GetAbsoluteAddress(function);
-  auto function_stats_it = functions_stats_.find(absolute_address);
+  auto function_stats_it = functions_stats_.find(function);
   if (function_stats_it == functions_stats_.end()) {
     return kDefaultFunctionStats;
   }
@@ -26,8 +25,7 @@ const FunctionStats& CaptureData::GetFunctionStatsOrDefault(const FunctionInfo& 
 }
 
 void CaptureData::UpdateFunctionStats(const FunctionInfo& function, uint64_t elapsed_nanos) {
-  const uint64_t absolute_address = FunctionUtils::GetAbsoluteAddress(function);
-  FunctionStats& stats = functions_stats_[absolute_address];
+  FunctionStats& stats = functions_stats_[function];
   stats.set_count(stats.count() + 1);
   stats.set_total_time_ns(stats.total_time_ns() + elapsed_nanos);
   stats.set_average_time_ns(stats.total_time_ns() / stats.count());
@@ -124,6 +122,12 @@ const FunctionInfo* CaptureData::FindFunctionByAddress(uint64_t absolute_address
   const auto result = process_.FindModuleByAddress(absolute_address);
   if (!result) return nullptr;
   return module_map_.at(result.value().first);
+}
+
+uint64_t CaptureData::GetAbsoluteAddress(const orbit_client_protos::FunctionInfo& function) const {
+  const auto module_it = module_map_.find(function.loaded_module_path());
+  CHECK(module_it != module_map_.end());
+  return FunctionUtils::GetAbsoluteAddress(function, process_, *module_it->second);
 }
 
 int32_t CaptureData::process_id() const { return process_.pid(); }

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -177,6 +177,10 @@ class CaptureData {
     sampling_profiler_ = std::move(sampling_profiler);
   }
 
+  [[nodiscard]] const absl::flat_hash_map<std::string, ModuleData*>& module_map() const {
+    return module_map_;
+  }
+
  private:
   ProcessData process_;
   absl::flat_hash_map<std::string, ModuleData*> module_map_;

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "CallstackData.h"
+#include "OrbitClientData/FunctionInfoSet.h"
 #include "OrbitClientData/ProcessData.h"
 #include "SamplingProfiler.h"
 #include "TracepointCustom.h"
@@ -79,6 +80,8 @@ class CaptureData {
   [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionByAddress(
       uint64_t absolute_address, bool is_exact) const;
   [[nodiscard]] ModuleData* FindModuleByAddress(uint64_t absolute_address) const;
+  [[nodiscard]] uint64_t GetAbsoluteAddress(
+      const orbit_client_protos::FunctionInfo& function) const;
 
   static const std::string kUnknownFunctionOrModuleName;
 
@@ -96,8 +99,7 @@ class CaptureData {
     thread_names_.insert_or_assign(thread_id, std::move(thread_name));
   }
 
-  [[nodiscard]] const absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionStats>&
-  functions_stats() const {
+  [[nodiscard]] const FunctionInfoMap<orbit_client_protos::FunctionStats>& functions_stats() const {
     return functions_stats_;
   }
 
@@ -194,7 +196,7 @@ class CaptureData {
 
   absl::flat_hash_map<uint64_t, orbit_client_protos::LinuxAddressInfo> address_infos_;
 
-  absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionStats> functions_stats_;
+  FunctionInfoMap<orbit_client_protos::FunctionStats> functions_stats_;
 
   absl::flat_hash_map<int32_t, std::string> thread_names_;
 

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -22,11 +22,10 @@
 class CaptureData {
  public:
   explicit CaptureData(
-      ProcessData&& process, absl::flat_hash_map<std::string, ModuleData*>&& module_map,
+      ProcessData&& process,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints)
       : process_(std::move(process)),
-        module_map_(std::move(module_map)),
         selected_functions_{std::move(selected_functions)},
         selected_tracepoints_{std::move(selected_tracepoints)},
         callstack_data_(std::make_unique<CallstackData>()),
@@ -74,14 +73,22 @@ class CaptureData {
 
   void InsertAddressInfo(orbit_client_protos::LinuxAddressInfo address_info);
 
-  [[nodiscard]] const std::string& GetFunctionNameByAddress(uint64_t absolute_address) const;
-  [[nodiscard]] const std::string& GetModulePathByAddress(uint64_t absolute_address) const;
+  [[nodiscard]] const std::string& GetFunctionNameByAddress(
+      uint64_t absolute_address,
+      const absl::flat_hash_map<std::string, ModuleData*>& module_map) const;
+  [[nodiscard]] const std::string& GetModulePathByAddress(
+      uint64_t absolute_address,
+      const absl::flat_hash_map<std::string, ModuleData*>& module_map) const;
 
   [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionByAddress(
-      uint64_t absolute_address, bool is_exact) const;
-  [[nodiscard]] ModuleData* FindModuleByAddress(uint64_t absolute_address) const;
+      uint64_t absolute_address, const absl::flat_hash_map<std::string, ModuleData*>& module_map,
+      bool is_exact) const;
+  [[nodiscard]] ModuleData* FindModuleByAddress(
+      uint64_t absolute_address,
+      const absl::flat_hash_map<std::string, ModuleData*>& module_map) const;
   [[nodiscard]] uint64_t GetAbsoluteAddress(
-      const orbit_client_protos::FunctionInfo& function) const;
+      const orbit_client_protos::FunctionInfo& function,
+      const absl::flat_hash_map<std::string, ModuleData*>& module_map) const;
 
   static const std::string kUnknownFunctionOrModuleName;
 
@@ -177,13 +184,8 @@ class CaptureData {
     sampling_profiler_ = std::move(sampling_profiler);
   }
 
-  [[nodiscard]] const absl::flat_hash_map<std::string, ModuleData*>& module_map() const {
-    return module_map_;
-  }
-
  private:
   ProcessData process_;
-  absl::flat_hash_map<std::string, ModuleData*> module_map_;
   absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions_;
 
   TracepointInfoSet selected_tracepoints_;

--- a/OrbitCore/ModuleLoadSymbolsFuzzer.cpp
+++ b/OrbitCore/ModuleLoadSymbolsFuzzer.cpp
@@ -12,5 +12,5 @@ using orbit_grpc_protos::ModuleSymbols;
 
 DEFINE_PROTO_FUZZER(const ModuleSymbols& symbols) {
   ModuleData module{orbit_grpc_protos::ModuleInfo{}};
-  module.AddSymbols(symbols, 0);
+  module.AddSymbols(symbols);
 }

--- a/OrbitCore/SamplingProfiler.cpp
+++ b/OrbitCore/SamplingProfiler.cpp
@@ -231,7 +231,7 @@ void SamplingProfiler::MapAddressToFunctionAddress(uint64_t absolute_address,
   // considered a different function.
   uint64_t absolute_function_address;
   if (function != nullptr) {
-    absolute_function_address = FunctionUtils::GetAbsoluteAddress(*function);
+    absolute_function_address = capture_data.GetAbsoluteAddress(*function);
   } else if (address_info != nullptr) {
     absolute_function_address = absolute_address - address_info->offset_in_function();
   } else {

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -15,6 +15,7 @@
 #include "Callstack.h"
 #include "CallstackData.h"
 #include "CallstackTypes.h"
+#include "OrbitClientData/ModuleData.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "capture_data.pb.h"
@@ -65,8 +66,9 @@ class SamplingProfiler {
  public:
   explicit SamplingProfiler() = default;
   explicit SamplingProfiler(const CallstackData& callstack_data, const CaptureData& capture_data,
+                            const absl::flat_hash_map<std::string, ModuleData*>& module_map,
                             bool generate_summary = true) {
-    ProcessSamples(callstack_data, capture_data, generate_summary);
+    ProcessSamples(callstack_data, capture_data, module_map, generate_summary);
   }
   SamplingProfiler& operator=(const SamplingProfiler& other) = default;
   SamplingProfiler(const SamplingProfiler& other) = default;
@@ -99,10 +101,15 @@ class SamplingProfiler {
 
  private:
   void ProcessSamples(const CallstackData& callstack_data, const CaptureData& capture_data,
+                      const absl::flat_hash_map<std::string, ModuleData*>& module_map,
                       bool generate_summary);
-  void ResolveCallstacks(const CallstackData& callstack_data, const CaptureData& capture_data);
-  void MapAddressToFunctionAddress(uint64_t absolute_address, const CaptureData& capture_data);
-  void FillThreadSampleDataSampleReports(const CaptureData& capture_data);
+  void ResolveCallstacks(const CallstackData& callstack_data, const CaptureData& capture_data,
+                         const absl::flat_hash_map<std::string, ModuleData*>& module_map);
+  void MapAddressToFunctionAddress(uint64_t absolute_address, const CaptureData& capture_data,
+                                   const absl::flat_hash_map<std::string, ModuleData*>& module_map);
+  void FillThreadSampleDataSampleReports(
+      const CaptureData& capture_data,
+      const absl::flat_hash_map<std::string, ModuleData*>& module_map);
   void SortByThreadUsage();
 
   // Filled by ProcessSamples.

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -431,8 +431,7 @@ void OrbitApp::Disassemble(int32_t pid, const FunctionInfo& function) {
     const std::string& memory = result.value();
     Disassembler disasm;
     disasm.AddLine(absl::StrFormat("asm: /* %s */", FunctionUtils::GetDisplayName(function)));
-    disasm.Disassemble(memory.data(), memory.size(), FunctionUtils::GetAbsoluteAddress(function),
-                       is_64_bit);
+    disasm.Disassemble(memory.data(), memory.size(), absolute_address, is_64_bit);
     if (!sampling_report_) {
       DisassemblyReport empty_report(disasm);
       SendDisassemblyToUi(disasm.GetResult(), std::move(empty_report));
@@ -441,7 +440,7 @@ void OrbitApp::Disassemble(int32_t pid, const FunctionInfo& function) {
     const CaptureData& capture_data = GetCaptureData();
     const SamplingProfiler& profiler = capture_data.sampling_profiler();
 
-    DisassemblyReport report(disasm, FunctionUtils::GetAbsoluteAddress(function), profiler,
+    DisassemblyReport report(disasm, absolute_address, profiler,
                              capture_data.GetCallstackData()->GetCallstackEventsCount());
     SendDisassemblyToUi(disasm.GetResult(), std::move(report));
   });

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -416,10 +416,12 @@ void OrbitApp::RefreshCaptureView() {
 void OrbitApp::Disassemble(int32_t pid, const FunctionInfo& function) {
   const ProcessData* process = data_manager_->GetProcessByPid(pid);
   CHECK(process != nullptr);
+  const ModuleData* module = data_manager_->GetModuleByPath(function.loaded_module_path());
+  CHECK(module != nullptr);
   const bool is_64_bit = process->is_64_bit();
-  thread_pool_->Schedule([this, is_64_bit, pid, function] {
-    auto result = process_manager_->LoadProcessMemory(
-        pid, FunctionUtils::GetAbsoluteAddress(function), function.size());
+  const uint64_t absolute_address = FunctionUtils::GetAbsoluteAddress(function, *process, *module);
+  thread_pool_->Schedule([this, absolute_address, is_64_bit, pid, function] {
+    auto result = process_manager_->LoadProcessMemory(pid, absolute_address, function.size());
     if (!result.has_value()) {
       SendErrorToUi("Error reading memory", absl::StrFormat("Could not read process memory: %s.",
                                                             result.error().message()));
@@ -727,7 +729,9 @@ bool OrbitApp::StartCapture() {
 
   absl::flat_hash_map<uint64_t, FunctionInfo> selected_functions;
   for (const auto& function : data_manager_->GetSelectedAndOrbitFunctions()) {
-    uint64_t absolute_address = FunctionUtils::GetAbsoluteAddress(function);
+    const ModuleData* module = data_manager_->GetModuleByPath(function.loaded_module_path());
+    CHECK(module != nullptr);
+    uint64_t absolute_address = FunctionUtils::GetAbsoluteAddress(function, *process, *module);
     selected_functions[absolute_address] = FunctionInfo(function);
   }
 
@@ -1096,11 +1100,8 @@ void OrbitApp::UpdateProcessAndModuleList(int32_t pid) {
 }
 
 void OrbitApp::SelectFunction(const orbit_client_protos::FunctionInfo& func) {
-  uint64_t absolute_address = FunctionUtils::GetAbsoluteAddress(func);
-  LOG("Selected %s at 0x%" PRIx64 " (address_=0x%" PRIx64 ", load_bias_= 0x%" PRIx64
-      ", base_address=0x%" PRIx64 ")",
-      func.pretty_name(), absolute_address, func.address(), func.load_bias(),
-      func.module_base_address());
+  LOG("Selected %s (address_=0x%" PRIx64 ", loaded_module_path_=%s)", func.pretty_name(),
+      func.address(), func.loaded_module_path());
   data_manager_->SelectFunction(func);
 }
 

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -95,7 +95,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void Disassemble(int32_t pid, const orbit_client_protos::FunctionInfo& function);
 
   void OnCaptureStarted(
-      ProcessData&& process, absl::flat_hash_map<std::string, ModuleData*>&& module_map,
+      ProcessData&& process,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints) override;
   void OnCaptureComplete() override;
@@ -249,6 +249,10 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void LoadModulesFromPreset(const ProcessData* process,
                              const std::shared_ptr<orbit_client_protos::PresetFile>& preset);
   void UpdateProcessAndModuleList(int32_t pid);
+  [[nodiscard]] absl::flat_hash_map<std::string, ModuleData*> GetModulesLoadedByProcess(
+      const ProcessData* process) const {
+    return data_manager_->GetModulesLoadedByProcess(process);
+  }
 
   void UpdateAfterSymbolLoading();
   void UpdateAfterCaptureCleared();

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -241,13 +241,9 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void SendErrorToUi(const std::string& title, const std::string& text);
   void NeedsRedraw();
 
-  // TODO(169309553) get rid of ProcessData here, the process should not be needed to load a module.
-  // Also remove shared_ptr from PresetFile. Also consider references instead of pointers
-  void LoadModules(const ProcessData* process, const std::vector<ModuleData*>& modules,
+  void LoadModules(const std::vector<ModuleData*>& modules,
                    const std::shared_ptr<orbit_client_protos::PresetFile>& preset = nullptr);
-  // TODO(169309553) get rid of Process
-  void LoadModulesFromPreset(const ProcessData* process,
-                             const std::shared_ptr<orbit_client_protos::PresetFile>& preset);
+  void LoadModulesFromPreset(const std::shared_ptr<orbit_client_protos::PresetFile>& preset);
   void UpdateProcessAndModuleList(int32_t pid);
   [[nodiscard]] absl::flat_hash_map<std::string, ModuleData*> GetModulesLoadedByProcess(
       const ProcessData* process) const {
@@ -308,13 +304,10 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
  private:
   ErrorMessageOr<std::filesystem::path> FindSymbolsLocally(const std::filesystem::path& module_path,
                                                            const std::string& build_id);
-  // TODO(169309553): remove the process here, as soon as module_base_address is removed from
-  // FunctionInfo
-  void LoadSymbols(const std::filesystem::path& symbols_path, const ProcessData* process,
-                   ModuleData* module_data, const orbit_client_protos::PresetModule* preset_module);
-  // TODO(169309553): remove the process here, as soon as module_base_address is removed from
-  // FunctionInfo
-  void LoadModuleOnRemote(const ProcessData* process, ModuleData* module_data,
+  void LoadSymbols(const std::filesystem::path& symbols_path, ModuleData* module_data,
+                   const orbit_client_protos::PresetModule* preset_module);
+
+  void LoadModuleOnRemote(ModuleData* module_data,
                           const orbit_client_protos::PresetModule* preset_module);
   ErrorMessageOr<void> SelectFunctionsFromPreset(const ModuleData* module,
                                                  const orbit_client_protos::PresetModule& preset);

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -118,8 +118,7 @@ void CallStackDataView::OnContextMenu(const std::string& action, int menu_index,
         modules_to_load.push_back(module);
       }
     }
-    const ProcessData* process = GOrbitApp->GetCaptureData().process();
-    GOrbitApp->LoadModules(process, modules_to_load);
+    GOrbitApp->LoadModules(modules_to_load);
 
   } else if (action == kMenuActionSelect) {
     for (int i : item_indices) {

--- a/OrbitGl/CallTreeView.h
+++ b/OrbitGl/CallTreeView.h
@@ -110,10 +110,12 @@ class CallTreeThread : public CallTreeNode {
 class CallTreeView : public CallTreeNode {
  public:
   [[nodiscard]] static std::unique_ptr<CallTreeView> CreateTopDownViewFromSamplingProfiler(
-      const SamplingProfiler& sampling_profiler, const CaptureData& capture_data);
+      const SamplingProfiler& sampling_profiler, const CaptureData& capture_data,
+      const absl::flat_hash_map<std::string, ModuleData*>& module_map);
 
   [[nodiscard]] static std::unique_ptr<CallTreeView> CreateBottomUpViewFromSamplingProfiler(
-      const SamplingProfiler& sampling_profiler, const CaptureData& capture_data);
+      const SamplingProfiler& sampling_profiler, const CaptureData& capture_data,
+      const absl::flat_hash_map<std::string, ModuleData*>& module_map);
 
   CallTreeView() : CallTreeNode{nullptr} {}
 };

--- a/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
+++ b/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
@@ -36,7 +36,7 @@ DEFINE_PROTO_FUZZER(const orbit_client_protos::CaptureDeserializerFuzzerInfo& in
     google::protobuf::io::StringOutputStream stream{&buffer};
     google::protobuf::io::CodedOutputStream coded_stream{&stream};
     orbit_client_protos::CaptureHeader capture_header{};
-    capture_header.set_version("1.52");
+    capture_header.set_version("1.54");
 
     capture_serializer::WriteMessage(&capture_header, &coded_stream);
     capture_serializer::WriteMessage(&info.capture_info(), &coded_stream);

--- a/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
+++ b/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
@@ -72,7 +72,13 @@ DEFINE_PROTO_FUZZER(const orbit_client_protos::CaptureDeserializerFuzzerInfo& in
   // NOLINTNEXTLINE
   std::istringstream input_stream{std::move(buffer)};
   std::atomic<bool> cancellation_requested = false;
-  capture_deserializer::Load(input_stream, "", GOrbitApp.get(), &cancellation_requested);
+
+  // The functions called by actual callback are already fuzzed in
+  // DataManagerUpdateModuleInfosFuzzer
+  const auto& modules_callback = [](const orbit_grpc_protos::ProcessInfo&,
+                                    const std::vector<orbit_grpc_protos::ModuleInfo>&) {};
+  capture_deserializer::Load(input_stream, "", GOrbitApp.get(), modules_callback,
+                             &cancellation_requested);
 
   GOrbitApp->GetThreadPool()->ShutdownAndWait();
   GOrbitApp.reset();

--- a/OrbitGl/DataManager.cpp
+++ b/OrbitGl/DataManager.cpp
@@ -47,17 +47,6 @@ void DataManager::UpdateModuleInfos(int32_t process_id,
       const auto [inserted_it, success] = module_map_.try_emplace(
           module_info.file_path(), std::make_unique<ModuleData>(module_info));
       CHECK(success);
-    } else {
-      ModuleData* module = (*module_it).second.get();
-      if (!module->is_loaded()) continue;
-      // When a module is already loaded (has loaded symbols), it could be the case that the
-      // modules base address changed. Since the module base address is *currently* saved in
-      // FunctionInfo, these need to be updated.
-      // TODO(169309553): As soon as module base address is not part of FunctionInfo anymore, remove
-      // the following.
-      if (module_info.address_start() != process.GetModuleBaseAddress(module->file_path())) {
-        module->UpdateFunctionsModuleBaseAddress(module_info.address_start());
-      }
     }
   }
 

--- a/OrbitGl/DataManagerUpdateModuleInfosFuzzer.cpp
+++ b/OrbitGl/DataManagerUpdateModuleInfosFuzzer.cpp
@@ -41,5 +41,5 @@ DEFINE_PROTO_FUZZER(const GetModuleListResponse& module_list) {
   data_manager.UpdateModuleInfos(1, modules);
 
   ModulesDataView modules_data_view{};
-  modules_data_view.SetProcess(data_manager.GetProcessByPid(1));
+  modules_data_view.UpdateModules(data_manager.GetProcessByPid(1));
 }

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -5,6 +5,7 @@
 #include "EventTrack.h"
 
 #include "App.h"
+#include "CaptureData.h"
 #include "GlCanvas.h"
 #include "PickingManager.h"
 
@@ -173,7 +174,9 @@ bool EventTrack::IsEmpty() const {
 }
 
 static std::string SafeGetFormattedFunctionName(uint64_t addr, int max_line_length) {
-  const std::string& function_name = GOrbitApp->GetCaptureData().GetFunctionNameByAddress(addr);
+  const CaptureData& capture_data = GOrbitApp->GetCaptureData();
+  const auto& module_map = GOrbitApp->GetModulesLoadedByProcess(capture_data.process());
+  const std::string& function_name = capture_data.GetFunctionNameByAddress(addr, module_map);
   if (function_name == CaptureData::kUnknownFunctionOrModuleName) {
     return std::string("<i>") + function_name + "</i>";
   }

--- a/OrbitGl/FramePointerValidatorClient.cpp
+++ b/OrbitGl/FramePointerValidatorClient.cpp
@@ -44,7 +44,7 @@ void FramePointerValidatorClient::AnalyzeModules(const std::vector<const ModuleD
     request.set_module_path(module->file_path());
     for (const FunctionInfo* function : functions) {
       CodeBlock* function_info = request.add_functions();
-      function_info->set_offset(FunctionUtils::Offset(*function));
+      function_info->set_offset(FunctionUtils::Offset(*function, *module));
       function_info->set_size(function->size());
     }
     grpc::ClientContext context;

--- a/OrbitGl/FunctionsDataView.cpp
+++ b/OrbitGl/FunctionsDataView.cpp
@@ -53,8 +53,14 @@ std::string FunctionsDataView::GetValue(int row, int column) {
       return absl::StrFormat("%i", function.line());
     case kColumnModule:
       return FunctionUtils::GetLoadedModuleName(function);
-    case kColumnAddress:
-      return absl::StrFormat("0x%llx", FunctionUtils::GetAbsoluteAddress(function));
+    case kColumnAddress: {
+      const ProcessData* process = GOrbitApp->GetSelectedProcess();
+      CHECK(process != nullptr);
+      const ModuleData* module = GOrbitApp->GetMutableModuleByPath(function.loaded_module_path());
+      CHECK(module != nullptr);
+      return absl::StrFormat("0x%llx",
+                             FunctionUtils::GetAbsoluteAddress(function, *process, *module));
+    }
     default:
       return "";
   }

--- a/OrbitGl/LiveFunctionsController.cpp
+++ b/OrbitGl/LiveFunctionsController.cpp
@@ -100,9 +100,10 @@ bool LiveFunctionsController::OnAllNextButton() {
   uint64_t id_with_min_timestamp = 0;
   uint64_t min_timestamp = std::numeric_limits<uint64_t>::max();
   const CaptureData& capture_data = GOrbitApp->GetCaptureData();
+  const auto& modules_map = GOrbitApp->GetModulesLoadedByProcess(capture_data.process());
   for (auto it : function_iterators_) {
     const FunctionInfo* function = it.second;
-    auto function_address = capture_data.GetAbsoluteAddress(*function);
+    auto function_address = capture_data.GetAbsoluteAddress(*function, modules_map);
     const TextBox* current_box = current_textboxes_.find(it.first)->second;
     const TextBox* box = GCurrentTimeGraph->FindNextFunctionCall(function_address,
                                                                  current_box->GetTimerInfo().end());
@@ -128,9 +129,10 @@ bool LiveFunctionsController::OnAllPreviousButton() {
   uint64_t id_with_min_timestamp = 0;
   uint64_t min_timestamp = std::numeric_limits<uint64_t>::max();
   const CaptureData& capture_data = GOrbitApp->GetCaptureData();
+  const auto& modules_map = GOrbitApp->GetModulesLoadedByProcess(capture_data.process());
   for (auto it : function_iterators_) {
     const FunctionInfo* function = it.second;
-    auto function_address = capture_data.GetAbsoluteAddress(*function);
+    auto function_address = capture_data.GetAbsoluteAddress(*function, modules_map);
     const TextBox* current_box = current_textboxes_.find(it.first)->second;
     const TextBox* box = GCurrentTimeGraph->FindPreviousFunctionCall(
         function_address, current_box->GetTimerInfo().end());
@@ -152,8 +154,9 @@ bool LiveFunctionsController::OnAllPreviousButton() {
 }
 
 void LiveFunctionsController::OnNextButton(uint64_t id) {
-  auto function_address =
-      GOrbitApp->GetCaptureData().GetAbsoluteAddress(*(function_iterators_[id]));
+  const CaptureData& capture_data = GOrbitApp->GetCaptureData();
+  const auto& modules_map = GOrbitApp->GetModulesLoadedByProcess(capture_data.process());
+  auto function_address = capture_data.GetAbsoluteAddress(*(function_iterators_[id]), modules_map);
   const TextBox* text_box = GCurrentTimeGraph->FindNextFunctionCall(
       function_address, current_textboxes_[id]->GetTimerInfo().end());
   // If text_box is nullptr, then we have reached the right end of the timeline.
@@ -164,8 +167,9 @@ void LiveFunctionsController::OnNextButton(uint64_t id) {
   Move();
 }
 void LiveFunctionsController::OnPreviousButton(uint64_t id) {
-  auto function_address =
-      GOrbitApp->GetCaptureData().GetAbsoluteAddress(*(function_iterators_[id]));
+  const CaptureData& capture_data = GOrbitApp->GetCaptureData();
+  const auto& modules_map = GOrbitApp->GetModulesLoadedByProcess(capture_data.process());
+  auto function_address = capture_data.GetAbsoluteAddress(*(function_iterators_[id]), modules_map);
   const TextBox* text_box = GCurrentTimeGraph->FindPreviousFunctionCall(
       function_address, current_textboxes_[id]->GetTimerInfo().end());
   // If text_box is nullptr, then we have reached the left end of the timeline.
@@ -194,7 +198,9 @@ void LiveFunctionsController::AddIterator(FunctionInfo* function) {
   uint64_t id = next_iterator_id_;
   ++next_iterator_id_;
 
-  auto function_address = GOrbitApp->GetCaptureData().GetAbsoluteAddress(*function);
+  const CaptureData& capture_data = GOrbitApp->GetCaptureData();
+  const auto& modules_map = GOrbitApp->GetModulesLoadedByProcess(capture_data.process());
+  auto function_address = capture_data.GetAbsoluteAddress(*function, modules_map);
   const TextBox* box = GOrbitApp->selected_text_box();
   // If no box is currently selected or the selected box is a different
   // function, we search for the closest box to the current center of the
@@ -213,7 +219,9 @@ void LiveFunctionsController::AddIterator(FunctionInfo* function) {
 }
 
 void LiveFunctionsController::AddFrameTrack(const FunctionInfo& function) {
-  auto function_address = GOrbitApp->GetCaptureData().GetAbsoluteAddress(function);
+  const CaptureData& capture_data = GOrbitApp->GetCaptureData();
+  const auto& modules_map = GOrbitApp->GetModulesLoadedByProcess(capture_data.process());
+  auto function_address = capture_data.GetAbsoluteAddress(function, modules_map);
   std::vector<std::shared_ptr<TimerChain>> chains =
       GCurrentTimeGraph->GetAllThreadTrackTimerChains();
 

--- a/OrbitGl/LiveFunctionsController.cpp
+++ b/OrbitGl/LiveFunctionsController.cpp
@@ -99,9 +99,10 @@ bool LiveFunctionsController::OnAllNextButton() {
   absl::flat_hash_map<uint64_t, const TextBox*> next_boxes;
   uint64_t id_with_min_timestamp = 0;
   uint64_t min_timestamp = std::numeric_limits<uint64_t>::max();
+  const CaptureData& capture_data = GOrbitApp->GetCaptureData();
   for (auto it : function_iterators_) {
     const FunctionInfo* function = it.second;
-    auto function_address = FunctionUtils::GetAbsoluteAddress(*function);
+    auto function_address = capture_data.GetAbsoluteAddress(*function);
     const TextBox* current_box = current_textboxes_.find(it.first)->second;
     const TextBox* box = GCurrentTimeGraph->FindNextFunctionCall(function_address,
                                                                  current_box->GetTimerInfo().end());
@@ -126,9 +127,10 @@ bool LiveFunctionsController::OnAllPreviousButton() {
   absl::flat_hash_map<uint64_t, const TextBox*> next_boxes;
   uint64_t id_with_min_timestamp = 0;
   uint64_t min_timestamp = std::numeric_limits<uint64_t>::max();
+  const CaptureData& capture_data = GOrbitApp->GetCaptureData();
   for (auto it : function_iterators_) {
     const FunctionInfo* function = it.second;
-    auto function_address = FunctionUtils::GetAbsoluteAddress(*function);
+    auto function_address = capture_data.GetAbsoluteAddress(*function);
     const TextBox* current_box = current_textboxes_.find(it.first)->second;
     const TextBox* box = GCurrentTimeGraph->FindPreviousFunctionCall(
         function_address, current_box->GetTimerInfo().end());
@@ -150,7 +152,8 @@ bool LiveFunctionsController::OnAllPreviousButton() {
 }
 
 void LiveFunctionsController::OnNextButton(uint64_t id) {
-  auto function_address = FunctionUtils::GetAbsoluteAddress(*(function_iterators_[id]));
+  auto function_address =
+      GOrbitApp->GetCaptureData().GetAbsoluteAddress(*(function_iterators_[id]));
   const TextBox* text_box = GCurrentTimeGraph->FindNextFunctionCall(
       function_address, current_textboxes_[id]->GetTimerInfo().end());
   // If text_box is nullptr, then we have reached the right end of the timeline.
@@ -161,7 +164,8 @@ void LiveFunctionsController::OnNextButton(uint64_t id) {
   Move();
 }
 void LiveFunctionsController::OnPreviousButton(uint64_t id) {
-  auto function_address = FunctionUtils::GetAbsoluteAddress(*(function_iterators_[id]));
+  auto function_address =
+      GOrbitApp->GetCaptureData().GetAbsoluteAddress(*(function_iterators_[id]));
   const TextBox* text_box = GCurrentTimeGraph->FindPreviousFunctionCall(
       function_address, current_textboxes_[id]->GetTimerInfo().end());
   // If text_box is nullptr, then we have reached the left end of the timeline.
@@ -190,7 +194,7 @@ void LiveFunctionsController::AddIterator(FunctionInfo* function) {
   uint64_t id = next_iterator_id_;
   ++next_iterator_id_;
 
-  auto function_address = FunctionUtils::GetAbsoluteAddress(*function);
+  auto function_address = GOrbitApp->GetCaptureData().GetAbsoluteAddress(*function);
   const TextBox* box = GOrbitApp->selected_text_box();
   // If no box is currently selected or the selected box is a different
   // function, we search for the closest box to the current center of the
@@ -209,7 +213,7 @@ void LiveFunctionsController::AddIterator(FunctionInfo* function) {
 }
 
 void LiveFunctionsController::AddFrameTrack(const FunctionInfo& function) {
-  auto function_address = FunctionUtils::GetAbsoluteAddress(function);
+  auto function_address = GOrbitApp->GetCaptureData().GetAbsoluteAddress(function);
   std::vector<std::shared_ptr<TimerChain>> chains =
       GCurrentTimeGraph->GetAllThreadTrackTimerChains();
 

--- a/OrbitGl/ModulesDataView.cpp
+++ b/OrbitGl/ModulesDataView.cpp
@@ -125,8 +125,7 @@ void ModulesDataView::OnContextMenu(const std::string& action, int menu_index,
         modules_to_load.push_back(module_data);
       }
     }
-    CHECK(process_ != nullptr);
-    GOrbitApp->LoadModules(process_, modules_to_load);
+    GOrbitApp->LoadModules(modules_to_load);
 
   } else if (action == kMenuActionVerifyFramePointers) {
     std::vector<const ModuleData*> modules_to_validate;
@@ -171,8 +170,7 @@ void ModulesDataView::DoFilter() {
   indices_ = indices;
 }
 
-void ModulesDataView::SetProcess(const ProcessData* process) {
-  process_ = process;
+void ModulesDataView::UpdateModules(const ProcessData* process) {
   modules_.clear();
   module_memory_.clear();
   for (const auto& [module_path, memory_space] : process->GetMemoryMap()) {

--- a/OrbitGl/ModulesDataView.h
+++ b/OrbitGl/ModulesDataView.h
@@ -27,8 +27,7 @@ class ModulesDataView : public DataView {
   std::string GetLabel() override { return "Modules"; }
   bool HasRefreshButton() const override { return true; }
   void OnRefreshButtonClicked() override;
-
-  void SetProcess(const ProcessData* process);
+  void UpdateModules(const ProcessData* process);
 
  protected:
   void DoSort() override;
@@ -37,10 +36,6 @@ class ModulesDataView : public DataView {
  private:
   [[nodiscard]] ModuleData* GetModule(uint32_t row) const { return modules_[indices_[row]]; }
 
-  // TODO(169309553) Saving this process_ here is currently only necessary because symbol loading
-  // involves the process (see GOrbitApp->LoadSymbols). The plan is not involve the process in
-  // symbol loading anymore, once this changed, remove this process_ field.
-  const ProcessData* process_ = nullptr;
   std::vector<ModuleData*> modules_;
   absl::flat_hash_map<const ModuleData*, const MemorySpace*> module_memory_;
 

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -230,7 +230,7 @@ void SamplingReportDataView::OnContextMenu(const std::string& action, int menu_i
         modules_to_load.push_back(module);
       }
     }
-    GOrbitApp->LoadModules(GOrbitApp->GetCaptureData().process(), modules_to_load);
+    GOrbitApp->LoadModules(modules_to_load);
   } else if (action == kMenuActionDisassembly) {
     int32_t pid = GOrbitApp->GetCaptureData().process_id();
     for (const FunctionInfo* function : GetFunctionsFromIndices(item_indices)) {

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -141,11 +141,12 @@ absl::flat_hash_set<const FunctionInfo*> SamplingReportDataView::GetFunctionsFro
     const std::vector<int>& indices) {
   absl::flat_hash_set<const FunctionInfo*> functions_set;
   const CaptureData& capture_data = GOrbitApp->GetCaptureData();
+  const auto& module_map = GOrbitApp->GetModulesLoadedByProcess(capture_data.process());
   for (int index : indices) {
     SampledFunction& sampled_function = GetSampledFunction(index);
     if (sampled_function.function == nullptr) {
       const FunctionInfo* func =
-          capture_data.FindFunctionByAddress(sampled_function.absolute_address, false);
+          capture_data.FindFunctionByAddress(sampled_function.absolute_address, module_map, false);
       sampled_function.function = func;
     }
 
@@ -161,11 +162,13 @@ absl::flat_hash_set<const FunctionInfo*> SamplingReportDataView::GetFunctionsFro
 absl::flat_hash_set<ModuleData*> SamplingReportDataView::GetModulesFromIndices(
     const std::vector<int>& indices) const {
   absl::flat_hash_set<ModuleData*> modules;
+  const CaptureData& capture_data = GOrbitApp->GetCaptureData();
+  const auto& module_map = GOrbitApp->GetModulesLoadedByProcess(capture_data.process());
   for (int index : indices) {
     const SampledFunction& sampled_function = GetSampledFunction(index);
     CHECK(sampled_function.absolute_address != 0);
     ModuleData* module =
-        GOrbitApp->GetCaptureData().FindModuleByAddress(sampled_function.absolute_address);
+        capture_data.FindModuleByAddress(sampled_function.absolute_address, module_map);
     if (module != nullptr) {
       modules.insert(module);
     }

--- a/OrbitQt/CallTreeWidget.cpp
+++ b/OrbitQt/CallTreeWidget.cpp
@@ -307,7 +307,7 @@ void CallTreeWidget::onCustomContextMenuRequested(const QPoint& point) {
   } else if (action->text() == kActionCollapseAll) {
     ui_->callTreeTreeView->collapseAll();
   } else if (action->text() == kActionLoadSymbols) {
-    app_->LoadModules(app_->GetCaptureData().process(), modules_to_load);
+    app_->LoadModules(modules_to_load);
   } else if (action->text() == kActionSelect) {
     for (const FunctionInfo* function : functions) {
       app_->SelectFunction(*function);

--- a/OrbitQt/CallTreeWidget.cpp
+++ b/OrbitQt/CallTreeWidget.cpp
@@ -201,6 +201,8 @@ static std::vector<ModuleData*> GetModulesFromIndices(OrbitApp* app,
 static std::vector<const FunctionInfo*> GetFunctionsFromIndices(
     OrbitApp* app, const std::vector<QModelIndex>& indices) {
   absl::flat_hash_set<const FunctionInfo*> functions_set;
+  const CaptureData& capture_data = app->GetCaptureData();
+  const auto& module_map = app->GetModulesLoadedByProcess(capture_data.process());
   for (const auto& index : indices) {
     uint64_t absolute_address =
         index.model()
@@ -208,7 +210,7 @@ static std::vector<const FunctionInfo*> GetFunctionsFromIndices(
             .data(Qt::EditRole)
             .toLongLong();
     const FunctionInfo* function =
-        app->GetCaptureData().FindFunctionByAddress(absolute_address, false);
+        capture_data.FindFunctionByAddress(absolute_address, module_map, false);
     if (function != nullptr) {
       functions_set.insert(function);
     }


### PR DESCRIPTION
Towards making modules (and thus functions) independent from their
process, module base address and module load bias should not be stored
inside FunctionInfo.
This PR removes these fields, in particular by introducing a new GetAbsoluteAddress
function, that uses the process and module data.

It also serializes basic information about the modules and the process.
Loading a capture, will also create the basic information
in data manager.

Symbol loading does not require the process anymore.

Test: Compile, Take Captures, Load Captures, Save Captures
Bug: http://b/169309553