### PR TITLE
Only request data update on live view when needed

### DIFF
--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -354,7 +354,6 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   std::unique_ptr<ProcessesDataView> processes_data_view_;
   std::unique_ptr<ModulesDataView> modules_data_view_;
   std::unique_ptr<FunctionsDataView> functions_data_view_;
-  std::unique_ptr<LiveFunctionsDataView> live_functions_data_view_;
   std::unique_ptr<CallStackDataView> callstack_data_view_;
   std::unique_ptr<CallStackDataView> selection_callstack_data_view_;
   std::unique_ptr<PresetsDataView> presets_data_view_;

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -140,9 +140,11 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App,
   GOrbitApp->SetOpenCaptureFinishedCallback(
       [loading_capture_dialog] { loading_capture_dialog->close(); });
 
-  GOrbitApp->SetRefreshCallback([this](DataViewType a_Type) {
-    this->OnRefreshDataViewPanels(a_Type);
-    this->ui->liveFunctions->OnDataChanged();
+  GOrbitApp->SetRefreshCallback([this](DataViewType type) {
+    if (type == DataViewType::kAll || type == DataViewType::kLiveFunctions) {
+      this->ui->liveFunctions->OnDataChanged();
+    }
+    this->OnRefreshDataViewPanels(type);
   });
 
   GOrbitApp->SetSamplingReportCallback(


### PR DESCRIPTION
The live functions data view is handled differently than other data
views as creation of it is a bit more complex than for the view we can
handle generically. Therefore, this data view requires an explicit
extra call to OnDataChanged. So far, this call was done independent of
the type of data views to be updated. This leads to a bug with frame
tracks where some data in the live functions data view class is reset
that should not be reset. Note that this mimics the update behavior of
the generic other data view panels.

Bug: b/170392477.
Test: Manual test of taking a capture, adding and removing frame
track(s).