### PR TITLE
Draw in increasing z-value order in Capture View

### DIFF
--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -243,7 +243,7 @@ std::vector<float> Batcher::GetLayers() const {
   return layers;
 };
 
-void Batcher::Draw(float layer, bool picking) const {
+void Batcher::DrawLayer(float layer, bool picking) const {
   if (!primitive_buffers_by_layer_.count(layer)) return;
   glPushAttrib(GL_ENABLE_BIT | GL_COLOR_BUFFER_BIT);
   if (picking) {
@@ -264,6 +264,12 @@ void Batcher::Draw(float layer, bool picking) const {
   glDisableClientState(GL_COLOR_ARRAY);
   glDisableClientState(GL_VERTEX_ARRAY);
   glPopAttrib();
+}
+
+void Batcher::Draw(bool picking) const {
+  for (auto& [layer, unused_buffer] : primitive_buffers_by_layer_) {
+    DrawLayer(layer, picking);
+  }
 }
 
 void Batcher::DrawBoxBuffer(float layer, bool picking) const {

--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -235,10 +235,10 @@ void Batcher::StartNewFrame() {
   user_data_.clear();
 }
 
-std::set<float> Batcher::GetLayers() const {
-  std::set<float> layers;
+std::vector<float> Batcher::GetLayers() const {
+  std::vector<float> layers;
   for (auto& [layer, _] : primitive_buffers_by_layer_) {
-    layers.insert(layer);
+    layers.push_back(layer);
   }
   return layers;
 };

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -125,7 +125,8 @@ class Batcher {
 
   void AddCircle(Vec2 position, float radius, float z, Color color);
   [[nodiscard]] std::vector<float> GetLayers() const;
-  virtual void Draw(float layer, bool picking = false) const;
+  void DrawLayer(float layer, bool picking = false) const;
+  virtual void Draw(bool picking = false) const;
 
   void ResetElements();
   void StartNewFrame();

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -63,6 +63,18 @@ struct TriangleBuffer {
   BlockChain<Color, 3 * NUM_TRIANGLES_PER_BLOCK> picking_colors_;
 };
 
+struct PrimitiveBuffers {
+  void Reset() {
+    line_buffer.Reset();
+    box_buffer.Reset();
+    triangle_buffer.Reset();
+  }
+
+  LineBuffer line_buffer;
+  BoxBuffer box_buffer;
+  TriangleBuffer triangle_buffer;
+};
+
 enum class ShadingDirection { kLeftToRight, kRightToLeft, kTopToBottom, kBottomToTop };
 
 class Batcher {
@@ -112,7 +124,8 @@ class Batcher {
                    std::shared_ptr<Pickable> pickable);
 
   void AddCircle(Vec2 position, float radius, float z, Color color);
-  virtual void Draw(bool picking = false) const;
+  std::set<float> GetLayers() const;
+  virtual void Draw(float layer, bool picking = false) const;
 
   void ResetElements();
   void StartNewFrame();
@@ -126,9 +139,9 @@ class Batcher {
   [[nodiscard]] const TextBox* GetTextBox(PickingId id);
 
  protected:
-  void DrawLineBuffer(bool picking) const;
-  void DrawBoxBuffer(bool picking) const;
-  void DrawTriangleBuffer(bool picking) const;
+  void DrawLineBuffer(float layer, bool picking) const;
+  void DrawBoxBuffer(float layer, bool picking) const;
+  void DrawTriangleBuffer(float layer, bool picking) const;
 
   void GetBoxGradientColors(const Color& color, std::array<Color, 4>* colors,
                             ShadingDirection shading_direction = ShadingDirection::kLeftToRight);
@@ -142,9 +155,7 @@ class Batcher {
 
   BatcherId batcher_id_;
   PickingManager* picking_manager_;
-  LineBuffer line_buffer_;
-  BoxBuffer box_buffer_;
-  TriangleBuffer triangle_buffer_;
+  std::unordered_map<float, PrimitiveBuffers> primitive_buffers_by_layer_;
 
   std::vector<std::unique_ptr<PickingUserData>> user_data_;
 

--- a/OrbitGl/Batcher.h
+++ b/OrbitGl/Batcher.h
@@ -124,7 +124,7 @@ class Batcher {
                    std::shared_ptr<Pickable> pickable);
 
   void AddCircle(Vec2 position, float radius, float z, Color color);
-  std::set<float> GetLayers() const;
+  [[nodiscard]] std::vector<float> GetLayers() const;
   virtual void Draw(float layer, bool picking = false) const;
 
   void ResetElements();

--- a/OrbitGl/BatcherTest.cpp
+++ b/OrbitGl/BatcherTest.cpp
@@ -146,6 +146,7 @@ TEST(Batcher, PickingSimpleElements) {
   std::string box_custom_data = "box custom data";
   auto box_user_data = std::make_unique<PickingUserData>();
   box_user_data->custom_data_ = &box_custom_data;
+
   batcher.AddLine(Vec2(0, 0), Vec2(1, 0), 0, Color(255, 255, 255, 255), std::move(line_user_data));
   batcher.AddTriangle(Triangle(Vec3(0, 0, 0), Vec3(0, 1, 0), Vec3(1, 0, 0)), Color(0, 255, 0, 255),
                       std::move(triangle_user_data));

--- a/OrbitGl/BatcherTest.cpp
+++ b/OrbitGl/BatcherTest.cpp
@@ -27,50 +27,51 @@ class MockBatcher : public Batcher {
   // Simulate drawing by simple appending all colors to internal
   // buffers. Only a single color per element will be appended
   // (start point for line, first vertex for triangle and box)
-  void Draw(float layer = 0.f, bool picking = false) const override {
-    if (!primitive_buffers_by_layer_.count(layer)) return;
-    const PrimitiveBuffers& buffer = primitive_buffers_by_layer_.at(layer);
-    if (picking) {
-      for (auto it = buffer.line_buffer.picking_colors_.begin();
-           it != buffer.line_buffer.picking_colors_.end();) {
-        drawn_line_colors_.push_back(*it);
-        ++it;
-        ++it;
-      }
-      for (auto it = buffer.triangle_buffer.picking_colors_.begin();
-           it != buffer.triangle_buffer.picking_colors_.end();) {
-        drawn_triangle_colors_.push_back(*it);
-        ++it;
-        ++it;
-        ++it;
-      }
-      for (auto it = buffer.box_buffer.picking_colors_.begin();
-           it != buffer.box_buffer.picking_colors_.end();) {
-        drawn_box_colors_.push_back(*it);
-        ++it;
-        ++it;
-        ++it;
-        ++it;
-      }
-    } else {
-      for (auto it = buffer.line_buffer.colors_.begin(); it != buffer.line_buffer.colors_.end();) {
-        drawn_line_colors_.push_back(*it);
-        ++it;
-        ++it;
-      }
-      for (auto it = buffer.triangle_buffer.colors_.begin();
-           it != buffer.triangle_buffer.colors_.end();) {
-        drawn_triangle_colors_.push_back(*it);
-        ++it;
-        ++it;
-        ++it;
-      }
-      for (auto it = buffer.box_buffer.colors_.begin(); it != buffer.box_buffer.colors_.end();) {
-        drawn_box_colors_.push_back(*it);
-        ++it;
-        ++it;
-        ++it;
-        ++it;
+  void Draw(bool picking = false) const override {
+    for (auto& [unused_layer, buffer] : primitive_buffers_by_layer_) {
+      if (picking) {
+        for (auto it = buffer.line_buffer.picking_colors_.begin();
+             it != buffer.line_buffer.picking_colors_.end();) {
+          drawn_line_colors_.push_back(*it);
+          ++it;
+          ++it;
+        }
+        for (auto it = buffer.triangle_buffer.picking_colors_.begin();
+             it != buffer.triangle_buffer.picking_colors_.end();) {
+          drawn_triangle_colors_.push_back(*it);
+          ++it;
+          ++it;
+          ++it;
+        }
+        for (auto it = buffer.box_buffer.picking_colors_.begin();
+             it != buffer.box_buffer.picking_colors_.end();) {
+          drawn_box_colors_.push_back(*it);
+          ++it;
+          ++it;
+          ++it;
+          ++it;
+        }
+      } else {
+        for (auto it = buffer.line_buffer.colors_.begin();
+             it != buffer.line_buffer.colors_.end();) {
+          drawn_line_colors_.push_back(*it);
+          ++it;
+          ++it;
+        }
+        for (auto it = buffer.triangle_buffer.colors_.begin();
+             it != buffer.triangle_buffer.colors_.end();) {
+          drawn_triangle_colors_.push_back(*it);
+          ++it;
+          ++it;
+          ++it;
+        }
+        for (auto it = buffer.box_buffer.colors_.begin(); it != buffer.box_buffer.colors_.end();) {
+          drawn_box_colors_.push_back(*it);
+          ++it;
+          ++it;
+          ++it;
+          ++it;
+        }
       }
     }
   }
@@ -150,7 +151,7 @@ TEST(Batcher, PickingSimpleElements) {
                       std::move(triangle_user_data));
   batcher.AddBox(Box(Vec2(0, 0), Vec2(1, 1), 0), Color(255, 0, 0, 255), std::move(box_user_data));
 
-  batcher.Draw(0.f, true);
+  batcher.Draw(true);
   ExpectCustomDataEq(batcher, batcher.GetDrawnLineColors()[0], line_custom_data);
   ExpectCustomDataEq(batcher, batcher.GetDrawnTriangleColors()[0], triangle_custom_data);
   ExpectCustomDataEq(batcher, batcher.GetDrawnBoxColors()[0], box_custom_data);
@@ -177,7 +178,7 @@ TEST(Batcher, PickingPickables) {
                       triangle_pickable);
   batcher.AddBox(Box(Vec2(0, 0), Vec2(1, 1), 0), Color(255, 0, 0, 255), box_pickable);
 
-  batcher.Draw(0.f, true);
+  batcher.Draw(true);
   ExpectPickableEq(batcher, batcher.GetDrawnLineColors()[0], pm, line_pickable);
   ExpectPickableEq(batcher, batcher.GetDrawnTriangleColors()[0], pm, triangle_pickable);
   ExpectPickableEq(batcher, batcher.GetDrawnBoxColors()[0], pm, box_pickable);
@@ -203,7 +204,7 @@ TEST(Batcher, MultipleDrawCalls) {
                       std::move(triangle_user_data));
   batcher.AddBox(Box(Vec2(0, 0), Vec2(1, 1), 0), Color(255, 0, 0, 255), std::move(box_user_data));
 
-  batcher.Draw(0.f, true);
+  batcher.Draw(true);
 
   auto line_color = batcher.GetDrawnLineColors()[0];
   auto triangle_color = batcher.GetDrawnTriangleColors()[0];

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -524,6 +524,7 @@ void CaptureWindow::Draw() {
   Append(all_layers, time_graph_.GetTextRenderer()->GetLayers());
   std::sort(all_layers.begin(), all_layers.end());
   std::unique(all_layers.begin(), all_layers.end());
+  CHECK(all_layers.size() <= GlCanvas::kMaxNumberRealZLayers);
 
   for (float layer : all_layers) {
     // We use different coordinate systems for ScreenSpace items (margin, scrollbar, ...)

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -532,11 +532,11 @@ void CaptureWindow::Draw() {
     if (layer < GlCanvas::kScreenSpaceCutPoint) {
       Prepare2DViewport(0, 0, GetWidth(), GetHeight());
     }
-    time_graph_.GetBatcher().Draw(layer, GetPickingMode() != PickingMode::kNone);
-    ui_batcher_.Draw(layer, GetPickingMode() != PickingMode::kNone);
+    time_graph_.GetBatcher().DrawLayer(layer, GetPickingMode() != PickingMode::kNone);
+    ui_batcher_.DrawLayer(layer, GetPickingMode() != PickingMode::kNone);
 
     PrepareScreenSpaceViewport();
-    text_renderer_.Display(&ui_batcher_, layer);
+    text_renderer_.DisplayLayer(&ui_batcher_, layer);
     RenderText(layer);
   }
 }

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -809,11 +809,11 @@ void CaptureWindow::RenderTimeBar() {
 
       std::string text = GetPrettyTime(absl::Microseconds(current_micros));
       float world_x = time_graph_.GetWorldFromUs(current_micros);
-      text_renderer_.AddText(text.c_str(), world_x + x_margin, world_y, GlCanvas::kZValueTextUi,
+      text_renderer_.AddText(text.c_str(), world_x + x_margin, world_y, GlCanvas::kZValueTimeBar,
                              Color(255, 255, 255, 255), font_size_);
 
       Vec2 pos(world_x, world_y);
-      ui_batcher_.AddVerticalLine(pos, height, GlCanvas::kZValueTextUi, Color(255, 255, 255, 255));
+      ui_batcher_.AddVerticalLine(pos, height, GlCanvas::kZValueTimeBar, Color(255, 255, 255, 255));
     }
   }
 }

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -39,7 +39,7 @@ class CaptureWindow : public GlCanvas {
   void Draw() override;
   void DrawScreenSpace() override;
   void RenderImGui() override;
-  void RenderText() override;
+  void RenderText(float layer) override;
   void PreRender() override;
   void PostRender() override;
   void Resize(int width, int height) override;

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -38,7 +38,7 @@ class CaptureWindow : public GlCanvas {
   void OnTimer() override;
   void Draw() override;
   void DrawScreenSpace() override;
-  void RenderUI() override;
+  void RenderImGui() override;
   void RenderText() override;
   void PreRender() override;
   void PostRender() override;

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -28,6 +28,7 @@ float GlCanvas::kZValueText = 0.47f;
 float GlCanvas::kZValueEventBarPicking = 0.49f;
 float GlCanvas::kZValueUi = 0.61f;
 float GlCanvas::kZValueTextUi = 0.61f;
+float GlCanvas::kScreenSpaceCutPoint = 0.8f;
 float GlCanvas::kZValueTimeBarBg = 0.81f;
 float GlCanvas::kZValueTimeBar = 0.83f;
 float GlCanvas::kZValueMargin = 0.85f;

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -17,7 +17,7 @@
 // Tracks: 0.0 - 0.1
 // World Overlay: 0.4 - 0.5
 // UI: 0.6 - 0.7
-// UI Overlay: 0.8 - 0.9
+// ScreenSpace: 0.8 - 0.9
 float GlCanvas::kZValueTrack = 0.01f;
 float GlCanvas::kZValueEventBar = 0.03f;
 float GlCanvas::kZValueBox = 0.05f;
@@ -27,11 +27,12 @@ float GlCanvas::kZValueOverlayTextBackground = 0.45f;
 float GlCanvas::kZValueText = 0.47f;
 float GlCanvas::kZValueEventBarPicking = 0.49f;
 float GlCanvas::kZValueUi = 0.61f;
-float GlCanvas::kZValueTimeBarBg = 0.63f;
-float GlCanvas::kZValueTextUi = 0.65f;
-float GlCanvas::kZValueMargin = 0.81f;
-float GlCanvas::kZValueSliderBg = 0.83f;
-float GlCanvas::kZValueSlider = 0.85f;
+float GlCanvas::kZValueTextUi = 0.61f;
+float GlCanvas::kZValueTimeBarBg = 0.81f;
+float GlCanvas::kZValueTimeBar = 0.83f;
+float GlCanvas::kZValueMargin = 0.85f;
+float GlCanvas::kZValueSliderBg = 0.87f;
+float GlCanvas::kZValueSlider = 0.89f;
 
 float GlCanvas::kZOffsetMovingTack = 0.1f;
 float GlCanvas::kZOffsetPinnedTrack = 0.2f;

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -38,6 +38,9 @@ float GlCanvas::kZValueSlider = 0.89f;
 float GlCanvas::kZOffsetMovingTack = 0.1f;
 float GlCanvas::kZOffsetPinnedTrack = 0.2f;
 
+// Max Number of layers: 16 original, 4 for moving track, 4 for pinned Track
+unsigned GlCanvas::kMaxNumberRealZLayers = 16 + 4 + 4;
+
 const Color GlCanvas::kBackgroundColor = Color(67, 67, 67, 255);
 const Color GlCanvas::kTabTextColorSelected = Color(100, 181, 246, 255);
 

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -338,22 +338,7 @@ void GlCanvas::Render(int width, int height) {
 
   Draw();
 
-  // We have to draw everything collected in the batcher at this point,
-  // as PrepareScreenSpaceViewport() changes the coordinate system.
-  ui_batcher_.Draw(GetPickingMode() != PickingMode::kNone);
-  ui_batcher_.ResetElements();
-
-  PrepareScreenSpaceViewport();
-
-  DrawScreenSpace();
-
-  // Draw remaining elements collected with the batcher.
-  ui_batcher_.Draw(GetPickingMode() != PickingMode::kNone);
-
-  text_renderer_.Display(&ui_batcher_);
-  RenderText();
-  RenderUI();
-
+  RenderImGui();
   glFlush();
   CleanupGlState();
 

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -100,6 +100,7 @@ class GlCanvas : public GlPanel {
 
   static float kZOffsetMovingTack;
   static float kZOffsetPinnedTrack;
+  static unsigned kMaxNumberRealZLayers;
 
   static const Color kBackgroundColor;
   static const Color kTabTextColorSelected;

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -83,10 +83,11 @@ class GlCanvas : public GlPanel {
   static float kZValueSlider;
   static float kZValueSliderBg;
   static float kZValueMargin;
+  static float kZValueTimeBar;
+  static float kZValueTimeBarBg;
   static float kZValueTextUi;
   static float kZValueUi;
   static float kZValueEventBarPicking;
-  static float kZValueTimeBarBg;
   static float kZValueText;
   static float kZValueOverlayTextBackground;
   static float kZValueOverlay;

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -85,6 +85,7 @@ class GlCanvas : public GlPanel {
   static float kZValueMargin;
   static float kZValueTimeBar;
   static float kZValueTimeBarBg;
+  static float kScreenSpaceCutPoint;
   static float kZValueTextUi;
   static float kZValueUi;
   static float kZValueEventBarPicking;

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -70,7 +70,7 @@ class GlCanvas : public GlPanel {
 
   virtual void Draw() {}
   virtual void DrawScreenSpace() {}
-  virtual void RenderUI() {}
+  virtual void RenderImGui() {}
   virtual void RenderText() {}
 
   virtual void Hover(int /*X*/, int /*Y*/) {}

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -71,7 +71,7 @@ class GlCanvas : public GlPanel {
   virtual void Draw() {}
   virtual void DrawScreenSpace() {}
   virtual void RenderImGui() {}
-  virtual void RenderText() {}
+  virtual void RenderText(float) {}
 
   virtual void Hover(int /*X*/, int /*Y*/) {}
 

--- a/OrbitGl/TextRenderer.cpp
+++ b/OrbitGl/TextRenderer.cpp
@@ -90,7 +90,7 @@ void TextRenderer::SetFontSize(uint32_t size) {
 
 uint32_t TextRenderer::GetFontSize() const { return current_font_size_; }
 
-void TextRenderer::Display(Batcher* batcher, float layer) {
+void TextRenderer::DisplayLayer(Batcher* batcher, float layer) {
   if (!buffers_by_layer_.count(layer)) return;
   auto& buffer = buffers_by_layer_.at(layer);
   if (m_DrawOutline) {
@@ -135,6 +135,12 @@ void TextRenderer::Display(Batcher* batcher, float layer) {
   glUseProgram(0);
 
   glPopAttrib();
+}
+
+void TextRenderer::Display(Batcher* batcher) {
+  for (auto& [layer, unused_buffer] : buffers_by_layer_) {
+    DisplayLayer(batcher, layer);
+  }
 }
 
 void TextRenderer::DrawOutline(Batcher* batcher, vertex_buffer_t* a_Buffer) {

--- a/OrbitGl/TextRenderer.h
+++ b/OrbitGl/TextRenderer.h
@@ -23,7 +23,8 @@ class TextRenderer {
   ~TextRenderer();
 
   void Init();
-  void Display(Batcher* batcher, float layer);
+  void Display(Batcher* batcher);
+  void DisplayLayer(Batcher* batcher, float layer);
   void AddText(const char* a_Text, float a_X, float a_Y, float a_Z, const Color& a_Color,
                uint32_t font_size, float a_MaxSize = -1.f, bool a_RightJustified = false);
   // Returns the width of the rendered string.

--- a/OrbitGl/TextRenderer.h
+++ b/OrbitGl/TextRenderer.h
@@ -23,7 +23,7 @@ class TextRenderer {
   ~TextRenderer();
 
   void Init();
-  void Display(Batcher* batcher);
+  void Display(Batcher* batcher, float layer);
   void AddText(const char* a_Text, float a_X, float a_Y, float a_Z, const Color& a_Color,
                uint32_t font_size, float a_MaxSize = -1.f, bool a_RightJustified = false);
   // Returns the width of the rendered string.
@@ -34,11 +34,11 @@ class TextRenderer {
                 float a_MaxSize = -1.f, bool a_RightJustified = false, bool a_InvertY = true);
 
   int GetStringWidth(const char* a_Text) const;
+  [[nodiscard]] std::vector<float> GetLayers() const;
   void Clear();
   void SetCanvas(class GlCanvas* a_Canvas) { m_Canvas = a_Canvas; }
   const GlCanvas* GetCanvas() const { return m_Canvas; }
   GlCanvas* GetCanvas() { return m_Canvas; }
-  int GetNumCharacters() const;
   void ToggleDrawOutline() { m_DrawOutline = !m_DrawOutline; }
   void SetFontSize(uint32_t a_Size);
   uint32_t GetFontSize() const;
@@ -52,7 +52,7 @@ class TextRenderer {
 
  private:
   texture_atlas_t* m_Atlas;
-  vertex_buffer_t* m_Buffer;
+  std::unordered_map<float, vertex_buffer_t*> buffers_by_layer_;
   texture_font_t* m_Font;
   std::map<int, texture_font_t*> m_FontsBySize;
   uint32_t current_font_size_;

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -624,7 +624,6 @@ void TimeGraph::Draw(GlCanvas* canvas, PickingMode picking_mode) {
 
   DrawTracks(canvas, picking_mode);
   DrawOverlay(canvas, picking_mode);
-  batcher_.Draw(picking);
 
   needs_redraw_ = false;
 }

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -1217,7 +1217,7 @@ const TextBox* TimeGraph::FindDown(const TextBox* from) {
 
 void TimeGraph::DrawText(GlCanvas* canvas, float layer) {
   if (draw_text_) {
-    text_renderer_static_.Display(canvas->GetBatcher(), layer);
+    text_renderer_static_.DisplayLayer(canvas->GetBatcher(), layer);
   }
 }
 

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -1215,9 +1215,9 @@ const TextBox* TimeGraph::FindDown(const TextBox* from) {
   return GetOrCreateThreadTrack(timer_info.thread_id())->GetDown(from);
 }
 
-void TimeGraph::DrawText(GlCanvas* canvas) {
+void TimeGraph::DrawText(GlCanvas* canvas, float layer) {
   if (draw_text_) {
-    text_renderer_static_.Display(canvas->GetBatcher());
+    text_renderer_static_.Display(canvas->GetBatcher(), layer);
   }
 }
 

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -37,7 +37,7 @@ class TimeGraph {
   void Draw(GlCanvas* canvas, PickingMode picking_mode = PickingMode::kNone);
   void DrawTracks(GlCanvas* canvas, PickingMode picking_mode = PickingMode::kNone);
   void DrawOverlay(GlCanvas* canvas, PickingMode picking_mode);
-  void DrawText(GlCanvas* canvas);
+  void DrawText(GlCanvas* canvas, float layer);
 
   void NeedsUpdate();
   void UpdatePrimitives(PickingMode picking_mode);


### PR DESCRIPTION
Following the discussion in (https://github.com/google/orbit/pull/1119), we draw using layers to avoid the problem of transparency items who, when drawn before, we don't see what there are behind them.

For that, we add a layer to every box, triangle, line and text.

Mainly focusing b/167369762, but also b/167515371, b/170701548.

In the image: Now we can see rounding corners and text behind the transparency overlay.
<img width="299" alt="transparency" src="https://user-images.githubusercontent.com/8610429/97489136-732f4f80-195f-11eb-8301-1d85d3dc6a8e.png">

Ps: I recommend follow commit by commit.