### PR TITLE
Increase ssh tunnel's kChunkSize for faster reads

### DIFF
--- a/OrbitSshQt/Tunnel.cpp
+++ b/OrbitSshQt/Tunnel.cpp
@@ -157,7 +157,7 @@ outcome::result<void> Tunnel::shutdown() {
 
 outcome::result<void> Tunnel::readFromChannel() {
   while (true) {
-    const size_t kChunkSize = 8192;
+    const size_t kChunkSize = 1024 * 1024;
     const auto result = channel_->ReadStdOut(kChunkSize);
 
     if (!result && !OrbitSsh::ShouldITryAgain(result)) {
@@ -180,6 +180,7 @@ outcome::result<void> Tunnel::readFromChannel() {
     if (bytes_written == -1) {
       SetError(Error::kLocalSocketClosed);
     } else {
+      // TODO(b/172686811): avoid extra copy.
       read_buffer_ = read_buffer_.substr(bytes_written);
     }
   }


### PR DESCRIPTION
This greatly reduces the hangs we are sometimes seeing on capture
stop. The real cause is the fact that the tunnel is updated on the ui
thread, which shouldn't be the case as it can being drastically delayed
by a long render frame.

See b/172686811