### PR TITLE
Add FindFunctionAbsoluteAddressByAddress to CaptureData.

### DIFF
--- a/OrbitClientModel/CaptureData.cpp
+++ b/OrbitClientModel/CaptureData.cpp
@@ -112,11 +112,12 @@ const std::string& CaptureData::GetFunctionNameByAddress(uint64_t absolute_addre
   return function_name;
 }
 
-// Find the start address of the function this address falls inside. Use the Function returned by
+// Find the start address of the function this address falls inside. Use the function returned by
 // FindFunctionByAddress, and when this fails (e.g., the module containing the function has not
 // been loaded) use (for now) the LinuxAddressInfo that is collected for every address in a
 // callstack.
-uint64_t CaptureData::GetFunctionBaseAddressByAddress(uint64_t absolute_address) const {
+std::optional<uint64_t> CaptureData::FindFunctionAbsoluteAddressByAddress(
+    uint64_t absolute_address) const {
   const FunctionInfo* function = FindFunctionByAddress(absolute_address, false);
   if (function != nullptr) {
     return GetAbsoluteAddress(*function);
@@ -125,7 +126,7 @@ uint64_t CaptureData::GetFunctionBaseAddressByAddress(uint64_t absolute_address)
   if (address_info != nullptr) {
     return absolute_address - address_info->offset_in_function();
   }
-  return absolute_address;
+  return std::nullopt;
 }
 
 const std::string& CaptureData::GetModulePathByAddress(uint64_t absolute_address) const {

--- a/OrbitClientModel/CaptureData.cpp
+++ b/OrbitClientModel/CaptureData.cpp
@@ -112,6 +112,22 @@ const std::string& CaptureData::GetFunctionNameByAddress(uint64_t absolute_addre
   return function_name;
 }
 
+// Find the start address of the function this address falls inside. Use the Function returned by
+// FindFunctionByAddress, and when this fails (e.g., the module containing the function has not
+// been loaded) use (for now) the LinuxAddressInfo that is collected for every address in a
+// callstack.
+uint64_t CaptureData::GetFunctionBaseAddressByAddress(uint64_t absolute_address) const {
+  const FunctionInfo* function = FindFunctionByAddress(absolute_address, false);
+  if (function != nullptr) {
+    return GetAbsoluteAddress(*function);
+  }
+  const LinuxAddressInfo* address_info = GetAddressInfo(absolute_address);
+  if (address_info != nullptr) {
+    return absolute_address - address_info->offset_in_function();
+  }
+  return absolute_address;
+}
+
 const std::string& CaptureData::GetModulePathByAddress(uint64_t absolute_address) const {
   const ModuleData* module_data = FindModuleByAddress(absolute_address);
   if (module_data != nullptr) {

--- a/OrbitClientModel/SamplingDataPostProcessor.cpp
+++ b/OrbitClientModel/SamplingDataPostProcessor.cpp
@@ -189,8 +189,9 @@ void SamplingDataPostProcessor::MapAddressToFunctionAddress(uint64_t absolute_ad
   // SamplingDataPostProcessor relies heavily on the association between address and function
   // address held by exact_address_to_function_address_, otherwise each address is considered a
   // different function. We are storing this mapping for faster lookup.
-  uint64_t absolute_function_address =
-      capture_data.GetFunctionBaseAddressByAddress(absolute_address);
+  std::optional<uint64_t> absolute_function_address_option =
+      capture_data.FindFunctionAbsoluteAddressByAddress(absolute_address);
+  uint64_t absolute_function_address = absolute_function_address_option.value_or(absolute_address);
 
   exact_address_to_function_address_[absolute_address] = absolute_function_address;
   function_address_to_exact_addresses_[absolute_function_address].insert(absolute_address);

--- a/OrbitClientModel/include/OrbitClientModel/CaptureData.h
+++ b/OrbitClientModel/include/OrbitClientModel/CaptureData.h
@@ -70,7 +70,8 @@ class CaptureData {
   void InsertAddressInfo(orbit_client_protos::LinuxAddressInfo address_info);
 
   [[nodiscard]] const std::string& GetFunctionNameByAddress(uint64_t absolute_address) const;
-  [[nodiscard]] uint64_t GetFunctionBaseAddressByAddress(uint64_t absolute_address) const;
+  [[nodiscard]] std::optional<uint64_t> FindFunctionAbsoluteAddressByAddress(
+      uint64_t absolute_address) const;
   [[nodiscard]] const std::string& GetModulePathByAddress(uint64_t absolute_address) const;
   [[nodiscard]] const ModuleData* GetModuleByPath(const std::string& module_path) const {
     return module_manager_->GetModuleByPath(module_path);

--- a/OrbitClientModel/include/OrbitClientModel/CaptureData.h
+++ b/OrbitClientModel/include/OrbitClientModel/CaptureData.h
@@ -70,6 +70,7 @@ class CaptureData {
   void InsertAddressInfo(orbit_client_protos::LinuxAddressInfo address_info);
 
   [[nodiscard]] const std::string& GetFunctionNameByAddress(uint64_t absolute_address) const;
+  [[nodiscard]] uint64_t GetFunctionBaseAddressByAddress(uint64_t absolute_address) const;
   [[nodiscard]] const std::string& GetModulePathByAddress(uint64_t absolute_address) const;
   [[nodiscard]] const ModuleData* GetModuleByPath(const std::string& module_path) const {
     return module_manager_->GetModuleByPath(module_path);


### PR DESCRIPTION
This adds a `GetFunctionBaseAddressByAddress` to `CaptureData` that
computes the functions's base address from an absolute address
inside a function based on either `ModuleData` or `LinuxAddressInfo`.
If both information are not available, it assumes the give address
is the base address.

This information was already computed internally in the
`SamplingDataPostProcessor`, but not made available. Instead of
just making this available in the `PostProcessedSamplingData`,
the new function goes to `CaptureData`, where sematically close
functions like `GetFunctionNameByAddress` are located.
Inside the `SamplingDataPostProcessor`, we now use the new function,
but still store the results in the map to avoid recomputations.

Bug: http://b/176970009
Test: Take a capture validate callstacks, load module and redo
      the validation.