### PR TITLE
Fix crash when loading a capture

### DIFF
--- a/src/OrbitClientModel/CaptureSerializer.cpp
+++ b/src/OrbitClientModel/CaptureSerializer.cpp
@@ -75,7 +75,7 @@ CaptureInfo GenerateCaptureInfo(
     const absl::flat_hash_map<uint64_t, std::string>& key_to_string_map) {
   CaptureInfo capture_info;
   for (const auto& pair : capture_data.instrumented_functions()) {
-    capture_info.add_selected_functions()->CopyFrom(pair.second);
+    (*capture_info.mutable_instrumented_functions())[pair.first] = pair.second;
   }
 
   ProcessInfo* process = capture_info.mutable_process();

--- a/src/OrbitClientModel/CaptureSerializerTest.cpp
+++ b/src/OrbitClientModel/CaptureSerializerTest.cpp
@@ -182,8 +182,9 @@ TEST(CaptureSerializer, GenerateCaptureInfo) {
   CaptureInfo capture_info =
       capture_serializer::internal::GenerateCaptureInfo(capture_data, key_to_string_map);
 
-  ASSERT_EQ(1, capture_info.selected_functions_size());
-  const FunctionInfo& actual_selected_function = capture_info.selected_functions(0);
+  ASSERT_EQ(1, capture_info.instrumented_functions_size());
+  const FunctionInfo& actual_selected_function =
+      capture_info.instrumented_functions().begin()->second;
   EXPECT_EQ(instrumented_function.address(), actual_selected_function.address());
   EXPECT_EQ(instrumented_function.name(), actual_selected_function.name());
 

--- a/src/OrbitClientModel/include/OrbitClientModel/CaptureDeserializer.h
+++ b/src/OrbitClientModel/include/OrbitClientModel/CaptureDeserializer.h
@@ -38,7 +38,7 @@ void LoadCaptureInfo(const orbit_client_protos::CaptureInfo& capture_info,
                      google::protobuf::io::CodedInputStream* coded_input,
                      std::atomic<bool>* cancellation_requested);
 
-inline const std::string kRequiredCaptureVersion = "1.55";
+inline const std::string kRequiredCaptureVersion = "1.59";
 
 }  // namespace internal
 

--- a/src/OrbitClientModel/include/OrbitClientModel/CaptureSerializer.h
+++ b/src/OrbitClientModel/include/OrbitClientModel/CaptureSerializer.h
@@ -36,7 +36,7 @@ void IncludeOrbitExtensionInFile(std::string& file_name);
 
 namespace internal {
 
-inline const std::string kRequiredCaptureVersion = "1.55";
+inline const std::string kRequiredCaptureVersion = "1.59";
 
 orbit_client_protos::CaptureInfo GenerateCaptureInfo(
     const CaptureData& capture_data,

--- a/src/OrbitClientProtos/capture_data.proto
+++ b/src/OrbitClientProtos/capture_data.proto
@@ -119,8 +119,8 @@ message UserDefinedCaptureInfo {
 }
 
 message CaptureInfo {
-  reserved 2, 3;
-  repeated FunctionInfo selected_functions = 1;
+  reserved 1, 2, 3;
+  map<uint64, FunctionInfo> instrumented_functions = 16;
   map<int32, string> thread_names = 4;
   repeated ThreadStateSliceInfo thread_state_slices = 12;
   repeated LinuxAddressInfo address_infos = 5;

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -496,11 +496,6 @@ std::vector<std::string> CaptureWindow::GetContextMenu() { return std::vector<st
 
 void CaptureWindow::OnContextMenu(const std::string& /*action*/, int /*menu_index*/) {}
 
-void CaptureWindow::OnCaptureStarted() {
-  time_graph_.ZoomAll();
-  NeedsRedraw();
-}
-
 bool CaptureWindow::ShouldAutoZoom() const { return app_->IsCapturing(); }
 
 std::unique_ptr<AccessibleWidgetBridge> CaptureWindow::CreateAccessibilityInterface() {

--- a/src/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/CaptureWindow.h
@@ -67,7 +67,6 @@ class CaptureWindow : public GlCanvas {
   void UpdateWorldTopLeftY(float val) override;
 
   void NeedsUpdate();
-  void OnCaptureStarted();
   std::vector<std::string> GetContextMenu() override;
   void OnContextMenu(const std::string& action, int menu_index) override;
   virtual void ToggleRecording();

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -245,9 +245,8 @@ double TimeGraph::GetTime(double ratio) const {
 }
 
 void TimeGraph::ProcessTimer(const TimerInfo& timer_info, const FunctionInfo* function) {
-  if (timer_info.end() > capture_max_timestamp_) {
-    capture_max_timestamp_ = timer_info.end();
-  }
+  capture_min_timestamp_ = std::min(capture_min_timestamp_, timer_info.start());
+  capture_max_timestamp_ = std::max(capture_max_timestamp_, timer_info.end());
 
   // Functions for manual instrumentation scopes and tracked values are those with orbit_type() !=
   // FunctionInfo::kNone. All proper timers for these have timer_info.type() == TimerInfo::kNone. It

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -60,7 +60,6 @@ class TimeGraph {
   void SetCaptureData(CaptureData* capture_data) { capture_data_ = capture_data; }
   [[nodiscard]] TrackManager* GetTrackManager() { return track_manager_.get(); }
 
-  [[nodiscard]] float GetThreadTotalHeight() const;
   [[nodiscard]] float GetTextBoxHeight() const { return layout_.GetTextBoxHeight(); }
   [[nodiscard]] float GetWorldFromTick(uint64_t time) const;
   [[nodiscard]] float GetWorldFromUs(double micros) const;
@@ -198,7 +197,6 @@ class TimeGraph {
   TextRenderer* text_renderer_ = nullptr;
   GlCanvas* canvas_ = nullptr;
   int num_drawn_text_boxes_ = 0;
-  bool sorting_invalidated_ = true;
 
   // First member is id.
   absl::flat_hash_map<uint64_t, const TextBox*> iterator_text_boxes_;
@@ -207,7 +205,7 @@ class TimeGraph {
   double ref_time_us_ = 0;
   double min_time_us_ = 0;
   double max_time_us_ = 0;
-  uint64_t capture_min_timestamp_ = 0;
+  uint64_t capture_min_timestamp_ = std::numeric_limits<uint64_t>::max();
   uint64_t capture_max_timestamp_ = 0;
   uint64_t current_mouse_time_ns_ = 0;
   double time_window_us_ = 0;


### PR DESCRIPTION
Another one missed by absolute_address->function_id change.

Previously capture was only saving function infos for instrumented
functions. After this change it saves functions_ids as well.

Bug: http://b/177800361
Test: capture->save capture->close oribt-> open orbit -> load capture
      make sure it does not crash
Test: run unit-tests