### PR TITLE
Remove symbol.proto import in services.proto

### DIFF
--- a/src/GrpcProtos/services.proto
+++ b/src/GrpcProtos/services.proto
@@ -10,7 +10,6 @@ import "capture.proto";
 import "code_block.proto";
 import "module.proto";
 import "process.proto";
-import "symbol.proto";
 import "tracepoint.proto";
 
 message CaptureRequest {


### PR DESCRIPTION
There used to be the following warning in every build:

`services.proto:13:1: warning: Import symbol.proto but not used.` 

This PR fixes this warning.