### PR TITLE
Double-click should load presets and symbols.

### DIFF
--- a/OrbitGl/DataView.h
+++ b/OrbitGl/DataView.h
@@ -61,6 +61,7 @@ class DataView {
                              const std::vector<int>& item_indices);
   virtual void OnSelect(std::optional<int> /*index*/) {}
   virtual int GetSelectedIndex() { return selected_index_; }
+  virtual void OnDoubleClicked(int /*index*/) {}
   virtual void OnDataChanged();
   virtual void OnTimer() {}
   virtual bool WantsDisplayColor() { return false; }

--- a/OrbitGl/ModulesDataView.cpp
+++ b/OrbitGl/ModulesDataView.cpp
@@ -143,6 +143,14 @@ void ModulesDataView::OnContextMenu(const std::string& action, int menu_index,
   }
 }
 
+void ModulesDataView::OnDoubleClicked(int index) {
+  ModuleData* module_data = GetModule(index);
+  if (!module_data->is_loaded()) {
+    std::vector<ModuleData*> modules_to_load = {module_data};
+    app_->LoadModules(modules_to_load);
+  }
+}
+
 void ModulesDataView::DoFilter() {
   std::vector<uint32_t> indices;
   std::vector<std::string> tokens = absl::StrSplit(ToLower(filter_), ' ');

--- a/OrbitGl/ModulesDataView.h
+++ b/OrbitGl/ModulesDataView.h
@@ -23,6 +23,7 @@ class ModulesDataView : public DataView {
 
   void OnContextMenu(const std::string& action, int menu_index,
                      const std::vector<int>& item_indices) override;
+  void OnDoubleClicked(int index) override;
   bool WantsDisplayColor() override { return true; }
   bool GetDisplayColor(int row, int column, unsigned char& red, unsigned char& green,
                        unsigned char& blue) override;

--- a/OrbitGl/PresetsDataView.cpp
+++ b/OrbitGl/PresetsDataView.cpp
@@ -157,6 +157,11 @@ void PresetsDataView::OnContextMenu(const std::string& action, int menu_index,
   }
 }
 
+void PresetsDataView::OnDoubleClicked(int index) {
+  const std::shared_ptr<PresetFile>& preset = GetPreset(index);
+  app_->LoadPreset(preset);
+}
+
 void PresetsDataView::DoFilter() {
   std::vector<uint32_t> indices;
 

--- a/OrbitGl/PresetsDataView.h
+++ b/OrbitGl/PresetsDataView.h
@@ -27,6 +27,7 @@ class PresetsDataView : public DataView {
   void OnDataChanged() override;
   void OnContextMenu(const std::string& action, int menu_index,
                      const std::vector<int>& item_indices) override;
+  void OnDoubleClicked(int index) override;
 
   bool WantsDisplayColor() override { return true; }
   bool GetDisplayColor(int /*row*/, int /*column*/, unsigned char& /*red*/,

--- a/OrbitQt/orbittreeview.cpp
+++ b/OrbitQt/orbittreeview.cpp
@@ -47,6 +47,8 @@ OrbitTreeView::OrbitTreeView(QWidget* parent) : QTreeView(parent), auto_resize_(
 
   connect(verticalScrollBar(), SIGNAL(rangeChanged(int, int)), this,
           SLOT(OnRangeChanged(int, int)));
+
+  connect(this, &OrbitTreeView::doubleClicked, this, &OrbitTreeView::OnDoubleClicked);
 }
 
 void OrbitTreeView::Initialize(DataView* data_view, SelectionType selection_type,
@@ -293,6 +295,12 @@ void OrbitTreeView::OnRangeChanged(int /*min*/, int max) {
   DataView* data_view = model_->GetDataView();
   if (data_view->ScrollToBottom()) {
     verticalScrollBar()->setValue(max);
+  }
+}
+
+void OrbitTreeView::OnDoubleClicked(QModelIndex index) {
+  if (model_ != nullptr) {
+    model_->GetDataView()->OnDoubleClicked(index.row());
   }
 }
 

--- a/OrbitQt/orbittreeview.h
+++ b/OrbitQt/orbittreeview.h
@@ -48,6 +48,7 @@ class OrbitTreeView : public QTreeView {
   void OnMenuClicked(const std::string& action, int menu_index);
   void OnRangeChanged(int min, int max);
   void OnRowSelected(std::optional<int> row);
+  void OnDoubleClicked(QModelIndex index);
 
  private:
   std::unique_ptr<OrbitTableModel> model_;


### PR DESCRIPTION
With this change: double-click in the preset view will load preset, and; double click in the modules view will load symbols.

Fixes bug: b/167661761.