### PR TITLE
[Draft] Optimize buffer handling in OrbitSshQt

### DIFF
--- a/OrbitSshQt/Tunnel.cpp
+++ b/OrbitSshQt/Tunnel.cpp
@@ -221,7 +221,7 @@ void Tunnel::SetError(std::error_code e) {
 // local_socket -> write_buffer_
 void Tunnel::HandleIncomingDataLocalSocket() {
   const auto data = local_socket_->readAll();
-  write_buffer_.append(data.toStdString());
+  write_buffer_.insert(write_buffer_.end(), data.begin(), data.end());
 
   const auto result = writeToChannel();
 


### PR DESCRIPTION
This is based on #1442. Only the last two commits belong to this PR.

@pierricgimmig pointed out that tunnel processing logic makes unnecessary copies.
This fixes that by removing temporaries and replacing std::string::substr by memmove.