### PR TITLE
Visualize thread states in the capture view

### DIFF
--- a/OrbitCore/CaptureData.cpp
+++ b/OrbitCore/CaptureData.cpp
@@ -19,7 +19,7 @@ using orbit_client_protos::ThreadStateSliceInfo;
 void CaptureData::ForEachThreadStateSliceIntersectingTimeRange(
     int32_t thread_id, uint64_t min_timestamp, uint64_t max_timestamp,
     const std::function<void(const ThreadStateSliceInfo&)>& action) const {
-  std::lock_guard lock{*thread_state_slices_mutex_};
+  absl::MutexLock lock{thread_state_slices_mutex_.get()};
   auto tid_thread_state_slices_it = thread_state_slices_.find(thread_id);
   if (tid_thread_state_slices_it == thread_state_slices_.end()) {
     return;

--- a/OrbitCore/CaptureData.cpp
+++ b/OrbitCore/CaptureData.cpp
@@ -14,6 +14,30 @@
 using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::FunctionStats;
 using orbit_client_protos::LinuxAddressInfo;
+using orbit_client_protos::ThreadStateSliceInfo;
+
+void CaptureData::ForEachThreadStateSliceIntersectingTimeRange(
+    int32_t thread_id, uint64_t min_timestamp, uint64_t max_timestamp,
+    const std::function<void(const ThreadStateSliceInfo&)>& action) const {
+  std::lock_guard lock{*thread_state_slices_mutex_};
+  auto tid_thread_state_slices_it = thread_state_slices_.find(thread_id);
+  if (tid_thread_state_slices_it == thread_state_slices_.end()) {
+    return;
+  }
+
+  const std::vector<ThreadStateSliceInfo>& tid_thread_state_slices =
+      tid_thread_state_slices_it->second;
+  auto slice_it = std::lower_bound(tid_thread_state_slices.begin(), tid_thread_state_slices.end(),
+                                   min_timestamp,
+                                   [](const ThreadStateSliceInfo& slice, uint64_t min_timestamp) {
+                                     return slice.end_timestamp_ns() < min_timestamp;
+                                   });
+  while (slice_it != tid_thread_state_slices.end() &&
+         slice_it->begin_timestamp_ns() < max_timestamp) {
+    action(*slice_it);
+    ++slice_it;
+  }
+}
 
 const FunctionStats& CaptureData::GetFunctionStatsOrDefault(const FunctionInfo& function) const {
   static const FunctionStats kDefaultFunctionStats;

--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -51,6 +51,7 @@ target_sources(
          StatusListener.h
          TextBox.h
          TextRenderer.h
+         ThreadStateTrack.h
          ThreadTrack.h
          TimeGraph.h
          TimeGraphLayout.h
@@ -101,6 +102,7 @@ target_sources(
           TimerChain.cpp
           TimerInfosIterator.cpp
           TimerTrack.cpp
+          ThreadStateTrack.cpp
           ThreadTrack.cpp
           Track.cpp
           TriangleToggle.cpp

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -129,8 +129,6 @@ void EventTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingM
 
 void EventTrack::SetPos(float a_X, float a_Y) {
   pos_ = Vec2(a_X, a_Y);
-  thread_name_.SetPos(Vec2(a_X, a_Y));
-  thread_name_.SetSize(Vec2(size_[0] * 0.3f, size_[1]));
 }
 
 void EventTrack::SetSize(float a_SizeX, float a_SizeY) { size_ = Vec2(a_SizeX, a_SizeY); }

--- a/OrbitGl/ThreadStateTrack.cpp
+++ b/OrbitGl/ThreadStateTrack.cpp
@@ -34,32 +34,34 @@ void ThreadStateTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
 }
 
 static Color GetThreadStateColor(ThreadStateSliceInfo::ThreadState state) {
-  static const Color kGreen{0, 224, 0, 255};
-  static const Color kLightBlue{0, 255, 255, 255};
-  static const Color kYellow{255, 192, 0, 255};
-  static const Color kOrange{255, 128, 0, 255};
-  static const Color kRed{255, 0, 0, 255};
-  static const Color kGrey{128, 128, 128, 255};
+  static const Color kGreen500{76, 175, 80, 255};
+  static const Color kBlue500{33, 150, 243, 255};
+  static const Color kGray600{117, 117, 117, 255};
+  static const Color kOrange500{255, 152, 0, 255};
+  static const Color kRed500{244, 67, 54, 255};
+  static const Color kPurple500{156, 39, 176, 255};
   static const Color kBlack{0, 0, 0, 255};
+  static const Color kBrown500{121, 85, 72, 255};
 
   switch (state) {
     case ThreadStateSliceInfo::kRunning:
-      return kGreen;
+      return kGreen500;
     case ThreadStateSliceInfo::kRunnable:
-      return kLightBlue;
+      return kBlue500;
     case ThreadStateSliceInfo::kInterruptibleSleep:
-      return kYellow;
+      return kGray600;
     case ThreadStateSliceInfo::kUninterruptibleSleep:
-      return kOrange;
+      return kOrange500;
     case ThreadStateSliceInfo::kStopped:
+      return kRed500;
     case ThreadStateSliceInfo::kTraced:
-      return kRed;
+      return kPurple500;
     case ThreadStateSliceInfo::kDead:
     case ThreadStateSliceInfo::kZombie:
       return kBlack;
     case ThreadStateSliceInfo::kParked:
     case ThreadStateSliceInfo::kIdle:
-      return kGrey;
+      return kBrown500;
     default:
       UNREACHABLE();
   }

--- a/OrbitGl/ThreadStateTrack.cpp
+++ b/OrbitGl/ThreadStateTrack.cpp
@@ -1,0 +1,131 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ThreadStateTrack.h"
+
+#include "App.h"
+#include "capture_data.pb.h"
+
+using orbit_client_protos::ThreadStateSliceInfo;
+
+ThreadStateTrack::ThreadStateTrack(TimeGraph* time_graph, int32_t thread_id) : Track{time_graph} {
+  thread_id_ = thread_id;
+  picked_ = false;
+}
+
+bool ThreadStateTrack::IsEmpty() const {
+  return !GOrbitApp->GetCaptureData().HasThreadStatesForThread(thread_id_);
+}
+
+void ThreadStateTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
+  // Similarly to EventTrack::Draw, the thread state slices don't respond to clicks, but have a
+  // tooltip. For picking, we want to draw the event bar over them if handling a click, and
+  // underneath otherwise. This simulates "click-through" behavior.
+  const float thread_state_bar_z = picking_mode == PickingMode::kClick
+                                       ? GlCanvas::kZValueEventBarPicking
+                                       : GlCanvas::kZValueEventBar;
+
+  // Draw a transparent track just for clicking.
+  Batcher* batcher = canvas->GetBatcher();
+  Box box(pos_, Vec2(size_[0], -size_[1]), thread_state_bar_z);
+  static const Color kTransparent{0, 0, 0, 0};
+  batcher->AddBox(box, kTransparent, shared_from_this());
+}
+
+static Color GetThreadStateColor(ThreadStateSliceInfo::ThreadState state) {
+  static const Color kGreen{0, 224, 0, 255};
+  static const Color kLightBlue{0, 255, 255, 255};
+  static const Color kYellow{255, 192, 0, 255};
+  static const Color kOrange{255, 128, 0, 255};
+  static const Color kRed{255, 0, 0, 255};
+  static const Color kGrey{128, 128, 128, 255};
+  static const Color kBlack{0, 0, 0, 255};
+
+  switch (state) {
+    case ThreadStateSliceInfo::kRunning:
+      return kGreen;
+    case ThreadStateSliceInfo::kRunnable:
+      return kLightBlue;
+    case ThreadStateSliceInfo::kInterruptibleSleep:
+      return kYellow;
+    case ThreadStateSliceInfo::kUninterruptibleSleep:
+      return kOrange;
+    case ThreadStateSliceInfo::kStopped:
+    case ThreadStateSliceInfo::kTraced:
+      return kRed;
+    case ThreadStateSliceInfo::kDead:
+    case ThreadStateSliceInfo::kZombie:
+      return kBlack;
+    case ThreadStateSliceInfo::kParked:
+    case ThreadStateSliceInfo::kIdle:
+      return kGrey;
+    default:
+      UNREACHABLE();
+  }
+}
+
+static std::string GetThreadStateName(ThreadStateSliceInfo::ThreadState state) {
+  switch (state) {
+    case ThreadStateSliceInfo::kRunning:
+      return "Running";
+    case ThreadStateSliceInfo::kRunnable:
+      return "Runnable";
+    case ThreadStateSliceInfo::kInterruptibleSleep:
+      return "Interruptible sleep";
+    case ThreadStateSliceInfo::kUninterruptibleSleep:
+      return "Uninterruptible sleep";
+    case ThreadStateSliceInfo::kStopped:
+      return "Stopped";
+    case ThreadStateSliceInfo::kTraced:
+      return "Traced";
+    case ThreadStateSliceInfo::kDead:
+      return "Dead";
+    case ThreadStateSliceInfo::kZombie:
+      return "Zombie";
+    case ThreadStateSliceInfo::kParked:
+      return "Parked";
+    case ThreadStateSliceInfo::kIdle:
+      return "Idle";
+    default:
+      UNREACHABLE();
+  }
+}
+
+std::string ThreadStateTrack::GetThreadStateSliceTooltip(PickingId id) const {
+  auto user_data = time_graph_->GetBatcher().GetUserData(id);
+  if (user_data == nullptr || user_data->custom_data_ == nullptr) {
+    return "";
+  }
+
+  const auto* thread_state_slice =
+      static_cast<const ThreadStateSliceInfo*>(user_data->custom_data_);
+  return absl::StrFormat(
+      "<b>%s</b><br/>"
+      "<i>Thread state</i><br/>",
+      GetThreadStateName(thread_state_slice->thread_state()));
+}
+
+void ThreadStateTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
+                                        PickingMode /*picking_mode*/) {
+  Batcher* batcher = &time_graph_->GetBatcher();
+  GOrbitApp->GetCaptureData().ForEachThreadStateSliceIntersectingTimeRange(
+      thread_id_, min_tick, max_tick, [&](const ThreadStateSliceInfo& slice) {
+        float x0 = std::max(pos_[0], time_graph_->GetWorldFromTick(slice.begin_timestamp_ns()));
+        float x1 =
+            std::min(pos_[0] + size_[0], time_graph_->GetWorldFromTick(slice.end_timestamp_ns()));
+        Vec2 pos{x0, pos_[1]};
+        Vec2 size{x1 - x0, -size_[1]};
+        Box box(pos, size, GlCanvas::kZValueEvent);
+
+        auto user_data = std::make_unique<PickingUserData>(
+            nullptr, [&](PickingId id) { return GetThreadStateSliceTooltip(id); });
+        user_data->custom_data_ = &slice;
+        batcher->AddBox(box, GetThreadStateColor(slice.thread_state()), std::move(user_data));
+      });
+}
+
+void ThreadStateTrack::OnPick(int /*x*/, int /*y*/) {
+  GOrbitApp->set_selected_thread_id(thread_id_);
+  picked_ = true;
+}

--- a/OrbitGl/ThreadStateTrack.h
+++ b/OrbitGl/ThreadStateTrack.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_THREAD_STATE_TRACK_H_
+#define ORBIT_GL_THREAD_STATE_TRACK_H_
+
+#include "Track.h"
+
+// This is a track dedicated to displaying thread states in different colors
+// and with the corresponding tooltips.
+// It is a thin sub-track of ThreadTrack, added above the callstack track (EventTrack).
+// The colors are determined only by the states, not by the color assigned to the thread.
+
+class ThreadStateTrack final : public Track {
+ public:
+  ThreadStateTrack(TimeGraph* time_graph, int32_t thread_id);
+  Type GetType() const override { return kThreadStateTrack; }
+
+  void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
+  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode) override;
+
+  void OnPick(int x, int y) override;
+  void OnRelease() override { picked_ = false; };
+  float GetHeight() const override { return size_[1]; }
+
+  bool IsEmpty() const;
+
+ private:
+  std::string GetThreadStateSliceTooltip(PickingId id) const;
+};
+
+#endif  // ORBIT_GL_THREAD_STATE_TRACK_H_

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <memory>
 
+#include "ThreadStateTrack.h"
 #include "TimerTrack.h"
 #include "capture_data.pb.h"
 
@@ -44,9 +45,11 @@ class ThreadTrack : public TimerTrack {
   [[nodiscard]] std::string GetBoxTooltip(PickingId id) const override;
 
   [[nodiscard]] float GetHeight() const override;
-
   [[nodiscard]] float GetHeaderHeight() const override;
 
+  void UpdatePositionOfSubtracks();
+
+  std::shared_ptr<ThreadStateTrack> thread_state_track_;
   std::shared_ptr<EventTrack> event_track_;
   std::shared_ptr<TracepointTrack> tracepoint_track_;
 };

--- a/OrbitGl/TimeGraphLayout.cpp
+++ b/OrbitGl/TimeGraphLayout.cpp
@@ -10,6 +10,7 @@ TimeGraphLayout::TimeGraphLayout() {
   m_NumCores = 0;
   m_TextBoxHeight = 20.f;
   m_CoresHeight = 10.f;
+  thread_state_track_height_ = 4.0f;
   m_EventTrackHeight = 10.f;
   m_GraphTrackHeight = 20.f;
   m_TrackBottomMargin = 5.f;
@@ -51,6 +52,7 @@ bool TimeGraphLayout::DrawProperties() {
   FLOAT_SLIDER(m_TrackLabelOffsetX);
   FLOAT_SLIDER(m_TextBoxHeight);
   FLOAT_SLIDER(m_CoresHeight);
+  FLOAT_SLIDER(thread_state_track_height_);
   FLOAT_SLIDER(m_EventTrackHeight);
   FLOAT_SLIDER(m_GraphTrackHeight);
   FLOAT_SLIDER(m_SpaceBetweenCores);

--- a/OrbitGl/TimeGraphLayout.h
+++ b/OrbitGl/TimeGraphLayout.h
@@ -11,6 +11,7 @@ class TimeGraphLayout {
 
   float GetTextBoxHeight() const { return m_TextBoxHeight * scale_; }
   float GetTextCoresHeight() const { return m_CoresHeight * scale_; }
+  float GetThreadStateTrackHeight() const { return thread_state_track_height_ * scale_; }
   float GetEventTrackHeight() const { return m_EventTrackHeight * scale_; }
   float GetGraphTrackHeight() const { return m_GraphTrackHeight * scale_; }
   float GetTrackBottomMargin() const { return m_TrackBottomMargin * scale_; }
@@ -46,6 +47,7 @@ class TimeGraphLayout {
 
   float m_TextBoxHeight;
   float m_CoresHeight;
+  float thread_state_track_height_;
   float m_EventTrackHeight;
   float m_GraphTrackHeight;
   float m_TrackBottomMargin;

--- a/OrbitGl/TracepointTrack.cpp
+++ b/OrbitGl/TracepointTrack.cpp
@@ -110,19 +110,7 @@ void TracepointTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
 }
 
 void TracepointTrack::SetPos(float x, float y) {
-  if (thread_id_ != TracepointEventBuffer::kAllTracepointsFakeTid) {
-    y = y - GetHeight();
-  }
   pos_ = Vec2(x, y);
-
-  thread_name_.SetPos(pos_);
-  thread_name_.SetSize(Vec2(size_[0] * 0.3f, size_[1]));
-}
-
-float TracepointTrack::GetHeight() const {
-  TimeGraphLayout& layout = time_graph_->GetLayout();
-
-  return !IsEmpty() ? layout.GetEventTrackHeight() + layout.GetSpaceBetweenTracksAndThread() : 0;
 }
 
 void TracepointTrack::OnPick(int x, int y) {

--- a/OrbitGl/TracepointTrack.h
+++ b/OrbitGl/TracepointTrack.h
@@ -17,8 +17,6 @@ class TracepointTrack : public EventTrack {
 
   void SetPos(float x, float y);
 
-  [[nodiscard]] float GetHeight() const override;
-
   void OnPick(int x, int y) override;
   void OnRelease() override;
 

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -33,6 +33,7 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
     kGpuTrack,
     kSchedulerTrack,
     kAsyncTrack,
+    kThreadStateTrack,
     kUnknown,
   };
 
@@ -107,7 +108,6 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
   std::string name_;
   std::string label_;
   int num_prioritized_trailing_characters_;
-  TextBox thread_name_;
   int32_t thread_id_;
   Color color_;
   bool visible_ = true;


### PR DESCRIPTION
A dedicated thinner track (`ThreadStateTrack`) is added above the callstack track (`EventTrack`).

As the collection of thread states is behind the `-thread_state` command line flag, and the track shows up only if at least one thread state slice is available for that thread, this is only visible when that flag is enabled.

Screenshot from Trata:

<img width="677" alt="Untitled" src="https://user-images.githubusercontent.com/58685940/95988592-67a13c00-0e29-11eb-891e-bcff8246af4c.png">
