### PR TITLE
Display sftp error to user

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -863,6 +863,7 @@ void OrbitApp::LoadModuleOnRemote(const ProcessData* process, ModuleData* module
           SendErrorToUi("Error loading symbols",
                         absl::StrFormat("Could not copy debug info file from the remote: %s",
                                         scp_result.error().message()));
+          modules_currently_loading_.erase(module_data->file_path());
           return;
         }
       }

--- a/OrbitQt/servicedeploymanager.cpp
+++ b/OrbitQt/servicedeploymanager.cpp
@@ -226,8 +226,12 @@ ErrorMessageOr<void> ServiceDeployManager::CopyFileToLocal(std::string_view sour
   auto sftp_channel_stop_result = StopSftpChannel(&loop, sftp_channel.value().get());
 
   if (!sftp_channel_stop_result) {
-    ERROR(R"(Error closing sftp channel (after copied remote "%s" to "%s": %s))", source,
-          destination, sftp_channel_stop_result.error().message());
+    std::string sftp_error_message =
+        absl::StrFormat(R"(Error closing sftp channel (after copied remote "%s" to "%s": %s))",
+                        source, destination, sftp_channel_stop_result.error().message());
+    ERROR("%s", sftp_error_message);
+    return ErrorMessage(
+        absl::StrFormat("Download of file %s failed: %s", source, sftp_error_message));
   }
 
   return outcome::success();


### PR DESCRIPTION
One more sftp error is now displayed to the user, instead of only being
logged. Before this change the error would lead to a crash, because the
symbol loading mechanism would expect a file to be there, even though it
is not. Compare b/170698772