### PR TITLE
Clean TimeGraph dependences from TrackManager/Track

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -357,8 +357,6 @@ void OrbitApp::PostInit() {
 
   string_manager_ = std::make_shared<StringManager>();
 
-  GCurrentTimeGraph->SetStringManager(string_manager_);
-
   if (!absl::GetFlag(FLAGS_enable_tracepoint_feature)) {
     return;
   }
@@ -769,8 +767,7 @@ PresetLoadState OrbitApp::GetPresetLoadState(
 }
 
 ErrorMessageOr<void> OrbitApp::OnSaveCapture(const std::string& file_name) {
-  const auto& key_to_string_map =
-      GCurrentTimeGraph->GetTrackManager()->GetStringManager()->GetKeyToStringMap();
+  const auto& key_to_string_map = string_manager_->GetKeyToStringMap();
 
   std::vector<std::shared_ptr<TimerChain>> chains =
       GCurrentTimeGraph->GetAllSerializableTimerChains();

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -306,6 +306,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
 
   void CrashOrbitService(orbit_grpc_protos::CrashOrbitServiceRequest_CrashType crash_type);
 
+  [[nodiscard]] StringManager* GetStringManager() { return string_manager_.get(); }
   void SetGrpcChannel(std::shared_ptr<grpc::Channel> grpc_channel) {
     CHECK(grpc_channel_ == nullptr);
     CHECK(grpc_channel != nullptr);

--- a/OrbitGl/AsyncTrack.cpp
+++ b/OrbitGl/AsyncTrack.cpp
@@ -16,8 +16,8 @@ using orbit_client_protos::TimerInfo;
 
 AsyncTrack::AsyncTrack(TimeGraph* time_graph, const std::string& name, OrbitApp* app)
     : TimerTrack(time_graph, app) {
-  SetName(name);
-  SetLabel(name);
+  name_ = name;
+  label_ = name;
 }
 
 [[nodiscard]] std::string AsyncTrack::GetBoxTooltip(PickingId id) const {
@@ -111,7 +111,7 @@ Color AsyncTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected) c
   orbit_api::Event event = ManualInstrumentationManager::ApiEventFromTimerInfo(timer_info);
   const uint64_t event_id = event.data;
   std::string name = app_->GetManualInstrumentationManager()->GetString(event_id);
-  Color color = time_graph_->GetColor(name);
+  Color color = TimeGraph::GetColor(name);
 
   constexpr uint8_t kOddAlpha = 210;
   if (!(timer_info.depth() & 0x1)) {

--- a/OrbitGl/EventTrack.cpp
+++ b/OrbitGl/EventTrack.cpp
@@ -76,8 +76,7 @@ void EventTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingM
 
   const Color kWhite(255, 255, 255, 255);
   const Color kGreenSelection(0, 255, 0, 255);
-  const CaptureData* capture_data = time_graph_->GetCaptureData();
-  CHECK(capture_data != nullptr);
+  const CaptureData& capture_data = app_->GetCaptureData();
 
   if (!picking) {
     // Sampling Events
@@ -90,10 +89,10 @@ void EventTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingM
     };
 
     if (thread_id_ == orbit_base::kAllProcessThreadsTid) {
-      capture_data->GetCallstackData()->ForEachCallstackEvent(action_on_callstack_events);
+      capture_data.GetCallstackData()->ForEachCallstackEvent(action_on_callstack_events);
     } else {
-      capture_data->GetCallstackData()->ForEachCallstackEventOfTid(thread_id_,
-                                                                   action_on_callstack_events);
+      capture_data.GetCallstackData()->ForEachCallstackEventOfTid(thread_id_,
+                                                                  action_on_callstack_events);
     }
 
     // Draw selected events
@@ -122,10 +121,10 @@ void EventTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingM
       }
     };
     if (thread_id_ == orbit_base::kAllProcessThreadsTid) {
-      capture_data->GetCallstackData()->ForEachCallstackEvent(action_on_callstack_events);
+      capture_data.GetCallstackData()->ForEachCallstackEvent(action_on_callstack_events);
     } else {
-      capture_data->GetCallstackData()->ForEachCallstackEventOfTid(thread_id_,
-                                                                   action_on_callstack_events);
+      capture_data.GetCallstackData()->ForEachCallstackEventOfTid(thread_id_,
+                                                                  action_on_callstack_events);
     }
   }
 }
@@ -163,32 +162,29 @@ void EventTrack::SelectEvents() {
 }
 
 bool EventTrack::IsEmpty() const {
-  const CaptureData* capture_data = time_graph_->GetCaptureData();
-  if (capture_data == nullptr) return true;
+  if (!app_->HasCaptureData()) return true;
+  const CaptureData& capture_data = app_->GetCaptureData();
   const uint32_t callstack_count =
       (thread_id_ == orbit_base::kAllProcessThreadsTid)
-          ? capture_data->GetCallstackData()->GetCallstackEventsCount()
-          : capture_data->GetCallstackData()->GetCallstackEventsOfTidCount(thread_id_);
+          ? capture_data.GetCallstackData()->GetCallstackEventsCount()
+          : capture_data.GetCallstackData()->GetCallstackEventsOfTidCount(thread_id_);
   return callstack_count == 0;
 }
 
 [[nodiscard]] uint64_t EventTrack::GetMinTime() const {
-  const CaptureData* capture_data = time_graph_->GetCaptureData();
-  CHECK(capture_data != nullptr);
-  return capture_data->GetCallstackData()->min_time();
+  const CaptureData& capture_data = app_->GetCaptureData();
+  return capture_data.GetCallstackData()->min_time();
 }
 
 [[nodiscard]] uint64_t EventTrack::GetMaxTime() const {
-  const CaptureData* capture_data = time_graph_->GetCaptureData();
-  CHECK(capture_data != nullptr);
-  return capture_data->GetCallstackData()->max_time();
+  const CaptureData& capture_data = app_->GetCaptureData();
+  return capture_data.GetCallstackData()->max_time();
 }
 
 [[nodiscard]] std::string EventTrack::SafeGetFormattedFunctionName(uint64_t addr,
                                                                    int max_line_length) const {
-  const CaptureData* capture_data = time_graph_->GetCaptureData();
-  CHECK(capture_data != nullptr);
-  const std::string& function_name = capture_data->GetFunctionNameByAddress(addr);
+  const CaptureData& capture_data = app_->GetCaptureData();
+  const std::string& function_name = capture_data.GetFunctionNameByAddress(addr);
   if (function_name == CaptureData::kUnknownFunctionOrModuleName) {
     return std::string("<i>") + function_name + "</i>";
   }
@@ -237,9 +233,8 @@ std::string EventTrack::GetSampleTooltip(PickingId id) const {
     return unknown_return_text;
   }
 
-  const CaptureData* capture_data = time_graph_->GetCaptureData();
-  CHECK(capture_data != nullptr);
-  const CallstackData* callstack_data = capture_data->GetCallstackData();
+  const CaptureData& capture_data = app_->GetCaptureData();
+  const CallstackData* callstack_data = capture_data.GetCallstackData();
   const auto* callstack_event = static_cast<const CallstackEvent*>(user_data->custom_data_);
 
   uint64_t callstack_hash = callstack_event->callstack_hash();

--- a/OrbitGl/FrameTrack.cpp
+++ b/OrbitGl/FrameTrack.cpp
@@ -67,9 +67,8 @@ FrameTrack::FrameTrack(TimeGraph* time_graph, const FunctionInfo& function, Orbi
     : TimerTrack(time_graph, app), function_(function) {
   // TODO(b/169554463): Support manual instrumentation.
   std::string function_name = function_utils::GetDisplayName(function_);
-  std::string name = absl::StrFormat("Frame track based on %s", function_name);
-  SetName(name);
-  SetLabel(name);
+  name_ = absl::StrFormat("Frame track based on %s", function_name);
+  label_ = name_;
 
   // Frame tracks are collapsed by default.
   collapse_toggle_->SetState(TriangleToggle::State::kCollapsed,

--- a/OrbitGl/GpuTrack.h
+++ b/OrbitGl/GpuTrack.h
@@ -25,8 +25,7 @@ std::string MapGpuTimelineToTrackLabel(std::string_view timeline);
 
 class GpuTrack : public TimerTrack {
  public:
-  explicit GpuTrack(TimeGraph* time_graph, StringManager* string_manager, uint64_t timeline_hash,
-                    OrbitApp* app);
+  explicit GpuTrack(TimeGraph* time_graph, uint64_t timeline_hash, OrbitApp* app);
   ~GpuTrack() override = default;
   [[nodiscard]] std::string GetTooltip() const override;
   [[nodiscard]] Type GetType() const override { return kGpuTrack; }

--- a/OrbitGl/GraphTrack.cpp
+++ b/OrbitGl/GraphTrack.cpp
@@ -7,7 +7,9 @@
 #include "GlCanvas.h"
 
 GraphTrack::GraphTrack(TimeGraph* time_graph, std::string name)
-    : Track(time_graph), name_(std::move(name)) {}
+    : Track(time_graph), name_(std::move(name)) {
+  label_ = name_;
+}
 
 void GraphTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode,
                                   float z_offset) {

--- a/OrbitGl/IntrospectionWindow.cpp
+++ b/OrbitGl/IntrospectionWindow.cpp
@@ -10,7 +10,6 @@ using orbit_client_protos::TimerInfo;
 
 IntrospectionWindow::IntrospectionWindow(uint32_t font_size, OrbitApp* app)
     : CaptureWindow(font_size, app) {
-  time_graph_.SetStringManager(std::make_shared<StringManager>());
 }
 
 IntrospectionWindow::~IntrospectionWindow() { StopIntrospection(); }

--- a/OrbitGl/SchedulerTrack.h
+++ b/OrbitGl/SchedulerTrack.h
@@ -14,6 +14,7 @@ class SchedulerTrack final : public TimerTrack {
  public:
   explicit SchedulerTrack(TimeGraph* time_graph, OrbitApp* app);
   ~SchedulerTrack() override = default;
+  void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
 
   [[nodiscard]] Type GetType() const override { return kSchedulerTrack; }
   [[nodiscard]] std::string GetTooltip() const override;
@@ -29,6 +30,9 @@ class SchedulerTrack final : public TimerTrack {
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
                                     bool is_selected) const override;
   [[nodiscard]] std::string GetBoxTooltip(PickingId id) const override;
+
+ private:
+  uint32_t num_cores_;
 };
 
 #endif  // ORBIT_GL_SCHEDULER_TRACK_H_

--- a/OrbitGl/ThreadTrack.h
+++ b/OrbitGl/ThreadTrack.h
@@ -31,16 +31,17 @@ class ThreadTrack final : public TimerTrack {
   void OnPick(int x, int y) override;
 
   void UpdateBoxHeight() override;
-  void SetTrackColor(Color color);
   [[nodiscard]] bool IsEmpty() const override;
 
   void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode,
                         float z_offset = 0) override;
 
  protected:
+  void InitializeNameAndLabel(int32_t thread_id);
   [[nodiscard]] bool IsTimerActive(const orbit_client_protos::TimerInfo& timer) const override;
   [[nodiscard]] virtual bool IsTrackSelected() const override;
 
+  void SetTrackColor(Color color);
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer,
                                     bool is_selected) const override;
   void SetTimesliceText(const orbit_client_protos::TimerInfo& timer, double elapsed_us, float min_x,
@@ -56,6 +57,8 @@ class ThreadTrack final : public TimerTrack {
   std::shared_ptr<ThreadStateTrack> thread_state_track_;
   std::shared_ptr<EventTrack> event_track_;
   std::shared_ptr<TracepointTrack> tracepoint_track_;
+
+  OrbitApp* app_ = nullptr;
 };
 
 #endif  // ORBIT_GL_THREAD_TRACK_H_

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -46,17 +46,12 @@ TimeGraph::TimeGraph(uint32_t font_size, OrbitApp* app)
           [this](const std::string& name, const TimerInfo& timer_info) {
             ProcessAsyncTimer(name, timer_info);
           });
-  num_cores_ = 0;
   manual_instrumentation_manager_ = app_->GetManualInstrumentationManager();
   manual_instrumentation_manager_->AddAsyncTimerListener(async_timer_info_listener_.get());
 }
 
 TimeGraph::~TimeGraph() {
   manual_instrumentation_manager_->RemoveAsyncTimerListener(async_timer_info_listener_.get());
-}
-
-void TimeGraph::SetStringManager(std::shared_ptr<StringManager> str_manager) {
-  track_manager_->SetStringManager(str_manager.get());
 }
 
 void TimeGraph::SetCanvas(GlCanvas* canvas) {
@@ -269,12 +264,6 @@ void TimeGraph::ProcessTimer(const TimerInfo& timer_info, const FunctionInfo* fu
     } else {
       auto scheduler_track = track_manager_->GetOrCreateSchedulerTrack();
       scheduler_track->OnTimer(timer_info);
-      if (GetNumCores() <= static_cast<uint32_t>(timer_info.processor())) {
-        auto num_cores = timer_info.processor() + 1;
-        SetNumCores(num_cores);
-        layout_.SetNumCores(num_cores);
-        scheduler_track->SetLabel(absl::StrFormat("Scheduler (%u cores)", num_cores));
-      }
     }
   }
 
@@ -517,7 +506,7 @@ void TimeGraph::NeedsUpdate() {
 
 void TimeGraph::UpdatePrimitives(PickingMode picking_mode) {
   ORBIT_SCOPE_FUNCTION;
-  CHECK(track_manager_->GetStringManager() != nullptr);
+  CHECK(app_->GetStringManager() != nullptr);
 
   batcher_.StartNewFrame();
   text_renderer_static_.Clear();

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -23,7 +23,6 @@
 #include "ManualInstrumentationManager.h"
 #include "OrbitClientModel/CaptureData.h"
 #include "PickingManager.h"
-#include "StringManager.h"
 #include "TextBox.h"
 #include "TextRenderer.h"
 #include "TimeGraphLayout.h"
@@ -123,7 +122,6 @@ class TimeGraph {
   }
   [[nodiscard]] Batcher& GetBatcher() { return batcher_; }
   [[nodiscard]] uint32_t GetNumTimers() const;
-  [[nodiscard]] uint32_t GetNumCores() const { return num_cores_; }
   [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllTimerChains() const;
   [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllThreadTrackTimerChains() const;
   [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllSerializableTimerChains() const;
@@ -190,7 +188,6 @@ class TimeGraph {
   void ProcessValueTrackingTimer(const orbit_client_protos::TimerInfo& timer_info);
   void ProcessAsyncTimer(const std::string& track_name,
                          const orbit_client_protos::TimerInfo& timer_info);
-  void SetNumCores(uint32_t num_cores) { num_cores_ = num_cores; }
 
  private:
   uint32_t font_size_;
@@ -220,7 +217,6 @@ class TimeGraph {
   TimeGraphAccessibility accessibility_;
 
   std::map<int32_t, uint32_t> thread_count_map_;
-  uint32_t num_cores_;
   // Be careful when directly changing these members without using the
   // methods NeedsRedraw() or NeedsUpdate():
   // needs_update_primitives_ should always imply needs_redraw_, that is

--- a/OrbitGl/TimeGraphLayout.cpp
+++ b/OrbitGl/TimeGraphLayout.cpp
@@ -7,7 +7,6 @@
 #include "ImGuiOrbit.h"
 
 TimeGraphLayout::TimeGraphLayout() {
-  num_cores_ = 0;
   text_box_height_ = 20.f;
   core_height_ = 10.f;
   thread_state_track_height_ = 4.0f;

--- a/OrbitGl/TimeGraphLayout.h
+++ b/OrbitGl/TimeGraphLayout.h
@@ -38,13 +38,10 @@ class TimeGraphLayout {
   float GetScale() const { return scale_; }
   void SetScale(float value) { scale_ = value; }
   void SetDrawProperties(bool value) { draw_properties_ = value; }
-  void SetNumCores(int a_NumCores) { num_cores_ = a_NumCores; }
   bool DrawProperties();
   bool GetDrawTrackBackground() const { return draw_track_background_; }
 
  protected:
-  int num_cores_;
-
   float text_box_height_;
   float core_height_;
   float thread_state_track_height_;

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -169,7 +169,7 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
 
     text_renderer.AddTextTrailingCharsPrioritized(
         label_.c_str(), tab_x0 + label_offset_x, toggle_y_pos - label_offset_y, text_z, kColor,
-        GetNumberOfPrioritizedTrailingCharacters(), font_size, label_width - label_offset_x);
+        num_prioritized_trailing_characters_, font_size, label_width - label_offset_x);
   }
 
   canvas_ = canvas;

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -61,12 +61,6 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
   [[nodiscard]] uint32_t GetNumTimers() const { return num_timers_; }
   [[nodiscard]] virtual uint64_t GetMinTime() const { return min_time_; }
   [[nodiscard]] virtual uint64_t GetMaxTime() const { return max_time_; }
-  void SetNumberOfPrioritizedTrailingCharacters(int num_characters) {
-    num_prioritized_trailing_characters_ = num_characters;
-  }
-  [[nodiscard]] int GetNumberOfPrioritizedTrailingCharacters() const {
-    return num_prioritized_trailing_characters_;
-  }
 
   [[nodiscard]] virtual std::vector<std::shared_ptr<TimerChain>> GetTimers() const { return {}; }
   [[nodiscard]] virtual std::vector<std::shared_ptr<TimerChain>> GetAllChains() const { return {}; }
@@ -81,12 +75,9 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
   [[nodiscard]] Vec2 GetMoveDelta() const {
     return moving_ ? mouse_pos_[1] - mouse_pos_[0] : Vec2(0, 0);
   }
-  void SetName(const std::string& name) { name_ = name; }
   [[nodiscard]] const std::string& GetName() const { return name_; }
-  void SetLabel(const std::string& label) { label_ = label; }
   [[nodiscard]] const std::string& GetLabel() const { return label_; }
 
-  void SetTimeGraph(TimeGraph* timegraph) { time_graph_ = timegraph; }
   [[nodiscard]] TimeGraph* GetTimeGraph() { return time_graph_; }
 
   void SetPos(float a_X, float a_Y);

--- a/OrbitGl/TrackManager.h
+++ b/OrbitGl/TrackManager.h
@@ -46,9 +46,6 @@ class TrackManager {
     return tracepoints_system_wide_track_;
   }
 
-  void SetStringManager(StringManager* str_manager);
-  [[nodiscard]] const StringManager* GetStringManager() const { return string_manager_; }
-
   void SortTracks();
   void SetFilter(const std::string& filter);
 
@@ -98,7 +95,6 @@ class TrackManager {
   std::vector<Track*> visible_tracks_;
 
   float tracks_total_height_;
-  StringManager* string_manager_;
 
   OrbitApp* app_ = nullptr;
 };


### PR DESCRIPTION
In the process of making UnitTests for the Tracks, we want to erase
most dependences to TimeGraph to easily test TrackManager. Also we want
to get rid of the circular dependence from TimeGraph and the Tracks.

In this PR we:

 - Use correctly TimeGraph static methods.

 - Get CaptureData from App instead of TimeGraph (CaptureData now isn't
 on TimeGraph anymore).

 - Get StringManager from App instead of passing throught the classes.
 It is only used in GpuTrack.

 - Move initialization (Name, Label, ...) inside the Tracks and no inside
 TrackManager. Now GetOrCreate methods are really similar and could be
 templatized in the future or we can have an only list of tracks and
 easily get from there.

Bugs related:
https://b/176086740
https://b/176056427

Tested with the new_ui: Start a new capture/Load a capture/End session
and load it again.