### PR TITLE
Split the mutex for process and callback update

### DIFF
--- a/OrbitClientServices/include/OrbitClientServices/ProcessManager.h
+++ b/OrbitClientServices/include/OrbitClientServices/ProcessManager.h
@@ -35,17 +35,19 @@
 //
 class ProcessManager {
  public:
+  using ProcessList = std::vector<orbit_grpc_protos::ProcessInfo>;
+
   ProcessManager() = default;
   virtual ~ProcessManager() = default;
 
   virtual void SetProcessListUpdateListener(
-      const std::function<void(ProcessManager*)>& listener) = 0;
+      const std::function<void(const ProcessList)> listener) = 0;
 
   virtual ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> LoadModuleList(
       int32_t pid) = 0;
 
   // Get a copy of process list.
-  virtual std::vector<orbit_grpc_protos::ProcessInfo> GetProcessList() const = 0;
+  virtual ProcessList GetProcessList() const = 0;
 
   virtual ErrorMessageOr<std::string> LoadProcessMemory(int32_t pid, uint64_t address,
                                                         uint64_t size) = 0;

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -309,11 +309,10 @@ void OrbitApp::PostInit() {
     // TODO: Replace refresh_timeout with config option. Let users to modify it.
     process_manager_ = ProcessManager::Create(grpc_channel_, absl::Milliseconds(1000));
 
-    auto callback = [this](ProcessManager* process_manager) {
-      main_thread_executor_->Schedule([this, process_manager]() {
-        const std::vector<ProcessInfo>& process_infos = process_manager->GetProcessList();
-        data_manager_->UpdateProcessInfos(process_infos);
-        processes_data_view_->SetProcessList(process_infos);
+    auto callback = [this](const ProcessManager::ProcessList process_list) {
+      main_thread_executor_->Schedule([this, process_list{std::move(process_list)}]() {
+        data_manager_->UpdateProcessInfos(process_list);
+        processes_data_view_->SetProcessList(process_list);
 
         if (GetSelectedProcess() == nullptr && processes_data_view_->GetFirstProcessId() != -1) {
           processes_data_view_->SelectProcess(processes_data_view_->GetFirstProcessId());


### PR DESCRIPTION
Update of the process_list_ and process_list_update_listener_ was using the same mutex.

This causes a deadlock when the process_list_update_listener_ calls GetProcessList() when invoked from the WorkerFunction().
Problem could be observed in the new UI beta branch: Process List waits to be loaded indefinitely after connecting to an instance.