### PR TITLE
Handle thread names with spaces when parsing /proc/<pid>/stat

### DIFF
--- a/OrbitLinuxTracing/LinuxTracingUtilsTest.cpp
+++ b/OrbitLinuxTracing/LinuxTracingUtilsTest.cpp
@@ -4,6 +4,7 @@
 
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
+#include <pthread.h>
 #include <sys/syscall.h>
 
 #include <condition_variable>
@@ -113,6 +114,9 @@ TEST(GetThreadState, OrbitLinuxTracingTestsMainAndAnother) {
   std::optional<char> thread_state_holding_mutex;
   std::optional<char> main_state_waiting_mutex;
   std::thread thread{[&] {
+    // Make sure /proc/<pid>/stat is parsed correctly
+    // even when the thread name contains spaces and parentheses.
+    pthread_setname_np(pthread_self(), ") )  )()( )(  )");
     {
       absl::MutexLock lock{&mutex};
       thread_tid = syscall(SYS_gettid);


### PR DESCRIPTION
`GetCumulativeCpuTimeFromProcess` and `GetThreadState` parsed the content of
`/proc/<pid>/stat` by splitting on spaces, but didn't consider that the thread
name enclosed in parentheses could contain spaces itself.

Bug: http://b/170073156

Test: Start a process with one/two/three spaces in its name and check that its
displayed CPU utilization is correct. Update test for `GetThreadState`.