### PR TITLE
Rework QAccessibleInterface lifetimes

### DIFF
--- a/src/OrbitGl/TrackAccessibility.cpp
+++ b/src/OrbitGl/TrackAccessibility.cpp
@@ -19,6 +19,10 @@ namespace orbit_gl {
 
 using orbit_accessibility::AccessibleInterface;
 
+int AccessibleTrackContent::AccessibleChildCount() const { return 0; }
+
+const AccessibleInterface* AccessibleTrackContent::AccessibleChild(int) const { return nullptr; }
+
 const AccessibleInterface* AccessibleTrackContent::AccessibleParent() const {
   return track_->AccessibilityInterface();
 }
@@ -43,6 +47,10 @@ AccessibilityState AccessibleTrackContent::AccessibleState() const {
   return AccessibilityState::Normal;
 }
 
+int AccessibleTrackTab::AccessibleChildCount() const { return 0; }
+
+const AccessibleInterface* AccessibleTrackTab::AccessibleChild(int) const { return nullptr; }
+
 const AccessibleInterface* AccessibleTrackTab::AccessibleParent() const {
   return track_->AccessibilityInterface();
 }
@@ -65,6 +73,16 @@ AccessibilityRect AccessibleTrackTab::AccessibleLocalRect() const {
 
 AccessibilityState AccessibleTrackTab::AccessibleState() const {
   return AccessibilityState::Normal;
+}
+
+int AccessibleTrack::AccessibleChildCount() const { return 2; }
+
+const AccessibleInterface* AccessibleTrack::AccessibleChild(int index) const {
+  if (index == 0) {
+    return &tab_;
+  } else {
+    return &content_;
+  }
 }
 
 const AccessibleInterface* AccessibleTrack::AccessibleParent() const {

--- a/src/OrbitGl/TrackAccessibility.h
+++ b/src/OrbitGl/TrackAccessibility.h
@@ -27,8 +27,8 @@ class AccessibleTrackContent : public AccessibleInterface {
  public:
   AccessibleTrackContent(Track* track, TimeGraphLayout* layout) : track_(track), layout_(layout){};
 
-  [[nodiscard]] int AccessibleChildCount() const override { return 0; }
-  [[nodiscard]] const AccessibleInterface* AccessibleChild(int) const override { return nullptr; }
+  [[nodiscard]] int AccessibleChildCount() const override;
+  [[nodiscard]] const AccessibleInterface* AccessibleChild(int) const override;
   [[nodiscard]] const AccessibleInterface* AccessibleParent() const override;
 
   [[nodiscard]] std::string AccessibleName() const override;
@@ -52,8 +52,8 @@ class AccessibleTrackTab : public AccessibleInterface {
  public:
   AccessibleTrackTab(Track* track, TimeGraphLayout* layout) : track_(track), layout_(layout){};
 
-  [[nodiscard]] int AccessibleChildCount() const override { return 0; }
-  [[nodiscard]] const AccessibleInterface* AccessibleChild(int) const override { return nullptr; }
+  [[nodiscard]] int AccessibleChildCount() const override;
+  [[nodiscard]] const AccessibleInterface* AccessibleChild(int) const override;
   [[nodiscard]] const AccessibleInterface* AccessibleParent() const override;
 
   [[nodiscard]] std::string AccessibleName() const override;
@@ -77,14 +77,8 @@ class AccessibleTrack : public AccessibleInterface {
   AccessibleTrack(Track* track, TimeGraphLayout* layout)
       : track_(track), layout_(layout), content_(track_, layout_), tab_(track_, layout_){};
 
-  [[nodiscard]] int AccessibleChildCount() const override { return 2; }
-  [[nodiscard]] const AccessibleInterface* AccessibleChild(int index) const override {
-    if (index == 0) {
-      return &tab_;
-    } else {
-      return &content_;
-    }
-  }
+  [[nodiscard]] int AccessibleChildCount() const override;
+  [[nodiscard]] const AccessibleInterface* AccessibleChild(int index) const override;
   [[nodiscard]] const AccessibleInterface* AccessibleParent() const override;
 
   [[nodiscard]] std::string AccessibleName() const override;

--- a/src/OrbitQt/AccessibilityAdapter.cpp
+++ b/src/OrbitQt/AccessibilityAdapter.cpp
@@ -145,11 +145,11 @@ QAccessibleInterface* AdapterRegistry::GetOrCreateAdapter(const AccessibleInterf
     return it->second;
   }
 
-  auto adapter = std::unique_ptr<AccessibilityAdapter>(new AccessibilityAdapter(iface));
-  AccessibilityAdapter* ptr = adapter.get();
-  RegisterAdapter(iface, adapter.get());
-  managed_adapters_.emplace(iface, std::move(adapter));
-  return ptr;
+  auto wrapper = std::make_unique<OrbitGlInterfaceWrapper>(iface);
+  QAccessibleInterface* result = wrapper->GetAdapter();
+  RegisterAdapter(iface, result);
+  managed_adapters_.emplace(iface, std::move(wrapper));
+  return result;
 }
 
 int AccessibilityAdapter::indexOfChild(const QAccessibleInterface* child) const {
@@ -251,6 +251,11 @@ QAccessibleInterface* GlAccessibilityFactory(const QString& classname, QObject* 
 
 void InstallAccessibilityFactories() {
   QAccessible::installFactory(orbit_qt::GlAccessibilityFactory);
+}
+
+OrbitGlInterfaceWrapper::OrbitGlInterfaceWrapper(const orbit_gl::AccessibleInterface* iface)
+    : iface_(iface) {
+  adapter_ = std::unique_ptr<AccessibilityAdapter>(new AccessibilityAdapter(iface));
 }
 
 }  // namespace orbit_qt

--- a/src/OrbitQt/AccessibilityAdapter.h
+++ b/src/OrbitQt/AccessibilityAdapter.h
@@ -36,6 +36,20 @@ namespace orbit_qt {
 
 class AccessibilityAdapter;
 
+class OrbitGlInterfaceWrapper : public QObject {
+  Q_OBJECT;
+
+ public:
+  explicit OrbitGlInterfaceWrapper(const orbit_gl::AccessibleInterface* iface);
+  const orbit_gl::AccessibleInterface* GetInterface() const { return iface_; }
+  [[nodiscard]] const orbit_gl::AccessibleInterface* GetInterface() const { return iface_; }
+  AccessibilityAdapter* GetAdapter() { return adapter_.get(); }
+
+ private:
+  const orbit_gl::AccessibleInterface* iface_;
+  std::unique_ptr<AccessibilityAdapter> adapter_;
+};
+
 class AdapterRegistry {
  public:
   ~AdapterRegistry() { CHECK(all_interfaces_map_.size() == 0); }
@@ -60,7 +74,7 @@ class AdapterRegistry {
   absl::flat_hash_map<const orbit_accessibility::AccessibleInterface*, QAccessibleInterface*>
       all_interfaces_map_;
   absl::flat_hash_map<const orbit_accessibility::AccessibleInterface*,
-                      std::unique_ptr<AccessibilityAdapter>>
+                      std::unique_ptr<OrbitGlInterfaceWrapper>>
       managed_adapters_;
 };
 
@@ -72,7 +86,7 @@ class AdapterRegistry {
  * See file documentation above for more details.
  */
 class AccessibilityAdapter : public QAccessibleInterface {
-  friend class AdapterRegistry;
+  friend class OrbitGlInterfaceWrapper;
 
  public:
   AccessibilityAdapter() = delete;

--- a/src/OrbitQt/AccessibilityAdapterTest.cpp
+++ b/src/OrbitQt/AccessibilityAdapterTest.cpp
@@ -19,6 +19,8 @@ namespace orbit_qt {
 using orbit_accessibility::AccessibleObjectFake;
 
 TEST(AdapterRegistry, CreationAndManagement) {
+  InstallAccessibilityFactories();
+
   auto obj = std::make_unique<AccessibleObjectFake>(nullptr);
   QAccessibleInterface* a1 = AdapterRegistry::Get().GetOrCreateAdapter(obj.get());
   EXPECT_TRUE(a1->isValid());
@@ -29,6 +31,8 @@ TEST(AdapterRegistry, CreationAndManagement) {
 }
 
 TEST(AccessibilityAdapter, Hierarchy) {
+  InstallAccessibilityFactories();
+
   AccessibleObjectFake root(nullptr);
   root.Children().push_back(std::make_unique<AccessibleObjectFake>(&root));
   root.Children().push_back(std::make_unique<AccessibleObjectFake>(&root));

--- a/src/OrbitQt/AccessibilityAdapterTest.cpp
+++ b/src/OrbitQt/AccessibilityAdapterTest.cpp
@@ -18,17 +18,14 @@ namespace orbit_qt {
 
 using orbit_accessibility::AccessibleObjectFake;
 
-TEST(AccessibilityAdapter, CreationAndManagement) {
+TEST(AdapterRegistry, CreationAndManagement) {
   auto obj = std::make_unique<AccessibleObjectFake>(nullptr);
-  QAccessibleInterface* a1 = AccessibilityAdapter::GetOrCreateAdapter(obj.get());
+  QAccessibleInterface* a1 = AdapterRegistry::Get().GetOrCreateAdapter(obj.get());
   EXPECT_TRUE(a1->isValid());
 
-  QAccessibleInterface* a2 = AccessibilityAdapter::GetOrCreateAdapter(obj.get());
+  QAccessibleInterface* a2 = AdapterRegistry::Get().GetOrCreateAdapter(obj.get());
   EXPECT_TRUE(a2->isValid());
   EXPECT_EQ(a1, a2);
-
-  obj.reset();
-  EXPECT_EQ(AccessibilityAdapter::RegisteredAdapterCount(), 0);
 }
 
 TEST(AccessibilityAdapter, Hierarchy) {
@@ -36,7 +33,7 @@ TEST(AccessibilityAdapter, Hierarchy) {
   root.Children().push_back(std::make_unique<AccessibleObjectFake>(&root));
   root.Children().push_back(std::make_unique<AccessibleObjectFake>(&root));
 
-  QAccessibleInterface* root_adapter = AccessibilityAdapter::GetOrCreateAdapter(&root);
+  QAccessibleInterface* root_adapter = AdapterRegistry::Get().GetOrCreateAdapter(&root);
   EXPECT_EQ(root_adapter->text(QAccessible::Text::Name),
             QString::fromStdString(root.AccessibleName()));
   EXPECT_EQ(root_adapter->role(), static_cast<QAccessible::Role>(root.AccessibleRole()));
@@ -44,13 +41,13 @@ TEST(AccessibilityAdapter, Hierarchy) {
   EXPECT_TRUE(root_adapter->child(0)->isValid());
   EXPECT_TRUE(root_adapter->child(1)->isValid());
   EXPECT_EQ(root_adapter->child(0),
-            AccessibilityAdapter::GetOrCreateAdapter(root.AccessibleChild(0)));
+            AdapterRegistry::Get().GetOrCreateAdapter(root.AccessibleChild(0)));
   EXPECT_EQ(root_adapter->child(1),
-            AccessibilityAdapter::GetOrCreateAdapter(root.AccessibleChild(1)));
+            AdapterRegistry::Get().GetOrCreateAdapter(root.AccessibleChild(1)));
   EXPECT_EQ(root_adapter->childAt(0, 0),
-            AccessibilityAdapter::GetOrCreateAdapter(root.Children()[0].get()));
+            AdapterRegistry::Get().GetOrCreateAdapter(root.Children()[0].get()));
   EXPECT_EQ(root_adapter->childAt(0, 1),
-            AccessibilityAdapter::GetOrCreateAdapter(root.Children()[1].get()));
+            AdapterRegistry::Get().GetOrCreateAdapter(root.Children()[1].get()));
 
   EXPECT_EQ(root_adapter->child(0)->parent(), root_adapter);
   EXPECT_EQ(root_adapter->child(1)->parent(), root_adapter);


### PR DESCRIPTION
This fixes the crash reports sent from the E2E tests. Basically, whenever Accessibility info is queried from the capture window during a run of Orbit, a crash in `QAccessibleCache::deleteInterface(unsigned int,QObject *)` appears when closing down Orbit. This never shows up for the user, but spams the crash reporting.

Core issue is that we are creating instances of `QAccessibleInterface` which are not associated with a valid `QObject`, and this breaks tracking of those interfaces inside QT. To fix this, we should not create and manage `QAccessibleInterface` instances ourselfs, but instead manage dummy `QObject` instances and rely on QTs automatic creation of `QAccessibleInterface`.

Bug: b/177509546

There is another issue that is still present and not fixed with this PR, but is not exclusively related to the custom accessibility of the capture window: b/177655659