### PR TITLE
Move GetExecutablePath(pid) to OrbitBase

### DIFF
--- a/OrbitBase/CMakeLists.txt
+++ b/OrbitBase/CMakeLists.txt
@@ -64,6 +64,11 @@ target_sources(OrbitBaseTests PRIVATE
         UniqueResourceTest.cpp
 )
 
+if (NOT WIN32)
+target_sources(OrbitBaseTests PRIVATE
+        ExecutablePathLinuxTest.cpp)
+endif()
+
 # Threadpool test contains some sleeps we couldn't work around - disable them on the CI
 # since they are flaky there (but they work fine on local workstations).
 if (NOT (WIN32 AND "$ENV{QT_QPA_PLATFORM}" STREQUAL "offscreen"))

--- a/OrbitBase/ExecutablePathLinux.cpp
+++ b/OrbitBase/ExecutablePathLinux.cpp
@@ -23,4 +23,16 @@ std::filesystem::path GetExecutablePath() {
   return std::filesystem::path(std::string(buffer, length));
 }
 
+ErrorMessageOr<std::filesystem::path> GetExecutablePath(int32_t pid) {
+  char buffer[PATH_MAX];
+
+  ssize_t length = readlink(absl::StrFormat("/proc/%d/exe", pid).c_str(), buffer, sizeof(buffer));
+  if (length == -1) {
+    return ErrorMessage(absl::StrFormat("Unable to get executable path of process with pid %d: %s",
+                                        pid, SafeStrerror(errno)));
+  }
+
+  return std::filesystem::path{std::string(buffer, length)};
+}
+
 }  // namespace orbit_base

--- a/OrbitBase/ExecutablePathLinuxTest.cpp
+++ b/OrbitBase/ExecutablePathLinuxTest.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "OrbitBase/ExecutablePath.h"
+
+TEST(ExecutablePathLinux, GetExecutablePathWithPid) {
+  const auto result = orbit_base::GetExecutablePath(getpid());
+  ASSERT_TRUE(result) << result.error().message();
+  EXPECT_EQ(result.value().filename(), "OrbitBaseTests");
+}
+
+TEST(ExecutablePathLinux, GetExecutablePathWithInvalidPid) {
+  const auto result = orbit_base::GetExecutablePath(0);
+  ASSERT_FALSE(result);
+  EXPECT_EQ(result.error().message(),
+            "Unable to get executable path of process with pid 0: No such file or directory");
+}
+
+TEST(ExecutablePathLinux, GetExecutablePathWithPidPermissionDenied) {
+  if (getuid() == 0) {
+    GTEST_SKIP() << "This test is disabled for root user";
+  }
+
+  const auto result = orbit_base::GetExecutablePath(1);
+  ASSERT_FALSE(result);
+  EXPECT_EQ(result.error().message(),
+            "Unable to get executable path of process with pid 1: Permission denied");
+}

--- a/OrbitBase/ExecutablePathLinuxTest.cpp
+++ b/OrbitBase/ExecutablePathLinuxTest.cpp
@@ -18,14 +18,3 @@ TEST(ExecutablePathLinux, GetExecutablePathWithInvalidPid) {
   EXPECT_EQ(result.error().message(),
             "Unable to get executable path of process with pid 0: No such file or directory");
 }
-
-TEST(ExecutablePathLinux, GetExecutablePathWithPidPermissionDenied) {
-  if (getuid() == 0) {
-    GTEST_SKIP() << "This test is disabled for root user";
-  }
-
-  const auto result = orbit_base::GetExecutablePath(1);
-  ASSERT_FALSE(result);
-  EXPECT_EQ(result.error().message(),
-            "Unable to get executable path of process with pid 1: Permission denied");
-}

--- a/OrbitBase/ExecutablePathTest.cpp
+++ b/OrbitBase/ExecutablePathTest.cpp
@@ -6,7 +6,7 @@
 
 #include "OrbitBase/ExecutablePath.h"
 
-TEST(Path, GetExecutablePath) {
+TEST(ExecutablePath, GetExecutablePath) {
   std::filesystem::path path = orbit_base::GetExecutablePath();
 #ifdef _WIN32
   const std::string executable_name = "OrbitBaseTests.exe";
@@ -17,4 +17,6 @@ TEST(Path, GetExecutablePath) {
   EXPECT_EQ(path.parent_path().filename(), "bin");
 }
 
-TEST(Path, GetExecutableDir) { EXPECT_EQ(orbit_base::GetExecutableDir().filename(), "bin"); }
+TEST(ExecutablePath, GetExecutableDir) {
+  EXPECT_EQ(orbit_base::GetExecutableDir().filename(), "bin");
+}

--- a/OrbitBase/include/OrbitBase/ExecutablePath.h
+++ b/OrbitBase/include/OrbitBase/ExecutablePath.h
@@ -8,10 +8,16 @@
 #include <filesystem>
 #include <vector>
 
+#include "OrbitBase/Result.h"
+
 namespace orbit_base {
 
 [[nodiscard]] std::filesystem::path GetExecutablePath();
 [[nodiscard]] std::filesystem::path GetExecutableDir();
+
+#if defined(__linux)
+[[nodiscard]] ErrorMessageOr<std::filesystem::path> GetExecutablePath(int32_t pid);
+#endif
 
 }  // namespace orbit_base
 

--- a/OrbitLinuxTracing/LibunwindstackUnwinder.cpp
+++ b/OrbitLinuxTracing/LibunwindstackUnwinder.cpp
@@ -11,6 +11,8 @@
 #include <array>
 #include <cstdint>
 
+#include "OrbitBase/Logging.h"
+
 namespace LinuxTracing {
 
 std::unique_ptr<unwindstack::BufferMaps> LibunwindstackUnwinder::ParseMaps(

--- a/OrbitLinuxTracing/LibunwindstackUnwinder.h
+++ b/OrbitLinuxTracing/LibunwindstackUnwinder.h
@@ -6,14 +6,14 @@
 #define ORBIT_LINUX_TRACING_LIBUNWINDSTACK_UNWINDER_H_
 
 #include <asm/perf_regs.h>
-#include <stddef.h>
-#include <stdint.h>
 #include <unwindstack/Error.h>
 #include <unwindstack/MachineX86_64.h>
 #include <unwindstack/Maps.h>
 #include <unwindstack/Unwinder.h>
 
 #include <array>
+#include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>

--- a/OrbitService/Process.cpp
+++ b/OrbitService/Process.cpp
@@ -9,10 +9,10 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cstdint>
 #include <filesystem>
 
 #include "ElfUtils/ElfFile.h"
+#include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
 #include "ServiceUtils.h"
@@ -87,7 +87,7 @@ ErrorMessageOr<Process> Process::FromPid(pid_t pid) {
   std::replace(cmdline.begin(), cmdline.end(), '\0', ' ');
   process.set_command_line(cmdline);
 
-  auto file_path_result = utils::GetExecutablePath(pid);
+  auto file_path_result = orbit_base::GetExecutablePath(pid);
   if (file_path_result) {
     process.set_full_path(std::move(file_path_result.value()));
 

--- a/OrbitService/ServiceUtils.cpp
+++ b/OrbitService/ServiceUtils.cpp
@@ -15,7 +15,6 @@
 #include <unistd.h>
 
 #include <charconv>
-#include <cstdlib>
 #include <filesystem>
 #include <functional>
 #include <memory>
@@ -27,7 +26,6 @@
 #include "OrbitBase/Result.h"
 #include "OrbitBase/SafeStrerror.h"
 #include "absl/strings/str_format.h"
-#include "absl/strings/strip.h"
 
 namespace orbit_service::utils {
 

--- a/OrbitService/ServiceUtils.cpp
+++ b/OrbitService/ServiceUtils.cpp
@@ -291,18 +291,6 @@ std::optional<TotalCpuTime> GetCumulativeTotalCpuTime() {
   return TotalCpuTime{jiffies, cpus};
 }
 
-ErrorMessageOr<Path> GetExecutablePath(int32_t pid) {
-  char buffer[PATH_MAX];
-
-  ssize_t length = readlink(absl::StrFormat("/proc/%d/exe", pid).c_str(), buffer, sizeof(buffer));
-  if (length == -1) {
-    return ErrorMessage(absl::StrFormat("Unable to get executable path of process with pid %d: %s",
-                                        pid, SafeStrerror(errno)));
-  }
-
-  return Path{std::string(buffer, length)};
-}
-
 ErrorMessageOr<std::string> ReadFileToString(const std::filesystem::path& file_name) {
   std::ifstream file_stream(file_name);
   if (file_stream.fail()) {

--- a/OrbitService/ServiceUtils.h
+++ b/OrbitService/ServiceUtils.h
@@ -43,7 +43,6 @@ struct TotalCpuTime {
 std::optional<TotalCpuTime> GetCumulativeTotalCpuTime();
 std::optional<Jiffies> GetCumulativeCpuTimeFromProcess(pid_t pid);
 
-ErrorMessageOr<Path> GetExecutablePath(int32_t pid);
 ErrorMessageOr<std::string> ReadFileToString(const Path& file_name);
 ErrorMessageOr<Path> FindSymbolsFilePath(const Path& module_path,
                                          const std::vector<Path>& search_directories = {

--- a/OrbitService/ServiceUtilsTest.cpp
+++ b/OrbitService/ServiceUtilsTest.cpp
@@ -6,7 +6,7 @@
 
 #include <deque>
 
-#include "OrbitBase/Logging.h"
+#include "OrbitBase/ExecutablePath.h"
 #include "ServiceUtils.h"
 #include "absl/strings/str_format.h"
 #include "gmock/gmock-matchers.h"
@@ -31,9 +31,7 @@ TEST(ServiceUtils, ParseMaps) {
     EXPECT_TRUE(result.value().empty());
   }
 
-  const auto existing_elf_file_path = GetExecutablePath(getpid());
-  ASSERT_TRUE(existing_elf_file_path) << existing_elf_file_path.error().message();
-  const Path test_path = existing_elf_file_path.value().parent_path() / "testdata";
+  const Path test_path = orbit_base::GetExecutableDir() / "testdata";
   const Path hello_world_path = test_path / "hello_world_elf";
   const Path text_file = test_path / "textfile.txt";
 
@@ -132,12 +130,6 @@ TEST(ServiceUtils, GetCumulativeCpuTimeFromProcess) {
   ASSERT_TRUE(jiffies2->value <= total_cpu_time->jiffies.value);
 }
 
-TEST(ServiceUtils, GetExecutablePath) {
-  const auto result = GetExecutablePath(getpid());
-  ASSERT_TRUE(result) << result.error().message();
-  EXPECT_EQ(result.value().filename(), "OrbitServiceTests");
-}
-
 TEST(ServiceUtils, ReadFileToString) {
   {
     const auto result = ReadFileToString("non/existing/filename");
@@ -145,9 +137,8 @@ TEST(ServiceUtils, ReadFileToString) {
   }
 
   {
-    const auto executable_path = GetExecutablePath(getpid());
-    ASSERT_TRUE(executable_path) << executable_path.error().message();
-    const Path text_file = executable_path.value().parent_path() / "testdata/textfile.txt";
+    const auto executable_path = orbit_base::GetExecutableDir();
+    const Path text_file = executable_path / "testdata" / "textfile.txt";
     const auto result = ReadFileToString(text_file);
     ASSERT_TRUE(result) << result.error().message();
     EXPECT_EQ(result.value(), "content\nnew line");
@@ -155,9 +146,8 @@ TEST(ServiceUtils, ReadFileToString) {
 }
 
 TEST(ServiceUtils, FindSymbolsFilePath) {
-  const auto executable_path = GetExecutablePath(getpid());
-  ASSERT_TRUE(executable_path) << executable_path.error().message();
-  const Path test_path = executable_path.value().parent_path() / "testdata";
+  const auto executable_path = orbit_base::GetExecutableDir();
+  const Path test_path = executable_path / "testdata";
 
   {
     // same file


### PR DESCRIPTION
This implementation is only available for Linux
(because atm we need it on Linux only)

Test: run OrbitBaseTests