### PR TITLE
Fix flaky test of FutureWatcher

### DIFF
--- a/src/QtUtils/FutureWatcherTest.cpp
+++ b/src/QtUtils/FutureWatcherTest.cpp
@@ -117,11 +117,8 @@ TEST(FutureWatcher, WaitForWithThreadPoolAndTimeout) {
   EXPECT_TRUE(future.IsValid());
   EXPECT_FALSE(future.IsFinished());
 
-  // The lambda will be executed by the event loop, running inside of watcher.WaitFor.
-  QTimer::singleShot(std::chrono::milliseconds{20}, [&]() { mutex.Unlock(); });
-
   FutureWatcher watcher{};
-  const auto reason = watcher.WaitFor(std::move(future), std::chrono::milliseconds{5});
+  const auto reason = watcher.WaitFor(future, std::chrono::milliseconds{5});
 
   EXPECT_EQ(reason, FutureWatcher::Reason::kTimeout);
 


### PR DESCRIPTION
The FutureWatcher.WaitForWithThreadPoolAndTimeout test tries to test
whether the WaitFor call properly handles the given timeout.

For this two competing timers have been started and it should be shown
that WaitFor's shorter timer returns first and leads to a timeout
result, since the background job waits for the longer timer.

This fails from time to time. My guess is that the process is not
scheduled while it's waiting for the timers to finish. And it might not
be scheduled for a long time, allowing both timers to time out.

In this case it depends on Qt's implementation of the event loop
which timeout is handled first.

The solution is to remove the second competing timer and never allow the
background job to finish.