### PR TITLE
Coverage docker & kokoro

### DIFF
--- a/contrib/unit_test_coverage/generate_coverage_report.sh
+++ b/contrib/unit_test_coverage/generate_coverage_report.sh
@@ -10,7 +10,7 @@
 # llvm-cov and requires a build with build arguments -fprofile-instr-generate="%m.profraw"
 # and -fcoverage-mapping. 
 #
-# usage: generate_coverage_report.sh SOURCE_DIR BUILD_DIR
+# usage: generate_coverage_report.sh SOURCE_DIR BUILD_DIR OUTPUT_DIR
 
 # Settings:
 # grep inverted matching list for directories in BUILD_DIR/src that are not used
@@ -53,9 +53,9 @@ function generate_html_td {
   echo "<td class='$css_class'><pre> $percent_formatted% ($covered/$count)</pre></td>"
 }
 
-if [ "$#" -ne 2 ]; then
+if [ "$#" -ne 3 ]; then
   echo "error: wrong number of arguments."
-  echo "usage: generate_coverage_report.sh SOURCE_DIR BUILD_DIR"
+  echo "usage: generate_coverage_report.sh SOURCE_DIR BUILD_DIR OUTPUT_DIR"
   exit 1
 fi
 
@@ -71,7 +71,11 @@ if [ ! -d $BUILD_DIR ]; then
   exit 1
 fi
 
-OUTPUT_DIR=$BUILD_DIR/coverage
+OUTPUT_DIR=$(realpath $3)
+if [ ! -d $OUTPUT_DIR ]; then
+  echo "error: directory $3 does not exist."
+  exit 1
+fi
 
 LIBS=$(ls $BUILD_DIR/lib/* | grep -v "$LIB_FILE_FILTER")
 BINS=$(find $BUILD_DIR/bin/ -maxdepth 1 -type f | grep -v "$BIN_FILE_FILTER")

--- a/kokoro/builds/build.sh
+++ b/kokoro/builds/build.sh
@@ -142,6 +142,13 @@ if [ -n "$1" ]; then
   echo "Starting the build (conan build)."
   conan build -bf "${REPO_ROOT}/build/" "${REPO_ROOT}"
 
+  if [[ $CONAN_PROFILE == "coverage_clang9" ]]; then 
+    echo "Starting to generate unit test coverage report"
+    mkdir -p "${REPO_ROOT}/build/package/coverage"
+    ${REPO_ROOT}/contrib/unit_test_coverage/generate_coverage_report.sh \
+            "${REPO_ROOT}/src" "${REPO_ROOT}/build" "${REPO_ROOT}/build/package/coverage"
+  fi
+
   if [[ $CONAN_PROFILE != "iwyu" ]]; then
     echo "Start the packaging (conan package)."
     conan package -bf "${REPO_ROOT}/build/" "${REPO_ROOT}"

--- a/kokoro/builds/build.sh
+++ b/kokoro/builds/build.sh
@@ -142,14 +142,7 @@ if [ -n "$1" ]; then
   echo "Starting the build (conan build)."
   conan build -bf "${REPO_ROOT}/build/" "${REPO_ROOT}"
 
-  if [[ $CONAN_PROFILE == "coverage_clang9" ]]; then 
-    echo "Starting to generate unit test coverage report"
-    mkdir -p "${REPO_ROOT}/build/package/coverage"
-    ${REPO_ROOT}/contrib/unit_test_coverage/generate_coverage_report.sh \
-            "${REPO_ROOT}/src" "${REPO_ROOT}/build" "${REPO_ROOT}/build/package/coverage"
-  fi
-
-  if [[ $CONAN_PROFILE != "iwyu" ]]; then
+  if [[ $CONAN_PROFILE != "iwyu" && $CONAN_PROFILE != "coverage_clang9" ]]; then
     echo "Start the packaging (conan package)."
     conan package -bf "${REPO_ROOT}/build/" "${REPO_ROOT}"
     echo "Packaging is done."
@@ -203,7 +196,7 @@ if [ -n "$1" ]; then
   fi
 
   # Package build artifacts into a zip for integration in the installer.
-  if [[ $CONAN_PROFILE != ggp_* && $CONAN_PROFILE != "iwyu" ]]; then
+  if [[ $CONAN_PROFILE != ggp_* && $CONAN_PROFILE != "iwyu" && $CONAN_PROFILE != "coverage_clang9" ]]; then
     echo "Create a zip containing Orbit UI for integration in the installer."
     pushd "${REPO_ROOT}/build/package" > /dev/null
     cp -av bin/ Orbit
@@ -244,6 +237,14 @@ if [ -n "$1" ]; then
     fi
 
     popd > /dev/null
+  fi
+
+  # Generate unit test coverage report and save it in build/package for upload
+  if [[ $CONAN_PROFILE == "coverage_clang9" ]]; then 
+    echo "Starting to generate unit test coverage report"
+    mkdir -p "${REPO_ROOT}/build/package"
+    ${REPO_ROOT}/contrib/unit_test_coverage/generate_coverage_report.sh \
+            "${REPO_ROOT}/src" "${REPO_ROOT}/build" "${REPO_ROOT}/build/package"
   fi
 
   exit $?

--- a/kokoro/builds/linux/coverage_clang9/common.cfg
+++ b/kokoro/builds/linux/coverage_clang9/common.cfg
@@ -1,0 +1,5 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Location of the bash script. Should have value <github_scm.name>/<path_from_repository_root>.
+# github_scm.name is specified in the job configuration (next section).
+build_file: "orbitprofiler/kokoro/builds/build.sh"

--- a/kokoro/builds/linux/coverage_clang9/continous.cfg
+++ b/kokoro/builds/linux/coverage_clang9/continous.cfg
@@ -1,0 +1,8 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+action {
+  define_artifacts {
+    regex: "github/orbitprofiler/build/package/**"
+    strip_prefix: "github/orbitprofiler/build/package"
+  }
+}

--- a/third_party/conan/configs/linux/profiles/coverage_clang9
+++ b/third_party/conan/configs/linux/profiles/coverage_clang9
@@ -1,8 +1,5 @@
 include(clang9_relwithdebinfo)
 
-[options]
-OrbitProfiler:with_vulkan_layer=True
-
 [env]
 CFLAGS=$C_FLAGS -fprofile-instr-generate="%m.profraw" -fcoverage-mapping
 CXXFLAGS=$CXX_FLAGS -fprofile-instr-generate="%m.profraw" -fcoverage-mapping

--- a/third_party/conan/docker/Dockerfile.coverage_clang9
+++ b/third_party/conan/docker/Dockerfile.coverage_clang9
@@ -1,0 +1,14 @@
+FROM conanio/clang9:latest
+
+RUN sudo apt-get -qq update \
+    && sudo apt-get install -y --no-install-recommends \
+    qt5-default \
+    libqt5webchannel5-dev \
+    libqt5websockets5-dev \
+    qtwebengine5-dev \
+    jq \
+    python2.7 \
+    llvm-9 \
+    bc \
+    zip \
+    && sudo rm -rf /var/lib/apt/lists/*

--- a/third_party/conan/docker/build_containers.sh
+++ b/third_party/conan/docker/build_containers.sh
@@ -40,12 +40,14 @@ declare -A profile_to_dockerfile=( \
   ["msvc2019_debug_x86"]="msvc2019" \
   ["clang_format"]="clang_format" \
   ["license_headers"]="license_headers" \
-  ["iwyu"]="iwyu" )
+  ["iwyu"]="iwyu" \
+  ["coverage_clang9"]="coverage_clang9" \
+)
 
 source "${DIR}/tags.sh"
 
 if [ "$(uname -s)" == "Linux" ]; then
-  for profile in {clang{7,8,9},gcc{8,9},ggp}_{release,relwithdebinfo,debug} clang_format license_headers iwyu; do
+  for profile in {clang{7,8,9},gcc{8,9},ggp}_{release,relwithdebinfo,debug} clang_format license_headers iwyu coverage_clang9; do
     tag="${docker_image_tag_mapping[${profile}]-latest}"
     docker build "${DIR}" -f "${DIR}/Dockerfile.${profile_to_dockerfile[$profile]}" \
       -t gcr.io/orbitprofiler/${profile}:${tag} || exit $?

--- a/third_party/conan/docker/tags.sh
+++ b/third_party/conan/docker/tags.sh
@@ -8,6 +8,7 @@
 # should be / will be assumed.
 declare -rA docker_image_tag_mapping=( \
   [iwyu]="2" \
+  [coverage_clang9]="1" \
 )
 
 # Use `readonly DOCKER_IMAGE_TAG="${docker_image_tag_mapping[${CONAN_PROFILE}]-latest}"`

--- a/third_party/conan/docker/upload_containers.sh
+++ b/third_party/conan/docker/upload_containers.sh
@@ -10,7 +10,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source "${DIR}/tags.sh"
 
 if [ "$(uname -s)" == "Linux" ]; then
-  for profile in {clang{7,8,9},gcc{8,9},ggp}_{release,relwithdebinfo,debug} clang_format license_headers iwyu; do
+  for profile in {clang{7,8,9},gcc{8,9},ggp}_{release,relwithdebinfo,debug} clang_format license_headers iwyu coverage_clang9; do
     tag="${docker_image_tag_mapping[${profile}]-latest}"
     docker push gcr.io/orbitprofiler/$profile:${tag} || exit $?
   done


### PR DESCRIPTION
The docker container is already pushed to the cloud project. The successful test is here:

https://fusion.corp.google.com/runanalysis/info/prod:orbitprofiler%2Fbuilds%2Flinux%2Fclang7_relwithdebinfo%2Fcontinuous/prod:orbitprofiler%2Fbuilds%2Flinux%2Fclang7_relwithdebinfo%2Fcontinuous/KOKORO/a888eaee-c02f-44c5-9039-c75b10fa0855/1613132417885/build%20%23709/Targets

Bucket:
https://pantheon.corp.google.com/storage/browser/orbitprofiler-build/gcp_ubuntu_artifacts/prod/orbitprofiler/builds/linux/clang7_relwithdebinfo/continuous/709/20210212-042019;tab=objects?prefix=&forceOnObjectsSortingFiltering=false

(See coverage sub folder)