### PR TITLE
Draw white text boxes with black text for iterators overlay

### DIFF
--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -22,6 +22,7 @@ float GlCanvas::kZValueTimeBarBg = 0.004f;
 float GlCanvas::kZValueUi = 0.0f;
 float GlCanvas::kZValueEventBarPicking = -0.001f;
 float GlCanvas::kZValueText = -0.003f;
+float GlCanvas::kZValueOverlayTextBackground = -0.0035f;
 float GlCanvas::kZValueOverlay = -0.004f;
 float GlCanvas::kZValueRoundingCorner = -0.01f;
 float GlCanvas::kZValueEvent = -0.02f;

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -88,6 +88,7 @@ class GlCanvas : public GlPanel {
   static float kZValueEventBarPicking;
   static float kZValueTimeBarBg;
   static float kZValueText;
+  static float kZValueOverlayTextBackground;
   static float kZValueOverlay;
   static float kZValueRoundingCorner;
   static float kZValueEvent;

--- a/OrbitGl/TextRenderer.cpp
+++ b/OrbitGl/TextRenderer.cpp
@@ -230,10 +230,10 @@ void TextRenderer::AddText(const char* a_Text, float a_X, float a_Y, float a_Z,
   AddTextInternal(m_Font, a_Text, ColorToVec4(a_Color), &m_Pen, a_MaxSize, a_Z);
 }
 
-void TextRenderer::AddTextTrailingCharsPrioritized(const char* a_Text, float a_X, float a_Y,
-                                                   float a_Z, const Color& a_Color,
-                                                   size_t a_TrailingCharsLength, uint32_t font_size,
-                                                   float a_MaxSize) {
+int TextRenderer::AddTextTrailingCharsPrioritized(const char* a_Text, float a_X, float a_Y,
+                                                  float a_Z, const Color& a_Color,
+                                                  size_t a_TrailingCharsLength, uint32_t font_size,
+                                                  float a_MaxSize) {
   if (!m_Initialized) {
     Init();
   }
@@ -289,6 +289,7 @@ void TextRenderer::AddTextTrailingCharsPrioritized(const char* a_Text, float a_X
 
   if (!useEllipsisText) {
     AddText(a_Text, a_X, a_Y, a_Z, a_Color, font_size, a_MaxSize);
+    return GetStringWidth(a_Text);
   } else {
     auto leadingCharCount = fittingCharsCount - (a_TrailingCharsLength + ELLIPSIS_TEXT_LEN);
 
@@ -299,6 +300,7 @@ void TextRenderer::AddTextTrailingCharsPrioritized(const char* a_Text, float a_X
     modifiedText.append(&a_Text[timePosition], a_TrailingCharsLength);
 
     AddText(modifiedText.c_str(), a_X, a_Y, a_Z, a_Color, font_size, a_MaxSize);
+    return GetStringWidth(modifiedText.c_str());
   }
 }
 

--- a/OrbitGl/TextRenderer.h
+++ b/OrbitGl/TextRenderer.h
@@ -26,9 +26,10 @@ class TextRenderer {
   void Display(Batcher* batcher);
   void AddText(const char* a_Text, float a_X, float a_Y, float a_Z, const Color& a_Color,
                uint32_t font_size, float a_MaxSize = -1.f, bool a_RightJustified = false);
-  void AddTextTrailingCharsPrioritized(const char* a_Text, float a_X, float a_Y, float a_Z,
-                                       const Color& a_Color, size_t a_TrailingCharsLength,
-                                       uint32_t font_size, float a_MaxSize);
+  // Returns the width of the rendered string.
+  int AddTextTrailingCharsPrioritized(const char* a_Text, float a_X, float a_Y, float a_Z,
+                                      const Color& a_Color, size_t a_TrailingCharsLength,
+                                      uint32_t font_size, float a_MaxSize);
   int AddText2D(const char* a_Text, int a_X, int a_Y, float a_Z, const Color& a_Color,
                 float a_MaxSize = -1.f, bool a_RightJustified = false, bool a_InvertY = true);
 

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -160,6 +160,9 @@ class TimeGraph {
     NeedsRedraw();
   }
 
+  void DrawIteratorBox(GlCanvas* canvas, Vec2 pos, Vec2 size, const Color& color,
+                       const std::string& label, const std::string& time, float text_box_y);
+
   [[nodiscard]] uint64_t GetCaptureMin() const { return capture_min_timestamp_; }
   [[nodiscard]] uint64_t GetCaptureMax() const { return capture_max_timestamp_; }
   [[nodiscard]] uint64_t GetCurrentMouseTimeNs() const { return current_mouse_time_ns_; }


### PR DESCRIPTION
The white text showing iterator timings is hard to read and can be
easily confused with other text. This is in particular true as all
text for textboxes is drawn at the end above essentially everything
else. We fix this here partly by using solid white text boxes with black
text for the iterator timings.

Since the white timer text is still drawn last, the black text for the
iterator timings is still overdrawn with timer text when text is drawn
in the same position.