### PR TITLE
Remove CaptureGLWidget before OrbitApp

### DIFF
--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -472,6 +472,9 @@ QTabWidget* OrbitMainWindow::FindParentTabWidget(const QWidget* widget) const {
 
 OrbitMainWindow::~OrbitMainWindow() {
   DeinitTutorials();
+
+  // CaptureGLWidget needs to be deleted ahead of time to ensure that it is deleted before OrbitApp
+  delete ui->CaptureGLWidget;
   delete ui;
 }
 


### PR DESCRIPTION
Since OrbitApp is now living inside of OrbitMainWindow we need to ensure
that all resources living in OrbitMainWindow that require OrbitApp are
deleted before we delete OrbitApp.

That's particularly problematic with OrbitMainWindow's widgets because
they are deleted by a base class destructor (`QObject::~QObject()`) that
runs after `~OrbitMainWindow()` and hence after the destruction of
OrbitApp.

Currently that's not a problem because OrbitApp is not accessed by
CaptureGLWidget's destructor. But this will change with the upcoming UI
changes.

Obviously this is not the ideal solution, but a proper solution requires
untangling the cyclic dependencies of OrbitApp first, so that's the best
I can do for now.

Test: Build and unit tests and manual testing