### PR TITLE
Track ordering basics

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -53,7 +53,7 @@
 ABSL_DECLARE_FLAG(bool, devmode);
 ABSL_DECLARE_FLAG(bool, local);
 ABSL_DECLARE_FLAG(bool, enable_tracepoint_feature);
-ABSL_DECLARE_FLAG(bool, thread_ordering_feature);
+ABSL_DECLARE_FLAG(bool, track_ordering_feature);
 
 using orbit_client_protos::CallstackEvent;
 using orbit_client_protos::FunctionInfo;

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -53,6 +53,7 @@
 ABSL_DECLARE_FLAG(bool, devmode);
 ABSL_DECLARE_FLAG(bool, local);
 ABSL_DECLARE_FLAG(bool, enable_tracepoint_feature);
+ABSL_DECLARE_FLAG(bool, thread_ordering_feature);
 
 using orbit_client_protos::CallstackEvent;
 using orbit_client_protos::FunctionInfo;

--- a/OrbitGl/AsyncTrack.cpp
+++ b/OrbitGl/AsyncTrack.cpp
@@ -73,7 +73,7 @@ void AsyncTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
 }
 
 void AsyncTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_us, float min_x,
-                                  TextBox* text_box) {
+                                  float z_offset, TextBox* text_box) {
   TimeGraphLayout layout = time_graph_->GetLayout();
   std::string time = GetPrettyTime(absl::Microseconds(elapsed_us));
   text_box->SetElapsedTimeTextLength(time.length());
@@ -91,7 +91,7 @@ void AsyncTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_us
   float max_size = box_pos[0] + box_size[0] - pos_x;
   text_renderer_->AddTextTrailingCharsPrioritized(
       text_box->GetText().c_str(), pos_x, text_box->GetPos()[1] + layout.GetTextOffset(),
-      GlCanvas::kZValueText, kTextWhite, text_box->GetElapsedTimeTextLength(),
+      GlCanvas::kZValueBox + z_offset, kTextWhite, text_box->GetElapsedTimeTextLength(),
       time_graph_->CalculateZoomedFontSize(), max_size);
 }
 

--- a/OrbitGl/AsyncTrack.h
+++ b/OrbitGl/AsyncTrack.h
@@ -22,7 +22,7 @@ class AsyncTrack : public TimerTrack {
 
  protected:
   void SetTimesliceText(const orbit_client_protos::TimerInfo& timer, double elapsed_us, float min_x,
-                        TextBox* text_box) override;
+                        float z_offset, TextBox* text_box) override;
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
                                     bool is_selected) const override;
 

--- a/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
+++ b/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
@@ -30,6 +30,7 @@ ABSL_FLAG(bool, show_return_values, false, "Show return values on time slices");
 ABSL_FLAG(bool, enable_tracepoint_feature, false,
           "Enable the setting of the panel of kernel tracepoints");
 ABSL_FLAG(bool, thread_state, false, "Collect thread states");
+ABSL_FLAG(bool, thread_ordering_feature, false, "Allow reordering and pinning of threads");
 
 DEFINE_PROTO_FUZZER(const orbit_client_protos::CaptureDeserializerFuzzerInfo& info) {
   std::string buffer{};

--- a/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
+++ b/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
@@ -30,7 +30,7 @@ ABSL_FLAG(bool, show_return_values, false, "Show return values on time slices");
 ABSL_FLAG(bool, enable_tracepoint_feature, false,
           "Enable the setting of the panel of kernel tracepoints");
 ABSL_FLAG(bool, thread_state, false, "Collect thread states");
-ABSL_FLAG(bool, thread_ordering_feature, false, "Allow reordering and pinning of threads");
+ABSL_FLAG(bool, track_ordering_feature, false, "Allow reordering and pinning of threads");
 
 DEFINE_PROTO_FUZZER(const orbit_client_protos::CaptureDeserializerFuzzerInfo& info) {
   std::string buffer{};

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -526,17 +526,15 @@ void CaptureWindow::DrawScreenSpace() {
   const TimeGraphLayout& layout = time_graph_.GetLayout();
   float right_margin = layout.GetRightMargin();
 
-  const auto picking_mode = GetPickingMode();
-
   if (time_span > 0) {
     UpdateHorizontalSliderFromWorld();
     UpdateHorizontalScroll(slider_->GetPosRatio());
-    slider_->Draw(this, picking_mode);
+    slider_->Draw(this);
 
     UpdateVerticalSliderFromWorld();
     UpdateVerticalScroll(vertical_slider_->GetPosRatio());
     if (vertical_slider_->GetLengthRatio() < 1.f) {
-      vertical_slider_->Draw(this, picking_mode);
+      vertical_slider_->Draw(this);
       int slider_width = static_cast<int>(time_graph_.GetLayout().GetSliderWidth());
       right_margin += slider_width;
     }

--- a/OrbitGl/DataManagerUpdateModuleInfosFuzzer.cpp
+++ b/OrbitGl/DataManagerUpdateModuleInfosFuzzer.cpp
@@ -26,6 +26,7 @@ ABSL_FLAG(bool, show_return_values, false, "Show return values on time slices");
 ABSL_FLAG(bool, enable_tracepoint_feature, false,
           "Enable the setting of the panel of kernel tracepoints");
 ABSL_FLAG(bool, thread_state, false, "Collect thread states");
+ABSL_FLAG(bool, thread_ordering_feature, false, "Allow reordering and pinning of threads");
 
 using orbit_grpc_protos::GetModuleListResponse;
 using orbit_grpc_protos::ModuleInfo;

--- a/OrbitGl/DataManagerUpdateModuleInfosFuzzer.cpp
+++ b/OrbitGl/DataManagerUpdateModuleInfosFuzzer.cpp
@@ -26,7 +26,7 @@ ABSL_FLAG(bool, show_return_values, false, "Show return values on time slices");
 ABSL_FLAG(bool, enable_tracepoint_feature, false,
           "Enable the setting of the panel of kernel tracepoints");
 ABSL_FLAG(bool, thread_state, false, "Collect thread states");
-ABSL_FLAG(bool, thread_ordering_feature, false, "Allow reordering and pinning of threads");
+ABSL_FLAG(bool, track_ordering_feature, false, "Allow reordering and pinning of threads");
 
 using orbit_grpc_protos::GetModuleListResponse;
 using orbit_grpc_protos::ModuleInfo;

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -18,7 +18,7 @@ EventTrack::EventTrack(TimeGraph* a_TimeGraph) : Track(a_TimeGraph) {
 
 std::string EventTrack::GetTooltip() const { return "Left-click and drag to select samples"; }
 
-void EventTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
+void EventTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
   if (thread_id_ == TracepointEventBuffer::kAllTracepointsFakeTid) {
     return;
   }
@@ -29,10 +29,11 @@ void EventTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   // have a tooltip. For picking, we want to draw the event bar over them if
   // handling a click, and underneath otherwise.
   // This simulates "click-through" behavior.
-  const float eventBarZ = picking_mode == PickingMode::kClick ? GlCanvas::kZValueEventBarPicking
-                                                              : GlCanvas::kZValueEventBar;
+  float event_bar_z = picking_mode == PickingMode::kClick ? GlCanvas::kZValueEventBarPicking
+                                                          : GlCanvas::kZValueEventBar;
+  event_bar_z += z_offset;
   Color color = color_;
-  Box box(pos_, Vec2(size_[0], -size_[1]), eventBarZ);
+  Box box(pos_, Vec2(size_[0], -size_[1]), event_bar_z);
   batcher->AddBox(box, color, shared_from_this());
 
   if (canvas->GetPickingManager().IsThisElementPicked(this)) {
@@ -44,9 +45,8 @@ void EventTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   float x1 = x0 + size_[0];
   float y1 = y0 - size_[1];
 
-  batcher->AddLine(pos_, Vec2(x1, y0), GlCanvas::kZValueEventBar, color, shared_from_this());
-  batcher->AddLine(Vec2(x1, y1), Vec2(x0, y1), GlCanvas::kZValueEventBar, color,
-                   shared_from_this());
+  batcher->AddLine(pos_, Vec2(x1, y0), event_bar_z, color, shared_from_this());
+  batcher->AddLine(Vec2(x1, y1), Vec2(x0, y1), event_bar_z, color, shared_from_this());
 
   if (picked_) {
     Vec2& from = mouse_pos_[0];
@@ -58,17 +58,18 @@ void EventTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
     y1 = y0 - size_[1];
 
     Color picked_color(0, 128, 255, 128);
-    Box box(Vec2(x0, y0), Vec2(x1 - x0, -size_[1]), GlCanvas::kZValueUi);
+    Box box(Vec2(x0, y0), Vec2(x1 - x0, -size_[1]), GlCanvas::kZValueUi + z_offset);
     batcher->AddBox(box, picked_color, shared_from_this());
   }
 
   canvas_ = canvas;
 }
 
-void EventTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode) {
+void EventTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode,
+                                  float z_offset) {
   Batcher* batcher = &time_graph_->GetBatcher();
   const TimeGraphLayout& layout = time_graph_->GetLayout();
-  float z = GlCanvas::kZValueEvent;
+  float z = GlCanvas::kZValueEvent + z_offset;
   float track_height = layout.GetEventTrackHeight();
   const bool picking = picking_mode != PickingMode::kNone;
 

--- a/OrbitGl/EventTrack.h
+++ b/OrbitGl/EventTrack.h
@@ -17,8 +17,9 @@ class EventTrack : public Track {
 
   std::string GetTooltip() const override;
 
-  void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
-  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode) override;
+  void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
+  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode,
+                        float z_offset = 0) override;
 
   void OnPick(int x, int y) override;
   void OnRelease() override;
@@ -36,5 +37,4 @@ class EventTrack : public Track {
  protected:
   void SelectEvents();
   std::string GetSampleTooltip(PickingId id) const;
-
 };

--- a/OrbitGl/FrameTrack.cpp
+++ b/OrbitGl/FrameTrack.cpp
@@ -139,7 +139,7 @@ void FrameTrack::OnTimer(const TimerInfo& timer_info) {
 }
 
 void FrameTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_us, float min_x,
-                                  TextBox* text_box) {
+                                  float z_offset, TextBox* text_box) {
   TimeGraphLayout layout = time_graph_->GetLayout();
   if (text_box->GetText().empty()) {
     std::string time = GetPrettyTime(absl::Microseconds(elapsed_us));
@@ -156,7 +156,7 @@ void FrameTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_us
   float max_size = box_pos[0] + box_size[0] - pos_x;
   text_renderer_->AddTextTrailingCharsPrioritized(
       text_box->GetText().c_str(), pos_x, text_box->GetPos()[1] + layout.GetTextOffset(),
-      GlCanvas::kZValueText, kTextWhite, text_box->GetElapsedTimeTextLength(),
+      GlCanvas::kZValueBox + z_offset, kTextWhite, text_box->GetElapsedTimeTextLength(),
       time_graph_->CalculateZoomedFontSize(), max_size);
 }
 

--- a/OrbitGl/FrameTrack.cpp
+++ b/OrbitGl/FrameTrack.cpp
@@ -210,8 +210,8 @@ std::string FrameTrack::GetBoxTooltip(PickingId id) const {
           TicksToDuration(text_box->GetTimerInfo().start(), text_box->GetTimerInfo().end())));
 }
 
-void FrameTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
-  TimerTrack::Draw(canvas, picking_mode);
+void FrameTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
+  TimerTrack::Draw(canvas, picking_mode, z_offset);
 
   const Color kWhiteColor(255, 255, 255, 255);
   const Color kBlackColor(0, 0, 0, 255);

--- a/OrbitGl/FrameTrack.h
+++ b/OrbitGl/FrameTrack.h
@@ -21,7 +21,7 @@ class FrameTrack : public TimerTrack {
   [[nodiscard]] float GetHeaderHeight() const override;
 
   void SetTimesliceText(const orbit_client_protos::TimerInfo& timer, double elapsed_us, float min_x,
-                        TextBox* text_box) override;
+                        float z_offset, TextBox* text_box) override;
   [[nodiscard]] std::string GetTooltip() const override;
   [[nodiscard]] std::string GetBoxTooltip(PickingId id) const override;
 

--- a/OrbitGl/FrameTrack.h
+++ b/OrbitGl/FrameTrack.h
@@ -25,7 +25,7 @@ class FrameTrack : public TimerTrack {
   [[nodiscard]] std::string GetTooltip() const override;
   [[nodiscard]] std::string GetBoxTooltip(PickingId id) const override;
 
-  void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
+  void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
 
   void UpdateBoxHeight() override;
 

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -22,7 +22,6 @@ float GlCanvas::kZValueTrack = 0.01f;
 float GlCanvas::kZValueEventBar = 0.03f;
 float GlCanvas::kZValueBox = 0.05f;
 float GlCanvas::kZValueEvent = 0.07f;
-float GlCanvas::kZValueRoundingCorner = 0.09f;
 float GlCanvas::kZValueOverlay = 0.43f;
 float GlCanvas::kZValueOverlayTextBackground = 0.45f;
 float GlCanvas::kZValueText = 0.47f;

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -15,24 +15,24 @@
 #include "absl/strings/str_format.h"
 
 // Tracks: 0.0 - 0.1
-// World Overlay: 0.2 - 0.3
-// UI: 0.4 - 0.5
-// UI Overlay: 0.6 - 0.7
+// World Overlay: 0.4 - 0.5
+// UI: 0.6 - 0.7
+// UI Overlay: 0.8 - 0.9
 float GlCanvas::kZValueTrack = 0.01f;
 float GlCanvas::kZValueEventBar = 0.03f;
 float GlCanvas::kZValueBox = 0.05f;
 float GlCanvas::kZValueEvent = 0.07f;
 float GlCanvas::kZValueRoundingCorner = 0.09f;
-float GlCanvas::kZValueOverlay = 0.23f;
-float GlCanvas::kZValueOverlayTextBackground = 0.25f;
-float GlCanvas::kZValueText = 0.27f;
-float GlCanvas::kZValueEventBarPicking = 0.29f;
-float GlCanvas::kZValueUi = 0.41f;
-float GlCanvas::kZValueTimeBarBg = 0.43f;
-float GlCanvas::kZValueTextUi = 0.45f;
-float GlCanvas::kZValueMargin = 0.61f;
-float GlCanvas::kZValueSliderBg = 0.63f;
-float GlCanvas::kZValueSlider = 0.65f;
+float GlCanvas::kZValueOverlay = 0.43f;
+float GlCanvas::kZValueOverlayTextBackground = 0.45f;
+float GlCanvas::kZValueText = 0.47f;
+float GlCanvas::kZValueEventBarPicking = 0.49f;
+float GlCanvas::kZValueUi = 0.61f;
+float GlCanvas::kZValueTimeBarBg = 0.63f;
+float GlCanvas::kZValueTextUi = 0.65f;
+float GlCanvas::kZValueMargin = 0.81f;
+float GlCanvas::kZValueSliderBg = 0.83f;
+float GlCanvas::kZValueSlider = 0.85f;
 
 float GlCanvas::kZOffsetMovingTack = 0.1f;
 float GlCanvas::kZOffsetPinnedTrack = 0.2f;

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -34,6 +34,9 @@ float GlCanvas::kZValueMargin = 0.61f;
 float GlCanvas::kZValueSliderBg = 0.63f;
 float GlCanvas::kZValueSlider = 0.65f;
 
+float GlCanvas::kZOffsetMovingTack = 0.1f;
+float GlCanvas::kZOffsetPinnedTrack = 0.2f;
+
 const Color GlCanvas::kBackgroundColor = Color(67, 67, 67, 255);
 const Color GlCanvas::kTabTextColorSelected = Color(100, 181, 246, 255);
 
@@ -259,7 +262,7 @@ void GlCanvas::Prepare2DViewport(int top_left_x, int top_left_y, int bottom_righ
   if (world_height_ <= 0) world_height_ = 1.f;
 
   glOrtho(world_top_left_x_, world_top_left_x_ + world_width_, world_top_left_y_ - world_height_,
-          world_top_left_y_, -1.f, 1.f);
+          world_top_left_y_, -1, 1);
   glMatrixMode(GL_MODELVIEW);
   glLoadIdentity();
 }

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -96,6 +96,9 @@ class GlCanvas : public GlPanel {
   static float kZValueEventBar;
   static float kZValueTrack;
 
+  static float kZOffsetMovingTack;
+  static float kZOffsetPinnedTrack;
+
   static const Color kBackgroundColor;
   static const Color kTabTextColorSelected;
 

--- a/OrbitGl/GlSlider.cpp
+++ b/OrbitGl/GlSlider.cpp
@@ -177,7 +177,7 @@ bool GlSlider::HandlePageScroll(float click_value) {
   return true;
 }
 
-void GlVerticalSlider::Draw(GlCanvas* canvas, PickingMode /*picking_mode*/) {
+void GlVerticalSlider::Draw(GlCanvas* canvas) {
   CHECK(canvas == canvas_);
 
   float x = canvas_->GetWidth() - GetPixelHeight();
@@ -200,7 +200,7 @@ int GlVerticalSlider::GetBarPixelLength() const {
   return canvas_->GetHeight() - GetOrthogonalSliderSize();
 }
 
-void GlHorizontalSlider::Draw(GlCanvas* canvas, PickingMode /*picking_mode*/) {
+void GlHorizontalSlider::Draw(GlCanvas* canvas) {
   canvas_ = canvas;
   static float y = 0;
 

--- a/OrbitGl/GlSlider.h
+++ b/OrbitGl/GlSlider.h
@@ -17,6 +17,7 @@ class GlSlider : public Pickable, public std::enable_shared_from_this<GlSlider> 
   ~GlSlider(){};
 
   [[nodiscard]] bool Draggable() override { return true; }
+  virtual void Draw(GlCanvas* canvas) = 0;
 
   void SetCanvas(GlCanvas* canvas) { canvas_ = canvas; }
 
@@ -109,7 +110,7 @@ class GlVerticalSlider : public GlSlider {
   GlVerticalSlider() : GlSlider(true){};
   ~GlVerticalSlider(){};
 
-  void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
+  void Draw(GlCanvas* canvas) override;
 
  protected:
   [[nodiscard]] int GetBarPixelLength() const override;
@@ -120,7 +121,7 @@ class GlHorizontalSlider : public GlSlider {
   GlHorizontalSlider() : GlSlider(false) { can_resize_ = true; };
   ~GlHorizontalSlider(){};
 
-  void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
+  void Draw(GlCanvas* canvas) override;
 
  protected:
   [[nodiscard]] int GetBarPixelLength() const override;

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -118,7 +118,7 @@ bool GpuTrack::TimerFilter(const TimerInfo& timer_info) const {
 }
 
 void GpuTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_us, float min_x,
-                                TextBox* text_box) {
+                                float z_offset, TextBox* text_box) {
   TimeGraphLayout layout = time_graph_->GetLayout();
   if (text_box->GetText().empty()) {
     std::string time = GetPrettyTime(absl::Microseconds(elapsed_us));
@@ -140,7 +140,7 @@ void GpuTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_us, 
   float max_size = box_pos[0] + box_size[0] - pos_x;
   text_renderer_->AddTextTrailingCharsPrioritized(
       text_box->GetText().c_str(), pos_x, text_box->GetPos()[1] + layout.GetTextOffset(),
-      GlCanvas::kZValueText, kTextWhite, text_box->GetElapsedTimeTextLength(),
+      GlCanvas::kZValueBox + z_offset, kTextWhite, text_box->GetElapsedTimeTextLength(),
       time_graph_->CalculateZoomedFontSize(), max_size);
 }
 

--- a/OrbitGl/GpuTrack.h
+++ b/OrbitGl/GpuTrack.h
@@ -43,7 +43,7 @@ class GpuTrack : public TimerTrack {
                                     bool is_selected) const override;
   [[nodiscard]] bool TimerFilter(const orbit_client_protos::TimerInfo& timer) const override;
   void SetTimesliceText(const orbit_client_protos::TimerInfo& timer, double elapsed_us, float min_x,
-                        TextBox* text_box) override;
+                        float z_offset, TextBox* text_box) override;
   [[nodiscard]] std::string GetBoxTooltip(PickingId id) const override;
 
  private:

--- a/OrbitGl/GraphTrack.cpp
+++ b/OrbitGl/GraphTrack.cpp
@@ -25,7 +25,6 @@ void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset
   float y0 = pos_[1];
   float y1 = y0 - size_[1];
 
-  const Color kPickedColor(0, 128, 255, 128);
   Color color = GetBackgroundColor();
 
   float track_z = GlCanvas::kZValueTrack + z_offset;

--- a/OrbitGl/GraphTrack.cpp
+++ b/OrbitGl/GraphTrack.cpp
@@ -9,7 +9,7 @@
 GraphTrack::GraphTrack(TimeGraph* time_graph, std::string name)
     : Track(time_graph), name_(std::move(name)) {}
 
-void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
+void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
   Batcher* batcher = canvas->GetBatcher();
 
   float trackWidth = canvas->GetWorldWidth();
@@ -28,7 +28,7 @@ void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   const Color kPickedColor(0, 128, 255, 128);
   Color color = GetBackgroundColor();
 
-  float track_z = GlCanvas::kZValueTrack;
+  float track_z = GlCanvas::kZValueTrack + z_offset;
 
   Box box(pos_, Vec2(size_[0], -size_[1]), track_z);
 

--- a/OrbitGl/GraphTrack.cpp
+++ b/OrbitGl/GraphTrack.cpp
@@ -17,7 +17,7 @@ void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset
 
   pos_[0] = canvas->GetWorldTopLeftX();
   SetSize(trackWidth, GetHeight());
-  Track::Draw(canvas, picking_mode);
+  Track::Draw(canvas, picking_mode, z_offset);
 
   float x0 = pos_[0];
   float x1 = x0 + size_[0];
@@ -28,6 +28,9 @@ void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset
   Color color = GetBackgroundColor();
 
   float track_z = GlCanvas::kZValueTrack + z_offset;
+  float graph_z = GlCanvas::kZValueEventBar + z_offset;
+  float dot_z = GlCanvas::kZValueBox + z_offset;
+  float text_z = GlCanvas::kZValueEvent + z_offset;
 
   Box box(pos_, Vec2(size_[0], -size_[1]), track_z);
 
@@ -40,7 +43,7 @@ void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset
         float point_y = y0 - static_cast<float>((max_ - value) * size_[1] / value_range_);
         const Color kBlack(0, 0, 0, 255);
         const Color kWhite(255, 255, 255, 255);
-        DrawLabel(canvas, Vec2(point_x, point_y), std::to_string(value), kBlack, kWhite);
+        DrawLabel(canvas, Vec2(point_x, point_y), std::to_string(value), kBlack, kWhite, text_z);
       }
     }
   }
@@ -74,7 +77,7 @@ void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset
     DrawSquareDot(canvas,
                   Vec2(time_graph_->GetWorldFromTick(previous_time),
                        base_y + static_cast<float>(last_normalized_value) * size_[1]),
-                  kDotRadius, GlCanvas::kZValueText, kDotColor);
+                  kDotRadius, dot_z, kDotColor);
     for (++it; it != values_.end(); ++it) {
       if (previous_time > max_ns) break;
       uint64_t time = it->first;
@@ -83,9 +86,8 @@ void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset
       float x1 = time_graph_->GetWorldFromTick(time);
       float y0 = base_y + static_cast<float>(last_normalized_value) * size_[1];
       float y1 = base_y + static_cast<float>(normalized_value) * size_[1];
-      time_graph_->GetBatcher().AddLine(Vec2(x0, y0), Vec2(x1, y1), GlCanvas::kZValueText,
-                                        kLineColor);
-      DrawSquareDot(canvas, Vec2(x1, y1), kDotRadius, GlCanvas::kZValueText, kDotColor);
+      time_graph_->GetBatcher().AddLine(Vec2(x0, y0), Vec2(x1, y1), graph_z, kLineColor);
+      DrawSquareDot(canvas, Vec2(x1, y1), kDotRadius, dot_z, kDotColor);
 
       previous_time = time;
       last_normalized_value = normalized_value;
@@ -100,7 +102,7 @@ void GraphTrack::DrawSquareDot(GlCanvas* canvas, Vec2 center, float radius, floa
 }
 
 void GraphTrack::DrawLabel(GlCanvas* canvas, Vec2 target_pos, const std::string text,
-                           Color text_color, Color font_color) {
+                           Color text_color, Color font_color, float z) {
   const TimeGraphLayout& layout = time_graph_->GetLayout();
 
   int text_width = canvas->GetTextRenderer().GetStringWidth(text.c_str());
@@ -113,13 +115,8 @@ void GraphTrack::DrawLabel(GlCanvas* canvas, Vec2 target_pos, const std::string 
       target_pos[0] + (arrow_is_left_directed ? arrow_width : -arrow_width - text_box_size[0]),
       target_pos[1] - text_box_size[1] / 2.f);
 
-  canvas->GetTextRenderer().AddText(text.c_str(), text_box_position[0],
-                                    text_box_position[1] + layout.GetTextOffset(),
-                                    GlCanvas::kZValueTextUi, text_color,
-                                    time_graph_->CalculateZoomedFontSize(), text_box_size[0]);
-
-  Box arrow_text_box(text_box_position, text_box_size, GlCanvas::kZValueUi);
-  Vec3 arrow_extra_point(target_pos[0], target_pos[1], GlCanvas::kZValueUi);
+  Box arrow_text_box(text_box_position, text_box_size, z);
+  Vec3 arrow_extra_point(target_pos[0], target_pos[1], z);
 
   Batcher* batcher = canvas->GetBatcher();
   batcher->AddBox(arrow_text_box, font_color);
@@ -132,6 +129,10 @@ void GraphTrack::DrawLabel(GlCanvas* canvas, Vec2 target_pos, const std::string 
         Triangle(arrow_text_box.vertices[2], arrow_text_box.vertices[3], arrow_extra_point),
         font_color);
   }
+
+  canvas->GetTextRenderer().AddText(text.c_str(), text_box_position[0],
+                                    text_box_position[1] + layout.GetTextOffset(), z, text_color,
+                                    time_graph_->CalculateZoomedFontSize(), text_box_size[0]);
 }
 
 void GraphTrack::AddValue(double value, uint64_t time) {

--- a/OrbitGl/GraphTrack.h
+++ b/OrbitGl/GraphTrack.h
@@ -17,7 +17,7 @@ class GraphTrack : public Track {
  public:
   explicit GraphTrack(TimeGraph* time_graph, std::string name);
   [[nodiscard]] Type GetType() const override { return kGraphTrack; }
-  void Draw(GlCanvas* canvas, PickingMode /*picking_mode*/) override;
+  void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
   [[nodiscard]] float GetHeight() const override;
   void AddValue(double value, uint64_t time);
   [[nodiscard]] std::optional<std::pair<uint64_t, double> > GetPreviousValueAndTime(

--- a/OrbitGl/GraphTrack.h
+++ b/OrbitGl/GraphTrack.h
@@ -26,7 +26,7 @@ class GraphTrack : public Track {
  protected:
   void DrawSquareDot(GlCanvas* canvas, Vec2 center, float radius, float z, Color color);
   void DrawLabel(GlCanvas* canvas, Vec2 target_pos, std::string text, Color text_color,
-                 Color font_color);
+                 Color font_color, float z);
   std::map<uint64_t, double> values_;
   double min_ = std::numeric_limits<double>::max();
   double max_ = std::numeric_limits<double>::lowest();

--- a/OrbitGl/PickingManager.h
+++ b/OrbitGl/PickingManager.h
@@ -27,9 +27,7 @@ class Pickable {
   virtual void OnPick(int a_X, int a_Y) = 0;
   virtual void OnDrag(int /*a_X*/, int /*a_Y*/) {}
   virtual void OnRelease(){};
-  virtual void Draw(GlCanvas* a_Canvas, PickingMode a_PickingMode) = 0;
   [[nodiscard]] virtual bool Draggable() { return false; }
-  [[nodiscard]] virtual bool Movable() { return false; }
   [[nodiscard]] virtual std::string GetTooltip() const { return ""; }
 };
 

--- a/OrbitGl/PickingManagerTest.h
+++ b/OrbitGl/PickingManagerTest.h
@@ -17,7 +17,7 @@ class PickableMock : public Pickable {
     dragging_ = false;
     picked_ = false;
   }
-  void Draw(GlCanvas*, PickingMode) override {}
+  void Draw(GlCanvas*, PickingMode, float) {}
 
   bool Draggable() override { return true; }
 

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -4,6 +4,8 @@
 
 #include "SchedulerTrack.h"
 
+#include <absl/flags/flag.h>
+
 #include "App.h"
 #include "EventTrack.h"
 #include "GlCanvas.h"
@@ -16,7 +18,7 @@ using orbit_client_protos::TimerInfo;
 const Color kInactiveColor(100, 100, 100, 255);
 const Color kSelectionColor(0, 128, 255, 255);
 
-SchedulerTrack::SchedulerTrack(TimeGraph* time_graph) : TimerTrack(time_graph) { pinned_ = true; }
+SchedulerTrack::SchedulerTrack(TimeGraph* time_graph) : TimerTrack(time_graph) { SetPinned(true); }
 
 float SchedulerTrack::GetHeight() const {
   TimeGraphLayout& layout = time_graph_->GetLayout();

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -16,7 +16,7 @@ using orbit_client_protos::TimerInfo;
 const Color kInactiveColor(100, 100, 100, 255);
 const Color kSelectionColor(0, 128, 255, 255);
 
-SchedulerTrack::SchedulerTrack(TimeGraph* time_graph) : TimerTrack(time_graph) {}
+SchedulerTrack::SchedulerTrack(TimeGraph* time_graph) : TimerTrack(time_graph) { pinned_ = true; }
 
 float SchedulerTrack::GetHeight() const {
   TimeGraphLayout& layout = time_graph_->GetLayout();

--- a/OrbitGl/TextRenderer.cpp
+++ b/OrbitGl/TextRenderer.cpp
@@ -121,8 +121,6 @@ void TextRenderer::Display(Batcher* batcher) {
   mat4* proj = reinterpret_cast<mat4*>(&matrix[0]);
   m_Proj = *proj;
 
-  mat4_set_orthographic(&m_Proj, 0, m_Canvas->GetWidth(), 0, m_Canvas->GetHeight(), -1, 1);
-
   glUseProgram(m_Shader);
   {
     glUniform1i(glGetUniformLocation(m_Shader, "texture"), 0);
@@ -130,10 +128,6 @@ void TextRenderer::Display(Batcher* batcher) {
     glUniformMatrix4fv(glGetUniformLocation(m_Shader, "view"), 1, 0, m_View.data);
     glUniformMatrix4fv(glGetUniformLocation(m_Shader, "projection"), 1, 0, m_Proj.data);
     vertex_buffer_render(m_Buffer, GL_TRIANGLES);
-
-    /*PRINT_VAR(m_Model);
-    PRINT_VAR(m_View);
-    PRINT_VAR(m_Proj);*/
   }
 
   glBindTexture(GL_TEXTURE_2D, 0);

--- a/OrbitGl/ThreadStateTrack.h
+++ b/OrbitGl/ThreadStateTrack.h
@@ -17,8 +17,9 @@ class ThreadStateTrack final : public Track {
   ThreadStateTrack(TimeGraph* time_graph, int32_t thread_id);
   Type GetType() const override { return kThreadStateTrack; }
 
-  void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
-  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode) override;
+  void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) override;
+  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode,
+                        float z_offset) override;
 
   void OnPick(int x, int y) override;
   void OnRelease() override { picked_ = false; };

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -227,7 +227,7 @@ void ThreadTrack::SetTrackColor(Color color) {
 }
 
 void ThreadTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_us, float min_x,
-                                   TextBox* text_box) {
+                                   float z_offset, TextBox* text_box) {
   TimeGraphLayout layout = time_graph_->GetLayout();
   if (text_box->GetText().empty()) {
     std::string time = GetPrettyTime(absl::Microseconds(elapsed_us));
@@ -268,7 +268,7 @@ void ThreadTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_u
   float max_size = box_pos[0] + box_size[0] - pos_x;
   text_renderer_->AddTextTrailingCharsPrioritized(
       text_box->GetText().c_str(), pos_x, text_box->GetPos()[1] + layout.GetTextOffset(),
-      GlCanvas::kZValueText, kTextWhite, text_box->GetElapsedTimeTextLength(),
+      GlCanvas::kZValueBox + z_offset, kTextWhite, text_box->GetElapsedTimeTextLength(),
       time_graph_->CalculateZoomedFontSize(), max_size);
 }
 

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -175,8 +175,8 @@ void ThreadTrack::UpdatePositionOfSubtracks() {
   tracepoint_track_->SetPos(pos_[0], current_y);
 }
 
-void ThreadTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
-  TimerTrack::Draw(canvas, picking_mode);
+void ThreadTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
+  TimerTrack::Draw(canvas, picking_mode, z_offset);
 
   UpdatePositionOfSubtracks();
 
@@ -187,36 +187,36 @@ void ThreadTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
 
   if (!thread_state_track_->IsEmpty()) {
     thread_state_track_->SetSize(canvas->GetWorldWidth(), thread_state_track_height);
-    thread_state_track_->Draw(canvas, picking_mode);
+    thread_state_track_->Draw(canvas, picking_mode, z_offset);
   }
 
   if (!event_track_->IsEmpty()) {
     event_track_->SetSize(canvas->GetWorldWidth(), event_track_height);
-    event_track_->Draw(canvas, picking_mode);
+    event_track_->Draw(canvas, picking_mode, z_offset);
   }
 
   if (!tracepoint_track_->IsEmpty()) {
     tracepoint_track_->SetSize(canvas->GetWorldWidth(), tracepoint_track_height);
-    tracepoint_track_->Draw(canvas, picking_mode);
+    tracepoint_track_->Draw(canvas, picking_mode, z_offset);
   }
 }
 
 void ThreadTrack::OnPick(int /*x*/, int /*y*/) { GOrbitApp->set_selected_thread_id(thread_id_); }
 
-void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode) {
-  UpdatePositionOfSubtracks();
+void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode,
+                                   float z_offset) {
 
   if (!thread_state_track_->IsEmpty()) {
-    thread_state_track_->UpdatePrimitives(min_tick, max_tick, picking_mode);
+    thread_state_track_->UpdatePrimitives(min_tick, max_tick, picking_mode, z_offset);
   }
   if (!event_track_->IsEmpty()) {
-    event_track_->UpdatePrimitives(min_tick, max_tick, picking_mode);
+    event_track_->UpdatePrimitives(min_tick, max_tick, picking_mode, z_offset);
   }
   if (!tracepoint_track_->IsEmpty()) {
-    tracepoint_track_->UpdatePrimitives(min_tick, max_tick, picking_mode);
+    tracepoint_track_->UpdatePrimitives(min_tick, max_tick, picking_mode, z_offset);
   }
 
-  TimerTrack::UpdatePrimitives(min_tick, max_tick, picking_mode);
+  TimerTrack::UpdatePrimitives(min_tick, max_tick, picking_mode, z_offset);
 }
 
 void ThreadTrack::SetTrackColor(Color color) {

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -205,6 +205,7 @@ void ThreadTrack::OnPick(int /*x*/, int /*y*/) { GOrbitApp->set_selected_thread_
 
 void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode,
                                    float z_offset) {
+  UpdatePositionOfSubtracks();
 
   if (!thread_state_track_->IsEmpty()) {
     thread_state_track_->UpdatePrimitives(min_tick, max_tick, picking_mode, z_offset);

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -42,7 +42,7 @@ class ThreadTrack : public TimerTrack {
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer,
                                     bool is_selected) const override;
   void SetTimesliceText(const orbit_client_protos::TimerInfo& timer, double elapsed_us, float min_x,
-                        TextBox* text_box) override;
+                        float z_offset, TextBox* text_box) override;
   [[nodiscard]] std::string GetBoxTooltip(PickingId id) const override;
 
   [[nodiscard]] float GetHeight() const override;

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -24,7 +24,7 @@ class ThreadTrack : public TimerTrack {
   [[nodiscard]] const TextBox* GetLeft(const TextBox* textbox) const override;
   [[nodiscard]] const TextBox* GetRight(const TextBox* textbox) const override;
 
-  void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
+  void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
 
   void OnPick(int x, int y) override;
 
@@ -32,7 +32,8 @@ class ThreadTrack : public TimerTrack {
   void SetTrackColor(Color color);
   [[nodiscard]] bool IsEmpty() const override;
 
-  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode) override;
+  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode,
+                        float z_offset = 0) override;
 
  protected:
   [[nodiscard]] bool IsTimerActive(const orbit_client_protos::TimerInfo& timer) const override;

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -767,7 +767,12 @@ void TimeGraph::DrawOverlay(GlCanvas* canvas, PickingMode picking_mode) {
 
 void TimeGraph::DrawTracks(GlCanvas* canvas, PickingMode picking_mode) {
   for (auto& track : sorted_tracks_) {
-    const float z_offset = track->IsMoving() || track->IsPinned() ? 1.f : 0.f;
+    float z_offset = 0;
+    if (track->IsPinned()) {
+      z_offset = GlCanvas::kZOffsetPinnedTrack;
+    } else if (track->IsMoving()) {
+      z_offset = GlCanvas::kZOffsetMovingTack;
+    }
     track->Draw(canvas, picking_mode, z_offset);
   }
 }
@@ -1043,7 +1048,7 @@ void TimeGraph::UpdateTracks(uint64_t min_tick, uint64_t max_tick, PickingMode p
       continue;
     }
 
-    const float z_offset = 1.f;
+    const float z_offset = GlCanvas::kZOffsetPinnedTrack;
     track->SetY(current_y + canvas_->GetWorldTopLeftY() - layout_.GetTopMargin() -
                 layout_.GetSchedulerTrackOffset());
     track->UpdatePrimitives(min_tick, max_tick, picking_mode, z_offset);
@@ -1060,7 +1065,7 @@ void TimeGraph::UpdateTracks(uint64_t min_tick, uint64_t max_tick, PickingMode p
       continue;
     }
 
-    const float z_offset = track->IsMoving() || track->IsPinned() ? 1.f : 0.f;
+    const float z_offset = track->IsMoving() ? GlCanvas::kZOffsetMovingTack : 0.f;
     track->SetY(current_y);
     track->UpdatePrimitives(min_tick, max_tick, picking_mode, z_offset);
     current_y -= (track->GetHeight() + layout_.GetSpaceBetweenTracks());

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -88,6 +88,9 @@ void TimeGraph::Clear() {
   async_tracks_.clear();
   frame_tracks_.clear();
 
+  sorted_tracks_.clear();
+  sorted_filtered_tracks_.clear();
+
   scheduler_track_ = GetOrCreateSchedulerTrack();
 
   tracepoints_system_wide_track_ =

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -42,6 +42,7 @@ class TimeGraph {
   void NeedsUpdate();
   void UpdatePrimitives(PickingMode picking_mode);
   void SortTracks();
+  void UpdateFilteredTrackList();
   void UpdateMovingTrackSorting();
   void UpdateTracks(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode);
   void SelectEvents(float world_start, float world_end, int32_t thread_id);
@@ -241,6 +242,7 @@ class TimeGraph {
   std::unordered_map<uint64_t, std::shared_ptr<FrameTrack>> frame_tracks_;
 
   std::vector<std::shared_ptr<Track>> sorted_tracks_;
+  std::vector<std::shared_ptr<Track>> sorted_filtered_tracks_;
   std::string thread_filter_;
 
   std::shared_ptr<SchedulerTrack> scheduler_track_;

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -42,6 +42,8 @@ class TimeGraph {
   void NeedsUpdate();
   void UpdatePrimitives(PickingMode picking_mode);
   void SortTracks();
+  void UpdateMovingTrackSorting();
+  void UpdateTracks(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode);
   void SelectEvents(float world_start, float world_end, int32_t thread_id);
   const std::vector<orbit_client_protos::CallstackEvent>& GetSelectedCallstackEvents(int32_t tid);
 

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -180,6 +180,8 @@ class TimeGraph {
   std::shared_ptr<FrameTrack> GetOrCreateFrameTrack(
       const orbit_client_protos::FunctionInfo& function);
 
+  [[nodiscard]] std::vector<int32_t> GetSortedThreadIds();
+
   void ProcessOrbitFunctionTimer(orbit_client_protos::FunctionInfo::OrbitType type,
                                  const orbit_client_protos::TimerInfo& timer_info);
   void ProcessIntrospectionTimer(const orbit_client_protos::TimerInfo& timer_info);

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -180,6 +180,8 @@ class TimeGraph {
   std::shared_ptr<FrameTrack> GetOrCreateFrameTrack(
       const orbit_client_protos::FunctionInfo& function);
 
+  void AddTrack(std::shared_ptr<Track> track);
+
   [[nodiscard]] std::vector<int32_t> GetSortedThreadIds();
 
   void ProcessOrbitFunctionTimer(orbit_client_protos::FunctionInfo::OrbitType type,
@@ -196,6 +198,7 @@ class TimeGraph {
   TextRenderer* text_renderer_ = nullptr;
   GlCanvas* canvas_ = nullptr;
   int num_drawn_text_boxes_ = 0;
+  bool sorting_invalidated_ = true;
 
   // First member is id.
   absl::flat_hash_map<uint64_t, const TextBox*> iterator_text_boxes_;

--- a/OrbitGl/TimerTrack.cpp
+++ b/OrbitGl/TimerTrack.cpp
@@ -24,14 +24,14 @@ TimerTrack::TimerTrack(TimeGraph* time_graph) : Track(time_graph) {
   text_renderer_ = time_graph->GetTextRenderer();
 }
 
-void TimerTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
+void TimerTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
   float track_height = GetHeight();
   float track_width = canvas->GetWorldWidth();
 
   SetPos(canvas->GetWorldTopLeftX(), pos_[1]);
   SetSize(track_width, track_height);
 
-  Track::Draw(canvas, picking_mode);
+  Track::Draw(canvas, picking_mode, z_offset);
 }
 
 std::string TimerTrack::GetExtraInfo(const TimerInfo& timer_info) {
@@ -54,7 +54,7 @@ void TimerTrack::UpdateBoxHeight() { box_height_ = time_graph_->GetLayout().GetT
 float TimerTrack::GetTextBoxHeight(const TimerInfo& /*timer_info*/) const { return box_height_; }
 
 void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
-                                  PickingMode /*picking_mode*/) {
+                                  PickingMode /*picking_mode*/, float z_offset) {
   UpdateBoxHeight();
 
   Batcher* batcher = &time_graph_->GetBatcher();
@@ -110,7 +110,7 @@ void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
 
         Vec2 pos(world_timer_x, world_timer_y);
         Vec2 size(world_timer_width, GetTextBoxHeight(timer_info));
-        float z = GlCanvas::kZValueBox;
+        float z = GlCanvas::kZValueBox + z_offset;
         Color color = GetTimerColor(timer_info, is_selected);
         text_box.SetPos(pos);
         text_box.SetSize(size);

--- a/OrbitGl/TimerTrack.cpp
+++ b/OrbitGl/TimerTrack.cpp
@@ -120,7 +120,7 @@ void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
 
         if (is_visible_width) {
           if (!is_collapsed) {
-            SetTimesliceText(timer_info, elapsed_us, world_start_x, &text_box);
+            SetTimesliceText(timer_info, elapsed_us, world_start_x, z_offset, &text_box);
           }
           batcher->AddShadedBox(pos, size, z, color, std::move(user_data));
         } else {

--- a/OrbitGl/TimerTrack.h
+++ b/OrbitGl/TimerTrack.h
@@ -26,13 +26,13 @@ class TimerTrack : public Track {
   ~TimerTrack() override = default;
 
   // Pickable
-  void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
+  void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
   virtual void OnTimer(const orbit_client_protos::TimerInfo& timer_info);
   [[nodiscard]] std::string GetTooltip() const override;
 
   // Track
-  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
-                        PickingMode /*picking_mode*/) override;
+  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode /*picking_mode*/,
+                        float z_offset = 0) override;
   [[nodiscard]] Type GetType() const override { return kTimerTrack; }
 
   [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetTimers() override;

--- a/OrbitGl/TimerTrack.h
+++ b/OrbitGl/TimerTrack.h
@@ -84,7 +84,8 @@ class TimerTrack : public Track {
   [[nodiscard]] std::shared_ptr<TimerChain> GetTimers(uint32_t depth) const;
 
   virtual void SetTimesliceText(const orbit_client_protos::TimerInfo& /*timer*/,
-                                double /*elapsed_us*/, float /*min_x*/, TextBox* /*text_box*/) {}
+                                double /*elapsed_us*/, float /*min_x*/, float /*z_offset*/,
+                                TextBox* /*text_box*/) {}
   TextRenderer* text_renderer_ = nullptr;
   uint32_t depth_ = 0;
   mutable Mutex mutex_;

--- a/OrbitGl/TracepointTrack.cpp
+++ b/OrbitGl/TracepointTrack.cpp
@@ -11,17 +11,18 @@ TracepointTrack::TracepointTrack(TimeGraph* time_graph, int32_t thread_id)
   thread_id_ = thread_id;
 }
 
-void TracepointTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
+void TracepointTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
   if (IsEmpty()) {
     return;
   }
 
   Batcher* batcher = canvas->GetBatcher();
 
-  const float eventBarZ = picking_mode == PickingMode::kClick ? GlCanvas::kZValueEventBarPicking
-                                                              : GlCanvas::kZValueEventBar;
+  float event_bar_z = picking_mode == PickingMode::kClick ? GlCanvas::kZValueEventBarPicking
+                                                          : GlCanvas::kZValueEventBar;
+  event_bar_z += z_offset;
   Color color = color_;
-  Box box(pos_, Vec2(size_[0], -size_[1]), eventBarZ);
+  Box box(pos_, Vec2(size_[0], -size_[1]), event_bar_z);
   batcher->AddBox(box, color, shared_from_this());
 
   if (canvas->GetPickingManager().IsThisElementPicked(this)) {
@@ -33,9 +34,8 @@ void TracepointTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   float x1 = x0 + size_[0];
   float y1 = y0 - size_[1];
 
-  batcher->AddLine(pos_, Vec2(x1, y0), GlCanvas::kZValueEventBar, color, shared_from_this());
-  batcher->AddLine(Vec2(x1, y1), Vec2(x0, y1), GlCanvas::kZValueEventBar, color,
-                   shared_from_this());
+  batcher->AddLine(pos_, Vec2(x1, y0), event_bar_z, color, shared_from_this());
+  batcher->AddLine(Vec2(x1, y1), Vec2(x0, y1), event_bar_z, color, shared_from_this());
 
   if (picked_) {
     Vec2& from = mouse_pos_[0];
@@ -47,7 +47,7 @@ void TracepointTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
     y1 = y0 - size_[1];
 
     Color picked_color(0, 128, 255, 128);
-    Box box(Vec2(x0, y0), Vec2(x1 - x0, -size_[1]), GlCanvas::kZValueUi);
+    Box box(Vec2(x0, y0), Vec2(x1 - x0, -size_[1]), GlCanvas::kZValueUi + z_offset);
     batcher->AddBox(box, picked_color, shared_from_this());
   }
 
@@ -55,10 +55,10 @@ void TracepointTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
 }
 
 void TracepointTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
-                                       PickingMode picking_mode) {
+                                       PickingMode picking_mode, float z_offset) {
   Batcher* batcher = &time_graph_->GetBatcher();
   const TimeGraphLayout& layout = time_graph_->GetLayout();
-  float z = GlCanvas::kZValueEvent;
+  float z = GlCanvas::kZValueEvent + z_offset;
   float track_height = layout.GetEventTrackHeight();
   const bool picking = picking_mode != PickingMode::kNone;
 

--- a/OrbitGl/TracepointTrack.h
+++ b/OrbitGl/TracepointTrack.h
@@ -11,9 +11,10 @@ class TracepointTrack : public EventTrack {
  public:
   explicit TracepointTrack(TimeGraph* time_graph, int32_t thread_id);
 
-  void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
+  void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
 
-  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode) override;
+  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode,
+                        float z_offset = 0) override;
 
   void SetPos(float x, float y);
 

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -79,7 +79,7 @@ void Track::DrawTriangleFan(Batcher* batcher, const std::vector<Vec2>& points, c
   }
 }
 
-void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
+void Track::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
   Batcher* batcher = canvas->GetBatcher();
 
   const TimeGraphLayout& layout = time_graph_->GetLayout();
@@ -89,9 +89,15 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   float x1 = x0 + size_[0];
   float y0 = pos_[1];
   float y1 = y0 - size_[1];
-  float track_z = GlCanvas::kZValueTrack;
-  float text_z = GlCanvas::kZValueText;
+  float track_z = GlCanvas::kZValueTrack + z_offset;
+  float text_z = GlCanvas::kZValueText + z_offset;
   float top_margin = layout.GetTrackTopMargin();
+
+  // Draw pinned background
+  if (!picking && IsPinned()) {
+    Box box(Vec2(x0, y0), Vec2(size_[0], size_[1]), track_z);
+    batcher->AddBox(box, GlCanvas::kTabColor, shared_from_this());
+  }
 
   // Draw track background.
   Color background_color = GetBackgroundColor();
@@ -125,7 +131,7 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
     Vec2 top_left(tab_x0, y0 + label_height);
     Vec2 end_bottom(x1 - right_margin, y1);
     Vec2 end_top(x1 - right_margin, y0 + top_margin);
-    float z = GlCanvas::kZValueRoundingCorner;
+    float z = GlCanvas::kZValueRoundingCorner + z_offset;
 
     DrawTriangleFan(batcher, rounded_corner, bottom_left, GlCanvas::kBackgroundColor, 0, z);
     DrawTriangleFan(batcher, rounded_corner, bottom_right, background_color, 0, z);
@@ -147,7 +153,7 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   float toggle_y_pos = pos_[1] + half_label_height;
   Vec2 toggle_pos = Vec2(tab_x0 + button_offset, toggle_y_pos);
   collapse_toggle_->SetPos(toggle_pos);
-  collapse_toggle_->Draw(canvas, picking_mode);
+  collapse_toggle_->Draw(canvas, picking_mode, z_offset);
 
   if (!picking) {
     // Draw label.
@@ -165,8 +171,8 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   canvas_ = canvas;
 }
 
-void Track::UpdatePrimitives(uint64_t /*t_min*/, uint64_t /*t_max*/,
-                             PickingMode /*  picking_mode*/) {}
+void Track::UpdatePrimitives(uint64_t /*t_min*/, uint64_t /*t_max*/, PickingMode /*  picking_mode*/,
+                             float /*z_offset*/) {}
 
 void Track::SetPos(float a_X, float a_Y) {
   if (!moving_) {

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -100,14 +100,12 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
 
   const Color kBackgroundColor = GetBackgroundColor();
 
-  // Draw pinned background
-  if (!picking && IsPinned()) {
-    Box box(Vec2(x0, y0), Vec2(size_[0], size_[1]), track_z);
-    batcher->AddBox(box, kBackgroundColor, shared_from_this());
-  }
-
   // Draw track background.
   if (!picking) {
+    if (IsPinned()) {
+      Box box(Vec2(x0, y0), Vec2(size_[0], size_[1]), track_z);
+      batcher->AddBox(box, kBackgroundColor, shared_from_this());
+    }
     if (layout.GetDrawTrackBackground()) {
       Box box(Vec2(x0, y0 + top_margin), Vec2(size_[0], -size_[1] - top_margin), track_z);
       batcher->AddBox(box, kBackgroundColor, shared_from_this());
@@ -137,14 +135,13 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
     Vec2 top_left(tab_x0, y0 + label_height);
     Vec2 end_bottom(x1 - right_margin, y1);
     Vec2 end_top(x1 - right_margin, y0 + top_margin);
-    float z = GlCanvas::kZValueRoundingCorner + z_offset;
 
-    DrawTriangleFan(batcher, rounded_corner, bottom_left, GlCanvas::kBackgroundColor, 0, z);
-    DrawTriangleFan(batcher, rounded_corner, bottom_right, kBackgroundColor, 0, z);
-    DrawTriangleFan(batcher, rounded_corner, top_right, GlCanvas::kBackgroundColor, 180.f, z);
-    DrawTriangleFan(batcher, rounded_corner, top_left, GlCanvas::kBackgroundColor, -90.f, z);
-    DrawTriangleFan(batcher, rounded_corner, end_bottom, GlCanvas::kBackgroundColor, 90.f, z);
-    DrawTriangleFan(batcher, rounded_corner, end_top, GlCanvas::kBackgroundColor, 180.f, z);
+    DrawTriangleFan(batcher, rounded_corner, bottom_left, GlCanvas::kBackgroundColor, 0, track_z);
+    DrawTriangleFan(batcher, rounded_corner, bottom_right, kBackgroundColor, 0, track_z);
+    DrawTriangleFan(batcher, rounded_corner, top_right, GlCanvas::kBackgroundColor, 180.f, track_z);
+    DrawTriangleFan(batcher, rounded_corner, top_left, GlCanvas::kBackgroundColor, -90.f, track_z);
+    DrawTriangleFan(batcher, rounded_corner, end_bottom, GlCanvas::kBackgroundColor, 90.f, track_z);
+    DrawTriangleFan(batcher, rounded_corner, end_top, GlCanvas::kBackgroundColor, 180.f, track_z);
   }
 
   // Collapse toggle state management.

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -12,7 +12,7 @@
 #include "TimeGraphLayout.h"
 #include "absl/strings/str_format.h"
 
-ABSL_DECLARE_FLAG(bool, thread_ordering_feature);
+ABSL_DECLARE_FLAG(bool, track_ordering_feature);
 
 Track::Track(TimeGraph* time_graph)
     : time_graph_(time_graph),
@@ -180,11 +180,11 @@ void Track::UpdatePrimitives(uint64_t /*t_min*/, uint64_t /*t_max*/, PickingMode
                              float /*z_offset*/) {}
 
 void Track::SetPinned(bool value) {
-  pinned_ = value && absl::GetFlag(FLAGS_thread_ordering_feature);
+  pinned_ = value && absl::GetFlag(FLAGS_track_ordering_feature);
   if (pinned_) {
     picking_enabled_ = false;
   } else {
-    picking_enabled_ = absl::GetFlag(FLAGS_thread_ordering_feature);
+    picking_enabled_ = absl::GetFlag(FLAGS_track_ordering_feature);
   }
 }
 

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -90,7 +90,7 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
   float y0 = pos_[1];
   float y1 = y0 - size_[1];
   float track_z = GlCanvas::kZValueTrack + z_offset;
-  float text_z = GlCanvas::kZValueText + z_offset;
+  float text_z = GlCanvas::kZValueTrack + z_offset;
   float top_margin = layout.GetTrackTopMargin();
 
   // Draw pinned background

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -5,8 +5,8 @@
 #include "Track.h"
 
 #include <absl/flags/flag.h>
-#include "App.h"
 
+#include "App.h"
 #include "CoreMath.h"
 #include "GlCanvas.h"
 #include "TimeGraphLayout.h"
@@ -98,18 +98,19 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
   float text_z = GlCanvas::kZValueTrack + z_offset;
   float top_margin = layout.GetTrackTopMargin();
 
+  const Color kBackgroundColor = GetBackgroundColor();
+
   // Draw pinned background
   if (!picking && IsPinned()) {
     Box box(Vec2(x0, y0), Vec2(size_[0], size_[1]), track_z);
-    batcher->AddBox(box, GlCanvas::kTabColor, shared_from_this());
+    batcher->AddBox(box, kBackgroundColor, shared_from_this());
   }
 
   // Draw track background.
-  Color background_color = GetBackgroundColor();
   if (!picking) {
     if (layout.GetDrawTrackBackground()) {
       Box box(Vec2(x0, y0 + top_margin), Vec2(size_[0], -size_[1] - top_margin), track_z);
-      batcher->AddBox(box, background_color, shared_from_this());
+      batcher->AddBox(box, kBackgroundColor, shared_from_this());
     }
   }
 
@@ -121,7 +122,7 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
   float tab_x0 = x0 + layout.GetTrackTabOffset();
 
   Box box(Vec2(tab_x0, y0), Vec2(label_width, label_height), track_z);
-  batcher->AddBox(box, background_color, shared_from_this());
+  batcher->AddBox(box, kBackgroundColor, shared_from_this());
 
   // Draw rounded corners.
   if (!picking) {
@@ -139,7 +140,7 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
     float z = GlCanvas::kZValueRoundingCorner + z_offset;
 
     DrawTriangleFan(batcher, rounded_corner, bottom_left, GlCanvas::kBackgroundColor, 0, z);
-    DrawTriangleFan(batcher, rounded_corner, bottom_right, background_color, 0, z);
+    DrawTriangleFan(batcher, rounded_corner, bottom_right, kBackgroundColor, 0, z);
     DrawTriangleFan(batcher, rounded_corner, top_right, GlCanvas::kBackgroundColor, 180.f, z);
     DrawTriangleFan(batcher, rounded_corner, top_left, GlCanvas::kBackgroundColor, -90.f, z);
     DrawTriangleFan(batcher, rounded_corner, end_bottom, GlCanvas::kBackgroundColor, 90.f, z);
@@ -180,11 +181,12 @@ void Track::UpdatePrimitives(uint64_t /*t_min*/, uint64_t /*t_max*/, PickingMode
                              float /*z_offset*/) {}
 
 void Track::SetPinned(bool value) {
-  pinned_ = value && absl::GetFlag(FLAGS_track_ordering_feature);
+  const bool track_ordering_feature = absl::GetFlag(FLAGS_track_ordering_feature);
+  pinned_ = value && track_ordering_feature;
   if (pinned_) {
     picking_enabled_ = false;
   } else {
-    picking_enabled_ = absl::GetFlag(FLAGS_track_ordering_feature);
+    picking_enabled_ = track_ordering_feature;
   }
 }
 

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -39,17 +39,18 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
 
   explicit Track(TimeGraph* time_graph);
   ~Track() override = default;
+  virtual void Draw(GlCanvas* a_Canvas, PickingMode a_PickingMode, float z_offset = 0);
+  virtual void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode,
+                                float z_offset = 0);
 
   // Pickable
-  void Draw(GlCanvas* a_Canvas, PickingMode a_PickingMode) override;
-  virtual void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode);
   void OnPick(int a_X, int a_Y) override;
   void OnRelease() override;
   void OnDrag(int a_X, int a_Y) override;
   [[nodiscard]] bool Draggable() override { return true; }
-  [[nodiscard]] bool Movable() override { return true; }
 
   [[nodiscard]] virtual Type GetType() const = 0;
+  [[nodiscard]] virtual bool Movable() { return true; }
 
   [[nodiscard]] virtual float GetHeight() const { return 0.f; };
   [[nodiscard]] bool GetVisible() const { return visible_; }
@@ -70,6 +71,8 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
   [[nodiscard]] virtual std::vector<std::shared_ptr<TimerChain>> GetAllSerializableChains() {
     return {};
   }
+
+  [[nodiscard]] bool IsPinned() const { return pinned_; }
 
   [[nodiscard]] bool IsMoving() const { return moving_; }
   [[nodiscard]] Vec2 GetMoveDelta() const {
@@ -115,10 +118,11 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
   int32_t process_id_;
   Color color_;
   bool visible_ = true;
+  bool pinned_ = false;
   std::atomic<uint32_t> num_timers_;
   std::atomic<uint64_t> min_time_;
   std::atomic<uint64_t> max_time_;
-  bool picking_enabled_ = false;
+  bool picking_enabled_ = true;
   Type type_ = kUnknown;
   std::vector<std::shared_ptr<Track>> children_;
   std::shared_ptr<TriangleToggle> collapse_toggle_;

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -73,6 +73,7 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
   }
 
   [[nodiscard]] bool IsPinned() const { return pinned_; }
+  void SetPinned(bool value);
 
   [[nodiscard]] bool IsMoving() const { return moving_; }
   [[nodiscard]] Vec2 GetMoveDelta() const {
@@ -122,7 +123,7 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
   std::atomic<uint32_t> num_timers_;
   std::atomic<uint64_t> min_time_;
   std::atomic<uint64_t> max_time_;
-  bool picking_enabled_ = true;
+  bool picking_enabled_ = false;
   Type type_ = kUnknown;
   std::vector<std::shared_ptr<Track>> children_;
   std::shared_ptr<TriangleToggle> collapse_toggle_;

--- a/OrbitGl/TriangleToggle.cpp
+++ b/OrbitGl/TriangleToggle.cpp
@@ -14,8 +14,9 @@ TriangleToggle::TriangleToggle(State initial_state, StateChangeHandler handler,
       handler_(handler),
       time_graph_(time_graph) {}
 
-void TriangleToggle::Draw(GlCanvas* canvas, PickingMode picking_mode) {
+void TriangleToggle::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
   Batcher* batcher = canvas->GetBatcher();
+  const float z = GlCanvas::kZValueTrack + z_offset;
 
   const bool picking = picking_mode != PickingMode::kNone;
   const Color kWhite(255, 255, 255, 255);
@@ -32,13 +33,11 @@ void TriangleToggle::Draw(GlCanvas* canvas, PickingMode picking_mode) {
 
     Triangle triangle;
     if (state_ == State::kCollapsed) {
-      triangle = Triangle(position + Vec3(-half_h, half_w, GlCanvas::kZValueUi),
-                          position + Vec3(-half_h, -half_w, GlCanvas::kZValueUi),
-                          position + Vec3(half_w, 0.f, GlCanvas::kZValueUi));
+      triangle = Triangle(position + Vec3(-half_h, half_w, z), position + Vec3(-half_h, -half_w, z),
+                          position + Vec3(half_w, 0.f, z));
     } else {
-      triangle = Triangle(position + Vec3(half_w, half_h, GlCanvas::kZValueUi),
-                          position + Vec3(-half_w, half_h, GlCanvas::kZValueUi),
-                          position + Vec3(0.f, -half_w, GlCanvas::kZValueUi));
+      triangle = Triangle(position + Vec3(half_w, half_h, z), position + Vec3(-half_w, half_h, z),
+                          position + Vec3(0.f, -half_w, z));
     }
     batcher->AddTriangle(triangle, color, shared_from_this());
   } else {
@@ -46,7 +45,7 @@ void TriangleToggle::Draw(GlCanvas* canvas, PickingMode picking_mode) {
     float original_width = 2 * half_w;
     float large_width = 2 * original_width;
     Box box(Vec2(pos_[0] - original_width, pos_[1] - original_width),
-            Vec2(large_width, large_width), GlCanvas::kZValueUi);
+            Vec2(large_width, large_width), z);
     batcher->AddBox(box, color, shared_from_this());
   }
 }

--- a/OrbitGl/TriangleToggle.h
+++ b/OrbitGl/TriangleToggle.h
@@ -27,8 +27,9 @@ class TriangleToggle : public Pickable, public std::enable_shared_from_this<Tria
   TriangleToggle(TriangleToggle&&) = delete;
   TriangleToggle& operator=(TriangleToggle&&) = delete;
 
+  void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0);
+
   // Pickable
-  void Draw(GlCanvas* canvas, PickingMode picking_mode) override;
   void OnPick(int x, int y) override;
   void OnRelease() override;
 

--- a/OrbitGl/UnitTestMockEnvironment.cpp
+++ b/OrbitGl/UnitTestMockEnvironment.cpp
@@ -16,4 +16,4 @@ ABSL_FLAG(bool, show_return_values, false, "Show return values on time slices");
 ABSL_FLAG(bool, enable_tracepoint_feature, false,
           "Enable the setting of the panel of kernel tracepoints");
 ABSL_FLAG(bool, thread_state, false, "Collect thread states");
-ABSL_FLAG(bool, thread_ordering_feature, false, "Allow reordering and pinning of threads");
+ABSL_FLAG(bool, track_ordering_feature, false, "Allow reordering and pinning of threads");

--- a/OrbitGl/UnitTestMockEnvironment.cpp
+++ b/OrbitGl/UnitTestMockEnvironment.cpp
@@ -5,18 +5,6 @@
 #include <absl/flags/flag.h>
 
 // Flag declarations
-ABSL_DECLARE_FLAG(bool, devmode);
-ABSL_DECLARE_FLAG(bool, local);
-
-ABSL_DECLARE_FLAG(uint16_t, sampling_rate);
-ABSL_DECLARE_FLAG(bool, frame_pointer_unwinding);
-
-ABSL_DECLARE_FLAG(bool, show_return_values);
-ABSL_DECLARE_FLAG(bool, enable_frame_pointer_validator);
-ABSL_DECLARE_FLAG(bool, enable_tracepoint_feature);
-ABSL_DECLARE_FLAG(bool, thread_state);
-
-// Flag usages
 ABSL_FLAG(bool, devmode, false, "Enable developer mode in the client's UI");
 ABSL_FLAG(bool, local, false, "Connects to local instance of OrbitService");
 
@@ -28,3 +16,4 @@ ABSL_FLAG(bool, show_return_values, false, "Show return values on time slices");
 ABSL_FLAG(bool, enable_tracepoint_feature, false,
           "Enable the setting of the panel of kernel tracepoints");
 ABSL_FLAG(bool, thread_state, false, "Collect thread states");
+ABSL_FLAG(bool, thread_ordering_feature, false, "Allow reordering and pinning of threads");

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -69,6 +69,7 @@ ABSL_FLAG(bool, enable_tracepoint_feature, false,
           "Enable the setting of the panel of kernel tracepoints");
 
 ABSL_FLAG(bool, thread_state, false, "Collect thread states");
+ABSL_FLAG(bool, thread_ordering_feature, false, "Allow reordering and pinning of threads");
 
 using ServiceDeployManager = OrbitQt::ServiceDeployManager;
 using DeploymentConfiguration = OrbitQt::DeploymentConfiguration;

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -69,7 +69,7 @@ ABSL_FLAG(bool, enable_tracepoint_feature, false,
           "Enable the setting of the panel of kernel tracepoints");
 
 ABSL_FLAG(bool, thread_state, false, "Collect thread states");
-ABSL_FLAG(bool, thread_ordering_feature, false, "Allow reordering and pinning of threads");
+ABSL_FLAG(bool, track_ordering_feature, false, "Allow reordering and pinning of threads");
 
 using ServiceDeployManager = OrbitQt::ServiceDeployManager;
 using DeploymentConfiguration = OrbitQt::DeploymentConfiguration;


### PR DESCRIPTION
Basics for thread pinning and sorting.

**Pinned** tracks are always displayed on top of the capture window,
similar to frozen panes in a spreadsheet. Scrolling will not affect the
position of those tracks, and other tracks are rendered underneath
them.

Track tabs can be clicked and dragged up and down to adjust the
**sorting** in the capture window.

**Core changes**

Changes are distributed across multiple commits. Basically:
- Removed unneeded definition of methods in `Pickable` (now defined
by the tracks)
- Added `z_offset` parameter to all drawing / update functions to
allow stacking thacks "on top" of others
- Auto-sorting of tracks is now only happening during a running capture

**Open issues**

- Sorting / Pinning is not saved with the capture, and lost when the
capture is restarted
- Not all elements are ordered correctly w.r.t. depth (e.g. rounded
corners pose an issue)

Due to the open issues, this change is behind a feature flag.
Use `-track_ordering_feature` to enable.