### PR TITLE
Make OrbitApp::LoadModuleOnRemote return a Future

### DIFF
--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -416,6 +416,9 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void LoadModuleOnRemote(ModuleData* module_data, std::vector<uint64_t> function_hashes_to_hook,
                           std::vector<uint64_t> frame_track_function_hashes,
                           std::string error_message_from_local);
+  [[nodiscard]] orbit_base::Future<ErrorMessageOr<std::filesystem::path>> LoadModuleOnRemote(
+      const std::string& module_file_path);
+
   void SelectFunctionsFromHashes(const ModuleData* module,
                                  const std::vector<uint64_t>& function_hashes);
 
@@ -423,6 +426,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
                                                           const std::string& build_id);
   [[nodiscard]] orbit_base::Future<ErrorMessageOr<void>> LoadSymbols(
       const std::filesystem::path& symbols_path, const std::string& module_file_path);
+
   ErrorMessageOr<orbit_client_protos::PresetInfo> ReadPresetFromFile(
       const std::filesystem::path& filename);
 


### PR DESCRIPTION
The new version of `LoadModuleOnRemote` returns a future and works
asynchronously. An additional temporary overload was added that
calls the new implemenation but polyfills the old behaviour. This
overload will be removed in a later commit.