### PR TITLE
Add environment variable to enable the Vulkan layer.

### DIFF
--- a/src/OrbitVulkanLayer/resources/VkLayer_Orbit_implicit.json
+++ b/src/OrbitVulkanLayer/resources/VkLayer_Orbit_implicit.json
@@ -10,6 +10,9 @@
         "disable_environment": {
             "DISABLE_ORBIT_VULKAN_LAYER": "1"
         },
+        "enable_environment": {
+            "ENABLE_ORBIT_VULKAN_LAYER": "1"
+        },
         "functions": {
             "vkGetInstanceProcAddr": "OrbitGetInstanceProcAddr",
             "vkGetDeviceProcAddr": "OrbitGetDeviceProcAddr"


### PR DESCRIPTION
Prior this, the Vulkan layer was always auto loaded and enabled if
it was present in one of the Vulkan load directories.

With this change, you need to set the ENABLE_ORBIT_VULKAN_LAYER
(which will be done by the "run --orbit" option), to actually enable
the layer.