### PR TITLE
[Refactor] Move Tracks out of Timegraph

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -541,7 +541,8 @@ void OrbitApp::MainTick() {
   GMainTimer.Restart();
 
   if (DoZoom && HasCaptureData()) {
-    GCurrentTimeGraph->SortTracks();
+    // TODO (b/176077097): TrackManager has to manage sorting by their own.
+    GCurrentTimeGraph->GetTrackManager()->SortTracks();
     capture_window_->ZoomAll();
     NeedsRedraw();
     DoZoom = false;
@@ -768,7 +769,8 @@ PresetLoadState OrbitApp::GetPresetLoadState(
 }
 
 ErrorMessageOr<void> OrbitApp::OnSaveCapture(const std::string& file_name) {
-  const auto& key_to_string_map = GCurrentTimeGraph->GetStringManager()->GetKeyToStringMap();
+  const auto& key_to_string_map =
+      GCurrentTimeGraph->GetTrackManager()->GetStringManager()->GetKeyToStringMap();
 
   std::vector<std::shared_ptr<TimerChain>> chains =
       GCurrentTimeGraph->GetAllSerializableTimerChains();

--- a/OrbitGl/AsyncTrack.cpp
+++ b/OrbitGl/AsyncTrack.cpp
@@ -57,7 +57,7 @@ void AsyncTrack::UpdateBoxHeight() {
   }
 }
 
-std::vector<std::shared_ptr<TimerChain>> AsyncTrack::GetAllSerializableChains() {
+std::vector<std::shared_ptr<TimerChain>> AsyncTrack::GetAllSerializableChains() const {
   // For async time slices, the start and stop events are their own individual timers and are
   // already serialized on their initial thread tracks. Return an empty vector so that we don't
   // serialize the async timer twice.

--- a/OrbitGl/AsyncTrack.h
+++ b/OrbitGl/AsyncTrack.h
@@ -18,7 +18,7 @@ class AsyncTrack final : public TimerTrack {
 
   [[nodiscard]] Type GetType() const override { return kAsyncTrack; };
   [[nodiscard]] std::string GetBoxTooltip(PickingId id) const override;
-  [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllSerializableChains() override;
+  [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllSerializableChains() const override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
   void UpdateBoxHeight() override;
 

--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -62,6 +62,7 @@ target_sources(
          TimerInfosIterator.h
          TimerTrack.h
          Track.h
+         TrackManager.h
          TriangleToggle.h
          TracepointsDataView.h
          TracepointTrack.h)
@@ -109,6 +110,7 @@ target_sources(
           ThreadStateTrack.cpp
           ThreadTrack.cpp
           Track.cpp
+          TrackManager.cpp
           TriangleToggle.cpp
           TracepointsDataView.cpp
           TracepointTrack.cpp)

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -90,7 +90,8 @@ void CaptureWindow::MouseMoved(int x, int y, bool left, bool /*right*/, bool /*m
 
     world_top_left_x_ = clamp(world_top_left_x_, world_min, world_max - world_width_);
     world_top_left_y_ =
-        clamp(world_top_left_y_, world_height_ - time_graph_.GetThreadTotalHeight(), world_max_y_);
+        clamp(world_top_left_y_,
+              world_height_ - time_graph_.GetTrackManager()->GetTracksTotalHeight(), world_max_y_);
 
     time_graph_.PanTime(screen_click_x_, x, GetWidth(), ref_time_click_);
     NeedsUpdate();
@@ -564,7 +565,7 @@ void CaptureWindow::UpdateHorizontalScroll(float ratio) {
 
 void CaptureWindow::UpdateVerticalScroll(float ratio) {
   float min = world_max_y_;
-  float max = world_height_ - time_graph_.GetThreadTotalHeight();
+  float max = world_height_ - time_graph_.GetTrackManager()->GetTracksTotalHeight();
   float range = max - min;
   float new_top_left_y = min + ratio * range;
   if (new_top_left_y != world_top_left_y_) {
@@ -594,9 +595,9 @@ void CaptureWindow::UpdateHorizontalSliderFromWorld() {
 
 void CaptureWindow::UpdateVerticalSliderFromWorld() {
   float min = world_max_y_;
-  float max = world_height_ - time_graph_.GetThreadTotalHeight();
+  float max = world_height_ - time_graph_.GetTrackManager()->GetTracksTotalHeight();
   float ratio = (world_top_left_y_ - min) / (max - min);
-  float vertical_ratio = world_height_ / time_graph_.GetThreadTotalHeight();
+  float vertical_ratio = world_height_ / time_graph_.GetTrackManager()->GetTracksTotalHeight();
   int slider_width = static_cast<int>(time_graph_.GetLayout().GetSliderWidth());
   vertical_slider_->SetPixelHeight(slider_width);
   vertical_slider_->SetNormalizedPosition(ratio);
@@ -605,7 +606,8 @@ void CaptureWindow::UpdateVerticalSliderFromWorld() {
 }
 
 void CaptureWindow::UpdateWorldTopLeftY(float val) {
-  float min_world_top_left = GetWorldHeight() - time_graph_.GetThreadTotalHeight();
+  float min_world_top_left =
+      GetWorldHeight() - time_graph_.GetTrackManager()->GetTracksTotalHeight();
   GlCanvas::UpdateWorldTopLeftY(clamp(val, min_world_top_left, GetWorldMaxY()));
   NeedsUpdate();
 }
@@ -682,7 +684,7 @@ void CaptureWindow::RenderImGui() {
       IMGUI_VAR_TO_TEXT(mouse_world_y_);
       IMGUI_VAR_TO_TEXT(time_graph_.GetNumDrawnTextBoxes());
       IMGUI_VAR_TO_TEXT(time_graph_.GetNumTimers());
-      IMGUI_VAR_TO_TEXT(time_graph_.GetThreadTotalHeight());
+      IMGUI_VAR_TO_TEXT(time_graph_.GetTrackManager()->GetTracksTotalHeight());
       IMGUI_VAR_TO_TEXT(time_graph_.GetMinTimeUs());
       IMGUI_VAR_TO_TEXT(time_graph_.GetMaxTimeUs());
       IMGUI_VAR_TO_TEXT(time_graph_.GetCaptureMin());

--- a/OrbitGl/FrameTrack.cpp
+++ b/OrbitGl/FrameTrack.cpp
@@ -246,7 +246,7 @@ void FrameTrack::UpdateBoxHeight() {
   box_height_ = kBoxHeightMultiplier * time_graph_->GetLayout().GetTextBoxHeight();
 }
 
-std::vector<std::shared_ptr<TimerChain>> FrameTrack::GetAllSerializableChains() {
+std::vector<std::shared_ptr<TimerChain>> FrameTrack::GetAllSerializableChains() const {
   // Frametracks are just displaying existing data in a different way.
   // We don't want to write out all the timers of that track.
   // TODO(b/171026228): However, we should serialize them in some form.

--- a/OrbitGl/FrameTrack.cpp
+++ b/OrbitGl/FrameTrack.cpp
@@ -4,7 +4,16 @@
 
 #include "FrameTrack.h"
 
-#include "App.h"
+#include <GteVector.h>
+#include <absl/strings/str_format.h>
+#include <absl/time/time.h>
+
+#include <algorithm>
+
+#include "Batcher.h"
+#include "CoreUtils.h"
+#include "GlCanvas.h"
+#include "GlUtils.h"
 #include "OrbitClientData/FunctionUtils.h"
 #include "TimeGraph.h"
 #include "TimeGraphLayout.h"

--- a/OrbitGl/FrameTrack.h
+++ b/OrbitGl/FrameTrack.h
@@ -14,6 +14,7 @@ class FrameTrack : public TimerTrack {
   explicit FrameTrack(TimeGraph* time_graph, const orbit_client_protos::FunctionInfo& function,
                       OrbitApp* app);
   [[nodiscard]] Type GetType() const override { return kFrameTrack; }
+  [[nodiscard]] uint64_t GetFunctionAddress() const { return function_.address(); }
   [[nodiscard]] bool IsCollapsable() const override { return GetMaximumScaleFactor() > 0.f; }
 
   [[nodiscard]] virtual float GetYFromDepth(uint32_t depth) const override;
@@ -32,7 +33,7 @@ class FrameTrack : public TimerTrack {
 
   void UpdateBoxHeight() override;
 
-  [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllSerializableChains() override;
+  [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllSerializableChains() const override;
 
  protected:
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,

--- a/OrbitGl/FrameTrack.h
+++ b/OrbitGl/FrameTrack.h
@@ -5,7 +5,19 @@
 #ifndef ORBIT_GL_FRAME_TRACK_H_
 #define ORBIT_GL_FRAME_TRACK_H_
 
+#include <stdint.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "CoreMath.h"
+#include "PickingManager.h"
+#include "TextBox.h"
+#include "TimerChain.h"
 #include "TimerTrack.h"
+#include "Track.h"
+#include "capture_data.pb.h"
 
 class OrbitApp;
 

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -38,8 +38,8 @@ std::string MapGpuTimelineToTrackLabel(std::string_view timeline) {
 
 }  // namespace orbit_gl
 
-GpuTrack::GpuTrack(TimeGraph* time_graph, std::shared_ptr<StringManager> string_manager,
-                   uint64_t timeline_hash, OrbitApp* app)
+GpuTrack::GpuTrack(TimeGraph* time_graph, StringManager* string_manager, uint64_t timeline_hash,
+                   OrbitApp* app)
     : TimerTrack(time_graph, app) {
   text_renderer_ = time_graph->GetTextRenderer();
   timeline_hash_ = timeline_hash;
@@ -129,8 +129,7 @@ void GpuTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_us, 
     CHECK(timer_info.type() == TimerInfo::kGpuActivity);
 
     std::string text = absl::StrFormat(
-        "%s  %s", time_graph_->GetStringManager()->Get(timer_info.user_data_key()).value_or(""),
-        time.c_str());
+        "%s  %s", string_manager_->Get(timer_info.user_data_key()).value_or(""), time.c_str());
     text_box->SetText(text);
   }
 

--- a/OrbitGl/GpuTrack.h
+++ b/OrbitGl/GpuTrack.h
@@ -25,8 +25,8 @@ std::string MapGpuTimelineToTrackLabel(std::string_view timeline);
 
 class GpuTrack : public TimerTrack {
  public:
-  explicit GpuTrack(TimeGraph* time_graph, std::shared_ptr<StringManager> string_manager,
-                    uint64_t timeline_hash, OrbitApp* app);
+  explicit GpuTrack(TimeGraph* time_graph, StringManager* string_manager, uint64_t timeline_hash,
+                    OrbitApp* app);
   ~GpuTrack() override = default;
   [[nodiscard]] std::string GetTooltip() const override;
   [[nodiscard]] Type GetType() const override { return kGpuTrack; }
@@ -48,7 +48,7 @@ class GpuTrack : public TimerTrack {
 
  private:
   uint64_t timeline_hash_;
-  std::shared_ptr<StringManager> string_manager_;
+  StringManager* string_manager_;
   [[nodiscard]] std::string GetSwQueueTooltip(
       const orbit_client_protos::TimerInfo& timer_info) const;
   [[nodiscard]] std::string GetHwQueueTooltip(

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -4,28 +4,31 @@
 
 #include "TimeGraph.h"
 
+#include <GteVector.h>
 #include <OrbitBase/Logging.h>
-#include <OrbitBase/Profiling.h>
 #include <OrbitBase/Tracing.h>
+#include <absl/time/time.h>
+#include <google/protobuf/stubs/port.h>
+#include <stddef.h>
 
 #include <algorithm>
+#include <limits>
 #include <utility>
 
 #include "App.h"
+#include "AsyncTrack.h"
 #include "CoreUtils.h"
 #include "Geometry.h"
 #include "GlCanvas.h"
-#include "GpuTrack.h"
+#include "GlUtils.h"
 #include "GraphTrack.h"
 #include "ManualInstrumentationManager.h"
 #include "OrbitBase/ThreadConstants.h"
 #include "OrbitClientData/FunctionUtils.h"
 #include "PickingManager.h"
-#include "SchedulerTrack.h"
 #include "StringManager.h"
 #include "TextBox.h"
-#include "ThreadTrack.h"
-#include "absl/flags/flag.h"
+#include "TrackManager.h"
 #include "absl/strings/str_format.h"
 
 using orbit_client_protos::CallstackEvent;

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -29,6 +29,7 @@
 #include "TimeGraphLayout.h"
 #include "Timer.h"
 #include "TimerChain.h"
+#include "TrackManager.h"
 #include "absl/container/flat_hash_map.h"
 #include "capture_data.pb.h"
 
@@ -46,10 +47,6 @@ class TimeGraph {
 
   void NeedsUpdate();
   void UpdatePrimitives(PickingMode picking_mode);
-  void SortTracks();
-  void UpdateFilteredTrackList();
-  void UpdateMovingTrackSorting();
-  void UpdateTracks(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode);
   void SelectEvents(float world_start, float world_end, int32_t thread_id);
   const std::vector<orbit_client_protos::CallstackEvent>& GetSelectedCallstackEvents(int32_t tid);
 
@@ -57,8 +54,10 @@ class TimeGraph {
                     const orbit_client_protos::FunctionInfo* function);
   void UpdateMaxTimeStamp(uint64_t time);
 
+  // TODO (b/176056427): TimeGraph should not store nor expose CaptureData.
   [[nodiscard]] const CaptureData* GetCaptureData() const { return capture_data_; }
   void SetCaptureData(CaptureData* capture_data) { capture_data_ = capture_data; }
+  [[nodiscard]] TrackManager* const GetTrackManager() const { return track_manager_.get(); }
 
   [[nodiscard]] float GetThreadTotalHeight() const;
   [[nodiscard]] float GetTextBoxHeight() const { return layout_.GetTextBoxHeight(); }
@@ -117,7 +116,6 @@ class TimeGraph {
   void SetTextRenderer(TextRenderer* text_renderer) { text_renderer_ = text_renderer; }
   [[nodiscard]] TextRenderer* GetTextRenderer() { return &text_renderer_static_; }
   void SetStringManager(std::shared_ptr<StringManager> str_manager);
-  [[nodiscard]] StringManager* GetStringManager() { return string_manager_.get(); }
   void SetCanvas(GlCanvas* canvas);
   [[nodiscard]] GlCanvas* GetCanvas() { return canvas_; }
   [[nodiscard]] uint32_t CalculateZoomedFontSize() const {
@@ -182,19 +180,6 @@ class TimeGraph {
   [[nodiscard]] std::string GetThreadNameFromTid(uint32_t tid);
 
  protected:
-  std::shared_ptr<SchedulerTrack> GetOrCreateSchedulerTrack();
-  std::shared_ptr<ThreadTrack> GetOrCreateThreadTrack(int32_t tid);
-  std::shared_ptr<GpuTrack> GetOrCreateGpuTrack(uint64_t timeline_hash);
-  GraphTrack* GetOrCreateGraphTrack(const std::string& name);
-  AsyncTrack* GetOrCreateAsyncTrack(const std::string& name);
-  std::shared_ptr<FrameTrack> GetOrCreateFrameTrack(
-      const orbit_client_protos::FunctionInfo& function);
-
-  void AddTrack(std::shared_ptr<Track> track);
-  int FindMovingTrackIndex();
-
-  [[nodiscard]] std::vector<int32_t> GetSortedThreadIds();
-
   void ProcessOrbitFunctionTimer(orbit_client_protos::FunctionInfo::OrbitType type,
                                  const orbit_client_protos::TimerInfo& timer_info);
   void ProcessIntrospectionTimer(const orbit_client_protos::TimerInfo& timer_info);
@@ -221,11 +206,9 @@ class TimeGraph {
   uint64_t capture_min_timestamp_ = 0;
   uint64_t capture_max_timestamp_ = 0;
   uint64_t current_mouse_time_ns_ = 0;
-  std::map<int32_t, uint32_t> event_count_;
   double time_window_us_ = 0;
   float world_start_x_ = 0;
   float world_width_ = 0;
-  float min_y_ = 0;
   float right_margin_ = 0;
 
   TimeGraphLayout layout_;
@@ -245,31 +228,15 @@ class TimeGraph {
   bool draw_text_ = true;
 
   Batcher batcher_;
-  Timer last_thread_reorder_;
 
   // TODO(b/174655559): Use absl's mutex here.
   mutable std::recursive_mutex mutex_;
 
-  std::vector<std::shared_ptr<Track>> tracks_;
-  std::unordered_map<int32_t, std::shared_ptr<ThreadTrack>> thread_tracks_;
-  std::map<std::string, std::shared_ptr<AsyncTrack>> async_tracks_;
-  std::map<std::string, std::shared_ptr<GraphTrack>> graph_tracks_;
-  // Mapping from timeline hash to GPU tracks.
-  std::unordered_map<uint64_t, std::shared_ptr<GpuTrack>> gpu_tracks_;
-  // Mapping from function address to frame tracks.
-  std::unordered_map<uint64_t, std::shared_ptr<FrameTrack>> frame_tracks_;
-
-  std::vector<std::shared_ptr<Track>> sorted_tracks_;
-  std::vector<std::shared_ptr<Track>> sorted_filtered_tracks_;
-  std::string thread_filter_;
-
-  std::shared_ptr<SchedulerTrack> scheduler_track_;
-  std::shared_ptr<ThreadTrack> tracepoints_system_wide_track_;
+  std::unique_ptr<TrackManager> track_manager_;
 
   absl::flat_hash_map<int32_t, std::vector<orbit_client_protos::CallstackEvent>>
       selected_callstack_events_per_thread_;
 
-  std::shared_ptr<StringManager> string_manager_;
   ManualInstrumentationManager* manual_instrumentation_manager_;
   std::unique_ptr<ManualInstrumentationManager::AsyncTimerInfoListener> async_timer_info_listener_;
   CaptureData* capture_data_ = nullptr;

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -5,30 +5,29 @@
 #ifndef ORBIT_GL_TIME_GRAPH_H_
 #define ORBIT_GL_TIME_GRAPH_H_
 
-#include <thread>
-#include <unordered_map>
-#include <utility>
+#include <absl/container/flat_hash_map.h>
+#include <math.h>
 
-#include "AsyncTrack.h"
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
 #include "Batcher.h"
-#include "BlockChain.h"
+#include "CoreMath.h"
 #include "CoreUtils.h"
-#include "FrameTrack.h"
-#include "Geometry.h"
-#include "GpuTrack.h"
-#include "GraphTrack.h"
 #include "ManualInstrumentationManager.h"
-#include "OrbitBase/Profiling.h"
-#include "OrbitBase/Tracing.h"
 #include "OrbitClientModel/CaptureData.h"
-#include "SchedulerTrack.h"
+#include "PickingManager.h"
 #include "StringManager.h"
 #include "TextBox.h"
 #include "TextRenderer.h"
-#include "ThreadTrack.h"
 #include "TimeGraphLayout.h"
-#include "Timer.h"
 #include "TimerChain.h"
+#include "Track.h"
 #include "TrackManager.h"
 #include "absl/container/flat_hash_map.h"
 #include "capture_data.pb.h"

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -179,6 +179,7 @@ class TimeGraph {
 
   [[nodiscard]] bool HasFrameTrack(const orbit_client_protos::FunctionInfo& function) const;
   void RemoveFrameTrack(const orbit_client_protos::FunctionInfo& function);
+  [[nodiscard]] std::string GetThreadNameFromTid(uint32_t tid);
 
  protected:
   std::shared_ptr<SchedulerTrack> GetOrCreateSchedulerTrack();
@@ -201,7 +202,6 @@ class TimeGraph {
   void ProcessAsyncTimer(const std::string& track_name,
                          const orbit_client_protos::TimerInfo& timer_info);
   void SetNumCores(uint32_t num_cores) { num_cores_ = num_cores; }
-  [[nodiscard]] std::string GetThreadNameFromTid(uint32_t tid);
 
  private:
   uint32_t font_size_;

--- a/OrbitGl/TimerTrack.cpp
+++ b/OrbitGl/TimerTrack.cpp
@@ -185,7 +185,7 @@ std::string TimerTrack::GetTooltip() const {
          "functions";
 }
 
-std::vector<std::shared_ptr<TimerChain>> TimerTrack::GetTimers() {
+std::vector<std::shared_ptr<TimerChain>> TimerTrack::GetTimers() const {
   std::vector<std::shared_ptr<TimerChain>> timers;
   absl::MutexLock lock(&mutex_);
   for (auto& pair : timers_) {
@@ -247,7 +247,7 @@ const TextBox* TimerTrack::GetDown(const TextBox* text_box) const {
   return GetFirstAfterTime(timer_info.start(), timer_info.depth() + 1);
 }
 
-std::vector<std::shared_ptr<TimerChain>> TimerTrack::GetAllChains() {
+std::vector<std::shared_ptr<TimerChain>> TimerTrack::GetAllChains() const {
   std::vector<std::shared_ptr<TimerChain>> chains;
   for (const auto& pair : timers_) {
     chains.push_back(pair.second);
@@ -255,7 +255,7 @@ std::vector<std::shared_ptr<TimerChain>> TimerTrack::GetAllChains() {
   return chains;
 }
 
-std::vector<std::shared_ptr<TimerChain>> TimerTrack::GetAllSerializableChains() {
+std::vector<std::shared_ptr<TimerChain>> TimerTrack::GetAllSerializableChains() const {
   return GetAllChains();
 }
 

--- a/OrbitGl/TimerTrack.h
+++ b/OrbitGl/TimerTrack.h
@@ -36,7 +36,7 @@ class TimerTrack : public Track {
                         float z_offset = 0) override;
   [[nodiscard]] Type GetType() const override { return kTimerTrack; }
 
-  [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetTimers() override;
+  [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetTimers() const override;
   [[nodiscard]] uint32_t GetDepth() const { return depth_; }
   [[nodiscard]] std::string GetExtraInfo(const orbit_client_protos::TimerInfo& timer);
   [[nodiscard]] uint32_t GetNumTimers() const { return num_timers_; }
@@ -52,8 +52,8 @@ class TimerTrack : public Track {
   [[nodiscard]] virtual const TextBox* GetUp(const TextBox* textbox) const;
   [[nodiscard]] virtual const TextBox* GetDown(const TextBox* textbox) const;
 
-  [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllChains() override;
-  [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllSerializableChains() override;
+  [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllChains() const override;
+  [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllSerializableChains() const override;
   [[nodiscard]] bool IsEmpty() const override;
 
   [[nodiscard]] bool IsCollapsable() const override { return depth_ > 1; }

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -66,9 +66,9 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
     return num_prioritized_trailing_characters_;
   }
 
-  [[nodiscard]] virtual std::vector<std::shared_ptr<TimerChain>> GetTimers() { return {}; }
-  [[nodiscard]] virtual std::vector<std::shared_ptr<TimerChain>> GetAllChains() { return {}; }
-  [[nodiscard]] virtual std::vector<std::shared_ptr<TimerChain>> GetAllSerializableChains() {
+  [[nodiscard]] virtual std::vector<std::shared_ptr<TimerChain>> GetTimers() const { return {}; }
+  [[nodiscard]] virtual std::vector<std::shared_ptr<TimerChain>> GetAllChains() const { return {}; }
+  [[nodiscard]] virtual std::vector<std::shared_ptr<TimerChain>> GetAllSerializableChains() const {
     return {};
   }
 

--- a/OrbitGl/TrackManager.cpp
+++ b/OrbitGl/TrackManager.cpp
@@ -4,9 +4,28 @@
 
 #include "TrackManager.h"
 
+#include <GteVector.h>
+#include <absl/strings/ascii.h>
+#include <absl/strings/match.h>
+#include <absl/strings/str_format.h>
+#include <absl/strings/str_split.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <optional>
+#include <string_view>
+#include <utility>
+
 #include "App.h"
+#include "CoreMath.h"
 #include "CoreUtils.h"
+#include "GlCanvas.h"
+#include "OrbitBase/Logging.h"
 #include "OrbitBase/ThreadConstants.h"
+#include "OrbitClientData/CallstackData.h"
+#include "OrbitClientModel/CaptureData.h"
+#include "TimeGraph.h"
+#include "TimeGraphLayout.h"
 
 using orbit_client_protos::FunctionInfo;
 

--- a/OrbitGl/TrackManager.cpp
+++ b/OrbitGl/TrackManager.cpp
@@ -1,0 +1,446 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "TrackManager.h"
+
+#include "App.h"
+#include "CoreUtils.h"
+#include "OrbitBase/ThreadConstants.h"
+
+using orbit_client_protos::FunctionInfo;
+
+TrackManager::TrackManager(TimeGraph* time_graph) : time_graph_(time_graph) {
+  scheduler_track_ = GetOrCreateSchedulerTrack();
+
+  tracepoints_system_wide_track_ = GetOrCreateThreadTrack(orbit_base::kAllThreadsOfAllProcessesTid);
+}
+
+void TrackManager::Clear() {
+  tracks_.clear();
+  scheduler_track_ = nullptr;
+  thread_tracks_.clear();
+  gpu_tracks_.clear();
+  graph_tracks_.clear();
+  async_tracks_.clear();
+  frame_tracks_.clear();
+
+  sorted_tracks_.clear();
+  sorted_filtered_tracks_.clear();
+
+  scheduler_track_ = GetOrCreateSchedulerTrack();
+  tracepoints_system_wide_track_ = GetOrCreateThreadTrack(orbit_base::kAllThreadsOfAllProcessesTid);
+}
+
+void TrackManager::SetStringManager(std::shared_ptr<StringManager> str_manager) {
+  string_manager_ = std::move(str_manager);
+}
+
+std::vector<std::shared_ptr<Track>> TrackManager::GetTracks() const { return tracks_; }
+
+std::vector<std::shared_ptr<ThreadTrack>> TrackManager::GetThreadTracks() const {
+  std::vector<std::shared_ptr<ThreadTrack>> tracks;
+  for (auto& [unused_key, thread_track] : thread_tracks_) {
+    tracks.emplace_back(thread_track);
+  }
+  return tracks;
+}
+
+std::vector<std::shared_ptr<FrameTrack>> TrackManager::GetFrameTracks() const {
+  std::vector<std::shared_ptr<FrameTrack>> tracks;
+  for (auto& [unused_key, track] : frame_tracks_) {
+    tracks.emplace_back(track);
+  }
+  return tracks;
+}
+
+std::vector<std::shared_ptr<AsyncTrack>> TrackManager::GetAsyncTracks() const {
+  std::vector<std::shared_ptr<AsyncTrack>> tracks;
+  for (auto& [unused_key, track] : async_tracks_) {
+    tracks.emplace_back(track);
+  }
+  return tracks;
+}
+
+std::vector<std::shared_ptr<GraphTrack>> TrackManager::GetGraphTracks() const {
+  std::vector<std::shared_ptr<GraphTrack>> tracks;
+  for (auto& [unused_key, track] : graph_tracks_) {
+    tracks.emplace_back(track);
+  }
+  return tracks;
+}
+
+std::vector<std::shared_ptr<GpuTrack>> TrackManager::GetGpuTracks() const {
+  std::vector<std::shared_ptr<GpuTrack>> tracks;
+  for (auto& [unused_key, track] : gpu_tracks_) {
+    tracks.emplace_back(track);
+  }
+  return tracks;
+}
+
+void TrackManager::SortTracks() {
+  std::shared_ptr<ThreadTrack> process_track = nullptr;
+
+  const CaptureData* capture_data = time_graph_->GetCaptureData();
+  if (capture_data != nullptr) {
+    // Get or create thread track from events' thread id.
+    event_count_.clear();
+    event_count_[orbit_base::kAllProcessThreadsTid] =
+        capture_data->GetCallstackData()->GetCallstackEventsCount();
+
+    // The process track is a special ThreadTrack of id "kAllThreadsFakeTid".
+    process_track = GetOrCreateThreadTrack(orbit_base::kAllProcessThreadsTid);
+    for (const auto& tid_and_count :
+         capture_data->GetCallstackData()->GetCallstackEventsCountsPerTid()) {
+      const int32_t thread_id = tid_and_count.first;
+      const uint32_t count = tid_and_count.second;
+      event_count_[thread_id] = count;
+      GetOrCreateThreadTrack(thread_id);
+    }
+  }
+
+  // Reorder threads once every second when capturing
+  if (!GOrbitApp->IsCapturing() || last_thread_reorder_.ElapsedMillis() > 1000.0) {
+    std::vector<int32_t> sorted_thread_ids = GetSortedThreadIds();
+
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
+    // Gather all tracks regardless of the process in sorted order
+    std::vector<std::shared_ptr<Track>> all_processes_sorted_tracks;
+
+    // Gpu tracks.
+    for (const auto& timeline_and_track : gpu_tracks_) {
+      all_processes_sorted_tracks.emplace_back(timeline_and_track.second);
+    }
+
+    // Frame tracks.
+    for (const auto& name_and_track : frame_tracks_) {
+      all_processes_sorted_tracks.emplace_back(name_and_track.second);
+    }
+
+    // Graph tracks.
+    for (const auto& graph_track : graph_tracks_) {
+      all_processes_sorted_tracks.emplace_back(graph_track.second);
+    }
+
+    // Async tracks.
+    for (const auto& async_track : async_tracks_) {
+      all_processes_sorted_tracks.emplace_back(async_track.second);
+    }
+
+    // Tracepoint tracks.
+    if (!tracepoints_system_wide_track_->IsEmpty()) {
+      all_processes_sorted_tracks.emplace_back(tracepoints_system_wide_track_);
+    }
+
+    // Process track.
+    if (process_track && !process_track->IsEmpty()) {
+      all_processes_sorted_tracks.emplace_back(process_track);
+    }
+
+    // Thread tracks.
+    for (auto thread_id : sorted_thread_ids) {
+      std::shared_ptr<ThreadTrack> track = GetOrCreateThreadTrack(thread_id);
+      if (!track->IsEmpty()) {
+        all_processes_sorted_tracks.emplace_back(track);
+      }
+    }
+
+    // Separate "capture_pid" tracks from tracks that originate from other processes.
+    int32_t capture_pid = capture_data ? capture_data->process_id() : 0;
+    std::vector<std::shared_ptr<Track>> capture_pid_tracks;
+    std::vector<std::shared_ptr<Track>> external_pid_tracks;
+    for (auto& track : all_processes_sorted_tracks) {
+      int32_t pid = track->GetProcessId();
+      if (pid != -1 && pid != capture_pid) {
+        external_pid_tracks.emplace_back(track);
+      } else {
+        capture_pid_tracks.emplace_back(track);
+      }
+    }
+
+    // Clear before repopulating.
+    sorted_tracks_.clear();
+
+    // Scheduler track.
+    if (!scheduler_track_->IsEmpty()) {
+      sorted_tracks_.emplace_back(scheduler_track_);
+    }
+
+    // For now, "external_pid_tracks" should only contain
+    // introspection tracks. Display them on top.
+    Append(sorted_tracks_, external_pid_tracks);
+    Append(sorted_tracks_, capture_pid_tracks);
+
+    last_thread_reorder_.Restart();
+
+    UpdateFilteredTrackList();
+  }
+}
+
+void TrackManager::SetFilter(const std::string& filter) {
+  filter_ = absl::AsciiStrToLower(filter);
+  UpdateFilteredTrackList();
+}
+
+void TrackManager::UpdateFilteredTrackList() {
+  if (filter_.empty()) {
+    sorted_filtered_tracks_ = sorted_tracks_;
+    return;
+  }
+
+  sorted_filtered_tracks_.clear();
+  std::vector<std::string> filters = absl::StrSplit(filter_, ' ', absl::SkipWhitespace());
+  for (const auto& track : sorted_tracks_) {
+    std::string lower_case_label = absl::AsciiStrToLower(track->GetLabel());
+    for (auto& filter : filters) {
+      if (absl::StrContains(lower_case_label, filter)) {
+        sorted_filtered_tracks_.emplace_back(track);
+        break;
+      }
+    }
+  }
+}
+
+std::vector<int32_t>
+TrackManager::GetSortedThreadIds() {  // Show threads with instrumented functions first
+  std::vector<int32_t> sorted_thread_ids;
+  std::vector<std::pair<int32_t, uint32_t>> sorted_threads =
+      OrbitUtils::ReverseValueSort(thread_count_map_);
+
+  for (auto& [tid, unused_value] : sorted_threads) {
+    // Track "kAllThreadsFakeTid" holds all target process sampling info, it is handled
+    // separately.
+    if (tid != orbit_base::kAllProcessThreadsTid) {
+      sorted_thread_ids.push_back(tid);
+    }
+  }
+
+  // Then show threads sorted by number of events
+  std::vector<std::pair<int32_t, uint32_t>> sorted_by_events =
+      OrbitUtils::ReverseValueSort(event_count_);
+  for (auto& [tid, unused_value] : sorted_by_events) {
+    // Track "kAllThreadsFakeTid" holds all target process sampling info, it is handled
+    // separately.
+    if (tid == orbit_base::kAllProcessThreadsTid) continue;
+    if (thread_count_map_.find(tid) == thread_count_map_.end()) {
+      sorted_thread_ids.push_back(tid);
+    }
+  }
+
+  return sorted_thread_ids;
+}
+
+void TrackManager::UpdateMovingTrackSorting() {
+  // This updates the position of the currently moving track in both the sorted_tracks_
+  // and the sorted_filtered_tracks_ array. The moving track is inserted after the first track
+  // with a value of top + height smaller than the current mouse position.
+  // Only drawn (i.e. not filtered out) tracks are taken into account to determine the
+  // insertion position, but both arrays are updated accordingly.
+  //
+  // Note: We do an O(n) search for the correct position in the sorted_tracks_ array which
+  // could be optimized, but this is not worth the effort for the limited number of tracks.
+
+  int moving_track_previous_position = FindMovingTrackIndex();
+
+  if (moving_track_previous_position != -1) {
+    std::shared_ptr<Track> moving_track = sorted_filtered_tracks_[moving_track_previous_position];
+    sorted_filtered_tracks_.erase(sorted_filtered_tracks_.begin() + moving_track_previous_position);
+
+    int moving_track_current_position = -1;
+    for (auto track_it = sorted_filtered_tracks_.begin(); track_it != sorted_filtered_tracks_.end();
+         ++track_it) {
+      if (moving_track->GetPos()[1] >= (*track_it)->GetPos()[1]) {
+        sorted_filtered_tracks_.insert(track_it, moving_track);
+        moving_track_current_position = track_it - sorted_filtered_tracks_.begin();
+        break;
+      }
+    }
+
+    if (moving_track_current_position == -1) {
+      sorted_filtered_tracks_.push_back(moving_track);
+      moving_track_current_position = static_cast<int>(sorted_filtered_tracks_.size()) - 1;
+    }
+
+    // Now we have to change the position of the moving_track in the non-filtered array
+    if (moving_track_current_position == moving_track_previous_position) {
+      return;
+    }
+    sorted_tracks_.erase(std::find(sorted_tracks_.begin(), sorted_tracks_.end(), moving_track));
+    if (moving_track_current_position > moving_track_previous_position) {
+      // In this case we will insert the moving_track right after the one who is before in the
+      // filtered array
+      auto previous_filtered_track = sorted_filtered_tracks_[moving_track_current_position - 1];
+      sorted_tracks_.insert(
+          ++std::find(sorted_tracks_.begin(), sorted_tracks_.end(), previous_filtered_track),
+          moving_track);
+    } else {
+      // In this case we will insert the moving_track right before the one who is after in the
+      // filtered array
+      auto next_filtered_track = sorted_filtered_tracks_[moving_track_current_position + 1];
+      sorted_tracks_.insert(
+          std::find(sorted_tracks_.begin(), sorted_tracks_.end(), next_filtered_track),
+          moving_track);
+    }
+  }
+}
+
+int TrackManager::FindMovingTrackIndex() {
+  // Returns the position of the moving track, or -1 if there is none.
+  for (auto track_it = sorted_filtered_tracks_.begin(); track_it != sorted_filtered_tracks_.end();
+       ++track_it) {
+    if ((*track_it)->IsMoving()) {
+      return track_it - sorted_filtered_tracks_.begin();
+    }
+  }
+  return -1;
+}
+
+void TrackManager::UpdateTracks(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode) {
+  TimeGraphLayout layout = time_graph_->GetLayout();
+
+  // Make sure track tab fits in the viewport.
+  float current_y = -layout.GetSchedulerTrackOffset() - layout.GetTrackTabHeight();
+  float pinned_tracks_height = 0.f;
+
+  // Draw pinned tracks
+  for (auto& track : sorted_filtered_tracks_) {
+    if (!track->IsPinned()) {
+      continue;
+    }
+
+    const float z_offset = GlCanvas::kZOffsetPinnedTrack;
+    track->SetY(current_y + time_graph_->GetCanvas()->GetWorldTopLeftY() - layout.GetTopMargin() -
+                layout.GetSchedulerTrackOffset());
+    track->UpdatePrimitives(min_tick, max_tick, picking_mode, z_offset);
+    const float height = (track->GetHeight() + layout.GetSpaceBetweenTracks());
+    current_y -= height;
+    pinned_tracks_height += height;
+  }
+
+  // Draw unpinned tracks
+  for (auto& track : sorted_filtered_tracks_) {
+    if (track->IsPinned()) {
+      continue;
+    }
+
+    const float z_offset = track->IsMoving() ? GlCanvas::kZOffsetMovingTack : 0.f;
+    track->SetY(current_y);
+    track->UpdatePrimitives(min_tick, max_tick, picking_mode, z_offset);
+    current_y -= (track->GetHeight() + layout.GetSpaceBetweenTracks());
+  }
+
+  // Tracks are drawn from 0 (top) to negative y-coordinates.
+  tracks_height_ = std::abs(current_y);
+}
+
+void TrackManager::AddTrack(std::shared_ptr<Track> track) {
+  tracks_.emplace_back(track);
+  sorting_invalidated_ = true;
+}
+
+void TrackManager::RemoveFrameTrack(uint64_t function_address) {
+  frame_tracks_.erase(function_address);
+  sorting_invalidated_ = true;
+}
+
+std::shared_ptr<SchedulerTrack> TrackManager::GetOrCreateSchedulerTrack() {
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  std::shared_ptr<SchedulerTrack> track = scheduler_track_;
+  if (track == nullptr) {
+    track = std::make_shared<SchedulerTrack>(time_graph_);
+    AddTrack(track);
+    scheduler_track_ = track;
+    uint32_t num_cores = time_graph_->GetNumCores();
+    time_graph_->GetLayout().SetNumCores(num_cores);
+    scheduler_track_->SetLabel(absl::StrFormat("Scheduler (%u cores)", num_cores));
+  }
+  return track;
+}
+
+std::shared_ptr<ThreadTrack> TrackManager::GetOrCreateThreadTrack(int32_t tid) {
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  std::shared_ptr<ThreadTrack> track = thread_tracks_[tid];
+  if (track == nullptr) {
+    track = std::make_shared<ThreadTrack>(time_graph_, tid);
+    AddTrack(track);
+    thread_tracks_[tid] = track;
+    track->SetTrackColor(TimeGraph::GetThreadColor(tid));
+    if (tid == orbit_base::kAllThreadsOfAllProcessesTid) {
+      track->SetName("All tracepoint events");
+      track->SetLabel("All tracepoint events");
+    } else if (tid == orbit_base::kAllProcessThreadsTid) {
+      // This is the process track.
+      const CaptureData& capture_data = GOrbitApp->GetCaptureData();
+      std::string process_name = capture_data.process_name();
+      track->SetName(process_name);
+      const std::string_view all_threads = " (all_threads)";
+      track->SetLabel(process_name.append(all_threads));
+      track->SetNumberOfPrioritizedTrailingCharacters(all_threads.size() - 1);
+    } else {
+      const std::string& thread_name = time_graph_->GetThreadNameFromTid(tid);
+      track->SetName(thread_name);
+      std::string tid_str = std::to_string(tid);
+      std::string track_label = absl::StrFormat("%s [%s]", thread_name, tid_str);
+      track->SetNumberOfPrioritizedTrailingCharacters(tid_str.size() + 2);
+      track->SetLabel(track_label);
+    }
+  }
+  return track;
+}
+
+std::shared_ptr<GpuTrack> TrackManager::GetOrCreateGpuTrack(uint64_t timeline_hash) {
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  std::shared_ptr<GpuTrack> track = gpu_tracks_[timeline_hash];
+  if (track == nullptr) {
+    track = std::make_shared<GpuTrack>(time_graph_, string_manager_, timeline_hash);
+    std::string timeline = string_manager_->Get(timeline_hash).value_or("");
+    std::string label = OrbitGl::MapGpuTimelineToTrackLabel(timeline);
+    track->SetName(timeline);
+    track->SetLabel(label);
+    // This min combine two cases, label == timeline and when label includes timeline
+    track->SetNumberOfPrioritizedTrailingCharacters(std::min(label.size(), timeline.size() + 2));
+    AddTrack(track);
+    gpu_tracks_[timeline_hash] = track;
+  }
+
+  return track;
+}
+
+GraphTrack* TrackManager::GetOrCreateGraphTrack(const std::string& name) {
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  std::shared_ptr<GraphTrack> track = graph_tracks_[name];
+  if (track == nullptr) {
+    track = std::make_shared<GraphTrack>(time_graph_, name);
+    track->SetName(name);
+    track->SetLabel(name);
+    AddTrack(track);
+    graph_tracks_[name] = track;
+  }
+
+  return track.get();
+}
+
+AsyncTrack* TrackManager::GetOrCreateAsyncTrack(const std::string& name) {
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  std::shared_ptr<AsyncTrack> track = async_tracks_[name];
+  if (track == nullptr) {
+    track = std::make_shared<AsyncTrack>(time_graph_, name);
+    AddTrack(track);
+    async_tracks_[name] = track;
+  }
+
+  return track.get();
+}
+
+std::shared_ptr<FrameTrack> TimeGraph::GetOrCreateFrameTrack(const FunctionInfo& function) {
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  std::shared_ptr<FrameTrack> track = frame_tracks_[function.address()];
+  if (track == nullptr) {
+    track = std::make_shared<FrameTrack>(this, function);
+    // Normally we would call AddTrack(track) here, but frame tracks are removable by users
+    // and therefore cannot be simply thrown into the flat vector of tracks.
+    sorting_invalidated_ = true;
+    frame_tracks_[function.address()] = track;
+  }
+  return track;
+}

--- a/OrbitGl/TrackManager.cpp
+++ b/OrbitGl/TrackManager.cpp
@@ -57,7 +57,7 @@ void TrackManager::SetStringManager(StringManager* str_manager) { string_manager
 std::vector<Track*> TrackManager::GetAllTracks() const {
   std::vector<Track*> tracks;
   for (auto track : all_tracks_) {
-    tracks.emplace_back(track.get());
+    tracks.push_back(track.get());
   }
   return tracks;
 }
@@ -65,7 +65,7 @@ std::vector<Track*> TrackManager::GetAllTracks() const {
 std::vector<ThreadTrack*> TrackManager::GetThreadTracks() const {
   std::vector<ThreadTrack*> tracks;
   for (auto& [unused_key, track] : thread_tracks_) {
-    tracks.emplace_back(track.get());
+    tracks.push_back(track.get());
   }
   return tracks;
 }
@@ -73,7 +73,7 @@ std::vector<ThreadTrack*> TrackManager::GetThreadTracks() const {
 std::vector<FrameTrack*> TrackManager::GetFrameTracks() const {
   std::vector<FrameTrack*> tracks;
   for (auto& [unused_key, track] : frame_tracks_) {
-    tracks.emplace_back(track.get());
+    tracks.push_back(track.get());
   }
   return tracks;
 }
@@ -111,39 +111,39 @@ void TrackManager::SortTracks() {
 
     // Gpu tracks.
     for (const auto& timeline_and_track : gpu_tracks_) {
-      all_processes_sorted_tracks.emplace_back(timeline_and_track.second.get());
+      all_processes_sorted_tracks.push_back(timeline_and_track.second.get());
     }
 
     // Frame tracks.
     for (const auto& name_and_track : frame_tracks_) {
-      all_processes_sorted_tracks.emplace_back(name_and_track.second.get());
+      all_processes_sorted_tracks.push_back(name_and_track.second.get());
     }
 
     // Graph tracks.
     for (const auto& graph_track : graph_tracks_) {
-      all_processes_sorted_tracks.emplace_back(graph_track.second.get());
+      all_processes_sorted_tracks.push_back(graph_track.second.get());
     }
 
     // Async tracks.
     for (const auto& async_track : async_tracks_) {
-      all_processes_sorted_tracks.emplace_back(async_track.second.get());
+      all_processes_sorted_tracks.push_back(async_track.second.get());
     }
 
     // Tracepoint tracks.
     if (!tracepoints_system_wide_track_->IsEmpty()) {
-      all_processes_sorted_tracks.emplace_back(tracepoints_system_wide_track_);
+      all_processes_sorted_tracks.push_back(tracepoints_system_wide_track_);
     }
 
     // Process track.
     if (process_track && !process_track->IsEmpty()) {
-      all_processes_sorted_tracks.emplace_back(process_track);
+      all_processes_sorted_tracks.push_back(process_track);
     }
 
     // Thread tracks.
     for (auto thread_id : sorted_thread_ids) {
       auto track = GetOrCreateThreadTrack(thread_id);
       if (!track->IsEmpty()) {
-        all_processes_sorted_tracks.emplace_back(track);
+        all_processes_sorted_tracks.push_back(track);
       }
     }
 
@@ -154,9 +154,9 @@ void TrackManager::SortTracks() {
     for (auto& track : all_processes_sorted_tracks) {
       int32_t pid = track->GetProcessId();
       if (pid != -1 && pid != capture_pid) {
-        external_pid_tracks.emplace_back(track);
+        external_pid_tracks.push_back(track);
       } else {
-        capture_pid_tracks.emplace_back(track);
+        capture_pid_tracks.push_back(track);
       }
     }
 
@@ -165,7 +165,7 @@ void TrackManager::SortTracks() {
 
     // Scheduler track.
     if (!scheduler_track_->IsEmpty()) {
-      sorted_tracks_.emplace_back(scheduler_track_.get());
+      sorted_tracks_.push_back(scheduler_track_.get());
     }
 
     // For now, "external_pid_tracks" should only contain
@@ -197,7 +197,7 @@ void TrackManager::UpdateFilteredTrackList() {
     std::string lower_case_label = absl::AsciiStrToLower(track->GetLabel());
     for (auto& filter : filters) {
       if (absl::StrContains(lower_case_label, filter)) {
-        visible_tracks_.emplace_back(track);
+        visible_tracks_.push_back(track);
         break;
       }
     }
@@ -335,7 +335,7 @@ void TrackManager::UpdateTracks(uint64_t min_tick, uint64_t max_tick, PickingMod
 }
 
 void TrackManager::AddTrack(std::shared_ptr<Track> track) {
-  all_tracks_.emplace_back(track);
+  all_tracks_.push_back(track);
   sorting_invalidated_ = true;
 }
 

--- a/OrbitGl/TrackManager.h
+++ b/OrbitGl/TrackManager.h
@@ -14,13 +14,14 @@
 #include "SchedulerTrack.h"
 #include "ThreadTrack.h"
 
+class OrbitApp;
 class Timegraph;
 
 // TrackManager is in charge of the active Tracks in Timegraph (their creation, searching, erasing
 // and sorting).
 class TrackManager {
  public:
-  explicit TrackManager(TimeGraph* time_graph);
+  explicit TrackManager(TimeGraph* time_graph, OrbitApp* app);
 
   void Clear();
 
@@ -41,14 +42,14 @@ class TrackManager {
     return tracepoints_system_wide_track_;
   }
 
-  void SetStringManager(std::shared_ptr<StringManager> str_manager);
-  [[nodiscard]] std::shared_ptr<StringManager> GetStringManager() { return string_manager_; }
+  void SetStringManager(StringManager* str_manager);
+  [[nodiscard]] const StringManager* GetStringManager() const { return string_manager_; }
 
   void SortTracks();
   void SetFilter(const std::string& filter);
 
   void UpdateTracks(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode);
-  [[nodiscard]] float GetTracksHeight() const { return tracks_height_; }
+  [[nodiscard]] float GetTracksTotalHeight() const { return tracks_total_height_; }
 
   std::shared_ptr<SchedulerTrack> GetOrCreateSchedulerTrack();
   std::shared_ptr<ThreadTrack> GetOrCreateThreadTrack(int32_t tid);
@@ -77,6 +78,7 @@ class TrackManager {
   // Mapping from timeline hash to GPU tracks.
   std::unordered_map<uint64_t, std::shared_ptr<GpuTrack>> gpu_tracks_;
   // Mapping from function address to frame tracks.
+  // TODO (b/175865913): Use Function info instead of their address as key to FrameTracks
   std::unordered_map<uint64_t, std::shared_ptr<FrameTrack>> frame_tracks_;
   std::shared_ptr<SchedulerTrack> scheduler_track_;
   std::shared_ptr<ThreadTrack> tracepoints_system_wide_track_;
@@ -91,6 +93,8 @@ class TrackManager {
 
   std::string filter_;
   std::vector<std::shared_ptr<Track>> sorted_filtered_tracks_;
-  float tracks_height_;
-  std::shared_ptr<StringManager> string_manager_;
+  float tracks_total_height_;
+  StringManager* string_manager_;
+
+  OrbitApp* app_ = nullptr;
 };

--- a/OrbitGl/TrackManager.h
+++ b/OrbitGl/TrackManager.h
@@ -4,15 +4,27 @@
 
 #pragma once
 
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
 #include <unordered_map>
-#include <utility>
+#include <vector>
 
 #include "AsyncTrack.h"
 #include "FrameTrack.h"
 #include "GpuTrack.h"
 #include "GraphTrack.h"
+#include "PickingManager.h"
 #include "SchedulerTrack.h"
+#include "StringManager.h"
 #include "ThreadTrack.h"
+#include "Timer.h"
+#include "Track.h"
+#include "capture_data.pb.h"
 
 class OrbitApp;
 class Timegraph;

--- a/OrbitGl/TrackManager.h
+++ b/OrbitGl/TrackManager.h
@@ -1,0 +1,96 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#pragma once
+
+#include <unordered_map>
+#include <utility>
+
+#include "AsyncTrack.h"
+#include "FrameTrack.h"
+#include "GpuTrack.h"
+#include "GraphTrack.h"
+#include "SchedulerTrack.h"
+#include "ThreadTrack.h"
+
+class Timegraph;
+
+// TrackManager is in charge of the active Tracks in Timegraph (their creation, searching, erasing
+// and sorting).
+class TrackManager {
+ public:
+  explicit TrackManager(TimeGraph* time_graph);
+
+  void Clear();
+
+  [[nodiscard]] std::vector<std::shared_ptr<Track>> GetTracks() const;
+  [[nodiscard]] std::vector<std::shared_ptr<Track>> GetFilteredTracks() const {
+    return sorted_filtered_tracks_;
+  }
+  [[nodiscard]] std::vector<std::shared_ptr<ThreadTrack>> GetThreadTracks() const;
+  [[nodiscard]] std::vector<std::shared_ptr<FrameTrack>> GetFrameTracks() const;
+  [[nodiscard]] std::vector<std::shared_ptr<AsyncTrack>> GetAsyncTracks() const;
+  [[nodiscard]] std::vector<std::shared_ptr<GraphTrack>> GetGraphTracks() const;
+  [[nodiscard]] std::vector<std::shared_ptr<GpuTrack>> GetGpuTracks() const;
+
+  [[nodiscard]] std::shared_ptr<SchedulerTrack> GetSchedulerTrack() const {
+    return scheduler_track_;
+  };
+  [[nodiscard]] std::shared_ptr<ThreadTrack> GetTracepointsSystemWideTrack() const {
+    return tracepoints_system_wide_track_;
+  }
+
+  void SetStringManager(std::shared_ptr<StringManager> str_manager);
+  [[nodiscard]] std::shared_ptr<StringManager> GetStringManager() { return string_manager_; }
+
+  void SortTracks();
+  void SetFilter(const std::string& filter);
+
+  void UpdateTracks(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode);
+  [[nodiscard]] float GetTracksHeight() const { return tracks_height_; }
+
+  std::shared_ptr<SchedulerTrack> GetOrCreateSchedulerTrack();
+  std::shared_ptr<ThreadTrack> GetOrCreateThreadTrack(int32_t tid);
+  std::shared_ptr<GpuTrack> GetOrCreateGpuTrack(uint64_t timeline_hash);
+  GraphTrack* GetOrCreateGraphTrack(const std::string& name);
+  AsyncTrack* GetOrCreateAsyncTrack(const std::string& name);
+  std::shared_ptr<FrameTrack> GetOrCreateFrameTrack(
+      const orbit_client_protos::FunctionInfo& function);
+
+  void AddTrack(std::shared_ptr<Track> track);
+  void RemoveFrameTrack(uint64_t function_address);
+
+  void UpdateMovingTrackSorting();
+
+ private:
+  void UpdateFilteredTrackList();
+  [[nodiscard]] int FindMovingTrackIndex();
+  [[nodiscard]] std::vector<int32_t> GetSortedThreadIds();
+
+  mutable std::recursive_mutex mutex_;
+
+  std::vector<std::shared_ptr<Track>> tracks_;
+  std::unordered_map<int32_t, std::shared_ptr<ThreadTrack>> thread_tracks_;
+  std::map<std::string, std::shared_ptr<AsyncTrack>> async_tracks_;
+  std::map<std::string, std::shared_ptr<GraphTrack>> graph_tracks_;
+  // Mapping from timeline hash to GPU tracks.
+  std::unordered_map<uint64_t, std::shared_ptr<GpuTrack>> gpu_tracks_;
+  // Mapping from function address to frame tracks.
+  std::unordered_map<uint64_t, std::shared_ptr<FrameTrack>> frame_tracks_;
+  std::shared_ptr<SchedulerTrack> scheduler_track_;
+  std::shared_ptr<ThreadTrack> tracepoints_system_wide_track_;
+
+  TimeGraph* time_graph_;
+
+  std::vector<std::shared_ptr<Track>> sorted_tracks_;
+  bool sorting_invalidated_;
+  Timer last_thread_reorder_;
+  std::map<int32_t, uint32_t> thread_count_map_;
+  std::map<int32_t, uint32_t> event_count_;
+
+  std::string filter_;
+  std::vector<std::shared_ptr<Track>> sorted_filtered_tracks_;
+  float tracks_height_;
+  std::shared_ptr<StringManager> string_manager_;
+};

--- a/OrbitGl/TrackManager.h
+++ b/OrbitGl/TrackManager.h
@@ -37,20 +37,12 @@ class TrackManager {
 
   void Clear();
 
-  [[nodiscard]] std::vector<std::shared_ptr<Track>> GetTracks() const;
-  [[nodiscard]] std::vector<std::shared_ptr<Track>> GetFilteredTracks() const {
-    return sorted_filtered_tracks_;
-  }
-  [[nodiscard]] std::vector<std::shared_ptr<ThreadTrack>> GetThreadTracks() const;
-  [[nodiscard]] std::vector<std::shared_ptr<FrameTrack>> GetFrameTracks() const;
-  [[nodiscard]] std::vector<std::shared_ptr<AsyncTrack>> GetAsyncTracks() const;
-  [[nodiscard]] std::vector<std::shared_ptr<GraphTrack>> GetGraphTracks() const;
-  [[nodiscard]] std::vector<std::shared_ptr<GpuTrack>> GetGpuTracks() const;
+  [[nodiscard]] std::vector<Track*> GetAllTracks() const;
+  [[nodiscard]] std::vector<Track*> GetVisibleTracks() const { return visible_tracks_; }
+  [[nodiscard]] std::vector<ThreadTrack*> GetThreadTracks() const;
+  [[nodiscard]] std::vector<FrameTrack*> GetFrameTracks() const;
 
-  [[nodiscard]] std::shared_ptr<SchedulerTrack> GetSchedulerTrack() const {
-    return scheduler_track_;
-  };
-  [[nodiscard]] std::shared_ptr<ThreadTrack> GetTracepointsSystemWideTrack() const {
+  [[nodiscard]] ThreadTrack* GetTracepointsSystemWideTrack() const {
     return tracepoints_system_wide_track_;
   }
 
@@ -63,13 +55,12 @@ class TrackManager {
   void UpdateTracks(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode);
   [[nodiscard]] float GetTracksTotalHeight() const { return tracks_total_height_; }
 
-  std::shared_ptr<SchedulerTrack> GetOrCreateSchedulerTrack();
-  std::shared_ptr<ThreadTrack> GetOrCreateThreadTrack(int32_t tid);
-  std::shared_ptr<GpuTrack> GetOrCreateGpuTrack(uint64_t timeline_hash);
+  SchedulerTrack* GetOrCreateSchedulerTrack();
+  ThreadTrack* GetOrCreateThreadTrack(int32_t tid);
+  GpuTrack* GetOrCreateGpuTrack(uint64_t timeline_hash);
   GraphTrack* GetOrCreateGraphTrack(const std::string& name);
   AsyncTrack* GetOrCreateAsyncTrack(const std::string& name);
-  std::shared_ptr<FrameTrack> GetOrCreateFrameTrack(
-      const orbit_client_protos::FunctionInfo& function);
+  FrameTrack* GetOrCreateFrameTrack(const orbit_client_protos::FunctionInfo& function);
 
   void AddTrack(std::shared_ptr<Track> track);
   void RemoveFrameTrack(uint64_t function_address);
@@ -83,7 +74,7 @@ class TrackManager {
 
   mutable std::recursive_mutex mutex_;
 
-  std::vector<std::shared_ptr<Track>> tracks_;
+  std::vector<std::shared_ptr<Track>> all_tracks_;
   std::unordered_map<int32_t, std::shared_ptr<ThreadTrack>> thread_tracks_;
   std::map<std::string, std::shared_ptr<AsyncTrack>> async_tracks_;
   std::map<std::string, std::shared_ptr<GraphTrack>> graph_tracks_;
@@ -93,18 +84,19 @@ class TrackManager {
   // TODO (b/175865913): Use Function info instead of their address as key to FrameTracks
   std::unordered_map<uint64_t, std::shared_ptr<FrameTrack>> frame_tracks_;
   std::shared_ptr<SchedulerTrack> scheduler_track_;
-  std::shared_ptr<ThreadTrack> tracepoints_system_wide_track_;
+  ThreadTrack* tracepoints_system_wide_track_;
 
   TimeGraph* time_graph_;
 
-  std::vector<std::shared_ptr<Track>> sorted_tracks_;
+  std::vector<Track*> sorted_tracks_;
   bool sorting_invalidated_;
   Timer last_thread_reorder_;
   std::map<int32_t, uint32_t> thread_count_map_;
   std::map<int32_t, uint32_t> event_count_;
 
   std::string filter_;
-  std::vector<std::shared_ptr<Track>> sorted_filtered_tracks_;
+  std::vector<Track*> visible_tracks_;
+
   float tracks_total_height_;
   StringManager* string_manager_;
 


### PR DESCRIPTION
Splitting TimeGraph by the creation of TrackManager, who will be on charge of everything related to the tracks (creation, searching, erasing and sorting). For now, this class have a reference to TimeGraph but in the future we want to erase it. We want to make unit tests on the tracks, which will be better if these test doesn't need to know about TimeGraph.

Future work appeared during the refactor:

**Next Steps in my roadmap:**
- Eliminate the TimeGraph dependence in TrackManager and in Tracks (b/176086740).
- Try to erase StringManager in TrackManager and TimeGraph 
- TrackManager should manage sorting by their own (b/176077097)

**Possible bugs:**
- Use FunctionInfo instead of only their address as key to FrameTracks (b/175865913)
- TimeGraph should not hold and expose CaptureData (b/176056427)

**Better design:**
- Improve the way to store, create and get the Tracks (b/175869409)
- Having tracks unique pointers instead of shared_ptr in TrackManager whenever possible.

