### PR TITLE
Fix Crash in IsFunctionSelected

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -1118,8 +1118,15 @@ void OrbitApp::DeselectFunction(const orbit_client_protos::FunctionInfo& func) {
 }
 
 [[nodiscard]] bool OrbitApp::IsFunctionSelected(uint64_t absolute_address) const {
-  int32_t pid = data_manager_->selected_process()->pid();
+  const ProcessData* process = data_manager_->selected_process();
+  if (process == nullptr) {
+    return false;
+  }
+  const int32_t pid = process->pid();
   const FunctionInfo* function = data_manager_->FindFunctionByAddress(pid, absolute_address, false);
+  if (function == nullptr) {
+    return false;
+  }
   return data_manager_->IsFunctionSelected(*function);
 }
 


### PR DESCRIPTION
When switching from absolute address to function info values to
represent the selected functions, we querry the selected process
and the absolute address to find the function.
Both, the process and the function might be nullptr.
In those cases, the function can't be selected, thus we return false.

Test: Take a capture, load a capture