### PR TITLE
Handle Vulkan related timers in TimeGraph.

### DIFF
--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -258,6 +258,18 @@ void TimeGraph::ProcessTimer(const TimerInfo& timer_info, const FunctionInfo* fu
       track->OnTimer(timer_info);
       break;
     }
+    case TimerInfo::kGpuCommandBuffer: {
+      uint64_t timeline_hash = timer_info.timeline_hash();
+      GpuTrack* track = track_manager_->GetOrCreateGpuTrack(timeline_hash);
+      track->OnTimer(timer_info);
+      break;
+    }
+    case TimerInfo::kGpuDebugMarker: {
+      uint64_t timeline_hash = timer_info.timeline_hash();
+      GpuTrack* track = track_manager_->GetOrCreateGpuTrack(timeline_hash);
+      track->OnTimer(timer_info);
+      break;
+    }
     case TimerInfo::kFrame: {
       if (function == nullptr) {
         break;

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -252,18 +252,9 @@ void TimeGraph::ProcessTimer(const TimerInfo& timer_info, const FunctionInfo* fu
   // TODO (b/175869409): Change the way to create and get the tracks. Move this part to
   // TrackManager.
   switch (timer_info.type()) {
-    case TimerInfo::kGpuActivity: {
-      uint64_t timeline_hash = timer_info.timeline_hash();
-      GpuTrack* track = track_manager_->GetOrCreateGpuTrack(timeline_hash);
-      track->OnTimer(timer_info);
-      break;
-    }
-    case TimerInfo::kGpuCommandBuffer: {
-      uint64_t timeline_hash = timer_info.timeline_hash();
-      GpuTrack* track = track_manager_->GetOrCreateGpuTrack(timeline_hash);
-      track->OnTimer(timer_info);
-      break;
-    }
+    // All GPU timers are handled equally here.
+    case TimerInfo::kGpuActivity:
+    case TimerInfo::kGpuCommandBuffer:
     case TimerInfo::kGpuDebugMarker: {
       uint64_t timeline_hash = timer_info.timeline_hash();
       GpuTrack* track = track_manager_->GetOrCreateGpuTrack(timeline_hash);


### PR DESCRIPTION
This adds support to the new Vulkan related timer types (command
buffers and debug markers) to `TimeGraph`, which will forward them
to the `GpuTrack` that already has support for those (#1642).

Test: Compile -- Not really testable without producing the timers.
Bug: http://b/176809754