### PR TITLE
Copy .so from/to "lib" instead of "bin".

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -276,6 +276,7 @@ chmod -v 4775 /opt/developer/tools/OrbitService
         self.copy("*", src="bin/resources", dst="bin/resources", symlinks=True)
         self.copy("*", src="bin/translations", dst="bin/translations", symlinks=True)
         self.copy("*.so*", src="lib/", dst="lib", symlinks=True)
+        self.copy("*.json*", src="lib/", dst="lib", symlinks=True)
         self.copy("*.dll", src="bin/", dst="bin", symlinks=True)
         self.copy("*.pdb", src="bin/", dst="bin")
         self.copy("Orbit", src="bin/", dst="bin")

--- a/conanfile.py
+++ b/conanfile.py
@@ -275,7 +275,7 @@ chmod -v 4775 /opt/developer/tools/OrbitService
         self.copy("*", src="bin/icons", dst="bin/icons", symlinks=True)
         self.copy("*", src="bin/resources", dst="bin/resources", symlinks=True)
         self.copy("*", src="bin/translations", dst="bin/translations", symlinks=True)
-        self.copy("*.so*", src="bin/", dst="bin", symlinks=True)
+        self.copy("*.so*", src="lib/", dst="lib", symlinks=True)
         self.copy("*.dll", src="bin/", dst="bin", symlinks=True)
         self.copy("*.pdb", src="bin/", dst="bin")
         self.copy("Orbit", src="bin/", dst="bin")


### PR DESCRIPTION
As per convention on Linux, shared object files are located under
"lib" rather than "bin". This adjust the src/tgt directory for those
files in the conanfile.py.

This fixes the failing nightly builds due to #1681.

Test: Manually trigger nightly build.