### PR TITLE
Re-add metrics uploader

### DIFF
--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -143,10 +143,11 @@ void OpenDisassembly(const std::string& assembly, const DisassemblyReport& repor
 }  // namespace
 
 OrbitMainWindow::OrbitMainWindow(orbit_qt::TargetConfiguration target_configuration,
-                                 uint32_t font_size)
+                                 uint32_t font_size,
+                                 orbit_metrics_uploader::MetricsUploader* metrics_uploader)
     : QMainWindow(nullptr),
       main_thread_executor_{std::make_unique<orbit_qt::MainThreadExecutorImpl>()},
-      app_{OrbitApp::Create(main_thread_executor_.get())},
+      app_{OrbitApp::Create(main_thread_executor_.get(), metrics_uploader)},
       ui(new Ui::OrbitMainWindow),
       target_configuration_(std::move(target_configuration)) {
   SetupMainWindow(font_size);

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -55,7 +55,8 @@ class OrbitMainWindow : public QMainWindow {
  public:
   static constexpr int kEndSessionReturnCode = 1;
 
-  explicit OrbitMainWindow(orbit_qt::TargetConfiguration target_configuration, uint32_t font_size);
+  explicit OrbitMainWindow(orbit_qt::TargetConfiguration target_configuration, uint32_t font_size,
+                           orbit_metrics_uploader::MetricsUploader* metrics_uploader = nullptr);
   ~OrbitMainWindow() override;
 
   void RegisterGlWidget(OrbitGLWidget* widget) { gl_widgets_.push_back(widget); }


### PR DESCRIPTION
Creation of MetricsUploader was removed in one of the latest PRs. But I
think that it's too early to deprecate this feature, so I add it again.

Bug: http://b/170389366.

Test: start Orbit, check that the ORBIT_INITIALIZED and
ORBIT_CAPTURE_DURATION log messages appeared on the server.