### PR TITLE
Fix when open disassembly while capturing.

### DIFF
--- a/src/OrbitClientModel/include/OrbitClientModel/CaptureData.h
+++ b/src/OrbitClientModel/include/OrbitClientModel/CaptureData.h
@@ -198,6 +198,10 @@ class CaptureData {
 
   [[nodiscard]] const ProcessData* process() const { return &process_; }
 
+  [[nodiscard]] bool has_post_processed_sampling_data() const {
+    return post_processed_sampling_data_.has_value();
+  }
+
   [[nodiscard]] const PostProcessedSamplingData& post_processed_sampling_data() const {
     CHECK(post_processed_sampling_data_.has_value());
     return post_processed_sampling_data_.value();

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -533,7 +533,7 @@ void OrbitApp::Disassemble(int32_t pid, const FunctionInfo& function) {
     Disassembler disasm;
     disasm.AddLine(absl::StrFormat("asm: /* %s */", function_utils::GetDisplayName(function)));
     disasm.Disassemble(memory.data(), memory.size(), absolute_address, is_64_bit);
-    if (!sampling_report_) {
+    if (!HasCaptureData() || !GetCaptureData().has_post_processed_sampling_data()) {
       DisassemblyReport empty_report(disasm);
       SendDisassemblyToUi(disasm.GetResult(), std::move(empty_report));
       return;
@@ -1658,12 +1658,14 @@ void OrbitApp::UpdateAfterCaptureCleared() {
   PostProcessedSamplingData empty_post_processed_sampling_data;
   absl::flat_hash_map<CallstackID, std::shared_ptr<CallStack>> empty_unique_callstacks;
 
-  SetSamplingReport(empty_post_processed_sampling_data, empty_unique_callstacks);
+  if (sampling_report_ != nullptr) {
+    SetSamplingReport(empty_post_processed_sampling_data, empty_unique_callstacks);
+  }
   ClearTopDownView();
   ClearSelectionTopDownView();
   ClearBottomUpView();
   ClearSelectionBottomUpView();
-  if (selection_report_) {
+  if (selection_report_ != nullptr) {
     SetSelectionReport(std::move(empty_post_processed_sampling_data), empty_unique_callstacks,
                        false);
   }


### PR DESCRIPTION
App's `sampling_report_` and `capture_data_` are tightly coupled
with both containing the post processed data.
While capturing we end up in having a non-null `sampling_report_`,
that does not yet have any data. In this situation `capture_data_`
does not contain any post processed data at all.

While a larger refactoring is needed, this change ensures for the
current situation two things:
1. Whenever sampling_report_ is not nullptr, capture_data_ contains
post processed sampling data.
2. When accessing post processed sampling data from CaptureData,
we check if it is present directly, rather then checking if there
is a sampling report.

Bug: http://b/179902321
Test: Open disassembly while taking the first capture does not crash.