### PR TITLE
Crash because too many z-layers

### DIFF
--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -523,8 +523,11 @@ void CaptureWindow::Draw() {
   Append(all_layers, text_renderer_.GetLayers());
   Append(all_layers, time_graph_.GetTextRenderer()->GetLayers());
   std::sort(all_layers.begin(), all_layers.end());
-  std::unique(all_layers.begin(), all_layers.end());
-  CHECK(all_layers.size() <= GlCanvas::kMaxNumberRealZLayers);
+  auto it = std::unique(all_layers.begin(), all_layers.end());
+  all_layers.resize(std::distance(all_layers.begin(), it));
+  if (all_layers.size() > GlCanvas::kMaxNumberRealZLayers) {
+    ERROR("Too many z-layers. The current number is %d", all_layers.size());
+  }
 
   for (float layer : all_layers) {
     // We use different coordinate systems for ScreenSpace items (margin, scrollbar, ...)

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -38,8 +38,8 @@ float GlCanvas::kZValueSlider = 0.89f;
 float GlCanvas::kZOffsetMovingTack = 0.1f;
 float GlCanvas::kZOffsetPinnedTrack = 0.2f;
 
-// Max Number of layers: 16 original, 4 for moving track, 4 for pinned Track
-unsigned GlCanvas::kMaxNumberRealZLayers = 16 + 4 + 4;
+// Max Number of layers: 16 original, 4 for moving track, 4 for pinned Track, 4 epsilon in Slider
+unsigned GlCanvas::kMaxNumberRealZLayers = 16 + 4 + 4 + 4;
 
 const Color GlCanvas::kBackgroundColor = Color(67, 67, 67, 255);
 const Color GlCanvas::kTabTextColorSelected = Color(100, 181, 246, 255);


### PR DESCRIPTION
This change includes:
- Misuse of unique (didn't resize after)
- Add 4 to the maximum number of layers (epsilon in GlSlider)
- Change the CHECK for ERROR to not have a unnecesary crash

Solve b/172455056.