### PR TITLE
Fix run_clang_format.sh so that it uses the non-chromium clang-format

### DIFF
--- a/run_clang_format.sh
+++ b/run_clang_format.sh
@@ -4,4 +4,4 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-find . \( -name '*.cpp' -o -name '*.h' \) ! -path './third_party/*' ! -path './build*/*' ! -path './cmake-*' ! -name 'resource.h' | xargs clang-format -i
+find . \( -name '*.cpp' -o -name '*.h' \) ! -path './third_party/*' ! -path './build*/*' ! -path './cmake-*' ! -name 'resource.h' | xargs /usr/bin/clang-format -i


### PR DESCRIPTION
depot-tools overrides clang-format and prevents it from working outside a chromium directory...

go/clang-format-faq#why-am-i-getting-a-problem-while-looking-for-clang-format-in-chromium-source-tree-could-not-find-checkout-in-any-parent-of-current-path-error-when-running-clang-format

Explicitly use /usr/bin/clang-format