### PR TITLE
Introspection revival

### DIFF
--- a/OrbitBase/TracingTest.cpp
+++ b/OrbitBase/TracingTest.cpp
@@ -30,13 +30,12 @@ TEST(Tracing, Scopes) {
 
   absl::flat_hash_map<pid_t, std::vector<Scope>> scopes_by_thread_id;
   {
-    Listener tracing_listener(
-        std::make_unique<TimerCallback>([&scopes_by_thread_id](const Scope& scope) {
-          // Check that callback is called from a single thread.
-          static pid_t callback_thread_id = GetCurrentThreadId();
-          EXPECT_EQ(GetCurrentThreadId(), callback_thread_id);
-          scopes_by_thread_id[scope.tid].emplace_back(scope);
-        }));
+    Listener tracing_listener([&scopes_by_thread_id](const Scope& scope) {
+      // Check that callback is called from a single thread.
+      static pid_t callback_thread_id = GetCurrentThreadId();
+      EXPECT_EQ(GetCurrentThreadId(), callback_thread_id);
+      scopes_by_thread_id[scope.tid].emplace_back(scope);
+    });
 
     std::vector<std::unique_ptr<std::thread>> threads;
     for (size_t i = 0; i < kNumThreads; ++i) {

--- a/OrbitBase/include/OrbitBase/Tracing.h
+++ b/OrbitBase/include/OrbitBase/Tracing.h
@@ -14,31 +14,32 @@
 #include "../../../Orbit.h"
 #include "OrbitBase/ThreadPool.h"
 
+#define ORBIT_SCOPE_FUNCTION ORBIT_SCOPE(__FUNCTION__)
+
 namespace orbit::tracing {
 
 struct Scope {
+  Scope(orbit_api::EventType type, const char* name = nullptr, uint64_t data = 0,
+        orbit::Color color = orbit::Color::kAuto);
   uint64_t begin = 0;
   uint64_t end = 0;
-  uint64_t tracked_value = 0;
   uint32_t depth = 0;
   uint32_t tid = 0;
-  orbit::Color color = orbit::Color::kAuto;
-  const char* name = nullptr;
-  orbit_api::EventType type = orbit_api::kNone;
+  orbit_api::EncodedEvent encoded_event;
 };
 
 using TimerCallback = std::function<void(const Scope& scope)>;
 
 class Listener {
  public:
-  explicit Listener(std::unique_ptr<TimerCallback> callback);
+  explicit Listener(TimerCallback callback);
   ~Listener();
 
   static void DeferScopeProcessing(const Scope& scope);
   [[nodiscard]] inline static bool IsActive() { return active_; }
 
  private:
-  std::unique_ptr<TimerCallback> user_callback_ = {};
+  TimerCallback user_callback_ = nullptr;
   std::unique_ptr<ThreadPool> thread_pool_ = {};
   inline static bool active_ = false;
 };

--- a/OrbitCaptureClient/CaptureEventProcessor.cpp
+++ b/OrbitCaptureClient/CaptureEventProcessor.cpp
@@ -4,7 +4,9 @@
 
 #include "OrbitCaptureClient/CaptureEventProcessor.h"
 
+#include "../Orbit.h"
 #include "CoreUtils.h"
+#include "OrbitBase/Tracing.h"
 #include "capture_data.pb.h"
 
 using orbit_client_protos::CallstackEvent;
@@ -20,6 +22,7 @@ using orbit_grpc_protos::FunctionCall;
 using orbit_grpc_protos::GpuJob;
 using orbit_grpc_protos::InternedCallstack;
 using orbit_grpc_protos::InternedString;
+using orbit_grpc_protos::IntrospectionCall;
 using orbit_grpc_protos::SchedulingSlice;
 using orbit_grpc_protos::ThreadName;
 using orbit_grpc_protos::ThreadStateSlice;
@@ -37,6 +40,9 @@ void CaptureEventProcessor::ProcessEvent(const CaptureEvent& event) {
       break;
     case CaptureEvent::kFunctionCall:
       ProcessFunctionCall(event.function_call());
+      break;
+    case CaptureEvent::kIntrospectionCall:
+      ProcessIntrospectionCall(event.introspection_call());
       break;
     case CaptureEvent::kInternedString:
       ProcessInternedString(event.interned_string());
@@ -104,6 +110,7 @@ void CaptureEventProcessor::ProcessCallstackSample(const CallstackSample& callst
 
 void CaptureEventProcessor::ProcessFunctionCall(const FunctionCall& function_call) {
   TimerInfo timer_info;
+  timer_info.set_process_id(function_call.pid());
   timer_info.set_thread_id(function_call.tid());
   timer_info.set_start(function_call.begin_timestamp_ns());
   timer_info.set_end(function_call.end_timestamp_ns());
@@ -116,6 +123,22 @@ void CaptureEventProcessor::ProcessFunctionCall(const FunctionCall& function_cal
   for (int i = 0; i < function_call.registers_size(); ++i) {
     timer_info.add_registers(function_call.registers(i));
   }
+
+  capture_listener_->OnTimer(timer_info);
+}
+
+void CaptureEventProcessor::ProcessIntrospectionCall(const IntrospectionCall& introspection_call) {
+  const FunctionCall& function_call = introspection_call.function_call();
+  TimerInfo timer_info;
+  timer_info.set_process_id(function_call.pid());
+  timer_info.set_thread_id(function_call.tid());
+  timer_info.set_start(function_call.begin_timestamp_ns());
+  timer_info.set_end(function_call.end_timestamp_ns());
+  timer_info.set_depth(static_cast<uint8_t>(function_call.depth()));
+  timer_info.set_function_address(0);
+  timer_info.set_processor(-1);
+  timer_info.set_type(TimerInfo::kIntrospection);
+  timer_info.mutable_registers()->CopyFrom(function_call.registers());
 
   capture_listener_->OnTimer(timer_info);
 }

--- a/OrbitCaptureClient/CaptureEventProcessor.cpp
+++ b/OrbitCaptureClient/CaptureEventProcessor.cpp
@@ -22,7 +22,7 @@ using orbit_grpc_protos::FunctionCall;
 using orbit_grpc_protos::GpuJob;
 using orbit_grpc_protos::InternedCallstack;
 using orbit_grpc_protos::InternedString;
-using orbit_grpc_protos::IntrospectionCall;
+using orbit_grpc_protos::IntrospectionScope;
 using orbit_grpc_protos::SchedulingSlice;
 using orbit_grpc_protos::ThreadName;
 using orbit_grpc_protos::ThreadStateSlice;
@@ -41,8 +41,8 @@ void CaptureEventProcessor::ProcessEvent(const CaptureEvent& event) {
     case CaptureEvent::kFunctionCall:
       ProcessFunctionCall(event.function_call());
       break;
-    case CaptureEvent::kIntrospectionCall:
-      ProcessIntrospectionCall(event.introspection_call());
+    case CaptureEvent::kIntrospectionScope:
+      ProcessIntrospectionScope(event.introspection_scope());
       break;
     case CaptureEvent::kInternedString:
       ProcessInternedString(event.interned_string());
@@ -127,19 +127,18 @@ void CaptureEventProcessor::ProcessFunctionCall(const FunctionCall& function_cal
   capture_listener_->OnTimer(timer_info);
 }
 
-void CaptureEventProcessor::ProcessIntrospectionCall(const IntrospectionCall& introspection_call) {
-  const FunctionCall& function_call = introspection_call.function_call();
+void CaptureEventProcessor::ProcessIntrospectionScope(
+    const IntrospectionScope& introspection_scope) {
   TimerInfo timer_info;
-  timer_info.set_process_id(function_call.pid());
-  timer_info.set_thread_id(function_call.tid());
-  timer_info.set_start(function_call.begin_timestamp_ns());
-  timer_info.set_end(function_call.end_timestamp_ns());
-  timer_info.set_depth(static_cast<uint8_t>(function_call.depth()));
-  timer_info.set_function_address(0);
-  timer_info.set_processor(-1);
+  timer_info.set_process_id(introspection_scope.pid());
+  timer_info.set_thread_id(introspection_scope.tid());
+  timer_info.set_start(introspection_scope.begin_timestamp_ns());
+  timer_info.set_end(introspection_scope.end_timestamp_ns());
+  timer_info.set_depth(static_cast<uint8_t>(introspection_scope.depth()));
+  timer_info.set_function_address(0);  // function address n/a, set to invalid value
+  timer_info.set_processor(-1);        // cpu info not available, set to invalid value
   timer_info.set_type(TimerInfo::kIntrospection);
-  timer_info.mutable_registers()->CopyFrom(function_call.registers());
-
+  timer_info.mutable_registers()->CopyFrom(introspection_scope.registers());
   capture_listener_->OnTimer(timer_info);
 }
 

--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
@@ -29,6 +29,7 @@ class CaptureEventProcessor {
   void ProcessInternedCallstack(orbit_grpc_protos::InternedCallstack interned_callstack);
   void ProcessCallstackSample(const orbit_grpc_protos::CallstackSample& callstack_sample);
   void ProcessFunctionCall(const orbit_grpc_protos::FunctionCall& function_call);
+  void ProcessIntrospectionCall(const orbit_grpc_protos::IntrospectionCall& introspection_call);
   void ProcessInternedString(orbit_grpc_protos::InternedString interned_string);
   void ProcessGpuJob(const orbit_grpc_protos::GpuJob& gpu_job);
   void ProcessThreadName(const orbit_grpc_protos::ThreadName& thread_name);

--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
@@ -29,7 +29,7 @@ class CaptureEventProcessor {
   void ProcessInternedCallstack(orbit_grpc_protos::InternedCallstack interned_callstack);
   void ProcessCallstackSample(const orbit_grpc_protos::CallstackSample& callstack_sample);
   void ProcessFunctionCall(const orbit_grpc_protos::FunctionCall& function_call);
-  void ProcessIntrospectionCall(const orbit_grpc_protos::IntrospectionCall& introspection_call);
+  void ProcessIntrospectionScope(const orbit_grpc_protos::IntrospectionScope& introspection_scope);
   void ProcessInternedString(orbit_grpc_protos::InternedString interned_string);
   void ProcessGpuJob(const orbit_grpc_protos::GpuJob& gpu_job);
   void ProcessThreadName(const orbit_grpc_protos::ThreadName& thread_name);

--- a/OrbitGl/AsyncTrack.cpp
+++ b/OrbitGl/AsyncTrack.cpp
@@ -29,7 +29,7 @@ AsyncTrack::AsyncTrack(TimeGraph* time_graph, const std::string& name) : TimerTr
   // Orbit.h. Use it to retrieve the module from which the manually instrumented scope originated.
   const FunctionInfo* func =
       GOrbitApp->GetCaptureData().GetSelectedFunction(text_box->GetTimerInfo().function_address());
-  std::string module_name = FunctionUtils::GetLoadedModuleName(*func);
+  std::string module_name = func != nullptr ? FunctionUtils::GetLoadedModuleName(*func) : "unknown";
   const uint64_t event_id = event.data;
   std::string function_name = manual_inst_manager->GetString(event_id);
 

--- a/OrbitGl/AsyncTrack.cpp
+++ b/OrbitGl/AsyncTrack.cpp
@@ -23,12 +23,14 @@ AsyncTrack::AsyncTrack(TimeGraph* time_graph, const std::string& name) : TimerTr
   const TextBox* text_box = time_graph_->GetBatcher().GetTextBox(id);
   if (text_box == nullptr) return "";
   auto* manual_inst_manager = GOrbitApp->GetManualInstrumentationManager();
-  orbit_api::Event event = manual_inst_manager->ApiEventFromTimerInfo(text_box->GetTimerInfo());
+  TimerInfo timer_info = text_box->GetTimerInfo();
+  orbit_api::Event event = manual_inst_manager->ApiEventFromTimerInfo(timer_info);
 
   // The FunctionInfo here corresponds to one of the automatically instrumented empty stubs from
   // Orbit.h. Use it to retrieve the module from which the manually instrumented scope originated.
   const FunctionInfo* func =
       GOrbitApp->GetCaptureData().GetSelectedFunction(text_box->GetTimerInfo().function_address());
+  CHECK(func || timer_info.type() == TimerInfo::kIntrospection);
   std::string module_name = func != nullptr ? FunctionUtils::GetLoadedModuleName(*func) : "unknown";
   const uint64_t event_id = event.data;
   std::string function_name = manual_inst_manager->GetString(event_id);

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -35,7 +35,6 @@ float GlCanvas::kZValueSliderBg = 0.63f;
 float GlCanvas::kZValueSlider = 0.65f;
 
 const Color GlCanvas::kBackgroundColor = Color(67, 67, 67, 255);
-const Color GlCanvas::kTabColor = Color(50, 50, 50, 255);
 const Color GlCanvas::kTabTextColorSelected = Color(100, 181, 246, 255);
 
 GlCanvas::GlCanvas(uint32_t font_size)

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -97,7 +97,6 @@ class GlCanvas : public GlPanel {
   static float kZValueTrack;
 
   static const Color kBackgroundColor;
-  static const Color kTabColor;
   static const Color kTabTextColorSelected;
 
  protected:

--- a/OrbitGl/GraphTrack.cpp
+++ b/OrbitGl/GraphTrack.cpp
@@ -27,11 +27,7 @@ void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   float y1 = y0 - size_[1];
 
   const Color kPickedColor(0, 128, 255, 128);
-  Color color = color_;
-  if (picked_) {
-    // TODO: Is this really used? Is picked_ even a thing?
-    color = kPickedColor;
-  }
+  Color color = GetBackGroundColor();
 
   float track_z = GlCanvas::kZValueTrack;
 

--- a/OrbitGl/GraphTrack.cpp
+++ b/OrbitGl/GraphTrack.cpp
@@ -27,7 +27,7 @@ void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   float y1 = y0 - size_[1];
 
   const Color kPickedColor(0, 128, 255, 128);
-  Color color = GetBackGroundColor();
+  Color color = GetBackgroundColor();
 
   float track_z = GlCanvas::kZValueTrack;
 

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -53,7 +53,6 @@ std::string ThreadTrack::GetBoxTooltip(PickingId id) const {
 
   const FunctionInfo* func =
       GOrbitApp->GetCaptureData().GetSelectedFunction(text_box->GetTimerInfo().function_address());
-  CHECK(func != nullptr);
 
   if (!func) {
     return text_box->GetText();
@@ -81,7 +80,8 @@ std::string ThreadTrack::GetBoxTooltip(PickingId id) const {
 }
 
 bool ThreadTrack::IsTimerActive(const TimerInfo& timer_info) const {
-  return GOrbitApp->IsFunctionVisible(timer_info.function_address());
+  return timer_info.type() == TimerInfo::kIntrospection ||
+         GOrbitApp->IsFunctionVisible(timer_info.function_address());
 }
 
 bool ThreadTrack::IsTrackSelected() const {
@@ -119,11 +119,19 @@ Color ThreadTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected) 
 
   uint64_t address = timer_info.function_address();
   const FunctionInfo* function_info = GOrbitApp->GetCaptureData().GetSelectedFunction(address);
-  CHECK(function_info);
-  std::optional<Color> user_color = GetUserColor(timer_info, *function_info);
+  std::optional<Color> user_color =
+      function_info ? GetUserColor(timer_info, *function_info) : std::nullopt;
 
-  Color color = user_color.has_value() ? user_color.value()
-                                       : time_graph_->GetThreadColor(timer_info.thread_id());
+  Color color = kInactiveColor;
+  if (user_color.has_value()) {
+    color = user_color.value();
+  } else if (timer_info.type() == TimerInfo::kIntrospection) {
+    orbit_api::Event event = ManualInstrumentationManager::ApiEventFromTimerInfo(timer_info);
+    color = event.color == orbit::Color::kAuto ? time_graph_->GetColor(event.name)
+                                               : ToColor(static_cast<uint64_t>(event.color));
+  } else {
+    color = time_graph_->GetThreadColor(timer_info.thread_id());
+  }
 
   constexpr uint8_t kOddAlpha = 210;
   if (!(timer_info.depth() & 0x1)) {
@@ -240,9 +248,8 @@ void ThreadTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_u
 
       text_box->SetText(text);
     } else if (timer_info.type() == TimerInfo::kIntrospection) {
-      std::string text = absl::StrFormat(
-          "%s %s", time_graph_->GetStringManager()->Get(timer_info.user_data_key()).value_or(""),
-          time.c_str());
+      auto api_event = ManualInstrumentationManager::ApiEventFromTimerInfo(timer_info);
+      std::string text = absl::StrFormat("%s %s", api_event.name, time.c_str());
       text_box->SetText(text);
     } else {
       ERROR(

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -119,6 +119,7 @@ Color ThreadTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected) 
 
   uint64_t address = timer_info.function_address();
   const FunctionInfo* function_info = GOrbitApp->GetCaptureData().GetSelectedFunction(address);
+  CHECK(function_info || timer_info.type() == TimerInfo::kIntrospection);
   std::optional<Color> user_color =
       function_info ? GetUserColor(timer_info, *function_info) : std::nullopt;
 

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -179,6 +179,7 @@ class TimeGraph {
 
   void ProcessOrbitFunctionTimer(orbit_client_protos::FunctionInfo::OrbitType type,
                                  const orbit_client_protos::TimerInfo& timer_info);
+  void ProcessIntrospectionTimer(const orbit_client_protos::TimerInfo& timer_info);
   void ProcessValueTrackingTimer(const orbit_client_protos::TimerInfo& timer_info);
   void ProcessAsyncTimer(const std::string& track_name,
                          const orbit_client_protos::TimerInfo& timer_info);

--- a/OrbitGl/TimerTrack.cpp
+++ b/OrbitGl/TimerTrack.cpp
@@ -147,6 +147,10 @@ void TimerTrack::OnTimer(const TimerInfo& timer_info) {
     UpdateDepth(timer_info.depth() + 1);
   }
 
+  if(process_id_ == -1) {
+    process_id_ = timer_info.process_id();
+  }
+
   TextBox text_box(Vec2(0, 0), Vec2(0, 0), "");
   text_box.SetTimerInfo(timer_info);
 

--- a/OrbitGl/TimerTrack.cpp
+++ b/OrbitGl/TimerTrack.cpp
@@ -147,7 +147,7 @@ void TimerTrack::OnTimer(const TimerInfo& timer_info) {
     UpdateDepth(timer_info.depth() + 1);
   }
 
-  if(process_id_ == -1) {
+  if (process_id_ == -1) {
     process_id_ = timer_info.process_id();
   }
 

--- a/OrbitGl/TimerTrack.h
+++ b/OrbitGl/TimerTrack.h
@@ -38,9 +38,6 @@ class TimerTrack : public Track {
   [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetTimers() override;
   [[nodiscard]] uint32_t GetDepth() const { return depth_; }
   [[nodiscard]] std::string GetExtraInfo(const orbit_client_protos::TimerInfo& timer);
-
-  [[nodiscard]] Color GetColor() const;
-  [[nodiscard]] static Color GetColor(ThreadID a_TID);
   [[nodiscard]] uint32_t GetNumTimers() const { return num_timers_; }
   [[nodiscard]] uint64_t GetMinTime() const { return min_time_; }
   [[nodiscard]] uint64_t GetMaxTime() const { return max_time_; }

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -94,7 +94,7 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode) {
   float top_margin = layout.GetTrackTopMargin();
 
   // Draw track background.
-  Color background_color = GetBackGroundColor();
+  Color background_color = GetBackgroundColor();
   if (!picking) {
     if (layout.GetDrawTrackBackground()) {
       Box box(Vec2(x0, y0 + top_margin), Vec2(size_[0], -size_[1] - top_margin), track_z);
@@ -180,7 +180,7 @@ void Track::SetY(float y) {
   }
 }
 
-Color Track::GetBackGroundColor() const {
+Color Track::GetBackgroundColor() const {
   int32_t capture_process_id = GOrbitApp->GetCaptureData().process_id();
   if (GetType() == kSchedulerTrack) {
     return color_;

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -86,10 +86,13 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
   [[nodiscard]] Vec2 GetPos() const { return pos_; }
   void SetSize(float a_SizeX, float a_SizeY);
   void SetColor(Color a_Color) { color_ = a_Color; }
+  [[nodiscard]] Color GetBackGroundColor() const;
 
   void AddChild(std::shared_ptr<Track> track) { children_.emplace_back(track); }
   virtual void OnCollapseToggle(TriangleToggle::State state);
   [[nodiscard]] virtual bool IsCollapsable() const { return false; }
+  [[nodiscard]] int32_t GetProcessId() const { return process_id_; }
+  void SetProcessId(uint32_t pid) { process_id_ = pid; }
 
  protected:
   void DrawTriangleFan(Batcher* batcher, const std::vector<Vec2>& points, const Vec2& pos,
@@ -109,6 +112,7 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
   std::string label_;
   int num_prioritized_trailing_characters_;
   int32_t thread_id_;
+  int32_t process_id_;
   Color color_;
   bool visible_ = true;
   std::atomic<uint32_t> num_timers_;

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -86,7 +86,7 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
   [[nodiscard]] Vec2 GetPos() const { return pos_; }
   void SetSize(float a_SizeX, float a_SizeY);
   void SetColor(Color a_Color) { color_ = a_Color; }
-  [[nodiscard]] Color GetBackGroundColor() const;
+  [[nodiscard]] Color GetBackgroundColor() const;
 
   void AddChild(std::shared_ptr<Track> track) { children_.emplace_back(track); }
   virtual void OnCollapseToggle(TriangleToggle::State state);

--- a/OrbitGrpcProtos/capture.proto
+++ b/OrbitGrpcProtos/capture.proto
@@ -61,6 +61,10 @@ message FunctionCall {
   repeated uint64 registers = 8;
 }
 
+message IntrospectionCall {
+  FunctionCall function_call = 1;
+}
+
 message Callstack {
   repeated uint64 pcs = 1;
 }
@@ -179,5 +183,6 @@ message CaptureEvent {
     AddressInfo address_info = 8;
     InternedTracepointInfo interned_tracepoint_info = 9;
     TracepointEvent tracepoint_event = 10;
+    IntrospectionCall introspection_call = 12;
   }
 }

--- a/OrbitGrpcProtos/capture.proto
+++ b/OrbitGrpcProtos/capture.proto
@@ -61,8 +61,13 @@ message FunctionCall {
   repeated uint64 registers = 8;
 }
 
-message IntrospectionCall {
-  FunctionCall function_call = 1;
+message IntrospectionScope {
+  int32 pid = 1;
+  int32 tid = 2;
+  uint64 begin_timestamp_ns = 3;
+  uint64 end_timestamp_ns = 4;
+  int32 depth = 5;
+  repeated uint64 registers = 6;
 }
 
 message Callstack {
@@ -183,6 +188,6 @@ message CaptureEvent {
     AddressInfo address_info = 8;
     InternedTracepointInfo interned_tracepoint_info = 9;
     TracepointEvent tracepoint_event = 10;
-    IntrospectionCall introspection_call = 12;
+    IntrospectionScope introspection_scope = 12;
   }
 }

--- a/OrbitLinuxTracing/UprobesFunctionCallManager.h
+++ b/OrbitLinuxTracing/UprobesFunctionCallManager.h
@@ -33,7 +33,7 @@ class UprobesFunctionCallManager {
     tid_uprobes_stack.emplace(function_address, begin_timestamp, regs);
   }
 
-  std::optional<orbit_grpc_protos::FunctionCall> ProcessUretprobes(pid_t tid,
+  std::optional<orbit_grpc_protos::FunctionCall> ProcessUretprobes(pid_t pid, pid_t tid,
                                                                    uint64_t end_timestamp,
                                                                    uint64_t return_value) {
     if (!tid_uprobes_stacks_.contains(tid)) {
@@ -47,6 +47,7 @@ class UprobesFunctionCallManager {
     auto& tid_uprobe = tid_uprobes_stack.top();
 
     orbit_grpc_protos::FunctionCall function_call;
+    function_call.set_pid(pid);
     function_call.set_tid(tid);
     function_call.set_absolute_address(tid_uprobe.function_address);
     function_call.set_begin_timestamp_ns(tid_uprobe.begin_timestamp);

--- a/OrbitLinuxTracing/UprobesFunctionCallManagerTest.cpp
+++ b/OrbitLinuxTracing/UprobesFunctionCallManagerTest.cpp
@@ -12,6 +12,7 @@ namespace LinuxTracing {
 using orbit_grpc_protos::FunctionCall;
 
 TEST(UprobesFunctionCallManager, OneUprobe) {
+  constexpr pid_t pid = 41;
   constexpr pid_t tid = 42;
   std::optional<FunctionCall> processed_function_call;
   UprobesFunctionCallManager function_call_manager;
@@ -19,8 +20,9 @@ TEST(UprobesFunctionCallManager, OneUprobe) {
 
   function_call_manager.ProcessUprobes(tid, 100, 1, registers);
 
-  processed_function_call = function_call_manager.ProcessUretprobes(tid, 2, 3);
+  processed_function_call = function_call_manager.ProcessUretprobes(pid, tid, 2, 3);
   ASSERT_TRUE(processed_function_call.has_value());
+  EXPECT_EQ(processed_function_call.value().pid(), pid);
   EXPECT_EQ(processed_function_call.value().tid(), tid);
   EXPECT_EQ(processed_function_call.value().absolute_address(), 100);
   EXPECT_EQ(processed_function_call.value().begin_timestamp_ns(), 1);
@@ -31,6 +33,7 @@ TEST(UprobesFunctionCallManager, OneUprobe) {
 }
 
 TEST(UprobesFunctionCallManager, TwoNestedUprobesAndAnotherUprobe) {
+  constexpr pid_t pid = 41;
   constexpr pid_t tid = 42;
   std::optional<FunctionCall> processed_function_call;
   UprobesFunctionCallManager function_call_manager;
@@ -40,8 +43,9 @@ TEST(UprobesFunctionCallManager, TwoNestedUprobesAndAnotherUprobe) {
 
   function_call_manager.ProcessUprobes(tid, 200, 2, registers);
 
-  processed_function_call = function_call_manager.ProcessUretprobes(tid, 3, 4);
+  processed_function_call = function_call_manager.ProcessUretprobes(pid, tid, 3, 4);
   ASSERT_TRUE(processed_function_call.has_value());
+  EXPECT_EQ(processed_function_call.value().pid(), pid);
   EXPECT_EQ(processed_function_call.value().tid(), tid);
   EXPECT_EQ(processed_function_call.value().absolute_address(), 200);
   EXPECT_EQ(processed_function_call.value().begin_timestamp_ns(), 2);
@@ -50,8 +54,9 @@ TEST(UprobesFunctionCallManager, TwoNestedUprobesAndAnotherUprobe) {
   EXPECT_EQ(processed_function_call.value().return_value(), 4);
   EXPECT_EQ(processed_function_call.value().registers_size(), 6);
 
-  processed_function_call = function_call_manager.ProcessUretprobes(tid, 4, 5);
+  processed_function_call = function_call_manager.ProcessUretprobes(pid, tid, 4, 5);
   ASSERT_TRUE(processed_function_call.has_value());
+  EXPECT_EQ(processed_function_call.value().pid(), pid);
   EXPECT_EQ(processed_function_call.value().tid(), tid);
   EXPECT_EQ(processed_function_call.value().absolute_address(), 100);
   EXPECT_EQ(processed_function_call.value().begin_timestamp_ns(), 1);
@@ -62,8 +67,9 @@ TEST(UprobesFunctionCallManager, TwoNestedUprobesAndAnotherUprobe) {
 
   function_call_manager.ProcessUprobes(tid, 300, 5, registers);
 
-  processed_function_call = function_call_manager.ProcessUretprobes(tid, 6, 7);
+  processed_function_call = function_call_manager.ProcessUretprobes(pid, tid, 6, 7);
   ASSERT_TRUE(processed_function_call.has_value());
+  EXPECT_EQ(processed_function_call.value().pid(), pid);
   EXPECT_EQ(processed_function_call.value().tid(), tid);
   EXPECT_EQ(processed_function_call.value().absolute_address(), 300);
   EXPECT_EQ(processed_function_call.value().begin_timestamp_ns(), 5);
@@ -74,6 +80,7 @@ TEST(UprobesFunctionCallManager, TwoNestedUprobesAndAnotherUprobe) {
 }
 
 TEST(UprobesFunctionCallManager, TwoUprobesDifferentThreads) {
+  constexpr pid_t pid = 41;
   constexpr pid_t tid = 42;
   constexpr pid_t tid2 = 111;
   std::optional<FunctionCall> processed_function_call;
@@ -84,8 +91,9 @@ TEST(UprobesFunctionCallManager, TwoUprobesDifferentThreads) {
 
   function_call_manager.ProcessUprobes(tid2, 200, 2, registers);
 
-  processed_function_call = function_call_manager.ProcessUretprobes(tid, 3, 4);
+  processed_function_call = function_call_manager.ProcessUretprobes(pid, tid, 3, 4);
   ASSERT_TRUE(processed_function_call.has_value());
+  EXPECT_EQ(processed_function_call.value().pid(), pid);
   EXPECT_EQ(processed_function_call.value().tid(), tid);
   EXPECT_EQ(processed_function_call.value().absolute_address(), 100);
   EXPECT_EQ(processed_function_call.value().begin_timestamp_ns(), 1);
@@ -94,8 +102,9 @@ TEST(UprobesFunctionCallManager, TwoUprobesDifferentThreads) {
   EXPECT_EQ(processed_function_call.value().return_value(), 4);
   EXPECT_EQ(processed_function_call.value().registers_size(), 6);
 
-  processed_function_call = function_call_manager.ProcessUretprobes(tid2, 4, 5);
+  processed_function_call = function_call_manager.ProcessUretprobes(pid, tid2, 4, 5);
   ASSERT_TRUE(processed_function_call.has_value());
+  EXPECT_EQ(processed_function_call.value().pid(), pid);
   EXPECT_EQ(processed_function_call.value().tid(), tid2);
   EXPECT_EQ(processed_function_call.value().absolute_address(), 200);
   EXPECT_EQ(processed_function_call.value().begin_timestamp_ns(), 2);
@@ -106,11 +115,12 @@ TEST(UprobesFunctionCallManager, TwoUprobesDifferentThreads) {
 }
 
 TEST(UprobesFunctionCallManager, OnlyUretprobe) {
+  constexpr pid_t pid = 41;
   constexpr pid_t tid = 42;
   std::optional<FunctionCall> processed_function_call;
   UprobesFunctionCallManager function_call_manager;
 
-  processed_function_call = function_call_manager.ProcessUretprobes(tid, 2, 3);
+  processed_function_call = function_call_manager.ProcessUretprobes(pid, tid, 2, 3);
   ASSERT_FALSE(processed_function_call.has_value());
 }
 

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
@@ -164,7 +164,7 @@ void UprobesUnwindingVisitor::visit(UretprobesPerfEvent* event) {
   }
 
   std::optional<FunctionCall> function_call = function_call_manager_.ProcessUretprobes(
-      event->GetTid(), event->GetTimestamp(), event->GetAx());
+      event->GetPid(), event->GetTid(), event->GetTimestamp(), event->GetAx());
   if (function_call.has_value()) {
     listener_->OnFunctionCall(std::move(function_call.value()));
   }

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/TracerListener.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/TracerListener.h
@@ -15,6 +15,7 @@ class TracerListener {
   virtual void OnSchedulingSlice(orbit_grpc_protos::SchedulingSlice scheduling_slice) = 0;
   virtual void OnCallstackSample(orbit_grpc_protos::CallstackSample callstack_sample) = 0;
   virtual void OnFunctionCall(orbit_grpc_protos::FunctionCall function_call) = 0;
+  virtual void OnIntrospectionCall(orbit_grpc_protos::IntrospectionCall introspection_call) = 0;
   virtual void OnGpuJob(orbit_grpc_protos::GpuJob gpu_job) = 0;
   virtual void OnThreadName(orbit_grpc_protos::ThreadName thread_name) = 0;
   virtual void OnThreadStateSlice(orbit_grpc_protos::ThreadStateSlice thread_state_slice) = 0;

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/TracerListener.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/TracerListener.h
@@ -15,7 +15,7 @@ class TracerListener {
   virtual void OnSchedulingSlice(orbit_grpc_protos::SchedulingSlice scheduling_slice) = 0;
   virtual void OnCallstackSample(orbit_grpc_protos::CallstackSample callstack_sample) = 0;
   virtual void OnFunctionCall(orbit_grpc_protos::FunctionCall function_call) = 0;
-  virtual void OnIntrospectionCall(orbit_grpc_protos::IntrospectionCall introspection_call) = 0;
+  virtual void OnIntrospectionScope(orbit_grpc_protos::IntrospectionScope introspection_scope) = 0;
   virtual void OnGpuJob(orbit_grpc_protos::GpuJob gpu_job) = 0;
   virtual void OnThreadName(orbit_grpc_protos::ThreadName thread_name) = 0;
   virtual void OnThreadStateSlice(orbit_grpc_protos::ThreadStateSlice thread_state_slice) = 0;

--- a/OrbitService/LinuxTracingGrpcHandler.cpp
+++ b/OrbitService/LinuxTracingGrpcHandler.cpp
@@ -19,7 +19,7 @@ using orbit_grpc_protos::CaptureOptions;
 using orbit_grpc_protos::CaptureResponse;
 using orbit_grpc_protos::FunctionCall;
 using orbit_grpc_protos::GpuJob;
-using orbit_grpc_protos::IntrospectionCall;
+using orbit_grpc_protos::IntrospectionScope;
 using orbit_grpc_protos::SchedulingSlice;
 using orbit_grpc_protos::ThreadName;
 using orbit_grpc_protos::ThreadStateSlice;
@@ -47,23 +47,20 @@ void LinuxTracingGrpcHandler::Start(CaptureOptions capture_options) {
 void LinuxTracingGrpcHandler::SetupIntrospection() {
   orbit_tracing_listener_ =
       std::make_unique<orbit::tracing::Listener>([this](const orbit::tracing::Scope& scope) {
-        IntrospectionCall introspection_call;
-        FunctionCall& function_call = *introspection_call.mutable_function_call();
-
-        function_call.set_tid(scope.tid);
-        function_call.set_pid(getpid());
-        function_call.set_begin_timestamp_ns(scope.begin);
-        function_call.set_end_timestamp_ns(scope.end);
-        function_call.set_depth(scope.depth);
-        function_call.mutable_registers()->Reserve(6);
-        function_call.add_registers(scope.encoded_event.args[0]);
-        function_call.add_registers(scope.encoded_event.args[1]);
-        function_call.add_registers(scope.encoded_event.args[2]);
-        function_call.add_registers(scope.encoded_event.args[3]);
-        function_call.add_registers(scope.encoded_event.args[4]);
-        function_call.add_registers(scope.encoded_event.args[5]);
-
-        OnIntrospectionCall(introspection_call);
+        IntrospectionScope introspection_scope;
+        introspection_scope.set_pid(getpid());
+        introspection_scope.set_tid(scope.tid);
+        introspection_scope.set_begin_timestamp_ns(scope.begin);
+        introspection_scope.set_end_timestamp_ns(scope.end);
+        introspection_scope.set_depth(scope.depth);
+        introspection_scope.mutable_registers()->Reserve(6);
+        introspection_scope.add_registers(scope.encoded_event.args[0]);
+        introspection_scope.add_registers(scope.encoded_event.args[1]);
+        introspection_scope.add_registers(scope.encoded_event.args[2]);
+        introspection_scope.add_registers(scope.encoded_event.args[3]);
+        introspection_scope.add_registers(scope.encoded_event.args[4]);
+        introspection_scope.add_registers(scope.encoded_event.args[5]);
+        OnIntrospectionScope(introspection_scope);
       });
 }
 
@@ -111,12 +108,14 @@ void LinuxTracingGrpcHandler::OnFunctionCall(FunctionCall function_call) {
   }
 }
 
-void LinuxTracingGrpcHandler::OnIntrospectionCall(
-    orbit_grpc_protos::IntrospectionCall introspection_call) {
+void LinuxTracingGrpcHandler::OnIntrospectionScope(
+    orbit_grpc_protos::IntrospectionScope introspection_scope) {
   CaptureEvent event;
-  *event.mutable_introspection_call() = std::move(introspection_call);
-  absl::MutexLock lock{&event_buffer_mutex_};
-  event_buffer_.emplace_back(std::move(event));
+  *event.mutable_introspection_scope() = std::move(introspection_scope);
+  {
+    absl::MutexLock lock{&event_buffer_mutex_};
+    event_buffer_.emplace_back(std::move(event));
+  }
 }
 
 void LinuxTracingGrpcHandler::OnGpuJob(GpuJob gpu_job) {

--- a/OrbitService/LinuxTracingGrpcHandler.h
+++ b/OrbitService/LinuxTracingGrpcHandler.h
@@ -35,7 +35,7 @@ class LinuxTracingGrpcHandler : public LinuxTracing::TracerListener {
   void OnSchedulingSlice(orbit_grpc_protos::SchedulingSlice scheduling_slice) override;
   void OnCallstackSample(orbit_grpc_protos::CallstackSample callstack_sample) override;
   void OnFunctionCall(orbit_grpc_protos::FunctionCall function_call) override;
-  void OnIntrospectionCall(orbit_grpc_protos::IntrospectionCall introspection_call) override;
+  void OnIntrospectionScope(orbit_grpc_protos::IntrospectionScope introspection_call) override;
   void OnGpuJob(orbit_grpc_protos::GpuJob gpu_job) override;
   void OnThreadName(orbit_grpc_protos::ThreadName thread_name) override;
   void OnThreadStateSlice(orbit_grpc_protos::ThreadStateSlice thread_state_slice) override;

--- a/OrbitService/LinuxTracingGrpcHandler.h
+++ b/OrbitService/LinuxTracingGrpcHandler.h
@@ -6,6 +6,7 @@
 #define ORBIT_SERVICE_LINUX_TRACING_GRPC_HANDLER_H_
 
 #include <OrbitBase/Logging.h>
+#include <OrbitBase/Tracing.h>
 #include <OrbitLinuxTracing/Tracer.h>
 #include <OrbitLinuxTracing/TracerListener.h>
 
@@ -34,6 +35,7 @@ class LinuxTracingGrpcHandler : public LinuxTracing::TracerListener {
   void OnSchedulingSlice(orbit_grpc_protos::SchedulingSlice scheduling_slice) override;
   void OnCallstackSample(orbit_grpc_protos::CallstackSample callstack_sample) override;
   void OnFunctionCall(orbit_grpc_protos::FunctionCall function_call) override;
+  void OnIntrospectionCall(orbit_grpc_protos::IntrospectionCall introspection_call) override;
   void OnGpuJob(orbit_grpc_protos::GpuJob gpu_job) override;
   void OnThreadName(orbit_grpc_protos::ThreadName thread_name) override;
   void OnThreadStateSlice(orbit_grpc_protos::ThreadStateSlice thread_state_slice) override;
@@ -44,6 +46,9 @@ class LinuxTracingGrpcHandler : public LinuxTracing::TracerListener {
   grpc::ServerReaderWriter<orbit_grpc_protos::CaptureResponse, orbit_grpc_protos::CaptureRequest>*
       reader_writer_;
   std::unique_ptr<LinuxTracing::Tracer> tracer_;
+
+  // Manual instrumentation tracing listener.
+  std::unique_ptr<orbit::tracing::Listener> orbit_tracing_listener_;
 
   [[nodiscard]] static uint64_t ComputeCallstackKey(const orbit_grpc_protos::Callstack& callstack);
   [[nodiscard]] uint64_t InternCallstackIfNecessaryAndGetKey(
@@ -62,6 +67,7 @@ class LinuxTracingGrpcHandler : public LinuxTracing::TracerListener {
   absl::flat_hash_set<uint64_t> tracepoint_keys_sent_;
   absl::Mutex tracepoint_keys_sent_mutex_;
 
+  void SetupIntrospection();
   void SenderThread();
   void SendBufferedEvents(std::vector<orbit_grpc_protos::CaptureEvent>&& buffered_events);
 


### PR DESCRIPTION
We can now use the manual instrumentation API inside OrbitService and visualize our own code
(and graphed variables) alongside the target process data in the capture view. Introspection 
tracks are displayed right after the scheduler track and have a darker background. TracerThread 
has been instrumented as starting point. The feature is automatically enabled when in "--devmode".

![image](https://user-images.githubusercontent.com/3687222/96548509-ddab0600-1262-11eb-830f-c127b8dc3846.png)


The PR is broken down in 7 independent commits that are in logical order.