### PR TITLE
ClientGgp: Make LoadSelectedFunctions private and add call when functions are updated

### DIFF
--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -259,6 +259,7 @@ absl::flat_hash_map<uint64_t, FunctionInfo> ClientGgp::GetSelectedFunctions() {
 
 void ClientGgp::UpdateCaptureFunctions(std::vector<std::string> capture_functions) {
   options_.capture_functions = capture_functions;
+  LoadSelectedFunctions();
   return;
 }
 

--- a/OrbitClientGgp/include/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/include/OrbitClientGgp/ClientGgp.h
@@ -27,7 +27,6 @@ class ClientGgp final : public CaptureListener {
   bool RequestStartCapture(ThreadPool* thread_pool);
   bool StopCapture();
   bool SaveCapture();
-  void LoadSelectedFunctions();
   void UpdateCaptureFunctions(std::vector<std::string> capture_functions);
 
   // CaptureListener implementation
@@ -66,6 +65,7 @@ class ClientGgp final : public CaptureListener {
   ErrorMessageOr<ProcessData> GetOrbitProcessByPid(int32_t pid);
   bool InitCapture();
   ErrorMessageOr<void> LoadModuleAndSymbols();
+  void LoadSelectedFunctions();
   std::string SelectedFunctionMatch(const orbit_client_protos::FunctionInfo& func);
   absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> GetSelectedFunctions();
   void InformUsedSelectedCaptureFunctions(


### PR DESCRIPTION
Update the scope of _LoadSelectedFunctions_ as it is just used internally: during the initialisation of the client and when the method to update the capture functions is called (_UpdateCaptureFunctions_).

I realised it was a design flaw when using the _ClientGgp_ in a non-linear client. I consider it makes more sense to update the functions and load them so they are used when capturing in a unique call.