### PR TITLE
Add OverlayWidget class

### DIFF
--- a/OrbitQt/CMakeLists.txt
+++ b/OrbitQt/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(
           orbittreeview.h
           opengldetect.h
           ProcessItemModel.h
+          OverlayWidget.h
           processlauncherwidget.h
           resource.h
           servicedeploymanager.h
@@ -67,6 +68,8 @@ target_sources(
           orbittreeview.cpp
           opengldetect.cpp
           ProcessItemModel.cpp
+          OverlayWidget.cpp
+          OverlayWidget.ui
           processlauncherwidget.cpp
           servicedeploymanager.cpp
           TutorialContent.cpp

--- a/OrbitQt/OverlayWidget.cpp
+++ b/OrbitQt/OverlayWidget.cpp
@@ -1,0 +1,38 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "OverlayWidget.h"
+
+namespace {
+
+// This color is used as a "background" for the overlay. The alpha value of 128 makes it
+// transparent
+const QColor kOverlayShadeColor{100, 100, 100, 128};
+
+}  // namespace
+
+namespace orbit_qt {
+
+OverlayWidget::OverlayWidget(QWidget* parent)
+    : QWidget(parent), ui_(std::make_unique<Ui::OverlayWidget>()) {
+  CHECK(parent != nullptr);
+  parent->installEventFilter(this);
+  ui_->setupUi(this);
+  ui_->cancelButton->setEnabled(true);
+
+  QObject::connect(ui_->cancelButton, &QPushButton::clicked, this, [this] { emit Cancelled(); });
+}
+
+void OverlayWidget::paintEvent(QPaintEvent* /*event*/) {
+  QPainter(this).fillRect(rect(), kOverlayShadeColor);
+}
+
+bool OverlayWidget::eventFilter(QObject* obj, QEvent* event) {
+  if (obj == parent() && event->type() == QEvent::Resize) {
+    resize(parentWidget()->size());
+  }
+  return false;
+}
+
+}  // namespace orbit_qt

--- a/OrbitQt/OverlayWidget.h
+++ b/OrbitQt/OverlayWidget.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_QT_OVERLAY_WIDGET_H_
+#define ORBIT_QT_OVERLAY_WIDGET_H_
+
+#include <QEvent>
+#include <QObject>
+#include <QPainter>
+#include <QWidget>
+#include <memory>
+
+#include "OrbitBase/Logging.h"
+#include "ui_OverlayWidget.h"
+
+namespace orbit_qt {
+
+class OverlayWidget : public QWidget {
+  Q_OBJECT
+  Q_PROPERTY(bool spinning READ IsSpinning WRITE SetSpinning)
+  Q_PROPERTY(bool cancelable READ IsCancelable WRITE SetCancelable);
+  Q_PROPERTY(QString statusMessage READ GetStatusMessage WRITE SetStatusMessage)
+  Q_PROPERTY(QString buttonMessage READ GetButtonMessage WRITE SetButtonMessage);
+
+ public:
+  explicit OverlayWidget(QWidget* parent);
+
+ protected:
+  void paintEvent(QPaintEvent* /*event*/) override;
+  bool eventFilter(QObject* obj, QEvent* event) override;
+
+ private slots:
+  void SetSpinning(bool value) { ui_->progressBar->setVisible(value); }
+  void SetCancelable(bool value) { ui_->cancelButton->setVisible(value); }
+  void SetStatusMessage(const QString& message) { ui_->messageLabel->setText(message); }
+  void SetButtonMessage(const QString& message) { ui_->cancelButton->setText(message); }
+
+ signals:
+  void Cancelled();
+
+ private:
+  std::unique_ptr<Ui::OverlayWidget> ui_;
+
+  [[nodiscard]] bool IsSpinning() const { return ui_->progressBar->isVisible(); }
+  [[nodiscard]] bool IsCancelable() const { return ui_->cancelButton->isVisible(); }
+  [[nodiscard]] QString GetStatusMessage() const { return ui_->messageLabel->text(); }
+  [[nodiscard]] QString GetButtonMessage() const { return ui_->cancelButton->text(); }
+};
+
+}  // namespace orbit_qt
+
+#endif  // ORBIT_QT_OVERLAY_WIDGET_H_

--- a/OrbitQt/OverlayWidget.ui
+++ b/OrbitQt/OverlayWidget.ui
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>OverlayWidget</class>
+ <widget class="QWidget" name="OverlayWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>326</width>
+    <height>395</height>
+   </rect>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <property name="spacing">
+      <number>15</number>
+     </property>
+     <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0,0">
+       <item>
+        <spacer name="horizontalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QProgressBar" name="progressBar">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximum">
+          <number>0</number>
+         </property>
+         <property name="value">
+          <number>-1</number>
+         </property>
+         <property name="textVisible">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="QLabel" name="messageLabel">
+       <property name="text">
+        <string>Loading...</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QPushButton" name="cancelButton">
+         <property name="text">
+          <string>Cancel</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <spacer name="verticalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../icons/orbiticons.qrc"/>
+ </resources>
+ <connections/>
+</ui>


### PR DESCRIPTION
This class is an overlay above any other large enough widget
(e.g. a table). The overlay provides an animation to signal to the user
that something is happening an the program is not frozen. It also provides
a status message field and a button to cancel. Whoever uses the
OverlayWidget has to make sure to react to the "Cancelled" signal, and
shutdown the overlay afterwards (either setVisible(false) or remove all
together)


I do not know if having a unit test for this class makes sense. I did not add one for now. 