### PR TITLE
Add Session UUID to MetricsUploader

### DIFF
--- a/src/MetricsUploader/CMakeLists.txt
+++ b/src/MetricsUploader/CMakeLists.txt
@@ -30,6 +30,10 @@ target_link_libraries(MetricsUploader PUBLIC OrbitBase
                                              OrbitVersion
                                              CONAN_PKG::abseil)
 
+if (WIN32)
+target_link_libraries(MetricsUploader PUBLIC rpcrt4.lib)
+endif()
+
 # generate protos for communication
 protobuf_generate(TARGET MetricsUploader PROTOS proto/orbit_log_event.proto)
 target_include_directories(MetricsUploader PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/src/MetricsUploader/MetricsUploader.cpp
+++ b/src/MetricsUploader/MetricsUploader.cpp
@@ -18,6 +18,7 @@ bool MetricsUploader::SendLogEvent(OrbitLogEvent_LogEventType log_event_type,
     log_event.set_log_event_type(log_event_type);
     log_event.set_orbit_version(orbit_core::GetVersion());
     log_event.set_event_duration_milliseconds(event_duration.count());
+    log_event.set_session_uuid(session_uuid_);
 
     int message_size = log_event.ByteSize();
     std::vector<uint8_t> buffer(message_size);

--- a/src/MetricsUploader/MetricsUploaderLinux.cpp
+++ b/src/MetricsUploader/MetricsUploaderLinux.cpp
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "MetricsUploader/MetricsUploader.h"
+#include "OrbitBase/Result.h"
 
 namespace orbit_metrics_uploader {
 
@@ -13,6 +14,10 @@ MetricsUploader& MetricsUploader::operator=(MetricsUploader&& other) = default;
 
 ErrorMessageOr<MetricsUploader> MetricsUploader::CreateMetricsUploader(std::string) {
   return ErrorMessage("MetricsUploader is not implemented on Linux");
+}
+
+ErrorMessageOr<std::string> GenerateUUID() {
+  return ErrorMessage("UUID generation is not implemented on Linux");
 }
 
 }  // namespace orbit_metrics_uploader

--- a/src/MetricsUploader/MetricsUploaderWindows.cpp
+++ b/src/MetricsUploader/MetricsUploaderWindows.cpp
@@ -2,25 +2,31 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <Rpc.h>
 #include <absl/memory/memory.h>
+
+#include <type_traits>
 
 #include "MetricsUploader/MetricsUploader.h"
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/Result.h"
 
 namespace orbit_metrics_uploader {
 
 constexpr const char* kSendLogEventFunctionName = "SendOrbitLogEvent";
 constexpr const char* kStartUploaderClientFunctionName = "StartUploaderClient";
 
-MetricsUploader::MetricsUploader(std::string client_name,
+MetricsUploader::MetricsUploader(std::string client_name, std::string session_uuid,
                                  Result (*send_log_event_addr)(const uint8_t*, int),
                                  HMODULE metrics_uploader_client_dll)
     : client_name_(std::move(client_name)),
+      session_uuid_(std::move(session_uuid)),
       send_log_event_addr_(send_log_event_addr),
       metrics_uploader_client_dll_(metrics_uploader_client_dll) {}
 
 MetricsUploader::MetricsUploader(MetricsUploader&& other)
     : client_name_(std::move(other.client_name_)),
+      session_uuid_(std::move(other.session_uuid_)),
       metrics_uploader_client_dll_(other.metrics_uploader_client_dll_),
       send_log_event_addr_(other.send_log_event_addr_) {
   other.metrics_uploader_client_dll_ = nullptr;
@@ -56,34 +62,59 @@ ErrorMessageOr<MetricsUploader> MetricsUploader::CreateMetricsUploader(std::stri
     return ErrorMessage("MetricsUploader is already created");
   }
 
+  OUTCOME_TRY(session_uuid, GenerateUUID());
+  LOG("Session UUID for metrics: %s", session_uuid);
+
   metrics_uploader_client_dll = LoadLibraryA(client_name.c_str());
-  if (nullptr != metrics_uploader_client_dll) {
-    auto start_uploader_client_addr = reinterpret_cast<Result (*)()>(
-        GetProcAddress(metrics_uploader_client_dll, kStartUploaderClientFunctionName));
-    if (nullptr == start_uploader_client_addr) {
-      FreeLibrary(metrics_uploader_client_dll);
-      return ErrorMessage(
-          absl::StrFormat("%s function not found", kStartUploaderClientFunctionName));
-    }
-
-    auto send_log_event_addr = reinterpret_cast<Result (*)(const uint8_t*, int)>(
-        GetProcAddress(metrics_uploader_client_dll, kSendLogEventFunctionName));
-    if (nullptr == send_log_event_addr) {
-      FreeLibrary(metrics_uploader_client_dll);
-      return ErrorMessage(absl::StrFormat("%s function not found", kSendLogEventFunctionName));
-    }
-
-    // set up connection and create a client
-    Result result = start_uploader_client_addr();
-    if (result != kNoError) {
-      FreeLibrary(metrics_uploader_client_dll);
-      return ErrorMessage(absl::StrFormat("Error while starting the metrics uploader client: %s",
-                                          GetErrorMessage(result)));
-    }
-
-    return MetricsUploader(client_name, send_log_event_addr, metrics_uploader_client_dll);
+  if (metrics_uploader_client_dll == nullptr) {
+    return ErrorMessage("Metrics uploader client library is not found");
   }
-  return ErrorMessage("Metrics uploader client library is not found");
+
+  auto start_uploader_client_addr = reinterpret_cast<Result (*)()>(
+      GetProcAddress(metrics_uploader_client_dll, kStartUploaderClientFunctionName));
+  if (nullptr == start_uploader_client_addr) {
+    FreeLibrary(metrics_uploader_client_dll);
+    return ErrorMessage(absl::StrFormat("%s function not found", kStartUploaderClientFunctionName));
+  }
+
+  auto send_log_event_addr = reinterpret_cast<Result (*)(const uint8_t*, int)>(
+      GetProcAddress(metrics_uploader_client_dll, kSendLogEventFunctionName));
+  if (nullptr == send_log_event_addr) {
+    FreeLibrary(metrics_uploader_client_dll);
+    return ErrorMessage(absl::StrFormat("%s function not found", kSendLogEventFunctionName));
+  }
+
+  // set up connection and create a client
+  Result result = start_uploader_client_addr();
+  if (result != kNoError) {
+    FreeLibrary(metrics_uploader_client_dll);
+    return ErrorMessage(absl::StrFormat("Error while starting the metrics uploader client: %s",
+                                        GetErrorMessage(result)));
+  }
+
+  return MetricsUploader(client_name, session_uuid, send_log_event_addr,
+                         metrics_uploader_client_dll);
+}
+
+ErrorMessageOr<std::string> GenerateUUID() {
+  UUID uuid;
+  RPC_STATUS create_status = UuidCreate(&uuid);
+  if (create_status != RPC_S_OK) {
+    return ErrorMessage("Unable to create UUID for metrics uploader");
+  }
+  RPC_CSTR uuid_c_str = nullptr;
+  RPC_STATUS convert_status = UuidToStringA(&uuid, &uuid_c_str);
+  if (convert_status != RPC_S_OK) {
+    return ErrorMessage("Unable to convert UUID to string for metrics uploader");
+  }
+
+  static_assert(std::is_same_v<RPC_CSTR, unsigned char*>,
+                "The type of RPC_CSTR needs to be castable to const char*");
+
+  std::string uuid_string{reinterpret_cast<const char*>(uuid_c_str)};
+  RpcStringFreeA(&uuid_c_str);
+
+  return uuid_string;
 }
 
 }  // namespace orbit_metrics_uploader

--- a/src/MetricsUploader/include/MetricsUploader/MetricsUploader.h
+++ b/src/MetricsUploader/include/MetricsUploader/MetricsUploader.h
@@ -58,7 +58,7 @@ class MetricsUploader {
  private:
 #ifdef _WIN32
   HMODULE metrics_uploader_client_dll_;
-  explicit MetricsUploader(std::string client_name,
+  explicit MetricsUploader(std::string client_name, std::string session_uuid,
                            Result (*send_log_event_addr)(const uint8_t*, int),
                            HMODULE metrics_uploader_client_dll);
 #else
@@ -67,7 +67,10 @@ class MetricsUploader {
 
   Result (*send_log_event_addr_)(const uint8_t*, int) = nullptr;
   std::string client_name_;
+  std::string session_uuid_;
 };
+
+[[nodiscard]] ErrorMessageOr<std::string> GenerateUUID();
 
 }  // namespace orbit_metrics_uploader
 

--- a/src/MetricsUploader/proto/orbit_log_event.proto
+++ b/src/MetricsUploader/proto/orbit_log_event.proto
@@ -19,4 +19,5 @@ message OrbitLogEvent {
 
   string orbit_version = 2;
   int64 event_duration_milliseconds = 3;
+  string session_uuid = 4;
 }


### PR DESCRIPTION
This adds a uuid for tracking sessions to the orbit_log_event_proto and
generates a uuid based on msdn libraries.

Test: Start orbit with --enable_metrics and then in Orbit.log there should be a line like this: 
[2021-01-28T10:51:39.738459] [MetricsUploader/MetricsUploaderWindows.cpp:77] Session UUID for metrics: b3d65cfa-8438-4c7a-8f59-a2368567b15a