### PR TITLE
Fix load_bias calculation

### DIFF
--- a/src/ElfUtils/ElfFileTest.cpp
+++ b/src/ElfUtils/ElfFileTest.cpp
@@ -88,9 +88,9 @@ TEST(ElfFile, CalculateLoadBiasNoProgramHeaders) {
   const auto load_bias_result = elf_file->GetLoadBias();
   ASSERT_FALSE(load_bias_result);
   EXPECT_EQ(load_bias_result.error().message(),
-            absl::StrFormat("Unable to get load bias of ELF file: \"%s\". No PT_LOAD program "
-                            "headers found.",
-                            test_elf_file.string()));
+            absl::StrFormat(
+                "Unable to get load bias of ELF file: \"%s\". No executable PT_LOAD segment found.",
+                test_elf_file.string()));
 }
 
 TEST(ElfFile, HasSymtab) {


### PR DESCRIPTION
Calculate load_bias based on the executable PT_LOAD segment.

Newer linkers create first segment as read only and
put .text section into a separate segment. Which means
load_bias calculation is off if second segment vaddr-offset
difference is different from the first PT_LOAD segment

Test: run unit-tests
Test: run capture on executable with executable PT_LOAD
      segment different from the first PT_LOAD
Bug: http://b/179894572
