### PR TITLE
Replace MonotonicTimestampNs() by orbit_base::CaptureTimestampNs()

### DIFF
--- a/src/LinuxTracing/PerfEventOpen.cpp
+++ b/src/LinuxTracing/PerfEventOpen.cpp
@@ -13,6 +13,7 @@
 
 #include "LinuxTracingUtils.h"
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/Profiling.h"
 #include "OrbitBase/SafeStrerror.h"
 
 namespace orbit_linux_tracing {
@@ -22,7 +23,7 @@ perf_event_attr generic_event_attr() {
   pe.size = sizeof(struct perf_event_attr);
   pe.sample_period = 1;
   pe.use_clockid = 1;
-  pe.clockid = CLOCK_MONOTONIC;
+  pe.clockid = kOrbitTimelineClock;
   pe.sample_id_all = 1;  // Also include timestamps for lost events.
   pe.disabled = 1;
   pe.sample_type = SAMPLE_TYPE_TID_TIME_STREAMID_CPU;

--- a/src/LinuxTracing/PerfEventOpen.cpp
+++ b/src/LinuxTracing/PerfEventOpen.cpp
@@ -23,7 +23,7 @@ perf_event_attr generic_event_attr() {
   pe.size = sizeof(struct perf_event_attr);
   pe.sample_period = 1;
   pe.use_clockid = 1;
-  pe.clockid = kOrbitTimelineClock;
+  pe.clockid = orbit_base::kOrbitCaptureClock;
   pe.sample_id_all = 1;  // Also include timestamps for lost events.
   pe.disabled = 1;
   pe.sample_type = SAMPLE_TYPE_TID_TIME_STREAMID_CPU;

--- a/src/LinuxTracing/PerfEventProcessor.cpp
+++ b/src/LinuxTracing/PerfEventProcessor.cpp
@@ -39,7 +39,7 @@ void PerfEventProcessor::ProcessAllEvents() {
 
 void PerfEventProcessor::ProcessOldEvents() {
   CHECK(!visitors_.empty());
-  uint64_t current_timestamp_ns = MonotonicTimestampNs();
+  uint64_t current_timestamp_ns = orbit_base::CaptureTimestampNs();
 
   while (event_queue_.HasEvent()) {
     PerfEvent* event = event_queue_.TopEvent();

--- a/src/LinuxTracing/PerfEventProcessorTest.cpp
+++ b/src/LinuxTracing/PerfEventProcessorTest.cpp
@@ -55,9 +55,9 @@ std::unique_ptr<PerfEvent> MakeFakePerfEvent(int origin_fd, uint64_t timestamp_n
 
 TEST_F(PerfEventProcessorTest, ProcessOldEvents) {
   EXPECT_CALL(mock_visitor_, visit).Times(0);
-  processor_.AddEvent(MakeFakePerfEvent(11, MonotonicTimestampNs()));
-  processor_.AddEvent(MakeFakePerfEvent(11, MonotonicTimestampNs()));
-  processor_.AddEvent(MakeFakePerfEvent(22, MonotonicTimestampNs()));
+  processor_.AddEvent(MakeFakePerfEvent(11, orbit_base::CaptureTimestampNs()));
+  processor_.AddEvent(MakeFakePerfEvent(11, orbit_base::CaptureTimestampNs()));
+  processor_.AddEvent(MakeFakePerfEvent(22, orbit_base::CaptureTimestampNs()));
   processor_.ProcessOldEvents();
 
   ::testing::Mock::VerifyAndClearExpectations(&mock_visitor_);
@@ -65,7 +65,7 @@ TEST_F(PerfEventProcessorTest, ProcessOldEvents) {
   std::this_thread::sleep_for(std::chrono::milliseconds(kDelayBeforeProcessOldEventsMs));
 
   EXPECT_CALL(mock_visitor_, visit).Times(3);
-  processor_.AddEvent(MakeFakePerfEvent(11, MonotonicTimestampNs()));
+  processor_.AddEvent(MakeFakePerfEvent(11, orbit_base::CaptureTimestampNs()));
   processor_.ProcessOldEvents();
   EXPECT_EQ(discarded_out_of_order_counter_, 0);
 
@@ -80,10 +80,10 @@ TEST_F(PerfEventProcessorTest, ProcessOldEvents) {
 
 TEST_F(PerfEventProcessorTest, ProcessAllEvents) {
   EXPECT_CALL(mock_visitor_, visit).Times(4);
-  processor_.AddEvent(MakeFakePerfEvent(11, MonotonicTimestampNs()));
-  processor_.AddEvent(MakeFakePerfEvent(22, MonotonicTimestampNs()));
-  processor_.AddEvent(MakeFakePerfEvent(11, MonotonicTimestampNs()));
-  processor_.AddEvent(MakeFakePerfEvent(33, MonotonicTimestampNs()));
+  processor_.AddEvent(MakeFakePerfEvent(11, orbit_base::CaptureTimestampNs()));
+  processor_.AddEvent(MakeFakePerfEvent(22, orbit_base::CaptureTimestampNs()));
+  processor_.AddEvent(MakeFakePerfEvent(11, orbit_base::CaptureTimestampNs()));
+  processor_.AddEvent(MakeFakePerfEvent(33, orbit_base::CaptureTimestampNs()));
   processor_.ProcessAllEvents();
 
   ::testing::Mock::VerifyAndClearExpectations(&mock_visitor_);
@@ -97,9 +97,9 @@ TEST_F(PerfEventProcessorTest, ProcessAllEvents) {
 
 TEST_F(PerfEventProcessorTest, DiscardedOutOfOrderCounter) {
   EXPECT_CALL(mock_visitor_, visit).Times(4);
-  processor_.AddEvent(MakeFakePerfEvent(11, MonotonicTimestampNs()));
-  processor_.AddEvent(MakeFakePerfEvent(11, MonotonicTimestampNs()));
-  uint64_t last_processed_timestamp_ns = MonotonicTimestampNs();
+  processor_.AddEvent(MakeFakePerfEvent(11, orbit_base::CaptureTimestampNs()));
+  processor_.AddEvent(MakeFakePerfEvent(11, orbit_base::CaptureTimestampNs()));
+  uint64_t last_processed_timestamp_ns = orbit_base::CaptureTimestampNs();
   processor_.AddEvent(MakeFakePerfEvent(22, last_processed_timestamp_ns));
 
   std::this_thread::sleep_for(std::chrono::milliseconds(kDelayBeforeProcessOldEventsMs));
@@ -116,14 +116,14 @@ TEST_F(PerfEventProcessorTest, DiscardedOutOfOrderCounter) {
 
 TEST_F(PerfEventProcessorTest, ProcessOldEventsNeedsVisitor) {
   processor_.ClearVisitors();
-  processor_.AddEvent(MakeFakePerfEvent(11, MonotonicTimestampNs()));
+  processor_.AddEvent(MakeFakePerfEvent(11, orbit_base::CaptureTimestampNs()));
   std::this_thread::sleep_for(std::chrono::milliseconds(kDelayBeforeProcessOldEventsMs));
   EXPECT_DEATH(processor_.ProcessOldEvents(), "!visitors_.empty()");
 }
 
 TEST_F(PerfEventProcessorTest, ProcessAllEventsNeedsVisitor) {
   processor_.ClearVisitors();
-  processor_.AddEvent(MakeFakePerfEvent(11, MonotonicTimestampNs()));
+  processor_.AddEvent(MakeFakePerfEvent(11, orbit_base::CaptureTimestampNs()));
   std::this_thread::sleep_for(std::chrono::milliseconds(kDelayBeforeProcessOldEventsMs));
   EXPECT_DEATH(processor_.ProcessAllEvents(), "!visitors_.empty()");
 }

--- a/src/LinuxTracing/TracerThread.cpp
+++ b/src/LinuxTracing/TracerThread.cpp
@@ -588,7 +588,7 @@ void TracerThread::Run(const std::shared_ptr<std::atomic<bool>>& exit_requested)
     perf_event_enable(fd);
   }
 
-  effective_capture_start_timestamp_ns_ = MonotonicTimestampNs();
+  effective_capture_start_timestamp_ns_ = orbit_base::CaptureTimestampNs();
 
   // Get the initial thread names and notify the listener_.
   RetrieveThreadNamesSystemWide();
@@ -702,7 +702,7 @@ void TracerThread::Run(const std::shared_ptr<std::atomic<bool>>& exit_requested)
   event_processor_.ProcessAllEvents();
 
   if (trace_thread_state_) {
-    switches_states_names_visitor_->ProcessRemainingOpenStates(MonotonicTimestampNs());
+    switches_states_names_visitor_->ProcessRemainingOpenStates(orbit_base::CaptureTimestampNs());
   }
 
   // Stop recording.
@@ -989,7 +989,7 @@ void TracerThread::ProcessDeferredEvents() {
 }
 
 void TracerThread::RetrieveThreadNamesSystemWide() {
-  uint64_t timestamp_ns = MonotonicTimestampNs();
+  uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
   for (pid_t pid : GetAllPids()) {
     for (pid_t tid : GetTidsOfProcess(pid)) {
       std::string name = orbit_base::GetThreadName(tid);
@@ -1017,7 +1017,7 @@ void TracerThread::RetrieveTidToPidAssociationSystemWide() {
 
 void TracerThread::RetrieveThreadStatesOfTarget() {
   for (pid_t tid : GetTidsOfProcess(target_pid_)) {
-    uint64_t timestamp_ns = MonotonicTimestampNs();
+    uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
     std::optional<char> state = GetThreadState(tid);
     if (!state.has_value()) {
       continue;
@@ -1057,7 +1057,7 @@ void TracerThread::Reset() {
 
 void TracerThread::PrintStatsIfTimerElapsed() {
   ORBIT_SCOPE_FUNCTION;
-  uint64_t timestamp_ns = MonotonicTimestampNs();
+  uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
   if (stats_.event_count_begin_ns + EVENT_STATS_WINDOW_S * NS_PER_SECOND < timestamp_ns) {
     double actual_window_s =
         static_cast<double>(timestamp_ns - stats_.event_count_begin_ns) / NS_PER_SECOND;

--- a/src/LinuxTracing/TracerThread.h
+++ b/src/LinuxTracing/TracerThread.h
@@ -162,7 +162,7 @@ class TracerThread {
 
   struct EventStats {
     void Reset() {
-      event_count_begin_ns = MonotonicTimestampNs();
+      event_count_begin_ns = orbit_base::CaptureTimestampNs();
       sched_switch_count = 0;
       sample_count = 0;
       uprobes_count = 0;

--- a/src/OrbitBase/ProfilingTest.cpp
+++ b/src/OrbitBase/ProfilingTest.cpp
@@ -12,8 +12,8 @@
 #include "OrbitBase/Profiling.h"
 
 TEST(Profiling, MonotonicClock) {
-  uint64_t t0 = MonotonicTimestampNs();
+  uint64_t t0 = orbit_base::CaptureTimestampNs();
   std::this_thread::sleep_for(std::chrono::milliseconds(10));
-  uint64_t t1 = MonotonicTimestampNs();
+  uint64_t t1 = orbit_base::CaptureTimestampNs();
   EXPECT_TRUE(t1 > t0);
 }

--- a/src/OrbitBase/Tracing.cpp
+++ b/src/OrbitBase/Tracing.cpp
@@ -85,12 +85,12 @@ void Start(const char* name, orbit::Color color) {
   GetThreadLocalScopes().emplace_back(
       TracingScope(orbit_api::kScopeStart, name, /*data*/ 0, color));
   auto& scope = GetThreadLocalScopes().back();
-  scope.begin = MonotonicTimestampNs();
+  scope.begin = orbit_base::CaptureTimestampNs();
 }
 
 void Stop() {
   auto& scope = GetThreadLocalScopes().back();
-  scope.end = MonotonicTimestampNs();
+  scope.end = orbit_base::CaptureTimestampNs();
   scope.depth = GetThreadLocalScopes().size() - 1;
   scope.tid = static_cast<uint32_t>(orbit_base::GetCurrentThreadId());
   TracingListener::DeferScopeProcessing(scope);
@@ -99,7 +99,7 @@ void Stop() {
 
 void StartAsync(const char* name, uint64_t id, orbit::Color color) {
   TracingScope scope(orbit_api::kScopeStartAsync, name, id, color);
-  scope.begin = MonotonicTimestampNs();
+  scope.begin = orbit_base::CaptureTimestampNs();
   scope.end = scope.begin;
   scope.tid = static_cast<uint32_t>(orbit_base::GetCurrentThreadId());
   TracingListener::DeferScopeProcessing(scope);
@@ -107,7 +107,7 @@ void StartAsync(const char* name, uint64_t id, orbit::Color color) {
 
 void StopAsync(uint64_t id) {
   TracingScope scope(orbit_api::kScopeStopAsync, /*name*/ nullptr, id);
-  scope.begin = MonotonicTimestampNs();
+  scope.begin = orbit_base::CaptureTimestampNs();
   scope.end = scope.begin;
   scope.tid = static_cast<uint32_t>(orbit_base::GetCurrentThreadId());
   TracingListener::DeferScopeProcessing(scope);
@@ -129,7 +129,7 @@ void AsyncString(const char* str, uint64_t id, orbit::Color color) {
 
 void TrackValue(orbit_api::EventType type, const char* name, uint64_t value, orbit::Color color) {
   TracingScope scope(type, name, value, color);
-  scope.begin = MonotonicTimestampNs();
+  scope.begin = orbit_base::CaptureTimestampNs();
   scope.tid = static_cast<uint32_t>(orbit_base::GetCurrentThreadId());
   TracingListener::DeferScopeProcessing(scope);
 }

--- a/src/OrbitBase/include/OrbitBase/Profiling.h
+++ b/src/OrbitBase/include/OrbitBase/Profiling.h
@@ -13,16 +13,23 @@
 #endif
 
 #ifdef _WIN32
+
 [[nodiscard]] inline uint64_t MonotonicTimestampNs() {
   auto time_since_epoch = std::chrono::steady_clock::now().time_since_epoch();
   return std::chrono::duration_cast<std::chrono::nanoseconds>(time_since_epoch).count();
 }
+
 #else
+
+// Linux clock associated with Orbit's main time domain.
+constexpr clockid_t kOrbitTimelineClock = CLOCK_MONOTONIC;
+
 [[nodiscard]] inline uint64_t MonotonicTimestampNs() {
   timespec ts;
-  clock_gettime(CLOCK_MONOTONIC, &ts);
+  clock_gettime(kOrbitTimelineClock, &ts);
   return 1000000000LL * ts.tv_sec + ts.tv_nsec;
 }
+
 #endif
 
 #endif  // ORBIT_BASE_PROFILING_H_

--- a/src/OrbitBase/include/OrbitBase/Profiling.h
+++ b/src/OrbitBase/include/OrbitBase/Profiling.h
@@ -12,9 +12,16 @@
 #include <time.h>
 #endif
 
+namespace orbit_base {
+
+// CaptureTimestampNs() provides timestamps to place events on Orbit's main capture timeline.
+// Event producers on a given platform should all be part of the same time domain for their events
+// to be correlatable to other profiling events in Orbit. CaptureTimestatmpNs() produces timestamps
+// that increase monotonically.
+
 #ifdef _WIN32
 
-[[nodiscard]] inline uint64_t MonotonicTimestampNs() {
+[[nodiscard]] inline uint64_t CaptureTimestampNs() {
   auto time_since_epoch = std::chrono::steady_clock::now().time_since_epoch();
   return std::chrono::duration_cast<std::chrono::nanoseconds>(time_since_epoch).count();
 }
@@ -22,14 +29,16 @@
 #else
 
 // Linux clock associated with Orbit's main time domain.
-constexpr clockid_t kOrbitTimelineClock = CLOCK_MONOTONIC;
+constexpr clockid_t kOrbitCaptureClock = CLOCK_MONOTONIC;
 
-[[nodiscard]] inline uint64_t MonotonicTimestampNs() {
+[[nodiscard]] inline uint64_t CaptureTimestampNs() {
   timespec ts;
-  clock_gettime(kOrbitTimelineClock, &ts);
+  clock_gettime(kOrbitCaptureClock, &ts);
   return 1000000000LL * ts.tv_sec + ts.tv_nsec;
 }
 
 #endif
+
+}  // namespace orbit_base
 
 #endif  // ORBIT_BASE_PROFILING_H_

--- a/src/OrbitGl/Timer.h
+++ b/src/OrbitGl/Timer.h
@@ -26,7 +26,7 @@ class Timer {
 
  private:
   [[nodiscard]] uint64_t EndOrNow() const { return end_ == 0 ? Now() : end_; }
-  [[nodiscard]] static uint64_t Now() { return MonotonicTimestampNs(); }
+  [[nodiscard]] static uint64_t Now() { return orbit_base::CaptureTimestampNs(); }
 
   uint64_t start_ = 0;
   uint64_t end_ = 0;

--- a/src/OrbitVulkanLayer/SubmissionTracker.h
+++ b/src/OrbitVulkanLayer/SubmissionTracker.h
@@ -304,7 +304,8 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
     }
 
     QueueSubmission queue_submission;
-    queue_submission.meta_information.pre_submission_cpu_timestamp = MonotonicTimestampNs();
+    queue_submission.meta_information.pre_submission_cpu_timestamp =
+        orbit_base::CaptureTimestampNs();
     queue_submission.meta_information.thread_id = orbit_base::GetCurrentThreadId();
 
     for (uint32_t submit_index = 0; submit_index < submit_count; ++submit_index) {
@@ -365,7 +366,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
     // debug marker, as they may span across different submissions.
     if (queue_submission_optional.has_value()) {
       queue_submission_optional->meta_information.post_submission_cpu_timestamp =
-          MonotonicTimestampNs();
+          orbit_base::CaptureTimestampNs();
     }
 
     std::vector<uint32_t> marker_slots_to_reset;

--- a/src/OrbitVulkanLayer/SubmissionTrackerTest.cpp
+++ b/src/OrbitVulkanLayer/SubmissionTrackerTest.cpp
@@ -482,11 +482,11 @@ TEST_F(SubmissionTrackerTest, CanRetrieveCommandBufferTimestampsForACompleteSubm
   tracker_.MarkCommandBufferBegin(command_buffer_);
   tracker_.MarkCommandBufferEnd(command_buffer_);
   pid_t pid = orbit_base::GetCurrentThreadId();
-  uint64_t pre_submit_time = MonotonicTimestampNs();
+  uint64_t pre_submit_time = orbit_base::CaptureTimestampNs();
   std::optional<QueueSubmission> queue_submission_optional =
       tracker_.PersistCommandBuffersOnSubmit(1, &submit_info_);
   tracker_.PersistDebugMarkersOnSubmit(queue_, 1, &submit_info_, queue_submission_optional);
-  uint64_t post_submit_time = MonotonicTimestampNs();
+  uint64_t post_submit_time = orbit_base::CaptureTimestampNs();
   tracker_.CompleteSubmits(device_);
 
   EXPECT_THAT(actual_reset_slots, UnorderedElementsAre(kSlotIndex1, kSlotIndex2));
@@ -519,11 +519,11 @@ TEST_F(SubmissionTrackerTest,
   tracker_.MarkCommandBufferBegin(command_buffer_);
   tracker_.MarkCommandBufferEnd(command_buffer_);
   pid_t pid = orbit_base::GetCurrentThreadId();
-  uint64_t pre_submit_time = MonotonicTimestampNs();
+  uint64_t pre_submit_time = orbit_base::CaptureTimestampNs();
   std::optional<QueueSubmission> queue_submission_optional =
       tracker_.PersistCommandBuffersOnSubmit(1, &submit_info_);
   tracker_.PersistDebugMarkersOnSubmit(queue_, 1, &submit_info_, queue_submission_optional);
-  uint64_t post_submit_time = MonotonicTimestampNs();
+  uint64_t post_submit_time = orbit_base::CaptureTimestampNs();
   tracker_.CompleteSubmits(device_);
   tracker_.CompleteSubmits(device_);
 
@@ -579,11 +579,11 @@ TEST_F(SubmissionTrackerTest,
   tracker_.MarkCommandBufferBegin(command_buffer_);
   tracker_.MarkCommandBufferEnd(command_buffer_);
   pid_t pid = orbit_base::GetCurrentThreadId();
-  uint64_t pre_submit_time = MonotonicTimestampNs();
+  uint64_t pre_submit_time = orbit_base::CaptureTimestampNs();
   std::optional<QueueSubmission> queue_submission_optional =
       tracker_.PersistCommandBuffersOnSubmit(1, &submit_info_);
   tracker_.PersistDebugMarkersOnSubmit(queue_, 1, &submit_info_, queue_submission_optional);
-  uint64_t post_submit_time = MonotonicTimestampNs();
+  uint64_t post_submit_time = orbit_base::CaptureTimestampNs();
   producer_->StopCapture();
   tracker_.CompleteSubmits(device_);
 
@@ -615,12 +615,12 @@ TEST_F(SubmissionTrackerTest, StopCaptureDuringSubmissionWillStillYieldResults) 
   tracker_.MarkCommandBufferBegin(command_buffer_);
   tracker_.MarkCommandBufferEnd(command_buffer_);
   pid_t pid = orbit_base::GetCurrentThreadId();
-  uint64_t pre_submit_time = MonotonicTimestampNs();
+  uint64_t pre_submit_time = orbit_base::CaptureTimestampNs();
   std::optional<QueueSubmission> queue_submission_optional =
       tracker_.PersistCommandBuffersOnSubmit(1, &submit_info_);
   producer_->StopCapture();
   tracker_.PersistDebugMarkersOnSubmit(queue_, 1, &submit_info_, queue_submission_optional);
-  uint64_t post_submit_time = MonotonicTimestampNs();
+  uint64_t post_submit_time = orbit_base::CaptureTimestampNs();
   tracker_.CompleteSubmits(device_);
 
   EXPECT_THAT(actual_reset_slots, UnorderedElementsAre(kSlotIndex1, kSlotIndex2));
@@ -884,11 +884,11 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerTimestampsForACompleteSubmis
   tracker_.MarkDebugMarkerEnd(command_buffer_);
   tracker_.MarkCommandBufferEnd(command_buffer_);
   pid_t tid = orbit_base::GetCurrentThreadId();
-  uint64_t pre_submit_time = MonotonicTimestampNs();
+  uint64_t pre_submit_time = orbit_base::CaptureTimestampNs();
   std::optional<QueueSubmission> queue_submission_optional =
       tracker_.PersistCommandBuffersOnSubmit(1, &submit_info_);
   tracker_.PersistDebugMarkersOnSubmit(queue_, 1, &submit_info_, queue_submission_optional);
-  uint64_t post_submit_time = MonotonicTimestampNs();
+  uint64_t post_submit_time = orbit_base::CaptureTimestampNs();
   tracker_.CompleteSubmits(device_);
 
   EXPECT_THAT(actual_reset_slots,
@@ -1006,11 +1006,11 @@ TEST_F(SubmissionTrackerTest, CanRetrieveNestedDebugMarkerTimestampsForAComplete
   tracker_.MarkDebugMarkerEnd(command_buffer_);
   tracker_.MarkCommandBufferEnd(command_buffer_);
   pid_t tid = orbit_base::GetCurrentThreadId();
-  uint64_t pre_submit_time = MonotonicTimestampNs();
+  uint64_t pre_submit_time = orbit_base::CaptureTimestampNs();
   std::optional<QueueSubmission> queue_submission_optional =
       tracker_.PersistCommandBuffersOnSubmit(1, &submit_info_);
   tracker_.PersistDebugMarkersOnSubmit(queue_, 1, &submit_info_, queue_submission_optional);
-  uint64_t post_submit_time = MonotonicTimestampNs();
+  uint64_t post_submit_time = orbit_base::CaptureTimestampNs();
   tracker_.CompleteSubmits(device_);
 
   EXPECT_THAT(actual_reset_slots, UnorderedElementsAre(kSlotIndex1, kSlotIndex2, kSlotIndex3,
@@ -1083,11 +1083,11 @@ TEST_F(SubmissionTrackerTest,
   tracker_.MarkDebugMarkerEnd(command_buffer_);
   tracker_.MarkCommandBufferEnd(command_buffer_);
   pid_t tid = orbit_base::GetCurrentThreadId();
-  uint64_t pre_submit_time = MonotonicTimestampNs();
+  uint64_t pre_submit_time = orbit_base::CaptureTimestampNs();
   std::optional<QueueSubmission> queue_submission_optional =
       tracker_.PersistCommandBuffersOnSubmit(1, &submit_info_);
   tracker_.PersistDebugMarkersOnSubmit(queue_, 1, &submit_info_, queue_submission_optional);
-  uint64_t post_submit_time = MonotonicTimestampNs();
+  uint64_t post_submit_time = orbit_base::CaptureTimestampNs();
   tracker_.CompleteSubmits(device_);
 
   EXPECT_THAT(actual_reset_slots,
@@ -1151,11 +1151,11 @@ TEST_F(SubmissionTrackerTest, CanRetrieveDebugMarkerAcrossTwoSubmissions) {
   tracker_.MarkCommandBufferBegin(command_buffer_);
   tracker_.MarkDebugMarkerBegin(command_buffer_, text, expected_color);
   tracker_.MarkCommandBufferEnd(command_buffer_);
-  uint64_t pre_submit_time_1 = MonotonicTimestampNs();
+  uint64_t pre_submit_time_1 = orbit_base::CaptureTimestampNs();
   std::optional<QueueSubmission> queue_submission_optional_1 =
       tracker_.PersistCommandBuffersOnSubmit(1, &submit_info_);
   tracker_.PersistDebugMarkersOnSubmit(queue_, 1, &submit_info_, queue_submission_optional_1);
-  uint64_t post_submit_time_1 = MonotonicTimestampNs();
+  uint64_t post_submit_time_1 = orbit_base::CaptureTimestampNs();
   tracker_.CompleteSubmits(device_);
   tracker_.ResetCommandBuffer(command_buffer_);
   tracker_.MarkCommandBufferBegin(command_buffer_);
@@ -1397,11 +1397,11 @@ TEST_F(SubmissionTrackerTest, CanLimitNestedDebugMarkerDepthPerCommandBuffer) {
   tracker_.MarkDebugMarkerEnd(command_buffer_);
   tracker_.MarkCommandBufferEnd(command_buffer_);
   pid_t tid = orbit_base::GetCurrentThreadId();
-  uint64_t pre_submit_time = MonotonicTimestampNs();
+  uint64_t pre_submit_time = orbit_base::CaptureTimestampNs();
   std::optional<QueueSubmission> queue_submission_optional =
       tracker_.PersistCommandBuffersOnSubmit(1, &submit_info_);
   tracker_.PersistDebugMarkersOnSubmit(queue_, 1, &submit_info_, queue_submission_optional);
-  uint64_t post_submit_time = MonotonicTimestampNs();
+  uint64_t post_submit_time = orbit_base::CaptureTimestampNs();
   tracker_.CompleteSubmits(device_);
 
   EXPECT_THAT(actual_reset_slots,
@@ -1466,11 +1466,11 @@ TEST_F(SubmissionTrackerTest, CanLimitNestedDebugMarkerDepthPerCommandBufferAcro
                                 expected_color);  // timestamp 2
   tracker_.MarkDebugMarkerBegin(command_buffer_, text_inner.c_str(), expected_color);  // cut-off
   tracker_.MarkCommandBufferEnd(command_buffer_);  // timestamp 3
-  uint64_t pre_submit_time_1 = MonotonicTimestampNs();
+  uint64_t pre_submit_time_1 = orbit_base::CaptureTimestampNs();
   std::optional<QueueSubmission> queue_submission_optional_1 =
       tracker_.PersistCommandBuffersOnSubmit(1, &submit_info_);
   tracker_.PersistDebugMarkersOnSubmit(queue_, 1, &submit_info_, queue_submission_optional_1);
-  uint64_t post_submit_time_1 = MonotonicTimestampNs();
+  uint64_t post_submit_time_1 = orbit_base::CaptureTimestampNs();
   tracker_.CompleteSubmits(device_);
 
   tracker_.ResetCommandBuffer(command_buffer_);


### PR DESCRIPTION
This PR is split in two commits.

The first one defines Orbit's main Linux clock as "kOrbitTimelineClock" and uses it
for internal timestamping and for events obtained through the perf_event_open api.
This is done to explicitly link perf_event_open's clock to Orbit's timestamping clock.

The second commit puts the timestamping functions in the orbit_base namespace
and removes the "Monotonic" prefix.

This change stems from a discussion in https://github.com/google/orbit/pull/1772.