### PR TITLE
Fixes after E2E test updates

### DIFF
--- a/OrbitQt/orbitdataviewpanel.cpp
+++ b/OrbitQt/orbitdataviewpanel.cpp
@@ -46,8 +46,6 @@ void OrbitDataViewPanel::Initialize(DataView* data_view, SelectionType selection
   }
 
   data_view->SetUiFilterCallback([this](const std::string& filter) { SetFilter(filter.c_str()); });
-
-  setAccessibleName(QString("DataViewPanel") + QString::fromStdString(data_view->GetLabel()));
 }
 
 void OrbitDataViewPanel::Deinitialize() { ui->treeView->Deinitialize(); }

--- a/OrbitQt/orbitmainwindow.ui
+++ b/OrbitQt/orbitmainwindow.ui
@@ -96,7 +96,11 @@ QPushButton:disabled {
              <enum>Qt::Horizontal</enum>
             </property>
             <widget class="ProcessLauncherWidget" name="ProcessesList" native="true"/>
-            <widget class="OrbitDataViewPanel" name="SessionList" native="true"/>
+            <widget class="OrbitDataViewPanel" name="SessionList" native="true">
+             <property name="accessibleName">
+              <string>PresetsDataView</string>
+             </property>
+            </widget>
            </widget>
            <widget class="OrbitDataViewPanel" name="ModulesList" native="true">
             <property name="accessibleName">
@@ -267,7 +271,11 @@ QPushButton:disabled {
         </attribute>
         <layout class="QGridLayout" name="gridLayout_8">
          <item row="0" column="0">
-          <widget class="OrbitDataViewPanel" name="CallStackView" native="true"/>
+          <widget class="OrbitDataViewPanel" name="CallStackView" native="true">
+           <property name="accessibleName">
+            <string>CallstackDataView</string>
+           </property>
+          </widget>
          </item>
         </layout>
        </widget>
@@ -277,7 +285,11 @@ QPushButton:disabled {
         </attribute>
         <layout class="QGridLayout" name="liveGridLayout">
          <item row="0" column="0">
-          <widget class="OrbitLiveFunctions" name="liveFunctions" native="true"/>
+          <widget class="OrbitLiveFunctions" name="liveFunctions" native="true">
+           <property name="accessibleName">
+            <string>LiveDataView</string>
+           </property>
+          </widget>
          </item>
         </layout>
        </widget>
@@ -287,7 +299,11 @@ QPushButton:disabled {
         </attribute>
         <layout class="QGridLayout" name="samplingGridLayout">
          <item row="0" column="0">
-          <widget class="OrbitSamplingReport" name="samplingReport" native="true"/>
+          <widget class="OrbitSamplingReport" name="samplingReport" native="true">
+           <property name="accessibleName">
+            <string>SamplingDataView</string>
+           </property>
+          </widget>
          </item>
         </layout>
        </widget>

--- a/OrbitQt/processlauncherwidget.ui
+++ b/OrbitQt/processlauncherwidget.ui
@@ -16,7 +16,11 @@
     <number>0</number>
    </property>
    <item row="0" column="0">
-    <widget class="OrbitDataViewPanel" name="LiveProcessList"/>
+    <widget class="OrbitDataViewPanel" name="LiveProcessList" native="true">
+     <property name="accessibleName">
+      <string>ProcessesDataView</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/contrib/automation_tests/core/orbit_e2e.py
+++ b/contrib/automation_tests/core/orbit_e2e.py
@@ -114,6 +114,7 @@ class E2ETestSuite:
     def set_up(self):
         timings.Timings.after_click_wait = 0.5
         timings.Timings.after_clickinput_wait = 0.5
+        timings.Timings.after_editsetedittext_wait = 0.1
         logging.info("Setting up with dev_mode = %s", self.dev_mode)
         self.top_window(True).set_focus()
 

--- a/contrib/automation_tests/test_cases/connection_window.py
+++ b/contrib/automation_tests/test_cases/connection_window.py
@@ -11,6 +11,7 @@ from absl import flags
 from pywinauto.application import Application
 
 from core.orbit_e2e import E2ETestCase, wait_for_condition, find_control
+from core.common_controls import DataViewPanel
 
 
 flags.DEFINE_bool('enable_ui_beta', False, 'Expect Orbit to be started with the new UI')
@@ -66,10 +67,11 @@ class FilterAndSelectFirstProcess(E2ETestCase):
 
         if flags.FLAGS.enable_ui_beta:
             filter_edit = self.find_control('Edit', 'FilterProcesses')
-            process_list = window.ProcessList
+            process_list = self.find_control('Table', 'ProcessList')
         else:
-            filter_edit = self.find_control('Edit', 'Filter', parent=window.DataViewProcesses)
-            process_list = window.DataViewProcesses.DataView
+            process_data_view = DataViewPanel(self.find_control('Group', 'ProcessesDataView'))
+            filter_edit = process_data_view.filter
+            process_list = process_data_view.table
 
         logging.info('Waiting for process list to be populated')
         wait_for_condition(lambda: process_list.item_count() > 0, 30)
@@ -80,9 +82,9 @@ class FilterAndSelectFirstProcess(E2ETestCase):
 
         if flags.FLAGS.enable_ui_beta:
             logging.info('Process selected, continuing to main window...')
-            process_list.DataItem0.double_click_input()
+            process_list.children(control_type='DataItem')[0].double_click_input()
             wait_for_main_window(self.suite.application)
             window = self.suite.top_window(True)
             self.expect_eq(window.class_name(), "OrbitMainWindow", 'Main window is visible')
         else:
-            process_list.DataItem0.click_input()
+            process_list.children(control_type='TreeItem')[0].click_input()

--- a/contrib/automation_tests/test_cases/connection_window.py
+++ b/contrib/automation_tests/test_cases/connection_window.py
@@ -63,7 +63,6 @@ class FilterAndSelectFirstProcess(E2ETestCase):
     """
     def _execute(self, process_filter):
         window = self.suite.top_window()
-        logging.info('Setting filter text for process list')
 
         if flags.FLAGS.enable_ui_beta:
             filter_edit = self.find_control('Edit', 'FilterProcesses')
@@ -72,6 +71,9 @@ class FilterAndSelectFirstProcess(E2ETestCase):
             filter_edit = self.find_control('Edit', 'Filter', parent=window.DataViewProcesses)
             process_list = window.DataViewProcesses.DataView
 
+        logging.info('Waiting for process list to be populated')
+        wait_for_condition(lambda: process_list.item_count() > 0, 30)
+        logging.info('Setting filter text for process list')
         if process_filter:
             filter_edit.set_edit_text(process_filter)
         self.expect_true(process_list.item_count() > 0, 'Process list has at least one entry')

--- a/contrib/automation_tests/test_cases/symbols_tab.py
+++ b/contrib/automation_tests/test_cases/symbols_tab.py
@@ -35,7 +35,7 @@ class LoadSymbols(E2ETestCase):
         _show_symbols_and_functions_tabs(self.suite.top_window())
 
         logging.info('Start loading symbols for module %s', module_search_string)
-        modules_dataview = DataViewPanel(self.find_control("Group", "DataViewPanelModules"))
+        modules_dataview = DataViewPanel(self.find_control("Group", "ModulesDataView"))
 
         logging.info('Waiting for module list to be populated...')
         wait_for_condition(lambda: modules_dataview.get_row_count() > 0, 100)
@@ -51,7 +51,7 @@ class LoadSymbols(E2ETestCase):
 
         wait_for_condition(lambda: modules_dataview.get_item_at(0, 4).texts()[0] == "*")
 
-        functions_dataview = DataViewPanel(self.find_control("Group", "DataViewPanelFunctions"))
+        functions_dataview = DataViewPanel(self.find_control("Group", "FunctionsDataView"))
         wait_for_condition(lambda: functions_dataview.get_row_count() > 0)
 
 
@@ -63,7 +63,7 @@ class FilterAndHookFunction(E2ETestCase):
         _show_symbols_and_functions_tabs(self.suite.top_window())
 
         logging.info('Hooking function based on search "%s"', function_search_string)
-        functions_dataview = DataViewPanel(self.find_control("Group", "DataViewPanelFunctions"))
+        functions_dataview = DataViewPanel(self.find_control("Group", "FunctionsDataView"))
 
         logging.info('Waiting for function list to be populated...')
         wait_for_condition(lambda: functions_dataview.get_row_count() > 0, 100)
@@ -95,7 +95,7 @@ class LoadAndVerifyHelloGgpPreset(E2ETestCase):
         VerifyFunctionCallCount(function_name='GgpIssueFrameToken', min_calls=30, max_calls=3000).execute(self.suite)
 
     def _load_presets(self):
-        presets_panel = DataViewPanel(self.find_control('Group', 'DataViewPanelPresets'))
+        presets_panel = DataViewPanel(self.find_control('Group', 'PresetsDataView'))
 
         draw_frame_preset_row = presets_panel.find_first_item_row('draw_frame_in_hello_ggp_1_52', 1, True)
         issue_frame_token_preset_row = presets_panel.find_first_item_row(
@@ -114,7 +114,7 @@ class LoadAndVerifyHelloGgpPreset(E2ETestCase):
 
     def _try_verify_functions_are_hooked(self):
         logging.info('Finding rows in the function list')
-        functions_panel = DataViewPanel(self.find_control('Group', 'DataViewPanelFunctions'))
+        functions_panel = DataViewPanel(self.find_control('Group', 'FunctionsDataViewD'))
         draw_frame_row = functions_panel.find_first_item_row('DrawFrame', 1)
         issue_frame_token_row = functions_panel.find_first_item_row('GgpIssueFrameToken', 1)
 


### PR DESCRIPTION
Fixes two issues on the current E2E tests:

- Accessibility names of some data views were not consistent between old and new UI. This was because the names were based on the labels of the dataview, I've changed this to explicitely set the accessibility names for the panels instead
- Filtering the process list did not always work. I assume it's because there is a default wait of "0" in pywinauto in between setting the filter text and checking the list