### PR TITLE
Don't package shared objects meant for testing

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -274,9 +274,6 @@ chmod -v 4775 /opt/developer/tools/OrbitService
         self.copy("*", src="bin/icons", dst="bin/icons", symlinks=True)
         self.copy("*", src="bin/resources", dst="bin/resources", symlinks=True)
         self.copy("*", src="bin/translations", dst="bin/translations", symlinks=True)
-        self.copy("*.so*", src="lib/", dst="lib", symlinks=True)
-        self.copy("*.json*", src="lib/", dst="lib", symlinks=True)
-        self.copy("*.dll", src="bin/", dst="bin", symlinks=True)
         self.copy("*.pdb", src="bin/", dst="bin")
         self.copy("Orbit", src="bin/", dst="bin")
         self.copy("Orbit.exe", src="bin/", dst="bin")
@@ -292,6 +289,8 @@ chmod -v 4775 /opt/developer/tools/OrbitService
         self.copy("NOTICE.Chromium")
         self.copy("NOTICE.Chromium.csv")
         self.copy("LICENSE")
+        self.copy("libOrbitVulkanLayer.so", src="lib/", dst="lib")
+        self.copy("VkLayer_Orbit_implicit.json", src="lib/", dst="lib")
 
     def deploy(self):
         self.copy("*", src="bin", dst="bin")


### PR DESCRIPTION
We have a bunch of test-only libraries (DLLs or SOs). They all have been
packaged and copied to our GCS bucket.

This commit ensures that only explicitly specified libraries are packaged.

This is the proper fix of #1789 