### PR TITLE
Make --local connection faster

### DIFF
--- a/src/OrbitQt/ProfilingTargetDialog.h
+++ b/src/OrbitQt/ProfilingTargetDialog.h
@@ -52,8 +52,7 @@ class ProfilingTargetDialog : public QDialog {
   void ProcessSelected();
   void NoProcessSelected();
   void StadiaIsConnected();
-  void LocalIsConnected();
-  void TryConnectToLocal();
+  void ProcessListUpdated();
 
  private:
   std::unique_ptr<Ui::ProfilingTargetDialog> ui_;


### PR DESCRIPTION
Orbit connects faster to a locally running OrbitService. Orbit does not
wait until the state of the local grpc connection is "ready". Instead
the connection is used immediately after setting it up. The local
connection is determined successful, when Orbit receives the first
response from OrbitService.

Adds a tool tip to the "Connecting..." text with more explanation.

Minor Refactoring in ProfilingTargetDialog.cpp