### PR TITLE
Update Conan recipe for libjpeg to fix non-corp compilation

### DIFF
--- a/third_party/conan/lockfiles/base.lock
+++ b/third_party/conan/lockfiles/base.lock
@@ -630,7 +630,7 @@
     "context": "host"
    },
    "75": {
-    "ref": "libjpeg/9d#49cd55b89e283cef306e31b8ce8d1d7f",
+    "ref": "libjpeg/9d#9c2c46fd74c85f5e6058e14abcf985e4",
     "context": "host"
    },
    "76": {


### PR DESCRIPTION
We were running into the same issue presented here:
https://github.com/conan-io/conan-center-index/issues/4151

Switching to the latest recipe seems to fix the problem.