### PR TITLE
Include .py and .proto files in license_headers check

### DIFF
--- a/kokoro/checks/license_headers/check.sh
+++ b/kokoro/checks/license_headers/check.sh
@@ -30,7 +30,7 @@ if [ "$0" == "$SCRIPT" ]; then
   done <<< $(git diff -U0 --no-color --relative --name-only $MERGE_BASE \
   | grep -v third_party/ \
   | grep -v /build \
-  | egrep '\.cpp$|\.h$|CMakeLists\.txt$|\.js$')
+  | egrep '\.cpp$|\.h$|CMakeLists\.txt$|\.js$|\.proto$|\.py$')
 
   if [ -n "$LICENSE_HEADER_MISSED" ]; then
     exit 1


### PR DESCRIPTION
Test: delete license headers in .py and .proto files and run check.sh
script locally; verify that the result of the script is that these files
are missing a license/copyright header.