### PR TITLE
Remove wrong CHECK in ServiceDeployManager

### DIFF
--- a/OrbitQt/servicedeploymanager.cpp
+++ b/OrbitQt/servicedeploymanager.cpp
@@ -246,7 +246,6 @@ outcome::result<void> ServiceDeployManager::CopyOrbitServicePackage() {
 
 ErrorMessageOr<void> ServiceDeployManager::CopyFileToLocal(std::string source,
                                                            std::string destination) {
-  CHECK(QThread::currentThread() == thread());
   ErrorMessageOr<void> result = outcome::success();
   DeferToBackgroundThreadAndWait(
       this, [&, source = std::move(source), destination = std::move(destination)]() {


### PR DESCRIPTION
CopyFileToLocal is intended to be called from a different thread, so the
CHECK shouldn't be there. (Copy-and-paste error).