### PR TITLE
Remove the clear capture button

### DIFF
--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -547,7 +547,6 @@ void OrbitMainWindow::UpdateCaptureStateDependentWidgets() {
       capture_state == CaptureClient::State::kStarted ||
       (capture_state == CaptureClient::State::kStopped && is_target_process_running));
   ui->actionToggle_Capture->setIcon(is_capturing ? icon_stop_capture_ : icon_start_capture_);
-  ui->actionClear_Capture->setEnabled(!is_capturing && has_data);
   ui->actionCaptureOptions->setEnabled(!is_capturing);
   ui->actionOpen_Capture->setEnabled(!is_capturing);
   ui->actionSave_Capture->setEnabled(!is_capturing && has_data);
@@ -888,8 +887,6 @@ void OrbitMainWindow::on_actionSave_Preset_As_triggered() {
 }
 
 void OrbitMainWindow::on_actionToggle_Capture_triggered() { app_->ToggleCapture(); }
-
-void OrbitMainWindow::on_actionClear_Capture_triggered() { app_->ClearCapture(); }
 
 const QString OrbitMainWindow::kCollectThreadStatesSettingKey{"CollectThreadStates"};
 

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -119,7 +119,6 @@ class OrbitMainWindow : public QMainWindow {
   void on_actionToggle_Capture_triggered();
   void on_actionSave_Capture_triggered();
   void on_actionOpen_Capture_triggered();
-  void on_actionClear_Capture_triggered();
   void on_actionCaptureOptions_triggered();
   void on_actionHelp_triggered();
   void on_actionIntrospection_triggered();

--- a/src/OrbitQt/orbitmainwindow.ui
+++ b/src/OrbitQt/orbitmainwindow.ui
@@ -333,7 +333,7 @@ QPushButton:disabled {
   <widget class="QStatusBar" name="statusBar"/>
   <action name="actionReport_Missing_Feature">
    <property name="icon">
-    <iconset resource="../icons/orbiticons.qrc">
+    <iconset resource="../../icons/orbiticons.qrc">
      <normaloff>:/actions/feedback</normaloff>:/actions/feedback</iconset>
    </property>
    <property name="text">
@@ -342,7 +342,7 @@ QPushButton:disabled {
   </action>
   <action name="actionReport_Bug">
    <property name="icon">
-    <iconset resource="../icons/orbiticons.qrc">
+    <iconset resource="../../icons/orbiticons.qrc">
      <normaloff>:/actions/bug_report</normaloff>:/actions/bug_report</iconset>
    </property>
    <property name="text">
@@ -351,7 +351,7 @@ QPushButton:disabled {
   </action>
   <action name="actionAbout">
    <property name="icon">
-    <iconset resource="../icons/orbiticons.qrc">
+    <iconset resource="../../icons/orbiticons.qrc">
      <normaloff>:/actions/info</normaloff>:/actions/info</iconset>
    </property>
    <property name="text">
@@ -360,7 +360,7 @@ QPushButton:disabled {
   </action>
   <action name="actionOpen_Preset">
    <property name="icon">
-    <iconset resource="../icons/orbiticons.qrc">
+    <iconset resource="../../icons/orbiticons.qrc">
      <normaloff>:/actions/bookmarks</normaloff>:/actions/bookmarks</iconset>
    </property>
    <property name="text">
@@ -369,7 +369,7 @@ QPushButton:disabled {
   </action>
   <action name="actionToggle_Capture">
    <property name="icon">
-    <iconset resource="../icons/orbiticons.qrc">
+    <iconset resource="../../icons/orbiticons.qrc">
      <normaloff>:/actions/play_arrow</normaloff>:/actions/play_arrow</iconset>
    </property>
    <property name="text">
@@ -381,7 +381,7 @@ QPushButton:disabled {
   </action>
   <action name="actionCaptureOptions">
    <property name="icon">
-    <iconset resource="../icons/orbiticons.qrc">
+    <iconset resource="../../icons/orbiticons.qrc">
      <normaloff>:/actions/settings</normaloff>:/actions/settings</iconset>
    </property>
    <property name="text">
@@ -393,7 +393,7 @@ QPushButton:disabled {
   </action>
   <action name="actionFilter_Tracks">
    <property name="icon">
-    <iconset resource="../icons/orbiticons.qrc">
+    <iconset resource="../../icons/orbiticons.qrc">
      <normaloff>:/actions/filter_list</normaloff>:/actions/filter_list</iconset>
    </property>
    <property name="text">
@@ -405,7 +405,7 @@ QPushButton:disabled {
   </action>
   <action name="actionFilter_Functions">
    <property name="icon">
-    <iconset resource="../icons/orbiticons.qrc">
+    <iconset resource="../../icons/orbiticons.qrc">
      <normaloff>:/actions/search</normaloff>:/actions/search</iconset>
    </property>
    <property name="text">
@@ -417,7 +417,7 @@ QPushButton:disabled {
   </action>
   <action name="actionHelp">
    <property name="icon">
-    <iconset resource="../icons/orbiticons.qrc">
+    <iconset resource="../../icons/orbiticons.qrc">
      <normaloff>:/actions/help</normaloff>:/actions/help</iconset>
    </property>
    <property name="text">
@@ -429,7 +429,7 @@ QPushButton:disabled {
   </action>
   <action name="actionIntrospection">
    <property name="icon">
-    <iconset resource="../icons/orbiticons.qrc">
+    <iconset resource="../../icons/orbiticons.qrc">
      <normaloff>:/actions/info</normaloff>:/actions/info</iconset>
    </property>
    <property name="text">
@@ -441,7 +441,7 @@ QPushButton:disabled {
   </action>
   <action name="actionEnd_Session">
    <property name="icon">
-    <iconset resource="../icons/orbiticons.qrc">
+    <iconset resource="../../icons/orbiticons.qrc">
      <normaloff>:/actions/arrow_back</normaloff>:/actions/arrow_back</iconset>
    </property>
    <property name="text">
@@ -450,7 +450,7 @@ QPushButton:disabled {
   </action>
   <action name="actionQuit">
    <property name="icon">
-    <iconset resource="../icons/orbiticons.qrc">
+    <iconset resource="../../icons/orbiticons.qrc">
      <normaloff>:/actions/exit_to_app</normaloff>:/actions/exit_to_app</iconset>
    </property>
    <property name="text">
@@ -467,7 +467,7 @@ QPushButton:disabled {
   </action>
   <action name="actionSave_Preset_As">
    <property name="icon">
-    <iconset resource="../icons/orbiticons.qrc">
+    <iconset resource="../../icons/orbiticons.qrc">
      <normaloff>:/actions/bookmark_border</normaloff>:/actions/bookmark_border</iconset>
    </property>
    <property name="text">
@@ -476,7 +476,7 @@ QPushButton:disabled {
   </action>
   <action name="actionOpen_Capture">
    <property name="icon">
-    <iconset resource="../icons/orbiticons.qrc">
+    <iconset resource="../../icons/orbiticons.qrc">
      <normaloff>:/actions/folder</normaloff>:/actions/folder</iconset>
    </property>
    <property name="text">
@@ -485,7 +485,7 @@ QPushButton:disabled {
   </action>
   <action name="actionSave_Capture">
    <property name="icon">
-    <iconset resource="../icons/orbiticons.qrc">
+    <iconset resource="../../icons/orbiticons.qrc">
      <normaloff>:/actions/save_alt</normaloff>:/actions/save_alt</iconset>
    </property>
    <property name="text">
@@ -524,7 +524,7 @@ QPushButton:disabled {
   </action>
   <action name="actionOpenUserDataDirectory">
    <property name="icon">
-    <iconset resource="../icons/orbiticons.qrc">
+    <iconset resource="../../icons/orbiticons.qrc">
      <normaloff>:/actions/folder</normaloff>:/actions/folder</iconset>
    </property>
    <property name="text">
@@ -561,8 +561,8 @@ QPushButton:disabled {
   </customwidget>
  </customwidgets>
  <resources>
-  <include location="../icons/orbiticons.qrc"/>
-  <include location="../images/orbitimages.qrc"/>
+  <include location="../../icons/orbiticons.qrc"/>
+  <include location="../../images/orbitimages.qrc"/>
  </resources>
  <connections/>
  <slots>

--- a/src/OrbitQt/orbitmainwindow.ui
+++ b/src/OrbitQt/orbitmainwindow.ui
@@ -130,7 +130,6 @@ QPushButton:disabled {
             <string>CaptureToolBar</string>
            </property>
            <addaction name="actionToggle_Capture"/>
-           <addaction name="actionClear_Capture"/>
            <addaction name="actionCaptureOptions"/>
            <addaction name="actionOpen_Capture"/>
            <addaction name="actionSave_Capture"/>
@@ -378,18 +377,6 @@ QPushButton:disabled {
    </property>
    <property name="toolTip">
     <string>Toggle Capture</string>
-   </property>
-  </action>
-  <action name="actionClear_Capture">
-   <property name="icon">
-    <iconset resource="../icons/orbiticons.qrc">
-     <normaloff>:/actions/clear</normaloff>:/actions/clear</iconset>
-   </property>
-   <property name="text">
-    <string>Clear Capture</string>
-   </property>
-   <property name="toolTip">
-    <string>Clear Capture</string>
    </property>
   </action>
   <action name="actionCaptureOptions">


### PR DESCRIPTION
As there is no use case of the "Clear Capture" button in the new ui, we remove it completely.

bug: http://b/179470701