### PR TITLE
Parse and send module updates to the client

### DIFF
--- a/OrbitCaptureClient/CaptureEventProcessor.cpp
+++ b/OrbitCaptureClient/CaptureEventProcessor.cpp
@@ -66,6 +66,8 @@ void CaptureEventProcessor::ProcessEvent(const CaptureEvent& event) {
       break;
     case CaptureEvent::kGpuQueueSubmission:
       UNREACHABLE();
+    case CaptureEvent::kModulesUpdateEvent:
+      // TODO (http://b/168797897): Process module update events
       break;
     case CaptureEvent::EVENT_NOT_SET:
       ERROR("CaptureEvent::EVENT_NOT_SET read from Capture's gRPC stream");

--- a/OrbitGrpcProtos/capture.proto
+++ b/OrbitGrpcProtos/capture.proto
@@ -6,6 +6,7 @@ syntax = "proto3";
 
 package orbit_grpc_protos;
 
+import "module.proto";
 import "tracepoint.proto";
 
 message CaptureOptions {
@@ -224,6 +225,12 @@ message AddressInfo {
   }
 }
 
+message ModulesUpdateEvent {
+  int32 pid = 1;
+  uint64 timestamp_ns = 2;
+  repeated ModuleInfo modules = 3;
+}
+
 message CaptureEvent {
   oneof event {
     SchedulingSlice scheduling_slice = 1;
@@ -239,5 +246,6 @@ message CaptureEvent {
     InternedTracepointInfo interned_tracepoint_info = 9;
     TracepointEvent tracepoint_event = 10;
     IntrospectionScope introspection_scope = 12;
+    ModulesUpdateEvent modules_update_event = 14;
   }
 }

--- a/OrbitLinuxTracing/CMakeLists.txt
+++ b/OrbitLinuxTracing/CMakeLists.txt
@@ -60,6 +60,7 @@ target_sources(OrbitLinuxTracing PRIVATE
         UprobesUnwindingVisitor.h)
 
 target_link_libraries(OrbitLinuxTracing PUBLIC
+        ElfUtils
         OrbitBase
         OrbitProtos
         CONAN_PKG::abseil

--- a/OrbitLinuxTracing/PerfEvent.h
+++ b/OrbitLinuxTracing/PerfEvent.h
@@ -309,16 +309,18 @@ class UretprobesPerfEvent : public PerfEvent, public AbstractUprobesPerfEvent {
 // perf_event_open event, but we want it to be part of the same hierarchy.
 class MapsPerfEvent : public PerfEvent {
  public:
-  MapsPerfEvent(uint64_t timestamp, std::string maps)
-      : timestamp_{timestamp}, maps_{std::move(maps)} {}
+  MapsPerfEvent(int32_t pid, uint64_t timestamp, std::string maps)
+      : pid_{pid}, timestamp_{timestamp}, maps_{std::move(maps)} {}
 
   uint64_t GetTimestamp() const override { return timestamp_; }
 
   void Accept(PerfEventVisitor* visitor) override;
 
-  const std::string& GetMaps() const { return maps_; }
+  [[nodiscard]] const std::string& GetMaps() const { return maps_; }
+  [[nodiscard]] int32_t GetPid() const { return pid_; }
 
  private:
+  int32_t pid_;
   uint64_t timestamp_;
   std::string maps_;
 };

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -835,7 +835,7 @@ void TracerThread::ProcessMmapEvent(const perf_event_header& header,
 
   // There was a call to mmap with PROT_EXEC, hence refresh the maps.
   // This should happen rarely.
-  auto event = std::make_unique<MapsPerfEvent>(MonotonicTimestampNs(), ReadMaps(pid_));
+  auto event = std::make_unique<MapsPerfEvent>(pid_, MonotonicTimestampNs(), ReadMaps(pid_));
   event->SetOriginFileDescriptor(ring_buffer->GetFileDescriptor());
   DeferEvent(std::move(event));
 }

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
@@ -13,6 +13,7 @@
 #include <optional>
 #include <utility>
 
+#include "ElfUtils/LinuxMap.h"
 #include "Function.h"
 #include "OrbitBase/Logging.h"
 #include "capture.pb.h"
@@ -184,7 +185,22 @@ void UprobesUnwindingVisitor::visit(UretprobesPerfEvent* event) {
 }
 
 void UprobesUnwindingVisitor::visit(MapsPerfEvent* event) {
+  CHECK(listener_ != nullptr);
   current_maps_ = LibunwindstackUnwinder::ParseMaps(event->GetMaps());
+
+  auto result_or_error = orbit_elf_utils::ParseMaps(event->GetMaps());
+  if (!result_or_error) {
+    ERROR("Couldn't parse maps: %s", result_or_error.error().message());
+    return;
+  }
+
+  orbit_grpc_protos::ModulesUpdateEvent modules_update_event;
+  modules_update_event.set_pid(event->GetPid());
+  modules_update_event.set_timestamp_ns(event->GetTimestamp());
+  const auto& modules = result_or_error.value();
+  *modules_update_event.mutable_modules() = {modules.begin(), modules.end()};
+
+  listener_->OnModulesUpdate(std::move(modules_update_event));
 }
 
 }  // namespace LinuxTracing

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/TracerListener.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/TracerListener.h
@@ -21,6 +21,7 @@ class TracerListener {
   virtual void OnThreadStateSlice(orbit_grpc_protos::ThreadStateSlice thread_state_slice) = 0;
   virtual void OnAddressInfo(orbit_grpc_protos::AddressInfo address_info) = 0;
   virtual void OnTracepointEvent(orbit_grpc_protos::TracepointEvent tracepoint_event) = 0;
+  virtual void OnModulesUpdate(orbit_grpc_protos::ModulesUpdateEvent modules_update_event) = 0;
 };
 
 }  // namespace LinuxTracing

--- a/OrbitService/LinuxTracingHandler.cpp
+++ b/OrbitService/LinuxTracingHandler.cpp
@@ -143,6 +143,14 @@ void LinuxTracingHandler::OnTracepointEvent(orbit_grpc_protos::TracepointEvent t
   capture_event_buffer_->AddEvent(std::move(event));
 }
 
+void LinuxTracingHandler::OnModulesUpdate(
+    orbit_grpc_protos::ModulesUpdateEvent modules_update_event) {
+  orbit_grpc_protos::CaptureEvent event;
+  *event.mutable_modules_update_event() = std::move(modules_update_event);
+
+  capture_event_buffer_->AddEvent(std::move(event));
+}
+
 uint64_t LinuxTracingHandler::ComputeCallstackKey(const Callstack& callstack) {
   uint64_t key = 17;
   for (uint64_t pc : callstack.pcs()) {

--- a/OrbitService/LinuxTracingHandler.h
+++ b/OrbitService/LinuxTracingHandler.h
@@ -39,6 +39,7 @@ class LinuxTracingHandler : public LinuxTracing::TracerListener {
   void OnThreadStateSlice(orbit_grpc_protos::ThreadStateSlice thread_state_slice) override;
   void OnAddressInfo(orbit_grpc_protos::AddressInfo address_info) override;
   void OnTracepointEvent(orbit_grpc_protos::TracepointEvent tracepoint_event) override;
+  void OnModulesUpdate(orbit_grpc_protos::ModulesUpdateEvent modules_update_event) override;
 
  private:
   CaptureEventBuffer* capture_event_buffer_;


### PR DESCRIPTION
In event of a module load/unload during capture send
updated modules list to the client.

Bug: http://b/168797897
Test: capture