### PR TITLE
Fix incorrect notebook import for Python code

### DIFF
--- a/contrib/jupyter/orbit_example_notebook.ipynb
+++ b/contrib/jupyter/orbit_example_notebook.ipynb
@@ -23,7 +23,7 @@
    "outputs": [],
    "source": [
     "# Read the file and open the capture by creating an OrbitCapture instance.\n",
-    "from orbitutils.orbit_capture_utils import OrbitCapture\n",
+    "from orbitutils.orbit_capture import OrbitCapture\n",
     "\n",
     "file_content = open(\"./orbitutils/testdata/OrbitTest_capture.orbit\", \"rb\").read()\n",
     "capture = OrbitCapture(file_content)\n",


### PR DESCRIPTION
I renamed the Python file orbit_capture.py and forgot to update the
import in the Jupyter notebook (which is not unit tested). This change
fixes the import.