### PR TITLE
Add IntrospectionWindow class

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -509,13 +509,13 @@ void OrbitApp::MainTick() {
   }
 }
 
-void OrbitApp::RegisterCaptureWindow(CaptureWindow* capture) {
+void OrbitApp::SetCaptureWindow(CaptureWindow* capture) {
   CHECK(capture_window_ == nullptr);
   GCurrentTimeGraph = capture->GetTimeGraph();
   capture_window_ = capture;
 }
 
-void OrbitApp::RegisterDebugCanvas(GlCanvas* debug_canvas) {
+void OrbitApp::SetDebugCanvas(GlCanvas* debug_canvas) {
   CHECK(debug_canvas_ == nullptr);
   debug_canvas_ = debug_canvas;
   debug_canvas_->EnableImGui();
@@ -523,7 +523,7 @@ void OrbitApp::RegisterDebugCanvas(GlCanvas* debug_canvas) {
   debug_canvas_->AddRenderCallback([this]() { RenderImGui(); });
 }
 
-void OrbitApp::RegisterIntrospectionWindow(IntrospectionWindow* introspection_window) {
+void OrbitApp::SetIntrospectionWindow(IntrospectionWindow* introspection_window) {
   CHECK(introspection_window_ == nullptr);
   introspection_window_ = introspection_window;
 }

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -170,6 +170,7 @@ void OrbitApp::OnCaptureComplete() {
 
   main_thread_executor_->Schedule(
       [this, sampling_profiler = std::move(sampling_profiler)]() mutable {
+        ORBIT_SCOPE("OnCaptureComplete");
         GetMutableCaptureData().set_sampling_profiler(sampling_profiler);
         RefreshCaptureView();
 
@@ -190,6 +191,7 @@ void OrbitApp::OnCaptureComplete() {
 
 void OrbitApp::OnCaptureCancelled() {
   main_thread_executor_->Schedule([this]() mutable {
+    ORBIT_SCOPE("OnCaptureCancelled");
     CHECK(capture_failed_callback_);
     capture_failed_callback_();
 
@@ -202,6 +204,7 @@ void OrbitApp::OnCaptureCancelled() {
 
 void OrbitApp::OnCaptureFailed(ErrorMessage error_message) {
   main_thread_executor_->Schedule([this, error_message = std::move(error_message)]() mutable {
+    ORBIT_SCOPE("OnCaptureFailed");
     CHECK(capture_failed_callback_);
     capture_failed_callback_();
 
@@ -417,6 +420,7 @@ void OrbitApp::ListPresets() {
 }
 
 void OrbitApp::RefreshCaptureView() {
+  ORBIT_SCOPE_FUNCTION;
   NeedsRedraw();
   GOrbitApp->FireRefreshCallbacks();
   DoZoom = true;  // TODO: remove global, review logic
@@ -437,6 +441,9 @@ void OrbitApp::RenderImGui() {
   ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0.0f);
   ImGui::Begin("OrbitDebug", nullptr, ImVec2(0, 0), 1.f, window_flags);
   capture_window_->RenderImGui();
+  if (introspection_window_) {
+    introspection_window_->RenderImGui();
+  }
   ImGui::PopStyleVar();
   ImGui::PopStyleColor();
   ImGui::End();
@@ -491,6 +498,7 @@ Timer GMainTimer;
 
 // TODO: make it non-static
 void OrbitApp::MainTick() {
+  ORBIT_SCOPE("OrbitApp::MainTick");
   GMainTimer.Restart();
 
   if (DoZoom && GOrbitApp->HasCaptureData()) {
@@ -503,6 +511,7 @@ void OrbitApp::MainTick() {
 
 void OrbitApp::RegisterCaptureWindow(CaptureWindow* capture) {
   CHECK(capture_window_ == nullptr);
+  GCurrentTimeGraph = capture->GetTimeGraph();
   capture_window_ = capture;
 }
 
@@ -514,6 +523,17 @@ void OrbitApp::RegisterDebugCanvas(GlCanvas* debug_canvas) {
   debug_canvas_->AddRenderCallback([this]() { RenderImGui(); });
 }
 
+void OrbitApp::RegisterIntrospectionWindow(IntrospectionWindow* introspection_window) {
+  CHECK(introspection_window_ == nullptr);
+  introspection_window_ = introspection_window;
+}
+
+void OrbitApp::StopIntrospection() {
+  if (introspection_window_) {
+    introspection_window_->StopIntrospection();
+  }
+}
+
 void OrbitApp::NeedsRedraw() {
   if (capture_window_ != nullptr) {
     capture_window_->NeedsUpdate();
@@ -523,6 +543,7 @@ void OrbitApp::NeedsRedraw() {
 void OrbitApp::SetSamplingReport(
     SamplingProfiler sampling_profiler,
     absl::flat_hash_map<CallstackID, std::shared_ptr<CallStack>> unique_callstacks) {
+  ORBIT_SCOPE_FUNCTION;
   // clear old sampling report
   if (sampling_report_ != nullptr) {
     sampling_report_->ClearReport();
@@ -557,6 +578,7 @@ void OrbitApp::SetSelectionReport(
 }
 
 void OrbitApp::SetTopDownView(const CaptureData& capture_data) {
+  ORBIT_SCOPE_FUNCTION;
   CHECK(top_down_view_callback_);
   std::unique_ptr<CallTreeView> top_down_view = CallTreeView::CreateTopDownViewFromSamplingProfiler(
       capture_data.sampling_profiler(), capture_data);
@@ -583,6 +605,7 @@ void OrbitApp::ClearSelectionTopDownView() {
 }
 
 void OrbitApp::SetBottomUpView(const CaptureData& capture_data) {
+  ORBIT_SCOPE_FUNCTION;
   CHECK(bottom_up_view_callback_);
   std::unique_ptr<CallTreeView> bottom_up_view =
       CallTreeView::CreateBottomUpViewFromSamplingProfiler(capture_data.sampling_profiler(),
@@ -803,6 +826,7 @@ void OrbitApp::AbortCapture() {
 }
 
 void OrbitApp::ClearCapture() {
+  ORBIT_SCOPE_FUNCTION;
   capture_data_.reset();
   set_selected_thread_id(SamplingProfiler::kAllThreadsFakeTid);
   SelectTextBox(nullptr);
@@ -1502,7 +1526,9 @@ void OrbitApp::CrashOrbitService(CrashOrbitServiceRequest_CrashType crash_type) 
   }
 }
 
-bool OrbitApp::IsCapturing() const { return capture_client_->IsCapturing(); }
+bool OrbitApp::IsCapturing() const {
+  return capture_client_ ? capture_client_->IsCapturing() : false;
+}
 
 ScopedStatus OrbitApp::CreateScopedStatus(const std::string& initial_message) {
   CHECK(std::this_thread::get_id() == main_thread_id_);

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -130,9 +130,9 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
 
   void OnValidateFramePointers(std::vector<const ModuleData*> modules_to_validate);
 
-  void RegisterCaptureWindow(CaptureWindow* capture);
-  void RegisterDebugCanvas(GlCanvas* debug_canvas);
-  void RegisterIntrospectionWindow(IntrospectionWindow* canvas);
+  void SetCaptureWindow(CaptureWindow* capture);
+  void SetDebugCanvas(GlCanvas* debug_canvas);
+  void SetIntrospectionWindow(IntrospectionWindow* canvas);
   void StopIntrospection();
 
   void SetSamplingReport(

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -28,6 +28,7 @@
 #include "FrameTrackOnlineProcessor.h"
 #include "FunctionsDataView.h"
 #include "ImGuiOrbit.h"
+#include "IntrospectionWindow.h"
 #include "LiveFunctionsDataView.h"
 #include "MainThreadExecutor.h"
 #include "ModulesDataView.h"
@@ -131,6 +132,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
 
   void RegisterCaptureWindow(CaptureWindow* capture);
   void RegisterDebugCanvas(GlCanvas* debug_canvas);
+  void RegisterIntrospectionWindow(IntrospectionWindow* canvas);
+  void StopIntrospection();
 
   void SetSamplingReport(
       SamplingProfiler sampling_profiler,
@@ -392,6 +395,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   std::unique_ptr<TracepointsDataView> tracepoints_data_view_;
 
   CaptureWindow* capture_window_ = nullptr;
+  IntrospectionWindow* introspection_window_ = nullptr;
   GlCanvas* debug_canvas_ = nullptr;
 
   std::shared_ptr<SamplingReport> sampling_report_;

--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -36,6 +36,7 @@ target_sources(
          GraphTrack.h
          Images.h
          ImGuiOrbit.h
+         IntrospectionWindow.h
          LiveFunctionsController.h
          LiveFunctionsDataView.h
          ManualInstrumentationManager.h
@@ -88,6 +89,7 @@ target_sources(
           GpuTrack.cpp
           GraphTrack.cpp
           ImGuiOrbit.cpp
+          IntrospectionWindow.cpp
           LiveFunctionsDataView.cpp
           ManualInstrumentationManager.cpp
           ModulesDataView.cpp

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -13,7 +13,6 @@ using orbit_client_protos::TimerInfo;
 
 CaptureWindow::CaptureWindow(uint32_t font_size)
     : GlCanvas(font_size), font_size_(font_size), time_graph_(font_size) {
-  GCurrentTimeGraph = &time_graph_;
   time_graph_.SetTextRenderer(&text_renderer_);
   time_graph_.SetCanvas(this);
   draw_help_ = true;
@@ -43,8 +42,6 @@ CaptureWindow::CaptureWindow(uint32_t font_size)
 
   vertical_slider_->SetOrthogonalSliderPixelHeight(slider_->GetPixelHeight());
   slider_->SetOrthogonalSliderPixelHeight(vertical_slider_->GetPixelHeight());
-
-  GOrbitApp->RegisterCaptureWindow(this);
 }
 
 CaptureWindow::~CaptureWindow() {
@@ -403,11 +400,7 @@ void CaptureWindow::KeyPressed(unsigned int key_code, bool ctrl, bool shift, boo
         draw_help_ = !draw_help_;
         break;
       case 'X':
-        GOrbitApp->ToggleCapture();
-        draw_help_ = false;
-#ifdef __linux__
-        ZoomAll();
-#endif
+        ToggleCapture();
         break;
       case 'O':
         if (ctrl) {
@@ -469,10 +462,13 @@ void CaptureWindow::OnCaptureStarted() {
   NeedsRedraw();
 }
 
+bool CaptureWindow::ShouldAutoZoom() { return GOrbitApp->IsCapturing(); }
+
 void CaptureWindow::Draw() {
+  ORBIT_SCOPE("CaptureWindow::Draw");
   world_max_y_ = 1.5f * ScreenToWorldHeight(static_cast<int>(slider_->GetPixelHeight()));
 
-  if (GOrbitApp->IsCapturing()) {
+  if (ShouldAutoZoom()) {
     ZoomAll();
   }
 
@@ -528,6 +524,7 @@ void CaptureWindow::Draw() {
 }
 
 void CaptureWindow::DrawScreenSpace() {
+  ORBIT_SCOPE("CaptureWindow::DrawScreenSpace");
   double time_span = time_graph_.GetCaptureTimeSpanUs();
 
   Color col = slider_->GetBarColor();
@@ -620,6 +617,14 @@ void CaptureWindow::UpdateWorldTopLeftY(float val) {
   NeedsUpdate();
 }
 
+void CaptureWindow::ToggleCapture() {
+  GOrbitApp->ToggleCapture();
+  draw_help_ = false;
+#ifdef __linux__
+  ZoomAll();
+#endif
+}
+
 void CaptureWindow::ToggleDrawHelp() { set_draw_help(!draw_help_); }
 
 void CaptureWindow::set_draw_help(bool draw_help) {
@@ -679,10 +684,18 @@ void CaptureWindow::RenderImGui() {
       IMGUI_VAR_TO_TEXT(time_graph_.GetNumDrawnTextBoxes());
       IMGUI_VAR_TO_TEXT(time_graph_.GetNumTimers());
       IMGUI_VAR_TO_TEXT(time_graph_.GetThreadTotalHeight());
+      IMGUI_VAR_TO_TEXT(time_graph_.GetMinTimeUs());
+      IMGUI_VAR_TO_TEXT(time_graph_.GetMaxTimeUs());
+      IMGUI_VAR_TO_TEXT(time_graph_.GetCaptureMin());
+      IMGUI_VAR_TO_TEXT(time_graph_.GetCaptureMax());
+      IMGUI_VAR_TO_TEXT(time_graph_.GetTimeWindowUs());
 
-      IMGUI_VAR_TO_TEXT(
-          GOrbitApp->GetCaptureData().GetCallstackData()->callstack_events_by_tid().size());
-      IMGUI_VAR_TO_TEXT(GOrbitApp->GetCaptureData().GetCallstackData()->GetCallstackEventsCount());
+      if (GOrbitApp->HasCaptureData()) {
+        IMGUI_VAR_TO_TEXT(
+            GOrbitApp->GetCaptureData().GetCallstackData()->callstack_events_by_tid().size());
+        IMGUI_VAR_TO_TEXT(
+            GOrbitApp->GetCaptureData().GetCallstackData()->GetCallstackEventsCount());
+      }
 
       ImGui::EndTabItem();
     }
@@ -700,6 +713,7 @@ void CaptureWindow::RenderImGui() {
 }
 
 void CaptureWindow::RenderText(float layer) {
+  ORBIT_SCOPE_FUNCTION;
   if (GetPickingMode() == PickingMode::kNone) {
     time_graph_.DrawText(this, layer);
   }
@@ -725,19 +739,10 @@ void CaptureWindow::RenderHelpUi() {
   float world_y = 0;
   ScreenToWorld(kXOffset, kYOffset, world_x, world_y);
 
-  const char* help_message =
-      "Start/Stop Capture: 'X'\n"
-      "Pan: 'A','D' or \"Left Click + Drag\"\n"
-      "Zoom: 'W', 'S', Scroll or \"Ctrl + Right Click + Drag\"\n"
-      "Vertical Zoom: \"Ctrl + Scroll\"\n"
-      "Select: Left Click\n"
-      "Measure: \"Right Click + Drag\"\n"
-      "Toggle Help: 'H'";
-
   const uint32_t kHelpMessageFontSize = 2 * font_size_;
   Vec2 text_bounding_box_pos;
   Vec2 text_bounding_box_size;
-  text_renderer_.AddText(help_message, world_x, world_y, GlCanvas::kZValueTextUi,
+  text_renderer_.AddText(GetHelpText(), world_x, world_y, GlCanvas::kZValueTextUi,
                          Color(255, 255, 255, 255), kHelpMessageFontSize, -1.f /*max_size*/,
                          false /*right_justified*/, &text_bounding_box_pos,
                          &text_bounding_box_size);
@@ -747,6 +752,18 @@ void CaptureWindow::RenderHelpUi() {
   const float kRoundingRadius = 20.f;
   ui_batcher_.AddRoundedBox(text_bounding_box_pos, text_bounding_box_size, GlCanvas::kZValueUi,
                             kRoundingRadius, kBoxColor, kMargin);
+}
+
+const char* CaptureWindow::GetHelpText() {
+  const char* help_message =
+      "Start/Stop Capture: 'X'\n"
+      "Pan: 'A','D' or \"Left Click + Drag\"\n"
+      "Zoom: 'W', 'S', Scroll or \"Ctrl + Right Click + Drag\"\n"
+      "Vertical Zoom: \"Ctrl + Scroll\"\n"
+      "Select: Left Click\n"
+      "Measure: \"Right Click + Drag\"\n"
+      "Toggle Help: 'H'";
+  return help_message;
 }
 
 inline double GetIncrementMs(double milli_seconds) {

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -400,7 +400,7 @@ void CaptureWindow::KeyPressed(unsigned int key_code, bool ctrl, bool shift, boo
         draw_help_ = !draw_help_;
         break;
       case 'X':
-        ToggleCapture();
+        ToggleRecording();
         break;
       case 'O':
         if (ctrl) {
@@ -617,7 +617,7 @@ void CaptureWindow::UpdateWorldTopLeftY(float val) {
   NeedsUpdate();
 }
 
-void CaptureWindow::ToggleCapture() {
+void CaptureWindow::ToggleRecording() {
   GOrbitApp->ToggleCapture();
   draw_help_ = false;
 #ifdef __linux__

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -462,7 +462,7 @@ void CaptureWindow::OnCaptureStarted() {
   NeedsRedraw();
 }
 
-bool CaptureWindow::ShouldAutoZoom() { return GOrbitApp->IsCapturing(); }
+bool CaptureWindow::ShouldAutoZoom() const { return GOrbitApp->IsCapturing(); }
 
 void CaptureWindow::Draw() {
   ORBIT_SCOPE("CaptureWindow::Draw");
@@ -754,7 +754,7 @@ void CaptureWindow::RenderHelpUi() {
                             kRoundingRadius, kBoxColor, kMargin);
 }
 
-const char* CaptureWindow::GetHelpText() {
+const char* CaptureWindow::GetHelpText() const {
   const char* help_message =
       "Start/Stop Capture: 'X'\n"
       "Pan: 'A','D' or \"Left Click + Drag\"\n"

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -59,12 +59,18 @@ class CaptureWindow : public GlCanvas {
   void OnCaptureStarted();
   std::vector<std::string> GetContextMenu() override;
   void OnContextMenu(const std::string& action, int menu_index) override;
+  virtual void ToggleCapture();
   void ToggleDrawHelp();
   void set_draw_help(bool draw_help);
+  [[nodiscard]] TimeGraph* GetTimeGraph() { return &time_graph_; }
 
   Batcher& GetBatcherById(BatcherId batcher_id);
 
- private:
+ protected:
+  [[nodiscard]] virtual const char* GetHelpText();
+  [[nodiscard]] virtual bool ShouldAutoZoom();
+
+ protected:
   uint32_t font_size_;
   TimeGraph time_graph_;
   bool draw_help_;

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -59,7 +59,7 @@ class CaptureWindow : public GlCanvas {
   void OnCaptureStarted();
   std::vector<std::string> GetContextMenu() override;
   void OnContextMenu(const std::string& action, int menu_index) override;
-  virtual void ToggleCapture();
+  virtual void ToggleRecording();
   void ToggleDrawHelp();
   void set_draw_help(bool draw_help);
   [[nodiscard]] TimeGraph* GetTimeGraph() { return &time_graph_; }

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -67,8 +67,8 @@ class CaptureWindow : public GlCanvas {
   Batcher& GetBatcherById(BatcherId batcher_id);
 
  protected:
-  [[nodiscard]] virtual const char* GetHelpText();
-  [[nodiscard]] virtual bool ShouldAutoZoom();
+  [[nodiscard]] virtual const char* GetHelpText() const;
+  [[nodiscard]] virtual bool ShouldAutoZoom() const;
 
  protected:
   uint32_t font_size_;

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -101,12 +101,12 @@ std::unique_ptr<GlCanvas> GlCanvas::Create(CanvasType canvas_type, uint32_t font
   switch (canvas_type) {
     case CanvasType::kCaptureWindow: {
       auto main_capture_window = std::make_unique<CaptureWindow>(font_size);
-      GOrbitApp->RegisterCaptureWindow(main_capture_window.get());
+      GOrbitApp->SetCaptureWindow(main_capture_window.get());
       return main_capture_window;
     }
     case CanvasType::kIntrospectionWindow: {
       auto introspection_window = std::make_unique<IntrospectionWindow>(font_size);
-      GOrbitApp->RegisterIntrospectionWindow(introspection_window.get());
+      GOrbitApp->SetIntrospectionWindow(introspection_window.get());
       return introspection_window;
     }
     case CanvasType::kDebug:

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -9,6 +9,7 @@
 #include "App.h"
 #include "GlUtils.h"
 #include "ImGuiOrbit.h"
+#include "IntrospectionWindow.h"
 #include "OpenGl.h"
 #include "SamplingProfiler.h"
 #include "TextBox.h"
@@ -98,8 +99,16 @@ GlCanvas::~GlCanvas() {
 
 std::unique_ptr<GlCanvas> GlCanvas::Create(CanvasType canvas_type, uint32_t font_size) {
   switch (canvas_type) {
-    case CanvasType::kCaptureWindow:
-      return std::make_unique<CaptureWindow>(font_size);
+    case CanvasType::kCaptureWindow: {
+      auto main_capture_window = std::make_unique<CaptureWindow>(font_size);
+      GOrbitApp->RegisterCaptureWindow(main_capture_window.get());
+      return main_capture_window;
+    }
+    case CanvasType::kIntrospectionWindow: {
+      auto introspection_window = std::make_unique<IntrospectionWindow>(font_size);
+      GOrbitApp->RegisterIntrospectionWindow(introspection_window.get());
+      return introspection_window;
+    }
     case CanvasType::kDebug:
       return std::make_unique<GlCanvas>(font_size);
     default:
@@ -280,6 +289,7 @@ void GlCanvas::Prepare2DViewport(int top_left_x, int top_left_y, int bottom_righ
 }
 
 void GlCanvas::PrepareScreenSpaceViewport() {
+  ORBIT_SCOPE_FUNCTION;
   glViewport(0, 0, GetWidth(), GetHeight());
   glMatrixMode(GL_PROJECTION);
   glLoadIdentity();
@@ -337,6 +347,7 @@ int GlCanvas::GetWidth() const { return screen_width_; }
 int GlCanvas::GetHeight() const { return screen_height_; }
 
 void GlCanvas::Render(int width, int height) {
+  ORBIT_SCOPE("GlCanvas::Render");
   screen_width_ = width;
   screen_height_ = height;
 

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -17,7 +17,7 @@ class GlCanvas {
   explicit GlCanvas(uint32_t font_size);
   virtual ~GlCanvas();
 
-  enum class CanvasType { kCaptureWindow, kDebug };
+  enum class CanvasType { kCaptureWindow, kIntrospectionWindow, kDebug };
   static std::unique_ptr<GlCanvas> Create(CanvasType canvas_type, uint32_t font_size);
 
   virtual void Initialize();

--- a/OrbitGl/IntrospectionWindow.cpp
+++ b/OrbitGl/IntrospectionWindow.cpp
@@ -14,7 +14,7 @@ IntrospectionWindow::IntrospectionWindow(uint32_t font_size) : CaptureWindow(fon
 
 IntrospectionWindow::~IntrospectionWindow() { StopIntrospection(); }
 
-const char* IntrospectionWindow::GetHelpText() {
+const char* IntrospectionWindow::GetHelpText() const {
   const char* help_message =
       "Client Side Introspection\n\n"
       "Start/Stop Capture: 'X'\n"
@@ -22,7 +22,7 @@ const char* IntrospectionWindow::GetHelpText() {
   return help_message;
 }
 
-bool IntrospectionWindow::IsIntrospecting() { return introspection_listener_ != nullptr; }
+bool IntrospectionWindow::IsIntrospecting() const { return introspection_listener_ != nullptr; }
 
 void IntrospectionWindow::StartIntrospection() {
   CHECK(!IsIntrospecting());
@@ -56,4 +56,4 @@ void IntrospectionWindow::ToggleCapture() {
   }
 }
 
-bool IntrospectionWindow::ShouldAutoZoom() { return IsIntrospecting(); }
+bool IntrospectionWindow::ShouldAutoZoom() const { return IsIntrospecting(); }

--- a/OrbitGl/IntrospectionWindow.cpp
+++ b/OrbitGl/IntrospectionWindow.cpp
@@ -1,0 +1,59 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "IntrospectionWindow.h"
+
+#include "App.h"
+
+using orbit_client_protos::TimerInfo;
+
+IntrospectionWindow::IntrospectionWindow(uint32_t font_size) : CaptureWindow(font_size) {
+  time_graph_.SetStringManager(std::make_shared<StringManager>());
+}
+
+IntrospectionWindow::~IntrospectionWindow() { StopIntrospection(); }
+
+const char* IntrospectionWindow::GetHelpText() {
+  const char* help_message =
+      "Client Side Introspection\n\n"
+      "Start/Stop Capture: 'X'\n"
+      "Toggle Help: 'H'";
+  return help_message;
+}
+
+bool IntrospectionWindow::IsIntrospecting() { return introspection_listener_ != nullptr; }
+
+void IntrospectionWindow::StartIntrospection() {
+  CHECK(!IsIntrospecting());
+  draw_help_ = false;
+  time_graph_.Clear();
+  introspection_listener_ =
+      std::make_unique<orbit::tracing::Listener>([this](const orbit::tracing::Scope& scope) {
+        TimerInfo timer_info;
+        timer_info.set_thread_id(scope.tid);
+        timer_info.set_start(scope.begin);
+        timer_info.set_end(scope.end);
+        timer_info.set_depth(static_cast<uint8_t>(scope.depth));
+        timer_info.set_type(TimerInfo::kIntrospection);
+        timer_info.mutable_registers()->Reserve(6);
+        timer_info.add_registers(scope.encoded_event.args[0]);
+        timer_info.add_registers(scope.encoded_event.args[1]);
+        timer_info.add_registers(scope.encoded_event.args[2]);
+        timer_info.add_registers(scope.encoded_event.args[3]);
+        timer_info.add_registers(scope.encoded_event.args[4]);
+        timer_info.add_registers(scope.encoded_event.args[5]);
+        time_graph_.ProcessTimer(timer_info, /*FunctionInfo*/ nullptr);
+      });
+}
+void IntrospectionWindow::StopIntrospection() { introspection_listener_ = nullptr; }
+
+void IntrospectionWindow::ToggleCapture() {
+  if (!IsIntrospecting()) {
+    StartIntrospection();
+  } else {
+    StopIntrospection();
+  }
+}
+
+bool IntrospectionWindow::ShouldAutoZoom() { return IsIntrospecting(); }

--- a/OrbitGl/IntrospectionWindow.cpp
+++ b/OrbitGl/IntrospectionWindow.cpp
@@ -48,7 +48,7 @@ void IntrospectionWindow::StartIntrospection() {
 }
 void IntrospectionWindow::StopIntrospection() { introspection_listener_ = nullptr; }
 
-void IntrospectionWindow::ToggleCapture() {
+void IntrospectionWindow::ToggleRecording() {
   if (!IsIntrospecting()) {
     StartIntrospection();
   } else {

--- a/OrbitGl/IntrospectionWindow.h
+++ b/OrbitGl/IntrospectionWindow.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include <memory>
+
+#include "CaptureWindow.h"
+#include "OrbitBase/Tracing.h"
+
+class IntrospectionWindow : public CaptureWindow {
+ public:
+  explicit IntrospectionWindow(uint32_t font_size);
+  ~IntrospectionWindow() override;
+  void ToggleCapture() override;
+
+  [[nodiscard]] bool IsIntrospecting();
+  void StartIntrospection();
+  void StopIntrospection();
+
+ protected:
+  [[nodiscard]] const char* GetHelpText() override;
+  [[nodiscard]] bool ShouldAutoZoom() override;
+
+ private:
+  std::unique_ptr<orbit::tracing::Listener> introspection_listener_;
+};

--- a/OrbitGl/IntrospectionWindow.h
+++ b/OrbitGl/IntrospectionWindow.h
@@ -13,7 +13,7 @@ class IntrospectionWindow : public CaptureWindow {
  public:
   explicit IntrospectionWindow(uint32_t font_size);
   ~IntrospectionWindow() override;
-  void ToggleCapture() override;
+  void ToggleRecording() override;
 
   [[nodiscard]] bool IsIntrospecting() const;
   void StartIntrospection();

--- a/OrbitGl/IntrospectionWindow.h
+++ b/OrbitGl/IntrospectionWindow.h
@@ -15,13 +15,13 @@ class IntrospectionWindow : public CaptureWindow {
   ~IntrospectionWindow() override;
   void ToggleCapture() override;
 
-  [[nodiscard]] bool IsIntrospecting();
+  [[nodiscard]] bool IsIntrospecting() const;
   void StartIntrospection();
   void StopIntrospection();
 
  protected:
-  [[nodiscard]] const char* GetHelpText() override;
-  [[nodiscard]] bool ShouldAutoZoom() override;
+  [[nodiscard]] const char* GetHelpText() const override;
+  [[nodiscard]] bool ShouldAutoZoom() const override;
 
  private:
   std::unique_ptr<orbit::tracing::Listener> introspection_listener_;

--- a/OrbitQt/orbitglwidget.cpp
+++ b/OrbitQt/orbitglwidget.cpp
@@ -167,6 +167,7 @@ void OrbitGLWidget::resizeGL(int w, int h) {
 }
 
 void OrbitGLWidget::paintGL() {
+  ORBIT_SCOPE_FUNCTION;
   if (gl_canvas_) {
     gl_canvas_->Render(width(), height());
   }

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -221,7 +221,7 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App,
 
   if (absl::GetFlag(FLAGS_devmode)) {
     ui->debugOpenGLWidget->Initialize(GlCanvas::CanvasType::kDebug, this, font_size);
-    GOrbitApp->RegisterDebugCanvas(ui->debugOpenGLWidget->GetCanvas());
+    GOrbitApp->SetDebugCanvas(ui->debugOpenGLWidget->GetCanvas());
   } else {
     ui->RightTabWidget->removeTab(ui->RightTabWidget->indexOf(ui->debugTab));
   }


### PR DESCRIPTION
The IntrospectionWindow is a CaptureWindow used to show a second
time graph dedicated to introspection of the client side Orbit app.
This change only adds the new class, a subsequent change will
enable introspection via some new UI in the main CaptureWindow.

Also add a few profiling markers in our code.