### PR TITLE
Introduce GTest::QtGuiMain and GTest::QtCoreMain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,21 +82,12 @@ if (NOT WIN32)
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif()
 
-include(cmake/fuzzing.cmake)
-include(cmake/strip.cmake)
-include(cmake/tests.cmake)
-include(cmake/iwyu.cmake)
-enable_testing()
 
 find_package(Threads REQUIRED)
 find_package(xxHash REQUIRED)
 find_package(multicore REQUIRED)
 find_package(concurrentqueue REQUIRED)
 find_package(gte REQUIRED)
-
-include("cmake/protobuf.cmake")
-include("cmake/grpc_helper.cmake")
-
 
 if(WITH_ORBITGL)
   find_package(OpenGL REQUIRED)
@@ -125,6 +116,14 @@ if(NOT WIN32 AND WITH_VULKAN_LAYER)
   find_package(Vulkan REQUIRED)
   find_package(VulkanValidationLayers REQUIRED)
 endif()
+
+include("cmake/protobuf.cmake")
+include("cmake/grpc_helper.cmake")
+include("cmake/fuzzing.cmake")
+include("cmake/strip.cmake")
+include("cmake/tests.cmake")
+include("cmake/iwyu.cmake")
+enable_testing()
 
 # Set preprocessor defines These are only necessary for windows, but we will
 # define them on all platforms, to keep the builds similar as possible.

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -48,3 +48,51 @@ int main(int argc, char* argv[]) {\n\
   target_link_libraries(GTest_Main PUBLIC GTest::GTest)
   add_library(GTest::Main ALIAS GTest_Main)
 endif()
+
+if(NOT TARGET GTest::QtCoreMain AND TARGET Qt5::Core)
+  set(FILE_PATH ${CMAKE_BINARY_DIR}/test_qtcore_main.cpp)
+  if(NOT EXISTS ${FILE_PATH})
+    set(GTEST_MAIN_CPP "\
+#include <cstdio>\n\
+#include <gtest/gtest.h>\n\
+#include <QCoreApplication>\n\
+\n\
+int main(int argc, char* argv[]) {\n\
+  QCoreApplication app{argc, argv}\;\n\
+  printf(\"Running main() from %s\\n\", __FILE__)\;\n\
+  ::testing::InitGoogleTest(&argc, argv)\;\n\
+  return RUN_ALL_TESTS()\;\n\
+}\n\
+")
+
+    file(WRITE ${FILE_PATH} ${GTEST_MAIN_CPP})
+  endif()
+
+  add_library(GTest_QtCoreMain STATIC EXCLUDE_FROM_ALL ${FILE_PATH})
+  target_link_libraries(GTest_QtCoreMain PUBLIC GTest::GTest Qt5::Core)
+  add_library(GTest::QtCoreMain ALIAS GTest_QtCoreMain)
+endif()
+
+if(NOT TARGET GTest::QtGuiMain AND TARGET Qt5::Widgets)
+  set(FILE_PATH ${CMAKE_BINARY_DIR}/test_qtgui_main.cpp)
+  if(NOT EXISTS ${FILE_PATH})
+    set(GTEST_MAIN_CPP "\
+#include <cstdio>\n\
+#include <gtest/gtest.h>\n\
+#include <QApplication>\n\
+\n\
+int main(int argc, char* argv[]) {\n\
+  QApplication app{argc, argv}\;\n\
+  printf(\"Running main() from %s\\n\", __FILE__)\;\n\
+  ::testing::InitGoogleTest(&argc, argv)\;\n\
+  return RUN_ALL_TESTS()\;\n\
+}\n\
+")
+
+    file(WRITE ${FILE_PATH} ${GTEST_MAIN_CPP})
+  endif()
+
+  add_library(GTest_QtGuiMain STATIC EXCLUDE_FROM_ALL ${FILE_PATH})
+  target_link_libraries(GTest_QtGuiMain PUBLIC GTest::GTest Qt5::Widgets)
+  add_library(GTest::QtGuiMain ALIAS GTest_QtGuiMain)
+endif()

--- a/src/OrbitQt/CMakeLists.txt
+++ b/src/OrbitQt/CMakeLists.txt
@@ -187,7 +187,7 @@ target_link_libraries(
           Qt5::Widgets
           Qt5::Core
           Qt5::Test
-          GTest::Main)
+          GTest::QtGuiMain)
 
 set_target_properties(OrbitQtTests PROPERTIES AUTOMOC ON)
 set_target_properties(OrbitQtTests PROPERTIES AUTOUIC ON)

--- a/src/OrbitQt/EventLoopTest.cpp
+++ b/src/OrbitQt/EventLoopTest.cpp
@@ -15,10 +15,6 @@
 #include "gtest/gtest.h"
 
 TEST(EventLoop, exec) {
-  int argc = 0;
-
-  QApplication app{argc, nullptr};
-
   // Case 1: The event loop finishes successfully
   {
     orbit_qt::EventLoop loop{};

--- a/src/OrbitQt/MainThreadExecutorImplTest.cpp
+++ b/src/OrbitQt/MainThreadExecutorImplTest.cpp
@@ -11,42 +11,32 @@
 
 namespace orbit_qt {
 
-static int argc = 0;
-
 TEST(MainThreadExecutorImpl, Schedule) {
-  QCoreApplication app{argc, nullptr};
-
   auto executor = MainThreadExecutorImpl::Create();
   executor->Schedule([]() { QCoreApplication::exit(42); });
 
-  EXPECT_EQ(app.exec(), 42);
+  EXPECT_EQ(QCoreApplication::exec(), 42);
 }
 
 TEST(MainThreadExecutorImpl, ScheduleAfterAllVoid) {
-  QCoreApplication app{argc, nullptr};
-
   bool called = false;
   auto executor = MainThreadExecutorImpl::Create();
   auto future = executor->Schedule([&called]() { called = true; });
   executor->ScheduleAfter(future, []() { QCoreApplication::exit(42); });
 
-  EXPECT_EQ(app.exec(), 42);
+  EXPECT_EQ(QCoreApplication::exec(), 42);
   EXPECT_TRUE(called);
 }
 
 TEST(MainThreadExecutorImpl, ScheduleAfterWithIntegerBetweenJobs) {
-  QCoreApplication app{argc, nullptr};
-
   auto executor = MainThreadExecutorImpl::Create();
   auto future = executor->Schedule([]() { return 42; });
   executor->ScheduleAfter(future, [](int val) { QCoreApplication::exit(val); });
 
-  EXPECT_EQ(app.exec(), 42);
+  EXPECT_EQ(QCoreApplication::exec(), 42);
 }
 
 TEST(MainThreadExecutorImpl, ScheduleAfterWithIntegerAsFinalResultAndBetweenJobs) {
-  QCoreApplication app{argc, nullptr};
-
   auto executor = MainThreadExecutorImpl::Create();
   auto future = executor->Schedule([]() { return 42; });
   auto future2 = executor->ScheduleAfter(future, [](int val) {
@@ -54,14 +44,12 @@ TEST(MainThreadExecutorImpl, ScheduleAfterWithIntegerAsFinalResultAndBetweenJobs
     return val + 42;
   });
 
-  EXPECT_EQ(app.exec(), 42);
+  EXPECT_EQ(QCoreApplication::exec(), 42);
   EXPECT_TRUE(future2.IsFinished());
   EXPECT_EQ(future2.Get(), 42 + 42);
 }
 
 TEST(MainThreadExecutorImpl, ScheduleAfterWithIntegerOnlyAsFinalResult) {
-  QCoreApplication app{argc, nullptr};
-
   bool called = false;
   auto executor = MainThreadExecutorImpl::Create();
   auto future = executor->Schedule([&called]() { called = true; });
@@ -70,15 +58,13 @@ TEST(MainThreadExecutorImpl, ScheduleAfterWithIntegerOnlyAsFinalResult) {
     return 42 + 42;
   });
 
-  EXPECT_EQ(app.exec(), 42);
+  EXPECT_EQ(QCoreApplication::exec(), 42);
   EXPECT_TRUE(future2.IsFinished());
   EXPECT_EQ(future2.Get(), 42 + 42);
   EXPECT_TRUE(called);
 }
 
 TEST(MainThreadExecutorImpl, ScheduleAfterMultipleContinuations) {
-  QCoreApplication app{argc, nullptr};
-
   auto executor = MainThreadExecutorImpl::Create();
   auto future = executor->Schedule([]() { return 42; });
   auto future2 = executor->ScheduleAfter(future, [](int val) {
@@ -94,12 +80,10 @@ TEST(MainThreadExecutorImpl, ScheduleAfterMultipleContinuations) {
     QCoreApplication::exit(val + 42);
   });
 
-  EXPECT_EQ(app.exec(), 4 * 42);
+  EXPECT_EQ(QCoreApplication::exec(), 4 * 42);
 }
 
 TEST(MainThreadExecutorImpl, ScheduleAfterWithExecutorOutOfScope) {
-  QCoreApplication app{argc, nullptr};
-
   orbit_base::Promise<void> promise;
   orbit_base::Future<void> future = promise.GetFuture();
 
@@ -118,8 +102,6 @@ TEST(MainThreadExecutorImpl, ScheduleAfterWithExecutorOutOfScope) {
 }
 
 TEST(MainThreadExecutorImpl, Wait) {
-  QCoreApplication app{argc, nullptr};
-
   bool called = false;
   auto executor = MainThreadExecutorImpl::Create();
   orbit_base::Future<void> future = executor->Schedule([&called]() { called = true; });
@@ -127,8 +109,6 @@ TEST(MainThreadExecutorImpl, Wait) {
 }
 
 TEST(MainThreadExecutorImpl, ChainFuturesWithThen) {
-  QCoreApplication app{argc, nullptr};
-
   auto executor = MainThreadExecutorImpl::Create();
   const auto future = executor->Schedule([]() { return 42; });
   const auto future2 = future.Then(executor.get(), [](int val) {
@@ -136,19 +116,17 @@ TEST(MainThreadExecutorImpl, ChainFuturesWithThen) {
     return val + 42;
   });
 
-  EXPECT_EQ(app.exec(), 42);
+  EXPECT_EQ(QCoreApplication::exec(), 42);
   EXPECT_TRUE(future2.IsFinished());
   EXPECT_EQ(future2.Get(), 42 + 42);
 }
 
 TEST(MainThreadExecutorImpl, TrySchedule) {
-  QCoreApplication app{argc, nullptr};
-
   auto executor = MainThreadExecutorImpl::Create();
   const auto result = TrySchedule(executor, []() { QCoreApplication::exit(42); });
 
   EXPECT_TRUE(result.has_value());
-  EXPECT_EQ(app.exec(), 42);
+  EXPECT_EQ(QCoreApplication::exec(), 42);
 }
 
 TEST(MainThreadExecutorImpl, TryScheduleWithInvalidWeakPtr) {

--- a/src/OrbitQt/StatusListenerImplTest.cpp
+++ b/src/OrbitQt/StatusListenerImplTest.cpp
@@ -12,10 +12,8 @@
 #include "StatusListenerImpl.h"
 #include "gtest/gtest.h"
 
-static int argc = 0;
 
 TEST(StatusListenerImpl, ShowAndClearOneMessage) {
-  QApplication app(argc, nullptr);
   auto status_bar = std::make_unique<QStatusBar>(nullptr);
   auto status_listener = StatusListenerImpl::Create(status_bar.get());
 
@@ -32,7 +30,6 @@ TEST(StatusListenerImpl, ShowAndUpdate) {
   constexpr const char* message3 = "message 3";
   constexpr const char* updated_message = "updated message";
 
-  QApplication app(argc, nullptr);
   auto status_bar = std::make_unique<QStatusBar>(nullptr);
   auto status_listener = StatusListenerImpl::Create(status_bar.get());
 
@@ -67,7 +64,6 @@ TEST(StatusListenerImpl, CheckOrder) {
   constexpr const char* message4 = "message 4";
   constexpr const char* message5 = "message 5";
 
-  QApplication app(argc, nullptr);
   auto status_bar = std::make_unique<QStatusBar>(nullptr);
   auto status_listener = StatusListenerImpl::Create(status_bar.get());
 
@@ -115,7 +111,6 @@ TEST(StatusListenerImpl, CheckOrder) {
 TEST(StatusListenerImpl, UpdateStatusInvalidId) {
   EXPECT_DEATH(
       {
-        QApplication app(argc, nullptr);
         auto status_bar = std::make_unique<QStatusBar>(nullptr);
         auto status_listener = StatusListenerImpl::Create(status_bar.get());
 
@@ -127,7 +122,6 @@ TEST(StatusListenerImpl, UpdateStatusInvalidId) {
 TEST(StatusListenerImpl, ClearStatusInvalidId) {
   EXPECT_DEATH(
       {
-        QApplication app(argc, nullptr);
         auto status_bar = std::make_unique<QStatusBar>(nullptr);
         auto status_listener = StatusListenerImpl::Create(status_bar.get());
 

--- a/src/OrbitQt/TutorialOverlayTest.cpp
+++ b/src/OrbitQt/TutorialOverlayTest.cpp
@@ -17,13 +17,10 @@
 #include "TutorialOverlay.h"
 #include "gtest/gtest.h"
 
-static int argc = 0;
-
 // TODO: These tests use the actual Tutorial UI and can be broken
 // by updating this UI... it should use a dedicated unit testing UI
 
 TEST(TutorialOverlay, StepExists) {
-  QApplication app(argc, nullptr);
   auto overlay = std::make_unique<TutorialOverlay>(nullptr);
 
   // Check if StepExists works, and implicitely check if the UI file
@@ -35,7 +32,6 @@ TEST(TutorialOverlay, StepExists) {
 }
 
 TEST(TutorialOverlay, SetupSections) {
-  QApplication app(argc, nullptr);
   auto overlay = std::make_unique<TutorialOverlay>(nullptr);
 
   overlay->AddSection("unitTest", "Unit Testing", {"unitTest1", "unitTest2"});
@@ -45,7 +41,6 @@ TEST(TutorialOverlay, SetupSections) {
 }
 
 TEST(TutorialOverlay, callbackSuccess) {
-  QApplication app(argc, nullptr);
   auto overlay = std::make_unique<TutorialOverlay>(nullptr);
 
   std::map<std::string, int> init_count{std::make_pair<std::string, int>("unitTest1", 0),
@@ -93,7 +88,6 @@ TEST(TutorialOverlay, callbackSuccess) {
 }
 
 TEST(TutorialOverlay, CallbackFail) {
-  QApplication app(argc, nullptr);
   auto overlay = std::make_unique<TutorialOverlay>(nullptr);
 
   TutorialOverlay::StepSetup setup{
@@ -111,7 +105,6 @@ TEST(TutorialOverlay, CallbackFail) {
 }
 
 TEST(TutorialOverlay, SignalsAndSlots) {
-  QApplication app(argc, nullptr);
   auto overlay = std::make_unique<TutorialOverlay>(nullptr);
 
   bool shown = false, hidden = false;
@@ -158,7 +151,6 @@ TEST(TutorialOverlay, SignalsAndSlots) {
 }
 
 TEST(TutorialOverlay, FailTests) {
-  QApplication app(argc, nullptr);
   auto overlay = std::make_unique<TutorialOverlay>(nullptr);
   EXPECT_DEATH({ overlay->SetupStep("xx_invalid_step_name_xx", {}); }, "Check failed");
   EXPECT_DEATH({ overlay->AddSection("test", "Unit Testing", {"xx_invalid_step_name_xx"}); },

--- a/src/QtUtils/CMakeLists.txt
+++ b/src/QtUtils/CMakeLists.txt
@@ -20,7 +20,7 @@ set_target_properties(QtUtils PROPERTIES AUTOMOC ON)
 add_executable(QtUtilsTests)
 target_compile_options(QtUtilsTests PRIVATE ${STRICT_COMPILE_FLAGS})
 target_sources(QtUtilsTests PRIVATE FutureWatcherTest.cpp)
-target_link_libraries(QtUtilsTests PRIVATE QtUtils GTest::Main)
+target_link_libraries(QtUtilsTests PRIVATE QtUtils GTest::QtCoreMain)
 
 if (WIN32 AND "$ENV{QT_QPA_PLATFORM}" STREQUAL "offscreen")
   register_test(QtUtilsTests PROPERTIES DISABLED TRUE)

--- a/src/QtUtils/FutureWatcherTest.cpp
+++ b/src/QtUtils/FutureWatcherTest.cpp
@@ -16,11 +16,7 @@
 
 namespace orbit_qt_utils {
 
-static int argc = 0;
-
 TEST(FutureWatcher, WaitFor) {
-  QCoreApplication app{argc, nullptr};
-
   orbit_base::Promise<void> promise{};
   orbit_base::Future<void> future = promise.GetFuture();
 
@@ -34,8 +30,6 @@ TEST(FutureWatcher, WaitFor) {
 }
 
 TEST(FutureWatcher, WaitForWithTimeout) {
-  QCoreApplication app{argc, nullptr};
-
   orbit_base::Promise<void> promise{};
   orbit_base::Future<void> future = promise.GetFuture();
 
@@ -49,8 +43,6 @@ TEST(FutureWatcher, WaitForWithTimeout) {
 }
 
 TEST(FutureWatcher, WaitForWithAbort) {
-  QCoreApplication app{argc, nullptr};
-
   orbit_base::Promise<void> promise{};
   orbit_base::Future<void> future = promise.GetFuture();
 
@@ -70,8 +62,6 @@ TEST(FutureWatcher, WaitForWithAbort) {
 
 TEST(FutureWatcher, WaitForWithThreadPool) {
   // One background job which is supposed to succeed. (No timeout, no abort)
-
-  QCoreApplication app{argc, nullptr};
 
   constexpr size_t kThreadPoolMinSize = 1;
   constexpr size_t kThreadPoolMaxSize = 2;
@@ -101,8 +91,6 @@ TEST(FutureWatcher, WaitForWithThreadPool) {
 TEST(FutureWatcher, WaitForWithThreadPoolAndTimeout) {
   // One background job which is supposed to time out.
 
-  QCoreApplication app{argc, nullptr};
-
   constexpr size_t kThreadPoolMinSize = 1;
   constexpr size_t kThreadPoolMaxSize = 2;
   constexpr absl::Duration kThreadTtl = absl::Milliseconds(5);
@@ -128,8 +116,6 @@ TEST(FutureWatcher, WaitForWithThreadPoolAndTimeout) {
 
 TEST(FutureWatcher, WaitForAllWithThreadPool) {
   // Multiple background jobs which are all supposed to succeed.
-
-  QCoreApplication app{argc, nullptr};
 
   constexpr size_t kThreadPoolMinSize = 1;
   constexpr size_t kThreadPoolMaxSize = 2;
@@ -162,8 +148,6 @@ TEST(FutureWatcher, WaitForAllWithThreadPool) {
 
 TEST(FutureWatcher, WaitForAllWithThreadPoolAndTimeout) {
   // Multiple background jobs which are all supposed to time out.
-
-  QCoreApplication app{argc, nullptr};
 
   constexpr size_t kThreadPoolMinSize = 1;
   constexpr size_t kThreadPoolMaxSize = 2;
@@ -204,8 +188,6 @@ TEST(FutureWatcher, WaitForAllWithThreadPoolAndTimeout) {
 }
 
 TEST(FutureWatcher, WaitForAllWithEmptyList) {
-  QCoreApplication app{argc, nullptr};
-
   FutureWatcher watcher{};
   const auto reason = watcher.WaitForAll({}, std::nullopt);
 


### PR DESCRIPTION
`GTest::QtCoreMain` and `QTest::QtGuiMain` are alternatives to `GTest::Main`.

They provide a main function that initializes GoogleTest, but that also instantiates
a `QCoreApplication` (or `QApplication`) object.

By doing so, qt-based tests can avoid doing that locally.