### PR TITLE
Move SSH tunnel processing to a background thread

### DIFF
--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -209,11 +209,11 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App,
       [this](const std::string& extension) { return this->OnGetSaveFileName(extension); });
   GOrbitApp->SetClipboardCallback([this](const std::string& text) { this->OnSetClipboard(text); });
 
-  GOrbitApp->SetSecureCopyCallback(
-      [service_deploy_manager](std::string_view source, std::string_view destination) {
-        CHECK(service_deploy_manager != nullptr);
-        return service_deploy_manager->CopyFileToLocal(source, destination);
-      });
+  GOrbitApp->SetSecureCopyCallback([service_deploy_manager](std::string_view source,
+                                                            std::string_view destination) {
+    CHECK(service_deploy_manager != nullptr);
+    return service_deploy_manager->CopyFileToLocal(std::string{source}, std::string{destination});
+  });
 
   ui->CaptureGLWidget->Initialize(GlCanvas::CanvasType::kCaptureWindow, this, font_size);
 

--- a/OrbitQt/servicedeploymanager.h
+++ b/OrbitQt/servicedeploymanager.h
@@ -10,6 +10,7 @@
 #include <QPointer>
 #include <QThread>
 #include <QTimer>
+#include <optional>
 #include <string>
 
 #include "OrbitBase/Result.h"
@@ -50,7 +51,8 @@ class ServiceDeployManager : public QObject {
   void socketErrorOccurred(std::error_code);
 
  private:
-  EventLoop loop_;
+  std::optional<EventLoop> loop_;  // It's an optional since it's initialization needs to happen in
+                                   // the background thread.
 
   const DeploymentConfiguration* deployment_configuration_;
   const OrbitSsh::Context* context_;
@@ -91,7 +93,7 @@ class ServiceDeployManager : public QObject {
   template <typename Func>
   [[nodiscard]] OrbitSshQt::ScopedConnection ConnectQuitHandler(
       const typename QtPrivate::FunctionPointer<Func>::Object* sender, Func signal) {
-    return ConnectQuitHandler(&loop_, sender, signal);
+    return ConnectQuitHandler(&loop_.value(), sender, signal);
   }
 
   template <typename Func>
@@ -104,7 +106,7 @@ class ServiceDeployManager : public QObject {
   template <typename Func>
   [[nodiscard]] OrbitSshQt::ScopedConnection ConnectErrorHandler(
       const typename QtPrivate::FunctionPointer<Func>::Object* sender, Func signal) {
-    return ConnectErrorHandler(&loop_, sender, signal);
+    return ConnectErrorHandler(&loop_.value(), sender, signal);
   }
 
   template <typename Func>

--- a/OrbitSshQt/Session.cpp
+++ b/OrbitSshQt/Session.cpp
@@ -20,7 +20,7 @@ outcome::result<void> Session::startup() {
     case State::kDisconnected: {
       OUTCOME_TRY(socket, OrbitSsh::Socket::Create());
       socket_ = std::move(socket);
-      notifiers_.emplace(socket_->GetFileDescriptor());
+      notifiers_.emplace(socket_->GetFileDescriptor(), this);
       QObject::connect(&notifiers_->read, &QSocketNotifier::activated, this, &Session::OnEvent);
       QObject::connect(&notifiers_->write, &QSocketNotifier::activated, this, &Session::OnEvent);
       SetState(State::kSocketCreated);

--- a/OrbitSshQt/Tunnel.cpp
+++ b/OrbitSshQt/Tunnel.cpp
@@ -30,8 +30,11 @@ static void deleteByEventLoop(P* parent, std::optional<T>* opt) {
 }
 
 namespace OrbitSshQt {
-Tunnel::Tunnel(Session* session, std::string remote_host, uint16_t remote_port)
-    : session_(session), remote_host_(std::move(remote_host)), remote_port_(remote_port) {
+Tunnel::Tunnel(Session* session, std::string remote_host, uint16_t remote_port, QObject* parent)
+    : StateMachineHelper(parent),
+      session_(session),
+      remote_host_(std::move(remote_host)),
+      remote_port_(remote_port) {
   about_to_shutdown_connection_.emplace(
       QObject::connect(session_, &Session::aboutToShutdown, this, &Tunnel::HandleSessionShutdown));
 }
@@ -76,7 +79,7 @@ outcome::result<void> Tunnel::startup() {
       ABSL_FALLTHROUGH_INTENDED;
     }
     case State::kChannelInitialized: {
-      local_server_.emplace();
+      local_server_.emplace(this);
       const auto result = local_server_->listen(QHostAddress{QHostAddress::LocalHost});
 
       if (!result) {

--- a/OrbitSshQt/include/OrbitSshQt/Session.h
+++ b/OrbitSshQt/include/OrbitSshQt/Session.h
@@ -79,8 +79,8 @@ class Session : public StateMachineHelper<Session, details::SessionState> {
     QSocketNotifier read;
     QSocketNotifier write;
 
-    explicit NotifierSet(qintptr socket)
-        : read(socket, QSocketNotifier::Read), write(socket, QSocketNotifier::Write) {}
+    explicit NotifierSet(qintptr socket, QObject* parent = nullptr)
+        : read(socket, QSocketNotifier::Read, parent), write(socket, QSocketNotifier::Write, parent) {}
   };
 
   std::optional<NotifierSet> notifiers_;

--- a/OrbitSshQt/include/OrbitSshQt/Session.h
+++ b/OrbitSshQt/include/OrbitSshQt/Session.h
@@ -80,7 +80,8 @@ class Session : public StateMachineHelper<Session, details::SessionState> {
     QSocketNotifier write;
 
     explicit NotifierSet(qintptr socket, QObject* parent = nullptr)
-        : read(socket, QSocketNotifier::Read, parent), write(socket, QSocketNotifier::Write, parent) {}
+        : read(socket, QSocketNotifier::Read, parent),
+          write(socket, QSocketNotifier::Write, parent) {}
   };
 
   std::optional<NotifierSet> notifiers_;

--- a/OrbitSshQt/include/OrbitSshQt/Tunnel.h
+++ b/OrbitSshQt/include/OrbitSshQt/Tunnel.h
@@ -51,7 +51,8 @@ class Tunnel : public StateMachineHelper<Tunnel, details::TunnelState> {
   friend StateMachineHelper;
 
  public:
-  explicit Tunnel(Session* session, std::string remote_host, uint16_t remote_port);
+  explicit Tunnel(Session* session, std::string remote_host, uint16_t remote_port,
+                  QObject* parent = nullptr);
 
   void Start();
   void Stop();


### PR DESCRIPTION
I expected that there is not much more to do than `service_deploy_manager->moveToThread(ssh_background_thread);`, but some cleanup needed to be done as well.

Furthermore some synchronization needed to happen to make the public interface of ServiceDeployManager thread-safe.