### PR TITLE
Ensure a stable ordering of the GpuTracks -- align marker tracks.

### DIFF
--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -72,7 +72,8 @@ GpuTrack::GpuTrack(TimeGraph* time_graph, TimeGraphLayout* layout, uint64_t time
   timeline_hash_ = timeline_hash;
   string_manager_ = app->GetStringManager();
 
-  std::string timeline = app_->GetStringManager()->Get(timeline_hash).value_or("");
+  std::string timeline =
+      app_->GetStringManager()->Get(timeline_hash).value_or(std::to_string(timeline_hash));
   std::string label = orbit_gl::MapGpuTimelineToTrackLabel(timeline);
   SetName(timeline);
   SetLabel(label);

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -338,11 +338,13 @@ ThreadTrack* TrackManager::GetOrCreateThreadTrack(int32_t tid) {
 
 GpuTrack* TrackManager::GetOrCreateGpuTrack(uint64_t timeline_hash) {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
-  std::shared_ptr<GpuTrack> track = gpu_tracks_[timeline_hash];
+  std::string timeline =
+      app_->GetStringManager()->Get(timeline_hash).value_or(std::to_string(timeline_hash));
+  std::shared_ptr<GpuTrack> track = gpu_tracks_[timeline];
   if (track == nullptr) {
     track = std::make_shared<GpuTrack>(time_graph_, layout_, timeline_hash, app_, capture_data_);
     AddTrack(track);
-    gpu_tracks_[timeline_hash] = track;
+    gpu_tracks_[timeline] = track;
   }
   return track.get();
 }

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -77,7 +77,7 @@ class TrackManager {
   std::unordered_map<int32_t, std::shared_ptr<ThreadTrack>> thread_tracks_;
   std::map<std::string, std::shared_ptr<AsyncTrack>> async_tracks_;
   std::map<std::string, std::shared_ptr<GraphTrack>> graph_tracks_;
-  // Mapping from timeline to GPU tracks.
+  // Mapping from timeline to GPU tracks. Timeline name is used for stable ordering.
   std::map<std::string, std::shared_ptr<GpuTrack>> gpu_tracks_;
   // Mapping from function address to frame tracks.
   // TODO (b/175865913): Use Function info instead of their address as key to FrameTracks

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -77,7 +77,9 @@ class TrackManager {
   std::unordered_map<int32_t, std::shared_ptr<ThreadTrack>> thread_tracks_;
   std::map<std::string, std::shared_ptr<AsyncTrack>> async_tracks_;
   std::map<std::string, std::shared_ptr<GraphTrack>> graph_tracks_;
-  // Mapping from timeline to GPU tracks. Timeline name is used for stable ordering.
+  // Mapping from timeline to GPU tracks. Timeline name is used for stable ordering. In particular
+  // we want the marker tracks next to their queue track. E.g. "gfx" and "gfx_markers" should appear
+  // next to each other.
   std::map<std::string, std::shared_ptr<GpuTrack>> gpu_tracks_;
   // Mapping from function address to frame tracks.
   // TODO (b/175865913): Use Function info instead of their address as key to FrameTracks

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -77,8 +77,8 @@ class TrackManager {
   std::unordered_map<int32_t, std::shared_ptr<ThreadTrack>> thread_tracks_;
   std::map<std::string, std::shared_ptr<AsyncTrack>> async_tracks_;
   std::map<std::string, std::shared_ptr<GraphTrack>> graph_tracks_;
-  // Mapping from timeline hash to GPU tracks.
-  std::unordered_map<uint64_t, std::shared_ptr<GpuTrack>> gpu_tracks_;
+  // Mapping from timeline to GPU tracks.
+  std::map<std::string, std::shared_ptr<GpuTrack>> gpu_tracks_;
   // Mapping from function address to frame tracks.
   // TODO (b/175865913): Use Function info instead of their address as key to FrameTracks
   std::unordered_map<uint64_t, std::shared_ptr<FrameTrack>> frame_tracks_;


### PR DESCRIPTION
This stablelizes the ordering of GpuTracks by also using an ordered
std::map<string,track> (as already done for other tracks).
Main benefit is, that the marker tracks are always below and alligned
to their corresponding queue track.

Test: Take multiple captures with Vulkan layer and sort tracks.
Bug: http://b/179888337