### PR TITLE
Improve BatcherId/PickingType encoding logic  

### DIFF
--- a/src/OrbitGl/Batcher.cpp
+++ b/src/OrbitGl/Batcher.cpp
@@ -266,6 +266,9 @@ const PickingUserData* Batcher::GetUserData(PickingId id) const {
       return user_data_[id.element_id].get();
     case PickingType::kPickable:
       return nullptr;
+    case PickingType::kCount:
+      UNREACHABLE();
+      return nullptr;
   }
 
   UNREACHABLE();

--- a/src/OrbitGl/Batcher.cpp
+++ b/src/OrbitGl/Batcher.cpp
@@ -268,7 +268,6 @@ const PickingUserData* Batcher::GetUserData(PickingId id) const {
       return nullptr;
     case PickingType::kCount:
       UNREACHABLE();
-      return nullptr;
   }
 
   UNREACHABLE();

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -244,7 +244,7 @@ void CaptureWindow::Hover(int x, int y) {
   uint8_t pixels[1 * 1 * 4] = {0, 0, 0, 0};
   glReadPixels(x, m_MainWindowHeight - y, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, &pixels[0]);
 
-  auto pick_id = absl::bit_cast<PickingId>(pixels);
+  auto pick_id = PickingId::FromPixelValue(absl::bit_cast<uint32_t>(pixels));
   Batcher& batcher = GetBatcherById(pick_id.batcher_id);
 
   std::string tooltip;

--- a/src/OrbitGl/PickingManager.cpp
+++ b/src/OrbitGl/PickingManager.cpp
@@ -96,6 +96,6 @@ bool PickingManager::IsThisElementPicked(const Pickable* pickable) const {
 }
 
 Color PickingManager::ColorFromPickingID(PickingId id) const {
-  auto color_values = absl::bit_cast<std::array<uint8_t, 4>>(id);
+  auto color_values = absl::bit_cast<std::array<uint8_t, 4>>(id.ToPixelValue());
   return Color(color_values[0], color_values[1], color_values[2], color_values[3]);
 }

--- a/src/OrbitGl/PickingManager.h
+++ b/src/OrbitGl/PickingManager.h
@@ -68,6 +68,8 @@ struct PickingId {
   [[nodiscard]] inline static PickingId Create(PickingType type, uint32_t element_id,
                                                BatcherId batcher_id = BatcherId::kTimeGraph) {
     CHECK(element_id >> kElementIDBitSize == 0);
+    CHECK(type >= PickingType{} && type < PickingType::kCount);
+    CHECK(batcher_id >= BatcherId{} && batcher_id < BatcherId::kCount);
     PickingId result{};
     result.type = type;
     result.element_id = element_id;
@@ -77,10 +79,8 @@ struct PickingId {
 
   [[nodiscard]] inline static PickingId FromPixelValue(uint32_t value) {
     const Layout layout = absl::bit_cast<Layout, uint32_t>(value);
-    CHECK(layout.type >= static_cast<uint32_t>(PickingType::kInvalid) &&
-          layout.type <= static_cast<uint32_t>(PickingType::kPickable));
-    CHECK(layout.batcher_id >= static_cast<uint32_t>(BatcherId::kTimeGraph) &&
-          layout.batcher_id <= static_cast<uint32_t>(BatcherId::kUi));
+    CHECK(layout.type < static_cast<uint32_t>(PickingType::kCount));
+    CHECK(layout.batcher_id < static_cast<uint32_t>(BatcherId::kCount));
 
     PickingId id{};
     id.element_id = layout.element_id;

--- a/src/OrbitGl/PickingManager.h
+++ b/src/OrbitGl/PickingManager.h
@@ -33,7 +33,7 @@ class Pickable {
   [[nodiscard]] virtual std::string GetTooltip() const { return ""; }
 };
 
-enum class PickingType { kInvalid = 0, kLine = 1, kBox = 2, kTriangle = 3, kPickable = 4 };
+enum class PickingType { kInvalid, kLine, kBox, kTriangle, kPickable, kCount };
 
 // Instances of batchers used to draw must be in 1:1 correspondence with
 // values in the following enum. Currently, two batchers are used, one to draw
@@ -45,7 +45,7 @@ enum class PickingType { kInvalid = 0, kLine = 1, kBox = 2, kTriangle = 3, kPick
 // in the bits remaining after encoding the batcher id, and the
 // PickingType, so adding more batchers or types has to be carefully
 // considered.
-enum class BatcherId { kTimeGraph, kUi };
+enum class BatcherId { kTimeGraph, kUi, kCount };
 
 struct PickingId {
   static constexpr uint32_t kElementIDBitSize = 28;
@@ -60,6 +60,10 @@ struct PickingId {
 
   static_assert(sizeof(Layout) == sizeof(uint32_t),
                 "Layout needs to have the size of a single uint32_t.");
+  static_assert(1 << kPickingTypeBitSize >= static_cast<int>(PickingType::kCount),
+                "PickingType cannot be encoded in the specified number of bits.");
+  static_assert(1 << kBatcherIDBitSize >= static_cast<int>(BatcherId::kCount),
+                "BatcherId cannot be encoded in the specified number of bits.");
 
   [[nodiscard]] inline static PickingId Create(PickingType type, uint32_t element_id,
                                                BatcherId batcher_id = BatcherId::kTimeGraph) {


### PR DESCRIPTION
Integrate Henning's suggestion to get rid of annoying warnings related to
BatcherId/PickingType encoding logic. Add additional static asserts to make 
sure we allocate enough bits for the number of entries we need to encode.