### PR TITLE
[release/1.56] Fix issues with frame tracks when loading a capture

### DIFF
--- a/OrbitGl/FunctionsDataView.cpp
+++ b/OrbitGl/FunctionsDataView.cpp
@@ -33,14 +33,34 @@ const std::vector<DataView::Column>& FunctionsDataView::GetColumns() {
   return columns;
 }
 
+bool FunctionsDataView::ShouldShowSelectedFunctionIcon(const FunctionInfo& function) {
+  return GOrbitApp->IsFunctionSelected(function);
+}
+
+bool FunctionsDataView::ShouldShowFrameTrackIcon(const FunctionInfo& function) {
+  if (GOrbitApp->IsFrameTrackEnabled(function)) {
+    return true;
+  }
+  if (GOrbitApp->HasCaptureData()) {
+    const CaptureData& capture_data = GOrbitApp->GetCaptureData();
+    if (!GOrbitApp->IsCaptureConnected(capture_data) &&
+        GOrbitApp->HasFrameTrackInCaptureData(function)) {
+      // This case occurs when loading a capture. We still want to show the indicator that a frame
+      // track is enabled for the function.
+      return true;
+    }
+  }
+  return false;
+}
+
 std::string FunctionsDataView::BuildSelectedColumnsString(const FunctionInfo& function) {
   std::string result = kUnselectedFunctionString;
-  if (GOrbitApp->IsFunctionSelected(function)) {
+  if (ShouldShowSelectedFunctionIcon(function)) {
     absl::StrAppend(&result, kSelectedFunctionString);
-    if (GOrbitApp->IsFrameTrackEnabled(function)) {
+    if (ShouldShowFrameTrackIcon(function)) {
       absl::StrAppend(&result, " ", kFrameTrackString);
     }
-  } else if (GOrbitApp->IsFrameTrackEnabled(function)) {
+  } else if (ShouldShowFrameTrackIcon(function)) {
     absl::StrAppend(&result, kFrameTrackString);
   }
   return result;

--- a/OrbitGl/FunctionsDataView.h
+++ b/OrbitGl/FunctionsDataView.h
@@ -56,6 +56,8 @@ class FunctionsDataView : public DataView {
   static const std::string kMenuActionDisassembly;
 
  private:
+  static bool ShouldShowSelectedFunctionIcon(const orbit_client_protos::FunctionInfo& function);
+  static bool ShouldShowFrameTrackIcon(const orbit_client_protos::FunctionInfo& function);
   std::vector<const orbit_client_protos::FunctionInfo*> functions_;
 };
 

--- a/OrbitGl/LiveFunctionsDataView.cpp
+++ b/OrbitGl/LiveFunctionsDataView.cpp
@@ -174,8 +174,14 @@ std::vector<std::string> LiveFunctionsDataView::GetContextMenu(
     const FunctionStats& stats = capture_data.GetFunctionStatsOrDefault(selected_function);
     // We need at least one function call to a function so that adding iterators makes sense.
     enable_iterator |= stats.count() > 0;
-    enable_enable_frame_track |= !GOrbitApp->IsFrameTrackEnabled(selected_function);
-    enable_disable_frame_track |= GOrbitApp->IsFrameTrackEnabled(selected_function);
+
+    if (GOrbitApp->IsCaptureConnected(capture_data)) {
+      enable_enable_frame_track |= !GOrbitApp->IsFrameTrackEnabled(selected_function);
+      enable_disable_frame_track |= GOrbitApp->IsFrameTrackEnabled(selected_function);
+    } else {
+      enable_enable_frame_track |= !GOrbitApp->HasFrameTrackInCaptureData(selected_function);
+      enable_disable_frame_track |= GOrbitApp->HasFrameTrackInCaptureData(selected_function);
+    }
   }
 
   std::vector<std::string> menu;
@@ -267,7 +273,9 @@ void LiveFunctionsDataView::OnContextMenu(const std::string& action, int menu_in
   } else if (action == kMenuActionEnableFrameTrack) {
     for (int i : item_indices) {
       FunctionInfo* function = GetSelectedFunction(i);
-      GOrbitApp->SelectFunction(*function);
+      if (GOrbitApp->IsCaptureConnected(capture_data)) {
+        GOrbitApp->SelectFunction(*function);
+      }
       GOrbitApp->EnableFrameTrack(*function);
       GOrbitApp->AddFrameTrack(*function);
     }


### PR DESCRIPTION
When loading a capture, Orbit can be in a state where hooking a function
that has hits in the "Live" tab must not be allowed, either because
Orbit is not in a connected state (no process selected) or because the
module to which the function belongs is not loaded. In both these cases,
the "Hook" option is disabled in the "Live" context menu, however it was
incorrectly possible to hook a function by enabling a frame track. In
the connected state, this leads to a crash when taking a capture with
the incorrectly hooked function.

We now apply the same check that is used for enabling the "Hook" context
menu entry when enabling the frame track for a function to make sure
it's only hooked when possible.

Bug: http://b/174296341

Tested: Manual tests for the cases described on the bug.