### PR TITLE
Add CHECK(module != nullptr) and pass vector by reference.

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1229,6 +1229,7 @@ void OrbitApp::LoadSymbols(const std::filesystem::path& symbols_path, ModuleData
 ErrorMessageOr<void> OrbitApp::GetFunctionInfosFromHashes(
     const ModuleData* module, const std::vector<uint64_t>& function_hashes,
     std::vector<const FunctionInfo*>* function_infos) {
+  CHECK(module != nullptr);
   const ProcessData* process = GetTargetProcess();
   if (process == nullptr) {
     return ErrorMessage(absl::StrFormat(
@@ -1268,7 +1269,7 @@ ErrorMessageOr<void> OrbitApp::SelectFunctionsFromHashes(
 }
 
 ErrorMessageOr<void> OrbitApp::EnableFrameTracksFromHashes(
-    const ModuleData* module, const std::vector<uint64_t> function_hashes) {
+    const ModuleData* module, const std::vector<uint64_t>& function_hashes) {
   std::vector<const FunctionInfo*> function_infos;
   const auto& error = GetFunctionInfosFromHashes(module, function_hashes, &function_infos);
   for (const auto* function : function_infos) {

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -418,7 +418,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
       std::vector<const orbit_client_protos::FunctionInfo*>* function_infos);
 
   ErrorMessageOr<void> EnableFrameTracksFromHashes(const ModuleData* module,
-                                                   const std::vector<uint64_t> function_hashes);
+                                                   const std::vector<uint64_t>& function_hashes);
   void AddFrameTrackTimers(const orbit_client_protos::FunctionInfo& function);
   void RefreshFrameTracks();
 


### PR DESCRIPTION
This adds a `CHECK` to `App::GetFunctionInfosFromHashes`,
as the `module` was accessed without any checks and we previously
already had crashes related to this code (it must not be nullptr in the
current code, though).

Also it passes `function_hashes` as reference to `SelectFunctionsFromHashes`.

Test: Compile.
Bug: http://b/173712098.