### PR TITLE
Introspection window is correctly freed on shutdown

### DIFF
--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -938,7 +938,7 @@ void OrbitMainWindow::on_actionHelp_triggered() { app_->ToggleDrawHelp(); }
 
 void OrbitMainWindow::on_actionIntrospection_triggered() {
   if (introspection_widget_ == nullptr) {
-    introspection_widget_ = new OrbitGLWidget();
+    introspection_widget_ = std::make_unique<OrbitGLWidget>();
     introspection_widget_->setWindowFlags(Qt::WindowStaysOnTopHint);
     introspection_widget_->Initialize(GlCanvas::CanvasType::kIntrospectionWindow, this, 14,
                                       app_.get());
@@ -1116,7 +1116,7 @@ bool OrbitMainWindow::eventFilter(QObject* watched, QEvent* event) {
         }
       }
     }
-  } else if (watched == introspection_widget_) {
+  } else if (watched == introspection_widget_.get()) {
     if (event->type() == QEvent::Close) {
       app_->StopIntrospection();
     }
@@ -1139,6 +1139,9 @@ void OrbitMainWindow::closeEvent(QCloseEvent* event) {
   } else {
     if (main_thread_executor_) {
       main_thread_executor_->AbortWaitingJobs();
+    }
+    if (introspection_widget_ != nullptr) {
+      introspection_widget_->close();
     }
     QMainWindow::closeEvent(event);
   }

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -169,7 +169,7 @@ class OrbitMainWindow : public QMainWindow {
   FilterPanelWidgetAction* filter_panel_action_ = nullptr;
   QTimer* m_MainTimer = nullptr;
   std::vector<OrbitGLWidget*> gl_widgets_;
-  OrbitGLWidget* introspection_widget_ = nullptr;
+  std::unique_ptr<OrbitGLWidget> introspection_widget_ = nullptr;
   QFrame* hint_frame_ = nullptr;
   QLabel* target_label_ = nullptr;
 


### PR DESCRIPTION
Fixes b/176509021

The introspection window is not parented under the main window, and is therefore not freed automatically when the UI is destroyed. Changing the pointer to unique_ptr fixes the issue.

In addition, closing Orbit while the introspection window is open will now automatically close the introspection.