### PR TITLE
Update dependencies in lockfile

### DIFF
--- a/third_party/conan/lockfiles/base.lock
+++ b/third_party/conan/lockfiles/base.lock
@@ -566,7 +566,7 @@
     "context": "host"
    },
    "65": {
-    "ref": "pcre2/10.33#0",
+    "ref": "pcre2/10.33#54adea8f4f46f14720b65849988c274a",
     "requires": [
      "6",
      "3"
@@ -609,7 +609,7 @@
     "context": "host"
    },
    "71": {
-    "ref": "double-conversion/3.1.5#0",
+    "ref": "double-conversion/3.1.5#bf7fceaa33f97d13a341039f49a5ec8f",
     "context": "host"
    },
    "72": {


### PR DESCRIPTION
The official conan-center remote does not contain packages without
revisions anymore. So we should also switch our dependencies to
revisions-enabled ones. Otherwise the external build will be broken.

Bug: http://b/172125379