### PR TITLE
Source Code Syntax Highlighter 1.0

### DIFF
--- a/src/CodeViewerDemo/CodeExamples.h
+++ b/src/CodeViewerDemo/CodeExamples.h
@@ -19,17 +19,25 @@ inline const QString testing_example =
   OrbitService o;
   QSyntaxHighlighter q;
   ORBIT_SCOPE; // no lowercase regex
-  x;
-  kTreeSize == 3;
-  _Tree_;
+  x = _Tree_;
+  bool P = (kTreeSize == 3);
+
+  // Class members
+  Track* track_;
+  int __int__ = 3;
+  m_PascalCase = 5;
+  Track::SortTracks();
+  class TrackManager {};
 
   // Function unit tests
-  int my_function(void)
+  int my_function(void);
+  int MyFunction(void);
   bool b = a.insert(3);
   void AddEvent();
   char _my_underscore_func();
-  int CaptureServiceImpl::Capture() // Function from other class
-  void QSyntaxHighlighter::Play
+  int CaptureServiceImpl::Capture(); // Function from other class
+  a = absl::Milliseconds(20); // method that we don't have to highlight
+  int QSyntaxHighlighter::PlayInteger;
   CHECK(false); // no lowercase regex
 
   // Preprocessor + <> unit tests

--- a/src/SyntaxHighlighter/Cpp.cpp
+++ b/src/SyntaxHighlighter/Cpp.cpp
@@ -10,10 +10,8 @@
 #include <QTextCharFormat>
 
 namespace orbit_syntax_highlighter {
-namespace C {
 namespace {
-enum HighlighterState { kInitialState, kOpenCommentState, kOpenStringState };
-
+// Colors are taken from Clion Darcula theme
 const QColor kGrey{0x80, 0x80, 0x80};
 const QColor kBlue{0x61, 0x96, 0xcc};
 const QColor kYellow{0xa0, 0xa0, 0x33};
@@ -21,20 +19,42 @@ const QColor kYellowOrange{0xff, 0xcc, 0x66};
 const QColor kOrange{0xcc, 0x66, 0x33};
 const QColor kOlive{0x80, 0x80, 0x00};
 const QColor kGreen{0x66, 0x99, 0x66};
-const QColor kViolet{0xcc, 0x99, 0xcd};
+const QColor kViolet{0x99, 0x66, 0x99};
+const QColor kGreyViolet{0xcc, 0xaa, 0xcc};
 
+enum CppHighlighterState { kInitialState, kOpenCommentState, kOpenStringState };
+namespace CppRegex {
 const char* const kNumberRegex =
-    "(?:\\b0x(?:[\\da-f]+(?:\\.[\\da-f]*)?|\\.[\\da-f]+)(?:p[+-]?\\d+)?|(?:\\b\\d+(?:\\.\\d*)?|"
-    "\\B\\.\\d+)(?:e[+-]?\\d+)?)[ful]{0,4}";
+    "(?:\\b0b[01']+|\\b0x(?:[\\da-f']+(?:\\.[\\da-f']*)?|\\.[\\da-f']+)(?:p[+-]?[\\d']+)?|(?:\\b["
+    "\\d']+(?:\\.[\\d']*)?|\\B\\.[\\d']+)(?:e[+-]?[\\d']+)?)[ful]{0,4}";
 const char* const kConstantRegex =
     "__FILE__|__LINE__|__DATE__|__TIME__|__TIMESTAMP__|__func__|EOF|NULL|SEEK_CUR|SEEK_END|SEEK_"
     "SET|stdin|stdout|stderr";
 const char* const kKeywordRegex =
-    "\\b(?:__attribute__|_Alignas|_Alignof|_Atomic|_Bool|_Complex|_Generic|_Imaginary|_Noreturn|_"
-    "Static_assert|_Thread_local|asm|typeof|inline|auto|break|case|char|const|continue|default|do|"
-    "double|else|enum|extern|float|for|goto|if|int|long|register|return|short|signed|sizeof|static|"
-    "struct|switch|typedef|union|unsigned|void|volatile|while|)\\b";
-// Match with comments starting and ending in the same line
+    "\\b(?:alignas|alignof|asm|auto|bool|break|case|catch|char|char8_t|char16_t|char32_t|class|"
+    "compl|concept|const|consteval|constexpr|constinit|const_cast|continue|co_await|co_return|co_"
+    "yield|decltype|default|delete|do|double|dynamic_cast|else|enum|explicit|export|extern|false|"
+    "final|float|for|friend|goto|if|import|inline|int|int8_t|int16_t|int32_t|int64_t|uint8_t|"
+    "uint16_t|uint32_t|uint64_t|long|mutable|namespace|new|noexcept|nullptr|operator|override|"
+    "private|protected|public|register|reinterpret_cast|requires|return|short|signed|sizeof|static|"
+    "static_|assert|static_cast|struct|switch|template|this|thread_local|throw|true|try|typedef|"
+    "typeid|typename|union|unsigned|using|virtual|void|volatile|wchar_t|while)\\b";
+
+const char* const kCapitalizedRegex = "(?<=[\\s\\(<])[A-Z][\\w]*";
+// int Function( or Namespace::FunctionName( patterns
+const char* const kFunctionDefinitionRegex = "(?<=\\w)\\s+([A-Za-z_]\\w*::)*[A-Za-z_]\\w*(?=\\()";
+const char* const kOnlyUppercaseRegex = "(?<=[\\s\\(])[A-Z][0-9A-Z\\_]*(?=\\b)";
+const char* const kCommaRegex = "[\\;\\,]";
+// Methods and variables from a namespace, after "::" (e.g. std::cout, absl::Milliseconds)
+const char* const kNamespaceVariablesRegex = "(?<=::)[A-Za-z_]\\w*(?=\\b)";
+// Namespaces itself, before "::"
+const char* const kNamespaceRegex = "[A-Za-z_]\\w*::";
+const char* const kClassNameRegex = "\\b(?:class|concept|enum|namespace|struct|typename)\\s+(\\w+)";
+// Variables starting with lowercase and finishing with _ (e.g. tracks_) or starting with "m_"
+const char* const kClassMemberRegex = "\\b[a-z]\\w*\\_(?<=\\b)|m_\\w*";
+const char* const kPreprocessorRegex = "(^\\s*)#\\s*[A-Za-z_]\\w*";
+// Match with <word> after #include
+const char* const kIncludeFileRegex = "(?<=#include)\\s*<[^>]*>";
 const char* const kCommentRegex =
     "\\/\\/(?:[^\\r\\n\\\\]|\\\\(?:\\r\\n?|\\n|(?![\\r\\n])))*|\\/\\*[\\s\\S]*?\\*\\/";
 // Match with "/*" comments which starts but not finishes in this line
@@ -43,45 +63,44 @@ const char* const kOpenCommentRegex = "\\/\\*([^\\*]|[\\*]+[^\\/])*?$";
 const char* const kEndCommentRegex = "[\\s\\S]*\\*\\/";
 // Match with a line without a closing comment
 const char* const kNoEndCommentRegex = "([^\\*]|\\*+[^\\/\\*])*$";
-// A word who is followed with an open-parenthesis (
-const char* const kFunctionRegex = "(?<=[^\\(\\:\\.\\w\\>])[a-z_]\\w*(?=\\s*\\()";
-const char* const kPreprocessorRegex = "(^\\s*)#\\s*[a-z_]\\w*";
-// Match with <word> after #include
-const char* const kIncludeFileRegex = "(?<=#include)\\s*<[^>]+>";
 // Similar process to comments to match a multiline string
 const char* const kStringRegex = "\"([^\\\\\"]|\\\\.)*\"|\'[^\']*\'";
 const char* const kOpenStringRegex = "\"([^\\\\\"]|\\\\.)*\\\\$";
 const char* const kEndStringRegex = "([^\\\\\"]|\\\\.)*\"";
 const char* const kNoEndStringRegex = "([^\\\\\"]|\\\\.)*\\\\$";
-const char* const kCapitalizedRegex = "(?<=[\\s\\(<])[A-Z][\\w\\*\\&]*";
-const char* const kNoLowercaseRegex = "(?<=[\\s\\(])[A-Z][0-9A-Z\\_\\*\\&]*(?=[\\;\\,\\(\\s\\)])";
+}  // namespace CppRegex
 }  // namespace
-}  // namespace C
 
 Cpp::Cpp() : QSyntaxHighlighter{static_cast<QObject*>(nullptr)} {
   using PatternOption = QRegularExpression::PatternOption;
-  number_regex_ = QRegularExpression{C::kNumberRegex, PatternOption::CaseInsensitiveOption};
-  constant_regex_ = QRegularExpression{C::kConstantRegex};
-  keyword_regex_ = QRegularExpression{C::kKeywordRegex};
-  comment_regex_ = QRegularExpression{C::kCommentRegex};
-  open_comment_regex_ = QRegularExpression{C::kOpenCommentRegex};
-  end_comment_regex_ = QRegularExpression{C::kEndCommentRegex};
-  no_end_comment_regex_ = QRegularExpression{C::kNoEndCommentRegex};
-  function_regex_ = QRegularExpression{C::kFunctionRegex, PatternOption::CaseInsensitiveOption};
-  preprocessor_regex_ = QRegularExpression{C::kPreprocessorRegex};
-  include_file_regex_ = QRegularExpression{C::kIncludeFileRegex};
-  string_regex_ = QRegularExpression{C::kStringRegex};
-  open_string_regex_ = QRegularExpression{C::kOpenStringRegex};
-  end_string_regex_ = QRegularExpression{C::kEndStringRegex};
-  no_end_string_regex_ = QRegularExpression{C::kNoEndStringRegex};
-  capitalized_regex_ = QRegularExpression{C::kCapitalizedRegex};
-  no_lowercase_regex_ = QRegularExpression{C::kNoLowercaseRegex};
+  number_regex_ = QRegularExpression{CppRegex::kNumberRegex, PatternOption::CaseInsensitiveOption};
+  constant_regex_ = QRegularExpression{CppRegex::kConstantRegex};
+  keyword_regex_ = QRegularExpression{CppRegex::kKeywordRegex};
+  comment_regex_ = QRegularExpression{CppRegex::kCommentRegex};
+  open_comment_regex_ = QRegularExpression{CppRegex::kOpenCommentRegex};
+  end_comment_regex_ = QRegularExpression{CppRegex::kEndCommentRegex};
+  no_end_comment_regex_ = QRegularExpression{CppRegex::kNoEndCommentRegex};
+  function_definition_regex_ =
+      QRegularExpression{CppRegex::kFunctionDefinitionRegex, PatternOption::CaseInsensitiveOption};
+  preprocessor_regex_ = QRegularExpression{CppRegex::kPreprocessorRegex};
+  include_file_regex_ = QRegularExpression{CppRegex::kIncludeFileRegex};
+  string_regex_ = QRegularExpression{CppRegex::kStringRegex};
+  open_string_regex_ = QRegularExpression{CppRegex::kOpenStringRegex};
+  end_string_regex_ = QRegularExpression{CppRegex::kEndStringRegex};
+  no_end_string_regex_ = QRegularExpression{CppRegex::kNoEndStringRegex};
+  comma_regex_ = QRegularExpression{CppRegex::kCommaRegex};
+  capitalized_regex_ = QRegularExpression{CppRegex::kCapitalizedRegex};
+  only_uppercase_regex_ = QRegularExpression{CppRegex::kOnlyUppercaseRegex};
+  namespace_regex_ = QRegularExpression{CppRegex::kNamespaceRegex};
+  namespace_variables_regex_ = QRegularExpression{CppRegex::kNamespaceVariablesRegex};
+  class_name_regex_ = QRegularExpression{CppRegex::kClassNameRegex};
+  class_member_regex_ = QRegularExpression{CppRegex::kClassMemberRegex};
 }
 
 void Cpp::highlightBlock(const QString& code) {
   const auto apply = [&code, this](
                          QRegularExpression* expression, const QColor& color,
-                         C::HighlighterState new_state = C::HighlighterState::kInitialState) {
+                         CppHighlighterState new_state = CppHighlighterState::kInitialState) {
     QTextCharFormat format{};
     format.setForeground(color);
 
@@ -95,33 +114,39 @@ void Cpp::highlightBlock(const QString& code) {
   // We are processing line by line and trying to find all substrings that match with these
   // patterns. As each one paints over the others, order matters.
 
-  // Ordered heuristics for painting certain word patterns.
-  apply(&capitalized_regex_, C::kViolet);
-  apply(&function_regex_, C::kYellowOrange);
-  apply(&no_lowercase_regex_, C::kOlive);
+  // Ordered heuristics for painting certain word patterns. Should be at the first.
+  apply(&capitalized_regex_, kGreyViolet);
+  apply(&namespace_variables_regex_, kGreyViolet);
+  apply(&function_definition_regex_, kYellowOrange);
+  apply(&namespace_regex_, kGreyViolet);
+  apply(&only_uppercase_regex_, kOlive);
 
-  apply(&number_regex_, C::kBlue);
+  // Extra patterns which make the syntax highlighter nicer. Order doesn't matter.
+  apply(&class_name_regex_, kGreyViolet);
+  apply(&number_regex_, kBlue);
+  apply(&class_member_regex_, kViolet);
+  apply(&comma_regex_, kOrange);
 
-  // Special C/C++ words: The order here doesn't matter.
-  apply(&keyword_regex_, C::kOrange);
-  apply(&constant_regex_, C::kOlive);
-  apply(&include_file_regex_, C::kGreen);
-  apply(&preprocessor_regex_, C::kYellow);
+  // Special C/C++ patterns. Order doesn't matter.
+  apply(&keyword_regex_, kOrange);
+  apply(&constant_regex_, kOlive);
+  apply(&include_file_regex_, kGreen);
+  apply(&preprocessor_regex_, kYellow);
 
   // Comments and strings should be painted at the end.
-  apply(&string_regex_, C::kGreen);
-  apply(&comment_regex_, C::kGrey);
+  apply(&string_regex_, kGreen);
+  apply(&comment_regex_, kGrey);
 
   // For several-lines comments and strings, we have these states.
-  if (previousBlockState() == C::HighlighterState::kOpenStringState) {
-    apply(&no_end_string_regex_, C::kGreen, C::HighlighterState::kOpenStringState);
-    apply(&end_string_regex_, C::kGreen);
+  if (previousBlockState() == CppHighlighterState::kOpenStringState) {
+    apply(&no_end_string_regex_, kGreen, CppHighlighterState::kOpenStringState);
+    apply(&end_string_regex_, kGreen);
   }
-  if (previousBlockState() == C::HighlighterState::kOpenCommentState) {
-    apply(&no_end_comment_regex_, C::kGrey, C::HighlighterState::kOpenCommentState);
-    apply(&end_comment_regex_, C::kGrey);
+  if (previousBlockState() == CppHighlighterState::kOpenCommentState) {
+    apply(&no_end_comment_regex_, kGrey, CppHighlighterState::kOpenCommentState);
+    apply(&end_comment_regex_, kGrey);
   }
-  apply(&open_string_regex_, C::kGreen, C::HighlighterState::kOpenStringState);
-  apply(&open_comment_regex_, C::kGrey, C::HighlighterState::kOpenCommentState);
+  apply(&open_string_regex_, kGreen, CppHighlighterState::kOpenStringState);
+  apply(&open_comment_regex_, kGrey, CppHighlighterState::kOpenCommentState);
 }
 }  // namespace orbit_syntax_highlighter

--- a/src/SyntaxHighlighter/include/SyntaxHighlighter/Cpp.h
+++ b/src/SyntaxHighlighter/include/SyntaxHighlighter/Cpp.h
@@ -27,7 +27,7 @@ class Cpp : public QSyntaxHighlighter {
   QRegularExpression open_comment_regex_;
   QRegularExpression end_comment_regex_;
   QRegularExpression no_end_comment_regex_;
-  QRegularExpression function_regex_;
+  QRegularExpression function_definition_regex_;
   QRegularExpression number_regex_;
   QRegularExpression constant_regex_;
   QRegularExpression keyword_regex_;
@@ -37,8 +37,13 @@ class Cpp : public QSyntaxHighlighter {
   QRegularExpression open_string_regex_;
   QRegularExpression end_string_regex_;
   QRegularExpression no_end_string_regex_;
-  QRegularExpression no_lowercase_regex_;
+  QRegularExpression comma_regex_;
+  QRegularExpression only_uppercase_regex_;
   QRegularExpression capitalized_regex_;
+  QRegularExpression namespace_regex_;
+  QRegularExpression namespace_variables_regex_;
+  QRegularExpression class_name_regex_;
+  QRegularExpression class_member_regex_;
 };
 
 }  // namespace orbit_syntax_highlighter


### PR DESCRIPTION
This PR upgrades the C Syntax Highlighter adding C++ rules. More
specific:

 - Upgrades number and keyword regex.

 - Modifies function regex to only include function definitions
 (as discussed)

 - Introduces class members and add examples (track_, m_track, ..)

 - Introduces comma regex (to paint ',' and ';'), and also modifies
 capitalized words (to not paint '*' and '&' in variables).

 - Update few colors following CLion color conventions and uses a new
 one to paint class' names and types like std::vector.

Screenshots:
<img width="489" alt="file" src="https://user-images.githubusercontent.com/8610429/108527107-31416500-72d2-11eb-999e-e089ab8d3604.png">
<img width="491" alt="tests" src="https://user-images.githubusercontent.com/8610429/108527139-37cfdc80-72d2-11eb-8ce7-f604aeac7daa.png">


To test it:
 - Run CodeViewerDemo. You will see there some examples and a real file.

Last step in http://b/177651839.