### PR TITLE
Accessible tracks

### DIFF
--- a/OrbitAccessibility/include/OrbitAccessibility/AccessibleInterface.h
+++ b/OrbitAccessibility/include/OrbitAccessibility/AccessibleInterface.h
@@ -50,8 +50,8 @@ enum class AccessibilityRole {
 enum class AccessibilityState : uint64_t {
   Normal = 0,
   Disabled = 1,
-  Selected = 1 << 1,
   Focusable = 1 << 2,
+  Focused = 1 << 3,
   Expanded = 1 << 11,
   Collapsed = 1 << 12,
   Expandable = 1 << 14,

--- a/OrbitGl/AccessibleTimeGraph.cpp
+++ b/OrbitGl/AccessibleTimeGraph.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "AccessibleTimeGraph.h"
+
+#include "GlCanvas.h"
+#include "TimeGraph.h"
+
+AccessibilityRect TimeGraphAccessibility::AccessibleLocalRect() const {
+  GlCanvas* canvas = time_graph_->GetCanvas();
+  return AccessibilityRect(0, 0, canvas->GetWidth(), canvas->GetHeight());
+}
+
+AccessibilityState TimeGraphAccessibility::AccessibleState() const {
+  return orbit_gl::AccessibilityState::Focusable;
+}
+
+int TimeGraphAccessibility::AccessibleChildCount() const {
+  return time_graph_->GetTrackManager()->GetVisibleTracks().size();
+}
+
+const AccessibleInterface* TimeGraphAccessibility::AccessibleChild(int index) const {
+  return time_graph_->GetTrackManager()->GetVisibleTracks()[index]->AccessibilityInterface();
+}
+
+const AccessibleInterface* TimeGraphAccessibility::AccessibleParent() const {
+  return time_graph_->GetCanvas()->GetOrCreateAccessibleInterface();
+}

--- a/OrbitGl/AccessibleTimeGraph.h
+++ b/OrbitGl/AccessibleTimeGraph.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_ACCESSIBLE_TIME_GRAPH_H_
+#define ORBIT_GL_ACCESSIBLE_TIME_GRAPH_H_
+
+#include "OrbitAccessibility/AccessibleInterface.h"
+#include "OrbitBase/Logging.h"
+
+class TimeGraph;
+
+using orbit_accessibility::AccessibilityRect;
+using orbit_accessibility::AccessibilityRole;
+using orbit_accessibility::AccessibilityState;
+using orbit_accessibility::AccessibleInterface;
+
+class TimeGraphAccessibility : public AccessibleInterface {
+ public:
+  TimeGraphAccessibility(TimeGraph* time_graph) : time_graph_(time_graph) {
+    CHECK(time_graph != nullptr);
+  }
+  [[nodiscard]] int AccessibleChildCount() const override;
+  [[nodiscard]] const AccessibleInterface* AccessibleChild(int) const override;
+  [[nodiscard]] const AccessibleInterface* AccessibleParent() const override;
+
+  [[nodiscard]] std::string AccessibleName() const override { return "TimeGraph"; }
+  [[nodiscard]] AccessibilityRole AccessibleRole() const override {
+    return AccessibilityRole::Graphic;
+  }
+  [[nodiscard]] AccessibilityRect AccessibleLocalRect() const override;
+  [[nodiscard]] AccessibilityState AccessibleState() const override;
+
+ private:
+  TimeGraph* time_graph_;
+};
+
+#endif

--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -11,7 +11,8 @@ target_compile_options(OrbitGl PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(
   OrbitGl
-  PUBLIC App.h
+  PUBLIC AccessibleTimeGraph.h
+         App.h
          AsyncTrack.h
          Batcher.h
          BlockChain.h
@@ -70,7 +71,8 @@ target_sources(
 
 target_sources(
   OrbitGl
-  PRIVATE App.cpp
+  PRIVATE AccessibleTimeGraph.cpp
+          App.cpp
           AsyncTrack.cpp
           Batcher.cpp
           CallStackDataView.cpp

--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -154,7 +154,7 @@ target_sources(OrbitGlTests PRIVATE
                ScopedStatusTest.cpp
                SliderTest.cpp
                TimerInfosIteratorTest.cpp
-               UnitTestMockEnvironment.cpp)
+               ClientFlags.cpp)
 
 target_link_libraries(
   OrbitGlTests

--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -62,6 +62,7 @@ target_sources(
          TimerInfosIterator.h
          TimerTrack.h
          Track.h
+         TrackAccessibility.h
          TrackManager.h
          TriangleToggle.h
          TracepointsDataView.h
@@ -110,6 +111,7 @@ target_sources(
           ThreadStateTrack.cpp
           ThreadTrack.cpp
           Track.cpp
+          TrackAccessibility.cpp
           TrackManager.cpp
           TriangleToggle.cpp
           TracepointsDataView.cpp

--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -10,6 +10,23 @@
 #include "TimeGraph.h"
 #include "absl/base/casts.h"
 
+using orbit_accessibility::AccessibleInterface;
+using orbit_accessibility::AccessibleWidgetBridge;
+
+class AccessibleCaptureWindow : public AccessibleWidgetBridge {
+ public:
+  AccessibleCaptureWindow(CaptureWindow* window) : window_(window) {}
+
+  int AccessibleChildCount() const override { return 1; }
+
+  const AccessibleInterface* AccessibleChild(int /*index*/) const override {
+    return window_->GetTimeGraph()->GetOrCreateAccessibleInterface();
+  }
+
+ private:
+  CaptureWindow* window_;
+};
+
 using orbit_client_protos::TimerInfo;
 
 CaptureWindow::CaptureWindow(uint32_t font_size, OrbitApp* app)
@@ -455,6 +472,10 @@ void CaptureWindow::OnCaptureStarted() {
 }
 
 bool CaptureWindow::ShouldAutoZoom() const { return app_->IsCapturing(); }
+
+std::unique_ptr<AccessibleWidgetBridge> CaptureWindow::CreateAccessibilityInterface() {
+  return std::make_unique<AccessibleCaptureWindow>(this);
+}
 
 void CaptureWindow::Draw() {
   ORBIT_SCOPE("CaptureWindow::Draw");

--- a/OrbitGl/CaptureWindow.h
+++ b/OrbitGl/CaptureWindow.h
@@ -7,6 +7,7 @@
 #include "Batcher.h"
 #include "GlCanvas.h"
 #include "GlSlider.h"
+#include "OrbitAccessibility/AccessibleWidgetBridge.h"
 #include "TextBox.h"
 
 class OrbitApp;
@@ -85,4 +86,6 @@ class CaptureWindow : public GlCanvas {
 
  private:
   OrbitApp* app_ = nullptr;
+  [[nodiscard]] std::unique_ptr<orbit_accessibility::AccessibleWidgetBridge>
+  CreateAccessibilityInterface() override;
 };

--- a/OrbitGl/ClientFlags.cpp
+++ b/OrbitGl/ClientFlags.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <absl/flags/flag.h>
+
+#include <cstdint>
+#include <string>
+
+ABSL_FLAG(bool, enable_stale_features, false,
+          "Enable obsolete features that are not working or are not "
+          "implemented in the client's UI");
+
+ABSL_FLAG(bool, devmode, false, "Enable developer mode in the client's UI");
+
+ABSL_FLAG(bool, nodeploy, false, "Disable automatic deployment of OrbitService");
+
+ABSL_FLAG(std::string, collector, "", "Full path of collector to be deployed");
+
+ABSL_FLAG(std::string, collector_root_password, "", "Collector's machine root password");
+
+ABSL_FLAG(uint16_t, grpc_port, 44765,
+          "The service's GRPC server port (use default value if unsure)");
+ABSL_FLAG(bool, local, false, "Connects to local instance of OrbitService");
+
+ABSL_FLAG(bool, enable_tutorials_feature, false, "Enable tutorials");
+
+// TODO(b/160549506): Remove this flag once it can be specified in the ui.
+ABSL_FLAG(uint16_t, sampling_rate, 1000, "Frequency of callstack sampling in samples per second");
+
+// TODO(b/160549506): Remove this flag once it can be specified in the ui.
+ABSL_FLAG(bool, frame_pointer_unwinding, false, "Use frame pointers for unwinding");
+
+// TODO(kuebler): remove this once we have the validator complete
+ABSL_FLAG(bool, enable_frame_pointer_validator, false, "Enable validation of frame pointers");
+
+// TODO: Remove this flag once we have a way to toggle the display return values
+ABSL_FLAG(bool, show_return_values, false, "Show return values on time slices");
+
+ABSL_FLAG(bool, enable_tracepoint_feature, false,
+          "Enable the setting of the panel of kernel tracepoints");
+
+ABSL_FLAG(bool, thread_state, false, "Collect thread states");
+
+// TODO(170468590): [ui beta] Remove this flag when the new UI is finished
+ABSL_FLAG(bool, enable_ui_beta, false, "Enable the new user interface");

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -138,6 +138,13 @@ void GlCanvas::EnableImGui() {
   }
 }
 
+orbit_accessibility::AccessibleInterface* GlCanvas::GetOrCreateAccessibleInterface() {
+  if (accessibility_ == nullptr) {
+    accessibility_ = CreateAccessibilityInterface();
+  }
+  return accessibility_.get();
+}
+
 void GlCanvas::MouseMoved(int x, int y, bool left, bool /*right*/, bool /*middle*/) {
   int mouse_x = x;
   int mouse_y = y;
@@ -412,6 +419,7 @@ PickingMode GlCanvas::GetPickingMode() {
   return PickingMode::kNone;
 }
 
-void GlCanvas::CreateAccessibilityInterface() {
-  accessibility_ = std::make_unique<orbit_accessibility::AccessibleWidgetBridge>();
+std::unique_ptr<orbit_accessibility::AccessibleWidgetBridge>
+GlCanvas::CreateAccessibilityInterface() {
+  return std::make_unique<orbit_accessibility::AccessibleWidgetBridge>();
 }

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -333,12 +333,11 @@ void GlCanvas::ScreenToWorld(int x, int y, float& wx, float& wy) const {
       world_top_left_y_ - (static_cast<float>(y) / static_cast<float>(GetHeight())) * world_height_;
 }
 
-Vec2 GlCanvas::ScreenToWorld(Vec2 screen_pos) {
+Vec2 GlCanvas::ScreenToWorld(Vec2 screen_pos) const {
   Vec2 world_pos;
-  world_pos[0] =
-      world_top_left_x_ + (screen_pos[0] / static_cast<float>(GetWidth())) * world_width_;
+  world_pos[0] = world_top_left_x_ + screen_pos[0] / static_cast<float>(GetWidth()) * world_width_;
   world_pos[1] =
-      world_top_left_y_ - (screen_pos[1] / static_cast<float>(GetHeight())) * world_height_;
+      world_top_left_y_ - screen_pos[1] / static_cast<float>(GetHeight()) * world_height_;
   return world_pos;
 }
 
@@ -348,6 +347,21 @@ float GlCanvas::ScreenToWorldHeight(int height) const {
 
 float GlCanvas::ScreenToWorldWidth(int width) const {
   return (static_cast<float>(width) / static_cast<float>(GetWidth())) * world_width_;
+}
+
+Vec2 GlCanvas::WorldToScreen(Vec2 world_pos) const {
+  Vec2 screen_pos;
+  screen_pos[0] = floorf((world_pos[0] - world_top_left_x_) / world_width_ * GetWidth());
+  screen_pos[1] = floorf((world_top_left_y_ - world_pos[1]) / world_height_ * GetHeight());
+  return screen_pos;
+}
+
+int GlCanvas::WorldToScreenHeight(float height) const {
+  return static_cast<int>(height / world_height_ * GetHeight());
+}
+
+int GlCanvas::WorldToScreenWidth(float width) const {
+  return static_cast<int>(width / world_width_ * GetWidth());
 }
 
 int GlCanvas::GetWidth() const { return screen_width_; }

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -41,10 +41,15 @@ class GlCanvas {
   void PrepareScreenSpaceViewport();
   void PrepareGlState();
   static void CleanupGlState();
+
   void ScreenToWorld(int x, int y, float& wx, float& wy) const;
-  Vec2 ScreenToWorld(Vec2 screen_pos);
+  Vec2 ScreenToWorld(Vec2 screen_pos) const;
   float ScreenToWorldHeight(int height) const;
   float ScreenToWorldWidth(int width) const;
+
+  Vec2 WorldToScreen(Vec2 world_pos) const;
+  int WorldToScreenHeight(float height) const;
+  int WorldToScreenWidth(float width) const;
 
   // events
   virtual void MouseMoved(int x, int y, bool left, bool right, bool middle);

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -7,7 +7,7 @@
 
 #include "GlUtils.h"
 #include "ImGuiOrbit.h"
-#include "OrbitAccessibility/AccessibleInterface.h"
+#include "OrbitAccessibility/AccessibleWidgetBridge.h"
 #include "PickingManager.h"
 #include "TextRenderer.h"
 #include "TimeGraph.h"
@@ -114,9 +114,7 @@ class GlCanvas {
 
   [[nodiscard]] PickingManager& GetPickingManager() { return picking_manager_; }
 
-  [[nodiscard]] orbit_accessibility::AccessibleInterface* Accessibility() {
-    return accessibility_.get();
-  }
+  [[nodiscard]] orbit_accessibility::AccessibleInterface* GetOrCreateAccessibleInterface();
 
   static float kZValueSlider;
   static float kZValueSliderBg;
@@ -145,7 +143,6 @@ class GlCanvas {
 
  protected:
   [[nodiscard]] PickingMode GetPickingMode();
-  virtual void CreateAccessibilityInterface();
 
   std::unique_ptr<orbit_accessibility::AccessibleInterface> accessibility_;
 
@@ -198,6 +195,10 @@ class GlCanvas {
   // Batcher to draw elements in the UI.
   Batcher ui_batcher_;
   std::vector<RenderCallback> render_callbacks_;
+
+ private:
+  [[nodiscard]] virtual std::unique_ptr<orbit_accessibility::AccessibleWidgetBridge>
+  CreateAccessibilityInterface();
 };
 
 #endif  // ORBIT_GL_GL_CANVAS_H_

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -38,7 +38,7 @@ using orbit_client_protos::TimerInfo;
 TimeGraph* GCurrentTimeGraph = nullptr;
 
 TimeGraph::TimeGraph(uint32_t font_size, OrbitApp* app)
-    : font_size_(font_size), batcher_(BatcherId::kTimeGraph), app_{app} {
+    : font_size_(font_size), accessibility_(this), batcher_(BatcherId::kTimeGraph), app_{app} {
   track_manager_ = std::make_unique<TrackManager>(this, app);
 
   async_timer_info_listener_ =

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -16,6 +16,7 @@
 #include <string>
 #include <vector>
 
+#include "AccessibleTimeGraph.h"
 #include "Batcher.h"
 #include "CoreMath.h"
 #include "CoreUtils.h"
@@ -178,6 +179,10 @@ class TimeGraph {
   void RemoveFrameTrack(const orbit_client_protos::FunctionInfo& function);
   [[nodiscard]] std::string GetThreadNameFromTid(uint32_t tid);
 
+  [[nodiscard]] const TimeGraphAccessibility* GetOrCreateAccessibleInterface() const {
+    return &accessibility_;
+  }
+
  protected:
   void ProcessOrbitFunctionTimer(orbit_client_protos::FunctionInfo::OrbitType type,
                                  const orbit_client_protos::TimerInfo& timer_info);
@@ -211,6 +216,8 @@ class TimeGraph {
   float right_margin_ = 0;
 
   TimeGraphLayout layout_;
+
+  TimeGraphAccessibility accessibility_;
 
   std::map<int32_t, uint32_t> thread_count_map_;
   uint32_t num_cores_;

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -16,7 +16,8 @@ Track::Track(TimeGraph* time_graph)
     : time_graph_(time_graph),
       collapse_toggle_(std::make_shared<TriangleToggle>(
           TriangleToggle::State::kExpanded,
-          [this](TriangleToggle::State state) { OnCollapseToggle(state); }, time_graph)) {
+          [this](TriangleToggle::State state) { OnCollapseToggle(state); }, time_graph)),
+      accessibility_(this, &time_graph->GetLayout()) {
   mouse_pos_[0] = mouse_pos_[1] = Vec2(0, 0);
   pos_ = Vec2(0, 0);
   size_ = Vec2(0, 0);

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#pragma once
+#ifndef ORBIT_GL_TRACK_H_
+#define ORBIT_GL_TRACK_H_
 
 #include <atomic>
 #include <memory>
@@ -17,6 +18,7 @@
 #include "TextRenderer.h"
 #include "TimeGraphLayout.h"
 #include "TimerChain.h"
+#include "TrackAccessibility.h"
 #include "TriangleToggle.h"
 
 class GlCanvas;
@@ -85,12 +87,17 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
   [[nodiscard]] const std::string& GetLabel() const { return label_; }
 
   void SetTimeGraph(TimeGraph* timegraph) { time_graph_ = timegraph; }
+  [[nodiscard]] TimeGraph* GetTimeGraph() { return time_graph_; }
+
   void SetPos(float a_X, float a_Y);
   void SetY(float y);
   [[nodiscard]] Vec2 GetPos() const { return pos_; }
   void SetSize(float a_SizeX, float a_SizeY);
+  [[nodiscard]] Vec2 GetSize() const { return size_; }
   void SetColor(Color a_Color) { color_ = a_Color; }
   [[nodiscard]] Color GetBackgroundColor() const;
+
+  [[nodiscard]] GlCanvas* GetCanvas() const { return canvas_; }
 
   void AddChild(std::shared_ptr<Track> track) { children_.emplace_back(track); }
   virtual void OnCollapseToggle(TriangleToggle::State state);
@@ -99,11 +106,18 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
   void SetProcessId(uint32_t pid) { process_id_ = pid; }
   [[nodiscard]] virtual bool IsEmpty() const = 0;
 
+  [[nodiscard]] virtual bool IsTrackSelected() const { return false; }
+
+  [[nodiscard]] bool IsCollapsed() const { return collapse_toggle_->IsCollapsed(); }
+
+  // Accessibility
+  [[nodiscard]] const orbit_gl::AccessibleTrack* AccessibilityInterface() const {
+    return &accessibility_;
+  }
+
  protected:
   void DrawTriangleFan(Batcher* batcher, const std::vector<Vec2>& points, const Vec2& pos,
                        const Color& color, float rotation, float z);
-
-  [[nodiscard]] virtual bool IsTrackSelected() const { return false; }
 
   GlCanvas* canvas_;
   TimeGraph* time_graph_;
@@ -128,4 +142,8 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
   Type type_ = kUnknown;
   std::vector<std::shared_ptr<Track>> children_;
   std::shared_ptr<TriangleToggle> collapse_toggle_;
+
+  orbit_gl::AccessibleTrack accessibility_;
 };
+
+#endif

--- a/OrbitGl/TrackAccessibility.cpp
+++ b/OrbitGl/TrackAccessibility.cpp
@@ -1,0 +1,128 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "TrackAccessibility.h"
+
+#include "GlCanvas.h"
+#include "Track.h"
+
+namespace orbit_gl {
+
+using orbit_accessibility::AccessibleInterface;
+
+const AccessibleInterface* AccessibleTrackContent::AccessibleParent() const {
+  return track_->AccessibilityInterface();
+}
+
+std::string AccessibleTrackContent::AccessibleName() const {
+  CHECK(track_ != nullptr);
+  return track_->GetName() + "_content";
+}
+
+AccessibilityRect AccessibleTrackContent::AccessibleLocalRect() const {
+  CHECK(track_ != nullptr);
+
+  GlCanvas* canvas = track_->GetCanvas();
+
+  return AccessibilityRect(canvas->WorldToScreenWidth(0),
+                           canvas->WorldToScreenHeight(layout_->GetTrackTabHeight()),
+                           canvas->WorldToScreenWidth(track_->GetSize()[0]),
+                           canvas->WorldToScreenHeight(track_->GetSize()[1]));
+}
+
+AccessibilityState AccessibleTrackContent::AccessibleState() const {
+  return AccessibilityState::Normal;
+}
+
+const AccessibleInterface* AccessibleTrackTab::AccessibleParent() const {
+  return track_->AccessibilityInterface();
+}
+
+std::string AccessibleTrackTab::AccessibleName() const {
+  CHECK(track_ != nullptr);
+  return track_->GetName() + "_tab";
+}
+
+AccessibilityRect AccessibleTrackTab::AccessibleLocalRect() const {
+  CHECK(track_ != nullptr);
+
+  GlCanvas* canvas = track_->GetCanvas();
+
+  return AccessibilityRect(canvas->WorldToScreenWidth(layout_->GetTrackTabOffset()),
+                           canvas->WorldToScreenHeight(0),
+                           canvas->WorldToScreenWidth(layout_->GetTrackTabWidth()),
+                           canvas->WorldToScreenHeight(layout_->GetTrackTabHeight()));
+}
+
+AccessibilityState AccessibleTrackTab::AccessibleState() const {
+  return AccessibilityState::Normal;
+}
+
+const AccessibleInterface* AccessibleTrack::AccessibleParent() const {
+  CHECK(track_ != nullptr);
+  return track_->GetTimeGraph()->GetOrCreateAccessibleInterface();
+}
+
+std::string AccessibleTrack::AccessibleName() const {
+  CHECK(track_ != nullptr);
+  return track_->GetName();
+}
+
+AccessibilityRect AccessibleTrack::AccessibleLocalRect() const {
+  CHECK(track_ != nullptr);
+  CHECK(track_->GetCanvas() != nullptr);
+
+  GlCanvas* canvas = track_->GetCanvas();
+  Vec2 pos = track_->GetPos();
+  pos[1] += layout_->GetTrackTabHeight();
+  Vec2 size = track_->GetSize();
+  size[1] += layout_->GetTrackTabHeight();
+
+  Vec2 screen_pos = canvas->WorldToScreen(pos);
+  int screen_width = canvas->WorldToScreenWidth(size[0]);
+  int screen_height = canvas->WorldToScreenHeight(size[1]);
+
+  // Adjust the coordinates to clamp the result to an on-screen rect
+  // This will "cut" any part that is offscreen due to scrolling, and may result
+  // in a final result with width / height of 0.
+
+  // First: Clamp bottom
+  if (screen_pos[1] + screen_height > canvas->GetHeight()) {
+    screen_height = std::max(0, canvas->GetHeight() - static_cast<int>(screen_pos[1]));
+  }
+  // Second: Clamp top
+  if (screen_pos[1] < 0) {
+    screen_height = std::max(0, static_cast<int>(screen_pos[1]) + screen_height);
+    screen_pos[1] = 0;
+  }
+
+  return AccessibilityRect(static_cast<int>(screen_pos[0]), static_cast<int>(screen_pos[1]),
+                           screen_width, screen_height);
+}
+
+AccessibilityState AccessibleTrack::AccessibleState() const {
+  CHECK(track_ != nullptr);
+
+  using State = orbit_accessibility::AccessibilityState;
+
+  State result = State::Normal | State::Focusable | State::Movable;
+  if (track_->IsTrackSelected()) {
+    result |= State::Focused;
+  }
+  if (track_->IsCollapsable()) {
+    result |= State::Expandable;
+    if (track_->IsCollapsed()) {
+      result |= State::Collapsed;
+    } else {
+      result |= State::Expanded;
+    }
+  }
+
+  if (AccessibleLocalRect().height == 0) {
+    result |= State::Offscreen;
+  }
+  return result;
+}
+
+}  // namespace orbit_gl

--- a/OrbitGl/TrackAccessibility.h
+++ b/OrbitGl/TrackAccessibility.h
@@ -1,0 +1,104 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_TRACK_ACCESSIBILITY_H_
+#define ORBIT_GL_TRACK_ACCESSIBILITY_H_
+
+#include "OrbitAccessibility/AccessibleInterface.h"
+#include "TimeGraphLayout.h"
+
+class Track;
+
+namespace orbit_gl {
+using orbit_accessibility::AccessibilityRect;
+using orbit_accessibility::AccessibilityRole;
+using orbit_accessibility::AccessibilityState;
+using orbit_accessibility::AccessibleInterface;
+
+/*
+ * Accessibility implementation for the track content.
+ * This is a "virtual" control and will be generated as a child of AccessibleTrack to split the
+ * areas for the track title and the content.
+ */
+class AccessibleTrackContent : public AccessibleInterface {
+ public:
+  AccessibleTrackContent(Track* track, TimeGraphLayout* layout) : track_(track), layout_(layout){};
+
+  [[nodiscard]] int AccessibleChildCount() const override { return 0; }
+  [[nodiscard]] const AccessibleInterface* AccessibleChild(int) const override { return nullptr; }
+  [[nodiscard]] const AccessibleInterface* AccessibleParent() const override;
+
+  [[nodiscard]] std::string AccessibleName() const override;
+  [[nodiscard]] AccessibilityRole AccessibleRole() const override {
+    return AccessibilityRole::Grouping;
+  }
+  [[nodiscard]] AccessibilityRect AccessibleLocalRect() const override;
+  [[nodiscard]] AccessibilityState AccessibleState() const override;
+
+ private:
+  Track* track_;
+  TimeGraphLayout* layout_;
+};
+
+/*
+ * Accessibility implementation for the track tab.
+ * This is a "virtual" control and will be generated as a child of AccessibleTrack to make the track
+ * tab clickable.
+ */
+class AccessibleTrackTab : public AccessibleInterface {
+ public:
+  AccessibleTrackTab(Track* track, TimeGraphLayout* layout) : track_(track), layout_(layout){};
+
+  [[nodiscard]] int AccessibleChildCount() const override { return 0; }
+  [[nodiscard]] const AccessibleInterface* AccessibleChild(int) const override { return nullptr; }
+  [[nodiscard]] const AccessibleInterface* AccessibleParent() const override;
+
+  [[nodiscard]] std::string AccessibleName() const override;
+  [[nodiscard]] AccessibilityRole AccessibleRole() const override {
+    return AccessibilityRole::PageTab;
+  }
+  [[nodiscard]] AccessibilityRect AccessibleLocalRect() const override;
+  [[nodiscard]] AccessibilityState AccessibleState() const override;
+
+ private:
+  Track* track_;
+  TimeGraphLayout* layout_;
+};
+
+/*
+ * Accessibility information for the track.
+ * This will return two "virtual" children to split the track tab and its content.
+ */
+class AccessibleTrack : public AccessibleInterface {
+ public:
+  AccessibleTrack(Track* track, TimeGraphLayout* layout)
+      : track_(track), layout_(layout), content_(track_, layout_), tab_(track_, layout_){};
+
+  [[nodiscard]] int AccessibleChildCount() const override { return 2; }
+  [[nodiscard]] const AccessibleInterface* AccessibleChild(int index) const override {
+    if (index == 0) {
+      return &tab_;
+    } else {
+      return &content_;
+    }
+  }
+  [[nodiscard]] const AccessibleInterface* AccessibleParent() const override;
+
+  [[nodiscard]] std::string AccessibleName() const override;
+  [[nodiscard]] AccessibilityRole AccessibleRole() const override {
+    return orbit_gl::AccessibilityRole::Grouping;
+  }
+  [[nodiscard]] AccessibilityRect AccessibleLocalRect() const override;
+  [[nodiscard]] AccessibilityState AccessibleState() const override;
+
+ private:
+  Track* track_;
+  TimeGraphLayout* layout_;
+  AccessibleTrackContent content_;
+  AccessibleTrackTab tab_;
+};
+
+}  // namespace orbit_gl
+
+#endif

--- a/OrbitQt/AccessibilityAdapter.cpp
+++ b/OrbitQt/AccessibilityAdapter.cpp
@@ -223,7 +223,7 @@ OrbitGlWidgetAccessible::OrbitGlWidgetAccessible(OrbitGLWidget* widget)
    */
   CHECK(widget->accessibleName() == "");
   AccessibilityAdapter::RegisterAdapter(
-      static_cast<OrbitGLWidget*>(widget)->GetCanvas()->Accessibility(), this);
+      static_cast<OrbitGLWidget*>(widget)->GetCanvas()->GetOrCreateAccessibleInterface(), this);
 }
 
 OrbitGlWidgetAccessible::~OrbitGlWidgetAccessible() {
@@ -233,7 +233,7 @@ OrbitGlWidgetAccessible::~OrbitGlWidgetAccessible() {
 int OrbitGlWidgetAccessible::childCount() const {
   return static_cast<OrbitGLWidget*>(widget())
       ->GetCanvas()
-      ->Accessibility()
+      ->GetOrCreateAccessibleInterface()
       ->AccessibleChildCount();
 }
 
@@ -248,8 +248,10 @@ int OrbitGlWidgetAccessible::indexOfChild(const QAccessibleInterface* child) con
 }
 
 QAccessibleInterface* OrbitGlWidgetAccessible::child(int index) const {
-  return AccessibilityAdapter::GetOrCreateAdapter(
-      static_cast<OrbitGLWidget*>(widget())->GetCanvas()->Accessibility()->AccessibleChild(index));
+  return AccessibilityAdapter::GetOrCreateAdapter(static_cast<OrbitGLWidget*>(widget())
+                                                      ->GetCanvas()
+                                                      ->GetOrCreateAccessibleInterface()
+                                                      ->AccessibleChild(index));
 }
 
 QAccessibleInterface* GlAccessibilityFactory(const QString& classname, QObject* object) {

--- a/OrbitQt/CMakeLists.txt
+++ b/OrbitQt/CMakeLists.txt
@@ -155,7 +155,7 @@ add_executable(OrbitQtTests)
 target_compile_options(OrbitQtTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(OrbitQtTests
-        PRIVATE
+        PRIVATE AccessibilityAdapter.h
                 CutoutWidget.h
                 EventLoop.h
                 TutorialOverlay.h)

--- a/OrbitQt/CMakeLists.txt
+++ b/OrbitQt/CMakeLists.txt
@@ -94,7 +94,11 @@ target_sources(
           TutorialOverlay.cpp
           TutorialOverlay.ui
           ../icons/orbiticons.qrc
-          ../images/orbitimages.qrc)
+          ../images/orbitimages.qrc
+          # Todo (176066030): OrbitGl relies on flags usually defined in the OrbitQt executable, so the
+          # tests needs this to link against them. To avoid multiple definitions, we compile the flags
+          # cpp with the tests
+          ../OrbitGl/ClientFlags.cpp)
 
 target_include_directories(OrbitQt PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -171,6 +175,7 @@ target_sources(OrbitQtTests
                 TutorialOverlayTest.cpp
                 TutorialOverlay.cpp
                 TutorialOverlay.ui
+                ../OrbitGl/ClientFlags.cpp
                 ../images/orbitimages.qrc)
 
 target_include_directories(OrbitQtTests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -65,43 +65,12 @@
 #include "CrashOptions.h"
 #endif
 
-ABSL_FLAG(bool, enable_stale_features, false,
-          "Enable obsolete features that are not working or are not "
-          "implemented in the client's UI");
-
-ABSL_FLAG(bool, devmode, false, "Enable developer mode in the client's UI");
-
-ABSL_FLAG(bool, nodeploy, false, "Disable automatic deployment of OrbitService");
-
-ABSL_FLAG(std::string, collector, "", "Full path of collector to be deployed");
-
-ABSL_FLAG(std::string, collector_root_password, "", "Collector's machine root password");
-
-ABSL_FLAG(uint16_t, grpc_port, 44765,
-          "The service's GRPC server port (use default value if unsure)");
-ABSL_FLAG(bool, local, false, "Connects to local instance of OrbitService");
-
-ABSL_FLAG(bool, enable_tutorials_feature, false, "Enable tutorials");
-
-// TODO(b/160549506): Remove this flag once it can be specified in the ui.
-ABSL_FLAG(uint16_t, sampling_rate, 1000, "Frequency of callstack sampling in samples per second");
-
-// TODO(b/160549506): Remove this flag once it can be specified in the ui.
-ABSL_FLAG(bool, frame_pointer_unwinding, false, "Use frame pointers for unwinding");
-
-// TODO(kuebler): remove this once we have the validator complete
-ABSL_FLAG(bool, enable_frame_pointer_validator, false, "Enable validation of frame pointers");
-
-// TODO: Remove this flag once we have a way to toggle the display return values
-ABSL_FLAG(bool, show_return_values, false, "Show return values on time slices");
-
-ABSL_FLAG(bool, enable_tracepoint_feature, false,
-          "Enable the setting of the panel of kernel tracepoints");
-
-ABSL_FLAG(bool, thread_state, false, "Collect thread states");
-
-// TODO(170468590): [ui beta] Remove this flag when the new UI is finished
-ABSL_FLAG(bool, enable_ui_beta, false, "Enable the new user interface");
+ABSL_DECLARE_FLAG(uint16_t, grpc_port);
+ABSL_DECLARE_FLAG(std::string, collector_root_password);
+ABSL_DECLARE_FLAG(std::string, collector);
+ABSL_DECLARE_FLAG(bool, local);
+ABSL_DECLARE_FLAG(bool, devmode);
+ABSL_DECLARE_FLAG(bool, nodeploy);
 
 using ServiceDeployManager = orbit_qt::ServiceDeployManager;
 using DeploymentConfiguration = orbit_qt::DeploymentConfiguration;

--- a/OrbitQt/main.cpp
+++ b/OrbitQt/main.cpp
@@ -8,6 +8,7 @@
 #include <absl/flags/usage_config.h>
 #include <absl/strings/str_format.h>
 
+#include <QAccessible>
 #include <QApplication>
 #include <QByteArray>
 #include <QColor>
@@ -42,6 +43,7 @@
 #include <unistd.h>
 #endif
 
+#include "AccessibilityAdapter.h"
 #include "Connections.h"
 #include "DeploymentConfigurations.h"
 #include "Error.h"
@@ -136,6 +138,7 @@ static outcome::result<void> RunUiInstance(
 
   std::optional<std::error_code> error;
 
+  orbit_qt::InstallAccessibilityFactories();
   {  // Scoping of QT UI Resources
     constexpr uint32_t kDefaultFontSize = 14;
 


### PR DESCRIPTION
Adds accessibility information for `CaptureWindow`, `TimeGraph` and `Track`.

I've decided to not introduce a new base class for our UI elements for now, and instead create custom accessibility interfaces for this. We may want to introduce this later nevertheless to handle at least parent / child relationships and maybe relative positioning, but in this case it will be straightforward to generalize these existing interfaces.

This PR is split into multiple commits that can be reviewed one by one.