### PR TITLE
Move DataViewType specific refresh operation to DataView::OnRefresh

### DIFF
--- a/src/OrbitGl/DataView.h
+++ b/src/OrbitGl/DataView.h
@@ -40,10 +40,7 @@ class DataView {
   };
 
   explicit DataView(DataViewType type, OrbitApp* app)
-      : update_period_ms_(-1),
-        refresh_mode_(RefreshMode::kOther),
-        type_(type),
-        app_{app} {}
+      : update_period_ms_(-1), type_(type), app_{app} {}
 
   virtual ~DataView() = default;
 
@@ -64,7 +61,8 @@ class DataView {
   // Filter callback set from UI layer.
   using FilterCallback = std::function<void(const std::string&)>;
   void SetUiFilterCallback(FilterCallback callback) { filter_callback_ = std::move(callback); }
-  void SetRefreshMode(RefreshMode mode) { refresh_mode_ = mode; }
+  virtual void OnRefresh(const std::vector<int>& /*visible_selected_indices*/,
+                         const RefreshMode& /*mode*/) {}
 
   void OnSort(int column, std::optional<SortingOrder> new_order);
   virtual void OnContextMenu(const std::string& action, int menu_index,
@@ -95,6 +93,7 @@ class DataView {
 
   int GetUpdatePeriodMs() const { return update_period_ms_; }
   DataViewType GetType() const { return type_; }
+  [[nodiscard]] virtual bool ResetOnRefresh() const { return true; }
 
  protected:
   void InitSortingOrders();
@@ -108,7 +107,6 @@ class DataView {
   std::string filter_;
   int update_period_ms_;
   absl::flat_hash_set<int> selected_indices_;
-  RefreshMode refresh_mode_;
   DataViewType type_;
 
   static const std::string kMenuActionCopySelection;

--- a/src/OrbitGl/LiveFunctionsDataView.h
+++ b/src/OrbitGl/LiveFunctionsDataView.h
@@ -33,6 +33,7 @@ class LiveFunctionsDataView : public DataView {
   // As we allow single selection on Live tab, this method returns either an empty vector or a
   // single-value vector.
   std::vector<int> GetVisibleSelectedIndices() override;
+  void UpdateHighlightedFunctionId(const std::vector<int>& rows);
   void UpdateSelectedFunctionId();
 
   void OnSelect(const std::vector<int>& rows) override;
@@ -40,6 +41,9 @@ class LiveFunctionsDataView : public DataView {
                      const std::vector<int>& item_indices) override;
   void OnDataChanged() override;
   void OnTimer() override;
+  void OnRefresh(const std::vector<int>& visible_selected_indices,
+                 const RefreshMode& mode) override;
+  [[nodiscard]] bool ResetOnRefresh() const override { return false; }
   std::optional<int> GetRowFromFunctionId(uint64_t function_id);
 
  protected:

--- a/src/OrbitGl/SamplingReportDataView.cpp
+++ b/src/OrbitGl/SamplingReportDataView.cpp
@@ -266,19 +266,27 @@ void SamplingReportDataView::OnContextMenu(const std::string& action, int menu_i
   }
 }
 
-void SamplingReportDataView::OnSelect(const std::vector<int>& indices) {
+void SamplingReportDataView::UpdateSelectedAddressesAndTid(const std::vector<int>& indices) {
   absl::flat_hash_set<uint64_t> addresses;
   for (int index : indices) {
     addresses.insert(GetSampledFunction(index).absolute_address);
   }
   sampling_report_->OnSelectAddresses(addresses, tid_);
+}
 
-  if (refresh_mode_ != RefreshMode::kOnFilter && refresh_mode_ != RefreshMode::kOnSort) {
-    selected_indices_.clear();
-    for (int row : indices) {
-      selected_indices_.insert(indices_[row]);
-    }
+void SamplingReportDataView::OnSelect(const std::vector<int>& indices) {
+  UpdateSelectedAddressesAndTid(indices);
+
+  selected_indices_.clear();
+  for (int row : indices) {
+    selected_indices_.insert(indices_[row]);
   }
+}
+
+void SamplingReportDataView::OnRefresh(const std::vector<int>& visible_selected_indices,
+                                       const RefreshMode& mode) {
+  if (mode != RefreshMode::kOnFilter && mode != RefreshMode::kOnSort) return;
+  UpdateSelectedAddressesAndTid(visible_selected_indices);
 }
 
 void SamplingReportDataView::LinkDataView(DataView* data_view) {

--- a/src/OrbitGl/SamplingReportDataView.h
+++ b/src/OrbitGl/SamplingReportDataView.h
@@ -33,7 +33,10 @@ class SamplingReportDataView : public DataView {
   void OnContextMenu(const std::string& action, int menu_index,
                      const std::vector<int>& item_indices) override;
   void OnSelect(const std::vector<int>& indices) override;
+  void OnRefresh(const std::vector<int>& visible_selected_indices,
+                 const RefreshMode& mode) override;
 
+  void UpdateSelectedAddressesAndTid(const std::vector<int>& indices);
   void LinkDataView(DataView* data_view) override;
   void SetSamplingReport(class SamplingReport* sampling_report) {
     sampling_report_ = sampling_report;

--- a/src/OrbitQt/orbittreeview.h
+++ b/src/OrbitQt/orbittreeview.h
@@ -53,9 +53,6 @@ class OrbitTreeView : public QTreeView {
   void SetIsInternalRefresh(bool status) { is_internal_refresh_ = status; }
   void SetIsMultiSelection(bool status) { is_multi_selection_ = status; }
 
- private:
-  void DoReselection(RefreshMode refresh_mode);
-
  public slots:
   void columnResized(int column, int oldSize, int newSize);
 


### PR DESCRIPTION
In the current `OrbitTreeView::Refresh` method, we change the behavior of `OrbitTreeView` based on the specific type of `DataView`.
In order to remove the internal information of `DataView` from `OrbitTreeView`, we move the `DataViewType` specific refresh operations to the `DataView::OnRefresh` method. 

bug: http://b/177812629