### PR TITLE
Rename TracerListener::OnModulesUpdate to OnModuleUpdate

### DIFF
--- a/src/LinuxTracing/GpuTracepointEventProcessorTest.cpp
+++ b/src/LinuxTracing/GpuTracepointEventProcessorTest.cpp
@@ -36,7 +36,7 @@ class MockTracerListener : public TracerListener {
   MOCK_METHOD(void, OnThreadStateSlice, (orbit_grpc_protos::ThreadStateSlice), (override));
   MOCK_METHOD(void, OnAddressInfo, (orbit_grpc_protos::AddressInfo), (override));
   MOCK_METHOD(void, OnTracepointEvent, (orbit_grpc_protos::TracepointEvent), (override));
-  MOCK_METHOD(void, OnModulesUpdate, (orbit_grpc_protos::ModuleUpdateEvent), (override));
+  MOCK_METHOD(void, OnModuleUpdate, (orbit_grpc_protos::ModuleUpdateEvent), (override));
 };
 
 class GpuTracepointEventProcessorTest : public ::testing::Test {

--- a/src/LinuxTracing/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracing/LinuxTracingIntegrationTest.cpp
@@ -190,7 +190,7 @@ class BufferTracerListener : public TracerListener {
     events_.emplace_back(std::move(event));
   }
 
-  void OnModulesUpdate(orbit_grpc_protos::ModuleUpdateEvent module_update_event) override {
+  void OnModuleUpdate(orbit_grpc_protos::ModuleUpdateEvent module_update_event) override {
     orbit_grpc_protos::CaptureEvent event;
     *event.mutable_module_update_event() = std::move(module_update_event);
     events_.emplace_back(std::move(event));

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -209,12 +209,12 @@ void UprobesUnwindingVisitor::visit(MmapPerfEvent* event) {
   // This Sort is important here since libunwindstack does binary search for module by pc.
   current_maps_->Sort();
 
-  orbit_grpc_protos::ModuleUpdateEvent modules_update_event;
-  modules_update_event.set_pid(event->pid());
-  modules_update_event.set_timestamp_ns(event->GetTimestamp());
-  *modules_update_event.mutable_module() = std::move(module_info);
+  orbit_grpc_protos::ModuleUpdateEvent module_update_event;
+  module_update_event.set_pid(event->pid());
+  module_update_event.set_timestamp_ns(event->GetTimestamp());
+  *module_update_event.mutable_module() = std::move(module_info);
 
-  listener_->OnModulesUpdate(std::move(modules_update_event));
+  listener_->OnModuleUpdate(std::move(module_update_event));
 }
 
 }  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/include/LinuxTracing/TracerListener.h
+++ b/src/LinuxTracing/include/LinuxTracing/TracerListener.h
@@ -21,7 +21,7 @@ class TracerListener {
   virtual void OnThreadStateSlice(orbit_grpc_protos::ThreadStateSlice thread_state_slice) = 0;
   virtual void OnAddressInfo(orbit_grpc_protos::AddressInfo address_info) = 0;
   virtual void OnTracepointEvent(orbit_grpc_protos::TracepointEvent tracepoint_event) = 0;
-  virtual void OnModulesUpdate(orbit_grpc_protos::ModuleUpdateEvent module_update_event) = 0;
+  virtual void OnModuleUpdate(orbit_grpc_protos::ModuleUpdateEvent module_update_event) = 0;
 };
 
 }  // namespace orbit_linux_tracing

--- a/src/OrbitService/LinuxTracingHandler.cpp
+++ b/src/OrbitService/LinuxTracingHandler.cpp
@@ -150,8 +150,7 @@ void LinuxTracingHandler::OnTracepointEvent(orbit_grpc_protos::TracepointEvent t
   capture_event_buffer_->AddEvent(std::move(event));
 }
 
-void LinuxTracingHandler::OnModulesUpdate(
-    orbit_grpc_protos::ModuleUpdateEvent module_update_event) {
+void LinuxTracingHandler::OnModuleUpdate(orbit_grpc_protos::ModuleUpdateEvent module_update_event) {
   orbit_grpc_protos::CaptureEvent event;
   *event.mutable_module_update_event() = std::move(module_update_event);
 

--- a/src/OrbitService/LinuxTracingHandler.h
+++ b/src/OrbitService/LinuxTracingHandler.h
@@ -45,7 +45,7 @@ class LinuxTracingHandler : public orbit_linux_tracing::TracerListener {
   void OnThreadStateSlice(orbit_grpc_protos::ThreadStateSlice thread_state_slice) override;
   void OnAddressInfo(orbit_grpc_protos::AddressInfo address_info) override;
   void OnTracepointEvent(orbit_grpc_protos::TracepointEvent tracepoint_event) override;
-  void OnModulesUpdate(orbit_grpc_protos::ModuleUpdateEvent module_update_event) override;
+  void OnModuleUpdate(orbit_grpc_protos::ModuleUpdateEvent module_update_event) override;
 
  private:
   CaptureEventBuffer* capture_event_buffer_;


### PR DESCRIPTION
To match the event's name.