### PR TITLE
Minor improvements for GPU timeline track labels

### DIFF
--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -158,6 +158,7 @@ target_sources(OrbitGlTests PRIVATE
                BatcherTest.cpp
                BlockChainTest.cpp
                GlUtilsTest.cpp
+               GpuTrackTest.cpp
                PickingManagerTest.cpp
                ScopedStatusTest.cpp
                SliderTest.cpp

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -36,30 +36,31 @@ constexpr const char* kCmdBufferString = "command buffer";
 namespace orbit_gl {
 
 std::string MapGpuTimelineToTrackLabel(std::string_view timeline) {
-  std::string label;
+  std::string queue_pretty_name;
+  std::string timeline_label(timeline);
   if (timeline.rfind("gfx", 0) == 0) {
-    if (timeline.find("_marker") != std::string::npos) {
-      return absl::StrFormat("Graphics queue debug markers (%s)", timeline);
-    }
-    return absl::StrFormat("Graphics queue (%s)", timeline);
+    queue_pretty_name = "Graphics queue";
+    timeline_label = absl::StrFormat(" (%s)", timeline);
   }
   if (timeline.rfind("sdma", 0) == 0) {
-    if (timeline.find("_marker") != std::string::npos) {
-      return absl::StrFormat("Transfer queue debug markers (%s)", timeline);
-    }
-    return absl::StrFormat("Transfer queue (%s)", timeline);
+    queue_pretty_name = "DMA queue";
+    timeline_label = absl::StrFormat(" (%s)", timeline);
   }
   if (timeline.rfind("comp", 0) == 0) {
-    if (timeline.find("_marker") != std::string::npos) {
-      return absl::StrFormat("Compute queue debug markers (%s)", timeline);
-    }
-    return absl::StrFormat("Compute queue (%s)", timeline);
+    queue_pretty_name = "Compute queue";
+    timeline_label = absl::StrFormat(" (%s)", timeline);
   }
-  // On AMD, this should not happen and we don't support tracepoints for
-  // other GPUs (at the moment). We return the timeline to make sure we
-  // at least display something. When we add support for other GPU
-  // tracepoints, this needs to be changed.
-  return std::string(timeline);
+  if (timeline.rfind("vce", 0) == 0) {
+    queue_pretty_name = "Video Coding Engine";
+    timeline_label = absl::StrFormat(" (%s)", timeline);
+  }
+  std::string debug_marker_label;
+  if (timeline.find("_marker") != std::string::npos) {
+    // Space at start is intentional as we want that space between the queue name
+    // and "debug markers". This makes constructing the string simpler.
+    debug_marker_label = " debug markers";
+  }
+  return absl::StrFormat("%s%s%s", queue_pretty_name, debug_marker_label, timeline_label);
 }
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/GpuTrackTest.cpp
+++ b/src/OrbitGl/GpuTrackTest.cpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+#include <gtest/gtest.h>
+
+#include "GpuTrack.h"
+
+using orbit_gl::MapGpuTimelineToTrackLabel;
+
+TEST(GpuTrack, MapGpuTimelineToTrackLabelMapsRegularQueuesCorrectly) {
+  EXPECT_EQ("Graphics queue (gfx)", MapGpuTimelineToTrackLabel("gfx"));
+
+  EXPECT_EQ("DMA queue (sdma0)", MapGpuTimelineToTrackLabel("sdma0"));
+  EXPECT_EQ("DMA queue (sdma1)", MapGpuTimelineToTrackLabel("sdma1"));
+
+  EXPECT_EQ("Compute queue (comp_1.0.0)", MapGpuTimelineToTrackLabel("comp_1.0.0"));
+  EXPECT_EQ("Compute queue (comp_1.1.0)", MapGpuTimelineToTrackLabel("comp_1.1.0"));
+
+  EXPECT_EQ("Video Coding Engine (vce0)", MapGpuTimelineToTrackLabel("vce0"));
+  EXPECT_EQ("Video Coding Engine (vce1)", MapGpuTimelineToTrackLabel("vce1"));
+}
+
+TEST(GpuTrack, MapGpuTimelineToTrackLabelMapsDebugMarkerQueuesCorrectly) {
+  EXPECT_EQ("Graphics queue debug markers (gfx_marker)", MapGpuTimelineToTrackLabel("gfx_marker"));
+
+  EXPECT_EQ("DMA queue debug markers (sdma0_marker)", MapGpuTimelineToTrackLabel("sdma0_marker"));
+  EXPECT_EQ("DMA queue debug markers (sdma1_marker)", MapGpuTimelineToTrackLabel("sdma1_marker"));
+
+  EXPECT_EQ("Compute queue debug markers (comp_1.0.0_marker)",
+            MapGpuTimelineToTrackLabel("comp_1.0.0_marker"));
+  EXPECT_EQ("Compute queue debug markers (comp_1.1.0_marker)",
+            MapGpuTimelineToTrackLabel("comp_1.1.0_marker"));
+
+  EXPECT_EQ("Video Coding Engine debug markers (vce0_marker)",
+            MapGpuTimelineToTrackLabel("vce0_marker"));
+  EXPECT_EQ("Video Coding Engine debug markers (vce1_marker)",
+            MapGpuTimelineToTrackLabel("vce1_marker"));
+}
+
+TEST(GpuTrack, MapGpuTimelineToTrackLabelIgnoresUnknownTimelines) {
+  EXPECT_EQ("unknown_timeline", MapGpuTimelineToTrackLabel("unknown_timeline"));
+}


### PR DESCRIPTION
Three small improvements for GPU track labels:
1) Include "vce" queues and map them to a descriptive string,
2) simplify the logic for constructing the labels,
3) add test for function that constructs the labels.

Tested: Unit test, and manually tested Orbit and checked track labels.
Bug: http://b/177827173