### PR TITLE
Draw overlaps of timers as triangles.

### DIFF
--- a/src/OrbitGl/Batcher.cpp
+++ b/src/OrbitGl/Batcher.cpp
@@ -225,24 +225,19 @@ void Batcher::AddTriangle(const Triangle& triangle, const Color& color, const Co
   AddTriangle(triangle, colors, picking_color, std::move(user_data));
 }
 
+// Draw a shaded trapezium with two sides parallel to the x-axis or y-axis.
 void Batcher::AddShadedTrapezium(const Vec3& top_left, const Vec3& bottom_left,
                                  const Vec3& bottom_right, const Vec3& top_right,
                                  const Color& color, std::unique_ptr<PickingUserData> user_data,
                                  ShadingDirection shading_direction) {
   std::array<Color, 4> colors;  // top_left, bottom_left, bottom_right, top_right.
-  GetBoxGradientColors(color, &colors, shading_direction);  // left points will be "darker".
+  GetBoxGradientColors(color, &colors, shading_direction);
   Color picking_color = PickingId::ToColor(PickingType::kTriangle, user_data_.size(), batcher_id_);
   Triangle triangle_1{top_left, bottom_left, top_right};
-  std::array<Color, 3> colors_1;
-  colors_1[0] = colors[0];
-  colors_1[1] = colors[1];
-  colors_1[2] = colors[2];
+  std::array<Color, 3> colors_1{colors[0], colors[1], colors[2]};
   AddTriangle(triangle_1, colors_1, picking_color, std::make_unique<PickingUserData>(*user_data));
   Triangle triangle_2{bottom_left, bottom_right, top_right};
-  std::array<Color, 3> colors_2;
-  colors_2[0] = colors[1];
-  colors_2[1] = colors[2];
-  colors_2[2] = colors[3];
+  std::array<Color, 3> colors_2{colors[1], colors[2], colors[3]};
   AddTriangle(triangle_2, colors_2, picking_color, std::move(user_data));
 }
 

--- a/src/OrbitGl/Batcher.h
+++ b/src/OrbitGl/Batcher.h
@@ -32,6 +32,8 @@ struct PickingUserData {
 
   explicit PickingUserData(TextBox* text_box = nullptr, TooltipCallback generate_tooltip = nullptr)
       : text_box_(text_box), generate_tooltip_(std::move(generate_tooltip)) {}
+
+  explicit PickingUserData(const PickingUserData& other) = default;
 };
 
 struct LineBuffer {
@@ -149,9 +151,10 @@ class Batcher {
 
   void AddTriangle(const Triangle& triangle, const Color& color,
                    std::unique_ptr<PickingUserData> user_data = nullptr);
-  void AddShadedTriangle(const Triangle& triangle, const Color& color,
-                         std::unique_ptr<PickingUserData> user_data = nullptr,
-                         ShadingDirection shading_direction = ShadingDirection::kLeftToRight);
+  void AddShadedTrapezium(const Vec3& top_left, const Vec3& bottom_left, const Vec3& bottom_right,
+                          const Vec3& top_right, const Color& color,
+                          std::unique_ptr<PickingUserData> user_data = nullptr,
+                          ShadingDirection shading_direction = ShadingDirection::kLeftToRight);
   void AddTriangle(const Triangle& triangle, const Color& color,
                    std::shared_ptr<Pickable> pickable);
 

--- a/src/OrbitGl/Batcher.h
+++ b/src/OrbitGl/Batcher.h
@@ -149,6 +149,9 @@ class Batcher {
 
   void AddTriangle(const Triangle& triangle, const Color& color,
                    std::unique_ptr<PickingUserData> user_data = nullptr);
+  void AddShadedTriangle(const Triangle& triangle, const Color& color,
+                         std::unique_ptr<PickingUserData> user_data = nullptr,
+                         ShadingDirection shading_direction = ShadingDirection::kLeftToRight);
   void AddTriangle(const Triangle& triangle, const Color& color,
                    std::shared_ptr<Pickable> pickable);
 
@@ -183,6 +186,9 @@ class Batcher {
   void AddBox(const Box& box, const std::array<Color, 4>& colors, const Color& picking_color,
               std::unique_ptr<PickingUserData> user_data = nullptr);
   void AddTriangle(const Triangle& triangle, const Color& color, const Color& picking_color,
+                   std::unique_ptr<PickingUserData> user_data = nullptr);
+  void AddTriangle(const Triangle& triangle, const std::array<Color, 3>& colors,
+                   const Color& picking_color,
                    std::unique_ptr<PickingUserData> user_data = nullptr);
 
   BatcherId batcher_id_;

--- a/src/OrbitGl/Batcher.h
+++ b/src/OrbitGl/Batcher.h
@@ -32,8 +32,6 @@ struct PickingUserData {
 
   explicit PickingUserData(TextBox* text_box = nullptr, TooltipCallback generate_tooltip = nullptr)
       : text_box_(text_box), generate_tooltip_(std::move(generate_tooltip)) {}
-
-  explicit PickingUserData(const PickingUserData& other) = default;
 };
 
 struct LineBuffer {

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -185,11 +185,12 @@ float GpuTrack::GetYFromTimer(const TimerInfo& timer_info) const {
   return pos_[1] - layout.GetTextBoxHeight() * (adjusted_depth + 1.f) - gap_space;
 }
 
-// When track is collapsed, only draw "hardware execution" timers and "debug markers".
+// When track is collapsed, only draw "hardware execution" timers and the root "debug markers".
 bool GpuTrack::TimerFilter(const TimerInfo& timer_info) const {
   if (collapse_toggle_->IsCollapsed()) {
     std::string gpu_stage = string_manager_->Get(timer_info.user_data_key()).value_or("");
-    return gpu_stage == kHwExecutionString || timer_info.type() == TimerInfo::kGpuDebugMarker;
+    return gpu_stage == kHwExecutionString ||
+           (timer_info.type() == TimerInfo::kGpuDebugMarker && timer_info.depth() == 0);
   }
   return true;
 }

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -75,7 +75,7 @@ WorldXInfo ToWorldX(double start_us, double end_us, double inv_time_window, floa
   double normalized_start = start_us * inv_time_window;
   double normalized_width = width_us * inv_time_window;
 
-  WorldXInfo result;
+  WorldXInfo result{};
   result.world_x_start = static_cast<float>(world_start_x + normalized_start * world_width);
   result.world_x_width = static_cast<float>(normalized_width * world_width);
   result.is_visible_width = normalized_width * canvas_width > 1;

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -75,10 +75,10 @@ WorldXInfo ToWorldX(double start_us, double end_us, double inv_time_window, floa
   double normalized_start = start_us * inv_time_window;
   double normalized_width = width_us * inv_time_window;
 
-  WorldXInfo result{
-      .world_x_start = static_cast<float>(world_start_x + normalized_start * world_width),
-      .world_x_width = static_cast<float>(normalized_width * world_width),
-      .is_visible_width = normalized_width * canvas_width > 1};
+  WorldXInfo result;
+  result.world_x_start = static_cast<float>(world_start_x + normalized_start * world_width);
+  result.world_x_width = static_cast<float>(normalized_width * world_width);
+  result.is_visible_width = normalized_width * canvas_width > 1;
   return result;
 }
 

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -65,7 +65,6 @@ namespace {
 struct WorldXInfo {
   float world_x_start;
   float world_x_width;
-  bool is_visible_width;
 };
 
 WorldXInfo ToWorldX(double start_us, double end_us, double inv_time_window, float world_start_x,
@@ -178,10 +177,13 @@ void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
           double text_x_start_us = start_or_prev_end_us - (.25 * left_overlap_width_us);
           double right_overlap_width_us = end_us - end_or_next_start_us;
           double text_x_end_us = end_or_next_start_us + (.25 * right_overlap_width_us);
+
+          bool is_visible_width =
+              (text_x_end_us - text_x_start_us) * inv_time_window * canvas->GetWidth() > 1;
           WorldXInfo world_x_info =
               ToWorldX(text_x_start_us, text_x_end_us, inv_time_window, world_start_x, world_width);
 
-          if (world_x_info.is_visible_width) {
+          if (is_visible_width) {
             Vec2 pos(world_x_info.world_x_start, world_timer_y);
             Vec2 size(world_x_info.world_x_width, GetTextBoxHeight(timer_info));
             text_box.SetPos(pos);


### PR DESCRIPTION
Especially GPU timers can overlap (due to the pipeline nature).
This change ensures that the text of such timers does not overlap
and that it is clearly visible to the user that these timers do
overlap.

To do so, the overlapping area is drawn as two triangles. Further,
the coloring is slightly adjusted, such that overlapping timers
do not have the same color, and the triangles can be seen.

Test: Need to be done on the feature/vulkan_layer branch.

![Screenshot 2021-01-29 at 18 07 14](https://user-images.githubusercontent.com/2725914/106306082-d4680700-625d-11eb-9e82-2dd707ae4e45.png)
