### PR TITLE
Make Qt widgets deinitializable

### DIFF
--- a/OrbitQt/CallTreeWidget.cpp
+++ b/OrbitQt/CallTreeWidget.cpp
@@ -54,6 +54,13 @@ void CallTreeWidget::SetCallTreeView(std::unique_ptr<CallTreeView> call_tree_vie
   ResizeColumnsIfNecessary();
 }
 
+void CallTreeWidget::ClearCallTreeView() {
+  hooked_proxy_model_.reset();
+  search_proxy_model_.reset();
+  hide_values_proxy_model_.reset();
+  model_.reset();
+}
+
 namespace {
 
 class HideValuesForTopDownProxyModel : public QIdentityProxyModel {
@@ -250,6 +257,10 @@ static std::vector<const FunctionInfo*> GetFunctionsFromIndices(
 }
 
 void CallTreeWidget::onCustomContextMenuRequested(const QPoint& point) {
+  if (app_ == nullptr) {
+    return;
+  }
+
   QModelIndex index = ui_->callTreeTreeView->indexAt(point);
   if (!index.isValid()) {
     return;

--- a/OrbitQt/CallTreeWidget.h
+++ b/OrbitQt/CallTreeWidget.h
@@ -26,9 +26,14 @@ class CallTreeWidget : public QWidget {
   explicit CallTreeWidget(QWidget* parent = nullptr);
 
   void Initialize(OrbitApp* app) { app_ = app; }
+  void Deinitialize() {
+    ClearCallTreeView();
+    app_ = nullptr;
+  }
 
   void SetTopDownView(std::unique_ptr<CallTreeView> top_down_view);
   void SetBottomUpView(std::unique_ptr<CallTreeView> bottom_up_view);
+  void ClearCallTreeView();
 
  protected:
   void resizeEvent(QResizeEvent* event) override;

--- a/OrbitQt/orbitdataviewpanel.cpp
+++ b/OrbitQt/orbitdataviewpanel.cpp
@@ -42,6 +42,8 @@ void OrbitDataViewPanel::Initialize(DataView* data_view, SelectionType selection
   data_view->SetUiFilterCallback([this](const std::string& filter) { SetFilter(filter.c_str()); });
 }
 
+void OrbitDataViewPanel::Deinitialize() { ui->treeView->Deinitialize(); }
+
 OrbitTreeView* OrbitDataViewPanel::GetTreeView() { return ui->treeView; }
 
 QLineEdit* OrbitDataViewPanel::GetFilterLineEdit() { return ui->FilterLineEdit; }
@@ -53,6 +55,8 @@ void OrbitDataViewPanel::Link(OrbitDataViewPanel* a_Panel) {
 void OrbitDataViewPanel::Refresh() { ui->treeView->Refresh(); }
 
 void OrbitDataViewPanel::SetDataModel(DataView* model) { ui->treeView->SetDataModel(model); }
+
+void OrbitDataViewPanel::ClearDataModel() { ui->treeView->ClearDataModel(); }
 
 void OrbitDataViewPanel::SetFilter(const QString& a_Filter) {
   ui->FilterLineEdit->setText(a_Filter);

--- a/OrbitQt/orbitdataviewpanel.h
+++ b/OrbitQt/orbitdataviewpanel.h
@@ -26,9 +26,11 @@ class OrbitDataViewPanel : public QWidget {
   void Initialize(DataView* data_view, SelectionType selection_type, FontType font_type,
                   bool is_main_instance = true, bool uniform_row_height = true,
                   QFlags<Qt::AlignmentFlag> text_alignment = Qt::AlignVCenter | Qt::AlignLeft);
+  void Deinitialize();
   void Link(OrbitDataViewPanel* a_Panel);
   void Refresh();
   void SetDataModel(DataView* model);
+  void ClearDataModel();
   void SetFilter(const QString& a_Filter);
   OrbitTreeView* GetTreeView();
   QLineEdit* GetFilterLineEdit();

--- a/OrbitQt/orbitglwidget.cpp
+++ b/OrbitQt/orbitglwidget.cpp
@@ -39,13 +39,20 @@ bool OrbitGLWidget::eventFilter(QObject* /*object*/, QEvent* event) {
   return false;
 }
 
-void OrbitGLWidget::Initialize(GlCanvas::CanvasType canvas_type, OrbitMainWindow* a_MainWindow,
+void OrbitGLWidget::Initialize(GlCanvas::CanvasType canvas_type, OrbitMainWindow* main_window,
                                uint32_t font_size, OrbitApp* app) {
   gl_canvas_ = GlCanvas::Create(canvas_type, font_size, app);
 
-  if (a_MainWindow) {
-    a_MainWindow->RegisterGlWidget(this);
+  if (main_window) {
+    main_window->RegisterGlWidget(this);
   }
+}
+
+void OrbitGLWidget::Deinitialize(OrbitMainWindow* main_window) {
+  if (main_window) {
+    main_window->UnregisterGlWidget(this);
+  }
+  gl_canvas_.reset();
 }
 
 void OrbitGLWidget::initializeGL() {

--- a/OrbitQt/orbitglwidget.h
+++ b/OrbitQt/orbitglwidget.h
@@ -15,6 +15,7 @@
 #include "GlCanvas.h"
 
 class OrbitApp;
+class OrbitMainWindow;
 class QOpenGLDebugMessage;
 class QOpenGLDebugLogger;
 
@@ -23,8 +24,9 @@ class OrbitGLWidget : public QOpenGLWidget, protected QOpenGLFunctions {
 
  public:
   explicit OrbitGLWidget(QWidget* parent = nullptr);
-  void Initialize(GlCanvas::CanvasType canvas_type, class OrbitMainWindow* a_MainWindow,
+  void Initialize(GlCanvas::CanvasType canvas_type, OrbitMainWindow* main_window,
                   uint32_t font_size, OrbitApp* app);
+  void Deinitialize(OrbitMainWindow* main_window);
   void initializeGL() override;
   void resizeGL(int w, int h) override;
   void paintGL() override;

--- a/OrbitQt/orbitlivefunctions.cpp
+++ b/OrbitQt/orbitlivefunctions.cpp
@@ -51,6 +51,13 @@ void OrbitLiveFunctions::Initialize(OrbitApp* app, SelectionType selection_type,
       ->insertWidget(ui->iteratorFrame->layout()->count() - 1, all_events_iterator_);
 }
 
+void OrbitLiveFunctions::Deinitialize() {
+  delete all_events_iterator_;
+  live_functions_->SetAddIteratorCallback([](size_t, FunctionInfo*) {});
+  ui->data_view_panel_->Deinitialize();
+  live_functions_.reset();
+}
+
 void OrbitLiveFunctions::SetFilter(const QString& a_Filter) {
   ui->data_view_panel_->SetFilter(a_Filter);
 }

--- a/OrbitQt/orbitlivefunctions.h
+++ b/OrbitQt/orbitlivefunctions.h
@@ -31,6 +31,7 @@ class OrbitLiveFunctions : public QWidget {
 
   void Initialize(OrbitApp* app, SelectionType selection_type, FontType font_type,
                   bool is_main_instance = true);
+  void Deinitialize();
   void Refresh();
   void OnDataChanged();
   void OnRowSelected(std::optional<int> row);

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -630,8 +630,8 @@ void OrbitMainWindow::OnTimer() {
   ORBIT_SCOPE("OrbitMainWindow::OnTimer");
   app_->MainTick();
 
-  for (OrbitGLWidget* glWidget : m_GlWidgets) {
-    glWidget->update();
+  for (OrbitGLWidget* gl_widget : gl_widgets_) {
+    gl_widget->update();
   }
 
   ui->timerLabel->setText(QString::fromStdString(app_->GetCaptureTime()));

--- a/OrbitQt/orbitmainwindow.cpp
+++ b/OrbitQt/orbitmainwindow.cpp
@@ -473,8 +473,24 @@ QTabWidget* OrbitMainWindow::FindParentTabWidget(const QWidget* widget) const {
 OrbitMainWindow::~OrbitMainWindow() {
   DeinitTutorials();
 
-  // CaptureGLWidget needs to be deleted ahead of time to ensure that it is deleted before OrbitApp
-  delete ui->CaptureGLWidget;
+  ui->selectionBottomUpWidget->Deinitialize();
+  ui->bottomUpWidget->Deinitialize();
+  ui->selectionTopDownWidget->Deinitialize();
+  ui->topDownWidget->Deinitialize();
+  ui->TracepointsList->Deinitialize();
+  ui->CallStackView->Deinitialize();
+  ui->liveFunctions->Deinitialize();
+
+  if (absl::GetFlag(FLAGS_devmode)) {
+    ui->debugOpenGLWidget->Deinitialize(this);
+  }
+
+  ui->CaptureGLWidget->Deinitialize(this);
+  ui->SessionList->Deinitialize();
+  ui->FunctionsList->Deinitialize();
+  ui->ModulesList->Deinitialize();
+  ui->ProcessesList->ClearDataView();
+
   delete ui;
 }
 

--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -21,6 +21,7 @@
 #include "CallStackDataView.h"
 #include "CallTreeView.h"
 #include "StatusListener.h"
+#include "orbitglwidget.h"
 #include "servicedeploymanager.h"
 
 namespace Ui {
@@ -36,7 +37,13 @@ class OrbitMainWindow : public QMainWindow {
                            uint32_t font_size);
   ~OrbitMainWindow() override;
 
-  void RegisterGlWidget(class OrbitGLWidget* a_GlWidget) { m_GlWidgets.push_back(a_GlWidget); }
+  void RegisterGlWidget(OrbitGLWidget* widget) { gl_widgets_.push_back(widget); }
+  void UnregisterGlWidget(OrbitGLWidget* widget) {
+    const auto it = std::find(gl_widgets_.begin(), gl_widgets_.end(), widget);
+    if (it != gl_widgets_.end()) {
+      gl_widgets_.erase(it);
+    }
+  }
   void OnRefreshDataViewPanels(DataViewType a_Type);
   void UpdatePanel(DataViewType a_Type);
 
@@ -117,7 +124,7 @@ class OrbitMainWindow : public QMainWindow {
   std::unique_ptr<OrbitApp> app_;
   Ui::OrbitMainWindow* ui;
   QTimer* m_MainTimer = nullptr;
-  std::vector<OrbitGLWidget*> m_GlWidgets;
+  std::vector<OrbitGLWidget*> gl_widgets_;
   OrbitGLWidget* introspection_widget_ = nullptr;
 
   // Capture toolbar.

--- a/OrbitQt/orbittreeview.cpp
+++ b/OrbitQt/orbittreeview.cpp
@@ -85,10 +85,21 @@ void OrbitTreeView::Initialize(DataView* data_view, SelectionType selection_type
   }
 }
 
+void OrbitTreeView::Deinitialize() {
+  timer_.reset();
+  setModel(nullptr);
+  model_.reset();
+}
+
 void OrbitTreeView::SetDataModel(DataView* data_view) {
   model_ = std::make_unique<OrbitTableModel>();
   model_->SetDataView(data_view);
   setModel(model_.get());
+}
+
+void OrbitTreeView::ClearDataModel() {
+  setModel(nullptr);
+  model_.reset();
 }
 
 void OrbitTreeView::OnSort(int section, Qt::SortOrder order) {

--- a/OrbitQt/orbittreeview.h
+++ b/OrbitQt/orbittreeview.h
@@ -21,7 +21,9 @@ class OrbitTreeView : public QTreeView {
   void Initialize(DataView* data_view, SelectionType selection_type, FontType font_type,
                   bool uniform_row_height = true,
                   QFlags<Qt::AlignmentFlag> text_alignment = Qt::AlignVCenter | Qt::AlignLeft);
+  void Deinitialize();
   void SetDataModel(DataView* model);
+  void ClearDataModel();
   void OnFilter(const QString& filter);
   void Refresh();
   void Link(OrbitTreeView* link);

--- a/OrbitQt/processlauncherwidget.cpp
+++ b/OrbitQt/processlauncherwidget.cpp
@@ -22,4 +22,6 @@ void ProcessLauncherWidget::SetDataView(DataView* data_view) {
   ui->LiveProcessList->Initialize(data_view, SelectionType::kDefault, FontType::kDefault);
 }
 
+void ProcessLauncherWidget::ClearDataView() { ui->LiveProcessList->Deinitialize(); }
+
 void ProcessLauncherWidget::Refresh() { ui->LiveProcessList->Refresh(); }

--- a/OrbitQt/processlauncherwidget.h
+++ b/OrbitQt/processlauncherwidget.h
@@ -22,6 +22,7 @@ class ProcessLauncherWidget : public QWidget {
 
   void Refresh();
   void SetDataView(DataView* data_view);
+  void ClearDataView();
 
  private:
   Ui::ProcessLauncherWidget* ui;


### PR DESCRIPTION
You all know the problem, that Qt-classes that need to be declared in a UI-file may not have additional constructor arguments.

The solution to this is having a `Initialize` method which most of these classes have. The `Initialize` method passes pointers
to other resources into the widget (OrbitApp, DataView, etc.) such that the widget can call methods of these resources.

This becomes problematic during destruction. Widgets are destructed by Qt's QObject-based lifetime handling mechanism, which
means OrbitMainWindow's widgets are destructed in QObject's destructor - hence OrbitMainWindow does not exist anymore when
its widgets are destructed.

That's a problem for resources living in OrbitMainWindow and required by these widgets.

To my knowledge the best solution to this problem without refactoring everything is making the `Initialize` method symmetric and
also provide a `Deinitialize` method. So `Initialize` is called in OrbitMainWindows's constructor while `Deinitialize` is called in its destructor. This is what is implemented here.