### PR TITLE
Refactor module loading in OrbitApp

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1459,8 +1459,25 @@ void OrbitApp::UpdateProcessAndModuleList(int32_t pid) {
         }
       }
       // (D) Load Modules again (and pass on functions to hook after loading)
-      LoadModules(modules_to_reload, std::move(function_hashes_to_hook_map),
-                  std::move(frame_track_function_hashes_map));
+      const auto future = LoadModules(modules_to_reload);
+
+      if (main_thread_executor_->WaitFor(future) != MainThreadExecutor::WaitResult::kCompleted) {
+        return;
+      }
+
+      for (const auto& [module_path, function_hashes] : function_hashes_to_hook_map) {
+        ModuleData* const module_data = GetMutableModuleByPath(module_path);
+        if (module_data == nullptr) continue;
+        (void)SelectFunctionsFromHashes(module_data, function_hashes);
+        LOG("Auto hooked functions in module \"%s\"", module_data->file_path());
+      }
+
+      for (const auto& [module_path, function_hashes] : frame_track_function_hashes_map) {
+        ModuleData* const module_data = GetMutableModuleByPath(module_path);
+        if (module_data == nullptr) continue;
+        (void)EnableFrameTracksFromHashes(module_data, function_hashes);
+        LOG("Added frame tracks in module \"%s\"", module_data->file_path());
+      }
 
       // Refresh UI
       modules_data_view_->UpdateModules(process);

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1038,37 +1038,6 @@ orbit_base::Future<ErrorMessageOr<std::filesystem::path>> OrbitApp::LoadModuleOn
       });
 }
 
-void OrbitApp::LoadModuleOnRemote(ModuleData* module_data,
-                                  std::vector<uint64_t> function_hashes_to_hook,
-                                  std::vector<uint64_t> frame_track_function_hashes,
-                                  std::string error_message_from_local) {
-  // This overload will be removed in a subsequent commit.
-
-  const auto future =
-      LoadModuleOnRemote(module_data->file_path())
-          .Then(main_thread_executor_,
-                [this, module_data, function_hashes_to_hook, frame_track_function_hashes,
-                 error_message_from_local](const ErrorMessageOr<std::string>& result) {
-                  if (!result) {
-                    SendErrorToUi(
-                        "Error loading symbols",
-                        absl::StrFormat(
-                            "Did not find symbols locally or on remote for module \"%s\": %s\n%s",
-                            module_data->file_path(), error_message_from_local,
-                            result.error().message()));
-                    main_thread_executor_->Schedule([this, module_data]() {
-                      modules_currently_loading_.erase(module_data->file_path());
-                    });
-                    return;
-                  }
-
-                  LoadSymbols(result.value(), module_data, function_hashes_to_hook,
-                              frame_track_function_hashes);
-                });
-
-  (void)main_thread_executor_->WaitFor(future);
-}
-
 void OrbitApp::LoadModules(
     const std::vector<ModuleData*>& modules,
     absl::flat_hash_map<std::string, std::vector<uint64_t>> function_hashes_to_hook_map,

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1038,28 +1038,6 @@ orbit_base::Future<ErrorMessageOr<std::filesystem::path>> OrbitApp::LoadModuleOn
       });
 }
 
-void OrbitApp::LoadModules(
-    const std::vector<ModuleData*>& modules,
-    absl::flat_hash_map<std::string, std::vector<uint64_t>> function_hashes_to_hook_map,
-    absl::flat_hash_map<std::string, std::vector<uint64_t>> frame_track_function_hashes_map) {
-  // This overload will be removed in a subsequent commit
-
-  std::vector<orbit_base::Future<void>> futures;
-  futures.reserve(modules.size());
-
-  for (const auto& module : modules) {
-    futures.push_back(LoadModule(module).Then(main_thread_executor_, [&, module]() {
-      const auto& select_functions = function_hashes_to_hook_map[module->file_path()];
-      (void)SelectFunctionsFromHashes(module, select_functions);
-
-      const auto& frame_tracks = frame_track_function_hashes_map[module->file_path()];
-      (void)EnableFrameTracksFromHashes(module, frame_tracks);
-    }));
-  }
-
-  (void)main_thread_executor_->WaitForAll(absl::MakeSpan(futures));
-}
-
 orbit_base::Future<void> OrbitApp::LoadModules(absl::Span<const ModuleData* const> modules) {
   std::vector<orbit_base::Future<void>> futures;
   futures.reserve(modules.size());

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -292,10 +292,6 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void NeedsRedraw();
   void RenderImGui();
 
-  void LoadModules(
-      const std::vector<ModuleData*>& modules,
-      absl::flat_hash_map<std::string, std::vector<uint64_t>> function_hashes_to_hook_map,
-      absl::flat_hash_map<std::string, std::vector<uint64_t>> frame_track_function_hashes_map);
   orbit_base::Future<void> LoadModule(const ModuleData* module);
   orbit_base::Future<void> LoadModule(const std::string& module_path, const std::string& build_id);
   orbit_base::Future<void> LoadModules(absl::Span<const ModuleData* const> modules);

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -410,6 +410,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
 
   ErrorMessageOr<std::filesystem::path> FindModuleLocally(const std::filesystem::path& module_path,
                                                           const std::string& build_id);
+  [[nodiscard]] orbit_base::Future<ErrorMessageOr<void>> LoadSymbols(
+      const std::filesystem::path& symbols_path, const std::string& module_file_path);
   ErrorMessageOr<orbit_client_protos::PresetInfo> ReadPresetFromFile(
       const std::filesystem::path& filename);
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -308,6 +308,9 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void UpdateAfterSymbolLoading();
   void UpdateAfterCaptureCleared();
 
+  enum class LoadPresetModuleResult { kSuccess, kModuleNotFound, kAbort };
+  LoadPresetModuleResult LoadPresetModule(const std::string& module_path,
+                                          const orbit_client_protos::PresetModule& preset_module);
   void LoadPreset(const std::shared_ptr<orbit_client_protos::PresetFile>& preset);
   PresetLoadState GetPresetLoadState(
       const std::shared_ptr<orbit_client_protos::PresetFile>& preset) const;

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -411,10 +411,6 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
                    std::vector<uint64_t> function_hashes_to_hook,
                    std::vector<uint64_t> frame_track_function_hashes);
 
-  void LoadModuleOnRemote(ModuleData* module_data, std::vector<uint64_t> function_hashes_to_hook,
-                          std::vector<uint64_t> frame_track_function_hashes,
-                          std::string error_message_from_local);
-
   ErrorMessageOr<void> SelectFunctionsFromHashes(const ModuleData* module,
                                                  const std::vector<uint64_t>& function_hashes);
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -405,6 +405,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void LoadModuleOnRemote(ModuleData* module_data, std::vector<uint64_t> function_hashes_to_hook,
                           std::vector<uint64_t> frame_track_function_hashes,
                           std::string error_message_from_local);
+
   ErrorMessageOr<void> SelectFunctionsFromHashes(const ModuleData* module,
                                                  const std::vector<uint64_t>& function_hashes);
 
@@ -412,6 +413,9 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
                                                           const std::string& build_id);
   [[nodiscard]] orbit_base::Future<ErrorMessageOr<void>> LoadSymbols(
       const std::filesystem::path& symbols_path, const std::string& module_file_path);
+
+  [[nodiscard]] orbit_base::Future<ErrorMessageOr<std::filesystem::path>> LoadModuleOnRemote(
+      const std::string& module_file_path);
   ErrorMessageOr<orbit_client_protos::PresetInfo> ReadPresetFromFile(
       const std::filesystem::path& filename);
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -416,10 +416,6 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   ErrorMessageOr<void> SavePreset(const std::string& filename);
   [[nodiscard]] ScopedStatus CreateScopedStatus(const std::string& initial_message);
 
-  ErrorMessageOr<void> GetFunctionInfosFromHashes(
-      const ModuleData* module, const std::vector<uint64_t>& function_hashes,
-      std::vector<const orbit_client_protos::FunctionInfo*>* function_infos);
-
   ErrorMessageOr<void> EnableFrameTracksFromHashes(const ModuleData* module,
                                                    const std::vector<uint64_t>& function_hashes);
   void AddFrameTrackTimers(uint64_t instrumented_function_id);

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -407,10 +407,6 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   [[nodiscard]] bool HasFrameTrackInCaptureData(uint64_t instrumented_function_id) const;
 
  private:
-  void LoadSymbols(const std::filesystem::path& symbols_path, ModuleData* module_data,
-                   std::vector<uint64_t> function_hashes_to_hook,
-                   std::vector<uint64_t> frame_track_function_hashes);
-
   ErrorMessageOr<void> SelectFunctionsFromHashes(const ModuleData* module,
                                                  const std::vector<uint64_t>& function_hashes);
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -398,8 +398,6 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   [[nodiscard]] bool HasFrameTrackInCaptureData(uint64_t instrumented_function_id) const;
 
  private:
-  ErrorMessageOr<std::filesystem::path> FindSymbolsLocally(const std::filesystem::path& module_path,
-                                                           const std::string& build_id);
   void LoadSymbols(const std::filesystem::path& symbols_path, ModuleData* module_data,
                    std::vector<uint64_t> function_hashes_to_hook,
                    std::vector<uint64_t> frame_track_function_hashes);
@@ -410,6 +408,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   ErrorMessageOr<void> SelectFunctionsFromHashes(const ModuleData* module,
                                                  const std::vector<uint64_t>& function_hashes);
 
+  ErrorMessageOr<std::filesystem::path> FindModuleLocally(const std::filesystem::path& module_path,
+                                                          const std::string& build_id);
   ErrorMessageOr<orbit_client_protos::PresetInfo> ReadPresetFromFile(
       const std::filesystem::path& filename);
 


### PR DESCRIPTION
This PR refactors some function in OrbitApp that are concerned with symbol or module loading.

### The initial problem
The function `OrbitApp::LoadModules` has the following function signature:

```cpp
void LoadModules(
      const std::vector<ModuleData*>& modules,
      absl::flat_hash_map<std::string, std::vector<uint64_t>> function_hashes_to_hook_map = {},
      absl::flat_hash_map<std::string, std::vector<uint64_t>> frame_track_function_hashes_map = {});
```

The whole function works asynchronously, meaning when the function returns the work is not done.
It first loads the modules given by `modules` and then hooks functions given by the second parameter
and enable frame tracks given by the third parameter.

Adding another task that has to happen after loading a module would mean adding another parameter to the function.
I think it's obvious that this does not scale and violates the principle of separation of concerns.

The proper solution is to add a mechanism which can tell a caller of `LoadModules` when module loading is done
and when it's safe to trigger follow-up work. The recently introduced Future-type is made for that purpose.

### The new `LoadModule` method

The function signature of the new `LoadModule` method looks like this:

```cpp
orbit_base::Future<void> LoadModule(const ModuleData* module);
```

It now returns a future which can tell the caller when the asynchronous task is done. It can be either ignored,
or transformed into a synchronous task by using `MainThreadExecutor::WaitFor`:

```cpp

auto future = LoadModule(module);

main_thread_executor->WaitFor(future);
// This call is blocking. MainThreadExecutor will process other UI events in the mean time.

for(const auto& function : functions) SelectFunction(function); // Or other follow-up tasks
```

The third option is chain a continuation using `Future::Then`:

```cpp

LoadModule(module).Then(main_thread_executor_, [functions](){
  // This lambda is executed on the main thread when `LoadModule` is done.

  for(const auto& function : functions) SelectFunction(function);
});
```

Note: Of course there is also a replacement for the previous `LoadModules` method:

```cpp
orbit_base::Future<void> LoadModules(absl::Span<const ModuleData* const> modules);
```

It takes a span (think a vector) of ModuleData pointers and returns a future that completes
when all modules have been loaded (or at least have been tried to load).