### PR TITLE
Collect thread states, send them to the client, store and serialize them

### DIFF
--- a/OrbitCaptureClient/CaptureClient.cpp
+++ b/OrbitCaptureClient/CaptureClient.cpp
@@ -15,13 +15,13 @@
 
 ABSL_DECLARE_FLAG(uint16_t, sampling_rate);
 ABSL_DECLARE_FLAG(bool, frame_pointer_unwinding);
+ABSL_DECLARE_FLAG(bool, thread_state);
 
 using orbit_client_protos::FunctionInfo;
 
 using orbit_grpc_protos::CaptureOptions;
 using orbit_grpc_protos::CaptureRequest;
 using orbit_grpc_protos::CaptureResponse;
-using orbit_grpc_protos::ProcessInfo;
 using orbit_grpc_protos::TracepointInfo;
 
 static CaptureOptions::InstrumentedFunction::FunctionType IntrumentedFunctionTypeFromOrbitType(
@@ -93,6 +93,7 @@ void CaptureClient::Capture(ProcessData&& process,
     }
   }
 
+  capture_options->set_trace_thread_state(absl::GetFlag(FLAGS_thread_state));
   capture_options->set_trace_gpu_driver(true);
   for (const auto& pair : selected_functions) {
     const FunctionInfo& function = pair.second;

--- a/OrbitCaptureClient/CaptureEventProcessor.cpp
+++ b/OrbitCaptureClient/CaptureEventProcessor.cpp
@@ -21,6 +21,7 @@ using orbit_grpc_protos::InternedCallstack;
 using orbit_grpc_protos::InternedString;
 using orbit_grpc_protos::SchedulingSlice;
 using orbit_grpc_protos::ThreadName;
+using orbit_grpc_protos::ThreadStateSlice;
 
 void CaptureEventProcessor::ProcessEvent(const CaptureEvent& event) {
   switch (event.event_case()) {
@@ -32,12 +33,6 @@ void CaptureEventProcessor::ProcessEvent(const CaptureEvent& event) {
       break;
     case CaptureEvent::kCallstackSample:
       ProcessCallstackSample(event.callstack_sample());
-      break;
-    case CaptureEvent::kInternedTracepointInfo:
-      ProcessInternedTracepointInfo(event.interned_tracepoint_info());
-      break;
-    case CaptureEvent::kTracepointEvent:
-      ProcessTracepointEvent(event.tracepoint_event());
       break;
     case CaptureEvent::kFunctionCall:
       ProcessFunctionCall(event.function_call());
@@ -51,8 +46,17 @@ void CaptureEventProcessor::ProcessEvent(const CaptureEvent& event) {
     case CaptureEvent::kThreadName:
       ProcessThreadName(event.thread_name());
       break;
+    case CaptureEvent::kThreadStateSlice:
+      ProcessThreadStateSlice(event.thread_state_slice());
+      break;
     case CaptureEvent::kAddressInfo:
       ProcessAddressInfo(event.address_info());
+      break;
+    case CaptureEvent::kInternedTracepointInfo:
+      ProcessInternedTracepointInfo(event.interned_tracepoint_info());
+      break;
+    case CaptureEvent::kTracepointEvent:
+      ProcessTracepointEvent(event.tracepoint_event());
       break;
     case CaptureEvent::EVENT_NOT_SET:
       ERROR("CaptureEvent::EVENT_NOT_SET read from Capture's gRPC stream");
@@ -176,6 +180,11 @@ void CaptureEventProcessor::ProcessGpuJob(const GpuJob& gpu_job) {
 
 void CaptureEventProcessor::ProcessThreadName(const ThreadName& thread_name) {
   capture_listener_->OnThreadName(thread_name.tid(), thread_name.name());
+}
+
+void CaptureEventProcessor::ProcessThreadStateSlice(
+    const ThreadStateSlice& /*thread_state_slice*/) {
+  // TODO(dpallotti,b/168790833): Send to OrbitApp and ClientGgp.
 }
 
 void CaptureEventProcessor::ProcessAddressInfo(const AddressInfo& address_info) {

--- a/OrbitCaptureClient/CaptureEventProcessor.cpp
+++ b/OrbitCaptureClient/CaptureEventProcessor.cpp
@@ -9,6 +9,7 @@
 
 using orbit_client_protos::CallstackEvent;
 using orbit_client_protos::LinuxAddressInfo;
+using orbit_client_protos::ThreadStateSliceInfo;
 using orbit_client_protos::TimerInfo;
 
 using orbit_grpc_protos::AddressInfo;
@@ -182,9 +183,46 @@ void CaptureEventProcessor::ProcessThreadName(const ThreadName& thread_name) {
   capture_listener_->OnThreadName(thread_name.tid(), thread_name.name());
 }
 
-void CaptureEventProcessor::ProcessThreadStateSlice(
-    const ThreadStateSlice& /*thread_state_slice*/) {
-  // TODO(dpallotti,b/168790833): Send to OrbitApp and ClientGgp.
+void CaptureEventProcessor::ProcessThreadStateSlice(const ThreadStateSlice& thread_state_slice) {
+  ThreadStateSliceInfo slice_info;
+  slice_info.set_tid(thread_state_slice.tid());
+  switch (thread_state_slice.thread_state()) {
+    case ThreadStateSlice::kRunning:
+      slice_info.set_thread_state(ThreadStateSliceInfo::kRunning);
+      break;
+    case ThreadStateSlice::kRunnable:
+      slice_info.set_thread_state(ThreadStateSliceInfo::kRunnable);
+      break;
+    case ThreadStateSlice::kInterruptibleSleep:
+      slice_info.set_thread_state(ThreadStateSliceInfo::kInterruptibleSleep);
+      break;
+    case ThreadStateSlice::kUninterruptibleSleep:
+      slice_info.set_thread_state(ThreadStateSliceInfo::kUninterruptibleSleep);
+      break;
+    case ThreadStateSlice::kStopped:
+      slice_info.set_thread_state(ThreadStateSliceInfo::kStopped);
+      break;
+    case ThreadStateSlice::kTraced:
+      slice_info.set_thread_state(ThreadStateSliceInfo::kTraced);
+      break;
+    case ThreadStateSlice::kDead:
+      slice_info.set_thread_state(ThreadStateSliceInfo::kDead);
+      break;
+    case ThreadStateSlice::kZombie:
+      slice_info.set_thread_state(ThreadStateSliceInfo::kZombie);
+      break;
+    case ThreadStateSlice::kParked:
+      slice_info.set_thread_state(ThreadStateSliceInfo::kParked);
+      break;
+    case ThreadStateSlice::kIdle:
+      slice_info.set_thread_state(ThreadStateSliceInfo::kIdle);
+      break;
+    default:
+      UNREACHABLE();
+  }
+  slice_info.set_begin_timestamp_ns(thread_state_slice.begin_timestamp_ns());
+  slice_info.set_end_timestamp_ns(thread_state_slice.end_timestamp_ns());
+  capture_listener_->OnThreadStateSlice(std::move(slice_info));
 }
 
 void CaptureEventProcessor::ProcessAddressInfo(const AddressInfo& address_info) {

--- a/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -36,6 +36,7 @@ class MyCaptureListener : public CaptureListener {
   void OnUniqueCallStack(CallStack) override {}
   void OnCallstackEvent(CallstackEvent) override {}
   void OnThreadName(int32_t, std::string) override {}
+  void OnThreadStateSlice(orbit_client_protos::ThreadStateSliceInfo) override {}
   void OnAddressInfo(LinuxAddressInfo) override {}
   void OnUniqueTracepointInfo(uint64_t, orbit_grpc_protos::TracepointInfo) override {}
   void OnTracepointEvent(orbit_client_protos::TracepointEventInfo) override {}

--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
@@ -32,10 +32,11 @@ class CaptureEventProcessor {
   void ProcessInternedString(orbit_grpc_protos::InternedString interned_string);
   void ProcessGpuJob(const orbit_grpc_protos::GpuJob& gpu_job);
   void ProcessThreadName(const orbit_grpc_protos::ThreadName& thread_name);
+  void ProcessThreadStateSlice(const orbit_grpc_protos::ThreadStateSlice& thread_state_slice);
+  void ProcessAddressInfo(const orbit_grpc_protos::AddressInfo& address_info);
   void ProcessInternedTracepointInfo(
       orbit_grpc_protos::InternedTracepointInfo interned_tracepoint_info);
   void ProcessTracepointEvent(const orbit_grpc_protos::TracepointEvent& tracepoint_event);
-  void ProcessAddressInfo(const orbit_grpc_protos::AddressInfo& address_info);
 
   absl::flat_hash_map<uint64_t, orbit_grpc_protos::Callstack> callstack_intern_pool;
   absl::flat_hash_map<uint64_t, std::string> string_intern_pool;

--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
@@ -35,6 +35,7 @@ class CaptureListener {
   virtual void OnUniqueCallStack(CallStack callstack) = 0;
   virtual void OnCallstackEvent(orbit_client_protos::CallstackEvent callstack_event) = 0;
   virtual void OnThreadName(int32_t thread_id, std::string thread_name) = 0;
+  virtual void OnThreadStateSlice(orbit_client_protos::ThreadStateSliceInfo thread_state_slice) = 0;
   virtual void OnAddressInfo(orbit_client_protos::LinuxAddressInfo address_info) = 0;
   virtual void OnUniqueTracepointInfo(uint64_t key,
                                       orbit_grpc_protos::TracepointInfo tracepoint_info) = 0;

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -312,6 +312,10 @@ void ClientGgp::OnThreadName(int32_t thread_id, std::string thread_name) {
   capture_data_.AddOrAssignThreadName(thread_id, std::move(thread_name));
 }
 
+void ClientGgp::OnThreadStateSlice(orbit_client_protos::ThreadStateSliceInfo thread_state_slice) {
+  capture_data_.AddThreadStateSlice(std::move(thread_state_slice));
+}
+
 void ClientGgp::OnAddressInfo(LinuxAddressInfo address_info) {
   capture_data_.InsertAddressInfo(std::move(address_info));
 }

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -43,6 +43,7 @@ class ClientGgp final : public CaptureListener {
   void OnUniqueCallStack(CallStack callstack) override;
   void OnCallstackEvent(orbit_client_protos::CallstackEvent callstack_event) override;
   void OnThreadName(int32_t thread_id, std::string thread_name) override;
+  void OnThreadStateSlice(orbit_client_protos::ThreadStateSliceInfo thread_state_slice) override;
   void OnAddressInfo(orbit_client_protos::LinuxAddressInfo address_info) override;
   void OnUniqueTracepointInfo(uint64_t key,
                               orbit_grpc_protos::TracepointInfo tracepoint_info) override;

--- a/OrbitClientGgp/main.cpp
+++ b/OrbitClientGgp/main.cpp
@@ -25,6 +25,7 @@ ABSL_FLAG(std::string, log_directory, "",
           "Path to locate debug file. By default only stdout is used for logs");
 ABSL_FLAG(uint16_t, sampling_rate, 1000, "Frequency of callstack sampling in samples per second");
 ABSL_FLAG(bool, frame_pointer_unwinding, false, "Use frame pointers for unwinding");
+ABSL_FLAG(bool, thread_state, false, "Collect thread states");
 
 namespace {
 

--- a/OrbitClientModel/CMakeLists.txt
+++ b/OrbitClientModel/CMakeLists.txt
@@ -33,6 +33,7 @@ target_compile_options(OrbitClientModelTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(OrbitClientModelTests PRIVATE
         CaptureDeserializerTest.cpp
+        CaptureSerializationTestMatchers.h
         CaptureSerializerTest.cpp)
 
 target_link_libraries(

--- a/OrbitClientModel/CaptureDeserializer.cpp
+++ b/OrbitClientModel/CaptureDeserializer.cpp
@@ -147,6 +147,15 @@ void LoadCaptureInfo(const CaptureInfo& capture_info, CaptureListener* capture_l
     capture_listener->OnThreadName(thread_id_and_name.first, thread_id_and_name.second);
   }
 
+  for (const orbit_client_protos::ThreadStateSliceInfo& thread_state_slice :
+       capture_info.thread_state_slices()) {
+    if (*cancellation_requested) {
+      capture_listener->OnCaptureCancelled();
+      return;
+    }
+    capture_listener->OnThreadStateSlice(thread_state_slice);
+  }
+
   for (const CallstackInfo& callstack : capture_info.callstacks()) {
     CallStack unique_callstack({callstack.data().begin(), callstack.data().end()});
     if (*cancellation_requested) {

--- a/OrbitClientModel/CaptureSerializationTestMatchers.h
+++ b/OrbitClientModel/CaptureSerializationTestMatchers.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_CLIENT_MODEL_CAPTURE_SERIALIZATION_TEST_MATCHERS_H_
+#define ORBIT_CLIENT_MODEL_CAPTURE_SERIALIZATION_TEST_MATCHERS_H_
+
+#include <gmock/gmock-generated-matchers.h>
+
+#include "capture_data.pb.h"
+
+MATCHER(ThreadStateSliceInfoEq, "") {
+  const orbit_client_protos::ThreadStateSliceInfo& a = std::get<0>(arg);
+  const orbit_client_protos::ThreadStateSliceInfo& b = std::get<1>(arg);
+  return a.tid() == b.tid() && a.thread_state() == b.thread_state() &&
+         a.begin_timestamp_ns() == b.begin_timestamp_ns() &&
+         a.end_timestamp_ns() == b.end_timestamp_ns();
+}
+
+MATCHER_P(ThreadStateSliceInfoEq, that, "") {
+  const orbit_client_protos::ThreadStateSliceInfo& a = arg;
+  const orbit_client_protos::ThreadStateSliceInfo& b = that;
+  return a.tid() == b.tid() && a.thread_state() == b.thread_state() &&
+         a.begin_timestamp_ns() == b.begin_timestamp_ns() &&
+         a.end_timestamp_ns() == b.end_timestamp_ns();
+}
+
+#endif  // ORBIT_CLIENT_MODEL_CAPTURE_SERIALIZATION_TEST_MATCHERS_H_

--- a/OrbitClientModel/CaptureSerializer.cpp
+++ b/OrbitClientModel/CaptureSerializer.cpp
@@ -62,6 +62,17 @@ CaptureInfo GenerateCaptureInfo(
   capture_info.mutable_thread_names()->insert(capture_data.thread_names().begin(),
                                               capture_data.thread_names().end());
 
+  for (const auto& tid_and_thread_state_slices : capture_data.thread_state_slices()) {
+    // Note that thread state slices are saved in their original order only among the same thread,
+    // but all slices related to the same thread are saved sequentially. This might not be desired
+    // if the capture is opened in a streaming fashion.
+    for (const auto& thread_state_slice : tid_and_thread_state_slices.second) {
+      orbit_client_protos::ThreadStateSliceInfo* added_thread_state_slice =
+          capture_info.add_thread_state_slices();
+      added_thread_state_slice->CopyFrom(thread_state_slice);
+    }
+  }
+
   capture_info.mutable_address_infos()->Reserve(capture_data.address_infos().size());
   for (const auto& address_info : capture_data.address_infos()) {
     orbit_client_protos::LinuxAddressInfo* added_address_info = capture_info.add_address_infos();

--- a/OrbitClientProtos/capture_data.proto
+++ b/OrbitClientProtos/capture_data.proto
@@ -47,6 +47,26 @@ message CallstackInfo {
   repeated uint64 data = 1;
 }
 
+message ThreadStateSliceInfo {
+  // pid is absent as we don't yet get that information from the service.
+  int32 tid = 1;
+  enum ThreadState {
+    kRunning = 0;
+    kRunnable = 1;
+    kInterruptibleSleep = 2;
+    kUninterruptibleSleep = 3;
+    kStopped = 4;
+    kTraced = 5;
+    kDead = 6;
+    kZombie = 7;
+    kParked = 8;
+    kIdle = 9;
+  }
+  ThreadState thread_state = 2;
+  uint64 begin_timestamp_ns = 3;
+  uint64 end_timestamp_ns = 4;
+}
+
 message TracepointInfo {
   string name = 1;
   string category = 2;
@@ -77,6 +97,7 @@ message CaptureInfo {
   int32 process_id = 2;
   string process_name = 3;
   map<int32, string> thread_names = 4;
+  repeated ThreadStateSliceInfo thread_state_slices = 12;
   repeated LinuxAddressInfo address_infos = 5;
   repeated CallstackInfo callstacks = 6;
   repeated CallstackEvent callstack_events = 7;

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -96,6 +96,16 @@ class CaptureData {
     thread_names_.insert_or_assign(thread_id, std::move(thread_name));
   }
 
+  [[nodiscard]] const absl::flat_hash_map<int32_t,
+                                          std::vector<orbit_client_protos::ThreadStateSliceInfo>>&
+  thread_state_slices() const {
+    return thread_state_slices_;
+  }
+
+  void AddThreadStateSlice(orbit_client_protos::ThreadStateSliceInfo state_slice) {
+    thread_state_slices_[state_slice.tid()].emplace_back(std::move(state_slice));
+  }
+
   [[nodiscard]] const absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionStats>&
   functions_stats() const {
     return functions_stats_;
@@ -197,6 +207,9 @@ class CaptureData {
   absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionStats> functions_stats_;
 
   absl::flat_hash_map<int32_t, std::string> thread_names_;
+
+  absl::flat_hash_map<int32_t, std::vector<orbit_client_protos::ThreadStateSliceInfo>>
+      thread_state_slices_;  // For each thread, assume sorted by timestamp and not overlapping.
 
   std::chrono::system_clock::time_point capture_start_time_ = std::chrono::system_clock::now();
 };

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -230,6 +230,10 @@ void OrbitApp::OnThreadName(int32_t thread_id, std::string thread_name) {
   capture_data_.AddOrAssignThreadName(thread_id, std::move(thread_name));
 }
 
+void OrbitApp::OnThreadStateSlice(orbit_client_protos::ThreadStateSliceInfo thread_state_slice) {
+  capture_data_.AddThreadStateSlice(std::move(thread_state_slice));
+}
+
 void OrbitApp::OnAddressInfo(LinuxAddressInfo address_info) {
   capture_data_.InsertAddressInfo(std::move(address_info));
 }

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -106,6 +106,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void OnUniqueCallStack(CallStack callstack) override;
   void OnCallstackEvent(orbit_client_protos::CallstackEvent callstack_event) override;
   void OnThreadName(int32_t thread_id, std::string thread_name) override;
+  void OnThreadStateSlice(orbit_client_protos::ThreadStateSliceInfo thread_state_slice) override;
   void OnAddressInfo(orbit_client_protos::LinuxAddressInfo address_info) override;
   void OnUniqueTracepointInfo(uint64_t key,
                               orbit_grpc_protos::TracepointInfo tracepoint_info) override;

--- a/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
+++ b/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
@@ -29,6 +29,7 @@ ABSL_FLAG(bool, enable_frame_pointer_validator, false, "Enable validation of fra
 ABSL_FLAG(bool, show_return_values, false, "Show return values on time slices");
 ABSL_FLAG(bool, enable_tracepoint_feature, false,
           "Enable the setting of the panel of kernel tracepoints");
+ABSL_FLAG(bool, thread_state, false, "Collect thread states");
 
 DEFINE_PROTO_FUZZER(const orbit_client_protos::CaptureDeserializerFuzzerInfo& info) {
   std::string buffer{};

--- a/OrbitGl/DataManagerUpdateModuleInfosFuzzer.cpp
+++ b/OrbitGl/DataManagerUpdateModuleInfosFuzzer.cpp
@@ -24,6 +24,7 @@ ABSL_FLAG(bool, enable_frame_pointer_validator, false, "Enable validation of fra
 ABSL_FLAG(bool, show_return_values, false, "Show return values on time slices");
 ABSL_FLAG(bool, enable_tracepoint_feature, false,
           "Enable the setting of the panel of kernel tracepoints");
+ABSL_FLAG(bool, thread_state, false, "Collect thread states");
 
 using orbit_grpc_protos::GetModuleListResponse;
 using orbit_grpc_protos::ModuleInfo;

--- a/OrbitGl/UnitTestMockEnvironment.cpp
+++ b/OrbitGl/UnitTestMockEnvironment.cpp
@@ -11,9 +11,10 @@ ABSL_DECLARE_FLAG(bool, local);
 ABSL_DECLARE_FLAG(uint16_t, sampling_rate);
 ABSL_DECLARE_FLAG(bool, frame_pointer_unwinding);
 
-ABSL_DECLARE_FLAG(bool, enable_tracepoint_feature);
 ABSL_DECLARE_FLAG(bool, show_return_values);
 ABSL_DECLARE_FLAG(bool, enable_frame_pointer_validator);
+ABSL_DECLARE_FLAG(bool, enable_tracepoint_feature);
+ABSL_DECLARE_FLAG(bool, thread_state);
 
 // Flag usages
 ABSL_FLAG(bool, devmode, false, "Enable developer mode in the client's UI");
@@ -26,3 +27,4 @@ ABSL_FLAG(bool, enable_frame_pointer_validator, false, "Enable validation of fra
 ABSL_FLAG(bool, show_return_values, false, "Show return values on time slices");
 ABSL_FLAG(bool, enable_tracepoint_feature, false,
           "Enable the setting of the panel of kernel tracepoints");
+ABSL_FLAG(bool, thread_state, false, "Collect thread states");

--- a/OrbitGrpcProtos/capture.proto
+++ b/OrbitGrpcProtos/capture.proto
@@ -35,6 +35,8 @@ message CaptureOptions {
 
   repeated InstrumentedFunction instrumented_functions = 5;
 
+  bool trace_thread_state = 8;
+
   bool trace_gpu_driver = 6;
 
   repeated TracepointInfo instrumented_tracepoint = 7;

--- a/OrbitGrpcProtos/capture.proto
+++ b/OrbitGrpcProtos/capture.proto
@@ -118,10 +118,39 @@ message GpuJob {
 }
 
 message ThreadName {
-  int32 pid = 1;
+  int32 pid = 1;  // Note that pid is currently not set.
   int32 tid = 2;
   string name = 3;
   uint64 timestamp_ns = 4;
+}
+
+message ThreadStateSlice {
+  int32 pid = 1;  // pid is currently not set as we don't have the information.
+  int32 tid = 2;
+
+  // These are the ones listed in
+  // /sys/kernel/debug/tracing/events/sched/sched_switch/format and in
+  // https://github.com/torvalds/linux/blob/master/fs/proc/array.c in
+  // task_state_array[], with the difference that the OS doesn't distinguish
+  // between "running" (scheduled on a CPU) and "runnable" (ready to be
+  // scheduled but not actually scheduled), rather they are the same state
+  // (often referred to as "running", sometimes as "runnable or running").
+  enum ThreadState {
+    kRunning = 0;
+    kRunnable = 1;
+    kInterruptibleSleep = 2;
+    kUninterruptibleSleep = 3;
+    kStopped = 4;
+    kTraced = 5;
+    kDead = 6;
+    kZombie = 7;
+    kParked = 8;
+    kIdle = 9;
+  }
+  ThreadState thread_state = 3;
+
+  uint64 begin_timestamp_ns = 4;
+  uint64 end_timestamp_ns = 5;
 }
 
 message AddressInfo {
@@ -146,6 +175,7 @@ message CaptureEvent {
     InternedString interned_string = 5;
     GpuJob gpu_job = 6;
     ThreadName thread_name = 7;
+    ThreadStateSlice thread_state_slice = 11;
     AddressInfo address_info = 8;
     InternedTracepointInfo interned_tracepoint_info = 9;
     TracepointEvent tracepoint_event = 10;

--- a/OrbitLinuxTracing/CMakeLists.txt
+++ b/OrbitLinuxTracing/CMakeLists.txt
@@ -72,6 +72,7 @@ if (NOT WIN32)
             ContextSwitchManagerTest.cpp
             LinuxTracingUtilsTest.cpp
             PerfEventProcessorTest.cpp
+            ThreadStateVisitorTest.cpp
             UprobesFunctionCallManagerTest.cpp
             UprobesReturnAddressManagerTest.cpp)
 endif()

--- a/OrbitLinuxTracing/CMakeLists.txt
+++ b/OrbitLinuxTracing/CMakeLists.txt
@@ -47,6 +47,8 @@ target_sources(OrbitLinuxTracing PRIVATE
         PerfEventRingBuffer.cpp
         PerfEventRingBuffer.h
         PerfEventVisitor.h
+        ThreadStateVisitor.cpp
+        ThreadStateVisitor.h
         Tracer.cpp
         TracerThread.cpp
         TracerThread.h

--- a/OrbitLinuxTracing/KernelTracepoints.h
+++ b/OrbitLinuxTracing/KernelTracepoints.h
@@ -33,6 +33,18 @@ struct __attribute__((__packed__)) task_rename_tracepoint {
   int16_t oom_score_adj;
 };
 
+struct __attribute__((__packed__)) sched_switch_tracepoint {
+  tracepoint_common common;
+  char prev_comm[16];
+  int32_t prev_pid;
+  int32_t prev_prio;
+  int64_t prev_state;
+  char next_comm[16];
+  int32_t next_pid;
+  int32_t next_prio;
+  uint32_t reserved;  // These four bytes are not documented in the format file.
+};
+
 struct __attribute__((__packed__)) amdgpu_cs_ioctl_tracepoint {
   tracepoint_common common;
   uint64_t sched_job_id;

--- a/OrbitLinuxTracing/KernelTracepoints.h
+++ b/OrbitLinuxTracing/KernelTracepoints.h
@@ -45,6 +45,15 @@ struct __attribute__((__packed__)) sched_switch_tracepoint {
   uint32_t reserved;  // These four bytes are not documented in the format file.
 };
 
+struct __attribute__((__packed__)) sched_wakeup_tracepoint {
+  tracepoint_common common;
+  char comm[16];
+  int32_t pid;
+  int32_t prio;
+  int32_t success;
+  int32_t target_cpu;
+};
+
 struct __attribute__((__packed__)) amdgpu_cs_ioctl_tracepoint {
   tracepoint_common common;
   uint64_t sched_job_id;

--- a/OrbitLinuxTracing/PerfEvent.cpp
+++ b/OrbitLinuxTracing/PerfEvent.cpp
@@ -38,6 +38,8 @@ void TaskRenamePerfEvent::Accept(PerfEventVisitor* visitor) { visitor->visit(thi
 
 void SchedSwitchPerfEvent::Accept(PerfEventVisitor* visitor) { visitor->visit(this); }
 
+void SchedWakeupPerfEvent::Accept(PerfEventVisitor* visitor) { visitor->visit(this); }
+
 void AmdgpuCsIoctlPerfEvent::Accept(PerfEventVisitor* visitor) { visitor->visit(this); }
 
 void AmdgpuSchedRunJobPerfEvent::Accept(PerfEventVisitor* visitor) { visitor->visit(this); }

--- a/OrbitLinuxTracing/PerfEvent.cpp
+++ b/OrbitLinuxTracing/PerfEvent.cpp
@@ -36,6 +36,8 @@ void TaskNewtaskPerfEvent::Accept(PerfEventVisitor* visitor) { visitor->visit(th
 
 void TaskRenamePerfEvent::Accept(PerfEventVisitor* visitor) { visitor->visit(this); }
 
+void SchedSwitchPerfEvent::Accept(PerfEventVisitor* visitor) { visitor->visit(this); }
+
 void AmdgpuCsIoctlPerfEvent::Accept(PerfEventVisitor* visitor) { visitor->visit(this); }
 
 void AmdgpuSchedRunJobPerfEvent::Accept(PerfEventVisitor* visitor) { visitor->visit(this); }

--- a/OrbitLinuxTracing/PerfEvent.h
+++ b/OrbitLinuxTracing/PerfEvent.h
@@ -409,6 +409,20 @@ class SchedSwitchPerfEvent : public TracepointPerfEvent {
   pid_t GetNextTid() const { return GetTypedTracepointData<sched_switch_tracepoint>().next_pid; }
 };
 
+class SchedWakeupPerfEvent : public TracepointPerfEvent {
+ public:
+  explicit SchedWakeupPerfEvent(uint32_t tracepoint_size) : TracepointPerfEvent(tracepoint_size) {}
+
+  void Accept(PerfEventVisitor* visitor) override;
+
+  pid_t GetWakerPid() const { return ring_buffer_record.sample_id.pid; }
+
+  pid_t GetWakerTid() const { return ring_buffer_record.sample_id.tid; }
+
+  // The tracepoint format calls this "pid" but it's effectively the thread id.
+  pid_t GetWokenTid() const { return GetTypedTracepointData<sched_wakeup_tracepoint>().pid; }
+};
+
 class GpuPerfEvent : public TracepointPerfEvent {
  public:
   explicit GpuPerfEvent(uint32_t tracepoint_size) : TracepointPerfEvent(tracepoint_size) {}

--- a/OrbitLinuxTracing/PerfEvent.h
+++ b/OrbitLinuxTracing/PerfEvent.h
@@ -386,6 +386,29 @@ class TaskRenamePerfEvent : public TracepointPerfEvent {
   }
 };
 
+class SchedSwitchPerfEvent : public TracepointPerfEvent {
+ public:
+  explicit SchedSwitchPerfEvent(uint32_t tracepoint_size) : TracepointPerfEvent(tracepoint_size) {}
+
+  void Accept(PerfEventVisitor* visitor) override;
+
+  const char* GetPrevComm() const {
+    return GetTypedTracepointData<sched_switch_tracepoint>().prev_comm;
+  }
+
+  pid_t GetPrevTid() const { return GetTypedTracepointData<sched_switch_tracepoint>().prev_pid; }
+
+  int64_t GetPrevState() const {
+    return GetTypedTracepointData<sched_switch_tracepoint>().prev_state;
+  }
+
+  const char* GetNextComm() const {
+    return GetTypedTracepointData<sched_switch_tracepoint>().next_comm;
+  }
+
+  pid_t GetNextTid() const { return GetTypedTracepointData<sched_switch_tracepoint>().next_pid; }
+};
+
 class GpuPerfEvent : public TracepointPerfEvent {
  public:
   explicit GpuPerfEvent(uint32_t tracepoint_size) : TracepointPerfEvent(tracepoint_size) {}

--- a/OrbitLinuxTracing/PerfEventVisitor.h
+++ b/OrbitLinuxTracing/PerfEventVisitor.h
@@ -26,6 +26,7 @@ class PerfEventVisitor {
   virtual void visit(TaskNewtaskPerfEvent*) {}
   virtual void visit(TaskRenamePerfEvent*) {}
   virtual void visit(SchedSwitchPerfEvent*) {}
+  virtual void visit(SchedWakeupPerfEvent*) {}
   virtual void visit(AmdgpuCsIoctlPerfEvent*) {}
   virtual void visit(AmdgpuSchedRunJobPerfEvent*) {}
   virtual void visit(DmaFenceSignaledPerfEvent*) {}

--- a/OrbitLinuxTracing/PerfEventVisitor.h
+++ b/OrbitLinuxTracing/PerfEventVisitor.h
@@ -25,6 +25,7 @@ class PerfEventVisitor {
   virtual void visit(MapsPerfEvent*) {}
   virtual void visit(TaskNewtaskPerfEvent*) {}
   virtual void visit(TaskRenamePerfEvent*) {}
+  virtual void visit(SchedSwitchPerfEvent*) {}
   virtual void visit(AmdgpuCsIoctlPerfEvent*) {}
   virtual void visit(AmdgpuSchedRunJobPerfEvent*) {}
   virtual void visit(DmaFenceSignaledPerfEvent*) {}

--- a/OrbitLinuxTracing/ThreadStateVisitor.cpp
+++ b/OrbitLinuxTracing/ThreadStateVisitor.cpp
@@ -1,0 +1,38 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ThreadStateVisitor.h"
+
+namespace LinuxTracing {
+
+void ThreadStateVisitor::ProcessInitialState(uint64_t /*timestamp_ns*/, pid_t tid,
+                                             char state_char) {
+  LOG("ProcessInitialState(tid=%d, state_char=%c)", tid, state_char);
+}
+
+void ThreadStateVisitor::visit(TaskNewtaskPerfEvent* event) {
+  CHECK(listener_ != nullptr);
+  LOG("task/task_newtask | tid: %d", event->GetTid());
+}
+
+void ThreadStateVisitor::visit(SchedSwitchPerfEvent* event) {
+  CHECK(listener_ != nullptr);
+  LOG("sched/sched_switch | prev_comm: %s, prev_pid: %d, prev_state: %#lx; next_comm: %s, "
+      "next_pid: %d",
+      event->GetPrevComm(), event->GetPrevTid(), event->GetPrevState(), event->GetNextComm(),
+      event->GetNextTid());
+}
+
+void ThreadStateVisitor::visit(SchedWakeupPerfEvent* event) {
+  CHECK(listener_ != nullptr);
+  LOG("sched/sched_wakeup | (waker)pid: %d, (waker)tid: %d; (woken)tid: %d", event->GetWakerPid(),
+      event->GetWakerTid(), event->GetWokenTid());
+}
+
+void ThreadStateVisitor::ProcessRemainingOpenStates(uint64_t /*timestamp_ns*/) {
+  CHECK(listener_ != nullptr);
+  LOG("ProcessRemainingOpenStates");
+}
+
+}  // namespace LinuxTracing

--- a/OrbitLinuxTracing/ThreadStateVisitor.cpp
+++ b/OrbitLinuxTracing/ThreadStateVisitor.cpp
@@ -6,33 +6,271 @@
 
 namespace LinuxTracing {
 
-void ThreadStateVisitor::ProcessInitialState(uint64_t /*timestamp_ns*/, pid_t tid,
-                                             char state_char) {
-  LOG("ProcessInitialState(tid=%d, state_char=%c)", tid, state_char);
+using orbit_grpc_protos::ThreadStateSlice;
+
+// Note: Since we use PerfEventProcessor to process perf_event_open events in order, OnNewTask,
+// OnSchedWakeup, OnSchedSwitchIn, OnSchedSwitchOut are expected to be called in order of
+// timestamp. But the initial thread states are retrieved (and OnInitialState is called) after the
+// perf_event_open file descriptors have been enabled, so that we don't lose thread states between
+// retrieving the initial states and enabling the file descriptors. It is then common for some of
+// the first tracepoint events to have a timestamp lower than the timestamp of initial retrieval. In
+// all these cases, we discard the previous known state (the one retrieved at the beginning, with a
+// larger timestamp) and replace it with the thread state carried by the tracepoint.
+
+void ThreadStateManager::OnInitialState(uint64_t timestamp_ns, pid_t tid,
+                                        ThreadStateSlice::ThreadState state) {
+  CHECK(!tid_open_states_.contains(tid));
+  tid_open_states_.emplace(tid, OpenState{state, timestamp_ns});
+}
+
+void ThreadStateManager::OnNewTask(uint64_t timestamp_ns, pid_t tid) {
+  static constexpr ThreadStateSlice::ThreadState kNewState = ThreadStateSlice::kRunnable;
+
+  if (auto open_state_it = tid_open_states_.find(tid);
+      open_state_it != tid_open_states_.end() &&
+      timestamp_ns >= open_state_it->second.begin_timestamp_ns) {
+    ERROR("Processed task:task_newtask but thread %d was already known", tid);
+    return;
+  }
+  tid_open_states_.insert_or_assign(tid, OpenState{kNewState, timestamp_ns});
+}
+
+std::optional<ThreadStateSlice> ThreadStateManager::OnSchedWakeup(uint64_t timestamp_ns,
+                                                                  pid_t tid) {
+  static constexpr ThreadStateSlice::ThreadState kNewState = ThreadStateSlice::kRunnable;
+
+  auto open_state_it = tid_open_states_.find(tid);
+  if (open_state_it == tid_open_states_.end()) {
+    ERROR("Processed sched:sched_wakeup but previous state of thread %d is unknown", tid);
+    tid_open_states_.insert_or_assign(tid, OpenState{kNewState, timestamp_ns});
+    return std::nullopt;
+  }
+
+  const OpenState& open_state = open_state_it->second;
+  if (timestamp_ns < open_state.begin_timestamp_ns) {
+    // As noted above, overwrite the thread state retrieved at the beginning.
+    tid_open_states_.insert_or_assign(tid, OpenState{kNewState, timestamp_ns});
+    return std::nullopt;
+  }
+
+  if (open_state.state == kNewState || open_state.state == ThreadStateSlice::kRunning) {
+    // It seems to be somewhat common for a thread to receive a wakeup
+    // while already in runnable or running state: disregard the state change.
+    return std::nullopt;
+  }
+
+  if (open_state.state == ThreadStateSlice::kZombie ||
+      open_state.state == ThreadStateSlice::kDead) {
+    ERROR("Processed sched:sched_wakeup for thread %d but unexpected previous state %s", tid,
+          ThreadStateSlice::ThreadState_Name(open_state.state));
+  }
+
+  ThreadStateSlice slice;
+  slice.set_tid(tid);
+  slice.set_thread_state(open_state.state);
+  slice.set_begin_timestamp_ns(open_state.begin_timestamp_ns);
+  slice.set_end_timestamp_ns(timestamp_ns);
+  tid_open_states_.insert_or_assign(tid, OpenState{kNewState, timestamp_ns});
+  return slice;
+}
+
+std::optional<ThreadStateSlice> ThreadStateManager::OnSchedSwitchIn(uint64_t timestamp_ns,
+                                                                    pid_t tid) {
+  static constexpr ThreadStateSlice::ThreadState kNewState = ThreadStateSlice::kRunning;
+
+  auto open_state_it = tid_open_states_.find(tid);
+  if (open_state_it == tid_open_states_.end()) {
+    ERROR("Processed sched:sched_switch(in) but previous state of thread %d is unknown", tid);
+    tid_open_states_.insert_or_assign(tid, OpenState{kNewState, timestamp_ns});
+    return std::nullopt;
+  }
+
+  const OpenState& open_state = open_state_it->second;
+  if (timestamp_ns < open_state.begin_timestamp_ns) {
+    tid_open_states_.insert_or_assign(tid, OpenState{kNewState, timestamp_ns});
+    return std::nullopt;
+  }
+
+  if (open_state.state == kNewState) {
+    // No state change: do nothing and don't overwrite the previous begin timestamp.
+    return std::nullopt;
+  }
+
+  // Don't print an error even if open_state.state != ThreadStateSlice::kRunnable: it seems to be
+  // sometimes possible for a thread to go from a non-runnable state directly to running, skipping
+  // the sched:sched_wakeup event.
+
+  ThreadStateSlice slice;
+  slice.set_tid(tid);
+  slice.set_thread_state(open_state.state);
+  slice.set_begin_timestamp_ns(open_state.begin_timestamp_ns);
+  slice.set_end_timestamp_ns(timestamp_ns);
+  tid_open_states_.insert_or_assign(tid, OpenState{kNewState, timestamp_ns});
+  return slice;
+}
+
+std::optional<ThreadStateSlice> ThreadStateManager::OnSchedSwitchOut(
+    uint64_t timestamp_ns, pid_t tid, ThreadStateSlice::ThreadState new_state) {
+  auto open_state_it = tid_open_states_.find(tid);
+  if (open_state_it == tid_open_states_.end()) {
+    ERROR("Processed sched:sched_switch(out) but previous state of thread %d is unknown", tid);
+    tid_open_states_.insert_or_assign(tid, OpenState{new_state, timestamp_ns});
+    return std::nullopt;
+  }
+
+  const OpenState& open_state = open_state_it->second;
+  if (timestamp_ns < open_state.begin_timestamp_ns) {
+    tid_open_states_.insert_or_assign(tid, OpenState{new_state, timestamp_ns});
+    return std::nullopt;
+  }
+
+  // As we are switching out of a CPU, if the previous state was kRunnable, assume it was kRunning.
+  // This is because when we retrieve the initial thread states we have no way to distinguish
+  // between kRunnable and kRunning. After all, for the OS they are the same state.
+  ThreadStateSlice::ThreadState adjusted_open_state_state = open_state.state;
+  if (adjusted_open_state_state == ThreadStateSlice::kRunnable) {
+    adjusted_open_state_state = ThreadStateSlice::kRunning;
+  }
+
+  if (adjusted_open_state_state != ThreadStateSlice::kRunning) {
+    ERROR("Processed sched:sched_switch(out) for thread %d but unexpected previous state %s", tid,
+          ThreadStateSlice::ThreadState_Name(adjusted_open_state_state));
+    if (adjusted_open_state_state == new_state) {
+      // No state change: do nothing and don't overwrite the previous begin timestamp.
+      return std::nullopt;
+    }
+  }
+
+  ThreadStateSlice slice;
+  slice.set_tid(tid);
+  slice.set_thread_state(adjusted_open_state_state);
+  slice.set_begin_timestamp_ns(open_state.begin_timestamp_ns);
+  slice.set_end_timestamp_ns(timestamp_ns);
+
+  // Note: If the thread exits but the new_state is kZombie instead of kDead,
+  // the switch to kDead will never be reported.
+  tid_open_states_.insert_or_assign(tid, OpenState{new_state, timestamp_ns});
+  return slice;
+}
+
+std::vector<ThreadStateSlice> ThreadStateManager::OnCaptureFinished(uint64_t timestamp_ns) {
+  std::vector<ThreadStateSlice> slices;
+  for (const auto& [tid, open_state] : tid_open_states_) {
+    ThreadStateSlice slice;
+    slice.set_tid(tid);
+    slice.set_thread_state(open_state.state);
+    slice.set_begin_timestamp_ns(open_state.begin_timestamp_ns);
+    slice.set_end_timestamp_ns(timestamp_ns);
+    slices.emplace_back(std::move(slice));
+  }
+  return slices;
+}
+
+void ThreadStateVisitor::ProcessInitialState(uint64_t timestamp_ns, pid_t tid, char state_char) {
+  std::optional<ThreadStateSlice::ThreadState> initial_state = GetThreadStateFromChar(state_char);
+  if (!initial_state.has_value()) {
+    ERROR("Parsing thread state char '%c' for tid %d", state_char, tid);
+    return;
+  }
+  state_manager_.OnInitialState(timestamp_ns, tid, initial_state.value());
 }
 
 void ThreadStateVisitor::visit(TaskNewtaskPerfEvent* event) {
   CHECK(listener_ != nullptr);
-  LOG("task/task_newtask | tid: %d", event->GetTid());
+  state_manager_.OnNewTask(event->GetTimestamp(), event->GetTid());
 }
 
 void ThreadStateVisitor::visit(SchedSwitchPerfEvent* event) {
   CHECK(listener_ != nullptr);
-  LOG("sched/sched_switch | prev_comm: %s, prev_pid: %d, prev_state: %#lx; next_comm: %s, "
-      "next_pid: %d",
-      event->GetPrevComm(), event->GetPrevTid(), event->GetPrevState(), event->GetNextComm(),
-      event->GetNextTid());
+  // Switches with tid 0 are associated with idle CPU, don't consider them.
+  if (event->GetPrevTid() != 0) {
+    ThreadStateSlice::ThreadState new_state = GetThreadStateFromBits(event->GetPrevState());
+    std::optional<ThreadStateSlice> out_slice =
+        state_manager_.OnSchedSwitchOut(event->GetTimestamp(), event->GetPrevTid(), new_state);
+    if (out_slice.has_value()) {
+      listener_->OnThreadStateSlice(std::move(out_slice.value()));
+    }
+  }
+  if (event->GetNextTid() != 0) {
+    std::optional<ThreadStateSlice> in_slice =
+        state_manager_.OnSchedSwitchIn(event->GetTimestamp(), event->GetNextTid());
+    if (in_slice.has_value()) {
+      listener_->OnThreadStateSlice(std::move(in_slice.value()));
+    }
+  }
 }
 
 void ThreadStateVisitor::visit(SchedWakeupPerfEvent* event) {
   CHECK(listener_ != nullptr);
-  LOG("sched/sched_wakeup | (waker)pid: %d, (waker)tid: %d; (woken)tid: %d", event->GetWakerPid(),
-      event->GetWakerTid(), event->GetWokenTid());
+  std::optional<ThreadStateSlice> state_slice =
+      state_manager_.OnSchedWakeup(event->GetTimestamp(), event->GetWokenTid());
+  if (state_slice.has_value()) {
+    listener_->OnThreadStateSlice(std::move(state_slice.value()));
+  }
 }
 
-void ThreadStateVisitor::ProcessRemainingOpenStates(uint64_t /*timestamp_ns*/) {
+void ThreadStateVisitor::ProcessRemainingOpenStates(uint64_t timestamp_ns) {
   CHECK(listener_ != nullptr);
-  LOG("ProcessRemainingOpenStates");
+  std::vector<ThreadStateSlice> state_slices = state_manager_.OnCaptureFinished(timestamp_ns);
+  for (ThreadStateSlice& slice : state_slices) {
+    listener_->OnThreadStateSlice(slice);
+  }
+}
+
+// Associates a ThreadStateSlice::ThreadState to a thread state character retrieved from
+// /proc/<pid>/stat or the `ps` command. The possible characters are obtained from
+// /sys/kernel/debug/tracing/events/sched/sched_switch/format and compared with the ones listed in
+// https://man7.org/linux/man-pages/man5/proc.5.html and
+// https://www.man7.org/linux/man-pages/man1/ps.1.html#PROCESS_STATE_CODES to make sure we are not
+// missing any additional valid one.
+std::optional<ThreadStateSlice::ThreadState> ThreadStateVisitor::GetThreadStateFromChar(char c) {
+  switch (c) {
+    case 'R':
+      return ThreadStateSlice::kRunnable;
+    case 'S':
+      return ThreadStateSlice::kInterruptibleSleep;
+    case 'D':
+      return ThreadStateSlice::kUninterruptibleSleep;
+    case 'T':
+      return ThreadStateSlice::kStopped;
+    case 't':
+      return ThreadStateSlice::kTraced;
+    case 'X':
+      return ThreadStateSlice::kDead;
+    case 'Z':
+      return ThreadStateSlice::kZombie;
+    case 'P':
+      // Note that 'P' (Parked) is only valid from Linux 3.9 to 3.13, but we still include it as it
+      // is mentioned in /sys/kernel/debug/tracing/events/sched/sched_switch/format and in
+      // https://github.com/torvalds/linux/blob/master/fs/proc/array.c.
+      return ThreadStateSlice::kParked;
+    case 'I':
+      // 'I' (Idle) only applies to kernel threads. See
+      // https://github.com/torvalds/linux/commit/06eb61844d841d0032a9950ce7f8e783ee49c0d0.
+      return ThreadStateSlice::kIdle;
+    default:
+      return std::nullopt;
+  }
+}
+
+// Associates a ThreadStateSlice::ThreadState to the bits of the prev_state field of the
+// sched:sched_switch tracepoint. The association is given away by "print fmt" in
+// /sys/kernel/debug/tracing/events/sched/sched_switch/format or by
+// https://github.com/torvalds/linux/blob/master/fs/proc/array.c.
+ThreadStateSlice::ThreadState ThreadStateVisitor::GetThreadStateFromBits(uint64_t bits) {
+  if (__builtin_popcountl(bits & 0xFF) > 1) {
+    ERROR("The thread state mask %#lx is a combination of states, reporting only the first",
+          bits & 0xFF);
+  }
+  if ((bits & 0x01) != 0) return ThreadStateSlice::kInterruptibleSleep;
+  if ((bits & 0x02) != 0) return ThreadStateSlice::kUninterruptibleSleep;
+  if ((bits & 0x04) != 0) return ThreadStateSlice::kStopped;
+  if ((bits & 0x08) != 0) return ThreadStateSlice::kTraced;
+  if ((bits & 0x10) != 0) return ThreadStateSlice::kDead;
+  if ((bits & 0x20) != 0) return ThreadStateSlice::kZombie;
+  if ((bits & 0x40) != 0) return ThreadStateSlice::kParked;
+  if ((bits & 0x80) != 0) return ThreadStateSlice::kIdle;
+  return ThreadStateSlice::kRunnable;
 }
 
 }  // namespace LinuxTracing

--- a/OrbitLinuxTracing/ThreadStateVisitor.h
+++ b/OrbitLinuxTracing/ThreadStateVisitor.h
@@ -8,8 +8,61 @@
 #include <OrbitLinuxTracing/TracerListener.h>
 
 #include "PerfEventVisitor.h"
+#include "absl/container/flat_hash_map.h"
 
 namespace LinuxTracing {
+
+// ThreadStateManager stores the state of threads, handles the state transitions,
+// builds and returns ThreadStateSlices.
+// The following diagram shows the relationship between the states and the tracepoints.
+// Note that, for some state transitions multiple tracepoints could be used
+// (e.g., both sched:sched_waking and sched:sched_wakeup for "not runnable" to "runnable").
+// The diagram indicates them all but we only use the ones not in parentheses.
+// Also note we don't have a transition out of the diagram for a thread that exits.
+// Instead, a thread that has exited will remain "not runnable" with state "dead"
+// or sometimes "zombie". This is mostly for simplicity reasons,
+// as a thread that exits first goes through sched:sched_process_exit,
+// but then still goes through one or often multiple sched:sched_switches.
+//
+//       task:task_newtask                             sched:sched_switch(in)
+//   (OR sched:sched_wakeup_new)    ------------ -------------------------------> -----------
+// -------------------------------> | Runnable |                                  | Running |
+//                                  ------------ <------------------------------- -----------
+//                                       ^            sched:sched_switch(out)       ^  |
+//                                       |             with prev_state=='R'         .  |
+//                                       |                                          .  |
+//                                       |                   sched:sched_switch(in) .  |
+//                                       |               ---------------- . . . . . .  |
+//                                       |               | Not runnable |              |
+//                                       --------------- | incl. exited | <-------------
+//                                sched:sched_wakeup     ----------------    sched_switch(out)
+//                             (OR sched:sched_waking)                      with prev_state!='R'
+//                                                                   (ALSO sched:sched_process_exit)
+
+class ThreadStateManager {
+ public:
+  void OnInitialState(uint64_t timestamp_ns, pid_t tid,
+                      orbit_grpc_protos::ThreadStateSlice::ThreadState state);
+  void OnNewTask(uint64_t timestamp_ns, pid_t tid);
+  [[nodiscard]] std::optional<orbit_grpc_protos::ThreadStateSlice> OnSchedWakeup(
+      uint64_t timestamp_ns, pid_t tid);
+  [[nodiscard]] std::optional<orbit_grpc_protos::ThreadStateSlice> OnSchedSwitchIn(
+      uint64_t timestamp_ns, pid_t tid);
+  [[nodiscard]] std::optional<orbit_grpc_protos::ThreadStateSlice> OnSchedSwitchOut(
+      uint64_t timestamp_ns, pid_t tid, orbit_grpc_protos::ThreadStateSlice::ThreadState new_state);
+  [[nodiscard]] std::vector<orbit_grpc_protos::ThreadStateSlice> OnCaptureFinished(
+      uint64_t timestamp_ns);
+
+ private:
+  struct OpenState {
+    OpenState(orbit_grpc_protos::ThreadStateSlice::ThreadState state, uint64_t begin_timestamp_ns)
+        : state{state}, begin_timestamp_ns{begin_timestamp_ns} {}
+    orbit_grpc_protos::ThreadStateSlice::ThreadState state;
+    uint64_t begin_timestamp_ns;
+  };
+
+  absl::flat_hash_map<pid_t, OpenState> tid_open_states_;
+};
 
 class ThreadStateVisitor : public PerfEventVisitor {
  public:
@@ -22,7 +75,12 @@ class ThreadStateVisitor : public PerfEventVisitor {
   void ProcessRemainingOpenStates(uint64_t timestamp_ns);
 
  private:
+  static std::optional<orbit_grpc_protos::ThreadStateSlice::ThreadState> GetThreadStateFromChar(
+      char c);
+  static orbit_grpc_protos::ThreadStateSlice::ThreadState GetThreadStateFromBits(uint64_t bits);
+
   TracerListener* listener_ = nullptr;
+  ThreadStateManager state_manager_;
 };
 
 }  // namespace LinuxTracing

--- a/OrbitLinuxTracing/ThreadStateVisitor.h
+++ b/OrbitLinuxTracing/ThreadStateVisitor.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_LINUX_TRACING_THREAD_STATE_VISITOR_H_
+#define ORBIT_LINUX_TRACING_THREAD_STATE_VISITOR_H_
+
+#include <OrbitLinuxTracing/TracerListener.h>
+
+#include "PerfEventVisitor.h"
+
+namespace LinuxTracing {
+
+class ThreadStateVisitor : public PerfEventVisitor {
+ public:
+  void SetListener(TracerListener* listener) { listener_ = listener; }
+
+  void ProcessInitialState(uint64_t timestamp_ns, pid_t tid, char state_char);
+  void visit(TaskNewtaskPerfEvent* event) override;
+  void visit(SchedSwitchPerfEvent* event) override;
+  void visit(SchedWakeupPerfEvent* event) override;
+  void ProcessRemainingOpenStates(uint64_t timestamp_ns);
+
+ private:
+  TracerListener* listener_ = nullptr;
+};
+
+}  // namespace LinuxTracing
+
+#endif  // ORBIT_LINUX_TRACING_THREAD_STATE_VISITOR_H_

--- a/OrbitLinuxTracing/ThreadStateVisitorTest.cpp
+++ b/OrbitLinuxTracing/ThreadStateVisitorTest.cpp
@@ -1,0 +1,340 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include "ThreadStateVisitor.h"
+
+namespace LinuxTracing {
+
+using orbit_grpc_protos::ThreadStateSlice;
+
+TEST(ThreadStateManager, OneThread) {
+  constexpr pid_t kTid = 42;
+  ThreadStateManager manager;
+  std::optional<ThreadStateSlice> slice;
+
+  manager.OnInitialState(100, kTid, ThreadStateSlice::kRunnable);
+
+  slice = manager.OnSchedSwitchIn(200, kTid);
+  ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->tid(), kTid);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
+  EXPECT_EQ(slice->begin_timestamp_ns(), 100);
+  EXPECT_EQ(slice->end_timestamp_ns(), 200);
+
+  slice = manager.OnSchedSwitchOut(300, kTid, ThreadStateSlice::kInterruptibleSleep);
+  ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->tid(), kTid);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
+  EXPECT_EQ(slice->begin_timestamp_ns(), 200);
+  EXPECT_EQ(slice->end_timestamp_ns(), 300);
+
+  slice = manager.OnSchedWakeup(400, kTid);
+  ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->tid(), kTid);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kInterruptibleSleep);
+  EXPECT_EQ(slice->begin_timestamp_ns(), 300);
+  EXPECT_EQ(slice->end_timestamp_ns(), 400);
+
+  slice = manager.OnSchedSwitchIn(500, kTid);
+  ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->tid(), kTid);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
+  EXPECT_EQ(slice->begin_timestamp_ns(), 400);
+  EXPECT_EQ(slice->end_timestamp_ns(), 500);
+
+  std::vector<ThreadStateSlice> slices = manager.OnCaptureFinished(600);
+  ASSERT_TRUE(!slices.empty());
+  EXPECT_EQ(slices.size(), 1);
+  slice = slices[0];
+  EXPECT_EQ(slice->tid(), kTid);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
+  EXPECT_EQ(slice->begin_timestamp_ns(), 500);
+  EXPECT_EQ(slice->end_timestamp_ns(), 600);
+}
+
+TEST(ThreadStateManager, NewTask) {
+  constexpr pid_t kTid = 42;
+  ThreadStateManager manager;
+  std::optional<ThreadStateSlice> slice;
+
+  manager.OnNewTask(100, kTid);
+
+  slice = manager.OnSchedSwitchIn(200, kTid);
+  ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->tid(), kTid);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
+  EXPECT_EQ(slice->begin_timestamp_ns(), 100);
+  EXPECT_EQ(slice->end_timestamp_ns(), 200);
+
+  slice = manager.OnSchedSwitchOut(300, kTid, ThreadStateSlice::kRunnable);
+  ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->tid(), kTid);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
+  EXPECT_EQ(slice->begin_timestamp_ns(), 200);
+  EXPECT_EQ(slice->end_timestamp_ns(), 300);
+
+  std::vector<ThreadStateSlice> slices = manager.OnCaptureFinished(400);
+  ASSERT_TRUE(!slices.empty());
+  EXPECT_EQ(slices.size(), 1);
+  slice = slices[0];
+  EXPECT_EQ(slice->tid(), kTid);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
+  EXPECT_EQ(slice->begin_timestamp_ns(), 300);
+  EXPECT_EQ(slice->end_timestamp_ns(), 400);
+}
+
+TEST(ThreadStateManager, TwoThreads) {
+  constexpr pid_t kTid1 = 42;
+  constexpr pid_t kTid2 = 52;
+  ThreadStateManager manager;
+  std::optional<ThreadStateSlice> slice;
+
+  manager.OnInitialState(100, kTid1, ThreadStateSlice::kRunnable);
+
+  slice = manager.OnSchedSwitchIn(200, kTid1);
+  ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->tid(), kTid1);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
+  EXPECT_EQ(slice->begin_timestamp_ns(), 100);
+  EXPECT_EQ(slice->end_timestamp_ns(), 200);
+
+  manager.OnNewTask(250, kTid2);
+
+  slice = manager.OnSchedSwitchOut(300, kTid1, ThreadStateSlice::kInterruptibleSleep);
+  ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->tid(), kTid1);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
+  EXPECT_EQ(slice->begin_timestamp_ns(), 200);
+  EXPECT_EQ(slice->end_timestamp_ns(), 300);
+
+  slice = manager.OnSchedSwitchIn(350, kTid2);
+  ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->tid(), kTid2);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
+  EXPECT_EQ(slice->begin_timestamp_ns(), 250);
+  EXPECT_EQ(slice->end_timestamp_ns(), 350);
+
+  slice = manager.OnSchedWakeup(400, kTid1);
+  ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->tid(), kTid1);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kInterruptibleSleep);
+  EXPECT_EQ(slice->begin_timestamp_ns(), 300);
+  EXPECT_EQ(slice->end_timestamp_ns(), 400);
+
+  slice = manager.OnSchedSwitchOut(450, kTid2, ThreadStateSlice::kRunnable);
+  ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->tid(), kTid2);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
+  EXPECT_EQ(slice->begin_timestamp_ns(), 350);
+  EXPECT_EQ(slice->end_timestamp_ns(), 450);
+
+  slice = manager.OnSchedSwitchIn(500, kTid1);
+  ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->tid(), kTid1);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
+  EXPECT_EQ(slice->begin_timestamp_ns(), 400);
+  EXPECT_EQ(slice->end_timestamp_ns(), 500);
+
+  std::vector<ThreadStateSlice> slices = manager.OnCaptureFinished(600);
+  ASSERT_TRUE(slices.size() >= 2);
+  EXPECT_EQ(slices.size(), 2);
+
+  if (slices[0].tid() > slices[1].tid()) {
+    std::swap(slices[0], slices[1]);
+  }
+
+  slice = slices[0];
+  EXPECT_EQ(slice->tid(), kTid1);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
+  EXPECT_EQ(slice->begin_timestamp_ns(), 500);
+  EXPECT_EQ(slice->end_timestamp_ns(), 600);
+
+  slice = slices[1];
+  EXPECT_EQ(slice->tid(), kTid2);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
+  EXPECT_EQ(slice->begin_timestamp_ns(), 450);
+  EXPECT_EQ(slice->end_timestamp_ns(), 600);
+}
+
+TEST(ThreadStateManager, SwitchOutAfterInitialStateRunnable) {
+  constexpr pid_t kTid = 42;
+  ThreadStateManager manager;
+  std::optional<ThreadStateSlice> slice;
+
+  manager.OnInitialState(100, kTid, ThreadStateSlice::kRunnable);
+
+  slice = manager.OnSchedSwitchOut(200, kTid, ThreadStateSlice::kInterruptibleSleep);
+  ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->tid(), kTid);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
+  EXPECT_EQ(slice->begin_timestamp_ns(), 100);
+  EXPECT_EQ(slice->end_timestamp_ns(), 200);
+}
+
+TEST(ThreadStateManager, StaleInitialStateWithNewTask) {
+  constexpr pid_t kTid = 42;
+  ThreadStateManager manager;
+  std::optional<ThreadStateSlice> slice;
+
+  manager.OnInitialState(150, kTid, ThreadStateSlice::kRunnable);
+
+  manager.OnNewTask(100, kTid);
+
+  slice = manager.OnSchedSwitchIn(200, kTid);
+  ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->tid(), kTid);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
+  EXPECT_EQ(slice->begin_timestamp_ns(), 100);
+  EXPECT_EQ(slice->end_timestamp_ns(), 200);
+}
+
+TEST(ThreadStateManager, StaleInitialStateWithSchedWakeup) {
+  constexpr pid_t kTid = 42;
+  ThreadStateManager manager;
+  std::optional<ThreadStateSlice> slice;
+
+  manager.OnInitialState(150, kTid, ThreadStateSlice::kRunnable);
+
+  slice = manager.OnSchedWakeup(100, kTid);
+  EXPECT_FALSE(slice.has_value());
+
+  slice = manager.OnSchedSwitchIn(200, kTid);
+  ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->tid(), kTid);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
+  EXPECT_EQ(slice->begin_timestamp_ns(), 100);
+  EXPECT_EQ(slice->end_timestamp_ns(), 200);
+}
+
+TEST(ThreadStateManager, StaleInitialStateWithSwitchIn) {
+  constexpr pid_t kTid = 42;
+  ThreadStateManager manager;
+  std::optional<ThreadStateSlice> slice;
+
+  manager.OnInitialState(150, kTid, ThreadStateSlice::kRunnable);
+
+  slice = manager.OnSchedSwitchIn(100, kTid);
+  EXPECT_FALSE(slice.has_value());
+
+  slice = manager.OnSchedSwitchOut(200, kTid, ThreadStateSlice::kRunnable);
+  ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->tid(), kTid);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
+  EXPECT_EQ(slice->begin_timestamp_ns(), 100);
+  EXPECT_EQ(slice->end_timestamp_ns(), 200);
+}
+
+TEST(ThreadStateManager, StaleInitialStateWithSwitchOut) {
+  constexpr pid_t kTid = 42;
+  ThreadStateManager manager;
+  std::optional<ThreadStateSlice> slice;
+
+  manager.OnInitialState(150, kTid, ThreadStateSlice::kRunnable);
+
+  slice = manager.OnSchedSwitchOut(100, kTid, ThreadStateSlice::kInterruptibleSleep);
+  EXPECT_FALSE(slice.has_value());
+
+  slice = manager.OnSchedWakeup(200, kTid);
+  ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->tid(), kTid);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kInterruptibleSleep);
+  EXPECT_EQ(slice->begin_timestamp_ns(), 100);
+  EXPECT_EQ(slice->end_timestamp_ns(), 200);
+}
+
+TEST(ThreadStateManager, UnknownInitialStateWithSchedWakeup) {
+  constexpr pid_t kTid = 42;
+  ThreadStateManager manager;
+  std::optional<ThreadStateSlice> slice;
+
+  slice = manager.OnSchedWakeup(100, kTid);
+  EXPECT_FALSE(slice.has_value());
+
+  slice = manager.OnSchedSwitchIn(200, kTid);
+  ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->tid(), kTid);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
+  EXPECT_EQ(slice->begin_timestamp_ns(), 100);
+  EXPECT_EQ(slice->end_timestamp_ns(), 200);
+}
+
+TEST(ThreadStateManager, UnknownInitialStateWithSwitchIn) {
+  constexpr pid_t kTid = 42;
+  ThreadStateManager manager;
+  std::optional<ThreadStateSlice> slice;
+
+  slice = manager.OnSchedSwitchIn(100, kTid);
+  EXPECT_FALSE(slice.has_value());
+
+  slice = manager.OnSchedSwitchOut(200, kTid, ThreadStateSlice::kRunnable);
+  ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->tid(), kTid);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
+  EXPECT_EQ(slice->begin_timestamp_ns(), 100);
+  EXPECT_EQ(slice->end_timestamp_ns(), 200);
+}
+
+TEST(ThreadStateManager, UnknownInitialStateWithSwitchOut) {
+  constexpr pid_t kTid = 42;
+  ThreadStateManager manager;
+  std::optional<ThreadStateSlice> slice;
+
+  slice = manager.OnSchedSwitchOut(100, kTid, ThreadStateSlice::kInterruptibleSleep);
+  EXPECT_FALSE(slice.has_value());
+
+  slice = manager.OnSchedWakeup(200, kTid);
+  ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->tid(), kTid);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kInterruptibleSleep);
+  EXPECT_EQ(slice->begin_timestamp_ns(), 100);
+  EXPECT_EQ(slice->end_timestamp_ns(), 200);
+}
+
+TEST(ThreadStateManager, NoStateChangeWithSchedWakeup) {
+  constexpr pid_t kTid = 42;
+  ThreadStateManager manager;
+  std::optional<ThreadStateSlice> slice;
+
+  manager.OnInitialState(100, kTid, ThreadStateSlice::kRunnable);
+
+  slice = manager.OnSchedWakeup(150, kTid);
+  EXPECT_FALSE(slice.has_value());
+
+  slice = manager.OnSchedSwitchIn(200, kTid);
+  ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->tid(), kTid);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
+  EXPECT_EQ(slice->begin_timestamp_ns(), 100);
+  EXPECT_EQ(slice->end_timestamp_ns(), 200);
+}
+
+TEST(ThreadStateManager, NoStateChangeWithSwitchIn) {
+  constexpr pid_t kTid = 42;
+  ThreadStateManager manager;
+  std::optional<ThreadStateSlice> slice;
+
+  manager.OnInitialState(100, kTid, ThreadStateSlice::kRunnable);
+
+  slice = manager.OnSchedSwitchIn(200, kTid);
+  ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->tid(), kTid);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
+  EXPECT_EQ(slice->begin_timestamp_ns(), 100);
+  EXPECT_EQ(slice->end_timestamp_ns(), 200);
+
+  slice = manager.OnSchedSwitchIn(250, kTid);
+  EXPECT_FALSE(slice.has_value());
+
+  slice = manager.OnSchedSwitchOut(300, kTid, ThreadStateSlice::kInterruptibleSleep);
+  ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->tid(), kTid);
+  EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
+  EXPECT_EQ(slice->begin_timestamp_ns(), 200);
+  EXPECT_EQ(slice->end_timestamp_ns(), 300);
+}
+
+}  // namespace LinuxTracing

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -22,6 +22,7 @@ TracerThread::TracerThread(const CaptureOptions& capture_options)
     : trace_context_switches_{capture_options.trace_context_switches()},
       pid_{capture_options.pid()},
       unwinding_method_{capture_options.unwinding_method()},
+      trace_thread_state_{capture_options.trace_thread_state()},
       trace_gpu_driver_{capture_options.trace_gpu_driver()} {
   if (unwinding_method_ != CaptureOptions::kUndefined) {
     std::optional<uint64_t> sampling_period_ns =

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -121,8 +121,9 @@ class TracerThread {
   uint64_t sampling_period_ns_;
   orbit_grpc_protos::CaptureOptions::UnwindingMethod unwinding_method_;
   std::vector<Function> instrumented_functions_;
-  std::deque<orbit_grpc_protos::TracepointInfo> instrumented_tracepoints_;
+  bool trace_thread_state_;
   bool trace_gpu_driver_;
+  std::vector<orbit_grpc_protos::TracepointInfo> instrumented_tracepoints_;
 
   TracerListener* listener_ = nullptr;
 

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -74,6 +74,7 @@ class TracerThread {
   void OpenUserSpaceProbesRingBuffers();
 
   bool OpenThreadNameTracepoints(const std::vector<int32_t>& cpus);
+  bool OpenThreadStateTracepoints(const std::vector<int32_t>& cpus);
 
   bool InitGpuTracepointEventProcessor();
   bool OpenGpuTracepoints(const std::vector<int32_t>& cpus);
@@ -110,6 +111,7 @@ class TracerThread {
   static constexpr uint64_t MMAP_TASK_RING_BUFFER_SIZE_KB = 64;
   static constexpr uint64_t SAMPLING_RING_BUFFER_SIZE_KB = 16 * 1024;
   static constexpr uint64_t THREAD_NAMES_RING_BUFFER_SIZE_KB = 64;
+  static constexpr uint64_t THREAD_STATE_RING_BUFFER_SIZE_KB = 2 * 1024;
   static constexpr uint64_t GPU_TRACING_RING_BUFFER_SIZE_KB = 256;
   static constexpr uint64_t INSTRUMENTED_TRACEPOINTS_RING_BUFFER_SIZE_KB = 8 * 1024;
 
@@ -138,6 +140,7 @@ class TracerThread {
   absl::flat_hash_set<uint64_t> callchain_sampling_ids_;
   absl::flat_hash_set<uint64_t> task_newtask_ids_;
   absl::flat_hash_set<uint64_t> task_rename_ids_;
+  absl::flat_hash_set<uint64_t> sched_switch_ids_;
   absl::flat_hash_set<uint64_t> amdgpu_cs_ioctl_ids_;
   absl::flat_hash_set<uint64_t> amdgpu_sched_run_job_ids_;
   absl::flat_hash_set<uint64_t> dma_fence_signaled_ids_;

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -25,6 +25,7 @@
 #include "PerfEventProcessor.h"
 #include "PerfEventReaders.h"
 #include "PerfEventRingBuffer.h"
+#include "ThreadStateVisitor.h"
 #include "UprobesUnwindingVisitor.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
@@ -74,6 +75,7 @@ class TracerThread {
   void OpenUserSpaceProbesRingBuffers();
 
   bool OpenThreadNameTracepoints(const std::vector<int32_t>& cpus);
+  void InitThreadStateVisitor();
   bool OpenThreadStateTracepoints(const std::vector<int32_t>& cpus);
 
   bool InitGpuTracepointEventProcessor();
@@ -94,6 +96,7 @@ class TracerThread {
   void ProcessDeferredEvents();
 
   void RetrieveThreadNamesSystemWide();
+  void RetrieveThreadStatesSystemWide();
 
   void PrintStatsIfTimerElapsed();
 
@@ -152,6 +155,7 @@ class TracerThread {
   std::mutex deferred_events_mutex_;
   ContextSwitchManager context_switch_manager_;
   std::unique_ptr<UprobesUnwindingVisitor> uprobes_unwinding_visitor_;
+  std::unique_ptr<ThreadStateVisitor> thread_state_visitor_;
   PerfEventProcessor event_processor_;
   std::unique_ptr<GpuTracepointEventProcessor> gpu_event_processor_;
 

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -141,6 +141,7 @@ class TracerThread {
   absl::flat_hash_set<uint64_t> task_newtask_ids_;
   absl::flat_hash_set<uint64_t> task_rename_ids_;
   absl::flat_hash_set<uint64_t> sched_switch_ids_;
+  absl::flat_hash_set<uint64_t> sched_wakeup_ids_;
   absl::flat_hash_set<uint64_t> amdgpu_cs_ioctl_ids_;
   absl::flat_hash_set<uint64_t> amdgpu_sched_run_job_ids_;
   absl::flat_hash_set<uint64_t> dma_fence_signaled_ids_;

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/TracerListener.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/TracerListener.h
@@ -17,6 +17,7 @@ class TracerListener {
   virtual void OnFunctionCall(orbit_grpc_protos::FunctionCall function_call) = 0;
   virtual void OnGpuJob(orbit_grpc_protos::GpuJob gpu_job) = 0;
   virtual void OnThreadName(orbit_grpc_protos::ThreadName thread_name) = 0;
+  virtual void OnThreadStateSlice(orbit_grpc_protos::ThreadStateSlice thread_state_slice) = 0;
   virtual void OnAddressInfo(orbit_grpc_protos::AddressInfo address_info) = 0;
   virtual void OnTracepointEvent(orbit_grpc_protos::TracepointEvent tracepoint_event) = 0;
 };

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -68,6 +68,8 @@ ABSL_FLAG(bool, show_return_values, false, "Show return values on time slices");
 ABSL_FLAG(bool, enable_tracepoint_feature, false,
           "Enable the setting of the panel of kernel tracepoints");
 
+ABSL_FLAG(bool, thread_state, false, "Collect thread states");
+
 using ServiceDeployManager = OrbitQt::ServiceDeployManager;
 using DeploymentConfiguration = OrbitQt::DeploymentConfiguration;
 using OrbitStartupWindow = OrbitQt::OrbitStartupWindow;

--- a/OrbitService/LinuxTracingGrpcHandler.h
+++ b/OrbitService/LinuxTracingGrpcHandler.h
@@ -36,6 +36,7 @@ class LinuxTracingGrpcHandler : public LinuxTracing::TracerListener {
   void OnFunctionCall(orbit_grpc_protos::FunctionCall function_call) override;
   void OnGpuJob(orbit_grpc_protos::GpuJob gpu_job) override;
   void OnThreadName(orbit_grpc_protos::ThreadName thread_name) override;
+  void OnThreadStateSlice(orbit_grpc_protos::ThreadStateSlice thread_state_slice) override;
   void OnAddressInfo(orbit_grpc_protos::AddressInfo address_info) override;
   void OnTracepointEvent(orbit_grpc_protos::TracepointEvent tracepoint_event) override;
 


### PR DESCRIPTION
This is the first pull request regarding thread states.
It touches many of Orbit's components hence the number of reviewers.
The only main missing part is the visualization in the capture view.
The unification with the logic that handles scheduling slices is still open.