### PR TITLE
Introduce ProducerCaptureEvent/ClientCaptureEvent

### DIFF
--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -136,20 +136,30 @@ message FullTracepointEvent {
   TracepointInfo tracepoint_info = 5;
 }
 
-message GpuJob {
+message FullGpuJobEvent {
   int32 pid = 1;
   int32 tid = 2;
   uint32 context = 3;
   uint32 seqno = 4;
-  oneof timeline_or_key {
-    string timeline = 5;
-    uint64 timeline_key = 6;
-  }
-  int32 depth = 7;
-  uint64 amdgpu_cs_ioctl_time_ns = 8;
-  uint64 amdgpu_sched_run_job_time_ns = 9;
-  uint64 gpu_hardware_start_time_ns = 10;
-  uint64 dma_fence_signaled_time_ns = 11;
+  int32 depth = 5;
+  uint64 amdgpu_cs_ioctl_time_ns = 6;
+  uint64 amdgpu_sched_run_job_time_ns = 7;
+  uint64 gpu_hardware_start_time_ns = 8;
+  uint64 dma_fence_signaled_time_ns = 9;
+  string timeline = 10;
+}
+
+message InternedGpuJobEvent {
+  int32 pid = 1;
+  int32 tid = 2;
+  uint32 context = 3;
+  uint32 seqno = 4;
+  int32 depth = 5;
+  uint64 amdgpu_cs_ioctl_time_ns = 6;
+  uint64 amdgpu_sched_run_job_time_ns = 7;
+  uint64 gpu_hardware_start_time_ns = 8;
+  uint64 dma_fence_signaled_time_ns = 9;
+  uint64 timeline_key = 10;
 }
 
 message GpuQueueSubmission {
@@ -263,7 +273,7 @@ message ClientCaptureEvent {
     InternedCallstackSample interned_callstack_sample = 16;
     FunctionCall function_call = 4;
     InternedString interned_string = 5;
-    GpuJob gpu_job = 6;
+    InternedGpuJobEvent interned_gpu_job_event = 6;
     GpuQueueSubmission gpu_queue_submission = 13;
     ThreadName thread_name = 7;
     ThreadStateSlice thread_state_slice = 11;
@@ -283,7 +293,7 @@ message ProducerCaptureEvent {
     FullCallstackSample full_callstack_sample = 4;
     FunctionCall function_call = 5;
     InternedString interned_string = 6;
-    GpuJob gpu_job = 7;
+    FullGpuJobEvent full_gpu_job_event = 7;
     GpuQueueSubmission gpu_queue_submission = 8;
     ThreadName thread_name = 9;
     ThreadStateSlice thread_state_slice = 10;

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -96,14 +96,18 @@ message InternedCallstack {
   Callstack intern = 2;
 }
 
-message CallstackSample {
+message InternedCallstackSample {
   int32 pid = 1;
   int32 tid = 2;
-  oneof callstack_or_key {
-    Callstack callstack = 3;
-    uint64 callstack_key = 4;
-  }
-  uint64 timestamp_ns = 5;
+  uint64 callstack_id = 3;
+  uint64 timestamp_ns = 4;
+}
+
+message FullCallstackSample {
+  int32 pid = 1;
+  int32 tid = 2;
+  Callstack callstack = 3;
+  uint64 timestamp_ns = 4;
 }
 
 message InternedString {
@@ -246,12 +250,12 @@ message ModuleUpdateEvent {
   ModuleInfo module = 3;
 }
 
-message CaptureEvent {
-  reserved 14;
+message ClientCaptureEvent {
+  reserved 3, 14;
   oneof event {
     SchedulingSlice scheduling_slice = 1;
     InternedCallstack interned_callstack = 2;
-    CallstackSample callstack_sample = 3;
+    InternedCallstackSample interned_callstack_sample = 16;
     FunctionCall function_call = 4;
     InternedString interned_string = 5;
     GpuJob gpu_job = 6;
@@ -262,6 +266,26 @@ message CaptureEvent {
     InternedTracepointInfo interned_tracepoint_info = 9;
     TracepointEvent tracepoint_event = 10;
     IntrospectionScope introspection_scope = 12;
+    ModuleUpdateEvent module_update_event = 15;
+  }
+}
+
+message ProducerCaptureEvent {
+  oneof event {
+    SchedulingSlice scheduling_slice = 1;
+    InternedCallstack interned_callstack = 2;
+    InternedCallstackSample interned_callstack_sample = 3;
+    FullCallstackSample full_callstack_sample = 4;
+    FunctionCall function_call = 5;
+    InternedString interned_string = 6;
+    GpuJob gpu_job = 7;
+    GpuQueueSubmission gpu_queue_submission = 8;
+    ThreadName thread_name = 9;
+    ThreadStateSlice thread_state_slice = 10;
+    AddressInfo address_info = 11;
+    InternedTracepointInfo interned_tracepoint_info = 12;
+    TracepointEvent tracepoint_event = 13;
+    IntrospectionScope introspection_scope = 14;
     ModuleUpdateEvent module_update_event = 15;
   }
 }

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -120,15 +120,20 @@ message InternedTracepointInfo {
   TracepointInfo intern = 2;
 }
 
-message TracepointEvent {
+message InternedTracepointEvent {
   int32 pid = 1;
   int32 tid = 2;
-  uint64 time = 3;
+  uint64 timestamp_ns = 3;
   int32 cpu = 4;
-  oneof tracepoint_info_or_key {
-    TracepointInfo tracepoint_info = 5;
-    uint64 tracepoint_info_key = 6;
-  }
+  uint64 tracepoint_info_key = 5;
+}
+
+message FullTracepointEvent {
+  int32 pid = 1;
+  int32 tid = 2;
+  uint64 timestamp_ns = 3;
+  int32 cpu = 4;
+  TracepointInfo tracepoint_info = 5;
 }
 
 message GpuJob {
@@ -264,7 +269,7 @@ message ClientCaptureEvent {
     ThreadStateSlice thread_state_slice = 11;
     AddressInfo address_info = 8;
     InternedTracepointInfo interned_tracepoint_info = 9;
-    TracepointEvent tracepoint_event = 10;
+    InternedTracepointEvent interned_tracepoint_event = 10;
     IntrospectionScope introspection_scope = 12;
     ModuleUpdateEvent module_update_event = 15;
   }
@@ -284,8 +289,9 @@ message ProducerCaptureEvent {
     ThreadStateSlice thread_state_slice = 10;
     AddressInfo address_info = 11;
     InternedTracepointInfo interned_tracepoint_info = 12;
-    TracepointEvent tracepoint_event = 13;
-    IntrospectionScope introspection_scope = 14;
-    ModuleUpdateEvent module_update_event = 15;
+    InternedTracepointEvent interned_tracepoint_event = 13;
+    FullTracepointEvent full_tracepoint_event = 14;
+    IntrospectionScope introspection_scope = 15;
+    ModuleUpdateEvent module_update_event = 16;
   }
 }

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -96,7 +96,7 @@ message InternedCallstack {
   Callstack intern = 2;
 }
 
-message InternedCallstackSample {
+message CallstackSample {
   int32 pid = 1;
   int32 tid = 2;
   uint64 callstack_id = 3;
@@ -120,7 +120,7 @@ message InternedTracepointInfo {
   TracepointInfo intern = 2;
 }
 
-message InternedTracepointEvent {
+message TracepointEvent {
   int32 pid = 1;
   int32 tid = 2;
   uint64 timestamp_ns = 3;
@@ -136,7 +136,7 @@ message FullTracepointEvent {
   TracepointInfo tracepoint_info = 5;
 }
 
-message FullGpuJobEvent {
+message FullGpuJob {
   int32 pid = 1;
   int32 tid = 2;
   uint32 context = 3;
@@ -149,7 +149,7 @@ message FullGpuJobEvent {
   string timeline = 10;
 }
 
-message InternedGpuJobEvent {
+message GpuJob {
   int32 pid = 1;
   int32 tid = 2;
   uint32 context = 3;
@@ -246,7 +246,7 @@ message ThreadStateSlice {
   uint64 end_timestamp_ns = 5;
 }
 
-message InternedAddressInfo {
+message AddressInfo {
   uint64 absolute_address = 1;
   uint64 offset_in_function = 2;
   uint64 function_name_key = 3;
@@ -267,40 +267,41 @@ message ModuleUpdateEvent {
 }
 
 message ClientCaptureEvent {
-  reserved 3, 14;
   oneof event {
-    SchedulingSlice scheduling_slice = 1;
-    InternedCallstack interned_callstack = 2;
-    InternedCallstackSample interned_callstack_sample = 16;
-    FunctionCall function_call = 4;
-    InternedString interned_string = 5;
-    InternedGpuJobEvent interned_gpu_job_event = 6;
-    GpuQueueSubmission gpu_queue_submission = 13;
-    ThreadName thread_name = 7;
-    ThreadStateSlice thread_state_slice = 11;
-    InternedAddressInfo interned_address_info = 8;
-    InternedTracepointInfo interned_tracepoint_info = 9;
-    InternedTracepointEvent interned_tracepoint_event = 10;
-    IntrospectionScope introspection_scope = 12;
-    ModuleUpdateEvent module_update_event = 15;
+    // Please keep these alphabetically ordered.
+    AddressInfo address_info = 1;
+    CallstackSample callstack_sample = 2;
+    FunctionCall function_call = 3;
+    GpuJob gpu_job = 4;
+    GpuQueueSubmission gpu_queue_submission = 5;
+    InternedCallstack interned_callstack = 6;
+    InternedString interned_string = 7;
+    InternedTracepointInfo interned_tracepoint_info = 8;
+    IntrospectionScope introspection_scope = 9;
+    ModuleUpdateEvent module_update_event = 10;
+    SchedulingSlice scheduling_slice = 11;
+    ThreadName thread_name = 12;
+    ThreadStateSlice thread_state_slice = 13;
+    TracepointEvent tracepoint_event = 14;
   }
 }
 
 message ProducerCaptureEvent {
   oneof event {
-    SchedulingSlice scheduling_slice = 1;
-    InternedCallstack interned_callstack = 2;
-    InternedCallstackSample interned_callstack_sample = 3;
-    FullCallstackSample full_callstack_sample = 4;
-    FunctionCall function_call = 5;
-    InternedString interned_string = 6;
-    FullGpuJobEvent full_gpu_job_event = 7;
-    GpuQueueSubmission gpu_queue_submission = 8;
-    ThreadName thread_name = 9;
-    ThreadStateSlice thread_state_slice = 10;
-    FullAddressInfo full_address_info = 11;
-    FullTracepointEvent full_tracepoint_event = 12;
-    IntrospectionScope introspection_scope = 13;
-    ModuleUpdateEvent module_update_event = 14;
+    // Please keep these alphabetically ordered.
+    CallstackSample callstack_sample = 1;
+    FullCallstackSample full_callstack_sample = 2;
+    FullAddressInfo full_address_info = 3;
+    FullGpuJob full_gpu_job = 4;
+    FullTracepointEvent full_tracepoint_event = 5;
+    FunctionCall function_call = 6;
+    GpuQueueSubmission gpu_queue_submission = 7;
+    InternedCallstack interned_callstack = 8;
+    InternedString interned_string = 9;
+    IntrospectionScope introspection_scope = 10;
+    ModuleUpdateEvent module_update_event = 11;
+    SchedulingSlice scheduling_slice = 12;
+    ThreadName thread_name = 13;
+    ThreadStateSlice thread_state_slice = 14;
   }
 }

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -246,17 +246,18 @@ message ThreadStateSlice {
   uint64 end_timestamp_ns = 5;
 }
 
-message AddressInfo {
+message InternedAddressInfo {
   uint64 absolute_address = 1;
-  oneof function_name_or_key {
-    string function_name = 2;
-    uint64 function_name_key = 3;
-  }
-  uint64 offset_in_function = 4;
-  oneof map_name_or_key {
-    string map_name = 5;
-    uint64 map_name_key = 6;
-  }
+  uint64 offset_in_function = 2;
+  uint64 function_name_key = 3;
+  uint64 module_name_key = 4;
+}
+
+message FullAddressInfo {
+  uint64 absolute_address = 1;
+  uint64 offset_in_function = 2;
+  string function_name = 3;
+  string module_name = 4;
 }
 
 message ModuleUpdateEvent {
@@ -277,7 +278,7 @@ message ClientCaptureEvent {
     GpuQueueSubmission gpu_queue_submission = 13;
     ThreadName thread_name = 7;
     ThreadStateSlice thread_state_slice = 11;
-    AddressInfo address_info = 8;
+    InternedAddressInfo interned_address_info = 8;
     InternedTracepointInfo interned_tracepoint_info = 9;
     InternedTracepointEvent interned_tracepoint_event = 10;
     IntrospectionScope introspection_scope = 12;
@@ -297,7 +298,7 @@ message ProducerCaptureEvent {
     GpuQueueSubmission gpu_queue_submission = 8;
     ThreadName thread_name = 9;
     ThreadStateSlice thread_state_slice = 10;
-    AddressInfo address_info = 11;
+    FullAddressInfo full_address_info = 11;
     InternedTracepointInfo interned_tracepoint_info = 12;
     InternedTracepointEvent interned_tracepoint_event = 13;
     FullTracepointEvent full_tracepoint_event = 14;

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -299,10 +299,8 @@ message ProducerCaptureEvent {
     ThreadName thread_name = 9;
     ThreadStateSlice thread_state_slice = 10;
     FullAddressInfo full_address_info = 11;
-    InternedTracepointInfo interned_tracepoint_info = 12;
-    InternedTracepointEvent interned_tracepoint_event = 13;
-    FullTracepointEvent full_tracepoint_event = 14;
-    IntrospectionScope introspection_scope = 15;
-    ModuleUpdateEvent module_update_event = 16;
+    FullTracepointEvent full_tracepoint_event = 12;
+    IntrospectionScope introspection_scope = 13;
+    ModuleUpdateEvent module_update_event = 14;
   }
 }

--- a/src/GrpcProtos/include/GrpcProtos/Constants.h
+++ b/src/GrpcProtos/include/GrpcProtos/Constants.h
@@ -5,7 +5,10 @@
 #ifndef GRPC_PROTOS_CONSTANTS_H_
 #define GRPC_PROTOS_CONSTANTS_H_
 
+#include <stdint.h>
+
 namespace orbit_grpc_protos {
+constexpr uint64_t kInvalidInternId = 0;
 constexpr uint64_t kInvalidFunctionId = 0;
 }
 

--- a/src/GrpcProtos/producer_side_services.proto
+++ b/src/GrpcProtos/producer_side_services.proto
@@ -10,7 +10,8 @@ import "capture.proto";
 
 message ReceiveCommandsAndSendEventsRequest {
   message BufferedCaptureEvents {
-    repeated CaptureEvent capture_events = 1;
+    reserved 1;
+    repeated ProducerCaptureEvent capture_events = 2;
   }
   message AllEventsSent {}
 

--- a/src/GrpcProtos/services.proto
+++ b/src/GrpcProtos/services.proto
@@ -17,7 +17,8 @@ message CaptureRequest {
 }
 
 message CaptureResponse {
-  repeated CaptureEvent capture_events = 1;
+  reserved 1;
+  repeated ClientCaptureEvent capture_events = 2;
 }
 
 service CaptureService {

--- a/src/LinuxTracing/GpuTracepointVisitor.cpp
+++ b/src/LinuxTracing/GpuTracepointVisitor.cpp
@@ -19,7 +19,7 @@
 
 namespace orbit_linux_tracing {
 
-using orbit_grpc_protos::GpuJob;
+using orbit_grpc_protos::FullGpuJobEvent;
 
 int GpuTracepointVisitor::ComputeDepthForGpuJob(const std::string& timeline,
                                                 uint64_t start_timestamp, uint64_t end_timestamp) {
@@ -90,19 +90,19 @@ void GpuTracepointVisitor::CreateGpuJobAndSendToListenerIfComplete(const Key& ke
 
   int depth =
       ComputeDepthForGpuJob(timeline, cs_it->second.timestamp_ns, dma_it->second.timestamp_ns);
-  GpuJob gpu_job;
-  gpu_job.set_tid(tid);
-  gpu_job.set_context(cs_it->second.context);
-  gpu_job.set_seqno(cs_it->second.seqno);
-  gpu_job.set_timeline(cs_it->second.timeline);
-  gpu_job.set_depth(depth);
-  gpu_job.set_amdgpu_cs_ioctl_time_ns(cs_it->second.timestamp_ns);
-  gpu_job.set_amdgpu_sched_run_job_time_ns(sched_it->second.timestamp_ns);
-  gpu_job.set_gpu_hardware_start_time_ns(hw_start_time);
-  gpu_job.set_dma_fence_signaled_time_ns(dma_it->second.timestamp_ns);
+  FullGpuJobEvent gpu_job_event;
+  gpu_job_event.set_tid(tid);
+  gpu_job_event.set_context(cs_it->second.context);
+  gpu_job_event.set_seqno(cs_it->second.seqno);
+  gpu_job_event.set_depth(depth);
+  gpu_job_event.set_amdgpu_cs_ioctl_time_ns(cs_it->second.timestamp_ns);
+  gpu_job_event.set_amdgpu_sched_run_job_time_ns(sched_it->second.timestamp_ns);
+  gpu_job_event.set_gpu_hardware_start_time_ns(hw_start_time);
+  gpu_job_event.set_dma_fence_signaled_time_ns(dma_it->second.timestamp_ns);
+  gpu_job_event.set_timeline(cs_it->second.timeline);
 
   CHECK(listener_ != nullptr);
-  listener_->OnGpuJob(std::move(gpu_job));
+  listener_->OnGpuJob(std::move(gpu_job_event));
 
   // We need to update the timestamp when the last GPU job so far seen
   // finishes on this timeline.

--- a/src/LinuxTracing/GpuTracepointVisitor.cpp
+++ b/src/LinuxTracing/GpuTracepointVisitor.cpp
@@ -19,7 +19,7 @@
 
 namespace orbit_linux_tracing {
 
-using orbit_grpc_protos::FullGpuJobEvent;
+using orbit_grpc_protos::FullGpuJob;
 
 int GpuTracepointVisitor::ComputeDepthForGpuJob(const std::string& timeline,
                                                 uint64_t start_timestamp, uint64_t end_timestamp) {
@@ -90,19 +90,19 @@ void GpuTracepointVisitor::CreateGpuJobAndSendToListenerIfComplete(const Key& ke
 
   int depth =
       ComputeDepthForGpuJob(timeline, cs_it->second.timestamp_ns, dma_it->second.timestamp_ns);
-  FullGpuJobEvent gpu_job_event;
-  gpu_job_event.set_tid(tid);
-  gpu_job_event.set_context(cs_it->second.context);
-  gpu_job_event.set_seqno(cs_it->second.seqno);
-  gpu_job_event.set_depth(depth);
-  gpu_job_event.set_amdgpu_cs_ioctl_time_ns(cs_it->second.timestamp_ns);
-  gpu_job_event.set_amdgpu_sched_run_job_time_ns(sched_it->second.timestamp_ns);
-  gpu_job_event.set_gpu_hardware_start_time_ns(hw_start_time);
-  gpu_job_event.set_dma_fence_signaled_time_ns(dma_it->second.timestamp_ns);
-  gpu_job_event.set_timeline(cs_it->second.timeline);
+  FullGpuJob gpu_job;
+  gpu_job.set_tid(tid);
+  gpu_job.set_context(cs_it->second.context);
+  gpu_job.set_seqno(cs_it->second.seqno);
+  gpu_job.set_depth(depth);
+  gpu_job.set_amdgpu_cs_ioctl_time_ns(cs_it->second.timestamp_ns);
+  gpu_job.set_amdgpu_sched_run_job_time_ns(sched_it->second.timestamp_ns);
+  gpu_job.set_gpu_hardware_start_time_ns(hw_start_time);
+  gpu_job.set_dma_fence_signaled_time_ns(dma_it->second.timestamp_ns);
+  gpu_job.set_timeline(cs_it->second.timeline);
 
   CHECK(listener_ != nullptr);
-  listener_->OnGpuJob(std::move(gpu_job_event));
+  listener_->OnGpuJob(std::move(gpu_job));
 
   // We need to update the timestamp when the last GPU job so far seen
   // finishes on this timeline.

--- a/src/LinuxTracing/GpuTracepointVisitorTest.cpp
+++ b/src/LinuxTracing/GpuTracepointVisitorTest.cpp
@@ -35,7 +35,7 @@ class MockTracerListener : public TracerListener {
   MOCK_METHOD(void, OnThreadName, (orbit_grpc_protos::ThreadName), (override));
   MOCK_METHOD(void, OnThreadStateSlice, (orbit_grpc_protos::ThreadStateSlice), (override));
   MOCK_METHOD(void, OnAddressInfo, (orbit_grpc_protos::AddressInfo), (override));
-  MOCK_METHOD(void, OnTracepointEvent, (orbit_grpc_protos::TracepointEvent), (override));
+  MOCK_METHOD(void, OnTracepointEvent, (orbit_grpc_protos::FullTracepointEvent), (override));
   MOCK_METHOD(void, OnModuleUpdate, (orbit_grpc_protos::ModuleUpdateEvent), (override));
 };
 

--- a/src/LinuxTracing/GpuTracepointVisitorTest.cpp
+++ b/src/LinuxTracing/GpuTracepointVisitorTest.cpp
@@ -34,7 +34,7 @@ class MockTracerListener : public TracerListener {
   MOCK_METHOD(void, OnGpuJob, (orbit_grpc_protos::FullGpuJobEvent full_gpu_job_event), (override));
   MOCK_METHOD(void, OnThreadName, (orbit_grpc_protos::ThreadName), (override));
   MOCK_METHOD(void, OnThreadStateSlice, (orbit_grpc_protos::ThreadStateSlice), (override));
-  MOCK_METHOD(void, OnAddressInfo, (orbit_grpc_protos::AddressInfo), (override));
+  MOCK_METHOD(void, OnAddressInfo, (orbit_grpc_protos::FullAddressInfo), (override));
   MOCK_METHOD(void, OnTracepointEvent, (orbit_grpc_protos::FullTracepointEvent), (override));
   MOCK_METHOD(void, OnModuleUpdate, (orbit_grpc_protos::ModuleUpdateEvent), (override));
 };

--- a/src/LinuxTracing/GpuTracepointVisitorTest.cpp
+++ b/src/LinuxTracing/GpuTracepointVisitorTest.cpp
@@ -28,7 +28,7 @@ namespace {
 class MockTracerListener : public TracerListener {
  public:
   MOCK_METHOD(void, OnSchedulingSlice, (orbit_grpc_protos::SchedulingSlice), (override));
-  MOCK_METHOD(void, OnCallstackSample, (orbit_grpc_protos::CallstackSample), (override));
+  MOCK_METHOD(void, OnCallstackSample, (orbit_grpc_protos::FullCallstackSample), (override));
   MOCK_METHOD(void, OnFunctionCall, (orbit_grpc_protos::FunctionCall), (override));
   MOCK_METHOD(void, OnIntrospectionScope, (orbit_grpc_protos::IntrospectionScope), (override));
   MOCK_METHOD(void, OnGpuJob, (orbit_grpc_protos::GpuJob gpu_job), (override));

--- a/src/LinuxTracing/GpuTracepointVisitorTest.cpp
+++ b/src/LinuxTracing/GpuTracepointVisitorTest.cpp
@@ -31,7 +31,7 @@ class MockTracerListener : public TracerListener {
   MOCK_METHOD(void, OnCallstackSample, (orbit_grpc_protos::FullCallstackSample), (override));
   MOCK_METHOD(void, OnFunctionCall, (orbit_grpc_protos::FunctionCall), (override));
   MOCK_METHOD(void, OnIntrospectionScope, (orbit_grpc_protos::IntrospectionScope), (override));
-  MOCK_METHOD(void, OnGpuJob, (orbit_grpc_protos::GpuJob gpu_job), (override));
+  MOCK_METHOD(void, OnGpuJob, (orbit_grpc_protos::FullGpuJobEvent full_gpu_job_event), (override));
   MOCK_METHOD(void, OnThreadName, (orbit_grpc_protos::ThreadName), (override));
   MOCK_METHOD(void, OnThreadStateSlice, (orbit_grpc_protos::ThreadStateSlice), (override));
   MOCK_METHOD(void, OnAddressInfo, (orbit_grpc_protos::AddressInfo), (override));
@@ -108,13 +108,13 @@ std::unique_ptr<DmaFenceSignaledPerfEvent> MakeFakeDmaFenceSignaledPerfEvent(
   return event;
 }
 
-orbit_grpc_protos::GpuJob MakeGpuJob(int32_t tid, uint32_t context, uint32_t seqno,
-                                     std::string timeline, int32_t depth,
-                                     uint64_t amdgpu_cs_ioctl_time_ns,
-                                     uint64_t amdgpu_sched_run_job_time_ns,
-                                     uint64_t gpu_hardware_start_time_ns,
-                                     uint64_t dma_fence_signaled_time_ns) {
-  orbit_grpc_protos::GpuJob expected_gpu_job;
+orbit_grpc_protos::FullGpuJobEvent MakeGpuJob(int32_t tid, uint32_t context, uint32_t seqno,
+                                              std::string timeline, int32_t depth,
+                                              uint64_t amdgpu_cs_ioctl_time_ns,
+                                              uint64_t amdgpu_sched_run_job_time_ns,
+                                              uint64_t gpu_hardware_start_time_ns,
+                                              uint64_t dma_fence_signaled_time_ns) {
+  orbit_grpc_protos::FullGpuJobEvent expected_gpu_job;
   expected_gpu_job.set_tid(tid);
   expected_gpu_job.set_context(context);
   expected_gpu_job.set_seqno(seqno);
@@ -127,24 +127,27 @@ orbit_grpc_protos::GpuJob MakeGpuJob(int32_t tid, uint32_t context, uint32_t seq
   return expected_gpu_job;
 }
 
-::testing::Matcher<orbit_grpc_protos::GpuJob> GpuJobEq(const orbit_grpc_protos::GpuJob& expected) {
+::testing::Matcher<orbit_grpc_protos::FullGpuJobEvent> GpuJobEq(
+    const orbit_grpc_protos::FullGpuJobEvent& expected) {
   return ::testing::AllOf(
-      ::testing::Property("tid", &orbit_grpc_protos::GpuJob::tid, expected.tid()),
-      ::testing::Property("context", &orbit_grpc_protos::GpuJob::context, expected.context()),
-      ::testing::Property("seqno", &orbit_grpc_protos::GpuJob::seqno, expected.seqno()),
-      ::testing::Property("timeline", &orbit_grpc_protos::GpuJob::timeline, expected.timeline()),
-      ::testing::Property("depth", &orbit_grpc_protos::GpuJob::depth, expected.depth()),
+      ::testing::Property("tid", &orbit_grpc_protos::FullGpuJobEvent::tid, expected.tid()),
+      ::testing::Property("context", &orbit_grpc_protos::FullGpuJobEvent::context,
+                          expected.context()),
+      ::testing::Property("seqno", &orbit_grpc_protos::FullGpuJobEvent::seqno, expected.seqno()),
+      ::testing::Property("timeline", &orbit_grpc_protos::FullGpuJobEvent::timeline,
+                          expected.timeline()),
+      ::testing::Property("depth", &orbit_grpc_protos::FullGpuJobEvent::depth, expected.depth()),
       ::testing::Property("amdgpu_cs_ioctl_time_ns",
-                          &orbit_grpc_protos::GpuJob::amdgpu_cs_ioctl_time_ns,
+                          &orbit_grpc_protos::FullGpuJobEvent::amdgpu_cs_ioctl_time_ns,
                           expected.amdgpu_cs_ioctl_time_ns()),
       ::testing::Property("amdgpu_sched_run_job_time_ns",
-                          &orbit_grpc_protos::GpuJob::amdgpu_sched_run_job_time_ns,
+                          &orbit_grpc_protos::FullGpuJobEvent::amdgpu_sched_run_job_time_ns,
                           expected.amdgpu_sched_run_job_time_ns()),
       ::testing::Property("gpu_hardware_start_time_ns",
-                          &orbit_grpc_protos::GpuJob::gpu_hardware_start_time_ns,
+                          &orbit_grpc_protos::FullGpuJobEvent::gpu_hardware_start_time_ns,
                           expected.gpu_hardware_start_time_ns()),
       ::testing::Property("dma_fence_signaled_time_ns",
-                          &orbit_grpc_protos::GpuJob::dma_fence_signaled_time_ns,
+                          &orbit_grpc_protos::FullGpuJobEvent::dma_fence_signaled_time_ns,
                           expected.dma_fence_signaled_time_ns()));
 }
 
@@ -178,9 +181,9 @@ TEST_F(GpuTracepointVisitorTest, JobCreatedWithAllThreePerfEvents) {
   static constexpr uint64_t kTimestampC = kTimestampB;
   static constexpr uint64_t kTimestampD = 300;
 
-  orbit_grpc_protos::GpuJob expected_gpu_job = MakeGpuJob(
+  orbit_grpc_protos::FullGpuJobEvent expected_gpu_job = MakeGpuJob(
       kTid, kContext, kSeqno, kTimeline, 0, kTimestampA, kTimestampB, kTimestampC, kTimestampD);
-  orbit_grpc_protos::GpuJob actual_gpu_job;
+  orbit_grpc_protos::FullGpuJobEvent actual_gpu_job;
   EXPECT_CALL(mock_listener_, OnGpuJob).Times(1).WillOnce(::testing::SaveArg<0>(&actual_gpu_job));
   MakeFakeAmdgpuCsIoctlPerfEvent(kTid, kTimestampA, kContext, kSeqno, kTimeline)->Accept(&visitor_);
   MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, kTimeline)->Accept(&visitor_);
@@ -198,9 +201,9 @@ TEST_F(GpuTracepointVisitorTest, JobCreatedEvenWithOutOfOrderPerfEvents1) {
   static constexpr uint64_t kTimestampC = kTimestampB;
   static constexpr uint64_t kTimestampD = 300;
 
-  orbit_grpc_protos::GpuJob expected_gpu_job = MakeGpuJob(
+  orbit_grpc_protos::FullGpuJobEvent expected_gpu_job = MakeGpuJob(
       kTid, kContext, kSeqno, kTimeline, 0, kTimestampA, kTimestampB, kTimestampC, kTimestampD);
-  orbit_grpc_protos::GpuJob actual_gpu_job;
+  orbit_grpc_protos::FullGpuJobEvent actual_gpu_job;
   EXPECT_CALL(mock_listener_, OnGpuJob).Times(1).WillOnce(::testing::SaveArg<0>(&actual_gpu_job));
   MakeFakeDmaFenceSignaledPerfEvent(kTimestampD, kContext, kSeqno, kTimeline)->Accept(&visitor_);
   MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, kTimeline)->Accept(&visitor_);
@@ -219,9 +222,9 @@ TEST_F(GpuTracepointVisitorTest, JobCreatedEvenWithOutOfOrderPerfEvents2) {
   static constexpr uint64_t kTimestampC = kTimestampB;
   static constexpr uint64_t kTimestampD = 300;
 
-  orbit_grpc_protos::GpuJob expected_gpu_job = MakeGpuJob(
+  orbit_grpc_protos::FullGpuJobEvent expected_gpu_job = MakeGpuJob(
       kTid, kContext, kSeqno, kTimeline, 0, kTimestampA, kTimestampB, kTimestampC, kTimestampD);
-  orbit_grpc_protos::GpuJob actual_gpu_job;
+  orbit_grpc_protos::FullGpuJobEvent actual_gpu_job;
   EXPECT_CALL(mock_listener_, OnGpuJob).Times(1).WillOnce(::testing::SaveArg<0>(&actual_gpu_job));
   MakeFakeAmdgpuSchedRunJobPerfEvent(kTimestampB, kContext, kSeqno, kTimeline)->Accept(&visitor_);
   MakeFakeAmdgpuCsIoctlPerfEvent(kTid, kTimestampA, kContext, kSeqno, kTimeline)->Accept(&visitor_);
@@ -294,14 +297,14 @@ TEST_F(GpuTracepointVisitorTest, TwoNonOverlappingJobsWithSameDepthDifferingByCo
   static constexpr uint64_t kTimestampC2 = kTimestampB2;
   static constexpr uint64_t kTimestampD2 = kNsDistanceForSameDepth + 500;
 
-  orbit_grpc_protos::GpuJob expected_gpu_job1 =
+  orbit_grpc_protos::FullGpuJobEvent expected_gpu_job1 =
       MakeGpuJob(kTid, kContext1, kSeqno, kTimeline, 0, kTimestampA1, kTimestampB1, kTimestampC1,
                  kTimestampD1);
-  orbit_grpc_protos::GpuJob expected_gpu_job2 =
+  orbit_grpc_protos::FullGpuJobEvent expected_gpu_job2 =
       MakeGpuJob(kTid, kContext2, kSeqno, kTimeline, 0, kTimestampA2, kTimestampB2, kTimestampC2,
                  kTimestampD2);
-  orbit_grpc_protos::GpuJob actual_gpu_job1;
-  orbit_grpc_protos::GpuJob actual_gpu_job2;
+  orbit_grpc_protos::FullGpuJobEvent actual_gpu_job1;
+  orbit_grpc_protos::FullGpuJobEvent actual_gpu_job2;
   EXPECT_CALL(mock_listener_, OnGpuJob)
       .Times(2)
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job1))
@@ -337,14 +340,14 @@ TEST_F(GpuTracepointVisitorTest, TwoNonOverlappingJobsWithSameDepthDifferingBySe
   static constexpr uint64_t kTimestampC2 = kTimestampB2;
   static constexpr uint64_t kTimestampD2 = kNsDistanceForSameDepth + 500;
 
-  orbit_grpc_protos::GpuJob expected_gpu_job1 =
+  orbit_grpc_protos::FullGpuJobEvent expected_gpu_job1 =
       MakeGpuJob(kTid, kContext, kSeqno1, kTimeline, 0, kTimestampA1, kTimestampB1, kTimestampC1,
                  kTimestampD1);
-  orbit_grpc_protos::GpuJob expected_gpu_job2 =
+  orbit_grpc_protos::FullGpuJobEvent expected_gpu_job2 =
       MakeGpuJob(kTid, kContext, kSeqno2, kTimeline, 0, kTimestampA2, kTimestampB2, kTimestampC2,
                  kTimestampD2);
-  orbit_grpc_protos::GpuJob actual_gpu_job1;
-  orbit_grpc_protos::GpuJob actual_gpu_job2;
+  orbit_grpc_protos::FullGpuJobEvent actual_gpu_job1;
+  orbit_grpc_protos::FullGpuJobEvent actual_gpu_job2;
   EXPECT_CALL(mock_listener_, OnGpuJob)
       .Times(2)
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job1))
@@ -375,12 +378,12 @@ TEST_F(GpuTracepointVisitorTest, TwoOverlappingJobsButOnDifferentTimelines) {
   static constexpr uint64_t kTimestampC = kTimestampB;
   static constexpr uint64_t kTimestampD = 300;
 
-  orbit_grpc_protos::GpuJob expected_gpu_job1 = MakeGpuJob(
+  orbit_grpc_protos::FullGpuJobEvent expected_gpu_job1 = MakeGpuJob(
       kTid, kContext, kSeqno, kTimeline1, 0, kTimestampA, kTimestampB, kTimestampC, kTimestampD);
-  orbit_grpc_protos::GpuJob expected_gpu_job2 = MakeGpuJob(
+  orbit_grpc_protos::FullGpuJobEvent expected_gpu_job2 = MakeGpuJob(
       kTid, kContext, kSeqno, kTimeline2, 0, kTimestampA, kTimestampB, kTimestampC, kTimestampD);
-  orbit_grpc_protos::GpuJob actual_gpu_job1;
-  orbit_grpc_protos::GpuJob actual_gpu_job2;
+  orbit_grpc_protos::FullGpuJobEvent actual_gpu_job1;
+  orbit_grpc_protos::FullGpuJobEvent actual_gpu_job2;
   EXPECT_CALL(mock_listener_, OnGpuJob)
       .Times(2)
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job1))
@@ -415,14 +418,14 @@ TEST_F(GpuTracepointVisitorTest, TwoNonOverlappingJobsWithDifferentDepthsBecause
   static constexpr uint64_t kTimestampC2 = kTimestampB2;
   static constexpr uint64_t kTimestampD2 = 600;
 
-  orbit_grpc_protos::GpuJob expected_gpu_job1 =
+  orbit_grpc_protos::FullGpuJobEvent expected_gpu_job1 =
       MakeGpuJob(kTid, kContext, kSeqno1, kTimeline, 0, kTimestampA1, kTimestampB1, kTimestampC1,
                  kTimestampD1);
-  orbit_grpc_protos::GpuJob expected_gpu_job2 =
+  orbit_grpc_protos::FullGpuJobEvent expected_gpu_job2 =
       MakeGpuJob(kTid, kContext, kSeqno2, kTimeline, 1, kTimestampA2, kTimestampB2, kTimestampC2,
                  kTimestampD2);
-  orbit_grpc_protos::GpuJob actual_gpu_job1;
-  orbit_grpc_protos::GpuJob actual_gpu_job2;
+  orbit_grpc_protos::FullGpuJobEvent actual_gpu_job1;
+  orbit_grpc_protos::FullGpuJobEvent actual_gpu_job2;
   EXPECT_CALL(mock_listener_, OnGpuJob)
       .Times(2)
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job1))
@@ -457,14 +460,14 @@ TEST_F(GpuTracepointVisitorTest, TwoOverlappingJobsWithImmediateHwExecution) {
   static constexpr uint64_t kTimestampC2 = kTimestampB2;
   static constexpr uint64_t kTimestampD2 = 410;
 
-  orbit_grpc_protos::GpuJob expected_gpu_job1 =
+  orbit_grpc_protos::FullGpuJobEvent expected_gpu_job1 =
       MakeGpuJob(kTid, kContext, kSeqno1, kTimeline, 0, kTimestampA1, kTimestampB1, kTimestampC1,
                  kTimestampD1);
-  orbit_grpc_protos::GpuJob expected_gpu_job2 =
+  orbit_grpc_protos::FullGpuJobEvent expected_gpu_job2 =
       MakeGpuJob(kTid, kContext, kSeqno2, kTimeline, 1, kTimestampA2, kTimestampB2, kTimestampC2,
                  kTimestampD2);
-  orbit_grpc_protos::GpuJob actual_gpu_job1;
-  orbit_grpc_protos::GpuJob actual_gpu_job2;
+  orbit_grpc_protos::FullGpuJobEvent actual_gpu_job1;
+  orbit_grpc_protos::FullGpuJobEvent actual_gpu_job2;
   EXPECT_CALL(mock_listener_, OnGpuJob)
       .Times(2)
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job1))
@@ -499,14 +502,14 @@ TEST_F(GpuTracepointVisitorTest, TwoOverlappingJobsWithDelayedHwExecution) {
   static constexpr uint64_t kTimestampC2 = kTimestampD1;
   static constexpr uint64_t kTimestampD2 = 400;
 
-  orbit_grpc_protos::GpuJob expected_gpu_job1 =
+  orbit_grpc_protos::FullGpuJobEvent expected_gpu_job1 =
       MakeGpuJob(kTid, kContext, kSeqno1, kTimeline, 0, kTimestampA1, kTimestampB1, kTimestampC1,
                  kTimestampD1);
-  orbit_grpc_protos::GpuJob expected_gpu_job2 =
+  orbit_grpc_protos::FullGpuJobEvent expected_gpu_job2 =
       MakeGpuJob(kTid, kContext, kSeqno2, kTimeline, 1, kTimestampA2, kTimestampB2, kTimestampC2,
                  kTimestampD2);
-  orbit_grpc_protos::GpuJob actual_gpu_job1;
-  orbit_grpc_protos::GpuJob actual_gpu_job2;
+  orbit_grpc_protos::FullGpuJobEvent actual_gpu_job1;
+  orbit_grpc_protos::FullGpuJobEvent actual_gpu_job2;
   EXPECT_CALL(mock_listener_, OnGpuJob)
       .Times(2)
       .WillOnce(::testing::SaveArg<0>(&actual_gpu_job1))
@@ -545,14 +548,14 @@ TEST_F(GpuTracepointVisitorTest,
   // events are processed reasonably in order doesn't hold.
   static constexpr uint64_t kTimestampC1 = kTimestampD2;
 
-  orbit_grpc_protos::GpuJob expected_gpu_job1 =
+  orbit_grpc_protos::FullGpuJobEvent expected_gpu_job1 =
       MakeGpuJob(kTid, kContext, kSeqno1, kTimeline, 1, kTimestampA1, kTimestampB1, kTimestampC1,
                  kTimestampD1);
-  orbit_grpc_protos::GpuJob expected_gpu_job2 =
+  orbit_grpc_protos::FullGpuJobEvent expected_gpu_job2 =
       MakeGpuJob(kTid, kContext, kSeqno2, kTimeline, 0, kTimestampA2, kTimestampB2, kTimestampC2,
                  kTimestampD2);
-  orbit_grpc_protos::GpuJob actual_gpu_job1;
-  orbit_grpc_protos::GpuJob actual_gpu_job2;
+  orbit_grpc_protos::FullGpuJobEvent actual_gpu_job1;
+  orbit_grpc_protos::FullGpuJobEvent actual_gpu_job2;
   EXPECT_CALL(mock_listener_, OnGpuJob)
       .Times(2)
       // Save actual_gpu_job2 first as it's created first (its last PerfEvent is processed first).

--- a/src/LinuxTracing/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracing/LinuxTracingIntegrationTest.cpp
@@ -184,9 +184,9 @@ class BufferTracerListener : public TracerListener {
     }
   }
 
-  void OnGpuJob(orbit_grpc_protos::GpuJob gpu_job) override {
+  void OnGpuJob(orbit_grpc_protos::FullGpuJobEvent full_gpu_job_event) override {
     orbit_grpc_protos::ProducerCaptureEvent event;
-    *event.mutable_gpu_job() = std::move(gpu_job);
+    *event.mutable_full_gpu_job_event() = std::move(full_gpu_job_event);
     {
       absl::MutexLock lock{&events_mutex_};
       events_.emplace_back(std::move(event));
@@ -399,9 +399,10 @@ void VerifyOrderOfAllEvents(const std::vector<orbit_grpc_protos::ProducerCapture
         UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kInternedString:
         UNREACHABLE();
-      case orbit_grpc_protos::ProducerCaptureEvent::kGpuJob:
-        EXPECT_GE(event.gpu_job().dma_fence_signaled_time_ns(), previous_event_timestamp_ns);
-        previous_event_timestamp_ns = event.gpu_job().dma_fence_signaled_time_ns();
+      case orbit_grpc_protos::ProducerCaptureEvent::kFullGpuJobEvent:
+        EXPECT_GE(event.full_gpu_job_event().dma_fence_signaled_time_ns(),
+                  previous_event_timestamp_ns);
+        previous_event_timestamp_ns = event.full_gpu_job_event().dma_fence_signaled_time_ns();
         break;
       case orbit_grpc_protos::ProducerCaptureEvent::kThreadName:
         EXPECT_GE(event.thread_name().timestamp_ns(), previous_event_timestamp_ns);

--- a/src/LinuxTracing/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracing/LinuxTracingIntegrationTest.cpp
@@ -184,9 +184,9 @@ class BufferTracerListener : public TracerListener {
     }
   }
 
-  void OnGpuJob(orbit_grpc_protos::FullGpuJobEvent full_gpu_job_event) override {
+  void OnGpuJob(orbit_grpc_protos::FullGpuJob full_gpu_job_event) override {
     orbit_grpc_protos::ProducerCaptureEvent event;
-    *event.mutable_full_gpu_job_event() = std::move(full_gpu_job_event);
+    *event.mutable_full_gpu_job() = std::move(full_gpu_job_event);
     {
       absl::MutexLock lock{&events_mutex_};
       events_.emplace_back(std::move(event));
@@ -383,7 +383,7 @@ void VerifyOrderOfAllEvents(const std::vector<orbit_grpc_protos::ProducerCapture
         break;
       case orbit_grpc_protos::ProducerCaptureEvent::kInternedCallstack:
         UNREACHABLE();
-      case orbit_grpc_protos::ProducerCaptureEvent::kInternedCallstackSample:
+      case orbit_grpc_protos::ProducerCaptureEvent::kCallstackSample:
         UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kFullCallstackSample:
         EXPECT_GE(event.full_callstack_sample().timestamp_ns(), previous_event_timestamp_ns);
@@ -399,10 +399,9 @@ void VerifyOrderOfAllEvents(const std::vector<orbit_grpc_protos::ProducerCapture
         UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kInternedString:
         UNREACHABLE();
-      case orbit_grpc_protos::ProducerCaptureEvent::kFullGpuJobEvent:
-        EXPECT_GE(event.full_gpu_job_event().dma_fence_signaled_time_ns(),
-                  previous_event_timestamp_ns);
-        previous_event_timestamp_ns = event.full_gpu_job_event().dma_fence_signaled_time_ns();
+      case orbit_grpc_protos::ProducerCaptureEvent::kFullGpuJob:
+        EXPECT_GE(event.full_gpu_job().dma_fence_signaled_time_ns(), previous_event_timestamp_ns);
+        previous_event_timestamp_ns = event.full_gpu_job().dma_fence_signaled_time_ns();
         break;
       case orbit_grpc_protos::ProducerCaptureEvent::kThreadName:
         EXPECT_GE(event.thread_name().timestamp_ns(), previous_event_timestamp_ns);

--- a/src/LinuxTracing/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracing/LinuxTracingIntegrationTest.cpp
@@ -415,10 +415,6 @@ void VerifyOrderOfAllEvents(const std::vector<orbit_grpc_protos::ProducerCapture
       case orbit_grpc_protos::ProducerCaptureEvent::kFullAddressInfo:
         // AddressInfos have no timestamp.
         break;
-      case orbit_grpc_protos::ProducerCaptureEvent::kInternedTracepointInfo:
-        UNREACHABLE();
-      case orbit_grpc_protos::ProducerCaptureEvent::kInternedTracepointEvent:
-        UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kGpuQueueSubmission:
         UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kModuleUpdateEvent:

--- a/src/LinuxTracing/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracing/LinuxTracingIntegrationTest.cpp
@@ -220,9 +220,9 @@ class BufferTracerListener : public TracerListener {
     }
   }
 
-  void OnTracepointEvent(orbit_grpc_protos::TracepointEvent tracepoint_event) override {
+  void OnTracepointEvent(orbit_grpc_protos::FullTracepointEvent tracepoint_event) override {
     orbit_grpc_protos::ProducerCaptureEvent event;
-    *event.mutable_tracepoint_event() = std::move(tracepoint_event);
+    *event.mutable_full_tracepoint_event() = std::move(tracepoint_event);
     {
       absl::MutexLock lock{&events_mutex_};
       events_.emplace_back(std::move(event));
@@ -389,6 +389,8 @@ void VerifyOrderOfAllEvents(const std::vector<orbit_grpc_protos::ProducerCapture
         EXPECT_GE(event.full_callstack_sample().timestamp_ns(), previous_event_timestamp_ns);
         previous_event_timestamp_ns = event.full_callstack_sample().timestamp_ns();
         break;
+      case orbit_grpc_protos::ProducerCaptureEvent::kFullTracepointEvent:
+        UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kFunctionCall:
         EXPECT_GE(event.function_call().end_timestamp_ns(), previous_event_timestamp_ns);
         previous_event_timestamp_ns = event.function_call().end_timestamp_ns();
@@ -414,7 +416,7 @@ void VerifyOrderOfAllEvents(const std::vector<orbit_grpc_protos::ProducerCapture
         break;
       case orbit_grpc_protos::ProducerCaptureEvent::kInternedTracepointInfo:
         UNREACHABLE();
-      case orbit_grpc_protos::ProducerCaptureEvent::kTracepointEvent:
+      case orbit_grpc_protos::ProducerCaptureEvent::kInternedTracepointEvent:
         UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kGpuQueueSubmission:
         UNREACHABLE();

--- a/src/LinuxTracing/TracerThread.cpp
+++ b/src/LinuxTracing/TracerThread.cpp
@@ -922,10 +922,10 @@ void TracerThread::ProcessSampleEvent(const perf_event_header& header,
 
     auto event = ConsumeGenericTracepointPerfEvent(ring_buffer, header);
 
-    orbit_grpc_protos::TracepointEvent tracepoint_event;
+    orbit_grpc_protos::FullTracepointEvent tracepoint_event;
     tracepoint_event.set_pid(event->GetPid());
     tracepoint_event.set_tid(event->GetTid());
-    tracepoint_event.set_time(event->GetTimestamp());
+    tracepoint_event.set_timestamp_ns(event->GetTimestamp());
     tracepoint_event.set_cpu(event->GetCpu());
 
     orbit_grpc_protos::TracepointInfo* tracepoint = tracepoint_event.mutable_tracepoint_info();

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -25,8 +25,8 @@
 
 namespace orbit_linux_tracing {
 
-using orbit_grpc_protos::AddressInfo;
 using orbit_grpc_protos::Callstack;
+using orbit_grpc_protos::FullAddressInfo;
 using orbit_grpc_protos::FullCallstackSample;
 using orbit_grpc_protos::FunctionCall;
 
@@ -66,11 +66,11 @@ void UprobesUnwindingVisitor::visit(StackSamplePerfEvent* event) {
 
   Callstack* callstack = sample.mutable_callstack();
   for (const unwindstack::FrameData& libunwindstack_frame : libunwindstack_callstack) {
-    AddressInfo address_info;
+    FullAddressInfo address_info;
     address_info.set_absolute_address(libunwindstack_frame.pc);
     address_info.set_function_name(libunwindstack_frame.function_name);
     address_info.set_offset_in_function(libunwindstack_frame.function_offset);
-    address_info.set_map_name(libunwindstack_frame.map_name);
+    address_info.set_module_name(libunwindstack_frame.map_name);
     listener_->OnAddressInfo(std::move(address_info));
 
     callstack->add_pcs(libunwindstack_frame.pc);

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -27,7 +27,7 @@ namespace orbit_linux_tracing {
 
 using orbit_grpc_protos::AddressInfo;
 using orbit_grpc_protos::Callstack;
-using orbit_grpc_protos::CallstackSample;
+using orbit_grpc_protos::FullCallstackSample;
 using orbit_grpc_protos::FunctionCall;
 
 void UprobesUnwindingVisitor::visit(StackSamplePerfEvent* event) {
@@ -59,7 +59,7 @@ void UprobesUnwindingVisitor::visit(StackSamplePerfEvent* event) {
     return;
   }
 
-  CallstackSample sample;
+  FullCallstackSample sample;
   sample.set_pid(event->GetPid());
   sample.set_tid(event->GetTid());
   sample.set_timestamp_ns(event->GetTimestamp());
@@ -112,7 +112,7 @@ void UprobesUnwindingVisitor::visit(CallchainSamplePerfEvent* event) {
     return;
   }
 
-  CallstackSample sample;
+  FullCallstackSample sample;
   sample.set_pid(event->GetPid());
   sample.set_tid(event->GetTid());
   sample.set_timestamp_ns(event->GetTimestamp());

--- a/src/LinuxTracing/include/LinuxTracing/TracerListener.h
+++ b/src/LinuxTracing/include/LinuxTracing/TracerListener.h
@@ -16,7 +16,7 @@ class TracerListener {
   virtual void OnCallstackSample(orbit_grpc_protos::FullCallstackSample callstack_sample) = 0;
   virtual void OnFunctionCall(orbit_grpc_protos::FunctionCall function_call) = 0;
   virtual void OnIntrospectionScope(orbit_grpc_protos::IntrospectionScope introspection_scope) = 0;
-  virtual void OnGpuJob(orbit_grpc_protos::GpuJob gpu_job) = 0;
+  virtual void OnGpuJob(orbit_grpc_protos::FullGpuJobEvent gpu_job_event) = 0;
   virtual void OnThreadName(orbit_grpc_protos::ThreadName thread_name) = 0;
   virtual void OnThreadStateSlice(orbit_grpc_protos::ThreadStateSlice thread_state_slice) = 0;
   virtual void OnAddressInfo(orbit_grpc_protos::AddressInfo address_info) = 0;

--- a/src/LinuxTracing/include/LinuxTracing/TracerListener.h
+++ b/src/LinuxTracing/include/LinuxTracing/TracerListener.h
@@ -20,7 +20,7 @@ class TracerListener {
   virtual void OnThreadName(orbit_grpc_protos::ThreadName thread_name) = 0;
   virtual void OnThreadStateSlice(orbit_grpc_protos::ThreadStateSlice thread_state_slice) = 0;
   virtual void OnAddressInfo(orbit_grpc_protos::AddressInfo address_info) = 0;
-  virtual void OnTracepointEvent(orbit_grpc_protos::TracepointEvent tracepoint_event) = 0;
+  virtual void OnTracepointEvent(orbit_grpc_protos::FullTracepointEvent tracepoint_event) = 0;
   virtual void OnModuleUpdate(orbit_grpc_protos::ModuleUpdateEvent module_update_event) = 0;
 };
 

--- a/src/LinuxTracing/include/LinuxTracing/TracerListener.h
+++ b/src/LinuxTracing/include/LinuxTracing/TracerListener.h
@@ -19,7 +19,7 @@ class TracerListener {
   virtual void OnGpuJob(orbit_grpc_protos::FullGpuJobEvent gpu_job_event) = 0;
   virtual void OnThreadName(orbit_grpc_protos::ThreadName thread_name) = 0;
   virtual void OnThreadStateSlice(orbit_grpc_protos::ThreadStateSlice thread_state_slice) = 0;
-  virtual void OnAddressInfo(orbit_grpc_protos::AddressInfo address_info) = 0;
+  virtual void OnAddressInfo(orbit_grpc_protos::FullAddressInfo full_address_info) = 0;
   virtual void OnTracepointEvent(orbit_grpc_protos::FullTracepointEvent tracepoint_event) = 0;
   virtual void OnModuleUpdate(orbit_grpc_protos::ModuleUpdateEvent module_update_event) = 0;
 };

--- a/src/LinuxTracing/include/LinuxTracing/TracerListener.h
+++ b/src/LinuxTracing/include/LinuxTracing/TracerListener.h
@@ -13,7 +13,7 @@ class TracerListener {
  public:
   virtual ~TracerListener() = default;
   virtual void OnSchedulingSlice(orbit_grpc_protos::SchedulingSlice scheduling_slice) = 0;
-  virtual void OnCallstackSample(orbit_grpc_protos::CallstackSample callstack_sample) = 0;
+  virtual void OnCallstackSample(orbit_grpc_protos::FullCallstackSample callstack_sample) = 0;
   virtual void OnFunctionCall(orbit_grpc_protos::FunctionCall function_call) = 0;
   virtual void OnIntrospectionScope(orbit_grpc_protos::IntrospectionScope introspection_scope) = 0;
   virtual void OnGpuJob(orbit_grpc_protos::GpuJob gpu_job) = 0;

--- a/src/LinuxTracing/include/LinuxTracing/TracerListener.h
+++ b/src/LinuxTracing/include/LinuxTracing/TracerListener.h
@@ -16,7 +16,7 @@ class TracerListener {
   virtual void OnCallstackSample(orbit_grpc_protos::FullCallstackSample callstack_sample) = 0;
   virtual void OnFunctionCall(orbit_grpc_protos::FunctionCall function_call) = 0;
   virtual void OnIntrospectionScope(orbit_grpc_protos::IntrospectionScope introspection_scope) = 0;
-  virtual void OnGpuJob(orbit_grpc_protos::FullGpuJobEvent gpu_job_event) = 0;
+  virtual void OnGpuJob(orbit_grpc_protos::FullGpuJob gpu_job) = 0;
   virtual void OnThreadName(orbit_grpc_protos::ThreadName thread_name) = 0;
   virtual void OnThreadStateSlice(orbit_grpc_protos::ThreadStateSlice thread_state_slice) = 0;
   virtual void OnAddressInfo(orbit_grpc_protos::FullAddressInfo full_address_info) = 0;

--- a/src/OrbitCaptureClient/GpuQueueSubmissionProcessor.cpp
+++ b/src/OrbitCaptureClient/GpuQueueSubmissionProcessor.cpp
@@ -11,11 +11,11 @@ using orbit_client_protos::TimerInfo;
 
 using orbit_grpc_protos::GpuCommandBuffer;
 using orbit_grpc_protos::GpuDebugMarker;
+using orbit_grpc_protos::GpuJob;
 using orbit_grpc_protos::GpuQueueSubmission;
-using orbit_grpc_protos::InternedGpuJobEvent;
 
 std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuQueueSubmission(
-    const orbit_grpc_protos::GpuQueueSubmission& gpu_queue_submission,
+    const GpuQueueSubmission& gpu_queue_submission,
     const absl::flat_hash_map<uint64_t, std::string>& string_intern_pool,
     const std::function<uint64_t(const std::string& str)>&
         get_string_hash_and_send_to_listener_if_necessary) {
@@ -24,7 +24,7 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuQueueSubmission(
       gpu_queue_submission.meta_info().pre_submission_cpu_timestamp();
   uint64_t post_submission_cpu_timestamp =
       gpu_queue_submission.meta_info().post_submission_cpu_timestamp();
-  const InternedGpuJobEvent* matching_gpu_job =
+  const GpuJob* matching_gpu_job =
       FindMatchingGpuJob(thread_id, pre_submission_cpu_timestamp, post_submission_cpu_timestamp);
 
   // If we haven't found the matching "GpuJob" or the submission contains "begin" markers (which
@@ -53,8 +53,7 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuQueueSubmission(
   return result;
 }
 std::vector<orbit_client_protos::TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuJob(
-    const InternedGpuJobEvent& gpu_job,
-    const absl::flat_hash_map<uint64_t, std::string>& string_intern_pool,
+    const GpuJob& gpu_job, const absl::flat_hash_map<uint64_t, std::string>& string_intern_pool,
     const std::function<uint64_t(const std::string& str)>&
         get_string_hash_and_send_to_listener_if_necessary) {
   int32_t thread_id = gpu_job.tid();
@@ -115,7 +114,7 @@ const GpuQueueSubmission* GpuQueueSubmissionProcessor::FindMatchingGpuQueueSubmi
   return matching_gpu_submission;
 }
 
-const InternedGpuJobEvent* GpuQueueSubmissionProcessor::FindMatchingGpuJob(
+const GpuJob* GpuQueueSubmissionProcessor::FindMatchingGpuJob(
     int32_t thread_id, uint64_t pre_submission_cpu_timestamp,
     uint64_t post_submission_cpu_timestamp) {
   const auto& submission_time_to_gpu_job_it = tid_to_submission_time_to_gpu_job_.find(thread_id);
@@ -149,7 +148,7 @@ const InternedGpuJobEvent* GpuQueueSubmissionProcessor::FindMatchingGpuJob(
 }
 
 std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuQueueSubmissionWithMatchingGpuJob(
-    const GpuQueueSubmission& gpu_queue_submission, const InternedGpuJobEvent& matching_gpu_job,
+    const GpuQueueSubmission& gpu_queue_submission, const GpuJob& matching_gpu_job,
     const absl::flat_hash_map<uint64_t, std::string>& string_intern_pool,
     const std::function<uint64_t(const std::string& str)>&
         get_string_hash_and_send_to_listener_if_necessary) {
@@ -233,10 +232,8 @@ void GpuQueueSubmissionProcessor::DeleteSavedGpuSubmission(int32_t thread_id,
 }
 
 std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuCommandBuffers(
-    const orbit_grpc_protos::GpuQueueSubmission& gpu_queue_submission,
-    const orbit_grpc_protos::InternedGpuJobEvent& matching_gpu_job,
-    const std::optional<orbit_grpc_protos::GpuCommandBuffer>& first_command_buffer,
-    uint64_t timeline_hash,
+    const GpuQueueSubmission& gpu_queue_submission, const GpuJob& matching_gpu_job,
+    const std::optional<GpuCommandBuffer>& first_command_buffer, uint64_t timeline_hash,
     const std::function<uint64_t(const std::string& str)>&
         get_string_hash_and_send_to_listener_if_necessary) {
   constexpr const char* kCommandBufferLabel = "command buffer";
@@ -275,7 +272,7 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuCommandBuffers(
 }
 
 std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuDebugMarkers(
-    const GpuQueueSubmission& gpu_queue_submission, const InternedGpuJobEvent& matching_gpu_job,
+    const GpuQueueSubmission& gpu_queue_submission, const GpuJob& matching_gpu_job,
     const std::optional<GpuCommandBuffer>& first_command_buffer, const std::string& timeline,
     const std::function<uint64_t(const std::string& str)>&
         get_string_hash_and_send_to_listener_if_necessary) {
@@ -348,7 +345,7 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuDebugMarkers(
       }
       CHECK(begin_submission_first_command_buffer.has_value());
 
-      const InternedGpuJobEvent* matching_begin_job = FindMatchingGpuJob(
+      const GpuJob* matching_begin_job = FindMatchingGpuJob(
           begin_marker_thread_id, begin_marker_meta_info.pre_submission_cpu_timestamp(),
           begin_marker_post_submission_cpu_timestamp);
       CHECK(matching_begin_job != nullptr);
@@ -402,9 +399,8 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuDebugMarkers(
   return result;
 }
 
-std::optional<orbit_grpc_protos::GpuCommandBuffer>
-GpuQueueSubmissionProcessor::ExtractFirstCommandBuffer(
-    const orbit_grpc_protos::GpuQueueSubmission& gpu_queue_submission) {
+std::optional<GpuCommandBuffer> GpuQueueSubmissionProcessor::ExtractFirstCommandBuffer(
+    const GpuQueueSubmission& gpu_queue_submission) {
   for (const auto& submit_info : gpu_queue_submission.submit_infos()) {
     for (const auto& command_buffer : submit_info.command_buffers()) {
       return command_buffer;

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
@@ -22,7 +22,7 @@ class CaptureEventProcessor {
   explicit CaptureEventProcessor(CaptureListener* capture_listener)
       : capture_listener_(capture_listener) {}
 
-  void ProcessEvent(const orbit_grpc_protos::CaptureEvent& event);
+  void ProcessEvent(const orbit_grpc_protos::ClientCaptureEvent& event);
 
   template <typename Iterable>
   void ProcessEvents(const Iterable& events) {
@@ -34,7 +34,7 @@ class CaptureEventProcessor {
  private:
   void ProcessSchedulingSlice(const orbit_grpc_protos::SchedulingSlice& scheduling_slice);
   void ProcessInternedCallstack(orbit_grpc_protos::InternedCallstack interned_callstack);
-  void ProcessCallstackSample(const orbit_grpc_protos::CallstackSample& callstack_sample);
+  void ProcessCallstackSample(const orbit_grpc_protos::InternedCallstackSample& callstack_sample);
   void ProcessFunctionCall(const orbit_grpc_protos::FunctionCall& function_call);
   void ProcessIntrospectionScope(const orbit_grpc_protos::IntrospectionScope& introspection_scope);
   void ProcessInternedString(orbit_grpc_protos::InternedString interned_string);

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
@@ -44,12 +44,11 @@ class CaptureEventProcessor {
   void ProcessAddressInfo(const orbit_grpc_protos::AddressInfo& address_info);
   void ProcessInternedTracepointInfo(
       orbit_grpc_protos::InternedTracepointInfo interned_tracepoint_info);
-  void ProcessTracepointEvent(const orbit_grpc_protos::TracepointEvent& tracepoint_event);
+  void ProcessTracepointEvent(const orbit_grpc_protos::InternedTracepointEvent& tracepoint_event);
   void ProcessGpuQueueSubmission(const orbit_grpc_protos::GpuQueueSubmission& gpu_command_buffer);
 
   absl::flat_hash_map<uint64_t, orbit_grpc_protos::Callstack> callstack_intern_pool;
   absl::flat_hash_map<uint64_t, std::string> string_intern_pool_;
-  absl::flat_hash_map<uint64_t, orbit_grpc_protos::TracepointInfo> tracepoint_intern_pool_;
   CaptureListener* capture_listener_ = nullptr;
 
   absl::flat_hash_set<uint64_t> callstack_hashes_seen_;
@@ -57,9 +56,6 @@ class CaptureEventProcessor {
                                           const orbit_grpc_protos::Callstack& callstack);
   absl::flat_hash_set<uint64_t> string_hashes_seen_;
   uint64_t GetStringHashAndSendToListenerIfNecessary(const std::string& str);
-  absl::flat_hash_set<uint64_t> tracepoint_hashes_seen_;
-  void SendTracepointInfoToListenerIfNecessary(
-      const orbit_grpc_protos::TracepointInfo& tracepoint_info, const uint64_t& hash);
 
   GpuQueueSubmissionProcessor gpu_queue_submission_processor_;
 };

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
@@ -38,7 +38,7 @@ class CaptureEventProcessor {
   void ProcessFunctionCall(const orbit_grpc_protos::FunctionCall& function_call);
   void ProcessIntrospectionScope(const orbit_grpc_protos::IntrospectionScope& introspection_scope);
   void ProcessInternedString(orbit_grpc_protos::InternedString interned_string);
-  void ProcessGpuJob(const orbit_grpc_protos::GpuJob& gpu_job);
+  void ProcessInternedGpuJobEvent(const orbit_grpc_protos::InternedGpuJobEvent& gpu_job);
   void ProcessThreadName(const orbit_grpc_protos::ThreadName& thread_name);
   void ProcessThreadStateSlice(const orbit_grpc_protos::ThreadStateSlice& thread_state_slice);
   void ProcessAddressInfo(const orbit_grpc_protos::AddressInfo& address_info);

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
@@ -41,7 +41,8 @@ class CaptureEventProcessor {
   void ProcessInternedGpuJobEvent(const orbit_grpc_protos::InternedGpuJobEvent& gpu_job);
   void ProcessThreadName(const orbit_grpc_protos::ThreadName& thread_name);
   void ProcessThreadStateSlice(const orbit_grpc_protos::ThreadStateSlice& thread_state_slice);
-  void ProcessAddressInfo(const orbit_grpc_protos::AddressInfo& address_info);
+  void ProcessInternedAddressInfo(
+      const orbit_grpc_protos::InternedAddressInfo& interned_address_info);
   void ProcessInternedTracepointInfo(
       orbit_grpc_protos::InternedTracepointInfo interned_tracepoint_info);
   void ProcessTracepointEvent(const orbit_grpc_protos::InternedTracepointEvent& tracepoint_event);

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
@@ -34,18 +34,17 @@ class CaptureEventProcessor {
  private:
   void ProcessSchedulingSlice(const orbit_grpc_protos::SchedulingSlice& scheduling_slice);
   void ProcessInternedCallstack(orbit_grpc_protos::InternedCallstack interned_callstack);
-  void ProcessCallstackSample(const orbit_grpc_protos::InternedCallstackSample& callstack_sample);
+  void ProcessCallstackSample(const orbit_grpc_protos::CallstackSample& callstack_sample);
   void ProcessFunctionCall(const orbit_grpc_protos::FunctionCall& function_call);
   void ProcessIntrospectionScope(const orbit_grpc_protos::IntrospectionScope& introspection_scope);
   void ProcessInternedString(orbit_grpc_protos::InternedString interned_string);
-  void ProcessInternedGpuJobEvent(const orbit_grpc_protos::InternedGpuJobEvent& gpu_job);
+  void ProcessGpuJob(const orbit_grpc_protos::GpuJob& gpu_job);
   void ProcessThreadName(const orbit_grpc_protos::ThreadName& thread_name);
   void ProcessThreadStateSlice(const orbit_grpc_protos::ThreadStateSlice& thread_state_slice);
-  void ProcessInternedAddressInfo(
-      const orbit_grpc_protos::InternedAddressInfo& interned_address_info);
+  void ProcessAddressInfo(const orbit_grpc_protos::AddressInfo& address_info);
   void ProcessInternedTracepointInfo(
       orbit_grpc_protos::InternedTracepointInfo interned_tracepoint_info);
-  void ProcessTracepointEvent(const orbit_grpc_protos::InternedTracepointEvent& tracepoint_event);
+  void ProcessTracepointEvent(const orbit_grpc_protos::TracepointEvent& tracepoint_event);
   void ProcessGpuQueueSubmission(const orbit_grpc_protos::GpuQueueSubmission& gpu_command_buffer);
 
   absl::flat_hash_map<uint64_t, orbit_grpc_protos::Callstack> callstack_intern_pool;

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/GpuQueueSubmissionProcessor.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/GpuQueueSubmissionProcessor.h
@@ -45,7 +45,7 @@ class GpuQueueSubmissionProcessor {
   // `TimerInfo`s. Otherwise, it returns an empty vector and stores the `GpuJob for later
   // processing.
   [[nodiscard]] std::vector<orbit_client_protos::TimerInfo> ProcessGpuJob(
-      const orbit_grpc_protos::GpuJob& gpu_job,
+      const orbit_grpc_protos::InternedGpuJobEvent& gpu_job,
       const absl::flat_hash_map<uint64_t, std::string>& string_intern_pool,
       const std::function<uint64_t(const std::string& str)>&
           get_string_hash_and_send_to_listener_if_necessary);
@@ -61,14 +61,14 @@ class GpuQueueSubmissionProcessor {
   [[nodiscard]] std::vector<orbit_client_protos::TimerInfo>
   ProcessGpuQueueSubmissionWithMatchingGpuJob(
       const orbit_grpc_protos::GpuQueueSubmission& gpu_queue_submission,
-      const orbit_grpc_protos::GpuJob& matching_gpu_job,
+      const orbit_grpc_protos::InternedGpuJobEvent& matching_gpu_job,
       const absl::flat_hash_map<uint64_t, std::string>& string_intern_pool,
       const std::function<uint64_t(const std::string& str)>&
           get_string_hash_and_send_to_listener_if_necessary);
 
   [[nodiscard]] std::vector<orbit_client_protos::TimerInfo> ProcessGpuCommandBuffers(
       const orbit_grpc_protos::GpuQueueSubmission& gpu_queue_submission,
-      const orbit_grpc_protos::GpuJob& matching_gpu_job,
+      const orbit_grpc_protos::InternedGpuJobEvent& matching_gpu_job,
       const std::optional<orbit_grpc_protos::GpuCommandBuffer>& first_command_buffer,
       uint64_t timeline_hash,
       const std::function<uint64_t(const std::string& str)>&
@@ -76,10 +76,9 @@ class GpuQueueSubmissionProcessor {
 
   [[nodiscard]] std::vector<orbit_client_protos::TimerInfo> ProcessGpuDebugMarkers(
       const orbit_grpc_protos::GpuQueueSubmission& gpu_queue_submission,
-      const orbit_grpc_protos::GpuJob& matching_gpu_job,
+      const orbit_grpc_protos::InternedGpuJobEvent& matching_gpu_job,
       const std::optional<orbit_grpc_protos::GpuCommandBuffer>& first_command_buffer,
       const std::string& timeline,
-      const absl::flat_hash_map<uint64_t, std::string>& string_intern_pool,
       const std::function<uint64_t(const std::string& str)>&
           get_string_hash_and_send_to_listener_if_necessary);
 
@@ -88,7 +87,7 @@ class GpuQueueSubmissionProcessor {
 
   // Finds the GpuJob that is fully inside the given timestamps and happened on the given thread id.
   // Returns `nullptr` if there is no such job.
-  [[nodiscard]] const orbit_grpc_protos::GpuJob* FindMatchingGpuJob(
+  [[nodiscard]] const orbit_grpc_protos::InternedGpuJobEvent* FindMatchingGpuJob(
       int32_t thread_id, uint64_t pre_submission_cpu_timestamp,
       uint64_t post_submission_cpu_timestamp);
 
@@ -107,7 +106,7 @@ class GpuQueueSubmissionProcessor {
 
   void DeleteSavedGpuSubmission(int32_t thread_id, uint64_t post_submission_timestamp);
 
-  absl::node_hash_map<int32_t, std::map<uint64_t, orbit_grpc_protos::GpuJob>>
+  absl::node_hash_map<int32_t, std::map<uint64_t, orbit_grpc_protos::InternedGpuJobEvent>>
       tid_to_submission_time_to_gpu_job_;
   absl::node_hash_map<int32_t, std::map<uint64_t, orbit_grpc_protos::GpuQueueSubmission>>
       tid_to_post_submission_time_to_gpu_submission_;

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/GpuQueueSubmissionProcessor.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/GpuQueueSubmissionProcessor.h
@@ -45,7 +45,7 @@ class GpuQueueSubmissionProcessor {
   // `TimerInfo`s. Otherwise, it returns an empty vector and stores the `GpuJob for later
   // processing.
   [[nodiscard]] std::vector<orbit_client_protos::TimerInfo> ProcessGpuJob(
-      const orbit_grpc_protos::InternedGpuJobEvent& gpu_job,
+      const orbit_grpc_protos::GpuJob& gpu_job,
       const absl::flat_hash_map<uint64_t, std::string>& string_intern_pool,
       const std::function<uint64_t(const std::string& str)>&
           get_string_hash_and_send_to_listener_if_necessary);
@@ -61,14 +61,14 @@ class GpuQueueSubmissionProcessor {
   [[nodiscard]] std::vector<orbit_client_protos::TimerInfo>
   ProcessGpuQueueSubmissionWithMatchingGpuJob(
       const orbit_grpc_protos::GpuQueueSubmission& gpu_queue_submission,
-      const orbit_grpc_protos::InternedGpuJobEvent& matching_gpu_job,
+      const orbit_grpc_protos::GpuJob& matching_gpu_job,
       const absl::flat_hash_map<uint64_t, std::string>& string_intern_pool,
       const std::function<uint64_t(const std::string& str)>&
           get_string_hash_and_send_to_listener_if_necessary);
 
   [[nodiscard]] std::vector<orbit_client_protos::TimerInfo> ProcessGpuCommandBuffers(
       const orbit_grpc_protos::GpuQueueSubmission& gpu_queue_submission,
-      const orbit_grpc_protos::InternedGpuJobEvent& matching_gpu_job,
+      const orbit_grpc_protos::GpuJob& matching_gpu_job,
       const std::optional<orbit_grpc_protos::GpuCommandBuffer>& first_command_buffer,
       uint64_t timeline_hash,
       const std::function<uint64_t(const std::string& str)>&
@@ -76,7 +76,7 @@ class GpuQueueSubmissionProcessor {
 
   [[nodiscard]] std::vector<orbit_client_protos::TimerInfo> ProcessGpuDebugMarkers(
       const orbit_grpc_protos::GpuQueueSubmission& gpu_queue_submission,
-      const orbit_grpc_protos::InternedGpuJobEvent& matching_gpu_job,
+      const orbit_grpc_protos::GpuJob& matching_gpu_job,
       const std::optional<orbit_grpc_protos::GpuCommandBuffer>& first_command_buffer,
       const std::string& timeline,
       const std::function<uint64_t(const std::string& str)>&
@@ -87,7 +87,7 @@ class GpuQueueSubmissionProcessor {
 
   // Finds the GpuJob that is fully inside the given timestamps and happened on the given thread id.
   // Returns `nullptr` if there is no such job.
-  [[nodiscard]] const orbit_grpc_protos::InternedGpuJobEvent* FindMatchingGpuJob(
+  [[nodiscard]] const orbit_grpc_protos::GpuJob* FindMatchingGpuJob(
       int32_t thread_id, uint64_t pre_submission_cpu_timestamp,
       uint64_t post_submission_cpu_timestamp);
 
@@ -106,7 +106,7 @@ class GpuQueueSubmissionProcessor {
 
   void DeleteSavedGpuSubmission(int32_t thread_id, uint64_t post_submission_timestamp);
 
-  absl::node_hash_map<int32_t, std::map<uint64_t, orbit_grpc_protos::InternedGpuJobEvent>>
+  absl::node_hash_map<int32_t, std::map<uint64_t, orbit_grpc_protos::GpuJob>>
       tid_to_submission_time_to_gpu_job_;
   absl::node_hash_map<int32_t, std::map<uint64_t, orbit_grpc_protos::GpuQueueSubmission>>
       tid_to_post_submission_time_to_gpu_submission_;

--- a/src/OrbitProducer/LockFreeBufferCaptureEventProducerTest.cpp
+++ b/src/OrbitProducer/LockFreeBufferCaptureEventProducerTest.cpp
@@ -28,9 +28,9 @@ namespace {
 class LockFreeBufferCaptureEventProducerImpl
     : public LockFreeBufferCaptureEventProducer<std::string> {
  protected:
-  orbit_grpc_protos::CaptureEvent TranslateIntermediateEvent(
+  orbit_grpc_protos::ProducerCaptureEvent TranslateIntermediateEvent(
       std::string&& /*intermediate_event*/) override {
-    return orbit_grpc_protos::CaptureEvent{};
+    return orbit_grpc_protos::ProducerCaptureEvent{};
   }
 };
 
@@ -94,7 +94,7 @@ TEST_F(LockFreeBufferCaptureEventProducerTest, EnqueueIntermediateEventIfCapturi
   int32_t capture_events_received_count = 0;
   ON_CALL(*fake_service_, OnCaptureEventsReceived)
       .WillByDefault([&capture_events_received_count](
-                         const std::vector<orbit_grpc_protos::CaptureEvent>& events) {
+                         const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events) {
         capture_events_received_count += events.size();
       });
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived).Times(::testing::Between(1, 3));
@@ -146,7 +146,7 @@ TEST_F(LockFreeBufferCaptureEventProducerTest, EnqueueIntermediateEvent) {
   int32_t capture_events_received_count = 0;
   ON_CALL(*fake_service_, OnCaptureEventsReceived)
       .WillByDefault([&capture_events_received_count](
-                         const std::vector<orbit_grpc_protos::CaptureEvent>& events) {
+                         const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events) {
         capture_events_received_count += events.size();
       });
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived).Times(::testing::Between(1, 3));
@@ -202,7 +202,7 @@ TEST_F(LockFreeBufferCaptureEventProducerTest, DuplicatedCommands) {
   int32_t capture_events_received_count = 0;
   ON_CALL(*fake_service_, OnCaptureEventsReceived)
       .WillByDefault([&capture_events_received_count](
-                         const std::vector<orbit_grpc_protos::CaptureEvent>& events) {
+                         const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events) {
         capture_events_received_count += events.size();
       });
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived).Times(::testing::Between(1, 3));
@@ -303,7 +303,7 @@ TEST_F(LockFreeBufferCaptureEventProducerTest, ServiceDisconnects) {
   int32_t capture_events_received_count = 0;
   ON_CALL(*fake_service_, OnCaptureEventsReceived)
       .WillByDefault([&capture_events_received_count](
-                         const std::vector<orbit_grpc_protos::CaptureEvent>& events) {
+                         const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events) {
         capture_events_received_count += events.size();
       });
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived).Times(::testing::Between(1, 3));
@@ -343,7 +343,7 @@ TEST_F(LockFreeBufferCaptureEventProducerTest, DisconnectAndReconnect) {
   int32_t capture_events_received_count = 0;
   ON_CALL(*fake_service_, OnCaptureEventsReceived)
       .WillByDefault([&capture_events_received_count](
-                         const std::vector<orbit_grpc_protos::CaptureEvent>& events) {
+                         const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events) {
         capture_events_received_count += events.size();
       });
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived).Times(::testing::Between(1, 3));

--- a/src/OrbitProducer/include/OrbitProducer/FakeProducerSideService.h
+++ b/src/OrbitProducer/include/OrbitProducer/FakeProducerSideService.h
@@ -32,7 +32,7 @@ class FakeProducerSideService : public orbit_grpc_protos::ProducerSideService::S
                 orbit_grpc_protos::ReceiveCommandsAndSendEventsRequest::EVENT_NOT_SET);
       switch (request.event_case()) {
         case orbit_grpc_protos::ReceiveCommandsAndSendEventsRequest::kBufferedCaptureEvents: {
-          std::vector<orbit_grpc_protos::CaptureEvent> capture_events_received{
+          std::vector<orbit_grpc_protos::ProducerCaptureEvent> capture_events_received{
               request.buffered_capture_events().capture_events().begin(),
               request.buffered_capture_events().capture_events().end()};
           OnCaptureEventsReceived(capture_events_received);
@@ -88,7 +88,7 @@ class FakeProducerSideService : public orbit_grpc_protos::ProducerSideService::S
   void ReAllowRpc() { rpc_allowed_ = true; }
 
   MOCK_METHOD(void, OnCaptureEventsReceived,
-              (const std::vector<orbit_grpc_protos::CaptureEvent>& events), ());
+              (const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events), ());
   MOCK_METHOD(void, OnAllEventsSentReceived, (), ());
 
  private:

--- a/src/OrbitProducer/include/OrbitProducer/LockFreeBufferCaptureEventProducer.h
+++ b/src/OrbitProducer/include/OrbitProducer/LockFreeBufferCaptureEventProducer.h
@@ -76,7 +76,7 @@ class LockFreeBufferCaptureEventProducer : public CaptureEventProducer {
 
   // Subclasses need to implement this method to convert an IntermediateEventT enqueued
   // in the internal lock-free buffer to a CaptureEvent to be sent to ProducerSideService.
-  [[nodiscard]] virtual orbit_grpc_protos::CaptureEvent TranslateIntermediateEvent(
+  [[nodiscard]] virtual orbit_grpc_protos::ProducerCaptureEvent TranslateIntermediateEvent(
       IntermediateEventT&& intermediate_event) = 0;
 
  private:
@@ -106,7 +106,7 @@ class LockFreeBufferCaptureEventProducer : public CaptureEventProducer {
           auto* capture_events =
               send_request.mutable_buffered_capture_events()->mutable_capture_events();
           for (size_t i = 0; i < dequeued_event_count; ++i) {
-            orbit_grpc_protos::CaptureEvent* event = capture_events->Add();
+            orbit_grpc_protos::ProducerCaptureEvent* event = capture_events->Add();
             *event = TranslateIntermediateEvent(std::move(dequeued_events[i]));
           }
           if (!SendCaptureEvents(send_request)) {

--- a/src/OrbitVulkanLayer/SubmissionTracker.h
+++ b/src/OrbitVulkanLayer/SubmissionTracker.h
@@ -481,7 +481,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
 
     std::vector<uint32_t> query_slots_to_reset = {};
     for (const auto& completed_submission : completed_submissions) {
-      orbit_grpc_protos::CaptureEvent capture_event;
+      orbit_grpc_protos::ProducerCaptureEvent capture_event;
       orbit_grpc_protos::GpuQueueSubmission* submission_proto =
           capture_event.mutable_gpu_queue_submission();
       WriteMetaInfo(completed_submission.meta_information, submission_proto->mutable_meta_info());

--- a/src/OrbitVulkanLayer/SubmissionTrackerTest.cpp
+++ b/src/OrbitVulkanLayer/SubmissionTrackerTest.cpp
@@ -45,7 +45,7 @@ class MockVulkanLayerProducer : public VulkanLayerProducer {
  public:
   MOCK_METHOD(bool, IsCapturing, (), (override));
   MOCK_METHOD(uint64_t, InternStringIfNecessaryAndGetKey, (std::string), (override));
-  MOCK_METHOD(bool, EnqueueCaptureEvent, (orbit_grpc_protos::CaptureEvent && capture_event),
+  MOCK_METHOD(bool, EnqueueCaptureEvent, (orbit_grpc_protos::ProducerCaptureEvent && capture_event),
               (override));
 
   MOCK_METHOD(void, BringUp, (const std::shared_ptr<grpc::Channel>& channel), (override));
@@ -218,8 +218,8 @@ class SubmissionTrackerTest : public ::testing::Test {
           VkQueryResultFlags /*flags*/) -> VkResult { return VK_NOT_READY; };
 
   static void ExpectSingleCommandBufferSubmissionEq(
-      const orbit_grpc_protos::CaptureEvent& actual_capture_event, uint64_t test_pre_submit_time,
-      uint64_t test_post_submit_time, pid_t expected_tid,
+      const orbit_grpc_protos::ProducerCaptureEvent& actual_capture_event,
+      uint64_t test_pre_submit_time, uint64_t test_post_submit_time, pid_t expected_tid,
       uint64_t expected_command_buffer_begin_timestamp,
       uint64_t expected_command_buffer_end_timestamp) {
     EXPECT_TRUE(actual_capture_event.has_gpu_queue_submission());
@@ -467,9 +467,9 @@ TEST_F(SubmissionTrackerTest, CanRetrieveCommandBufferTimestampsForACompleteSubm
   EXPECT_CALL(timer_query_pool_, ResetQuerySlots)
       .Times(1)
       .WillOnce(SaveArg<1>(&actual_reset_slots));
-  orbit_grpc_protos::CaptureEvent actual_capture_event;
+  orbit_grpc_protos::ProducerCaptureEvent actual_capture_event;
   auto mock_enqueue_capture_event =
-      [&actual_capture_event](orbit_grpc_protos::CaptureEvent&& capture_event) {
+      [&actual_capture_event](orbit_grpc_protos::ProducerCaptureEvent&& capture_event) {
         actual_capture_event = std::move(capture_event);
         return true;
       };
@@ -504,9 +504,9 @@ TEST_F(SubmissionTrackerTest,
   EXPECT_CALL(timer_query_pool_, ResetQuerySlots)
       .Times(1)
       .WillOnce(SaveArg<1>(&actual_reset_slots));
-  orbit_grpc_protos::CaptureEvent actual_capture_event;
+  orbit_grpc_protos::ProducerCaptureEvent actual_capture_event;
   auto mock_enqueue_capture_event =
-      [&actual_capture_event](orbit_grpc_protos::CaptureEvent&& capture_event) {
+      [&actual_capture_event](orbit_grpc_protos::ProducerCaptureEvent&& capture_event) {
         actual_capture_event = std::move(capture_event);
         return true;
       };
@@ -564,9 +564,9 @@ TEST_F(SubmissionTrackerTest,
   EXPECT_CALL(timer_query_pool_, ResetQuerySlots)
       .Times(1)
       .WillOnce(SaveArg<1>(&actual_reset_slots));
-  orbit_grpc_protos::CaptureEvent actual_capture_event;
+  orbit_grpc_protos::ProducerCaptureEvent actual_capture_event;
   auto mock_enqueue_capture_event =
-      [&actual_capture_event](orbit_grpc_protos::CaptureEvent&& capture_event) {
+      [&actual_capture_event](orbit_grpc_protos::ProducerCaptureEvent&& capture_event) {
         actual_capture_event = std::move(capture_event);
         return true;
       };
@@ -600,9 +600,9 @@ TEST_F(SubmissionTrackerTest, StopCaptureDuringSubmissionWillStillYieldResults) 
   EXPECT_CALL(timer_query_pool_, ResetQuerySlots)
       .Times(1)
       .WillOnce(SaveArg<1>(&actual_reset_slots));
-  orbit_grpc_protos::CaptureEvent actual_capture_event;
+  orbit_grpc_protos::ProducerCaptureEvent actual_capture_event;
   auto mock_enqueue_capture_event =
-      [&actual_capture_event](orbit_grpc_protos::CaptureEvent&& capture_event) {
+      [&actual_capture_event](orbit_grpc_protos::ProducerCaptureEvent&& capture_event) {
         actual_capture_event = std::move(capture_event);
         return true;
       };
@@ -676,9 +676,9 @@ TEST_F(SubmissionTrackerTest, MultipleSubmissionsWontBeOutOfOrder) {
   };
   EXPECT_CALL(timer_query_pool_, ResetQuerySlots).WillRepeatedly(Invoke(fake_reset_query_slots));
 
-  std::vector<orbit_grpc_protos::CaptureEvent> actual_capture_events;
+  std::vector<orbit_grpc_protos::ProducerCaptureEvent> actual_capture_events;
   auto fake_enqueue_capture_event =
-      [&actual_capture_events](orbit_grpc_protos::CaptureEvent&& capture_event) {
+      [&actual_capture_events](orbit_grpc_protos::ProducerCaptureEvent&& capture_event) {
         actual_capture_events.emplace_back(std::move(capture_event));
         return true;
       };
@@ -855,9 +855,9 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerTimestampsForACompleteSubmis
   EXPECT_CALL(timer_query_pool_, ResetQuerySlots)
       .Times(1)
       .WillOnce(SaveArg<1>(&actual_reset_slots));
-  orbit_grpc_protos::CaptureEvent actual_capture_event;
+  orbit_grpc_protos::ProducerCaptureEvent actual_capture_event;
   auto mock_enqueue_capture_event =
-      [&actual_capture_event](orbit_grpc_protos::CaptureEvent&& capture_event) {
+      [&actual_capture_event](orbit_grpc_protos::ProducerCaptureEvent&& capture_event) {
         actual_capture_event = std::move(capture_event);
         return true;
       };
@@ -914,9 +914,9 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerEndEvenWhenBeginNotCaptured)
   EXPECT_CALL(timer_query_pool_, ResetQuerySlots)
       .Times(1)
       .WillOnce(SaveArg<1>(&actual_reset_slots));
-  orbit_grpc_protos::CaptureEvent actual_capture_event;
+  orbit_grpc_protos::ProducerCaptureEvent actual_capture_event;
   auto mock_enqueue_capture_event =
-      [&actual_capture_event](orbit_grpc_protos::CaptureEvent&& capture_event) {
+      [&actual_capture_event](orbit_grpc_protos::ProducerCaptureEvent&& capture_event) {
         actual_capture_event = std::move(capture_event);
         return true;
       };
@@ -968,9 +968,9 @@ TEST_F(SubmissionTrackerTest, CanRetrieveNestedDebugMarkerTimestampsForAComplete
   EXPECT_CALL(timer_query_pool_, ResetQuerySlots)
       .Times(1)
       .WillOnce(SaveArg<1>(&actual_reset_slots));
-  orbit_grpc_protos::CaptureEvent actual_capture_event;
+  orbit_grpc_protos::ProducerCaptureEvent actual_capture_event;
   auto mock_enqueue_capture_event =
-      [&actual_capture_event](orbit_grpc_protos::CaptureEvent&& capture_event) {
+      [&actual_capture_event](orbit_grpc_protos::ProducerCaptureEvent&& capture_event) {
         actual_capture_event = std::move(capture_event);
         return true;
       };
@@ -1045,9 +1045,9 @@ TEST_F(SubmissionTrackerTest,
   EXPECT_CALL(timer_query_pool_, ResetQuerySlots)
       .Times(1)
       .WillOnce(SaveArg<1>(&actual_reset_slots));
-  orbit_grpc_protos::CaptureEvent actual_capture_event;
+  orbit_grpc_protos::ProducerCaptureEvent actual_capture_event;
   auto mock_enqueue_capture_event =
-      [&actual_capture_event](orbit_grpc_protos::CaptureEvent&& capture_event) {
+      [&actual_capture_event](orbit_grpc_protos::ProducerCaptureEvent&& capture_event) {
         actual_capture_event = std::move(capture_event);
         return true;
       };
@@ -1122,9 +1122,9 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerAcrossTwoSubmissions) {
       .Times(2)
       .WillOnce(SaveArg<1>(&actual_reset_slots_1))
       .WillOnce(SaveArg<1>(&actual_reset_slots_2));
-  std::vector<orbit_grpc_protos::CaptureEvent> actual_capture_events;
+  std::vector<orbit_grpc_protos::ProducerCaptureEvent> actual_capture_events;
   auto mock_enqueue_capture_event =
-      [&actual_capture_events](orbit_grpc_protos::CaptureEvent&& capture_event) {
+      [&actual_capture_events](orbit_grpc_protos::ProducerCaptureEvent&& capture_event) {
         actual_capture_events.emplace_back(std::move(capture_event));
         return true;
       };
@@ -1171,14 +1171,16 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerAcrossTwoSubmissions) {
               UnorderedElementsAre(kSlotIndex2, kSlotIndex4, kSlotIndex5, kSlotIndex6));
   ASSERT_EQ(actual_capture_events.size(), 2);
 
-  const orbit_grpc_protos::CaptureEvent& actual_capture_event_1 = actual_capture_events.at(0);
+  const orbit_grpc_protos::ProducerCaptureEvent& actual_capture_event_1 =
+      actual_capture_events.at(0);
   EXPECT_TRUE(actual_capture_event_1.has_gpu_queue_submission());
   const orbit_grpc_protos::GpuQueueSubmission& actual_queue_submission_1 =
       actual_capture_event_1.gpu_queue_submission();
   EXPECT_EQ(actual_queue_submission_1.num_begin_markers(), 1);
   EXPECT_EQ(actual_queue_submission_1.completed_markers_size(), 0);
 
-  const orbit_grpc_protos::CaptureEvent& actual_capture_event_2 = actual_capture_events.at(1);
+  const orbit_grpc_protos::ProducerCaptureEvent& actual_capture_event_2 =
+      actual_capture_events.at(1);
   EXPECT_TRUE(actual_capture_event_2.has_gpu_queue_submission());
   const orbit_grpc_protos::GpuQueueSubmission& actual_queue_submission_2 =
       actual_capture_event_2.gpu_queue_submission();
@@ -1202,9 +1204,9 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerAcrossTwoSubmissionsEvenWhen
       .Times(2)
       .WillOnce(SaveArg<1>(&actual_reset_slots_1))
       .WillOnce(SaveArg<1>(&actual_reset_slots_2));
-  std::vector<orbit_grpc_protos::CaptureEvent> actual_capture_events;
+  std::vector<orbit_grpc_protos::ProducerCaptureEvent> actual_capture_events;
   auto mock_enqueue_capture_event =
-      [&actual_capture_events](orbit_grpc_protos::CaptureEvent&& capture_event) {
+      [&actual_capture_events](orbit_grpc_protos::ProducerCaptureEvent&& capture_event) {
         actual_capture_events.emplace_back(std::move(capture_event));
         return true;
       };
@@ -1246,14 +1248,16 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerAcrossTwoSubmissionsEvenWhen
   EXPECT_THAT(actual_reset_slots_2, UnorderedElementsAre(kSlotIndex2, kSlotIndex3, kSlotIndex4));
   ASSERT_EQ(actual_capture_events.size(), 2);
 
-  const orbit_grpc_protos::CaptureEvent& actual_capture_event_1 = actual_capture_events.at(0);
+  const orbit_grpc_protos::ProducerCaptureEvent& actual_capture_event_1 =
+      actual_capture_events.at(0);
   EXPECT_TRUE(actual_capture_event_1.has_gpu_queue_submission());
   const orbit_grpc_protos::GpuQueueSubmission& actual_queue_submission_1 =
       actual_capture_event_1.gpu_queue_submission();
   EXPECT_EQ(actual_queue_submission_1.num_begin_markers(), 0);
   EXPECT_EQ(actual_queue_submission_1.completed_markers_size(), 0);
 
-  const orbit_grpc_protos::CaptureEvent& actual_capture_event_2 = actual_capture_events.at(1);
+  const orbit_grpc_protos::ProducerCaptureEvent& actual_capture_event_2 =
+      actual_capture_events.at(1);
   EXPECT_TRUE(actual_capture_event_2.has_gpu_queue_submission());
   const orbit_grpc_protos::GpuQueueSubmission& actual_queue_submission_2 =
       actual_capture_event_2.gpu_queue_submission();
@@ -1276,9 +1280,9 @@ TEST_F(SubmissionTrackerTest, ResetSlotsOnDebugMarkerAcrossTwoSubmissionsWhenEnd
       .Times(2)
       .WillOnce(SaveArg<1>(&actual_reset_slots_1))
       .WillOnce(SaveArg<1>(&actual_reset_slots_2));
-  orbit_grpc_protos::CaptureEvent actual_capture_event;
+  orbit_grpc_protos::ProducerCaptureEvent actual_capture_event;
   auto mock_enqueue_capture_event =
-      [&actual_capture_event](orbit_grpc_protos::CaptureEvent&& capture_event) {
+      [&actual_capture_event](orbit_grpc_protos::ProducerCaptureEvent&& capture_event) {
         actual_capture_event = std::move(capture_event);
         return true;
       };
@@ -1359,9 +1363,9 @@ TEST_F(SubmissionTrackerTest, CanLimitNestedDebugMarkerDepthPerCommandBuffer) {
   EXPECT_CALL(timer_query_pool_, ResetQuerySlots)
       .Times(1)
       .WillOnce(SaveArg<1>(&actual_reset_slots));
-  orbit_grpc_protos::CaptureEvent actual_capture_event;
+  orbit_grpc_protos::ProducerCaptureEvent actual_capture_event;
   auto mock_enqueue_capture_event =
-      [&actual_capture_event](orbit_grpc_protos::CaptureEvent&& capture_event) {
+      [&actual_capture_event](orbit_grpc_protos::ProducerCaptureEvent&& capture_event) {
         actual_capture_event = std::move(capture_event);
         return true;
       };
@@ -1430,9 +1434,9 @@ TEST_F(SubmissionTrackerTest, CanLimitNestedDebugMarkerDepthPerCommandBufferAcro
   };
   EXPECT_CALL(timer_query_pool_, ResetQuerySlots).WillRepeatedly(Invoke(mock_reset_query_slots));
 
-  std::vector<orbit_grpc_protos::CaptureEvent> actual_capture_events;
+  std::vector<orbit_grpc_protos::ProducerCaptureEvent> actual_capture_events;
   auto mock_enqueue_capture_event =
-      [&actual_capture_events](orbit_grpc_protos::CaptureEvent&& capture_event) {
+      [&actual_capture_events](orbit_grpc_protos::ProducerCaptureEvent&& capture_event) {
         actual_capture_events.emplace_back(std::move(capture_event));
         return true;
       };
@@ -1484,14 +1488,16 @@ TEST_F(SubmissionTrackerTest, CanLimitNestedDebugMarkerDepthPerCommandBufferAcro
                                    kSlotIndex6, kSlotIndex7));
   ASSERT_EQ(actual_capture_events.size(), 2);
 
-  const orbit_grpc_protos::CaptureEvent& actual_capture_event_1 = actual_capture_events.at(0);
+  const orbit_grpc_protos::ProducerCaptureEvent& actual_capture_event_1 =
+      actual_capture_events.at(0);
   EXPECT_TRUE(actual_capture_event_1.has_gpu_queue_submission());
   const orbit_grpc_protos::GpuQueueSubmission& actual_queue_submission_1 =
       actual_capture_event_1.gpu_queue_submission();
   EXPECT_EQ(actual_queue_submission_1.num_begin_markers(), 1);
   EXPECT_EQ(actual_queue_submission_1.completed_markers_size(), 0);
 
-  const orbit_grpc_protos::CaptureEvent& actual_capture_event_2 = actual_capture_events.at(1);
+  const orbit_grpc_protos::ProducerCaptureEvent& actual_capture_event_2 =
+      actual_capture_events.at(1);
   EXPECT_TRUE(actual_capture_event_2.has_gpu_queue_submission());
   const orbit_grpc_protos::GpuQueueSubmission& actual_queue_submission_2 =
       actual_capture_event_2.gpu_queue_submission();

--- a/src/OrbitVulkanLayer/VulkanLayerProducer.h
+++ b/src/OrbitVulkanLayer/VulkanLayerProducer.h
@@ -32,7 +32,7 @@ class VulkanLayerProducer {
   // Returns true if the event was enqueued as the capture is in progress, false otherwise.
   // Callers can use the return value to check if the event was actually enqueued as the capture
   // is in progress.
-  virtual bool EnqueueCaptureEvent(orbit_grpc_protos::CaptureEvent&& capture_event) = 0;
+  virtual bool EnqueueCaptureEvent(orbit_grpc_protos::ProducerCaptureEvent&& capture_event) = 0;
 
   // This method enqueues an InternedString to be sent to OrbitService the first time the string
   // passed as argument is seen. In all cases, it returns the key corresponding to the string.

--- a/src/OrbitVulkanLayer/VulkanLayerProducerImpl.cpp
+++ b/src/OrbitVulkanLayer/VulkanLayerProducerImpl.cpp
@@ -15,7 +15,7 @@ uint64_t VulkanLayerProducerImpl::InternStringIfNecessaryAndGetKey(std::string s
       return key;
     }
 
-    orbit_grpc_protos::CaptureEvent event;
+    orbit_grpc_protos::ProducerCaptureEvent event;
     event.mutable_interned_string()->set_key(key);
     event.mutable_interned_string()->set_intern(std::move(str));
     if (!EnqueueCaptureEvent(std::move(event))) {

--- a/src/OrbitVulkanLayer/VulkanLayerProducerImpl.h
+++ b/src/OrbitVulkanLayer/VulkanLayerProducerImpl.h
@@ -24,7 +24,7 @@ class VulkanLayerProducerImpl : public VulkanLayerProducer {
 
   [[nodiscard]] bool IsCapturing() override { return lock_free_producer_.IsCapturing(); }
 
-  bool EnqueueCaptureEvent(orbit_grpc_protos::CaptureEvent&& capture_event) override {
+  bool EnqueueCaptureEvent(orbit_grpc_protos::ProducerCaptureEvent&& capture_event) override {
     return lock_free_producer_.EnqueueIntermediateEventIfCapturing(
         [&capture_event] { return capture_event; });
   }
@@ -35,7 +35,8 @@ class VulkanLayerProducerImpl : public VulkanLayerProducer {
 
  private:
   class LockFreeBufferVulkanLayerProducer
-      : public orbit_producer::LockFreeBufferCaptureEventProducer<orbit_grpc_protos::CaptureEvent> {
+      : public orbit_producer::LockFreeBufferCaptureEventProducer<
+            orbit_grpc_protos::ProducerCaptureEvent> {
    public:
     explicit LockFreeBufferVulkanLayerProducer(VulkanLayerProducerImpl* outer) : outer_{outer} {}
 
@@ -63,8 +64,8 @@ class VulkanLayerProducerImpl : public VulkanLayerProducer {
       outer_->ClearStringInternPool();
     }
 
-    orbit_grpc_protos::CaptureEvent TranslateIntermediateEvent(
-        orbit_grpc_protos::CaptureEvent&& intermediate_event) override {
+    orbit_grpc_protos::ProducerCaptureEvent TranslateIntermediateEvent(
+        orbit_grpc_protos::ProducerCaptureEvent&& intermediate_event) override {
       return std::move(intermediate_event);
     }
 

--- a/src/OrbitVulkanLayer/VulkanLayerProducerImplTest.cpp
+++ b/src/OrbitVulkanLayer/VulkanLayerProducerImplTest.cpp
@@ -170,7 +170,7 @@ TEST_F(VulkanLayerProducerImplTest, WorksWithNoListener) {
 TEST_F(VulkanLayerProducerImplTest, EnqueueCaptureEvent) {
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived).Times(0);
   EXPECT_CALL(*fake_service_, OnAllEventsSentReceived).Times(0);
-  EXPECT_FALSE(producer_->EnqueueCaptureEvent(orbit_grpc_protos::CaptureEvent()));
+  EXPECT_FALSE(producer_->EnqueueCaptureEvent(orbit_grpc_protos::ProducerCaptureEvent()));
   std::this_thread::sleep_for(kWaitMessagesSentDuration);
 
   ::testing::Mock::VerifyAndClearExpectations(&*fake_service_);
@@ -187,14 +187,14 @@ TEST_F(VulkanLayerProducerImplTest, EnqueueCaptureEvent) {
   int32_t capture_events_received_count = 0;
   ON_CALL(*fake_service_, OnCaptureEventsReceived)
       .WillByDefault([&capture_events_received_count](
-                         const std::vector<orbit_grpc_protos::CaptureEvent>& events) {
+                         const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events) {
         capture_events_received_count += events.size();
       });
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived).Times(::testing::Between(1, 3));
   EXPECT_CALL(*fake_service_, OnAllEventsSentReceived).Times(0);
-  EXPECT_TRUE(producer_->EnqueueCaptureEvent(orbit_grpc_protos::CaptureEvent()));
-  EXPECT_TRUE(producer_->EnqueueCaptureEvent(orbit_grpc_protos::CaptureEvent()));
-  EXPECT_TRUE(producer_->EnqueueCaptureEvent(orbit_grpc_protos::CaptureEvent()));
+  EXPECT_TRUE(producer_->EnqueueCaptureEvent(orbit_grpc_protos::ProducerCaptureEvent()));
+  EXPECT_TRUE(producer_->EnqueueCaptureEvent(orbit_grpc_protos::ProducerCaptureEvent()));
+  EXPECT_TRUE(producer_->EnqueueCaptureEvent(orbit_grpc_protos::ProducerCaptureEvent()));
   std::this_thread::sleep_for(kWaitMessagesSentDuration);
   EXPECT_EQ(capture_events_received_count, 3);
 
@@ -211,7 +211,7 @@ TEST_F(VulkanLayerProducerImplTest, EnqueueCaptureEvent) {
 
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived).Times(0);
   EXPECT_CALL(*fake_service_, OnAllEventsSentReceived).Times(0);
-  EXPECT_FALSE(producer_->EnqueueCaptureEvent(orbit_grpc_protos::CaptureEvent()));
+  EXPECT_FALSE(producer_->EnqueueCaptureEvent(orbit_grpc_protos::ProducerCaptureEvent()));
   std::this_thread::sleep_for(kWaitMessagesSentDuration);
 
   ::testing::Mock::VerifyAndClearExpectations(&*fake_service_);
@@ -227,15 +227,16 @@ TEST_F(VulkanLayerProducerImplTest, EnqueueCaptureEvent) {
 
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived).Times(0);
   EXPECT_CALL(*fake_service_, OnAllEventsSentReceived).Times(0);
-  EXPECT_FALSE(producer_->EnqueueCaptureEvent(orbit_grpc_protos::CaptureEvent()));
+  EXPECT_FALSE(producer_->EnqueueCaptureEvent(orbit_grpc_protos::ProducerCaptureEvent()));
 }
 
 static void ExpectInternedStrings(
-    const std::vector<orbit_grpc_protos::CaptureEvent>& actual_events,
+    const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& actual_events,
     const std::vector<std::pair<std::string, uint64_t>>& expected_interns) {
   ASSERT_EQ(actual_events.size(), expected_interns.size());
   for (size_t i = 0; i < actual_events.size(); ++i) {
-    ASSERT_EQ(actual_events[i].event_case(), orbit_grpc_protos::CaptureEvent::kInternedString);
+    ASSERT_EQ(actual_events[i].event_case(),
+              orbit_grpc_protos::ProducerCaptureEvent::kInternedString);
     EXPECT_EQ(actual_events[i].interned_string().intern(), expected_interns[i].first);
     EXPECT_EQ(actual_events[i].interned_string().key(), expected_interns[i].second);
   }
@@ -251,11 +252,11 @@ TEST_F(VulkanLayerProducerImplTest, InternStringIfNecessaryAndGetKey) {
   ::testing::Mock::VerifyAndClearExpectations(&mock_listener_);
   ::testing::Mock::VerifyAndClearExpectations(&*fake_service_);
 
-  std::vector<orbit_grpc_protos::CaptureEvent> events_received;
+  std::vector<orbit_grpc_protos::ProducerCaptureEvent> events_received;
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived)
       .Times(::testing::Between(1, 2))
       .WillRepeatedly(
-          [&events_received](const std::vector<orbit_grpc_protos::CaptureEvent>& events) {
+          [&events_received](const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events) {
             events_received.insert(events_received.end(), events.begin(), events.end());
           });
   EXPECT_CALL(*fake_service_, OnAllEventsSentReceived).Times(0);
@@ -314,11 +315,11 @@ TEST_F(VulkanLayerProducerImplTest, DontSendInternTwice) {
   ::testing::Mock::VerifyAndClearExpectations(&mock_listener_);
   ::testing::Mock::VerifyAndClearExpectations(&*fake_service_);
 
-  std::vector<orbit_grpc_protos::CaptureEvent> events_received;
+  std::vector<orbit_grpc_protos::ProducerCaptureEvent> events_received;
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived)
       .Times(1)
       .WillRepeatedly(
-          [&events_received](const std::vector<orbit_grpc_protos::CaptureEvent>& events) {
+          [&events_received](const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events) {
             events_received.insert(events_received.end(), events.begin(), events.end());
           });
   EXPECT_CALL(*fake_service_, OnAllEventsSentReceived).Times(0);
@@ -357,11 +358,11 @@ TEST_F(VulkanLayerProducerImplTest, ReInternInNewCapture) {
   ::testing::Mock::VerifyAndClearExpectations(&mock_listener_);
   ::testing::Mock::VerifyAndClearExpectations(&*fake_service_);
 
-  std::vector<orbit_grpc_protos::CaptureEvent> events_received;
+  std::vector<orbit_grpc_protos::ProducerCaptureEvent> events_received;
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived)
       .Times(::testing::Between(1, 2))
       .WillRepeatedly(
-          [&events_received](const std::vector<orbit_grpc_protos::CaptureEvent>& events) {
+          [&events_received](const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events) {
             events_received.insert(events_received.end(), events.begin(), events.end());
           });
   EXPECT_CALL(*fake_service_, OnAllEventsSentReceived).Times(0);
@@ -407,7 +408,7 @@ TEST_F(VulkanLayerProducerImplTest, ReInternInNewCapture) {
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived)
       .Times(::testing::Between(1, 2))
       .WillRepeatedly(
-          [&events_received](const std::vector<orbit_grpc_protos::CaptureEvent>& events) {
+          [&events_received](const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events) {
             events_received.insert(events_received.end(), events.begin(), events.end());
           });
   EXPECT_CALL(*fake_service_, OnAllEventsSentReceived).Times(0);
@@ -486,11 +487,11 @@ TEST_F(VulkanLayerProducerImplTest, InternOnlyWhenCapturing) {
   ::testing::Mock::VerifyAndClearExpectations(&mock_listener_);
   ::testing::Mock::VerifyAndClearExpectations(&*fake_service_);
 
-  std::vector<orbit_grpc_protos::CaptureEvent> events_received;
+  std::vector<orbit_grpc_protos::ProducerCaptureEvent> events_received;
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived)
       .Times(::testing::Between(1, 2))
       .WillRepeatedly(
-          [&events_received](const std::vector<orbit_grpc_protos::CaptureEvent>& events) {
+          [&events_received](const std::vector<orbit_grpc_protos::ProducerCaptureEvent>& events) {
             events_received.insert(events_received.end(), events.begin(), events.end());
           });
   EXPECT_CALL(*fake_service_, OnAllEventsSentReceived).Times(0);

--- a/src/Service/CMakeLists.txt
+++ b/src/Service/CMakeLists.txt
@@ -70,6 +70,7 @@ target_compile_options(ServiceTests PRIVATE ${STRICT_COMPILE_FLAGS})
 target_sources(ServiceTests PRIVATE
         ProcessListTest.cpp
         ProcessTest.cpp
+        ProducerEventProcessorTest.cpp
         ProducerSideServiceImplTest.cpp
         ServiceUtilsTest.cpp)
 

--- a/src/Service/CMakeLists.txt
+++ b/src/Service/CMakeLists.txt
@@ -32,6 +32,8 @@ target_sources(ServiceLib PRIVATE
         ProcessList.h
         ProcessServiceImpl.cpp
         ProcessServiceImpl.h
+        ProducerEventProcessor.cpp
+        ProducerEventProcessor.h
         ProducerSideServer.cpp
         ProducerSideServer.h
         ProducerSideServiceImpl.cpp

--- a/src/Service/CaptureEventBuffer.h
+++ b/src/Service/CaptureEventBuffer.h
@@ -15,7 +15,7 @@ namespace orbit_service {
 class CaptureEventBuffer {
  public:
   virtual ~CaptureEventBuffer() = default;
-  virtual void AddEvent(orbit_grpc_protos::CaptureEvent&& event) = 0;
+  virtual void AddEvent(orbit_grpc_protos::ClientCaptureEvent&& event) = 0;
 };
 
 }  // namespace orbit_service

--- a/src/Service/CaptureEventSender.h
+++ b/src/Service/CaptureEventSender.h
@@ -14,7 +14,7 @@ namespace orbit_service {
 class CaptureEventSender {
  public:
   virtual ~CaptureEventSender() = default;
-  virtual void SendEvents(std::vector<orbit_grpc_protos::CaptureEvent>&& events) = 0;
+  virtual void SendEvents(std::vector<orbit_grpc_protos::ClientCaptureEvent>&& events) = 0;
 };
 
 }  // namespace orbit_service

--- a/src/Service/CaptureServiceImpl.cpp
+++ b/src/Service/CaptureServiceImpl.cpp
@@ -201,7 +201,7 @@ grpc::Status CaptureServiceImpl::Capture(
   GrpcCaptureEventSender capture_event_sender{reader_writer};
   SenderThreadCaptureEventBuffer capture_event_buffer{&capture_event_sender};
   std::unique_ptr<ProducerEventProcessor> producer_event_processor =
-      CreateProducerEventProcessor(&capture_event_buffer);
+      ProducerEventProcessor::Create(&capture_event_buffer);
   LinuxTracingHandler tracing_handler{producer_event_processor.get()};
 
   CaptureRequest request;

--- a/src/Service/CaptureServiceImpl.cpp
+++ b/src/Service/CaptureServiceImpl.cpp
@@ -202,7 +202,7 @@ grpc::Status CaptureServiceImpl::Capture(
   SenderThreadCaptureEventBuffer capture_event_buffer{&capture_event_sender};
   std::unique_ptr<ProducerEventProcessor> producer_event_processor =
       CreateProducerEventProcessor(&capture_event_buffer);
-  LinuxTracingHandler tracing_handler{&capture_event_buffer};
+  LinuxTracingHandler tracing_handler{producer_event_processor.get()};
 
   CaptureRequest request;
   reader_writer->Read(&request);

--- a/src/Service/CaptureStartStopListener.h
+++ b/src/Service/CaptureStartStopListener.h
@@ -5,7 +5,7 @@
 #ifndef ORBIT_SERVICE_CAPTURE_START_STOP_LISTENER_H_
 #define ORBIT_SERVICE_CAPTURE_START_STOP_LISTENER_H_
 
-#include "CaptureEventBuffer.h"
+#include "ProducerEventProcessor.h"
 #include "capture.pb.h"
 
 namespace orbit_service {
@@ -18,7 +18,7 @@ class CaptureStartStopListener {
   virtual ~CaptureStartStopListener() = default;
 
   virtual void OnCaptureStartRequested(orbit_grpc_protos::CaptureOptions capture_options,
-                                       CaptureEventBuffer* capture_event_buffer) = 0;
+                                       ProducerEventProcessor* producer_event_processor) = 0;
 
   // This is to be assumed blocking until the capture stop has been fully processed by the listener.
   virtual void OnCaptureStopRequested() = 0;

--- a/src/Service/LinuxTracingHandler.cpp
+++ b/src/Service/LinuxTracingHandler.cpp
@@ -4,8 +4,6 @@
 
 #include "LinuxTracingHandler.h"
 
-#include <absl/container/flat_hash_set.h>
-#include <absl/strings/str_cat.h>
 #include <absl/synchronization/mutex.h>
 #include <unistd.h>
 
@@ -20,8 +18,8 @@ using orbit_grpc_protos::AddressInfo;
 using orbit_grpc_protos::Callstack;
 using orbit_grpc_protos::CaptureOptions;
 using orbit_grpc_protos::FullCallstackSample;
+using orbit_grpc_protos::FullGpuJobEvent;
 using orbit_grpc_protos::FunctionCall;
-using orbit_grpc_protos::GpuJob;
 using orbit_grpc_protos::InternedCallstackSample;
 using orbit_grpc_protos::IntrospectionScope;
 using orbit_grpc_protos::ProducerCaptureEvent;
@@ -95,10 +93,9 @@ void LinuxTracingHandler::OnIntrospectionScope(
   producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
-void LinuxTracingHandler::OnGpuJob(GpuJob gpu_job) {
-  CHECK(gpu_job.timeline_or_key_case() == GpuJob::kTimeline);
+void LinuxTracingHandler::OnGpuJob(FullGpuJobEvent full_gpu_job_event) {
   ProducerCaptureEvent event;
-  *event.mutable_gpu_job() = std::move(gpu_job);
+  *event.mutable_full_gpu_job_event() = std::move(full_gpu_job_event);
   producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 

--- a/src/Service/LinuxTracingHandler.cpp
+++ b/src/Service/LinuxTracingHandler.cpp
@@ -123,11 +123,10 @@ void LinuxTracingHandler::OnAddressInfo(AddressInfo address_info) {
   producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
-void LinuxTracingHandler::OnTracepointEvent(orbit_grpc_protos::TracepointEvent tracepoint_event) {
-  CHECK(tracepoint_event.tracepoint_info_or_key_case() ==
-        orbit_grpc_protos::TracepointEvent::kTracepointInfo);
+void LinuxTracingHandler::OnTracepointEvent(
+    orbit_grpc_protos::FullTracepointEvent tracepoint_event) {
   ProducerCaptureEvent event;
-  *event.mutable_tracepoint_event() = std::move(tracepoint_event);
+  *event.mutable_full_tracepoint_event() = std::move(tracepoint_event);
   producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 

--- a/src/Service/LinuxTracingHandler.cpp
+++ b/src/Service/LinuxTracingHandler.cpp
@@ -15,12 +15,12 @@
 namespace orbit_service {
 
 using orbit_grpc_protos::Callstack;
+using orbit_grpc_protos::CallstackSample;
 using orbit_grpc_protos::CaptureOptions;
 using orbit_grpc_protos::FullAddressInfo;
 using orbit_grpc_protos::FullCallstackSample;
-using orbit_grpc_protos::FullGpuJobEvent;
+using orbit_grpc_protos::FullGpuJob;
 using orbit_grpc_protos::FunctionCall;
-using orbit_grpc_protos::InternedCallstackSample;
 using orbit_grpc_protos::IntrospectionScope;
 using orbit_grpc_protos::ProducerCaptureEvent;
 using orbit_grpc_protos::SchedulingSlice;
@@ -93,9 +93,9 @@ void LinuxTracingHandler::OnIntrospectionScope(
   producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
-void LinuxTracingHandler::OnGpuJob(FullGpuJobEvent full_gpu_job_event) {
+void LinuxTracingHandler::OnGpuJob(FullGpuJob full_gpu_job) {
   ProducerCaptureEvent event;
-  *event.mutable_full_gpu_job_event() = std::move(full_gpu_job_event);
+  *event.mutable_full_gpu_job() = std::move(full_gpu_job);
   producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 

--- a/src/Service/LinuxTracingHandler.cpp
+++ b/src/Service/LinuxTracingHandler.cpp
@@ -14,9 +14,9 @@
 
 namespace orbit_service {
 
-using orbit_grpc_protos::AddressInfo;
 using orbit_grpc_protos::Callstack;
 using orbit_grpc_protos::CaptureOptions;
+using orbit_grpc_protos::FullAddressInfo;
 using orbit_grpc_protos::FullCallstackSample;
 using orbit_grpc_protos::FullGpuJobEvent;
 using orbit_grpc_protos::FunctionCall;
@@ -111,12 +111,9 @@ void LinuxTracingHandler::OnThreadStateSlice(ThreadStateSlice thread_state_slice
   producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
-void LinuxTracingHandler::OnAddressInfo(AddressInfo address_info) {
-  CHECK(address_info.function_name_or_key_case() == AddressInfo::kFunctionName);
-  CHECK(address_info.map_name_or_key_case() == AddressInfo::kMapName);
-
+void LinuxTracingHandler::OnAddressInfo(FullAddressInfo full_address_info) {
   ProducerCaptureEvent event;
-  *event.mutable_address_info() = std::move(address_info);
+  *event.mutable_full_address_info() = std::move(full_address_info);
   producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 

--- a/src/Service/LinuxTracingHandler.cpp
+++ b/src/Service/LinuxTracingHandler.cpp
@@ -19,15 +19,17 @@ namespace orbit_service {
 using orbit_grpc_protos::AddressInfo;
 using orbit_grpc_protos::Callstack;
 using orbit_grpc_protos::CaptureOptions;
-using orbit_grpc_protos::ClientCaptureEvent;
 using orbit_grpc_protos::FullCallstackSample;
 using orbit_grpc_protos::FunctionCall;
 using orbit_grpc_protos::GpuJob;
 using orbit_grpc_protos::InternedCallstackSample;
 using orbit_grpc_protos::IntrospectionScope;
+using orbit_grpc_protos::ProducerCaptureEvent;
 using orbit_grpc_protos::SchedulingSlice;
 using orbit_grpc_protos::ThreadName;
 using orbit_grpc_protos::ThreadStateSlice;
+
+constexpr uint64_t kLinuxTracingProducerId = 0;
 
 void LinuxTracingHandler::Start(CaptureOptions capture_options) {
   CHECK(tracer_ == nullptr);
@@ -69,158 +71,70 @@ void LinuxTracingHandler::Stop() {
 }
 
 void LinuxTracingHandler::OnSchedulingSlice(SchedulingSlice scheduling_slice) {
-  ClientCaptureEvent event;
+  ProducerCaptureEvent event;
   *event.mutable_scheduling_slice() = std::move(scheduling_slice);
-  capture_event_buffer_->AddEvent(std::move(event));
+  producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
 void LinuxTracingHandler::OnCallstackSample(FullCallstackSample callstack_sample) {
-  ClientCaptureEvent event;
-  InternedCallstackSample* interned_callstack_sample = event.mutable_interned_callstack_sample();
-  interned_callstack_sample->set_pid(callstack_sample.pid());
-  interned_callstack_sample->set_tid(callstack_sample.tid());
-  interned_callstack_sample->set_timestamp_ns(callstack_sample.timestamp_ns());
-  interned_callstack_sample->set_callstack_id(
-      InternCallstackIfNecessaryAndGetKey(callstack_sample.callstack()));
-
-  capture_event_buffer_->AddEvent(std::move(event));
+  ProducerCaptureEvent event;
+  *event.mutable_full_callstack_sample() = std::move(callstack_sample);
+  producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
 void LinuxTracingHandler::OnFunctionCall(FunctionCall function_call) {
-  ClientCaptureEvent event;
+  ProducerCaptureEvent event;
   *event.mutable_function_call() = std::move(function_call);
-  capture_event_buffer_->AddEvent(std::move(event));
+  producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
 void LinuxTracingHandler::OnIntrospectionScope(
     orbit_grpc_protos::IntrospectionScope introspection_scope) {
-  ClientCaptureEvent event;
+  ProducerCaptureEvent event;
   *event.mutable_introspection_scope() = std::move(introspection_scope);
-  capture_event_buffer_->AddEvent(std::move(event));
+  producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
 void LinuxTracingHandler::OnGpuJob(GpuJob gpu_job) {
   CHECK(gpu_job.timeline_or_key_case() == GpuJob::kTimeline);
-  gpu_job.set_timeline_key(
-      InternStringIfNecessaryAndGetKey(std::move(*gpu_job.mutable_timeline())));
-
-  ClientCaptureEvent event;
+  ProducerCaptureEvent event;
   *event.mutable_gpu_job() = std::move(gpu_job);
-  capture_event_buffer_->AddEvent(std::move(event));
+  producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
 void LinuxTracingHandler::OnThreadName(ThreadName thread_name) {
-  ClientCaptureEvent event;
+  ProducerCaptureEvent event;
   *event.mutable_thread_name() = std::move(thread_name);
-  capture_event_buffer_->AddEvent(std::move(event));
+  producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
 void LinuxTracingHandler::OnThreadStateSlice(ThreadStateSlice thread_state_slice) {
-  ClientCaptureEvent event;
+  ProducerCaptureEvent event;
   *event.mutable_thread_state_slice() = std::move(thread_state_slice);
-  capture_event_buffer_->AddEvent(std::move(event));
+  producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
 void LinuxTracingHandler::OnAddressInfo(AddressInfo address_info) {
-  {
-    absl::MutexLock lock{&addresses_seen_mutex_};
-    if (addresses_seen_.contains(address_info.absolute_address())) {
-      return;
-    }
-    addresses_seen_.emplace(address_info.absolute_address());
-  }
-
   CHECK(address_info.function_name_or_key_case() == AddressInfo::kFunctionName);
-  address_info.set_function_name_key(
-      InternStringIfNecessaryAndGetKey(llvm::demangle(address_info.function_name())));
   CHECK(address_info.map_name_or_key_case() == AddressInfo::kMapName);
-  address_info.set_map_name_key(
-      InternStringIfNecessaryAndGetKey(std::move(*address_info.mutable_map_name())));
 
-  ClientCaptureEvent event;
+  ProducerCaptureEvent event;
   *event.mutable_address_info() = std::move(address_info);
-  capture_event_buffer_->AddEvent(std::move(event));
+  producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
 void LinuxTracingHandler::OnTracepointEvent(orbit_grpc_protos::TracepointEvent tracepoint_event) {
   CHECK(tracepoint_event.tracepoint_info_or_key_case() ==
         orbit_grpc_protos::TracepointEvent::kTracepointInfo);
-  tracepoint_event.set_tracepoint_info_key(
-      InternTracepointInfoIfNecessaryAndGetKey(tracepoint_event.tracepoint_info()));
-
-  ClientCaptureEvent event;
+  ProducerCaptureEvent event;
   *event.mutable_tracepoint_event() = std::move(tracepoint_event);
-  capture_event_buffer_->AddEvent(std::move(event));
+  producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
 void LinuxTracingHandler::OnModuleUpdate(orbit_grpc_protos::ModuleUpdateEvent module_update_event) {
-  ClientCaptureEvent event;
+  ProducerCaptureEvent event;
   *event.mutable_module_update_event() = std::move(module_update_event);
-
-  capture_event_buffer_->AddEvent(std::move(event));
-}
-
-uint64_t LinuxTracingHandler::InternCallstackIfNecessaryAndGetKey(const Callstack& callstack) {
-  std::vector<uint64_t> callstack_vector{callstack.pcs().begin(), callstack.pcs().end()};
-  uint64_t callstack_id = 0;
-  {
-    absl::MutexLock lock{&callstack_id_mutex_};
-    auto it = callstack_to_id_.find(callstack_vector);
-    if (it != callstack_to_id_.end()) {
-      return it->second;
-    }
-
-    callstack_id = next_callstack_id_++;
-    callstack_to_id_.insert_or_assign(std::move(callstack_vector), callstack_id);
-  }
-
-  ClientCaptureEvent event;
-  event.mutable_interned_callstack()->set_key(callstack_id);
-  *event.mutable_interned_callstack()->mutable_intern() = callstack;
-  capture_event_buffer_->AddEvent(std::move(event));
-  return callstack_id;
-}
-
-uint64_t LinuxTracingHandler::ComputeStringKey(const std::string& str) {
-  return std::hash<std::string>{}(str);
-}
-
-uint64_t LinuxTracingHandler::InternStringIfNecessaryAndGetKey(std::string str) {
-  uint64_t key = ComputeStringKey(str);
-  {
-    absl::MutexLock lock{&string_keys_sent_mutex_};
-    if (string_keys_sent_.contains(key)) {
-      return key;
-    }
-    string_keys_sent_.emplace(key);
-  }
-
-  ClientCaptureEvent event;
-  event.mutable_interned_string()->set_key(key);
-  event.mutable_interned_string()->set_intern(std::move(str));
-  capture_event_buffer_->AddEvent(std::move(event));
-  return key;
-}
-
-uint64_t LinuxTracingHandler::InternTracepointInfoIfNecessaryAndGetKey(
-    const orbit_grpc_protos::TracepointInfo& tracepoint_info) {
-  uint64_t key =
-      ComputeStringKey(absl::StrCat(tracepoint_info.category(), ":", tracepoint_info.name()));
-  {
-    absl::MutexLock lock{&tracepoint_keys_sent_mutex_};
-    if (tracepoint_keys_sent_.contains(key)) {
-      return key;
-    }
-    tracepoint_keys_sent_.emplace(key);
-  }
-
-  ClientCaptureEvent event;
-  event.mutable_interned_tracepoint_info()->set_key(key);
-  event.mutable_interned_tracepoint_info()->mutable_intern()->set_name(tracepoint_info.name());
-  event.mutable_interned_tracepoint_info()->mutable_intern()->set_category(
-      tracepoint_info.category());
-  capture_event_buffer_->AddEvent(std::move(event));
-  return key;
+  producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
 }  // namespace orbit_service

--- a/src/Service/LinuxTracingHandler.h
+++ b/src/Service/LinuxTracingHandler.h
@@ -44,7 +44,7 @@ class LinuxTracingHandler : public orbit_linux_tracing::TracerListener {
   void OnGpuJob(orbit_grpc_protos::FullGpuJobEvent gpu_job) override;
   void OnThreadName(orbit_grpc_protos::ThreadName thread_name) override;
   void OnThreadStateSlice(orbit_grpc_protos::ThreadStateSlice thread_state_slice) override;
-  void OnAddressInfo(orbit_grpc_protos::AddressInfo address_info) override;
+  void OnAddressInfo(orbit_grpc_protos::FullAddressInfo full_address_info) override;
   void OnTracepointEvent(orbit_grpc_protos::FullTracepointEvent tracepoint_event) override;
   void OnModuleUpdate(orbit_grpc_protos::ModuleUpdateEvent module_update_event) override;
 

--- a/src/Service/LinuxTracingHandler.h
+++ b/src/Service/LinuxTracingHandler.h
@@ -45,7 +45,7 @@ class LinuxTracingHandler : public orbit_linux_tracing::TracerListener {
   void OnThreadName(orbit_grpc_protos::ThreadName thread_name) override;
   void OnThreadStateSlice(orbit_grpc_protos::ThreadStateSlice thread_state_slice) override;
   void OnAddressInfo(orbit_grpc_protos::AddressInfo address_info) override;
-  void OnTracepointEvent(orbit_grpc_protos::TracepointEvent tracepoint_event) override;
+  void OnTracepointEvent(orbit_grpc_protos::FullTracepointEvent tracepoint_event) override;
   void OnModuleUpdate(orbit_grpc_protos::ModuleUpdateEvent module_update_event) override;
 
  private:

--- a/src/Service/LinuxTracingHandler.h
+++ b/src/Service/LinuxTracingHandler.h
@@ -38,7 +38,7 @@ class LinuxTracingHandler : public orbit_linux_tracing::TracerListener {
   void Stop();
 
   void OnSchedulingSlice(orbit_grpc_protos::SchedulingSlice scheduling_slice) override;
-  void OnCallstackSample(orbit_grpc_protos::CallstackSample callstack_sample) override;
+  void OnCallstackSample(orbit_grpc_protos::FullCallstackSample callstack_sample) override;
   void OnFunctionCall(orbit_grpc_protos::FunctionCall function_call) override;
   void OnIntrospectionScope(orbit_grpc_protos::IntrospectionScope introspection_call) override;
   void OnGpuJob(orbit_grpc_protos::GpuJob gpu_job) override;

--- a/src/Service/LinuxTracingHandler.h
+++ b/src/Service/LinuxTracingHandler.h
@@ -41,7 +41,7 @@ class LinuxTracingHandler : public orbit_linux_tracing::TracerListener {
   void OnCallstackSample(orbit_grpc_protos::FullCallstackSample callstack_sample) override;
   void OnFunctionCall(orbit_grpc_protos::FunctionCall function_call) override;
   void OnIntrospectionScope(orbit_grpc_protos::IntrospectionScope introspection_call) override;
-  void OnGpuJob(orbit_grpc_protos::GpuJob gpu_job) override;
+  void OnGpuJob(orbit_grpc_protos::FullGpuJobEvent gpu_job) override;
   void OnThreadName(orbit_grpc_protos::ThreadName thread_name) override;
   void OnThreadStateSlice(orbit_grpc_protos::ThreadStateSlice thread_state_slice) override;
   void OnAddressInfo(orbit_grpc_protos::AddressInfo address_info) override;

--- a/src/Service/LinuxTracingHandler.h
+++ b/src/Service/LinuxTracingHandler.h
@@ -41,7 +41,7 @@ class LinuxTracingHandler : public orbit_linux_tracing::TracerListener {
   void OnCallstackSample(orbit_grpc_protos::FullCallstackSample callstack_sample) override;
   void OnFunctionCall(orbit_grpc_protos::FunctionCall function_call) override;
   void OnIntrospectionScope(orbit_grpc_protos::IntrospectionScope introspection_call) override;
-  void OnGpuJob(orbit_grpc_protos::FullGpuJobEvent gpu_job) override;
+  void OnGpuJob(orbit_grpc_protos::FullGpuJob gpu_job) override;
   void OnThreadName(orbit_grpc_protos::ThreadName thread_name) override;
   void OnThreadStateSlice(orbit_grpc_protos::ThreadStateSlice thread_state_slice) override;
   void OnAddressInfo(orbit_grpc_protos::FullAddressInfo full_address_info) override;

--- a/src/Service/ProducerEventProcessor.cpp
+++ b/src/Service/ProducerEventProcessor.cpp
@@ -36,6 +36,7 @@ using orbit_grpc_protos::TracepointEvent;
 template <typename T>
 class InternedCache final {
  public:
+  InternedCache() = delete;
   explicit InternedCache(std::atomic<uint64_t>* id_counter) : id_counter_{id_counter} {}
 
   // Return pair of <id, assigned>, where assigned is true if the entry was assigned a new id
@@ -61,6 +62,7 @@ class InternedCache final {
 
 class ProducerEventProcessorImpl : public ProducerEventProcessor {
  public:
+  ProducerEventProcessorImpl() = delete;
   explicit ProducerEventProcessorImpl(CaptureEventBuffer* capture_event_buffer)
       : capture_event_buffer_{capture_event_buffer},
         callstack_id_counter_{1},

--- a/src/Service/ProducerEventProcessor.cpp
+++ b/src/Service/ProducerEventProcessor.cpp
@@ -1,0 +1,395 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ProducerEventProcessor.h"
+
+#include <absl/container/flat_hash_map.h>
+
+#include "OrbitBase/Logging.h"
+#include "capture.pb.h"
+
+namespace orbit_service {
+
+namespace {
+
+using orbit_grpc_protos::AddressInfo;
+using orbit_grpc_protos::Callstack;
+using orbit_grpc_protos::ClientCaptureEvent;
+using orbit_grpc_protos::FullCallstackSample;
+using orbit_grpc_protos::FunctionCall;
+using orbit_grpc_protos::GpuDebugMarker;
+using orbit_grpc_protos::GpuJob;
+using orbit_grpc_protos::GpuQueueSubmission;
+using orbit_grpc_protos::InternedCallstack;
+using orbit_grpc_protos::InternedCallstackSample;
+using orbit_grpc_protos::InternedString;
+using orbit_grpc_protos::InternedTracepointInfo;
+using orbit_grpc_protos::IntrospectionScope;
+using orbit_grpc_protos::ModuleUpdateEvent;
+using orbit_grpc_protos::ProducerCaptureEvent;
+using orbit_grpc_protos::SchedulingSlice;
+using orbit_grpc_protos::ThreadName;
+using orbit_grpc_protos::ThreadStateSlice;
+using orbit_grpc_protos::TracepointEvent;
+
+template <typename T>
+class InternedCache final {
+ public:
+  explicit InternedCache(std::atomic<uint64_t>* id_counter) : id_counter_{id_counter} {}
+
+  // Return pair of <id, assigned>, where assigned is true if the entry was assigned a new id
+  // and false if returning id for already existing entry.
+  std::pair<uint64_t, bool> GetOrAssignId(const T& entry) {
+    absl::MutexLock lock(&entry_to_id_mutex_);
+    auto it = entry_to_id_.find(entry);
+    if (it != entry_to_id_.end()) {
+      return std::make_pair(it->second, false);
+    }
+
+    uint64_t new_id = (*id_counter_)++;
+    auto [unused_it, inserted] = entry_to_id_.insert_or_assign(entry, new_id);
+    CHECK(inserted);
+    return std::make_pair(new_id, true);
+  }
+
+ private:
+  std::atomic<uint64_t>* id_counter_ = nullptr;
+  absl::flat_hash_map<T, uint64_t> entry_to_id_;
+  absl::Mutex entry_to_id_mutex_;
+};
+
+class ProducerEventProcessorImpl : public ProducerEventProcessor {
+ public:
+  explicit ProducerEventProcessorImpl(CaptureEventBuffer* capture_event_buffer)
+      : capture_event_buffer_{capture_event_buffer},
+        callstack_id_counter_{1},
+        string_id_counter_{1},
+        tracepoint_id_counter_{1},
+        callstack_cache_{&callstack_id_counter_},
+        string_cache_{&string_id_counter_},
+        tracepoint_cache_{&tracepoint_id_counter_},
+        interned_callstack_id_cache_{&callstack_id_counter_},
+        interned_string_id_cache_{&string_id_counter_},
+        interned_tracepoint_id_cache_{&tracepoint_id_counter_} {}
+
+  void ProcessEvent(uint64_t producer_id, ProducerCaptureEvent event) override;
+
+ private:
+  void ProcessAddressInfo(uint64_t producer_id, AddressInfo* address_info);
+  void ProcessFullCallstackSample(FullCallstackSample* callstack_sample);
+  void ProcessFunctionCall(FunctionCall* function_call);
+  void ProcessGpuJob(uint64_t producer, GpuJob* gpu_job);
+  void ProcessGpuQueueSubmission(uint64_t producer_id, GpuQueueSubmission* gpu_queue_submission);
+  void ProcessInternedCallstack(uint64_t producer_id, InternedCallstack* interned_callstack);
+  void ProcessInternedCallstackSample(uint64_t producer_id,
+                                      InternedCallstackSample* callstack_sample);
+  void ProcessInternedString(uint64_t producer_id, InternedString* interned_string);
+  void ProcessInternedTracepointInfo(uint64_t producer_id,
+                                     InternedTracepointInfo* interned_tracepoint_info);
+  void ProcessIntrospectionScope(IntrospectionScope* introspection_scope);
+  void ProcessModuleUpdateEvent(ModuleUpdateEvent* module_update_event);
+  void ProcessSchedulingSlice(SchedulingSlice* scheduling_slice);
+  void ProcessThreadName(ThreadName* thread_name);
+  void ProcessThreadStateSlice(ThreadStateSlice* thread_state_slice);
+  void ProcessTracepointEvent(uint64_t producer_id, TracepointEvent* tracepoint_event);
+
+  void SendStringAndKeyEvent(uint64_t key, std::string value);
+
+  CaptureEventBuffer* capture_event_buffer_;
+
+  std::atomic<uint64_t> callstack_id_counter_;
+  std::atomic<uint64_t> string_id_counter_;
+  std::atomic<uint64_t> tracepoint_id_counter_;
+
+  InternedCache<std::vector<uint64_t>> callstack_cache_;
+  InternedCache<std::string> string_cache_;
+  InternedCache<std::pair<std::string, std::string>> tracepoint_cache_;
+
+  // These are mapping InternStrings and Callstacks from producer ids
+  // to client ids:
+  // <producer_id, producer_string_id> -> client_string_id and
+  // <producer_id, producer_callstack_id> -> client_callstack_id
+  InternedCache<std::pair<uint64_t, uint64_t>> interned_callstack_id_cache_;
+  InternedCache<std::pair<uint64_t, uint64_t>> interned_string_id_cache_;
+  InternedCache<std::pair<uint64_t, uint64_t>> interned_tracepoint_id_cache_;
+};
+
+void ProducerEventProcessorImpl::ProcessAddressInfo(uint64_t producer_id,
+                                                    AddressInfo* address_info) {
+  // TODO: Split address info into 2 separate messages, one with strings another one with keys.
+  if (address_info->function_name_or_key_case() == AddressInfo::kFunctionName) {
+    auto [function_name_key, assigned] = string_cache_.GetOrAssignId(address_info->function_name());
+    if (assigned) {
+      SendStringAndKeyEvent(function_name_key, address_info->function_name());
+    }
+    address_info->set_function_name_key(function_name_key);
+  } else {
+    CHECK(address_info->function_name_or_key_case() == AddressInfo::kFunctionNameKey);
+    auto [function_name_key, assigned] =
+        interned_string_id_cache_.GetOrAssignId({producer_id, address_info->function_name_key()});
+    CHECK(!assigned);
+    address_info->set_function_name_key(function_name_key);
+  }
+
+  if (address_info->map_name_or_key_case() == AddressInfo::kMapName) {
+    auto [module_name_key, assigned] = string_cache_.GetOrAssignId(address_info->map_name());
+    if (assigned) {
+      SendStringAndKeyEvent(module_name_key, address_info->map_name());
+    }
+    address_info->set_map_name_key(module_name_key);
+  } else {
+    CHECK(address_info->map_name_or_key_case() == AddressInfo::kMapNameKey);
+    auto [module_name_key, assigned] =
+        interned_string_id_cache_.GetOrAssignId({producer_id, address_info->map_name_key()});
+    CHECK(!assigned);
+    address_info->set_map_name_key(module_name_key);
+  }
+
+  ClientCaptureEvent event;
+  *event.mutable_address_info() = std::move(*address_info);
+  capture_event_buffer_->AddEvent(std::move(event));
+}
+
+void ProducerEventProcessorImpl::ProcessFunctionCall(FunctionCall* function_call) {
+  ClientCaptureEvent event;
+  *event.mutable_function_call() = std::move(*function_call);
+  capture_event_buffer_->AddEvent(std::move(event));
+}
+
+void ProducerEventProcessorImpl::ProcessGpuJob(uint64_t producer_id, GpuJob* gpu_job) {
+  // TODO: Split GpuJob into 2 separate messages, one with string and another one with the key
+  if (gpu_job->timeline_or_key_case() == GpuJob::kTimeline) {
+    auto [timeline_key, assigned] = string_cache_.GetOrAssignId(gpu_job->timeline());
+    if (assigned) {
+      SendStringAndKeyEvent(timeline_key, gpu_job->timeline());
+    }
+    gpu_job->set_timeline_key(timeline_key);
+  } else {  // gpu_job->timeline_or_key_case() == GpuJob::kTimelineKey
+    CHECK(gpu_job->timeline_or_key_case() == GpuJob::kTimelineKey);
+    auto [timeline_key, assigned] =
+        interned_string_id_cache_.GetOrAssignId({producer_id, gpu_job->timeline_key()});
+    CHECK(!assigned);
+    gpu_job->set_timeline_key(timeline_key);
+  }
+
+  ClientCaptureEvent event;
+  *event.mutable_gpu_job() = std::move(*gpu_job);
+  capture_event_buffer_->AddEvent(std::move(event));
+}
+
+void ProducerEventProcessorImpl::ProcessGpuQueueSubmission(
+    uint64_t producer_id, GpuQueueSubmission* gpu_queue_submission) {
+  // Translate debug marker keys
+  for (GpuDebugMarker& mutable_marker : *gpu_queue_submission->mutable_completed_markers()) {
+    auto [client_text_key, assigned] =
+        interned_string_id_cache_.GetOrAssignId({producer_id, mutable_marker.text_key()});
+    CHECK(!assigned);
+    mutable_marker.set_text_key(client_text_key);
+  }
+
+  ClientCaptureEvent event;
+  *event.mutable_gpu_queue_submission() = std::move(*gpu_queue_submission);
+  capture_event_buffer_->AddEvent(std::move(event));
+}
+
+void ProducerEventProcessorImpl::ProcessFullCallstackSample(FullCallstackSample* callstack_sample) {
+  Callstack* callstack = callstack_sample->mutable_callstack();
+  auto [callstack_id, assigned] =
+      callstack_cache_.GetOrAssignId({callstack->pcs().begin(), callstack->pcs().end()});
+
+  if (assigned) {
+    ClientCaptureEvent interned_callstack_event;
+    interned_callstack_event.mutable_interned_callstack()->set_key(callstack_id);
+    *interned_callstack_event.mutable_interned_callstack()->mutable_intern() =
+        std::move(*callstack);
+    capture_event_buffer_->AddEvent(std::move(interned_callstack_event));
+  }
+
+  ClientCaptureEvent interned_callstack_sample_event;
+  InternedCallstackSample* interned_callstack_sample =
+      interned_callstack_sample_event.mutable_interned_callstack_sample();
+  interned_callstack_sample->set_pid(callstack_sample->pid());
+  interned_callstack_sample->set_tid(callstack_sample->tid());
+  interned_callstack_sample->set_timestamp_ns(callstack_sample->timestamp_ns());
+  interned_callstack_sample->set_callstack_id(callstack_id);
+  capture_event_buffer_->AddEvent(std::move(interned_callstack_sample_event));
+}
+
+void ProducerEventProcessorImpl::ProcessInternedCallstack(uint64_t producer_id,
+                                                          InternedCallstack* interned_callstack) {
+  auto [interned_callstack_id, assigned] =
+      interned_callstack_id_cache_.GetOrAssignId({producer_id, interned_callstack->key()});
+  CHECK(assigned);
+  interned_callstack->set_key(interned_callstack_id);
+
+  ClientCaptureEvent event;
+  *event.mutable_interned_callstack() = std::move(*interned_callstack);
+  capture_event_buffer_->AddEvent(std::move(event));
+}
+
+void ProducerEventProcessorImpl::ProcessInternedCallstackSample(
+    uint64_t producer_id, InternedCallstackSample* callstack_sample) {
+  // traslate ids
+  auto [callstack_id, assigned] =
+      interned_callstack_id_cache_.GetOrAssignId({producer_id, callstack_sample->callstack_id()});
+  CHECK(!assigned);
+  callstack_sample->set_callstack_id(callstack_id);
+
+  ClientCaptureEvent event;
+  *event.mutable_interned_callstack_sample() = std::move(*callstack_sample);
+  capture_event_buffer_->AddEvent(std::move(event));
+}
+
+void ProducerEventProcessorImpl::ProcessInternedString(uint64_t producer_id,
+                                                       InternedString* interned_string) {
+  auto [interned_string_id, assigned] =
+      interned_string_id_cache_.GetOrAssignId({producer_id, interned_string->key()});
+  CHECK(assigned);
+  interned_string->set_key(interned_string_id);
+
+  ClientCaptureEvent event;
+  *event.mutable_interned_string() = std::move(*interned_string);
+  capture_event_buffer_->AddEvent(std::move(event));
+}
+
+void ProducerEventProcessorImpl::ProcessInternedTracepointInfo(
+    uint64_t producer_id, InternedTracepointInfo* interned_tracepoint_info) {
+  auto [interned_tracepoint_id, assigned] =
+      interned_tracepoint_id_cache_.GetOrAssignId({producer_id, interned_tracepoint_info->key()});
+  CHECK(assigned);
+  interned_tracepoint_info->set_key(interned_tracepoint_id);
+
+  ClientCaptureEvent event;
+  *event.mutable_interned_tracepoint_info() = std::move(*interned_tracepoint_info);
+  capture_event_buffer_->AddEvent(std::move(event));
+}
+
+void ProducerEventProcessorImpl::ProcessIntrospectionScope(
+    IntrospectionScope* introspection_scope) {
+  ClientCaptureEvent event;
+  *event.mutable_introspection_scope() = std::move(*introspection_scope);
+  capture_event_buffer_->AddEvent(std::move(event));
+}
+
+void ProducerEventProcessorImpl::ProcessModuleUpdateEvent(
+    orbit_grpc_protos::ModuleUpdateEvent* module_update_event) {
+  ClientCaptureEvent event;
+  *event.mutable_module_update_event() = std::move(*module_update_event);
+  capture_event_buffer_->AddEvent(std::move(event));
+}
+
+void ProducerEventProcessorImpl::ProcessSchedulingSlice(SchedulingSlice* scheduling_slice) {
+  ClientCaptureEvent event;
+  *event.mutable_scheduling_slice() = std::move(*scheduling_slice);
+  capture_event_buffer_->AddEvent(std::move(event));
+}
+
+void ProducerEventProcessorImpl::ProcessThreadName(ThreadName* thread_name) {
+  ClientCaptureEvent event;
+  *event.mutable_thread_name() = std::move(*thread_name);
+  capture_event_buffer_->AddEvent(std::move(event));
+}
+
+void ProducerEventProcessorImpl::ProcessThreadStateSlice(ThreadStateSlice* thread_state_slice) {
+  ClientCaptureEvent event;
+  *event.mutable_thread_state_slice() = std::move(*thread_state_slice);
+  capture_event_buffer_->AddEvent(std::move(event));
+}
+
+void ProducerEventProcessorImpl::ProcessTracepointEvent(uint64_t producer_id,
+                                                        TracepointEvent* tracepoint_event) {
+  // TODO: Split TracepointEvent in two, one with key another one with string
+  if (tracepoint_event->tracepoint_info_or_key_case() == TracepointEvent::kTracepointInfo) {
+    auto [tracepoint_key, assigned] =
+        tracepoint_cache_.GetOrAssignId({tracepoint_event->tracepoint_info().category(),
+                                         tracepoint_event->tracepoint_info().name()});
+    if (assigned) {
+      ClientCaptureEvent event;
+      event.mutable_interned_tracepoint_info()->set_key(tracepoint_key);
+      *event.mutable_interned_tracepoint_info()->mutable_intern() =
+          tracepoint_event->tracepoint_info();
+      capture_event_buffer_->AddEvent(std::move(event));
+    }
+    tracepoint_event->set_tracepoint_info_key(tracepoint_key);
+  } else {
+    CHECK(tracepoint_event->tracepoint_info_or_key_case() == TracepointEvent::kTracepointInfoKey);
+    auto [tracepoint_key, assigned] = interned_tracepoint_id_cache_.GetOrAssignId(
+        {producer_id, tracepoint_event->tracepoint_info_key()});
+    CHECK(!assigned);
+    tracepoint_event->set_tracepoint_info_key(tracepoint_key);
+  }
+
+  ClientCaptureEvent event;
+  *event.mutable_tracepoint_event() = std::move(*tracepoint_event);
+  capture_event_buffer_->AddEvent(std::move(event));
+}
+
+void ProducerEventProcessorImpl::ProcessEvent(uint64_t producer_id, ProducerCaptureEvent event) {
+  switch (event.event_case()) {
+    case ProducerCaptureEvent::kInternedCallstack:
+      ProcessInternedCallstack(producer_id, event.mutable_interned_callstack());
+      break;
+    case ProducerCaptureEvent::kSchedulingSlice:
+      ProcessSchedulingSlice(event.mutable_scheduling_slice());
+      break;
+    case ProducerCaptureEvent::kInternedCallstackSample:
+      ProcessInternedCallstackSample(producer_id, event.mutable_interned_callstack_sample());
+      break;
+    case ProducerCaptureEvent::kFullCallstackSample:
+      ProcessFullCallstackSample(event.mutable_full_callstack_sample());
+      break;
+    case ProducerCaptureEvent::kFunctionCall:
+      ProcessFunctionCall(event.mutable_function_call());
+      break;
+    case ProducerCaptureEvent::kInternedString:
+      ProcessInternedString(producer_id, event.mutable_interned_string());
+      break;
+    case ProducerCaptureEvent::kGpuJob:
+      ProcessGpuJob(producer_id, event.mutable_gpu_job());
+      break;
+    case ProducerCaptureEvent::kGpuQueueSubmission:
+      ProcessGpuQueueSubmission(producer_id, event.mutable_gpu_queue_submission());
+      break;
+    case ProducerCaptureEvent::kThreadName:
+      ProcessThreadName(event.mutable_thread_name());
+      break;
+    case ProducerCaptureEvent::kThreadStateSlice:
+      ProcessThreadStateSlice(event.mutable_thread_state_slice());
+      break;
+    case ProducerCaptureEvent::kAddressInfo:
+      ProcessAddressInfo(producer_id, event.mutable_address_info());
+      break;
+    case ProducerCaptureEvent::kInternedTracepointInfo:
+      ProcessInternedTracepointInfo(producer_id, event.mutable_interned_tracepoint_info());
+      break;
+    case ProducerCaptureEvent::kTracepointEvent:
+      ProcessTracepointEvent(producer_id, event.mutable_tracepoint_event());
+      break;
+    case ProducerCaptureEvent::kIntrospectionScope:
+      ProcessIntrospectionScope(event.mutable_introspection_scope());
+      break;
+    case ProducerCaptureEvent::kModuleUpdateEvent:
+      ProcessModuleUpdateEvent(event.mutable_module_update_event());
+      break;
+    case ProducerCaptureEvent::EVENT_NOT_SET:
+      UNREACHABLE();
+  }
+}
+
+void ProducerEventProcessorImpl::SendStringAndKeyEvent(uint64_t key, std::string value) {
+  ClientCaptureEvent event;
+  InternedString* interned_string = event.mutable_interned_string();
+  interned_string->set_key(key);
+  interned_string->set_intern(std::move(value));
+  capture_event_buffer_->AddEvent(std::move(event));
+}
+
+}  // namespace
+
+std::unique_ptr<ProducerEventProcessor> CreateProducerEventProcessor(
+    CaptureEventBuffer* capture_event_buffer) {
+  return std::make_unique<ProducerEventProcessorImpl>(capture_event_buffer);
+}
+
+}  // namespace orbit_service

--- a/src/Service/ProducerEventProcessor.cpp
+++ b/src/Service/ProducerEventProcessor.cpp
@@ -39,8 +39,7 @@ using orbit_grpc_protos::ThreadStateSlice;
 template <typename T>
 class InternedCache final {
  public:
-  InternedCache() = delete;
-  explicit InternedCache(std::atomic<uint64_t>* id_counter) : id_counter_{id_counter} {}
+  InternedCache() = default;
 
   // Return pair of <id, assigned>, where assigned is true if the entry was assigned a new id
   // and false if returning id for already existing entry.
@@ -51,14 +50,14 @@ class InternedCache final {
       return std::make_pair(it->second, false);
     }
 
-    uint64_t new_id = (*id_counter_)++;
+    uint64_t new_id = id_counter_++;
     auto [unused_it, inserted] = entry_to_id_.insert_or_assign(entry, new_id);
     CHECK(inserted);
     return std::make_pair(new_id, true);
   }
 
  private:
-  std::atomic<uint64_t>* id_counter_ = nullptr;
+  uint64_t id_counter_ = 1;  // 0 is reserved for invalid_id
   absl::flat_hash_map<T, uint64_t> entry_to_id_;
   absl::Mutex entry_to_id_mutex_;
 };
@@ -67,16 +66,7 @@ class ProducerEventProcessorImpl : public ProducerEventProcessor {
  public:
   ProducerEventProcessorImpl() = delete;
   explicit ProducerEventProcessorImpl(CaptureEventBuffer* capture_event_buffer)
-      : capture_event_buffer_{capture_event_buffer},
-        callstack_id_counter_{1},
-        string_id_counter_{1},
-        tracepoint_id_counter_{1},
-        callstack_cache_{&callstack_id_counter_},
-        string_cache_{&string_id_counter_},
-        tracepoint_cache_{&tracepoint_id_counter_},
-        interned_callstack_id_cache_{&callstack_id_counter_},
-        interned_string_id_cache_{&string_id_counter_},
-        interned_tracepoint_id_cache_{&tracepoint_id_counter_} {}
+      : capture_event_buffer_{capture_event_buffer} {}
 
   void ProcessEvent(uint64_t producer_id, ProducerCaptureEvent event) override;
 
@@ -90,36 +80,29 @@ class ProducerEventProcessorImpl : public ProducerEventProcessor {
   void ProcessInternedCallstackSample(uint64_t producer_id,
                                       InternedCallstackSample* callstack_sample);
   void ProcessInternedString(uint64_t producer_id, InternedString* interned_string);
-  void ProcessInternedTracepointInfo(uint64_t producer_id,
-                                     InternedTracepointInfo* interned_tracepoint_info);
   void ProcessIntrospectionScope(IntrospectionScope* introspection_scope);
   void ProcessModuleUpdateEvent(ModuleUpdateEvent* module_update_event);
   void ProcessSchedulingSlice(SchedulingSlice* scheduling_slice);
   void ProcessThreadName(ThreadName* thread_name);
   void ProcessThreadStateSlice(ThreadStateSlice* thread_state_slice);
   void ProcessFullTracepointEvent(FullTracepointEvent* tracepoint_event);
-  void ProcessInternedTracepointEvent(uint64_t producer_id,
-                                      InternedTracepointEvent* tracepoint_event);
 
   void SendStringAndKeyEvent(uint64_t key, std::string value);
 
   CaptureEventBuffer* capture_event_buffer_;
 
-  std::atomic<uint64_t> callstack_id_counter_;
-  std::atomic<uint64_t> string_id_counter_;
-  std::atomic<uint64_t> tracepoint_id_counter_;
-
   InternedCache<std::vector<uint64_t>> callstack_cache_;
   InternedCache<std::string> string_cache_;
   InternedCache<std::pair<std::string, std::string>> tracepoint_cache_;
 
-  // These are mapping InternStrings and Callstacks from producer ids
+  // These are mapping InternStrings and InternedCallstacks from producer ids
   // to client ids:
-  // <producer_id, producer_string_id> -> client_string_id and
   // <producer_id, producer_callstack_id> -> client_callstack_id
-  InternedCache<std::pair<uint64_t, uint64_t>> interned_callstack_id_cache_;
-  InternedCache<std::pair<uint64_t, uint64_t>> interned_string_id_cache_;
-  InternedCache<std::pair<uint64_t, uint64_t>> interned_tracepoint_id_cache_;
+  absl::flat_hash_map<std::pair<uint64_t, uint64_t>, uint64_t>
+      producer_interned_callstack_id_to_client_callstack_id_;
+  // <producer_id, producer_string_id> -> client_string_id
+  absl::flat_hash_map<std::pair<uint64_t, uint64_t>, uint64_t>
+      producer_interned_string_id_to_client_string_id_;
 };
 
 void ProducerEventProcessorImpl::ProcessFullAddressInfo(FullAddressInfo* full_address_info) {
@@ -180,10 +163,10 @@ void ProducerEventProcessorImpl::ProcessGpuQueueSubmission(
     uint64_t producer_id, GpuQueueSubmission* gpu_queue_submission) {
   // Translate debug marker keys
   for (GpuDebugMarker& mutable_marker : *gpu_queue_submission->mutable_completed_markers()) {
-    auto [client_text_key, assigned] =
-        interned_string_id_cache_.GetOrAssignId({producer_id, mutable_marker.text_key()});
-    CHECK(!assigned);
-    mutable_marker.set_text_key(client_text_key);
+    auto it = producer_interned_string_id_to_client_string_id_.find(
+        {producer_id, mutable_marker.text_key()});
+    CHECK(it != producer_interned_string_id_to_client_string_id_.end());
+    mutable_marker.set_text_key(it->second);
   }
 
   ClientCaptureEvent event;
@@ -216,11 +199,23 @@ void ProducerEventProcessorImpl::ProcessFullCallstackSample(FullCallstackSample*
 
 void ProducerEventProcessorImpl::ProcessInternedCallstack(uint64_t producer_id,
                                                           InternedCallstack* interned_callstack) {
-  auto [interned_callstack_id, assigned] =
-      interned_callstack_id_cache_.GetOrAssignId({producer_id, interned_callstack->key()});
-  CHECK(assigned);
-  interned_callstack->set_key(interned_callstack_id);
+  // TODO(http://b/180235290): replace with error message
+  CHECK(!producer_interned_callstack_id_to_client_callstack_id_.contains(
+      {producer_id, interned_callstack->key()}));
 
+  std::vector<uint64_t> callstack_data{interned_callstack->intern().pcs().begin(),
+                                       interned_callstack->intern().pcs().end()};
+  auto [interned_callstack_id, assigned] = callstack_cache_.GetOrAssignId(callstack_data);
+
+  producer_interned_callstack_id_to_client_callstack_id_.insert_or_assign(
+      {producer_id, interned_callstack->key()}, interned_callstack_id);
+
+  if (!assigned) {
+    return;
+  }
+
+  // If this is first time we see it -> send it over with client_id
+  interned_callstack->set_key(interned_callstack_id);
   ClientCaptureEvent event;
   *event.mutable_interned_callstack() = std::move(*interned_callstack);
   capture_event_buffer_->AddEvent(std::move(event));
@@ -228,11 +223,12 @@ void ProducerEventProcessorImpl::ProcessInternedCallstack(uint64_t producer_id,
 
 void ProducerEventProcessorImpl::ProcessInternedCallstackSample(
     uint64_t producer_id, InternedCallstackSample* callstack_sample) {
-  // traslate ids
-  auto [callstack_id, assigned] =
-      interned_callstack_id_cache_.GetOrAssignId({producer_id, callstack_sample->callstack_id()});
-  CHECK(!assigned);
-  callstack_sample->set_callstack_id(callstack_id);
+  // translate producer id to client id
+  auto it = producer_interned_callstack_id_to_client_callstack_id_.find(
+      {producer_id, callstack_sample->callstack_id()});
+  // TODO(http://b/180235290): replace with error message
+  CHECK(it != producer_interned_callstack_id_to_client_callstack_id_.end());
+  callstack_sample->set_callstack_id(it->second);
 
   ClientCaptureEvent event;
   *event.mutable_interned_callstack_sample() = std::move(*callstack_sample);
@@ -241,25 +237,22 @@ void ProducerEventProcessorImpl::ProcessInternedCallstackSample(
 
 void ProducerEventProcessorImpl::ProcessInternedString(uint64_t producer_id,
                                                        InternedString* interned_string) {
-  auto [interned_string_id, assigned] =
-      interned_string_id_cache_.GetOrAssignId({producer_id, interned_string->key()});
-  CHECK(assigned);
-  interned_string->set_key(interned_string_id);
+  // TODO(http://b/180235290): replace with error message
+  CHECK(!producer_interned_string_id_to_client_string_id_.contains(
+      {producer_id, interned_string->key()}));
+
+  auto [client_string_id, assigned] = string_cache_.GetOrAssignId(interned_string->intern());
+  producer_interned_string_id_to_client_string_id_.insert_or_assign(
+      {producer_id, interned_string->key()}, client_string_id);
+
+  if (!assigned) {
+    return;
+  }
+
+  interned_string->set_key(client_string_id);
 
   ClientCaptureEvent event;
   *event.mutable_interned_string() = std::move(*interned_string);
-  capture_event_buffer_->AddEvent(std::move(event));
-}
-
-void ProducerEventProcessorImpl::ProcessInternedTracepointInfo(
-    uint64_t producer_id, InternedTracepointInfo* interned_tracepoint_info) {
-  auto [interned_tracepoint_id, assigned] =
-      interned_tracepoint_id_cache_.GetOrAssignId({producer_id, interned_tracepoint_info->key()});
-  CHECK(assigned);
-  interned_tracepoint_info->set_key(interned_tracepoint_id);
-
-  ClientCaptureEvent event;
-  *event.mutable_interned_tracepoint_info() = std::move(*interned_tracepoint_info);
   capture_event_buffer_->AddEvent(std::move(event));
 }
 
@@ -316,17 +309,6 @@ void ProducerEventProcessorImpl::ProcessFullTracepointEvent(FullTracepointEvent*
   capture_event_buffer_->AddEvent(std::move(event));
 }
 
-void ProducerEventProcessorImpl::ProcessInternedTracepointEvent(
-    uint64_t producer_id, InternedTracepointEvent* tracepoint_event) {
-  auto [tracepoint_key, assigned] = interned_tracepoint_id_cache_.GetOrAssignId(
-      {producer_id, tracepoint_event->tracepoint_info_key()});
-  tracepoint_event->set_tracepoint_info_key(tracepoint_key);
-
-  ClientCaptureEvent event;
-  *event.mutable_interned_tracepoint_event() = std::move(*tracepoint_event);
-  capture_event_buffer_->AddEvent(std::move(event));
-}
-
 void ProducerEventProcessorImpl::ProcessEvent(uint64_t producer_id, ProducerCaptureEvent event) {
   switch (event.event_case()) {
     case ProducerCaptureEvent::kInternedCallstack:
@@ -364,12 +346,6 @@ void ProducerEventProcessorImpl::ProcessEvent(uint64_t producer_id, ProducerCapt
       break;
     case ProducerCaptureEvent::kFullAddressInfo:
       ProcessFullAddressInfo(event.mutable_full_address_info());
-      break;
-    case ProducerCaptureEvent::kInternedTracepointEvent:
-      ProcessInternedTracepointEvent(producer_id, event.mutable_interned_tracepoint_event());
-      break;
-    case ProducerCaptureEvent::kInternedTracepointInfo:
-      ProcessInternedTracepointInfo(producer_id, event.mutable_interned_tracepoint_info());
       break;
     case ProducerCaptureEvent::kIntrospectionScope:
       ProcessIntrospectionScope(event.mutable_introspection_scope());

--- a/src/Service/ProducerEventProcessor.h
+++ b/src/Service/ProducerEventProcessor.h
@@ -22,10 +22,9 @@ class ProducerEventProcessor {
 
   virtual void ProcessEvent(uint64_t producer_id,
                             orbit_grpc_protos::ProducerCaptureEvent event) = 0;
-};
 
-std::unique_ptr<ProducerEventProcessor> CreateProducerEventProcessor(
-    CaptureEventBuffer* capture_event_buffer);
+  static std::unique_ptr<ProducerEventProcessor> Create(CaptureEventBuffer* capture_event_buffer);
+};
 
 }  // namespace orbit_service
 

--- a/src/Service/ProducerEventProcessor.h
+++ b/src/Service/ProducerEventProcessor.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SERVICE_PRODUCER_EVENT_PROCESSOR_H_
+#define SERVICE_PRODUCER_EVENT_PROCESSOR_H_
+
+#include <stdint.h>
+
+#include "CaptureEventBuffer.h"
+#include "capture.pb.h"
+
+namespace orbit_service {
+
+// The implementation of this interface is responsible for processing
+// ProducerCaptureEvents from multiple producers.
+// It converts them to ClientCaptureEvents and sends to CaptureEventBuffer.
+class ProducerEventProcessor {
+ public:
+  ProducerEventProcessor() = default;
+  virtual ~ProducerEventProcessor() = default;
+
+  virtual void ProcessEvent(uint64_t producer_id,
+                            orbit_grpc_protos::ProducerCaptureEvent event) = 0;
+};
+
+std::unique_ptr<ProducerEventProcessor> CreateProducerEventProcessor(
+    CaptureEventBuffer* capture_event_buffer);
+
+}  // namespace orbit_service
+
+#endif  // SERVICE_PRODUCER_EVENT_PROCESSOR_H_

--- a/src/Service/ProducerEventProcessorTest.cpp
+++ b/src/Service/ProducerEventProcessorTest.cpp
@@ -1,0 +1,1268 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <stdint.h>
+
+#include "ProducerEventProcessor.h"
+#include "capture.pb.h"
+
+namespace orbit_service {
+
+namespace {
+
+using orbit_grpc_protos::Callstack;
+using orbit_grpc_protos::ClientCaptureEvent;
+using orbit_grpc_protos::FullAddressInfo;
+using orbit_grpc_protos::FullCallstackSample;
+using orbit_grpc_protos::FullGpuJobEvent;
+using orbit_grpc_protos::FullTracepointEvent;
+using orbit_grpc_protos::FunctionCall;
+using orbit_grpc_protos::GpuCommandBuffer;
+using orbit_grpc_protos::GpuDebugMarker;
+using orbit_grpc_protos::GpuQueueSubmission;
+using orbit_grpc_protos::GpuSubmitInfo;
+using orbit_grpc_protos::InternedAddressInfo;
+using orbit_grpc_protos::InternedCallstack;
+using orbit_grpc_protos::InternedCallstackSample;
+using orbit_grpc_protos::InternedGpuJobEvent;
+using orbit_grpc_protos::InternedString;
+using orbit_grpc_protos::InternedTracepointEvent;
+using orbit_grpc_protos::InternedTracepointInfo;
+using orbit_grpc_protos::ModuleInfo;
+using orbit_grpc_protos::ModuleUpdateEvent;
+using orbit_grpc_protos::ProducerCaptureEvent;
+using orbit_grpc_protos::SchedulingSlice;
+using orbit_grpc_protos::ThreadStateSlice;
+using orbit_grpc_protos::TracepointInfo;
+
+using ::testing::SaveArg;
+
+class MockCaptureEventBuffer : public CaptureEventBuffer {
+ public:
+  MOCK_METHOD(void, AddEvent, (orbit_grpc_protos::ClientCaptureEvent && /*event*/), (override));
+};
+
+constexpr uint64_t kDefaultProducerId = 31;
+
+constexpr int32_t kPid1 = 5;
+constexpr int32_t kPid2 = 17;
+constexpr int32_t kTid1 = 7;
+constexpr int32_t kTid2 = 111;
+constexpr int32_t kCore1 = 11;
+constexpr uint64_t kKey1 = 13;
+constexpr uint64_t kKey2 = 113;
+
+constexpr uint64_t kDurationNs1 = 971;
+constexpr uint64_t kDurationNs2 = 977;
+
+constexpr uint64_t kTimestampNs1 = 7723;
+constexpr uint64_t kTimestampNs2 = 7727;
+
+constexpr int32_t kNumBeginMarkers1 = 19;
+constexpr int32_t kNumBeginMarkers2 = 23;
+
+constexpr int32_t kDepth1 = 29;
+constexpr int32_t kDepth2 = 31;
+
+constexpr uint64_t kFunctionId1 = 37;
+constexpr uint64_t kFunctionId2 = 41;
+
+constexpr uint32_t kGpuJobContext1 = 43;
+constexpr uint32_t kGpuJobContext2 = 47;
+
+constexpr uint32_t kSeqNo1 = 53;
+constexpr uint32_t kSeqNo2 = 59;
+
+constexpr float kAlpha1 = 0.1f;
+constexpr float kRed1 = 0.2f;
+constexpr float kGreen1 = 0.3f;
+constexpr float kBlue1 = 0.4f;
+
+constexpr float kAlpha2 = 2.1f;
+constexpr float kRed2 = 2.2f;
+constexpr float kGreen2 = 2.3f;
+constexpr float kBlue2 = 2.4f;
+
+}  // namespace
+
+TEST(ProducerEventProcessor, OneSchedulingSliceEvent) {
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = CreateProducerEventProcessor(&buffer);
+
+  ProducerCaptureEvent event;
+  SchedulingSlice* scheduling_slice = event.mutable_scheduling_slice();
+  scheduling_slice->set_pid(kPid1);
+  scheduling_slice->set_tid(kTid1);
+  scheduling_slice->set_core(kCore1);
+  scheduling_slice->set_duration_ns(kDurationNs1);
+  scheduling_slice->set_out_timestamp_ns(kTimestampNs1);
+
+  ClientCaptureEvent client_capture_event;
+  EXPECT_CALL(buffer, AddEvent).Times(1).WillOnce(SaveArg<0>(&client_capture_event));
+
+  producer_event_processor->ProcessEvent(kDefaultProducerId, event);
+  ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kSchedulingSlice);
+  const SchedulingSlice& actual_scheduling_slice = client_capture_event.scheduling_slice();
+
+  EXPECT_EQ(actual_scheduling_slice.pid(), kPid1);
+  EXPECT_EQ(actual_scheduling_slice.tid(), kTid1);
+  EXPECT_EQ(actual_scheduling_slice.core(), kCore1);
+  EXPECT_EQ(actual_scheduling_slice.duration_ns(), kDurationNs1);
+  EXPECT_EQ(actual_scheduling_slice.out_timestamp_ns(), kTimestampNs1);
+}
+
+TEST(ProducerEventProcessor, OneInternedCallstack) {
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = CreateProducerEventProcessor(&buffer);
+
+  ProducerCaptureEvent event;
+  InternedCallstack* interned_callstack = event.mutable_interned_callstack();
+  interned_callstack->set_key(kKey1);
+  Callstack* callstack = interned_callstack->mutable_intern();
+  callstack->add_pcs(1);
+  callstack->add_pcs(2);
+  callstack->add_pcs(3);
+
+  ClientCaptureEvent client_capture_event;
+  EXPECT_CALL(buffer, AddEvent).Times(1).WillOnce(SaveArg<0>(&client_capture_event));
+
+  producer_event_processor->ProcessEvent(kDefaultProducerId, event);
+
+  ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kInternedCallstack);
+  const InternedCallstack& actual_interned_callstack = client_capture_event.interned_callstack();
+
+  // We do not expect resulting id to be the same, but we also do not
+  // enforce sequential ids in the test. 0 value is reserved.
+  EXPECT_NE(actual_interned_callstack.key(), 0);
+  ASSERT_EQ(actual_interned_callstack.intern().pcs_size(), 3);
+  EXPECT_EQ(actual_interned_callstack.intern().pcs()[0], 1);
+  EXPECT_EQ(actual_interned_callstack.intern().pcs()[1], 2);
+  EXPECT_EQ(actual_interned_callstack.intern().pcs()[2], 3);
+}
+
+TEST(ProducerEventProcessor, TwoInternedCallstacskDifferentProducersSameKey) {
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = CreateProducerEventProcessor(&buffer);
+
+  ProducerCaptureEvent event1;
+  InternedCallstack* interned_callstack1 = event1.mutable_interned_callstack();
+  interned_callstack1->set_key(kKey1);
+  Callstack* callstack1 = interned_callstack1->mutable_intern();
+  callstack1->add_pcs(1);
+  callstack1->add_pcs(2);
+  callstack1->add_pcs(3);
+
+  ProducerCaptureEvent event2;
+  InternedCallstack* interned_callstack2 = event2.mutable_interned_callstack();
+  interned_callstack2->set_key(kKey1);
+  Callstack* callstack2 = interned_callstack2->mutable_intern();
+  callstack2->add_pcs(1);
+  callstack2->add_pcs(2);
+  callstack2->add_pcs(4);
+
+  ClientCaptureEvent client_capture_event1;
+  EXPECT_CALL(buffer, AddEvent).Times(1).WillOnce(SaveArg<0>(&client_capture_event1));
+  producer_event_processor->ProcessEvent(1, event1);
+
+  ClientCaptureEvent client_capture_event2;
+  EXPECT_CALL(buffer, AddEvent).Times(1).WillOnce(SaveArg<0>(&client_capture_event2));
+  producer_event_processor->ProcessEvent(2, event2);
+
+  ASSERT_EQ(client_capture_event1.event_case(), ClientCaptureEvent::kInternedCallstack);
+  ASSERT_EQ(client_capture_event2.event_case(), ClientCaptureEvent::kInternedCallstack);
+
+  const InternedCallstack& actual_interned_callstack1 = client_capture_event1.interned_callstack();
+  const InternedCallstack& actual_interned_callstack2 = client_capture_event2.interned_callstack();
+
+  EXPECT_NE(actual_interned_callstack1.key(), actual_interned_callstack2.key());
+
+  EXPECT_NE(actual_interned_callstack1.key(), 0);
+  ASSERT_EQ(actual_interned_callstack1.intern().pcs_size(), 3);
+  EXPECT_EQ(actual_interned_callstack1.intern().pcs()[0], 1);
+  EXPECT_EQ(actual_interned_callstack1.intern().pcs()[1], 2);
+  EXPECT_EQ(actual_interned_callstack1.intern().pcs()[2], 3);
+
+  EXPECT_NE(actual_interned_callstack2.key(), 0);
+  ASSERT_EQ(actual_interned_callstack2.intern().pcs_size(), 3);
+  EXPECT_EQ(actual_interned_callstack2.intern().pcs()[0], 1);
+  EXPECT_EQ(actual_interned_callstack2.intern().pcs()[1], 2);
+  EXPECT_EQ(actual_interned_callstack2.intern().pcs()[2], 4);
+}
+
+TEST(ProducerEventProcessor, TwoInternedCallstacksDifferentProducersSameIntern) {
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = CreateProducerEventProcessor(&buffer);
+
+  constexpr uint64_t kProducer1CallstackKey = kKey1;
+  constexpr uint64_t kProducer2CallstackKey = kKey2;
+
+  ProducerCaptureEvent event1;
+  InternedCallstack* interned_callstack1 = event1.mutable_interned_callstack();
+  interned_callstack1->set_key(kProducer1CallstackKey);
+  Callstack* callstack1 = interned_callstack1->mutable_intern();
+  callstack1->add_pcs(1);
+  callstack1->add_pcs(2);
+  callstack1->add_pcs(3);
+
+  ProducerCaptureEvent event2;
+  InternedCallstack* interned_callstack2 = event2.mutable_interned_callstack();
+  interned_callstack2->set_key(kProducer2CallstackKey);
+  interned_callstack2->mutable_intern()->CopyFrom(*callstack1);
+
+  ClientCaptureEvent client_capture_event;
+  // We expect only one call here because we have similar callstacks.
+  EXPECT_CALL(buffer, AddEvent).Times(1).WillOnce(SaveArg<0>(&client_capture_event));
+  producer_event_processor->ProcessEvent(1, event1);
+  producer_event_processor->ProcessEvent(2, event2);
+
+  ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kInternedCallstack);
+  const InternedCallstack& actual_interned_callstack = client_capture_event.interned_callstack();
+
+  EXPECT_NE(actual_interned_callstack.key(), 0);
+  ASSERT_EQ(actual_interned_callstack.intern().pcs_size(), 3);
+  EXPECT_EQ(actual_interned_callstack.intern().pcs()[0], 1);
+  EXPECT_EQ(actual_interned_callstack.intern().pcs()[1], 2);
+  EXPECT_EQ(actual_interned_callstack.intern().pcs()[2], 3);
+
+  // Now check that the both producer's callstack are still tracked by
+  // ProducerEventProcessor
+  testing::Mock::VerifyAndClearExpectations(&buffer);
+
+  ProducerCaptureEvent callstack_sample_event1;
+  InternedCallstackSample* callstack_sample1 =
+      callstack_sample_event1.mutable_interned_callstack_sample();
+  callstack_sample1->set_pid(kPid1);
+  callstack_sample1->set_tid(kTid1);
+  callstack_sample1->set_timestamp_ns(kTimestampNs1);
+  callstack_sample1->set_callstack_id(kProducer1CallstackKey);
+
+  ProducerCaptureEvent callstack_sample_event2;
+  InternedCallstackSample* callstack_sample2 =
+      callstack_sample_event2.mutable_interned_callstack_sample();
+  callstack_sample2->set_pid(kPid2);
+  callstack_sample2->set_tid(kTid2);
+  callstack_sample2->set_timestamp_ns(kTimestampNs2);
+  callstack_sample2->set_callstack_id(kProducer2CallstackKey);
+
+  ClientCaptureEvent sample_capture_event1;
+  ClientCaptureEvent sample_capture_event2;
+  EXPECT_CALL(buffer, AddEvent)
+      .Times(2)
+      .WillOnce(SaveArg<0>(&sample_capture_event1))
+      .WillOnce(SaveArg<0>(&sample_capture_event2));
+  producer_event_processor->ProcessEvent(1, callstack_sample_event1);
+  producer_event_processor->ProcessEvent(2, callstack_sample_event2);
+
+  ASSERT_EQ(sample_capture_event1.event_case(), ClientCaptureEvent::kInternedCallstackSample);
+  ASSERT_EQ(sample_capture_event2.event_case(), ClientCaptureEvent::kInternedCallstackSample);
+
+  const InternedCallstackSample& sample1 = sample_capture_event1.interned_callstack_sample();
+  const InternedCallstackSample& sample2 = sample_capture_event2.interned_callstack_sample();
+
+  EXPECT_EQ(sample1.pid(), kPid1);
+  EXPECT_EQ(sample1.tid(), kTid1);
+  EXPECT_EQ(sample1.timestamp_ns(), kTimestampNs1);
+  EXPECT_EQ(sample1.callstack_id(), actual_interned_callstack.key());
+
+  EXPECT_EQ(sample2.pid(), kPid2);
+  EXPECT_EQ(sample2.tid(), kTid2);
+  EXPECT_EQ(sample2.timestamp_ns(), kTimestampNs2);
+  EXPECT_EQ(sample2.callstack_id(), actual_interned_callstack.key());
+}
+
+static ProducerCaptureEvent CreateInternedStringEvent(uint64_t key, const std::string& str) {
+  ProducerCaptureEvent interned_string_event;
+  InternedString* interned_string = interned_string_event.mutable_interned_string();
+  interned_string->set_key(key);
+  interned_string->set_intern(str);
+  return interned_string_event;
+}
+
+TEST(ProducerEventProcessor, OneInternedString) {
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = CreateProducerEventProcessor(&buffer);
+
+  ProducerCaptureEvent event = CreateInternedStringEvent(kKey1, "string");
+
+  ClientCaptureEvent client_capture_event;
+  EXPECT_CALL(buffer, AddEvent).Times(1).WillOnce(SaveArg<0>(&client_capture_event));
+
+  producer_event_processor->ProcessEvent(kDefaultProducerId, event);
+
+  ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kInternedString);
+  const InternedString& actual_interned_string = client_capture_event.interned_string();
+
+  // We do not expect resulting id to be the same, but we also do not
+  // enforce sequential ids in the test. 0 value is reserved.
+  EXPECT_NE(actual_interned_string.key(), 0);
+  ASSERT_EQ(actual_interned_string.intern(), "string");
+}
+
+TEST(ProducerEventProcessor, TwoInternedStringsDifferentProducersSameKey) {
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = CreateProducerEventProcessor(&buffer);
+
+  ProducerCaptureEvent event1 = CreateInternedStringEvent(kKey1, "string1");
+  ProducerCaptureEvent event2 = CreateInternedStringEvent(kKey1, "string2");
+
+  ClientCaptureEvent client_capture_event1;
+  EXPECT_CALL(buffer, AddEvent).Times(1).WillOnce(SaveArg<0>(&client_capture_event1));
+  producer_event_processor->ProcessEvent(1, event1);
+
+  ClientCaptureEvent client_capture_event2;
+  EXPECT_CALL(buffer, AddEvent).Times(1).WillOnce(SaveArg<0>(&client_capture_event2));
+  producer_event_processor->ProcessEvent(2, event2);
+
+  ASSERT_EQ(client_capture_event1.event_case(), ClientCaptureEvent::kInternedString);
+  ASSERT_EQ(client_capture_event2.event_case(), ClientCaptureEvent::kInternedString);
+
+  const InternedString& actual_interned_string1 = client_capture_event1.interned_string();
+  const InternedString& actual_interned_string2 = client_capture_event2.interned_string();
+
+  EXPECT_NE(actual_interned_string1.key(), actual_interned_string2.key());
+
+  EXPECT_NE(actual_interned_string1.key(), 0);
+  EXPECT_EQ(actual_interned_string1.intern(), "string1");
+
+  EXPECT_NE(actual_interned_string1.key(), 0);
+  EXPECT_EQ(actual_interned_string2.intern(), "string2");
+}
+
+TEST(ProducerEventProcessor, TwoInternedStringsDifferentProducersSameIntern) {
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = CreateProducerEventProcessor(&buffer);
+
+  constexpr uint64_t kProducer1StringKey = kKey1;
+  constexpr uint64_t kProducer2StringKey = kKey2;
+
+  ProducerCaptureEvent event1 = CreateInternedStringEvent(kProducer1StringKey, "string");
+  ProducerCaptureEvent event2 = CreateInternedStringEvent(kProducer2StringKey, "string");
+
+  ClientCaptureEvent client_capture_event;
+  // We expect only one call here because we have same string.
+  EXPECT_CALL(buffer, AddEvent).Times(1).WillOnce(SaveArg<0>(&client_capture_event));
+  producer_event_processor->ProcessEvent(1, event1);
+  producer_event_processor->ProcessEvent(2, event2);
+
+  ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kInternedString);
+  const InternedString& actual_interned_string = client_capture_event.interned_string();
+
+  EXPECT_NE(actual_interned_string.key(), 0);
+  EXPECT_EQ(actual_interned_string.intern(), "string");
+
+  // Now check that the both producer's strings are still tracked by
+  // ProducerEventProcessor
+  testing::Mock::VerifyAndClearExpectations(&buffer);
+
+  ProducerCaptureEvent gpu_queue_submission_event1;
+  GpuQueueSubmission* gpu_queue_submission1 =
+      gpu_queue_submission_event1.mutable_gpu_queue_submission();
+  gpu_queue_submission1->set_num_begin_markers(kNumBeginMarkers1);
+  gpu_queue_submission1->mutable_meta_info()->set_tid(kTid1);
+  gpu_queue_submission1->mutable_meta_info()->set_pre_submission_cpu_timestamp(kTimestampNs1);
+  gpu_queue_submission1->mutable_meta_info()->set_post_submission_cpu_timestamp(kTimestampNs2);
+  GpuDebugMarker* completed_marker1 = gpu_queue_submission1->add_completed_markers();
+  completed_marker1->set_depth(kDepth1);
+  completed_marker1->set_end_gpu_timestamp_ns(kTimestampNs1);
+  completed_marker1->set_text_key(kProducer1StringKey);
+
+  ProducerCaptureEvent gpu_queue_submission_event2;
+  GpuQueueSubmission* gpu_queue_submission2 =
+      gpu_queue_submission_event2.mutable_gpu_queue_submission();
+  gpu_queue_submission2->set_num_begin_markers(kNumBeginMarkers2);
+  gpu_queue_submission2->mutable_meta_info()->set_tid(kTid2);
+  gpu_queue_submission2->mutable_meta_info()->set_pre_submission_cpu_timestamp(kTimestampNs1);
+  gpu_queue_submission2->mutable_meta_info()->set_post_submission_cpu_timestamp(kTimestampNs2);
+  GpuDebugMarker* completed_marker2 = gpu_queue_submission2->add_completed_markers();
+  completed_marker2->set_depth(kDepth2);
+  completed_marker2->set_end_gpu_timestamp_ns(kTimestampNs2);
+  completed_marker2->set_text_key(kProducer2StringKey);
+
+  ClientCaptureEvent client_capture_event1;
+  ClientCaptureEvent client_capture_event2;
+  EXPECT_CALL(buffer, AddEvent)
+      .Times(2)
+      .WillOnce(SaveArg<0>(&client_capture_event1))
+      .WillOnce(SaveArg<0>(&client_capture_event2));
+  producer_event_processor->ProcessEvent(1, gpu_queue_submission_event1);
+  producer_event_processor->ProcessEvent(2, gpu_queue_submission_event2);
+
+  ASSERT_EQ(client_capture_event1.event_case(), ClientCaptureEvent::kGpuQueueSubmission);
+  ASSERT_EQ(client_capture_event2.event_case(), ClientCaptureEvent::kGpuQueueSubmission);
+
+  const GpuQueueSubmission& submission1 = client_capture_event1.gpu_queue_submission();
+  const GpuQueueSubmission& submission2 = client_capture_event2.gpu_queue_submission();
+
+  EXPECT_EQ(submission1.num_begin_markers(), kNumBeginMarkers1);
+  EXPECT_EQ(submission1.meta_info().tid(), kTid1);
+  EXPECT_EQ(submission1.meta_info().pre_submission_cpu_timestamp(), kTimestampNs1);
+  EXPECT_EQ(submission1.meta_info().post_submission_cpu_timestamp(), kTimestampNs2);
+  ASSERT_EQ(submission1.completed_markers_size(), 1);
+  EXPECT_EQ(submission1.completed_markers()[0].depth(), kDepth1);
+  EXPECT_EQ(submission1.completed_markers()[0].end_gpu_timestamp_ns(), kTimestampNs1);
+  EXPECT_EQ(submission1.completed_markers()[0].text_key(), actual_interned_string.key());
+
+  EXPECT_EQ(submission2.num_begin_markers(), kNumBeginMarkers2);
+  EXPECT_EQ(submission2.meta_info().tid(), kTid2);
+  EXPECT_EQ(submission2.meta_info().pre_submission_cpu_timestamp(), kTimestampNs1);
+  EXPECT_EQ(submission2.meta_info().post_submission_cpu_timestamp(), kTimestampNs2);
+  ASSERT_EQ(submission2.completed_markers_size(), 1);
+  EXPECT_EQ(submission2.completed_markers()[0].depth(), kDepth2);
+  EXPECT_EQ(submission2.completed_markers()[0].end_gpu_timestamp_ns(), kTimestampNs2);
+  EXPECT_EQ(submission2.completed_markers()[0].text_key(), actual_interned_string.key());
+}
+
+TEST(ProducerEventProcessor, FullCallstackSampleDifferentCallstacks) {
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = CreateProducerEventProcessor(&buffer);
+
+  ProducerCaptureEvent event1;
+  FullCallstackSample* full_callstack_sample1 = event1.mutable_full_callstack_sample();
+  full_callstack_sample1->set_pid(kPid1);
+  full_callstack_sample1->set_tid(kTid1);
+  full_callstack_sample1->set_timestamp_ns(kTimestampNs1);
+  Callstack* callstack1 = full_callstack_sample1->mutable_callstack();
+  callstack1->add_pcs(1);
+  callstack1->add_pcs(2);
+  callstack1->add_pcs(3);
+  callstack1->add_pcs(4);
+
+  ProducerCaptureEvent event2;
+  FullCallstackSample* full_callstack_sample2 = event2.mutable_full_callstack_sample();
+  full_callstack_sample2->set_pid(kPid2);
+  full_callstack_sample2->set_tid(kTid2);
+  full_callstack_sample2->set_timestamp_ns(kTimestampNs2);
+  Callstack* callstack2 = full_callstack_sample2->mutable_callstack();
+  callstack2->add_pcs(5);
+  callstack2->add_pcs(6);
+  callstack2->add_pcs(7);
+  callstack2->add_pcs(8);
+
+  ClientCaptureEvent interned_callstack_event1;
+  ClientCaptureEvent callstack_sameple_event1;
+  ClientCaptureEvent interned_callstack_event2;
+  ClientCaptureEvent callstack_sameple_event2;
+  EXPECT_CALL(buffer, AddEvent)
+      .Times(4)
+      .WillOnce(SaveArg<0>(&interned_callstack_event1))
+      .WillOnce(SaveArg<0>(&callstack_sameple_event1))
+      .WillOnce(SaveArg<0>(&interned_callstack_event2))
+      .WillOnce(SaveArg<0>(&callstack_sameple_event2));
+
+  producer_event_processor->ProcessEvent(1, event1);
+  producer_event_processor->ProcessEvent(1, event2);
+
+  ASSERT_EQ(interned_callstack_event1.event_case(), ClientCaptureEvent::kInternedCallstack);
+  ASSERT_EQ(interned_callstack_event2.event_case(), ClientCaptureEvent::kInternedCallstack);
+  ASSERT_EQ(callstack_sameple_event1.event_case(), ClientCaptureEvent::kInternedCallstackSample);
+  ASSERT_EQ(callstack_sameple_event2.event_case(), ClientCaptureEvent::kInternedCallstackSample);
+
+  const InternedCallstack& interned_callstack1 = interned_callstack_event1.interned_callstack();
+  EXPECT_NE(interned_callstack1.key(), 0);
+  ASSERT_EQ(interned_callstack1.intern().pcs_size(), 4);
+  EXPECT_EQ(interned_callstack1.intern().pcs(0), 1);
+  EXPECT_EQ(interned_callstack1.intern().pcs(1), 2);
+  EXPECT_EQ(interned_callstack1.intern().pcs(2), 3);
+  EXPECT_EQ(interned_callstack1.intern().pcs(3), 4);
+
+  const InternedCallstack& interned_callstack2 = interned_callstack_event2.interned_callstack();
+  EXPECT_NE(interned_callstack2.key(), 0);
+  ASSERT_EQ(interned_callstack2.intern().pcs_size(), 4);
+  EXPECT_EQ(interned_callstack2.intern().pcs(0), 5);
+  EXPECT_EQ(interned_callstack2.intern().pcs(1), 6);
+  EXPECT_EQ(interned_callstack2.intern().pcs(2), 7);
+  EXPECT_EQ(interned_callstack2.intern().pcs(3), 8);
+
+  const InternedCallstackSample& callstack_sample1 =
+      callstack_sameple_event1.interned_callstack_sample();
+  EXPECT_EQ(callstack_sample1.pid(), kPid1);
+  EXPECT_EQ(callstack_sample1.tid(), kTid1);
+  EXPECT_EQ(callstack_sample1.timestamp_ns(), kTimestampNs1);
+  EXPECT_EQ(callstack_sample1.callstack_id(), interned_callstack1.key());
+
+  const InternedCallstackSample& callstack_sample2 =
+      callstack_sameple_event2.interned_callstack_sample();
+  EXPECT_EQ(callstack_sample2.pid(), kPid2);
+  EXPECT_EQ(callstack_sample2.tid(), kTid2);
+  EXPECT_EQ(callstack_sample2.timestamp_ns(), kTimestampNs2);
+  EXPECT_EQ(callstack_sample2.callstack_id(), interned_callstack2.key());
+}
+
+TEST(ProducerEventProcessor, FullCallstackSamplesSameCallstack) {
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = CreateProducerEventProcessor(&buffer);
+
+  ProducerCaptureEvent event1;
+  FullCallstackSample* full_callstack_sample1 = event1.mutable_full_callstack_sample();
+  full_callstack_sample1->set_pid(kPid1);
+  full_callstack_sample1->set_tid(kTid1);
+  full_callstack_sample1->set_timestamp_ns(kTimestampNs1);
+  Callstack* callstack1 = full_callstack_sample1->mutable_callstack();
+  callstack1->add_pcs(1);
+  callstack1->add_pcs(2);
+  callstack1->add_pcs(3);
+  callstack1->add_pcs(4);
+
+  ProducerCaptureEvent event2;
+  FullCallstackSample* full_callstack_sample2 = event2.mutable_full_callstack_sample();
+  full_callstack_sample2->set_pid(kPid2);
+  full_callstack_sample2->set_tid(kTid2);
+  full_callstack_sample2->set_timestamp_ns(kTimestampNs2);
+  Callstack* callstack2 = full_callstack_sample2->mutable_callstack();
+  callstack2->add_pcs(1);
+  callstack2->add_pcs(2);
+  callstack2->add_pcs(3);
+  callstack2->add_pcs(4);
+
+  ClientCaptureEvent interned_callstack_event1;
+  ClientCaptureEvent callstack_sameple_event1;
+  ClientCaptureEvent callstack_sameple_event2;
+  EXPECT_CALL(buffer, AddEvent)
+      .Times(3)
+      .WillOnce(SaveArg<0>(&interned_callstack_event1))
+      .WillOnce(SaveArg<0>(&callstack_sameple_event1))
+      .WillOnce(SaveArg<0>(&callstack_sameple_event2));
+
+  producer_event_processor->ProcessEvent(1, event1);
+  producer_event_processor->ProcessEvent(1, event2);
+
+  ASSERT_EQ(interned_callstack_event1.event_case(), ClientCaptureEvent::kInternedCallstack);
+  ASSERT_EQ(callstack_sameple_event1.event_case(), ClientCaptureEvent::kInternedCallstackSample);
+  ASSERT_EQ(callstack_sameple_event2.event_case(), ClientCaptureEvent::kInternedCallstackSample);
+
+  const InternedCallstack& interned_callstack1 = interned_callstack_event1.interned_callstack();
+  EXPECT_NE(interned_callstack1.key(), 0);
+  ASSERT_EQ(interned_callstack1.intern().pcs_size(), 4);
+  EXPECT_EQ(interned_callstack1.intern().pcs(0), 1);
+  EXPECT_EQ(interned_callstack1.intern().pcs(1), 2);
+  EXPECT_EQ(interned_callstack1.intern().pcs(2), 3);
+  EXPECT_EQ(interned_callstack1.intern().pcs(3), 4);
+
+  const InternedCallstackSample& callstack_sample1 =
+      callstack_sameple_event1.interned_callstack_sample();
+  EXPECT_EQ(callstack_sample1.pid(), kPid1);
+  EXPECT_EQ(callstack_sample1.tid(), kTid1);
+  EXPECT_EQ(callstack_sample1.timestamp_ns(), kTimestampNs1);
+  EXPECT_EQ(callstack_sample1.callstack_id(), interned_callstack1.key());
+
+  const InternedCallstackSample& callstack_sample2 =
+      callstack_sameple_event2.interned_callstack_sample();
+  EXPECT_EQ(callstack_sample2.pid(), kPid2);
+  EXPECT_EQ(callstack_sample2.tid(), kTid2);
+  EXPECT_EQ(callstack_sample2.timestamp_ns(), kTimestampNs2);
+  EXPECT_EQ(callstack_sample2.callstack_id(), interned_callstack1.key());
+}
+
+TEST(ProducerEventProcessor, FullTracepointEventsDifferentTracepoints) {
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = CreateProducerEventProcessor(&buffer);
+
+  ProducerCaptureEvent event1;
+  FullTracepointEvent* full_tracepoint_event1 = event1.mutable_full_tracepoint_event();
+  full_tracepoint_event1->set_pid(kPid1);
+  full_tracepoint_event1->set_tid(kTid1);
+  full_tracepoint_event1->set_timestamp_ns(kTimestampNs1);
+  full_tracepoint_event1->mutable_tracepoint_info()->set_category("category1");
+  full_tracepoint_event1->mutable_tracepoint_info()->set_name("name1");
+
+  ProducerCaptureEvent event2;
+  FullTracepointEvent* full_tracepoint_event2 = event2.mutable_full_tracepoint_event();
+  full_tracepoint_event2->set_pid(kPid2);
+  full_tracepoint_event2->set_tid(kTid2);
+  full_tracepoint_event2->set_timestamp_ns(kTimestampNs2);
+  full_tracepoint_event2->mutable_tracepoint_info()->set_category("category2");
+  full_tracepoint_event2->mutable_tracepoint_info()->set_name("name2");
+
+  ClientCaptureEvent interned_tracepoint_info_event1;
+  ClientCaptureEvent tracepoint_event1;
+  ClientCaptureEvent interned_tracepoint_info_event2;
+  ClientCaptureEvent tracepoint_event2;
+  EXPECT_CALL(buffer, AddEvent)
+      .Times(4)
+      .WillOnce(SaveArg<0>(&interned_tracepoint_info_event1))
+      .WillOnce(SaveArg<0>(&tracepoint_event1))
+      .WillOnce(SaveArg<0>(&interned_tracepoint_info_event2))
+      .WillOnce(SaveArg<0>(&tracepoint_event2));
+
+  producer_event_processor->ProcessEvent(1, event1);
+  producer_event_processor->ProcessEvent(1, event2);
+
+  ASSERT_EQ(interned_tracepoint_info_event1.event_case(),
+            ClientCaptureEvent::kInternedTracepointInfo);
+  ASSERT_EQ(interned_tracepoint_info_event2.event_case(),
+            ClientCaptureEvent::kInternedTracepointInfo);
+  ASSERT_EQ(tracepoint_event1.event_case(), ClientCaptureEvent::kInternedTracepointEvent);
+  ASSERT_EQ(tracepoint_event2.event_case(), ClientCaptureEvent::kInternedTracepointEvent);
+
+  const InternedTracepointInfo& interned_tracepoint_info1 =
+      interned_tracepoint_info_event1.interned_tracepoint_info();
+  EXPECT_NE(interned_tracepoint_info1.key(), 0);
+  ASSERT_EQ(interned_tracepoint_info1.intern().name(), "name1");
+  EXPECT_EQ(interned_tracepoint_info1.intern().category(), "category1");
+
+  const InternedTracepointInfo& interned_tracepoint_info2 =
+      interned_tracepoint_info_event2.interned_tracepoint_info();
+  EXPECT_NE(interned_tracepoint_info2.key(), 0);
+  ASSERT_EQ(interned_tracepoint_info2.intern().name(), "name2");
+  EXPECT_EQ(interned_tracepoint_info2.intern().category(), "category2");
+
+  const InternedTracepointEvent& interned_tracepoint_event1 =
+      tracepoint_event1.interned_tracepoint_event();
+  EXPECT_EQ(interned_tracepoint_event1.pid(), kPid1);
+  EXPECT_EQ(interned_tracepoint_event1.tid(), kTid1);
+  EXPECT_EQ(interned_tracepoint_event1.timestamp_ns(), kTimestampNs1);
+  EXPECT_EQ(interned_tracepoint_event1.tracepoint_info_key(), interned_tracepoint_info1.key());
+
+  const InternedTracepointEvent& interned_tracepoint_event2 =
+      tracepoint_event2.interned_tracepoint_event();
+  EXPECT_EQ(interned_tracepoint_event2.pid(), kPid2);
+  EXPECT_EQ(interned_tracepoint_event2.tid(), kTid2);
+  EXPECT_EQ(interned_tracepoint_event2.timestamp_ns(), kTimestampNs2);
+  EXPECT_EQ(interned_tracepoint_event2.tracepoint_info_key(), interned_tracepoint_info2.key());
+}
+
+TEST(ProducerEventProcessor, FullTracepointEventsSameTracepoint) {
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = CreateProducerEventProcessor(&buffer);
+
+  ProducerCaptureEvent event1;
+  FullTracepointEvent* full_tracepoint_event1 = event1.mutable_full_tracepoint_event();
+  full_tracepoint_event1->set_pid(kPid1);
+  full_tracepoint_event1->set_tid(kTid1);
+  full_tracepoint_event1->set_timestamp_ns(kTimestampNs1);
+  full_tracepoint_event1->mutable_tracepoint_info()->set_category("category1");
+  full_tracepoint_event1->mutable_tracepoint_info()->set_name("name1");
+
+  ProducerCaptureEvent event2;
+  FullTracepointEvent* full_tracepoint_event2 = event2.mutable_full_tracepoint_event();
+  full_tracepoint_event2->set_pid(kPid2);
+  full_tracepoint_event2->set_tid(kTid2);
+  full_tracepoint_event2->set_timestamp_ns(kTimestampNs2);
+  full_tracepoint_event2->mutable_tracepoint_info()->set_category("category1");
+  full_tracepoint_event2->mutable_tracepoint_info()->set_name("name1");
+
+  ClientCaptureEvent interned_tracepoint_info_event1;
+  ClientCaptureEvent tracepoint_event1;
+  ClientCaptureEvent tracepoint_event2;
+  EXPECT_CALL(buffer, AddEvent)
+      .Times(3)
+      .WillOnce(SaveArg<0>(&interned_tracepoint_info_event1))
+      .WillOnce(SaveArg<0>(&tracepoint_event1))
+      .WillOnce(SaveArg<0>(&tracepoint_event2));
+
+  producer_event_processor->ProcessEvent(1, event1);
+  producer_event_processor->ProcessEvent(1, event2);
+
+  ASSERT_EQ(interned_tracepoint_info_event1.event_case(),
+            ClientCaptureEvent::kInternedTracepointInfo);
+  ASSERT_EQ(tracepoint_event1.event_case(), ClientCaptureEvent::kInternedTracepointEvent);
+  ASSERT_EQ(tracepoint_event2.event_case(), ClientCaptureEvent::kInternedTracepointEvent);
+
+  const InternedTracepointInfo& interned_tracepoint_info1 =
+      interned_tracepoint_info_event1.interned_tracepoint_info();
+  EXPECT_NE(interned_tracepoint_info1.key(), 0);
+  ASSERT_EQ(interned_tracepoint_info1.intern().name(), "name1");
+  EXPECT_EQ(interned_tracepoint_info1.intern().category(), "category1");
+
+  const InternedTracepointEvent& interned_tracepoint_event1 =
+      tracepoint_event1.interned_tracepoint_event();
+  EXPECT_EQ(interned_tracepoint_event1.pid(), kPid1);
+  EXPECT_EQ(interned_tracepoint_event1.tid(), kTid1);
+  EXPECT_EQ(interned_tracepoint_event1.timestamp_ns(), kTimestampNs1);
+  EXPECT_EQ(interned_tracepoint_event1.tracepoint_info_key(), interned_tracepoint_info1.key());
+
+  const InternedTracepointEvent& interned_tracepoint_event2 =
+      tracepoint_event2.interned_tracepoint_event();
+  EXPECT_EQ(interned_tracepoint_event2.pid(), kPid2);
+  EXPECT_EQ(interned_tracepoint_event2.tid(), kTid2);
+  EXPECT_EQ(interned_tracepoint_event2.timestamp_ns(), kTimestampNs2);
+  EXPECT_EQ(interned_tracepoint_event2.tracepoint_info_key(), interned_tracepoint_info1.key());
+}
+
+TEST(ProducerEventProcessor, FunctionCallSmoke) {
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = CreateProducerEventProcessor(&buffer);
+
+  ProducerCaptureEvent event1;
+  {
+    FunctionCall* function_call = event1.mutable_function_call();
+    function_call->set_pid(kPid1);
+    function_call->set_tid(kTid1);
+    function_call->set_function_id(kFunctionId1);
+    function_call->set_depth(kDepth1);
+    function_call->set_duration_ns(kDurationNs1);
+    function_call->set_end_timestamp_ns(kTimestampNs1);
+    function_call->set_return_value(42);
+    function_call->add_registers(42);
+    function_call->add_registers(2);
+    function_call->add_registers(3);
+  }
+
+  ProducerCaptureEvent event2;
+  {
+    FunctionCall* function_call = event2.mutable_function_call();
+    function_call->set_pid(kPid2);
+    function_call->set_tid(kTid2);
+    function_call->set_function_id(kFunctionId2);
+    function_call->set_depth(kDepth2);
+    function_call->set_duration_ns(kDurationNs2);
+    function_call->set_end_timestamp_ns(kTimestampNs2);
+    function_call->set_return_value(42);
+    function_call->add_registers(42);
+    function_call->add_registers(21);
+    function_call->add_registers(31);
+  }
+
+  ClientCaptureEvent function_call_event1;
+  ClientCaptureEvent function_call_event2;
+  EXPECT_CALL(buffer, AddEvent)
+      .Times(2)
+      .WillOnce(SaveArg<0>(&function_call_event1))
+      .WillOnce(SaveArg<0>(&function_call_event2));
+
+  producer_event_processor->ProcessEvent(1, event1);
+  producer_event_processor->ProcessEvent(1, event2);
+
+  ASSERT_EQ(function_call_event1.event_case(), ClientCaptureEvent::kFunctionCall);
+  ASSERT_EQ(function_call_event1.event_case(), ClientCaptureEvent::kFunctionCall);
+
+  {
+    const FunctionCall& function_call = function_call_event1.function_call();
+    EXPECT_EQ(function_call.pid(), kPid1);
+    EXPECT_EQ(function_call.tid(), kTid1);
+    EXPECT_EQ(function_call.function_id(), kFunctionId1);
+    EXPECT_EQ(function_call.duration_ns(), kDurationNs1);
+    EXPECT_EQ(function_call.end_timestamp_ns(), kTimestampNs1);
+    EXPECT_EQ(function_call.depth(), kDepth1);
+    EXPECT_EQ(function_call.return_value(), 42);
+    ASSERT_EQ(function_call.registers_size(), 3);
+    EXPECT_EQ(function_call.registers(0), 42);
+    EXPECT_EQ(function_call.registers(1), 2);
+    EXPECT_EQ(function_call.registers(2), 3);
+  }
+
+  {
+    const FunctionCall& function_call = function_call_event2.function_call();
+    EXPECT_EQ(function_call.pid(), kPid2);
+    EXPECT_EQ(function_call.tid(), kTid2);
+    EXPECT_EQ(function_call.function_id(), kFunctionId2);
+    EXPECT_EQ(function_call.duration_ns(), kDurationNs2);
+    EXPECT_EQ(function_call.end_timestamp_ns(), kTimestampNs2);
+    EXPECT_EQ(function_call.depth(), kDepth2);
+    EXPECT_EQ(function_call.return_value(), 42);
+    ASSERT_EQ(function_call.registers_size(), 3);
+    EXPECT_EQ(function_call.registers(0), 42);
+    EXPECT_EQ(function_call.registers(1), 21);
+    EXPECT_EQ(function_call.registers(2), 31);
+  }
+}
+
+TEST(ProducerEventProcessor, FullGpuJobEventDifferentTimelines) {
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = CreateProducerEventProcessor(&buffer);
+
+  ProducerCaptureEvent event1;
+  {
+    FullGpuJobEvent* gpu_job_event = event1.mutable_full_gpu_job_event();
+    gpu_job_event->set_pid(kPid1);
+    gpu_job_event->set_tid(kTid1);
+    gpu_job_event->set_context(kGpuJobContext1);
+    gpu_job_event->set_seqno(kSeqNo1);
+    gpu_job_event->set_depth(kDepth1);
+    gpu_job_event->set_amdgpu_cs_ioctl_time_ns(kTimestampNs1);
+    gpu_job_event->set_amdgpu_sched_run_job_time_ns(kTimestampNs1 + 1);
+    gpu_job_event->set_gpu_hardware_start_time_ns(kTimestampNs1 + 2);
+    gpu_job_event->set_dma_fence_signaled_time_ns(kTimestampNs1 + 3);
+    gpu_job_event->set_timeline("timeline1");
+  }
+
+  ProducerCaptureEvent event2;
+  {
+    FullGpuJobEvent* gpu_job_event = event2.mutable_full_gpu_job_event();
+    gpu_job_event->set_pid(kPid2);
+    gpu_job_event->set_tid(kTid2);
+    gpu_job_event->set_context(kGpuJobContext2);
+    gpu_job_event->set_seqno(kSeqNo2);
+    gpu_job_event->set_depth(kDepth2);
+    gpu_job_event->set_amdgpu_cs_ioctl_time_ns(kTimestampNs2);
+    gpu_job_event->set_amdgpu_sched_run_job_time_ns(kTimestampNs2 + 1);
+    gpu_job_event->set_gpu_hardware_start_time_ns(kTimestampNs2 + 2);
+    gpu_job_event->set_dma_fence_signaled_time_ns(kTimestampNs2 + 3);
+    gpu_job_event->set_timeline("timeline2");
+  }
+
+  ClientCaptureEvent interned_string1;
+  ClientCaptureEvent gpu_job_event1;
+  ClientCaptureEvent interned_string2;
+  ClientCaptureEvent gpu_job_event2;
+
+  EXPECT_CALL(buffer, AddEvent)
+      .Times(4)
+      .WillOnce(SaveArg<0>(&interned_string1))
+      .WillOnce(SaveArg<0>(&gpu_job_event1))
+      .WillOnce(SaveArg<0>(&interned_string2))
+      .WillOnce(SaveArg<0>(&gpu_job_event2));
+
+  producer_event_processor->ProcessEvent(1, event1);
+  producer_event_processor->ProcessEvent(1, event2);
+
+  ASSERT_EQ(interned_string1.event_case(), ClientCaptureEvent::kInternedString);
+  ASSERT_EQ(interned_string2.event_case(), ClientCaptureEvent::kInternedString);
+  ASSERT_EQ(gpu_job_event1.event_case(), ClientCaptureEvent::kInternedGpuJobEvent);
+  ASSERT_EQ(gpu_job_event2.event_case(), ClientCaptureEvent::kInternedGpuJobEvent);
+
+  {
+    const InternedString& interned_string = interned_string1.interned_string();
+    EXPECT_NE(interned_string.key(), 0);
+    EXPECT_EQ(interned_string.intern(), "timeline1");
+  }
+
+  {
+    const InternedString& interned_string = interned_string2.interned_string();
+    EXPECT_NE(interned_string.key(), 0);
+    EXPECT_EQ(interned_string.intern(), "timeline2");
+  }
+
+  {
+    const InternedGpuJobEvent& gpu_job_event = gpu_job_event1.interned_gpu_job_event();
+    EXPECT_EQ(gpu_job_event.pid(), kPid1);
+    EXPECT_EQ(gpu_job_event.tid(), kTid1);
+    EXPECT_EQ(gpu_job_event.context(), kGpuJobContext1);
+    EXPECT_EQ(gpu_job_event.seqno(), kSeqNo1);
+    EXPECT_EQ(gpu_job_event.depth(), kDepth1);
+    EXPECT_EQ(gpu_job_event.amdgpu_cs_ioctl_time_ns(), kTimestampNs1);
+    EXPECT_EQ(gpu_job_event.amdgpu_sched_run_job_time_ns(), kTimestampNs1 + 1);
+    EXPECT_EQ(gpu_job_event.gpu_hardware_start_time_ns(), kTimestampNs1 + 2);
+    EXPECT_EQ(gpu_job_event.dma_fence_signaled_time_ns(), kTimestampNs1 + 3);
+    EXPECT_EQ(gpu_job_event.timeline_key(), interned_string1.interned_string().key());
+  }
+
+  {
+    const InternedGpuJobEvent& gpu_job_event = gpu_job_event2.interned_gpu_job_event();
+    EXPECT_EQ(gpu_job_event.pid(), kPid2);
+    EXPECT_EQ(gpu_job_event.tid(), kTid2);
+    EXPECT_EQ(gpu_job_event.context(), kGpuJobContext2);
+    EXPECT_EQ(gpu_job_event.seqno(), kSeqNo2);
+    EXPECT_EQ(gpu_job_event.depth(), kDepth2);
+    EXPECT_EQ(gpu_job_event.amdgpu_cs_ioctl_time_ns(), kTimestampNs2);
+    EXPECT_EQ(gpu_job_event.amdgpu_sched_run_job_time_ns(), kTimestampNs2 + 1);
+    EXPECT_EQ(gpu_job_event.gpu_hardware_start_time_ns(), kTimestampNs2 + 2);
+    EXPECT_EQ(gpu_job_event.dma_fence_signaled_time_ns(), kTimestampNs2 + 3);
+    EXPECT_EQ(gpu_job_event.timeline_key(), interned_string2.interned_string().key());
+  }
+}
+
+TEST(ProducerEventProcessor, FullGpuJobEventSameTimeline) {
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = CreateProducerEventProcessor(&buffer);
+
+  ProducerCaptureEvent event1;
+  {
+    FullGpuJobEvent* gpu_job_event = event1.mutable_full_gpu_job_event();
+    gpu_job_event->set_pid(kPid1);
+    gpu_job_event->set_tid(kTid1);
+    gpu_job_event->set_context(kGpuJobContext1);
+    gpu_job_event->set_seqno(kSeqNo1);
+    gpu_job_event->set_depth(kDepth1);
+    gpu_job_event->set_amdgpu_cs_ioctl_time_ns(kTimestampNs1);
+    gpu_job_event->set_amdgpu_sched_run_job_time_ns(kTimestampNs1 + 1);
+    gpu_job_event->set_gpu_hardware_start_time_ns(kTimestampNs1 + 2);
+    gpu_job_event->set_dma_fence_signaled_time_ns(kTimestampNs1 + 3);
+    gpu_job_event->set_timeline("timeline1");
+  }
+
+  ProducerCaptureEvent event2;
+  {
+    FullGpuJobEvent* gpu_job_event = event2.mutable_full_gpu_job_event();
+    gpu_job_event->set_pid(kPid2);
+    gpu_job_event->set_tid(kTid2);
+    gpu_job_event->set_context(kGpuJobContext2);
+    gpu_job_event->set_seqno(kSeqNo2);
+    gpu_job_event->set_depth(kDepth2);
+    gpu_job_event->set_amdgpu_cs_ioctl_time_ns(kTimestampNs2);
+    gpu_job_event->set_amdgpu_sched_run_job_time_ns(kTimestampNs2 + 1);
+    gpu_job_event->set_gpu_hardware_start_time_ns(kTimestampNs2 + 2);
+    gpu_job_event->set_dma_fence_signaled_time_ns(kTimestampNs2 + 3);
+    gpu_job_event->set_timeline("timeline1");
+  }
+
+  ClientCaptureEvent interned_string_event;
+  ClientCaptureEvent gpu_job_event1;
+  ClientCaptureEvent gpu_job_event2;
+
+  EXPECT_CALL(buffer, AddEvent)
+      .Times(3)
+      .WillOnce(SaveArg<0>(&interned_string_event))
+      .WillOnce(SaveArg<0>(&gpu_job_event1))
+      .WillOnce(SaveArg<0>(&gpu_job_event2));
+
+  producer_event_processor->ProcessEvent(1, event1);
+  producer_event_processor->ProcessEvent(1, event2);
+
+  ASSERT_EQ(interned_string_event.event_case(), ClientCaptureEvent::kInternedString);
+  ASSERT_EQ(gpu_job_event1.event_case(), ClientCaptureEvent::kInternedGpuJobEvent);
+  ASSERT_EQ(gpu_job_event2.event_case(), ClientCaptureEvent::kInternedGpuJobEvent);
+
+  {
+    const InternedString& interned_string = interned_string_event.interned_string();
+    EXPECT_NE(interned_string.key(), 0);
+    EXPECT_EQ(interned_string.intern(), "timeline1");
+  }
+
+  {
+    const InternedGpuJobEvent& gpu_job_event = gpu_job_event1.interned_gpu_job_event();
+    EXPECT_EQ(gpu_job_event.pid(), kPid1);
+    EXPECT_EQ(gpu_job_event.tid(), kTid1);
+    EXPECT_EQ(gpu_job_event.context(), kGpuJobContext1);
+    EXPECT_EQ(gpu_job_event.seqno(), kSeqNo1);
+    EXPECT_EQ(gpu_job_event.depth(), kDepth1);
+    EXPECT_EQ(gpu_job_event.amdgpu_cs_ioctl_time_ns(), kTimestampNs1);
+    EXPECT_EQ(gpu_job_event.amdgpu_sched_run_job_time_ns(), kTimestampNs1 + 1);
+    EXPECT_EQ(gpu_job_event.gpu_hardware_start_time_ns(), kTimestampNs1 + 2);
+    EXPECT_EQ(gpu_job_event.dma_fence_signaled_time_ns(), kTimestampNs1 + 3);
+    EXPECT_EQ(gpu_job_event.timeline_key(), interned_string_event.interned_string().key());
+  }
+
+  {
+    const InternedGpuJobEvent& gpu_job_event = gpu_job_event2.interned_gpu_job_event();
+    EXPECT_EQ(gpu_job_event.pid(), kPid2);
+    EXPECT_EQ(gpu_job_event.tid(), kTid2);
+    EXPECT_EQ(gpu_job_event.context(), kGpuJobContext2);
+    EXPECT_EQ(gpu_job_event.seqno(), kSeqNo2);
+    EXPECT_EQ(gpu_job_event.depth(), kDepth2);
+    EXPECT_EQ(gpu_job_event.amdgpu_cs_ioctl_time_ns(), kTimestampNs2);
+    EXPECT_EQ(gpu_job_event.amdgpu_sched_run_job_time_ns(), kTimestampNs2 + 1);
+    EXPECT_EQ(gpu_job_event.gpu_hardware_start_time_ns(), kTimestampNs2 + 2);
+    EXPECT_EQ(gpu_job_event.dma_fence_signaled_time_ns(), kTimestampNs2 + 3);
+    EXPECT_EQ(gpu_job_event.timeline_key(), interned_string_event.interned_string().key());
+  }
+}
+
+TEST(ProducerEventProcessor, GpuQueueSubmissionSmoke) {
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = CreateProducerEventProcessor(&buffer);
+
+  ProducerCaptureEvent producer_string_event1 = CreateInternedStringEvent(kKey1, "debug marker1");
+  ProducerCaptureEvent producer_string_event2 = CreateInternedStringEvent(kKey2, "debug marker2");
+
+  ProducerCaptureEvent producer_gpu_submission_event;
+  {
+    GpuQueueSubmission* gpu_queue_submission =
+        producer_gpu_submission_event.mutable_gpu_queue_submission();
+    gpu_queue_submission->mutable_meta_info()->set_tid(kTid1);
+    gpu_queue_submission->mutable_meta_info()->set_pre_submission_cpu_timestamp(kTimestampNs1);
+    gpu_queue_submission->mutable_meta_info()->set_post_submission_cpu_timestamp(kTimestampNs1 + 1);
+    gpu_queue_submission->set_num_begin_markers(2);
+
+    {
+      GpuSubmitInfo* submit_info = gpu_queue_submission->add_submit_infos();
+      {
+        GpuCommandBuffer* command_buffer = submit_info->add_command_buffers();
+        command_buffer->set_begin_gpu_timestamp_ns(kTimestampNs1 + 10);
+        command_buffer->set_end_gpu_timestamp_ns(kTimestampNs1 + 11);
+      }
+      {
+        GpuCommandBuffer* command_buffer = submit_info->add_command_buffers();
+        command_buffer->set_begin_gpu_timestamp_ns(kTimestampNs1 + 20);
+        command_buffer->set_end_gpu_timestamp_ns(kTimestampNs1 + 21);
+      }
+    }
+
+    {
+      GpuSubmitInfo* submit_info = gpu_queue_submission->add_submit_infos();
+      {
+        GpuCommandBuffer* command_buffer = submit_info->add_command_buffers();
+        command_buffer->set_begin_gpu_timestamp_ns(kTimestampNs1 + 30);
+        command_buffer->set_end_gpu_timestamp_ns(kTimestampNs1 + 31);
+      }
+    }
+
+    {
+      GpuDebugMarker* debug_marker = gpu_queue_submission->add_completed_markers();
+      debug_marker->mutable_begin_marker()->set_gpu_timestamp_ns(kTimestampNs1 + 40);
+      debug_marker->mutable_begin_marker()->mutable_meta_info()->set_tid(kTid1 + 1);
+      debug_marker->mutable_begin_marker()->mutable_meta_info()->set_pre_submission_cpu_timestamp(
+          kTimestampNs1 + 100);
+      debug_marker->mutable_begin_marker()->mutable_meta_info()->set_post_submission_cpu_timestamp(
+          kTimestampNs1 + 101);
+      debug_marker->set_text_key(kKey1);
+      debug_marker->set_depth(kDepth1);
+      debug_marker->set_end_gpu_timestamp_ns(kTimestampNs1 + 50);
+
+      debug_marker->mutable_color()->set_alpha(kAlpha1);
+      debug_marker->mutable_color()->set_red(kRed1);
+      debug_marker->mutable_color()->set_green(kGreen1);
+      debug_marker->mutable_color()->set_blue(kBlue1);
+    }
+
+    {
+      GpuDebugMarker* debug_marker = gpu_queue_submission->add_completed_markers();
+      debug_marker->mutable_begin_marker()->set_gpu_timestamp_ns(kTimestampNs2 + 40);
+      debug_marker->mutable_begin_marker()->mutable_meta_info()->set_tid(kTid2 + 1);
+      debug_marker->mutable_begin_marker()->mutable_meta_info()->set_pre_submission_cpu_timestamp(
+          kTimestampNs2 + 100);
+      debug_marker->mutable_begin_marker()->mutable_meta_info()->set_post_submission_cpu_timestamp(
+          kTimestampNs2 + 101);
+      debug_marker->set_text_key(kKey2);
+      debug_marker->set_depth(kDepth2);
+      debug_marker->set_end_gpu_timestamp_ns(kTimestampNs2 + 50);
+
+      debug_marker->mutable_color()->set_alpha(kAlpha2);
+      debug_marker->mutable_color()->set_red(kRed2);
+      debug_marker->mutable_color()->set_green(kGreen2);
+      debug_marker->mutable_color()->set_blue(kBlue2);
+    }
+  }
+
+  ClientCaptureEvent string_event1;
+  ClientCaptureEvent string_event2;
+  ClientCaptureEvent gpu_submission_event;
+
+  EXPECT_CALL(buffer, AddEvent)
+      .Times(3)
+      .WillOnce(SaveArg<0>(&string_event1))
+      .WillOnce(SaveArg<0>(&string_event2))
+      .WillOnce(SaveArg<0>(&gpu_submission_event));
+
+  producer_event_processor->ProcessEvent(1, producer_string_event1);
+  producer_event_processor->ProcessEvent(1, producer_string_event2);
+  producer_event_processor->ProcessEvent(1, producer_gpu_submission_event);
+
+  ASSERT_EQ(string_event1.event_case(), ClientCaptureEvent::kInternedString);
+  ASSERT_EQ(string_event2.event_case(), ClientCaptureEvent::kInternedString);
+  ASSERT_EQ(gpu_submission_event.event_case(), ClientCaptureEvent::kGpuQueueSubmission);
+
+  uint64_t string_key1 = string_event1.interned_string().key();
+  uint64_t string_key2 = string_event2.interned_string().key();
+  EXPECT_NE(string_key1, 0);
+  EXPECT_EQ(string_event1.interned_string().intern(), "debug marker1");
+  EXPECT_NE(string_key2, 0);
+  EXPECT_EQ(string_event2.interned_string().intern(), "debug marker2");
+
+  const GpuQueueSubmission& gpu_queue_submission = gpu_submission_event.gpu_queue_submission();
+  EXPECT_EQ(gpu_queue_submission.meta_info().tid(), kTid1);
+  EXPECT_EQ(gpu_queue_submission.meta_info().pre_submission_cpu_timestamp(), kTimestampNs1);
+  EXPECT_EQ(gpu_queue_submission.meta_info().post_submission_cpu_timestamp(), kTimestampNs1 + 1);
+  EXPECT_EQ(gpu_queue_submission.num_begin_markers(), 2);
+  ASSERT_EQ(gpu_queue_submission.submit_infos_size(), 2);
+  {
+    const GpuSubmitInfo& submit_info = gpu_queue_submission.submit_infos(0);
+    ASSERT_EQ(submit_info.command_buffers_size(), 2);
+    EXPECT_EQ(submit_info.command_buffers(0).begin_gpu_timestamp_ns(), kTimestampNs1 + 10);
+    EXPECT_EQ(submit_info.command_buffers(0).end_gpu_timestamp_ns(), kTimestampNs1 + 11);
+    EXPECT_EQ(submit_info.command_buffers(1).begin_gpu_timestamp_ns(), kTimestampNs1 + 20);
+    EXPECT_EQ(submit_info.command_buffers(1).end_gpu_timestamp_ns(), kTimestampNs1 + 21);
+  }
+  {
+    const GpuSubmitInfo& submit_info = gpu_queue_submission.submit_infos(1);
+    ASSERT_EQ(submit_info.command_buffers_size(), 1);
+    EXPECT_EQ(submit_info.command_buffers(0).begin_gpu_timestamp_ns(), kTimestampNs1 + 30);
+    EXPECT_EQ(submit_info.command_buffers(0).end_gpu_timestamp_ns(), kTimestampNs1 + 31);
+  }
+
+  ASSERT_EQ(gpu_queue_submission.completed_markers_size(), 2);
+  {
+    const GpuDebugMarker& debug_marker = gpu_queue_submission.completed_markers(0);
+    EXPECT_EQ(debug_marker.begin_marker().gpu_timestamp_ns(), kTimestampNs1 + 40);
+    EXPECT_EQ(debug_marker.begin_marker().meta_info().tid(), kTid1 + 1);
+    EXPECT_EQ(debug_marker.begin_marker().meta_info().pre_submission_cpu_timestamp(),
+              kTimestampNs1 + 100);
+    EXPECT_EQ(debug_marker.begin_marker().meta_info().post_submission_cpu_timestamp(),
+              kTimestampNs1 + 101);
+    EXPECT_EQ(debug_marker.text_key(), string_key1);
+    EXPECT_EQ(debug_marker.depth(), kDepth1);
+    EXPECT_EQ(debug_marker.end_gpu_timestamp_ns(), kTimestampNs1 + 50);
+
+    EXPECT_EQ(debug_marker.color().alpha(), kAlpha1);
+    EXPECT_EQ(debug_marker.color().red(), kRed1);
+    EXPECT_EQ(debug_marker.color().green(), kGreen1);
+    EXPECT_EQ(debug_marker.color().blue(), kBlue1);
+  }
+
+  {
+    const GpuDebugMarker& debug_marker = gpu_queue_submission.completed_markers(1);
+    EXPECT_EQ(debug_marker.begin_marker().gpu_timestamp_ns(), kTimestampNs2 + 40);
+    EXPECT_EQ(debug_marker.begin_marker().meta_info().tid(), kTid2 + 1);
+    EXPECT_EQ(debug_marker.begin_marker().meta_info().pre_submission_cpu_timestamp(),
+              kTimestampNs2 + 100);
+    EXPECT_EQ(debug_marker.begin_marker().meta_info().post_submission_cpu_timestamp(),
+              kTimestampNs2 + 101);
+    EXPECT_EQ(debug_marker.text_key(), string_key2);
+    EXPECT_EQ(debug_marker.depth(), kDepth2);
+    EXPECT_EQ(debug_marker.end_gpu_timestamp_ns(), kTimestampNs2 + 50);
+
+    EXPECT_EQ(debug_marker.color().alpha(), kAlpha2);
+    EXPECT_EQ(debug_marker.color().red(), kRed2);
+    EXPECT_EQ(debug_marker.color().green(), kGreen2);
+    EXPECT_EQ(debug_marker.color().blue(), kBlue2);
+  }
+}
+
+TEST(ProducerEventProcessor, ThreadNameSmoke) {
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = CreateProducerEventProcessor(&buffer);
+
+  ProducerCaptureEvent producer_thread_name;
+  producer_thread_name.mutable_thread_name()->set_pid(kPid1);
+  producer_thread_name.mutable_thread_name()->set_tid(kTid1);
+  producer_thread_name.mutable_thread_name()->set_timestamp_ns(kTimestampNs1);
+  producer_thread_name.mutable_thread_name()->set_name("Main Thread");
+
+  ClientCaptureEvent event;
+
+  EXPECT_CALL(buffer, AddEvent).Times(1).WillOnce(SaveArg<0>(&event));
+
+  producer_event_processor->ProcessEvent(1, producer_thread_name);
+
+  ASSERT_EQ(event.event_case(), ClientCaptureEvent::kThreadName);
+  EXPECT_EQ(event.thread_name().pid(), kPid1);
+  EXPECT_EQ(event.thread_name().tid(), kTid1);
+  EXPECT_EQ(event.thread_name().timestamp_ns(), kTimestampNs1);
+  EXPECT_EQ(event.thread_name().name(), "Main Thread");
+}
+
+TEST(ProducerEventProcessor, ThreadStateSliceSmoke) {
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = CreateProducerEventProcessor(&buffer);
+
+  ProducerCaptureEvent producer_event;
+  {
+    ThreadStateSlice* thread_state_slice = producer_event.mutable_thread_state_slice();
+    thread_state_slice->set_pid(kPid1);
+    thread_state_slice->set_tid(kTid1);
+    thread_state_slice->set_thread_state(ThreadStateSlice::kIdle);
+    thread_state_slice->set_duration_ns(kDurationNs1);
+    thread_state_slice->set_end_timestamp_ns(kTimestampNs1);
+  }
+
+  ClientCaptureEvent event;
+
+  EXPECT_CALL(buffer, AddEvent).Times(1).WillOnce(SaveArg<0>(&event));
+
+  producer_event_processor->ProcessEvent(1, producer_event);
+
+  ASSERT_EQ(event.event_case(), ClientCaptureEvent::kThreadStateSlice);
+  const ThreadStateSlice& thread_state_slice = event.thread_state_slice();
+  EXPECT_EQ(thread_state_slice.pid(), kPid1);
+  EXPECT_EQ(thread_state_slice.tid(), kTid1);
+  EXPECT_EQ(thread_state_slice.thread_state(), ThreadStateSlice::kIdle);
+  EXPECT_EQ(thread_state_slice.duration_ns(), kDurationNs1);
+  EXPECT_EQ(thread_state_slice.end_timestamp_ns(), kTimestampNs1);
+}
+
+TEST(ProducerEventProcessor, ModuleUpdateEventSmoke) {
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = CreateProducerEventProcessor(&buffer);
+
+  ProducerCaptureEvent producer_event;
+  {
+    ModuleUpdateEvent* module_update_event = producer_event.mutable_module_update_event();
+    module_update_event->set_pid(kPid1);
+    module_update_event->set_timestamp_ns(kTimestampNs1);
+    ModuleInfo* module_info = module_update_event->mutable_module();
+    module_info->set_name("module");
+    module_info->set_file_path("file path");
+    module_info->set_file_size(1000);
+    module_info->set_address_start(5000);
+    module_info->set_address_end(7000);
+    module_info->set_build_id("build id 42");
+    module_info->set_load_bias(0x2000);
+  }
+
+  ClientCaptureEvent event;
+
+  EXPECT_CALL(buffer, AddEvent).Times(1).WillOnce(SaveArg<0>(&event));
+
+  producer_event_processor->ProcessEvent(1, producer_event);
+
+  ASSERT_EQ(event.event_case(), ClientCaptureEvent::kModuleUpdateEvent);
+  const ModuleUpdateEvent& module_update = event.module_update_event();
+  EXPECT_EQ(module_update.pid(), kPid1);
+  EXPECT_EQ(module_update.timestamp_ns(), kTimestampNs1);
+  EXPECT_EQ(module_update.module().name(), "module");
+  EXPECT_EQ(module_update.module().file_path(), "file path");
+  EXPECT_EQ(module_update.module().file_size(), 1000);
+  EXPECT_EQ(module_update.module().address_start(), 5000);
+  EXPECT_EQ(module_update.module().address_end(), 7000);
+  EXPECT_EQ(module_update.module().build_id(), "build id 42");
+  EXPECT_EQ(module_update.module().load_bias(), 0x2000);
+}
+
+TEST(ProducerEventProcessor, FullAddressInfoSmoke) {
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = CreateProducerEventProcessor(&buffer);
+
+  ProducerCaptureEvent producer_event1;
+  {
+    FullAddressInfo* address_info = producer_event1.mutable_full_address_info();
+    address_info->set_absolute_address(1000);
+    address_info->set_offset_in_function(10);
+    address_info->set_function_name("function1");
+    address_info->set_module_name("module");
+  }
+
+  ProducerCaptureEvent producer_event2;
+  {
+    FullAddressInfo* address_info = producer_event2.mutable_full_address_info();
+    address_info->set_absolute_address(2000);
+    address_info->set_offset_in_function(20);
+    address_info->set_function_name("function2");
+    address_info->set_module_name("module");
+  }
+
+  ClientCaptureEvent interned_string_function1;
+  ClientCaptureEvent interned_string_module;
+  ClientCaptureEvent interned_string_function2;
+  ClientCaptureEvent address_info_event1;
+  ClientCaptureEvent address_info_event2;
+
+  EXPECT_CALL(buffer, AddEvent)
+      .Times(5)
+      .WillOnce(SaveArg<0>(&interned_string_function1))
+      .WillOnce(SaveArg<0>(&interned_string_module))
+      .WillOnce(SaveArg<0>(&address_info_event1))
+      .WillOnce(SaveArg<0>(&interned_string_function2))
+      .WillOnce(SaveArg<0>(&address_info_event2));
+
+  producer_event_processor->ProcessEvent(1, producer_event1);
+  producer_event_processor->ProcessEvent(1, producer_event2);
+
+  ASSERT_EQ(interned_string_function1.event_case(), ClientCaptureEvent::kInternedString);
+  ASSERT_EQ(interned_string_function2.event_case(), ClientCaptureEvent::kInternedString);
+  ASSERT_EQ(interned_string_module.event_case(), ClientCaptureEvent::kInternedString);
+  ASSERT_EQ(address_info_event1.event_case(), ClientCaptureEvent::kInternedAddressInfo);
+  ASSERT_EQ(address_info_event2.event_case(), ClientCaptureEvent::kInternedAddressInfo);
+
+  EXPECT_EQ(interned_string_function1.interned_string().intern(), "function1");
+  EXPECT_EQ(interned_string_function2.interned_string().intern(), "function2");
+  EXPECT_EQ(interned_string_module.interned_string().intern(), "module");
+
+  const uint64_t module_key = interned_string_module.interned_string().key();
+  const uint64_t function1_key = interned_string_function1.interned_string().key();
+  const uint64_t function2_key = interned_string_function2.interned_string().key();
+
+  EXPECT_NE(module_key, 0);
+  EXPECT_NE(function1_key, 0);
+  EXPECT_NE(function2_key, 0);
+
+  {
+    const InternedAddressInfo& address_info = address_info_event1.interned_address_info();
+    EXPECT_EQ(address_info.absolute_address(), 1000);
+    EXPECT_EQ(address_info.offset_in_function(), 10);
+    EXPECT_EQ(address_info.function_name_key(), function1_key);
+    EXPECT_EQ(address_info.module_name_key(), module_key);
+  }
+
+  {
+    const InternedAddressInfo& address_info = address_info_event2.interned_address_info();
+    EXPECT_EQ(address_info.absolute_address(), 2000);
+    EXPECT_EQ(address_info.offset_in_function(), 20);
+    EXPECT_EQ(address_info.function_name_key(), function2_key);
+    EXPECT_EQ(address_info.module_name_key(), module_key);
+  }
+}
+
+}  // namespace orbit_service

--- a/src/Service/ProducerEventProcessorTest.cpp
+++ b/src/Service/ProducerEventProcessorTest.cpp
@@ -1265,4 +1265,37 @@ TEST(ProducerEventProcessor, FullAddressInfoSmoke) {
   }
 }
 
+TEST(ProducerEventProcessor, TwoInternedStringsSameProducerSameKey) {
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = CreateProducerEventProcessor(&buffer);
+
+  ProducerCaptureEvent event1 = CreateInternedStringEvent(kKey1, "string1");
+  ProducerCaptureEvent event2 = CreateInternedStringEvent(kKey1, "string2");
+
+  producer_event_processor->ProcessEvent(1, event1);
+  EXPECT_DEATH(producer_event_processor->ProcessEvent(1, event2), "");
+}
+
+TEST(ProducerEventProcessor, TwoInternedCallstacksSameProducerSameKey) {
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = CreateProducerEventProcessor(&buffer);
+
+  ProducerCaptureEvent event1;
+  {
+    InternedCallstack* callstack = event1.mutable_interned_callstack();
+    callstack->set_key(kKey1);
+    callstack->mutable_intern()->add_pcs(1);
+  }
+
+  ProducerCaptureEvent event2;
+  {
+    InternedCallstack* callstack = event2.mutable_interned_callstack();
+    callstack->set_key(kKey1);
+    callstack->mutable_intern()->add_pcs(2);
+  }
+
+  producer_event_processor->ProcessEvent(1, event1);
+  EXPECT_DEATH(producer_event_processor->ProcessEvent(1, event2), "");
+}
+
 }  // namespace orbit_service

--- a/src/Service/ProducerSideServer.cpp
+++ b/src/Service/ProducerSideServer.cpp
@@ -53,8 +53,9 @@ void ProducerSideServer::ShutdownAndWait() {
 }
 
 void ProducerSideServer::OnCaptureStartRequested(orbit_grpc_protos::CaptureOptions capture_options,
-                                                 CaptureEventBuffer* capture_event_buffer) {
-  producer_side_service_.OnCaptureStartRequested(std::move(capture_options), capture_event_buffer);
+                                                 ProducerEventProcessor* producer_event_processor) {
+  producer_side_service_.OnCaptureStartRequested(std::move(capture_options),
+                                                 producer_event_processor);
 }
 
 void ProducerSideServer::OnCaptureStopRequested() {

--- a/src/Service/ProducerSideServer.h
+++ b/src/Service/ProducerSideServer.h
@@ -25,7 +25,7 @@ class ProducerSideServer final : public CaptureStartStopListener {
   void ShutdownAndWait();
 
   void OnCaptureStartRequested(orbit_grpc_protos::CaptureOptions capture_options,
-                               CaptureEventBuffer* capture_event_buffer) override;
+                               ProducerEventProcessor* producer_event_processor) override;
   void OnCaptureStopRequested() override;
 
  private:

--- a/src/Service/ProducerSideServiceImpl.cpp
+++ b/src/Service/ProducerSideServiceImpl.cpp
@@ -118,7 +118,7 @@ grpc::Status ProducerSideServiceImpl::ReceiveCommandsAndSendEvents(
                                    &receive_events_thread_exited};
 
   // This thread is responsible for reading from stream, and specifically for
-  // receiving CaptureEvents and AllEventsSent messages.
+  // receiving ProducerCaptureEvents and AllEventsSent messages.
   std::thread receive_events_thread{&ProducerSideServiceImpl::ReceiveEventsThread,
                                     this,
                                     context,

--- a/src/Service/ProducerSideServiceImplTest.cpp
+++ b/src/Service/ProducerSideServiceImplTest.cpp
@@ -110,7 +110,7 @@ class FakeProducer {
 
 class MockCaptureEventBuffer : public CaptureEventBuffer {
  public:
-  MOCK_METHOD(void, AddEvent, (orbit_grpc_protos::CaptureEvent && event), (override));
+  MOCK_METHOD(void, AddEvent, (orbit_grpc_protos::ClientCaptureEvent && event), (override));
 };
 
 class ProducerSideServiceImplTest : public ::testing::Test {


### PR DESCRIPTION
This change achieves 2 objectives

1. Separate Producer<->Service interface from Service<->Client interface on proto level by splitting CaptureEvent into ClientCaptureEvent and ProducerCaptureEvent.
2. Remove dual intent protos like CallstackSample/AddressInfo and provide 2 variants, one with keys another one with full objects
