### PR TITLE
Add client side ORBIT_SCOPE markers

### DIFF
--- a/OrbitBase/ThreadPool.cpp
+++ b/OrbitBase/ThreadPool.cpp
@@ -8,6 +8,7 @@
 #include <thread>
 
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/Tracing.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/synchronization/mutex.h"
 
@@ -23,6 +24,7 @@ class ThreadPoolImpl : public ThreadPool {
   void Schedule(std::unique_ptr<Action> action) override;
   void Shutdown() override;
   void Wait() override;
+  void EnableAutoProfiling(bool value) override;
 
  private:
   bool ActionsAvailableOrShutdownInitiated();
@@ -41,6 +43,7 @@ class ThreadPoolImpl : public ThreadPool {
   absl::Duration thread_ttl_;
   size_t idle_threads_;
   bool shutdown_initiated_;
+  bool auto_profile_;
 };
 
 ThreadPoolImpl::ThreadPoolImpl(size_t thread_pool_min_size, size_t thread_pool_max_size,
@@ -49,7 +52,8 @@ ThreadPoolImpl::ThreadPoolImpl(size_t thread_pool_min_size, size_t thread_pool_m
       thread_pool_max_size_(thread_pool_max_size),
       thread_ttl_(thread_ttl),
       idle_threads_(0),
-      shutdown_initiated_(false) {
+      shutdown_initiated_(false),
+      auto_profile_(true) {
   CHECK(thread_pool_min_size > 0);
   CHECK(thread_pool_max_size >= thread_pool_min_size);
   // Ttl should not be too small
@@ -116,6 +120,11 @@ void ThreadPoolImpl::Wait() {
   CleanupFinishedThreads();
 }
 
+void ThreadPoolImpl::EnableAutoProfiling(bool value) {
+  absl::MutexLock lock(&mutex_);
+  auto_profile_ = value;
+}
+
 bool ThreadPoolImpl::ActionsAvailableOrShutdownInitiated() {
   return !scheduled_actions_.empty() || shutdown_initiated_;
 }
@@ -162,8 +171,11 @@ void ThreadPoolImpl::WorkerFunction() {
       break;
     }
 
+    bool auto_profile = auto_profile_;
     mutex_.Unlock();
+    if (auto_profile) ORBIT_START("Execute Action");
     action->Execute();
+    if (auto_profile) ORBIT_STOP();
     mutex_.Lock();
     ++idle_threads_;
   }

--- a/OrbitBase/Tracing.cpp
+++ b/OrbitBase/Tracing.cpp
@@ -27,6 +27,7 @@ Listener::Listener(TimerCallback callback) {
   constexpr size_t kMinNumThreads = 1;
   constexpr size_t kMaxNumThreads = 1;
   thread_pool_ = ThreadPool::Create(kMinNumThreads, kMaxNumThreads, absl::Milliseconds(500));
+  thread_pool_->EnableAutoProfiling(false);  // To prevent feedback loop.
   user_callback_ = std::move(callback);
 
   // Activate listener (only one listener instance is supported).

--- a/OrbitBase/include/OrbitBase/ThreadPool.h
+++ b/OrbitBase/include/OrbitBase/ThreadPool.h
@@ -47,6 +47,8 @@ class ThreadPool {
   // Shutdown().
   virtual void Wait() = 0;
 
+  virtual void EnableAutoProfiling(bool value) = 0;
+
   void ShutdownAndWait() {
     Shutdown();
     Wait();

--- a/OrbitCaptureClient/CaptureClient.cpp
+++ b/OrbitCaptureClient/CaptureClient.cpp
@@ -6,6 +6,7 @@
 
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
+#include "OrbitBase/Tracing.h"
 #include "OrbitCaptureClient/CaptureEventProcessor.h"
 #include "OrbitClientData/FunctionUtils.h"
 #include "OrbitClientData/ProcessData.h"
@@ -74,6 +75,7 @@ void CaptureClient::Capture(ProcessData&& process,
                             TracepointInfoSet selected_tracepoints,
                             UserDefinedCaptureData user_defined_capture_data,
                             bool enable_introspection) {
+  ORBIT_SCOPE_FUNCTION;
   CHECK(client_context_ == nullptr);
   CHECK(reader_writer_ == nullptr);
 
@@ -215,6 +217,7 @@ bool CaptureClient::TryAbortCapture() {
 }
 
 ErrorMessageOr<void> CaptureClient::FinishCapture() {
+  ORBIT_SCOPE_FUNCTION;
   if (reader_writer_ == nullptr) {
     return outcome::success();
   }

--- a/OrbitClientServices/ProcessClient.cpp
+++ b/OrbitClientServices/ProcessClient.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/Tracing.h"
 #include "grpcpp/grpcpp.h"
 #include "outcome.hpp"
 #include "services.grpc.pb.h"
@@ -42,6 +43,7 @@ std::unique_ptr<grpc::ClientContext> CreateContext(
 }  // namespace
 
 ErrorMessageOr<std::vector<orbit_grpc_protos::ProcessInfo>> ProcessClient::GetProcessList() {
+  ORBIT_SCOPE_FUNCTION;
   GetProcessListRequest request;
   GetProcessListResponse response;
   std::unique_ptr<grpc::ClientContext> context = CreateContext();
@@ -59,6 +61,7 @@ ErrorMessageOr<std::vector<orbit_grpc_protos::ProcessInfo>> ProcessClient::GetPr
 }
 
 ErrorMessageOr<std::vector<ModuleInfo>> ProcessClient::LoadModuleList(int32_t pid) {
+  ORBIT_SCOPE_FUNCTION;
   GetModuleListRequest request;
   GetModuleListResponse response;
   request.set_process_id(pid);
@@ -77,6 +80,7 @@ ErrorMessageOr<std::vector<ModuleInfo>> ProcessClient::LoadModuleList(int32_t pi
 }
 
 ErrorMessageOr<std::string> ProcessClient::FindDebugInfoFile(const std::string& module_path) {
+  ORBIT_SCOPE_FUNCTION;
   GetDebugInfoFileRequest request;
   GetDebugInfoFileResponse response;
 
@@ -95,6 +99,7 @@ ErrorMessageOr<std::string> ProcessClient::FindDebugInfoFile(const std::string& 
 
 ErrorMessageOr<std::string> ProcessClient::LoadProcessMemory(int32_t pid, uint64_t address,
                                                              uint64_t size) {
+  ORBIT_SCOPE_FUNCTION;
   GetProcessMemoryRequest request;
   request.set_pid(pid);
   request.set_address(address);

--- a/OrbitCore/SymbolHelper.cpp
+++ b/OrbitCore/SymbolHelper.cpp
@@ -14,6 +14,7 @@
 #include "ElfUtils/ElfFile.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
+#include "OrbitBase/Tracing.h"
 #include "Path.h"
 
 using orbit_grpc_protos::ModuleSymbols;
@@ -141,6 +142,7 @@ ErrorMessageOr<fs::path> SymbolHelper::FindSymbolsWithSymbolsPathFile(
 }
 
 ErrorMessageOr<ModuleSymbols> SymbolHelper::LoadSymbolsFromFile(const fs::path& file_path) {
+  ORBIT_SCOPE_FUNCTION;
   SCOPED_TIMED_LOG("LoadSymbolsFromFile: %s", file_path.string());
   ErrorMessageOr<std::unique_ptr<ElfFile>> elf_file_result = ElfFile::Create(file_path.string());
 

--- a/OrbitGl/Batcher.cpp
+++ b/OrbitGl/Batcher.cpp
@@ -6,6 +6,7 @@
 
 #include "CoreUtils.h"
 #include "OpenGl.h"
+#include "OrbitBase/Tracing.h"
 
 void Batcher::AddLine(Vec2 from, Vec2 to, float z, const Color& color,
                       std::unique_ptr<PickingUserData> user_data) {
@@ -323,6 +324,7 @@ std::vector<float> Batcher::GetLayers() const {
 };
 
 void Batcher::DrawLayer(float layer, bool picking) const {
+  ORBIT_SCOPE_FUNCTION;
   if (!primitive_buffers_by_layer_.count(layer)) return;
   glPushAttrib(GL_ENABLE_BIT | GL_COLOR_BUFFER_BIT);
   if (picking) {

--- a/OrbitGl/ProcessesDataView.cpp
+++ b/OrbitGl/ProcessesDataView.cpp
@@ -176,6 +176,7 @@ void ProcessesDataView::UpdateProcessList() {
 }
 
 void ProcessesDataView::SetProcessList(const std::vector<ProcessInfo>& process_list) {
+  ORBIT_SCOPE("ProcessesDataView::SetProcessList");
   process_list_ = process_list;
   UpdateProcessList();
   OnDataChanged();

--- a/OrbitGl/ProcessesDataView.cpp
+++ b/OrbitGl/ProcessesDataView.cpp
@@ -176,7 +176,7 @@ void ProcessesDataView::UpdateProcessList() {
 }
 
 void ProcessesDataView::SetProcessList(const std::vector<ProcessInfo>& process_list) {
-  ORBIT_SCOPE("ProcessesDataView::SetProcessList");
+  ORBIT_SCOPE_FUNCTION;
   process_list_ = process_list;
   UpdateProcessList();
   OnDataChanged();

--- a/OrbitGl/TextRenderer.cpp
+++ b/OrbitGl/TextRenderer.cpp
@@ -82,6 +82,7 @@ texture_font_t* TextRenderer::GetFont(uint32_t size) {
 }
 
 void TextRenderer::RenderLayer(Batcher*, float layer) {
+  ORBIT_SCOPE_FUNCTION;
   if (!vertex_buffers_by_layer_.count(layer)) return;
   auto& buffer = vertex_buffers_by_layer_.at(layer);
 

--- a/OrbitQt/MainThreadExecutorImpl.cpp
+++ b/OrbitQt/MainThreadExecutorImpl.cpp
@@ -9,6 +9,8 @@
 #include <list>
 #include <thread>
 
+#include "OrbitBase/Tracing.h"
+
 namespace {
 
 class MainThreadExecutorImpl : public MainThreadExecutor {
@@ -19,8 +21,10 @@ class MainThreadExecutorImpl : public MainThreadExecutor {
 };
 
 void MainThreadExecutorImpl::Schedule(std::unique_ptr<Action> action) {
-  QMetaObject::invokeMethod(QCoreApplication::instance(),
-                            [action = std::move(action)]() { action->Execute(); });
+  QMetaObject::invokeMethod(QCoreApplication::instance(), [action = std::move(action)]() {
+    ORBIT_SCOPE("MainThreadExecutor Action");
+    action->Execute();
+  });
 }
 
 }  // namespace

--- a/OrbitSshQt/Tunnel.cpp
+++ b/OrbitSshQt/Tunnel.cpp
@@ -160,7 +160,7 @@ outcome::result<void> Tunnel::shutdown() {
 }
 
 outcome::result<void> Tunnel::readFromChannel() {
-  ORBIT_SCOPE("Tunnel::readFromChannel");
+  ORBIT_SCOPE_FUNCTION;
   while (true) {
     const size_t kChunkSize = 1024 * 1024;
     const auto result = channel_->ReadStdOut(kChunkSize);
@@ -195,13 +195,13 @@ outcome::result<void> Tunnel::readFromChannel() {
 }
 
 outcome::result<void> Tunnel::writeToChannel() {
-  ORBIT_SCOPE("Tunnel::writeToChannel");
+  ORBIT_SCOPE_FUNCTION;
   if (!write_buffer_.empty()) {
     const std::string_view buffer_view{write_buffer_.data(), write_buffer_.size()};
     OUTCOME_TRY(bytes_written, channel_->Write(buffer_view));
     CHECK(static_cast<size_t>(bytes_written) <= write_buffer_.size());
     write_buffer_.erase(write_buffer_.begin(), write_buffer_.begin() + bytes_written);
-    ORBIT_UINT64("Tunnel::writeToChannel bytes written", bytes_written);
+    ORBIT_UINT64("writeToChannel bytes written", bytes_written);
   }
   return outcome::success();
 }


### PR DESCRIPTION
- Automatically profile thread pools by default using the new client-side
  introspection. The only thread pool that is not profiled is the one used
  by the introspection system itself (to avoid a feedback loop)
- Profile MainThreadExecutor
- Add various profiling markers in client code

![image](https://user-images.githubusercontent.com/3687222/100691620-f0265e00-333d-11eb-9ede-6ef6c769415d.png)
