### PR TITLE
Draw frametrack text in the correct layer

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -525,7 +525,7 @@ void CaptureWindow::Draw() {
 
     Vec2 pos(mouse_world_x_, world_top_left_y_);
     // Vertical green line at mouse x position
-    ui_batcher_.AddVerticalLine(pos, -world_height_, kZValueText, Color(0, 255, 0, 127));
+    ui_batcher_.AddVerticalLine(pos, -world_height_, kZValueUi, Color(0, 255, 0, 127));
 
     if (draw_help_) {
       RenderHelpUi();
@@ -888,8 +888,8 @@ void CaptureWindow::RenderSelectionOverlay() {
     const Color text_color(255, 255, 255, 255);
     float pos_x = pos[0] + size[0];
 
-    text_renderer_.AddText(text.c_str(), pos_x, select_stop_[1], GlCanvas::kZValueText, text_color,
-                           font_size_, size[0], true);
+    text_renderer_.AddText(text.c_str(), pos_x, select_stop_[1], GlCanvas::kZValueTextUi,
+                           text_color, font_size_, size[0], true);
 
     const unsigned char g = 100;
     Color grey(g, g, g, 255);

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -232,7 +232,7 @@ void FrameTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset
   float x = pos_[0];
   Vec2 from(x, y);
   Vec2 to(x + size_[0], y);
-  float ui_z = GlCanvas::kZValueUi;
+  float text_z = GlCanvas::kZValueTrackText + z_offset;
 
   const TimeGraphLayout& layout = time_graph_->GetLayout();
   std::string avg_time = GetPrettyTime(absl::Nanoseconds(stats_.average_time_ns()));
@@ -243,14 +243,13 @@ void FrameTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset
   Vec2 white_text_box_position(pos_[0] + layout.GetRightMargin(),
                                y - layout.GetTextBoxHeight() / 2.f);
 
-  batcher->AddLine(from, from + Vec2(layout.GetRightMargin() / 2.f, 0), ui_z, kWhiteColor);
-  batcher->AddLine(Vec2(white_text_box_position[0] + white_text_box_size[0], y), to, ui_z,
+  batcher->AddLine(from, from + Vec2(layout.GetRightMargin() / 2.f, 0), text_z, kWhiteColor);
+  batcher->AddLine(Vec2(white_text_box_position[0] + white_text_box_size[0], y), to, text_z,
                    kWhiteColor);
 
   canvas->GetTextRenderer().AddText(label.c_str(), white_text_box_position[0],
-                                    white_text_box_position[1] + layout.GetTextOffset(),
-                                    GlCanvas::kZValueTextUi, kWhiteColor, font_size,
-                                    white_text_box_size[0]);
+                                    white_text_box_position[1] + layout.GetTextOffset(), text_z,
+                                    kWhiteColor, font_size, white_text_box_size[0]);
 }
 
 void FrameTrack::UpdateBoxHeight() {

--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -27,9 +27,9 @@ float GlCanvas::kZValueTrack = 0.01f;
 float GlCanvas::kZValueEventBar = 0.03f;
 float GlCanvas::kZValueBox = 0.05f;
 float GlCanvas::kZValueEvent = 0.07f;
+float GlCanvas::kZValueTrackText = 0.09f;
 float GlCanvas::kZValueOverlay = 0.43f;
 float GlCanvas::kZValueOverlayTextBackground = 0.45f;
-float GlCanvas::kZValueText = 0.47f;
 float GlCanvas::kZValueEventBarPicking = 0.49f;
 float GlCanvas::kZValueUi = 0.61f;
 float GlCanvas::kZValueTextUi = 0.61f;
@@ -43,8 +43,13 @@ float GlCanvas::kZValueSlider = 0.89f;
 float GlCanvas::kZOffsetMovingTack = 0.1f;
 float GlCanvas::kZOffsetPinnedTrack = 0.2f;
 
-// Max Number of layers: 16 original, 4 for moving track, 4 for pinned Track, 4 epsilon in Slider
-unsigned GlCanvas::kMaxNumberRealZLayers = 16 + 4 + 4 + 4;
+constexpr unsigned kNumberOriginalLayers = 16;
+constexpr unsigned kExtraLayersForMovingTracks = 5;
+constexpr unsigned kExtraLayersForPinnedTracks = 5;
+constexpr unsigned kExtraLayersForSliderEpsilons = 4;
+unsigned GlCanvas::kMaxNumberRealZLayers = kNumberOriginalLayers + kExtraLayersForMovingTracks +
+                                           kExtraLayersForPinnedTracks +
+                                           kExtraLayersForSliderEpsilons;
 
 const Color GlCanvas::kBackgroundColor = Color(67, 67, 67, 255);
 const Color GlCanvas::kTabTextColorSelected = Color(100, 181, 246, 255);

--- a/src/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/GlCanvas.h
@@ -146,10 +146,9 @@ class GlCanvas {
   static float kZValueTextUi;
   static float kZValueUi;
   static float kZValueEventBarPicking;
-  static float kZValueText;
   static float kZValueOverlayTextBackground;
   static float kZValueOverlay;
-  static float kZValueRoundingCorner;
+  static float kZValueTrackText;
   static float kZValueEvent;
   static float kZValueBox;
   static float kZValueEventBar;

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -643,7 +643,7 @@ void TimeGraph::DrawIteratorBox(GlCanvas* canvas, Vec2 pos, Vec2 size, const Col
 
   const Color kBlack(0, 0, 0, 255);
   float text_width = canvas->GetTextRenderer().AddTextTrailingCharsPrioritized(
-      text.c_str(), pos[0], text_box_y + layout_.GetTextOffset(), GlCanvas::kZValueText, kBlack,
+      text.c_str(), pos[0], text_box_y + layout_.GetTextOffset(), GlCanvas::kZValueTextUi, kBlack,
       time.length(), font_size_, max_size);
 
   Vec2 white_box_size(std::min(static_cast<float>(text_width), max_size), GetTextBoxHeight());

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -99,7 +99,7 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
   float y0 = pos_[1];
   float y1 = y0 - size_[1];
   float track_z = GlCanvas::kZValueTrack + z_offset;
-  float text_z = GlCanvas::kZValueTrack + z_offset;
+  float text_z = GlCanvas::kZValueTrackText + z_offset;
   float top_margin = layout.GetTrackTopMargin();
 
   const Color kBackgroundColor = GetBackgroundColor();


### PR DESCRIPTION
We were drawing Frame-track-text as text on top in the capture view. So,
this text was drawn on top of other pinned/moving tracks and also over
the green overlay and iterators.

This PR erased completely the text z-layer because it makes confusion
and draw some text in the new track-text layer and other in UI-text
layer.

It solved http://b/177420768.

Test: Load a capture, enable a frame track, add iterators/overlays and
move tracks one on top of another several times.