### PR TITLE
Fix parsing of OpenGL version numbers

### DIFF
--- a/src/OrbitQt/opengldetect.cpp
+++ b/src/OrbitQt/opengldetect.cpp
@@ -20,21 +20,19 @@
 namespace orbit_qt {
 namespace {
 
-// Must have created an OpenGl context before calling this.
+// Must have created an OpenGl context before calling this. Assumes that both
+// major and minor versions of the string are single digits.
 std::optional<OpenGlVersion> GetOpenGlVersionViaDirectCall() {
   std::string gl_version = reinterpret_cast<const char*>(glGetString(GL_VERSION));
-  std::vector<std::string> version_tokenized = absl::StrSplit(gl_version, '.');
-
-  if (version_tokenized.size() < 2) {
+  if (gl_version.size() < 3) {
     return std::nullopt;
   }
-
   int major_version;
-  if (!absl::SimpleAtoi(version_tokenized[0], &major_version)) {
+  if (!absl::SimpleAtoi(gl_version.substr(0, 1), &major_version)) {
     return std::nullopt;
   }
   int minor_version;
-  if (!absl::SimpleAtoi(version_tokenized[1], &minor_version)) {
+  if (!absl::SimpleAtoi(gl_version.substr(2, 1), &minor_version)) {
     return std::nullopt;
   }
   return OpenGlVersion{major_version, minor_version};


### PR DESCRIPTION
I incorrectly assumed that tokenizing the OpenGL version string can
be done with just splitting on ".", but this does not yield correct
results in cases like "3.1 Mesa 20.1.8". Since all major and minor
version numbers are single digits for all OpenGL versions released so
far, we just check the 0th and 2nd digit of the string and consider
them as our major and minor versions. This is wrong for version numbers
with more than one digit, but in our check will only cause issues for
OpenGL 10.x and higher (if we ever see that).

Tested: Ran Orbit manually.
Bug: http://b/179247771