### PR TITLE
Optimize text rendering by avoiding unnecessary font texture uploads

### DIFF
--- a/src/OrbitGl/TextRenderer.h
+++ b/src/OrbitGl/TextRenderer.h
@@ -70,6 +70,10 @@ class TextRenderer {
 
  private:
   texture_atlas_t* texture_atlas_;
+  // Indicates when a change to the texture atlas occurred so that we have to reupload the
+  // texture data. Only freetype-gl's texture_font_load_glyph modifies the texture atlas,
+  // so we need to set this to true when and only when we call that function.
+  bool texture_atlas_changed_;
   std::unordered_map<float, vertex_buffer_t*> vertex_buffers_by_layer_;
   std::map<uint32_t, texture_font_t*> fonts_by_size_;
   GlCanvas* canvas_;


### PR DESCRIPTION
We used to upload the font texture atlas for text rendering on every
render pass where we rendered text (due to layers, there are multiple
such passes). However most of the time, the texture atlas does not
change and the upload is unnecessary. We now track whether the texture
atlas was updated and only upload when needed. We also now use
glTexSubImage2D instead glTexImage2D whenever updating the texture data.

As noted on http://b/179644073, glTexImage2D accounted for more than
half the CPU time of rendering a frame in Orbit. This time is now
entirely removed for almost all frames.

Timings (sample frame):
Before change: 10.256ms
After change: 3.197ms

Tested: Manually ran Orbit and checked that text is rendered correctly.
Bug: http://b/179644073