### PR TITLE
Read buffer optimizations

### DIFF
--- a/OrbitSshQt/Tunnel.cpp
+++ b/OrbitSshQt/Tunnel.cpp
@@ -221,7 +221,7 @@ void Tunnel::SetError(std::error_code e) {
 // local_socket -> write_buffer_
 void Tunnel::HandleIncomingDataLocalSocket() {
   const auto data = local_socket_->readAll();
-  write_buffer_.append(data.toStdString());
+  write_buffer_.insert(write_buffer_.end(), data.begin(), data.end());
 
   const auto result = writeToChannel();
 


### PR DESCRIPTION
Two smallish optimizations to the SSH buffer handling code. This avoids superfluous allocations and makes the code faster.

I tried that with @pierricgimmig new introspection feature and saw improvements up to a factor of 2 or 3. No changes for small data chunks (as expected) but for larger ones the time spent in the copy-function went down quite a bit. For my example it was 25ms before, afterwards 10ms - 15ms.

So I'm rather confident this change doesn't make the situation worse. Obviously more can be done.