### PR TITLE
Fix incorrect computation of the maximum box ratio for frame tracks

### DIFF
--- a/OrbitGl/FrameTrack.h
+++ b/OrbitGl/FrameTrack.h
@@ -11,7 +11,7 @@ class FrameTrack : public TimerTrack {
  public:
   explicit FrameTrack(TimeGraph* time_graph, const orbit_client_protos::FunctionInfo& function);
   [[nodiscard]] Type GetType() const override { return kFrameTrack; }
-  [[nodiscard]] bool IsCollapsable() const override { return maximum_box_ratio_ > 0.f; }
+  [[nodiscard]] bool IsCollapsable() const override { return GetMaximumScaleFactor() > 0.f; }
 
   [[nodiscard]] virtual float GetYFromDepth(uint32_t depth) const override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
@@ -37,13 +37,12 @@ class FrameTrack : public TimerTrack {
   [[nodiscard]] float GetHeight() const override;
 
  private:
+  [[nodiscard]] float GetMaximumScaleFactor() const;
   [[nodiscard]] float GetMaximumBoxHeight() const;
   [[nodiscard]] float GetAverageBoxHeight() const;
 
   orbit_client_protos::FunctionInfo function_;
   orbit_client_protos::FunctionStats stats_;
-
-  float maximum_box_ratio_ = 0.f;
 };
 
 #endif  // ORBIT_GL_THREAD_TRACK_H_


### PR DESCRIPTION
Maximum box ratio determines the scaling factor for the boxes on the
track and is based on the largest box height and the average box height.
So far, this ratio was computed online whenever a timer was added. This
is incorrect as the average value (obviously) still changes with future
timers to be added.

We fix this be computing the maxium scale factor (box ratio) only when
needed for drawing when all timers have been added.

This approach should also be correct when live updating a frame track
during a capture, which is not working yet, but planned for the future.