### PR TITLE
Fix the flickering capture toolbar extension popup

### DIFF
--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -590,6 +590,18 @@ void OrbitMainWindow::UpdateCaptureStateDependentWidgets() {
   }
 }
 
+void OrbitMainWindow::UpdateProcessConnectionStateDependentWidgets() {
+  CaptureClient::State capture_state = app_->GetCaptureState();
+  const bool is_capturing = capture_state != CaptureClient::State::kStopped;
+  const bool is_connected = app_->IsConnectedToInstance();
+  const bool is_target_process_running = target_process_state_ == TargetProcessState::kRunning;
+
+  ui->actionToggle_Capture->setEnabled(
+      capture_state == CaptureClient::State::kStarted ||
+      (capture_state == CaptureClient::State::kStopped && is_target_process_running));
+  ui->actionOpen_Preset->setEnabled(!is_capturing && is_connected);
+}
+
 void OrbitMainWindow::UpdateActiveTabsAfterSelection(bool selection_has_samples) {
   const QTabWidget* capture_parent = FindParentTabWidget(ui->CaptureTab);
 
@@ -1196,7 +1208,7 @@ void OrbitMainWindow::OnProcessListUpdated(
     target_label_->setToolTip({});
     target_process_state_ = TargetProcessState::kRunning;
   }
-  UpdateCaptureStateDependentWidgets();
+  UpdateProcessConnectionStateDependentWidgets();
 }
 
 orbit_qt::TargetConfiguration OrbitMainWindow::ClearTargetConfiguration() {

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -143,6 +143,7 @@ class OrbitMainWindow : public QMainWindow {
 
   void CreateTabBarContextMenu(QTabWidget* tab_widget, int tab_index, const QPoint pos);
   void UpdateCaptureStateDependentWidgets();
+  void UpdateProcessConnectionStateDependentWidgets();
 
   void UpdateActiveTabsAfterSelection(bool selection_has_samples);
 


### PR DESCRIPTION
When the user moves the splitter, shrinks down the main window, or works on a very low resolution screen, the capture toolbar extension toolbar keeps flickering. 

The reason is that every time when the process list updates (i.e., `OnProcessListUpdated(...)` triggered), we reset the icon of capture toggle button (i.e., in `UpdateCaptureStateDependentWidgets()`) and so cause the toolbar to re-insert every actions.

To fix the above problem, and also consider that these is no need to update every capture state dependent widget when the process connection state changes, we add the `UpdateProcessConnectionStateDependentWidgets()` method which only updates the widget affected by the process connection states when the process list is updated.

Bug: http://b/178063378
Blocking bug: http://b/169397517 (in PR https://github.com/google/orbit/pull/1695)
Test: Move the splitter to the left, click the capture toolbar extension button on the right sider, and then check the extension popup does not flicker any more.