### PR TITLE
Add typed ConsumeRecord and CHECK for size

### DIFF
--- a/OrbitLinuxTracing/PerfEventRingBuffer.cpp
+++ b/OrbitLinuxTracing/PerfEventRingBuffer.cpp
@@ -121,7 +121,7 @@ void PerfEventRingBuffer::SkipRecord(const perf_event_header& header) {
   WriteRingBufferTail(metadata_page_, new_tail);
 }
 
-void PerfEventRingBuffer::ConsumeRecord(const perf_event_header& header, void* record) {
+void PerfEventRingBuffer::ConsumeRawRecord(const perf_event_header& header, void* record) {
   ReadAtTail(static_cast<uint8_t*>(record), header.size);
   SkipRecord(header);
 }

--- a/OrbitLinuxTracing/PerfEventRingBuffer.h
+++ b/OrbitLinuxTracing/PerfEventRingBuffer.h
@@ -6,9 +6,10 @@
 #define ORBIT_LINUX_TRACING_PERF_RING_BUFFER_H_
 
 #include <linux/perf_event.h>
-#include <stdint.h>
 
 #include <string>
+
+#include "OrbitBase/Logging.h"
 
 namespace LinuxTracing {
 
@@ -30,7 +31,12 @@ class PerfEventRingBuffer {
   bool HasNewData();
   void ReadHeader(perf_event_header* header);
   void SkipRecord(const perf_event_header& header);
-  void ConsumeRecord(const perf_event_header& header, void* record);
+
+  template <typename T>
+  void ConsumeRecord(const perf_event_header& header, T* record) {
+    CHECK(header.size == sizeof(T));
+    ConsumeRawRecord(header, record);
+  }
 
   template <typename T>
   void ReadValueAtOffset(T* value, uint64_t offset) {
@@ -52,8 +58,9 @@ class PerfEventRingBuffer {
   int file_descriptor_ = -1;
   std::string name_;
 
+  // ConsumeRawRecord reads header.size bytes into record buffer and then skips the record.
+  void ConsumeRawRecord(const perf_event_header& header, void* record);
   void ReadAtTail(void* dest, uint64_t count) { return ReadAtOffsetFromTail(dest, 0, count); }
-
   void ReadAtOffsetFromTail(void* dest, uint64_t offset_from_tail, uint64_t count);
 };
 


### PR DESCRIPTION
Provide template variant of ConsumeRecord and add size to void* variant to always explicitly specify size. 

Test: Build, Start Orbit, Capture