### PR TITLE
Serialize, deserialize and persist frame tracks between captures

### DIFF
--- a/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -9,6 +9,7 @@
 #include "OrbitCaptureClient/CaptureListener.h"
 #include "OrbitClientData/ProcessData.h"
 #include "TracepointCustom.h"
+#include "UserDefinedCaptureData.h"
 #include "absl/flags/flag.h"
 #include "services.pb.h"
 
@@ -27,7 +28,8 @@ class MyCaptureListener : public CaptureListener {
   void OnCaptureStarted(
       ProcessData&& /*process*/,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> /*selected_functions*/,
-      TracepointInfoSet /*selected_tracepoints*/) override {}
+      TracepointInfoSet /*selected_tracepoints*/,
+      UserDefinedCaptureData /*user_defined_capture_data*/) override {}
   void OnCaptureComplete() override {}
   void OnCaptureCancelled() override {}
   void OnCaptureFailed(ErrorMessage) override {}

--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
@@ -12,6 +12,7 @@
 #include "OrbitClientData/ModuleManager.h"
 #include "OrbitClientData/ProcessData.h"
 #include "TracepointCustom.h"
+#include "UserDefinedCaptureData.h"
 #include "absl/container/flat_hash_set.h"
 #include "capture_data.pb.h"
 #include "grpcpp/channel.h"
@@ -32,7 +33,8 @@ class CaptureClient {
       ThreadPool* thread_pool, const ProcessData& process,
       const OrbitClientData::ModuleManager& module_manager,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
-      TracepointInfoSet selected_tracepoints, bool enable_introspection);
+      TracepointInfoSet selected_tracepoints, UserDefinedCaptureData user_defined_capture_data,
+      bool enable_introspection);
 
   // Returns true if stop was initiated and false otherwise.
   // The latter can happen if for example the stop was already
@@ -57,7 +59,8 @@ class CaptureClient {
  private:
   void Capture(ProcessData&& process, const OrbitClientData::ModuleManager& module_manager,
                absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
-               TracepointInfoSet selected_tracepoints, bool enable_introspection);
+               TracepointInfoSet selected_tracepoints,
+               UserDefinedCaptureData user_defined_capture_data, bool enable_introspection);
 
   void FinishCapture();
 

--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
@@ -9,6 +9,7 @@
 #include "OrbitBase/Result.h"
 #include "OrbitClientData/ProcessData.h"
 #include "TracepointCustom.h"
+#include "UserDefinedCaptureData.h"
 #include "absl/container/flat_hash_set.h"
 #include "capture_data.pb.h"
 
@@ -20,7 +21,7 @@ class CaptureListener {
   virtual void OnCaptureStarted(
       ProcessData&& process,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
-      TracepointInfoSet selected_tracepoints) = 0;
+      TracepointInfoSet selected_tracepoints, UserDefinedCaptureData user_defined_capture_data) = 0;
   // Called when capture is complete.
   virtual void OnCaptureComplete() = 0;
 

--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -22,6 +22,7 @@
 #include "SamplingProfiler.h"
 #include "StringManager.h"
 #include "SymbolHelper.h"
+#include "UserDefinedCaptureData.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "capture_data.pb.h"
@@ -81,7 +82,7 @@ bool ClientGgp::RequestStartCapture(ThreadPool* thread_pool) {
   bool enable_introspection = false;
   ErrorMessageOr<void> result = capture_client_->StartCapture(
       thread_pool, target_process_, module_manager_, selected_functions_, selected_tracepoints,
-      enable_introspection);
+      UserDefinedCaptureData(), enable_introspection);
 
   if (result.has_error()) {
     ERROR("Error starting capture: %s", result.error().message());
@@ -266,9 +267,9 @@ void ClientGgp::ProcessTimer(const TimerInfo& timer_info) { timer_infos_.push_ba
 void ClientGgp::OnCaptureStarted(
     ProcessData&& process,
     absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
-    TracepointInfoSet selected_tracepoints) {
+    TracepointInfoSet selected_tracepoints, UserDefinedCaptureData user_defined_capture_data) {
   capture_data_ = CaptureData(std::move(process), &module_manager_, std::move(selected_functions),
-                              std::move(selected_tracepoints));
+                              std::move(selected_tracepoints), user_defined_capture_data);
   LOG("Capture started");
 }
 

--- a/OrbitClientGgp/include/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/include/OrbitClientGgp/ClientGgp.h
@@ -19,6 +19,7 @@
 #include "OrbitClientServices/ProcessClient.h"
 #include "StringManager.h"
 #include "TracepointCustom.h"
+#include "UserDefinedCaptureData.h"
 #include "grpcpp/grpcpp.h"
 
 class ClientGgp final : public CaptureListener {
@@ -37,7 +38,8 @@ class ClientGgp final : public CaptureListener {
   void OnCaptureStarted(
       ProcessData&& process,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
-      TracepointInfoSet selected_tracepoints) override;
+      TracepointInfoSet selected_tracepoints,
+      UserDefinedCaptureData user_defined_capture_data) override;
   void OnCaptureComplete() override;
   void OnCaptureCancelled() override;
   void OnCaptureFailed(ErrorMessage error_message) override;

--- a/OrbitClientModel/CaptureDeserializer.cpp
+++ b/OrbitClientModel/CaptureDeserializer.cpp
@@ -166,8 +166,15 @@ void LoadCaptureInfo(const CaptureInfo& capture_info, CaptureListener* capture_l
     return;
   }
 
+  UserDefinedCaptureData user_defined_capture_data;
+  for (const auto& function :
+       capture_info.user_defined_capture_info().frame_tracks_info().frame_track_functions()) {
+    user_defined_capture_data.InsertFrameTrack(function);
+  }
+
   capture_listener->OnCaptureStarted(std::move(process), std::move(selected_functions),
-                                     std::move(selected_tracepoints));
+                                     std::move(selected_tracepoints),
+                                     std::move(user_defined_capture_data));
 
   for (const auto& address_info : capture_info.address_infos()) {
     if (*cancellation_requested) {

--- a/OrbitClientModel/CaptureSerializer.cpp
+++ b/OrbitClientModel/CaptureSerializer.cpp
@@ -150,6 +150,13 @@ CaptureInfo GenerateCaptureInfo(
 
   capture_info.mutable_key_to_string()->insert(key_to_string_map.begin(), key_to_string_map.end());
 
+  for (const auto& function : capture_data.user_defined_capture_data().frame_track_functions()) {
+    capture_info.mutable_user_defined_capture_info()
+        ->mutable_frame_tracks_info()
+        ->add_frame_track_functions()
+        ->CopyFrom(function);
+  }
+
   return capture_info;
 }
 

--- a/OrbitClientProtos/capture_data.proto
+++ b/OrbitClientProtos/capture_data.proto
@@ -109,6 +109,14 @@ message CaptureHeader {
   string version = 1;
 }
 
+message FrameTracksInfo {
+  repeated FunctionInfo frame_track_functions = 1;
+}
+
+message UserDefinedCaptureInfo {
+  FrameTracksInfo frame_tracks_info = 1;
+}
+
 message CaptureInfo {
   reserved 2, 3;
   repeated FunctionInfo selected_functions = 1;
@@ -124,6 +132,7 @@ message CaptureInfo {
   repeated TracepointEventInfo tracepoint_event_infos = 11;
   ProcessInfo process = 13;
   repeated ModuleInfo modules = 14;
+  UserDefinedCaptureInfo user_defined_capture_info = 15;
 }
 
 message TimerInfo {

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -26,7 +26,7 @@ class CaptureData {
   explicit CaptureData(
       ProcessData&& process, OrbitClientData::ModuleManager* module_manager,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
-      TracepointInfoSet selected_tracepoints)
+      TracepointInfoSet selected_tracepoints, UserDefinedCaptureData user_defined_capture_data)
       : process_(std::move(process)),
         module_manager_(module_manager),
         selected_functions_{std::move(selected_functions)},
@@ -34,7 +34,8 @@ class CaptureData {
         callstack_data_(std::make_unique<CallstackData>()),
         selection_callstack_data_(std::make_unique<CallstackData>()),
         tracepoint_info_manager_(std::make_unique<TracepointInfoManager>()),
-        tracepoint_event_buffer_(std::make_unique<TracepointEventBuffer>()) {}
+        tracepoint_event_buffer_(std::make_unique<TracepointEventBuffer>()),
+        user_defined_capture_data_(std::move(user_defined_capture_data)) {}
 
   explicit CaptureData()
       : process_(),
@@ -208,6 +209,9 @@ class CaptureData {
   void EraseFrameTrack(const orbit_client_protos::FunctionInfo& function);
   [[nodiscard]] bool ContainsFrameTrack(const orbit_client_protos::FunctionInfo& function) const;
   void ClearUserDefinedCaptureData();
+  [[nodiscard]] const UserDefinedCaptureData& user_defined_capture_data() const {
+    return user_defined_capture_data_;
+  }
 
  private:
   ProcessData process_;

--- a/OrbitCore/UserDefinedCaptureData.h
+++ b/OrbitCore/UserDefinedCaptureData.h
@@ -12,7 +12,9 @@
 // Note that this class is not thread-safe.
 class UserDefinedCaptureData {
  public:
-  [[nodiscard]] FunctionInfoSet frame_track_functions() const { return frame_track_functions_; }
+  [[nodiscard]] const FunctionInfoSet& frame_track_functions() const {
+    return frame_track_functions_;
+  }
   void InsertFrameTrack(const orbit_client_protos::FunctionInfo& function);
   void EraseFrameTrack(const orbit_client_protos::FunctionInfo& function);
   [[nodiscard]] bool ContainsFrameTrack(const orbit_client_protos::FunctionInfo& function) const;

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -102,7 +102,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void OnCaptureStarted(
       ProcessData&& process,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
-      TracepointInfoSet selected_tracepoints) override;
+      TracepointInfoSet selected_tracepoints,
+      UserDefinedCaptureData user_defined_capture_data) override;
   void OnCaptureComplete() override;
   void OnCaptureCancelled() override;
   void OnCaptureFailed(ErrorMessage error_message) override;
@@ -329,6 +330,9 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
 
   ErrorMessageOr<void> SavePreset(const std::string& filename);
   [[nodiscard]] ScopedStatus CreateScopedStatus(const std::string& initial_message);
+
+  void AddFrameTrackTimers(const orbit_client_protos::FunctionInfo& function);
+  void RefreshFrameTracks();
 
   ApplicationOptions options_;
 

--- a/OrbitGl/DataManager.h
+++ b/OrbitGl/DataManager.h
@@ -12,6 +12,7 @@
 #include "OrbitClientData/ProcessData.h"
 #include "TextBox.h"
 #include "TracepointCustom.h"
+#include "UserDefinedCaptureData.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/container/node_hash_map.h"
@@ -53,6 +54,13 @@ class DataManager final {
 
   [[nodiscard]] const TracepointInfoSet& selected_tracepoints() const;
 
+  void set_user_defined_capture_data(const UserDefinedCaptureData& user_defined_capture_data) {
+    user_defined_capture_data_ = user_defined_capture_data;
+  }
+  [[nodiscard]] const UserDefinedCaptureData& user_defined_capture_data() const {
+    return user_defined_capture_data_;
+  }
+
  private:
   const std::thread::id main_thread_id_;
   // We are sharing pointers to that entries and ensure reference stability by using node_hash_map
@@ -66,6 +74,10 @@ class DataManager final {
   const TextBox* selected_text_box_ = nullptr;
 
   const ProcessData* selected_process_ = nullptr;
+
+  // DataManager needs a copy of this so that we can persist user choices like frame tracks between
+  // captures.
+  UserDefinedCaptureData user_defined_capture_data_;
 };
 
 #endif  // ORBIT_GL_DATA_MANAGER_H_


### PR DESCRIPTION
Frame tracks are now serialized when saving captures and are properly
deserialized when loading a capture. The user choice of a frame track
is also persisted between captures, that is, when a user selects a
function as a frame track, and takes a new capture, the frame track
is properly added at the end of the capture (what is still missing
are live updates to the frame track during capture).

Bug: http://b/171026228
Tested: Unit tests; manual tests (capture/save/load, etc.)