### PR TITLE
Imgui shutdown fix

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -468,7 +468,7 @@ void OrbitApp::RefreshCaptureView() {
   DoZoom = true;  // TODO: remove global, review logic
 }
 
-void OrbitApp::RenderImGui() {
+void OrbitApp::RenderImGuiDebugUI() {
   CHECK(debug_canvas_ != nullptr);
   CHECK(capture_window_ != nullptr);
   ScopeImguiContext context(debug_canvas_->GetImGuiContext());
@@ -485,13 +485,13 @@ void OrbitApp::RenderImGui() {
 
   if (ImGui::BeginTabBar("DebugTabBar", ImGuiTabBarFlags_None)) {
     if (ImGui::BeginTabItem("CaptureWindow")) {
-      capture_window_->RenderImGui();
+      capture_window_->RenderImGuiDebugUI();
       ImGui::EndTabItem();
     }
 
     if (introspection_window_) {
       if (ImGui::BeginTabItem("Introspection")) {
-        introspection_window_->RenderImGui();
+        introspection_window_->RenderImGuiDebugUI();
         ImGui::EndTabItem();
       }
     }
@@ -576,9 +576,7 @@ void OrbitApp::SetDebugCanvas(GlCanvas* debug_canvas) {
   CHECK(debug_canvas_ == nullptr);
   debug_canvas_ = debug_canvas;
   debug_canvas_->EnableImGui();
-  constexpr uint32_t kImGuiFontSize = 12;
-  Orbit_ImGui_Init(kImGuiFontSize);
-  debug_canvas_->AddRenderCallback([this]() { RenderImGui(); });
+  debug_canvas_->AddRenderCallback([this]() { RenderImGuiDebugUI(); });
 }
 
 void OrbitApp::SetIntrospectionWindow(IntrospectionWindow* introspection_window) {

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -576,7 +576,8 @@ void OrbitApp::SetDebugCanvas(GlCanvas* debug_canvas) {
   CHECK(debug_canvas_ == nullptr);
   debug_canvas_ = debug_canvas;
   debug_canvas_->EnableImGui();
-  Orbit_ImGui_Init(debug_canvas_->GetInitialFontSize());
+  constexpr uint32_t kImGuiFontSize = 12;
+  Orbit_ImGui_Init(kImGuiFontSize);
   debug_canvas_->AddRenderCallback([this]() { RenderImGui(); });
 }
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -288,7 +288,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void SendWarningToUi(const std::string& title, const std::string& text);
   void SendErrorToUi(const std::string& title, const std::string& text);
   void NeedsRedraw();
-  void RenderImGui();
+  void RenderImGuiDebugUI();
 
   void LoadModules(
       const std::vector<ModuleData*>& modules,

--- a/src/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
+++ b/src/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
@@ -70,7 +70,7 @@ DEFINE_PROTO_FUZZER(const orbit_client_protos::CaptureDeserializerFuzzerInfo& in
   app->SetTopDownViewCallback([](std::unique_ptr<CallTreeView> /*view*/) {});
   app->SetBottomUpViewCallback([](std::unique_ptr<CallTreeView> /*view*/) {});
 
-  TimeGraph time_graph{14, app.get()};
+  TimeGraph time_graph{app.get()};
   GCurrentTimeGraph = &time_graph;
   app->ClearCapture();
 

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -59,8 +59,7 @@ class AccessibleCaptureWindow : public AccessibleWidgetBridge {
 
 using orbit_client_protos::TimerInfo;
 
-CaptureWindow::CaptureWindow(uint32_t font_size, OrbitApp* app)
-    : GlCanvas(font_size), font_size_(font_size), time_graph_(font_size, app), app_{app} {
+CaptureWindow::CaptureWindow(OrbitApp* app) : GlCanvas(), time_graph_(app), app_{app} {
   time_graph_.SetTextRenderer(&text_renderer_);
   time_graph_.SetCanvas(this);
   draw_help_ = true;
@@ -769,8 +768,8 @@ void CaptureWindow::RenderHelpUi() {
   Vec2 text_bounding_box_pos;
   Vec2 text_bounding_box_size;
   text_renderer_.AddText(GetHelpText(), world_x, world_y, GlCanvas::kZValueTextUi,
-                         Color(255, 255, 255, 255), font_size_, -1.f /*max_size*/,
-                         false /*right_justified*/, &text_bounding_box_pos,
+                         Color(255, 255, 255, 255), time_graph_.GetLayout().GetFontSize(),
+                         -1.f /*max_size*/, false /*right_justified*/, &text_bounding_box_pos,
                          &text_bounding_box_size);
 
   const Color kBoxColor(50, 50, 50, 230);
@@ -853,7 +852,7 @@ void CaptureWindow::RenderTimeBar() {
       std::string text = GetPrettyTime(absl::Microseconds(current_micros));
       float world_x = time_graph_.GetWorldFromUs(current_micros);
       text_renderer_.AddText(text.c_str(), world_x + x_margin, world_y, GlCanvas::kZValueTimeBar,
-                             Color(255, 255, 255, 255), font_size_);
+                             Color(255, 255, 255, 255), time_graph_.GetLayout().GetFontSize());
 
       // Lines from time bar are drawn in screen space.
       Vec2 pos = QtScreenToGlScreen(WorldToScreen(Vec2(world_x, world_y)));
@@ -884,7 +883,7 @@ void CaptureWindow::RenderSelectionOverlay() {
     float pos_x = pos[0] + size[0];
 
     text_renderer_.AddText(text.c_str(), pos_x, select_stop_[1], GlCanvas::kZValueTextUi,
-                           text_color, font_size_, size[0], true);
+                           text_color, time_graph_.GetLayout().GetFontSize(), size[0], true);
 
     const unsigned char g = 100;
     Color grey(g, g, g, 255);

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -696,7 +696,7 @@ static std::string VariableToString(std::string_view name, const T& value) {
   return string_stream.str();
 }
 
-void CaptureWindow::RenderImGui() {
+void CaptureWindow::RenderImGuiDebugUI() {
   if (ImGui::CollapsingHeader("Layout Properties")) {
     if (time_graph_.GetLayout().DrawProperties()) {
       NeedsUpdate();

--- a/src/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/CaptureWindow.h
@@ -50,7 +50,7 @@ class CaptureWindow : public GlCanvas {
   void OnTimer() override;
   void Draw() override;
   void DrawScreenSpace() override;
-  void RenderImGui() override;
+  void RenderImGuiDebugUI() override;
   void RenderText(float layer) override;
   void PreRender() override;
   void PostRender() override;

--- a/src/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/CaptureWindow.h
@@ -23,7 +23,7 @@ class OrbitApp;
 
 class CaptureWindow : public GlCanvas {
  public:
-  explicit CaptureWindow(uint32_t font_size, OrbitApp* app);
+  explicit CaptureWindow(OrbitApp* app);
   ~CaptureWindow() override;
 
   void Initialize() override;
@@ -82,7 +82,6 @@ class CaptureWindow : public GlCanvas {
   [[nodiscard]] virtual bool ShouldAutoZoom() const;
 
  protected:
-  uint32_t font_size_;
   TimeGraph time_graph_;
   bool draw_help_;
   bool draw_filter_;

--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -54,7 +54,7 @@ unsigned GlCanvas::kMaxNumberRealZLayers = kNumberOriginalLayers + kExtraLayersF
 const Color GlCanvas::kBackgroundColor = Color(67, 67, 67, 255);
 const Color GlCanvas::kTabTextColorSelected = Color(100, 181, 246, 255);
 
-GlCanvas::GlCanvas(uint32_t font_size) : ui_batcher_(BatcherId::kUi, &picking_manager_) {
+GlCanvas::GlCanvas() : ui_batcher_(BatcherId::kUi, &picking_manager_) {
   text_renderer_.SetCanvas(this);
 
   screen_width_ = 0;
@@ -95,7 +95,6 @@ GlCanvas::GlCanvas(uint32_t font_size) : ui_batcher_(BatcherId::kUi, &picking_ma
   hover_delay_ms_ = 300;
   can_hover_ = false;
   is_hovering_ = false;
-  initial_font_size_ = font_size;
   ResetHoverTimer();
 }
 
@@ -105,21 +104,20 @@ GlCanvas::~GlCanvas() {
   }
 }
 
-std::unique_ptr<GlCanvas> GlCanvas::Create(CanvasType canvas_type, uint32_t font_size,
-                                           OrbitApp* app) {
+std::unique_ptr<GlCanvas> GlCanvas::Create(CanvasType canvas_type, OrbitApp* app) {
   switch (canvas_type) {
     case CanvasType::kCaptureWindow: {
-      auto main_capture_window = std::make_unique<CaptureWindow>(font_size, app);
+      auto main_capture_window = std::make_unique<CaptureWindow>(app);
       app->SetCaptureWindow(main_capture_window.get());
       return main_capture_window;
     }
     case CanvasType::kIntrospectionWindow: {
-      auto introspection_window = std::make_unique<IntrospectionWindow>(font_size, app);
+      auto introspection_window = std::make_unique<IntrospectionWindow>(app);
       app->SetIntrospectionWindow(introspection_window.get());
       return introspection_window;
     }
     case CanvasType::kDebug:
-      return std::make_unique<GlCanvas>(font_size);
+      return std::make_unique<GlCanvas>();
     default:
       UNREACHABLE();
   }

--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -100,7 +100,8 @@ GlCanvas::GlCanvas() : ui_batcher_(BatcherId::kUi, &picking_manager_) {
 
 GlCanvas::~GlCanvas() {
   if (imgui_context_ != nullptr) {
-    ImGui::DestroyContext(imgui_context_);
+    Orbit_ImGui_Shutdown();
+    ImGui::DestroyContext();
   }
 }
 
@@ -141,6 +142,8 @@ void GlCanvas::Initialize() {
 void GlCanvas::EnableImGui() {
   if (imgui_context_ == nullptr) {
     imgui_context_ = ImGui::CreateContext();
+    constexpr uint32_t kImGuiFontSize = 12;
+    Orbit_ImGui_Init(kImGuiFontSize);
   }
 }
 

--- a/src/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/GlCanvas.h
@@ -31,12 +31,11 @@ class OrbitApp;
 
 class GlCanvas {
  public:
-  explicit GlCanvas(uint32_t font_size);
+  explicit GlCanvas();
   virtual ~GlCanvas();
 
   enum class CanvasType { kCaptureWindow, kIntrospectionWindow, kDebug };
-  static std::unique_ptr<GlCanvas> Create(CanvasType canvas_type, uint32_t font_size,
-                                          OrbitApp* app);
+  static std::unique_ptr<GlCanvas> Create(CanvasType canvas_type, OrbitApp* app);
 
   virtual void Initialize();
   virtual void Resize(int width, int height);
@@ -99,7 +98,6 @@ class GlCanvas {
   virtual void UpdateWorldTopLeftY(float val) { world_top_left_y_ = val; }
 
   [[nodiscard]] TextRenderer& GetTextRenderer() { return text_renderer_; }
-  [[nodiscard]] uint32_t GetInitialFontSize() const { return initial_font_size_; }
 
   virtual void UpdateWheelMomentum(float delta_time);
   virtual void OnTimer();
@@ -199,7 +197,6 @@ class GlCanvas {
   int hover_delay_ms_;
   bool is_hovering_;
   bool can_hover_;
-  uint32_t initial_font_size_;
 
   ImGuiContext* imgui_context_ = nullptr;
   double ref_time_click_;

--- a/src/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/GlCanvas.h
@@ -113,7 +113,7 @@ class GlCanvas {
 
   virtual void Draw() {}
   virtual void DrawScreenSpace() {}
-  virtual void RenderImGui() {}
+  virtual void RenderImGuiDebugUI() {}
   virtual void RenderText(float /*layer*/) {}
 
   virtual void Hover(int /*X*/, int /*Y*/) {}

--- a/src/OrbitGl/IntrospectionWindow.cpp
+++ b/src/OrbitGl/IntrospectionWindow.cpp
@@ -12,8 +12,7 @@
 
 using orbit_client_protos::TimerInfo;
 
-IntrospectionWindow::IntrospectionWindow(uint32_t font_size, OrbitApp* app)
-    : CaptureWindow(font_size, app) {}
+IntrospectionWindow::IntrospectionWindow(OrbitApp* app) : CaptureWindow(app) {}
 
 IntrospectionWindow::~IntrospectionWindow() { StopIntrospection(); }
 

--- a/src/OrbitGl/IntrospectionWindow.cpp
+++ b/src/OrbitGl/IntrospectionWindow.cpp
@@ -58,8 +58,8 @@ void IntrospectionWindow::ToggleRecording() {
   }
 }
 
-void IntrospectionWindow::RenderImGui() {
-  CaptureWindow::RenderImGui();
+void IntrospectionWindow::RenderImGuiDebugUI() {
+  CaptureWindow::RenderImGuiDebugUI();
 
   if (ImGui::CollapsingHeader("IntrospectionWindow")) {
     IMGUI_VAR_TO_TEXT(IsIntrospecting());

--- a/src/OrbitGl/IntrospectionWindow.h
+++ b/src/OrbitGl/IntrospectionWindow.h
@@ -19,7 +19,7 @@ class IntrospectionWindow : public CaptureWindow {
   explicit IntrospectionWindow(OrbitApp* app);
   ~IntrospectionWindow() override;
   void ToggleRecording() override;
-  void RenderImGui() override;
+  void RenderImGuiDebugUI() override;
 
   [[nodiscard]] bool IsIntrospecting() const;
   void StartIntrospection();

--- a/src/OrbitGl/IntrospectionWindow.h
+++ b/src/OrbitGl/IntrospectionWindow.h
@@ -16,7 +16,7 @@ class OrbitApp;
 
 class IntrospectionWindow : public CaptureWindow {
  public:
-  explicit IntrospectionWindow(uint32_t font_size, OrbitApp* app);
+  explicit IntrospectionWindow(OrbitApp* app);
   ~IntrospectionWindow() override;
   void ToggleRecording() override;
   void RenderImGui() override;

--- a/src/OrbitGl/SliderTest.cpp
+++ b/src/OrbitGl/SliderTest.cpp
@@ -14,10 +14,8 @@
 #include "GlSlider.h"
 
 class MockCanvas : public GlCanvas {
-  static constexpr uint32_t kFontSize = 14;
-
  public:
-  MockCanvas() : GlCanvas(kFontSize) {}
+  MockCanvas() : GlCanvas() {}
   MOCK_METHOD(int, GetWidth, (), (const, override));
   MOCK_METHOD(int, GetHeight, (), (const, override));
 };

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -41,8 +41,8 @@ using orbit_client_protos::TimerInfo;
 
 TimeGraph* GCurrentTimeGraph = nullptr;
 
-TimeGraph::TimeGraph(uint32_t font_size, OrbitApp* app)
-    : font_size_(font_size), accessibility_(this), batcher_(BatcherId::kTimeGraph), app_{app} {
+TimeGraph::TimeGraph(OrbitApp* app)
+    : accessibility_(this), batcher_(BatcherId::kTimeGraph), app_{app} {
   track_manager_ = std::make_unique<TrackManager>(this, app);
 
   async_timer_info_listener_ =
@@ -644,7 +644,7 @@ void TimeGraph::DrawIteratorBox(GlCanvas* canvas, Vec2 pos, Vec2 size, const Col
   const Color kBlack(0, 0, 0, 255);
   float text_width = canvas->GetTextRenderer().AddTextTrailingCharsPrioritized(
       text.c_str(), pos[0], text_box_y + layout_.GetTextOffset(), GlCanvas::kZValueTextUi, kBlack,
-      time.length(), font_size_, max_size);
+      time.length(), GetLayout().GetFontSize(), max_size);
 
   Vec2 white_box_size(std::min(static_cast<float>(text_width), max_size), GetTextBoxHeight());
   Vec2 white_box_position(pos[0], text_box_y);

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -37,7 +37,7 @@ class OrbitApp;
 
 class TimeGraph {
  public:
-  explicit TimeGraph(uint32_t font_size, OrbitApp* app);
+  explicit TimeGraph(OrbitApp* app);
   ~TimeGraph();
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode = PickingMode::kNone);
@@ -117,7 +117,7 @@ class TimeGraph {
   void SetCanvas(GlCanvas* canvas);
   [[nodiscard]] GlCanvas* GetCanvas() { return canvas_; }
   [[nodiscard]] uint32_t CalculateZoomedFontSize() const {
-    return lround((font_size_)*layout_.GetScale());
+    return lround(layout_.GetFontSize() * layout_.GetScale());
   }
   [[nodiscard]] Batcher& GetBatcher() { return batcher_; }
   [[nodiscard]] uint32_t GetNumTimers() const;
@@ -188,7 +188,6 @@ class TimeGraph {
                          const orbit_client_protos::TimerInfo& timer_info);
 
  private:
-  uint32_t font_size_;
   TextRenderer text_renderer_static_;
   TextRenderer* text_renderer_ = nullptr;
   GlCanvas* canvas_ = nullptr;

--- a/src/OrbitGl/TimeGraphLayout.cpp
+++ b/src/OrbitGl/TimeGraphLayout.cpp
@@ -33,6 +33,7 @@ TimeGraphLayout::TimeGraphLayout() {
   toolbar_icon_height_ = 24.f;
   scale_ = 1.f;
   time_bar_height_ = 15.f;
+  font_size_ = 14;
 };
 
 #define FLOAT_SLIDER(x) FLOAT_SLIDER_MIN_MAX(x, 0, 100.f)

--- a/src/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/TimeGraphLayout.h
@@ -5,6 +5,8 @@
 #ifndef ORBIT_GL_TIME_GRAPH_LAYOUT_H_
 #define ORBIT_GL_TIME_GRAPH_LAYOUT_H_
 
+#include <stdint.h>
+
 class TimeGraphLayout {
  public:
   TimeGraphLayout();
@@ -40,6 +42,7 @@ class TimeGraphLayout {
   void SetDrawProperties(bool value) { draw_properties_ = value; }
   bool DrawProperties();
   bool GetDrawTrackBackground() const { return draw_track_background_; }
+  uint32_t GetFontSize() const { return font_size_; }
 
  protected:
   float text_box_height_;
@@ -61,6 +64,8 @@ class TimeGraphLayout {
   float text_offset_;
   float right_margin_;
   float scheduler_track_offset_;
+
+  uint32_t font_size_;
 
   float space_between_cores_;
   float space_between_gpu_depths_;

--- a/src/OrbitQt/main.cpp
+++ b/src/OrbitQt/main.cpp
@@ -119,9 +119,7 @@ void RunUiInstance(const DeploymentConfiguration& deployment_configuration,
                                          ->GetServiceDeployManager();
       }
 
-      constexpr uint32_t kDefaultFontSize = 14;
-
-      OrbitMainWindow w(std::move(target_config.value()), kDefaultFontSize,
+      OrbitMainWindow w(std::move(target_config.value()),
                         metrics_uploader.has_value() ? &metrics_uploader.value() : nullptr);
 
       // "resize" is required to make "showMaximized" work properly.

--- a/src/OrbitQt/main.cpp
+++ b/src/OrbitQt/main.cpp
@@ -149,8 +149,6 @@ void RunUiInstance(const DeploymentConfiguration& deployment_configuration,
       target_config = w.ClearTargetConfiguration();
     }
 
-    Orbit_ImGui_Shutdown();
-
     if (application_return_code == 0) {
       // User closed window
       break;

--- a/src/OrbitQt/orbitglwidget.cpp
+++ b/src/OrbitQt/orbitglwidget.cpp
@@ -56,8 +56,8 @@ bool OrbitGLWidget::eventFilter(QObject* /*object*/, QEvent* event) {
 }
 
 void OrbitGLWidget::Initialize(GlCanvas::CanvasType canvas_type, OrbitMainWindow* main_window,
-                               uint32_t font_size, OrbitApp* app) {
-  gl_canvas_ = GlCanvas::Create(canvas_type, font_size, app);
+                               OrbitApp* app) {
+  gl_canvas_ = GlCanvas::Create(canvas_type, app);
 
   if (main_window) {
     main_window->RegisterGlWidget(this);

--- a/src/OrbitQt/orbitglwidget.h
+++ b/src/OrbitQt/orbitglwidget.h
@@ -55,8 +55,7 @@ class OrbitGLWidget : public QOpenGLWidget, protected QOpenGLFunctions {
 
  public:
   explicit OrbitGLWidget(QWidget* parent = nullptr);
-  void Initialize(GlCanvas::CanvasType canvas_type, OrbitMainWindow* main_window,
-                  uint32_t font_size, OrbitApp* app);
+  void Initialize(GlCanvas::CanvasType canvas_type, OrbitMainWindow* main_window, OrbitApp* app);
   void Deinitialize(OrbitMainWindow* main_window);
   void initializeGL() override;
   void resizeGL(int w, int h) override;

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -143,14 +143,13 @@ void OpenDisassembly(const std::string& assembly, const DisassemblyReport& repor
 }  // namespace
 
 OrbitMainWindow::OrbitMainWindow(orbit_qt::TargetConfiguration target_configuration,
-                                 uint32_t font_size,
                                  orbit_metrics_uploader::MetricsUploader* metrics_uploader)
     : QMainWindow(nullptr),
       main_thread_executor_{orbit_qt::MainThreadExecutorImpl::Create()},
       app_{OrbitApp::Create(main_thread_executor_.get(), metrics_uploader)},
       ui(new Ui::OrbitMainWindow),
       target_configuration_(std::move(target_configuration)) {
-  SetupMainWindow(font_size);
+  SetupMainWindow();
 
   SetupTargetLabel();
   SetupHintFrame();
@@ -208,7 +207,7 @@ OrbitMainWindow::OrbitMainWindow(orbit_qt::TargetConfiguration target_configurat
   LoadCaptureOptionsIntoApp();
 }
 
-void OrbitMainWindow::SetupMainWindow(uint32_t font_size) {
+void OrbitMainWindow::SetupMainWindow() {
   DataViewFactory* data_view_factory = app_.get();
 
   ui->setupUi(this);
@@ -350,15 +349,14 @@ void OrbitMainWindow::SetupMainWindow(uint32_t font_size) {
   app_->SetShowEmptyFrameTrackWarningCallback(
       [this](std::string_view function) { this->ShowEmptyFrameTrackWarningIfNeeded(function); });
 
-  ui->CaptureGLWidget->Initialize(GlCanvas::CanvasType::kCaptureWindow, this, font_size,
-                                  app_.get());
+  ui->CaptureGLWidget->Initialize(GlCanvas::CanvasType::kCaptureWindow, this, app_.get());
 
   app_->SetTimerSelectedCallback([this](const orbit_client_protos::TimerInfo* timer_info) {
     OnTimerSelectionChanged(timer_info);
   });
 
   if (absl::GetFlag(FLAGS_devmode)) {
-    ui->debugOpenGLWidget->Initialize(GlCanvas::CanvasType::kDebug, this, font_size, app_.get());
+    ui->debugOpenGLWidget->Initialize(GlCanvas::CanvasType::kDebug, this, app_.get());
     app_->SetDebugCanvas(ui->debugOpenGLWidget->GetCanvas());
   } else {
     ui->RightTabWidget->removeTab(ui->RightTabWidget->indexOf(ui->debugTab));
@@ -940,8 +938,7 @@ void OrbitMainWindow::on_actionIntrospection_triggered() {
   if (introspection_widget_ == nullptr) {
     introspection_widget_ = std::make_unique<OrbitGLWidget>();
     introspection_widget_->setWindowFlags(Qt::WindowStaysOnTopHint);
-    introspection_widget_->Initialize(GlCanvas::CanvasType::kIntrospectionWindow, this, 14,
-                                      app_.get());
+    introspection_widget_->Initialize(GlCanvas::CanvasType::kIntrospectionWindow, this, app_.get());
     introspection_widget_->installEventFilter(this);
   }
 

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -55,7 +55,7 @@ class OrbitMainWindow : public QMainWindow {
  public:
   static constexpr int kEndSessionReturnCode = 1;
 
-  explicit OrbitMainWindow(orbit_qt::TargetConfiguration target_configuration, uint32_t font_size,
+  explicit OrbitMainWindow(orbit_qt::TargetConfiguration target_configuration,
                            orbit_metrics_uploader::MetricsUploader* metrics_uploader = nullptr);
   ~OrbitMainWindow() override;
 
@@ -137,7 +137,7 @@ class OrbitMainWindow : public QMainWindow {
  private:
   void StartMainTimer();
   void SetupCaptureToolbar();
-  void SetupMainWindow(uint32_t font_size);
+  void SetupMainWindow();
   void SetupHintFrame();
   void SetupTargetLabel();
 


### PR DESCRIPTION
Fixes b/176540571 by correcting the lifetimes of ImGui resources and the ImGui context.

The first commit removes the font_size parameters to prepare for this. In hindsight, this might not have been completely required, but IMHO clearer separates the font_size used for our UI from the ImGui font size. 

Detailed comments on the actual change are in the last commit.