### PR TITLE
Apply include-what-you-use findings to OrbitLinuxTracing

### DIFF
--- a/OrbitLinuxTracing/ContextSwitchManager.cpp
+++ b/OrbitLinuxTracing/ContextSwitchManager.cpp
@@ -4,6 +4,10 @@
 
 #include "ContextSwitchManager.h"
 
+#include <utility>
+
+#include "OrbitBase/Logging.h"
+
 namespace LinuxTracing {
 
 using orbit_grpc_protos::SchedulingSlice;

--- a/OrbitLinuxTracing/ContextSwitchManager.h
+++ b/OrbitLinuxTracing/ContextSwitchManager.h
@@ -5,9 +5,12 @@
 #ifndef ORBIT_LINUX_TRACING_CONTEXT_SWITCH_MANAGER_H_
 #define ORBIT_LINUX_TRACING_CONTEXT_SWITCH_MANAGER_H_
 
-#include <OrbitBase/Logging.h>
+#include <absl/container/flat_hash_map.h>
+#include <stdint.h>
+#include <sys/types.h>
 
-#include "absl/container/flat_hash_map.h"
+#include <optional>
+
 #include "capture.pb.h"
 
 namespace LinuxTracing {

--- a/OrbitLinuxTracing/ContextSwitchManagerTest.cpp
+++ b/OrbitLinuxTracing/ContextSwitchManagerTest.cpp
@@ -2,10 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+#include <memory>
+#include <optional>
 
 #include "ContextSwitchManager.h"
+#include "capture.pb.h"
 
 namespace LinuxTracing {
 

--- a/OrbitLinuxTracing/GpuTracepointEventProcessor.cpp
+++ b/OrbitLinuxTracing/GpuTracepointEventProcessor.cpp
@@ -4,9 +4,16 @@
 
 #include "GpuTracepointEventProcessor.h"
 
+#include <absl/container/flat_hash_map.h>
+
+#include <algorithm>
+#include <ctime>
 #include <string>
 #include <tuple>
+#include <utility>
 #include <vector>
+
+#include "capture.pb.h"
 
 namespace LinuxTracing {
 

--- a/OrbitLinuxTracing/GpuTracepointEventProcessor.h
+++ b/OrbitLinuxTracing/GpuTracepointEventProcessor.h
@@ -5,11 +5,17 @@
 #ifndef ORBIT_LINUX_TRACING_GPU_TRACEPOINT_EVENT_PROCESSOR
 #define ORBIT_LINUX_TRACING_GPU_TRACEPOINT_EVENT_PROCESSOR
 
+#include <absl/container/flat_hash_map.h>
+#include <absl/hash/hash.h>
+#include <sys/types.h>
+
+#include <cstdint>
+#include <string>
 #include <tuple>
+#include <vector>
 
 #include "OrbitLinuxTracing/TracerListener.h"
 #include "PerfEvent.h"
-#include "absl/container/flat_hash_map.h"
 
 namespace LinuxTracing {
 

--- a/OrbitLinuxTracing/LibunwindstackUnwinder.cpp
+++ b/OrbitLinuxTracing/LibunwindstackUnwinder.cpp
@@ -4,9 +4,12 @@
 
 #include "LibunwindstackUnwinder.h"
 
-#include <OrbitBase/Logging.h>
+#include <unwindstack/Memory.h>
+#include <unwindstack/Regs.h>
+#include <unwindstack/RegsX86_64.h>
 
 #include <array>
+#include <cstdint>
 
 namespace LinuxTracing {
 

--- a/OrbitLinuxTracing/LibunwindstackUnwinder.h
+++ b/OrbitLinuxTracing/LibunwindstackUnwinder.h
@@ -6,10 +6,15 @@
 #define ORBIT_LINUX_TRACING_LIBUNWINDSTACK_UNWINDER_H_
 
 #include <asm/perf_regs.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <unwindstack/Error.h>
 #include <unwindstack/MachineX86_64.h>
-#include <unwindstack/RegsX86_64.h>
+#include <unwindstack/Maps.h>
 #include <unwindstack/Unwinder.h>
 
+#include <array>
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/OrbitLinuxTracing/LinuxTracingUtils.cpp
+++ b/OrbitLinuxTracing/LinuxTracingUtils.cpp
@@ -4,14 +4,26 @@
 
 #include <OrbitBase/Logging.h>
 #include <OrbitBase/SafeStrerror.h>
+#include <absl/strings/numbers.h>
+#include <absl/strings/str_format.h>
+#include <absl/strings/str_split.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
 #include <sys/resource.h>
 
+#include <array>
+#include <ctime>
+#include <filesystem>
 #include <fstream>
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <system_error>
 #include <thread>
-
-#include "absl/strings/numbers.h"
-#include "absl/strings/str_format.h"
-#include "absl/strings/str_split.h"
+#include <vector>
 
 namespace LinuxTracing {
 

--- a/OrbitLinuxTracing/LinuxTracingUtilsTest.cpp
+++ b/OrbitLinuxTracing/LinuxTracingUtilsTest.cpp
@@ -2,17 +2,24 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <gmock/gmock-matchers.h>
+#include <absl/strings/str_format.h>
+#include <absl/synchronization/mutex.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <pthread.h>
-#include <sys/syscall.h>
+#include <syscall.h>
+#include <unistd.h>
 
+#include <algorithm>
+#include <chrono>
 #include <condition_variable>
 #include <mutex>
+#include <optional>
+#include <string>
 #include <thread>
+#include <vector>
 
 #include "LinuxTracingUtils.h"
-#include "absl/synchronization/mutex.h"
 
 namespace LinuxTracing {
 

--- a/OrbitLinuxTracing/ManualInstrumentationConfig.h
+++ b/OrbitLinuxTracing/ManualInstrumentationConfig.h
@@ -5,9 +5,9 @@
 #ifndef ORBIT_LINUX_TRACING_MANUAL_INSTRUMENTATION_CONFIG_H_
 #define ORBIT_LINUX_TRACING_MANUAL_INSTRUMENTATION_CONFIG_H_
 
-#include <cstdint>
+#include <absl/container/flat_hash_set.h>
 
-#include "absl/container/flat_hash_set.h"
+#include <cstdint>
 
 class ManualInstrumentationConfig {
  public:

--- a/OrbitLinuxTracing/PerfEvent.h
+++ b/OrbitLinuxTracing/PerfEvent.h
@@ -5,8 +5,17 @@
 #ifndef ORBIT_LINUX_TRACING_PERF_EVENT_H_
 #define ORBIT_LINUX_TRACING_PERF_EVENT_H_
 
+#include <asm/perf_regs.h>
+#include <linux/perf_event.h>
+#include <string.h>
+#include <sys/types.h>
+
 #include <array>
+#include <cstdint>
 #include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "Function.h"
 #include "KernelTracepoints.h"

--- a/OrbitLinuxTracing/PerfEventOpen.cpp
+++ b/OrbitLinuxTracing/PerfEventOpen.cpp
@@ -6,13 +6,14 @@
 
 #include <OrbitBase/Logging.h>
 #include <OrbitBase/SafeStrerror.h>
+#include <absl/base/casts.h>
 #include <linux/perf_event.h>
+#include <sys/mman.h>
+#include <sys/time.h>
 
 #include <cerrno>
 
-#include "Function.h"
 #include "LinuxTracingUtils.h"
-#include "absl/base/casts.h"
 
 namespace LinuxTracing {
 namespace {

--- a/OrbitLinuxTracing/PerfEventOpen.h
+++ b/OrbitLinuxTracing/PerfEventOpen.h
@@ -8,17 +8,13 @@
 #include <OrbitBase/Logging.h>
 #include <OrbitBase/SafeStrerror.h>
 #include <asm/perf_regs.h>
-#include <asm/unistd.h>
 #include <linux/perf_event.h>
-#include <linux/version.h>
 #include <sys/ioctl.h>
-#include <sys/mman.h>
+#include <syscall.h>
 #include <unistd.h>
 
 #include <cerrno>
 #include <cstdint>
-#include <cstring>
-#include <ctime>
 
 inline int perf_event_open(struct perf_event_attr* attr, pid_t pid, int cpu, int group_fd,
                            unsigned long flags) {

--- a/OrbitLinuxTracing/PerfEventProcessor.cpp
+++ b/OrbitLinuxTracing/PerfEventProcessor.cpp
@@ -7,6 +7,7 @@
 #include <OrbitBase/Logging.h>
 
 #include <memory>
+#include <utility>
 
 #include "LinuxTracingUtils.h"
 #include "PerfEvent.h"

--- a/OrbitLinuxTracing/PerfEventProcessor.h
+++ b/OrbitLinuxTracing/PerfEventProcessor.h
@@ -5,8 +5,12 @@
 #ifndef ORBIT_LINUX_TRACING_PERF_EVENT_PROCESSOR_H_
 #define ORBIT_LINUX_TRACING_PERF_EVENT_PROCESSOR_H_
 
-#include <ctime>
+#include <stdint.h>
+
+#include <algorithm>
+#include <atomic>
 #include <memory>
+#include <vector>
 
 #include "PerfEvent.h"
 #include "PerfEventQueue.h"

--- a/OrbitLinuxTracing/PerfEventProcessorTest.cpp
+++ b/OrbitLinuxTracing/PerfEventProcessorTest.cpp
@@ -4,11 +4,17 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <stdint.h>
 
+#include <atomic>
+#include <chrono>
+#include <memory>
 #include <thread>
 
 #include "LinuxTracingUtils.h"
+#include "PerfEvent.h"
 #include "PerfEventProcessor.h"
+#include "PerfEventRecords.h"
 #include "PerfEventVisitor.h"
 
 namespace LinuxTracing {

--- a/OrbitLinuxTracing/PerfEventQueue.h
+++ b/OrbitLinuxTracing/PerfEventQueue.h
@@ -5,11 +5,14 @@
 #ifndef ORBIT_LINUX_TRACING_PERF_EVENT_QUEUE_H_
 #define ORBIT_LINUX_TRACING_PERF_EVENT_QUEUE_H_
 
+#include <absl/container/flat_hash_map.h>
+#include <absl/hash/hash.h>
+
 #include <memory>
 #include <queue>
+#include <vector>
 
 #include "PerfEvent.h"
-#include "absl/container/flat_hash_map.h"
 
 namespace LinuxTracing {
 

--- a/OrbitLinuxTracing/PerfEventReaders.cpp
+++ b/OrbitLinuxTracing/PerfEventReaders.cpp
@@ -4,7 +4,7 @@
 
 #include "PerfEventReaders.h"
 
-#include <OrbitBase/Logging.h>
+#include <vector>
 
 #include "PerfEventRecords.h"
 #include "PerfEventRingBuffer.h"

--- a/OrbitLinuxTracing/PerfEventReaders.h
+++ b/OrbitLinuxTracing/PerfEventReaders.h
@@ -5,7 +5,16 @@
 #ifndef ORBIT_LINUX_TRACING_PERF_EVENT_READERS_H_
 #define ORBIT_LINUX_TRACING_PERF_EVENT_READERS_H_
 
+#include <linux/perf_event.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+#include <memory>
+#include <type_traits>
+
 #include "PerfEvent.h"
+#include "PerfEventRecords.h"
 #include "PerfEventRingBuffer.h"
 
 namespace LinuxTracing {

--- a/OrbitLinuxTracing/PerfEventRingBuffer.cpp
+++ b/OrbitLinuxTracing/PerfEventRingBuffer.cpp
@@ -6,9 +6,12 @@
 
 #include <OrbitBase/Logging.h>
 #include <OrbitBase/SafeStrerror.h>
+#include <errno.h>
 #include <linux/perf_event.h>
+#include <string.h>
 #include <sys/mman.h>
 
+#include <cstdint>
 #include <utility>
 
 #include "LinuxTracingUtils.h"

--- a/OrbitLinuxTracing/PerfEventRingBuffer.h
+++ b/OrbitLinuxTracing/PerfEventRingBuffer.h
@@ -6,10 +6,9 @@
 #define ORBIT_LINUX_TRACING_PERF_RING_BUFFER_H_
 
 #include <linux/perf_event.h>
+#include <stdint.h>
 
 #include <string>
-
-#include "PerfEventOpen.h"
 
 namespace LinuxTracing {
 

--- a/OrbitLinuxTracing/ThreadStateVisitor.cpp
+++ b/OrbitLinuxTracing/ThreadStateVisitor.cpp
@@ -4,6 +4,15 @@
 
 #include "ThreadStateVisitor.h"
 
+#include <absl/container/flat_hash_map.h>
+
+#include <algorithm>
+#include <type_traits>
+#include <utility>
+
+#include "OrbitBase/Logging.h"
+#include "OrbitLinuxTracing/TracerListener.h"
+
 namespace LinuxTracing {
 
 using orbit_grpc_protos::ThreadStateSlice;

--- a/OrbitLinuxTracing/ThreadStateVisitor.h
+++ b/OrbitLinuxTracing/ThreadStateVisitor.h
@@ -6,9 +6,17 @@
 #define ORBIT_LINUX_TRACING_THREAD_STATE_VISITOR_H_
 
 #include <OrbitLinuxTracing/TracerListener.h>
+#include <absl/container/flat_hash_map.h>
+#include <absl/hash/hash.h>
+#include <stdint.h>
+#include <sys/types.h>
 
+#include <optional>
+#include <vector>
+
+#include "PerfEvent.h"
 #include "PerfEventVisitor.h"
-#include "absl/container/flat_hash_map.h"
+#include "capture.pb.h"
 
 namespace LinuxTracing {
 

--- a/OrbitLinuxTracing/ThreadStateVisitorTest.cpp
+++ b/OrbitLinuxTracing/ThreadStateVisitorTest.cpp
@@ -2,10 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
+#include <sys/types.h>
+
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
 
 #include "ThreadStateVisitor.h"
+#include "capture.pb.h"
 
 namespace LinuxTracing {
 

--- a/OrbitLinuxTracing/Tracer.cpp
+++ b/OrbitLinuxTracing/Tracer.cpp
@@ -2,10 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <OrbitBase/Logging.h>
 #include <OrbitLinuxTracing/Tracer.h>
+#include <pthread.h>
 
+#include <atomic>
+#include <memory>
+
+#include "OrbitLinuxTracing/TracerListener.h"
 #include "TracerThread.h"
+#include "capture.pb.h"
 
 namespace LinuxTracing {
 

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -6,10 +6,28 @@
 
 #include <OrbitBase/Logging.h>
 #include <OrbitBase/Tracing.h>
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
+#include <absl/hash/hash.h>
+#include <absl/strings/str_format.h>
+#include <pthread.h>
+#include <stddef.h>
+#include <unistd.h>
 
+#include <algorithm>
+#include <string>
+#include <string_view>
 #include <thread>
+#include <type_traits>
+#include <utility>
 
-#include "absl/strings/str_format.h"
+#include "Function.h"
+#include "OrbitBase/MakeUniqueForOverwrite.h"
+#include "OrbitLinuxTracing/TracerListener.h"
+#include "PerfEventOpen.h"
+#include "PerfEventReaders.h"
+#include "PerfEventRecords.h"
+#include "tracepoint.pb.h"
 
 namespace LinuxTracing {
 

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -7,14 +7,18 @@
 
 #include <Function.h>
 #include <OrbitLinuxTracing/TracerListener.h>
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
 #include <linux/perf_event.h>
+#include <sys/types.h>
 #include <tracepoint.pb.h>
 
 #include <atomic>
+#include <cstdint>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <optional>
-#include <regex>
 #include <vector>
 
 #include "ContextSwitchManager.h"
@@ -23,12 +27,9 @@
 #include "ManualInstrumentationConfig.h"
 #include "PerfEvent.h"
 #include "PerfEventProcessor.h"
-#include "PerfEventReaders.h"
 #include "PerfEventRingBuffer.h"
 #include "ThreadStateVisitor.h"
 #include "UprobesUnwindingVisitor.h"
-#include "absl/container/flat_hash_map.h"
-#include "absl/container/flat_hash_set.h"
 #include "capture.pb.h"
 
 namespace LinuxTracing {

--- a/OrbitLinuxTracing/UprobesFunctionCallManager.h
+++ b/OrbitLinuxTracing/UprobesFunctionCallManager.h
@@ -6,11 +6,11 @@
 #define ORBIT_LINUX_TRACING_UPROBES_FUNCTION_CALL_MANAGER_H_
 
 #include <OrbitBase/Logging.h>
+#include <absl/container/flat_hash_map.h>
 
 #include <stack>
 
 #include "PerfEventRecords.h"
-#include "absl/container/flat_hash_map.h"
 #include "capture.pb.h"
 
 namespace LinuxTracing {

--- a/OrbitLinuxTracing/UprobesFunctionCallManagerTest.cpp
+++ b/OrbitLinuxTracing/UprobesFunctionCallManagerTest.cpp
@@ -2,10 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
+#include <sys/types.h>
 
+#include <memory>
+#include <optional>
+
+#include "PerfEventRecords.h"
 #include "UprobesFunctionCallManager.h"
+#include "capture.pb.h"
 
 namespace LinuxTracing {
 

--- a/OrbitLinuxTracing/UprobesReturnAddressManager.h
+++ b/OrbitLinuxTracing/UprobesReturnAddressManager.h
@@ -6,14 +6,13 @@
 #define ORBIT_LINUX_TRACING_UPROBES_RETURN_ADDRESS_MANAGER_H_
 
 #include <OrbitBase/Logging.h>
+#include <absl/container/flat_hash_map.h>
 #include <absl/strings/str_join.h>
 #include <unwindstack/MapInfo.h>
 #include <unwindstack/Maps.h>
 
 #include <stack>
 #include <vector>
-
-#include "absl/container/flat_hash_map.h"
 
 // Keeps a stack, for every thread, of the return addresses at the top of the
 // stack when uprobes are hit, before they are hijacked by uretprobes. Patches

--- a/OrbitLinuxTracing/UprobesReturnAddressManagerTest.cpp
+++ b/OrbitLinuxTracing/UprobesReturnAddressManagerTest.cpp
@@ -2,8 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <gmock/gmock-matchers.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <unwindstack/Maps.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <ctime>
+#include <memory>
+#include <string>
+#include <vector>
 
 #include "LibunwindstackUnwinder.h"
 #include "UprobesReturnAddressManager.h"

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
@@ -4,7 +4,21 @@
 
 #include "UprobesUnwindingVisitor.h"
 
+#include <absl/container/flat_hash_map.h>
+#include <asm/perf_regs.h>
+#include <unwindstack/MapInfo.h>
+#include <unwindstack/Unwinder.h>
+
+#include <algorithm>
+#include <array>
+#include <optional>
+#include <utility>
+
+#include "Function.h"
 #include "OrbitBase/Logging.h"
+#include "OrbitLinuxTracing/TracerListener.h"
+#include "PerfEventRecords.h"
+#include "capture.pb.h"
 
 namespace LinuxTracing {
 

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.h
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.h
@@ -6,16 +6,23 @@
 #define ORBIT_LINUX_TRACING_UPROBES_UNWINDING_VISITOR_H_
 
 #include <OrbitLinuxTracing/TracerListener.h>
+#include <absl/container/flat_hash_map.h>
+#include <absl/hash/hash.h>
+#include <sys/types.h>
+#include <unwindstack/Maps.h>
 
-#include <stack>
-#include <utility>
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
 
 #include "LibunwindstackUnwinder.h"
 #include "PerfEvent.h"
 #include "PerfEventVisitor.h"
 #include "UprobesFunctionCallManager.h"
 #include "UprobesReturnAddressManager.h"
-#include "absl/container/flat_hash_map.h"
 
 namespace LinuxTracing {
 

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/Tracer.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/Tracer.h
@@ -6,14 +6,11 @@
 #define ORBIT_LINUX_TRACING_TRACER_H_
 
 #include <OrbitLinuxTracing/TracerListener.h>
-#include <unistd.h>
 
 #include <atomic>
-#include <functional>
 #include <memory>
-#include <optional>
 #include <thread>
-#include <vector>
+#include <utility>
 
 #include "capture.pb.h"
 


### PR DESCRIPTION
As a test run I manually applied all findings from include-what-you-use
to OrbitLinuxTracing. I was in particular interested how it works with
system headers (Linux, Posix, etc.) which are used a lot by OrbitLinuxTracing.

So far no complications.