### PR TITLE
Also process GPU events in order in the "processing" thread; increase kProcessingDelayMs

### DIFF
--- a/src/LinuxTracing/CMakeLists.txt
+++ b/src/LinuxTracing/CMakeLists.txt
@@ -26,8 +26,8 @@ target_sources(LinuxTracing PRIVATE
         ContextSwitchManager.cpp
         ContextSwitchManager.h
         Function.h
-        GpuTracepointEventProcessor.h
-        GpuTracepointEventProcessor.cpp
+        GpuTracepointVisitor.h
+        GpuTracepointVisitor.cpp
         KernelTracepoints.h
         LibunwindstackUnwinder.cpp
         LibunwindstackUnwinder.h
@@ -73,7 +73,7 @@ target_compile_options(LinuxTracingTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(LinuxTracingTests PRIVATE
         ContextSwitchManagerTest.cpp
-        GpuTracepointEventProcessorTest.cpp
+        GpuTracepointVisitorTest.cpp
         LinuxTracingUtilsTest.cpp
         PerfEventProcessorTest.cpp
         PerfEventQueueTest.cpp

--- a/src/LinuxTracing/GpuTracepointVisitor.h
+++ b/src/LinuxTracing/GpuTracepointVisitor.h
@@ -16,25 +16,26 @@
 
 #include "LinuxTracing/TracerListener.h"
 #include "PerfEvent.h"
+#include "PerfEventVisitor.h"
 
 namespace orbit_linux_tracing {
 
-class GpuTracepointEventProcessor {
+class GpuTracepointVisitor : public PerfEventVisitor {
  public:
-  void PushEvent(const AmdgpuCsIoctlPerfEvent& sample);
-  void PushEvent(const AmdgpuSchedRunJobPerfEvent& sample);
-  void PushEvent(const DmaFenceSignaledPerfEvent& sample);
-
   void SetListener(TracerListener* listener);
 
+  void visit(AmdgpuCsIoctlPerfEvent* event) override;
+  void visit(AmdgpuSchedRunJobPerfEvent* event) override;
+  void visit(DmaFenceSignaledPerfEvent* event) override;
+
  private:
-  // Keys are context, seqno, and timeline
+  // Keys are context, seqno, and timeline.
   using Key = std::tuple<uint32_t, uint32_t, std::string>;
 
-  int ComputeDepthForEvent(const std::string& timeline, uint64_t start_timestamp,
-                           uint64_t end_timestamp);
+  int ComputeDepthForGpuJob(const std::string& timeline, uint64_t start_timestamp,
+                            uint64_t end_timestamp);
 
-  void CreateGpuExecutionEventIfComplete(const Key& key);
+  void CreateGpuJobAndSendToListenerIfComplete(const Key& key);
 
   TracerListener* listener_ = nullptr;
 

--- a/src/LinuxTracing/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracing/LinuxTracingIntegrationTest.cpp
@@ -396,7 +396,8 @@ void VerifyOrderOfAllEvents(const std::vector<orbit_grpc_protos::CaptureEvent>& 
       case orbit_grpc_protos::CaptureEvent::kInternedString:
         UNREACHABLE();
       case orbit_grpc_protos::CaptureEvent::kGpuJob:
-        // Currently GpuJobs are not sent in order with the other events.
+        EXPECT_GE(event.gpu_job().dma_fence_signaled_time_ns(), previous_event_timestamp_ns);
+        previous_event_timestamp_ns = event.gpu_job().dma_fence_signaled_time_ns();
         break;
       case orbit_grpc_protos::CaptureEvent::kThreadName:
         EXPECT_GE(event.thread_name().timestamp_ns(), previous_event_timestamp_ns);

--- a/src/LinuxTracing/PerfEvent.h
+++ b/src/LinuxTracing/PerfEvent.h
@@ -37,11 +37,13 @@ class PerfEvent {
   virtual ~PerfEvent() = default;
   virtual uint64_t GetTimestamp() const = 0;
   virtual void Accept(PerfEventVisitor* visitor) = 0;
-  void SetOriginFileDescriptor(int fd) { origin_file_descriptor_ = fd; }
-  int GetOriginFileDescriptor() const { return origin_file_descriptor_; }
+
+  static constexpr int kNotOrderedInAnyFileDescriptor = -1;
+  void SetOrderedInFileDescriptor(int fd) { ordered_in_file_descriptor_ = fd; }
+  int GetOrderedInFileDescriptor() const { return ordered_in_file_descriptor_; }
 
  private:
-  int origin_file_descriptor_ = -1;
+  int ordered_in_file_descriptor_ = kNotOrderedInAnyFileDescriptor;
 };
 
 class ContextSwitchPerfEvent : public PerfEvent {

--- a/src/LinuxTracing/PerfEventProcessor.h
+++ b/src/LinuxTracing/PerfEventProcessor.h
@@ -41,11 +41,11 @@ class PerfEventProcessor {
   }
 
  private:
-  // Do not process events that are more recent than 0.1 seconds. There could be
-  // events coming out of order as they are read from different perf_event_open
-  // ring buffers and this ensure that all events are processed in the correct
+  // Do not process events that are more recent than kProcessingDelayMs. Events
+  // come out of order as they are read from different perf_event_open ring
+  // buffers and this ensures that all events are processed in the correct
   // order.
-  static constexpr uint64_t kProcessingDelayMs = 100;
+  static constexpr uint64_t kProcessingDelayMs = 333;
   uint64_t last_processed_timestamp_ns_ = 0;
   std::atomic<uint64_t>* discarded_out_of_order_counter_ = nullptr;
 

--- a/src/LinuxTracing/PerfEventProcessorTest.cpp
+++ b/src/LinuxTracing/PerfEventProcessorTest.cpp
@@ -39,7 +39,7 @@ class PerfEventProcessorTest : public ::testing::Test {
   MockVisitor mock_visitor_;
   std::atomic<uint64_t> discarded_out_of_order_counter_ = 0;
 
-  static constexpr uint64_t kDelayBeforeProcessOldEventsMs = 100;
+  static constexpr uint64_t kDelayBeforeProcessOldEventsMs = 333;
 };
 
 std::unique_ptr<PerfEvent> MakeFakePerfEvent(int origin_fd, uint64_t timestamp_ns) {

--- a/src/LinuxTracing/PerfEventProcessorTest.cpp
+++ b/src/LinuxTracing/PerfEventProcessorTest.cpp
@@ -46,7 +46,7 @@ std::unique_ptr<PerfEvent> MakeFakePerfEvent(int origin_fd, uint64_t timestamp_n
   // We use LostPerfEvent just because it's a simple one, but we could use any
   // as we only need to set the file descriptor and the timestamp.
   auto event = std::make_unique<LostPerfEvent>();
-  event->SetOriginFileDescriptor(origin_fd);
+  event->SetOrderedInFileDescriptor(origin_fd);
   event->ring_buffer_record.sample_id.time = timestamp_ns;
   return event;
 }

--- a/src/LinuxTracing/PerfEventQueue.cpp
+++ b/src/LinuxTracing/PerfEventQueue.cpp
@@ -17,10 +17,10 @@ namespace orbit_linux_tracing {
 void PerfEventQueue::PushEvent(std::unique_ptr<PerfEvent> event) {
   int origin_fd = event->GetOrderedInFileDescriptor();
   if (origin_fd == PerfEvent::kNotOrderedInAnyFileDescriptor) {
-    unordered_events_priority_queue_.push(std::move(event));
+    priority_queue_of_events_not_ordered_by_fd_.push(std::move(event));
 
-  } else if (auto queue_it = ordered_queues_by_fd_.find(origin_fd);
-             queue_it != ordered_queues_by_fd_.end()) {
+  } else if (auto queue_it = queues_of_events_ordered_by_fd_.find(origin_fd);
+             queue_it != queues_of_events_ordered_by_fd_.end()) {
     const std::unique_ptr<std::queue<std::unique_ptr<PerfEvent>>>& queue = queue_it->second;
 
     CHECK(!queue->empty());
@@ -29,68 +29,73 @@ void PerfEventQueue::PushEvent(std::unique_ptr<PerfEvent> event) {
     queue->push(std::move(event));
 
   } else {
-    queue_it = ordered_queues_by_fd_
+    queue_it = queues_of_events_ordered_by_fd_
                    .emplace(origin_fd, std::make_unique<std::queue<std::unique_ptr<PerfEvent>>>())
                    .first;
     const std::unique_ptr<std::queue<std::unique_ptr<PerfEvent>>>& queue = queue_it->second;
 
     queue->push(std::move(event));
-    ordered_queues_heap_.emplace_back(queue.get());
-    MoveUpBackOfOrderedQueuesHeap();
+    heap_of_queues_of_events_ordered_by_fd_.emplace_back(queue.get());
+    MoveUpBackOfHeapOfQueues();
   }
 }
 
 bool PerfEventQueue::HasEvent() const {
-  return !ordered_queues_heap_.empty() || !unordered_events_priority_queue_.empty();
+  return !heap_of_queues_of_events_ordered_by_fd_.empty() ||
+         !priority_queue_of_events_not_ordered_by_fd_.empty();
 }
 
 PerfEvent* PerfEventQueue::TopEvent() {
   // As we effectively have two priority queues, get the older event between the two events at the
   // top of the two queues.
   PerfEvent* top_event = nullptr;
-  if (!unordered_events_priority_queue_.empty()) {
-    top_event = unordered_events_priority_queue_.top().get();
+  if (!priority_queue_of_events_not_ordered_by_fd_.empty()) {
+    top_event = priority_queue_of_events_not_ordered_by_fd_.top().get();
   }
-  if (!ordered_queues_heap_.empty() &&
+  if (!heap_of_queues_of_events_ordered_by_fd_.empty() &&
       (top_event == nullptr ||
-       ordered_queues_heap_.front()->front()->GetTimestamp() < top_event->GetTimestamp())) {
-    top_event = ordered_queues_heap_.front()->front().get();
+       heap_of_queues_of_events_ordered_by_fd_.front()->front()->GetTimestamp() <
+           top_event->GetTimestamp())) {
+    top_event = heap_of_queues_of_events_ordered_by_fd_.front()->front().get();
   }
   CHECK(top_event != nullptr);
   return top_event;
 }
 
 std::unique_ptr<PerfEvent> PerfEventQueue::PopEvent() {
-  if (!unordered_events_priority_queue_.empty() &&
-      (ordered_queues_heap_.empty() || unordered_events_priority_queue_.top()->GetTimestamp() <
-                                           ordered_queues_heap_.front()->front()->GetTimestamp())) {
+  if (!priority_queue_of_events_not_ordered_by_fd_.empty() &&
+      (heap_of_queues_of_events_ordered_by_fd_.empty() ||
+       priority_queue_of_events_not_ordered_by_fd_.top()->GetTimestamp() <
+           heap_of_queues_of_events_ordered_by_fd_.front()->front()->GetTimestamp())) {
     // The oldest event is at the top of the priority queue holding the events that cannot be
     // assumed sorted in any ring buffer.
-    std::unique_ptr<PerfEvent> top_event =
-        std::move(const_cast<std::unique_ptr<PerfEvent>&>(unordered_events_priority_queue_.top()));
-    unordered_events_priority_queue_.pop();
+    std::unique_ptr<PerfEvent> top_event = std::move(
+        const_cast<std::unique_ptr<PerfEvent>&>(priority_queue_of_events_not_ordered_by_fd_.top()));
+    priority_queue_of_events_not_ordered_by_fd_.pop();
     return top_event;
   }
 
-  std::queue<std::unique_ptr<PerfEvent>>* top_queue = ordered_queues_heap_.front();
+  std::queue<std::unique_ptr<PerfEvent>>* top_queue =
+      heap_of_queues_of_events_ordered_by_fd_.front();
   std::unique_ptr<PerfEvent> top_event = std::move(top_queue->front());
   top_queue->pop();
 
   if (top_queue->empty()) {
     int top_fd = top_event->GetOrderedInFileDescriptor();
-    ordered_queues_by_fd_.erase(top_fd);
-    std::swap(ordered_queues_heap_.front(), ordered_queues_heap_.back());
-    ordered_queues_heap_.pop_back();
-    MoveDownFrontOfOrderedQueuesHeap();
+    queues_of_events_ordered_by_fd_.erase(top_fd);
+    std::swap(heap_of_queues_of_events_ordered_by_fd_.front(),
+              heap_of_queues_of_events_ordered_by_fd_.back());
+    heap_of_queues_of_events_ordered_by_fd_.pop_back();
+    MoveDownFrontOfHeapOfQueues();
   } else {
-    MoveDownFrontOfOrderedQueuesHeap();
+    MoveDownFrontOfHeapOfQueues();
   }
 
   return top_event;
 }
 
-void PerfEventQueue::MoveDownFrontOfOrderedQueuesHeap() {
-  if (ordered_queues_heap_.empty()) {
+void PerfEventQueue::MoveDownFrontOfHeapOfQueues() {
+  if (heap_of_queues_of_events_ordered_by_fd_.empty()) {
     return;
   }
 
@@ -100,18 +105,19 @@ void PerfEventQueue::MoveDownFrontOfOrderedQueuesHeap() {
     new_index = current_index;
     size_t left_index = current_index * 2 + 1;
     size_t right_index = current_index * 2 + 2;
-    if (left_index < ordered_queues_heap_.size() &&
-        ordered_queues_heap_[left_index]->front()->GetTimestamp() <
-            ordered_queues_heap_[new_index]->front()->GetTimestamp()) {
+    if (left_index < heap_of_queues_of_events_ordered_by_fd_.size() &&
+        heap_of_queues_of_events_ordered_by_fd_[left_index]->front()->GetTimestamp() <
+            heap_of_queues_of_events_ordered_by_fd_[new_index]->front()->GetTimestamp()) {
       new_index = left_index;
     }
-    if (right_index < ordered_queues_heap_.size() &&
-        ordered_queues_heap_[right_index]->front()->GetTimestamp() <
-            ordered_queues_heap_[new_index]->front()->GetTimestamp()) {
+    if (right_index < heap_of_queues_of_events_ordered_by_fd_.size() &&
+        heap_of_queues_of_events_ordered_by_fd_[right_index]->front()->GetTimestamp() <
+            heap_of_queues_of_events_ordered_by_fd_[new_index]->front()->GetTimestamp()) {
       new_index = right_index;
     }
     if (new_index != current_index) {
-      std::swap(ordered_queues_heap_[new_index], ordered_queues_heap_[current_index]);
+      std::swap(heap_of_queues_of_events_ordered_by_fd_[new_index],
+                heap_of_queues_of_events_ordered_by_fd_[current_index]);
       current_index = new_index;
     } else {
       break;
@@ -119,19 +125,20 @@ void PerfEventQueue::MoveDownFrontOfOrderedQueuesHeap() {
   }
 }
 
-void PerfEventQueue::MoveUpBackOfOrderedQueuesHeap() {
-  if (ordered_queues_heap_.empty()) {
+void PerfEventQueue::MoveUpBackOfHeapOfQueues() {
+  if (heap_of_queues_of_events_ordered_by_fd_.empty()) {
     return;
   }
 
-  size_t current_index = ordered_queues_heap_.size() - 1;
+  size_t current_index = heap_of_queues_of_events_ordered_by_fd_.size() - 1;
   while (current_index > 0) {
     size_t parent_index = (current_index - 1) / 2;
-    if (ordered_queues_heap_[parent_index]->front()->GetTimestamp() <=
-        ordered_queues_heap_[current_index]->front()->GetTimestamp()) {
+    if (heap_of_queues_of_events_ordered_by_fd_[parent_index]->front()->GetTimestamp() <=
+        heap_of_queues_of_events_ordered_by_fd_[current_index]->front()->GetTimestamp()) {
       break;
     }
-    std::swap(ordered_queues_heap_[parent_index], ordered_queues_heap_[current_index]);
+    std::swap(heap_of_queues_of_events_ordered_by_fd_[parent_index],
+              heap_of_queues_of_events_ordered_by_fd_[current_index]);
     current_index = parent_index;
   }
 }

--- a/src/LinuxTracing/PerfEventQueue.h
+++ b/src/LinuxTracing/PerfEventQueue.h
@@ -42,28 +42,28 @@ class PerfEventQueue {
  private:
   // Floats down the element at the top of the ordered_queues_heap_ to its correct place. Used when
   // the key of the top element changes, or as part of the process of removing the top element.
-  void MoveDownFrontOfOrderedQueuesHeap();
+  void MoveDownFrontOfHeapOfQueues();
   // Floats up an element that it is know should be further up in the heap. Used on insertion.
-  void MoveUpBackOfOrderedQueuesHeap();
+  void MoveUpBackOfHeapOfQueues();
 
  private:
   // This vector holds the heap of the queues each of which holds events coming from the same ring
   // buffer and assumes them already in order by timestamp.
-  std::vector<std::queue<std::unique_ptr<PerfEvent>>*> ordered_queues_heap_;
+  std::vector<std::queue<std::unique_ptr<PerfEvent>>*> heap_of_queues_of_events_ordered_by_fd_;
   // This map keeps the association between a file descriptor and the ordered queue of events coming
   // from the ring buffer corresponding to that file descriptor.
   absl::flat_hash_map<int, std::unique_ptr<std::queue<std::unique_ptr<PerfEvent>>>>
-      ordered_queues_by_fd_;
+      queues_of_events_ordered_by_fd_;
 
-  static constexpr auto kUnorderedEventsReverseTimestampCompare =
+  static constexpr auto kPerfEventReverseTimestampCompare =
       [](const std::unique_ptr<PerfEvent>& lhs, const std::unique_ptr<PerfEvent>& rhs) {
         return lhs->GetTimestamp() > rhs->GetTimestamp();
       };
   // This priority queue holds all those events that cannot be assumed already sorted in a specific
-  // ring buffer.
+  // ring buffer. All such events are simply sorted by the priority queue by increasing timestamp.
   std::priority_queue<std::unique_ptr<PerfEvent>, std::vector<std::unique_ptr<PerfEvent>>,
-                      decltype(kUnorderedEventsReverseTimestampCompare)>
-      unordered_events_priority_queue_{kUnorderedEventsReverseTimestampCompare};
+                      decltype(kPerfEventReverseTimestampCompare)>
+      priority_queue_of_events_not_ordered_by_fd_{kPerfEventReverseTimestampCompare};
 };
 
 }  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/PerfEventReaders.cpp
+++ b/src/LinuxTracing/PerfEventReaders.cpp
@@ -95,10 +95,7 @@ std::unique_ptr<MmapPerfEvent> ConsumeMmapPerfEvent(PerfEventRingBuffer* ring_bu
   int32_t pid = static_cast<int32_t>(sample_id.pid);
 
   // Consider moving this to MMAP2 event which has more information (like flags)
-  auto event = std::make_unique<MmapPerfEvent>(pid, timestamp, mmap_event, std::move(filename));
-  event->SetOriginFileDescriptor(ring_buffer->GetFileDescriptor());
-
-  return event;
+  return std::make_unique<MmapPerfEvent>(pid, timestamp, mmap_event, std::move(filename));
 }
 
 std::unique_ptr<StackSamplePerfEvent> ConsumeStackSamplePerfEvent(PerfEventRingBuffer* ring_buffer,

--- a/src/LinuxTracing/TracerThread.h
+++ b/src/LinuxTracing/TracerThread.h
@@ -80,7 +80,7 @@ class TracerThread {
   void InitSwitchesStatesNamesVisitor();
   bool OpenContextSwitchAndThreadStateTracepoints(const std::vector<int32_t>& cpus);
 
-  bool InitGpuTracepointEventVisitor();
+  void InitGpuTracepointEventVisitor();
   bool OpenGpuTracepoints(const std::vector<int32_t>& cpus);
 
   bool OpenInstrumentedTracepoints(const std::vector<int32_t>& cpus);
@@ -157,8 +157,8 @@ class TracerThread {
   std::mutex deferred_events_mutex_;
   std::unique_ptr<UprobesUnwindingVisitor> uprobes_unwinding_visitor_;
   std::unique_ptr<SwitchesStatesNamesVisitor> switches_states_names_visitor_;
-  PerfEventProcessor event_processor_;
   std::unique_ptr<GpuTracepointVisitor> gpu_event_visitor_;
+  PerfEventProcessor event_processor_;
 
   struct EventStats {
     void Reset() {

--- a/src/LinuxTracing/TracerThread.h
+++ b/src/LinuxTracing/TracerThread.h
@@ -21,7 +21,7 @@
 
 #include "ContextSwitchManager.h"
 #include "Function.h"
-#include "GpuTracepointEventProcessor.h"
+#include "GpuTracepointVisitor.h"
 #include "LinuxTracing/TracerListener.h"
 #include "LinuxTracingUtils.h"
 #include "ManualInstrumentationConfig.h"
@@ -80,7 +80,7 @@ class TracerThread {
   void InitSwitchesStatesNamesVisitor();
   bool OpenContextSwitchAndThreadStateTracepoints(const std::vector<int32_t>& cpus);
 
-  bool InitGpuTracepointEventProcessor();
+  bool InitGpuTracepointEventVisitor();
   bool OpenGpuTracepoints(const std::vector<int32_t>& cpus);
 
   bool OpenInstrumentedTracepoints(const std::vector<int32_t>& cpus);
@@ -158,7 +158,7 @@ class TracerThread {
   std::unique_ptr<UprobesUnwindingVisitor> uprobes_unwinding_visitor_;
   std::unique_ptr<SwitchesStatesNamesVisitor> switches_states_names_visitor_;
   PerfEventProcessor event_processor_;
-  std::unique_ptr<GpuTracepointEventProcessor> gpu_event_processor_;
+  std::unique_ptr<GpuTracepointVisitor> gpu_event_visitor_;
 
   struct EventStats {
     void Reset() {


### PR DESCRIPTION
#### Make GpuTracepointEventProcessor a PerfEventVisitor
This prepares the commit that follows, which will move the processing of
gpu tracepoint events from the thread reading from the ring buffers to the
"processing" thread.
#### Process GPU tracepoint events on the ProcessDeferredEvents thread
With this change, all `perf_event_open` events are now processed on a separate
thread than the one that reads from the ring buffers.
This is the last step towards unifying how we process events in `TracerThread`
and towards producing `CaptureEvent`s in order of timestamps.
This also means that individual GPU tracepoint events are now also processed in
order, which solves the potential problem captured by the last test in
`GpuTracepointVisitorTest`: if the tracepoint events are not processed reasonably
in order, some wrong `GpuJob`s could result.
Performance implications of this change are not an issue as these events are
relatively low frequency: small test on this on Trata and Infiltrator with the
next commit.

Note that this currently doesn't work: `dma_fence_signaled` events can come out
of order even in a single ring buffer, which is not supported by
`PerfEventProcessor`/`PerfEventQueue`.
This is going to be solved in the next commit, by adding support for it to
`PerfEventQueue`.
#### PerfEventQueue now also supports events not in order in their fd
`PerfEventQueue` now has two top-level heaps/priority queues to sort events from
the oldest. The old priority queue sorts fifo queues of events ordered in their
ring buffer. The new priority queue sorts a single group of all the other events
that are known to possibly come out of order (these are GPU events).

Tested with both Trata and Infiltrator, I haven't noticed any difference in CPU
utilization.
#### Increase PerfEventProcessor::kProcessingDelayMs
Albeit not a real solution, this is supposed to mitigate http://b/177532389
("discarded as out of order" events) in average captures.