### PR TITLE
Update listener methods in ClientGgp

### DIFF
--- a/OrbitClientGgp/ClientGgp.cpp
+++ b/OrbitClientGgp/ClientGgp.cpp
@@ -275,13 +275,17 @@ void ClientGgp::OnCaptureStarted(
 
 void ClientGgp::OnCaptureComplete() {
   LOG("Capture completed");
+  GetMutableCaptureData().FilterBrokenCallstacks();
   SamplingProfiler sampling_profiler(*GetCaptureData().GetCallstackData(), GetCaptureData());
   GetMutableCaptureData().set_sampling_profiler(sampling_profiler);
 }
 
-void ClientGgp::OnCaptureCancelled() {}
+void ClientGgp::OnCaptureCancelled() { ClearCapture(); }
 
-void ClientGgp::OnCaptureFailed(ErrorMessage /*error_message*/) {}
+void ClientGgp::OnCaptureFailed(ErrorMessage error_message) {
+  ClearCapture();
+  ERROR("Capture failed: %s", error_message.message());
+}
 
 void ClientGgp::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
   if (timer_info.function_address() > 0) {


### PR DESCRIPTION
Some of the listener methods implemented in _ClientGgp_ had some differences compared to the ones in _OrbitApp_, given by recent updates on them. They have been reviewed and updated.