### PR TITLE
Move part of codebase to std::filesystem::path

### DIFF
--- a/ElfUtils/CMakeLists.txt
+++ b/ElfUtils/CMakeLists.txt
@@ -37,7 +37,6 @@ target_sources(ElfUtilsTests PRIVATE
 target_link_libraries(
   ElfUtilsTests
   PRIVATE ElfUtils
-          OrbitCore # TODO: This is needed for GetExecutablePath - consider moving it to OrbitBase
           GTest::Main
           CONAN_PKG::llvm_object
           CONAN_PKG::abseil)

--- a/ElfUtils/ElfFileTest.cpp
+++ b/ElfUtils/ElfFileTest.cpp
@@ -9,7 +9,7 @@
 #include <utility>
 
 #include "ElfUtils/ElfFile.h"
-#include "Path.h"
+#include "OrbitBase/ExecutablePath.h"
 #include "absl/strings/ascii.h"
 #include "absl/strings/str_format.h"
 #include "symbol.pb.h"
@@ -18,9 +18,8 @@ using ElfUtils::ElfFile;
 using orbit_grpc_protos::SymbolInfo;
 
 TEST(ElfFile, LoadSymbols) {
-  std::string executable_dir = Path::GetExecutableDir();
-  std::string executable = "hello_world_elf_with_debug_info";
-  std::string file_path = executable_dir + "testdata/" + executable;
+  std::filesystem::path file_path =
+      orbit_base::GetExecutableDir() / "testdata" / "hello_world_elf_with_debug_info";
 
   auto elf_file_result = ElfFile::Create(file_path);
   ASSERT_TRUE(elf_file_result) << elf_file_result.error().message();
@@ -49,10 +48,11 @@ TEST(ElfFile, LoadSymbols) {
 }
 
 TEST(ElfFile, CalculateLoadBias) {
-  const std::string executable_dir = Path::GetExecutableDir();
+  std::filesystem::path executable_dir = orbit_base::GetExecutableDir();
 
   {
-    const std::string test_elf_file_dynamic = executable_dir + "/testdata/hello_world_elf";
+    const std::filesystem::path test_elf_file_dynamic =
+        executable_dir / "testdata" / "hello_world_elf";
     auto elf_file_dynamic = ElfFile::Create(test_elf_file_dynamic);
     ASSERT_TRUE(elf_file_dynamic);
     const auto load_bias = elf_file_dynamic.value()->GetLoadBias();
@@ -61,7 +61,8 @@ TEST(ElfFile, CalculateLoadBias) {
   }
 
   {
-    const std::string test_elf_file_static = executable_dir + "/testdata/hello_world_static_elf";
+    const std::filesystem::path test_elf_file_static =
+        executable_dir / "testdata" / "hello_world_static_elf";
     auto elf_file_static = ElfFile::Create(test_elf_file_static);
     ASSERT_TRUE(elf_file_static) << elf_file_static.error().message();
     const auto load_bias = elf_file_static.value()->GetLoadBias();
@@ -71,8 +72,8 @@ TEST(ElfFile, CalculateLoadBias) {
 }
 
 TEST(ElfFile, CalculateLoadBiasNoProgramHeaders) {
-  const std::string executable_dir = Path::GetExecutableDir();
-  const std::string test_elf_file = executable_dir + "/testdata/hello_world_elf_no_program_headers";
+  const std::filesystem::path test_elf_file =
+      orbit_base::GetExecutableDir() / "testdata" / "hello_world_elf_no_program_headers";
   auto elf_file_result = ElfFile::Create(test_elf_file);
 
   ASSERT_TRUE(elf_file_result) << elf_file_result.error().message();
@@ -82,13 +83,15 @@ TEST(ElfFile, CalculateLoadBiasNoProgramHeaders) {
   EXPECT_EQ(load_bias_result.error().message(),
             absl::StrFormat("Unable to get load bias of ELF file: \"%s\". No PT_LOAD program "
                             "headers found.",
-                            test_elf_file));
+                            test_elf_file.string()));
 }
 
 TEST(ElfFile, HasSymtab) {
-  std::string executable_dir = Path::GetExecutableDir();
-  std::string elf_with_symbols_path = executable_dir + "/testdata/hello_world_elf";
-  std::string elf_without_symbols_path = executable_dir + "/testdata/no_symbols_elf";
+  const std::filesystem::path executable_dir = orbit_base::GetExecutableDir();
+  const std::filesystem::path elf_with_symbols_path =
+      executable_dir / "testdata" / "hello_world_elf";
+  const std::filesystem::path elf_without_symbols_path =
+      executable_dir / "testdata" / "no_symbols_elf";
 
   auto elf_with_symbols = ElfFile::Create(elf_with_symbols_path);
   ASSERT_TRUE(elf_with_symbols) << elf_with_symbols.error().message();
@@ -102,14 +105,15 @@ TEST(ElfFile, HasSymtab) {
 }
 
 TEST(ElfFile, GetBuildId) {
-  std::string executable_dir = Path::GetExecutableDir();
-  std::string hello_world_path = executable_dir + "/testdata/hello_world_elf";
+  const std::filesystem::path executable_dir = orbit_base::GetExecutableDir();
+  const std::filesystem::path hello_world_path = executable_dir / "testdata" / "hello_world_elf";
 
   auto hello_world = ElfFile::Create(hello_world_path);
   ASSERT_TRUE(hello_world) << hello_world.error().message();
   EXPECT_EQ(hello_world.value()->GetBuildId(), "d12d54bc5b72ccce54a408bdeda65e2530740ac8");
 
-  std::string elf_without_build_id_path = executable_dir + "/testdata/hello_world_elf_no_build_id";
+  const std::filesystem::path elf_without_build_id_path =
+      executable_dir / "testdata" / "hello_world_elf_no_build_id";
 
   auto elf_without_build_id = ElfFile::Create(elf_without_build_id_path);
   ASSERT_TRUE(elf_without_build_id) << elf_without_build_id.error().message();
@@ -117,8 +121,8 @@ TEST(ElfFile, GetBuildId) {
 }
 
 TEST(ElfFile, GetFilePath) {
-  std::string executable_dir = Path::GetExecutableDir();
-  std::string hello_world_path = executable_dir + "/testdata/hello_world_elf";
+  const std::filesystem::path hello_world_path =
+      orbit_base::GetExecutableDir() / "testdata" / "hello_world_elf";
 
   auto hello_world = ElfFile::Create(hello_world_path);
   ASSERT_TRUE(hello_world) << hello_world.error().message();
@@ -127,8 +131,8 @@ TEST(ElfFile, GetFilePath) {
 }
 
 TEST(ElfFile, CreateFromBuffer) {
-  std::string executable_dir = Path::GetExecutableDir();
-  std::string test_elf_file = executable_dir + "/testdata/hello_world_elf";
+  const std::filesystem::path test_elf_file =
+      orbit_base::GetExecutableDir() / "testdata" / "hello_world_elf";
 
   std::ifstream test_elf_stream{test_elf_file, std::ios::binary};
   const std::string buffer{std::istreambuf_iterator<char>{test_elf_stream},
@@ -141,8 +145,8 @@ TEST(ElfFile, CreateFromBuffer) {
 }
 
 TEST(ElfFile, FileDoesNotExist) {
-  std::string executable_dir = Path::GetExecutableDir();
-  std::string file_path = executable_dir + "/testdata/does_not_exist";
+  const std::filesystem::path file_path =
+      orbit_base::GetExecutableDir() / "testdata" / "does_not_exist";
 
   auto elf_file = ElfFile::Create(file_path);
   ASSERT_FALSE(elf_file);
@@ -151,8 +155,8 @@ TEST(ElfFile, FileDoesNotExist) {
 }
 
 TEST(ElfFile, HasDebugInfo) {
-  std::string file_path =
-      Path::JoinPath({Path::GetExecutableDir(), "testdata", "hello_world_elf_with_debug_info"});
+  const std::filesystem::path file_path =
+      orbit_base::GetExecutableDir() / "testdata" / "hello_world_elf_with_debug_info";
 
   auto hello_world = ElfFile::Create(file_path);
   ASSERT_TRUE(hello_world) << hello_world.error().message();
@@ -161,7 +165,8 @@ TEST(ElfFile, HasDebugInfo) {
 }
 
 TEST(ElfFile, DoesNotHaveDebugInfo) {
-  std::string file_path = Path::JoinPath({Path::GetExecutableDir(), "testdata", "hello_world_elf"});
+  const std::filesystem::path file_path =
+      orbit_base::GetExecutableDir() / "testdata" / "hello_world_elf";
 
   auto hello_world = ElfFile::Create(file_path);
   ASSERT_TRUE(hello_world) << hello_world.error().message();
@@ -175,7 +180,7 @@ static void RunLineInfoTest(const char* file_name) {
 #else
   constexpr const char* const kSourcePath = "/ssd/local/hello.cpp";
 #endif
-  std::string file_path = Path::JoinPath({Path::GetExecutableDir(), "testdata", file_name});
+  const std::filesystem::path file_path = orbit_base::GetExecutableDir() / "testdata" / file_name;
 
   auto hello_world = ElfFile::Create(file_path);
   ASSERT_TRUE(hello_world) << hello_world.error().message();
@@ -203,7 +208,8 @@ TEST(ElfFile, LineInfo) { RunLineInfoTest("hello_world_elf_with_debug_info"); }
 TEST(ElfFile, LineInfoOnlyDebug) { RunLineInfoTest("hello_world_elf.debug"); }
 
 TEST(ElfFile, LineInfoNoDebugInfo) {
-  std::string file_path = Path::JoinPath({Path::GetExecutableDir(), "testdata", "hello_world_elf"});
+  const std::filesystem::path file_path =
+      orbit_base::GetExecutableDir() / "testdata" / "hello_world_elf";
 
   auto hello_world = ElfFile::Create(file_path);
   ASSERT_TRUE(hello_world) << hello_world.error().message();

--- a/ElfUtils/include/ElfUtils/ElfFile.h
+++ b/ElfUtils/include/ElfUtils/ElfFile.h
@@ -5,6 +5,7 @@
 #ifndef ELF_UTILS_ELF_FILE_H_
 #define ELF_UTILS_ELF_FILE_H_
 
+#include <filesystem>
 #include <memory>
 #include <optional>
 #include <vector>
@@ -41,15 +42,17 @@ class ElfFile {
   [[nodiscard]] virtual bool HasDebugInfo() const = 0;
   [[nodiscard]] virtual bool Is64Bit() const = 0;
   [[nodiscard]] virtual std::string GetBuildId() const = 0;
-  [[nodiscard]] virtual std::string GetFilePath() const = 0;
+  [[nodiscard]] virtual std::filesystem::path GetFilePath() const = 0;
   [[nodiscard]] virtual ErrorMessageOr<orbit_grpc_protos::LineInfo> GetLineInfo(
       uint64_t address) = 0;
 
-  [[nodiscard]] static ErrorMessageOr<std::unique_ptr<ElfFile>> Create(std::string_view file_path);
   [[nodiscard]] static ErrorMessageOr<std::unique_ptr<ElfFile>> Create(
-      std::string_view file_path, llvm::object::OwningBinary<llvm::object::ObjectFile>&& file);
+      const std::filesystem::path& file_path);
+  [[nodiscard]] static ErrorMessageOr<std::unique_ptr<ElfFile>> Create(
+      const std::filesystem::path& file_path,
+      llvm::object::OwningBinary<llvm::object::ObjectFile>&& file);
   [[nodiscard]] static ErrorMessageOr<std::unique_ptr<ElfFile>> CreateFromBuffer(
-      std::string_view file_path, const void* buf, size_t len);
+      const std::filesystem::path& file_path, const void* buf, size_t len);
 };
 
 }  // namespace ElfUtils

--- a/OrbitBase/CMakeLists.txt
+++ b/OrbitBase/CMakeLists.txt
@@ -21,6 +21,7 @@ target_include_directories(OrbitBase PRIVATE
 target_sources(OrbitBase PRIVATE
         include/OrbitBase/Action.h
         include/OrbitBase/DebugUtils.h
+        include/OrbitBase/ExecutablePath.h
         include/OrbitBase/Logging.h
         include/OrbitBase/MakeUniqueForOverwrite.h
         include/OrbitBase/Profiling.h
@@ -31,32 +32,43 @@ target_sources(OrbitBase PRIVATE
         include/OrbitBase/SafeStrerror.h)
 
 target_sources(OrbitBase PRIVATE
+        ExecutablePath.cpp
         Logging.cpp
+        SafeStrerror.cpp
         ThreadPool.cpp
-        Tracing.cpp
-        SafeStrerror.cpp)
+        Tracing.cpp)
+
+if (WIN32)
+target_sources(OrbitBase PRIVATE
+        ExecutablePathWindows.cpp)
+else()
+target_sources(OrbitBase PRIVATE
+        ExecutablePathLinux.cpp)
+endif()
 
 target_link_libraries(OrbitBase PUBLIC
         CONAN_PKG::Outcome
         CONAN_PKG::abseil
         std::filesystem)
 
+
 add_executable(OrbitBaseTests)
 
 target_compile_options(OrbitBaseTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(OrbitBaseTests PRIVATE
-    UniqueResourceTest.cpp
-    OrbitApiTest.cpp
-    ProfilingTest.cpp
-    TracingTest.cpp
+        ExecutablePathTest.cpp
+        OrbitApiTest.cpp
+        ProfilingTest.cpp
+        TracingTest.cpp
+        UniqueResourceTest.cpp
 )
 
 # Threadpool test contains some sleeps we couldn't work around - disable them on the CI
 # since they are flaky there (but they work fine on local workstations).
 if (NOT (WIN32 AND "$ENV{QT_QPA_PLATFORM}" STREQUAL "offscreen"))
 target_sources(OrbitBaseTests PRIVATE
-    ThreadPoolTest.cpp
+        ThreadPoolTest.cpp
 )
 endif()
 
@@ -65,5 +77,5 @@ target_link_libraries(OrbitBaseTests PRIVATE
         GTest::GTest
         GTest::Main)
 
-register_test(OrbitBaseTests)
 
+register_test(OrbitBaseTests)

--- a/OrbitBase/ExecutablePath.cpp
+++ b/OrbitBase/ExecutablePath.cpp
@@ -1,0 +1,13 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "OrbitBase/ExecutablePath.h"
+
+#include <filesystem>
+
+namespace orbit_base {
+
+std::filesystem::path GetExecutableDir() { return GetExecutablePath().parent_path(); }
+
+}  // namespace orbit_base

--- a/OrbitBase/ExecutablePathLinux.cpp
+++ b/OrbitBase/ExecutablePathLinux.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <dirent.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "OrbitBase/ExecutablePath.h"
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/SafeStrerror.h"
+#include "absl/strings/str_format.h"
+
+namespace orbit_base {
+
+std::filesystem::path GetExecutablePath() {
+  char buffer[PATH_MAX];
+  ssize_t length = readlink("/proc/self/exe", buffer, sizeof(buffer));
+  if (length == -1) {
+    FATAL("Unable to readlink /proc/self/exe: %s", SafeStrerror(errno));
+  }
+
+  return std::filesystem::path(std::string(buffer, length));
+}
+
+}  // namespace orbit_base

--- a/OrbitBase/ExecutablePathTest.cpp
+++ b/OrbitBase/ExecutablePathTest.cpp
@@ -1,0 +1,20 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "OrbitBase/ExecutablePath.h"
+
+TEST(Path, GetExecutablePath) {
+  std::filesystem::path path = orbit_base::GetExecutablePath();
+#ifdef _WIN32
+  const std::string executable_name = "OrbitBaseTests.exe";
+#else
+  const std::string executable_name = "OrbitBaseTests";
+#endif
+  EXPECT_EQ(path.filename(), executable_name);
+  EXPECT_EQ(path.parent_path().filename(), "bin");
+}
+
+TEST(Path, GetExecutableDir) { EXPECT_EQ(orbit_base::GetExecutableDir().filename(), "bin"); }

--- a/OrbitBase/ExecutablePathWindows.cpp
+++ b/OrbitBase/ExecutablePathWindows.cpp
@@ -1,0 +1,33 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <direct.h>
+#include <windows.h>
+
+#include "OrbitBase/ExecutablePath.h"
+#include "OrbitBase/Logging.h"
+#include "absl/strings/str_replace.h"
+
+namespace orbit_base {
+
+std::filesystem::path GetExecutablePath() {
+  char exe_file_name[2048] = {0};
+  LPSTR pszBuffer = exe_file_name;
+  DWORD dwMaxChars = _countof(exe_file_name);
+  DWORD dwLength = 0;
+
+  if (!GetModuleFileNameA(NULL, pszBuffer, dwMaxChars)) {
+    FATAL("GetModuleFileName failed with: %d", GetLastError());
+  }
+
+  // Clean up "../" inside full path
+  char exe_full_path[MAX_PATH];
+  if (!GetFullPathNameA(exe_file_name, MAX_PATH, exe_full_path, nullptr)) {
+    FATAL("GetFullPathNameA failed with: %d", GetLastError());
+  }
+
+  return std::filesystem::path(exe_full_path);
+}
+
+}  // namespace orbit_base

--- a/OrbitBase/Logging.cpp
+++ b/OrbitBase/Logging.cpp
@@ -7,7 +7,7 @@
 static absl::Mutex log_file_mutex(absl::kConstInit);
 std::ofstream log_file;
 
-void InitLogFile(const std::string& path) {
+void InitLogFile(const std::filesystem::path& path) {
   absl::MutexLock lock(&log_file_mutex);
   // Do not call CHECK here - it will end up calling LogToFile,
   // which tries to lock on the same mutex a second time. This will

--- a/OrbitBase/include/OrbitBase/ExecutablePath.h
+++ b/OrbitBase/include/OrbitBase/ExecutablePath.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_BASE_PATH_H_
+#define ORBIT_BASE_PATH_H_
+
+#include <filesystem>
+#include <vector>
+
+namespace orbit_base {
+
+[[nodiscard]] std::filesystem::path GetExecutablePath();
+[[nodiscard]] std::filesystem::path GetExecutableDir();
+
+}  // namespace orbit_base
+
+#endif  // ORBIT_BASE_PATH_H_

--- a/OrbitBase/include/OrbitBase/Logging.h
+++ b/OrbitBase/include/OrbitBase/Logging.h
@@ -111,7 +111,7 @@ constexpr const char* kLogTimeFormat = "%Y-%m-%dT%H:%M:%E6S";
   }
 
 extern std::ofstream log_file;
-void InitLogFile(const std::string& path);
+void InitLogFile(const std::filesystem::path& path);
 void LogToFile(const std::string& message);
 
 // Internal.

--- a/OrbitClientModel/CaptureSerializer.cpp
+++ b/OrbitClientModel/CaptureSerializer.cpp
@@ -9,8 +9,8 @@
 #include <memory>
 
 #include "CoreUtils.h"
+#include "OrbitBase/ExecutablePath.h"
 #include "OrbitClientData/Callstack.h"
-#include "Path.h"
 #include "capture_data.pb.h"
 #include "google/protobuf/io/coded_stream.h"
 #include "google/protobuf/message.h"
@@ -37,14 +37,15 @@ void WriteMessage(const google::protobuf::Message* message,
 
 std::string GetCaptureFileName(const CaptureData& capture_data) {
   time_t timestamp = std::chrono::system_clock::to_time_t(capture_data.capture_start_time());
-  std::string result = absl::StrCat(Path::StripExtension(capture_data.process_name()), "_",
-                                    OrbitUtils::FormatTime(timestamp));
+  std::string result =
+      absl::StrCat(std::filesystem::path(capture_data.process_name()).stem().string(), "_",
+                   OrbitUtils::FormatTime(timestamp));
   IncludeOrbitExtensionInFile(result);
   return result;
 }
 
 void IncludeOrbitExtensionInFile(std::string& file_name) {
-  const std::string extension = Path::GetExtension(file_name);
+  const std::string extension = std::filesystem::path(file_name).extension().string();
   if (extension != kFileOrbitExtension) {
     file_name.append(kFileOrbitExtension);
   }

--- a/OrbitCore/CMakeLists.txt
+++ b/OrbitCore/CMakeLists.txt
@@ -75,13 +75,6 @@ target_link_libraries(
           CONAN_PKG::llvm_object
           CONAN_PKG::abseil)
 
-add_custom_command(TARGET OrbitCoreTests POST_BUILD COMMAND ${CMAKE_COMMAND}
-                   -E remove_directory $<TARGET_FILE_DIR:OrbitCoreTests>/testdata/OrbitCore)
-
-add_custom_command(TARGET OrbitCoreTests POST_BUILD COMMAND ${CMAKE_COMMAND}
-                   -E copy_directory ${CMAKE_SOURCE_DIR}/OrbitCore/testdata/
-                   $<TARGET_FILE_DIR:OrbitCoreTests>/testdata/OrbitCore)
-
 register_test(OrbitCoreTests)
 
 add_fuzzer(ModuleLoadSymbolsFuzzer ModuleLoadSymbolsFuzzer.cpp)

--- a/OrbitCore/Path.cpp
+++ b/OrbitCore/Path.cpp
@@ -8,181 +8,65 @@
 #include <string>
 
 #include "CoreUtils.h"
-#include "OrbitBase/SafeStrerror.h"
 #include "absl/flags/flag.h"
-
-#ifdef _WIN32
-#include <direct.h>
-
-#include "Shlobj.h"
-#else
-#include <dirent.h>
-#include <linux/limits.h>
-#include <sys/stat.h>
-
-#endif
 
 ABSL_FLAG(std::string, log_dir, "", "Set directory for the log.");
 
-std::string Path::GetExecutablePath() {
-#ifdef _WIN32
-  WCHAR cwBuffer[2048] = {0};
-  LPWSTR pszBuffer = cwBuffer;
-  DWORD dwMaxChars = _countof(cwBuffer);
-  DWORD dwLength = 0;
-
-  dwLength = ::GetModuleFileNameW(NULL, pszBuffer, dwMaxChars);
-  std::wstring exeFullName = std::wstring(pszBuffer);
-
-  // Clean up "../" inside full path
-  wchar_t buffer[MAX_PATH];
-  GetFullPathName(exeFullName.c_str(), MAX_PATH, buffer, nullptr);
-  exeFullName = buffer;
-
-  std::replace(exeFullName.begin(), exeFullName.end(), '\\', '/');
-  return ws2s(exeFullName);
-#else
-  char buffer[PATH_MAX];
-  ssize_t length = readlink("/proc/self/exe", buffer, sizeof(buffer));
-  if (length == -1) {
-    // TODO (161419404): implement error handling
-    ERROR("Unable to readlink /proc/self/exe: %s", SafeStrerror(errno));
-    return "";
-  }
-
-  return std::string(buffer, length);
-#endif
+static std::filesystem::path CreateAndGetConfigPath() {
+  std::filesystem::path config_dir = Path::CreateOrGetOrbitAppDataDir() / "config";
+  std::filesystem::create_directory(config_dir);
+  return config_dir;
 }
 
-std::string Path::GetExecutableDir() { return GetDirectory(GetExecutablePath()); }
-
-static std::string CreateAndGetConfigPath() {
-  std::string configDir = Path::JoinPath({Path::CreateOrGetOrbitAppDataDir(), "config"});
-  std::filesystem::create_directory(configDir);
-  return configDir;
+std::filesystem::path Path::GetFileMappingFileName() {
+  return CreateAndGetConfigPath() / "FileMapping.txt";
 }
 
-std::string Path::GetFileMappingFileName() {
-  return Path::JoinPath({CreateAndGetConfigPath(), "FileMapping.txt"});
+std::filesystem::path Path::GetSymbolsFileName() {
+  return CreateAndGetConfigPath() / "SymbolPaths.txt";
 }
 
-std::string Path::GetSymbolsFileName() {
-  return Path::JoinPath({CreateAndGetConfigPath(), "SymbolPaths.txt"});
+std::filesystem::path Path::CreateOrGetCacheDir() {
+  std::filesystem::path cache_dir = Path::CreateOrGetOrbitAppDataDir() / "cache";
+  std::filesystem::create_directory(cache_dir);
+  return cache_dir;
 }
 
-std::string Path::CreateOrGetCacheDir() {
-  std::string cacheDir = Path::JoinPath({Path::CreateOrGetOrbitAppDataDir(), "cache"});
-  std::filesystem::create_directory(cacheDir);
-  return cacheDir;
+std::filesystem::path Path::CreateOrGetPresetDir() {
+  std::filesystem::path preset_dir = Path::CreateOrGetOrbitAppDataDir() / "presets";
+  std::filesystem::create_directory(preset_dir);
+  return preset_dir;
 }
 
-std::string Path::CreateOrGetPresetDir() {
-  std::string presetDir = Path::JoinPath({Path::CreateOrGetOrbitAppDataDir(), "presets"});
-  std::filesystem::create_directory(presetDir);
-  return presetDir;
+std::filesystem::path Path::CreateOrGetCaptureDir() {
+  std::filesystem::path capture_dir = Path::CreateOrGetOrbitAppDataDir() / "output";
+  std::filesystem::create_directory(capture_dir);
+  return capture_dir;
 }
 
-std::string Path::CreateOrGetCaptureDir() {
-  std::string captureDir = Path::JoinPath({Path::CreateOrGetOrbitAppDataDir(), "output"});
-  std::filesystem::create_directory(captureDir);
-  return captureDir;
+std::filesystem::path Path::CreateOrGetDumpDir() {
+  std::filesystem::path capture_dir = Path::CreateOrGetOrbitAppDataDir() / "dumps";
+  std::filesystem::create_directory(capture_dir);
+  return capture_dir;
 }
 
-std::string Path::CreateOrGetDumpDir() {
-  std::string captureDir = Path::JoinPath({Path::CreateOrGetOrbitAppDataDir(), "dumps"});
-  std::filesystem::create_directory(captureDir);
-  return captureDir;
-}
-
-std::string Path::GetFileName(const std::string& file_path) {
-  std::string full_name = file_path;
-  std::replace(full_name.begin(), full_name.end(), '\\', '/');
-  auto index = full_name.find_last_of('/');
-  if (index != std::string::npos) {
-    std::string file_name = full_name.substr(full_name.find_last_of('/') + 1);
-    return file_name;
-  }
-
-  return full_name;
-}
-
-std::string Path::StripExtension(const std::string& file_path) {
-  std::string full_name = file_path;
-  std::replace(full_name.begin(), full_name.end(), '\\', '/');
-  const std::string extension = GetExtension(full_name);
-  return full_name.substr(0, file_path.length() - extension.length());
-}
-
-std::string Path::GetExtension(const std::string& file_path) {
-  // returns ".ext" (includes point)
-  // Perform on file name to make sure we're not detecting "." within the directory path
-  const std::string file_name = GetFileName(file_path);
-  size_t index = file_name.find_last_of('.');
-  if (index != std::string::npos) return file_name.substr(index, file_name.length());
-  return "";
-}
-
-std::string Path::GetDirectory(const std::string& any_path) {
-  std::string FullName = any_path;
-  std::replace(FullName.begin(), FullName.end(), '\\', '/');
-  auto index = FullName.find_last_of('/');
-  if (index != std::string::npos) {
-    std::string FileName = FullName.substr(0, FullName.find_last_of('/') + 1);
-    return FileName;
-  }
-
-  return "";
-}
-
-std::string Path::JoinPath(const std::vector<std::string>& parts) {
-  if (parts.empty()) {
-    return "";
-  }
-  std::filesystem::path joined{parts[0]};
-  for (size_t i = 1; i < parts.size(); ++i) {
-    joined.append(parts[i]);
-  }
-  return joined.string();
-}
-
-std::string Path::CreateOrGetOrbitAppDataDir() {
+std::filesystem::path Path::CreateOrGetOrbitAppDataDir() {
 #ifdef WIN32
-  std::string appData = GetEnvVar("APPDATA");
-  std::string path = Path::JoinPath({appData, "OrbitProfiler"});
+  std::filesystem::path path = std::filesystem::path(GetEnvVar("APPDATA")) / "OrbitProfiler";
 #else
-  std::string path = Path::JoinPath({GetEnvVar("HOME"), ".orbitprofiler"});
+  std::filesystem::path path = std::filesystem::path(GetEnvVar("HOME")) / ".orbitprofiler";
 #endif
   std::filesystem::create_directory(path);
   return path;
 }
 
-std::string Path::GetLogFilePathAndCreateDir() {
-  std::string logs_dir;
+std::filesystem::path Path::GetLogFilePathAndCreateDir() {
+  std::filesystem::path logs_dir;
   if (!absl::GetFlag(FLAGS_log_dir).empty()) {
     logs_dir = absl::GetFlag(FLAGS_log_dir);
   } else {
-    logs_dir = Path::JoinPath({Path::CreateOrGetOrbitAppDataDir(), "logs"});
+    logs_dir = Path::CreateOrGetOrbitAppDataDir() / "logs";
   }
   std::filesystem::create_directory(logs_dir);
-  return Path::JoinPath({logs_dir, "Orbit.log"});
-}
-
-std::vector<std::string> Path::ListFiles(const std::string& directory,
-                                         const std::function<bool(const std::string&)>& filter) {
-  std::vector<std::string> files;
-
-  for (const auto& file : std::filesystem::directory_iterator(directory)) {
-    if (std::filesystem::is_regular_file(file)) {
-      std::string path(file.path().string());
-      if (filter(path)) files.push_back(path);
-    }
-  }
-
-  return files;
-}
-
-std::vector<std::string> Path::ListFiles(const std::string& directory, const std::string& filter) {
-  return ListFiles(directory, [&](const std::string& file_name) {
-    return absl::StrContains(file_name, filter);
-  });
+  return logs_dir / "Orbit.log";
 }

--- a/OrbitCore/Path.h
+++ b/OrbitCore/Path.h
@@ -4,30 +4,15 @@
 
 #pragma once
 
-#include <functional>
-#include <string>
-#include <vector>
+#include <filesystem>
 
 namespace Path {
-[[nodiscard]] std::string GetExecutablePath();
-[[nodiscard]] std::string GetExecutableDir();
-[[nodiscard]] std::string GetFileMappingFileName();
-[[nodiscard]] std::string GetSymbolsFileName();
-[[nodiscard]] std::string CreateOrGetCacheDir();
-[[nodiscard]] std::string CreateOrGetPresetDir();
-[[nodiscard]] std::string CreateOrGetCaptureDir();
-[[nodiscard]] std::string CreateOrGetDumpDir();
-[[nodiscard]] std::string CreateOrGetOrbitAppDataDir();
-[[nodiscard]] std::string GetLogFilePathAndCreateDir();
-[[nodiscard]] std::string GetFileName(const std::string& file_path);
-[[nodiscard]] std::string StripExtension(const std::string& file_path);
-[[nodiscard]] std::string GetExtension(const std::string& file_path);
-[[nodiscard]] std::string GetDirectory(const std::string& any_path);
-[[nodiscard]] std::string JoinPath(const std::vector<std::string>& parts);
-
-[[nodiscard]] std::vector<std::string> ListFiles(
-    const std::string& directory, const std::function<bool(const std::string&)>& filter =
-                                      [](const std::string&) { return true; });
-[[nodiscard]] std::vector<std::string> ListFiles(const std::string& directory,
-                                                 const std::string& filter);
+[[nodiscard]] std::filesystem::path GetFileMappingFileName();
+[[nodiscard]] std::filesystem::path GetSymbolsFileName();
+[[nodiscard]] std::filesystem::path CreateOrGetCacheDir();
+[[nodiscard]] std::filesystem::path CreateOrGetPresetDir();
+[[nodiscard]] std::filesystem::path CreateOrGetCaptureDir();
+[[nodiscard]] std::filesystem::path CreateOrGetDumpDir();
+[[nodiscard]] std::filesystem::path CreateOrGetOrbitAppDataDir();
+[[nodiscard]] std::filesystem::path GetLogFilePathAndCreateDir();
 };  // namespace Path

--- a/OrbitCore/PathTest.cpp
+++ b/OrbitCore/PathTest.cpp
@@ -32,192 +32,6 @@ TEST(Path, FileExistsDevNull) {
 }
 #endif
 
-TEST(Path, JoinPathPartsEmpty) {
-  std::string actual = Path::JoinPath({});
-  std::string expected{};
-  EXPECT_EQ(actual, expected);
-}
-
-TEST(Path, JoinPathPartsRelativeSlash) {
-  std::string actual = Path::JoinPath({"dir1/dir2", "dir3/dir4/", "dir5/dir6"});
-#ifdef _WIN32
-  std::string expected = "dir1/dir2\\dir3/dir4/dir5/dir6";
-#else
-  std::string expected = "dir1/dir2/dir3/dir4/dir5/dir6";
-#endif
-  EXPECT_EQ(actual, expected);
-}
-
-TEST(Path, JoinPathPartsAbsoluteSlash) {
-  std::string actual = Path::JoinPath({"/dir1/dir2", "dir3/dir4/", "dir5/dir6"});
-#ifdef _WIN32
-  std::string expected = "/dir1/dir2\\dir3/dir4/dir5/dir6";
-#else
-  std::string expected = "/dir1/dir2/dir3/dir4/dir5/dir6";
-#endif
-  EXPECT_EQ(actual, expected);
-}
-
-TEST(Path, JoinPathPartsAbsoluteRootSlash) {
-  std::string actual = Path::JoinPath({"/", "dir1/dir2", "dir3/dir4"});
-#ifdef _WIN32
-  std::string expected = "/dir1/dir2\\dir3/dir4";
-#else
-  std::string expected = "/dir1/dir2/dir3/dir4";
-#endif
-  EXPECT_EQ(actual, expected);
-}
-
-TEST(Path, JoinPathPartsRelativeBackslash) {
-  std::string actual = Path::JoinPath({"dir1\\dir2", "dir3\\dir4\\", "dir5\\dir6"});
-#ifdef _WIN32
-  std::string expected = "dir1\\dir2\\dir3\\dir4\\dir5\\dir6";
-#else
-  std::string expected = "dir1\\dir2/dir3\\dir4\\/dir5\\dir6";
-#endif
-  EXPECT_EQ(actual, expected);
-}
-
-TEST(Path, JoinPathPartsAbsoluteBackslash) {
-  std::string actual = Path::JoinPath({"C:\\dir1\\dir2", "dir3\\dir4\\", "dir5\\dir6"});
-#ifdef _WIN32
-  std::string expected = "C:\\dir1\\dir2\\dir3\\dir4\\dir5\\dir6";
-#else
-  std::string expected = "C:\\dir1\\dir2/dir3\\dir4\\/dir5\\dir6";
-#endif
-  EXPECT_EQ(actual, expected);
-}
-
-TEST(Path, JoinPathPartsAbsoluteRootBackslash) {
-  std::string actual = Path::JoinPath({"C:", "dir1\\dir2", "dir3\\dir4"});
-#ifdef _WIN32
-  std::string expected = "C:dir1\\dir2\\dir3\\dir4";
-#else
-  std::string expected = "C:/dir1\\dir2/dir3\\dir4";
-#endif
-  EXPECT_EQ(actual, expected);
-}
-
-TEST(Path, FileNamesAndExtensions) {
-  std::string input = "C:\\win_abs_path\\file.txt";
-  EXPECT_EQ(Path::GetExtension(input), ".txt");
-  EXPECT_EQ(Path::StripExtension(input), "C:/win_abs_path/file");
-  EXPECT_EQ(Path::GetFileName(input), "file.txt");
-
-  input = "/unix_abs_path/file.txt";
-  EXPECT_EQ(Path::GetExtension(input), ".txt");
-  EXPECT_EQ(Path::StripExtension(input), "/unix_abs_path/file");
-  EXPECT_EQ(Path::GetFileName(input), "file.txt");
-
-  input = "C:\\windir.with.dots\\file_without_ext";
-  EXPECT_EQ(Path::GetExtension(input), "");
-  EXPECT_EQ(Path::StripExtension(input), "C:/windir.with.dots/file_without_ext");
-  EXPECT_EQ(Path::GetFileName(input), "file_without_ext");
-
-  input = "/unixdir.with.dots/file_without_ext";
-  EXPECT_EQ(Path::GetExtension(input), "");
-  EXPECT_EQ(Path::StripExtension(input), "/unixdir.with.dots/file_without_ext");
-  EXPECT_EQ(Path::GetFileName(input), "file_without_ext");
-
-  input = "relative\\mixed/path/file.txt";
-  EXPECT_EQ(Path::GetExtension(input), ".txt");
-  EXPECT_EQ(Path::StripExtension(input), "relative/mixed/path/file");
-  EXPECT_EQ(Path::GetFileName(input), "file.txt");
-
-  input = "simple.file";
-  EXPECT_EQ(Path::GetExtension(input), ".file");
-  EXPECT_EQ(Path::StripExtension(input), "simple");
-  EXPECT_EQ(Path::GetFileName(input), "simple.file");
-
-  input = "no/ext";
-  EXPECT_EQ(Path::GetExtension(input), "");
-  EXPECT_EQ(Path::StripExtension(input), "no/ext");
-  EXPECT_EQ(Path::GetFileName(input), "ext");
-
-  input = "double.ext.txt";
-  EXPECT_EQ(Path::GetExtension(input), ".txt");
-  EXPECT_EQ(Path::StripExtension(input), "double.ext");
-  EXPECT_EQ(Path::StripExtension(Path::StripExtension(input)), "double");
-  EXPECT_EQ(Path::GetFileName(input), "double.ext.txt");
-}
-
-// TODO: A test for GetExecutableDir is missing - using this here makes this test
-// kind of invalid, since GetExecutableDir is using GetExecutablePath internally...
-TEST(Path, GetExecutablePath) {
-  std::string actual = Path::GetExecutablePath();
-#ifdef _WIN32
-  std::string expected = Path::JoinPath({Path::GetExecutableDir(), "OrbitCoreTests.exe"});
-#else
-  std::string expected = Path::JoinPath({Path::GetExecutableDir(), "OrbitCoreTests"});
-#endif
-  EXPECT_EQ(actual, expected);
-}
-
-static std::string GetTestDataAbsPath(const std::string& filename = "") {
-  if (filename.empty()) {
-    return Path::JoinPath({Path::GetExecutableDir(), "testdata", "OrbitCore"});
-  } else {
-    return Path::JoinPath({Path::GetExecutableDir(), "testdata", "OrbitCore", filename});
-  }
-}
-
-TEST(Path, GetDirectory) {
-  struct Test {
-    std::string input;
-    std::string dir;
-  };
-
-  // The hoops I'm jumping through to have the test declarations below nicely formatted...
-  using V = std::vector<Test>;
-#ifdef _WIN32
-  V tests = {{"C:\\dir/With\\fwd_slash.txt.ext", "C:/dir/With/"},
-             {"C:\\no\\ext\\file", "C:/no/ext/"},
-             {"C:\\dir\\subdir\\", "C:/dir/subdir/"},
-             {"C:\\file_in_root", "C:/"},
-             {"broken_path", ""},
-             {"C:\\", "C:/"}};
-#else
-  V tests = {{"/dir/With/mult_ext.txt.ext", "/dir/With/"},
-             {"/no/ext/file", "/no/ext/"},
-             {"/dir/subdir/", "/dir/subdir/"},
-             {"/file_in_root", "/"},
-             {"broken_path", ""},
-             {"/", "/"}};
-#endif
-
-  for (auto& test : tests) {
-    LOG("Checking directory of \"%s\"", test.input.c_str());
-    const std::string result_dir = Path::GetDirectory(test.input);
-    EXPECT_EQ(result_dir, test.dir);
-  }
-}
-
-TEST(Path, ListFiles) {
-  using Set = std::set<std::string>;
-
-  auto empty_file_path = GetTestDataAbsPath("empty_file.txt");
-  auto small_file_path = GetTestDataAbsPath("small_file");
-
-  auto files = Path::ListFiles(GetTestDataAbsPath());
-  Set unordered_files(files.begin(), files.end());
-  EXPECT_EQ(unordered_files, Set({empty_file_path, small_file_path}));
-
-  // Filter is NOT a regex...
-  files = Path::ListFiles(GetTestDataAbsPath(), "*.txt");
-  EXPECT_TRUE(files.empty());
-
-  // ... but simply a "contains"
-  files = Path::ListFiles(GetTestDataAbsPath(), ".txt");
-  unordered_files = Set(files.begin(), files.end());
-  EXPECT_EQ(unordered_files, Set({empty_file_path}));
-
-  // Filter lambda gets the absolute file path as a parameter
-  files = Path::ListFiles(GetTestDataAbsPath(), [](const std::string& file) -> bool {
-    return file == GetTestDataAbsPath("small_file");
-  });
-  unordered_files = Set(files.begin(), files.end());
-  EXPECT_EQ(unordered_files, Set({small_file_path}));
-}
 
 TEST(Path, AllAutoCreatedDirsExist) {
   auto test_fns = {Path::CreateOrGetOrbitAppDataDir, Path::CreateOrGetDumpDir,
@@ -225,8 +39,8 @@ TEST(Path, AllAutoCreatedDirsExist) {
                    Path::CreateOrGetOrbitAppDataDir};
 
   for (auto fn : test_fns) {
-    std::string path = fn();
-    LOG("Testing existence of \"%s\"", path.c_str());
+    std::filesystem::path path = fn();
+    LOG("Testing existence of \"%s\"", path.string());
     EXPECT_TRUE(std::filesystem::is_directory(path));
   }
 }
@@ -235,8 +49,8 @@ TEST(Path, AllDirsOfFilesExist) {
   auto test_fns = {Path::GetLogFilePathAndCreateDir};
 
   for (auto fn : test_fns) {
-    std::string path = Path::GetDirectory(fn());
-    LOG("Testing existence of \"%s\"", path.c_str());
+    std::filesystem::path path = fn().parent_path();
+    LOG("Testing existence of \"%s\"", path.string());
     EXPECT_TRUE(std::filesystem::is_directory(path));
   }
 }

--- a/OrbitCore/SymbolHelper.cpp
+++ b/OrbitCore/SymbolHelper.cpp
@@ -25,7 +25,7 @@ using ::ElfUtils::ElfFile;
 namespace {
 
 std::vector<fs::path> ReadSymbolsFile() {
-  std::string file_name = Path::GetSymbolsFileName();
+  fs::path file_name = Path::GetSymbolsFileName();
   if (!fs::exists(file_name)) {
     std::ofstream outfile(file_name);
     outfile << "//-------------------" << std::endl
@@ -67,7 +67,7 @@ std::vector<fs::path> ReadSymbolsFile() {
 
 ErrorMessageOr<void> SymbolHelper::VerifySymbolsFile(const fs::path& symbols_path,
                                                      const std::string& build_id) {
-  OUTCOME_TRY(symbols_file, ElfFile::Create(symbols_path.string()));
+  OUTCOME_TRY(symbols_file, ElfFile::Create(symbols_path));
 
   if (!symbols_file->HasSymtab()) {
     return ErrorMessage(

--- a/OrbitCore/SymbolHelperTest.cpp
+++ b/OrbitCore/SymbolHelperTest.cpp
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "OrbitBase/ExecutablePath.h"
 #include "Path.h"
 #include "SymbolHelper.h"
 #include "absl/strings/ascii.h"
@@ -15,7 +16,7 @@
 using orbit_grpc_protos::ModuleSymbols;
 namespace fs = std::filesystem;
 
-const std::filesystem::path executable_directory = Path::GetExecutableDir() + "testdata/";
+const std::filesystem::path executable_directory = orbit_base::GetExecutableDir() / "testdata";
 
 TEST(SymbolHelper, FindSymbolsWithSymbolsPathFile) {
   SymbolHelper symbol_helper({executable_directory}, "");
@@ -126,8 +127,9 @@ TEST(SymbolHelper, LoadFromFile) {
 
 TEST(SymbolHelper, GenerateCachedFileName) {
   SymbolHelper symbol_helper{{}, Path::CreateOrGetCacheDir()};
-  const std::string file_path = "/var/data/filename.elf";
-  const std::string cache_file_path = Path::CreateOrGetCacheDir() + "/_var_data_filename.elf";
+  const std::filesystem::path file_path = "/var/data/filename.elf";
+  const std::filesystem::path cache_file_path =
+      Path::CreateOrGetCacheDir() / "_var_data_filename.elf";
   EXPECT_EQ(symbol_helper.GenerateCachedFileName(file_path), cache_file_path);
 }
 

--- a/OrbitCore/testdata/small_file
+++ b/OrbitCore/testdata/small_file
@@ -1,1 +1,0 @@
-small file content

--- a/OrbitFramePointerValidator/FramePointerValidator.cpp
+++ b/OrbitFramePointerValidator/FramePointerValidator.cpp
@@ -13,7 +13,8 @@
 using orbit_grpc_protos::CodeBlock;
 
 std::optional<std::vector<CodeBlock>> FramePointerValidator::GetFpoFunctions(
-    const std::vector<CodeBlock>& functions, const std::string& file_name, bool is_64_bit) {
+    const std::vector<CodeBlock>& functions, const std::filesystem::path& file_name,
+    bool is_64_bit) {
   std::vector<CodeBlock> result;
 
   cs_mode mode = is_64_bit ? CS_MODE_64 : CS_MODE_32;

--- a/OrbitFramePointerValidator/FramePointerValidatorTest.cpp
+++ b/OrbitFramePointerValidator/FramePointerValidatorTest.cpp
@@ -8,16 +8,16 @@
 #include <vector>
 
 #include "ElfUtils/ElfFile.h"
+#include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Logging.h"
-#include "Path.h"
-#include "include/OrbitFramePointerValidator/FramePointerValidator.h"
+#include "OrbitFramePointerValidator/FramePointerValidator.h"
 
 using orbit_grpc_protos::CodeBlock;
 using orbit_grpc_protos::SymbolInfo;
 
 TEST(FramePointerValidator, GetFpoFunctions) {
-  std::string executable_dir = Path::GetExecutableDir();
-  std::string test_elf_file = executable_dir + "/testdata/hello_world_elf";
+  const std::filesystem::path executable_dir = orbit_base::GetExecutableDir();
+  const std::filesystem::path test_elf_file = executable_dir / "testdata" / "hello_world_elf";
 
   auto elf_file = ElfUtils::ElfFile::Create(test_elf_file);
   ASSERT_TRUE(elf_file) << elf_file.error().message();

--- a/OrbitFramePointerValidator/include/OrbitFramePointerValidator/FramePointerValidator.h
+++ b/OrbitFramePointerValidator/include/OrbitFramePointerValidator/FramePointerValidator.h
@@ -5,6 +5,7 @@
 #ifndef ORBIT_CORE_FRAME_POINTER_VALIDATOR_H_
 #define ORBIT_CORE_FRAME_POINTER_VALIDATOR_H_
 
+#include <filesystem>
 #include <optional>
 #include <vector>
 
@@ -16,8 +17,8 @@ class FramePointerValidator {
   // returns the functions, where validation failed. If there was an error
   // during validation, nullopt will be return.
   static std::optional<std::vector<orbit_grpc_protos::CodeBlock>> GetFpoFunctions(
-      const std::vector<orbit_grpc_protos::CodeBlock>& functions, const std::string& file_name,
-      bool is_64_bit);
+      const std::vector<orbit_grpc_protos::CodeBlock>& functions,
+      const std::filesystem::path& file_name, bool is_64_bit);
 };
 
 #endif  // ORBIT_CORE_FRAME_POINTER_VALIDATOR_H_

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -386,7 +386,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   ErrorMessageOr<void> SelectFunctionsFromHashes(const ModuleData* module,
                                                  const std::vector<uint64_t>& function_hashes);
 
-  ErrorMessageOr<orbit_client_protos::PresetInfo> ReadPresetFromFile(const std::string& filename);
+  ErrorMessageOr<orbit_client_protos::PresetInfo> ReadPresetFromFile(
+      const std::filesystem::path& filename);
 
   ErrorMessageOr<void> SavePreset(const std::string& filename);
   [[nodiscard]] ScopedStatus CreateScopedStatus(const std::string& initial_message);

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -5,9 +5,9 @@
 #include "CallStackDataView.h"
 
 #include "App.h"
+#include "OrbitBase/ExecutablePath.h"
 #include "OrbitClientData/Callstack.h"
 #include "OrbitClientData/FunctionUtils.h"
-#include "Path.h"
 #include "absl/flags/flag.h"
 #include "absl/strings/str_format.h"
 
@@ -63,7 +63,9 @@ std::string CallStackDataView::GetValue(int row, int column) {
         return module->name();
       }
       const CaptureData& capture_data = GOrbitApp->GetCaptureData();
-      return Path::GetFileName(capture_data.GetModulePathByAddress(frame.address));
+      return std::filesystem::path(capture_data.GetModulePathByAddress(frame.address))
+          .filename()
+          .string();
     }
     case kColumnAddress:
       return absl::StrFormat("%#llx", frame.address);

--- a/OrbitGl/CallTreeView.h
+++ b/OrbitGl/CallTreeView.h
@@ -7,7 +7,6 @@
 
 #include "OrbitClientData/PostProcessedSamplingData.h"
 #include "OrbitClientModel/CaptureData.h"
-#include "Path.h"
 #include "absl/container/node_hash_map.h"
 
 class CallTreeThread;
@@ -86,7 +85,9 @@ class CallTreeFunction : public CallTreeNode {
 
   [[nodiscard]] const std::string& module_path() const { return module_path_; }
 
-  [[nodiscard]] std::string GetModuleName() const { return Path::GetFileName(module_path()); }
+  [[nodiscard]] std::string GetModuleName() const {
+    return std::filesystem::path(module_path()).filename().string();
+  }
 
  private:
   uint64_t function_absolute_address_;

--- a/OrbitGl/ImGuiOrbit.cpp
+++ b/OrbitGl/ImGuiOrbit.cpp
@@ -17,8 +17,8 @@
 #include "GlCanvas.h"
 #include "Images.h"
 #include "OpenGl.h"
+#include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Logging.h"
-#include "Path.h"
 #include "absl/base/casts.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/strip.h"
@@ -581,8 +581,7 @@ void Orbit_ImGui_RenderDrawLists(ImDrawData* draw_data) {
 }
 
 ImFont* AddOrbitFont(float pixel_size) {
-  const auto exe_dir = Path::GetExecutableDir();
-  const auto font_file_name = Path::JoinPath({exe_dir, "fonts", "Vera.ttf"});
+  const auto font_file_name = (orbit_base::GetExecutableDir() / "fonts" / "Vera.ttf").string();
   return ImGui::GetIO().Fonts->AddFontFromFileTTF(font_file_name.c_str(), pixel_size);
 }
 

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -11,7 +11,6 @@
 #include "OrbitBase/ThreadConstants.h"
 #include "OrbitClientData/FunctionUtils.h"
 #include "OrbitClientData/ModuleData.h"
-#include "Path.h"
 #include "absl/strings/str_format.h"
 
 using orbit_client_protos::FunctionInfo;
@@ -50,9 +49,7 @@ std::string SamplingReportDataView::GetValue(int row, int column) {
     case kColumnInclusive:
       return absl::StrFormat("%.2f", func.inclusive);
     case kColumnModuleName:
-      // LOG("%s", func.module_path);
-      // LOG("%s", Path::GetFileName(func.module_path));
-      return Path::GetFileName(func.module_path);
+      return std::filesystem::path(func.module_path).filename().string();
     case kColumnFile:
       return func.file;
     case kColumnLine:
@@ -74,10 +71,11 @@ std::string SamplingReportDataView::GetValue(int row, int column) {
     return OrbitUtils::Compare(Func(functions[a]), Func(functions[b]), ascending); \
   }
 
-#define ORBIT_MODULE_NAME_FUNC_SORT                                                     \
-  [&](int a, int b) {                                                                   \
-    return OrbitUtils::Compare(Path::GetFileName(functions[a].module_path),             \
-                               Path::GetFileName(functions[b].module_path), ascending); \
+#define ORBIT_MODULE_NAME_FUNC_SORT                                                        \
+  [&](int a, int b) {                                                                      \
+    return OrbitUtils::Compare(std::filesystem::path(functions[a].module_path).filename(), \
+                               std::filesystem::path(functions[b].module_path).filename(), \
+                               ascending);                                                 \
   }
 
 void SamplingReportDataView::DoSort() {
@@ -292,7 +290,7 @@ void SamplingReportDataView::DoFilter() {
   for (size_t i = 0; i < functions_.size(); ++i) {
     SampledFunction& func = functions_[i];
     std::string name = ToLower(func.name);
-    std::string module_name = ToLower(Path::GetFileName(func.module_path));
+    std::string module_name = ToLower(std::filesystem::path(func.module_path).filename().string());
 
     bool match = true;
 

--- a/OrbitGl/TextRenderer.cpp
+++ b/OrbitGl/TextRenderer.cpp
@@ -10,7 +10,7 @@
 #include "App.h"
 #include "GlCanvas.h"
 #include "GlUtils.h"
-#include "Path.h"
+#include "OrbitBase/ExecutablePath.h"
 
 typedef struct {
   float x, y, z;     // position
@@ -44,11 +44,11 @@ void TextRenderer::Init() {
   int atlasSize = 2 * 1024;
   texture_atlas_ = texture_atlas_new(atlasSize, atlasSize, 1);
 
-  const auto exe_dir = Path::GetExecutableDir();
-  const auto fontFileName = exe_dir + "fonts/Vera.ttf";
+  const auto exe_dir = orbit_base::GetExecutableDir();
+  const auto font_file_name = (exe_dir / "fonts" / "Vera.ttf").string();
 
   for (int i = 1; i <= 100; i += 1) {
-    fonts_by_size_[i] = texture_font_new_from_file(texture_atlas_, i, fontFileName.c_str());
+    fonts_by_size_[i] = texture_font_new_from_file(texture_atlas_, i, font_file_name.c_str());
   }
 
   pen_.x = 0;
@@ -56,9 +56,9 @@ void TextRenderer::Init() {
 
   glGenTextures(1, &texture_atlas_->id);
 
-  const auto vertShaderFileName = Path::JoinPath({exe_dir, "shaders", "v3f-t2f-c4f.vert"});
-  const auto fragShaderFileName = Path::JoinPath({exe_dir, "shaders", "v3f-t2f-c4f.frag"});
-  shader_ = shader_load(vertShaderFileName.c_str(), fragShaderFileName.c_str());
+  const auto vert_shader_file_name = (exe_dir / "shaders" / "v3f-t2f-c4f.vert").string();
+  const auto frag_shader_file_name = (exe_dir / "shaders" / "v3f-t2f-c4f.frag").string();
+  shader_ = shader_load(vert_shader_file_name.c_str(), frag_shader_file_name.c_str());
 
   mat4_set_identity(&projection_);
   mat4_set_identity(&model_);

--- a/OrbitQt/OrbitStartupWindow.cpp
+++ b/OrbitQt/OrbitStartupWindow.cpp
@@ -69,7 +69,8 @@ OrbitStartupWindow::OrbitStartupWindow(QWidget* parent)
 
   QObject::connect(load_capture_button, &QPushButton::clicked, this, [this, button_box]() {
     const QString file = QFileDialog::getOpenFileName(
-        this, "Open capture...", QString::fromStdString(Path::CreateOrGetCaptureDir()), "*.orbit");
+        this, "Open capture...", QString::fromStdString(Path::CreateOrGetCaptureDir().string()),
+        "*.orbit");
     if (!file.isEmpty()) {
       result_ = file;
       accept();

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -31,7 +31,6 @@
 #include "OrbitGgp/Error.h"
 #include "OrbitSsh/Context.h"
 #include "OrbitSsh/Credentials.h"
-#include "OrbitSshQt/Session.h"
 #include "OrbitStartupWindow.h"
 #include "OrbitVersion/OrbitVersion.h"
 #include "Path.h"
@@ -305,8 +304,7 @@ int main(int argc, char* argv[]) {
     absl::SetFlagsUsageConfig(absl::FlagsUsageConfig{{}, {}, {}, &OrbitCore::GetBuildReport, {}});
     absl::ParseCommandLine(argc, argv);
 
-    const std::string log_file_path = Path::GetLogFilePathAndCreateDir();
-    InitLogFile(log_file_path);
+    InitLogFile(Path::GetLogFilePathAndCreateDir());
     LOG("You are running Orbit Profiler version %s", OrbitCore::GetVersion());
 
 #if __linux__
@@ -334,7 +332,7 @@ int main(int argc, char* argv[]) {
     path_to_executable = QCoreApplication::applicationFilePath();
 
 #ifdef ORBIT_CRASH_HANDLING
-    const std::string dump_path = Path::CreateOrGetDumpDir();
+    const std::string dump_path = Path::CreateOrGetDumpDir().string();
 #ifdef _WIN32
     const char* handler_name = "crashpad_handler.exe";
 #else
@@ -343,7 +341,7 @@ int main(int argc, char* argv[]) {
     const std::string handler_path =
         QDir(QCoreApplication::applicationDirPath()).absoluteFilePath(handler_name).toStdString();
     const std::string crash_server_url = CrashServerOptions::GetUrl();
-    const std::vector<std::string> attachments = {Path::GetLogFilePathAndCreateDir()};
+    const std::vector<std::string> attachments = {Path::GetLogFilePathAndCreateDir().string()};
 
     CrashHandler crash_handler(dump_path, handler_path, crash_server_url, attachments);
 #endif  // ORBIT_CRASH_HANDLING

--- a/OrbitQt/orbitcodeeditor.cpp
+++ b/OrbitQt/orbitcodeeditor.cpp
@@ -194,7 +194,7 @@ bool OrbitCodeEditor::loadCode(std::string a_Msg) {
 }
 
 void OrbitCodeEditor::loadFileMap() {
-  QFile file(QString::fromStdString(Path::GetFileMappingFileName()));
+  QFile file(QString::fromStdString(Path::GetFileMappingFileName().string()));
   bool success = file.open(QFile::ReadWrite | QFile::Text);
   if (success) {
     QTextStream ReadFile(&file);
@@ -324,8 +324,7 @@ void OrbitCodeEditor::keyPressEvent(QKeyEvent* e) {
 }
 
 void OrbitCodeEditor::saveFileMap() {
-  std::string fileName = Path::GetFileMappingFileName();
-  std::wofstream outFile(fileName);
+  std::wofstream outFile(Path::GetFileMappingFileName());
   if (!outFile.fail()) {
     outFile << document()->toPlainText().toStdWString();
     outFile.close();

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -9,19 +9,18 @@
 #include <QClipboard>
 #include <QCoreApplication>
 #include <QDesktopServices>
-#include <QDialogButtonBox>
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QMouseEvent>
 #include <QProgressDialog>
 #include <QSettings>
-#include <QStatusBar>
 #include <QTimer>
 #include <QToolTip>
 #include <utility>
 
 #include "App.h"
 #include "CallTreeViewItemModel.h"
+#include "OrbitBase/ExecutablePath.h"
 #include "OrbitClientModel/CaptureSerializer.h"
 #include "OrbitVersion/OrbitVersion.h"
 #include "Path.h"
@@ -274,8 +273,8 @@ OrbitMainWindow::OrbitMainWindow(QApplication* a_App,
   ui->RightTabWidget->tabBar()->installEventFilter(this);
 
   setWindowTitle({});
-  std::string iconFileName = Path::JoinPath({Path::GetExecutableDir(), "orbit.ico"});
-  this->setWindowIcon(QIcon(iconFileName.c_str()));
+  std::filesystem::path icon_file_name = (orbit_base::GetExecutableDir() / "orbit.ico");
+  this->setWindowIcon(QIcon(QString::fromStdString(icon_file_name.string())));
 
   GOrbitApp->PostInit();
 
@@ -641,8 +640,9 @@ void OrbitMainWindow::OnFilterTracksTextChanged(const QString& text) {
 }
 
 void OrbitMainWindow::on_actionOpen_Preset_triggered() {
-  QStringList list = QFileDialog::getOpenFileNames(this, "Select a file to open...",
-                                                   Path::CreateOrGetPresetDir().c_str(), "*.opr");
+  QStringList list = QFileDialog::getOpenFileNames(
+      this, "Select a file to open...",
+      QString::fromStdString(Path::CreateOrGetPresetDir().string()), "*.opr");
   for (const auto& file : list) {
     ErrorMessageOr<void> result = GOrbitApp->OnLoadPreset(file.toStdString());
     if (result.has_error()) {
@@ -670,8 +670,9 @@ QPixmap QtGrab(OrbitMainWindow* a_Window) {
 }
 
 void OrbitMainWindow::on_actionSave_Preset_As_triggered() {
-  QString file = QFileDialog::getSaveFileName(this, "Specify a file to save...",
-                                              Path::CreateOrGetPresetDir().c_str(), "*.opr");
+  QString file = QFileDialog::getSaveFileName(
+      this, "Specify a file to save...",
+      QString::fromStdString(Path::CreateOrGetPresetDir().string()), "*.opr");
   if (file.isEmpty()) {
     return;
   }
@@ -783,9 +784,9 @@ void OrbitMainWindow::on_actionSave_Capture_triggered() {
   const CaptureData& capture_data = GOrbitApp->GetCaptureData();
   QString file = QFileDialog::getSaveFileName(
       this, "Save capture...",
-      Path::JoinPath(
-          {Path::CreateOrGetCaptureDir(), capture_serializer::GetCaptureFileName(capture_data)})
-          .c_str(),
+      QString::fromStdString(
+          (Path::CreateOrGetCaptureDir() / capture_serializer::GetCaptureFileName(capture_data))
+              .string()),
       "*.orbit");
   if (file.isEmpty()) {
     return;
@@ -802,7 +803,8 @@ void OrbitMainWindow::on_actionSave_Capture_triggered() {
 
 void OrbitMainWindow::on_actionOpen_Capture_triggered() {
   QString file = QFileDialog::getOpenFileName(
-      this, "Open capture...", QString::fromStdString(Path::CreateOrGetCaptureDir()), "*.orbit");
+      this, "Open capture...", QString::fromStdString(Path::CreateOrGetCaptureDir().string()),
+      "*.orbit");
   if (file.isEmpty()) {
     return;
   }


### PR DESCRIPTION
This change also simplifies most of the functions, and adds error
handling (in form of FATAL in the case executable_path is not available)

Test: build, run OrbitBaseTests