### PR TITLE
[CHERRY-PICK] Fix crash in iterators

### DIFF
--- a/OrbitGl/LiveFunctionsController.cpp
+++ b/OrbitGl/LiveFunctionsController.cpp
@@ -69,6 +69,10 @@ const TextBox* SnapToClosestStart(uint64_t absolute_function_address) {
   if (box->GetTimerInfo().start() <= center) {
     const TextBox* next_box = GCurrentTimeGraph->FindNextFunctionCall(absolute_function_address,
                                                                       box->GetTimerInfo().end());
+    if (!next_box) {
+      return box;
+    }
+
     return ClosestTo(center, box, next_box);
   }
 


### PR DESCRIPTION
When you create an iterator where the center of the screen is between the
start and the end of the last function, it produces a crash because
next_box is a null pointer. Add an if there.

I only could reproduce the issue on Windows.