### PR TITLE
Add option for enabling a frame track for a function to Functions tab

### DIFF
--- a/OrbitCore/CaptureData.cpp
+++ b/OrbitCore/CaptureData.cpp
@@ -159,15 +159,15 @@ int32_t CaptureData::process_id() const { return process_.pid(); }
 
 std::string CaptureData::process_name() const { return process_.name(); }
 
-void CaptureData::InsertFrameTrack(const FunctionInfo& function) {
+void CaptureData::EnableFrameTrack(const FunctionInfo& function) {
   user_defined_capture_data_.InsertFrameTrack(function);
 }
 
-void CaptureData::EraseFrameTrack(const FunctionInfo& function) {
+void CaptureData::DisableFrameTrack(const FunctionInfo& function) {
   user_defined_capture_data_.EraseFrameTrack(function);
 }
 
-[[nodiscard]] bool CaptureData::ContainsFrameTrack(const FunctionInfo& function) const {
+[[nodiscard]] bool CaptureData::IsFrameTrackEnabled(const FunctionInfo& function) const {
   return user_defined_capture_data_.ContainsFrameTrack(function);
 }
 

--- a/OrbitCore/CaptureData.h
+++ b/OrbitCore/CaptureData.h
@@ -198,9 +198,9 @@ class CaptureData {
     sampling_profiler_ = std::move(sampling_profiler);
   }
 
-  void InsertFrameTrack(const orbit_client_protos::FunctionInfo& function);
-  void EraseFrameTrack(const orbit_client_protos::FunctionInfo& function);
-  [[nodiscard]] bool ContainsFrameTrack(const orbit_client_protos::FunctionInfo& function) const;
+  void EnableFrameTrack(const orbit_client_protos::FunctionInfo& function);
+  void DisableFrameTrack(const orbit_client_protos::FunctionInfo& function);
+  [[nodiscard]] bool IsFrameTrackEnabled(const orbit_client_protos::FunctionInfo& function) const;
   void ClearUserDefinedCaptureData();
   [[nodiscard]] const UserDefinedCaptureData& user_defined_capture_data() const {
     return user_defined_capture_data_;

--- a/OrbitCore/UserDefinedCaptureData.cpp
+++ b/OrbitCore/UserDefinedCaptureData.cpp
@@ -7,13 +7,11 @@
 #include "OrbitClientData/FunctionUtils.h"
 
 void UserDefinedCaptureData::InsertFrameTrack(const orbit_client_protos::FunctionInfo& function) {
-  // We do not allow insertion of frame tracks twice.
-  CHECK(frame_track_functions_.insert(function).second);
+  frame_track_functions_.insert(function);
 }
 
 void UserDefinedCaptureData::EraseFrameTrack(const orbit_client_protos::FunctionInfo& function) {
-  // We do not allow erasing a frame track that does not exist.
-  CHECK(frame_track_functions_.erase(function));
+  frame_track_functions_.erase(function);
 }
 
 [[nodiscard]] bool UserDefinedCaptureData::ContainsFrameTrack(

--- a/OrbitCore/UserDefinedCaptureDataTest.cpp
+++ b/OrbitCore/UserDefinedCaptureDataTest.cpp
@@ -34,7 +34,8 @@ TEST(UserDefinedCaptureData, InsertFrameTrackDuplicateFunctions) {
   UserDefinedCaptureData data;
   FunctionInfo info = CreateFunctionInfo("fun0_name", 0);
   data.InsertFrameTrack(info);
-  EXPECT_DEATH(data.InsertFrameTrack(info), "");
+  data.InsertFrameTrack(info);
+  EXPECT_TRUE(data.ContainsFrameTrack(info));
 }
 
 TEST(UserDefinedCaptureData, InsertFrameTrackDifferentFunctions) {
@@ -50,7 +51,8 @@ TEST(UserDefinedCaptureData, InsertFrameTrackDifferentFunctions) {
 TEST(UserDefinedCaptureData, EraseNonExistentFrameTrack) {
   UserDefinedCaptureData data;
   FunctionInfo info = CreateFunctionInfo("fun0_name", 0);
-  EXPECT_DEATH(data.EraseFrameTrack(info), "");
+  data.EraseFrameTrack(info);
+  EXPECT_FALSE(data.ContainsFrameTrack(info));
 }
 
 TEST(UserDefinedCaptureData, EraseFrameTrack) {

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -131,6 +131,7 @@ void CallStackDataView::OnContextMenu(const std::string& action, int menu_index,
       CallStackDataViewFrame frame = GetFrameFromRow(i);
       const FunctionInfo* function = frame.function;
       GOrbitApp->DeselectFunction(*function);
+      GOrbitApp->DisableFrameTrack(*function);
     }
 
   } else if (action == kMenuActionDisassembly) {

--- a/OrbitGl/DataManager.cpp
+++ b/OrbitGl/DataManager.cpp
@@ -134,3 +134,17 @@ bool DataManager::IsTracepointSelected(const TracepointInfo& info) const {
 }
 
 const TracepointInfoSet& DataManager::selected_tracepoints() const { return selected_tracepoints_; }
+
+void DataManager::EnableFrameTrack(const FunctionInfo& function) {
+  user_defined_capture_data_.InsertFrameTrack(function);
+}
+
+void DataManager::DisableFrameTrack(const FunctionInfo& function) {
+  user_defined_capture_data_.EraseFrameTrack(function);
+}
+
+[[nodiscard]] bool DataManager::IsFrameTrackEnabled(const FunctionInfo& function) const {
+  return user_defined_capture_data_.ContainsFrameTrack(function);
+}
+
+void DataManager::ClearUserDefinedCaptureData() { user_defined_capture_data_.Clear(); }

--- a/OrbitGl/DataManager.h
+++ b/OrbitGl/DataManager.h
@@ -54,13 +54,18 @@ class DataManager final {
 
   [[nodiscard]] const TracepointInfoSet& selected_tracepoints() const;
 
+  void EnableFrameTrack(const orbit_client_protos::FunctionInfo& function);
+  void DisableFrameTrack(const orbit_client_protos::FunctionInfo& function);
+  [[nodiscard]] bool IsFrameTrackEnabled(const orbit_client_protos::FunctionInfo& function) const;
+  void ClearUserDefinedCaptureData();
+
   void set_user_defined_capture_data(const UserDefinedCaptureData& user_defined_capture_data) {
     user_defined_capture_data_ = user_defined_capture_data;
   }
-  [[nodiscard]] const UserDefinedCaptureData& mutable_user_defined_capture_data() const {
+  [[nodiscard]] const UserDefinedCaptureData& user_defined_capture_data() const {
     return user_defined_capture_data_;
   }
-  [[nodiscard]] UserDefinedCaptureData& user_defined_capture_data() {
+  [[nodiscard]] UserDefinedCaptureData& mutable_user_defined_capture_data() {
     return user_defined_capture_data_;
   }
 

--- a/OrbitGl/FunctionsDataView.h
+++ b/OrbitGl/FunctionsDataView.h
@@ -12,8 +12,10 @@ class FunctionsDataView : public DataView {
  public:
   FunctionsDataView();
 
-  static const std::string kSelectedFunctionString;
   static const std::string kUnselectedFunctionString;
+  static const std::string kSelectedFunctionString;
+  static const std::string kFrameTrackString;
+  static std::string BuildSelectedColumnsString(const orbit_client_protos::FunctionInfo& function);
 
   const std::vector<Column>& GetColumns() override;
   int GetDefaultSortingColumn() override { return kColumnAddress; }
@@ -49,6 +51,8 @@ class FunctionsDataView : public DataView {
 
   static const std::string kMenuActionSelect;
   static const std::string kMenuActionUnselect;
+  static const std::string kMenuActionEnableFrameTrack;
+  static const std::string kMenuActionDisableFrameTrack;
   static const std::string kMenuActionDisassembly;
 
  private:

--- a/OrbitGl/LiveFunctionsController.cpp
+++ b/OrbitGl/LiveFunctionsController.cpp
@@ -213,14 +213,6 @@ void LiveFunctionsController::AddIterator(FunctionInfo* function) {
   Move();
 }
 
-void LiveFunctionsController::AddFrameTrack(const FunctionInfo& function) {
-  GOrbitApp->AddFrameTrack(function);
-}
-
-void LiveFunctionsController::RemoveFrameTrack(const FunctionInfo& function) {
-  GOrbitApp->RemoveFrameTrack(function);
-}
-
 uint64_t LiveFunctionsController::GetStartTime(uint64_t index) {
   const auto& it = current_textboxes_.find(index);
   if (it != current_textboxes_.end()) {

--- a/OrbitGl/LiveFunctionsController.h
+++ b/OrbitGl/LiveFunctionsController.h
@@ -39,8 +39,6 @@ class LiveFunctionsController {
   uint64_t GetStartTime(uint64_t index);
 
   void AddIterator(orbit_client_protos::FunctionInfo* function);
-  void AddFrameTrack(const orbit_client_protos::FunctionInfo& function);
-  void RemoveFrameTrack(const orbit_client_protos::FunctionInfo& function);
 
  private:
   void Move();

--- a/OrbitGl/LiveFunctionsDataView.h
+++ b/OrbitGl/LiveFunctionsDataView.h
@@ -58,8 +58,8 @@ class LiveFunctionsDataView : public DataView {
   static const std::string kMenuActionJumpToMax;
   static const std::string kMenuActionDisassembly;
   static const std::string kMenuActionIterate;
-  static const std::string kMenuActionFrameTrack;
-  static const std::string kMenuActionRemoveFrameTrack;
+  static const std::string kMenuActionEnableFrameTrack;
+  static const std::string kMenuActionDisableFrameTrack;
 };
 
 #endif  // ORBIT_GL_LIVE_FUNCTIONS_DATA_VIEW_H_

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -229,6 +229,7 @@ void SamplingReportDataView::OnContextMenu(const std::string& action, int menu_i
   } else if (action == kMenuActionUnselect) {
     for (const FunctionInfo* function : GetFunctionsFromIndices(item_indices)) {
       GOrbitApp->DeselectFunction(*function);
+      GOrbitApp->DisableFrameTrack(*function);
     }
   } else if (action == kMenuActionLoadSymbols) {
     std::vector<ModuleData*> modules_to_load;

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -1269,6 +1269,10 @@ bool TimeGraph::IsVisible(VisibilityType vis_type, uint64_t min, uint64_t max) c
   }
 }
 
+bool TimeGraph::HasFrameTrack(const orbit_client_protos::FunctionInfo& function) const {
+  return frame_tracks_.count(function.address()) > 0;
+}
+
 void TimeGraph::RemoveFrameTrack(const orbit_client_protos::FunctionInfo& function) {
   frame_tracks_.erase(function.address());
   sorting_invalidated_ = true;

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -169,6 +169,7 @@ class TimeGraph {
   [[nodiscard]] uint64_t GetCaptureMax() const { return capture_max_timestamp_; }
   [[nodiscard]] uint64_t GetCurrentMouseTimeNs() const { return current_mouse_time_ns_; }
 
+  [[nodiscard]] bool HasFrameTrack(const orbit_client_protos::FunctionInfo& function) const;
   void RemoveFrameTrack(const orbit_client_protos::FunctionInfo& function);
 
  protected:

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -90,6 +90,7 @@ class OrbitMainWindow : public QMainWindow {
   void on_actionServiceStackOverflow_triggered();
 
   void ShowCaptureOnSaveWarningIfNeeded();
+  void ShowEmptyFrameTrackWarningIfNeeded(std::string_view function);
 
  private:
   void StartMainTimer();


### PR DESCRIPTION
So far it was only possible to add frame tracks after taking a capture.
With this change, it is now possible to enable a frame track (or
multiple) even before the first capture. This is possible from the
Functions tab by choosing the context menu option
"Enable frame track(s)".

Note that a function that is chosen as a frame track must be hooked, so
if a function is not hooked when enabling it as a frame track, it is
automatically hooked.

Bug: http://b/173191435

Tested: Lots of manual tests with taking captures, loading/saving
presets, loading/saving captures.