### PR TITLE
Disable test detection in cross compilation setup

### DIFF
--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -5,6 +5,10 @@
 include(${CMAKE_SOURCE_DIR}/third_party/cmake/Modules/GoogleTest.cmake)
 
 function(register_test TEST_TARGET)
+  if(CMAKE_CROSSCOMPILING)
+    return()
+  endif()
+
   cmake_parse_arguments(ARGS "" "" "PROPERTIES" ${ARGN})
   set(TESTRESULTS_DIRECTORY "${CMAKE_BINARY_DIR}/testresults")
 


### PR DESCRIPTION
CMake's GoogleTest integration calls the test executable to obtain a
list of all the included tests. Afterwards every test can be executed in
isolation by CTest.

This fails in a cross compilation scenario because the test executable
can't be executed. Previously we solved that by just not running the
tests, but this won't work with the new GoogleTest integration since the
test executable will be called as a part of the build process - to
enumerate all the tests.

We resolve that problem by not registering the test executable at all
when in a cross compilation scenario.