### PR TITLE
Add class to hold user defined capture data and use it for frametracks

### DIFF
--- a/OrbitCore/CMakeLists.txt
+++ b/OrbitCore/CMakeLists.txt
@@ -25,7 +25,8 @@ target_sources(
          Threading.h
          TracepointCustom.h
          TracepointEventBuffer.h
-         TracepointInfoManager.h)
+         TracepointInfoManager.h
+         UserDefinedCaptureData.h)
 
 target_sources(
   OrbitCore
@@ -37,7 +38,8 @@ target_sources(
           StringManager.cpp
           SymbolHelper.cpp
           TracepointEventBuffer.cpp
-          TracepointInfoManager.cpp)
+          TracepointInfoManager.cpp
+          UserDefinedCaptureData.cpp)
 
 target_include_directories(OrbitCore PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 
@@ -83,7 +85,8 @@ target_sources(OrbitCoreTests PRIVATE
     StringManagerTest.cpp
     SymbolHelperTest.cpp
     TracepointEventBufferTest.cpp
-    TracepointInfoManagerTest.cpp)
+    TracepointInfoManagerTest.cpp
+    UserDefinedCaptureDataTest.cpp)
 
 target_link_libraries(
   OrbitCoreTests

--- a/OrbitCore/CaptureData.cpp
+++ b/OrbitCore/CaptureData.cpp
@@ -158,3 +158,17 @@ uint64_t CaptureData::GetAbsoluteAddress(const orbit_client_protos::FunctionInfo
 int32_t CaptureData::process_id() const { return process_.pid(); }
 
 std::string CaptureData::process_name() const { return process_.name(); }
+
+void CaptureData::InsertFrameTrack(const FunctionInfo& function) {
+  user_defined_capture_data_.InsertFrameTrack(function);
+}
+
+void CaptureData::EraseFrameTrack(const FunctionInfo& function) {
+  user_defined_capture_data_.EraseFrameTrack(function);
+}
+
+[[nodiscard]] bool CaptureData::ContainsFrameTrack(const FunctionInfo& function) const {
+  return user_defined_capture_data_.ContainsFrameTrack(function);
+}
+
+void CaptureData::ClearUserDefinedCaptureData() { user_defined_capture_data_.Clear(); }

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -16,6 +16,7 @@
 #include "TracepointCustom.h"
 #include "TracepointEventBuffer.h"
 #include "TracepointInfoManager.h"
+#include "UserDefinedCaptureData.h"
 #include "absl/container/flat_hash_map.h"
 #include "capture_data.pb.h"
 #include "process.pb.h"
@@ -203,6 +204,11 @@ class CaptureData {
     sampling_profiler_ = std::move(sampling_profiler);
   }
 
+  void InsertFrameTrack(const orbit_client_protos::FunctionInfo& function);
+  void EraseFrameTrack(const orbit_client_protos::FunctionInfo& function);
+  [[nodiscard]] bool ContainsFrameTrack(const orbit_client_protos::FunctionInfo& function) const;
+  void ClearUserDefinedCaptureData();
+
  private:
   ProcessData process_;
   OrbitClientData::ModuleManager* module_manager_;
@@ -231,6 +237,8 @@ class CaptureData {
   mutable std::unique_ptr<absl::Mutex> thread_state_slices_mutex_ = std::make_unique<absl::Mutex>();
 
   std::chrono::system_clock::time_point capture_start_time_ = std::chrono::system_clock::now();
+
+  UserDefinedCaptureData user_defined_capture_data_;
 };
 
 #endif  // ORBIT_CORE_CAPTURE_DATA_H_

--- a/OrbitCore/UserDefinedCaptureData.cpp
+++ b/OrbitCore/UserDefinedCaptureData.cpp
@@ -1,0 +1,22 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "UserDefinedCaptureData.h"
+
+#include "OrbitClientData/FunctionUtils.h"
+
+void UserDefinedCaptureData::InsertFrameTrack(const orbit_client_protos::FunctionInfo& function) {
+  // We do not allow insertion of frame tracks twice.
+  CHECK(frame_track_functions_.insert(function).second);
+}
+
+void UserDefinedCaptureData::EraseFrameTrack(const orbit_client_protos::FunctionInfo& function) {
+  // We do not allow erasing a frame track that does not exist.
+  CHECK(frame_track_functions_.erase(function));
+}
+
+[[nodiscard]] bool UserDefinedCaptureData::ContainsFrameTrack(
+    const orbit_client_protos::FunctionInfo& function) const {
+  return frame_track_functions_.contains(function);
+}

--- a/OrbitCore/UserDefinedCaptureData.h
+++ b/OrbitCore/UserDefinedCaptureData.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_CORE_USER_DEFINED_CAPTURE_DATA_H_
+#define ORBIT_CORE_USER_DEFINED_CAPTURE_DATA_H_
+
+#include "OrbitClientData/FunctionInfoSet.h"
+
+// UserDefinedCaptureData holds any capture related data that was added by the user. Examples
+// for this include frame tracks, iterators, timeline annotations or comments.
+// Note that this class is not thread-safe.
+class UserDefinedCaptureData {
+ public:
+  [[nodiscard]] FunctionInfoSet frame_track_functions() const { return frame_track_functions_; }
+  void InsertFrameTrack(const orbit_client_protos::FunctionInfo& function);
+  void EraseFrameTrack(const orbit_client_protos::FunctionInfo& function);
+  [[nodiscard]] bool ContainsFrameTrack(const orbit_client_protos::FunctionInfo& function) const;
+  void Clear() { frame_track_functions_.clear(); }
+
+ private:
+  FunctionInfoSet frame_track_functions_;
+};
+
+#endif  // ORBIT_CORE_USER_DEFINED_CAPTURE_DATA_H_

--- a/OrbitCore/UserDefinedCaptureDataTest.cpp
+++ b/OrbitCore/UserDefinedCaptureDataTest.cpp
@@ -1,0 +1,89 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "UserDefinedCaptureData.h"
+#include "capture_data.pb.h"
+
+using orbit_client_protos::FunctionInfo;
+
+FunctionInfo CreateFunctionInfo(const std::string& function_name, uint64_t function_address) {
+  FunctionInfo info;
+  info.set_name(function_name);
+  info.set_pretty_name(function_name);
+  info.set_loaded_module_path("/path/to/module");
+  info.set_address(function_address);
+  info.set_size(16);
+  info.set_file("file.cpp");
+  info.set_line(13);
+  return info;
+}
+
+TEST(UserDefinedCaptureData, InsertFrameTrack) {
+  UserDefinedCaptureData data;
+  FunctionInfo info = CreateFunctionInfo("fun0_name", 0);
+  data.InsertFrameTrack(info);
+  EXPECT_TRUE(data.ContainsFrameTrack(info));
+}
+
+TEST(UserDefinedCaptureData, InsertFrameTrackDuplicateFunctions) {
+  UserDefinedCaptureData data;
+  FunctionInfo info = CreateFunctionInfo("fun0_name", 0);
+  data.InsertFrameTrack(info);
+  EXPECT_DEATH(data.InsertFrameTrack(info), "");
+}
+
+TEST(UserDefinedCaptureData, InsertFrameTrackDifferentFunctions) {
+  UserDefinedCaptureData data;
+  FunctionInfo info0 = CreateFunctionInfo("fun0_name", 0);
+  FunctionInfo info1 = CreateFunctionInfo("fun1_name", 1);
+  data.InsertFrameTrack(info0);
+  data.InsertFrameTrack(info1);
+  FunctionInfoSet set = data.frame_track_functions();
+  EXPECT_EQ(set.size(), 2);
+}
+
+TEST(UserDefinedCaptureData, EraseNonExistentFrameTrack) {
+  UserDefinedCaptureData data;
+  FunctionInfo info = CreateFunctionInfo("fun0_name", 0);
+  EXPECT_DEATH(data.EraseFrameTrack(info), "");
+}
+
+TEST(UserDefinedCaptureData, EraseFrameTrack) {
+  UserDefinedCaptureData data;
+  FunctionInfo info = CreateFunctionInfo("fun0_name", 0);
+  data.InsertFrameTrack(info);
+  data.EraseFrameTrack(info);
+  EXPECT_FALSE(data.ContainsFrameTrack(info));
+}
+
+TEST(UserDefinedCaptureData, EraseFrameTrackDifferentFunctions) {
+  UserDefinedCaptureData data;
+  FunctionInfo info0 = CreateFunctionInfo("fun0_name", 0);
+  FunctionInfo info1 = CreateFunctionInfo("fun1_name", 1);
+  data.InsertFrameTrack(info0);
+  data.InsertFrameTrack(info1);
+  data.EraseFrameTrack(info0);
+  EXPECT_FALSE(data.ContainsFrameTrack(info0));
+  EXPECT_TRUE(data.ContainsFrameTrack(info1));
+}
+
+TEST(UserDefinedCaptureData, ContainsFrameTrackEmpty) {
+  UserDefinedCaptureData data;
+  FunctionInfo info = CreateFunctionInfo("fun1_name", 0);
+  EXPECT_FALSE(data.ContainsFrameTrack(info));
+}
+
+TEST(UserDefinedCaptureData, Clear) {
+  UserDefinedCaptureData data;
+  FunctionInfo info = CreateFunctionInfo("fun0_name", 0);
+  data.InsertFrameTrack(info);
+  EXPECT_TRUE(data.ContainsFrameTrack(info));
+  data.Clear();
+  FunctionInfoSet set = data.frame_track_functions();
+  EXPECT_TRUE(set.empty());
+}

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -34,6 +34,7 @@
 #include "OrbitBase/ThreadPool.h"
 #include "OrbitCaptureClient/CaptureClient.h"
 #include "OrbitCaptureClient/CaptureListener.h"
+#include "OrbitClientData/FunctionInfoSet.h"
 #include "OrbitClientData/ModuleData.h"
 #include "OrbitClientData/ModuleManager.h"
 #include "OrbitClientData/ProcessData.h"
@@ -313,7 +314,6 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void AddFrameTrack(const orbit_client_protos::FunctionInfo& function);
   void RemoveFrameTrack(const orbit_client_protos::FunctionInfo& function);
   [[nodiscard]] bool HasFrameTrack(const orbit_client_protos::FunctionInfo& function) const;
-  void ClearFrameTrackFunctions();
 
  private:
   ErrorMessageOr<std::filesystem::path> FindSymbolsLocally(const std::filesystem::path& module_path,
@@ -401,9 +401,6 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   //  CaptureListener parts of App, but may be read also during capturing by all threads.
   //  Currently, it is not properly synchronized (and thus it can't live at DataManager).
   CaptureData capture_data_;
-  // Keep track of the functions that we show frame tracks for. This is needed for
-  // serialization.
-  absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> frame_track_functions_;
 };
 
 extern std::unique_ptr<OrbitApp> GOrbitApp;


### PR DESCRIPTION
We add a class UserDefinedCaptureData to hold any user defined capture
data such as frame tracks, iterators, annotations, comments. It is
currently only used for frame tracks.

Note that this is another preparation step for serialization of frametracks.

Bug: b/171026228

Tested: Unit test; manual test of frame tracks.