### PR TITLE
Fix Crash in TracepointEventBuffer::GetNumTracepointsForThreadId

### DIFF
--- a/OrbitClientData/TracepointEventBuffer.cpp
+++ b/OrbitClientData/TracepointEventBuffer.cpp
@@ -89,7 +89,12 @@ uint32_t TracepointEventBuffer::GetNumTracepointsForThreadId(int32_t thread_id) 
       return num_total_tracepoints_;
     }
     if (thread_id == -1 /*TODO(b/166238019) Use a proper constant again*/) {
-      return num_total_tracepoints_ - tracepoint_events_.at(kNotTargetProcessThreadId).size();
+      auto const not_target_process_tracepoints_it =
+          tracepoint_events_.find(kNotTargetProcessThreadId);
+      if (not_target_process_tracepoints_it != tracepoint_events_.end()) {
+        return num_total_tracepoints_ - not_target_process_tracepoints_it->second.size();
+      }
+      return num_total_tracepoints_;
     }
   }
 


### PR DESCRIPTION
With the recent change #1537 a map access in
"GetNumTracePointsForThreadId" was changed from "[]" to ".at",
assuming the key was in that map. This turned out to be a wrong
assumption.

This changes the code to handle the case where the data is not there
without modifying the map.

Bug: http://174730511
Test: Compile and take a capture