### PR TITLE
Introduce ImmediateExecutor

### DIFF
--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -76,6 +76,7 @@ target_sources(OrbitBaseTests PRIVATE
         ExecutablePathTest.cpp
         FutureTest.cpp
         FutureHelpersTest.cpp
+        ImmediateExecutorTest.cpp
         JoinFuturesTest.cpp
         LoggingUtilsTest.cpp
         ReadFileToStringTest.cpp

--- a/src/OrbitBase/ImmediateExecutorTest.cpp
+++ b/src/OrbitBase/ImmediateExecutorTest.cpp
@@ -1,0 +1,44 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "OrbitBase/ImmediateExecutor.h"
+
+namespace orbit_base {
+
+TEST(ImmediateExecutor, ScheduledTaskShouldBeCalledImmediatelyWithVoid) {
+  ImmediateExecutor executor{};
+  bool called = false;
+  auto future = executor.Schedule([&called]() { called = true; });
+  EXPECT_TRUE(called);
+  EXPECT_TRUE(future.IsFinished());
+}
+
+TEST(ImmediateExecutor, ScheduledTaskShouldBeCalledImmediatelyWithInt) {
+  ImmediateExecutor executor{};
+  bool called = false;
+  auto future = executor.Schedule([&called]() {
+    called = true;
+    return 42;
+  });
+  EXPECT_TRUE(called);
+  EXPECT_TRUE(future.IsFinished());
+  EXPECT_EQ(future.Get(), 42);
+}
+
+TEST(ImmediateExecutor, ChainedTaskedShouldBeCalledImmediately) {
+  ImmediateExecutor executor{};
+  bool called = false;
+  Promise<void> promise{};
+  auto future = promise.GetFuture();
+  auto chained_future = executor.ScheduleAfter(future, [&called]() { called = true; });
+  EXPECT_FALSE(called);
+  EXPECT_FALSE(chained_future.IsFinished());
+  promise.MarkFinished();
+  EXPECT_TRUE(called);
+  EXPECT_TRUE(chained_future.IsFinished());
+}
+
+}  // namespace orbit_base

--- a/src/OrbitBase/include/OrbitBase/FutureHelpers.h
+++ b/src/OrbitBase/include/OrbitBase/FutureHelpers.h
@@ -14,8 +14,8 @@
 namespace orbit_base {
 
 template <typename T, typename Invocable>
-void RegisterContinuationOrCallDirectly(const Future<T>& future, Invocable continuation) {
-  const auto result = future.RegisterContinuation(continuation);
+void RegisterContinuationOrCallDirectly(const Future<T>& future, Invocable&& continuation) {
+  const auto result = future.RegisterContinuation(std::forward<Invocable>(continuation));
 
   if (result == FutureRegisterContinuationResult::kFutureAlreadyCompleted) {
     continuation(future.Get());
@@ -23,8 +23,8 @@ void RegisterContinuationOrCallDirectly(const Future<T>& future, Invocable conti
 }
 
 template <typename Invocable>
-void RegisterContinuationOrCallDirectly(const Future<void>& future, Invocable continuation) {
-  const auto result = future.RegisterContinuation(continuation);
+void RegisterContinuationOrCallDirectly(const Future<void>& future, Invocable&& continuation) {
+  const auto result = future.RegisterContinuation(std::forward<Invocable>(continuation));
 
   if (result == FutureRegisterContinuationResult::kFutureAlreadyCompleted) {
     continuation();

--- a/src/OrbitBase/include/OrbitBase/ImmediateExecutor.h
+++ b/src/OrbitBase/include/OrbitBase/ImmediateExecutor.h
@@ -1,0 +1,64 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_BASE_IMMEDIATE_EXECUTOR_H_
+#define ORBIT_BASE_IMMEDIATE_EXECUTOR_H_
+
+#include <type_traits>
+
+#include "OrbitBase/Future.h"
+#include "OrbitBase/FutureHelpers.h"
+#include "OrbitBase/Promise.h"
+#include "OrbitBase/PromiseHelpers.h"
+
+namespace orbit_base {
+
+// ImmediateExecutor is a special type of executor that executes its action during the Schedule or
+// ScheduleAfter call. When called directly it's just a verbose abstraction around a standard
+// function call.
+//
+// Its usage only makes sense in combination with Future::Then.
+//
+// Example:
+// Future<std::string> result = thread_pool_->Schedule(/* whatever */);
+// ImmediateExecutor immediate_executor{};
+// Future<void> void_future = result.Then(&immediate_executor, [](const std::string& str) {
+//   (void) str;
+// });
+// main_thread_executor_->WaitFor(void_future); // WaitFor only works with Future<void>
+//
+class ImmediateExecutor {
+ public:
+  template <typename F>
+  auto Schedule(F&& invocable) {
+    using ReturnType = decltype(invocable());
+    if constexpr (std::is_same_v<ReturnType, void>) {
+      invocable();
+      return Future<void>{};
+    } else {
+      return Future<ReturnType>{invocable()};
+    }
+  }
+
+  template <typename T, typename F>
+  auto ScheduleAfter(const Future<T>& future, F&& invocable) {
+    CHECK(future.IsValid());
+
+    using ReturnType = typename ContinuationReturnType<T, F>::Type;
+    orbit_base::Promise<ReturnType> promise{};
+    orbit_base::Future<ReturnType> resulting_future = promise.GetFuture();
+
+    auto continuation = [invocable = std::forward<F>(invocable),
+                         promise = std::move(promise)](auto&&... argument) mutable {
+      orbit_base::CallTaskAndSetResultInPromise<ReturnType> helper{&promise};
+      helper.Call(invocable, argument...);
+    };
+
+    orbit_base::RegisterContinuationOrCallDirectly(future, std::move(continuation));
+    return resulting_future;
+  }
+};
+}  // namespace orbit_base
+
+#endif  // ORBIT_BASE_IMMEDIATE_EXECUTOR_H_


### PR DESCRIPTION
ImmediateExecutor is a helper class to be used in conjunction with
`Future::Then`. It allows to chain a task to be executed whenever the
future completes. The task will be executed in the execution context
that sets the result of the promise.

This type of executor should only be used for tasks that don't depend on
any outside resources since it can't be guaranteed when and where this
task is executed.