### PR TITLE
Changed TimerTrack::GetYFromDepth to TimerTrack::GetYFromTimer.

### DIFF
--- a/OrbitGl/FrameTrack.cpp
+++ b/OrbitGl/FrameTrack.cpp
@@ -83,7 +83,7 @@ float FrameTrack::GetHeight() const {
   return GetMaximumBoxHeight() + layout.GetTrackBottomMargin();
 }
 
-float FrameTrack::GetYFromDepth(uint32_t /*depth*/) const {
+float FrameTrack::GetYFromTimer(const TimerInfo& /*timer_info*/) const {
   return pos_[1] - GetMaximumBoxHeight();
 }
 

--- a/OrbitGl/FrameTrack.h
+++ b/OrbitGl/FrameTrack.h
@@ -29,7 +29,8 @@ class FrameTrack : public TimerTrack {
   [[nodiscard]] uint64_t GetFunctionAddress() const { return function_.address(); }
   [[nodiscard]] bool IsCollapsable() const override { return GetMaximumScaleFactor() > 0.f; }
 
-  [[nodiscard]] virtual float GetYFromDepth(uint32_t depth) const override;
+  [[nodiscard]] virtual float GetYFromTimer(
+      const orbit_client_protos::TimerInfo& timer_info) const override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
 
   [[nodiscard]] float GetTextBoxHeight(

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -97,9 +97,9 @@ Color GpuTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected) con
   return color;
 }
 
-float GpuTrack::GetYFromDepth(uint32_t depth) const {
+float GpuTrack::GetYFromTimer(const TimerInfo& timer_info) const {
   const TimeGraphLayout& layout = time_graph_->GetLayout();
-  float adjusted_depth = static_cast<float>(depth);
+  auto adjusted_depth = static_cast<float>(timer_info.depth());
   if (collapse_toggle_->IsCollapsed()) {
     adjusted_depth = 0.f;
   }

--- a/OrbitGl/GpuTrack.h
+++ b/OrbitGl/GpuTrack.h
@@ -35,7 +35,8 @@ class GpuTrack : public TimerTrack {
   [[nodiscard]] const TextBox* GetLeft(const TextBox* text_box) const override;
   [[nodiscard]] const TextBox* GetRight(const TextBox* text_box) const override;
 
-  [[nodiscard]] float GetYFromDepth(uint32_t depth) const override;
+  [[nodiscard]] float GetYFromTimer(
+      const orbit_client_protos::TimerInfo& timer_info) const override;
 
  protected:
   [[nodiscard]] bool IsTimerActive(const orbit_client_protos::TimerInfo& timer) const override;

--- a/OrbitGl/SchedulerTrack.cpp
+++ b/OrbitGl/SchedulerTrack.cpp
@@ -49,10 +49,10 @@ Color SchedulerTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selecte
   return time_graph_->GetThreadColor(timer_info.thread_id());
 }
 
-float SchedulerTrack::GetYFromDepth(uint32_t depth) const {
+float SchedulerTrack::GetYFromTimer(const TimerInfo& timer_info) const {
   const TimeGraphLayout& layout = time_graph_->GetLayout();
-  uint32_t num_gaps = depth;
-  return pos_[1] - (layout.GetTextCoresHeight() * (depth + 1)) -
+  uint32_t num_gaps = timer_info.depth();
+  return pos_[1] - (layout.GetTextCoresHeight() * static_cast<float>(timer_info.depth() + 1)) -
          num_gaps * layout.GetSpaceBetweenCores();
 }
 

--- a/OrbitGl/SchedulerTrack.h
+++ b/OrbitGl/SchedulerTrack.h
@@ -22,7 +22,8 @@ class SchedulerTrack final : public TimerTrack {
   [[nodiscard]] bool IsCollapsable() const override { return false; }
 
   void UpdateBoxHeight() override;
-  [[nodiscard]] float GetYFromDepth(uint32_t depth) const override;
+  [[nodiscard]] float GetYFromTimer(
+      const orbit_client_protos::TimerInfo& timer_info) const override;
 
  protected:
   [[nodiscard]] bool IsTimerActive(const orbit_client_protos::TimerInfo& timer_info) const override;

--- a/OrbitGl/TimerTrack.cpp
+++ b/OrbitGl/TimerTrack.cpp
@@ -43,10 +43,10 @@ std::string TimerTrack::GetExtraInfo(const TimerInfo& timer_info) {
   return info;
 }
 
-float TimerTrack::GetYFromDepth(uint32_t depth) const {
+float TimerTrack::GetYFromTimer(const TimerInfo& timer_info) const {
   const TimeGraphLayout& layout = time_graph_->GetLayout();
   return pos_[1] - GetHeaderHeight() - layout.GetSpaceBetweenTracksAndThread() -
-         box_height_ * (depth + 1);
+         box_height_ * static_cast<float>(timer_info.depth() + 1);
 }
 
 void TimerTrack::UpdateBoxHeight() { box_height_ = time_graph_->GetLayout().GetTextBoxHeight(); }
@@ -106,7 +106,7 @@ void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
         double normalized_length = elapsed_us * inv_time_window;
         float world_timer_width = static_cast<float>(normalized_length * world_width);
         float world_timer_x = static_cast<float>(world_start_x + normalized_start * world_width);
-        float world_timer_y = GetYFromDepth(timer_info.depth());
+        float world_timer_y = GetYFromTimer(timer_info);
 
         bool is_visible_width = normalized_length * canvas->GetWidth() > 1;
         bool is_selected = &text_box == selected_textbox;

--- a/OrbitGl/TimerTrack.h
+++ b/OrbitGl/TimerTrack.h
@@ -61,7 +61,7 @@ class TimerTrack : public Track {
   virtual void UpdateBoxHeight();
   [[nodiscard]] virtual float GetTextBoxHeight(
       const orbit_client_protos::TimerInfo& /*timer_info*/) const;
-  [[nodiscard]] virtual float GetYFromDepth(uint32_t depth) const;
+  [[nodiscard]] virtual float GetYFromTimer(const orbit_client_protos::TimerInfo& timer_info) const;
 
   [[nodiscard]] virtual float GetHeaderHeight() const;
 


### PR DESCRIPTION
In order to share the implementation of GpuTracks with and without
command buffer information, GpuTrack's `GetY...` implementations
needs to be aware of the timer type (in addition to the plain depth).
Therefore, this changes the method signature, to pass a timer
instead of only the timer's depth.

Test: Compile
Bug: http://b/176809754