### PR TITLE
Enable C++17 for Abseil in fuzzing conan profile

### DIFF
--- a/third_party/conan/configs/linux/profiles/libfuzzer_base
+++ b/third_party/conan/configs/linux/profiles/libfuzzer_base
@@ -4,7 +4,9 @@
 BASE_CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -D_FORTIFY_SOURCE=2 -fstack-protector-all -fPIC
 BASE_CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all -fPIC
 BASE_LDFLAGS=-Wl,-z,relro,-z,now,-z,noexecstack -pthread
-
+[settings]
+abseil:compiler=clang
+abseil:compiler.cppstd=17
 [options]
 OrbitProfiler:with_gui=False
 OrbitProfiler:run_tests=False


### PR DESCRIPTION
With that flag abseil will be compiled without C++17 support which leads
to missing symbols when compiling Orbit later on in the build process.

This change has already been made for all other profiles, but missed for
this fuzzing profile.