### PR TITLE
Same warning messages on close

### DIFF
--- a/src/OrbitQt/ConnectToStadiaWidget.cpp
+++ b/src/OrbitQt/ConnectToStadiaWidget.cpp
@@ -328,7 +328,7 @@ void ConnectToStadiaWidget::OnConnectToStadiaRadioButtonClicked(bool checked) {
 }
 
 void ConnectToStadiaWidget::OnErrorOccurred(const QString& message) {
-  if (isVisible()) {
+  if (IsActive()) {
     QMessageBox::critical(this, QApplication::applicationName(), message);
   } else {
     ERROR("%s", message.toStdString());

--- a/src/OrbitQt/main.cpp
+++ b/src/OrbitQt/main.cpp
@@ -164,7 +164,7 @@ void RunUiInstance(const DeploymentConfiguration& deployment_configuration,
       target_config = w.ClearTargetConfiguration();
     }
 
-    if (application_return_code == 0) {
+    if (application_return_code == OrbitMainWindow::kQuitOrbitReturnCode) {
       // User closed window
       break;
     } else if (application_return_code == OrbitMainWindow::kEndSessionReturnCode) {

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -54,6 +54,7 @@ class OrbitMainWindow : public QMainWindow {
   Q_OBJECT
 
  public:
+  static constexpr int kQuitOrbitReturnCode = 0;
   static constexpr int kEndSessionReturnCode = 1;
 
   explicit OrbitMainWindow(orbit_qt::TargetConfiguration target_configuration,
@@ -163,6 +164,8 @@ class OrbitMainWindow : public QMainWindow {
 
   static const QString kCollectThreadStatesSettingKey;
   void LoadCaptureOptionsIntoApp();
+
+  bool RequestExitWithReturnCode(int return_code);
 
  private:
   std::shared_ptr<MainThreadExecutor> main_thread_executor_;


### PR DESCRIPTION
2 commits. 

1. fixes a bug, where ConnectToStadiaWidget error messages have been displayed, even though the widget was not active.
2. Shows the same warnings when clicking "End Session" and "X"