### PR TITLE
Connection dialog overlay

### DIFF
--- a/contrib/automation_tests/core/orbit_e2e.py
+++ b/contrib/automation_tests/core/orbit_e2e.py
@@ -150,7 +150,7 @@ class E2ETestSuite:
         self.top_window(True).set_focus()
 
 
-def wait_for_condition(any_callable: Callable, max_seconds: int = 5, interval: int = 1):
+def wait_for_condition(any_callable: Callable, max_seconds: int = 5, interval: int = 1, raise_exceptions: bool = False):
     """
     Wait until a condition is satisfied.
 
@@ -158,6 +158,8 @@ def wait_for_condition(any_callable: Callable, max_seconds: int = 5, interval: i
         satisfied.
     :param max_seconds: Maximum time to wait for the condition to be satisfied
     :param interval: Sleep time in between calls to callable, in seconds
+    :param raise_exceptions: If true, exceptions are raised and cause the wait to fail. Usually should only be used
+        for debugging.
     """
     start = time.time()
     while time.time() - start < max_seconds:
@@ -165,7 +167,10 @@ def wait_for_condition(any_callable: Callable, max_seconds: int = 5, interval: i
             if any_callable():
                 return
         except:
-            pass
+            if raise_exceptions:
+                raise
+            else:
+                pass
         time.sleep(interval)
     raise OrbitE2EError('Wait time exceeded')
 

--- a/contrib/automation_tests/test_cases/connection_window.py
+++ b/contrib/automation_tests/test_cases/connection_window.py
@@ -40,11 +40,12 @@ class ConnectToStadiaInstance(E2ETestCase):
         logging.info('Connecting to Instance, waiting for the process list...')
 
         # In the new UI, use small waits until the process list is active, and then some more for the
-        # semi-transparent "loading" Overlay of the tables to disappear...
+        # semi-transparent "loading" Overlay of the tables to disappear
         wait_for_condition(lambda: self.find_control('Custom', 'ProcessesFrame').is_enabled() is True, 15)
         wait_for_condition(lambda: self.find_control('Table', 'ProcessList').is_active(), 10)
-        # TODO(b/177037834): Get rid of this sleep and correctly wait for the overlay to be hidden
-        time.sleep(2)
+        # This is a bit annoying, but since the overlay is invisible when loading is done, we need to check for
+        # absence of the overlay... not sure if there is a better way
+        wait_for_condition(lambda: self.find_control('Group', 'ProcessListOverlay', raise_on_failure=False) is None)
         logging.info('Process list ready')
 
 

--- a/src/OrbitQt/ConnectToStadiaWidget.cpp
+++ b/src/OrbitQt/ConnectToStadiaWidget.cpp
@@ -57,6 +57,7 @@ ConnectToStadiaWidget::ConnectToStadiaWidget(QWidget* parent)
       s_deploying_(&state_machine_),
       s_connected_(&state_machine_) {
   ui_->setupUi(this);
+  ui_->instancesTableOverlay->raise();
 
   DetachRadioButton();
 

--- a/src/OrbitQt/ConnectToStadiaWidget.ui
+++ b/src/OrbitQt/ConnectToStadiaWidget.ui
@@ -41,7 +41,7 @@
       <number>1</number>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
+      <item row="1" column="0">
        <widget class="QFrame" name="contentFrame">
         <property name="lineWidth">
          <number>0</number>
@@ -137,7 +137,7 @@
               <string>RefreshInstanceList</string>
              </property>
              <property name="icon">
-              <iconset resource="../icons/orbiticons.qrc">
+              <iconset resource="../../icons/orbiticons.qrc">
                <normaloff>:/actions/refresh</normaloff>:/actions/refresh</iconset>
              </property>
              <property name="autoDefault">
@@ -164,35 +164,65 @@
            </item>
            <item>
             <layout class="QVBoxLayout" name="verticalLayout">
+             <property name="spacing">
+              <number>7</number>
+             </property>
              <item>
-              <widget class="QTableView" name="instancesTableView">
-               <property name="enabled">
-                <bool>true</bool>
+              <widget class="QFrame" name="frame">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
                </property>
-               <property name="focusPolicy">
-                <enum>Qt::NoFocus</enum>
-               </property>
-               <property name="accessibleName">
-                <string>InstanceList</string>
-               </property>
-               <property name="alternatingRowColors">
-                <bool>true</bool>
-               </property>
-               <property name="selectionMode">
-                <enum>QAbstractItemView::SingleSelection</enum>
-               </property>
-               <property name="selectionBehavior">
-                <enum>QAbstractItemView::SelectRows</enum>
-               </property>
-               <property name="showGrid">
-                <bool>false</bool>
-               </property>
-               <property name="wordWrap">
-                <bool>false</bool>
-               </property>
-               <attribute name="horizontalHeaderStretchLastSection">
-                <bool>true</bool>
-               </attribute>
+               <layout class="QVBoxLayout" name="verticalLayout_3">
+                <property name="spacing">
+                 <number>0</number>
+                </property>
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QTableView" name="instancesTableView">
+                  <property name="enabled">
+                   <bool>true</bool>
+                  </property>
+                  <property name="focusPolicy">
+                   <enum>Qt::NoFocus</enum>
+                  </property>
+                  <property name="accessibleName">
+                   <string>InstanceList</string>
+                  </property>
+                  <property name="alternatingRowColors">
+                   <bool>true</bool>
+                  </property>
+                  <property name="selectionMode">
+                   <enum>QAbstractItemView::SingleSelection</enum>
+                  </property>
+                  <property name="selectionBehavior">
+                   <enum>QAbstractItemView::SelectRows</enum>
+                  </property>
+                  <property name="showGrid">
+                   <bool>false</bool>
+                  </property>
+                  <property name="wordWrap">
+                   <bool>false</bool>
+                  </property>
+                  <attribute name="horizontalHeaderStretchLastSection">
+                   <bool>true</bool>
+                  </attribute>
+                 </widget>
+                </item>
+               </layout>
                <widget class="orbit_qt::OverlayWidget" name="instancesTableOverlay" native="true">
                 <property name="geometry">
                  <rect>
@@ -206,13 +236,16 @@
                  <bool>false</bool>
                 </property>
                 <property name="accessibleName">
-                 <string>Overlay</string>
+                 <string>InstanceListOverlay</string>
                 </property>
                </widget>
               </widget>
              </item>
              <item>
               <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0">
+               <property name="spacing">
+                <number>7</number>
+               </property>
                <item>
                 <widget class="QCheckBox" name="rememberCheckBox">
                  <property name="enabled">
@@ -261,10 +294,11 @@
    <class>orbit_qt::OverlayWidget</class>
    <extends>QWidget</extends>
    <header>OverlayWidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources>
-  <include location="../icons/orbiticons.qrc"/>
+  <include location="../../icons/orbiticons.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/src/OrbitQt/OverlayWidget.cpp
+++ b/src/OrbitQt/OverlayWidget.cpp
@@ -11,9 +11,8 @@
 
 namespace {
 
-// This color is used as a "background" for the overlay. The alpha value of 128 makes it
-// transparent
-const QColor kOverlayShadeColor{100, 100, 100, 128};
+// This color is used as a "background" for the overlay. The alpha value makes it transparent
+const QColor kOverlayShadeColor{100, 100, 100, 200};
 
 }  // namespace
 

--- a/src/OrbitQt/OverlayWidget.ui
+++ b/src/OrbitQt/OverlayWidget.ui
@@ -143,7 +143,7 @@
   </layout>
  </widget>
  <resources>
-  <include location="../icons/orbiticons.qrc"/>
+  <include location="../../icons/orbiticons.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/src/OrbitQt/ProfilingTargetDialog.cpp
+++ b/src/OrbitQt/ProfilingTargetDialog.cpp
@@ -88,6 +88,7 @@ ProfilingTargetDialog::ProfilingTargetDialog(
   CHECK(ssh_connection_artifacts != nullptr);
 
   ui_->setupUi(this);
+  ui_->processesTableOverlay->raise();
 
   state_machine_.setGlobalRestorePolicy(QStateMachine::RestoreProperties);
   SetupStadiaStates();

--- a/src/OrbitQt/ProfilingTargetDialog.ui
+++ b/src/OrbitQt/ProfilingTargetDialog.ui
@@ -270,25 +270,43 @@
              </widget>
             </item>
             <item>
-             <widget class="QTableView" name="processesTableView">
-              <property name="enabled">
-               <bool>true</bool>
-              </property>
-              <property name="accessibleName">
-               <string>ProcessList</string>
-              </property>
-              <property name="alternatingRowColors">
-               <bool>true</bool>
-              </property>
-              <property name="selectionMode">
-               <enum>QAbstractItemView::SingleSelection</enum>
-              </property>
-              <property name="selectionBehavior">
-               <enum>QAbstractItemView::SelectRows</enum>
-              </property>
-              <property name="showGrid">
-               <bool>false</bool>
-              </property>
+             <widget class="QFrame" name="frame2">
+              <layout class="QVBoxLayout" name="verticalLayout_2">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QTableView" name="processesTableView">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="accessibleName">
+                  <string>ProcessList</string>
+                 </property>
+                 <property name="alternatingRowColors">
+                  <bool>true</bool>
+                 </property>
+                 <property name="selectionMode">
+                  <enum>QAbstractItemView::SingleSelection</enum>
+                 </property>
+                 <property name="selectionBehavior">
+                  <enum>QAbstractItemView::SelectRows</enum>
+                 </property>
+                 <property name="showGrid">
+                  <bool>false</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
               <widget class="orbit_qt::OverlayWidget" name="processesTableOverlay" native="true">
                <property name="geometry">
                 <rect>
@@ -298,12 +316,12 @@
                  <height>30</height>
                 </rect>
                </property>
-               <property name="visible">
-                <bool>false</bool>
-               </property>
                <property name="accessibleName">
-                <string>Overlay</string>
+                <string>ProcessListOverlay</string>
                </property>
+			   <property name="visible">
+                 <bool>false</bool>
+                </property>
               </widget>
              </widget>
             </item>
@@ -365,14 +383,15 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>orbit_qt::OverlayWidget</class>
-   <extends>QWidget</extends>
-   <header>OverlayWidget.h</header>
-  </customwidget>
-  <customwidget>
    <class>orbit_qt::ConnectToStadiaWidget</class>
    <extends>QWidget</extends>
    <header>ConnectToStadiaWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>orbit_qt::OverlayWidget</class>
+   <extends>QWidget</extends>
+   <header>OverlayWidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources>


### PR DESCRIPTION
The transparent overlays where not accessible by the E2E tests, so when loading the process list, a "sleep" was added to make sure the overlay disappeared before clicking the table. This PR changes the parenting of the overlays and removes the sleep from the E2E tests.

Bug: b/177037834