### PR TITLE
Reduce ThreadPool.CheckGetNumberOfBusyThreads flakiness

### DIFF
--- a/OrbitBase/ThreadPoolTest.cpp
+++ b/OrbitBase/ThreadPoolTest.cpp
@@ -306,6 +306,9 @@ TEST(ThreadPool, CheckGetNumberOfBusyThreads) {
         << "actions_executed=" << actions_executed << ", expected 2";
   }
 
+  // Give it some time to finish the action
+  absl::SleepFor(absl::Milliseconds(50));
+
   // Check there are no busy threads anymore
   EXPECT_EQ(thread_pool->GetNumberOfBusyThreads(), 0);
 


### PR DESCRIPTION
Sleep before checking that the number of busy threads is reduced to 0

Test: run the test