### PR TITLE
Use `switch` instead of `if(...) else if(...)` in TimerGraph.

### DIFF
--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -271,6 +271,9 @@ void TimeGraph::ProcessTimer(const TimerInfo& timer_info, const FunctionInfo* fu
       break;
     }
     case TimerInfo::kCoreActivity: {
+      // TODO(b/176962090): We need to create the `ThreadTrack` here even we don't use it, as we
+      //  don't create it on new callstack events, yet.
+      track_manager_->GetOrCreateThreadTrack(timer_info.thread_id());
       SchedulerTrack* track = track_manager_->GetOrCreateSchedulerTrack();
       track->OnTimer(timer_info);
       if (GetNumCores() <= static_cast<uint32_t>(timer_info.processor())) {

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -249,6 +249,8 @@ void TimeGraph::ProcessTimer(const TimerInfo& timer_info, const FunctionInfo* fu
     ProcessOrbitFunctionTimer(function->orbit_type(), timer_info);
   }
 
+  // TODO (b/175869409): Change the way to create and get the tracks. Move this part to
+  // TrackManager.
   switch (timer_info.type()) {
     case TimerInfo::kGpuActivity: {
       uint64_t timeline_hash = timer_info.timeline_hash();


### PR DESCRIPTION
This changes the switch over the different timer types from
an `if(...) else if(...)` construct to a switch statement,
which makes the code more readable and error prone (we will fail
if we miss a case).
Also it avoids having a "default" case (as present before) to
make the code more robust by explicitly stating the expected
case.

Test: Compile