### PR TITLE
Add/Remove FrameTracks properly while capturing

### DIFF
--- a/OrbitGl/FrameTrackOnlineProcessor.cpp
+++ b/OrbitGl/FrameTrackOnlineProcessor.cpp
@@ -52,3 +52,18 @@ void FrameTrackOnlineProcessor::ProcessTimer(const orbit_client_protos::TimerInf
     previous_timestamp_ns_[function_address] = timer_info.start();
   }
 }
+
+void FrameTrackOnlineProcessor::AddFrameTrack(const CaptureData& capture_data,
+                                              const orbit_client_protos::FunctionInfo& function) {
+  const uint64_t function_address = capture_data.GetAbsoluteAddress(function);
+  current_frame_track_functions_.insert(function_address);
+  previous_timestamp_ns_.insert(
+      std::make_pair(function_address, std::numeric_limits<uint64_t>::max()));
+}
+
+void FrameTrackOnlineProcessor::RemoveFrameTrack(
+    const CaptureData& capture_data, const orbit_client_protos::FunctionInfo& function) {
+  const uint64_t function_address = capture_data.GetAbsoluteAddress(function);
+  current_frame_track_functions_.erase(function_address);
+  previous_timestamp_ns_.erase(function_address);
+}

--- a/OrbitGl/FrameTrackOnlineProcessor.h
+++ b/OrbitGl/FrameTrackOnlineProcessor.h
@@ -19,6 +19,11 @@ class FrameTrackOnlineProcessor {
   void ProcessTimer(const orbit_client_protos::TimerInfo& timer_info,
                     const orbit_client_protos::FunctionInfo& function);
 
+  void AddFrameTrack(const CaptureData& capture_data,
+                     const orbit_client_protos::FunctionInfo& function);
+  void RemoveFrameTrack(const CaptureData& capture_data,
+                        const orbit_client_protos::FunctionInfo& function);
+
  private:
   absl::flat_hash_set<uint64_t> current_frame_track_functions_;
   absl::flat_hash_map<uint64_t, uint64_t> previous_timestamp_ns_;

--- a/OrbitGl/TrackManager.cpp
+++ b/OrbitGl/TrackManager.cpp
@@ -82,8 +82,8 @@ std::vector<FrameTrack*> TrackManager::GetFrameTracks() const {
 void TrackManager::SortTracks() {
   if (!app_->IsCapturing() && !sorted_tracks_.empty() && !sorting_invalidated_) return;
 
-  // Reorder threads once every second when capturing
-  if (!app_->IsCapturing() || last_thread_reorder_.ElapsedMillis() > 1000.0) {
+  // Reorder threads if sorting isn't valid or once per second when capturing
+  if (sorting_invalidated_ || last_thread_reorder_.ElapsedMillis() > 1000.0) {
     std::lock_guard<std::recursive_mutex> lock(mutex_);
     // Gather all tracks regardless of the process in sorted order
     std::vector<Track*> all_processes_sorted_tracks;
@@ -321,6 +321,8 @@ void TrackManager::AddTrack(std::shared_ptr<Track> track) {
 void TrackManager::RemoveFrameTrack(uint64_t function_address) {
   frame_tracks_.erase(function_address);
   sorting_invalidated_ = true;
+  // We need to do SortTracks again to have visible_tracks_ updated
+  SortTracks();
 }
 
 SchedulerTrack* TrackManager::GetOrCreateSchedulerTrack() {


### PR DESCRIPTION
Frame tracks are a special track because could be added or erased while
capturing. In this PR we are solving a few issues about inconsistent
information when adding or removing a frame track while capturing.
Basically, we updated:

 - FrameTrackOnlineProcessor in App (info while capturing)

 - Visible Tracks in TrackManager after removing Frame Tracks.

There are still an issue about multithreading problems (more information
in http://b/176959931).

Test: Start a capture, enable/disable Frame Tracks/ Stop a capture several times.