### PR TITLE
Fix inconsistent min/max capture timestamp.

### DIFF
--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -440,12 +440,6 @@ void TimeGraph::SetCaptureData(CaptureData* capture_data) {
   track_manager_->SetCaptureData(capture_data);
 }
 
-void TimeGraph::UpdateMaxTimeStamp(uint64_t time) {
-  if (time > capture_max_timestamp_) {
-    capture_max_timestamp_ = time;
-  }
-};
-
 float TimeGraph::GetWorldFromTick(uint64_t time) const {
   if (time_window_us_ > 0) {
     double start = TicksToMicroseconds(capture_min_timestamp_, time) - min_time_us_;
@@ -552,7 +546,10 @@ void TimeGraph::UpdatePrimitives(PickingMode picking_mode) {
   text_renderer_static_.Clear();
 
   if (capture_data_) {
-    UpdateMaxTimeStamp(capture_data_->GetCallstackData()->max_time());
+    capture_min_timestamp_ =
+        std::min(capture_min_timestamp_, capture_data_->GetCallstackData()->min_time());
+    capture_max_timestamp_ =
+        std::max(capture_max_timestamp_, capture_data_->GetCallstackData()->max_time());
   }
 
   time_window_us_ = max_time_us_ - min_time_us_;

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -52,7 +52,6 @@ class TimeGraph {
 
   void ProcessTimer(const orbit_client_protos::TimerInfo& timer_info,
                     const orbit_client_protos::FunctionInfo* function);
-  void UpdateMaxTimeStamp(uint64_t time);
 
   // TODO (b/176056427): TimeGraph should not store nor expose CaptureData.
   [[nodiscard]] const CaptureData* GetCaptureData() const { return capture_data_; }


### PR DESCRIPTION
Whenever we update the capture timestamps in TimeGraph, we should
make sure to update both, such that they are always consistent.

Bug: http://b/179884465
Test: Load the capture linked in the bug.
Note: Loading the capture still fails sometimes, but this is a different bug.