### PR TITLE
Fix crash on capture abort on exit

### DIFF
--- a/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
+++ b/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
@@ -54,7 +54,7 @@ class CaptureClient {
     return state_ != State::kStopped;
   }
 
-  bool TryAbortCapture();
+  bool AbortCaptureAndWait(int64_t max_wait_ms);
 
  private:
   void Capture(ProcessData&& process, const orbit_client_data::ModuleManager& module_manager,
@@ -69,6 +69,7 @@ class CaptureClient {
   std::unique_ptr<grpc::ClientReaderWriter<orbit_grpc_protos::CaptureRequest,
                                            orbit_grpc_protos::CaptureResponse>>
       reader_writer_;
+  absl::Mutex context_and_stream_mutex_;
 
   CaptureListener* capture_listener_ = nullptr;
 

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -850,7 +850,8 @@ void OrbitApp::StopCapture() {
 }
 
 void OrbitApp::AbortCapture() {
-  if (!capture_client_->TryAbortCapture()) {
+  static constexpr int64_t kMaxWaitForAbortCaptureMs = 2000;
+  if (!capture_client_->AbortCaptureAndWait(kMaxWaitForAbortCaptureMs)) {
     return;
   }
 


### PR DESCRIPTION
Change `TryAbort` to `AbortCaptureAndWait` and wait (for a limited time) for the
`CaptureClient::Capture` thread to change `state_` to `State::kStopped`, so that
`client_context_` has been cleaned up.
This is mostly done by improving synchronization in the class, adding a mutex
for `client_context_` and `reader_writer_`.

Bug: http://b/175211279

Test: locally and with Trata both taking "normal" captures and aborting captures
on exit.