### PR TITLE
Rename master to main everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Orbit combines sampling and dynamic instrumentation to optimize the profiling wo
 
 **Note**
 
-Orbit is undergoing a major overhaul. The focus has now shifted to the Linux version. Windows local profiling is currently broken in the master branch. It is possible however to profile Linux exectuable from a Windows UI instance. For Windows local profiling, please use the released [binaries](https://github.com/google/orbit/releases). Windows development will resume in the coming months.
+Orbit is undergoing a major overhaul. The focus has now shifted to the Linux version. Windows local profiling is currently broken in the main branch. It is possible however to profile Linux exectuable from a Windows UI instance. For Windows local profiling, please use the released [binaries](https://github.com/google/orbit/releases). Windows development will resume in the coming months.
 
 **Build**
 

--- a/kokoro/builds/build.sh
+++ b/kokoro/builds/build.sh
@@ -215,8 +215,8 @@ if [ -n "$1" ]; then
 
     echo -e "\n\n\nThe following is a diff that fixes all problems in files this PR touched:"
     echo 'Execute `patch -p1 -i <filename.diff>` in the repo root to apply it to the code base.'
-    readonly REFERENCE="${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-origin/master}"
-    readonly MERGE_BASE="$(git merge-base $REFERENCE HEAD)" # Merge base is the commit on master this PR was branched from.
+    readonly REFERENCE="${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-origin/main}"
+    readonly MERGE_BASE="$(git merge-base $REFERENCE HEAD)" # Merge base is the commit on main this PR was branched from.
 
     PATTERN_FILE="$(mktemp)"
     git diff -U0 --no-color --relative --name-only $MERGE_BASE > ${PATTERN_FILE}

--- a/kokoro/checks/clang_format/check.sh
+++ b/kokoro/checks/clang_format/check.sh
@@ -27,9 +27,9 @@ if [ "$0" == "$SCRIPT" ]; then
   echo -e "--\n"
 
   cd /mnt
-  # Use origin/master as reference branch, if not specified by kokoro
-  REFERENCE="origin/${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-master}"
-  MERGE_BASE="$(git merge-base $REFERENCE HEAD)" # Merge base is the commit on master this PR was branched from.
+  # Use origin/main as reference branch, if not specified by kokoro
+  REFERENCE="origin/${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-main}"
+  MERGE_BASE="$(git merge-base $REFERENCE HEAD)" # Merge base is the commit on main this PR was branched from.
   FORMATTING_DIFF="$(git diff -U0 --no-color --relative --diff-filter=r $MERGE_BASE | clang-format-diff-9 -p1)"
 
   if [ -n "$FORMATTING_DIFF" ]; then

--- a/kokoro/checks/license_headers/check.sh
+++ b/kokoro/checks/license_headers/check.sh
@@ -14,9 +14,9 @@ if [ "$0" == "$SCRIPT" ]; then
   # We are inside the docker container
 
   cd /mnt
-  # Use origin/master as reference branch, if not specified by kokoro
-  REFERENCE="origin/${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-master}"
-  MERGE_BASE="$(git merge-base $REFERENCE HEAD)" # Merge base is the commit on master this PR was branched from.
+  # Use origin/main as reference branch, if not specified by kokoro
+  REFERENCE="origin/${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH:-main}"
+  MERGE_BASE="$(git merge-base $REFERENCE HEAD)" # Merge base is the commit on main this PR was branched from.
   LICENSE_HEADER_MISSED=""
 
   echo -e "The following files are missing a license/copyright header:\n"


### PR DESCRIPTION
I did this change by searching "master" in the repository. For the kokoro scripts, I don't know how to test if everything works. I also don't know if there are any other locations (outside of this repository) where things have to be changed accordingly. 


This change was prompted because I looked at the iwyu presubmit check in a different PR and saw this:
```
...
The following is a diff that fixes all problems in files this PR touched:
Execute `patch -p1 -i <filename.diff>` in the repo root to apply it to the code base.
fatal: Not a valid object name origin/master
...
```