### PR TITLE
Add Wrapper and Manager for a Vulkan Query Pool

### DIFF
--- a/OrbitVulkanLayer/CMakeLists.txt
+++ b/OrbitVulkanLayer/CMakeLists.txt
@@ -16,7 +16,8 @@ target_include_directories(OrbitVulkanLayer PRIVATE
 target_sources(OrbitVulkanLayer PRIVATE
         DeviceManager.h
         QueueManager.cpp
-        QueueManager.h)
+        QueueManager.h
+        TimerQueryPool.h)
 
 target_link_libraries(OrbitVulkanLayer PUBLIC
         OrbitBase
@@ -28,6 +29,7 @@ target_compile_options(OrbitVulkanLayerTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(OrbitVulkanLayerTests PRIVATE
         DeviceManagerTest.cpp
+        TimerQueryPoolTest.cpp
         QueueManagerTest.cpp)
 
 target_link_libraries(

--- a/OrbitVulkanLayer/TimerQueryPool.h
+++ b/OrbitVulkanLayer/TimerQueryPool.h
@@ -1,0 +1,146 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_VULKAN_LAYER_TIMER_QUERY_POOL_H_
+#define ORBIT_VULKAN_LAYER_TIMER_QUERY_POOL_H_
+
+#include "OrbitBase/Logging.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/synchronization/mutex.h"
+#include "vulkan/vulkan.h"
+
+namespace orbit_vulkan_layer {
+
+namespace internal {
+enum SlotState {
+  kReadyForQueryIssue = 0,
+  kQueryPendingOnGPU,
+};
+}
+
+/*
+ * This class wraps Vulkan's VkQueryPool specific for timestamp queries, and provides utility
+ * methods to (1) initialize a poo, (2) retrieve an available slot index and (3) reset slot indices.
+ * In order to do so, it stores the internal `SlotState` for each index.
+ *
+ * Thread-Safety: This class is internally synchronized (using read/write locks) and can be safely
+ * accessed from different threads.
+ */
+template <class DispatchTable>
+class TimerQueryPool {
+ public:
+  explicit TimerQueryPool(DispatchTable* dispatch_table, uint32_t num_timer_query_slots)
+      : dispatch_table_(dispatch_table), num_timer_query_slots_(num_timer_query_slots) {}
+
+  /*
+   * Creates and resets a vulkan `VkQueryPool`, ready to use for timestamp queries.
+   */
+  void InitializeTimerQueryPool(VkDevice device) {
+    VkQueryPool query_pool;
+
+    VkQueryPoolCreateInfo create_info = {.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO,
+                                         .pNext = nullptr,
+                                         .flags = 0,
+                                         .queryType = VK_QUERY_TYPE_TIMESTAMP,
+                                         .queryCount = num_timer_query_slots_,
+                                         .pipelineStatistics = 0};
+
+    VkResult result =
+        dispatch_table_->CreateQueryPool(device)(device, &create_info, nullptr, &query_pool);
+    CHECK(result == VK_SUCCESS);
+
+    dispatch_table_->ResetQueryPoolEXT(device)(device, query_pool, 0, num_timer_query_slots_);
+
+    {
+      absl::WriterMutexLock lock(&mutex_);
+      device_to_query_pool_[device] = query_pool;
+      std::vector<internal::SlotState> slots{num_timer_query_slots_};
+      std::fill(slots.begin(), slots.end(), internal::SlotState::kReadyForQueryIssue);
+      device_to_query_slots_[device] = slots;
+      device_to_potential_next_free_index_[device] = 0;
+    }
+  }
+
+  /*
+   * Retrieves the query pool for a give device. Note, that the pool must be initialized using
+   * `InitializeTimerQueryPool` before.
+   */
+  [[nodiscard]] VkQueryPool GetQueryPool(VkDevice device) {
+    absl::ReaderMutexLock lock(&mutex_);
+    CHECK(device_to_query_pool_.contains(device));
+    return device_to_query_pool_.at(device);
+  }
+
+  /*
+   * Tries to find a free query slot in the device`s pool. It returns `false` if no slot was found
+   * (all slots are occupied) and true otherwise.
+   * In case it successfully found a slot, the index will be written to the given `allocated_index`.
+   *
+   * Note, that the pool pool must be initialized using `InitializeTimerQueryPool` before.
+   * See also `ResetQuerySlots` to make occupied slots available again.
+   */
+  [[nodiscard]] bool NextReadyQuerySlot(VkDevice device, uint32_t* allocated_index) {
+    absl::WriterMutexLock lock(&mutex_);
+    CHECK(device_to_potential_next_free_index_.contains(device));
+    CHECK(device_to_query_slots_.contains(device));
+    uint32_t potential_next_free_slot = device_to_potential_next_free_index_.at(device);
+    std::vector<internal::SlotState>& slots = device_to_query_slots_.at(device);
+    uint32_t current_slot = potential_next_free_slot;
+    do {
+      if (slots.at(current_slot) == internal::SlotState::kReadyForQueryIssue) {
+        device_to_potential_next_free_index_[device] = (current_slot + 1) % num_timer_query_slots_;
+        slots.at(current_slot) = internal::SlotState::kQueryPendingOnGPU;
+        *allocated_index = current_slot;
+        return true;
+      }
+      current_slot = (current_slot + 1) % num_timer_query_slots_;
+    } while (current_slot != potential_next_free_slot);
+
+    return false;
+  }
+
+  /*
+   * Resets an occupied slot to be ready for queries again.
+   * If `rollback_only` is set, it will not call to Vulkan to reset the content at that slot.
+   * This is useful, if the slot was retrieved, but the actual query was not yet submitted to
+   * Vulkan (e.g. if on resetting the command buffer).
+   *
+   * Note, that the pool pool must be initialized using `InitializeTimerQueryPool` before.
+   * Further, the given slots must be in the `kReadyForQueryIssue` state, i.e. must be a result
+   * of `NextReadyQuerySlot` and have not been reset yet.
+   */
+  void ResetQuerySlots(VkDevice device, const std::vector<uint32_t>& physical_slot_indices,
+                       bool rollback_only) {
+    if (physical_slot_indices.empty()) {
+      return;
+    }
+    absl::WriterMutexLock lock(&mutex_);
+    CHECK(device_to_query_slots_.contains(device));
+    std::vector<internal::SlotState>& slot_states = device_to_query_slots_.at(device);
+    for (uint32_t physical_slot_index : physical_slot_indices) {
+      CHECK(physical_slot_index < num_timer_query_slots_);
+      const internal::SlotState& current_state = slot_states.at(physical_slot_index);
+      CHECK(current_state == internal::SlotState::kQueryPendingOnGPU);
+      slot_states.at(physical_slot_index) = internal::SlotState::kReadyForQueryIssue;
+      if (rollback_only) {
+        continue;
+      }
+      VkQueryPool query_pool = device_to_query_pool_.at(device);
+      dispatch_table_->ResetQueryPoolEXT(device)(device, query_pool, physical_slot_index, 1);
+    }
+  }
+
+ private:
+  DispatchTable* dispatch_table_;
+  const uint32_t num_timer_query_slots_;
+
+  absl::Mutex mutex_;
+
+  absl::flat_hash_map<VkDevice, VkQueryPool> device_to_query_pool_;
+  absl::flat_hash_map<VkDevice, std::vector<internal::SlotState>> device_to_query_slots_;
+  absl::flat_hash_map<VkDevice, uint32_t> device_to_potential_next_free_index_;
+};
+}  // namespace orbit_vulkan_layer
+
+#endif  // ORBIT_VULKAN_LAYER_TIMER_QUERY_POOL_H_

--- a/OrbitVulkanLayer/TimerQueryPool.h
+++ b/OrbitVulkanLayer/TimerQueryPool.h
@@ -96,7 +96,7 @@ class TimerQueryPool {
   // Further, the given slots must be in the `kReadyForQueryIssue` state, i.e. must be a result
   // of `NextReadyQuerySlot` and must not have been reset yet.
   void ResetQuerySlots(VkDevice device, const std::vector<uint32_t>& slot_indices) {
-    ResetQuerySlots(device, slot_indices, false);
+    ResetQuerySlotsInternal(device, slot_indices, false);
   }
 
   // Resets an occupied slot to be ready for queries again. It will *not* call to Vulkan to reset
@@ -108,7 +108,7 @@ class TimerQueryPool {
   // Further, the given slots must be in the `kReadyForQueryIssue` state, i.e. must be a result
   // of `NextReadyQuerySlot` and must not have been reset yet.
   void RollbackPendingQuerySlots(VkDevice device, const std::vector<uint32_t>& slot_indices) {
-    ResetQuerySlots(device, slot_indices, true);
+    ResetQuerySlotsInternal(device, slot_indices, true);
   }
 
  private:
@@ -122,8 +122,8 @@ class TimerQueryPool {
   // Note that the pool must be initialized using `InitializeTimerQueryPool` before.
   // Further, the given slots must be in the `kReadyForQueryIssue` state, i.e. must be a result
   // of `NextReadyQuerySlot` and must not have been reset yet.
-  void ResetQuerySlots(VkDevice device, const std::vector<uint32_t>& slot_indices,
-                       bool rollback_only) {
+  void ResetQuerySlotsInternal(VkDevice device, const std::vector<uint32_t>& slot_indices,
+                               bool rollback_only) {
     if (slot_indices.empty()) {
       return;
     }

--- a/OrbitVulkanLayer/TimerQueryPoolTest.cpp
+++ b/OrbitVulkanLayer/TimerQueryPoolTest.cpp
@@ -1,0 +1,279 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "TimerQueryPool.h"
+#include "absl/container/flat_hash_set.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using ::testing::_;
+using ::testing::Return;
+
+namespace orbit_vulkan_layer {
+
+namespace {
+class MockDispatchTable {
+ public:
+  MOCK_METHOD(PFN_vkCreateQueryPool, CreateQueryPool, (VkDevice), ());
+  MOCK_METHOD(PFN_vkResetQueryPoolEXT, ResetQueryPoolEXT, (VkDevice), ());
+};
+
+PFN_vkCreateQueryPool dummy_create_query_pool_function =
+    +[](VkDevice /*device*/, const VkQueryPoolCreateInfo* /*create_info*/,
+        const VkAllocationCallbacks* /*allocator*/, VkQueryPool* query_pool_out) -> VkResult {
+  *query_pool_out = {};
+  return VK_SUCCESS;
+};
+
+PFN_vkResetQueryPoolEXT dummy_reset_query_pool_function =
+    +[](VkDevice /*device*/, VkQueryPool /*query_pool*/, uint32_t /*first_query*/,
+        uint32_t /*query_count*/) {};
+
+}  // namespace
+
+TEST(TimerQueryPool, ATimerQueryPoolMustGetInitialized) {
+  MockDispatchTable dispatch_table;
+  uint32_t num_slots = 4;
+  TimerQueryPool query_pool(&dispatch_table, num_slots);
+  VkDevice device = {};
+
+  uint32_t slot_index = 32;
+  std::vector<uint32_t> reset_slots;
+  EXPECT_DEATH({ (void)query_pool.GetQueryPool(device); }, "");
+  EXPECT_DEATH({ (void)query_pool.NextReadyQuerySlot(device, &slot_index); }, "");
+  reset_slots.push_back(slot_index);
+  EXPECT_DEATH({ (void)query_pool.ResetQuerySlots(device, reset_slots, true); }, "");
+  EXPECT_DEATH({ (void)query_pool.ResetQuerySlots(device, reset_slots, false); }, "");
+}
+
+TEST(TimerQueryPool, InitializationWillCreateAndResetAPool) {
+  MockDispatchTable dispatch_table;
+  static constexpr uint32_t kNumSlots = 4;
+  TimerQueryPool<MockDispatchTable> query_pool(&dispatch_table, kNumSlots);
+  VkDevice device = {};
+
+  PFN_vkCreateQueryPool mock_create_query_pool_function =
+      +[](VkDevice /*device*/, const VkQueryPoolCreateInfo* create_info,
+          const VkAllocationCallbacks* /*allocator*/, VkQueryPool* query_pool_out) -> VkResult {
+    EXPECT_EQ(create_info->queryType, VK_QUERY_TYPE_TIMESTAMP);
+    EXPECT_EQ(create_info->queryCount, kNumSlots);
+
+    *query_pool_out = {};
+    return VK_SUCCESS;
+  };
+
+  PFN_vkResetQueryPoolEXT mock_reset_query_pool_function =
+      +[](VkDevice /*device*/, VkQueryPool /*query_pool*/, uint32_t first_query,
+          uint32_t query_count) {
+        EXPECT_EQ(first_query, 0);
+        EXPECT_EQ(query_count, kNumSlots);
+      };
+
+  EXPECT_CALL(dispatch_table, CreateQueryPool)
+      .Times(1)
+      .WillOnce(Return(mock_create_query_pool_function));
+  EXPECT_CALL(dispatch_table, ResetQueryPoolEXT)
+      .Times(1)
+      .WillOnce(Return(mock_reset_query_pool_function));
+
+  query_pool.InitializeTimerQueryPool(device);
+}
+
+TEST(TimerQueryPool, QueryPoolCanBeRetrievedAfterInitialization) {
+  MockDispatchTable dispatch_table;
+  static constexpr uint32_t kNumSlots = 4;
+  TimerQueryPool<MockDispatchTable> query_pool(&dispatch_table, kNumSlots);
+  VkDevice device = {};
+  static VkQueryPool expected_vulkan_query_pool = {};
+
+  PFN_vkCreateQueryPool mock_create_query_pool_function =
+      +[](VkDevice /*device*/, const VkQueryPoolCreateInfo* create_info,
+          const VkAllocationCallbacks* /*allocator*/, VkQueryPool* query_pool_out) -> VkResult {
+    EXPECT_EQ(create_info->queryType, VK_QUERY_TYPE_TIMESTAMP);
+    EXPECT_EQ(create_info->queryCount, kNumSlots);
+
+    *query_pool_out = expected_vulkan_query_pool;
+    return VK_SUCCESS;
+  };
+
+  EXPECT_CALL(dispatch_table, CreateQueryPool)
+      .WillRepeatedly(Return(mock_create_query_pool_function));
+  EXPECT_CALL(dispatch_table, ResetQueryPoolEXT)
+      .WillRepeatedly(Return(dummy_reset_query_pool_function));
+
+  query_pool.InitializeTimerQueryPool(device);
+
+  VkQueryPool vulkan_query_pool = query_pool.GetQueryPool(device);
+  EXPECT_EQ(vulkan_query_pool, expected_vulkan_query_pool);
+}
+
+TEST(TimerQueryPool, CanRetrieveNumSlotsUniqueSlots) {
+  MockDispatchTable dispatch_table;
+  static constexpr uint32_t kNumSlots = 4;
+  TimerQueryPool<MockDispatchTable> query_pool(&dispatch_table, kNumSlots);
+  VkDevice device = {};
+
+  EXPECT_CALL(dispatch_table, CreateQueryPool)
+      .WillRepeatedly(Return(dummy_create_query_pool_function));
+  EXPECT_CALL(dispatch_table, ResetQueryPoolEXT)
+      .WillRepeatedly(Return(dummy_reset_query_pool_function));
+
+  query_pool.InitializeTimerQueryPool(device);
+
+  absl::flat_hash_set<uint32_t> slots;
+
+  for (uint32_t i = 0; i < kNumSlots; ++i) {
+    uint32_t slot;
+    bool found_slot = query_pool.NextReadyQuerySlot(device, &slot);
+    ASSERT_TRUE(found_slot);
+    slots.insert(slot);
+  }
+
+  EXPECT_EQ(slots.size(), kNumSlots);
+}
+
+TEST(TimerQueryPool, CannotRetrieveMoreThanNumSlotsSlots) {
+  MockDispatchTable dispatch_table;
+  static constexpr uint32_t kNumSlots = 4;
+  TimerQueryPool<MockDispatchTable> query_pool(&dispatch_table, kNumSlots);
+  VkDevice device = {};
+
+  EXPECT_CALL(dispatch_table, CreateQueryPool)
+      .WillRepeatedly(Return(dummy_create_query_pool_function));
+  EXPECT_CALL(dispatch_table, ResetQueryPoolEXT)
+      .WillRepeatedly(Return(dummy_reset_query_pool_function));
+
+  query_pool.InitializeTimerQueryPool(device);
+
+  for (uint32_t i = 0; i < kNumSlots; ++i) {
+    uint32_t slot;
+    (void)query_pool.NextReadyQuerySlot(device, &slot);
+  }
+  uint32_t slot;
+  bool found_slot = query_pool.NextReadyQuerySlot(device, &slot);
+  ASSERT_FALSE(found_slot);
+}
+
+TEST(TimerQueryPool, ResettingSlotsMakesSlotsReady) {
+  MockDispatchTable dispatch_table;
+  static constexpr uint32_t kNumSlots = 1;
+  TimerQueryPool<MockDispatchTable> query_pool(&dispatch_table, kNumSlots);
+  VkDevice device = {};
+  EXPECT_CALL(dispatch_table, CreateQueryPool)
+      .WillRepeatedly(Return(dummy_create_query_pool_function));
+  EXPECT_CALL(dispatch_table, ResetQueryPoolEXT)
+      .WillRepeatedly(Return(dummy_reset_query_pool_function));
+
+  query_pool.InitializeTimerQueryPool(device);
+  uint32_t slot;
+  (void)query_pool.NextReadyQuerySlot(device, &slot);
+
+  std::vector<uint32_t> reset_slots;
+  reset_slots.push_back(slot);
+
+  query_pool.ResetQuerySlots(device, reset_slots, true);
+
+  bool found_slot = query_pool.NextReadyQuerySlot(device, &slot);
+  ASSERT_TRUE(found_slot);
+}
+
+TEST(TimerQueryPool, RollingBackSlotsDoesNotResetOnVulkan) {
+  MockDispatchTable dispatch_table;
+  static constexpr uint32_t kNumSlots = 1;
+  TimerQueryPool<MockDispatchTable> query_pool(&dispatch_table, kNumSlots);
+  VkDevice device = {};
+  EXPECT_CALL(dispatch_table, CreateQueryPool)
+      .WillRepeatedly(Return(dummy_create_query_pool_function));
+
+  // Explicitly expect this call only once, as rolling back should not reset on vulkan side.
+  EXPECT_CALL(dispatch_table, ResetQueryPoolEXT)
+      .Times(1)
+      .WillRepeatedly(Return(dummy_reset_query_pool_function));
+
+  query_pool.InitializeTimerQueryPool(device);
+  uint32_t slot;
+  (void)query_pool.NextReadyQuerySlot(device, &slot);
+
+  std::vector<uint32_t> reset_slots;
+  reset_slots.push_back(slot);
+
+  query_pool.ResetQuerySlots(device, reset_slots, true);
+}
+
+TEST(TimerQueryPool, ResettingSlotsDoesResetOnVulkan) {
+  MockDispatchTable dispatch_table;
+  static constexpr uint32_t kNumSlots = 1;
+  TimerQueryPool<MockDispatchTable> query_pool(&dispatch_table, kNumSlots);
+  VkDevice device = {};
+  EXPECT_CALL(dispatch_table, CreateQueryPool)
+      .WillRepeatedly(Return(dummy_create_query_pool_function));
+
+  static uint32_t expected_reset_slot;
+  PFN_vkResetQueryPoolEXT mock_reset_query_pool_function =
+      +[](VkDevice /*device*/, VkQueryPool /*query_pool*/, uint32_t first_query,
+          uint32_t query_count) {
+        EXPECT_EQ(expected_reset_slot, first_query);
+        EXPECT_EQ(1, query_count);
+      };
+
+  // Explicitly expect this call only once, as rolling back should not reset on vulkan side.
+  EXPECT_CALL(dispatch_table, ResetQueryPoolEXT)
+      .Times(2)
+      .WillOnce(Return(dummy_reset_query_pool_function))
+      .WillOnce(Return(mock_reset_query_pool_function));
+
+  query_pool.InitializeTimerQueryPool(device);
+  (void)query_pool.NextReadyQuerySlot(device, &expected_reset_slot);
+
+  std::vector<uint32_t> reset_slots;
+  reset_slots.push_back(expected_reset_slot);
+
+  query_pool.ResetQuerySlots(device, reset_slots, false);
+}
+
+TEST(TimerQueryPool, CannotResetReadySlots) {
+  MockDispatchTable dispatch_table;
+  static constexpr uint32_t kNumSlots = 1;
+  TimerQueryPool<MockDispatchTable> query_pool(&dispatch_table, kNumSlots);
+  VkDevice device = {};
+  EXPECT_CALL(dispatch_table, CreateQueryPool)
+      .WillRepeatedly(Return(dummy_create_query_pool_function));
+  EXPECT_CALL(dispatch_table, ResetQueryPoolEXT)
+      .WillRepeatedly(Return(dummy_reset_query_pool_function));
+
+  query_pool.InitializeTimerQueryPool(device);
+
+  uint32_t first_slot_index = 0;
+  std::vector<uint32_t> rollback_slots;
+  rollback_slots.push_back(first_slot_index);
+
+  EXPECT_DEATH({ query_pool.ResetQuerySlots(device, rollback_slots, true); }, "");
+}
+
+TEST(TimerQueryPool, CanRepeatatleRetrieveAndResetSlots) {
+  MockDispatchTable dispatch_table;
+  static constexpr uint32_t kNumSlots = 16;
+  TimerQueryPool<MockDispatchTable> query_pool(&dispatch_table, kNumSlots);
+  VkDevice device = {};
+  EXPECT_CALL(dispatch_table, CreateQueryPool)
+      .WillRepeatedly(Return(dummy_create_query_pool_function));
+  EXPECT_CALL(dispatch_table, ResetQueryPoolEXT)
+      .WillRepeatedly(Return(dummy_reset_query_pool_function));
+
+  query_pool.InitializeTimerQueryPool(device);
+
+  for (int i = 0; i < 2000; ++i) {
+    uint32_t slot_index;
+    bool found_slot = query_pool.NextReadyQuerySlot(device, &slot_index);
+    EXPECT_TRUE(found_slot);
+
+    std::vector<uint32_t> reset_slots;
+    reset_slots.push_back(slot_index);
+
+    // Check for both, rollback and actual resets.
+    query_pool.ResetQuerySlots(device, reset_slots, i % 2 == 0);
+  }
+}
+
+}  // namespace orbit_vulkan_layer


### PR DESCRIPTION
This add a wrapper and manager for Vulkan's `VkQueryPool` specific
for timestamp queries.
It provides utility functions to initialize a new pool, retrieve
free slot indices and reset slots after the result have read.

Test: Compile and run tests
Bug: http://b/168200502