### PR TITLE
Draw only in negative y-coordinates on Capture Window

### DIFF
--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -461,8 +461,6 @@ bool CaptureWindow::ShouldAutoZoom() const { return GOrbitApp->IsCapturing(); }
 
 void CaptureWindow::Draw() {
   ORBIT_SCOPE("CaptureWindow::Draw");
-  world_max_y_ = 1.5f * ScreenToWorldHeight(static_cast<int>(slider_->GetPixelHeight()));
-
   if (ShouldAutoZoom()) {
     ZoomAll();
   }

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -1099,7 +1099,8 @@ int TimeGraph::FindMovingTrackIndex() {
 }
 
 void TimeGraph::UpdateTracks(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode) {
-  float current_y = -layout_.GetSchedulerTrackOffset();
+  // Make sure track tab fits in the viewport.
+  float current_y = -layout_.GetSchedulerTrackOffset() - layout_.GetTrackTabHeight();
   float pinned_tracks_height = 0.f;
 
   // Draw pinned tracks
@@ -1116,8 +1117,6 @@ void TimeGraph::UpdateTracks(uint64_t min_tick, uint64_t max_tick, PickingMode p
     current_y -= height;
     pinned_tracks_height += height;
   }
-
-  current_y = -layout_.GetSchedulerTrackOffset() - pinned_tracks_height;
 
   // Draw unpinned tracks
   for (auto& track : sorted_filtered_tracks_) {

--- a/OrbitGl/TimeGraphLayout.h
+++ b/OrbitGl/TimeGraphLayout.h
@@ -29,7 +29,7 @@ class TimeGraphLayout {
   float GetBottomMargin() const;
   float GetTopMargin() const { return GetSchedulerTrackOffset(); }
   float GetRightMargin() const { return right_margin_; }
-  float GetSchedulerTrackOffset() const { return scheduler_track_offset_ * scale_; }
+  float GetSchedulerTrackOffset() const { return scheduler_track_offset_; }
   float GetSpaceBetweenTracks() const { return space_between_tracks_ * scale_; }
   float GetSpaceBetweenCores() const { return space_between_cores_ * scale_; }
   float GetSpaceBetweenGpuDepths() const { return space_between_gpu_depths_ * scale_; }


### PR DESCRIPTION
Solving 2 issues.
First b/173575460, a regression in 1.55 about wrong y-initialization when loading
a capture (probably from https://github.com/google/orbit/commit/1a58be3766c411bb2d143872eb9b95299db8f209).

Starting orbit by loading a capture:
![Screen Shot 2020-11-24 at 18 16 33](https://user-images.githubusercontent.com/8610429/100129018-49474b00-2e81-11eb-9fec-76fc6278f8fb.png)

Second, an issue with vertical zooming where you stop seeing the top
part of the scheduler track because it is on positive y-coordinates.

Orbit after zooming-in a lot:
![Screen Shot 2020-11-24 at 18 16 51](https://user-images.githubusercontent.com/8610429/100129046-4fd5c280-2e81-11eb-99c5-0a6f909b5700.png)
