### PR TITLE
Add "collector" and "collector_root_password" flags

### DIFF
--- a/OrbitService/OrbitService.cpp
+++ b/OrbitService/OrbitService.cpp
@@ -43,6 +43,11 @@ namespace orbit_service {
 
 void OrbitService::Run(std::atomic<bool>* exit_requested) {
   LOG("Running Orbit Service version %s", OrbitCore::GetVersion());
+#ifndef NDEBUG
+  LOG("**********************************");
+  LOG("Orbit Service is running in DEBUG!");
+  LOG("**********************************");
+#endif
   std::string grpc_address = absl::StrFormat("127.0.0.1:%d", grpc_port_);
   LOG("Starting gRPC server at %s", grpc_address);
   std::unique_ptr<OrbitGrpcServer> grpc_server;


### PR DESCRIPTION
The passed in values have precedence over the environment variables.
This makes it possible to easily launch different configurations of the
collector (OrbitService) from scripts or IDE's. Also, clearly log that when
are using a debug version of OrbitService.