### PR TITLE
Actually abort a running capture on exit

### DIFF
--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
@@ -24,9 +24,7 @@ class CaptureClient {
   explicit CaptureClient(const std::shared_ptr<grpc::Channel>& channel,
                          CaptureListener* capture_listener)
       : capture_service_{orbit_grpc_protos::CaptureService::NewStub(channel)},
-        capture_listener_{capture_listener},
-        state_{State::kStopped},
-        force_stop_{false} {
+        capture_listener_{capture_listener} {
     CHECK(capture_listener_ != nullptr);
   }
 
@@ -69,8 +67,8 @@ class CaptureClient {
   CaptureListener* capture_listener_ = nullptr;
 
   mutable absl::Mutex state_mutex_;
-  State state_;
-  std::atomic<bool> force_stop_;
+  State state_ = State::kStopped;
+  std::atomic<bool> writes_done_failed_ = false;
 };
 
 #endif  // ORBIT_GL_CAPTURE_CLIENT_H_

--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
@@ -52,6 +52,8 @@ class CaptureClient {
     return state_ != State::kStopped;
   }
 
+  bool TryAbortCapture();
+
  private:
   void Capture(ProcessData&& process, const OrbitClientData::ModuleManager& module_manager,
                absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
@@ -60,6 +62,7 @@ class CaptureClient {
   void FinishCapture();
 
   std::unique_ptr<orbit_grpc_protos::CaptureService::Stub> capture_service_;
+  std::unique_ptr<grpc::ClientContext> client_context_;
   std::unique_ptr<grpc::ClientReaderWriter<orbit_grpc_protos::CaptureRequest,
                                            orbit_grpc_protos::CaptureResponse>>
       reader_writer_;
@@ -69,6 +72,7 @@ class CaptureClient {
   mutable absl::Mutex state_mutex_;
   State state_ = State::kStopped;
   std::atomic<bool> writes_done_failed_ = false;
+  std::atomic<bool> try_abort_ = false;
 };
 
 #endif  // ORBIT_GL_CAPTURE_CLIENT_H_

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -446,7 +446,7 @@ void OrbitApp::Disassemble(int32_t pid, const FunctionInfo& function) {
 }
 
 void OrbitApp::OnExit() {
-  StopCapture();
+  AbortCapture();
 
   process_manager_->Shutdown();
   thread_pool_->ShutdownAndWait();
@@ -737,6 +737,15 @@ bool OrbitApp::StartCapture() {
 
 void OrbitApp::StopCapture() {
   if (!capture_client_->StopCapture()) {
+    return;
+  }
+
+  CHECK(capture_stop_requested_callback_);
+  capture_stop_requested_callback_();
+}
+
+void OrbitApp::AbortCapture() {
+  if (!capture_client_->TryAbortCapture()) {
     return;
   }
 

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -86,6 +86,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   [[nodiscard]] bool IsCapturing() const;
   bool StartCapture();
   void StopCapture();
+  void AbortCapture();
   void ClearCapture();
   void SetCaptureData(CaptureData capture_data) { capture_data_ = std::move(capture_data); }
   [[nodiscard]] const CaptureData& GetCaptureData() const { return capture_data_; }

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -695,8 +695,8 @@ void OrbitMainWindow::closeEvent(QCloseEvent* event) {
                               "A capture is currently in progress. Do you want to abort the "
                               "capture and exit Orbit?") == QMessageBox::Yes) {
       // We need for the capture to clean up - close as soon as this is done
-      GOrbitApp->SetCaptureStoppedCallback([&] { close(); });
-      GOrbitApp->StopCapture();
+      GOrbitApp->SetCaptureFailedCallback([&] { close(); });
+      GOrbitApp->AbortCapture();
     }
   } else {
     QMainWindow::closeEvent(event);


### PR DESCRIPTION
#### Use ClientContext::TryCancel to actually abort the capture when exiting
So far, "aborting" the capture on exit only meant stopping it, which could still
take a long time. Now this is immediate.

This even seems to allow to close Orbit in the situation of http://b/171923841.

Test: In addition to several local and normal captures on Trata, also capture
Trata as per http://b/171923841#comment17 until the issue arises, and try to
(now successfully) close Orbit.
#### force_stop_: reset to false, rename to writes_done_failed_