### PR TITLE
Add logging to GetModuleList.

### DIFF
--- a/OrbitService/ProcessServiceImpl.cpp
+++ b/OrbitService/ProcessServiceImpl.cpp
@@ -61,7 +61,9 @@ Status ProcessServiceImpl::GetModuleList(ServerContext* /*context*/,
     return Status(StatusCode::NOT_FOUND, module_infos.error().message());
   }
 
+  LOG("Construct response containing %d modules.", module_infos.value().size());
   for (const auto& module_info : module_infos.value()) {
+    LOG("Add module: %s", module_info.name());
     *(response->add_modules()) = module_info;
   }
 

--- a/OrbitService/ServiceUtils.cpp
+++ b/OrbitService/ServiceUtils.cpp
@@ -62,6 +62,7 @@ ErrorMessageOr<std::vector<ModuleInfo>> ParseMaps(std::string_view proc_maps_dat
     uint64_t end_address;
     bool is_executable;
   };
+
   const std::vector<std::string> proc_maps = absl::StrSplit(proc_maps_data, '\n');
 
   LOG("Build address map.");


### PR DESCRIPTION
There might be an issue in the code collecting the information about
the modules. Occationally the request fails in the e2e tests due to an
exceeded deadline in the grpc communication.
This logging is a bit too much for my taste so I filed
http://b/173498020 to clean it up after the underlying bug is fixed.

Bug: http://b/173358603
Test: Ran locally, logging looks helpful now.