### PR TITLE
Syntax highlighting for C

### DIFF
--- a/src/CodeViewerDemo/CMakeLists.txt
+++ b/src/CodeViewerDemo/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.15)
 
 project(CodeViewerDemo)
-add_executable(CodeViewerDemo main.cpp)
+add_executable(CodeViewerDemo main.cpp CodeExamples.h)
 
 target_compile_options(CodeViewerDemo PRIVATE ${STRICT_COMPILE_FLAGS})
 target_link_libraries(CodeViewerDemo PRIVATE CodeViewer Qt5::Gui SyntaxHighlighter)

--- a/src/CodeViewerDemo/CodeExamples.h
+++ b/src/CodeViewerDemo/CodeExamples.h
@@ -1,0 +1,69 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <QString>
+
+inline const QString cpp_example = R"(#pragma twice
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <iostream>
+
+#include "TrackManager.h"
+
+class TrackManager {
+ public:
+  explicit TrackManager(TimeGraph* time_graph, OrbitApp* app);
+  void Clear();
+
+  [[nodiscard]] std::vector<Track*> GetAllTracks() const;
+
+ protected:
+  /* This is a protected area. "This is not a string" */
+ private: /* Nobody
+           * can
+           * access
+           * this
+           * part */
+  std::vector<Track*> tracks_;
+}
+
+int main (int argc, char **argv) {
+  char start_capture = 'x';
+  std::string multiline =
+      " This \
+                            is a \
+                       multiline \
+                          string";
+  int* my_ptr = NULL;
+  printf("Hi Orbit's user, if you want to start a capture please press \"%c\"\n", start_capture);
+  return 0;
+
+})";
+
+inline const QString x86Assembly_example = R"(Platform: X86 64 (Intel syntax)
+0x557e1f8091d0:	push         rbp
+0x557e1f8091d1:	mov          rbp, rsp
+0x557e1f8091d4:	sub          rsp, 0x10
+0x557e1f8091d8:	mov          rax, qword ptr fs:[0x28]
+0x557e1f8091e1:	mov          qword ptr [rbp - 8], rax
+0x557e1f8091e5:	xorps        xmm0, xmm0
+0x557e1f8091e8:	movups       xmmword ptr [rdi], xmm0
+0x557e1f8091eb:	mov          qword ptr [rdi + 0x10], 0
+0x557e1f8091f3:	mov          byte ptr [rdi], 0x2a
+0x557e1f8091f6:	movabs       rax, 0x65646f6d20726570
+0x557e1f809200:	mov          qword ptr [rdi + 0xe], rax
+0x557e1f809204:	movups       xmm0, xmmword ptr [rip - 0x36e2d5]
+0x557e1f80920b:	movups       xmmword ptr [rdi + 1], xmm0
+0x557e1f80920f:	mov          byte ptr [rdi + 0x16], 0
+0x557e1f809213:	mov          rax, qword ptr fs:[0x28]
+0x557e1f80921c:	cmp          rax, qword ptr [rbp - 8]
+0x557e1f809220:	jne          0x557e1f80922b
+0x557e1f809222:	mov          rax, rdi
+0x557e1f809225:	add          rsp, 0x10
+0x557e1f809229:	pop          rbp
+0x557e1f80922a:	ret
+0x557e1f80922b:	call         0x557e2000aa70
+0x557e1f809230:)";

--- a/src/CodeViewerDemo/CodeExamples.h
+++ b/src/CodeViewerDemo/CodeExamples.h
@@ -4,6 +4,299 @@
 
 #include <QString>
 
+inline const QString testing_example =
+    R"(
+// Tests to understand how the syntax highlighter works
+  // Number unit tests
+  a = 0x8542;
+  a = 4103;
+  a = 0;
+  a = 01ab;
+  a = a105;
+  a = _103;
+
+  // Capitalized words unit tests
+  OrbitService o;
+  QSyntaxHighlighter q;
+  ORBIT_SCOPE; // no lowercase regex
+  x;
+  kTreeSize == 3;
+  _Tree_;
+
+  // Function unit tests
+  int my_function(void)
+  bool b = a.insert(3);
+  void AddEvent();
+  char _my_underscore_func();
+  int CaptureServiceImpl::Capture() // Function from other class
+  void QSyntaxHighlighter::Play
+  CHECK(false); // no lowercase regex
+
+  // Preprocessor + <> unit tests
+  #include <iostream>
+  std::vector<Typeee>
+  #include<iostream>
+   #pragma<ios>
+  include<iostream>
+
+  // Strings unit tests
+  "Hola mundo\n"
+  "I'm an \"only\" string"
+  "I'm 2" + "strings"
+  "CHECK(false)\\\\"
+  "Multi\
+  Line"
+
+  // Comments unit tests
+  // return
+  // This is a comment
+  return; // This isn't a comment
+  /*This
+  is a
+  long comment*/
+  /* One line comment */ int main;
+
+// CaptureServiceImpl.cpp
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <absl/container/flat_hash_set.h>
+#include <absl/synchronization/mutex.h>
+#include <absl/time/time.h>
+#include <pthread.h>
+#include <stdint.h>
+
+#include <algorithm>
+#include <limits>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "CaptureEventBuffer.h"
+#include "CaptureEventSender.h"
+#include "CaptureServiceImpl.h"
+#include "LinuxTracingHandler.h"
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/Tracing.h"
+#include "capture.pb.h"
+
+namespace orbit_service {
+
+using orbit_grpc_protos::CaptureRequest;
+using orbit_grpc_protos::CaptureResponse;
+
+namespace {
+
+using orbit_grpc_protos::CaptureEvent;
+
+class SenderThreadCaptureEventBuffer final : public CaptureEventBuffer {
+ public:
+  explicit SenderThreadCaptureEventBuffer(CaptureEventSender* event_sender)
+      : capture_event_sender_{event_sender} {
+    CHECK(capture_event_sender_ != nullptr);
+    sender_thread_ = std::thread{[this] { SenderThread(); }};
+  }
+
+  void AddEvent(orbit_grpc_protos::CaptureEvent&& event) override {
+    absl::MutexLock lock{&event_buffer_mutex_};
+    if (stop_requested_) {
+      return;
+    }
+    event_buffer_.emplace_back(std::move(event));
+  }
+
+  void StopAndWait() {
+    CHECK(sender_thread_.joinable());
+    {
+      // Protect stop_requested_ with event_buffer_mutex_ so that we can use stop_requested_
+      // in Conditions for Await/LockWhen (specifically, in SenderThread).
+      absl::MutexLock lock{&event_buffer_mutex_};
+      stop_requested_ = true;
+    }
+    sender_thread_.join();
+  }
+
+  ~SenderThreadCaptureEventBuffer() override { CHECK(!sender_thread_.joinable()); }
+
+ private:
+  void SenderThread() {
+    pthread_setname_np(pthread_self(), "SenderThread");
+    constexpr absl::Duration kSendTimeInterval = absl::Milliseconds(20);
+    // This should be lower than kMaxEventsPerResponse in GrpcCaptureEventSender::SendEvents
+    // as a few more events are likely to arrive after the condition becomes true.
+    constexpr uint64_t kSendEventCountInterval = 5000;
+
+    bool stopped = false;
+    while (!stopped) {
+      ORBIT_SCOPE("SenderThread iteration");
+      event_buffer_mutex_.LockWhenWithTimeout(absl::Condition(
+                                                  +[](SenderThreadCaptureEventBuffer* self) {
+                                                    return self->event_buffer_.size() >=
+                                                               kSendEventCountInterval ||
+                                                           self->stop_requested_;
+                                                  },
+                                                  this),
+                                              kSendTimeInterval);
+      if (stop_requested_) {
+        stopped = true;
+      }
+      std::vector<CaptureEvent> buffered_events = std::move(event_buffer_);
+      event_buffer_.clear();
+      event_buffer_mutex_.Unlock();
+      capture_event_sender_->SendEvents(std::move(buffered_events));
+    }
+  }
+
+  std::vector<orbit_grpc_protos::CaptureEvent> event_buffer_;
+  absl::Mutex event_buffer_mutex_;
+  CaptureEventSender* capture_event_sender_;
+  std::thread sender_thread_;
+  bool stop_requested_ = false;
+};
+
+class GrpcCaptureEventSender final : public CaptureEventSender {
+ public:
+  explicit GrpcCaptureEventSender(
+      grpc::ServerReaderWriter<CaptureResponse, CaptureRequest>* reader_writer)
+      : reader_writer_{reader_writer} {
+    CHECK(reader_writer_ != nullptr);
+  }
+
+  ~GrpcCaptureEventSender() override {
+    LOG("Total number of events sent: %lu", total_number_of_events_sent_);
+    LOG("Total number of bytes sent: %lu", total_number_of_bytes_sent_);
+
+    // Ensure we can divide by 0.f safely.
+    static_assert(std::numeric_limits<float>::is_iec559);
+    float average_bytes =
+        static_cast<float>(total_number_of_bytes_sent_) / total_number_of_events_sent_;
+
+    LOG("Average number of bytes per event: %.2f", average_bytes);
+  }
+
+  void SendEvents(std::vector<orbit_grpc_protos::CaptureEvent>&& events) override {
+    ORBIT_SCOPE_FUNCTION;
+    ORBIT_UINT64("Number of buffered events sent", events.size());
+    if (events.empty()) {
+      return;
+    }
+
+    constexpr uint64_t kMaxEventsPerResponse = 10'000;
+    uint64_t number_of_bytes_sent = 0;
+    CaptureResponse response;
+    for (CaptureEvent& event : events) {
+      // We buffer to avoid sending countless tiny messages, but we also want to
+      // avoid huge messages, which would cause the capture on the client to jump
+      // forward in time in few big steps and not look live anymore.
+      if (response.capture_events_size() == kMaxEventsPerResponse) {
+        number_of_bytes_sent += response.ByteSizeLong();
+        reader_writer_->Write(response);
+        response.clear_capture_events();
+      }
+      response.mutable_capture_events()->Add(std::move(event));
+    }
+    number_of_bytes_sent += response.ByteSizeLong();
+    reader_writer_->Write(response);
+
+    // Ensure we can divide by 0.f safely.
+    static_assert(std::numeric_limits<float>::is_iec559);
+    float average_bytes = static_cast<float>(number_of_bytes_sent) / events.size();
+
+    ORBIT_FLOAT("Average bytes per CaptureEvent", average_bytes);
+    total_number_of_events_sent_ += events.size();
+    total_number_of_bytes_sent_ += number_of_bytes_sent;
+  }
+
+ private:
+  grpc::ServerReaderWriter<CaptureResponse, CaptureRequest>* reader_writer_;
+
+  uint64_t total_number_of_events_sent_ = 0;
+  uint64_t total_number_of_bytes_sent_ = 0;
+};
+
+}  // namespace
+
+// LinuxTracingHandler::Stop is blocking, until all perf_event_open events have been processed
+// and all perf_event_open file descriptors have been closed.
+// CaptureStartStopListener::OnCaptureStopRequested is also to be assumed blocking,
+// for example until all CaptureEvents from external producers have been received.
+// Hence why these methods need to be called in parallel on different threads.
+static void StopTracingHandlerAndCaptureStartStopListenersInParallel(
+    LinuxTracingHandler* tracing_handler,
+    absl::flat_hash_set<CaptureStartStopListener*>* capture_start_stop_listeners) {
+  std::vector<std::thread> stop_threads;
+
+  stop_threads.emplace_back([&tracing_handler] {
+    tracing_handler->Stop();
+    LOG("LinuxTracingHandler stopped: perf_event_open tracing is done");
+  });
+
+  for (CaptureStartStopListener* listener : *capture_start_stop_listeners) {
+    stop_threads.emplace_back([&listener] {
+      listener->OnCaptureStopRequested();
+      LOG("CaptureStartStopListener stopped: one or more producers finished capturing");
+    });
+  }
+
+  for (std::thread& stop_thread : stop_threads) {
+    stop_thread.join();
+  }
+}
+
+grpc::Status CaptureServiceImpl::Capture(
+    grpc::ServerContext*,
+    grpc::ServerReaderWriter<CaptureResponse, CaptureRequest>* reader_writer) {
+  pthread_setname_np(pthread_self(), "CSImpl::Capture");
+  if (is_capturing) {
+    ERROR("Cannot start capture because another capture is already in progress");
+    return grpc::Status(grpc::StatusCode::ALREADY_EXISTS,
+                        "Cannot start capture because another capture is already in progress.");
+  }
+  is_capturing = true;
+
+  GrpcCaptureEventSender capture_event_sender{reader_writer};
+  SenderThreadCaptureEventBuffer capture_event_buffer{&capture_event_sender};
+  LinuxTracingHandler tracing_handler{&capture_event_buffer};
+
+  CaptureRequest request;
+  reader_writer->Read(&request);
+  LOG("Read CaptureRequest from Capture's gRPC stream: starting capture");
+
+  tracing_handler.Start(std::move(*request.mutable_capture_options()));
+  for (CaptureStartStopListener* listener : capture_start_stop_listeners_) {
+    listener->OnCaptureStartRequested(&capture_event_buffer);
+  }
+
+  // The client asks for the capture to be stopped by calling WritesDone.
+  // At that point, this call to Read will return false.
+  // In the meantime, it blocks if no message is received.
+  while (reader_writer->Read(&request)) {
+  }
+  LOG("Client finished writing on Capture's gRPC stream: stopping capture");
+
+  StopTracingHandlerAndCaptureStartStopListenersInParallel(&tracing_handler,
+                                                           &capture_start_stop_listeners_);
+
+  capture_event_buffer.StopAndWait();
+  LOG("Finished handling gRPC call to Capture: all capture data has been sent");
+  is_capturing = false;
+  return grpc::Status::OK;
+}
+
+void CaptureServiceImpl::AddCaptureStartStopListener(CaptureStartStopListener* listener) {
+  bool new_insertion = capture_start_stop_listeners_.insert(listener).second;
+  CHECK(new_insertion);
+}
+
+void CaptureServiceImpl::RemoveCaptureStartStopListener(CaptureStartStopListener* listener) {
+  bool was_removed = capture_start_stop_listeners_.erase(listener) > 0;
+  CHECK(was_removed);
+}
+
+}  // namespace orbit_service
+)";
+
 inline const QString cpp_example = R"(#pragma twice
 // Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/src/CodeViewerDemo/main.cpp
+++ b/src/CodeViewerDemo/main.cpp
@@ -4,41 +4,19 @@
 
 #include <QApplication>
 
+#include "CodeExamples.h"
 #include "CodeViewer/Dialog.h"
-#include "SyntaxHighlighter/X86Assembly.h"
+#include "SyntaxHighlighter/Cpp.h"
 
 int main(int argc, char* argv[]) {
   QApplication app{argc, argv};
 
   orbit_code_viewer::Dialog dialog{};
 
-  // Example assembly as it's produced by capstone.
-  const QString content = R"(Platform: X86 64 (Intel syntax)
-0x557e1f8091d0:	push         rbp
-0x557e1f8091d1:	mov          rbp, rsp
-0x557e1f8091d4:	sub          rsp, 0x10
-0x557e1f8091d8:	mov          rax, qword ptr fs:[0x28]
-0x557e1f8091e1:	mov          qword ptr [rbp - 8], rax
-0x557e1f8091e5:	xorps        xmm0, xmm0
-0x557e1f8091e8:	movups       xmmword ptr [rdi], xmm0
-0x557e1f8091eb:	mov          qword ptr [rdi + 0x10], 0
-0x557e1f8091f3:	mov          byte ptr [rdi], 0x2a
-0x557e1f8091f6:	movabs       rax, 0x65646f6d20726570
-0x557e1f809200:	mov          qword ptr [rdi + 0xe], rax
-0x557e1f809204:	movups       xmm0, xmmword ptr [rip - 0x36e2d5]
-0x557e1f80920b:	movups       xmmword ptr [rdi + 1], xmm0
-0x557e1f80920f:	mov          byte ptr [rdi + 0x16], 0
-0x557e1f809213:	mov          rax, qword ptr fs:[0x28]
-0x557e1f80921c:	cmp          rax, qword ptr [rbp - 8]
-0x557e1f809220:	jne          0x557e1f80922b
-0x557e1f809222:	mov          rax, rdi
-0x557e1f809225:	add          rsp, 0x10
-0x557e1f809229:	pop          rbp
-0x557e1f80922a:	ret          
-0x557e1f80922b:	call         0x557e2000aa70
-0x557e1f809230:)";
+  // Example file
+  const QString content = cpp_example;
 
-  dialog.SetSourceCode(content, std::make_unique<orbit_syntax_highlighter::X86Assembly>());
+  dialog.SetSourceCode(content, std::make_unique<orbit_syntax_highlighter::Cpp>());
 
   const auto line_numbers = content.count('\n');
   dialog.SetHeatmap(orbit_code_viewer::FontSizeInEm{1.2f}, [line_numbers](int line_number) {

--- a/src/CodeViewerDemo/main.cpp
+++ b/src/CodeViewerDemo/main.cpp
@@ -14,7 +14,7 @@ int main(int argc, char* argv[]) {
   orbit_code_viewer::Dialog dialog{};
 
   // Example file
-  const QString content = cpp_example;
+  const QString content = testing_example;
 
   dialog.SetSourceCode(content, std::make_unique<orbit_syntax_highlighter::Cpp>());
 

--- a/src/SyntaxHighlighter/CMakeLists.txt
+++ b/src/SyntaxHighlighter/CMakeLists.txt
@@ -14,3 +14,5 @@ set_target_properties(SyntaxHighlighter PROPERTIES AUTOMOC ON)
 
 target_sources(SyntaxHighlighter PUBLIC include/SyntaxHighlighter/X86Assembly.h)
 target_sources(SyntaxHighlighter PRIVATE X86Assembly.cpp)
+target_sources(SyntaxHighlighter PUBLIC include/SyntaxHighlighter/Cpp.h)
+target_sources(SyntaxHighlighter PRIVATE Cpp.cpp)

--- a/src/SyntaxHighlighter/Cpp.cpp
+++ b/src/SyntaxHighlighter/Cpp.cpp
@@ -45,15 +45,15 @@ const char* const kEndCommentRegex = "[\\s\\S]*\\*\\/";
 const char* const kNoEndCommentRegex = "([^\\*]|\\*+[^\\/\\*])*$";
 // A word who is followed with an open-parenthesis (
 const char* const kFunctionRegex = "(?<=[^\\(\\:\\.\\w\\>])[a-z_]\\w*(?=\\s*\\()";
-const char* const kPreprocessorRegex = "(^\\s*)#\\s*[a-z_]\\S*";
+const char* const kPreprocessorRegex = "(^\\s*)#\\s*[a-z_]\\w*";
 // Match with <word> after #include
-const char* const kIncludeFileRegex = "(?!#(\\\\s*)include)\\s<[^>]+>";
+const char* const kIncludeFileRegex = "(?<=#include)\\s*<[^>]+>";
 // Similar process to comments to match a multiline string
 const char* const kStringRegex = "\"([^\\\\\"]|\\\\.)*\"|\'[^\']*\'";
 const char* const kOpenStringRegex = "\"([^\\\\\"]|\\\\.)*\\\\$";
 const char* const kEndStringRegex = "([^\\\\\"]|\\\\.)*\"";
 const char* const kNoEndStringRegex = "([^\\\\\"]|\\\\.)*\\\\$";
-const char* const kCapitalizedRegex = "(?<=[\\s\\(])[A-Z][\\w\\*\\&]*";
+const char* const kCapitalizedRegex = "(?<=[\\s\\(<])[A-Z][\\w\\*\\&]*";
 const char* const kNoLowercaseRegex = "(?<=[\\s\\(])[A-Z][0-9A-Z\\_\\*\\&]*(?=[\\;\\,\\(\\s\\)])";
 }  // namespace
 }  // namespace C

--- a/src/SyntaxHighlighter/Cpp.cpp
+++ b/src/SyntaxHighlighter/Cpp.cpp
@@ -1,0 +1,127 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "SyntaxHighlighter/Cpp.h"
+
+#include <QColor>
+#include <QRegularExpression>
+#include <QString>
+#include <QTextCharFormat>
+
+namespace orbit_syntax_highlighter {
+namespace C {
+namespace {
+enum HighlighterState { kInitialState, kOpenCommentState, kOpenStringState };
+
+const QColor kGrey{0x80, 0x80, 0x80};
+const QColor kBlue{0x61, 0x96, 0xcc};
+const QColor kYellow{0xa0, 0xa0, 0x33};
+const QColor kYellowOrange{0xff, 0xcc, 0x66};
+const QColor kOrange{0xcc, 0x66, 0x33};
+const QColor kOlive{0x80, 0x80, 0x00};
+const QColor kGreen{0x66, 0x99, 0x66};
+const QColor kViolet{0xcc, 0x99, 0xcd};
+
+const char* const kNumberRegex =
+    "(?:\\b0x(?:[\\da-f]+(?:\\.[\\da-f]*)?|\\.[\\da-f]+)(?:p[+-]?\\d+)?|(?:\\b\\d+(?:\\.\\d*)?|"
+    "\\B\\.\\d+)(?:e[+-]?\\d+)?)[ful]{0,4}";
+const char* const kConstantRegex =
+    "__FILE__|__LINE__|__DATE__|__TIME__|__TIMESTAMP__|__func__|EOF|NULL|SEEK_CUR|SEEK_END|SEEK_"
+    "SET|stdin|stdout|stderr";
+const char* const kKeywordRegex =
+    "\\b(?:__attribute__|_Alignas|_Alignof|_Atomic|_Bool|_Complex|_Generic|_Imaginary|_Noreturn|_"
+    "Static_assert|_Thread_local|asm|typeof|inline|auto|break|case|char|const|continue|default|do|"
+    "double|else|enum|extern|float|for|goto|if|int|long|register|return|short|signed|sizeof|static|"
+    "struct|switch|typedef|union|unsigned|void|volatile|while|)\\b";
+// Match with comments starting and ending in the same line
+const char* const kCommentRegex =
+    "\\/\\/(?:[^\\r\\n\\\\]|\\\\(?:\\r\\n?|\\n|(?![\\r\\n])))*|\\/\\*[\\s\\S]*?\\*\\/";
+// Match with "/*" comments which starts but not finishes in this line
+const char* const kOpenCommentRegex = "\\/\\*([^\\*]|[\\*]+[^\\/])*?$";
+// Match with the closing part of the comment
+const char* const kEndCommentRegex = "[\\s\\S]*\\*\\/";
+// Match with a line without a closing comment
+const char* const kNoEndCommentRegex = "([^\\*]|\\*+[^\\/\\*])*$";
+// A word who is followed with an open-parenthesis (
+const char* const kFunctionRegex = "(?<=[^\\(\\:\\.\\w\\>])[a-z_]\\w*(?=\\s*\\()";
+const char* const kPreprocessorRegex = "(^\\s*)#\\s*[a-z_]\\S*";
+// Match with <word> after #include
+const char* const kIncludeFileRegex = "(?!#(\\\\s*)include)\\s<[^>]+>";
+// Similar process to comments to match a multiline string
+const char* const kStringRegex = "\"([^\\\\\"]|\\\\.)*\"|\'[^\']*\'";
+const char* const kOpenStringRegex = "\"([^\\\\\"]|\\\\.)*\\\\$";
+const char* const kEndStringRegex = "([^\\\\\"]|\\\\.)*\"";
+const char* const kNoEndStringRegex = "([^\\\\\"]|\\\\.)*\\\\$";
+const char* const kCapitalizedRegex = "(?<=[\\s\\(])[A-Z][\\w\\*\\&]*";
+const char* const kNoLowercaseRegex = "(?<=[\\s\\(])[A-Z][0-9A-Z\\_\\*\\&]*(?=[\\;\\,\\(\\s\\)])";
+}  // namespace
+}  // namespace C
+
+Cpp::Cpp() : QSyntaxHighlighter{static_cast<QObject*>(nullptr)} {
+  using PatternOption = QRegularExpression::PatternOption;
+  number_regex_ = QRegularExpression{C::kNumberRegex, PatternOption::CaseInsensitiveOption};
+  constant_regex_ = QRegularExpression{C::kConstantRegex};
+  keyword_regex_ = QRegularExpression{C::kKeywordRegex};
+  comment_regex_ = QRegularExpression{C::kCommentRegex};
+  open_comment_regex_ = QRegularExpression{C::kOpenCommentRegex};
+  end_comment_regex_ = QRegularExpression{C::kEndCommentRegex};
+  no_end_comment_regex_ = QRegularExpression{C::kNoEndCommentRegex};
+  function_regex_ = QRegularExpression{C::kFunctionRegex, PatternOption::CaseInsensitiveOption};
+  preprocessor_regex_ = QRegularExpression{C::kPreprocessorRegex};
+  include_file_regex_ = QRegularExpression{C::kIncludeFileRegex};
+  string_regex_ = QRegularExpression{C::kStringRegex};
+  open_string_regex_ = QRegularExpression{C::kOpenStringRegex};
+  end_string_regex_ = QRegularExpression{C::kEndStringRegex};
+  no_end_string_regex_ = QRegularExpression{C::kNoEndStringRegex};
+  capitalized_regex_ = QRegularExpression{C::kCapitalizedRegex};
+  no_lowercase_regex_ = QRegularExpression{C::kNoLowercaseRegex};
+}
+
+void Cpp::highlightBlock(const QString& code) {
+  const auto apply = [&code, this](
+                         QRegularExpression* expression, const QColor& color,
+                         C::HighlighterState new_state = C::HighlighterState::kInitialState) {
+    QTextCharFormat format{};
+    format.setForeground(color);
+
+    for (auto it = expression->globalMatch(code); it.hasNext();) {
+      const auto match = it.next();
+      setFormat(match.capturedStart(), match.capturedLength(), format);
+      setCurrentBlockState(new_state);
+    }
+  };
+
+  // We are processing line by line and trying to find all substrings that match with these
+  // patterns. As each one paints over the others, order matters.
+
+  // Ordered heuristics for painting certain word patterns.
+  apply(&capitalized_regex_, C::kViolet);
+  apply(&function_regex_, C::kYellowOrange);
+  apply(&no_lowercase_regex_, C::kOlive);
+
+  apply(&number_regex_, C::kBlue);
+
+  // Special C/C++ words: The order here doesn't matter.
+  apply(&keyword_regex_, C::kOrange);
+  apply(&constant_regex_, C::kOlive);
+  apply(&include_file_regex_, C::kGreen);
+  apply(&preprocessor_regex_, C::kYellow);
+
+  // Comments and strings should be painted at the end.
+  apply(&string_regex_, C::kGreen);
+  apply(&comment_regex_, C::kGrey);
+
+  // For several-lines comments and strings, we have these states.
+  if (previousBlockState() == C::HighlighterState::kOpenStringState) {
+    apply(&no_end_string_regex_, C::kGreen, C::HighlighterState::kOpenStringState);
+    apply(&end_string_regex_, C::kGreen);
+  }
+  if (previousBlockState() == C::HighlighterState::kOpenCommentState) {
+    apply(&no_end_comment_regex_, C::kGrey, C::HighlighterState::kOpenCommentState);
+    apply(&end_comment_regex_, C::kGrey);
+  }
+  apply(&open_string_regex_, C::kGreen, C::HighlighterState::kOpenStringState);
+  apply(&open_comment_regex_, C::kGrey, C::HighlighterState::kOpenCommentState);
+}
+}  // namespace orbit_syntax_highlighter

--- a/src/SyntaxHighlighter/include/SyntaxHighlighter/Cpp.h
+++ b/src/SyntaxHighlighter/include/SyntaxHighlighter/Cpp.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SYNTAX_HIGHLIGHTER_CPP_H_
+#define SYNTAX_HIGHLIGHTER_CPP_H_
+
+#include <QRegularExpression>
+#include <QSyntaxHighlighter>
+
+namespace orbit_syntax_highlighter {
+
+//  This a syntax highlighter for C++.
+//  It derives from QSyntaxHighlighter, so check out QSyntaxHighlighter's
+//  documentation on how to use it. There are no additional settings or
+//  APIs.
+
+class Cpp : public QSyntaxHighlighter {
+  Q_OBJECT
+  void highlightBlock(const QString& code) override;
+
+ public:
+  explicit Cpp();
+
+ private:
+  QRegularExpression comment_regex_;
+  QRegularExpression open_comment_regex_;
+  QRegularExpression end_comment_regex_;
+  QRegularExpression no_end_comment_regex_;
+  QRegularExpression function_regex_;
+  QRegularExpression number_regex_;
+  QRegularExpression constant_regex_;
+  QRegularExpression keyword_regex_;
+  QRegularExpression preprocessor_regex_;
+  QRegularExpression include_file_regex_;
+  QRegularExpression string_regex_;
+  QRegularExpression open_string_regex_;
+  QRegularExpression end_string_regex_;
+  QRegularExpression no_end_string_regex_;
+  QRegularExpression no_lowercase_regex_;
+  QRegularExpression capitalized_regex_;
+};
+
+}  // namespace orbit_syntax_highlighter
+
+#endif  // SYNTAX_HIGHLIGHTER_CPP_H_


### PR DESCRIPTION
This PR creates the Syntax highlighter for source code (C++).
For now, the syntax highlighter is only using C-rules. It will be
expanded with C++ rule in a future PR.

It can be tested using CodeViewerDemo. There you will see a few fake unit-tests only to make regex more understandable and easier to modify in the future. 
<img width="470" alt="fake unit tests" src="https://user-images.githubusercontent.com/8610429/106737269-c546d780-6616-11eb-9576-03e83556f4b3.png">

Also there is a copy of CaptureServiceImpl.cpp as an
example to test how the Syntax Highlighter works with a real file.
<img width="491" alt="real example" src="https://user-images.githubusercontent.com/8610429/106737304-cd9f1280-6616-11eb-8368-4f3056bfb0d5.png">

Related to http://b/177651839.


