### PR TITLE
Improve Hash Performance of FunctionInfoSet and Fix Clang-Tidy Warning

### DIFF
--- a/OrbitClientData/FunctionInfoSetTest.cpp
+++ b/OrbitClientData/FunctionInfoSetTest.cpp
@@ -56,8 +56,6 @@ TEST(FunctionInfoSet, DifferentName) {
 
   internal::EqualFunctionInfo eq;
   EXPECT_FALSE(eq(left, right));
-  internal::HashFunctionInfo hash;
-  EXPECT_NE(hash(left), hash(right));
 }
 
 TEST(FunctionInfoSet, DifferentPrettyName) {
@@ -78,8 +76,6 @@ TEST(FunctionInfoSet, DifferentPrettyName) {
 
   internal::EqualFunctionInfo eq;
   EXPECT_FALSE(eq(left, right));
-  internal::HashFunctionInfo hash;
-  EXPECT_NE(hash(left), hash(right));
 }
 
 TEST(FunctionInfoSet, DifferentLoadedModulePath) {
@@ -100,8 +96,6 @@ TEST(FunctionInfoSet, DifferentLoadedModulePath) {
 
   internal::EqualFunctionInfo eq;
   EXPECT_FALSE(eq(left, right));
-  internal::HashFunctionInfo hash;
-  EXPECT_NE(hash(left), hash(right));
 }
 
 TEST(FunctionInfoSet, DifferentModuleBaseAddress) {
@@ -122,8 +116,6 @@ TEST(FunctionInfoSet, DifferentModuleBaseAddress) {
 
   internal::EqualFunctionInfo eq;
   EXPECT_FALSE(eq(left, right));
-  internal::HashFunctionInfo hash;
-  EXPECT_NE(hash(left), hash(right));
 }
 
 TEST(FunctionInfoSet, DifferentAddress) {
@@ -144,8 +136,6 @@ TEST(FunctionInfoSet, DifferentAddress) {
 
   internal::EqualFunctionInfo eq;
   EXPECT_FALSE(eq(left, right));
-  internal::HashFunctionInfo hash;
-  EXPECT_NE(hash(left), hash(right));
 }
 
 TEST(FunctionInfoSet, DifferentLoadBias) {
@@ -166,8 +156,6 @@ TEST(FunctionInfoSet, DifferentLoadBias) {
 
   internal::EqualFunctionInfo eq;
   EXPECT_FALSE(eq(left, right));
-  internal::HashFunctionInfo hash;
-  EXPECT_NE(hash(left), hash(right));
 }
 
 TEST(FunctionInfoSet, DifferentSize) {
@@ -188,8 +176,6 @@ TEST(FunctionInfoSet, DifferentSize) {
 
   internal::EqualFunctionInfo eq;
   EXPECT_FALSE(eq(left, right));
-  internal::HashFunctionInfo hash;
-  EXPECT_NE(hash(left), hash(right));
 }
 
 TEST(FunctionInfoSet, DifferentFile) {
@@ -210,8 +196,6 @@ TEST(FunctionInfoSet, DifferentFile) {
 
   internal::EqualFunctionInfo eq;
   EXPECT_FALSE(eq(left, right));
-  internal::HashFunctionInfo hash;
-  EXPECT_NE(hash(left), hash(right));
 }
 
 TEST(FunctionInfoSet, DifferentLine) {
@@ -232,8 +216,6 @@ TEST(FunctionInfoSet, DifferentLine) {
 
   internal::EqualFunctionInfo eq;
   EXPECT_FALSE(eq(left, right));
-  internal::HashFunctionInfo hash;
-  EXPECT_NE(hash(left), hash(right));
 }
 
 TEST(FunctionInfoSet, Insertion) {

--- a/OrbitClientData/include/OrbitClientData/FunctionInfoSet.h
+++ b/OrbitClientData/include/OrbitClientData/FunctionInfoSet.h
@@ -12,27 +12,19 @@
 namespace internal {
 struct HashFunctionInfo {
   size_t operator()(const orbit_client_protos::FunctionInfo& function) const {
-    return std::hash<std::string>{}(function.name()) * 37 +
-           std::hash<std::string>{}(function.pretty_name()) * 37 +
-           std::hash<std::string>{}(function.loaded_module_path()) * 37 +
-           std::hash<uint64_t>{}(function.module_base_address()) * 37 +
-           std::hash<uint64_t>{}(function.address()) * 37 +
-           std::hash<uint64_t>{}(function.load_bias()) * 37 +
-           std::hash<uint64_t>{}(function.size()) * 37 +
-           std::hash<std::string>{}(function.file()) * 37 + std::hash<uint32_t>{}(function.line());
+    return std::hash<uint64_t>{}(function.address()) * 37 + std::hash<uint64_t>{}(function.size());
   }
 };
 
 struct EqualFunctionInfo {
   bool operator()(const orbit_client_protos::FunctionInfo& left,
                   const orbit_client_protos::FunctionInfo& right) const {
-    return left.name().compare(right.name()) == 0 &&
-           left.pretty_name().compare(right.pretty_name()) == 0 &&
-           left.loaded_module_path().compare(right.loaded_module_path()) == 0 &&
+    return left.size() == right.size() && left.name() == right.name() &&
+           left.pretty_name() == right.pretty_name() &&
+           left.loaded_module_path() == right.loaded_module_path() &&
            left.module_base_address() == right.module_base_address() &&
            left.address() == right.address() && left.load_bias() == right.load_bias() &&
-           left.size() == right.size() && left.file().compare(right.file()) == 0 &&
-           left.line() == right.line();
+           left.file().compare(right.file()) == 0 && left.line() == right.line();
   }
 };
 


### PR DESCRIPTION
Hashing of function infos now only uses the address and the size, instead
of all the strings.

Also, as clang-tidy suggested, use "==" instead of compare for the strings
in the equality comparison.

Test: Compile