### PR TITLE
Move the view when dragging a track to the border

### DIFF
--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -614,6 +614,12 @@ void CaptureWindow::UpdateVerticalSliderFromWorld() {
   vertical_slider_->SetOrthogonalSliderPixelHeight(slider_->GetPixelHeight());
 }
 
+void CaptureWindow::UpdateWorldTopLeftY(float val) {
+  float min_world_top_left = GetWorldHeight() - time_graph_.GetThreadTotalHeight();
+  GlCanvas::UpdateWorldTopLeftY(clamp(val, min_world_top_left, GetWorldMaxY()));
+  NeedsUpdate();
+}
+
 void CaptureWindow::ToggleDrawHelp() { set_draw_help(!draw_help_); }
 
 void CaptureWindow::set_draw_help(bool draw_help) {

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -53,6 +53,7 @@ class CaptureWindow : public GlCanvas {
   void UpdateHorizontalZoom(float normalized_start, float normalized_end);
   void UpdateVerticalSliderFromWorld();
   void UpdateHorizontalSliderFromWorld();
+  void UpdateWorldTopLeftY(float val) override;
 
   void NeedsUpdate();
   void OnCaptureStarted();

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -67,9 +67,10 @@ class GlCanvas {
 
   float GetWorldWidth() const { return world_width_; }
   float GetWorldHeight() const { return world_height_; }
+  float GetWorldMaxY() const { return world_max_y_; }
   float GetWorldTopLeftX() const { return world_top_left_x_; }
   float GetWorldTopLeftY() const { return world_top_left_y_; }
-  void SetWorldTopLeftY(float val) { world_top_left_y_ = val; }
+  virtual void UpdateWorldTopLeftY(float val) { world_top_left_y_ = val; }
 
   TextRenderer& GetTextRenderer() { return text_renderer_; }
   uint32_t GetInitialFontSize() const { return initial_font_size_; }

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -18,7 +18,7 @@ using orbit_client_protos::TimerInfo;
 const Color kInactiveColor(100, 100, 100, 255);
 const Color kSelectionColor(0, 128, 255, 255);
 
-SchedulerTrack::SchedulerTrack(TimeGraph* time_graph) : TimerTrack(time_graph) { SetPinned(true); }
+SchedulerTrack::SchedulerTrack(TimeGraph* time_graph) : TimerTrack(time_graph) { SetPinned(false); }
 
 float SchedulerTrack::GetHeight() const {
   TimeGraphLayout& layout = time_graph_->GetLayout();

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -81,6 +81,8 @@ class TimeGraph {
                                 const orbit_client_protos::TimerInfo& timer_info,
                                 double distance = 0.3);
   void VerticallyMoveIntoView(const orbit_client_protos::TimerInfo& timer_info);
+  void VerticallyMoveIntoView(Track& track);
+
   [[nodiscard]] double GetTime(double ratio) const;
   void Select(const TextBox* text_box);
   enum class JumpScope { kGlobal, kSameDepth, kSameThread, kSameFunction, kSameThreadSameFunction };

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -241,5 +241,6 @@ void Track::OnDrag(int a_X, int a_Y) {
   canvas_->ScreenToWorld(a_X, a_Y, x, pos_[1]);
   mouse_pos_[1] = pos_;
   pos_[1] -= picking_offset_[1];
+  time_graph_->VerticallyMoveIntoView(*this);
   time_graph_->NeedsUpdate();
 }


### PR DESCRIPTION
Before this, we couldn't move a track behind or above to some track that
wasn't in the screen. Now if we drag a track to the top or to the
bottom, the view is going to move.

Also, we refactored and renamed UpdateTopLeftY so each time that we update
where is the topY on the screen, we check that fits in the min-max range
of the slider.

Lastly, temporarily we don't pin the scheduler track. 