### PR TITLE
Add SubmissionTracker to Vulkan Layer.

### DIFF
--- a/OrbitVulkanLayer/CMakeLists.txt
+++ b/OrbitVulkanLayer/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(OrbitVulkanLayer PRIVATE
         DispatchTable.h
         QueueManager.cpp
         QueueManager.h
+        SubmissionTracker.h
         TimerQueryPool.h
         VulkanLayerProducer.h)
 
@@ -33,6 +34,7 @@ target_compile_options(OrbitVulkanLayerTests PRIVATE ${STRICT_COMPILE_FLAGS})
 target_sources(OrbitVulkanLayerTests PRIVATE
         DeviceManagerTest.cpp
         DispatchTableTest.cpp
+        SubmissionTrackerTest.cpp
         TimerQueryPoolTest.cpp
         QueueManagerTest.cpp)
 

--- a/OrbitVulkanLayer/SubmissionTracker.h
+++ b/OrbitVulkanLayer/SubmissionTracker.h
@@ -777,10 +777,6 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
     }
   }
 
-  // We use std::numeric_limits<uint32_t>::max() to disable filtering of markers and 0 to discard
-  // all debug markers.
-  uint32_t max_local_marker_depth_per_command_buffer_ = std::numeric_limits<uint32_t>::max();
-
   absl::Mutex mutex_;
   absl::flat_hash_map<VkCommandPool, absl::flat_hash_set<VkCommandBuffer>> pool_to_command_buffers_;
   absl::flat_hash_map<VkCommandBuffer, VkDevice> command_buffer_to_device_;
@@ -792,6 +788,10 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
   DispatchTable* dispatch_table_;
   TimerQueryPool* timer_query_pool_;
   DeviceManager* device_manager_;
+
+  // We use std::numeric_limits<uint32_t>::max() to disable filtering of markers and 0 to discard
+  // all debug markers.
+  uint32_t max_local_marker_depth_per_command_buffer_ = std::numeric_limits<uint32_t>::max();
 
   [[nodiscard]] bool IsCapturing() {
     return vulkan_layer_producer_ != nullptr && vulkan_layer_producer_->IsCapturing();

--- a/OrbitVulkanLayer/SubmissionTracker.h
+++ b/OrbitVulkanLayer/SubmissionTracker.h
@@ -1,0 +1,757 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_VULKAN_LAYER_COMMAND_BUFFER_MANAGER_H_
+#define ORBIT_VULKAN_LAYER_COMMAND_BUFFER_MANAGER_H_
+
+#include <stack>
+
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/Profiling.h"
+#include "VulkanLayerProducer.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/synchronization/mutex.h"
+#include "vulkan/vulkan.h"
+
+namespace orbit_vulkan_layer {
+
+namespace internal {
+
+// Stores meta information about a submit (VkQueueSubmit), e.g. to allow to identify the matching
+// Gpu tracepoint.
+struct SubmissionMetaInformation {
+  uint64_t pre_submission_cpu_timestamp;
+  uint64_t post_submission_cpu_timestamp;
+  int32_t thread_id;
+};
+
+// A persistent version of a command buffer that was submitted and its begin/end slot in the
+// `TimerQueryPoool`. Note that the begin is optional, as it might not be part of the capture.
+// This struct is created if we capture the submission, so if we would not have captured the end
+// we also not have captured the begin, and don't need to store info about that command buffer at
+// all.
+struct SubmittedCommandBuffer {
+  std::optional<uint32_t> command_buffer_begin_slot_index;
+  uint32_t command_buffer_end_slot_index;
+};
+
+// A persistent version of a debug marker (either begin or end) that was submitted and its slot
+// in the `TimerQueryPool`. Note that we also store the `SubmissionMetaInformation` as begin markers
+// can originate in different submissions then the matching end markers.
+struct SubmittedMarker {
+  SubmissionMetaInformation meta_information;
+  uint32_t slot_index;
+};
+
+// Represents a color to be used to in debug markers. The values are all in range [0.f, 1.f.].
+struct Color {
+  float red;
+  float green;
+  float blue;
+  float alpha;
+};
+
+// Identifies a particular debug marker region. We have a stack of all markers of a queue, that gets
+// updated upon a submission (VkQueueSubmit). If at that time we have a value for the end_info, we
+// use that structure to persist the marker description. So once it is submitted, the
+// end_info will always set.
+// Beside the information about the begin/end, it also stores the text, color and the depth of the
+// marker. If a debug marker begin was limited because of its depth, cut_off is set to true.
+// This allows end markers on a different submission to also through the end marker away.
+// Example: Max Depth = 1
+// Submission 1: Begin("Foo"), Begin("Bar) -- "Bar" will be cut-off
+// Submission 2: End("Bar"), End("Foo") -- We now know, that the first end needs to be cut-off.
+struct MarkerState {
+  std::optional<SubmittedMarker> begin_info;
+  std::optional<SubmittedMarker> end_info;
+  std::string text;
+  Color color;
+  size_t depth;
+  bool cut_off;
+};
+
+// A single submission (VkQueueSubmit) can contain multiple `SubmitInfo
+struct SubmitInfo {
+  std::vector<SubmittedCommandBuffer> command_buffers;
+};
+
+// Wraps up all the data that needs to be persistent upon a submission (VkQueueSubmit).
+// `completed_markers` are all the debug markers, that got completed (via "End") within this
+// submission. Their "Begin" might still be in a different submission.
+struct QueueSubmission {
+  SubmissionMetaInformation meta_information;
+  std::vector<SubmitInfo> submit_infos;
+  std::vector<MarkerState> completed_markers;
+  uint32_t num_begin_markers = 0;
+};
+
+}  // namespace internal
+
+/*
+ * This class ultimately is responsible to track command buffer and debug marker timings.
+ * To do so, it keeps tracks of command-buffer allocations, destruction, begins, ends as well as
+ * submissions.
+ * On `VkBeginCommandBuffer` and `VkEndCommandBuffer` it can (if capturing) insert write timestamp
+ * commands (`VkCmdWriteTimestamp`). The same is done for debug marker begins and ends. All that
+ * data will be gathered together at a queue submission (`VkQueueSubmit`).
+ *
+ * Upon every `VkQueuePresentKHR` it will check if the timestamps of a certain submission are
+ * already available, and if so, it will send the results over to the `VulkanLayerProducer`.
+ *
+ * See also `DispatchTable` (for vulkan dispatch), `TimerQueryPool` (to manage the timestamp slots),
+ * and `DeviceManager` (to retrieve device properties).
+ *
+ * Thread-Safety: This class is internally synchronized (using read/write locks), and can be
+ * safely accessed from different threads.
+ */
+template <class DispatchTable, class DeviceManager, class TimerQueryPool>
+class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
+ public:
+  explicit SubmissionTracker(uint32_t max_local_marker_depth_per_command_buffer,
+                             DispatchTable* dispatch_table, TimerQueryPool* timer_query_pool,
+                             DeviceManager* device_manager)
+      : max_local_marker_depth_per_command_buffer_(max_local_marker_depth_per_command_buffer),
+        dispatch_table_(dispatch_table),
+        timer_query_pool_(timer_query_pool),
+        device_manager_(device_manager) {
+    CHECK(dispatch_table_ != nullptr);
+    CHECK(timer_query_pool_ != nullptr);
+    CHECK(device_manager_ != nullptr);
+  }
+
+  // Sets a producer to be used to enqueue capture events and ask if we are capturing.
+  // We will also register our self as CaptureStatusListener, in order to get nofified on
+  // capture finish (OnCaptureFinished). Will reset the open query slots then.
+  void SetVulkanLayerProducer(VulkanLayerProducer* vulkan_layer_producer) {
+    vulkan_layer_producer_ = vulkan_layer_producer;
+    if (vulkan_layer_producer_ != nullptr) {
+      vulkan_layer_producer_->SetCaptureStatusListener(this);
+    }
+  }
+
+  // Sets the maximal depth of debug markers within one command buffer. If set to 0, command buffers
+  // won't be limited by depth.
+  void SetMaxLocalMarkerDepthPerCommandBuffer(uint32_t max_local_marker_depth_per_command_buffer) {
+    max_local_marker_depth_per_command_buffer_ = max_local_marker_depth_per_command_buffer;
+  }
+
+  void TrackCommandBuffers(VkDevice device, VkCommandPool pool,
+                           const VkCommandBuffer* command_buffers, uint32_t count) {
+    absl::WriterMutexLock lock(&mutex_);
+    if (!pool_to_command_buffers_.contains(pool)) {
+      pool_to_command_buffers_[pool] = {};
+    }
+    absl::flat_hash_set<VkCommandBuffer>& associated_cbs = pool_to_command_buffers_.at(pool);
+    for (uint32_t i = 0; i < count; ++i) {
+      VkCommandBuffer cb = command_buffers[i];
+      associated_cbs.insert(cb);
+      command_buffer_to_device_[cb] = device;
+    }
+  }
+
+  void UntrackCommandBuffers(VkDevice device, VkCommandPool pool,
+                             const VkCommandBuffer* command_buffers, uint32_t count) {
+    absl::WriterMutexLock lock(&mutex_);
+    CHECK(pool_to_command_buffers_.contains(pool));
+    absl::flat_hash_set<VkCommandBuffer>& associated_command_buffers =
+        pool_to_command_buffers_.at(pool);
+    for (uint32_t i = 0; i < count; ++i) {
+      VkCommandBuffer command_buffer = command_buffers[i];
+      associated_command_buffers.erase(command_buffer);
+      CHECK(command_buffer_to_device_.contains(command_buffer));
+      CHECK(command_buffer_to_device_.at(command_buffer) == device);
+      command_buffer_to_device_.erase(command_buffer);
+    }
+    if (associated_command_buffers.empty()) {
+      pool_to_command_buffers_.erase(pool);
+    }
+  }
+
+  void MarkCommandBufferBegin(VkCommandBuffer command_buffer) {
+    // Even when we are not capturing we create state for this command buffer to allow the
+    // debug marker tracking.
+    {
+      absl::WriterMutexLock lock(&mutex_);
+      CHECK(!command_buffer_to_state_.contains(command_buffer));
+      command_buffer_to_state_[command_buffer] = {};
+    }
+    if (!IsCapturing()) {
+      return;
+    }
+
+    uint32_t slot_index = RecordTimestamp(command_buffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
+    {
+      absl::WriterMutexLock lock(&mutex_);
+      CHECK(command_buffer_to_state_.contains(command_buffer));
+      command_buffer_to_state_.at(command_buffer).command_buffer_begin_slot_index =
+          std::make_optional(slot_index);
+    }
+  }
+
+  void MarkCommandBufferEnd(VkCommandBuffer command_buffer) {
+    if (!IsCapturing()) {
+      return;
+    }
+
+    uint32_t slot_index = RecordTimestamp(command_buffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
+
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(command_buffer_to_state_.contains(command_buffer));
+      CommandBufferState& command_buffer_state = command_buffer_to_state_.at(command_buffer);
+      // Writing to this field is safe, as there can't be any operation on this command buffer
+      // in parallel.
+      command_buffer_state.command_buffer_end_slot_index = std::make_optional(slot_index);
+    }
+  }
+
+  void MarkDebugMarkerBegin(VkCommandBuffer command_buffer, const char* text,
+                            internal::Color color) {
+    CHECK(text != nullptr);
+    bool too_many_markers;
+    {
+      absl::WriterMutexLock lock(&mutex_);
+      CHECK(command_buffer_to_state_.contains(command_buffer));
+      CommandBufferState& state = command_buffer_to_state_.at(command_buffer);
+      ++state.local_marker_stack_size;
+      too_many_markers = max_local_marker_depth_per_command_buffer_ > 0 &&
+                         state.local_marker_stack_size > max_local_marker_depth_per_command_buffer_;
+      Marker marker{.type = MarkerType::kDebugMarkerBegin,
+                    .text = std::string(text),
+                    .color = color,
+                    .cut_off = too_many_markers};
+      state.markers.emplace_back(std::move(marker));
+    }
+
+    if (!IsCapturing() || too_many_markers) {
+      return;
+    }
+
+    uint32_t slot_index = RecordTimestamp(command_buffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
+
+    {
+      absl::WriterMutexLock lock(&mutex_);
+      CHECK(command_buffer_to_state_.contains(command_buffer));
+      CommandBufferState& state = command_buffer_to_state_.at(command_buffer);
+      state.markers.back().slot_index = std::make_optional(slot_index);
+    }
+  }
+
+  void MarkDebugMarkerEnd(VkCommandBuffer command_buffer) {
+    bool too_many_markers;
+    {
+      absl::WriterMutexLock lock(&mutex_);
+      CHECK(command_buffer_to_state_.contains(command_buffer));
+      CommandBufferState& state = command_buffer_to_state_.at(command_buffer);
+      too_many_markers = max_local_marker_depth_per_command_buffer_ > 0 &&
+                         state.local_marker_stack_size > max_local_marker_depth_per_command_buffer_;
+      Marker marker{.type = MarkerType::kDebugMarkerEnd, .cut_off = too_many_markers};
+      state.markers.emplace_back(std::move(marker));
+      // We might see more "ends" then "begins", as the "begins" can be on a different command
+      // buffer
+      if (state.local_marker_stack_size != 0) {
+        --state.local_marker_stack_size;
+      }
+    }
+
+    if (!IsCapturing() || too_many_markers) {
+      return;
+    }
+
+    uint32_t slot_index = RecordTimestamp(command_buffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
+    {
+      absl::WriterMutexLock lock(&mutex_);
+      CHECK(command_buffer_to_state_.contains(command_buffer));
+      CommandBufferState& state = command_buffer_to_state_.at(command_buffer);
+      state.markers.back().slot_index = std::make_optional(slot_index);
+    }
+  }
+
+  // After command buffers are submitted into a queue, they can be reused for further operations.
+  // Thus, our identification via the pointers become invalid. We will use the vkQueueSubmit
+  // to make our data persistent until we have processed the results of the execution of these
+  // command buffers (which will be done in the vkQueuePresentKHR).
+  // If we are not capturing, that method will do nothing and return `nullopt`.
+  // Otherwise, it will create and return an internal::QueueSubmission object, holding the
+  // information about all command buffers recorded in this submission.
+  // It also takes a timestamp before the execution of the driver code for the submission.
+  // This allows us to map submissions from the Vulkan layer to the driver submissions.
+  [[nodiscard]] std::optional<internal::QueueSubmission> PersistCommandBuffersOnSubmit(
+      uint32_t submit_count, const VkSubmitInfo* submits) {
+    if (!IsCapturing()) {
+      // `PersistDebugMarkersOnSubmit` and `OnCaptureFinished` will take care of clean up and
+      // slot resetting.
+      return std::nullopt;
+    }
+
+    internal::QueueSubmission queue_submission;
+    queue_submission.meta_information.pre_submission_cpu_timestamp = MonotonicTimestampNs();
+    queue_submission.meta_information.thread_id = GetCurrentThreadId();
+
+    for (uint32_t submit_index = 0; submit_index < submit_count; ++submit_index) {
+      VkSubmitInfo submit_info = submits[submit_index];
+      queue_submission.submit_infos.emplace_back();
+      internal::SubmitInfo& submitted_submit_info = queue_submission.submit_infos.back();
+      for (uint32_t command_buffer_index = 0; command_buffer_index < submit_info.commandBufferCount;
+           ++command_buffer_index) {
+        VkCommandBuffer command_buffer = submit_info.pCommandBuffers[command_buffer_index];
+        CHECK(command_buffer_to_state_.contains(command_buffer));
+        CommandBufferState& state = command_buffer_to_state_.at(command_buffer);
+
+        // If we neither recorded the end nor the begin of a command buffer, we have no information
+        // to send.
+        if (!state.command_buffer_end_slot_index.has_value()) {
+          CHECK(!state.command_buffer_end_slot_index.has_value());
+          continue;
+        }
+
+        internal::SubmittedCommandBuffer submitted_command_buffer{
+            .command_buffer_begin_slot_index = state.command_buffer_begin_slot_index,
+            .command_buffer_end_slot_index = state.command_buffer_end_slot_index.value()};
+        submitted_submit_info.command_buffers.emplace_back(submitted_command_buffer);
+
+        // Remove the slots from the state now, such that `OnCaptureFinished` wont reset the slots
+        // twice. Note, that they will be reset in `CompleteSubmits`.
+        state.command_buffer_begin_slot_index.reset();
+        state.command_buffer_end_slot_index.reset();
+      }
+    }
+
+    return queue_submission;
+  }
+
+  // We assume to be capturing if `queue_submission_optional` has content, i.e. we were capturing
+  // on this VkQueueSubmit before calling into the driver.
+  // It also takes a timestamp after the execution of the driver code for the submission.
+  // This allows us to map submissions from the Vulkan layer to the driver submissions.
+  void PersistDebugMarkersOnSubmit(
+      VkQueue queue, uint32_t submit_count, const VkSubmitInfo* submits,
+      std::optional<internal::QueueSubmission> queue_submission_optional) {
+    absl::WriterMutexLock lock(&mutex_);
+    if (!queue_to_markers_.contains(queue)) {
+      queue_to_markers_[queue] = {};
+    }
+    CHECK(queue_to_markers_.contains(queue));
+    QueueMarkerState& markers = queue_to_markers_.at(queue);
+
+    // If we consider this to still capturing, take a cpu timestamp as "post submission" such that
+    // the submission "meta information" is complete. We can then attach that also to each debug
+    // marker, as they may be spanned across different submissions.
+    if (queue_submission_optional.has_value()) {
+      queue_submission_optional->meta_information.post_submission_cpu_timestamp =
+          MonotonicTimestampNs();
+    }
+
+    std::vector<uint32_t> marker_slots_to_reset;
+    VkDevice device = VK_NULL_HANDLE;
+    for (uint32_t submit_index = 0; submit_index < submit_count; ++submit_index) {
+      VkSubmitInfo submit_info = submits[submit_index];
+      for (uint32_t command_buffer_index = 0; command_buffer_index < submit_info.commandBufferCount;
+           ++command_buffer_index) {
+        VkCommandBuffer command_buffer = submit_info.pCommandBuffers[command_buffer_index];
+        if (device == VK_NULL_HANDLE) {
+          CHECK(command_buffer_to_device_.contains(command_buffer));
+          device = command_buffer_to_device_.at(command_buffer);
+        }
+        CHECK(command_buffer_to_state_.contains(command_buffer));
+        CommandBufferState& state = command_buffer_to_state_.at(command_buffer);
+
+        for (const Marker& marker : state.markers) {
+          std::optional<internal::SubmittedMarker> submitted_marker = std::nullopt;
+          if (marker.slot_index.has_value() && queue_submission_optional.has_value()) {
+            submitted_marker = {.meta_information = queue_submission_optional->meta_information,
+                                .slot_index = marker.slot_index.value()};
+          }
+
+          switch (marker.type) {
+            case MarkerType::kDebugMarkerBegin: {
+              if (queue_submission_optional.has_value() && marker.slot_index.has_value()) {
+                ++queue_submission_optional->num_begin_markers;
+              }
+              CHECK(marker.text.has_value());
+              CHECK(marker.color.has_value());
+              internal::MarkerState marker_state{.text = marker.text.value(),
+                                                 .color = marker.color.value(),
+                                                 .begin_info = submitted_marker,
+                                                 .depth = markers.marker_stack.size(),
+                                                 .cut_off = marker.cut_off};
+              markers.marker_stack.push(std::move(marker_state));
+              break;
+            }
+
+            case MarkerType::kDebugMarkerEnd: {
+              internal::MarkerState marker_state = markers.marker_stack.top();
+              markers.marker_stack.pop();
+
+              // If there is a begin marker slot from a previous submission, this is our chance to
+              // reset the slot.
+              if (marker_state.begin_info.has_value() && !queue_submission_optional.has_value()) {
+                marker_slots_to_reset.push_back(marker_state.begin_info.value().slot_index);
+              }
+
+              // If the begin marker was cut off, but the end marker was not (as it is in a
+              // different submission), we reset the slot
+              if (marker_state.cut_off && marker.slot_index.has_value()) {
+                marker_slots_to_reset.push_back(marker.slot_index.value());
+              }
+
+              if (queue_submission_optional.has_value() && marker.slot_index.has_value() &&
+                  !marker_state.cut_off) {
+                marker_state.end_info = submitted_marker;
+                queue_submission_optional->completed_markers.emplace_back(std::move(marker_state));
+              }
+
+              break;
+            }
+          }
+        }
+        command_buffer_to_state_.erase(command_buffer);
+      }
+    }
+
+    if (!marker_slots_to_reset.empty()) {
+      timer_query_pool_->ResetQuerySlots(device, marker_slots_to_reset);
+    }
+
+    if (!queue_submission_optional.has_value()) {
+      return;
+    }
+
+    if (!queue_to_submissions_.contains(queue)) {
+      queue_to_submissions_[queue] = {};
+    }
+    CHECK(queue_to_submissions_.contains(queue));
+    queue_to_submissions_.at(queue).emplace_back(std::move(queue_submission_optional.value()));
+  }
+
+  void CompleteSubmits(VkDevice device) {
+    VkQueryPool query_pool = timer_query_pool_->GetQueryPool(device);
+    std::vector<internal::QueueSubmission> completed_submissions =
+        PullCompletedSubmissions(device, query_pool);
+
+    if (completed_submissions.empty()) {
+      return;
+    }
+
+    VkPhysicalDevice physical_device = device_manager_->GetPhysicalDeviceOfLogicalDevice(device);
+    const float timestamp_period =
+        device_manager_->GetPhysicalDeviceProperties(physical_device).limits.timestampPeriod;
+
+    std::vector<uint32_t> query_slots_to_reset = {};
+    for (const auto& completed_submission : completed_submissions) {
+      orbit_grpc_protos::CaptureEvent capture_event;
+      orbit_grpc_protos::GpuQueueSubmission* submission_proto =
+          capture_event.mutable_gpu_queue_submission();
+      WriteMetaInfo(completed_submission.meta_information, submission_proto->mutable_meta_info());
+
+      WriteCommandBufferTimings(completed_submission, submission_proto, query_slots_to_reset,
+                                device, query_pool, timestamp_period);
+
+      WriteDebugMarkers(completed_submission, submission_proto, query_slots_to_reset, device,
+                        query_pool, timestamp_period);
+
+      if (vulkan_layer_producer_ != nullptr) {
+        vulkan_layer_producer_->EnqueueCaptureEvent(std::move(capture_event));
+      }
+    }
+
+    timer_query_pool_->ResetQuerySlots(device, query_slots_to_reset);
+  }
+
+  void ResetCommandBuffer(VkCommandBuffer command_buffer) {
+    absl::WriterMutexLock lock(&mutex_);
+    if (!command_buffer_to_state_.contains(command_buffer)) {
+      return;
+    }
+    CHECK(command_buffer_to_state_.contains(command_buffer));
+    CommandBufferState& state = command_buffer_to_state_.at(command_buffer);
+    CHECK(command_buffer_to_device_.contains(command_buffer));
+    VkDevice device = command_buffer_to_device_.at(command_buffer);
+    std::vector<uint32_t> marker_slots_to_rollback = {};
+    if (state.command_buffer_begin_slot_index.has_value()) {
+      marker_slots_to_rollback.push_back(state.command_buffer_begin_slot_index.value());
+    }
+    if (state.command_buffer_end_slot_index.has_value()) {
+      marker_slots_to_rollback.push_back(state.command_buffer_end_slot_index.value());
+    }
+    for (const Marker& marker : state.markers) {
+      if (marker.slot_index.has_value()) {
+        marker_slots_to_rollback.push_back(marker.slot_index.value());
+      }
+    }
+    timer_query_pool_->RollbackPendingQuerySlots(device, marker_slots_to_rollback);
+
+    command_buffer_to_state_.erase(command_buffer);
+  }
+
+  void ResetCommandPool(VkCommandPool command_pool) {
+    absl::flat_hash_set<VkCommandBuffer> command_buffers;
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      if (!pool_to_command_buffers_.contains(command_pool)) {
+        return;
+      }
+      CHECK(pool_to_command_buffers_.contains(command_pool));
+      command_buffers = pool_to_command_buffers_.at(command_pool);
+    }
+    for (const auto& command_buffer : command_buffers) {
+      ResetCommandBuffer(command_buffer);
+    }
+  }
+
+  void OnCaptureStart() override {}
+
+  void OnCaptureStop() override {}
+
+  void OnCaptureFinished() override {
+    absl::WriterMutexLock lock(&mutex_);
+    std::vector<uint32_t> slots_to_reset;
+
+    VkDevice device = VK_NULL_HANDLE;
+
+    for (auto& [command_buffer, command_buffer_state] : command_buffer_to_state_) {
+      if (device == VK_NULL_HANDLE) {
+        CHECK(command_buffer_to_device_.contains(command_buffer));
+        device = command_buffer_to_device_.at(command_buffer);
+      }
+      if (command_buffer_state.command_buffer_begin_slot_index.has_value()) {
+        slots_to_reset.push_back(command_buffer_state.command_buffer_begin_slot_index.value());
+        command_buffer_state.command_buffer_begin_slot_index.reset();
+      }
+
+      if (command_buffer_state.command_buffer_end_slot_index.has_value()) {
+        slots_to_reset.push_back(command_buffer_state.command_buffer_end_slot_index.value());
+        command_buffer_state.command_buffer_end_slot_index.reset();
+      }
+
+      for (Marker& marker : command_buffer_state.markers) {
+        if (marker.slot_index.has_value()) {
+          slots_to_reset.push_back(marker.slot_index.value());
+          marker.slot_index.reset();
+        }
+      }
+    }
+    if (!slots_to_reset.empty()) {
+      timer_query_pool_->ResetQuerySlots(device, slots_to_reset);
+    }
+  }
+
+ private:
+  enum class MarkerType { kDebugMarkerBegin = 0, kDebugMarkerEnd };
+
+  struct Marker {
+    MarkerType type;
+    std::optional<uint32_t> slot_index;
+    std::optional<std::string> text;
+    std::optional<internal::Color> color;
+    bool cut_off;
+  };
+
+  struct QueueMarkerState {
+    std::stack<internal::MarkerState> marker_stack;
+  };
+
+  struct CommandBufferState {
+    std::optional<uint32_t> command_buffer_begin_slot_index;
+    std::optional<uint32_t> command_buffer_end_slot_index;
+    std::vector<Marker> markers;
+    uint32_t local_marker_stack_size;
+  };
+
+  uint32_t RecordTimestamp(VkCommandBuffer command_buffer,
+                           VkPipelineStageFlagBits pipeline_stage_flags) {
+    VkDevice device;
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(command_buffer_to_device_.contains(command_buffer));
+      device = command_buffer_to_device_.at(command_buffer);
+    }
+
+    VkQueryPool query_pool = timer_query_pool_->GetQueryPool(device);
+
+    uint32_t slot_index;
+    bool found_slot = timer_query_pool_->NextReadyQuerySlot(device, &slot_index);
+    CHECK(found_slot);
+    dispatch_table_->CmdWriteTimestamp(command_buffer)(command_buffer, pipeline_stage_flags,
+                                                       query_pool, slot_index);
+
+    return slot_index;
+  }
+
+  std::vector<internal::QueueSubmission> PullCompletedSubmissions(VkDevice device,
+                                                                  VkQueryPool query_pool) {
+    std::vector<internal::QueueSubmission> completed_submissions = {};
+
+    absl::WriterMutexLock lock(&mutex_);
+    for (auto& [unused_queue, queue_submissions] : queue_to_submissions_) {
+      auto submission_it = queue_submissions.begin();
+      while (submission_it != queue_submissions.end()) {
+        const internal::QueueSubmission& submission = *submission_it;
+        if (submission.submit_infos.empty()) {
+          submission_it = queue_submissions.erase(submission_it);
+          continue;
+        }
+
+        bool erase_submission = true;
+        // Let's find the last command buffer in this submission, so first find the last
+        // submit info that has at least one command buffer.
+        // We test if for this command buffer, we already have a query result for its last slot
+        // and if so (or if the submission does not contain any command buffer) erase this
+        // submission.
+        auto submit_info_reverse_it = submission.submit_infos.rbegin();
+        while (submit_info_reverse_it != submission.submit_infos.rend()) {
+          const internal::SubmitInfo& submit_info = submission.submit_infos.back();
+          if (submit_info.command_buffers.empty()) {
+            ++submit_info_reverse_it;
+            continue;
+          }
+          // We found our last command buffer, so lets check if its result is there:
+          const internal::SubmittedCommandBuffer& last_command_buffer =
+              submit_info.command_buffers.back();
+          uint32_t check_slot_index_end = last_command_buffer.command_buffer_end_slot_index;
+
+          static constexpr VkDeviceSize kResultStride = sizeof(uint64_t);
+          uint64_t test_query_result = 0;
+          VkResult query_worked = dispatch_table_->GetQueryPoolResults(device)(
+              device, query_pool, check_slot_index_end, 1, sizeof(test_query_result),
+              &test_query_result, kResultStride, VK_QUERY_RESULT_64_BIT);
+
+          // Only erase the submission if we query its timers now.
+          if (query_worked == VK_SUCCESS) {
+            erase_submission = true;
+            completed_submissions.push_back(submission);
+          } else {
+            erase_submission = false;
+          }
+          break;
+        }
+
+        if (erase_submission) {
+          submission_it = queue_submissions.erase(submission_it);
+        } else {
+          ++submission_it;
+        }
+      }
+    }
+
+    return completed_submissions;
+  }
+
+  uint64_t QueryGpuTimestampNs(VkDevice device, VkQueryPool query_pool, uint32_t slot_index,
+                               float timestamp_period) {
+    static constexpr VkDeviceSize kResultStride = sizeof(uint64_t);
+
+    uint64_t timestamp = 0;
+    VkResult result_status = dispatch_table_->GetQueryPoolResults(device)(
+        device, query_pool, slot_index, 1, sizeof(timestamp), &timestamp, kResultStride,
+        VK_QUERY_RESULT_64_BIT);
+    CHECK(result_status == VK_SUCCESS);
+
+    return static_cast<uint64_t>(static_cast<double>(timestamp) * timestamp_period);
+  }
+
+  static void WriteMetaInfo(const internal::SubmissionMetaInformation& meta_info,
+                            orbit_grpc_protos::GpuQueueSubmissionMetaInfo* target_proto) {
+    target_proto->set_tid(meta_info.thread_id);
+    target_proto->set_pre_submission_cpu_timestamp(meta_info.pre_submission_cpu_timestamp);
+    target_proto->set_post_submission_cpu_timestamp(meta_info.post_submission_cpu_timestamp);
+  }
+
+  void WriteCommandBufferTimings(const internal::QueueSubmission& completed_submission,
+                                 orbit_grpc_protos::GpuQueueSubmission* submission_proto,
+                                 std::vector<uint32_t>& query_slots_to_reset, VkDevice device,
+                                 VkQueryPool query_pool, float timestamp_period) {
+    for (const auto& completed_submit : completed_submission.submit_infos) {
+      orbit_grpc_protos::GpuSubmitInfo* submit_info_proto = submission_proto->add_submit_infos();
+      for (const auto& completed_command_buffer : completed_submit.command_buffers) {
+        orbit_grpc_protos::GpuCommandBuffer* command_buffer_proto =
+            submit_info_proto->add_command_buffers();
+
+        if (completed_command_buffer.command_buffer_begin_slot_index.has_value()) {
+          uint32_t slot_index = completed_command_buffer.command_buffer_begin_slot_index.value();
+          uint64_t begin_timestamp =
+              QueryGpuTimestampNs(device, query_pool, slot_index, timestamp_period);
+          command_buffer_proto->set_begin_gpu_timestamp_ns(begin_timestamp);
+
+          query_slots_to_reset.push_back(slot_index);
+        }
+
+        uint32_t slot_index = completed_command_buffer.command_buffer_end_slot_index;
+        uint64_t end_timestamp =
+            QueryGpuTimestampNs(device, query_pool, slot_index, timestamp_period);
+
+        command_buffer_proto->set_end_gpu_timestamp_ns(end_timestamp);
+        query_slots_to_reset.push_back(slot_index);
+      }
+    }
+  }
+
+  void WriteDebugMarkers(const internal::QueueSubmission& completed_submission,
+                         orbit_grpc_protos::GpuQueueSubmission* submission_proto,
+                         std::vector<uint32_t>& query_slots_to_reset, VkDevice device,
+                         VkQueryPool query_pool, const float timestamp_period) {
+    submission_proto->set_num_begin_markers(completed_submission.num_begin_markers);
+    for (const auto& marker_state : completed_submission.completed_markers) {
+      uint64_t end_timestamp = QueryGpuTimestampNs(
+          device, query_pool, marker_state.end_info->slot_index, timestamp_period);
+      query_slots_to_reset.push_back(marker_state.end_info->slot_index);
+
+      orbit_grpc_protos::GpuDebugMarker* marker_proto = submission_proto->add_completed_markers();
+      if (vulkan_layer_producer_ != nullptr) {
+        marker_proto->set_text_key(
+            vulkan_layer_producer_->InternStringIfNecessaryAndGetKey(marker_state.text));
+      }
+      if (marker_state.color.red != 0.0f || marker_state.color.green != 0.0f ||
+          marker_state.color.blue != 0.0f || marker_state.color.alpha != 0.0f) {
+        auto color = marker_proto->mutable_color();
+        color->set_red(marker_state.color.red);
+        color->set_green(marker_state.color.green);
+        color->set_blue(marker_state.color.blue);
+        color->set_alpha(marker_state.color.alpha);
+      }
+      marker_proto->set_depth(marker_state.depth);
+      marker_proto->set_end_gpu_timestamp_ns(end_timestamp);
+
+      // If we haven't captured the begin marker, we'll leave the optional begin_marker empty.
+      if (!marker_state.begin_info.has_value()) {
+        continue;
+      }
+      orbit_grpc_protos::GpuDebugMarkerBeginInfo* begin_debug_marker_proto =
+          marker_proto->mutable_begin_marker();
+      WriteMetaInfo(marker_state.begin_info->meta_information,
+                    begin_debug_marker_proto->mutable_meta_info());
+
+      uint64_t begin_timestamp = QueryGpuTimestampNs(
+          device, query_pool, marker_state.begin_info->slot_index, timestamp_period);
+      query_slots_to_reset.push_back(marker_state.begin_info->slot_index);
+
+      begin_debug_marker_proto->set_gpu_timestamp_ns(begin_timestamp);
+    }
+  }
+
+  // We use 0 to disable filtering of markers.
+  uint32_t max_local_marker_depth_per_command_buffer_ = 0;
+
+  absl::Mutex mutex_;
+  absl::flat_hash_map<VkCommandPool, absl::flat_hash_set<VkCommandBuffer>> pool_to_command_buffers_;
+  absl::flat_hash_map<VkCommandBuffer, VkDevice> command_buffer_to_device_;
+
+  absl::flat_hash_map<VkCommandBuffer, CommandBufferState> command_buffer_to_state_;
+  absl::flat_hash_map<VkQueue, std::vector<internal::QueueSubmission>> queue_to_submissions_;
+  absl::flat_hash_map<VkQueue, QueueMarkerState> queue_to_markers_;
+
+  DispatchTable* dispatch_table_;
+  TimerQueryPool* timer_query_pool_;
+  DeviceManager* device_manager_;
+
+  [[nodiscard]] bool IsCapturing() {
+    return vulkan_layer_producer_ != nullptr && vulkan_layer_producer_->IsCapturing();
+  }
+  VulkanLayerProducer* vulkan_layer_producer_;
+};
+
+}  // namespace orbit_vulkan_layer
+
+#endif  // ORBIT_VULKAN_LAYER_COMMAND_BUFFER_MANAGER_H_

--- a/OrbitVulkanLayer/SubmissionTrackerTest.cpp
+++ b/OrbitVulkanLayer/SubmissionTrackerTest.cpp
@@ -1,0 +1,1410 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "SubmissionTracker.h"
+#include "VulkanLayerProducer.h"
+#include "absl/base/casts.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using ::testing::ElementsAre;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::SaveArg;
+using ::testing::UnorderedElementsAre;
+
+namespace orbit_vulkan_layer {
+namespace {
+class MockDispatchTable {
+ public:
+  MOCK_METHOD(PFN_vkGetQueryPoolResults, GetQueryPoolResults, (VkDevice), ());
+  MOCK_METHOD(PFN_vkCmdWriteTimestamp, CmdWriteTimestamp, (VkCommandBuffer), ());
+};
+
+PFN_vkCmdWriteTimestamp dummy_write_timestamp_function =
+    +[](VkCommandBuffer /*command_buffer*/, VkPipelineStageFlagBits /*pipeline_stage*/,
+        VkQueryPool /*query_pool*/, uint32_t /*query*/) {};
+
+class MockTimerQueryPool {
+ public:
+  MOCK_METHOD(VkQueryPool, GetQueryPool, (VkDevice), ());
+  MOCK_METHOD(void, ResetQuerySlots, (VkDevice, const std::vector<uint32_t>&), ());
+  MOCK_METHOD(void, RollbackPendingQuerySlots, (VkDevice, const std::vector<uint32_t>&), ());
+  MOCK_METHOD(bool, NextReadyQuerySlot, (VkDevice, uint32_t*), ());
+};
+
+class MockDeviceManager {
+ public:
+  MOCK_METHOD(VkPhysicalDevice, GetPhysicalDeviceOfLogicalDevice, (VkDevice), ());
+  MOCK_METHOD(VkPhysicalDeviceProperties, GetPhysicalDeviceProperties, (VkPhysicalDevice), ());
+};
+
+class MockVulkanLayerProducer : public VulkanLayerProducer {
+ public:
+  MOCK_METHOD(bool, IsCapturing, (), (override));
+  MOCK_METHOD(uint64_t, InternStringIfNecessaryAndGetKey, (std::string), (override));
+  MOCK_METHOD(bool, EnqueueCaptureEvent, (orbit_grpc_protos::CaptureEvent && capture_event),
+              (override));
+
+  MOCK_METHOD(void, BringUp, (const std::shared_ptr<grpc::Channel>& channel), (override));
+  MOCK_METHOD(void, TakeDown, (), (override));
+
+  MOCK_METHOD(void, SetCaptureStatusListener, (CaptureStatusListener*), (override));
+
+  void StartCapture() {
+    is_capturing = true;
+    ASSERT_NE(listener_, nullptr);
+    listener_->OnCaptureStart();
+  }
+
+  void StopCapture() {
+    is_capturing = false;
+    ASSERT_NE(listener_, nullptr);
+    listener_->OnCaptureStop();
+    listener_->OnCaptureFinished();
+  }
+
+  void FakeSetCaptureStatusListener(VulkanLayerProducer::CaptureStatusListener* listener) {
+    listener_ = listener;
+  }
+
+  bool is_capturing = false;
+
+ private:
+  VulkanLayerProducer::CaptureStatusListener* listener_;
+};
+
+}  // namespace
+
+class SubmissionTrackerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    producer = std::make_unique<MockVulkanLayerProducer>();
+    auto set_capture_status_listener_function =
+        [this](VulkanLayerProducer::CaptureStatusListener* listener) {
+          producer->FakeSetCaptureStatusListener(listener);
+        };
+    EXPECT_CALL(*producer, SetCaptureStatusListener)
+        .Times(1)
+        .WillOnce(Invoke(set_capture_status_listener_function));
+    tracker.SetVulkanLayerProducer(producer.get());
+    auto is_capturing_function = [this]() -> bool { return producer->is_capturing; };
+    EXPECT_CALL(*producer, IsCapturing).WillRepeatedly(Invoke(is_capturing_function));
+    EXPECT_CALL(timer_query_pool, GetQueryPool).WillRepeatedly(Return(query_pool));
+    EXPECT_CALL(device_manager, GetPhysicalDeviceOfLogicalDevice)
+        .WillRepeatedly(Return(physical_device));
+    EXPECT_CALL(device_manager, GetPhysicalDeviceProperties)
+        .WillRepeatedly(Return(physical_device_properties));
+
+    EXPECT_CALL(dispatch_table, CmdWriteTimestamp)
+        .WillRepeatedly(Return(dummy_write_timestamp_function));
+  }
+
+  MockDispatchTable dispatch_table;
+  MockTimerQueryPool timer_query_pool;
+  MockDeviceManager device_manager;
+  std::unique_ptr<MockVulkanLayerProducer> producer;
+  SubmissionTracker<MockDispatchTable, MockDeviceManager, MockTimerQueryPool> tracker =
+      SubmissionTracker<MockDispatchTable, MockDeviceManager, MockTimerQueryPool>(
+          0, &dispatch_table, &timer_query_pool, &device_manager);
+
+  VkDevice device = {};
+  VkCommandPool command_pool = {};
+  VkCommandBuffer command_buffer = {};
+  VkQueryPool query_pool = {};
+  VkPhysicalDevice physical_device = {};
+  VkPhysicalDeviceProperties physical_device_properties = {.limits = {.timestampPeriod = 1.f}};
+  VkQueue queue = {};
+  VkSubmitInfo submit_info = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+                              .pNext = nullptr,
+                              .pCommandBuffers = &command_buffer,
+                              .commandBufferCount = 1};
+
+  static constexpr uint32_t kSlotIndex1 = 32;
+  static constexpr uint32_t kSlotIndex2 = 33;
+  static constexpr uint32_t kSlotIndex3 = 34;
+  static constexpr uint32_t kSlotIndex4 = 35;
+  static constexpr uint32_t kSlotIndex5 = 36;
+  static constexpr uint32_t kSlotIndex6 = 37;
+  static constexpr uint32_t kSlotIndex7 = 38;
+
+  const std::function<bool(VkDevice, uint32_t*)> mock_next_ready_query_slot_function_1 =
+      [](VkDevice /*device*/, uint32_t* allocated_slot) -> bool {
+    *allocated_slot = kSlotIndex1;
+    return true;
+  };
+
+  const std::function<bool(VkDevice, uint32_t*)> mock_next_ready_query_slot_function_2 =
+      [](VkDevice /*device*/, uint32_t* allocated_slot) -> bool {
+    *allocated_slot = kSlotIndex2;
+    return true;
+  };
+
+  const std::function<bool(VkDevice, uint32_t*)> mock_next_ready_query_slot_function_3 =
+      [](VkDevice /*device*/, uint32_t* allocated_slot) -> bool {
+    *allocated_slot = kSlotIndex3;
+    return true;
+  };
+
+  const std::function<bool(VkDevice, uint32_t*)> mock_next_ready_query_slot_function_4 =
+      [](VkDevice /*device*/, uint32_t* allocated_slot) -> bool {
+    *allocated_slot = kSlotIndex4;
+    return true;
+  };
+
+  const std::function<bool(VkDevice, uint32_t*)> mock_next_ready_query_slot_function_5 =
+      [](VkDevice /*device*/, uint32_t* allocated_slot) -> bool {
+    *allocated_slot = kSlotIndex5;
+    return true;
+  };
+
+  const std::function<bool(VkDevice, uint32_t*)> mock_next_ready_query_slot_function_6 =
+      [](VkDevice /*device*/, uint32_t* allocated_slot) -> bool {
+    *allocated_slot = kSlotIndex6;
+    return true;
+  };
+
+  const std::function<bool(VkDevice, uint32_t*)> mock_next_ready_query_slot_function_7 =
+      [](VkDevice /*device*/, uint32_t* allocated_slot) -> bool {
+    *allocated_slot = kSlotIndex7;
+    return true;
+  };
+
+  static constexpr uint64_t kTimestamp1 = 11;
+  static constexpr uint64_t kTimestamp2 = 12;
+  static constexpr uint64_t kTimestamp3 = 13;
+  static constexpr uint64_t kTimestamp4 = 14;
+  static constexpr uint64_t kTimestamp5 = 15;
+  static constexpr uint64_t kTimestamp6 = 16;
+  static constexpr uint64_t kTimestamp7 = 17;
+
+  const PFN_vkGetQueryPoolResults mock_get_query_pool_results_function_all_ready =
+      +[](VkDevice /*device*/, VkQueryPool /*queryPool*/, uint32_t first_query,
+          uint32_t query_count, size_t /*dataSize*/, void* data, VkDeviceSize /*stride*/,
+          VkQueryResultFlags flags) -> VkResult {
+    EXPECT_EQ(query_count, 1);
+    EXPECT_NE((flags & VK_QUERY_RESULT_64_BIT), 0);
+    switch (first_query) {
+      case kSlotIndex1:
+        *absl::bit_cast<uint64_t*>(data) = kTimestamp1;
+        break;
+      case kSlotIndex2:
+        *absl::bit_cast<uint64_t*>(data) = kTimestamp2;
+        break;
+      case kSlotIndex3:
+        *absl::bit_cast<uint64_t*>(data) = kTimestamp3;
+        break;
+      case kSlotIndex4:
+        *absl::bit_cast<uint64_t*>(data) = kTimestamp4;
+        break;
+      case kSlotIndex5:
+        *absl::bit_cast<uint64_t*>(data) = kTimestamp5;
+        break;
+      case kSlotIndex6:
+        *absl::bit_cast<uint64_t*>(data) = kTimestamp6;
+        break;
+      case kSlotIndex7:
+        *absl::bit_cast<uint64_t*>(data) = kTimestamp7;
+        break;
+      default:
+        UNREACHABLE();
+    }
+    return VK_SUCCESS;
+  };
+
+  const PFN_vkGetQueryPoolResults mock_get_query_pool_results_function_not_ready =
+      +[](VkDevice /*device*/, VkQueryPool /*queryPool*/, uint32_t /*first_query*/,
+          uint32_t /*query_count*/, size_t /*dataSize*/, void* /*data*/, VkDeviceSize /*stride*/,
+          VkQueryResultFlags /*flags*/) -> VkResult { return VK_NOT_READY; };
+
+  void EXPECT_SINGLE_COMMAND_BUFFER_SUBMISSION_EQ(
+      const orbit_grpc_protos::CaptureEvent& actual_capture_event, uint64_t test_pre_submit_time,
+      uint64_t test_post_submit_time, pid_t expected_tid,
+      uint64_t expected_command_buffer_begin_timestamp,
+      uint64_t expected_command_buffer_end_timestamp) {
+    EXPECT_TRUE(actual_capture_event.has_gpu_queue_submission());
+    const orbit_grpc_protos::GpuQueueSubmission& actual_queue_submission =
+        actual_capture_event.gpu_queue_submission();
+
+    EXPECT_SUBMIT_EQ(actual_queue_submission.meta_info(), test_pre_submit_time,
+                     test_post_submit_time, expected_tid);
+
+    ASSERT_EQ(actual_queue_submission.submit_infos_size(), 1);
+    const orbit_grpc_protos::GpuSubmitInfo& actual_submit_info =
+        actual_queue_submission.submit_infos(0);
+
+    ASSERT_EQ(actual_submit_info.command_buffers_size(), 1);
+    const orbit_grpc_protos::GpuCommandBuffer& actual_command_buffer =
+        actual_submit_info.command_buffers(0);
+
+    EXPECT_EQ(expected_command_buffer_begin_timestamp,
+              actual_command_buffer.begin_gpu_timestamp_ns());
+    EXPECT_EQ(expected_command_buffer_end_timestamp, actual_command_buffer.end_gpu_timestamp_ns());
+  }
+
+  void EXPECT_SUBMIT_EQ(const orbit_grpc_protos::GpuQueueSubmissionMetaInfo& actual_meta_info,
+                        int64_t test_pre_submit_time, uint64_t test_post_submit_time,
+                        pid_t expected_tid) {
+    EXPECT_LE(test_pre_submit_time, actual_meta_info.pre_submission_cpu_timestamp());
+    EXPECT_LE(actual_meta_info.pre_submission_cpu_timestamp(),
+              actual_meta_info.post_submission_cpu_timestamp());
+    EXPECT_LE(actual_meta_info.post_submission_cpu_timestamp(), test_post_submit_time);
+    EXPECT_EQ(expected_tid, actual_meta_info.tid());
+  }
+
+  void EXPECT_DEBUG_MARKER_END_EQ(const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker,
+                                  uint64_t expected_end_timestamp, uint64_t expected_text_key,
+                                  internal::Color expected_color, int32_t expected_depth) {
+    EXPECT_EQ(actual_debug_marker.end_gpu_timestamp_ns(), expected_end_timestamp);
+    EXPECT_EQ(actual_debug_marker.color().red(), expected_color.red);
+    EXPECT_EQ(actual_debug_marker.color().green(), expected_color.green);
+    EXPECT_EQ(actual_debug_marker.color().blue(), expected_color.blue);
+    EXPECT_EQ(actual_debug_marker.color().alpha(), expected_color.alpha);
+    EXPECT_EQ(actual_debug_marker.text_key(), expected_text_key);
+    EXPECT_EQ(actual_debug_marker.depth(), expected_depth);
+  }
+
+  void EXPECT_DEBUG_MARKER_BEGIN_EQ(const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker,
+                                    uint64_t expected_timestamp, int64_t test_pre_submit_time,
+                                    uint64_t test_post_submit_time, pid_t expected_tid) {
+    ASSERT_TRUE(actual_debug_marker.has_begin_marker());
+    EXPECT_EQ(actual_debug_marker.begin_marker().gpu_timestamp_ns(), expected_timestamp);
+    const orbit_grpc_protos::GpuQueueSubmissionMetaInfo& actual_begin_marker_meta_info =
+        actual_debug_marker.begin_marker().meta_info();
+    EXPECT_SUBMIT_EQ(actual_begin_marker_meta_info, test_pre_submit_time, test_post_submit_time,
+                     expected_tid);
+  }
+
+  void EXPECT_TWO_NEXT_READY_QUERY_SLOT_CALLS() {
+    EXPECT_CALL(timer_query_pool, NextReadyQuerySlot)
+        .Times(2)
+        .WillOnce(Invoke(mock_next_ready_query_slot_function_1))
+        .WillOnce(Invoke(mock_next_ready_query_slot_function_2));
+  }
+
+  void EXPECT_THREE_NEXT_READY_QUERY_SLOT_CALLS() {
+    EXPECT_CALL(timer_query_pool, NextReadyQuerySlot)
+        .Times(3)
+        .WillOnce(Invoke(mock_next_ready_query_slot_function_1))
+        .WillOnce(Invoke(mock_next_ready_query_slot_function_2))
+        .WillOnce(Invoke(mock_next_ready_query_slot_function_3));
+  }
+
+  void EXPECT_FOUR_NEXT_READY_QUERY_SLOT_CALLS() {
+    EXPECT_CALL(timer_query_pool, NextReadyQuerySlot)
+        .Times(4)
+        .WillOnce(Invoke(mock_next_ready_query_slot_function_1))
+        .WillOnce(Invoke(mock_next_ready_query_slot_function_2))
+        .WillOnce(Invoke(mock_next_ready_query_slot_function_3))
+        .WillOnce(Invoke(mock_next_ready_query_slot_function_4));
+  }
+
+  void EXPECT_SIX_NEXT_READY_QUERY_SLOT_CALLS() {
+    EXPECT_CALL(timer_query_pool, NextReadyQuerySlot)
+        .Times(6)
+        .WillOnce(Invoke(mock_next_ready_query_slot_function_1))
+        .WillOnce(Invoke(mock_next_ready_query_slot_function_2))
+        .WillOnce(Invoke(mock_next_ready_query_slot_function_3))
+        .WillOnce(Invoke(mock_next_ready_query_slot_function_4))
+        .WillOnce(Invoke(mock_next_ready_query_slot_function_5))
+        .WillOnce(Invoke(mock_next_ready_query_slot_function_6));
+  }
+
+  void EXPECT_SEVEN_NEXT_READY_QUERY_SLOT_CALLS() {
+    EXPECT_CALL(timer_query_pool, NextReadyQuerySlot)
+        .Times(7)
+        .WillOnce(Invoke(mock_next_ready_query_slot_function_1))
+        .WillOnce(Invoke(mock_next_ready_query_slot_function_2))
+        .WillOnce(Invoke(mock_next_ready_query_slot_function_3))
+        .WillOnce(Invoke(mock_next_ready_query_slot_function_4))
+        .WillOnce(Invoke(mock_next_ready_query_slot_function_5))
+        .WillOnce(Invoke(mock_next_ready_query_slot_function_6))
+        .WillOnce(Invoke(mock_next_ready_query_slot_function_7));
+  }
+};
+
+TEST(SubmissionTracker, CanBeInitialized) {
+  MockDispatchTable dispatch_table;
+  MockTimerQueryPool timer_query_pool;
+  MockDeviceManager device_manager;
+  SubmissionTracker<MockDispatchTable, MockDeviceManager, MockTimerQueryPool> tracker(
+      0, &dispatch_table, &timer_query_pool, &device_manager);
+}
+
+TEST(SubmissionTracker, SetVulkanLayerProducerWillCallSetListener) {
+  MockDispatchTable dispatch_table;
+  MockTimerQueryPool timer_query_pool;
+  MockDeviceManager device_manager;
+  std::unique_ptr<MockVulkanLayerProducer> producer = std::make_unique<MockVulkanLayerProducer>();
+
+  SubmissionTracker<MockDispatchTable, MockDeviceManager, MockTimerQueryPool> tracker(
+      0, &dispatch_table, &timer_query_pool, &device_manager);
+
+  VulkanLayerProducer::CaptureStatusListener* actual_listener;
+  EXPECT_CALL(*producer, SetCaptureStatusListener).Times(1).WillOnce(SaveArg<0>(&actual_listener));
+  tracker.SetVulkanLayerProducer(producer.get());
+  EXPECT_EQ(actual_listener, &tracker);
+}
+
+TEST_F(SubmissionTrackerTest, CannotUntrackAnUntrackedCommandBuffer) {
+  EXPECT_DEATH({ tracker.UntrackCommandBuffers(device, command_pool, &command_buffer, 1); }, "");
+}
+
+TEST_F(SubmissionTrackerTest, CanTrackCommandBufferAgainAfterUntrack) {
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.UntrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+}
+
+TEST_F(SubmissionTrackerTest, MarkCommandBufferBeginWontWriteTimestampsWhenNotCapturing) {
+  EXPECT_CALL(timer_query_pool, NextReadyQuerySlot).Times(0);
+
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.MarkCommandBufferBegin(command_buffer);
+}
+
+TEST_F(SubmissionTrackerTest, MarkCommandBufferBeginWillWriteTimestampWhenCapturing) {
+  // We cannot capture anything in that lambda as we need to cast it to a function pointer.
+  static bool was_called = false;
+
+  PFN_vkCmdWriteTimestamp mock_write_timestamp_function =
+      +[](VkCommandBuffer /*command_buffer*/, VkPipelineStageFlagBits /*pipeline_stage*/,
+          VkQueryPool /*query_pool*/, uint32_t query) {
+        EXPECT_EQ(query, kSlotIndex1);
+        was_called = true;
+      };
+
+  EXPECT_CALL(timer_query_pool, NextReadyQuerySlot)
+      .Times(1)
+      .WillOnce(Invoke(mock_next_ready_query_slot_function_1));
+  EXPECT_CALL(dispatch_table, CmdWriteTimestamp)
+      .Times(1)
+      .WillOnce(Return(mock_write_timestamp_function));
+
+  producer->StartCapture();
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.MarkCommandBufferBegin(command_buffer);
+
+  EXPECT_TRUE(was_called);
+  was_called = false;
+}
+
+TEST_F(SubmissionTrackerTest, ResetCommandBufferShouldRollbackUnsubmittedSlots) {
+  EXPECT_CALL(timer_query_pool, NextReadyQuerySlot)
+      .Times(1)
+      .WillOnce(Invoke(mock_next_ready_query_slot_function_1));
+  std::vector<uint32_t> actual_slots_to_rollback;
+  EXPECT_CALL(timer_query_pool, RollbackPendingQuerySlots)
+      .Times(1)
+      .WillOnce(SaveArg<1>(&actual_slots_to_rollback));
+
+  producer->StartCapture();
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.MarkCommandBufferBegin(command_buffer);
+  tracker.ResetCommandBuffer(command_buffer);
+
+  EXPECT_THAT(actual_slots_to_rollback, ElementsAre(kSlotIndex1));
+}
+
+TEST_F(SubmissionTrackerTest, ResetCommandPoolShouldRollbackUnsubmittedSlots) {
+  EXPECT_CALL(timer_query_pool, NextReadyQuerySlot)
+      .Times(1)
+      .WillOnce(Invoke(mock_next_ready_query_slot_function_1));
+  std::vector<uint32_t> actual_slots_to_rollback;
+  EXPECT_CALL(timer_query_pool, RollbackPendingQuerySlots)
+      .Times(1)
+      .WillOnce(SaveArg<1>(&actual_slots_to_rollback));
+
+  producer->StartCapture();
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.MarkCommandBufferBegin(command_buffer);
+  tracker.ResetCommandPool(command_pool);
+
+  EXPECT_THAT(actual_slots_to_rollback, ElementsAre(kSlotIndex1));
+}
+
+TEST_F(SubmissionTrackerTest, MarkCommandBufferEndWontWriteTimestampsWhenNotCapturing) {
+  EXPECT_CALL(timer_query_pool, NextReadyQuerySlot).Times(0);
+  EXPECT_CALL(dispatch_table, CmdWriteTimestamp).Times(0);
+
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.MarkCommandBufferBegin(command_buffer);
+  tracker.MarkCommandBufferEnd(command_buffer);
+}
+
+TEST_F(SubmissionTrackerTest, MarkCommandBufferEndWillWriteTimestampsWhenNotCapturedBegin) {
+  static bool was_called = false;
+
+  PFN_vkCmdWriteTimestamp mock_write_timestamp_function =
+      +[](VkCommandBuffer /*command_buffer*/, VkPipelineStageFlagBits /*pipeline_stage*/,
+          VkQueryPool /*query_pool*/, uint32_t query) {
+        EXPECT_EQ(query, kSlotIndex1);
+        was_called = true;
+      };
+
+  EXPECT_CALL(timer_query_pool, NextReadyQuerySlot)
+      .Times(1)
+      .WillOnce(Invoke(mock_next_ready_query_slot_function_1));
+  EXPECT_CALL(dispatch_table, CmdWriteTimestamp)
+      .Times(1)
+      .WillOnce(Return(mock_write_timestamp_function));
+
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.MarkCommandBufferBegin(command_buffer);
+  producer->StartCapture();
+  tracker.MarkCommandBufferEnd(command_buffer);
+
+  EXPECT_TRUE(was_called);
+  was_called = false;
+}
+
+TEST_F(SubmissionTrackerTest, CanRetrieveCommandBufferTimestampsForACompleteSubmission) {
+  EXPECT_TWO_NEXT_READY_QUERY_SLOT_CALLS();
+  EXPECT_CALL(dispatch_table, GetQueryPoolResults)
+      .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
+  std::vector<uint32_t> actual_reset_slots;
+  EXPECT_CALL(timer_query_pool, ResetQuerySlots).Times(1).WillOnce(SaveArg<1>(&actual_reset_slots));
+  orbit_grpc_protos::CaptureEvent actual_capture_event;
+  auto mock_enqueue_capture_event =
+      [&actual_capture_event](orbit_grpc_protos::CaptureEvent&& capture_event) {
+        actual_capture_event = std::move(capture_event);
+        return true;
+      };
+  EXPECT_CALL(*producer, EnqueueCaptureEvent).Times(1).WillOnce(Invoke(mock_enqueue_capture_event));
+
+  producer->StartCapture();
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.MarkCommandBufferBegin(command_buffer);
+  tracker.MarkCommandBufferEnd(command_buffer);
+  pid_t pid = GetCurrentThreadId();
+  uint64_t pre_submit_time = MonotonicTimestampNs();
+  std::optional<internal::QueueSubmission> queue_submission_optional =
+      tracker.PersistCommandBuffersOnSubmit(1, &submit_info);
+  tracker.PersistDebugMarkersOnSubmit(queue, 1, &submit_info, queue_submission_optional);
+  uint64_t post_submit_time = MonotonicTimestampNs();
+  tracker.CompleteSubmits(device);
+
+  EXPECT_THAT(actual_reset_slots, UnorderedElementsAre(kSlotIndex1, kSlotIndex2));
+  EXPECT_SINGLE_COMMAND_BUFFER_SUBMISSION_EQ(actual_capture_event, pre_submit_time,
+                                             post_submit_time, pid, kTimestamp1, kTimestamp2);
+}
+
+TEST_F(SubmissionTrackerTest,
+       CanRetrieveCommandBufferTimestampsForACompleteSubmissionAtSecondPresent) {
+  EXPECT_TWO_NEXT_READY_QUERY_SLOT_CALLS();
+  EXPECT_CALL(dispatch_table, GetQueryPoolResults)
+      .WillOnce(Return(mock_get_query_pool_results_function_not_ready))
+      .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
+  std::vector<uint32_t> actual_reset_slots;
+  EXPECT_CALL(timer_query_pool, ResetQuerySlots).Times(1).WillOnce(SaveArg<1>(&actual_reset_slots));
+  orbit_grpc_protos::CaptureEvent actual_capture_event;
+  auto mock_enqueue_capture_event =
+      [&actual_capture_event](orbit_grpc_protos::CaptureEvent&& capture_event) {
+        actual_capture_event = std::move(capture_event);
+        return true;
+      };
+  EXPECT_CALL(*producer, EnqueueCaptureEvent).Times(1).WillOnce(Invoke(mock_enqueue_capture_event));
+
+  producer->StartCapture();
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.MarkCommandBufferBegin(command_buffer);
+  tracker.MarkCommandBufferEnd(command_buffer);
+  pid_t pid = GetCurrentThreadId();
+  uint64_t pre_submit_time = MonotonicTimestampNs();
+  std::optional<internal::QueueSubmission> queue_submission_optional =
+      tracker.PersistCommandBuffersOnSubmit(1, &submit_info);
+  tracker.PersistDebugMarkersOnSubmit(queue, 1, &submit_info, queue_submission_optional);
+  uint64_t post_submit_time = MonotonicTimestampNs();
+  tracker.CompleteSubmits(device);
+  tracker.CompleteSubmits(device);
+
+  EXPECT_THAT(actual_reset_slots, UnorderedElementsAre(kSlotIndex1, kSlotIndex2));
+  EXPECT_SINGLE_COMMAND_BUFFER_SUBMISSION_EQ(actual_capture_event, pre_submit_time,
+                                             post_submit_time, pid, kTimestamp1, kTimestamp2);
+}
+
+TEST_F(SubmissionTrackerTest, StopCaptureBeforeSubmissionWillResetTheSlots) {
+  EXPECT_TWO_NEXT_READY_QUERY_SLOT_CALLS();
+  EXPECT_CALL(dispatch_table, GetQueryPoolResults).Times(0);
+  std::vector<uint32_t> actual_reset_slots;
+  EXPECT_CALL(timer_query_pool, ResetQuerySlots).Times(1).WillOnce(SaveArg<1>(&actual_reset_slots));
+
+  EXPECT_CALL(*producer, EnqueueCaptureEvent).Times(0);
+
+  producer->StartCapture();
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.MarkCommandBufferBegin(command_buffer);
+  tracker.MarkCommandBufferEnd(command_buffer);
+  producer->StopCapture();
+  std::optional<internal::QueueSubmission> queue_submission_optional =
+      tracker.PersistCommandBuffersOnSubmit(1, &submit_info);
+  tracker.PersistDebugMarkersOnSubmit(queue, 1, &submit_info, queue_submission_optional);
+  tracker.CompleteSubmits(device);
+
+  EXPECT_THAT(actual_reset_slots, UnorderedElementsAre(kSlotIndex1, kSlotIndex2));
+}
+
+TEST_F(SubmissionTrackerTest, CanRetrieveCommandBufferTimestampsWhenNotCapturingAtPresent) {
+  EXPECT_TWO_NEXT_READY_QUERY_SLOT_CALLS();
+  EXPECT_CALL(dispatch_table, GetQueryPoolResults)
+      .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
+  std::vector<uint32_t> actual_reset_slots;
+  EXPECT_CALL(timer_query_pool, ResetQuerySlots).Times(1).WillOnce(SaveArg<1>(&actual_reset_slots));
+  orbit_grpc_protos::CaptureEvent actual_capture_event;
+  auto mock_enqueue_capture_event =
+      [&actual_capture_event](orbit_grpc_protos::CaptureEvent&& capture_event) {
+        actual_capture_event = std::move(capture_event);
+        return true;
+      };
+  EXPECT_CALL(*producer, EnqueueCaptureEvent).Times(1).WillOnce(Invoke(mock_enqueue_capture_event));
+
+  producer->StartCapture();
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.MarkCommandBufferBegin(command_buffer);
+  tracker.MarkCommandBufferEnd(command_buffer);
+  pid_t pid = GetCurrentThreadId();
+  uint64_t pre_submit_time = MonotonicTimestampNs();
+  std::optional<internal::QueueSubmission> queue_submission_optional =
+      tracker.PersistCommandBuffersOnSubmit(1, &submit_info);
+  tracker.PersistDebugMarkersOnSubmit(queue, 1, &submit_info, queue_submission_optional);
+  uint64_t post_submit_time = MonotonicTimestampNs();
+  producer->StopCapture();
+  tracker.CompleteSubmits(device);
+
+  EXPECT_THAT(actual_reset_slots, UnorderedElementsAre(kSlotIndex1, kSlotIndex2));
+  EXPECT_SINGLE_COMMAND_BUFFER_SUBMISSION_EQ(actual_capture_event, pre_submit_time,
+                                             post_submit_time, pid, kTimestamp1, kTimestamp2);
+}
+
+TEST_F(SubmissionTrackerTest, StopCaptureWhileSubmissionWillStillYieldResults) {
+  EXPECT_TWO_NEXT_READY_QUERY_SLOT_CALLS();
+  EXPECT_CALL(dispatch_table, GetQueryPoolResults)
+      .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
+  std::vector<uint32_t> actual_reset_slots;
+  EXPECT_CALL(timer_query_pool, ResetQuerySlots).Times(1).WillOnce(SaveArg<1>(&actual_reset_slots));
+  orbit_grpc_protos::CaptureEvent actual_capture_event;
+  auto mock_enqueue_capture_event =
+      [&actual_capture_event](orbit_grpc_protos::CaptureEvent&& capture_event) {
+        actual_capture_event = std::move(capture_event);
+        return true;
+      };
+  EXPECT_CALL(*producer, EnqueueCaptureEvent).Times(1).WillOnce(Invoke(mock_enqueue_capture_event));
+
+  producer->StartCapture();
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.MarkCommandBufferBegin(command_buffer);
+  tracker.MarkCommandBufferEnd(command_buffer);
+  pid_t pid = GetCurrentThreadId();
+  uint64_t pre_submit_time = MonotonicTimestampNs();
+  std::optional<internal::QueueSubmission> queue_submission_optional =
+      tracker.PersistCommandBuffersOnSubmit(1, &submit_info);
+  producer->StopCapture();
+  tracker.PersistDebugMarkersOnSubmit(queue, 1, &submit_info, queue_submission_optional);
+  uint64_t post_submit_time = MonotonicTimestampNs();
+  tracker.CompleteSubmits(device);
+
+  EXPECT_THAT(actual_reset_slots, UnorderedElementsAre(kSlotIndex1, kSlotIndex2));
+  EXPECT_SINGLE_COMMAND_BUFFER_SUBMISSION_EQ(actual_capture_event, pre_submit_time,
+                                             post_submit_time, pid, kTimestamp1, kTimestamp2);
+}
+
+TEST_F(SubmissionTrackerTest, StartCaptureJustBeforeSubmissionWontWriteData) {
+  EXPECT_CALL(timer_query_pool, NextReadyQuerySlot).Times(0);
+  EXPECT_CALL(dispatch_table, GetQueryPoolResults).Times(0);
+  EXPECT_CALL(timer_query_pool, ResetQuerySlots).Times(0);
+  EXPECT_CALL(*producer, EnqueueCaptureEvent).Times(0);
+
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.MarkCommandBufferBegin(command_buffer);
+  tracker.MarkCommandBufferEnd(command_buffer);
+  producer->StartCapture();
+  std::optional<internal::QueueSubmission> queue_submission_optional =
+      tracker.PersistCommandBuffersOnSubmit(1, &submit_info);
+  tracker.PersistDebugMarkersOnSubmit(queue, 1, &submit_info, queue_submission_optional);
+  tracker.CompleteSubmits(device);
+}
+
+TEST_F(SubmissionTrackerTest, StartCaptureWhileSubmissionWontWriteData) {
+  EXPECT_CALL(timer_query_pool, NextReadyQuerySlot).Times(0);
+  EXPECT_CALL(dispatch_table, GetQueryPoolResults).Times(0);
+  EXPECT_CALL(timer_query_pool, ResetQuerySlots).Times(0);
+  EXPECT_CALL(*producer, EnqueueCaptureEvent).Times(0);
+
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.MarkCommandBufferBegin(command_buffer);
+  tracker.MarkCommandBufferEnd(command_buffer);
+  std::optional<internal::QueueSubmission> queue_submission_optional =
+      tracker.PersistCommandBuffersOnSubmit(1, &submit_info);
+  producer->StartCapture();
+  tracker.PersistDebugMarkersOnSubmit(queue, 1, &submit_info, queue_submission_optional);
+  tracker.CompleteSubmits(device);
+}
+
+TEST_F(SubmissionTrackerTest, WillResetProperlyWhenStartStopAndStartACaptureWithinASubmission) {
+  EXPECT_CALL(timer_query_pool, NextReadyQuerySlot)
+      .Times(1)
+      .WillOnce(Invoke(mock_next_ready_query_slot_function_1));
+  EXPECT_CALL(dispatch_table, GetQueryPoolResults).Times(0);
+  std::vector<uint32_t> actual_reset_slots;
+  EXPECT_CALL(timer_query_pool, ResetQuerySlots).Times(1).WillOnce(SaveArg<1>(&actual_reset_slots));
+  EXPECT_CALL(*producer, EnqueueCaptureEvent).Times(0);
+
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  producer->StartCapture();
+  tracker.MarkCommandBufferBegin(command_buffer);
+  producer->StopCapture();
+  tracker.MarkCommandBufferEnd(command_buffer);
+  producer->StartCapture();
+  std::optional<internal::QueueSubmission> queue_submission_optional =
+      tracker.PersistCommandBuffersOnSubmit(1, &submit_info);
+  tracker.PersistDebugMarkersOnSubmit(queue, 1, &submit_info, queue_submission_optional);
+  tracker.CompleteSubmits(device);
+
+  EXPECT_THAT(actual_reset_slots, UnorderedElementsAre(kSlotIndex1));
+}
+
+TEST_F(SubmissionTrackerTest, CannotReuseCommandBufferWithoutReset) {
+  EXPECT_TWO_NEXT_READY_QUERY_SLOT_CALLS();
+  EXPECT_CALL(dispatch_table, GetQueryPoolResults)
+      .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
+  EXPECT_CALL(timer_query_pool, ResetQuerySlots).Times(1);
+  EXPECT_CALL(*producer, EnqueueCaptureEvent).Times(1);
+
+  producer->StartCapture();
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.MarkCommandBufferBegin(command_buffer);
+  tracker.MarkCommandBufferEnd(command_buffer);
+  std::optional<internal::QueueSubmission> queue_submission_optional =
+      tracker.PersistCommandBuffersOnSubmit(1, &submit_info);
+  tracker.PersistDebugMarkersOnSubmit(queue, 1, &submit_info, queue_submission_optional);
+  tracker.CompleteSubmits(device);
+
+  EXPECT_DEATH({ tracker.MarkCommandBufferBegin(command_buffer); }, "");
+}
+
+TEST_F(SubmissionTrackerTest, CanReuseCommandBufferAfterReset) {
+  EXPECT_CALL(timer_query_pool, NextReadyQuerySlot)
+      .Times(3)
+      .WillOnce(Invoke(mock_next_ready_query_slot_function_1))
+      .WillOnce(Invoke(mock_next_ready_query_slot_function_2))
+      .WillOnce(Invoke(mock_next_ready_query_slot_function_3));
+  EXPECT_CALL(dispatch_table, GetQueryPoolResults)
+      .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
+  EXPECT_CALL(timer_query_pool, ResetQuerySlots).Times(1);
+  EXPECT_CALL(*producer, EnqueueCaptureEvent).Times(1);
+
+  producer->StartCapture();
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.MarkCommandBufferBegin(command_buffer);
+  tracker.MarkCommandBufferEnd(command_buffer);
+  std::optional<internal::QueueSubmission> queue_submission_optional =
+      tracker.PersistCommandBuffersOnSubmit(1, &submit_info);
+  tracker.PersistDebugMarkersOnSubmit(queue, 1, &submit_info, queue_submission_optional);
+  tracker.CompleteSubmits(device);
+  tracker.ResetCommandBuffer(command_buffer);
+  tracker.MarkCommandBufferBegin(command_buffer);
+}
+
+TEST_F(SubmissionTrackerTest, DebugMarkerBeginWillWriteTimestampWhenCapturing) {
+  // We cannot capture anything in that lambda as we need to cast it to a function pointer.
+  static bool was_called = false;
+
+  PFN_vkCmdWriteTimestamp mock_write_timestamp_function =
+      +[](VkCommandBuffer /*command_buffer*/, VkPipelineStageFlagBits /*pipeline_stage*/,
+          VkQueryPool /*query_pool*/, uint32_t query) {
+        EXPECT_EQ(query, kSlotIndex2);
+        was_called = true;
+      };
+
+  EXPECT_TWO_NEXT_READY_QUERY_SLOT_CALLS();
+  EXPECT_CALL(dispatch_table, CmdWriteTimestamp)
+      .Times(2)
+      .WillOnce(Return(dummy_write_timestamp_function))
+      .WillOnce(Return(mock_write_timestamp_function));
+
+  producer->StartCapture();
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.MarkCommandBufferBegin(command_buffer);
+  tracker.MarkDebugMarkerBegin(command_buffer, "Marker", {});
+
+  EXPECT_TRUE(was_called);
+  was_called = false;
+}
+
+TEST_F(SubmissionTrackerTest, ResetCommandBufferShouldRollbackUnsubmittedMarkerSlots) {
+  EXPECT_TWO_NEXT_READY_QUERY_SLOT_CALLS();
+  std::vector<uint32_t> actual_slots_to_rollback;
+  EXPECT_CALL(timer_query_pool, RollbackPendingQuerySlots)
+      .Times(1)
+      .WillOnce(SaveArg<1>(&actual_slots_to_rollback));
+
+  producer->StartCapture();
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.MarkCommandBufferBegin(command_buffer);
+  tracker.MarkDebugMarkerBegin(command_buffer, "Marker", {});
+  tracker.ResetCommandBuffer(command_buffer);
+
+  EXPECT_THAT(actual_slots_to_rollback, UnorderedElementsAre(kSlotIndex1, kSlotIndex2));
+}
+
+TEST_F(SubmissionTrackerTest, DebugMarkerBeginWontWriteTimestampsWhenNotCapturing) {
+  EXPECT_CALL(timer_query_pool, NextReadyQuerySlot).Times(0);
+  EXPECT_CALL(dispatch_table, CmdWriteTimestamp).Times(0);
+
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.MarkCommandBufferBegin(command_buffer);
+  tracker.MarkDebugMarkerBegin(command_buffer, "Marker", {});
+}
+
+TEST_F(SubmissionTrackerTest, DebugMarkerEndWontWriteTimestampsWhenNotCapturing) {
+  EXPECT_CALL(timer_query_pool, NextReadyQuerySlot).Times(0);
+  EXPECT_CALL(dispatch_table, CmdWriteTimestamp).Times(0);
+
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.MarkCommandBufferBegin(command_buffer);
+  tracker.MarkDebugMarkerBegin(command_buffer, "Marker", {});
+  tracker.MarkDebugMarkerEnd(command_buffer);
+}
+
+TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerTimestampsForACompleteSubmission) {
+  EXPECT_FOUR_NEXT_READY_QUERY_SLOT_CALLS();
+  EXPECT_CALL(dispatch_table, GetQueryPoolResults)
+      .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
+  std::vector<uint32_t> actual_reset_slots;
+  EXPECT_CALL(timer_query_pool, ResetQuerySlots).Times(1).WillOnce(SaveArg<1>(&actual_reset_slots));
+  orbit_grpc_protos::CaptureEvent actual_capture_event;
+  auto mock_enqueue_capture_event =
+      [&actual_capture_event](orbit_grpc_protos::CaptureEvent&& capture_event) {
+        actual_capture_event = std::move(capture_event);
+        return true;
+      };
+
+  const char* text = "Text";
+  constexpr uint64_t expected_text_key = 111;
+  auto mock_intern_string_if_necessary_and_get_key = [&text](std::string str) {
+    EXPECT_STREQ(text, str.c_str());
+    return expected_text_key;
+  };
+  EXPECT_CALL(*producer, InternStringIfNecessaryAndGetKey)
+      .Times(1)
+      .WillOnce(Invoke(mock_intern_string_if_necessary_and_get_key));
+  EXPECT_CALL(*producer, EnqueueCaptureEvent).Times(1).WillOnce(Invoke(mock_enqueue_capture_event));
+
+  internal::Color expected_color{1.f, 0.8f, 0.6f, 0.4f};
+
+  producer->StartCapture();
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.MarkCommandBufferBegin(command_buffer);
+  tracker.MarkDebugMarkerBegin(command_buffer, text, expected_color);
+  tracker.MarkDebugMarkerEnd(command_buffer);
+  tracker.MarkCommandBufferEnd(command_buffer);
+  pid_t tid = GetCurrentThreadId();
+  uint64_t pre_submit_time = MonotonicTimestampNs();
+  std::optional<internal::QueueSubmission> queue_submission_optional =
+      tracker.PersistCommandBuffersOnSubmit(1, &submit_info);
+  tracker.PersistDebugMarkersOnSubmit(queue, 1, &submit_info, queue_submission_optional);
+  uint64_t post_submit_time = MonotonicTimestampNs();
+  tracker.CompleteSubmits(device);
+
+  EXPECT_THAT(actual_reset_slots,
+              UnorderedElementsAre(kSlotIndex1, kSlotIndex2, kSlotIndex3, kSlotIndex4));
+  EXPECT_TRUE(actual_capture_event.has_gpu_queue_submission());
+  const orbit_grpc_protos::GpuQueueSubmission& actual_queue_submission =
+      actual_capture_event.gpu_queue_submission();
+  EXPECT_EQ(actual_queue_submission.num_begin_markers(), 1);
+  EXPECT_EQ(actual_queue_submission.completed_markers_size(), 1);
+  const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker =
+      actual_queue_submission.completed_markers(0);
+
+  EXPECT_DEBUG_MARKER_END_EQ(actual_debug_marker, kTimestamp3, expected_text_key, expected_color,
+                             0);
+  EXPECT_DEBUG_MARKER_BEGIN_EQ(actual_debug_marker, kTimestamp2, pre_submit_time, post_submit_time,
+                               tid);
+}
+
+TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerEndEvenWhenNotCapturedBegin) {
+  EXPECT_TWO_NEXT_READY_QUERY_SLOT_CALLS();
+  EXPECT_CALL(dispatch_table, GetQueryPoolResults)
+      .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
+  std::vector<uint32_t> actual_reset_slots;
+  EXPECT_CALL(timer_query_pool, ResetQuerySlots).Times(1).WillOnce(SaveArg<1>(&actual_reset_slots));
+  orbit_grpc_protos::CaptureEvent actual_capture_event;
+  auto mock_enqueue_capture_event =
+      [&actual_capture_event](orbit_grpc_protos::CaptureEvent&& capture_event) {
+        actual_capture_event = std::move(capture_event);
+        return true;
+      };
+
+  const char* text = "Text";
+  constexpr uint64_t expected_text_key = 111;
+  auto mock_intern_string_if_necessary_and_get_key = [&text](std::string str) {
+    EXPECT_STREQ(text, str.c_str());
+    return expected_text_key;
+  };
+  EXPECT_CALL(*producer, InternStringIfNecessaryAndGetKey)
+      .Times(1)
+      .WillOnce(Invoke(mock_intern_string_if_necessary_and_get_key));
+  EXPECT_CALL(*producer, EnqueueCaptureEvent).Times(1).WillOnce(Invoke(mock_enqueue_capture_event));
+
+  internal::Color expected_color{1.f, 0.8f, 0.6f, 0.4f};
+
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.MarkCommandBufferBegin(command_buffer);
+  tracker.MarkDebugMarkerBegin(command_buffer, text, expected_color);
+  producer->StartCapture();
+  tracker.MarkDebugMarkerEnd(command_buffer);
+  tracker.MarkCommandBufferEnd(command_buffer);
+  std::optional<internal::QueueSubmission> queue_submission_optional =
+      tracker.PersistCommandBuffersOnSubmit(1, &submit_info);
+  tracker.PersistDebugMarkersOnSubmit(queue, 1, &submit_info, queue_submission_optional);
+  tracker.CompleteSubmits(device);
+
+  EXPECT_THAT(actual_reset_slots, UnorderedElementsAre(kSlotIndex1, kSlotIndex2));
+  EXPECT_TRUE(actual_capture_event.has_gpu_queue_submission());
+  const orbit_grpc_protos::GpuQueueSubmission& actual_queue_submission =
+      actual_capture_event.gpu_queue_submission();
+  EXPECT_EQ(actual_queue_submission.num_begin_markers(), 0);
+  EXPECT_EQ(actual_queue_submission.completed_markers_size(), 1);
+  const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker =
+      actual_queue_submission.completed_markers(0);
+
+  EXPECT_DEBUG_MARKER_END_EQ(actual_debug_marker, kTimestamp1, expected_text_key, expected_color,
+                             0);
+  EXPECT_FALSE(actual_debug_marker.has_begin_marker());
+}
+
+TEST_F(SubmissionTrackerTest, CanRetrieveNextedDebugMarkerTimestampsForACompleteSubmission) {
+  EXPECT_SIX_NEXT_READY_QUERY_SLOT_CALLS();
+  EXPECT_CALL(dispatch_table, GetQueryPoolResults)
+      .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
+  std::vector<uint32_t> actual_reset_slots;
+  EXPECT_CALL(timer_query_pool, ResetQuerySlots).Times(1).WillOnce(SaveArg<1>(&actual_reset_slots));
+  orbit_grpc_protos::CaptureEvent actual_capture_event;
+  auto mock_enqueue_capture_event =
+      [&actual_capture_event](orbit_grpc_protos::CaptureEvent&& capture_event) {
+        actual_capture_event = std::move(capture_event);
+        return true;
+      };
+
+  const std::string text_outer = "Outer";
+  const std::string text_inner = "Inner";
+  constexpr uint64_t expected_text_key_outer = 111;
+  constexpr uint64_t expected_text_key_inner = 112;
+  auto mock_intern_string_if_necessary_and_get_key = [&text_outer, &text_inner](std::string str) {
+    if (str == text_outer) {
+      return expected_text_key_outer;
+    }
+    if (str == text_inner) {
+      return expected_text_key_inner;
+    }
+    UNREACHABLE();
+  };
+  EXPECT_CALL(*producer, InternStringIfNecessaryAndGetKey)
+      .Times(2)
+      .WillRepeatedly(Invoke(mock_intern_string_if_necessary_and_get_key));
+  EXPECT_CALL(*producer, EnqueueCaptureEvent).Times(1).WillOnce(Invoke(mock_enqueue_capture_event));
+
+  internal::Color expected_color{1.f, 0.8f, 0.6f, 0.4f};
+
+  producer->StartCapture();
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.MarkCommandBufferBegin(command_buffer);
+  tracker.MarkDebugMarkerBegin(command_buffer, text_outer.c_str(), expected_color);
+  tracker.MarkDebugMarkerBegin(command_buffer, text_inner.c_str(), expected_color);
+  tracker.MarkDebugMarkerEnd(command_buffer);
+  tracker.MarkDebugMarkerEnd(command_buffer);
+  tracker.MarkCommandBufferEnd(command_buffer);
+  pid_t tid = GetCurrentThreadId();
+  uint64_t pre_submit_time = MonotonicTimestampNs();
+  std::optional<internal::QueueSubmission> queue_submission_optional =
+      tracker.PersistCommandBuffersOnSubmit(1, &submit_info);
+  tracker.PersistDebugMarkersOnSubmit(queue, 1, &submit_info, queue_submission_optional);
+  uint64_t post_submit_time = MonotonicTimestampNs();
+  tracker.CompleteSubmits(device);
+
+  EXPECT_THAT(actual_reset_slots, UnorderedElementsAre(kSlotIndex1, kSlotIndex2, kSlotIndex3,
+                                                       kSlotIndex4, kSlotIndex5, kSlotIndex6));
+  EXPECT_TRUE(actual_capture_event.has_gpu_queue_submission());
+  const orbit_grpc_protos::GpuQueueSubmission& actual_queue_submission =
+      actual_capture_event.gpu_queue_submission();
+  EXPECT_EQ(actual_queue_submission.num_begin_markers(), 2);
+  EXPECT_EQ(actual_queue_submission.completed_markers_size(), 2);
+  const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker_inner =
+      actual_queue_submission.completed_markers(0);
+  const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker_outer =
+      actual_queue_submission.completed_markers(1);
+
+  EXPECT_DEBUG_MARKER_END_EQ(actual_debug_marker_outer, kTimestamp5, expected_text_key_outer,
+                             expected_color, 0);
+  EXPECT_DEBUG_MARKER_BEGIN_EQ(actual_debug_marker_outer, kTimestamp2, pre_submit_time,
+                               post_submit_time, tid);
+
+  EXPECT_DEBUG_MARKER_END_EQ(actual_debug_marker_inner, kTimestamp4, expected_text_key_inner,
+                             expected_color, 1);
+  EXPECT_DEBUG_MARKER_BEGIN_EQ(actual_debug_marker_inner, kTimestamp3, pre_submit_time,
+                               post_submit_time, tid);
+}  // namespace orbit_vulkan_layer
+
+TEST_F(SubmissionTrackerTest,
+       CanRetrieveNextedDebugMarkerTimestampsForASubmissionMissingFirstBegin) {
+  EXPECT_FOUR_NEXT_READY_QUERY_SLOT_CALLS();
+  EXPECT_CALL(dispatch_table, GetQueryPoolResults)
+      .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
+  std::vector<uint32_t> actual_reset_slots;
+  EXPECT_CALL(timer_query_pool, ResetQuerySlots).Times(1).WillOnce(SaveArg<1>(&actual_reset_slots));
+  orbit_grpc_protos::CaptureEvent actual_capture_event;
+  auto mock_enqueue_capture_event =
+      [&actual_capture_event](orbit_grpc_protos::CaptureEvent&& capture_event) {
+        actual_capture_event = std::move(capture_event);
+        return true;
+      };
+
+  const std::string text_outer = "Outer";
+  const std::string text_inner = "Inner";
+  constexpr uint64_t expected_text_key_outer = 111;
+  constexpr uint64_t expected_text_key_inner = 112;
+  auto mock_intern_string_if_necessary_and_get_key = [&text_outer, &text_inner](std::string str) {
+    if (str == text_outer) {
+      return expected_text_key_outer;
+    }
+    if (str == text_inner) {
+      return expected_text_key_inner;
+    }
+    UNREACHABLE();
+  };
+  EXPECT_CALL(*producer, InternStringIfNecessaryAndGetKey)
+      .Times(2)
+      .WillRepeatedly(Invoke(mock_intern_string_if_necessary_and_get_key));
+  EXPECT_CALL(*producer, EnqueueCaptureEvent).Times(1).WillOnce(Invoke(mock_enqueue_capture_event));
+
+  internal::Color expected_color{1.f, 0.8f, 0.6f, 0.4f};
+
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.MarkCommandBufferBegin(command_buffer);
+  tracker.MarkDebugMarkerBegin(command_buffer, text_outer.c_str(), expected_color);
+  producer->StartCapture();
+  tracker.MarkDebugMarkerBegin(command_buffer, text_inner.c_str(), expected_color);
+  tracker.MarkDebugMarkerEnd(command_buffer);
+  tracker.MarkDebugMarkerEnd(command_buffer);
+  tracker.MarkCommandBufferEnd(command_buffer);
+  pid_t tid = GetCurrentThreadId();
+  uint64_t pre_submit_time = MonotonicTimestampNs();
+  std::optional<internal::QueueSubmission> queue_submission_optional =
+      tracker.PersistCommandBuffersOnSubmit(1, &submit_info);
+  tracker.PersistDebugMarkersOnSubmit(queue, 1, &submit_info, queue_submission_optional);
+  uint64_t post_submit_time = MonotonicTimestampNs();
+  tracker.CompleteSubmits(device);
+
+  EXPECT_THAT(actual_reset_slots,
+              UnorderedElementsAre(kSlotIndex1, kSlotIndex2, kSlotIndex3, kSlotIndex4));
+  EXPECT_TRUE(actual_capture_event.has_gpu_queue_submission());
+  const orbit_grpc_protos::GpuQueueSubmission& actual_queue_submission =
+      actual_capture_event.gpu_queue_submission();
+  EXPECT_EQ(actual_queue_submission.num_begin_markers(), 1);
+  EXPECT_EQ(actual_queue_submission.completed_markers_size(), 2);
+  const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker_inner =
+      actual_queue_submission.completed_markers(0);
+  const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker_outer =
+      actual_queue_submission.completed_markers(1);
+
+  EXPECT_DEBUG_MARKER_END_EQ(actual_debug_marker_outer, kTimestamp3, expected_text_key_outer,
+                             expected_color, 0);
+  EXPECT_FALSE(actual_debug_marker_outer.has_begin_marker());
+
+  EXPECT_DEBUG_MARKER_END_EQ(actual_debug_marker_inner, kTimestamp2, expected_text_key_inner,
+                             expected_color, 1);
+  EXPECT_DEBUG_MARKER_BEGIN_EQ(actual_debug_marker_inner, kTimestamp1, pre_submit_time,
+                               post_submit_time, tid);
+}  // namespace orbit_vulkan_layer
+
+TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerAcrossTwoSubmissions) {
+  EXPECT_SIX_NEXT_READY_QUERY_SLOT_CALLS();
+  EXPECT_CALL(dispatch_table, GetQueryPoolResults)
+      .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
+  std::vector<uint32_t> actual_reset_slots_1;
+  std::vector<uint32_t> actual_reset_slots_2;
+  EXPECT_CALL(timer_query_pool, ResetQuerySlots)
+      .Times(2)
+      .WillOnce(SaveArg<1>(&actual_reset_slots_1))
+      .WillOnce(SaveArg<1>(&actual_reset_slots_2));
+  std::vector<orbit_grpc_protos::CaptureEvent> actual_capture_events;
+  auto mock_enqueue_capture_event =
+      [&actual_capture_events](orbit_grpc_protos::CaptureEvent&& capture_event) {
+        actual_capture_events.emplace_back(std::move(capture_event));
+        return true;
+      };
+
+  const char* text = "Text";
+  constexpr uint64_t expected_text_key = 111;
+  auto mock_intern_string_if_necessary_and_get_key = [&text](std::string str) {
+    EXPECT_STREQ(text, str.c_str());
+    return expected_text_key;
+  };
+  EXPECT_CALL(*producer, InternStringIfNecessaryAndGetKey)
+      .Times(1)
+      .WillOnce(Invoke(mock_intern_string_if_necessary_and_get_key));
+  EXPECT_CALL(*producer, EnqueueCaptureEvent)
+      .Times(2)
+      .WillRepeatedly(Invoke(mock_enqueue_capture_event));
+
+  internal::Color expected_color{1.f, 0.8f, 0.6f, 0.4f};
+
+  pid_t tid = GetCurrentThreadId();
+
+  producer->StartCapture();
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.MarkCommandBufferBegin(command_buffer);
+  tracker.MarkDebugMarkerBegin(command_buffer, text, expected_color);
+  tracker.MarkCommandBufferEnd(command_buffer);
+  uint64_t pre_submit_time_1 = MonotonicTimestampNs();
+  std::optional<internal::QueueSubmission> queue_submission_optional_1 =
+      tracker.PersistCommandBuffersOnSubmit(1, &submit_info);
+  tracker.PersistDebugMarkersOnSubmit(queue, 1, &submit_info, queue_submission_optional_1);
+  uint64_t post_submit_time_1 = MonotonicTimestampNs();
+  tracker.CompleteSubmits(device);
+  tracker.ResetCommandBuffer(command_buffer);
+  tracker.MarkCommandBufferBegin(command_buffer);
+  tracker.MarkDebugMarkerEnd(command_buffer);
+  tracker.MarkCommandBufferEnd(command_buffer);
+  std::optional<internal::QueueSubmission> queue_submission_optional_2 =
+      tracker.PersistCommandBuffersOnSubmit(1, &submit_info);
+  tracker.PersistDebugMarkersOnSubmit(queue, 1, &submit_info, queue_submission_optional_2);
+  tracker.CompleteSubmits(device);
+
+  EXPECT_THAT(actual_reset_slots_1, UnorderedElementsAre(kSlotIndex1, kSlotIndex3));
+  EXPECT_THAT(actual_reset_slots_2,
+              UnorderedElementsAre(kSlotIndex2, kSlotIndex4, kSlotIndex5, kSlotIndex6));
+  ASSERT_EQ(actual_capture_events.size(), 2);
+
+  const orbit_grpc_protos::CaptureEvent& actual_capture_event_1 = actual_capture_events.at(0);
+  EXPECT_TRUE(actual_capture_event_1.has_gpu_queue_submission());
+  const orbit_grpc_protos::GpuQueueSubmission& actual_queue_submission_1 =
+      actual_capture_event_1.gpu_queue_submission();
+  EXPECT_EQ(actual_queue_submission_1.num_begin_markers(), 1);
+  EXPECT_EQ(actual_queue_submission_1.completed_markers_size(), 0);
+
+  const orbit_grpc_protos::CaptureEvent& actual_capture_event_2 = actual_capture_events.at(1);
+  EXPECT_TRUE(actual_capture_event_2.has_gpu_queue_submission());
+  const orbit_grpc_protos::GpuQueueSubmission& actual_queue_submission_2 =
+      actual_capture_event_2.gpu_queue_submission();
+  EXPECT_EQ(actual_queue_submission_2.num_begin_markers(), 0);
+  EXPECT_EQ(actual_queue_submission_2.completed_markers_size(), 1);
+  const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker =
+      actual_queue_submission_2.completed_markers(0);
+
+  EXPECT_DEBUG_MARKER_END_EQ(actual_debug_marker, kTimestamp5, expected_text_key, expected_color,
+                             0);
+  EXPECT_DEBUG_MARKER_BEGIN_EQ(actual_debug_marker, kTimestamp2, pre_submit_time_1,
+                               post_submit_time_1, tid);
+}
+
+TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerAcrossTwoSubmissionsEvenWhenNotCapturingBegin) {
+  EXPECT_FOUR_NEXT_READY_QUERY_SLOT_CALLS();
+  EXPECT_CALL(dispatch_table, GetQueryPoolResults)
+      .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
+  std::vector<uint32_t> actual_reset_slots_1;
+  std::vector<uint32_t> actual_reset_slots_2;
+  EXPECT_CALL(timer_query_pool, ResetQuerySlots)
+      .Times(2)
+      .WillOnce(SaveArg<1>(&actual_reset_slots_1))
+      .WillOnce(SaveArg<1>(&actual_reset_slots_2));
+  std::vector<orbit_grpc_protos::CaptureEvent> actual_capture_events;
+  auto mock_enqueue_capture_event =
+      [&actual_capture_events](orbit_grpc_protos::CaptureEvent&& capture_event) {
+        actual_capture_events.emplace_back(std::move(capture_event));
+        return true;
+      };
+
+  const char* text = "Text";
+  constexpr uint64_t expected_text_key = 111;
+  auto mock_intern_string_if_necessary_and_get_key = [&text](std::string str) {
+    EXPECT_STREQ(text, str.c_str());
+    return expected_text_key;
+  };
+  EXPECT_CALL(*producer, InternStringIfNecessaryAndGetKey)
+      .Times(1)
+      .WillOnce(Invoke(mock_intern_string_if_necessary_and_get_key));
+  EXPECT_CALL(*producer, EnqueueCaptureEvent)
+      .Times(2)
+      .WillRepeatedly(Invoke(mock_enqueue_capture_event));
+
+  internal::Color expected_color{1.f, 0.8f, 0.6f, 0.4f};
+
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.MarkCommandBufferBegin(command_buffer);
+  tracker.MarkDebugMarkerBegin(command_buffer, text, expected_color);
+  producer->StartCapture();
+  tracker.MarkCommandBufferEnd(command_buffer);
+  std::optional<internal::QueueSubmission> queue_submission_optional_1 =
+      tracker.PersistCommandBuffersOnSubmit(1, &submit_info);
+  tracker.PersistDebugMarkersOnSubmit(queue, 1, &submit_info, queue_submission_optional_1);
+  tracker.CompleteSubmits(device);
+  tracker.ResetCommandBuffer(command_buffer);
+  tracker.MarkCommandBufferBegin(command_buffer);
+  tracker.MarkDebugMarkerEnd(command_buffer);
+  tracker.MarkCommandBufferEnd(command_buffer);
+  std::optional<internal::QueueSubmission> queue_submission_optional_2 =
+      tracker.PersistCommandBuffersOnSubmit(1, &submit_info);
+  tracker.PersistDebugMarkersOnSubmit(queue, 1, &submit_info, queue_submission_optional_2);
+  tracker.CompleteSubmits(device);
+
+  EXPECT_THAT(actual_reset_slots_1, UnorderedElementsAre(kSlotIndex1));
+  EXPECT_THAT(actual_reset_slots_2, UnorderedElementsAre(kSlotIndex2, kSlotIndex3, kSlotIndex4));
+  ASSERT_EQ(actual_capture_events.size(), 2);
+
+  const orbit_grpc_protos::CaptureEvent& actual_capture_event_1 = actual_capture_events.at(0);
+  EXPECT_TRUE(actual_capture_event_1.has_gpu_queue_submission());
+  const orbit_grpc_protos::GpuQueueSubmission& actual_queue_submission_1 =
+      actual_capture_event_1.gpu_queue_submission();
+  EXPECT_EQ(actual_queue_submission_1.num_begin_markers(), 0);
+  EXPECT_EQ(actual_queue_submission_1.completed_markers_size(), 0);
+
+  const orbit_grpc_protos::CaptureEvent& actual_capture_event_2 = actual_capture_events.at(1);
+  EXPECT_TRUE(actual_capture_event_2.has_gpu_queue_submission());
+  const orbit_grpc_protos::GpuQueueSubmission& actual_queue_submission_2 =
+      actual_capture_event_2.gpu_queue_submission();
+  EXPECT_EQ(actual_queue_submission_2.num_begin_markers(), 0);
+  EXPECT_EQ(actual_queue_submission_2.completed_markers_size(), 1);
+  const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker =
+      actual_queue_submission_2.completed_markers(0);
+
+  EXPECT_DEBUG_MARKER_END_EQ(actual_debug_marker, kTimestamp3, expected_text_key, expected_color,
+                             0);
+  EXPECT_FALSE(actual_debug_marker.has_begin_marker());
+}
+
+TEST_F(SubmissionTrackerTest, ResetSlotsOnDebugMarkerAcrossTwoSubmissionsWhenNotCapturingEnd) {
+  EXPECT_THREE_NEXT_READY_QUERY_SLOT_CALLS();
+  EXPECT_CALL(dispatch_table, GetQueryPoolResults)
+      .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
+  std::vector<uint32_t> actual_reset_slots_1;
+  std::vector<uint32_t> actual_reset_slots_2;
+  EXPECT_CALL(timer_query_pool, ResetQuerySlots)
+      .Times(2)
+      .WillOnce(SaveArg<1>(&actual_reset_slots_1))
+      .WillOnce(SaveArg<1>(&actual_reset_slots_2));
+  orbit_grpc_protos::CaptureEvent actual_capture_event;
+  auto mock_enqueue_capture_event =
+      [&actual_capture_event](orbit_grpc_protos::CaptureEvent&& capture_event) {
+        actual_capture_event = std::move(capture_event);
+        return true;
+      };
+
+  const char* text = "Text";
+  EXPECT_CALL(*producer, InternStringIfNecessaryAndGetKey).Times(0);
+  EXPECT_CALL(*producer, EnqueueCaptureEvent).Times(1).WillOnce(Invoke(mock_enqueue_capture_event));
+
+  internal::Color expected_color{1.f, 0.8f, 0.6f, 0.4f};
+
+  producer->StartCapture();
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.MarkCommandBufferBegin(command_buffer);
+  tracker.MarkDebugMarkerBegin(command_buffer, text, expected_color);
+  tracker.MarkCommandBufferEnd(command_buffer);
+  std::optional<internal::QueueSubmission> queue_submission_optional_1 =
+      tracker.PersistCommandBuffersOnSubmit(1, &submit_info);
+  tracker.PersistDebugMarkersOnSubmit(queue, 1, &submit_info, queue_submission_optional_1);
+  tracker.CompleteSubmits(device);
+
+  producer->StopCapture();
+  tracker.ResetCommandBuffer(command_buffer);
+  tracker.MarkCommandBufferBegin(command_buffer);
+  tracker.MarkDebugMarkerEnd(command_buffer);
+  tracker.MarkCommandBufferEnd(command_buffer);
+  std::optional<internal::QueueSubmission> queue_submission_optional_2 =
+      tracker.PersistCommandBuffersOnSubmit(1, &submit_info);
+  tracker.PersistDebugMarkersOnSubmit(queue, 1, &submit_info, queue_submission_optional_2);
+  tracker.CompleteSubmits(device);
+
+  EXPECT_THAT(actual_reset_slots_1, UnorderedElementsAre(kSlotIndex1, kSlotIndex3));
+  EXPECT_THAT(actual_reset_slots_2, UnorderedElementsAre(kSlotIndex2));
+
+  EXPECT_TRUE(actual_capture_event.has_gpu_queue_submission());
+  const orbit_grpc_protos::GpuQueueSubmission& actual_queue_submission =
+      actual_capture_event.gpu_queue_submission();
+  EXPECT_EQ(actual_queue_submission.num_begin_markers(), 1);
+  EXPECT_EQ(actual_queue_submission.completed_markers_size(), 0);
+}
+
+TEST_F(SubmissionTrackerTest, ResetDebugMarkerSlotsWhenStopBeforeASubmission) {
+  EXPECT_FOUR_NEXT_READY_QUERY_SLOT_CALLS();
+  EXPECT_CALL(dispatch_table, GetQueryPoolResults).Times(0);
+  std::vector<uint32_t> actual_reset_slots;
+  EXPECT_CALL(timer_query_pool, ResetQuerySlots).Times(1).WillOnce(SaveArg<1>(&actual_reset_slots));
+  EXPECT_CALL(*producer, EnqueueCaptureEvent).Times(0);
+  const char* text = "Text";
+
+  internal::Color expected_color{1.f, 0.8f, 0.6f, 0.4f};
+
+  producer->StartCapture();
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.MarkCommandBufferBegin(command_buffer);
+  tracker.MarkDebugMarkerBegin(command_buffer, text, expected_color);
+  tracker.MarkDebugMarkerEnd(command_buffer);
+  tracker.MarkCommandBufferEnd(command_buffer);
+  producer->StopCapture();
+  std::optional<internal::QueueSubmission> queue_submission_optional =
+      tracker.PersistCommandBuffersOnSubmit(1, &submit_info);
+  tracker.PersistDebugMarkersOnSubmit(queue, 1, &submit_info, queue_submission_optional);
+  tracker.CompleteSubmits(device);
+
+  EXPECT_THAT(actual_reset_slots,
+              UnorderedElementsAre(kSlotIndex1, kSlotIndex2, kSlotIndex3, kSlotIndex4));
+}
+
+TEST_F(SubmissionTrackerTest, CanLimitNextedDebugMarkerDepthPerCommandBuffer) {
+  tracker.SetMaxLocalMarkerDepthPerCommandBuffer(1);
+
+  EXPECT_FOUR_NEXT_READY_QUERY_SLOT_CALLS();
+  EXPECT_CALL(dispatch_table, GetQueryPoolResults)
+      .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
+  std::vector<uint32_t> actual_reset_slots;
+  EXPECT_CALL(timer_query_pool, ResetQuerySlots).Times(1).WillOnce(SaveArg<1>(&actual_reset_slots));
+  orbit_grpc_protos::CaptureEvent actual_capture_event;
+  auto mock_enqueue_capture_event =
+      [&actual_capture_event](orbit_grpc_protos::CaptureEvent&& capture_event) {
+        actual_capture_event = std::move(capture_event);
+        return true;
+      };
+
+  const std::string text_outer = "Outer";
+  const std::string text_inner = "Inner";
+  constexpr uint64_t expected_text_key_outer = 111;
+  auto mock_intern_string_if_necessary_and_get_key = [&text_outer](std::string str) {
+    if (str == text_outer) {
+      return expected_text_key_outer;
+    }
+    UNREACHABLE();
+  };
+  EXPECT_CALL(*producer, InternStringIfNecessaryAndGetKey)
+      .Times(1)
+      .WillOnce(Invoke(mock_intern_string_if_necessary_and_get_key));
+  EXPECT_CALL(*producer, EnqueueCaptureEvent).Times(1).WillOnce(Invoke(mock_enqueue_capture_event));
+
+  internal::Color expected_color{1.f, 0.8f, 0.6f, 0.4f};
+
+  producer->StartCapture();
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.MarkCommandBufferBegin(command_buffer);
+  tracker.MarkDebugMarkerBegin(command_buffer, text_outer.c_str(), expected_color);
+  tracker.MarkDebugMarkerBegin(command_buffer, text_inner.c_str(), expected_color);
+  tracker.MarkDebugMarkerEnd(command_buffer);
+  tracker.MarkDebugMarkerEnd(command_buffer);
+  tracker.MarkCommandBufferEnd(command_buffer);
+  pid_t tid = GetCurrentThreadId();
+  uint64_t pre_submit_time = MonotonicTimestampNs();
+  std::optional<internal::QueueSubmission> queue_submission_optional =
+      tracker.PersistCommandBuffersOnSubmit(1, &submit_info);
+  tracker.PersistDebugMarkersOnSubmit(queue, 1, &submit_info, queue_submission_optional);
+  uint64_t post_submit_time = MonotonicTimestampNs();
+  tracker.CompleteSubmits(device);
+
+  EXPECT_THAT(actual_reset_slots,
+              UnorderedElementsAre(kSlotIndex1, kSlotIndex2, kSlotIndex3, kSlotIndex4));
+  EXPECT_TRUE(actual_capture_event.has_gpu_queue_submission());
+  const orbit_grpc_protos::GpuQueueSubmission& actual_queue_submission =
+      actual_capture_event.gpu_queue_submission();
+  EXPECT_EQ(actual_queue_submission.num_begin_markers(), 1);
+  EXPECT_EQ(actual_queue_submission.completed_markers_size(), 1);
+  const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker_outer =
+      actual_queue_submission.completed_markers(0);
+
+  EXPECT_DEBUG_MARKER_END_EQ(actual_debug_marker_outer, kTimestamp3, expected_text_key_outer,
+                             expected_color, 0);
+  EXPECT_DEBUG_MARKER_BEGIN_EQ(actual_debug_marker_outer, kTimestamp2, pre_submit_time,
+                               post_submit_time, tid);
+
+}  // namespace orbit_vulkan_layer
+
+TEST_F(SubmissionTrackerTest, CanLimitNextedDebugMarkerDepthPerCommandBufferAcrossSubmissions) {
+  tracker.SetMaxLocalMarkerDepthPerCommandBuffer(1);
+  EXPECT_SEVEN_NEXT_READY_QUERY_SLOT_CALLS();
+  EXPECT_CALL(dispatch_table, GetQueryPoolResults)
+      .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
+
+  std::vector<uint32_t> actual_reset_slots;
+  auto mock_reset_query_slots = [&actual_reset_slots](VkDevice /*device*/,
+                                                      const std::vector<uint32_t> slots_to_reset) {
+    actual_reset_slots.insert(actual_reset_slots.end(), slots_to_reset.begin(),
+                              slots_to_reset.end());
+  };
+  std::vector<uint32_t> actual_reset_slots_2;
+  EXPECT_CALL(timer_query_pool, ResetQuerySlots).WillRepeatedly(Invoke(mock_reset_query_slots));
+
+  std::vector<orbit_grpc_protos::CaptureEvent> actual_capture_events;
+  auto mock_enqueue_capture_event =
+      [&actual_capture_events](orbit_grpc_protos::CaptureEvent&& capture_event) {
+        actual_capture_events.emplace_back(std::move(capture_event));
+        return true;
+      };
+
+  const std::string text_outer = "Outer";
+  const std::string text_inner = "Inner";
+  constexpr uint64_t expected_outer_text_key = 111;
+  auto mock_intern_string_if_necessary_and_get_key = [&text_outer](std::string str) {
+    EXPECT_EQ(text_outer, str);
+    return expected_outer_text_key;
+  };
+  EXPECT_CALL(*producer, InternStringIfNecessaryAndGetKey)
+      .Times(1)
+      .WillOnce(Invoke(mock_intern_string_if_necessary_and_get_key));
+  EXPECT_CALL(*producer, EnqueueCaptureEvent)
+      .Times(2)
+      .WillRepeatedly(Invoke(mock_enqueue_capture_event));
+
+  internal::Color expected_color{1.f, 0.8f, 0.6f, 0.4f};
+
+  pid_t tid = GetCurrentThreadId();
+
+  producer->StartCapture();
+  tracker.TrackCommandBuffers(device, command_pool, &command_buffer, 1);
+  tracker.MarkCommandBufferBegin(command_buffer);                                    // timestamp 1
+  tracker.MarkDebugMarkerBegin(command_buffer, text_outer.c_str(), expected_color);  // timestamp 2
+  tracker.MarkDebugMarkerBegin(command_buffer, text_inner.c_str(), expected_color);  // cut-off
+  tracker.MarkCommandBufferEnd(command_buffer);                                      // timestamp 3
+  uint64_t pre_submit_time_1 = MonotonicTimestampNs();
+  std::optional<internal::QueueSubmission> queue_submission_optional_1 =
+      tracker.PersistCommandBuffersOnSubmit(1, &submit_info);
+  tracker.PersistDebugMarkersOnSubmit(queue, 1, &submit_info, queue_submission_optional_1);
+  uint64_t post_submit_time_1 = MonotonicTimestampNs();
+  tracker.CompleteSubmits(device);
+
+  tracker.ResetCommandBuffer(command_buffer);
+  tracker.MarkCommandBufferBegin(command_buffer);  // timestamp 4
+  tracker.MarkDebugMarkerEnd(command_buffer);      // timestamp 5 - we can't know now to cut-off
+  tracker.MarkDebugMarkerEnd(command_buffer);      // timestamp 6
+  tracker.MarkCommandBufferEnd(command_buffer);    // timestamp 7
+  std::optional<internal::QueueSubmission> queue_submission_optional_2 =
+      tracker.PersistCommandBuffersOnSubmit(1, &submit_info);
+  tracker.PersistDebugMarkersOnSubmit(queue, 1, &submit_info, queue_submission_optional_2);
+  tracker.CompleteSubmits(device);
+
+  EXPECT_THAT(actual_reset_slots,
+              UnorderedElementsAre(kSlotIndex1, kSlotIndex2, kSlotIndex3, kSlotIndex4, kSlotIndex5,
+                                   kSlotIndex6, kSlotIndex7));
+  ASSERT_EQ(actual_capture_events.size(), 2);
+
+  const orbit_grpc_protos::CaptureEvent& actual_capture_event_1 = actual_capture_events.at(0);
+  EXPECT_TRUE(actual_capture_event_1.has_gpu_queue_submission());
+  const orbit_grpc_protos::GpuQueueSubmission& actual_queue_submission_1 =
+      actual_capture_event_1.gpu_queue_submission();
+  EXPECT_EQ(actual_queue_submission_1.num_begin_markers(), 1);
+  EXPECT_EQ(actual_queue_submission_1.completed_markers_size(), 0);
+
+  const orbit_grpc_protos::CaptureEvent& actual_capture_event_2 = actual_capture_events.at(1);
+  EXPECT_TRUE(actual_capture_event_2.has_gpu_queue_submission());
+  const orbit_grpc_protos::GpuQueueSubmission& actual_queue_submission_2 =
+      actual_capture_event_2.gpu_queue_submission();
+  EXPECT_EQ(actual_queue_submission_2.num_begin_markers(), 0);
+  EXPECT_EQ(actual_queue_submission_2.completed_markers_size(), 1);
+  const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker =
+      actual_queue_submission_2.completed_markers(0);
+
+  EXPECT_DEBUG_MARKER_END_EQ(actual_debug_marker, kTimestamp6, expected_outer_text_key,
+                             expected_color, 0);
+  EXPECT_DEBUG_MARKER_BEGIN_EQ(actual_debug_marker, kTimestamp2, pre_submit_time_1,
+                               post_submit_time_1, tid);
+}
+
+}  // namespace orbit_vulkan_layer

--- a/OrbitVulkanLayer/SubmissionTrackerTest.cpp
+++ b/OrbitVulkanLayer/SubmissionTrackerTest.cpp
@@ -432,7 +432,7 @@ TEST_F(SubmissionTrackerTest, MarkCommandBufferEndWontWriteTimestampsWhenNotCapt
   tracker_.MarkCommandBufferEnd(command_buffer_);
 }
 
-TEST_F(SubmissionTrackerTest, MarkCommandBufferEndWillWriteTimestampsWhenNotCapturedBegin) {
+TEST_F(SubmissionTrackerTest, MarkCommandBufferEndWillWriteTimestampsWhenBeginNotCaptured) {
   static bool was_called = false;
 
   PFN_vkCmdWriteTimestamp mock_write_timestamp_function =
@@ -494,7 +494,7 @@ TEST_F(SubmissionTrackerTest, CanRetrieveCommandBufferTimestampsForACompleteSubm
 }
 
 TEST_F(SubmissionTrackerTest,
-       CanRetrieveCommandBufferTimestampsForACompleteSubmissionAtSecondPresent) {
+       CanRetrieveCommandBufferTimestampsForACompleteSubmissionAtALaterTime) {
   ExpectTwoNextReadyQuerySlotCalls();
   EXPECT_CALL(dispatch_table_, GetQueryPoolResults)
       .WillOnce(Return(mock_get_query_pool_results_function_not_ready_))
@@ -842,7 +842,7 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerTimestampsForACompleteSubmis
                            tid);
 }
 
-TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerEndEvenWhenNotCapturedBegin) {
+TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerEndEvenWhenBeginNotCaptured) {
   ExpectTwoNextReadyQuerySlotCalls();
   EXPECT_CALL(dispatch_table_, GetQueryPoolResults)
       .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready_));
@@ -896,7 +896,7 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerEndEvenWhenNotCapturedBegin)
   EXPECT_FALSE(actual_debug_marker.has_begin_marker());
 }
 
-TEST_F(SubmissionTrackerTest, CanRetrieveNextedDebugMarkerTimestampsForACompleteSubmission) {
+TEST_F(SubmissionTrackerTest, CanRetrieveNestedDebugMarkerTimestampsForACompleteSubmission) {
   ExpectSixNextReadyQuerySlotCalls();
   EXPECT_CALL(dispatch_table_, GetQueryPoolResults)
       .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready_));
@@ -1128,7 +1128,7 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerAcrossTwoSubmissions) {
                            tid);
 }
 
-TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerAcrossTwoSubmissionsEvenWhenNotCapturingBegin) {
+TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerAcrossTwoSubmissionsEvenWhenBeginNotCaptured) {
   ExpectFourNextReadyQuerySlotCalls();
   EXPECT_CALL(dispatch_table_, GetQueryPoolResults)
       .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready_));
@@ -1202,7 +1202,7 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerAcrossTwoSubmissionsEvenWhen
   EXPECT_FALSE(actual_debug_marker.has_begin_marker());
 }
 
-TEST_F(SubmissionTrackerTest, ResetSlotsOnDebugMarkerAcrossTwoSubmissionsWhenNotCapturingEnd) {
+TEST_F(SubmissionTrackerTest, ResetSlotsOnDebugMarkerAcrossTwoSubmissionsWhenEndNotCaptured) {
   ExpectThreeNextReadyQuerySlotCalls();
   EXPECT_CALL(dispatch_table_, GetQueryPoolResults)
       .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready_));
@@ -1285,7 +1285,7 @@ TEST_F(SubmissionTrackerTest, ResetDebugMarkerSlotsWhenStopBeforeASubmission) {
               UnorderedElementsAre(kSlotIndex1, kSlotIndex2, kSlotIndex3, kSlotIndex4));
 }
 
-TEST_F(SubmissionTrackerTest, CanLimitNextedDebugMarkerDepthPerCommandBuffer) {
+TEST_F(SubmissionTrackerTest, CanLimitNestedDebugMarkerDepthPerCommandBuffer) {
   tracker_.SetMaxLocalMarkerDepthPerCommandBuffer(1);
 
   ExpectFourNextReadyQuerySlotCalls();
@@ -1352,7 +1352,7 @@ TEST_F(SubmissionTrackerTest, CanLimitNextedDebugMarkerDepthPerCommandBuffer) {
                            post_submit_time, tid);
 }
 
-TEST_F(SubmissionTrackerTest, CanLimitNextedDebugMarkerDepthPerCommandBufferAcrossSubmissions) {
+TEST_F(SubmissionTrackerTest, CanLimitNestedDebugMarkerDepthPerCommandBufferAcrossSubmissions) {
   tracker_.SetMaxLocalMarkerDepthPerCommandBuffer(1);
   ExpectSevenNextReadyQuerySlotCalls();
   EXPECT_CALL(dispatch_table_, GetQueryPoolResults)

--- a/OrbitVulkanLayer/SubmissionTrackerTest.cpp
+++ b/OrbitVulkanLayer/SubmissionTrackerTest.cpp
@@ -92,7 +92,7 @@ class SubmissionTrackerTest : public ::testing::Test {
     EXPECT_CALL(*producer_, SetCaptureStatusListener)
         .Times(1)
         .WillOnce(Invoke(set_capture_status_listener_function));
-    tracker.SetVulkanLayerProducer(producer_.get());
+    tracker_.SetVulkanLayerProducer(producer_.get());
     auto is_capturing_function = [this]() -> bool { return producer_->is_capturing_; };
     EXPECT_CALL(*producer_, IsCapturing).WillRepeatedly(Invoke(is_capturing_function));
     EXPECT_CALL(timer_query_pool_, GetQueryPool).WillRepeatedly(Return(query_pool_));

--- a/OrbitVulkanLayer/SubmissionTrackerTest.cpp
+++ b/OrbitVulkanLayer/SubmissionTrackerTest.cpp
@@ -107,7 +107,8 @@ class SubmissionTrackerTest : public ::testing::Test {
   std::unique_ptr<MockVulkanLayerProducer> producer;
   SubmissionTracker<MockDispatchTable, MockDeviceManager, MockTimerQueryPool> tracker =
       SubmissionTracker<MockDispatchTable, MockDeviceManager, MockTimerQueryPool>(
-          0, &dispatch_table, &timer_query_pool, &device_manager);
+          std::numeric_limits<uint32_t>::max(), &dispatch_table, &timer_query_pool,
+          &device_manager);
 
   VkDevice device = {};
   VkCommandPool command_pool = {};
@@ -329,7 +330,7 @@ TEST(SubmissionTracker, CanBeInitialized) {
   MockTimerQueryPool timer_query_pool;
   MockDeviceManager device_manager;
   SubmissionTracker<MockDispatchTable, MockDeviceManager, MockTimerQueryPool> tracker(
-      0, &dispatch_table, &timer_query_pool, &device_manager);
+      std::numeric_limits<uint32_t>::max(), &dispatch_table, &timer_query_pool, &device_manager);
 }
 
 TEST(SubmissionTracker, SetVulkanLayerProducerWillCallSetListener) {
@@ -339,7 +340,7 @@ TEST(SubmissionTracker, SetVulkanLayerProducerWillCallSetListener) {
   std::unique_ptr<MockVulkanLayerProducer> producer = std::make_unique<MockVulkanLayerProducer>();
 
   SubmissionTracker<MockDispatchTable, MockDeviceManager, MockTimerQueryPool> tracker(
-      0, &dispatch_table, &timer_query_pool, &device_manager);
+      std::numeric_limits<uint32_t>::max(), &dispatch_table, &timer_query_pool, &device_manager);
 
   VulkanLayerProducer::CaptureStatusListener* actual_listener;
   EXPECT_CALL(*producer, SetCaptureStatusListener).Times(1).WillOnce(SaveArg<0>(&actual_listener));

--- a/OrbitVulkanLayer/SubmissionTrackerTest.cpp
+++ b/OrbitVulkanLayer/SubmissionTrackerTest.cpp
@@ -130,47 +130,40 @@ class SubmissionTrackerTest : public ::testing::Test {
   static constexpr uint32_t kSlotIndex6 = 37;
   static constexpr uint32_t kSlotIndex7 = 38;
 
-  const std::function<bool(VkDevice, uint32_t*)> mock_next_ready_query_slot_function_1 =
-      [](VkDevice /*device*/, uint32_t* allocated_slot) -> bool {
+  static bool MockNextReadyQuerySlot1(VkDevice /*device*/, uint32_t* allocated_slot) {
     *allocated_slot = kSlotIndex1;
     return true;
-  };
+  }
 
-  const std::function<bool(VkDevice, uint32_t*)> mock_next_ready_query_slot_function_2 =
-      [](VkDevice /*device*/, uint32_t* allocated_slot) -> bool {
+  static bool MockNextReadyQuerySlot2(VkDevice /*device*/, uint32_t* allocated_slot) {
     *allocated_slot = kSlotIndex2;
     return true;
-  };
+  }
 
-  const std::function<bool(VkDevice, uint32_t*)> mock_next_ready_query_slot_function_3 =
-      [](VkDevice /*device*/, uint32_t* allocated_slot) -> bool {
+  static bool MockNextReadyQuerySlot3(VkDevice /*device*/, uint32_t* allocated_slot) {
     *allocated_slot = kSlotIndex3;
     return true;
-  };
+  }
 
-  const std::function<bool(VkDevice, uint32_t*)> mock_next_ready_query_slot_function_4 =
-      [](VkDevice /*device*/, uint32_t* allocated_slot) -> bool {
+  static bool MockNextReadyQuerySlot4(VkDevice /*device*/, uint32_t* allocated_slot) {
     *allocated_slot = kSlotIndex4;
     return true;
-  };
+  }
 
-  const std::function<bool(VkDevice, uint32_t*)> mock_next_ready_query_slot_function_5 =
-      [](VkDevice /*device*/, uint32_t* allocated_slot) -> bool {
+  static bool MockNextReadyQuerySlot5(VkDevice /*device*/, uint32_t* allocated_slot) {
     *allocated_slot = kSlotIndex5;
     return true;
-  };
+  }
 
-  const std::function<bool(VkDevice, uint32_t*)> mock_next_ready_query_slot_function_6 =
-      [](VkDevice /*device*/, uint32_t* allocated_slot) -> bool {
+  static bool MockNextReadyQuerySlot6(VkDevice /*device*/, uint32_t* allocated_slot) {
     *allocated_slot = kSlotIndex6;
     return true;
-  };
+  }
 
-  const std::function<bool(VkDevice, uint32_t*)> mock_next_ready_query_slot_function_7 =
-      [](VkDevice /*device*/, uint32_t* allocated_slot) -> bool {
+  static bool MockNextReadyQuerySlot7(VkDevice /*device*/, uint32_t* allocated_slot) {
     *allocated_slot = kSlotIndex7;
     return true;
-  };
+  }
 
   static constexpr uint64_t kTimestamp1 = 11;
   static constexpr uint64_t kTimestamp2 = 12;
@@ -219,7 +212,7 @@ class SubmissionTrackerTest : public ::testing::Test {
           uint32_t /*query_count*/, size_t /*dataSize*/, void* /*data*/, VkDeviceSize /*stride*/,
           VkQueryResultFlags /*flags*/) -> VkResult { return VK_NOT_READY; };
 
-  void EXPECT_SINGLE_COMMAND_BUFFER_SUBMISSION_EQ(
+  static void ExpectSingleCommandBufferSubmissionEq(
       const orbit_grpc_protos::CaptureEvent& actual_capture_event, uint64_t test_pre_submit_time,
       uint64_t test_post_submit_time, pid_t expected_tid,
       uint64_t expected_command_buffer_begin_timestamp,
@@ -228,8 +221,8 @@ class SubmissionTrackerTest : public ::testing::Test {
     const orbit_grpc_protos::GpuQueueSubmission& actual_queue_submission =
         actual_capture_event.gpu_queue_submission();
 
-    EXPECT_SUBMIT_EQ(actual_queue_submission.meta_info(), test_pre_submit_time,
-                     test_post_submit_time, expected_tid);
+    ExpectSubmitEq(actual_queue_submission.meta_info(), test_pre_submit_time, test_post_submit_time,
+                   expected_tid);
 
     ASSERT_EQ(actual_queue_submission.submit_infos_size(), 1);
     const orbit_grpc_protos::GpuSubmitInfo& actual_submit_info =
@@ -244,9 +237,9 @@ class SubmissionTrackerTest : public ::testing::Test {
     EXPECT_EQ(expected_command_buffer_end_timestamp, actual_command_buffer.end_gpu_timestamp_ns());
   }
 
-  void EXPECT_SUBMIT_EQ(const orbit_grpc_protos::GpuQueueSubmissionMetaInfo& actual_meta_info,
-                        int64_t test_pre_submit_time, uint64_t test_post_submit_time,
-                        pid_t expected_tid) {
+  static void ExpectSubmitEq(const orbit_grpc_protos::GpuQueueSubmissionMetaInfo& actual_meta_info,
+                             int64_t test_pre_submit_time, uint64_t test_post_submit_time,
+                             pid_t expected_tid) {
     EXPECT_LE(test_pre_submit_time, actual_meta_info.pre_submission_cpu_timestamp());
     EXPECT_LE(actual_meta_info.pre_submission_cpu_timestamp(),
               actual_meta_info.post_submission_cpu_timestamp());
@@ -254,9 +247,9 @@ class SubmissionTrackerTest : public ::testing::Test {
     EXPECT_EQ(expected_tid, actual_meta_info.tid());
   }
 
-  void EXPECT_DEBUG_MARKER_END_EQ(const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker,
-                                  uint64_t expected_end_timestamp, uint64_t expected_text_key,
-                                  internal::Color expected_color, int32_t expected_depth) {
+  static void ExpectDebugMarkerEndEq(const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker,
+                                     uint64_t expected_end_timestamp, uint64_t expected_text_key,
+                                     internal::Color expected_color, int32_t expected_depth) {
     EXPECT_EQ(actual_debug_marker.end_gpu_timestamp_ns(), expected_end_timestamp);
     EXPECT_EQ(actual_debug_marker.color().red(), expected_color.red);
     EXPECT_EQ(actual_debug_marker.color().green(), expected_color.green);
@@ -266,62 +259,62 @@ class SubmissionTrackerTest : public ::testing::Test {
     EXPECT_EQ(actual_debug_marker.depth(), expected_depth);
   }
 
-  void EXPECT_DEBUG_MARKER_BEGIN_EQ(const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker,
-                                    uint64_t expected_timestamp, int64_t test_pre_submit_time,
-                                    uint64_t test_post_submit_time, pid_t expected_tid) {
+  static void ExpectDebugMarkerBeginEq(const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker,
+                                       uint64_t expected_timestamp, int64_t test_pre_submit_time,
+                                       uint64_t test_post_submit_time, pid_t expected_tid) {
     ASSERT_TRUE(actual_debug_marker.has_begin_marker());
     EXPECT_EQ(actual_debug_marker.begin_marker().gpu_timestamp_ns(), expected_timestamp);
     const orbit_grpc_protos::GpuQueueSubmissionMetaInfo& actual_begin_marker_meta_info =
         actual_debug_marker.begin_marker().meta_info();
-    EXPECT_SUBMIT_EQ(actual_begin_marker_meta_info, test_pre_submit_time, test_post_submit_time,
-                     expected_tid);
+    ExpectSubmitEq(actual_begin_marker_meta_info, test_pre_submit_time, test_post_submit_time,
+                   expected_tid);
   }
 
-  void EXPECT_TWO_NEXT_READY_QUERY_SLOT_CALLS() {
+  void ExpectTwoNextReadyQuerySlotCalls() {
     EXPECT_CALL(timer_query_pool, NextReadyQuerySlot)
         .Times(2)
-        .WillOnce(Invoke(mock_next_ready_query_slot_function_1))
-        .WillOnce(Invoke(mock_next_ready_query_slot_function_2));
+        .WillOnce(Invoke(MockNextReadyQuerySlot1))
+        .WillOnce(Invoke(MockNextReadyQuerySlot2));
   }
 
-  void EXPECT_THREE_NEXT_READY_QUERY_SLOT_CALLS() {
+  void ExpectThreeNextReadyQuerySlotCalls() {
     EXPECT_CALL(timer_query_pool, NextReadyQuerySlot)
         .Times(3)
-        .WillOnce(Invoke(mock_next_ready_query_slot_function_1))
-        .WillOnce(Invoke(mock_next_ready_query_slot_function_2))
-        .WillOnce(Invoke(mock_next_ready_query_slot_function_3));
+        .WillOnce(Invoke(MockNextReadyQuerySlot1))
+        .WillOnce(Invoke(MockNextReadyQuerySlot2))
+        .WillOnce(Invoke(MockNextReadyQuerySlot3));
   }
 
-  void EXPECT_FOUR_NEXT_READY_QUERY_SLOT_CALLS() {
+  void ExpectFourNextReadyQuerySlotCalls() {
     EXPECT_CALL(timer_query_pool, NextReadyQuerySlot)
         .Times(4)
-        .WillOnce(Invoke(mock_next_ready_query_slot_function_1))
-        .WillOnce(Invoke(mock_next_ready_query_slot_function_2))
-        .WillOnce(Invoke(mock_next_ready_query_slot_function_3))
-        .WillOnce(Invoke(mock_next_ready_query_slot_function_4));
+        .WillOnce(Invoke(MockNextReadyQuerySlot1))
+        .WillOnce(Invoke(MockNextReadyQuerySlot2))
+        .WillOnce(Invoke(MockNextReadyQuerySlot3))
+        .WillOnce(Invoke(MockNextReadyQuerySlot4));
   }
 
-  void EXPECT_SIX_NEXT_READY_QUERY_SLOT_CALLS() {
+  void ExpectSixNextReadyQuerySlotCalls() {
     EXPECT_CALL(timer_query_pool, NextReadyQuerySlot)
         .Times(6)
-        .WillOnce(Invoke(mock_next_ready_query_slot_function_1))
-        .WillOnce(Invoke(mock_next_ready_query_slot_function_2))
-        .WillOnce(Invoke(mock_next_ready_query_slot_function_3))
-        .WillOnce(Invoke(mock_next_ready_query_slot_function_4))
-        .WillOnce(Invoke(mock_next_ready_query_slot_function_5))
-        .WillOnce(Invoke(mock_next_ready_query_slot_function_6));
+        .WillOnce(Invoke(MockNextReadyQuerySlot1))
+        .WillOnce(Invoke(MockNextReadyQuerySlot2))
+        .WillOnce(Invoke(MockNextReadyQuerySlot3))
+        .WillOnce(Invoke(MockNextReadyQuerySlot4))
+        .WillOnce(Invoke(MockNextReadyQuerySlot5))
+        .WillOnce(Invoke(MockNextReadyQuerySlot6));
   }
 
-  void EXPECT_SEVEN_NEXT_READY_QUERY_SLOT_CALLS() {
+  void ExpectSevenNextReadyQuerySlotCalls() {
     EXPECT_CALL(timer_query_pool, NextReadyQuerySlot)
         .Times(7)
-        .WillOnce(Invoke(mock_next_ready_query_slot_function_1))
-        .WillOnce(Invoke(mock_next_ready_query_slot_function_2))
-        .WillOnce(Invoke(mock_next_ready_query_slot_function_3))
-        .WillOnce(Invoke(mock_next_ready_query_slot_function_4))
-        .WillOnce(Invoke(mock_next_ready_query_slot_function_5))
-        .WillOnce(Invoke(mock_next_ready_query_slot_function_6))
-        .WillOnce(Invoke(mock_next_ready_query_slot_function_7));
+        .WillOnce(Invoke(MockNextReadyQuerySlot1))
+        .WillOnce(Invoke(MockNextReadyQuerySlot2))
+        .WillOnce(Invoke(MockNextReadyQuerySlot3))
+        .WillOnce(Invoke(MockNextReadyQuerySlot4))
+        .WillOnce(Invoke(MockNextReadyQuerySlot5))
+        .WillOnce(Invoke(MockNextReadyQuerySlot6))
+        .WillOnce(Invoke(MockNextReadyQuerySlot7));
   }
 };
 
@@ -378,7 +371,7 @@ TEST_F(SubmissionTrackerTest, MarkCommandBufferBeginWillWriteTimestampWhenCaptur
 
   EXPECT_CALL(timer_query_pool, NextReadyQuerySlot)
       .Times(1)
-      .WillOnce(Invoke(mock_next_ready_query_slot_function_1));
+      .WillOnce(Invoke(MockNextReadyQuerySlot1));
   EXPECT_CALL(dispatch_table, CmdWriteTimestamp)
       .Times(1)
       .WillOnce(Return(mock_write_timestamp_function));
@@ -394,7 +387,7 @@ TEST_F(SubmissionTrackerTest, MarkCommandBufferBeginWillWriteTimestampWhenCaptur
 TEST_F(SubmissionTrackerTest, ResetCommandBufferShouldRollbackUnsubmittedSlots) {
   EXPECT_CALL(timer_query_pool, NextReadyQuerySlot)
       .Times(1)
-      .WillOnce(Invoke(mock_next_ready_query_slot_function_1));
+      .WillOnce(Invoke(MockNextReadyQuerySlot1));
   std::vector<uint32_t> actual_slots_to_rollback;
   EXPECT_CALL(timer_query_pool, RollbackPendingQuerySlots)
       .Times(1)
@@ -411,7 +404,7 @@ TEST_F(SubmissionTrackerTest, ResetCommandBufferShouldRollbackUnsubmittedSlots) 
 TEST_F(SubmissionTrackerTest, ResetCommandPoolShouldRollbackUnsubmittedSlots) {
   EXPECT_CALL(timer_query_pool, NextReadyQuerySlot)
       .Times(1)
-      .WillOnce(Invoke(mock_next_ready_query_slot_function_1));
+      .WillOnce(Invoke(MockNextReadyQuerySlot1));
   std::vector<uint32_t> actual_slots_to_rollback;
   EXPECT_CALL(timer_query_pool, RollbackPendingQuerySlots)
       .Times(1)
@@ -446,7 +439,7 @@ TEST_F(SubmissionTrackerTest, MarkCommandBufferEndWillWriteTimestampsWhenNotCapt
 
   EXPECT_CALL(timer_query_pool, NextReadyQuerySlot)
       .Times(1)
-      .WillOnce(Invoke(mock_next_ready_query_slot_function_1));
+      .WillOnce(Invoke(MockNextReadyQuerySlot1));
   EXPECT_CALL(dispatch_table, CmdWriteTimestamp)
       .Times(1)
       .WillOnce(Return(mock_write_timestamp_function));
@@ -461,7 +454,7 @@ TEST_F(SubmissionTrackerTest, MarkCommandBufferEndWillWriteTimestampsWhenNotCapt
 }
 
 TEST_F(SubmissionTrackerTest, CanRetrieveCommandBufferTimestampsForACompleteSubmission) {
-  EXPECT_TWO_NEXT_READY_QUERY_SLOT_CALLS();
+  ExpectTwoNextReadyQuerySlotCalls();
   EXPECT_CALL(dispatch_table, GetQueryPoolResults)
       .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
   std::vector<uint32_t> actual_reset_slots;
@@ -487,13 +480,13 @@ TEST_F(SubmissionTrackerTest, CanRetrieveCommandBufferTimestampsForACompleteSubm
   tracker.CompleteSubmits(device);
 
   EXPECT_THAT(actual_reset_slots, UnorderedElementsAre(kSlotIndex1, kSlotIndex2));
-  EXPECT_SINGLE_COMMAND_BUFFER_SUBMISSION_EQ(actual_capture_event, pre_submit_time,
-                                             post_submit_time, pid, kTimestamp1, kTimestamp2);
+  ExpectSingleCommandBufferSubmissionEq(actual_capture_event, pre_submit_time, post_submit_time,
+                                        pid, kTimestamp1, kTimestamp2);
 }
 
 TEST_F(SubmissionTrackerTest,
        CanRetrieveCommandBufferTimestampsForACompleteSubmissionAtSecondPresent) {
-  EXPECT_TWO_NEXT_READY_QUERY_SLOT_CALLS();
+  ExpectTwoNextReadyQuerySlotCalls();
   EXPECT_CALL(dispatch_table, GetQueryPoolResults)
       .WillOnce(Return(mock_get_query_pool_results_function_not_ready))
       .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
@@ -521,12 +514,12 @@ TEST_F(SubmissionTrackerTest,
   tracker.CompleteSubmits(device);
 
   EXPECT_THAT(actual_reset_slots, UnorderedElementsAre(kSlotIndex1, kSlotIndex2));
-  EXPECT_SINGLE_COMMAND_BUFFER_SUBMISSION_EQ(actual_capture_event, pre_submit_time,
-                                             post_submit_time, pid, kTimestamp1, kTimestamp2);
+  ExpectSingleCommandBufferSubmissionEq(actual_capture_event, pre_submit_time, post_submit_time,
+                                        pid, kTimestamp1, kTimestamp2);
 }
 
 TEST_F(SubmissionTrackerTest, StopCaptureBeforeSubmissionWillResetTheSlots) {
-  EXPECT_TWO_NEXT_READY_QUERY_SLOT_CALLS();
+  ExpectTwoNextReadyQuerySlotCalls();
   EXPECT_CALL(dispatch_table, GetQueryPoolResults).Times(0);
   std::vector<uint32_t> actual_reset_slots;
   EXPECT_CALL(timer_query_pool, ResetQuerySlots).Times(1).WillOnce(SaveArg<1>(&actual_reset_slots));
@@ -547,7 +540,7 @@ TEST_F(SubmissionTrackerTest, StopCaptureBeforeSubmissionWillResetTheSlots) {
 }
 
 TEST_F(SubmissionTrackerTest, CanRetrieveCommandBufferTimestampsWhenNotCapturingAtPresent) {
-  EXPECT_TWO_NEXT_READY_QUERY_SLOT_CALLS();
+  ExpectTwoNextReadyQuerySlotCalls();
   EXPECT_CALL(dispatch_table, GetQueryPoolResults)
       .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
   std::vector<uint32_t> actual_reset_slots;
@@ -574,12 +567,12 @@ TEST_F(SubmissionTrackerTest, CanRetrieveCommandBufferTimestampsWhenNotCapturing
   tracker.CompleteSubmits(device);
 
   EXPECT_THAT(actual_reset_slots, UnorderedElementsAre(kSlotIndex1, kSlotIndex2));
-  EXPECT_SINGLE_COMMAND_BUFFER_SUBMISSION_EQ(actual_capture_event, pre_submit_time,
-                                             post_submit_time, pid, kTimestamp1, kTimestamp2);
+  ExpectSingleCommandBufferSubmissionEq(actual_capture_event, pre_submit_time, post_submit_time,
+                                        pid, kTimestamp1, kTimestamp2);
 }
 
 TEST_F(SubmissionTrackerTest, StopCaptureWhileSubmissionWillStillYieldResults) {
-  EXPECT_TWO_NEXT_READY_QUERY_SLOT_CALLS();
+  ExpectTwoNextReadyQuerySlotCalls();
   EXPECT_CALL(dispatch_table, GetQueryPoolResults)
       .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
   std::vector<uint32_t> actual_reset_slots;
@@ -606,8 +599,8 @@ TEST_F(SubmissionTrackerTest, StopCaptureWhileSubmissionWillStillYieldResults) {
   tracker.CompleteSubmits(device);
 
   EXPECT_THAT(actual_reset_slots, UnorderedElementsAre(kSlotIndex1, kSlotIndex2));
-  EXPECT_SINGLE_COMMAND_BUFFER_SUBMISSION_EQ(actual_capture_event, pre_submit_time,
-                                             post_submit_time, pid, kTimestamp1, kTimestamp2);
+  ExpectSingleCommandBufferSubmissionEq(actual_capture_event, pre_submit_time, post_submit_time,
+                                        pid, kTimestamp1, kTimestamp2);
 }
 
 TEST_F(SubmissionTrackerTest, StartCaptureJustBeforeSubmissionWontWriteData) {
@@ -645,7 +638,7 @@ TEST_F(SubmissionTrackerTest, StartCaptureWhileSubmissionWontWriteData) {
 TEST_F(SubmissionTrackerTest, WillResetProperlyWhenStartStopAndStartACaptureWithinASubmission) {
   EXPECT_CALL(timer_query_pool, NextReadyQuerySlot)
       .Times(1)
-      .WillOnce(Invoke(mock_next_ready_query_slot_function_1));
+      .WillOnce(Invoke(MockNextReadyQuerySlot1));
   EXPECT_CALL(dispatch_table, GetQueryPoolResults).Times(0);
   std::vector<uint32_t> actual_reset_slots;
   EXPECT_CALL(timer_query_pool, ResetQuerySlots).Times(1).WillOnce(SaveArg<1>(&actual_reset_slots));
@@ -666,7 +659,7 @@ TEST_F(SubmissionTrackerTest, WillResetProperlyWhenStartStopAndStartACaptureWith
 }
 
 TEST_F(SubmissionTrackerTest, CannotReuseCommandBufferWithoutReset) {
-  EXPECT_TWO_NEXT_READY_QUERY_SLOT_CALLS();
+  ExpectTwoNextReadyQuerySlotCalls();
   EXPECT_CALL(dispatch_table, GetQueryPoolResults)
       .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
   EXPECT_CALL(timer_query_pool, ResetQuerySlots).Times(1);
@@ -685,11 +678,7 @@ TEST_F(SubmissionTrackerTest, CannotReuseCommandBufferWithoutReset) {
 }
 
 TEST_F(SubmissionTrackerTest, CanReuseCommandBufferAfterReset) {
-  EXPECT_CALL(timer_query_pool, NextReadyQuerySlot)
-      .Times(3)
-      .WillOnce(Invoke(mock_next_ready_query_slot_function_1))
-      .WillOnce(Invoke(mock_next_ready_query_slot_function_2))
-      .WillOnce(Invoke(mock_next_ready_query_slot_function_3));
+  ExpectThreeNextReadyQuerySlotCalls();
   EXPECT_CALL(dispatch_table, GetQueryPoolResults)
       .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
   EXPECT_CALL(timer_query_pool, ResetQuerySlots).Times(1);
@@ -718,7 +707,7 @@ TEST_F(SubmissionTrackerTest, DebugMarkerBeginWillWriteTimestampWhenCapturing) {
         was_called = true;
       };
 
-  EXPECT_TWO_NEXT_READY_QUERY_SLOT_CALLS();
+  ExpectTwoNextReadyQuerySlotCalls();
   EXPECT_CALL(dispatch_table, CmdWriteTimestamp)
       .Times(2)
       .WillOnce(Return(dummy_write_timestamp_function))
@@ -734,7 +723,7 @@ TEST_F(SubmissionTrackerTest, DebugMarkerBeginWillWriteTimestampWhenCapturing) {
 }
 
 TEST_F(SubmissionTrackerTest, ResetCommandBufferShouldRollbackUnsubmittedMarkerSlots) {
-  EXPECT_TWO_NEXT_READY_QUERY_SLOT_CALLS();
+  ExpectTwoNextReadyQuerySlotCalls();
   std::vector<uint32_t> actual_slots_to_rollback;
   EXPECT_CALL(timer_query_pool, RollbackPendingQuerySlots)
       .Times(1)
@@ -769,7 +758,7 @@ TEST_F(SubmissionTrackerTest, DebugMarkerEndWontWriteTimestampsWhenNotCapturing)
 }
 
 TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerTimestampsForACompleteSubmission) {
-  EXPECT_FOUR_NEXT_READY_QUERY_SLOT_CALLS();
+  ExpectFourNextReadyQuerySlotCalls();
   EXPECT_CALL(dispatch_table, GetQueryPoolResults)
       .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
   std::vector<uint32_t> actual_reset_slots;
@@ -818,14 +807,13 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerTimestampsForACompleteSubmis
   const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker =
       actual_queue_submission.completed_markers(0);
 
-  EXPECT_DEBUG_MARKER_END_EQ(actual_debug_marker, kTimestamp3, expected_text_key, expected_color,
-                             0);
-  EXPECT_DEBUG_MARKER_BEGIN_EQ(actual_debug_marker, kTimestamp2, pre_submit_time, post_submit_time,
-                               tid);
+  ExpectDebugMarkerEndEq(actual_debug_marker, kTimestamp3, expected_text_key, expected_color, 0);
+  ExpectDebugMarkerBeginEq(actual_debug_marker, kTimestamp2, pre_submit_time, post_submit_time,
+                           tid);
 }
 
 TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerEndEvenWhenNotCapturedBegin) {
-  EXPECT_TWO_NEXT_READY_QUERY_SLOT_CALLS();
+  ExpectTwoNextReadyQuerySlotCalls();
   EXPECT_CALL(dispatch_table, GetQueryPoolResults)
       .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
   std::vector<uint32_t> actual_reset_slots;
@@ -870,13 +858,12 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerEndEvenWhenNotCapturedBegin)
   const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker =
       actual_queue_submission.completed_markers(0);
 
-  EXPECT_DEBUG_MARKER_END_EQ(actual_debug_marker, kTimestamp1, expected_text_key, expected_color,
-                             0);
+  ExpectDebugMarkerEndEq(actual_debug_marker, kTimestamp1, expected_text_key, expected_color, 0);
   EXPECT_FALSE(actual_debug_marker.has_begin_marker());
 }
 
 TEST_F(SubmissionTrackerTest, CanRetrieveNextedDebugMarkerTimestampsForACompleteSubmission) {
-  EXPECT_SIX_NEXT_READY_QUERY_SLOT_CALLS();
+  ExpectSixNextReadyQuerySlotCalls();
   EXPECT_CALL(dispatch_table, GetQueryPoolResults)
       .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
   std::vector<uint32_t> actual_reset_slots;
@@ -936,20 +923,20 @@ TEST_F(SubmissionTrackerTest, CanRetrieveNextedDebugMarkerTimestampsForAComplete
   const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker_outer =
       actual_queue_submission.completed_markers(1);
 
-  EXPECT_DEBUG_MARKER_END_EQ(actual_debug_marker_outer, kTimestamp5, expected_text_key_outer,
-                             expected_color, 0);
-  EXPECT_DEBUG_MARKER_BEGIN_EQ(actual_debug_marker_outer, kTimestamp2, pre_submit_time,
-                               post_submit_time, tid);
+  ExpectDebugMarkerEndEq(actual_debug_marker_outer, kTimestamp5, expected_text_key_outer,
+                         expected_color, 0);
+  ExpectDebugMarkerBeginEq(actual_debug_marker_outer, kTimestamp2, pre_submit_time,
+                           post_submit_time, tid);
 
-  EXPECT_DEBUG_MARKER_END_EQ(actual_debug_marker_inner, kTimestamp4, expected_text_key_inner,
-                             expected_color, 1);
-  EXPECT_DEBUG_MARKER_BEGIN_EQ(actual_debug_marker_inner, kTimestamp3, pre_submit_time,
-                               post_submit_time, tid);
+  ExpectDebugMarkerEndEq(actual_debug_marker_inner, kTimestamp4, expected_text_key_inner,
+                         expected_color, 1);
+  ExpectDebugMarkerBeginEq(actual_debug_marker_inner, kTimestamp3, pre_submit_time,
+                           post_submit_time, tid);
 }  // namespace orbit_vulkan_layer
 
 TEST_F(SubmissionTrackerTest,
        CanRetrieveNextedDebugMarkerTimestampsForASubmissionMissingFirstBegin) {
-  EXPECT_FOUR_NEXT_READY_QUERY_SLOT_CALLS();
+  ExpectFourNextReadyQuerySlotCalls();
   EXPECT_CALL(dispatch_table, GetQueryPoolResults)
       .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
   std::vector<uint32_t> actual_reset_slots;
@@ -1009,18 +996,18 @@ TEST_F(SubmissionTrackerTest,
   const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker_outer =
       actual_queue_submission.completed_markers(1);
 
-  EXPECT_DEBUG_MARKER_END_EQ(actual_debug_marker_outer, kTimestamp3, expected_text_key_outer,
-                             expected_color, 0);
+  ExpectDebugMarkerEndEq(actual_debug_marker_outer, kTimestamp3, expected_text_key_outer,
+                         expected_color, 0);
   EXPECT_FALSE(actual_debug_marker_outer.has_begin_marker());
 
-  EXPECT_DEBUG_MARKER_END_EQ(actual_debug_marker_inner, kTimestamp2, expected_text_key_inner,
-                             expected_color, 1);
-  EXPECT_DEBUG_MARKER_BEGIN_EQ(actual_debug_marker_inner, kTimestamp1, pre_submit_time,
-                               post_submit_time, tid);
+  ExpectDebugMarkerEndEq(actual_debug_marker_inner, kTimestamp2, expected_text_key_inner,
+                         expected_color, 1);
+  ExpectDebugMarkerBeginEq(actual_debug_marker_inner, kTimestamp1, pre_submit_time,
+                           post_submit_time, tid);
 }  // namespace orbit_vulkan_layer
 
 TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerAcrossTwoSubmissions) {
-  EXPECT_SIX_NEXT_READY_QUERY_SLOT_CALLS();
+  ExpectSixNextReadyQuerySlotCalls();
   EXPECT_CALL(dispatch_table, GetQueryPoolResults)
       .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
   std::vector<uint32_t> actual_reset_slots_1;
@@ -1094,14 +1081,13 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerAcrossTwoSubmissions) {
   const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker =
       actual_queue_submission_2.completed_markers(0);
 
-  EXPECT_DEBUG_MARKER_END_EQ(actual_debug_marker, kTimestamp5, expected_text_key, expected_color,
-                             0);
-  EXPECT_DEBUG_MARKER_BEGIN_EQ(actual_debug_marker, kTimestamp2, pre_submit_time_1,
-                               post_submit_time_1, tid);
+  ExpectDebugMarkerEndEq(actual_debug_marker, kTimestamp5, expected_text_key, expected_color, 0);
+  ExpectDebugMarkerBeginEq(actual_debug_marker, kTimestamp2, pre_submit_time_1, post_submit_time_1,
+                           tid);
 }
 
 TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerAcrossTwoSubmissionsEvenWhenNotCapturingBegin) {
-  EXPECT_FOUR_NEXT_READY_QUERY_SLOT_CALLS();
+  ExpectFourNextReadyQuerySlotCalls();
   EXPECT_CALL(dispatch_table, GetQueryPoolResults)
       .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
   std::vector<uint32_t> actual_reset_slots_1;
@@ -1170,13 +1156,12 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerAcrossTwoSubmissionsEvenWhen
   const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker =
       actual_queue_submission_2.completed_markers(0);
 
-  EXPECT_DEBUG_MARKER_END_EQ(actual_debug_marker, kTimestamp3, expected_text_key, expected_color,
-                             0);
+  ExpectDebugMarkerEndEq(actual_debug_marker, kTimestamp3, expected_text_key, expected_color, 0);
   EXPECT_FALSE(actual_debug_marker.has_begin_marker());
 }
 
 TEST_F(SubmissionTrackerTest, ResetSlotsOnDebugMarkerAcrossTwoSubmissionsWhenNotCapturingEnd) {
-  EXPECT_THREE_NEXT_READY_QUERY_SLOT_CALLS();
+  ExpectThreeNextReadyQuerySlotCalls();
   EXPECT_CALL(dispatch_table, GetQueryPoolResults)
       .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
   std::vector<uint32_t> actual_reset_slots_1;
@@ -1229,7 +1214,7 @@ TEST_F(SubmissionTrackerTest, ResetSlotsOnDebugMarkerAcrossTwoSubmissionsWhenNot
 }
 
 TEST_F(SubmissionTrackerTest, ResetDebugMarkerSlotsWhenStopBeforeASubmission) {
-  EXPECT_FOUR_NEXT_READY_QUERY_SLOT_CALLS();
+  ExpectFourNextReadyQuerySlotCalls();
   EXPECT_CALL(dispatch_table, GetQueryPoolResults).Times(0);
   std::vector<uint32_t> actual_reset_slots;
   EXPECT_CALL(timer_query_pool, ResetQuerySlots).Times(1).WillOnce(SaveArg<1>(&actual_reset_slots));
@@ -1257,7 +1242,7 @@ TEST_F(SubmissionTrackerTest, ResetDebugMarkerSlotsWhenStopBeforeASubmission) {
 TEST_F(SubmissionTrackerTest, CanLimitNextedDebugMarkerDepthPerCommandBuffer) {
   tracker.SetMaxLocalMarkerDepthPerCommandBuffer(1);
 
-  EXPECT_FOUR_NEXT_READY_QUERY_SLOT_CALLS();
+  ExpectFourNextReadyQuerySlotCalls();
   EXPECT_CALL(dispatch_table, GetQueryPoolResults)
       .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
   std::vector<uint32_t> actual_reset_slots;
@@ -1311,16 +1296,16 @@ TEST_F(SubmissionTrackerTest, CanLimitNextedDebugMarkerDepthPerCommandBuffer) {
   const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker_outer =
       actual_queue_submission.completed_markers(0);
 
-  EXPECT_DEBUG_MARKER_END_EQ(actual_debug_marker_outer, kTimestamp3, expected_text_key_outer,
-                             expected_color, 0);
-  EXPECT_DEBUG_MARKER_BEGIN_EQ(actual_debug_marker_outer, kTimestamp2, pre_submit_time,
-                               post_submit_time, tid);
+  ExpectDebugMarkerEndEq(actual_debug_marker_outer, kTimestamp3, expected_text_key_outer,
+                         expected_color, 0);
+  ExpectDebugMarkerBeginEq(actual_debug_marker_outer, kTimestamp2, pre_submit_time,
+                           post_submit_time, tid);
 
 }  // namespace orbit_vulkan_layer
 
 TEST_F(SubmissionTrackerTest, CanLimitNextedDebugMarkerDepthPerCommandBufferAcrossSubmissions) {
   tracker.SetMaxLocalMarkerDepthPerCommandBuffer(1);
-  EXPECT_SEVEN_NEXT_READY_QUERY_SLOT_CALLS();
+  ExpectSevenNextReadyQuerySlotCalls();
   EXPECT_CALL(dispatch_table, GetQueryPoolResults)
       .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
 
@@ -1402,10 +1387,10 @@ TEST_F(SubmissionTrackerTest, CanLimitNextedDebugMarkerDepthPerCommandBufferAcro
   const orbit_grpc_protos::GpuDebugMarker& actual_debug_marker =
       actual_queue_submission_2.completed_markers(0);
 
-  EXPECT_DEBUG_MARKER_END_EQ(actual_debug_marker, kTimestamp6, expected_outer_text_key,
-                             expected_color, 0);
-  EXPECT_DEBUG_MARKER_BEGIN_EQ(actual_debug_marker, kTimestamp2, pre_submit_time_1,
-                               post_submit_time_1, tid);
+  ExpectDebugMarkerEndEq(actual_debug_marker, kTimestamp6, expected_outer_text_key, expected_color,
+                         0);
+  ExpectDebugMarkerBeginEq(actual_debug_marker, kTimestamp2, pre_submit_time_1, post_submit_time_1,
+                           tid);
 }
 
 }  // namespace orbit_vulkan_layer

--- a/OrbitVulkanLayer/SubmissionTrackerTest.cpp
+++ b/OrbitVulkanLayer/SubmissionTrackerTest.cpp
@@ -575,7 +575,7 @@ TEST_F(SubmissionTrackerTest, CanRetrieveCommandBufferTimestampsWhenNotCapturing
                                         pid, kTimestamp1, kTimestamp2);
 }
 
-TEST_F(SubmissionTrackerTest, StopCaptureWhileSubmissionWillStillYieldResults) {
+TEST_F(SubmissionTrackerTest, StopCaptureDuringSubmissionWillStillYieldResults) {
   ExpectTwoNextReadyQuerySlotCalls();
   EXPECT_CALL(dispatch_table, GetQueryPoolResults)
       .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));
@@ -623,7 +623,7 @@ TEST_F(SubmissionTrackerTest, StartCaptureJustBeforeSubmissionWontWriteData) {
   tracker.CompleteSubmits(device);
 }
 
-TEST_F(SubmissionTrackerTest, StartCaptureWhileSubmissionWontWriteData) {
+TEST_F(SubmissionTrackerTest, StartCaptureDuringSubmissionWontWriteData) {
   EXPECT_CALL(timer_query_pool, NextReadyQuerySlot).Times(0);
   EXPECT_CALL(dispatch_table, GetQueryPoolResults).Times(0);
   EXPECT_CALL(timer_query_pool, ResetQuerySlots).Times(0);
@@ -936,7 +936,7 @@ TEST_F(SubmissionTrackerTest, CanRetrieveNextedDebugMarkerTimestampsForAComplete
                          expected_color, 1);
   ExpectDebugMarkerBeginEq(actual_debug_marker_inner, kTimestamp3, pre_submit_time,
                            post_submit_time, tid);
-}  // namespace orbit_vulkan_layer
+}
 
 TEST_F(SubmissionTrackerTest,
        CanRetrieveNextedDebugMarkerTimestampsForASubmissionMissingFirstBegin) {
@@ -1008,7 +1008,7 @@ TEST_F(SubmissionTrackerTest,
                          expected_color, 1);
   ExpectDebugMarkerBeginEq(actual_debug_marker_inner, kTimestamp1, pre_submit_time,
                            post_submit_time, tid);
-}  // namespace orbit_vulkan_layer
+}
 
 TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerAcrossTwoSubmissions) {
   ExpectSixNextReadyQuerySlotCalls();
@@ -1304,8 +1304,7 @@ TEST_F(SubmissionTrackerTest, CanLimitNextedDebugMarkerDepthPerCommandBuffer) {
                          expected_color, 0);
   ExpectDebugMarkerBeginEq(actual_debug_marker_outer, kTimestamp2, pre_submit_time,
                            post_submit_time, tid);
-
-}  // namespace orbit_vulkan_layer
+}
 
 TEST_F(SubmissionTrackerTest, CanLimitNextedDebugMarkerDepthPerCommandBufferAcrossSubmissions) {
   tracker.SetMaxLocalMarkerDepthPerCommandBuffer(1);

--- a/OrbitVulkanLayer/SubmissionTrackerTest.cpp
+++ b/OrbitVulkanLayer/SubmissionTrackerTest.cpp
@@ -111,8 +111,8 @@ class SubmissionTrackerTest : public ::testing::Test {
   std::unique_ptr<MockVulkanLayerProducer> producer;
   SubmissionTracker<MockDispatchTable, MockDeviceManager, MockTimerQueryPool> tracker =
       SubmissionTracker<MockDispatchTable, MockDeviceManager, MockTimerQueryPool>(
-          std::numeric_limits<uint32_t>::max(), &dispatch_table, &timer_query_pool,
-          &device_manager);
+          &dispatch_table, &timer_query_pool, &device_manager,
+          std::numeric_limits<uint32_t>::max());
 
   VkDevice device = {};
   VkCommandPool command_pool = {};
@@ -327,7 +327,7 @@ TEST(SubmissionTracker, CanBeInitialized) {
   MockTimerQueryPool timer_query_pool;
   MockDeviceManager device_manager;
   SubmissionTracker<MockDispatchTable, MockDeviceManager, MockTimerQueryPool> tracker(
-      std::numeric_limits<uint32_t>::max(), &dispatch_table, &timer_query_pool, &device_manager);
+      &dispatch_table, &timer_query_pool, &device_manager, std::numeric_limits<uint32_t>::max());
 }
 
 TEST(SubmissionTracker, SetVulkanLayerProducerWillCallSetListener) {
@@ -337,7 +337,7 @@ TEST(SubmissionTracker, SetVulkanLayerProducerWillCallSetListener) {
   std::unique_ptr<MockVulkanLayerProducer> producer = std::make_unique<MockVulkanLayerProducer>();
 
   SubmissionTracker<MockDispatchTable, MockDeviceManager, MockTimerQueryPool> tracker(
-      std::numeric_limits<uint32_t>::max(), &dispatch_table, &timer_query_pool, &device_manager);
+      &dispatch_table, &timer_query_pool, &device_manager, std::numeric_limits<uint32_t>::max());
 
   VulkanLayerProducer::CaptureStatusListener* actual_listener;
   EXPECT_CALL(*producer, SetCaptureStatusListener).Times(1).WillOnce(SaveArg<0>(&actual_listener));

--- a/OrbitVulkanLayer/SubmissionTrackerTest.cpp
+++ b/OrbitVulkanLayer/SubmissionTrackerTest.cpp
@@ -543,7 +543,8 @@ TEST_F(SubmissionTrackerTest, StopCaptureBeforeSubmissionWillResetTheSlots) {
   EXPECT_THAT(actual_reset_slots, UnorderedElementsAre(kSlotIndex1, kSlotIndex2));
 }
 
-TEST_F(SubmissionTrackerTest, CanRetrieveCommandBufferTimestampsWhenNotCapturingAtPresent) {
+TEST_F(SubmissionTrackerTest,
+       CommandBufferTimestampsRecordedWhenCapturingCanBeRetrievedWhenNotCapturing) {
   ExpectTwoNextReadyQuerySlotCalls();
   EXPECT_CALL(dispatch_table, GetQueryPoolResults)
       .WillRepeatedly(Return(mock_get_query_pool_results_function_all_ready));

--- a/OrbitVulkanLayer/VulkanLayerProducer.h
+++ b/OrbitVulkanLayer/VulkanLayerProducer.h
@@ -17,8 +17,8 @@ class VulkanLayerProducer {
  public:
   virtual ~VulkanLayerProducer() = default;
 
-  // This method tries to establish a gRPC connection with OrbitService over Unix domain socket
-  // and gets the class ready to send CaptureEvents.
+  // This method tries to establish a gRPC connection with OrbitService over the specified gRPC
+  // channel and gets the class ready to send CaptureEvents.
   virtual void BringUp(const std::shared_ptr<grpc::Channel>& channel) = 0;
 
   // This method causes the class to stop sending any remaining queued CaptureEvent
@@ -29,6 +29,7 @@ class VulkanLayerProducer {
   [[nodiscard]] virtual bool IsCapturing() = 0;
 
   // Use this method to enqueue a CaptureEvent to be sent to OrbitService.
+  // Returns true if the event was enqueued as the capture is in progress, false otherwise.
   virtual bool EnqueueCaptureEvent(orbit_grpc_protos::CaptureEvent&& capture_event) = 0;
 
   // This method enqueues an InternedString to be sent to OrbitService the first time the string

--- a/OrbitVulkanLayer/VulkanLayerProducer.h
+++ b/OrbitVulkanLayer/VulkanLayerProducer.h
@@ -30,8 +30,8 @@ class VulkanLayerProducer {
 
   // Use this method to enqueue a CaptureEvent to be sent to OrbitService.
   // Returns true if the event was enqueued as the capture is in progress, false otherwise.
-  // So callers can check the return value if the event was actually enqueued, in case they need
-  // this information.
+  // Callers can use the return value to check if the event was actually enqueued as the capture
+  // is in progress.
   virtual bool EnqueueCaptureEvent(orbit_grpc_protos::CaptureEvent&& capture_event) = 0;
 
   // This method enqueues an InternedString to be sent to OrbitService the first time the string

--- a/OrbitVulkanLayer/VulkanLayerProducer.h
+++ b/OrbitVulkanLayer/VulkanLayerProducer.h
@@ -30,6 +30,8 @@ class VulkanLayerProducer {
 
   // Use this method to enqueue a CaptureEvent to be sent to OrbitService.
   // Returns true if the event was enqueued as the capture is in progress, false otherwise.
+  // So callers can check the return value if the event was actually enqueued, in case they need
+  // this information.
   virtual bool EnqueueCaptureEvent(orbit_grpc_protos::CaptureEvent&& capture_event) = 0;
 
   // This method enqueues an InternedString to be sent to OrbitService the first time the string


### PR DESCRIPTION
This adds a class `SubmissionTracker` to the Vulkan layer, which
in particular takes care of tracking the command buffer and debug
marker timings and sending them to the producer.

Test: Compile & Test
Bug: http://b/168200502