### PR TITLE
Introduce absl::Span in ModuleManager and ProcessData

### DIFF
--- a/src/OrbitClientData/ModuleManager.cpp
+++ b/src/OrbitClientData/ModuleManager.cpp
@@ -22,7 +22,7 @@ using orbit_client_protos::FunctionInfo;
 namespace orbit_client_data {
 
 std::vector<ModuleData*> ModuleManager::AddOrUpdateModules(
-    const std::vector<orbit_grpc_protos::ModuleInfo>& module_infos) {
+    absl::Span<const orbit_grpc_protos::ModuleInfo> module_infos) {
   absl::MutexLock lock(&mutex_);
 
   std::vector<ModuleData*> unloaded_modules;

--- a/src/OrbitClientData/ProcessData.cpp
+++ b/src/OrbitClientData/ProcessData.cpp
@@ -19,8 +19,7 @@ using orbit_grpc_protos::ProcessInfo;
 
 ProcessData::ProcessData() { process_info_.set_pid(-1); }
 
-void ProcessData::UpdateModuleInfos(
-    const std::vector<orbit_grpc_protos::ModuleInfo>& module_infos) {
+void ProcessData::UpdateModuleInfos(absl::Span<const orbit_grpc_protos::ModuleInfo> module_infos) {
   module_memory_map_.clear();
   start_addresses_.clear();
 

--- a/src/OrbitClientData/include/OrbitClientData/ModuleManager.h
+++ b/src/OrbitClientData/include/OrbitClientData/ModuleManager.h
@@ -28,7 +28,7 @@ class ModuleManager final {
   // symbols are discarded aka the module is not loaded anymore. This method returns the list of
   // modules that used to be loaded before the call and are not loaded anymore after the call.
   std::vector<ModuleData*> AddOrUpdateModules(
-      const std::vector<orbit_grpc_protos::ModuleInfo>& module_infos);
+      absl::Span<const orbit_grpc_protos::ModuleInfo> module_infos);
   [[nodiscard]] std::vector<orbit_client_protos::FunctionInfo> GetOrbitFunctionsOfProcess(
       const ProcessData& process) const;
 

--- a/src/OrbitClientData/include/OrbitClientData/ProcessData.h
+++ b/src/OrbitClientData/include/OrbitClientData/ProcessData.h
@@ -57,7 +57,7 @@ class ProcessData final {
   [[nodiscard]] const std::string& command_line() const { return process_info_.command_line(); }
   [[nodiscard]] bool is_64_bit() const { return process_info_.is_64_bit(); }
 
-  void UpdateModuleInfos(const std::vector<orbit_grpc_protos::ModuleInfo>& module_infos);
+  void UpdateModuleInfos(absl::Span<const orbit_grpc_protos::ModuleInfo> module_infos);
 
   [[nodiscard]] ErrorMessageOr<std::pair<std::string, uint64_t>> FindModuleByAddress(
       uint64_t absolute_address) const;


### PR DESCRIPTION
This simply replaces some `const std::vector<T>&` arguments by
`absl::Span<const T>` arguments. They implementation or caller changes
needed.

I will introduce the first real users of that in a subsequent commit.