### PR TITLE
continued: Remove Module Base Address and Load Bias from FunctionInfo

### DIFF
--- a/OrbitCaptureClient/CaptureClient.cpp
+++ b/OrbitCaptureClient/CaptureClient.cpp
@@ -102,7 +102,8 @@ void CaptureClient::Capture(ProcessData&& process,
         capture_options->add_instrumented_functions();
     instrumented_function->set_file_path(function.loaded_module_path());
     instrumented_function->set_file_offset(FunctionUtils::Offset(function));
-    instrumented_function->set_absolute_address(FunctionUtils::GetAbsoluteAddress(function));
+    instrumented_function->set_absolute_address(FunctionUtils::GetAbsoluteAddress(
+        function, process, *module_map.at(function.loaded_module_path())));
     instrumented_function->set_function_type(
         IntrumentedFunctionTypeFromOrbitType(function.orbit_type()));
   }

--- a/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -25,7 +25,7 @@ using orbit_client_protos::TimerInfo;
 class MyCaptureListener : public CaptureListener {
  private:
   void OnCaptureStarted(
-      ProcessData&& /*process*/, absl::flat_hash_map<std::string, ModuleData*>&& /*module_map*/,
+      ProcessData&& /*process*/,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> /*selected_functions*/,
       TracepointInfoSet /*selected_tracepoints*/) override {}
   void OnCaptureComplete() override {}

--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
@@ -9,6 +9,7 @@
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
 #include "OrbitBase/ThreadPool.h"
+#include "OrbitClientData/ModuleManager.h"
 #include "OrbitClientData/ProcessData.h"
 #include "TracepointCustom.h"
 #include "absl/container/flat_hash_set.h"
@@ -31,7 +32,7 @@ class CaptureClient {
 
   [[nodiscard]] ErrorMessageOr<void> StartCapture(
       ThreadPool* thread_pool, const ProcessData& process,
-      const absl::flat_hash_map<std::string, ModuleData*>& module_map,
+      const OrbitClientData::ModuleManager& module_manager,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints, bool enable_introspection);
 
@@ -54,7 +55,7 @@ class CaptureClient {
   }
 
  private:
-  void Capture(ProcessData&& process, absl::flat_hash_map<std::string, ModuleData*>&& module_map,
+  void Capture(ProcessData&& process, const OrbitClientData::ModuleManager& module_manager,
                absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
                TracepointInfoSet selected_tracepoints, bool enable_introspection);
 

--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
@@ -19,7 +19,7 @@ class CaptureListener {
 
   // Called after capture started but before the first event arrived.
   virtual void OnCaptureStarted(
-      ProcessData&& process, absl::flat_hash_map<std::string, ModuleData*>&& module_map,
+      ProcessData&& process,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints) = 0;
   // Called when capture is complete.

--- a/OrbitClientData/CMakeLists.txt
+++ b/OrbitClientData/CMakeLists.txt
@@ -17,11 +17,13 @@ target_sources(OrbitClientData PUBLIC
         include/OrbitClientData/FunctionInfoSet.h
         include/OrbitClientData/FunctionUtils.h
         include/OrbitClientData/ModuleData.h
+        include/OrbitClientData/ModuleManager.h
         include/OrbitClientData/ProcessData.h)
 
 target_sources(OrbitClientData PRIVATE
         FunctionUtils.cpp
         ModuleData.cpp
+        ModuleManager.cpp
         ProcessData.cpp)
 
 target_link_libraries(OrbitClientData PUBLIC 
@@ -37,6 +39,7 @@ target_compile_options(OrbitClientDataTests PRIVATE ${STRICT_COMPILE_FLAGS})
 target_sources(OrbitClientDataTests PRIVATE
         FunctionInfoSetTest.cpp
         ModuleDataTest.cpp
+        ModuleManagerTest.cpp
         ProcessDataTest.cpp)
 
 target_link_libraries(OrbitClientDataTests PRIVATE 

--- a/OrbitClientData/FunctionInfoSetTest.cpp
+++ b/OrbitClientData/FunctionInfoSetTest.cpp
@@ -14,9 +14,7 @@ TEST(FunctionInfoSet, EqualFunctions) {
   left.set_name("foo");
   left.set_pretty_name("void foo()");
   left.set_loaded_module_path("/path/to/module");
-  left.set_module_base_address(42);
   left.set_address(12);
-  left.set_load_bias(4);
   left.set_size(16);
   left.set_file("file.cpp");
   left.set_line(13);
@@ -25,9 +23,7 @@ TEST(FunctionInfoSet, EqualFunctions) {
   right.set_name("foo");
   right.set_pretty_name("void foo()");
   right.set_loaded_module_path("/path/to/module");
-  right.set_module_base_address(42);
   right.set_address(12);
-  right.set_load_bias(4);
   right.set_size(16);
   right.set_file("file.cpp");
   right.set_line(13);
@@ -43,9 +39,7 @@ TEST(FunctionInfoSet, DifferentName) {
   left.set_name("foo");
   left.set_pretty_name("void foo()");
   left.set_loaded_module_path("/path/to/module");
-  left.set_module_base_address(42);
   left.set_address(12);
-  left.set_load_bias(4);
   left.set_size(16);
   left.set_file("file.cpp");
   left.set_line(13);
@@ -63,9 +57,7 @@ TEST(FunctionInfoSet, DifferentPrettyName) {
   left.set_name("foo");
   left.set_pretty_name("void foo()");
   left.set_loaded_module_path("/path/to/module");
-  left.set_module_base_address(42);
   left.set_address(12);
-  left.set_load_bias(4);
   left.set_size(16);
   left.set_file("file.cpp");
   left.set_line(13);
@@ -83,9 +75,7 @@ TEST(FunctionInfoSet, DifferentLoadedModulePath) {
   left.set_name("foo");
   left.set_pretty_name("void foo()");
   left.set_loaded_module_path("/path/to/module");
-  left.set_module_base_address(42);
   left.set_address(12);
-  left.set_load_bias(4);
   left.set_size(16);
   left.set_file("file.cpp");
   left.set_line(13);
@@ -98,34 +88,12 @@ TEST(FunctionInfoSet, DifferentLoadedModulePath) {
   EXPECT_FALSE(eq(left, right));
 }
 
-TEST(FunctionInfoSet, DifferentModuleBaseAddress) {
-  FunctionInfo left;
-  left.set_name("foo");
-  left.set_pretty_name("void foo()");
-  left.set_loaded_module_path("/path/to/module");
-  left.set_module_base_address(42);
-  left.set_address(12);
-  left.set_load_bias(4);
-  left.set_size(16);
-  left.set_file("file.cpp");
-  left.set_line(13);
-
-  FunctionInfo right;
-  right.CopyFrom(left);
-  right.set_module_base_address(43);
-
-  internal::EqualFunctionInfo eq;
-  EXPECT_FALSE(eq(left, right));
-}
-
 TEST(FunctionInfoSet, DifferentAddress) {
   FunctionInfo left;
   left.set_name("foo");
   left.set_pretty_name("void foo()");
   left.set_loaded_module_path("/path/to/module");
-  left.set_module_base_address(42);
   left.set_address(12);
-  left.set_load_bias(4);
   left.set_size(16);
   left.set_file("file.cpp");
   left.set_line(13);
@@ -138,34 +106,12 @@ TEST(FunctionInfoSet, DifferentAddress) {
   EXPECT_FALSE(eq(left, right));
 }
 
-TEST(FunctionInfoSet, DifferentLoadBias) {
-  FunctionInfo left;
-  left.set_name("foo");
-  left.set_pretty_name("void foo()");
-  left.set_loaded_module_path("/path/to/module");
-  left.set_module_base_address(42);
-  left.set_address(12);
-  left.set_load_bias(4);
-  left.set_size(16);
-  left.set_file("file.cpp");
-  left.set_line(13);
-
-  FunctionInfo right;
-  right.CopyFrom(left);
-  right.set_load_bias(3);
-
-  internal::EqualFunctionInfo eq;
-  EXPECT_FALSE(eq(left, right));
-}
-
 TEST(FunctionInfoSet, DifferentSize) {
   FunctionInfo left;
   left.set_name("foo");
   left.set_pretty_name("void foo()");
   left.set_loaded_module_path("/path/to/module");
-  left.set_module_base_address(42);
   left.set_address(12);
-  left.set_load_bias(4);
   left.set_size(16);
   left.set_file("file.cpp");
   left.set_line(13);
@@ -183,9 +129,7 @@ TEST(FunctionInfoSet, DifferentFile) {
   left.set_name("foo");
   left.set_pretty_name("void foo()");
   left.set_loaded_module_path("/path/to/module");
-  left.set_module_base_address(42);
   left.set_address(12);
-  left.set_load_bias(4);
   left.set_size(16);
   left.set_file("file.cpp");
   left.set_line(13);
@@ -203,9 +147,7 @@ TEST(FunctionInfoSet, DifferentLine) {
   left.set_name("foo");
   left.set_pretty_name("void foo()");
   left.set_loaded_module_path("/path/to/module");
-  left.set_module_base_address(42);
   left.set_address(12);
-  left.set_load_bias(4);
   left.set_size(16);
   left.set_file("file.cpp");
   left.set_line(13);
@@ -223,9 +165,7 @@ TEST(FunctionInfoSet, Insertion) {
   function.set_name("foo");
   function.set_pretty_name("void foo()");
   function.set_loaded_module_path("/path/to/module");
-  function.set_module_base_address(42);
   function.set_address(12);
-  function.set_load_bias(4);
   function.set_size(16);
   function.set_file("file.cpp");
   function.set_line(13);
@@ -245,9 +185,7 @@ TEST(FunctionInfoSet, Deletion) {
   function.set_name("foo");
   function.set_pretty_name("void foo()");
   function.set_loaded_module_path("/path/to/module");
-  function.set_module_base_address(42);
   function.set_address(12);
-  function.set_load_bias(4);
   function.set_size(16);
   function.set_file("file.cpp");
   function.set_line(13);

--- a/OrbitClientData/FunctionUtils.cpp
+++ b/OrbitClientData/FunctionUtils.cpp
@@ -28,24 +28,23 @@ std::string GetLoadedModuleName(const FunctionInfo& func) {
 
 uint64_t GetHash(const FunctionInfo& func) { return StringHash(func.pretty_name()); }
 
-uint64_t Offset(const FunctionInfo& func) { return func.address() - func.load_bias(); }
+uint64_t Offset(const FunctionInfo& func, const ModuleData& module) {
+  return func.address() - module.load_bias();
+}
 
 bool IsOrbitFunc(const FunctionInfo& func) { return func.orbit_type() != FunctionInfo::kNone; }
 
-std::unique_ptr<FunctionInfo> CreateFunctionInfo(const SymbolInfo& symbol_info, uint64_t load_bias,
-                                                 const std::string& module_path,
-                                                 uint64_t module_base_address) {
+std::unique_ptr<FunctionInfo> CreateFunctionInfo(const SymbolInfo& symbol_info,
+                                                 const std::string& module_path) {
   auto function_info = std::make_unique<FunctionInfo>();
 
   function_info->set_name(symbol_info.name());
   function_info->set_pretty_name(symbol_info.demangled_name());
   function_info->set_address(symbol_info.address());
-  function_info->set_load_bias(load_bias);
   function_info->set_size(symbol_info.size());
   function_info->set_file("");
   function_info->set_line(0);
   function_info->set_loaded_module_path(module_path);
-  function_info->set_module_base_address(module_base_address);
 
   SetOrbitTypeFromName(function_info.get());
   return function_info;

--- a/OrbitClientData/ModuleDataTest.cpp
+++ b/OrbitClientData/ModuleDataTest.cpp
@@ -44,11 +44,8 @@ TEST(ModuleData, Constructor) {
 TEST(ModuleData, LoadSymbols) {
   // Setup ModuleData
   std::string module_file_path = "/test/file/path";
-  uint64_t module_base_start = 0x40;
-  uint64_t module_load_bias = 0x400;
   ModuleInfo module_info{};
   module_info.set_file_path(module_file_path);
-  module_info.set_load_bias(module_load_bias);
   ModuleData module{module_info};
 
   // Setup ModuleSymbols
@@ -65,7 +62,7 @@ TEST(ModuleData, LoadSymbols) {
   symbol_info->set_size(symbol_size);
 
   // Test
-  module.AddSymbols(module_symbols, module_base_start);
+  module.AddSymbols(module_symbols);
   EXPECT_TRUE(module.is_loaded());
 
   ASSERT_EQ(module.GetFunctions().size(), 1);
@@ -74,41 +71,10 @@ TEST(ModuleData, LoadSymbols) {
   EXPECT_EQ(function->name(), symbol_name);
   EXPECT_EQ(function->pretty_name(), symbol_pretty_name);
   EXPECT_EQ(function->loaded_module_path(), module_file_path);
-  EXPECT_EQ(function->module_base_address(), module_base_start);
   EXPECT_EQ(function->address(), symbol_address);
-  EXPECT_EQ(function->load_bias(), module_load_bias);
   EXPECT_EQ(function->size(), symbol_size);
   EXPECT_EQ(function->file(), "");
   EXPECT_EQ(function->line(), 0);
-}
-
-TEST(ModuleData, UpdateFunctionsModuleBaseAddress) {
-  ModuleData module{ModuleInfo{}};
-
-  ModuleSymbols symbols{};
-  SymbolInfo* symbol = symbols.add_symbol_infos();
-  symbol->set_name("test name");
-
-  module.AddSymbols(symbols, 0);
-
-  ASSERT_TRUE(module.is_loaded());
-  ASSERT_EQ(module.GetFunctions().size(), 1);
-
-  {
-    const FunctionInfo* function = module.GetFunctions()[0];
-    EXPECT_EQ(function->name(), "test name");
-    EXPECT_EQ(function->module_base_address(), 0);
-  }
-  module.UpdateFunctionsModuleBaseAddress(100);
-
-  ASSERT_TRUE(module.is_loaded());
-  ASSERT_EQ(module.GetFunctions().size(), 1);
-
-  {
-    const FunctionInfo* function = module.GetFunctions()[0];
-    EXPECT_EQ(function->name(), "test name");
-    EXPECT_EQ(function->module_base_address(), 100);
-  }
 }
 
 TEST(ModuleData, FindFunctionByRelativeAddress) {
@@ -130,7 +96,7 @@ TEST(ModuleData, FindFunctionByRelativeAddress) {
 
   ModuleData module{ModuleInfo{}};
 
-  module.AddSymbols(symbols, 1000);
+  module.AddSymbols(symbols);
   EXPECT_TRUE(module.is_loaded());
 
   // Find exact
@@ -192,7 +158,7 @@ TEST(ModuleData, FindFunctionFromHash) {
   symbol->set_name("Symbol Name");
 
   ModuleData module{ModuleInfo{}};
-  module.AddSymbols(symbols, 0);
+  module.AddSymbols(symbols);
 
   ASSERT_TRUE(module.is_loaded());
   ASSERT_FALSE(module.GetFunctions().empty());

--- a/OrbitClientData/ModuleManager.cpp
+++ b/OrbitClientData/ModuleManager.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "OrbitClientData/ModuleManager.h"
+
+#include <vector>
+
+#include "OrbitBase/Logging.h"
+#include "absl/synchronization/mutex.h"
+#include "capture_data.pb.h"
+
+using orbit_client_protos::FunctionInfo;
+
+namespace OrbitClientData {
+
+void ModuleManager::AddNewModules(const std::vector<orbit_grpc_protos::ModuleInfo>& module_infos) {
+  absl::MutexLock lock(&mutex_);
+
+  for (const auto& module_info : module_infos) {
+    auto module_it = module_map_.find(module_info.file_path());
+    if (module_it == module_map_.end()) {
+      const auto [inserted_it, success] =
+          module_map_.try_emplace(module_info.file_path(), module_info);
+      CHECK(success);
+    }
+  }
+}
+
+const ModuleData* ModuleManager::GetModuleByPath(const std::string& path) const {
+  absl::MutexLock lock(&mutex_);
+
+  auto it = module_map_.find(path);
+  if (it == module_map_.end()) return nullptr;
+
+  return &it->second;
+}
+
+ModuleData* ModuleManager::GetMutableModuleByPath(const std::string& path) {
+  absl::MutexLock lock(&mutex_);
+
+  auto it = module_map_.find(path);
+  if (it == module_map_.end()) return nullptr;
+
+  return &it->second;
+}
+
+std::vector<FunctionInfo> ModuleManager::GetOrbitFunctionsOfProcess(
+    const ProcessData& process) const {
+  absl::MutexLock lock(&mutex_);
+
+  std::vector<FunctionInfo> result;
+
+  for (const auto& [module_path, _] : process.GetMemoryMap()) {
+    auto it = module_map_.find(module_path);
+    CHECK(it != module_map_.end());
+    const ModuleData* module = &it->second;
+    CHECK(module != nullptr);
+    if (!module->is_loaded()) continue;
+
+    const std::vector<FunctionInfo>& orbit_functions = module->GetOrbitFunctions();
+    result.insert(result.end(), orbit_functions.begin(), orbit_functions.end());
+  }
+  return result;
+}
+
+}  // namespace OrbitClientData

--- a/OrbitClientData/ModuleManagerTest.cpp
+++ b/OrbitClientData/ModuleManagerTest.cpp
@@ -1,0 +1,202 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "OrbitClientData/ModuleData.h"
+#include "OrbitClientData/ModuleManager.h"
+#include "capture_data.pb.h"
+#include "module.pb.h"
+#include "symbol.pb.h"
+
+namespace OrbitClientData {
+
+using orbit_client_protos::FunctionInfo;
+using orbit_grpc_protos::ModuleInfo;
+using orbit_grpc_protos::ModuleSymbols;
+using orbit_grpc_protos::ProcessInfo;
+using orbit_grpc_protos::SymbolInfo;
+
+TEST(ModuleManager, GetModuleByPath) {
+  std::string name = "name of module";
+  std::string file_path = "path/of/module";
+  uint64_t file_size = 300;
+  std::string build_id = "build id example";
+  uint64_t load_bias = 0x400;
+
+  ModuleInfo module_info;
+  module_info.set_name(name);
+  module_info.set_file_path(file_path);
+  module_info.set_file_size(file_size);
+  module_info.set_build_id(build_id);
+  module_info.set_load_bias(load_bias);
+
+  ModuleManager module_manager;
+  module_manager.AddNewModules({module_info});
+
+  const ModuleData* module = module_manager.GetModuleByPath(file_path);
+  ASSERT_NE(module, nullptr);
+  EXPECT_EQ(module->name(), name);
+  EXPECT_EQ(module->file_path(), file_path);
+  EXPECT_EQ(module->file_size(), file_size);
+  EXPECT_EQ(module->build_id(), build_id);
+  EXPECT_EQ(module->load_bias(), load_bias);
+
+  const ModuleData* non_existing_module = module_manager.GetModuleByPath("wrong/path");
+  EXPECT_EQ(non_existing_module, nullptr);
+}
+
+TEST(ModuleManager, GetMutableModuleByPath) {
+  std::string name = "name of module";
+  std::string file_path = "path/of/module";
+  uint64_t file_size = 300;
+  std::string build_id = "build id example";
+  uint64_t load_bias = 0x400;
+
+  ModuleInfo module_info;
+  module_info.set_name(name);
+  module_info.set_file_path(file_path);
+  module_info.set_file_size(file_size);
+  module_info.set_build_id(build_id);
+  module_info.set_load_bias(load_bias);
+
+  ModuleManager module_manager;
+  module_manager.AddNewModules({module_info});
+
+  ModuleData* module = module_manager.GetMutableModuleByPath(file_path);
+  ASSERT_NE(module, nullptr);
+  EXPECT_EQ(module->name(), name);
+  EXPECT_EQ(module->file_path(), file_path);
+  EXPECT_EQ(module->file_size(), file_size);
+  EXPECT_EQ(module->build_id(), build_id);
+  EXPECT_EQ(module->load_bias(), load_bias);
+
+  EXPECT_FALSE(module->is_loaded());
+  module->AddSymbols({});
+  EXPECT_TRUE(module->is_loaded());
+
+  ModuleData* non_existing_module = module_manager.GetMutableModuleByPath("wrong/path");
+  EXPECT_EQ(non_existing_module, nullptr);
+}
+
+TEST(ModuleManager, AddNewModules) {
+  std::string name = "name of module";
+  std::string file_path = "path/of/module";
+  uint64_t file_size = 300;
+  std::string build_id = "build id example";
+  uint64_t load_bias = 0x400;
+
+  ModuleInfo module_info;
+  module_info.set_name(name);
+  module_info.set_file_path(file_path);
+  module_info.set_file_size(file_size);
+  module_info.set_build_id(build_id);
+  module_info.set_load_bias(load_bias);
+
+  ModuleManager module_manager;
+  module_manager.AddNewModules({module_info});
+  {
+    const ModuleData* module = module_manager.GetModuleByPath(file_path);
+    ASSERT_NE(module, nullptr);
+    EXPECT_EQ(module->name(), name);
+  }
+
+  // change name and add again (should not be added again, since module is identified by file path)
+  std::string different_name = "different name";
+  module_info.set_name(different_name);
+  module_manager.AddNewModules({module_info});
+  {
+    const ModuleData* module = module_manager.GetModuleByPath(file_path);
+    ASSERT_NE(module, nullptr);
+    EXPECT_EQ(module->name(), name);
+    EXPECT_NE(module->name(), different_name);
+  }
+
+  // change file path and add again (should be added again, because it is now considered a different
+  // module)
+  std::string different_path = "different/path/of/module";
+  module_info.set_file_path(different_path);
+  module_manager.AddNewModules({module_info});
+  {
+    // original module
+    const ModuleData* module = module_manager.GetModuleByPath(file_path);
+    ASSERT_NE(module, nullptr);
+    EXPECT_EQ(module->name(), name);
+    EXPECT_NE(module->name(), different_name);
+  }
+  {
+    // second module
+    const ModuleData* module = module_manager.GetModuleByPath(different_path);
+    ASSERT_NE(module, nullptr);
+    EXPECT_EQ(module->name(), different_name);
+    EXPECT_NE(module->name(), name);
+    EXPECT_EQ(module->file_path(), different_path);
+    EXPECT_NE(module->file_path(), file_path);
+  }
+}
+
+TEST(ModuleManager, GetOrbitFunctionsOfProcess) {
+  std::string name = "name of module";
+  std::string file_path = "path/of/module";
+  uint64_t file_size = 300;
+  std::string build_id = "build id example";
+  uint64_t load_bias = 0x400;
+  uint64_t address_start = 100;
+  uint64_t address_end = 1000;
+
+  ModuleInfo module_info;
+  module_info.set_name(name);
+  module_info.set_file_path(file_path);
+  module_info.set_file_size(file_size);
+  module_info.set_build_id(build_id);
+  module_info.set_load_bias(load_bias);
+  module_info.set_address_start(address_start);
+  module_info.set_address_end(address_end);
+
+  ModuleManager module_manager;
+  module_manager.AddNewModules({module_info});
+
+  ProcessInfo process_info;
+  ProcessData process{process_info};
+
+  {
+    // process does not have any modules loaded
+    std::vector<FunctionInfo> functions = module_manager.GetOrbitFunctionsOfProcess(process);
+    EXPECT_TRUE(functions.empty());
+  }
+
+  process.UpdateModuleInfos({module_info});
+  {
+    // process has module loaded, but module does not have symbols loaded
+    std::vector<FunctionInfo> functions = module_manager.GetOrbitFunctionsOfProcess(process);
+    EXPECT_TRUE(functions.empty());
+  }
+
+  ModuleSymbols module_symbols;
+  {
+    SymbolInfo* symbol_info = module_symbols.add_symbol_infos();
+    symbol_info->set_name("not an orbit function");
+  }
+  {
+    SymbolInfo* symbol_info = module_symbols.add_symbol_infos();
+    symbol_info->set_name("orbit_api::Start()");
+    symbol_info->set_address(500);
+  }
+
+  ModuleData* module = module_manager.GetMutableModuleByPath(file_path);
+  module->AddSymbols(module_symbols);
+
+  {
+    // process has module loaded and module has functions loaded. One of the functions is an orbit
+    // function
+    std::vector<FunctionInfo> functions = module_manager.GetOrbitFunctionsOfProcess(process);
+    ASSERT_EQ(functions.size(), 1);
+
+    FunctionInfo& function{functions[0]};
+    EXPECT_EQ(function.name(), "orbit_api::Start()");
+    EXPECT_EQ(function.address(), 500);
+  }
+}
+
+}  // namespace OrbitClientData

--- a/OrbitClientData/ProcessData.cpp
+++ b/OrbitClientData/ProcessData.cpp
@@ -60,8 +60,3 @@ ErrorMessageOr<std::pair<std::string, uint64_t>> ProcessData::FindModuleByAddres
 
   return std::make_pair(module_path, memory_space.start);
 }
-
-void ProcessData::AddSymbols(ModuleData* module, const ModuleSymbols& module_symbols) const {
-  uint64_t module_base_address = module_memory_map_.at(module->file_path()).start;
-  module->AddSymbols(module_symbols, module_base_address);
-}

--- a/OrbitClientData/include/OrbitClientData/FunctionInfoSet.h
+++ b/OrbitClientData/include/OrbitClientData/FunctionInfoSet.h
@@ -5,8 +5,8 @@
 #ifndef ORBIT_CLIENT_DATA_FUNCTION_INFO_SET_H_
 #define ORBIT_CLIENT_DATA_FUNCTION_INFO_SET_H_
 
-#include <absl/container/flat_hash_set.h>
-
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
 #include "capture_data.pb.h"
 
 namespace internal {
@@ -32,6 +32,11 @@ struct EqualFunctionInfo {
 
 using FunctionInfoSet =
     absl::flat_hash_set<orbit_client_protos::FunctionInfo, internal::HashFunctionInfo,
+                        internal::EqualFunctionInfo>;
+
+template <class V>
+using FunctionInfoMap =
+    absl::flat_hash_map<orbit_client_protos::FunctionInfo, V, internal::HashFunctionInfo,
                         internal::EqualFunctionInfo>;
 
 #endif  // ORBIT_CLIENT_DATA_FUNCTION_INFO_SET_H_

--- a/OrbitClientData/include/OrbitClientData/FunctionInfoSet.h
+++ b/OrbitClientData/include/OrbitClientData/FunctionInfoSet.h
@@ -22,9 +22,8 @@ struct EqualFunctionInfo {
     return left.size() == right.size() && left.name() == right.name() &&
            left.pretty_name() == right.pretty_name() &&
            left.loaded_module_path() == right.loaded_module_path() &&
-           left.module_base_address() == right.module_base_address() &&
-           left.address() == right.address() && left.load_bias() == right.load_bias() &&
-           left.file().compare(right.file()) == 0 && left.line() == right.line();
+           left.address() == right.address() && left.file().compare(right.file()) == 0 &&
+           left.line() == right.line();
   }
 };
 

--- a/OrbitClientData/include/OrbitClientData/FunctionUtils.h
+++ b/OrbitClientData/include/OrbitClientData/FunctionUtils.h
@@ -13,22 +13,23 @@
 
 namespace FunctionUtils {
 
-inline const std::string& GetDisplayName(const orbit_client_protos::FunctionInfo& func) {
+[[nodiscard]] inline const std::string& GetDisplayName(
+    const orbit_client_protos::FunctionInfo& func) {
   return func.pretty_name().empty() ? func.name() : func.pretty_name();
 }
 
-std::string GetLoadedModuleName(const orbit_client_protos::FunctionInfo& func);
-uint64_t GetHash(const orbit_client_protos::FunctionInfo& func);
+[[nodiscard]] std::string GetLoadedModuleName(const orbit_client_protos::FunctionInfo& func);
+[[nodiscard]] uint64_t GetHash(const orbit_client_protos::FunctionInfo& func);
 
 // Calculates and returns the absolute address of the function.
-uint64_t Offset(const orbit_client_protos::FunctionInfo& func);
-inline uint64_t GetAbsoluteAddress(const orbit_client_protos::FunctionInfo& func) {
+[[nodiscard]] uint64_t Offset(const orbit_client_protos::FunctionInfo& func);
+[[nodiscard]] inline uint64_t GetAbsoluteAddress(const orbit_client_protos::FunctionInfo& func) {
   return func.address() + func.module_base_address() - func.load_bias();
 }
 
-bool IsOrbitFunc(const orbit_client_protos::FunctionInfo& func);
+[[nodiscard]] bool IsOrbitFunc(const orbit_client_protos::FunctionInfo& func);
 
-std::unique_ptr<orbit_client_protos::FunctionInfo> CreateFunctionInfo(
+[[nodiscard]] std::unique_ptr<orbit_client_protos::FunctionInfo> CreateFunctionInfo(
     const orbit_grpc_protos::SymbolInfo& symbol_info, uint64_t load_bias,
     const std::string& module_path, uint64_t module_base_address);
 

--- a/OrbitClientData/include/OrbitClientData/FunctionUtils.h
+++ b/OrbitClientData/include/OrbitClientData/FunctionUtils.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef ORBIT_CORE_FUNCTION_UTILS_H_
-#define ORBIT_CORE_FUNCTION_UTILS_H_
+#ifndef ORBIT_CLIENT_DATA_FUNCTION_UTILS_H_
+#define ORBIT_CLIENT_DATA_FUNCTION_UTILS_H_
 
 #include <cstdint>
 #include <string>
@@ -23,10 +23,8 @@ namespace FunctionUtils {
 [[nodiscard]] uint64_t GetHash(const orbit_client_protos::FunctionInfo& func);
 
 // Calculates and returns the absolute address of the function.
-[[nodiscard]] uint64_t Offset(const orbit_client_protos::FunctionInfo& func);
-[[nodiscard]] inline uint64_t GetAbsoluteAddress(const orbit_client_protos::FunctionInfo& func) {
-  return func.address() + func.module_base_address() - func.load_bias();
-}
+[[nodiscard]] uint64_t Offset(const orbit_client_protos::FunctionInfo& func,
+                              const ModuleData& module);
 [[nodiscard]] inline uint64_t GetAbsoluteAddress(const orbit_client_protos::FunctionInfo& func,
                                                  const ProcessData& process,
                                                  const ModuleData& module) {
@@ -37,8 +35,7 @@ namespace FunctionUtils {
 [[nodiscard]] bool IsOrbitFunc(const orbit_client_protos::FunctionInfo& func);
 
 [[nodiscard]] std::unique_ptr<orbit_client_protos::FunctionInfo> CreateFunctionInfo(
-    const orbit_grpc_protos::SymbolInfo& symbol_info, uint64_t load_bias,
-    const std::string& module_path, uint64_t module_base_address);
+    const orbit_grpc_protos::SymbolInfo& symbol_info, const std::string& module_path);
 
 bool SetOrbitTypeFromName(orbit_client_protos::FunctionInfo* func);
 

--- a/OrbitClientData/include/OrbitClientData/FunctionUtils.h
+++ b/OrbitClientData/include/OrbitClientData/FunctionUtils.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <string>
 
+#include "ProcessData.h"
 #include "capture_data.pb.h"
 #include "symbol.pb.h"
 
@@ -25,6 +26,12 @@ namespace FunctionUtils {
 [[nodiscard]] uint64_t Offset(const orbit_client_protos::FunctionInfo& func);
 [[nodiscard]] inline uint64_t GetAbsoluteAddress(const orbit_client_protos::FunctionInfo& func) {
   return func.address() + func.module_base_address() - func.load_bias();
+}
+[[nodiscard]] inline uint64_t GetAbsoluteAddress(const orbit_client_protos::FunctionInfo& func,
+                                                 const ProcessData& process,
+                                                 const ModuleData& module) {
+  return func.address() + process.GetModuleBaseAddress(func.loaded_module_path()) -
+         module.load_bias();
 }
 
 [[nodiscard]] bool IsOrbitFunc(const orbit_client_protos::FunctionInfo& func);

--- a/OrbitClientData/include/OrbitClientData/ModuleData.h
+++ b/OrbitClientData/include/OrbitClientData/ModuleData.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef ORBIT_GL_MODULE_DATA_H_
-#define ORBIT_GL_MODULE_DATA_H_
+#ifndef ORBIT_CLIENT_DATA_MODULE_DATA_H_
+#define ORBIT_CLIENT_DATA_MODULE_DATA_H_
 
 #include <cinttypes>
 #include <memory>
@@ -30,21 +30,13 @@ class ModuleData final {
   [[nodiscard]] const std::string& build_id() const { return module_info_.build_id(); }
   [[nodiscard]] uint64_t load_bias() const { return module_info_.load_bias(); }
   [[nodiscard]] bool is_loaded() const;
-
   // relative_address here is the absolute address minus the address this module was loaded at by
   // the process (module base address)
   [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionByRelativeAddress(
       uint64_t relative_address, bool is_exact) const;
   [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionByElfAddress(
       uint64_t elf_address, bool is_exact) const;
-  // TODO(169309553): The module_base_address parameter should not be needed here, but it is
-  // because FunctionInfo still contains the field module_base_address. As soon as that field is
-  // gone, remove the parameter here
-  void AddSymbols(const orbit_grpc_protos::ModuleSymbols& module_symbols,
-                  uint64_t module_base_address);
-  // TODO(169309553): As soon as FunctionInfo does not contain module_base_address anymore,
-  // completely remove the following method
-  void UpdateFunctionsModuleBaseAddress(uint64_t module_base_address);
+  void AddSymbols(const orbit_grpc_protos::ModuleSymbols& module_symbols);
   [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionFromHash(uint64_t hash) const;
   [[nodiscard]] const std::vector<const orbit_client_protos::FunctionInfo*> GetFunctions() const;
   [[nodiscard]] std::vector<orbit_client_protos::FunctionInfo> GetOrbitFunctions() const;

--- a/OrbitClientData/include/OrbitClientData/ModuleManager.h
+++ b/OrbitClientData/include/OrbitClientData/ModuleManager.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_CLIENT_DATA_MODULE_MANAGER_H_
+#define ORBIT_CLIENT_DATA_MODULE_MANAGER_H_
+
+#include <vector>
+
+#include "OrbitClientData/ModuleData.h"
+#include "OrbitClientData/ProcessData.h"
+#include "absl/container/node_hash_map.h"
+#include "absl/synchronization/mutex.h"
+#include "capture_data.pb.h"
+#include "module.pb.h"
+
+namespace OrbitClientData {
+
+class ModuleManager final {
+ public:
+  explicit ModuleManager() = default;
+
+  [[nodiscard]] const ModuleData* GetModuleByPath(const std::string& path) const;
+  [[nodiscard]] ModuleData* GetMutableModuleByPath(const std::string& path);
+  void AddNewModules(const std::vector<orbit_grpc_protos::ModuleInfo>& module_infos);
+  [[nodiscard]] std::vector<orbit_client_protos::FunctionInfo> GetOrbitFunctionsOfProcess(
+      const ProcessData& process) const;
+
+ private:
+  mutable absl::Mutex mutex_;
+  // We are sharing pointers to that entries and ensure reference stability by using node_hash_map
+  absl::node_hash_map<std::string, ModuleData> module_map_;
+};
+
+}  // namespace OrbitClientData
+
+#endif

--- a/OrbitClientData/include/OrbitClientData/ProcessData.h
+++ b/OrbitClientData/include/OrbitClientData/ProcessData.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef ORBIT_GL_PROCESS_DATA_H_
-#define ORBIT_GL_PROCESS_DATA_H_
+#ifndef ORBIT_CLIENT_DATA_PROCESS_DATA_H_
+#define ORBIT_CLIENT_DATA_PROCESS_DATA_H_
 
 #include <memory>
 #include <utility>
@@ -55,9 +55,6 @@ class ProcessData final {
   [[nodiscard]] ErrorMessageOr<std::pair<std::string, uint64_t>> FindModuleByAddress(
       uint64_t absolute_address) const;
 
-  // TODO(169309553): remove this function and add symbols directly into a module, as soon as the
-  // module_base_address is not needed anymore (FunctionInfo needs to be changed)
-  void AddSymbols(ModuleData* module, const orbit_grpc_protos::ModuleSymbols& module_symbols) const;
   uint64_t GetModuleBaseAddress(const std::string& module_path) const {
     CHECK(module_memory_map_.contains(module_path));
     return module_memory_map_.at(module_path).start;

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -248,7 +248,7 @@ absl::flat_hash_map<uint64_t, FunctionInfo> ClientGgp::GetSelectedFunctions() {
   for (const FunctionInfo* func : main_module_->GetFunctions()) {
     const std::string& selected_function_match = SelectedFunctionMatch(*func);
     if (!selected_function_match.empty()) {
-      uint64_t address = FunctionUtils::GetAbsoluteAddress(*func);
+      uint64_t address = FunctionUtils::GetAbsoluteAddress(*func, target_process_, *main_module_);
       selected_functions[address] = *func;
       if (!capture_functions_used.contains(selected_function_match)) {
         capture_functions_used.insert(selected_function_match);

--- a/OrbitClientGgp/include/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/include/OrbitClientGgp/ClientGgp.h
@@ -13,6 +13,7 @@
 #include "OrbitBase/Result.h"
 #include "OrbitCaptureClient/CaptureClient.h"
 #include "OrbitCaptureClient/CaptureListener.h"
+#include "OrbitClientData/ModuleManager.h"
 #include "OrbitClientData/ProcessData.h"
 #include "OrbitClientGgp/ClientGgpOptions.h"
 #include "OrbitClientServices/ProcessClient.h"
@@ -31,7 +32,7 @@ class ClientGgp final : public CaptureListener {
 
   // CaptureListener implementation
   void OnCaptureStarted(
-      ProcessData&& process, absl::flat_hash_map<std::string, ModuleData*>&& module_map,
+      ProcessData&& process,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints) override;
   void OnCaptureComplete() override;
@@ -52,8 +53,7 @@ class ClientGgp final : public CaptureListener {
   ClientGgpOptions options_;
   std::shared_ptr<grpc::Channel> grpc_channel_;
   ProcessData target_process_;
-  absl::flat_hash_set<std::unique_ptr<ModuleData>> modules_;
-  absl::flat_hash_map<std::string, ModuleData*> module_map_;
+  OrbitClientData::ModuleManager module_manager_;
   absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions_;
   ModuleData* main_module_;
   std::shared_ptr<StringManager> string_manager_;

--- a/OrbitClientModel/CaptureSerializer.cpp
+++ b/OrbitClientModel/CaptureSerializer.cpp
@@ -18,6 +18,8 @@ using orbit_client_protos::CallstackInfo;
 using orbit_client_protos::CaptureInfo;
 using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::FunctionStats;
+using orbit_client_protos::ModuleInfo;
+using orbit_client_protos::ProcessInfo;
 
 namespace {
 inline constexpr std::string_view kFileOrbitExtension = ".orbit";
@@ -57,8 +59,26 @@ CaptureInfo GenerateCaptureInfo(
     capture_info.add_selected_functions()->CopyFrom(pair.second);
   }
 
-  capture_info.set_process_id(capture_data.process_id());
-  capture_info.set_process_name(capture_data.process_name());
+  ProcessInfo* process = capture_info.mutable_process();
+  process->set_pid(capture_data.process()->pid());
+  process->set_name(capture_data.process()->name());
+  process->set_cpu_usage(capture_data.process()->cpu_usage());
+  process->set_full_path(capture_data.process()->full_path());
+  process->set_command_line(capture_data.process()->command_line());
+  process->set_is_64_bit(capture_data.process()->is_64_bit());
+
+  for (const auto& [module_path, memory_space] : capture_data.process()->GetMemoryMap()) {
+    const ModuleData* module = capture_data.GetModuleByPath(module_path);
+    CHECK(module != nullptr);
+    ModuleInfo* module_info = capture_info.add_modules();
+    module_info->set_name(module->name());
+    module_info->set_file_path(module->file_path());
+    module_info->set_file_size(module->file_size());
+    module_info->set_address_start(memory_space.start);
+    module_info->set_address_end(memory_space.end);
+    module_info->set_build_id(module->build_id());
+    module_info->set_load_bias(module->load_bias());
+  }
 
   capture_info.mutable_thread_names()->insert(capture_data.thread_names().begin(),
                                               capture_data.thread_names().end());
@@ -93,10 +113,9 @@ CaptureInfo GenerateCaptureInfo(
   }
 
   const FunctionInfoMap<FunctionStats>& functions_stats = capture_data.functions_stats();
-  for (const auto& function_to_stats : functions_stats) {
-    const FunctionInfo& function = function_to_stats.first;
+  for (const auto& [function, stats] : functions_stats) {
     uint64_t absolute_address = capture_data.GetAbsoluteAddress(function);
-    capture_info.mutable_function_stats()->operator[](absolute_address) = function_to_stats.second;
+    capture_info.mutable_function_stats()->operator[](absolute_address) = stats;
   }
 
   // TODO: this is not really synchronized, since GetCallstackData processing below is not under the

--- a/OrbitClientModel/include/OrbitClientModel/CaptureDeserializer.h
+++ b/OrbitClientModel/include/OrbitClientModel/CaptureDeserializer.h
@@ -12,6 +12,7 @@
 #include "CaptureData.h"
 #include "OrbitBase/Result.h"
 #include "OrbitCaptureClient/CaptureListener.h"
+#include "OrbitClientData/ModuleManager.h"
 #include "capture_data.pb.h"
 #include "google/protobuf/io/coded_stream.h"
 #include "google/protobuf/io/zero_copy_stream_impl.h"
@@ -20,8 +21,10 @@
 namespace capture_deserializer {
 
 void Load(std::istream& stream, const std::string& file_name, CaptureListener* capture_listener,
+          OrbitClientData::ModuleManager* module_manager,
           std::atomic<bool>* cancellation_requested);
 void Load(const std::string& file_name, CaptureListener* capture_listener,
+          OrbitClientData::ModuleManager* module_manager,
           std::atomic<bool>* cancellation_requested);
 
 namespace internal {
@@ -30,10 +33,11 @@ bool ReadMessage(google::protobuf::Message* message, google::protobuf::io::Coded
 
 void LoadCaptureInfo(const orbit_client_protos::CaptureInfo& capture_info,
                      CaptureListener* capture_listener,
+                     OrbitClientData::ModuleManager* module_manager,
                      google::protobuf::io::CodedInputStream* coded_input,
                      std::atomic<bool>* cancellation_requested);
 
-inline const std::string kRequiredCaptureVersion = "1.52";
+inline const std::string kRequiredCaptureVersion = "1.55";
 
 }  // namespace internal
 

--- a/OrbitClientModel/include/OrbitClientModel/CaptureSerializer.h
+++ b/OrbitClientModel/include/OrbitClientModel/CaptureSerializer.h
@@ -33,7 +33,7 @@ void IncludeOrbitExtensionInFile(std::string& file_name);
 
 namespace internal {
 
-inline const std::string kRequiredCaptureVersion = "1.52";
+inline const std::string kRequiredCaptureVersion = "1.55";
 
 orbit_client_protos::CaptureInfo GenerateCaptureInfo(
     const CaptureData& capture_data,

--- a/OrbitClientProtos/capture_data.proto
+++ b/OrbitClientProtos/capture_data.proto
@@ -14,14 +14,31 @@ message FunctionStats {
   uint64 max_ns = 5;
 }
 
+message ProcessInfo {
+  int32 pid = 1;
+  string name = 2;
+  double cpu_usage = 3;
+  string full_path = 4;
+  string command_line = 5;
+  bool is_64_bit = 6;
+}
+
+message ModuleInfo {
+  string name = 1;
+  string file_path = 2;
+  uint64 file_size = 3;
+  uint64 address_start = 4;
+  uint64 address_end = 5;
+  string build_id = 6;
+  uint64 load_bias = 7;
+}
+
 message FunctionInfo {
-  reserved 11;
+  reserved 4, 6, 11;
   string name = 1;
   string pretty_name = 2;
   string loaded_module_path = 3;
-  uint64 module_base_address = 4;
   uint64 address = 5;
-  uint64 load_bias = 6;
   uint64 size = 7;
   string file = 8;
   uint32 line = 9;
@@ -93,9 +110,8 @@ message CaptureHeader {
 }
 
 message CaptureInfo {
+  reserved 2, 3;
   repeated FunctionInfo selected_functions = 1;
-  int32 process_id = 2;
-  string process_name = 3;
   map<int32, string> thread_names = 4;
   repeated ThreadStateSliceInfo thread_state_slices = 12;
   repeated LinuxAddressInfo address_infos = 5;
@@ -106,6 +122,8 @@ message CaptureInfo {
   map<uint64, FunctionStats> function_stats = 9;
   repeated TracepointInfo tracepoint_infos = 10;
   repeated TracepointEventInfo tracepoint_event_infos = 11;
+  ProcessInfo process = 13;
+  repeated ModuleInfo modules = 14;
 }
 
 message TimerInfo {

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -10,6 +10,7 @@
 
 #include "CallstackData.h"
 #include "OrbitClientData/FunctionInfoSet.h"
+#include "OrbitClientData/ModuleManager.h"
 #include "OrbitClientData/ProcessData.h"
 #include "SamplingProfiler.h"
 #include "TracepointCustom.h"
@@ -22,11 +23,11 @@
 class CaptureData {
  public:
   explicit CaptureData(
-      ProcessData&& process, absl::flat_hash_map<std::string, ModuleData*>&& module_map,
+      ProcessData&& process, OrbitClientData::ModuleManager* module_manager,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints)
       : process_(std::move(process)),
-        module_map_(std::move(module_map)),
+        module_manager_(module_manager),
         selected_functions_{std::move(selected_functions)},
         selected_tracepoints_{std::move(selected_tracepoints)},
         callstack_data_(std::make_unique<CallstackData>()),
@@ -76,6 +77,9 @@ class CaptureData {
 
   [[nodiscard]] const std::string& GetFunctionNameByAddress(uint64_t absolute_address) const;
   [[nodiscard]] const std::string& GetModulePathByAddress(uint64_t absolute_address) const;
+  [[nodiscard]] const ModuleData* GetModuleByPath(const std::string& module_path) const {
+    return module_manager_->GetModuleByPath(module_path);
+  }
 
   [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionByAddress(
       uint64_t absolute_address, bool is_exact) const;
@@ -201,7 +205,7 @@ class CaptureData {
 
  private:
   ProcessData process_;
-  absl::flat_hash_map<std::string, ModuleData*> module_map_;
+  OrbitClientData::ModuleManager* module_manager_;
   absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions_;
 
   TracepointInfoSet selected_tracepoints_;

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "CallstackData.h"
+#include "OrbitClientData/FunctionInfoSet.h"
 #include "OrbitClientData/ProcessData.h"
 #include "SamplingProfiler.h"
 #include "TracepointCustom.h"
@@ -79,6 +80,8 @@ class CaptureData {
   [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionByAddress(
       uint64_t absolute_address, bool is_exact) const;
   [[nodiscard]] ModuleData* FindModuleByAddress(uint64_t absolute_address) const;
+  [[nodiscard]] uint64_t GetAbsoluteAddress(
+      const orbit_client_protos::FunctionInfo& function) const;
 
   static const std::string kUnknownFunctionOrModuleName;
 
@@ -118,8 +121,7 @@ class CaptureData {
       int32_t thread_id, uint64_t min_timestamp, uint64_t max_timestamp,
       const std::function<void(const orbit_client_protos::ThreadStateSliceInfo&)>& action) const;
 
-  [[nodiscard]] const absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionStats>&
-  functions_stats() const {
+  [[nodiscard]] const FunctionInfoMap<orbit_client_protos::FunctionStats>& functions_stats() const {
     return functions_stats_;
   }
 
@@ -216,7 +218,7 @@ class CaptureData {
 
   absl::flat_hash_map<uint64_t, orbit_client_protos::LinuxAddressInfo> address_infos_;
 
-  absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionStats> functions_stats_;
+  FunctionInfoMap<orbit_client_protos::FunctionStats> functions_stats_;
 
   absl::flat_hash_map<int32_t, std::string> thread_names_;
 

--- a/OrbitCore/ModuleLoadSymbolsFuzzer.cpp
+++ b/OrbitCore/ModuleLoadSymbolsFuzzer.cpp
@@ -12,5 +12,5 @@ using orbit_grpc_protos::ModuleSymbols;
 
 DEFINE_PROTO_FUZZER(const ModuleSymbols& symbols) {
   ModuleData module{orbit_grpc_protos::ModuleInfo{}};
-  module.AddSymbols(symbols, 0);
+  module.AddSymbols(symbols);
 }

--- a/OrbitCore/SamplingProfiler.cpp
+++ b/OrbitCore/SamplingProfiler.cpp
@@ -231,7 +231,7 @@ void SamplingProfiler::MapAddressToFunctionAddress(uint64_t absolute_address,
   // considered a different function.
   uint64_t absolute_function_address;
   if (function != nullptr) {
-    absolute_function_address = FunctionUtils::GetAbsoluteAddress(*function);
+    absolute_function_address = capture_data.GetAbsoluteAddress(*function);
   } else if (address_info != nullptr) {
     absolute_function_address = absolute_address - address_info->offset_in_function();
   } else {

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -139,6 +139,9 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
 
   bool SelectProcess(const std::string& process);
 
+  // This needs to be called from the main thread.
+  [[nodiscard]] bool IsCaptureConnected(const CaptureData& capture) const;
+
   // Callbacks
   using CaptureStartedCallback = std::function<void()>;
   void SetCaptureStartedCallback(CaptureStartedCallback callback) {
@@ -246,7 +249,6 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
 
   void LoadModules(const std::vector<ModuleData*>& modules,
                    const std::shared_ptr<orbit_client_protos::PresetFile>& preset = nullptr);
-  void LoadModulesFromPreset(const std::shared_ptr<orbit_client_protos::PresetFile>& preset);
   void UpdateProcessAndModuleList(int32_t pid);
 
   void UpdateAfterSymbolLoading();

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -88,7 +88,7 @@ std::vector<std::string> CallStackDataView::GetContextMenu(
     const FunctionInfo* function = frame.function;
     const ModuleData* module = frame.module;
 
-    if (frame.function != nullptr) {
+    if (frame.function != nullptr && GOrbitApp->IsCaptureConnected(GOrbitApp->GetCaptureData())) {
       enable_select |= !GOrbitApp->IsFunctionSelected(*function);
       enable_unselect |= GOrbitApp->IsFunctionSelected(*function);
       enable_disassembly = true;

--- a/OrbitGl/CallStackDataView.h
+++ b/OrbitGl/CallStackDataView.h
@@ -10,7 +10,6 @@
 #include "Callstack.h"
 #include "DataView.h"
 #include "OrbitClientData/ModuleData.h"
-#include "capture_data.pb.h"
 
 class CallStackDataView : public DataView {
  public:
@@ -43,7 +42,6 @@ class CallStackDataView : public DataView {
   CallStack callstack_;
 
   struct CallStackDataViewFrame {
-    CallStackDataViewFrame() = default;
     CallStackDataViewFrame(uint64_t address, const orbit_client_protos::FunctionInfo* function,
                            ModuleData* module)
         : address(address), function(function), module(module) {}

--- a/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
+++ b/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
@@ -37,7 +37,7 @@ DEFINE_PROTO_FUZZER(const orbit_client_protos::CaptureDeserializerFuzzerInfo& in
     google::protobuf::io::StringOutputStream stream{&buffer};
     google::protobuf::io::CodedOutputStream coded_stream{&stream};
     orbit_client_protos::CaptureHeader capture_header{};
-    capture_header.set_version("1.52");
+    capture_header.set_version("1.55");
 
     capture_serializer::WriteMessage(&capture_header, &coded_stream);
     capture_serializer::WriteMessage(&info.capture_info(), &coded_stream);
@@ -72,7 +72,10 @@ DEFINE_PROTO_FUZZER(const orbit_client_protos::CaptureDeserializerFuzzerInfo& in
   // NOLINTNEXTLINE
   std::istringstream input_stream{std::move(buffer)};
   std::atomic<bool> cancellation_requested = false;
-  capture_deserializer::Load(input_stream, "", GOrbitApp.get(), &cancellation_requested);
+
+  OrbitClientData::ModuleManager module_manager;
+  capture_deserializer::Load(input_stream, "", GOrbitApp.get(), &module_manager,
+                             &cancellation_requested);
 
   app->GetThreadPool()->ShutdownAndWait();
 }

--- a/OrbitGl/DataManager.h
+++ b/OrbitGl/DataManager.h
@@ -15,6 +15,7 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/container/node_hash_map.h"
+#include "module.pb.h"
 
 // This class is responsible for storing and
 // navigating data on the client side. Note that

--- a/OrbitGl/DataManager.h
+++ b/OrbitGl/DataManager.h
@@ -27,8 +27,6 @@ class DataManager final {
       : main_thread_id_(thread_id) {}
 
   void UpdateProcessInfos(const std::vector<orbit_grpc_protos::ProcessInfo>& process_infos);
-  void UpdateModuleInfos(int32_t process_id,
-                         const std::vector<orbit_grpc_protos::ModuleInfo>& module_infos);
 
   void SelectFunction(const orbit_client_protos::FunctionInfo& function);
   void DeselectFunction(const orbit_client_protos::FunctionInfo& function);
@@ -39,17 +37,9 @@ class DataManager final {
   void set_selected_process(int32_t pid);
 
   [[nodiscard]] const ProcessData* GetProcessByPid(int32_t process_id) const;
-  [[nodiscard]] const ModuleData* GetModuleByPath(const std::string& path) const;
-  [[nodiscard]] ModuleData* GetMutableModuleByPath(const std::string& path) const;
-  [[nodiscard]] const ModuleData* FindModuleByAddress(int32_t process_id,
-                                                      uint64_t absolute_address);
-  [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionByAddress(
-      int32_t process_id, uint64_t absolute_address, bool is_exact) const;
-  [[nodiscard]] absl::flat_hash_map<std::string, ModuleData*> GetModulesLoadedByProcess(
-      const ProcessData* process) const;
+  [[nodiscard]] ProcessData* GetMutableProcessByPid(int32_t process_id);
   [[nodiscard]] bool IsFunctionSelected(const orbit_client_protos::FunctionInfo& function) const;
   [[nodiscard]] std::vector<orbit_client_protos::FunctionInfo> GetSelectedFunctions() const;
-  [[nodiscard]] std::vector<orbit_client_protos::FunctionInfo> GetSelectedAndOrbitFunctions() const;
   [[nodiscard]] bool IsFunctionVisible(uint64_t function_address) const;
   [[nodiscard]] int32_t selected_thread_id() const;
   [[nodiscard]] const TextBox* selected_text_box() const;
@@ -66,7 +56,6 @@ class DataManager final {
   const std::thread::id main_thread_id_;
   // We are sharing pointers to that entries and ensure reference stability by using node_hash_map
   absl::node_hash_map<int32_t, ProcessData> process_map_;
-  absl::flat_hash_map<std::string, std::unique_ptr<ModuleData>> module_map_;
   FunctionInfoSet selected_functions_;
   absl::flat_hash_set<uint64_t> visible_functions_;
 

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -127,9 +127,7 @@ void EventTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingM
   }
 }
 
-void EventTrack::SetPos(float a_X, float a_Y) {
-  pos_ = Vec2(a_X, a_Y);
-}
+void EventTrack::SetPos(float a_X, float a_Y) { pos_ = Vec2(a_X, a_Y); }
 
 void EventTrack::SetSize(float a_SizeX, float a_SizeY) { size_ = Vec2(a_SizeX, a_SizeY); }
 

--- a/OrbitGl/FramePointerValidatorClient.cpp
+++ b/OrbitGl/FramePointerValidatorClient.cpp
@@ -44,7 +44,7 @@ void FramePointerValidatorClient::AnalyzeModules(const std::vector<const ModuleD
     request.set_module_path(module->file_path());
     for (const FunctionInfo* function : functions) {
       CodeBlock* function_info = request.add_functions();
-      function_info->set_offset(FunctionUtils::Offset(*function));
+      function_info->set_offset(FunctionUtils::Offset(*function, *module));
       function_info->set_size(function->size());
     }
     grpc::ClientContext context;

--- a/OrbitGl/FunctionsDataView.cpp
+++ b/OrbitGl/FunctionsDataView.cpp
@@ -55,8 +55,15 @@ std::string FunctionsDataView::GetValue(int row, int column) {
       return FunctionUtils::GetLoadedModuleName(function);
     case kColumnAddress: {
       const ProcessData* process = GOrbitApp->GetSelectedProcess();
+      // If no process is selected, that means Orbit is in a disconnected state aka displaying a
+      // capture that has been loaded from file. CaptureData then holds the process
+      if (process == nullptr) {
+        const CaptureData& capture_data = GOrbitApp->GetCaptureData();
+        process = capture_data.process();
+        CHECK(!GOrbitApp->IsCaptureConnected(capture_data));
+      }
       CHECK(process != nullptr);
-      const ModuleData* module = GOrbitApp->GetMutableModuleByPath(function.loaded_module_path());
+      const ModuleData* module = GOrbitApp->GetModuleByPath(function.loaded_module_path());
       CHECK(module != nullptr);
       return absl::StrFormat("0x%llx",
                              FunctionUtils::GetAbsoluteAddress(function, *process, *module));

--- a/OrbitGl/FunctionsDataView.cpp
+++ b/OrbitGl/FunctionsDataView.cpp
@@ -53,8 +53,14 @@ std::string FunctionsDataView::GetValue(int row, int column) {
       return absl::StrFormat("%i", function.line());
     case kColumnModule:
       return FunctionUtils::GetLoadedModuleName(function);
-    case kColumnAddress:
-      return absl::StrFormat("0x%llx", FunctionUtils::GetAbsoluteAddress(function));
+    case kColumnAddress: {
+      const ProcessData* process = GOrbitApp->GetSelectedProcess();
+      CHECK(process != nullptr);
+      const ModuleData* module = GOrbitApp->GetMutableModuleByPath(function.loaded_module_path());
+      CHECK(module != nullptr);
+      return absl::StrFormat("0x%llx",
+                             FunctionUtils::GetAbsoluteAddress(function, *process, *module));
+    }
     default:
       return "";
   }

--- a/OrbitGl/LiveFunctionsController.cpp
+++ b/OrbitGl/LiveFunctionsController.cpp
@@ -99,9 +99,10 @@ bool LiveFunctionsController::OnAllNextButton() {
   absl::flat_hash_map<uint64_t, const TextBox*> next_boxes;
   uint64_t id_with_min_timestamp = 0;
   uint64_t min_timestamp = std::numeric_limits<uint64_t>::max();
+  const CaptureData& capture_data = GOrbitApp->GetCaptureData();
   for (auto it : function_iterators_) {
     const FunctionInfo* function = it.second;
-    auto function_address = FunctionUtils::GetAbsoluteAddress(*function);
+    auto function_address = capture_data.GetAbsoluteAddress(*function);
     const TextBox* current_box = current_textboxes_.find(it.first)->second;
     const TextBox* box = GCurrentTimeGraph->FindNextFunctionCall(function_address,
                                                                  current_box->GetTimerInfo().end());
@@ -126,9 +127,10 @@ bool LiveFunctionsController::OnAllPreviousButton() {
   absl::flat_hash_map<uint64_t, const TextBox*> next_boxes;
   uint64_t id_with_min_timestamp = 0;
   uint64_t min_timestamp = std::numeric_limits<uint64_t>::max();
+  const CaptureData& capture_data = GOrbitApp->GetCaptureData();
   for (auto it : function_iterators_) {
     const FunctionInfo* function = it.second;
-    auto function_address = FunctionUtils::GetAbsoluteAddress(*function);
+    auto function_address = capture_data.GetAbsoluteAddress(*function);
     const TextBox* current_box = current_textboxes_.find(it.first)->second;
     const TextBox* box = GCurrentTimeGraph->FindPreviousFunctionCall(
         function_address, current_box->GetTimerInfo().end());
@@ -150,7 +152,8 @@ bool LiveFunctionsController::OnAllPreviousButton() {
 }
 
 void LiveFunctionsController::OnNextButton(uint64_t id) {
-  auto function_address = FunctionUtils::GetAbsoluteAddress(*(function_iterators_[id]));
+  const CaptureData& capture_data = GOrbitApp->GetCaptureData();
+  auto function_address = capture_data.GetAbsoluteAddress(*(function_iterators_[id]));
   const TextBox* text_box = GCurrentTimeGraph->FindNextFunctionCall(
       function_address, current_textboxes_[id]->GetTimerInfo().end());
   // If text_box is nullptr, then we have reached the right end of the timeline.
@@ -161,7 +164,8 @@ void LiveFunctionsController::OnNextButton(uint64_t id) {
   Move();
 }
 void LiveFunctionsController::OnPreviousButton(uint64_t id) {
-  auto function_address = FunctionUtils::GetAbsoluteAddress(*(function_iterators_[id]));
+  const CaptureData& capture_data = GOrbitApp->GetCaptureData();
+  auto function_address = capture_data.GetAbsoluteAddress(*(function_iterators_[id]));
   const TextBox* text_box = GCurrentTimeGraph->FindPreviousFunctionCall(
       function_address, current_textboxes_[id]->GetTimerInfo().end());
   // If text_box is nullptr, then we have reached the left end of the timeline.
@@ -190,7 +194,8 @@ void LiveFunctionsController::AddIterator(FunctionInfo* function) {
   uint64_t id = next_iterator_id_;
   ++next_iterator_id_;
 
-  auto function_address = FunctionUtils::GetAbsoluteAddress(*function);
+  const CaptureData& capture_data = GOrbitApp->GetCaptureData();
+  auto function_address = capture_data.GetAbsoluteAddress(*function);
   const TextBox* box = GOrbitApp->selected_text_box();
   // If no box is currently selected or the selected box is a different
   // function, we search for the closest box to the current center of the
@@ -209,7 +214,8 @@ void LiveFunctionsController::AddIterator(FunctionInfo* function) {
 }
 
 void LiveFunctionsController::AddFrameTrack(const FunctionInfo& function) {
-  auto function_address = FunctionUtils::GetAbsoluteAddress(function);
+  const CaptureData& capture_data = GOrbitApp->GetCaptureData();
+  auto function_address = capture_data.GetAbsoluteAddress(function);
   std::vector<std::shared_ptr<TimerChain>> chains =
       GCurrentTimeGraph->GetAllThreadTrackTimerChains();
 

--- a/OrbitGl/LiveFunctionsDataView.cpp
+++ b/OrbitGl/LiveFunctionsDataView.cpp
@@ -66,8 +66,10 @@ std::string LiveFunctionsDataView::GetValue(int row, int column) {
       return GetPrettyTime(absl::Nanoseconds(stats.max_ns()));
     case kColumnModule:
       return function.loaded_module_path();
-    case kColumnAddress:
-      return absl::StrFormat("0x%llx", FunctionUtils::GetAbsoluteAddress(function));
+    case kColumnAddress: {
+      const CaptureData& capture_data = GOrbitApp->GetCaptureData();
+      return absl::StrFormat("0x%llx", capture_data.GetAbsoluteAddress(function));
+    }
     default:
       return "";
   }
@@ -156,7 +158,7 @@ std::vector<std::string> LiveFunctionsDataView::GetContextMenu(
   const CaptureData& capture_data = GOrbitApp->GetCaptureData();
   for (int index : selected_indices) {
     const FunctionInfo& selected_function = *GetSelectedFunction(index);
-    const uint64_t absolute_address = FunctionUtils::GetAbsoluteAddress(selected_function);
+    const uint64_t absolute_address = capture_data.GetAbsoluteAddress(selected_function);
 
     // Is that function actually inside a module of the process (i.e. can we disassemble)?
     const FunctionInfo* actual_function =
@@ -211,7 +213,7 @@ void LiveFunctionsDataView::OnContextMenu(const std::string& action, int menu_in
       action == kMenuActionDisassembly) {
     for (int i : item_indices) {
       FunctionInfo* selected_function = GetSelectedFunction(i);
-      const uint64_t absolute_address = FunctionUtils::GetAbsoluteAddress(*selected_function);
+      const uint64_t absolute_address = capture_data.GetAbsoluteAddress(*selected_function);
       // Is that function actually inside a module of the process?
       if (capture_data.FindFunctionByAddress(absolute_address, false) == nullptr) {
         continue;
@@ -227,8 +229,7 @@ void LiveFunctionsDataView::OnContextMenu(const std::string& action, int menu_in
     }
   } else if (action == kMenuActionJumpToFirst) {
     CHECK(item_indices.size() == 1);
-    auto function_address =
-        FunctionUtils::GetAbsoluteAddress(*GetSelectedFunction(item_indices[0]));
+    auto function_address = capture_data.GetAbsoluteAddress(*GetSelectedFunction(item_indices[0]));
     auto first_box = GCurrentTimeGraph->FindNextFunctionCall(
         function_address, std::numeric_limits<uint64_t>::lowest());
     if (first_box != nullptr) {
@@ -236,8 +237,7 @@ void LiveFunctionsDataView::OnContextMenu(const std::string& action, int menu_in
     }
   } else if (action == kMenuActionJumpToLast) {
     CHECK(item_indices.size() == 1);
-    auto function_address =
-        FunctionUtils::GetAbsoluteAddress(*GetSelectedFunction(item_indices[0]));
+    auto function_address = capture_data.GetAbsoluteAddress(*GetSelectedFunction(item_indices[0]));
     auto last_box = GCurrentTimeGraph->FindPreviousFunctionCall(
         function_address, std::numeric_limits<uint64_t>::max());
     if (last_box != nullptr) {
@@ -269,8 +269,8 @@ void LiveFunctionsDataView::OnContextMenu(const std::string& action, int menu_in
   } else if (action == kMenuActionFrameTrack) {
     for (int i : item_indices) {
       FunctionInfo* function = GetSelectedFunction(i);
-      const FunctionStats& stats = GOrbitApp->GetCaptureData().GetFunctionStatsOrDefault(*function);
-      uint64_t function_address = FunctionUtils::GetAbsoluteAddress(*function);
+      const FunctionStats& stats = capture_data.GetFunctionStatsOrDefault(*function);
+      uint64_t function_address = capture_data.GetAbsoluteAddress(*function);
       if (stats.count() > 1 && added_frame_tracks_.count(function_address) == 0) {
         live_functions_->AddFrameTrack(*function);
         added_frame_tracks_.insert(function_address);
@@ -279,7 +279,7 @@ void LiveFunctionsDataView::OnContextMenu(const std::string& action, int menu_in
   } else if (action == kMenuActionRemoveFrameTrack) {
     for (int i : item_indices) {
       FunctionInfo* function = GetSelectedFunction(i);
-      uint64_t function_address = FunctionUtils::GetAbsoluteAddress(*function);
+      uint64_t function_address = capture_data.GetAbsoluteAddress(*function);
       if (added_frame_tracks_.count(function_address) > 0) {
         added_frame_tracks_.erase(function_address);
         live_functions_->RemoveFrameTrack(*function);
@@ -317,9 +317,10 @@ void LiveFunctionsDataView::DoFilter() {
 
   // Filter drawn textboxes
   absl::flat_hash_set<uint64_t> visible_functions;
+  const CaptureData& capture_data = GOrbitApp->GetCaptureData();
   for (size_t i = 0; i < indices_.size(); ++i) {
     FunctionInfo* func = GetSelectedFunction(i);
-    visible_functions.insert(FunctionUtils::GetAbsoluteAddress(*func));
+    visible_functions.insert(capture_data.GetAbsoluteAddress(*func));
   }
   GOrbitApp->SetVisibleFunctions(std::move(visible_functions));
 }
@@ -353,7 +354,8 @@ FunctionInfo* LiveFunctionsDataView::GetSelectedFunction(unsigned int row) {
 }
 
 std::pair<TextBox*, TextBox*> LiveFunctionsDataView::GetMinMax(const FunctionInfo& function) const {
-  auto function_address = FunctionUtils::GetAbsoluteAddress(function);
+  const CaptureData& capture_data = GOrbitApp->GetCaptureData();
+  auto function_address = capture_data.GetAbsoluteAddress(function);
   TextBox* min_box = nullptr;
   TextBox* max_box = nullptr;
   std::vector<std::shared_ptr<TimerChain>> chains =

--- a/OrbitGl/ModulesDataView.cpp
+++ b/OrbitGl/ModulesDataView.cpp
@@ -125,8 +125,7 @@ void ModulesDataView::OnContextMenu(const std::string& action, int menu_index,
         modules_to_load.push_back(module_data);
       }
     }
-    CHECK(process_ != nullptr);
-    GOrbitApp->LoadModules(process_, modules_to_load);
+    GOrbitApp->LoadModules(modules_to_load);
 
   } else if (action == kMenuActionVerifyFramePointers) {
     std::vector<const ModuleData*> modules_to_validate;
@@ -171,8 +170,7 @@ void ModulesDataView::DoFilter() {
   indices_ = indices;
 }
 
-void ModulesDataView::SetProcess(const ProcessData* process) {
-  process_ = process;
+void ModulesDataView::UpdateModules(const ProcessData* process) {
   modules_.clear();
   module_memory_.clear();
   for (const auto& [module_path, memory_space] : process->GetMemoryMap()) {

--- a/OrbitGl/ModulesDataView.h
+++ b/OrbitGl/ModulesDataView.h
@@ -27,8 +27,7 @@ class ModulesDataView : public DataView {
   std::string GetLabel() override { return "Modules"; }
   bool HasRefreshButton() const override { return true; }
   void OnRefreshButtonClicked() override;
-
-  void SetProcess(const ProcessData* process);
+  void UpdateModules(const ProcessData* process);
 
  protected:
   void DoSort() override;
@@ -37,10 +36,6 @@ class ModulesDataView : public DataView {
  private:
   [[nodiscard]] ModuleData* GetModule(uint32_t row) const { return modules_[indices_[row]]; }
 
-  // TODO(169309553) Saving this process_ here is currently only necessary because symbol loading
-  // involves the process (see GOrbitApp->LoadSymbols). The plan is not involve the process in
-  // symbol loading anymore, once this changed, remove this process_ field.
-  const ProcessData* process_ = nullptr;
   std::vector<ModuleData*> modules_;
   absl::flat_hash_map<const ModuleData*, const MemorySpace*> module_memory_;
 

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -161,16 +161,15 @@ absl::flat_hash_set<const FunctionInfo*> SamplingReportDataView::GetFunctionsFro
 absl::flat_hash_set<ModuleData*> SamplingReportDataView::GetModulesFromIndices(
     const std::vector<int>& indices) const {
   absl::flat_hash_set<ModuleData*> modules;
+  const CaptureData& capture_data = GOrbitApp->GetCaptureData();
   for (int index : indices) {
     const SampledFunction& sampled_function = GetSampledFunction(index);
     CHECK(sampled_function.absolute_address != 0);
-    ModuleData* module =
-        GOrbitApp->GetCaptureData().FindModuleByAddress(sampled_function.absolute_address);
+    ModuleData* module = capture_data.FindModuleByAddress(sampled_function.absolute_address);
     if (module != nullptr) {
       modules.insert(module);
     }
   }
-
   return modules;
 }
 
@@ -227,7 +226,7 @@ void SamplingReportDataView::OnContextMenu(const std::string& action, int menu_i
         modules_to_load.push_back(module);
       }
     }
-    GOrbitApp->LoadModules(GOrbitApp->GetCaptureData().process(), modules_to_load);
+    GOrbitApp->LoadModules(modules_to_load);
   } else if (action == kMenuActionDisassembly) {
     int32_t pid = GOrbitApp->GetCaptureData().process_id();
     for (const FunctionInfo* function : GetFunctionsFromIndices(item_indices)) {

--- a/OrbitGl/SamplingReportDataView.h
+++ b/OrbitGl/SamplingReportDataView.h
@@ -39,7 +39,7 @@ class SamplingReportDataView : public DataView {
   SampledFunction& GetSampledFunction(unsigned int row);
   absl::flat_hash_set<const orbit_client_protos::FunctionInfo*> GetFunctionsFromIndices(
       const std::vector<int>& indices);
-  [[nodiscard]] absl::flat_hash_set<ModuleData*> GetModulesFromIndices(
+  [[nodiscard]] absl::flat_hash_set<std::string> GetModulePathsFromIndices(
       const std::vector<int>& indices) const;
 
  private:

--- a/OrbitQt/CallTreeWidget.cpp
+++ b/OrbitQt/CallTreeWidget.cpp
@@ -201,14 +201,14 @@ static std::vector<ModuleData*> GetModulesFromIndices(OrbitApp* app,
 static std::vector<const FunctionInfo*> GetFunctionsFromIndices(
     OrbitApp* app, const std::vector<QModelIndex>& indices) {
   absl::flat_hash_set<const FunctionInfo*> functions_set;
+  const CaptureData& capture_data = app->GetCaptureData();
   for (const auto& index : indices) {
     uint64_t absolute_address =
         index.model()
             ->index(index.row(), CallTreeViewItemModel::kFunctionAddress, index.parent())
             .data(Qt::EditRole)
             .toLongLong();
-    const FunctionInfo* function =
-        app->GetCaptureData().FindFunctionByAddress(absolute_address, false);
+    const FunctionInfo* function = capture_data.FindFunctionByAddress(absolute_address, false);
     if (function != nullptr) {
       functions_set.insert(function);
     }
@@ -305,7 +305,7 @@ void CallTreeWidget::onCustomContextMenuRequested(const QPoint& point) {
   } else if (action->text() == kActionCollapseAll) {
     ui_->callTreeTreeView->collapseAll();
   } else if (action->text() == kActionLoadSymbols) {
-    app_->LoadModules(app_->GetCaptureData().process(), modules_to_load);
+    app_->LoadModules(modules_to_load);
   } else if (action->text() == kActionSelect) {
     for (const FunctionInfo* function : functions) {
       app_->SelectFunction(*function);

--- a/OrbitQt/CallTreeWidget.cpp
+++ b/OrbitQt/CallTreeWidget.cpp
@@ -259,12 +259,14 @@ void CallTreeWidget::onCustomContextMenuRequested(const QPoint& point) {
   std::vector<const FunctionInfo*> functions = GetFunctionsFromIndices(app_, selected_tree_indices);
   bool enable_select = false;
   bool enable_deselect = false;
-  for (const FunctionInfo* function : functions) {
-    enable_select |= !app_->IsFunctionSelected(*function);
-    enable_deselect |= app_->IsFunctionSelected(*function);
+  bool enable_disassembly = false;
+  if (GOrbitApp->IsCaptureConnected(GOrbitApp->GetCaptureData())) {
+    for (const FunctionInfo* function : functions) {
+      enable_select |= !app_->IsFunctionSelected(*function);
+      enable_deselect |= app_->IsFunctionSelected(*function);
+      enable_disassembly = true;
+    }
   }
-
-  bool enable_disassembly = !functions.empty();
 
   bool enable_copy = ui_->callTreeTreeView->selectionModel()->hasSelection();
 


### PR DESCRIPTION
This continues PR #1315 

Everything should now work as expected, aka the context menus in the different views should be correct and show options like "hook" only if Orbit is connected and the correct process is selected. 

I marked this as draft, because I can't help but think this is currently more complicated than it needs to be. The commit that moves "module_map" out of capture data seemed necessary, because capture deserialization is done off the main thread and the "module_map" is stored in DataManager which can only be accessed from the main thread. 
I would propose to change the deserialization instead and still keep a copy of the module_map in CaptureData as it was done before. I think this would simplify some function calls, but I am unsure if its the best way to go forward. wdyt? Maybe one of you has a good idea on a conceptual level. 


