### PR TITLE
Replace isgreater by std::isgreater

### DIFF
--- a/OrbitTriggerCaptureVulkanLayer/LayerLogic.cpp
+++ b/OrbitTriggerCaptureVulkanLayer/LayerLogic.cpp
@@ -8,6 +8,7 @@
 #include <unistd.h>
 
 #include <chrono>
+#include <cmath>
 #include <cstdint>
 #include <string>
 
@@ -96,7 +97,7 @@ void LayerLogic::ProcessQueuePresentKHR() {
   if (!orbit_capture_running_) {
     auto frame_time = std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(
         current_time - last_frame_time_);
-    if (isgreater(frame_time.count(), layer_options_.GetFrameTimeThresholdMilliseconds())) {
+    if (std::isgreater(frame_time.count(), layer_options_.GetFrameTimeThresholdMilliseconds())) {
       LOG("Time frame is %fms and exceeds the %fms threshold; starting capture", frame_time.count(),
           layer_options_.GetFrameTimeThresholdMilliseconds());
       RunCapture();


### PR DESCRIPTION
LayerLogic.cpp uses the C99 function isgreater. We should avoid using
C-functions and use the C++ equivalent std::isgreater instead.

This also triggered a bug in include-what-you-use. That's why I'm fixing
it.

@florian-kuebler: I'm not sure why `isgreater` has been used. Do you happen to know
whether it's special behaviour is actually needed here? Using `operator >` would be a lot more readable to me.