### PR TITLE
Handle Vulkan-based Timers in GpuTrack.

### DIFF
--- a/OrbitGl/FrameTrack.h
+++ b/OrbitGl/FrameTrack.h
@@ -27,7 +27,7 @@ class FrameTrack : public TimerTrack {
                       OrbitApp* app);
   [[nodiscard]] Type GetType() const override { return kFrameTrack; }
   [[nodiscard]] uint64_t GetFunctionAddress() const { return function_.address(); }
-  [[nodiscard]] bool IsCollapsable() const override { return GetMaximumScaleFactor() > 0.f; }
+  [[nodiscard]] bool IsCollapsible() const override { return GetMaximumScaleFactor() > 0.f; }
 
   [[nodiscard]] virtual float GetYFromTimer(
       const orbit_client_protos::TimerInfo& timer_info) const override;

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -64,7 +64,7 @@ GpuTrack::GpuTrack(TimeGraph* time_graph, StringManager* string_manager, uint64_
 }
 
 void GpuTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
-  // In case of having command buffer timers, we need to double the depth of the Gpu timers (as we
+  // In case of having command buffer timers, we need to double the depth of the GPU timers (as we
   // are drawing the corresponding command buffer timers below them). Therefore, we watch out for
   // those timers.
   if (timer_info.type() == TimerInfo::kGpuCommandBuffer) {
@@ -147,7 +147,7 @@ float GpuTrack::GetYFromTimer(const TimerInfo& timer_info) const {
   CHECK(timer_info.type() == TimerInfo::kGpuActivity ||
         timer_info.type() == TimerInfo::kGpuCommandBuffer);
 
-  // Command buffer timers to be drawn underneath the matching "hw execution" timer, which as the
+  // Command buffer timers are drawn underneath the matching "hw execution" timer, which has the
   // same depth value as the command buffer timer. Therefore, we need to double the depth in the
   // case that we have command buffer timers.
   if (has_vulkan_layer_command_buffer_timers_) {

--- a/OrbitGl/GpuTrack.cpp
+++ b/OrbitGl/GpuTrack.cpp
@@ -93,10 +93,14 @@ Color GpuTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected) con
     return kInactiveColor;
   }
   if (timer_info.has_color()) {
-    return Color(static_cast<uint8_t>(timer_info.color().red() * 255),
-                 static_cast<uint8_t>(timer_info.color().green() * 255),
-                 static_cast<uint8_t>(timer_info.color().blue() * 255),
-                 static_cast<uint8_t>(timer_info.color().alpha() * 255));
+    CHECK(timer_info.color().red() < 256);
+    CHECK(timer_info.color().green() < 256);
+    CHECK(timer_info.color().blue() < 256);
+    CHECK(timer_info.color().alpha() < 256);
+    return Color(static_cast<uint8_t>(timer_info.color().red()),
+                 static_cast<uint8_t>(timer_info.color().green()),
+                 static_cast<uint8_t>(timer_info.color().blue()),
+                 static_cast<uint8_t>(timer_info.color().alpha()));
   }
   if (timer_info.type() == TimerInfo::kGpuDebugMarker) {
     std::string marker_text = string_manager_->Get(timer_info.user_data_key()).value_or("");

--- a/OrbitGl/GpuTrack.h
+++ b/OrbitGl/GpuTrack.h
@@ -38,6 +38,12 @@ class GpuTrack : public TimerTrack {
   [[nodiscard]] float GetYFromTimer(
       const orbit_client_protos::TimerInfo& timer_info) const override;
 
+  void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
+
+  [[nodiscard]] bool IsCollapsable() const override {
+    return depth_ > 1 || has_vulkan_layer_command_buffer_timers_;
+  }
+
  protected:
   [[nodiscard]] bool IsTimerActive(const orbit_client_protos::TimerInfo& timer) const override;
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer,
@@ -50,11 +56,16 @@ class GpuTrack : public TimerTrack {
  private:
   uint64_t timeline_hash_;
   StringManager* string_manager_;
+  bool has_vulkan_layer_command_buffer_timers_ = false;
   [[nodiscard]] std::string GetSwQueueTooltip(
       const orbit_client_protos::TimerInfo& timer_info) const;
   [[nodiscard]] std::string GetHwQueueTooltip(
       const orbit_client_protos::TimerInfo& timer_info) const;
   [[nodiscard]] std::string GetHwExecutionTooltip(
+      const orbit_client_protos::TimerInfo& timer_info) const;
+  [[nodiscard]] std::string GetCommandBufferTooltip(
+      const orbit_client_protos::TimerInfo& timer_info) const;
+  [[nodiscard]] std::string GetDebugMarkerTooltip(
       const orbit_client_protos::TimerInfo& timer_info) const;
 };
 

--- a/OrbitGl/GpuTrack.h
+++ b/OrbitGl/GpuTrack.h
@@ -40,7 +40,7 @@ class GpuTrack : public TimerTrack {
 
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
 
-  [[nodiscard]] bool IsCollapsable() const override {
+  [[nodiscard]] bool IsCollapsible() const override {
     return depth_ > 1 || has_vulkan_layer_command_buffer_timers_;
   }
 

--- a/OrbitGl/SchedulerTrack.h
+++ b/OrbitGl/SchedulerTrack.h
@@ -19,7 +19,7 @@ class SchedulerTrack final : public TimerTrack {
   [[nodiscard]] std::string GetTooltip() const override;
 
   [[nodiscard]] float GetHeight() const override;
-  [[nodiscard]] bool IsCollapsable() const override { return false; }
+  [[nodiscard]] bool IsCollapsible() const override { return false; }
 
   void UpdateBoxHeight() override;
   [[nodiscard]] float GetYFromTimer(

--- a/OrbitGl/TimerTrack.h
+++ b/OrbitGl/TimerTrack.h
@@ -56,7 +56,7 @@ class TimerTrack : public Track {
   [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllSerializableChains() const override;
   [[nodiscard]] bool IsEmpty() const override;
 
-  [[nodiscard]] bool IsCollapsable() const override { return depth_ > 1; }
+  [[nodiscard]] bool IsCollapsible() const override { return depth_ > 1; }
 
   virtual void UpdateBoxHeight();
   [[nodiscard]] virtual float GetTextBoxHeight(

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -144,7 +144,7 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
   }
 
   // Collapse toggle state management.
-  if (!this->IsCollapsable()) {
+  if (!this->IsCollapsible()) {
     collapse_toggle_->SetState(TriangleToggle::State::kInactive);
   } else if (collapse_toggle_->IsInactive()) {
     collapse_toggle_->ResetToInitialState();

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -101,7 +101,7 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
 
   void AddChild(std::shared_ptr<Track> track) { children_.emplace_back(track); }
   virtual void OnCollapseToggle(TriangleToggle::State state);
-  [[nodiscard]] virtual bool IsCollapsable() const { return false; }
+  [[nodiscard]] virtual bool IsCollapsible() const { return false; }
   [[nodiscard]] int32_t GetProcessId() const { return process_id_; }
   void SetProcessId(uint32_t pid) { process_id_ = pid; }
   [[nodiscard]] virtual bool IsEmpty() const = 0;

--- a/OrbitGl/TrackAccessibility.cpp
+++ b/OrbitGl/TrackAccessibility.cpp
@@ -110,7 +110,7 @@ AccessibilityState AccessibleTrack::AccessibleState() const {
   if (track_->IsTrackSelected()) {
     result |= State::Focused;
   }
-  if (track_->IsCollapsable()) {
+  if (track_->IsCollapsible()) {
     result |= State::Expandable;
     if (track_->IsCollapsed()) {
       result |= State::Collapsed;


### PR DESCRIPTION
This adds support for Vulkan debug marker and command buffer timers
to the GpuTrack.
Command buffer timers will be drawn underneath their corresponding
hw execution timer, which requires to double the depth in the case
that we do have those timers.

For now, debug markers will be drawn on a separate track (named by
the timeline + "_marker"). For the future, we want to combine those
into a composed track.
Colors of the debug markers will either be picked up by the user's
choice, or be determined by the marker's text string.

Bug: http://b/176809754
Test: Compile -- Not really testable without producing the timers,
      which will be the next PR.
      
**Note: Requires #1632 to be in first**