### PR TITLE
Fix segfault in TimerTrack::UpdatePrimitives.

### DIFF
--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -82,6 +82,147 @@ WorldXInfo ToWorldX(double start_us, double end_us, double inv_time_window, floa
 
 }  // namespace
 
+void TimerTrack::DrawTimer(TextBox* prev_text_box, TextBox* current_text_box,
+                           TextBox* next_text_box, uint64_t min_tick, uint64_t max_tick,
+                           float z_offset, Batcher* batcher, GlCanvas* canvas, float world_start_x,
+                           float world_width, double inv_time_window, bool is_collapsed, float z,
+                           const TextBox* selected_textbox, uint64_t highlighted_function_id,
+                           uint64_t pixel_delta_in_ticks, uint64_t min_timegraph_tick,
+                           uint64_t* min_ignore, uint64_t* max_ignore) {
+  CHECK(min_ignore != nullptr);
+  CHECK(max_ignore != nullptr);
+  if (current_text_box == nullptr) return;
+  const TimerInfo& current_timer_info = current_text_box->GetTimerInfo();
+  if (min_tick > current_timer_info.end() || max_tick < current_timer_info.start()) return;
+  if (current_timer_info.start() >= *min_ignore && current_timer_info.end() <= *max_ignore) return;
+  if (!TimerFilter(current_timer_info)) return;
+
+  UpdateDepth(current_timer_info.depth() + 1);
+  double start_us = time_graph_->GetUsFromTick(current_timer_info.start());
+  double start_or_prev_end_us = start_us;
+  double end_us = time_graph_->GetUsFromTick(current_timer_info.end());
+  double end_or_next_start_us = end_us;
+
+  float world_timer_y = GetYFromTimer(current_timer_info);
+  float box_height = GetTextBoxHeight(current_timer_info);
+
+  // Check if the previous timer overlaps with the current one, and if so draw the overlap
+  // as triangles rather than as overlapping rectangles.
+  if (prev_text_box != nullptr) {
+    const TimerInfo& prev_timer_info = prev_text_box->GetTimerInfo();
+    // TODO(b/179985943): Turn this back into a check.
+    if (prev_timer_info.start() < current_timer_info.start()) {
+      // Note, that for timers that are completely inside the previous one, we will keep drawing
+      // them above each other, as a proper solution would require us to keep a list of all
+      // prev. intersecting timers. Further, we also compare the type, as for the Gpu timers,
+      // timers of different type but same depth are drawn below each other (and thus do not
+      // overlap).
+      if (prev_timer_info.end() > current_timer_info.start() &&
+          prev_timer_info.end() <= current_timer_info.end() &&
+          prev_timer_info.type() == current_timer_info.type()) {
+        start_or_prev_end_us = time_graph_->GetUsFromTick(prev_timer_info.end());
+      }
+    }
+  }
+
+  // Check if the next timer overlaps with the current one, and if so draw the overlap
+  // as triangles rather than as overlapping rectangles.
+  if (next_text_box != nullptr) {
+    const TimerInfo& next_timer_info = next_text_box->GetTimerInfo();
+    // TODO(b/179985943): Turn this back into a check.
+    if (current_timer_info.start() < next_timer_info.start()) {
+      // Note, that for timers that are completely inside the next one, we will keep drawing
+      // them above each other, as a proper solution would require us to keep a list of all
+      // upcoming intersecting timers. We also compare the type, as for the Gpu timers, timers
+      // of different type but same depth are drawn below each other (and thus do not overlap).
+      if (current_timer_info.end() > next_timer_info.start() &&
+          current_timer_info.end() <= next_timer_info.end() &&
+          next_timer_info.type() == current_timer_info.type()) {
+        end_or_next_start_us = time_graph_->GetUsFromTick(next_timer_info.start());
+      }
+    }
+  }
+
+  double elapsed_us = end_us - start_us;
+
+  // Draw the Timer's text if it is not collapsed.
+  if (!is_collapsed) {
+    // For overlaps, let us make the textbox just a bit wider:
+    double left_overlap_width_us = start_or_prev_end_us - start_us;
+    double text_x_start_us = start_or_prev_end_us - (.25 * left_overlap_width_us);
+    double right_overlap_width_us = end_us - end_or_next_start_us;
+    double text_x_end_us = end_or_next_start_us + (.25 * right_overlap_width_us);
+
+    bool is_visible_width =
+        (text_x_end_us - text_x_start_us) * inv_time_window * canvas->GetWidth() > 1;
+    WorldXInfo world_x_info =
+        ToWorldX(text_x_start_us, text_x_end_us, inv_time_window, world_start_x, world_width);
+
+    if (is_visible_width) {
+      Vec2 pos(world_x_info.world_x_start, world_timer_y);
+      Vec2 size(world_x_info.world_x_width, GetTextBoxHeight(current_timer_info));
+      current_text_box->SetPos(pos);
+      current_text_box->SetSize(size);
+
+      SetTimesliceText(current_timer_info, elapsed_us, world_start_x, z_offset, current_text_box);
+    }
+  }
+
+  uint64_t function_id = current_timer_info.function_id();
+
+  bool is_selected = current_text_box == selected_textbox;
+  bool is_highlighted = !is_selected && function_id != orbit_grpc_protos::kInvalidFunctionId &&
+                        function_id == highlighted_function_id;
+
+  static const Color kHighlightColor(100, 181, 246, 255);
+  Color color = is_highlighted ? kHighlightColor : GetTimerColor(current_timer_info, is_selected);
+
+  bool is_visible_width = elapsed_us * inv_time_window * canvas->GetWidth() > 1;
+
+  if (is_visible_width) {
+    WorldXInfo world_x_info_left_overlap =
+        ToWorldX(start_us, start_or_prev_end_us, inv_time_window, world_start_x, world_width);
+
+    WorldXInfo world_x_info_right_overlap =
+        ToWorldX(end_or_next_start_us, end_us, inv_time_window, world_start_x, world_width);
+
+    Vec3 top_left(world_x_info_left_overlap.world_x_start, world_timer_y + box_height, z);
+    Vec3 bottom_left(
+        world_x_info_left_overlap.world_x_start + world_x_info_left_overlap.world_x_width,
+        world_timer_y, z);
+    Vec3 top_right(world_x_info_right_overlap.world_x_start, world_timer_y + box_height, z);
+    Vec3 bottom_right(
+        world_x_info_right_overlap.world_x_start + world_x_info_right_overlap.world_x_width,
+        world_timer_y, z);
+    batcher->AddShadedTrapezium(
+        top_left, bottom_left, bottom_right, top_right, color,
+        std::make_unique<PickingUserData>(current_text_box,
+                                          [&](PickingId id) { return this->GetBoxTooltip(id); }));
+
+  } else {
+    auto user_data = std::make_unique<PickingUserData>(
+        current_text_box, [&](PickingId id) { return this->GetBoxTooltip(id); });
+
+    WorldXInfo world_x_info =
+        ToWorldX(start_us, end_us, inv_time_window, world_start_x, world_width);
+
+    Vec2 pos(world_x_info.world_x_start, world_timer_y);
+    batcher->AddVerticalLine(pos, GetTextBoxHeight(current_timer_info), z, color,
+                             std::move(user_data));
+    // For lines, we can ignore the entire pixel into which this event
+    // falls. We align this precisely on the pixel x-coordinate of the
+    // current line being drawn (in ticks). If pixel_delta_in_ticks is
+    // zero, we need to avoid dividing by zero, but we also wouldn't
+    // gain anything here.
+    if (pixel_delta_in_ticks != 0) {
+      *min_ignore = min_timegraph_tick +
+                    ((current_timer_info.start() - min_timegraph_tick) / pixel_delta_in_ticks) *
+                        pixel_delta_in_ticks;
+      *max_ignore = *min_ignore + pixel_delta_in_ticks;
+    }
+  }
+}
+
 void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
                                   PickingMode /*picking_mode*/, float z_offset) {
   UpdateBoxHeight();
@@ -110,151 +251,34 @@ void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
 
   for (auto& chain : chains_by_depth) {
     if (!chain) continue;
-    auto chain_iterator = chain->begin();
-    const TimerInfo* prev_timer_info = nullptr;
-    while (chain_iterator != chain->end()) {
-      TimerBlock& block = *chain_iterator;
+    TextBox* prev_text_box = nullptr;
+    TextBox* current_text_box = nullptr;
+    TextBox* next_text_box = nullptr;
+
+    // We have to reset this when we go to the next depth, as otherwise we
+    // would miss drawing events that should be drawn.
+    uint64_t min_ignore = std::numeric_limits<uint64_t>::max();
+    uint64_t max_ignore = std::numeric_limits<uint64_t>::min();
+    for (TimerBlock& block : *chain) {
       if (!block.Intersects(min_tick, max_tick)) continue;
 
-      // We have to reset this when we go to the next depth, as otherwise we
-      // would miss drawing events that should be drawn.
-      uint64_t min_ignore = std::numeric_limits<uint64_t>::max();
-      uint64_t max_ignore = std::numeric_limits<uint64_t>::min();
-
       for (size_t k = 0; k < block.size(); ++k) {
-        TextBox& text_box = block[k];
-        const TimerInfo& timer_info = text_box.GetTimerInfo();
-        if (min_tick > timer_info.end() || max_tick < timer_info.start()) continue;
-        if (timer_info.start() >= min_ignore && timer_info.end() <= max_ignore) continue;
-        if (!TimerFilter(timer_info)) continue;
+        next_text_box = &block[k];
 
-        UpdateDepth(timer_info.depth() + 1);
-        double start_us = time_graph_->GetUsFromTick(timer_info.start());
-        double start_or_prev_end_us = start_us;
-        double end_us = time_graph_->GetUsFromTick(timer_info.end());
-        double end_or_next_start_us = end_us;
+        DrawTimer(prev_text_box, current_text_box, next_text_box, min_tick, max_tick, z_offset,
+                  batcher, canvas, world_start_x, world_width, inv_time_window, is_collapsed, z,
+                  selected_textbox, highlighted_function_id, pixel_delta_in_ticks,
+                  min_timegraph_tick, &min_ignore, &max_ignore);
 
-        float world_timer_y = GetYFromTimer(timer_info);
-        float box_height = GetTextBoxHeight(timer_info);
-
-        // Check if the previous timer overlaps with the current one, and if so draw the overlap
-        // as triangles rather than as overlapping rectangles.
-        if (prev_timer_info != nullptr) {
-          CHECK(prev_timer_info->start() < timer_info.start());
-          // Note, that for timers that are completely inside the previous one, we will keep drawing
-          // them above each other, as a proper solution would require us to keep a list of all
-          // prev. intersecting timers. Further, we also compare the type, as for the Gpu timers,
-          // timers of different type but same depth are drawn below each other (and thus do not
-          // overlap).
-          if (prev_timer_info->end() > timer_info.start() &&
-              prev_timer_info->end() <= timer_info.end() &&
-              prev_timer_info->type() == timer_info.type()) {
-            start_or_prev_end_us = time_graph_->GetUsFromTick(prev_timer_info->end());
-          }
-        }
-
-        // Check if the next timer overlaps with the current one, and if so draw the overlap
-        // as triangles rather than as overlapping rectangles.
-        if (auto next_chain_it = ++chain_iterator;
-            next_chain_it != chain->end() || k + 1 < block.size()) {
-          const TimerInfo& next_timer_info = (k + 1 < block.size())
-                                                 ? block[k + 1].GetTimerInfo()
-                                                 : (*next_chain_it)[0].GetTimerInfo();
-          CHECK(timer_info.start() < next_timer_info.start());
-          // Note, that for timers that are completely inside the next one, we will keep drawing
-          // them above each other, as a proper solution would require us to keep a list of all
-          // upcoming intersecting timers. We also compare the type, as for the Gpu timers, timers
-          // of different type but same depth are drawn below each other (and thus do not overlap).
-          if (timer_info.end() > next_timer_info.start() &&
-              timer_info.end() <= next_timer_info.end() &&
-              next_timer_info.type() == timer_info.type()) {
-            end_or_next_start_us = time_graph_->GetUsFromTick(next_timer_info.start());
-          }
-        }
-
-        double elapsed_us = end_us - start_us;
-
-        // Draw the Timer's text if it is not collapsed.
-        if (!is_collapsed) {
-          // For overlaps, let us make the textbox just a bit wider:
-          double left_overlap_width_us = start_or_prev_end_us - start_us;
-          double text_x_start_us = start_or_prev_end_us - (.25 * left_overlap_width_us);
-          double right_overlap_width_us = end_us - end_or_next_start_us;
-          double text_x_end_us = end_or_next_start_us + (.25 * right_overlap_width_us);
-
-          bool is_visible_width =
-              (text_x_end_us - text_x_start_us) * inv_time_window * canvas->GetWidth() > 1;
-          WorldXInfo world_x_info =
-              ToWorldX(text_x_start_us, text_x_end_us, inv_time_window, world_start_x, world_width);
-
-          if (is_visible_width) {
-            Vec2 pos(world_x_info.world_x_start, world_timer_y);
-            Vec2 size(world_x_info.world_x_width, GetTextBoxHeight(timer_info));
-            text_box.SetPos(pos);
-            text_box.SetSize(size);
-
-            SetTimesliceText(timer_info, elapsed_us, world_start_x, z_offset, &text_box);
-          }
-        }
-
-        uint64_t function_id = timer_info.function_id();
-
-        bool is_selected = &text_box == selected_textbox;
-        bool is_highlighted = !is_selected &&
-                              function_id != orbit_grpc_protos::kInvalidFunctionId &&
-                              function_id == highlighted_function_id;
-
-        static const Color kHighlightColor(100, 181, 246, 255);
-        Color color = is_highlighted ? kHighlightColor : GetTimerColor(timer_info, is_selected);
-
-        bool is_visible_width = elapsed_us * inv_time_window * canvas->GetWidth() > 1;
-
-        if (is_visible_width) {
-          WorldXInfo world_x_info_left_overlap =
-              ToWorldX(start_us, start_or_prev_end_us, inv_time_window, world_start_x, world_width);
-
-          WorldXInfo world_x_info_right_overlap =
-              ToWorldX(end_or_next_start_us, end_us, inv_time_window, world_start_x, world_width);
-
-          Vec3 top_left(world_x_info_left_overlap.world_x_start, world_timer_y + box_height, z);
-          Vec3 bottom_left(
-              world_x_info_left_overlap.world_x_start + world_x_info_left_overlap.world_x_width,
-              world_timer_y, z);
-          Vec3 top_right(world_x_info_right_overlap.world_x_start, world_timer_y + box_height, z);
-          Vec3 bottom_right(
-              world_x_info_right_overlap.world_x_start + world_x_info_right_overlap.world_x_width,
-              world_timer_y, z);
-          batcher->AddShadedTrapezium(
-              top_left, bottom_left, bottom_right, top_right, color,
-              std::make_unique<PickingUserData>(
-                  &text_box, [&](PickingId id) { return this->GetBoxTooltip(id); }));
-
-        } else {
-          auto user_data = std::make_unique<PickingUserData>(
-              &text_box, [&](PickingId id) { return this->GetBoxTooltip(id); });
-
-          WorldXInfo world_x_info =
-              ToWorldX(start_us, end_us, inv_time_window, world_start_x, world_width);
-
-          Vec2 pos(world_x_info.world_x_start, world_timer_y);
-          batcher->AddVerticalLine(pos, GetTextBoxHeight(timer_info), z, color,
-                                   std::move(user_data));
-          // For lines, we can ignore the entire pixel into which this event
-          // falls. We align this precisely on the pixel x-coordinate of the
-          // current line being drawn (in ticks). If pixel_delta_in_ticks is
-          // zero, we need to avoid dividing by zero, but we also wouldn't
-          // gain anything here.
-          if (pixel_delta_in_ticks != 0) {
-            min_ignore = min_timegraph_tick +
-                         ((timer_info.start() - min_timegraph_tick) / pixel_delta_in_ticks) *
-                             pixel_delta_in_ticks;
-            max_ignore = min_ignore + pixel_delta_in_ticks;
-          }
-        }
-
-        prev_timer_info = &timer_info;
+        prev_text_box = current_text_box;
+        current_text_box = next_text_box;
       }
     }
+    next_text_box = nullptr;
+    DrawTimer(prev_text_box, current_text_box, next_text_box, min_tick, max_tick, z_offset, batcher,
+              canvas, world_start_x, world_width, inv_time_window, is_collapsed, z,
+              selected_textbox, highlighted_function_id, pixel_delta_in_ticks, min_timegraph_tick,
+              &min_ignore, &max_ignore);
   }
 }
 

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -254,10 +254,9 @@ void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
     // In order to draw overlaps correctly, we need for every text box to be drawn (current),
     // its previous and next text box. In order to avoid looking ahead for the next text (which is
     // error-prone), we are doing just one traversal of the text boxes, while keeping track of the
-    // previous two timers and will draw the previous one, thus the currents iteration value being
-    // the "next" textbox.
+    // previous two timers, thus the currents iteration value being the "next" textbox.
     // Note: This will require us to draw the last timer after the traversal of the text boxes.
-    // Also note: The draw method will take care of nullptr's being passed into.
+    // Also note: The draw method will take care of nullptr's being passed into (first iteration).
     TextBox* prev_text_box = nullptr;
     TextBox* current_text_box = nullptr;
     TextBox* next_text_box = nullptr;
@@ -270,8 +269,8 @@ void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
       if (!block.Intersects(min_tick, max_tick)) continue;
 
       for (size_t k = 0; k < block.size(); ++k) {
-        // Remember that the current index (k) points to the "next" text box and we want to draw
-        // the text box from the previous iteration ("current").
+        // The current index (k) points to the "next" text box and we want to draw the text box from
+        // the previous iteration ("current").
         next_text_box = &block[k];
 
         DrawTimer(prev_text_box, current_text_box, next_text_box, min_tick, max_tick, z_offset,

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -84,6 +84,13 @@ class TimerTrack : public Track {
     return true;
   }
 
+  void DrawTimer(TextBox* prev_text_box, TextBox* current_text_box, TextBox* next_text_box,
+                 uint64_t min_tick, uint64_t max_tick, float z_offset, Batcher* batcher,
+                 GlCanvas* canvas, float world_start_x, float world_width, double inv_time_window,
+                 bool is_collapsed, float z, const TextBox* selected_textbox,
+                 uint64_t highlighted_function_id, uint64_t pixel_delta_in_ticks,
+                 uint64_t min_timegraph_tick, uint64_t* min_ignore, uint64_t* max_ignore);
+
   void UpdateDepth(uint32_t depth) {
     if (depth > depth_) depth_ = depth;
   }


### PR DESCRIPTION
PR #1760 introduced handling for overlapping timers, which required
to look forward to the next timer. This code was broken.

This change fixes this and simplifies the logic. The iteration
is now a "sliding window" of previous, current and next pointers
to the TextBoxes (with underlying timers).

Test: Take a capture.