### PR TITLE
Manual instrumentation API fixes

### DIFF
--- a/Orbit.h
+++ b/Orbit.h
@@ -282,7 +282,7 @@ enum class Color : uint32_t {
 
 #if defined(_WIN32)
 #define ORBIT_STUB inline __declspec(noinline)
-#define ORBIT_FORCE_INLINE __declspec(__forceinline)
+#define ORBIT_FORCE_INLINE __forceinline
 #else
 #define ORBIT_STUB inline __attribute__((noinline))
 #define ORBIT_FORCE_INLINE __attribute__((always_inline))

--- a/Orbit.h
+++ b/Orbit.h
@@ -280,10 +280,12 @@ enum class Color : uint32_t {
 #define ORBIT_TRACK(type, name, val, col) \
   orbit_api::TrackValue(type, name, orbit_api::Encode<uint64_t>(val), col)
 
-#if _WIN32
+#if defined(_WIN32)
 #define ORBIT_STUB inline __declspec(noinline)
+#define ORBIT_FORCE_INLINE __declspec(__forceinline)
 #else
 #define ORBIT_STUB inline __attribute__((noinline))
+#define ORBIT_FORCE_INLINE __attribute__((always_inline))
 #endif
 
 namespace orbit_api {
@@ -343,33 +345,34 @@ union EncodedEvent {
 };
 
 template <typename Dest, typename Source>
-inline Dest Encode(const Source& source) {
-  static_assert(sizeof(Source) <= sizeof(Dest));
+ORBIT_FORCE_INLINE Dest Encode(const Source& source) {
+  static_assert(sizeof(Source) <= sizeof(Dest), "orbit_api::Encode destination type is too small");
   Dest dest = 0;
   std::memcpy(&dest, &source, sizeof(Source));
   return dest;
 }
 
 template <typename Dest, typename Source>
-inline Dest Decode(const Source& source) {
-  static_assert(sizeof(Dest) <= sizeof(Source));
+ORBIT_FORCE_INLINE Dest Decode(const Source& source) {
+  static_assert(sizeof(Dest) <= sizeof(Source), "orbit_api::Decode destination type is too big");
   Dest dest = 0;
   std::memcpy(&dest, &source, sizeof(Dest));
   return dest;
 }
 
 // Used to prevent compiler from stripping out empty function.
-inline void Noop() {
-  static volatile int x;
-  x;
-}
+#define ORB_NOOP           \
+  do {                     \
+    static volatile int x; \
+    x;                     \
+  } while (0)
 
 // The stub functions below are automatically dynamically instrumented.
-ORBIT_STUB void Start(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) { Noop(); }
-ORBIT_STUB void Stop(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) { Noop(); }
-ORBIT_STUB void StartAsync(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) { Noop(); }
-ORBIT_STUB void StopAsync(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) { Noop(); }
-ORBIT_STUB void TrackValue(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) { Noop(); }
+ORBIT_STUB void Start(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) { ORB_NOOP; }
+ORBIT_STUB void Stop(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) { ORB_NOOP; }
+ORBIT_STUB void StartAsync(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) { ORB_NOOP; }
+ORBIT_STUB void StopAsync(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) { ORB_NOOP; }
+ORBIT_STUB void TrackValue(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t) { ORB_NOOP; }
 
 // NOTE: Do not use these directly, use corresponding macros instead.
 #ifndef ORBIT_API_INTERNAL_IMPL
@@ -379,27 +382,27 @@ constexpr const char* kNameNullPtr = nullptr;
 constexpr uint64_t kDataZero = 0;
 constexpr orbit::Color kColorAuto = orbit::Color::kAuto;
 
-inline void Start(const char* name, orbit::Color color) {
+ORBIT_FORCE_INLINE void Start(const char* name, orbit::Color color) {
   EncodedEvent e(EventType::kScopeStart, name, kDataZero, color);
   Start(e.args[0], e.args[1], e.args[2], e.args[3], e.args[4], e.args[5]);
 }
 
-inline void Stop() {
+ORBIT_FORCE_INLINE void Stop() {
   EncodedEvent e(EventType::kScopeStop);
   Stop(e.args[0], e.args[1], e.args[2], e.args[3], e.args[4], e.args[5]);
 }
 
-inline void StartAsync(const char* name, uint64_t id, orbit::Color color) {
+ORBIT_FORCE_INLINE void StartAsync(const char* name, uint64_t id, orbit::Color color) {
   EncodedEvent e(EventType::kScopeStartAsync, name, id, color);
   StartAsync(e.args[0], e.args[1], e.args[2], e.args[3], e.args[4], e.args[5]);
 }
 
-inline void StopAsync(uint64_t id) {
+ORBIT_FORCE_INLINE void StopAsync(uint64_t id) {
   EncodedEvent e(EventType::kScopeStopAsync, kNameNullPtr, id, kColorAuto);
   StopAsync(e.args[0], e.args[1], e.args[2], e.args[3], e.args[4], e.args[5]);
 }
 
-inline void AsyncString(const char* str, uint64_t id, orbit::Color color) {
+ORBIT_FORCE_INLINE void AsyncString(const char* str, uint64_t id, orbit::Color color) {
   if (str == nullptr) return;
   constexpr size_t chunk_size = kMaxEventStringSize - 1;
   const char* end = str + strlen(str);
@@ -412,7 +415,8 @@ inline void AsyncString(const char* str, uint64_t id, orbit::Color color) {
   }
 }
 
-inline void TrackValue(EventType type, const char* name, uint64_t value, orbit::Color color) {
+ORBIT_FORCE_INLINE void TrackValue(EventType type, const char* name, uint64_t value,
+                                   orbit::Color color) {
   EncodedEvent e(type, name, value, color);
   TrackValue(e.args[0], e.args[1], e.args[2], e.args[3], e.args[4], e.args[5]);
 }
@@ -423,7 +427,7 @@ void Start(const char* name, orbit::Color color);
 void Stop();
 void StartAsync(const char* name, uint64_t id, orbit::Color color);
 void StopAsync(uint64_t id);
-void AsyncString(const char* str, uint64_t id);
+void AsyncString(const char* str, uint64_t id, orbit::Color color);
 void TrackValue(EventType type, const char* name, uint64_t value, orbit::Color color);
 
 #endif  // ORBIT_API_INTERNAL_IMPL

--- a/OrbitBase/OrbitApiTest.cpp
+++ b/OrbitBase/OrbitApiTest.cpp
@@ -4,7 +4,7 @@
 
 #include <gtest/gtest.h>
 
-#include "../Orbit.h"
+#include "OrbitBase/Tracing.h"
 
 static orbit_api::Event Decode(uint64_t a1, uint64_t a2, uint64_t a3, uint64_t a4, uint64_t a5,
                                uint64_t a6) {

--- a/OrbitBase/Tracing.cpp
+++ b/OrbitBase/Tracing.cpp
@@ -103,6 +103,20 @@ void StopAsync(uint64_t id) {
   Listener::DeferScopeProcessing(scope);
 }
 
+void AsyncString(const char* str, uint64_t id, orbit::Color color) {
+  if (str == nullptr) return;
+  orbit::tracing::Scope scope(orbit_api::kString, /*name*/ nullptr, id, color);
+  auto& e = scope.encoded_event;
+  constexpr size_t chunk_size = kMaxEventStringSize - 1;
+  const char* end = str + strlen(str);
+  while (str < end) {
+    std::strncpy(e.event.name, str, chunk_size);
+    e.event.name[chunk_size] = 0;
+    Listener::DeferScopeProcessing(scope);
+    str += chunk_size;
+  }
+}
+
 void TrackValue(orbit_api::EventType type, const char* name, uint64_t value, orbit::Color color) {
   orbit::tracing::Scope scope(type, name, value, color);
   scope.begin = MonotonicTimestampNs();

--- a/OrbitCaptureClient/CaptureEventProcessor.cpp
+++ b/OrbitCaptureClient/CaptureEventProcessor.cpp
@@ -4,7 +4,6 @@
 
 #include "OrbitCaptureClient/CaptureEventProcessor.h"
 
-#include "../Orbit.h"
 #include "CoreUtils.h"
 #include "OrbitBase/Tracing.h"
 #include "capture_data.pb.h"

--- a/OrbitGl/ManualInstrumentationManager.h
+++ b/OrbitGl/ManualInstrumentationManager.h
@@ -5,8 +5,8 @@
 #ifndef ORBIT_GL_MANUAL_INSTRUMENTATION_MANAGER_H_
 #define ORBIT_GL_MANUAL_INSTRUMENTATION_MANAGER_H_
 
-#include "../Orbit.h"
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/Tracing.h"
 #include "StringManager.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -4,11 +4,11 @@
 
 #include "ThreadTrack.h"
 
-#include "../Orbit.h"
 #include "App.h"
 #include "GlCanvas.h"
 #include "ManualInstrumentationManager.h"
 #include "OrbitBase/Profiling.h"
+#include "OrbitBase/Tracing.h"
 #include "OrbitClientData/FunctionUtils.h"
 #include "TextBox.h"
 #include "TimeGraph.h"

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -8,7 +8,6 @@
 #include <unordered_map>
 #include <utility>
 
-#include "../Orbit.h"
 #include "AsyncTrack.h"
 #include "Batcher.h"
 #include "BlockChain.h"
@@ -18,6 +17,7 @@
 #include "GraphTrack.h"
 #include "ManualInstrumentationManager.h"
 #include "OrbitBase/Profiling.h"
+#include "OrbitBase/Tracing.h"
 #include "SchedulerTrack.h"
 #include "StringManager.h"
 #include "TextBox.h"

--- a/OrbitTest/OrbitTest.cpp
+++ b/OrbitTest/OrbitTest.cpp
@@ -12,7 +12,7 @@
 #include <sstream>
 #include <thread>
 
-#include "../Orbit.h"
+#include "OrbitBase/Tracing.h"
 #include "absl/strings/str_format.h"
 
 #if __linux__


### PR DESCRIPTION
Orbit.h contains two versions of "orbit_api::Start" style functions.
One is usually inlined and optimized out, leaving only the empty stub
to hook into. In certain configurations, the inlining does not occur and
we have two functions with the same name. Make sure we force inlining to
avoid the problem. This fixes the duplicate scope issue with garbled
strings for manually instrumented functions.

Replace direct internal includes of "Orbit.h" by "OrbitBase/Tracing.h".

Add missing internal implementation of AsyncString(...).

Fix static assert errors for C++ versions <17.

Fix compilation warning when _WIN32 is undefined.

Fixes b/173449243