### PR TITLE
Remove package upload from CI build script

### DIFF
--- a/kokoro/builds/build.sh
+++ b/kokoro/builds/build.sh
@@ -165,17 +165,6 @@ if [ -n "$1" ]; then
     done
   fi
 
-  # Uploading prebuilt packages of our dependencies
-  readonly ARTIFACTORY_ACCESS_TOKEN="${KEYSTORE_PATH}/74938_orbitprofiler_artifactory_access_token"
-  if [ -f "${ARTIFACTORY_ACCESS_TOKEN}" ]; then
-    conan user -r artifactory -p "$(cat "${ARTIFACTORY_ACCESS_TOKEN}" | tr -d '\n')" kokoro
-    # The llvm-package is very large and not needed as a prebuilt because it is not consumed directly.
-    conan remove 'llvm/*@orbitdeps/stable'
-    conan upload -r artifactory --all --no-overwrite all --confirm --parallel \*
-  else
-    echo "No access token available. Won't upload packages."
-  fi
-
   # Package the Debian package, the signature and the ggp client into a zip for integration in the 
   # installer.
   if [ -f ${KEYSTORE_PATH}/74938_SigningPrivateGpg ] && [[ $CONAN_PROFILE == ggp_* ]]; then


### PR DESCRIPTION
We used to automatically upload built packages to the internal
artifactory server when they have been built by the CI during the
run.

But with build_and_upload_dependencies.sh we have a better solution
for a while now, which we have been using exclusively for uploading
new packages.

Furthermore this upload step once corrupted the cache in the past due
to a partially uploaded package.

This all concludes that the best option is to remove the automatic
package uploading and require manual uploading with
build_and_upload_dependencies.sh.