### PR TITLE
Fix ClientGgpLib issue

### DIFF
--- a/OrbitClientGgp/CMakeLists.txt
+++ b/OrbitClientGgp/CMakeLists.txt
@@ -20,8 +20,7 @@ target_sources(OrbitClientGgpLib PUBLIC
     include/OrbitClientGgp/ClientGgpOptions.h)
 
 target_sources(OrbitClientGgpLib PRIVATE
-    ClientGgp.cpp
-    main.cpp)
+    ClientGgp.cpp)
 
 target_link_libraries(OrbitClientGgpLib PUBLIC
     OrbitBase


### PR DESCRIPTION
_CMakeLists.txt_ in _OrbitClientGgp_ was updated to separate the main executable (OrbitClientGgp) from the library classes
(OrbitClientGgpLib) but _main.cpp_ was still being included in the library resulting in compilation errors when importing ClientGgp. This update fixes the issue.