### PR TITLE
Remove unused enum from orbit_qt::Error

### DIFF
--- a/src/OrbitQt/Error.cpp
+++ b/src/OrbitQt/Error.cpp
@@ -25,8 +25,6 @@ std::string ErrorCategory::message(int condition) const {
       return "Could not start tunnel to remote.";
     case Error::kUserCanceledServiceDeployment:
       return "User canceled the deployment.";
-    case Error::kUserClosedStartUpWindow:
-      return "User closed window.";
   }
 
   return absl::StrFormat("Unknown error condition: %i.", condition);

--- a/src/OrbitQt/Error.h
+++ b/src/OrbitQt/Error.h
@@ -18,8 +18,7 @@ enum class Error {
   kCouldNotUploadSignature,
   kCouldNotInstallPackage,
   kCouldNotStartTunnel,
-  kUserCanceledServiceDeployment,
-  kUserClosedStartUpWindow
+  kUserCanceledServiceDeployment
 };
 
 struct ErrorCategory : std::error_category {


### PR DESCRIPTION
This was only used in the old ui