### PR TITLE
Set pid of orbit_gprc_protos::ThreadStateSlice

### DIFF
--- a/src/ClientProtos/capture_data.proto
+++ b/src/ClientProtos/capture_data.proto
@@ -65,7 +65,6 @@ message CallstackInfo {
 }
 
 message ThreadStateSliceInfo {
-  // pid is absent as we don't yet get that information from the service.
   int32 tid = 1;
   enum ThreadState {
     kRunning = 0;

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -199,7 +199,7 @@ message ThreadName {
 
 message ThreadStateSlice {
   reserved 4;
-  int32 pid = 1;  // pid is currently not set as we don't have the information.
+  int32 pid = 1;
   int32 tid = 2;
 
   // These are the ones listed in

--- a/src/LinuxTracing/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracing/LinuxTracingIntegrationTest.cpp
@@ -769,8 +769,7 @@ TEST(LinuxTracingIntegrationTest, ThreadStateSlices) {
       continue;
     }
 
-    // We currently don't set the pid.
-    EXPECT_EQ(thread_state_slice.pid(), 0);
+    EXPECT_EQ(thread_state_slice.pid(), fixture.GetPuppetPid());
 
     EXPECT_TRUE(
         thread_state_slice.thread_state() == orbit_grpc_protos::ThreadStateSlice::kRunning ||

--- a/src/LinuxTracing/ThreadStateManager.h
+++ b/src/LinuxTracing/ThreadStateManager.h
@@ -46,22 +46,25 @@ namespace orbit_linux_tracing {
 
 class ThreadStateManager {
  public:
-  void OnInitialState(uint64_t timestamp_ns, pid_t tid,
+  void OnInitialState(uint64_t timestamp_ns, pid_t pid, pid_t tid,
                       orbit_grpc_protos::ThreadStateSlice::ThreadState state);
-  void OnNewTask(uint64_t timestamp_ns, pid_t tid);
+  void OnNewTask(uint64_t timestamp_ns, pid_t pid, pid_t tid);
   [[nodiscard]] std::optional<orbit_grpc_protos::ThreadStateSlice> OnSchedWakeup(
-      uint64_t timestamp_ns, pid_t tid);
+      uint64_t timestamp_ns, pid_t pid, pid_t tid);
   [[nodiscard]] std::optional<orbit_grpc_protos::ThreadStateSlice> OnSchedSwitchIn(
-      uint64_t timestamp_ns, pid_t tid);
+      uint64_t timestamp_ns, pid_t pid, pid_t tid);
   [[nodiscard]] std::optional<orbit_grpc_protos::ThreadStateSlice> OnSchedSwitchOut(
-      uint64_t timestamp_ns, pid_t tid, orbit_grpc_protos::ThreadStateSlice::ThreadState new_state);
+      uint64_t timestamp_ns, pid_t pid, pid_t tid,
+      orbit_grpc_protos::ThreadStateSlice::ThreadState new_state);
   [[nodiscard]] std::vector<orbit_grpc_protos::ThreadStateSlice> OnCaptureFinished(
       uint64_t timestamp_ns);
 
  private:
   struct OpenState {
-    OpenState(orbit_grpc_protos::ThreadStateSlice::ThreadState state, uint64_t begin_timestamp_ns)
-        : state{state}, begin_timestamp_ns{begin_timestamp_ns} {}
+    OpenState(pid_t pid, orbit_grpc_protos::ThreadStateSlice::ThreadState state,
+              uint64_t begin_timestamp_ns)
+        : pid{pid}, state{state}, begin_timestamp_ns{begin_timestamp_ns} {}
+    pid_t pid;
     orbit_grpc_protos::ThreadStateSlice::ThreadState state;
     uint64_t begin_timestamp_ns;
   };

--- a/src/LinuxTracing/ThreadStateManagerTest.cpp
+++ b/src/LinuxTracing/ThreadStateManagerTest.cpp
@@ -18,35 +18,40 @@ namespace orbit_linux_tracing {
 using orbit_grpc_protos::ThreadStateSlice;
 
 TEST(ThreadStateManager, OneThread) {
+  constexpr pid_t kPid = 41;
   constexpr pid_t kTid = 42;
   ThreadStateManager manager;
   std::optional<ThreadStateSlice> slice;
 
-  manager.OnInitialState(100, kTid, ThreadStateSlice::kRunnable);
+  manager.OnInitialState(100, kPid, kTid, ThreadStateSlice::kRunnable);
 
-  slice = manager.OnSchedSwitchIn(200, kTid);
+  slice = manager.OnSchedSwitchIn(200, kPid, kTid);
   ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->pid(), kPid);
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
   EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 200);
 
-  slice = manager.OnSchedSwitchOut(300, kTid, ThreadStateSlice::kInterruptibleSleep);
+  slice = manager.OnSchedSwitchOut(300, kPid, kTid, ThreadStateSlice::kInterruptibleSleep);
   ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->pid(), kPid);
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
   EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 300);
 
-  slice = manager.OnSchedWakeup(400, kTid);
+  slice = manager.OnSchedWakeup(400, kPid, kTid);
   ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->pid(), kPid);
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kInterruptibleSleep);
   EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 400);
 
-  slice = manager.OnSchedSwitchIn(500, kTid);
+  slice = manager.OnSchedSwitchIn(500, kPid, kTid);
   ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->pid(), kPid);
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
   EXPECT_EQ(slice->duration_ns(), 100);
@@ -56,6 +61,7 @@ TEST(ThreadStateManager, OneThread) {
   ASSERT_TRUE(!slices.empty());
   EXPECT_EQ(slices.size(), 1);
   slice = slices[0];
+  EXPECT_EQ(slice->pid(), kPid);
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
   EXPECT_EQ(slice->duration_ns(), 100);
@@ -63,21 +69,24 @@ TEST(ThreadStateManager, OneThread) {
 }
 
 TEST(ThreadStateManager, NewTask) {
+  constexpr pid_t kPid = 41;
   constexpr pid_t kTid = 42;
   ThreadStateManager manager;
   std::optional<ThreadStateSlice> slice;
 
-  manager.OnNewTask(100, kTid);
+  manager.OnNewTask(100, kPid, kTid);
 
-  slice = manager.OnSchedSwitchIn(200, kTid);
+  slice = manager.OnSchedSwitchIn(200, kPid, kTid);
   ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->pid(), kPid);
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
   EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 200);
 
-  slice = manager.OnSchedSwitchOut(300, kTid, ThreadStateSlice::kRunnable);
+  slice = manager.OnSchedSwitchOut(300, kPid, kTid, ThreadStateSlice::kRunnable);
   ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->pid(), kPid);
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
   EXPECT_EQ(slice->duration_ns(), 100);
@@ -87,6 +96,7 @@ TEST(ThreadStateManager, NewTask) {
   ASSERT_TRUE(!slices.empty());
   EXPECT_EQ(slices.size(), 1);
   slice = slices[0];
+  EXPECT_EQ(slice->pid(), kPid);
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
   EXPECT_EQ(slice->duration_ns(), 100);
@@ -94,52 +104,59 @@ TEST(ThreadStateManager, NewTask) {
 }
 
 TEST(ThreadStateManager, TwoThreads) {
+  constexpr pid_t kPid1 = 41;
   constexpr pid_t kTid1 = 42;
+  constexpr pid_t kPid2 = 51;
   constexpr pid_t kTid2 = 52;
   ThreadStateManager manager;
   std::optional<ThreadStateSlice> slice;
 
-  manager.OnInitialState(100, kTid1, ThreadStateSlice::kRunnable);
+  manager.OnInitialState(100, kPid1, kTid1, ThreadStateSlice::kRunnable);
 
-  slice = manager.OnSchedSwitchIn(200, kTid1);
+  slice = manager.OnSchedSwitchIn(200, kPid1, kTid1);
   ASSERT_TRUE(slice.has_value());
   EXPECT_EQ(slice->tid(), kTid1);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
   EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 200);
 
-  manager.OnNewTask(250, kTid2);
+  manager.OnNewTask(250, kPid2, kTid2);
 
-  slice = manager.OnSchedSwitchOut(300, kTid1, ThreadStateSlice::kInterruptibleSleep);
+  slice = manager.OnSchedSwitchOut(300, kPid1, kTid1, ThreadStateSlice::kInterruptibleSleep);
   ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->pid(), kPid1);
   EXPECT_EQ(slice->tid(), kTid1);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
   EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 300);
 
-  slice = manager.OnSchedSwitchIn(350, kTid2);
+  slice = manager.OnSchedSwitchIn(350, kPid2, kTid2);
   ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->pid(), kPid2);
   EXPECT_EQ(slice->tid(), kTid2);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
   EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 350);
 
-  slice = manager.OnSchedWakeup(400, kTid1);
+  slice = manager.OnSchedWakeup(400, kPid1, kTid1);
   ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->pid(), kPid1);
   EXPECT_EQ(slice->tid(), kTid1);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kInterruptibleSleep);
   EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 400);
 
-  slice = manager.OnSchedSwitchOut(450, kTid2, ThreadStateSlice::kRunnable);
+  slice = manager.OnSchedSwitchOut(450, kPid2, kTid2, ThreadStateSlice::kRunnable);
   ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->pid(), kPid2);
   EXPECT_EQ(slice->tid(), kTid2);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
   EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 450);
 
-  slice = manager.OnSchedSwitchIn(500, kTid1);
+  slice = manager.OnSchedSwitchIn(500, kPid1, kTid1);
   ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->pid(), kPid1);
   EXPECT_EQ(slice->tid(), kTid1);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
   EXPECT_EQ(slice->duration_ns(), 100);
@@ -154,12 +171,14 @@ TEST(ThreadStateManager, TwoThreads) {
   }
 
   slice = slices[0];
+  EXPECT_EQ(slice->pid(), kPid1);
   EXPECT_EQ(slice->tid(), kTid1);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
   EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 600);
 
   slice = slices[1];
+  EXPECT_EQ(slice->pid(), kPid2);
   EXPECT_EQ(slice->tid(), kTid2);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
   EXPECT_EQ(slice->duration_ns(), 150);
@@ -167,14 +186,16 @@ TEST(ThreadStateManager, TwoThreads) {
 }
 
 TEST(ThreadStateManager, SwitchOutAfterInitialStateRunnable) {
+  constexpr pid_t kPid = 41;
   constexpr pid_t kTid = 42;
   ThreadStateManager manager;
   std::optional<ThreadStateSlice> slice;
 
-  manager.OnInitialState(100, kTid, ThreadStateSlice::kRunnable);
+  manager.OnInitialState(100, kPid, kTid, ThreadStateSlice::kRunnable);
 
-  slice = manager.OnSchedSwitchOut(200, kTid, ThreadStateSlice::kInterruptibleSleep);
+  slice = manager.OnSchedSwitchOut(200, kPid, kTid, ThreadStateSlice::kInterruptibleSleep);
   ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->pid(), kPid);
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
   EXPECT_EQ(slice->duration_ns(), 100);
@@ -182,16 +203,18 @@ TEST(ThreadStateManager, SwitchOutAfterInitialStateRunnable) {
 }
 
 TEST(ThreadStateManager, StaleInitialStateWithNewTask) {
+  constexpr pid_t kPid = 41;
   constexpr pid_t kTid = 42;
   ThreadStateManager manager;
   std::optional<ThreadStateSlice> slice;
 
-  manager.OnInitialState(150, kTid, ThreadStateSlice::kRunnable);
+  manager.OnInitialState(150, kPid, kTid, ThreadStateSlice::kRunnable);
 
-  manager.OnNewTask(100, kTid);
+  manager.OnNewTask(100, kPid, kTid);
 
-  slice = manager.OnSchedSwitchIn(200, kTid);
+  slice = manager.OnSchedSwitchIn(200, kPid, kTid);
   ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->pid(), kPid);
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
   EXPECT_EQ(slice->duration_ns(), 100);
@@ -199,17 +222,19 @@ TEST(ThreadStateManager, StaleInitialStateWithNewTask) {
 }
 
 TEST(ThreadStateManager, StaleInitialStateWithSchedWakeup) {
+  constexpr pid_t kPid = 41;
   constexpr pid_t kTid = 42;
   ThreadStateManager manager;
   std::optional<ThreadStateSlice> slice;
 
-  manager.OnInitialState(150, kTid, ThreadStateSlice::kRunnable);
+  manager.OnInitialState(150, kPid, kTid, ThreadStateSlice::kRunnable);
 
-  slice = manager.OnSchedWakeup(100, kTid);
+  slice = manager.OnSchedWakeup(100, kPid, kTid);
   EXPECT_FALSE(slice.has_value());
 
-  slice = manager.OnSchedSwitchIn(200, kTid);
+  slice = manager.OnSchedSwitchIn(200, kPid, kTid);
   ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->pid(), kPid);
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
   EXPECT_EQ(slice->duration_ns(), 100);
@@ -217,17 +242,19 @@ TEST(ThreadStateManager, StaleInitialStateWithSchedWakeup) {
 }
 
 TEST(ThreadStateManager, StaleInitialStateWithSwitchIn) {
+  constexpr pid_t kPid = 41;
   constexpr pid_t kTid = 42;
   ThreadStateManager manager;
   std::optional<ThreadStateSlice> slice;
 
-  manager.OnInitialState(150, kTid, ThreadStateSlice::kRunnable);
+  manager.OnInitialState(150, kPid, kTid, ThreadStateSlice::kRunnable);
 
-  slice = manager.OnSchedSwitchIn(100, kTid);
+  slice = manager.OnSchedSwitchIn(100, kPid, kTid);
   EXPECT_FALSE(slice.has_value());
 
-  slice = manager.OnSchedSwitchOut(200, kTid, ThreadStateSlice::kRunnable);
+  slice = manager.OnSchedSwitchOut(200, kPid, kTid, ThreadStateSlice::kRunnable);
   ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->pid(), kPid);
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
   EXPECT_EQ(slice->duration_ns(), 100);
@@ -235,17 +262,19 @@ TEST(ThreadStateManager, StaleInitialStateWithSwitchIn) {
 }
 
 TEST(ThreadStateManager, StaleInitialStateWithSwitchOut) {
+  constexpr pid_t kPid = 41;
   constexpr pid_t kTid = 42;
   ThreadStateManager manager;
   std::optional<ThreadStateSlice> slice;
 
-  manager.OnInitialState(150, kTid, ThreadStateSlice::kRunnable);
+  manager.OnInitialState(150, kPid, kTid, ThreadStateSlice::kRunnable);
 
-  slice = manager.OnSchedSwitchOut(100, kTid, ThreadStateSlice::kInterruptibleSleep);
+  slice = manager.OnSchedSwitchOut(100, kPid, kTid, ThreadStateSlice::kInterruptibleSleep);
   EXPECT_FALSE(slice.has_value());
 
-  slice = manager.OnSchedWakeup(200, kTid);
+  slice = manager.OnSchedWakeup(200, kPid, kTid);
   ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->pid(), kPid);
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kInterruptibleSleep);
   EXPECT_EQ(slice->duration_ns(), 100);
@@ -253,15 +282,17 @@ TEST(ThreadStateManager, StaleInitialStateWithSwitchOut) {
 }
 
 TEST(ThreadStateManager, UnknownInitialStateWithSchedWakeup) {
+  constexpr pid_t kPid = 41;
   constexpr pid_t kTid = 42;
   ThreadStateManager manager;
   std::optional<ThreadStateSlice> slice;
 
-  slice = manager.OnSchedWakeup(100, kTid);
+  slice = manager.OnSchedWakeup(100, kPid, kTid);
   EXPECT_FALSE(slice.has_value());
 
-  slice = manager.OnSchedSwitchIn(200, kTid);
+  slice = manager.OnSchedSwitchIn(200, kPid, kTid);
   ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->pid(), kPid);
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
   EXPECT_EQ(slice->duration_ns(), 100);
@@ -269,15 +300,17 @@ TEST(ThreadStateManager, UnknownInitialStateWithSchedWakeup) {
 }
 
 TEST(ThreadStateManager, UnknownInitialStateWithSwitchIn) {
+  constexpr pid_t kPid = 41;
   constexpr pid_t kTid = 42;
   ThreadStateManager manager;
   std::optional<ThreadStateSlice> slice;
 
-  slice = manager.OnSchedSwitchIn(100, kTid);
+  slice = manager.OnSchedSwitchIn(100, kPid, kTid);
   EXPECT_FALSE(slice.has_value());
 
-  slice = manager.OnSchedSwitchOut(200, kTid, ThreadStateSlice::kRunnable);
+  slice = manager.OnSchedSwitchOut(200, kPid, kTid, ThreadStateSlice::kRunnable);
   ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->pid(), kPid);
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
   EXPECT_EQ(slice->duration_ns(), 100);
@@ -285,15 +318,17 @@ TEST(ThreadStateManager, UnknownInitialStateWithSwitchIn) {
 }
 
 TEST(ThreadStateManager, UnknownInitialStateWithSwitchOut) {
+  constexpr pid_t kPid = 41;
   constexpr pid_t kTid = 42;
   ThreadStateManager manager;
   std::optional<ThreadStateSlice> slice;
 
-  slice = manager.OnSchedSwitchOut(100, kTid, ThreadStateSlice::kInterruptibleSleep);
+  slice = manager.OnSchedSwitchOut(100, kPid, kTid, ThreadStateSlice::kInterruptibleSleep);
   EXPECT_FALSE(slice.has_value());
 
-  slice = manager.OnSchedWakeup(200, kTid);
+  slice = manager.OnSchedWakeup(200, kPid, kTid);
   ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->pid(), kPid);
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kInterruptibleSleep);
   EXPECT_EQ(slice->duration_ns(), 100);
@@ -301,17 +336,19 @@ TEST(ThreadStateManager, UnknownInitialStateWithSwitchOut) {
 }
 
 TEST(ThreadStateManager, NoStateChangeWithSchedWakeup) {
+  constexpr pid_t kPid = 41;
   constexpr pid_t kTid = 42;
   ThreadStateManager manager;
   std::optional<ThreadStateSlice> slice;
 
-  manager.OnInitialState(100, kTid, ThreadStateSlice::kRunnable);
+  manager.OnInitialState(100, kPid, kTid, ThreadStateSlice::kRunnable);
 
-  slice = manager.OnSchedWakeup(150, kTid);
+  slice = manager.OnSchedWakeup(150, kPid, kTid);
   EXPECT_FALSE(slice.has_value());
 
-  slice = manager.OnSchedSwitchIn(200, kTid);
+  slice = manager.OnSchedSwitchIn(200, kPid, kTid);
   ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->pid(), kPid);
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
   EXPECT_EQ(slice->duration_ns(), 100);
@@ -319,24 +356,27 @@ TEST(ThreadStateManager, NoStateChangeWithSchedWakeup) {
 }
 
 TEST(ThreadStateManager, NoStateChangeWithSwitchIn) {
+  constexpr pid_t kPid = 41;
   constexpr pid_t kTid = 42;
   ThreadStateManager manager;
   std::optional<ThreadStateSlice> slice;
 
-  manager.OnInitialState(100, kTid, ThreadStateSlice::kRunnable);
+  manager.OnInitialState(100, kPid, kTid, ThreadStateSlice::kRunnable);
 
-  slice = manager.OnSchedSwitchIn(200, kTid);
+  slice = manager.OnSchedSwitchIn(200, kPid, kTid);
   ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->pid(), kPid);
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunnable);
   EXPECT_EQ(slice->duration_ns(), 100);
   EXPECT_EQ(slice->end_timestamp_ns(), 200);
 
-  slice = manager.OnSchedSwitchIn(250, kTid);
+  slice = manager.OnSchedSwitchIn(250, kPid, kTid);
   EXPECT_FALSE(slice.has_value());
 
-  slice = manager.OnSchedSwitchOut(300, kTid, ThreadStateSlice::kInterruptibleSleep);
+  slice = manager.OnSchedSwitchOut(300, kPid, kTid, ThreadStateSlice::kInterruptibleSleep);
   ASSERT_TRUE(slice.has_value());
+  EXPECT_EQ(slice->pid(), kPid);
   EXPECT_EQ(slice->tid(), kTid);
   EXPECT_EQ(slice->thread_state(), ThreadStateSlice::kRunning);
   EXPECT_EQ(slice->duration_ns(), 100);

--- a/src/OrbitCaptureClient/CaptureEventProcessor.cpp
+++ b/src/OrbitCaptureClient/CaptureEventProcessor.cpp
@@ -262,6 +262,7 @@ void CaptureEventProcessor::ProcessThreadName(const ThreadName& thread_name) {
 
 void CaptureEventProcessor::ProcessThreadStateSlice(const ThreadStateSlice& thread_state_slice) {
   ThreadStateSliceInfo slice_info;
+  // Note: thread_state_slice.pid() is available, but currently dropped.
   slice_info.set_tid(thread_state_slice.tid());
   switch (thread_state_slice.thread_state()) {
     case ThreadStateSlice::kRunning:


### PR DESCRIPTION
Compared bandwidth usage before and after this change with a simple capture on
Trata: thread state enabled, no dynamic instrumentation.
The average bytes per event goes from 23.1 to 25.7, which is quite an increase.

---

Given what I wrote in the commit message about the increase in data usage,
I'm not sure I want to merge this change, but I'm creating it al least for discussion.

Context: Some protos in `orbit_grpc_protos` had a `pid` field not set. In coordination
with Dimitry, as we are moving towards a stable format, it seems reasonable to have
them set when it's very cheap to do so.
This is the last remaining one but also the one for which such a change is not exactly
free.