### PR TITLE
Make e2e test more reliable.

### DIFF
--- a/contrib/automation_tests/test_cases/connection_window.py
+++ b/contrib/automation_tests/test_cases/connection_window.py
@@ -55,6 +55,8 @@ class FilterAndSelectFirstProcess(E2ETestCase):
     """
     def _execute(self, process_filter):
         filter_edit = self.find_control('Edit', 'FilterProcesses')
+        # Finding ProcessList occationally throws from within pywinauto. This is not understood. The while loop
+        # with the try/except block is a workaround for that.
         while (True):
             try:
                 process_list = self.find_control('Table', 'ProcessList')

--- a/contrib/automation_tests/test_cases/connection_window.py
+++ b/contrib/automation_tests/test_cases/connection_window.py
@@ -55,7 +55,12 @@ class FilterAndSelectFirstProcess(E2ETestCase):
     """
     def _execute(self, process_filter):
         filter_edit = self.find_control('Edit', 'FilterProcesses')
-        process_list = self.find_control('Table', 'ProcessList')
+        while (True):
+            try:
+                process_list = self.find_control('Table', 'ProcessList')
+                break
+            except KeyError:
+                logging.info('Find ProcessList failed. Try again.')        
 
         logging.info('Waiting for process list to be populated')
         wait_for_condition(lambda: process_list.item_count() > 0, 30)


### PR DESCRIPTION
This is a workaround for a bug that is not understood. It is unclear why the
method getting the ProcessList occationally throws.

Bug: http://b/179418210