### PR TITLE
Bring TimerTrack::UpdatePrimitives back to speed again.

### DIFF
--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -151,9 +151,8 @@ void TimerTrack::DrawTimer(TextBox* prev_text_box, TextBox* current_text_box,
     double right_overlap_width_us = end_us - end_or_next_start_us;
     double text_x_end_us = end_or_next_start_us + (.25 * right_overlap_width_us);
 
-    bool is_visible_width = (text_x_end_us - text_x_start_us) * draw_data.inv_time_window *
-                                draw_data.canvas->GetWidth() >
-                            1;
+    bool is_visible_width = ((text_x_end_us - text_x_start_us) * draw_data.inv_time_window *
+                             draw_data.canvas->GetWidth()) > 1;
     WorldXInfo world_x_info = ToWorldX(text_x_start_us, text_x_end_us, draw_data.inv_time_window,
                                        draw_data.world_start_x, draw_data.world_width);
 

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -82,16 +82,17 @@ WorldXInfo ToWorldX(double start_us, double end_us, double inv_time_window, floa
 
 }  // namespace
 
-void TimerTrack::DrawTimer(TextBox* prev_text_box, TextBox* current_text_box,
-                           TextBox* next_text_box, const internal::DrawData& draw_data,
+void TimerTrack::DrawTimer(const TextBox* prev_text_box, const TextBox* next_text_box,
+                           const internal::DrawData& draw_data, TextBox* current_text_box,
                            uint64_t* min_ignore, uint64_t* max_ignore) {
   CHECK(min_ignore != nullptr);
   CHECK(max_ignore != nullptr);
   if (current_text_box == nullptr) return;
   const TimerInfo& current_timer_info = current_text_box->GetTimerInfo();
   if (draw_data.min_tick > current_timer_info.end() ||
-      draw_data.max_tick < current_timer_info.start())
+      draw_data.max_tick < current_timer_info.start()) {
     return;
+  }
   if (current_timer_info.start() >= *min_ignore && current_timer_info.end() <= *max_ignore) return;
   if (!TimerFilter(current_timer_info)) return;
 
@@ -284,7 +285,7 @@ void TimerTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t 
         // the previous iteration ("current").
         next_text_box = &block[k];
 
-        DrawTimer(prev_text_box, current_text_box, next_text_box, draw_data, &min_ignore,
+        DrawTimer(prev_text_box, next_text_box, draw_data, current_text_box, &min_ignore,
                   &max_ignore);
 
         prev_text_box = current_text_box;
@@ -293,7 +294,7 @@ void TimerTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t 
     }
     // We still need to draw the last timer.
     next_text_box = nullptr;
-    DrawTimer(prev_text_box, current_text_box, next_text_box, draw_data, &min_ignore, &max_ignore);
+    DrawTimer(prev_text_box, next_text_box, draw_data, current_text_box, &min_ignore, &max_ignore);
   }
 }
 

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -29,6 +29,25 @@
 class OrbitApp;
 class TextRenderer;
 
+namespace internal {
+struct DrawData {
+  uint64_t min_tick;
+  uint64_t max_tick;
+  float z_offset;
+  Batcher* batcher;
+  GlCanvas* canvas;
+  float world_start_x;
+  float world_width;
+  double inv_time_window;
+  bool is_collapsed;
+  float z;
+  const TextBox* selected_textbox;
+  uint64_t highlighted_function_id;
+  uint64_t pixel_delta_in_ticks;
+  uint64_t min_timegraph_tick;
+};
+}  // namespace internal
+
 class TimerTrack : public Track {
  public:
   explicit TimerTrack(TimeGraph* time_graph, OrbitApp* app, CaptureData* capture_data);
@@ -85,11 +104,7 @@ class TimerTrack : public Track {
   }
 
   void DrawTimer(TextBox* prev_text_box, TextBox* current_text_box, TextBox* next_text_box,
-                 uint64_t min_tick, uint64_t max_tick, float z_offset, Batcher* batcher,
-                 GlCanvas* canvas, float world_start_x, float world_width, double inv_time_window,
-                 bool is_collapsed, float z, const TextBox* selected_textbox,
-                 uint64_t highlighted_function_id, uint64_t pixel_delta_in_ticks,
-                 uint64_t min_timegraph_tick, uint64_t* min_ignore, uint64_t* max_ignore);
+                 const internal::DrawData& draw_data, uint64_t* min_ignore, uint64_t* max_ignore);
 
   void UpdateDepth(uint32_t depth) {
     if (depth > depth_) depth_ = depth;

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -103,8 +103,9 @@ class TimerTrack : public Track {
     return true;
   }
 
-  void DrawTimer(TextBox* prev_text_box, TextBox* current_text_box, TextBox* next_text_box,
-                 const internal::DrawData& draw_data, uint64_t* min_ignore, uint64_t* max_ignore);
+  void DrawTimer(const TextBox* prev_text_box, const TextBox* next_text_box,
+                 const internal::DrawData& draw_data, TextBox* current_text_box,
+                 uint64_t* min_ignore, uint64_t* max_ignore);
 
   void UpdateDepth(uint32_t depth) {
     if (depth > depth_) depth_ = depth;

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -33,18 +33,18 @@ namespace internal {
 struct DrawData {
   uint64_t min_tick;
   uint64_t max_tick;
-  float z_offset;
-  Batcher* batcher;
-  GlCanvas* canvas;
-  float world_start_x;
-  float world_width;
-  double inv_time_window;
-  bool is_collapsed;
-  float z;
-  const TextBox* selected_textbox;
   uint64_t highlighted_function_id;
   uint64_t pixel_delta_in_ticks;
   uint64_t min_timegraph_tick;
+  Batcher* batcher;
+  GlCanvas* canvas;
+  const TextBox* selected_textbox;
+  double inv_time_window;
+  float world_start_x;
+  float world_width;
+  float z_offset;
+  float z;
+  bool is_collapsed;
 };
 }  // namespace internal
 


### PR DESCRIPTION
The recent fix for the iteration over timers introduced up to 30%
overhead. The time was spent in passing the large number of
arguments.

This change wraps the constant arguments into a struct and then
simply pass this as reference to the Draw function.

Test: Load a capture with timers and introspect.