### PR TITLE
Some E2E Tests for tracks in the capture window

### DIFF
--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -20,6 +20,7 @@ const Color kSelectionColor(0, 128, 255, 255);
 
 SchedulerTrack::SchedulerTrack(TimeGraph* time_graph, OrbitApp* app) : TimerTrack(time_graph, app) {
   SetPinned(false);
+  SetName("Scheduler");
 }
 
 float SchedulerTrack::GetHeight() const {

--- a/OrbitQt/orbitmainwindow.ui
+++ b/OrbitQt/orbitmainwindow.ui
@@ -14,7 +14,7 @@
    <string>Orbit Profiler</string>
   </property>
   <property name="styleSheet">
-   <string notr="true">QLineEdit[accessibleName=&quot;filter&quot;] {
+   <string notr="true">QLineEdit[clearButtonEnabled=&quot;true&quot;] {
 	background-image: url(:/actions/search_small_offset);
 	background-position: left center;
 	background-repeat: no-repeat;
@@ -116,6 +116,9 @@ QPushButton:disabled {
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
+           <property name="accessibleName">
+            <string>CaptureToolBar</string>
+           </property>
            <addaction name="actionToggle_Capture"/>
            <addaction name="actionClear_Capture"/>
            <addaction name="actionOpen_Capture"/>
@@ -148,7 +151,7 @@ QPushButton:disabled {
             <item>
              <widget class="QLineEdit" name="filterTracks">
               <property name="accessibleName">
-               <string>filter</string>
+               <string>FilterTracks</string>
               </property>
               <property name="styleSheet">
                <string notr="true">QLineEdit {
@@ -166,7 +169,7 @@ QPushButton:disabled {
             <item>
              <widget class="QLineEdit" name="filterFunctions">
               <property name="accessibleName">
-               <string>filter</string>
+               <string>FilterFunctions</string>
               </property>
               <property name="placeholderText">
                <string>Filter Functions</string>

--- a/contrib/automation_tests/core/orbit_e2e.py
+++ b/contrib/automation_tests/core/orbit_e2e.py
@@ -6,6 +6,7 @@ found in the LICENSE file.
 
 import logging
 from typing import Iterable, Type
+from collections import deque
 
 from absl import flags
 from pywinauto import Application, timings
@@ -22,26 +23,27 @@ class OrbitE2EError(RuntimeError):
 
 
 class Fragment:
-    def __init__(self):
+    def __init__(self, **kwargs):
         self._e2e_test = None
+        self._args = kwargs
 
     e2e_test = property(lambda self: self._e2e_test)
 
-    def execute(self, e2e_test):
+    def execute(self, e2e_test: "E2ETest"):
         self._e2e_test = e2e_test
-        self._execute()
+        self._execute(**self._args)
 
     def expect_true(self, cond, description):
         if not cond:
-            raise OrbitE2EError('Error executing test case %s, fragment %s. Condition did not hold: "%s"' %
+            raise OrbitE2EError('Error executing test case %s, fragment %s. Condition expected to be True: "%s"' %
                                 (self.e2e_test.name, self.__class__.__name__, description))
 
     def expect_eq(self, left, right, description):
         self.expect_true(left == right, description)
 
-    def _execute(self):
+    def _execute(self, **kwargs):
         """
-        Override this in your fragment
+        Provide this method in your fragment
         """
         pass
 
@@ -71,6 +73,7 @@ class E2ETest:
 
     def set_up(self):
         timings.Timings.after_click_wait = 0.5
+        timings.Timings.after_clickinput_wait = 0.5
         ot.wait_for_orbit()
         logging.info("Setting up with dev_mode = %s", self.dev_mode)
         if not self.dev_mode:
@@ -98,21 +101,44 @@ class E2ETest:
 
 
 def find_control(parent: BaseWrapper, control_type, name=None, name_contains=None,
-                 auto_id_leaf=None, qt_class=None) -> BaseWrapper:
+                 auto_id_leaf=None, qt_class=None, recurse=True) -> BaseWrapper:
     """
     Returns the first child of BaseWrapper that matches all of the search parameters.
     As soon as a matching child is encountered, this function returns.
 
     If no child is found, an exception is thrown.
     """
-    desc = parent.descendants(control_type=control_type)
+    if not recurse:
+        desc = parent.children(control_type=control_type)
+    else:
+        desc = parent.descendants(control_type=control_type)
 
     for elem in desc:
+        # This seems to be a lot more reliable than the properties exposed by the wrapper element
+        # At least, this seems to consistently return the accessible name if it exists...
+        elem_name = elem.element_info.element.CurrentName
+        elem_text = elem.texts()[0] if elem.texts() else ""
         if (not qt_class or elem.class_name() == qt_class) and \
-                (not name or elem.texts()[0] == name) and \
-                (not name_contains or name_contains in elem.texts()[0]) and \
+                (not name or elem_text == name or elem_name == name) and \
+                (not name_contains or name_contains in elem_text or name_contains in elem_name) and \
                 (not auto_id_leaf or elem.automation_id().rsplit(".", 1)[-1]):
             return elem
 
-    raise OrbitE2EError('Could not find element of type %s (name="%s", name_contains="%s", qt_class=%s)' %
+    # If a name was given, try the magic lookup to give a hint what was wrong
+    if name:
+        try:
+            candidate = parent.__getattribute__(name)
+        except:
+            candidate = None
+
+        if candidate:
+            logging.error("Could not find the control you were looking for, but found a potential candidate: %s. "
+                          "Printing control identifiers.",
+                          candidate)
+            candidate.print_control_identifiers()
+        else:
+            logging.error("Could not find the control you were looking for. Tried magic, didn't work.")
+
+    raise OrbitE2EError('Could not find element of type %s (name="%s", name_contains="%s", qt_class="%s"). The log '
+                        'above may contain more details.' %
                         (control_type, name, name_contains, qt_class))

--- a/contrib/automation_tests/fragments/capturing.py
+++ b/contrib/automation_tests/fragments/capturing.py
@@ -1,0 +1,19 @@
+"""
+Copyright (c) 2020 The Orbit Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+"""
+
+from core.orbit_e2e import E2ETestCase
+from orbit_testing import select_process, capture, focus_on_capture_window
+
+
+class SelectProcess(E2ETestCase):
+    def _execute(self, process_search_term="hello_"):
+        select_process(self.suite.application, process_search_term=process_search_term)
+
+
+class Capture(E2ETestCase):
+    def _execute(self, length_in_seconds):
+        focus_on_capture_window(self.suite.application)
+        capture(self.suite.application, length=length_in_seconds)

--- a/contrib/automation_tests/fragments/move_tabs.py
+++ b/contrib/automation_tests/fragments/move_tabs.py
@@ -22,10 +22,10 @@ class MoveFunctionsTab(Fragment):
         tab_item = find_control(wnd, "TabItem", name="Functions")
         right_tab_bar = find_control(
             find_control(wnd, "Group", name="RightTabWidget"),
-            "Tab")
+            "Tab", recurse=False)
         left_tab_bar = find_control(
             find_control(wnd, "Group", name="MainTabWidget"),
-            "Tab")
+            "Tab", recurse=False)
 
         # Init tests
         left_tab_count = left_tab_bar.control_count()

--- a/contrib/automation_tests/fragments/move_tabs.py
+++ b/contrib/automation_tests/fragments/move_tabs.py
@@ -6,17 +6,17 @@ found in the LICENSE file.
 
 import logging
 
-from core.orbit_e2e import Fragment, find_control
+from core.orbit_e2e import E2ETestCase, find_control
 
 
-class MoveFunctionsTab(Fragment):
+class MoveFunctionsTab(E2ETestCase):
     def right_click_move_context(self, item):
         item.click_input(button='right')
-        context_menu = self.e2e_test.application.window(best_match="TabBarContextMenu")
+        context_menu = self.suite.application.window(best_match="TabBarContextMenu")
         find_control(context_menu, "MenuItem", name_contains="Move").click_input(button='left')
 
     def _execute(self):
-        wnd = self.e2e_test.top_window()
+        wnd = self.suite.top_window()
 
         # Find "Functions" tab and left and right tab bar
         tab_item = find_control(wnd, "TabItem", name="Functions")

--- a/contrib/automation_tests/fragments/tracks.py
+++ b/contrib/automation_tests/fragments/tracks.py
@@ -1,0 +1,194 @@
+"""
+Copyright (c) 2020 The Orbit Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+"""
+
+import logging
+
+from typing import Tuple, List
+
+from core.orbit_e2e import E2ETestCase, find_control, E2ETestSuite
+from collections import namedtuple
+from pywinauto.base_wrapper import BaseWrapper
+from pywinauto import mouse
+
+
+Track = namedtuple('Track', ['Container', 'Title', 'Content'])
+
+
+def get_track_components(track_control) -> Track:
+    """
+    Utility method to split a Track into the main container, the title tab, and the content.
+    """
+    return Track(Container=track_control,
+                 Title=find_control(track_control, 'TabItem'),
+                 Content=find_control(track_control, 'Group'))
+
+
+class CaptureWindowE2ETestCaseBase(E2ETestCase):
+    """
+    Base class for fragments interacting with the capture window, provides common functionality.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._time_graph = None
+
+    def execute(self, suite: E2ETestSuite):
+        self._time_graph = find_control(suite.top_window(), 'Image', name='TimeGraph')
+        super().execute(suite=suite)
+
+    def _find_tracks(self):
+        return self._time_graph.children()
+
+
+class SelectTrack(CaptureWindowE2ETestCaseBase):
+    """
+    Select a track in the capture window and check the selection afterwards.
+    """
+
+    def _execute(self, track_index: int = 0, check_selection_before: bool = False, expect_failure: bool = False):
+        """
+        :param track_index: Index of the track to select
+        :param check_selection_before: If True, verifies that this track was not selected before
+        :param expect_failure: If True, it is expected that the track in question is NOT selected after executing this
+        """
+        track = get_track_components(self._find_tracks()[track_index])
+
+        if check_selection_before:
+            self.expect_true(not track.Container.has_keyboard_focus(), "Track is not selected")
+        logging.info("Selecting track with index %s", track_index)
+        track.Title.click_input()
+        if expect_failure:
+            self.expect_true(not track.Container.has_keyboard_focus(), "Track is not selected")
+        else:
+            self.expect_true(track.Container.has_keyboard_focus(), "Track is selected")
+
+
+class DeselectTrack(CaptureWindowE2ETestCaseBase):
+    """
+    Deselect the currently selected track in the capture window, verify no track is selected afterwards.
+    Expects a track to be selected, fails otherwise.
+    """
+
+    def _find_focused_track_and_index(self) -> Tuple[BaseWrapper, int]:
+        children = self._find_tracks()
+        for i in range(len(children)):
+            if children[i].has_keyboard_focus():
+                return children[i], i
+        return None, None
+
+    def _execute(self):
+        track, index = self._find_focused_track_and_index()
+
+        self.expect_true(index is not None, "A track is selected")
+        # Click slightly above the track to hit any empty space
+        rect = track.rectangle()
+        mouse.click(button='left', coords=(rect.left + 10, rect.top - 5))
+        # TODO: I need to call this twice to work, why?
+        mouse.click(button='left', coords=(rect.left + 10, rect.top - 5))
+        self.expect_true(not self._find_tracks()[index].has_keyboard_focus(), "Track is no longer selected")
+        self.expect_true(self._find_focused_track_and_index()[0] is None, "No Track is selected")
+
+
+class MoveTrack(CaptureWindowE2ETestCaseBase):
+    """
+    Click and drag a track in the capture window, verify ordering of tracks afterwards.
+    """
+
+    def _execute(self, track_index: int = 0, new_index: int = 0, expected_new_index: int = None):
+        """
+        :param track_index: Track index (before dragging) to move
+        :param new_index: New index the track should be moved to
+        :param expected_new_index: Optional - Expected index of the track after moving. If None, it is expected that
+            the track will be at position <new_index> after execution.
+        """
+        if expected_new_index is None:
+            expected_new_index = new_index
+
+        # Drag 1 px above the target track index if moving up, or 1 px below if moving down
+        tracks = self._find_tracks()
+        rect = tracks[new_index].rectangle()
+        track_count = len(tracks)
+        if track_index % track_count >= new_index % track_count:
+            new_y = rect.top - 1
+        else:
+            new_y = rect.bottom + 1
+
+        track = get_track_components(tracks[track_index])
+        mouse_x = track.Title.rectangle().left + 5
+        logging.info("Moving track '%s' from index %s to y=%s (expected new index: %s)",
+                     track.Container.texts()[0], track_index, new_y, expected_new_index)
+
+        track.Title.drag_mouse_input((mouse_x, new_y + 5))
+
+        index = self._find_tracks().index(track.Container)
+        self.expect_eq(index, expected_new_index % track_count, "Expected track index after reordering")
+
+
+class MatchTracks(CaptureWindowE2ETestCaseBase):
+    """
+    Verify that the existing visible tracks match the expected tracks
+    """
+    def _execute(self, expected_count: int = None, expected_names: List[str] = None, allow_additional_tracks=False):
+        """
+        You need to pass either expected_track_count, or expected_name_list. If both are passed, they need to match
+        w.r.t. expected number of tracks.
+        :param expected_count: # of tracks to be visible
+        :param expected_names: List of (partial) matching names of tracks to be visible.
+            The name is a partial match, but the exact number of tracks is expected.
+        :param allow_additional_tracks: If True, encountering additional tracks beyond the given list / number is not
+            considered an error
+        """
+        assert (expected_count is not None or expected_names)
+        if expected_count is not None and expected_names:
+            assert (expected_count == len(expected_names))
+        if expected_count is None:
+            expected_count = len(expected_names)
+
+        tracks = self._find_tracks()
+
+        if not allow_additional_tracks:
+            self.expect_eq(len(tracks), expected_count, "# of tracks matches %s" % expected_count)
+        else:
+            self.expect_true(len(tracks) >= expected_count, "# of tracks is at least %s" % expected_count)
+
+        names_found = 0
+        if expected_names:
+            logging.info("Matching visible tracks against name list (%s)", expected_names)
+            for name in expected_names:
+                found = False
+                for track in tracks:
+                    track_name = track.texts()[0]
+                    if name in track_name:
+                        found = True
+                        names_found += 1
+                        break
+                self.expect_true(found, "Found a match for track name '%s'" % name)
+
+        if not allow_additional_tracks:
+            self.expect_eq(names_found, expected_count, "No additional tracks are found")
+
+
+class FilterTracks(CaptureWindowE2ETestCaseBase):
+    """
+    Set a filter in the capture tab, and verify either the amount of visible tracks or their names
+    """
+
+    def _execute(self, filter_string: str = "", expected_count: int = None, expected_names: List[str] = None,
+                 allow_additional_tracks=False):
+        """
+        See MatchTracks._execute() for documentation.
+        """
+        toolbar = find_control(self.suite.top_window(), "ToolBar", name="CaptureToolBar")
+        track_filter = find_control(toolbar, "Edit", "FilterTracks")
+
+        logging.info("Setting track filter text: '%s'", filter_string)
+        track_filter.set_edit_text(filter_string)
+        tracks = self._find_tracks()
+
+        # Verify by re-using a MatchTracks Fragment
+        match_tracks = MatchTracks(expected_count=expected_count, expected_names=expected_names,
+                                   allow_additional_tracks=allow_additional_tracks)
+        match_tracks.execute(self.suite)

--- a/contrib/automation_tests/orbit_move_tabs.py
+++ b/contrib/automation_tests/orbit_move_tabs.py
@@ -6,14 +6,14 @@ found in the LICENSE file.
 
 from absl import app
 
-from core.orbit_e2e import E2ETest
+from core.orbit_e2e import E2ETestSuite
 from fragments.move_tabs import MoveFunctionsTab
 
 
 def main(argv):
-    fragments = [MoveFunctionsTab()]
-    test = E2ETest(test_name="Move tabs", fragments=fragments)
-    test.execute()
+    tests = [MoveFunctionsTab()]
+    suite = E2ETestSuite(test_name="Move tabs", tests=tests)
+    suite.execute()
 
 
 if __name__ == '__main__':

--- a/contrib/automation_tests/orbit_tracks.py
+++ b/contrib/automation_tests/orbit_tracks.py
@@ -1,0 +1,37 @@
+"""
+Copyright (c) 2020 The Orbit Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+"""
+
+from absl import app
+
+from core.orbit_e2e import E2ETestSuite
+from fragments.tracks import SelectTrack, DeselectTrack, MoveTrack, FilterTracks, MatchTracks
+from fragments.capturing import SelectProcess, Capture
+
+
+def main(argv):
+    tests = [SelectProcess(process_search_term="hello_"),
+             Capture(length_in_seconds=5),
+             MatchTracks(expected_names=["Scheduler", "gfx", "sdma0",
+                                         "hello_ggp_stand", "hello_ggp_stand", "GgpSwapchain",
+                                         "GgpVideoIpcRead", "GgpVideoIpcRead", "GgpVideoIpc"],
+                         allow_additional_tracks=True),
+             SelectTrack(track_index=5),
+             DeselectTrack(),
+             SelectTrack(track_index=0, expect_failure=True),   # Scheduler track cannot be selected
+             MoveTrack(track_index=5, new_index=0),
+             MoveTrack(track_index=0, new_index=3),
+             MoveTrack(track_index=3, new_index=5),
+             # TODO: Filtering tracks should probably be tested on a loaded capture...
+             FilterTracks(filter_string="hello", expected_count=2),
+             FilterTracks(filter_string="Hello", expected_count=2),
+             FilterTracks(filter_string="ggp", expected_count=7, allow_additional_tracks=True),
+             FilterTracks(filter_string="", expected_count=9, allow_additional_tracks=True)]
+    suite = E2ETestSuite(test_name="Track Interaction", tests=tests)
+    suite.execute()
+
+
+if __name__ == '__main__':
+    app.run(main)


### PR DESCRIPTION
**Based on https://github.com/google/orbit/pull/1614**

Ignore the first 2 commits if you want to review this, they are also contained in the linked PR.

This add a couple of E2E tests for tracks inside the capture window:

- Verify selection and deselection of tracks by clicking in the capture
window
- Verify drag / drop behavior for track sorting
- Verify filtering of tracks correctly affects track in the capture
window

I have to admit that it is not super structured in terms of what is tested, and it's not an exhaustive test for the track functionality. This mainly served the purpose of verifying the accessibility of the capture window, and could be extended later.