### PR TITLE
Fix clang_format/license_header checks on release branches

### DIFF
--- a/kokoro/checks/clang_format/check.sh
+++ b/kokoro/checks/clang_format/check.sh
@@ -28,7 +28,7 @@ if [ "$0" == "$SCRIPT" ]; then
 
   cd /mnt
   # Use origin/master as reference branch, if not specified by kokoro
-  REFERENCE="${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-origin/master}"
+  REFERENCE="origin/${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-master}"
   MERGE_BASE="$(git merge-base $REFERENCE HEAD)" # Merge base is the commit on master this PR was branched from.
   FORMATTING_DIFF="$(git diff -U0 --no-color --relative $MERGE_BASE | clang-format-diff-9 -p1)"
 

--- a/kokoro/checks/license_headers/check.sh
+++ b/kokoro/checks/license_headers/check.sh
@@ -15,7 +15,7 @@ if [ "$0" == "$SCRIPT" ]; then
 
   cd /mnt
   # Use origin/master as reference branch, if not specified by kokoro
-  REFERENCE="${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-origin/master}"
+  REFERENCE="origin/${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-master}"
   MERGE_BASE="$(git merge-base $REFERENCE HEAD)" # Merge base is the commit on master this PR was branched from.
   LICENSE_HEADER_MISSED=""
 


### PR DESCRIPTION
These checks were broken due to the recently introduced automatic
detection of git target branch names. The kokoro variable contains the
branch name but for a checkout we also need to specify the remote name
`origin`. It happened to work for `master` because it's the default
branch and a local copy exists. That's not the case for a release
branch.

Bug: http://b/175678721
Test: Tested by creating a PR against an old release branch