### PR TITLE
Optimize EventTrack: only iterate on the CallstackEvent in the visible time range

### DIFF
--- a/src/OrbitClientData/include/OrbitClientData/CallstackData.h
+++ b/src/OrbitClientData/include/OrbitClientData/CallstackData.h
@@ -58,8 +58,12 @@ class CallstackData {
   void ForEachCallstackEvent(
       const std::function<void(const orbit_client_protos::CallstackEvent&)>& action) const;
 
-  void ForEachCallstackEventOfTid(
-      int32_t tid,
+  void ForEachCallstackEventInTimeRange(
+      uint64_t min_timestamp, uint64_t max_timestamp,
+      const std::function<void(const orbit_client_protos::CallstackEvent&)>& action) const;
+
+  void ForEachCallstackEventOfTidInTimeRange(
+      int32_t tid, uint64_t min_timestamp, uint64_t max_timestamp,
       const std::function<void(const orbit_client_protos::CallstackEvent&)>& action) const;
 
   [[nodiscard]] uint64_t max_time() const {

--- a/src/OrbitGl/EventTrack.h
+++ b/src/OrbitGl/EventTrack.h
@@ -21,7 +21,7 @@ class TimeGraph;
 
 class EventTrack : public Track {
  public:
-  explicit EventTrack(TimeGraph* a_TimeGraph, OrbitApp* app);
+  explicit EventTrack(TimeGraph* time_graph, OrbitApp* app);
   Type GetType() const override { return kEventTrack; }
 
   std::string GetTooltip() const override;
@@ -32,15 +32,12 @@ class EventTrack : public Track {
 
   void OnPick(int x, int y) override;
   void OnRelease() override;
-  void OnDrag(int a_X, int a_Y) override;
+  void OnDrag(int x, int y) override;
   bool Draggable() override { return true; }
   float GetHeight() const override { return size_[1]; }
 
   void SetThreadId(ThreadID thread_id) { thread_id_ = thread_id; }
-  void SetTimeGraph(TimeGraph* a_TimeGraph) { time_graph_ = a_TimeGraph; }
-  void SetPos(float a_X, float a_Y);
-  void SetSize(float a_SizeX, float a_SizeY);
-  void SetColor(Color color) { color_ = color; }
+  void SetPos(float x, float y) { pos_ = Vec2(x, y); }
   bool IsEmpty() const override;
   [[nodiscard]] uint64_t GetMinTime() const override;
   [[nodiscard]] uint64_t GetMaxTime() const override;


### PR DESCRIPTION
#### Optimize `EventTrack`: don't iterate over all events in `CallstackData`
Only iterate on the `CallstackEvent`s in the visible range.
We already had `std::map`s in place to do this, I guess something was lost
during some old refactoring.
Of course this doesn't make a difference when completely zoomed out, but
otherwise it makes the capture windows so much smoother with long captures.
#### Address some lint warnings in `EventTrack`
In particular, I removed some methods that shadowed an identical implementation
in `Track`. But I left `SetPos` as its implementation is different.