### PR TITLE
Fix parsing /proc/$pid/maps

### DIFF
--- a/OrbitService/ServiceUtils.cpp
+++ b/OrbitService/ServiceUtils.cpp
@@ -5,6 +5,7 @@
 #include "ServiceUtils.h"
 
 #include <absl/base/casts.h>
+#include <absl/strings/match.h>
 #include <absl/strings/str_join.h>
 #include <absl/strings/str_split.h>
 #include <cxxabi.h>
@@ -76,7 +77,7 @@ ErrorMessageOr<std::vector<ModuleInfo>> ParseMaps(std::string_view proc_maps_dat
     const std::string& module_path = tokens[5];
 
     // This excludes mapped character or block devices.
-    if (module_path.rfind("/dev/", 0) == 0) continue;
+    if (absl::StartsWith(module_path, "/dev/")) continue;
 
     std::vector<std::string> addresses = absl::StrSplit(tokens[0], '-');
     if (addresses.size() != 2) continue;

--- a/OrbitService/ServiceUtils.cpp
+++ b/OrbitService/ServiceUtils.cpp
@@ -75,6 +75,9 @@ ErrorMessageOr<std::vector<ModuleInfo>> ParseMaps(std::string_view proc_maps_dat
 
     const std::string& module_path = tokens[5];
 
+    // This excludes mapped character or block devices.
+    if (module_path.rfind("/dev/", 0) == 0) continue;
+
     std::vector<std::string> addresses = absl::StrSplit(tokens[0], '-');
     if (addresses.size() != 2) continue;
 

--- a/OrbitService/ServiceUtilsTest.cpp
+++ b/OrbitService/ServiceUtilsTest.cpp
@@ -38,12 +38,13 @@ TEST(ServiceUtils, ParseMaps) {
   const Path text_file = test_path / "textfile.txt";
 
   {
-    // Testing correct size of result. The last entry has a valid path, but the
-    // executable flag is not set.
+    // Testing correct size of result. The entry with dev/zero is ignored due to the path starting
+    // with /dev/. The last entry has a valid path, but the executable flag is not set.
     const std::string data{absl::StrFormat(
         "7f687428f000-7f6874290000 r-xp 00009000 fe:01 661216                     "
         "/not/a/valid/file/path\n"
         "7f6874290000-7f6874297000 r-xp 00000000 fe:01 661214                     %s\n"
+        "7f6874290000-7f6874297000 r-xp 00000000 fe:01 661214                     /dev/zero\n"
         "7f6874290001-7f6874297002 r-dp 00000000 fe:01 661214                     %s\n",
         hello_world_path, text_file)};
     const auto result = ParseMaps(data);


### PR DESCRIPTION
It is possible to map some character or block devices. Previously these
were interpreted as candidates for modules and that lead to problems. We
now filter out every mapping with a pathname under "/dev/".

Bug: http://b/173358603
Test: Unit test & ran locally.