### PR TITLE
Refactor TextRenderer

### DIFF
--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -498,7 +498,7 @@ void CaptureWindow::Draw() {
   Append(all_layers, text_renderer_.GetLayers());
   Append(all_layers, time_graph_.GetTextRenderer()->GetLayers());
 
-  // Remove duplicates.
+  // Sort and remove duplicates.
   std::sort(all_layers.begin(), all_layers.end());
   auto it = std::unique(all_layers.begin(), all_layers.end());
   all_layers.resize(std::distance(all_layers.begin(), it));

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -402,11 +402,6 @@ void CaptureWindow::KeyPressed(unsigned int key_code, bool ctrl, bool shift, boo
       case 'X':
         ToggleRecording();
         break;
-      case 'O':
-        if (ctrl) {
-          text_renderer_.ToggleDrawOutline();
-        }
-        break;
       case 18:  // Left
         if (shift) {
           time_graph_.JumpToNeighborBox(GOrbitApp->selected_text_box(),
@@ -493,11 +488,17 @@ void CaptureWindow::Draw() {
 
   DrawScreenSpace();
 
-  // We start by getting all layers
+  if (GetPickingMode() == PickingMode::kNone) {
+    text_renderer_.RenderDebug(&ui_batcher_);
+  }
+
+  // Get all layers.
   std::vector<float> all_layers = time_graph_.GetBatcher().GetLayers();
   Append(all_layers, ui_batcher_.GetLayers());
   Append(all_layers, text_renderer_.GetLayers());
   Append(all_layers, time_graph_.GetTextRenderer()->GetLayers());
+
+  // Remove duplicates.
   std::sort(all_layers.begin(), all_layers.end());
   auto it = std::unique(all_layers.begin(), all_layers.end());
   all_layers.resize(std::distance(all_layers.begin(), it));
@@ -517,7 +518,7 @@ void CaptureWindow::Draw() {
 
     PrepareScreenSpaceViewport();
     if (GetPickingMode() == PickingMode::kNone) {
-      text_renderer_.DisplayLayer(&ui_batcher_, layer);
+      text_renderer_.RenderLayer(&ui_batcher_, layer);
       RenderText(layer);
     }
   }
@@ -666,6 +667,12 @@ void CaptureWindow::RenderImGui() {
       if (time_graph_.GetLayout().DrawProperties()) {
         NeedsUpdate();
       }
+
+      static bool draw_text_outline = false;
+      if (ImGui::Checkbox("Draw Text Outline", &draw_text_outline)) {
+        TextRenderer::SetDrawOutline(draw_text_outline);
+        NeedsUpdate();
+      }
       ImGui::EndTabItem();
     }
 
@@ -733,17 +740,15 @@ Vec2 ScreenToWorld(GlCanvas* canvas, Vec2 screen_pos) {
 }
 
 void CaptureWindow::RenderHelpUi() {
-  constexpr int kXOffset = 50;
-  constexpr int kYOffset = 80;
+  constexpr int kOffset = 30;
   float world_x = 0;
   float world_y = 0;
-  ScreenToWorld(kXOffset, kYOffset, world_x, world_y);
+  ScreenToWorld(kOffset, kOffset, world_x, world_y);
 
-  const uint32_t kHelpMessageFontSize = 2 * font_size_;
   Vec2 text_bounding_box_pos;
   Vec2 text_bounding_box_size;
   text_renderer_.AddText(GetHelpText(), world_x, world_y, GlCanvas::kZValueTextUi,
-                         Color(255, 255, 255, 255), kHelpMessageFontSize, -1.f /*max_size*/,
+                         Color(255, 255, 255, 255), font_size_, -1.f /*max_size*/,
                          false /*right_justified*/, &text_bounding_box_pos,
                          &text_bounding_box_size);
 

--- a/OrbitGl/FrameTrack.cpp
+++ b/OrbitGl/FrameTrack.cpp
@@ -228,7 +228,7 @@ void FrameTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset
   std::string label = absl::StrFormat("Avg: %s", avg_time);
   uint32_t font_size = time_graph_->CalculateZoomedFontSize();
   float string_width = canvas->GetTextRenderer().GetStringWidth(label.c_str(), font_size);
-  Vec2 white_text_box_size(static_cast<float>(string_width), layout.GetTextBoxHeight());
+  Vec2 white_text_box_size(string_width, layout.GetTextBoxHeight());
   Vec2 white_text_box_position(pos_[0] + layout.GetRightMargin(),
                                y - layout.GetTextBoxHeight() / 2.f);
 

--- a/OrbitGl/FrameTrack.cpp
+++ b/OrbitGl/FrameTrack.cpp
@@ -226,8 +226,8 @@ void FrameTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset
   const TimeGraphLayout& layout = time_graph_->GetLayout();
   std::string avg_time = GetPrettyTime(absl::Nanoseconds(stats_.average_time_ns()));
   std::string label = absl::StrFormat("Avg: %s", avg_time);
-
-  int string_width = canvas->GetTextRenderer().GetStringWidth(label.c_str());
+  uint32_t font_size = time_graph_->CalculateZoomedFontSize();
+  float string_width = canvas->GetTextRenderer().GetStringWidth(label.c_str(), font_size);
   Vec2 white_text_box_size(static_cast<float>(string_width), layout.GetTextBoxHeight());
   Vec2 white_text_box_position(pos_[0] + layout.GetRightMargin(),
                                y - layout.GetTextBoxHeight() / 2.f);
@@ -238,8 +238,8 @@ void FrameTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset
 
   canvas->GetTextRenderer().AddText(label.c_str(), white_text_box_position[0],
                                     white_text_box_position[1] + layout.GetTextOffset(),
-                                    GlCanvas::kZValueTextUi, kWhiteColor,
-                                    time_graph_->CalculateZoomedFontSize(), white_text_box_size[0]);
+                                    GlCanvas::kZValueTextUi, kWhiteColor, font_size,
+                                    white_text_box_size[0]);
 }
 
 void FrameTrack::UpdateBoxHeight() {

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -45,8 +45,7 @@ unsigned GlCanvas::kMaxNumberRealZLayers = 16 + 4 + 4 + 4;
 const Color GlCanvas::kBackgroundColor = Color(67, 67, 67, 255);
 const Color GlCanvas::kTabTextColorSelected = Color(100, 181, 246, 255);
 
-GlCanvas::GlCanvas(uint32_t font_size)
-    : text_renderer_(font_size), ui_batcher_(BatcherId::kUi, &picking_manager_) {
+GlCanvas::GlCanvas(uint32_t font_size) : ui_batcher_(BatcherId::kUi, &picking_manager_) {
   text_renderer_.SetCanvas(this);
 
   screen_width_ = 0;

--- a/OrbitGl/GraphTrack.cpp
+++ b/OrbitGl/GraphTrack.cpp
@@ -102,8 +102,9 @@ void GraphTrack::DrawSquareDot(Batcher* batcher, Vec2 center, float radius, floa
 void GraphTrack::DrawLabel(GlCanvas* canvas, Vec2 target_pos, const std::string text,
                            Color text_color, Color font_color, float z) {
   const TimeGraphLayout& layout = time_graph_->GetLayout();
+  uint32_t font_size = time_graph_->CalculateZoomedFontSize();
 
-  int text_width = canvas->GetTextRenderer().GetStringWidth(text.c_str());
+  float text_width = canvas->GetTextRenderer().GetStringWidth(text.c_str(), font_size);
   Vec2 text_box_size(text_width, layout.GetTextBoxHeight());
 
   float arrow_width = text_box_size[1] / 2.f;
@@ -130,7 +131,7 @@ void GraphTrack::DrawLabel(GlCanvas* canvas, Vec2 target_pos, const std::string 
 
   canvas->GetTextRenderer().AddText(text.c_str(), text_box_position[0],
                                     text_box_position[1] + layout.GetTextOffset(), z, text_color,
-                                    time_graph_->CalculateZoomedFontSize(), text_box_size[0]);
+                                    font_size, text_box_size[0]);
 }
 
 void GraphTrack::AddValue(double value, uint64_t time) {

--- a/OrbitGl/TextRenderer.cpp
+++ b/OrbitGl/TextRenderer.cpp
@@ -18,87 +18,75 @@ typedef struct {
   float r, g, b, a;  // color
 } vertex_t;
 
-TextRenderer::TextRenderer(uint32_t font_size)
-    : m_Atlas(nullptr),
-      m_Font(nullptr),
-      current_font_size_(font_size),
-      m_Canvas(nullptr),
-      m_Initialized(false),
-      m_DrawOutline(false) {}
+bool TextRenderer::draw_outline_ = false;
+
+TextRenderer::TextRenderer() : texture_atlas_(nullptr), canvas_(nullptr), initialized_(false) {}
 
 TextRenderer::~TextRenderer() {
-  for (const auto& pair : m_FontsBySize) {
+  for (const auto& pair : fonts_by_size_) {
     texture_font_delete(pair.second);
   }
-  m_FontsBySize.clear();
+  fonts_by_size_.clear();
 
-  for (auto& [unused_layer, buffer] : buffers_by_layer_) {
+  for (auto& [unused_layer, buffer] : vertex_buffers_by_layer_) {
     vertex_buffer_delete(buffer);
   }
-  buffers_by_layer_.clear();
+  vertex_buffers_by_layer_.clear();
 
-  if (m_Atlas) {
-    texture_atlas_delete(m_Atlas);
+  if (texture_atlas_) {
+    texture_atlas_delete(texture_atlas_);
   }
 }
 
 void TextRenderer::Init() {
-  if (m_Initialized) return;
+  if (initialized_) return;
 
   int atlasSize = 2 * 1024;
-  m_Atlas = texture_atlas_new(atlasSize, atlasSize, 1);
+  texture_atlas_ = texture_atlas_new(atlasSize, atlasSize, 1);
 
   const auto exe_dir = Path::GetExecutableDir();
   const auto fontFileName = exe_dir + "fonts/Vera.ttf";
 
   for (int i = 1; i <= 100; i += 1) {
-    m_FontsBySize[i] = texture_font_new_from_file(m_Atlas, i, fontFileName.c_str());
+    fonts_by_size_[i] = texture_font_new_from_file(texture_atlas_, i, fontFileName.c_str());
   }
-  SetFontSize(current_font_size_);
 
-  m_Pen.x = 0;
-  m_Pen.y = 0;
+  pen_.x = 0;
+  pen_.y = 0;
 
-  glGenTextures(1, &m_Atlas->id);
+  glGenTextures(1, &texture_atlas_->id);
 
   const auto vertShaderFileName = Path::JoinPath({exe_dir, "shaders", "v3f-t2f-c4f.vert"});
   const auto fragShaderFileName = Path::JoinPath({exe_dir, "shaders", "v3f-t2f-c4f.frag"});
-  m_Shader = shader_load(vertShaderFileName.c_str(), fragShaderFileName.c_str());
+  shader_ = shader_load(vertShaderFileName.c_str(), fragShaderFileName.c_str());
 
-  mat4_set_identity(&m_Proj);
-  mat4_set_identity(&m_Model);
-  mat4_set_identity(&m_View);
+  mat4_set_identity(&projection_);
+  mat4_set_identity(&model_);
+  mat4_set_identity(&view_);
 
-  m_Initialized = true;
+  initialized_ = true;
 }
 
-void TextRenderer::SetFontSize(uint32_t size) {
-  CHECK(!m_FontsBySize.empty());
-  if (!m_FontsBySize.count(size)) {
-    auto iterator_next = m_FontsBySize.upper_bound(size);
+texture_font_t* TextRenderer::GetFont(uint32_t size) {
+  CHECK(!fonts_by_size_.empty());
+  if (!fonts_by_size_.count(size)) {
+    auto iterator_next = fonts_by_size_.upper_bound(size);
     // If there isn't that font_size in the map, we will search for the next one or previous one
-    if (iterator_next != m_FontsBySize.end()) {
+    if (iterator_next != fonts_by_size_.end()) {
       size = iterator_next->first;
-    } else if (iterator_next != m_FontsBySize.begin()) {
+    } else if (iterator_next != fonts_by_size_.begin()) {
       size = (--iterator_next)->first;
     }
   }
-  texture_font_t* font = m_FontsBySize[size];
-  m_Font = font;
-  current_font_size_ = size;
+  return fonts_by_size_[size];
 }
 
-uint32_t TextRenderer::GetFontSize() const { return current_font_size_; }
-
-void TextRenderer::DisplayLayer(Batcher* batcher, float layer) {
-  if (!buffers_by_layer_.count(layer)) return;
-  auto& buffer = buffers_by_layer_.at(layer);
-  if (m_DrawOutline) {
-    DrawOutline(batcher, buffer);
-  }
+void TextRenderer::RenderLayer(Batcher*, float layer) {
+  if (!vertex_buffers_by_layer_.count(layer)) return;
+  auto& buffer = vertex_buffers_by_layer_.at(layer);
 
   // Lazy init
-  if (!m_Initialized) {
+  if (!initialized_) {
     Init();
   }
 
@@ -107,27 +95,28 @@ void TextRenderer::DisplayLayer(Batcher* batcher, float layer) {
   glDepthMask(GL_FALSE);
   glBlendEquation(GL_FUNC_ADD);
   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-  glBindTexture(GL_TEXTURE_2D, m_Atlas->id);
+  glBindTexture(GL_TEXTURE_2D, texture_atlas_->id);
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RED, static_cast<GLsizei>(m_Atlas->width),
-               static_cast<GLsizei>(m_Atlas->height), 0, GL_RED, GL_UNSIGNED_BYTE, m_Atlas->data);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RED, static_cast<GLsizei>(texture_atlas_->width),
+               static_cast<GLsizei>(texture_atlas_->height), 0, GL_RED, GL_UNSIGNED_BYTE,
+               texture_atlas_->data);
 
   // Get current projection matrix
   GLfloat matrix[16];
   glGetFloatv(GL_PROJECTION_MATRIX, matrix);
-  mat4* proj = reinterpret_cast<mat4*>(&matrix[0]);
-  m_Proj = *proj;
+  mat4* projection = reinterpret_cast<mat4*>(&matrix[0]);
+  projection_ = *projection;
 
-  glUseProgram(m_Shader);
+  glUseProgram(shader_);
   {
-    glUniform1i(glGetUniformLocation(m_Shader, "texture"), 0);
-    glUniformMatrix4fv(glGetUniformLocation(m_Shader, "model"), 1, 0, m_Model.data);
-    glUniformMatrix4fv(glGetUniformLocation(m_Shader, "view"), 1, 0, m_View.data);
-    glUniformMatrix4fv(glGetUniformLocation(m_Shader, "projection"), 1, 0, m_Proj.data);
+    glUniform1i(glGetUniformLocation(shader_, "texture"), 0);
+    glUniformMatrix4fv(glGetUniformLocation(shader_, "model"), 1, 0, model_.data);
+    glUniformMatrix4fv(glGetUniformLocation(shader_, "view"), 1, 0, view_.data);
+    glUniformMatrix4fv(glGetUniformLocation(shader_, "projection"), 1, 0, projection_.data);
     vertex_buffer_render(buffer, GL_TRIANGLES);
   }
 
@@ -137,38 +126,37 @@ void TextRenderer::DisplayLayer(Batcher* batcher, float layer) {
   glPopAttrib();
 }
 
-void TextRenderer::Display(Batcher* batcher) {
-  for (auto& [layer, unused_buffer] : buffers_by_layer_) {
-    DisplayLayer(batcher, layer);
+void TextRenderer::RenderDebug(Batcher* batcher) {
+  if (!draw_outline_) return;
+  for (auto& [unused_layer, buffer] : vertex_buffers_by_layer_) {
+    DrawOutline(batcher, buffer);
   }
 }
 
-void TextRenderer::DrawOutline(Batcher* batcher, vertex_buffer_t* a_Buffer) {
-  if (a_Buffer == nullptr) return;
-  // TODO: No color was set here before.
-  Color color(255, 255, 255, 255);
+void TextRenderer::DrawOutline(Batcher* batcher, vertex_buffer_t* vertex_buffer) {
+  if (vertex_buffer == nullptr) return;
+  const Color color(255, 255, 255, 255);
 
-  for (size_t i = 0; i < a_Buffer->indices->size; i += 3) {
-    GLuint i0 = *static_cast<const GLuint*>(vector_get(a_Buffer->indices, i + 0));
-    GLuint i1 = *static_cast<const GLuint*>(vector_get(a_Buffer->indices, i + 1));
-    GLuint i2 = *static_cast<const GLuint*>(vector_get(a_Buffer->indices, i + 2));
+  for (size_t i = 0; i < vertex_buffer->indices->size; i += 3) {
+    GLuint i0 = *static_cast<const GLuint*>(vector_get(vertex_buffer->indices, i + 0));
+    GLuint i1 = *static_cast<const GLuint*>(vector_get(vertex_buffer->indices, i + 1));
+    GLuint i2 = *static_cast<const GLuint*>(vector_get(vertex_buffer->indices, i + 2));
 
-    vertex_t v0 = *static_cast<const vertex_t*>(vector_get(a_Buffer->vertices, i0));
-    vertex_t v1 = *static_cast<const vertex_t*>(vector_get(a_Buffer->vertices, i1));
-    vertex_t v2 = *static_cast<const vertex_t*>(vector_get(a_Buffer->vertices, i2));
+    vertex_t v0 = *static_cast<const vertex_t*>(vector_get(vertex_buffer->vertices, i0));
+    vertex_t v1 = *static_cast<const vertex_t*>(vector_get(vertex_buffer->vertices, i1));
+    vertex_t v2 = *static_cast<const vertex_t*>(vector_get(vertex_buffer->vertices, i2));
 
     // TODO: This should be pickable??
-    batcher->AddLine(Vec2(v0.x, v0.y), Vec2(v1.x, v1.y), v0.z, color);
-    batcher->AddLine(Vec2(v1.x, v1.y), Vec2(v2.x, v2.y), v1.z, color);
-    batcher->AddLine(Vec2(v2.x, v2.y), Vec2(v0.x, v0.y), v2.z, color);
+    batcher->AddLine(Vec2(v0.x, v0.y), Vec2(v1.x, v1.y), GlCanvas::kZValueSlider, color);
+    batcher->AddLine(Vec2(v1.x, v1.y), Vec2(v2.x, v2.y), GlCanvas::kZValueSlider, color);
+    batcher->AddLine(Vec2(v2.x, v2.y), Vec2(v0.x, v0.y), GlCanvas::kZValueSlider, color);
   }
 }
 
 void TextRenderer::AddTextInternal(texture_font_t* font, const char* text, const vec4& color,
-                                   vec2* pen, float max_size, float a_Z, vec2* out_text_pos,
+                                   vec2* pen, float max_size, float z, vec2* out_text_pos,
                                    vec2* out_text_size) {
   float r = color.red, g = color.green, b = color.blue, a = color.alpha;
-  float textZ = a_Z;
 
   float max_width = max_size == -1.f ? FLT_MAX : ToScreenSpace(max_size);
   float str_width = 0.f;
@@ -205,10 +193,10 @@ void TextRenderer::AddTextInternal(texture_font_t* font, const char* text, const
       float s1 = glyph->s1;
       float t1 = glyph->t1;
 
-      vertex_t vertices[4] = {{x0, y0, textZ, s0, t0, r, g, b, a},
-                              {x0, y1, textZ, s0, t1, r, g, b, a},
-                              {x1, y1, textZ, s1, t1, r, g, b, a},
-                              {x1, y0, textZ, s1, t0, r, g, b, a}};
+      vertex_t vertices[4] = {{x0, y0, z, s0, t0, r, g, b, a},
+                              {x0, y1, z, s0, t1, r, g, b, a},
+                              {x1, y1, z, s1, t1, r, g, b, a},
+                              {x1, y0, z, s1, t0, r, g, b, a}};
 
       min_x = std::min(min_x, x0);
       max_x = std::max(max_x, x1);
@@ -220,10 +208,10 @@ void TextRenderer::AddTextInternal(texture_font_t* font, const char* text, const
       if (str_width > max_width) {
         break;
       }
-      if (!buffers_by_layer_.count(textZ)) {
-        buffers_by_layer_[textZ] = vertex_buffer_new("vertex:3f,tex_coord:2f,color:4f");
+      if (!vertex_buffers_by_layer_.count(z)) {
+        vertex_buffers_by_layer_[z] = vertex_buffer_new("vertex:3f,tex_coord:2f,color:4f");
       }
-      vertex_buffer_push_back(buffers_by_layer_.at(textZ), vertices, 4, indices.data(), 6);
+      vertex_buffer_push_back(vertex_buffers_by_layer_.at(z), vertices, 4, indices.data(), 6);
       pen->x += glyph->advance_x;
     }
   }
@@ -239,169 +227,183 @@ void TextRenderer::AddTextInternal(texture_font_t* font, const char* text, const
   }
 }
 
-void TextRenderer::AddText(const char* a_Text, float a_X, float a_Y, float a_Z,
-                           const Color& a_Color, uint32_t font_size, float a_MaxSize,
-                           bool a_RightJustified, Vec2* out_text_pos, Vec2* out_text_size) {
+void TextRenderer::AddText(const char* text, float x, float y, float z, const Color& color,
+                           uint32_t font_size, float max_size, bool right_justified,
+                           Vec2* out_text_pos, Vec2* out_text_size) {
   if (!font_size) return;
-  ToScreenSpace(a_X, a_Y, m_Pen.x, m_Pen.y);
+  ToScreenSpace(x, y, pen_.x, pen_.y);
 
-  if (a_RightJustified) {
-    a_MaxSize = FLT_MAX;
-    int stringWidth = GetStringWidth(a_Text);
-    m_Pen.x -= stringWidth;
+  if (right_justified) {
+    max_size = FLT_MAX;
+    int string_width = GetStringWidthScreenSpace(text, font_size);
+    pen_.x -= string_width;
   }
-  SetFontSize(font_size);
 
   vec2 out_screen_pos;
   vec2 out_screen_size;
-  AddTextInternal(m_Font, a_Text, ColorToVec4(a_Color), &m_Pen, a_MaxSize, a_Z, &out_screen_pos,
+  AddTextInternal(GetFont(font_size), text, ColorToVec4(color), &pen_, max_size, z, &out_screen_pos,
                   &out_screen_size);
   if (out_text_pos) {
-    float inv_y = m_Canvas->GetHeight() - out_screen_pos.y;
-    (*out_text_pos) = m_Canvas->ScreenToWorld(Vec2(out_screen_pos.x, inv_y));
+    float inv_y = canvas_->GetHeight() - out_screen_pos.y;
+    (*out_text_pos) = canvas_->ScreenToWorld(Vec2(out_screen_pos.x, inv_y));
   }
 
   if (out_text_size) {
-    (*out_text_size)[0] = m_Canvas->ScreenToWorldWidth(static_cast<int>(out_screen_size.x));
-    (*out_text_size)[1] = m_Canvas->ScreenToWorldHeight(static_cast<int>(out_screen_size.y));
+    (*out_text_size)[0] = canvas_->ScreenToWorldWidth(static_cast<int>(out_screen_size.x));
+    (*out_text_size)[1] = canvas_->ScreenToWorldHeight(static_cast<int>(out_screen_size.y));
   }
 }
 
-int TextRenderer::AddTextTrailingCharsPrioritized(const char* a_Text, float a_X, float a_Y,
-                                                  float a_Z, const Color& a_Color,
-                                                  size_t a_TrailingCharsLength, uint32_t font_size,
-                                                  float a_MaxSize) {
-  if (!m_Initialized) {
+float TextRenderer::AddTextTrailingCharsPrioritized(const char* text, float x, float y, float z,
+                                                    const Color& color,
+                                                    size_t trailing_chars_length,
+                                                    uint32_t font_size, float max_size) {
+  if (!initialized_) {
     Init();
   }
 
-  float tempPenX = ToScreenSpace(a_X);
-  float maxWidth = a_MaxSize == -1.f ? FLT_MAX : ToScreenSpace(a_MaxSize);
-  float strWidth = 0.f;
-  int minX = INT_MAX;
-  int maxX = -INT_MAX;
+  float temp_pen_x = ToScreenSpace(x);
+  float max_width = max_size == -1.f ? FLT_MAX : ToScreenSpace(max_size);
+  float string_width = 0.f;
+  int min_x = INT_MAX;
+  int max_x = -INT_MAX;
 
-  const size_t textLen = strlen(a_Text);
-
+  const size_t text_length = strlen(text);
+  texture_font_t* font = GetFont(font_size);
   size_t i;
-  for (i = 0; i < textLen; ++i) {
-    if (!texture_font_find_glyph(m_Font, a_Text + i)) {
-      texture_font_load_glyph(m_Font, a_Text + i);
+  for (i = 0; i < text_length; ++i) {
+    if (!texture_font_find_glyph(font, text + i)) {
+      texture_font_load_glyph(font, text + i);
     }
 
-    texture_glyph_t* glyph = texture_font_get_glyph(m_Font, a_Text + i);
+    texture_glyph_t* glyph = texture_font_get_glyph(font, text + i);
     if (glyph != NULL) {
       float kerning = 0.0f;
       if (i > 0) {
-        kerning = texture_glyph_get_kerning(glyph, a_Text + i - 1);
+        kerning = texture_glyph_get_kerning(glyph, text + i - 1);
       }
-      tempPenX += kerning;
-      int x0 = static_cast<int>(tempPenX + glyph->offset_x);
+      temp_pen_x += kerning;
+      int x0 = static_cast<int>(temp_pen_x + glyph->offset_x);
       int x1 = static_cast<int>(x0 + glyph->width);
 
-      minX = std::min(minX, x0);
-      maxX = std::max(maxX, x1);
-      strWidth = float(maxX - minX);
+      min_x = std::min(min_x, x0);
+      max_x = std::max(max_x, x1);
+      string_width = float(max_x - min_x);
 
-      if (strWidth > maxWidth) {
+      if (string_width > max_width) {
         break;
       }
 
-      tempPenX += glyph->advance_x;
+      temp_pen_x += glyph->advance_x;
     }
   }
 
   // TODO: Technically, we'd want the size of "... <TIME>" + remaining
   // characters
 
-  auto fittingCharsCount = i;
+  auto fitting_chars_count = i;
 
   static const char* ELLIPSIS_TEXT = "... ";
   static const size_t ELLIPSIS_TEXT_LEN = strlen(ELLIPSIS_TEXT);
   static const size_t LEADING_CHARS_COUNT = 1;
   static const size_t ELLIPSIS_BUFFER_SIZE = ELLIPSIS_TEXT_LEN + LEADING_CHARS_COUNT;
 
-  bool useEllipsisText = (fittingCharsCount < textLen) &&
-                         (fittingCharsCount > (a_TrailingCharsLength + ELLIPSIS_BUFFER_SIZE));
+  bool use_ellipsis_text = (fitting_chars_count < text_length) &&
+                           (fitting_chars_count > (trailing_chars_length + ELLIPSIS_BUFFER_SIZE));
 
-  if (!useEllipsisText) {
-    AddText(a_Text, a_X, a_Y, a_Z, a_Color, font_size, a_MaxSize);
-    return GetStringWidth(a_Text);
+  if (!use_ellipsis_text) {
+    AddText(text, x, y, z, color, font_size, max_size);
+    return GetStringWidth(text, font_size);
   } else {
-    auto leadingCharCount = fittingCharsCount - (a_TrailingCharsLength + ELLIPSIS_TEXT_LEN);
+    auto leading_char_count = fitting_chars_count - (trailing_chars_length + ELLIPSIS_TEXT_LEN);
 
-    std::string modifiedText(a_Text, leadingCharCount);
-    modifiedText.append(ELLIPSIS_TEXT);
+    std::string modified_text(text, leading_char_count);
+    modified_text.append(ELLIPSIS_TEXT);
 
-    auto timePosition = textLen - a_TrailingCharsLength;
-    modifiedText.append(&a_Text[timePosition], a_TrailingCharsLength);
+    auto timePosition = text_length - trailing_chars_length;
+    modified_text.append(&text[timePosition], trailing_chars_length);
 
-    AddText(modifiedText.c_str(), a_X, a_Y, a_Z, a_Color, font_size, a_MaxSize);
-    return GetStringWidth(modifiedText.c_str());
+    AddText(modified_text.c_str(), x, y, z, color, font_size, max_size);
+    return GetStringWidth(modified_text.c_str(), font_size);
   }
 }
 
-int TextRenderer::AddText2D(const char* a_Text, int a_X, int a_Y, float a_Z, const Color& a_Color,
-                            float a_MaxSize, bool a_RightJustified, bool a_InvertY) {
-  if (a_RightJustified) {
-    int stringWidth = GetStringWidth(a_Text);
-    a_X -= stringWidth;
-  }
-
-  m_Pen.x = a_X;
-  m_Pen.y = a_InvertY ? m_Canvas->GetHeight() - a_Y : a_Y;
-
-  AddTextInternal(m_Font, a_Text, ColorToVec4(a_Color), &m_Pen, a_MaxSize, a_Z);
-
-  return a_X;
+float TextRenderer::GetStringWidth(const char* text, uint32_t font_size) {
+  return canvas_->ScreenToWorldWidth(GetStringWidthScreenSpace(text, font_size));
 }
 
-int TextRenderer::GetStringWidth(const char* a_Text) const {
-  float stringWidth = 0;
+float TextRenderer::GetStringHeight(const char* text, uint32_t font_size) {
+  return canvas_->ScreenToWorldHeight(GetStringHeightScreenSpace(text, font_size));
+}
 
-  std::size_t len = strlen(a_Text);
+int TextRenderer::GetStringWidthScreenSpace(const char* text, uint32_t font_size) {
+  float string_width = 0;
+
+  std::size_t len = strlen(text);
   for (std::size_t i = 0; i < len; ++i) {
-    texture_glyph_t* glyph = texture_font_get_glyph(m_Font, a_Text + i);
+    texture_glyph_t* glyph = texture_font_get_glyph(GetFont(font_size), text + i);
     if (glyph != NULL) {
       float kerning = 0.0f;
       if (i > 0) {
-        kerning = texture_glyph_get_kerning(glyph, a_Text + i - 1);
+        kerning = texture_glyph_get_kerning(glyph, text + i - 1);
       }
 
-      stringWidth += kerning;
-      stringWidth += glyph->advance_x;
+      string_width += kerning;
+      string_width += glyph->advance_x;
     }
+
+    // Only return width of first line.
+    if (text[i] == '\n') break;
   }
 
-  return static_cast<int>(ceil(stringWidth));
+  return static_cast<int>(ceil(string_width));
+}
+
+int TextRenderer::GetStringHeightScreenSpace(const char* text, uint32_t font_size) {
+  int max_height = 0.f;
+  texture_font_t* font = GetFont(font_size);
+  for (std::size_t i = 0; i < strlen(text); ++i) {
+    if (!texture_font_find_glyph(font, text + i)) {
+      texture_font_load_glyph(font, text + i);
+    }
+
+    texture_glyph_t* glyph = texture_font_get_glyph(font, text + i);
+    if (glyph != nullptr) {
+      max_height = std::max(max_height, glyph->offset_y);
+    }
+
+    // Only return height of first line.
+    if (text[i] == '\n') break;
+  }
+  return max_height;
 }
 
 std::vector<float> TextRenderer::GetLayers() const {
   std::vector<float> layers;
-  for (auto& [layer, unused_buffer] : buffers_by_layer_) {
+  for (auto& [layer, unused_buffer] : vertex_buffers_by_layer_) {
     layers.push_back(layer);
   }
   return layers;
 };
 
-void TextRenderer::ToScreenSpace(float a_X, float a_Y, float& o_X, float& o_Y) {
-  float WorldWidth = m_Canvas->GetWorldWidth();
-  float WorldHeight = m_Canvas->GetWorldHeight();
-  float WorldTopLeftX = m_Canvas->GetWorldTopLeftX();
-  float WorldMinLeftY = m_Canvas->GetWorldTopLeftY() - WorldHeight;
+void TextRenderer::ToScreenSpace(float x, float y, float& o_x, float& o_y) {
+  float world_width = canvas_->GetWorldWidth();
+  float world_height = canvas_->GetWorldHeight();
+  float world_top_left_x = canvas_->GetWorldTopLeftX();
+  float world_min_left_y = canvas_->GetWorldTopLeftY() - world_height;
 
-  o_X = ((a_X - WorldTopLeftX) / WorldWidth) * m_Canvas->GetWidth();
-  o_Y = ((a_Y - WorldMinLeftY) / WorldHeight) * m_Canvas->GetHeight();
+  o_x = ((x - world_top_left_x) / world_width) * canvas_->GetWidth();
+  o_y = ((y - world_min_left_y) / world_height) * canvas_->GetHeight();
 }
 
-float TextRenderer::ToScreenSpace(float a_Size) {
-  return (a_Size / m_Canvas->GetWorldWidth()) * m_Canvas->GetWidth();
+float TextRenderer::ToScreenSpace(float width) {
+  return (width / canvas_->GetWorldWidth()) * canvas_->GetWidth();
 }
 
 void TextRenderer::Clear() {
-  m_Pen.x = 0.f;
-  m_Pen.y = 0.f;
-  for (auto& [unused_layer, buffer] : buffers_by_layer_) {
+  pen_.x = 0.f;
+  pen_.y = 0.f;
+  for (auto& [unused_layer, buffer] : vertex_buffers_by_layer_) {
     vertex_buffer_clear(buffer);
   }
 }

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -34,8 +34,7 @@ using orbit_client_protos::TimerInfo;
 
 TimeGraph* GCurrentTimeGraph = nullptr;
 
-TimeGraph::TimeGraph(uint32_t font_size)
-    : font_size_(font_size), text_renderer_static_(font_size), batcher_(BatcherId::kTimeGraph) {
+TimeGraph::TimeGraph(uint32_t font_size) : font_size_(font_size), batcher_(BatcherId::kTimeGraph) {
   scheduler_track_ = GetOrCreateSchedulerTrack();
 
   tracepoints_system_wide_track_ =
@@ -64,11 +63,6 @@ void TimeGraph::SetCanvas(GlCanvas* canvas) {
   text_renderer_->SetCanvas(canvas);
   text_renderer_static_.SetCanvas(canvas);
   batcher_.SetPickingManager(&canvas->GetPickingManager());
-}
-
-void TimeGraph::SetFontSize(uint32_t font_size) {
-  text_renderer_->SetFontSize(font_size);
-  text_renderer_static_.SetFontSize(font_size);
 }
 
 void TimeGraph::Clear() {
@@ -661,9 +655,9 @@ void TimeGraph::DrawIteratorBox(GlCanvas* canvas, Vec2 pos, Vec2 size, const Col
   float max_size = size[0];
 
   const Color kBlack(0, 0, 0, 255);
-  int text_width = canvas->GetTextRenderer().AddTextTrailingCharsPrioritized(
+  float text_width = canvas->GetTextRenderer().AddTextTrailingCharsPrioritized(
       text.c_str(), pos[0], text_box_y + layout_.GetTextOffset(), GlCanvas::kZValueText, kBlack,
-      time.length(), GetFontSize(), max_size);
+      time.length(), font_size_, max_size);
 
   Vec2 white_box_size(std::min(static_cast<float>(text_width), max_size), GetTextBoxHeight());
   Vec2 white_box_position(pos[0], text_box_y);
@@ -1246,7 +1240,7 @@ const TextBox* TimeGraph::FindDown(const TextBox* from) {
 
 void TimeGraph::DrawText(GlCanvas* canvas, float layer) {
   if (draw_text_) {
-    text_renderer_static_.DisplayLayer(canvas->GetBatcher(), layer);
+    text_renderer_static_.RenderLayer(canvas->GetBatcher(), layer);
   }
 }
 

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -112,8 +112,6 @@ class TimeGraph {
   [[nodiscard]] StringManager* GetStringManager() { return string_manager_.get(); }
   void SetCanvas(GlCanvas* canvas);
   [[nodiscard]] GlCanvas* GetCanvas() { return canvas_; }
-  void SetFontSize(uint32_t font_size);
-  [[nodiscard]] uint32_t GetFontSize() const { return text_renderer_static_.GetFontSize(); }
   [[nodiscard]] uint32_t CalculateZoomedFontSize() const {
     return lround((font_size_)*layout_.GetScale());
   }

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -158,17 +158,19 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
   collapse_toggle_->SetPos(toggle_pos);
   collapse_toggle_->Draw(canvas, picking_mode, z_offset);
 
+  // Draw label.
   if (!picking) {
-    // Draw label.
+    uint32_t font_size = time_graph_->CalculateZoomedFontSize();
+    auto& text_renderer = canvas->GetTextRenderer();
     float label_offset_x = layout.GetTrackLabelOffsetX();
-    // Vertical offset for the text to be aligned to the center of the triangle.
-    float label_offset_y = GCurrentTimeGraph->GetFontSize() / 3.f;
+    float label_offset_y = text_renderer.GetStringHeight("o", font_size) / 2.f;
+
     const Color kColor =
         IsTrackSelected() ? GlCanvas::kTabTextColorSelected : Color(255, 255, 255, 255);
-    canvas->GetTextRenderer().AddTextTrailingCharsPrioritized(
+
+    text_renderer.AddTextTrailingCharsPrioritized(
         label_.c_str(), tab_x0 + label_offset_x, toggle_y_pos - label_offset_y, text_z, kColor,
-        GetNumberOfPrioritizedTrailingCharacters(), time_graph_->CalculateZoomedFontSize(),
-        label_width - label_offset_x);
+        GetNumberOfPrioritizedTrailingCharacters(), font_size, label_width - label_offset_x);
   }
 
   canvas_ = canvas;


### PR DESCRIPTION
- Font size is now only passed as argument to the AddText methods
- GetStringWidth now takes font size as input
- Add GetStringHeight method
- Revive DrawOutline for character debug rendering
- Rename variables

There were strange bugs caused by the fact that the text renderer
kept the last font size passed by a call to AddText as the current
font size to be used by other methods like GetStringWidth.