### PR TITLE
Use protobuf Arenas in LockFreeBufferCaptureEventProducer

### DIFF
--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -9,6 +9,9 @@ package orbit_grpc_protos;
 import "module.proto";
 import "tracepoint.proto";
 
+// This is needed by LockFreeBufferCaptureEventProducer.
+option cc_enable_arenas = true;
+
 message CaptureOptions {
   bool trace_context_switches = 1;
   int32 pid = 2;

--- a/src/GrpcProtos/producer_side_services.proto
+++ b/src/GrpcProtos/producer_side_services.proto
@@ -8,6 +8,9 @@ package orbit_grpc_protos;
 
 import "capture.proto";
 
+// This is needed by LockFreeBufferCaptureEventProducer.
+option cc_enable_arenas = true;
+
 message ReceiveCommandsAndSendEventsRequest {
   message BufferedCaptureEvents {
     reserved 1;

--- a/src/OrbitProducer/LockFreeBufferCaptureEventProducerTest.cpp
+++ b/src/OrbitProducer/LockFreeBufferCaptureEventProducerTest.cpp
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <gmock/gmock.h>
+#include <google/protobuf/arena.h>
 #include <grpcpp/server_impl.h>
 #include <grpcpp/support/channel_arguments.h>
 #include <gtest/gtest.h>
@@ -28,9 +29,9 @@ namespace {
 class LockFreeBufferCaptureEventProducerImpl
     : public LockFreeBufferCaptureEventProducer<std::string> {
  protected:
-  orbit_grpc_protos::ProducerCaptureEvent TranslateIntermediateEvent(
-      std::string&& /*intermediate_event*/) override {
-    return orbit_grpc_protos::ProducerCaptureEvent{};
+  orbit_grpc_protos::ProducerCaptureEvent* TranslateIntermediateEvent(
+      std::string&& /*intermediate_event*/, google::protobuf::Arena* arena) override {
+    return google::protobuf::Arena::CreateMessage<orbit_grpc_protos::ProducerCaptureEvent>(arena);
   }
 };
 

--- a/src/OrbitProducer/include/OrbitProducer/LockFreeBufferCaptureEventProducer.h
+++ b/src/OrbitProducer/include/OrbitProducer/LockFreeBufferCaptureEventProducer.h
@@ -108,6 +108,7 @@ class LockFreeBufferCaptureEventProducer : public CaptureEventProducer {
           orbit_grpc_protos::ReceiveCommandsAndSendEventsRequest send_request;
           auto* capture_events =
               send_request.mutable_buffered_capture_events()->mutable_capture_events();
+          capture_events->Reserve(dequeued_event_count);
           for (size_t i = 0; i < dequeued_event_count; ++i) {
             orbit_grpc_protos::ProducerCaptureEvent* event = capture_events->Add();
             *event = TranslateIntermediateEvent(std::move(dequeued_events[i]));
@@ -135,7 +136,7 @@ class LockFreeBufferCaptureEventProducer : public CaptureEventProducer {
         }
       }
 
-      static constexpr std::chrono::duration kSleepOnEmptyQueue = std::chrono::microseconds{100};
+      static constexpr std::chrono::duration kSleepOnEmptyQueue = std::chrono::microseconds{1000};
       // Wait for lock_free_queue_ to fill up with new CaptureEvents.
       std::this_thread::sleep_for(kSleepOnEmptyQueue);
     }

--- a/src/Service/ProducerSideServiceImpl.cpp
+++ b/src/Service/ProducerSideServiceImpl.cpp
@@ -11,11 +11,11 @@
 #include <utility>
 
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/ThreadUtils.h"
 #include "capture.pb.h"
 
 namespace orbit_service {
 
-using orbit_grpc_protos::ClientCaptureEvent;
 using orbit_grpc_protos::ProducerCaptureEvent;
 
 void ProducerSideServiceImpl::OnCaptureStartRequested(
@@ -354,6 +354,8 @@ void ProducerSideServiceImpl::ReceiveEventsThread(
     grpc::ServerReaderWriter<orbit_grpc_protos::ReceiveCommandsAndSendEventsResponse,
                              orbit_grpc_protos::ReceiveCommandsAndSendEventsRequest>* stream,
     uint64_t producer_id, bool* all_events_sent_received) {
+  orbit_base::SetCurrentThreadName("PSSI::RcvEvents");
+
   orbit_grpc_protos::ReceiveCommandsAndSendEventsRequest request;
   while (stream->Read(&request)) {
     {


### PR DESCRIPTION
#### Name a couple of threads related to the channel to OrbitService
#### Minor performance tweaks to LockFreeBufferCaptureEventProducer
#### Use protobuf Arenas in LockFreeBufferCaptureEventProducer
After various experimenting, I can say that this can save *a lot* of extra work
in `LockFreeBufferCaptureEventProducer::ForwarderThread`, specifically in terms
of heap allocations and deallocations.

The one downside is that it prevents moves from an already constructed protobuf,
which is the case for the Vulkan layer. I tested the two cases on Trata and
Infiltrator and didn't notice any difference: `ForwarderThread` was and still is
around 1 to 2 % CPU utilizaton.

Bug: http://b/179969217