### PR TITLE
Add retry to ssh tunnel connect

### DIFF
--- a/src/Service/OrbitService.cpp
+++ b/src/Service/OrbitService.cpp
@@ -28,8 +28,6 @@
 namespace orbit_service {
 
 static void PrintInstanceVersions() {
-  return;  // For investigation of b/179977813.
-
   {
     constexpr const char* kKernelVersionCommand = "uname -a";
     std::optional<std::string> version = orbit_base::ExecuteCommand(kKernelVersionCommand);


### PR DESCRIPTION
Orbit now retries to establish a ssh tunnel 3 times. There is a waiting
time of 500ms between each retry.

Also restores the OrbitService version logging.