### PR TITLE
Eventtrack refactor

### DIFF
--- a/src/OrbitGl/Batcher.cpp
+++ b/src/OrbitGl/Batcher.cpp
@@ -239,6 +239,8 @@ void Batcher::AddCircle(Vec2 position, float radius, float z, Color color) {
     circle_points_scaled_by_radius.emplace_back(radius * point);
   }
 
+  position = Vec2(floorf(position[0]), floorf(position[1]));
+
   Vec3 prev_point(position[0], position[1] - radius, z);
   Vec3 point_0 = Vec3(position[0], position[1], z);
   for (size_t i = 0; i < circle_points_scaled_by_radius.size(); ++i) {

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(
          CallStackDataView.h
          CallTreeView.h
          CaptureWindow.h
+         CaptureViewElement.h
          CodeReport.h
          CoreMath.h
          DataView.h
@@ -53,6 +54,7 @@ target_sources(
          StatusListener.h
          TextBox.h
          TextRenderer.h
+         ThreadBar.h
          ThreadStateTrack.h
          ThreadTrack.h
          TimeGraph.h
@@ -77,6 +79,7 @@ target_sources(
           CallStackDataView.cpp
           CallTreeView.cpp
           CaptureWindow.cpp
+          CaptureViewElement.cpp
           DataManager.cpp
           DataView.cpp
           Disassembler.cpp

--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "CaptureViewElement.h"
+
+#include "GlCanvas.h"
+#include "TimeGraph.h"
+
+namespace orbit_gl {
+
+CaptureViewElement::CaptureViewElement(TimeGraph* time_graph) : time_graph_(time_graph) {}
+
+void CaptureViewElement::OnPick(int x, int y) {
+  canvas_->ScreenToWorld(x, y, mouse_pos_last_click_[0], mouse_pos_last_click_[1]);
+  picking_offset_ = mouse_pos_last_click_ - pos_;
+  mouse_pos_cur_ = mouse_pos_last_click_;
+  picked_ = true;
+}
+
+void CaptureViewElement::OnRelease() {
+  picked_ = false;
+  time_graph_->NeedsUpdate();
+}
+
+void CaptureViewElement::OnDrag(int x, int y) {
+  canvas_->ScreenToWorld(x, y, mouse_pos_cur_[0], mouse_pos_cur_[1]);
+  time_graph_->NeedsUpdate();
+}
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -1,0 +1,55 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_CAPTURE_VIEW_ELEMENT_H_
+#define ORBIT_GL_CAPTURE_VIEW_ELEMENT_H_
+
+#include "PickingManager.h"
+
+class TimeGraph;
+class GlCanvas;
+
+namespace orbit_gl {
+
+/* Base class for UI elements drawn underneath the capture window. */
+class CaptureViewElement : public Pickable {
+ public:
+  explicit CaptureViewElement(TimeGraph* time_graph);
+  virtual void Draw(GlCanvas* canvas, PickingMode /*picking_mode*/, float /*z_offset*/ = 0) {
+    canvas_ = canvas;
+  }
+
+  virtual void UpdatePrimitives(uint64_t /*min_tick*/, uint64_t /*max_tick*/,
+                                PickingMode /*picking_mode*/, float /*z_offset*/ = 0){};
+
+  void SetTimeGraph(TimeGraph* timegraph) { time_graph_ = timegraph; }
+  [[nodiscard]] TimeGraph* GetTimeGraph() { return time_graph_; }
+
+  [[nodiscard]] GlCanvas* GetCanvas() const { return canvas_; }
+
+  virtual void SetPos(float x, float y) { pos_ = Vec2(x, y); }
+  [[nodiscard]] Vec2 GetPos() const { return pos_; }
+  void SetSize(float width, float height) { size_ = Vec2(width, height); }
+  [[nodiscard]] Vec2 GetSize() const { return size_; }
+
+  // Pickable
+  void OnPick(int x, int y) override;
+  void OnRelease() override;
+  void OnDrag(int x, int y) override;
+  [[nodiscard]] bool Draggable() override { return true; }
+
+ protected:
+  GlCanvas* canvas_ = nullptr;
+  TimeGraph* time_graph_;
+  Vec2 pos_ = Vec2(0, 0);
+  Vec2 size_ = Vec2(0, 0);
+
+  Vec2 mouse_pos_last_click_;
+  Vec2 mouse_pos_cur_;
+  Vec2 picking_offset_ = Vec2(0, 0);
+  bool picked_ = false;
+};
+}  // namespace orbit_gl
+
+#endif

--- a/src/OrbitGl/EventTrack.h
+++ b/src/OrbitGl/EventTrack.h
@@ -8,22 +8,23 @@
 #include <GteVector.h>
 #include <stdint.h>
 
+#include <memory>
 #include <string>
 
 #include "CoreMath.h"
+#include "OrbitClientData/Callstack.h"
 #include "OrbitClientData/CallstackTypes.h"
-#include "PickingManager.h"
-#include "Track.h"
+#include "OrbitClientModel/CaptureData.h"
+#include "ThreadBar.h"
 
-class CallStack;
-class GlCanvas;
 class OrbitApp;
-class TimeGraph;
 
-class EventTrack : public Track {
+namespace orbit_gl {
+
+class EventTrack : public ThreadBar {
  public:
-  explicit EventTrack(TimeGraph* time_graph, OrbitApp* app, CaptureData* capture_data);
-  Type GetType() const override { return kEventTrack; }
+  explicit EventTrack(OrbitApp* app, TimeGraph* time_graph, CaptureData* capture_data,
+                      ThreadID thread_id);
 
   std::string GetTooltip() const override;
 
@@ -33,15 +34,10 @@ class EventTrack : public Track {
 
   void OnPick(int x, int y) override;
   void OnRelease() override;
-  void OnDrag(int x, int y) override;
-  bool Draggable() override { return true; }
-  float GetHeight() const override { return size_[1]; }
 
-  void SetThreadId(ThreadID thread_id) { thread_id_ = thread_id; }
-  void SetPos(float x, float y) { pos_ = Vec2(x, y); }
-  bool IsEmpty() const override;
-  [[nodiscard]] uint64_t GetMinTime() const override;
-  [[nodiscard]] uint64_t GetMaxTime() const override;
+  [[nodiscard]] bool IsEmpty() const override;
+
+  void SetColor(const Color& color) { color_ = color; }
 
  protected:
   void SelectEvents();
@@ -50,10 +46,11 @@ class EventTrack : public Track {
                                                       int max_line_length = 80, int max_lines = 20,
                                                       int bottom_n_lines = 5) const;
 
- private:
   [[nodiscard]] std::string GetSampleTooltip(PickingId id) const;
 
-  OrbitApp* app_ = nullptr;
+  Color color_;
 };
+
+}  // namespace orbit_gl
 
 #endif  // ORBIT_GL_EVENT_TRACK_H_

--- a/src/OrbitGl/ThreadBar.h
+++ b/src/OrbitGl/ThreadBar.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_THREAD_BAR_H_
+#define ORBIT_GL_THREAD_BAR_H_
+
+#include <memory>
+#include <string>
+
+#include "CaptureViewElement.h"
+#include "OrbitClientModel/CaptureData.h"
+
+class OrbitApp;
+
+namespace orbit_gl {
+
+class ThreadBar : public CaptureViewElement, public std::enable_shared_from_this<ThreadBar> {
+ public:
+  explicit ThreadBar(OrbitApp* app, TimeGraph* time_graph, CaptureData* capture_data,
+                     ThreadID thread_id)
+      : CaptureViewElement(time_graph),
+        thread_id_(thread_id),
+        app_(app),
+        capture_data_(capture_data){};
+
+  void SetThreadId(ThreadID thread_id) { thread_id_ = thread_id; }
+  [[nodiscard]] virtual bool IsEmpty() const { return false; }
+
+  void SetCaptureData(CaptureData* capture_data) { capture_data_ = capture_data; }
+
+ protected:
+  ThreadID thread_id_ = -1;
+  OrbitApp* app_;
+  CaptureData* capture_data_;
+};
+
+}  // namespace orbit_gl
+#endif

--- a/src/OrbitGl/ThreadStateTrack.cpp
+++ b/src/OrbitGl/ThreadStateTrack.cpp
@@ -20,12 +20,11 @@
 
 using orbit_client_protos::ThreadStateSliceInfo;
 
-ThreadStateTrack::ThreadStateTrack(TimeGraph* time_graph, int32_t thread_id, OrbitApp* app,
-                                   CaptureData* capture_data)
-    : Track{time_graph, capture_data}, app_{app} {
-  thread_id_ = thread_id;
-  picked_ = false;
-}
+namespace orbit_gl {
+
+ThreadStateTrack::ThreadStateTrack(OrbitApp* app, TimeGraph* time_graph, CaptureData* capture_data,
+                                   ThreadID thread_id)
+    : ThreadBar(app, time_graph, capture_data, thread_id) {}
 
 bool ThreadStateTrack::IsEmpty() const {
   if (capture_data_ == nullptr) return true;
@@ -33,6 +32,8 @@ bool ThreadStateTrack::IsEmpty() const {
 }
 
 void ThreadStateTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
+  ThreadBar::Draw(canvas, picking_mode, z_offset);
+
   // Similarly to EventTrack::Draw, the thread state slices don't respond to clicks, but have a
   // tooltip. For picking, we want to draw the event bar over them if handling a click, and
   // underneath otherwise. This simulates "click-through" behavior.
@@ -156,7 +157,9 @@ std::string ThreadStateTrack::GetThreadStateSliceTooltip(PickingId id) const {
 }
 
 void ThreadStateTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
-                                        PickingMode /*picking_mode*/, float z_offset) {
+                                        PickingMode picking_mode, float z_offset) {
+  ThreadBar::UpdatePrimitives(min_tick, max_tick, picking_mode, z_offset);
+
   Batcher* batcher = &time_graph_->GetBatcher();
   const GlCanvas* canvas = time_graph_->GetCanvas();
 
@@ -211,7 +214,9 @@ void ThreadStateTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
       });
 }
 
-void ThreadStateTrack::OnPick(int /*x*/, int /*y*/) {
+void ThreadStateTrack::OnPick(int x, int y) {
+  ThreadBar::OnPick(x, y);
   app_->set_selected_thread_id(thread_id_);
-  picked_ = true;
 }
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/ThreadStateTrack.h
+++ b/src/OrbitGl/ThreadStateTrack.h
@@ -8,40 +8,36 @@
 #include <GteVector.h>
 #include <stdint.h>
 
+#include <memory>
 #include <string>
 
 #include "CoreMath.h"
-#include "PickingManager.h"
-#include "Track.h"
+#include "ThreadBar.h"
 
-class OrbitApp;
+namespace orbit_gl {
 
 // This is a track dedicated to displaying thread states in different colors
 // and with the corresponding tooltips.
 // It is a thin sub-track of ThreadTrack, added above the callstack track (EventTrack).
 // The colors are determined only by the states, not by the color assigned to the thread.
 
-class ThreadStateTrack final : public Track {
+class ThreadStateTrack final : public ThreadBar {
  public:
-  explicit ThreadStateTrack(TimeGraph* time_graph, int32_t thread_id, OrbitApp* app,
-                            CaptureData* capture_data);
-  Type GetType() const override { return kThreadStateTrack; }
+  explicit ThreadStateTrack(OrbitApp* app, TimeGraph* time_graph, CaptureData* capture_data,
+                            ThreadID thread_id);
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) override;
   void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode,
                         float z_offset) override;
 
   void OnPick(int x, int y) override;
-  void OnDrag(int /*x*/, int /*y*/) override {}
-  void OnRelease() override { picked_ = false; };
-  float GetHeight() const override { return size_[1]; }
 
-  bool IsEmpty() const override;
+  [[nodiscard]] bool IsEmpty() const override;
 
  private:
   std::string GetThreadStateSliceTooltip(PickingId id) const;
-
-  OrbitApp* app_ = nullptr;
 };
+
+}  // namespace orbit_gl
 
 #endif  // ORBIT_GL_THREAD_STATE_TRACK_H_

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -41,12 +41,13 @@ ThreadTrack::ThreadTrack(TimeGraph* time_graph, int32_t thread_id, OrbitApp* app
   InitializeNameAndLabel(thread_id);
 
   thread_state_track_ =
-      std::make_shared<ThreadStateTrack>(time_graph, thread_id, app_, capture_data);
+      std::make_shared<orbit_gl::ThreadStateTrack>(app_, time_graph, capture_data, thread_id_);
 
-  event_track_ = std::make_shared<EventTrack>(time_graph, app_, capture_data);
+  event_track_ = std::make_shared<orbit_gl::EventTrack>(app_, time_graph, capture_data, thread_id_);
   event_track_->SetThreadId(thread_id);
 
-  tracepoint_track_ = std::make_shared<TracepointTrack>(time_graph, thread_id, app_, capture_data);
+  tracepoint_track_ =
+      std::make_shared<orbit_gl::TracepointTrack>(app_, time_graph, capture_data, thread_id_);
   SetTrackColor(TimeGraph::GetThreadColor(thread_id));
 }
 
@@ -231,10 +232,10 @@ void ThreadTrack::UpdatePositionOfSubtracks() {
 }
 
 void ThreadTrack::UpdateMinMaxTimestamps() {
-  if (!event_track_->IsEmpty()) {
-    min_time_ = std::min(min_time_.load(), event_track_->GetMinTime());
-    max_time_ = std::max(max_time_.load(), event_track_->GetMaxTime());
-  }
+  CHECK(capture_data_ != nullptr);
+
+  min_time_ = std::min(min_time_.load(), capture_data_->GetCallstackData()->min_time());
+  max_time_ = std::max(max_time_.load(), capture_data_->GetCallstackData()->max_time());
 }
 
 void ThreadTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -66,9 +66,9 @@ class ThreadTrack final : public TimerTrack {
   void UpdatePositionOfSubtracks();
   void UpdateMinMaxTimestamps();
 
-  std::shared_ptr<ThreadStateTrack> thread_state_track_;
-  std::shared_ptr<EventTrack> event_track_;
-  std::shared_ptr<TracepointTrack> tracepoint_track_;
+  std::shared_ptr<orbit_gl::ThreadStateTrack> thread_state_track_;
+  std::shared_ptr<orbit_gl::EventTrack> event_track_;
+  std::shared_ptr<orbit_gl::TracepointTrack> tracepoint_track_;
 };
 
 #endif  // ORBIT_GL_THREAD_TRACK_H_

--- a/src/OrbitGl/TracepointTrack.h
+++ b/src/OrbitGl/TracepointTrack.h
@@ -9,25 +9,30 @@
 
 #include <string>
 
-#include "EventTrack.h"
-#include "PickingManager.h"
+#include "ThreadBar.h"
 
-class TracepointTrack : public EventTrack {
+namespace orbit_gl {
+
+class TracepointTrack : public ThreadBar {
  public:
-  explicit TracepointTrack(TimeGraph* time_graph, int32_t thread_id, OrbitApp* app,
-                           CaptureData* capture_data);
+  explicit TracepointTrack(OrbitApp* app, TimeGraph* time_graph, CaptureData* capture_data,
+                           int32_t thread_id);
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
 
   void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode,
                         float z_offset = 0) override;
 
-  void OnPick(int x, int y) override;
-  void OnRelease() override;
-  bool IsEmpty() const override;
+  [[nodiscard]] bool IsEmpty() const override;
+
+  void SetColor(const Color& color) { color_ = color; }
 
  private:
   std::string GetTracepointTooltip(PickingId id) const;
+
+  Color color_;
 };
+
+}  // namespace orbit_gl
 
 #endif  // ORBIT_GL_TRACEPOINT_TRACK_H_

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -296,8 +296,11 @@ void TrackManager::UpdateTracks(uint64_t min_tick, uint64_t max_tick, PickingMod
     }
 
     const float z_offset = GlCanvas::kZOffsetPinnedTrack;
-    track->SetY(current_y + time_graph_->GetCanvas()->GetWorldTopLeftY() - layout.GetTopMargin() -
-                layout.GetSchedulerTrackOffset());
+    if (!track->IsMoving()) {
+      track->SetPos(track->GetPos()[0], current_y + time_graph_->GetCanvas()->GetWorldTopLeftY() -
+                                            layout.GetTopMargin() -
+                                            layout.GetSchedulerTrackOffset());
+    }
     track->UpdatePrimitives(min_tick, max_tick, picking_mode, z_offset);
     const float height = (track->GetHeight() + layout.GetSpaceBetweenTracks());
     current_y -= height;
@@ -311,7 +314,9 @@ void TrackManager::UpdateTracks(uint64_t min_tick, uint64_t max_tick, PickingMod
     }
 
     const float z_offset = track->IsMoving() ? GlCanvas::kZOffsetMovingTack : 0.f;
-    track->SetY(current_y);
+    if (!track->IsMoving()) {
+      track->SetPos(track->GetPos()[0], current_y);
+    }
     track->UpdatePrimitives(min_tick, max_tick, picking_mode, z_offset);
     current_y -= (track->GetHeight() + layout.GetSpaceBetweenTracks());
   }

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -16,12 +16,14 @@
 
 TriangleToggle::TriangleToggle(State initial_state, StateChangeHandler handler,
                                TimeGraph* time_graph)
-    : state_(initial_state),
+    : CaptureViewElement(time_graph),
+      state_(initial_state),
       initial_state_(initial_state),
-      handler_(std::move(handler)),
-      time_graph_(time_graph) {}
+      handler_(std::move(handler)) {}
 
 void TriangleToggle::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
+  CaptureViewElement::Draw(canvas, picking_mode, z_offset);
+
   Batcher* batcher = canvas->GetBatcher();
   const float z = GlCanvas::kZValueTrack + z_offset;
 
@@ -57,16 +59,15 @@ void TriangleToggle::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_of
   }
 }
 
-void TriangleToggle::OnPick(int /*x*/, int /*y*/) {}
-
 void TriangleToggle::OnRelease() {
   if (IsInactive()) {
     return;
   }
 
+  CaptureViewElement::OnRelease();
+
   state_ = IsCollapsed() ? State::kExpanded : State::kCollapsed;
   handler_(state_);
-  time_graph_->NeedsUpdate();
 }
 
 void TriangleToggle::SetState(State state, InitialStateUpdate behavior) {

--- a/src/OrbitGl/TriangleToggle.h
+++ b/src/OrbitGl/TriangleToggle.h
@@ -8,13 +8,11 @@
 #include <functional>
 #include <memory>
 
+#include "CaptureViewElement.h"
 #include "CoreMath.h"
-#include "PickingManager.h"
 
-class TimeGraph;
-class GlCanvas;
-
-class TriangleToggle : public Pickable, public std::enable_shared_from_this<TriangleToggle> {
+class TriangleToggle : public orbit_gl::CaptureViewElement,
+                       public std::enable_shared_from_this<TriangleToggle> {
  public:
   enum class State { kInactive, kExpanded, kCollapsed };
   enum class InitialStateUpdate { kKeepInitialState, kReplaceInitialState };
@@ -29,10 +27,9 @@ class TriangleToggle : public Pickable, public std::enable_shared_from_this<Tria
   TriangleToggle(TriangleToggle&&) = delete;
   TriangleToggle& operator=(TriangleToggle&&) = delete;
 
-  void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0);
+  void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
 
   // Pickable
-  void OnPick(int x, int y) override;
   void OnRelease() override;
 
   State GetState() const { return state_; }
@@ -42,15 +39,11 @@ class TriangleToggle : public Pickable, public std::enable_shared_from_this<Tria
   bool IsCollapsed() const { return state_ == State::kCollapsed; }
   bool IsExpanded() const { return state_ == State::kExpanded; }
   bool IsInactive() const { return state_ == State::kInactive; }
-  Vec2 GetPos() const { return pos_; }
-  void SetPos(const Vec2& pos) { pos_ = pos; }
 
  private:
   State state_ = State::kInactive;
   State initial_state_ = State::kInactive;
   StateChangeHandler handler_;
-  TimeGraph* time_graph_;
-  Vec2 pos_ = {0, 0};
   float size_ = 10.f;
 };
 


### PR DESCRIPTION
Refactoring of `EventTrack`, `TracepointTrack` and `ThreadStateTrack` to have them no longer inherit from `Track` and reduce code duplication.

This PR also introduces a new common base class for UI Elements underneath the `TimeGraph` which hopefully will make accessibility and removal of the TimeGraph dependency easier lateron.