### PR TITLE
Remove MetricsUploader libraries from installer ZIP

### DIFF
--- a/kokoro/builds/build.sh
+++ b/kokoro/builds/build.sh
@@ -196,6 +196,7 @@ if [ -n "$1" ]; then
     pushd "${REPO_ROOT}/build/package" > /dev/null
     cp -av bin/ Orbit
     find Orbit/ -name \*.pdb -delete
+    find Orbit/ -name MetricsUploader\*.dll -print -delete
     cp -v NOTICE Orbit/NOTICE
     test -f NOTICE.Chromium && cp -v NOTICE.Chromium Orbit/NOTICE.Chromium
     cp -v LICENSE Orbit/LICENSE.txt


### PR DESCRIPTION
We generate a bunch of test libraries that mimic the SDK's metrics
uploader client library. They should not be packaged.

![image](https://user-images.githubusercontent.com/43133967/106875285-c9d2c500-66d6-11eb-9e50-09df18a45553.png)
