### PR TITLE
Slider resizing

### DIFF
--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -28,6 +28,15 @@ void Batcher::AddVerticalLine(Vec2 pos, float size, float z, const Color& color,
   AddLine(pos, pos + Vec2(0, size), z, color, std::move(user_data));
 }
 
+void Batcher::AddVerticalLine(Vec2 pos, float size, float z, const Color& color,
+                              std::shared_ptr<Pickable> pickable) {
+  CHECK(picking_manager_ != nullptr);
+
+  Color picking_color = picking_manager_->GetPickableColor(pickable, batcher_id_);
+
+  AddLine(pos, pos + Vec2(0, size), z, color, picking_color, nullptr);
+}
+
 void Batcher::AddLine(Vec2 from, Vec2 to, float z, const Color& color, const Color& picking_color,
                       std::unique_ptr<PickingUserData> user_data) {
   Line line;

--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -141,7 +141,9 @@ target_sources(OrbitGlTests PRIVATE
                BatcherTest.cpp
                PickingManagerTest.cpp
                ScopedStatusTest.cpp
-               TimerInfosIteratorTest.cpp)
+               SliderTest.cpp
+               TimerInfosIteratorTest.cpp
+               UnitTestMockEnvironment.cpp)
 
 target_link_libraries(
   OrbitGlTests

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -27,9 +27,12 @@ CaptureWindow::CaptureWindow(CaptureWindow::StatsMode stats_mode)
   vertical_slider_ = std::make_shared<GlVerticalSlider>();
 
   slider_->SetDragCallback([&](float ratio) { this->OnDrag(ratio); });
+  slider_->SetResizeCallback([&](float start, float end) { this->OnZoom(start, end); });
   slider_->SetCanvas(this);
 
   vertical_slider_->SetDragCallback([&](float ratio) { this->OnVerticalDrag(ratio); });
+  vertical_slider_->SetResizeCallback(
+      [&](float start, float end) { this->OnVerticalZoom(start, end); });
   vertical_slider_->SetCanvas(this);
 
   vertical_slider_->SetOrthogonalSliderSize(slider_->GetPixelHeight());
@@ -569,6 +572,16 @@ void CaptureWindow::OnVerticalDrag(float ratio) {
   float range = max - min;
   world_top_left_y_ = min + ratio * range;
   NeedsUpdate();
+}
+
+void CaptureWindow::OnZoom(float start, float end) {
+  double time_span = time_graph_.GetCaptureTimeSpanUs();
+  time_graph_.SetMinMax(start * time_span, end * time_span);
+}
+
+void CaptureWindow::OnVerticalZoom(float start, float end) {
+  // double time_span = time_graph_.GetCaptureTimeSpanUs();
+  // time_graph_.Zoom(start * time_span, end * time_span);
 }
 
 void CaptureWindow::UpdateVerticalSlider() {

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -524,14 +524,14 @@ void CaptureWindow::DrawScreenSpace() {
     double ratio = GOrbitApp->IsCapturing() ? 1 : (max_start != 0 ? start / max_start : 0);
     float slider_width = layout.GetSliderWidth();
     slider_->SetPixelHeight(slider_width);
-    slider_->SetSliderRatio(static_cast<float>(ratio));
-    slider_->SetSliderWidthRatio(static_cast<float>(width / time_span));
+    slider_->SetSliderPosRatio(static_cast<float>(ratio));
+    slider_->SetSliderLengthRatio(static_cast<float>(width / time_span));
     slider_->Draw(this, picking_mode);
 
     float vertical_ratio = world_height_ / time_graph_.GetThreadTotalHeight();
     if (vertical_ratio < 1.f) {
       vertical_slider_->SetPixelHeight(slider_width);
-      vertical_slider_->SetSliderWidthRatio(vertical_ratio);
+      vertical_slider_->SetSliderLengthRatio(vertical_ratio);
       vertical_slider_->Draw(this, picking_mode);
       right_margin += slider_width;
     }
@@ -575,7 +575,7 @@ void CaptureWindow::UpdateVerticalSlider() {
   float min = world_max_y_;
   float max = world_height_ - time_graph_.GetThreadTotalHeight();
   float ratio = (world_top_left_y_ - min) / (max - min);
-  vertical_slider_->SetSliderRatio(ratio);
+  vertical_slider_->SetSliderPosRatio(ratio);
 }
 
 void CaptureWindow::ToggleDrawHelp() { set_draw_help(!draw_help_); }

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -31,8 +31,6 @@ CaptureWindow::CaptureWindow(CaptureWindow::StatsMode stats_mode)
   slider_->SetCanvas(this);
 
   vertical_slider_->SetDragCallback([&](float ratio) { this->OnVerticalDrag(ratio); });
-  vertical_slider_->SetResizeCallback(
-      [&](float start, float end) { this->OnVerticalZoom(start, end); });
   vertical_slider_->SetCanvas(this);
 
   vertical_slider_->SetOrthogonalSliderSize(slider_->GetPixelHeight());
@@ -577,11 +575,6 @@ void CaptureWindow::OnVerticalDrag(float ratio) {
 void CaptureWindow::OnZoom(float start, float end) {
   double time_span = time_graph_.GetCaptureTimeSpanUs();
   time_graph_.SetMinMax(start * time_span, end * time_span);
-}
-
-void CaptureWindow::OnVerticalZoom(float start, float end) {
-  // double time_span = time_graph_.GetCaptureTimeSpanUs();
-  // time_graph_.Zoom(start * time_span, end * time_span);
 }
 
 void CaptureWindow::UpdateVerticalSlider() {

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -49,6 +49,8 @@ class CaptureWindow : public GlCanvas {
   void SelectTextBox(const TextBox* text_box);
   void OnDrag(float ratio);
   void OnVerticalDrag(float ratio);
+  void OnZoom(float start, float end);
+  void OnVerticalZoom(float start, float end);
   void NeedsUpdate();
   void OnCaptureStarted();
   std::vector<std::string> GetContextMenu() override;

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -50,7 +50,6 @@ class CaptureWindow : public GlCanvas {
   void OnDrag(float ratio);
   void OnVerticalDrag(float ratio);
   void OnZoom(float start, float end);
-  void OnVerticalZoom(float start, float end);
   void NeedsUpdate();
   void OnCaptureStarted();
   std::vector<std::string> GetContextMenu() override;

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -49,7 +49,7 @@ class CaptureWindow : public GlCanvas {
   void SelectTextBox(const TextBox* text_box);
   void OnDrag(float ratio);
   void OnVerticalDrag(float ratio);
-  void OnZoom(float start, float end);
+  void OnZoom(float normalized_start, float normalized_end);
   void NeedsUpdate();
   void OnCaptureStarted();
   std::vector<std::string> GetContextMenu() override;

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -23,8 +23,8 @@ class GlCanvas : public GlPanel {
   void Render(int width, int height) override;
   virtual void PostRender() {}
 
-  int GetWidth() const;
-  int GetHeight() const;
+  virtual int GetWidth() const;
+  virtual int GetHeight() const;
 
   void Prepare2DViewport(int top_left_x, int top_left_y, int bottom_right_x, int bottom_right_y);
   void PrepareScreenSpaceViewport();

--- a/OrbitGl/GlSlider.h
+++ b/OrbitGl/GlSlider.h
@@ -34,7 +34,7 @@ class GlSlider : public Pickable, public std::enable_shared_from_this<GlSlider> 
   typedef std::function<void(float)> DragCallback;
   void SetDragCallback(DragCallback callback) { drag_callback_ = callback; }
 
-  typedef std::function<void(float)> ResizeCallback;
+  typedef std::function<void(float, float)> ResizeCallback;
   void SetResizeCallback(ResizeCallback callback) { resize_callback_ = callback; }
 
   [[nodiscard]] float GetPosRatio() { return pos_ratio_; }
@@ -42,6 +42,11 @@ class GlSlider : public Pickable, public std::enable_shared_from_this<GlSlider> 
 
   void OnPick(int x, int y) override;
   void OnDrag(int x, int y) override;
+
+  [[nodiscard]] float GetMinSliderPixelLength() { return min_slider_pixel_length_; }
+
+  float GetPixelPos() { return PosToPixel(pos_ratio_); }
+  float GetPixelLength() { return LenToPixel(length_ratio_); }
 
  protected:
   static Color GetLighterColor(const Color& color);

--- a/OrbitGl/GlSlider.h
+++ b/OrbitGl/GlSlider.h
@@ -15,65 +15,70 @@ class GlCanvas;
 
 class GlSlider : public Pickable, public std::enable_shared_from_this<GlSlider> {
  public:
-  GlSlider();
   ~GlSlider(){};
 
   [[nodiscard]] bool Draggable() override { return true; }
 
   void SetCanvas(GlCanvas* canvas) { canvas_ = canvas; }
-  void SetSliderPosRatio(float start_ratio);  // [0,1]
 
-  void SetSliderLengthRatio(float length_ratio);  // [0,1]
+  void SetNormalizedPosition(float start_ratio);  // [0,1]
+  void SetNormalizedLength(float length_ratio);   // [0,1]
+
   [[nodiscard]] Color GetBarColor() const { return slider_color_; }
-  void SetPixelHeight(float height) { pixel_height_ = height; }
-  [[nodiscard]] float GetPixelHeight() const { return pixel_height_; }
 
-  void SetOrthogonalSliderSize(float size) { orthogonal_slider_size_ = size; }
-  [[nodiscard]] float GetOrthogonalSliderSize() { return orthogonal_slider_size_; }
+  void SetPixelHeight(int height) { pixel_height_ = height; }
+  [[nodiscard]] int GetPixelHeight() const { return pixel_height_; }
+
+  void SetOrthogonalSliderPixelHeight(int size) { orthogonal_slider_size_ = size; }
+  [[nodiscard]] int GetOrthogonalSliderSize() const { return orthogonal_slider_size_; }
 
   // Parameter: Position in [0, 1], relative to the size of the current data window
-  typedef std::function<void(float)> DragCallback;
-  void SetDragCallback(DragCallback callback) { drag_callback_ = callback; }
+  using DragCallback = std::function<void(float)>;
+  void SetDragCallback(DragCallback callback) { drag_callback_ = std::move(callback); }
 
   // Parameters: Start and End of the slider in [0, 1], relative to the full data window
-  typedef std::function<void(float, float)> ResizeCallback;
-  void SetResizeCallback(ResizeCallback callback) { resize_callback_ = callback; }
+  using ResizeCallback = std::function<void(float, float)>;
+  void SetResizeCallback(ResizeCallback callback) { resize_callback_ = std::move(callback); }
 
-  [[nodiscard]] float GetPosRatio() { return pos_ratio_; }
-  [[nodiscard]] float GetLengthRatio() { return length_ratio_; }
+  [[nodiscard]] float GetPosRatio() const { return pos_ratio_; }
+  [[nodiscard]] float GetLengthRatio() const { return length_ratio_; }
 
   void OnPick(int x, int y) override;
   void OnDrag(int x, int y) override;
 
-  [[nodiscard]] float GetMinSliderPixelLength() { return min_slider_pixel_length_; }
+  [[nodiscard]] float GetMinSliderPixelLength() const { return min_slider_pixel_length_; }
 
-  [[nodiscard]] float GetPixelPos() { return PosToPixel(pos_ratio_); }
-  [[nodiscard]] float GetPixelLength() { return LenToPixel(length_ratio_); }
+  [[nodiscard]] float GetPixelPos() const { return PosToPixel(pos_ratio_); }
+  [[nodiscard]] float GetPixelLength() const { return LenToPixel(length_ratio_); }
 
-  [[nodiscard]] bool CanResize() { return can_resize_; }
+  [[nodiscard]] bool CanResize() const { return can_resize_; }
 
  protected:
+  GlSlider(bool is_vertical);
+
   static Color GetLighterColor(const Color& color);
   static Color GetDarkerColor(const Color& color);
 
   void DrawBackground(GlCanvas* canvas, float x, float y, float width, float height);
   void DrawSlider(GlCanvas* canvas, float x, float y, float width, float height,
                   ShadingDirection shading_direction);
-  virtual int GetRelevantMouseDim(int x, int y) = 0;
 
-  [[nodiscard]] virtual float GetCanvasEdgeLength() = 0;
+  [[nodiscard]] virtual int GetBarPixelLength() const = 0;
 
-  [[nodiscard]] float PixelToLen(float value) { return value / GetCanvasEdgeLength(); }
-  [[nodiscard]] float LenToPixel(float value) { return value * GetCanvasEdgeLength(); }
-  [[nodiscard]] float PixelToPos(float value) {
+  [[nodiscard]] float PixelToLen(float value) const { return value / GetBarPixelLength(); }
+  [[nodiscard]] float LenToPixel(float value) const { return value * GetBarPixelLength(); }
+  [[nodiscard]] float PixelToPos(float value) const {
     return length_ratio_ < 1.0f ? value / LenToPixel(1.0f - length_ratio_) : 0.f;
   }
-  [[nodiscard]] float PosToPixel(float value) { return value * LenToPixel(1.0f - length_ratio_); }
+  [[nodiscard]] float PosToPixel(float value) const {
+    return value * LenToPixel(1.0f - length_ratio_);
+  }
 
   [[nodiscard]] bool HandlePageScroll(float click_value);
 
  protected:
   static const float kGradientFactor;
+  const bool is_vertical_;
 
   GlCanvas* canvas_;
 
@@ -89,37 +94,35 @@ class GlSlider : public Pickable, public std::enable_shared_from_this<GlSlider> 
   Color slider_color_;
   Color bar_color_;
   int min_slider_pixel_length_;
-  float pixel_height_;
-  float orthogonal_slider_size_;
+  int pixel_height_;
+  int orthogonal_slider_size_;
 
   bool can_resize_ = false;
 
   int slider_resize_pixel_margin_;
 
   enum class DragType { kPan, kScaleMin, kScaleMax, kNone };
-  DragType drag_type_;
+  DragType drag_type_ = DragType::kNone;
 };
 
 class GlVerticalSlider : public GlSlider {
  public:
-  GlVerticalSlider() : GlSlider(){};
+  GlVerticalSlider() : GlSlider(true){};
   ~GlVerticalSlider(){};
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
 
  protected:
-  [[nodiscard]] float GetCanvasEdgeLength() override;
-  [[nodiscard]] int GetRelevantMouseDim(int /*x*/, int y) override { return y; }
+  [[nodiscard]] int GetBarPixelLength() const override;
 };
 
 class GlHorizontalSlider : public GlSlider {
  public:
-  GlHorizontalSlider() : GlSlider() { can_resize_ = true; };
+  GlHorizontalSlider() : GlSlider(false) { can_resize_ = true; };
   ~GlHorizontalSlider(){};
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
 
  protected:
-  [[nodiscard]] float GetCanvasEdgeLength() override;
-  [[nodiscard]] int GetRelevantMouseDim(int x, int /*y*/) override { return x; }
+  [[nodiscard]] int GetBarPixelLength() const override;
 };

--- a/OrbitGl/SliderTest.cpp
+++ b/OrbitGl/SliderTest.cpp
@@ -14,48 +14,271 @@ class MockCanvas : public GlCanvas {
   MOCK_METHOD(int, GetHeight, (), (const, override));
 };
 
-TEST(Slider, Dragging) {
-  using ::testing::Return;
-  const float kEpsilon = 0.01f;
+template <int dim>
+void pick(GlSlider& slider, int start, int other_dim = 0);
 
-  MockCanvas canvas;
+template <>
+void pick<0>(GlSlider& slider, int start, int other_dim) {
+  slider.OnPick(start, other_dim);
+}
+
+template <>
+void pick<1>(GlSlider& slider, int start, int other_dim) {
+  slider.OnPick(other_dim, start);
+}
+
+template <int dim>
+void drag(GlSlider& slider, int end, int other_dim = 0);
+
+template <>
+void drag<0>(GlSlider& slider, int end, int other_dim) {
+  slider.OnDrag(end, other_dim);
+}
+
+template <>
+void drag<1>(GlSlider& slider, int end, int other_dim) {
+  slider.OnDrag(other_dim, end);
+}
+
+template <int dim>
+void pick_drag(GlSlider& slider, int start, int end = -1, int other_dim = 0) {
+  if (end < 0) {
+    end = start;
+  }
+  pick<dim>(slider, start, other_dim);
+  drag<dim>(slider, end, other_dim);
+}
+
+template <int dim>
+void pick_drag_release(GlSlider& slider, int start, int end = -1, int other_dim = 0) {
+  pick_drag<dim>(slider, start, end, other_dim);
+  slider.OnRelease();
+}
+
+template <typename SliderClass>
+std::pair<std::unique_ptr<SliderClass>, std::unique_ptr<MockCanvas>> setup() {
+  std::unique_ptr<MockCanvas> canvas = std::make_unique<MockCanvas>();
   // Simulate a 1000x100 canvas
-  EXPECT_CALL(canvas, GetWidth()).WillRepeatedly(Return(1000));
-  EXPECT_CALL(canvas, GetHeight()).WillRepeatedly(Return(100));
+  EXPECT_CALL(*canvas, GetWidth()).WillRepeatedly(::testing::Return(150));
+  EXPECT_CALL(*canvas, GetHeight()).WillRepeatedly(::testing::Return(1050));
 
-  float hpos;
+  std::unique_ptr<SliderClass> slider = std::make_unique<SliderClass>();
+  slider->SetCanvas(canvas.get());
+  slider->SetPixelHeight(10);
+  slider->SetOrthogonalSliderSize(50);
 
-  GlHorizontalSlider hslider;
-  hslider.SetCanvas(&canvas);
-  hslider.SetPixelHeight(10);
+  // Set the slider to be 50% of the maximum size, position in the middle
+  slider->SetSliderPosRatio(0.5f);
+  slider->SetSliderLengthRatio(0.5f);
 
-  // Set the slider to be 50% of the maximum size, position to the very left
-  hslider.SetSliderPosRatio(0.f);
-  hslider.SetSliderLengthRatio(0.5f);
+  return std::make_pair<std::unique_ptr<SliderClass>, std::unique_ptr<MockCanvas>>(
+      std::move(slider), std::move(canvas));
+}
 
-  hslider.SetDragCallback([&](float ratio) { hpos = ratio; });
+const float kEpsilon = 0.01f;
 
-  hslider.OnPick(0, 0);
-  hslider.OnDrag(1000, 0);
+template <typename SliderClass, int dim>
+void test_drag_type() {
+  auto [slider, canvas] = setup<SliderClass>();
+
+  const float kPos = 0.5f;
+  const float kSize = 0.5f;
+  const float kOffset = 2;
+
+  int drag_count = 0;
+  float pos = kPos;
+  int size_count = 0;
+  float size = kSize;
+
+  slider->SetDragCallback([&](float ratio) {
+    ++drag_count;
+    pos = ratio;
+  });
+  slider->SetResizeCallback([&](float ratio) {
+    ++size_count;
+    size = ratio;
+  });
+
+  // Use different scales for x and y to make sure dims are chosen correctly
+  float scale = pow(10, dim);
+
+  pick_drag_release<dim>(*slider, 50 * scale);
+  EXPECT_EQ(drag_count, 1);
+  EXPECT_EQ(size_count, 0);
+  EXPECT_EQ(pos, kPos);
+  EXPECT_EQ(size, kSize);
+
+  pick_drag_release<dim>(*slider, 25 * scale + kOffset);
+  EXPECT_EQ(drag_count, 2);
+  EXPECT_EQ(size_count, 1);
+  EXPECT_EQ(pos, kPos);
+  EXPECT_EQ(size, kSize);
+
+  pick_drag_release<dim>(*slider, 75 * scale - kOffset);
+  EXPECT_EQ(drag_count, 3);
+  EXPECT_EQ(size_count, 2);
+  EXPECT_EQ(pos, kPos);
+  EXPECT_EQ(size, kSize);
+
+  pick_drag_release<dim>(*slider, kOffset);
+  EXPECT_EQ(drag_count, 4);
+  EXPECT_EQ(size_count, 2);
+  EXPECT_NE(pos, kPos);
+  EXPECT_EQ(size, kSize);
+
+  pick_drag_release<dim>(*slider, 100 * scale - kOffset);
+  EXPECT_EQ(drag_count, 5);
+  EXPECT_EQ(size_count, 2);
+  EXPECT_NE(pos, kPos);
+  EXPECT_EQ(size, kSize);
+}
+
+TEST(Slider, DragType) {
+  test_drag_type<GlHorizontalSlider, 0>();
+  test_drag_type<GlVerticalSlider, 1>();
+}
+
+template <typename SliderClass, int dim>
+void test_scroll(float slider_length = 0.25) {
+  auto [slider, canvas] = setup<SliderClass>();
+
+  // Use different scales for x and y to make sure dims are chosen correctly
+  float scale = pow(10, dim);
+  float pos;
+  const float kOffset = 2;
+
+  slider->SetDragCallback([&](float ratio) { pos = ratio; });
+  slider->SetSliderLengthRatio(slider_length);
+
+  pick_drag_release<dim>(*slider, kOffset);
+  EXPECT_LT(pos, 0.5f);
+  const float kCurPos = pos;
+
+  pick_drag_release<dim>(*slider, 100 * scale - kOffset);
+  EXPECT_GT(pos, kCurPos);
+}
+
+TEST(Slider, Scroll) {
+  test_scroll<GlHorizontalSlider, 0>();
+  test_scroll<GlVerticalSlider, 1>();
+}
+
+template <typename SliderClass, int dim>
+void test_drag(float slider_length = 0.25) {
+  auto [slider, canvas] = setup<SliderClass>();
+
+  // Use different scales for x and y to make sure dims are chosen correctly
+  float scale = pow(10, dim);
+  float pos;
+
+  slider->SetDragCallback([&](float ratio) { pos = ratio; });
+  slider->SetSliderLengthRatio(slider_length);
+
+  pick<dim>(*slider, 50 * scale);
 
   // Expect the slider to be dragged all the way to the right
   // (overshoot, first, then go back to exact drag pos)
-  EXPECT_NEAR(hpos, 1.f, kEpsilon);
-  hslider.OnDrag(500, 0);
-  EXPECT_NEAR(hpos, 1.0f, kEpsilon);
+  drag<dim>(*slider, 100 * scale);
+  EXPECT_NEAR(pos, 1.f, kEpsilon);
+  EXPECT_EQ(slider->GetPosRatio(), pos);
+  drag<dim>(*slider, (100 - slider->GetLengthRatio() * 0.5f * 100) * scale);
+  EXPECT_NEAR(pos, 1.f, kEpsilon);
 
   // Drag to middle
-  hslider.OnDrag(250, 0);
-  EXPECT_NEAR(hpos, 0.5f, kEpsilon);
+  drag<dim>(*slider, 50 * scale);
+  EXPECT_NEAR(pos, 0.5f, kEpsilon);
+
+  // Drag to left
+  drag<dim>(*slider, 0);
+  EXPECT_NEAR(pos, 0.f, kEpsilon);
+
+  // Back to middle
+  drag<dim>(*slider, 50 * scale);
+  EXPECT_NEAR(pos, 0.5f, kEpsilon);
 
   // "Invalid" drags sanity check
-  hslider.OnDrag(250, 100);
-  EXPECT_NEAR(hpos, 0.5f, kEpsilon);
+  drag<dim>(*slider, 50 * scale, 5000);
+  EXPECT_NEAR(pos, 0.5f, kEpsilon);
+}
 
-  hslider.OnRelease();
+TEST(Slider, Drag) {
+  test_drag<GlHorizontalSlider, 0>();
+  test_drag<GlVerticalSlider, 1>();
+}
 
-  // Tests when picked on the far right
-  hslider.OnPick(500, 0);
-  hslider.OnDrag(500, 0);
-  EXPECT_NEAR(hpos, 0.f, kEpsilon);
+TEST(Slider, DragBreakTests) {
+  test_drag<GlHorizontalSlider, 0>(0.0001f);
+  test_drag<GlVerticalSlider, 1>(0.0001f);
+}
+
+template <typename SliderClass, int dim>
+void test_scaling() {
+  auto [slider, canvas] = setup<SliderClass>();
+
+  float size = 0.5f;
+  float pos = 0.5f;
+  const float kOffset = 2;
+
+  // Use different scales for x and y to make sure dims are chosen correctly
+  float scale = pow(10, dim);
+
+  slider->SetResizeCallback([&](float ratio) { size = ratio; });
+  slider->SetDragCallback([&](float ratio) { pos = ratio; });
+
+  // Pick on the left
+  pick<dim>(*slider, 25 * scale + kOffset);
+
+  // Resize 10% to the left, then all the way
+  drag<dim>(*slider, 15 * scale + kOffset);
+  EXPECT_NEAR(size, 0.6f, kEpsilon);
+  EXPECT_NEAR(pos, 0.15f / 0.4f, kEpsilon);
+  EXPECT_EQ(slider->GetLengthRatio(), size);
+  EXPECT_EQ(slider->GetPosRatio(), pos);
+
+  drag<dim>(*slider, 0);
+  EXPECT_NEAR(size, 0.75f, kEpsilon);
+  EXPECT_NEAR(pos, 0.f, kEpsilon);
+
+  // Drag back
+  drag<dim>(*slider, 25 * scale + kOffset);
+  EXPECT_NEAR(size, 0.5f, kEpsilon);
+  EXPECT_NEAR(pos, 0.5f, kEpsilon);
+  slider->OnRelease();
+
+  // Pick on the right
+  pick<dim>(*slider, 75 * scale - kOffset);
+
+  // Resize 10% to the right, then all the way
+  drag<dim>(*slider, 85 * scale - kOffset);
+  EXPECT_NEAR(size, 0.6f, kEpsilon);
+  EXPECT_NEAR(pos, 0.25f / 0.4f, kEpsilon);
+
+  drag<dim>(*slider, 100 * scale);
+  EXPECT_NEAR(size, 0.75f, kEpsilon);
+  EXPECT_NEAR(pos, 1.f, kEpsilon);
+
+  // Drag back
+  drag<dim>(*slider, 75 * scale - kOffset);
+  EXPECT_NEAR(size, 0.5f, kEpsilon);
+  EXPECT_NEAR(pos, 0.25f / 0.5f, kEpsilon);
+  slider->OnRelease();
+}
+
+template <typename SliderClass, int dim>
+void test_break_scaling() {
+  auto [slider, canvas] = setup<SliderClass>();
+
+  float size;
+  float pos;
+
+  // Use different scales for x and y to make sure dims are chosen correctly
+  float scale = pow(10, dim);
+
+  // Position in the middle
+  slider->SetSliderPosRatio(0.25f);
+}
+
+TEST(Slider, Scale) {
+  test_scaling<GlHorizontalSlider, 0>();
+  test_scaling<GlVerticalSlider, 1>();
 }

--- a/OrbitGl/SliderTest.cpp
+++ b/OrbitGl/SliderTest.cpp
@@ -83,7 +83,7 @@ void test_drag_type() {
 
   const float kPos = 0.5f;
   const float kSize = 0.5f;
-  const float kOffset = 2;
+  const int kOffset = 2;
 
   int drag_count = 0;
   float pos = kPos;
@@ -100,7 +100,7 @@ void test_drag_type() {
   });
 
   // Use different scales for x and y to make sure dims are chosen correctly
-  float scale = pow(10, dim);
+  int scale = static_cast<int>(pow(10, dim));
 
   pick_drag_release<dim>(*slider, 50 * scale);
   EXPECT_EQ(drag_count, 1);
@@ -109,26 +109,39 @@ void test_drag_type() {
   EXPECT_EQ(size, kSize);
 
   pick_drag_release<dim>(*slider, 25 * scale + kOffset);
-  EXPECT_EQ(drag_count, 2);
-  EXPECT_EQ(size_count, 1);
+  if (slider->CanResize()) {
+    EXPECT_EQ(drag_count, 2);
+    EXPECT_EQ(size_count, 1);
+  } else {
+    EXPECT_EQ(drag_count, 2);
+    EXPECT_EQ(size_count, 0);
+  }
   EXPECT_EQ(pos, kPos);
   EXPECT_EQ(size, kSize);
 
   pick_drag_release<dim>(*slider, 75 * scale - kOffset);
-  EXPECT_EQ(drag_count, 3);
-  EXPECT_EQ(size_count, 2);
+  if (slider->CanResize()) {
+    EXPECT_EQ(drag_count, 3);
+    EXPECT_EQ(size_count, 2);
+  } else {
+    EXPECT_EQ(drag_count, 3);
+    EXPECT_EQ(size_count, 0);
+  }
   EXPECT_EQ(pos, kPos);
   EXPECT_EQ(size, kSize);
 
+  drag_count = 0;
+  size_count = 0;
+
   pick_drag_release<dim>(*slider, kOffset);
-  EXPECT_EQ(drag_count, 4);
-  EXPECT_EQ(size_count, 2);
+  EXPECT_EQ(drag_count, 1);
+  EXPECT_EQ(size_count, 0);
   EXPECT_NE(pos, kPos);
   EXPECT_EQ(size, kSize);
 
   pick_drag_release<dim>(*slider, 100 * scale - kOffset);
-  EXPECT_EQ(drag_count, 5);
-  EXPECT_EQ(size_count, 2);
+  EXPECT_EQ(drag_count, 2);
+  EXPECT_EQ(size_count, 0);
   EXPECT_NE(pos, kPos);
   EXPECT_EQ(size, kSize);
 }
@@ -143,9 +156,9 @@ void test_scroll(float slider_length = 0.25) {
   auto [slider, canvas] = setup<SliderClass>();
 
   // Use different scales for x and y to make sure dims are chosen correctly
-  float scale = pow(10, dim);
+  int scale = static_cast<int>(pow(10, dim));
   float pos;
-  const float kOffset = 2;
+  const int kOffset = 2;
 
   slider->SetDragCallback([&](float ratio) { pos = ratio; });
   slider->SetSliderLengthRatio(slider_length);
@@ -168,7 +181,7 @@ void test_drag(float slider_length = 0.25) {
   auto [slider, canvas] = setup<SliderClass>();
 
   // Use different scales for x and y to make sure dims are chosen correctly
-  float scale = pow(10, dim);
+  int scale = static_cast<int>(pow(10, dim));
   float pos;
 
   slider->SetDragCallback([&](float ratio) { pos = ratio; });
@@ -181,7 +194,7 @@ void test_drag(float slider_length = 0.25) {
   drag<dim>(*slider, 100 * scale);
   EXPECT_NEAR(pos, 1.f, kEpsilon);
   EXPECT_EQ(slider->GetPosRatio(), pos);
-  drag<dim>(*slider, (100 - slider->GetLengthRatio() * 0.5f * 100) * scale);
+  drag<dim>(*slider, 100 * scale - static_cast<int>(slider->GetPixelLength() / 2));
   EXPECT_NEAR(pos, 1.f, kEpsilon);
 
   // Drag to middle
@@ -215,12 +228,16 @@ template <typename SliderClass, int dim>
 void test_scaling() {
   auto [slider, canvas] = setup<SliderClass>();
 
+  if (!slider->CanResize()) {
+    return;
+  }
+
   float size = 0.5f;
   float pos = 0.5f;
-  const float kOffset = 2;
+  const int kOffset = 2;
 
   // Use different scales for x and y to make sure dims are chosen correctly
-  float scale = pow(10, dim);
+  int scale = static_cast<int>(pow(10, dim));
 
   slider->SetResizeCallback([&](float start, float end) { size = end - start; });
   slider->SetDragCallback([&](float ratio) { pos = ratio; });
@@ -273,12 +290,16 @@ template <typename SliderClass, int dim>
 void test_break_scaling() {
   auto [slider, canvas] = setup<SliderClass>();
 
+  if (!slider->CanResize()) {
+    return;
+  }
+
   float pos;
   float len;
-  const float kOffset = 2;
+  const int kOffset = 2;
 
   // Use different scales for x and y to make sure dims are chosen correctly
-  float scale = pow(10, dim);
+  int scale = static_cast<int>(pow(10, dim));
 
   // Pick on the right, then drag across the end of the slider
   pos = slider->GetPixelPos();

--- a/OrbitGl/SliderTest.cpp
+++ b/OrbitGl/SliderTest.cpp
@@ -1,0 +1,61 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "GlCanvas.h"
+#include "GlSlider.h"
+
+class MockCanvas : public GlCanvas {
+ public:
+  MOCK_METHOD(int, GetWidth, (), (const, override));
+  MOCK_METHOD(int, GetHeight, (), (const, override));
+};
+
+TEST(Slider, Dragging) {
+  using ::testing::Return;
+  const float kEpsilon = 0.01f;
+
+  MockCanvas canvas;
+  // Simulate a 1000x100 canvas
+  EXPECT_CALL(canvas, GetWidth()).WillRepeatedly(Return(1000));
+  EXPECT_CALL(canvas, GetHeight()).WillRepeatedly(Return(100));
+
+  float hpos;
+
+  GlHorizontalSlider hslider;
+  hslider.SetCanvas(&canvas);
+  hslider.SetPixelHeight(10);
+
+  // Set the slider to be 50% of the maximum size, position to the very left
+  hslider.SetSliderPosRatio(0.f);
+  hslider.SetSliderLengthRatio(0.5f);
+
+  hslider.SetDragCallback([&](float ratio) { hpos = ratio; });
+
+  hslider.OnPick(0, 0);
+  hslider.OnDrag(1000, 0);
+
+  // Expect the slider to be dragged all the way to the right
+  // (overshoot, first, then go back to exact drag pos)
+  EXPECT_NEAR(hpos, 1.f, kEpsilon);
+  hslider.OnDrag(500, 0);
+  EXPECT_NEAR(hpos, 1.0f, kEpsilon);
+
+  // Drag to middle
+  hslider.OnDrag(250, 0);
+  EXPECT_NEAR(hpos, 0.5f, kEpsilon);
+
+  // "Invalid" drags sanity check
+  hslider.OnDrag(250, 100);
+  EXPECT_NEAR(hpos, 0.5f, kEpsilon);
+
+  hslider.OnRelease();
+
+  // Tests when picked on the far right
+  hslider.OnPick(500, 0);
+  hslider.OnDrag(500, 0);
+  EXPECT_NEAR(hpos, 0.f, kEpsilon);
+}

--- a/OrbitGl/UnitTestMockEnvironment.cpp
+++ b/OrbitGl/UnitTestMockEnvironment.cpp
@@ -1,0 +1,15 @@
+#include <absl/flags/flag.h>
+
+// Flag declarations
+ABSL_DECLARE_FLAG(bool, devmode);
+ABSL_DECLARE_FLAG(bool, local);
+
+ABSL_DECLARE_FLAG(uint16_t, sampling_rate);
+ABSL_DECLARE_FLAG(bool, frame_pointer_unwinding);
+
+// Flag usages
+ABSL_FLAG(bool, devmode, false, "Enable developer mode in the client's UI");
+ABSL_FLAG(bool, local, false, "Connects to local instance of OrbitService");
+
+ABSL_FLAG(uint16_t, sampling_rate, 1000, "Frequency of callstack sampling in samples per second");
+ABSL_FLAG(bool, frame_pointer_unwinding, false, "Use frame pointers for unwinding");

--- a/OrbitGl/UnitTestMockEnvironment.cpp
+++ b/OrbitGl/UnitTestMockEnvironment.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <absl/flags/flag.h>
 
 // Flag declarations
@@ -7,9 +11,18 @@ ABSL_DECLARE_FLAG(bool, local);
 ABSL_DECLARE_FLAG(uint16_t, sampling_rate);
 ABSL_DECLARE_FLAG(bool, frame_pointer_unwinding);
 
+ABSL_DECLARE_FLAG(bool, enable_tracepoint_feature);
+ABSL_DECLARE_FLAG(bool, show_return_values);
+ABSL_DECLARE_FLAG(bool, enable_frame_pointer_validator);
+
 // Flag usages
 ABSL_FLAG(bool, devmode, false, "Enable developer mode in the client's UI");
 ABSL_FLAG(bool, local, false, "Connects to local instance of OrbitService");
 
 ABSL_FLAG(uint16_t, sampling_rate, 1000, "Frequency of callstack sampling in samples per second");
 ABSL_FLAG(bool, frame_pointer_unwinding, false, "Use frame pointers for unwinding");
+
+ABSL_FLAG(bool, enable_frame_pointer_validator, false, "Enable validation of frame pointers");
+ABSL_FLAG(bool, show_return_values, false, "Show return values on time slices");
+ABSL_FLAG(bool, enable_tracepoint_feature, false,
+          "Enable the setting of the panel of kernel tracepoints");


### PR DESCRIPTION
Sliders are now resizable by clicking a small area at the left or right edge.

Resizing the slider keeps the non-clicked edge fixed and adjust the
currently displayed data window according to the new slider size.

Both sliders support this behavior, but it is only enabled for the horizontal
slider at this point.
Missing for the vertical slider:

- Rendering of the small arrows inside the slider
- Callback implementation in CaptureWindow to react to the resizing
changes of the slider.

New scrollbar:
![image](https://user-images.githubusercontent.com/63750742/95082212-012a6880-071b-11eb-88b6-2f23adae5d59.png)

Clicking highlights only the arrow:
![image](https://user-images.githubusercontent.com/63750742/95082248-0f788480-071b-11eb-8357-f846507cf8ab.png)

Resizing the slider resizes the visible data window:
![image](https://user-images.githubusercontent.com/63750742/95082300-2323eb00-071b-11eb-98b0-9f7b892cbb19.png)

This was a bit of back and forth between the unit tests, integrating the slider into 
the capture window, and rework / bugfixing, so it's not easily separated into
smaller chunks. I rebased it into 4 bigger commits, but some contain issues that
were fixed lateron. Let me know if it's too hard to follow.