### PR TITLE
Put Mock Class in an Anonymous Namespace

### DIFF
--- a/OrbitVulkanLayer/DeviceManagerTest.cpp
+++ b/OrbitVulkanLayer/DeviceManagerTest.cpp
@@ -18,7 +18,7 @@ class MockDispatchTable {
               (VkPhysicalDevice dispatchable_object));
 };
 
-}  //  namespace
+}  // namespace
 
 TEST(DeviceManager, AnUntrackedDeviceCannotBeQueried) {
   MockDispatchTable dispatch_table;

--- a/OrbitVulkanLayer/DeviceManagerTest.cpp
+++ b/OrbitVulkanLayer/DeviceManagerTest.cpp
@@ -10,11 +10,15 @@ using ::testing::Return;
 
 namespace orbit_vulkan_layer {
 
+namespace {
+
 class MockDispatchTable {
  public:
   MOCK_METHOD(PFN_vkGetPhysicalDeviceProperties, GetPhysicalDeviceProperties,
               (VkPhysicalDevice dispatchable_object));
 };
+
+}  //  namespace
 
 TEST(DeviceManager, AnUntrackedDeviceCannotBeQueried) {
   MockDispatchTable dispatch_table;


### PR DESCRIPTION
This allows other tests also define a `MockDispatchTable`.

Test: Compile & Run Tests