### PR TITLE
Use information from MapPerfEvent to update process maps

### DIFF
--- a/OrbitGrpcProtos/capture.proto
+++ b/OrbitGrpcProtos/capture.proto
@@ -225,13 +225,14 @@ message AddressInfo {
   }
 }
 
-message ModulesUpdateEvent {
+message ModuleUpdateEvent {
   int32 pid = 1;
   uint64 timestamp_ns = 2;
-  repeated ModuleInfo modules = 3;
+  ModuleInfo module = 3;
 }
 
 message CaptureEvent {
+  reserved 14;
   oneof event {
     SchedulingSlice scheduling_slice = 1;
     InternedCallstack interned_callstack = 2;
@@ -246,6 +247,6 @@ message CaptureEvent {
     InternedTracepointInfo interned_tracepoint_info = 9;
     TracepointEvent tracepoint_event = 10;
     IntrospectionScope introspection_scope = 12;
-    ModulesUpdateEvent modules_update_event = 14;
+    ModuleUpdateEvent modules_update_event = 15;
   }
 }

--- a/OrbitLinuxTracing/CMakeLists.txt
+++ b/OrbitLinuxTracing/CMakeLists.txt
@@ -67,21 +67,37 @@ target_link_libraries(OrbitLinuxTracing PUBLIC
         CONAN_PKG::abseil
         CONAN_PKG::libunwindstack)
 
+add_executable(OrbitLinuxTracingTestDlopenPuppet)
+
+target_compile_options(OrbitLinuxTracingTestDlopenPuppet PRIVATE ${STRICT_COMPILE_FLAGS})
+
+target_sources(OrbitLinuxTracingTestDlopenPuppet PRIVATE
+        TestPuppet.cpp)
+
+target_link_libraries(OrbitLinuxTracingTestDlopenPuppet PUBLIC
+        dl
+        OrbitBase)
+
+add_library(OrbitLinuxTracingTestPuppetLibrary SHARED)
+
+target_compile_options(OrbitLinuxTracingTestPuppetLibrary PRIVATE ${STRICT_COMPILE_FLAGS})
+
+target_sources(OrbitLinuxTracingTestPuppetLibrary PRIVATE
+        TestPuppetLibrary.cpp)
+
 add_executable(OrbitLinuxTracingTests)
 
 target_compile_options(OrbitLinuxTracingTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
-if (NOT WIN32)
-    target_sources(OrbitLinuxTracingTests PRIVATE
-            ContextSwitchManagerTest.cpp
-            GpuTracepointEventProcessorTest.cpp
-            LinuxTracingUtilsTest.cpp
-            PerfEventProcessorTest.cpp
-            PerfEventQueueTest.cpp
-            ThreadStateManagerTest.cpp
-            UprobesFunctionCallManagerTest.cpp
-            UprobesReturnAddressManagerTest.cpp)
-endif()
+target_sources(OrbitLinuxTracingTests PRIVATE
+        ContextSwitchManagerTest.cpp
+        GpuTracepointEventProcessorTest.cpp
+        LinuxTracingUtilsTest.cpp
+        PerfEventProcessorTest.cpp
+        PerfEventQueueTest.cpp
+        ThreadStateManagerTest.cpp
+        UprobesFunctionCallManagerTest.cpp
+        UprobesReturnAddressManagerTest.cpp)
 
 target_link_libraries(OrbitLinuxTracingTests PRIVATE
         OrbitLinuxTracing

--- a/OrbitLinuxTracing/GpuTracepointEventProcessorTest.cpp
+++ b/OrbitLinuxTracing/GpuTracepointEventProcessorTest.cpp
@@ -25,7 +25,7 @@ class MockTracerListener : public TracerListener {
   MOCK_METHOD(void, OnThreadStateSlice, (orbit_grpc_protos::ThreadStateSlice), (override));
   MOCK_METHOD(void, OnAddressInfo, (orbit_grpc_protos::AddressInfo), (override));
   MOCK_METHOD(void, OnTracepointEvent, (orbit_grpc_protos::TracepointEvent), (override));
-  MOCK_METHOD(void, OnModulesUpdate, (orbit_grpc_protos::ModulesUpdateEvent), (override));
+  MOCK_METHOD(void, OnModulesUpdate, (orbit_grpc_protos::ModuleUpdateEvent), (override));
 };
 
 class GpuTracepointEventProcessorTest : public ::testing::Test {

--- a/OrbitLinuxTracing/PerfEvent.cpp
+++ b/OrbitLinuxTracing/PerfEvent.cpp
@@ -30,7 +30,7 @@ void UretprobesPerfEvent::Accept(PerfEventVisitor* visitor) { visitor->visit(thi
 
 void LostPerfEvent::Accept(PerfEventVisitor* visitor) { visitor->visit(this); }
 
-void MapsPerfEvent::Accept(PerfEventVisitor* visitor) { visitor->visit(this); }
+void MmapPerfEvent::Accept(PerfEventVisitor* visitor) { visitor->visit(this); }
 
 void TaskNewtaskPerfEvent::Accept(PerfEventVisitor* visitor) { visitor->visit(this); }
 

--- a/OrbitLinuxTracing/PerfEventReaders.h
+++ b/OrbitLinuxTracing/PerfEventReaders.h
@@ -21,7 +21,11 @@ namespace orbit_linux_tracing {
 
 // Helper functions for reads from a perf_event_open ring buffer that require
 // more complex operations than simply copying an entire perf_event_open record.
-pid_t ReadMmapRecordPid(PerfEventRingBuffer* ring_buffer);
+
+// This function reads sample_id, which is always the last field
+// in the perf event record unless it is PERF_RECORD_SAMPLE.
+void ReadPerfSampleIdAll(PerfEventRingBuffer* ring_buffer, const perf_event_header& header,
+                         perf_event_sample_id_tid_time_streamid_cpu* sample_id);
 
 uint64_t ReadSampleRecordTime(PerfEventRingBuffer* ring_buffer);
 
@@ -37,6 +41,9 @@ std::unique_ptr<CallchainSamplePerfEvent> ConsumeCallchainSamplePerfEvent(
 
 std::unique_ptr<GenericTracepointPerfEvent> ConsumeGenericTracepointPerfEvent(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header);
+
+std::unique_ptr<MmapPerfEvent> ConsumeMmapPerfEvent(PerfEventRingBuffer* ring_buffer,
+                                                    const perf_event_header& header);
 
 template <typename T, typename = std::enable_if_t<std::is_base_of_v<TracepointPerfEvent, T>>>
 std::unique_ptr<T> ConsumeTracepointPerfEvent(PerfEventRingBuffer* ring_buffer,

--- a/OrbitLinuxTracing/PerfEventRecords.h
+++ b/OrbitLinuxTracing/PerfEventRecords.h
@@ -139,6 +139,17 @@ struct __attribute__((__packed__)) perf_event_lost {
   perf_event_sample_id_tid_time_streamid_cpu sample_id;
 };
 
+struct __attribute__((__packed__)) perf_event_mmap_up_to_pgoff {
+  perf_event_header header;
+  uint32_t pid;
+  uint32_t tid;
+  uint64_t address;
+  uint64_t length;
+  uint64_t page_offset;
+  // OMITTED: char filename[]
+  // OMITTED: perf_event_sample_id_tid_time_streamid_cpu sample_id;
+};
+
 }  // namespace orbit_linux_tracing
 
 #endif  // ORBIT_LINUX_TRACING_PERF_EVENT_RECORDS_H_

--- a/OrbitLinuxTracing/PerfEventVisitor.h
+++ b/OrbitLinuxTracing/PerfEventVisitor.h
@@ -22,7 +22,7 @@ class PerfEventVisitor {
   virtual void visit(UprobesPerfEvent*) {}
   virtual void visit(UretprobesPerfEvent*) {}
   virtual void visit(LostPerfEvent*) {}
-  virtual void visit(MapsPerfEvent*) {}
+  virtual void visit(MmapPerfEvent*) {}
   virtual void visit(TaskNewtaskPerfEvent*) {}
   virtual void visit(TaskRenamePerfEvent*) {}
   virtual void visit(SchedSwitchPerfEvent*) {}

--- a/OrbitLinuxTracing/TestPuppet.cpp
+++ b/OrbitLinuxTracing/TestPuppet.cpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This is test executable used by LinuxTracing tests to test profiling functionality
+// The control is done by executing commands
+
+#include <dlfcn.h>
+
+#include <iostream>
+#include <string>
+#include <thread>
+
+#include "OrbitBase/ExecutablePath.h"
+#include "OrbitBase/Logging.h"
+
+// dlopen and call function_that_sleeps_for_one_second 10 times.
+static void run_dlopen() {
+  static const char* kLibraryFile = "libOrbitLinuxTracingTestPuppetLibrary.so";
+  static const char* kFunctionName = "function_that_works_for_considerable_amount_of_time";
+  // Setting rpath in CMAKE is a nightmare.. I was not able to do that, so we are going
+  // to emulate "$ORIGIN/../lib" rpath here.
+  std::string library_path =
+      (orbit_base::GetExecutableDir() / ".." / "lib" / kLibraryFile).string();
+  void* handle = dlopen(library_path.c_str(), RTLD_NOW);
+  if (handle == nullptr) {
+    FATAL("Unable to open \"%s\": %s", kLibraryFile, dlerror());
+  }
+
+  typedef double (*function_type)();
+  function_type function = reinterpret_cast<function_type>(dlsym(handle, kFunctionName));
+  if (function == nullptr) {
+    FATAL("Unable to find function \"%s\" in \"%s\": %s", kFunctionName, kLibraryFile, dlerror());
+  }
+
+  for (size_t i = 0; i < 10; ++i) {
+    std::cout << "Some useless number: " << function() << std::endl;
+  }
+}
+
+int main() {
+  std::cout << "Press ENTER to continue... ";
+  std::string line;
+  std::getline(std::cin, line);
+  run_dlopen();
+  std::cout << "Press ENTER to exit... ";
+  std::getline(std::cin, line);
+  return 0;
+}

--- a/OrbitLinuxTracing/TestPuppetLibrary.cpp
+++ b/OrbitLinuxTracing/TestPuppetLibrary.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <cmath>
+
+// extern "C" to have unmangled name in the symbol table
+extern "C" double function_that_works_for_considerable_amount_of_time() {
+  double result = 2;
+
+  for (size_t i = 0; i < 100'000'000; ++i) {
+    result = sqrt(result + 1.0);
+  }
+
+  return result;
+}

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.h
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.h
@@ -66,7 +66,7 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   void visit(CallchainSamplePerfEvent* event) override;
   void visit(UprobesPerfEvent* event) override;
   void visit(UretprobesPerfEvent* event) override;
-  void visit(MapsPerfEvent* event) override;
+  void visit(MmapPerfEvent* event) override;
 
  private:
   UprobesFunctionCallManager function_call_manager_{};

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/TracerListener.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/TracerListener.h
@@ -21,7 +21,7 @@ class TracerListener {
   virtual void OnThreadStateSlice(orbit_grpc_protos::ThreadStateSlice thread_state_slice) = 0;
   virtual void OnAddressInfo(orbit_grpc_protos::AddressInfo address_info) = 0;
   virtual void OnTracepointEvent(orbit_grpc_protos::TracepointEvent tracepoint_event) = 0;
-  virtual void OnModulesUpdate(orbit_grpc_protos::ModulesUpdateEvent modules_update_event) = 0;
+  virtual void OnModulesUpdate(orbit_grpc_protos::ModuleUpdateEvent modules_update_event) = 0;
 };
 
 }  // namespace orbit_linux_tracing

--- a/OrbitService/LinuxTracingHandler.cpp
+++ b/OrbitService/LinuxTracingHandler.cpp
@@ -144,7 +144,7 @@ void LinuxTracingHandler::OnTracepointEvent(orbit_grpc_protos::TracepointEvent t
 }
 
 void LinuxTracingHandler::OnModulesUpdate(
-    orbit_grpc_protos::ModulesUpdateEvent modules_update_event) {
+    orbit_grpc_protos::ModuleUpdateEvent modules_update_event) {
   orbit_grpc_protos::CaptureEvent event;
   *event.mutable_modules_update_event() = std::move(modules_update_event);
 

--- a/OrbitService/LinuxTracingHandler.h
+++ b/OrbitService/LinuxTracingHandler.h
@@ -39,7 +39,7 @@ class LinuxTracingHandler : public orbit_linux_tracing::TracerListener {
   void OnThreadStateSlice(orbit_grpc_protos::ThreadStateSlice thread_state_slice) override;
   void OnAddressInfo(orbit_grpc_protos::AddressInfo address_info) override;
   void OnTracepointEvent(orbit_grpc_protos::TracepointEvent tracepoint_event) override;
-  void OnModulesUpdate(orbit_grpc_protos::ModulesUpdateEvent modules_update_event) override;
+  void OnModulesUpdate(orbit_grpc_protos::ModuleUpdateEvent modules_update_event) override;
 
  private:
   CaptureEventBuffer* capture_event_buffer_;


### PR DESCRIPTION
Instead of reading /proc/pid/maps on every MapPerfEvent
update existing map using information from MapsPerfEvent

Also add a test process that dlopens a library and calls it to
test this scenario.

Test: Run capture OrbitLinuxTracingTestPuppet, check stack-traces.