### PR TITLE
Fix Crash on "go to disassembly".

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -526,12 +526,12 @@ void OrbitApp::RenderImGui() {
 }
 
 void OrbitApp::Disassemble(int32_t pid, const FunctionInfo& function) {
-  const ProcessData* process = data_manager_->GetProcessByPid(pid);
-  CHECK(process != nullptr);
+  CHECK(process_ != nullptr);
   const ModuleData* module = module_manager_->GetModuleByPath(function.loaded_module_path());
   CHECK(module != nullptr);
-  const bool is_64_bit = process->is_64_bit();
-  const uint64_t absolute_address = function_utils::GetAbsoluteAddress(function, *process, *module);
+  const bool is_64_bit = process_->is_64_bit();
+  const uint64_t absolute_address =
+      function_utils::GetAbsoluteAddress(function, *process_, *module);
   thread_pool_->Schedule([this, absolute_address, is_64_bit, pid, function] {
     auto result = GetProcessManager()->LoadProcessMemory(pid, absolute_address, function.size());
     if (!result.has_value()) {

--- a/OrbitGl/DataManager.cpp
+++ b/OrbitGl/DataManager.cpp
@@ -106,15 +106,6 @@ ProcessData* DataManager::GetMutableProcessByPid(int32_t process_id) {
   return &it->second;
 }
 
-const ProcessData* DataManager::GetProcessByPid(int32_t process_id) const {
-  CHECK(std::this_thread::get_id() == main_thread_id_);
-
-  auto it = process_map_.find(process_id);
-  if (it == process_map_.end()) return nullptr;
-
-  return &it->second;
-}
-
 bool DataManager::IsFunctionSelected(const FunctionInfo& function) const {
   CHECK(std::this_thread::get_id() == main_thread_id_);
   return selected_functions_.contains(function);

--- a/OrbitGl/DataManager.h
+++ b/OrbitGl/DataManager.h
@@ -41,7 +41,6 @@ class DataManager final {
   void set_selected_thread_id(int32_t thread_id);
   void set_selected_text_box(const TextBox* text_box);
 
-  [[nodiscard]] const ProcessData* GetProcessByPid(int32_t process_id) const;
   [[nodiscard]] ProcessData* GetMutableProcessByPid(int32_t process_id);
   [[nodiscard]] bool IsFunctionSelected(const orbit_client_protos::FunctionInfo& function) const;
   [[nodiscard]] std::vector<orbit_client_protos::FunctionInfo> GetSelectedFunctions() const;


### PR DESCRIPTION
The recent UI change resulted in App having one process (the selected process).
In DataManager the process list is not added anymore, as this is obsolete.

App::Disassemly however still used DataManager to retrieve the process.

This change the usage to `process_` instead of using `DataManager::GetProcessByPid`
and removes this function.

Bug: http://b/177499048.
Test: Go to disassembly.