### PR TITLE
Fix save capture when there is no capture data crash

### DIFF
--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -760,6 +760,11 @@ void OrbitMainWindow::RestoreDefaultTabLayout() {
 void OrbitMainWindow::on_actionSave_Capture_triggered() {
   ShowCaptureOnSaveWarningIfNeeded();
 
+  if (!GOrbitApp->HasCaptureData()) {
+    QMessageBox::information(this, "Save capture", "Looks like there is no capture to save.");
+    return;
+  }
+
   const CaptureData& capture_data = GOrbitApp->GetCaptureData();
   QString file = QFileDialog::getSaveFileName(
       this, "Save capture...",


### PR DESCRIPTION
Test: start orbit -> save capture (without loading/taking capture)
      check that it displays message instead of crashing.