### PR TITLE
Make `capture_data_` const* in all Tracks and remove SetCaptureData.

### DIFF
--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -31,7 +31,7 @@ using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::TimerInfo;
 
 AsyncTrack::AsyncTrack(TimeGraph* time_graph, TimeGraphLayout* layout, const std::string& name,
-                       OrbitApp* app, CaptureData* capture_data)
+                       OrbitApp* app, const CaptureData* capture_data)
     : TimerTrack(time_graph, layout, app, capture_data) {
   SetName(name);
   SetLabel(name);

--- a/src/OrbitGl/AsyncTrack.h
+++ b/src/OrbitGl/AsyncTrack.h
@@ -25,7 +25,7 @@ class OrbitApp;
 class AsyncTrack final : public TimerTrack {
  public:
   explicit AsyncTrack(TimeGraph* time_graph, TimeGraphLayout* layout, const std::string& name,
-                      OrbitApp* app, CaptureData* capture_data);
+                      OrbitApp* app, const CaptureData* capture_data);
 
   [[nodiscard]] Type GetType() const override { return kAsyncTrack; };
   [[nodiscard]] std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const override;

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -703,7 +703,7 @@ void CaptureWindow::set_draw_help(bool draw_help) {
   NeedsRedraw();
 }
 
-void CaptureWindow::CreateTimeGraph(CaptureData* capture_data) {
+void CaptureWindow::CreateTimeGraph(const CaptureData* capture_data) {
   time_graph_ = std::make_unique<TimeGraph>(app_, &text_renderer_, this, capture_data);
 }
 

--- a/src/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/CaptureWindow.h
@@ -76,7 +76,7 @@ class CaptureWindow : public GlCanvas {
     if (time_graph_ == nullptr) return nullptr;
     return time_graph_.get();
   }
-  void CreateTimeGraph(CaptureData* capture_data);
+  void CreateTimeGraph(const CaptureData* capture_data);
   void ClearTimeGraph() { time_graph_ = nullptr; }
 
   Batcher& GetBatcherById(BatcherId batcher_id);

--- a/src/OrbitGl/EventTrack.cpp
+++ b/src/OrbitGl/EventTrack.cpp
@@ -32,7 +32,7 @@ using orbit_client_protos::CallstackEvent;
 namespace orbit_gl {
 
 EventTrack::EventTrack(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
-                       CaptureData* capture_data, ThreadID thread_id)
+                       const CaptureData* capture_data, ThreadID thread_id)
     : ThreadBar(app, time_graph, layout, capture_data, thread_id), color_{0, 255, 0, 255} {}
 
 std::string EventTrack::GetTooltip() const { return "Left-click and drag to select samples"; }

--- a/src/OrbitGl/EventTrack.h
+++ b/src/OrbitGl/EventTrack.h
@@ -24,7 +24,7 @@ namespace orbit_gl {
 class EventTrack : public ThreadBar {
  public:
   explicit EventTrack(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
-                      CaptureData* capture_data, ThreadID thread_id);
+                      const CaptureData* capture_data, ThreadID thread_id);
 
   std::string GetTooltip() const override;
 

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -65,7 +65,7 @@ float FrameTrack::GetAverageBoxHeight() const {
 }
 
 FrameTrack::FrameTrack(TimeGraph* time_graph, TimeGraphLayout* layout, uint64_t function_id,
-                       FunctionInfo function, OrbitApp* app, CaptureData* capture_data)
+                       FunctionInfo function, OrbitApp* app, const CaptureData* capture_data)
     : TimerTrack(time_graph, layout, app, capture_data),
       function_id_(function_id),
       function_(std::move(function)) {

--- a/src/OrbitGl/FrameTrack.h
+++ b/src/OrbitGl/FrameTrack.h
@@ -26,7 +26,7 @@ class FrameTrack : public TimerTrack {
  public:
   explicit FrameTrack(TimeGraph* time_graph, TimeGraphLayout* layout, uint64_t function_id,
                       orbit_client_protos::FunctionInfo function, OrbitApp* app,
-                      CaptureData* capture_data);
+                      const CaptureData* capture_data);
   [[nodiscard]] Type GetType() const override { return kFrameTrack; }
   [[nodiscard]] uint64_t GetFunctionId() const { return function_id_; }
   [[nodiscard]] bool IsCollapsible() const override { return GetMaximumScaleFactor() > 0.f; }

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -66,7 +66,7 @@ std::string MapGpuTimelineToTrackLabel(std::string_view timeline) {
 }  // namespace orbit_gl
 
 GpuTrack::GpuTrack(TimeGraph* time_graph, TimeGraphLayout* layout, uint64_t timeline_hash,
-                   OrbitApp* app, CaptureData* capture_data)
+                   OrbitApp* app, const CaptureData* capture_data)
     : TimerTrack(time_graph, layout, app, capture_data) {
   text_renderer_ = time_graph->GetTextRenderer();
   timeline_hash_ = timeline_hash;

--- a/src/OrbitGl/GpuTrack.h
+++ b/src/OrbitGl/GpuTrack.h
@@ -34,7 +34,7 @@ std::string MapGpuTimelineToTrackLabel(std::string_view timeline);
 class GpuTrack : public TimerTrack {
  public:
   explicit GpuTrack(TimeGraph* time_graph, TimeGraphLayout* layout, uint64_t timeline_hash,
-                    OrbitApp* app, CaptureData* capture_data);
+                    OrbitApp* app, const CaptureData* capture_data);
   ~GpuTrack() override = default;
   [[nodiscard]] std::string GetTooltip() const override;
   [[nodiscard]] Type GetType() const override { return kGpuTrack; }

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -16,7 +16,7 @@
 #include "TimeGraphLayout.h"
 
 GraphTrack::GraphTrack(TimeGraph* time_graph, TimeGraphLayout* layout, std::string name,
-                       CaptureData* capture_data)
+                       const CaptureData* capture_data)
     : Track(time_graph, layout, capture_data) {
   SetName(name);
   SetLabel(name);

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -24,7 +24,7 @@ class TimeGraph;
 class GraphTrack : public Track {
  public:
   explicit GraphTrack(TimeGraph* time_graph, TimeGraphLayout* layout, std::string name,
-                      CaptureData* capture_data);
+                      const CaptureData* capture_data);
   [[nodiscard]] Type GetType() const override { return kGraphTrack; }
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -22,7 +22,7 @@ const Color kInactiveColor(100, 100, 100, 255);
 const Color kSelectionColor(0, 128, 255, 255);
 
 SchedulerTrack::SchedulerTrack(TimeGraph* time_graph, TimeGraphLayout* layout, OrbitApp* app,
-                               CaptureData* capture_data)
+                               const CaptureData* capture_data)
     : TimerTrack(time_graph, layout, app, capture_data) {
   SetPinned(false);
   SetName("Scheduler");

--- a/src/OrbitGl/SchedulerTrack.h
+++ b/src/OrbitGl/SchedulerTrack.h
@@ -19,7 +19,7 @@ class OrbitApp;
 class SchedulerTrack final : public TimerTrack {
  public:
   explicit SchedulerTrack(TimeGraph* time_graph, TimeGraphLayout* layout, OrbitApp* app,
-                          CaptureData* capture_data);
+                          const CaptureData* capture_data);
   ~SchedulerTrack() override = default;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
 

--- a/src/OrbitGl/ThreadBar.h
+++ b/src/OrbitGl/ThreadBar.h
@@ -19,7 +19,7 @@ namespace orbit_gl {
 class ThreadBar : public CaptureViewElement, public std::enable_shared_from_this<ThreadBar> {
  public:
   explicit ThreadBar(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
-                     CaptureData* capture_data, ThreadID thread_id)
+                     const CaptureData* capture_data, ThreadID thread_id)
       : CaptureViewElement(time_graph, layout),
         thread_id_(thread_id),
         app_(app),
@@ -28,12 +28,10 @@ class ThreadBar : public CaptureViewElement, public std::enable_shared_from_this
   void SetThreadId(ThreadID thread_id) { thread_id_ = thread_id; }
   [[nodiscard]] virtual bool IsEmpty() const { return false; }
 
-  void SetCaptureData(CaptureData* capture_data) { capture_data_ = capture_data; }
-
  protected:
   ThreadID thread_id_ = -1;
   OrbitApp* app_;
-  CaptureData* capture_data_;
+  const CaptureData* capture_data_;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/ThreadStateTrack.cpp
+++ b/src/OrbitGl/ThreadStateTrack.cpp
@@ -23,7 +23,7 @@ using orbit_client_protos::ThreadStateSliceInfo;
 namespace orbit_gl {
 
 ThreadStateTrack::ThreadStateTrack(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
-                                   CaptureData* capture_data, ThreadID thread_id)
+                                   const CaptureData* capture_data, ThreadID thread_id)
     : ThreadBar(app, time_graph, layout, capture_data, thread_id) {}
 
 bool ThreadStateTrack::IsEmpty() const {

--- a/src/OrbitGl/ThreadStateTrack.h
+++ b/src/OrbitGl/ThreadStateTrack.h
@@ -24,7 +24,7 @@ namespace orbit_gl {
 class ThreadStateTrack final : public ThreadBar {
  public:
   explicit ThreadStateTrack(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
-                            CaptureData* capture_data, ThreadID thread_id);
+                            const CaptureData* capture_data, ThreadID thread_id);
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -35,7 +35,7 @@ using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::TimerInfo;
 
 ThreadTrack::ThreadTrack(TimeGraph* time_graph, TimeGraphLayout* layout, int32_t thread_id,
-                         OrbitApp* app, CaptureData* capture_data)
+                         OrbitApp* app, const CaptureData* capture_data)
     : TimerTrack(time_graph, layout, app, capture_data) {
   thread_id_ = thread_id;
   InitializeNameAndLabel(thread_id);
@@ -72,13 +72,6 @@ void ThreadTrack::InitializeNameAndLabel(int32_t thread_id) {
     SetLabel(track_label);
     SetNumberOfPrioritizedTrailingCharacters(tid_str.size() + 2);
   }
-}
-
-void ThreadTrack::SetCaptureData(CaptureData* capture_data) {
-  Track::SetCaptureData(capture_data);
-  thread_state_track_->SetCaptureData(capture_data);
-  event_track_->SetCaptureData(capture_data);
-  tracepoint_track_->SetCaptureData(capture_data);
 }
 
 const TextBox* ThreadTrack::GetLeft(const TextBox* text_box) const {

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -26,10 +26,8 @@ class OrbitApp;
 class ThreadTrack final : public TimerTrack {
  public:
   explicit ThreadTrack(TimeGraph* time_graph, TimeGraphLayout* layout, int32_t thread_id,
-                       OrbitApp* app, CaptureData* capture_data);
+                       OrbitApp* app, const CaptureData* capture_data);
   void InitializeNameAndLabel(int32_t thread_id);
-
-  void SetCaptureData(CaptureData* capture_data) override;
 
   [[nodiscard]] int32_t GetThreadId() const { return thread_id_; }
 

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -40,7 +40,7 @@ using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::TimerInfo;
 
 TimeGraph::TimeGraph(OrbitApp* app, TextRenderer* text_renderer, GlCanvas* canvas,
-                     CaptureData* capture_data)
+                     const CaptureData* capture_data)
     : text_renderer_{text_renderer},
       canvas_{canvas},
       accessibility_(this),

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -37,7 +37,7 @@ class OrbitApp;
 class TimeGraph {
  public:
   explicit TimeGraph(OrbitApp* app, TextRenderer* text_renderer, GlCanvas* canvas,
-                     CaptureData* capture_data);
+                     const CaptureData* capture_data);
   ~TimeGraph();
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode = PickingMode::kNone);
@@ -228,7 +228,7 @@ class TimeGraph {
 
   ManualInstrumentationManager* manual_instrumentation_manager_;
   std::unique_ptr<ManualInstrumentationManager::AsyncTimerInfoListener> async_timer_info_listener_;
-  CaptureData* capture_data_ = nullptr;
+  const CaptureData* capture_data_ = nullptr;
 
   OrbitApp* app_ = nullptr;
 };

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -28,7 +28,7 @@ using orbit_client_protos::TimerInfo;
 ABSL_DECLARE_FLAG(bool, show_return_values);
 
 TimerTrack::TimerTrack(TimeGraph* time_graph, TimeGraphLayout* layout, OrbitApp* app,
-                       CaptureData* capture_data)
+                       const CaptureData* capture_data)
     : Track(time_graph, layout, capture_data), app_{app} {
   text_renderer_ = time_graph->GetTextRenderer();
 }

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -51,7 +51,7 @@ struct DrawData {
 class TimerTrack : public Track {
  public:
   explicit TimerTrack(TimeGraph* time_graph, TimeGraphLayout* layout, OrbitApp* app,
-                      CaptureData* capture_data);
+                      const CaptureData* capture_data);
   ~TimerTrack() override = default;
 
   // Pickable

--- a/src/OrbitGl/TracepointTrack.cpp
+++ b/src/OrbitGl/TracepointTrack.cpp
@@ -27,7 +27,7 @@
 namespace orbit_gl {
 
 TracepointTrack::TracepointTrack(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
-                                 CaptureData* capture_data, int32_t thread_id)
+                                 const CaptureData* capture_data, int32_t thread_id)
     : ThreadBar(app, time_graph, layout, capture_data, thread_id), color_{255, 0, 0, 255} {}
 
 void TracepointTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {

--- a/src/OrbitGl/TracepointTrack.h
+++ b/src/OrbitGl/TracepointTrack.h
@@ -16,7 +16,7 @@ namespace orbit_gl {
 class TracepointTrack : public ThreadBar {
  public:
   explicit TracepointTrack(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
-                           CaptureData* capture_data, int32_t thread_id);
+                           const CaptureData* capture_data, int32_t thread_id);
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
 

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -17,7 +17,7 @@
 #include "TimeGraph.h"
 #include "TimeGraphLayout.h"
 
-Track::Track(TimeGraph* time_graph, TimeGraphLayout* layout, CaptureData* capture_data)
+Track::Track(TimeGraph* time_graph, TimeGraphLayout* layout, const CaptureData* capture_data)
     : CaptureViewElement(time_graph, layout),
       collapse_toggle_(std::make_shared<TriangleToggle>(
           TriangleToggle::State::kExpanded,

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -43,7 +43,7 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
     kUnknown,
   };
 
-  explicit Track(TimeGraph* time_graph, TimeGraphLayout* layout, CaptureData* capture_data);
+  explicit Track(TimeGraph* time_graph, TimeGraphLayout* layout, const CaptureData* capture_data);
   ~Track() override = default;
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
@@ -51,8 +51,6 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;
   void OnDrag(int x, int y) override;
-
-  virtual void SetCaptureData(CaptureData* capture_data) { capture_data_ = capture_data; }
 
   [[nodiscard]] virtual Type GetType() const = 0;
   [[nodiscard]] virtual bool Movable() { return !pinned_; }
@@ -126,7 +124,7 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   std::shared_ptr<TriangleToggle> collapse_toggle_;
 
   orbit_gl::AccessibleTrack accessibility_;
-  CaptureData* capture_data_ = nullptr;
+  const CaptureData* capture_data_ = nullptr;
 };
 
 #endif

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -33,7 +33,7 @@
 using orbit_client_protos::FunctionInfo;
 
 TrackManager::TrackManager(TimeGraph* time_graph, TimeGraphLayout* layout, OrbitApp* app,
-                           CaptureData* capture_data)
+                           const CaptureData* capture_data)
     : time_graph_(time_graph), layout_(layout), capture_data_{capture_data}, app_{app} {
   GetOrCreateSchedulerTrack();
   tracepoints_system_wide_track_ = GetOrCreateThreadTrack(orbit_base::kAllThreadsOfAllProcessesTid);

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -35,7 +35,7 @@ class Timegraph;
 class TrackManager {
  public:
   explicit TrackManager(TimeGraph* time_graph, TimeGraphLayout* layout, OrbitApp* app,
-                        CaptureData* capture_data);
+                        const CaptureData* capture_data);
 
   [[nodiscard]] std::vector<Track*> GetAllTracks() const;
   [[nodiscard]] std::vector<Track*> GetVisibleTracks() const { return visible_tracks_; }
@@ -96,7 +96,7 @@ class TrackManager {
   std::vector<Track*> visible_tracks_;
 
   float tracks_total_height_ = 0.0f;
-  CaptureData* capture_data_ = nullptr;
+  const CaptureData* capture_data_ = nullptr;
 
   OrbitApp* app_ = nullptr;
 };


### PR DESCRIPTION
This makes the `capture_data_` member const* in all Track(like)
classes. Further it removes some unused SetCaptureData methods,
that are not needed anymore, as TimeGraph/TrackManager will be
fresh for every capture, thus for every capture data.

Bug: http://b/180313647
Test: Compile