### PR TITLE
Clear user defined capture data when switching processes

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -1296,6 +1296,7 @@ void OrbitApp::UpdateProcessAndModuleList(int32_t pid) {
       // If no process was selected before, or the process changed
       if (GetSelectedProcess() == nullptr || pid != GetSelectedProcess()->pid()) {
         data_manager_->ClearSelectedFunctions();
+        data_manager_->ClearUserDefinedCaptureData();
         data_manager_->set_selected_process(pid);
       }
 


### PR DESCRIPTION
We have to clear user defined capture data including frame track data
when switching processes similar to how this is done with selected
(hooked) functions. This fixes a violated CHECK when switching
processes when frame tracks are enabled.

Test: Manual test.
Bug: http://b/175674080