### PR TITLE
Don't make unnecessary swaps when moving tracks

### DIFF
--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -181,6 +181,7 @@ class TimeGraph {
       const orbit_client_protos::FunctionInfo& function);
 
   void AddTrack(std::shared_ptr<Track> track);
+  int FindMovingTrackIndex();
 
   [[nodiscard]] std::vector<int32_t> GetSortedThreadIds();
 


### PR DESCRIPTION
When we move a track after making a filter, it is moved to the last
possible position (just before the next track in the filtered array).

This is what you expect if you are moving tracks upwards, but if you
move tracks downwards or take a track but don't change its position at
all, this results in  a strange behavior where the moved_track is moved
more to the bottom than what it is expected.

Specially noticed when you move a track to the end. After erasing the
filter, the moved_track will be at the end of the complete list.

Related to b/170370861.