### PR TITLE
Dynamic tab layout

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -1530,6 +1530,10 @@ void OrbitApp::CrashOrbitService(CrashOrbitServiceRequest_CrashType crash_type) 
   }
 }
 
+CaptureClient::State OrbitApp::GetCaptureState() const {
+  return capture_client_ ? capture_client_->state() : CaptureClient::State::kStopped;
+}
+
 bool OrbitApp::IsCapturing() const {
   return capture_client_ ? capture_client_->IsCapturing() : false;
 }

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -571,9 +571,9 @@ void OrbitApp::SetSelectionReport(
   auto report = std::make_shared<SamplingReport>(std::move(sampling_profiler),
                                                  std::move(unique_callstacks), has_summary);
   DataView* callstack_data_view = GetOrCreateSelectionCallstackDataView();
-  selection_report_callback_(callstack_data_view, report);
 
   selection_report_ = report;
+  selection_report_callback_(callstack_data_view, report);
   FireRefreshCallbacks();
 }
 

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -777,6 +777,10 @@ bool OrbitApp::StartCapture() {
     return false;
   }
 
+  if (capture_window_ != nullptr) {
+    capture_window_->set_draw_help(false);
+  }
+
   std::vector<FunctionInfo> selected_functions = data_manager_->GetSelectedFunctions();
   std::vector<FunctionInfo> orbit_functions = module_manager_->GetOrbitFunctionsOfProcess(*process);
   selected_functions.insert(selected_functions.end(), orbit_functions.begin(),

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -87,7 +87,10 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   ErrorMessageOr<void> OnSaveCapture(const std::string& file_name);
   void OnLoadCapture(const std::string& file_name);
   void OnLoadCaptureCancelRequested();
+
+  [[nodiscard]] CaptureClient::State GetCaptureState() const;
   [[nodiscard]] bool IsCapturing() const;
+
   bool StartCapture();
   void StopCapture();
   void AbortCapture();

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -102,6 +102,11 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
     CHECK(capture_data_.has_value());
     return capture_data_.value();
   }
+
+  [[nodiscard]] bool HasSampleSelection() const {
+    return selection_report_ != nullptr && selection_report_->HasSamples();
+  }
+
   void ToggleDrawHelp();
   void ToggleCapture();
   void LoadFileMapping();
@@ -158,6 +163,10 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
 
   // This needs to be called from the main thread.
   [[nodiscard]] bool IsCaptureConnected(const CaptureData& capture) const;
+
+  [[nodiscard]] bool IsConnectedToInstance() const {
+    return grpc_channel_ != nullptr && grpc_channel_->GetState(false) == GRPC_CHANNEL_READY;
+  }
 
   // Callbacks
   using CaptureStartedCallback = std::function<void()>;

--- a/OrbitQt/TutorialContent.cpp
+++ b/OrbitQt/TutorialContent.cpp
@@ -12,6 +12,11 @@
 
 std::unique_ptr<TutorialOverlay> overlay;
 
+void StartTutorialSection(OrbitMainWindow* main_window, const std::string& section_name) {
+  main_window->RestoreDefaultTabLayout();
+  overlay->StartSection(section_name);
+}
+
 TutorialOverlay::StepSetup CreateTakeACaptureStepSetup(OrbitMainWindow* main_window) {
   TutorialOverlay::StepSetup setup;
 
@@ -30,12 +35,13 @@ void SetupAllSteps(OrbitMainWindow* main_window) {
   overlay->SetupStep("analyze", CreateAnalyzeResultsStepSetup(main_window));
 }
 
-void SetupDynamicInstrumentationTutorial(QMenu* menu) {
+void SetupDynamicInstrumentationTutorial(OrbitMainWindow* main_window, QMenu* menu) {
   auto action = menu->addAction("Dynamic Instrumentation");
 
   overlay->AddSection("dynamicInstrumentation", "Dynamic Instrumentation", {"capture", "analyze"});
-  QObject::connect(action, &QAction::triggered,
-                   []() { overlay->StartSection("dynamicInstrumentation"); });
+  QObject::connect(action, &QAction::triggered, [main_window]() {
+    StartTutorialSection(main_window, "dynamicInstrumentation");
+  });
 }
 
 void InitTutorials(OrbitMainWindow* main_window) {
@@ -55,7 +61,7 @@ void InitTutorials(OrbitMainWindow* main_window) {
   });
 
   SetupAllSteps(main_window);
-  SetupDynamicInstrumentationTutorial(tutorials_menu);
+  SetupDynamicInstrumentationTutorial(main_window, tutorials_menu);
 }
 
 void DeinitTutorials() { overlay.reset(); }

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -60,6 +60,8 @@ class OrbitMainWindow : public QMainWindow {
 
   bool eventFilter(QObject* watched, QEvent* event) override;
 
+  void RestoreDefaultTabLayout();
+
  protected:
   void closeEvent(QCloseEvent* event) override;
 
@@ -99,6 +101,8 @@ class OrbitMainWindow : public QMainWindow {
   void SetupCaptureToolbar();
   void SetupCodeView();
 
+  void SaveCurrentTabLayoutAsDefaultInMemory();
+
   void CreateTabBarContextMenu(QTabWidget* tab_widget, int tab_index, const QPoint pos);
   void UpdateCaptureStateDependentWidgets();
 
@@ -121,6 +125,12 @@ class OrbitMainWindow : public QMainWindow {
 
   // Status listener
   std::unique_ptr<StatusListener> status_listener_;
+
+  struct TabWidgetLayout {
+    std::vector<std::pair<QWidget*, QString>> tabs_and_titles;
+    int current_index;
+  };
+  std::map<QTabWidget*, TabWidgetLayout> default_tab_layout_;
 };
 
 #endif  // ORBIT_QT_ORBIT_MAIN_WINDOW_H_

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -123,6 +123,8 @@ class OrbitMainWindow : public QMainWindow {
   QIcon icon_keyboard_arrow_left_;
   QIcon icon_keyboard_arrow_right_;
 
+  bool capture_stop_requested_ = false;
+
   // Status listener
   std::unique_ptr<StatusListener> status_listener_;
 

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -101,6 +101,9 @@ class OrbitMainWindow : public QMainWindow {
 
   void CreateTabBarContextMenu(QTabWidget* tab_widget, int tab_index, const QPoint pos);
   void UpdateCaptureStateDependentWidgets();
+
+  void UpdateActiveTabsAfterSelection(bool selection_has_samples);
+
   QTabWidget* FindParentTabWidget(const QWidget* widget) const;
 
  private:

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -123,8 +123,6 @@ class OrbitMainWindow : public QMainWindow {
   QIcon icon_keyboard_arrow_left_;
   QIcon icon_keyboard_arrow_right_;
 
-  bool capture_stop_requested_ = false;
-
   // Status listener
   std::unique_ptr<StatusListener> status_listener_;
 

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -58,6 +58,8 @@ class OrbitMainWindow : public QMainWindow {
 
   Ui::OrbitMainWindow* GetUi() { return ui; }
 
+  bool eventFilter(QObject* watched, QEvent* event) override;
+
  protected:
   void closeEvent(QCloseEvent* event) override;
 
@@ -97,6 +99,10 @@ class OrbitMainWindow : public QMainWindow {
   void SetupCaptureToolbar();
   void SetupCodeView();
 
+  void CreateTabBarContextMenu(QTabWidget* tab_widget, int tab_index, const QPoint pos);
+  void UpdateCaptureStateDependentWidgets();
+  QTabWidget* FindParentTabWidget(const QWidget* widget) const;
+
  private:
   QApplication* m_App;
   Ui::OrbitMainWindow* ui;
@@ -106,6 +112,9 @@ class OrbitMainWindow : public QMainWindow {
   // Capture toolbar.
   QIcon icon_start_capture_;
   QIcon icon_stop_capture_;
+
+  QIcon icon_keyboard_arrow_left_;
+  QIcon icon_keyboard_arrow_right_;
 
   // Status listener
   std::unique_ptr<StatusListener> status_listener_;

--- a/OrbitQt/orbitmainwindow.ui
+++ b/OrbitQt/orbitmainwindow.ui
@@ -223,7 +223,7 @@ QPushButton:disabled {
       <widget class="QTabWidget" name="RightTabWidget">
        <property name="currentIndex">
         <number>0</number>
-	   </property>
+       </property>
        <property name="movable">
         <bool>true</bool>
        </property>

--- a/OrbitQt/orbitmainwindow.ui
+++ b/OrbitQt/orbitmainwindow.ui
@@ -54,6 +54,9 @@ QPushButton:disabled {
        <property name="currentIndex">
         <number>0</number>
        </property>
+       <property name="movable">
+        <bool>true</bool>
+       </property>
        <widget class="QWidget" name="HomeTab">
         <attribute name="title">
          <string>Home</string>
@@ -220,6 +223,9 @@ QPushButton:disabled {
       <widget class="QTabWidget" name="RightTabWidget">
        <property name="currentIndex">
         <number>0</number>
+	   </property>
+       <property name="movable">
+        <bool>true</bool>
        </property>
        <widget class="QWidget" name="FunctionsTab">
         <attribute name="title">


### PR DESCRIPTION
Allows users to move tabs in between the two panels.

This way, they can customize the layout at least slightly to best fit the current workflow.
Few things to note:

- Changes are **not** saved across sessions. This would be a nice addition and is in theory not that hard to do, but could introduce issues as soon as we update QT to a new version, or by changes introduced in Orbit itself, and this should be given some thought before implementing a quick-fix
- The functionality is a bit hidden behind a right-click menu on the tab bar. It would be nice if tabs could just be dragged across widgets, but this is more work and could be done in a subsequent PR.
- I've tried to retain the logic of when tabs are enabled / disabled and when Orbit automatically switches tabs (e.g. from the sampling to the sampling selection tab) as much as possible, but it's not as straightforward anymore when we don't know how the tabs are arranged
- Tutorials still work by restoring the default layout first. I've opened a bug to either improve this or to at least notify the user that this is happening before we ship the Tutorials

3 commits for easier review:
- Introduce the changes, disable the automatic tab selection
- Restore the automatic tab selection
- Add the layout restore functionality for Tutorials

![image](https://user-images.githubusercontent.com/63750742/100341757-482b3080-2fdd-11eb-863d-10826edef295.png)
