### PR TITLE
Fix Vulkan validation layer include path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,11 @@ endif()
 
 find_package(Filesystem REQUIRED)
 
+if(NOT WIN32)
+  find_package(Vulkan REQUIRED)
+  find_package(VulkanValidationLayers REQUIRED)
+endif()
+
 # Set preprocessor defines These are only necessary for windows, but we will
 # define them on all platforms, to keep the builds similar as possible.
 add_definitions(-DNOMINMAX)

--- a/OrbitTriggerCaptureVulkanLayer/CMakeLists.txt
+++ b/OrbitTriggerCaptureVulkanLayer/CMakeLists.txt
@@ -22,7 +22,9 @@ target_sources(OrbitTriggerCaptureVulkanLayer PRIVATE
 target_link_libraries(OrbitTriggerCaptureVulkanLayer PUBLIC
         OrbitBase
         OrbitCaptureGgpClientLib
-        OrbitTriggerCaptureVulkanLayerProtos)
+        OrbitTriggerCaptureVulkanLayerProtos
+        Vulkan::Vulkan
+        Vulkan::ValidationLayers)
 
 project(OrbitTriggerCaptureVulkanLayerProtos)
 add_library(OrbitTriggerCaptureVulkanLayerProtos STATIC)

--- a/OrbitTriggerCaptureVulkanLayer/DispatchTable.cpp
+++ b/OrbitTriggerCaptureVulkanLayer/DispatchTable.cpp
@@ -11,9 +11,11 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/synchronization/mutex.h"
-#include "vulkan/vk_layer.h"
-#include "vulkan/vk_layer_dispatch_table.h"
+
+// clang-format off
 #include "vulkan/vulkan.h"
+#include "vk_layer_dispatch_table.h"
+// clang-format on
 
 namespace {
 // All dispatchable objects have a pointer to the dispatch table. The loader's dispatch

--- a/OrbitTriggerCaptureVulkanLayer/DispatchTable.h
+++ b/OrbitTriggerCaptureVulkanLayer/DispatchTable.h
@@ -10,8 +10,11 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/synchronization/mutex.h"
-#include "vulkan/vk_layer_dispatch_table.h"
+
+// clang-format off
 #include "vulkan/vulkan.h"
+#include "vk_layer_dispatch_table.h"
+// clang-format on
 
 // Contains the logic related to the dispatch table so the creation of the table as well as the
 // management of its keys are transparent to the main file.

--- a/OrbitTriggerCaptureVulkanLayer/OrbitCaptureClientLayer.cpp
+++ b/OrbitTriggerCaptureVulkanLayer/OrbitCaptureClientLayer.cpp
@@ -12,9 +12,11 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/synchronization/mutex.h"
+
+// clang-format off
 #include "vulkan/vk_layer.h"
-#include "vulkan/vk_layer_dispatch_table.h"
-#include "vulkan/vulkan.h"
+#include "vk_layer_dispatch_table.h"
+// clang-format on
 
 #undef VK_LAYER_EXPORT
 #if defined(WIN32)

--- a/OrbitVulkanLayer/CMakeLists.txt
+++ b/OrbitVulkanLayer/CMakeLists.txt
@@ -24,7 +24,9 @@ target_sources(OrbitVulkanLayer PRIVATE
 
 target_link_libraries(OrbitVulkanLayer PUBLIC
         OrbitBase
-        OrbitProtos)
+        OrbitProtos
+        Vulkan::Vulkan
+        Vulkan::ValidationLayers)
 
 add_executable(OrbitVulkanLayerTests)
 

--- a/OrbitVulkanLayer/DispatchTable.h
+++ b/OrbitVulkanLayer/DispatchTable.h
@@ -10,9 +10,11 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/synchronization/mutex.h"
-#include "vulkan/vk_layer.h"
-#include "vulkan/vk_layer_dispatch_table.h"
+
+// clang-format off
 #include "vulkan/vulkan.h"
+#include "vk_layer_dispatch_table.h"
+// clang-format on
 
 namespace orbit_vulkan_layer {
 

--- a/cmake/FindVulkanValidationLayers.cmake
+++ b/cmake/FindVulkanValidationLayers.cmake
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+find_path(VulkanValidationLayers_INCLUDE_DIR
+  NAMES vk_layer_dispatch_table.h 
+  PATH_SUFFIXES vulkan/
+  HINTS "$ENV{VULKAN_SDK}/include")
+
+set(VulkanValidationLayers_INCLUDE_DIRS ${VulkanValidationLayers_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(VulkanValidationLayers DEFAULT_MSG VulkanValidationLayers_INCLUDE_DIR)
+
+mark_as_advanced(VulkanValidationLayers_INCLUDE_DIR)
+
+if(VulkanValidationLayers_FOUND AND NOT TARGET Vulkan::ValidationLayers)
+  add_library(Vulkan::ValidationLayers INTERFACE IMPORTED)
+  set_target_properties(Vulkan::ValidationLayers PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${VulkanValidationLayers_INCLUDE_DIRS}")
+  target_link_libraries(Vulkan::ValidationLayers INTERFACE Vulkan::Vulkan)
+endif()


### PR DESCRIPTION
Depending on the version of the vulkan validationlayers header package,
the include path is different. Old versions put the headers into the
vulkan/ subdirectory, laters ones don't use that sub-directory.

Since we have to work with both versions, this commit adds a cmake
find-package detection script which adds a cmake target
Vulkan::ValidationLayers which conveys for the proper include path.

The vk_layer_dispatch_table.h header is not self-contained and needs a
special inclusion order. That's why this commit als adds some
clang-format descriptors which avoid reordering of the vulkan layers.
Ideally this will be fixed upstream.