### PR TITLE
Draw timebar lines again

### DIFF
--- a/OrbitGl/CaptureWindow.cpp
+++ b/OrbitGl/CaptureWindow.cpp
@@ -563,6 +563,7 @@ void CaptureWindow::Draw() {
     ui_batcher_.DrawLayer(layer, GetPickingMode() != PickingMode::kNone);
 
     PrepareScreenSpaceViewport();
+    // Text needs to be drawn in screen space.
     if (GetPickingMode() == PickingMode::kNone) {
       text_renderer_.RenderLayer(&ui_batcher_, layer);
       RenderText(layer);
@@ -859,7 +860,8 @@ void CaptureWindow::RenderTimeBar() {
       text_renderer_.AddText(text.c_str(), world_x + x_margin, world_y, GlCanvas::kZValueTimeBar,
                              Color(255, 255, 255, 255), font_size_);
 
-      Vec2 pos(world_x, world_y);
+      // Lines from time bar are drawn in screen space.
+      Vec2 pos = QtScreenToGlScreen(WorldToScreen(Vec2(world_x, world_y)));
       ui_batcher_.AddVerticalLine(pos, height, GlCanvas::kZValueTimeBar, Color(255, 255, 255, 255));
     }
   }

--- a/OrbitGl/GlCanvas.cpp
+++ b/OrbitGl/GlCanvas.cpp
@@ -359,6 +359,14 @@ Vec2 GlCanvas::WorldToScreen(Vec2 world_pos) const {
   return screen_pos;
 }
 
+// TODO (b/177350599): Unify QtScreen and GlScreen
+// QtScreen(x,y) --> GlScreen(x,height-y)
+Vec2 GlCanvas::QtScreenToGlScreen(Vec2 qt_pos) const {
+  Vec2 gl_pos = qt_pos;
+  gl_pos[1] = GetHeight() - qt_pos[1];
+  return gl_pos;
+}
+
 int GlCanvas::WorldToScreenHeight(float height) const {
   return static_cast<int>(height / world_height_ * GetHeight());
 }

--- a/OrbitGl/GlCanvas.h
+++ b/OrbitGl/GlCanvas.h
@@ -65,6 +65,7 @@ class GlCanvas {
   Vec2 WorldToScreen(Vec2 world_pos) const;
   int WorldToScreenHeight(float height) const;
   int WorldToScreenWidth(float width) const;
+  Vec2 QtScreenToGlScreen(Vec2 qt_pos) const;
 
   // events
   virtual void MouseMoved(int x, int y, bool left, bool right, bool middle);


### PR DESCRIPTION
Regression from 1.55 (new drawing order).
We are using a wrong coordinate system to draw time bar lines.
Before 1.55 we had two different batchers to draw items for each
coordinate system and we had merged both in one. 

In this PR:
 - We draw time bar lines using screen space coordinate system.
 
 - We make a function to convert Qt-Screen To Gl-Screen 
 
 - We added a comment after a discussion with Pierric about Text should be drawn in screen space.

Related to http://b/175532525.

Test: Run Orbit + Load a Capture.