### PR TITLE
[rebase to master] Fix crash when enabling frame tracks for manual instrumentation functions

### DIFF
--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -250,7 +250,14 @@ void TimeGraph::ProcessTimer(const TimerInfo& timer_info, const FunctionInfo* fu
     capture_max_timestamp_ = timer_info.end();
   }
 
-  if (function != nullptr && function->orbit_type() != FunctionInfo::kNone) {
+  // Functions for manual instrumentation scopes and tracked values are those with orbit_type() !=
+  // FunctionInfo::kNone. All proper timers for these have timer_info.type() == TimerInfo::kNone. It
+  // is possible to add frame tracks for these special functions, as they are simply hooked
+  // functions, but in those cases the timer type is TimerInfo::kFrame. We need to exclude those
+  // frame track timers from the special processing here as they do not represent manual
+  // instrumentation scopes.
+  if (function != nullptr && function_utils::IsOrbitFunc(*function) &&
+      timer_info.type() == TimerInfo::kNone) {
     ProcessOrbitFunctionTimer(function->orbit_type(), timer_info);
   }
 


### PR DESCRIPTION
Functions dynamically instrumented for manual instrumentation (that is,
functions with OrbitType not kNone) show up in the "Live" functions
view (which needs to be changed at some point) and it is possible to
enable a frame track for them. Due to the case distinction in
TimeGraph::ProcessTimer that checks for those special functions with
OrbitType != kNone, when adding a frame track, frame track timers were
processed incorrectly. This is fixed here.

Tested: Manual test with OrbitTest
Bug: http://b/177432700