### PR TITLE
Removal of global variable GOrbitApp

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -1567,7 +1567,7 @@ DataView* OrbitApp::GetOrCreateDataView(DataViewType type) {
 
     case DataViewType::kPresets:
       if (!presets_data_view_) {
-        presets_data_view_ = std::make_unique<PresetsDataView>();
+        presets_data_view_ = std::make_unique<PresetsDataView>(this);
         panels_.push_back(presets_data_view_.get());
       }
       return presets_data_view_.get();

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -104,7 +104,6 @@ PresetLoadState GetPresetLoadStateForProcess(
 }
 }  // namespace
 
-std::unique_ptr<OrbitApp> GOrbitApp;
 bool DoZoom = false;
 
 OrbitApp::OrbitApp(ApplicationOptions&& options,

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -462,7 +462,7 @@ void OrbitApp::ListPresets() {
 void OrbitApp::RefreshCaptureView() {
   ORBIT_SCOPE_FUNCTION;
   NeedsRedraw();
-  GOrbitApp->FireRefreshCallbacks();
+  FireRefreshCallbacks();
   DoZoom = true;  // TODO: remove global, review logic
 }
 
@@ -528,15 +528,14 @@ void OrbitApp::Disassemble(int32_t pid, const FunctionInfo& function) {
 
 Timer GMainTimer;
 
-// TODO: make it non-static
 void OrbitApp::MainTick() {
   ORBIT_SCOPE("OrbitApp::MainTick");
   GMainTimer.Restart();
 
-  if (DoZoom && GOrbitApp->HasCaptureData()) {
+  if (DoZoom && HasCaptureData()) {
     GCurrentTimeGraph->SortTracks();
-    GOrbitApp->capture_window_->ZoomAll();
-    GOrbitApp->NeedsRedraw();
+    capture_window_->ZoomAll();
+    NeedsRedraw();
     DoZoom = false;
   }
 }
@@ -1162,7 +1161,7 @@ void OrbitApp::LoadSymbols(const std::filesystem::path& symbols_path, ModuleData
       }
 
       UpdateAfterSymbolLoading();
-      GOrbitApp->FireRefreshCallbacks();
+      FireRefreshCallbacks();
     });
   });
 }

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -1551,7 +1551,7 @@ DataView* OrbitApp::GetOrCreateDataView(DataViewType type) {
 
     case DataViewType::kModules:
       if (!modules_data_view_) {
-        modules_data_view_ = std::make_unique<ModulesDataView>();
+        modules_data_view_ = std::make_unique<ModulesDataView>(this);
         panels_.push_back(modules_data_view_.get());
       }
       return modules_data_view_.get();

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -1537,7 +1537,7 @@ DataView* OrbitApp::GetOrCreateDataView(DataViewType type) {
   switch (type) {
     case DataViewType::kFunctions:
       if (!functions_data_view_) {
-        functions_data_view_ = std::make_unique<FunctionsDataView>();
+        functions_data_view_ = std::make_unique<FunctionsDataView>(this);
         panels_.push_back(functions_data_view_.get());
       }
       return functions_data_view_.get();

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -1544,7 +1544,7 @@ DataView* OrbitApp::GetOrCreateDataView(DataViewType type) {
 
     case DataViewType::kCallstack:
       if (!callstack_data_view_) {
-        callstack_data_view_ = std::make_unique<CallStackDataView>();
+        callstack_data_view_ = std::make_unique<CallStackDataView>(this);
         panels_.push_back(callstack_data_view_.get());
       }
       return callstack_data_view_.get();
@@ -1597,7 +1597,7 @@ DataView* OrbitApp::GetOrCreateDataView(DataViewType type) {
 
 DataView* OrbitApp::GetOrCreateSelectionCallstackDataView() {
   if (selection_callstack_data_view_ == nullptr) {
-    selection_callstack_data_view_ = std::make_unique<CallStackDataView>();
+    selection_callstack_data_view_ = std::make_unique<CallStackDataView>(this);
     panels_.push_back(selection_callstack_data_view_.get());
   }
   return selection_callstack_data_view_.get();

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -1558,7 +1558,7 @@ DataView* OrbitApp::GetOrCreateDataView(DataViewType type) {
 
     case DataViewType::kProcesses:
       if (!processes_data_view_) {
-        processes_data_view_ = std::make_unique<ProcessesDataView>();
+        processes_data_view_ = std::make_unique<ProcessesDataView>(this);
         processes_data_view_->SetSelectionListener(
             [&](int32_t pid) { UpdateProcessAndModuleList(pid); });
         panels_.push_back(processes_data_view_.get());

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -1584,7 +1584,7 @@ DataView* OrbitApp::GetOrCreateDataView(DataViewType type) {
 
     case DataViewType::kTracepoints:
       if (!tracepoints_data_view_) {
-        tracepoints_data_view_ = std::make_unique<TracepointsDataView>();
+        tracepoints_data_view_ = std::make_unique<TracepointsDataView>(this);
         panels_.push_back(tracepoints_data_view_.get());
       }
       return tracepoints_data_view_.get();

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -580,7 +580,7 @@ void OrbitApp::SetSamplingReport(
     sampling_report_->ClearReport();
   }
 
-  auto report = std::make_shared<SamplingReport>(std::move(post_processed_sampling_data),
+  auto report = std::make_shared<SamplingReport>(this, std::move(post_processed_sampling_data),
                                                  std::move(unique_callstacks));
   CHECK(sampling_reports_callback_);
   DataView* callstack_data_view = GetOrCreateDataView(DataViewType::kCallstack);
@@ -599,7 +599,7 @@ void OrbitApp::SetSelectionReport(
     selection_report_->ClearReport();
   }
 
-  auto report = std::make_shared<SamplingReport>(std::move(post_processed_sampling_data),
+  auto report = std::make_shared<SamplingReport>(this, std::move(post_processed_sampling_data),
                                                  std::move(unique_callstacks), has_summary);
   DataView* callstack_data_view = GetOrCreateSelectionCallstackDataView();
 

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -478,6 +478,4 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   FrameTrackOnlineProcessor frame_track_online_processor_;
 };
 
-extern std::unique_ptr<OrbitApp> GOrbitApp;
-
 #endif  // ORBIT_GL_APP_H_

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -76,7 +76,6 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
                                           std::unique_ptr<MainThreadExecutor> main_thread_executor);
 
   void PostInit();
-  void OnExit();
   void MainTick();
 
   std::string GetCaptureTime();

--- a/OrbitGl/AsyncTrack.cpp
+++ b/OrbitGl/AsyncTrack.cpp
@@ -15,7 +15,7 @@ using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::TimerInfo;
 
 AsyncTrack::AsyncTrack(TimeGraph* time_graph, const std::string& name, OrbitApp* app)
-    : TimerTrack(time_graph), app_{app} {
+    : TimerTrack(time_graph, app) {
   SetName(name);
   SetLabel(name);
 }

--- a/OrbitGl/AsyncTrack.cpp
+++ b/OrbitGl/AsyncTrack.cpp
@@ -14,7 +14,8 @@
 using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::TimerInfo;
 
-AsyncTrack::AsyncTrack(TimeGraph* time_graph, const std::string& name) : TimerTrack(time_graph) {
+AsyncTrack::AsyncTrack(TimeGraph* time_graph, const std::string& name, OrbitApp* app)
+    : TimerTrack(time_graph), app_{app} {
   SetName(name);
   SetLabel(name);
 }
@@ -22,7 +23,7 @@ AsyncTrack::AsyncTrack(TimeGraph* time_graph, const std::string& name) : TimerTr
 [[nodiscard]] std::string AsyncTrack::GetBoxTooltip(PickingId id) const {
   const TextBox* text_box = time_graph_->GetBatcher().GetTextBox(id);
   if (text_box == nullptr) return "";
-  auto* manual_inst_manager = GOrbitApp->GetManualInstrumentationManager();
+  auto* manual_inst_manager = app_->GetManualInstrumentationManager();
   TimerInfo timer_info = text_box->GetTimerInfo();
   orbit_api::Event event = manual_inst_manager->ApiEventFromTimerInfo(timer_info);
 
@@ -83,7 +84,7 @@ void AsyncTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_us
 
   orbit_api::Event event = ManualInstrumentationManager::ApiEventFromTimerInfo(timer_info);
   const uint64_t event_id = event.data;
-  std::string name = GOrbitApp->GetManualInstrumentationManager()->GetString(event_id);
+  std::string name = app_->GetManualInstrumentationManager()->GetString(event_id);
   std::string text = absl::StrFormat("%s %s", name, time.c_str());
   text_box->SetText(text);
 
@@ -109,7 +110,7 @@ Color AsyncTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected) c
 
   orbit_api::Event event = ManualInstrumentationManager::ApiEventFromTimerInfo(timer_info);
   const uint64_t event_id = event.data;
-  std::string name = GOrbitApp->GetManualInstrumentationManager()->GetString(event_id);
+  std::string name = app_->GetManualInstrumentationManager()->GetString(event_id);
   Color color = time_graph_->GetColor(name);
 
   constexpr uint8_t kOddAlpha = 210;

--- a/OrbitGl/AsyncTrack.h
+++ b/OrbitGl/AsyncTrack.h
@@ -30,9 +30,6 @@ class AsyncTrack final : public TimerTrack {
 
   // Used for determining what row can receive a new timer with no overlap.
   absl::flat_hash_map<uint32_t, uint64_t> max_span_time_by_depth_;
-
- private:
-  OrbitApp* app_ = nullptr;
 };
 
 #endif  // ORBIT_GL_ASYNC_TRACK_H_

--- a/OrbitGl/AsyncTrack.h
+++ b/OrbitGl/AsyncTrack.h
@@ -10,9 +10,11 @@
 #include "TimerTrack.h"
 #include "absl/container/flat_hash_map.h"
 
-class AsyncTrack : public TimerTrack {
+class OrbitApp;
+
+class AsyncTrack final : public TimerTrack {
  public:
-  AsyncTrack(TimeGraph* time_graph, const std::string& name);
+  explicit AsyncTrack(TimeGraph* time_graph, const std::string& name, OrbitApp* app);
 
   [[nodiscard]] Type GetType() const override { return kAsyncTrack; };
   [[nodiscard]] std::string GetBoxTooltip(PickingId id) const override;
@@ -28,6 +30,9 @@ class AsyncTrack : public TimerTrack {
 
   // Used for determining what row can receive a new timer with no overlap.
   absl::flat_hash_map<uint32_t, uint64_t> max_span_time_by_depth_;
+
+ private:
+  OrbitApp* app_ = nullptr;
 };
 
 #endif  // ORBIT_GL_ASYNC_TRACK_H_

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -13,8 +13,7 @@
 
 using orbit_client_protos::FunctionInfo;
 
-CallStackDataView::CallStackDataView(OrbitApp* app)
-    : DataView(DataViewType::kCallstack), app_{app} {}
+CallStackDataView::CallStackDataView(OrbitApp* app) : DataView(DataViewType::kCallstack, app) {}
 
 void CallStackDataView::SetAsMainInstance() {}
 

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -13,7 +13,8 @@
 
 using orbit_client_protos::FunctionInfo;
 
-CallStackDataView::CallStackDataView() : DataView(DataViewType::kCallstack) {}
+CallStackDataView::CallStackDataView(OrbitApp* app)
+    : DataView(DataViewType::kCallstack), app_{app} {}
 
 void CallStackDataView::SetAsMainInstance() {}
 
@@ -44,7 +45,7 @@ std::string CallStackDataView::GetValue(int row, int column) {
 
   switch (column) {
     case kColumnSelected:
-      return (function != nullptr && GOrbitApp->IsFunctionSelected(*function))
+      return (function != nullptr && app_->IsFunctionSelected(*function))
                  ? FunctionsDataView::kSelectedFunctionString
                  : FunctionsDataView::kUnselectedFunctionString;
     case kColumnName:
@@ -62,7 +63,7 @@ std::string CallStackDataView::GetValue(int row, int column) {
       if (module != nullptr) {
         return module->name();
       }
-      const CaptureData& capture_data = GOrbitApp->GetCaptureData();
+      const CaptureData& capture_data = app_->GetCaptureData();
       return std::filesystem::path(capture_data.GetModulePathByAddress(frame.address))
           .filename()
           .string();
@@ -90,9 +91,9 @@ std::vector<std::string> CallStackDataView::GetContextMenu(
     const FunctionInfo* function = frame.function;
     const ModuleData* module = frame.module;
 
-    if (frame.function != nullptr && GOrbitApp->IsCaptureConnected(GOrbitApp->GetCaptureData())) {
-      enable_select |= !GOrbitApp->IsFunctionSelected(*function);
-      enable_unselect |= GOrbitApp->IsFunctionSelected(*function);
+    if (frame.function != nullptr && app_->IsCaptureConnected(app_->GetCaptureData())) {
+      enable_select |= !app_->IsFunctionSelected(*function);
+      enable_unselect |= app_->IsFunctionSelected(*function);
       enable_disassembly = true;
     } else if (module != nullptr && !module->is_loaded()) {
       enable_load = true;
@@ -119,27 +120,27 @@ void CallStackDataView::OnContextMenu(const std::string& action, int menu_index,
         modules_to_load.push_back(module);
       }
     }
-    GOrbitApp->LoadModules(modules_to_load);
+    app_->LoadModules(modules_to_load);
 
   } else if (action == kMenuActionSelect) {
     for (int i : item_indices) {
       CallStackDataViewFrame frame = GetFrameFromRow(i);
       const FunctionInfo* function = frame.function;
-      GOrbitApp->SelectFunction(*function);
+      app_->SelectFunction(*function);
     }
 
   } else if (action == kMenuActionUnselect) {
     for (int i : item_indices) {
       CallStackDataViewFrame frame = GetFrameFromRow(i);
       const FunctionInfo* function = frame.function;
-      GOrbitApp->DeselectFunction(*function);
-      GOrbitApp->DisableFrameTrack(*function);
+      app_->DeselectFunction(*function);
+      app_->DisableFrameTrack(*function);
     }
 
   } else if (action == kMenuActionDisassembly) {
-    const int32_t pid = GOrbitApp->GetCaptureData().process_id();
+    const int32_t pid = app_->GetCaptureData().process_id();
     for (int i : item_indices) {
-      GOrbitApp->Disassemble(pid, *GetFrameFromRow(i).function);
+      app_->Disassemble(pid, *GetFrameFromRow(i).function);
     }
 
   } else {
@@ -196,7 +197,7 @@ CallStackDataView::CallStackDataViewFrame CallStackDataView::GetFrameFromIndex(
   CHECK(index_in_callstack < static_cast<int>(callstack_.GetFramesCount()));
   uint64_t address = callstack_.GetFrame(index_in_callstack);
 
-  const CaptureData& capture_data = GOrbitApp->GetCaptureData();
+  const CaptureData& capture_data = app_->GetCaptureData();
   const FunctionInfo* function = capture_data.FindFunctionByAddress(address, false);
   ModuleData* module = capture_data.FindModuleByAddress(address);
 

--- a/OrbitGl/CallStackDataView.h
+++ b/OrbitGl/CallStackDataView.h
@@ -11,8 +11,6 @@
 #include "OrbitClientData/Callstack.h"
 #include "OrbitClientData/ModuleData.h"
 
-class OrbitApp;
-
 class CallStackDataView : public DataView {
  public:
   explicit CallStackDataView(OrbitApp* app);
@@ -74,9 +72,6 @@ class CallStackDataView : public DataView {
   static const std::string kMenuActionSelect;
   static const std::string kMenuActionUnselect;
   static const std::string kMenuActionDisassembly;
-
- private:
-  OrbitApp* app_ = nullptr;
 };
 
 #endif  // ORBIT_GL_CALLSTACK_DATA_VIEW_H_

--- a/OrbitGl/CallStackDataView.h
+++ b/OrbitGl/CallStackDataView.h
@@ -11,9 +11,11 @@
 #include "OrbitClientData/Callstack.h"
 #include "OrbitClientData/ModuleData.h"
 
+class OrbitApp;
+
 class CallStackDataView : public DataView {
  public:
-  CallStackDataView();
+  explicit CallStackDataView(OrbitApp* app);
 
   void SetAsMainInstance() override;
   const std::vector<Column>& GetColumns() override;
@@ -72,6 +74,9 @@ class CallStackDataView : public DataView {
   static const std::string kMenuActionSelect;
   static const std::string kMenuActionUnselect;
   static const std::string kMenuActionDisassembly;
+
+ private:
+  OrbitApp* app_ = nullptr;
 };
 
 #endif  // ORBIT_GL_CALLSTACK_DATA_VIEW_H_

--- a/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
+++ b/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
@@ -62,7 +62,7 @@ DEFINE_PROTO_FUZZER(const orbit_client_protos::CaptureDeserializerFuzzerInfo& in
   app->SetTopDownViewCallback([](std::unique_ptr<CallTreeView> /*view*/) {});
   app->SetBottomUpViewCallback([](std::unique_ptr<CallTreeView> /*view*/) {});
 
-  TimeGraph time_graph{14};
+  TimeGraph time_graph{14, app.get()};
   GCurrentTimeGraph = &time_graph;
   auto string_manager = std::make_shared<StringManager>();
   time_graph.SetStringManager(string_manager);

--- a/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
+++ b/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
@@ -73,8 +73,7 @@ DEFINE_PROTO_FUZZER(const orbit_client_protos::CaptureDeserializerFuzzerInfo& in
   std::atomic<bool> cancellation_requested = false;
 
   orbit_client_data::ModuleManager module_manager;
-  capture_deserializer::Load(input_stream, "", GOrbitApp.get(), &module_manager,
-                             &cancellation_requested);
+  capture_deserializer::Load(input_stream, "", app.get(), &module_manager, &cancellation_requested);
 
   app->GetThreadPool()->ShutdownAndWait();
 }

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -13,7 +13,7 @@
 using orbit_client_protos::TimerInfo;
 
 CaptureWindow::CaptureWindow(uint32_t font_size, OrbitApp* app)
-    : GlCanvas(font_size), font_size_(font_size), time_graph_(font_size), app_{app} {
+    : GlCanvas(font_size), font_size_(font_size), time_graph_(font_size, app), app_{app} {
   time_graph_.SetTextRenderer(&text_renderer_);
   time_graph_.SetCanvas(this);
   draw_help_ = true;

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -12,8 +12,8 @@
 
 using orbit_client_protos::TimerInfo;
 
-CaptureWindow::CaptureWindow(uint32_t font_size)
-    : GlCanvas(font_size), font_size_(font_size), time_graph_(font_size) {
+CaptureWindow::CaptureWindow(uint32_t font_size, OrbitApp* app)
+    : GlCanvas(font_size), font_size_(font_size), time_graph_(font_size), app_{app} {
   time_graph_.SetTextRenderer(&text_renderer_);
   time_graph_.SetCanvas(this);
   draw_help_ = true;
@@ -77,7 +77,7 @@ void CaptureWindow::MouseMoved(int x, int y, bool left, bool /*right*/, bool /*m
   mouse_screen_y_ = y;
 
   // Pan
-  if (left && !im_gui_active_ && !picking_manager_.IsDragging() && !GOrbitApp->IsCapturing()) {
+  if (left && !im_gui_active_ && !picking_manager_.IsDragging() && !app_->IsCapturing()) {
     float world_min;
     float world_max;
 
@@ -131,8 +131,8 @@ void CaptureWindow::LeftUp() {
   GlCanvas::LeftUp();
 
   if (!click_was_drag_ && background_clicked_) {
-    GOrbitApp->SelectTextBox(nullptr);
-    GOrbitApp->set_selected_thread_id(orbit_base::kAllProcessThreadsTid);
+    app_->SelectTextBox(nullptr);
+    app_->set_selected_thread_id(orbit_base::kAllProcessThreadsTid);
     NeedsUpdate();
   }
 }
@@ -181,8 +181,8 @@ void CaptureWindow::Pick(PickingId picking_id, int x, int y) {
 
 void CaptureWindow::SelectTextBox(const TextBox* text_box) {
   if (text_box == nullptr) return;
-  GOrbitApp->SelectTextBox(text_box);
-  GOrbitApp->set_selected_thread_id(text_box->GetTimerInfo().thread_id());
+  app_->SelectTextBox(text_box);
+  app_->set_selected_thread_id(text_box->GetTimerInfo().thread_id());
   needs_check_highlight_change_ = true;
 
   const TimerInfo& timer_info = text_box->GetTimerInfo();
@@ -215,7 +215,7 @@ void CaptureWindow::Hover(int x, int y) {
     }
   }
 
-  GOrbitApp->SendTooltipToUi(tooltip);
+  app_->SendTooltipToUi(tooltip);
 }
 
 void CaptureWindow::PreRender() {
@@ -406,15 +406,15 @@ void CaptureWindow::KeyPressed(unsigned int key_code, bool ctrl, bool shift, boo
         break;
       case 18:  // Left
         if (shift) {
-          time_graph_.JumpToNeighborBox(GOrbitApp->selected_text_box(),
+          time_graph_.JumpToNeighborBox(app_->selected_text_box(),
                                         TimeGraph::JumpDirection::kPrevious,
                                         TimeGraph::JumpScope::kSameFunction);
         } else if (alt) {
-          time_graph_.JumpToNeighborBox(GOrbitApp->selected_text_box(),
+          time_graph_.JumpToNeighborBox(app_->selected_text_box(),
                                         TimeGraph::JumpDirection::kPrevious,
                                         TimeGraph::JumpScope::kSameThreadSameFunction);
         } else {
-          time_graph_.JumpToNeighborBox(GOrbitApp->selected_text_box(),
+          time_graph_.JumpToNeighborBox(app_->selected_text_box(),
                                         TimeGraph::JumpDirection::kPrevious,
                                         TimeGraph::JumpScope::kSameDepth);
           needs_check_highlight_change_ = true;
@@ -422,28 +422,23 @@ void CaptureWindow::KeyPressed(unsigned int key_code, bool ctrl, bool shift, boo
         break;
       case 20:  // Right
         if (shift) {
-          time_graph_.JumpToNeighborBox(GOrbitApp->selected_text_box(),
-                                        TimeGraph::JumpDirection::kNext,
+          time_graph_.JumpToNeighborBox(app_->selected_text_box(), TimeGraph::JumpDirection::kNext,
                                         TimeGraph::JumpScope::kSameFunction);
         } else if (alt) {
-          time_graph_.JumpToNeighborBox(GOrbitApp->selected_text_box(),
-                                        TimeGraph::JumpDirection::kNext,
+          time_graph_.JumpToNeighborBox(app_->selected_text_box(), TimeGraph::JumpDirection::kNext,
                                         TimeGraph::JumpScope::kSameThreadSameFunction);
         } else {
-          time_graph_.JumpToNeighborBox(GOrbitApp->selected_text_box(),
-                                        TimeGraph::JumpDirection::kNext,
+          time_graph_.JumpToNeighborBox(app_->selected_text_box(), TimeGraph::JumpDirection::kNext,
                                         TimeGraph::JumpScope::kSameDepth);
           needs_check_highlight_change_ = true;
         }
         break;
       case 19:  // Up
-        time_graph_.JumpToNeighborBox(GOrbitApp->selected_text_box(),
-                                      TimeGraph::JumpDirection::kTop,
+        time_graph_.JumpToNeighborBox(app_->selected_text_box(), TimeGraph::JumpDirection::kTop,
                                       TimeGraph::JumpScope::kSameThread);
         break;
       case 21:  // Down
-        time_graph_.JumpToNeighborBox(GOrbitApp->selected_text_box(),
-                                      TimeGraph::JumpDirection::kDown,
+        time_graph_.JumpToNeighborBox(app_->selected_text_box(), TimeGraph::JumpDirection::kDown,
                                       TimeGraph::JumpScope::kSameThread);
         break;
     }
@@ -461,7 +456,7 @@ void CaptureWindow::OnCaptureStarted() {
   NeedsRedraw();
 }
 
-bool CaptureWindow::ShouldAutoZoom() const { return GOrbitApp->IsCapturing(); }
+bool CaptureWindow::ShouldAutoZoom() const { return app_->IsCapturing(); }
 
 void CaptureWindow::Draw() {
   ORBIT_SCOPE("CaptureWindow::Draw");
@@ -592,7 +587,7 @@ void CaptureWindow::UpdateHorizontalSliderFromWorld() {
   double stop = time_graph_.GetMaxTimeUs();
   double width = stop - start;
   double max_start = time_span - width;
-  double ratio = GOrbitApp->IsCapturing() ? 1 : (max_start != 0 ? start / max_start : 0);
+  double ratio = app_->IsCapturing() ? 1 : (max_start != 0 ? start / max_start : 0);
   int slider_width = static_cast<int>(time_graph_.GetLayout().GetSliderWidth());
   slider_->SetPixelHeight(slider_width);
   slider_->SetNormalizedPosition(static_cast<float>(ratio));
@@ -619,7 +614,7 @@ void CaptureWindow::UpdateWorldTopLeftY(float val) {
 }
 
 void CaptureWindow::ToggleRecording() {
-  GOrbitApp->ToggleCapture();
+  app_->ToggleCapture();
   draw_help_ = false;
 #ifdef __linux__
   ZoomAll();

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -9,9 +9,11 @@
 #include "GlSlider.h"
 #include "TextBox.h"
 
+class OrbitApp;
+
 class CaptureWindow : public GlCanvas {
  public:
-  explicit CaptureWindow(uint32_t font_size);
+  explicit CaptureWindow(uint32_t font_size, OrbitApp* app);
   ~CaptureWindow() override;
 
   void Initialize() override;
@@ -80,4 +82,7 @@ class CaptureWindow : public GlCanvas {
 
   bool click_was_drag_ = false;
   bool background_clicked_ = false;
+
+ private:
+  OrbitApp* app_ = nullptr;
 };

--- a/OrbitGl/DataManagerUpdateModuleInfosFuzzer.cpp
+++ b/OrbitGl/DataManagerUpdateModuleInfosFuzzer.cpp
@@ -50,6 +50,6 @@ DEFINE_PROTO_FUZZER(const GetModuleListResponse& module_list) {
   CHECK(process != nullptr);
   process->UpdateModuleInfos(modules);
 
-  ModulesDataView modules_data_view{};
+  ModulesDataView modules_data_view{nullptr};
   modules_data_view.UpdateModules(process);
 }

--- a/OrbitGl/DataView.cpp
+++ b/OrbitGl/DataView.cpp
@@ -67,7 +67,7 @@ std::vector<std::string> DataView::GetContextMenu(int /*clicked_index*/,
 void DataView::OnContextMenu(const std::string& action, int /*menu_index*/,
                              const std::vector<int>& item_indices) {
   if (action == kMenuActionExportToCsv) {
-    std::string save_file = GOrbitApp->GetSaveFile(".csv");
+    std::string save_file = app_->GetSaveFile(".csv");
     if (!save_file.empty()) {
       ExportCSV(save_file);
     }
@@ -119,5 +119,5 @@ void DataView::CopySelection(const std::vector<int>& selection) {
     }
   }
 
-  GOrbitApp->SetClipboard(clipboard);
+  app_->SetClipboard(clipboard);
 }

--- a/OrbitGl/DataView.h
+++ b/OrbitGl/DataView.h
@@ -15,6 +15,8 @@
 
 #include "DataViewTypes.h"
 
+class OrbitApp;
+
 class DataView {
  public:
   enum class SortingOrder {
@@ -31,7 +33,8 @@ class DataView {
     SortingOrder initial_order;
   };
 
-  explicit DataView(DataViewType type) : update_period_ms_(-1), selected_index_(-1), type_(type) {}
+  explicit DataView(DataViewType type, OrbitApp* app)
+      : update_period_ms_(-1), selected_index_(-1), type_(type), app_{app} {}
 
   virtual ~DataView() = default;
 
@@ -95,4 +98,6 @@ class DataView {
 
   static const std::string kMenuActionCopySelection;
   static const std::string kMenuActionExportToCsv;
+
+  OrbitApp* app_ = nullptr;
 };

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -11,7 +11,7 @@
 
 using orbit_client_protos::CallstackEvent;
 
-EventTrack::EventTrack(TimeGraph* a_TimeGraph) : Track(a_TimeGraph) {
+EventTrack::EventTrack(TimeGraph* a_TimeGraph, OrbitApp* app) : Track(a_TimeGraph), app_{app} {
   mouse_pos_[0] = mouse_pos_[1] = Vec2(0, 0);
   picked_ = false;
   color_ = Color(0, 255, 0, 255);
@@ -135,7 +135,7 @@ void EventTrack::SetPos(float a_X, float a_Y) { pos_ = Vec2(a_X, a_Y); }
 void EventTrack::SetSize(float a_SizeX, float a_SizeY) { size_ = Vec2(a_SizeX, a_SizeY); }
 
 void EventTrack::OnPick(int x, int y) {
-  GOrbitApp->set_selected_thread_id(thread_id_);
+  app_->set_selected_thread_id(thread_id_);
   Vec2& mouse_pos = mouse_pos_[0];
   canvas_->ScreenToWorld(x, y, mouse_pos[0], mouse_pos[1]);
   mouse_pos_[1] = mouse_pos_[0];

--- a/OrbitGl/EventTrack.h
+++ b/OrbitGl/EventTrack.h
@@ -9,11 +9,12 @@
 
 class CallStack;
 class GlCanvas;
+class OrbitApp;
 class TimeGraph;
 
 class EventTrack : public Track {
  public:
-  explicit EventTrack(TimeGraph* a_TimeGraph);
+  explicit EventTrack(TimeGraph* a_TimeGraph, OrbitApp* app);
   Type GetType() const override { return kEventTrack; }
 
   std::string GetTooltip() const override;
@@ -44,4 +45,7 @@ class EventTrack : public Track {
   [[nodiscard]] std::string FormatCallstackForTooltip(const CallStack& callstack,
                                                       int max_line_length = 80, int max_lines = 20,
                                                       int bottom_n_lines = 5) const;
+
+ private:
+  OrbitApp* app_ = nullptr;
 };

--- a/OrbitGl/FrameTrack.cpp
+++ b/OrbitGl/FrameTrack.cpp
@@ -54,8 +54,8 @@ float FrameTrack::GetAverageBoxHeight() const {
   }
 }
 
-FrameTrack::FrameTrack(TimeGraph* time_graph, const FunctionInfo& function)
-    : TimerTrack(time_graph), function_(function) {
+FrameTrack::FrameTrack(TimeGraph* time_graph, const FunctionInfo& function, OrbitApp* app)
+    : TimerTrack(time_graph, app), function_(function) {
   // TODO(b/169554463): Support manual instrumentation.
   std::string function_name = function_utils::GetDisplayName(function_);
   std::string name = absl::StrFormat("Frame track based on %s", function_name);

--- a/OrbitGl/FrameTrack.h
+++ b/OrbitGl/FrameTrack.h
@@ -7,9 +7,12 @@
 
 #include "TimerTrack.h"
 
+class OrbitApp;
+
 class FrameTrack : public TimerTrack {
  public:
-  explicit FrameTrack(TimeGraph* time_graph, const orbit_client_protos::FunctionInfo& function);
+  explicit FrameTrack(TimeGraph* time_graph, const orbit_client_protos::FunctionInfo& function,
+                      OrbitApp* app);
   [[nodiscard]] Type GetType() const override { return kFrameTrack; }
   [[nodiscard]] bool IsCollapsable() const override { return GetMaximumScaleFactor() > 0.f; }
 

--- a/OrbitGl/FunctionsDataView.cpp
+++ b/OrbitGl/FunctionsDataView.cpp
@@ -16,8 +16,7 @@
 
 using orbit_client_protos::FunctionInfo;
 
-FunctionsDataView::FunctionsDataView(OrbitApp* app)
-    : DataView(DataViewType::kFunctions), app_{app} {}
+FunctionsDataView::FunctionsDataView(OrbitApp* app) : DataView(DataViewType::kFunctions, app) {}
 
 const std::string FunctionsDataView::kUnselectedFunctionString = "";
 const std::string FunctionsDataView::kSelectedFunctionString = "✓";

--- a/OrbitGl/FunctionsDataView.h
+++ b/OrbitGl/FunctionsDataView.h
@@ -64,8 +64,6 @@ class FunctionsDataView : public DataView {
   static bool ShouldShowFrameTrackIcon(OrbitApp* app,
                                        const orbit_client_protos::FunctionInfo& function);
   std::vector<const orbit_client_protos::FunctionInfo*> functions_;
-
-  OrbitApp* app_ = nullptr;
 };
 
 #endif  // ORBIT_GL_FUNCTIONS_DATA_VIEW_H_

--- a/OrbitGl/FunctionsDataView.h
+++ b/OrbitGl/FunctionsDataView.h
@@ -8,14 +8,17 @@
 #include "DataView.h"
 #include "capture_data.pb.h"
 
+class OrbitApp;
+
 class FunctionsDataView : public DataView {
  public:
-  FunctionsDataView();
+  explicit FunctionsDataView(OrbitApp* app);
 
   static const std::string kUnselectedFunctionString;
   static const std::string kSelectedFunctionString;
   static const std::string kFrameTrackString;
-  static std::string BuildSelectedColumnsString(const orbit_client_protos::FunctionInfo& function);
+  static std::string BuildSelectedColumnsString(OrbitApp* app,
+                                                const orbit_client_protos::FunctionInfo& function);
 
   const std::vector<Column>& GetColumns() override;
   int GetDefaultSortingColumn() override { return kColumnAddress; }
@@ -56,9 +59,13 @@ class FunctionsDataView : public DataView {
   static const std::string kMenuActionDisassembly;
 
  private:
-  static bool ShouldShowSelectedFunctionIcon(const orbit_client_protos::FunctionInfo& function);
-  static bool ShouldShowFrameTrackIcon(const orbit_client_protos::FunctionInfo& function);
+  static bool ShouldShowSelectedFunctionIcon(OrbitApp* app,
+                                             const orbit_client_protos::FunctionInfo& function);
+  static bool ShouldShowFrameTrackIcon(OrbitApp* app,
+                                       const orbit_client_protos::FunctionInfo& function);
   std::vector<const orbit_client_protos::FunctionInfo*> functions_;
+
+  OrbitApp* app_ = nullptr;
 };
 
 #endif  // ORBIT_GL_FUNCTIONS_DATA_VIEW_H_

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -99,12 +99,12 @@ GlCanvas::~GlCanvas() {
 std::unique_ptr<GlCanvas> GlCanvas::Create(CanvasType canvas_type, uint32_t font_size) {
   switch (canvas_type) {
     case CanvasType::kCaptureWindow: {
-      auto main_capture_window = std::make_unique<CaptureWindow>(font_size);
+      auto main_capture_window = std::make_unique<CaptureWindow>(font_size, GOrbitApp.get());
       GOrbitApp->SetCaptureWindow(main_capture_window.get());
       return main_capture_window;
     }
     case CanvasType::kIntrospectionWindow: {
-      auto introspection_window = std::make_unique<IntrospectionWindow>(font_size);
+      auto introspection_window = std::make_unique<IntrospectionWindow>(font_size, GOrbitApp.get());
       GOrbitApp->SetIntrospectionWindow(introspection_window.get());
       return introspection_window;
     }

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -96,16 +96,17 @@ GlCanvas::~GlCanvas() {
   }
 }
 
-std::unique_ptr<GlCanvas> GlCanvas::Create(CanvasType canvas_type, uint32_t font_size) {
+std::unique_ptr<GlCanvas> GlCanvas::Create(CanvasType canvas_type, uint32_t font_size,
+                                           OrbitApp* app) {
   switch (canvas_type) {
     case CanvasType::kCaptureWindow: {
-      auto main_capture_window = std::make_unique<CaptureWindow>(font_size, GOrbitApp.get());
-      GOrbitApp->SetCaptureWindow(main_capture_window.get());
+      auto main_capture_window = std::make_unique<CaptureWindow>(font_size, app);
+      app->SetCaptureWindow(main_capture_window.get());
       return main_capture_window;
     }
     case CanvasType::kIntrospectionWindow: {
-      auto introspection_window = std::make_unique<IntrospectionWindow>(font_size, GOrbitApp.get());
-      GOrbitApp->SetIntrospectionWindow(introspection_window.get());
+      auto introspection_window = std::make_unique<IntrospectionWindow>(font_size, app);
+      app->SetIntrospectionWindow(introspection_window.get());
       return introspection_window;
     }
     case CanvasType::kDebug:

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -12,13 +12,16 @@
 #include "TimeGraph.h"
 #include "Timer.h"
 
+class OrbitApp;
+
 class GlCanvas {
  public:
   explicit GlCanvas(uint32_t font_size);
   virtual ~GlCanvas();
 
   enum class CanvasType { kCaptureWindow, kIntrospectionWindow, kDebug };
-  static std::unique_ptr<GlCanvas> Create(CanvasType canvas_type, uint32_t font_size);
+  static std::unique_ptr<GlCanvas> Create(CanvasType canvas_type, uint32_t font_size,
+                                          OrbitApp* app);
 
   virtual void Initialize();
   virtual void Resize(int width, int height);

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -40,7 +40,7 @@ std::string MapGpuTimelineToTrackLabel(std::string_view timeline) {
 
 GpuTrack::GpuTrack(TimeGraph* time_graph, std::shared_ptr<StringManager> string_manager,
                    uint64_t timeline_hash, OrbitApp* app)
-    : TimerTrack(time_graph), app_{app} {
+    : TimerTrack(time_graph, app) {
   text_renderer_ = time_graph->GetTextRenderer();
   timeline_hash_ = timeline_hash;
   string_manager_ = string_manager;

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -39,8 +39,8 @@ std::string MapGpuTimelineToTrackLabel(std::string_view timeline) {
 }  // namespace orbit_gl
 
 GpuTrack::GpuTrack(TimeGraph* time_graph, std::shared_ptr<StringManager> string_manager,
-                   uint64_t timeline_hash)
-    : TimerTrack(time_graph) {
+                   uint64_t timeline_hash, OrbitApp* app)
+    : TimerTrack(time_graph), app_{app} {
   text_renderer_ = time_graph->GetTextRenderer();
   timeline_hash_ = timeline_hash;
   string_manager_ = string_manager;
@@ -51,11 +51,11 @@ GpuTrack::GpuTrack(TimeGraph* time_graph, std::shared_ptr<StringManager> string_
 }
 
 bool GpuTrack::IsTimerActive(const TimerInfo& timer_info) const {
-  bool is_same_tid_as_selected = timer_info.thread_id() == GOrbitApp->selected_thread_id();
+  bool is_same_tid_as_selected = timer_info.thread_id() == app_->selected_thread_id();
   // We do not properly track the PID for GPU jobs and we still want to show
   // all jobs as active when no thread is selected, so this logic is a bit
   // different than SchedulerTrack::IsTimerActive.
-  bool no_thread_selected = GOrbitApp->selected_thread_id() == orbit_base::kAllProcessThreadsTid;
+  bool no_thread_selected = app_->selected_thread_id() == orbit_base::kAllProcessThreadsTid;
 
   return is_same_tid_as_selected || no_thread_selected;
 }

--- a/OrbitGl/GpuTrack.h
+++ b/OrbitGl/GpuTrack.h
@@ -55,8 +55,6 @@ class GpuTrack : public TimerTrack {
       const orbit_client_protos::TimerInfo& timer_info) const;
   [[nodiscard]] std::string GetHwExecutionTooltip(
       const orbit_client_protos::TimerInfo& timer_info) const;
-
-  OrbitApp* app_ = nullptr;
 };
 
 #endif  // ORBIT_GL_GPU_TRACK_H_

--- a/OrbitGl/GpuTrack.h
+++ b/OrbitGl/GpuTrack.h
@@ -12,6 +12,7 @@
 #include "TimerTrack.h"
 #include "capture_data.pb.h"
 
+class OrbitApp;
 class TextRenderer;
 
 namespace orbit_gl {
@@ -24,8 +25,8 @@ std::string MapGpuTimelineToTrackLabel(std::string_view timeline);
 
 class GpuTrack : public TimerTrack {
  public:
-  GpuTrack(TimeGraph* time_graph, std::shared_ptr<StringManager> string_manager,
-           uint64_t timeline_hash);
+  explicit GpuTrack(TimeGraph* time_graph, std::shared_ptr<StringManager> string_manager,
+                    uint64_t timeline_hash, OrbitApp* app);
   ~GpuTrack() override = default;
   [[nodiscard]] std::string GetTooltip() const override;
   [[nodiscard]] Type GetType() const override { return kGpuTrack; }
@@ -54,6 +55,8 @@ class GpuTrack : public TimerTrack {
       const orbit_client_protos::TimerInfo& timer_info) const;
   [[nodiscard]] std::string GetHwExecutionTooltip(
       const orbit_client_protos::TimerInfo& timer_info) const;
+
+  OrbitApp* app_ = nullptr;
 };
 
 #endif  // ORBIT_GL_GPU_TRACK_H_

--- a/OrbitGl/IntrospectionWindow.cpp
+++ b/OrbitGl/IntrospectionWindow.cpp
@@ -8,7 +8,8 @@
 
 using orbit_client_protos::TimerInfo;
 
-IntrospectionWindow::IntrospectionWindow(uint32_t font_size) : CaptureWindow(font_size) {
+IntrospectionWindow::IntrospectionWindow(uint32_t font_size, OrbitApp* app)
+    : CaptureWindow(font_size, app) {
   time_graph_.SetStringManager(std::make_shared<StringManager>());
 }
 

--- a/OrbitGl/IntrospectionWindow.h
+++ b/OrbitGl/IntrospectionWindow.h
@@ -9,9 +9,11 @@
 #include "CaptureWindow.h"
 #include "OrbitBase/Tracing.h"
 
+class OrbitApp;
+
 class IntrospectionWindow : public CaptureWindow {
  public:
-  explicit IntrospectionWindow(uint32_t font_size);
+  explicit IntrospectionWindow(uint32_t font_size, OrbitApp* app);
   ~IntrospectionWindow() override;
   void ToggleRecording() override;
 

--- a/OrbitGl/LiveFunctionsController.cpp
+++ b/OrbitGl/LiveFunctionsController.cpp
@@ -103,7 +103,7 @@ bool LiveFunctionsController::OnAllNextButton() {
   absl::flat_hash_map<uint64_t, const TextBox*> next_boxes;
   uint64_t id_with_min_timestamp = 0;
   uint64_t min_timestamp = std::numeric_limits<uint64_t>::max();
-  const CaptureData& capture_data = GOrbitApp->GetCaptureData();
+  const CaptureData& capture_data = app_->GetCaptureData();
   for (auto it : function_iterators_) {
     const FunctionInfo* function = it.second;
     auto function_address = capture_data.GetAbsoluteAddress(*function);
@@ -131,7 +131,7 @@ bool LiveFunctionsController::OnAllPreviousButton() {
   absl::flat_hash_map<uint64_t, const TextBox*> next_boxes;
   uint64_t id_with_min_timestamp = 0;
   uint64_t min_timestamp = std::numeric_limits<uint64_t>::max();
-  const CaptureData& capture_data = GOrbitApp->GetCaptureData();
+  const CaptureData& capture_data = app_->GetCaptureData();
   for (auto it : function_iterators_) {
     const FunctionInfo* function = it.second;
     auto function_address = capture_data.GetAbsoluteAddress(*function);
@@ -156,7 +156,7 @@ bool LiveFunctionsController::OnAllPreviousButton() {
 }
 
 void LiveFunctionsController::OnNextButton(uint64_t id) {
-  const CaptureData& capture_data = GOrbitApp->GetCaptureData();
+  const CaptureData& capture_data = app_->GetCaptureData();
   auto function_address = capture_data.GetAbsoluteAddress(*(function_iterators_[id]));
   const TextBox* text_box = GCurrentTimeGraph->FindNextFunctionCall(
       function_address, current_textboxes_[id]->GetTimerInfo().end());
@@ -168,7 +168,7 @@ void LiveFunctionsController::OnNextButton(uint64_t id) {
   Move();
 }
 void LiveFunctionsController::OnPreviousButton(uint64_t id) {
-  const CaptureData& capture_data = GOrbitApp->GetCaptureData();
+  const CaptureData& capture_data = app_->GetCaptureData();
   auto function_address = capture_data.GetAbsoluteAddress(*(function_iterators_[id]));
   const TextBox* text_box = GCurrentTimeGraph->FindPreviousFunctionCall(
       function_address, current_textboxes_[id]->GetTimerInfo().end());
@@ -198,9 +198,9 @@ void LiveFunctionsController::AddIterator(FunctionInfo* function) {
   uint64_t id = next_iterator_id_;
   ++next_iterator_id_;
 
-  const CaptureData& capture_data = GOrbitApp->GetCaptureData();
+  const CaptureData& capture_data = app_->GetCaptureData();
   auto function_address = capture_data.GetAbsoluteAddress(*function);
-  const TextBox* box = GOrbitApp->selected_text_box();
+  const TextBox* box = app_->selected_text_box();
   // If no box is currently selected or the selected box is a different
   // function, we search for the closest box to the current center of the
   // screen.

--- a/OrbitGl/LiveFunctionsController.h
+++ b/OrbitGl/LiveFunctionsController.h
@@ -13,9 +13,12 @@
 #include "absl/container/flat_hash_map.h"
 #include "capture_data.pb.h"
 
+class OrbitApp;
+
 class LiveFunctionsController {
  public:
-  LiveFunctionsController() : live_functions_data_view_(this) {}
+  explicit LiveFunctionsController(OrbitApp* app)
+      : live_functions_data_view_(this, app), app_{app} {}
 
   LiveFunctionsDataView& GetDataView() { return live_functions_data_view_; }
 
@@ -53,6 +56,8 @@ class LiveFunctionsController {
   uint64_t next_iterator_id_ = 0;
 
   uint64_t id_to_select_ = 0;
+
+  OrbitApp* app_ = nullptr;
 };
 
 #endif  // LIVE_FUNCTIONS_H_

--- a/OrbitGl/LiveFunctionsDataView.cpp
+++ b/OrbitGl/LiveFunctionsDataView.cpp
@@ -17,7 +17,7 @@ using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::FunctionStats;
 
 LiveFunctionsDataView::LiveFunctionsDataView(LiveFunctionsController* live_functions, OrbitApp* app)
-    : DataView(DataViewType::kLiveFunctions), live_functions_(live_functions), app_{app} {
+    : DataView(DataViewType::kLiveFunctions, app), live_functions_(live_functions) {
   update_period_ms_ = 300;
   OnDataChanged();
 }

--- a/OrbitGl/LiveFunctionsDataView.cpp
+++ b/OrbitGl/LiveFunctionsDataView.cpp
@@ -53,7 +53,7 @@ std::string LiveFunctionsDataView::GetValue(int row, int column) {
 
   switch (column) {
     case kColumnSelected:
-      return FunctionsDataView::BuildSelectedColumnsString(function);
+      return FunctionsDataView::BuildSelectedColumnsString(GOrbitApp.get(), function);
     case kColumnName:
       return function_utils::GetDisplayName(function);
     case kColumnCount:

--- a/OrbitGl/LiveFunctionsDataView.h
+++ b/OrbitGl/LiveFunctionsDataView.h
@@ -10,10 +10,11 @@
 #include "capture_data.pb.h"
 
 class LiveFunctionsController;
+class OrbitApp;
 
 class LiveFunctionsDataView : public DataView {
  public:
-  LiveFunctionsDataView(LiveFunctionsController* live_functions);
+  explicit LiveFunctionsDataView(LiveFunctionsController* live_functions, OrbitApp* app);
 
   const std::vector<Column>& GetColumns() override;
   int GetDefaultSortingColumn() override { return kColumnCount; }
@@ -62,6 +63,9 @@ class LiveFunctionsDataView : public DataView {
   static const std::string kMenuActionIterate;
   static const std::string kMenuActionEnableFrameTrack;
   static const std::string kMenuActionDisableFrameTrack;
+
+ private:
+  OrbitApp* app_ = nullptr;
 };
 
 #endif  // ORBIT_GL_LIVE_FUNCTIONS_DATA_VIEW_H_

--- a/OrbitGl/LiveFunctionsDataView.h
+++ b/OrbitGl/LiveFunctionsDataView.h
@@ -63,9 +63,6 @@ class LiveFunctionsDataView : public DataView {
   static const std::string kMenuActionIterate;
   static const std::string kMenuActionEnableFrameTrack;
   static const std::string kMenuActionDisableFrameTrack;
-
- private:
-  OrbitApp* app_ = nullptr;
 };
 
 #endif  // ORBIT_GL_LIVE_FUNCTIONS_DATA_VIEW_H_

--- a/OrbitGl/ModulesDataView.cpp
+++ b/OrbitGl/ModulesDataView.cpp
@@ -10,7 +10,7 @@
 
 ABSL_DECLARE_FLAG(bool, enable_frame_pointer_validator);
 
-ModulesDataView::ModulesDataView() : DataView(DataViewType::kModules) {}
+ModulesDataView::ModulesDataView(OrbitApp* app) : DataView(DataViewType::kModules), app_{app} {}
 
 const std::vector<DataView::Column>& ModulesDataView::GetColumns() {
   static const std::vector<Column> columns = [] {
@@ -125,7 +125,7 @@ void ModulesDataView::OnContextMenu(const std::string& action, int menu_index,
         modules_to_load.push_back(module_data);
       }
     }
-    GOrbitApp->LoadModules(modules_to_load);
+    app_->LoadModules(modules_to_load);
 
   } else if (action == kMenuActionVerifyFramePointers) {
     std::vector<const ModuleData*> modules_to_validate;
@@ -136,7 +136,7 @@ void ModulesDataView::OnContextMenu(const std::string& action, int menu_index,
     }
 
     if (!modules_to_validate.empty()) {
-      GOrbitApp->OnValidateFramePointers(modules_to_validate);
+      app_->OnValidateFramePointers(modules_to_validate);
     }
   } else {
     DataView::OnContextMenu(action, menu_index, item_indices);
@@ -174,7 +174,7 @@ void ModulesDataView::UpdateModules(const ProcessData* process) {
   modules_.clear();
   module_memory_.clear();
   for (const auto& [module_path, memory_space] : process->GetMemoryMap()) {
-    ModuleData* module = GOrbitApp->GetMutableModuleByPath(module_path);
+    ModuleData* module = app_->GetMutableModuleByPath(module_path);
     modules_.push_back(module);
     module_memory_[module] = &memory_space;
   }
@@ -188,12 +188,12 @@ void ModulesDataView::UpdateModules(const ProcessData* process) {
 }
 
 void ModulesDataView::OnRefreshButtonClicked() {
-  const ProcessData* process = GOrbitApp->GetSelectedProcess();
+  const ProcessData* process = app_->GetSelectedProcess();
   if (process == nullptr) {
     LOG("Unable to refresh module list, no process selected");
     return;
   }
-  GOrbitApp->UpdateProcessAndModuleList(process->pid());
+  app_->UpdateProcessAndModuleList(process->pid());
 }
 
 bool ModulesDataView::GetDisplayColor(int row, int /*column*/, unsigned char& red,

--- a/OrbitGl/ModulesDataView.cpp
+++ b/OrbitGl/ModulesDataView.cpp
@@ -10,7 +10,7 @@
 
 ABSL_DECLARE_FLAG(bool, enable_frame_pointer_validator);
 
-ModulesDataView::ModulesDataView(OrbitApp* app) : DataView(DataViewType::kModules), app_{app} {}
+ModulesDataView::ModulesDataView(OrbitApp* app) : DataView(DataViewType::kModules, app) {}
 
 const std::vector<DataView::Column>& ModulesDataView::GetColumns() {
   static const std::vector<Column> columns = [] {

--- a/OrbitGl/ModulesDataView.h
+++ b/OrbitGl/ModulesDataView.h
@@ -9,9 +9,11 @@
 #include "OrbitClientData/ModuleData.h"
 #include "OrbitClientData/ProcessData.h"
 
+class OrbitApp;
+
 class ModulesDataView : public DataView {
  public:
-  ModulesDataView();
+  explicit ModulesDataView(OrbitApp* app);
 
   const std::vector<Column>& GetColumns() override;
   int GetDefaultSortingColumn() override { return kColumnFileSize; }
@@ -50,6 +52,8 @@ class ModulesDataView : public DataView {
 
   static const std::string kMenuActionLoadSymbols;
   static const std::string kMenuActionVerifyFramePointers;
+
+  OrbitApp* app_ = nullptr;
 };
 
 #endif  // ORBIT_GL_MODULES_DATA_VIEW_H_

--- a/OrbitGl/ModulesDataView.h
+++ b/OrbitGl/ModulesDataView.h
@@ -52,8 +52,6 @@ class ModulesDataView : public DataView {
 
   static const std::string kMenuActionLoadSymbols;
   static const std::string kMenuActionVerifyFramePointers;
-
-  OrbitApp* app_ = nullptr;
 };
 
 #endif  // ORBIT_GL_MODULES_DATA_VIEW_H_

--- a/OrbitGl/PresetsDataView.cpp
+++ b/OrbitGl/PresetsDataView.cpp
@@ -36,7 +36,7 @@ std::string GetLoadStateString(OrbitApp* app,
 }
 }  // namespace
 
-PresetsDataView::PresetsDataView(OrbitApp* app) : DataView(DataViewType::kPresets), app_{app} {}
+PresetsDataView::PresetsDataView(OrbitApp* app) : DataView(DataViewType::kPresets, app) {}
 
 std::string PresetsDataView::GetModulesList(const std::vector<ModuleView>& modules) const {
   return absl::StrJoin(modules, "\n", [](std::string* out, const ModuleView& module) {

--- a/OrbitGl/PresetsDataView.h
+++ b/OrbitGl/PresetsDataView.h
@@ -62,9 +62,6 @@ class PresetsDataView : public DataView {
 
   static const std::string kMenuActionLoad;
   static const std::string kMenuActionDelete;
-
- private:
-  OrbitApp* app_ = nullptr;
 };
 
 #endif  // ORBIT_GL_PRESET_DATA_VIEW_H_

--- a/OrbitGl/PresetsDataView.h
+++ b/OrbitGl/PresetsDataView.h
@@ -10,9 +10,11 @@
 #include "DataView.h"
 #include "preset.pb.h"
 
+class OrbitApp;
+
 class PresetsDataView : public DataView {
  public:
-  PresetsDataView();
+  explicit PresetsDataView(OrbitApp* app);
 
   const std::vector<Column>& GetColumns() override;
   int GetDefaultSortingColumn() override { return kColumnSessionName; }
@@ -60,6 +62,9 @@ class PresetsDataView : public DataView {
 
   static const std::string kMenuActionLoad;
   static const std::string kMenuActionDelete;
+
+ private:
+  OrbitApp* app_ = nullptr;
 };
 
 #endif  // ORBIT_GL_PRESET_DATA_VIEW_H_

--- a/OrbitGl/ProcessesDataView.cpp
+++ b/OrbitGl/ProcessesDataView.cpp
@@ -13,8 +13,8 @@
 
 using orbit_grpc_protos::ProcessInfo;
 
-ProcessesDataView::ProcessesDataView()
-    : DataView(DataViewType::kProcesses), selected_process_id_(-1) {}
+ProcessesDataView::ProcessesDataView(OrbitApp* app)
+    : DataView(DataViewType::kProcesses, app), selected_process_id_(-1) {}
 
 const std::vector<DataView::Column>& ProcessesDataView::GetColumns() {
   static const std::vector<Column> columns = [] {

--- a/OrbitGl/ProcessesDataView.h
+++ b/OrbitGl/ProcessesDataView.h
@@ -10,7 +10,7 @@
 
 class ProcessesDataView final : public DataView {
  public:
-  ProcessesDataView();
+  explicit ProcessesDataView(OrbitApp* app);
 
   void SetSelectionListener(const std::function<void(int32_t)>& selection_listener);
   const std::vector<Column>& GetColumns() override;

--- a/OrbitGl/SamplingReport.cpp
+++ b/OrbitGl/SamplingReport.cpp
@@ -4,6 +4,7 @@
 
 #include "SamplingReport.h"
 
+#include "App.h"
 #include "CallStackDataView.h"
 #include "absl/strings/str_format.h"
 
@@ -34,7 +35,7 @@ void SamplingReport::FillReport() {
   const auto& sample_data = post_processed_sampling_data_.GetThreadSampleData();
 
   for (const ThreadSampleData& thread_sample_data : sample_data) {
-    SamplingReportDataView thread_report;
+    SamplingReportDataView thread_report{GOrbitApp.get()};
     thread_report.SetSampledFunctions(thread_sample_data.sampled_function);
     thread_report.SetThreadID(thread_sample_data.thread_id);
     thread_report.SetSamplingReport(this);

--- a/OrbitGl/SamplingReport.cpp
+++ b/OrbitGl/SamplingReport.cpp
@@ -9,12 +9,13 @@
 #include "absl/strings/str_format.h"
 
 SamplingReport::SamplingReport(
-    PostProcessedSamplingData post_processed_sampling_data,
+    OrbitApp* app, PostProcessedSamplingData post_processed_sampling_data,
     absl::flat_hash_map<CallstackID, std::shared_ptr<CallStack>> unique_callstacks,
     bool has_summary)
     : post_processed_sampling_data_{std::move(post_processed_sampling_data)},
       unique_callstacks_{std::move(unique_callstacks)},
-      has_summary_{has_summary} {
+      has_summary_{has_summary},
+      app_{app} {
   selected_address_ = kInvalidFunctionAddress;
   selected_thread_id_ = 0;
   callstack_data_view_ = nullptr;
@@ -35,7 +36,7 @@ void SamplingReport::FillReport() {
   const auto& sample_data = post_processed_sampling_data_.GetThreadSampleData();
 
   for (const ThreadSampleData& thread_sample_data : sample_data) {
-    SamplingReportDataView thread_report{GOrbitApp.get()};
+    SamplingReportDataView thread_report{app_};
     thread_report.SetSampledFunctions(thread_sample_data.sampled_function);
     thread_report.SetThreadID(thread_sample_data.thread_id);
     thread_report.SetSamplingReport(this);

--- a/OrbitGl/SamplingReport.h
+++ b/OrbitGl/SamplingReport.h
@@ -16,10 +16,12 @@
 #include "OrbitClientData/PostProcessedSamplingData.h"
 #include "SamplingReportDataView.h"
 
+class OrbitApp;
+
 class SamplingReport {
  public:
   explicit SamplingReport(
-      PostProcessedSamplingData post_processed_sampling_data,
+      OrbitApp* app, PostProcessedSamplingData post_processed_sampling_data,
       absl::flat_hash_map<CallstackID, std::shared_ptr<CallStack>> unique_callstacks,
       bool has_summary = true);
   void UpdateReport(PostProcessedSamplingData post_processed_sampling_data,
@@ -54,6 +56,7 @@ class SamplingReport {
   size_t selected_callstack_index_;
   std::function<void()> ui_refresh_func_;
   bool has_summary_;
+  OrbitApp* app_ = nullptr;
 };
 
 #endif  // ORBIT_GL_SAMPLING_REPORT_H_

--- a/OrbitGl/SamplingReportDataView.cpp
+++ b/OrbitGl/SamplingReportDataView.cpp
@@ -16,7 +16,7 @@
 using orbit_client_protos::FunctionInfo;
 
 SamplingReportDataView::SamplingReportDataView(OrbitApp* app)
-    : DataView(DataViewType::kSampling), callstack_data_view_(nullptr), app_{app} {}
+    : DataView(DataViewType::kSampling, app), callstack_data_view_(nullptr) {}
 
 const std::vector<DataView::Column>& SamplingReportDataView::GetColumns() {
   static const std::vector<Column> columns = [] {

--- a/OrbitGl/SamplingReportDataView.h
+++ b/OrbitGl/SamplingReportDataView.h
@@ -67,6 +67,4 @@ class SamplingReportDataView : public DataView {
   static const std::string kMenuActionUnselect;
   static const std::string kMenuActionLoadSymbols;
   static const std::string kMenuActionDisassembly;
-
-  OrbitApp* app_ = nullptr;
 };

--- a/OrbitGl/SamplingReportDataView.h
+++ b/OrbitGl/SamplingReportDataView.h
@@ -9,9 +9,11 @@
 #include "OrbitClientModel/SamplingDataPostProcessor.h"
 #include "absl/container/flat_hash_set.h"
 
+class OrbitApp;
+
 class SamplingReportDataView : public DataView {
  public:
-  SamplingReportDataView();
+  explicit SamplingReportDataView(OrbitApp* app);
 
   const std::vector<Column>& GetColumns() override;
   int GetDefaultSortingColumn() override { return kColumnInclusive; }
@@ -65,4 +67,6 @@ class SamplingReportDataView : public DataView {
   static const std::string kMenuActionUnselect;
   static const std::string kMenuActionLoadSymbols;
   static const std::string kMenuActionDisassembly;
+
+  OrbitApp* app_ = nullptr;
 };

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -18,8 +18,7 @@ using orbit_client_protos::TimerInfo;
 const Color kInactiveColor(100, 100, 100, 255);
 const Color kSelectionColor(0, 128, 255, 255);
 
-SchedulerTrack::SchedulerTrack(TimeGraph* time_graph, OrbitApp* app)
-    : TimerTrack(time_graph), app_{app} {
+SchedulerTrack::SchedulerTrack(TimeGraph* time_graph, OrbitApp* app) : TimerTrack(time_graph, app) {
   SetPinned(false);
 }
 

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -18,7 +18,10 @@ using orbit_client_protos::TimerInfo;
 const Color kInactiveColor(100, 100, 100, 255);
 const Color kSelectionColor(0, 128, 255, 255);
 
-SchedulerTrack::SchedulerTrack(TimeGraph* time_graph) : TimerTrack(time_graph) { SetPinned(false); }
+SchedulerTrack::SchedulerTrack(TimeGraph* time_graph, OrbitApp* app)
+    : TimerTrack(time_graph), app_{app} {
+  SetPinned(false);
+}
 
 float SchedulerTrack::GetHeight() const {
   TimeGraphLayout& layout = time_graph_->GetLayout();
@@ -28,15 +31,14 @@ float SchedulerTrack::GetHeight() const {
 }
 
 bool SchedulerTrack::IsTimerActive(const TimerInfo& timer_info) const {
-  bool is_same_tid_as_selected = timer_info.thread_id() == GOrbitApp->selected_thread_id();
+  bool is_same_tid_as_selected = timer_info.thread_id() == app_->selected_thread_id();
   const CaptureData* capture_data = time_graph_->GetCaptureData();
   CHECK(capture_data != nullptr);
   int32_t capture_process_id = capture_data->process_id();
   bool is_same_pid_as_target =
       capture_process_id == 0 || capture_process_id == timer_info.process_id();
 
-  return is_same_tid_as_selected ||
-         (GOrbitApp->selected_thread_id() == -1 && is_same_pid_as_target);
+  return is_same_tid_as_selected || (app_->selected_thread_id() == -1 && is_same_pid_as_target);
 }
 
 Color SchedulerTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected) const {

--- a/OrbitGl/SchedulerTrack.h
+++ b/OrbitGl/SchedulerTrack.h
@@ -8,9 +8,11 @@
 #include "TimerTrack.h"
 #include "capture_data.pb.h"
 
-class SchedulerTrack : public TimerTrack {
+class OrbitApp;
+
+class SchedulerTrack final : public TimerTrack {
  public:
-  explicit SchedulerTrack(TimeGraph* time_graph);
+  explicit SchedulerTrack(TimeGraph* time_graph, OrbitApp* app);
   ~SchedulerTrack() override = default;
 
   [[nodiscard]] Type GetType() const override { return kSchedulerTrack; }
@@ -27,6 +29,9 @@ class SchedulerTrack : public TimerTrack {
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
                                     bool is_selected) const override;
   [[nodiscard]] std::string GetBoxTooltip(PickingId id) const override;
+
+ private:
+  OrbitApp* app_ = nullptr;
 };
 
 #endif  // ORBIT_GL_SCHEDULER_TRACK_H_

--- a/OrbitGl/SchedulerTrack.h
+++ b/OrbitGl/SchedulerTrack.h
@@ -29,9 +29,6 @@ class SchedulerTrack final : public TimerTrack {
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
                                     bool is_selected) const override;
   [[nodiscard]] std::string GetBoxTooltip(PickingId id) const override;
-
- private:
-  OrbitApp* app_ = nullptr;
 };
 
 #endif  // ORBIT_GL_SCHEDULER_TRACK_H_

--- a/OrbitGl/ThreadStateTrack.cpp
+++ b/OrbitGl/ThreadStateTrack.cpp
@@ -9,7 +9,8 @@
 
 using orbit_client_protos::ThreadStateSliceInfo;
 
-ThreadStateTrack::ThreadStateTrack(TimeGraph* time_graph, int32_t thread_id) : Track{time_graph} {
+ThreadStateTrack::ThreadStateTrack(TimeGraph* time_graph, int32_t thread_id, OrbitApp* app)
+    : Track{time_graph}, app_{app} {
   thread_id_ = thread_id;
   picked_ = false;
 }
@@ -168,6 +169,6 @@ void ThreadStateTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
 }
 
 void ThreadStateTrack::OnPick(int /*x*/, int /*y*/) {
-  GOrbitApp->set_selected_thread_id(thread_id_);
+  app_->set_selected_thread_id(thread_id_);
   picked_ = true;
 }

--- a/OrbitGl/ThreadStateTrack.h
+++ b/OrbitGl/ThreadStateTrack.h
@@ -7,6 +7,8 @@
 
 #include "Track.h"
 
+class OrbitApp;
+
 // This is a track dedicated to displaying thread states in different colors
 // and with the corresponding tooltips.
 // It is a thin sub-track of ThreadTrack, added above the callstack track (EventTrack).
@@ -14,7 +16,7 @@
 
 class ThreadStateTrack final : public Track {
  public:
-  ThreadStateTrack(TimeGraph* time_graph, int32_t thread_id);
+  explicit ThreadStateTrack(TimeGraph* time_graph, int32_t thread_id, OrbitApp* app);
   Type GetType() const override { return kThreadStateTrack; }
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) override;
@@ -30,6 +32,8 @@ class ThreadStateTrack final : public Track {
 
  private:
   std::string GetThreadStateSliceTooltip(PickingId id) const;
+
+  OrbitApp* app_ = nullptr;
 };
 
 #endif  // ORBIT_GL_THREAD_STATE_TRACK_H_

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -21,7 +21,7 @@ ThreadTrack::ThreadTrack(TimeGraph* time_graph, int32_t thread_id, OrbitApp* app
     : TimerTrack(time_graph), app_{app} {
   thread_id_ = thread_id;
 
-  thread_state_track_ = std::make_shared<ThreadStateTrack>(time_graph, thread_id);
+  thread_state_track_ = std::make_shared<ThreadStateTrack>(time_graph, thread_id, app_);
 
   event_track_ = std::make_shared<EventTrack>(time_graph);
   event_track_->SetThreadId(thread_id);

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -18,7 +18,7 @@ using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::TimerInfo;
 
 ThreadTrack::ThreadTrack(TimeGraph* time_graph, int32_t thread_id, OrbitApp* app)
-    : TimerTrack(time_graph), app_{app} {
+    : TimerTrack(time_graph, app) {
   thread_id_ = thread_id;
 
   thread_state_track_ = std::make_shared<ThreadStateTrack>(time_graph, thread_id, app_);

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -17,7 +17,8 @@
 using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::TimerInfo;
 
-ThreadTrack::ThreadTrack(TimeGraph* time_graph, int32_t thread_id) : TimerTrack(time_graph) {
+ThreadTrack::ThreadTrack(TimeGraph* time_graph, int32_t thread_id, OrbitApp* app)
+    : TimerTrack(time_graph), app_{app} {
   thread_id_ = thread_id;
 
   thread_state_track_ = std::make_shared<ThreadStateTrack>(time_graph, thread_id);
@@ -84,12 +85,12 @@ std::string ThreadTrack::GetBoxTooltip(PickingId id) const {
 
 bool ThreadTrack::IsTimerActive(const TimerInfo& timer_info) const {
   return timer_info.type() == TimerInfo::kIntrospection ||
-         GOrbitApp->IsFunctionVisible(timer_info.function_address());
+         app_->IsFunctionVisible(timer_info.function_address());
 }
 
 bool ThreadTrack::IsTrackSelected() const {
   return thread_id_ != orbit_base::kAllProcessThreadsTid &&
-         GOrbitApp->selected_thread_id() == thread_id_;
+         app_->selected_thread_id() == thread_id_;
 }
 
 [[nodiscard]] static inline Color ToColor(uint64_t val) {
@@ -121,7 +122,7 @@ Color ThreadTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected) 
   }
 
   uint64_t address = timer_info.function_address();
-  const FunctionInfo* function_info = GOrbitApp->GetSelectedFunction(address);
+  const FunctionInfo* function_info = app_->GetSelectedFunction(address);
   CHECK(function_info || timer_info.type() == TimerInfo::kIntrospection);
   std::optional<Color> user_color =
       function_info ? GetUserColor(timer_info, *function_info) : std::nullopt;
@@ -214,7 +215,7 @@ void ThreadTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offse
 
 void ThreadTrack::OnPick(int x, int y) {
   Track::OnPick(x, y);
-  GOrbitApp->set_selected_thread_id(thread_id_);
+  app_->set_selected_thread_id(thread_id_);
 }
 
 void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode,
@@ -247,7 +248,7 @@ void ThreadTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_u
     std::string time = GetPrettyTime(absl::Microseconds(elapsed_us));
     text_box->SetElapsedTimeTextLength(time.length());
 
-    const FunctionInfo* func = GOrbitApp->GetSelectedFunction(timer_info.function_address());
+    const FunctionInfo* func = app_->GetSelectedFunction(timer_info.function_address());
     if (func) {
       std::string extra_info = GetExtraInfo(timer_info);
       std::string name;

--- a/OrbitGl/ThreadTrack.cpp
+++ b/OrbitGl/ThreadTrack.cpp
@@ -23,10 +23,10 @@ ThreadTrack::ThreadTrack(TimeGraph* time_graph, int32_t thread_id, OrbitApp* app
 
   thread_state_track_ = std::make_shared<ThreadStateTrack>(time_graph, thread_id, app_);
 
-  event_track_ = std::make_shared<EventTrack>(time_graph);
+  event_track_ = std::make_shared<EventTrack>(time_graph, app_);
   event_track_->SetThreadId(thread_id);
 
-  tracepoint_track_ = std::make_shared<TracepointTrack>(time_graph, thread_id);
+  tracepoint_track_ = std::make_shared<TracepointTrack>(time_graph, thread_id, app_);
 }
 
 const TextBox* ThreadTrack::GetLeft(const TextBox* text_box) const {

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -12,9 +12,11 @@
 #include "TimerTrack.h"
 #include "capture_data.pb.h"
 
-class ThreadTrack : public TimerTrack {
+class OrbitApp;
+
+class ThreadTrack final : public TimerTrack {
  public:
-  ThreadTrack(TimeGraph* time_graph, int32_t thread_id);
+  explicit ThreadTrack(TimeGraph* time_graph, int32_t thread_id, OrbitApp* app);
 
   [[nodiscard]] int32_t GetThreadId() const { return thread_id_; }
 
@@ -54,6 +56,9 @@ class ThreadTrack : public TimerTrack {
   std::shared_ptr<ThreadStateTrack> thread_state_track_;
   std::shared_ptr<EventTrack> event_track_;
   std::shared_ptr<TracepointTrack> tracepoint_track_;
+
+ private:
+  OrbitApp* app_ = nullptr;
 };
 
 #endif  // ORBIT_GL_THREAD_TRACK_H_

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -56,9 +56,6 @@ class ThreadTrack final : public TimerTrack {
   std::shared_ptr<ThreadStateTrack> thread_state_track_;
   std::shared_ptr<EventTrack> event_track_;
   std::shared_ptr<TracepointTrack> tracepoint_track_;
-
- private:
-  OrbitApp* app_ = nullptr;
 };
 
 #endif  // ORBIT_GL_THREAD_TRACK_H_

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -768,7 +768,7 @@ std::shared_ptr<SchedulerTrack> TimeGraph::GetOrCreateSchedulerTrack() {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
   std::shared_ptr<SchedulerTrack> track = scheduler_track_;
   if (track == nullptr) {
-    track = std::make_shared<SchedulerTrack>(this);
+    track = std::make_shared<SchedulerTrack>(this, GOrbitApp.get());
     AddTrack(track);
     scheduler_track_ = track;
     uint32_t num_cores = GetNumCores();

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -813,7 +813,7 @@ std::shared_ptr<GpuTrack> TimeGraph::GetOrCreateGpuTrack(uint64_t timeline_hash)
   std::lock_guard<std::recursive_mutex> lock(mutex_);
   std::shared_ptr<GpuTrack> track = gpu_tracks_[timeline_hash];
   if (track == nullptr) {
-    track = std::make_shared<GpuTrack>(this, string_manager_, timeline_hash);
+    track = std::make_shared<GpuTrack>(this, string_manager_, timeline_hash, GOrbitApp.get());
     std::string timeline = string_manager_->Get(timeline_hash).value_or("");
     std::string label = orbit_gl::MapGpuTimelineToTrackLabel(timeline);
     track->SetName(timeline);

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -782,7 +782,7 @@ std::shared_ptr<ThreadTrack> TimeGraph::GetOrCreateThreadTrack(int32_t tid) {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
   std::shared_ptr<ThreadTrack> track = thread_tracks_[tid];
   if (track == nullptr) {
-    track = std::make_shared<ThreadTrack>(this, tid);
+    track = std::make_shared<ThreadTrack>(this, tid, GOrbitApp.get());
     AddTrack(track);
     thread_tracks_[tid] = track;
     track->SetTrackColor(GetThreadColor(tid));

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -845,7 +845,7 @@ AsyncTrack* TimeGraph::GetOrCreateAsyncTrack(const std::string& name) {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
   std::shared_ptr<AsyncTrack> track = async_tracks_[name];
   if (track == nullptr) {
-    track = std::make_shared<AsyncTrack>(this, name);
+    track = std::make_shared<AsyncTrack>(this, name, GOrbitApp.get());
     AddTrack(track);
     async_tracks_[name] = track;
   }

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -857,7 +857,7 @@ std::shared_ptr<FrameTrack> TimeGraph::GetOrCreateFrameTrack(const FunctionInfo&
   std::lock_guard<std::recursive_mutex> lock(mutex_);
   std::shared_ptr<FrameTrack> track = frame_tracks_[function.address()];
   if (track == nullptr) {
-    track = std::make_shared<FrameTrack>(this, function);
+    track = std::make_shared<FrameTrack>(this, function, GOrbitApp.get());
     // Normally we would call AddTrack(track) here, but frame tracks are removable by users
     // and therefore cannot be simply thrown into the flat vector of tracks.
     sorting_invalidated_ = true;

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -32,9 +32,11 @@
 #include "absl/container/flat_hash_map.h"
 #include "capture_data.pb.h"
 
+class OrbitApp;
+
 class TimeGraph {
  public:
-  explicit TimeGraph(uint32_t font_size);
+  explicit TimeGraph(uint32_t font_size, OrbitApp* app);
   ~TimeGraph();
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode = PickingMode::kNone);
@@ -271,6 +273,8 @@ class TimeGraph {
   ManualInstrumentationManager* manual_instrumentation_manager_;
   std::unique_ptr<ManualInstrumentationManager::AsyncTimerInfoListener> async_timer_info_listener_;
   CaptureData* capture_data_ = nullptr;
+
+  OrbitApp* app_ = nullptr;
 };
 
 extern TimeGraph* GCurrentTimeGraph;

--- a/OrbitGl/TimerTrack.cpp
+++ b/OrbitGl/TimerTrack.cpp
@@ -20,7 +20,7 @@ using orbit_client_protos::TimerInfo;
 
 ABSL_DECLARE_FLAG(bool, show_return_values);
 
-TimerTrack::TimerTrack(TimeGraph* time_graph) : Track(time_graph) {
+TimerTrack::TimerTrack(TimeGraph* time_graph, OrbitApp* app) : Track(time_graph), app_{app} {
   text_renderer_ = time_graph->GetTextRenderer();
 }
 
@@ -66,8 +66,8 @@ void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
   bool is_collapsed = collapse_toggle_->IsCollapsed();
 
   std::vector<std::shared_ptr<TimerChain>> chains_by_depth = GetTimers();
-  const TextBox* selected_textbox = GOrbitApp->selected_text_box();
-  uint64_t highlighted_address = GOrbitApp->GetFunctionAddressToHighlight();
+  const TextBox* selected_textbox = app_->selected_text_box();
+  uint64_t highlighted_address = app_->GetFunctionAddressToHighlight();
 
   // We minimize overdraw when drawing lines for small events by discarding
   // events that would just draw over an already drawn line. When zoomed in

--- a/OrbitGl/TimerTrack.h
+++ b/OrbitGl/TimerTrack.h
@@ -18,11 +18,12 @@
 #include "absl/synchronization/mutex.h"
 #include "capture_data.pb.h"
 
+class OrbitApp;
 class TextRenderer;
 
 class TimerTrack : public Track {
  public:
-  explicit TimerTrack(TimeGraph* time_graph);
+  explicit TimerTrack(TimeGraph* time_graph, OrbitApp* app);
   ~TimerTrack() override = default;
 
   // Pickable
@@ -92,6 +93,8 @@ class TimerTrack : public Track {
   [[nodiscard]] virtual std::string GetBoxTooltip(PickingId id) const;
   float GetHeight() const override;
   float box_height_;
+
+  OrbitApp* app_ = nullptr;
 };
 
 #endif  // ORBIT_GL_TIMER_TRACK_H_

--- a/OrbitGl/TracepointTrack.cpp
+++ b/OrbitGl/TracepointTrack.cpp
@@ -7,8 +7,8 @@
 #include "App.h"
 #include "OrbitBase/ThreadConstants.h"
 
-TracepointTrack::TracepointTrack(TimeGraph* time_graph, int32_t thread_id)
-    : EventTrack(time_graph) {
+TracepointTrack::TracepointTrack(TimeGraph* time_graph, int32_t thread_id, OrbitApp* app)
+    : EventTrack(time_graph, app) {
   thread_id_ = thread_id;
 }
 

--- a/OrbitGl/TracepointTrack.h
+++ b/OrbitGl/TracepointTrack.h
@@ -9,7 +9,7 @@
 
 class TracepointTrack : public EventTrack {
  public:
-  explicit TracepointTrack(TimeGraph* time_graph, int32_t thread_id);
+  explicit TracepointTrack(TimeGraph* time_graph, int32_t thread_id, OrbitApp* app);
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
 

--- a/OrbitGl/TracepointsDataView.cpp
+++ b/OrbitGl/TracepointsDataView.cpp
@@ -12,7 +12,7 @@ static const std::string kMenuActionUnselect = "Unhook";
 }  // namespace
 
 TracepointsDataView::TracepointsDataView(OrbitApp* app)
-    : DataView(DataViewType::kTracepoints), app_{app} {}
+    : DataView(DataViewType::kTracepoints, app) {}
 
 const std::vector<DataView::Column>& TracepointsDataView::GetColumns() {
   static const std::vector<Column>& columns = [] {

--- a/OrbitGl/TracepointsDataView.cpp
+++ b/OrbitGl/TracepointsDataView.cpp
@@ -11,7 +11,8 @@ static const std::string kMenuActionSelect = "Hook";
 static const std::string kMenuActionUnselect = "Unhook";
 }  // namespace
 
-TracepointsDataView::TracepointsDataView() : DataView(DataViewType::kTracepoints) {}
+TracepointsDataView::TracepointsDataView(OrbitApp* app)
+    : DataView(DataViewType::kTracepoints), app_{app} {}
 
 const std::vector<DataView::Column>& TracepointsDataView::GetColumns() {
   static const std::vector<Column>& columns = [] {
@@ -30,7 +31,7 @@ std::string TracepointsDataView::GetValue(int row, int col) {
 
   switch (col) {
     case kColumnSelected:
-      return GOrbitApp->IsTracepointSelected(tracepoint) ? "X" : "-";
+      return app_->IsTracepointSelected(tracepoint) ? "X" : "-";
     case kColumnName:
       return tracepoint.name();
     case kColumnCategory:
@@ -98,8 +99,8 @@ std::vector<std::string> TracepointsDataView::GetContextMenu(
   bool enable_unselect = false;
   for (int index : selected_indices) {
     const TracepointInfo& tracepoint = GetTracepoint(index);
-    enable_select |= !GOrbitApp->IsTracepointSelected(tracepoint);
-    enable_unselect |= GOrbitApp->IsTracepointSelected(tracepoint);
+    enable_select |= !app_->IsTracepointSelected(tracepoint);
+    enable_unselect |= app_->IsTracepointSelected(tracepoint);
   }
 
   if (enable_select) menu.emplace_back(kMenuActionSelect);
@@ -113,11 +114,11 @@ void TracepointsDataView::OnContextMenu(const std::string& action, int menu_inde
                                         const std::vector<int>& item_indices) {
   if (action == kMenuActionSelect) {
     for (int i : item_indices) {
-      GOrbitApp->SelectTracepoint(GetTracepoint(i));
+      app_->SelectTracepoint(GetTracepoint(i));
     }
   } else if (action == kMenuActionUnselect) {
     for (int i : item_indices) {
-      GOrbitApp->DeselectTracepoint(GetTracepoint(i));
+      app_->DeselectTracepoint(GetTracepoint(i));
     }
   } else {
     DataView::OnContextMenu(action, menu_index, item_indices);

--- a/OrbitGl/TracepointsDataView.h
+++ b/OrbitGl/TracepointsDataView.h
@@ -41,8 +41,6 @@ class TracepointsDataView : public DataView {
   enum ColumnIndex { kColumnSelected, kColumnCategory, kColumnName, kNumColumns };
 
   const TracepointInfo& GetTracepoint(uint32_t row) const;
-
-  OrbitApp* app_ = nullptr;
 };
 
 #endif  // ORBIT_TRACEPOINTSDATAVIEW_H

--- a/OrbitGl/TracepointsDataView.h
+++ b/OrbitGl/TracepointsDataView.h
@@ -14,9 +14,11 @@
 
 using orbit_grpc_protos::TracepointInfo;
 
+class OrbitApp;
+
 class TracepointsDataView : public DataView {
  public:
-  TracepointsDataView();
+  explicit TracepointsDataView(OrbitApp* app);
 
   const std::vector<Column>& GetColumns() override;
   int GetDefaultSortingColumn() override { return kColumnCategory; }
@@ -39,6 +41,8 @@ class TracepointsDataView : public DataView {
   enum ColumnIndex { kColumnSelected, kColumnCategory, kColumnName, kNumColumns };
 
   const TracepointInfo& GetTracepoint(uint32_t row) const;
+
+  OrbitApp* app_ = nullptr;
 };
 
 #endif  // ORBIT_TRACEPOINTSDATAVIEW_H

--- a/OrbitQt/CallTreeWidget.cpp
+++ b/OrbitQt/CallTreeWidget.cpp
@@ -293,7 +293,7 @@ void CallTreeWidget::onCustomContextMenuRequested(const QPoint& point) {
   bool enable_select = false;
   bool enable_deselect = false;
   bool enable_disassembly = false;
-  if (GOrbitApp->IsCaptureConnected(GOrbitApp->GetCaptureData())) {
+  if (app_->IsCaptureConnected(app_->GetCaptureData())) {
     for (const FunctionInfo* function : functions) {
       enable_select |= !app_->IsFunctionSelected(*function);
       enable_deselect |= app_->IsFunctionSelected(*function);

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -126,8 +126,7 @@ static outcome::result<GrpcPort> DeployOrbitService(
 }
 
 static outcome::result<void> RunUiInstance(
-    QApplication* app, std::optional<DeploymentConfiguration> deployment_configuration,
-    Context* context) {
+    std::optional<DeploymentConfiguration> deployment_configuration, Context* context) {
   std::optional<orbit_qt::ServiceDeployManager> service_deploy_manager;
 
   OUTCOME_TRY(result, [&]() -> outcome::result<std::tuple<GrpcPort, QString>> {
@@ -170,7 +169,7 @@ static outcome::result<void> RunUiInstance(
   {  // Scoping of QT UI Resources
     constexpr uint32_t kDefaultFontSize = 14;
 
-    OrbitMainWindow w(app, service_deploy_manager_ptr, kDefaultFontSize);
+    OrbitMainWindow w(service_deploy_manager_ptr, kDefaultFontSize);
 
     // "resize" is required to make "showMaximized" work properly.
     w.resize(1280, 720);
@@ -402,7 +401,7 @@ int main(int argc, char* argv[]) {
     }
 
     while (true) {
-      const auto result = RunUiInstance(&app, deployment_configuration, &(context.value()));
+      const auto result = RunUiInstance(deployment_configuration, &(context.value()));
       if (result || result.error() == make_error_code(Error::kUserClosedStartUpWindow) ||
           !deployment_configuration) {
         // It was either a clean shutdown or the deliberately closed the

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -41,12 +41,10 @@
 #include <unistd.h>
 #endif
 
-#include "App.h"
 #include "ApplicationOptions.h"
 #include "DeploymentConfigurations.h"
 #include "Error.h"
 #include "ImGuiOrbit.h"
-#include "MainThreadExecutorImpl.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitGgp/Error.h"
 #include "OrbitSsh/Context.h"
@@ -164,12 +162,10 @@ static outcome::result<void> RunUiInstance(
 
   std::optional<std::error_code> error;
 
-  GOrbitApp = OrbitApp::Create(std::move(options), CreateMainThreadExecutor());
-
   {  // Scoping of QT UI Resources
     constexpr uint32_t kDefaultFontSize = 14;
 
-    OrbitMainWindow w(GOrbitApp.get(), service_deploy_manager_ptr, kDefaultFontSize);
+    OrbitMainWindow w(std::move(options), service_deploy_manager_ptr, kDefaultFontSize);
 
     // "resize" is required to make "showMaximized" work properly.
     w.resize(1280, 720);
@@ -197,8 +193,6 @@ static outcome::result<void> RunUiInstance(
 
     Orbit_ImGui_Shutdown();
   }
-
-  GOrbitApp.reset();
 
   if (error) {
     return outcome::failure(error.value());

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -169,7 +169,7 @@ static outcome::result<void> RunUiInstance(
   {  // Scoping of QT UI Resources
     constexpr uint32_t kDefaultFontSize = 14;
 
-    OrbitMainWindow w(service_deploy_manager_ptr, kDefaultFontSize);
+    OrbitMainWindow w(GOrbitApp.get(), service_deploy_manager_ptr, kDefaultFontSize);
 
     // "resize" is required to make "showMaximized" work properly.
     w.resize(1280, 720);

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -199,7 +199,7 @@ static outcome::result<void> RunUiInstance(
     Orbit_ImGui_Shutdown();
   }
 
-  GOrbitApp->OnExit();
+  GOrbitApp.reset();
 
   if (error) {
     return outcome::failure(error.value());

--- a/OrbitQt/orbitcodeeditor.cpp
+++ b/OrbitQt/orbitcodeeditor.cpp
@@ -61,7 +61,6 @@
 #include <QtWidgets>
 #include <fstream>
 
-#include "App.h"
 #include "Path.h"
 #include "CoreUtils.h"
 #include "absl/strings/str_format.h"
@@ -311,12 +310,10 @@ void OrbitCodeEditor::keyPressEvent(QKeyEvent* e) {
   } else if (m_Type == OrbitCodeEditor::FILE_MAPPING && e->key() == Qt::Key_S &&
              e->modifiers() == Qt::ControlModifier) {
     saveFileMap();
-    GOrbitApp->LoadFileMapping();
   } else if (e->key() == Qt::Key_M && e->modifiers() == Qt::ControlModifier) {
     if (GFileMapWidget->isVisible()) {
       GFileMapWidget->hide();
     } else {
-      GOrbitApp->LoadFileMapping();
       GFileMapEditor->loadFileMap();
       GFileMapWidget->show();
     }

--- a/OrbitQt/orbitglwidget.cpp
+++ b/OrbitQt/orbitglwidget.cpp
@@ -40,8 +40,8 @@ bool OrbitGLWidget::eventFilter(QObject* /*object*/, QEvent* event) {
 }
 
 void OrbitGLWidget::Initialize(GlCanvas::CanvasType canvas_type, OrbitMainWindow* a_MainWindow,
-                               uint32_t font_size) {
-  gl_canvas_ = GlCanvas::Create(canvas_type, font_size, GOrbitApp.get());
+                               uint32_t font_size, OrbitApp* app) {
+  gl_canvas_ = GlCanvas::Create(canvas_type, font_size, app);
 
   if (a_MainWindow) {
     a_MainWindow->RegisterGlWidget(this);

--- a/OrbitQt/orbitglwidget.cpp
+++ b/OrbitQt/orbitglwidget.cpp
@@ -10,6 +10,7 @@
 #include <QOpenGLDebugLogger>
 #include <QSignalMapper>
 
+#include "App.h"
 #include "GlCanvas.h"
 #include "OrbitBase/Logging.h"
 #include "orbitmainwindow.h"
@@ -40,7 +41,7 @@ bool OrbitGLWidget::eventFilter(QObject* /*object*/, QEvent* event) {
 
 void OrbitGLWidget::Initialize(GlCanvas::CanvasType canvas_type, OrbitMainWindow* a_MainWindow,
                                uint32_t font_size) {
-  gl_canvas_ = GlCanvas::Create(canvas_type, font_size);
+  gl_canvas_ = GlCanvas::Create(canvas_type, font_size, GOrbitApp.get());
 
   if (a_MainWindow) {
     a_MainWindow->RegisterGlWidget(this);

--- a/OrbitQt/orbitglwidget.h
+++ b/OrbitQt/orbitglwidget.h
@@ -14,6 +14,7 @@
 
 #include "GlCanvas.h"
 
+class OrbitApp;
 class QOpenGLDebugMessage;
 class QOpenGLDebugLogger;
 
@@ -23,7 +24,7 @@ class OrbitGLWidget : public QOpenGLWidget, protected QOpenGLFunctions {
  public:
   explicit OrbitGLWidget(QWidget* parent = nullptr);
   void Initialize(GlCanvas::CanvasType canvas_type, class OrbitMainWindow* a_MainWindow,
-                  uint32_t font_size);
+                  uint32_t font_size, OrbitApp* app);
   void initializeGL() override;
   void resizeGL(int w, int h) override;
   void paintGL() override;

--- a/OrbitQt/orbitlivefunctions.cpp
+++ b/OrbitQt/orbitlivefunctions.cpp
@@ -4,12 +4,13 @@
 
 #include "orbitlivefunctions.h"
 
+#include "App.h"
 #include "ui_orbitlivefunctions.h"
 
 using orbit_client_protos::FunctionInfo;
 
 OrbitLiveFunctions::OrbitLiveFunctions(QWidget* parent)
-    : QWidget(parent), ui(new Ui::OrbitLiveFunctions) {
+    : QWidget(parent), ui(new Ui::OrbitLiveFunctions), live_functions_{GOrbitApp.get()} {
   ui->setupUi(this);
 
   live_functions_.SetAddIteratorCallback(

--- a/OrbitQt/orbitlivefunctions.cpp
+++ b/OrbitQt/orbitlivefunctions.cpp
@@ -10,29 +10,38 @@
 using orbit_client_protos::FunctionInfo;
 
 OrbitLiveFunctions::OrbitLiveFunctions(QWidget* parent)
-    : QWidget(parent), ui(new Ui::OrbitLiveFunctions), live_functions_{GOrbitApp.get()} {
+    : QWidget(parent), ui(new Ui::OrbitLiveFunctions) {
   ui->setupUi(this);
+}
 
-  live_functions_.SetAddIteratorCallback(
+OrbitLiveFunctions::~OrbitLiveFunctions() { delete ui; }
+
+void OrbitLiveFunctions::Initialize(OrbitApp* app, SelectionType selection_type, FontType font_type,
+                                    bool is_main_instance) {
+  live_functions_.emplace(app);
+  DataView* data_view = &live_functions_->GetDataView();
+  ui->data_view_panel_->Initialize(data_view, selection_type, font_type, is_main_instance);
+
+  live_functions_->SetAddIteratorCallback(
       [this](size_t id, FunctionInfo* function) { this->AddIterator(id, function); });
 
   all_events_iterator_ = new OrbitEventIterator(this);
   all_events_iterator_->SetNextButtonCallback([this]() {
-    if (!this->live_functions_.OnAllNextButton()) {
+    if (!this->live_functions_->OnAllNextButton()) {
       return;
     }
     for (auto& iterator_ui : iterator_uis) {
       uint64_t index = iterator_ui.first;
-      iterator_ui.second->SetCurrentTime(this->live_functions_.GetStartTime(index));
+      iterator_ui.second->SetCurrentTime(this->live_functions_->GetStartTime(index));
     }
   });
   all_events_iterator_->SetPreviousButtonCallback([this]() {
-    if (!this->live_functions_.OnAllPreviousButton()) {
+    if (!this->live_functions_->OnAllPreviousButton()) {
       return;
     }
     for (auto& iterator_ui : iterator_uis) {
       uint64_t index = iterator_ui.first;
-      iterator_ui.second->SetCurrentTime(this->live_functions_.GetStartTime(index));
+      iterator_ui.second->SetCurrentTime(this->live_functions_->GetStartTime(index));
     }
   });
   all_events_iterator_->SetFunctionName("All functions");
@@ -42,37 +51,35 @@ OrbitLiveFunctions::OrbitLiveFunctions(QWidget* parent)
       ->insertWidget(ui->iteratorFrame->layout()->count() - 1, all_events_iterator_);
 }
 
-OrbitLiveFunctions::~OrbitLiveFunctions() { delete ui; }
-
-void OrbitLiveFunctions::Initialize(SelectionType selection_type, FontType font_type,
-                                    bool is_main_instance) {
-  DataView* data_view = &live_functions_.GetDataView();
-  ui->data_view_panel_->Initialize(data_view, selection_type, font_type, is_main_instance);
-}
-
 void OrbitLiveFunctions::SetFilter(const QString& a_Filter) {
   ui->data_view_panel_->SetFilter(a_Filter);
 }
 
 void OrbitLiveFunctions::Refresh() { ui->data_view_panel_->Refresh(); }
 
-void OrbitLiveFunctions::OnDataChanged() { live_functions_.OnDataChanged(); }
+void OrbitLiveFunctions::OnDataChanged() {
+  if (live_functions_) {
+    live_functions_->OnDataChanged();
+  }
+}
 
 void OrbitLiveFunctions::AddIterator(size_t id, FunctionInfo* function) {
+  if (!live_functions_) return;
+
   OrbitEventIterator* iterator_ui = new OrbitEventIterator(this);
 
   iterator_ui->SetNextButtonCallback([this, id]() {
-    this->live_functions_.OnNextButton(id);
+    live_functions_->OnNextButton(id);
     auto it = this->iterator_uis.find(id);
-    it->second->SetCurrentTime(this->live_functions_.GetStartTime(id));
+    it->second->SetCurrentTime(live_functions_->GetStartTime(id));
   });
   iterator_ui->SetPreviousButtonCallback([this, id]() {
-    this->live_functions_.OnPreviousButton(id);
+    live_functions_->OnPreviousButton(id);
     auto it = this->iterator_uis.find(id);
-    it->second->SetCurrentTime(this->live_functions_.GetStartTime(id));
+    it->second->SetCurrentTime(live_functions_->GetStartTime(id));
   });
   iterator_ui->SetDeleteButtonCallback([this, id]() {
-    this->live_functions_.OnDeleteButton(id);
+    live_functions_->OnDeleteButton(id);
     auto it = this->iterator_uis.find(id);
     ui->iteratorFrame->layout()->removeWidget(it->second);
     it->second->deleteLater();
@@ -83,8 +90,8 @@ void OrbitLiveFunctions::AddIterator(size_t id, FunctionInfo* function) {
   });
   iterator_ui->SetFunctionName(function->pretty_name());
 
-  iterator_ui->SetMinMaxTime(live_functions_.GetCaptureMin(), live_functions_.GetCaptureMax());
-  iterator_ui->SetCurrentTime(live_functions_.GetStartTime(id));
+  iterator_ui->SetMinMaxTime(live_functions_->GetCaptureMin(), live_functions_->GetCaptureMax());
+  iterator_ui->SetCurrentTime(live_functions_->GetStartTime(id));
 
   iterator_uis.insert(std::make_pair(id, iterator_ui));
 
@@ -99,7 +106,9 @@ QLineEdit* OrbitLiveFunctions::GetFilterLineEdit() {
 }
 
 void OrbitLiveFunctions::Reset() {
-  live_functions_.Reset();
+  if (!live_functions_) return;
+
+  live_functions_->Reset();
 
   for (auto& [_, iterator_ui] : iterator_uis) {
     ui->iteratorFrame->layout()->removeWidget(iterator_ui);

--- a/OrbitQt/orbitlivefunctions.h
+++ b/OrbitQt/orbitlivefunctions.h
@@ -8,6 +8,7 @@
 #include <QLineEdit>
 #include <QVBoxLayout>
 #include <QWidget>
+#include <optional>
 
 #include "LiveFunctionsController.h"
 #include "absl/container/flat_hash_map.h"
@@ -19,6 +20,8 @@ namespace Ui {
 class OrbitLiveFunctions;
 }
 
+class OrbitApp;
+
 class OrbitLiveFunctions : public QWidget {
   Q_OBJECT
 
@@ -26,7 +29,8 @@ class OrbitLiveFunctions : public QWidget {
   explicit OrbitLiveFunctions(QWidget* parent = nullptr);
   ~OrbitLiveFunctions() override;
 
-  void Initialize(SelectionType selection_type, FontType font_type, bool is_main_instance = true);
+  void Initialize(OrbitApp* app, SelectionType selection_type, FontType font_type,
+                  bool is_main_instance = true);
   void Refresh();
   void OnDataChanged();
   void onRowSelected(int row);
@@ -34,11 +38,13 @@ class OrbitLiveFunctions : public QWidget {
   void SetFilter(const QString& a_Filter);
   void AddIterator(uint64_t id, orbit_client_protos::FunctionInfo* function);
   QLineEdit* GetFilterLineEdit();
-  LiveFunctionsController& GetLiveFunctionsController() { return live_functions_; }
+  std::optional<LiveFunctionsController*> GetLiveFunctionsController() {
+    return live_functions_ ? &live_functions_.value() : nullptr;
+  }
 
  private:
   Ui::OrbitLiveFunctions* ui;
-  LiveFunctionsController live_functions_;
+  std::optional<LiveFunctionsController> live_functions_;
   absl::flat_hash_map<uint64_t, OrbitEventIterator*> iterator_uis;
   OrbitEventIterator* all_events_iterator_;
 };

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -6,6 +6,7 @@
 
 #include <absl/flags/flag.h>
 
+#include <QApplication>
 #include <QBuffer>
 #include <QCheckBox>
 #include <QClipboard>
@@ -52,10 +53,9 @@ using orbit_grpc_protos::CrashOrbitServiceRequest_CrashType_STACK_OVERFLOW;
 
 extern QMenu* GContextMenu;
 
-OrbitMainWindow::OrbitMainWindow(QApplication* a_App,
-                                 orbit_qt::ServiceDeployManager* service_deploy_manager,
+OrbitMainWindow::OrbitMainWindow(orbit_qt::ServiceDeployManager* service_deploy_manager,
                                  uint32_t font_size)
-    : QMainWindow(nullptr), m_App(a_App), ui(new Ui::OrbitMainWindow) {
+    : QMainWindow(nullptr), ui(new Ui::OrbitMainWindow) {
   DataViewFactory* data_view_factory = GOrbitApp.get();
 
   ui->setupUi(this);

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -261,7 +261,7 @@ OrbitMainWindow::OrbitMainWindow(OrbitApp* app,
 
   StartMainTimer();
 
-  ui->liveFunctions->Initialize(SelectionType::kExtended, FontType::kDefault);
+  ui->liveFunctions->Initialize(app_, SelectionType::kExtended, FontType::kDefault);
 
   connect(ui->liveFunctions->GetFilterLineEdit(), &QLineEdit::textChanged, this,
           [this](const QString& text) { OnLiveTabFunctionsFilterTextChanged(text); });
@@ -771,8 +771,10 @@ void OrbitMainWindow::RestoreDefaultTabLayout() {
 void OrbitMainWindow::OnTimerSelectionChanged(const orbit_client_protos::TimerInfo* timer_info) {
   if (!timer_info) return;
   uint64_t function_address = timer_info->function_address();
+  const auto live_functions_controller = ui->liveFunctions->GetLiveFunctionsController();
+  CHECK(live_functions_controller.has_value());
   LiveFunctionsDataView& live_functions_data_view =
-      ui->liveFunctions->GetLiveFunctionsController().GetDataView();
+      live_functions_controller.value()->GetDataView();
   int selected_row = live_functions_data_view.GetRowFromFunctionAddress(function_address);
   if (selected_row != -1) {
     ui->liveFunctions->onRowSelected(selected_row);

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -208,14 +208,14 @@ OrbitMainWindow::OrbitMainWindow(OrbitApp* app,
   app_->SetShowEmptyFrameTrackWarningCallback(
       [this](std::string_view function) { this->ShowEmptyFrameTrackWarningIfNeeded(function); });
 
-  ui->CaptureGLWidget->Initialize(GlCanvas::CanvasType::kCaptureWindow, this, font_size);
+  ui->CaptureGLWidget->Initialize(GlCanvas::CanvasType::kCaptureWindow, this, font_size, app_);
 
   app_->SetTimerSelectedCallback([this](const orbit_client_protos::TimerInfo* timer_info) {
     OnTimerSelectionChanged(timer_info);
   });
 
   if (absl::GetFlag(FLAGS_devmode)) {
-    ui->debugOpenGLWidget->Initialize(GlCanvas::CanvasType::kDebug, this, font_size);
+    ui->debugOpenGLWidget->Initialize(GlCanvas::CanvasType::kDebug, this, font_size, app_);
     app_->SetDebugCanvas(ui->debugOpenGLWidget->GetCanvas());
   } else {
     ui->RightTabWidget->removeTab(ui->RightTabWidget->indexOf(ui->debugTab));
@@ -702,7 +702,7 @@ void OrbitMainWindow::on_actionIntrospection_triggered() {
   if (introspection_widget_ == nullptr) {
     introspection_widget_ = new OrbitGLWidget();
     introspection_widget_->setWindowFlags(Qt::WindowStaysOnTopHint);
-    introspection_widget_->Initialize(GlCanvas::CanvasType::kIntrospectionWindow, this, 14);
+    introspection_widget_->Initialize(GlCanvas::CanvasType::kIntrospectionWindow, this, 14, app_);
     introspection_widget_->installEventFilter(this);
   }
 

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -17,6 +17,7 @@
 #include <string>
 #include <vector>
 
+#include "App.h"
 #include "CallStackDataView.h"
 #include "CallTreeView.h"
 #include "StatusListener.h"
@@ -30,7 +31,7 @@ class OrbitMainWindow : public QMainWindow {
   Q_OBJECT
 
  public:
-  OrbitMainWindow(orbit_qt::ServiceDeployManager* service_deploy_manager,
+  OrbitMainWindow(OrbitApp* app, orbit_qt::ServiceDeployManager* service_deploy_manager,
                   uint32_t font_size);
   ~OrbitMainWindow() override;
 
@@ -112,6 +113,7 @@ class OrbitMainWindow : public QMainWindow {
   QTabWidget* FindParentTabWidget(const QWidget* widget) const;
 
  private:
+  OrbitApp* app_ = nullptr;
   Ui::OrbitMainWindow* ui;
   QTimer* m_MainTimer = nullptr;
   std::vector<OrbitGLWidget*> m_GlWidgets;

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -7,7 +7,6 @@
 
 #include <DisassemblyReport.h>
 
-#include <QApplication>
 #include <QLabel>
 #include <QLineEdit>
 #include <QMainWindow>
@@ -31,7 +30,7 @@ class OrbitMainWindow : public QMainWindow {
   Q_OBJECT
 
  public:
-  OrbitMainWindow(QApplication* a_App, orbit_qt::ServiceDeployManager* service_deploy_manager,
+  OrbitMainWindow(orbit_qt::ServiceDeployManager* service_deploy_manager,
                   uint32_t font_size);
   ~OrbitMainWindow() override;
 
@@ -113,7 +112,6 @@ class OrbitMainWindow : public QMainWindow {
   QTabWidget* FindParentTabWidget(const QWidget* widget) const;
 
  private:
-  QApplication* m_App;
   Ui::OrbitMainWindow* ui;
   QTimer* m_MainTimer = nullptr;
   std::vector<OrbitGLWidget*> m_GlWidgets;

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -31,8 +31,9 @@ class OrbitMainWindow : public QMainWindow {
   Q_OBJECT
 
  public:
-  OrbitMainWindow(OrbitApp* app, orbit_qt::ServiceDeployManager* service_deploy_manager,
-                  uint32_t font_size);
+  explicit OrbitMainWindow(ApplicationOptions options,
+                           orbit_qt::ServiceDeployManager* service_deploy_manager,
+                           uint32_t font_size);
   ~OrbitMainWindow() override;
 
   void RegisterGlWidget(class OrbitGLWidget* a_GlWidget) { m_GlWidgets.push_back(a_GlWidget); }
@@ -113,7 +114,7 @@ class OrbitMainWindow : public QMainWindow {
   QTabWidget* FindParentTabWidget(const QWidget* widget) const;
 
  private:
-  OrbitApp* app_ = nullptr;
+  std::unique_ptr<OrbitApp> app_;
   Ui::OrbitMainWindow* ui;
   QTimer* m_MainTimer = nullptr;
   std::vector<OrbitGLWidget*> m_GlWidgets;


### PR DESCRIPTION
This PR removes GOrbitApp from the code base.

It has a lot of commits - mainly separated by class. Almost all of them a straight forward.
They introduce a member variable `OrbitApp* app_` which is initialized via the constructor and used
in the class's implementation instead of GOrbitApp.

All commits compile on its own and I recommend to review them one-by-one. It's a large PR,
but the commits itself are rather small. Let me know if you think this needs to be split up into multiple PRs.

The reason for doing this is mainly #1526. This PR needs to move some resource ownership (i.e. ProcessManager) from OrbitApp to OrbitMainWindow, which means OrbitMainWindow needs to control the lifetime of OrbitApp, otherwise OrbitApp might end up with a dangling pointer when OrbitMainWindow gets out of scope. So after removing all of GOrbitApp, there is a commit that hands ownership of OrbitApp to OrbitMainWindow.

It did some extensive manual testing with the branch and I couldn't crash it or found any bug.

Note: This does not solve the cyclic dependency problem that we have with OrbitApp ("OrbitApp owns X and X needs to access OrbitApp"). It can and has to be refactored independently. This is also the reason why this change introduces a lot of forward declarations of OrbitApp. They are needed due to cyclic dependencies.

EDIT: Note that the license_headers presubmit check is expected to fail due to the known orbitcodeeditor-problem. b/163462463 for more details.

EDIT: Bug added for tracking the progress of follow-up refactorings of the cyclic dependencies: http://b/175759190