### PR TITLE
Fix crash on ending session during the capture

### DIFF
--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -482,6 +482,9 @@ void OrbitMainWindow::SetupTargetLabel() {
         "This discards any unsaved progress. Are you sure you want to continue?");
 
     if (reply == QMessageBox::Yes) {
+      if (app_->IsCapturing()) {
+        app_->AbortCapture();
+      }
       QApplication::exit(kEndSessionReturnCode);
     }
   });


### PR DESCRIPTION
Bug: http://b/179474593
Test: start capture, press "end session", confirm => no crash.