### PR TITLE
Add test for metrics uploader client

### DIFF
--- a/src/MetricsUploader/MetricsUploaderWindowsTest.cpp
+++ b/src/MetricsUploader/MetricsUploaderWindowsTest.cpp
@@ -47,3 +47,9 @@ TEST(MetricsUploader, CreateTwoMetricsUploaders) {
   auto metrics_uploader2 = MetricsUploader::CreateMetricsUploader("MetricsUploaderCompleteClient");
   EXPECT_EQ(metrics_uploader2.has_value(), false);
 }
+
+TEST(MetricsUploader, CreateMetricsUploaderFromNonexistentClient) {
+  auto metrics_uploader =
+      MetricsUploader::CreateMetricsUploader("NonexistentMetricsUploaderClient");
+  EXPECT_EQ(metrics_uploader.has_value(), false);
+}

--- a/src/MetricsUploader/include/MetricsUploader/Result.h
+++ b/src/MetricsUploader/include/MetricsUploader/Result.h
@@ -16,6 +16,7 @@ enum Result {
   kMetricsUploaderServiceNotStarted,
   kSdkConfigNotLoaded,
   kCannotMarshalLogEvent,
+  kUnknownEventTypeName,
   kCannotQueueLogEvent,
   kClientNotInitialized,
   kCannotUnmarshalLogEvent


### PR DESCRIPTION
 - Add kUnknownEventTypeName to Result
 - Add test for MetricsUploader that verifies behavior when `.dll` is not present