### PR TITLE
Move UserDefinedCaptureData from CaptureData to DataManager only

### DIFF
--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -82,7 +82,7 @@ bool ClientGgp::RequestStartCapture(ThreadPool* thread_pool) {
   bool enable_introspection = false;
   ErrorMessageOr<void> result = capture_client_->StartCapture(
       thread_pool, target_process_, module_manager_, selected_functions_, selected_tracepoints,
-      UserDefinedCaptureData(), enable_introspection);
+      UserDefinedCaptureData{}, enable_introspection);
 
   if (result.has_error()) {
     ERROR("Error starting capture: %s", result.error().message());
@@ -109,8 +109,9 @@ bool ClientGgp::SaveCapture() {
   // Add the location where the capture is saved
   file_name.insert(0, options_.capture_file_directory);
 
-  ErrorMessageOr<void> result = capture_serializer::Save(
-      file_name, GetCaptureData(), key_to_string_map, timer_infos_.begin(), timer_infos_.end());
+  ErrorMessageOr<void> result =
+      capture_serializer::Save(file_name, GetCaptureData(), UserDefinedCaptureData{},
+                               key_to_string_map, timer_infos_.begin(), timer_infos_.end());
   if (result.has_error()) {
     ERROR("Could not save the capture: %s", result.error().message());
     return false;
@@ -267,9 +268,9 @@ void ClientGgp::ProcessTimer(const TimerInfo& timer_info) { timer_infos_.push_ba
 void ClientGgp::OnCaptureStarted(
     ProcessData&& process,
     absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
-    TracepointInfoSet selected_tracepoints, UserDefinedCaptureData user_defined_capture_data) {
+    TracepointInfoSet selected_tracepoints, UserDefinedCaptureData /*unused*/) {
   capture_data_ = CaptureData(std::move(process), &module_manager_, std::move(selected_functions),
-                              std::move(selected_tracepoints), user_defined_capture_data);
+                              std::move(selected_tracepoints));
   LOG("Capture started");
 }
 

--- a/OrbitClientGgp/include/OrbitClientGgp/ClientGgp.h
+++ b/OrbitClientGgp/include/OrbitClientGgp/ClientGgp.h
@@ -19,7 +19,6 @@
 #include "OrbitClientServices/ProcessClient.h"
 #include "StringManager.h"
 #include "TracepointCustom.h"
-#include "UserDefinedCaptureData.h"
 #include "grpcpp/grpcpp.h"
 
 class ClientGgp final : public CaptureListener {

--- a/OrbitClientModel/CaptureSerializer.cpp
+++ b/OrbitClientModel/CaptureSerializer.cpp
@@ -52,7 +52,7 @@ void IncludeOrbitExtensionInFile(std::string& file_name) {
 namespace internal {
 
 CaptureInfo GenerateCaptureInfo(
-    const CaptureData& capture_data,
+    const CaptureData& capture_data, const UserDefinedCaptureData& user_defined_capture_data,
     const absl::flat_hash_map<uint64_t, std::string>& key_to_string_map) {
   CaptureInfo capture_info;
   for (const auto& pair : capture_data.selected_functions()) {
@@ -150,7 +150,7 @@ CaptureInfo GenerateCaptureInfo(
 
   capture_info.mutable_key_to_string()->insert(key_to_string_map.begin(), key_to_string_map.end());
 
-  for (const auto& function : capture_data.user_defined_capture_data().frame_track_functions()) {
+  for (const auto& function : user_defined_capture_data.frame_track_functions()) {
     capture_info.mutable_user_defined_capture_info()
         ->mutable_frame_tracks_info()
         ->add_frame_track_functions()

--- a/OrbitCore/CaptureData.cpp
+++ b/OrbitCore/CaptureData.cpp
@@ -158,17 +158,3 @@ uint64_t CaptureData::GetAbsoluteAddress(const orbit_client_protos::FunctionInfo
 int32_t CaptureData::process_id() const { return process_.pid(); }
 
 std::string CaptureData::process_name() const { return process_.name(); }
-
-void CaptureData::InsertFrameTrack(const FunctionInfo& function) {
-  user_defined_capture_data_.InsertFrameTrack(function);
-}
-
-void CaptureData::EraseFrameTrack(const FunctionInfo& function) {
-  user_defined_capture_data_.EraseFrameTrack(function);
-}
-
-[[nodiscard]] bool CaptureData::ContainsFrameTrack(const FunctionInfo& function) const {
-  return user_defined_capture_data_.ContainsFrameTrack(function);
-}
-
-void CaptureData::ClearUserDefinedCaptureData() { user_defined_capture_data_.Clear(); }

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -16,7 +16,6 @@
 #include "TracepointCustom.h"
 #include "TracepointEventBuffer.h"
 #include "TracepointInfoManager.h"
-#include "UserDefinedCaptureData.h"
 #include "absl/container/flat_hash_map.h"
 #include "capture_data.pb.h"
 #include "process.pb.h"
@@ -26,7 +25,7 @@ class CaptureData {
   explicit CaptureData(
       ProcessData&& process, OrbitClientData::ModuleManager* module_manager,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
-      TracepointInfoSet selected_tracepoints, UserDefinedCaptureData user_defined_capture_data)
+      TracepointInfoSet selected_tracepoints)
       : process_(std::move(process)),
         module_manager_(module_manager),
         selected_functions_{std::move(selected_functions)},
@@ -34,8 +33,7 @@ class CaptureData {
         callstack_data_(std::make_unique<CallstackData>()),
         selection_callstack_data_(std::make_unique<CallstackData>()),
         tracepoint_info_manager_(std::make_unique<TracepointInfoManager>()),
-        tracepoint_event_buffer_(std::make_unique<TracepointEventBuffer>()),
-        user_defined_capture_data_(std::move(user_defined_capture_data)) {}
+        tracepoint_event_buffer_(std::make_unique<TracepointEventBuffer>()) {}
 
   // We can not copy the unique_ptr, so we can not copy this object.
   CaptureData& operator=(const CaptureData& other) = delete;
@@ -198,14 +196,6 @@ class CaptureData {
     sampling_profiler_ = std::move(sampling_profiler);
   }
 
-  void InsertFrameTrack(const orbit_client_protos::FunctionInfo& function);
-  void EraseFrameTrack(const orbit_client_protos::FunctionInfo& function);
-  [[nodiscard]] bool ContainsFrameTrack(const orbit_client_protos::FunctionInfo& function) const;
-  void ClearUserDefinedCaptureData();
-  [[nodiscard]] const UserDefinedCaptureData& user_defined_capture_data() const {
-    return user_defined_capture_data_;
-  }
-
  private:
   ProcessData process_;
   OrbitClientData::ModuleManager* module_manager_;
@@ -234,8 +224,6 @@ class CaptureData {
   mutable std::unique_ptr<absl::Mutex> thread_state_slices_mutex_ = std::make_unique<absl::Mutex>();
 
   std::chrono::system_clock::time_point capture_start_time_ = std::chrono::system_clock::now();
-
-  UserDefinedCaptureData user_defined_capture_data_;
 };
 
 #endif  // ORBIT_CORE_CAPTURE_DATA_H_

--- a/OrbitGl/DataManager.cpp
+++ b/OrbitGl/DataManager.cpp
@@ -134,3 +134,17 @@ bool DataManager::IsTracepointSelected(const TracepointInfo& info) const {
 }
 
 const TracepointInfoSet& DataManager::selected_tracepoints() const { return selected_tracepoints_; }
+
+void DataManager::InsertFrameTrack(const FunctionInfo& function) {
+  user_defined_capture_data_.InsertFrameTrack(function);
+}
+
+void DataManager::EraseFrameTrack(const FunctionInfo& function) {
+  user_defined_capture_data_.EraseFrameTrack(function);
+}
+
+[[nodiscard]] bool DataManager::ContainsFrameTrack(const FunctionInfo& function) const {
+  return user_defined_capture_data_.ContainsFrameTrack(function);
+}
+
+void DataManager::ClearUserDefinedCaptureData() { user_defined_capture_data_.Clear(); }

--- a/OrbitGl/DataManager.h
+++ b/OrbitGl/DataManager.h
@@ -54,13 +54,17 @@ class DataManager final {
 
   [[nodiscard]] const TracepointInfoSet& selected_tracepoints() const;
 
-  void set_user_defined_capture_data(const UserDefinedCaptureData& user_defined_capture_data) {
+  void set_user_defined_capture_data(UserDefinedCaptureData user_defined_capture_data) {
     user_defined_capture_data_ = user_defined_capture_data;
   }
-  [[nodiscard]] const UserDefinedCaptureData& mutable_user_defined_capture_data() const {
+  void InsertFrameTrack(const orbit_client_protos::FunctionInfo& function);
+  void EraseFrameTrack(const orbit_client_protos::FunctionInfo& function);
+  [[nodiscard]] bool ContainsFrameTrack(const orbit_client_protos::FunctionInfo& function) const;
+  void ClearUserDefinedCaptureData();
+  [[nodiscard]] const UserDefinedCaptureData& user_defined_capture_data() const {
     return user_defined_capture_data_;
   }
-  [[nodiscard]] UserDefinedCaptureData& user_defined_capture_data() {
+  [[nodiscard]] UserDefinedCaptureData& mutable_user_defined_capture_data() {
     return user_defined_capture_data_;
   }
 
@@ -78,8 +82,6 @@ class DataManager final {
 
   const ProcessData* selected_process_ = nullptr;
 
-  // DataManager needs a copy of this so that we can persist user choices like frame tracks between
-  // captures.
   UserDefinedCaptureData user_defined_capture_data_;
 };
 

--- a/OrbitGl/FrameTrackOnlineProcessor.cpp
+++ b/OrbitGl/FrameTrackOnlineProcessor.cpp
@@ -10,11 +10,10 @@
 #include "TimeGraph.h"
 #include "UserDefinedCaptureData.h"
 
-FrameTrackOnlineProcessor::FrameTrackOnlineProcessor(const CaptureData& capture_data,
-                                                     TimeGraph* time_graph)
+FrameTrackOnlineProcessor::FrameTrackOnlineProcessor(
+    const CaptureData& capture_data, const UserDefinedCaptureData& user_defined_capture_data,
+    TimeGraph* time_graph)
     : time_graph_(time_graph) {
-  const UserDefinedCaptureData& user_defined_capture_data =
-      capture_data.user_defined_capture_data();
   for (const auto& function : user_defined_capture_data.frame_track_functions()) {
     const uint64_t function_address = capture_data.GetAbsoluteAddress(function);
     current_frame_track_functions_.insert(function_address);

--- a/OrbitGl/FrameTrackOnlineProcessor.h
+++ b/OrbitGl/FrameTrackOnlineProcessor.h
@@ -5,6 +5,8 @@
 #ifndef ORBIT_GL_FRAME_TRACK_ONLINE_PROCESSOR_H_
 #define ORBIT_GL_FRAME_TRACK_ONLINE_PROCESSOR_H_
 
+#include "CaptureData.h"
+#include "UserDefinedCaptureData.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "capture_data.pb.h"
@@ -15,7 +17,9 @@ class TimeGraph;
 class FrameTrackOnlineProcessor {
  public:
   FrameTrackOnlineProcessor() : time_graph_(nullptr) {}
-  FrameTrackOnlineProcessor(const CaptureData& capture_data, TimeGraph* time_graph);
+  FrameTrackOnlineProcessor(const CaptureData& capture_data,
+                            const UserDefinedCaptureData& user_defined_capture_data,
+                            TimeGraph* time_graph);
   void ProcessTimer(const orbit_client_protos::TimerInfo& timer_info,
                     const orbit_client_protos::FunctionInfo& function);
 


### PR DESCRIPTION
The recent refactoring of CaptureData to using std::optional and the
need of adding frame tracks before a capture makes it clear that
UserDefinedCaptureData (which owns frame track data) should not be a
member of CaptureData (and indeed does not have to be a member).

This is a mostly mechanical change that removes the
UserDefinedCaptureData member from CaptureData.

Tested: Ran unit tests; manual load/save/capture tests with and without
presets.

Bug: b/173191435