### PR TITLE
Use (duration,end) instead of (begin,end) for CaptureEvent gRPC protos

### DIFF
--- a/src/OrbitCaptureClient/CaptureEventProcessor.cpp
+++ b/src/OrbitCaptureClient/CaptureEventProcessor.cpp
@@ -84,7 +84,7 @@ void CaptureEventProcessor::ProcessEvent(const CaptureEvent& event) {
 
 void CaptureEventProcessor::ProcessSchedulingSlice(const SchedulingSlice& scheduling_slice) {
   TimerInfo timer_info;
-  timer_info.set_start(scheduling_slice.in_timestamp_ns());
+  timer_info.set_start(scheduling_slice.out_timestamp_ns() - scheduling_slice.duration_ns());
   timer_info.set_end(scheduling_slice.out_timestamp_ns());
   timer_info.set_process_id(scheduling_slice.pid());
   timer_info.set_thread_id(scheduling_slice.tid());
@@ -123,7 +123,7 @@ void CaptureEventProcessor::ProcessFunctionCall(const FunctionCall& function_cal
   TimerInfo timer_info;
   timer_info.set_process_id(function_call.pid());
   timer_info.set_thread_id(function_call.tid());
-  timer_info.set_start(function_call.begin_timestamp_ns());
+  timer_info.set_start(function_call.end_timestamp_ns() - function_call.duration_ns());
   timer_info.set_end(function_call.end_timestamp_ns());
   timer_info.set_depth(static_cast<uint8_t>(function_call.depth()));
   timer_info.set_function_address(function_call.absolute_address());
@@ -143,7 +143,7 @@ void CaptureEventProcessor::ProcessIntrospectionScope(
   TimerInfo timer_info;
   timer_info.set_process_id(introspection_scope.pid());
   timer_info.set_thread_id(introspection_scope.tid());
-  timer_info.set_start(introspection_scope.begin_timestamp_ns());
+  timer_info.set_start(introspection_scope.end_timestamp_ns() - introspection_scope.duration_ns());
   timer_info.set_end(introspection_scope.end_timestamp_ns());
   timer_info.set_depth(static_cast<uint8_t>(introspection_scope.depth()));
   timer_info.set_function_address(0);  // function address n/a, set to invalid value
@@ -253,7 +253,8 @@ void CaptureEventProcessor::ProcessThreadStateSlice(const ThreadStateSlice& thre
     default:
       UNREACHABLE();
   }
-  slice_info.set_begin_timestamp_ns(thread_state_slice.begin_timestamp_ns());
+  slice_info.set_begin_timestamp_ns(thread_state_slice.end_timestamp_ns() -
+                                    thread_state_slice.duration_ns());
   slice_info.set_end_timestamp_ns(thread_state_slice.end_timestamp_ns());
   capture_listener_->OnThreadStateSlice(std::move(slice_info));
 }

--- a/src/OrbitGrpcProtos/capture.proto
+++ b/src/OrbitGrpcProtos/capture.proto
@@ -45,19 +45,32 @@ message CaptureOptions {
   bool enable_introspection = 9;
 }
 
+// For CaptureEvents with a duration, excluding for now GPU-related ones, we
+// represent the time interval as (duration_ns, end_timestamp_ns). As durations
+// are smaller in magnitude than absolute timestamps, and as protobufs use
+// variable-length encoding, this saves some bandwidth compared to
+// (start_timestamp_ns, end_timestamp_ns).
+// The pair (duration_ns, end_timestamp_ns) was preferred over
+// (start_timestamp_ns, duration_ns) because this way, when perf_event_open
+// events are processed in order, the CaptureEvents are sorted by the only
+// absolute timestamp contained in them (as they are obviously generated when
+// the "end" perf_event_open event is processed).
+
 message SchedulingSlice {
+  reserved 4;
   int32 pid = 1;
   int32 tid = 2;
   int32 core = 3;
-  uint64 in_timestamp_ns = 4;
+  uint64 duration_ns = 6;
   uint64 out_timestamp_ns = 5;
 }
 
 message FunctionCall {
+  reserved 4;
   int32 pid = 1;
   int32 tid = 2;
   uint64 absolute_address = 3;
-  uint64 begin_timestamp_ns = 4;
+  uint64 duration_ns = 9;
   uint64 end_timestamp_ns = 5;
   int32 depth = 6;
   uint64 return_value = 7;
@@ -65,9 +78,10 @@ message FunctionCall {
 }
 
 message IntrospectionScope {
+  reserved 3;
   int32 pid = 1;
   int32 tid = 2;
-  uint64 begin_timestamp_ns = 3;
+  uint64 duration_ns = 7;
   uint64 end_timestamp_ns = 4;
   int32 depth = 5;
   repeated uint64 registers = 6;
@@ -184,6 +198,7 @@ message ThreadName {
 }
 
 message ThreadStateSlice {
+  reserved 4;
   int32 pid = 1;  // pid is currently not set as we don't have the information.
   int32 tid = 2;
 
@@ -208,7 +223,7 @@ message ThreadStateSlice {
   }
   ThreadState thread_state = 3;
 
-  uint64 begin_timestamp_ns = 4;
+  uint64 duration_ns = 6;
   uint64 end_timestamp_ns = 5;
 }
 

--- a/src/OrbitLinuxTracing/ContextSwitchManager.cpp
+++ b/src/OrbitLinuxTracing/ContextSwitchManager.cpp
@@ -60,7 +60,7 @@ std::optional<SchedulingSlice> ContextSwitchManager::ProcessContextSwitchOut(
   scheduling_slice.set_pid(pid_to_set);
   scheduling_slice.set_tid(tid);
   scheduling_slice.set_core(core);
-  scheduling_slice.set_in_timestamp_ns(open_timestamp_ns);
+  scheduling_slice.set_duration_ns(timestamp_ns - open_timestamp_ns);
   scheduling_slice.set_out_timestamp_ns(timestamp_ns);
   return scheduling_slice;
 }

--- a/src/OrbitLinuxTracing/ContextSwitchManagerTest.cpp
+++ b/src/OrbitLinuxTracing/ContextSwitchManagerTest.cpp
@@ -31,7 +31,7 @@ TEST(ContextSwitchManager, OneCoreMatch) {
   EXPECT_EQ(processed_scheduling_slice.value().pid(), kPid);
   EXPECT_EQ(processed_scheduling_slice.value().tid(), kTid);
   EXPECT_EQ(processed_scheduling_slice.value().core(), kCore);
-  EXPECT_EQ(processed_scheduling_slice.value().in_timestamp_ns(), 100);
+  EXPECT_EQ(processed_scheduling_slice.value().duration_ns(), 1);
   EXPECT_EQ(processed_scheduling_slice.value().out_timestamp_ns(), 101);
 
   processed_scheduling_slice =
@@ -54,7 +54,7 @@ TEST(ContextSwitchManager, OneCoreMatchUnknownInPid) {
   EXPECT_EQ(processed_scheduling_slice.value().pid(), kPid);
   EXPECT_EQ(processed_scheduling_slice.value().tid(), kTid);
   EXPECT_EQ(processed_scheduling_slice.value().core(), kCore);
-  EXPECT_EQ(processed_scheduling_slice.value().in_timestamp_ns(), 100);
+  EXPECT_EQ(processed_scheduling_slice.value().duration_ns(), 1);
   EXPECT_EQ(processed_scheduling_slice.value().out_timestamp_ns(), 101);
 
   processed_scheduling_slice =
@@ -76,7 +76,7 @@ TEST(ContextSwitchManager, OneCoreThreadExit) {
   EXPECT_EQ(processed_scheduling_slice.value().pid(), kPid);
   EXPECT_EQ(processed_scheduling_slice.value().tid(), kTid);
   EXPECT_EQ(processed_scheduling_slice.value().core(), kCore);
-  EXPECT_EQ(processed_scheduling_slice.value().in_timestamp_ns(), 100);
+  EXPECT_EQ(processed_scheduling_slice.value().duration_ns(), 1);
   EXPECT_EQ(processed_scheduling_slice.value().out_timestamp_ns(), 101);
 
   processed_scheduling_slice =
@@ -98,7 +98,7 @@ TEST(ContextSwitchManager, OneCoreThreadExitUnknownPid) {
   EXPECT_EQ(processed_scheduling_slice.value().pid(), -1);
   EXPECT_EQ(processed_scheduling_slice.value().tid(), kTid);
   EXPECT_EQ(processed_scheduling_slice.value().core(), kCore);
-  EXPECT_EQ(processed_scheduling_slice.value().in_timestamp_ns(), 100);
+  EXPECT_EQ(processed_scheduling_slice.value().duration_ns(), 1);
   EXPECT_EQ(processed_scheduling_slice.value().out_timestamp_ns(), 101);
 
   processed_scheduling_slice =
@@ -163,7 +163,7 @@ TEST(ContextSwitchManager, OneCoreTwoMatches) {
   EXPECT_EQ(processed_scheduling_slice.value().pid(), kPid1);
   EXPECT_EQ(processed_scheduling_slice.value().tid(), kTid1);
   EXPECT_EQ(processed_scheduling_slice.value().core(), kCore);
-  EXPECT_EQ(processed_scheduling_slice.value().in_timestamp_ns(), 100);
+  EXPECT_EQ(processed_scheduling_slice.value().duration_ns(), 1);
   EXPECT_EQ(processed_scheduling_slice.value().out_timestamp_ns(), 101);
 
   context_switch_manager.ProcessContextSwitchIn(kPid2, kTid2, kCore, 102);
@@ -174,7 +174,7 @@ TEST(ContextSwitchManager, OneCoreTwoMatches) {
   EXPECT_EQ(processed_scheduling_slice.value().pid(), kPid2);
   EXPECT_EQ(processed_scheduling_slice.value().tid(), kTid2);
   EXPECT_EQ(processed_scheduling_slice.value().core(), kCore);
-  EXPECT_EQ(processed_scheduling_slice.value().in_timestamp_ns(), 102);
+  EXPECT_EQ(processed_scheduling_slice.value().duration_ns(), 1);
   EXPECT_EQ(processed_scheduling_slice.value().out_timestamp_ns(), 103);
 
   processed_scheduling_slice =
@@ -202,7 +202,7 @@ TEST(ContextSwitchManager, TwoCoresMatches) {
   EXPECT_EQ(processed_scheduling_slice.value().pid(), kPid2);
   EXPECT_EQ(processed_scheduling_slice.value().tid(), kTid2);
   EXPECT_EQ(processed_scheduling_slice.value().core(), kCore2);
-  EXPECT_EQ(processed_scheduling_slice.value().in_timestamp_ns(), 101);
+  EXPECT_EQ(processed_scheduling_slice.value().duration_ns(), 2);
   EXPECT_EQ(processed_scheduling_slice.value().out_timestamp_ns(), 103);
 
   processed_scheduling_slice =
@@ -211,7 +211,7 @@ TEST(ContextSwitchManager, TwoCoresMatches) {
   EXPECT_EQ(processed_scheduling_slice.value().pid(), kPid1);
   EXPECT_EQ(processed_scheduling_slice.value().tid(), kTid1);
   EXPECT_EQ(processed_scheduling_slice.value().core(), kCore1);
-  EXPECT_EQ(processed_scheduling_slice.value().in_timestamp_ns(), 100);
+  EXPECT_EQ(processed_scheduling_slice.value().duration_ns(), 2);
   EXPECT_EQ(processed_scheduling_slice.value().out_timestamp_ns(), 102);
 
   processed_scheduling_slice =

--- a/src/OrbitLinuxTracing/ThreadStateManager.cpp
+++ b/src/OrbitLinuxTracing/ThreadStateManager.cpp
@@ -76,7 +76,7 @@ std::optional<ThreadStateSlice> ThreadStateManager::OnSchedWakeup(uint64_t times
   ThreadStateSlice slice;
   slice.set_tid(tid);
   slice.set_thread_state(open_state.state);
-  slice.set_begin_timestamp_ns(open_state.begin_timestamp_ns);
+  slice.set_duration_ns(timestamp_ns - open_state.begin_timestamp_ns);
   slice.set_end_timestamp_ns(timestamp_ns);
   tid_open_states_.insert_or_assign(tid, OpenState{kNewState, timestamp_ns});
   return slice;
@@ -111,7 +111,7 @@ std::optional<ThreadStateSlice> ThreadStateManager::OnSchedSwitchIn(uint64_t tim
   ThreadStateSlice slice;
   slice.set_tid(tid);
   slice.set_thread_state(open_state.state);
-  slice.set_begin_timestamp_ns(open_state.begin_timestamp_ns);
+  slice.set_duration_ns(timestamp_ns - open_state.begin_timestamp_ns);
   slice.set_end_timestamp_ns(timestamp_ns);
   tid_open_states_.insert_or_assign(tid, OpenState{kNewState, timestamp_ns});
   return slice;
@@ -152,7 +152,7 @@ std::optional<ThreadStateSlice> ThreadStateManager::OnSchedSwitchOut(
   ThreadStateSlice slice;
   slice.set_tid(tid);
   slice.set_thread_state(adjusted_open_state_state);
-  slice.set_begin_timestamp_ns(open_state.begin_timestamp_ns);
+  slice.set_duration_ns(timestamp_ns - open_state.begin_timestamp_ns);
   slice.set_end_timestamp_ns(timestamp_ns);
 
   // Note: If the thread exits but the new_state is kZombie instead of kDead,
@@ -167,7 +167,7 @@ std::vector<ThreadStateSlice> ThreadStateManager::OnCaptureFinished(uint64_t tim
     ThreadStateSlice slice;
     slice.set_tid(tid);
     slice.set_thread_state(open_state.state);
-    slice.set_begin_timestamp_ns(open_state.begin_timestamp_ns);
+    slice.set_duration_ns(timestamp_ns - open_state.begin_timestamp_ns);
     slice.set_end_timestamp_ns(timestamp_ns);
     slices.emplace_back(std::move(slice));
   }

--- a/src/OrbitLinuxTracing/ThreadStateManagerTest.cpp
+++ b/src/OrbitLinuxTracing/ThreadStateManagerTest.cpp
@@ -28,28 +28,28 @@ TEST(ThreadStateManager, OneThread) {
   ASSERT_TRUE(slice.has_value());
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
-  EXPECT_EQ(slice->begin_timestamp_ns(), 100);
+  EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 200);
 
   slice = manager.OnSchedSwitchOut(300, kTid, ThreadStateSlice::kInterruptibleSleep);
   ASSERT_TRUE(slice.has_value());
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
-  EXPECT_EQ(slice->begin_timestamp_ns(), 200);
+  EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 300);
 
   slice = manager.OnSchedWakeup(400, kTid);
   ASSERT_TRUE(slice.has_value());
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kInterruptibleSleep);
-  EXPECT_EQ(slice->begin_timestamp_ns(), 300);
+  EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 400);
 
   slice = manager.OnSchedSwitchIn(500, kTid);
   ASSERT_TRUE(slice.has_value());
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
-  EXPECT_EQ(slice->begin_timestamp_ns(), 400);
+  EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 500);
 
   std::vector<ThreadStateSlice> slices = manager.OnCaptureFinished(600);
@@ -58,7 +58,7 @@ TEST(ThreadStateManager, OneThread) {
   slice = slices[0];
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
-  EXPECT_EQ(slice->begin_timestamp_ns(), 500);
+  EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 600);
 }
 
@@ -73,14 +73,14 @@ TEST(ThreadStateManager, NewTask) {
   ASSERT_TRUE(slice.has_value());
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
-  EXPECT_EQ(slice->begin_timestamp_ns(), 100);
+  EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 200);
 
   slice = manager.OnSchedSwitchOut(300, kTid, ThreadStateSlice::kRunnable);
   ASSERT_TRUE(slice.has_value());
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
-  EXPECT_EQ(slice->begin_timestamp_ns(), 200);
+  EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 300);
 
   std::vector<ThreadStateSlice> slices = manager.OnCaptureFinished(400);
@@ -89,7 +89,7 @@ TEST(ThreadStateManager, NewTask) {
   slice = slices[0];
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
-  EXPECT_EQ(slice->begin_timestamp_ns(), 300);
+  EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 400);
 }
 
@@ -105,7 +105,7 @@ TEST(ThreadStateManager, TwoThreads) {
   ASSERT_TRUE(slice.has_value());
   EXPECT_EQ(slice->tid(), kTid1);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
-  EXPECT_EQ(slice->begin_timestamp_ns(), 100);
+  EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 200);
 
   manager.OnNewTask(250, kTid2);
@@ -114,35 +114,35 @@ TEST(ThreadStateManager, TwoThreads) {
   ASSERT_TRUE(slice.has_value());
   EXPECT_EQ(slice->tid(), kTid1);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
-  EXPECT_EQ(slice->begin_timestamp_ns(), 200);
+  EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 300);
 
   slice = manager.OnSchedSwitchIn(350, kTid2);
   ASSERT_TRUE(slice.has_value());
   EXPECT_EQ(slice->tid(), kTid2);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
-  EXPECT_EQ(slice->begin_timestamp_ns(), 250);
+  EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 350);
 
   slice = manager.OnSchedWakeup(400, kTid1);
   ASSERT_TRUE(slice.has_value());
   EXPECT_EQ(slice->tid(), kTid1);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kInterruptibleSleep);
-  EXPECT_EQ(slice->begin_timestamp_ns(), 300);
+  EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 400);
 
   slice = manager.OnSchedSwitchOut(450, kTid2, ThreadStateSlice::kRunnable);
   ASSERT_TRUE(slice.has_value());
   EXPECT_EQ(slice->tid(), kTid2);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
-  EXPECT_EQ(slice->begin_timestamp_ns(), 350);
+  EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 450);
 
   slice = manager.OnSchedSwitchIn(500, kTid1);
   ASSERT_TRUE(slice.has_value());
   EXPECT_EQ(slice->tid(), kTid1);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
-  EXPECT_EQ(slice->begin_timestamp_ns(), 400);
+  EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 500);
 
   std::vector<ThreadStateSlice> slices = manager.OnCaptureFinished(600);
@@ -156,13 +156,13 @@ TEST(ThreadStateManager, TwoThreads) {
   slice = slices[0];
   EXPECT_EQ(slice->tid(), kTid1);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
-  EXPECT_EQ(slice->begin_timestamp_ns(), 500);
+  EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 600);
 
   slice = slices[1];
   EXPECT_EQ(slice->tid(), kTid2);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
-  EXPECT_EQ(slice->begin_timestamp_ns(), 450);
+  EXPECT_EQ(slice->duration_ns(), 150);
   EXPECT_EQ(slice->end_timestamp_ns(), 600);
 }
 
@@ -177,7 +177,7 @@ TEST(ThreadStateManager, SwitchOutAfterInitialStateRunnable) {
   ASSERT_TRUE(slice.has_value());
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
-  EXPECT_EQ(slice->begin_timestamp_ns(), 100);
+  EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 200);
 }
 
@@ -194,7 +194,7 @@ TEST(ThreadStateManager, StaleInitialStateWithNewTask) {
   ASSERT_TRUE(slice.has_value());
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
-  EXPECT_EQ(slice->begin_timestamp_ns(), 100);
+  EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 200);
 }
 
@@ -212,7 +212,7 @@ TEST(ThreadStateManager, StaleInitialStateWithSchedWakeup) {
   ASSERT_TRUE(slice.has_value());
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
-  EXPECT_EQ(slice->begin_timestamp_ns(), 100);
+  EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 200);
 }
 
@@ -230,7 +230,7 @@ TEST(ThreadStateManager, StaleInitialStateWithSwitchIn) {
   ASSERT_TRUE(slice.has_value());
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
-  EXPECT_EQ(slice->begin_timestamp_ns(), 100);
+  EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 200);
 }
 
@@ -248,7 +248,7 @@ TEST(ThreadStateManager, StaleInitialStateWithSwitchOut) {
   ASSERT_TRUE(slice.has_value());
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kInterruptibleSleep);
-  EXPECT_EQ(slice->begin_timestamp_ns(), 100);
+  EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 200);
 }
 
@@ -264,7 +264,7 @@ TEST(ThreadStateManager, UnknownInitialStateWithSchedWakeup) {
   ASSERT_TRUE(slice.has_value());
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
-  EXPECT_EQ(slice->begin_timestamp_ns(), 100);
+  EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 200);
 }
 
@@ -280,7 +280,7 @@ TEST(ThreadStateManager, UnknownInitialStateWithSwitchIn) {
   ASSERT_TRUE(slice.has_value());
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
-  EXPECT_EQ(slice->begin_timestamp_ns(), 100);
+  EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 200);
 }
 
@@ -296,7 +296,7 @@ TEST(ThreadStateManager, UnknownInitialStateWithSwitchOut) {
   ASSERT_TRUE(slice.has_value());
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kInterruptibleSleep);
-  EXPECT_EQ(slice->begin_timestamp_ns(), 100);
+  EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 200);
 }
 
@@ -314,7 +314,7 @@ TEST(ThreadStateManager, NoStateChangeWithSchedWakeup) {
   ASSERT_TRUE(slice.has_value());
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
-  EXPECT_EQ(slice->begin_timestamp_ns(), 100);
+  EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 200);
 }
 
@@ -329,7 +329,7 @@ TEST(ThreadStateManager, NoStateChangeWithSwitchIn) {
   ASSERT_TRUE(slice.has_value());
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
-  EXPECT_EQ(slice->begin_timestamp_ns(), 100);
+  EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 200);
 
   slice = manager.OnSchedSwitchIn(250, kTid);
@@ -339,7 +339,7 @@ TEST(ThreadStateManager, NoStateChangeWithSwitchIn) {
   ASSERT_TRUE(slice.has_value());
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
-  EXPECT_EQ(slice->begin_timestamp_ns(), 200);
+  EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 300);
 }
 

--- a/src/OrbitLinuxTracing/UprobesFunctionCallManager.h
+++ b/src/OrbitLinuxTracing/UprobesFunctionCallManager.h
@@ -50,7 +50,7 @@ class UprobesFunctionCallManager {
     function_call.set_pid(pid);
     function_call.set_tid(tid);
     function_call.set_absolute_address(tid_uprobe.function_address);
-    function_call.set_begin_timestamp_ns(tid_uprobe.begin_timestamp);
+    function_call.set_duration_ns(end_timestamp - tid_uprobe.begin_timestamp);
     function_call.set_end_timestamp_ns(end_timestamp);
     function_call.set_depth(tid_uprobes_stack.size() - 1);
     function_call.set_return_value(return_value);

--- a/src/OrbitLinuxTracing/UprobesFunctionCallManagerTest.cpp
+++ b/src/OrbitLinuxTracing/UprobesFunctionCallManagerTest.cpp
@@ -30,7 +30,7 @@ TEST(UprobesFunctionCallManager, OneUprobe) {
   EXPECT_EQ(processed_function_call.value().pid(), pid);
   EXPECT_EQ(processed_function_call.value().tid(), tid);
   EXPECT_EQ(processed_function_call.value().absolute_address(), 100);
-  EXPECT_EQ(processed_function_call.value().begin_timestamp_ns(), 1);
+  EXPECT_EQ(processed_function_call.value().duration_ns(), 1);
   EXPECT_EQ(processed_function_call.value().end_timestamp_ns(), 2);
   EXPECT_EQ(processed_function_call.value().depth(), 0);
   EXPECT_EQ(processed_function_call.value().return_value(), 3);
@@ -53,7 +53,7 @@ TEST(UprobesFunctionCallManager, TwoNestedUprobesAndAnotherUprobe) {
   EXPECT_EQ(processed_function_call.value().pid(), pid);
   EXPECT_EQ(processed_function_call.value().tid(), tid);
   EXPECT_EQ(processed_function_call.value().absolute_address(), 200);
-  EXPECT_EQ(processed_function_call.value().begin_timestamp_ns(), 2);
+  EXPECT_EQ(processed_function_call.value().duration_ns(), 1);
   EXPECT_EQ(processed_function_call.value().end_timestamp_ns(), 3);
   EXPECT_EQ(processed_function_call.value().depth(), 1);
   EXPECT_EQ(processed_function_call.value().return_value(), 4);
@@ -64,7 +64,7 @@ TEST(UprobesFunctionCallManager, TwoNestedUprobesAndAnotherUprobe) {
   EXPECT_EQ(processed_function_call.value().pid(), pid);
   EXPECT_EQ(processed_function_call.value().tid(), tid);
   EXPECT_EQ(processed_function_call.value().absolute_address(), 100);
-  EXPECT_EQ(processed_function_call.value().begin_timestamp_ns(), 1);
+  EXPECT_EQ(processed_function_call.value().duration_ns(), 3);
   EXPECT_EQ(processed_function_call.value().end_timestamp_ns(), 4);
   EXPECT_EQ(processed_function_call.value().depth(), 0);
   EXPECT_EQ(processed_function_call.value().return_value(), 5);
@@ -77,7 +77,7 @@ TEST(UprobesFunctionCallManager, TwoNestedUprobesAndAnotherUprobe) {
   EXPECT_EQ(processed_function_call.value().pid(), pid);
   EXPECT_EQ(processed_function_call.value().tid(), tid);
   EXPECT_EQ(processed_function_call.value().absolute_address(), 300);
-  EXPECT_EQ(processed_function_call.value().begin_timestamp_ns(), 5);
+  EXPECT_EQ(processed_function_call.value().duration_ns(), 1);
   EXPECT_EQ(processed_function_call.value().end_timestamp_ns(), 6);
   EXPECT_EQ(processed_function_call.value().depth(), 0);
   EXPECT_EQ(processed_function_call.value().return_value(), 7);
@@ -101,7 +101,7 @@ TEST(UprobesFunctionCallManager, TwoUprobesDifferentThreads) {
   EXPECT_EQ(processed_function_call.value().pid(), pid);
   EXPECT_EQ(processed_function_call.value().tid(), tid);
   EXPECT_EQ(processed_function_call.value().absolute_address(), 100);
-  EXPECT_EQ(processed_function_call.value().begin_timestamp_ns(), 1);
+  EXPECT_EQ(processed_function_call.value().duration_ns(), 2);
   EXPECT_EQ(processed_function_call.value().end_timestamp_ns(), 3);
   EXPECT_EQ(processed_function_call.value().depth(), 0);
   EXPECT_EQ(processed_function_call.value().return_value(), 4);
@@ -112,7 +112,7 @@ TEST(UprobesFunctionCallManager, TwoUprobesDifferentThreads) {
   EXPECT_EQ(processed_function_call.value().pid(), pid);
   EXPECT_EQ(processed_function_call.value().tid(), tid2);
   EXPECT_EQ(processed_function_call.value().absolute_address(), 200);
-  EXPECT_EQ(processed_function_call.value().begin_timestamp_ns(), 2);
+  EXPECT_EQ(processed_function_call.value().duration_ns(), 2);
   EXPECT_EQ(processed_function_call.value().end_timestamp_ns(), 4);
   EXPECT_EQ(processed_function_call.value().depth(), 0);
   EXPECT_EQ(processed_function_call.value().return_value(), 5);

--- a/src/OrbitService/LinuxTracingHandler.cpp
+++ b/src/OrbitService/LinuxTracingHandler.cpp
@@ -47,7 +47,7 @@ void LinuxTracingHandler::SetupIntrospection() {
         IntrospectionScope introspection_scope;
         introspection_scope.set_pid(getpid());
         introspection_scope.set_tid(scope.tid);
-        introspection_scope.set_begin_timestamp_ns(scope.begin);
+        introspection_scope.set_duration_ns(scope.end - scope.begin);
         introspection_scope.set_end_timestamp_ns(scope.end);
         introspection_scope.set_depth(scope.depth);
         introspection_scope.mutable_registers()->Reserve(6);


### PR DESCRIPTION
This saves some bandwidth thanks to variable-length encoding of protobufs.
More details in the bug.
GPU-related events are (at least for now) not included in the change. As the
frequency of those events is relatively low compared to scheduler, thread state,
dynamic instrumentation, that would in any case have a smalelr impact.
This does not affect "client protos" (i.e., serialization to file), so that we
don't break compatibility with previous versions.

Bug: http://b/177222925

Test: Update unit tests. Take a few captures on Trata and Infiltrator and verify
that things look good.