### PR TITLE
Fix incorrect computation of the maximum box ratio for frame tracks

### DIFF
--- a/OrbitGl/FrameTrack.cpp
+++ b/OrbitGl/FrameTrack.cpp
@@ -119,14 +119,7 @@ void FrameTrack::OnTimer(const TimerInfo& timer_info) {
     stats_.set_min_ns(duration_ns);
   }
 
-  double ratio = 0.0;
-  if (stats_.average_time_ns() != 0) {
-    ratio = static_cast<double>(duration_ns) / static_cast<double>(stats_.average_time_ns());
-  }
-
-  maximum_box_ratio_ = std::max(maximum_box_ratio_, static_cast<float>(ratio));
-  maximum_box_ratio_ =
-      std::min(maximum_box_ratio_, static_cast<float>(kHeightCapAverageMultipleDouble));
+  durations_.push_back(duration_ns);
 
   TimerTrack::OnTimer(timer_info);
 }
@@ -201,6 +194,21 @@ std::string FrameTrack::GetBoxTooltip(PickingId id) const {
       FunctionUtils::GetLoadedModuleName(function_), text_box->GetTimerInfo().user_data_key(),
       GetPrettyTime(
           TicksToDuration(text_box->GetTimerInfo().start(), text_box->GetTimerInfo().end())));
+}
+
+void FrameTrack::Finalize() {
+  for (uint64_t duration : durations_) {
+    double ratio = 0.0;
+    if (stats_.average_time_ns() != 0) {
+      ratio = static_cast<double>(duration) / static_cast<double>(stats_.average_time_ns());
+    }
+
+    maximum_box_ratio_ = std::max(maximum_box_ratio_, static_cast<float>(ratio));
+    maximum_box_ratio_ =
+        std::min(maximum_box_ratio_, static_cast<float>(kHeightCapAverageMultipleDouble));
+  }
+
+  durations_.clear();
 }
 
 void FrameTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {

--- a/OrbitGl/FrameTrack.h
+++ b/OrbitGl/FrameTrack.h
@@ -15,6 +15,9 @@ class FrameTrack : public TimerTrack {
 
   [[nodiscard]] virtual float GetYFromDepth(uint32_t depth) const override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
+  // Some values needed for visualization have to be computed after all timers have been added to
+  // the track. This can be done using the Finalize() method.
+  void Finalize();
 
   [[nodiscard]] float GetTextBoxHeight(
       const orbit_client_protos::TimerInfo& timer_info) const override;
@@ -40,6 +43,8 @@ class FrameTrack : public TimerTrack {
 
   orbit_client_protos::FunctionInfo function_;
   orbit_client_protos::FunctionStats stats_;
+
+  std::vector<uint64_t> durations_;
 
   float maximum_box_ratio_ = 0.f;
 };

--- a/OrbitGl/LiveFunctionsController.cpp
+++ b/OrbitGl/LiveFunctionsController.cpp
@@ -243,6 +243,7 @@ void LiveFunctionsController::AddFrameTrack(const FunctionInfo& function) {
 
     GCurrentTimeGraph->ProcessTimer(frame_timer, &function);
   }
+  GCurrentTimeGraph->FinalizeFrameTrack(function);
 }
 
 void LiveFunctionsController::RemoveFrameTrack(const FunctionInfo& function) {

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -1090,3 +1090,10 @@ void TimeGraph::RemoveFrameTrack(const orbit_client_protos::FunctionInfo& functi
   frame_tracks_.erase(function.address());
   NeedsUpdate();
 }
+
+void TimeGraph::FinalizeFrameTrack(const orbit_client_protos::FunctionInfo& function) {
+  auto it = frame_tracks_.find(function.address());
+  if (it != frame_tracks_.end()) {
+    it->second->Finalize();
+  }
+}

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -166,6 +166,7 @@ class TimeGraph {
   [[nodiscard]] uint64_t GetCaptureMax() const { return capture_max_timestamp_; }
   [[nodiscard]] uint64_t GetCurrentMouseTimeNs() const { return current_mouse_time_ns_; }
 
+  void FinalizeFrameTrack(const orbit_client_protos::FunctionInfo& function);
   void RemoveFrameTrack(const orbit_client_protos::FunctionInfo& function);
 
  protected:


### PR DESCRIPTION
Maximum box ratio determines the scaling factor for the boxes on the
track and is based on the largest box height and the average box height.
So far, this ratio was computed online whenever a timer was added. This
is incorrect as the average value (obviously) still changes with future
timers to be added.

We fix this be adding a Finalize() method to the FrameTrack class that
has to be called after all timers have been added.