### PR TITLE
Switch LinxuTracingUtils to ReadFileToString

### DIFF
--- a/src/LinuxTracing/LinuxTracingUtils.h
+++ b/src/LinuxTracing/LinuxTracingUtils.h
@@ -15,8 +15,6 @@
 
 namespace orbit_linux_tracing {
 
-std::optional<std::string> ReadFile(std::string_view filename);
-
 std::string ReadMaps(pid_t pid);
 
 // The association between a character and a thread state is documented at

--- a/src/LinuxTracing/LinuxTracingUtilsTest.cpp
+++ b/src/LinuxTracing/LinuxTracingUtilsTest.cpp
@@ -25,15 +25,6 @@
 
 namespace orbit_linux_tracing {
 
-TEST(ReadFile, ProcPidCommOfLinuxTracingTests) {
-  std::string filename = absl::StrFormat("/proc/%d/comm", getpid());
-  std::optional<std::string> returned_comm = ReadFile(filename);
-  // Comm values have a size limit of 15 characters.
-  std::string expected_comm = std::string{"LinuxTracingTests"}.substr(0, 15).append("\n");
-  ASSERT_TRUE(returned_comm.has_value());
-  EXPECT_EQ(returned_comm.value(), expected_comm);
-}
-
 TEST(GetThreadName, LinuxTracingTests) {
   // Thread names have a length limit of 15 characters.
   std::string expected_name = std::string{"LinuxTracingTests"}.substr(0, 15);


### PR DESCRIPTION
Remove alternative implementation of this method from LinuxTracingUtils
and switch to orbit_base::ReadFileToString

Test: run LinuxTracingTests