### PR TITLE
Use std::optional rather than address of const ref or address of map …

### DIFF
--- a/src/OrbitCaptureClient/GpuQueueSubmissionProcessor.cpp
+++ b/src/OrbitCaptureClient/GpuQueueSubmissionProcessor.cpp
@@ -301,7 +301,7 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuDebugMarkers(
       submission_meta_info.post_submission_cpu_timestamp();
 
   static constexpr int32_t kUnknownThreadId = -1;
-  
+
   for (const auto& completed_marker : gpu_queue_submission.completed_markers()) {
     CHECK(first_command_buffer != std::nullopt);
     TimerInfo marker_timer;

--- a/src/OrbitCaptureClient/GpuQueueSubmissionProcessor.cpp
+++ b/src/OrbitCaptureClient/GpuQueueSubmissionProcessor.cpp
@@ -307,7 +307,7 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuDebugMarkers(
   // The "begin markers" are likely in the same submission as their "end marker",
   // thus will be erased after the last completed marker was processed.
   // This would also erase the current "gpu_queue_submission" if we would do it
-  // right away. 
+  // right away.
   // To prevent this, we do our processing first, collect all "begin markers" to
   // decrement, and decrement them at then very and.
   std::vector<std::tuple<int32_t /*thread_id*/, uint64_t /*submit_time_ns*/,
@@ -371,9 +371,9 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuDebugMarkers(
         marker_timer.set_thread_id(kUnknownThreadId);
       }
 
-	  // Remember, it would be safe to decrement (and thus possible erease) the "begin marker"
-	  // here right away, as its begin submission might be the same as "gpu_queue_submission",
-	  // which we still use afterwards.
+      // Remember, it would not be safe to decrement (and thus possible erese) the "begin marker"
+      // here right away, as its begin submission might be the same as "gpu_queue_submission",
+      // which we still use afterwards.
       begin_markers_to_decrement.emplace_back(begin_marker_thread_id,
                                               matching_begin_job->amdgpu_cs_ioctl_time_ns(),
                                               begin_marker_post_submission_cpu_timestamp);

--- a/src/OrbitCaptureClient/GpuQueueSubmissionProcessor.cpp
+++ b/src/OrbitCaptureClient/GpuQueueSubmissionProcessor.cpp
@@ -10,9 +10,9 @@ using orbit_client_protos::Color;
 using orbit_client_protos::TimerInfo;
 
 using orbit_grpc_protos::GpuCommandBuffer;
+using orbit_grpc_protos::GpuDebugMarker;
 using orbit_grpc_protos::GpuJob;
 using orbit_grpc_protos::GpuQueueSubmission;
-using orbit_grpc_protos::GpuDebugMarker;
 
 std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuQueueSubmission(
     const orbit_grpc_protos::GpuQueueSubmission& gpu_queue_submission,
@@ -331,11 +331,12 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuDebugMarkers(
           submission_thread_id == begin_marker_thread_id) {
         begin_submission_first_command_buffer = ExtractFirstCommandBuffer(gpu_queue_submission);
       } else {
-        std::optional<GpuQueueSubmission> matching_begin_submission = FindMatchingGpuQueueSubmission(
-            begin_marker_thread_id, begin_marker_post_submission_cpu_timestamp);
+        std::optional<GpuQueueSubmission> matching_begin_submission =
+            FindMatchingGpuQueueSubmission(begin_marker_thread_id,
+                                           begin_marker_post_submission_cpu_timestamp);
         // Note that we receive submissions of a single queue in order (by CPU submission time). So
-        // if there is no matching "begin submission", the "begin" was submitted before the "end" and
-        // we lost the record of the "begin submission" (which should not happen).
+        // if there is no matching "begin submission", the "begin" was submitted before the "end"
+        // and we lost the record of the "begin submission" (which should not happen).
         CHECK(matching_begin_submission.has_value());
         begin_submission_first_command_buffer =
             ExtractFirstCommandBuffer(matching_begin_submission.value());

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/GpuQueueSubmissionProcessor.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/GpuQueueSubmissionProcessor.h
@@ -6,6 +6,7 @@
 #define ORBIT_CAPTURE_CLIENT_GPU_QUEUE_SUBMISSION_PROCESSOR_H_
 
 #include <absl/container/flat_hash_map.h>
+#include <absl/container/node_hash_map.h>
 
 #include <algorithm>
 #include <functional>
@@ -86,15 +87,16 @@ class GpuQueueSubmissionProcessor {
       const orbit_grpc_protos::GpuQueueSubmission& gpu_queue_submission);
 
   // Finds the GpuJob that is fully inside the given timestamps and happened on the given thread id.
-  // Returns `nullopt` if there is no such job.
+  // Returns `nullptr` if there is no such job.
   [[nodiscard]] const orbit_grpc_protos::GpuJob* FindMatchingGpuJob(
       int32_t thread_id, uint64_t pre_submission_cpu_timestamp,
       uint64_t post_submission_cpu_timestamp);
 
   // Finds the GpuQueueSubmission that fully contains the given timestamp and happened on the given
-  // thread id. Returns `nullopt` if there is no such submission.
-  [[nodiscard]]const orbit_grpc_protos::GpuQueueSubmission* FindMatchingGpuQueueSubmission(
+  // thread id. Returns `nullptr` if there is no such submission.
+  [[nodiscard]] const orbit_grpc_protos::GpuQueueSubmission* FindMatchingGpuQueueSubmission(
       int32_t thread_id, uint64_t submit_time);
+
   [[nodiscard]] bool HasUnprocessedBeginMarkers(int32_t thread_id,
                                                 uint64_t post_submission_timestamp) const;
 
@@ -105,9 +107,9 @@ class GpuQueueSubmissionProcessor {
 
   void DeleteSavedGpuSubmission(int32_t thread_id, uint64_t post_submission_timestamp);
 
-  absl::flat_hash_map<int32_t, std::map<uint64_t, orbit_grpc_protos::GpuJob>>
+  absl::node_hash_map<int32_t, std::map<uint64_t, orbit_grpc_protos::GpuJob>>
       tid_to_submission_time_to_gpu_job_;
-  absl::flat_hash_map<int32_t, std::map<uint64_t, orbit_grpc_protos::GpuQueueSubmission>>
+  absl::node_hash_map<int32_t, std::map<uint64_t, orbit_grpc_protos::GpuQueueSubmission>>
       tid_to_post_submission_time_to_gpu_submission_;
   absl::flat_hash_map<int32_t, absl::flat_hash_map<uint64_t, uint32_t>>
       tid_to_post_submission_time_to_num_begin_markers_;

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/GpuQueueSubmissionProcessor.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/GpuQueueSubmissionProcessor.h
@@ -85,13 +85,15 @@ class GpuQueueSubmissionProcessor {
   [[nodiscard]] static std::optional<orbit_grpc_protos::GpuCommandBuffer> ExtractFirstCommandBuffer(
       const orbit_grpc_protos::GpuQueueSubmission& gpu_queue_submission);
 
-  [[nodiscard]] const orbit_grpc_protos::GpuJob* FindMatchingGpuJob(
+  // Finds the GpuJob that is fully inside the given timestamps and happened on the given thread id.
+  // Returns `nullopt` if there is no such job.
+  [[nodiscard]] std::optional<orbit_grpc_protos::GpuJob> FindMatchingGpuJob(
       int32_t thread_id, uint64_t pre_submission_cpu_timestamp,
       uint64_t post_submission_cpu_timestamp);
 
   // Finds the GpuQueueSubmission that fully contains the given timestamp and happened on the given
-  // thread id. Returns `nullptr` if there is no such submission.
-  [[nodiscard]] const orbit_grpc_protos::GpuQueueSubmission* FindMatchingGpuQueueSubmission(
+  // thread id. Returns `nullopt` if there is no such submission.
+  [[nodiscard]] std::optional<orbit_grpc_protos::GpuQueueSubmission> FindMatchingGpuQueueSubmission(
       int32_t thread_id, uint64_t submit_time);
   [[nodiscard]] bool HasUnprocessedBeginMarkers(int32_t thread_id,
                                                 uint64_t post_submission_timestamp) const;

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/GpuQueueSubmissionProcessor.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/GpuQueueSubmissionProcessor.h
@@ -87,13 +87,13 @@ class GpuQueueSubmissionProcessor {
 
   // Finds the GpuJob that is fully inside the given timestamps and happened on the given thread id.
   // Returns `nullopt` if there is no such job.
-  [[nodiscard]] std::optional<orbit_grpc_protos::GpuJob> FindMatchingGpuJob(
+  [[nodiscard]] const orbit_grpc_protos::GpuJob* FindMatchingGpuJob(
       int32_t thread_id, uint64_t pre_submission_cpu_timestamp,
       uint64_t post_submission_cpu_timestamp);
 
   // Finds the GpuQueueSubmission that fully contains the given timestamp and happened on the given
   // thread id. Returns `nullopt` if there is no such submission.
-  [[nodiscard]] std::optional<orbit_grpc_protos::GpuQueueSubmission> FindMatchingGpuQueueSubmission(
+  [[nodiscard]]const orbit_grpc_protos::GpuQueueSubmission* FindMatchingGpuQueueSubmission(
       int32_t thread_id, uint64_t submit_time);
   [[nodiscard]] bool HasUnprocessedBeginMarkers(int32_t thread_id,
                                                 uint64_t post_submission_timestamp) const;


### PR DESCRIPTION
…element.

This fixes the flaky CaptureEventProcessor test. `FindMatching*` returned a
pointer to a map element. However, this map is not garantueed to be pointer
stable. Thus, we now return std::optional instead.

Also we used the address of operator on a const-ref., which is also
undefined. Again, we are now using std::optional here.

Test: Run CaptureEventProcessorTest a couple of times.