### PR TITLE
Callstacks no longer use hashes as ids

### DIFF
--- a/src/ClientProtos/capture_data.proto
+++ b/src/ClientProtos/capture_data.proto
@@ -56,7 +56,7 @@ message FunctionInfo {
 
 message CallstackEvent {
   uint64 time = 1;
-  uint64 callstack_hash = 2;
+  uint64 callstack_id = 2;
   int32 thread_id = 3;
 }
 
@@ -119,12 +119,12 @@ message UserDefinedCaptureInfo {
 }
 
 message CaptureInfo {
-  reserved 1, 2, 3;
+  reserved 1, 2, 3, 6;
   map<uint64, FunctionInfo> instrumented_functions = 16;
   map<int32, string> thread_names = 4;
   repeated ThreadStateSliceInfo thread_state_slices = 12;
   repeated LinuxAddressInfo address_infos = 5;
-  repeated CallstackInfo callstacks = 6;
+  map<uint64, CallstackInfo> callstacks = 17;
   repeated CallstackEvent callstack_events = 7;
   map<uint64, string> key_to_string = 8;
   // TODO(kuebler): consider removing this field completely.

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
@@ -53,8 +53,8 @@ class CaptureEventProcessor {
   CaptureListener* capture_listener_ = nullptr;
 
   absl::flat_hash_set<uint64_t> callstack_hashes_seen_;
-  uint64_t GetCallstackHashAndSendToListenerIfNecessary(
-      const orbit_grpc_protos::Callstack& callstack);
+  void SendCallstackToListenerIfNecessary(uint64_t callstack_id,
+                                          const orbit_grpc_protos::Callstack& callstack);
   absl::flat_hash_set<uint64_t> string_hashes_seen_;
   uint64_t GetStringHashAndSendToListenerIfNecessary(const std::string& str);
   absl::flat_hash_set<uint64_t> tracepoint_hashes_seen_;

--- a/src/OrbitClientData/CallstackDataTest.cpp
+++ b/src/OrbitClientData/CallstackDataTest.cpp
@@ -17,7 +17,7 @@
 MATCHER(CallstackEventEq, "") {
   const orbit_client_protos::CallstackEvent& a = std::get<0>(arg);
   const orbit_client_protos::CallstackEvent& b = std::get<1>(arg);
-  return a.time() == b.time() && a.callstack_hash() == b.callstack_hash() &&
+  return a.time() == b.time() && a.callstack_id() == b.callstack_id() &&
          a.thread_id() == b.thread_id();
 }
 
@@ -28,71 +28,71 @@ TEST(CallstackData, FilterCallstackEventsBasedOnMajorityStart) {
   const int32_t tid_with_broken_only = 43;
   const int32_t tid_without_supermajority = 44;
 
+  const uint64_t cs1_id = 12;
   const uint64_t cs1_outer = 0x10;
   const uint64_t cs1_inner = 0x11;
-  const CallStack cs1{{cs1_inner, cs1_outer}};
-  const uint64_t hash1 = cs1.GetHash();
+  const CallStack cs1{cs1_id, {cs1_inner, cs1_outer}};
   callstack_data.AddUniqueCallStack(cs1);
 
+  const uint64_t cs2_id = 13;
   const uint64_t cs2_outer = 0x10;
   const uint64_t cs2_inner = 0x21;
-  const CallStack cs2{{cs2_inner, cs2_outer}};
-  const uint64_t hash2 = cs2.GetHash();
+  const CallStack cs2{cs2_id, {cs2_inner, cs2_outer}};
   callstack_data.AddUniqueCallStack(cs2);
 
+  const uint64_t broken_cs_id = 81;
   const uint64_t broken_cs_outer = 0x30;
   const uint64_t broken_cs_inner = 0x31;
-  const CallStack broken_cs{{broken_cs_inner, broken_cs_outer}};
-  const uint64_t broken_hash = broken_cs.GetHash();
+  const CallStack broken_cs{broken_cs_id, {broken_cs_inner, broken_cs_outer}};
   callstack_data.AddUniqueCallStack(broken_cs);
 
   const uint64_t time1 = 100;
   orbit_client_protos::CallstackEvent event1;
   event1.set_time(time1);
   event1.set_thread_id(tid);
-  event1.set_callstack_hash(hash1);
+  event1.set_callstack_id(cs1_id);
   callstack_data.AddCallstackEvent(event1);
 
   const uint64_t time2 = 200;
   orbit_client_protos::CallstackEvent event2;
   event2.set_time(time2);
   event2.set_thread_id(tid);
-  event2.set_callstack_hash(broken_hash);
+  event2.set_callstack_id(broken_cs_id);
   callstack_data.AddCallstackEvent(event2);
 
   const uint64_t time3 = 300;
   orbit_client_protos::CallstackEvent event3;
   event3.set_time(time3);
   event3.set_thread_id(tid);
-  event3.set_callstack_hash(hash2);
+  event3.set_callstack_id(cs2_id);
   callstack_data.AddCallstackEvent(event3);
 
   const uint64_t time4 = 400;
   orbit_client_protos::CallstackEvent event4;
   event4.set_time(time4);
   event4.set_thread_id(tid);
-  event4.set_callstack_hash(hash1);
+  event4.set_callstack_id(cs1_id);
   callstack_data.AddCallstackEvent(event4);
 
   const uint64_t time5 = 500;
   orbit_client_protos::CallstackEvent event5;
   event5.set_time(time5);
   event5.set_thread_id(tid_with_broken_only);
-  event5.set_callstack_hash(broken_hash);
+  event5.set_callstack_id(broken_cs_id);
   callstack_data.AddCallstackEvent(event5);
 
   const uint64_t time6 = 600;
   orbit_client_protos::CallstackEvent event6;
   event6.set_time(time6);
   event6.set_thread_id(tid_without_supermajority);
-  event6.set_callstack_hash(hash1);
+  event6.set_callstack_id(cs1_id);
   callstack_data.AddCallstackEvent(event6);
 
   const uint64_t time7 = 700;
   orbit_client_protos::CallstackEvent event7;
   event7.set_time(time7);
   event7.set_thread_id(tid_without_supermajority);
-  event7.set_callstack_hash(broken_hash);
+  event7.set_callstack_id(broken_cs_id);
   callstack_data.AddCallstackEvent(event7);
 
   callstack_data.FilterCallstackEventsBasedOnMajorityStart();

--- a/src/OrbitClientData/PostProcessedSamplingData.cpp
+++ b/src/OrbitClientData/PostProcessedSamplingData.cpp
@@ -45,7 +45,7 @@ const CallStack& PostProcessedSamplingData::GetResolvedCallstack(
   CHECK(resolved_callstack_id_it != original_to_resolved_callstack_.end());
   auto resolved_callstack_it = unique_resolved_callstacks_.find(resolved_callstack_id_it->second);
   CHECK(resolved_callstack_it != unique_resolved_callstacks_.end());
-  return *resolved_callstack_it->second;
+  return resolved_callstack_it->second;
 }
 
 std::multimap<int, CallstackID> PostProcessedSamplingData::GetCallstacksFromAddresses(

--- a/src/OrbitClientData/include/OrbitClientData/Callstack.h
+++ b/src/OrbitClientData/include/OrbitClientData/Callstack.h
@@ -5,8 +5,6 @@
 #ifndef ORBIT_CORE_CALLSTACK_H_
 #define ORBIT_CORE_CALLSTACK_H_
 
-#include <xxhash.h>
-
 #include <vector>
 
 #include "CallstackTypes.h"
@@ -14,18 +12,16 @@
 class CallStack {
  public:
   CallStack() = default;
-  explicit CallStack(std::vector<uint64_t>&& addresses) {
-    frames_ = std::move(addresses);
-    hash_ = XXH64(frames_.data(), frames_.size() * sizeof(uint64_t), 0xca1157ac);
-  };
+  explicit CallStack(CallstackID id, std::vector<uint64_t>&& addresses)
+      : id_{id}, frames_{std::move(addresses)} {};
 
-  CallstackID GetHash() const { return hash_; }
-  uint64_t GetFrame(size_t index) const { return frames_.at(index); }
-  const std::vector<uint64_t>& GetFrames() const { return frames_; };
-  size_t GetFramesCount() const { return frames_.size(); }
+  [[nodiscard]] CallstackID id() const { return id_; }
+  [[nodiscard]] uint64_t GetFrame(size_t index) const { return frames_.at(index); }
+  [[nodiscard]] const std::vector<uint64_t>& frames() const { return frames_; };
+  [[nodiscard]] size_t GetFramesCount() const { return frames_.size(); }
 
  private:
-  CallstackID hash_ = 0;
+  CallstackID id_ = 0;
   std::vector<uint64_t> frames_;
 };
 #endif  // ORBIT_CORE_CALLSTACK_H_

--- a/src/OrbitClientData/include/OrbitClientData/PostProcessedSamplingData.h
+++ b/src/OrbitClientData/include/OrbitClientData/PostProcessedSamplingData.h
@@ -63,7 +63,7 @@ class PostProcessedSamplingData {
   PostProcessedSamplingData() = default;
   PostProcessedSamplingData(
       absl::flat_hash_map<ThreadID, ThreadSampleData> thread_id_to_sample_data,
-      absl::flat_hash_map<CallstackID, std::shared_ptr<CallStack>> unique_resolved_callstacks,
+      absl::flat_hash_map<CallstackID, CallStack> unique_resolved_callstacks,
       absl::flat_hash_map<CallstackID, CallstackID> original_to_resolved_callstack,
       absl::flat_hash_map<uint64_t, std::set<CallstackID>> function_address_to_callstack,
       absl::flat_hash_map<uint64_t, absl::flat_hash_set<uint64_t>>
@@ -106,7 +106,7 @@ class PostProcessedSamplingData {
 
  private:
   absl::flat_hash_map<ThreadID, ThreadSampleData> thread_id_to_sample_data_;
-  absl::flat_hash_map<CallstackID, std::shared_ptr<CallStack>> unique_resolved_callstacks_;
+  absl::flat_hash_map<CallstackID, CallStack> unique_resolved_callstacks_;
   absl::flat_hash_map<CallstackID, CallstackID> original_to_resolved_callstack_;
   absl::flat_hash_map<uint64_t, std::set<CallstackID>> function_address_to_callstack_;
   absl::flat_hash_map<uint64_t, absl::flat_hash_set<uint64_t>> function_address_to_exact_addresses_;

--- a/src/OrbitClientModel/CaptureDeserializer.cpp
+++ b/src/OrbitClientModel/CaptureDeserializer.cpp
@@ -210,8 +210,10 @@ void LoadCaptureInfo(const CaptureInfo& capture_info, CaptureListener* capture_l
     capture_listener->OnThreadStateSlice(thread_state_slice);
   }
 
-  for (const CallstackInfo& callstack : capture_info.callstacks()) {
-    CallStack unique_callstack({callstack.data().begin(), callstack.data().end()});
+  for (const auto& callstack_it : capture_info.callstacks()) {
+    const CallstackInfo& callstack = callstack_it.second;
+    CallStack unique_callstack(callstack_it.first,
+                               {callstack.data().begin(), callstack.data().end()});
     if (*cancellation_requested) {
       capture_listener->OnCaptureCancelled();
       return;

--- a/src/OrbitClientModel/CaptureDeserializerTest.cpp
+++ b/src/OrbitClientModel/CaptureDeserializerTest.cpp
@@ -422,31 +422,31 @@ TEST(CaptureDeserializer, LoadCaptureInfoCallstacks) {
   callstack_data_1.push_back(1);
   callstack_data_1.push_back(2);
   callstack_data_1.push_back(3);
-  CallStack callstack_1(std::move(callstack_data_1));
-  CallstackInfo* callstack_info_1 = capture_info.add_callstacks();
-  *callstack_info_1->mutable_data() = {callstack_1.GetFrames().begin(),
-                                       callstack_1.GetFrames().end()};
+  CallStack callstack_1(1, std::move(callstack_data_1));
+  CallstackInfo callstack_info_1;
+  *callstack_info_1.mutable_data() = {callstack_1.frames().begin(), callstack_1.frames().end()};
+  (*capture_info.mutable_callstacks())[1] = callstack_info_1;
   CallstackEvent* callstack_event_1_1 = capture_info.add_callstack_events();
   callstack_event_1_1->set_thread_id(1);
   callstack_event_1_1->set_time(1);
-  callstack_event_1_1->set_callstack_hash(callstack_1.GetHash());
+  callstack_event_1_1->set_callstack_id(callstack_1.id());
   CallstackEvent* callstack_event_1_2 = capture_info.add_callstack_events();
   callstack_event_1_2->set_thread_id(1);
   callstack_event_1_2->set_time(2);
-  callstack_event_1_2->set_callstack_hash(callstack_1.GetHash());
+  callstack_event_1_2->set_callstack_id(callstack_1.id());
 
   // Add one additional callstack with a different hash:
   std::vector<uint64_t> callstack_data_2;
   callstack_data_2.push_back(4);
   callstack_data_2.push_back(5);
-  CallStack callstack_2(std::move(callstack_data_2));
-  CallstackInfo* callstack_info_2 = capture_info.add_callstacks();
-  *callstack_info_2->mutable_data() = {callstack_2.GetFrames().begin(),
-                                       callstack_2.GetFrames().end()};
+  CallStack callstack_2(2, std::move(callstack_data_2));
+  CallstackInfo callstack_info_2;
+  *callstack_info_2.mutable_data() = {callstack_2.frames().begin(), callstack_2.frames().end()};
+  (*capture_info.mutable_callstacks())[2] = callstack_info_2;
   CallstackEvent* callstack_event_2 = capture_info.add_callstack_events();
   callstack_event_2->set_thread_id(2);
   callstack_event_2->set_time(3);
-  callstack_event_2->set_callstack_hash(callstack_2.GetHash());
+  callstack_event_2->set_callstack_id(callstack_2.id());
 
   std::atomic<bool> cancellation_requested = false;
   uint8_t empty_data = 0;

--- a/src/OrbitClientModel/CaptureSerializer.cpp
+++ b/src/OrbitClientModel/CaptureSerializer.cpp
@@ -142,8 +142,9 @@ CaptureInfo GenerateCaptureInfo(
   // Revisit sampling profiler data thread-safety.
   capture_data.GetCallstackData()->ForEachUniqueCallstack(
       [&capture_info](const CallStack& call_stack) {
-        CallstackInfo* callstack = capture_info.add_callstacks();
-        *callstack->mutable_data() = {call_stack.GetFrames().begin(), call_stack.GetFrames().end()};
+        CallstackInfo callstack;
+        *callstack.mutable_data() = {call_stack.frames().begin(), call_stack.frames().end()};
+        (*capture_info.mutable_callstacks())[call_stack.id()] = callstack;
       });
 
   capture_info.mutable_callstack_events()->Reserve(

--- a/src/OrbitGl/CallTreeView.cpp
+++ b/src/OrbitGl/CallTreeView.cpp
@@ -91,8 +91,8 @@ static void AddCallstackToTopDownThread(CallTreeThread* thread_node,
                                         uint64_t callstack_sample_count,
                                         const CaptureData& capture_data) {
   CallTreeNode* current_thread_or_function = thread_node;
-  for (auto frame_it = resolved_callstack.GetFrames().crbegin();
-       frame_it != resolved_callstack.GetFrames().crend(); ++frame_it) {
+  for (auto frame_it = resolved_callstack.frames().crbegin();
+       frame_it != resolved_callstack.frames().crend(); ++frame_it) {
     uint64_t frame = *frame_it;
     const std::string& function_name = capture_data.GetFunctionNameByAddress(frame);
     const std::string& module_path = capture_data.GetModulePathByAddress(frame);
@@ -152,7 +152,7 @@ std::unique_ptr<CallTreeView> CallTreeView::CreateTopDownViewFromSamplingProfile
     CallTreeView* bottom_up_view, const CallStack& resolved_callstack,
     uint64_t callstack_sample_count, const CaptureData& capture_data) {
   CallTreeNode* current_node = bottom_up_view;
-  for (uint64_t frame : resolved_callstack.GetFrames()) {
+  for (uint64_t frame : resolved_callstack.frames()) {
     const std::string& function_name = capture_data.GetFunctionNameByAddress(frame);
     const std::string& module_path = capture_data.GetModulePathByAddress(frame);
     CallTreeFunction* function_node =

--- a/src/OrbitGl/EventTrack.cpp
+++ b/src/OrbitGl/EventTrack.cpp
@@ -248,8 +248,8 @@ std::string EventTrack::GetSampleTooltip(PickingId id) const {
   const CallstackData* callstack_data = capture_data_->GetCallstackData();
   const auto* callstack_event = static_cast<const CallstackEvent*>(user_data->custom_data_);
 
-  uint64_t callstack_hash = callstack_event->callstack_hash();
-  const CallStack* callstack = callstack_data->GetCallStack(callstack_hash);
+  uint64_t callstack_id = callstack_event->callstack_id();
+  const CallStack* callstack = callstack_data->GetCallStack(callstack_id);
   if (callstack == nullptr) {
     return unknown_return_text;
   }


### PR DESCRIPTION
Changed the code to stop using hashes as unique identifiers.
Now callstack lookup is using absl::flat_hash_map<std::vector<uint64_t>,
id>. Ids are assigned sequentially. Changed client code to use ids
provided by the service.

Test: Run integration tests, run capture with instrumentation, save and
     load capture.