### PR TITLE
Do not log Deadline expired errors

### DIFF
--- a/OrbitClientServices/ProcessClient.cpp
+++ b/OrbitClientServices/ProcessClient.cpp
@@ -48,8 +48,10 @@ ErrorMessageOr<std::vector<orbit_grpc_protos::ProcessInfo>> ProcessClient::GetPr
 
   grpc::Status status = process_service_->GetProcessList(context.get(), request, &response);
   if (!status.ok()) {
-    ERROR("gRPC call to GetProcessList failed: %s (error_code=%d)", status.error_message(),
-          status.error_code());
+    if (status.error_code() != grpc::StatusCode::DEADLINE_EXCEEDED) {
+      ERROR("gRPC call to GetProcessList failed: %s (error_code=%d)", status.error_message(),
+            status.error_code());
+    }
     return ErrorMessage(status.error_message());
   }
 

--- a/OrbitSshQt/include/OrbitSshQt/Tunnel.h
+++ b/OrbitSshQt/include/OrbitSshQt/Tunnel.h
@@ -56,7 +56,9 @@ class Tunnel : public StateMachineHelper<Tunnel, details::TunnelState> {
   void Start();
   void Stop();
 
-  uint16_t GetListenPort() const { return local_server_ ? local_server_->serverPort() : 0; }
+  [[nodiscard]] uint16_t GetListenPort() const {
+    return local_server_ ? local_server_->serverPort() : 0;
+  }
 
  signals:
   void tunnelOpened(uint16_t listen_port);


### PR DESCRIPTION
GetProcessList no longer pollutes log with Deadline expired error messages.
Also add a missing nodiscard

Test: build, run & capture