### PR TITLE
Fix crash when dragging a thread state track

### DIFF
--- a/OrbitGl/ThreadStateTrack.h
+++ b/OrbitGl/ThreadStateTrack.h
@@ -22,6 +22,7 @@ class ThreadStateTrack final : public Track {
                         float z_offset) override;
 
   void OnPick(int x, int y) override;
+  void OnDrag(int, int) override {}
   void OnRelease() override { picked_ = false; };
   float GetHeight() const override { return size_[1]; }
 


### PR DESCRIPTION
Only when you have enabled track_ordering_feature, this class inherit
OnDrag from Track and crashed.

Related to b/173093860.