### PR TITLE
Support saving and loading frame tracks as part of presets

### DIFF
--- a/OrbitClientProtos/preset.proto
+++ b/OrbitClientProtos/preset.proto
@@ -8,6 +8,7 @@ package orbit_client_protos;
 
 message PresetModule {
   repeated uint64 function_hashes = 1;
+  repeated uint64 frame_track_function_hashes = 2;
 }
 
 message PresetInfo {

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -256,7 +256,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
 
   void LoadModules(
       const std::vector<ModuleData*>& modules,
-      absl::flat_hash_map<std::string, std::vector<uint64_t>> function_hashes_to_hook_map = {});
+      absl::flat_hash_map<std::string, std::vector<uint64_t>> function_hashes_to_hook_map = {},
+      absl::flat_hash_map<std::string, std::vector<uint64_t>> frame_track_function_hashes_map = {});
   void UpdateProcessAndModuleList(int32_t pid);
 
   void UpdateAfterSymbolLoading();
@@ -321,9 +322,11 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   ErrorMessageOr<std::filesystem::path> FindSymbolsLocally(const std::filesystem::path& module_path,
                                                            const std::string& build_id);
   void LoadSymbols(const std::filesystem::path& symbols_path, ModuleData* module_data,
-                   std::vector<uint64_t> function_hashes_to_hook);
+                   std::vector<uint64_t> function_hashes_to_hook,
+                   std::vector<uint64_t> frame_track_function_hashes);
 
-  void LoadModuleOnRemote(ModuleData* module_data, std::vector<uint64_t> function_hashes_to_hook);
+  void LoadModuleOnRemote(ModuleData* module_data, std::vector<uint64_t> function_hashes_to_hook,
+                          std::vector<uint64_t> frame_track_function_hashes);
   ErrorMessageOr<void> SelectFunctionsFromHashes(const ModuleData* module,
                                                  const std::vector<uint64_t>& function_hashes);
 
@@ -332,6 +335,12 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   ErrorMessageOr<void> SavePreset(const std::string& filename);
   [[nodiscard]] ScopedStatus CreateScopedStatus(const std::string& initial_message);
 
+  ErrorMessageOr<void> GetFunctionInfosFromHashes(
+      const ModuleData* module, const std::vector<uint64_t>& function_hashes,
+      std::vector<const orbit_client_protos::FunctionInfo*>* function_infos);
+
+  ErrorMessageOr<void> InsertFrameTracksFromHashes(const ModuleData* module,
+                                                   const std::vector<uint64_t> function_hashes);
   void AddFrameTrackTimers(const orbit_client_protos::FunctionInfo& function);
   void RefreshFrameTracks();
 


### PR DESCRIPTION
Frame tracks based on hooked functions are now also stored in and
loaded from presets.

Bug: http://b/173490995

Tested: Manual tests: load/save presets with frame tracks; load/save
presets without frame tracks, both during different states of Orbit
including before and after capture.