### PR TITLE
Fix the deselection behavior in the data view panel

### DIFF
--- a/OrbitGl/LiveFunctionsDataView.cpp
+++ b/OrbitGl/LiveFunctionsDataView.cpp
@@ -78,13 +78,15 @@ std::string LiveFunctionsDataView::GetValue(int row, int column) {
 }
 
 void LiveFunctionsDataView::OnSelect(std::optional<int> row) {
-  if (!row.has_value()) {
-    return;
-  }
   app_->DeselectTextBox();
-  const CaptureData& capture_data = app_->GetCaptureData();
-  app_->set_highlighted_function(
-      capture_data.GetAbsoluteAddress(*GetSelectedFunction(row.value())));
+
+  if (!row.has_value()) {
+    app_->set_highlighted_function(DataManager::kInvalidFunctionAddress);
+  } else {
+    const CaptureData& capture_data = app_->GetCaptureData();
+    app_->set_highlighted_function(
+        capture_data.GetAbsoluteAddress(*GetSelectedFunction(row.value())));
+  }
 }
 
 #define ORBIT_FUNC_SORT(Member)                                                      \
@@ -400,11 +402,11 @@ std::pair<TextBox*, TextBox*> LiveFunctionsDataView::GetMinMax(const FunctionInf
   return std::make_pair(min_box, max_box);
 }
 
-int LiveFunctionsDataView::GetRowFromFunctionAddress(uint64_t function_address) {
+std::optional<int> LiveFunctionsDataView::GetRowFromFunctionAddress(uint64_t function_address) {
   for (int function_row = 0; function_row < static_cast<int>(GetNumElements()); function_row++) {
     if (absl::StrFormat("0x%llx", function_address) == GetValue(function_row, kColumnAddress)) {
       return function_row;
     }
   }
-  return -1;
+  return std::nullopt;
 }

--- a/OrbitGl/LiveFunctionsDataView.h
+++ b/OrbitGl/LiveFunctionsDataView.h
@@ -27,7 +27,7 @@ class LiveFunctionsDataView : public DataView {
                      const std::vector<int>& item_indices) override;
   void OnDataChanged() override;
   void OnTimer() override;
-  int GetRowFromFunctionAddress(uint64_t function_address);
+  std::optional<int> GetRowFromFunctionAddress(uint64_t function_address);
 
  protected:
   void DoFilter() override;

--- a/OrbitQt/orbitlivefunctions.cpp
+++ b/OrbitQt/orbitlivefunctions.cpp
@@ -118,12 +118,13 @@ void OrbitLiveFunctions::Reset() {
   all_events_iterator_->DisableButtons();
 }
 
-void OrbitLiveFunctions::onRowSelected(int row) {
-  CHECK(row >= 0);
+void OrbitLiveFunctions::OnRowSelected(std::optional<int> row) {
   ui->data_view_panel_->GetTreeView()->SetIsInternalRefresh(true);
   QItemSelectionModel* selection = ui->data_view_panel_->GetTreeView()->selectionModel();
-  QModelIndex idx = ui->data_view_panel_->GetTreeView()->GetModel()->CreateIndex(row, 0);
-  selection->select(idx, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
-  selection->setCurrentIndex(idx, QItemSelectionModel::Rows);
+  QModelIndex index;
+  if (row.has_value()) {
+    index = ui->data_view_panel_->GetTreeView()->GetModel()->CreateIndex(row.value(), 0);
+  }
+  selection->select(index, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows);
   ui->data_view_panel_->GetTreeView()->SetIsInternalRefresh(false);
 }

--- a/OrbitQt/orbitlivefunctions.h
+++ b/OrbitQt/orbitlivefunctions.h
@@ -33,7 +33,7 @@ class OrbitLiveFunctions : public QWidget {
                   bool is_main_instance = true);
   void Refresh();
   void OnDataChanged();
-  void onRowSelected(int row);
+  void OnRowSelected(std::optional<int> row);
   void Reset();
   void SetFilter(const QString& a_Filter);
   void AddIterator(uint64_t id, orbit_client_protos::FunctionInfo* function);

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -778,16 +778,16 @@ void OrbitMainWindow::RestoreDefaultTabLayout() {
 }
 
 void OrbitMainWindow::OnTimerSelectionChanged(const orbit_client_protos::TimerInfo* timer_info) {
-  if (!timer_info) return;
-  uint64_t function_address = timer_info->function_address();
-  const auto live_functions_controller = ui->liveFunctions->GetLiveFunctionsController();
-  CHECK(live_functions_controller.has_value());
-  LiveFunctionsDataView& live_functions_data_view =
-      live_functions_controller.value()->GetDataView();
-  int selected_row = live_functions_data_view.GetRowFromFunctionAddress(function_address);
-  if (selected_row != -1) {
-    ui->liveFunctions->onRowSelected(selected_row);
+  std::optional<int> selected_row(std::nullopt);
+  if (timer_info) {
+    uint64_t function_address = timer_info->function_address();
+    const auto live_functions_controller = ui->liveFunctions->GetLiveFunctionsController();
+    CHECK(live_functions_controller.has_value());
+    LiveFunctionsDataView& live_functions_data_view =
+        live_functions_controller.value()->GetDataView();
+    selected_row = live_functions_data_view.GetRowFromFunctionAddress(function_address);
   }
+  ui->liveFunctions->OnRowSelected(selected_row);
 }
 
 void OrbitMainWindow::on_actionSave_Capture_triggered() {

--- a/OrbitQt/orbittreeview.cpp
+++ b/OrbitQt/orbittreeview.cpp
@@ -15,6 +15,7 @@
 #include <QHeaderView>
 #include <QKeyEvent>
 #include <QMenu>
+#include <QMouseEvent>
 #include <QPainter>
 #include <QScrollBar>
 #include <QSignalMapper>
@@ -223,6 +224,16 @@ void OrbitTreeView::keyPressEvent(QKeyEvent* event) {
   }
 }
 
+void OrbitTreeView::mousePressEvent(QMouseEvent* event) {
+  QModelIndex index = indexAt(event->pos());
+  // Deselect previous selections if clicking the empty area of the OrbitTreeView.
+  if (!index.isValid()) {
+    setCurrentIndex(QModelIndex());
+  } else {
+    QTreeView::mousePressEvent(event);
+  }
+}
+
 void OrbitTreeView::selectionChanged(const QItemSelection& selected,
                                      const QItemSelection& deselected) {
   QTreeView::selectionChanged(selected, deselected);
@@ -232,12 +243,14 @@ void OrbitTreeView::selectionChanged(const QItemSelection& selected,
 
   // Row selection callback.
   QModelIndex index = selectionModel()->currentIndex();
+  std::optional<int> row(std::nullopt);
   if (index.isValid()) {
-    OnRowSelected(index.row());
+    row = index.row();
   }
+  OnRowSelected(row);
 }
 
-void OrbitTreeView::OnRowSelected(int row) {
+void OrbitTreeView::OnRowSelected(std::optional<int> row) {
   model_->OnRowSelected(row);
   for (OrbitTreeView* tree_view : links_) {
     tree_view->Refresh();

--- a/OrbitQt/orbittreeview.h
+++ b/OrbitQt/orbittreeview.h
@@ -28,6 +28,7 @@ class OrbitTreeView : public QTreeView {
   void SetGlWidget(OrbitGLWidget* gl_widget);
   void resizeEvent(QResizeEvent* event) override;
   void keyPressEvent(QKeyEvent* event) override;
+  void mousePressEvent(QMouseEvent* event) override;
   void selectionChanged(const QItemSelection& selected, const QItemSelection& deselected) override;
   OrbitTableModel* GetModel() { return model_.get(); }
   std::string GetLabel();
@@ -50,7 +51,7 @@ class OrbitTreeView : public QTreeView {
   void ShowContextMenu(const QPoint& pos);
   void OnMenuClicked(const std::string& action, int menu_index);
   void OnRangeChanged(int min, int max);
-  void OnRowSelected(int row);
+  void OnRowSelected(std::optional<int> row);
 
  private:
   std::unique_ptr<OrbitTableModel> model_;


### PR DESCRIPTION
This PR fixes the following misleading deselection behaviours in the data view panels:
* When clicking the empty area in the live tab, sampling tab or callstack tab, the previous selection stays but the highlight disappears. 
* When deselecting a function call in the capture window, or if we change to select another function that cannot be found in the live tab, the previous selection in the live tab stays the same.
* When deselecting a function in the live tab (i.e., click the empty area), the highlighted function calls in the capture window stay the same. 

We now allow the user to deselect functions in data view panel by clicking the empty area. And we fix the above problems by:
* Deselecting previous selections when clicking the empty area in the data view panels.
* Clearing the highlighting of function calls in the capture window if we click the empty area in the live tab.
* Clearing the selection in the live tab if we deselect a function call in the capture window or if we change to select a function which cannot be found in the live tab.
