### PR TITLE
Expose setting to limit the local depth of markers per command buffer.

### DIFF
--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -46,6 +46,8 @@ message CaptureOptions {
   repeated TracepointInfo instrumented_tracepoint = 7;
 
   bool enable_introspection = 9;
+
+  uint64 max_local_marker_depth_per_command_buffer = 10;
 }
 
 // For CaptureEvents with a duration, excluding for now GPU-related ones, we

--- a/src/OrbitCaptureClient/CaptureClient.cpp
+++ b/src/OrbitCaptureClient/CaptureClient.cpp
@@ -57,7 +57,8 @@ Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> CaptureClient::Capture(
     const orbit_client_data::ModuleManager& module_manager,
     absl::flat_hash_map<uint64_t, FunctionInfo> selected_functions,
     TracepointInfoSet selected_tracepoints, absl::flat_hash_set<uint64_t> frame_track_function_ids,
-    bool collect_thread_state, bool enable_introspection) {
+    bool collect_thread_state, bool enable_introspection,
+    uint64_t max_local_marker_depth_per_command_buffer) {
   absl::MutexLock lock(&state_mutex_);
   if (state_ != State::kStopped) {
     return {
@@ -77,10 +78,11 @@ Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> CaptureClient::Capture(
       [this, process = std::move(process_copy), &module_manager,
        selected_functions = std::move(selected_functions), selected_tracepoints,
        frame_track_function_ids = std::move(frame_track_function_ids), collect_thread_state,
-       enable_introspection]() mutable {
+       enable_introspection, max_local_marker_depth_per_command_buffer]() mutable {
         return CaptureSync(std::move(process), module_manager, std::move(selected_functions),
                            std::move(selected_tracepoints), std::move(frame_track_function_ids),
-                           collect_thread_state, enable_introspection);
+                           collect_thread_state, enable_introspection,
+                           max_local_marker_depth_per_command_buffer);
       });
 
   return capture_result;
@@ -90,7 +92,8 @@ ErrorMessageOr<CaptureListener::CaptureOutcome> CaptureClient::CaptureSync(
     ProcessData&& process, const orbit_client_data::ModuleManager& module_manager,
     absl::flat_hash_map<uint64_t, FunctionInfo> selected_functions,
     TracepointInfoSet selected_tracepoints, absl::flat_hash_set<uint64_t> frame_track_function_ids,
-    bool collect_thread_state, bool enable_introspection) {
+    bool collect_thread_state, bool enable_introspection,
+    uint64_t max_local_marker_depth_per_command_buffer) {
   ORBIT_SCOPE_FUNCTION;
   writes_done_failed_ = false;
   try_abort_ = false;
@@ -120,6 +123,8 @@ ErrorMessageOr<CaptureListener::CaptureOutcome> CaptureClient::CaptureSync(
 
   capture_options->set_trace_thread_state(collect_thread_state);
   capture_options->set_trace_gpu_driver(true);
+  capture_options->set_max_local_marker_depth_per_command_buffer(
+      max_local_marker_depth_per_command_buffer);
   for (const auto& [function_id, function] : selected_functions) {
     CaptureOptions::InstrumentedFunction* instrumented_function =
         capture_options->add_instrumented_functions();

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
@@ -44,7 +44,7 @@ class CaptureClient {
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints,
       absl::flat_hash_set<uint64_t> frame_track_function_ids, bool collect_thread_state,
-      bool enable_introspection);
+      bool enable_introspection, uint64_t max_local_marker_depth_per_command_buffer);
 
   // Returns true if stop was initiated and false otherwise.
   // The latter can happen if for example the stop was already
@@ -72,7 +72,7 @@ class CaptureClient {
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints,
       absl::flat_hash_set<uint64_t> frame_track_function_ids, bool collect_thread_state,
-      bool enable_introspection);
+      bool enable_introspection, uint64_t max_local_marker_depth_per_command_buffer);
 
   [[nodiscard]] ErrorMessageOr<void> FinishCapture();
 

--- a/src/OrbitCaptureGgpService/main.cpp
+++ b/src/OrbitCaptureGgpService/main.cpp
@@ -29,6 +29,8 @@ ABSL_FLAG(std::string, log_directory, "",
 ABSL_FLAG(uint16_t, sampling_rate, 1000, "Frequency of callstack sampling in samples per second");
 ABSL_FLAG(bool, frame_pointer_unwinding, false, "Use frame pointers for unwinding");
 ABSL_FLAG(bool, thread_state, false, "Collect thread states");
+ABSL_FLAG(uint64_t, max_local_marker_depth_per_command_buffer, std::numeric_limits<uint64_t>::max(),
+          "Max local marker depth per command buffer");
 
 namespace {
 

--- a/src/OrbitClientGgp/ClientGgp.cpp
+++ b/src/OrbitClientGgp/ClientGgp.cpp
@@ -40,6 +40,7 @@
 #include "process.pb.h"
 
 ABSL_DECLARE_FLAG(bool, thread_state);
+ABSL_DECLARE_FLAG(uint64_t, max_local_marker_depth_per_command_buffer);
 
 using orbit_base::Future;
 using orbit_client_protos::CallstackEvent;
@@ -94,10 +95,13 @@ bool ClientGgp::RequestStartCapture(ThreadPool* thread_pool) {
   LOG("Capture pid %d", pid);
   TracepointInfoSet selected_tracepoints;
   bool collect_thread_state = absl::GetFlag(FLAGS_thread_state);
+  uint64_t max_local_marker_depth_per_command_buffer =
+      absl::GetFlag(FLAGS_max_local_marker_depth_per_command_buffer);
   bool enable_introspection = false;
   Future<ErrorMessageOr<CaptureOutcome>> result = capture_client_->Capture(
       thread_pool, target_process_, module_manager_, selected_functions_, selected_tracepoints,
-      absl::flat_hash_set<uint64_t>{}, collect_thread_state, enable_introspection);
+      absl::flat_hash_set<uint64_t>{}, collect_thread_state, enable_introspection,
+      max_local_marker_depth_per_command_buffer);
 
   orbit_base::ImmediateExecutor executer;
   result.Then(&executer, [this](ErrorMessageOr<CaptureOutcome> result) {

--- a/src/OrbitClientGgp/main.cpp
+++ b/src/OrbitClientGgp/main.cpp
@@ -36,6 +36,8 @@ ABSL_FLAG(std::string, log_directory, "",
 ABSL_FLAG(uint16_t, sampling_rate, 1000, "Frequency of callstack sampling in samples per second");
 ABSL_FLAG(bool, frame_pointer_unwinding, false, "Use frame pointers for unwinding");
 ABSL_FLAG(bool, thread_state, false, "Collect thread states");
+ABSL_FLAG(uint64_t, max_local_marker_depth_per_command_buffer, std::numeric_limits<uint64_t>::max(),
+          "Max local marker depth per command buffer");
 
 namespace {
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -868,12 +868,14 @@ void OrbitApp::StartCapture() {
   TracepointInfoSet selected_tracepoints = data_manager_->selected_tracepoints();
   bool collect_thread_states = data_manager_->collect_thread_states();
   bool enable_introspection = absl::GetFlag(FLAGS_devmode);
+  uint64_t max_local_marker_depth_per_command_buffer =
+      data_manager_->max_local_marker_depth_per_command_buffer();
 
   CHECK(capture_client_ != nullptr);
   Future<ErrorMessageOr<CaptureOutcome>> capture_result = capture_client_->Capture(
       thread_pool_.get(), *process, *module_manager_, std::move(selected_functions_map),
       std::move(selected_tracepoints), std::move(frame_track_function_ids), collect_thread_states,
-      enable_introspection);
+      enable_introspection, max_local_marker_depth_per_command_buffer);
 
   capture_result.Then(main_thread_executor_, [this](ErrorMessageOr<CaptureOutcome> capture_result) {
     if (capture_result.has_error()) {
@@ -1487,6 +1489,12 @@ void OrbitApp::UpdateProcessAndModuleList(int32_t pid) {
 
 void OrbitApp::SetCollectThreadStates(bool collect_thread_states) {
   data_manager_->set_collect_thread_states(collect_thread_states);
+}
+
+void OrbitApp::SetMaxLocalMarkerDepthPerCommandBuffer(
+    uint64_t max_local_marker_depth_per_command_buffer) {
+  data_manager_->set_max_local_marker_depth_per_command_buffer(
+      max_local_marker_depth_per_command_buffer);
 }
 
 void OrbitApp::SelectFunction(const orbit_client_protos::FunctionInfo& func) {

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -346,6 +346,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   }
 
   void SetCollectThreadStates(bool collect_thread_states);
+  void SetMaxLocalMarkerDepthPerCommandBuffer(uint64_t max_local_marker_depth_per_command_buffer);
 
   // TODO(kuebler): Move them to a separate controler at some point
   void SelectFunction(const orbit_client_protos::FunctionInfo& func);

--- a/src/OrbitGl/DataManager.h
+++ b/src/OrbitGl/DataManager.h
@@ -72,6 +72,15 @@ class DataManager final {
   }
   [[nodiscard]] bool collect_thread_states() const { return collect_thread_states_; }
 
+  void set_max_local_marker_depth_per_command_buffer(
+      uint64_t max_local_marker_depth_per_command_buffer) {
+    max_local_marker_depth_per_command_buffer_ = max_local_marker_depth_per_command_buffer;
+  }
+
+  [[nodiscard]] uint64_t max_local_marker_depth_per_command_buffer() {
+    return max_local_marker_depth_per_command_buffer_;
+  }
+
  private:
   const std::thread::id main_thread_id_;
   FunctionInfoSet selected_functions_;
@@ -88,6 +97,7 @@ class DataManager final {
   UserDefinedCaptureData user_defined_capture_data_;
 
   bool collect_thread_states_ = false;
+  uint64_t max_local_marker_depth_per_command_buffer_ = std::numeric_limits<uint64_t>::max();
 };
 
 #endif  // ORBIT_GL_DATA_MANAGER_H_

--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -4,10 +4,10 @@
 
 #include "CaptureOptionsDialog.h"
 
-#include <QCheckBox>
 #include <QDialog>
 #include <QDialogButtonBox>
 #include <QWidget>
+#include <QtGui/QValidator>
 
 #include "ui_CaptureOptionsDialog.h"
 
@@ -19,6 +19,8 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
 
   QObject::connect(ui_->buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
   QObject::connect(ui_->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+  ui_->localMarkerDepthLineEdit->setValidator(&uint64_validator_);
 }
 
 bool CaptureOptionsDialog::GetCollectThreadStates() const {
@@ -28,5 +30,33 @@ bool CaptureOptionsDialog::GetCollectThreadStates() const {
 void CaptureOptionsDialog::SetCollectThreadStates(bool collect_thread_state) {
   ui_->threadStateCheckBox->setChecked(collect_thread_state);
 }
+
+void CaptureOptionsDialog::SetLimitLocalMarkerDepthPerCommandBuffer(
+    bool limit_local_marker_depth_per_command_buffer) {
+  ui_->localMarkerDepthCheckBox->setChecked(limit_local_marker_depth_per_command_buffer);
+}
+
+bool CaptureOptionsDialog::GetLimitLocalMarkerDepthPerCommandBuffer() const {
+  return ui_->localMarkerDepthCheckBox->isChecked();
+}
+
+void CaptureOptionsDialog::SetMaxLocalMarkerDepthPerCommandBuffer(
+    uint64_t local_marker_depth_per_command_buffer) {
+  ui_->localMarkerDepthLineEdit->setText(QString::number(local_marker_depth_per_command_buffer));
+}
+
+uint64_t CaptureOptionsDialog::GetMaxLocalMarkerDepthPerCommandBuffer() const {
+  CHECK(!ui_->localMarkerDepthLineEdit->text().isEmpty());
+  bool valid = false;
+  uint64_t result = ui_->localMarkerDepthLineEdit->text().toULongLong(&valid);
+  CHECK(valid);
+  return result;
+}
+
+void CaptureOptionsDialog::resetLocalMarkerDepthLineEdit() {
+  if (ui_->localMarkerDepthLineEdit->text().isEmpty()) {
+    ui_->localMarkerDepthLineEdit->setText(QString::number(0));
+  }
+};
 
 }  // namespace orbit_qt

--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -53,10 +53,10 @@ uint64_t CaptureOptionsDialog::GetMaxLocalMarkerDepthPerCommandBuffer() const {
   return result;
 }
 
-void CaptureOptionsDialog::resetLocalMarkerDepthLineEdit() {
+void CaptureOptionsDialog::ResetLocalMarkerDepthLineEdit() {
   if (ui_->localMarkerDepthLineEdit->text().isEmpty()) {
     ui_->localMarkerDepthLineEdit->setText(QString::number(0));
   }
-};
+}
 
 }  // namespace orbit_qt

--- a/src/OrbitQt/CaptureOptionsDialog.h
+++ b/src/OrbitQt/CaptureOptionsDialog.h
@@ -8,6 +8,7 @@
 #include <QDialog>
 #include <QObject>
 #include <QString>
+#include <QValidator>
 #include <QWidget>
 #include <memory>
 
@@ -15,6 +16,24 @@
 #include "ui_CaptureOptionsDialog.h"
 
 namespace orbit_qt {
+
+namespace internal {
+class UInt64Validator : public QValidator {
+ public:
+  explicit UInt64Validator(QObject* parent = nullptr) : QValidator(parent) {}
+  QValidator::State validate(QString& input, int& /*pos*/) const override {
+    if (input.isEmpty()) {
+      return QValidator::State::Acceptable;
+    }
+    bool valid = false;
+    input.toULongLong(&valid);
+    if (valid) {
+      return QValidator::State::Acceptable;
+    }
+    return QValidator::State::Invalid;
+  }
+};
+}  // namespace internal
 
 class CaptureOptionsDialog : public QDialog {
   Q_OBJECT
@@ -24,9 +43,17 @@ class CaptureOptionsDialog : public QDialog {
 
   void SetCollectThreadStates(bool collect_thread_state);
   [[nodiscard]] bool GetCollectThreadStates() const;
+  void SetLimitLocalMarkerDepthPerCommandBuffer(bool limit_local_marker_depth_per_command_buffer);
+  [[nodiscard]] bool GetLimitLocalMarkerDepthPerCommandBuffer() const;
+  void SetMaxLocalMarkerDepthPerCommandBuffer(uint64_t local_marker_depth_per_command_buffer);
+  [[nodiscard]] uint64_t GetMaxLocalMarkerDepthPerCommandBuffer() const;
+
+ public slots:
+  void resetLocalMarkerDepthLineEdit();
 
  private:
   std::unique_ptr<Ui::CaptureOptionsDialog> ui_;
+  internal::UInt64Validator uint64_validator_;
 };
 
 }  // namespace orbit_qt

--- a/src/OrbitQt/CaptureOptionsDialog.h
+++ b/src/OrbitQt/CaptureOptionsDialog.h
@@ -17,7 +17,6 @@
 
 namespace orbit_qt {
 
-namespace internal {
 class UInt64Validator : public QValidator {
  public:
   explicit UInt64Validator(QObject* parent = nullptr) : QValidator(parent) {}
@@ -33,7 +32,6 @@ class UInt64Validator : public QValidator {
     return QValidator::State::Invalid;
   }
 };
-}  // namespace internal
 
 class CaptureOptionsDialog : public QDialog {
   Q_OBJECT
@@ -49,11 +47,11 @@ class CaptureOptionsDialog : public QDialog {
   [[nodiscard]] uint64_t GetMaxLocalMarkerDepthPerCommandBuffer() const;
 
  public slots:
-  void resetLocalMarkerDepthLineEdit();
+  void ResetLocalMarkerDepthLineEdit();
 
  private:
   std::unique_ptr<Ui::CaptureOptionsDialog> ui_;
-  internal::UInt64Validator uint64_validator_;
+  UInt64Validator uint64_validator_;
 };
 
 }  // namespace orbit_qt

--- a/src/OrbitQt/CaptureOptionsDialog.ui
+++ b/src/OrbitQt/CaptureOptionsDialog.ui
@@ -9,12 +9,16 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>200</height>
+    <width>440</width>
+    <height>260</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Capture Options</string>
+  </property>
+  <property name="toolTip">
+   <string>Limits the maximal depth of Vulkan debug markers per command buffer to the given value.
+Setting the value to &quot;0&quot; will disable Vulkan debug marker tracking.</string>
   </property>
   <property name="modal">
    <bool>true</bool>
@@ -23,30 +27,12 @@
    <property name="verticalSpacing">
     <number>9</number>
    </property>
-   <item row="0" column="0">
-    <layout class="QVBoxLayout" name="verticalLayout">
-     <item>
-      <widget class="QCheckBox" name="threadStateCheckBox">
-       <property name="text">
-        <string>Collect thread states</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="verticalSpacer">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>These settings will only apply starting from your next capture.</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+   <item row="2" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
    </item>
    <item row="1" column="0">
     <widget class="Line" name="line">
@@ -58,15 +44,234 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
+   <item row="0" column="0">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <item>
+        <widget class="Line" name="line_4">
+         <property name="styleSheet">
+          <string notr="true">background: #353535</string>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_4">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>General</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="Line" name="line_5">
+         <property name="styleSheet">
+          <string notr="true">background: #353535</string>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="threadStateCheckBox">
+       <property name="text">
+        <string>Collect thread states</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <widget class="Line" name="line_3">
+         <property name="styleSheet">
+          <string notr="true">background: #353535</string>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_3">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Vulkan layer</string>
+         </property>
+         <property name="scaledContents">
+          <bool>false</bool>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="Line" name="line_2">
+         <property name="styleSheet">
+          <string notr="true">background: #353535</string>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="localMarkerDepthCheckBox">
+       <property name="text">
+        <string>Limit local marker depth per command buffer</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QLineEdit" name="localMarkerDepthLineEdit">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="inputMethodHints">
+          <set>Qt::ImhDigitsOnly</set>
+         </property>
+         <property name="text">
+          <string>0</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>4</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_2">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Max local marker depth per command buffer </string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="Line" name="line_6">
+       <property name="styleSheet">
+        <string notr="true">background: #353535</string>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>These settings will only apply starting from your next capture.</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>localMarkerDepthCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>localMarkerDepthLineEdit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>219</x>
+     <y>93</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>80</x>
+     <y>122</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>localMarkerDepthCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>label_2</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>219</x>
+     <y>93</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>292</x>
+     <y>122</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>localMarkerDepthLineEdit</sender>
+   <signal>editingFinished()</signal>
+   <receiver>CaptureOptionsDialog</receiver>
+   <slot>resetLocalMarkerDepthLineEdit()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>73</x>
+     <y>122</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>219</x>
+     <y>129</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+ <slots>
+  <slot>resetLocalMarkerDepthLineEdit()</slot>
+ </slots>
 </ui>

--- a/src/OrbitQt/CaptureOptionsDialog.ui
+++ b/src/OrbitQt/CaptureOptionsDialog.ui
@@ -47,144 +47,85 @@ Setting the value to &quot;0&quot; will disable Vulkan debug marker tracking.</s
    <item row="0" column="0">
     <layout class="QVBoxLayout" name="verticalLayout">
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_3">
-       <item>
-        <widget class="Line" name="line_4">
-         <property name="styleSheet">
-          <string notr="true">background: #353535</string>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="label_4">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>General</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Line" name="line_5">
-         <property name="styleSheet">
-          <string notr="true">background: #353535</string>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="threadStateCheckBox">
-       <property name="text">
-        <string>Collect thread states</string>
+      <widget class="QGroupBox" name="groupBox">
+       <property name="title">
+        <string>General</string>
        </property>
+       <layout class="QVBoxLayout" name="verticalLayout_3">
+        <item>
+         <widget class="QCheckBox" name="threadStateCheckBox">
+          <property name="text">
+           <string>Collect thread states</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </widget>
      </item>
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
-       <item>
-        <widget class="Line" name="line_3">
-         <property name="styleSheet">
-          <string notr="true">background: #353535</string>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="label_3">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Vulkan layer</string>
-         </property>
-         <property name="scaledContents">
-          <bool>false</bool>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Line" name="line_2">
-         <property name="styleSheet">
-          <string notr="true">background: #353535</string>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="localMarkerDepthCheckBox">
-       <property name="text">
-        <string>Limit local marker depth per command buffer</string>
+      <spacer name="verticalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
        </property>
-      </widget>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>6</height>
+        </size>
+       </property>
+      </spacer>
      </item>
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <widget class="QLineEdit" name="localMarkerDepthLineEdit">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="inputMethodHints">
-          <set>Qt::ImhDigitsOnly</set>
-         </property>
-         <property name="text">
-          <string>0</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>4</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QLabel" name="label_2">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="text">
-          <string>Max local marker depth per command buffer </string>
-         </property>
-        </widget>
-       </item>
-      </layout>
+      <widget class="QGroupBox" name="groupBox_2">
+       <property name="toolTip">
+        <string>This requires Orbit's Vulkan layer to be loaded by the target process.</string>
+       </property>
+       <property name="title">
+        <string>Vulkan layer</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_4">
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <item>
+           <widget class="QCheckBox" name="localMarkerDepthCheckBox">
+            <property name="text">
+             <string>Limit local depth of markers per command buffer to:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="localMarkerDepthLineEdit">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="inputMethodHints">
+             <set>Qt::ImhDigitsOnly</set>
+            </property>
+            <property name="text">
+             <string>0</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>4</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
      </item>
      <item>
       <spacer name="verticalSpacer">
@@ -198,16 +139,6 @@ Setting the value to &quot;0&quot; will disable Vulkan debug marker tracking.</s
         </size>
        </property>
       </spacer>
-     </item>
-     <item>
-      <widget class="Line" name="line_6">
-       <property name="styleSheet">
-        <string notr="true">background: #353535</string>
-       </property>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
      </item>
      <item>
       <widget class="QLabel" name="label">
@@ -229,28 +160,12 @@ Setting the value to &quot;0&quot; will disable Vulkan debug marker tracking.</s
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>219</x>
-     <y>93</y>
+     <x>193</x>
+     <y>133</y>
     </hint>
     <hint type="destinationlabel">
-     <x>80</x>
-     <y>122</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>localMarkerDepthCheckBox</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>label_2</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>219</x>
-     <y>93</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>292</x>
-     <y>122</y>
+     <x>390</x>
+     <y>133</y>
     </hint>
    </hints>
   </connection>
@@ -258,11 +173,11 @@ Setting the value to &quot;0&quot; will disable Vulkan debug marker tracking.</s
    <sender>localMarkerDepthLineEdit</sender>
    <signal>editingFinished()</signal>
    <receiver>CaptureOptionsDialog</receiver>
-   <slot>resetLocalMarkerDepthLineEdit()</slot>
+   <slot>ResetLocalMarkerDepthLineEdit()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>73</x>
-     <y>122</y>
+     <x>390</x>
+     <y>133</y>
     </hint>
     <hint type="destinationlabel">
      <x>219</x>
@@ -272,6 +187,6 @@ Setting the value to &quot;0&quot; will disable Vulkan debug marker tracking.</s
   </connection>
  </connections>
  <slots>
-  <slot>resetLocalMarkerDepthLineEdit()</slot>
+  <slot>ResetLocalMarkerDepthLineEdit()</slot>
  </slots>
 </ui>

--- a/src/OrbitQt/CaptureOptionsDialog.ui
+++ b/src/OrbitQt/CaptureOptionsDialog.ui
@@ -9,16 +9,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>440</width>
+    <width>480</width>
     <height>260</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Capture Options</string>
-  </property>
-  <property name="toolTip">
-   <string>Limits the maximal depth of Vulkan debug markers per command buffer to the given value.
-Setting the value to &quot;0&quot; will disable Vulkan debug marker tracking.</string>
   </property>
   <property name="modal">
    <bool>true</bool>
@@ -46,6 +42,9 @@ Setting the value to &quot;0&quot; will disable Vulkan debug marker tracking.</s
    </item>
    <item row="0" column="0">
     <layout class="QVBoxLayout" name="verticalLayout">
+     <property name="spacing">
+      <number>12</number>
+     </property>
      <item>
       <widget class="QGroupBox" name="groupBox">
        <property name="title">
@@ -63,28 +62,12 @@ Setting the value to &quot;0&quot; will disable Vulkan debug marker tracking.</s
       </widget>
      </item>
      <item>
-      <spacer name="verticalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>6</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
       <widget class="QGroupBox" name="groupBox_2">
        <property name="toolTip">
         <string>This requires Orbit's Vulkan layer to be loaded by the target process.</string>
        </property>
        <property name="title">
-        <string>Vulkan layer</string>
+        <string>Vulkan layer (requires Orbit's Vulkan layer to be loaded by the target)</string>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_4">
         <item>
@@ -101,26 +84,17 @@ Setting the value to &quot;0&quot; will disable Vulkan debug marker tracking.</s
             <property name="enabled">
              <bool>false</bool>
             </property>
+            <property name="toolTip">
+             <string>Limits the maximum depth of Vulkan debug markers per command buffer to the given value.
+Setting the value to &quot;0&quot; will disable Vulkan debug marker tracking.</string>
+            </property>
             <property name="inputMethodHints">
              <set>Qt::ImhDigitsOnly</set>
             </property>
             <property name="text">
-             <string>0</string>
+             <string>3</string>
             </property>
            </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>4</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
           </item>
          </layout>
         </item>
@@ -131,12 +105,6 @@ Setting the value to &quot;0&quot; will disable Vulkan debug marker tracking.</s
       <spacer name="verticalSpacer">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
        </property>
       </spacer>
      </item>

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -841,10 +841,22 @@ void OrbitMainWindow::on_actionSave_Preset_As_triggered() {
 void OrbitMainWindow::on_actionToggle_Capture_triggered() { app_->ToggleCapture(); }
 
 const QString OrbitMainWindow::kCollectThreadStatesSettingKey{"CollectThreadStates"};
+const QString OrbitMainWindow::kLimitLocalMarkerDepthPerCommandBufferSettingsKey{
+    "LimitLocalMarkerDepthPerCommandBuffer"};
+const QString OrbitMainWindow::kMaxLocalMarkerDepthPerCommandBufferSettingsKey{
+    "MaxLocalMarkerDepthPerCommandBuffer"};
+;
 
 void OrbitMainWindow::LoadCaptureOptionsIntoApp() {
   QSettings settings;
   app_->SetCollectThreadStates(settings.value(kCollectThreadStatesSettingKey, false).toBool());
+
+  uint64_t max_local_marker_depth_per_command_buffer = std::numeric_limits<uint64_t>::max();
+  if (settings.value(kLimitLocalMarkerDepthPerCommandBufferSettingsKey, false).toBool()) {
+    max_local_marker_depth_per_command_buffer =
+        settings.value(kMaxLocalMarkerDepthPerCommandBufferSettingsKey, 0).toULongLong();
+  }
+  app_->SetMaxLocalMarkerDepthPerCommandBuffer(max_local_marker_depth_per_command_buffer);
 }
 
 void OrbitMainWindow::on_actionCaptureOptions_triggered() {
@@ -852,6 +864,10 @@ void OrbitMainWindow::on_actionCaptureOptions_triggered() {
 
   orbit_qt::CaptureOptionsDialog dialog{this};
   dialog.SetCollectThreadStates(settings.value(kCollectThreadStatesSettingKey, false).toBool());
+  dialog.SetLimitLocalMarkerDepthPerCommandBuffer(
+      settings.value(kLimitLocalMarkerDepthPerCommandBufferSettingsKey, false).toBool());
+  dialog.SetMaxLocalMarkerDepthPerCommandBuffer(
+      settings.value(kMaxLocalMarkerDepthPerCommandBufferSettingsKey, 0).toULongLong());
 
   int result = dialog.exec();
   if (result != QDialog::Accepted) {
@@ -859,6 +875,10 @@ void OrbitMainWindow::on_actionCaptureOptions_triggered() {
   }
 
   settings.setValue(kCollectThreadStatesSettingKey, dialog.GetCollectThreadStates());
+  settings.setValue(kLimitLocalMarkerDepthPerCommandBufferSettingsKey,
+                    dialog.GetLimitLocalMarkerDepthPerCommandBuffer());
+  settings.setValue(kMaxLocalMarkerDepthPerCommandBufferSettingsKey,
+                    QString::number(dialog.GetMaxLocalMarkerDepthPerCommandBuffer()));
   LoadCaptureOptionsIntoApp();
 }
 

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -163,6 +163,8 @@ class OrbitMainWindow : public QMainWindow {
   void OnProcessListUpdated(const std::vector<orbit_grpc_protos::ProcessInfo>& processes);
 
   static const QString kCollectThreadStatesSettingKey;
+  static const QString kLimitLocalMarkerDepthPerCommandBufferSettingsKey;
+  static const QString kMaxLocalMarkerDepthPerCommandBufferSettingsKey;
   void LoadCaptureOptionsIntoApp();
 
   [[nodiscard]] bool ConfirmExit();

--- a/src/OrbitVulkanLayer/SubmissionTracker.h
+++ b/src/OrbitVulkanLayer/SubmissionTracker.h
@@ -542,7 +542,10 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
     }
   }
 
-  void OnCaptureStart(orbit_grpc_protos::CaptureOptions /*capture_options*/) override {}
+  void OnCaptureStart(orbit_grpc_protos::CaptureOptions capture_options) override {
+    SetMaxLocalMarkerDepthPerCommandBuffer(
+        capture_options.max_local_marker_depth_per_command_buffer());
+  }
 
   void OnCaptureStop() override {}
 


### PR DESCRIPTION
Adding a lot of Vulkan debug markers can have a significant performance
impact when capturing those.
On the layer, we already have an option to limit the depth of
markers (per command buffer). This change exposes this setting to the
capture settings dialog and transfer the specified value to the layer.

On the UI side, the setting is split into a boolean (checkbox) if
the depth should be limited at all and a text field (only enabled when
the checkbox is clicked and only allowing numeric strings in uint64 range).
Internally, we use uint64::max as to disable limitation of the depth
(as already done in the layer).

Note that the text fields also excepts empty strings (as otherwise
it is inconvenient to change the first digit), but resets those to
0.

Bug: http://b/180388662
Test: Try different settings in the capture options menu and take
 captures with Vulkan layer enabled.

![Screenshot 2021-02-17 at 11 21 05](https://user-images.githubusercontent.com/2725914/108192490-9c453d00-7114-11eb-89b9-5ea69610cd91.png)
![tooltip](https://user-images.githubusercontent.com/2725914/108192496-9ea79700-7114-11eb-9334-ba6a1b66dd52.png)
