### PR TITLE
Introduce AnyInvocable

### DIFF
--- a/src/OrbitBase/AnyInvocableTest.cpp
+++ b/src/OrbitBase/AnyInvocableTest.cpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "OrbitBase/AnyInvocable.h"
+
+namespace orbit_base {
+
+static int GetRandomNumber() {
+  return 4;  // chosen by a fair dice roll. guaranteed to be random.
+}
+
+TEST(AnyInvocable, ShouldStoreAndCallLambda) {
+  AnyInvocable<int()> invocable{[]() { return 42; }};
+  EXPECT_NE(invocable, nullptr);
+  EXPECT_TRUE(invocable);
+
+  EXPECT_EQ(invocable(), 42);
+}
+
+TEST(AnyInvocable, ShouldStoreAndCallFunctionPointer) {
+  AnyInvocable<int()> invocable{&GetRandomNumber};
+  EXPECT_NE(invocable, nullptr);
+  EXPECT_TRUE(invocable);
+
+  EXPECT_EQ(invocable(), GetRandomNumber());
+}
+
+TEST(AnyInvocable, ShouldStoreAndCallMoveOnlyLambda) {
+  AnyInvocable<int()> invocable{[val = std::make_unique<int>(42)]() { return *val; }};
+  EXPECT_NE(invocable, nullptr);
+  EXPECT_TRUE(invocable);
+
+  EXPECT_EQ(invocable(), 42);
+}
+
+TEST(AnyInvocable, ShouldBeMovableAndStillCallable) {
+  AnyInvocable<int()> first{[val = std::make_unique<int>(42)]() { return *val; }};
+
+  auto second = std::move(first);
+  EXPECT_EQ(first, nullptr);  // NOLINT
+  EXPECT_NE(second, nullptr);
+
+  EXPECT_EQ(second(), 42);
+}
+
+}  // namespace orbit_base

--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -20,6 +20,7 @@ target_include_directories(OrbitBase PRIVATE
 
 target_sources(OrbitBase PRIVATE
         include/OrbitBase/Action.h
+        include/OrbitBase/AnyInvocable.h
         include/OrbitBase/ExecutablePath.h
         include/OrbitBase/Future.h
         include/OrbitBase/FutureHelpers.h
@@ -71,6 +72,7 @@ add_executable(OrbitBaseTests)
 target_compile_options(OrbitBaseTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(OrbitBaseTests PRIVATE
+        AnyInvocableTest.cpp
         ExecutablePathTest.cpp
         FutureTest.cpp
         FutureHelpersTest.cpp

--- a/src/OrbitBase/include/OrbitBase/AnyInvocable.h
+++ b/src/OrbitBase/include/OrbitBase/AnyInvocable.h
@@ -1,0 +1,83 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_BASE_ANY_INVOCABLE_H_
+#define ORBIT_BASE_ANY_INVOCABLE_H_
+
+#include <cstddef>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <type_traits>
+
+namespace orbit_base {
+
+template <typename>
+class AnyInvocable;
+
+// AnyInvocable is a polymorphic function wrapper, just like std::function. But unlike std::function
+// and as the name suggests, it can wrap everything that fulfills the Invocable concept. That
+// means the wrapped function objects don't need to be copy-constructible. It's enough for them to
+// be movable.
+//
+// Usage: Think std::function when using AnyInvocable.
+// AnyInvocable<int(int)> invocable{[](int val) { return 42 * val; }};
+// std::cout << invocable(2) << std::endl; // Outputs 48
+template <typename R, typename... Args>
+class AnyInvocable<R(Args...)> {
+  struct Base {
+    constexpr Base() = default;
+    constexpr Base(Base&&) noexcept = default;
+    constexpr Base& operator=(Base&&) noexcept = default;
+
+    constexpr Base(const Base&) = delete;
+    constexpr Base& operator=(const Base&) = delete;
+
+    virtual R invoke(Args...) = 0;
+    virtual ~Base() = default;
+  };
+
+  template <typename T>
+  class Storage final : public Base {
+    T value_;
+
+   public:
+    using Base::Base;
+
+    template <typename... Urgs>
+    constexpr explicit Storage(std::in_place_t, Urgs... args)
+        : value_{std::forward<Urgs>(args)...} {}
+
+    constexpr explicit Storage(const T& value) : value_(value) {}
+    constexpr explicit Storage(T&& value) : value_(std::move(value)) {}
+
+    constexpr R invoke(Args... args) noexcept override {
+      return std::invoke(value_, std::forward<Args>(args)...);
+    }
+  };
+
+  std::unique_ptr<Base> storage_;
+
+ public:
+  template <typename F, typename = std::enable_if<!std::is_same_v<std::decay_t<F>, AnyInvocable>>>
+  constexpr explicit AnyInvocable(F&& func)
+      : storage_{std::make_unique<Storage<std::decay_t<F>>>(std::forward<F>(func))} {}
+
+  constexpr explicit operator bool() const noexcept { return storage_ != nullptr; }
+
+  constexpr R operator()(Args... args) { return storage_->invoke(std::forward<Args>(args)...); }
+
+  friend bool operator==(const AnyInvocable& lhs, std::nullptr_t) {
+    return !static_cast<bool>(lhs);
+  }
+  friend bool operator==(std::nullptr_t, const AnyInvocable& rhs) {
+    return !static_cast<bool>(rhs);
+  }
+  friend bool operator!=(const AnyInvocable& lhs, std::nullptr_t rhs) { return !(lhs == rhs); }
+  friend bool operator!=(std::nullptr_t lhs, const AnyInvocable& rhs) { return !(lhs == rhs); }
+};
+
+}  // namespace orbit_base
+
+#endif  // ORBIT_BASE_ANY_INVOCABLE_H_

--- a/src/OrbitBase/include/OrbitBase/Promise.h
+++ b/src/OrbitBase/include/OrbitBase/Promise.h
@@ -70,7 +70,7 @@ class Promise : public orbit_base_internal::PromiseBase<T> {
   void SetResult(T result) {
     absl::MutexLock lock{&this->shared_state_->mutex};
 
-    for (const auto& continuation : this->shared_state_->continuations) {
+    for (auto& continuation : this->shared_state_->continuations) {
       continuation(result);
     }
 
@@ -92,7 +92,7 @@ class Promise<void> : public orbit_base_internal::PromiseBase<void> {
   void MarkFinished() {
     absl::MutexLock lock{&this->shared_state_->mutex};
 
-    for (const auto& continuation : this->shared_state_->continuations) {
+    for (auto& continuation : this->shared_state_->continuations) {
       continuation();
     }
 

--- a/src/OrbitBase/include/OrbitBase/SharedState.h
+++ b/src/OrbitBase/include/OrbitBase/SharedState.h
@@ -7,10 +7,11 @@
 
 #include <absl/synchronization/mutex.h>
 
-#include <functional>
 #include <optional>
 #include <variant>
 #include <vector>
+
+#include "OrbitBase/AnyInvocable.h"
 
 namespace orbit_base_internal {
 
@@ -21,14 +22,14 @@ template <typename T>
 struct SharedState {
   absl::Mutex mutex;
   std::optional<T> result;
-  std::vector<std::function<void(const T&)>> continuations;
+  std::vector<orbit_base::AnyInvocable<void(const T&)>> continuations;
 };
 
 template <>
 struct SharedState<void> {
   absl::Mutex mutex;
   bool finished = false;
-  std::vector<std::function<void()>> continuations;
+  std::vector<orbit_base::AnyInvocable<void()>> continuations;
 };
 
 }  // namespace orbit_base_internal


### PR DESCRIPTION
`AnyInvocable` is a function-wrapper, similar to `std::function`. But it doesn't require its wrapped type to copy-constructible.

This PR introduces the type itself (first commit), then uses it in the Promise/Future framework.