### PR TITLE
Add test for Future::Then and Future::ThenIfSuccess

### DIFF
--- a/src/OrbitBase/include/OrbitBase/Future.h
+++ b/src/OrbitBase/include/OrbitBase/Future.h
@@ -177,7 +177,7 @@ class InternalFuture<void, Derived>
   // completes. Check the docs or implementation of `Executor::ScheduleAfter` to be sure.
   template <typename Executor, typename Invocable>
   auto Then(Executor* executor, Invocable&& invocable) const {
-    return executor->ScheduleAfter(*this->self(), std::forward<Invocable>(invocable));
+    return executor->ScheduleAfter(this->self(), std::forward<Invocable>(invocable));
   }
 
  private:


### PR DESCRIPTION
There was a typo in `Future::Then`'s implementation.

This PR fixes that and adds unit tests for Future::Then and Future::ThenIfSuccess.
These tests were not possible before because they require an executor. But since we
now have the `ImmediateExecutor` adding these missing tests was possible.