### PR TITLE
Fix presets for e2e test.

### DIFF
--- a/contrib/automation_tests/draw_frame_in_hello_ggp_1_52.opr
+++ b/contrib/automation_tests/draw_frame_in_hello_ggp_1_52.opr
@@ -1,3 +1,3 @@
-4
-%/srv/game/assets/hello_ggp_standalone
+2
+#/mnt/developer/hello_ggp_standalone
 	ªý‘šú¨ÐÚF

--- a/contrib/automation_tests/ggp_issue_frame_token_in_hello_ggp_1_52.opr
+++ b/contrib/automation_tests/ggp_issue_frame_token_in_hello_ggp_1_52.opr
@@ -1,4 +1,4 @@
-5
-%/srv/game/assets/hello_ggp_standalone
+3
+#/mnt/developer/hello_ggp_standalone
 
 ¨Ë’€¾Ù…õ¯


### PR DESCRIPTION
Previously presets contained a module name /srv/game/hello_ggp_standalone.
Changed that to /mnt/developer/hello_ggp_standalone such that local runs
can use this data as well.

Test: Ran locally.