### PR TITLE
Indicate an ended target process in new beta UI

### DIFF
--- a/OrbitQt/orbitmainwindow.h
+++ b/OrbitQt/orbitmainwindow.h
@@ -92,13 +92,7 @@ class OrbitMainWindow : public QMainWindow {
 
   void RestoreDefaultTabLayout();
 
-  // TODO(170468590): [ui beta] When out of ui beta, this can return TargetConfiguration (without
-  // std::optional)
-  std::optional<orbit_qt::TargetConfiguration> ClearTargetConfiguration() {
-    std::optional<orbit_qt::TargetConfiguration> result = std::move(target_configuration_);
-    target_configuration_ = std::nullopt;
-    return result;
-  }
+  std::optional<orbit_qt::TargetConfiguration> ClearTargetConfiguration();
 
  protected:
   void closeEvent(QCloseEvent* event) override;
@@ -163,6 +157,8 @@ class OrbitMainWindow : public QMainWindow {
   // ProfilingTargetDialog)
   void SetupGrpcAndProcessManager(std::string grpc_server_address);
 
+  void OnProcessListUpdated(std::vector<orbit_grpc_protos::ProcessInfo> processes);
+
  private:
   std::unique_ptr<MainThreadExecutor> main_thread_executor_;
   std::unique_ptr<OrbitApp> app_;
@@ -195,6 +191,10 @@ class OrbitMainWindow : public QMainWindow {
 
   // TODO(170468590): [ui beta] When out of ui beta, this does not need to be an optional anymore
   std::optional<orbit_qt::TargetConfiguration> target_configuration_;
+
+  enum class TargetProcessState { kRunning, kEnded };
+
+  TargetProcessState target_process_state_ = TargetProcessState::kRunning;
 };
 
 #endif  // ORBIT_QT_ORBIT_MAIN_WINDOW_H_


### PR DESCRIPTION
Since the process list was removed in the new (beta) UI it is
particurlary hard to realize that the target process has ended on the
instance.

This commit is adding a somewhat hacky fix. It's checking the regularly
incoming process list for existence of the target process. If the target
process pid cannot be found the corner widget will color the process
name in orange - indicating that the process has died. Additionally it
will disable the Start-Capture button.

Bug: http://b/176960277