### PR TITLE
Set pid for CallstackSample/ThreadName and ThreadStateSlice

### DIFF
--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -97,7 +97,7 @@ message InternedCallstack {
 }
 
 message CallstackSample {
-  int32 pid = 1;  // Note: pid is currently not set, the client doesn't need it.
+  int32 pid = 1;
   int32 tid = 2;
   oneof callstack_or_key {
     Callstack callstack = 3;

--- a/src/LinuxTracing/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracing/LinuxTracingIntegrationTest.cpp
@@ -273,7 +273,7 @@ using PuppetConstants = LinuxTracingIntegrationTestPuppetConstants;
   }
 
   fixture->StartTracing(capture_options.value());
-  constexpr absl::Duration kSleepAfterStartTracing = absl::Milliseconds(100);
+  constexpr absl::Duration kSleepAfterStartTracing = absl::Milliseconds(300);
   absl::SleepFor(kSleepAfterStartTracing);
 
   fixture->WriteLineToPuppet(command);
@@ -543,7 +543,7 @@ TEST(LinuxTracingIntegrationTest, CallstackSamplesAndAddressInfos) {
     previous_callstack_timestamp_ns = callstack_sample.timestamp_ns();
 
     // We currently don't set the pid.
-    EXPECT_EQ(callstack_sample.pid(), 0);
+    EXPECT_EQ(callstack_sample.pid(), fixture.GetPuppetPid());
     // We are only sampling the puppet and the puppet is expected single-threaded.
     ASSERT_EQ(callstack_sample.tid(), fixture.GetPuppetPid());
 
@@ -610,8 +610,7 @@ TEST(LinuxTracingIntegrationTest, ThreadStateSlices) {
       continue;
     }
 
-    // We currently don't set the pid.
-    EXPECT_EQ(thread_state_slice.pid(), 0);
+    EXPECT_EQ(thread_state_slice.pid(), fixture.GetPuppetPid());
 
     EXPECT_TRUE(
         thread_state_slice.thread_state() == orbit_grpc_protos::ThreadStateSlice::kRunning ||
@@ -669,8 +668,7 @@ TEST(LinuxTracingIntegrationTest, ThreadNames) {
       continue;
     }
 
-    // We currently don't set the pid.
-    EXPECT_EQ(thread_name.pid(), 0);
+    EXPECT_EQ(thread_name.pid(), fixture.GetPuppetPid());
 
     collected_event_names.emplace_back(thread_name.name());
   }

--- a/src/LinuxTracing/PerfEvent.h
+++ b/src/LinuxTracing/PerfEvent.h
@@ -354,6 +354,7 @@ class TracepointPerfEvent : public PerfEvent {
   std::unique_ptr<uint8_t[]> tracepoint_data;
 
   uint64_t GetTimestamp() const override { return ring_buffer_record.sample_id.time; }
+  [[nodiscard]] int32_t pid() const { return ring_buffer_record.sample_id.pid; }
 
   uint64_t GetStreamId() const { return ring_buffer_record.sample_id.stream_id; }
 

--- a/src/LinuxTracing/ThreadStateManager.h
+++ b/src/LinuxTracing/ThreadStateManager.h
@@ -50,13 +50,14 @@ class ThreadStateManager {
                       orbit_grpc_protos::ThreadStateSlice::ThreadState state);
   void OnNewTask(uint64_t timestamp_ns, pid_t tid);
   [[nodiscard]] std::optional<orbit_grpc_protos::ThreadStateSlice> OnSchedWakeup(
-      uint64_t timestamp_ns, pid_t tid);
+      pid_t pid, uint64_t timestamp_ns, pid_t tid);
   [[nodiscard]] std::optional<orbit_grpc_protos::ThreadStateSlice> OnSchedSwitchIn(
-      uint64_t timestamp_ns, pid_t tid);
+      pid_t pid, uint64_t timestamp_ns, pid_t tid);
   [[nodiscard]] std::optional<orbit_grpc_protos::ThreadStateSlice> OnSchedSwitchOut(
-      uint64_t timestamp_ns, pid_t tid, orbit_grpc_protos::ThreadStateSlice::ThreadState new_state);
+      pid_t pid, uint64_t timestamp_ns, pid_t tid,
+      orbit_grpc_protos::ThreadStateSlice::ThreadState new_state);
   [[nodiscard]] std::vector<orbit_grpc_protos::ThreadStateSlice> OnCaptureFinished(
-      uint64_t timestamp_ns);
+      pid_t pid, uint64_t timestamp_ns);
 
  private:
   struct OpenState {

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -60,6 +60,7 @@ void UprobesUnwindingVisitor::visit(StackSamplePerfEvent* event) {
   }
 
   CallstackSample sample;
+  sample.set_pid(event->GetPid());
   sample.set_tid(event->GetTid());
   sample.set_timestamp_ns(event->GetTimestamp());
 


### PR DESCRIPTION
This field was not previously set but since this costs us
nothing lets set them.

Test: run unit and integration tests.