### PR TITLE
Text is no longer rendered in picking mode

### DIFF
--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -520,8 +520,10 @@ void CaptureWindow::Draw() {
     ui_batcher_.DrawLayer(layer, GetPickingMode() != PickingMode::kNone);
 
     PrepareScreenSpaceViewport();
-    text_renderer_.DisplayLayer(&ui_batcher_, layer);
-    RenderText(layer);
+    if (GetPickingMode() == PickingMode::kNone) {
+      text_renderer_.DisplayLayer(&ui_batcher_, layer);
+      RenderText(layer);
+    }
   }
 }
 
@@ -692,7 +694,7 @@ void CaptureWindow::RenderImGui() {
 }
 
 void CaptureWindow::RenderText(float layer) {
-  if (!picking_) {
+  if (GetPickingMode() == PickingMode::kNone) {
     time_graph_.DrawText(this, layer);
   }
 }


### PR DESCRIPTION
The text renderers do not know about picking, so adding text during picking-mode
leads to crashes.

Before, it was the developers' responsibility to not add any text to the renderers when
in picking mode, which is easy to forget and lead to crashes in the past. CaptureWindow
now makes sure that even if text was added to the renderers, it is not drawn while in
picking mode.

Bug: b/170308628