### PR TITLE
Fix warning messages

### DIFF
--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -165,7 +165,8 @@ class OrbitMainWindow : public QMainWindow {
   static const QString kCollectThreadStatesSettingKey;
   void LoadCaptureOptionsIntoApp();
 
-  bool RequestExitWithReturnCode(int return_code);
+  [[nodiscard]] bool ConfirmExit();
+  void Exit(int return_code);
 
  private:
   std::shared_ptr<MainThreadExecutor> main_thread_executor_;


### PR DESCRIPTION
My recent change to align the warning messages on quit / end session, did introduce some unwanted behaviour. Before this change, cancelling the loading of a capture would lead to a "this discards any unsaved changes" warning. Same for when the capture loading failed. This PR fixes that.