### PR TITLE
[REBASE TO MASTER] Solve the twice frame-track issue (regression)

### DIFF
--- a/src/OrbitGl/FrameTrackOnlineProcessor.cpp
+++ b/src/OrbitGl/FrameTrackOnlineProcessor.cpp
@@ -44,6 +44,7 @@ void FrameTrackOnlineProcessor::ProcessTimer(const orbit_client_protos::TimerInf
     // TID is meaningless for this timer (start and end can be on two different threads).
     constexpr const int32_t kUnusedThreadId = -1;
     frame_timer.set_thread_id(kUnusedThreadId);
+    frame_timer.set_function_id(function_id);
     frame_timer.set_start(previous_timestamp_ns);
     frame_timer.set_end(timer_info.start());
     // We use user_data_key to keep track of the frame number.


### PR DESCRIPTION
We aren't updating function_id in FrameTrackOnlineProcessor. So, while
capturing only one frame track appeared (with function_id = 0). When
finishing the capture you can see duplicated frame_tracks. Here we are
adding the frame_track with updated function_id while capturing.

Related with http://b/179462976

Test: Start/Stop a capture. Save/Load a capture.