### PR TITLE
Fix concatenation in SCOPED_TIMED_LOG

### DIFF
--- a/OrbitBase/include/OrbitBase/Logging.h
+++ b/OrbitBase/include/OrbitBase/Logging.h
@@ -84,16 +84,19 @@ constexpr const char* kLogTimeFormat = "%Y-%m-%dT%H:%M:%E6S";
   } while (0 && (assertion))
 #endif
 
+#define SCOPED_TIMED_LOG_CONCAT_INDIRECT_(a, b) a##b
+#define SCOPED_TIMED_LOG_CONCAT_(a, b) SCOPED_TIMED_LOG_CONCAT_INDIRECT_(a, b)
+
 // Declare the class inside the macro so that file:line are the ones where SCOPED_TIMED_LOG is used.
 #define SCOPED_TIMED_LOG(format, ...)                                                          \
-  class ScopedTimedLog##__LINE__ {                                                             \
+  class SCOPED_TIMED_LOG_CONCAT_(ScopedTimedLog, __LINE__) {                                   \
    public:                                                                                     \
-    explicit ScopedTimedLog##__LINE__(std::string&& message)                                   \
+    explicit SCOPED_TIMED_LOG_CONCAT_(ScopedTimedLog, __LINE__)(std::string && message)        \
         : message_{std::move(message)}, begin_{std::chrono::steady_clock::now()} {             \
       LOG("%s started", message_);                                                             \
     }                                                                                          \
                                                                                                \
-    ~ScopedTimedLog##__LINE__() {                                                              \
+    ~SCOPED_TIMED_LOG_CONCAT_(ScopedTimedLog, __LINE__)() {                                    \
       auto end = std::chrono::steady_clock::now();                                             \
       auto duration =                                                                          \
           std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(end - begin_); \
@@ -103,7 +106,7 @@ constexpr const char* kLogTimeFormat = "%Y-%m-%dT%H:%M:%E6S";
    private:                                                                                    \
     std::string message_;                                                                      \
     std::chrono::time_point<std::chrono::steady_clock> begin_;                                 \
-  } scoped_timed_log_##__LINE__ {                                                              \
+  } SCOPED_TIMED_LOG_CONCAT_(scoped_timed_log_, __LINE__) {                                    \
     absl::StrFormat(format, ##__VA_ARGS__)                                                     \
   }
 


### PR DESCRIPTION
Bug: http://b/172091627

Test: Use the macro multiple times in the same scope:
builds, prints the expected messages