### PR TITLE
Enable multi-selection in sampling view.

### DIFF
--- a/src/OrbitClientData/include/OrbitClientData/PostProcessedSamplingData.h
+++ b/src/OrbitClientData/include/OrbitClientData/PostProcessedSamplingData.h
@@ -84,10 +84,10 @@ class PostProcessedSamplingData {
 
   [[nodiscard]] const CallStack& GetResolvedCallstack(CallstackID raw_callstack_id) const;
 
-  [[nodiscard]] std::multimap<int, CallstackID> GetCallstacksFromAddress(uint64_t address,
-                                                                         ThreadID thread_id) const;
-  [[nodiscard]] std::unique_ptr<SortedCallstackReport> GetSortedCallstackReportFromAddress(
-      uint64_t address, ThreadID thread_id) const;
+  [[nodiscard]] std::multimap<int, CallstackID> GetCallstacksFromAddresses(
+      const std::vector<uint64_t>& addresses, ThreadID thread_id) const;
+  [[nodiscard]] std::unique_ptr<SortedCallstackReport> GetSortedCallstackReportFromAddresses(
+      const std::vector<uint64_t>& addresses, ThreadID thread_id) const;
 
   [[nodiscard]] const std::vector<ThreadSampleData>& GetThreadSampleData() const {
     return sorted_thread_sample_data_;

--- a/src/OrbitGl/CallStackDataView.cpp
+++ b/src/OrbitGl/CallStackDataView.cpp
@@ -213,9 +213,8 @@ void CallStackDataView::OnDataChanged() {
   DataView::OnDataChanged();
 }
 
-void CallStackDataView::SetFunctionsToHighlight(const std::vector<uint64_t>& absolute_addresses) {
-  absl::flat_hash_set<uint64_t> sampling_function_set(absolute_addresses.begin(),
-                                                      absolute_addresses.end());
+void CallStackDataView::SetFunctionsToHighlight(
+    const absl::flat_hash_set<uint64_t>& absolute_addresses) {
   const CaptureData& capture_data = app_->GetCaptureData();
   functions_to_highlight_.clear();
 
@@ -224,7 +223,7 @@ void CallStackDataView::SetFunctionsToHighlight(const std::vector<uint64_t>& abs
     std::optional<uint64_t> callstack_function_absolute_address =
         capture_data.FindFunctionAbsoluteAddressByAddress(frame.address);
     if (callstack_function_absolute_address.has_value() &&
-        sampling_function_set.contains(callstack_function_absolute_address.value())) {
+        absolute_addresses.contains(callstack_function_absolute_address.value())) {
       functions_to_highlight_.insert(frame.address);
     }
   }

--- a/src/OrbitGl/CallStackDataView.cpp
+++ b/src/OrbitGl/CallStackDataView.cpp
@@ -86,6 +86,17 @@ std::string CallStackDataView::GetValue(int row, int column) {
   }
 }
 
+std::string CallStackDataView::GetToolTip(int row, int /*column*/) {
+  CallStackDataViewFrame frame = GetFrameFromRow(row);
+  if (functions_to_highlight_.find(frame.address) != functions_to_highlight_.end()) {
+    return absl::StrFormat(
+        "Functions marked with %s are part of the selection in the sampling report above",
+        CallStackDataView::kHighlightedFunctionString);
+  } else {
+    return "";
+  }
+}
+
 const std::string CallStackDataView::kMenuActionLoadSymbols = "Load Symbols";
 const std::string CallStackDataView::kMenuActionSelect = "Hook";
 const std::string CallStackDataView::kMenuActionUnselect = "Unhook";

--- a/src/OrbitGl/CallStackDataView.h
+++ b/src/OrbitGl/CallStackDataView.h
@@ -41,6 +41,11 @@ class CallStackDataView : public DataView {
     OnDataChanged();
   }
 
+  void SetFunctionsToHighlight(const std::vector<uint64_t>& absolute_addresses);
+  [[nodiscard]] bool WantsDisplayColor() override { return true; }
+  [[nodiscard]] bool GetDisplayColor(int row, int /*column*/, unsigned char& red,
+                                     unsigned char& green, unsigned char& blue) override;
+
  protected:
   void DoFilter() override;
 
@@ -77,6 +82,11 @@ class CallStackDataView : public DataView {
   static const std::string kMenuActionSelect;
   static const std::string kMenuActionUnselect;
   static const std::string kMenuActionDisassembly;
+  static const std::string kHighlightedFunctionString;
+  static const std::string kHighlightedFunctionBlankString;
+
+ private:
+  absl::flat_hash_set<uint64_t> functions_to_highlight_;
 };
 
 #endif  // ORBIT_GL_CALLSTACK_DATA_VIEW_H_

--- a/src/OrbitGl/CallStackDataView.h
+++ b/src/OrbitGl/CallStackDataView.h
@@ -27,6 +27,7 @@ class CallStackDataView : public DataView {
   std::vector<std::string> GetContextMenu(int clicked_index,
                                           const std::vector<int>& selected_indices) override;
   std::string GetValue(int row, int column) override;
+  virtual std::string GetToolTip(int row, int /*column*/) override;
 
   void OnContextMenu(const std::string& action, int menu_index,
                      const std::vector<int>& item_indices) override;

--- a/src/OrbitGl/CallStackDataView.h
+++ b/src/OrbitGl/CallStackDataView.h
@@ -42,7 +42,7 @@ class CallStackDataView : public DataView {
     OnDataChanged();
   }
 
-  void SetFunctionsToHighlight(const std::vector<uint64_t>& absolute_addresses);
+  void SetFunctionsToHighlight(const absl::flat_hash_set<uint64_t>& absolute_addresses);
   [[nodiscard]] bool WantsDisplayColor() override { return true; }
   [[nodiscard]] bool GetDisplayColor(int row, int /*column*/, unsigned char& red,
                                      unsigned char& green, unsigned char& blue) override;

--- a/src/OrbitGl/DataView.cpp
+++ b/src/OrbitGl/DataView.cpp
@@ -77,6 +77,16 @@ void DataView::OnContextMenu(const std::string& action, int /*menu_index*/,
   }
 }
 
+const std::vector<int> DataView::GetVisibleSelectedIndices() {
+  std::vector<int> visible_selected_indices;
+  for (size_t row = 0; row < indices_.size(); ++row) {
+    if (selected_indices_.contains(indices_[row])) {
+      visible_selected_indices.push_back(static_cast<int>(row));
+    }
+  }
+  return visible_selected_indices;
+}
+
 void DataView::ExportCSV(const std::string& file_path) {
   std::ofstream out(file_path);
   if (out.fail()) return;

--- a/src/OrbitGl/DataView.h
+++ b/src/OrbitGl/DataView.h
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "DataViewTypes.h"
+#include "absl/container/flat_hash_set.h"
 #include "OrbitBase/Logging.h"
 
 class OrbitApp;
@@ -36,7 +37,11 @@ class DataView {
   };
 
   explicit DataView(DataViewType type, OrbitApp* app)
-      : update_period_ms_(-1), selected_index_(-1), type_(type), app_{app} {}
+      : update_period_ms_(-1),
+        selected_index_(-1),
+        update_selected_indices_(true),
+        type_(type),
+        app_{app} {}
 
   virtual ~DataView() = default;
 
@@ -57,6 +62,7 @@ class DataView {
   // Filter callback set from UI layer.
   using FilterCallback = std::function<void(const std::string&)>;
   void SetUiFilterCallback(FilterCallback callback) { filter_callback_ = std::move(callback); }
+  void SetUpdateSelectedIndices(bool status) { update_selected_indices_ = status; }
 
   void OnSort(int column, std::optional<SortingOrder> new_order);
   virtual void OnContextMenu(const std::string& action, int menu_index,
@@ -64,6 +70,7 @@ class DataView {
   virtual void OnSelect(std::optional<int> /*index*/) {}
   virtual int GetSelectedIndex() { return selected_index_; }
   virtual void OnMultiSelect(const std::vector<int>& /*indices*/) {}
+  [[nodiscard]] virtual const std::vector<int> GetVisibleSelectedIndices();
   virtual void OnDoubleClicked(int /*index*/) {}
   virtual void OnDataChanged();
   virtual void OnTimer() {}
@@ -98,6 +105,8 @@ class DataView {
   std::string filter_;
   int update_period_ms_;
   int selected_index_;
+  absl::flat_hash_set<int> selected_indices_;
+  bool update_selected_indices_;
   DataViewType type_;
 
   static const std::string kMenuActionCopySelection;

--- a/src/OrbitGl/DataView.h
+++ b/src/OrbitGl/DataView.h
@@ -63,6 +63,7 @@ class DataView {
                              const std::vector<int>& item_indices);
   virtual void OnSelect(std::optional<int> /*index*/) {}
   virtual int GetSelectedIndex() { return selected_index_; }
+  virtual void OnMultiSelect(const std::vector<int>& /*indices*/) {}
   virtual void OnDoubleClicked(int /*index*/) {}
   virtual void OnDataChanged();
   virtual void OnTimer() {}

--- a/src/OrbitGl/LiveFunctionsDataView.cpp
+++ b/src/OrbitGl/LiveFunctionsDataView.cpp
@@ -35,7 +35,9 @@ using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::FunctionStats;
 
 LiveFunctionsDataView::LiveFunctionsDataView(LiveFunctionsController* live_functions, OrbitApp* app)
-    : DataView(DataViewType::kLiveFunctions, app), live_functions_(live_functions) {
+    : DataView(DataViewType::kLiveFunctions, app),
+      live_functions_(live_functions),
+      selected_function_id_(DataManager::kInvalidFunctionId) {
   update_period_ms_ = 300;
   OnDataChanged();
 }
@@ -95,6 +97,14 @@ std::string LiveFunctionsDataView::GetValue(int row, int column) {
   }
 }
 
+const std::optional<int> LiveFunctionsDataView::GetSelectedIndex() {
+  return GetRowFromFunctionId(selected_function_id_);
+}
+
+void LiveFunctionsDataView::UpdateSelectedFunctionId() {
+  selected_function_id_ = app_->highlighted_function_id();
+}
+
 void LiveFunctionsDataView::OnSelect(std::optional<int> row) {
   app_->DeselectTextBox();
 
@@ -102,6 +112,10 @@ void LiveFunctionsDataView::OnSelect(std::optional<int> row) {
     app_->set_highlighted_function_id(DataManager::kInvalidFunctionId);
   } else {
     app_->set_highlighted_function_id(GetInstrumentedFunctionId(row.value()));
+  }
+
+  if (refresh_mode_ != RefreshMode::kOnFilter && refresh_mode_ != RefreshMode::kOnSort) {
+    UpdateSelectedFunctionId();
   }
 }
 

--- a/src/OrbitGl/LiveFunctionsDataView.h
+++ b/src/OrbitGl/LiveFunctionsDataView.h
@@ -30,6 +30,8 @@ class LiveFunctionsDataView : public DataView {
   std::vector<std::string> GetContextMenu(int clicked_index,
                                           const std::vector<int>& selected_indices) override;
   std::string GetValue(int row, int column) override;
+  const std::optional<int> GetSelectedIndex() override;
+  void UpdateSelectedFunctionId();
 
   void OnSelect(std::optional<int> row) override;
   void OnContextMenu(const std::string& action, int menu_index,
@@ -49,6 +51,7 @@ class LiveFunctionsDataView : public DataView {
   absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> functions_;
 
   LiveFunctionsController* live_functions_;
+  uint64_t selected_function_id_;
 
   enum ColumnIndex {
     kColumnSelected,

--- a/src/OrbitGl/ProcessesDataView.cpp
+++ b/src/OrbitGl/ProcessesDataView.cpp
@@ -119,7 +119,7 @@ void ProcessesDataView::SetSelectedItem() {
   }
 
   // This happens when selected process disappears from the list.
-  selected_index_ = -1;
+  selected_index_ = std::nullopt;
 }
 
 bool ProcessesDataView::SelectProcess(const std::string& process_name) {

--- a/src/OrbitGl/SamplingReport.cpp
+++ b/src/OrbitGl/SamplingReport.cpp
@@ -55,8 +55,9 @@ void SamplingReport::UpdateDisplayedCallstack() {
   }
 
   selected_sorted_callstack_report_ =
-      post_processed_sampling_data_.GetSortedCallstackReportFromAddresses(selected_addresses_,
-                                                                          selected_thread_id_);
+      post_processed_sampling_data_.GetSortedCallstackReportFromAddresses(
+          std::vector<uint64_t>(selected_addresses_.begin(), selected_addresses_.end()),
+          selected_thread_id_);
   if (selected_sorted_callstack_report_->callstacks_count.empty()) {
     ClearReport();
   } else {
@@ -86,7 +87,8 @@ void SamplingReport::UpdateReport(
   UpdateDisplayedCallstack();
 }
 
-void SamplingReport::OnSelectAddresses(const std::vector<uint64_t>& addresses, ThreadID thread_id) {
+void SamplingReport::OnSelectAddresses(const absl::flat_hash_set<uint64_t>& addresses,
+                                       ThreadID thread_id) {
   if (callstack_data_view_) {
     if (selected_addresses_ != addresses || selected_thread_id_ != thread_id) {
       selected_addresses_ = addresses;

--- a/src/OrbitGl/SamplingReport.cpp
+++ b/src/OrbitGl/SamplingReport.cpp
@@ -21,7 +21,6 @@ SamplingReport::SamplingReport(
       unique_callstacks_{std::move(unique_callstacks)},
       has_summary_{has_summary},
       app_{app} {
-  selected_address_ = kInvalidFunctionAddress;
   selected_thread_id_ = 0;
   callstack_data_view_ = nullptr;
   selected_sorted_callstack_report_ = nullptr;
@@ -50,14 +49,14 @@ void SamplingReport::FillReport() {
 }
 
 void SamplingReport::UpdateDisplayedCallstack() {
-  if (selected_address_ == SamplingReport::kInvalidFunctionAddress) {
+  if (selected_addresses_.empty()) {
     ClearReport();
     return;
   }
 
   selected_sorted_callstack_report_ =
-      post_processed_sampling_data_.GetSortedCallstackReportFromAddress(selected_address_,
-                                                                        selected_thread_id_);
+      post_processed_sampling_data_.GetSortedCallstackReportFromAddresses(selected_addresses_,
+                                                                          selected_thread_id_);
   if (selected_sorted_callstack_report_->callstacks_count.empty()) {
     ClearReport();
   } else {
@@ -87,10 +86,10 @@ void SamplingReport::UpdateReport(
   UpdateDisplayedCallstack();
 }
 
-void SamplingReport::OnSelectAddress(uint64_t address, ThreadID thread_id) {
+void SamplingReport::OnSelectAddresses(const std::vector<uint64_t>& addresses, ThreadID thread_id) {
   if (callstack_data_view_) {
-    if (selected_address_ != address || selected_thread_id_ != thread_id) {
-      selected_address_ = address;
+    if (selected_addresses_ != addresses || selected_thread_id_ != thread_id) {
+      selected_addresses_ = addresses;
       selected_thread_id_ = thread_id;
       UpdateDisplayedCallstack();
     }

--- a/src/OrbitGl/SamplingReport.cpp
+++ b/src/OrbitGl/SamplingReport.cpp
@@ -144,6 +144,7 @@ void SamplingReport::OnCallstackIndexChanged(size_t index) {
     auto it = unique_callstacks_.find(cs.callstack_id);
     CHECK(it != unique_callstacks_.end());
     callstack_data_view_->SetCallStack(*it->second);
+    callstack_data_view_->SetFunctionsToHighlight(selected_addresses_);
   } else {
     selected_callstack_index_ = 0;
   }

--- a/src/OrbitGl/SamplingReport.h
+++ b/src/OrbitGl/SamplingReport.h
@@ -35,7 +35,7 @@ class SamplingReport {
                     absl::flat_hash_map<CallstackID, std::shared_ptr<CallStack>> unique_callstacks);
   [[nodiscard]] std::vector<SamplingReportDataView>& GetThreadReports() { return thread_reports_; };
   void SetCallstackDataView(CallStackDataView* data_view) { callstack_data_view_ = data_view; };
-  void OnSelectAddress(uint64_t address, ThreadID thread_id);
+  void OnSelectAddresses(const std::vector<uint64_t>& addresses, ThreadID thread_id);
   void IncrementCallstackIndex();
   void DecrementCallstackIndex();
   [[nodiscard]] std::string GetSelectedCallstackString() const;
@@ -44,7 +44,6 @@ class SamplingReport {
   [[nodiscard]] bool HasSamples() const { return !unique_callstacks_.empty(); }
   [[nodiscard]] bool has_summary() const { return has_summary_; }
   void ClearReport();
-  static const uint64_t kInvalidFunctionAddress = std::numeric_limits<uint64_t>::max();
 
  protected:
   void FillReport();
@@ -57,7 +56,7 @@ class SamplingReport {
   std::vector<SamplingReportDataView> thread_reports_;
   CallStackDataView* callstack_data_view_;
 
-  uint64_t selected_address_;
+  std::vector<uint64_t> selected_addresses_;
   ThreadID selected_thread_id_;
   std::unique_ptr<SortedCallstackReport> selected_sorted_callstack_report_;
   size_t selected_callstack_index_;

--- a/src/OrbitGl/SamplingReport.h
+++ b/src/OrbitGl/SamplingReport.h
@@ -35,7 +35,7 @@ class SamplingReport {
                     absl::flat_hash_map<CallstackID, std::shared_ptr<CallStack>> unique_callstacks);
   [[nodiscard]] std::vector<SamplingReportDataView>& GetThreadReports() { return thread_reports_; };
   void SetCallstackDataView(CallStackDataView* data_view) { callstack_data_view_ = data_view; };
-  void OnSelectAddresses(const std::vector<uint64_t>& addresses, ThreadID thread_id);
+  void OnSelectAddresses(const absl::flat_hash_set<uint64_t>& addresses, ThreadID thread_id);
   void IncrementCallstackIndex();
   void DecrementCallstackIndex();
   [[nodiscard]] std::string GetSelectedCallstackString() const;
@@ -56,7 +56,7 @@ class SamplingReport {
   std::vector<SamplingReportDataView> thread_reports_;
   CallStackDataView* callstack_data_view_;
 
-  std::vector<uint64_t> selected_addresses_;
+  absl::flat_hash_set<uint64_t> selected_addresses_;
   ThreadID selected_thread_id_;
   std::unique_ptr<SortedCallstackReport> selected_sorted_callstack_report_;
   size_t selected_callstack_index_;

--- a/src/OrbitGl/SamplingReportDataView.cpp
+++ b/src/OrbitGl/SamplingReportDataView.cpp
@@ -266,10 +266,13 @@ void SamplingReportDataView::OnContextMenu(const std::string& action, int menu_i
   }
 }
 
-void SamplingReportDataView::OnSelect(std::optional<int> index) {
-  uint64_t function_address = index.has_value() ? GetSampledFunction(index.value()).absolute_address
-                                                : SamplingReport::kInvalidFunctionAddress;
-  sampling_report_->OnSelectAddress(function_address, tid_);
+void SamplingReportDataView::OnMultiSelect(const std::vector<int>& indices) {
+  size_t num_indices = indices.size();
+  std::vector<uint64_t> addresses(num_indices);
+  for (size_t i = 0; i < num_indices; ++i) {
+    addresses[i] = GetSampledFunction(indices[i]).absolute_address;
+  }
+  sampling_report_->OnSelectAddresses(addresses, tid_);
 }
 
 void SamplingReportDataView::LinkDataView(DataView* data_view) {

--- a/src/OrbitGl/SamplingReportDataView.cpp
+++ b/src/OrbitGl/SamplingReportDataView.cpp
@@ -273,6 +273,13 @@ void SamplingReportDataView::OnMultiSelect(const std::vector<int>& indices) {
     addresses[i] = GetSampledFunction(indices[i]).absolute_address;
   }
   sampling_report_->OnSelectAddresses(addresses, tid_);
+
+  if (update_selected_indices_) {
+    selected_indices_.clear();
+    for (int row : indices) {
+      selected_indices_.insert(indices_[row]);
+    }
+  }
 }
 
 void SamplingReportDataView::LinkDataView(DataView* data_view) {

--- a/src/OrbitGl/SamplingReportDataView.cpp
+++ b/src/OrbitGl/SamplingReportDataView.cpp
@@ -267,10 +267,9 @@ void SamplingReportDataView::OnContextMenu(const std::string& action, int menu_i
 }
 
 void SamplingReportDataView::OnMultiSelect(const std::vector<int>& indices) {
-  size_t num_indices = indices.size();
-  std::vector<uint64_t> addresses(num_indices);
-  for (size_t i = 0; i < num_indices; ++i) {
-    addresses[i] = GetSampledFunction(indices[i]).absolute_address;
+  absl::flat_hash_set<uint64_t> addresses;
+  for (int index : indices) {
+    addresses.insert(GetSampledFunction(index).absolute_address);
   }
   sampling_report_->OnSelectAddresses(addresses, tid_);
 

--- a/src/OrbitGl/SamplingReportDataView.cpp
+++ b/src/OrbitGl/SamplingReportDataView.cpp
@@ -274,7 +274,7 @@ void SamplingReportDataView::OnMultiSelect(const std::vector<int>& indices) {
   }
   sampling_report_->OnSelectAddresses(addresses, tid_);
 
-  if (update_selected_indices_) {
+  if (refresh_mode_ != RefreshMode::kOnFilter && refresh_mode_ != RefreshMode::kOnSort) {
     selected_indices_.clear();
     for (int row : indices) {
       selected_indices_.insert(indices_[row]);

--- a/src/OrbitGl/SamplingReportDataView.h
+++ b/src/OrbitGl/SamplingReportDataView.h
@@ -32,7 +32,7 @@ class SamplingReportDataView : public DataView {
 
   void OnContextMenu(const std::string& action, int menu_index,
                      const std::vector<int>& item_indices) override;
-  void OnSelect(std::optional<int> index) override;
+  void OnMultiSelect(const std::vector<int>& indices) override;
 
   void LinkDataView(DataView* data_view) override;
   void SetSamplingReport(class SamplingReport* sampling_report) {

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1087,6 +1087,7 @@ void OrbitMainWindow::OnTimerSelectionChanged(const orbit_client_protos::TimerIn
     LiveFunctionsDataView& live_functions_data_view =
         live_functions_controller.value()->GetDataView();
     selected_row = live_functions_data_view.GetRowFromFunctionId(function_id);
+    live_functions_data_view.UpdateSelectedFunctionId();
   }
   ui->liveFunctions->OnRowSelected(selected_row);
 }

--- a/src/OrbitQt/orbitsamplingreport.cpp
+++ b/src/OrbitQt/orbitsamplingreport.cpp
@@ -80,6 +80,7 @@ void OrbitSamplingReport::Initialize(DataView* callstack_data_view,
     gridLayout_2->addWidget(treeView, 0, 0, 1, 1);
     treeView->Initialize(&report_data_view, SelectionType::kExtended, FontType::kDefault);
     treeView->GetTreeView()->header()->resizeSections(QHeaderView::ResizeToContents);
+    treeView->GetTreeView()->SetIsMultiSelection(true);
 
     treeView->Link(ui->CallstackTreeView);
 
@@ -118,11 +119,11 @@ void OrbitSamplingReport::on_PreviousCallstackButton_clicked() {
 void OrbitSamplingReport::OnCurrentThreadTabChanged(int current_tab_index) {
   auto treeView = m_OrbitDataViews[current_tab_index];
   QModelIndexList index_list = treeView->GetTreeView()->selectionModel()->selectedIndexes();
-  std::optional<int> row = std::nullopt;
-  if (!index_list.isEmpty() && index_list.front().isValid()) {
-    row = index_list.front().row();
+  std::vector<int> row_list;
+  for (QModelIndex& index : index_list) {
+    row_list.push_back(index.row());
   }
-  treeView->GetTreeView()->GetModel()->OnRowSelected(row);
+  treeView->GetTreeView()->GetModel()->OnMultiRowsSelected(row_list);
   RefreshCallstackView();
 }
 

--- a/src/OrbitQt/orbittablemodel.cpp
+++ b/src/OrbitQt/orbittablemodel.cpp
@@ -104,3 +104,7 @@ void OrbitTableModel::OnRowSelected(std::optional<int> row) {
     data_view_->OnSelect(row);
   }
 }
+
+void OrbitTableModel::OnMultiRowsSelected(const std::vector<int>& rows) {
+  data_view_->OnMultiSelect(rows);
+}

--- a/src/OrbitQt/orbittablemodel.h
+++ b/src/OrbitQt/orbittablemodel.h
@@ -34,7 +34,9 @@ class OrbitTableModel : public QAbstractTableModel {
   void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) override;
 
   int GetUpdatePeriodMs() { return data_view_->GetUpdatePeriodMs(); }
-  int GetSelectedIndex() { return data_view_->GetSelectedIndex(); }
+  [[nodiscard]] std::optional<int> GetSelectedIndex() const {
+    return data_view_->GetSelectedIndex();
+  }
   QModelIndex CreateIndex(int row, int column) { return createIndex(row, column); }
   DataView* GetDataView() { return data_view_; }
   void SetDataView(DataView* model) { data_view_ = model; }

--- a/src/OrbitQt/orbittablemodel.h
+++ b/src/OrbitQt/orbittablemodel.h
@@ -44,6 +44,7 @@ class OrbitTableModel : public QAbstractTableModel {
   void OnTimer();
   void OnFilter(const QString& filter);
   void OnRowSelected(std::optional<int> row);
+  void OnMultiRowsSelected(const std::vector<int>& rows);
 
  protected:
   DataView* data_view_;

--- a/src/OrbitQt/orbittreeview.h
+++ b/src/OrbitQt/orbittreeview.h
@@ -51,6 +51,7 @@ class OrbitTreeView : public QTreeView {
   bool HasRefreshButton() const;
   void OnRefreshButtonClicked();
   void SetIsInternalRefresh(bool status) { is_internal_refresh_ = status; }
+  void SetIsMultiSelection(bool status) { is_multi_selection_ = status; }
 
  public slots:
   void columnResized(int column, int oldSize, int newSize);
@@ -63,6 +64,7 @@ class OrbitTreeView : public QTreeView {
   void OnRangeChanged(int min, int max);
   void OnRowSelected(std::optional<int> row);
   void OnDoubleClicked(QModelIndex index);
+  void OnMultiRowsSelected(std::vector<int>& rows);
 
  private:
   std::unique_ptr<OrbitTableModel> model_;
@@ -70,6 +72,7 @@ class OrbitTreeView : public QTreeView {
   std::vector<OrbitTreeView*> links_;
   bool auto_resize_;
   bool is_internal_refresh_ = false;
+  bool is_multi_selection_ = false;
 };
 
 #endif  // ORBIT_QT_ORBIT_TREE_VIEW_H_

--- a/src/OrbitQt/orbittreeview.h
+++ b/src/OrbitQt/orbittreeview.h
@@ -39,7 +39,7 @@ class OrbitTreeView : public QTreeView {
   void SetDataModel(DataView* model);
   void ClearDataModel();
   void OnFilter(const QString& filter);
-  void Refresh();
+  void Refresh(RefreshMode refresh_mode = RefreshMode::kOther);
   void Link(OrbitTreeView* link);
   void SetGlWidget(OrbitGLWidget* gl_widget);
   void resizeEvent(QResizeEvent* event) override;
@@ -52,6 +52,9 @@ class OrbitTreeView : public QTreeView {
   void OnRefreshButtonClicked();
   void SetIsInternalRefresh(bool status) { is_internal_refresh_ = status; }
   void SetIsMultiSelection(bool status) { is_multi_selection_ = status; }
+
+ private:
+  void DoReselection(RefreshMode refresh_mode);
 
  public slots:
   void columnResized(int column, int oldSize, int newSize);


### PR DESCRIPTION
This PR enables multi-selection in the sampling view. More specifically, it enables the following features:

- If user selects multiple rows in the sampling view, the callstack view will show the callstack report of all selected functions (relevant to bug b/161531504).
- In the callstack view, functions selected in the sampling view will be highlighted with colors and arrow strings. We also add tooltips for this highlighting feature (relevant to bug b/168677314). 
- If user inputs some filtering conditions in the sampling view, the sampling view will refresh to re-select the visible selected functions. The callstack view will also update accordingly to highlight only the visible selected functions. If user clears the filtering condition, the sampling view will show the previous selections of the user.
- Keep selecting the same functions in the sampling view (rather than the same rows in the previous version) when filtering and sorting.


Fixes bugs: b/168677314, b/161531504.