### PR TITLE
Fix iterators

### DIFF
--- a/src/OrbitGl/LiveFunctionsController.h
+++ b/src/OrbitGl/LiveFunctionsController.h
@@ -50,11 +50,12 @@ class LiveFunctionsController {
 
   LiveFunctionsDataView live_functions_data_view_;
 
-  absl::flat_hash_map<uint64_t, const orbit_client_protos::FunctionInfo*> function_iterators_;
+  absl::flat_hash_map<uint64_t, uint64_t> iterator_id_to_function_id_;
   absl::flat_hash_map<uint64_t, const TextBox*> current_textboxes_;
 
   std::function<void(uint64_t, const orbit_client_protos::FunctionInfo*)> add_iterator_callback_;
 
+  uint64_t next_iterator_id_ = 1;
   uint64_t id_to_select_ = 0;
 
   OrbitApp* app_ = nullptr;

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -26,7 +26,6 @@
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ThreadConstants.h"
 #include "OrbitBase/Tracing.h"
-#include "OrbitClientData/CallstackData.h"
 #include "OrbitClientData/FunctionUtils.h"
 #include "PickingManager.h"
 #include "SchedulerTrack.h"
@@ -720,10 +719,16 @@ void TimeGraph::DrawOverlay(GlCanvas* canvas, PickingMode picking_mode) {
 
     uint64_t id_a = boxes[k - 1].first;
     uint64_t id_b = boxes[k].first;
-    CHECK(iterator_functions_.find(id_a) != iterator_functions_.end());
-    CHECK(iterator_functions_.find(id_b) != iterator_functions_.end());
-    const std::string& label =
-        GetLabelBetweenIterators(*(iterator_functions_[id_a]), *(iterator_functions_[id_b]));
+    CHECK(iterator_id_to_function_id_.find(id_a) != iterator_id_to_function_id_.end());
+    CHECK(iterator_id_to_function_id_.find(id_b) != iterator_id_to_function_id_.end());
+    uint64_t function_a_id = iterator_id_to_function_id_.at(id_a);
+    uint64_t function_b_id = iterator_id_to_function_id_.at(id_b);
+    const CaptureData& capture_data = app_->GetCaptureData();
+    const FunctionInfo* function_a = capture_data.GetInstrumentedFunctionById(function_a_id);
+    const FunctionInfo* function_b = capture_data.GetInstrumentedFunctionById(function_b_id);
+    CHECK(function_a != nullptr);
+    CHECK(function_b != nullptr);
+    const std::string& label = GetLabelBetweenIterators(*function_a, *function_b);
     const std::string& time =
         GetTimeString(boxes[k - 1].second->GetTimerInfo(), boxes[k].second->GetTimerInfo());
 

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -162,10 +162,9 @@ class TimeGraph {
 
   void SetIteratorOverlayData(
       const absl::flat_hash_map<uint64_t, const TextBox*>& iterator_text_boxes,
-      const absl::flat_hash_map<uint64_t, const orbit_client_protos::FunctionInfo*>&
-          iterator_functions) {
+      const absl::flat_hash_map<uint64_t, uint64_t>& iterator_id_to_function_id) {
     iterator_text_boxes_ = iterator_text_boxes;
-    iterator_functions_ = iterator_functions;
+    iterator_id_to_function_id_ = iterator_id_to_function_id;
     NeedsRedraw();
   }
 
@@ -203,7 +202,7 @@ class TimeGraph {
 
   // First member is id.
   absl::flat_hash_map<uint64_t, const TextBox*> iterator_text_boxes_;
-  absl::flat_hash_map<uint64_t, const orbit_client_protos::FunctionInfo*> iterator_functions_;
+  absl::flat_hash_map<uint64_t, uint64_t> iterator_id_to_function_id_;
 
   double ref_time_us_ = 0;
   double min_time_us_ = 0;


### PR DESCRIPTION
Replacing instrumented function addresses with function_ids
mistakenly changed iterator ids to function ids in
LiveFunctionController, this led to incorrect behaviour
when we add 2 iterators to the same function.

This change fixes it restoring iterator id and changing
iterator_id->function map to iterator_id->function_id map

It also fixes AllNext/AllPrevious behavior which was missed by
previous changed and was using absolute address for lookups.
Now it uses function_ids.

Test: capture add 2 iterators to the same function, click to next/prev
      nextall make sure they work. Delete iterators make sure app does
      not crash.
Bug: http://b/177525225