### PR TITLE
Clean TimeGraph dependencies from Tracks

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -352,8 +352,6 @@ void OrbitApp::PostInit() {
   ListPresets();
 
   string_manager_ = std::make_shared<StringManager>();
-
-  GCurrentTimeGraph->SetStringManager(string_manager_);
   if (metrics_uploader_ != nullptr) {
     metrics_uploader_->SendLogEvent(
         orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_INITIALIZED);
@@ -791,8 +789,7 @@ PresetLoadState OrbitApp::GetPresetLoadState(
 }
 
 ErrorMessageOr<void> OrbitApp::OnSaveCapture(const std::string& file_name) {
-  const auto& key_to_string_map =
-      GCurrentTimeGraph->GetTrackManager()->GetStringManager()->GetKeyToStringMap();
+  const auto& key_to_string_map = string_manager_->GetKeyToStringMap();
 
   std::vector<std::shared_ptr<TimerChain>> chains =
       GCurrentTimeGraph->GetAllSerializableTimerChains();

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -326,6 +326,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   [[nodiscard]] DataView* GetOrCreateDataView(DataViewType type) override;
   [[nodiscard]] DataView* GetOrCreateSelectionCallstackDataView();
 
+  [[nodiscard]] StringManager* GetStringManager() { return string_manager_.get(); }
   [[nodiscard]] ProcessManager* GetProcessManager() { return process_manager_; }
   [[nodiscard]] ThreadPool* GetThreadPool() { return thread_pool_.get(); }
   [[nodiscard]] MainThreadExecutor* GetMainThreadExecutor() { return main_thread_executor_; }

--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -128,7 +128,7 @@ Color AsyncTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected) c
   orbit_api::Event event = ManualInstrumentationManager::ApiEventFromTimerInfo(timer_info);
   const uint64_t event_id = event.data;
   std::string name = app_->GetManualInstrumentationManager()->GetString(event_id);
-  Color color = time_graph_->GetColor(name);
+  Color color = TimeGraph::GetColor(name);
 
   constexpr uint8_t kOddAlpha = 210;
   if (!(timer_info.depth() & 0x1)) {

--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -30,8 +30,9 @@
 using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::TimerInfo;
 
-AsyncTrack::AsyncTrack(TimeGraph* time_graph, const std::string& name, OrbitApp* app)
-    : TimerTrack(time_graph, app) {
+AsyncTrack::AsyncTrack(TimeGraph* time_graph, const std::string& name, OrbitApp* app,
+                       CaptureData* capture_data)
+    : TimerTrack(time_graph, app, capture_data) {
   SetName(name);
   SetLabel(name);
 }
@@ -45,10 +46,9 @@ AsyncTrack::AsyncTrack(TimeGraph* time_graph, const std::string& name, OrbitApp*
 
   // The FunctionInfo here corresponds to one of the automatically instrumented empty stubs from
   // Orbit.h. Use it to retrieve the module from which the manually instrumented scope originated.
-  const CaptureData* capture_data = time_graph_->GetCaptureData();
   const FunctionInfo* func =
-      capture_data
-          ? capture_data->GetInstrumentedFunctionById(text_box->GetTimerInfo().function_id())
+      capture_data_
+          ? capture_data_->GetInstrumentedFunctionById(text_box->GetTimerInfo().function_id())
           : nullptr;
   CHECK(func || timer_info.type() == TimerInfo::kIntrospection);
   std::string module_name =

--- a/src/OrbitGl/AsyncTrack.h
+++ b/src/OrbitGl/AsyncTrack.h
@@ -24,7 +24,8 @@ class OrbitApp;
 
 class AsyncTrack final : public TimerTrack {
  public:
-  explicit AsyncTrack(TimeGraph* time_graph, const std::string& name, OrbitApp* app);
+  explicit AsyncTrack(TimeGraph* time_graph, const std::string& name, OrbitApp* app,
+                      CaptureData* capture_data);
 
   [[nodiscard]] Type GetType() const override { return kAsyncTrack; };
   [[nodiscard]] std::string GetBoxTooltip(PickingId id) const override;

--- a/src/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
+++ b/src/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
@@ -72,8 +72,6 @@ DEFINE_PROTO_FUZZER(const orbit_client_protos::CaptureDeserializerFuzzerInfo& in
 
   TimeGraph time_graph{14, app.get()};
   GCurrentTimeGraph = &time_graph;
-  auto string_manager = std::make_shared<StringManager>();
-  time_graph.SetStringManager(string_manager);
   app->ClearCapture();
 
   // NOLINTNEXTLINE

--- a/src/OrbitGl/EventTrack.h
+++ b/src/OrbitGl/EventTrack.h
@@ -21,7 +21,7 @@ class TimeGraph;
 
 class EventTrack : public Track {
  public:
-  explicit EventTrack(TimeGraph* time_graph, OrbitApp* app);
+  explicit EventTrack(TimeGraph* time_graph, OrbitApp* app, CaptureData* capture_data);
   Type GetType() const override { return kEventTrack; }
 
   std::string GetTooltip() const override;

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -66,8 +66,8 @@ float FrameTrack::GetAverageBoxHeight() const {
 }
 
 FrameTrack::FrameTrack(TimeGraph* time_graph, uint64_t function_id, const FunctionInfo& function,
-                       OrbitApp* app)
-    : TimerTrack(time_graph, app), function_id_(function_id), function_(function) {
+                       OrbitApp* app, CaptureData* capture_data)
+    : TimerTrack(time_graph, app, capture_data), function_id_(function_id), function_(function) {
   // TODO(b/169554463): Support manual instrumentation.
   std::string function_name = function_utils::GetDisplayName(function_);
   std::string name = absl::StrFormat("Frame track based on %s", function_name);

--- a/src/OrbitGl/FrameTrack.h
+++ b/src/OrbitGl/FrameTrack.h
@@ -25,7 +25,8 @@ class OrbitApp;
 class FrameTrack : public TimerTrack {
  public:
   explicit FrameTrack(TimeGraph* time_graph, uint64_t function_id,
-                      const orbit_client_protos::FunctionInfo& function, OrbitApp* app);
+                      const orbit_client_protos::FunctionInfo& function, OrbitApp* app,
+                      CaptureData* capture_data);
   [[nodiscard]] Type GetType() const override { return kFrameTrack; }
   [[nodiscard]] uint64_t GetFunctionId() const { return function_id_; }
   [[nodiscard]] bool IsCollapsible() const override { return GetMaximumScaleFactor() > 0.f; }

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -64,8 +64,9 @@ std::string MapGpuTimelineToTrackLabel(std::string_view timeline) {
 
 }  // namespace orbit_gl
 
-GpuTrack::GpuTrack(TimeGraph* time_graph, uint64_t timeline_hash, OrbitApp* app)
-    : TimerTrack(time_graph, app) {
+GpuTrack::GpuTrack(TimeGraph* time_graph, uint64_t timeline_hash, OrbitApp* app,
+                   CaptureData* capture_data)
+    : TimerTrack(time_graph, app, capture_data) {
   text_renderer_ = time_graph->GetTextRenderer();
   timeline_hash_ = timeline_hash;
   string_manager_ = app->GetStringManager();
@@ -286,8 +287,7 @@ std::string GpuTrack::GetBoxTooltip(PickingId id) const {
 }
 
 std::string GpuTrack::GetSwQueueTooltip(const TimerInfo& timer_info) const {
-  const CaptureData* capture_data = time_graph_->GetCaptureData();
-  CHECK(capture_data != nullptr);
+  CHECK(capture_data_ != nullptr);
   return absl::StrFormat(
       "<b>Software Queue</b><br/>"
       "<i>Time between amdgpu_cs_ioctl (job submitted) and "
@@ -296,13 +296,12 @@ std::string GpuTrack::GetSwQueueTooltip(const TimerInfo& timer_info) const {
       "<br/>"
       "<b>Submitted from thread:</b> %s [%d]<br/>"
       "<b>Time:</b> %s",
-      capture_data->GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
+      capture_data_->GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
       GetPrettyTime(TicksToDuration(timer_info.start(), timer_info.end())).c_str());
 }
 
 std::string GpuTrack::GetHwQueueTooltip(const TimerInfo& timer_info) const {
-  const CaptureData* capture_data = time_graph_->GetCaptureData();
-  CHECK(capture_data != nullptr);
+  CHECK(capture_data_ != nullptr);
   return absl::StrFormat(
       "<b>Hardware Queue</b><br/><i>Time between amdgpu_sched_run_job "
       "(job scheduled) and start of GPU execution</i>"
@@ -310,13 +309,12 @@ std::string GpuTrack::GetHwQueueTooltip(const TimerInfo& timer_info) const {
       "<br/>"
       "<b>Submitted from thread:</b> %s [%d]<br/>"
       "<b>Time:</b> %s",
-      capture_data->GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
+      capture_data_->GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
       GetPrettyTime(TicksToDuration(timer_info.start(), timer_info.end())).c_str());
 }
 
 std::string GpuTrack::GetHwExecutionTooltip(const TimerInfo& timer_info) const {
-  const CaptureData* capture_data = time_graph_->GetCaptureData();
-  CHECK(capture_data != nullptr);
+  CHECK(capture_data_ != nullptr);
   return absl::StrFormat(
       "<b>Harware Execution</b><br/>"
       "<i>End is marked by \"dma_fence_signaled\" event for this command "
@@ -325,7 +323,7 @@ std::string GpuTrack::GetHwExecutionTooltip(const TimerInfo& timer_info) const {
       "<br/>"
       "<b>Submitted from thread:</b> %s [%d]<br/>"
       "<b>Time:</b> %s",
-      capture_data->GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
+      capture_data_->GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
       GetPrettyTime(TicksToDuration(timer_info.start(), timer_info.end())).c_str());
 }
 

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -70,6 +70,13 @@ GpuTrack::GpuTrack(TimeGraph* time_graph, uint64_t timeline_hash, OrbitApp* app)
   timeline_hash_ = timeline_hash;
   string_manager_ = app->GetStringManager();
 
+  std::string timeline = app_->GetStringManager()->Get(timeline_hash).value_or("");
+  std::string label = orbit_gl::MapGpuTimelineToTrackLabel(timeline);
+  SetName(timeline);
+  SetLabel(label);
+  // This min combine two cases, label == timeline and when label includes timeline
+  SetNumberOfPrioritizedTrailingCharacters(std::min(label.size(), timeline.size() + 2));
+
   // Gpu tracks are collapsed by default.
   collapse_toggle_->SetState(TriangleToggle::State::kCollapsed,
                              TriangleToggle::InitialStateUpdate::kReplaceInitialState);

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -64,12 +64,11 @@ std::string MapGpuTimelineToTrackLabel(std::string_view timeline) {
 
 }  // namespace orbit_gl
 
-GpuTrack::GpuTrack(TimeGraph* time_graph, StringManager* string_manager, uint64_t timeline_hash,
-                   OrbitApp* app)
+GpuTrack::GpuTrack(TimeGraph* time_graph, uint64_t timeline_hash, OrbitApp* app)
     : TimerTrack(time_graph, app) {
   text_renderer_ = time_graph->GetTextRenderer();
   timeline_hash_ = timeline_hash;
-  string_manager_ = string_manager;
+  string_manager_ = app->GetStringManager();
 
   // Gpu tracks are collapsed by default.
   collapse_toggle_->SetState(TriangleToggle::State::kCollapsed,

--- a/src/OrbitGl/GpuTrack.h
+++ b/src/OrbitGl/GpuTrack.h
@@ -33,7 +33,8 @@ std::string MapGpuTimelineToTrackLabel(std::string_view timeline);
 
 class GpuTrack : public TimerTrack {
  public:
-  explicit GpuTrack(TimeGraph* time_graph, uint64_t timeline_hash, OrbitApp* app);
+  explicit GpuTrack(TimeGraph* time_graph, uint64_t timeline_hash, OrbitApp* app,
+                    CaptureData* capture_data);
   ~GpuTrack() override = default;
   [[nodiscard]] std::string GetTooltip() const override;
   [[nodiscard]] Type GetType() const override { return kGpuTrack; }

--- a/src/OrbitGl/GpuTrack.h
+++ b/src/OrbitGl/GpuTrack.h
@@ -33,8 +33,7 @@ std::string MapGpuTimelineToTrackLabel(std::string_view timeline);
 
 class GpuTrack : public TimerTrack {
  public:
-  explicit GpuTrack(TimeGraph* time_graph, StringManager* string_manager, uint64_t timeline_hash,
-                    OrbitApp* app);
+  explicit GpuTrack(TimeGraph* time_graph, uint64_t timeline_hash, OrbitApp* app);
   ~GpuTrack() override = default;
   [[nodiscard]] std::string GetTooltip() const override;
   [[nodiscard]] Type GetType() const override { return kGpuTrack; }

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -15,8 +15,10 @@
 #include "TimeGraph.h"
 #include "TimeGraphLayout.h"
 
-GraphTrack::GraphTrack(TimeGraph* time_graph, std::string name)
-    : Track(time_graph), name_(std::move(name)) {}
+GraphTrack::GraphTrack(TimeGraph* time_graph, std::string name) : Track(time_graph) {
+  SetName(name);
+  SetLabel(name);
+}
 
 void GraphTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode,
                                   float z_offset) {

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -15,7 +15,8 @@
 #include "TimeGraph.h"
 #include "TimeGraphLayout.h"
 
-GraphTrack::GraphTrack(TimeGraph* time_graph, std::string name) : Track(time_graph) {
+GraphTrack::GraphTrack(TimeGraph* time_graph, std::string name, CaptureData* capture_data)
+    : Track(time_graph, capture_data) {
   SetName(name);
   SetLabel(name);
 }

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -43,7 +43,6 @@ class GraphTrack : public Track {
   double max_ = std::numeric_limits<double>::lowest();
   double value_range_ = 0;
   double inv_value_range_ = 0;
-  std::string name_;
 };
 
 #endif

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -23,7 +23,7 @@ class TimeGraph;
 
 class GraphTrack : public Track {
  public:
-  explicit GraphTrack(TimeGraph* time_graph, std::string name);
+  explicit GraphTrack(TimeGraph* time_graph, std::string name, CaptureData* capture_data);
   [[nodiscard]] Type GetType() const override { return kGraphTrack; }
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
   void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode,

--- a/src/OrbitGl/IntrospectionWindow.cpp
+++ b/src/OrbitGl/IntrospectionWindow.cpp
@@ -13,9 +13,7 @@
 using orbit_client_protos::TimerInfo;
 
 IntrospectionWindow::IntrospectionWindow(uint32_t font_size, OrbitApp* app)
-    : CaptureWindow(font_size, app) {
-  time_graph_.SetStringManager(std::make_shared<StringManager>());
-}
+    : CaptureWindow(font_size, app) {}
 
 IntrospectionWindow::~IntrospectionWindow() { StopIntrospection(); }
 

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -24,6 +24,7 @@ const Color kSelectionColor(0, 128, 255, 255);
 SchedulerTrack::SchedulerTrack(TimeGraph* time_graph, OrbitApp* app) : TimerTrack(time_graph, app) {
   SetPinned(false);
   SetName("Scheduler");
+  SetLabel("Scheduler (0 cores)");
   num_cores_ = 0;
 }
 
@@ -31,7 +32,7 @@ void SchedulerTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
   TimerTrack::OnTimer(timer_info);
   if (num_cores_ <= static_cast<uint32_t>(timer_info.processor())) {
     num_cores_ = timer_info.processor() + 1;
-    label_ = (absl::StrFormat("Scheduler (%u cores)", num_cores_));
+    SetLabel(absl::StrFormat("Scheduler (%u cores)", num_cores_));
   }
 }
 

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -24,6 +24,15 @@ const Color kSelectionColor(0, 128, 255, 255);
 SchedulerTrack::SchedulerTrack(TimeGraph* time_graph, OrbitApp* app) : TimerTrack(time_graph, app) {
   SetPinned(false);
   SetName("Scheduler");
+  num_cores_ = 0;
+}
+
+void SchedulerTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
+  TimerTrack::OnTimer(timer_info);
+  if (num_cores_ <= static_cast<uint32_t>(timer_info.processor())) {
+    num_cores_ = timer_info.processor() + 1;
+    label_ = (absl::StrFormat("Scheduler (%u cores)", num_cores_));
+  }
 }
 
 float SchedulerTrack::GetHeight() const {

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -50,7 +50,7 @@ Color SchedulerTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selecte
   } else if (!IsTimerActive(timer_info)) {
     return kInactiveColor;
   }
-  return time_graph_->GetThreadColor(timer_info.thread_id());
+  return TimeGraph::GetThreadColor(timer_info.thread_id());
 }
 
 float SchedulerTrack::GetYFromTimer(const TimerInfo& timer_info) const {

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -21,7 +21,8 @@ using orbit_client_protos::TimerInfo;
 const Color kInactiveColor(100, 100, 100, 255);
 const Color kSelectionColor(0, 128, 255, 255);
 
-SchedulerTrack::SchedulerTrack(TimeGraph* time_graph, OrbitApp* app) : TimerTrack(time_graph, app) {
+SchedulerTrack::SchedulerTrack(TimeGraph* time_graph, OrbitApp* app, CaptureData* capture_data)
+    : TimerTrack(time_graph, app, capture_data) {
   SetPinned(false);
   SetName("Scheduler");
   SetLabel("Scheduler (0 cores)");
@@ -45,9 +46,8 @@ float SchedulerTrack::GetHeight() const {
 
 bool SchedulerTrack::IsTimerActive(const TimerInfo& timer_info) const {
   bool is_same_tid_as_selected = timer_info.thread_id() == app_->selected_thread_id();
-  const CaptureData* capture_data = time_graph_->GetCaptureData();
-  CHECK(capture_data != nullptr);
-  int32_t capture_process_id = capture_data->process_id();
+  CHECK(capture_data_ != nullptr);
+  int32_t capture_process_id = capture_data_->process_id();
   bool is_same_pid_as_target =
       capture_process_id == 0 || capture_process_id == timer_info.process_id();
 
@@ -84,8 +84,7 @@ std::string SchedulerTrack::GetBoxTooltip(PickingId id) const {
     return "";
   }
 
-  const CaptureData* capture_data = time_graph_->GetCaptureData();
-  CHECK(capture_data != nullptr);
+  CHECK(capture_data_ != nullptr);
   return absl::StrFormat(
       "<b>CPU Core activity</b><br/>"
       "<br/>"
@@ -93,8 +92,8 @@ std::string SchedulerTrack::GetBoxTooltip(PickingId id) const {
       "<b>Process:</b> %s [%d]<br/>"
       "<b>Thread:</b> %s [%d]<br/>",
       text_box->GetTimerInfo().processor(),
-      capture_data->GetThreadName(text_box->GetTimerInfo().process_id()),
+      capture_data_->GetThreadName(text_box->GetTimerInfo().process_id()),
       text_box->GetTimerInfo().process_id(),
-      capture_data->GetThreadName(text_box->GetTimerInfo().thread_id()),
+      capture_data_->GetThreadName(text_box->GetTimerInfo().thread_id()),
       text_box->GetTimerInfo().thread_id());
 }

--- a/src/OrbitGl/SchedulerTrack.h
+++ b/src/OrbitGl/SchedulerTrack.h
@@ -18,7 +18,7 @@ class OrbitApp;
 
 class SchedulerTrack final : public TimerTrack {
  public:
-  explicit SchedulerTrack(TimeGraph* time_graph, OrbitApp* app);
+  explicit SchedulerTrack(TimeGraph* time_graph, OrbitApp* app, CaptureData* capture_data);
   ~SchedulerTrack() override = default;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
 

--- a/src/OrbitGl/SchedulerTrack.h
+++ b/src/OrbitGl/SchedulerTrack.h
@@ -20,6 +20,7 @@ class SchedulerTrack final : public TimerTrack {
  public:
   explicit SchedulerTrack(TimeGraph* time_graph, OrbitApp* app);
   ~SchedulerTrack() override = default;
+  void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
 
   [[nodiscard]] Type GetType() const override { return kSchedulerTrack; }
   [[nodiscard]] std::string GetTooltip() const override;
@@ -36,6 +37,9 @@ class SchedulerTrack final : public TimerTrack {
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
                                     bool is_selected) const override;
   [[nodiscard]] std::string GetBoxTooltip(PickingId id) const override;
+
+ private:
+  uint32_t num_cores_;
 };
 
 #endif  // ORBIT_GL_SCHEDULER_TRACK_H_

--- a/src/OrbitGl/ThreadStateTrack.cpp
+++ b/src/OrbitGl/ThreadStateTrack.cpp
@@ -20,16 +20,16 @@
 
 using orbit_client_protos::ThreadStateSliceInfo;
 
-ThreadStateTrack::ThreadStateTrack(TimeGraph* time_graph, int32_t thread_id, OrbitApp* app)
-    : Track{time_graph}, app_{app} {
+ThreadStateTrack::ThreadStateTrack(TimeGraph* time_graph, int32_t thread_id, OrbitApp* app,
+                                   CaptureData* capture_data)
+    : Track{time_graph, capture_data}, app_{app} {
   thread_id_ = thread_id;
   picked_ = false;
 }
 
 bool ThreadStateTrack::IsEmpty() const {
-  const CaptureData* capture_data = time_graph_->GetCaptureData();
-  if (capture_data == nullptr) return true;
-  return !capture_data->HasThreadStatesForThread(thread_id_);
+  if (capture_data_ == nullptr) return true;
+  return !capture_data_->HasThreadStatesForThread(thread_id_);
 }
 
 void ThreadStateTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
@@ -168,9 +168,8 @@ void ThreadStateTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
 
   uint64_t ignore_until_ns = 0;
 
-  const CaptureData* capture_data = time_graph_->GetCaptureData();
-  CHECK(capture_data != nullptr);
-  capture_data->ForEachThreadStateSliceIntersectingTimeRange(
+  CHECK(capture_data_ != nullptr);
+  capture_data_->ForEachThreadStateSliceIntersectingTimeRange(
       thread_id_, min_tick, max_tick, [&](const ThreadStateSliceInfo& slice) {
         if (slice.end_timestamp_ns() <= ignore_until_ns) {
           // Reduce overdraw by not drawing slices whose entire width would only draw over a

--- a/src/OrbitGl/ThreadStateTrack.h
+++ b/src/OrbitGl/ThreadStateTrack.h
@@ -23,7 +23,8 @@ class OrbitApp;
 
 class ThreadStateTrack final : public Track {
  public:
-  explicit ThreadStateTrack(TimeGraph* time_graph, int32_t thread_id, OrbitApp* app);
+  explicit ThreadStateTrack(TimeGraph* time_graph, int32_t thread_id, OrbitApp* app,
+                            CaptureData* capture_data);
   Type GetType() const override { return kThreadStateTrack; }
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) override;

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -37,6 +37,7 @@ using orbit_client_protos::TimerInfo;
 ThreadTrack::ThreadTrack(TimeGraph* time_graph, int32_t thread_id, OrbitApp* app)
     : TimerTrack(time_graph, app) {
   thread_id_ = thread_id;
+  InitializeNameAndLabel(thread_id);
 
   thread_state_track_ = std::make_shared<ThreadStateTrack>(time_graph, thread_id, app_);
 
@@ -44,6 +45,29 @@ ThreadTrack::ThreadTrack(TimeGraph* time_graph, int32_t thread_id, OrbitApp* app
   event_track_->SetThreadId(thread_id);
 
   tracepoint_track_ = std::make_shared<TracepointTrack>(time_graph, thread_id, app_);
+  SetTrackColor(TimeGraph::GetThreadColor(thread_id));
+}
+
+void ThreadTrack::InitializeNameAndLabel(int32_t thread_id) {
+  if (thread_id == orbit_base::kAllThreadsOfAllProcessesTid) {
+    SetName("All tracepoint events");
+    SetLabel("All tracepoint events");
+  } else if (thread_id == orbit_base::kAllProcessThreadsTid) {
+    // This is the process track.
+    const CaptureData& capture_data = app_->GetCaptureData();
+    std::string process_name = capture_data.process_name();
+    SetName(process_name);
+    const std::string_view all_threads = " (all_threads)";
+    SetLabel(process_name.append(all_threads));
+    SetNumberOfPrioritizedTrailingCharacters(all_threads.size() - 1);
+  } else {
+    const std::string& thread_name = time_graph_->GetThreadNameFromTid(thread_id);
+    SetName(thread_name);
+    std::string tid_str = std::to_string(thread_id);
+    std::string track_label = absl::StrFormat("%s [%s]", thread_name, tid_str);
+    SetLabel(track_label);
+    SetNumberOfPrioritizedTrailingCharacters(tid_str.size() + 2);
+  }
 }
 
 const TextBox* ThreadTrack::GetLeft(const TextBox* text_box) const {

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -150,10 +150,10 @@ Color ThreadTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected) 
     color = user_color.value();
   } else if (timer_info.type() == TimerInfo::kIntrospection) {
     orbit_api::Event event = ManualInstrumentationManager::ApiEventFromTimerInfo(timer_info);
-    color = event.color == orbit::Color::kAuto ? time_graph_->GetColor(event.name)
+    color = event.color == orbit::Color::kAuto ? TimeGraph::GetColor(event.name)
                                                : ToColor(static_cast<uint64_t>(event.color));
   } else {
-    color = time_graph_->GetThreadColor(timer_info.thread_id());
+    color = TimeGraph::GetThreadColor(timer_info.thread_id());
   }
 
   constexpr uint8_t kOddAlpha = 210;

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -25,8 +25,11 @@ class OrbitApp;
 
 class ThreadTrack final : public TimerTrack {
  public:
-  explicit ThreadTrack(TimeGraph* time_graph, int32_t thread_id, OrbitApp* app);
+  explicit ThreadTrack(TimeGraph* time_graph, int32_t thread_id, OrbitApp* app,
+                       CaptureData* capture_data);
   void InitializeNameAndLabel(int32_t thread_id);
+
+  void SetCaptureData(CaptureData* capture_data) override;
 
   [[nodiscard]] int32_t GetThreadId() const { return thread_id_; }
 

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -26,6 +26,7 @@ class OrbitApp;
 class ThreadTrack final : public TimerTrack {
  public:
   explicit ThreadTrack(TimeGraph* time_graph, int32_t thread_id, OrbitApp* app);
+  void InitializeNameAndLabel(int32_t thread_id);
 
   [[nodiscard]] int32_t GetThreadId() const { return thread_id_; }
 

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -59,10 +59,6 @@ TimeGraph::~TimeGraph() {
   manual_instrumentation_manager_->RemoveAsyncTimerListener(async_timer_info_listener_.get());
 }
 
-void TimeGraph::SetStringManager(std::shared_ptr<StringManager> str_manager) {
-  track_manager_->SetStringManager(str_manager.get());
-}
-
 void TimeGraph::SetCanvas(GlCanvas* canvas) {
   canvas_ = canvas;
   text_renderer_->SetCanvas(canvas);
@@ -545,7 +541,7 @@ void TimeGraph::NeedsUpdate() {
 
 void TimeGraph::UpdatePrimitives(PickingMode picking_mode) {
   ORBIT_SCOPE_FUNCTION;
-  CHECK(track_manager_->GetStringManager() != nullptr);
+  CHECK(app_->GetStringManager() != nullptr);
 
   batcher_.StartNewFrame();
   text_renderer_static_.Clear();

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -428,6 +428,11 @@ std::vector<std::shared_ptr<TimerChain>> TimeGraph::GetAllSerializableTimerChain
   return chains;
 }
 
+void TimeGraph::SetCaptureData(CaptureData* capture_data) {
+  capture_data_ = capture_data;
+  track_manager_->SetCaptureData(capture_data);
+}
+
 void TimeGraph::UpdateMaxTimeStamp(uint64_t time) {
   if (time > capture_max_timestamp_) {
     capture_max_timestamp_ = time;

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -50,7 +50,6 @@ TimeGraph::TimeGraph(uint32_t font_size, OrbitApp* app)
           [this](const std::string& name, const TimerInfo& timer_info) {
             ProcessAsyncTimer(name, timer_info);
           });
-  num_cores_ = 0;
   manual_instrumentation_manager_ = app_->GetManualInstrumentationManager();
   manual_instrumentation_manager_->AddAsyncTimerListener(async_timer_info_listener_.get());
 }
@@ -284,14 +283,8 @@ void TimeGraph::ProcessTimer(const TimerInfo& timer_info, const FunctionInfo* fu
       // TODO(b/176962090): We need to create the `ThreadTrack` here even we don't use it, as we
       //  don't create it on new callstack events, yet.
       track_manager_->GetOrCreateThreadTrack(timer_info.thread_id());
-      SchedulerTrack* track = track_manager_->GetOrCreateSchedulerTrack();
-      track->OnTimer(timer_info);
-      if (GetNumCores() <= static_cast<uint32_t>(timer_info.processor())) {
-        auto num_cores = timer_info.processor() + 1;
-        SetNumCores(num_cores);
-        layout_.SetNumCores(num_cores);
-        track->SetLabel(absl::StrFormat("Scheduler (%u cores)", num_cores));
-      }
+      SchedulerTrack* scheduler_track = track_manager_->GetOrCreateSchedulerTrack();
+      scheduler_track->OnTimer(timer_info);
       break;
     }
     case TimerInfo::kNone: {

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -24,7 +24,6 @@
 #include "ManualInstrumentationManager.h"
 #include "OrbitClientModel/CaptureData.h"
 #include "PickingManager.h"
-#include "StringManager.h"
 #include "TextBox.h"
 #include "TextRenderer.h"
 #include "TimeGraphLayout.h"
@@ -115,7 +114,6 @@ class TimeGraph {
   [[nodiscard]] int GetNumDrawnTextBoxes() { return num_drawn_text_boxes_; }
   void SetTextRenderer(TextRenderer* text_renderer) { text_renderer_ = text_renderer; }
   [[nodiscard]] TextRenderer* GetTextRenderer() { return &text_renderer_static_; }
-  void SetStringManager(std::shared_ptr<StringManager> str_manager);
   void SetCanvas(GlCanvas* canvas);
   [[nodiscard]] GlCanvas* GetCanvas() { return canvas_; }
   [[nodiscard]] uint32_t CalculateZoomedFontSize() const {

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -56,7 +56,7 @@ class TimeGraph {
 
   // TODO (b/176056427): TimeGraph should not store nor expose CaptureData.
   [[nodiscard]] const CaptureData* GetCaptureData() const { return capture_data_; }
-  void SetCaptureData(CaptureData* capture_data) { capture_data_ = capture_data; }
+  void SetCaptureData(CaptureData* capture_data);
   [[nodiscard]] TrackManager* GetTrackManager() { return track_manager_.get(); }
 
   [[nodiscard]] float GetTextBoxHeight() const { return layout_.GetTextBoxHeight(); }

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -121,7 +121,6 @@ class TimeGraph {
   }
   [[nodiscard]] Batcher& GetBatcher() { return batcher_; }
   [[nodiscard]] uint32_t GetNumTimers() const;
-  [[nodiscard]] uint32_t GetNumCores() const { return num_cores_; }
   [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllTimerChains() const;
   [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllThreadTrackTimerChains() const;
   [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllSerializableTimerChains() const;
@@ -187,7 +186,6 @@ class TimeGraph {
   void ProcessValueTrackingTimer(const orbit_client_protos::TimerInfo& timer_info);
   void ProcessAsyncTimer(const std::string& track_name,
                          const orbit_client_protos::TimerInfo& timer_info);
-  void SetNumCores(uint32_t num_cores) { num_cores_ = num_cores; }
 
  private:
   uint32_t font_size_;
@@ -215,7 +213,6 @@ class TimeGraph {
 
   TimeGraphAccessibility accessibility_;
 
-  uint32_t num_cores_;
   // Be careful when directly changing these members without using the
   // methods NeedsRedraw() or NeedsUpdate():
   // needs_update_primitives_ should always imply needs_redraw_, that is

--- a/src/OrbitGl/TimeGraphLayout.cpp
+++ b/src/OrbitGl/TimeGraphLayout.cpp
@@ -7,7 +7,6 @@
 #include <imgui.h>
 
 TimeGraphLayout::TimeGraphLayout() {
-  num_cores_ = 0;
   text_box_height_ = 20.f;
   core_height_ = 10.f;
   thread_state_track_height_ = 4.0f;

--- a/src/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/TimeGraphLayout.h
@@ -38,13 +38,10 @@ class TimeGraphLayout {
   float GetScale() const { return scale_; }
   void SetScale(float value) { scale_ = value; }
   void SetDrawProperties(bool value) { draw_properties_ = value; }
-  void SetNumCores(int a_NumCores) { num_cores_ = a_NumCores; }
   bool DrawProperties();
   bool GetDrawTrackBackground() const { return draw_track_background_; }
 
  protected:
-  int num_cores_;
-
   float text_box_height_;
   float core_height_;
   float thread_state_track_height_;

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -28,7 +28,8 @@ using orbit_client_protos::TimerInfo;
 
 ABSL_DECLARE_FLAG(bool, show_return_values);
 
-TimerTrack::TimerTrack(TimeGraph* time_graph, OrbitApp* app) : Track(time_graph), app_{app} {
+TimerTrack::TimerTrack(TimeGraph* time_graph, OrbitApp* app, CaptureData* capture_data)
+    : Track(time_graph, capture_data), app_{app} {
   text_renderer_ = time_graph->GetTextRenderer();
 }
 

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -31,7 +31,7 @@ class TextRenderer;
 
 class TimerTrack : public Track {
  public:
-  explicit TimerTrack(TimeGraph* time_graph, OrbitApp* app);
+  explicit TimerTrack(TimeGraph* time_graph, OrbitApp* app, CaptureData* capture_data);
   ~TimerTrack() override = default;
 
   // Pickable

--- a/src/OrbitGl/TracepointTrack.h
+++ b/src/OrbitGl/TracepointTrack.h
@@ -14,7 +14,8 @@
 
 class TracepointTrack : public EventTrack {
  public:
-  explicit TracepointTrack(TimeGraph* time_graph, int32_t thread_id, OrbitApp* app);
+  explicit TracepointTrack(TimeGraph* time_graph, int32_t thread_id, OrbitApp* app,
+                           CaptureData* capture_data);
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
 

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -17,12 +17,13 @@
 #include "TimeGraph.h"
 #include "TimeGraphLayout.h"
 
-Track::Track(TimeGraph* time_graph)
+Track::Track(TimeGraph* time_graph, CaptureData* capture_data)
     : time_graph_(time_graph),
       collapse_toggle_(std::make_shared<TriangleToggle>(
           TriangleToggle::State::kExpanded,
           [this](TriangleToggle::State state) { OnCollapseToggle(state); }, time_graph)),
-      accessibility_(this, &time_graph->GetLayout()) {
+      accessibility_(this, &time_graph->GetLayout()),
+      capture_data_(capture_data) {
   mouse_pos_[0] = mouse_pos_[1] = Vec2(0, 0);
   pos_ = Vec2(0, 0);
   size_ = Vec2(0, 0);
@@ -201,8 +202,7 @@ void Track::SetY(float y) {
 }
 
 Color Track::GetBackgroundColor() const {
-  const CaptureData* capture_data = time_graph_->GetCaptureData();
-  int32_t capture_process_id = capture_data ? capture_data->process_id() : -1;
+  int32_t capture_process_id = capture_data_ ? capture_data_->process_id() : -1;
   if (GetType() == kSchedulerTrack) {
     return color_;
   } else if (process_id_ != -1 && process_id_ != capture_process_id) {

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -6,6 +6,7 @@
 #define ORBIT_GL_TRACK_H_
 
 #include <GteVector.h>
+#include <OrbitClientModel/CaptureData.h>
 #include <stdint.h>
 
 #include <algorithm>
@@ -25,6 +26,7 @@
 #include "TimerChain.h"
 #include "TrackAccessibility.h"
 #include "TriangleToggle.h"
+#include "capture_data.pb.h"
 
 class GlCanvas;
 class TimeGraph;
@@ -44,8 +46,10 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
     kUnknown,
   };
 
-  explicit Track(TimeGraph* time_graph);
+  explicit Track(TimeGraph* time_graph, CaptureData* capture_data);
   ~Track() override = default;
+  virtual void SetCaptureData(CaptureData* capture_data) { capture_data_ = capture_data; }
+
   virtual void Draw(GlCanvas* a_Canvas, PickingMode a_PickingMode, float z_offset = 0);
   virtual void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode,
                                 float z_offset = 0);
@@ -149,6 +153,7 @@ class Track : public Pickable, public std::enable_shared_from_this<Track> {
   std::shared_ptr<TriangleToggle> collapse_toggle_;
 
   orbit_gl::AccessibleTrack accessibility_;
+  CaptureData* capture_data_ = nullptr;
 };
 
 #endif

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -345,26 +345,6 @@ ThreadTrack* TrackManager::GetOrCreateThreadTrack(int32_t tid) {
     track = std::make_shared<ThreadTrack>(time_graph_, tid, app_);
     AddTrack(track);
     thread_tracks_[tid] = track;
-    track->SetTrackColor(TimeGraph::GetThreadColor(tid));
-    if (tid == orbit_base::kAllThreadsOfAllProcessesTid) {
-      track->SetName("All tracepoint events");
-      track->SetLabel("All tracepoint events");
-    } else if (tid == orbit_base::kAllProcessThreadsTid) {
-      // This is the process track.
-      const CaptureData& capture_data = app_->GetCaptureData();
-      std::string process_name = capture_data.process_name();
-      track->SetName(process_name);
-      const std::string_view all_threads = " (all_threads)";
-      track->SetLabel(process_name.append(all_threads));
-      track->SetNumberOfPrioritizedTrailingCharacters(all_threads.size() - 1);
-    } else {
-      const std::string& thread_name = time_graph_->GetThreadNameFromTid(tid);
-      track->SetName(thread_name);
-      std::string tid_str = std::to_string(tid);
-      std::string track_label = absl::StrFormat("%s [%s]", thread_name, tid_str);
-      track->SetNumberOfPrioritizedTrailingCharacters(tid_str.size() + 2);
-      track->SetLabel(track_label);
-    }
   }
   return track.get();
 }
@@ -374,12 +354,6 @@ GpuTrack* TrackManager::GetOrCreateGpuTrack(uint64_t timeline_hash) {
   std::shared_ptr<GpuTrack> track = gpu_tracks_[timeline_hash];
   if (track == nullptr) {
     track = std::make_shared<GpuTrack>(time_graph_, timeline_hash, app_);
-    std::string timeline = app_->GetStringManager()->Get(timeline_hash).value_or("");
-    std::string label = orbit_gl::MapGpuTimelineToTrackLabel(timeline);
-    track->SetName(timeline);
-    track->SetLabel(label);
-    // This min combine two cases, label == timeline and when label includes timeline
-    track->SetNumberOfPrioritizedTrailingCharacters(std::min(label.size(), timeline.size() + 2));
     AddTrack(track);
     gpu_tracks_[timeline_hash] = track;
   }
@@ -391,8 +365,6 @@ GraphTrack* TrackManager::GetOrCreateGraphTrack(const std::string& name) {
   std::shared_ptr<GraphTrack> track = graph_tracks_[name];
   if (track == nullptr) {
     track = std::make_shared<GraphTrack>(time_graph_, name);
-    track->SetName(name);
-    track->SetLabel(name);
     AddTrack(track);
     graph_tracks_[name] = track;
   }

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -55,8 +55,6 @@ void TrackManager::Clear() {
   tracepoints_system_wide_track_ = GetOrCreateThreadTrack(orbit_base::kAllThreadsOfAllProcessesTid);
 }
 
-void TrackManager::SetStringManager(StringManager* str_manager) { string_manager_ = str_manager; }
-
 std::vector<Track*> TrackManager::GetAllTracks() const {
   std::vector<Track*> tracks;
   for (auto track : all_tracks_) {
@@ -378,8 +376,8 @@ GpuTrack* TrackManager::GetOrCreateGpuTrack(uint64_t timeline_hash) {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
   std::shared_ptr<GpuTrack> track = gpu_tracks_[timeline_hash];
   if (track == nullptr) {
-    track = std::make_shared<GpuTrack>(time_graph_, string_manager_, timeline_hash, app_);
-    std::string timeline = string_manager_->Get(timeline_hash).value_or("");
+    track = std::make_shared<GpuTrack>(time_graph_, timeline_hash, app_);
+    std::string timeline = app_->GetStringManager()->Get(timeline_hash).value_or("");
     std::string label = orbit_gl::MapGpuTimelineToTrackLabel(timeline);
     track->SetName(timeline);
     track->SetLabel(label);

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -334,9 +334,6 @@ SchedulerTrack* TrackManager::GetOrCreateSchedulerTrack() {
     track = std::make_shared<SchedulerTrack>(time_graph_, app_);
     AddTrack(track);
     scheduler_track_ = track;
-    uint32_t num_cores = time_graph_->GetNumCores();
-    time_graph_->GetLayout().SetNumCores(num_cores);
-    scheduler_track_->SetLabel(absl::StrFormat("Scheduler (%u cores)", num_cores));
   }
   return track.get();
 }

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -46,6 +46,7 @@ class TrackManager {
     return tracepoints_system_wide_track_;
   }
 
+  void SetCaptureData(CaptureData* capture_data);
   void SortTracks();
   void SetFilter(const std::string& filter);
 
@@ -94,6 +95,7 @@ class TrackManager {
   std::vector<Track*> visible_tracks_;
 
   float tracks_total_height_;
+  CaptureData* capture_data_ = nullptr;
 
   OrbitApp* app_ = nullptr;
 };

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -46,9 +46,6 @@ class TrackManager {
     return tracepoints_system_wide_track_;
   }
 
-  void SetStringManager(StringManager* str_manager);
-  [[nodiscard]] const StringManager* GetStringManager() const { return string_manager_; }
-
   void SortTracks();
   void SetFilter(const std::string& filter);
 
@@ -97,7 +94,6 @@ class TrackManager {
   std::vector<Track*> visible_tracks_;
 
   float tracks_total_height_;
-  StringManager* string_manager_;
 
   OrbitApp* app_ = nullptr;
 };


### PR DESCRIPTION
Replaced https://github.com/google/orbit/pull/1615. Is a little bigger, but I've addressed comments from there and make a little bit more.

In the process of making UnitTests for the Tracks, we want to erase
most dependencies to TimeGraph to easily test TrackManager. Also we want
to get rid of the circular dependence from TimeGraph and the Tracks.

In this PR we:

 - Call properly TimeGraph's static methods

 - Remove StringManager from TimeGraph & TrackManager
 
 - Move num_cores to SchedulerTrack
 
 - Initialization is inside Tracks
 
 - Erase Track's dependence to TimeGraph::GetCaptureData

Bugs related:
https://b/176086740
https://b/176056427

Future bug:
http://b/177885083

Test: Start a new capture/Stop.
