### PR TITLE
Stricter check for OpenGL version support

### DIFF
--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -134,6 +134,9 @@ void GlCanvas::Initialize() {
       FATAL("Problem: glewInit failed, something is seriously wrong: %s",
             absl::bit_cast<const char*>(glewGetErrorString(err)));
     }
+    if (!glewIsSupported("GL_VERSION_2_0")) {
+      FATAL("Problem: OpenGL version supported by GLEW must be at least 2.0!");
+    }
     LOG("Using GLEW %s", absl::bit_cast<const char*>(glewGetString(GLEW_VERSION)));
     first_init = false;
   }

--- a/src/OrbitQt/opengldetect.cpp
+++ b/src/OrbitQt/opengldetect.cpp
@@ -4,14 +4,64 @@
 
 #include "opengldetect.h"
 
+// This needs to be first because if it is not GL/glew.h
+// complains about being included after gl.h
+// clang-format off
+#include "OpenGl.h" // IWYU pragma: keep
+// clang-format on
+
+#include <absl/strings/numbers.h>
+#include <absl/strings/str_split.h>
+
 #include <QOffscreenSurface>
 #include <QOpenGLContext>
 #include <QSurfaceFormat>
 
 namespace orbit_qt {
+namespace {
 
-// Detects the supported version of Desktop OpenGL by requesting the most
-// recent version of OpenGL and checking what the system could provide.
+// Must have created an OpenGl context before calling this.
+std::optional<OpenGlVersion> GetOpenGlVersionViaDirectCall() {
+  std::string gl_version = reinterpret_cast<const char*>(glGetString(GL_VERSION));
+  std::vector<std::string> version_tokenized = absl::StrSplit(gl_version, '.');
+
+  if (version_tokenized.size() < 2) {
+    return std::nullopt;
+  }
+
+  int major_version;
+  if (!absl::SimpleAtoi(version_tokenized[0], &major_version)) {
+    return std::nullopt;
+  }
+  int minor_version;
+  if (!absl::SimpleAtoi(version_tokenized[1], &minor_version)) {
+    return std::nullopt;
+  }
+  return OpenGlVersion{major_version, minor_version};
+}
+
+std::optional<OpenGlVersion> ComputeMinimumVersion(std::optional<OpenGlVersion> version_a,
+                                                   std::optional<OpenGlVersion> version_b) {
+  if (!version_a || !version_b) {
+    return std::nullopt;
+  }
+  if (version_a.value().major < version_b.value().major) {
+    return version_a;
+  }
+  if (version_b.value().major < version_a.value().major) {
+    return version_b;
+  }
+  if (version_a.value().minor < version_b.value().minor) {
+    return version_a;
+  }
+  return version_b;
+}
+}  // namespace
+
+// Detects the supported version of Desktop OpenGL by (1) requesting the most
+// recent version of OpenGL and checking what the system could provide and (2)
+// calling glGetString(GL_VERSION). The versions obtained via (1) and (2) are
+// compared and the smaller of the two is returned.
 // OpenGL ES is automatically ignored.
 std::optional<OpenGlVersion> DetectOpenGlVersion() {
   QSurfaceFormat format{};
@@ -37,7 +87,12 @@ std::optional<OpenGlVersion> DetectOpenGlVersion() {
     return std::nullopt;
   }
 
-  return OpenGlVersion{gl_context.format().majorVersion(), gl_context.format().minorVersion()};
-}
+  std::optional<OpenGlVersion> gl_version_direct = GetOpenGlVersionViaDirectCall();
+  if (!gl_version_direct) {
+    return std::nullopt;
+  }
+  OpenGlVersion qt_gl_version{surface.format().majorVersion(), surface.format().minorVersion()};
 
+  return ComputeMinimumVersion(gl_version_direct, qt_gl_version);
+}
 }  // namespace orbit_qt

--- a/src/OrbitQt/orbitglwidget.cpp
+++ b/src/OrbitQt/orbitglwidget.cpp
@@ -34,6 +34,9 @@
 #define ORBIT_DEBUG_OPEN_GL 0
 
 OrbitGLWidget::OrbitGLWidget(QWidget* parent) : QOpenGLWidget(parent) {
+  QSurfaceFormat requested_format = QSurfaceFormat::defaultFormat();
+  LOG("OpenGL version requested: %i.%i", requested_format.majorVersion(),
+      requested_format.minorVersion());
   gl_canvas_ = nullptr;
   debug_logger_ = nullptr;
   setFocusPolicy(Qt::WheelFocus);


### PR DESCRIPTION
We use Qt's OpenGL support and OpenGL via GLEW. We have seen at least
one instance where there was a mismatch between these two and the
version detected by GLEW was < 2.0, which is the minimum version
required by Orbit. We therefore add a stricter check to also directly
check the version obtained by glGetString(GL_VERSION).

Tested: Manually ran Orbit locally.
Bug: http://b/178349019