### PR TITLE
Manual instrumentation bug fixes

### DIFF
--- a/Orbit.h
+++ b/Orbit.h
@@ -282,10 +282,8 @@ enum class Color : uint32_t {
 
 #if defined(_WIN32)
 #define ORBIT_STUB inline __declspec(noinline)
-#define ORBIT_FORCE_INLINE __forceinline
 #else
 #define ORBIT_STUB inline __attribute__((noinline))
-#define ORBIT_FORCE_INLINE __attribute__((always_inline))
 #endif
 
 namespace orbit_api {
@@ -345,7 +343,7 @@ union EncodedEvent {
 };
 
 template <typename Dest, typename Source>
-ORBIT_FORCE_INLINE Dest Encode(const Source& source) {
+inline Dest Encode(const Source& source) {
   static_assert(sizeof(Source) <= sizeof(Dest), "orbit_api::Encode destination type is too small");
   Dest dest = 0;
   std::memcpy(&dest, &source, sizeof(Source));
@@ -353,7 +351,7 @@ ORBIT_FORCE_INLINE Dest Encode(const Source& source) {
 }
 
 template <typename Dest, typename Source>
-ORBIT_FORCE_INLINE Dest Decode(const Source& source) {
+inline Dest Decode(const Source& source) {
   static_assert(sizeof(Dest) <= sizeof(Source), "orbit_api::Decode destination type is too big");
   Dest dest = 0;
   std::memcpy(&dest, &source, sizeof(Dest));
@@ -382,27 +380,27 @@ constexpr const char* kNameNullPtr = nullptr;
 constexpr uint64_t kDataZero = 0;
 constexpr orbit::Color kColorAuto = orbit::Color::kAuto;
 
-ORBIT_FORCE_INLINE void Start(const char* name, orbit::Color color) {
+inline void Start(const char* name, orbit::Color color) {
   EncodedEvent e(EventType::kScopeStart, name, kDataZero, color);
   Start(e.args[0], e.args[1], e.args[2], e.args[3], e.args[4], e.args[5]);
 }
 
-ORBIT_FORCE_INLINE void Stop() {
+inline void Stop() {
   EncodedEvent e(EventType::kScopeStop);
   Stop(e.args[0], e.args[1], e.args[2], e.args[3], e.args[4], e.args[5]);
 }
 
-ORBIT_FORCE_INLINE void StartAsync(const char* name, uint64_t id, orbit::Color color) {
+inline void StartAsync(const char* name, uint64_t id, orbit::Color color) {
   EncodedEvent e(EventType::kScopeStartAsync, name, id, color);
   StartAsync(e.args[0], e.args[1], e.args[2], e.args[3], e.args[4], e.args[5]);
 }
 
-ORBIT_FORCE_INLINE void StopAsync(uint64_t id) {
+inline void StopAsync(uint64_t id) {
   EncodedEvent e(EventType::kScopeStopAsync, kNameNullPtr, id, kColorAuto);
   StopAsync(e.args[0], e.args[1], e.args[2], e.args[3], e.args[4], e.args[5]);
 }
 
-ORBIT_FORCE_INLINE void AsyncString(const char* str, uint64_t id, orbit::Color color) {
+inline void AsyncString(const char* str, uint64_t id, orbit::Color color) {
   if (str == nullptr) return;
   constexpr size_t chunk_size = kMaxEventStringSize - 1;
   const char* end = str + strlen(str);
@@ -415,8 +413,7 @@ ORBIT_FORCE_INLINE void AsyncString(const char* str, uint64_t id, orbit::Color c
   }
 }
 
-ORBIT_FORCE_INLINE void TrackValue(EventType type, const char* name, uint64_t value,
-                                   orbit::Color color) {
+inline void TrackValue(EventType type, const char* name, uint64_t value, orbit::Color color) {
   EncodedEvent e(type, name, value, color);
   TrackValue(e.args[0], e.args[1], e.args[2], e.args[3], e.args[4], e.args[5]);
 }

--- a/OrbitClientData/FunctionUtils.cpp
+++ b/OrbitClientData/FunctionUtils.cpp
@@ -55,11 +55,11 @@ std::unique_ptr<FunctionInfo> CreateFunctionInfo(const SymbolInfo& symbol_info,
 
 const absl::flat_hash_map<const char*, FunctionInfo::OrbitType>& GetFunctionNameToOrbitTypeMap() {
   static absl::flat_hash_map<const char*, FunctionInfo::OrbitType> function_name_to_type_map{
-      {"Start" STUB_PARAMS, FunctionInfo::kOrbitTimerStart},
-      {"Stop" STUB_PARAMS, FunctionInfo::kOrbitTimerStop},
-      {"StartAsync" STUB_PARAMS, FunctionInfo::kOrbitTimerStartAsync},
-      {"StopAsync" STUB_PARAMS, FunctionInfo::kOrbitTimerStopAsync},
-      {"TrackValue" STUB_PARAMS, FunctionInfo::kOrbitTrackValue}};
+      {"orbit_api::Start" STUB_PARAMS, FunctionInfo::kOrbitTimerStart},
+      {"orbit_api::Stop" STUB_PARAMS, FunctionInfo::kOrbitTimerStop},
+      {"orbit_api::StartAsync" STUB_PARAMS, FunctionInfo::kOrbitTimerStartAsync},
+      {"orbit_api::StopAsync" STUB_PARAMS, FunctionInfo::kOrbitTimerStopAsync},
+      {"orbit_api::TrackValue" STUB_PARAMS, FunctionInfo::kOrbitTrackValue}};
   return function_name_to_type_map;
 }
 

--- a/OrbitClientData/FunctionUtils.cpp
+++ b/OrbitClientData/FunctionUtils.cpp
@@ -50,13 +50,16 @@ std::unique_ptr<FunctionInfo> CreateFunctionInfo(const SymbolInfo& symbol_info,
   return function_info;
 }
 
+#define STUB_PARAMS \
+  "(unsigned long, unsigned long, unsigned long, unsigned long, unsigned long, unsigned long)"
+
 const absl::flat_hash_map<const char*, FunctionInfo::OrbitType>& GetFunctionNameToOrbitTypeMap() {
   static absl::flat_hash_map<const char*, FunctionInfo::OrbitType> function_name_to_type_map{
-      {"Start(", FunctionInfo::kOrbitTimerStart},
-      {"Stop(", FunctionInfo::kOrbitTimerStop},
-      {"StartAsync(", FunctionInfo::kOrbitTimerStartAsync},
-      {"StopAsync(", FunctionInfo::kOrbitTimerStopAsync},
-      {"TrackValue(", FunctionInfo::kOrbitTrackValue}};
+      {"Start" STUB_PARAMS, FunctionInfo::kOrbitTimerStart},
+      {"Stop" STUB_PARAMS, FunctionInfo::kOrbitTimerStop},
+      {"StartAsync" STUB_PARAMS, FunctionInfo::kOrbitTimerStartAsync},
+      {"StopAsync" STUB_PARAMS, FunctionInfo::kOrbitTimerStopAsync},
+      {"TrackValue" STUB_PARAMS, FunctionInfo::kOrbitTrackValue}};
   return function_name_to_type_map;
 }
 
@@ -67,6 +70,7 @@ bool SetOrbitTypeFromName(FunctionInfo* func) {
   if (absl::StartsWith(name, "orbit_api::")) {
     for (auto& pair : GetFunctionNameToOrbitTypeMap()) {
       if (absl::StrContains(name, pair.first)) {
+        LOG("Found orbit_api function: %s", name);
         func->set_orbit_type(pair.second);
         return true;
       }

--- a/OrbitClientData/FunctionUtils.cpp
+++ b/OrbitClientData/FunctionUtils.cpp
@@ -50,16 +50,15 @@ std::unique_ptr<FunctionInfo> CreateFunctionInfo(const SymbolInfo& symbol_info,
   return function_info;
 }
 
-#define STUB_PARAMS \
-  "(unsigned long, unsigned long, unsigned long, unsigned long, unsigned long, unsigned long)"
-
-const absl::flat_hash_map<const char*, FunctionInfo::OrbitType>& GetFunctionNameToOrbitTypeMap() {
-  static absl::flat_hash_map<const char*, FunctionInfo::OrbitType> function_name_to_type_map{
-      {"orbit_api::Start" STUB_PARAMS, FunctionInfo::kOrbitTimerStart},
-      {"orbit_api::Stop" STUB_PARAMS, FunctionInfo::kOrbitTimerStop},
-      {"orbit_api::StartAsync" STUB_PARAMS, FunctionInfo::kOrbitTimerStartAsync},
-      {"orbit_api::StopAsync" STUB_PARAMS, FunctionInfo::kOrbitTimerStopAsync},
-      {"orbit_api::TrackValue" STUB_PARAMS, FunctionInfo::kOrbitTrackValue}};
+const absl::flat_hash_map<std::string, FunctionInfo::OrbitType>& GetFunctionNameToOrbitTypeMap() {
+  const char* kStubParams =
+      "(unsigned long, unsigned long, unsigned long, unsigned long, unsigned long, unsigned long)";
+  static absl::flat_hash_map<std::string, FunctionInfo::OrbitType> function_name_to_type_map{
+      {absl::StrCat("orbit_api::Start", kStubParams), FunctionInfo::kOrbitTimerStart},
+      {absl::StrCat("orbit_api::Stop", kStubParams), FunctionInfo::kOrbitTimerStop},
+      {absl::StrCat("orbit_api::StartAsync", kStubParams), FunctionInfo::kOrbitTimerStartAsync},
+      {absl::StrCat("orbit_api::StopAsync", kStubParams), FunctionInfo::kOrbitTimerStopAsync},
+      {absl::StrCat("orbit_api::TrackValue", kStubParams), FunctionInfo::kOrbitTrackValue}};
   return function_name_to_type_map;
 }
 

--- a/OrbitClientData/ModuleManagerTest.cpp
+++ b/OrbitClientData/ModuleManagerTest.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include "OrbitClientData/FunctionUtils.h"
 #include "OrbitClientData/ModuleData.h"
 #include "OrbitClientData/ModuleManager.h"
 #include "capture_data.pb.h"
@@ -190,10 +191,15 @@ TEST(ModuleManager, GetOrbitFunctionsOfProcess) {
     symbol_info->set_name("mangled_not_an_orbit_function");
     symbol_info->set_demangled_name("not an orbit function");
   }
+
+  const auto& orbit_name_to_orbit_type_map = FunctionUtils::GetFunctionNameToOrbitTypeMap();
+  const std::string kOrbitName = orbit_name_to_orbit_type_map.begin()->first;
+  const std::string kOrbitNameMangled = absl::StrFormat("mangled_%s", kOrbitName);
+
   {
     SymbolInfo* symbol_info = module_symbols.add_symbol_infos();
-    symbol_info->set_name("mangled_orbit_api::Start()");
-    symbol_info->set_demangled_name("orbit_api::Start()");
+    symbol_info->set_name(kOrbitNameMangled);
+    symbol_info->set_demangled_name(kOrbitName);
     symbol_info->set_address(500);
   }
 
@@ -207,8 +213,8 @@ TEST(ModuleManager, GetOrbitFunctionsOfProcess) {
     ASSERT_EQ(functions.size(), 1);
 
     FunctionInfo& function{functions[0]};
-    EXPECT_EQ(function.name(), "mangled_orbit_api::Start()");
-    EXPECT_EQ(function.pretty_name(), "orbit_api::Start()");
+    EXPECT_EQ(function.name(), kOrbitNameMangled);
+    EXPECT_EQ(function.pretty_name(), kOrbitName);
     EXPECT_EQ(function.address(), 500);
   }
 }

--- a/OrbitClientData/include/OrbitClientData/FunctionUtils.h
+++ b/OrbitClientData/include/OrbitClientData/FunctionUtils.h
@@ -37,7 +37,7 @@ namespace FunctionUtils {
 [[nodiscard]] std::unique_ptr<orbit_client_protos::FunctionInfo> CreateFunctionInfo(
     const orbit_grpc_protos::SymbolInfo& symbol_info, const std::string& module_path);
 
-[[nodiscard]] const absl::flat_hash_map<const char*, orbit_client_protos::FunctionInfo::OrbitType>&
+[[nodiscard]] const absl::flat_hash_map<std::string, orbit_client_protos::FunctionInfo::OrbitType>&
 GetFunctionNameToOrbitTypeMap();
 bool SetOrbitTypeFromName(orbit_client_protos::FunctionInfo* func);
 

--- a/OrbitClientData/include/OrbitClientData/FunctionUtils.h
+++ b/OrbitClientData/include/OrbitClientData/FunctionUtils.h
@@ -37,6 +37,8 @@ namespace FunctionUtils {
 [[nodiscard]] std::unique_ptr<orbit_client_protos::FunctionInfo> CreateFunctionInfo(
     const orbit_grpc_protos::SymbolInfo& symbol_info, const std::string& module_path);
 
+[[nodiscard]] const absl::flat_hash_map<const char*, orbit_client_protos::FunctionInfo::OrbitType>&
+GetFunctionNameToOrbitTypeMap();
 bool SetOrbitTypeFromName(orbit_client_protos::FunctionInfo* func);
 
 }  // namespace FunctionUtils

--- a/OrbitTest/OrbitTest.cpp
+++ b/OrbitTest/OrbitTest.cpp
@@ -12,7 +12,7 @@
 #include <sstream>
 #include <thread>
 
-#include "OrbitBase/Tracing.h"
+#include "../Orbit.h"
 #include "absl/strings/str_format.h"
 
 #if __linux__


### PR DESCRIPTION
- Include parameters when searching for orbit_api functions to hook
  into to  make sure we are hooking the stubs and not the compiled
  implementation of those functions (b/172988899)
- Remove force inlining of non-stub functions as it is not required
  anymore. (Also fixes warning with GCC)
- Include Orbit.h in OrbitTest.cpp, not Tracing.h. (OrbitTest needs to use the api directly)

Tests: 
- Profiling OrbitTest produces expected manual instrumentation scopes
- Profiling OrbitService doesn't generate garbled manual instrumentation scopes