### PR TITLE
Increase reliability of listing gamelets.

### DIFF
--- a/src/OrbitGgp/include/OrbitGgp/Client.h
+++ b/src/OrbitGgp/include/OrbitGgp/Client.h
@@ -24,7 +24,8 @@ class Client : public QObject {
  public:
   static outcome::result<QPointer<Client>> Create(QObject* parent);
 
-  void GetInstancesAsync(const std::function<void(outcome::result<QVector<Instance>>)>& callback);
+  void GetInstancesAsync(const std::function<void(outcome::result<QVector<Instance>>)>& callback,
+	                     int retry = 3);
   void GetSshInfoAsync(const Instance& ggp_instance,
                        const std::function<void(outcome::result<SshInfo>)>& callback);
 

--- a/src/OrbitGgp/include/OrbitGgp/Client.h
+++ b/src/OrbitGgp/include/OrbitGgp/Client.h
@@ -25,7 +25,7 @@ class Client : public QObject {
   static outcome::result<QPointer<Client>> Create(QObject* parent);
 
   void GetInstancesAsync(const std::function<void(outcome::result<QVector<Instance>>)>& callback,
-	                     int retry = 3);
+                         int retry = 3);
   void GetSshInfoAsync(const Instance& ggp_instance,
                        const std::function<void(outcome::result<SshInfo>)>& callback);
 


### PR DESCRIPTION
I had e2e tests failing due to "List available instances failed." although
the instance looked healthy otherwise.
Let's try to be a bit more persistant (or stubborn).

Bug: http://b/179808977
Test: Compiled, ran, still works fine.