### PR TITLE
Remove GCurrentTimeGraph global.

### DIFF
--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -145,6 +145,14 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void OnValidateFramePointers(std::vector<const ModuleData*> modules_to_validate);
 
   void SetCaptureWindow(CaptureWindow* capture);
+  [[nodiscard]] const TimeGraph* GetTimeGraph() const {
+    CHECK(capture_window_ != nullptr);
+    return capture_window_->GetTimeGraph();
+  }
+  [[nodiscard]] TimeGraph* GetMutableTimeGraph() {
+    CHECK(capture_window_ != nullptr);
+    return capture_window_->GetTimeGraph();
+  }
   void SetDebugCanvas(GlCanvas* debug_canvas);
   void SetIntrospectionWindow(IntrospectionWindow* canvas);
   void StopIntrospection();

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -170,7 +170,9 @@ register_test(OrbitGlTests)
 
 add_fuzzer(CaptureDeserializerLoadFuzzer CaptureDeserializerLoadFuzzer.cpp)
 target_link_libraries(CaptureDeserializerLoadFuzzer
-                      PRIVATE OrbitGl CONAN_PKG::libprotobuf-mutator)
+                      PRIVATE OrbitGl
+                              CONAN_PKG::libprotobuf-mutator
+                              GTest::Main)
 
 add_fuzzer(ModuleListFuzzer
            ModuleListFuzzer.cpp)

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -91,10 +91,6 @@ CaptureWindow::CaptureWindow(OrbitApp* app) : GlCanvas(), time_graph_(app), app_
   slider_->SetOrthogonalSliderPixelHeight(vertical_slider_->GetPixelHeight());
 }
 
-CaptureWindow::~CaptureWindow() {
-  if (GCurrentTimeGraph == &time_graph_) GCurrentTimeGraph = nullptr;
-}
-
 void CaptureWindow::OnTimer() { GlCanvas::OnTimer(); }
 
 void CaptureWindow::ZoomAll() {

--- a/src/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/CaptureWindow.h
@@ -24,7 +24,6 @@ class OrbitApp;
 class CaptureWindow : public GlCanvas {
  public:
   explicit CaptureWindow(OrbitApp* app);
-  ~CaptureWindow() override;
 
   void Initialize() override;
   void ZoomAll();

--- a/src/OrbitGl/LiveFunctionsController.cpp
+++ b/src/OrbitGl/LiveFunctionsController.cpp
@@ -44,9 +44,8 @@ const TextBox* ClosestTo(uint64_t point, const TextBox* box_a, const TextBox* bo
   uint64_t b_diff = AbsDiff(point, box_b->GetTimerInfo().start());
   if (a_diff <= b_diff) {
     return box_a;
-  } else {
-    return box_b;
   }
+  return box_b;
 }
 
 const TextBox* SnapToClosestStart(const TimeGraph* time_graph, uint64_t function_id) {

--- a/src/OrbitGl/LiveFunctionsDataView.cpp
+++ b/src/OrbitGl/LiveFunctionsDataView.cpp
@@ -283,32 +283,32 @@ void LiveFunctionsDataView::OnContextMenu(const std::string& action, int menu_in
   } else if (action == kMenuActionJumpToFirst) {
     CHECK(item_indices.size() == 1);
     auto function_id = GetInstrumentedFunctionId(item_indices[0]);
-    auto first_box = GCurrentTimeGraph->FindNextFunctionCall(
+    auto first_box = app_->GetTimeGraph()->FindNextFunctionCall(
         function_id, std::numeric_limits<uint64_t>::lowest());
     if (first_box != nullptr) {
-      GCurrentTimeGraph->SelectAndZoom(first_box);
+      app_->GetMutableTimeGraph()->SelectAndZoom(first_box);
     }
   } else if (action == kMenuActionJumpToLast) {
     CHECK(item_indices.size() == 1);
     auto function_id = GetInstrumentedFunctionId(item_indices[0]);
-    auto last_box = GCurrentTimeGraph->FindPreviousFunctionCall(
+    auto last_box = app_->GetTimeGraph()->FindPreviousFunctionCall(
         function_id, std::numeric_limits<uint64_t>::max());
     if (last_box != nullptr) {
-      GCurrentTimeGraph->SelectAndZoom(last_box);
+      app_->GetMutableTimeGraph()->SelectAndZoom(last_box);
     }
   } else if (action == kMenuActionJumpToMin) {
     CHECK(item_indices.size() == 1);
     uint64_t function_id = GetInstrumentedFunctionId(item_indices[0]);
     auto [min_box, _] = GetMinMax(function_id);
     if (min_box != nullptr) {
-      GCurrentTimeGraph->SelectAndZoom(min_box);
+      app_->GetMutableTimeGraph()->SelectAndZoom(min_box);
     }
   } else if (action == kMenuActionJumpToMax) {
     CHECK(item_indices.size() == 1);
     uint64_t function_id = GetInstrumentedFunctionId(item_indices[0]);
     auto [_, max_box] = GetMinMax(function_id);
     if (max_box != nullptr) {
-      GCurrentTimeGraph->SelectAndZoom(max_box);
+      app_->GetMutableTimeGraph()->SelectAndZoom(max_box);
     }
   } else if (action == kMenuActionIterate) {
     for (int i : item_indices) {
@@ -420,7 +420,7 @@ std::pair<TextBox*, TextBox*> LiveFunctionsDataView::GetMinMax(uint64_t function
   TextBox* min_box = nullptr;
   TextBox* max_box = nullptr;
   std::vector<std::shared_ptr<TimerChain>> chains =
-      GCurrentTimeGraph->GetAllThreadTrackTimerChains();
+      app_->GetTimeGraph()->GetAllThreadTrackTimerChains();
   for (auto& chain : chains) {
     if (!chain) continue;
     for (auto& block : *chain) {

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -39,8 +39,6 @@ using orbit_client_protos::CallstackEvent;
 using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::TimerInfo;
 
-TimeGraph* GCurrentTimeGraph = nullptr;
-
 TimeGraph::TimeGraph(OrbitApp* app)
     : accessibility_(this), batcher_(BatcherId::kTimeGraph), app_{app} {
   track_manager_ = std::make_unique<TrackManager>(this, app);
@@ -67,6 +65,9 @@ void TimeGraph::SetCanvas(GlCanvas* canvas) {
 
 void TimeGraph::Clear() {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
+
+  capture_data_ = nullptr;
+  track_manager_->SetCaptureData(nullptr);
 
   batcher_.StartNewFrame();
   capture_min_timestamp_ = std::numeric_limits<uint64_t>::max();
@@ -112,7 +113,7 @@ void TimeGraph::Zoom(uint64_t min, uint64_t max) {
 
 void TimeGraph::Zoom(const TimerInfo& timer_info) { Zoom(timer_info.start(), timer_info.end()); }
 
-double TimeGraph::GetCaptureTimeSpanUs() {
+double TimeGraph::GetCaptureTimeSpanUs() const {
   return TicksToMicroseconds(capture_min_timestamp_, capture_max_timestamp_);
 }
 

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -101,7 +101,7 @@ class TimeGraph {
       uint64_t function_address, uint64_t current_time,
       std::optional<int32_t> thread_id = std::nullopt) const;
   void SelectAndZoom(const TextBox* text_box);
-  [[nodiscard]] double GetCaptureTimeSpanUs();
+  [[nodiscard]] double GetCaptureTimeSpanUs() const;
   [[nodiscard]] double GetCurrentTimeSpanUs() const;
   void NeedsRedraw() { needs_redraw_ = true; }
   [[nodiscard]] bool IsRedrawNeeded() const { return needs_redraw_; }
@@ -240,7 +240,5 @@ class TimeGraph {
 
   OrbitApp* app_ = nullptr;
 };
-
-extern TimeGraph* GCurrentTimeGraph;
 
 #endif  // ORBIT_GL_TIME_GRAPH_H_


### PR DESCRIPTION
Effectively the global GCurrentTimeGraph is always
app_::capture_window_::time_graph_ (with the fuzzer being the only
exception). This change removes the global and use the value directly
instead.
It also fixes crashes in the fuzzer, which also works with this change
due to the check if capture_window_ exists.

Follow-up: There is an existing bug, that shows the timerange in
the capture window after clearing a capture. We on clearing a capture,
we should not "clear" the time graph, but actually remove it.

Test: Take, clear, load captures.
Bug: http://b/177651082