### PR TITLE
Hide manual instrumentation API functions in live view.

### DIFF
--- a/src/OrbitGl/LiveFunctionsDataView.cpp
+++ b/src/OrbitGl/LiveFunctionsDataView.cpp
@@ -377,6 +377,9 @@ void LiveFunctionsDataView::OnDataChanged() {
   indices_.resize(functions_count);
   size_t i = 0;
   for (const auto& pair : selected_functions) {
+    if (function_utils::IsOrbitFunc(pair.second)) {
+      continue;
+    }
     functions_.push_back(pair.second);
     indices_[i] = i;
     ++i;


### PR DESCRIPTION
The internal API functions for manual instrumentation show up in
the live functions view. This is missleading, as they are not
the results of manual instrumentation.

Also related: Adding a frame track for those is currently leading
to a crash. Hiding those, would also prevent the user for adding
a frame track (at least from this view).

Test: Capture OrbitTest.
Bug: http://b/177432700.