### PR TITLE
Only allow one Capture at a time in CaptureServiceImpl

### DIFF
--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
@@ -62,7 +62,7 @@ class CaptureClient {
                TracepointInfoSet selected_tracepoints,
                UserDefinedCaptureData user_defined_capture_data, bool enable_introspection);
 
-  void FinishCapture();
+  [[nodiscard]] ErrorMessageOr<void> FinishCapture();
 
   std::unique_ptr<orbit_grpc_protos::CaptureService::Stub> capture_service_;
   std::unique_ptr<grpc::ClientContext> client_context_;

--- a/OrbitService/CaptureServiceImpl.h
+++ b/OrbitService/CaptureServiceImpl.h
@@ -15,6 +15,9 @@ class CaptureServiceImpl final : public orbit_grpc_protos::CaptureService::Servi
       grpc::ServerContext* context,
       grpc::ServerReaderWriter<orbit_grpc_protos::CaptureResponse,
                                orbit_grpc_protos::CaptureRequest>* reader_writer) override;
+
+ private:
+  std::atomic<bool> is_capturing = false;
 };
 
 }  // namespace orbit_service


### PR DESCRIPTION
Also handle the `grpc::Status` returned by `Capture`.

The assumption of only one capture active at a time is in preparation of further
changes to `OrbitService` for the communication with the Vulkan layer.

As much as having a completely stateless `CaptureService` sounds nice:
- In the released version where the service is deployed, the fact that only
  one client at a time is connected to the service already enforces this,
  albeit by the client. Multiple captures in parallel are only possible when
  manually connecting to an already-started service.
- Even when it's possible to start multiple captures in parallel, they heavily
  interfere with each other: it's just better to diplay an error instead.