### PR TITLE
Fix bug where module update is necessary

### DIFF
--- a/OrbitClientData/ModuleManagerTest.cpp
+++ b/OrbitClientData/ModuleManagerTest.cpp
@@ -95,7 +95,9 @@ TEST(ModuleManager, AddOrUpdateModules) {
   module_info.set_load_bias(load_bias);
 
   ModuleManager module_manager;
-  module_manager.AddOrUpdateModules({module_info});
+  std::vector<ModuleData*> unloaded_modules = module_manager.AddOrUpdateModules({module_info});
+  EXPECT_TRUE(unloaded_modules.empty());
+
   ModuleData* module = module_manager.GetMutableModuleByPath(file_path);
 
   ASSERT_NE(module, nullptr);
@@ -105,7 +107,8 @@ TEST(ModuleManager, AddOrUpdateModules) {
   std::string changed_name = "changed name";
   module_info.set_name(changed_name);
 
-  module_manager.AddOrUpdateModules({module_info});
+  unloaded_modules = module_manager.AddOrUpdateModules({module_info});
+  EXPECT_TRUE(unloaded_modules.empty());
 
   ASSERT_NE(module, nullptr);
   EXPECT_EQ(module->file_path(), file_path);
@@ -118,7 +121,9 @@ TEST(ModuleManager, AddOrUpdateModules) {
 
   // change build id, this updates the module and removes the symbols
   module_info.set_build_id("different build id");
-  module_manager.AddOrUpdateModules({module_info});
+  unloaded_modules = module_manager.AddOrUpdateModules({module_info});
+  EXPECT_FALSE(unloaded_modules.empty());
+  EXPECT_EQ(unloaded_modules.size(), 1);
 
   EXPECT_EQ(module->build_id(), module_info.build_id());
   EXPECT_FALSE(module->is_loaded());
@@ -129,7 +134,8 @@ TEST(ModuleManager, AddOrUpdateModules) {
   module_info.set_file_path(different_path);
   uint64_t different_file_size = 301;
   module_info.set_file_size(different_file_size);
-  module_manager.AddOrUpdateModules({module_info});
+  unloaded_modules = module_manager.AddOrUpdateModules({module_info});
+  EXPECT_TRUE(unloaded_modules.empty());
 
   ASSERT_NE(module, nullptr);
   EXPECT_EQ(module->file_path(), file_path);

--- a/OrbitClientData/include/OrbitClientData/ModuleData.h
+++ b/OrbitClientData/include/OrbitClientData/ModuleData.h
@@ -30,6 +30,7 @@ class ModuleData final {
   [[nodiscard]] const std::string& build_id() const { return module_info_.build_id(); }
   [[nodiscard]] uint64_t load_bias() const { return module_info_.load_bias(); }
   [[nodiscard]] bool is_loaded() const;
+  void UpdateIfChanged(orbit_grpc_protos::ModuleInfo info);
   // relative_address here is the absolute address minus the address this module was loaded at by
   // the process (module base address)
   [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionByRelativeAddress(
@@ -43,7 +44,7 @@ class ModuleData final {
 
  private:
   mutable absl::Mutex mutex_;
-  const orbit_grpc_protos::ModuleInfo module_info_;
+  orbit_grpc_protos::ModuleInfo module_info_;
   bool is_loaded_;
   std::map<uint64_t, std::unique_ptr<orbit_client_protos::FunctionInfo>> functions_;
   // TODO(168799822) This is a map of hash to function used for preset loading. Currently presets

--- a/OrbitClientData/include/OrbitClientData/ModuleManager.h
+++ b/OrbitClientData/include/OrbitClientData/ModuleManager.h
@@ -22,7 +22,7 @@ class ModuleManager final {
 
   [[nodiscard]] const ModuleData* GetModuleByPath(const std::string& path) const;
   [[nodiscard]] ModuleData* GetMutableModuleByPath(const std::string& path);
-  void AddNewModules(const std::vector<orbit_grpc_protos::ModuleInfo>& module_infos);
+  void AddOrUpdateModules(const std::vector<orbit_grpc_protos::ModuleInfo>& module_infos);
   [[nodiscard]] std::vector<orbit_client_protos::FunctionInfo> GetOrbitFunctionsOfProcess(
       const ProcessData& process) const;
 

--- a/OrbitClientData/include/OrbitClientData/ModuleManager.h
+++ b/OrbitClientData/include/OrbitClientData/ModuleManager.h
@@ -22,7 +22,12 @@ class ModuleManager final {
 
   [[nodiscard]] const ModuleData* GetModuleByPath(const std::string& path) const;
   [[nodiscard]] ModuleData* GetMutableModuleByPath(const std::string& path);
-  void AddOrUpdateModules(const std::vector<orbit_grpc_protos::ModuleInfo>& module_infos);
+  // Add new modules for the module_infos that do not exist yet, and update the modules that do
+  // exist. If the update changed the module in a way that symbols were not valid anymore, the
+  // symbols are discarded aka the module is not loaded anymore. This method returns the list of
+  // modules that used to be loaded before the call and are not loaded anymore after the call.
+  std::vector<ModuleData*> AddOrUpdateModules(
+      const std::vector<orbit_grpc_protos::ModuleInfo>& module_infos);
   [[nodiscard]] std::vector<orbit_client_protos::FunctionInfo> GetOrbitFunctionsOfProcess(
       const ProcessData& process) const;
 

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -150,7 +150,7 @@ ErrorMessageOr<void> ClientGgp::LoadModuleAndSymbols() {
         info.build_id());
   }
 
-  module_manager_.AddNewModules(module_infos);
+  module_manager_.AddOrUpdateModules(module_infos);
 
   // Process name can be arbitrary so we use the path to find the module corresponding to the binary
   // of target_process_

--- a/OrbitClientModel/CaptureDeserializer.cpp
+++ b/OrbitClientModel/CaptureDeserializer.cpp
@@ -137,7 +137,7 @@ void LoadCaptureInfo(const CaptureInfo& capture_info, CaptureListener* capture_l
   }
   process.UpdateModuleInfos(modules);
 
-  module_manager->AddNewModules(modules);
+  module_manager->AddOrUpdateModules(modules);
 
   if (*cancellation_requested) {
     capture_listener->OnCaptureCancelled();

--- a/OrbitClientModel/CaptureSerializerTest.cpp
+++ b/OrbitClientModel/CaptureSerializerTest.cpp
@@ -92,7 +92,7 @@ TEST(CaptureSerializer, GenerateCaptureInfo) {
   std::vector<orbit_grpc_protos::ModuleInfo> module_infos{module_info};
   process.UpdateModuleInfos(module_infos);
   ModuleManager module_manager;
-  module_manager.AddNewModules(module_infos);
+  module_manager.AddOrUpdateModules(module_infos);
 
   absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions;
   FunctionInfo selected_function;

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -1096,7 +1096,16 @@ void OrbitApp::UpdateProcessAndModuleList(int32_t pid) {
         return;
       }
 
-      module_manager_->AddNewModules(module_infos);
+      module_manager_->AddOrUpdateModules(module_infos);
+
+      // Updating a module can result in not having symbols(functions) anymore. In that
+      // case these functions should also be removed from the selected (hooked) functions
+      for (const FunctionInfo& func : data_manager_->GetSelectedFunctions()) {
+        const ModuleData* module = module_manager_->GetModuleByPath(func.loaded_module_path());
+        if (!module->is_loaded()) {
+          data_manager_->DeselectFunction(func);
+        }
+      }
 
       ProcessData* process = data_manager_->GetMutableProcessByPid(pid);
       CHECK(process != nullptr);

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -247,8 +247,9 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void SendErrorToUi(const std::string& title, const std::string& text);
   void NeedsRedraw();
 
-  void LoadModules(const std::vector<ModuleData*>& modules,
-                   const std::shared_ptr<orbit_client_protos::PresetFile>& preset = nullptr);
+  void LoadModules(
+      const std::vector<ModuleData*>& modules,
+      absl::flat_hash_map<std::string, std::vector<uint64_t>> function_hashes_to_hook_map = {});
   void UpdateProcessAndModuleList(int32_t pid);
 
   void UpdateAfterSymbolLoading();
@@ -309,12 +310,11 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   ErrorMessageOr<std::filesystem::path> FindSymbolsLocally(const std::filesystem::path& module_path,
                                                            const std::string& build_id);
   void LoadSymbols(const std::filesystem::path& symbols_path, ModuleData* module_data,
-                   const orbit_client_protos::PresetModule* preset_module);
+                   std::vector<uint64_t> function_hashes_to_hook);
 
-  void LoadModuleOnRemote(ModuleData* module_data,
-                          const orbit_client_protos::PresetModule* preset_module);
-  ErrorMessageOr<void> SelectFunctionsFromPreset(const ModuleData* module,
-                                                 const orbit_client_protos::PresetModule& preset);
+  void LoadModuleOnRemote(ModuleData* module_data, std::vector<uint64_t> function_hashes_to_hook);
+  ErrorMessageOr<void> SelectFunctionsFromHashes(const ModuleData* module,
+                                                 const std::vector<uint64_t>& function_hashes);
 
   ErrorMessageOr<orbit_client_protos::PresetInfo> ReadPresetFromFile(const std::string& filename);
 

--- a/OrbitGl/DataManagerUpdateModuleInfosFuzzer.cpp
+++ b/OrbitGl/DataManagerUpdateModuleInfosFuzzer.cpp
@@ -38,7 +38,7 @@ DEFINE_PROTO_FUZZER(const GetModuleListResponse& module_list) {
   std::vector<ModuleInfo> modules{range.begin(), range.end()};
 
   ModuleManager module_manager;
-  module_manager.AddNewModules(modules);
+  module_manager.AddOrUpdateModules(modules);
 
   int32_t pid = 1;
   ProcessInfo process_info{};


### PR DESCRIPTION
Before this change, a module (ModuleData) was considered to not change
during a profiling session. Now modules are updated when they change.
Tests and usages are changed accordingly. b/171765631