### PR TITLE
Fix MetricsUploader

### DIFF
--- a/src/MetricsUploader/MetricsUploaderWindows.cpp
+++ b/src/MetricsUploader/MetricsUploaderWindows.cpp
@@ -16,6 +16,7 @@ namespace orbit_metrics_uploader {
 constexpr const char* kSendLogEventFunctionName = "SendOrbitLogEvent";
 constexpr const char* kSetupConnectionFunctionName = "SetupConnection";
 constexpr const char* kShutdownConnectionFunctionName = "ShutdownConnection";
+constexpr const char* kClientLogFileSuffix = "Orbit";
 
 MetricsUploader::MetricsUploader(std::string client_name, std::string session_uuid,
                                  Result (*send_log_event_addr)(const uint8_t*, int),
@@ -84,7 +85,7 @@ ErrorMessageOr<MetricsUploader> MetricsUploader::CreateMetricsUploader(std::stri
     return ErrorMessage("Metrics uploader client library is not found");
   }
 
-  auto setup_connection_addr = reinterpret_cast<Result (*)()>(
+  auto setup_connection_addr = reinterpret_cast<Result (*)(const char*)>(
       GetProcAddress(metrics_uploader_client_dll, kSetupConnectionFunctionName));
   if (nullptr == setup_connection_addr) {
     FreeLibrary(metrics_uploader_client_dll);
@@ -106,7 +107,7 @@ ErrorMessageOr<MetricsUploader> MetricsUploader::CreateMetricsUploader(std::stri
   }
 
   // set up connection and create a client
-  Result result = setup_connection_addr();
+  Result result = setup_connection_addr(kClientLogFileSuffix);
   if (result != kNoError) {
     if (result != kCannotOpenConnection) {
       Result shutdown_result = shutdown_connection_addr();


### PR DESCRIPTION
SetupConnection has one argument - string that will be used as suffix in
the metrics_uploader_client log file.

Removed FreeLibrary call that leads to crash.