### PR TITLE
UI fixes after capture toolbar change

### DIFF
--- a/src/OrbitQt/FilterPanelWidget.ui
+++ b/src/OrbitQt/FilterPanelWidget.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QLineEdit" name="filterTracks">
      <property name="accessibleName">
-      <string>filter</string>
+      <string>FilterTracks</string>
      </property>
      <property name="styleSheet">
       <string notr="true">QLineEdit {
@@ -35,7 +35,7 @@
    <item>
     <widget class="QLineEdit" name="filterFunctions">
      <property name="accessibleName">
-      <string>filter</string>
+      <string>FilterFunctions</string>
      </property>
      <property name="placeholderText">
       <string>Filter Functions</string>
@@ -69,7 +69,7 @@
       <string/>
      </property>
      <property name="pixmap">
-      <pixmap>:/actions/access_time</pixmap>
+      <pixmap resource="../../icons/orbiticons.qrc">:/actions/access_time</pixmap>
      </property>
      <property name="scaledContents">
       <bool>true</bool>
@@ -86,7 +86,7 @@
   </layout>
  </widget>
  <resources>
-  <include location="../icons/orbiticons.qrc"/>
+  <include location="../../icons/orbiticons.qrc"/>
  </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
Fixing issues introduced with https://github.com/google/orbit/pull/1695

- Resource file was referenced incorrectly
- Accessible names for "filterFunctions" and "filterTracks" were
changed, causing the track sorting E2E test to fail

This was caught by the E2E tests here: b/178171558