### PR TITLE
Fix "node not found" problem

### DIFF
--- a/WebUI/CMakeLists.txt
+++ b/WebUI/CMakeLists.txt
@@ -36,11 +36,15 @@ else()
   find_program(NPM npm)
 endif()
 
-execute_process(COMMAND ${NPM} install WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+set(NODE_AWARE_PATH "$ENV{PATH}" CACHE STRING "The state of PATH during config phase")
+
+execute_process(COMMAND ${CMAKE_COMMAND} -E env "PATH=${NODE_AWARE_PATH}"
+                        ${NPM} install WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dist/WebUI.qrc
                    COMMAND ${CMAKE_COMMAND}
                      -E env "ORBIT_BUILD_FOLDER=${CMAKE_BINARY_DIR}"
+                            "PATH=${NODE_AWARE_PATH}"
                      ${NPM} run build
                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                    MAIN_DEPENDENCY webpack.config.js


### PR DESCRIPTION
NodeJS is installed by conan as a build dependency but not added to the
user's global PATH variable. So the conan-supplied NodeJS executable is
only found when the executing environment is initialized by conan, i.e.
when cmake is called from conan like it is the case in build.{sh,ps1}.

When cmake is called either manually or by a third party like CLion the
NodeJS-executable won't be found because it's not in the PATH. This can
be circumvented by caching the contents of the PATH variable during the
configuration phase and restoring it on every subsequent call of cmake.

Limitation: This requires the initial build to be initiated by conan,
usually by running `build.{sh,ps1}` or the bootstrap script.