### PR TITLE
Metrics capture & preset; save & load

### DIFF
--- a/src/MetricsUploader/proto/orbit_log_event.proto
+++ b/src/MetricsUploader/proto/orbit_log_event.proto
@@ -15,6 +15,7 @@ message OrbitLogEvent {
     ORBIT_INITIALIZED = 1;
     ORBIT_CAPTURE_DURATION = 2;
     ORBIT_CAPTURE_SAVE_SUCCESS = 3;
+    ORBIT_CAPTURE_LOAD_SUCCESS = 4;
   }
   LogEventType log_event_type = 1;
 

--- a/src/MetricsUploader/proto/orbit_log_event.proto
+++ b/src/MetricsUploader/proto/orbit_log_event.proto
@@ -14,6 +14,7 @@ message OrbitLogEvent {
     UNKNOWN_EVENT_TYPE = 0;
     ORBIT_INITIALIZED = 1;
     ORBIT_CAPTURE_DURATION = 2;
+    ORBIT_CAPTURE_SAVE_SUCCESS = 3;
   }
   LogEventType log_event_type = 1;
 

--- a/src/MetricsUploader/proto/orbit_log_event.proto
+++ b/src/MetricsUploader/proto/orbit_log_event.proto
@@ -17,6 +17,7 @@ message OrbitLogEvent {
     ORBIT_CAPTURE_SAVE_SUCCESS = 3;
     ORBIT_CAPTURE_LOAD_SUCCESS = 4;
     ORBIT_PRESET_SAVE_SUCCESS = 5;
+    ORBIT_PRESET_LOAD_SUCCESS = 6;
   }
   LogEventType log_event_type = 1;
 

--- a/src/MetricsUploader/proto/orbit_log_event.proto
+++ b/src/MetricsUploader/proto/orbit_log_event.proto
@@ -16,6 +16,7 @@ message OrbitLogEvent {
     ORBIT_CAPTURE_DURATION = 2;
     ORBIT_CAPTURE_SAVE_SUCCESS = 3;
     ORBIT_CAPTURE_LOAD_SUCCESS = 4;
+    ORBIT_PRESET_SAVE_SUCCESS = 5;
   }
   LogEventType log_event_type = 1;
 

--- a/src/OrbitClientModel/CaptureDeserializerTest.cpp
+++ b/src/OrbitClientModel/CaptureDeserializerTest.cpp
@@ -94,8 +94,9 @@ TEST(CaptureDeserializer, LoadFileNotExists) {
   EXPECT_CALL(listener, OnCaptureComplete).Times(0);
   EXPECT_CALL(listener, OnCaptureCancelled).Times(0);
   ModuleManager module_manager;
-  capture_deserializer::Load("not_existing_test_file", &listener, &module_manager,
-                             &cancellation_requested);
+  bool success = capture_deserializer::Load("not_existing_test_file", &listener, &module_manager,
+                                            &cancellation_requested);
+  EXPECT_FALSE(success);
 
   EXPECT_EQ("Error opening file \"not_existing_test_file\" for reading", actual_error.message());
 }
@@ -119,8 +120,9 @@ TEST(CaptureDeserializer, LoadNoVersion) {
          << serialized_header;
 
   ModuleManager module_manager;
-  capture_deserializer::Load(stream, "file_name", &listener, &module_manager,
-                             &cancellation_requested);
+  bool success = capture_deserializer::Load(stream, "file_name", &listener, &module_manager,
+                                            &cancellation_requested);
+  EXPECT_FALSE(success);
 
   std::string expected_error_message =
       "Error parsing the capture from \"file_name\".\nNote: If the capture "
@@ -149,8 +151,9 @@ TEST(CaptureDeserializer, LoadOldVersion) {
          << serialized_header;
 
   ModuleManager module_manager;
-  capture_deserializer::Load(stream, "file_name", &listener, &module_manager,
-                             &cancellation_requested);
+  bool success = capture_deserializer::Load(stream, "file_name", &listener, &module_manager,
+                                            &cancellation_requested);
+  EXPECT_FALSE(success);
 
   EXPECT_THAT(actual_error.message(), HasSubstr("1.51"));
 }
@@ -174,8 +177,9 @@ TEST(CaptureDeserializer, LoadNoCaptureInfo) {
          << serialized_header;
 
   ModuleManager module_manager;
-  capture_deserializer::Load(stream, "file_name", &listener, &module_manager,
-                             &cancellation_requested);
+  bool success = capture_deserializer::Load(stream, "file_name", &listener, &module_manager,
+                                            &cancellation_requested);
+  EXPECT_FALSE(success);
 }
 
 TEST(CaptureDeserializer, LoadCaptureInfoOnCaptureStarted) {
@@ -235,8 +239,9 @@ TEST(CaptureDeserializer, LoadCaptureInfoOnCaptureStarted) {
   EXPECT_CALL(listener, OnThreadName).Times(0);
 
   ModuleManager module_manager;
-  capture_deserializer::internal::LoadCaptureInfo(capture_info, &listener, &module_manager,
-                                                  &empty_stream, &cancellation_requested);
+  bool success = capture_deserializer::internal::LoadCaptureInfo(
+      capture_info, &listener, &module_manager, &empty_stream, &cancellation_requested);
+  EXPECT_TRUE(success);
 }
 
 TEST(CaptureDeserializer, LoadCaptureInfoModuleManager) {
@@ -269,8 +274,9 @@ TEST(CaptureDeserializer, LoadCaptureInfoModuleManager) {
   EXPECT_CALL(listener, OnThreadName).Times(0);
 
   ModuleManager module_manager;
-  capture_deserializer::internal::LoadCaptureInfo(capture_info, &listener, &module_manager,
-                                                  &empty_stream, &cancellation_requested);
+  bool success = capture_deserializer::internal::LoadCaptureInfo(
+      capture_info, &listener, &module_manager, &empty_stream, &cancellation_requested);
+  EXPECT_TRUE(success);
 
   const ModuleData* module = module_manager.GetModuleByPath(module_path);
   ASSERT_NE(module, nullptr);
@@ -313,8 +319,9 @@ TEST(CaptureDeserializer, LoadCaptureInfoAddressInfos) {
   EXPECT_CALL(listener, OnCaptureComplete).Times(1);
 
   ModuleManager module_manager;
-  capture_deserializer::internal::LoadCaptureInfo(capture_info, &listener, &module_manager,
-                                                  &empty_stream, &cancellation_requested);
+  bool success = capture_deserializer::internal::LoadCaptureInfo(
+      capture_info, &listener, &module_manager, &empty_stream, &cancellation_requested);
+  EXPECT_TRUE(success);
 
   EXPECT_EQ(actual_address_info_1.function_name(), address_info_1.function_name());
   EXPECT_EQ(actual_address_info_2.function_name(), address_info_2.function_name());
@@ -347,8 +354,9 @@ TEST(CaptureDeserializer, LoadCaptureInfoThreadNames) {
   EXPECT_CALL(listener, OnCaptureComplete).Times(1);
 
   ModuleManager module_manager;
-  capture_deserializer::internal::LoadCaptureInfo(capture_info, &listener, &module_manager,
-                                                  &empty_stream, &cancellation_requested);
+  bool success = capture_deserializer::internal::LoadCaptureInfo(
+      capture_info, &listener, &module_manager, &empty_stream, &cancellation_requested);
+  EXPECT_TRUE(success);
 }
 
 TEST(CaptureDeserializer, LoadCaptureInfoThreadStateSlices) {
@@ -384,8 +392,9 @@ TEST(CaptureDeserializer, LoadCaptureInfoThreadStateSlices) {
   EXPECT_CALL(listener, OnCaptureComplete).Times(1);
 
   ModuleManager module_manager;
-  capture_deserializer::internal::LoadCaptureInfo(capture_info, &listener, &module_manager,
-                                                  &empty_stream, &cancellation_requested);
+  bool success = capture_deserializer::internal::LoadCaptureInfo(
+      capture_info, &listener, &module_manager, &empty_stream, &cancellation_requested);
+  EXPECT_TRUE(success);
 }
 
 TEST(CaptureDeserializer, LoadCaptureInfoKeysAndStrings) {
@@ -409,8 +418,9 @@ TEST(CaptureDeserializer, LoadCaptureInfoKeysAndStrings) {
   EXPECT_CALL(listener, OnCaptureComplete).Times(1);
 
   ModuleManager module_manager;
-  capture_deserializer::internal::LoadCaptureInfo(capture_info, &listener, &module_manager,
-                                                  &empty_stream, &cancellation_requested);
+  bool success = capture_deserializer::internal::LoadCaptureInfo(
+      capture_info, &listener, &module_manager, &empty_stream, &cancellation_requested);
+  EXPECT_TRUE(success);
 }
 
 TEST(CaptureDeserializer, LoadCaptureInfoCallstacks) {
@@ -493,8 +503,10 @@ TEST(CaptureDeserializer, LoadCaptureInfoCallstacks) {
   EXPECT_CALL(listener, OnCaptureComplete).Times(1);
 
   ModuleManager module_manager;
-  capture_deserializer::internal::LoadCaptureInfo(capture_info, &listener, &module_manager,
-                                                  &empty_stream, &cancellation_requested);
+  bool success = capture_deserializer::internal::LoadCaptureInfo(
+      capture_info, &listener, &module_manager, &empty_stream, &cancellation_requested);
+  EXPECT_TRUE(success);
+
   EXPECT_TRUE(hash_added_1);
   EXPECT_TRUE(hash_added_2);
   EXPECT_TRUE(hash_present_1_1);
@@ -584,8 +596,10 @@ TEST(CaptureDeserializer, LoadCaptureInfoTracepoints) {
   EXPECT_CALL(listener, OnCaptureComplete).Times(1);
 
   ModuleManager module_manager;
-  capture_deserializer::internal::LoadCaptureInfo(capture_info, &listener, &module_manager,
-                                                  &empty_stream, &cancellation_requested);
+  bool success = capture_deserializer::internal::LoadCaptureInfo(
+      capture_info, &listener, &module_manager, &empty_stream, &cancellation_requested);
+  EXPECT_TRUE(success);
+
   EXPECT_TRUE(hash_added_1);
   EXPECT_TRUE(hash_added_2);
   EXPECT_TRUE(hash_present_1_1);
@@ -647,8 +661,9 @@ TEST(CaptureDeserializer, LoadCaptureInfoTimers) {
   google::protobuf::io::CodedInputStream coded_input(&input_stream);
 
   ModuleManager module_manager;
-  capture_deserializer::internal::LoadCaptureInfo(empty_capture_info, &listener, &module_manager,
-                                                  &coded_input, &cancellation_requested);
+  bool success = capture_deserializer::internal::LoadCaptureInfo(
+      empty_capture_info, &listener, &module_manager, &coded_input, &cancellation_requested);
+  EXPECT_TRUE(success);
 
   EXPECT_EQ(timer_1.start(), actual_timer_1.start());
   EXPECT_EQ(timer_2.start(), actual_timer_2.start());
@@ -681,8 +696,9 @@ TEST(CaptureDeserializer, LoadCaptureInfoUserDefinedCaptureData) {
   EXPECT_CALL(listener, OnCaptureCancelled).Times(0);
 
   ModuleManager module_manager;
-  capture_deserializer::internal::LoadCaptureInfo(capture_info, &listener, &module_manager,
-                                                  &empty_stream, &cancellation_requested);
+  bool success = capture_deserializer::internal::LoadCaptureInfo(
+      capture_info, &listener, &module_manager, &empty_stream, &cancellation_requested);
+  EXPECT_TRUE(success);
 
   ASSERT_EQ(1, actual_frame_track_function_ids.size());
   EXPECT_TRUE(actual_frame_track_function_ids.contains(frame_track_function_id));

--- a/src/OrbitClientModel/include/OrbitClientModel/CaptureDeserializer.h
+++ b/src/OrbitClientModel/include/OrbitClientModel/CaptureDeserializer.h
@@ -21,22 +21,23 @@
 
 namespace capture_deserializer {
 
-void Load(std::istream& stream, const std::string& file_name, CaptureListener* capture_listener,
-          orbit_client_data::ModuleManager* module_manager,
-          std::atomic<bool>* cancellation_requested);
-void Load(const std::string& file_name, CaptureListener* capture_listener,
-          orbit_client_data::ModuleManager* module_manager,
-          std::atomic<bool>* cancellation_requested);
+[[nodiscard]] bool Load(std::istream& stream, const std::string& file_name,
+                        CaptureListener* capture_listener,
+                        orbit_client_data::ModuleManager* module_manager,
+                        std::atomic<bool>* cancellation_requested);
+[[nodiscard]] bool Load(const std::string& file_name, CaptureListener* capture_listener,
+                        orbit_client_data::ModuleManager* module_manager,
+                        std::atomic<bool>* cancellation_requested);
 
 namespace internal {
 
 bool ReadMessage(google::protobuf::Message* message, google::protobuf::io::CodedInputStream* input);
 
-void LoadCaptureInfo(const orbit_client_protos::CaptureInfo& capture_info,
-                     CaptureListener* capture_listener,
-                     orbit_client_data::ModuleManager* module_manager,
-                     google::protobuf::io::CodedInputStream* coded_input,
-                     std::atomic<bool>* cancellation_requested);
+[[nodiscard]] bool LoadCaptureInfo(const orbit_client_protos::CaptureInfo& capture_info,
+                                   CaptureListener* capture_listener,
+                                   orbit_client_data::ModuleManager* module_manager,
+                                   google::protobuf::io::CodedInputStream* coded_input,
+                                   std::atomic<bool>* cancellation_requested);
 
 inline const std::string kRequiredCaptureVersion = "1.59";
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -706,9 +706,21 @@ void OrbitApp::SetClipboard(const std::string& text) {
 }
 
 ErrorMessageOr<void> OrbitApp::OnSavePreset(const std::string& filename) {
+  auto timestamp_before_save = std::chrono::steady_clock::now();
+
   OUTCOME_TRY(SavePreset(filename));
   ListPresets();
   Refresh(DataViewType::kPresets);
+
+  if (metrics_uploader_ == nullptr) return outcome::success();
+
+  auto timestamp_after_save = std::chrono::steady_clock::now();
+  auto save_duration = std::chrono::duration_cast<std::chrono::milliseconds>(timestamp_after_save -
+                                                                             timestamp_before_save);
+
+  metrics_uploader_->SendLogEvent(
+      orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_PRESET_SAVE_SUCCESS, save_duration);
+
   return outcome::success();
 }
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -820,8 +820,8 @@ void OrbitApp::OnLoadCapture(const std::string& file_name) {
   string_manager_->Clear();
   thread_pool_->Schedule([this, file_name]() mutable {
     capture_loading_cancellation_requested_ = false;
-    capture_deserializer::Load(file_name, this, module_manager_.get(),
-                               &capture_loading_cancellation_requested_);
+    (void)capture_deserializer::Load(file_name, this, module_manager_.get(),
+                                     &capture_loading_cancellation_requested_);
   });
 
   DoZoom = true;  // TODO: remove global, review logic

--- a/src/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
+++ b/src/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
@@ -79,7 +79,8 @@ DEFINE_PROTO_FUZZER(const orbit_client_protos::CaptureDeserializerFuzzerInfo& in
   std::atomic<bool> cancellation_requested = false;
 
   orbit_client_data::ModuleManager module_manager;
-  capture_deserializer::Load(input_stream, "", app.get(), &module_manager, &cancellation_requested);
+  (void)capture_deserializer::Load(input_stream, "", app.get(), &module_manager,
+                                   &cancellation_requested);
 
   app->GetThreadPool()->ShutdownAndWait();
 }


### PR DESCRIPTION
This adds four metric events: 
ORBIT_CAPTURE_SAVE_SUCCESS
ORBIT_CAPTURE_LOAD_SUCCESS
ORBIT_PRESET_SAVE_SUCCESS
ORBIT_PRESET_LOAD_SUCCESS
This includes the time the saving / loading actually took. 

I added return type bool to `capture_deserializer::Load` to be able to tell when the load was successful. 