### PR TITLE
Multiple PerfEventVisitors in PerfEventProcessor, don't take ownership

### DIFF
--- a/OrbitLinuxTracing/GpuTracepointEventProcessor.h
+++ b/OrbitLinuxTracing/GpuTracepointEventProcessor.h
@@ -23,7 +23,7 @@ class GpuTracepointEventProcessor {
 
  private:
   // Keys are context, seqno, and timeline
-  typedef std::tuple<uint32_t, uint32_t, std::string> Key;
+  using Key = std::tuple<uint32_t, uint32_t, std::string>;
 
   int ComputeDepthForEvent(const std::string& timeline, uint64_t start_timestamp,
                            uint64_t end_timestamp);

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -25,6 +25,7 @@
 #include "PerfEventProcessor.h"
 #include "PerfEventReaders.h"
 #include "PerfEventRingBuffer.h"
+#include "UprobesUnwindingVisitor.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "capture.pb.h"
@@ -55,7 +56,7 @@ class TracerThread {
   }
 
   bool OpenContextSwitches(const std::vector<int32_t>& cpus);
-  void InitUprobesEventProcessor();
+  void InitUprobesEventVisitor();
   bool OpenUserSpaceProbes(const std::vector<int32_t>& cpus);
   bool OpenUprobes(const LinuxTracing::Function& function, const std::vector<int32_t>& cpus,
                    absl::flat_hash_map<int32_t, int>* fds_per_cpu);
@@ -145,7 +146,8 @@ class TracerThread {
   std::vector<std::unique_ptr<PerfEvent>> deferred_events_;
   std::mutex deferred_events_mutex_;
   ContextSwitchManager context_switch_manager_;
-  std::unique_ptr<PerfEventProcessor> uprobes_event_processor_;
+  std::unique_ptr<UprobesUnwindingVisitor> uprobes_unwinding_visitor_;
+  PerfEventProcessor event_processor_;
   std::unique_ptr<GpuTracepointEventProcessor> gpu_event_processor_;
 
   struct EventStats {


### PR DESCRIPTION
`PerfEventProcessor` now suports multiple `PerfEventVisitor`s and doesn't take
ownership of them, instead is passed bare pointers.
Having multiple visitors will allow for another visitor to handle thread states.
Not taking ownership will allow to store the `PerfEventVisitor`s independently
of `PerfEventProcessor` and hence to access them.