### PR TITLE
Fix scheduler track dragging

### DIFF
--- a/contrib/automation_tests/orbit_tracks.py
+++ b/contrib/automation_tests/orbit_tracks.py
@@ -23,6 +23,7 @@ def main(argv):
         SelectTrack(track_index=5),
         DeselectTrack(),
         SelectTrack(track_index=0, expect_failure=True),   # Scheduler track cannot be selected
+        MoveTrack(track_index=0, new_index=2, expected_new_index=0),    # Scheduler track cannot be dragged
         MoveTrack(track_index=5, new_index=0),
         MoveTrack(track_index=0, new_index=3),
         MoveTrack(track_index=3, new_index=5),

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -37,7 +37,7 @@ class CaptureViewElement : public Pickable {
   void OnPick(int x, int y) override;
   void OnRelease() override;
   void OnDrag(int x, int y) override;
-  [[nodiscard]] bool Draggable() override { return true; }
+  [[nodiscard]] bool Draggable() const override { return true; }
 
  protected:
   GlCanvas* canvas_ = nullptr;

--- a/src/OrbitGl/GlSlider.h
+++ b/src/OrbitGl/GlSlider.h
@@ -20,7 +20,7 @@ class GlSlider : public Pickable, public std::enable_shared_from_this<GlSlider> 
  public:
   ~GlSlider() override = default;
 
-  [[nodiscard]] bool Draggable() override { return true; }
+  [[nodiscard]] bool Draggable() const override { return true; }
   virtual void Draw(GlCanvas* canvas) = 0;
 
   void SetCanvas(GlCanvas* canvas) { canvas_ = canvas; }

--- a/src/OrbitGl/PickingManager.h
+++ b/src/OrbitGl/PickingManager.h
@@ -29,7 +29,7 @@ class Pickable {
   virtual void OnPick(int x, int y) = 0;
   virtual void OnDrag(int /*x*/, int /*y*/) {}
   virtual void OnRelease() {}
-  [[nodiscard]] virtual bool Draggable() { return false; }
+  [[nodiscard]] virtual bool Draggable() const { return false; }
   [[nodiscard]] virtual std::string GetTooltip() const { return ""; }
 };
 

--- a/src/OrbitGl/PickingManagerTest.cpp
+++ b/src/OrbitGl/PickingManagerTest.cpp
@@ -11,7 +11,7 @@
 #include "CoreUtils.h"
 
 class UndraggableMock : public PickableMock {
-  bool Draggable() override { return false; }
+  bool Draggable() const override { return false; }
 };
 
 TEST(PickingManager, PickableMock) {

--- a/src/OrbitGl/PickingManagerTest.h
+++ b/src/OrbitGl/PickingManagerTest.h
@@ -24,7 +24,7 @@ class PickableMock : public Pickable {
     picked_ = false;
   }
 
-  bool Draggable() override { return true; }
+  bool Draggable() const override { return true; }
 
   bool picked_ = false;
   bool dragging_ = false;

--- a/src/OrbitGl/SchedulerTrack.h
+++ b/src/OrbitGl/SchedulerTrack.h
@@ -32,6 +32,8 @@ class SchedulerTrack final : public TimerTrack {
   [[nodiscard]] float GetYFromTimer(
       const orbit_client_protos::TimerInfo& timer_info) const override;
 
+  [[nodiscard]] bool Draggable() const override { return false; }
+
  protected:
   [[nodiscard]] bool IsTimerActive(const orbit_client_protos::TimerInfo& timer_info) const override;
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,


### PR DESCRIPTION
Changing the base class of Track resulted in the Scheduler track being draggable, which is not intended.

To reproduce:
Take a capture, drag the scheduler track. This should not be possible.