### PR TITLE
[REBASE] Fix Crash on Loading a Capture with Frame Tracks

### DIFF
--- a/OrbitGl/FrameTrack.cpp
+++ b/OrbitGl/FrameTrack.cpp
@@ -238,3 +238,10 @@ void FrameTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
 void FrameTrack::UpdateBoxHeight() {
   box_height_ = kBoxHeightMultiplier * time_graph_->GetLayout().GetTextBoxHeight();
 }
+
+std::vector<std::shared_ptr<TimerChain>> FrameTrack::GetAllSerializableChains() {
+  // Frametracks are just displaying existing data in a different way.
+  // We don't want to write out all the timers of that track.
+  // TODO(b/171026228): However, we should serialize them in some form.
+  return {};
+}

--- a/OrbitGl/FrameTrack.h
+++ b/OrbitGl/FrameTrack.h
@@ -29,6 +29,8 @@ class FrameTrack : public TimerTrack {
 
   void UpdateBoxHeight() override;
 
+  [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllSerializableChains() override;
+
  protected:
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
                                     bool is_selected) const override;


### PR DESCRIPTION
Does not serialize the timers of a frame track.

Bug: http://b/171026702
Test: Save and load a capture with frame tracks

Original PR:
#1369