### PR TITLE
Close main window on load capture error

### DIFF
--- a/src/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/src/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -37,9 +37,6 @@ class MyCaptureListener : public CaptureListener {
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> /*selected_functions*/,
       TracepointInfoSet /*selected_tracepoints*/,
       absl::flat_hash_set<uint64_t> /*frame_track_function_ids*/) override {}
-  void OnCaptureComplete() override {}
-  void OnCaptureCancelled() override {}
-  void OnCaptureFailed(ErrorMessage) override {}
   void OnTimer(const TimerInfo&) override {}
   void OnKeyAndString(uint64_t, std::string) override {}
   void OnUniqueCallStack(CallStack) override {}

--- a/src/OrbitCaptureClient/CaptureEventProcessorTest.cpp
+++ b/src/OrbitCaptureClient/CaptureEventProcessorTest.cpp
@@ -69,9 +69,6 @@ class MockCaptureListener : public CaptureListener {
        TracepointInfoSet /*selected_tracepoints*/,
        absl::flat_hash_set<uint64_t> /*frame_track_function_ids*/),
       (override));
-  MOCK_METHOD(void, OnCaptureComplete, (), (override));
-  MOCK_METHOD(void, OnCaptureCancelled, (), (override));
-  MOCK_METHOD(void, OnCaptureFailed, (ErrorMessage), (override));
   MOCK_METHOD(void, OnTimer, (const TimerInfo&), (override));
   MOCK_METHOD(void, OnKeyAndString, (uint64_t /*key*/, std::string), (override));
   MOCK_METHOD(void, OnUniqueCallStack, (CallStack), (override));

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
@@ -38,7 +38,7 @@ class CaptureClient {
     CHECK(capture_listener_ != nullptr);
   }
 
-  [[nodiscard]] ErrorMessageOr<void> StartCapture(
+  orbit_base::Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> Capture(
       ThreadPool* thread_pool, const ProcessData& process,
       const orbit_client_data::ModuleManager& module_manager,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
@@ -67,11 +67,12 @@ class CaptureClient {
   bool AbortCaptureAndWait(int64_t max_wait_ms);
 
  private:
-  void Capture(ProcessData&& process, const orbit_client_data::ModuleManager& module_manager,
-               absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
-               TracepointInfoSet selected_tracepoints,
-               absl::flat_hash_set<uint64_t> frame_track_function_ids, bool collect_thread_state,
-               bool enable_introspection);
+  ErrorMessageOr<CaptureListener::CaptureOutcome> CaptureSync(
+      ProcessData&& process, const orbit_client_data::ModuleManager& module_manager,
+      absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
+      TracepointInfoSet selected_tracepoints,
+      absl::flat_hash_set<uint64_t> frame_track_function_ids, bool collect_thread_state,
+      bool enable_introspection);
 
   [[nodiscard]] ErrorMessageOr<void> FinishCapture();
 

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
@@ -15,6 +15,8 @@
 
 class CaptureListener {
  public:
+  enum class CaptureOutcome { kComplete, kCancelled };
+
   virtual ~CaptureListener() = default;
 
   // Called after capture started but before the first event arrived.
@@ -23,13 +25,6 @@ class CaptureListener {
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> instrumented_functions,
       TracepointInfoSet selected_tracepoints,
       absl::flat_hash_set<uint64_t> frame_track_function_ids) = 0;
-  // Called when capture is complete.
-  virtual void OnCaptureComplete() = 0;
-
-  // Called when capture is cancelled (not stopped). Mostly relevant for capture loading.
-  virtual void OnCaptureCancelled() = 0;
-  // Called when an internal error occurred that makes the capture invalid.
-  virtual void OnCaptureFailed(ErrorMessage error_message) = 0;
 
   virtual void OnTimer(const orbit_client_protos::TimerInfo& timer_info) = 0;
   virtual void OnKeyAndString(uint64_t key, std::string str) = 0;

--- a/src/OrbitClientGgp/include/OrbitClientGgp/ClientGgp.h
+++ b/src/OrbitClientGgp/include/OrbitClientGgp/ClientGgp.h
@@ -53,9 +53,6 @@ class ClientGgp final : public CaptureListener {
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints,
       absl::flat_hash_set<uint64_t> frame_track_function_ids) override;
-  void OnCaptureComplete() override;
-  void OnCaptureCancelled() override;
-  void OnCaptureFailed(ErrorMessage error_message) override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
   void OnKeyAndString(uint64_t key, std::string str) override;
   void OnUniqueCallStack(CallStack callstack) override;
@@ -98,6 +95,7 @@ class ClientGgp final : public CaptureListener {
   void InformUsedSelectedCaptureFunctions(
       const absl::flat_hash_set<std::string>& capture_functions_used);
   void ProcessTimer(const orbit_client_protos::TimerInfo& timer_info);
+  void PostprocessCaptureData();
 };
 
 #endif  // ORBIT_CLIENT_GGP_CLIENT_GGP_H_

--- a/src/OrbitClientModel/include/OrbitClientModel/CaptureDeserializer.h
+++ b/src/OrbitClientModel/include/OrbitClientModel/CaptureDeserializer.h
@@ -21,22 +21,21 @@
 
 namespace capture_deserializer {
 
-void Load(std::istream& stream, const std::string& file_name, CaptureListener* capture_listener,
-          orbit_client_data::ModuleManager* module_manager,
-          std::atomic<bool>* cancellation_requested);
-void Load(const std::string& file_name, CaptureListener* capture_listener,
-          orbit_client_data::ModuleManager* module_manager,
-          std::atomic<bool>* cancellation_requested);
+ErrorMessageOr<CaptureListener::CaptureOutcome> Load(
+    std::istream& stream, const std::string& file_name, CaptureListener* capture_listener,
+    orbit_client_data::ModuleManager* module_manager, std::atomic<bool>* cancellation_requested);
+ErrorMessageOr<CaptureListener::CaptureOutcome> Load(
+    const std::string& file_name, CaptureListener* capture_listener,
+    orbit_client_data::ModuleManager* module_manager, std::atomic<bool>* cancellation_requested);
 
 namespace internal {
 
 bool ReadMessage(google::protobuf::Message* message, google::protobuf::io::CodedInputStream* input);
 
-void LoadCaptureInfo(const orbit_client_protos::CaptureInfo& capture_info,
-                     CaptureListener* capture_listener,
-                     orbit_client_data::ModuleManager* module_manager,
-                     google::protobuf::io::CodedInputStream* coded_input,
-                     std::atomic<bool>* cancellation_requested);
+ErrorMessageOr<CaptureListener::CaptureOutcome> LoadCaptureInfo(
+    const orbit_client_protos::CaptureInfo& capture_info, CaptureListener* capture_listener,
+    orbit_client_data::ModuleManager* module_manager,
+    google::protobuf::io::CodedInputStream* coded_input, std::atomic<bool>* cancellation_requested);
 
 inline const std::string kRequiredCaptureVersion = "1.59";
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -227,9 +227,6 @@ void OrbitApp::OnCaptureComplete() {
         CHECK(capture_stopped_callback_);
         capture_stopped_callback_();
 
-        CHECK(open_capture_finished_callback_);
-        open_capture_finished_callback_();
-
         FireRefreshCallbacks();
       });
 }
@@ -240,9 +237,6 @@ void OrbitApp::OnCaptureCancelled() {
     CHECK(capture_failed_callback_);
     capture_failed_callback_();
 
-    CHECK(open_capture_failed_callback_);
-    open_capture_failed_callback_();
-
     ClearCapture();
   });
 }
@@ -252,9 +246,6 @@ void OrbitApp::OnCaptureFailed(ErrorMessage error_message) {
     ORBIT_SCOPE("OnCaptureFailed");
     CHECK(capture_failed_callback_);
     capture_failed_callback_();
-
-    CHECK(open_capture_failed_callback_);
-    open_capture_failed_callback_();
 
     ClearCapture();
     SendErrorToUi("Error in capture", error_message.message());
@@ -804,8 +795,6 @@ ErrorMessageOr<void> OrbitApp::OnSaveCapture(const std::string& file_name) {
 
 Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> OrbitApp::LoadCaptureFromFile(
     const std::string& file_name) {
-  CHECK(open_capture_callback_);
-  open_capture_callback_();
   if (capture_window_ != nullptr) {
     capture_window_->set_draw_help(false);
   }

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -94,13 +94,14 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   ErrorMessageOr<void> OnSavePreset(const std::string& file_name);
   ErrorMessageOr<void> OnLoadPreset(const std::string& file_name);
   ErrorMessageOr<void> OnSaveCapture(const std::string& file_name);
-  void OnLoadCapture(const std::string& file_name);
+  orbit_base::Future<ErrorMessageOr<CaptureOutcome>> LoadCaptureFromFile(
+      const std::string& file_name);
   void OnLoadCaptureCancelRequested();
 
   [[nodiscard]] CaptureClient::State GetCaptureState() const;
   [[nodiscard]] bool IsCapturing() const;
 
-  bool StartCapture();
+  void StartCapture();
   void StopCapture();
   void AbortCapture();
   void ClearCapture();
@@ -131,9 +132,6 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints,
       absl::flat_hash_set<uint64_t> frame_track_function_ids) override;
-  void OnCaptureComplete() override;
-  void OnCaptureCancelled() override;
-  void OnCaptureFailed(ErrorMessage error_message) override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
   void OnKeyAndString(uint64_t key, std::string str) override;
   void OnUniqueCallStack(CallStack callstack) override;
@@ -446,6 +444,10 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
                                    absl::Span<const uint64_t> function_hashes);
   void AddFrameTrackTimers(uint64_t instrumented_function_id);
   void RefreshFrameTracks();
+
+  void OnCaptureFailed(ErrorMessage error_message);
+  void OnCaptureCancelled();
+  void OnCaptureComplete();
 
   std::atomic<bool> capture_loading_cancellation_requested_ = false;
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -207,18 +207,6 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
     capture_cleared_callback_ = std::move(callback);
   }
 
-  using OpenCaptureCallback = std::function<void()>;
-  void SetOpenCaptureCallback(OpenCaptureCallback callback) {
-    open_capture_callback_ = std::move(callback);
-  }
-  using OpenCaptureFailedCallback = std::function<void()>;
-  void SetOpenCaptureFailedCallback(OpenCaptureFailedCallback callback) {
-    open_capture_failed_callback_ = std::move(callback);
-  }
-  using OpenCaptureFinishedCallback = std::function<void()>;
-  void SetOpenCaptureFinishedCallback(OpenCaptureFinishedCallback callback) {
-    open_capture_finished_callback_ = std::move(callback);
-  }
   using SelectLiveTabCallback = std::function<void()>;
   void SetSelectLiveTabCallback(SelectLiveTabCallback callback) {
     select_live_tab_callback_ = std::move(callback);
@@ -456,9 +444,6 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   CaptureStoppedCallback capture_stopped_callback_;
   CaptureFailedCallback capture_failed_callback_;
   CaptureClearedCallback capture_cleared_callback_;
-  OpenCaptureCallback open_capture_callback_;
-  OpenCaptureFailedCallback open_capture_failed_callback_;
-  OpenCaptureFinishedCallback open_capture_finished_callback_;
   SelectLiveTabCallback select_live_tab_callback_;
   DisassemblyCallback disassembly_callback_;
   ErrorMessageCallback error_message_callback_;

--- a/src/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
+++ b/src/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
@@ -75,9 +75,6 @@ DEFINE_PROTO_FUZZER(const orbit_client_protos::CaptureDeserializerFuzzerInfo& in
   app->SetCaptureStoppedCallback([]() {});
   app->SetCaptureFailedCallback([]() {});
   app->SetCaptureClearedCallback([]() {});
-  app->SetOpenCaptureCallback([]() {});
-  app->SetOpenCaptureFailedCallback([]() {});
-  app->SetOpenCaptureFinishedCallback([]() {});
   app->SetSelectLiveTabCallback([]() {});
   app->SetErrorMessageCallback([](const std::string& /*title*/, const std::string& /*text*/) {});
   app->SetRefreshCallback([](DataViewType /*type*/) {});

--- a/src/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
+++ b/src/OrbitGl/CaptureDeserializerLoadFuzzer.cpp
@@ -96,7 +96,8 @@ DEFINE_PROTO_FUZZER(const orbit_client_protos::CaptureDeserializerFuzzerInfo& in
   std::atomic<bool> cancellation_requested = false;
 
   orbit_client_data::ModuleManager module_manager;
-  capture_deserializer::Load(input_stream, "", app.get(), &module_manager, &cancellation_requested);
+  (void)capture_deserializer::Load(input_stream, "", app.get(), &module_manager,
+                                   &cancellation_requested);
 
   app->GetThreadPool()->ShutdownAndWait();
 }

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -266,40 +266,6 @@ void OrbitMainWindow::SetupMainWindow() {
   app_->SetCaptureFailedCallback(capture_finished_callback);
   app_->SetCaptureClearedCallback([this] { OnCaptureCleared(); });
 
-  auto loading_capture_dialog =
-      new QProgressDialog("Waiting for the capture to be loaded...", nullptr, 0, 0, this, Qt::Tool);
-  loading_capture_dialog->setWindowTitle("Loading capture");
-  loading_capture_dialog->setModal(true);
-  loading_capture_dialog->setWindowFlags(
-      (loading_capture_dialog->windowFlags() | Qt::CustomizeWindowHint) &
-      ~Qt::WindowCloseButtonHint & ~Qt::WindowSystemMenuHint);
-  loading_capture_dialog->setFixedSize(loading_capture_dialog->size());
-
-  auto loading_capture_cancel_button = QPointer{new QPushButton{this}};
-  loading_capture_cancel_button->setText("Cancel");
-  QObject::connect(loading_capture_cancel_button, &QPushButton::clicked, this,
-                   [this, loading_capture_dialog]() {
-                     app_->OnLoadCaptureCancelRequested();
-                     loading_capture_dialog->close();
-                   });
-  loading_capture_dialog->setCancelButton(loading_capture_cancel_button);
-
-  loading_capture_dialog->close();
-
-  app_->SetOpenCaptureCallback([this, loading_capture_dialog] {
-    setWindowTitle({});
-    loading_capture_dialog->show();
-  });
-  app_->SetOpenCaptureFailedCallback([this, loading_capture_dialog] {
-    setWindowTitle({});
-    loading_capture_dialog->close();
-    UpdateCaptureStateDependentWidgets();
-  });
-  app_->SetOpenCaptureFinishedCallback([this, loading_capture_dialog] {
-    loading_capture_dialog->close();
-    UpdateCaptureStateDependentWidgets();
-  });
-
   app_->SetRefreshCallback([this](DataViewType type) {
     if (type == DataViewType::kAll || type == DataViewType::kLiveFunctions) {
       this->ui->liveFunctions->OnDataChanged();
@@ -1108,6 +1074,7 @@ void OrbitMainWindow::OpenCapture(const std::string& filepath) {
             on_actionEnd_Session_triggered();
             return;
           case CaptureListener::CaptureOutcome::kComplete:
+            UpdateCaptureStateDependentWidgets();
             return;
         }
       });


### PR DESCRIPTION
This refactors capture loading and capturing in general by returning a Future instead of using the callbacks: OnCaptureCompleted, OnCaptureFailed and OnCaptureCancelled. 

There is for sure more that can be refactored. The main reason that started this is the ability to close the main window when capture loading fails. http://b/178071836 (Which is also solved by this PR).