### PR TITLE
Introduce function_id for instrumented functions

### DIFF
--- a/src/OrbitCaptureClient/CaptureEventProcessor.cpp
+++ b/src/OrbitCaptureClient/CaptureEventProcessor.cpp
@@ -33,6 +33,8 @@ using orbit_grpc_protos::SchedulingSlice;
 using orbit_grpc_protos::ThreadName;
 using orbit_grpc_protos::ThreadStateSlice;
 
+static constexpr uint64_t kInvalidFunctionId = 0;
+
 void CaptureEventProcessor::ProcessEvent(const CaptureEvent& event) {
   switch (event.event_case()) {
     case CaptureEvent::kSchedulingSlice:
@@ -126,7 +128,7 @@ void CaptureEventProcessor::ProcessFunctionCall(const FunctionCall& function_cal
   timer_info.set_start(function_call.end_timestamp_ns() - function_call.duration_ns());
   timer_info.set_end(function_call.end_timestamp_ns());
   timer_info.set_depth(static_cast<uint8_t>(function_call.depth()));
-  timer_info.set_function_address(function_call.absolute_address());
+  timer_info.set_function_id(function_call.function_id());
   timer_info.set_user_data_key(function_call.return_value());
   timer_info.set_processor(-1);
   timer_info.set_type(TimerInfo::kNone);
@@ -146,7 +148,7 @@ void CaptureEventProcessor::ProcessIntrospectionScope(
   timer_info.set_start(introspection_scope.end_timestamp_ns() - introspection_scope.duration_ns());
   timer_info.set_end(introspection_scope.end_timestamp_ns());
   timer_info.set_depth(static_cast<uint8_t>(introspection_scope.depth()));
-  timer_info.set_function_address(0);  // function address n/a, set to invalid value
+  timer_info.set_function_id(kInvalidFunctionId);  // function id n/a, set to 0
   timer_info.set_processor(-1);        // cpu info not available, set to invalid value
   timer_info.set_type(TimerInfo::kIntrospection);
   timer_info.mutable_registers()->CopyFrom(introspection_scope.registers());

--- a/src/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/src/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -36,7 +36,7 @@ class MyCaptureListener : public CaptureListener {
       ProcessData&& /*process*/,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> /*selected_functions*/,
       TracepointInfoSet /*selected_tracepoints*/,
-      UserDefinedCaptureData /*user_defined_capture_data*/) override {}
+      absl::flat_hash_set<uint64_t> /*frame_track_function_ids*/) override {}
   void OnCaptureComplete() override {}
   void OnCaptureCancelled() override {}
   void OnCaptureFailed(ErrorMessage) override {}

--- a/src/OrbitCaptureClient/CaptureEventProcessorTest.cpp
+++ b/src/OrbitCaptureClient/CaptureEventProcessorTest.cpp
@@ -59,7 +59,7 @@ class MockCaptureListener : public CaptureListener {
       (ProcessData&& /*process*/,
        (absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>)/*selected_functions*/,
        TracepointInfoSet /*selected_tracepoints*/,
-       UserDefinedCaptureData /*user_defined_capture_data*/),
+       absl::flat_hash_set<uint64_t> /*frame_track_function_ids*/),
       (override));
   MOCK_METHOD(void, OnCaptureComplete, (), (override));
   MOCK_METHOD(void, OnCaptureCancelled, (), (override));
@@ -213,7 +213,7 @@ TEST(CaptureEventProcessor, CanHandleFunctionCalls) {
   FunctionCall* function_call = event.mutable_function_call();
   function_call->set_pid(42);
   function_call->set_tid(24);
-  function_call->set_absolute_address(123);
+  function_call->set_function_id(123);
   function_call->set_duration_ns(97);
   function_call->set_end_timestamp_ns(100);
   function_call->set_depth(3);
@@ -228,7 +228,7 @@ TEST(CaptureEventProcessor, CanHandleFunctionCalls) {
 
   EXPECT_EQ(actual_timer.process_id(), function_call->pid());
   EXPECT_EQ(actual_timer.thread_id(), function_call->tid());
-  EXPECT_EQ(actual_timer.function_address(), function_call->absolute_address());
+  EXPECT_EQ(actual_timer.function_id(), function_call->function_id());
   EXPECT_EQ(actual_timer.start(), function_call->end_timestamp_ns() - function_call->duration_ns());
   EXPECT_EQ(actual_timer.end(), function_call->end_timestamp_ns());
   EXPECT_EQ(actual_timer.depth(), function_call->depth());

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
@@ -42,8 +42,9 @@ class CaptureClient {
       ThreadPool* thread_pool, const ProcessData& process,
       const orbit_client_data::ModuleManager& module_manager,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
-      TracepointInfoSet selected_tracepoints, UserDefinedCaptureData user_defined_capture_data,
-      bool collect_thread_state, bool enable_introspection);
+      TracepointInfoSet selected_tracepoints,
+      absl::flat_hash_set<uint64_t> frame_track_function_ids, bool collect_thread_state,
+      bool enable_introspection);
 
   // Returns true if stop was initiated and false otherwise.
   // The latter can happen if for example the stop was already
@@ -69,7 +70,7 @@ class CaptureClient {
   void Capture(ProcessData&& process, const orbit_client_data::ModuleManager& module_manager,
                absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
                TracepointInfoSet selected_tracepoints,
-               UserDefinedCaptureData user_defined_capture_data, bool collect_thread_state,
+               absl::flat_hash_set<uint64_t> frame_track_function_ids, bool collect_thread_state,
                bool enable_introspection);
 
   [[nodiscard]] ErrorMessageOr<void> FinishCapture();

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
@@ -20,8 +20,9 @@ class CaptureListener {
   // Called after capture started but before the first event arrived.
   virtual void OnCaptureStarted(
       ProcessData&& process,
-      absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
-      TracepointInfoSet selected_tracepoints, UserDefinedCaptureData user_defined_capture_data) = 0;
+      absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> instrumented_functions,
+      TracepointInfoSet selected_tracepoints,
+      absl::flat_hash_set<uint64_t> frame_track_function_ids) = 0;
   // Called when capture is complete.
   virtual void OnCaptureComplete() = 0;
 

--- a/src/OrbitClientGgp/include/OrbitClientGgp/ClientGgp.h
+++ b/src/OrbitClientGgp/include/OrbitClientGgp/ClientGgp.h
@@ -52,7 +52,7 @@ class ClientGgp final : public CaptureListener {
       ProcessData&& process,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints,
-      UserDefinedCaptureData user_defined_capture_data) override;
+      absl::flat_hash_set<uint64_t> frame_track_function_ids) override;
   void OnCaptureComplete() override;
   void OnCaptureCancelled() override;
   void OnCaptureFailed(ErrorMessage error_message) override;

--- a/src/OrbitClientModel/CaptureDeserializer.cpp
+++ b/src/OrbitClientModel/CaptureDeserializer.cpp
@@ -181,15 +181,15 @@ void LoadCaptureInfo(const CaptureInfo& capture_info, CaptureListener* capture_l
     return;
   }
 
-  UserDefinedCaptureData user_defined_capture_data;
-  for (const auto& function :
-       capture_info.user_defined_capture_info().frame_tracks_info().frame_track_functions()) {
-    user_defined_capture_data.InsertFrameTrack(function);
+  absl::flat_hash_set<uint64_t> frame_track_function_ids;
+  for (uint64_t function_id :
+       capture_info.user_defined_capture_info().frame_tracks_info().frame_track_function_ids()) {
+    frame_track_function_ids.insert(function_id);
   }
 
   capture_listener->OnCaptureStarted(std::move(process), std::move(selected_functions),
                                      std::move(selected_tracepoints),
-                                     std::move(user_defined_capture_data));
+                                     std::move(frame_track_function_ids));
 
   for (const auto& address_info : capture_info.address_infos()) {
     if (*cancellation_requested) {

--- a/src/OrbitClientModel/CaptureSerializer.cpp
+++ b/src/OrbitClientModel/CaptureSerializer.cpp
@@ -74,7 +74,7 @@ CaptureInfo GenerateCaptureInfo(
     const CaptureData& capture_data,
     const absl::flat_hash_map<uint64_t, std::string>& key_to_string_map) {
   CaptureInfo capture_info;
-  for (const auto& pair : capture_data.selected_functions()) {
+  for (const auto& pair : capture_data.instrumented_functions()) {
     capture_info.add_selected_functions()->CopyFrom(pair.second);
   }
 
@@ -169,11 +169,10 @@ CaptureInfo GenerateCaptureInfo(
 
   capture_info.mutable_key_to_string()->insert(key_to_string_map.begin(), key_to_string_map.end());
 
-  for (const auto& function : capture_data.user_defined_capture_data().frame_track_functions()) {
+  for (uint64_t function_id : capture_data.frame_track_function_ids()) {
     capture_info.mutable_user_defined_capture_info()
         ->mutable_frame_tracks_info()
-        ->add_frame_track_functions()
-        ->CopyFrom(function);
+        ->add_frame_track_function_ids(function_id);
   }
 
   return capture_info;

--- a/src/OrbitClientProtos/capture_data.proto
+++ b/src/OrbitClientProtos/capture_data.proto
@@ -110,7 +110,8 @@ message CaptureHeader {
 }
 
 message FrameTracksInfo {
-  repeated FunctionInfo frame_track_functions = 1;
+  reserved 1;
+  repeated uint64 frame_track_function_ids = 2;
 }
 
 message UserDefinedCaptureInfo {
@@ -155,7 +156,7 @@ message TimerInfo {
 
   int32 processor = 7;
   uint64 callstack_id = 8;
-  uint64 function_address = 9;
+  uint64 function_id = 9;
   uint64 user_data_key = 10;
   uint64 timeline_hash = 11;
   repeated uint64 registers = 12;

--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -47,8 +47,9 @@ AsyncTrack::AsyncTrack(TimeGraph* time_graph, const std::string& name, OrbitApp*
   // Orbit.h. Use it to retrieve the module from which the manually instrumented scope originated.
   const CaptureData* capture_data = time_graph_->GetCaptureData();
   const FunctionInfo* func =
-      capture_data ? capture_data->GetSelectedFunction(text_box->GetTimerInfo().function_address())
-                   : nullptr;
+      capture_data
+          ? capture_data->GetInstrumentedFunctionById(text_box->GetTimerInfo().function_id())
+          : nullptr;
   CHECK(func || timer_info.type() == TimerInfo::kIntrospection);
   std::string module_name =
       func != nullptr ? function_utils::GetLoadedModuleName(*func) : "unknown";

--- a/src/OrbitGl/CallStackDataView.cpp
+++ b/src/OrbitGl/CallStackDataView.cpp
@@ -161,7 +161,7 @@ void CallStackDataView::DoFilter() {
     return;
   }
 
-  std::vector<uint32_t> indices;
+  std::vector<uint64_t> indices;
   std::vector<std::string> tokens = absl::StrSplit(ToLower(filter_), ' ');
 
   for (size_t i = 0; i < callstack_.GetFramesCount(); ++i) {

--- a/src/OrbitGl/DataManager.cpp
+++ b/src/OrbitGl/DataManager.cpp
@@ -50,14 +50,14 @@ void DataManager::DeselectFunction(const FunctionInfo& function) {
   selected_functions_.erase(function);
 }
 
-void DataManager::set_visible_functions(absl::flat_hash_set<uint64_t> visible_functions) {
+void DataManager::set_visible_function_ids(absl::flat_hash_set<uint64_t> visible_function_ids) {
   CHECK(std::this_thread::get_id() == main_thread_id_);
-  visible_functions_ = std::move(visible_functions);
+  visible_function_ids_ = std::move(visible_function_ids);
 }
 
-void DataManager::set_highlighted_function(uint64_t highlighted_function_address) {
+void DataManager::set_highlighted_function_id(uint64_t highlighted_function_id) {
   CHECK(std::this_thread::get_id() == main_thread_id_);
-  highlighted_function_ = highlighted_function_address;
+  highlighted_function_id_ = highlighted_function_id;
 }
 
 void DataManager::set_selected_thread_id(int32_t thread_id) {
@@ -65,16 +65,14 @@ void DataManager::set_selected_thread_id(int32_t thread_id) {
   selected_thread_id_ = thread_id;
 }
 
-bool DataManager::IsFunctionVisible(uint64_t function_address) const {
+bool DataManager::IsFunctionVisible(uint64_t function_id) const {
   CHECK(std::this_thread::get_id() == main_thread_id_);
-  return visible_functions_.contains(function_address);
+  return visible_function_ids_.contains(function_id);
 }
 
-const uint64_t DataManager::kInvalidFunctionAddress = std::numeric_limits<uint64_t>::max();
-
-uint64_t DataManager::highlighted_function() const {
+uint64_t DataManager::highlighted_function_id() const {
   CHECK(std::this_thread::get_id() == main_thread_id_);
-  return highlighted_function_;
+  return highlighted_function_id_;
 }
 
 int32_t DataManager::selected_thread_id() const {

--- a/src/OrbitGl/DataManager.h
+++ b/src/OrbitGl/DataManager.h
@@ -36,8 +36,8 @@ class DataManager final {
   void SelectFunction(const orbit_client_protos::FunctionInfo& function);
   void DeselectFunction(const orbit_client_protos::FunctionInfo& function);
   void ClearSelectedFunctions();
-  void set_visible_functions(absl::flat_hash_set<uint64_t> visible_functions);
-  void set_highlighted_function(uint64_t highlighted_function_address);
+  void set_visible_function_ids(absl::flat_hash_set<uint64_t> visible_function_ids);
+  void set_highlighted_function_id(uint64_t highlighted_function_id);
   void set_selected_thread_id(int32_t thread_id);
   void set_selected_text_box(const TextBox* text_box);
 
@@ -45,7 +45,7 @@ class DataManager final {
   [[nodiscard]] bool IsFunctionSelected(const orbit_client_protos::FunctionInfo& function) const;
   [[nodiscard]] std::vector<orbit_client_protos::FunctionInfo> GetSelectedFunctions() const;
   [[nodiscard]] bool IsFunctionVisible(uint64_t function_address) const;
-  [[nodiscard]] uint64_t highlighted_function() const;
+  [[nodiscard]] uint64_t highlighted_function_id() const;
   [[nodiscard]] int32_t selected_thread_id() const;
   [[nodiscard]] const TextBox* selected_text_box() const;
 
@@ -76,15 +76,15 @@ class DataManager final {
   }
   [[nodiscard]] bool collect_thread_states() const { return collect_thread_states_; }
 
-  static const uint64_t kInvalidFunctionAddress;
+  static constexpr uint64_t kInvalidFunctionId = 0;
 
  private:
   const std::thread::id main_thread_id_;
   // We are sharing pointers to that entries and ensure reference stability by using node_hash_map
   absl::node_hash_map<int32_t, ProcessData> process_map_;
   FunctionInfoSet selected_functions_;
-  absl::flat_hash_set<uint64_t> visible_functions_;
-  uint64_t highlighted_function_ = kInvalidFunctionAddress;
+  absl::flat_hash_set<uint64_t> visible_function_ids_;
+  uint64_t highlighted_function_id_ = kInvalidFunctionId;
 
   TracepointInfoSet selected_tracepoints_;
 

--- a/src/OrbitGl/DataView.h
+++ b/src/OrbitGl/DataView.h
@@ -91,7 +91,7 @@ class DataView {
   virtual void DoFilter() {}
   FilterCallback filter_callback_;
 
-  std::vector<uint32_t> indices_;
+  std::vector<uint64_t> indices_;
   std::vector<SortingOrder> sorting_orders_;
   int sorting_column_ = 0;
   std::string filter_;

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -65,8 +65,9 @@ float FrameTrack::GetAverageBoxHeight() const {
   }
 }
 
-FrameTrack::FrameTrack(TimeGraph* time_graph, const FunctionInfo& function, OrbitApp* app)
-    : TimerTrack(time_graph, app), function_(function) {
+FrameTrack::FrameTrack(TimeGraph* time_graph, uint64_t function_id, const FunctionInfo& function,
+                       OrbitApp* app)
+    : TimerTrack(time_graph, app), function_id_(function_id), function_(function) {
   // TODO(b/169554463): Support manual instrumentation.
   std::string function_name = function_utils::GetDisplayName(function_);
   std::string name = absl::StrFormat("Frame track based on %s", function_name);

--- a/src/OrbitGl/FrameTrack.h
+++ b/src/OrbitGl/FrameTrack.h
@@ -24,10 +24,10 @@ class OrbitApp;
 
 class FrameTrack : public TimerTrack {
  public:
-  explicit FrameTrack(TimeGraph* time_graph, const orbit_client_protos::FunctionInfo& function,
-                      OrbitApp* app);
+  explicit FrameTrack(TimeGraph* time_graph, uint64_t function_id,
+                      const orbit_client_protos::FunctionInfo& function, OrbitApp* app);
   [[nodiscard]] Type GetType() const override { return kFrameTrack; }
-  [[nodiscard]] uint64_t GetFunctionAddress() const { return function_.address(); }
+  [[nodiscard]] uint64_t GetFunctionId() const { return function_id_; }
   [[nodiscard]] bool IsCollapsible() const override { return GetMaximumScaleFactor() > 0.f; }
 
   [[nodiscard]] virtual float GetYFromTimer(
@@ -59,6 +59,7 @@ class FrameTrack : public TimerTrack {
   [[nodiscard]] float GetMaximumBoxHeight() const;
   [[nodiscard]] float GetAverageBoxHeight() const;
 
+  uint64_t function_id_;
   orbit_client_protos::FunctionInfo function_;
   orbit_client_protos::FunctionStats stats_;
 };

--- a/src/OrbitGl/FrameTrackOnlineProcessor.h
+++ b/src/OrbitGl/FrameTrackOnlineProcessor.h
@@ -22,14 +22,12 @@ class FrameTrackOnlineProcessor {
   void ProcessTimer(const orbit_client_protos::TimerInfo& timer_info,
                     const orbit_client_protos::FunctionInfo& function);
 
-  void AddFrameTrack(const CaptureData& capture_data,
-                     const orbit_client_protos::FunctionInfo& function);
-  void RemoveFrameTrack(const CaptureData& capture_data,
-                        const orbit_client_protos::FunctionInfo& function);
+  void AddFrameTrack(uint64_t function_id);
+  void RemoveFrameTrack(uint64_t function_id);
 
  private:
-  absl::flat_hash_set<uint64_t> current_frame_track_functions_;
-  absl::flat_hash_map<uint64_t, uint64_t> previous_timestamp_ns_;
+  absl::flat_hash_set<uint64_t> current_frame_track_function_ids_;
+  absl::flat_hash_map<uint64_t, uint64_t> function_id_to_previous_timestamp_ns_;
 
   TimeGraph* time_graph_;
   int current_frame_index_ = 0;

--- a/src/OrbitGl/LiveFunctionsController.h
+++ b/src/OrbitGl/LiveFunctionsController.h
@@ -34,15 +34,16 @@ class LiveFunctionsController {
   void OnDataChanged() { live_functions_data_view_.OnDataChanged(); }
 
   void SetAddIteratorCallback(
-      std::function<void(uint64_t, orbit_client_protos::FunctionInfo*)> callback) {
-    add_iterator_callback_ = callback;
+      std::function<void(uint64_t, const orbit_client_protos::FunctionInfo*)> callback) {
+    add_iterator_callback_ = std::move(callback);
   }
 
   uint64_t GetCaptureMin();
   uint64_t GetCaptureMax();
   uint64_t GetStartTime(uint64_t index);
 
-  void AddIterator(orbit_client_protos::FunctionInfo* function);
+  void AddIterator(uint64_t instrumented_function_id,
+                   const orbit_client_protos::FunctionInfo* function);
 
  private:
   void Move();
@@ -52,9 +53,7 @@ class LiveFunctionsController {
   absl::flat_hash_map<uint64_t, const orbit_client_protos::FunctionInfo*> function_iterators_;
   absl::flat_hash_map<uint64_t, const TextBox*> current_textboxes_;
 
-  std::function<void(uint64_t, orbit_client_protos::FunctionInfo*)> add_iterator_callback_;
-
-  uint64_t next_iterator_id_ = 0;
+  std::function<void(uint64_t, const orbit_client_protos::FunctionInfo*)> add_iterator_callback_;
 
   uint64_t id_to_select_ = 0;
 

--- a/src/OrbitGl/LiveFunctionsDataView.h
+++ b/src/OrbitGl/LiveFunctionsDataView.h
@@ -5,6 +5,7 @@
 #ifndef ORBIT_GL_LIVE_FUNCTIONS_DATA_VIEW_H_
 #define ORBIT_GL_LIVE_FUNCTIONS_DATA_VIEW_H_
 
+#include <absl/container/flat_hash_map.h>
 #include <stdint.h>
 
 #include <optional>
@@ -35,16 +36,17 @@ class LiveFunctionsDataView : public DataView {
                      const std::vector<int>& item_indices) override;
   void OnDataChanged() override;
   void OnTimer() override;
-  std::optional<int> GetRowFromFunctionAddress(uint64_t function_address);
+  std::optional<int> GetRowFromFunctionId(uint64_t function_id);
 
  protected:
   void DoFilter() override;
   void DoSort() override;
-  [[nodiscard]] orbit_client_protos::FunctionInfo* GetSelectedFunction(unsigned int row);
-  [[nodiscard]] std::pair<TextBox*, TextBox*> GetMinMax(
-      const orbit_client_protos::FunctionInfo& function) const;
+  [[nodiscard]] uint64_t GetInstrumentedFunctionId(uint32_t row) const;
+  [[nodiscard]] const orbit_client_protos::FunctionInfo& GetInstrumentedFunction(
+      uint32_t row) const;
+  [[nodiscard]] const std::pair<TextBox*, TextBox*> GetMinMax(uint64_t function_id) const;
 
-  std::vector<orbit_client_protos::FunctionInfo> functions_;
+  absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> functions_;
 
   LiveFunctionsController* live_functions_;
 

--- a/src/OrbitGl/ModulesDataView.cpp
+++ b/src/OrbitGl/ModulesDataView.cpp
@@ -165,7 +165,7 @@ void ModulesDataView::OnDoubleClicked(int index) {
 }
 
 void ModulesDataView::DoFilter() {
-  std::vector<uint32_t> indices;
+  std::vector<uint64_t> indices;
   std::vector<std::string> tokens = absl::StrSplit(ToLower(filter_), ' ');
 
   for (size_t i = 0; i < modules_.size(); ++i) {

--- a/src/OrbitGl/PresetsDataView.cpp
+++ b/src/OrbitGl/PresetsDataView.cpp
@@ -180,7 +180,7 @@ void PresetsDataView::OnDoubleClicked(int index) {
 }
 
 void PresetsDataView::DoFilter() {
-  std::vector<uint32_t> indices;
+  std::vector<uint64_t> indices;
 
   std::vector<std::string> tokens = absl::StrSplit(ToLower(filter_), ' ');
 

--- a/src/OrbitGl/ProcessesDataView.cpp
+++ b/src/OrbitGl/ProcessesDataView.cpp
@@ -148,7 +148,7 @@ bool ProcessesDataView::SelectProcess(int32_t process_id) {
 }
 
 void ProcessesDataView::DoFilter() {
-  std::vector<uint32_t> indices;
+  std::vector<uint64_t> indices;
   const std::vector<ProcessInfo>& processes = process_list_;
 
   std::vector<std::string> tokens = absl::StrSplit(ToLower(filter_), ' ');

--- a/src/OrbitGl/SamplingReportDataView.cpp
+++ b/src/OrbitGl/SamplingReportDataView.cpp
@@ -301,7 +301,7 @@ void SamplingReportDataView::SetThreadID(ThreadID tid) {
 }
 
 void SamplingReportDataView::DoFilter() {
-  std::vector<uint32_t> indices;
+  std::vector<uint64_t> indices;
 
   std::vector<std::string> tokens = absl::StrSplit(ToLower(filter_), ' ');
 

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -72,8 +72,9 @@ std::string ThreadTrack::GetBoxTooltip(PickingId id) const {
 
   const CaptureData* capture_data = time_graph_->GetCaptureData();
   const FunctionInfo* func =
-      capture_data ? capture_data->GetSelectedFunction(text_box->GetTimerInfo().function_address())
-                   : nullptr;
+      capture_data
+          ? capture_data->GetInstrumentedFunctionById(text_box->GetTimerInfo().function_id())
+          : nullptr;
 
   if (!func) {
     return text_box->GetText();
@@ -102,7 +103,7 @@ std::string ThreadTrack::GetBoxTooltip(PickingId id) const {
 
 bool ThreadTrack::IsTimerActive(const TimerInfo& timer_info) const {
   return timer_info.type() == TimerInfo::kIntrospection ||
-         app_->IsFunctionVisible(timer_info.function_address());
+         app_->IsFunctionVisible(timer_info.function_id());
 }
 
 bool ThreadTrack::IsTrackSelected() const {
@@ -138,8 +139,8 @@ Color ThreadTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected) 
     return kInactiveColor;
   }
 
-  uint64_t address = timer_info.function_address();
-  const FunctionInfo* function_info = app_->GetSelectedFunction(address);
+  uint64_t function_id = timer_info.function_id();
+  const FunctionInfo* function_info = app_->GetInstrumentedFunction(function_id);
   CHECK(function_info || timer_info.type() == TimerInfo::kIntrospection);
   std::optional<Color> user_color =
       function_info ? GetUserColor(timer_info, *function_info) : std::nullopt;
@@ -265,7 +266,7 @@ void ThreadTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_u
     std::string time = GetPrettyTime(absl::Microseconds(elapsed_us));
     text_box->SetElapsedTimeTextLength(time.length());
 
-    const FunctionInfo* func = app_->GetSelectedFunction(timer_info.function_address());
+    const FunctionInfo* func = app_->GetInstrumentedFunction(timer_info.function_id());
     if (func) {
       std::string extra_info = GetExtraInfo(timer_info);
       std::string name;

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -58,7 +58,7 @@ class TimeGraph {
   // TODO (b/176056427): TimeGraph should not store nor expose CaptureData.
   [[nodiscard]] const CaptureData* GetCaptureData() const { return capture_data_; }
   void SetCaptureData(CaptureData* capture_data) { capture_data_ = capture_data; }
-  [[nodiscard]] TrackManager* const GetTrackManager() const { return track_manager_.get(); }
+  [[nodiscard]] TrackManager* GetTrackManager() { return track_manager_.get(); }
 
   [[nodiscard]] float GetThreadTotalHeight() const;
   [[nodiscard]] float GetTextBoxHeight() const { return layout_.GetTextBoxHeight(); }
@@ -176,8 +176,8 @@ class TimeGraph {
   [[nodiscard]] uint64_t GetCaptureMax() const { return capture_max_timestamp_; }
   [[nodiscard]] uint64_t GetCurrentMouseTimeNs() const { return current_mouse_time_ns_; }
 
-  [[nodiscard]] bool HasFrameTrack(const orbit_client_protos::FunctionInfo& function) const;
-  void RemoveFrameTrack(const orbit_client_protos::FunctionInfo& function);
+  [[nodiscard]] bool HasFrameTrack(uint64_t function_id) const;
+  void RemoveFrameTrack(uint64_t function_id);
   [[nodiscard]] std::string GetThreadNameFromTid(uint32_t tid);
 
   [[nodiscard]] const TimeGraphAccessibility* GetOrCreateAccessibleInterface() const {

--- a/src/OrbitGl/TimerInfosIteratorTest.cpp
+++ b/src/OrbitGl/TimerInfosIteratorTest.cpp
@@ -24,7 +24,7 @@ TEST(TimerInfosIterator, Access) {
   std::shared_ptr<TimerChain> chain = std::make_shared<TimerChain>();
   TextBox box;
   TimerInfo timer;
-  timer.set_function_address(1);
+  timer.set_function_id(1);
   // Need to set the end, as SetTimerInfo will refuse that timer otherwise.
   timer.set_end(1);
   box.SetTimerInfo(timer);
@@ -32,13 +32,13 @@ TEST(TimerInfosIterator, Access) {
   chains.push_back(chain);
 
   // Just validate setting worked as expected
-  EXPECT_EQ(1, timer.function_address());
-  EXPECT_EQ(1, box.GetTimerInfo().function_address());
+  EXPECT_EQ(1, timer.function_id());
+  EXPECT_EQ(1, box.GetTimerInfo().function_id());
 
   // Now create an iterator and test to access it
   TimerInfosIterator it(chains.begin(), chains.end());
-  EXPECT_EQ(1, it->function_address());
-  EXPECT_EQ(1, (*it).function_address());
+  EXPECT_EQ(1, it->function_id());
+  EXPECT_EQ(1, (*it).function_id());
 }
 
 TEST(TimerInfosIterator, Copy) {
@@ -46,7 +46,7 @@ TEST(TimerInfosIterator, Copy) {
   std::shared_ptr<TimerChain> chain = std::make_shared<TimerChain>();
   TextBox box;
   TimerInfo timer;
-  timer.set_function_address(1);
+  timer.set_function_id(1);
   // Need to set the end, as SetTimerInfo will refuse that timer otherwise.
   timer.set_end(1);
   box.SetTimerInfo(timer);
@@ -55,23 +55,23 @@ TEST(TimerInfosIterator, Copy) {
 
   // Now create an iterator and test to access it
   TimerInfosIterator it(chains.begin(), chains.end());
-  EXPECT_EQ(1, it->function_address());
+  EXPECT_EQ(1, it->function_id());
 
   // Now create a Copy
   TimerInfosIterator it_copy1 = it;
-  EXPECT_EQ(1, it_copy1->function_address());
+  EXPECT_EQ(1, it_copy1->function_id());
 
   // Increase the original and check that the copy does not modify
   ++it;
-  EXPECT_EQ(1, it_copy1->function_address());
+  EXPECT_EQ(1, it_copy1->function_id());
 
   // Create a copy using the copy-constructor
   TimerInfosIterator it_copy2(it_copy1);
-  EXPECT_EQ(1, it_copy2->function_address());
+  EXPECT_EQ(1, it_copy2->function_id());
 
   // Increase the original and check that the copy does not modify
   ++it_copy1;
-  EXPECT_EQ(1, it_copy2->function_address());
+  EXPECT_EQ(1, it_copy2->function_id());
 }
 
 TEST(TimerInfosIterator, Move) {
@@ -79,7 +79,7 @@ TEST(TimerInfosIterator, Move) {
   std::shared_ptr<TimerChain> chain = std::make_shared<TimerChain>();
   TextBox box;
   TimerInfo timer;
-  timer.set_function_address(1);
+  timer.set_function_id(1);
   // Need to set the end, as SetTimerInfo will refuse that timer otherwise.
   timer.set_end(1);
   box.SetTimerInfo(timer);
@@ -88,15 +88,15 @@ TEST(TimerInfosIterator, Move) {
 
   // Now create an iterator and test to access it
   TimerInfosIterator it(chains.begin(), chains.end());
-  EXPECT_EQ(1, it->function_address());
+  EXPECT_EQ(1, it->function_id());
 
   // Now create a Copy
   TimerInfosIterator it_copy1 = std::move(it);
-  EXPECT_EQ(1, it_copy1->function_address());
+  EXPECT_EQ(1, it_copy1->function_id());
 
   // Create a copy using the copy-constructor
   TimerInfosIterator it_copy2(std::move(it_copy1));
-  EXPECT_EQ(1, it_copy2->function_address());
+  EXPECT_EQ(1, it_copy2->function_id());
 }
 
 TEST(TimerInfosIterator, Equality) {
@@ -104,7 +104,7 @@ TEST(TimerInfosIterator, Equality) {
   std::shared_ptr<TimerChain> chain = std::make_shared<TimerChain>();
   TextBox box;
   TimerInfo timer;
-  timer.set_function_address(1);
+  timer.set_function_id(1);
   timer.set_end(1);
   box.SetTimerInfo(timer);
   chain->push_back(box);
@@ -136,7 +136,7 @@ TEST(TimerInfosIterator, ForEachEmpty) {
 
   std::vector<uint64_t> result;
   for (auto it = it_begin; it != it_end; ++it) {
-    result.push_back(it->function_address());
+    result.push_back(it->function_id());
   }
   EXPECT_THAT(result, testing::ElementsAre());
 }
@@ -155,7 +155,7 @@ TEST(TimerInfosIterator, ForEachLarge) {
     for (size_t box_count = 0; box_count < max_timers; ++box_count) {
       TextBox box;
       TimerInfo timer;
-      timer.set_function_address(count);
+      timer.set_function_id(count);
       timer.set_start(count);
       timer.set_end(count + 1);
       box.SetTimerInfo(timer);
@@ -172,7 +172,7 @@ TEST(TimerInfosIterator, ForEachLarge) {
 
   std::vector<uint64_t> result;
   for (auto it = it_begin; it != it_end; ++it) {
-    result.push_back(it->function_address());
+    result.push_back(it->function_id());
   }
   EXPECT_THAT(result, testing::ElementsAreArray(expected));
 }

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -75,7 +75,7 @@ void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
 
   std::vector<std::shared_ptr<TimerChain>> chains_by_depth = GetTimers();
   const TextBox* selected_textbox = app_->selected_text_box();
-  uint64_t highlighted_address = app_->GetFunctionAddressToHighlight();
+  uint64_t highlighted_function_id = app_->GetFunctionIdToHighlight();
 
   // We minimize overdraw when drawing lines for small events by discarding
   // events that would just draw over an already drawn line. When zoomed in
@@ -104,7 +104,7 @@ void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
         if (min_tick > timer_info.end() || max_tick < timer_info.start()) continue;
         if (timer_info.start() >= min_ignore && timer_info.end() <= max_ignore) continue;
         if (!TimerFilter(timer_info)) continue;
-        uint64_t function_address = timer_info.function_address();
+        uint64_t function_id = timer_info.function_id();
 
         UpdateDepth(timer_info.depth() + 1);
         double start_us = time_graph_->GetUsFromTick(timer_info.start());
@@ -118,7 +118,7 @@ void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
 
         bool is_visible_width = normalized_length * canvas->GetWidth() > 1;
         bool is_selected = &text_box == selected_textbox;
-        bool is_highlighted = !is_selected && function_address == highlighted_address;
+        bool is_highlighted = !is_selected && function_id == highlighted_function_id;
 
         Vec2 pos(world_timer_x, world_timer_y);
         Vec2 size(world_timer_width, GetTextBoxHeight(timer_info));

--- a/src/OrbitGl/TracepointsDataView.cpp
+++ b/src/OrbitGl/TracepointsDataView.cpp
@@ -77,7 +77,7 @@ void TracepointsDataView::DoSort() {
 }
 
 void TracepointsDataView::DoFilter() {
-  std::vector<uint32_t> indices;
+  std::vector<uint64_t> indices;
   std::vector<std::string> tokens = absl::StrSplit(ToLower(filter_), ' ');
 
   for (size_t i = 0; i < tracepoints_.size(); ++i) {

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -60,7 +60,8 @@ class TrackManager {
   GpuTrack* GetOrCreateGpuTrack(uint64_t timeline_hash);
   GraphTrack* GetOrCreateGraphTrack(const std::string& name);
   AsyncTrack* GetOrCreateAsyncTrack(const std::string& name);
-  FrameTrack* GetOrCreateFrameTrack(const orbit_client_protos::FunctionInfo& function);
+  FrameTrack* GetOrCreateFrameTrack(uint64_t function_id,
+                                    const orbit_client_protos::FunctionInfo& function);
 
   void AddTrack(std::shared_ptr<Track> track);
   void RemoveFrameTrack(uint64_t function_address);

--- a/src/OrbitGrpcProtos/capture.proto
+++ b/src/OrbitGrpcProtos/capture.proto
@@ -24,7 +24,7 @@ message CaptureOptions {
   message InstrumentedFunction {
     string file_path = 1;
     uint64 file_offset = 2;
-    uint64 absolute_address = 3;
+    uint64 function_id = 3;
 
     enum FunctionType {
       kRegular = 0;
@@ -69,7 +69,7 @@ message FunctionCall {
   reserved 4;
   int32 pid = 1;
   int32 tid = 2;
-  uint64 absolute_address = 3;
+  uint64 function_id = 3;
   uint64 duration_ns = 9;
   uint64 end_timestamp_ns = 5;
   int32 depth = 6;

--- a/src/OrbitLinuxTracing/Function.h
+++ b/src/OrbitLinuxTracing/Function.h
@@ -5,28 +5,35 @@
 #ifndef ORBIT_LINUX_TRACING_FUNCTION_H_
 #define ORBIT_LINUX_TRACING_FUNCTION_H_
 
+#include <absl/hash/hash.h>
+
 #include <cstdint>
 #include <string>
 
 namespace orbit_linux_tracing {
 class Function {
  public:
-  Function(std::string binary_path, uint64_t file_offset, uint64_t virtual_address)
-      : binary_path_{std::move(binary_path)},
-        file_offset_{file_offset},
-        virtual_address_{virtual_address} {}
+  Function(uint64_t function_id, std::string file_path, uint64_t file_offset)
+      : function_id_{function_id}, file_path_{std::move(file_path)}, file_offset_{file_offset} {}
 
-  const std::string& BinaryPath() const { return binary_path_; }
+  [[nodiscard]] uint64_t function_id() const { return function_id_; }
+  [[nodiscard]] const std::string& file_path() const { return file_path_; }
+  [[nodiscard]] uint64_t file_offset() const { return file_offset_; }
 
-  uint64_t FileOffset() const { return file_offset_; }
-
-  uint64_t VirtualAddress() const { return virtual_address_; }
+  bool operator==(const Function& other) {
+    return (this->file_offset_ == other.file_offset_) && (this->file_path_ == other.file_path_);
+  }
 
  private:
-  std::string binary_path_;
+  uint64_t function_id_;
+  std::string file_path_;
   uint64_t file_offset_;
-  uint64_t virtual_address_;
 };
+
+template <typename H>
+H AbslHashValue(H state, const Function& function) {
+  return H::combine(std::move(state), function.file_path(), function.file_offset());
+}
 }  // namespace orbit_linux_tracing
 
 #endif  // ORBIT_LINUX_TRACING_FUNCTION_H_

--- a/src/OrbitLinuxTracing/ManualInstrumentationConfig.h
+++ b/src/OrbitLinuxTracing/ManualInstrumentationConfig.h
@@ -9,23 +9,27 @@
 
 #include <cstdint>
 
+#include "Function.h"
+
+namespace orbit_linux_tracing {
 class ManualInstrumentationConfig {
  public:
-  void AddTimerStartAddress(uint64_t address) { timer_start_addresses_.insert(address); }
+  void AddTimerStartFunctionId(uint64_t id) { timer_start_function_ids_.insert(id); }
 
-  void AddTimerStopAddress(uint64_t address) { timer_stop_addresses_.insert(address); }
+  void AddTimerStopFunctionId(uint64_t id) { timer_stop_function_ids_.insert(id); }
 
-  bool IsTimerStartAddress(uint64_t address) const {
-    return timer_start_addresses_.contains(address);
+  [[nodiscard]] bool IsTimerStartFunction(uint64_t function_id) const {
+    return timer_start_function_ids_.contains(function_id);
   }
 
-  bool IsTimerStopAddress(uint64_t address) const {
-    return timer_stop_addresses_.contains(address);
+  [[nodiscard]] bool IsTimerStopFunction(uint64_t function_id) const {
+    return timer_stop_function_ids_.contains(function_id);
   }
 
  private:
-  absl::flat_hash_set<uint64_t> timer_start_addresses_;
-  absl::flat_hash_set<uint64_t> timer_stop_addresses_;
+  absl::flat_hash_set<uint64_t> timer_start_function_ids_;
+  absl::flat_hash_set<uint64_t> timer_stop_function_ids_;
 };
+}  // namespace orbit_linux_tracing
 
 #endif

--- a/src/OrbitLinuxTracing/UprobesFunctionCallManager.h
+++ b/src/OrbitLinuxTracing/UprobesFunctionCallManager.h
@@ -27,10 +27,10 @@ class UprobesFunctionCallManager {
   UprobesFunctionCallManager(UprobesFunctionCallManager&&) = default;
   UprobesFunctionCallManager& operator=(UprobesFunctionCallManager&&) = default;
 
-  void ProcessUprobes(pid_t tid, uint64_t function_address, uint64_t begin_timestamp,
+  void ProcessUprobes(pid_t tid, uint64_t function_id, uint64_t begin_timestamp,
                       const perf_event_sample_regs_user_sp_ip_arguments& regs) {
     auto& tid_uprobes_stack = tid_uprobes_stacks_[tid];
-    tid_uprobes_stack.emplace(function_address, begin_timestamp, regs);
+    tid_uprobes_stack.emplace(function_id, begin_timestamp, regs);
   }
 
   std::optional<orbit_grpc_protos::FunctionCall> ProcessUretprobes(pid_t pid, pid_t tid,
@@ -49,7 +49,7 @@ class UprobesFunctionCallManager {
     orbit_grpc_protos::FunctionCall function_call;
     function_call.set_pid(pid);
     function_call.set_tid(tid);
-    function_call.set_absolute_address(tid_uprobe.function_address);
+    function_call.set_function_id(tid_uprobe.function_id);
     function_call.set_duration_ns(end_timestamp - tid_uprobe.begin_timestamp);
     function_call.set_end_timestamp_ns(end_timestamp);
     function_call.set_depth(tid_uprobes_stack.size() - 1);
@@ -70,10 +70,10 @@ class UprobesFunctionCallManager {
 
  private:
   struct OpenUprobes {
-    OpenUprobes(uint64_t function_address, uint64_t begin_timestamp,
+    OpenUprobes(uint64_t function_id, uint64_t begin_timestamp,
                 const perf_event_sample_regs_user_sp_ip_arguments& regs)
-        : function_address{function_address}, begin_timestamp{begin_timestamp}, registers(regs) {}
-    uint64_t function_address;
+        : function_id{function_id}, begin_timestamp{begin_timestamp}, registers(regs) {}
+    uint64_t function_id;
     uint64_t begin_timestamp;
     perf_event_sample_regs_user_sp_ip_arguments registers;
   };

--- a/src/OrbitLinuxTracing/UprobesFunctionCallManagerTest.cpp
+++ b/src/OrbitLinuxTracing/UprobesFunctionCallManagerTest.cpp
@@ -29,7 +29,7 @@ TEST(UprobesFunctionCallManager, OneUprobe) {
   ASSERT_TRUE(processed_function_call.has_value());
   EXPECT_EQ(processed_function_call.value().pid(), pid);
   EXPECT_EQ(processed_function_call.value().tid(), tid);
-  EXPECT_EQ(processed_function_call.value().absolute_address(), 100);
+  EXPECT_EQ(processed_function_call.value().function_id(), 100);
   EXPECT_EQ(processed_function_call.value().duration_ns(), 1);
   EXPECT_EQ(processed_function_call.value().end_timestamp_ns(), 2);
   EXPECT_EQ(processed_function_call.value().depth(), 0);
@@ -52,7 +52,7 @@ TEST(UprobesFunctionCallManager, TwoNestedUprobesAndAnotherUprobe) {
   ASSERT_TRUE(processed_function_call.has_value());
   EXPECT_EQ(processed_function_call.value().pid(), pid);
   EXPECT_EQ(processed_function_call.value().tid(), tid);
-  EXPECT_EQ(processed_function_call.value().absolute_address(), 200);
+  EXPECT_EQ(processed_function_call.value().function_id(), 200);
   EXPECT_EQ(processed_function_call.value().duration_ns(), 1);
   EXPECT_EQ(processed_function_call.value().end_timestamp_ns(), 3);
   EXPECT_EQ(processed_function_call.value().depth(), 1);
@@ -63,7 +63,7 @@ TEST(UprobesFunctionCallManager, TwoNestedUprobesAndAnotherUprobe) {
   ASSERT_TRUE(processed_function_call.has_value());
   EXPECT_EQ(processed_function_call.value().pid(), pid);
   EXPECT_EQ(processed_function_call.value().tid(), tid);
-  EXPECT_EQ(processed_function_call.value().absolute_address(), 100);
+  EXPECT_EQ(processed_function_call.value().function_id(), 100);
   EXPECT_EQ(processed_function_call.value().duration_ns(), 3);
   EXPECT_EQ(processed_function_call.value().end_timestamp_ns(), 4);
   EXPECT_EQ(processed_function_call.value().depth(), 0);
@@ -76,7 +76,7 @@ TEST(UprobesFunctionCallManager, TwoNestedUprobesAndAnotherUprobe) {
   ASSERT_TRUE(processed_function_call.has_value());
   EXPECT_EQ(processed_function_call.value().pid(), pid);
   EXPECT_EQ(processed_function_call.value().tid(), tid);
-  EXPECT_EQ(processed_function_call.value().absolute_address(), 300);
+  EXPECT_EQ(processed_function_call.value().function_id(), 300);
   EXPECT_EQ(processed_function_call.value().duration_ns(), 1);
   EXPECT_EQ(processed_function_call.value().end_timestamp_ns(), 6);
   EXPECT_EQ(processed_function_call.value().depth(), 0);
@@ -100,7 +100,7 @@ TEST(UprobesFunctionCallManager, TwoUprobesDifferentThreads) {
   ASSERT_TRUE(processed_function_call.has_value());
   EXPECT_EQ(processed_function_call.value().pid(), pid);
   EXPECT_EQ(processed_function_call.value().tid(), tid);
-  EXPECT_EQ(processed_function_call.value().absolute_address(), 100);
+  EXPECT_EQ(processed_function_call.value().function_id(), 100);
   EXPECT_EQ(processed_function_call.value().duration_ns(), 2);
   EXPECT_EQ(processed_function_call.value().end_timestamp_ns(), 3);
   EXPECT_EQ(processed_function_call.value().depth(), 0);
@@ -111,7 +111,7 @@ TEST(UprobesFunctionCallManager, TwoUprobesDifferentThreads) {
   ASSERT_TRUE(processed_function_call.has_value());
   EXPECT_EQ(processed_function_call.value().pid(), pid);
   EXPECT_EQ(processed_function_call.value().tid(), tid2);
-  EXPECT_EQ(processed_function_call.value().absolute_address(), 200);
+  EXPECT_EQ(processed_function_call.value().function_id(), 200);
   EXPECT_EQ(processed_function_call.value().duration_ns(), 2);
   EXPECT_EQ(processed_function_call.value().end_timestamp_ns(), 4);
   EXPECT_EQ(processed_function_call.value().depth(), 0);

--- a/src/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
@@ -163,7 +163,7 @@ void UprobesUnwindingVisitor::visit(UprobesPerfEvent* event) {
   }
   uprobe_sps_ips_cpus.emplace_back(uprobe_sp, uprobe_ip, uprobe_cpu);
 
-  function_call_manager_.ProcessUprobes(event->GetTid(), event->GetFunction()->VirtualAddress(),
+  function_call_manager_.ProcessUprobes(event->GetTid(), event->GetFunction()->function_id(),
                                         event->GetTimestamp(), event->ring_buffer_record.regs);
 
   return_address_manager_.ProcessUprobes(event->GetTid(), event->GetSp(),

--- a/src/OrbitQt/orbitlivefunctions.cpp
+++ b/src/OrbitQt/orbitlivefunctions.cpp
@@ -40,7 +40,7 @@ void OrbitLiveFunctions::Initialize(OrbitApp* app, SelectionType selection_type,
   ui->data_view_panel_->Initialize(data_view, selection_type, font_type, is_main_instance);
 
   live_functions_->SetAddIteratorCallback(
-      [this](size_t id, FunctionInfo* function) { this->AddIterator(id, function); });
+      [this](uint64_t id, const FunctionInfo* function) { this->AddIterator(id, function); });
 
   all_events_iterator_ = new OrbitEventIterator(this);
   all_events_iterator_->SetNextButtonCallback([this]() {
@@ -70,7 +70,7 @@ void OrbitLiveFunctions::Initialize(OrbitApp* app, SelectionType selection_type,
 
 void OrbitLiveFunctions::Deinitialize() {
   delete all_events_iterator_;
-  live_functions_->SetAddIteratorCallback([](size_t, FunctionInfo*) {});
+  live_functions_->SetAddIteratorCallback([](uint64_t, const FunctionInfo*) {});
   ui->data_view_panel_->Deinitialize();
   live_functions_.reset();
 }
@@ -87,7 +87,7 @@ void OrbitLiveFunctions::OnDataChanged() {
   }
 }
 
-void OrbitLiveFunctions::AddIterator(size_t id, FunctionInfo* function) {
+void OrbitLiveFunctions::AddIterator(size_t id, const FunctionInfo* function) {
   if (!live_functions_) return;
 
   OrbitEventIterator* iterator_ui = new OrbitEventIterator(this);

--- a/src/OrbitQt/orbitlivefunctions.h
+++ b/src/OrbitQt/orbitlivefunctions.h
@@ -41,7 +41,7 @@ class OrbitLiveFunctions : public QWidget {
   void OnRowSelected(std::optional<int> row);
   void Reset();
   void SetFilter(const QString& a_Filter);
-  void AddIterator(uint64_t id, orbit_client_protos::FunctionInfo* function);
+  void AddIterator(uint64_t id, const orbit_client_protos::FunctionInfo* function);
   QLineEdit* GetFilterLineEdit();
   std::optional<LiveFunctionsController*> GetLiveFunctionsController() {
     return live_functions_ ? &live_functions_.value() : nullptr;

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1081,12 +1081,12 @@ void OrbitMainWindow::RestoreDefaultTabLayout() {
 void OrbitMainWindow::OnTimerSelectionChanged(const orbit_client_protos::TimerInfo* timer_info) {
   std::optional<int> selected_row(std::nullopt);
   if (timer_info) {
-    uint64_t function_address = timer_info->function_address();
+    uint64_t function_id = timer_info->function_id();
     const auto live_functions_controller = ui->liveFunctions->GetLiveFunctionsController();
     CHECK(live_functions_controller.has_value());
     LiveFunctionsDataView& live_functions_data_view =
         live_functions_controller.value()->GetDataView();
-    selected_row = live_functions_data_view.GetRowFromFunctionAddress(function_address);
+    selected_row = live_functions_data_view.GetRowFromFunctionId(function_id);
   }
   ui->liveFunctions->OnRowSelected(selected_row);
 }


### PR DESCRIPTION
Previously the client code used absolute function address to identify
the instrumented function in timers and in some other places in UI.

Since using the address assumes that the function address in memory is
fixed (which might not be true) this has been replaced with function_id
for instrumented functions.

Changed code relying on function absolute address where it is not needed
and replaced it with function_id.

Test: run unit tests
Test: hook functions run capture, create iterators and frame tracks
Bug: http://b/177525225
Bug: http://b/175865913