### PR TITLE
Move functions loading as an independent method in ClientGgp

### DIFF
--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -257,6 +257,11 @@ absl::flat_hash_map<uint64_t, FunctionInfo> ClientGgp::GetSelectedFunctions() {
   return selected_functions;
 }
 
+void ClientGgp::UpdateCaptureFunctions(std::vector<std::string> capture_functions) {
+  options_.capture_functions = capture_functions;
+  return;
+}
+
 void ClientGgp::ProcessTimer(const TimerInfo& timer_info) { timer_infos_.push_back(timer_info); }
 
 // CaptureListener implementation

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -27,6 +27,7 @@ class ClientGgp final : public CaptureListener {
   bool RequestStartCapture(ThreadPool* thread_pool);
   bool StopCapture();
   bool SaveCapture();
+  void LoadSelectedFunctions();
 
   // CaptureListener implementation
   void OnCaptureStarted(
@@ -52,6 +53,7 @@ class ClientGgp final : public CaptureListener {
   ProcessData target_process_;
   absl::flat_hash_set<std::unique_ptr<ModuleData>> modules_;
   absl::flat_hash_map<std::string, ModuleData*> module_map_;
+  absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions_;
   ModuleData* main_module_;
   std::shared_ptr<StringManager> string_manager_;
   std::unique_ptr<CaptureClient> capture_client_;

--- a/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/ClientGgp.h
@@ -28,6 +28,7 @@ class ClientGgp final : public CaptureListener {
   bool StopCapture();
   bool SaveCapture();
   void LoadSelectedFunctions();
+  void UpdateCaptureFunctions(std::vector<std::string> capture_functions);
 
   // CaptureListener implementation
   void OnCaptureStarted(


### PR DESCRIPTION
Allow to load the selected functions before the capture is requested to start. Provides more flexibility and prepares the class to be used in a client that can handle several captures.

* Create independent public _LoadSelectedFunctions_ in _ClientGgp_
* Moved _LoadSelectedFunctions_ from _RequestStartCapture_ to initialisation of the client
* Create _ClientGgp::UpdateCaptureFunctions_: allows updating the list of functions to hook in the capture

Tests: 
* OrbitClientGgp works as expected without requiring any modifications