### PR TITLE
Add file_directory location in ClientGgp

### DIFF
--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -120,6 +120,8 @@ bool ClientGgp::SaveCapture() {
     // Make sure the file is saved with orbit extension
     capture_serializer::IncludeOrbitExtensionInFile(file_name);
   }
+  // Add the location where the capture is saved
+  file_name.insert(0, options_.capture_file_directory);
 
   ErrorMessageOr<void> result = capture_serializer::Save(
       file_name, capture_data_, key_to_string_map, timer_infos_.begin(), timer_infos_.end());

--- a/OrbitClientGgp/ClientGgpOptions.h
+++ b/OrbitClientGgp/ClientGgpOptions.h
@@ -16,6 +16,7 @@ struct ClientGgpOptions {
   int32_t capture_pid;
   std::vector<std::string> capture_functions;
   std::string capture_file_name;
+  std::string capture_file_directory;
 };
 
 #endif  // ORBIT_CLIENT_GGP_CLIENT_GGP_OPTIONS_H_

--- a/OrbitClientGgp/main.cpp
+++ b/OrbitClientGgp/main.cpp
@@ -20,7 +20,7 @@ ABSL_FLAG(std::vector<std::string>, functions, {},
           "Comma-separated list of functions to hook to the capture");
 ABSL_FLAG(std::string, file_name, "", "File name used for saving the capture");
 ABSL_FLAG(std::string, file_directory, "/var/game/",
-          "Path to locate debug file. By default it is /var/game/");
+          "Path to locate orbit file. By default it is /var/game/");
 ABSL_FLAG(std::string, log_directory, "",
           "Path to locate debug file. By default only stdout is used for logs");
 ABSL_FLAG(uint16_t, sampling_rate, 1000, "Frequency of callstack sampling in samples per second");

--- a/OrbitClientGgp/main.cpp
+++ b/OrbitClientGgp/main.cpp
@@ -19,6 +19,8 @@ ABSL_FLAG(uint32_t, capture_length, 10, "duration of capture in seconds");
 ABSL_FLAG(std::vector<std::string>, functions, {},
           "Comma-separated list of functions to hook to the capture");
 ABSL_FLAG(std::string, file_name, "", "File name used for saving the capture");
+ABSL_FLAG(std::string, file_directory, "/var/game/",
+          "Path to locate debug file. By default it is /var/game/");
 ABSL_FLAG(std::string, log_directory, "",
           "Path to locate debug file. By default only stdout is used for logs");
 ABSL_FLAG(uint16_t, sampling_rate, 1000, "Frequency of callstack sampling in samples per second");
@@ -56,6 +58,7 @@ int main(int argc, char** argv) {
   options.capture_pid = absl::GetFlag(FLAGS_pid);
   options.capture_functions = absl::GetFlag(FLAGS_functions);
   options.capture_file_name = absl::GetFlag(FLAGS_file_name);
+  options.capture_file_directory = absl::GetFlag(FLAGS_file_directory);
 
   ClientGgp client_ggp(std::move(options));
   if (!client_ggp.InitClient()) {


### PR DESCRIPTION
By default the orbit file is now created in /var/game/ but the user can change it if they want to.
This change allows the orbit file to be created without issue by default when the client is called from a game.