### PR TITLE
Limit lifetime of MainThreadExecutor actions

### DIFF
--- a/src/OrbitGl/MainThreadExecutor.h
+++ b/src/OrbitGl/MainThreadExecutor.h
@@ -42,6 +42,13 @@ class MainThreadExecutor : public std::enable_shared_from_this<MainThreadExecuto
   // Schedules the action to be performed on the main thread.
   virtual void Schedule(std::unique_ptr<Action> action) = 0;
 
+  // Schedule schedules the function object `functor` to be executed
+  // on `*this`. The execution occures asynchronously, meaning this
+  // function call will only push the function object to a queue. It
+  // will be picked up by an event loop cycle.
+  //
+  // Note: The function object is only executed if `*this` is still alive when the event loop picks
+  // up the scheduled task.
   template <typename F>
   auto Schedule(F&& functor) -> orbit_base::Future<std::decay_t<decltype(functor())>> {
     using ReturnType = std::decay_t<decltype(functor())>;

--- a/src/OrbitQt/MainThreadExecutorImpl.cpp
+++ b/src/OrbitQt/MainThreadExecutorImpl.cpp
@@ -19,7 +19,7 @@ namespace orbit_qt {
 
 void MainThreadExecutorImpl::Schedule(std::unique_ptr<Action> action) {
   QMetaObject::invokeMethod(
-      QCoreApplication::instance(),
+      this,
       [action = std::move(action)]() {
         ORBIT_SCOPE("MainThreadExecutor Action");
         action->Execute();

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -685,6 +685,11 @@ OrbitMainWindow::~OrbitMainWindow() {
   ui->ModulesList->Deinitialize();
 
   delete ui;
+
+  // This explicitly destructs the main_thread_executor_ before all other members.
+  // That ensures that all scheduled main thread tasks will be destructed before
+  // we destruct all the resources these tasks might rely on.
+  main_thread_executor_.reset();
 }
 
 void OrbitMainWindow::OnRefreshDataViewPanels(DataViewType a_Type) {


### PR DESCRIPTION
The lifetime of a main thread executor action used to be bound to the lifetime of Qt's QApplication object.
And that's literally the last object that gets destructed in the life of a Orbit process.

But almost all actions require access to resources living in OrbitMainWindow or OrbitApp. These actions
will operate on dangling pointers if executed after OrbitMainWindow has been destructed, leading to a
variety of crashes.

The best solution is to bind the lifetime of an action to the executor itself. Thus it's up to the user of
MainThreadExecutor to maintain its lifetime and the lifetime of its actions.

This fixes a bunch of different crashes which appear when background tasks are still running while
Orbit is shutting down.