### PR TITLE
E2E Symbols tab and timeout fixes

### DIFF
--- a/contrib/automation_tests/core/orbit_e2e.py
+++ b/contrib/automation_tests/core/orbit_e2e.py
@@ -114,7 +114,6 @@ class E2ETestSuite:
     def set_up(self):
         timings.Timings.after_click_wait = 0.5
         timings.Timings.after_clickinput_wait = 0.5
-        timings.Timings.after_editsetedittext_wait = 0.1
         logging.info("Setting up with dev_mode = %s", self.dev_mode)
         self.top_window(True).set_focus()
 

--- a/contrib/automation_tests/test_cases/capture_window.py
+++ b/contrib/automation_tests/test_cases/capture_window.py
@@ -12,7 +12,7 @@ from typing import Tuple, List
 from core.common_controls import Track
 from core.orbit_e2e import E2ETestCase, E2ETestSuite
 from pywinauto.base_wrapper import BaseWrapper
-from pywinauto import mouse
+from pywinauto import mouse, keyboard
 
 
 class CaptureWindowE2ETestCaseBase(E2ETestCase):
@@ -174,8 +174,10 @@ class FilterTracks(CaptureWindowE2ETestCaseBase):
         track_filter = self.find_control("Edit", "FilterTracks", parent=toolbar)
 
         logging.info("Setting track filter text: '%s'", filter_string)
-        track_filter.set_edit_text(filter_string)
-        tracks = self._find_tracks()
+        track_filter.set_focus()
+        track_filter.set_edit_text('')
+        # Using send_keys instead of set_edit_text directly because set_edit_text ignores the wait timings...
+        keyboard.send_keys(filter_string)
 
         # Verify by re-using a MatchTracks Fragment
         match_tracks = MatchTracks(expected_count=expected_count, expected_names=expected_names,

--- a/contrib/automation_tests/test_cases/connection_window.py
+++ b/contrib/automation_tests/test_cases/connection_window.py
@@ -9,8 +9,9 @@ import time
 
 from absl import flags
 from pywinauto.application import Application
+from pywinauto.keyboard import send_keys
 
-from core.orbit_e2e import E2ETestCase, wait_for_condition, find_control
+from core.orbit_e2e import E2ETestCase, wait_for_condition
 from core.common_controls import DataViewPanel
 
 
@@ -77,7 +78,9 @@ class FilterAndSelectFirstProcess(E2ETestCase):
         wait_for_condition(lambda: process_list.item_count() > 0, 30)
         logging.info('Setting filter text for process list')
         if process_filter:
-            filter_edit.set_edit_text(process_filter)
+            filter_edit.set_focus()
+            filter_edit.set_edit_text('')
+            send_keys(process_filter)
         self.expect_true(process_list.item_count() > 0, 'Process list has at least one entry')
 
         if flags.FLAGS.enable_ui_beta:

--- a/contrib/automation_tests/test_cases/symbols_tab.py
+++ b/contrib/automation_tests/test_cases/symbols_tab.py
@@ -86,7 +86,7 @@ class LoadAndVerifyHelloGgpPreset(E2ETestCase):
         _show_symbols_and_functions_tabs(self.suite.top_window())
 
         self._load_presets()
-        wait_for_condition(self._try_verify_functions_are_hooked)
+        wait_for_condition(lambda: self._try_verify_functions_are_hooked)
 
         Capture().execute(self.suite)
 

--- a/contrib/automation_tests/test_cases/symbols_tab.py
+++ b/contrib/automation_tests/test_cases/symbols_tab.py
@@ -8,6 +8,8 @@ import logging
 
 from absl import flags
 
+from pywinauto.keyboard import send_keys
+
 from core.common_controls import DataViewPanel
 from core.orbit_e2e import E2ETestCase, wait_for_condition, find_control
 
@@ -41,7 +43,9 @@ class LoadSymbols(E2ETestCase):
         wait_for_condition(lambda: modules_dataview.get_row_count() > 0, 100)
 
         logging.info('Filtering and loading')
-        modules_dataview.filter.set_edit_text(module_search_string)
+        modules_dataview.filter.set_focus()
+        modules_dataview.filter.set_edit_text('')
+        send_keys(module_search_string)
         wait_for_condition(lambda: modules_dataview.get_row_count() == 1)
         modules_dataview.get_item_at(0, 0).click_input('right')
 
@@ -69,7 +73,9 @@ class FilterAndHookFunction(E2ETestCase):
         wait_for_condition(lambda: functions_dataview.get_row_count() > 0, 100)
 
         logging.info('Filtering and hooking')
-        functions_dataview.filter.set_edit_text(function_search_string)
+        functions_dataview.filter.set_focus()
+        functions_dataview.filter.set_edit_text('')
+        send_keys(function_search_string)
         wait_for_condition(lambda: functions_dataview.get_row_count() == 1)
         functions_dataview.get_item_at(0, 0).click_input('right')
 


### PR DESCRIPTION
First commit: Fix a broken wait in the symbol tab
Second commit: Replace set_edit_text with send_keys. In the current version of PyWinAuto, the sleep inside set_edit_text is commented out, thus any settings we change in timings.Timings.after_setedittext_wait is ignored.