### PR TITLE
Client side introspection UI

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -141,6 +141,7 @@ void OrbitApp::OnCaptureStarted(ProcessData&& process,
         capture_data_ =
             CaptureData(std::move(process), module_manager_.get(), std::move(selected_functions),
                         std::move(selected_tracepoints), std::move(user_defined_capture_data));
+        capture_window_->SetCaptureData(&capture_data_.value());
 
         frame_track_online_processor_ =
             FrameTrackOnlineProcessor(GetCaptureData(), GCurrentTimeGraph);
@@ -827,6 +828,7 @@ void OrbitApp::AbortCapture() {
 
 void OrbitApp::ClearCapture() {
   ORBIT_SCOPE_FUNCTION;
+  capture_window_->SetCaptureData(nullptr);
   capture_data_.reset();
   set_selected_thread_id(SamplingProfiler::kAllThreadsFakeTid);
   SelectTextBox(nullptr);

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -1359,6 +1359,10 @@ void OrbitApp::DeselectFunction(const orbit_client_protos::FunctionInfo& func) {
   return data_manager_->IsFunctionSelected(*function);
 }
 
+const FunctionInfo* OrbitApp::GetSelectedFunction(uint64_t absolute_address) const {
+  return HasCaptureData() ? GetCaptureData().GetSelectedFunction(absolute_address) : nullptr;
+}
+
 void OrbitApp::SetVisibleFunctions(absl::flat_hash_set<uint64_t> visible_functions) {
   data_manager_->set_visible_functions(std::move(visible_functions));
   NeedsRedraw();

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -141,7 +141,7 @@ void OrbitApp::OnCaptureStarted(ProcessData&& process,
         capture_data_ =
             CaptureData(std::move(process), module_manager_.get(), std::move(selected_functions),
                         std::move(selected_tracepoints), std::move(user_defined_capture_data));
-        capture_window_->SetCaptureData(&capture_data_.value());
+        capture_window_->GetTimeGraph()->SetCaptureData(&capture_data_.value());
 
         frame_track_online_processor_ =
             FrameTrackOnlineProcessor(GetCaptureData(), GCurrentTimeGraph);
@@ -828,7 +828,7 @@ void OrbitApp::AbortCapture() {
 
 void OrbitApp::ClearCapture() {
   ORBIT_SCOPE_FUNCTION;
-  capture_window_->SetCaptureData(nullptr);
+  capture_window_->GetTimeGraph()->SetCaptureData(nullptr);
   capture_data_.reset();
   set_selected_thread_id(SamplingProfiler::kAllThreadsFakeTid);
   SelectTextBox(nullptr);

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -306,6 +306,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   [[nodiscard]] bool IsFunctionSelected(const orbit_client_protos::FunctionInfo& func) const;
   [[nodiscard]] bool IsFunctionSelected(const SampledFunction& func) const;
   [[nodiscard]] bool IsFunctionSelected(uint64_t absolute_address) const;
+  [[nodiscard]] const orbit_client_protos::FunctionInfo* GetSelectedFunction(
+      uint64_t absolute_address) const;
 
   void SetVisibleFunctions(absl::flat_hash_set<uint64_t> visible_functions);
   [[nodiscard]] bool IsFunctionVisible(uint64_t function_address);

--- a/OrbitGl/AsyncTrack.cpp
+++ b/OrbitGl/AsyncTrack.cpp
@@ -28,8 +28,10 @@ AsyncTrack::AsyncTrack(TimeGraph* time_graph, const std::string& name) : TimerTr
 
   // The FunctionInfo here corresponds to one of the automatically instrumented empty stubs from
   // Orbit.h. Use it to retrieve the module from which the manually instrumented scope originated.
+  const CaptureData* capture_data = time_graph_->GetCaptureData();
   const FunctionInfo* func =
-      GOrbitApp->GetCaptureData().GetSelectedFunction(text_box->GetTimerInfo().function_address());
+      capture_data ? capture_data->GetSelectedFunction(text_box->GetTimerInfo().function_address())
+                   : nullptr;
   CHECK(func || timer_info.type() == TimerInfo::kIntrospection);
   std::string module_name = func != nullptr ? FunctionUtils::GetLoadedModuleName(*func) : "unknown";
   const uint64_t event_id = event.data;

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -690,7 +690,7 @@ void CaptureWindow::RenderImGui() {
       IMGUI_VAR_TO_TEXT(time_graph_.GetCaptureMax());
       IMGUI_VAR_TO_TEXT(time_graph_.GetTimeWindowUs());
 
-      CaptureData* capture_data = GetCaptureData();
+      const CaptureData* capture_data = GetCaptureData();
       if (capture_data != nullptr) {
         IMGUI_VAR_TO_TEXT(capture_data->GetCallstackData()->callstack_events_by_tid().size());
         IMGUI_VAR_TO_TEXT(capture_data->GetCallstackData()->GetCallstackEventsCount());

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -690,11 +690,10 @@ void CaptureWindow::RenderImGui() {
       IMGUI_VAR_TO_TEXT(time_graph_.GetCaptureMax());
       IMGUI_VAR_TO_TEXT(time_graph_.GetTimeWindowUs());
 
-      if (GOrbitApp->HasCaptureData()) {
-        IMGUI_VAR_TO_TEXT(
-            GOrbitApp->GetCaptureData().GetCallstackData()->callstack_events_by_tid().size());
-        IMGUI_VAR_TO_TEXT(
-            GOrbitApp->GetCaptureData().GetCallstackData()->GetCallstackEventsCount());
+      CaptureData* capture_data = GetCaptureData();
+      if (capture_data != nullptr) {
+        IMGUI_VAR_TO_TEXT(capture_data->GetCallstackData()->callstack_events_by_tid().size());
+        IMGUI_VAR_TO_TEXT(capture_data->GetCallstackData()->GetCallstackEventsCount());
       }
 
       ImGui::EndTabItem();

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -690,7 +690,7 @@ void CaptureWindow::RenderImGui() {
       IMGUI_VAR_TO_TEXT(time_graph_.GetCaptureMax());
       IMGUI_VAR_TO_TEXT(time_graph_.GetTimeWindowUs());
 
-      const CaptureData* capture_data = GetCaptureData();
+      const CaptureData* capture_data = time_graph_.GetCaptureData();
       if (capture_data != nullptr) {
         IMGUI_VAR_TO_TEXT(capture_data->GetCallstackData()->callstack_events_by_tid().size());
         IMGUI_VAR_TO_TEXT(capture_data->GetCallstackData()->GetCallstackEventsCount());

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -63,7 +63,7 @@ class CaptureWindow : public GlCanvas {
   void ToggleDrawHelp();
   void set_draw_help(bool draw_help);
   [[nodiscard]] TimeGraph* GetTimeGraph() { return &time_graph_; }
-  [[nodiscard]] CaptureData* GetCaptureData() const { return time_graph_.GetCaptureData(); }
+  [[nodiscard]] const CaptureData* GetCaptureData() const { return time_graph_.GetCaptureData(); }
   void SetCaptureData(CaptureData* capture_data) { time_graph_.SetCaptureData(capture_data); }
 
   Batcher& GetBatcherById(BatcherId batcher_id);

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -63,8 +63,6 @@ class CaptureWindow : public GlCanvas {
   void ToggleDrawHelp();
   void set_draw_help(bool draw_help);
   [[nodiscard]] TimeGraph* GetTimeGraph() { return &time_graph_; }
-  [[nodiscard]] const CaptureData* GetCaptureData() const { return time_graph_.GetCaptureData(); }
-  void SetCaptureData(CaptureData* capture_data) { time_graph_.SetCaptureData(capture_data); }
 
   Batcher& GetBatcherById(BatcherId batcher_id);
 

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -63,6 +63,8 @@ class CaptureWindow : public GlCanvas {
   void ToggleDrawHelp();
   void set_draw_help(bool draw_help);
   [[nodiscard]] TimeGraph* GetTimeGraph() { return &time_graph_; }
+  [[nodiscard]] CaptureData* GetCaptureData() const { return time_graph_.GetCaptureData(); }
+  void SetCaptureData(CaptureData* capture_data) { time_graph_.SetCaptureData(capture_data); }
 
   Batcher& GetBatcherById(BatcherId batcher_id);
 

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -161,6 +161,7 @@ void EventTrack::SelectEvents() {
 }
 
 bool EventTrack::IsEmpty() const {
+  if (!GOrbitApp->HasCaptureData()) return true;
   const uint32_t callstack_count =
       (thread_id_ == SamplingProfiler::kAllThreadsFakeTid)
           ? GOrbitApp->GetCaptureData().GetCallstackData()->GetCallstackEventsCount()

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -170,6 +170,16 @@ bool EventTrack::IsEmpty() const {
   return callstack_count == 0;
 }
 
+[[nodiscard]] uint64_t EventTrack::GetMinTime() const {
+  CHECK(GOrbitApp->HasCaptureData());
+  return GOrbitApp->GetCaptureData().GetCallstackData()->min_time();
+}
+
+[[nodiscard]] uint64_t EventTrack::GetMaxTime() const {
+  CHECK(GOrbitApp->HasCaptureData());
+  return GOrbitApp->GetCaptureData().GetCallstackData()->max_time();
+}
+
 static std::string SafeGetFormattedFunctionName(uint64_t addr, int max_line_length) {
   const std::string& function_name = GOrbitApp->GetCaptureData().GetFunctionNameByAddress(addr);
   if (function_name == CaptureData::kUnknownFunctionOrModuleName) {

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -76,7 +76,7 @@ void EventTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingM
   const Color kWhite(255, 255, 255, 255);
   const Color kGreenSelection(0, 255, 0, 255);
   const CaptureData* capture_data = time_graph_->GetCaptureData();
-  CHECK(capture_data);
+  CHECK(capture_data != nullptr);
 
   if (!picking) {
     // Sampling Events
@@ -173,20 +173,20 @@ bool EventTrack::IsEmpty() const {
 
 [[nodiscard]] uint64_t EventTrack::GetMinTime() const {
   const CaptureData* capture_data = time_graph_->GetCaptureData();
-  CHECK(capture_data);
+  CHECK(capture_data != nullptr);
   return capture_data->GetCallstackData()->min_time();
 }
 
 [[nodiscard]] uint64_t EventTrack::GetMaxTime() const {
   const CaptureData* capture_data = time_graph_->GetCaptureData();
-  CHECK(capture_data);
+  CHECK(capture_data != nullptr);
   return capture_data->GetCallstackData()->max_time();
 }
 
 [[nodiscard]] std::string EventTrack::SafeGetFormattedFunctionName(uint64_t addr,
                                                                    int max_line_length) const {
   const CaptureData* capture_data = time_graph_->GetCaptureData();
-  CHECK(capture_data);
+  CHECK(capture_data != nullptr);
   const std::string& function_name = capture_data->GetFunctionNameByAddress(addr);
   if (function_name == CaptureData::kUnknownFunctionOrModuleName) {
     return std::string("<i>") + function_name + "</i>";
@@ -237,7 +237,7 @@ std::string EventTrack::GetSampleTooltip(PickingId id) const {
   }
 
   const CaptureData* capture_data = time_graph_->GetCaptureData();
-  CHECK(capture_data);
+  CHECK(capture_data != nullptr);
   const CallstackData* callstack_data = capture_data->GetCallstackData();
   const auto* callstack_event = static_cast<const CallstackEvent*>(user_data->custom_data_);
 

--- a/OrbitGl/EventTrack.h
+++ b/OrbitGl/EventTrack.h
@@ -7,6 +7,7 @@
 #include "CallstackTypes.h"
 #include "Track.h"
 
+class CallStack;
 class GlCanvas;
 class TimeGraph;
 
@@ -38,5 +39,9 @@ class EventTrack : public Track {
 
  protected:
   void SelectEvents();
-  std::string GetSampleTooltip(PickingId id) const;
+  [[nodiscard]] std::string GetSampleTooltip(PickingId id) const;
+  [[nodiscard]] std::string SafeGetFormattedFunctionName(uint64_t addr, int max_line_length) const;
+  [[nodiscard]] std::string FormatCallstackForTooltip(const CallStack& callstack,
+                                                      int max_line_length = 80, int max_lines = 20,
+                                                      int bottom_n_lines = 5) const;
 };

--- a/OrbitGl/EventTrack.h
+++ b/OrbitGl/EventTrack.h
@@ -32,7 +32,9 @@ class EventTrack : public Track {
   void SetPos(float a_X, float a_Y);
   void SetSize(float a_SizeX, float a_SizeY);
   void SetColor(Color color) { color_ = color; }
-  bool IsEmpty() const;
+  bool IsEmpty() const override;
+  [[nodiscard]] uint64_t GetMinTime() const override;
+  [[nodiscard]] uint64_t GetMaxTime() const override;
 
  protected:
   void SelectEvents();

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -198,6 +198,8 @@ std::string GpuTrack::GetBoxTooltip(PickingId id) const {
 }
 
 std::string GpuTrack::GetSwQueueTooltip(const TimerInfo& timer_info) const {
+  const CaptureData* capture_data = time_graph_->GetCaptureData();
+  CHECK(capture_data);
   return absl::StrFormat(
       "<b>Software Queue</b><br/>"
       "<i>Time between amdgpu_cs_ioctl (job submitted) and "
@@ -206,11 +208,13 @@ std::string GpuTrack::GetSwQueueTooltip(const TimerInfo& timer_info) const {
       "<br/>"
       "<b>Submitted from thread:</b> %s [%d]<br/>"
       "<b>Time:</b> %s",
-      GOrbitApp->GetCaptureData().GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
+      capture_data->GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
       GetPrettyTime(TicksToDuration(timer_info.start(), timer_info.end())).c_str());
 }
 
 std::string GpuTrack::GetHwQueueTooltip(const TimerInfo& timer_info) const {
+  const CaptureData* capture_data = time_graph_->GetCaptureData();
+  CHECK(capture_data);
   return absl::StrFormat(
       "<b>Hardware Queue</b><br/><i>Time between amdgpu_sched_run_job "
       "(job scheduled) and start of GPU execution</i>"
@@ -218,11 +222,13 @@ std::string GpuTrack::GetHwQueueTooltip(const TimerInfo& timer_info) const {
       "<br/>"
       "<b>Submitted from thread:</b> %s [%d]<br/>"
       "<b>Time:</b> %s",
-      GOrbitApp->GetCaptureData().GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
+      capture_data->GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
       GetPrettyTime(TicksToDuration(timer_info.start(), timer_info.end())).c_str());
 }
 
 std::string GpuTrack::GetHwExecutionTooltip(const TimerInfo& timer_info) const {
+  const CaptureData* capture_data = time_graph_->GetCaptureData();
+  CHECK(capture_data);
   return absl::StrFormat(
       "<b>Harware Execution</b><br/>"
       "<i>End is marked by \"dma_fence_signaled\" event for this command "
@@ -231,6 +237,6 @@ std::string GpuTrack::GetHwExecutionTooltip(const TimerInfo& timer_info) const {
       "<br/>"
       "<b>Submitted from thread:</b> %s [%d]<br/>"
       "<b>Time:</b> %s",
-      GOrbitApp->GetCaptureData().GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
+      capture_data->GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
       GetPrettyTime(TicksToDuration(timer_info.start(), timer_info.end())).c_str());
 }

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -199,7 +199,7 @@ std::string GpuTrack::GetBoxTooltip(PickingId id) const {
 
 std::string GpuTrack::GetSwQueueTooltip(const TimerInfo& timer_info) const {
   const CaptureData* capture_data = time_graph_->GetCaptureData();
-  CHECK(capture_data);
+  CHECK(capture_data != nullptr);
   return absl::StrFormat(
       "<b>Software Queue</b><br/>"
       "<i>Time between amdgpu_cs_ioctl (job submitted) and "
@@ -214,7 +214,7 @@ std::string GpuTrack::GetSwQueueTooltip(const TimerInfo& timer_info) const {
 
 std::string GpuTrack::GetHwQueueTooltip(const TimerInfo& timer_info) const {
   const CaptureData* capture_data = time_graph_->GetCaptureData();
-  CHECK(capture_data);
+  CHECK(capture_data != nullptr);
   return absl::StrFormat(
       "<b>Hardware Queue</b><br/><i>Time between amdgpu_sched_run_job "
       "(job scheduled) and start of GPU execution</i>"
@@ -228,7 +228,7 @@ std::string GpuTrack::GetHwQueueTooltip(const TimerInfo& timer_info) const {
 
 std::string GpuTrack::GetHwExecutionTooltip(const TimerInfo& timer_info) const {
   const CaptureData* capture_data = time_graph_->GetCaptureData();
-  CHECK(capture_data);
+  CHECK(capture_data != nullptr);
   return absl::StrFormat(
       "<b>Harware Execution</b><br/>"
       "<i>End is marked by \"dma_fence_signaled\" event for this command "

--- a/OrbitGl/GraphTrack.h
+++ b/OrbitGl/GraphTrack.h
@@ -24,6 +24,7 @@ class GraphTrack : public Track {
   void AddValue(double value, uint64_t time);
   [[nodiscard]] std::optional<std::pair<uint64_t, double> > GetPreviousValueAndTime(
       uint64_t time) const;
+  [[nodiscard]] bool IsEmpty() const override { return values_.empty(); }
 
  protected:
   void DrawSquareDot(Batcher* batcher, Vec2 center, float radius, float z, Color color);

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -30,7 +30,7 @@ float SchedulerTrack::GetHeight() const {
 bool SchedulerTrack::IsTimerActive(const TimerInfo& timer_info) const {
   bool is_same_tid_as_selected = timer_info.thread_id() == GOrbitApp->selected_thread_id();
   const CaptureData* capture_data = time_graph_->GetCaptureData();
-  CHECK(capture_data);
+  CHECK(capture_data != nullptr);
   int32_t capture_process_id = capture_data->process_id();
   bool is_same_pid_as_target =
       capture_process_id == 0 || capture_process_id == timer_info.process_id();
@@ -70,7 +70,7 @@ std::string SchedulerTrack::GetBoxTooltip(PickingId id) const {
   }
 
   const CaptureData* capture_data = time_graph_->GetCaptureData();
-  CHECK(capture_data);
+  CHECK(capture_data != nullptr);
   return absl::StrFormat(
       "<b>CPU Core activity</b><br/>"
       "<br/>"

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -29,7 +29,9 @@ float SchedulerTrack::GetHeight() const {
 
 bool SchedulerTrack::IsTimerActive(const TimerInfo& timer_info) const {
   bool is_same_tid_as_selected = timer_info.thread_id() == GOrbitApp->selected_thread_id();
-  int32_t capture_process_id = GOrbitApp->GetCaptureData().process_id();
+  const CaptureData* capture_data = time_graph_->GetCaptureData();
+  CHECK(capture_data);
+  int32_t capture_process_id = capture_data->process_id();
   bool is_same_pid_as_target =
       capture_process_id == 0 || capture_process_id == timer_info.process_id();
 
@@ -67,6 +69,8 @@ std::string SchedulerTrack::GetBoxTooltip(PickingId id) const {
     return "";
   }
 
+  const CaptureData* capture_data = time_graph_->GetCaptureData();
+  CHECK(capture_data);
   return absl::StrFormat(
       "<b>CPU Core activity</b><br/>"
       "<br/>"
@@ -74,8 +78,8 @@ std::string SchedulerTrack::GetBoxTooltip(PickingId id) const {
       "<b>Process:</b> %s [%d]<br/>"
       "<b>Thread:</b> %s [%d]<br/>",
       text_box->GetTimerInfo().processor(),
-      GOrbitApp->GetCaptureData().GetThreadName(text_box->GetTimerInfo().process_id()),
+      capture_data->GetThreadName(text_box->GetTimerInfo().process_id()),
       text_box->GetTimerInfo().process_id(),
-      GOrbitApp->GetCaptureData().GetThreadName(text_box->GetTimerInfo().thread_id()),
+      capture_data->GetThreadName(text_box->GetTimerInfo().thread_id()),
       text_box->GetTimerInfo().thread_id());
 }

--- a/OrbitGl/ThreadStateTrack.cpp
+++ b/OrbitGl/ThreadStateTrack.cpp
@@ -15,6 +15,7 @@ ThreadStateTrack::ThreadStateTrack(TimeGraph* time_graph, int32_t thread_id) : T
 }
 
 bool ThreadStateTrack::IsEmpty() const {
+  if (!GOrbitApp->HasCaptureData()) return true;
   return !GOrbitApp->GetCaptureData().HasThreadStatesForThread(thread_id_);
 }
 

--- a/OrbitGl/ThreadStateTrack.cpp
+++ b/OrbitGl/ThreadStateTrack.cpp
@@ -15,8 +15,9 @@ ThreadStateTrack::ThreadStateTrack(TimeGraph* time_graph, int32_t thread_id) : T
 }
 
 bool ThreadStateTrack::IsEmpty() const {
-  if (!GOrbitApp->HasCaptureData()) return true;
-  return !GOrbitApp->GetCaptureData().HasThreadStatesForThread(thread_id_);
+  const CaptureData* capture_data = time_graph_->GetCaptureData();
+  if (capture_data == nullptr) return true;
+  return !capture_data->HasThreadStatesForThread(thread_id_);
 }
 
 void ThreadStateTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
@@ -122,7 +123,9 @@ void ThreadStateTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
 
   uint64_t ignore_until_ns = 0;
 
-  GOrbitApp->GetCaptureData().ForEachThreadStateSliceIntersectingTimeRange(
+  const CaptureData* capture_data = time_graph_->GetCaptureData();
+  CHECK(capture_data);
+  capture_data->ForEachThreadStateSliceIntersectingTimeRange(
       thread_id_, min_tick, max_tick, [&](const ThreadStateSliceInfo& slice) {
         if (slice.end_timestamp_ns() <= ignore_until_ns) {
           // Reduce overdraw by not drawing slices whose entire width would only draw over a

--- a/OrbitGl/ThreadStateTrack.cpp
+++ b/OrbitGl/ThreadStateTrack.cpp
@@ -124,7 +124,7 @@ void ThreadStateTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
   uint64_t ignore_until_ns = 0;
 
   const CaptureData* capture_data = time_graph_->GetCaptureData();
-  CHECK(capture_data);
+  CHECK(capture_data != nullptr);
   capture_data->ForEachThreadStateSliceIntersectingTimeRange(
       thread_id_, min_tick, max_tick, [&](const ThreadStateSliceInfo& slice) {
         if (slice.end_timestamp_ns() <= ignore_until_ns) {

--- a/OrbitGl/ThreadStateTrack.h
+++ b/OrbitGl/ThreadStateTrack.h
@@ -26,7 +26,7 @@ class ThreadStateTrack final : public Track {
   void OnRelease() override { picked_ = false; };
   float GetHeight() const override { return size_[1]; }
 
-  bool IsEmpty() const;
+  bool IsEmpty() const override;
 
  private:
   std::string GetThreadStateSliceTooltip(PickingId id) const;

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -51,8 +51,10 @@ std::string ThreadTrack::GetBoxTooltip(PickingId id) const {
     return "";
   }
 
+  CaptureData* capture_data = time_graph_->GetCaptureData();
   const FunctionInfo* func =
-      GOrbitApp->GetCaptureData().GetSelectedFunction(text_box->GetTimerInfo().function_address());
+      capture_data ? capture_data->GetSelectedFunction(text_box->GetTimerInfo().function_address())
+                   : nullptr;
 
   if (!func) {
     return text_box->GetText();
@@ -175,9 +177,17 @@ void ThreadTrack::UpdatePositionOfSubtracks() {
   tracepoint_track_->SetPos(pos_[0], current_y);
 }
 
+void ThreadTrack::UpdateMinMaxTimestamps() {
+  if (!event_track_->IsEmpty()) {
+    min_time_ = std::min(min_time_.load(), event_track_->GetMinTime());
+    max_time_ = std::max(max_time_.load(), event_track_->GetMaxTime());
+  }
+}
+
 void ThreadTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
   TimerTrack::Draw(canvas, picking_mode, z_offset);
 
+  UpdateMinMaxTimestamps();
   UpdatePositionOfSubtracks();
 
   const TimeGraphLayout& layout = time_graph_->GetLayout();

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -51,7 +51,7 @@ std::string ThreadTrack::GetBoxTooltip(PickingId id) const {
     return "";
   }
 
-  CaptureData* capture_data = time_graph_->GetCaptureData();
+  const CaptureData* capture_data = time_graph_->GetCaptureData();
   const FunctionInfo* func =
       capture_data ? capture_data->GetSelectedFunction(text_box->GetTimerInfo().function_address())
                    : nullptr;

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -118,7 +118,7 @@ Color ThreadTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected) 
   }
 
   uint64_t address = timer_info.function_address();
-  const FunctionInfo* function_info = GOrbitApp->GetCaptureData().GetSelectedFunction(address);
+  const FunctionInfo* function_info = GOrbitApp->GetSelectedFunction(address);
   CHECK(function_info || timer_info.type() == TimerInfo::kIntrospection);
   std::optional<Color> user_color =
       function_info ? GetUserColor(timer_info, *function_info) : std::nullopt;
@@ -234,11 +234,9 @@ void ThreadTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_u
   TimeGraphLayout layout = time_graph_->GetLayout();
   if (text_box->GetText().empty()) {
     std::string time = GetPrettyTime(absl::Microseconds(elapsed_us));
-    const FunctionInfo* func =
-        GOrbitApp->GetCaptureData().GetSelectedFunction(timer_info.function_address());
-
     text_box->SetElapsedTimeTextLength(time.length());
 
+    const FunctionInfo* func = GOrbitApp->GetSelectedFunction(timer_info.function_address());
     if (func) {
       std::string extra_info = GetExtraInfo(timer_info);
       std::string name;

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -49,6 +49,7 @@ class ThreadTrack : public TimerTrack {
   [[nodiscard]] float GetHeaderHeight() const override;
 
   void UpdatePositionOfSubtracks();
+  void UpdateMinMaxTimestamps();
 
   std::shared_ptr<ThreadStateTrack> thread_state_track_;
   std::shared_ptr<EventTrack> event_track_;

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -34,8 +34,6 @@ using orbit_client_protos::TimerInfo;
 
 TimeGraph* GCurrentTimeGraph = nullptr;
 
-bool TimeGraph::IsMainCaptureTimegraph() { return this == GCurrentTimeGraph; }
-
 TimeGraph::TimeGraph(uint32_t font_size)
     : font_size_(font_size), text_renderer_static_(font_size), batcher_(BatcherId::kTimeGraph) {
   scheduler_track_ = GetOrCreateSchedulerTrack();

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -104,39 +104,23 @@ void TimeGraph::Clear() {
 
 double GNumHistorySeconds = 2.f;
 
-bool TimeGraph::UpdateCaptureMinMaxTimestamps() {
-  capture_min_timestamp_ = std::numeric_limits<uint64_t>::max();
-
-  mutex_.lock();
+void TimeGraph::UpdateCaptureMinMaxTimestamps() {
+  ScopeLock lock(mutex_);
   for (auto& track : tracks_) {
-    if (track->GetNumTimers() > 0) {
-      uint64_t min = track->GetMinTime();
-      if (min > 0 && min < capture_min_timestamp_) {
-        capture_min_timestamp_ = min;
-      }
+    if (!track->IsEmpty()) {
+      capture_min_timestamp_ = std::min(capture_min_timestamp_, track->GetMinTime());
+      capture_max_timestamp_ = std::max(capture_max_timestamp_, track->GetMaxTime());
     }
   }
-  mutex_.unlock();
-
-  if (IsMainCaptureTimegraph() && GOrbitApp->HasCaptureData() &&
-      GOrbitApp->GetCaptureData().GetCallstackData()->GetCallstackEventsCount() > 0) {
-    capture_min_timestamp_ = std::min(capture_min_timestamp_,
-                                      GOrbitApp->GetCaptureData().GetCallstackData()->min_time());
-    capture_max_timestamp_ = std::max(capture_max_timestamp_,
-                                      GOrbitApp->GetCaptureData().GetCallstackData()->max_time());
-  }
-
-  return capture_min_timestamp_ != std::numeric_limits<uint64_t>::max();
 }
 
 void TimeGraph::ZoomAll() {
-  if (UpdateCaptureMinMaxTimestamps()) {
-    max_time_us_ = TicksToMicroseconds(capture_min_timestamp_, capture_max_timestamp_);
-    min_time_us_ = max_time_us_ - (GNumHistorySeconds * 1000 * 1000);
-    if (min_time_us_ < 0) min_time_us_ = 0;
+  UpdateCaptureMinMaxTimestamps();
+  max_time_us_ = TicksToMicroseconds(capture_min_timestamp_, capture_max_timestamp_);
+  min_time_us_ = max_time_us_ - (GNumHistorySeconds * 1000 * 1000);
+  if (min_time_us_ < 0) min_time_us_ = 0;
 
-    NeedsUpdate();
-  }
+  NeedsUpdate();
 }
 
 void TimeGraph::Zoom(uint64_t min, uint64_t max) {
@@ -152,11 +136,7 @@ void TimeGraph::Zoom(uint64_t min, uint64_t max) {
 void TimeGraph::Zoom(const TimerInfo& timer_info) { Zoom(timer_info.start(), timer_info.end()); }
 
 double TimeGraph::GetCaptureTimeSpanUs() {
-  if (UpdateCaptureMinMaxTimestamps()) {
-    return TicksToMicroseconds(capture_min_timestamp_, capture_max_timestamp_);
-  }
-
-  return 0.0;
+  return TicksToMicroseconds(capture_min_timestamp_, capture_max_timestamp_);
 }
 
 double TimeGraph::GetCurrentTimeSpanUs() const { return max_time_us_ - min_time_us_; }
@@ -562,8 +542,8 @@ void TimeGraph::UpdatePrimitives(PickingMode picking_mode) {
   batcher_.StartNewFrame();
   text_renderer_static_.Clear();
 
-  if (GOrbitApp->HasCaptureData()) {
-    UpdateMaxTimeStamp(GOrbitApp->GetCaptureData().GetCallstackData()->max_time());
+  if (capture_data_) {
+    UpdateMaxTimeStamp(capture_data_->GetCallstackData()->max_time());
   }
 
   time_window_us_ = max_time_us_ - min_time_us_;
@@ -591,11 +571,12 @@ void TimeGraph::SelectEvents(float world_start, float world_end, int32_t thread_
   uint64_t t0 = GetTickFromWorld(world_start);
   uint64_t t1 = GetTickFromWorld(world_end);
 
+  CHECK(capture_data_);
   std::vector<CallstackEvent> selected_callstack_events =
       (thread_id == SamplingProfiler::kAllThreadsFakeTid)
-          ? GOrbitApp->GetCaptureData().GetCallstackData()->GetCallstackEventsInTimeRange(t0, t1)
-          : GOrbitApp->GetCaptureData().GetCallstackData()->GetCallstackEventsOfTidInTimeRange(
-                thread_id, t0, t1);
+          ? capture_data_->GetCallstackData()->GetCallstackEventsInTimeRange(t0, t1)
+          : capture_data_->GetCallstackData()->GetCallstackEventsOfTidInTimeRange(thread_id, t0,
+                                                                                  t1);
 
   selected_callstack_events_per_thread_.clear();
   for (CallstackEvent& event : selected_callstack_events) {
@@ -778,8 +759,7 @@ void TimeGraph::DrawOverlay(GlCanvas* canvas, PickingMode picking_mode) {
 
 std::string TimeGraph::GetThreadNameFromTid(uint32_t tid) {
   const std::string kEmptyString;
-  return GOrbitApp->HasCaptureData() ? GOrbitApp->GetCaptureData().GetThreadName(tid)
-                                     : kEmptyString;
+  return capture_data_ ? capture_data_->GetThreadName(tid) : kEmptyString;
 }
 
 void TimeGraph::DrawTracks(GlCanvas* canvas, PickingMode picking_mode) {
@@ -821,7 +801,8 @@ std::shared_ptr<ThreadTrack> TimeGraph::GetOrCreateThreadTrack(int32_t tid) {
       track->SetLabel("All tracepoint events");
     } else if (tid == SamplingProfiler::kAllThreadsFakeTid) {
       // This is the process track.
-      std::string process_name = GOrbitApp->GetCaptureData().process_name();
+      CHECK(capture_data_);
+      std::string process_name = capture_data_->process_name();
       track->SetName(process_name);
       const std::string_view all_threads = " (all_threads)";
       track->SetLabel(process_name.append(all_threads));
@@ -938,16 +919,16 @@ void TimeGraph::SetThreadFilter(const std::string& filter) {
 void TimeGraph::SortTracks() {
   std::shared_ptr<ThreadTrack> process_track = nullptr;
 
-  if (IsMainCaptureTimegraph() && GOrbitApp->HasCaptureData()) {
+  if (capture_data_ != nullptr) {
     // Get or create thread track from events' thread id.
     event_count_.clear();
     event_count_[SamplingProfiler::kAllThreadsFakeTid] =
-        GOrbitApp->GetCaptureData().GetCallstackData()->GetCallstackEventsCount();
+        capture_data_->GetCallstackData()->GetCallstackEventsCount();
 
     // The process track is a special ThreadTrack of id "kAllThreadsFakeTid".
     process_track = GetOrCreateThreadTrack(SamplingProfiler::kAllThreadsFakeTid);
     for (const auto& tid_and_count :
-         GOrbitApp->GetCaptureData().GetCallstackData()->GetCallstackEventsCountsPerTid()) {
+         capture_data_->GetCallstackData()->GetCallstackEventsCountsPerTid()) {
       const int32_t thread_id = tid_and_count.first;
       const uint32_t count = tid_and_count.second;
       event_count_[thread_id] = count;
@@ -1002,8 +983,7 @@ void TimeGraph::SortTracks() {
     }
 
     // Separate "capture_pid" tracks from tracks that originate from other processes.
-    int32_t capture_pid =
-        GOrbitApp->HasCaptureData() ? GOrbitApp->GetCaptureData().process_id() : 0;
+    int32_t capture_pid = capture_data_ ? capture_data_->process_id() : 0;
     std::vector<std::shared_ptr<Track>> capture_pid_tracks;
     std::vector<std::shared_ptr<Track>> external_pid_tracks;
     for (auto& track : all_processes_sorted_tracks) {

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -53,7 +53,7 @@ class TimeGraph {
                     const orbit_client_protos::FunctionInfo* function);
   void UpdateMaxTimeStamp(uint64_t time);
 
-  [[nodiscard]] CaptureData* GetCaptureData() const { return capture_data_; }
+  [[nodiscard]] const CaptureData* GetCaptureData() const { return capture_data_; }
   void SetCaptureData(CaptureData* capture_data) { capture_data_ = capture_data; }
 
   [[nodiscard]] float GetThreadTotalHeight() const;

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -11,6 +11,7 @@
 #include "AsyncTrack.h"
 #include "Batcher.h"
 #include "BlockChain.h"
+#include "CaptureData.h"
 #include "FrameTrack.h"
 #include "Geometry.h"
 #include "GpuTrack.h"
@@ -52,6 +53,9 @@ class TimeGraph {
                     const orbit_client_protos::FunctionInfo* function);
   void UpdateMaxTimeStamp(uint64_t time);
 
+  [[nodiscard]] CaptureData* GetCaptureData() const { return capture_data_; }
+  void SetCaptureData(CaptureData* capture_data) { capture_data_ = capture_data; }
+
   [[nodiscard]] float GetThreadTotalHeight() const;
   [[nodiscard]] float GetTextBoxHeight() const { return layout_.GetTextBoxHeight(); }
   [[nodiscard]] float GetWorldFromTick(uint64_t time) const;
@@ -61,7 +65,7 @@ class TimeGraph {
   [[nodiscard]] double GetUsFromTick(uint64_t time) const;
   [[nodiscard]] double GetTimeWindowUs() const { return time_window_us_; }
   void GetWorldMinMax(float& min, float& max) const;
-  [[nodiscard]] bool UpdateCaptureMinMaxTimestamps();
+  void UpdateCaptureMinMaxTimestamps();
 
   void Clear();
   void ZoomAll();
@@ -264,6 +268,7 @@ class TimeGraph {
   std::shared_ptr<StringManager> string_manager_;
   ManualInstrumentationManager* manual_instrumentation_manager_;
   std::unique_ptr<ManualInstrumentationManager::AsyncTimerInfoListener> async_timer_info_listener_;
+  CaptureData* capture_data_ = nullptr;
 };
 
 extern TimeGraph* GCurrentTimeGraph;

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -198,7 +198,6 @@ class TimeGraph {
   void ProcessAsyncTimer(const std::string& track_name,
                          const orbit_client_protos::TimerInfo& timer_info);
   void SetNumCores(uint32_t num_cores) { num_cores_ = num_cores; }
-  [[nodiscard]] bool IsMainCaptureTimegraph();
   [[nodiscard]] std::string GetThreadNameFromTid(uint32_t tid);
 
  private:

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -194,6 +194,8 @@ class TimeGraph {
   void ProcessAsyncTimer(const std::string& track_name,
                          const orbit_client_protos::TimerInfo& timer_info);
   void SetNumCores(uint32_t num_cores) { num_cores_ = num_cores; }
+  [[nodiscard]] bool IsMainCaptureTimegraph();
+  [[nodiscard]] std::string GetThreadNameFromTid(uint32_t tid);
 
  private:
   uint32_t font_size_;

--- a/OrbitGl/TimerTrack.h
+++ b/OrbitGl/TimerTrack.h
@@ -39,8 +39,6 @@ class TimerTrack : public Track {
   [[nodiscard]] uint32_t GetDepth() const { return depth_; }
   [[nodiscard]] std::string GetExtraInfo(const orbit_client_protos::TimerInfo& timer);
   [[nodiscard]] uint32_t GetNumTimers() const { return num_timers_; }
-  [[nodiscard]] uint64_t GetMinTime() const { return min_time_; }
-  [[nodiscard]] uint64_t GetMaxTime() const { return max_time_; }
 
   [[nodiscard]] const TextBox* GetFirstAfterTime(uint64_t time, uint32_t depth) const;
   [[nodiscard]] const TextBox* GetFirstBeforeTime(uint64_t time, uint32_t depth) const;
@@ -55,7 +53,7 @@ class TimerTrack : public Track {
 
   [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllChains() override;
   [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllSerializableChains() override;
-  [[nodiscard]] virtual bool IsEmpty() const;
+  [[nodiscard]] bool IsEmpty() const override;
 
   [[nodiscard]] bool IsCollapsable() const override { return depth_ > 1; }
 

--- a/OrbitGl/TracepointTrack.cpp
+++ b/OrbitGl/TracepointTrack.cpp
@@ -156,5 +156,6 @@ std::string TracepointTrack::GetSampleTooltip(PickingId id) const {
 }
 
 bool TracepointTrack::IsEmpty() const {
+  if (!GOrbitApp->HasCaptureData()) return true;
   return GOrbitApp->GetCaptureData().GetNumTracepointsForThreadId(thread_id_) == 0;
 }

--- a/OrbitGl/TracepointTrack.cpp
+++ b/OrbitGl/TracepointTrack.cpp
@@ -71,7 +71,7 @@ void TracepointTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
   const Color kGreenSelection(0, 255, 0, 255);
 
   const CaptureData* capture_data = time_graph_->GetCaptureData();
-  CHECK(capture_data);
+  CHECK(capture_data != nullptr);
 
   if (!picking) {
     capture_data->ForEachTracepointEventOfThreadInTimeRange(
@@ -132,7 +132,7 @@ std::string TracepointTrack::GetSampleTooltip(PickingId id) const {
   uint64_t tracepoint_info_key = tracepoint_event_info->tracepoint_info_key();
 
   const CaptureData* capture_data = time_graph_->GetCaptureData();
-  CHECK(capture_data);
+  CHECK(capture_data != nullptr);
 
   TracepointInfo tracepoint_info = capture_data->GetTracepointInfo(tracepoint_info_key);
 

--- a/OrbitGl/TracepointTrack.cpp
+++ b/OrbitGl/TracepointTrack.cpp
@@ -70,16 +70,18 @@ void TracepointTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
 
   const Color kGreenSelection(0, 255, 0, 255);
 
+  const CaptureData* capture_data = time_graph_->GetCaptureData();
+  CHECK(capture_data);
+
   if (!picking) {
-    GOrbitApp->GetCaptureData().ForEachTracepointEventOfThreadInTimeRange(
+    capture_data->ForEachTracepointEventOfThreadInTimeRange(
         thread_id_, min_tick, max_tick,
         [&](const orbit_client_protos::TracepointEventInfo& tracepoint) {
           uint64_t time = tracepoint.time();
           float radius = track_height / 4;
           Vec2 pos(time_graph_->GetWorldFromTick(time), pos_[1]);
           if (thread_id_ == TracepointEventBuffer::kAllTracepointsFakeTid) {
-            const Color color =
-                tracepoint.pid() == GOrbitApp->GetCaptureData().process_id() ? kGrey : kWhite;
+            const Color color = tracepoint.pid() == capture_data->process_id() ? kGrey : kWhite;
             batcher->AddVerticalLine(pos, -track_height, z, color);
           } else {
             batcher->AddVerticalLine(pos, -radius, z, kWhiteTransparent);
@@ -94,7 +96,7 @@ void TracepointTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
     constexpr float kPickingBoxWidth = 9.0f;
     constexpr float kPickingBoxOffset = kPickingBoxWidth / 2.0f;
 
-    GOrbitApp->GetCaptureData().ForEachTracepointEventOfThreadInTimeRange(
+    capture_data->ForEachTracepointEventOfThreadInTimeRange(
         thread_id_, min_tick, max_tick,
         [&](const orbit_client_protos::TracepointEventInfo& tracepoint) {
           uint64_t time = tracepoint.time();
@@ -129,8 +131,10 @@ std::string TracepointTrack::GetSampleTooltip(PickingId id) const {
 
   uint64_t tracepoint_info_key = tracepoint_event_info->tracepoint_info_key();
 
-  TracepointInfo tracepoint_info =
-      GOrbitApp->GetCaptureData().GetTracepointInfo(tracepoint_info_key);
+  const CaptureData* capture_data = time_graph_->GetCaptureData();
+  CHECK(capture_data);
+
+  TracepointInfo tracepoint_info = capture_data->GetTracepointInfo(tracepoint_info_key);
 
   if (thread_id_ == TracepointEventBuffer::kAllTracepointsFakeTid) {
     return absl::StrFormat(
@@ -141,10 +145,8 @@ std::string TracepointTrack::GetSampleTooltip(PickingId id) const {
         "<b>Process:</b> %s [%d]<br/>"
         "<b>Thread:</b> %s [%d]<br/>",
         tracepoint_info.category(), tracepoint_info.name(), tracepoint_event_info->cpu(),
-        GOrbitApp->GetCaptureData().GetThreadName(tracepoint_event_info->pid()),
-        tracepoint_event_info->pid(),
-        GOrbitApp->GetCaptureData().GetThreadName(tracepoint_event_info->tid()),
-        tracepoint_event_info->tid());
+        capture_data->GetThreadName(tracepoint_event_info->pid()), tracepoint_event_info->pid(),
+        capture_data->GetThreadName(tracepoint_event_info->tid()), tracepoint_event_info->tid());
   } else {
     return absl::StrFormat(
         "<b>%s : %s</b><br/>"
@@ -156,6 +158,7 @@ std::string TracepointTrack::GetSampleTooltip(PickingId id) const {
 }
 
 bool TracepointTrack::IsEmpty() const {
-  if (!GOrbitApp->HasCaptureData()) return true;
-  return GOrbitApp->GetCaptureData().GetNumTracepointsForThreadId(thread_id_) == 0;
+  const CaptureData* capture_data = time_graph_->GetCaptureData();
+  if (capture_data == nullptr) return true;
+  return capture_data->GetNumTracepointsForThreadId(thread_id_) == 0;
 }

--- a/OrbitGl/TracepointTrack.h
+++ b/OrbitGl/TracepointTrack.h
@@ -22,7 +22,7 @@ class TracepointTrack : public EventTrack {
   void OnRelease() override;
 
   std::string GetSampleTooltip(PickingId id) const;
-  bool IsEmpty() const;
+  bool IsEmpty() const override;
 };
 
 #endif  // ORBIT_GL_TRACEPOINT_TRACK_H_

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -200,7 +200,7 @@ void Track::SetY(float y) {
 }
 
 Color Track::GetBackgroundColor() const {
-  CaptureData* capture_data = time_graph_->GetCaptureData();
+  const CaptureData* capture_data = time_graph_->GetCaptureData();
   int32_t capture_process_id = capture_data ? capture_data->process_id() : 0;
   if (GetType() == kSchedulerTrack) {
     return color_;

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -200,7 +200,8 @@ void Track::SetY(float y) {
 }
 
 Color Track::GetBackgroundColor() const {
-  int32_t capture_process_id = GOrbitApp->GetCaptureData().process_id();
+  CaptureData* capture_data = time_graph_->GetCaptureData();
+  int32_t capture_process_id = capture_data ? capture_data->process_id() : 0;
   if (GetType() == kSchedulerTrack) {
     return color_;
   } else if (process_id_ != -1 && process_id_ != capture_process_id) {

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -201,7 +201,7 @@ void Track::SetY(float y) {
 
 Color Track::GetBackgroundColor() const {
   const CaptureData* capture_data = time_graph_->GetCaptureData();
-  int32_t capture_process_id = capture_data ? capture_data->process_id() : 0;
+  int32_t capture_process_id = capture_data ? capture_data->process_id() : -1;
   if (GetType() == kSchedulerTrack) {
     return color_;
   } else if (process_id_ != -1 && process_id_ != capture_process_id) {

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -57,8 +57,8 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
   void SetVisible(bool value) { visible_ = value; }
 
   [[nodiscard]] uint32_t GetNumTimers() const { return num_timers_; }
-  [[nodiscard]] uint64_t GetMinTime() const { return min_time_; }
-  [[nodiscard]] uint64_t GetMaxTime() const { return max_time_; }
+  [[nodiscard]] virtual uint64_t GetMinTime() const { return min_time_; }
+  [[nodiscard]] virtual uint64_t GetMaxTime() const { return max_time_; }
   void SetNumberOfPrioritizedTrailingCharacters(int num_characters) {
     num_prioritized_trailing_characters_ = num_characters;
   }
@@ -97,6 +97,7 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
   [[nodiscard]] virtual bool IsCollapsable() const { return false; }
   [[nodiscard]] int32_t GetProcessId() const { return process_id_; }
   void SetProcessId(uint32_t pid) { process_id_ = pid; }
+  [[nodiscard]] virtual bool IsEmpty() const = 0;
 
  protected:
   void DrawTriangleFan(Batcher* batcher, const std::vector<Vec2>& points, const Vec2& pos,

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -509,6 +509,7 @@ void OrbitMainWindow::StartMainTimer() {
 }
 
 void OrbitMainWindow::OnTimer() {
+  ORBIT_SCOPE("OrbitMainWindow::OnTimer");
   GOrbitApp->MainTick();
 
   for (OrbitGLWidget* glWidget : m_GlWidgets) {
@@ -584,6 +585,26 @@ void OrbitMainWindow::on_actionToggle_Capture_triggered() { GOrbitApp->ToggleCap
 void OrbitMainWindow::on_actionClear_Capture_triggered() { GOrbitApp->ClearCapture(); }
 
 void OrbitMainWindow::on_actionHelp_triggered() { GOrbitApp->ToggleDrawHelp(); }
+
+void OrbitMainWindow::on_actionIntrospection_triggered() {
+  if (introspection_widget_ == nullptr) {
+    introspection_widget_ = new OrbitGLWidget();
+    introspection_widget_->setWindowFlags(Qt::WindowStaysOnTopHint);
+    introspection_widget_->Initialize(GlCanvas::CanvasType::kIntrospectionWindow, this, 14);
+    introspection_widget_->installEventFilter(this);
+  }
+
+  introspection_widget_->show();
+}
+
+bool OrbitMainWindow::eventFilter(QObject* object, QEvent* event) {
+  if (object == introspection_widget_) {
+    if (event->type() == QEvent::Close) {
+      GOrbitApp->StopIntrospection();
+    }
+  }
+  return false;
+}
 
 void OrbitMainWindow::ShowCaptureOnSaveWarningIfNeeded() {
   QSettings settings("The Orbit Authors", "Orbit Profiler");

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -58,6 +58,7 @@ class OrbitMainWindow : public QMainWindow {
 
  protected:
   void closeEvent(QCloseEvent* event) override;
+  bool eventFilter(QObject* object, QEvent* event) override;
 
  private slots:
   void on_actionAbout_triggered();
@@ -79,6 +80,7 @@ class OrbitMainWindow : public QMainWindow {
   void on_actionOpen_Capture_triggered();
   void on_actionClear_Capture_triggered();
   void on_actionHelp_triggered();
+  void on_actionIntrospection_triggered();
 
   void on_actionCheckFalse_triggered();
   void on_actionNullPointerDereference_triggered();
@@ -99,6 +101,7 @@ class OrbitMainWindow : public QMainWindow {
   Ui::OrbitMainWindow* ui;
   QTimer* m_MainTimer = nullptr;
   std::vector<OrbitGLWidget*> m_GlWidgets;
+  OrbitGLWidget* introspection_widget_ = nullptr;
 
   // Capture toolbar.
   QIcon icon_start_capture_;

--- a/OrbitQt/orbitmainwindow.ui
+++ b/OrbitQt/orbitmainwindow.ui
@@ -115,6 +115,7 @@ QPushButton:disabled {
            <addaction name="actionOpen_Capture"/>
            <addaction name="actionSave_Capture"/>
            <addaction name="actionHelp"/>
+           <addaction name="actionIntrospection"/>
           </widget>
          </item>
          <item>
@@ -536,6 +537,18 @@ QPushButton:disabled {
    </property>
    <property name="toolTip">
     <string>Help</string>
+   </property>
+  </action>
+  <action name="actionIntrospection">
+   <property name="icon">
+    <iconset resource="../icons/orbiticons.qrc">
+     <normaloff>:/actions/info</normaloff>:/actions/info</iconset>
+   </property>
+   <property name="text">
+    <string>Introspection</string>
+   </property>
+   <property name="toolTip">
+    <string>Introspection</string>
    </property>
   </action>
   <action name="actionQuit">


### PR DESCRIPTION
Activate client side introspection. In "--devmode", a new button in the 
capture view toolbar appears. Pressing it will instantiate an always-on-top 
IntrospectionWindow that can be used to profile Orbit inside of Orbit.
To start and stop a capture, press 'X' just like in the normal cpature window.
When the IntrospectionWindow is closed, introspection automatically stops.
You can add profiling markers in the Orbit code base by using the manual 
instrumentation API in Orbit.h.