### PR TITLE
Use clang-format-9 in run_clang_format.sh

### DIFF
--- a/run_clang_format.sh
+++ b/run_clang_format.sh
@@ -4,4 +4,4 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-find . \( -name '*.cpp' -o -name '*.h' \) ! -path './third_party/*' ! -path './build*/*' ! -path './cmake-*' ! -name 'resource.h' | xargs /usr/bin/clang-format -i
+find . \( -name '*.cpp' -o -name '*.h' \) ! -path './third_party/*' ! -path './build*/*' ! -path './cmake-*' ! -name 'resource.h' | xargs /usr/bin/clang-format-9 -i


### PR DESCRIPTION
Explicitly use "clang-format-9" instead of "clang-format" as it's
the version used by our build machines for presubmit checks.