### PR TITLE
Add GetNumberOfBusyThreads method to ThreadPool

### DIFF
--- a/OrbitBase/ThreadPool.cpp
+++ b/OrbitBase/ThreadPool.cpp
@@ -19,7 +19,7 @@ class ThreadPoolImpl : public ThreadPool {
                           absl::Duration thread_ttl);
 
   size_t GetPoolSize() override;
-  size_t GetNBusyThreads() override;
+  size_t GetNumberOfBusyThreads() override;
   void Schedule(std::unique_ptr<Action> action) override;
   void Shutdown() override;
   void Wait() override;
@@ -95,7 +95,7 @@ size_t ThreadPoolImpl::GetPoolSize() {
   return worker_threads_.size();
 }
 
-size_t ThreadPoolImpl::GetNBusyThreads() {
+size_t ThreadPoolImpl::GetNumberOfBusyThreads() {
   absl::MutexLock lock(&mutex_);
   return worker_threads_.size() - idle_threads_;
 }

--- a/OrbitBase/ThreadPool.cpp
+++ b/OrbitBase/ThreadPool.cpp
@@ -19,6 +19,7 @@ class ThreadPoolImpl : public ThreadPool {
                           absl::Duration thread_ttl);
 
   size_t GetPoolSize() override;
+  size_t GetNBusyThreads() override;
   void Schedule(std::unique_ptr<Action> action) override;
   void Shutdown() override;
   void Wait() override;
@@ -92,6 +93,11 @@ void ThreadPoolImpl::CleanupFinishedThreads() {
 size_t ThreadPoolImpl::GetPoolSize() {
   absl::MutexLock lock(&mutex_);
   return worker_threads_.size();
+}
+
+size_t ThreadPoolImpl::GetNBusyThreads() {
+  absl::MutexLock lock(&mutex_);
+  return worker_threads_.size() - idle_threads_;
 }
 
 void ThreadPoolImpl::Shutdown() {

--- a/OrbitBase/include/OrbitBase/ThreadPool.h
+++ b/OrbitBase/include/OrbitBase/ThreadPool.h
@@ -53,6 +53,7 @@ class ThreadPool {
   }
 
   virtual size_t GetPoolSize() = 0;
+  virtual size_t GetNBusyThreads() = 0;
 
   // Create ThreadPool with specified minimum and maximum number of worker
   // threads.

--- a/OrbitBase/include/OrbitBase/ThreadPool.h
+++ b/OrbitBase/include/OrbitBase/ThreadPool.h
@@ -53,7 +53,7 @@ class ThreadPool {
   }
 
   virtual size_t GetPoolSize() = 0;
-  virtual size_t GetNBusyThreads() = 0;
+  virtual size_t GetNumberOfBusyThreads() = 0;
 
   // Create ThreadPool with specified minimum and maximum number of worker
   // threads.


### PR DESCRIPTION
The new non-linear ggp client needs to know the number of the busy
threads in the pool so it has been created a new method to be able to
get this number.