### PR TITLE
Erase TimeGraph->GetLayout/FontSize dependences

### DIFF
--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -112,7 +112,7 @@ void AsyncTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_us
   text_renderer_->AddTextTrailingCharsPrioritized(
       text_box->GetText().c_str(), pos_x, text_box->GetPos()[1] + layout_->GetTextOffset(),
       GlCanvas::kZValueBox + z_offset, kTextWhite, text_box->GetElapsedTimeTextLength(),
-      time_graph_->CalculateZoomedFontSize(), max_size);
+      layout_->CalculateZoomedFontSize(), max_size);
 }
 
 Color AsyncTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected) const {

--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -30,9 +30,9 @@
 using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::TimerInfo;
 
-AsyncTrack::AsyncTrack(TimeGraph* time_graph, const std::string& name, OrbitApp* app,
-                       CaptureData* capture_data)
-    : TimerTrack(time_graph, app, capture_data) {
+AsyncTrack::AsyncTrack(TimeGraph* time_graph, TimeGraphLayout* layout, const std::string& name,
+                       OrbitApp* app, CaptureData* capture_data)
+    : TimerTrack(time_graph, layout, app, capture_data) {
   SetName(name);
   SetLabel(name);
 }
@@ -68,7 +68,7 @@ AsyncTrack::AsyncTrack(TimeGraph* time_graph, const std::string& name, OrbitApp*
 }
 
 void AsyncTrack::UpdateBoxHeight() {
-  box_height_ = time_graph_->GetLayout().GetTextBoxHeight();
+  box_height_ = layout_->GetTextBoxHeight();
   if (collapse_toggle_->IsCollapsed() && depth_ > 0) {
     box_height_ /= static_cast<float>(depth_);
   }
@@ -95,7 +95,6 @@ void AsyncTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
 
 void AsyncTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_us, float min_x,
                                   float z_offset, TextBox* text_box) {
-  TimeGraphLayout layout = time_graph_->GetLayout();
   std::string time = GetPrettyTime(absl::Microseconds(elapsed_us));
   text_box->SetElapsedTimeTextLength(time.length());
 
@@ -111,7 +110,7 @@ void AsyncTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_us
   float pos_x = std::max(box_pos[0], min_x);
   float max_size = box_pos[0] + box_size[0] - pos_x;
   text_renderer_->AddTextTrailingCharsPrioritized(
-      text_box->GetText().c_str(), pos_x, text_box->GetPos()[1] + layout.GetTextOffset(),
+      text_box->GetText().c_str(), pos_x, text_box->GetPos()[1] + layout_->GetTextOffset(),
       GlCanvas::kZValueBox + z_offset, kTextWhite, text_box->GetElapsedTimeTextLength(),
       time_graph_->CalculateZoomedFontSize(), max_size);
 }

--- a/src/OrbitGl/AsyncTrack.h
+++ b/src/OrbitGl/AsyncTrack.h
@@ -24,8 +24,8 @@ class OrbitApp;
 
 class AsyncTrack final : public TimerTrack {
  public:
-  explicit AsyncTrack(TimeGraph* time_graph, const std::string& name, OrbitApp* app,
-                      CaptureData* capture_data);
+  explicit AsyncTrack(TimeGraph* time_graph, TimeGraphLayout* layout, const std::string& name,
+                      OrbitApp* app, CaptureData* capture_data);
 
   [[nodiscard]] Type GetType() const override { return kAsyncTrack; };
   [[nodiscard]] std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const override;

--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -9,7 +9,10 @@
 
 namespace orbit_gl {
 
-CaptureViewElement::CaptureViewElement(TimeGraph* time_graph) : time_graph_(time_graph) {}
+CaptureViewElement::CaptureViewElement(TimeGraph* time_graph, TimeGraphLayout* layout)
+    : layout_(layout), time_graph_(time_graph) {
+  CHECK(layout != nullptr);
+}
 
 void CaptureViewElement::OnPick(int x, int y) {
   canvas_->ScreenToWorld(x, y, mouse_pos_last_click_[0], mouse_pos_last_click_[1]);

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -7,6 +7,7 @@
 
 #include "Batcher.h"
 #include "PickingManager.h"
+#include "TimeGraphLayout.h"
 
 class TimeGraph;
 class GlCanvas;
@@ -16,7 +17,7 @@ namespace orbit_gl {
 /* Base class for UI elements drawn underneath the capture window. */
 class CaptureViewElement : public Pickable {
  public:
-  explicit CaptureViewElement(TimeGraph* time_graph);
+  explicit CaptureViewElement(TimeGraph* time_graph, TimeGraphLayout* layout);
   virtual void Draw(GlCanvas* canvas, PickingMode /*picking_mode*/, float /*z_offset*/ = 0) {
     canvas_ = canvas;
   }
@@ -41,6 +42,7 @@ class CaptureViewElement : public Pickable {
   [[nodiscard]] bool Draggable() override { return true; }
 
  protected:
+  TimeGraphLayout* layout_;
   GlCanvas* canvas_ = nullptr;
   TimeGraph* time_graph_;
   Vec2 pos_ = Vec2(0, 0);

--- a/src/OrbitGl/EventTrack.cpp
+++ b/src/OrbitGl/EventTrack.cpp
@@ -31,9 +31,9 @@ using orbit_client_protos::CallstackEvent;
 
 namespace orbit_gl {
 
-EventTrack::EventTrack(OrbitApp* app, TimeGraph* time_graph, CaptureData* capture_data,
-                       ThreadID thread_id)
-    : ThreadBar(app, time_graph, capture_data, thread_id), color_{0, 255, 0, 255} {}
+EventTrack::EventTrack(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
+                       CaptureData* capture_data, ThreadID thread_id)
+    : ThreadBar(app, time_graph, layout, capture_data, thread_id), color_{0, 255, 0, 255} {}
 
 std::string EventTrack::GetTooltip() const { return "Left-click and drag to select samples"; }
 
@@ -88,9 +88,8 @@ void EventTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t 
                                   PickingMode picking_mode, float z_offset) {
   ThreadBar::UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
 
-  const TimeGraphLayout& layout = time_graph_->GetLayout();
   float z = GlCanvas::kZValueEvent + z_offset;
-  float track_height = layout.GetEventTrackHeight();
+  float track_height = layout_->GetEventTrackHeight();
   const bool picking = picking_mode != PickingMode::kNone;
 
   const Color kWhite(255, 255, 255, 255);

--- a/src/OrbitGl/EventTrack.h
+++ b/src/OrbitGl/EventTrack.h
@@ -23,8 +23,8 @@ namespace orbit_gl {
 
 class EventTrack : public ThreadBar {
  public:
-  explicit EventTrack(OrbitApp* app, TimeGraph* time_graph, CaptureData* capture_data,
-                      ThreadID thread_id);
+  explicit EventTrack(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
+                      CaptureData* capture_data, ThreadID thread_id);
 
   std::string GetTooltip() const override;
 

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -168,7 +168,7 @@ void FrameTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_us
   text_renderer_->AddTextTrailingCharsPrioritized(
       text_box->GetText().c_str(), pos_x, text_box->GetPos()[1] + layout_->GetTextOffset(),
       GlCanvas::kZValueBox + z_offset, kTextWhite, text_box->GetElapsedTimeTextLength(),
-      time_graph_->CalculateZoomedFontSize(), max_size);
+      layout_->CalculateZoomedFontSize(), max_size);
 }
 
 std::string FrameTrack::GetTooltip() const {
@@ -235,7 +235,7 @@ void FrameTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset
 
   std::string avg_time = GetPrettyTime(absl::Nanoseconds(stats_.average_time_ns()));
   std::string label = absl::StrFormat("Avg: %s", avg_time);
-  uint32_t font_size = time_graph_->CalculateZoomedFontSize();
+  uint32_t font_size = layout_->CalculateZoomedFontSize();
   float string_width = canvas->GetTextRenderer().GetStringWidth(label.c_str(), font_size);
   Vec2 white_text_box_size(string_width, layout_->GetTextBoxHeight());
   Vec2 white_text_box_position(pos_[0] + layout_->GetRightMargin(),

--- a/src/OrbitGl/FrameTrack.h
+++ b/src/OrbitGl/FrameTrack.h
@@ -24,7 +24,7 @@ class OrbitApp;
 
 class FrameTrack : public TimerTrack {
  public:
-  explicit FrameTrack(TimeGraph* time_graph, uint64_t function_id,
+  explicit FrameTrack(TimeGraph* time_graph, TimeGraphLayout* layout, uint64_t function_id,
                       orbit_client_protos::FunctionInfo function, OrbitApp* app,
                       CaptureData* capture_data);
   [[nodiscard]] Type GetType() const override { return kFrameTrack; }

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -219,7 +219,7 @@ void GpuTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_us, 
   text_renderer_->AddTextTrailingCharsPrioritized(
       text_box->GetText().c_str(), pos_x, text_box->GetPos()[1] + layout_->GetTextOffset(),
       GlCanvas::kZValueBox + z_offset, kTextWhite, text_box->GetElapsedTimeTextLength(),
-      time_graph_->CalculateZoomedFontSize(), max_size);
+      layout_->CalculateZoomedFontSize(), max_size);
 }
 
 std::string GpuTrack::GetTooltip() const {

--- a/src/OrbitGl/GpuTrack.h
+++ b/src/OrbitGl/GpuTrack.h
@@ -33,8 +33,8 @@ std::string MapGpuTimelineToTrackLabel(std::string_view timeline);
 
 class GpuTrack : public TimerTrack {
  public:
-  explicit GpuTrack(TimeGraph* time_graph, uint64_t timeline_hash, OrbitApp* app,
-                    CaptureData* capture_data);
+  explicit GpuTrack(TimeGraph* time_graph, TimeGraphLayout* layout, uint64_t timeline_hash,
+                    OrbitApp* app, CaptureData* capture_data);
   ~GpuTrack() override = default;
   [[nodiscard]] std::string GetTooltip() const override;
   [[nodiscard]] Type GetType() const override { return kGpuTrack; }

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -15,8 +15,9 @@
 #include "TimeGraph.h"
 #include "TimeGraphLayout.h"
 
-GraphTrack::GraphTrack(TimeGraph* time_graph, std::string name, CaptureData* capture_data)
-    : Track(time_graph, capture_data) {
+GraphTrack::GraphTrack(TimeGraph* time_graph, TimeGraphLayout* layout, std::string name,
+                       CaptureData* capture_data)
+    : Track(time_graph, layout, capture_data) {
   SetName(name);
   SetLabel(name);
 }
@@ -113,11 +114,10 @@ void GraphTrack::DrawSquareDot(Batcher* batcher, Vec2 center, float radius, floa
 
 void GraphTrack::DrawLabel(GlCanvas* canvas, Vec2 target_pos, const std::string& text,
                            const Color& text_color, const Color& font_color, float z) {
-  const TimeGraphLayout& layout = time_graph_->GetLayout();
   uint32_t font_size = time_graph_->CalculateZoomedFontSize();
 
   float text_width = canvas->GetTextRenderer().GetStringWidth(text.c_str(), font_size);
-  Vec2 text_box_size(text_width, layout.GetTextBoxHeight());
+  Vec2 text_box_size(text_width, layout_->GetTextBoxHeight());
 
   float arrow_width = text_box_size[1] / 2.f;
   bool arrow_is_left_directed =
@@ -142,7 +142,7 @@ void GraphTrack::DrawLabel(GlCanvas* canvas, Vec2 target_pos, const std::string&
   }
 
   canvas->GetTextRenderer().AddText(text.c_str(), text_box_position[0],
-                                    text_box_position[1] + layout.GetTextOffset(), z, text_color,
+                                    text_box_position[1] + layout_->GetTextOffset(), z, text_color,
                                     font_size, text_box_size[0]);
 }
 
@@ -166,8 +166,7 @@ std::optional<std::pair<uint64_t, double> > GraphTrack::GetPreviousValueAndTime(
 }
 
 float GraphTrack::GetHeight() const {
-  const TimeGraphLayout& layout = time_graph_->GetLayout();
-  float height = layout.GetTextBoxHeight() + layout.GetSpaceBetweenTracksAndThread() +
-                 layout.GetEventTrackHeight() + layout.GetTrackBottomMargin();
+  float height = layout_->GetTextBoxHeight() + layout_->GetSpaceBetweenTracksAndThread() +
+                 layout_->GetEventTrackHeight() + layout_->GetTrackBottomMargin();
   return height;
 }

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -114,7 +114,7 @@ void GraphTrack::DrawSquareDot(Batcher* batcher, Vec2 center, float radius, floa
 
 void GraphTrack::DrawLabel(GlCanvas* canvas, Vec2 target_pos, const std::string& text,
                            const Color& text_color, const Color& font_color, float z) {
-  uint32_t font_size = time_graph_->CalculateZoomedFontSize();
+  uint32_t font_size = layout_->CalculateZoomedFontSize();
 
   float text_width = canvas->GetTextRenderer().GetStringWidth(text.c_str(), font_size);
   Vec2 text_box_size(text_width, layout_->GetTextBoxHeight());

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -23,7 +23,8 @@ class TimeGraph;
 
 class GraphTrack : public Track {
  public:
-  explicit GraphTrack(TimeGraph* time_graph, std::string name, CaptureData* capture_data);
+  explicit GraphTrack(TimeGraph* time_graph, TimeGraphLayout* layout, std::string name,
+                      CaptureData* capture_data);
   [[nodiscard]] Type GetType() const override { return kGraphTrack; }
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -21,8 +21,9 @@ using orbit_client_protos::TimerInfo;
 const Color kInactiveColor(100, 100, 100, 255);
 const Color kSelectionColor(0, 128, 255, 255);
 
-SchedulerTrack::SchedulerTrack(TimeGraph* time_graph, OrbitApp* app, CaptureData* capture_data)
-    : TimerTrack(time_graph, app, capture_data) {
+SchedulerTrack::SchedulerTrack(TimeGraph* time_graph, TimeGraphLayout* layout, OrbitApp* app,
+                               CaptureData* capture_data)
+    : TimerTrack(time_graph, layout, app, capture_data) {
   SetPinned(false);
   SetName("Scheduler");
   SetLabel("Scheduler (0 cores)");
@@ -38,10 +39,9 @@ void SchedulerTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
 }
 
 float SchedulerTrack::GetHeight() const {
-  TimeGraphLayout& layout = time_graph_->GetLayout();
   uint32_t num_gaps = depth_ > 0 ? depth_ - 1 : 0;
-  return (depth_ * layout.GetTextCoresHeight()) + (num_gaps * layout.GetSpaceBetweenCores()) +
-         layout.GetTrackBottomMargin();
+  return (depth_ * layout_->GetTextCoresHeight()) + (num_gaps * layout_->GetSpaceBetweenCores()) +
+         layout_->GetTrackBottomMargin();
 }
 
 bool SchedulerTrack::IsTimerActive(const TimerInfo& timer_info) const {
@@ -65,19 +65,16 @@ Color SchedulerTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selecte
 }
 
 float SchedulerTrack::GetYFromTimer(const TimerInfo& timer_info) const {
-  const TimeGraphLayout& layout = time_graph_->GetLayout();
   uint32_t num_gaps = timer_info.depth();
-  return pos_[1] - (layout.GetTextCoresHeight() * static_cast<float>(timer_info.depth() + 1)) -
-         num_gaps * layout.GetSpaceBetweenCores();
+  return pos_[1] - (layout_->GetTextCoresHeight() * static_cast<float>(timer_info.depth() + 1)) -
+         num_gaps * layout_->GetSpaceBetweenCores();
 }
 
 std::string SchedulerTrack::GetTooltip() const {
   return "Shows scheduling information for CPU cores";
 }
 
-void SchedulerTrack::UpdateBoxHeight() {
-  box_height_ = time_graph_->GetLayout().GetTextCoresHeight();
-}
+void SchedulerTrack::UpdateBoxHeight() { box_height_ = layout_->GetTextCoresHeight(); }
 
 std::string SchedulerTrack::GetBoxTooltip(const Batcher& batcher, PickingId id) const {
   const TextBox* text_box = batcher.GetTextBox(id);

--- a/src/OrbitGl/SchedulerTrack.h
+++ b/src/OrbitGl/SchedulerTrack.h
@@ -18,7 +18,8 @@ class OrbitApp;
 
 class SchedulerTrack final : public TimerTrack {
  public:
-  explicit SchedulerTrack(TimeGraph* time_graph, OrbitApp* app, CaptureData* capture_data);
+  explicit SchedulerTrack(TimeGraph* time_graph, TimeGraphLayout* layout, OrbitApp* app,
+                          CaptureData* capture_data);
   ~SchedulerTrack() override = default;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
 

--- a/src/OrbitGl/ThreadBar.h
+++ b/src/OrbitGl/ThreadBar.h
@@ -10,6 +10,7 @@
 
 #include "CaptureViewElement.h"
 #include "OrbitClientModel/CaptureData.h"
+#include "TimeGraphLayout.h"
 
 class OrbitApp;
 
@@ -17,9 +18,9 @@ namespace orbit_gl {
 
 class ThreadBar : public CaptureViewElement, public std::enable_shared_from_this<ThreadBar> {
  public:
-  explicit ThreadBar(OrbitApp* app, TimeGraph* time_graph, CaptureData* capture_data,
-                     ThreadID thread_id)
-      : CaptureViewElement(time_graph),
+  explicit ThreadBar(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
+                     CaptureData* capture_data, ThreadID thread_id)
+      : CaptureViewElement(time_graph, layout),
         thread_id_(thread_id),
         app_(app),
         capture_data_(capture_data){};

--- a/src/OrbitGl/ThreadStateTrack.cpp
+++ b/src/OrbitGl/ThreadStateTrack.cpp
@@ -22,9 +22,9 @@ using orbit_client_protos::ThreadStateSliceInfo;
 
 namespace orbit_gl {
 
-ThreadStateTrack::ThreadStateTrack(OrbitApp* app, TimeGraph* time_graph, CaptureData* capture_data,
-                                   ThreadID thread_id)
-    : ThreadBar(app, time_graph, capture_data, thread_id) {}
+ThreadStateTrack::ThreadStateTrack(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
+                                   CaptureData* capture_data, ThreadID thread_id)
+    : ThreadBar(app, time_graph, layout, capture_data, thread_id) {}
 
 bool ThreadStateTrack::IsEmpty() const {
   if (capture_data_ == nullptr) return true;

--- a/src/OrbitGl/ThreadStateTrack.h
+++ b/src/OrbitGl/ThreadStateTrack.h
@@ -23,8 +23,8 @@ namespace orbit_gl {
 
 class ThreadStateTrack final : public ThreadBar {
  public:
-  explicit ThreadStateTrack(OrbitApp* app, TimeGraph* time_graph, CaptureData* capture_data,
-                            ThreadID thread_id);
+  explicit ThreadStateTrack(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
+                            CaptureData* capture_data, ThreadID thread_id);
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -333,7 +333,7 @@ void ThreadTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_u
   text_renderer_->AddTextTrailingCharsPrioritized(
       text_box->GetText().c_str(), pos_x, text_box->GetPos()[1] + layout_->GetTextOffset(),
       GlCanvas::kZValueBox + z_offset, kTextWhite, text_box->GetElapsedTimeTextLength(),
-      time_graph_->CalculateZoomedFontSize(), max_size);
+      layout_->CalculateZoomedFontSize(), max_size);
 }
 
 std::string ThreadTrack::GetTooltip() const {

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -25,8 +25,8 @@ class OrbitApp;
 
 class ThreadTrack final : public TimerTrack {
  public:
-  explicit ThreadTrack(TimeGraph* time_graph, int32_t thread_id, OrbitApp* app,
-                       CaptureData* capture_data);
+  explicit ThreadTrack(TimeGraph* time_graph, TimeGraphLayout* layout, int32_t thread_id,
+                       OrbitApp* app, CaptureData* capture_data);
   void InitializeNameAndLabel(int32_t thread_id);
 
   void SetCaptureData(CaptureData* capture_data) override;

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -50,7 +50,7 @@ TimeGraph::TimeGraph(OrbitApp* app, TextRenderer* text_renderer, GlCanvas* canva
   text_renderer_->SetCanvas(canvas);
   text_renderer_static_.SetCanvas(canvas);
   batcher_.SetPickingManager(&canvas->GetPickingManager());
-  track_manager_ = std::make_unique<TrackManager>(this, app, capture_data);
+  track_manager_ = std::make_unique<TrackManager>(this, &GetLayout(), app, capture_data);
 
   async_timer_info_listener_ =
       std::make_unique<ManualInstrumentationManager::AsyncTimerInfoListener>(

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -6,7 +6,6 @@
 #define ORBIT_GL_TIME_GRAPH_H_
 
 #include <absl/container/flat_hash_map.h>
-#include <math.h>
 
 #include <cstdint>
 #include <map>
@@ -112,9 +111,6 @@ class TimeGraph {
   [[nodiscard]] int GetNumDrawnTextBoxes() { return num_drawn_text_boxes_; }
   [[nodiscard]] TextRenderer* GetTextRenderer() { return &text_renderer_static_; }
   [[nodiscard]] GlCanvas* GetCanvas() { return canvas_; }
-  [[nodiscard]] uint32_t CalculateZoomedFontSize() const {
-    return lround(layout_.GetFontSize() * layout_.GetScale());
-  }
   [[nodiscard]] Batcher& GetBatcher() { return batcher_; }
   [[nodiscard]] uint32_t GetNumTimers() const;
   [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllTimerChains() const;

--- a/src/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/TimeGraphLayout.h
@@ -5,6 +5,7 @@
 #ifndef ORBIT_GL_TIME_GRAPH_LAYOUT_H_
 #define ORBIT_GL_TIME_GRAPH_LAYOUT_H_
 
+#include <math.h>
 #include <stdint.h>
 
 class TimeGraphLayout {
@@ -43,6 +44,9 @@ class TimeGraphLayout {
   bool DrawProperties();
   bool GetDrawTrackBackground() const { return draw_track_background_; }
   uint32_t GetFontSize() const { return font_size_; }
+  [[nodiscard]] uint32_t CalculateZoomedFontSize() const {
+    return lround(GetFontSize() * GetScale());
+  }
 
  protected:
   float text_box_height_;

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -27,8 +27,9 @@ using orbit_client_protos::TimerInfo;
 
 ABSL_DECLARE_FLAG(bool, show_return_values);
 
-TimerTrack::TimerTrack(TimeGraph* time_graph, OrbitApp* app, CaptureData* capture_data)
-    : Track(time_graph, capture_data), app_{app} {
+TimerTrack::TimerTrack(TimeGraph* time_graph, TimeGraphLayout* layout, OrbitApp* app,
+                       CaptureData* capture_data)
+    : Track(time_graph, layout, capture_data), app_{app} {
   text_renderer_ = time_graph->GetTextRenderer();
 }
 
@@ -52,12 +53,11 @@ std::string TimerTrack::GetExtraInfo(const TimerInfo& timer_info) {
 }
 
 float TimerTrack::GetYFromTimer(const TimerInfo& timer_info) const {
-  const TimeGraphLayout& layout = time_graph_->GetLayout();
-  return pos_[1] - GetHeaderHeight() - layout.GetSpaceBetweenTracksAndThread() -
+  return pos_[1] - GetHeaderHeight() - layout_->GetSpaceBetweenTracksAndThread() -
          box_height_ * static_cast<float>(timer_info.depth() + 1);
 }
 
-void TimerTrack::UpdateBoxHeight() { box_height_ = time_graph_->GetLayout().GetTextBoxHeight(); }
+void TimerTrack::UpdateBoxHeight() { box_height_ = layout_->GetTextBoxHeight(); }
 
 float TimerTrack::GetTextBoxHeight(const TimerInfo& /*timer_info*/) const { return box_height_; }
 
@@ -322,13 +322,12 @@ void TimerTrack::OnTimer(const TimerInfo& timer_info) {
 }
 
 float TimerTrack::GetHeight() const {
-  TimeGraphLayout& layout = time_graph_->GetLayout();
   bool is_collapsed = collapse_toggle_->IsCollapsed();
   uint32_t collapsed_depth = (GetNumTimers() == 0) ? 0 : 1;
   uint32_t depth = is_collapsed ? collapsed_depth : GetDepth();
-  return layout.GetTextBoxHeight() * depth +
-         (depth > 0 ? layout.GetSpaceBetweenTracksAndThread() : 0) + layout.GetEventTrackHeight() +
-         layout.GetTrackBottomMargin();
+  return layout_->GetTextBoxHeight() * depth +
+         (depth > 0 ? layout_->GetSpaceBetweenTracksAndThread() : 0) +
+         layout_->GetEventTrackHeight() + layout_->GetTrackBottomMargin();
 }
 
 std::string TimerTrack::GetTooltip() const {
@@ -416,7 +415,4 @@ std::string TimerTrack::GetBoxTooltip(const Batcher& /*batcher*/, PickingId /*id
   return "";
 }
 
-float TimerTrack::GetHeaderHeight() const {
-  const TimeGraphLayout& layout = time_graph_->GetLayout();
-  return layout.GetEventTrackHeight();
-}
+float TimerTrack::GetHeaderHeight() const { return layout_->GetEventTrackHeight(); }

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -50,7 +50,8 @@ struct DrawData {
 
 class TimerTrack : public Track {
  public:
-  explicit TimerTrack(TimeGraph* time_graph, OrbitApp* app, CaptureData* capture_data);
+  explicit TimerTrack(TimeGraph* time_graph, TimeGraphLayout* layout, OrbitApp* app,
+                      CaptureData* capture_data);
   ~TimerTrack() override = default;
 
   // Pickable

--- a/src/OrbitGl/TracepointTrack.cpp
+++ b/src/OrbitGl/TracepointTrack.cpp
@@ -26,9 +26,9 @@
 
 namespace orbit_gl {
 
-TracepointTrack::TracepointTrack(OrbitApp* app, TimeGraph* time_graph, CaptureData* capture_data,
-                                 int32_t thread_id)
-    : ThreadBar(app, time_graph, capture_data, thread_id), color_{255, 0, 0, 255} {}
+TracepointTrack::TracepointTrack(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
+                                 CaptureData* capture_data, int32_t thread_id)
+    : ThreadBar(app, time_graph, layout, capture_data, thread_id), color_{255, 0, 0, 255} {}
 
 void TracepointTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
   ThreadBar::Draw(canvas, picking_mode, z_offset);
@@ -51,9 +51,8 @@ void TracepointTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint
                                        PickingMode picking_mode, float z_offset) {
   ThreadBar::UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
 
-  const TimeGraphLayout& layout = time_graph_->GetLayout();
   float z = GlCanvas::kZValueEvent + z_offset;
-  float track_height = layout.GetEventTrackHeight();
+  float track_height = layout_->GetEventTrackHeight();
   const bool picking = picking_mode != PickingMode::kNone;
 
   const Color kWhite(255, 255, 255, 255);

--- a/src/OrbitGl/TracepointTrack.h
+++ b/src/OrbitGl/TracepointTrack.h
@@ -15,8 +15,8 @@ namespace orbit_gl {
 
 class TracepointTrack : public ThreadBar {
  public:
-  explicit TracepointTrack(OrbitApp* app, TimeGraph* time_graph, CaptureData* capture_data,
-                           int32_t thread_id);
+  explicit TracepointTrack(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
+                           CaptureData* capture_data, int32_t thread_id);
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
 

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -163,7 +163,7 @@ void Track::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
 
   // Draw label.
   if (!picking) {
-    uint32_t font_size = time_graph_->CalculateZoomedFontSize();
+    uint32_t font_size = layout_->CalculateZoomedFontSize();
     auto& text_renderer = canvas->GetTextRenderer();
     float label_offset_x = layout_->GetTrackLabelOffsetX();
     float label_offset_y = text_renderer.GetStringHeight("o", font_size) / 2.f;

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -43,7 +43,7 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
     kUnknown,
   };
 
-  explicit Track(TimeGraph* time_graph, CaptureData* capture_data);
+  explicit Track(TimeGraph* time_graph, TimeGraphLayout* layout, CaptureData* capture_data);
   ~Track() override = default;
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -34,7 +34,8 @@ class Timegraph;
 // and sorting).
 class TrackManager {
  public:
-  explicit TrackManager(TimeGraph* time_graph, OrbitApp* app, CaptureData* capture_data);
+  explicit TrackManager(TimeGraph* time_graph, TimeGraphLayout* layout, OrbitApp* app,
+                        CaptureData* capture_data);
 
   [[nodiscard]] std::vector<Track*> GetAllTracks() const;
   [[nodiscard]] std::vector<Track*> GetVisibleTracks() const { return visible_tracks_; }
@@ -85,6 +86,7 @@ class TrackManager {
   ThreadTrack* tracepoints_system_wide_track_;
 
   TimeGraph* time_graph_;
+  TimeGraphLayout* layout_;
 
   std::vector<Track*> sorted_tracks_;
   bool sorting_invalidated_ = false;

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -15,8 +15,8 @@
 #include "TimeGraph.h"
 
 TriangleToggle::TriangleToggle(State initial_state, StateChangeHandler handler,
-                               TimeGraph* time_graph)
-    : CaptureViewElement(time_graph),
+                               TimeGraph* time_graph, TimeGraphLayout* layout)
+    : CaptureViewElement(time_graph, layout),
       state_(initial_state),
       initial_state_(initial_state),
       handler_(std::move(handler)) {}

--- a/src/OrbitGl/TriangleToggle.h
+++ b/src/OrbitGl/TriangleToggle.h
@@ -18,7 +18,8 @@ class TriangleToggle : public orbit_gl::CaptureViewElement,
   enum class InitialStateUpdate { kKeepInitialState, kReplaceInitialState };
 
   using StateChangeHandler = std::function<void(TriangleToggle::State)>;
-  explicit TriangleToggle(State initial_state, StateChangeHandler handler, TimeGraph* time_graph);
+  explicit TriangleToggle(State initial_state, StateChangeHandler handler, TimeGraph* time_graph,
+                          TimeGraphLayout* layout);
   ~TriangleToggle() override = default;
 
   TriangleToggle() = delete;


### PR DESCRIPTION
Part of http://b/176086740.

We are erasing TimeGraph->GetLayout() dependence by adding the layout in
Tracks' constructors. Also TimeGraph->CalculateZoomedFontSize moving that
function into TimeGraphLayout.

Discussed in go/stadia-orbit-technical-debt.

Test: Loaded a capture.