### PR TITLE
Add missed change to package-lock.json

### DIFF
--- a/WebUI/package-lock.json
+++ b/WebUI/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "WebUI",
+  "name": "orbit-web-ui",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
I missed adding the package-lock.json to the changeset when updating the
package.json. NPM keeps these automatically in sync, at least for
properties like the project name.