### PR TITLE
Introducing Future<ErrorMessageOr<T>>::ThenIfSuccess

### DIFF
--- a/src/OrbitBase/ImmediateExecutorTest.cpp
+++ b/src/OrbitBase/ImmediateExecutorTest.cpp
@@ -41,4 +41,77 @@ TEST(ImmediateExecutor, ChainedTaskedShouldBeCalledImmediately) {
   EXPECT_TRUE(chained_future.IsFinished());
 }
 
+TEST(ImmediateExecutor, ScheduleAfterIfSuccessShortCircuitOnErrorVoid) {
+  ImmediateExecutor executor{};
+  bool called = false;
+  Promise<ErrorMessageOr<void>> promise{};
+  auto future = promise.GetFuture();
+  auto chained_future = executor.ScheduleAfterIfSuccess(future, [&called]() { called = true; });
+  EXPECT_FALSE(called);
+  EXPECT_FALSE(chained_future.IsFinished());
+
+  constexpr const char* const kErrorMessage{"Error"};
+  promise.SetResult(ErrorMessage{kErrorMessage});
+  EXPECT_FALSE(called);
+  EXPECT_TRUE(chained_future.IsFinished());
+  EXPECT_TRUE(chained_future.Get().has_error());
+  EXPECT_EQ(chained_future.Get().error().message(), kErrorMessage);
+}
+
+TEST(ImmediateExecutor, ScheduleAfterIfSuccessShortCircuitOnErrorInt) {
+  ImmediateExecutor executor{};
+  bool called = false;
+  Promise<ErrorMessageOr<int>> promise{};
+  auto future = promise.GetFuture();
+  auto chained_future = executor.ScheduleAfterIfSuccess(future, [&called](int value) {
+    EXPECT_EQ(value, 42);
+    called = true;
+    return 1 + value;
+  });
+  EXPECT_FALSE(called);
+  EXPECT_FALSE(chained_future.IsFinished());
+
+  constexpr const char* const kErrorMessage{"Error"};
+  promise.SetResult(ErrorMessage{kErrorMessage});
+  EXPECT_FALSE(called);
+  EXPECT_TRUE(chained_future.IsFinished());
+  EXPECT_TRUE(chained_future.Get().has_error());
+  EXPECT_EQ(chained_future.Get().error().message(), kErrorMessage);
+}
+
+TEST(ImmediateExecutor, ScheduleAfterIfSuccessCallOnSuccessVoid) {
+  ImmediateExecutor executor{};
+  bool called = false;
+  Promise<ErrorMessageOr<void>> promise{};
+  auto future = promise.GetFuture();
+  auto chained_future = executor.ScheduleAfterIfSuccess(future, [&called]() { called = true; });
+  EXPECT_FALSE(called);
+  EXPECT_FALSE(chained_future.IsFinished());
+
+  promise.SetResult(outcome::success());
+  EXPECT_TRUE(called);
+  EXPECT_TRUE(chained_future.IsFinished());
+  EXPECT_FALSE(chained_future.Get().has_error());
+}
+
+TEST(ImmediateExecutor, ScheduleAfterIfSuccessCallOnSuccessInt) {
+  ImmediateExecutor executor{};
+  bool called = false;
+  Promise<ErrorMessageOr<int>> promise{};
+  auto future = promise.GetFuture();
+  auto chained_future = executor.ScheduleAfterIfSuccess(future, [&called](int value) {
+    EXPECT_EQ(value, 42);
+    called = true;
+    return 1 + value;
+  });
+  EXPECT_FALSE(called);
+  EXPECT_FALSE(chained_future.IsFinished());
+
+  promise.SetResult(42);
+  EXPECT_TRUE(called);
+  EXPECT_TRUE(chained_future.IsFinished());
+  EXPECT_FALSE(chained_future.Get().has_error());
+  EXPECT_EQ(chained_future.Get().value(), 43);
+}
+
 }  // namespace orbit_base

--- a/src/OrbitBase/include/OrbitBase/PromiseHelpers.h
+++ b/src/OrbitBase/include/OrbitBase/PromiseHelpers.h
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "OrbitBase/Promise.h"
+#include "OrbitBase/Result.h"
 
 namespace orbit_base {
 
@@ -109,6 +110,22 @@ struct ContinuationReturnType {
 template <typename Invocable>
 struct ContinuationReturnType<void, Invocable> {
   using Type = std::decay_t<decltype(std::declval<Invocable>()())>;
+};
+
+// This type trait helps to wrap a type into a ErrorMessageOr-wrapper, but won't do that if the type
+// is already a ErrorMessageOr.
+//
+// Examples:
+// EnsureWrappedInErrorMessageOr<int>::Type == ErrorMessageOr<int>
+// EnsureWrappedInErrorMessageOr<ErrorMessageOr<int>>::Type == ErrorMessageOr<int>
+template <typename T>
+struct EnsureWrappedInErrorMessageOr {
+  using Type = ErrorMessageOr<T>;
+};
+
+template <typename T>
+struct EnsureWrappedInErrorMessageOr<ErrorMessageOr<T>> {
+  using Type = ErrorMessageOr<T>;
 };
 
 }  // namespace orbit_base

--- a/src/OrbitBase/include/OrbitBase/SharedState.h
+++ b/src/OrbitBase/include/OrbitBase/SharedState.h
@@ -23,6 +23,8 @@ struct SharedState {
   absl::Mutex mutex;
   std::optional<T> result;
   std::vector<orbit_base::AnyInvocable<void(const T&)>> continuations;
+
+  [[nodiscard]] bool IsFinished() const { return result.has_value(); }
 };
 
 template <>
@@ -30,6 +32,8 @@ struct SharedState<void> {
   absl::Mutex mutex;
   bool finished = false;
   std::vector<orbit_base::AnyInvocable<void()>> continuations;
+
+  [[nodiscard]] bool IsFinished() const { return finished; }
 };
 
 }  // namespace orbit_base_internal


### PR DESCRIPTION
`ThenIfSuccess` allows to schedule a continuation that is only executed when the returned `ErrorMessageOr<T>` return type does not contain an error. In case of an error the continuation won't run and the error message will be returned immediately. That means the return type of `ThenIfSuccess` will be a future with `ErrorMessageOr<R>` as its value type, while the `R` is determined by the continuation.

Example:
```cpp
Future<ErrorMessageOr<std::filesystem::path>> file_path = LoadModule("/tmp/OrbitService");

Future<ErrorMessageOr<void>> result = file_path.ThenIfSuccess(main_thread_executor,
                                 [this](const std::filesystem::path& local_file_path) {
  LoadSymbols(local_file_path);
});
```

This allows to chain continuations that only need to take care of the happy path which leads to cleaner code.