### PR TITLE
Move MainThreadExecutorImpl into QtUtils

### DIFF
--- a/src/OrbitQt/CMakeLists.txt
+++ b/src/OrbitQt/CMakeLists.txt
@@ -57,7 +57,6 @@ target_sources(
           ElidedLabel.cpp
           FilterPanelWidget.cpp
           FilterPanelWidgetAction.cpp
-          MainThreadExecutorImpl.cpp
           StatusListenerImpl.cpp
           DeploymentConfigurations.cpp
           main.cpp
@@ -164,8 +163,6 @@ target_sources(OrbitQtTests
         PRIVATE AccessibilityAdapter.cpp
                 AccessibilityAdapterTest.cpp
                 EventLoopTest.cpp
-                MainThreadExecutorImplTest.cpp
-                MainThreadExecutorImpl.cpp
                 ProcessItemModelTest.cpp
                 ProcessItemModel.cpp
                 StatusListenerImplTest.cpp

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -67,7 +67,6 @@
 #include "GlCanvas.h"
 #include "LiveFunctionsController.h"
 #include "LiveFunctionsDataView.h"
-#include "MainThreadExecutorImpl.h"
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Future.h"
 #include "OrbitBase/Logging.h"
@@ -82,6 +81,7 @@
 #include "OrbitGgp/Instance.h"
 #include "OrbitVersion/OrbitVersion.h"
 #include "Path.h"
+#include "QtUtils/MainThreadExecutorImpl.h"
 #include "SamplingReport.h"
 #include "StatusListenerImpl.h"
 #include "SyntaxHighlighter/X86Assembly.h"
@@ -151,7 +151,7 @@ OrbitMainWindow::OrbitMainWindow(orbit_qt::TargetConfiguration target_configurat
                                  orbit_metrics_uploader::MetricsUploader* metrics_uploader,
                                  const QStringList& command_line_flags)
     : QMainWindow(nullptr),
-      main_thread_executor_{orbit_qt::MainThreadExecutorImpl::Create()},
+      main_thread_executor_{orbit_qt_utils::MainThreadExecutorImpl::Create()},
       app_{OrbitApp::Create(main_thread_executor_.get(), metrics_uploader)},
       ui(new Ui::OrbitMainWindow),
       command_line_flags_(command_line_flags),

--- a/src/QtUtils/CMakeLists.txt
+++ b/src/QtUtils/CMakeLists.txt
@@ -9,23 +9,19 @@ add_library(QtUtils STATIC)
 
 target_compile_options(QtUtils PRIVATE ${STRICT_COMPILE_FLAGS})
 target_include_directories(QtUtils PUBLIC include/)
-target_link_libraries(QtUtils PUBLIC OrbitBase Qt5::Core CONAN_PKG::abseil)
+target_link_libraries(QtUtils PUBLIC OrbitBase OrbitGl Qt5::Core CONAN_PKG::abseil)
 
-target_sources(QtUtils PUBLIC include/QtUtils/FutureWatcher.h)
+target_sources(QtUtils PUBLIC include/QtUtils/FutureWatcher.h
+                              include/QtUtils/MainThreadExecutorImpl.h)
 
-target_sources(QtUtils PRIVATE FutureWatcher.cpp)
+target_sources(QtUtils PRIVATE FutureWatcher.cpp
+                               MainThreadExecutorImpl.cpp)
 
 set_target_properties(QtUtils PROPERTIES AUTOMOC ON)
 
 add_executable(QtUtilsTests)
 target_compile_options(QtUtilsTests PRIVATE ${STRICT_COMPILE_FLAGS})
-target_sources(QtUtilsTests PRIVATE FutureWatcherTest.cpp)
+target_sources(QtUtilsTests PRIVATE FutureWatcherTest.cpp
+                                    MainThreadExecutorImplTest.cpp)
 target_link_libraries(QtUtilsTests PRIVATE QtUtils GTest::QtCoreMain)
-
-if (WIN32 AND "$ENV{QT_QPA_PLATFORM}" STREQUAL "offscreen")
-  register_test(QtUtilsTests PROPERTIES DISABLED TRUE)
-endif()
-
-if (NOT WIN32)
-  register_test(QtUtilsTests PROPERTIES ENVIRONMENT QT_QPA_PLATFORM=offscreen)
-endif()
+register_test(QtUtilsTests)

--- a/src/QtUtils/MainThreadExecutorImpl.cpp
+++ b/src/QtUtils/MainThreadExecutorImpl.cpp
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "MainThreadExecutorImpl.h"
+#include "QtUtils/MainThreadExecutorImpl.h"
 
 #include <QCoreApplication>
 #include <QMetaObject>
@@ -15,7 +15,7 @@
 #include "OrbitBase/Tracing.h"
 #include "QtUtils/FutureWatcher.h"
 
-namespace orbit_qt {
+namespace orbit_qt_utils {
 
 void MainThreadExecutorImpl::Schedule(std::unique_ptr<Action> action) {
   QMetaObject::invokeMethod(
@@ -81,4 +81,4 @@ MainThreadExecutor::WaitResult MainThreadExecutorImpl::WaitForAll(
   return MapToWaitResult(result);
 }
 
-}  // namespace orbit_qt
+}  // namespace orbit_qt_utils

--- a/src/QtUtils/MainThreadExecutorImplTest.cpp
+++ b/src/QtUtils/MainThreadExecutorImplTest.cpp
@@ -7,9 +7,9 @@
 #include <QCoreApplication>
 #include <memory>
 
-#include "MainThreadExecutorImpl.h"
+#include "QtUtils/MainThreadExecutorImpl.h"
 
-namespace orbit_qt {
+namespace orbit_qt_utils {
 
 TEST(MainThreadExecutorImpl, Schedule) {
   auto executor = MainThreadExecutorImpl::Create();
@@ -154,4 +154,4 @@ TEST(MainThreadExecutorImpl, TryScheduleWithInvalidWeakPtr) {
   EXPECT_FALSE(result.has_value());
 }
 
-}  // namespace orbit_qt
+}  // namespace orbit_qt_utils

--- a/src/QtUtils/include/QtUtils/MainThreadExecutorImpl.h
+++ b/src/QtUtils/include/QtUtils/MainThreadExecutorImpl.h
@@ -10,7 +10,7 @@
 
 #include "MainThreadExecutor.h"
 
-namespace orbit_qt {
+namespace orbit_qt_utils {
 
 // An implementation of MainThreadExecutor that integrates with Qt's event loop
 class MainThreadExecutorImpl : public QObject, public MainThreadExecutor {
@@ -40,6 +40,6 @@ class MainThreadExecutorImpl : public QObject, public MainThreadExecutor {
   void AbortRequested();
 };
 
-}  // namespace orbit_qt
+}  // namespace orbit_qt_utils
 
 #endif  // ORBIT_QT_MAIN_THREAD_EXECUTOR_IMPL_H_


### PR DESCRIPTION
The main reason for moving into QtUtils are the tests. By moving this
class there, its tests won't need to link against Qt5::Widgets and the
executable runs fine in a command-line only setup.

One disadvantage: QtUtils now needs to link against OrbitGl since
OrbitGl contains the base class MainThreadExecutor. This should be
considered a temporary work-around and will be fixed by moving
MainThreadExecutor into a different module.