### PR TITLE
Move kInvalidFunctionId to GrpcProtos

### DIFF
--- a/src/GrpcProtos/CMakeLists.txt
+++ b/src/GrpcProtos/CMakeLists.txt
@@ -11,6 +11,12 @@ target_compile_options(GrpcProtos PRIVATE ${STRICT_COMPILE_FLAGS})
 target_compile_definitions(GrpcProtos PRIVATE -D_WIN32_WINNT=0x0700)
 target_compile_definitions(GrpcProtos PRIVATE -DNTDDI_VERSION=0x06030000)
 
+target_include_directories(GrpcProtos PUBLIC
+        ${CMAKE_CURRENT_LIST_DIR}/include)
+
+target_sources(GrpcProtos PUBLIC
+        include/GrpcProtos/Constants.h)
+
 target_sources(GrpcProtos PRIVATE
         capture.proto
         code_block.proto

--- a/src/GrpcProtos/include/GrpcProtos/Constants.h
+++ b/src/GrpcProtos/include/GrpcProtos/Constants.h
@@ -1,0 +1,12 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef GRPC_PROTOS_CONSTANTS_H_
+#define GRPC_PROTOS_CONSTANTS_H_
+
+namespace orbit_grpc_protos {
+constexpr uint64_t kInvalidFunctionId = 0;
+}
+
+#endif  // GRPC_PROTOS_CONSTANTS_H_

--- a/src/OrbitCaptureClient/CaptureEventProcessor.cpp
+++ b/src/OrbitCaptureClient/CaptureEventProcessor.cpp
@@ -11,6 +11,7 @@
 #include <utility>
 
 #include "CoreUtils.h"
+#include "GrpcProtos/Constants.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitClientData/Callstack.h"
 #include "capture_data.pb.h"
@@ -33,8 +34,6 @@ using orbit_grpc_protos::IntrospectionScope;
 using orbit_grpc_protos::SchedulingSlice;
 using orbit_grpc_protos::ThreadName;
 using orbit_grpc_protos::ThreadStateSlice;
-
-static constexpr uint64_t kInvalidFunctionId = 0;
 
 void CaptureEventProcessor::ProcessEvent(const CaptureEvent& event) {
   switch (event.event_case()) {
@@ -161,7 +160,7 @@ void CaptureEventProcessor::ProcessIntrospectionScope(
   timer_info.set_start(begin_timestamp_ns);
   timer_info.set_end(introspection_scope.end_timestamp_ns());
   timer_info.set_depth(static_cast<uint8_t>(introspection_scope.depth()));
-  timer_info.set_function_id(kInvalidFunctionId);  // function id n/a, set to 0
+  timer_info.set_function_id(orbit_grpc_protos::kInvalidFunctionId);  // function id n/a, set to 0
   timer_info.set_processor(-1);                    // cpu info not available, set to invalid value
   timer_info.set_type(TimerInfo::kIntrospection);
   timer_info.mutable_registers()->CopyFrom(introspection_scope.registers());

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -39,6 +39,7 @@
 #include "FrameTrackOnlineProcessor.h"
 #include "FunctionsDataView.h"
 #include "GlCanvas.h"
+#include "GrpcProtos/Constants.h"
 #include "ImGuiOrbit.h"
 #include "MainThreadExecutor.h"
 #include "ModulesDataView.h"
@@ -48,7 +49,6 @@
 #include "OrbitBase/Tracing.h"
 #include "OrbitClientData/Callstack.h"
 #include "OrbitClientData/CallstackData.h"
-#include "OrbitClientData/FunctionInfoSet.h"
 #include "OrbitClientData/FunctionUtils.h"
 #include "OrbitClientData/ModuleData.h"
 #include "OrbitClientData/ModuleManager.h"
@@ -1517,7 +1517,8 @@ const TextBox* OrbitApp::selected_text_box() const { return data_manager_->selec
 void OrbitApp::SelectTextBox(const TextBox* text_box) {
   data_manager_->set_selected_text_box(text_box);
   const TimerInfo* timer_info = text_box ? &text_box->GetTimerInfo() : nullptr;
-  uint64_t function_id = timer_info ? timer_info->function_id() : DataManager::kInvalidFunctionId;
+  uint64_t function_id =
+      timer_info ? timer_info->function_id() : orbit_grpc_protos::kInvalidFunctionId;
   data_manager_->set_highlighted_function_id(function_id);
   CHECK(timer_selected_callback_);
   timer_selected_callback_(timer_info);
@@ -1535,7 +1536,7 @@ uint64_t OrbitApp::GetFunctionIdToHighlight() const {
   // Highlighting of manually instrumented scopes is not yet supported.
   const FunctionInfo* function_info = GetInstrumentedFunction(selected_function_id);
   if (function_info == nullptr || function_utils::IsOrbitFunc(*function_info)) {
-    return DataManager::kInvalidFunctionId;
+    return orbit_grpc_protos::kInvalidFunctionId;
   }
 
   return selected_function_id;

--- a/src/OrbitGl/DataManager.h
+++ b/src/OrbitGl/DataManager.h
@@ -12,6 +12,7 @@
 #include <thread>
 #include <vector>
 
+#include "GrpcProtos/Constants.h"
 #include "OrbitClientData/FunctionInfoSet.h"
 #include "OrbitClientData/ProcessData.h"
 #include "OrbitClientData/TracepointCustom.h"
@@ -76,15 +77,13 @@ class DataManager final {
   }
   [[nodiscard]] bool collect_thread_states() const { return collect_thread_states_; }
 
-  static constexpr uint64_t kInvalidFunctionId = 0;
-
  private:
   const std::thread::id main_thread_id_;
   // We are sharing pointers to that entries and ensure reference stability by using node_hash_map
   absl::node_hash_map<int32_t, ProcessData> process_map_;
   FunctionInfoSet selected_functions_;
   absl::flat_hash_set<uint64_t> visible_function_ids_;
-  uint64_t highlighted_function_id_ = kInvalidFunctionId;
+  uint64_t highlighted_function_id_ = orbit_grpc_protos::kInvalidFunctionId;
 
   TracepointInfoSet selected_tracepoints_;
 

--- a/src/OrbitGl/LiveFunctionsController.cpp
+++ b/src/OrbitGl/LiveFunctionsController.cpp
@@ -185,7 +185,7 @@ void LiveFunctionsController::OnDeleteButton(uint64_t id) {
   if (id == id_to_select_ && !current_textboxes_.empty()) {
     id_to_select_ = current_textboxes_.begin()->first;
   } else if (current_textboxes_.empty()) {
-    id_to_select_ = DataManager::kInvalidFunctionId;
+    id_to_select_ = orbit_grpc_protos::kInvalidFunctionId;
   }
   Move();
 }
@@ -224,5 +224,5 @@ void LiveFunctionsController::Reset() {
   iterator_id_to_function_id_.clear();
   current_textboxes_.clear();
   GCurrentTimeGraph->SetIteratorOverlayData({}, {});
-  id_to_select_ = DataManager::kInvalidFunctionId;
+  id_to_select_ = orbit_grpc_protos::kInvalidFunctionId;
 }

--- a/src/OrbitGl/LiveFunctionsDataView.cpp
+++ b/src/OrbitGl/LiveFunctionsDataView.cpp
@@ -22,6 +22,7 @@
 #include "DataManager.h"
 #include "DataViewTypes.h"
 #include "FunctionsDataView.h"
+#include "GrpcProtos/Constants.h"
 #include "LiveFunctionsController.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitClientData/FunctionUtils.h"
@@ -37,7 +38,7 @@ using orbit_client_protos::FunctionStats;
 LiveFunctionsDataView::LiveFunctionsDataView(LiveFunctionsController* live_functions, OrbitApp* app)
     : DataView(DataViewType::kLiveFunctions, app),
       live_functions_(live_functions),
-      selected_function_id_(DataManager::kInvalidFunctionId) {
+      selected_function_id_(orbit_grpc_protos::kInvalidFunctionId) {
   update_period_ms_ = 300;
   OnDataChanged();
 }
@@ -109,7 +110,7 @@ void LiveFunctionsDataView::OnSelect(std::optional<int> row) {
   app_->DeselectTextBox();
 
   if (!row.has_value()) {
-    app_->set_highlighted_function_id(DataManager::kInvalidFunctionId);
+    app_->set_highlighted_function_id(orbit_grpc_protos::kInvalidFunctionId);
   } else {
     app_->set_highlighted_function_id(GetInstrumentedFunctionId(row.value()));
   }

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -81,22 +81,19 @@ void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
   // events that would just draw over an already drawn line. When zoomed in
   // enough that all events are drawn as boxes, this has no effect. When zoomed
   // out, many events will be discarded quickly.
-  uint64_t min_ignore = std::numeric_limits<uint64_t>::max();
-  uint64_t max_ignore = std::numeric_limits<uint64_t>::min();
   uint64_t time_window_ns = static_cast<uint64_t>(1000 * time_graph_->GetTimeWindowUs());
   uint64_t pixel_delta_in_ticks = time_window_ns / canvas->GetWidth();
   uint64_t min_timegraph_tick = time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
 
   for (auto& chain : chains_by_depth) {
     if (!chain) continue;
-    for (TimerChainIterator it = chain->begin(); it != chain->end(); ++it) {
-      TimerBlock& block = *it;
+    for (auto& block : *chain) {
       if (!block.Intersects(min_tick, max_tick)) continue;
 
       // We have to reset this when we go to the next depth, as otherwise we
       // would miss drawing events that should be drawn.
-      min_ignore = std::numeric_limits<uint64_t>::max();
-      max_ignore = std::numeric_limits<uint64_t>::min();
+      uint64_t min_ignore = std::numeric_limits<uint64_t>::max();
+      uint64_t max_ignore = std::numeric_limits<uint64_t>::min();
 
       for (size_t k = 0; k < block.size(); ++k) {
         TextBox& text_box = block[k];
@@ -118,7 +115,8 @@ void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
 
         bool is_visible_width = normalized_length * canvas->GetWidth() > 1;
         bool is_selected = &text_box == selected_textbox;
-        bool is_highlighted = !is_selected && function_id != DataManager::kInvalidFunctionId &&
+        bool is_highlighted = !is_selected &&
+                              function_id != orbit_grpc_protos::kInvalidFunctionId &&
                               function_id == highlighted_function_id;
 
         Vec2 pos(world_timer_x, world_timer_y);


### PR DESCRIPTION
This is to avoid redefinition in components that do not depend
on OrbitGl.

Also some code cleanups in TimerTrack::UpdatePrimitives

Test: builds