### PR TITLE
Add Vulkan Layer Controller

### DIFF
--- a/OrbitVulkanLayer/CMakeLists.txt
+++ b/OrbitVulkanLayer/CMakeLists.txt
@@ -17,11 +17,11 @@ target_sources(OrbitVulkanLayer PRIVATE
         DeviceManager.h
         DispatchTable.cpp
         DispatchTable.h
-        VulkanLayerController.h
         QueueManager.cpp
         QueueManager.h
         SubmissionTracker.h
         TimerQueryPool.h
+        VulkanLayerController.h
         VulkanLayerProducer.h
         VulkanLayerProducerImpl.cpp
         VulkanLayerProducerImpl.h)

--- a/OrbitVulkanLayer/CMakeLists.txt
+++ b/OrbitVulkanLayer/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(OrbitVulkanLayer PRIVATE
         DeviceManager.h
         DispatchTable.cpp
         DispatchTable.h
+        VulkanLayerController.h
         QueueManager.cpp
         QueueManager.h
         SubmissionTracker.h
@@ -42,6 +43,7 @@ target_sources(OrbitVulkanLayerTests PRIVATE
         SubmissionTrackerTest.cpp
         TimerQueryPoolTest.cpp
         QueueManagerTest.cpp
+        VulkanLayerControllerTest.cpp
         VulkanLayerProducerImplTest.cpp)
 
 target_link_libraries(

--- a/OrbitVulkanLayer/VulkanLayerController.h
+++ b/OrbitVulkanLayer/VulkanLayerController.h
@@ -392,14 +392,14 @@ class VulkanLayerController {
     // Append all of our extensions, that are not yet listed.
     // Note as this list of our extensions is very small, we are fine with O(N*M) runtime.
     for (const auto& extension : kDeviceExtensions) {
-      bool is_unique = true;
+      bool already_present = false;
       for (const auto& other_extension : extensions) {
         if (strcmp(extension.extensionName, other_extension.extensionName) == 0) {
-          is_unique = false;
+          already_present = true;
           break;
         }
       }
-      if (is_unique) {
+      if (!already_present) {
         extensions.push_back(extension);
       }
     }

--- a/OrbitVulkanLayer/VulkanLayerController.h
+++ b/OrbitVulkanLayer/VulkanLayerController.h
@@ -227,7 +227,7 @@ class VulkanLayerController {
 
   [[nodiscard]] VkResult OnQueueSubmit(VkQueue queue, uint32_t submit_count,
                                        const VkSubmitInfo* submits, VkFence fence) {
-    auto queue_submission_optional =
+    std::optional<typename SubmissionTracker::QueueSubmission> queue_submission_optional =
         submission_tracker_.PersistCommandBuffersOnSubmit(submit_count, submits);
     VkResult result = dispatch_table_.QueueSubmit(queue)(queue, submit_count, submits, fence);
     submission_tracker_.PersistDebugMarkersOnSubmit(queue, submit_count, submits,

--- a/OrbitVulkanLayer/VulkanLayerController.h
+++ b/OrbitVulkanLayer/VulkanLayerController.h
@@ -1,0 +1,454 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_VULKAN_LAYER_LAYER_LOGIC_H_
+#define ORBIT_VULKAN_LAYER_LAYER_LOGIC_H_
+
+#include "OrbitBase/Logging.h"
+#include "VulkanLayerProducerImpl.h"
+#include "absl/base/casts.h"
+#include "vulkan/vk_layer.h"
+#include "vulkan/vulkan.h"
+
+namespace orbit_vulkan_layer {
+
+/**
+ * This class controls the logic of this layer. For the instrumented vulkan functions,
+ * it provides an `On*` function (e.g. for `vkQueueSubmit` there is `OnQueueSubmit`) that delegates
+ * to the driver/next layer (see `DispatchTable`) and calls the required functions for this layer to
+ * function properly. So it ties together the classes like the `SubmissionTracker` or the
+ * `TimerQueryPool`.
+ * In particular it performs the bootstrapping code (OnCreateInstance/Device) and the enumerations
+ * required by every vulkan layer.
+ *
+ * Usage: For an instrumented vulkan function "X" a common pattern from the layers entry (Main.cpp)
+ * `OnX` needs to be called to the controller.
+ *
+ * Note, the main reason, to not expose the vulkan functions directly in this class, is that this
+ * allows us to write tests that check if we glue the code correctly together and does the proper
+ * bootstrapping.
+ */
+template <class DispatchTable, class QueueManager, class DeviceManager, class TimerQueryPool,
+          class SubmissionTracker>
+class VulkanLayerController {
+ public:
+  // layer metadata
+  static constexpr const char* const kLayerName = "ORBIT_VK_LAYER";
+  static constexpr const char* const kLayerDescription =
+      "Provides GPU insights for the Orbit Profiler";
+
+  static constexpr const uint32_t kLayerImplVersion = 1;
+  static constexpr const uint32_t kLayerSpecVersion = VK_API_VERSION_1_1;
+
+  static constexpr std::array<VkExtensionProperties, 3> kDeviceExtensions = {
+      VkExtensionProperties{.extensionName = VK_EXT_DEBUG_MARKER_EXTENSION_NAME,
+                            .specVersion = VK_EXT_DEBUG_MARKER_SPEC_VERSION},
+      VkExtensionProperties{.extensionName = VK_EXT_DEBUG_UTILS_EXTENSION_NAME,
+                            .specVersion = VK_EXT_DEBUG_UTILS_SPEC_VERSION},
+      VkExtensionProperties{.extensionName = VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME,
+                            .specVersion = VK_EXT_HOST_QUERY_RESET_SPEC_VERSION}};
+
+  VulkanLayerController()
+      : device_manager_(&dispatch_table_),
+        timer_query_pool_(&dispatch_table_, kNumTimerQuerySlots),
+        submission_tracker_(&dispatch_table_, &timer_query_pool_, &device_manager_,
+                            std::numeric_limits<uint32_t>::max()) {}
+
+  ~VulkanLayerController() { CloseVulkanLayerProducerIfNecessary(); }
+
+  // ----------------------------------------------------------------------------
+  // Layer bootstrapping code
+  // ----------------------------------------------------------------------------
+
+  [[nodiscard]] VkResult OnCreateInstance(const VkInstanceCreateInfo* create_info,
+                                          const VkAllocationCallbacks* allocator,
+                                          VkInstance* instance) {
+    // The specification ensures that the create_info pointer must not be nullptr.
+    CHECK(create_info != nullptr);
+
+    auto* layer_create_info = absl::bit_cast<VkLayerInstanceCreateInfo*>(create_info->pNext);
+
+    while (layer_create_info != nullptr &&
+           (layer_create_info->sType != VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO ||
+            layer_create_info->function != VK_LAYER_LINK_INFO)) {
+      layer_create_info = absl::bit_cast<VkLayerInstanceCreateInfo*>(layer_create_info->pNext);
+    }
+
+    if (layer_create_info == nullptr) {
+      return VK_ERROR_INITIALIZATION_FAILED;
+    }
+
+    InitVulkanLayerProducerIfNecessary();
+
+    PFN_vkGetInstanceProcAddr next_get_instance_proc_addr_function =
+        layer_create_info->u.pLayerInfo->pfnNextGetInstanceProcAddr;
+
+    // Advance linkage for next layer.
+    layer_create_info->u.pLayerInfo = layer_create_info->u.pLayerInfo->pNext;
+
+    // Need to call vkCreateInstance down the chain to actually create the
+    // instance, as we need it to be alive in the create instance dispatch table.
+    auto create_instance = absl::bit_cast<PFN_vkCreateInstance>(
+        next_get_instance_proc_addr_function(VK_NULL_HANDLE, "vkCreateInstance"));
+    VkResult result = create_instance(create_info, allocator, instance);
+
+    dispatch_table_.CreateInstanceDispatchTable(*instance, next_get_instance_proc_addr_function);
+
+    return result;
+  }
+
+  [[nodiscard]] VkResult OnCreateDevice(VkPhysicalDevice /*physical_device*/ physical_device,
+                                        const VkDeviceCreateInfo* create_info,
+                                        const VkAllocationCallbacks* allocator /*allocator*/,
+                                        VkDevice* device) {
+    auto* layer_create_info = absl::bit_cast<VkLayerDeviceCreateInfo*>(create_info->pNext);
+
+    while (layer_create_info != nullptr &&
+           (layer_create_info->sType != VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO ||
+            layer_create_info->function != VK_LAYER_LINK_INFO)) {
+      layer_create_info = absl::bit_cast<VkLayerDeviceCreateInfo*>(layer_create_info->pNext);
+    }
+
+    if (layer_create_info == nullptr) {
+      return VK_ERROR_INITIALIZATION_FAILED;
+    }
+
+    PFN_vkGetInstanceProcAddr next_get_instance_proc_addr_function =
+        layer_create_info->u.pLayerInfo->pfnNextGetInstanceProcAddr;
+    PFN_vkGetDeviceProcAddr next_get_device_proc_addr_function =
+        layer_create_info->u.pLayerInfo->pfnNextGetDeviceProcAddr;
+
+    // Advance linkage for next layer
+    layer_create_info->u.pLayerInfo = layer_create_info->u.pLayerInfo->pNext;
+
+    // Need to call vkCreateInstance down the chain to actually create the
+    // instance, as we need it to be alive in the create instance dispatch table.
+    auto create_device_function = absl::bit_cast<PFN_vkCreateDevice>(
+        next_get_instance_proc_addr_function(VK_NULL_HANDLE, "vkCreateDevice"));
+    VkResult result = create_device_function(physical_device, create_info, allocator, device);
+
+    dispatch_table_.CreateDeviceDispatchTable(*device, next_get_device_proc_addr_function);
+
+    device_manager_.TrackLogicalDevice(physical_device, *device);
+    timer_query_pool_.InitializeTimerQueryPool(*device);
+
+    return result;
+  }
+
+  [[nodiscard]] PFN_vkVoidFunction OnGetDeviceProcAddr(VkDevice device, const char* name) {
+    return dispatch_table_.GetDeviceProcAddr(device)(device, name);
+  }
+
+  [[nodiscard]] PFN_vkVoidFunction OnGetInstanceProcAddr(VkInstance instance, const char* name) {
+    return dispatch_table_.GetInstanceProcAddr(instance)(instance, name);
+  }
+
+  void OnDestroyInstance(VkInstance instance, const VkAllocationCallbacks* allocator) {
+    PFN_vkDestroyInstance destroy_instance_function = dispatch_table_.DestroyInstance(instance);
+    CHECK(destroy_instance_function != nullptr);
+    dispatch_table_.RemoveInstanceDispatchTable(instance);
+
+    destroy_instance_function(instance, allocator);
+
+    CloseVulkanLayerProducerIfNecessary();
+  }
+
+  void OnDestroyDevice(VkDevice device, const VkAllocationCallbacks* allocator) {
+    PFN_vkDestroyDevice destroy_device_function = dispatch_table_.DestroyDevice(device);
+    CHECK(destroy_device_function != nullptr);
+    device_manager_.UntrackLogicalDevice(device);
+    dispatch_table_.RemoveDeviceDispatchTable(device);
+
+    destroy_device_function(device, allocator);
+  }
+
+  // ----------------------------------------------------------------------------
+  // Core layer logic
+  // ----------------------------------------------------------------------------
+
+  [[nodiscard]] VkResult OnResetCommandPool(VkDevice device, VkCommandPool command_pool,
+                                            VkCommandPoolResetFlags flags) {
+    VkResult result = dispatch_table_.ResetCommandPool(device)(device, command_pool, flags);
+    submission_tracker_.ResetCommandPool(command_pool);
+    return result;
+  }
+
+  [[nodiscard]] VkResult OnAllocateCommandBuffers(VkDevice device,
+                                                  const VkCommandBufferAllocateInfo* allocate_info,
+                                                  VkCommandBuffer* command_buffers) {
+    VkResult result =
+        dispatch_table_.AllocateCommandBuffers(device)(device, allocate_info, command_buffers);
+
+    VkCommandPool pool = allocate_info->commandPool;
+    const uint32_t command_buffer_count = allocate_info->commandBufferCount;
+    submission_tracker_.TrackCommandBuffers(device, pool, command_buffers, command_buffer_count);
+    return result;
+  }
+
+  void OnFreeCommandBuffers(VkDevice device, VkCommandPool command_pool,
+                            uint32_t command_buffer_count, const VkCommandBuffer* command_buffers) {
+    submission_tracker_.UntrackCommandBuffers(device, command_pool, command_buffers,
+                                              command_buffer_count);
+    return dispatch_table_.FreeCommandBuffers(device)(device, command_pool, command_buffer_count,
+                                                      command_buffers);
+  }
+
+  [[nodiscard]] VkResult OnBeginCommandBuffer(VkCommandBuffer command_buffer,
+                                              const VkCommandBufferBeginInfo* begin_info) {
+    VkResult result =
+        dispatch_table_.BeginCommandBuffer(command_buffer)(command_buffer, begin_info);
+    submission_tracker_.MarkCommandBufferBegin(command_buffer);
+    return result;
+  }
+
+  [[nodiscard]] VkResult OnEndCommandBuffer(VkCommandBuffer command_buffer) {
+    submission_tracker_.MarkCommandBufferEnd(command_buffer);
+    return dispatch_table_.EndCommandBuffer(command_buffer)(command_buffer);
+  }
+
+  [[nodiscard]] VkResult OnResetCommandBuffer(VkCommandBuffer command_buffer,
+                                              VkCommandBufferResetFlags flags) {
+    submission_tracker_.ResetCommandBuffer(command_buffer);
+    return dispatch_table_.ResetCommandBuffer(command_buffer)(command_buffer, flags);
+  }
+
+  void OnGetDeviceQueue(VkDevice device, uint32_t queue_family_index, uint32_t queue_index,
+                        VkQueue* queue) {
+    dispatch_table_.GetDeviceQueue(device)(device, queue_family_index, queue_index, queue);
+    queue_manager_.TrackQueue(*queue, device);
+  }
+
+  void OnGetDeviceQueue2(VkDevice device, const VkDeviceQueueInfo2* queue_info, VkQueue* queue) {
+    dispatch_table_.GetDeviceQueue2(device)(device, queue_info, queue);
+    queue_manager_.TrackQueue(*queue, device);
+  }
+
+  [[nodiscard]] VkResult OnQueueSubmit(VkQueue queue, uint32_t submit_count,
+                                       const VkSubmitInfo* submits, VkFence fence) {
+    auto queue_submission_optional =
+        submission_tracker_.PersistCommandBuffersOnSubmit(submit_count, submits);
+    VkResult result = dispatch_table_.QueueSubmit(queue)(queue, submit_count, submits, fence);
+    submission_tracker_.PersistDebugMarkersOnSubmit(queue, submit_count, submits,
+                                                    queue_submission_optional);
+    return result;
+  }
+
+  [[nodiscard]] VkResult OnQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* present_info) {
+    submission_tracker_.CompleteSubmits(queue_manager_.GetDeviceOfQueue(queue));
+    return dispatch_table_.QueuePresentKHR(queue)(queue, present_info);
+  }
+
+  void OnCmdBeginDebugUtilsLabelEXT(VkCommandBuffer command_buffer,
+                                    const VkDebugUtilsLabelEXT* label_info) {
+    if (dispatch_table_.IsDebugUtilsExtensionSupported(command_buffer)) {
+      dispatch_table_.CmdBeginDebugUtilsLabelEXT(command_buffer)(command_buffer, label_info);
+    }
+
+    CHECK(label_info != nullptr);
+    submission_tracker_.MarkDebugMarkerBegin(command_buffer, label_info->pLabelName,
+                                             {
+                                                 .red = label_info->color[0],
+                                                 .green = label_info->color[1],
+                                                 .blue = label_info->color[2],
+                                                 .alpha = label_info->color[3],
+                                             });
+  }
+
+  void OnCmdEndDebugUtilsLabelEXT(VkCommandBuffer command_buffer) {
+    submission_tracker_.MarkDebugMarkerEnd(command_buffer);
+    if (dispatch_table_.IsDebugUtilsExtensionSupported(command_buffer)) {
+      dispatch_table_.CmdEndDebugUtilsLabelEXT(command_buffer)(command_buffer);
+    }
+  }
+
+  void OnCmdDebugMarkerBeginEXT(VkCommandBuffer command_buffer,
+                                const VkDebugMarkerMarkerInfoEXT* marker_info) {
+    if (dispatch_table_.IsDebugMarkerExtensionSupported(command_buffer)) {
+      dispatch_table_.CmdDebugMarkerBeginEXT(command_buffer)(command_buffer, marker_info);
+    }
+    CHECK(marker_info != nullptr);
+    submission_tracker_.MarkDebugMarkerBegin(command_buffer, marker_info->pMarkerName,
+                                             {
+                                                 .red = marker_info->color[0],
+                                                 .green = marker_info->color[1],
+                                                 .blue = marker_info->color[2],
+                                                 .alpha = marker_info->color[3],
+                                             });
+  }
+
+  void OnCmdDebugMarkerEndEXT(VkCommandBuffer command_buffer) {
+    submission_tracker_.MarkDebugMarkerEnd(command_buffer);
+    if (dispatch_table_.IsDebugMarkerExtensionSupported(command_buffer)) {
+      dispatch_table_.CmdDebugMarkerEndEXT(command_buffer)(command_buffer);
+    }
+  }
+
+  // ----------------------------------------------------------------------------
+  // Layer enumeration functions
+  // ----------------------------------------------------------------------------
+
+  [[nodiscard]] VkResult OnEnumerateInstanceLayerProperties(uint32_t* property_count,
+                                                            VkLayerProperties* properties) {
+    // Vulkan spec dictates that we are only supposed to enumerate ourselve.
+    if (property_count != nullptr) {
+      *property_count = 1;
+    }
+    if (properties != nullptr) {
+      snprintf(properties->layerName, sizeof(properties->layerName), kLayerName);
+      snprintf(properties->description, sizeof(properties->description), kLayerDescription);
+      properties->implementationVersion = kLayerImplVersion;
+      properties->specVersion = kLayerSpecVersion;
+    }
+
+    return VK_SUCCESS;
+  }
+
+  [[nodiscard]] VkResult OnEnumerateInstanceExtensionProperties(
+      const char* layer_name, uint32_t* property_count, VkExtensionProperties* /*properties*/) {
+    // Inform the client that we have no extension properties if this layer
+    // specifically is being queried.
+    if (layer_name != nullptr && strcmp(layer_name, kLayerName) == 0) {
+      if (property_count != nullptr) {
+        *property_count = 0;
+      }
+      return VK_SUCCESS;
+    }
+
+    // Vulkan spec mandates returning this when this layer isn't being queried.
+    return VK_ERROR_LAYER_NOT_PRESENT;
+  }
+
+  [[nodiscard]] VkResult OnEnumerateDeviceExtensionProperties(VkPhysicalDevice physical_device,
+                                                              const char* layer_name,
+                                                              uint32_t* property_count,
+                                                              VkExtensionProperties* properties) {
+    // If our layer is queried exclusively, we just return our extensions
+    if (layer_name != nullptr && strcmp(layer_name, kLayerName) == 0) {
+      // If properties == nullptr, only the number of extensions are queried.
+      if (properties == nullptr) {
+        *property_count = kDeviceExtensions.size();
+        return VK_SUCCESS;
+      }
+      uint32_t num_extensions_to_copy = kDeviceExtensions.size();
+      // In the case that less extensions are queried then the layer uses, we copy on this number
+      // and return VK_INCOMPLETE, according to the specification.
+      if (*property_count < num_extensions_to_copy) {
+        num_extensions_to_copy = *property_count;
+      }
+      memcpy(properties, kDeviceExtensions.data(),
+             num_extensions_to_copy * sizeof(VkExtensionProperties));
+      *property_count = num_extensions_to_copy;
+
+      if (num_extensions_to_copy < kDeviceExtensions.size()) {
+        return VK_INCOMPLETE;
+      }
+      return VK_SUCCESS;
+    }
+
+    // If a different layer is queried exclusively, we forward the call.
+    if (layer_name != nullptr) {
+      return dispatch_table_.EnumerateDeviceExtensionProperties(physical_device)(
+          physical_device, layer_name, property_count, properties);
+    }
+
+    // This is a general query, so we need to append our extensions to the once down in the
+    // callchain.
+    uint32_t num_other_extensions;
+    VkResult result = dispatch_table_.EnumerateDeviceExtensionProperties(physical_device)(
+        physical_device, nullptr, &num_other_extensions, nullptr);
+    if (result != VK_SUCCESS) {
+      return result;
+    }
+
+    std::vector<VkExtensionProperties> extensions(num_other_extensions);
+    result = dispatch_table_.EnumerateDeviceExtensionProperties(physical_device)(
+        physical_device, nullptr, &num_other_extensions, extensions.data());
+    if (result != VK_SUCCESS) {
+      return result;
+    }
+
+    // Lets append all of our extensions, that are not yet listed.
+    // Note, as this list of our extensions is very small, we are fine with O(N*M) runtime.
+    for (const auto& extension : kDeviceExtensions) {
+      bool is_unique = true;
+      for (const auto& other_extension : extensions) {
+        if (strcmp(extension.extensionName, other_extension.extensionName) == 0) {
+          is_unique = false;
+          break;
+        }
+      }
+      if (is_unique) {
+        extensions.push_back(extension);
+      }
+    }
+
+    // As above, if properties is nullptr, only the number if extensions is queried.
+    if (properties == nullptr) {
+      *property_count = extensions.size();
+      return VK_SUCCESS;
+    }
+
+    uint32_t num_extensions_to_copy = extensions.size();
+    // In the case that less extensions are queried then the layer uses, we copy on this number and
+    // return VK_INCOMPLETE, according to the specification.
+    if (*property_count < num_extensions_to_copy) {
+      num_extensions_to_copy = *property_count;
+    }
+    memcpy(properties, extensions.data(), num_extensions_to_copy * sizeof(VkExtensionProperties));
+    *property_count = num_extensions_to_copy;
+
+    if (num_extensions_to_copy < extensions.size()) {
+      return VK_INCOMPLETE;
+    }
+    return VK_SUCCESS;
+  }
+
+  [[nodiscard]] const DispatchTable* dispatch_table() const { return &dispatch_table_; }
+
+  [[nodiscard]] const SubmissionTracker* submission_tracker() const { return &submission_tracker_; }
+
+  [[nodiscard]] const DeviceManager* device_manager() const { return &device_manager_; }
+
+  [[nodiscard]] const TimerQueryPool* timer_query_pool() const { return &timer_query_pool_; }
+
+  [[nodiscard]] const QueueManager* queue_manager() const { return &queue_manager_; }
+
+ private:
+  void InitVulkanLayerProducerIfNecessary() {
+    absl::MutexLock lock{&vulkan_layer_producer_mutex_};
+    if (vulkan_layer_producer_ == nullptr) {
+      vulkan_layer_producer_ = std::make_unique<VulkanLayerProducerImpl>();
+      // TODO: As soon as we do have producer side channel for the port, use it.
+      vulkan_layer_producer_->BringUp(nullptr);
+      submission_tracker_.SetVulkanLayerProducer(vulkan_layer_producer_.get());
+    }
+  }
+
+  void CloseVulkanLayerProducerIfNecessary() {
+    absl::MutexLock lock{&vulkan_layer_producer_mutex_};
+    if (vulkan_layer_producer_ != nullptr) {
+      // TODO: Only do this when DestroyInstance has been called a number of times
+      //  equal to the number of times CreateInstance was called.
+      LOG("Taking down VulkanLayerProducer");
+      vulkan_layer_producer_->TakeDown();
+      vulkan_layer_producer_.reset();
+      submission_tracker_.SetVulkanLayerProducer(nullptr);
+    }
+  }
+
+  std::unique_ptr<VulkanLayerProducer> vulkan_layer_producer_ = nullptr;
+  absl::Mutex vulkan_layer_producer_mutex_;
+
+  DispatchTable dispatch_table_;
+  DeviceManager device_manager_;
+  TimerQueryPool timer_query_pool_;
+  SubmissionTracker submission_tracker_;
+  QueueManager queue_manager_;
+
+  static constexpr uint32_t kNumTimerQuerySlots = 65536;
+};
+
+}  // namespace orbit_vulkan_layer
+
+#endif  // ORBIT_VULKAN_LAYER_LAYER_LOGIC_H_

--- a/OrbitVulkanLayer/VulkanLayerController.h
+++ b/OrbitVulkanLayer/VulkanLayerController.h
@@ -38,7 +38,7 @@ class VulkanLayerController {
   static constexpr uint32_t kLayerImplVersion = 1;
   static constexpr uint32_t kLayerSpecVersion = VK_API_VERSION_1_1;
 
-  static constexpr std::array<VkExtensionProperties, 3> kDeviceExtensions = {
+  static constexpr std::array<VkExtensionProperties, 3> kRequiredDeviceExtensions = {
       VkExtensionProperties{.extensionName = VK_EXT_DEBUG_MARKER_EXTENSION_NAME,
                             .specVersion = VK_EXT_DEBUG_MARKER_SPEC_VERSION},
       VkExtensionProperties{.extensionName = VK_EXT_DEBUG_UTILS_EXTENSION_NAME,
@@ -348,20 +348,20 @@ class VulkanLayerController {
     if (layer_name != nullptr && strcmp(layer_name, kLayerName) == 0) {
       // If properties == nullptr, only the number of extensions is queried.
       if (properties == nullptr) {
-        *property_count = kDeviceExtensions.size();
+        *property_count = kRequiredDeviceExtensions.size();
         return VK_SUCCESS;
       }
-      uint32_t num_extensions_to_copy = kDeviceExtensions.size();
+      uint32_t num_extensions_to_copy = kRequiredDeviceExtensions.size();
       // In the case that less extensions are queried then the layer uses, we copy on this number
       // and return VK_INCOMPLETE, according to the specification.
       if (*property_count < num_extensions_to_copy) {
         num_extensions_to_copy = *property_count;
       }
-      memcpy(properties, kDeviceExtensions.data(),
+      memcpy(properties, kRequiredDeviceExtensions.data(),
              num_extensions_to_copy * sizeof(VkExtensionProperties));
       *property_count = num_extensions_to_copy;
 
-      if (num_extensions_to_copy < kDeviceExtensions.size()) {
+      if (num_extensions_to_copy < kRequiredDeviceExtensions.size()) {
         return VK_INCOMPLETE;
       }
       return VK_SUCCESS;
@@ -391,7 +391,7 @@ class VulkanLayerController {
 
     // Append all of our extensions, that are not yet listed.
     // Note as this list of our extensions is very small, we are fine with O(N*M) runtime.
-    for (const auto& extension : kDeviceExtensions) {
+    for (const auto& extension : kRequiredDeviceExtensions) {
       bool already_present = false;
       for (const auto& other_extension : extensions) {
         if (strcmp(extension.extensionName, other_extension.extensionName) == 0) {
@@ -468,6 +468,7 @@ class VulkanLayerController {
   SubmissionTracker submission_tracker_;
   QueueManager queue_manager_;
 
+  // The number of timer query slots is chosen arbitrary such that it is large enough.
   static constexpr uint32_t kNumTimerQuerySlots = 65536;
 };
 

--- a/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
+++ b/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
@@ -454,7 +454,7 @@ TEST_F(VulkanLayerControllerTest, WillCleanUpOnDestroyInstance) {
   controller_.OnDestroyInstance(instance, nullptr);
 }
 
-TEST_F(VulkanLayerControllerTest, WillClearUpOnDestroyDevice) {
+TEST_F(VulkanLayerControllerTest, WillCleanUpOnDestroyDevice) {
   PFN_vkDestroyDevice fake_destroy_device =
       +[](VkDevice /*device*/, const VkAllocationCallbacks* /*allocator*/) {};
   const MockDispatchTable* dispatch_table = controller_.dispatch_table();

--- a/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
+++ b/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
@@ -96,7 +96,7 @@ class MockSubmissionTracker {
   MOCK_METHOD(void, ResetCommandBuffer, (VkCommandBuffer));
   MOCK_METHOD(std::optional<QueueSubmission>, PersistCommandBuffersOnSubmit,
               (uint32_t, const VkSubmitInfo* submits));
-  MOCK_METHOD(bool, PersistDebugMarkersOnSubmit,
+  MOCK_METHOD(void, PersistDebugMarkersOnSubmit,
               (VkQueue, uint32_t, const VkSubmitInfo*, std::optional<QueueSubmission>));
   MOCK_METHOD(void, CompleteSubmits, (VkDevice));
   MOCK_METHOD(void, MarkDebugMarkerBegin, (VkCommandBuffer, const char*, Color));

--- a/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
+++ b/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
@@ -80,6 +80,8 @@ struct Color {
 
 class MockSubmissionTracker {
  public:
+  struct QueueSubmission {};
+
   explicit MockSubmissionTracker(MockDispatchTable* /*dispatch_table*/,
                                  MockTimerQueryPool* /*timer_query_pool*/,
                                  MockDeviceManager* /*device_manager*/, uint32_t /*max_depth*/) {}
@@ -92,9 +94,10 @@ class MockSubmissionTracker {
   MOCK_METHOD(void, MarkCommandBufferBegin, (VkCommandBuffer));
   MOCK_METHOD(void, MarkCommandBufferEnd, (VkCommandBuffer));
   MOCK_METHOD(void, ResetCommandBuffer, (VkCommandBuffer));
-  // Note we simplify the return type, as it is not really part of this test.
-  MOCK_METHOD(bool, PersistCommandBuffersOnSubmit, (uint32_t, const VkSubmitInfo* submits));
-  MOCK_METHOD(bool, PersistDebugMarkersOnSubmit, (VkQueue, uint32_t, const VkSubmitInfo*, bool));
+  MOCK_METHOD(std::optional<QueueSubmission>, PersistCommandBuffersOnSubmit,
+              (uint32_t, const VkSubmitInfo* submits));
+  MOCK_METHOD(bool, PersistDebugMarkersOnSubmit,
+              (VkQueue, uint32_t, const VkSubmitInfo*, std::optional<QueueSubmission>));
   MOCK_METHOD(void, CompleteSubmits, (VkDevice));
   MOCK_METHOD(void, MarkDebugMarkerBegin, (VkCommandBuffer, const char*, Color));
   MOCK_METHOD(void, MarkDebugMarkerEnd, (VkCommandBuffer));

--- a/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
+++ b/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
@@ -1,0 +1,770 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <vulkan/vk_layer.h>
+
+#include "VulkanLayerController.h"
+#include "VulkanLayerProducer.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using ::testing::AllOf;
+using ::testing::Field;
+using ::testing::IsSubsetOf;
+using ::testing::Matcher;
+using ::testing::Return;
+using ::testing::StrEq;
+using ::testing::UnorderedElementsAreArray;
+
+namespace orbit_vulkan_layer {
+
+namespace {
+
+class MockDispatchTable {
+ public:
+  MOCK_METHOD(PFN_vkEnumerateDeviceExtensionProperties, EnumerateDeviceExtensionProperties,
+              (VkPhysicalDevice));
+  MOCK_METHOD((void), CreateInstanceDispatchTable, (VkInstance, PFN_vkGetInstanceProcAddr));
+  MOCK_METHOD((void), CreateDeviceDispatchTable, (VkDevice, PFN_vkGetDeviceProcAddr));
+  MOCK_METHOD((void), RemoveInstanceDispatchTable, (VkInstance));
+  MOCK_METHOD((void), RemoveDeviceDispatchTable, (VkDevice));
+  MOCK_METHOD(PFN_vkGetDeviceProcAddr, GetDeviceProcAddr, (VkDevice));
+  MOCK_METHOD(PFN_vkGetInstanceProcAddr, GetInstanceProcAddr, (VkInstance));
+  MOCK_METHOD(PFN_vkDestroyInstance, DestroyInstance, (VkInstance));
+  MOCK_METHOD(PFN_vkDestroyDevice, DestroyDevice, (VkDevice));
+  MOCK_METHOD(PFN_vkResetCommandPool, ResetCommandPool, (VkDevice));
+  MOCK_METHOD(PFN_vkAllocateCommandBuffers, AllocateCommandBuffers, (VkDevice));
+  MOCK_METHOD(PFN_vkFreeCommandBuffers, FreeCommandBuffers, (VkDevice));
+  MOCK_METHOD(PFN_vkBeginCommandBuffer, BeginCommandBuffer, (VkCommandBuffer));
+  MOCK_METHOD(PFN_vkEndCommandBuffer, EndCommandBuffer, (VkCommandBuffer));
+  MOCK_METHOD(PFN_vkResetCommandBuffer, ResetCommandBuffer, (VkCommandBuffer));
+  MOCK_METHOD(PFN_vkGetDeviceQueue, GetDeviceQueue, (VkDevice));
+  MOCK_METHOD(PFN_vkGetDeviceQueue2, GetDeviceQueue2, (VkDevice));
+  MOCK_METHOD(PFN_vkQueueSubmit, QueueSubmit, (VkQueue));
+  MOCK_METHOD(PFN_vkQueuePresentKHR, QueuePresentKHR, (VkQueue));
+  MOCK_METHOD(PFN_vkCmdBeginDebugUtilsLabelEXT, CmdBeginDebugUtilsLabelEXT, (VkCommandBuffer));
+  MOCK_METHOD(PFN_vkCmdEndDebugUtilsLabelEXT, CmdEndDebugUtilsLabelEXT, (VkCommandBuffer));
+  MOCK_METHOD(PFN_vkCmdDebugMarkerBeginEXT, CmdDebugMarkerBeginEXT, (VkCommandBuffer));
+  MOCK_METHOD(PFN_vkCmdDebugMarkerEndEXT, CmdDebugMarkerEndEXT, (VkCommandBuffer));
+  MOCK_METHOD(bool, IsDebugUtilsExtensionSupported, (VkCommandBuffer));
+  MOCK_METHOD(bool, IsDebugMarkerExtensionSupported, (VkCommandBuffer));
+};
+
+class MockDeviceManager {
+ public:
+  explicit MockDeviceManager(MockDispatchTable* /*dispatch_table*/) {}
+  MOCK_METHOD((void), TrackLogicalDevice, (VkPhysicalDevice, VkDevice));
+  MOCK_METHOD((void), UntrackLogicalDevice, (VkDevice));
+};
+
+class MockQueueManager {
+ public:
+  MOCK_METHOD((void), TrackQueue, (VkQueue, VkDevice));
+  MOCK_METHOD((VkDevice), GetDeviceOfQueue, (VkQueue));
+};
+
+class MockTimerQueryPool {
+ public:
+  explicit MockTimerQueryPool(MockDispatchTable* /*dispatch_table*/, uint32_t /*num_slots*/) {}
+  MOCK_METHOD((void), InitializeTimerQueryPool, (VkDevice));
+};
+
+struct Color {
+  float red;
+  float green;
+  float blue;
+  float alpha;
+};
+
+class MockSubmissionTracker {
+ public:
+  explicit MockSubmissionTracker(MockDispatchTable* /*dispatch_table*/,
+                                 MockTimerQueryPool* /*timer_query_pool*/,
+                                 MockDeviceManager* /*device_manager*/, uint32_t /*max_depth*/) {}
+  MOCK_METHOD((void), SetVulkanLayerProducer, (VulkanLayerProducer*));
+  MOCK_METHOD((void), ResetCommandPool, (VkCommandPool));
+  MOCK_METHOD((void), TrackCommandBuffers,
+              (VkDevice, VkCommandPool, const VkCommandBuffer*, uint32_t));
+  MOCK_METHOD((void), UntrackCommandBuffers,
+              (VkDevice, VkCommandPool, const VkCommandBuffer*, uint32_t));
+  MOCK_METHOD((void), MarkCommandBufferBegin, (VkCommandBuffer));
+  MOCK_METHOD((void), MarkCommandBufferEnd, (VkCommandBuffer));
+  MOCK_METHOD((void), ResetCommandBuffer, (VkCommandBuffer));
+  // Note we simplify the return type, as it is not really part of this test.
+  MOCK_METHOD(bool, PersistCommandBuffersOnSubmit, (uint32_t, const VkSubmitInfo* submits));
+  MOCK_METHOD(bool, PersistDebugMarkersOnSubmit, (VkQueue, uint32_t, const VkSubmitInfo*, bool));
+  MOCK_METHOD((void), CompleteSubmits, (VkDevice));
+  MOCK_METHOD((void), MarkDebugMarkerBegin, (VkCommandBuffer, const char*, Color));
+  MOCK_METHOD((void), MarkDebugMarkerEnd, (VkCommandBuffer));
+};
+
+using VulkanLayerControllerImpl =
+    VulkanLayerController<MockDispatchTable, MockQueueManager, MockDeviceManager,
+                          MockTimerQueryPool, MockSubmissionTracker>;
+
+Matcher<VkExtensionProperties> VkExtensionPropertiesAreEqual(
+    const VkExtensionProperties& expected) {
+  return AllOf(
+      Field("specVersion", &VkExtensionProperties::specVersion, expected.specVersion),
+      Field("extensionName", &VkExtensionProperties::extensionName, StrEq(expected.extensionName)));
+}
+}  // namespace
+
+class VulkanLayerControllerTest : public ::testing::Test {
+ protected:
+  VulkanLayerController<MockDispatchTable, MockQueueManager, MockDeviceManager, MockTimerQueryPool,
+                        MockSubmissionTracker>
+      controller_;
+  static constexpr VkExtensionProperties kDebugMarkerExtension{
+      .extensionName = VK_EXT_DEBUG_MARKER_EXTENSION_NAME,
+      .specVersion = VK_EXT_DEBUG_MARKER_SPEC_VERSION};
+  static constexpr VkExtensionProperties kDebugUtilsExtension{
+      .extensionName = VK_EXT_DEBUG_UTILS_EXTENSION_NAME,
+      .specVersion = VK_EXT_DEBUG_UTILS_SPEC_VERSION};
+  static constexpr VkExtensionProperties kHostQueryResetExtension{
+      .extensionName = VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME,
+      .specVersion = VK_EXT_HOST_QUERY_RESET_SPEC_VERSION};
+
+  static constexpr VkExtensionProperties kFakeExtension1{.extensionName = "Other Extension 1",
+                                                         .specVersion = 3};
+  static constexpr VkExtensionProperties kFakeExtension2{.extensionName = "Other Extension 2",
+                                                         .specVersion = 2};
+
+  static constexpr PFN_vkEnumerateDeviceExtensionProperties
+      kMockEnumerateDeviceExtensionPropertiesFunction =
+          +[](VkPhysicalDevice /*physical_device*/, const char* /*layer_name*/,
+              uint32_t* property_count, VkExtensionProperties* properties) {
+            if (property_count != nullptr) {
+              *property_count = 3;
+            }
+
+            std::array<VkExtensionProperties, 3> fake_extensions{kFakeExtension1, kFakeExtension2,
+                                                                 kDebugMarkerExtension};
+            if (properties != nullptr) {
+              memcpy(properties, fake_extensions.data(), 3 * sizeof(VkExtensionProperties));
+            }
+
+            return VK_SUCCESS;
+          };
+};
+
+// ----------------------------------------------------------------------------
+// Layer enumeration functions
+// ----------------------------------------------------------------------------
+TEST_F(VulkanLayerControllerTest, CanEnumerateTheLayersInstanceLayerProperties) {
+  uint32_t actual_property_count;
+  VkResult result = controller_.OnEnumerateInstanceLayerProperties(&actual_property_count, nullptr);
+  ASSERT_EQ(result, VK_SUCCESS);
+  ASSERT_EQ(actual_property_count, 1);
+
+  VkLayerProperties actual_properties;
+  result =
+      controller_.OnEnumerateInstanceLayerProperties(&actual_property_count, &actual_properties);
+  ASSERT_EQ(result, VK_SUCCESS);
+  EXPECT_STREQ(actual_properties.layerName, VulkanLayerControllerImpl::kLayerName);
+  EXPECT_STREQ(actual_properties.description, VulkanLayerControllerImpl::kLayerDescription);
+  EXPECT_EQ(actual_properties.specVersion, VulkanLayerControllerImpl::kLayerSpecVersion);
+  EXPECT_EQ(actual_properties.implementationVersion, VulkanLayerControllerImpl::kLayerImplVersion);
+}
+
+TEST_F(VulkanLayerControllerTest, TheLayerHasNoInstanceExtensionProperties) {
+  uint32_t actual_property_count = 123;
+  VkResult result = controller_.OnEnumerateInstanceExtensionProperties(
+      VulkanLayerControllerImpl::kLayerName, &actual_property_count, nullptr);
+  EXPECT_EQ(result, VK_SUCCESS);
+  EXPECT_EQ(actual_property_count, 0);
+}
+
+TEST_F(VulkanLayerControllerTest, ErrorOnEnumerateInstanceExtensionPropertiesForDifferentLayer) {
+  uint32_t actual_property_count;
+  VkResult result = controller_.OnEnumerateInstanceExtensionProperties(
+      "some layer name", &actual_property_count, nullptr);
+  EXPECT_EQ(result, VK_ERROR_LAYER_NOT_PRESENT);
+}
+
+TEST_F(VulkanLayerControllerTest, ErrorOnEnumerateInstanceExtensionPropertiesOnNullString) {
+  uint32_t actual_property_count;
+  VkResult result =
+      controller_.OnEnumerateInstanceExtensionProperties(nullptr, &actual_property_count, nullptr);
+  EXPECT_EQ(result, VK_ERROR_LAYER_NOT_PRESENT);
+}
+
+TEST_F(VulkanLayerControllerTest, CanEnumerateTheLayersExclusiveDeviceExtensionProperties) {
+  VkPhysicalDevice physical_device = {};
+  uint32_t actual_property_count;
+  VkResult result = controller_.OnEnumerateDeviceExtensionProperties(
+      physical_device, VulkanLayerControllerImpl::kLayerName, &actual_property_count, nullptr);
+  EXPECT_EQ(result, VK_SUCCESS);
+  ASSERT_EQ(actual_property_count, 3);
+  std::array<VkExtensionProperties, 3> actual_properties = {};
+  result = controller_.OnEnumerateDeviceExtensionProperties(
+      physical_device, VulkanLayerControllerImpl::kLayerName, &actual_property_count,
+      actual_properties.data());
+  EXPECT_EQ(result, VK_SUCCESS);
+  EXPECT_THAT(actual_properties,
+              UnorderedElementsAreArray({VkExtensionPropertiesAreEqual(kDebugMarkerExtension),
+                                         VkExtensionPropertiesAreEqual(kDebugUtilsExtension),
+                                         VkExtensionPropertiesAreEqual(kHostQueryResetExtension)}));
+}
+
+TEST_F(VulkanLayerControllerTest,
+       CanEnumerateASubsetOfTheLayersExclusiveDeviceExtensionProperties) {
+  VkPhysicalDevice physical_device = {};
+  uint32_t actual_property_count = 2;
+  std::array<VkExtensionProperties, 2> actual_properties = {};
+  VkResult result = controller_.OnEnumerateDeviceExtensionProperties(
+      physical_device, VulkanLayerControllerImpl::kLayerName, &actual_property_count,
+      actual_properties.data());
+  EXPECT_EQ(result, VK_INCOMPLETE);
+  ASSERT_EQ(actual_property_count, 2);
+  EXPECT_THAT(actual_properties,
+              IsSubsetOf({VkExtensionPropertiesAreEqual(kDebugMarkerExtension),
+                          VkExtensionPropertiesAreEqual(kDebugUtilsExtension),
+                          VkExtensionPropertiesAreEqual(kHostQueryResetExtension)}));
+}
+
+TEST_F(VulkanLayerControllerTest, WillForwardCallOnEnumerateOtherLayersDeviceExtensionProperties) {
+  const MockDispatchTable* dispatch_table = controller_.dispatch_table();
+  EXPECT_CALL(*dispatch_table, EnumerateDeviceExtensionProperties)
+      .Times(2)
+      .WillRepeatedly(Return(kMockEnumerateDeviceExtensionPropertiesFunction));
+  VkPhysicalDevice physical_device = {};
+  uint32_t actual_property_count;
+
+  VkResult result = controller_.OnEnumerateDeviceExtensionProperties(
+      physical_device, "other layer", &actual_property_count, nullptr);
+
+  EXPECT_EQ(result, VK_SUCCESS);
+  ASSERT_EQ(actual_property_count, 3);
+
+  std::array<VkExtensionProperties, 3> actual_properties = {};
+  result = controller_.OnEnumerateDeviceExtensionProperties(
+      physical_device, "other layer", &actual_property_count, actual_properties.data());
+  EXPECT_EQ(result, VK_SUCCESS);
+  EXPECT_THAT(actual_properties,
+              UnorderedElementsAreArray({VkExtensionPropertiesAreEqual(kFakeExtension1),
+                                         VkExtensionPropertiesAreEqual(kFakeExtension2),
+                                         VkExtensionPropertiesAreEqual(kDebugMarkerExtension)}));
+}
+
+TEST_F(VulkanLayerControllerTest,
+       WillReturnErrorOnEnumerateAllLayersDeviceExtensionPropertiesError) {
+  PFN_vkEnumerateDeviceExtensionProperties mock_enumerate_device_extension_properties_function =
+      +[](VkPhysicalDevice /*physical_device*/, const char* /*layer_name*/,
+          uint32_t* /*property_count*/,
+          VkExtensionProperties* /*properties*/) { return VK_INCOMPLETE; };
+  const MockDispatchTable* dispatch_table = controller_.dispatch_table();
+  EXPECT_CALL(*dispatch_table, EnumerateDeviceExtensionProperties)
+      .Times(1)
+      .WillRepeatedly(Return(mock_enumerate_device_extension_properties_function));
+  VkPhysicalDevice physical_device = {};
+  uint32_t actual_property_count;
+  VkResult result = controller_.OnEnumerateDeviceExtensionProperties(
+      physical_device, nullptr, &actual_property_count, nullptr);
+  EXPECT_EQ(result, VK_INCOMPLETE);
+}
+
+TEST_F(VulkanLayerControllerTest,
+       WillMergePropertiesOnEnumerateAllLayersDeviceExtensionProperties) {
+  const MockDispatchTable* dispatch_table = controller_.dispatch_table();
+  EXPECT_CALL(*dispatch_table, EnumerateDeviceExtensionProperties)
+      .WillRepeatedly(Return(kMockEnumerateDeviceExtensionPropertiesFunction));
+  VkPhysicalDevice physical_device = {};
+  uint32_t actual_property_count;
+
+  VkResult result = controller_.OnEnumerateDeviceExtensionProperties(
+      physical_device, nullptr, &actual_property_count, nullptr);
+
+  EXPECT_EQ(result, VK_SUCCESS);
+  ASSERT_EQ(actual_property_count, 5);
+
+  std::array<VkExtensionProperties, 5> actual_properties = {};
+  result = controller_.OnEnumerateDeviceExtensionProperties(
+      physical_device, nullptr, &actual_property_count, actual_properties.data());
+  EXPECT_EQ(result, VK_SUCCESS);
+  EXPECT_THAT(actual_properties,
+              UnorderedElementsAreArray({VkExtensionPropertiesAreEqual(kFakeExtension1),
+                                         VkExtensionPropertiesAreEqual(kFakeExtension2),
+                                         VkExtensionPropertiesAreEqual(kDebugMarkerExtension),
+                                         VkExtensionPropertiesAreEqual(kDebugUtilsExtension),
+                                         VkExtensionPropertiesAreEqual(kHostQueryResetExtension)}));
+}
+
+TEST_F(VulkanLayerControllerTest,
+       CanMergePropertiesAndEnumerateASubsetForAllLayersDeviceExtensionProperties) {
+  const MockDispatchTable* dispatch_table = controller_.dispatch_table();
+  EXPECT_CALL(*dispatch_table, EnumerateDeviceExtensionProperties)
+      .WillRepeatedly(Return(kMockEnumerateDeviceExtensionPropertiesFunction));
+  VkPhysicalDevice physical_device = {};
+
+  std::array<VkExtensionProperties, 3> actual_properties = {};
+  uint32_t stripped_property_count = 3;
+  VkResult result = controller_.OnEnumerateDeviceExtensionProperties(
+      physical_device, nullptr, &stripped_property_count, actual_properties.data());
+  EXPECT_EQ(result, VK_INCOMPLETE);
+  EXPECT_THAT(actual_properties,
+              IsSubsetOf({VkExtensionPropertiesAreEqual(kFakeExtension1),
+                          VkExtensionPropertiesAreEqual(kFakeExtension2),
+                          VkExtensionPropertiesAreEqual(kDebugMarkerExtension),
+                          VkExtensionPropertiesAreEqual(kDebugUtilsExtension),
+                          VkExtensionPropertiesAreEqual(kHostQueryResetExtension)}));
+}
+
+// ----------------------------------------------------------------------------
+// Layer bootstrapping code
+// ----------------------------------------------------------------------------
+
+TEST_F(VulkanLayerControllerTest, InitializationFailsOnCreateInstanceWithNoInfo) {
+  VkInstance created_instance;
+  VkInstanceCreateInfo create_info{.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
+                                   .pNext = nullptr};
+  VkResult result = controller_.OnCreateInstance(&create_info, nullptr, &created_instance);
+  EXPECT_EQ(result, VK_ERROR_INITIALIZATION_FAILED);
+}
+
+TEST_F(VulkanLayerControllerTest,
+       WillCreateDispatchTableAndVulkanLayerProducerAndAdvanceLinkageOnCreateInstance) {
+  const MockDispatchTable* dispatch_table = controller_.dispatch_table();
+  const MockSubmissionTracker* submission_tracker = controller_.submission_tracker();
+  EXPECT_CALL(*dispatch_table, CreateInstanceDispatchTable).Times(1);
+  EXPECT_CALL(*submission_tracker, SetVulkanLayerProducer).Times(1);
+
+  static constexpr PFN_vkCreateInstance kMockDriverCreateInstance =
+      +[](const VkInstanceCreateInfo* /*create_info*/, const VkAllocationCallbacks* /*allocator*/,
+          VkInstance* /*instance*/) { return VK_SUCCESS; };
+
+  PFN_vkGetInstanceProcAddr mock_get_instance_proc_addr =
+      +[](VkInstance /*instance*/, const char* name) -> PFN_vkVoidFunction {
+    if (strcmp(name, "vkCreateInstance") == 0) {
+      return absl::bit_cast<PFN_vkVoidFunction>(kMockDriverCreateInstance);
+    }
+    return nullptr;
+  };
+
+  VkLayerInstanceLink layer_link_1 = {.pfnNextGetInstanceProcAddr = mock_get_instance_proc_addr};
+  VkLayerInstanceLink layer_link_2 = {.pfnNextGetInstanceProcAddr = mock_get_instance_proc_addr,
+                                      .pNext = &layer_link_1};
+  VkLayerInstanceCreateInfo layer_create_info{
+      .sType = VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO,
+      .function = VK_LAYER_LINK_INFO,
+      .u.pLayerInfo = &layer_link_2};
+  VkInstanceCreateInfo create_info{.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
+                                   .pNext = &layer_create_info};
+  VkInstance created_instance;
+  VkResult result = controller_.OnCreateInstance(&create_info, nullptr, &created_instance);
+  EXPECT_EQ(result, VK_SUCCESS);
+  EXPECT_EQ(layer_create_info.u.pLayerInfo, &layer_link_1);
+
+  ::testing::Mock::VerifyAndClearExpectations(absl::bit_cast<void*>(submission_tracker));
+  // There will be a call at the destructor.
+  EXPECT_CALL(*submission_tracker, SetVulkanLayerProducer).Times(1);
+}
+
+TEST_F(VulkanLayerControllerTest, InitializationFailsOnCreateDeviceWithNoInfo) {
+  VkDevice created_device;
+  VkPhysicalDevice physical_device = {};
+  VkDeviceCreateInfo create_info{.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO, .pNext = nullptr};
+  VkResult result =
+      controller_.OnCreateDevice(physical_device, &create_info, nullptr, &created_device);
+  EXPECT_EQ(result, VK_ERROR_INITIALIZATION_FAILED);
+}
+
+TEST_F(VulkanLayerControllerTest, CallInDispatchTableOnGetDeviceProcAddr) {
+  const MockDispatchTable* dispatch_table = controller_.dispatch_table();
+  static constexpr PFN_vkVoidFunction kExpectedFunction = +[]() {};
+  PFN_vkGetDeviceProcAddr mock_get_device_proc_addr =
+      +[](VkDevice /*device*/, const char* /*name*/) { return kExpectedFunction; };
+  EXPECT_CALL(*dispatch_table, GetDeviceProcAddr)
+      .Times(1)
+      .WillOnce(Return(mock_get_device_proc_addr));
+  VkDevice device = {};
+  PFN_vkVoidFunction result = controller_.OnGetDeviceProcAddr(device, "some function");
+  EXPECT_EQ(result, kExpectedFunction);
+}
+
+TEST_F(VulkanLayerControllerTest,
+       WillCreateDispatchTableAndVulkanLayerProducerAndAdvanceLinkageOnCreateDevice) {
+  const MockDispatchTable* dispatch_table = controller_.dispatch_table();
+  EXPECT_CALL(*dispatch_table, CreateDeviceDispatchTable).Times(1);
+  const MockDeviceManager* device_manager = controller_.device_manager();
+  EXPECT_CALL(*device_manager, TrackLogicalDevice).Times(1);
+  const MockTimerQueryPool* timer_query_pool = controller_.timer_query_pool();
+  EXPECT_CALL(*timer_query_pool, InitializeTimerQueryPool).Times(1);
+
+  static constexpr PFN_vkCreateDevice kMockDriverCreateDevice =
+      +[](VkPhysicalDevice /*physical_device*/, const VkDeviceCreateInfo* /*create_info*/,
+          const VkAllocationCallbacks* /*allocator*/,
+          VkDevice* /*instance*/) { return VK_SUCCESS; };
+
+  PFN_vkGetDeviceProcAddr mock_get_device_proc_addr =
+      +[](VkDevice /*device*/, const char * /*name*/) -> PFN_vkVoidFunction { return nullptr; };
+
+  PFN_vkGetInstanceProcAddr mock_get_instance_proc_addr =
+      +[](VkInstance /*instance*/, const char* name) -> PFN_vkVoidFunction {
+    if (strcmp(name, "vkCreateDevice") == 0) {
+      return absl::bit_cast<PFN_vkVoidFunction>(kMockDriverCreateDevice);
+    }
+    return nullptr;
+  };
+
+  VkLayerDeviceLink layer_link_1 = {.pfnNextGetDeviceProcAddr = mock_get_device_proc_addr,
+                                    .pfnNextGetInstanceProcAddr = mock_get_instance_proc_addr};
+  VkLayerDeviceLink layer_link_2 = {.pfnNextGetDeviceProcAddr = mock_get_device_proc_addr,
+                                    .pfnNextGetInstanceProcAddr = mock_get_instance_proc_addr,
+                                    .pNext = &layer_link_1};
+  VkLayerDeviceCreateInfo layer_create_info{.sType = VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO,
+                                            .function = VK_LAYER_LINK_INFO,
+                                            .u.pLayerInfo = &layer_link_2};
+  VkDeviceCreateInfo create_info{.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
+                                 .pNext = &layer_create_info};
+  VkDevice created_device;
+  VkPhysicalDevice physical_device = {};
+  VkResult result =
+      controller_.OnCreateDevice(physical_device, &create_info, nullptr, &created_device);
+  EXPECT_EQ(result, VK_SUCCESS);
+  EXPECT_EQ(layer_create_info.u.pLayerInfo, &layer_link_1);
+}
+
+TEST_F(VulkanLayerControllerTest, CallInDispatchTableOnGetInstanceProcAddr) {
+  const MockDispatchTable* dispatch_table = controller_.dispatch_table();
+  static constexpr PFN_vkVoidFunction kExpectedFunction = +[]() {};
+  PFN_vkGetInstanceProcAddr mock_get_instance_proc_addr =
+      +[](VkInstance /*instance*/, const char* /*name*/) { return kExpectedFunction; };
+  EXPECT_CALL(*dispatch_table, GetInstanceProcAddr)
+      .Times(1)
+      .WillOnce(Return(mock_get_instance_proc_addr));
+  VkInstance instance = {};
+  PFN_vkVoidFunction result = controller_.OnGetInstanceProcAddr(instance, "some function");
+  EXPECT_EQ(result, kExpectedFunction);
+}
+
+TEST_F(VulkanLayerControllerTest, WillClearUpOnDestroyInstance) {
+  PFN_vkDestroyInstance mock_destroy_instance =
+      +[](VkInstance /*instance*/, const VkAllocationCallbacks* /*allocator*/) {};
+  const MockDispatchTable* dispatch_table = controller_.dispatch_table();
+  EXPECT_CALL(*dispatch_table, DestroyInstance).Times(1).WillOnce(Return(mock_destroy_instance));
+  EXPECT_CALL(*dispatch_table, RemoveInstanceDispatchTable).Times(1);
+
+  VkInstance instance = {};
+
+  controller_.OnDestroyInstance(instance, nullptr);
+}
+
+TEST_F(VulkanLayerControllerTest, WillClearUpOnDestroyDevice) {
+  PFN_vkDestroyDevice mock_destroy_device =
+      +[](VkDevice /*device*/, const VkAllocationCallbacks* /*allocator*/) {};
+  const MockDispatchTable* dispatch_table = controller_.dispatch_table();
+  EXPECT_CALL(*dispatch_table, DestroyDevice).Times(1).WillOnce(Return(mock_destroy_device));
+  EXPECT_CALL(*dispatch_table, RemoveDeviceDispatchTable).Times(1);
+  const MockDeviceManager* device_manager = controller_.device_manager();
+  EXPECT_CALL(*device_manager, UntrackLogicalDevice).Times(1);
+
+  VkDevice device = {};
+
+  controller_.OnDestroyDevice(device, nullptr);
+}
+
+// ----------------------------------------------------------------------------
+// Core layer logic
+// ----------------------------------------------------------------------------
+
+TEST_F(VulkanLayerControllerTest, CanDelegateOnResetCommandPool) {
+  PFN_vkResetCommandPool mock_reset_command_pool =
+      +[](VkDevice /*device*/, VkCommandPool /*command_pool*/,
+          VkCommandPoolResetFlags /*flags*/) -> VkResult { return VK_SUCCESS; };
+  const MockDispatchTable* dispatch_table = controller_.dispatch_table();
+  EXPECT_CALL(*dispatch_table, ResetCommandPool).Times(1).WillOnce(Return(mock_reset_command_pool));
+
+  const MockSubmissionTracker* submission_tracker = controller_.submission_tracker();
+  EXPECT_CALL(*submission_tracker, ResetCommandPool).Times(1);
+  VkDevice device = {};
+  VkCommandPool command_pool = {};
+  VkCommandPoolResetFlags flags = {};
+  VkResult result = controller_.OnResetCommandPool(device, command_pool, flags);
+  EXPECT_EQ(result, VK_SUCCESS);
+}
+
+TEST_F(VulkanLayerControllerTest, CanDelegateOnAllocateCommandBuffers) {
+  PFN_vkAllocateCommandBuffers mock_allocate_command_buffers =
+      +[](VkDevice /*device*/, const VkCommandBufferAllocateInfo* /*allocate_info*/,
+          VkCommandBuffer *
+          /*command_buffers*/) -> VkResult { return VK_SUCCESS; };
+  const MockDispatchTable* dispatch_table = controller_.dispatch_table();
+  EXPECT_CALL(*dispatch_table, AllocateCommandBuffers)
+      .Times(1)
+      .WillOnce(Return(mock_allocate_command_buffers));
+
+  const MockSubmissionTracker* submission_tracker = controller_.submission_tracker();
+  EXPECT_CALL(*submission_tracker, TrackCommandBuffers).Times(1);
+  VkDevice device = {};
+  VkCommandPool command_pool = {};
+  VkCommandBuffer command_buffer;
+
+  VkCommandBufferAllocateInfo allocate_info{.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+                                            .pNext = nullptr,
+                                            .commandBufferCount = 1,
+                                            .commandPool = command_pool};
+
+  VkResult result = controller_.OnAllocateCommandBuffers(device, &allocate_info, &command_buffer);
+  EXPECT_EQ(result, VK_SUCCESS);
+}
+
+TEST_F(VulkanLayerControllerTest, CanDelegateOnFreeCommandBuffers) {
+  PFN_vkFreeCommandBuffers mock_free_command_buffers =
+      +[](VkDevice /*device*/, VkCommandPool /*command_pool*/, uint32_t /*command_buffer_count*/,
+          const VkCommandBuffer*
+          /*command_buffers*/) {};
+  const MockDispatchTable* dispatch_table = controller_.dispatch_table();
+  EXPECT_CALL(*dispatch_table, FreeCommandBuffers)
+      .Times(1)
+      .WillOnce(Return(mock_free_command_buffers));
+
+  const MockSubmissionTracker* submission_tracker = controller_.submission_tracker();
+  EXPECT_CALL(*submission_tracker, UntrackCommandBuffers).Times(1);
+  VkDevice device = {};
+  VkCommandPool command_pool = {};
+  VkCommandBuffer command_buffer;
+
+  controller_.OnFreeCommandBuffers(device, command_pool, 1, &command_buffer);
+}
+
+TEST_F(VulkanLayerControllerTest, CanDelegateOnBeginCommandBuffer) {
+  PFN_vkBeginCommandBuffer mock_begin_command_buffer =
+      +[](VkCommandBuffer /*command_buffer*/, const VkCommandBufferBeginInfo *
+          /*begin_info*/) -> VkResult { return VK_SUCCESS; };
+  const MockDispatchTable* dispatch_table = controller_.dispatch_table();
+  EXPECT_CALL(*dispatch_table, BeginCommandBuffer)
+      .Times(1)
+      .WillOnce(Return(mock_begin_command_buffer));
+
+  const MockSubmissionTracker* submission_tracker = controller_.submission_tracker();
+  EXPECT_CALL(*submission_tracker, MarkCommandBufferBegin).Times(1);
+  VkCommandBuffer command_buffer = {};
+  VkResult result = controller_.OnBeginCommandBuffer(command_buffer, nullptr);
+  EXPECT_EQ(result, VK_SUCCESS);
+}
+
+TEST_F(VulkanLayerControllerTest, CanDelegateOnEndCommandBuffer) {
+  PFN_vkEndCommandBuffer mock_end_command_buffer =
+      +[](VkCommandBuffer /*command_buffer*/) -> VkResult { return VK_SUCCESS; };
+  const MockDispatchTable* dispatch_table = controller_.dispatch_table();
+  EXPECT_CALL(*dispatch_table, EndCommandBuffer).Times(1).WillOnce(Return(mock_end_command_buffer));
+
+  const MockSubmissionTracker* submission_tracker = controller_.submission_tracker();
+  EXPECT_CALL(*submission_tracker, MarkCommandBufferEnd).Times(1);
+  VkCommandBuffer command_buffer = {};
+  VkResult result = controller_.OnEndCommandBuffer(command_buffer);
+  EXPECT_EQ(result, VK_SUCCESS);
+}
+
+TEST_F(VulkanLayerControllerTest, CanDelegateOnResetCommandBuffer) {
+  PFN_vkResetCommandBuffer mock_reset_command_buffer =
+      +[](VkCommandBuffer /*command_buffer*/, VkCommandBufferResetFlags /*flags*/) -> VkResult {
+    return VK_SUCCESS;
+  };
+  const MockDispatchTable* dispatch_table = controller_.dispatch_table();
+  EXPECT_CALL(*dispatch_table, ResetCommandBuffer)
+      .Times(1)
+      .WillOnce(Return(mock_reset_command_buffer));
+
+  const MockSubmissionTracker* submission_tracker = controller_.submission_tracker();
+  EXPECT_CALL(*submission_tracker, ResetCommandBuffer).Times(1);
+  VkCommandBuffer command_buffer = {};
+  VkResult result = controller_.OnResetCommandBuffer(
+      command_buffer, VkCommandBufferResetFlagBits::VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT);
+  EXPECT_EQ(result, VK_SUCCESS);
+}
+
+TEST_F(VulkanLayerControllerTest, CanDelegateOnGetDeviceQueue) {
+  PFN_vkGetDeviceQueue mock_get_device_queue =
+      +[](VkDevice /*device*/, uint32_t /*queue_family_index*/, uint32_t /*queue_index*/,
+          VkQueue* /*queue*/) {};
+  const MockDispatchTable* dispatch_table = controller_.dispatch_table();
+  EXPECT_CALL(*dispatch_table, GetDeviceQueue).Times(1).WillOnce(Return(mock_get_device_queue));
+
+  const MockQueueManager* queue_manager = controller_.queue_manager();
+  EXPECT_CALL(*queue_manager, TrackQueue).Times(1);
+  VkDevice device = {};
+  VkQueue queue;
+  controller_.OnGetDeviceQueue(device, 1, 2, &queue);
+}
+
+TEST_F(VulkanLayerControllerTest, CanDelegateOnGetDeviceQueue2) {
+  PFN_vkGetDeviceQueue2 mock_get_device_queue2 =
+      +[](VkDevice /*device*/, const VkDeviceQueueInfo2* /*queue_info*/, VkQueue* /*queue*/) {};
+  const MockDispatchTable* dispatch_table = controller_.dispatch_table();
+  EXPECT_CALL(*dispatch_table, GetDeviceQueue2).Times(1).WillOnce(Return(mock_get_device_queue2));
+
+  const MockQueueManager* queue_manager = controller_.queue_manager();
+  EXPECT_CALL(*queue_manager, TrackQueue).Times(1);
+
+  VkDevice device = {};
+  VkQueue queue;
+  VkDeviceQueueInfo2 queue_info{
+      .sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_INFO_2, .queueFamilyIndex = 1, .queueIndex = 2};
+  controller_.OnGetDeviceQueue2(device, &queue_info, &queue);
+}
+
+TEST_F(VulkanLayerControllerTest, CanDelegateOnGetQueueSubmit) {
+  PFN_vkQueueSubmit mock_queue_submit =
+      +[](VkQueue /*queue*/, uint32_t /*submit_count*/, const VkSubmitInfo* /*submits*/,
+          VkFence /*fence*/) -> VkResult { return VK_SUCCESS; };
+  const MockDispatchTable* dispatch_table = controller_.dispatch_table();
+  EXPECT_CALL(*dispatch_table, QueueSubmit).Times(1).WillOnce(Return(mock_queue_submit));
+
+  const MockSubmissionTracker* submission_tracker = controller_.submission_tracker();
+  EXPECT_CALL(*submission_tracker, PersistCommandBuffersOnSubmit).Times(1);
+  EXPECT_CALL(*submission_tracker, PersistDebugMarkersOnSubmit).Times(1);
+
+  VkQueue queue = {};
+  VkCommandBuffer command_buffer = {};
+  VkSubmitInfo submit_info{.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+                           .commandBufferCount = 1,
+                           .pCommandBuffers = &command_buffer};
+  VkFence fence = {};
+  VkResult result = controller_.OnQueueSubmit(queue, 1, &submit_info, fence);
+  EXPECT_EQ(result, VK_SUCCESS);
+}
+
+TEST_F(VulkanLayerControllerTest, CanDelegateOnQueuePresentKHR) {
+  PFN_vkQueuePresentKHR mock_queue_present =
+      +[](VkQueue /*queue*/, const VkPresentInfoKHR * /*present_info*/) -> VkResult {
+    return VK_SUCCESS;
+  };
+  const MockDispatchTable* dispatch_table = controller_.dispatch_table();
+  EXPECT_CALL(*dispatch_table, QueuePresentKHR).Times(1).WillOnce(Return(mock_queue_present));
+
+  const MockSubmissionTracker* submission_tracker = controller_.submission_tracker();
+  EXPECT_CALL(*submission_tracker, CompleteSubmits).Times(1);
+  VkDevice device = {};
+  const MockQueueManager* queue_manager = controller_.queue_manager();
+  EXPECT_CALL(*queue_manager, GetDeviceOfQueue).Times(1).WillOnce(Return(device));
+
+  VkQueue queue = {};
+  VkPresentInfoKHR present_info{.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR};
+  VkResult result = controller_.OnQueuePresentKHR(queue, &present_info);
+  EXPECT_EQ(result, VK_SUCCESS);
+}
+
+TEST_F(VulkanLayerControllerTest,
+       WillMarkDebugMarkerBeginButNotDelegateIfDriverDoesNotSupportDebugUtils) {
+  const MockDispatchTable* dispatch_table = controller_.dispatch_table();
+  EXPECT_CALL(*dispatch_table, IsDebugUtilsExtensionSupported).Times(1).WillOnce(Return(false));
+  const MockSubmissionTracker* submission_tracker = controller_.submission_tracker();
+  EXPECT_CALL(*submission_tracker, MarkDebugMarkerBegin).Times(1);
+
+  VkCommandBuffer command_buffer = {};
+  VkDebugUtilsLabelEXT debug_marker = {.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT,
+                                       .pLabelName = "Marker"};
+  controller_.OnCmdBeginDebugUtilsLabelEXT(command_buffer, &debug_marker);
+}
+
+TEST_F(VulkanLayerControllerTest, WillDelegateOnBeginDebugLabelIfDriverDoesSupportDebugUtils) {
+  const MockDispatchTable* dispatch_table = controller_.dispatch_table();
+  EXPECT_CALL(*dispatch_table, IsDebugUtilsExtensionSupported).Times(1).WillOnce(Return(true));
+
+  PFN_vkCmdBeginDebugUtilsLabelEXT mock_cmd_begin_debug_utils_label_ext =
+      +[](VkCommandBuffer /*command_buffer*/, const VkDebugUtilsLabelEXT* /*label_info*/) {};
+  EXPECT_CALL(*dispatch_table, CmdBeginDebugUtilsLabelEXT)
+      .Times(1)
+      .WillOnce(Return(mock_cmd_begin_debug_utils_label_ext));
+
+  const MockSubmissionTracker* submission_tracker = controller_.submission_tracker();
+  EXPECT_CALL(*submission_tracker, MarkDebugMarkerBegin).Times(1);
+
+  VkCommandBuffer command_buffer = {};
+  VkDebugUtilsLabelEXT debug_marker = {.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT,
+                                       .pLabelName = "Marker"};
+  controller_.OnCmdBeginDebugUtilsLabelEXT(command_buffer, &debug_marker);
+}
+
+TEST_F(VulkanLayerControllerTest,
+       WillMarkDebugMarkerEndButNotDelegateIfDriverDoesNotSupportDebugUtils) {
+  const MockDispatchTable* dispatch_table = controller_.dispatch_table();
+  EXPECT_CALL(*dispatch_table, IsDebugUtilsExtensionSupported).Times(1).WillOnce(Return(false));
+  const MockSubmissionTracker* submission_tracker = controller_.submission_tracker();
+  EXPECT_CALL(*submission_tracker, MarkDebugMarkerEnd).Times(1);
+
+  VkCommandBuffer command_buffer = {};
+  controller_.OnCmdEndDebugUtilsLabelEXT(command_buffer);
+}
+
+TEST_F(VulkanLayerControllerTest, WillDelegateOnEndDebugLabelIfDriverDoesSupportDebugUtils) {
+  const MockDispatchTable* dispatch_table = controller_.dispatch_table();
+  EXPECT_CALL(*dispatch_table, IsDebugUtilsExtensionSupported).Times(1).WillOnce(Return(true));
+
+  PFN_vkCmdEndDebugUtilsLabelEXT mock_cmd_end_debug_utils_label_ext =
+      +[](VkCommandBuffer /*command_buffer*/) {};
+  EXPECT_CALL(*dispatch_table, CmdEndDebugUtilsLabelEXT)
+      .Times(1)
+      .WillOnce(Return(mock_cmd_end_debug_utils_label_ext));
+
+  const MockSubmissionTracker* submission_tracker = controller_.submission_tracker();
+  EXPECT_CALL(*submission_tracker, MarkDebugMarkerEnd).Times(1);
+
+  VkCommandBuffer command_buffer = {};
+  controller_.OnCmdEndDebugUtilsLabelEXT(command_buffer);
+}
+
+TEST_F(VulkanLayerControllerTest,
+       WillMarkDebugMarkerBeginButNotDelegateIfDriverDoesNotSupportDebugMarkers) {
+  const MockDispatchTable* dispatch_table = controller_.dispatch_table();
+  EXPECT_CALL(*dispatch_table, IsDebugMarkerExtensionSupported).Times(1).WillOnce(Return(false));
+  const MockSubmissionTracker* submission_tracker = controller_.submission_tracker();
+  EXPECT_CALL(*submission_tracker, MarkDebugMarkerBegin).Times(1);
+
+  VkCommandBuffer command_buffer = {};
+  VkDebugMarkerMarkerInfoEXT debug_marker = {
+      .sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT, .pMarkerName = "Marker"};
+  controller_.OnCmdDebugMarkerBeginEXT(command_buffer, &debug_marker);
+}
+
+TEST_F(VulkanLayerControllerTest, WillDelegateOnBeginDebugMarkerIfDriverDoesSupportDebugMrkers) {
+  const MockDispatchTable* dispatch_table = controller_.dispatch_table();
+  EXPECT_CALL(*dispatch_table, IsDebugMarkerExtensionSupported).Times(1).WillOnce(Return(true));
+
+  PFN_vkCmdDebugMarkerBeginEXT mock_cmd_debug_marker_begin_ext =
+      +[](VkCommandBuffer /*command_buffer*/, const VkDebugMarkerMarkerInfoEXT* /*label_info*/) {};
+  EXPECT_CALL(*dispatch_table, CmdDebugMarkerBeginEXT)
+      .Times(1)
+      .WillOnce(Return(mock_cmd_debug_marker_begin_ext));
+
+  const MockSubmissionTracker* submission_tracker = controller_.submission_tracker();
+  EXPECT_CALL(*submission_tracker, MarkDebugMarkerBegin).Times(1);
+
+  VkCommandBuffer command_buffer = {};
+  VkDebugMarkerMarkerInfoEXT debug_marker = {
+      .sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT, .pMarkerName = "Marker"};
+  controller_.OnCmdDebugMarkerBeginEXT(command_buffer, &debug_marker);
+}
+
+TEST_F(VulkanLayerControllerTest,
+       WillMarkDebugMarkerEndButNotDelegateIfDriverDoesNotSupportDebugMarkers) {
+  const MockDispatchTable* dispatch_table = controller_.dispatch_table();
+  EXPECT_CALL(*dispatch_table, IsDebugMarkerExtensionSupported).Times(1).WillOnce(Return(false));
+  const MockSubmissionTracker* submission_tracker = controller_.submission_tracker();
+  EXPECT_CALL(*submission_tracker, MarkDebugMarkerEnd).Times(1);
+
+  VkCommandBuffer command_buffer = {};
+  controller_.OnCmdDebugMarkerEndEXT(command_buffer);
+}
+
+TEST_F(VulkanLayerControllerTest, WillDelegateOnEndDebugMarkerIfDriverDoesSupportDebugMarkers) {
+  const MockDispatchTable* dispatch_table = controller_.dispatch_table();
+  EXPECT_CALL(*dispatch_table, IsDebugMarkerExtensionSupported).Times(1).WillOnce(Return(true));
+
+  PFN_vkCmdDebugMarkerEndEXT mock_cmd_debug_marker_end_ext =
+      +[](VkCommandBuffer /*command_buffer*/) {};
+  EXPECT_CALL(*dispatch_table, CmdDebugMarkerEndEXT)
+      .Times(1)
+      .WillOnce(Return(mock_cmd_debug_marker_end_ext));
+
+  const MockSubmissionTracker* submission_tracker = controller_.submission_tracker();
+  EXPECT_CALL(*submission_tracker, MarkDebugMarkerEnd).Times(1);
+
+  VkCommandBuffer command_buffer = {};
+  controller_.OnCmdDebugMarkerEndEXT(command_buffer);
+}
+
+}  // namespace orbit_vulkan_layer


### PR DESCRIPTION
The `VulkanLayerController` glues together all the logic of the
Vulkan layer by having an representative for every instrumented
Vulkan function ("OnFunctionName").

It is also responsible for the bootstrapping (in particular
vkCreateInstance/Device) and the enumeration functions to expose
the layer's properties.

Bug: http://b/168200502
Test: Compile & Run tests

TODO: The commit introducing the grpc channel is missing, thus
the tests will fail, at the moment.