### PR TITLE
Open capture in a new window

### DIFF
--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -33,6 +33,7 @@
 #include <QMouseEvent>
 #include <QPixmap>
 #include <QPointer>
+#include <QProcess>
 #include <QProgressDialog>
 #include <QPushButton>
 #include <QSettings>
@@ -143,11 +144,13 @@ void OpenDisassembly(const std::string& assembly, const DisassemblyReport& repor
 }  // namespace
 
 OrbitMainWindow::OrbitMainWindow(orbit_qt::TargetConfiguration target_configuration,
-                                 orbit_metrics_uploader::MetricsUploader* metrics_uploader)
+                                 orbit_metrics_uploader::MetricsUploader* metrics_uploader,
+                                 const QStringList& command_line_flags)
     : QMainWindow(nullptr),
       main_thread_executor_{orbit_qt::MainThreadExecutorImpl::Create()},
       app_{OrbitApp::Create(main_thread_executor_.get(), metrics_uploader)},
       ui(new Ui::OrbitMainWindow),
+      command_line_flags_(command_line_flags),
       target_configuration_(std::move(target_configuration)) {
   SetupMainWindow();
 
@@ -1062,7 +1065,10 @@ void OrbitMainWindow::on_actionOpen_Capture_triggered() {
     return;
   }
 
-  OpenCapture(file.toStdString());
+  QString orbit_executable =
+      QString::fromStdString(orbit_base::GetExecutablePath().generic_string());
+  QStringList arguments;
+  QProcess::startDetached(orbit_executable, arguments << file << command_line_flags_);
 }
 
 void OrbitMainWindow::OpenCapture(const std::string& filepath) {

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -56,7 +56,8 @@ class OrbitMainWindow : public QMainWindow {
   static constexpr int kEndSessionReturnCode = 1;
 
   explicit OrbitMainWindow(orbit_qt::TargetConfiguration target_configuration,
-                           orbit_metrics_uploader::MetricsUploader* metrics_uploader = nullptr);
+                           orbit_metrics_uploader::MetricsUploader* metrics_uploader = nullptr,
+                           const QStringList& command_line_flags = QStringList());
   ~OrbitMainWindow() override;
 
   void RegisterGlWidget(OrbitGLWidget* widget) { gl_widgets_.push_back(widget); }
@@ -172,6 +173,7 @@ class OrbitMainWindow : public QMainWindow {
   std::unique_ptr<OrbitGLWidget> introspection_widget_ = nullptr;
   QFrame* hint_frame_ = nullptr;
   QLabel* target_label_ = nullptr;
+  QStringList command_line_flags_;
 
   // Capture toolbar.
   QIcon icon_start_capture_;


### PR DESCRIPTION
With this change, when the user clicks "Open Capture" in the capture toolbar, the selected capture file will be opened with a new Orbit instance (with the same command line flags as the current Orbit instance).

Bug: http://b/163303287
Test: Open an Orbit instance from the command line with flags, e.g., `--devmode`, and then select a new capture file from the `OrbitMainWindow` . See the selected capture file is opened in a new window with developer mode enabled.

Further discussion:
The `OrbitMainWindow` becomes useless in two cases (i.e., the user cannot reuse the current window): 1) Open Orbit with "Loading a Capture" and then clear the capture; 2) Opening Orbit with "Loading a Capture" and Orbit fails to open the capture file.
The above cases can be avoided by fixing http://b/179470701 (i.e., remove "Clear Capture" button) and http://b/178071836 (i.e., return to the connection window when failing to load the capture file).
        