### PR TITLE
Make ListFilesRecursivelyIgnoreErrors noexcept

### DIFF
--- a/src/OrbitBase/Logging.cpp
+++ b/src/OrbitBase/Logging.cpp
@@ -21,16 +21,18 @@ static absl::Mutex log_file_mutex(absl::kConstInit);
 std::ofstream log_file;
 
 std::string GetLogFileName() {
-  std::string timestamp_string =
-      absl::FormatTime(kLogFileNameTimeFormat, absl::Now(), absl::LocalTimeZone());
-  return absl::StrFormat(kLogFileNameDelimiter, timestamp_string,
+  std::string timestamp_string = absl::FormatTime(orbit_base_internal::kLogFileNameTimeFormat,
+                                                  absl::Now(), absl::UTCTimeZone());
+  return absl::StrFormat(orbit_base_internal::kLogFileNameDelimiter, timestamp_string,
                          static_cast<uint32_t>(orbit_base::GetCurrentProcessId()));
 }
 
 ErrorMessageOr<void> TryRemoveOldLogFiles(const std::filesystem::path& log_dir) {
-  std::vector<std::filesystem::path> log_file_paths = ListFiles(log_dir);
-  std::vector<std::filesystem::path> old_files = FilterOldLogFiles(log_file_paths);
-  return RemoveFiles(old_files);
+  std::vector<std::filesystem::path> log_file_paths =
+      orbit_base_internal::ListFilesRecursivelyIgnoreErrors(log_dir);
+  std::vector<std::filesystem::path> old_files =
+      orbit_base_internal::FindOldLogFiles(log_file_paths);
+  return orbit_base_internal::RemoveFiles(old_files);
 }
 
 void InitLogFile(const std::filesystem::path& path) {

--- a/src/OrbitBase/LoggingUtils.cpp
+++ b/src/OrbitBase/LoggingUtils.cpp
@@ -11,6 +11,9 @@
 #include <system_error>
 
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/SafeStrerror.h"
+
+namespace orbit_base_internal {
 
 const absl::Duration kLogFileLifetime = absl::Hours(24 * 7);  // one week
 // Determined by kLogFileNameDelimiter, i.e., the format of log file names.
@@ -18,17 +21,39 @@ const int kTimestampStartPos = 6;
 // Determined by kLogFileNameTimeFormat, i.e., the format of timestamp contained in log file names.
 const int kTimestampStringLength = 19;
 
-std::vector<std::filesystem::path> ListFiles(const std::filesystem::path& log_dir) {
+std::vector<std::filesystem::path> ListFilesRecursivelyIgnoreErrors(
+    const std::filesystem::path& dir) noexcept {
   std::vector<std::filesystem::path> files_in_dir;
-  for (const auto& file_path : std::filesystem::recursive_directory_iterator(log_dir)) {
-    if (file_path.is_regular_file()) {
-      files_in_dir.push_back(file_path.path());
+  std::error_code error;
+  auto directory_iterator = std::filesystem::recursive_directory_iterator(dir, error);
+  if (error) {
+    ERROR("Unable to open directory \"%s\": %s", dir.string(), error.message());
+    return {};
+  }
+
+  for (auto it = std::filesystem::begin(directory_iterator),
+            end = std::filesystem::end(directory_iterator);
+       it != end; it.increment(error)) {
+    if (error) {
+      ERROR("directory_iterator::increment failed for \"%s\": %s (will ignore)", dir.string(),
+            error.message());
+      continue;
+    }
+    bool is_regular_file = it->is_regular_file(error);
+    if (error) {
+      ERROR("Unable to stat \"%s\": %s (will ignore)", it->path().string(), error.message());
+      continue;
+    }
+
+    if (is_regular_file) {
+      files_in_dir.push_back(it->path());
     }
   }
+
   return files_in_dir;
 }
 
-ErrorMessageOr<absl::Duration> GetLogFileLifetime(const std::string& log_file_name) {
+ErrorMessageOr<absl::Time> ParseLogFileTimestamp(const std::string& log_file_name) noexcept {
   if (log_file_name.size() < kTimestampStartPos + kTimestampStringLength) {
     return ErrorMessage(
         absl::StrFormat("Unable to extract time information from log file: %s", log_file_name));
@@ -36,39 +61,40 @@ ErrorMessageOr<absl::Duration> GetLogFileLifetime(const std::string& log_file_na
   std::string timestamp_string = log_file_name.substr(kTimestampStartPos, kTimestampStringLength);
   absl::Time log_file_timestamp;
   std::string parse_time_error;
-  if (!absl::ParseTime(kLogFileNameTimeFormat, timestamp_string, absl::LocalTimeZone(),
+  if (!absl::ParseTime(kLogFileNameTimeFormat, timestamp_string, absl::UTCTimeZone(),
                        &log_file_timestamp, &parse_time_error)) {
     return ErrorMessage(
         absl::StrFormat("Error while parsing time information from log file %s : %s", log_file_name,
                         parse_time_error));
   }
-  return absl::Now() - log_file_timestamp;
+  return log_file_timestamp;
 }
 
-std::vector<std::filesystem::path> FilterOldLogFiles(
-    const std::vector<std::filesystem::path>& log_file_paths) {
+std::vector<std::filesystem::path> FindOldLogFiles(
+    const std::vector<std::filesystem::path>& file_paths) noexcept {
   std::vector<std::filesystem::path> old_files;
-  for (std::filesystem::path log_file_path : log_file_paths) {
-    ErrorMessageOr<absl::Duration> get_lifetime_result =
-        GetLogFileLifetime(log_file_path.filename().string());
-    if (!get_lifetime_result) {
-      LOG("Warning: %s", get_lifetime_result.error().message());
+  absl::Time expiration_time = absl::Now() - kLogFileLifetime;
+  for (const std::filesystem::path& log_file_path : file_paths) {
+    ErrorMessageOr<absl::Time> timestamp_result =
+        ParseLogFileTimestamp(log_file_path.filename().string());
+    if (!timestamp_result) {
+      LOG("Warning: %s", timestamp_result.error().message());
       continue;
     }
-    if (get_lifetime_result.value() > kLogFileLifetime) {
+    if (timestamp_result.value() < expiration_time) {
       old_files.push_back(log_file_path);
     }
   }
   return old_files;
 }
 
-ErrorMessageOr<void> RemoveFiles(const std::vector<std::filesystem::path>& log_file_paths) {
+ErrorMessageOr<void> RemoveFiles(const std::vector<std::filesystem::path>& file_paths) noexcept {
   std::string error_message;
-  for (const auto& log_file_path : log_file_paths) {
+  for (const auto& file_path : file_paths) {
     std::error_code file_remove_error;
-    if (!std::filesystem::remove(log_file_path, file_remove_error)) {
-      absl::StrAppend(&error_message, "Error while removing ", log_file_path.filename().string(),
-                      ": ", file_remove_error.message(), "\n");
+    if (!std::filesystem::remove(file_path, file_remove_error)) {
+      absl::StrAppend(&error_message, "Error while removing ", file_path.filename().string(), ": ",
+                      file_remove_error.message(), "\n");
     }
   }
   if (!error_message.empty()) {
@@ -76,3 +102,5 @@ ErrorMessageOr<void> RemoveFiles(const std::vector<std::filesystem::path>& log_f
   }
   return outcome::success();
 }
+
+}  // namespace orbit_base_internal

--- a/src/OrbitBase/LoggingUtils.h
+++ b/src/OrbitBase/LoggingUtils.h
@@ -12,16 +12,20 @@
 
 #include "OrbitBase/Result.h"
 
-constexpr const char* kLogFileNameTimeFormat = "%Y_%m_%d_%H_%M_%S";
-constexpr absl::string_view kLogFileNameDelimiter = "Orbit-%s-%u.log";
+namespace orbit_base_internal {
 
-[[nodiscard]] std::vector<std::filesystem::path> ListFiles(const std::filesystem::path& log_dir);
-ErrorMessageOr<absl::Duration> GetLogFileLifetime(const std::string& log_file_name);
-[[nodiscard]] std::vector<std::filesystem::path> FilterOldLogFiles(
-    const std::vector<std::filesystem::path>& log_file_paths);
+constexpr const char* kLogFileNameTimeFormat = "%Y_%m_%d_%H_%M_%S";
+constexpr const char* kLogFileNameDelimiter = "Orbit-%s-%u.log";
+
+[[nodiscard]] std::vector<std::filesystem::path> ListFilesRecursivelyIgnoreErrors(
+    const std::filesystem::path& dir) noexcept;
+ErrorMessageOr<absl::Time> ParseLogFileTimestamp(const std::string& log_file_name) noexcept;
+[[nodiscard]] std::vector<std::filesystem::path> FindOldLogFiles(
+    const std::vector<std::filesystem::path>& log_file_paths) noexcept;
 // This function tries to remove files even when an error is returned. If some files are unable to
 // remove, it returns an error message to record names of those functions and details about the
 // remove failures.
-ErrorMessageOr<void> RemoveFiles(const std::vector<std::filesystem::path>& log_file_paths);
+ErrorMessageOr<void> RemoveFiles(const std::vector<std::filesystem::path>& file_paths) noexcept;
 
+}  // namespace orbit_base_internal
 #endif  // ORBIT_BASE_LOGGING_UTILS_H_


### PR DESCRIPTION
Also changed GetLogFileLifetime->ParseLogFileTimestamp it is easier to
test if it returns timestamp. Switched timestamps to UTC.

Move LoggingUtils methods to orbit_base_internal namespace

Test: run OrbitBaseTests