### PR TITLE
Include vulkan to the build chain

### DIFF
--- a/bootstrap-orbit.sh
+++ b/bootstrap-orbit.sh
@@ -26,7 +26,8 @@ done
 readonly REQUIRED_PACKAGES=( build-essential libglu1-mesa-dev mesa-common-dev \
                              libxmu-dev libxi-dev libopengl0 qt5-default \
                              qtwebengine5-dev libqt5webchannel5-dev \
-                             libqt5websockets5-dev libxxf86vm-dev python3-pip )
+                             libqt5websockets5-dev libxxf86vm-dev python3-pip \
+                             libvulkan-dev vulkan-validationlayers-dev )
 
 function add_ubuntu_universe_repo {
   sudo add-apt-repository universe

--- a/third_party/conan/docker/Dockerfile.clang7
+++ b/third_party/conan/docker/Dockerfile.clang7
@@ -4,6 +4,8 @@ RUN sudo apt-get -qq update \
     && sudo apt-get install -y --no-install-recommends \
     jq \
     libtinfo5 \
+    libvulkan-dev \
+    vulkan-validationlayers-dev \
     python2.7 \
     zip \
     && sudo rm -rf /var/lib/apt/lists/*

--- a/third_party/conan/docker/Dockerfile.gcc8
+++ b/third_party/conan/docker/Dockerfile.gcc8
@@ -10,6 +10,7 @@ RUN sudo apt-get -qq update \
     libqt5webchannel5-dev \
     libqt5websockets5-dev \
     qtwebengine5-dev \
+    libvulkan-dev \
     jq \
     python2.7 \
     zip

--- a/third_party/conan/docker/Dockerfile.gcc9
+++ b/third_party/conan/docker/Dockerfile.gcc9
@@ -10,6 +10,8 @@ RUN sudo apt-get -qq update \
     libqt5webchannel5-dev \
     libqt5websockets5-dev \
     qtwebengine5-dev \
+    libvulkan-dev \
+    vulkan-validationlayers-dev \
     jq \
     python2.7 \
     zip


### PR DESCRIPTION
The vulkan layer created requires having the vulkan packages installed to build successfully. 

This is a fix related to the recently merged PR: https://github.com/google/orbit/pull/1432 