### PR TITLE
Add Grpc Protos used for the Vulkan Layer.

### DIFF
--- a/OrbitCaptureClient/CaptureEventProcessor.cpp
+++ b/OrbitCaptureClient/CaptureEventProcessor.cpp
@@ -64,6 +64,9 @@ void CaptureEventProcessor::ProcessEvent(const CaptureEvent& event) {
     case CaptureEvent::kTracepointEvent:
       ProcessTracepointEvent(event.tracepoint_event());
       break;
+    case CaptureEvent::kGpuQueueSubmission:
+      UNREACHABLE();
+      break;
     case CaptureEvent::EVENT_NOT_SET:
       ERROR("CaptureEvent::EVENT_NOT_SET read from Capture's gRPC stream");
       break;

--- a/OrbitGrpcProtos/capture.proto
+++ b/OrbitGrpcProtos/capture.proto
@@ -128,6 +128,48 @@ message GpuJob {
   uint64 dma_fence_signaled_time_ns = 11;
 }
 
+message GpuQueueSubmission {
+  GpuQueueSubmissionMetaInfo meta_info = 1;
+  repeated GpuSubmitInfo submit_infos = 2;
+  repeated GpuDebugMarker completed_markers = 3;
+  int32 num_begin_markers = 4;
+}
+
+message GpuQueueSubmissionMetaInfo {
+  int32 tid = 1;
+  uint64 pre_submission_cpu_timestamp = 2;
+  uint64 post_submission_cpu_timestamp = 3;
+}
+
+message GpuSubmitInfo {
+  repeated GpuCommandBuffer command_buffers = 1;
+}
+
+message GpuCommandBuffer {
+  uint64 begin_gpu_timestamp_ns = 1;
+  uint64 end_gpu_timestamp_ns = 2;
+}
+
+message GpuDebugMarkerBeginInfo {
+  GpuQueueSubmissionMetaInfo meta_info = 1;
+  uint64 gpu_timestamp_ns = 2;
+}
+
+message GpuDebugMarker {
+  GpuDebugMarkerBeginInfo begin_marker = 1;
+  uint64 end_gpu_timestamp_ns = 2;
+  uint64 text_key = 3;
+  int32 depth = 4;
+  Color color = 5;
+}
+
+message Color {
+  float red = 1;
+  float green = 2;
+  float blue = 3;
+  float alpha = 4;
+}
+
 message ThreadName {
   int32 pid = 1;  // Note that pid is currently not set.
   int32 tid = 2;
@@ -175,50 +217,6 @@ message AddressInfo {
     string map_name = 5;
     uint64 map_name_key = 6;
   }
-}
-
-message GpuQueueSubmission {
-  GpuQueueSubmissionMetaInfo meta_info = 1;
-  repeated GpuSubmitInfo submit_infos = 2;
-  repeated GpuDebugMarker completed_markers = 3;
-  uint32 num_begin_markers = 4;
-}
-
-message GpuQueueSubmissionMetaInfo {
-  int32 thread_id = 1;
-  uint64 pre_submission_cpu_timestamp = 2;
-  uint64 post_submission_cpu_timestamp = 3;
-}
-
-message GpuSubmitInfo {
-  repeated GpuCommandBuffer command_buffers = 1;
-}
-
-message GpuCommandBuffer {
-  uint64 begin_gpu_timestamp_ns = 1;
-  uint64 end_gpu_timestamp_ns = 2;
-}
-
-message GpuDebugMarkerBeginInfo {
-  GpuQueueSubmissionMetaInfo meta_info = 1;
-  uint64 gpu_timestamp_ns = 2;
-}
-
-message GpuDebugMarker {
-  oneof begin_marker_option {
-    GpuDebugMarkerBeginInfo begin_marker = 1;
-  };
-  uint64 end_gpu_timestamp_ns = 2;
-  uint64 text_key = 3;
-  uint64 depth = 4;
-  Color color = 5;
-}
-
-message Color {
-  float red = 1;
-  float green = 2;
-  float blue = 3;
-  float alpha = 4;
 }
 
 message CaptureEvent {

--- a/OrbitGrpcProtos/capture.proto
+++ b/OrbitGrpcProtos/capture.proto
@@ -227,12 +227,12 @@ message CaptureEvent {
     FunctionCall function_call = 4;
     InternedString interned_string = 5;
     GpuJob gpu_job = 6;
+    GpuQueueSubmission gpu_queue_submission = 13;
     ThreadName thread_name = 7;
     ThreadStateSlice thread_state_slice = 11;
     AddressInfo address_info = 8;
     InternedTracepointInfo interned_tracepoint_info = 9;
     TracepointEvent tracepoint_event = 10;
     IntrospectionScope introspection_scope = 12;
-    GpuQueueSubmission gpu_queue_submission = 13;
   }
 }

--- a/OrbitGrpcProtos/capture.proto
+++ b/OrbitGrpcProtos/capture.proto
@@ -104,7 +104,7 @@ message InternedTracepointInfo {
 message TracepointEvent {
   int32 pid = 1;
   int32 tid = 2;
-  int64 time = 3;
+  uint64 time = 3;
   int32 cpu = 4;
   oneof tracepoint_info_or_key {
     TracepointInfo tracepoint_info = 5;
@@ -177,6 +177,50 @@ message AddressInfo {
   }
 }
 
+message GpuQueueSubmission {
+  GpuQueueSubmissionMetaInfo meta_info = 1;
+  repeated GpuSubmitInfo submit_infos = 2;
+  repeated GpuDebugMarker completed_markers = 3;
+  uint32 num_begin_markers = 4;
+}
+
+message GpuQueueSubmissionMetaInfo {
+  int32 thread_id = 1;
+  uint64 pre_submission_cpu_timestamp = 2;
+  uint64 post_submission_cpu_timestamp = 3;
+}
+
+message GpuSubmitInfo {
+  repeated GpuCommandBuffer command_buffers = 1;
+}
+
+message GpuCommandBuffer {
+  uint64 begin_gpu_timestamp_ns = 1;
+  uint64 end_gpu_timestamp_ns = 2;
+}
+
+message GpuDebugMarkerBeginInfo {
+  GpuQueueSubmissionMetaInfo meta_info = 1;
+  uint64 gpu_timestamp_ns = 2;
+}
+
+message GpuDebugMarker {
+  oneof begin_marker_option {
+    GpuDebugMarkerBeginInfo begin_marker = 1;
+  };
+  uint64 end_gpu_timestamp_ns = 2;
+  uint64 text_key = 3;
+  uint64 depth = 4;
+  Color color = 5;
+}
+
+message Color {
+  float red = 1;
+  float green = 2;
+  float blue = 3;
+  float alpha = 4;
+}
+
 message CaptureEvent {
   oneof event {
     SchedulingSlice scheduling_slice = 1;
@@ -191,5 +235,6 @@ message CaptureEvent {
     InternedTracepointInfo interned_tracepoint_info = 9;
     TracepointEvent tracepoint_event = 10;
     IntrospectionScope introspection_scope = 12;
+    GpuQueueSubmission gpu_queue_submission = 13;
   }
 }

--- a/OrbitGrpcProtos/capture.proto
+++ b/OrbitGrpcProtos/capture.proto
@@ -132,7 +132,8 @@ message GpuQueueSubmission {
   GpuQueueSubmissionMetaInfo meta_info = 1;
   repeated GpuSubmitInfo submit_infos = 2;
   repeated GpuDebugMarker completed_markers = 3;
-  int32 num_begin_markers = 4; // This is the total number of begin markers submitted in this submission.
+  // This is the total number of begin markers submitted in this submission.
+  int32 num_begin_markers = 4;
 }
 
 message GpuQueueSubmissionMetaInfo {
@@ -151,8 +152,9 @@ message GpuCommandBuffer {
 }
 
 message GpuDebugMarkerBeginInfo {
-  // Begin markers can be submitted in a different submission then the end markers, thus the submission meta info
-  // of a begin marker might differ from the one of the submission containing the complete debug marker.
+  // Begin markers can be submitted in a different submission then the end
+  // markers, thus the submission meta info of a begin marker might differ from
+  // the one of the submission containing the complete debug marker.
   GpuQueueSubmissionMetaInfo meta_info = 1;
   uint64 gpu_timestamp_ns = 2;
 }

--- a/OrbitGrpcProtos/capture.proto
+++ b/OrbitGrpcProtos/capture.proto
@@ -132,7 +132,7 @@ message GpuQueueSubmission {
   GpuQueueSubmissionMetaInfo meta_info = 1;
   repeated GpuSubmitInfo submit_infos = 2;
   repeated GpuDebugMarker completed_markers = 3;
-  int32 num_begin_markers = 4;
+  int32 num_begin_markers = 4; // This is the total number of begin markers submitted in this submission.
 }
 
 message GpuQueueSubmissionMetaInfo {
@@ -151,6 +151,8 @@ message GpuCommandBuffer {
 }
 
 message GpuDebugMarkerBeginInfo {
+  // Begin markers can be submitted in a different submission then the end markers, thus the submission meta info
+  // of a begin marker might differ from the one of the submission containing the complete debug marker.
   GpuQueueSubmissionMetaInfo meta_info = 1;
   uint64 gpu_timestamp_ns = 2;
 }

--- a/OrbitGrpcProtos/capture.proto
+++ b/OrbitGrpcProtos/capture.proto
@@ -104,7 +104,7 @@ message InternedTracepointInfo {
 message TracepointEvent {
   int32 pid = 1;
   int32 tid = 2;
-  uint64 time = 3;
+  int64 time = 3;
   int32 cpu = 4;
   oneof tracepoint_info_or_key {
     TracepointInfo tracepoint_info = 5;
@@ -166,6 +166,7 @@ message GpuDebugMarker {
 }
 
 message Color {
+  // Color ranges are [0.f, 1.f] for the following fields.
   float red = 1;
   float green = 2;
   float blue = 3;


### PR DESCRIPTION
This adds a CaptureEvent proto for a Vulkan submission, which gathers
information from a single submission (VkQueueSubmit). In particular
it contains the timings for all the command buffers in that submission
and the debug markers opend/closed in that submission.

These protos can be then used by the layer to send information to the
service.

Test: Compile