### PR TITLE
Introduce OrbitApp::LoadModule

### DIFF
--- a/src/OrbitBase/include/OrbitBase/Future.h
+++ b/src/OrbitBase/include/OrbitBase/Future.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include <optional>
 #include <type_traits>
+#include <utility>
 #include <variant>
 
 #include "OrbitBase/Logging.h"
@@ -79,8 +80,22 @@ template <typename T>
 class [[nodiscard]] Future : public orbit_base_internal::FutureBase<T> {
  public:
   // Constructs a completed future
+  /* explicit(false) */ Future(const T& val)
+      : orbit_base_internal::FutureBase<T>{
+            std::make_shared<orbit_base_internal::SharedState<T>>()} {
+    this->shared_state_->result.emplace(val);
+  }
+
+  // Constructs a completed future
+  /* explicit(false) */ Future(T && val)
+      : orbit_base_internal::FutureBase<T>{
+            std::make_shared<orbit_base_internal::SharedState<T>>()} {
+    this->shared_state_->result.emplace(std::move(val));
+  }
+
+  // Constructs a completed future
   template <typename... Args>
-  explicit Future(Args && ... args)
+  explicit Future(std::in_place_t, Args && ... args)
       : orbit_base_internal::FutureBase<T>{
             std::make_shared<orbit_base_internal::SharedState<T>>()} {
     this->shared_state_->result.emplace(std::forward<Args>(args)...);

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -7,6 +7,7 @@
 
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
+#include <absl/types/span.h>
 #include <grpc/impl/codegen/connectivity_state.h>
 #include <grpcpp/channel.h>
 
@@ -41,6 +42,7 @@
 #include "ManualInstrumentationManager.h"
 #include "MetricsUploader/MetricsUploader.h"
 #include "ModulesDataView.h"
+#include "OrbitBase/Future.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
 #include "OrbitBase/ThreadPool.h"
@@ -301,8 +303,13 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
 
   void LoadModules(
       const std::vector<ModuleData*>& modules,
-      absl::flat_hash_map<std::string, std::vector<uint64_t>> function_hashes_to_hook_map = {},
-      absl::flat_hash_map<std::string, std::vector<uint64_t>> frame_track_function_hashes_map = {});
+      absl::flat_hash_map<std::string, std::vector<uint64_t>> function_hashes_to_hook_map,
+      absl::flat_hash_map<std::string, std::vector<uint64_t>> frame_track_function_hashes_map);
+  orbit_base::Future<ErrorMessageOr<void>> LoadModule(const ModuleData* module);
+  orbit_base::Future<ErrorMessageOr<void>> LoadModule(const std::string& module_path,
+                                                      const std::string& build_id);
+  orbit_base::Future<void> LoadModules(absl::Span<const ModuleData* const> modules);
+
   // TODO(177304549): This is still the way it is because of the old UI. Refactor: clean this up (it
   // should not be necessary to have an argument here, since OrbitApp will always only have one
   // process associated)
@@ -484,7 +491,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   std::shared_ptr<SamplingReport> selection_report_ = nullptr;
   std::map<std::string, std::string> file_mapping_;
 
-  absl::flat_hash_set<std::string> modules_currently_loading_;
+  absl::flat_hash_map<std::string, orbit_base::Future<ErrorMessageOr<void>>>
+      modules_currently_loading_;
 
   std::shared_ptr<StringManager> string_manager_;
   std::shared_ptr<grpc::Channel> grpc_channel_;


### PR DESCRIPTION
There is a function `OrbitApp::LoadModules` which loads a list of modules.

To simplify the process the first step is to introduce a function `OrbitApp::LoadModule` which
only takes care of loading a single module.

Futures and Promises allow to stich together the asynchronous `LoadModule` implementation to a
simpler implementation of `OrbitApp::LoadModules` that has the same behaviour as the function had before.