### PR TITLE
Live updates to frame tracks during a capture

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -24,6 +24,7 @@
 #include "CoreUtils.h"
 #include "Disassembler.h"
 #include "DisassemblyReport.h"
+#include "FrameTrackOnlineProcessor.h"
 #include "FunctionsDataView.h"
 #include "GlCanvas.h"
 #include "ImGuiOrbit.h"
@@ -141,6 +142,8 @@ void OrbitApp::OnCaptureStarted(ProcessData&& process,
             CaptureData(std::move(process), module_manager_.get(), std::move(selected_functions),
                         std::move(selected_tracepoints), std::move(user_defined_capture_data));
 
+        frame_track_online_processor_ = FrameTrackOnlineProcessor(capture_data_, GCurrentTimeGraph);
+
         CHECK(capture_started_callback_);
         capture_started_callback_();
 
@@ -216,6 +219,7 @@ void OrbitApp::OnTimer(const TimerInfo& timer_info) {
     uint64_t elapsed_nanos = timer_info.end() - timer_info.start();
     capture_data_.UpdateFunctionStats(func, elapsed_nanos);
     GCurrentTimeGraph->ProcessTimer(timer_info, &func);
+    frame_track_online_processor_.ProcessTimer(timer_info, func);
   } else {
     GCurrentTimeGraph->ProcessTimer(timer_info, nullptr);
   }

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -25,6 +25,7 @@
 #include "DataViewTypes.h"
 #include "DisassemblyReport.h"
 #include "FramePointerValidatorClient.h"
+#include "FrameTrackOnlineProcessor.h"
 #include "FunctionsDataView.h"
 #include "ImGuiOrbit.h"
 #include "LiveFunctionsDataView.h"
@@ -405,6 +406,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   //  CaptureListener parts of App, but may be read also during capturing by all threads.
   //  Currently, it is not properly synchronized (and thus it can't live at DataManager).
   CaptureData capture_data_;
+
+  FrameTrackOnlineProcessor frame_track_online_processor_;
 };
 
 extern std::unique_ptr<OrbitApp> GOrbitApp;

--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(
          EventTrack.h
          FramePointerValidatorClient.h
          FrameTrack.h
+         FrameTrackOnlineProcessor.h
          FunctionsDataView.h
          Geometry.h
          GlCanvas.h
@@ -78,6 +79,7 @@ target_sources(
           EventTrack.cpp
           FramePointerValidatorClient.cpp
           FrameTrack.cpp
+          FrameTrackOnlineProcessor.cpp
           LiveFunctionsController.cpp
           FunctionsDataView.cpp
           GlCanvas.cpp

--- a/OrbitGl/FrameTrack.h
+++ b/OrbitGl/FrameTrack.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef ORBIT_GL_DELTA_TRACK_H_
-#define ORBIT_GL_DELTA_TRACK_H_
+#ifndef ORBIT_GL_FRAME_TRACK_H_
+#define ORBIT_GL_FRAME_TRACK_H_
 
 #include "TimerTrack.h"
 
@@ -45,4 +45,4 @@ class FrameTrack : public TimerTrack {
   orbit_client_protos::FunctionStats stats_;
 };
 
-#endif  // ORBIT_GL_THREAD_TRACK_H_
+#endif  // ORBIT_GL_FRAME_TRACK_H_

--- a/OrbitGl/FrameTrackOnlineProcessor.cpp
+++ b/OrbitGl/FrameTrackOnlineProcessor.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "FrameTrackOnlineProcessor.h"
+
+#include <limits>
+
+#include "CaptureData.h"
+#include "TimeGraph.h"
+#include "UserDefinedCaptureData.h"
+
+FrameTrackOnlineProcessor::FrameTrackOnlineProcessor(const CaptureData& capture_data,
+                                                     TimeGraph* time_graph)
+    : time_graph_(time_graph) {
+  const UserDefinedCaptureData& user_defined_capture_data =
+      capture_data.user_defined_capture_data();
+  for (const auto& function : user_defined_capture_data.frame_track_functions()) {
+    const uint64_t function_address = capture_data.GetAbsoluteAddress(function);
+    current_frame_track_functions_.insert(function_address);
+    previous_timestamp_ns_.insert(
+        std::make_pair(function_address, std::numeric_limits<uint64_t>::max()));
+  }
+}
+
+void FrameTrackOnlineProcessor::ProcessTimer(const orbit_client_protos::TimerInfo& timer_info,
+                                             const orbit_client_protos::FunctionInfo& function) {
+  uint64_t function_address = timer_info.function_address();
+  if (!current_frame_track_functions_.contains(function_address)) {
+    return;
+  }
+  uint64_t previous_timestamp_ns = previous_timestamp_ns_.at(function_address);
+  if (previous_timestamp_ns == std::numeric_limits<uint64_t>::max()) {
+    previous_timestamp_ns_[function_address] = timer_info.start();
+    return;
+  }
+
+  if (previous_timestamp_ns < timer_info.start()) {
+    orbit_client_protos::TimerInfo frame_timer;
+
+    // TID is meaningless for this timer (start and end can be on two different threads).
+    constexpr const int32_t kUnusedThreadId = -1;
+    frame_timer.set_thread_id(kUnusedThreadId);
+    frame_timer.set_start(previous_timestamp_ns);
+    frame_timer.set_end(timer_info.start());
+    // We use user_data_key to keep track of the frame number.
+    frame_timer.set_user_data_key(current_frame_index_++);
+    frame_timer.set_type(orbit_client_protos::TimerInfo::kFrame);
+
+    time_graph_->ProcessTimer(frame_timer, &function);
+
+    previous_timestamp_ns_[function_address] = timer_info.start();
+  }
+}

--- a/OrbitGl/FrameTrackOnlineProcessor.h
+++ b/OrbitGl/FrameTrackOnlineProcessor.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_FRAME_TRACK_ONLINE_PROCESSOR_H_
+#define ORBIT_GL_FRAME_TRACK_ONLINE_PROCESSOR_H_
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "capture_data.pb.h"
+class CaptureData;
+class TimeGraph;
+
+// FrameTrackOnlineProcessor is used to create frame track timers during a capture.
+class FrameTrackOnlineProcessor {
+ public:
+  FrameTrackOnlineProcessor() : time_graph_(nullptr) {}
+  FrameTrackOnlineProcessor(const CaptureData& capture_data, TimeGraph* time_graph);
+  void ProcessTimer(const orbit_client_protos::TimerInfo& timer_info,
+                    const orbit_client_protos::FunctionInfo& function);
+
+ private:
+  absl::flat_hash_set<uint64_t> current_frame_track_functions_;
+  absl::flat_hash_map<uint64_t, uint64_t> previous_timestamp_ns_;
+
+  TimeGraph* time_graph_;
+  int current_frame_index_ = 0;
+};
+
+#endif  // ORBIT_GL_FRAME_TRACK_ONLINE_PROCESSOR_H_


### PR DESCRIPTION
We now update frame tracks live during a capture by processing each
timer that belongs to a function call, creating a frame track timer
from its timestamp and the previously encountered timestamp for this
function call.

Note that timers may arrive out of order, in particular when a frame
track function was chosen that is called from multiple threads. During
live capture we do not correct for this, but at the end of the capture,
the entire frame track is refreshed to correct any mistakes made during
capture.

Bug: http://b/173100696
Tested: Unit tests; various manual tests, including serialization of
frame tracks.