### PR TITLE
Margin change in timegraph forces update

### DIFF
--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -1068,6 +1068,15 @@ void TimeGraph::JumpToNeighborBox(const TextBox* from, JumpDirection jump_direct
   }
 }
 
+void TimeGraph::SetRightMargin(float margin) {
+  {
+    if (right_margin_ != margin) {
+      NeedsUpdate();
+    }
+    right_margin_ = margin;
+  }
+}
+
 const TextBox* TimeGraph::FindPrevious(const TextBox* from) {
   CHECK(from);
   const TimerInfo& timer_info = from->GetTimerInfo();

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -125,7 +125,7 @@ class TimeGraph {
   [[nodiscard]] const TimeGraphLayout& GetLayout() const { return layout_; }
   [[nodiscard]] TimeGraphLayout& GetLayout() { return layout_; }
   [[nodiscard]] float GetRightMargin() const { return right_margin_; }
-  void SetRightMargin(float margin) { right_margin_ = margin; }
+  void SetRightMargin(float margin);
 
   [[nodiscard]] const TextBox* FindPrevious(const TextBox* from);
   [[nodiscard]] const TextBox* FindNext(const TextBox* from);


### PR DESCRIPTION
To reproduce:

* Take a capture
* Filter tracks to make the vertical scrollbar disappear (e.g. type "s" for the scheduler track)

The right margin in the capture window is in an invalid state, rounded corners are drawn incorrectly:
![image](https://user-images.githubusercontent.com/63750742/97001395-9a89b500-1538-11eb-80cb-1df7fe7a4adc.png)

This PR fixes that issue.
