### PR TITLE
Fix track filter background image

### DIFF
--- a/OrbitQt/orbitmainwindow.ui
+++ b/OrbitQt/orbitmainwindow.ui
@@ -148,7 +148,9 @@ QPushButton:disabled {
                <string>filter</string>
               </property>
               <property name="styleSheet">
-               <string notr="true">background-image: url(:/actions/filter_list_small_offset);</string>
+               <string notr="true">QLineEdit {
+	background-image: url(:/actions/filter_list_small_offset);
+}</string>
               </property>
               <property name="placeholderText">
                <string>Filter Tracks</string>


### PR DESCRIPTION
The image was showing up in the right-click context because it was not
restricted to the QLineEdit class

To reproduce:
- Right-click "Filter tracks" textbox
- The "list filter" icon is set as background for the menu

After the fix:
- Context menu looks correct

b/173577095