### PR TITLE
Fix GraphTrack overdraw

### DIFF
--- a/OrbitGl/GraphTrack.cpp
+++ b/OrbitGl/GraphTrack.cpp
@@ -9,85 +9,52 @@
 GraphTrack::GraphTrack(TimeGraph* time_graph, std::string name)
     : Track(time_graph), name_(std::move(name)) {}
 
-void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
-  Batcher* batcher = canvas->GetBatcher();
+void GraphTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode,
+                                  float z_offset) {
+  Batcher* batcher = &time_graph_->GetBatcher();
+  GlCanvas* canvas = time_graph_->GetCanvas();
 
   float trackWidth = canvas->GetWorldWidth();
-  const bool picking = picking_mode != PickingMode::kNone;
-
-  pos_[0] = canvas->GetWorldTopLeftX();
   SetSize(trackWidth, GetHeight());
-  Track::Draw(canvas, picking_mode, z_offset);
-
-  float x0 = pos_[0];
-  float x1 = x0 + size_[0];
-
-  float y0 = pos_[1];
-  float y1 = y0 - size_[1];
+  pos_[0] = canvas->GetWorldTopLeftX();
 
   Color color = GetBackgroundColor();
-
+  const Color kLineColor(0, 128, 255, 128);
+  const Color kDotColor(0, 128, 255, 255);
   float track_z = GlCanvas::kZValueTrack + z_offset;
   float graph_z = GlCanvas::kZValueEventBar + z_offset;
   float dot_z = GlCanvas::kZValueBox + z_offset;
-  float text_z = GlCanvas::kZValueEvent + z_offset;
 
   Box box(pos_, Vec2(size_[0], -size_[1]), track_z);
-
-  if (!picking) {
-    auto last_measure = GetPreviousValueAndTime(time_graph_->GetCurrentMouseTimeNs());
-    if (last_measure.has_value()) {
-      auto& [time, value] = last_measure.value();
-      if (time_graph_->IsFullyVisible(time, time)) {
-        float point_x = time_graph_->GetWorldFromTick(time);
-        float point_y = y0 - static_cast<float>((max_ - value) * size_[1] / value_range_);
-        const Color kBlack(0, 0, 0, 255);
-        const Color kWhite(255, 255, 255, 255);
-        DrawLabel(canvas, Vec2(point_x, point_y), std::to_string(value), kBlack, kWhite, text_z);
-      }
-    }
-  }
-
   batcher->AddBox(box, color, shared_from_this());
 
-  if (canvas->GetPickingManager().IsThisElementPicked(this)) {
-    color = Color(255, 255, 255, 255);
-  }
-
-  batcher->AddLine(pos_, Vec2(x1, y0), track_z, color, shared_from_this());
-  batcher->AddLine(Vec2(x1, y1), Vec2(x0, y1), track_z, color, shared_from_this());
-
-  const Color kLineColor(0, 128, 255, 128);
-  const Color kDotColor(0, 128, 255, 255);
-
+  const bool picking = picking_mode != PickingMode::kNone;
   if (!picking) {
-    // Current time window
-    uint64_t min_ns = time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
-    uint64_t max_ns = time_graph_->GetTickFromUs(time_graph_->GetMaxTimeUs());
-    double time_range = static_cast<float>(max_ns - min_ns);
+    double time_range = static_cast<double>(max_tick - min_tick);
     if (values_.size() < 2 || time_range == 0) return;
 
-    auto it = values_.upper_bound(min_ns);
+    auto it = values_.upper_bound(min_tick);
     if (it == values_.end()) return;
     if (it != values_.begin()) --it;
     uint64_t previous_time = it->first;
     double last_normalized_value = (it->second - min_) * inv_value_range_;
     constexpr float kDotRadius = 2.f;
     float base_y = pos_[1] - size_[1];
-    DrawSquareDot(canvas,
+    DrawSquareDot(batcher,
                   Vec2(time_graph_->GetWorldFromTick(previous_time),
                        base_y + static_cast<float>(last_normalized_value) * size_[1]),
                   kDotRadius, dot_z, kDotColor);
+
     for (++it; it != values_.end(); ++it) {
-      if (previous_time > max_ns) break;
+      if (previous_time > max_tick) break;
       uint64_t time = it->first;
       double normalized_value = (it->second - min_) * inv_value_range_;
       float x0 = time_graph_->GetWorldFromTick(previous_time);
       float x1 = time_graph_->GetWorldFromTick(time);
       float y0 = base_y + static_cast<float>(last_normalized_value) * size_[1];
       float y1 = base_y + static_cast<float>(normalized_value) * size_[1];
-      time_graph_->GetBatcher().AddLine(Vec2(x0, y0), Vec2(x1, y1), graph_z, kLineColor);
-      DrawSquareDot(canvas, Vec2(x1, y1), kDotRadius, dot_z, kDotColor);
+      batcher->AddLine(Vec2(x0, y0), Vec2(x1, y1), graph_z, kLineColor);
+      DrawSquareDot(batcher, Vec2(x1, y1), kDotRadius, dot_z, kDotColor);
 
       previous_time = time;
       last_normalized_value = normalized_value;
@@ -95,10 +62,31 @@ void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset
   }
 }
 
-void GraphTrack::DrawSquareDot(GlCanvas* canvas, Vec2 center, float radius, float z, Color color) {
+void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
+  const bool picking = picking_mode != PickingMode::kNone;
+  if (picking) {
+    return;
+  }
+
+  // Draw label
+  auto last_measure = GetPreviousValueAndTime(time_graph_->GetCurrentMouseTimeNs());
+  if (last_measure.has_value()) {
+    auto& [time, value] = last_measure.value();
+    if (time_graph_->IsFullyVisible(time, time)) {
+      float point_x = time_graph_->GetWorldFromTick(time);
+      float point_y = pos_[1] - static_cast<float>((max_ - value) * size_[1] / value_range_);
+      const Color kBlack(0, 0, 0, 255);
+      const Color kWhite(255, 255, 255, 255);
+      float text_z = GlCanvas::kZValueEvent + z_offset;
+      DrawLabel(canvas, Vec2(point_x, point_y), std::to_string(value), kBlack, kWhite, text_z);
+    }
+  }
+}
+
+void GraphTrack::DrawSquareDot(Batcher* batcher, Vec2 center, float radius, float z, Color color) {
   Vec2 position(center[0] - radius, center[1] - radius);
   Vec2 size(2 * radius, 2 * radius);
-  canvas->GetBatcher()->AddBox(Box(position, size, z), color);
+  batcher->AddBox(Box(position, size, z), color);
 }
 
 void GraphTrack::DrawLabel(GlCanvas* canvas, Vec2 target_pos, const std::string text,

--- a/OrbitGl/GraphTrack.h
+++ b/OrbitGl/GraphTrack.h
@@ -18,13 +18,15 @@ class GraphTrack : public Track {
   explicit GraphTrack(TimeGraph* time_graph, std::string name);
   [[nodiscard]] Type GetType() const override { return kGraphTrack; }
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
+  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode,
+                        float z_offset = 0) override;
   [[nodiscard]] float GetHeight() const override;
   void AddValue(double value, uint64_t time);
   [[nodiscard]] std::optional<std::pair<uint64_t, double> > GetPreviousValueAndTime(
       uint64_t time) const;
 
  protected:
-  void DrawSquareDot(GlCanvas* canvas, Vec2 center, float radius, float z, Color color);
+  void DrawSquareDot(Batcher* batcher, Vec2 center, float radius, float z, Color color);
   void DrawLabel(GlCanvas* canvas, Vec2 target_pos, std::string text, Color text_color,
                  Color font_color, float z);
   std::map<uint64_t, double> values_;


### PR DESCRIPTION
Redraw curves only when an unpdate is required (zoom, pan), not
on mouse move. The labels do need to be redrawn on mouse move so
split rendering into "UpdatePrimitives" and "Draw".