### PR TITLE
Refactor: Add const in a few places

### DIFF
--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -84,7 +84,7 @@ using Context = OrbitSsh::Context;
 
 static outcome::result<GrpcPort> DeployOrbitService(
     std::optional<ServiceDeployManager>& service_deploy_manager,
-    const DeploymentConfiguration& deployment_configuration, Context* context,
+    const DeploymentConfiguration* deployment_configuration, Context* context,
     const SshCredentials& ssh_credentials, const GrpcPort& remote_ports) {
   QProgressDialog progress_dialog{};
 
@@ -122,7 +122,7 @@ static outcome::result<void> RunUiInstance(
 
     // The user chose a remote profiling target.
     OUTCOME_TRY(tunnel_ports,
-                DeployOrbitService(service_deploy_manager, deployment_configuration.value(),
+                DeployOrbitService(service_deploy_manager, &(deployment_configuration.value()),
                                    context, std::get<SshCredentials>(result), remote_ports));
     return std::make_tuple(tunnel_ports, QString{});
   }());

--- a/OrbitQt/servicedeploymanager.cpp
+++ b/OrbitQt/servicedeploymanager.cpp
@@ -58,13 +58,13 @@ static outcome::result<T> MapError(outcome::result<T> result, Error new_error) {
   }
 }
 
-ServiceDeployManager::ServiceDeployManager(DeploymentConfiguration deployment_configuration,
-                                           OrbitSsh::Context* context,
+ServiceDeployManager::ServiceDeployManager(const DeploymentConfiguration& deployment_configuration,
+                                           const OrbitSsh::Context* context,
                                            OrbitSsh::Credentials credentials,
                                            const ServiceDeployManager::GrpcPort& grpc_port,
                                            QObject* parent)
     : QObject(parent),
-      deployment_configuration_(std::move(deployment_configuration)),
+      deployment_configuration_(deployment_configuration),
       context_(context),
       credentials_(std::move(credentials)),
       grpc_port_(grpc_port) {}

--- a/OrbitQt/servicedeploymanager.h
+++ b/OrbitQt/servicedeploymanager.h
@@ -30,8 +30,8 @@ class ServiceDeployManager : public QObject {
     uint16_t grpc_port;
   };
 
-  explicit ServiceDeployManager(DeploymentConfiguration deployment_configuration,
-                                OrbitSsh::Context* context, OrbitSsh::Credentials creds,
+  explicit ServiceDeployManager(const DeploymentConfiguration& deployment_configuration,
+                                const OrbitSsh::Context* context, OrbitSsh::Credentials creds,
                                 const GrpcPort& grpc_port, QObject* parent = nullptr);
 
   outcome::result<GrpcPort> Exec();
@@ -49,8 +49,8 @@ class ServiceDeployManager : public QObject {
  private:
   EventLoop loop_;
 
-  DeploymentConfiguration deployment_configuration_;
-  OrbitSsh::Context* context_ = nullptr;
+  const DeploymentConfiguration& deployment_configuration_;
+  const OrbitSsh::Context* context_;
   OrbitSsh::Credentials credentials_;
   GrpcPort grpc_port_;
   std::optional<OrbitSshQt::Session> session_;

--- a/OrbitQt/servicedeploymanager.h
+++ b/OrbitQt/servicedeploymanager.h
@@ -30,7 +30,7 @@ class ServiceDeployManager : public QObject {
     uint16_t grpc_port;
   };
 
-  explicit ServiceDeployManager(const DeploymentConfiguration& deployment_configuration,
+  explicit ServiceDeployManager(const DeploymentConfiguration* deployment_configuration,
                                 const OrbitSsh::Context* context, OrbitSsh::Credentials creds,
                                 const GrpcPort& grpc_port, QObject* parent = nullptr);
 
@@ -49,7 +49,7 @@ class ServiceDeployManager : public QObject {
  private:
   EventLoop loop_;
 
-  const DeploymentConfiguration& deployment_configuration_;
+  const DeploymentConfiguration* deployment_configuration_;
   const OrbitSsh::Context* context_;
   OrbitSsh::Credentials credentials_;
   GrpcPort grpc_port_;

--- a/OrbitSsh/Session.cpp
+++ b/OrbitSsh/Session.cpp
@@ -20,7 +20,7 @@ namespace OrbitSsh {
 Session::Session(LIBSSH2_SESSION* raw_session_ptr)
     : raw_session_ptr_(raw_session_ptr, &libssh2_session_free) {}
 
-outcome::result<Session> Session::Create(Context* context) {
+outcome::result<Session> Session::Create(const Context* context) {
   CHECK(context->active());
   LIBSSH2_SESSION* raw_session_ptr = libssh2_session_init();
 

--- a/OrbitSsh/include/OrbitSsh/Session.h
+++ b/OrbitSsh/include/OrbitSsh/Session.h
@@ -20,7 +20,7 @@ namespace OrbitSsh {
 
 class Session {
  public:
-  static outcome::result<Session> Create(Context* context);
+  static outcome::result<Session> Create(const Context* context);
 
   outcome::result<void> Handshake(Socket* socket_ptr);
   outcome::result<void> MatchKnownHosts(const AddrAndPort& addr_and_port,

--- a/OrbitSshQt/include/OrbitSshQt/Session.h
+++ b/OrbitSshQt/include/OrbitSshQt/Session.h
@@ -50,7 +50,7 @@ class Session : public StateMachineHelper<Session, details::SessionState> {
   using State = details::SessionState;
 
  public:
-  explicit Session(OrbitSsh::Context* context, QObject* parent = nullptr)
+  explicit Session(const OrbitSsh::Context* context, QObject* parent = nullptr)
       : StateMachineHelper(parent), context_(context) {}
 
   void ConnectToServer(OrbitSsh::Credentials creds);
@@ -69,7 +69,7 @@ class Session : public StateMachineHelper<Session, details::SessionState> {
   void dataEvent();
 
  private:
-  OrbitSsh::Context* context_ = nullptr;
+  const OrbitSsh::Context* context_;
   OrbitSsh::Credentials credentials_;
 
   std::optional<OrbitSsh::Socket> socket_;


### PR DESCRIPTION
This adds const in a few places and uses a reference instead of a move in one place.

This is actually not meaningful on its own, but makes some things easier for an upcoming PR. 

Test: compile