### PR TITLE
Extend JoinFutures to support arbitrary types

### DIFF
--- a/src/OrbitBase/JoinFutures.cpp
+++ b/src/OrbitBase/JoinFutures.cpp
@@ -12,14 +12,6 @@
 #include "absl/synchronization/mutex.h"
 
 namespace orbit_base {
-namespace {
-struct SharedStateJoin {
-  Promise<void> promise;
-  absl::Mutex mutex;
-  int incompleted_futures;
-};
-}  // namespace
-
 Future<void> JoinFutures(absl::Span<const Future<void>> futures) {
   if (futures.empty()) {
     Promise<void> promise;
@@ -27,30 +19,30 @@ Future<void> JoinFutures(absl::Span<const Future<void>> futures) {
     return promise.GetFuture();
   }
 
-  auto shared_state = std::make_shared<SharedStateJoin>();
-  shared_state->incompleted_futures = static_cast<int>(futures.size());
+  auto shared_state = std::make_shared<orbit_base_internal::SharedStateJoin<void>>();
+  shared_state->incomplete_futures = futures.size();
 
   for (const auto& future : futures) {
     CHECK(future.IsValid());
     orbit_base::FutureRegisterContinuationResult const result =
         future.RegisterContinuation([shared_state]() {
           absl::MutexLock lock{&shared_state->mutex};
-          --shared_state->incompleted_futures;
+          --shared_state->incomplete_futures;
 
-          if (shared_state->incompleted_futures == 0) {
+          if (shared_state->incomplete_futures == 0) {
             shared_state->promise.MarkFinished();
           }
         });
 
     if (result != orbit_base::FutureRegisterContinuationResult::kSuccessfullyRegistered) {
       absl::MutexLock lock{&shared_state->mutex};
-      --shared_state->incompleted_futures;
+      --shared_state->incomplete_futures;
     }
   }
 
   {
     absl::MutexLock lock{&shared_state->mutex};
-    if (shared_state->incompleted_futures == 0) {
+    if (shared_state->incomplete_futures == 0) {
       shared_state->promise.MarkFinished();
     }
   }

--- a/src/OrbitBase/include/OrbitBase/JoinFutures.h
+++ b/src/OrbitBase/include/OrbitBase/JoinFutures.h
@@ -6,13 +6,90 @@
 #define ORBIT_BASE_JOIN_FUTURES_H_
 
 #include "OrbitBase/Future.h"
+#include "OrbitBase/FutureHelpers.h"
+#include "OrbitBase/Promise.h"
 #include "absl/types/span.h"
+
+namespace orbit_base_internal {
+
+template <typename T>
+class SharedStateJoin {
+  orbit_base::Promise<std::vector<T>> promise;
+  absl::Mutex mutex;
+  size_t incomplete_futures;
+  std::vector<std::optional<T>> results;
+
+  void SetResultsInPromise() {
+    std::vector<T> output;
+    output.reserve(results.size());
+    std::transform(results.begin(), results.end(), std::back_inserter(output),
+                   [](std::optional<T>& element) {
+                     CHECK(element.has_value());
+                     return *std::move(element);
+                   });
+    results.clear();
+    promise.SetResult(std::move(output));
+  }
+
+ public:
+  void SetNumberOfFutures(size_t size) {
+    absl::MutexLock lock{&mutex};
+    incomplete_futures = size;
+    results.resize(size);
+  }
+
+  void SetResult(size_t index, const T& argument) {
+    absl::MutexLock lock{&mutex};
+    if (!results[index].has_value()) {
+      results[index] = argument;
+      --incomplete_futures;
+    }
+
+    if (incomplete_futures == 0) {
+      SetResultsInPromise();
+    }
+  }
+
+  orbit_base::Future<std::vector<T>> GetFuture() const { return promise.GetFuture(); }
+};
+
+template <>
+struct SharedStateJoin<void> {
+  orbit_base::Promise<void> promise;
+  absl::Mutex mutex;
+  size_t incomplete_futures;
+};
+}  // namespace orbit_base_internal
 
 namespace orbit_base {
 
 // Returns a future which completes when all futures in the argument have completed.
 // Currently only available for Future<void>.
 [[nodiscard]] Future<void> JoinFutures(absl::Span<const Future<void>> futures);
+
+template <typename T>
+Future<std::vector<T>> JoinFutures(absl::Span<const Future<T>> futures) {
+  if (futures.empty()) {
+    Promise<std::vector<T>> promise;
+    promise.SetResult({});
+    return promise.GetFuture();
+  }
+
+  auto shared_state = std::make_shared<orbit_base_internal::SharedStateJoin<T>>();
+  shared_state->SetNumberOfFutures(futures.size());
+
+  for (auto it = futures.begin(); it != futures.end(); ++it) {
+    const auto& future = *it;
+    CHECK(future.IsValid());
+
+    const size_t index = it - futures.begin();
+    RegisterContinuationOrCallDirectly(future, [shared_state, index](const T& argument) {
+      shared_state->SetResult(index, argument);
+    });
+  }
+
+  return shared_state->GetFuture();
+}
 }  // namespace orbit_base
 
 #endif  // ORBIT_BASE_JOIN_FUTURES_H_


### PR DESCRIPTION
`JoinFutures` used to be only implemented for `Future<void>`. This new
change implements `JoinFutures` for `Future<T>`. It takes an
`absl::Span<const Future<T>>` as its argument and returns a
`Future<std::vector<T>>`. So far it's not possible to change the
container, that is returned. It's also not allocator-aware.