### PR TITLE
Add some helpers for Future-based code

### DIFF
--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(OrbitBase PRIVATE
         include/OrbitBase/Action.h
         include/OrbitBase/ExecutablePath.h
         include/OrbitBase/Future.h
+        include/OrbitBase/FutureHelpers.h
         include/OrbitBase/JoinFutures.h
         include/OrbitBase/Logging.h
         include/OrbitBase/MakeUniqueForOverwrite.h
@@ -71,6 +72,7 @@ target_compile_options(OrbitBaseTests PRIVATE ${STRICT_COMPILE_FLAGS})
 target_sources(OrbitBaseTests PRIVATE
         ExecutablePathTest.cpp
         FutureTest.cpp
+        FutureHelpersTest.cpp
         JoinFuturesTest.cpp
         ReadFileToStringTest.cpp
         OrbitApiTest.cpp

--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(OrbitBase PRIVATE
         include/OrbitBase/GetProcessIds.h
         include/OrbitBase/Profiling.h
         include/OrbitBase/Promise.h
+        include/OrbitBase/PromiseHelpers.h
         include/OrbitBase/ReadFileToString.h
         include/OrbitBase/SafeStrerror.h
         include/OrbitBase/SharedState.h
@@ -75,6 +76,7 @@ target_sources(OrbitBaseTests PRIVATE
         OrbitApiTest.cpp
         ProfilingTest.cpp
         PromiseTest.cpp
+        PromiseHelpersTest.cpp
         ThreadUtilsTest.cpp
         TracingTest.cpp
         UniqueResourceTest.cpp

--- a/src/OrbitBase/FutureHelpersTest.cpp
+++ b/src/OrbitBase/FutureHelpersTest.cpp
@@ -1,0 +1,129 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "OrbitBase/Future.h"
+#include "OrbitBase/FutureHelpers.h"
+#include "OrbitBase/Promise.h"
+
+namespace orbit_base {
+TEST(RegisterContinuationOrCallDirectly, RegisteringSucceeds) {
+  Promise<void> promise;
+  auto future = promise.GetFuture();
+
+  bool called = false;
+  RegisterContinuationOrCallDirectly(future, [&called]() { called = true; });
+
+  promise.MarkFinished();
+  EXPECT_TRUE(called);
+}
+
+TEST(RegisterContinuationOrCallDirectly, DirectCallSucceeds) {
+  Promise<void> promise;
+  promise.MarkFinished();
+  auto future = promise.GetFuture();
+
+  bool called = false;
+  RegisterContinuationOrCallDirectly(future, [&called]() { called = true; });
+  EXPECT_TRUE(called);
+}
+
+TEST(UnwrapFuture, PassthroughWithVoid) {
+  Promise<void> promise;
+  auto future = promise.GetFuture();
+
+  auto unwrapped_future = UnwrapFuture(future);
+  EXPECT_EQ(future.IsFinished(), unwrapped_future.IsFinished());
+
+  promise.MarkFinished();
+  EXPECT_EQ(future.IsFinished(), unwrapped_future.IsFinished());
+}
+
+TEST(UnwrapFuture, PassthroughWithInt) {
+  Promise<int> promise;
+  auto future = promise.GetFuture();
+
+  auto unwrapped_future = UnwrapFuture(future);
+  EXPECT_EQ(future.IsFinished(), unwrapped_future.IsFinished());
+
+  promise.SetResult(42);
+  EXPECT_EQ(future.IsFinished(), unwrapped_future.IsFinished());
+  EXPECT_EQ(future.Get(), unwrapped_future.Get());
+}
+
+TEST(UnwrapFuture, InnerFutureCompletesFirstWithVoid) {
+  Promise<Future<void>> outer_promise;
+  auto outer_future = outer_promise.GetFuture();
+
+  auto unwrapped_future = UnwrapFuture(outer_future);
+  EXPECT_TRUE(unwrapped_future.IsValid());
+  EXPECT_FALSE(unwrapped_future.IsFinished());
+
+  Promise<void> inner_promise;
+  auto inner_future = inner_promise.GetFuture();
+
+  outer_promise.SetResult(inner_future);
+  EXPECT_FALSE(unwrapped_future.IsFinished());
+
+  inner_promise.MarkFinished();
+  EXPECT_TRUE(unwrapped_future.IsFinished());
+}
+
+TEST(UnwrapFuture, OuterFutureCompletesFirstWithVoid) {
+  Promise<Future<void>> outer_promise;
+  auto outer_future = outer_promise.GetFuture();
+
+  auto unwrapped_future = UnwrapFuture(outer_future);
+  EXPECT_TRUE(unwrapped_future.IsValid());
+  EXPECT_FALSE(unwrapped_future.IsFinished());
+
+  Promise<void> inner_promise;
+  auto inner_future = inner_promise.GetFuture();
+
+  inner_promise.MarkFinished();
+  EXPECT_FALSE(unwrapped_future.IsFinished());
+
+  outer_promise.SetResult(inner_future);
+  EXPECT_TRUE(unwrapped_future.IsFinished());
+}
+
+TEST(UnwrapFuture, InnerFutureCompletesFirstWithInt) {
+  Promise<Future<int>> outer_promise;
+  auto outer_future = outer_promise.GetFuture();
+
+  auto unwrapped_future = UnwrapFuture(outer_future);
+  EXPECT_TRUE(unwrapped_future.IsValid());
+  EXPECT_FALSE(unwrapped_future.IsFinished());
+
+  Promise<int> inner_promise;
+  auto inner_future = inner_promise.GetFuture();
+
+  outer_promise.SetResult(inner_future);
+  EXPECT_FALSE(unwrapped_future.IsFinished());
+
+  inner_promise.SetResult(42);
+  EXPECT_TRUE(unwrapped_future.IsFinished());
+  EXPECT_EQ(unwrapped_future.Get(), 42);
+}
+
+TEST(UnwrapFuture, OuterFutureCompletesFirstWithInt) {
+  Promise<Future<int>> outer_promise;
+  auto outer_future = outer_promise.GetFuture();
+
+  auto unwrapped_future = UnwrapFuture(outer_future);
+  EXPECT_TRUE(unwrapped_future.IsValid());
+  EXPECT_FALSE(unwrapped_future.IsFinished());
+
+  Promise<int> inner_promise;
+  auto inner_future = inner_promise.GetFuture();
+
+  inner_promise.SetResult(42);
+  EXPECT_FALSE(unwrapped_future.IsFinished());
+
+  outer_promise.SetResult(inner_future);
+  EXPECT_TRUE(unwrapped_future.IsFinished());
+  EXPECT_EQ(unwrapped_future.Get(), 42);
+}
+}  // namespace orbit_base

--- a/src/OrbitBase/FutureTest.cpp
+++ b/src/OrbitBase/FutureTest.cpp
@@ -98,4 +98,17 @@ TEST(Future, RegisterContinuationOnValidAndUnfinishedFuture) {
   EXPECT_EQ(future.RegisterContinuation([]() {}),
             orbit_base::FutureRegisterContinuationResult::kSuccessfullyRegistered);
 }
+
+TEST(Future, CreateCompletedFuture) {
+  orbit_base::Future<void> future{};
+  EXPECT_TRUE(future.IsValid());
+  EXPECT_TRUE(future.IsFinished());
+}
+
+TEST(Future, CreateCompletedFutureWithInt) {
+  orbit_base::Future<int> future{42};
+  EXPECT_TRUE(future.IsValid());
+  EXPECT_TRUE(future.IsFinished());
+  EXPECT_EQ(future.Get(), 42);
+}
 }  // namespace orbit_base

--- a/src/OrbitBase/PromiseHelpersTest.cpp
+++ b/src/OrbitBase/PromiseHelpersTest.cpp
@@ -1,0 +1,93 @@
+
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest-typed-test.h>
+#include <gtest/gtest.h>
+
+#include "OrbitBase/Promise.h"
+#include "OrbitBase/PromiseHelpers.h"
+
+namespace orbit_base {
+
+TEST(CallTaskAndSetResultInPromise, CallWithVoid) {
+  Promise<void> promise;
+  CallTaskAndSetResultInPromise<void> helper{&promise};
+
+  bool called = false;
+  helper.Call([&called]() { called = true; });
+
+  EXPECT_TRUE(called);
+}
+
+TEST(CallTaskAndSetResultInPromise, CallWithInt) {
+  Promise<int> promise;
+  CallTaskAndSetResultInPromise<int> helper{&promise};
+
+  bool called = false;
+  helper.Call([&called]() {
+    called = true;
+    return 42;
+  });
+
+  EXPECT_TRUE(called);
+}
+
+TEST(CallTaskAndSetResultInPromise, CallWithMoveOnlyType) {
+  Promise<std::unique_ptr<int>> promise;
+  CallTaskAndSetResultInPromise<std::unique_ptr<int>> helper{&promise};
+
+  bool called = false;
+  helper.Call([&called]() {
+    called = true;
+    return std::make_unique<int>(42);
+  });
+
+  EXPECT_TRUE(called);
+}
+
+TEST(GetResultFromFutureAndCallContinuation, CallWithoutResult) {
+  Promise<void> promise;
+  promise.MarkFinished();
+  auto future = promise.GetFuture();
+
+  GetResultFromFutureAndCallContinuation<void> helper{&future};
+
+  bool called = false;
+  helper.Call([&called]() { called = true; });
+
+  EXPECT_TRUE(called);
+}
+
+TEST(GetResultFromFutureAndCallContinuation, CallWithResult) {
+  Promise<int> promise;
+  promise.SetResult(42);
+  auto future = promise.GetFuture();
+
+  GetResultFromFutureAndCallContinuation<int> helper{&future};
+
+  bool called = false;
+  helper.Call([&called](int val) {
+    EXPECT_EQ(val, 42);
+    called = true;
+  });
+
+  EXPECT_TRUE(called);
+}
+
+TEST(CopyableFunctionObjectContainer, IsCopyable) {
+  CopyableFunctionObjectContainer container{[]() { return 42; }};
+
+  auto copy = container;
+  EXPECT_EQ(copy(), 42);
+}
+
+TEST(CopyableFunctionObjectContainer, IsCopyableWithMoveOnlyElement) {
+  CopyableFunctionObjectContainer container{[ptr = std::make_unique<int>(42)]() { return *ptr; }};
+
+  auto copy = container;
+  EXPECT_EQ(copy(), 42);
+}
+
+}  // namespace orbit_base

--- a/src/OrbitBase/include/OrbitBase/Future.h
+++ b/src/OrbitBase/include/OrbitBase/Future.h
@@ -73,9 +73,19 @@ enum class FutureRegisterContinuationResult {
 //
 // Real-world examples should involved an executor like MainThreadExecutor or ThreadPool.
 // Check-out their tests and docs to learn how to use Future.
+//
+// The default constructor creates a completed future. This is handy as a return value.
 template <typename T>
 class [[nodiscard]] Future : public orbit_base_internal::FutureBase<T> {
  public:
+  // Constructs a completed future
+  template <typename... Args>
+  explicit Future(Args && ... args)
+      : orbit_base_internal::FutureBase<T>{
+            std::make_shared<orbit_base_internal::SharedState<T>>()} {
+    this->shared_state_->result.emplace(std::forward<Args>(args)...);
+  }
+
   [[nodiscard]] bool IsFinished() const {
     if (this->shared_state_.use_count() == 0) return false;
 
@@ -143,9 +153,18 @@ class [[nodiscard]] Future : public orbit_base_internal::FutureBase<T> {
 // notify the caller, when the asynchronous tasks completes.
 //
 // Unlike Future<T>, Future<void> has no `Get()` method since there is no return value.
+//
+// The default constructor creates a completed future. This is handy as a return value.
 template <>
 class Future<void> : public orbit_base_internal::FutureBase<void> {
  public:
+  // Constructs a completed future
+  explicit Future()
+      : orbit_base_internal::FutureBase<void>{
+            std::make_shared<orbit_base_internal::SharedState<void>>()} {
+    this->shared_state_->finished = true;
+  }
+
   [[nodiscard]] bool IsFinished() const {
     if (shared_state_.use_count() == 0) return false;
 

--- a/src/OrbitBase/include/OrbitBase/FutureHelpers.h
+++ b/src/OrbitBase/include/OrbitBase/FutureHelpers.h
@@ -1,0 +1,78 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_BASE_FUTURE_HELPERS_H_
+#define ORBIT_BASE_FUTURE_HELPERS_H_
+
+#include <type_traits>
+#include <utility>
+
+#include "OrbitBase/Future.h"
+#include "OrbitBase/Promise.h"
+
+namespace orbit_base {
+
+template <typename T, typename Invocable>
+void RegisterContinuationOrCallDirectly(const Future<T>& future, Invocable continuation) {
+  const auto result = future.RegisterContinuation(continuation);
+
+  if (result == FutureRegisterContinuationResult::kFutureAlreadyCompleted) {
+    continuation(future.Get());
+  }
+}
+
+template <typename Invocable>
+void RegisterContinuationOrCallDirectly(const Future<void>& future, Invocable continuation) {
+  const auto result = future.RegisterContinuation(continuation);
+
+  if (result == FutureRegisterContinuationResult::kFutureAlreadyCompleted) {
+    continuation();
+  }
+}
+
+template <typename T>
+[[nodiscard]] inline Future<T> UnwrapFuture(const Future<T>& future) {
+  return future;
+}
+
+template <typename T>
+[[nodiscard]] inline Future<T> UnwrapFuture(const Future<Future<T>>& outer_future) {
+  CHECK(outer_future.IsValid());
+
+  // A quick explanation what's happening here:
+  // We have an outer and a inner future. When the outer future completes, the inner
+  // one gets available. When the inner one completes the value of type T gets available.
+  //
+  // Ideally we would just return the inner future. But since it is not available at the time this
+  // function is executed that is not an option. So we create a new promise/future pair.
+  // Then we register a continuation with the inner future that sets the result in the just created
+  // promise. That's also not so simple because - as said before - the inner future is not yet
+  // available. So we have to register an outer continuation that takes care of registering the
+  // inner continuation.
+  auto promise = std::make_shared<Promise<T>>();
+
+  auto outer_continuation = [promise](const Future<T>& inner_future) {
+    auto inner_continuation = [promise](const T& arg) { promise->SetResult(arg); };
+    RegisterContinuationOrCallDirectly(inner_future, inner_continuation);
+  };
+  RegisterContinuationOrCallDirectly(outer_future, outer_continuation);
+  return promise->GetFuture();
+}
+
+[[nodiscard]] inline Future<void> UnwrapFuture(const Future<Future<void>>& outer_future) {
+  CHECK(outer_future.IsValid());
+
+  auto promise = std::make_shared<Promise<void>>();
+
+  auto outer_continuation = [promise](const Future<void>& inner_future) {
+    auto inner_continuation = [promise]() { promise->MarkFinished(); };
+    RegisterContinuationOrCallDirectly(inner_future, inner_continuation);
+  };
+  RegisterContinuationOrCallDirectly(outer_future, outer_continuation);
+  return promise->GetFuture();
+}
+
+}  // namespace orbit_base
+
+#endif  // ORBIT_BASE_FUTURE_HELPERS_H_

--- a/src/OrbitBase/include/OrbitBase/PromiseHelpers.h
+++ b/src/OrbitBase/include/OrbitBase/PromiseHelpers.h
@@ -1,0 +1,122 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_BASE_PROMISE_HELPERS_H_
+#define ORBIT_BASE_PROMISE_HELPERS_H_
+
+#include <type_traits>
+#include <utility>
+
+#include "OrbitBase/Promise.h"
+
+namespace orbit_base {
+
+// Calls `invocable` and sets the return value as the result in the given promise.
+// It also works when `invocable` returns `void`. In this case `MarkFinished` is called on the
+// promise.
+template <typename T>
+struct CallTaskAndSetResultInPromise {
+  orbit_base::Promise<T>* promise;
+
+  template <typename Invocable, typename... Args>
+  void Call(Invocable&& invocable, Args&&... args) {
+    promise->SetResult(invocable(std::forward<Args>(args)...));
+  }
+};
+
+template <>
+struct CallTaskAndSetResultInPromise<void> {
+  orbit_base::Promise<void>* promise;
+
+  template <typename Invocable, typename... Args>
+  void Call(Invocable&& invocable, Args&&... args) {
+    invocable(std::forward<Args>(args)...);
+    promise->MarkFinished();
+  }
+};
+
+// Retrieves the result from a futures and calls `invocable` with the result as a parameter.
+// It also works when the futures value type is void. In this case `invocable` is called without
+// parameters.
+template <typename T>
+struct GetResultFromFutureAndCallContinuation {
+  const orbit_base::Future<T>* future;
+
+  template <typename Invocable>
+  void Call(Invocable&& invocable) {
+    invocable(future->Get());
+  }
+};
+
+template <>
+struct GetResultFromFutureAndCallContinuation<void> {
+  const orbit_base::Future<void>* future;
+
+  template <typename Invocable>
+  void Call(Invocable&& invocable) {
+    future->Wait();
+    invocable();
+  }
+};
+
+// CopyableFunctionObjectContainer can hold any function object.
+// If the function object type is copyable, it will hold the function object by value. If it is
+// only movable, the function object will be moved into a shared_ptr.
+//
+// You can use this work-around to wrap a move-only function object in a std::function, which
+// requires copyability.
+template <typename FunctionObject,
+          typename = typename std::is_copy_constructible<FunctionObject>::type>
+class CopyableFunctionObjectContainer {
+  FunctionObject function_object_;
+
+ public:
+  explicit CopyableFunctionObjectContainer(FunctionObject&& obj)
+      : function_object_{std::move(obj)} {}
+
+  template <typename... Args>
+  decltype(auto) operator()(Args&&... args) {
+    return function_object_(std::forward<Args>(args)...);
+  }
+
+  template <typename... Args>
+  decltype(auto) operator()(Args&&... args) const {
+    return function_object_(std::forward<Args>(args)...);
+  }
+};
+
+template <typename FunctionObject>
+class CopyableFunctionObjectContainer<FunctionObject, std::false_type> {
+  std::shared_ptr<FunctionObject> function_object_;
+
+ public:
+  explicit CopyableFunctionObjectContainer(FunctionObject&& obj)
+      : function_object_{std::make_shared<FunctionObject>(std::move(obj))} {}
+
+  template <typename... Args>
+  decltype(auto) operator()(Args&&... args) {
+    return (*function_object_)(std::forward<Args>(args)...);
+  }
+
+  template <typename... Args>
+  decltype(auto) operator()(Args&&... args) const {
+    return static_cast<const FunctionObject&>(*function_object_)(std::forward<Args>(args)...);
+  }
+};
+
+// Determines the return type of the call "Invocable(T)". If `T` is `void` it returns the return
+// type of the call `Invocable()`.
+template <typename T, typename Invocable>
+struct ContinuationReturnType {
+  using Type = std::decay_t<decltype(std::declval<Invocable>()(std::declval<T>()))>;
+};
+
+template <typename Invocable>
+struct ContinuationReturnType<void, Invocable> {
+  using Type = std::decay_t<decltype(std::declval<Invocable>()())>;
+};
+
+}  // namespace orbit_base
+
+#endif  // ORBIT_BASE_PROMISE_HELPERS_H_

--- a/src/OrbitGl/MainThreadExecutor.h
+++ b/src/OrbitGl/MainThreadExecutor.h
@@ -16,6 +16,7 @@
 #include "OrbitBase/Action.h"
 #include "OrbitBase/Future.h"
 #include "OrbitBase/Promise.h"
+#include "OrbitBase/PromiseHelpers.h"
 
 // This class implements a mechanism for landing
 // actions to the main thread. As a general rule
@@ -48,20 +49,12 @@ class MainThreadExecutor : public std::enable_shared_from_this<MainThreadExecuto
     orbit_base::Promise<ReturnType> promise;
     orbit_base::Future<ReturnType> future = promise.GetFuture();
 
-    if constexpr (std::is_same_v<ReturnType, void>) {
-      auto function_wrapper = [functor = std::forward<F>(functor),
-                               promise = std::move(promise)]() mutable {
-        functor();
-        promise.MarkFinished();
-      };
-      Schedule(CreateAction(std::move(function_wrapper)));
-    } else {
-      auto function_wrapper = [functor = std::forward<F>(functor),
-                               promise = std::move(promise)]() mutable {
-        promise.SetResult(functor());
-      };
-      Schedule(CreateAction(std::move(function_wrapper)));
-    }
+    auto function_wrapper = [functor = std::forward<F>(functor),
+                             promise = std::move(promise)]() mutable {
+      orbit_base::CallTaskAndSetResultInPromise<ReturnType> helper{&promise};
+      helper.Call(functor);
+    };
+    Schedule(CreateAction(std::move(function_wrapper)));
 
     return future;
   }
@@ -70,133 +63,45 @@ class MainThreadExecutor : public std::enable_shared_from_this<MainThreadExecuto
   // on `*this` after `future` has completed.
   //
   // Note: The continuation is only executed if `*this` is still alive when `future` completes.
-  template <typename F>
-  auto ScheduleAfter(const orbit_base::Future<void>& future, F&& functor)
-      -> orbit_base::Future<std::decay_t<decltype(functor())>> {
-    CHECK(future.IsValid());
-
-    using ReturnType = std::decay_t<decltype(functor())>;
-
-    // Since std::function needs to be copyable, promise also needs to be copyable.
-    auto promise = std::make_shared<orbit_base::Promise<ReturnType>>();
-    orbit_base::Future<ReturnType> resulting_future = promise->GetFuture();
-
-    // Since MSVC2017 crashes with a compiler error when using `if constexpr` inside of lambda, we
-    // have to put the check on the outside. That's unfortunate since it leads to four almost
-    // identical version of the same code.
-    if constexpr (std::is_same_v<ReturnType, void>) {
-      auto continuation = [functor = std::forward<F>(functor), executor_weak_ptr = weak_from_this(),
-                           promise = std::move(promise)]() mutable {
-        auto executor = executor_weak_ptr.lock();
-        if (executor == nullptr) return;
-
-        auto function_wrapper = [functor = std::move(functor),
-                                 promise = std::move(promise)]() mutable {
-          functor();
-          promise->MarkFinished();
-        };
-        executor->Schedule(CreateAction(std::move(function_wrapper)));
-      };
-
-      const orbit_base::FutureRegisterContinuationResult result =
-          future.RegisterContinuation(std::move(continuation));
-
-      if (result != orbit_base::FutureRegisterContinuationResult::kSuccessfullyRegistered) {
-        // If the future has already been finished, we call the continuation here.
-        // Keep in mind, this will not run the task synchronously. This will only
-        // SCHEDULE the task synchronously.
-        continuation();
-      }
-    } else {
-      auto continuation = [functor = std::forward<F>(functor), executor_weak_ptr = weak_from_this(),
-                           promise = std::move(promise)]() mutable {
-        auto executor = executor_weak_ptr.lock();
-        if (executor == nullptr) return;
-
-        auto function_wrapper = [functor = std::move(functor),
-                                 promise = std::move(promise)]() mutable {
-          promise->SetResult(functor());
-        };
-        executor->Schedule(CreateAction(std::move(function_wrapper)));
-      };
-
-      const orbit_base::FutureRegisterContinuationResult result =
-          future.RegisterContinuation(std::move(continuation));
-
-      if (result != orbit_base::FutureRegisterContinuationResult::kSuccessfullyRegistered) {
-        // If the future has already been finished, we call the continuation here.
-        // Keep in mind, this will not run the task synchronously. This will only
-        // SCHEDULE the task synchronously.
-        continuation();
-      }
-    }
-
-    return resulting_future;
-  }
-
-  // ScheduleAfter schedules the continuation `functor` to be executed
-  // on `*this` after `future` has completed.
-  //
-  // Note: The continuation is only executed if `*this` is still alive when `future` completes.
   template <typename T, typename F>
-  auto ScheduleAfter(const orbit_base::Future<T>& future, F&& functor)
-      -> orbit_base::Future<std::decay_t<decltype(functor(std::declval<T>()))>> {
+  auto ScheduleAfter(const orbit_base::Future<T>& future, F&& functor) {
     CHECK(future.IsValid());
 
-    using ReturnType = std::decay_t<decltype(functor(std::declval<T>()))>;
+    using ReturnType = typename orbit_base::ContinuationReturnType<T, F>::Type;
 
-    // Since std::function needs to be copyable, promise also needs to be copyable.
+    // Since std::function is copyable, promise and functor also need to be copyable.
+    // That's why we wrap both in shared_ptr-based wrappers. That's not ideal.
+    // std::function in SharedState should be replaced by absl::any_invocable as soon as it is
+    // released.
     auto promise = std::make_shared<orbit_base::Promise<ReturnType>>();
     orbit_base::Future<ReturnType> resulting_future = promise->GetFuture();
+    orbit_base::CopyableFunctionObjectContainer copyable_function{std::forward<F>(functor)};
 
-    // Since MSVC2017 crashes with a compiler error when using `if constexpr` inside of lambda, we
-    // have to put the check on the outside. That's unfortunate since it leads to four almost
-    // identical version of the same code.
-    if constexpr (std::is_same_v<ReturnType, void>) {
-      auto continuation = [functor = std::forward<F>(functor), executor_weak_ptr = weak_from_this(),
-                           promise = std::move(promise)](auto&& argument) mutable {
-        auto executor = executor_weak_ptr.lock();
-        if (executor == nullptr) return;
+    auto continuation = [copyable_function = std::move(copyable_function),
+                         executor_weak_ptr = weak_from_this(),
+                         promise = std::move(promise)](auto&&... argument) mutable {
+      auto executor = executor_weak_ptr.lock();
+      if (executor == nullptr) return;
 
-        auto function_wrapper = [functor = std::move(functor), promise = std::move(promise),
-                                 argument = std::forward<decltype(argument)>(argument)]() mutable {
-          functor(std::move(argument));
-          promise->MarkFinished();
-        };
-        executor->Schedule(CreateAction(std::move(function_wrapper)));
-      };
+      auto function_wrapper =
+          [copyable_function = std::move(copyable_function), promise = std::move(promise),
+           argument = std::make_tuple(std::forward<decltype(argument)>(argument)...)]() mutable {
+            orbit_base::CallTaskAndSetResultInPromise<ReturnType> helper{promise.get()};
+            std::apply([&](auto... args) { helper.Call(copyable_function, args...); },
+                       std::move(argument));
+          };
+      executor->Schedule(CreateAction(std::move(function_wrapper)));
+    };
 
-      const orbit_base::FutureRegisterContinuationResult result =
-          future.RegisterContinuation(std::move(continuation));
+    const orbit_base::FutureRegisterContinuationResult result =
+        future.RegisterContinuation(std::move(continuation));
 
-      if (result != orbit_base::FutureRegisterContinuationResult::kSuccessfullyRegistered) {
-        // If the future has already been finished, we call the continuation here.
-        // Keep in mind, this will not run the task synchronously. This will only
-        // SCHEDULE the task synchronously.
-        continuation(future.Get());
-      }
-    } else {
-      auto continuation = [functor = std::forward<F>(functor), executor_weak_ptr = weak_from_this(),
-                           promise = std::move(promise)](auto&& argument) mutable {
-        auto executor = executor_weak_ptr.lock();
-        if (executor == nullptr) return;
-
-        auto function_wrapper = [functor = std::move(functor), promise = std::move(promise),
-                                 argument = std::forward<decltype(argument)>(argument)]() mutable {
-          promise->SetResult(functor(std::move(argument)));
-        };
-        executor->Schedule(CreateAction(std::move(function_wrapper)));
-      };
-
-      const orbit_base::FutureRegisterContinuationResult result =
-          future.RegisterContinuation(std::move(continuation));
-
-      if (result != orbit_base::FutureRegisterContinuationResult::kSuccessfullyRegistered) {
-        // If the future has already been finished, we call the continuation here.
-        // Keep in mind, this will not run the task synchronously. This will only
-        // SCHEDULE the task synchronously.
-        continuation(future.Get());
-      }
+    if (result != orbit_base::FutureRegisterContinuationResult::kSuccessfullyRegistered) {
+      // If the future has already been finished, we call the continuation here.
+      // Keep in mind, this will not run the task synchronously. This will only
+      // SCHEDULE the task synchronously.
+      orbit_base::GetResultFromFutureAndCallContinuation<T> helper{&future};
+      helper.Call(continuation);
     }
 
     return resulting_future;


### PR DESCRIPTION
As far as I can see, this will finally be the last PR for the promise framework.

It adds some tools which should simplify writing code with futures, making it more readable and easier to understand.

### PromiseHelpers.h

These are mainly small trait-like helper classes to deal with semantic difference between `Promise<T>` and `Promise<void>`.
Not so useful for the general use case, but helpful for simplifying `MainThreadExecutor::ScheduleAfter` (2nd commit).

### UnwrapFuture from FutureHelpers.h

This function unwraps (or flattens) nested futures. Imagine you have a type `Future<Future<T>>`. Calling UnwrapFuture on that type will return a future that completes when the inner future completes.

This is often useful when using `Future::Then` with a continuation that returns a Future.

```cpp

Future<ErrorMessageOr<void>> LoadModule(const std::string& module_path) {
  const auto load_module_future = main_thread_executor_->Schedule([this, module_path]() -> Future<ErrorMessageOr<void>> {
    const auto symbols_path = LoadModuleLocally(module_path);

    if (symbols_path.error()) return symbols_path.error();

    return LoadModuleOnRemote(module_path);
  });

  // Since the lambda returns a future, `load_module_future` is of type `Future<Future<ErrorMessageOr<void>>`.
  return UnwrapFuture(load_module_future);
```

### Public constructors for Futures

Sometimes it's useful to construct Futures without its asynchronous nature. Example:

```cpp
Future<ErrorMessageOr<std::string>> process(std::string input) {

  // Return early with error if precondition is not met.
  if (input.empty()) return Future<ErrorMessageOr<std::string>>{ErrorMessage{"input is invalid!"}};

  return thread_pool_->Schedule([input]() {
    // do expensive processing
    return output;
  });
}
```

That's why I added public constructors to the Future type which create valid, and completed futures that are not connected to any promise.