### PR TITLE
Fix generate_coverage_report.sh

### DIFF
--- a/third_party/conan/configs/linux/profiles/coverage_clang9
+++ b/third_party/conan/configs/linux/profiles/coverage_clang9
@@ -1,5 +1,5 @@
 include(clang9_relwithdebinfo)
 
 [env]
-CFLAGS=$C_FLAGS -fprofile-instr-generate -fcoverage-mapping
-CXXFLAGS=$CXX_FLAGS -fprofile-instr-generate -fcoverage-mapping
+CFLAGS=$C_FLAGS -fprofile-instr-generate="%m.profraw" -fcoverage-mapping
+CXXFLAGS=$CXX_FLAGS -fprofile-instr-generate="%m.profraw" -fcoverage-mapping


### PR DESCRIPTION
The script to generate unit test coverage reports was broken since
ctest was used differently. This commit fixes this and coverage reports
can now be generated again.

Test: 
third_party/conan/configs/install.sh &&
./build.sh coverage_clang9 &&
contrib/unit_test_coverage/generate_coverage_report.sh . build_coverage_clang9/