### PR TITLE
Clang-format

### DIFF
--- a/src/CrashHandler/CrashHandler.cpp
+++ b/src/CrashHandler/CrashHandler.cpp
@@ -4,13 +4,13 @@
 
 #include "CrashHandler/CrashHandler.h"
 
-#include <algorithm>
-#include <map>
-
 #include <base/files/file_path.h>
 #include <client/crash_report_database.h>
 #include <client/settings.h>
 #include <util/misc/capture_context.h>
+
+#include <algorithm>
+#include <map>
 
 #include "CoreUtils.h"
 #include "OrbitVersion/OrbitVersion.h"

--- a/src/CrashHandler/include/CrashHandler/CrashHandler.h
+++ b/src/CrashHandler/include/CrashHandler/CrashHandler.h
@@ -5,18 +5,18 @@
 #ifndef CRASH_HANDLER_CRASH_HANDLER_H_
 #define CRASH_HANDLER_CRASH_HANDLER_H_
 
+#include <client/crash_report_database.h>
+#include <client/crashpad_client.h>
+
 #include <memory>
 #include <string>
 #include <vector>
-
-#include <client/crash_report_database.h>
-#include <client/crashpad_client.h>
 
 #include "OrbitBase/CrashHandler.h"
 
 namespace orbit_crash_handler {
 
-class CrashHandler : public orbit_base::CrashHandler{
+class CrashHandler : public orbit_base::CrashHandler {
  public:
   explicit CrashHandler(const std::string& dump_path, const std::string& handler_path,
                         const std::string& crash_server_url,

--- a/src/GrpcProtos/include/GrpcProtos/Constants.h
+++ b/src/GrpcProtos/include/GrpcProtos/Constants.h
@@ -10,6 +10,6 @@
 namespace orbit_grpc_protos {
 constexpr uint64_t kInvalidInternId = 0;
 constexpr uint64_t kInvalidFunctionId = 0;
-}
+}  // namespace orbit_grpc_protos
 
 #endif  // GRPC_PROTOS_CONSTANTS_H_

--- a/src/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/CaptureWindow.h
@@ -72,9 +72,7 @@ class CaptureWindow : public GlCanvas {
   virtual void ToggleRecording();
   void ToggleDrawHelp();
   void set_draw_help(bool draw_help);
-  [[nodiscard]] TimeGraph* GetTimeGraph() {
-    return time_graph_.get();
-  }
+  [[nodiscard]] TimeGraph* GetTimeGraph() { return time_graph_.get(); }
   void CreateTimeGraph(const CaptureData* capture_data);
   void ClearTimeGraph() { time_graph_.reset(nullptr); }
 

--- a/src/OrbitQt/StatusListenerImplTest.cpp
+++ b/src/OrbitQt/StatusListenerImplTest.cpp
@@ -12,7 +12,6 @@
 #include "StatusListenerImpl.h"
 #include "gtest/gtest.h"
 
-
 TEST(StatusListenerImpl, ShowAndClearOneMessage) {
   auto status_bar = std::make_unique<QStatusBar>(nullptr);
   auto status_listener = StatusListenerImpl::Create(status_bar.get());


### PR DESCRIPTION
@beckerhe , @florian-kuebler , if I understand correctly, our CI runs clang-format only on the lines that changed. Would it be possible to run it on the entire file instead so that we don't risk submitting a change that is not properly formatted in the context of the entire file?