### PR TITLE
Add LinuxTracingUtils/GetThreadState

### DIFF
--- a/OrbitLinuxTracing/LinuxTracingUtils.h
+++ b/OrbitLinuxTracing/LinuxTracingUtils.h
@@ -31,6 +31,11 @@ std::vector<pid_t> GetAllTids();
 
 std::string GetThreadName(pid_t tid);
 
+// The association between a character and a thread state is documented at
+// https://man7.org/linux/man-pages/man5/proc.5.html in the "/proc/[pid]/stat" section,
+// and at https://www.man7.org/linux/man-pages/man1/ps.1.html#PROCESS_STATE_CODES.
+std::optional<char> GetThreadState(pid_t tid);
+
 std::optional<std::string> ExecuteCommand(const std::string& cmd);
 
 int GetNumCores();


### PR DESCRIPTION
This will be used to fetch the state of threads at the beginning of the capture
(although in an approximate way).