### PR TITLE
Fix the partial disappeared capture toolbar on small screens

### DIFF
--- a/src/OrbitQt/CMakeLists.txt
+++ b/src/OrbitQt/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(
           Error.h
           EventLoop.h
           FilterPanelWidget.h
+          FilterPanelWidgetAction.h
           orbitaboutdialog.h
           orbitdataviewpanel.h
           orbiteventiterator.h
@@ -55,6 +56,7 @@ target_sources(
           Error.cpp
           ElidedLabel.cpp
           FilterPanelWidget.cpp
+          FilterPanelWidgetAction.cpp
           MainThreadExecutorImpl.cpp
           StatusListenerImpl.cpp
           DeploymentConfigurations.cpp

--- a/src/OrbitQt/CMakeLists.txt
+++ b/src/OrbitQt/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(
           ElidedLabel.h
           Error.h
           EventLoop.h
+          FilterPanelWidget.h
           orbitaboutdialog.h
           orbitdataviewpanel.h
           orbiteventiterator.h
@@ -53,6 +54,7 @@ target_sources(
           ConnectToStadiaWidget.ui
           Error.cpp
           ElidedLabel.cpp
+          FilterPanelWidget.cpp
           MainThreadExecutorImpl.cpp
           StatusListenerImpl.cpp
           DeploymentConfigurations.cpp

--- a/src/OrbitQt/FilterPanelWidget.cpp
+++ b/src/OrbitQt/FilterPanelWidget.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "FilterPanelWidget.h"
+
+#include <QFontMetrics>
+#include <QFrame>
+#include <QWidget>
+
+#include "orbitmainwindow.h"
+#include "ui_FilterPanelWidget.h"
+
+FilterPanelWidget::FilterPanelWidget(QWidget* parent)
+    : QFrame(parent), ui(new Ui::FilterPanelWidget) {
+  ui->setupUi(this);
+
+  connect(ui->filterTracks, &QLineEdit::textChanged, this,
+          &FilterPanelWidget::FilterTracksTextChanged);
+  connect(ui->filterFunctions, &QLineEdit::textChanged, this,
+          &FilterPanelWidget::FilterFunctionsTextChanged);
+
+  QFontMetrics fm(ui->timerLabel->font());
+  int pixel_width = fm.horizontalAdvance("w");
+  ui->timerLabel->setMinimumWidth(5 * pixel_width);
+}
+
+void FilterPanelWidget::SetFilterFunctionsText(const QString& text) {
+  ui->filterFunctions->blockSignals(true);
+  ui->filterFunctions->setText(text);
+  ui->filterFunctions->blockSignals(false);
+}
+
+void FilterPanelWidget::SetTimerLabelText(const QString& text) { ui->timerLabel->setText(text); }

--- a/src/OrbitQt/FilterPanelWidget.h
+++ b/src/OrbitQt/FilterPanelWidget.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_QT_FILTER_PANEL_WIDGET_H_
+#define ORBIT_QT_FILTER_PANEL_WIDGET_H_
+
+#include <QFrame>
+#include <QWidget>
+
+#include "ui_FilterPanelWidget.h"
+
+namespace Ui {
+class FilterPanelWidget;
+}
+
+/*
+ * A widget containing a track filter, a function filter, and a timer label. Will be added as a
+ * widget action to the capture toolbar. (see FilterPanelWidgetAction.h for more details)
+ */
+class FilterPanelWidget : public QFrame {
+  Q_OBJECT
+
+ public:
+  explicit FilterPanelWidget(QWidget* parent = nullptr);
+
+  void SetFilterFunctionsText(const QString& text);
+  void SetTimerLabelText(const QString& text);
+
+ signals:
+  void FilterTracksTextChanged(const QString& text);
+  void FilterFunctionsTextChanged(const QString& text);
+
+ private:
+  Ui::FilterPanelWidget* ui;
+};
+#endif  // ORBIT_QT_FILTER_PANEL_WIDGET_H_

--- a/src/OrbitQt/FilterPanelWidget.ui
+++ b/src/OrbitQt/FilterPanelWidget.ui
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>FilterPanelWidget</class>
+ <widget class="QFrame" name="FilterPanelWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>389</width>
+    <height>42</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Frame</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QLineEdit" name="filterTracks">
+     <property name="accessibleName">
+      <string>filter</string>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QLineEdit {
+	background-image: url(:/actions/filter_list_small_offset);
+}</string>
+     </property>
+     <property name="placeholderText">
+      <string>Filter Tracks</string>
+     </property>
+     <property name="clearButtonEnabled">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="filterFunctions">
+     <property name="accessibleName">
+      <string>filter</string>
+     </property>
+     <property name="placeholderText">
+      <string>Filter Functions</string>
+     </property>
+     <property name="clearButtonEnabled">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>24</width>
+       <height>24</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>24</width>
+       <height>24</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="pixmap">
+      <pixmap>:/actions/access_time</pixmap>
+     </property>
+     <property name="scaledContents">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="timerLabel">
+     <property name="text">
+      <string>1s</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../icons/orbiticons.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/OrbitQt/FilterPanelWidgetAction.cpp
+++ b/src/OrbitQt/FilterPanelWidgetAction.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "FilterPanelWidgetAction.h"
+
+#include <QWidget>
+
+#include "FilterPanelWidget.h"
+
+FilterPanelWidgetAction::FilterPanelWidgetAction(QWidget* parent) : QWidgetAction(parent) {}
+
+QWidget* FilterPanelWidgetAction::createWidget(QWidget* parent) {
+  filter_panel_ = new FilterPanelWidget(parent);
+  connect(filter_panel_, &FilterPanelWidget::FilterTracksTextChanged, this,
+          &FilterPanelWidgetAction::FilterTracksTextChanged);
+  connect(filter_panel_, &FilterPanelWidget::FilterFunctionsTextChanged, this,
+          &FilterPanelWidgetAction::FilterFunctionsTextChanged);
+
+  // Directly call `FilterPanelWidget::SetTimerLabelText` from `OrbitMainWindow::OnTimer()` causes
+  // the access violation when the toolbar layout changes and the filter panel appears on the
+  // capture toolbar again. For the thread-safety consideration, using signal/slot system instead of
+  // calling functions for the QWidgetAction.
+  connect(this, &FilterPanelWidgetAction::SetTimerLabelText, filter_panel_,
+          &FilterPanelWidget::SetTimerLabelText);
+  connect(this, &FilterPanelWidgetAction::SetFilterFunctionsText, filter_panel_,
+          &FilterPanelWidget::SetFilterFunctionsText);
+  return filter_panel_;
+}

--- a/src/OrbitQt/FilterPanelWidgetAction.h
+++ b/src/OrbitQt/FilterPanelWidgetAction.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_QT_FILTER_PANEL_WIDGET_ACTION_H_
+#define ORBIT_QT_FILTER_PANEL_WIDGET_ACTION_H_
+
+#include <QFrame>
+#include <QWidget>
+#include <QWidgetAction>
+
+#include "FilterPanelWidget.h"
+
+/*
+ * Widget action used to insert the custom widget, i.e., FilterPanelWidget, into capture toolbar.
+ *
+ * As the capture toolbar is not a child of a QMainWindow, it loses the ability to populate the
+ * extension pop up with widgets added to the toolbar using addWidget(). To insert custom widgets,
+ * we need widget actions created by inheriting QWidgetAction and implementing
+ * QWidgetAction::createWidget() method.
+ */
+class FilterPanelWidgetAction : public QWidgetAction {
+  Q_OBJECT
+
+ public:
+  explicit FilterPanelWidgetAction(QWidget* parent);
+  QWidget* createWidget(QWidget* parent);
+
+ signals:
+  void FilterFunctionsTextChanged(const QString& text);
+  void FilterTracksTextChanged(const QString& text);
+  void SetTimerLabelText(const QString& text);
+  void SetFilterFunctionsText(const QString& text);
+
+ private:
+  FilterPanelWidget* filter_panel_ = nullptr;
+};
+#endif  // ORBIT_QT_FILTER_PANEL_WIDGET_ACTION_H_

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -431,13 +431,6 @@ void OrbitMainWindow::SetupCaptureToolbar() {
   connect(filter_panel_action_, &FilterPanelWidgetAction::FilterFunctionsTextChanged, this,
           &OrbitMainWindow::OnFilterFunctionsTextChanged);
   toolbar->addAction(filter_panel_action_);
-  toolbar->addWidget(ui->filterPanel);
-
-  // Timer
-  toolbar->addWidget(CreateSpacer(toolbar));
-  QFontMetrics fm(ui->timerLabel->font());
-  int pixel_width = fm.horizontalAdvance("w");
-  ui->timerLabel->setMinimumWidth(5 * pixel_width);
 }
 
 void OrbitMainWindow::SetupHintFrame() {
@@ -851,7 +844,6 @@ void OrbitMainWindow::OnTimer() {
     gl_widget->update();
   }
 
-  ui->timerLabel->setText(QString::fromStdString(app_->GetCaptureTime()));
   filter_panel_action_->SetTimerLabelText(QString::fromStdString(app_->GetCaptureTime()));
 }
 
@@ -862,9 +854,6 @@ void OrbitMainWindow::OnFilterFunctionsTextChanged(const QString& text) {
 
 void OrbitMainWindow::OnLiveTabFunctionsFilterTextChanged(const QString& text) {
   // Set main toolbar functions filter without triggering signals.
-  ui->filterFunctions->blockSignals(true);
-  ui->filterFunctions->setText(text);
-  ui->filterFunctions->blockSignals(false);
   filter_panel_action_->SetFilterFunctionsText(text);
 }
 

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -425,6 +425,12 @@ void OrbitMainWindow::SetupCaptureToolbar() {
 
   // Attach the filter panel to the toolbar
   toolbar->addWidget(CreateSpacer(toolbar));
+  filter_panel_action_ = new FilterPanelWidgetAction(toolbar);
+  connect(filter_panel_action_, &FilterPanelWidgetAction::FilterTracksTextChanged, this,
+          &OrbitMainWindow::OnFilterTracksTextChanged);
+  connect(filter_panel_action_, &FilterPanelWidgetAction::FilterFunctionsTextChanged, this,
+          &OrbitMainWindow::OnFilterFunctionsTextChanged);
+  toolbar->addAction(filter_panel_action_);
   toolbar->addWidget(ui->filterPanel);
 
   // Timer
@@ -846,6 +852,7 @@ void OrbitMainWindow::OnTimer() {
   }
 
   ui->timerLabel->setText(QString::fromStdString(app_->GetCaptureTime()));
+  filter_panel_action_->SetTimerLabelText(QString::fromStdString(app_->GetCaptureTime()));
 }
 
 void OrbitMainWindow::OnFilterFunctionsTextChanged(const QString& text) {
@@ -858,6 +865,7 @@ void OrbitMainWindow::OnLiveTabFunctionsFilterTextChanged(const QString& text) {
   ui->filterFunctions->blockSignals(true);
   ui->filterFunctions->setText(text);
   ui->filterFunctions->blockSignals(false);
+  filter_panel_action_->SetFilterFunctionsText(text);
 }
 
 void OrbitMainWindow::OnFilterTracksTextChanged(const QString& text) {

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -33,6 +33,7 @@
 #include "DataView.h"
 #include "DataViewTypes.h"
 #include "DisassemblyReport.h"
+#include "FilterPanelWidgetAction.h"
 #include "MainThreadExecutor.h"
 #include "MetricsUploader/MetricsUploader.h"
 #include "OrbitClientServices/ProcessManager.h"
@@ -94,6 +95,10 @@ class OrbitMainWindow : public QMainWindow {
  protected:
   void closeEvent(QCloseEvent* event) override;
 
+ public slots:
+  void OnFilterFunctionsTextChanged(const QString& text);
+  void OnFilterTracksTextChanged(const QString& text);
+
  private slots:
   void on_actionOpenUserDataDirectory_triggered();
   void on_actionAbout_triggered();
@@ -103,8 +108,6 @@ class OrbitMainWindow : public QMainWindow {
 
   void OnTimer();
   void OnLiveTabFunctionsFilterTextChanged(const QString& text);
-  void OnFilterFunctionsTextChanged(const QString& text);
-  void OnFilterTracksTextChanged(const QString& text);
 
   void on_actionOpen_Preset_triggered();
   void on_actionEnd_Session_triggered();
@@ -162,6 +165,7 @@ class OrbitMainWindow : public QMainWindow {
   std::unique_ptr<MainThreadExecutor> main_thread_executor_;
   std::unique_ptr<OrbitApp> app_;
   Ui::OrbitMainWindow* ui;
+  FilterPanelWidgetAction* filter_panel_action_ = nullptr;
   QTimer* m_MainTimer = nullptr;
   std::vector<OrbitGLWidget*> gl_widgets_;
   OrbitGLWidget* introspection_widget_ = nullptr;

--- a/src/OrbitQt/orbitmainwindow.ui
+++ b/src/OrbitQt/orbitmainwindow.ui
@@ -139,105 +139,11 @@ QPushButton:disabled {
           </widget>
          </item>
          <item>
-          <widget class="QFrame" name="filterPanel">
-           <property name="accessibleName">
-            <string/>
-           </property>
-           <property name="frameShape">
-            <enum>QFrame::NoFrame</enum>
-           </property>
-           <property name="frameShadow">
-            <enum>QFrame::Raised</enum>
-           </property>
-           <property name="lineWidth">
-            <number>0</number>
-           </property>
-           <layout class="QHBoxLayout" name="horizontalLayout">
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-            <property name="bottomMargin">
-             <number>0</number>
-            </property>
-            <item>
-             <widget class="QLineEdit" name="filterTracks">
-              <property name="accessibleName">
-               <string>FilterTracks</string>
-              </property>
-              <property name="styleSheet">
-               <string notr="true">QLineEdit {
-	background-image: url(:/actions/filter_list_small_offset);
-}</string>
-              </property>
-              <property name="placeholderText">
-               <string>Filter Tracks</string>
-              </property>
-              <property name="clearButtonEnabled">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLineEdit" name="filterFunctions">
-              <property name="accessibleName">
-               <string>FilterFunctions</string>
-              </property>
-              <property name="placeholderText">
-               <string>Filter Functions</string>
-              </property>
-              <property name="clearButtonEnabled">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLabel" name="label">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>24</width>
-                <height>24</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>24</width>
-                <height>24</height>
-               </size>
-              </property>
-              <property name="text">
-               <string/>
-              </property>
-              <property name="pixmap">
-               <pixmap resource="../icons/orbiticons.qrc">:/actions/access_time</pixmap>
-              </property>
-              <property name="scaledContents">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLabel" name="timerLabel">
-              <property name="text">
-               <string>1s</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item>
           <widget class="OrbitGLWidget" name="CaptureGLWidget"/>
          </item>
         </layout>
         <zorder>CaptureGLWidget</zorder>
         <zorder>capture_toolbar</zorder>
-        <zorder>filterPanel</zorder>
        </widget>
       </widget>
       <widget class="QTabWidget" name="RightTabWidget">
@@ -671,40 +577,7 @@ QPushButton:disabled {
   <include location="../icons/orbiticons.qrc"/>
   <include location="../images/orbitimages.qrc"/>
  </resources>
- <connections>
-  <connection>
-   <sender>filterFunctions</sender>
-   <signal>textChanged(QString)</signal>
-   <receiver>OrbitMainWindow</receiver>
-   <slot>OnFilterFunctionsTextChanged(QString)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>281</x>
-     <y>230</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>487</x>
-     <y>335</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>filterTracks</sender>
-   <signal>textChanged(QString)</signal>
-   <receiver>OrbitMainWindow</receiver>
-   <slot>OnFilterTracksTextChanged(QString)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>111</x>
-     <y>230</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>487</x>
-     <y>335</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
  <slots>
   <slot>OnFilterTracksTextChanged(QString)</slot>
   <slot>OnFilterFunctionsTextChanged(QString)</slot>


### PR DESCRIPTION
The filter panel in the capture toolbar partially disappears on small screens. The toolbar extension button (i.e., the small grey arrow) on the right side does not do anything.

The reason is that, when a `QToolBar` is not a child of a `QMainWindow`, it loses the ability to populate the extension pop up with widgets added to the toolbar using `addWidget()`. To make the extension button works for the filter panel, we need use the widget action (i.e., `FilterPanelWidgetAction`) created by inheriting QWidgetAction and implementing `QWidgetAction::createWidget()` instead. 

In this PR:
* we move the filter panel from orbitmainwindow.ui to FilterPanelWidget.ui and create the `FilterPanelWidget` class;
* we create the `FilterPanelWidgetAction` class and add the customized widget action to capture toolbar.

Bug: http://b/169397517.

Test: start a new capture / load a capture &#10233; move the splitter / change the size of window &#10233; edit filters in the capture toolbar or in the extension button.    




