### PR TITLE
Explicit construction of ErrorMessageOr in generics

### DIFF
--- a/src/OrbitBase/include/OrbitBase/Result.h
+++ b/src/OrbitBase/include/OrbitBase/Result.h
@@ -6,6 +6,7 @@
 #define ORBIT_BASE_RESULT_H_
 
 #include <string>
+#include <type_traits>
 
 #include "outcome.hpp"
 
@@ -25,5 +26,11 @@ using Result = outcome::result<T, E, outcome::policy::terminate>;
 
 template <typename T>
 using ErrorMessageOr = Result<T, ErrorMessage>;
+
+template <typename T>
+struct IsErrorMessageOr : std::false_type {};
+
+template <typename T>
+struct IsErrorMessageOr<ErrorMessageOr<T>> : std::true_type {};
 
 #endif  // ORBIT_BASE_RESULT_H_

--- a/src/OrbitGl/MainThreadExecutor.h
+++ b/src/OrbitGl/MainThreadExecutor.h
@@ -149,7 +149,7 @@ class MainThreadExecutor : public std::enable_shared_from_this<MainThreadExecuto
       // might do things that need synchronization and can't happen in a different context (like a
       // thread pool), i.e. when the continuation owns a ScopedStatus.
       if (argument.has_error()) {
-        promise.SetResult(argument.error());
+        promise.SetResult(outcome::failure(argument.error()));
         executor->Schedule(CreateAction(
             [this, function_reference]() { waiting_continuations_.erase(function_reference); }));
         return;


### PR DESCRIPTION
`outcome::basic_result` disables its generic templated constructor if the
arguments could both construct the value and the error type to avoid any
kind of ambiguity. In this case the user is supposed to use the explicit
wrappers `outcome::success` and `outcome::failure`.

In generic code we should always use the explicit wrappers to avoid
problems with certain types that clash with `ErrorMessage`.

This commit adds the wrapper in Promise/Future code.