### PR TITLE
Add a Thread-Safe Dispatch Table for the Vulkan Layer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 option(WITH_ORBITGL "Setting this option will enable the OrbitGL component." ON)
 option(WITH_GUI "Setting this option will enable the Qt-based UI client." ON)
 option(WITH_CRASH_HANDLING "Setting this option will enable crash handling based on crashpad." ON)
+option(WITH_VULKAN_LAYER "Setting this option will enable the Vulkan layer for advanced GPU information." OFF)
 
 set(CRASHDUMP_SERVER "" CACHE STRING "Setting this option will enable uploading crash dumps to the url specified.")
 
@@ -146,6 +147,9 @@ else()
   add_subdirectory(OrbitLinuxTracing)
   add_subdirectory(OrbitService)
   add_subdirectory(OrbitTriggerCaptureVulkanLayer)
+endif()
+
+if(WITH_VULKAN_LAYER)
   add_subdirectory(OrbitVulkanLayer)
 endif()
 

--- a/OrbitVulkanLayer/CMakeLists.txt
+++ b/OrbitVulkanLayer/CMakeLists.txt
@@ -15,6 +15,7 @@ target_include_directories(OrbitVulkanLayer PRIVATE
 
 target_sources(OrbitVulkanLayer PRIVATE
         DeviceManager.h
+        DispatchTable.cpp
         DispatchTable.h
         QueueManager.cpp
         QueueManager.h

--- a/OrbitVulkanLayer/CMakeLists.txt
+++ b/OrbitVulkanLayer/CMakeLists.txt
@@ -15,6 +15,7 @@ target_include_directories(OrbitVulkanLayer PRIVATE
 
 target_sources(OrbitVulkanLayer PRIVATE
         DeviceManager.h
+        DispatchTable.h
         QueueManager.cpp
         QueueManager.h
         TimerQueryPool.h)
@@ -29,6 +30,7 @@ target_compile_options(OrbitVulkanLayerTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(OrbitVulkanLayerTests PRIVATE
         DeviceManagerTest.cpp
+        DispatchTableTest.cpp
         TimerQueryPoolTest.cpp
         QueueManagerTest.cpp)
 

--- a/OrbitVulkanLayer/DispatchTable.cpp
+++ b/OrbitVulkanLayer/DispatchTable.cpp
@@ -7,7 +7,7 @@
 namespace orbit_vulkan_layer {
 
 void DispatchTable::CreateInstanceDispatchTable(
-    VkInstance instance, const PFN_vkGetInstanceProcAddr& next_get_instance_proc_addr_function) {
+    VkInstance instance, PFN_vkGetInstanceProcAddr next_get_instance_proc_addr_function) {
   VkLayerInstanceDispatchTable dispatch_table;
   dispatch_table.DestroyInstance = absl::bit_cast<PFN_vkDestroyInstance>(
       next_get_instance_proc_addr_function(instance, "vkDestroyInstance"));
@@ -35,7 +35,7 @@ void DispatchTable::RemoveInstanceDispatchTable(VkInstance instance) {
 }
 
 void DispatchTable::CreateDeviceDispatchTable(
-    VkDevice device, const PFN_vkGetDeviceProcAddr& next_get_device_proc_addr_function) {
+    VkDevice device, PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function) {
   VkLayerDispatchTable dispatch_table;
 
   dispatch_table.DestroyDevice = absl::bit_cast<PFN_vkDestroyDevice>(

--- a/OrbitVulkanLayer/DispatchTable.cpp
+++ b/OrbitVulkanLayer/DispatchTable.cpp
@@ -91,7 +91,6 @@ void DispatchTable::CreateDeviceDispatchTable(
       next_get_device_proc_addr_function(device, "vkCmdDebugMarkerEndEXT"));
 
   void* key = GetDispatchTableKey(device);
-
   {
     absl::WriterMutexLock lock(&mutex_);
     CHECK(!device_dispatch_table_.contains(key));

--- a/OrbitVulkanLayer/DispatchTable.cpp
+++ b/OrbitVulkanLayer/DispatchTable.cpp
@@ -29,9 +29,11 @@ void DispatchTable::CreateInstanceDispatchTable(
 
 void DispatchTable::RemoveInstanceDispatchTable(VkInstance instance) {
   void* key = GetDispatchTableKey(instance);
-  absl::WriterMutexLock lock(&mutex_);
-  CHECK(instance_dispatch_table_.contains(key));
-  instance_dispatch_table_.erase(key);
+  {
+    absl::WriterMutexLock lock(&mutex_);
+    CHECK(instance_dispatch_table_.contains(key));
+    instance_dispatch_table_.erase(key);
+  }
 }
 
 void DispatchTable::CreateDeviceDispatchTable(
@@ -109,16 +111,18 @@ void DispatchTable::CreateDeviceDispatchTable(
 
 void DispatchTable::RemoveDeviceDispatchTable(VkDevice device) {
   void* key = GetDispatchTableKey(device);
-  absl::WriterMutexLock lock(&mutex_);
+  {
+    absl::WriterMutexLock lock(&mutex_);
 
-  CHECK(device_dispatch_table_.contains(key));
-  device_dispatch_table_.erase(key);
+    CHECK(device_dispatch_table_.contains(key));
+    device_dispatch_table_.erase(key);
 
-  CHECK(device_supports_debug_utils_extension_.contains(key));
-  device_supports_debug_utils_extension_.erase(key);
+    CHECK(device_supports_debug_utils_extension_.contains(key));
+    device_supports_debug_utils_extension_.erase(key);
 
-  CHECK(device_supports_debug_marker_extension_.contains(key));
-  device_supports_debug_marker_extension_.erase(key);
+    CHECK(device_supports_debug_marker_extension_.contains(key));
+    device_supports_debug_marker_extension_.erase(key);
+  }
 }
 
 }  // namespace orbit_vulkan_layer

--- a/OrbitVulkanLayer/DispatchTable.cpp
+++ b/OrbitVulkanLayer/DispatchTable.cpp
@@ -1,0 +1,124 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "DispatchTable.h"
+
+namespace orbit_vulkan_layer {
+
+void DispatchTable::CreateInstanceDispatchTable(
+    VkInstance instance, const PFN_vkGetInstanceProcAddr& next_get_instance_proc_addr_function) {
+  VkLayerInstanceDispatchTable dispatch_table;
+  dispatch_table.DestroyInstance = absl::bit_cast<PFN_vkDestroyInstance>(
+      next_get_instance_proc_addr_function(instance, "vkDestroyInstance"));
+  dispatch_table.GetInstanceProcAddr = absl::bit_cast<PFN_vkGetInstanceProcAddr>(
+      next_get_instance_proc_addr_function(instance, "vkGetInstanceProcAddr"));
+  dispatch_table.EnumerateDeviceExtensionProperties =
+      absl::bit_cast<PFN_vkEnumerateDeviceExtensionProperties>(
+          next_get_instance_proc_addr_function(instance, "vkEnumerateDeviceExtensionProperties"));
+  dispatch_table.GetPhysicalDeviceProperties = absl::bit_cast<PFN_vkGetPhysicalDeviceProperties>(
+      next_get_instance_proc_addr_function(instance, "vkGetPhysicalDeviceProperties"));
+
+  void* key = GetDispatchTableKey(instance);
+  {
+    absl::WriterMutexLock lock(&mutex_);
+    CHECK(!instance_dispatch_table_.contains(key));
+    instance_dispatch_table_[key] = dispatch_table;
+  }
+}
+
+void DispatchTable::RemoveInstanceDispatchTable(VkInstance instance) {
+  void* key = GetDispatchTableKey(instance);
+  absl::WriterMutexLock lock(&mutex_);
+  CHECK(instance_dispatch_table_.contains(key));
+  instance_dispatch_table_.erase(key);
+}
+
+void DispatchTable::CreateDeviceDispatchTable(
+    VkDevice device, const PFN_vkGetDeviceProcAddr& next_get_device_proc_addr_function) {
+  VkLayerDispatchTable dispatch_table;
+
+  dispatch_table.DestroyDevice = absl::bit_cast<PFN_vkDestroyDevice>(
+      next_get_device_proc_addr_function(device, "vkDestroyDevice"));
+  dispatch_table.GetDeviceProcAddr = absl::bit_cast<PFN_vkGetDeviceProcAddr>(
+      next_get_device_proc_addr_function(device, "vkGetDeviceProcAddr"));
+
+  dispatch_table.ResetCommandPool = absl::bit_cast<PFN_vkResetCommandPool>(
+      next_get_device_proc_addr_function(device, "vkResetCommandPool"));
+
+  dispatch_table.AllocateCommandBuffers = absl::bit_cast<PFN_vkAllocateCommandBuffers>(
+      next_get_device_proc_addr_function(device, "vkAllocateCommandBuffers"));
+  dispatch_table.FreeCommandBuffers = absl::bit_cast<PFN_vkFreeCommandBuffers>(
+      next_get_device_proc_addr_function(device, "vkFreeCommandBuffers"));
+  dispatch_table.BeginCommandBuffer = absl::bit_cast<PFN_vkBeginCommandBuffer>(
+      next_get_device_proc_addr_function(device, "vkBeginCommandBuffer"));
+  dispatch_table.EndCommandBuffer = absl::bit_cast<PFN_vkEndCommandBuffer>(
+      next_get_device_proc_addr_function(device, "vkEndCommandBuffer"));
+  dispatch_table.ResetCommandBuffer = absl::bit_cast<PFN_vkResetCommandBuffer>(
+      next_get_device_proc_addr_function(device, "vkResetCommandBuffer"));
+
+  dispatch_table.QueueSubmit = absl::bit_cast<PFN_vkQueueSubmit>(
+      next_get_device_proc_addr_function(device, "vkQueueSubmit"));
+  dispatch_table.QueuePresentKHR = absl::bit_cast<PFN_vkQueuePresentKHR>(
+      next_get_device_proc_addr_function(device, "vkQueuePresentKHR"));
+
+  dispatch_table.GetDeviceQueue = absl::bit_cast<PFN_vkGetDeviceQueue>(
+      next_get_device_proc_addr_function(device, "vkGetDeviceQueue"));
+  dispatch_table.GetDeviceQueue2 = absl::bit_cast<PFN_vkGetDeviceQueue2>(
+      next_get_device_proc_addr_function(device, "vkGetDeviceQueue2"));
+
+  dispatch_table.CreateQueryPool = absl::bit_cast<PFN_vkCreateQueryPool>(
+      next_get_device_proc_addr_function(device, "vkCreateQueryPool"));
+  dispatch_table.ResetQueryPoolEXT = absl::bit_cast<PFN_vkResetQueryPoolEXT>(
+      next_get_device_proc_addr_function(device, "vkResetQueryPoolEXT"));
+
+  dispatch_table.CmdWriteTimestamp = absl::bit_cast<PFN_vkCmdWriteTimestamp>(
+      next_get_device_proc_addr_function(device, "vkCmdWriteTimestamp"));
+
+  dispatch_table.GetQueryPoolResults = absl::bit_cast<PFN_vkGetQueryPoolResults>(
+      next_get_device_proc_addr_function(device, "vkGetQueryPoolResults"));
+
+  dispatch_table.CmdBeginDebugUtilsLabelEXT = absl::bit_cast<PFN_vkCmdBeginDebugUtilsLabelEXT>(
+      next_get_device_proc_addr_function(device, "vkCmdBeginDebugUtilsLabelEXT"));
+  dispatch_table.CmdEndDebugUtilsLabelEXT = absl::bit_cast<PFN_vkCmdEndDebugUtilsLabelEXT>(
+      next_get_device_proc_addr_function(device, "vkCmdEndDebugUtilsLabelEXT"));
+
+  dispatch_table.CmdDebugMarkerBeginEXT = absl::bit_cast<PFN_vkCmdDebugMarkerBeginEXT>(
+      next_get_device_proc_addr_function(device, "vkCmdDebugMarkerBeginEXT"));
+  dispatch_table.CmdDebugMarkerEndEXT = absl::bit_cast<PFN_vkCmdDebugMarkerEndEXT>(
+      next_get_device_proc_addr_function(device, "vkCmdDebugMarkerEndEXT"));
+
+  void* key = GetDispatchTableKey(device);
+
+  {
+    absl::WriterMutexLock lock(&mutex_);
+    CHECK(!device_dispatch_table_.contains(key));
+    device_dispatch_table_[key] = dispatch_table;
+
+    CHECK(!device_supports_debug_utils_extension_.contains(key));
+    device_supports_debug_utils_extension_[key] =
+        dispatch_table.CmdBeginDebugUtilsLabelEXT != nullptr &&
+        dispatch_table.CmdEndDebugUtilsLabelEXT != nullptr;
+
+    CHECK(!device_supports_debug_marker_extension_.contains(key));
+    device_supports_debug_marker_extension_[key] =
+        dispatch_table.CmdDebugMarkerBeginEXT != nullptr &&
+        dispatch_table.CmdDebugMarkerEndEXT != nullptr;
+  }
+}
+
+void DispatchTable::RemoveDeviceDispatchTable(VkDevice device) {
+  void* key = GetDispatchTableKey(device);
+  absl::WriterMutexLock lock(&mutex_);
+
+  CHECK(device_dispatch_table_.contains(key));
+  device_dispatch_table_.erase(key);
+
+  CHECK(device_supports_debug_utils_extension_.contains(key));
+  device_supports_debug_utils_extension_.erase(key);
+
+  CHECK(device_supports_debug_marker_extension_.contains(key));
+  device_supports_debug_marker_extension_.erase(key);
+}
+
+}  // namespace orbit_vulkan_layer

--- a/OrbitVulkanLayer/DispatchTable.h
+++ b/OrbitVulkanLayer/DispatchTable.h
@@ -43,236 +43,288 @@ class DispatchTable {
   template <typename DispatchableType>
   PFN_vkDestroyDevice DestroyDevice(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
-    absl::ReaderMutexLock lock(&mutex_);
-    CHECK(device_dispatch_table_.contains(key));
-    CHECK(device_dispatch_table_.at(key).DestroyDevice != nullptr);
-    return device_dispatch_table_.at(key).DestroyDevice;
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).DestroyDevice != nullptr);
+      return device_dispatch_table_.at(key).DestroyDevice;
+    }
   }
 
   template <typename DispatchableType>
   PFN_vkDestroyInstance DestroyInstance(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
-    absl::ReaderMutexLock lock(&mutex_);
-    CHECK(instance_dispatch_table_.contains(key));
-    CHECK(instance_dispatch_table_.at(key).DestroyInstance != nullptr);
-    return instance_dispatch_table_.at(key).DestroyInstance;
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(instance_dispatch_table_.contains(key));
+      CHECK(instance_dispatch_table_.at(key).DestroyInstance != nullptr);
+      return instance_dispatch_table_.at(key).DestroyInstance;
+    }
   }
 
   template <typename DispatchableType>
   PFN_vkEnumerateDeviceExtensionProperties EnumerateDeviceExtensionProperties(
       DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
-    absl::ReaderMutexLock lock(&mutex_);
-    CHECK(instance_dispatch_table_.contains(key));
-    CHECK(instance_dispatch_table_.at(key).EnumerateDeviceExtensionProperties != nullptr);
-    return instance_dispatch_table_.at(key).EnumerateDeviceExtensionProperties;
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(instance_dispatch_table_.contains(key));
+      CHECK(instance_dispatch_table_.at(key).EnumerateDeviceExtensionProperties != nullptr);
+      return instance_dispatch_table_.at(key).EnumerateDeviceExtensionProperties;
+    }
   }
 
   template <typename DispatchableType>
   PFN_vkGetPhysicalDeviceProperties GetPhysicalDeviceProperties(
       DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
-    absl::ReaderMutexLock lock(&mutex_);
-    CHECK(instance_dispatch_table_.contains(key));
-    CHECK(instance_dispatch_table_.at(key).GetPhysicalDeviceProperties != nullptr);
-    return instance_dispatch_table_.at(key).GetPhysicalDeviceProperties;
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(instance_dispatch_table_.contains(key));
+      CHECK(instance_dispatch_table_.at(key).GetPhysicalDeviceProperties != nullptr);
+      return instance_dispatch_table_.at(key).GetPhysicalDeviceProperties;
+    }
   }
 
   template <typename DispatchableType>
   PFN_vkGetInstanceProcAddr GetInstanceProcAddr(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
-    absl::ReaderMutexLock lock(&mutex_);
-    CHECK(instance_dispatch_table_.contains(key));
-    CHECK(instance_dispatch_table_.at(key).GetInstanceProcAddr != nullptr);
-    return instance_dispatch_table_.at(key).GetInstanceProcAddr;
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(instance_dispatch_table_.contains(key));
+      CHECK(instance_dispatch_table_.at(key).GetInstanceProcAddr != nullptr);
+      return instance_dispatch_table_.at(key).GetInstanceProcAddr;
+    }
   }
 
   template <typename DispatchableType>
   PFN_vkGetDeviceProcAddr GetDeviceProcAddr(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
-    absl::ReaderMutexLock lock(&mutex_);
-    CHECK(device_dispatch_table_.contains(key));
-    CHECK(device_dispatch_table_.at(key).GetDeviceProcAddr != nullptr);
-    return device_dispatch_table_.at(key).GetDeviceProcAddr;
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).GetDeviceProcAddr != nullptr);
+      return device_dispatch_table_.at(key).GetDeviceProcAddr;
+    }
   }
 
   template <typename DispatchableType>
   PFN_vkResetCommandPool ResetCommandPool(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
-    absl::ReaderMutexLock lock(&mutex_);
-    CHECK(device_dispatch_table_.contains(key));
-    CHECK(device_dispatch_table_.at(key).ResetCommandPool != nullptr);
-    return device_dispatch_table_.at(key).ResetCommandPool;
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).ResetCommandPool != nullptr);
+      return device_dispatch_table_.at(key).ResetCommandPool;
+    }
   }
 
   template <typename DispatchableType>
   PFN_vkAllocateCommandBuffers AllocateCommandBuffers(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
-    absl::ReaderMutexLock lock(&mutex_);
-    CHECK(device_dispatch_table_.contains(key));
-    CHECK(device_dispatch_table_.at(key).AllocateCommandBuffers != nullptr);
-    return device_dispatch_table_.at(key).AllocateCommandBuffers;
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).AllocateCommandBuffers != nullptr);
+      return device_dispatch_table_.at(key).AllocateCommandBuffers;
+    }
   }
 
   template <typename DispatchableType>
   PFN_vkFreeCommandBuffers FreeCommandBuffers(DispatchableType dispatchable_object) {
-    absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
-    CHECK(device_dispatch_table_.contains(key));
-    CHECK(device_dispatch_table_.at(key).FreeCommandBuffers != nullptr);
-    return device_dispatch_table_.at(key).FreeCommandBuffers;
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).FreeCommandBuffers != nullptr);
+      return device_dispatch_table_.at(key).FreeCommandBuffers;
+    }
   }
 
   template <typename DispatchableType>
   PFN_vkBeginCommandBuffer BeginCommandBuffer(DispatchableType dispatchable_object) {
-    absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
-    CHECK(device_dispatch_table_.contains(key));
-    CHECK(device_dispatch_table_.at(key).BeginCommandBuffer != nullptr);
-    return device_dispatch_table_.at(key).BeginCommandBuffer;
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).BeginCommandBuffer != nullptr);
+      return device_dispatch_table_.at(key).BeginCommandBuffer;
+    }
   }
 
   template <typename DispatchableType>
   PFN_vkEndCommandBuffer EndCommandBuffer(DispatchableType dispatchable_object) {
-    absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
-    CHECK(device_dispatch_table_.contains(key));
-    CHECK(device_dispatch_table_.at(key).EndCommandBuffer != nullptr);
-    return device_dispatch_table_.at(key).EndCommandBuffer;
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).EndCommandBuffer != nullptr);
+      return device_dispatch_table_.at(key).EndCommandBuffer;
+    }
   }
 
   template <typename DispatchableType>
   PFN_vkResetCommandBuffer ResetCommandBuffer(DispatchableType dispatchable_object) {
-    absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
-    CHECK(device_dispatch_table_.contains(key));
-    CHECK(device_dispatch_table_.at(key).ResetCommandBuffer != nullptr);
-    return device_dispatch_table_.at(key).ResetCommandBuffer;
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).ResetCommandBuffer != nullptr);
+      return device_dispatch_table_.at(key).ResetCommandBuffer;
+    }
   }
 
   template <typename DispatchableType>
   PFN_vkGetDeviceQueue GetDeviceQueue(DispatchableType dispatchable_object) {
-    absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
-    CHECK(device_dispatch_table_.contains(key));
-    CHECK(device_dispatch_table_.at(key).GetDeviceQueue != nullptr);
-    return device_dispatch_table_.at(key).GetDeviceQueue;
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).GetDeviceQueue != nullptr);
+      return device_dispatch_table_.at(key).GetDeviceQueue;
+    }
   }
 
   template <typename DispatchableType>
   PFN_vkGetDeviceQueue2 GetDeviceQueue2(DispatchableType dispatchable_object) {
-    absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
-    CHECK(device_dispatch_table_.contains(key));
-    CHECK(device_dispatch_table_.at(key).GetDeviceQueue2 != nullptr);
-    return device_dispatch_table_.at(key).GetDeviceQueue2;
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).GetDeviceQueue2 != nullptr);
+      return device_dispatch_table_.at(key).GetDeviceQueue2;
+    }
   }
 
   template <typename DispatchableType>
   PFN_vkQueueSubmit QueueSubmit(DispatchableType dispatchable_object) {
-    absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
-    CHECK(device_dispatch_table_.contains(key));
-    CHECK(device_dispatch_table_.at(key).QueueSubmit != nullptr);
-    return device_dispatch_table_.at(key).QueueSubmit;
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).QueueSubmit != nullptr);
+      return device_dispatch_table_.at(key).QueueSubmit;
+    }
   }
 
   template <typename DispatchableType>
   PFN_vkQueuePresentKHR QueuePresentKHR(DispatchableType dispatchable_object) {
-    absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
-    CHECK(device_dispatch_table_.contains(key));
-    CHECK(device_dispatch_table_.at(key).QueuePresentKHR != nullptr);
-    return device_dispatch_table_.at(key).QueuePresentKHR;
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).QueuePresentKHR != nullptr);
+      return device_dispatch_table_.at(key).QueuePresentKHR;
+    }
   }
 
   template <typename DispatchableType>
   PFN_vkCreateQueryPool CreateQueryPool(DispatchableType dispatchable_object) {
-    absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
-    CHECK(device_dispatch_table_.contains(key));
-    CHECK(device_dispatch_table_.at(key).CreateQueryPool != nullptr);
-    return device_dispatch_table_.at(key).CreateQueryPool;
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).CreateQueryPool != nullptr);
+      return device_dispatch_table_.at(key).CreateQueryPool;
+    }
   }
 
   template <typename DispatchableType>
   PFN_vkResetQueryPoolEXT ResetQueryPoolEXT(DispatchableType dispatchable_object) {
-    absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
-    CHECK(device_dispatch_table_.contains(key));
-    CHECK(device_dispatch_table_.at(key).ResetQueryPoolEXT != nullptr);
-    return device_dispatch_table_.at(key).ResetQueryPoolEXT;
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).ResetQueryPoolEXT != nullptr);
+      return device_dispatch_table_.at(key).ResetQueryPoolEXT;
+    }
   }
 
   template <typename DispatchableType>
   PFN_vkGetQueryPoolResults GetQueryPoolResults(DispatchableType dispatchable_object) {
-    absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
-    CHECK(device_dispatch_table_.contains(key));
-    CHECK(device_dispatch_table_.at(key).GetQueryPoolResults != nullptr);
-    return device_dispatch_table_.at(key).GetQueryPoolResults;
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).GetQueryPoolResults != nullptr);
+      return device_dispatch_table_.at(key).GetQueryPoolResults;
+    }
   }
 
   template <typename DispatchableType>
   PFN_vkCmdWriteTimestamp CmdWriteTimestamp(DispatchableType dispatchable_object) {
-    absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
-    CHECK(device_dispatch_table_.contains(key));
-    CHECK(device_dispatch_table_.at(key).CmdWriteTimestamp != nullptr);
-    return device_dispatch_table_.at(key).CmdWriteTimestamp;
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).CmdWriteTimestamp != nullptr);
+      return device_dispatch_table_.at(key).CmdWriteTimestamp;
+    }
   }
 
   template <typename DispatchableType>
   PFN_vkCmdBeginDebugUtilsLabelEXT CmdBeginDebugUtilsLabelEXT(
       DispatchableType dispatchable_object) {
-    absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
-    CHECK(device_dispatch_table_.contains(key));
-    CHECK(device_dispatch_table_.at(key).CmdBeginDebugUtilsLabelEXT != nullptr);
-    return device_dispatch_table_.at(key).CmdBeginDebugUtilsLabelEXT;
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).CmdBeginDebugUtilsLabelEXT != nullptr);
+      return device_dispatch_table_.at(key).CmdBeginDebugUtilsLabelEXT;
+    }
   }
 
   template <typename DispatchableType>
   PFN_vkCmdEndDebugUtilsLabelEXT CmdEndDebugUtilsLabelEXT(DispatchableType dispatchable_object) {
-    absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
-    CHECK(device_dispatch_table_.contains(key));
-    CHECK(device_dispatch_table_.at(key).CmdEndDebugUtilsLabelEXT != nullptr);
-    return device_dispatch_table_.at(key).CmdEndDebugUtilsLabelEXT;
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).CmdEndDebugUtilsLabelEXT != nullptr);
+      return device_dispatch_table_.at(key).CmdEndDebugUtilsLabelEXT;
+    }
   }
 
   template <typename DispatchableType>
   PFN_vkCmdDebugMarkerBeginEXT CmdDebugMarkerBeginEXT(DispatchableType dispatchable_object) {
-    absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
-    CHECK(device_dispatch_table_.contains(key));
-    CHECK(device_dispatch_table_.at(key).CmdDebugMarkerBeginEXT != nullptr);
-    return device_dispatch_table_.at(key).CmdDebugMarkerBeginEXT;
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).CmdDebugMarkerBeginEXT != nullptr);
+      return device_dispatch_table_.at(key).CmdDebugMarkerBeginEXT;
+    }
   }
 
   template <typename DispatchableType>
   PFN_vkCmdDebugMarkerEndEXT CmdDebugMarkerEndEXT(DispatchableType dispatchable_object) {
-    absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
-    CHECK(device_dispatch_table_.contains(key));
-    CHECK(device_dispatch_table_.at(key).CmdDebugMarkerEndEXT != nullptr);
-    return device_dispatch_table_.at(key).CmdDebugMarkerEndEXT;
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).CmdDebugMarkerEndEXT != nullptr);
+      return device_dispatch_table_.at(key).CmdDebugMarkerEndEXT;
+    }
   }
 
   template <typename DispatchableType>
   bool IsDebugMarkerExtensionSupported(DispatchableType dispatchable_object) {
-    absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
-    CHECK(device_supports_debug_marker_extension_.contains(key));
-    return device_supports_debug_marker_extension_.at(key);
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_supports_debug_marker_extension_.contains(key));
+      return device_supports_debug_marker_extension_.at(key);
+    }
   }
 
   template <typename DispatchableType>
   bool IsDebugUtilsExtensionSupported(DispatchableType dispatchable_object) {
-    absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
-    CHECK(device_supports_debug_utils_extension_.contains(key));
-    return device_supports_debug_utils_extension_.at(key);
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_supports_debug_utils_extension_.contains(key));
+      return device_supports_debug_utils_extension_.at(key);
+    }
   }
 
  private:

--- a/OrbitVulkanLayer/DispatchTable.h
+++ b/OrbitVulkanLayer/DispatchTable.h
@@ -329,7 +329,7 @@ class DispatchTable {
 
  private:
   // Vulkan has the concept of "dispatchable types". Basically every Vulkan type whose objects can
-  // be associated with a VkInstance or VkDevice are "dispatchable". As an example both, a device
+  // be associated with a VkInstance or VkDevice are "dispatchable". As an example, both a device
   // and a command buffer corresponding to this device are "dispatchable".
   // Every "dispatchable type" has as a very first field in memory a pointer to the internal
   // dispatch table. This pointer is unique per device/instance. So for example for a command buffer
@@ -337,7 +337,9 @@ class DispatchTable {
   // we can use that pointer to uniquely map "dispatchable types" to their dispatch table.
   template <typename DispatchableType>
   void* GetDispatchTableKey(DispatchableType dispatchable_object) {
-    return *absl::bit_cast<void**>(dispatchable_object);
+    void* dispatch;
+    memcpy(&dispatch, dispatchable_object, sizeof(void*));
+    return dispatch;
   }
 
   // Dispatch tables required for routing instance and device calls onto the next

--- a/OrbitVulkanLayer/DispatchTable.h
+++ b/OrbitVulkanLayer/DispatchTable.h
@@ -22,7 +22,7 @@ namespace orbit_vulkan_layer {
  * It computes/stores the Vulkan dispatch tables for concrete devices/instances and provides
  * accessors to the functions.
  *
- * For functions provided by extensions it also provide predicate functions to check if the
+ * For functions provided by extensions it also provides predicate functions to check if the
  * extension is available.
  *
  * Thread-Safety: This class is internally synchronized (using read/write locks) and can be safely
@@ -41,18 +41,18 @@ class DispatchTable {
   void RemoveDeviceDispatchTable(VkDevice device);
 
   template <typename DispatchableType>
-  PFN_vkDestroyDevice DestroyDevice(const DispatchableType& dispatchable_object) {
-    absl::ReaderMutexLock lock(&mutex_);
+  PFN_vkDestroyDevice DestroyDevice(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
+    absl::ReaderMutexLock lock(&mutex_);
     CHECK(device_dispatch_table_.contains(key));
     CHECK(device_dispatch_table_.at(key).DestroyDevice != nullptr);
     return device_dispatch_table_.at(key).DestroyDevice;
   }
 
   template <typename DispatchableType>
-  PFN_vkDestroyInstance DestroyInstance(const DispatchableType& dispatchable_object) {
-    absl::ReaderMutexLock lock(&mutex_);
+  PFN_vkDestroyInstance DestroyInstance(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
+    absl::ReaderMutexLock lock(&mutex_);
     CHECK(instance_dispatch_table_.contains(key));
     CHECK(instance_dispatch_table_.at(key).DestroyInstance != nullptr);
     return instance_dispatch_table_.at(key).DestroyInstance;
@@ -60,9 +60,9 @@ class DispatchTable {
 
   template <typename DispatchableType>
   PFN_vkEnumerateDeviceExtensionProperties EnumerateDeviceExtensionProperties(
-      const DispatchableType& dispatchable_object) {
-    absl::ReaderMutexLock lock(&mutex_);
+      DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
+    absl::ReaderMutexLock lock(&mutex_);
     CHECK(instance_dispatch_table_.contains(key));
     CHECK(instance_dispatch_table_.at(key).EnumerateDeviceExtensionProperties != nullptr);
     return instance_dispatch_table_.at(key).EnumerateDeviceExtensionProperties;
@@ -70,52 +70,52 @@ class DispatchTable {
 
   template <typename DispatchableType>
   PFN_vkGetPhysicalDeviceProperties GetPhysicalDeviceProperties(
-      const DispatchableType& dispatchable_object) {
-    absl::ReaderMutexLock lock(&mutex_);
+      DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
+    absl::ReaderMutexLock lock(&mutex_);
     CHECK(instance_dispatch_table_.contains(key));
     CHECK(instance_dispatch_table_.at(key).GetPhysicalDeviceProperties != nullptr);
     return instance_dispatch_table_.at(key).GetPhysicalDeviceProperties;
   }
 
   template <typename DispatchableType>
-  PFN_vkGetInstanceProcAddr GetInstanceProcAddr(const DispatchableType& dispatchable_object) {
-    absl::ReaderMutexLock lock(&mutex_);
+  PFN_vkGetInstanceProcAddr GetInstanceProcAddr(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
+    absl::ReaderMutexLock lock(&mutex_);
     CHECK(instance_dispatch_table_.contains(key));
     CHECK(instance_dispatch_table_.at(key).GetInstanceProcAddr != nullptr);
     return instance_dispatch_table_.at(key).GetInstanceProcAddr;
   }
 
   template <typename DispatchableType>
-  PFN_vkGetDeviceProcAddr GetDeviceProcAddr(const DispatchableType& dispatchable_object) {
-    absl::ReaderMutexLock lock(&mutex_);
+  PFN_vkGetDeviceProcAddr GetDeviceProcAddr(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
+    absl::ReaderMutexLock lock(&mutex_);
     CHECK(device_dispatch_table_.contains(key));
     CHECK(device_dispatch_table_.at(key).GetDeviceProcAddr != nullptr);
     return device_dispatch_table_.at(key).GetDeviceProcAddr;
   }
 
   template <typename DispatchableType>
-  PFN_vkResetCommandPool ResetCommandPool(const DispatchableType& dispatchable_object) {
-    absl::ReaderMutexLock lock(&mutex_);
+  PFN_vkResetCommandPool ResetCommandPool(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
+    absl::ReaderMutexLock lock(&mutex_);
     CHECK(device_dispatch_table_.contains(key));
     CHECK(device_dispatch_table_.at(key).ResetCommandPool != nullptr);
     return device_dispatch_table_.at(key).ResetCommandPool;
   }
 
   template <typename DispatchableType>
-  PFN_vkAllocateCommandBuffers AllocateCommandBuffers(const DispatchableType& dispatchable_object) {
-    absl::ReaderMutexLock lock(&mutex_);
+  PFN_vkAllocateCommandBuffers AllocateCommandBuffers(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
+    absl::ReaderMutexLock lock(&mutex_);
     CHECK(device_dispatch_table_.contains(key));
     CHECK(device_dispatch_table_.at(key).AllocateCommandBuffers != nullptr);
     return device_dispatch_table_.at(key).AllocateCommandBuffers;
   }
 
   template <typename DispatchableType>
-  PFN_vkFreeCommandBuffers FreeCommandBuffers(const DispatchableType& dispatchable_object) {
+  PFN_vkFreeCommandBuffers FreeCommandBuffers(DispatchableType dispatchable_object) {
     absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
     CHECK(device_dispatch_table_.contains(key));
@@ -124,7 +124,7 @@ class DispatchTable {
   }
 
   template <typename DispatchableType>
-  PFN_vkBeginCommandBuffer BeginCommandBuffer(const DispatchableType& dispatchable_object) {
+  PFN_vkBeginCommandBuffer BeginCommandBuffer(DispatchableType dispatchable_object) {
     absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
     CHECK(device_dispatch_table_.contains(key));
@@ -133,7 +133,7 @@ class DispatchTable {
   }
 
   template <typename DispatchableType>
-  PFN_vkEndCommandBuffer EndCommandBuffer(const DispatchableType& dispatchable_object) {
+  PFN_vkEndCommandBuffer EndCommandBuffer(DispatchableType dispatchable_object) {
     absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
     CHECK(device_dispatch_table_.contains(key));
@@ -142,7 +142,7 @@ class DispatchTable {
   }
 
   template <typename DispatchableType>
-  PFN_vkResetCommandBuffer ResetCommandBuffer(const DispatchableType& dispatchable_object) {
+  PFN_vkResetCommandBuffer ResetCommandBuffer(DispatchableType dispatchable_object) {
     absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
     CHECK(device_dispatch_table_.contains(key));
@@ -151,7 +151,7 @@ class DispatchTable {
   }
 
   template <typename DispatchableType>
-  PFN_vkGetDeviceQueue GetDeviceQueue(const DispatchableType& dispatchable_object) {
+  PFN_vkGetDeviceQueue GetDeviceQueue(DispatchableType dispatchable_object) {
     absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
     CHECK(device_dispatch_table_.contains(key));
@@ -160,7 +160,7 @@ class DispatchTable {
   }
 
   template <typename DispatchableType>
-  PFN_vkGetDeviceQueue2 GetDeviceQueue2(const DispatchableType& dispatchable_object) {
+  PFN_vkGetDeviceQueue2 GetDeviceQueue2(DispatchableType dispatchable_object) {
     absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
     CHECK(device_dispatch_table_.contains(key));
@@ -169,7 +169,7 @@ class DispatchTable {
   }
 
   template <typename DispatchableType>
-  PFN_vkQueueSubmit QueueSubmit(const DispatchableType& dispatchable_object) {
+  PFN_vkQueueSubmit QueueSubmit(DispatchableType dispatchable_object) {
     absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
     CHECK(device_dispatch_table_.contains(key));
@@ -178,7 +178,7 @@ class DispatchTable {
   }
 
   template <typename DispatchableType>
-  PFN_vkQueuePresentKHR QueuePresentKHR(const DispatchableType& dispatchable_object) {
+  PFN_vkQueuePresentKHR QueuePresentKHR(DispatchableType dispatchable_object) {
     absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
     CHECK(device_dispatch_table_.contains(key));
@@ -187,7 +187,7 @@ class DispatchTable {
   }
 
   template <typename DispatchableType>
-  PFN_vkCreateQueryPool CreateQueryPool(const DispatchableType& dispatchable_object) {
+  PFN_vkCreateQueryPool CreateQueryPool(DispatchableType dispatchable_object) {
     absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
     CHECK(device_dispatch_table_.contains(key));
@@ -196,7 +196,7 @@ class DispatchTable {
   }
 
   template <typename DispatchableType>
-  PFN_vkResetQueryPoolEXT ResetQueryPoolEXT(const DispatchableType& dispatchable_object) {
+  PFN_vkResetQueryPoolEXT ResetQueryPoolEXT(DispatchableType dispatchable_object) {
     absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
     CHECK(device_dispatch_table_.contains(key));
@@ -205,7 +205,7 @@ class DispatchTable {
   }
 
   template <typename DispatchableType>
-  PFN_vkGetQueryPoolResults GetQueryPoolResults(const DispatchableType& dispatchable_object) {
+  PFN_vkGetQueryPoolResults GetQueryPoolResults(DispatchableType dispatchable_object) {
     absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
     CHECK(device_dispatch_table_.contains(key));
@@ -214,7 +214,7 @@ class DispatchTable {
   }
 
   template <typename DispatchableType>
-  PFN_vkCmdWriteTimestamp CmdWriteTimestamp(const DispatchableType& dispatchable_object) {
+  PFN_vkCmdWriteTimestamp CmdWriteTimestamp(DispatchableType dispatchable_object) {
     absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
     CHECK(device_dispatch_table_.contains(key));
@@ -224,7 +224,7 @@ class DispatchTable {
 
   template <typename DispatchableType>
   PFN_vkCmdBeginDebugUtilsLabelEXT CmdBeginDebugUtilsLabelEXT(
-      const DispatchableType& dispatchable_object) {
+      DispatchableType dispatchable_object) {
     absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
     CHECK(device_dispatch_table_.contains(key));
@@ -233,8 +233,7 @@ class DispatchTable {
   }
 
   template <typename DispatchableType>
-  PFN_vkCmdEndDebugUtilsLabelEXT CmdEndDebugUtilsLabelEXT(
-      const DispatchableType& dispatchable_object) {
+  PFN_vkCmdEndDebugUtilsLabelEXT CmdEndDebugUtilsLabelEXT(DispatchableType dispatchable_object) {
     absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
     CHECK(device_dispatch_table_.contains(key));
@@ -243,7 +242,7 @@ class DispatchTable {
   }
 
   template <typename DispatchableType>
-  PFN_vkCmdDebugMarkerBeginEXT CmdDebugMarkerBeginEXT(const DispatchableType& dispatchable_object) {
+  PFN_vkCmdDebugMarkerBeginEXT CmdDebugMarkerBeginEXT(DispatchableType dispatchable_object) {
     absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
     CHECK(device_dispatch_table_.contains(key));
@@ -252,7 +251,7 @@ class DispatchTable {
   }
 
   template <typename DispatchableType>
-  PFN_vkCmdDebugMarkerEndEXT CmdDebugMarkerEndEXT(const DispatchableType& dispatchable_object) {
+  PFN_vkCmdDebugMarkerEndEXT CmdDebugMarkerEndEXT(DispatchableType dispatchable_object) {
     absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
     CHECK(device_dispatch_table_.contains(key));
@@ -261,7 +260,7 @@ class DispatchTable {
   }
 
   template <typename DispatchableType>
-  bool IsDebugMarkerExtensionSupported(const DispatchableType& dispatchable_object) {
+  bool IsDebugMarkerExtensionSupported(DispatchableType dispatchable_object) {
     absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
     CHECK(device_supports_debug_marker_extension_.contains(key));
@@ -269,7 +268,7 @@ class DispatchTable {
   }
 
   template <typename DispatchableType>
-  bool IsDebugUtilsExtensionSupported(const DispatchableType& dispatchable_object) {
+  bool IsDebugUtilsExtensionSupported(DispatchableType dispatchable_object) {
     absl::ReaderMutexLock lock(&mutex_);
     void* key = GetDispatchTableKey(dispatchable_object);
     CHECK(device_supports_debug_utils_extension_.contains(key));
@@ -277,11 +276,13 @@ class DispatchTable {
   }
 
  private:
-  // In vulkan, every "dispatchable type" has as a very first field in memory a pointer to the
-  // internal dispatch table. This pointer is unique per device/instance. So for example
-  // for a command buffer allocated on a certain device, this pointer is the same for the buffer
-  // and for the device. So we can use that pointer to uniquely map dispatchable types to their
-  // dispatch table.
+  // Vulkan has the concept of "dispatchable types". Basically every Vulkan type whose objects can
+  // be associated with a VkInstance or VkDevice are "dispatchable". As an example both, a device
+  // and a command buffer corresponding to this device are "dispatchable".
+  // Every "dispatchable type" has as a very first field in memory a pointer to the internal
+  // dispatch table. This pointer is unique per device/instance. So for example for a command buffer
+  // allocated on a certain device, this pointer is the same for the buffer and for the device. So
+  // we can use that pointer to uniquely map "dispatchable types" to their dispatch table.
   template <typename DispatchableType>
   void* GetDispatchTableKey(DispatchableType dispatchable_object) {
     return *absl::bit_cast<void**>(dispatchable_object);
@@ -297,7 +298,7 @@ class DispatchTable {
   // Must protect access to dispatch tables above by mutex since the Vulkan
   // application may be calling these functions from different threads.
   // However, they are usually filled once (per device/instance) at the beginning
-  // and afterwards we only read that data. So we use a read/write lock.
+  // and afterwards we only read that data. So we use read/write locks.
   absl::Mutex mutex_;
 };
 

--- a/OrbitVulkanLayer/DispatchTable.h
+++ b/OrbitVulkanLayer/DispatchTable.h
@@ -33,119 +33,12 @@ class DispatchTable {
   DispatchTable() = default;
 
   void CreateInstanceDispatchTable(
-      VkInstance instance, const PFN_vkGetInstanceProcAddr& next_get_instance_proc_addr_function) {
-    VkLayerInstanceDispatchTable dispatch_table;
-    dispatch_table.DestroyInstance = absl::bit_cast<PFN_vkDestroyInstance>(
-        next_get_instance_proc_addr_function(instance, "vkDestroyInstance"));
-    dispatch_table.GetInstanceProcAddr = absl::bit_cast<PFN_vkGetInstanceProcAddr>(
-        next_get_instance_proc_addr_function(instance, "vkGetInstanceProcAddr"));
-    dispatch_table.EnumerateDeviceExtensionProperties =
-        absl::bit_cast<PFN_vkEnumerateDeviceExtensionProperties>(
-            next_get_instance_proc_addr_function(instance, "vkEnumerateDeviceExtensionProperties"));
-    dispatch_table.GetPhysicalDeviceProperties = absl::bit_cast<PFN_vkGetPhysicalDeviceProperties>(
-        next_get_instance_proc_addr_function(instance, "vkGetPhysicalDeviceProperties"));
+      VkInstance instance, const PFN_vkGetInstanceProcAddr& next_get_instance_proc_addr_function);
+  void RemoveInstanceDispatchTable(VkInstance instance);
 
-    void* key = GetDispatchTableKey(instance);
-    {
-      absl::WriterMutexLock lock(&mutex_);
-      CHECK(!instance_dispatch_table_.contains(key));
-      instance_dispatch_table_[key] = dispatch_table;
-    }
-  }
-
-  void RemoveInstanceDispatchTable(VkInstance instance) {
-    void* key = GetDispatchTableKey(instance);
-    absl::WriterMutexLock lock(&mutex_);
-    CHECK(instance_dispatch_table_.contains(key));
-    instance_dispatch_table_.erase(key);
-  }
-
-  void CreateDeviceDispatchTable(
-      VkDevice device, const PFN_vkGetDeviceProcAddr& next_get_device_proc_addr_function) {
-    VkLayerDispatchTable dispatch_table;
-
-    dispatch_table.DestroyDevice = absl::bit_cast<PFN_vkDestroyDevice>(
-        next_get_device_proc_addr_function(device, "vkDestroyDevice"));
-    dispatch_table.GetDeviceProcAddr = absl::bit_cast<PFN_vkGetDeviceProcAddr>(
-        next_get_device_proc_addr_function(device, "vkGetDeviceProcAddr"));
-
-    dispatch_table.ResetCommandPool = absl::bit_cast<PFN_vkResetCommandPool>(
-        next_get_device_proc_addr_function(device, "vkResetCommandPool"));
-
-    dispatch_table.AllocateCommandBuffers = absl::bit_cast<PFN_vkAllocateCommandBuffers>(
-        next_get_device_proc_addr_function(device, "vkAllocateCommandBuffers"));
-    dispatch_table.FreeCommandBuffers = absl::bit_cast<PFN_vkFreeCommandBuffers>(
-        next_get_device_proc_addr_function(device, "vkFreeCommandBuffers"));
-    dispatch_table.BeginCommandBuffer = absl::bit_cast<PFN_vkBeginCommandBuffer>(
-        next_get_device_proc_addr_function(device, "vkBeginCommandBuffer"));
-    dispatch_table.EndCommandBuffer = absl::bit_cast<PFN_vkEndCommandBuffer>(
-        next_get_device_proc_addr_function(device, "vkEndCommandBuffer"));
-    dispatch_table.ResetCommandBuffer = absl::bit_cast<PFN_vkResetCommandBuffer>(
-        next_get_device_proc_addr_function(device, "vkResetCommandBuffer"));
-
-    dispatch_table.QueueSubmit = absl::bit_cast<PFN_vkQueueSubmit>(
-        next_get_device_proc_addr_function(device, "vkQueueSubmit"));
-    dispatch_table.QueuePresentKHR = absl::bit_cast<PFN_vkQueuePresentKHR>(
-        next_get_device_proc_addr_function(device, "vkQueuePresentKHR"));
-
-    dispatch_table.GetDeviceQueue = absl::bit_cast<PFN_vkGetDeviceQueue>(
-        next_get_device_proc_addr_function(device, "vkGetDeviceQueue"));
-    dispatch_table.GetDeviceQueue2 = absl::bit_cast<PFN_vkGetDeviceQueue2>(
-        next_get_device_proc_addr_function(device, "vkGetDeviceQueue2"));
-
-    dispatch_table.CreateQueryPool = absl::bit_cast<PFN_vkCreateQueryPool>(
-        next_get_device_proc_addr_function(device, "vkCreateQueryPool"));
-    dispatch_table.ResetQueryPoolEXT = absl::bit_cast<PFN_vkResetQueryPoolEXT>(
-        next_get_device_proc_addr_function(device, "vkResetQueryPoolEXT"));
-
-    dispatch_table.CmdWriteTimestamp = absl::bit_cast<PFN_vkCmdWriteTimestamp>(
-        next_get_device_proc_addr_function(device, "vkCmdWriteTimestamp"));
-
-    dispatch_table.GetQueryPoolResults = absl::bit_cast<PFN_vkGetQueryPoolResults>(
-        next_get_device_proc_addr_function(device, "vkGetQueryPoolResults"));
-
-    dispatch_table.CmdBeginDebugUtilsLabelEXT = absl::bit_cast<PFN_vkCmdBeginDebugUtilsLabelEXT>(
-        next_get_device_proc_addr_function(device, "vkCmdBeginDebugUtilsLabelEXT"));
-    dispatch_table.CmdEndDebugUtilsLabelEXT = absl::bit_cast<PFN_vkCmdEndDebugUtilsLabelEXT>(
-        next_get_device_proc_addr_function(device, "vkCmdEndDebugUtilsLabelEXT"));
-
-    dispatch_table.CmdDebugMarkerBeginEXT = absl::bit_cast<PFN_vkCmdDebugMarkerBeginEXT>(
-        next_get_device_proc_addr_function(device, "vkCmdDebugMarkerBeginEXT"));
-    dispatch_table.CmdDebugMarkerEndEXT = absl::bit_cast<PFN_vkCmdDebugMarkerEndEXT>(
-        next_get_device_proc_addr_function(device, "vkCmdDebugMarkerEndEXT"));
-
-    void* key = GetDispatchTableKey(device);
-
-    {
-      absl::WriterMutexLock lock(&mutex_);
-      CHECK(!device_dispatch_table_.contains(key));
-      device_dispatch_table_[key] = dispatch_table;
-
-      CHECK(!device_supports_debug_utils_extension_.contains(key));
-      device_supports_debug_utils_extension_[key] =
-          dispatch_table.CmdBeginDebugUtilsLabelEXT != nullptr &&
-          dispatch_table.CmdEndDebugUtilsLabelEXT != nullptr;
-
-      CHECK(!device_supports_debug_marker_extension_.contains(key));
-      device_supports_debug_marker_extension_[key] =
-          dispatch_table.CmdDebugMarkerBeginEXT != nullptr &&
-          dispatch_table.CmdDebugMarkerEndEXT != nullptr;
-    }
-  }
-
-  void RemoveDeviceDispatchTable(VkDevice device) {
-    void* key = GetDispatchTableKey(device);
-    absl::WriterMutexLock lock(&mutex_);
-
-    CHECK(device_dispatch_table_.contains(key));
-    device_dispatch_table_.erase(key);
-
-    CHECK(device_supports_debug_utils_extension_.contains(key));
-    device_supports_debug_utils_extension_.erase(key);
-
-    CHECK(device_supports_debug_marker_extension_.contains(key));
-    device_supports_debug_marker_extension_.erase(key);
-  }
+  void CreateDeviceDispatchTable(VkDevice device,
+                                 const PFN_vkGetDeviceProcAddr& next_get_device_proc_addr_function);
+  void RemoveDeviceDispatchTable(VkDevice device);
 
   template <typename DispatchableType>
   PFN_vkDestroyDevice DestroyDevice(const DispatchableType& dispatchable_object) {

--- a/OrbitVulkanLayer/DispatchTable.h
+++ b/OrbitVulkanLayer/DispatchTable.h
@@ -32,12 +32,12 @@ class DispatchTable {
  public:
   DispatchTable() = default;
 
-  void CreateInstanceDispatchTable(
-      VkInstance instance, const PFN_vkGetInstanceProcAddr& next_get_instance_proc_addr_function);
+  void CreateInstanceDispatchTable(VkInstance instance,
+                                   PFN_vkGetInstanceProcAddr next_get_instance_proc_addr_function);
   void RemoveInstanceDispatchTable(VkInstance instance);
 
   void CreateDeviceDispatchTable(VkDevice device,
-                                 const PFN_vkGetDeviceProcAddr& next_get_device_proc_addr_function);
+                                 PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function);
   void RemoveDeviceDispatchTable(VkDevice device);
 
   template <typename DispatchableType>

--- a/OrbitVulkanLayer/DispatchTable.h
+++ b/OrbitVulkanLayer/DispatchTable.h
@@ -1,0 +1,413 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_VULKAN_LAYER_DISPATCH_TABLE_H_
+#define ORBIT_VULKAN_LAYER_DISPATCH_TABLE_H_
+
+#include "OrbitBase/Logging.h"
+#include "absl/base/casts.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/synchronization/mutex.h"
+#include "vulkan/vk_layer.h"
+#include "vulkan/vk_layer_dispatch_table.h"
+#include "vulkan/vulkan.h"
+
+namespace orbit_vulkan_layer {
+
+/*
+ * A thread-safe dispatch table for Vulkan function look-up.
+ *
+ * It computes/stores the Vulkan dispatch tables for concrete devices/instances and provides
+ * accessors to the functions.
+ *
+ * For functions provided by extensions it also provide predicate functions to check if the
+ * extension is available.
+ *
+ * Thread-Safety: This class is internally synchronized (using read/write locks) and can be safely
+ * accessed from different threads.
+ */
+class DispatchTable {
+ public:
+  DispatchTable() = default;
+
+  void CreateInstanceDispatchTable(
+      VkInstance instance, const PFN_vkGetInstanceProcAddr& next_get_instance_proc_addr_function) {
+    VkLayerInstanceDispatchTable dispatch_table;
+    dispatch_table.DestroyInstance = absl::bit_cast<PFN_vkDestroyInstance>(
+        next_get_instance_proc_addr_function(instance, "vkDestroyInstance"));
+    dispatch_table.GetInstanceProcAddr = absl::bit_cast<PFN_vkGetInstanceProcAddr>(
+        next_get_instance_proc_addr_function(instance, "vkGetInstanceProcAddr"));
+    dispatch_table.EnumerateDeviceExtensionProperties =
+        absl::bit_cast<PFN_vkEnumerateDeviceExtensionProperties>(
+            next_get_instance_proc_addr_function(instance, "vkEnumerateDeviceExtensionProperties"));
+    dispatch_table.GetPhysicalDeviceProperties = absl::bit_cast<PFN_vkGetPhysicalDeviceProperties>(
+        next_get_instance_proc_addr_function(instance, "vkGetPhysicalDeviceProperties"));
+
+    void* key = GetDispatchTableKey(instance);
+    {
+      absl::WriterMutexLock lock(&mutex_);
+      CHECK(!instance_dispatch_table_.contains(key));
+      instance_dispatch_table_[key] = dispatch_table;
+    }
+  }
+
+  void RemoveInstanceDispatchTable(VkInstance instance) {
+    void* key = GetDispatchTableKey(instance);
+    absl::WriterMutexLock lock(&mutex_);
+    CHECK(instance_dispatch_table_.contains(key));
+    instance_dispatch_table_.erase(key);
+  }
+
+  void CreateDeviceDispatchTable(
+      VkDevice device, const PFN_vkGetDeviceProcAddr& next_get_device_proc_addr_function) {
+    VkLayerDispatchTable dispatch_table;
+
+    dispatch_table.DestroyDevice = absl::bit_cast<PFN_vkDestroyDevice>(
+        next_get_device_proc_addr_function(device, "vkDestroyDevice"));
+    dispatch_table.GetDeviceProcAddr = absl::bit_cast<PFN_vkGetDeviceProcAddr>(
+        next_get_device_proc_addr_function(device, "vkGetDeviceProcAddr"));
+
+    dispatch_table.ResetCommandPool = absl::bit_cast<PFN_vkResetCommandPool>(
+        next_get_device_proc_addr_function(device, "vkResetCommandPool"));
+
+    dispatch_table.AllocateCommandBuffers = absl::bit_cast<PFN_vkAllocateCommandBuffers>(
+        next_get_device_proc_addr_function(device, "vkAllocateCommandBuffers"));
+    dispatch_table.FreeCommandBuffers = absl::bit_cast<PFN_vkFreeCommandBuffers>(
+        next_get_device_proc_addr_function(device, "vkFreeCommandBuffers"));
+    dispatch_table.BeginCommandBuffer = absl::bit_cast<PFN_vkBeginCommandBuffer>(
+        next_get_device_proc_addr_function(device, "vkBeginCommandBuffer"));
+    dispatch_table.EndCommandBuffer = absl::bit_cast<PFN_vkEndCommandBuffer>(
+        next_get_device_proc_addr_function(device, "vkEndCommandBuffer"));
+    dispatch_table.ResetCommandBuffer = absl::bit_cast<PFN_vkResetCommandBuffer>(
+        next_get_device_proc_addr_function(device, "vkResetCommandBuffer"));
+
+    dispatch_table.QueueSubmit = absl::bit_cast<PFN_vkQueueSubmit>(
+        next_get_device_proc_addr_function(device, "vkQueueSubmit"));
+    dispatch_table.QueuePresentKHR = absl::bit_cast<PFN_vkQueuePresentKHR>(
+        next_get_device_proc_addr_function(device, "vkQueuePresentKHR"));
+
+    dispatch_table.GetDeviceQueue = absl::bit_cast<PFN_vkGetDeviceQueue>(
+        next_get_device_proc_addr_function(device, "vkGetDeviceQueue"));
+    dispatch_table.GetDeviceQueue2 = absl::bit_cast<PFN_vkGetDeviceQueue2>(
+        next_get_device_proc_addr_function(device, "vkGetDeviceQueue2"));
+
+    dispatch_table.CreateQueryPool = absl::bit_cast<PFN_vkCreateQueryPool>(
+        next_get_device_proc_addr_function(device, "vkCreateQueryPool"));
+    dispatch_table.ResetQueryPoolEXT = absl::bit_cast<PFN_vkResetQueryPoolEXT>(
+        next_get_device_proc_addr_function(device, "vkResetQueryPoolEXT"));
+
+    dispatch_table.CmdWriteTimestamp = absl::bit_cast<PFN_vkCmdWriteTimestamp>(
+        next_get_device_proc_addr_function(device, "vkCmdWriteTimestamp"));
+
+    dispatch_table.GetQueryPoolResults = absl::bit_cast<PFN_vkGetQueryPoolResults>(
+        next_get_device_proc_addr_function(device, "vkGetQueryPoolResults"));
+
+    dispatch_table.CmdBeginDebugUtilsLabelEXT = absl::bit_cast<PFN_vkCmdBeginDebugUtilsLabelEXT>(
+        next_get_device_proc_addr_function(device, "vkCmdBeginDebugUtilsLabelEXT"));
+    dispatch_table.CmdEndDebugUtilsLabelEXT = absl::bit_cast<PFN_vkCmdEndDebugUtilsLabelEXT>(
+        next_get_device_proc_addr_function(device, "vkCmdEndDebugUtilsLabelEXT"));
+
+    dispatch_table.CmdDebugMarkerBeginEXT = absl::bit_cast<PFN_vkCmdDebugMarkerBeginEXT>(
+        next_get_device_proc_addr_function(device, "vkCmdDebugMarkerBeginEXT"));
+    dispatch_table.CmdDebugMarkerEndEXT = absl::bit_cast<PFN_vkCmdDebugMarkerEndEXT>(
+        next_get_device_proc_addr_function(device, "vkCmdDebugMarkerEndEXT"));
+
+    void* key = GetDispatchTableKey(device);
+
+    {
+      absl::WriterMutexLock lock(&mutex_);
+      CHECK(!device_dispatch_table_.contains(key));
+      device_dispatch_table_[key] = dispatch_table;
+
+      CHECK(!device_supports_debug_utils_extension_.contains(key));
+      device_supports_debug_utils_extension_[key] =
+          dispatch_table.CmdBeginDebugUtilsLabelEXT != nullptr &&
+          dispatch_table.CmdEndDebugUtilsLabelEXT != nullptr;
+
+      CHECK(!device_supports_debug_marker_extension_.contains(key));
+      device_supports_debug_marker_extension_[key] =
+          dispatch_table.CmdDebugMarkerBeginEXT != nullptr &&
+          dispatch_table.CmdDebugMarkerEndEXT != nullptr;
+    }
+  }
+
+  void RemoveDeviceDispatchTable(VkDevice device) {
+    void* key = GetDispatchTableKey(device);
+    absl::WriterMutexLock lock(&mutex_);
+
+    CHECK(device_dispatch_table_.contains(key));
+    device_dispatch_table_.erase(key);
+
+    CHECK(device_supports_debug_utils_extension_.contains(key));
+    device_supports_debug_utils_extension_.erase(key);
+
+    CHECK(device_supports_debug_marker_extension_.contains(key));
+    device_supports_debug_marker_extension_.erase(key);
+  }
+
+  template <typename DispatchableType>
+  PFN_vkDestroyDevice DestroyDevice(const DispatchableType& dispatchable_object) {
+    absl::ReaderMutexLock lock(&mutex_);
+    void* key = GetDispatchTableKey(dispatchable_object);
+    CHECK(device_dispatch_table_.contains(key));
+    CHECK(device_dispatch_table_.at(key).DestroyDevice != nullptr);
+    return device_dispatch_table_.at(key).DestroyDevice;
+  }
+
+  template <typename DispatchableType>
+  PFN_vkDestroyInstance DestroyInstance(const DispatchableType& dispatchable_object) {
+    absl::ReaderMutexLock lock(&mutex_);
+    void* key = GetDispatchTableKey(dispatchable_object);
+    CHECK(instance_dispatch_table_.contains(key));
+    CHECK(instance_dispatch_table_.at(key).DestroyInstance != nullptr);
+    return instance_dispatch_table_.at(key).DestroyInstance;
+  }
+
+  template <typename DispatchableType>
+  PFN_vkEnumerateDeviceExtensionProperties EnumerateDeviceExtensionProperties(
+      const DispatchableType& dispatchable_object) {
+    absl::ReaderMutexLock lock(&mutex_);
+    void* key = GetDispatchTableKey(dispatchable_object);
+    CHECK(instance_dispatch_table_.contains(key));
+    CHECK(instance_dispatch_table_.at(key).EnumerateDeviceExtensionProperties != nullptr);
+    return instance_dispatch_table_.at(key).EnumerateDeviceExtensionProperties;
+  }
+
+  template <typename DispatchableType>
+  PFN_vkGetPhysicalDeviceProperties GetPhysicalDeviceProperties(
+      const DispatchableType& dispatchable_object) {
+    absl::ReaderMutexLock lock(&mutex_);
+    void* key = GetDispatchTableKey(dispatchable_object);
+    CHECK(instance_dispatch_table_.contains(key));
+    CHECK(instance_dispatch_table_.at(key).GetPhysicalDeviceProperties != nullptr);
+    return instance_dispatch_table_.at(key).GetPhysicalDeviceProperties;
+  }
+
+  template <typename DispatchableType>
+  PFN_vkGetInstanceProcAddr GetInstanceProcAddr(const DispatchableType& dispatchable_object) {
+    absl::ReaderMutexLock lock(&mutex_);
+    void* key = GetDispatchTableKey(dispatchable_object);
+    CHECK(instance_dispatch_table_.contains(key));
+    CHECK(instance_dispatch_table_.at(key).GetInstanceProcAddr != nullptr);
+    return instance_dispatch_table_.at(key).GetInstanceProcAddr;
+  }
+
+  template <typename DispatchableType>
+  PFN_vkGetDeviceProcAddr GetDeviceProcAddr(const DispatchableType& dispatchable_object) {
+    absl::ReaderMutexLock lock(&mutex_);
+    void* key = GetDispatchTableKey(dispatchable_object);
+    CHECK(device_dispatch_table_.contains(key));
+    CHECK(device_dispatch_table_.at(key).GetDeviceProcAddr != nullptr);
+    return device_dispatch_table_.at(key).GetDeviceProcAddr;
+  }
+
+  template <typename DispatchableType>
+  PFN_vkResetCommandPool ResetCommandPool(const DispatchableType& dispatchable_object) {
+    absl::ReaderMutexLock lock(&mutex_);
+    void* key = GetDispatchTableKey(dispatchable_object);
+    CHECK(device_dispatch_table_.contains(key));
+    CHECK(device_dispatch_table_.at(key).ResetCommandPool != nullptr);
+    return device_dispatch_table_.at(key).ResetCommandPool;
+  }
+
+  template <typename DispatchableType>
+  PFN_vkAllocateCommandBuffers AllocateCommandBuffers(const DispatchableType& dispatchable_object) {
+    absl::ReaderMutexLock lock(&mutex_);
+    void* key = GetDispatchTableKey(dispatchable_object);
+    CHECK(device_dispatch_table_.contains(key));
+    CHECK(device_dispatch_table_.at(key).AllocateCommandBuffers != nullptr);
+    return device_dispatch_table_.at(key).AllocateCommandBuffers;
+  }
+
+  template <typename DispatchableType>
+  PFN_vkFreeCommandBuffers FreeCommandBuffers(const DispatchableType& dispatchable_object) {
+    absl::ReaderMutexLock lock(&mutex_);
+    void* key = GetDispatchTableKey(dispatchable_object);
+    CHECK(device_dispatch_table_.contains(key));
+    CHECK(device_dispatch_table_.at(key).FreeCommandBuffers != nullptr);
+    return device_dispatch_table_.at(key).FreeCommandBuffers;
+  }
+
+  template <typename DispatchableType>
+  PFN_vkBeginCommandBuffer BeginCommandBuffer(const DispatchableType& dispatchable_object) {
+    absl::ReaderMutexLock lock(&mutex_);
+    void* key = GetDispatchTableKey(dispatchable_object);
+    CHECK(device_dispatch_table_.contains(key));
+    CHECK(device_dispatch_table_.at(key).BeginCommandBuffer != nullptr);
+    return device_dispatch_table_.at(key).BeginCommandBuffer;
+  }
+
+  template <typename DispatchableType>
+  PFN_vkEndCommandBuffer EndCommandBuffer(const DispatchableType& dispatchable_object) {
+    absl::ReaderMutexLock lock(&mutex_);
+    void* key = GetDispatchTableKey(dispatchable_object);
+    CHECK(device_dispatch_table_.contains(key));
+    CHECK(device_dispatch_table_.at(key).EndCommandBuffer != nullptr);
+    return device_dispatch_table_.at(key).EndCommandBuffer;
+  }
+
+  template <typename DispatchableType>
+  PFN_vkResetCommandBuffer ResetCommandBuffer(const DispatchableType& dispatchable_object) {
+    absl::ReaderMutexLock lock(&mutex_);
+    void* key = GetDispatchTableKey(dispatchable_object);
+    CHECK(device_dispatch_table_.contains(key));
+    CHECK(device_dispatch_table_.at(key).ResetCommandBuffer != nullptr);
+    return device_dispatch_table_.at(key).ResetCommandBuffer;
+  }
+
+  template <typename DispatchableType>
+  PFN_vkGetDeviceQueue GetDeviceQueue(const DispatchableType& dispatchable_object) {
+    absl::ReaderMutexLock lock(&mutex_);
+    void* key = GetDispatchTableKey(dispatchable_object);
+    CHECK(device_dispatch_table_.contains(key));
+    CHECK(device_dispatch_table_.at(key).GetDeviceQueue != nullptr);
+    return device_dispatch_table_.at(key).GetDeviceQueue;
+  }
+
+  template <typename DispatchableType>
+  PFN_vkGetDeviceQueue2 GetDeviceQueue2(const DispatchableType& dispatchable_object) {
+    absl::ReaderMutexLock lock(&mutex_);
+    void* key = GetDispatchTableKey(dispatchable_object);
+    CHECK(device_dispatch_table_.contains(key));
+    CHECK(device_dispatch_table_.at(key).GetDeviceQueue2 != nullptr);
+    return device_dispatch_table_.at(key).GetDeviceQueue2;
+  }
+
+  template <typename DispatchableType>
+  PFN_vkQueueSubmit QueueSubmit(const DispatchableType& dispatchable_object) {
+    absl::ReaderMutexLock lock(&mutex_);
+    void* key = GetDispatchTableKey(dispatchable_object);
+    CHECK(device_dispatch_table_.contains(key));
+    CHECK(device_dispatch_table_.at(key).QueueSubmit != nullptr);
+    return device_dispatch_table_.at(key).QueueSubmit;
+  }
+
+  template <typename DispatchableType>
+  PFN_vkQueuePresentKHR QueuePresentKHR(const DispatchableType& dispatchable_object) {
+    absl::ReaderMutexLock lock(&mutex_);
+    void* key = GetDispatchTableKey(dispatchable_object);
+    CHECK(device_dispatch_table_.contains(key));
+    CHECK(device_dispatch_table_.at(key).QueuePresentKHR != nullptr);
+    return device_dispatch_table_.at(key).QueuePresentKHR;
+  }
+
+  template <typename DispatchableType>
+  PFN_vkCreateQueryPool CreateQueryPool(const DispatchableType& dispatchable_object) {
+    absl::ReaderMutexLock lock(&mutex_);
+    void* key = GetDispatchTableKey(dispatchable_object);
+    CHECK(device_dispatch_table_.contains(key));
+    CHECK(device_dispatch_table_.at(key).CreateQueryPool != nullptr);
+    return device_dispatch_table_.at(key).CreateQueryPool;
+  }
+
+  template <typename DispatchableType>
+  PFN_vkResetQueryPoolEXT ResetQueryPoolEXT(const DispatchableType& dispatchable_object) {
+    absl::ReaderMutexLock lock(&mutex_);
+    void* key = GetDispatchTableKey(dispatchable_object);
+    CHECK(device_dispatch_table_.contains(key));
+    CHECK(device_dispatch_table_.at(key).ResetQueryPoolEXT != nullptr);
+    return device_dispatch_table_.at(key).ResetQueryPoolEXT;
+  }
+
+  template <typename DispatchableType>
+  PFN_vkGetQueryPoolResults GetQueryPoolResults(const DispatchableType& dispatchable_object) {
+    absl::ReaderMutexLock lock(&mutex_);
+    void* key = GetDispatchTableKey(dispatchable_object);
+    CHECK(device_dispatch_table_.contains(key));
+    CHECK(device_dispatch_table_.at(key).GetQueryPoolResults != nullptr);
+    return device_dispatch_table_.at(key).GetQueryPoolResults;
+  }
+
+  template <typename DispatchableType>
+  PFN_vkCmdWriteTimestamp CmdWriteTimestamp(const DispatchableType& dispatchable_object) {
+    absl::ReaderMutexLock lock(&mutex_);
+    void* key = GetDispatchTableKey(dispatchable_object);
+    CHECK(device_dispatch_table_.contains(key));
+    CHECK(device_dispatch_table_.at(key).CmdWriteTimestamp != nullptr);
+    return device_dispatch_table_.at(key).CmdWriteTimestamp;
+  }
+
+  template <typename DispatchableType>
+  PFN_vkCmdBeginDebugUtilsLabelEXT CmdBeginDebugUtilsLabelEXT(
+      const DispatchableType& dispatchable_object) {
+    absl::ReaderMutexLock lock(&mutex_);
+    void* key = GetDispatchTableKey(dispatchable_object);
+    CHECK(device_dispatch_table_.contains(key));
+    CHECK(device_dispatch_table_.at(key).CmdBeginDebugUtilsLabelEXT != nullptr);
+    return device_dispatch_table_.at(key).CmdBeginDebugUtilsLabelEXT;
+  }
+
+  template <typename DispatchableType>
+  PFN_vkCmdEndDebugUtilsLabelEXT CmdEndDebugUtilsLabelEXT(
+      const DispatchableType& dispatchable_object) {
+    absl::ReaderMutexLock lock(&mutex_);
+    void* key = GetDispatchTableKey(dispatchable_object);
+    CHECK(device_dispatch_table_.contains(key));
+    CHECK(device_dispatch_table_.at(key).CmdEndDebugUtilsLabelEXT != nullptr);
+    return device_dispatch_table_.at(key).CmdEndDebugUtilsLabelEXT;
+  }
+
+  template <typename DispatchableType>
+  PFN_vkCmdDebugMarkerBeginEXT CmdDebugMarkerBeginEXT(const DispatchableType& dispatchable_object) {
+    absl::ReaderMutexLock lock(&mutex_);
+    void* key = GetDispatchTableKey(dispatchable_object);
+    CHECK(device_dispatch_table_.contains(key));
+    CHECK(device_dispatch_table_.at(key).CmdDebugMarkerBeginEXT != nullptr);
+    return device_dispatch_table_.at(key).CmdDebugMarkerBeginEXT;
+  }
+
+  template <typename DispatchableType>
+  PFN_vkCmdDebugMarkerEndEXT CmdDebugMarkerEndEXT(const DispatchableType& dispatchable_object) {
+    absl::ReaderMutexLock lock(&mutex_);
+    void* key = GetDispatchTableKey(dispatchable_object);
+    CHECK(device_dispatch_table_.contains(key));
+    CHECK(device_dispatch_table_.at(key).CmdDebugMarkerEndEXT != nullptr);
+    return device_dispatch_table_.at(key).CmdDebugMarkerEndEXT;
+  }
+
+  template <typename DispatchableType>
+  bool IsDebugMarkerExtensionSupported(const DispatchableType& dispatchable_object) {
+    absl::ReaderMutexLock lock(&mutex_);
+    void* key = GetDispatchTableKey(dispatchable_object);
+    CHECK(device_supports_debug_marker_extension_.contains(key));
+    return device_supports_debug_marker_extension_.at(key);
+  }
+
+  template <typename DispatchableType>
+  bool IsDebugUtilsExtensionSupported(const DispatchableType& dispatchable_object) {
+    absl::ReaderMutexLock lock(&mutex_);
+    void* key = GetDispatchTableKey(dispatchable_object);
+    CHECK(device_supports_debug_utils_extension_.contains(key));
+    return device_supports_debug_utils_extension_.at(key);
+  }
+
+ private:
+  // In vulkan, every "dispatchable type" has as a very first field in memory a pointer to the
+  // internal dispatch table. This pointer is unique per device/instance. So for example
+  // for a command buffer allocated on a certain device, this pointer is the same for the buffer
+  // and for the device. So we can use that pointer to uniquely map dispatchable types to their
+  // dispatch table.
+  template <typename DispatchableType>
+  void* GetDispatchTableKey(DispatchableType dispatchable_object) {
+    return *absl::bit_cast<void**>(dispatchable_object);
+  }
+
+  // Dispatch tables required for routing instance and device calls onto the next
+  // layer in the dispatch chain among our handling of functions we intercept.
+  absl::flat_hash_map<void*, VkLayerInstanceDispatchTable> instance_dispatch_table_;
+  absl::flat_hash_map<void*, VkLayerDispatchTable> device_dispatch_table_;
+  absl::flat_hash_map<void*, bool> device_supports_debug_marker_extension_;
+  absl::flat_hash_map<void*, bool> device_supports_debug_utils_extension_;
+
+  // Must protect access to dispatch tables above by mutex since the Vulkan
+  // application may be calling these functions from different threads.
+  // However, they are usually filled once (per device/instance) at the beginning
+  // and afterwards we only read that data. So we use a read/write lock.
+  absl::Mutex mutex_;
+};
+
+}  // namespace orbit_vulkan_layer
+
+#endif  // ORBIT_VULKAN_LAYER_DISPATCH_TABLE_H_

--- a/OrbitVulkanLayer/DispatchTableTest.cpp
+++ b/OrbitVulkanLayer/DispatchTableTest.cpp
@@ -1,0 +1,803 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "DispatchTable.h"
+#include "gtest/gtest.h"
+
+namespace orbit_vulkan_layer {
+
+TEST(DispatchTable, CanInitializeInstance) {
+  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerInstanceDispatchTable some_dispatch_table = {};
+  auto instance = absl::bit_cast<VkInstance>(&some_dispatch_table);
+  PFN_vkGetInstanceProcAddr next_get_instance_proc_addr_function =
+      +[](VkInstance /*instance*/, const char * /*name*/) -> PFN_vkVoidFunction { return nullptr; };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateInstanceDispatchTable(instance, next_get_instance_proc_addr_function);
+}
+
+TEST(DispatchTable, CannotInitializeInstanceTwice) {
+  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerInstanceDispatchTable some_dispatch_table = {};
+  auto instance = absl::bit_cast<VkInstance>(&some_dispatch_table);
+  PFN_vkGetInstanceProcAddr next_get_instance_proc_addr_function =
+      +[](VkInstance /*instance*/, const char * /*name*/) -> PFN_vkVoidFunction { return nullptr; };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateInstanceDispatchTable(instance, next_get_instance_proc_addr_function);
+  EXPECT_DEATH(
+      {
+        dispatch_table.CreateInstanceDispatchTable(instance, next_get_instance_proc_addr_function);
+      },
+      "");
+}
+
+TEST(DispatchTable, CanRemoveInstance) {
+  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerInstanceDispatchTable some_dispatch_table = {};
+  auto instance = absl::bit_cast<VkInstance>(&some_dispatch_table);
+  PFN_vkGetInstanceProcAddr next_get_instance_proc_addr_function =
+      +[](VkInstance /*instance*/, const char * /*name*/) -> PFN_vkVoidFunction { return nullptr; };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateInstanceDispatchTable(instance, next_get_instance_proc_addr_function);
+  dispatch_table.RemoveInstanceDispatchTable(instance);
+}
+
+TEST(DispatchTable, CanInitializeInstanceTwiceAfterRemove) {
+  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerInstanceDispatchTable some_dispatch_table = {};
+  auto instance = absl::bit_cast<VkInstance>(&some_dispatch_table);
+  PFN_vkGetInstanceProcAddr next_get_instance_proc_addr_function =
+      +[](VkInstance /*instance*/, const char * /*name*/) -> PFN_vkVoidFunction { return nullptr; };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateInstanceDispatchTable(instance, next_get_instance_proc_addr_function);
+  dispatch_table.RemoveInstanceDispatchTable(instance);
+  dispatch_table.CreateInstanceDispatchTable(instance, next_get_instance_proc_addr_function);
+}
+
+TEST(DispatchTable, CanInitializeDevice) {
+  // We can not create an actual VkDevice, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerDispatchTable some_dispatch_table = {};
+  auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
+  PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
+      +[](VkDevice /*instance*/, const char * /*name*/) -> PFN_vkVoidFunction { return nullptr; };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
+}
+
+TEST(DispatchTable, CannotInitializeDeviceTwice) {
+  // We can not create an actual VkDevice, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerDispatchTable some_dispatch_table = {};
+  auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
+  PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
+      +[](VkDevice /*instance*/, const char * /*name*/) -> PFN_vkVoidFunction { return nullptr; };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
+  EXPECT_DEATH(
+      { dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function); },
+      "");
+}
+
+TEST(DispatchTable, CanRemoveDevice) {
+  // We can not create an actual VkDevice, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerDispatchTable some_dispatch_table = {};
+  auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
+  PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
+      +[](VkDevice /*instance*/, const char * /*name*/) -> PFN_vkVoidFunction { return nullptr; };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
+  dispatch_table.RemoveDeviceDispatchTable(device);
+}
+
+TEST(DispatchTable, CanInitializeDeviceTwiceAfterRemove) {
+  // We can not create an actual VkDevice, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerDispatchTable some_dispatch_table = {};
+  auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
+  PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
+      +[](VkDevice /*instance*/, const char * /*name*/) -> PFN_vkVoidFunction { return nullptr; };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
+  dispatch_table.RemoveDeviceDispatchTable(device);
+  dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
+}
+
+TEST(DispatchTable, NoExtensionAvailable) {
+  // We can not create an actual VkDevice, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerDispatchTable some_dispatch_table = {};
+  auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
+  PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
+      +[](VkDevice /*instance*/, const char * /*name*/) -> PFN_vkVoidFunction { return nullptr; };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
+  EXPECT_FALSE(dispatch_table.IsDebugUtilsExtensionSupported(device));
+  EXPECT_FALSE(dispatch_table.IsDebugMarkerExtensionSupported(device));
+}
+
+TEST(DispatchTable, CanSupportDebugUtilsExtension) {
+  // We can not create an actual VkDevice, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerDispatchTable some_dispatch_table = {};
+  auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
+  PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
+      +[](VkDevice /*instance*/, const char* name) -> PFN_vkVoidFunction {
+    if (strcmp(name, "vkCmdBeginDebugUtilsLabelEXT") == 0) {
+      PFN_vkCmdBeginDebugUtilsLabelEXT begin_function =
+          +[](VkCommandBuffer /*command_buffer*/, const VkDebugUtilsLabelEXT* /*label_info*/) {};
+      return absl::bit_cast<PFN_vkVoidFunction>(begin_function);
+    }
+    if (strcmp(name, "vkCmdEndDebugUtilsLabelEXT") == 0) {
+      PFN_vkCmdEndDebugUtilsLabelEXT end_function = +[](VkCommandBuffer /*command_buffer*/) {};
+      return absl::bit_cast<PFN_vkVoidFunction>(end_function);
+    }
+    return nullptr;
+  };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
+  EXPECT_TRUE(dispatch_table.IsDebugUtilsExtensionSupported(device));
+}
+
+TEST(DispatchTable, CanSupportDebugMarkerExtension) {
+  // We can not create an actual VkDevice, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerDispatchTable some_dispatch_table = {};
+  auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
+  PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
+      +[](VkDevice /*instance*/, const char* name) -> PFN_vkVoidFunction {
+    if (strcmp(name, "vkCmdDebugMarkerBeginEXT") == 0) {
+      PFN_vkCmdDebugMarkerBeginEXT begin_function =
+          +[](VkCommandBuffer /*command_buffer*/,
+              const VkDebugMarkerMarkerInfoEXT* /*label_info*/) {};
+      return absl::bit_cast<PFN_vkVoidFunction>(begin_function);
+    }
+    if (strcmp(name, "vkCmdDebugMarkerEndEXT") == 0) {
+      PFN_vkCmdDebugMarkerEndEXT end_function = +[](VkCommandBuffer /*command_buffer*/) {};
+      return absl::bit_cast<PFN_vkVoidFunction>(end_function);
+    }
+    return nullptr;
+  };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
+  EXPECT_TRUE(dispatch_table.IsDebugMarkerExtensionSupported(device));
+}
+
+TEST(DispatchTable, CanCallEnumerateDeviceExtensionProperties) {
+  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerInstanceDispatchTable some_dispatch_table = {};
+  auto instance = absl::bit_cast<VkInstance>(&some_dispatch_table);
+  PFN_vkGetInstanceProcAddr next_get_instance_proc_addr_function =
+      +[](VkInstance /*instance*/, const char* name) -> PFN_vkVoidFunction {
+    if (strcmp(name, "vkEnumerateDeviceExtensionProperties") == 0) {
+      PFN_vkEnumerateDeviceExtensionProperties function =
+          +[](VkPhysicalDevice /*physical_device*/, const char* /*layer_name*/,
+              uint32_t* property_count, VkExtensionProperties *
+              /*properties*/) -> VkResult {
+        *property_count = 42;
+        return VK_SUCCESS;
+      };
+      return absl::bit_cast<PFN_vkVoidFunction>(function);
+    }
+    return nullptr;
+  };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateInstanceDispatchTable(instance, next_get_instance_proc_addr_function);
+
+  VkPhysicalDevice device = {};
+  uint32_t property_count;
+
+  VkResult result = dispatch_table.EnumerateDeviceExtensionProperties(instance)(
+      device, nullptr, &property_count, nullptr);
+  EXPECT_EQ(result, VK_SUCCESS);
+  EXPECT_EQ(property_count, 42);
+}
+
+TEST(DispatchTable, CanCallGetPhysicalDeviceProperties) {
+  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerInstanceDispatchTable some_dispatch_table = {};
+  auto instance = absl::bit_cast<VkInstance>(&some_dispatch_table);
+
+  static bool was_called = false;
+
+  PFN_vkGetInstanceProcAddr next_get_instance_proc_addr_function =
+      +[](VkInstance /*instance*/, const char* name) -> PFN_vkVoidFunction {
+    if (strcmp(name, "vkGetPhysicalDeviceProperties") == 0) {
+      PFN_vkGetPhysicalDeviceProperties function =
+          +[](VkPhysicalDevice /*physical_device*/, VkPhysicalDeviceProperties*
+              /*properties*/) { was_called = true; };
+      return absl::bit_cast<PFN_vkVoidFunction>(function);
+    }
+    return nullptr;
+  };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateInstanceDispatchTable(instance, next_get_instance_proc_addr_function);
+
+  VkPhysicalDevice device = {};
+  dispatch_table.GetPhysicalDeviceProperties(instance)(device, nullptr);
+  EXPECT_TRUE(was_called);
+}
+
+TEST(DispatchTable, CanCallGetInstanceProcAddr) {
+  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerInstanceDispatchTable some_dispatch_table = {};
+  auto instance = absl::bit_cast<VkInstance>(&some_dispatch_table);
+
+  static bool was_called = false;
+
+  PFN_vkGetInstanceProcAddr next_get_instance_proc_addr_function =
+      +[](VkInstance /*instance*/, const char* name) -> PFN_vkVoidFunction {
+    if (strcmp(name, "vkGetInstanceProcAddr") == 0) {
+      PFN_vkGetInstanceProcAddr function = +[](VkInstance /*instance*/, const char *
+                                               /*name*/) -> PFN_vkVoidFunction {
+        was_called = true;
+        return nullptr;
+      };
+      return absl::bit_cast<PFN_vkVoidFunction>(function);
+    }
+    return nullptr;
+  };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateInstanceDispatchTable(instance, next_get_instance_proc_addr_function);
+
+  dispatch_table.GetInstanceProcAddr(instance)(instance, "");
+  EXPECT_TRUE(was_called);
+}
+
+TEST(DispatchTable, CanCallGetDeviceProcAddr) {
+  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerDispatchTable some_dispatch_table = {};
+  auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
+
+  static bool was_called = false;
+
+  PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
+      +[](VkDevice /*device*/, const char* name) -> PFN_vkVoidFunction {
+    if (strcmp(name, "vkGetDeviceProcAddr") == 0) {
+      PFN_vkGetDeviceProcAddr function = +[](VkDevice /*device*/, const char *
+                                             /*name*/) -> PFN_vkVoidFunction {
+        was_called = true;
+        return nullptr;
+      };
+      return absl::bit_cast<PFN_vkVoidFunction>(function);
+    }
+    return nullptr;
+  };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
+
+  dispatch_table.GetDeviceProcAddr(device)(device, "");
+  EXPECT_TRUE(was_called);
+}
+
+TEST(DispatchTable, CanCallResetCommandPool) {
+  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerDispatchTable some_dispatch_table = {};
+  auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
+
+  PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
+      +[](VkDevice /*device*/, const char* name) -> PFN_vkVoidFunction {
+    if (strcmp(name, "vkResetCommandPool") == 0) {
+      PFN_vkResetCommandPool function =
+          +[](VkDevice /*device*/, VkCommandPool /*command_pool*/,
+              VkCommandPoolResetFlags /*flags*/) -> VkResult { return VK_SUCCESS; };
+      return absl::bit_cast<PFN_vkVoidFunction>(function);
+    }
+    return nullptr;
+  };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
+
+  VkCommandPool command_pool = {};
+  VkResult result = dispatch_table.ResetCommandPool(device)(device, command_pool, 0);
+  EXPECT_EQ(result, VK_SUCCESS);
+}
+
+TEST(DispatchTable, CanCallAllocateCommandBuffers) {
+  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerDispatchTable some_dispatch_table = {};
+  auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
+
+  PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
+      +[](VkDevice /*device*/, const char* name) -> PFN_vkVoidFunction {
+    if (strcmp(name, "vkAllocateCommandBuffers") == 0) {
+      PFN_vkAllocateCommandBuffers function =
+          +[](VkDevice /*device*/, const VkCommandBufferAllocateInfo* /*allocate_info*/,
+              VkCommandBuffer *
+              /*command_buffers*/) -> VkResult { return VK_SUCCESS; };
+      return absl::bit_cast<PFN_vkVoidFunction>(function);
+    }
+    return nullptr;
+  };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
+
+  VkResult result = dispatch_table.AllocateCommandBuffers(device)(device, nullptr, nullptr);
+  EXPECT_EQ(result, VK_SUCCESS);
+}
+
+TEST(DispatchTable, CanCallFreeCommandBuffers) {
+  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerDispatchTable some_dispatch_table = {};
+  auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
+
+  static bool was_called = false;
+
+  PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
+      +[](VkDevice /*device*/, const char* name) -> PFN_vkVoidFunction {
+    if (strcmp(name, "vkFreeCommandBuffers") == 0) {
+      PFN_vkFreeCommandBuffers function =
+          +[](VkDevice /*device*/, VkCommandPool /*command_pool*/,
+              uint32_t /*command_buffer_count*/, const VkCommandBuffer*
+              /*command_buffers*/) { was_called = true; };
+      return absl::bit_cast<PFN_vkVoidFunction>(function);
+    }
+    return nullptr;
+  };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
+
+  VkCommandPool command_pool = {};
+  dispatch_table.FreeCommandBuffers(device)(device, command_pool, 0, nullptr);
+  EXPECT_TRUE(was_called);
+}
+
+TEST(DispatchTable, CanCallBeginCommandBuffer) {
+  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerDispatchTable some_dispatch_table = {};
+  auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
+
+  PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
+      +[](VkDevice /*device*/, const char* name) -> PFN_vkVoidFunction {
+    if (strcmp(name, "vkBeginCommandBuffer") == 0) {
+      PFN_vkBeginCommandBuffer function =
+          +[](VkCommandBuffer /*command_buffer*/, const VkCommandBufferBeginInfo *
+              /*begin_info*/) -> VkResult { return VK_SUCCESS; };
+      return absl::bit_cast<PFN_vkVoidFunction>(function);
+    }
+    return nullptr;
+  };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
+
+  VkCommandBuffer command_buffer = {};
+  VkResult result = dispatch_table.BeginCommandBuffer(device)(command_buffer, nullptr);
+  EXPECT_EQ(result, VK_SUCCESS);
+}
+
+TEST(DispatchTable, CanCallEndCommandBuffer) {
+  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerDispatchTable some_dispatch_table = {};
+  auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
+
+  PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
+      +[](VkDevice /*device*/, const char* name) -> PFN_vkVoidFunction {
+    if (strcmp(name, "vkEndCommandBuffer") == 0) {
+      PFN_vkEndCommandBuffer function =
+          +[](VkCommandBuffer /*command_buffer*/) -> VkResult { return VK_SUCCESS; };
+      return absl::bit_cast<PFN_vkVoidFunction>(function);
+    }
+    return nullptr;
+  };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
+
+  VkCommandBuffer command_buffer = {};
+  VkResult result = dispatch_table.EndCommandBuffer(device)(command_buffer);
+  EXPECT_EQ(result, VK_SUCCESS);
+}
+
+TEST(DispatchTable, CanCallResetCommandBuffer) {
+  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerDispatchTable some_dispatch_table = {};
+  auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
+
+  PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
+      +[](VkDevice /*device*/, const char* name) -> PFN_vkVoidFunction {
+    if (strcmp(name, "vkResetCommandBuffer") == 0) {
+      PFN_vkResetCommandBuffer function =
+          +[](VkCommandBuffer /*command_buffer*/, VkCommandBufferResetFlags /*flags*/) -> VkResult {
+        return VK_SUCCESS;
+      };
+      return absl::bit_cast<PFN_vkVoidFunction>(function);
+    }
+    return nullptr;
+  };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
+
+  VkCommandBuffer command_buffer = {};
+  VkResult result = dispatch_table.ResetCommandBuffer(device)(command_buffer, 0);
+  EXPECT_EQ(result, VK_SUCCESS);
+}
+
+TEST(DispatchTable, CanCallGetDeviceQueue) {
+  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerDispatchTable some_dispatch_table = {};
+  auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
+
+  static bool was_called = false;
+
+  PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
+      +[](VkDevice /*device*/, const char* name) -> PFN_vkVoidFunction {
+    if (strcmp(name, "vkGetDeviceQueue") == 0) {
+      PFN_vkGetDeviceQueue function = +[](VkDevice /*device*/, uint32_t /*queue_family_index*/,
+                                          uint32_t /*queue_index*/, VkQueue*
+                                          /*queue*/) { was_called = true; };
+      return absl::bit_cast<PFN_vkVoidFunction>(function);
+    }
+    return nullptr;
+  };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
+
+  dispatch_table.GetDeviceQueue(device)(device, 0, 0, nullptr);
+  EXPECT_TRUE(was_called);
+}
+
+TEST(DispatchTable, CanCallGetDeviceQueue2) {
+  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerDispatchTable some_dispatch_table = {};
+  auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
+
+  static bool was_called = false;
+
+  PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
+      +[](VkDevice /*device*/, const char* name) -> PFN_vkVoidFunction {
+    if (strcmp(name, "vkGetDeviceQueue2") == 0) {
+      PFN_vkGetDeviceQueue2 function =
+          +[](VkDevice /*device*/, const VkDeviceQueueInfo2* /*queue_info*/, VkQueue*
+              /*queue*/) { was_called = true; };
+      return absl::bit_cast<PFN_vkVoidFunction>(function);
+    }
+    return nullptr;
+  };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
+
+  dispatch_table.GetDeviceQueue2(device)(device, nullptr, nullptr);
+  EXPECT_TRUE(was_called);
+}
+
+TEST(DispatchTable, CanCallQueueSubmit) {
+  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerDispatchTable some_dispatch_table = {};
+  auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
+
+  PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
+      +[](VkDevice /*device*/, const char* name) -> PFN_vkVoidFunction {
+    if (strcmp(name, "vkQueueSubmit") == 0) {
+      PFN_vkQueueSubmit function =
+          +[](VkQueue /*queue*/, uint32_t /*submit_count*/, const VkSubmitInfo* /*submit_info*/,
+              VkFence /*fence*/) -> VkResult { return VK_SUCCESS; };
+      return absl::bit_cast<PFN_vkVoidFunction>(function);
+    }
+    return nullptr;
+  };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
+
+  VkQueue queue = {};
+  VkFence fence = {};
+  VkResult result = dispatch_table.QueueSubmit(device)(queue, 0, nullptr, fence);
+  EXPECT_EQ(result, VK_SUCCESS);
+}
+
+TEST(DispatchTable, CanCallQueuePresentKHR) {
+  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerDispatchTable some_dispatch_table = {};
+  auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
+
+  PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
+      +[](VkDevice /*device*/, const char* name) -> PFN_vkVoidFunction {
+    if (strcmp(name, "vkQueuePresentKHR") == 0) {
+      PFN_vkQueuePresentKHR function = +[](VkQueue /*queue*/, const VkPresentInfoKHR *
+                                           /*present_info*/) -> VkResult { return VK_SUCCESS; };
+      return absl::bit_cast<PFN_vkVoidFunction>(function);
+    }
+    return nullptr;
+  };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
+
+  VkQueue queue = {};
+  VkResult result = dispatch_table.QueuePresentKHR(device)(queue, nullptr);
+  EXPECT_EQ(result, VK_SUCCESS);
+}
+
+TEST(DispatchTable, CanCallCreateQueryPool) {
+  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerDispatchTable some_dispatch_table = {};
+  auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
+
+  PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
+      +[](VkDevice /*device*/, const char* name) -> PFN_vkVoidFunction {
+    if (strcmp(name, "vkCreateQueryPool") == 0) {
+      PFN_vkCreateQueryPool function =
+          +[](VkDevice /*device*/, const VkQueryPoolCreateInfo* /*create_info*/,
+              const VkAllocationCallbacks* /*allocator*/, VkQueryPool *
+              /*query_pool*/) -> VkResult { return VK_SUCCESS; };
+      return absl::bit_cast<PFN_vkVoidFunction>(function);
+    }
+    return nullptr;
+  };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
+
+  VkResult result = dispatch_table.CreateQueryPool(device)(device, nullptr, nullptr, nullptr);
+  EXPECT_EQ(result, VK_SUCCESS);
+}
+
+TEST(DispatchTable, CanCallResetQueryPoolEXT) {
+  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerDispatchTable some_dispatch_table = {};
+  auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
+
+  static bool was_called = false;
+
+  PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
+      +[](VkDevice /*device*/, const char* name) -> PFN_vkVoidFunction {
+    if (strcmp(name, "vkResetQueryPoolEXT") == 0) {
+      PFN_vkResetQueryPoolEXT function = +[](VkDevice /*device*/, VkQueryPool /*query_pool*/,
+                                             uint32_t
+                                             /*first_query*/,
+                                             uint32_t /*query_count*/) { was_called = true; };
+      return absl::bit_cast<PFN_vkVoidFunction>(function);
+    }
+    return nullptr;
+  };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
+
+  VkQueryPool query_pool = {};
+  dispatch_table.ResetQueryPoolEXT(device)(device, query_pool, 0, 0);
+  EXPECT_TRUE(was_called);
+}
+
+TEST(DispatchTable, CanCallGetQueryPoolResults) {
+  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerDispatchTable some_dispatch_table = {};
+  auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
+
+  PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
+      +[](VkDevice /*device*/, const char* name) -> PFN_vkVoidFunction {
+    if (strcmp(name, "vkGetQueryPoolResults") == 0) {
+      PFN_vkGetQueryPoolResults function =
+          +[](VkDevice /*device*/, VkQueryPool /*query_pool*/, uint32_t /*first_query*/,
+              uint32_t /*query_count*/, size_t /*data_size*/, void* /*data*/,
+              VkDeviceSize /*stride*/,
+              VkQueryResultFlags /*flags*/) -> VkResult { return VK_SUCCESS; };
+      return absl::bit_cast<PFN_vkVoidFunction>(function);
+    }
+    return nullptr;
+  };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
+
+  VkQueryPool query_pool = {};
+  VkResult result =
+      dispatch_table.GetQueryPoolResults(device)(device, query_pool, 0, 0, 0, nullptr, 0, 0);
+  EXPECT_EQ(result, VK_SUCCESS);
+}
+
+TEST(DispatchTable, CanCallCmdWriteTimestamp) {
+  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerDispatchTable some_dispatch_table = {};
+  auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
+
+  static bool was_called = false;
+
+  PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
+      +[](VkDevice /*device*/, const char* name) -> PFN_vkVoidFunction {
+    if (strcmp(name, "vkCmdWriteTimestamp") == 0) {
+      PFN_vkCmdWriteTimestamp function =
+          +[](VkCommandBuffer /*command_buffer*/, VkPipelineStageFlagBits /*pipeline_stage*/,
+              VkQueryPool /*query_pool*/, uint32_t /*query*/) { was_called = true; };
+      return absl::bit_cast<PFN_vkVoidFunction>(function);
+    }
+    return nullptr;
+  };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
+
+  VkCommandBuffer command_buffer = {};
+  VkQueryPool query_pool = {};
+  dispatch_table.CmdWriteTimestamp(device)(command_buffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                                           query_pool, 0);
+  EXPECT_TRUE(was_called);
+}
+
+TEST(DispatchTable, CanCallCmdBeginDebugUtilsLabelEXT) {
+  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerDispatchTable some_dispatch_table = {};
+  auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
+
+  static bool was_called = false;
+
+  PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
+      +[](VkDevice /*device*/, const char* name) -> PFN_vkVoidFunction {
+    if (strcmp(name, "vkCmdBeginDebugUtilsLabelEXT") == 0) {
+      PFN_vkCmdBeginDebugUtilsLabelEXT function =
+          +[](VkCommandBuffer /*command_buffer*/, const VkDebugUtilsLabelEXT* /*label_info*/) {
+            was_called = true;
+          };
+      return absl::bit_cast<PFN_vkVoidFunction>(function);
+    }
+    return nullptr;
+  };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
+
+  VkCommandBuffer command_buffer = {};
+  dispatch_table.CmdBeginDebugUtilsLabelEXT(device)(command_buffer, nullptr);
+  EXPECT_TRUE(was_called);
+}
+
+TEST(DispatchTable, CanCallCmdEndDebugUtilsLabelEXT) {
+  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerDispatchTable some_dispatch_table = {};
+  auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
+
+  static bool was_called = false;
+
+  PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
+      +[](VkDevice /*device*/, const char* name) -> PFN_vkVoidFunction {
+    if (strcmp(name, "vkCmdEndDebugUtilsLabelEXT") == 0) {
+      PFN_vkCmdEndDebugUtilsLabelEXT function =
+          +[](VkCommandBuffer /*command_buffer*/) { was_called = true; };
+      return absl::bit_cast<PFN_vkVoidFunction>(function);
+    }
+    return nullptr;
+  };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
+
+  VkCommandBuffer command_buffer = {};
+  dispatch_table.CmdEndDebugUtilsLabelEXT(device)(command_buffer);
+  EXPECT_TRUE(was_called);
+}
+
+TEST(DispatchTable, CanCallCmdDebugMarkerBeginEXT) {
+  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerDispatchTable some_dispatch_table = {};
+  auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
+
+  static bool was_called = false;
+
+  PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
+      +[](VkDevice /*device*/, const char* name) -> PFN_vkVoidFunction {
+    if (strcmp(name, "vkCmdDebugMarkerBeginEXT") == 0) {
+      PFN_vkCmdDebugMarkerBeginEXT function =
+          +[](VkCommandBuffer /*command_buffer*/,
+              const VkDebugMarkerMarkerInfoEXT* /*marker_info*/) { was_called = true; };
+      return absl::bit_cast<PFN_vkVoidFunction>(function);
+    }
+    return nullptr;
+  };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
+
+  VkCommandBuffer command_buffer = {};
+  dispatch_table.CmdDebugMarkerBeginEXT(device)(command_buffer, nullptr);
+  EXPECT_TRUE(was_called);
+}
+
+TEST(DispatchTable, CanCallCmdDebugMarkerEndEXT) {
+  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
+  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+  // table wrapper, so we need to mimic it.
+  VkLayerDispatchTable some_dispatch_table = {};
+  auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
+
+  static bool was_called = false;
+
+  PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
+      +[](VkDevice /*device*/, const char* name) -> PFN_vkVoidFunction {
+    if (strcmp(name, "vkCmdDebugMarkerEndEXT") == 0) {
+      PFN_vkCmdDebugMarkerEndEXT function =
+          +[](VkCommandBuffer /*command_buffer*/) { was_called = true; };
+      return absl::bit_cast<PFN_vkVoidFunction>(function);
+    }
+    return nullptr;
+  };
+
+  DispatchTable dispatch_table = {};
+  dispatch_table.CreateDeviceDispatchTable(device, next_get_device_proc_addr_function);
+
+  VkCommandBuffer command_buffer = {};
+  dispatch_table.CmdDebugMarkerEndEXT(device)(command_buffer);
+  EXPECT_TRUE(was_called);
+}
+
+}  // namespace orbit_vulkan_layer

--- a/OrbitVulkanLayer/DispatchTableTest.cpp
+++ b/OrbitVulkanLayer/DispatchTableTest.cpp
@@ -49,7 +49,7 @@ TEST(DispatchTable, CanRemoveInstance) {
   dispatch_table.RemoveInstanceDispatchTable(instance);
 }
 
-TEST(DispatchTable, CanInitializeInstanceTwiceAfterRemove) {
+TEST(DispatchTable, CanReinitializeInstanceAfterRemove) {
   VkLayerInstanceDispatchTable some_dispatch_table = {};
   auto instance = absl::bit_cast<VkInstance>(&some_dispatch_table);
   PFN_vkGetInstanceProcAddr next_get_instance_proc_addr_function =
@@ -95,7 +95,7 @@ TEST(DispatchTable, CanRemoveDevice) {
   dispatch_table.RemoveDeviceDispatchTable(device);
 }
 
-TEST(DispatchTable, CanInitializeDeviceTwiceAfterRemove) {
+TEST(DispatchTable, CanReinitializeDeviceAfterRemove) {
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
   PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =

--- a/OrbitVulkanLayer/DispatchTableTest.cpp
+++ b/OrbitVulkanLayer/DispatchTableTest.cpp
@@ -7,10 +7,13 @@
 
 namespace orbit_vulkan_layer {
 
+// Note the following for all the following tests:
+// We can not create an actual VkInstance/VkDevice, but the first bytes of any dispatchable type in
+// Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
+// table wrapper, so we need to mimic it.
+// Thus, we will create VkLayer(Instance)DispatchTables and cast its address to VkInstance/VkDevice.
+
 TEST(DispatchTable, CanInitializeInstance) {
-  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerInstanceDispatchTable some_dispatch_table = {};
   auto instance = absl::bit_cast<VkInstance>(&some_dispatch_table);
   PFN_vkGetInstanceProcAddr next_get_instance_proc_addr_function =
@@ -21,9 +24,6 @@ TEST(DispatchTable, CanInitializeInstance) {
 }
 
 TEST(DispatchTable, CannotInitializeInstanceTwice) {
-  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerInstanceDispatchTable some_dispatch_table = {};
   auto instance = absl::bit_cast<VkInstance>(&some_dispatch_table);
   PFN_vkGetInstanceProcAddr next_get_instance_proc_addr_function =
@@ -39,9 +39,6 @@ TEST(DispatchTable, CannotInitializeInstanceTwice) {
 }
 
 TEST(DispatchTable, CanRemoveInstance) {
-  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerInstanceDispatchTable some_dispatch_table = {};
   auto instance = absl::bit_cast<VkInstance>(&some_dispatch_table);
   PFN_vkGetInstanceProcAddr next_get_instance_proc_addr_function =
@@ -53,9 +50,6 @@ TEST(DispatchTable, CanRemoveInstance) {
 }
 
 TEST(DispatchTable, CanInitializeInstanceTwiceAfterRemove) {
-  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerInstanceDispatchTable some_dispatch_table = {};
   auto instance = absl::bit_cast<VkInstance>(&some_dispatch_table);
   PFN_vkGetInstanceProcAddr next_get_instance_proc_addr_function =
@@ -68,9 +62,6 @@ TEST(DispatchTable, CanInitializeInstanceTwiceAfterRemove) {
 }
 
 TEST(DispatchTable, CanInitializeDevice) {
-  // We can not create an actual VkDevice, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
   PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
@@ -81,9 +72,6 @@ TEST(DispatchTable, CanInitializeDevice) {
 }
 
 TEST(DispatchTable, CannotInitializeDeviceTwice) {
-  // We can not create an actual VkDevice, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
   PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
@@ -97,9 +85,6 @@ TEST(DispatchTable, CannotInitializeDeviceTwice) {
 }
 
 TEST(DispatchTable, CanRemoveDevice) {
-  // We can not create an actual VkDevice, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
   PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
@@ -111,9 +96,6 @@ TEST(DispatchTable, CanRemoveDevice) {
 }
 
 TEST(DispatchTable, CanInitializeDeviceTwiceAfterRemove) {
-  // We can not create an actual VkDevice, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
   PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
@@ -126,9 +108,6 @@ TEST(DispatchTable, CanInitializeDeviceTwiceAfterRemove) {
 }
 
 TEST(DispatchTable, NoExtensionAvailable) {
-  // We can not create an actual VkDevice, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
   PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
@@ -141,9 +120,6 @@ TEST(DispatchTable, NoExtensionAvailable) {
 }
 
 TEST(DispatchTable, CanSupportDebugUtilsExtension) {
-  // We can not create an actual VkDevice, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
   PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
@@ -166,9 +142,6 @@ TEST(DispatchTable, CanSupportDebugUtilsExtension) {
 }
 
 TEST(DispatchTable, CanSupportDebugMarkerExtension) {
-  // We can not create an actual VkDevice, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
   PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
@@ -192,9 +165,6 @@ TEST(DispatchTable, CanSupportDebugMarkerExtension) {
 }
 
 TEST(DispatchTable, CanCallEnumerateDeviceExtensionProperties) {
-  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerInstanceDispatchTable some_dispatch_table = {};
   auto instance = absl::bit_cast<VkInstance>(&some_dispatch_table);
   PFN_vkGetInstanceProcAddr next_get_instance_proc_addr_function =
@@ -225,9 +195,6 @@ TEST(DispatchTable, CanCallEnumerateDeviceExtensionProperties) {
 }
 
 TEST(DispatchTable, CanCallGetPhysicalDeviceProperties) {
-  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerInstanceDispatchTable some_dispatch_table = {};
   auto instance = absl::bit_cast<VkInstance>(&some_dispatch_table);
 
@@ -250,12 +217,10 @@ TEST(DispatchTable, CanCallGetPhysicalDeviceProperties) {
   VkPhysicalDevice device = {};
   dispatch_table.GetPhysicalDeviceProperties(instance)(device, nullptr);
   EXPECT_TRUE(was_called);
+  was_called = false;
 }
 
 TEST(DispatchTable, CanCallGetInstanceProcAddr) {
-  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerInstanceDispatchTable some_dispatch_table = {};
   auto instance = absl::bit_cast<VkInstance>(&some_dispatch_table);
 
@@ -279,12 +244,10 @@ TEST(DispatchTable, CanCallGetInstanceProcAddr) {
 
   dispatch_table.GetInstanceProcAddr(instance)(instance, "");
   EXPECT_TRUE(was_called);
+  was_called = false;
 }
 
 TEST(DispatchTable, CanCallGetDeviceProcAddr) {
-  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
 
@@ -308,12 +271,10 @@ TEST(DispatchTable, CanCallGetDeviceProcAddr) {
 
   dispatch_table.GetDeviceProcAddr(device)(device, "");
   EXPECT_TRUE(was_called);
+  was_called = false;
 }
 
 TEST(DispatchTable, CanCallResetCommandPool) {
-  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
 
@@ -337,9 +298,6 @@ TEST(DispatchTable, CanCallResetCommandPool) {
 }
 
 TEST(DispatchTable, CanCallAllocateCommandBuffers) {
-  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
 
@@ -363,9 +321,6 @@ TEST(DispatchTable, CanCallAllocateCommandBuffers) {
 }
 
 TEST(DispatchTable, CanCallFreeCommandBuffers) {
-  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
 
@@ -389,12 +344,10 @@ TEST(DispatchTable, CanCallFreeCommandBuffers) {
   VkCommandPool command_pool = {};
   dispatch_table.FreeCommandBuffers(device)(device, command_pool, 0, nullptr);
   EXPECT_TRUE(was_called);
+  was_called = false;
 }
 
 TEST(DispatchTable, CanCallBeginCommandBuffer) {
-  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
 
@@ -418,9 +371,6 @@ TEST(DispatchTable, CanCallBeginCommandBuffer) {
 }
 
 TEST(DispatchTable, CanCallEndCommandBuffer) {
-  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
 
@@ -443,9 +393,6 @@ TEST(DispatchTable, CanCallEndCommandBuffer) {
 }
 
 TEST(DispatchTable, CanCallResetCommandBuffer) {
-  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
 
@@ -470,9 +417,6 @@ TEST(DispatchTable, CanCallResetCommandBuffer) {
 }
 
 TEST(DispatchTable, CanCallGetDeviceQueue) {
-  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
 
@@ -494,12 +438,10 @@ TEST(DispatchTable, CanCallGetDeviceQueue) {
 
   dispatch_table.GetDeviceQueue(device)(device, 0, 0, nullptr);
   EXPECT_TRUE(was_called);
+  was_called = false;
 }
 
 TEST(DispatchTable, CanCallGetDeviceQueue2) {
-  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
 
@@ -521,12 +463,10 @@ TEST(DispatchTable, CanCallGetDeviceQueue2) {
 
   dispatch_table.GetDeviceQueue2(device)(device, nullptr, nullptr);
   EXPECT_TRUE(was_called);
+  was_called = false;
 }
 
 TEST(DispatchTable, CanCallQueueSubmit) {
-  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
 
@@ -551,9 +491,6 @@ TEST(DispatchTable, CanCallQueueSubmit) {
 }
 
 TEST(DispatchTable, CanCallQueuePresentKHR) {
-  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
 
@@ -576,9 +513,6 @@ TEST(DispatchTable, CanCallQueuePresentKHR) {
 }
 
 TEST(DispatchTable, CanCallCreateQueryPool) {
-  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
 
@@ -602,9 +536,6 @@ TEST(DispatchTable, CanCallCreateQueryPool) {
 }
 
 TEST(DispatchTable, CanCallResetQueryPoolEXT) {
-  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
 
@@ -628,12 +559,10 @@ TEST(DispatchTable, CanCallResetQueryPoolEXT) {
   VkQueryPool query_pool = {};
   dispatch_table.ResetQueryPoolEXT(device)(device, query_pool, 0, 0);
   EXPECT_TRUE(was_called);
+  was_called = false;
 }
 
 TEST(DispatchTable, CanCallGetQueryPoolResults) {
-  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
 
@@ -660,9 +589,6 @@ TEST(DispatchTable, CanCallGetQueryPoolResults) {
 }
 
 TEST(DispatchTable, CanCallCmdWriteTimestamp) {
-  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
 
@@ -687,12 +613,10 @@ TEST(DispatchTable, CanCallCmdWriteTimestamp) {
   dispatch_table.CmdWriteTimestamp(device)(command_buffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
                                            query_pool, 0);
   EXPECT_TRUE(was_called);
+  was_called = false;
 }
 
 TEST(DispatchTable, CanCallCmdBeginDebugUtilsLabelEXT) {
-  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
 
@@ -716,12 +640,10 @@ TEST(DispatchTable, CanCallCmdBeginDebugUtilsLabelEXT) {
   VkCommandBuffer command_buffer = {};
   dispatch_table.CmdBeginDebugUtilsLabelEXT(device)(command_buffer, nullptr);
   EXPECT_TRUE(was_called);
+  was_called = false;
 }
 
 TEST(DispatchTable, CanCallCmdEndDebugUtilsLabelEXT) {
-  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
 
@@ -743,12 +665,10 @@ TEST(DispatchTable, CanCallCmdEndDebugUtilsLabelEXT) {
   VkCommandBuffer command_buffer = {};
   dispatch_table.CmdEndDebugUtilsLabelEXT(device)(command_buffer);
   EXPECT_TRUE(was_called);
+  was_called = false;
 }
 
 TEST(DispatchTable, CanCallCmdDebugMarkerBeginEXT) {
-  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
 
@@ -771,12 +691,10 @@ TEST(DispatchTable, CanCallCmdDebugMarkerBeginEXT) {
   VkCommandBuffer command_buffer = {};
   dispatch_table.CmdDebugMarkerBeginEXT(device)(command_buffer, nullptr);
   EXPECT_TRUE(was_called);
+  was_called = false;
 }
 
 TEST(DispatchTable, CanCallCmdDebugMarkerEndEXT) {
-  // We can not create an actual VkInstance, but the first bytes of an any dispatchable type in
-  // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
-  // table wrapper, so we need to mimic it.
   VkLayerDispatchTable some_dispatch_table = {};
   auto device = absl::bit_cast<VkDevice>(&some_dispatch_table);
 
@@ -798,6 +716,7 @@ TEST(DispatchTable, CanCallCmdDebugMarkerEndEXT) {
   VkCommandBuffer command_buffer = {};
   dispatch_table.CmdDebugMarkerEndEXT(device)(command_buffer);
   EXPECT_TRUE(was_called);
+  was_called = false;
 }
 
 }  // namespace orbit_vulkan_layer

--- a/OrbitVulkanLayer/DispatchTableTest.cpp
+++ b/OrbitVulkanLayer/DispatchTableTest.cpp
@@ -8,7 +8,7 @@
 namespace orbit_vulkan_layer {
 
 // Note the following for all the following tests:
-// We can not create an actual VkInstance/VkDevice, but the first bytes of any dispatchable type in
+// We cannot create an actual VkInstance/VkDevice, but the first bytes of any dispatchable type in
 // Vulkan will be a pointer to a dispatch table. This characteristic will be used by our dispatch
 // table wrapper, so we need to mimic it.
 // Thus, we will create VkLayer(Instance)DispatchTables and cast its address to VkInstance/VkDevice.
@@ -198,6 +198,8 @@ TEST(DispatchTable, CanCallGetPhysicalDeviceProperties) {
   VkLayerInstanceDispatchTable some_dispatch_table = {};
   auto instance = absl::bit_cast<VkInstance>(&some_dispatch_table);
 
+  // This bool needs to be static, as it will be used in the lambda below, which must not capture
+  // anything in order to convert it to a function pointer.
   static bool was_called = false;
 
   PFN_vkGetInstanceProcAddr next_get_instance_proc_addr_function =

--- a/conanfile.py
+++ b/conanfile.py
@@ -29,7 +29,8 @@ class OrbitConan(ConanFile):
                "crashdump_server": "ANY",
                "with_crash_handling": [True, False],
                "with_orbitgl": [True, False],
-               "run_tests": [True, False]}
+               "run_tests": [True, False],
+               "with_vulkan_layer": [True, False]}
     default_options = {"system_mesa": True,
                        "system_qt": True, "with_gui": True,
                        "debian_packaging": False,
@@ -37,6 +38,7 @@ class OrbitConan(ConanFile):
                        "crashdump_server": "",
                        "with_crash_handling": True,
                        "with_orbitgl": True,
+                       "with_vulkan_layer": False,
                        "run_tests": True}
     _orbit_channel = "orbitdeps/stable"
     exports_sources = "CMakeLists.txt", "Orbit*", "bin/*", "cmake/*", "third_party/*", "LICENSE"
@@ -154,6 +156,7 @@ class OrbitConan(ConanFile):
         cmake = CMake(self)
         cmake.definitions["WITH_GUI"] = "ON" if self.options.with_gui else "OFF"
         cmake.definitions["WITH_ORBITGL"] = "ON" if self.options.with_orbitgl else "OFF"
+        cmake.definitions["WITH_VULKAN_LAYER"] = "ON" if self.options.with_vulkan_layer else "OFF"
         if self.options.with_gui:
             if self.options.with_crash_handling:
                 cmake.definitions["WITH_CRASH_HANDLING"] = "ON"

--- a/third_party/conan/configs/linux/profiles/ggp_debug
+++ b/third_party/conan/configs/linux/profiles/ggp_debug
@@ -12,6 +12,7 @@ build_type=Debug
 [options]
 OrbitProfiler:with_gui=False
 OrbitProfiler:with_orbitgl=False
+OrbitProfiler:with_vulkan_layer=True
 [build_requires]
 &: cmake_installer/3.16.3@conan/stable
 ggp_sdk/1.43.0.14282@orbitdeps/stable

--- a/third_party/conan/configs/linux/profiles/ggp_release
+++ b/third_party/conan/configs/linux/profiles/ggp_release
@@ -12,6 +12,7 @@ build_type=Release
 [options]
 OrbitProfiler:with_gui=False
 OrbitProfiler:with_orbitgl=False
+OrbitProfiler:with_vulkan_layer=True
 [build_requires]
 &: cmake_installer/3.16.3@conan/stable
 ggp_sdk/1.43.0.14282@orbitdeps/stable

--- a/third_party/conan/configs/linux/profiles/ggp_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/ggp_relwithdebinfo
@@ -12,6 +12,7 @@ build_type=RelWithDebInfo
 [options]
 OrbitProfiler:with_gui=False
 OrbitProfiler:with_orbitgl=False
+OrbitProfiler:with_vulkan_layer=True
 [build_requires]
 &: cmake_installer/3.16.3@conan/stable
 ggp_sdk/1.43.0.14282@orbitdeps/stable

--- a/third_party/conan/configs/windows/profiles/ggp_debug
+++ b/third_party/conan/configs/windows/profiles/ggp_debug
@@ -15,6 +15,7 @@ build_type=Debug
 [options]
 OrbitProfiler:with_gui=False
 OrbitProfiler:with_orbitgl=False
+OrbitProfiler:with_vulkan_layer=True
 [build_requires]
 &: cmake_installer/3.16.3@conan/stable
 ggp_sdk/1.43.0.14282@orbitdeps/stable

--- a/third_party/conan/configs/windows/profiles/ggp_release
+++ b/third_party/conan/configs/windows/profiles/ggp_release
@@ -15,6 +15,7 @@ build_type=Release
 [options]
 OrbitProfiler:with_gui=False
 OrbitProfiler:with_orbitgl=False
+OrbitProfiler:with_vulkan_layer=True
 [build_requires]
 &: cmake_installer/3.16.3@conan/stable
 ggp_sdk/1.43.0.14282@orbitdeps/stable

--- a/third_party/conan/configs/windows/profiles/ggp_relwithdebinfo
+++ b/third_party/conan/configs/windows/profiles/ggp_relwithdebinfo
@@ -15,6 +15,7 @@ build_type=RelWithDebInfo
 [options]
 OrbitProfiler:with_gui=False
 OrbitProfiler:with_orbitgl=False
+OrbitProfiler:with_vulkan_layer=True
 [build_requires]
 &: cmake_installer/3.16.3@conan/stable
 ggp_sdk/1.43.0.14282@orbitdeps/stable


### PR DESCRIPTION
This wrapper provides methods to create a Vulkan dispatch table,
perform function look-up (queries on that table) and provide the
information whether certain extensions are available in the next
layer (or in the driver).

Test: Compile & run tests
Bug: http://b/168200502