### PR TITLE
Actually start ProducerSideService/Server in OrbitService

### DIFF
--- a/src/Service/CMakeLists.txt
+++ b/src/Service/CMakeLists.txt
@@ -52,7 +52,8 @@ target_link_libraries(ServiceLib PUBLIC
         FramePointerValidator
         GrpcProtos
         LinuxTracing
-        OrbitVersion)
+        OrbitVersion
+        ProducerSideChannel)
 
 project(OrbitService)
 add_executable(OrbitService main.cpp)

--- a/src/Service/OrbitService.cpp
+++ b/src/Service/OrbitService.cpp
@@ -11,6 +11,7 @@
 
 #include <chrono>
 #include <cstdio>
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <thread>
@@ -21,7 +22,7 @@
 #include "ProducerSideChannel/ProducerSideChannel.h"
 #include "ProducerSideServer.h"
 
-namespace {
+namespace orbit_service {
 
 static std::string ReadStdIn() {
   int tmp = fgetc(stdin);
@@ -43,9 +44,42 @@ static bool IsSshConnectionAlive(
                                                           last_ssh_message)
              .count() < timeout_in_seconds;
 }
-}  // namespace
 
-namespace orbit_service {
+static std::unique_ptr<OrbitGrpcServer> CreateGrpcServer(uint16_t grpc_port) {
+  std::string grpc_address = absl::StrFormat("127.0.0.1:%d", grpc_port);
+  LOG("Starting gRPC server at %s", grpc_address);
+  std::unique_ptr<OrbitGrpcServer> grpc_server = OrbitGrpcServer::Create(grpc_address);
+  if (grpc_server == nullptr) {
+    ERROR("Unable to start gRPC server");
+    return nullptr;
+  }
+  LOG("gRPC server is running");
+  return grpc_server;
+}
+
+static std::unique_ptr<ProducerSideServer> BuildAndStartProducerSideServer() {
+  const std::filesystem::path unix_domain_socket_dir =
+      std::filesystem::path{orbit_producer_side_channel::kProducerSideUnixDomainSocketPath}
+          .parent_path();
+  std::error_code error_code;
+  std::filesystem::create_directories(unix_domain_socket_dir, error_code);
+  if (error_code) {
+    ERROR("Unable to create directory for socket for producer-side server: %s",
+          error_code.message());
+    return nullptr;
+  }
+
+  auto producer_side_server = std::make_unique<ProducerSideServer>();
+  LOG("Starting producer-side server at %s",
+      orbit_producer_side_channel::kProducerSideUnixDomainSocketPath);
+  if (!producer_side_server->BuildAndStart(
+          orbit_producer_side_channel::kProducerSideUnixDomainSocketPath)) {
+    ERROR("Unable to start producer-side server");
+    return nullptr;
+  }
+  LOG("Producer-side server is running");
+  return producer_side_server;
+}
 
 void OrbitService::Run(std::atomic<bool>* exit_requested) {
   LOG("Running Orbit Service version %s", orbit_core::GetVersion());
@@ -55,26 +89,16 @@ void OrbitService::Run(std::atomic<bool>* exit_requested) {
   LOG("**********************************");
 #endif
 
-  std::string grpc_address = absl::StrFormat("127.0.0.1:%d", grpc_port_);
-  LOG("Starting gRPC server at %s", grpc_address);
-  std::unique_ptr<OrbitGrpcServer> grpc_server;
-  grpc_server = OrbitGrpcServer::Create(grpc_address);
+  std::unique_ptr<OrbitGrpcServer> grpc_server = CreateGrpcServer(grpc_port_);
   if (grpc_server == nullptr) {
-    ERROR("Unable to start gRPC server");
     return;
   }
-  LOG("gRPC server is running");
 
-  LOG("Starting producer-side server at %s",
-      orbit_producer_side_channel::kProducerSideUnixDomainSocketPath);
-  ProducerSideServer producer_side_server;
-  if (!producer_side_server.BuildAndStart(
-          orbit_producer_side_channel::kProducerSideUnixDomainSocketPath)) {
-    ERROR("Unable to start producer-side server");
+  std::unique_ptr<ProducerSideServer> producer_side_server = BuildAndStartProducerSideServer();
+  if (producer_side_server == nullptr) {
     return;
   }
-  LOG("Producer-side server is running");
-  grpc_server->AddCaptureStartStopListener(&producer_side_server);
+  grpc_server->AddCaptureStartStopListener(producer_side_server.get());
 
   // Make stdin non-blocking.
   fcntl(STDIN_FILENO, F_SETFL, O_NONBLOCK);
@@ -98,8 +122,8 @@ void OrbitService::Run(std::atomic<bool>* exit_requested) {
     std::this_thread::sleep_for(std::chrono::seconds{1});
   }
 
-  producer_side_server.ShutdownAndWait();
-  grpc_server->RemoveCaptureStartStopListener(&producer_side_server);
+  producer_side_server->ShutdownAndWait();
+  grpc_server->RemoveCaptureStartStopListener(producer_side_server.get());
 
   grpc_server->Shutdown();
   grpc_server->Wait();


### PR DESCRIPTION
This is the final piece that enables the first iteration of the communication
between `CaptureEventProducer`s and OrbitService.

Bug: http://b/174028631

This change was blocked by security review http://b/177833637 but we should
now have to green light (somewhat).