### PR TITLE
Introduce AnyMovable and use in MainThreadExecutor

### DIFF
--- a/src/OrbitBase/AnyMovableTest.cpp
+++ b/src/OrbitBase/AnyMovableTest.cpp
@@ -1,0 +1,98 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "OrbitBase/AnyMovable.h"
+
+namespace orbit_base {
+
+TEST(AnyMovable, DefaultConstruction) {
+  AnyMovable any{};
+  EXPECT_FALSE(any.HasValue());
+}
+
+TEST(AnyMovable, CarryInt) {
+  AnyMovable any{42};
+
+  EXPECT_TRUE(any.HasValue());
+  EXPECT_EQ(any.type(), typeid(42));
+}
+
+TEST(AnyMovable, CarryUniquePtr) {
+  AnyMovable any{std::make_unique<int>(42)};
+
+  EXPECT_TRUE(any.HasValue());
+  EXPECT_EQ(any.type(), typeid(std::unique_ptr<int>));
+}
+
+TEST(AnyMovable, InPlaceConstructInt) {
+  AnyMovable any{std::in_place_type<int>, 42};
+
+  EXPECT_TRUE(any.HasValue());
+  EXPECT_EQ(any.type(), typeid(int));
+}
+
+TEST(AnyMovable, InPlaceConstructUniquePtr) {
+  AnyMovable any{std::in_place_type<std::unique_ptr<int>>, new int{42}};
+
+  EXPECT_TRUE(any.HasValue());
+  EXPECT_EQ(any.type(), typeid(std::unique_ptr<int>));
+}
+
+TEST(AnyMovable, EmplaceInt) {
+  AnyMovable any{};
+  any.Emplace<int>(42);
+
+  EXPECT_TRUE(any.HasValue());
+  EXPECT_EQ(any.type(), typeid(int));
+}
+
+TEST(AnyMovable, EmplaceUniquePtr) {
+  AnyMovable any{};
+  any.Emplace<std::unique_ptr<int>>(new int{42});
+
+  EXPECT_TRUE(any.HasValue());
+  EXPECT_EQ(any.type(), typeid(std::unique_ptr<int>));
+}
+
+TEST(any_movable_cast, ExtractInt) {
+  AnyMovable any{42};
+
+  auto* ptr = any_movable_cast<int>(&any);
+  EXPECT_NE(ptr, nullptr);
+  EXPECT_EQ(*ptr, 42);
+}
+TEST(any_movable_cast, ExtractUniquePtr) {
+  AnyMovable any{std::make_unique<int>(42)};
+
+  auto* ptr = any_movable_cast<std::unique_ptr<int>>(&any);
+  EXPECT_NE(ptr, nullptr);
+  EXPECT_EQ(**ptr, 42);
+}
+
+TEST(any_movable_cast, RefuseExtractingWrongType) {
+  AnyMovable any{std::make_unique<int>(42)};
+
+  auto* ptr = any_movable_cast<int>(&any);
+  EXPECT_EQ(ptr, nullptr);
+}
+
+TEST(MakeAnyMovable, InPlaceConstructInt) {
+  auto any = MakeAnyMovable<int>(42);
+
+  EXPECT_TRUE(any.HasValue());
+  EXPECT_EQ(any.type(), typeid(int));
+}
+
+TEST(MakeAnyMovable, InPlaceConstructUniquePtr) {
+  auto any = MakeAnyMovable<std::unique_ptr<int>>(new int{42});
+
+  EXPECT_TRUE(any.HasValue());
+  EXPECT_EQ(any.type(), typeid(std::unique_ptr<int>));
+}
+
+}  // namespace orbit_base

--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -21,6 +21,7 @@ target_include_directories(OrbitBase PRIVATE
 target_sources(OrbitBase PRIVATE
         include/OrbitBase/Action.h
         include/OrbitBase/AnyInvocable.h
+        include/OrbitBase/AnyMovable.h
         include/OrbitBase/ExecutablePath.h
         include/OrbitBase/Future.h
         include/OrbitBase/FutureHelpers.h
@@ -73,6 +74,7 @@ target_compile_options(OrbitBaseTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(OrbitBaseTests PRIVATE
         AnyInvocableTest.cpp
+        AnyMovableTest.cpp
         ExecutablePathTest.cpp
         FutureTest.cpp
         FutureHelpersTest.cpp

--- a/src/OrbitBase/include/OrbitBase/AnyMovable.h
+++ b/src/OrbitBase/include/OrbitBase/AnyMovable.h
@@ -1,0 +1,121 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_BASE_ANY_MOVABLE_H_
+#define ORBIT_BASE_ANY_MOVABLE_H_
+
+#include <memory>
+#include <type_traits>
+
+namespace orbit_base {
+
+// AnyMovable is a type-safe container for values of any type that fulfills the Movable concept.
+// It's very similar to std::any but does not require the type to be copy-constructible.
+// Hence AnyMovable itself is a move-only type.
+//
+// Usage: The API is pretty similar to std::any. In most of the places the naming styles has been
+// adjusted to Google style. Store a value by assignment or Emplace and use any_movable_cast to get
+// it back out.
+//
+// AnyMovable m = std::make_unique<int>(42);
+// auto other = std::move(m);
+// std::cout << std::boolalpha << m.HasValue() << other.HasValue(); // Prints "falsetrue"
+//
+// int* int_ptr = any_movable_cast<int>(&other);
+// std::cout << int_ptr; // Prints 0, since `other` does not hold an `int`.
+//
+// std::unique_ptr<int>* unique_int_ptr = any_movable_cast<std::unique_ptr<int>>(&other);
+// CHECK(unique_int_ptr != nulllptr);
+// std::cout << **unique_int_ptr; // Prints "42"
+class AnyMovable {
+  struct Base {
+    constexpr Base() = default;
+    constexpr Base(Base&&) = default;
+    Base& operator=(Base&&) = default;
+
+    constexpr Base(const Base&) = delete;
+    constexpr Base& operator=(const Base&) = delete;
+
+    virtual void* AccessValue() = 0;
+    virtual ~Base() = default;
+  };
+
+  template <typename T>
+  class Storage final : public Base {
+    T value_;
+
+   public:
+    using Base::Base;
+
+    template <typename... Args>
+    constexpr explicit Storage(std::in_place_t, Args&&... args)
+        : value_{std::forward<Args>(args)...} {}
+
+    constexpr explicit Storage(const T& value) : value_(value) {}
+    constexpr explicit Storage(T&& value) : value_(std::move(value)) {}
+
+    [[nodiscard]] void* AccessValue() noexcept override { return static_cast<void*>(&value_); }
+  };
+
+  std::unique_ptr<Base> storage_;
+  const std::type_info* type_info_;
+
+ public:
+  explicit AnyMovable() noexcept = default;
+
+  template <typename T, typename = std::enable_if<!std::is_same_v<std::decay_t<T>, AnyMovable>>>
+  explicit AnyMovable(T&& value)
+      : storage_{std::make_unique<Storage<std::decay_t<T>>>(std::forward<T>(value))},
+        type_info_{&typeid(value)} {}
+
+  template <typename T, typename... Args>
+  explicit AnyMovable(std::in_place_type_t<T>, Args&&... args)
+      : storage_{std::make_unique<Storage<std::decay_t<T>>>(std::in_place,
+                                                            std::forward<Args>(args)...)},
+        type_info_{&typeid(std::decay_t<T>)} {}
+
+  void Reset() noexcept { storage_.reset(); }
+
+  [[nodiscard]] bool HasValue() const noexcept { return storage_ != nullptr; }
+
+  template <typename ValueType, typename... Args>
+  std::decay_t<ValueType>& Emplace(Args&&... args) noexcept {
+    storage_ = std::make_unique<Storage<ValueType>>(std::in_place, std::forward<Args>(args)...);
+    type_info_ = &typeid(ValueType);
+    return *static_cast<ValueType*>(storage_->AccessValue());
+  }
+
+  [[nodiscard]] const std::type_info& type() const noexcept { return *type_info_; }
+
+  template <typename T>
+  friend T* any_movable_cast(AnyMovable*) noexcept;
+
+  template <typename T>
+  friend const T* any_movable_cast(const AnyMovable*) noexcept;
+};
+
+// This is deviating from Google's naming style to be in line with `static_cast` and others.
+// Abseil is doing the same with `abseil::bit_cast`.
+template <typename T>
+[[nodiscard]] T* any_movable_cast(AnyMovable* movable) noexcept {
+  if (!(movable->type() == typeid(T))) return nullptr;
+
+  return static_cast<T*>(movable->storage_->AccessValue());
+}
+
+template <typename T>
+[[nodiscard]] const T* any_movable_cast(const AnyMovable* movable) noexcept {
+  if (!(movable->type() == typeid(T))) return nullptr;
+
+  return static_cast<const T*>(movable->storage_->AccessValue());
+}
+
+template <typename T, typename... Args>
+[[nodiscard]] AnyMovable MakeAnyMovable(Args&&... args) {
+  return AnyMovable{std::in_place_type<T>, std::forward<Args>(args)...};
+}
+
+}  // namespace orbit_base
+
+#endif  // ORBIT_BASE_ANY_MOVABLE_H_

--- a/src/OrbitGl/MainThreadExecutor.h
+++ b/src/OrbitGl/MainThreadExecutor.h
@@ -8,12 +8,14 @@
 #include <absl/types/span.h>
 
 #include <chrono>
+#include <list>
 #include <memory>
 #include <thread>
 #include <type_traits>
 #include <utility>
 
 #include "OrbitBase/Action.h"
+#include "OrbitBase/AnyMovable.h"
 #include "OrbitBase/Future.h"
 #include "OrbitBase/Promise.h"
 #include "OrbitBase/PromiseHelpers.h"
@@ -79,16 +81,26 @@ class MainThreadExecutor : public std::enable_shared_from_this<MainThreadExecuto
     orbit_base::Promise<ReturnType> promise{};
     orbit_base::Future<ReturnType> resulting_future = promise.GetFuture();
 
-    auto continuation = [functor = std::forward<F>(functor), executor_weak_ptr = weak_from_this(),
+    waiting_continuations_.emplace_front(std::forward<F>(functor));
+    auto function_reference = waiting_continuations_.begin();
+
+    auto continuation = [this, function_reference, executor_weak_ptr = weak_from_this(),
                          promise = std::move(promise)](auto&&... argument) mutable {
       auto executor = executor_weak_ptr.lock();
       if (executor == nullptr) return;
 
       auto function_wrapper =
-          [functor = std::move(functor), promise = std::move(promise),
+          [this, function_reference, promise = std::move(promise),
            argument = std::make_tuple(std::forward<decltype(argument)>(argument)...)]() mutable {
             orbit_base::CallTaskAndSetResultInPromise<ReturnType> helper{&promise};
-            std::apply([&](auto... args) { helper.Call(functor, args...); }, std::move(argument));
+
+            // We don't have to worry about `function_reference` being invalid. It's a stable
+            // iterator under the hood and this lambda will only be executed if the executor is
+            // still alive.
+            auto functor = orbit_base::any_movable_cast<std::decay_t<F>>(&*function_reference);
+            CHECK(functor != nullptr);
+            std::apply([&](auto... args) { helper.Call(*functor, args...); }, std::move(argument));
+            waiting_continuations_.erase(function_reference);
           };
       executor->Schedule(CreateAction(std::move(function_wrapper)));
     };
@@ -119,6 +131,13 @@ class MainThreadExecutor : public std::enable_shared_from_this<MainThreadExecuto
   [[nodiscard]] virtual WaitResult WaitForAll(absl::Span<orbit_base::Future<void>> futures) = 0;
 
   virtual void AbortWaitingJobs() = 0;
+
+  [[nodiscard]] size_t GetNumberOfWaitingContinuations() const {
+    return waiting_continuations_.size();
+  }
+
+ private:
+  std::list<orbit_base::AnyMovable> waiting_continuations_;
 };
 
 template <typename F>


### PR DESCRIPTION
`AnyMovable` is typed-erase Value wrapper for types that fulfill the the `std::movable` concept.
It is similar to `std::any`, but types don't need to be copyable.

In a second commit,  `AnyMovable` is introduced to `MainThreadExecutor`. 
All tasks scheduled with `MainThreadExecutor::ScheduleAfter` are only executed as long as `MainThreadExecutor` exists.
But the function objects itself might live longer than `MainThreadExecutor` because they are owned by the `SharedState`-object
of the future which gets destroyed when the Future completes.

That's a problem when the function object has a non-trivial destructor that accesses resources. These resources might have
already been destroyed when the function object gets destroyed. One example is `ScopedStatus` which calls `StatusListener`
in its destructor. When such a `ScopedStatus` is captured in a lambda, the lambda should not live longer than `MainThreadExecutor` to ensure that the pointer to `StatusListener` is always valid.

The solution: Tasks scheduled by `MainThreadExecutor::ScheduleAfter` live in a `std::list` in `MainThreadExecutor` and the
`SharedState` hold by the `Future` only gets a stable reference to this `std::list`-entry. That ensure that the task is destructed when `MainThreadExecutor` is destructed.