### PR TITLE
Fix clean-up routine in Kokoro's Build script

### DIFF
--- a/kokoro/builds/build.sh
+++ b/kokoro/builds/build.sh
@@ -71,7 +71,7 @@ if [ -n "$1" ]; then
                             ! -path "${MOUNT_POINT}/github" \
                             ! -path "${REPO_ROOT}" \
                             ! -path "${REPO_ROOT}/kokoro*" \
-                            ! -path "${REPO_ROOT}/build*"
+                            ! -path "${REPO_ROOT}/build*" \
                             -delete
       echo "Cleanup for non-presubmit done."
     fi


### PR DESCRIPTION
There was a backslash missing which made the `-delete` option be
interpreted as an independent command. Fixed by the commit.