### PR TITLE
Use Ninja for CI builds

### DIFF
--- a/kokoro/builds/build.sh
+++ b/kokoro/builds/build.sh
@@ -78,6 +78,11 @@ if [ -n "$1" ]; then
   }
   trap cleanup EXIT
 
+  # TODO(http://b/179358697): Temporary Ninja hack - will be removed when we move to Ninja in general
+  if [[ $CONAN_PROFILE == "msvc2017_relwithdebinfo" ]]; then
+    CONAN_PROFILE="msvc2017_relwithdebinfo_ninja"
+  fi
+
   echo "Using conan profile ${CONAN_PROFILE} and performing a ${BUILD_TYPE} build."
 
   set +e

--- a/third_party/conan/configs/windows/profiles/msvc2017_relwithdebinfo_ninja
+++ b/third_party/conan/configs/windows/profiles/msvc2017_relwithdebinfo_ninja
@@ -1,0 +1,8 @@
+include(msvc2017_relwithdebinfo)
+
+[settings]
+ninja:build_type=Release
+[build_requires]
+&: ninja/1.10.2
+[env]
+CONAN_CMAKE_GENERATOR=Ninja


### PR DESCRIPTION
I got tired of the slow build times on the CI, so this commit replaces
MSBuild by Ninja when invoked by the CI.

We can't yet change this out in general, because that would break the
Visual Studio development workflow.

Results:
- Usual build time with MSBuild: 22 mins
- With Ninja: 14 mins

I think that's worthwhile even if it is a bit hacky.