### PR TITLE
Enable PRE_TEST test discovery

### DIFF
--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -18,7 +18,8 @@ function(register_test TEST_TARGET)
 
   gtest_discover_tests(${TEST_TARGET}
     XML_OUTPUT_DIR "${TESTRESULTS_DIRECTORY}"
-    PROPERTIES ${ARGS_PROPERTIES})
+    PROPERTIES ${ARGS_PROPERTIES}
+    DISCOVERY_MODE PRE_TEST)
 endfunction()
 
 if(NOT TARGET GTest::GTest)


### PR DESCRIPTION
Previously the test binaries have been called during build time to
enumerate all the included tests. This call is now deferred to just
before starting the tests.
    
The previous way made problems with test binaries like
OrbitQtTests.exe which need extra libraries like Qt5Core.dll.
Qt libraries are copied to the binary directory as part of the build
which means we can't be sure that these are available when executing
the test binary for lisitng. It has been working so far due to pure
luck, but it breaks when a race condition.