### PR TITLE
Remove "filter" and "enable" entries from tracepoint tab.

### DIFF
--- a/OrbitService/ServiceUtils.cpp
+++ b/OrbitService/ServiceUtils.cpp
@@ -138,6 +138,9 @@ ErrorMessageOr<std::vector<orbit_grpc_protos::TracepointInfo>> ReadTracepoints()
   for (const auto& category : fs::directory_iterator(kLinuxTracingEvents, error_code_category)) {
     if (fs::is_directory(category)) {
       for (const auto& name : fs::directory_iterator(category, error_code_name)) {
+        if (fs::path(name).filename() == "enable" || fs::path(name).filename() == "filter") {
+          continue;
+        }
         TracepointInfo tracepoint_info;
         tracepoint_info.set_name(fs::path(name).filename());
         tracepoint_info.set_category(fs::path(category).filename());

--- a/OrbitService/ServiceUtilsTest.cpp
+++ b/OrbitService/ServiceUtilsTest.cpp
@@ -249,8 +249,9 @@ TEST(ServiceUtils, NamesTracepoints) {
       "sched_switch", "sched_wakeup",    "sched_process_fork", "sched_waking", "task_rename",
       "task_newtask", "signal_generate", "signal_deliver",     "timer_init",   "timer_start"};
 
-  static const std::array<std::string, 3> kNamesUnavailable = {"orbit", "profiler",
-                                                               "instrumentation"};
+  static const std::array<std::string, 5> kNamesUnavailable = {"orbit", "profiler",
+                                                               "instrumentation", "enable", 
+                                                               "filter"};
 
   for (std::string name_available : kNamesAvailable) {
     ASSERT_TRUE(find(names.begin(), names.end(), name_available) != names.end());

--- a/OrbitService/ServiceUtilsTest.cpp
+++ b/OrbitService/ServiceUtilsTest.cpp
@@ -249,9 +249,8 @@ TEST(ServiceUtils, NamesTracepoints) {
       "sched_switch", "sched_wakeup",    "sched_process_fork", "sched_waking", "task_rename",
       "task_newtask", "signal_generate", "signal_deliver",     "timer_init",   "timer_start"};
 
-  static const std::array<std::string, 5> kNamesUnavailable = {"orbit", "profiler",
-                                                               "instrumentation", "enable", 
-                                                               "filter"};
+  static const std::array<std::string, 5> kNamesUnavailable = {
+      "orbit", "profiler", "instrumentation", "enable", "filter"};
 
   for (std::string name_available : kNamesAvailable) {
     ASSERT_TRUE(find(names.begin(), names.end(), name_available) != names.end());


### PR DESCRIPTION
These are not tracepoints but special entires in the virtual filesystem
to control the collection through the filesystem interface. Should not
be displayed here.

Bug: http://b/169832683
Test: Ran unit test.