### PR TITLE
Fix bug with optimized text rendering

### DIFF
--- a/src/OrbitGl/TextRenderer.h
+++ b/src/OrbitGl/TextRenderer.h
@@ -65,6 +65,7 @@ class TextRenderer {
   [[nodiscard]] int GetStringWidthScreenSpace(const char* text, uint32_t font_size);
   [[nodiscard]] int GetStringHeightScreenSpace(const char* text, uint32_t font_size);
   [[nodiscard]] texture_font_t* GetFont(uint32_t size);
+  [[nodiscard]] texture_glyph_t* MaybeLoadAndGetGlyph(texture_font_t* self, const char* character);
 
   void DrawOutline(Batcher* batcher, vertex_buffer_t* buffer);
 


### PR DESCRIPTION
There was a small and somewhat subtle issue with the new optimization in
our text renderer: One code path used texture_font_get_glyph without
checking if the glyph was already loaded. This is normally fine as
texture_font_get_glyph internally loads the glyph if it cannot be found.
However, this updates the texture atlas, which the optimization needs to
know about. We fix this by introducing a new helper method that always
checks if a glyph has been loaded already, maybe loads it, and then
gets the glyph and returns it. If the glyph is loaded, the method
indicates that the texture atlas was updated.

Tested: Manually built Orbit and checked if text is rendered correctly.
Bug: http://b/179810089