### PR TITLE
Refactor: Stop renaming/relabeling in each draw.

### DIFF
--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -115,7 +115,7 @@ class TimeGraph {
   }
   [[nodiscard]] Batcher& GetBatcher() { return batcher_; }
   [[nodiscard]] uint32_t GetNumTimers() const;
-  [[nodiscard]] uint32_t GetNumCores() const;
+  [[nodiscard]] uint32_t GetNumCores() const { return num_cores_; }
   [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllTimerChains() const;
   [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllThreadTrackTimerChains() const;
   [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllSerializableTimerChains() const;
@@ -183,6 +183,7 @@ class TimeGraph {
   void ProcessValueTrackingTimer(const orbit_client_protos::TimerInfo& timer_info);
   void ProcessAsyncTimer(const std::string& track_name,
                          const orbit_client_protos::TimerInfo& timer_info);
+  void SetNumCores(uint32_t num_cores) { num_cores_ = num_cores; }
 
  private:
   TextRenderer text_renderer_static_;
@@ -210,7 +211,7 @@ class TimeGraph {
   TimeGraphLayout layout_;
 
   std::map<int32_t, uint32_t> thread_count_map_;
-
+  uint32_t num_cores_;
   // Be careful when directly changing these members without using the
   // methods NeedsRedraw() or NeedsUpdate():
   // needs_update_primitives_ should always imply needs_redraw_, that is
@@ -239,7 +240,6 @@ class TimeGraph {
   std::vector<std::shared_ptr<Track>> sorted_tracks_;
   std::string thread_filter_;
 
-  std::set<uint32_t> cores_seen_;
   std::shared_ptr<SchedulerTrack> scheduler_track_;
   std::shared_ptr<ThreadTrack> tracepoints_system_wide_track_;
 

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -241,7 +241,6 @@ class TimeGraph {
 
   std::set<uint32_t> cores_seen_;
   std::shared_ptr<SchedulerTrack> scheduler_track_;
-  std::shared_ptr<ThreadTrack> process_track_;
   std::shared_ptr<ThreadTrack> tracepoints_system_wide_track_;
 
   absl::flat_hash_map<int32_t, std::vector<orbit_client_protos::CallstackEvent>>


### PR DESCRIPTION
Before this commit we renamed each track every time when we
draw them. Now, we are making that only once.