### PR TITLE
Fix GetCaptureTimeSpanUs for empty captures.

### DIFF
--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -119,6 +119,7 @@ double TimeGraph::GetCaptureTimeSpanUs() const {
       capture_min_timestamp_ == std::numeric_limits<uint64_t>::max()) {
     return 0.0;
   }
+  CHECK(capture_min_timestamp_ <= capture_max_timestamp_);
   return TicksToMicroseconds(capture_min_timestamp_, capture_max_timestamp_);
 }
 

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -114,6 +114,11 @@ void TimeGraph::Zoom(uint64_t min, uint64_t max) {
 void TimeGraph::Zoom(const TimerInfo& timer_info) { Zoom(timer_info.start(), timer_info.end()); }
 
 double TimeGraph::GetCaptureTimeSpanUs() const {
+  // Do we have an empty capture?
+  if (capture_max_timestamp_ == 0 &&
+      capture_min_timestamp_ == std::numeric_limits<uint64_t>::max()) {
+    return 0.0;
+  }
   return TicksToMicroseconds(capture_min_timestamp_, capture_max_timestamp_);
 }
 


### PR DESCRIPTION
TimeGraph initializes the min and max capture time to
std::numeric_limits<uint64_t>::max and 0, leading to uint64_t max
as a result for GetCaptureTimeSpan for an empty capture and thus
not zero.

In fact there are checks on the caller-side, to not draw, e.g. the
scroll bar if the timespan is 0.

Test: Connect to an instance, see that the capture window does not
show a timeline.