### PR TITLE
Update callstack view when switching between thread tabs

### DIFF
--- a/OrbitGl/DataView.h
+++ b/OrbitGl/DataView.h
@@ -56,7 +56,7 @@ class DataView {
   void OnSort(int column, std::optional<SortingOrder> new_order);
   virtual void OnContextMenu(const std::string& action, int menu_index,
                              const std::vector<int>& item_indices);
-  virtual void OnSelect(int /*index*/) {}
+  virtual void OnSelect(std::optional<int> /*index*/) {}
   virtual int GetSelectedIndex() { return selected_index_; }
   virtual void OnDataChanged();
   virtual void OnTimer() {}

--- a/OrbitGl/LiveFunctionsDataView.cpp
+++ b/OrbitGl/LiveFunctionsDataView.cpp
@@ -77,10 +77,14 @@ std::string LiveFunctionsDataView::GetValue(int row, int column) {
   }
 }
 
-void LiveFunctionsDataView::OnSelect(int row) {
+void LiveFunctionsDataView::OnSelect(std::optional<int> row) {
+  if (!row.has_value()) {
+    return;
+  }
   GOrbitApp->DeselectTextBox();
   const CaptureData& capture_data = GOrbitApp->GetCaptureData();
-  GOrbitApp->set_highlighted_function(capture_data.GetAbsoluteAddress(*GetSelectedFunction(row)));
+  GOrbitApp->set_highlighted_function(
+      capture_data.GetAbsoluteAddress(*GetSelectedFunction(row.value())));
 }
 
 #define ORBIT_FUNC_SORT(Member)                                                      \

--- a/OrbitGl/LiveFunctionsDataView.h
+++ b/OrbitGl/LiveFunctionsDataView.h
@@ -21,7 +21,7 @@ class LiveFunctionsDataView : public DataView {
                                           const std::vector<int>& selected_indices) override;
   std::string GetValue(int row, int column) override;
 
-  void OnSelect(int row) override;
+  void OnSelect(std::optional<int> row) override;
   void OnContextMenu(const std::string& action, int menu_index,
                      const std::vector<int>& item_indices) override;
   void OnDataChanged() override;

--- a/OrbitGl/ProcessesDataView.cpp
+++ b/OrbitGl/ProcessesDataView.cpp
@@ -81,8 +81,11 @@ void ProcessesDataView::DoSort() {
 
 #undef ORBIT_PROC_SORT
 
-void ProcessesDataView::OnSelect(int index) {
-  const ProcessInfo& selected_process = GetProcess(index);
+void ProcessesDataView::OnSelect(std::optional<int> index) {
+  if (!index.has_value()) {
+    return;
+  }
+  const ProcessInfo& selected_process = GetProcess(index.value());
   selected_process_id_ = selected_process.pid();
 
   SetSelectedItem();

--- a/OrbitGl/ProcessesDataView.h
+++ b/OrbitGl/ProcessesDataView.h
@@ -19,7 +19,7 @@ class ProcessesDataView final : public DataView {
   std::string GetToolTip(int row, int column) override;
   std::string GetLabel() override { return "Processes"; }
 
-  void OnSelect(int index) override;
+  void OnSelect(std::optional<int> index) override;
   bool SelectProcess(const std::string& process_name);
   bool SelectProcess(int32_t process_id);
   void SetProcessList(const std::vector<orbit_grpc_protos::ProcessInfo>& process_list);

--- a/OrbitGl/SamplingReport.cpp
+++ b/OrbitGl/SamplingReport.cpp
@@ -14,7 +14,7 @@ SamplingReport::SamplingReport(
     : post_processed_sampling_data_{std::move(post_processed_sampling_data)},
       unique_callstacks_{std::move(unique_callstacks)},
       has_summary_{has_summary} {
-  selected_address_ = 0;
+  selected_address_ = kInvalidFunctionAddress;
   selected_thread_id_ = 0;
   callstack_data_view_ = nullptr;
   selected_sorted_callstack_report_ = nullptr;
@@ -43,6 +43,11 @@ void SamplingReport::FillReport() {
 }
 
 void SamplingReport::UpdateDisplayedCallstack() {
+  if (selected_address_ == SamplingReport::kInvalidFunctionAddress) {
+    ClearReport();
+    return;
+  }
+
   selected_sorted_callstack_report_ =
       post_processed_sampling_data_.GetSortedCallstackReportFromAddress(selected_address_,
                                                                         selected_thread_id_);

--- a/OrbitGl/SamplingReport.h
+++ b/OrbitGl/SamplingReport.h
@@ -35,6 +35,7 @@ class SamplingReport {
   [[nodiscard]] bool HasSamples() const { return !unique_callstacks_.empty(); }
   [[nodiscard]] bool has_summary() const { return has_summary_; }
   void ClearReport();
+  static const uint64_t kInvalidFunctionAddress = std::numeric_limits<uint64_t>::max();
 
  protected:
   void FillReport();

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -249,9 +249,9 @@ void SamplingReportDataView::OnContextMenu(const std::string& action, int menu_i
   }
 }
 
-void SamplingReportDataView::OnSelect(int index) {
-  uint64_t function_address = (index == -1) ? SamplingReport::kInvalidFunctionAddress
-                                            : GetSampledFunction(index).absolute_address;
+void SamplingReportDataView::OnSelect(std::optional<int> index) {
+  uint64_t function_address = index.has_value() ? GetSampledFunction(index.value()).absolute_address
+                                                : SamplingReport::kInvalidFunctionAddress;
   sampling_report_->OnSelectAddress(function_address, tid_);
 }
 

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -250,8 +250,9 @@ void SamplingReportDataView::OnContextMenu(const std::string& action, int menu_i
 }
 
 void SamplingReportDataView::OnSelect(int index) {
-  SampledFunction& func = GetSampledFunction(index);
-  sampling_report_->OnSelectAddress(func.absolute_address, tid_);
+  uint64_t function_address = (index == -1) ? SamplingReport::kInvalidFunctionAddress
+                                            : GetSampledFunction(index).absolute_address;
+  sampling_report_->OnSelectAddress(function_address, tid_);
 }
 
 void SamplingReportDataView::LinkDataView(DataView* data_view) {

--- a/OrbitGl/SamplingReportDataView.h
+++ b/OrbitGl/SamplingReportDataView.h
@@ -22,7 +22,7 @@ class SamplingReportDataView : public DataView {
 
   void OnContextMenu(const std::string& action, int menu_index,
                      const std::vector<int>& item_indices) override;
-  void OnSelect(int index) override;
+  void OnSelect(std::optional<int> index) override;
 
   void LinkDataView(DataView* data_view) override;
   void SetSamplingReport(class SamplingReport* sampling_report) {

--- a/OrbitQt/orbitsamplingreport.cpp
+++ b/OrbitQt/orbitsamplingreport.cpp
@@ -92,7 +92,10 @@ void OrbitSamplingReport::on_PreviousCallstackButton_clicked() {
 void OrbitSamplingReport::OnCurrentThreadTabChanged(int current_tab_index) {
   auto treeView = m_OrbitDataViews[current_tab_index];
   QModelIndexList index_list = treeView->GetTreeView()->selectionModel()->selectedIndexes();
-  int row = (!index_list.isEmpty() && index_list.front().isValid()) ? index_list.front().row() : -1;
+  std::optional<int> row = std::nullopt;
+  if (!index_list.isEmpty() && index_list.front().isValid()) {
+    row = index_list.front().row();
+  }
   treeView->GetTreeView()->GetModel()->OnRowSelected(row);
   RefreshCallstackView();
 }

--- a/OrbitQt/orbitsamplingreport.cpp
+++ b/OrbitQt/orbitsamplingreport.cpp
@@ -72,6 +72,9 @@ void OrbitSamplingReport::Initialize(DataView* callstack_data_view,
     QString threadName = QString::fromStdString(report_data_view.GetName());
     ui->tabWidget->addTab(tab, threadName);
   }
+
+  connect(ui->tabWidget, &QTabWidget::currentChanged, this,
+          &OrbitSamplingReport::OnCurrentThreadTabChanged);
 }
 
 void OrbitSamplingReport::on_NextCallstackButton_clicked() {
@@ -83,6 +86,14 @@ void OrbitSamplingReport::on_NextCallstackButton_clicked() {
 void OrbitSamplingReport::on_PreviousCallstackButton_clicked() {
   CHECK(m_SamplingReport != nullptr);
   m_SamplingReport->DecrementCallstackIndex();
+  RefreshCallstackView();
+}
+
+void OrbitSamplingReport::OnCurrentThreadTabChanged(int current_tab_index) {
+  auto treeView = m_OrbitDataViews[current_tab_index];
+  QModelIndexList index_list = treeView->GetTreeView()->selectionModel()->selectedIndexes();
+  int row = (!index_list.isEmpty() && index_list.front().isValid()) ? index_list.front().row() : -1;
+  treeView->GetTreeView()->GetModel()->OnRowSelected(row);
   RefreshCallstackView();
 }
 

--- a/OrbitQt/orbitsamplingreport.h
+++ b/OrbitQt/orbitsamplingreport.h
@@ -31,6 +31,7 @@ class OrbitSamplingReport : public QWidget {
  private slots:
   void on_NextCallstackButton_clicked();
   void on_PreviousCallstackButton_clicked();
+  void OnCurrentThreadTabChanged(int current_tab_index);
 
  private:
   Ui::OrbitSamplingReport* ui;

--- a/OrbitQt/orbittablemodel.cpp
+++ b/OrbitQt/orbittablemodel.cpp
@@ -97,8 +97,8 @@ void OrbitTableModel::OnFilter(const QString& filter) {
   data_view_->OnFilter(filter.toStdString());
 }
 
-void OrbitTableModel::OnRowSelected(int row) {
-  if (static_cast<int>(data_view_->GetNumElements()) > row) {
+void OrbitTableModel::OnRowSelected(std::optional<int> row) {
+  if (!row.has_value() || static_cast<int>(data_view_->GetNumElements()) > row.value()) {
     data_view_->OnSelect(row);
   }
 }

--- a/OrbitQt/orbittablemodel.h
+++ b/OrbitQt/orbittablemodel.h
@@ -36,7 +36,7 @@ class OrbitTableModel : public QAbstractTableModel {
 
   void OnTimer();
   void OnFilter(const QString& filter);
-  void OnRowSelected(int row);
+  void OnRowSelected(std::optional<int> row);
 
  protected:
   DataView* data_view_;


### PR DESCRIPTION
Make the callstack view show consistent selections when the user selects in multiple thread tabs and switches tabs.

Current callstack widget is not refreshed when the user switch thread tabs. Therefore, it is not clear which selection is shown if the user selects in multiple thread tabs. We fix this inconsistency by keeping the selection for each thread tab and update the callstack view accordingly when we switch thread tabs.

Fixes the bug b/170468638.