### PR TITLE
Fix e2e test for frame tracks due to renaming

### DIFF
--- a/contrib/automation_tests/orbit_create_frame_track.py
+++ b/contrib/automation_tests/orbit_create_frame_track.py
@@ -44,7 +44,7 @@ def main(argv):
   for i in range(len(children)):
     if 'DrawFrame' in children[i].window_text():
       children[i].click_input(button='right')
-      main_wnd.child_window(title='Add frame track(s)', control_type="MenuItem").click_input()
+      main_wnd.child_window(title='Enable frame track(s)', control_type="MenuItem").click_input()
 
   # Since the frame track is only a visualization and only affects the 
   # OpenGL rendered capture window, there is currently no way to verify


### PR DESCRIPTION
The option to add a frame track was renamed for "Add frame track(s)" to
"Enable frame track(s)" as it is now possible to enable frame tracks
before taking a capture from the "Functions" tap and hence to have
a consistent naming in the options.

This caused the e2e test to fail, which is fixed with this change.

Bug: http://b/174214930
Tested: Ran e2e test locally with the new version.