### PR TITLE
Solve mini-jump after each position change (Revert)

### DIFF
--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -534,11 +534,9 @@ void CaptureWindow::DrawScreenSpace() {
 
   if (time_span > 0) {
     UpdateHorizontalSliderFromWorld();
-    UpdateHorizontalScroll(slider_->GetPosRatio());
     slider_->Draw(this);
 
     UpdateVerticalSliderFromWorld();
-    UpdateVerticalScroll(vertical_slider_->GetPosRatio());
     if (vertical_slider_->GetLengthRatio() < 1.f) {
       vertical_slider_->Draw(this);
       int slider_width = static_cast<int>(time_graph_.GetLayout().GetSliderWidth());


### PR DESCRIPTION
Regression from 1.54. After every zooming, or other position changes,
the screen glitched and make a small movement. Noticeable after
zooming-in a lot in the horizontal coordinates.

Small revert from https://github.com/google/orbit/pull/1390.