### PR TITLE
Fix kokoro cleanup for presubmit coverage

### DIFF
--- a/kokoro/builds/build.sh
+++ b/kokoro/builds/build.sh
@@ -51,7 +51,19 @@ if [ -n "$1" ]; then
     echo "Delete all unnecessary files from the src/-directory."
     
     set +e # This is allowed to fail when deleting
-    if [ "${BUILD_TYPE}" == "presubmit" ]; then
+    if [ $CONAN_PROFILE == "coverage_clang9" ]; then
+      # In the coverage_clang9 case, we spare the results at build/package and this
+      # script (well, everything under kokoro).
+      echo "Cleanup for coverage_clang9"
+      find "${MOUNT_POINT}" ! -path "${MOUNT_POINT}" \
+                            ! -path "${MOUNT_POINT}/github" \
+                            ! -path "${REPO_ROOT}" \
+                            ! -path "${REPO_ROOT}/kokoro*" \
+                            ! -path "${REPO_ROOT}/build" \
+                            ! -path "${REPO_ROOT}/build/package*"\
+                            -delete
+      echo "Cleanup for coverage_clang9 done."
+    elif [ "${BUILD_TYPE}" == "presubmit" ]; then
       # In the presubmit case we only spare the testresults (under build/) and this
       # script (well, everything under kokoro).
       echo "Cleanup for presubmit."


### PR DESCRIPTION
The presubmit code coverage currently does not produce any results. I think this is because the results are "cleaned up" before kokoro can upload them to the bucket. This commit changes that by having an extra case in the cleanup part, for the `coverage_clang9` profile.