### PR TITLE
Fix GetThreadName: it was always returning the current thread's name

### DIFF
--- a/OrbitBase/ReadFileToString.cpp
+++ b/OrbitBase/ReadFileToString.cpp
@@ -16,7 +16,7 @@ ErrorMessageOr<std::string> ReadFileToString(const std::filesystem::path& file_n
   std::ifstream file_stream(file_name);
   if (file_stream.fail()) {
     return ErrorMessage(
-        absl::StrFormat("Unable to read file %s: %s", file_name.string(), SafeStrerror(errno)));
+        absl::StrFormat("Unable to read file \"%s\": %s", file_name.string(), SafeStrerror(errno)));
   }
 
   return std::string{std::istreambuf_iterator<char>{file_stream}, std::istreambuf_iterator<char>{}};

--- a/OrbitBase/ThreadUtilsTest.cpp
+++ b/OrbitBase/ThreadUtilsTest.cpp
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <absl/synchronization/mutex.h>
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
@@ -25,19 +26,19 @@ TEST(ThreadUtils, GetCurrentThreadId) {
   EXPECT_TRUE(worker_tid != current_tid);
 }
 
-TEST(ThreadUtils, GetSetThreadNames) {
+TEST(ThreadUtils, GetSetCurrentThreadNames) {
   // Set thread name of exactly 15 characters. This should work on both Linux and Windows.
-  const std::string kThreadName = "123456789012345";
+  static const std::string kThreadName = "123456789012345";
   orbit_base::SetCurrentThreadName(kThreadName);
   std::string thread_name = orbit_base::GetThreadName(orbit_base::GetCurrentThreadId());
   EXPECT_EQ(kThreadName, thread_name);
 
   // On Linux, the maximum length for a thread name is 16 characters including '\0'.
-  const size_t kMaxNonZeroCharactersLinux = 15;
+  static constexpr size_t kMaxNonZeroCharactersLinux = 15;
 
   // Set thread name longer than 15 characters. The Linux version will truncate the name to 15
   // characters.
-  const std::string kLongThreadName = "1234567890123456";
+  static const std::string kLongThreadName = "1234567890123456";
   EXPECT_GT(kLongThreadName.size(), kMaxNonZeroCharactersLinux);
   orbit_base::SetCurrentThreadName(kLongThreadName);
   std::string long_thread_name = orbit_base::GetThreadName(orbit_base::GetCurrentThreadId());
@@ -50,4 +51,44 @@ TEST(ThreadUtils, GetSetThreadNames) {
   // to allow for longer thread names.
   EXPECT_NE(pthread_setname_np(pthread_self(), kLongThreadName.data()), 0);
 #endif
+}
+
+TEST(ThreadUtils, GetThreadName) {
+  absl::Mutex mutex;
+#if _WIN32
+  using PidType = uint32_t;
+#else
+  using PidType = pid_t;
+#endif
+  PidType other_tid = 0;
+  bool other_name_read = false;
+  static const std::string kThreadName = "OtherThread";
+
+  std::thread other_thread{[&mutex, &other_tid, &other_name_read] {
+    orbit_base::SetCurrentThreadName(kThreadName);
+    {
+      absl::MutexLock lock{&mutex};
+      other_tid = orbit_base::GetCurrentThreadId();
+    }
+    {
+      absl::MutexLock lock{&mutex};
+      // Wait for the main thread to read this thread's name before exiting.
+      mutex.Await(absl::Condition(
+          +[](bool* other_name_read) { return *other_name_read; }, &other_name_read));
+    }
+  }};
+
+  {
+    absl::MutexLock lock{&mutex};
+    // Wait for other_thread to set its own name and communicate its pid.
+    mutex.Await(absl::Condition(
+        +[](PidType* other_tid) { return *other_tid != 0; }, &other_tid));
+  }
+  std::string other_name = orbit_base::GetThreadName(other_tid);
+  EXPECT_EQ(other_name, kThreadName);
+  {
+    absl::MutexLock lock{&mutex};
+    other_name_read = true;
+  }
+  other_thread.join();
 }

--- a/OrbitBase/ThreadUtilsTest.cpp
+++ b/OrbitBase/ThreadUtilsTest.cpp
@@ -26,13 +26,15 @@ TEST(ThreadUtils, GetCurrentThreadId) {
   EXPECT_TRUE(worker_tid != current_tid);
 }
 
-TEST(ThreadUtils, GetSetCurrentThreadNames) {
+TEST(ThreadUtils, GetSetCurrentThreadShortName) {
   // Set thread name of exactly 15 characters. This should work on both Linux and Windows.
   static const std::string kThreadName = "123456789012345";
   orbit_base::SetCurrentThreadName(kThreadName);
   std::string thread_name = orbit_base::GetThreadName(orbit_base::GetCurrentThreadId());
   EXPECT_EQ(kThreadName, thread_name);
+}
 
+TEST(ThreadUtils, GetSetCurrentThreadLongName) {
   // On Linux, the maximum length for a thread name is 16 characters including '\0'.
   static constexpr size_t kMaxNonZeroCharactersLinux = 15;
 
@@ -51,6 +53,14 @@ TEST(ThreadUtils, GetSetCurrentThreadNames) {
   // to allow for longer thread names.
   EXPECT_NE(pthread_setname_np(pthread_self(), kLongThreadName.data()), 0);
 #endif
+}
+
+TEST(ThreadUtils, GetSetCurrentThreadEmptyName) {
+  // Set thread name of exactly 15 characters. This should work on both Linux and Windows.
+  static const std::string kEmptyThreadName{};
+  orbit_base::SetCurrentThreadName(kEmptyThreadName);
+  std::string thread_name = orbit_base::GetThreadName(orbit_base::GetCurrentThreadId());
+  EXPECT_EQ(kEmptyThreadName, thread_name);
 }
 
 TEST(ThreadUtils, GetThreadName) {


### PR DESCRIPTION
Use an implementation similar to the one previously used in `OrbitLinuxTracing`.
Also add the unit test that would catch this.

Bug: http://b/175663948