### PR TITLE
Use std::optional for CaptureData to indicate when it is available

### DIFF
--- a/OrbitClientGgp/include/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/include/OrbitClientGgp/ClientGgp.h
@@ -55,6 +55,14 @@ class ClientGgp final : public CaptureListener {
   void OnTracepointEvent(orbit_client_protos::TracepointEventInfo tracepoint_event_info) override;
 
  private:
+  [[nodiscard]] CaptureData& GetMutableCaptureData() {
+    CHECK(capture_data_.has_value());
+    return capture_data_.value();
+  }
+  [[nodiscard]] const CaptureData& GetCaptureData() const {
+    CHECK(capture_data_.has_value());
+    return capture_data_.value();
+  }
   ClientGgpOptions options_;
   std::shared_ptr<grpc::Channel> grpc_channel_;
   ProcessData target_process_;
@@ -64,7 +72,7 @@ class ClientGgp final : public CaptureListener {
   std::shared_ptr<StringManager> string_manager_;
   std::unique_ptr<CaptureClient> capture_client_;
   std::unique_ptr<ProcessClient> process_client_;
-  CaptureData capture_data_;
+  std::optional<CaptureData> capture_data_;
   std::vector<orbit_client_protos::TimerInfo> timer_infos_;
 
   ErrorMessageOr<ProcessData> GetOrbitProcessByPid(int32_t pid);

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -37,13 +37,6 @@ class CaptureData {
         tracepoint_event_buffer_(std::make_unique<TracepointEventBuffer>()),
         user_defined_capture_data_(std::move(user_defined_capture_data)) {}
 
-  explicit CaptureData()
-      : process_(),
-        callstack_data_(std::make_unique<CallstackData>()),
-        selection_callstack_data_(std::make_unique<CallstackData>()),
-        tracepoint_info_manager_(std::make_unique<TracepointInfoManager>()),
-        tracepoint_event_buffer_(std::make_unique<TracepointEventBuffer>()){};
-
   // We can not copy the unique_ptr, so we can not copy this object.
   CaptureData& operator=(const CaptureData& other) = delete;
   CaptureData(const CaptureData& other) = delete;

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -91,8 +91,16 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void StopCapture();
   void AbortCapture();
   void ClearCapture();
+  bool HasCaptureData() const { return capture_data_.has_value(); }
   void SetCaptureData(CaptureData capture_data) { capture_data_ = std::move(capture_data); }
-  [[nodiscard]] const CaptureData& GetCaptureData() const { return capture_data_; }
+  [[nodiscard]] CaptureData& GetMutableCaptureData() {
+    CHECK(capture_data_.has_value());
+    return capture_data_.value();
+  }
+  [[nodiscard]] const CaptureData& GetCaptureData() const {
+    CHECK(capture_data_.has_value());
+    return capture_data_.value();
+  }
   void ToggleDrawHelp();
   void ToggleCapture();
   void LoadFileMapping();
@@ -414,7 +422,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   // TODO(kuebler): This is mostely written during capture by the capture thread on the
   //  CaptureListener parts of App, but may be read also during capturing by all threads.
   //  Currently, it is not properly synchronized (and thus it can't live at DataManager).
-  CaptureData capture_data_;
+  std::optional<CaptureData> capture_data_;
 
   FrameTrackOnlineProcessor frame_track_online_processor_;
 };

--- a/OrbitGl/DataManager.h
+++ b/OrbitGl/DataManager.h
@@ -57,7 +57,10 @@ class DataManager final {
   void set_user_defined_capture_data(const UserDefinedCaptureData& user_defined_capture_data) {
     user_defined_capture_data_ = user_defined_capture_data;
   }
-  [[nodiscard]] const UserDefinedCaptureData& user_defined_capture_data() const {
+  [[nodiscard]] const UserDefinedCaptureData& mutable_user_defined_capture_data() const {
+    return user_defined_capture_data_;
+  }
+  [[nodiscard]] UserDefinedCaptureData& user_defined_capture_data() {
     return user_defined_capture_data_;
   }
 

--- a/OrbitGl/LiveFunctionsDataView.cpp
+++ b/OrbitGl/LiveFunctionsDataView.cpp
@@ -41,6 +41,9 @@ const std::vector<DataView::Column>& LiveFunctionsDataView::GetColumns() {
 }
 
 std::string LiveFunctionsDataView::GetValue(int row, int column) {
+  if (!GOrbitApp->HasCaptureData()) {
+    return "";
+  }
   if (row >= static_cast<int>(GetNumElements())) {
     return "";
   }
@@ -93,6 +96,10 @@ std::string LiveFunctionsDataView::GetValue(int row, int column) {
   }
 
 void LiveFunctionsDataView::DoSort() {
+  if (!GOrbitApp->HasCaptureData()) {
+    CHECK(functions_.size() == 0);
+    return;
+  }
   bool ascending = sorting_orders_[sorting_column_] == SortingOrder::kAscending;
   std::function<bool(int a, int b)> sorter = nullptr;
 
@@ -279,6 +286,10 @@ void LiveFunctionsDataView::OnContextMenu(const std::string& action, int menu_in
 }
 
 void LiveFunctionsDataView::DoFilter() {
+  if (!GOrbitApp->HasCaptureData()) {
+    CHECK(functions_.size() == 0);
+    return;
+  }
   std::vector<uint32_t> indices;
 
   std::vector<std::string> tokens = absl::StrSplit(ToLower(filter_), ' ');
@@ -315,6 +326,13 @@ void LiveFunctionsDataView::DoFilter() {
 
 void LiveFunctionsDataView::OnDataChanged() {
   functions_.clear();
+  indices_.clear();
+
+  if (!GOrbitApp->HasCaptureData()) {
+    DataView::OnDataChanged();
+    return;
+  }
+
   const absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>& selected_functions =
       GOrbitApp->GetCaptureData().selected_functions();
   size_t functions_count = selected_functions.size();

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -116,7 +116,8 @@ bool TimeGraph::UpdateCaptureMinMaxTimestamps() {
   }
   mutex_.unlock();
 
-  if (GOrbitApp->GetCaptureData().GetCallstackData()->GetCallstackEventsCount() > 0) {
+  if (GOrbitApp->HasCaptureData() &&
+      GOrbitApp->GetCaptureData().GetCallstackData()->GetCallstackEventsCount() > 0) {
     capture_min_timestamp_ = std::min(capture_min_timestamp_,
                                       GOrbitApp->GetCaptureData().GetCallstackData()->min_time());
     capture_max_timestamp_ = std::max(capture_max_timestamp_,
@@ -557,6 +558,10 @@ void TimeGraph::UpdatePrimitives(PickingMode picking_mode) {
 
   batcher_.StartNewFrame();
   text_renderer_static_.Clear();
+
+  if (!GOrbitApp->HasCaptureData()) {
+    return;
+  }
 
   UpdateMaxTimeStamp(GOrbitApp->GetCaptureData().GetCallstackData()->max_time());
 

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -56,6 +56,8 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App,
   DataViewFactory* data_view_factory = GOrbitApp.get();
 
   ui->setupUi(this);
+  // Cannot save a capture as long as no capture has been loaded or captured.
+  ui->actionSave_Capture->setDisabled(true);
 
   ui->ProcessesList->SetDataView(data_view_factory->GetOrCreateDataView(DataViewType::kProcesses));
 
@@ -684,7 +686,10 @@ void OrbitMainWindow::on_actionServiceStackOverflow_triggered() {
   GOrbitApp->CrashOrbitService(CrashOrbitServiceRequest_CrashType_STACK_OVERFLOW);
 }
 
-void OrbitMainWindow::OnCaptureCleared() { ui->liveFunctions->Reset(); }
+void OrbitMainWindow::OnCaptureCleared() {
+  ui->liveFunctions->Reset();
+  ui->actionSave_Capture->setDisabled(true);
+}
 
 void OrbitMainWindow::closeEvent(QCloseEvent* event) {
   if (GOrbitApp->IsCapturing()) {


### PR DESCRIPTION
We have relied on CaptureData to be empty in a sane way when no actual
capture data is available, for example, we draw empty captures and we
save empty captures, even when no capture was loaded or captured.

We now use std::optional to indicate whether actual capture data is
available and react accordingly when drawing, updating, and saving
captures. That is, in particular when no capture data is available,
these actions are skipped or not allowed (users now cannot save anymore
when no capture is available).

This is mainly a refactor, but some user visible changes were needed to
disallow saving captures when no capture is available.

Tested: Ran unit tests; lots of manual testing with loading/saving/
capturing profiles, etc.