### PR TITLE
Make logging (to file) exception-free

### DIFF
--- a/src/OrbitBase/include/OrbitBase/Logging.h
+++ b/src/OrbitBase/include/OrbitBase/Logging.h
@@ -114,23 +114,13 @@ constexpr const char* kLogTimeFormat = "%Y-%m-%dT%H:%M:%E6S";
     absl::StrFormat(format, ##__VA_ARGS__)                                                     \
   }
 
-std::string GetLogFileName();
-// This function tries to remove log files older than kLogFileLifetime even when an error is
-// returned. An error returns, for instance, if some log files to remove are used by other
-// applications. If so, both the file name and the error message will be recorded in the log file.
-ErrorMessageOr<void> TryRemoveOldLogFiles(const std::filesystem::path& log_dir);
-
-extern std::ofstream log_file;
-void InitLogFile(const std::filesystem::path& path);
-void LogToFile(const std::string& message);
-
 // Internal.
 #if defined(_WIN32)
 #define PLATFORM_LOG(message)       \
   do {                              \
     fprintf(stderr, "%s", message); \
     OutputDebugStringA(message);    \
-    LogToFile(message);             \
+    orbit_base::LogToFile(message); \
   } while (0)
 #define PLATFORM_ABORT() \
   do {                   \
@@ -141,7 +131,7 @@ void LogToFile(const std::string& message);
 #define PLATFORM_LOG(message)       \
   do {                              \
     fprintf(stderr, "%s", message); \
-    LogToFile(message);             \
+    orbit_base::LogToFile(message); \
   } while (0)
 #define PLATFORM_ABORT() abort()
 #endif
@@ -150,6 +140,17 @@ void LogToFile(const std::string& message);
 #pragma clang diagnostic pop
 #endif
 
+namespace orbit_base {
+std::string GetLogFileName();
+// This function tries to remove log files older than kLogFileLifetime even when an error is
+// returned. An error returns, for instance, if some log files to remove are used by other
+// applications. If so, both the file name and the error message will be recorded in the log file.
+ErrorMessageOr<void> TryRemoveOldLogFiles(const std::filesystem::path& log_dir);
+
+void InitLogFile(const std::filesystem::path& path) noexcept;
+void LogToFile(const std::string& message) noexcept;
+
 void LogStacktrace();
+}  // namespace orbit_base
 
 #endif  // ORBIT_BASE_LOGGING_H_

--- a/src/OrbitBase/include/OrbitBase/UniqueResource.h
+++ b/src/OrbitBase/include/OrbitBase/UniqueResource.h
@@ -27,7 +27,7 @@ class unique_resource {
   using Resource = Resource_;
   using Deleter = Deleter_;
 
-  constexpr unique_resource() {}
+  constexpr unique_resource() = default;
   constexpr unique_resource(Resource resource, Deleter deleter = Deleter{})
       : resource_(std::move(resource)), deleter_(std::move(deleter)) {}
 

--- a/src/OrbitCaptureGgpService/main.cpp
+++ b/src/OrbitCaptureGgpService/main.cpp
@@ -53,7 +53,7 @@ int main(int argc, char** argv) {
 
   const std::string log_directory = absl::GetFlag(FLAGS_log_directory);
   if (!log_directory.empty()) {
-    InitLogFile(GetLogFilePath(log_directory));
+    orbit_base::InitLogFile(GetLogFilePath(log_directory));
   }
 
   if (!absl::GetFlag(FLAGS_pid)) {

--- a/src/OrbitClientGgp/main.cpp
+++ b/src/OrbitClientGgp/main.cpp
@@ -56,7 +56,7 @@ int main(int argc, char** argv) {
 
   const std::string log_directory = absl::GetFlag(FLAGS_log_directory);
   if (!log_directory.empty()) {
-    InitLogFile(GetLogFilePath(log_directory));
+    orbit_base::InitLogFile(GetLogFilePath(log_directory));
   }
 
   if (!absl::GetFlag(FLAGS_pid)) {

--- a/src/OrbitCore/Path.cpp
+++ b/src/OrbitCore/Path.cpp
@@ -73,5 +73,5 @@ std::filesystem::path Path::CreateOrGetLogDir() {
 }
 
 std::filesystem::path Path::GetLogFilePath() {
-  return Path::CreateOrGetLogDir() / GetLogFileName();
+  return Path::CreateOrGetLogDir() / orbit_base::GetLogFileName();
 }

--- a/src/OrbitQt/main.cpp
+++ b/src/OrbitQt/main.cpp
@@ -301,9 +301,10 @@ int main(int argc, char* argv[]) {
   // Skip program name in positional_args[0].
   std::vector<std::string> capture_file_paths(positional_args.begin() + 1, positional_args.end());
 
-  InitLogFile(Path::GetLogFilePath());
+  orbit_base::InitLogFile(Path::GetLogFilePath());
   LOG("You are running Orbit Profiler version %s", orbit_core::GetVersion());
-  ErrorMessageOr<void> remove_old_log_result = TryRemoveOldLogFiles(Path::CreateOrGetLogDir());
+  ErrorMessageOr<void> remove_old_log_result =
+      orbit_base::TryRemoveOldLogFiles(Path::CreateOrGetLogDir());
   if (remove_old_log_result.has_error()) {
     LOG("Warning: Unable to remove some old log files:\n%s",
         remove_old_log_result.error().message());

--- a/src/Service/main.cpp
+++ b/src/Service/main.cpp
@@ -49,7 +49,7 @@ std::string GetLogFilePath() {
 }  // namespace
 
 int main(int argc, char** argv) {
-  InitLogFile(GetLogFilePath());
+  orbit_base::InitLogFile(GetLogFilePath());
 
   absl::SetProgramUsageMessage("Orbit CPU Profiler Service");
   absl::SetFlagsUsageConfig(absl::FlagsUsageConfig{{}, {}, {}, &orbit_core::GetBuildReport, {}});


### PR DESCRIPTION
Switch from ofstream to FILE* to avoid accidental
exceptions while writing to log file.

Test: run orbit client - check logfile