### PR TITLE
Replace symbol loading CHECK with Error message

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1157,7 +1157,15 @@ void OrbitApp::LoadSymbols(const std::filesystem::path& symbols_path, ModuleData
                           frame_track_function_hashes =
                               std::move(frame_track_function_hashes)]() mutable {
     auto symbols_result = SymbolHelper::LoadSymbolsFromFile(symbols_path);
-    CHECK(symbols_result);
+    if (!symbols_result) {
+      std::string error_message{absl::StrFormat("Unable to load symbols for %s from file %s: %s",
+                                                module_data->file_path(), symbols_path.string(),
+                                                symbols_result.error().message())};
+      ERROR("%s", error_message);
+      SendErrorToUi("Unexpected error while loading symbols", error_message);
+      return;
+    }
+
     module_data->AddSymbols(symbols_result.value());
 
     std::string message =


### PR DESCRIPTION
b/178176772
The solution this change represents is in general not a good idea. But I don't have any clue why the Check fails in the first place and cannot reproduce it. Additionally this code will change with the upcoming #1752. Since #1752 wont make it into 1.59, I made this quick-n-dirty fix. If there are any better ideas, I would like to hear about it.