### PR TITLE
Rework log files to support multiple instances of Orbit at the same time

### DIFF
--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -44,6 +44,7 @@ target_sources(OrbitBase PRIVATE
         JoinFutures.cpp
         ReadFileToString.cpp
         Logging.cpp
+        LoggingUtils.cpp
         SafeStrerror.cpp
         ThreadPool.cpp
         Tracing.cpp)
@@ -74,6 +75,7 @@ target_sources(OrbitBaseTests PRIVATE
         FutureTest.cpp
         FutureHelpersTest.cpp
         JoinFuturesTest.cpp
+        LoggingUtilsTest.cpp
         ReadFileToStringTest.cpp
         OrbitApiTest.cpp
         ProfilingTest.cpp

--- a/src/OrbitBase/Logging.cpp
+++ b/src/OrbitBase/Logging.cpp
@@ -6,14 +6,23 @@
 
 #include <array>
 
+#include "OrbitBase/ThreadUtils.h"
 #include "absl/base/const_init.h"
 #include "absl/debugging/stacktrace.h"
 #include "absl/debugging/symbolize.h"
 #include "absl/strings/str_format.h"
 #include "absl/synchronization/mutex.h"
+#include "absl/time/time.h"
 
 static absl::Mutex log_file_mutex(absl::kConstInit);
 std::ofstream log_file;
+
+std::string GetLogFileName() {
+  std::string timestamp_string =
+      absl::FormatTime(kLogFileNameTimeFormat, absl::Now(), absl::LocalTimeZone());
+  return absl::StrFormat(kLogFileNameDelimiter, timestamp_string,
+                         static_cast<uint32_t>(orbit_base::GetCurrentProcessId()));
+}
 
 void InitLogFile(const std::filesystem::path& path) {
   absl::MutexLock lock(&log_file_mutex);

--- a/src/OrbitBase/LoggingUtils.cpp
+++ b/src/OrbitBase/LoggingUtils.cpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "LoggingUtils.h"
+
+#include <absl/strings/str_cat.h>
+#include <absl/strings/str_format.h>
+#include <absl/time/time.h>
+
+#include <system_error>
+
+#include "OrbitBase/Logging.h"
+
+const absl::Duration kLogFileLifetime = absl::Hours(24 * 7);  // one week
+// Determined by kLogFileNameDelimiter, i.e., the format of log file names.
+const int kTimestampStartPos = 6;
+// Determined by kLogFileNameTimeFormat, i.e., the format of timestamp contained in log file names.
+const int kTimestampStringLength = 19;
+
+std::vector<std::filesystem::path> ListFiles(const std::filesystem::path& log_dir) {
+  std::vector<std::filesystem::path> files_in_dir;
+  for (const auto& file_path : std::filesystem::recursive_directory_iterator(log_dir)) {
+    if (file_path.is_regular_file()) {
+      files_in_dir.push_back(file_path.path());
+    }
+  }
+  return files_in_dir;
+}
+
+ErrorMessageOr<absl::Duration> GetLogFileLifetime(const std::string& log_file_name) {
+  if (log_file_name.size() < kTimestampStartPos + kTimestampStringLength) {
+    return ErrorMessage(
+        absl::StrFormat("Unable to extract time information from log file: %s", log_file_name));
+  }
+  std::string timestamp_string = log_file_name.substr(kTimestampStartPos, kTimestampStringLength);
+  absl::Time log_file_timestamp;
+  std::string parse_time_error;
+  if (!absl::ParseTime(kLogFileNameTimeFormat, timestamp_string, absl::LocalTimeZone(),
+                       &log_file_timestamp, &parse_time_error)) {
+    return ErrorMessage(
+        absl::StrFormat("Error while parsing time information from log file %s : %s", log_file_name,
+                        parse_time_error));
+  }
+  return absl::Now() - log_file_timestamp;
+}
+
+std::vector<std::filesystem::path> FilterOldLogFiles(
+    const std::vector<std::filesystem::path>& log_file_paths) {
+  std::vector<std::filesystem::path> old_files;
+  for (std::filesystem::path log_file_path : log_file_paths) {
+    ErrorMessageOr<absl::Duration> get_lifetime_result =
+        GetLogFileLifetime(log_file_path.filename().string());
+    if (!get_lifetime_result) {
+      LOG("Warning: %s", get_lifetime_result.error().message());
+      continue;
+    }
+    if (get_lifetime_result.value() > kLogFileLifetime) {
+      old_files.push_back(log_file_path);
+    }
+  }
+  return old_files;
+}
+
+ErrorMessageOr<void> RemoveFiles(const std::vector<std::filesystem::path>& log_file_paths) {
+  std::string error_message;
+  for (const auto& log_file_path : log_file_paths) {
+    std::error_code file_remove_error;
+    if (!std::filesystem::remove(log_file_path, file_remove_error)) {
+      absl::StrAppend(&error_message, "Error while removing ", log_file_path.filename().string(),
+                      ": ", file_remove_error.message(), "\n");
+    }
+  }
+  if (!error_message.empty()) {
+    return ErrorMessage(error_message);
+  }
+  return outcome::success();
+}

--- a/src/OrbitBase/LoggingUtils.h
+++ b/src/OrbitBase/LoggingUtils.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_BASE_LOGGING_UTILS_H_
+#define ORBIT_BASE_LOGGING_UTILS_H_
+
+#include <absl/strings/str_format.h>
+#include <absl/time/time.h>
+
+#include <filesystem>
+
+#include "OrbitBase/Result.h"
+
+constexpr const char* kLogFileNameTimeFormat = "%Y_%m_%d_%H_%M_%S";
+constexpr absl::string_view kLogFileNameDelimiter = "Orbit-%s-%u.log";
+
+[[nodiscard]] std::vector<std::filesystem::path> ListFiles(const std::filesystem::path& log_dir);
+ErrorMessageOr<absl::Duration> GetLogFileLifetime(const std::string& log_file_name);
+[[nodiscard]] std::vector<std::filesystem::path> FilterOldLogFiles(
+    const std::vector<std::filesystem::path>& log_file_paths);
+// This function tries to remove files even when an error is returned. If some files are unable to
+// remove, it returns an error message to record names of those functions and details about the
+// remove failures.
+ErrorMessageOr<void> RemoveFiles(const std::vector<std::filesystem::path>& log_file_paths);
+
+#endif  // ORBIT_BASE_LOGGING_UTILS_H_

--- a/src/OrbitBase/LoggingUtilsTest.cpp
+++ b/src/OrbitBase/LoggingUtilsTest.cpp
@@ -1,0 +1,64 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <absl/strings/str_format.h>
+#include <absl/time/clock.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "LoggingUtils.h"
+
+namespace {
+std::filesystem::path GenerateTestLogFilePath(const absl::Time& timestamp) {
+  std::filesystem::path test_log_dir = "C:/OrbitAppDataDir/logs";
+  uint32_t test_pid = 12345;
+  std::string timestamp_string =
+      absl::FormatTime(kLogFileNameTimeFormat, timestamp, absl::LocalTimeZone());
+  std::string filename = absl::StrFormat(kLogFileNameDelimiter, timestamp_string, test_pid);
+  return test_log_dir / filename;
+}
+}  // namespace
+
+namespace orbit_base {
+
+TEST(LoggingUtils, GetLogFileLifetime) {
+  const std::string kFilenameInvalidNoTimestamp = "sfsdf-.log ";
+  const std::string kFilenameInvalidValidTimestampWrongFormat =
+      "Orbitfoobar-2021_01_31_00_00_00-.log";
+  const std::string kFilenameValid = "Orbit-2021_01_31_00_00_00-7188.log";
+
+  ErrorMessageOr<absl::Duration> result_extract_failed =
+      GetLogFileLifetime(kFilenameInvalidNoTimestamp);
+  ASSERT_FALSE(result_extract_failed);
+  EXPECT_EQ(result_extract_failed.error().message(),
+            absl::StrFormat("Unable to extract time information from log file: %s",
+                            kFilenameInvalidNoTimestamp));
+
+  ErrorMessageOr<absl::Duration> result_parse_failed =
+      GetLogFileLifetime(kFilenameInvalidValidTimestampWrongFormat);
+  ASSERT_FALSE(result_parse_failed);
+  EXPECT_THAT(
+      result_parse_failed.error().message(),
+      testing::HasSubstr(absl::StrFormat("Error while parsing time information from log file %s",
+                                         kFilenameInvalidValidTimestampWrongFormat)));
+
+  ErrorMessageOr<absl::Duration> result_parse_succeed = GetLogFileLifetime(kFilenameValid);
+  absl::Duration expected_result =
+      absl::Now() - absl::FromCivil(absl::CivilSecond(2021, 1, 31, 0, 0, 0), absl::LocalTimeZone());
+  EXPECT_NEAR(absl::ToDoubleSeconds(result_parse_succeed.value()),
+              absl::ToDoubleSeconds(expected_result), 1);
+}
+
+TEST(LoggingUtils, FilterOldLogFiles) {
+  absl::Time now = absl::Now();
+  std::filesystem::path recent_file = GenerateTestLogFilePath(now - absl::Hours(24));
+  std::filesystem::path old_file = GenerateTestLogFilePath(now - absl::Hours(24 * 14));
+
+  std::vector<std::filesystem::path> test_case({recent_file, old_file});
+  std::vector<std::filesystem::path> result = FilterOldLogFiles(test_case);
+  std::vector<std::filesystem::path> expected_result({old_file});
+  EXPECT_EQ(result, expected_result);
+}
+
+}  // namespace orbit_base

--- a/src/OrbitBase/ThreadUtilsLinux.cpp
+++ b/src/OrbitBase/ThreadUtilsLinux.cpp
@@ -51,4 +51,6 @@ void SetCurrentThreadName(const std::string& thread_name) {
   }
 }
 
+pid_t GetCurrentProcessId() { return getpid(); }
+
 }  // namespace orbit_base

--- a/src/OrbitBase/ThreadUtilsWindows.cpp
+++ b/src/OrbitBase/ThreadUtilsWindows.cpp
@@ -68,4 +68,6 @@ void SetCurrentThreadName(const std::string& name) {
   }
 }
 
+uint32_t GetCurrentProcessId() { return ::GetCurrentProcessId(); }
+
 }  // namespace orbit_base

--- a/src/OrbitBase/include/OrbitBase/Logging.h
+++ b/src/OrbitBase/include/OrbitBase/Logging.h
@@ -5,6 +5,9 @@
 #ifndef ORBIT_BASE_LOGGING_H_
 #define ORBIT_BASE_LOGGING_H_
 
+#include <absl/strings/str_format.h>
+#include <absl/synchronization/mutex.h>
+#include <absl/time/time.h>
 #include <stdlib.h>
 
 #include <cstdio>
@@ -16,9 +19,6 @@
 #include <Windows.h>
 #endif
 
-#include "absl/strings/str_format.h"
-#include "absl/synchronization/mutex.h"
-#include "absl/time/time.h"
 
 #ifdef __clang__
 #pragma clang diagnostic push
@@ -113,6 +113,9 @@ constexpr const char* kLogTimeFormat = "%Y-%m-%dT%H:%M:%E6S";
     absl::StrFormat(format, ##__VA_ARGS__)                                                     \
   }
 
+constexpr const char* kLogFileNameTimeFormat = "%Y_%m_%d_%H_%M_%S";
+constexpr absl::string_view kLogFileNameDelimiter = "Orbit-%s-%u.log";
+std::string GetLogFileName();
 extern std::ofstream log_file;
 void InitLogFile(const std::filesystem::path& path);
 void LogToFile(const std::string& message);

--- a/src/OrbitBase/include/OrbitBase/Logging.h
+++ b/src/OrbitBase/include/OrbitBase/Logging.h
@@ -19,6 +19,7 @@
 #include <Windows.h>
 #endif
 
+#include "OrbitBase/Result.h"
 
 #ifdef __clang__
 #pragma clang diagnostic push
@@ -113,9 +114,12 @@ constexpr const char* kLogTimeFormat = "%Y-%m-%dT%H:%M:%E6S";
     absl::StrFormat(format, ##__VA_ARGS__)                                                     \
   }
 
-constexpr const char* kLogFileNameTimeFormat = "%Y_%m_%d_%H_%M_%S";
-constexpr absl::string_view kLogFileNameDelimiter = "Orbit-%s-%u.log";
 std::string GetLogFileName();
+// This function tries to remove log files older than kLogFileLifetime even when an error is
+// returned. An error returns, for instance, if some log files to remove are used by other
+// applications. If so, both the file name and the error message will be recorded in the log file.
+ErrorMessageOr<void> TryRemoveOldLogFiles(const std::filesystem::path& log_dir);
+
 extern std::ofstream log_file;
 void InitLogFile(const std::filesystem::path& path);
 void LogToFile(const std::string& message);

--- a/src/OrbitBase/include/OrbitBase/ThreadUtils.h
+++ b/src/OrbitBase/include/OrbitBase/ThreadUtils.h
@@ -5,18 +5,25 @@
 #ifndef ORBIT_BASE_THREAD_UTILS_H_
 #define ORBIT_BASE_THREAD_UTILS_H_
 
+#ifdef _WIN32
+#include <stdint.h>
+#else
+#include <sys/types.h>
+#include <unistd.h>
+#endif
+
 #include <string>
 
 namespace orbit_base {
 
 #ifdef _WIN32
-#include <stdint.h>
 [[nodiscard]] uint32_t GetCurrentThreadId();
 [[nodiscard]] std::string GetThreadName(uint32_t tid);
+[[nodiscard]] uint32_t GetCurrentProcessId();
 #else
-#include <sys/types.h>
 [[nodiscard]] pid_t GetCurrentThreadId();
 [[nodiscard]] std::string GetThreadName(pid_t tid);
+[[nodiscard]] pid_t GetCurrentProcessId();
 #endif
 
 void SetCurrentThreadName(const std::string& thread_name);

--- a/src/OrbitCore/Path.cpp
+++ b/src/OrbitCore/Path.cpp
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "CoreUtils.h"
+#include "OrbitBase/Logging.h"
 #include "absl/flags/flag.h"
 
 ABSL_FLAG(std::string, log_dir, "", "Set directory for the log.");
@@ -60,7 +61,7 @@ std::filesystem::path Path::CreateOrGetOrbitAppDataDir() {
   return path;
 }
 
-std::filesystem::path Path::GetLogFilePathAndCreateDir() {
+std::filesystem::path Path::CreateOrGetLogDir() {
   std::filesystem::path logs_dir;
   if (!absl::GetFlag(FLAGS_log_dir).empty()) {
     logs_dir = absl::GetFlag(FLAGS_log_dir);
@@ -68,5 +69,9 @@ std::filesystem::path Path::GetLogFilePathAndCreateDir() {
     logs_dir = Path::CreateOrGetOrbitAppDataDir() / "logs";
   }
   std::filesystem::create_directory(logs_dir);
-  return logs_dir / "Orbit.log";
+  return logs_dir;
+}
+
+std::filesystem::path Path::GetLogFilePath() {
+  return Path::CreateOrGetLogDir() / GetLogFileName();
 }

--- a/src/OrbitCore/Path.h
+++ b/src/OrbitCore/Path.h
@@ -14,5 +14,6 @@ namespace Path {
 [[nodiscard]] std::filesystem::path CreateOrGetCaptureDir();
 [[nodiscard]] std::filesystem::path CreateOrGetDumpDir();
 [[nodiscard]] std::filesystem::path CreateOrGetOrbitAppDataDir();
-[[nodiscard]] std::filesystem::path GetLogFilePathAndCreateDir();
+[[nodiscard]] std::filesystem::path CreateOrGetLogDir();
+[[nodiscard]] std::filesystem::path GetLogFilePath();
 };  // namespace Path

--- a/src/OrbitCore/PathTest.cpp
+++ b/src/OrbitCore/PathTest.cpp
@@ -35,8 +35,8 @@ TEST(Path, FileExistsDevNull) {
 
 TEST(Path, AllAutoCreatedDirsExist) {
   auto test_fns = {Path::CreateOrGetOrbitAppDataDir, Path::CreateOrGetDumpDir,
-                   Path::CreateOrGetPresetDir, Path::CreateOrGetCacheDir,
-                   Path::CreateOrGetOrbitAppDataDir};
+                   Path::CreateOrGetPresetDir,       Path::CreateOrGetCacheDir,
+                   Path::CreateOrGetCaptureDir,      Path::CreateOrGetLogDir};
 
   for (auto fn : test_fns) {
     std::filesystem::path path = fn();
@@ -46,7 +46,7 @@ TEST(Path, AllAutoCreatedDirsExist) {
 }
 
 TEST(Path, AllDirsOfFilesExist) {
-  auto test_fns = {Path::GetLogFilePathAndCreateDir};
+  auto test_fns = {Path::GetLogFilePath};
 
   for (auto fn : test_fns) {
     std::filesystem::path path = fn().parent_path();

--- a/src/OrbitQt/main.cpp
+++ b/src/OrbitQt/main.cpp
@@ -262,7 +262,7 @@ int main(int argc, char* argv[]) {
   absl::SetFlagsUsageConfig(absl::FlagsUsageConfig{{}, {}, {}, &orbit_core::GetBuildReport, {}});
   absl::ParseCommandLine(argc, argv);
 
-  InitLogFile(Path::GetLogFilePathAndCreateDir());
+  InitLogFile(Path::GetLogFilePath());
   LOG("You are running Orbit Profiler version %s", orbit_core::GetVersion());
 
 #if __linux__
@@ -299,7 +299,7 @@ int main(int argc, char* argv[]) {
   const std::string handler_path =
       QDir(QCoreApplication::applicationDirPath()).absoluteFilePath(handler_name).toStdString();
   const std::string crash_server_url = CrashServerOptions::GetUrl();
-  const std::vector<std::string> attachments = {Path::GetLogFilePathAndCreateDir().string()};
+  const std::vector<std::string> attachments = {Path::GetLogFilePath().string()};
 
   CrashHandler crash_handler(dump_path, handler_path, crash_server_url, attachments);
 #endif  // ORBIT_CRASH_HANDLING

--- a/src/OrbitQt/main.cpp
+++ b/src/OrbitQt/main.cpp
@@ -264,6 +264,11 @@ int main(int argc, char* argv[]) {
 
   InitLogFile(Path::GetLogFilePath());
   LOG("You are running Orbit Profiler version %s", orbit_core::GetVersion());
+  ErrorMessageOr<void> remove_old_log_result = TryRemoveOldLogFiles(Path::CreateOrGetLogDir());
+  if (remove_old_log_result.has_error()) {
+    LOG("Warning: Unable to remove some old log files:\n%s",
+        remove_old_log_result.error().message());
+  }
 
 #if __linux__
   QCoreApplication::setAttribute(Qt::AA_DontUseNativeDialogs);


### PR DESCRIPTION
Currently there is only one log file named as `Orbit.log` in the log directory, and this file is overwritten every time when starting an Orbit instance. Therefore, if multiple Orbit instances are running at the same time, they will write to the same log file.

To address the above issue, we rename the log file in a format of `Orbit-<yyyy_MM_dd_HH_mm_ss>-<pid>.log`, and remove old log files that are older than one week.

Bug: http://b/177978487.
Test: 1) Open several Orbit instances at the same time, check the name of log files in the `%APPDATA%\OrbitProfiler\logs\` folder;
2) Create some log files with names indicate a much earlier time, e.g. `Orbit-2020_01_01_00_00_00-12345.log`.  Open a new Orbit instance and see the old log files are removed.