### PR TITLE
Add ProducerSideServiceImpl and ProducerSideServer

### DIFF
--- a/OrbitService/CMakeLists.txt
+++ b/OrbitService/CMakeLists.txt
@@ -32,6 +32,8 @@ target_sources(OrbitServiceLib PRIVATE
         ProcessList.h
         ProcessServiceImpl.cpp
         ProcessServiceImpl.h
+        ProducerSideServiceImpl.cpp
+        ProducerSideServiceImpl.h
         TracepointServiceImpl.h
         TracepointServiceImpl.cpp
         ServiceUtils.cpp
@@ -60,9 +62,11 @@ strip_symbols(OrbitService)
 add_executable(OrbitServiceTests)
 target_compile_options(OrbitServiceTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
-target_sources(OrbitServiceTests PRIVATE ProcessListTest.cpp
-                                         ProcessTest.cpp
-                                         ServiceUtilsTest.cpp)
+target_sources(OrbitServiceTests PRIVATE
+        ProcessListTest.cpp
+        ProcessTest.cpp
+        ProducerSideServiceImplTest.cpp
+        ServiceUtilsTest.cpp)
 
 target_link_libraries(OrbitServiceTests PRIVATE 
         OrbitServiceLib

--- a/OrbitService/CMakeLists.txt
+++ b/OrbitService/CMakeLists.txt
@@ -32,6 +32,8 @@ target_sources(OrbitServiceLib PRIVATE
         ProcessList.h
         ProcessServiceImpl.cpp
         ProcessServiceImpl.h
+        ProducerSideServer.cpp
+        ProducerSideServer.h
         ProducerSideServiceImpl.cpp
         ProducerSideServiceImpl.h
         TracepointServiceImpl.h

--- a/OrbitService/CaptureEventBuffer.h
+++ b/OrbitService/CaptureEventBuffer.h
@@ -12,7 +12,6 @@ namespace orbit_service {
 // Interface used to buffer CaptureEvents so that multiple CaptureEvents
 // can be processed at the same time (e.g., grouped into fewer bigger CaptureResponses).
 // AddEvent is to be assumed thread safe.
-
 class CaptureEventBuffer {
  public:
   virtual ~CaptureEventBuffer() = default;

--- a/OrbitService/CaptureEventSender.h
+++ b/OrbitService/CaptureEventSender.h
@@ -11,7 +11,6 @@ namespace orbit_service {
 
 // Interface used to process at once multiple CaptureEvents that were previously buffered
 // (e.g., to group all those CaptureEvents into a single CaptureResponse).
-
 class CaptureEventSender {
  public:
   virtual ~CaptureEventSender() = default;

--- a/OrbitService/ProducerSideServer.cpp
+++ b/OrbitService/ProducerSideServer.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ProducerSideServer.h"
+
+#include <sys/stat.h>
+
+#include "OrbitBase/SafeStrerror.h"
+
+namespace orbit_service {
+
+bool ProducerSideServer::BuildAndStart(std::string_view unix_domain_socket_path) {
+  CHECK(server_ == nullptr);
+
+  grpc::ServerBuilder builder;
+  builder.AddListeningPort(absl::StrFormat("unix:%s", unix_domain_socket_path),
+                           grpc::InsecureServerCredentials());
+
+  builder.RegisterService(&producer_side_service_);
+
+  server_ = builder.BuildAndStart();
+  if (server_ == nullptr) {
+    return false;
+  }
+
+  // When OrbitService runs as root, also allow non-root producers
+  // (e.g., the game) to communicate over the Unix domain socket.
+  if (chmod(std::string{unix_domain_socket_path}.c_str(), 0777) != 0) {
+    ERROR("Changing mode bits to 777 of \"%s\": %s", unix_domain_socket_path, SafeStrerror(errno));
+    server_->Shutdown();
+    server_->Wait();
+    return false;
+  }
+
+  return true;
+}
+
+void ProducerSideServer::ShutdownAndWait() {
+  CHECK(server_ != nullptr);
+  producer_side_service_.OnExitRequest();
+  server_->Shutdown();
+  server_->Wait();
+}
+
+void ProducerSideServer::OnCaptureStartRequested(CaptureEventBuffer* capture_event_buffer) {
+  producer_side_service_.OnCaptureStartRequested(capture_event_buffer);
+}
+
+void ProducerSideServer::OnCaptureStopRequested() {
+  producer_side_service_.OnCaptureStopRequested();
+}
+
+}  // namespace orbit_service

--- a/OrbitService/ProducerSideServer.h
+++ b/OrbitService/ProducerSideServer.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_SERVICE_TARGET_SIDE_SERVER_H_
+#define ORBIT_SERVICE_TARGET_SIDE_SERVER_H_
+
+#include "CaptureStartStopListener.h"
+#include "OrbitBase/Logging.h"
+#include "ProducerSideServiceImpl.h"
+#include "grpcpp/grpcpp.h"
+
+namespace orbit_service {
+
+// Wrapper around a grpc::Server that registers the service ProducerSideServiceImpl
+// and listens on a Unix domain socket.
+class ProducerSideServer final : public CaptureStartStopListener {
+ public:
+  bool BuildAndStart(std::string_view unix_domain_socket_path);
+  void ShutdownAndWait();
+
+  void OnCaptureStartRequested(CaptureEventBuffer* capture_event_buffer) override;
+  void OnCaptureStopRequested() override;
+
+ private:
+  ProducerSideServiceImpl producer_side_service_;
+  std::unique_ptr<grpc::Server> server_;
+};
+
+}  // namespace orbit_service
+
+#endif  // ORBIT_SERVICE_TARGET_SIDE_SERVER_H_

--- a/OrbitService/ProducerSideServiceImpl.cpp
+++ b/OrbitService/ProducerSideServiceImpl.cpp
@@ -28,7 +28,6 @@ void ProducerSideServiceImpl::OnCaptureStopRequested() {
   {
     absl::MutexLock lock{&service_state_mutex_};
     service_state_.capture_status = CaptureStatus::kCaptureStopping;
-    static constexpr absl::Duration kMaxWaitForAllEventsSent = absl::Seconds(10);
 
     // Wait (for a limited amount of time) for all producers to send AllEventsSent or to disconnect.
     service_state_mutex_.AwaitWithTimeout(absl::Condition(
@@ -37,7 +36,7 @@ void ProducerSideServiceImpl::OnCaptureStopRequested() {
                                                        service_state->exit_requested;
                                               },
                                               &service_state_),
-                                          kMaxWaitForAllEventsSent);
+                                          max_wait_for_all_events_sent_);
     CHECK(service_state_.producers_remaining >= 0);
     if (service_state_.producers_remaining == 0) {
       LOG("All CaptureEventProducers have finished sending their CaptureEvents");

--- a/OrbitService/ProducerSideServiceImpl.cpp
+++ b/OrbitService/ProducerSideServiceImpl.cpp
@@ -1,0 +1,325 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ProducerSideServiceImpl.h"
+
+#include <thread>
+
+#include "OrbitBase/Logging.h"
+
+namespace orbit_service {
+
+void ProducerSideServiceImpl::OnCaptureStartRequested(CaptureEventBuffer* capture_event_buffer) {
+  CHECK(capture_event_buffer != nullptr);
+  LOG("About to send StartCaptureCommand to CaptureEventProducers (if any)");
+  {
+    absl::WriterMutexLock lock{&capture_event_buffer_mutex_};
+    capture_event_buffer_ = capture_event_buffer;
+  }
+  {
+    absl::MutexLock lock{&service_state_mutex_};
+    service_state_.capture_status = CaptureStatus::kCaptureStarted;
+  }
+}
+
+void ProducerSideServiceImpl::OnCaptureStopRequested() {
+  LOG("About to send StopCaptureCommand to CaptureEventProducers (if any)");
+  {
+    absl::MutexLock lock{&service_state_mutex_};
+    service_state_.capture_status = CaptureStatus::kCaptureStopping;
+    static constexpr absl::Duration kMaxWaitForAllEventsSent = absl::Seconds(10);
+
+    // Wait (for a limited amount of time) for all producers to send AllEventsSent or to disconnect.
+    service_state_mutex_.AwaitWithTimeout(absl::Condition(
+                                              +[](ServiceState* service_state) {
+                                                return service_state->producers_remaining == 0 ||
+                                                       service_state->exit_requested;
+                                              },
+                                              &service_state_),
+                                          kMaxWaitForAllEventsSent);
+    CHECK(service_state_.producers_remaining >= 0);
+    if (service_state_.producers_remaining == 0) {
+      LOG("All CaptureEventProducers have finished sending their CaptureEvents");
+    } else {
+      ERROR(
+          "Stopped receiving CaptureEvents from CaptureEventProducers "
+          "even if not all have sent all their CaptureEvents");
+    }
+    service_state_.capture_status = CaptureStatus::kCaptureFinished;
+    service_state_.producers_remaining = 0;
+  }
+
+  {
+    absl::WriterMutexLock lock{&capture_event_buffer_mutex_};
+    capture_event_buffer_ = nullptr;
+  }
+}
+
+void ProducerSideServiceImpl::OnExitRequest() {
+  {
+    absl::MutexLock lock{&service_state_mutex_};
+    service_state_.exit_requested = true;
+  }
+
+  LOG("Attempting to disconnect from CaptureEventProducers as exit was requested");
+  {
+    absl::MutexLock lock{&server_contexts_mutex_};
+    for (grpc::ServerContext* context : server_contexts_) {
+      // This should cause blocking Reads on ServerReaderWriter to fail immediately.
+      context->TryCancel();
+    }
+  }
+
+  {
+    absl::WriterMutexLock lock{&capture_event_buffer_mutex_};
+    capture_event_buffer_ = nullptr;
+  }
+}
+
+grpc::Status ProducerSideServiceImpl::ReceiveCommandsAndSendEvents(
+    ::grpc::ServerContext* context,
+    ::grpc::ServerReaderWriter< ::orbit_grpc_protos::ReceiveCommandsAndSendEventsResponse,
+                                ::orbit_grpc_protos::ReceiveCommandsAndSendEventsRequest>* stream) {
+  LOG("A CaptureEventProducer has connected calling ReceiveCommandsAndSendEvents");
+
+  {
+    absl::MutexLock lock{&server_contexts_mutex_};
+    server_contexts_.emplace(context);
+  }
+
+  // This keeps whether we are still waiting for an AllEventsSent message at the end of a capture.
+  // It starts as true as we aren't yet waiting for such message when the connection is established.
+  // Note that this will also be protected by service_state_mutex_.
+  bool all_events_sent_received = true;
+
+  std::atomic<bool> exit_send_commands_thread = false;
+
+  // This thread is responsible for writing on stream, and specifically for
+  // sending StartCaptureCommands and StopCaptureCommands to the connected producer.
+  std::thread send_commands_thread{&ProducerSideServiceImpl::SendCommandsThread,
+                                   this,
+                                   context,
+                                   stream,
+                                   &all_events_sent_received,
+                                   &exit_send_commands_thread};
+
+  // This thread is responsible for reading from stream, and specifically for
+  // receiving CaptureEvents and AllEventsSent messages.
+  std::thread receive_events_thread{&ProducerSideServiceImpl::ReceiveEventsThread, this, context,
+                                    stream, &all_events_sent_received};
+  receive_events_thread.join();
+
+  // When receive_events_thread exits because stream->Read(&request) fails,
+  // it means that the producer has disconnected: ask send_commands_thread to exit, too.
+  exit_send_commands_thread = true;
+  send_commands_thread.join();
+
+  {
+    absl::MutexLock lock{&server_contexts_mutex_};
+    server_contexts_.erase(context);
+  }
+
+  LOG("Finished handling ReceiveCommandsAndSendEvents for a CaptureEventProducer");
+  return grpc::Status::OK;
+}
+
+void ProducerSideServiceImpl::SendCommandsThread(
+    grpc::ServerContext* context,
+    grpc::ServerReaderWriter<orbit_grpc_protos::ReceiveCommandsAndSendEventsResponse,
+                             orbit_grpc_protos::ReceiveCommandsAndSendEventsRequest>* stream,
+    bool* all_events_sent_received, std::atomic<bool>* exit_send_commands_thread) {
+  // As a result of initializing prev_capture_status to kCaptureFinished,
+  // an initial StartCaptureCommand is sent
+  // if service_state_.capture_status is actually CaptureStatus::kCaptureStarted,
+  // and an initial StopCaptureCommand is sent (with little effect)
+  // if service_state_.capture_status is actually CaptureStatus::kCaptureStopping.
+  CaptureStatus prev_capture_status = CaptureStatus::kCaptureFinished;
+
+  // This loop keeps track of changes to service_state_.capture_status using
+  // conditional critical sections on service_state_mutex_ and updating prev_capture_status,
+  // and sends StartCaptureCommands and StopCaptureCommands accordingly.
+  // It exits when *exit_send_commands_thread is true, when service_state_.exit_requested is true,
+  // or when Write fails (because the producer disconnected or because the context was cancelled).
+  while (true) {
+    // This is set when ReceiveEventsThread has exited. At that point this thread should also exit.
+    if (*exit_send_commands_thread) {
+      return;
+    }
+
+    service_state_mutex_.Lock();
+    if (service_state_.exit_requested) {
+      service_state_mutex_.Unlock();
+      return;
+    }
+
+    if (service_state_.capture_status != prev_capture_status) {
+      switch (service_state_.capture_status) {
+        case CaptureStatus::kCaptureStarted: {
+          prev_capture_status = service_state_.capture_status;
+          ++service_state_.producers_remaining;
+          *all_events_sent_received = false;
+          service_state_mutex_.Unlock();
+
+          orbit_grpc_protos::ReceiveCommandsAndSendEventsResponse command;
+          command.mutable_start_capture_command();
+          if (!stream->Write(command)) {
+            ERROR("Sending StartCaptureCommand to CaptureEventProducer");
+            LOG("Terminating call to ReceiveCommandsAndSendEvents as Write failed");
+            // Cause Read in ReceiveEventsThread to also fail if for some reason it hasn't already.
+            context->TryCancel();
+            return;
+          }
+          LOG("Sent StartCaptureCommand to CaptureEventProducer");
+        } break;
+
+        case CaptureStatus::kCaptureStopping: {
+          prev_capture_status = service_state_.capture_status;
+          service_state_mutex_.Unlock();
+
+          orbit_grpc_protos::ReceiveCommandsAndSendEventsResponse command;
+          command.mutable_stop_capture_command();
+          if (!stream->Write(command)) {
+            ERROR("Sending StopCaptureCommand to CaptureEventProducer");
+            LOG("Terminating call to ReceiveCommandsAndSendEvents as Write failed");
+            // Cause Read in ReceiveEventsThread to also fail if for some reason it hasn't already.
+            context->TryCancel();
+            return;
+          }
+          LOG("Sent StopCaptureCommand to CaptureEventProducer");
+        } break;
+
+        case CaptureStatus::kCaptureFinished: {
+          prev_capture_status = service_state_.capture_status;
+          *all_events_sent_received = true;
+          service_state_mutex_.Unlock();
+        } break;
+      }
+      continue;
+    }
+
+    // Wait for service_state_.capture_status to change or for service_state->exit_requested
+    // (the next iteration will handle the change).
+    // Use a timeout to periodically check (in the next iteration)
+    // for *terminate_send_commands_thread, set by ReceiveCommandsAndSendEvents.
+    static constexpr absl::Duration kCheckExitSendCommandsThreadInterval = absl::Seconds(1);
+
+    // The three cases in this switch are almost identical,
+    // except for the value service_state->capture_status is compared with.
+    // The reason for the duplication is that AwaitWithTimeout takes a function pointer,
+    // which means that the lambda cannot capture the initial state.
+    switch (service_state_.capture_status) {
+      case CaptureStatus::kCaptureStarted: {
+        service_state_mutex_.AwaitWithTimeout(absl::Condition(
+                                                  +[](ServiceState* service_state) {
+                                                    return service_state->exit_requested ||
+                                                           service_state->capture_status !=
+                                                               CaptureStatus::kCaptureStarted;
+                                                  },
+                                                  &service_state_),
+                                              kCheckExitSendCommandsThreadInterval);
+        service_state_mutex_.Unlock();
+      } break;
+
+      case CaptureStatus::kCaptureStopping: {
+        service_state_mutex_.AwaitWithTimeout(absl::Condition(
+                                                  +[](ServiceState* service_state) {
+                                                    return service_state->exit_requested ||
+                                                           service_state->capture_status !=
+                                                               CaptureStatus::kCaptureStopping;
+                                                  },
+                                                  &service_state_),
+                                              kCheckExitSendCommandsThreadInterval);
+        service_state_mutex_.Unlock();
+      } break;
+
+      case CaptureStatus::kCaptureFinished: {
+        service_state_mutex_.AwaitWithTimeout(absl::Condition(
+                                                  +[](ServiceState* service_state) {
+                                                    return service_state->exit_requested ||
+                                                           service_state->capture_status !=
+                                                               CaptureStatus::kCaptureFinished;
+                                                  },
+                                                  &service_state_),
+                                              kCheckExitSendCommandsThreadInterval);
+        service_state_mutex_.Unlock();
+      } break;
+    }
+  }
+}
+
+void ProducerSideServiceImpl::ReceiveEventsThread(
+    grpc::ServerContext* /*context*/,
+    grpc::ServerReaderWriter<orbit_grpc_protos::ReceiveCommandsAndSendEventsResponse,
+                             orbit_grpc_protos::ReceiveCommandsAndSendEventsRequest>* stream,
+    bool* all_events_sent_received) {
+  orbit_grpc_protos::ReceiveCommandsAndSendEventsRequest request;
+  while (stream->Read(&request)) {
+    {
+      absl::MutexLock lock{&service_state_mutex_};
+      if (service_state_.exit_requested) {
+        break;
+      }
+    }
+
+    switch (request.event_case()) {
+      case orbit_grpc_protos::ReceiveCommandsAndSendEventsRequest::kBufferedCaptureEvents: {
+        absl::MutexLock lock{&capture_event_buffer_mutex_};
+        // capture_event_buffer_ can be nullptr if a producer sends events while not capturing.
+        // Don't log an error in such a case as it could easily spam the logs.
+        if (capture_event_buffer_ != nullptr) {
+          for (orbit_grpc_protos::CaptureEvent event :
+               request.buffered_capture_events().capture_events()) {
+            capture_event_buffer_->AddEvent(std::move(event));
+          }
+        }
+      } break;
+
+      case orbit_grpc_protos::ReceiveCommandsAndSendEventsRequest::kAllEventsSent: {
+        LOG("Received AllEventsSent from CaptureEventProducer");
+        absl::MutexLock lock{&service_state_mutex_};
+        switch (service_state_.capture_status) {
+          case CaptureStatus::kCaptureStarted: {
+            ERROR("CaptureEventProducer sent AllEventsSent while still capturing");
+            // Even if we weren't waiting for the AllEventsSent message yet,
+            // still keep track of the fact that we have already received it.
+            if (!*all_events_sent_received) {
+              --service_state_.producers_remaining;
+              *all_events_sent_received = true;
+            }
+          } break;
+
+          case CaptureStatus::kCaptureStopping: {
+            // If we were waiting for AllEventsSent, keep track of the fact that we received it.
+            if (!*all_events_sent_received) {
+              --service_state_.producers_remaining;
+              *all_events_sent_received = true;
+            }
+          } break;
+
+          case CaptureStatus::kCaptureFinished: {
+            ERROR("CaptureEventProducer sent AllEventsSent after the capture had finished");
+          } break;
+        }
+      } break;
+
+      case orbit_grpc_protos::ReceiveCommandsAndSendEventsRequest::EVENT_NOT_SET: {
+        ERROR("CaptureEventProducer sent EVENT_NOT_SET");
+      } break;
+    }
+  }
+
+  ERROR("Receiving ReceiveCommandsAndSendEventsRequest from CaptureEventProducer");
+  {
+    absl::MutexLock lock{&service_state_mutex_};
+    // Producer has disconnected: treat this as if it had sent all its CaptureEvents.
+    if (!*all_events_sent_received &&
+        (service_state_.capture_status == CaptureStatus::kCaptureStarted ||
+         service_state_.capture_status == CaptureStatus::kCaptureStopping)) {
+      --service_state_.producers_remaining;
+      *all_events_sent_received = true;
+    }
+  }
+}
+
+}  // namespace orbit_service

--- a/OrbitService/ProducerSideServiceImpl.h
+++ b/OrbitService/ProducerSideServiceImpl.h
@@ -1,0 +1,71 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_SERVICE_PRODUCER_SIDE_SERVICE_IMPL_H_
+#define ORBIT_SERVICE_PRODUCER_SIDE_SERVICE_IMPL_H_
+
+#include "CaptureStartStopListener.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/synchronization/mutex.h"
+#include "producer_side_services.grpc.pb.h"
+
+namespace orbit_service {
+
+class ProducerSideServiceImpl final : public orbit_grpc_protos::ProducerSideService::Service,
+                                      public CaptureStartStopListener {
+ public:
+  // This method causes the StartCaptureCommand to be sent to connected producers
+  // (but if it's called multiple times in a row, the command will only be sent once).
+  // CaptureEvents received from producers will be added to capture_event_buffer.
+  void OnCaptureStartRequested(CaptureEventBuffer* capture_event_buffer) override;
+
+  // This method causes the StopCaptureCommand to be sent to connected producers
+  // (but if it's called multiple times in a row, the command will only be sent once).
+  // The CaptureEventBuffer passed with OnCaptureStartRequested will no longer be filled.
+  void OnCaptureStopRequested() override;
+
+  // This method forces to disconnect from connected producers and to terminate running threads.
+  // It doesn't cause StopCaptureCommand to be sent, but producers will be able to handle
+  // the fact that the connection was interrupted.
+  // No OnCaptureStartRequested or OnCaptureStopRequested should be called afterwards.
+  void OnExitRequest();
+
+  grpc::Status ReceiveCommandsAndSendEvents(
+      ::grpc::ServerContext* context,
+      ::grpc::ServerReaderWriter< ::orbit_grpc_protos::ReceiveCommandsAndSendEventsResponse,
+                                  ::orbit_grpc_protos::ReceiveCommandsAndSendEventsRequest>* stream)
+      override;
+
+ private:
+  void SendCommandsThread(
+      grpc::ServerContext* context,
+      grpc::ServerReaderWriter<orbit_grpc_protos::ReceiveCommandsAndSendEventsResponse,
+                               orbit_grpc_protos::ReceiveCommandsAndSendEventsRequest>* stream,
+      bool* all_events_sent_received, std::atomic<bool>* exit_send_commands_thread);
+
+  void ReceiveEventsThread(
+      grpc::ServerContext* context,
+      grpc::ServerReaderWriter<orbit_grpc_protos::ReceiveCommandsAndSendEventsResponse,
+                               orbit_grpc_protos::ReceiveCommandsAndSendEventsRequest>* stream,
+      bool* all_events_sent_received);
+
+ private:
+  absl::flat_hash_set<grpc::ServerContext*> server_contexts_;
+  absl::Mutex server_contexts_mutex_;
+
+  enum class CaptureStatus { kCaptureStarted, kCaptureStopping, kCaptureFinished };
+  struct ServiceState {
+    CaptureStatus capture_status = CaptureStatus::kCaptureFinished;
+    int32_t producers_remaining = 0;
+    bool exit_requested = false;
+  } service_state_;
+  absl::Mutex service_state_mutex_;
+
+  CaptureEventBuffer* capture_event_buffer_ = nullptr;
+  absl::Mutex capture_event_buffer_mutex_;
+};
+
+}  // namespace orbit_service
+
+#endif  // ORBIT_SERVICE_PRODUCER_SIDE_SERVICE_IMPL_H_

--- a/OrbitService/ProducerSideServiceImpl.h
+++ b/OrbitService/ProducerSideServiceImpl.h
@@ -12,6 +12,14 @@
 
 namespace orbit_service {
 
+// This class implements the gRPC service ProducerSideService, and in particular its only RPC
+// ReceiveCommandsAndSendEvents, through which producers of CaptureEvents connect to OrbitService.
+// It also implements the CaptureStartStopListener interface, whose methods cause this service to
+// notify the producers that a capture has been started (and that they can start sending
+// CaptureEvents) or stopped (and that the producers should finish sending CaptureEvents).
+// As OnCaptureStopRequested waits for the remaining CaptureEvents, SetMaxWaitForAllCaptureEvents
+// allows to specify a timeout for that method.
+// OnExitRequest disconnects all producers, preparing this service for shutdown.
 class ProducerSideServiceImpl final : public orbit_grpc_protos::ProducerSideService::Service,
                                       public CaptureStartStopListener {
  public:

--- a/OrbitService/ProducerSideServiceImpl.h
+++ b/OrbitService/ProducerSideServiceImpl.h
@@ -58,7 +58,7 @@ class ProducerSideServiceImpl final : public orbit_grpc_protos::ProducerSideServ
       grpc::ServerContext* context,
       grpc::ServerReaderWriter<orbit_grpc_protos::ReceiveCommandsAndSendEventsResponse,
                                orbit_grpc_protos::ReceiveCommandsAndSendEventsRequest>* stream,
-      bool* all_events_sent_received, std::atomic<bool>* exit_send_commands_thread);
+      bool* all_events_sent_received, std::atomic<bool>* receive_events_thread_exited);
 
   void ReceiveEventsThread(
       grpc::ServerContext* context,

--- a/OrbitService/ProducerSideServiceImpl.h
+++ b/OrbitService/ProducerSideServiceImpl.h
@@ -23,7 +23,15 @@ class ProducerSideServiceImpl final : public orbit_grpc_protos::ProducerSideServ
   // This method causes the StopCaptureCommand to be sent to connected producers
   // (but if it's called multiple times in a row, the command will only be sent once).
   // The CaptureEventBuffer passed with OnCaptureStartRequested will no longer be filled.
+  // This method blocks until all producers have notified they have sent all their CaptureEvents,
+  // for a maximum time that can be specified with SetMaxWaitForAllCaptureEvents (default 10 s).
   void OnCaptureStopRequested() override;
+
+  // This methods allows to specify a timeout for OnCaptureStopRequested, which blocks
+  // until all CaptureEvents have been sent by the producers. The default is 10 seconds.
+  void SetMaxWaitForAllCaptureEvents(absl::Duration duration) {
+    max_wait_for_all_events_sent_ = duration;
+  }
 
   // This method forces to disconnect from connected producers and to terminate running threads.
   // It doesn't cause StopCaptureCommand to be sent, but producers will be able to handle
@@ -64,6 +72,8 @@ class ProducerSideServiceImpl final : public orbit_grpc_protos::ProducerSideServ
 
   CaptureEventBuffer* capture_event_buffer_ = nullptr;
   absl::Mutex capture_event_buffer_mutex_;
+
+  absl::Duration max_wait_for_all_events_sent_ = absl::Seconds(10);
 };
 
 }  // namespace orbit_service

--- a/OrbitService/ProducerSideServiceImplTest.cpp
+++ b/OrbitService/ProducerSideServiceImplTest.cpp
@@ -1,0 +1,248 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <thread>
+
+#include "ProducerSideServiceImpl.h"
+#include "absl/strings/str_format.h"
+#include "grpcpp/grpcpp.h"
+
+namespace orbit_service {
+
+namespace {
+
+// This class fakes a client of ProducerSideService for use in tests.
+class FakeProducer {
+ public:
+  void RunRpc(std::string_view unix_domain_socket_path) {
+    std::string server_address = absl::StrFormat("unix:%s", unix_domain_socket_path);
+    std::shared_ptr<grpc::Channel> channel = grpc::CreateCustomChannel(
+        server_address, grpc::InsecureChannelCredentials(), grpc::ChannelArguments{});
+    ASSERT_NE(channel, nullptr);
+
+    std::unique_ptr<orbit_grpc_protos::ProducerSideService::Stub> stub =
+        orbit_grpc_protos::ProducerSideService::NewStub(channel);
+    ASSERT_NE(stub, nullptr);
+
+    EXPECT_EQ(context_, nullptr);
+    EXPECT_EQ(stream_, nullptr);
+    context_ = std::make_unique<grpc::ClientContext>();
+    stream_ = stub->ReceiveCommandsAndSendEvents(context_.get());
+    ASSERT_NE(stream_, nullptr);
+
+    read_thread_ = std::thread([this] {
+      orbit_grpc_protos::ReceiveCommandsAndSendEventsResponse response;
+      while (stream_->Read(&response)) {
+        EXPECT_NE(response.command_case(),
+                  orbit_grpc_protos::ReceiveCommandsAndSendEventsResponse::COMMAND_NOT_SET);
+        switch (response.command_case()) {
+          case orbit_grpc_protos::ReceiveCommandsAndSendEventsResponse::kStartCaptureCommand:
+            OnStartCaptureCommandReceived();
+            break;
+          case orbit_grpc_protos::ReceiveCommandsAndSendEventsResponse::kStopCaptureCommand:
+            OnStopCaptureCommandReceived();
+            break;
+          case orbit_grpc_protos::ReceiveCommandsAndSendEventsResponse::COMMAND_NOT_SET:
+            break;
+        }
+      }
+    });
+  }
+
+  void SendBufferedCaptureEvents(int32_t num_to_send) {
+    ASSERT_NE(stream_, nullptr);
+    orbit_grpc_protos::ReceiveCommandsAndSendEventsRequest request;
+    request.mutable_buffered_capture_events();
+    for (int32_t i = 0; i < num_to_send; ++i) {
+      request.mutable_buffered_capture_events()->mutable_capture_events()->Add();
+    }
+    bool written = stream_->Write(request);
+    EXPECT_TRUE(written);
+  }
+
+  void SendAllEventsSent() {
+    ASSERT_NE(stream_, nullptr);
+    orbit_grpc_protos::ReceiveCommandsAndSendEventsRequest request;
+    request.mutable_all_events_sent();
+    bool written = stream_->Write(request);
+    EXPECT_TRUE(written);
+  }
+
+  void FinishRpc() {
+    if (context_ != nullptr) {
+      context_->TryCancel();
+      context_ = nullptr;
+      EXPECT_NE(stream_, nullptr);
+      EXPECT_TRUE(read_thread_.joinable());
+    }
+    stream_ = nullptr;
+    if (read_thread_.joinable()) {
+      read_thread_.join();
+    }
+  }
+
+  MOCK_METHOD(void, OnStartCaptureCommandReceived, (), ());
+  MOCK_METHOD(void, OnStopCaptureCommandReceived, (), ());
+
+ private:
+  std::unique_ptr<grpc::ClientContext> context_;
+  std::unique_ptr<grpc::ClientReaderWriter<orbit_grpc_protos::ReceiveCommandsAndSendEventsRequest,
+                                           orbit_grpc_protos::ReceiveCommandsAndSendEventsResponse>>
+      stream_;
+  std::thread read_thread_;
+};
+
+class MockCaptureEventBuffer : public CaptureEventBuffer {
+ public:
+  MOCK_METHOD(void, AddEvent, (orbit_grpc_protos::CaptureEvent && event), (override));
+};
+
+class ProducerSideServiceImplTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    static const std::string kUnixDomainSocketPath = "./producer-side-service-impl-test-socket";
+
+    grpc::ServerBuilder builder;
+    builder.AddListeningPort(absl::StrFormat("unix:%s", kUnixDomainSocketPath),
+                             grpc::InsecureServerCredentials());
+
+    service.emplace();
+    builder.RegisterService(&*service);
+    fake_server = builder.BuildAndStart();
+
+    fake_producer.emplace();
+    ON_CALL(*fake_producer, OnStopCaptureCommandReceived).WillByDefault([this] {
+      fake_producer->SendAllEventsSent();
+    });
+    fake_producer->RunRpc(kUnixDomainSocketPath);
+
+    // Leave some time for the ReceiveCommandsAndSendEvents RPC to actually happen.
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+
+  void TearDown() override {
+    // Leave some time for all pending communication to finish.
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    fake_producer->FinishRpc();
+    fake_producer.reset();
+
+    service->OnExitRequest();
+    fake_server->Shutdown();
+    fake_server->Wait();
+
+    service.reset();
+    fake_server.reset();
+  }
+
+  std::optional<ProducerSideServiceImpl> service;
+  std::unique_ptr<grpc::Server> fake_server;
+  std::optional<FakeProducer> fake_producer;
+};
+
+constexpr std::chrono::duration kWaitMessagesSentDuration = std::chrono::milliseconds(25);
+
+}  // namespace
+
+TEST_F(ProducerSideServiceImplTest, OneCapture) {
+  MockCaptureEventBuffer mock_buffer;
+
+  EXPECT_CALL(*fake_producer, OnStartCaptureCommandReceived).Times(1);
+  service->OnCaptureStartRequested(&mock_buffer);
+  std::this_thread::sleep_for(kWaitMessagesSentDuration);
+
+  ::testing::Mock::VerifyAndClearExpectations(&*fake_producer);
+
+  EXPECT_CALL(mock_buffer, AddEvent).Times(6);
+  fake_producer->SendBufferedCaptureEvents(3);
+  fake_producer->SendBufferedCaptureEvents(3);
+  std::this_thread::sleep_for(kWaitMessagesSentDuration);
+
+  ::testing::Mock::VerifyAndClearExpectations(&mock_buffer);
+
+  EXPECT_CALL(*fake_producer, OnStopCaptureCommandReceived).Times(1);
+  service->OnCaptureStopRequested();
+  std::this_thread::sleep_for(kWaitMessagesSentDuration);
+}
+
+TEST_F(ProducerSideServiceImplTest, TwoCaptures) {
+  MockCaptureEventBuffer mock_buffer;
+
+  EXPECT_CALL(*fake_producer, OnStartCaptureCommandReceived).Times(1);
+  service->OnCaptureStartRequested(&mock_buffer);
+  std::this_thread::sleep_for(kWaitMessagesSentDuration);
+
+  ::testing::Mock::VerifyAndClearExpectations(&*fake_producer);
+
+  EXPECT_CALL(mock_buffer, AddEvent).Times(6);
+  fake_producer->SendBufferedCaptureEvents(3);
+  fake_producer->SendBufferedCaptureEvents(3);
+  std::this_thread::sleep_for(kWaitMessagesSentDuration);
+
+  ::testing::Mock::VerifyAndClearExpectations(&mock_buffer);
+
+  EXPECT_CALL(*fake_producer, OnStopCaptureCommandReceived).Times(1);
+  service->OnCaptureStopRequested();
+  std::this_thread::sleep_for(kWaitMessagesSentDuration);
+
+  ::testing::Mock::VerifyAndClearExpectations(&*fake_producer);
+
+  EXPECT_CALL(*fake_producer, OnStartCaptureCommandReceived).Times(1);
+  service->OnCaptureStartRequested(&mock_buffer);
+  std::this_thread::sleep_for(kWaitMessagesSentDuration);
+
+  ::testing::Mock::VerifyAndClearExpectations(&*fake_producer);
+
+  EXPECT_CALL(mock_buffer, AddEvent).Times(6);
+  fake_producer->SendBufferedCaptureEvents(1);
+  fake_producer->SendBufferedCaptureEvents(2);
+  fake_producer->SendBufferedCaptureEvents(3);
+  std::this_thread::sleep_for(kWaitMessagesSentDuration);
+
+  ::testing::Mock::VerifyAndClearExpectations(&mock_buffer);
+
+  EXPECT_CALL(*fake_producer, OnStopCaptureCommandReceived).Times(1);
+  service->OnCaptureStopRequested();
+  std::this_thread::sleep_for(kWaitMessagesSentDuration);
+}
+
+TEST_F(ProducerSideServiceImplTest, MultipleOnCaptureStartStop) {
+  MockCaptureEventBuffer mock_buffer;
+
+  EXPECT_CALL(*fake_producer, OnStartCaptureCommandReceived).Times(1);
+  service->OnCaptureStartRequested(&mock_buffer);
+  std::this_thread::sleep_for(kWaitMessagesSentDuration);
+
+  ::testing::Mock::VerifyAndClearExpectations(&*fake_producer);
+
+  EXPECT_CALL(*fake_producer, OnStartCaptureCommandReceived).Times(0);
+  // This should *not* cause StartCaptureCommand to be sent again.
+  service->OnCaptureStartRequested(&mock_buffer);
+  std::this_thread::sleep_for(kWaitMessagesSentDuration);
+
+  ::testing::Mock::VerifyAndClearExpectations(&*fake_producer);
+
+  EXPECT_CALL(mock_buffer, AddEvent).Times(6);
+  fake_producer->SendBufferedCaptureEvents(3);
+  fake_producer->SendBufferedCaptureEvents(3);
+  std::this_thread::sleep_for(kWaitMessagesSentDuration);
+
+  ::testing::Mock::VerifyAndClearExpectations(&mock_buffer);
+
+  EXPECT_CALL(*fake_producer, OnStopCaptureCommandReceived).Times(1);
+  service->OnCaptureStopRequested();
+  std::this_thread::sleep_for(kWaitMessagesSentDuration);
+
+  ::testing::Mock::VerifyAndClearExpectations(&*fake_producer);
+
+  EXPECT_CALL(*fake_producer, OnStopCaptureCommandReceived).Times(0);
+  // This should *not* cause StopCaptureCommand to be sent again.
+  service->OnCaptureStopRequested();
+  std::this_thread::sleep_for(kWaitMessagesSentDuration);
+}
+
+}  // namespace orbit_service


### PR DESCRIPTION
For the communication between producers and `OrbitService`. Bug: http://b/174028631.

Synchronization mess part 1: I'm aware that the synchronization in `ProducerSideServiceImpl` is a bit tricky and especially not so easy on the reader. I'm not really sure how to improve it, but I tried to test it quite a bit.