### PR TITLE
Fix crash in ScopedStatus' destructor

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1671,7 +1671,7 @@ bool OrbitApp::IsCapturing() const {
 ScopedStatus OrbitApp::CreateScopedStatus(const std::string& initial_message) {
   CHECK(std::this_thread::get_id() == main_thread_id_);
   CHECK(status_listener_ != nullptr);
-  return ScopedStatus{GetMainThreadExecutor(), status_listener_, initial_message};
+  return ScopedStatus{GetMainThreadExecutor()->weak_from_this(), status_listener_, initial_message};
 }
 
 void OrbitApp::SelectTracepoint(const TracepointInfo& tracepoint) {

--- a/src/OrbitGl/MainThreadExecutor.h
+++ b/src/OrbitGl/MainThreadExecutor.h
@@ -128,4 +128,13 @@ class MainThreadExecutor : public std::enable_shared_from_this<MainThreadExecuto
   virtual void AbortWaitingJobs() = 0;
 };
 
+template <typename F>
+auto TrySchedule(const std::weak_ptr<MainThreadExecutor>& executor, F&& function_object)
+    -> std::optional<decltype(std::declval<MainThreadExecutor>().Schedule(function_object))> {
+  auto executor_ptr = executor.lock();
+  if (executor_ptr == nullptr) return std::nullopt;
+
+  return std::make_optional(executor_ptr->Schedule(std::forward<F>(function_object)));
+}
+
 #endif  // ORBIT_GL_MAIN_THREAD_EXECUTOR_H_

--- a/src/OrbitQt/MainThreadExecutorImplTest.cpp
+++ b/src/OrbitQt/MainThreadExecutorImplTest.cpp
@@ -141,4 +141,19 @@ TEST(MainThreadExecutorImpl, ChainFuturesWithThen) {
   EXPECT_EQ(future2.Get(), 42 + 42);
 }
 
+TEST(MainThreadExecutorImpl, TrySchedule) {
+  QCoreApplication app{argc, nullptr};
+
+  auto executor = MainThreadExecutorImpl::Create();
+  const auto result = TrySchedule(executor, []() { QCoreApplication::exit(42); });
+
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(app.exec(), 42);
+}
+
+TEST(MainThreadExecutorImpl, TryScheduleWithInvalidWeakPtr) {
+  const auto result = TrySchedule(std::weak_ptr<MainThreadExecutor>{}, []() {});
+  EXPECT_FALSE(result.has_value());
+}
+
 }  // namespace orbit_qt


### PR DESCRIPTION
ScopedStatus used to hold a raw pointer to MainThreadExecutor, which
means it's the creators responsibility to ensure that the
MainThreadExecutor instance stays alive as long as the ScopedStatus
instance is alive.

This doesn't work well with the use-case of ScopedStatus. It is meant to
be used in background threads, which means the creator cannot ensure
that the MainThreadExecutor instance still exists, when the ScopedStatus
object is destructed - at least not without bigger changes to the
codebase.

This commit fixes the problem by making ScopedStatus keep a weak_ptr of
MainThreadExecutor. Whenever it is meant to schedule an action it will
first check whether a lock can still be acquired. If not the action will
be ignored.

Note, it's still the users responsiblity to keep the MainThreadExecutor
alive to make ScopeStatus work properly.