### PR TITLE
Copy the Vulkan layer to the build artefacts.

### DIFF
--- a/kokoro/builds/build.sh
+++ b/kokoro/builds/build.sh
@@ -183,6 +183,8 @@ if [ -n "$1" ]; then
     cp -v OrbitProfiler*.deb Orbit/collector/
     cp -v OrbitProfiler*.deb.asc Orbit/collector/
     cp -v bin/OrbitClientGgp Orbit/collector/
+    cp -v lib/libOrbitVulkanLayer.so Orbit/collector/
+    cp -v lib/VkLayer_Orbit_implicit.json Orbit/collector/
     zip Collector.zip -r Orbit/
     rm -rf Orbit/
     popd > /dev/null

--- a/src/OrbitVulkanLayer/CMakeLists.txt
+++ b/src/OrbitVulkanLayer/CMakeLists.txt
@@ -27,6 +27,10 @@ target_sources(OrbitVulkanLayer PRIVATE
         VulkanLayerProducerImpl.cpp
         VulkanLayerProducerImpl.h)
 
+add_custom_command(TARGET OrbitVulkanLayer POST_BUILD COMMAND ${CMAKE_COMMAND}
+                   -E copy ${CMAKE_CURRENT_SOURCE_DIR}/resources/VkLayer_Orbit_implicit.json
+                   $<TARGET_FILE_DIR:OrbitVulkanLayer>/VkLayer_Orbit_implicit.json)
+
 target_link_libraries(OrbitVulkanLayer PUBLIC
         OrbitBase
         OrbitProducer


### PR DESCRIPTION
This change prepares the deployment of the Vulkan layer.
When building the Vulkan layer, we now copy the .json file
to the lib directory.
In the Kokoro build script, we now also copy the layer's
shared object file and the json file, such that it will be
part of the resulting artefact .zip file.

Doing so, the layer will be part of the SDK content, and
a new "ggp run --orbit" option can deploy these files
to the gamelet.

Test: Run CI.
Bug: http://b/176814898.