### PR TITLE
Preparation for frame track serialization

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -1348,3 +1348,70 @@ void OrbitApp::DeselectTracepoint(const TracepointInfo& tracepoint) {
 [[nodiscard]] bool OrbitApp::IsTracepointSelected(const TracepointInfo& info) const {
   return data_manager_->IsTracepointSelected(info);
 }
+
+void OrbitApp::AddFrameTrack(const FunctionInfo& function) {
+  const CaptureData& capture_data = GetCaptureData();
+  const uint64_t function_address = capture_data.GetAbsoluteAddress(function);
+
+  if (frame_track_functions_.contains(function_address)) {
+    ERROR("Trying to add duplicate frame track for function: %s",
+          FunctionUtils::GetDisplayName(function));
+    DCHECK(false);
+    return;
+  }
+
+  std::vector<std::shared_ptr<TimerChain>> chains =
+      GCurrentTimeGraph->GetAllThreadTrackTimerChains();
+
+  std::vector<uint64_t> all_start_times;
+
+  for (const auto& chain : chains) {
+    if (!chain) continue;
+    for (const TimerBlock& block : *chain) {
+      for (uint64_t i = 0; i < block.size(); ++i) {
+        const TextBox& box = block[i];
+        if (box.GetTimerInfo().function_address() == function_address) {
+          all_start_times.push_back(box.GetTimerInfo().start());
+        }
+      }
+    }
+  }
+  std::sort(all_start_times.begin(), all_start_times.end());
+
+  for (size_t k = 0; k < all_start_times.size() - 1; ++k) {
+    TimerInfo frame_timer;
+
+    // TID is meaningless for this timer (start and end can be on two different threads).
+    constexpr const int32_t kUnusedThreadId = -1;
+    frame_timer.set_thread_id(kUnusedThreadId);
+    frame_timer.set_start(all_start_times[k]);
+    frame_timer.set_end(all_start_times[k + 1]);
+    // We use user_data_key to keep track of the frame number.
+    frame_timer.set_user_data_key(k);
+    frame_timer.set_type(TimerInfo::kFrame);
+
+    GCurrentTimeGraph->ProcessTimer(frame_timer, &function);
+  }
+  frame_track_functions_.insert(std::make_pair(function_address, function));
+}
+
+void OrbitApp::RemoveFrameTrack(const FunctionInfo& function) {
+  const CaptureData& capture_data = GetCaptureData();
+  auto function_address = capture_data.GetAbsoluteAddress(function);
+
+  if (!frame_track_functions_.contains(function_address)) {
+    ERROR("Trying to remove non-existent frame track for function: %s",
+          FunctionUtils::GetDisplayName(function));
+    DCHECK(false);
+    return;
+  }
+
+  frame_track_functions_.erase(function_address);
+  GCurrentTimeGraph->RemoveFrameTrack(function);
+}
+
+bool OrbitApp::HasFrameTrack(const FunctionInfo& function) const {
+  const CaptureData& capture_data = GetCaptureData();
+  auto function_address = capture_data.GetAbsoluteAddress(function);
+  return frame_track_functions_.contains(function_address);
+}

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -305,6 +305,10 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
 
   [[nodiscard]] bool IsTracepointSelected(const TracepointInfo& info) const;
 
+  void AddFrameTrack(const orbit_client_protos::FunctionInfo& function);
+  void RemoveFrameTrack(const orbit_client_protos::FunctionInfo& function);
+  [[nodiscard]] bool HasFrameTrack(const orbit_client_protos::FunctionInfo& function) const;
+
  private:
   ErrorMessageOr<std::filesystem::path> FindSymbolsLocally(const std::filesystem::path& module_path,
                                                            const std::string& build_id);
@@ -391,6 +395,9 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   //  CaptureListener parts of App, but may be read also during capturing by all threads.
   //  Currently, it is not properly synchronized (and thus it can't live at DataManager).
   CaptureData capture_data_;
+  // Keep track of the functions that we show frame tracks for. This is needed for
+  // serialization.
+  absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> frame_track_functions_;
 };
 
 extern std::unique_ptr<OrbitApp> GOrbitApp;

--- a/OrbitGl/LiveFunctionsController.cpp
+++ b/OrbitGl/LiveFunctionsController.cpp
@@ -214,45 +214,11 @@ void LiveFunctionsController::AddIterator(FunctionInfo* function) {
 }
 
 void LiveFunctionsController::AddFrameTrack(const FunctionInfo& function) {
-  const CaptureData& capture_data = GOrbitApp->GetCaptureData();
-  auto function_address = capture_data.GetAbsoluteAddress(function);
-  std::vector<std::shared_ptr<TimerChain>> chains =
-      GCurrentTimeGraph->GetAllThreadTrackTimerChains();
-
-  std::vector<uint64_t> all_start_times;
-
-  for (auto& chain : chains) {
-    if (!chain) continue;
-    for (TimerChainIterator it = chain->begin(); it != chain->end(); ++it) {
-      TimerBlock& block = *it;
-      for (uint64_t i = 0; i < block.size(); i++) {
-        TextBox& box = block[i];
-        if (box.GetTimerInfo().function_address() == function_address) {
-          all_start_times.push_back(box.GetTimerInfo().start());
-        }
-      }
-    }
-  }
-  std::sort(all_start_times.begin(), all_start_times.end());
-
-  for (size_t k = 0; k < all_start_times.size() - 1; ++k) {
-    TimerInfo frame_timer;
-
-    // TID is meaningless for this timer (start and end can be on two different threads).
-    constexpr const int32_t kUnusedThreadId = -1;
-    frame_timer.set_thread_id(kUnusedThreadId);
-    frame_timer.set_start(all_start_times[k]);
-    frame_timer.set_end(all_start_times[k + 1]);
-    // We use user_data_key to keep track of the frame number.
-    frame_timer.set_user_data_key(k);
-    frame_timer.set_type(TimerInfo::kFrame);
-
-    GCurrentTimeGraph->ProcessTimer(frame_timer, &function);
-  }
+  GOrbitApp->AddFrameTrack(function);
 }
 
 void LiveFunctionsController::RemoveFrameTrack(const FunctionInfo& function) {
-  GCurrentTimeGraph->RemoveFrameTrack(function);
+  GOrbitApp->RemoveFrameTrack(function);
 }
 
 uint64_t LiveFunctionsController::GetStartTime(uint64_t index) {

--- a/OrbitGl/LiveFunctionsDataView.h
+++ b/OrbitGl/LiveFunctionsDataView.h
@@ -34,7 +34,6 @@ class LiveFunctionsDataView : public DataView {
       const orbit_client_protos::FunctionInfo& function) const;
 
   std::vector<orbit_client_protos::FunctionInfo> functions_;
-  std::set<uint64_t> added_frame_tracks_;
 
   LiveFunctionsController* live_functions_;
 


### PR DESCRIPTION
Data for frame tracks is now kept in App and that is the source of
truth for added frame tracks. This is in preparation of supporting
serialization of frame tracks (and possibly live updates during a
capture, or at least maintaining added frame tracks in-between
captures).

This change also fixes a bug on master where removing a frame track 
was not possible anymore.