### PR TITLE
Add metrics uploader client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,7 @@ if(WITH_ORBITGL)
 endif()
 
 if(WITH_GUI)
+  add_subdirectory(MetricsUploader)
   add_subdirectory(OrbitGgp)
   add_subdirectory(OrbitSsh)
   add_subdirectory(OrbitSshQt)

--- a/MetricsUploader/CMakeLists.txt
+++ b/MetricsUploader/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(MetricsUploader PRIVATE MetricsUploaderLinux.cpp)
 endif()
 
 target_link_libraries(MetricsUploader PUBLIC OrbitBase
+                                             OrbitVersion
                                              CONAN_PKG::abseil)
 
 # generate protos for communication

--- a/MetricsUploader/CMakeLists.txt
+++ b/MetricsUploader/CMakeLists.txt
@@ -35,3 +35,37 @@ protobuf_generate(TARGET MetricsUploader PROTOS proto/orbit_log_event.proto)
 target_include_directories(MetricsUploader PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(MetricsUploader PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/proto)
 target_link_libraries(MetricsUploader PUBLIC CONAN_PKG::protobuf)
+
+if (WIN32)
+# build .dll for tests
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
+add_library(MetricsUploaderClientWithoutSendEvent SHARED TestClients/ClientWithoutSendEvent.cpp)
+target_link_libraries(MetricsUploaderClientWithoutSendEvent PRIVATE MetricsUploader)
+set_target_properties(MetricsUploaderClientWithoutSendEvent PROPERTIES FOLDER "MetricsUploaderTestClients")
+
+add_library(MetricsUploaderClientWithoutStart SHARED TestClients/ClientWithoutStart.cpp)
+target_link_libraries(MetricsUploaderClientWithoutStart PRIVATE MetricsUploader)
+set_target_properties(MetricsUploaderClientWithoutStart PROPERTIES FOLDER "MetricsUploaderTestClients")
+
+add_library(MetricsUploaderCompleteClient SHARED TestClients/CompleteClient.cpp)
+target_link_libraries(MetricsUploaderCompleteClient PRIVATE MetricsUploader)
+set_target_properties(MetricsUploaderCompleteClient PROPERTIES FOLDER "MetricsUploaderTestClients")
+
+add_library(MetricsUploaderStartWithErrorClient SHARED TestClients/StartWithErrorClient.cpp)
+target_link_libraries(MetricsUploaderStartWithErrorClient PRIVATE MetricsUploader)
+set_target_properties(MetricsUploaderStartWithErrorClient PROPERTIES FOLDER "MetricsUploaderTestClients")
+
+# add tests
+add_executable(MetricsUploaderTests)
+
+target_compile_options(MetricsUploaderTests PRIVATE ${STRICT_COMPILE_FLAGS})
+
+target_sources(MetricsUploaderTests PRIVATE MetricsUploaderWindowsTest.cpp)
+
+target_link_libraries(MetricsUploaderTests PRIVATE MetricsUploader
+                                                   GTest::GTest
+                                                   GTest::Main)
+
+register_test(MetricsUploaderTests)
+endif()

--- a/MetricsUploader/CMakeLists.txt
+++ b/MetricsUploader/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+cmake_minimum_required(VERSION 3.15)
+
+project(MetricsUploader)
+
+add_library(MetricsUploader STATIC)
+
+target_compile_options(MetricsUploader PRIVATE ${STRICT_COMPILE_FLAGS})
+
+target_compile_features(MetricsUploader PUBLIC cxx_std_17)
+
+target_include_directories(MetricsUploader PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include
+                                           PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+
+target_sources(MetricsUploader PUBLIC include/MetricsUploader/MetricsUploader.h
+                                      include/MetricsUploader/Result.h
+                               PRIVATE MetricsUploader.cpp
+                                       Result.cpp)
+
+if (WIN32)
+target_sources(MetricsUploader PRIVATE MetricsUploaderWindows.cpp)
+else()
+target_sources(MetricsUploader PRIVATE MetricsUploaderLinux.cpp)
+endif()
+
+target_link_libraries(MetricsUploader PUBLIC OrbitBase
+                                             CONAN_PKG::abseil)
+
+# generate protos for communication
+protobuf_generate(TARGET MetricsUploader PROTOS proto/orbit_log_event.proto)
+target_include_directories(MetricsUploader PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(MetricsUploader PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/proto)
+target_link_libraries(MetricsUploader PUBLIC CONAN_PKG::protobuf)

--- a/MetricsUploader/MetricsUploader.cpp
+++ b/MetricsUploader/MetricsUploader.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "OrbitBase/Logging.h"
+#include "OrbitVersion/OrbitVersion.h"
 
 namespace orbit_metrics_uploader {
 
@@ -14,6 +15,7 @@ bool MetricsUploader::SendLogEvent(OrbitLogEvent_LogEventType log_event_type) {
   if (send_log_event_addr_ != nullptr) {
     OrbitLogEvent log_event;
     log_event.set_log_event_type(log_event_type);
+    log_event.set_orbit_version(orbit_core::GetVersion());
 
     int message_size = log_event.ByteSize();
     std::vector<uint8_t> buffer(message_size);

--- a/MetricsUploader/MetricsUploader.cpp
+++ b/MetricsUploader/MetricsUploader.cpp
@@ -11,11 +11,13 @@
 
 namespace orbit_metrics_uploader {
 
-bool MetricsUploader::SendLogEvent(OrbitLogEvent_LogEventType log_event_type) {
+bool MetricsUploader::SendLogEvent(OrbitLogEvent_LogEventType log_event_type,
+                                   std::chrono::milliseconds event_duration) {
   if (send_log_event_addr_ != nullptr) {
     OrbitLogEvent log_event;
     log_event.set_log_event_type(log_event_type);
     log_event.set_orbit_version(orbit_core::GetVersion());
+    log_event.set_event_duration_milliseconds(event_duration.count());
 
     int message_size = log_event.ByteSize();
     std::vector<uint8_t> buffer(message_size);

--- a/MetricsUploader/MetricsUploader.cpp
+++ b/MetricsUploader/MetricsUploader.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "MetricsUploader/MetricsUploader.h"
+
+#include <vector>
+
+#include "OrbitBase/Logging.h"
+
+namespace orbit_metrics_uploader {
+
+bool MetricsUploader::SendLogEvent(OrbitLogEvent_LogEventType log_event_type) {
+  if (send_log_event_addr_ != nullptr) {
+    OrbitLogEvent log_event;
+    log_event.set_log_event_type(log_event_type);
+
+    int message_size = log_event.ByteSize();
+    std::vector<uint8_t> buffer(message_size);
+    log_event.SerializeToArray(buffer.data(), message_size);
+
+    Result result = send_log_event_addr_(buffer.data(), message_size);
+    if (result == kNoError) {
+      return true;
+    }
+    ERROR("Can't start the metrics uploader client: %s", GetErrorMessage(result));
+  }
+  return false;
+}
+
+}  // namespace orbit_metrics_uploader

--- a/MetricsUploader/MetricsUploaderLinux.cpp
+++ b/MetricsUploader/MetricsUploaderLinux.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "MetricsUploader/MetricsUploader.h"
+
+namespace orbit_metrics_uploader {
+
+MetricsUploader::MetricsUploader() = default;
+MetricsUploader::~MetricsUploader() = default;
+MetricsUploader::MetricsUploader(MetricsUploader&& other) = default;
+MetricsUploader& MetricsUploader::operator=(MetricsUploader&& other) = default;
+
+ErrorMessageOr<MetricsUploader> MetricsUploader::CreateMetricsUploader(std::string) {
+  return ErrorMessage("MetricsUploader is not implemented on Linux");
+}
+
+}  // namespace orbit_metrics_uploader

--- a/MetricsUploader/MetricsUploaderWindows.cpp
+++ b/MetricsUploader/MetricsUploaderWindows.cpp
@@ -1,0 +1,100 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <absl/memory/memory.h>
+
+#include "MetricsUploader/MetricsUploader.h"
+#include "OrbitBase/Logging.h"
+
+namespace orbit_metrics_uploader {
+
+constexpr const char* kSendLogEventFunctionName = "SendOrbitLogEvent";
+constexpr const char* kStartUploaderClientFunctionName = "StartUploaderClient";
+
+MetricsUploader::MetricsUploader(std::string client_name,
+                                 Result (*send_log_event_addr)(const uint8_t*, int),
+                                 HMODULE metrics_uploader_client_dll)
+    : client_name_(std::move(client_name)),
+      send_log_event_addr_(send_log_event_addr),
+      metrics_uploader_client_dll_(metrics_uploader_client_dll) {}
+
+MetricsUploader::MetricsUploader(MetricsUploader&& other)
+    : client_name_(std::move(other.client_name_)),
+      metrics_uploader_client_dll_(other.metrics_uploader_client_dll_),
+      send_log_event_addr_(other.send_log_event_addr_) {
+  other.metrics_uploader_client_dll_ = nullptr;
+  other.send_log_event_addr_ = nullptr;
+}
+
+MetricsUploader& MetricsUploader::operator=(MetricsUploader&& other) {
+  if (&other == this) {
+    return *this;
+  }
+
+  client_name_ = std::move(other.client_name_);
+
+  metrics_uploader_client_dll_ = other.metrics_uploader_client_dll_;
+  other.metrics_uploader_client_dll_ = nullptr;
+
+  send_log_event_addr_ = other.send_log_event_addr_;
+  other.send_log_event_addr_ = nullptr;
+
+  return *this;
+}
+
+MetricsUploader::~MetricsUploader() {
+  if (nullptr != metrics_uploader_client_dll_) {
+    FreeLibrary(metrics_uploader_client_dll_);
+  }
+}
+
+ErrorMessageOr<MetricsUploader> MetricsUploader::CreateMetricsUploader(std::string client_name) {
+  HMODULE metrics_uploader_client_dll;
+  if (GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, client_name.c_str(),
+                         &metrics_uploader_client_dll) != 0) {
+    return ErrorMessage("MetricsUploader is already created");
+  }
+
+  metrics_uploader_client_dll = LoadLibraryA(client_name.c_str());
+  if (nullptr != metrics_uploader_client_dll) {
+    LOG("Metrics uploader client library is loaded");
+
+    auto start_uploader_client_addr = reinterpret_cast<Result (*)()>(
+        GetProcAddress(metrics_uploader_client_dll, kStartUploaderClientFunctionName));
+    if (nullptr == start_uploader_client_addr) {
+      std::string error_message =
+          absl::StrFormat("%s function not found", kStartUploaderClientFunctionName);
+      ERROR("%s", error_message);
+      FreeLibrary(metrics_uploader_client_dll);
+      return ErrorMessage(error_message);
+    }
+
+    auto send_log_event_addr = reinterpret_cast<Result (*)(const uint8_t*, int)>(
+        GetProcAddress(metrics_uploader_client_dll, kSendLogEventFunctionName));
+    if (nullptr == send_log_event_addr) {
+      std::string error_message =
+          absl::StrFormat("%s function not found", kSendLogEventFunctionName);
+      ERROR("%s", error_message);
+      FreeLibrary(metrics_uploader_client_dll);
+      return ErrorMessage(error_message);
+    }
+
+    // set up connection and create a client
+    Result result = start_uploader_client_addr();
+    if (result != kNoError) {
+      std::string error_message = absl::StrFormat(
+          "Error while starting the metrics uploader client: %s", GetErrorMessage(result));
+      ERROR("%s", error_message);
+      FreeLibrary(metrics_uploader_client_dll);
+      return ErrorMessage(error_message);
+    }
+
+    return MetricsUploader(client_name, send_log_event_addr, metrics_uploader_client_dll);
+  }
+  std::string error_message = "Metrics uploader client library is not found";
+  ERROR("%s", error_message);
+  return ErrorMessage(error_message);
+}
+
+}  // namespace orbit_metrics_uploader

--- a/MetricsUploader/MetricsUploaderWindowsTest.cpp
+++ b/MetricsUploader/MetricsUploaderWindowsTest.cpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "MetricsUploader/MetricsUploader.h"
+
+using orbit_metrics_uploader::MetricsUploader;
+
+TEST(MetricsUploader, CreateMetricsUploaderFromClientWithoutSendEvent) {
+  auto metrics_uploader =
+      MetricsUploader::CreateMetricsUploader("MetricsUploaderClientWithoutSendEvent");
+  EXPECT_EQ(metrics_uploader.has_value(), false);
+}
+
+TEST(MetricsUploader, CreateMetricsUploaderFromClientWithoutStart) {
+  auto metrics_uploader =
+      MetricsUploader::CreateMetricsUploader("MetricsUploaderClientWithoutStart");
+  EXPECT_EQ(metrics_uploader.has_value(), false);
+}
+
+TEST(MetricsUploader, StartMetricsUploaderWithError) {
+  auto metrics_uploader =
+      MetricsUploader::CreateMetricsUploader("MetricsUploaderStartWithErrorClient");
+  EXPECT_EQ(metrics_uploader.has_value(), false);
+}
+
+TEST(MetricsUploader, SendLogEvent) {
+  auto metrics_uploader = MetricsUploader::CreateMetricsUploader("MetricsUploaderCompleteClient");
+  EXPECT_EQ(metrics_uploader.has_value(), true);
+  bool result = metrics_uploader.value().SendLogEvent(
+      orbit_metrics_uploader::OrbitLogEvent_LogEventType_UNKNOWN_EVENT_TYPE);
+  EXPECT_EQ(result, false);
+  result = metrics_uploader.value().SendLogEvent(
+      orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_INITIALIZED);
+  EXPECT_EQ(result, true);
+  result = metrics_uploader.value().SendLogEvent(
+      orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_CAPTURE_DURATION,
+      std::chrono::milliseconds(100));
+  EXPECT_EQ(result, true);
+}
+
+TEST(MetricsUploader, CreateTwoMetricsUploaders) {
+  auto metrics_uploader1 = MetricsUploader::CreateMetricsUploader("MetricsUploaderCompleteClient");
+  EXPECT_EQ(metrics_uploader1.has_value(), true);
+  auto metrics_uploader2 = MetricsUploader::CreateMetricsUploader("MetricsUploaderCompleteClient");
+  EXPECT_EQ(metrics_uploader2.has_value(), false);
+}

--- a/MetricsUploader/Result.cpp
+++ b/MetricsUploader/Result.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "MetricsUploader/Result.h"
+
+namespace orbit_metrics_uploader {
+
+std::string GetErrorMessage(Result result) {
+  switch (result) {
+    case kMetricsUploaderServiceNotStarted:
+      return "Metrics uploader service was not started";
+    case kSdkConfigNotLoaded:
+      return "SDK config was not loaded";
+    case kCannotMarshalLogEvent:
+      return "Can't marshall log event";
+    case kCannotQueueLogEvent:
+      return "Can't queue log event";
+    case kClientNotInitialized:
+      return "Uploader client wasn't initialized. StartUploaderClient() should be called before "
+             "sending log events.";
+    case kCannotUnmarshalLogEvent:
+      return "Can't unmarshal OrbitLogEvent proto";
+    default:
+      return "No errors";
+  }
+}
+
+}  // namespace orbit_metrics_uploader

--- a/MetricsUploader/TestClients/ClientWithoutSendEvent.cpp
+++ b/MetricsUploader/TestClients/ClientWithoutSendEvent.cpp
@@ -1,0 +1,11 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "MetricsUploader/Result.h"
+
+using orbit_metrics_uploader::Result;
+
+extern "C" {
+__declspec(dllexport) enum Result StartUploaderClient() { return Result::kNoError; }
+}  // extern "C"

--- a/MetricsUploader/TestClients/ClientWithoutStart.cpp
+++ b/MetricsUploader/TestClients/ClientWithoutStart.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <cstdint>
+
+#include "MetricsUploader/Result.h"
+
+using orbit_metrics_uploader::Result;
+
+extern "C" {
+__declspec(dllexport) enum Result SendOrbitLogEvent(uint8_t* serialized_proto, int length) {
+  return Result::kNoError;
+}
+}  // extern "C"

--- a/MetricsUploader/TestClients/CompleteClient.cpp
+++ b/MetricsUploader/TestClients/CompleteClient.cpp
@@ -1,0 +1,28 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <cstdint>
+
+#include "MetricsUploader/Result.h"
+#include "orbit_log_event.pb.h"
+
+using orbit_metrics_uploader::OrbitLogEvent;
+using orbit_metrics_uploader::OrbitLogEvent_LogEventType_UNKNOWN_EVENT_TYPE;
+
+using orbit_metrics_uploader::Result;
+
+extern "C" {
+__declspec(dllexport) enum Result StartUploaderClient() { return Result::kNoError; }
+__declspec(dllexport) enum Result SendOrbitLogEvent(uint8_t* serialized_proto, int length) {
+  OrbitLogEvent log_event;
+  bool result = log_event.ParseFromArray(serialized_proto, length);
+  if (!result) {
+    return Result::kCannotUnmarshalLogEvent;
+  }
+  if (log_event.log_event_type() == OrbitLogEvent_LogEventType_UNKNOWN_EVENT_TYPE) {
+    return Result::kCannotQueueLogEvent;
+  }
+  return Result::kNoError;
+}
+}  // extern "C"

--- a/MetricsUploader/TestClients/StartWithErrorClient.cpp
+++ b/MetricsUploader/TestClients/StartWithErrorClient.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <cstdint>
+
+#include "MetricsUploader/Result.h"
+
+using orbit_metrics_uploader::Result;
+
+extern "C" {
+__declspec(dllexport) enum Result StartUploaderClient() { return Result::kSdkConfigNotLoaded; }
+__declspec(dllexport) enum Result SendOrbitLogEvent(uint8_t* serialized_proto, int length) {
+  return Result::kNoError;
+}
+}  // extern "C"

--- a/MetricsUploader/include/MetricsUploader/MetricsUploader.h
+++ b/MetricsUploader/include/MetricsUploader/MetricsUploader.h
@@ -9,6 +9,7 @@
 #include <windows.h>
 #endif  // WIN32
 
+#include <chrono>
 #include <cstdint>
 #include <string>
 
@@ -51,7 +52,8 @@ class MetricsUploader {
 
   // Send log events to the server using metrics_uploader.
   // Returns true on success and false otherwise.
-  bool SendLogEvent(OrbitLogEvent_LogEventType log_event_type);
+  bool SendLogEvent(OrbitLogEvent_LogEventType log_event_type,
+                    std::chrono::milliseconds event_duration = std::chrono::milliseconds::zero());
 
  private:
 #ifdef _WIN32

--- a/MetricsUploader/include/MetricsUploader/MetricsUploader.h
+++ b/MetricsUploader/include/MetricsUploader/MetricsUploader.h
@@ -1,0 +1,72 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_METRICS_UPLOADER_METRICS_UPLOADER_H_
+#define ORBIT_METRICS_UPLOADER_METRICS_UPLOADER_H_
+
+#ifdef _WIN32
+#include <windows.h>
+#endif  // WIN32
+
+#include <cstdint>
+#include <string>
+
+#include "MetricsUploader/Result.h"
+#include "OrbitBase/Result.h"
+#include "orbit_log_event.pb.h"
+
+namespace orbit_metrics_uploader {
+
+const std::string kMetricsUploaderClientDllName = "metrics_uploader_client";
+
+// This class is used for sending log events from Orbit. It works only on Windows and only if
+// metrics_uploader_client.dll is available. The types of logs that could be send are defined in
+// orbit_client_protos::OrbitLogEvent::LogEventType.
+//
+// Only one instance of the class is allowed.
+//
+// Usage example:
+//
+// auto metrics_uploader = MetricsUploader::CreateMetricsUploader();
+// if (metrics_uploader.has_value()) {
+//   metrics_uploader.value().SendLogEvent(...);
+// }
+//
+class MetricsUploader {
+ public:
+  // Create a MetricsUploader instance, load metrics uploader client library if available and starts
+  // metrics uploader client when called first time. Return the instance if there are no errors and
+  // ErrorMessage otherwise.
+  [[nodiscard]] static ErrorMessageOr<MetricsUploader> CreateMetricsUploader(
+      std::string client_name = kMetricsUploaderClientDllName);
+
+  // Unload metrics_uploader_client.dll
+  ~MetricsUploader();
+
+  MetricsUploader(const MetricsUploader& other) = delete;
+  MetricsUploader(MetricsUploader&& other);
+  MetricsUploader& operator=(const MetricsUploader& other) = delete;
+  MetricsUploader& operator=(MetricsUploader&& other);
+
+  // Send log events to the server using metrics_uploader.
+  // Returns true on success and false otherwise.
+  bool SendLogEvent(OrbitLogEvent_LogEventType log_event_type);
+
+ private:
+#ifdef _WIN32
+  HMODULE metrics_uploader_client_dll_;
+  explicit MetricsUploader(std::string client_name,
+                           Result (*send_log_event_addr)(const uint8_t*, int),
+                           HMODULE metrics_uploader_client_dll);
+#else
+  MetricsUploader();
+#endif
+
+  Result (*send_log_event_addr_)(const uint8_t*, int) = nullptr;
+  std::string client_name_;
+};
+
+}  // namespace orbit_metrics_uploader
+
+#endif  // ORBIT_METRICS_UPLOADER_METRICS_UPLOADER_H_

--- a/MetricsUploader/include/MetricsUploader/Result.h
+++ b/MetricsUploader/include/MetricsUploader/Result.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_METRICS_UPLOADER_RESULT_H_
+#define ORBIT_METRICS_UPLOADER_RESULT_H_
+
+#include <string>
+
+namespace orbit_metrics_uploader {
+
+// This enum represents the errors that could happen inside the metrics uploader client library, and
+// should be in sync with the enum in the library itself.
+enum Result {
+  kNoError,
+  kMetricsUploaderServiceNotStarted,
+  kSdkConfigNotLoaded,
+  kCannotMarshalLogEvent,
+  kCannotQueueLogEvent,
+  kClientNotInitialized,
+  kCannotUnmarshalLogEvent
+};
+
+std::string GetErrorMessage(Result result);
+
+}  // namespace orbit_metrics_uploader
+
+#endif  // ORBIT_METRICS_UPLOADER_RESULT_H_

--- a/MetricsUploader/proto/orbit_log_event.proto
+++ b/MetricsUploader/proto/orbit_log_event.proto
@@ -13,8 +13,10 @@ message OrbitLogEvent {
   enum LogEventType {
     UNKNOWN_EVENT_TYPE = 0;
     ORBIT_INITIALIZED = 1;
+    ORBIT_CAPTURE_DURATION = 2;
   }
   LogEventType log_event_type = 1;
 
   string orbit_version = 2;
+  int64 event_duration_milliseconds = 3;
 }

--- a/MetricsUploader/proto/orbit_log_event.proto
+++ b/MetricsUploader/proto/orbit_log_event.proto
@@ -15,4 +15,6 @@ message OrbitLogEvent {
     ORBIT_INITIALIZED = 1;
   }
   LogEventType log_event_type = 1;
+
+  string orbit_version = 2;
 }

--- a/MetricsUploader/proto/orbit_log_event.proto
+++ b/MetricsUploader/proto/orbit_log_event.proto
@@ -1,0 +1,18 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+syntax = "proto3";
+
+package orbit_metrics_uploader;
+
+// This proto is used for communication between Orbit and metrics uploader
+// client. Changing this proto requires changing the metrics uploader client
+// library accordingly.
+message OrbitLogEvent {
+  enum LogEventType {
+    UNKNOWN_EVENT_TYPE = 0;
+    ORBIT_INITIALIZED = 1;
+  }
+  LogEventType log_event_type = 1;
+}

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -896,6 +896,15 @@ void OrbitApp::StopCapture() {
     return;
   }
 
+  if (metrics_uploader_ != nullptr) {
+    CHECK(GCurrentTimeGraph != nullptr);
+    auto capture_time_us =
+        std::chrono::duration<double, std::micro>(GCurrentTimeGraph->GetCaptureTimeSpanUs());
+    auto capture_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(capture_time_us);
+    metrics_uploader_->SendLogEvent(
+        orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_CAPTURE_DURATION, capture_time_ms);
+  }
+
   CHECK(capture_stop_requested_callback_);
   capture_stop_requested_callback_();
 }

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -39,6 +39,7 @@
 #include "IntrospectionWindow.h"
 #include "MainThreadExecutor.h"
 #include "ManualInstrumentationManager.h"
+#include "MetricsUploader/MetricsUploader.h"
 #include "ModulesDataView.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
@@ -74,10 +75,13 @@
 
 class OrbitApp final : public DataViewFactory, public CaptureListener {
  public:
-  OrbitApp(MainThreadExecutor* main_thread_executor);
+  OrbitApp(MainThreadExecutor* main_thread_executor,
+           orbit_metrics_uploader::MetricsUploader* metrics_uploader = nullptr);
   ~OrbitApp() override;
 
-  static std::unique_ptr<OrbitApp> Create(MainThreadExecutor* main_thread_executor);
+  static std::unique_ptr<OrbitApp> Create(
+      MainThreadExecutor* main_thread_executor,
+      orbit_metrics_uploader::MetricsUploader* metrics_uploader = nullptr);
 
   void PostInit();
   void MainTick();
@@ -494,6 +498,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   std::optional<CaptureData> capture_data_;
 
   FrameTrackOnlineProcessor frame_track_online_processor_;
+
+  orbit_metrics_uploader::MetricsUploader* metrics_uploader_;
 };
 
 #endif  // ORBIT_GL_APP_H_

--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -123,7 +123,8 @@ target_include_directories(OrbitGl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_link_libraries(
   OrbitGl
-  PUBLIC OrbitAccessibility
+  PUBLIC MetricsUploader
+         OrbitAccessibility
          OrbitCore
          OrbitCaptureClient
          OrbitClientData

--- a/OrbitQt/CMakeLists.txt
+++ b/OrbitQt/CMakeLists.txt
@@ -104,7 +104,8 @@ target_include_directories(OrbitQt PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_link_libraries(
   OrbitQt
-  PRIVATE OrbitAccessibility
+  PRIVATE MetricsUploader
+          OrbitAccessibility
           OrbitCore
           OrbitGl
           OrbitGgp

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -48,6 +48,7 @@
 #include "Error.h"
 #include "FunctionsDataView.h"
 #include "ImGuiOrbit.h"
+#include "MetricsUploader/MetricsUploader.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitGgp/Error.h"
 #include "OrbitSsh/Context.h"
@@ -129,6 +130,7 @@ static outcome::result<void> RunUiInstance(
   const auto& [ports, capture_path] = result;
 
   std::string grpc_server_address = absl::StrFormat("127.0.0.1:%d", ports.grpc_port);
+  auto metrics_uploader = orbit_metrics_uploader::MetricsUploader::CreateMetricsUploader();
 
   ServiceDeployManager* service_deploy_manager_ptr = nullptr;
 
@@ -142,7 +144,8 @@ static outcome::result<void> RunUiInstance(
   {  // Scoping of QT UI Resources
     constexpr uint32_t kDefaultFontSize = 14;
 
-    OrbitMainWindow w(service_deploy_manager_ptr, grpc_server_address, kDefaultFontSize);
+    OrbitMainWindow w(service_deploy_manager_ptr, grpc_server_address, kDefaultFontSize,
+                      metrics_uploader.has_value() ? &metrics_uploader.value() : nullptr);
 
     // "resize" is required to make "showMaximized" work properly.
     w.resize(1280, 720);

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -75,6 +75,9 @@ ABSL_DECLARE_FLAG(bool, local);
 ABSL_DECLARE_FLAG(bool, devmode);
 ABSL_DECLARE_FLAG(bool, nodeploy);
 
+// TODO(irinashkviro): remove this flag when metrics uploading is finished
+ABSL_FLAG(bool, enable_metrics, false, "Enables sending log events");
+
 using ServiceDeployManager = orbit_qt::ServiceDeployManager;
 using DeploymentConfiguration = orbit_qt::DeploymentConfiguration;
 using OrbitStartupWindow = orbit_qt::OrbitStartupWindow;
@@ -130,7 +133,10 @@ static outcome::result<void> RunUiInstance(
   const auto& [ports, capture_path] = result;
 
   std::string grpc_server_address = absl::StrFormat("127.0.0.1:%d", ports.grpc_port);
-  auto metrics_uploader = orbit_metrics_uploader::MetricsUploader::CreateMetricsUploader();
+  ErrorMessageOr<orbit_metrics_uploader::MetricsUploader> metrics_uploader = ErrorMessage("");
+  if (absl::GetFlag(FLAGS_enable_metrics)) {
+    metrics_uploader = orbit_metrics_uploader::MetricsUploader::CreateMetricsUploader();
+  }
 
   ServiceDeployManager* service_deploy_manager_ptr = nullptr;
 

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -197,10 +197,11 @@ OrbitMainWindow::OrbitMainWindow(orbit_qt::TargetConfiguration target_configurat
 }
 
 OrbitMainWindow::OrbitMainWindow(orbit_qt::ServiceDeployManager* service_deploy_manager,
-                                 std::string grpc_server_address, uint32_t font_size)
+                                 std::string grpc_server_address, uint32_t font_size,
+                                 orbit_metrics_uploader::MetricsUploader* metrics_uploader)
     : QMainWindow(nullptr),
       main_thread_executor_{CreateMainThreadExecutor()},
-      app_{OrbitApp::Create(main_thread_executor_.get())},
+      app_{OrbitApp::Create(main_thread_executor_.get(), metrics_uploader)},
       ui(new Ui::OrbitMainWindow) {
   SetupMainWindow(font_size);
 

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -34,6 +34,7 @@
 #include "DataViewTypes.h"
 #include "DisassemblyReport.h"
 #include "MainThreadExecutor.h"
+#include "MetricsUploader/MetricsUploader.h"
 #include "OrbitClientServices/ProcessManager.h"
 #include "StatusListener.h"
 #include "TargetConfiguration.h"
@@ -55,7 +56,8 @@ class OrbitMainWindow : public QMainWindow {
 
   // TODO (170468590) remove when not needed anymore
   explicit OrbitMainWindow(orbit_qt::ServiceDeployManager* service_deploy_manager,
-                           std::string grpc_server_address, uint32_t font_size);
+                           std::string grpc_server_address, uint32_t font_size,
+                           orbit_metrics_uploader::MetricsUploader* metrics_uploader = nullptr);
 
   explicit OrbitMainWindow(orbit_qt::TargetConfiguration target_configuration, uint32_t font_size);
   ~OrbitMainWindow() override;


### PR DESCRIPTION
Add MetricsUploader subproject to send log events from Orbit. For
communication between Orbit and metrics_uploader_client.dll
OrbitLogEvent proto message is used.

Currently only ORBIT_INITIALIZED and ORBIT_CAPTURE_DURATION
log message are available.

The metrics will be sent only if metrics_uploader_client.dll is available
and --enable_metrics flag is set.

Bug: http://b/170389366

Test: start Orbit, check that the ORBIT_INITIALIZED and
ORBIT_CAPTURE_DURATION log messages appears on the server.