### PR TITLE
Add JoinFutures and Future::Then helpers

### DIFF
--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(OrbitBase PRIVATE
         include/OrbitBase/Action.h
         include/OrbitBase/ExecutablePath.h
         include/OrbitBase/Future.h
+        include/OrbitBase/JoinFutures.h
         include/OrbitBase/Logging.h
         include/OrbitBase/MakeUniqueForOverwrite.h
         include/OrbitBase/GetProcessIds.h
@@ -38,6 +39,7 @@ target_sources(OrbitBase PRIVATE
 
 target_sources(OrbitBase PRIVATE
         ExecutablePath.cpp
+        JoinFutures.cpp
         ReadFileToString.cpp
         Logging.cpp
         SafeStrerror.cpp
@@ -67,14 +69,15 @@ target_compile_options(OrbitBaseTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(OrbitBaseTests PRIVATE
         ExecutablePathTest.cpp
+        FutureTest.cpp
+        JoinFuturesTest.cpp
         ReadFileToStringTest.cpp
         OrbitApiTest.cpp
         ProfilingTest.cpp
+        PromiseTest.cpp
         ThreadUtilsTest.cpp
         TracingTest.cpp
         UniqueResourceTest.cpp
-        FutureTest.cpp
-        PromiseTest.cpp
 )
 
 if (NOT WIN32)

--- a/src/OrbitBase/JoinFutures.cpp
+++ b/src/OrbitBase/JoinFutures.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "OrbitBase/JoinFutures.h"
+
+#include <memory>
+
+#include "OrbitBase/Future.h"
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/Promise.h"
+#include "absl/synchronization/mutex.h"
+
+namespace orbit_base {
+namespace {
+struct SharedStateJoin {
+  Promise<void> promise;
+  absl::Mutex mutex;
+  int incompleted_futures;
+};
+}  // namespace
+
+Future<void> JoinFutures(absl::Span<const Future<void>> futures) {
+  if (futures.empty()) {
+    Promise<void> promise;
+    promise.MarkFinished();
+    return promise.GetFuture();
+  }
+
+  auto shared_state = std::make_shared<SharedStateJoin>();
+  absl::MutexLock lock{&shared_state->mutex};
+
+  for (const auto& future : futures) {
+    CHECK(future.IsValid());
+    orbit_base::FutureRegisterContinuationResult const result =
+        future.RegisterContinuation([shared_state]() {
+          absl::MutexLock lock{&shared_state->mutex};
+          --shared_state->incompleted_futures;
+
+          if (shared_state->incompleted_futures == 0) {
+            shared_state->promise.MarkFinished();
+          }
+        });
+
+    if (result == orbit_base::FutureRegisterContinuationResult::kSuccessfullyRegistered) {
+      ++shared_state->incompleted_futures;
+    }
+  }
+
+  return shared_state->promise.GetFuture();
+}
+}  // namespace orbit_base

--- a/src/OrbitBase/JoinFuturesTest.cpp
+++ b/src/OrbitBase/JoinFuturesTest.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "OrbitBase/Future.h"
+#include "OrbitBase/JoinFutures.h"
+#include "OrbitBase/Promise.h"
+#include "absl/types/span.h"
+
+namespace orbit_base {
+
+TEST(JoinFutures, JoinEmptySpan) {
+  Future<void> joined_future = JoinFutures({});
+  EXPECT_TRUE(joined_future.IsValid());
+  EXPECT_TRUE(joined_future.IsFinished());
+}
+
+TEST(JoinFutures, JoinSpanWithOneElement) {
+  Promise<void> promise{};
+  Future<void> future = promise.GetFuture();
+
+  Future<void> joined_future = JoinFutures({future});
+  EXPECT_TRUE(joined_future.IsValid());
+  EXPECT_FALSE(joined_future.IsFinished());
+
+  promise.MarkFinished();
+  EXPECT_TRUE(joined_future.IsFinished());
+}
+
+TEST(JoinFutures, JoinSpanWithManyElements) {
+  Promise<void> promise0{};
+  Future<void> future0 = promise0.GetFuture();
+
+  Promise<void> promise1{};
+  Future<void> future1 = promise1.GetFuture();
+
+  Promise<void> promise2{};
+  Future<void> future2 = promise2.GetFuture();
+
+  Future<void> joined_future = JoinFutures({future0, future1, future2});
+  EXPECT_TRUE(joined_future.IsValid());
+  EXPECT_FALSE(joined_future.IsFinished());
+
+  promise0.MarkFinished();
+  EXPECT_FALSE(joined_future.IsFinished());
+
+  promise2.MarkFinished();
+  EXPECT_FALSE(joined_future.IsFinished());
+
+  promise1.MarkFinished();
+  EXPECT_TRUE(joined_future.IsFinished());
+}
+
+TEST(JoinFutures, JoinSpanWithDuplicateElements) {
+  Promise<void> promise{};
+  Future<void> future = promise.GetFuture();
+
+  Future<void> joined_future = JoinFutures({future, future});
+  EXPECT_TRUE(joined_future.IsValid());
+  EXPECT_FALSE(joined_future.IsFinished());
+
+  promise.MarkFinished();
+  EXPECT_TRUE(joined_future.IsFinished());
+}
+
+}  // namespace orbit_base

--- a/src/OrbitBase/ThreadPoolTest.cpp
+++ b/src/OrbitBase/ThreadPoolTest.cpp
@@ -431,7 +431,8 @@ TEST(ThreadPool, FutureContinuation) {
     orbit_base::Future<void> future =
         thread_pool->Schedule([&]() { absl::MutexLock lock(&mutex); });
 
-    future.RegisterContinuation([&]() { called = true; });
+    auto const result = future.RegisterContinuation([&]() { called = true; });
+    EXPECT_EQ(result, orbit_base::FutureRegisterContinuationResult::kSuccessfullyRegistered);
 
     EXPECT_TRUE(future.IsValid());
     EXPECT_FALSE(future.IsFinished());

--- a/src/OrbitBase/include/OrbitBase/Future.h
+++ b/src/OrbitBase/include/OrbitBase/Future.h
@@ -121,6 +121,16 @@ class [[nodiscard]] Future : public orbit_base_internal::FutureBase<T> {
         &this->shared_state_->result));
   }
 
+  // This is syntactic sugar for MainThreadExecutor (or maybe other executors in the future).
+  // `invocable` will be executed by `executor` after this future has completed.
+  //
+  // Note: Usually `invocable` won't be executed if `executor` gets destroyed before `*this`
+  // completes. Check the docs or implementation of `Executor::ScheduleAfter` to be sure.
+  template <typename Executor, typename Invocable>
+  auto Then(Executor * executor, Invocable && invocable) const {
+    return executor->ScheduleAfter(*this, std::forward<Invocable>(invocable));
+  }
+
  private:
   friend orbit_base_internal::PromiseBase<T>;
 
@@ -167,6 +177,16 @@ class Future<void> : public orbit_base_internal::FutureBase<void> {
     absl::MutexLock lock{&this->shared_state_->mutex};
     shared_state_->mutex.Await(absl::Condition(
         +[](bool* finished) { return *finished; }, &shared_state_->finished));
+  }
+
+  // This is syntactic sugar for MainThreadExecutor (or maybe other executors in the future).
+  // `invocable` will be executed by `executor` after this future has completed.
+  //
+  // Note: Usually `invocable` won't be executed if `executor` gets destroyed before `*this`
+  // completes. Check the docs or implementation of `Executor::ScheduleAfter` to be sure.
+  template <typename Executor, typename Invocable>
+  auto Then(Executor* executor, Invocable&& invocable) const {
+    return executor->ScheduleAfter(*this, std::forward<Invocable>(invocable));
   }
 
  private:

--- a/src/OrbitBase/include/OrbitBase/JoinFutures.h
+++ b/src/OrbitBase/include/OrbitBase/JoinFutures.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_BASE_JOIN_FUTURES_H_
+#define ORBIT_BASE_JOIN_FUTURES_H_
+
+#include "OrbitBase/Future.h"
+#include "absl/types/span.h"
+
+namespace orbit_base {
+
+// Returns a future which completes when all futures in the argument have completed.
+// Currently only available for Future<void>.
+[[nodiscard]] Future<void> JoinFutures(absl::Span<const Future<void>> futures);
+}  // namespace orbit_base
+
+#endif  // ORBIT_BASE_JOIN_FUTURES_H_

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -162,7 +162,7 @@ void OrbitApp::OnCaptureStarted(ProcessData&& process,
   absl::MutexLock mutex_lock(&mutex);
   bool initialization_complete = false;
 
-  (void)main_thread_executor_->Schedule(
+  main_thread_executor_->Schedule(
       [this, &initialization_complete, &mutex, process = std::move(process),
        selected_functions = std::move(selected_functions),
        selected_tracepoints = std::move(selected_tracepoints),
@@ -205,7 +205,7 @@ void OrbitApp::OnCaptureComplete() {
       orbit_client_model::CreatePostProcessedSamplingData(*GetCaptureData().GetCallstackData(),
                                                           GetCaptureData());
 
-  (void)main_thread_executor_->Schedule(
+  main_thread_executor_->Schedule(
       [this, sampling_profiler = std::move(post_processed_sampling_data)]() mutable {
         ORBIT_SCOPE("OnCaptureComplete");
         RefreshFrameTracks();
@@ -228,7 +228,7 @@ void OrbitApp::OnCaptureComplete() {
 }
 
 void OrbitApp::OnCaptureCancelled() {
-  (void)main_thread_executor_->Schedule([this]() mutable {
+  main_thread_executor_->Schedule([this]() mutable {
     ORBIT_SCOPE("OnCaptureCancelled");
     CHECK(capture_failed_callback_);
     capture_failed_callback_();
@@ -241,7 +241,7 @@ void OrbitApp::OnCaptureCancelled() {
 }
 
 void OrbitApp::OnCaptureFailed(ErrorMessage error_message) {
-  (void)main_thread_executor_->Schedule([this, error_message = std::move(error_message)]() mutable {
+  main_thread_executor_->Schedule([this, error_message = std::move(error_message)]() mutable {
     ORBIT_SCOPE("OnCaptureFailed");
     CHECK(capture_failed_callback_);
     capture_failed_callback_();
@@ -369,7 +369,7 @@ void OrbitApp::PostInit() {
       return;
     }
 
-    (void)main_thread_executor_->Schedule([result, this]() {
+    main_thread_executor_->Schedule([result, this]() {
       tracepoints_data_view_->SetTracepoints(result.value());
 
       FireRefreshCallbacks(DataViewType::kTracepoints);
@@ -964,7 +964,7 @@ bool OrbitApp::IsCaptureConnected(const CaptureData& capture) const {
 }
 
 void OrbitApp::SendDisassemblyToUi(std::string disassembly, DisassemblyReport report) {
-  (void)main_thread_executor_->Schedule(
+  main_thread_executor_->Schedule(
       [this, disassembly = std::move(disassembly), report = std::move(report)]() mutable {
         CHECK(disassembly_callback_);
         disassembly_callback_(std::move(disassembly), std::move(report));
@@ -972,28 +972,28 @@ void OrbitApp::SendDisassemblyToUi(std::string disassembly, DisassemblyReport re
 }
 
 void OrbitApp::SendTooltipToUi(const std::string& tooltip) {
-  (void)main_thread_executor_->Schedule([this, tooltip] {
+  main_thread_executor_->Schedule([this, tooltip] {
     CHECK(tooltip_callback_);
     tooltip_callback_(tooltip);
   });
 }
 
 void OrbitApp::SendInfoToUi(const std::string& title, const std::string& text) {
-  (void)main_thread_executor_->Schedule([this, title, text] {
+  main_thread_executor_->Schedule([this, title, text] {
     CHECK(info_message_callback_);
     info_message_callback_(title, text);
   });
 }
 
 void OrbitApp::SendWarningToUi(const std::string& title, const std::string& text) {
-  (void)main_thread_executor_->Schedule([this, title, text] {
+  main_thread_executor_->Schedule([this, title, text] {
     CHECK(warning_message_callback_);
     warning_message_callback_(title, text);
   });
 }
 
 void OrbitApp::SendErrorToUi(const std::string& title, const std::string& text) {
-  (void)main_thread_executor_->Schedule([this, title, text] {
+  main_thread_executor_->Schedule([this, title, text] {
     CHECK(error_message_callback_);
     error_message_callback_(title, text);
   });
@@ -1018,7 +1018,7 @@ void OrbitApp::LoadModuleOnRemote(ModuleData* module_data,
               absl::StrFormat("Did not find symbols locally or on remote for module \"%s\": %s\n%s",
                               module_data->file_path(), error_message_from_local,
                               result.error().message()));
-          (void)main_thread_executor_->Schedule([this, module_data]() {
+          main_thread_executor_->Schedule([this, module_data]() {
             modules_currently_loading_.erase(module_data->file_path());
           });
           return;
@@ -1028,7 +1028,7 @@ void OrbitApp::LoadModuleOnRemote(ModuleData* module_data,
 
         LOG("Found symbols file on the remote: \"%s\" - loading it using scp...", debug_file_path);
 
-        (void)main_thread_executor_->Schedule(
+        main_thread_executor_->Schedule(
             [this, module_data, function_hashes_to_hook = std::move(function_hashes_to_hook),
              frame_track_function_hashes = std::move(frame_track_function_hashes), debug_file_path,
              scoped_status = std::move(scoped_status)]() mutable {
@@ -1167,7 +1167,7 @@ void OrbitApp::LoadSymbols(const std::filesystem::path& symbols_path, ModuleData
     scoped_status.UpdateMessage(message);
     LOG("%s", message);
 
-    (void)main_thread_executor_->Schedule(
+    main_thread_executor_->Schedule(
         [this, scoped_status = std::move(scoped_status), module_data,
          function_hashes_to_hook = std::move(function_hashes_to_hook),
          frame_track_function_hashes = std::move(frame_track_function_hashes)] {
@@ -1320,7 +1320,7 @@ void OrbitApp::UpdateProcessAndModuleList(int32_t pid) {
       return;
     }
 
-    (void)main_thread_executor_->Schedule([pid, module_infos = std::move(result.value()), this] {
+    main_thread_executor_->Schedule([pid, module_infos = std::move(result.value()), this] {
       // Since this callback is executed asynchronously we can't be sure the target process has
       // been changed in the meantime. So we check and abort in case.
       if (pid != GetTargetProcess()->pid()) {

--- a/src/OrbitGl/MainThreadExecutor.h
+++ b/src/OrbitGl/MainThreadExecutor.h
@@ -10,6 +10,8 @@
 #include <chrono>
 #include <memory>
 #include <thread>
+#include <type_traits>
+#include <utility>
 
 #include "OrbitBase/Action.h"
 #include "OrbitBase/Future.h"
@@ -31,7 +33,7 @@
 // manager->Schedule(CreateAction([data]{
 //   UpdateSomethingWith(data);
 // }));
-class MainThreadExecutor {
+class MainThreadExecutor : public std::enable_shared_from_this<MainThreadExecutor> {
  public:
   MainThreadExecutor() = default;
   virtual ~MainThreadExecutor() = default;
@@ -63,6 +65,142 @@ class MainThreadExecutor {
     }
 
     return future;
+  }
+
+  // ScheduleAfter schedules the continuation `functor` to be executed
+  // on `*this` after `future` has completed.
+  //
+  // Note: The continuation is only executed if `*this` is still alive when `future` completes.
+  template <typename F>
+  [[nodiscard]] auto ScheduleAfter(const orbit_base::Future<void>& future, F&& functor)
+      -> orbit_base::Future<std::decay_t<decltype(functor())>> {
+    CHECK(future.IsValid());
+
+    using ReturnType = std::decay_t<decltype(functor())>;
+
+    // Since std::function needs to be copyable, promise also needs to be copyable.
+    auto promise = std::make_shared<orbit_base::Promise<ReturnType>>();
+    orbit_base::Future<ReturnType> resulting_future = promise->GetFuture();
+
+    // Since MSVC2017 crashes with a compiler error when using `if constexpr` inside of lambda, we
+    // have to put the check on the outside. That's unfortunate since it leads to four almost
+    // identical version of the same code.
+    if constexpr (std::is_same_v<ReturnType, void>) {
+      auto continuation = [functor = std::forward<F>(functor), executor_weak_ptr = weak_from_this(),
+                           promise = std::move(promise)]() mutable {
+        auto executor = executor_weak_ptr.lock();
+        if (executor == nullptr) return;
+
+        auto function_wrapper = [functor = std::move(functor),
+                                 promise = std::move(promise)]() mutable {
+          functor();
+          promise->MarkFinished();
+        };
+        executor->Schedule(CreateAction(std::move(function_wrapper)));
+      };
+
+      const orbit_base::FutureRegisterContinuationResult result =
+          future.RegisterContinuation(std::move(continuation));
+
+      if (result != orbit_base::FutureRegisterContinuationResult::kSuccessfullyRegistered) {
+        // If the future has already been finished, we call the continuation here.
+        // Keep in mind, this will not run the task synchronously. This will only
+        // SCHEDULE the task synchronously.
+        continuation();
+      }
+    } else {
+      auto continuation = [functor = std::forward<F>(functor), executor_weak_ptr = weak_from_this(),
+                           promise = std::move(promise)]() mutable {
+        auto executor = executor_weak_ptr.lock();
+        if (executor == nullptr) return;
+
+        auto function_wrapper = [functor = std::move(functor),
+                                 promise = std::move(promise)]() mutable {
+          promise->SetResult(functor());
+        };
+        executor->Schedule(CreateAction(std::move(function_wrapper)));
+      };
+
+      const orbit_base::FutureRegisterContinuationResult result =
+          future.RegisterContinuation(std::move(continuation));
+
+      if (result != orbit_base::FutureRegisterContinuationResult::kSuccessfullyRegistered) {
+        // If the future has already been finished, we call the continuation here.
+        // Keep in mind, this will not run the task synchronously. This will only
+        // SCHEDULE the task synchronously.
+        continuation();
+      }
+    }
+
+    return resulting_future;
+  }
+
+  // ScheduleAfter schedules the continuation `functor` to be executed
+  // on `*this` after `future` has completed.
+  //
+  // Note: The continuation is only executed if `*this` is still alive when `future` completes.
+  template <typename T, typename F>
+  [[nodiscard]] auto ScheduleAfter(const orbit_base::Future<T>& future, F&& functor)
+      -> orbit_base::Future<std::decay_t<decltype(functor(std::declval<T>()))>> {
+    CHECK(future.IsValid());
+
+    using ReturnType = std::decay_t<decltype(functor(std::declval<T>()))>;
+
+    // Since std::function needs to be copyable, promise also needs to be copyable.
+    auto promise = std::make_shared<orbit_base::Promise<ReturnType>>();
+    orbit_base::Future<ReturnType> resulting_future = promise->GetFuture();
+
+    // Since MSVC2017 crashes with a compiler error when using `if constexpr` inside of lambda, we
+    // have to put the check on the outside. That's unfortunate since it leads to four almost
+    // identical version of the same code.
+    if constexpr (std::is_same_v<ReturnType, void>) {
+      auto continuation = [functor = std::forward<F>(functor), executor_weak_ptr = weak_from_this(),
+                           promise = std::move(promise)](auto&& argument) mutable {
+        auto executor = executor_weak_ptr.lock();
+        if (executor == nullptr) return;
+
+        auto function_wrapper = [functor = std::move(functor), promise = std::move(promise),
+                                 argument = std::forward<decltype(argument)>(argument)]() mutable {
+          functor(std::move(argument));
+          promise->MarkFinished();
+        };
+        executor->Schedule(CreateAction(std::move(function_wrapper)));
+      };
+
+      const orbit_base::FutureRegisterContinuationResult result =
+          future.RegisterContinuation(std::move(continuation));
+
+      if (result != orbit_base::FutureRegisterContinuationResult::kSuccessfullyRegistered) {
+        // If the future has already been finished, we call the continuation here.
+        // Keep in mind, this will not run the task synchronously. This will only
+        // SCHEDULE the task synchronously.
+        continuation(future.Get());
+      }
+    } else {
+      auto continuation = [functor = std::forward<F>(functor), executor_weak_ptr = weak_from_this(),
+                           promise = std::move(promise)](auto&& argument) mutable {
+        auto executor = executor_weak_ptr.lock();
+        if (executor == nullptr) return;
+
+        auto function_wrapper = [functor = std::move(functor), promise = std::move(promise),
+                                 argument = std::forward<decltype(argument)>(argument)]() mutable {
+          promise->SetResult(functor(std::move(argument)));
+        };
+        executor->Schedule(CreateAction(std::move(function_wrapper)));
+      };
+
+      const orbit_base::FutureRegisterContinuationResult result =
+          future.RegisterContinuation(std::move(continuation));
+
+      if (result != orbit_base::FutureRegisterContinuationResult::kSuccessfullyRegistered) {
+        // If the future has already been finished, we call the continuation here.
+        // Keep in mind, this will not run the task synchronously. This will only
+        // SCHEDULE the task synchronously.
+        continuation(future.Get());
+      }
+    }
+
+    return resulting_future;
   }
 
   enum class WaitResult { kCompleted, kTimedOut, kAborted };

--- a/src/OrbitGl/MainThreadExecutor.h
+++ b/src/OrbitGl/MainThreadExecutor.h
@@ -42,8 +42,7 @@ class MainThreadExecutor : public std::enable_shared_from_this<MainThreadExecuto
   virtual void Schedule(std::unique_ptr<Action> action) = 0;
 
   template <typename F>
-  [[nodiscard]] auto Schedule(F&& functor)
-      -> orbit_base::Future<std::decay_t<decltype(functor())>> {
+  auto Schedule(F&& functor) -> orbit_base::Future<std::decay_t<decltype(functor())>> {
     using ReturnType = std::decay_t<decltype(functor())>;
 
     orbit_base::Promise<ReturnType> promise;
@@ -72,7 +71,7 @@ class MainThreadExecutor : public std::enable_shared_from_this<MainThreadExecuto
   //
   // Note: The continuation is only executed if `*this` is still alive when `future` completes.
   template <typename F>
-  [[nodiscard]] auto ScheduleAfter(const orbit_base::Future<void>& future, F&& functor)
+  auto ScheduleAfter(const orbit_base::Future<void>& future, F&& functor)
       -> orbit_base::Future<std::decay_t<decltype(functor())>> {
     CHECK(future.IsValid());
 
@@ -140,7 +139,7 @@ class MainThreadExecutor : public std::enable_shared_from_this<MainThreadExecuto
   //
   // Note: The continuation is only executed if `*this` is still alive when `future` completes.
   template <typename T, typename F>
-  [[nodiscard]] auto ScheduleAfter(const orbit_base::Future<T>& future, F&& functor)
+  auto ScheduleAfter(const orbit_base::Future<T>& future, F&& functor)
       -> orbit_base::Future<std::decay_t<decltype(functor(std::declval<T>()))>> {
     CHECK(future.IsValid());
 

--- a/src/OrbitGl/ScopedStatus.h
+++ b/src/OrbitGl/ScopedStatus.h
@@ -67,7 +67,7 @@ class ScopedStatus final {
     if (std::this_thread::get_id() == data_->main_thread_id) {
       data_->status_listener->UpdateStatus(data_->status_id, message);
     } else {
-      (void)data_->main_thread_executor->Schedule(
+      data_->main_thread_executor->Schedule(
           [status_id = data_->status_id, status_listener = data_->status_listener, message] {
             status_listener->UpdateStatus(status_id, message);
           });
@@ -83,7 +83,7 @@ class ScopedStatus final {
     if (std::this_thread::get_id() == data_->main_thread_id) {
       data_->status_listener->ClearStatus(data_->status_id);
     } else {
-      (void)data_->main_thread_executor->Schedule(
+      data_->main_thread_executor->Schedule(
           [status_listener = data_->status_listener, status_id = data_->status_id] {
             status_listener->ClearStatus(status_id);
           });

--- a/src/OrbitQt/MainThreadExecutorImpl.h
+++ b/src/OrbitQt/MainThreadExecutorImpl.h
@@ -15,8 +15,12 @@ namespace orbit_qt {
 // An implementation of MainThreadExecutor that integrates with Qt's event loop
 class MainThreadExecutorImpl : public QObject, public MainThreadExecutor {
   Q_OBJECT
- public:
   explicit MainThreadExecutorImpl(QObject* parent = nullptr) : QObject(parent) {}
+
+ public:
+  [[nodiscard]] static std::shared_ptr<MainThreadExecutorImpl> Create() {
+    return std::shared_ptr<MainThreadExecutorImpl>{new MainThreadExecutorImpl{}};
+  }
 
   using MainThreadExecutor::Schedule;
   void Schedule(std::unique_ptr<Action> action) override;

--- a/src/OrbitQt/MainThreadExecutorImplTest.cpp
+++ b/src/OrbitQt/MainThreadExecutorImplTest.cpp
@@ -126,4 +126,19 @@ TEST(MainThreadExecutorImpl, Wait) {
   EXPECT_EQ(executor->WaitFor(future), MainThreadExecutor::WaitResult::kCompleted);
 }
 
+TEST(MainThreadExecutorImpl, ChainFuturesWithThen) {
+  QCoreApplication app{argc, nullptr};
+
+  auto executor = MainThreadExecutorImpl::Create();
+  const auto future = executor->Schedule([]() { return 42; });
+  const auto future2 = future.Then(executor.get(), [](int val) {
+    QCoreApplication::exit(val);
+    return val + 42;
+  });
+
+  EXPECT_EQ(app.exec(), 42);
+  EXPECT_TRUE(future2.IsFinished());
+  EXPECT_EQ(future2.Get(), 42 + 42);
+}
+
 }  // namespace orbit_qt

--- a/src/OrbitQt/MainThreadExecutorImplTest.cpp
+++ b/src/OrbitQt/MainThreadExecutorImplTest.cpp
@@ -17,7 +17,7 @@ TEST(MainThreadExecutorImpl, Schedule) {
   QCoreApplication app{argc, nullptr};
 
   auto executor = MainThreadExecutorImpl::Create();
-  (void)executor->Schedule([]() { QCoreApplication::exit(42); });
+  executor->Schedule([]() { QCoreApplication::exit(42); });
 
   EXPECT_EQ(app.exec(), 42);
 }
@@ -28,7 +28,7 @@ TEST(MainThreadExecutorImpl, ScheduleAfterAllVoid) {
   bool called = false;
   auto executor = MainThreadExecutorImpl::Create();
   auto future = executor->Schedule([&called]() { called = true; });
-  (void)executor->ScheduleAfter(future, []() { QCoreApplication::exit(42); });
+  executor->ScheduleAfter(future, []() { QCoreApplication::exit(42); });
 
   EXPECT_EQ(app.exec(), 42);
   EXPECT_TRUE(called);
@@ -39,7 +39,7 @@ TEST(MainThreadExecutorImpl, ScheduleAfterWithIntegerBetweenJobs) {
 
   auto executor = MainThreadExecutorImpl::Create();
   auto future = executor->Schedule([]() { return 42; });
-  (void)executor->ScheduleAfter(future, [](int val) { QCoreApplication::exit(val); });
+  executor->ScheduleAfter(future, [](int val) { QCoreApplication::exit(val); });
 
   EXPECT_EQ(app.exec(), 42);
 }

--- a/src/OrbitQt/MainThreadExecutorImplTest.cpp
+++ b/src/OrbitQt/MainThreadExecutorImplTest.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include <QCoreApplication>
+#include <memory>
 
 #include "MainThreadExecutorImpl.h"
 
@@ -15,8 +16,8 @@ static int argc = 0;
 TEST(MainThreadExecutorImpl, Schedule) {
   QCoreApplication app{argc, nullptr};
 
-  MainThreadExecutorImpl executor{};
-  (void)executor.Schedule([]() { QCoreApplication::instance()->exit(42); });
+  auto executor = MainThreadExecutorImpl::Create();
+  (void)executor->Schedule([]() { QCoreApplication::exit(42); });
 
   EXPECT_EQ(app.exec(), 42);
 }
@@ -25,9 +26,9 @@ TEST(MainThreadExecutorImpl, Wait) {
   QCoreApplication app{argc, nullptr};
 
   bool called = false;
-  MainThreadExecutorImpl executor{};
-  orbit_base::Future<void> future = executor.Schedule([&called]() { called = true; });
-  EXPECT_EQ(executor.WaitFor(future), MainThreadExecutor::WaitResult::kCompleted);
+  auto executor = MainThreadExecutorImpl::Create();
+  orbit_base::Future<void> future = executor->Schedule([&called]() { called = true; });
+  EXPECT_EQ(executor->WaitFor(future), MainThreadExecutor::WaitResult::kCompleted);
 }
 
 }  // namespace orbit_qt

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -146,7 +146,7 @@ OrbitMainWindow::OrbitMainWindow(orbit_qt::TargetConfiguration target_configurat
                                  uint32_t font_size,
                                  orbit_metrics_uploader::MetricsUploader* metrics_uploader)
     : QMainWindow(nullptr),
-      main_thread_executor_{std::make_unique<orbit_qt::MainThreadExecutorImpl>()},
+      main_thread_executor_{orbit_qt::MainThreadExecutorImpl::Create()},
       app_{OrbitApp::Create(main_thread_executor_.get(), metrics_uploader)},
       ui(new Ui::OrbitMainWindow),
       target_configuration_(std::move(target_configuration)) {

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -163,7 +163,7 @@ class OrbitMainWindow : public QMainWindow {
   void LoadCaptureOptionsIntoApp();
 
  private:
-  std::unique_ptr<MainThreadExecutor> main_thread_executor_;
+  std::shared_ptr<MainThreadExecutor> main_thread_executor_;
   std::unique_ptr<OrbitApp> app_;
   Ui::OrbitMainWindow* ui;
   FilterPanelWidgetAction* filter_panel_action_ = nullptr;

--- a/src/QtUtils/FutureWatcher.cpp
+++ b/src/QtUtils/FutureWatcher.cpp
@@ -13,6 +13,8 @@
 #include <QTimer>
 #include <chrono>
 
+#include "OrbitBase/JoinFutures.h"
+
 namespace orbit_qt_utils {
 
 FutureWatcher::FutureWatcher(QObject* parent) : QObject{parent} {}
@@ -57,83 +59,6 @@ FutureWatcher::Reason FutureWatcher::WaitFor(
 FutureWatcher::Reason FutureWatcher::WaitForAll(
     absl::Span<orbit_base::Future<void>> futures,
     std::optional<std::chrono::milliseconds> timeout) const {
-  if (futures.empty()) return Reason::kFutureCompleted;
-
-  QTimer timer{};
-  timer.setSingleShot(true);
-
-  QEventLoop loop{};
-  QObject::connect(this, &FutureWatcher::AbortRequested, &loop, &QEventLoop::quit);
-  QObject::connect(&timer, &QTimer::timeout, &loop, &QEventLoop::quit);
-
-  if (timeout.has_value()) {
-    timer.start(timeout.value());
-  }
-
-  struct SharedData {
-    absl::Mutex mutex;
-    size_t completion_counter{};
-    std::vector<bool> finished_indicator;
-  };
-
-  auto shared_data = std::make_shared<SharedData>();
-  shared_data->finished_indicator.resize(futures.size(), false);
-  shared_data->completion_counter = futures.size();  // Counts downwards
-
-  auto indicator_iterator = shared_data->finished_indicator.begin();
-  for (auto& future : futures) {
-    if (!future.IsValid() || future.IsFinished()) {
-      absl::MutexLock lock{&shared_data->mutex};
-      --shared_data->completion_counter;
-      *indicator_iterator = true;
-    } else {
-      const orbit_base::FutureRegisterContinuationResult result =
-          future.RegisterContinuation([shared_data, indicator_iterator, loop = QPointer{&loop}]() {
-            absl::MutexLock lock{&shared_data->mutex};
-
-            if (shared_data->completion_counter == 0) return;
-
-            if (!*indicator_iterator) {
-              *indicator_iterator = true;
-              --shared_data->completion_counter;
-            }
-
-            if (shared_data->completion_counter == 0) {
-              QMetaObject::invokeMethod(loop, &QEventLoop::quit);
-            }
-          });
-
-      if (result == orbit_base::FutureRegisterContinuationResult::kFutureAlreadyCompleted) {
-        absl::MutexLock lock{&shared_data->mutex};
-        if (!*indicator_iterator) {
-          --shared_data->completion_counter;
-          *indicator_iterator = true;
-        }
-      }
-    }
-
-    ++indicator_iterator;
-  }
-
-  {
-    absl::MutexLock lock{&shared_data->mutex};
-    if (shared_data->completion_counter == 0) return Reason::kFutureCompleted;
-  }
-
-  loop.exec();
-
-  {
-    absl::MutexLock lock{&shared_data->mutex};
-    if (shared_data->completion_counter == 0) return Reason::kFutureCompleted;
-
-    // If we reach this point, it means the waiting was cancelled (either by Abort or by timeout).
-    // We set completion_counter to zero to inform later executing continuations that we are done.
-    shared_data->completion_counter = 0;
-  }
-
-  constexpr int kInvalidRemainingTime = -1;
-  if (timeout && timer.remainingTime() == kInvalidRemainingTime) return Reason::kTimeout;
-
-  return Reason::kAbortRequested;
+  return WaitFor(orbit_base::JoinFutures(futures), timeout);
 }
 }  // namespace orbit_qt_utils


### PR DESCRIPTION
This PR is foremost adding two additional features to the Promise/Future framework.

1. `orbit_base::JoinFutures`: This free function takes a span of Futures and creates a joined future that completes after all the "child"-futures have been completed. Currently it's a non-templated implementation for `orbit_base::Future<void>`. This can be extended for non-void futures in the future. (no pun intended.)
2. `orbit_base::Future<T>::Then`: This is a member function that allows to chain tasks, even when executed on different executors. The member function takes a pointer to an executor and a function-object as parameters. The function object will be executed on the given executor when the future finishes.

### A typical example for the 1st
(from the upcoming symbol loading refactoring)
```
orbit_base::Future<void> OrbitApp::LoadModules(absl::Span<const ModuleData*> modules) {
  std::vector<orbit_base::Future<void>> futures;
  futures.reserve(modules.size());

  for(const auto& module : modules) {
    futures.emplace_back(LoadModule(module));
  }

  return orbit_base::JoinFutures(futures);  
}
```
All executions of `LoadModule` happen in parallel. `LoadModules` has been simplified by separating concerns.
`LoadModule` can only load one module at a time, while `LoadModules` only contains the logic for handling multiple
`LoadModule` calls.


### A typical example for the 2nd
```
auto future = thread_pool_->Schedule([]() {
  // do something expensive
 return Result{};
});
// or
auto future = MyAsyncOperation(); // Think `LoadModule` as from the previous example

future.Then(main_thread_executor_.get(), [](Result result) {
  // process `result` and update the UI
});
```

Previously the call of `main_thread_executor->Schedule` was part of the background job,
which ties the background task to the processing on the main thread. By using `Then` the
background task gets independent of the continuation. Once more this leads to better separation
of concerns.