### PR TITLE
Remove enable_stale_features flag and "Callstack" tab

### DIFF
--- a/src/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
+++ b/src/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
@@ -29,9 +29,6 @@
 
 // Hack: This is declared in a header we include here
 // and the definition needs to take place somewhere.
-ABSL_FLAG(bool, enable_stale_features, false,
-          "Enable obsolete features that are not working or are not "
-          "implemented in the client's UI");
 ABSL_FLAG(bool, devmode, false, "Enable developer mode in the client's UI");
 ABSL_FLAG(bool, local, false, "Connects to local instance of OrbitService");
 ABSL_FLAG(uint16_t, sampling_rate, 1000, "Frequency of callstack sampling in samples per second");

--- a/src/OrbitGl/ClientFlags.cpp
+++ b/src/OrbitGl/ClientFlags.cpp
@@ -7,10 +7,6 @@
 #include <cstdint>
 #include <string>
 
-ABSL_FLAG(bool, enable_stale_features, false,
-          "Enable obsolete features that are not working or are not "
-          "implemented in the client's UI");
-
 ABSL_FLAG(bool, devmode, false, "Enable developer mode in the client's UI");
 
 ABSL_FLAG(bool, nodeploy, false, "Disable automatic deployment of OrbitService");

--- a/src/OrbitGl/ModuleListFuzzer.cpp
+++ b/src/OrbitGl/ModuleListFuzzer.cpp
@@ -18,9 +18,6 @@
 
 // Hack: This is declared in a header we include here
 // and the definition needs to take place somewhere.
-ABSL_FLAG(bool, enable_stale_features, false,
-          "Enable obsolete features that are not working or are not "
-          "implemented in the client's UI");
 ABSL_FLAG(bool, devmode, false, "Enable developer mode in the client's UI");
 ABSL_FLAG(bool, local, false, "Connects to local instance of OrbitService");
 ABSL_FLAG(uint16_t, sampling_rate, 1000, "Frequency of callstack sampling in samples per second");

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -97,7 +97,6 @@
 #include "types.h"
 #include "ui_orbitmainwindow.h"
 
-ABSL_DECLARE_FLAG(bool, enable_stale_features);
 ABSL_DECLARE_FLAG(bool, devmode);
 ABSL_DECLARE_FLAG(bool, enable_tracepoint_feature);
 ABSL_DECLARE_FLAG(bool, enable_tutorials_feature);
@@ -364,15 +363,9 @@ void OrbitMainWindow::SetupMainWindow(uint32_t font_size) {
     ui->RightTabWidget->removeTab(ui->RightTabWidget->indexOf(ui->debugTab));
   }
 
-  ui->CallStackView->Initialize(data_view_factory->GetOrCreateDataView(DataViewType::kCallstack),
-                                SelectionType::kExtended, FontType::kDefault);
   ui->TracepointsList->Initialize(
       data_view_factory->GetOrCreateDataView(DataViewType::kTracepoints), SelectionType::kExtended,
       FontType::kDefault);
-
-  if (!absl::GetFlag(FLAGS_enable_stale_features)) {
-    ui->RightTabWidget->removeTab(ui->RightTabWidget->indexOf(ui->CallStackTab));
-  }
 
   if (!absl::GetFlag(FLAGS_enable_tracepoint_feature)) {
     ui->RightTabWidget->removeTab(ui->RightTabWidget->indexOf(ui->tracepointsTab));
@@ -665,7 +658,6 @@ OrbitMainWindow::~OrbitMainWindow() {
   ui->selectionTopDownWidget->Deinitialize();
   ui->topDownWidget->Deinitialize();
   ui->TracepointsList->Deinitialize();
-  ui->CallStackView->Deinitialize();
   ui->liveFunctions->Deinitialize();
 
   ui->samplingReport->Deinitialize();
@@ -698,9 +690,6 @@ void OrbitMainWindow::OnRefreshDataViewPanels(DataViewType a_Type) {
 
 void OrbitMainWindow::UpdatePanel(DataViewType a_Type) {
   switch (a_Type) {
-    case DataViewType::kCallstack:
-      ui->CallStackView->Refresh();
-      break;
     case DataViewType::kFunctions:
       ui->FunctionsList->Refresh();
       break;

--- a/src/OrbitQt/orbitmainwindow.ui
+++ b/src/OrbitQt/orbitmainwindow.ui
@@ -265,20 +265,6 @@ QPushButton:disabled {
          </item>
         </layout>
        </widget>
-       <widget class="QWidget" name="CallStackTab">
-        <attribute name="title">
-         <string>Callstack</string>
-        </attribute>
-        <layout class="QGridLayout" name="gridLayout_8">
-         <item row="0" column="0">
-          <widget class="OrbitDataViewPanel" name="CallStackView" native="true">
-           <property name="accessibleName">
-            <string>CallstackDataView</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
        <widget class="QWidget" name="liveTab">
         <attribute name="title">
          <string>Live</string>


### PR DESCRIPTION
The "Callstack" tab is obsolete and unmaintaned, let's remove it.
This also clarifies the usage of `DataViewType::kCallstack` (callstack in the
"Sampling" tab).
Let's also remove the flag, that is now unnecessary and was once guarding more
UI parts.