### PR TITLE
LinuxTracingIntegrationTest: handle missing second frame with FPs

### DIFF
--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -86,6 +86,10 @@ void UprobesUnwindingVisitor::visit(CallchainSamplePerfEvent* event) {
     return;
   }
 
+  // TODO(b/179976268): When a sample falls on the first (push rbp) or second (mov rbp,rsp)
+  //  instruction of the current function, frame-pointer unwinding skips the caller's frame,
+  //  because rbp hasn't yet been updated to rsp. Drop the sample in this case?
+
   if (!return_address_manager_.PatchCallchain(event->GetTid(), event->GetCallchain(),
                                               event->GetCallchainSize(), current_maps_.get())) {
     return;


### PR DESCRIPTION
This happens when the sample is on `push rbp` or `mov rbp,rsp`.
The goal here is only to handle this gracefully in the tests for now.

Bug: http://b/179376436
Bug: http://b/179976268