### PR TITLE
Don't clamp process cpu usage to 100%

### DIFF
--- a/OrbitService/Process.h
+++ b/OrbitService/Process.h
@@ -15,7 +15,7 @@ class Process : public orbit_grpc_protos::ProcessInfo {
  public:
   using orbit_grpc_protos::ProcessInfo::ProcessInfo;
 
-  void UpdateCpuUsage(utils::Jiffies process_cpu_time, utils::Jiffies total_cpu_time);
+  void UpdateCpuUsage(utils::Jiffies process_cpu_time, utils::TotalCpuTime total_cpu_time);
 
   // Creates a `Process` by reading details from the `/proc` filesystem.
   // This might fail due to a non existing pid or due to permission problems.

--- a/OrbitService/ProcessListTest.cpp
+++ b/OrbitService/ProcessListTest.cpp
@@ -22,7 +22,8 @@ TEST(ProcessList, ProcessList) {
   const auto total_cpu_cycles = utils::GetCumulativeTotalCpuTime().value();
 
   // We wait until the stats have been updated
-  while (utils::GetCumulativeTotalCpuTime().value().value == total_cpu_cycles.value) {
+  while (utils::GetCumulativeTotalCpuTime().value().jiffies.value ==
+         total_cpu_cycles.jiffies.value) {
     // If this loop never ends it will be caught by the automatic timeout feature
     usleep(10'000);
   }

--- a/OrbitService/ServiceUtils.h
+++ b/OrbitService/ServiceUtils.h
@@ -32,7 +32,15 @@ struct Jiffies {
   uint64_t value;
 };
 
-std::optional<Jiffies> GetCumulativeTotalCpuTime();
+struct TotalCpuTime {
+  // jiffies is the sum over all cycles executed on all cores.
+  Jiffies jiffies;
+
+  // cpus is the number of (logical) cores available and accumulated in jiffies.
+  size_t cpus;
+};
+
+std::optional<TotalCpuTime> GetCumulativeTotalCpuTime();
 std::optional<Jiffies> GetCumulativeCpuTimeFromProcess(pid_t pid);
 
 ErrorMessageOr<Path> GetExecutablePath(int32_t pid);

--- a/OrbitService/ServiceUtilsTest.cpp
+++ b/OrbitService/ServiceUtilsTest.cpp
@@ -101,15 +101,17 @@ TEST(ServiceUtils, GetCumulativeTotalCpuTime) {
   // We know the optional should return a value and we know it's positive and
   // monotonically increasing.
 
-  const auto& jiffies1 = GetCumulativeTotalCpuTime();
-  ASSERT_TRUE(jiffies1.has_value());
-  ASSERT_TRUE(jiffies1->value > 0ul);
+  const auto& total_cpu_time1 = GetCumulativeTotalCpuTime();
+  ASSERT_TRUE(total_cpu_time1.has_value());
+  ASSERT_TRUE(total_cpu_time1->jiffies.value > 0ul);
+  ASSERT_TRUE(total_cpu_time1->cpus > 0ul);
 
-  const auto& jiffies2 = GetCumulativeTotalCpuTime();
-  ASSERT_TRUE(jiffies2.has_value());
-  ASSERT_TRUE(jiffies2->value > 0ul);
+  const auto& total_cpu_time2 = GetCumulativeTotalCpuTime();
+  ASSERT_TRUE(total_cpu_time2.has_value());
+  ASSERT_TRUE(total_cpu_time2->jiffies.value > 0ul);
+  ASSERT_TRUE(total_cpu_time2->cpus == total_cpu_time1->cpus);
 
-  ASSERT_TRUE(jiffies2->value >= jiffies1->value);
+  ASSERT_TRUE(total_cpu_time2->jiffies.value >= total_cpu_time1->jiffies.value);
 }
 
 TEST(ServiceUtils, GetCumulativeCpuTimeFromProcess) {
@@ -121,12 +123,12 @@ TEST(ServiceUtils, GetCumulativeCpuTimeFromProcess) {
 
   ASSERT_TRUE(jiffies2->value >= jiffies1->value);
 
-  const auto& jiffies_total = GetCumulativeTotalCpuTime();
-  ASSERT_TRUE(jiffies_total.has_value());
-  ASSERT_TRUE(jiffies_total->value > 0ul);
+  const auto& total_cpu_time = GetCumulativeTotalCpuTime();
+  ASSERT_TRUE(total_cpu_time.has_value());
+  ASSERT_TRUE(total_cpu_time->jiffies.value > 0ul);
 
   // A single process should never have consumed more CPU cycles than the total CPU time
-  ASSERT_TRUE(jiffies2->value <= jiffies_total->value);
+  ASSERT_TRUE(jiffies2->value <= total_cpu_time->jiffies.value);
 }
 
 TEST(ServiceUtils, GetExecutablePath) {


### PR DESCRIPTION
A process's cpu usage is considered 100% when it fully occupies a single
logical core. This means a process can easily reach more than 100% cpu
usage by performing tasks on different cores in parallel.

This was not properly handled in the new process utility code which used
to clamp to 100%. This commit fixes that.

Test: Manual test with Trata
Bug: http://b/172332478