### PR TITLE
Refactor Preset Loading

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1300,7 +1300,7 @@ void OrbitApp::LoadSymbols(const std::filesystem::path& symbols_path, ModuleData
 }
 
 void OrbitApp::SelectFunctionsFromHashes(const ModuleData* module,
-                                         const std::vector<uint64_t>& function_hashes) {
+                                         absl::Span<const uint64_t> function_hashes) {
   for (const auto function_hash : function_hashes) {
     const orbit_client_protos::FunctionInfo* const function_info =
         module->FindFunctionFromHash(function_hash);
@@ -1314,7 +1314,7 @@ void OrbitApp::SelectFunctionsFromHashes(const ModuleData* module,
 }
 
 void OrbitApp::EnableFrameTracksFromHashes(const ModuleData* module,
-                                           const std::vector<uint64_t>& function_hashes) {
+                                           absl::Span<const uint64_t> function_hashes) {
   for (const auto function_hash : function_hashes) {
     const orbit_client_protos::FunctionInfo* const function_info =
         module->FindFunctionFromHash(function_hash);

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1114,6 +1114,14 @@ orbit_base::Future<ErrorMessageOr<void>> OrbitApp::LoadModule(const ModuleData* 
 
 orbit_base::Future<ErrorMessageOr<void>> OrbitApp::LoadModule(const std::string& module_path,
                                                               const std::string& build_id) {
+  const ModuleData* module_data = GetModuleByPath(module_path);
+
+  if (module_data == nullptr) {
+    return {ErrorMessage{absl::StrFormat("Module \"%s\" was not found", module_path)}};
+  }
+
+  if (module_data->is_loaded()) return {outcome::success()};
+
   const auto it = modules_currently_loading_.find(module_path);
   if (it != modules_currently_loading_.end()) {
     return it->second;

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -318,6 +318,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void UpdateAfterSymbolLoading();
   void UpdateAfterCaptureCleared();
 
+  orbit_base::Future<ErrorMessageOr<void>> LoadPresetModule(
+      const std::string& module_path, const orbit_client_protos::PresetModule& preset_module);
   void LoadPreset(const std::shared_ptr<orbit_client_protos::PresetFile>& preset);
   PresetLoadState GetPresetLoadState(
       const std::shared_ptr<orbit_client_protos::PresetFile>& preset) const;

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -427,7 +427,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
       const std::string& module_file_path);
 
   void SelectFunctionsFromHashes(const ModuleData* module,
-                                 const std::vector<uint64_t>& function_hashes);
+                                 absl::Span<const uint64_t> function_hashes);
 
   ErrorMessageOr<std::filesystem::path> FindModuleLocally(const std::filesystem::path& module_path,
                                                           const std::string& build_id);
@@ -441,7 +441,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   [[nodiscard]] ScopedStatus CreateScopedStatus(const std::string& initial_message);
 
   void EnableFrameTracksFromHashes(const ModuleData* module,
-                                   const std::vector<uint64_t>& function_hashes);
+                                   absl::Span<const uint64_t> function_hashes);
   void AddFrameTrackTimers(uint64_t instrumented_function_id);
   void RefreshFrameTracks();
 


### PR DESCRIPTION
This PR refactors preset loading, especially the `OrbitApp::LoadPreset` function.

It is now split up into all the work that is done per module (`OrbitApp::LoadPresetModule`) and
all the work that is done after all preset modules have been loaded, like updating the UI, etc.

Also note, that `LoadPresetModule` (just like `LoadModule`) does not depend on UI-specific functionality.
That means it can be moved out of OrbitApp more easily in a subsequent PR.

This is necessary for usage in OrbitClientGgp, for example.

I tested the following manually:
- Loading a preset
- Loading a partial preset
- Loading a preset with frametracks
- Loading a partial preset with frametracks