### PR TITLE
Fix track sorting

### DIFF
--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -72,7 +72,6 @@ void TimeGraph::Clear() {
   batcher_.StartNewFrame();
   capture_min_timestamp_ = std::numeric_limits<uint64_t>::max();
   capture_max_timestamp_ = 0;
-  thread_count_map_.clear();
 
   track_manager_->Clear();
 
@@ -265,7 +264,6 @@ void TimeGraph::ProcessTimer(const TimerInfo& timer_info, const FunctionInfo* fu
     ThreadTrack* track = track_manager_->GetOrCreateThreadTrack(timer_info.thread_id());
     if (timer_info.type() != TimerInfo::kCoreActivity) {
       track->OnTimer(timer_info);
-      ++thread_count_map_[timer_info.thread_id()];
     } else {
       auto scheduler_track = track_manager_->GetOrCreateSchedulerTrack();
       scheduler_track->OnTimer(timer_info);
@@ -303,7 +301,6 @@ void TimeGraph::ProcessIntrospectionTimer(const TimerInfo& timer_info) {
     case orbit_api::kScopeStart: {
       ThreadTrack* track = track_manager_->GetOrCreateThreadTrack(timer_info.thread_id());
       track->OnTimer(timer_info);
-      ++thread_count_map_[timer_info.thread_id()];
     } break;
     case orbit_api::kScopeStartAsync:
     case orbit_api::kScopeStopAsync:

--- a/OrbitGl/TimeGraph.h
+++ b/OrbitGl/TimeGraph.h
@@ -219,7 +219,6 @@ class TimeGraph {
 
   TimeGraphAccessibility accessibility_;
 
-  std::map<int32_t, uint32_t> thread_count_map_;
   uint32_t num_cores_;
   // Be careful when directly changing these members without using the
   // methods NeedsRedraw() or NeedsUpdate():

--- a/OrbitGl/TrackManager.cpp
+++ b/OrbitGl/TrackManager.cpp
@@ -202,7 +202,7 @@ std::vector<ThreadTrack*> TrackManager::GetSortedThreadTracks() {
   }
 
   // Tracks with instrumented timers appear first, ordered by descending order of timers.
-  // The remaining tracks appear after ordered by number of events.
+  // The remaining tracks appear after, ordered by descending order of callstack events.
   std::sort(sorted_tracks.begin(), sorted_tracks.end(),
             [&num_events_by_track](ThreadTrack* a, ThreadTrack* b) {
               return std::make_tuple(a->GetNumTimers(), num_events_by_track[a]) >

--- a/OrbitGl/TrackManager.cpp
+++ b/OrbitGl/TrackManager.cpp
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <optional>
 #include <string_view>
+#include <tuple>
 #include <utility>
 
 #include "App.h"
@@ -81,30 +82,8 @@ std::vector<FrameTrack*> TrackManager::GetFrameTracks() const {
 void TrackManager::SortTracks() {
   if (!app_->IsCapturing() && !sorted_tracks_.empty() && !sorting_invalidated_) return;
 
-  ThreadTrack* process_track = nullptr;
-
-  const CaptureData* capture_data = time_graph_->GetCaptureData();
-  if (capture_data != nullptr) {
-    // Get or create thread track from events' thread id.
-    event_count_.clear();
-    event_count_[orbit_base::kAllProcessThreadsTid] =
-        capture_data->GetCallstackData()->GetCallstackEventsCount();
-
-    // The process track is a special ThreadTrack of id "kAllThreadsFakeTid".
-    process_track = GetOrCreateThreadTrack(orbit_base::kAllProcessThreadsTid);
-    for (const auto& tid_and_count :
-         capture_data->GetCallstackData()->GetCallstackEventsCountsPerTid()) {
-      const int32_t thread_id = tid_and_count.first;
-      const uint32_t count = tid_and_count.second;
-      event_count_[thread_id] = count;
-      GetOrCreateThreadTrack(thread_id);
-    }
-  }
-
   // Reorder threads once every second when capturing
   if (!app_->IsCapturing() || last_thread_reorder_.ElapsedMillis() > 1000.0) {
-    std::vector<int32_t> sorted_thread_ids = GetSortedThreadIds();
-
     std::lock_guard<std::recursive_mutex> lock(mutex_);
     // Gather all tracks regardless of the process in sorted order
     std::vector<Track*> all_processes_sorted_tracks;
@@ -135,19 +114,23 @@ void TrackManager::SortTracks() {
     }
 
     // Process track.
-    if (process_track && !process_track->IsEmpty()) {
-      all_processes_sorted_tracks.push_back(process_track);
+    if (app_->HasCaptureData()) {
+      ThreadTrack* process_track = GetOrCreateThreadTrack(orbit_base::kAllProcessThreadsTid);
+      if (!process_track->IsEmpty()) {
+        all_processes_sorted_tracks.push_back(process_track);
+      }
     }
 
     // Thread tracks.
-    for (auto thread_id : sorted_thread_ids) {
-      auto track = GetOrCreateThreadTrack(thread_id);
-      if (!track->IsEmpty()) {
-        all_processes_sorted_tracks.push_back(track);
+    std::vector<ThreadTrack*> sorted_thread_tracks = GetSortedThreadTracks();
+    for (ThreadTrack* thread_track : sorted_thread_tracks) {
+      if (!thread_track->IsEmpty()) {
+        all_processes_sorted_tracks.push_back(thread_track);
       }
     }
 
     // Separate "capture_pid" tracks from tracks that originate from other processes.
+    const CaptureData* capture_data = time_graph_->GetCaptureData();
     int32_t capture_pid = capture_data ? capture_data->process_id() : 0;
     std::vector<Track*> capture_pid_tracks;
     std::vector<Track*> external_pid_tracks;
@@ -204,33 +187,29 @@ void TrackManager::UpdateFilteredTrackList() {
   }
 }
 
-std::vector<int32_t>
-TrackManager::GetSortedThreadIds() {  // Show threads with instrumented functions first
-  std::vector<int32_t> sorted_thread_ids;
-  std::vector<std::pair<int32_t, uint32_t>> sorted_threads =
-      orbit_core::ReverseValueSort(thread_count_map_);
+std::vector<ThreadTrack*> TrackManager::GetSortedThreadTracks() {
+  std::vector<ThreadTrack*> sorted_tracks;
+  absl::flat_hash_map<ThreadTrack*, uint32_t> num_events_by_track;
+  const CaptureData* capture_data = time_graph_->GetCaptureData();
+  const CallstackData* callstack_data = capture_data ? capture_data->GetCallstackData() : nullptr;
 
-  for (auto& [tid, unused_value] : sorted_threads) {
-    // Track "kAllThreadsFakeTid" holds all target process sampling info, it is handled
-    // separately.
-    if (tid != orbit_base::kAllProcessThreadsTid) {
-      sorted_thread_ids.push_back(tid);
-    }
+  for (auto& [tid, track] : thread_tracks_) {
+    if (tid == orbit_base::kAllProcessThreadsTid)
+      continue;  // "kAllProcessThreadsTid" is handled separately.
+    sorted_tracks.push_back(track.get());
+    uint32_t num_events = callstack_data ? callstack_data->GetCallstackEventsOfTidCount(tid) : 0;
+    num_events_by_track[track.get()] = num_events;
   }
 
-  // Then show threads sorted by number of events
-  std::vector<std::pair<int32_t, uint32_t>> sorted_by_events =
-      orbit_core::ReverseValueSort(event_count_);
-  for (auto& [tid, unused_value] : sorted_by_events) {
-    // Track "kAllThreadsFakeTid" holds all target process sampling info, it is handled
-    // separately.
-    if (tid == orbit_base::kAllProcessThreadsTid) continue;
-    if (thread_count_map_.find(tid) == thread_count_map_.end()) {
-      sorted_thread_ids.push_back(tid);
-    }
-  }
+  // Tracks with instrumented timers appear first, ordered by descending order of timers.
+  // The remaining tracks appear after ordered by number of events.
+  std::sort(sorted_tracks.begin(), sorted_tracks.end(),
+            [&num_events_by_track](ThreadTrack* a, ThreadTrack* b) {
+              return std::make_tuple(a->GetNumTimers(), num_events_by_track[a]) >
+                     std::make_tuple(b->GetNumTimers(), num_events_by_track[b]);
+            });
 
-  return sorted_thread_ids;
+  return sorted_tracks;
 }
 
 void TrackManager::UpdateMovingTrackSorting() {

--- a/OrbitGl/TrackManager.h
+++ b/OrbitGl/TrackManager.h
@@ -70,7 +70,7 @@ class TrackManager {
  private:
   void UpdateFilteredTrackList();
   [[nodiscard]] int FindMovingTrackIndex();
-  [[nodiscard]] std::vector<int32_t> GetSortedThreadIds();
+  [[nodiscard]] std::vector<ThreadTrack*> GetSortedThreadTracks();
 
   mutable std::recursive_mutex mutex_;
 
@@ -91,8 +91,6 @@ class TrackManager {
   std::vector<Track*> sorted_tracks_;
   bool sorting_invalidated_;
   Timer last_thread_reorder_;
-  std::map<int32_t, uint32_t> thread_count_map_;
-  std::map<int32_t, uint32_t> event_count_;
 
   std::string filter_;
   std::vector<Track*> visible_tracks_;


### PR DESCRIPTION
The TrackManager change introduced a bug that causes tracks that don't
have callstack events to never show up. It also broke the previous
sorting policy which was to display tracks with instrumented functions
first. Reimplement track sorting and remove unused and duplicated
"thread_count_map_" and "event_count_" vectors.

This change also fixes introspection tracks not showing up anymore.