### PR TITLE
Combine single selection and multi-selection methods

### DIFF
--- a/src/OrbitGl/DataView.cpp
+++ b/src/OrbitGl/DataView.cpp
@@ -77,11 +77,6 @@ void DataView::OnContextMenu(const std::string& action, int /*menu_index*/,
   }
 }
 
-std::optional<int> DataView::GetSelectedIndex() {
-  if (selected_indices_.empty()) return std::nullopt;
-  return *selected_indices_.begin();
-}
-
 std::vector<int> DataView::GetVisibleSelectedIndices() {
   std::vector<int> visible_selected_indices;
   for (size_t row = 0; row < indices_.size(); ++row) {

--- a/src/OrbitGl/DataView.cpp
+++ b/src/OrbitGl/DataView.cpp
@@ -77,6 +77,11 @@ void DataView::OnContextMenu(const std::string& action, int /*menu_index*/,
   }
 }
 
+std::optional<int> DataView::GetSelectedIndex() {
+  if (selected_indices_.empty()) return std::nullopt;
+  return *selected_indices_.begin();
+}
+
 std::vector<int> DataView::GetVisibleSelectedIndices() {
   std::vector<int> visible_selected_indices;
   for (size_t row = 0; row < indices_.size(); ++row) {

--- a/src/OrbitGl/DataView.h
+++ b/src/OrbitGl/DataView.h
@@ -69,8 +69,7 @@ class DataView {
   void OnSort(int column, std::optional<SortingOrder> new_order);
   virtual void OnContextMenu(const std::string& action, int menu_index,
                              const std::vector<int>& item_indices);
-  virtual void OnSelect(std::optional<int> /*index*/) {}
-  virtual void OnMultiSelect(const std::vector<int>& /*indices*/) {}
+  virtual void OnSelect(const std::vector<int>& /*indices*/) {}
   // This method returns the intersection of selected indices and visible indices. The returned
   // value contains 0 or 1 index for a DataView with single selection, and contains 0 or
   // multiple indices for a DataView with multi-selection.

--- a/src/OrbitGl/DataView.h
+++ b/src/OrbitGl/DataView.h
@@ -70,8 +70,10 @@ class DataView {
   virtual void OnContextMenu(const std::string& action, int menu_index,
                              const std::vector<int>& item_indices);
   virtual void OnSelect(std::optional<int> /*index*/) {}
-  [[nodiscard]] virtual std::optional<int> GetSelectedIndex();
   virtual void OnMultiSelect(const std::vector<int>& /*indices*/) {}
+  // This method returns the intersection of selected indices and visible indices. The returned
+  // value contains 0 or 1 index for a DataView with single selection, and contains 0 or
+  // multiple indices for a DataView with multi-selection.
   [[nodiscard]] virtual std::vector<int> GetVisibleSelectedIndices();
   virtual void OnDoubleClicked(int /*index*/) {}
   virtual void OnDataChanged();

--- a/src/OrbitGl/DataView.h
+++ b/src/OrbitGl/DataView.h
@@ -41,7 +41,6 @@ class DataView {
 
   explicit DataView(DataViewType type, OrbitApp* app)
       : update_period_ms_(-1),
-        selected_index_(std::nullopt),
         refresh_mode_(RefreshMode::kOther),
         type_(type),
         app_{app} {}
@@ -71,7 +70,7 @@ class DataView {
   virtual void OnContextMenu(const std::string& action, int menu_index,
                              const std::vector<int>& item_indices);
   virtual void OnSelect(std::optional<int> /*index*/) {}
-  [[nodiscard]] virtual std::optional<int> GetSelectedIndex() { return selected_index_; }
+  [[nodiscard]] virtual std::optional<int> GetSelectedIndex();
   virtual void OnMultiSelect(const std::vector<int>& /*indices*/) {}
   [[nodiscard]] virtual std::vector<int> GetVisibleSelectedIndices();
   virtual void OnDoubleClicked(int /*index*/) {}
@@ -107,7 +106,6 @@ class DataView {
   int sorting_column_ = 0;
   std::string filter_;
   int update_period_ms_;
-  std::optional<int> selected_index_;
   absl::flat_hash_set<int> selected_indices_;
   RefreshMode refresh_mode_;
   DataViewType type_;

--- a/src/OrbitGl/LiveFunctionsDataView.cpp
+++ b/src/OrbitGl/LiveFunctionsDataView.cpp
@@ -108,13 +108,13 @@ void LiveFunctionsDataView::UpdateSelectedFunctionId() {
   selected_function_id_ = app_->highlighted_function_id();
 }
 
-void LiveFunctionsDataView::OnSelect(std::optional<int> row) {
+void LiveFunctionsDataView::OnSelect(const std::vector<int>& rows) {
   app_->DeselectTextBox();
 
-  if (!row.has_value()) {
+  if (rows.empty()) {
     app_->set_highlighted_function_id(orbit_grpc_protos::kInvalidFunctionId);
   } else {
-    app_->set_highlighted_function_id(GetInstrumentedFunctionId(row.value()));
+    app_->set_highlighted_function_id(GetInstrumentedFunctionId(rows[0]));
   }
 
   if (refresh_mode_ != RefreshMode::kOnFilter && refresh_mode_ != RefreshMode::kOnSort) {

--- a/src/OrbitGl/LiveFunctionsDataView.cpp
+++ b/src/OrbitGl/LiveFunctionsDataView.cpp
@@ -98,8 +98,10 @@ std::string LiveFunctionsDataView::GetValue(int row, int column) {
   }
 }
 
-std::optional<int> LiveFunctionsDataView::GetSelectedIndex() {
-  return GetRowFromFunctionId(selected_function_id_);
+std::vector<int> LiveFunctionsDataView::GetVisibleSelectedIndices() {
+  std::optional<int> visible_selected_index = GetRowFromFunctionId(selected_function_id_);
+  if (!visible_selected_index.has_value()) return {};
+  return {visible_selected_index.value()};
 }
 
 void LiveFunctionsDataView::UpdateSelectedFunctionId() {

--- a/src/OrbitGl/LiveFunctionsDataView.h
+++ b/src/OrbitGl/LiveFunctionsDataView.h
@@ -30,7 +30,9 @@ class LiveFunctionsDataView : public DataView {
   std::vector<std::string> GetContextMenu(int clicked_index,
                                           const std::vector<int>& selected_indices) override;
   std::string GetValue(int row, int column) override;
-  std::optional<int> GetSelectedIndex() override;
+  // As we allow single selection on Live tab, this method returns either an empty vector or a
+  // single-value vector.
+  std::vector<int> GetVisibleSelectedIndices() override;
   void UpdateSelectedFunctionId();
 
   void OnSelect(std::optional<int> row) override;

--- a/src/OrbitGl/LiveFunctionsDataView.h
+++ b/src/OrbitGl/LiveFunctionsDataView.h
@@ -35,7 +35,7 @@ class LiveFunctionsDataView : public DataView {
   std::vector<int> GetVisibleSelectedIndices() override;
   void UpdateSelectedFunctionId();
 
-  void OnSelect(std::optional<int> row) override;
+  void OnSelect(const std::vector<int>& rows) override;
   void OnContextMenu(const std::string& action, int menu_index,
                      const std::vector<int>& item_indices) override;
   void OnDataChanged() override;

--- a/src/OrbitGl/SamplingReportDataView.cpp
+++ b/src/OrbitGl/SamplingReportDataView.cpp
@@ -266,7 +266,7 @@ void SamplingReportDataView::OnContextMenu(const std::string& action, int menu_i
   }
 }
 
-void SamplingReportDataView::OnMultiSelect(const std::vector<int>& indices) {
+void SamplingReportDataView::OnSelect(const std::vector<int>& indices) {
   absl::flat_hash_set<uint64_t> addresses;
   for (int index : indices) {
     addresses.insert(GetSampledFunction(index).absolute_address);

--- a/src/OrbitGl/SamplingReportDataView.h
+++ b/src/OrbitGl/SamplingReportDataView.h
@@ -32,7 +32,7 @@ class SamplingReportDataView : public DataView {
 
   void OnContextMenu(const std::string& action, int menu_index,
                      const std::vector<int>& item_indices) override;
-  void OnMultiSelect(const std::vector<int>& indices) override;
+  void OnSelect(const std::vector<int>& indices) override;
 
   void LinkDataView(DataView* data_view) override;
   void SetSamplingReport(class SamplingReport* sampling_report) {

--- a/src/OrbitQt/orbitsamplingreport.cpp
+++ b/src/OrbitQt/orbitsamplingreport.cpp
@@ -123,7 +123,7 @@ void OrbitSamplingReport::OnCurrentThreadTabChanged(int current_tab_index) {
   for (QModelIndex& index : index_list) {
     row_list.push_back(index.row());
   }
-  treeView->GetTreeView()->GetModel()->OnMultiRowsSelected(row_list);
+  treeView->GetTreeView()->GetModel()->OnRowsSelected(row_list);
   RefreshCallstackView();
 }
 

--- a/src/OrbitQt/orbittablemodel.cpp
+++ b/src/OrbitQt/orbittablemodel.cpp
@@ -99,14 +99,4 @@ void OrbitTableModel::OnFilter(const QString& filter) {
   data_view_->OnFilter(filter.toStdString());
 }
 
-void OrbitTableModel::OnRowSelected(std::optional<int> row) {
-  std::vector<int> rows;
-  if (row.has_value()) rows.push_back(row.value());
-  if (rows.empty() || static_cast<int>(data_view_->GetNumElements()) > rows[0]) {
-    data_view_->OnSelect(rows);
-  }
-}
-
-void OrbitTableModel::OnMultiRowsSelected(const std::vector<int>& rows) {
-  data_view_->OnSelect(rows);
-}
+void OrbitTableModel::OnRowsSelected(const std::vector<int>& rows) { data_view_->OnSelect(rows); }

--- a/src/OrbitQt/orbittablemodel.cpp
+++ b/src/OrbitQt/orbittablemodel.cpp
@@ -100,11 +100,13 @@ void OrbitTableModel::OnFilter(const QString& filter) {
 }
 
 void OrbitTableModel::OnRowSelected(std::optional<int> row) {
-  if (!row.has_value() || static_cast<int>(data_view_->GetNumElements()) > row.value()) {
-    data_view_->OnSelect(row);
+  std::vector<int> rows;
+  if (row.has_value()) rows.push_back(row.value());
+  if (rows.empty() || static_cast<int>(data_view_->GetNumElements()) > rows[0]) {
+    data_view_->OnSelect(rows);
   }
 }
 
 void OrbitTableModel::OnMultiRowsSelected(const std::vector<int>& rows) {
-  data_view_->OnMultiSelect(rows);
+  data_view_->OnSelect(rows);
 }

--- a/src/OrbitQt/orbittablemodel.h
+++ b/src/OrbitQt/orbittablemodel.h
@@ -45,8 +45,7 @@ class OrbitTableModel : public QAbstractTableModel {
 
   void OnTimer();
   void OnFilter(const QString& filter);
-  void OnRowSelected(std::optional<int> row);
-  void OnMultiRowsSelected(const std::vector<int>& rows);
+  void OnRowsSelected(const std::vector<int>& rows);
 
  protected:
   DataView* data_view_;

--- a/src/OrbitQt/orbittablemodel.h
+++ b/src/OrbitQt/orbittablemodel.h
@@ -34,8 +34,8 @@ class OrbitTableModel : public QAbstractTableModel {
   void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) override;
 
   int GetUpdatePeriodMs() { return data_view_->GetUpdatePeriodMs(); }
-  [[nodiscard]] std::optional<int> GetSelectedIndex() const {
-    return data_view_->GetSelectedIndex();
+  [[nodiscard]] std::vector<int> GetVisibleSelectedIndices() const {
+    return data_view_->GetVisibleSelectedIndices();
   }
   QModelIndex CreateIndex(int row, int column) { return createIndex(row, column); }
   DataView* GetDataView() { return data_view_; }

--- a/src/OrbitQt/orbittreeview.h
+++ b/src/OrbitQt/orbittreeview.h
@@ -65,9 +65,8 @@ class OrbitTreeView : public QTreeView {
   void ShowContextMenu(const QPoint& pos);
   void OnMenuClicked(const std::string& action, int menu_index);
   void OnRangeChanged(int min, int max);
-  void OnRowSelected(std::optional<int> row);
   void OnDoubleClicked(QModelIndex index);
-  void OnMultiRowsSelected(std::vector<int>& rows);
+  void OnRowsSelected(std::vector<int>& rows);
 
  private:
   std::unique_ptr<OrbitTableModel> model_;


### PR DESCRIPTION
As single selection can be considered as a special cases of the multi-selection, 
some methods and variables of single selection and multi-selection can be combined. 

More specifically, with this change, we 
* Replace `DataView::selected_index_` by using one index in `DataView::selected_indices_`;
* Replace `DataView::GetSelectedIndex` by returning an empty or single-valued vector with `DataView::GetVisibleSelectedIndices`;
* Update the `DataView::OnSelect` method to support both single selection and multi-selection and so remove `DataView::OnMultiSelect` method;
* Replace `OnRowSelected(std::optional<int> row)` and `OnMultiRowsSelected(const std::vector<int>& rows)` by
`OnRowsSelected(const std::vector<int>& rows)` in both `OrbitTreeView` and `OrbitTableModel`.

Bug: http://b/177814945.
Test: Check the selection, sorting and filtering behaviors in Live tab and Sampling tab, it should be same with the previous version.