### PR TITLE
Increase timeout for ggp commands.

### DIFF
--- a/OrbitGgp/Client.cpp
+++ b/OrbitGgp/Client.cpp
@@ -29,7 +29,7 @@ void RunProcessWithTimeout(const QString& program, const QStringList& arguments,
   const auto timeout_timer = QPointer{new QTimer{parent}};
 
   QObject::connect(timeout_timer, &QTimer::timeout, parent, [process, timeout_timer, callback]() {
-    if (process && !process->waitForFinished(10)) {
+    if (process && !process->waitForFinished(20)) {
       ERROR("Process request timed out after %dms", kDefaultTimeoutInMs);
       callback(Error::kRequestTimedOut);
       if (process) {

--- a/OrbitService/ProcessListTest.cpp
+++ b/OrbitService/ProcessListTest.cpp
@@ -24,7 +24,7 @@ TEST(ProcessList, ProcessList) {
   // We wait until the stats have been updated
   while (utils::GetCumulativeTotalCpuTime().value().value == total_cpu_cycles.value) {
     // If this loop never ends it will be caught by the automatic timeout feature
-    usleep(20'000);
+    usleep(10'000);
   }
 
   const auto result2 = process_list.Refresh();

--- a/OrbitService/ProcessListTest.cpp
+++ b/OrbitService/ProcessListTest.cpp
@@ -24,7 +24,7 @@ TEST(ProcessList, ProcessList) {
   // We wait until the stats have been updated
   while (utils::GetCumulativeTotalCpuTime().value().value == total_cpu_cycles.value) {
     // If this loop never ends it will be caught by the automatic timeout feature
-    usleep(10'000);
+    usleep(20'000);
   }
 
   const auto result2 = process_list.Refresh();


### PR DESCRIPTION
There are occational timeouts in the nightly tests. From what I saw it
looked as if 10s were just a tiny bit too little in the worst case.
Probably this will not fix everything but I'm hapyy if it fixes 90%.

Test: N/A
Bug: http://b/172336735