### PR TITLE
Make configs/install.{sh,ps1} detect catchall DNS

### DIFF
--- a/third_party/conan/configs/install.ps1
+++ b/third_party/conan/configs/install.ps1
@@ -25,6 +25,14 @@ if (Test-Path Env:ORBIT_OVERRIDE_ARTIFACTORY_URL) {
   conan_disable_public_remotes
 } else {
   try {
+    $response = Invoke-WebRequest -URI http://invalid-hostname.internal/ -ErrorAction Ignore -MaximumRedirection 0 -UseBasicParsing
+    Write-Host "Detected catch-all DNS configuration. Using public remotes for conan."
+    exit
+  } catch {
+    # If we jump into this catch-block, that means there is no catch-all DNS.
+  }
+
+  try {
     $response = Invoke-WebRequest -URI http://artifactory.internal/ -ErrorAction Ignore -MaximumRedirection 0 -UseBasicParsing
     Write-Host "CI machine detected. Adjusting remotes..."
 

--- a/third_party/conan/configs/install.sh
+++ b/third_party/conan/configs/install.sh
@@ -44,9 +44,9 @@ elif [ -n "$ORBIT_OVERRIDE_ARTIFACTORY_URL" ]; then
   conan remote add -i 0 -f artifactory "$ORBIT_OVERRIDE_ARTIFACTORY_URL" || exit $?
   conan_disable_public_remotes || exit $?
 else
-  curl -s http://artifactory.internal/ >/dev/null 2>&1
-  
-  if [ $? -eq 0 ]; then
+  if curl -s http://invalid-name.internal/ >/dev/null 2>&1; then
+    echo "Detected catchall-DNS configuration. Using public remotes for conan."
+  elif curl -s http://artifactory.internal/ >/dev/null 2>&1; then
     echo "CI machine detected. Adjusting remotes..."
     conan remote add -i 0 -f artifactory "http://artifactory.internal/artifactory/api/conan/conan" || exit $?
     conan_disable_public_remotes || exit $?


### PR DESCRIPTION
Some ISPs have their DNS servers configured in such a way
that they return an A or AAAA record even for invalid DNS
names. That allows them to show the user a "Domain Name Not Found"
website - at least when the wrong request originates from a browser.

This behaviour breaks our CI machine detection which relied on
making an HTTP request to a hostname that only exists internally.

This commit fixes that by making another HTTP request which should does
not exist inside of the CI environment. If it succeeds we will know that
we hit the ISP's catchall website.

Bug: http://b/176184061
Test: Manually tested