### PR TITLE
Replace qt5-default dependency by qtbase5-dev

### DIFF
--- a/bootstrap-orbit.sh
+++ b/bootstrap-orbit.sh
@@ -24,7 +24,7 @@ while true; do
 done
 
 readonly REQUIRED_PACKAGES=( build-essential libglu1-mesa-dev mesa-common-dev \
-                             libxmu-dev libxi-dev libopengl0 qt5-default \
+                             libxmu-dev libxi-dev libopengl0 qtbase5-dev \
                              qtwebengine5-dev libqt5webchannel5-dev \
                              libqt5websockets5-dev libxxf86vm-dev python3-pip \
                              libvulkan-dev vulkan-validationlayers-dev )


### PR DESCRIPTION
qt5-default is being removed from Debian.

b/177100727