### PR TITLE
Clean datamanager

### DIFF
--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -172,8 +172,8 @@ add_fuzzer(CaptureDeserializerLoadFuzzer CaptureDeserializerLoadFuzzer.cpp)
 target_link_libraries(CaptureDeserializerLoadFuzzer
                       PRIVATE OrbitGl CONAN_PKG::libprotobuf-mutator)
 
-add_fuzzer(DataManagerUpdateModuleInfosFuzzer
-           DataManagerUpdateModuleInfosFuzzer.cpp)
-target_link_libraries(DataManagerUpdateModuleInfosFuzzer
+add_fuzzer(ModuleListFuzzer
+           ModuleListFuzzer.cpp)
+target_link_libraries(ModuleListFuzzer
                       PRIVATE OrbitGl CONAN_PKG::libprotobuf-mutator)
 

--- a/src/OrbitGl/DataManager.h
+++ b/src/OrbitGl/DataManager.h
@@ -14,12 +14,10 @@
 
 #include "GrpcProtos/Constants.h"
 #include "OrbitClientData/FunctionInfoSet.h"
-#include "OrbitClientData/ProcessData.h"
 #include "OrbitClientData/TracepointCustom.h"
 #include "OrbitClientData/UserDefinedCaptureData.h"
 #include "TextBox.h"
 #include "capture_data.pb.h"
-#include "process.pb.h"
 #include "tracepoint.pb.h"
 
 // This class is responsible for storing and
@@ -32,9 +30,6 @@ class DataManager final {
   explicit DataManager(std::thread::id thread_id = std::this_thread::get_id())
       : main_thread_id_(thread_id) {}
 
-  // TODO(177304549): This was necessary for the old UI. Remove
-  void UpdateProcessInfos(const std::vector<orbit_grpc_protos::ProcessInfo>& process_infos);
-
   void SelectFunction(const orbit_client_protos::FunctionInfo& function);
   void DeselectFunction(const orbit_client_protos::FunctionInfo& function);
   void ClearSelectedFunctions();
@@ -43,8 +38,6 @@ class DataManager final {
   void set_selected_thread_id(int32_t thread_id);
   void set_selected_text_box(const TextBox* text_box);
 
-  // TODO(177304549): This was necessary for the old UI. Remove
-  [[nodiscard]] ProcessData* GetMutableProcessByPid(int32_t process_id);
   [[nodiscard]] bool IsFunctionSelected(const orbit_client_protos::FunctionInfo& function) const;
   [[nodiscard]] std::vector<orbit_client_protos::FunctionInfo> GetSelectedFunctions() const;
   [[nodiscard]] bool IsFunctionVisible(uint64_t function_address) const;
@@ -81,8 +74,6 @@ class DataManager final {
 
  private:
   const std::thread::id main_thread_id_;
-  // We are sharing pointers to that entries and ensure reference stability by using node_hash_map
-  absl::node_hash_map<int32_t, ProcessData> process_map_;
   FunctionInfoSet selected_functions_;
   absl::flat_hash_set<uint64_t> visible_function_ids_;
   uint64_t highlighted_function_id_ = orbit_grpc_protos::kInvalidFunctionId;

--- a/src/OrbitGl/DataManagerUpdateModuleInfosFuzzer.cpp
+++ b/src/OrbitGl/DataManagerUpdateModuleInfosFuzzer.cpp
@@ -8,7 +8,6 @@
 #include <string>
 #include <vector>
 
-#include "DataManager.h"
 #include "ModulesDataView.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitClientData/ModuleManager.h"
@@ -47,14 +46,10 @@ DEFINE_PROTO_FUZZER(const GetModuleListResponse& module_list) {
   int32_t pid = 1;
   ProcessInfo process_info{};
   process_info.set_pid(pid);
+  ProcessData process = ProcessData(process_info);
 
-  DataManager data_manager{};
-  data_manager.UpdateProcessInfos(std::vector{process_info});
-
-  ProcessData* process = data_manager.GetMutableProcessByPid(pid);
-  CHECK(process != nullptr);
-  process->UpdateModuleInfos(modules);
+  process.UpdateModuleInfos(modules);
 
   ModulesDataView modules_data_view{nullptr};
-  modules_data_view.UpdateModules(process);
+  modules_data_view.UpdateModules(&process);
 }

--- a/src/OrbitGl/ModuleListFuzzer.cpp
+++ b/src/OrbitGl/ModuleListFuzzer.cpp
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "ModulesDataView.h"
-#include "OrbitBase/Logging.h"
 #include "OrbitClientData/ModuleManager.h"
 #include "OrbitClientData/ProcessData.h"
 #include "absl/flags/flag.h"


### PR DESCRIPTION
This PR removes all code related to processes from DataManager. These parts are still leftovers from the old ui. 

Since this needed to touch DataManagerUpdateModuleInfosFuzzer and removed DataManager from it, I also renamed it to ModuleListFuzzer. 
@beckerhe I don't know if there are implications with this rename outside of this repository (maybe with oss fuzz configs or similar). If, then we should probably talk about it and I can change those as well. 