### PR TITLE
Fix the selection behavior of frametrack

### DIFF
--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -115,9 +115,13 @@ void AsyncTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_us
       layout_->CalculateZoomedFontSize(), max_size);
 }
 
-Color AsyncTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected) const {
+Color AsyncTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected,
+                                bool is_highlighted) const {
   const Color kInactiveColor(100, 100, 100, 255);
   const Color kSelectionColor(0, 128, 255, 255);
+  if (is_highlighted) {
+    return TimerTrack::kHighlightColor;
+  }
   if (is_selected) {
     return kSelectionColor;
   }

--- a/src/OrbitGl/AsyncTrack.h
+++ b/src/OrbitGl/AsyncTrack.h
@@ -37,7 +37,7 @@ class AsyncTrack final : public TimerTrack {
   void SetTimesliceText(const orbit_client_protos::TimerInfo& timer, double elapsed_us, float min_x,
                         float z_offset, TextBox* text_box) override;
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
-                                    bool is_selected) const override;
+                                    bool is_selected, bool is_highlighted) const override;
 
   // Used for determining what row can receive a new timer with no overlap.
   absl::flat_hash_map<uint32_t, uint64_t> max_span_time_by_depth_;

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -102,7 +102,7 @@ float FrameTrack::GetTextBoxHeight(const TimerInfo& timer_info) const {
 }
 
 Color FrameTrack::GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
-                                bool /*is_selected*/) const {
+                                bool /*is_selected*/, bool /*is_highlighted*/) const {
   Vec4 min_color(76.f, 175.f, 80.f, 255.f);
   Vec4 max_color(63.f, 81.f, 181.f, 255.f);
   Vec4 warn_color(244.f, 67.f, 54.f, 255.f);

--- a/src/OrbitGl/FrameTrack.h
+++ b/src/OrbitGl/FrameTrack.h
@@ -52,7 +52,7 @@ class FrameTrack : public TimerTrack {
 
  protected:
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
-                                    bool is_selected) const override;
+                                    bool is_selected, bool is_highlighted) const override;
   [[nodiscard]] float GetHeight() const override;
 
  private:

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -104,9 +104,13 @@ bool GpuTrack::IsTimerActive(const TimerInfo& timer_info) const {
   return is_same_tid_as_selected || no_thread_selected;
 }
 
-Color GpuTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected) const {
+Color GpuTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected,
+                              bool is_highlighted) const {
   const Color kInactiveColor(100, 100, 100, 255);
   const Color kSelectionColor(0, 128, 255, 255);
+  if (is_highlighted) {
+    return TimerTrack::kHighlightColor;
+  }
   if (is_selected) {
     return kSelectionColor;
   }

--- a/src/OrbitGl/GpuTrack.h
+++ b/src/OrbitGl/GpuTrack.h
@@ -54,8 +54,8 @@ class GpuTrack : public TimerTrack {
 
  protected:
   [[nodiscard]] bool IsTimerActive(const orbit_client_protos::TimerInfo& timer) const override;
-  [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer,
-                                    bool is_selected) const override;
+  [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer, bool is_selected,
+                                    bool is_highlighted) const override;
   [[nodiscard]] bool TimerFilter(const orbit_client_protos::TimerInfo& timer) const override;
   void SetTimesliceText(const orbit_client_protos::TimerInfo& timer, double elapsed_us, float min_x,
                         float z_offset, TextBox* text_box) override;

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -54,7 +54,11 @@ bool SchedulerTrack::IsTimerActive(const TimerInfo& timer_info) const {
   return is_same_tid_as_selected || (app_->selected_thread_id() == -1 && is_same_pid_as_target);
 }
 
-Color SchedulerTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected) const {
+Color SchedulerTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected,
+                                    bool is_highlighted) const {
+  if (is_highlighted) {
+    return TimerTrack::kHighlightColor;
+  }
   if (is_selected) {
     return kSelectionColor;
   }

--- a/src/OrbitGl/SchedulerTrack.h
+++ b/src/OrbitGl/SchedulerTrack.h
@@ -36,7 +36,7 @@ class SchedulerTrack final : public TimerTrack {
  protected:
   [[nodiscard]] bool IsTimerActive(const orbit_client_protos::TimerInfo& timer_info) const override;
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
-                                    bool is_selected) const override;
+                                    bool is_selected, bool is_highlighted) const override;
   [[nodiscard]] std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const override;
 
  private:

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -157,9 +157,13 @@ bool ThreadTrack::IsTrackSelected() const {
   return ToColor(static_cast<uint64_t>(event.color));
 }
 
-Color ThreadTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected) const {
+Color ThreadTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected,
+                                 bool is_highlighted) const {
   const Color kInactiveColor(100, 100, 100, 255);
   const Color kSelectionColor(0, 128, 255, 255);
+  if (is_highlighted) {
+    return TimerTrack::kHighlightColor;
+  }
   if (is_selected) {
     return kSelectionColor;
   }

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -52,8 +52,8 @@ class ThreadTrack final : public TimerTrack {
   [[nodiscard]] bool IsTimerActive(const orbit_client_protos::TimerInfo& timer) const override;
   [[nodiscard]] bool IsTrackSelected() const override;
 
-  [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer,
-                                    bool is_selected) const override;
+  [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer, bool is_selected,
+                                    bool is_highlighted) const override;
   void SetTimesliceText(const orbit_client_protos::TimerInfo& timer, double elapsed_us, float min_x,
                         float z_offset, TextBox* text_box) override;
   [[nodiscard]] std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const override;

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -27,6 +27,8 @@ using orbit_client_protos::TimerInfo;
 
 ABSL_DECLARE_FLAG(bool, show_return_values);
 
+const Color TimerTrack::kHighlightColor = Color(100, 181, 246, 255);
+
 TimerTrack::TimerTrack(TimeGraph* time_graph, TimeGraphLayout* layout, OrbitApp* app,
                        const CaptureData* capture_data)
     : Track(time_graph, layout, capture_data), app_{app} {
@@ -174,8 +176,7 @@ void TimerTrack::DrawTimer(const TextBox* prev_text_box, const TextBox* next_tex
   bool is_highlighted = !is_selected && function_id != orbit_grpc_protos::kInvalidFunctionId &&
                         function_id == draw_data.highlighted_function_id;
 
-  static const Color kHighlightColor(100, 181, 246, 255);
-  Color color = is_highlighted ? kHighlightColor : GetTimerColor(current_timer_info, is_selected);
+  Color color = GetTimerColor(current_timer_info, is_selected, is_highlighted);
 
   bool is_visible_width = elapsed_us * draw_data.inv_time_window * draw_data.canvas->GetWidth() > 1;
 

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -98,7 +98,7 @@ class TimerTrack : public Track {
     return true;
   }
   [[nodiscard]] virtual Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
-                                            bool is_selected) const = 0;
+                                            bool is_selected, bool is_highlighted) const = 0;
   [[nodiscard]] virtual bool TimerFilter(
       const orbit_client_protos::TimerInfo& /*timer_info*/) const {
     return true;
@@ -124,6 +124,8 @@ class TimerTrack : public Track {
   [[nodiscard]] virtual std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const;
   float GetHeight() const override;
   float box_height_ = 0.0f;
+
+  static const Color kHighlightColor;
 
   OrbitApp* app_ = nullptr;
 };


### PR DESCRIPTION
After adding frametrack, when clicking the corresponding function in the live tab or the corresponding function calls in the capture window, the frametrack is also highlighted. This defeats the purpose of the frametrack colors (i.e., indicating long frames) and the selection should not influence the frametrack.

With this change, we disable the highlighting for the frametrack. More specifically:
- When clicking a function in live tab or a function call in the capture window, the color of frametrack will not be affected;
- When clicking the frametrack, the frametrack will not be highlighted, but the other function calls with the same function id in the capture window and the function in the live tab will still be highlighted.

Bug: http://b/179976757
Test: 1) create a frametrack for a function; 2) select the function in the live view, see the corresponding function calls in the thread tracks are highlighted but the frametrack is not affected; 3) select the frametrack, see the corresponding function calls in the thread tracks and the function in the live tab are highlighted, but the frametrack is not affected.
