### PR TITLE
Clear frame track functions in App when clearing the capture

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -763,6 +763,10 @@ void OrbitApp::ClearCapture() {
   if (GCurrentTimeGraph != nullptr) {
     GCurrentTimeGraph->Clear();
   }
+  // The following call only removes any functions stored as frame track
+  // functions in App, it does not remove the frame tracks from the
+  // time graph. This was done with the call above to TimeGraph::Clear().
+  ClearFrameTrackFunctions();
 
   CHECK(capture_cleared_callback_);
   capture_cleared_callback_();
@@ -1463,3 +1467,5 @@ bool OrbitApp::HasFrameTrack(const FunctionInfo& function) const {
   auto function_address = capture_data.GetAbsoluteAddress(function);
   return frame_track_functions_.contains(function_address);
 }
+
+void OrbitApp::ClearFrameTrackFunctions() { frame_track_functions_.clear(); }

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -310,6 +310,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void AddFrameTrack(const orbit_client_protos::FunctionInfo& function);
   void RemoveFrameTrack(const orbit_client_protos::FunctionInfo& function);
   [[nodiscard]] bool HasFrameTrack(const orbit_client_protos::FunctionInfo& function) const;
+  void ClearFrameTrackFunctions();
 
  private:
   ErrorMessageOr<std::filesystem::path> FindSymbolsLocally(const std::filesystem::path& module_path,


### PR DESCRIPTION
We have to clear the stored frame track functions in App when the
capture is cleared to make sure that the UI behaves consistently.

Fixes b/172452901.