### PR TITLE
E2E Framework fixes

### DIFF
--- a/contrib/automation_tests/core/orbit_e2e.py
+++ b/contrib/automation_tests/core/orbit_e2e.py
@@ -6,6 +6,7 @@ found in the LICENSE file.
 
 import logging
 from typing import Iterable, Type
+from collections import deque
 
 from absl import flags
 from pywinauto import Application, timings
@@ -22,26 +23,27 @@ class OrbitE2EError(RuntimeError):
 
 
 class Fragment:
-    def __init__(self):
+    def __init__(self, **kwargs):
         self._e2e_test = None
+        self._args = kwargs
 
     e2e_test = property(lambda self: self._e2e_test)
 
-    def execute(self, e2e_test):
+    def execute(self, e2e_test: "E2ETest"):
         self._e2e_test = e2e_test
-        self._execute()
+        self._execute(**self._args)
 
     def expect_true(self, cond, description):
         if not cond:
-            raise OrbitE2EError('Error executing test case %s, fragment %s. Condition did not hold: "%s"' %
+            raise OrbitE2EError('Error executing test case %s, fragment %s. Condition expected to be True: "%s"' %
                                 (self.e2e_test.name, self.__class__.__name__, description))
 
     def expect_eq(self, left, right, description):
         self.expect_true(left == right, description)
 
-    def _execute(self):
+    def _execute(self, **kwargs):
         """
-        Override this in your fragment
+        Provide this method in your fragment
         """
         pass
 
@@ -71,6 +73,7 @@ class E2ETest:
 
     def set_up(self):
         timings.Timings.after_click_wait = 0.5
+        timings.Timings.after_clickinput_wait = 0.5
         ot.wait_for_orbit()
         logging.info("Setting up with dev_mode = %s", self.dev_mode)
         if not self.dev_mode:
@@ -98,21 +101,44 @@ class E2ETest:
 
 
 def find_control(parent: BaseWrapper, control_type, name=None, name_contains=None,
-                 auto_id_leaf=None, qt_class=None) -> BaseWrapper:
+                 auto_id_leaf=None, qt_class=None, recurse=True) -> BaseWrapper:
     """
     Returns the first child of BaseWrapper that matches all of the search parameters.
     As soon as a matching child is encountered, this function returns.
 
     If no child is found, an exception is thrown.
     """
-    desc = parent.descendants(control_type=control_type)
+    if not recurse:
+        desc = parent.children(control_type=control_type)
+    else:
+        desc = parent.descendants(control_type=control_type)
 
     for elem in desc:
+        # This seems to be a lot more reliable than the properties exposed by the wrapper element
+        # At least, this seems to consistently return the accessible name if it exists...
+        elem_name = elem.element_info.element.CurrentName
+        elem_text = elem.texts()[0] if elem.texts() else ""
         if (not qt_class or elem.class_name() == qt_class) and \
-                (not name or elem.texts()[0] == name) and \
-                (not name_contains or name_contains in elem.texts()[0]) and \
+                (not name or elem.texts()[0] == name or elem_name == name) and \
+                (not name_contains or name_contains in elem.texts()[0] or name_contains in name) and \
                 (not auto_id_leaf or elem.automation_id().rsplit(".", 1)[-1]):
             return elem
 
-    raise OrbitE2EError('Could not find element of type %s (name="%s", name_contains="%s", qt_class=%s)' %
+    # If a name was given, try the magic lookup to give a hint what was wrong
+    if name:
+        try:
+            candidate = parent.__getattribute__(name)
+        except:
+            candidate = None
+
+        if candidate:
+            logging.error("Could not find the control you were looking for, but found a potential candidate: %s. "
+                          "Printing control identifiers.",
+                          candidate)
+            candidate.print_control_identifiers()
+        else:
+            logging.error("Could not find the control you were looking for. Tried magic, didn't work.")
+
+    raise OrbitE2EError('Could not find element of type %s (name="%s", name_contains="%s", qt_class="%s"). The log '
+                        'above may contain more details.' %
                         (control_type, name, name_contains, qt_class))

--- a/contrib/automation_tests/fragments/move_tabs.py
+++ b/contrib/automation_tests/fragments/move_tabs.py
@@ -22,10 +22,10 @@ class MoveFunctionsTab(Fragment):
         tab_item = find_control(wnd, "TabItem", name="Functions")
         right_tab_bar = find_control(
             find_control(wnd, "Group", name="RightTabWidget"),
-            "Tab")
+            "Tab", recurse=False)
         left_tab_bar = find_control(
             find_control(wnd, "Group", name="MainTabWidget"),
-            "Tab")
+            "Tab", recurse=False)
 
         # Init tests
         left_tab_count = left_tab_bar.control_count()

--- a/contrib/automation_tests/fragments/move_tabs.py
+++ b/contrib/automation_tests/fragments/move_tabs.py
@@ -6,17 +6,17 @@ found in the LICENSE file.
 
 import logging
 
-from core.orbit_e2e import Fragment, find_control
+from core.orbit_e2e import E2ETestCase, find_control
 
 
-class MoveFunctionsTab(Fragment):
+class MoveFunctionsTab(E2ETestCase):
     def right_click_move_context(self, item):
         item.click_input(button='right')
-        context_menu = self.e2e_test.application.window(best_match="TabBarContextMenu")
+        context_menu = self.suite.application.window(best_match="TabBarContextMenu")
         find_control(context_menu, "MenuItem", name_contains="Move").click_input(button='left')
 
     def _execute(self):
-        wnd = self.e2e_test.top_window()
+        wnd = self.suite.top_window()
 
         # Find "Functions" tab and left and right tab bar
         tab_item = find_control(wnd, "TabItem", name="Functions")

--- a/contrib/automation_tests/orbit_move_tabs.py
+++ b/contrib/automation_tests/orbit_move_tabs.py
@@ -6,14 +6,14 @@ found in the LICENSE file.
 
 from absl import app
 
-from core.orbit_e2e import E2ETest
+from core.orbit_e2e import E2ETestSuite
 from fragments.move_tabs import MoveFunctionsTab
 
 
 def main(argv):
-    fragments = [MoveFunctionsTab()]
-    test = E2ETest(test_name="Move tabs", fragments=fragments)
-    test.execute()
+    tests = [MoveFunctionsTab()]
+    suite = E2ETestSuite(test_name="Move tabs", tests=tests)
+    suite.execute()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Several fixes / updates to the E2E tests before merging the capture window tests.

- `find_control` did not always work as expected. For some control types, the AccessibleName was not returned as expected, and it looks like pywinauto is not exposing this in all cases. I've changed it to use the underlying COM functionality now, this seems to work a lot more reliable
- `find_control` can be instructed to not recurse
- Renamed `E2ETest` and `Fragment` to `E2ETestSuite` and `E2ETestCase` as this is clearer and more common