### PR TITLE
Add static_assert to ensure floating point adheres to IEEE 754 (IEC 559)

### DIFF
--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -1097,16 +1097,17 @@ void TracerThread::PrintStatsIfTimerElapsed() {
                                           : "DISCARDED AS OUT OF ORDER",
         discarded_out_of_order_count / actual_window_s, discarded_out_of_order_count);
 
-    if (stats_.sample_count > 0) {
-      uint64_t unwind_error_count = stats_.unwind_error_count;
-      LOG("  unwind errors: %.0f/s (%lu) [%.1f%%])", unwind_error_count / actual_window_s,
-          unwind_error_count, 100.0 * unwind_error_count / stats_.sample_count);
-      uint64_t discarded_samples_in_uretprobes_count = stats_.discarded_samples_in_uretprobes_count;
-      LOG("  discarded samples in u(ret)probes: %.0f/s (%lu) [%.1f%%]",
-          discarded_samples_in_uretprobes_count / actual_window_s,
-          discarded_samples_in_uretprobes_count,
-          100.0 * discarded_samples_in_uretprobes_count / stats_.sample_count);
-    }
+    // Ensure we can divide by 0.0 safely in case stats_.sample_count is zero.
+    static_assert(std::numeric_limits<double>::is_iec559);
+
+    uint64_t unwind_error_count = stats_.unwind_error_count;
+    LOG("  unwind errors: %.0f/s (%lu) [%.1f%%])", unwind_error_count / actual_window_s,
+        unwind_error_count, 100.0 * unwind_error_count / stats_.sample_count);
+    uint64_t discarded_samples_in_uretprobes_count = stats_.discarded_samples_in_uretprobes_count;
+    LOG("  discarded samples in u(ret)probes: %.0f/s (%lu) [%.1f%%]",
+        discarded_samples_in_uretprobes_count / actual_window_s,
+        discarded_samples_in_uretprobes_count,
+        100.0 * discarded_samples_in_uretprobes_count / stats_.sample_count);
 
     uint64_t thread_state_count = stats_.thread_state_count;
     LOG("  target's thread states: %.0f/s (%lu)", thread_state_count / actual_window_s,

--- a/OrbitService/CaptureServiceImpl.cpp
+++ b/OrbitService/CaptureServiceImpl.cpp
@@ -4,6 +4,8 @@
 
 #include "CaptureServiceImpl.h"
 
+#include <limits>
+
 #include "CaptureEventBuffer.h"
 #include "CaptureEventSender.h"
 #include "LinuxTracingHandler.h"
@@ -94,8 +96,12 @@ class GrpcCaptureEventSender final : public CaptureEventSender {
   ~GrpcCaptureEventSender() override {
     LOG("Total number of events sent: %lu", total_number_of_events_sent_);
     LOG("Total number of bytes sent: %lu", total_number_of_bytes_sent_);
+
+    // Ensure we can divide by 0.f safely.
+    static_assert(std::numeric_limits<float>::is_iec559);
     float average_bytes =
         static_cast<float>(total_number_of_bytes_sent_) / total_number_of_events_sent_;
+
     LOG("Average number of bytes per event: %.2f", average_bytes);
   }
 
@@ -123,7 +129,10 @@ class GrpcCaptureEventSender final : public CaptureEventSender {
     number_of_bytes_sent += response.ByteSizeLong();
     reader_writer_->Write(response);
 
+    // Ensure we can divide by 0.f safely.
+    static_assert(std::numeric_limits<float>::is_iec559);
     float average_bytes = static_cast<float>(number_of_bytes_sent) / events.size();
+
     ORBIT_FLOAT("Average bytes per CaptureEvent", average_bytes);
     total_number_of_events_sent_ += events.size();
     total_number_of_bytes_sent_ += number_of_bytes_sent;


### PR DESCRIPTION
We have a couple of places were it's more convenient to possibly divide
by 0.f or 0.0 instead of checking. This is fine as long as floating
point computations adhere to IEEE 754, o/w it's undefined behavior. We
add static_assert's to check for this. The asserts are added in all
(known) places where we may divide by 0.0 or 0.f to ensure we still have
the assert when some of the places are changed or removed.

Test: Compiled.
Bug: N/A