### PR TITLE
Erase TimeGraph->GetBatcher() dependence

### DIFF
--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -37,8 +37,8 @@ AsyncTrack::AsyncTrack(TimeGraph* time_graph, const std::string& name, OrbitApp*
   SetLabel(name);
 }
 
-[[nodiscard]] std::string AsyncTrack::GetBoxTooltip(PickingId id) const {
-  const TextBox* text_box = time_graph_->GetBatcher().GetTextBox(id);
+[[nodiscard]] std::string AsyncTrack::GetBoxTooltip(const Batcher& batcher, PickingId id) const {
+  const TextBox* text_box = batcher.GetTextBox(id);
   if (text_box == nullptr) return "";
   auto* manual_inst_manager = app_->GetManualInstrumentationManager();
   TimerInfo timer_info = text_box->GetTimerInfo();

--- a/src/OrbitGl/AsyncTrack.h
+++ b/src/OrbitGl/AsyncTrack.h
@@ -28,7 +28,7 @@ class AsyncTrack final : public TimerTrack {
                       CaptureData* capture_data);
 
   [[nodiscard]] Type GetType() const override { return kAsyncTrack; };
-  [[nodiscard]] std::string GetBoxTooltip(PickingId id) const override;
+  [[nodiscard]] std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const override;
   [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllSerializableChains() const override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
   void UpdateBoxHeight() override;

--- a/src/OrbitGl/Batcher.cpp
+++ b/src/OrbitGl/Batcher.cpp
@@ -302,8 +302,8 @@ PickingUserData* Batcher::GetUserData(PickingId id) {
   return const_cast<PickingUserData*>(static_cast<const Batcher*>(this)->GetUserData(id));
 }
 
-const TextBox* Batcher::GetTextBox(PickingId id) {
-  PickingUserData* data = GetUserData(id);
+const TextBox* Batcher::GetTextBox(PickingId id) const {
+  const PickingUserData* data = GetUserData(id);
 
   if (data && data->text_box_) {
     return data->text_box_;

--- a/src/OrbitGl/Batcher.h
+++ b/src/OrbitGl/Batcher.h
@@ -164,13 +164,13 @@ class Batcher {
   void ResetElements();
   void StartNewFrame();
 
-  [[nodiscard]] PickingManager* GetPickingManager() { return picking_manager_; }
+  [[nodiscard]] PickingManager* GetPickingManager() const { return picking_manager_; }
   void SetPickingManager(PickingManager* picking_manager) { picking_manager_ = picking_manager; }
 
   [[nodiscard]] const PickingUserData* GetUserData(PickingId id) const;
   [[nodiscard]] PickingUserData* GetUserData(PickingId id);
 
-  [[nodiscard]] const TextBox* GetTextBox(PickingId id);
+  [[nodiscard]] const TextBox* GetTextBox(PickingId id) const;
 
   static constexpr uint32_t kNumArcSides = 16;
 

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -5,6 +5,7 @@
 #ifndef ORBIT_GL_CAPTURE_VIEW_ELEMENT_H_
 #define ORBIT_GL_CAPTURE_VIEW_ELEMENT_H_
 
+#include "Batcher.h"
 #include "PickingManager.h"
 
 class TimeGraph;
@@ -20,7 +21,7 @@ class CaptureViewElement : public Pickable {
     canvas_ = canvas;
   }
 
-  virtual void UpdatePrimitives(uint64_t /*min_tick*/, uint64_t /*max_tick*/,
+  virtual void UpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/, uint64_t /*max_tick*/,
                                 PickingMode /*picking_mode*/, float /*z_offset*/ = 0){};
 
   void SetTimeGraph(TimeGraph* timegraph) { time_graph_ = timegraph; }

--- a/src/OrbitGl/EventTrack.h
+++ b/src/OrbitGl/EventTrack.h
@@ -29,8 +29,8 @@ class EventTrack : public ThreadBar {
   std::string GetTooltip() const override;
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
-  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode,
-                        float z_offset = 0) override;
+  void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                        PickingMode picking_mode, float z_offset = 0) override;
 
   void OnPick(int x, int y) override;
   void OnRelease() override;
@@ -46,7 +46,7 @@ class EventTrack : public ThreadBar {
                                                       int max_line_length = 80, int max_lines = 20,
                                                       int bottom_n_lines = 5) const;
 
-  [[nodiscard]] std::string GetSampleTooltip(PickingId id) const;
+  [[nodiscard]] std::string GetSampleTooltip(const Batcher& batcher, PickingId id) const;
 
   Color color_;
 };

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -199,8 +199,8 @@ std::string FrameTrack::GetTooltip() const {
       GetPrettyTime(absl::Nanoseconds(stats_.average_time_ns())));
 }
 
-std::string FrameTrack::GetBoxTooltip(PickingId id) const {
-  const TextBox* text_box = time_graph_->GetBatcher().GetTextBox(id);
+std::string FrameTrack::GetBoxTooltip(const Batcher& batcher, PickingId id) const {
+  const TextBox* text_box = batcher.GetTextBox(id);
   if (!text_box) {
     return "";
   }
@@ -229,7 +229,6 @@ void FrameTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset
   const Color kWhiteColor(255, 255, 255, 255);
   const Color kBlackColor(0, 0, 0, 255);
 
-  Batcher* batcher = &time_graph_->GetBatcher();
   float y = pos_[1] - GetMaximumBoxHeight() + GetAverageBoxHeight();
   float x = pos_[0];
   Vec2 from(x, y);
@@ -245,9 +244,10 @@ void FrameTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset
   Vec2 white_text_box_position(pos_[0] + layout.GetRightMargin(),
                                y - layout.GetTextBoxHeight() / 2.f);
 
-  batcher->AddLine(from, from + Vec2(layout.GetRightMargin() / 2.f, 0), text_z, kWhiteColor);
-  batcher->AddLine(Vec2(white_text_box_position[0] + white_text_box_size[0], y), to, text_z,
-                   kWhiteColor);
+  Batcher* ui_batcher = canvas->GetBatcher();
+  ui_batcher->AddLine(from, from + Vec2(layout.GetRightMargin() / 2.f, 0), text_z, kWhiteColor);
+  ui_batcher->AddLine(Vec2(white_text_box_position[0] + white_text_box_size[0], y), to, text_z,
+                      kWhiteColor);
 
   canvas->GetTextRenderer().AddText(label.c_str(), white_text_box_position[0],
                                     white_text_box_position[1] + layout.GetTextOffset(), text_z,

--- a/src/OrbitGl/FrameTrack.h
+++ b/src/OrbitGl/FrameTrack.h
@@ -42,7 +42,7 @@ class FrameTrack : public TimerTrack {
   void SetTimesliceText(const orbit_client_protos::TimerInfo& timer, double elapsed_us, float min_x,
                         float z_offset, TextBox* text_box) override;
   [[nodiscard]] std::string GetTooltip() const override;
-  [[nodiscard]] std::string GetBoxTooltip(PickingId id) const override;
+  [[nodiscard]] std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const override;
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
 

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -260,8 +260,8 @@ const TextBox* GpuTrack::GetRight(const TextBox* text_box) const {
   return nullptr;
 }
 
-std::string GpuTrack::GetBoxTooltip(PickingId id) const {
-  const TextBox* text_box = time_graph_->GetBatcher().GetTextBox(id);
+std::string GpuTrack::GetBoxTooltip(const Batcher& batcher, PickingId id) const {
+  const TextBox* text_box = batcher.GetTextBox(id);
   if (!text_box || text_box->GetTimerInfo().type() == TimerInfo::kCoreActivity) {
     return "";
   }

--- a/src/OrbitGl/GpuTrack.h
+++ b/src/OrbitGl/GpuTrack.h
@@ -59,7 +59,7 @@ class GpuTrack : public TimerTrack {
   [[nodiscard]] bool TimerFilter(const orbit_client_protos::TimerInfo& timer) const override;
   void SetTimesliceText(const orbit_client_protos::TimerInfo& timer, double elapsed_us, float min_x,
                         float z_offset, TextBox* text_box) override;
-  [[nodiscard]] std::string GetBoxTooltip(PickingId id) const override;
+  [[nodiscard]] std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const override;
 
  private:
   uint64_t timeline_hash_;

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -21,9 +21,8 @@ GraphTrack::GraphTrack(TimeGraph* time_graph, std::string name, CaptureData* cap
   SetLabel(name);
 }
 
-void GraphTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode,
-                                  float z_offset) {
-  Batcher* batcher = &time_graph_->GetBatcher();
+void GraphTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                                  PickingMode picking_mode, float z_offset) {
   GlCanvas* canvas = time_graph_->GetCanvas();
 
   float track_width = canvas->GetWorldWidth();
@@ -130,14 +129,14 @@ void GraphTrack::DrawLabel(GlCanvas* canvas, Vec2 target_pos, const std::string&
   Box arrow_text_box(text_box_position, text_box_size, z);
   Vec3 arrow_extra_point(target_pos[0], target_pos[1], z);
 
-  Batcher* batcher = canvas->GetBatcher();
-  batcher->AddBox(arrow_text_box, font_color);
+  Batcher* ui_batcher = canvas->GetBatcher();
+  ui_batcher->AddBox(arrow_text_box, font_color);
   if (arrow_is_left_directed) {
-    batcher->AddTriangle(
+    ui_batcher->AddTriangle(
         Triangle(arrow_text_box.vertices[0], arrow_text_box.vertices[1], arrow_extra_point),
         font_color);
   } else {
-    batcher->AddTriangle(
+    ui_batcher->AddTriangle(
         Triangle(arrow_text_box.vertices[2], arrow_text_box.vertices[3], arrow_extra_point),
         font_color);
   }

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -26,8 +26,8 @@ class GraphTrack : public Track {
   explicit GraphTrack(TimeGraph* time_graph, std::string name, CaptureData* capture_data);
   [[nodiscard]] Type GetType() const override { return kGraphTrack; }
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
-  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode,
-                        float z_offset = 0) override;
+  void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                        PickingMode picking_mode, float z_offset = 0) override;
   [[nodiscard]] float GetHeight() const override;
   void AddValue(double value, uint64_t time);
   [[nodiscard]] std::optional<std::pair<uint64_t, double> > GetPreviousValueAndTime(

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -79,8 +79,8 @@ void SchedulerTrack::UpdateBoxHeight() {
   box_height_ = time_graph_->GetLayout().GetTextCoresHeight();
 }
 
-std::string SchedulerTrack::GetBoxTooltip(PickingId id) const {
-  const TextBox* text_box = time_graph_->GetBatcher().GetTextBox(id);
+std::string SchedulerTrack::GetBoxTooltip(const Batcher& batcher, PickingId id) const {
+  const TextBox* text_box = batcher.GetTextBox(id);
   if (!text_box) {
     return "";
   }

--- a/src/OrbitGl/SchedulerTrack.h
+++ b/src/OrbitGl/SchedulerTrack.h
@@ -36,7 +36,7 @@ class SchedulerTrack final : public TimerTrack {
   [[nodiscard]] bool IsTimerActive(const orbit_client_protos::TimerInfo& timer_info) const override;
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
                                     bool is_selected) const override;
-  [[nodiscard]] std::string GetBoxTooltip(PickingId id) const override;
+  [[nodiscard]] std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const override;
 
  private:
   uint32_t num_cores_;

--- a/src/OrbitGl/ThreadStateTrack.h
+++ b/src/OrbitGl/ThreadStateTrack.h
@@ -27,15 +27,15 @@ class ThreadStateTrack final : public ThreadBar {
                             ThreadID thread_id);
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) override;
-  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode,
-                        float z_offset) override;
+  void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                        PickingMode picking_mode, float z_offset) override;
 
   void OnPick(int x, int y) override;
 
   [[nodiscard]] bool IsEmpty() const override;
 
  private:
-  std::string GetThreadStateSliceTooltip(PickingId id) const;
+  std::string GetThreadStateSliceTooltip(Batcher* batcher, PickingId id) const;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -98,8 +98,8 @@ const TextBox* ThreadTrack::GetRight(const TextBox* text_box) const {
   return nullptr;
 }
 
-std::string ThreadTrack::GetBoxTooltip(PickingId id) const {
-  const TextBox* text_box = time_graph_->GetBatcher().GetTextBox(id);
+std::string ThreadTrack::GetBoxTooltip(const Batcher& batcher, PickingId id) const {
+  const TextBox* text_box = batcher.GetTextBox(id);
   if (!text_box || text_box->GetTimerInfo().type() == TimerInfo::kCoreActivity) {
     return "";
   }
@@ -270,21 +270,21 @@ void ThreadTrack::OnPick(int x, int y) {
   app_->set_selected_thread_id(thread_id_);
 }
 
-void ThreadTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode,
-                                   float z_offset) {
+void ThreadTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                                   PickingMode picking_mode, float z_offset) {
   UpdatePositionOfSubtracks();
 
   if (!thread_state_track_->IsEmpty()) {
-    thread_state_track_->UpdatePrimitives(min_tick, max_tick, picking_mode, z_offset);
+    thread_state_track_->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
   }
   if (!event_track_->IsEmpty()) {
-    event_track_->UpdatePrimitives(min_tick, max_tick, picking_mode, z_offset);
+    event_track_->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
   }
   if (!tracepoint_track_->IsEmpty()) {
-    tracepoint_track_->UpdatePrimitives(min_tick, max_tick, picking_mode, z_offset);
+    tracepoint_track_->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
   }
 
-  TimerTrack::UpdatePrimitives(min_tick, max_tick, picking_mode, z_offset);
+  TimerTrack::UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
 }
 
 void ThreadTrack::SetTrackColor(Color color) {

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -47,8 +47,8 @@ class ThreadTrack final : public TimerTrack {
   void SetTrackColor(Color color);
   [[nodiscard]] bool IsEmpty() const override;
 
-  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode,
-                        float z_offset = 0) override;
+  void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                        PickingMode picking_mode, float z_offset = 0) override;
 
  protected:
   [[nodiscard]] bool IsTimerActive(const orbit_client_protos::TimerInfo& timer) const override;
@@ -58,7 +58,7 @@ class ThreadTrack final : public TimerTrack {
                                     bool is_selected) const override;
   void SetTimesliceText(const orbit_client_protos::TimerInfo& timer, double elapsed_us, float min_x,
                         float z_offset, TextBox* text_box) override;
-  [[nodiscard]] std::string GetBoxTooltip(PickingId id) const override;
+  [[nodiscard]] std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const override;
 
   [[nodiscard]] float GetHeight() const override;
   [[nodiscard]] float GetHeaderHeight() const override;

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -538,6 +538,7 @@ void TimeGraph::NeedsUpdate() {
   needs_redraw_ = true;
 }
 
+// UpdatePrimitives updates all the drawable track timers in the timegraph's batcher
 void TimeGraph::UpdatePrimitives(PickingMode picking_mode) {
   ORBIT_SCOPE_FUNCTION;
   CHECK(app_->GetStringManager() != nullptr);
@@ -560,7 +561,7 @@ void TimeGraph::UpdatePrimitives(PickingMode picking_mode) {
 
   track_manager_->SortTracks();
   track_manager_->UpdateMovingTrackSorting();
-  track_manager_->UpdateTracks(min_tick, max_tick, picking_mode);
+  track_manager_->UpdateTracks(&batcher_, min_tick, max_tick, picking_mode);
 
   needs_update_primitives_ = false;
 }

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -196,12 +196,13 @@ void TimerTrack::DrawTimer(TextBox* prev_text_box, TextBox* current_text_box,
         world_timer_y, z);
     batcher->AddShadedTrapezium(
         top_left, bottom_left, bottom_right, top_right, color,
-        std::make_unique<PickingUserData>(current_text_box,
-                                          [&](PickingId id) { return this->GetBoxTooltip(id); }));
+        std::make_unique<PickingUserData>(current_text_box, [&, batcher](PickingId id) {
+          return this->GetBoxTooltip(*batcher, id);
+        }));
 
   } else {
     auto user_data = std::make_unique<PickingUserData>(
-        current_text_box, [&](PickingId id) { return this->GetBoxTooltip(id); });
+        current_text_box, [&, batcher](PickingId id) { return this->GetBoxTooltip(*batcher, id); });
 
     WorldXInfo world_x_info =
         ToWorldX(start_us, end_us, inv_time_window, world_start_x, world_width);
@@ -223,11 +224,10 @@ void TimerTrack::DrawTimer(TextBox* prev_text_box, TextBox* current_text_box,
   }
 }
 
-void TimerTrack::UpdatePrimitives(uint64_t min_tick, uint64_t max_tick,
+void TimerTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                                   PickingMode /*picking_mode*/, float z_offset) {
   UpdateBoxHeight();
 
-  Batcher* batcher = &time_graph_->GetBatcher();
   GlCanvas* canvas = time_graph_->GetCanvas();
 
   float world_start_x = canvas->GetWorldTopLeftX();
@@ -405,7 +405,9 @@ std::vector<std::shared_ptr<TimerChain>> TimerTrack::GetAllSerializableChains() 
 
 bool TimerTrack::IsEmpty() const { return GetNumTimers() == 0; }
 
-std::string TimerTrack::GetBoxTooltip(PickingId /*id*/) const { return ""; }
+std::string TimerTrack::GetBoxTooltip(const Batcher& /*batcher*/, PickingId /*id*/) const {
+  return "";
+}
 
 float TimerTrack::GetHeaderHeight() const {
   const TimeGraphLayout& layout = time_graph_->GetLayout();

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -40,8 +40,8 @@ class TimerTrack : public Track {
   [[nodiscard]] std::string GetTooltip() const override;
 
   // Track
-  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode /*picking_mode*/,
-                        float z_offset = 0) override;
+  void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                        PickingMode /*picking_mode*/, float z_offset = 0) override;
   [[nodiscard]] Type GetType() const override { return kTimerTrack; }
 
   [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetTimers() const override;
@@ -104,7 +104,7 @@ class TimerTrack : public Track {
   mutable absl::Mutex mutex_;
   std::map<int, std::shared_ptr<TimerChain>> timers_;
 
-  [[nodiscard]] virtual std::string GetBoxTooltip(PickingId id) const;
+  [[nodiscard]] virtual std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const;
   float GetHeight() const override;
   float box_height_ = 0.0f;
 

--- a/src/OrbitGl/TracepointTrack.h
+++ b/src/OrbitGl/TracepointTrack.h
@@ -20,15 +20,15 @@ class TracepointTrack : public ThreadBar {
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
 
-  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode,
-                        float z_offset = 0) override;
+  void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                        PickingMode picking_mode, float z_offset = 0) override;
 
   [[nodiscard]] bool IsEmpty() const override;
 
   void SetColor(const Color& color) { color_ = color; }
 
  private:
-  std::string GetTracepointTooltip(PickingId id) const;
+  std::string GetTracepointTooltip(Batcher* batcher, PickingId id) const;
 
   Color color_;
 };

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -85,8 +85,7 @@ void Track::DrawTriangleFan(Batcher* batcher, const std::vector<Vec2>& points, c
 void Track::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
   CaptureViewElement::Draw(canvas, picking_mode, z_offset);
 
-  Batcher* batcher = canvas->GetBatcher();
-
+  Batcher* ui_batcher = canvas->GetBatcher();
   const TimeGraphLayout& layout = time_graph_->GetLayout();
   const bool picking = picking_mode != PickingMode::kNone;
 
@@ -104,11 +103,11 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
   if (!picking) {
     if (IsPinned()) {
       Box box(Vec2(x0, y0), Vec2(size_[0], size_[1]), track_z);
-      batcher->AddBox(box, kBackgroundColor, shared_from_this());
+      ui_batcher->AddBox(box, kBackgroundColor, shared_from_this());
     }
     if (layout.GetDrawTrackBackground()) {
       Box box(Vec2(x0, y0 + top_margin), Vec2(size_[0], -size_[1] - top_margin), track_z);
-      batcher->AddBox(box, kBackgroundColor, shared_from_this());
+      ui_batcher->AddBox(box, kBackgroundColor, shared_from_this());
     }
   }
 
@@ -120,7 +119,7 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
   float tab_x0 = x0 + layout.GetTrackTabOffset();
 
   Box box(Vec2(tab_x0, y0), Vec2(label_width, label_height), track_z);
-  batcher->AddBox(box, kBackgroundColor, shared_from_this());
+  ui_batcher->AddBox(box, kBackgroundColor, shared_from_this());
 
   // Draw rounded corners.
   if (!picking) {
@@ -136,12 +135,17 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
     Vec2 end_bottom(x1 - right_margin, y1);
     Vec2 end_top(x1 - right_margin, y0 + top_margin);
 
-    DrawTriangleFan(batcher, rounded_corner, bottom_left, GlCanvas::kBackgroundColor, 0, track_z);
-    DrawTriangleFan(batcher, rounded_corner, bottom_right, kBackgroundColor, 0, track_z);
-    DrawTriangleFan(batcher, rounded_corner, top_right, GlCanvas::kBackgroundColor, 180.f, track_z);
-    DrawTriangleFan(batcher, rounded_corner, top_left, GlCanvas::kBackgroundColor, -90.f, track_z);
-    DrawTriangleFan(batcher, rounded_corner, end_bottom, GlCanvas::kBackgroundColor, 90.f, track_z);
-    DrawTriangleFan(batcher, rounded_corner, end_top, GlCanvas::kBackgroundColor, 180.f, track_z);
+    DrawTriangleFan(ui_batcher, rounded_corner, bottom_left, GlCanvas::kBackgroundColor, 0,
+                    track_z);
+    DrawTriangleFan(ui_batcher, rounded_corner, bottom_right, kBackgroundColor, 0, track_z);
+    DrawTriangleFan(ui_batcher, rounded_corner, top_right, GlCanvas::kBackgroundColor, 180.f,
+                    track_z);
+    DrawTriangleFan(ui_batcher, rounded_corner, top_left, GlCanvas::kBackgroundColor, -90.f,
+                    track_z);
+    DrawTriangleFan(ui_batcher, rounded_corner, end_bottom, GlCanvas::kBackgroundColor, 90.f,
+                    track_z);
+    DrawTriangleFan(ui_batcher, rounded_corner, end_top, GlCanvas::kBackgroundColor, 180.f,
+                    track_z);
   }
 
   // Collapse toggle state management.
@@ -174,8 +178,8 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
   }
 }
 
-void Track::UpdatePrimitives(uint64_t /*t_min*/, uint64_t /*t_max*/, PickingMode /*  picking_mode*/,
-                             float /*z_offset*/) {}
+void Track::UpdatePrimitives(Batcher* /*batcher*/, uint64_t /*t_min*/, uint64_t /*t_max*/,
+                             PickingMode /*  picking_mode*/, float /*z_offset*/) {}
 
 void Track::SetPinned(bool value) { pinned_ = value; }
 

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -48,8 +48,8 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
 
-  void UpdatePrimitives(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode,
-                        float z_offset = 0) override;
+  void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                        PickingMode picking_mode, float z_offset = 0) override;
   void OnDrag(int x, int y) override;
 
   virtual void SetCaptureData(CaptureData* capture_data) { capture_data_ = capture_data; }

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -282,7 +282,8 @@ int TrackManager::FindMovingTrackIndex() {
   return -1;
 }
 
-void TrackManager::UpdateTracks(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode) {
+void TrackManager::UpdateTracks(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                                PickingMode picking_mode) {
   TimeGraphLayout layout = time_graph_->GetLayout();
 
   // Make sure track tab fits in the viewport.
@@ -301,7 +302,7 @@ void TrackManager::UpdateTracks(uint64_t min_tick, uint64_t max_tick, PickingMod
                                             layout.GetTopMargin() -
                                             layout.GetSchedulerTrackOffset());
     }
-    track->UpdatePrimitives(min_tick, max_tick, picking_mode, z_offset);
+    track->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
     const float height = (track->GetHeight() + layout.GetSpaceBetweenTracks());
     current_y -= height;
     pinned_tracks_height += height;
@@ -317,7 +318,7 @@ void TrackManager::UpdateTracks(uint64_t min_tick, uint64_t max_tick, PickingMod
     if (!track->IsMoving()) {
       track->SetPos(track->GetPos()[0], current_y);
     }
-    track->UpdatePrimitives(min_tick, max_tick, picking_mode, z_offset);
+    track->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
     current_y -= (track->GetHeight() + layout.GetSpaceBetweenTracks());
   }
 

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -51,7 +51,8 @@ class TrackManager {
   void SortTracks();
   void SetFilter(const std::string& filter);
 
-  void UpdateTracks(uint64_t min_tick, uint64_t max_tick, PickingMode picking_mode);
+  void UpdateTracks(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                    PickingMode picking_mode);
   [[nodiscard]] float GetTracksTotalHeight() const { return tracks_total_height_; }
 
   SchedulerTrack* GetOrCreateSchedulerTrack();

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -24,7 +24,7 @@ TriangleToggle::TriangleToggle(State initial_state, StateChangeHandler handler,
 void TriangleToggle::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
   CaptureViewElement::Draw(canvas, picking_mode, z_offset);
 
-  Batcher* batcher = canvas->GetBatcher();
+  Batcher* ui_batcher = canvas->GetBatcher();
   const float z = GlCanvas::kZValueTrack + z_offset;
 
   const bool picking = picking_mode != PickingMode::kNone;
@@ -48,14 +48,14 @@ void TriangleToggle::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_of
       triangle = Triangle(position + Vec3(half_w, half_h, z), position + Vec3(-half_w, half_h, z),
                           position + Vec3(0.f, -half_w, z));
     }
-    batcher->AddTriangle(triangle, color, shared_from_this());
+    ui_batcher->AddTriangle(triangle, color, shared_from_this());
   } else {
     // When picking, draw a big square for easier picking.
     float original_width = 2 * half_w;
     float large_width = 2 * original_width;
     Box box(Vec2(pos_[0] - original_width, pos_[1] - original_width),
             Vec2(large_width, large_width), z);
-    batcher->AddBox(box, color, shared_from_this());
+    ui_batcher->AddBox(box, color, shared_from_this());
   }
 }
 


### PR DESCRIPTION
Part of http://b/176086740.

We are erasing TimeGraph->GetBatcher() dependence by adding the
timegraph-batcher as a parameter of UpdatePrimitives functions.

Also I included a few renamings to differentiate it with the UI-batcher
used in Draw functions. We should use also the batcher from the 
timegraph to draw the tracks themselves, but this will come in another PR.

Note that we are changing the batcher used in the FrameTrack to be consistent.

Test: Load a capture