### PR TITLE
A couple of fixes to the collector, in particular Skip events coming before all file descriptors have been enabled

### DIFF
--- a/OrbitLinuxTracing/PerfEventOpen.cpp
+++ b/OrbitLinuxTracing/PerfEventOpen.cpp
@@ -30,7 +30,7 @@ perf_event_attr generic_event_attr() {
 }
 
 int generic_event_open(perf_event_attr* attr, pid_t pid, int32_t cpu) {
-  int fd = perf_event_open(attr, pid, cpu, -1, 0);
+  int fd = perf_event_open(attr, pid, cpu, -1, PERF_FLAG_FD_CLOEXEC);
   if (fd == -1) {
     ERROR("perf_event_open: %s", SafeStrerror(errno));
   }

--- a/OrbitLinuxTracing/PerfEventProcessor.h
+++ b/OrbitLinuxTracing/PerfEventProcessor.h
@@ -78,19 +78,21 @@ class PerfEventProcessor {
 
   void ClearVisitors() { visitors_.clear(); }
 
+  void SetDiscardedOutOfOrderCounter(std::atomic<uint64_t>* discarded_out_of_order_counter) {
+    discarded_out_of_order_counter_ = discarded_out_of_order_counter;
+  }
+
  private:
   // Do not process events that are more recent than 0.1 seconds. There could be
   // events coming out of order as they are read from different perf_event_open
   // ring buffers and this ensure that all events are processed in the correct
   // order.
   static constexpr uint64_t kProcessingDelayMs = 100;
+  uint64_t last_processed_timestamp_ns_ = 0;
+  std::atomic<uint64_t>* discarded_out_of_order_counter_ = nullptr;
 
   PerfEventQueue event_queue_;
   std::vector<PerfEventVisitor*> visitors_;
-
-#ifndef NDEBUG
-  uint64_t last_processed_timestamp_ = 0;
-#endif
 };
 
 }  // namespace LinuxTracing

--- a/OrbitLinuxTracing/PerfEventReaders.cpp
+++ b/OrbitLinuxTracing/PerfEventReaders.cpp
@@ -29,6 +29,17 @@ pid_t ReadMmapRecordPid(PerfEventRingBuffer* ring_buffer) {
   return pid;
 }
 
+uint64_t ReadSampleRecordTime(PerfEventRingBuffer* ring_buffer) {
+  uint64_t time;
+  // All PERF_RECORD_SAMPLEs start with
+  //   perf_event_header header;
+  //   perf_event_sample_id_tid_time_streamid_cpu sample_id;
+  ring_buffer->ReadValueAtOffset(
+      &time,
+      sizeof(perf_event_header) + offsetof(perf_event_sample_id_tid_time_streamid_cpu, time));
+  return time;
+}
+
 uint64_t ReadSampleRecordStreamId(PerfEventRingBuffer* ring_buffer) {
   uint64_t stream_id;
   // All PERF_RECORD_SAMPLEs start with

--- a/OrbitLinuxTracing/PerfEventReaders.h
+++ b/OrbitLinuxTracing/PerfEventReaders.h
@@ -14,6 +14,8 @@ namespace LinuxTracing {
 // more complex operations than simply copying an entire perf_event_open record.
 pid_t ReadMmapRecordPid(PerfEventRingBuffer* ring_buffer);
 
+uint64_t ReadSampleRecordTime(PerfEventRingBuffer* ring_buffer);
+
 uint64_t ReadSampleRecordStreamId(PerfEventRingBuffer* ring_buffer);
 
 pid_t ReadSampleRecordPid(PerfEventRingBuffer* ring_buffer);

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -545,8 +545,6 @@ void TracerThread::Run(const std::shared_ptr<std::atomic<bool>>& exit_requested)
     perf_event_open_errors |= !OpenContextSwitches(all_cpus);
   }
 
-  context_switch_manager_.Clear();
-
   perf_event_open_errors |= !OpenMmapTask(cpuset_cpus);
 
   bool uprobes_event_open_errors = false;
@@ -1065,10 +1063,6 @@ void TracerThread::Reset() {
   tracing_fds_.clear();
   ring_buffers_.clear();
 
-  uprobes_unwinding_visitor_.reset();
-  thread_state_visitor_.reset();
-  event_processor_.ClearVisitors();
-
   uprobes_uretprobes_ids_to_function_.clear();
   uprobes_ids_.clear();
   uretprobes_ids_.clear();
@@ -1083,8 +1077,15 @@ void TracerThread::Reset() {
   dma_fence_signaled_ids_.clear();
   ids_to_tracepoint_info_.clear();
 
-  deferred_events_.clear();
+  effective_capture_start_timestamp_ns_ = 0;
+
   stop_deferred_thread_ = false;
+  deferred_events_.clear();
+  context_switch_manager_.Clear();
+  uprobes_unwinding_visitor_.reset();
+  thread_state_visitor_.reset();
+  event_processor_.ClearVisitors();
+  gpu_event_processor_.reset();
 }
 
 void TracerThread::PrintStatsIfTimerElapsed() {

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -120,7 +120,7 @@ bool TracerThread::OpenUprobes(const LinuxTracing::Function& function,
   for (int32_t cpu : cpus) {
     int fd = uprobes_retaddr_event_open(module, offset, -1, cpu);
     if (fd < 0) {
-      ERROR("Opening uprobe 0x%lx on cpu %d", function.VirtualAddress(), cpu);
+      ERROR("Opening uprobe %#lx on cpu %d", function.VirtualAddress(), cpu);
       return false;
     }
     (*fds_per_cpu)[cpu] = fd;
@@ -137,7 +137,7 @@ bool TracerThread::OpenUretprobes(const LinuxTracing::Function& function,
   for (int32_t cpu : cpus) {
     int fd = uretprobes_event_open(module, offset, -1, cpu);
     if (fd < 0) {
-      ERROR("Opening uretprobe 0x%lx on cpu %d", function.VirtualAddress(), cpu);
+      ERROR("Opening uretprobe %#lx on cpu %d", function.VirtualAddress(), cpu);
       return false;
     }
     (*fds_per_cpu)[cpu] = fd;

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -150,6 +150,8 @@ class TracerThread {
   absl::flat_hash_set<uint64_t> dma_fence_signaled_ids_;
   absl::flat_hash_map<uint64_t, orbit_grpc_protos::TracepointInfo> ids_to_tracepoint_info_;
 
+  uint64_t effective_capture_start_timestamp_ns_ = 0;
+
   std::atomic<bool> stop_deferred_thread_ = false;
   std::vector<std::unique_ptr<PerfEvent>> deferred_events_;
   std::mutex deferred_events_mutex_;

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -71,8 +71,8 @@ class TracerThread {
 
   void AddUretprobesFileDescriptors(const absl::flat_hash_map<int32_t, int>& uretprobes_fds_per_cpu,
                                     const LinuxTracing::Function& function);
-
-  void OpenUserSpaceProbesRingBuffers();
+  void OpenUserSpaceProbesRingBuffers(
+      const absl::flat_hash_map<int32_t, std::vector<int>>& uprobes_uretpobres_fds_per_cpu);
 
   bool OpenThreadNameTracepoints(const std::vector<int32_t>& cpus);
   void InitThreadStateVisitor();
@@ -133,7 +133,6 @@ class TracerThread {
   TracerListener* listener_ = nullptr;
 
   std::vector<int> tracing_fds_;
-  absl::flat_hash_map<int32_t, std::vector<int>> fds_per_cpu_;
   std::vector<PerfEventRingBuffer> ring_buffers_;
 
   absl::flat_hash_map<uint64_t, const Function*> uprobes_uretprobes_ids_to_function_;

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -126,6 +126,7 @@ class TracerThread {
   uint64_t sampling_period_ns_;
   orbit_grpc_protos::CaptureOptions::UnwindingMethod unwinding_method_;
   std::vector<Function> instrumented_functions_;
+  ManualInstrumentationConfig manual_instrumentation_config_;
   bool trace_thread_state_;
   bool trace_gpu_driver_;
   std::vector<orbit_grpc_protos::TracepointInfo> instrumented_tracepoints_;
@@ -167,8 +168,9 @@ class TracerThread {
       gpu_events_count = 0;
       lost_count = 0;
       lost_count_per_buffer.clear();
-      *unwind_error_count = 0;
-      *discarded_samples_in_uretprobes_count = 0;
+      discarded_out_of_order_count = 0;
+      unwind_error_count = 0;
+      discarded_samples_in_uretprobes_count = 0;
     }
 
     uint64_t event_count_begin_ns = 0;
@@ -178,15 +180,13 @@ class TracerThread {
     uint64_t gpu_events_count = 0;
     uint64_t lost_count = 0;
     absl::flat_hash_map<PerfEventRingBuffer*, uint64_t> lost_count_per_buffer{};
-    std::shared_ptr<std::atomic<uint64_t>> unwind_error_count =
-        std::make_unique<std::atomic<uint64_t>>(0);
-    std::shared_ptr<std::atomic<uint64_t>> discarded_samples_in_uretprobes_count =
-        std::make_unique<std::atomic<uint64_t>>(0);
+    std::atomic<uint64_t> discarded_out_of_order_count = 0;
+    std::atomic<uint64_t> unwind_error_count = 0;
+    std::atomic<uint64_t> discarded_samples_in_uretprobes_count = 0;
   };
 
   static constexpr uint64_t EVENT_STATS_WINDOW_S = 5;
   EventStats stats_{};
-  ManualInstrumentationConfig manual_instrumentation_config_;
 
   static constexpr uint64_t NS_PER_MILLISECOND = 1'000'000;
   static constexpr uint64_t NS_PER_SECOND = 1'000'000'000;

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -164,6 +164,7 @@ class TracerThread {
       sched_switch_count = 0;
       sample_count = 0;
       uprobes_count = 0;
+      gpu_events_count = 0;
       lost_count = 0;
       lost_count_per_buffer.clear();
       *unwind_error_count = 0;

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.h
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.h
@@ -49,10 +49,10 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   void SetListener(TracerListener* listener) { listener_ = listener; }
 
   void SetUnwindErrorsAndDiscardedSamplesCounters(
-      std::shared_ptr<std::atomic<uint64_t>> unwind_error_counter,
-      std::shared_ptr<std::atomic<uint64_t>> discarded_samples_in_uretprobes_counter) {
-    unwind_error_counter_ = std::move(unwind_error_counter);
-    discarded_samples_in_uretprobes_counter_ = std::move(discarded_samples_in_uretprobes_counter);
+      std::atomic<uint64_t>* unwind_error_counter,
+      std::atomic<uint64_t>* discarded_samples_in_uretprobes_counter) {
+    unwind_error_counter_ = unwind_error_counter;
+    discarded_samples_in_uretprobes_counter_ = discarded_samples_in_uretprobes_counter;
   }
 
   void visit(StackSamplePerfEvent* event) override;
@@ -68,8 +68,9 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   LibunwindstackUnwinder unwinder_{};
 
   TracerListener* listener_ = nullptr;
-  std::shared_ptr<std::atomic<uint64_t>> unwind_error_counter_ = nullptr;
-  std::shared_ptr<std::atomic<uint64_t>> discarded_samples_in_uretprobes_counter_ = nullptr;
+
+  std::atomic<uint64_t>* unwind_error_counter_ = nullptr;
+  std::atomic<uint64_t>* discarded_samples_in_uretprobes_counter_ = nullptr;
 
   absl::flat_hash_map<pid_t, std::vector<std::tuple<uint64_t, uint64_t, uint32_t>>>
       uprobe_sps_ips_cpus_per_thread_{};


### PR DESCRIPTION
#### Use %#lx over 0x%lx
#### Replace fds_per_cpu_ with a parameter
It's a class member used to pass data from a method to another, make it a local
variable and pass it as a parameter.
#### Use perf_event_open with PERF_FLAG_FD_CLOEXEC
See http://b/170711685#comment17
#### Fix resetting EventStats::gpu_events_count
#### PerfEventProcessor discards events that would be out of order
Count the events discarded in `EventStats`, don't log them as if one event is
discarded, usually hundreds of events are discarded, which would flood the logs.
#### Skip events coming before all file descriptors have been enabled
Enabling the perf_event_open file descriptors can take a while when we have a
lot of them (and also once we go back to allowing to start a new capture while
the file descriptors from the previous ones are still being closed).
Some events can start coming to the ring buffers from the first file
descriptors to have been enabled, while we are still enabling other file
descriptors and hence before we start reading from the ring buffers.
`PerfEventProcessor` would have to buffer for all this arbitrarily long interval
in order to guarantee events to be processed in order.
Therefore, we discard events that came before the last file descriptor had been
enabled.
We prefer this to simply enabling all file descriptors in a different thread, as
we want to perform additional work after enabling the file descriptors but
before starting to read from the ring buffers.
This also prevents the beginning of the capture to be missing parts of
information as some events are already being recorded and others aren't.
Also refer to http://b/170711685#comment4.

Bug: http://b/170711685

Test: Capture Trata hooking all the `vk*` functions in `libvulkan.so.1`,
see from the logs that no event is out of order.
#### Tweak TracerThread::Reset()