### PR TITLE
Measure and LOG clock resolution on start of OrbitService

### DIFF
--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -51,6 +51,7 @@ target_sources(OrbitBase PRIVATE
         JoinFutures.cpp
         Logging.cpp
         LoggingUtils.cpp
+        Profiling.cpp
         ReadFileToString.cpp
         SafeStrerror.cpp
         ThreadPool.cpp

--- a/src/OrbitBase/Profiling.cpp
+++ b/src/OrbitBase/Profiling.cpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "OrbitBase/Profiling.h"
+
+#include <algorithm>
+#include <limits>
+
+namespace orbit_base {
+uint64_t EstimateClockResolution() {
+  uint64_t minimum_resolution_found = std::numeric_limits<uint64_t>::max();
+
+  // We limit the amount of time spent to measure timer resolution.
+  uint64_t iteration_start_time_ns = orbit_base::CaptureTimestampNs();
+  uint64_t duration_ns = 0;
+  constexpr uint64_t kMaximumDurationNs = 1000 * 1000;  // 1 ms
+
+  while (duration_ns < kMaximumDurationNs) {
+    // Count to limit the number of iterations in the while loop below. Note that the loop
+    // below will terminate within one quantum of the clock used. For the unlikely (broken?)
+    // case that the clock does not increase, this additional limit is checked.
+    constexpr int kSafetyNetCount = 100'000;
+
+    uint64_t resolution = 0;
+    int safety_net_counter = 0;
+    while (resolution == 0 && safety_net_counter < kSafetyNetCount) {
+      uint64_t start_time_ns = orbit_base::CaptureTimestampNs();
+      uint64_t end_time_ns = orbit_base::CaptureTimestampNs();
+      // This will be >= 0 as we use a monotonic clock.
+      resolution = end_time_ns - start_time_ns;
+      safety_net_counter++;
+    }
+    minimum_resolution_found = std::min(minimum_resolution_found, resolution);
+    duration_ns = orbit_base::CaptureTimestampNs() - iteration_start_time_ns;
+  }
+  return minimum_resolution_found;
+}
+}  // namespace orbit_base

--- a/src/OrbitBase/ProfilingTest.cpp
+++ b/src/OrbitBase/ProfilingTest.cpp
@@ -17,3 +17,10 @@ TEST(Profiling, MonotonicClock) {
   uint64_t t1 = orbit_base::CaptureTimestampNs();
   EXPECT_TRUE(t1 > t0);
 }
+
+TEST(Profiling, EstimatedClockResolutionNonNegative) {
+  uint64_t resolution = orbit_base::EstimateClockResolution();
+
+  // There's not really any guarantee we have for results of the above call.
+  EXPECT_TRUE(resolution >= 0);
+}

--- a/src/OrbitBase/include/OrbitBase/Profiling.h
+++ b/src/OrbitBase/include/OrbitBase/Profiling.h
@@ -39,6 +39,10 @@ constexpr clockid_t kOrbitCaptureClock = CLOCK_MONOTONIC;
 
 #endif
 
+// Estimates the clock resolution for debugging purposes. Should only be used to display this
+// information to the user or log it.
+[[nodiscard]] uint64_t EstimateClockResolution();
+
 }  // namespace orbit_base
 
 #endif  // ORBIT_BASE_PROFILING_H_

--- a/src/Service/OrbitService.cpp
+++ b/src/Service/OrbitService.cpp
@@ -11,6 +11,7 @@
 #include <unistd.h>
 
 #include <chrono>
+#include <cinttypes>
 #include <cstdio>
 #include <filesystem>
 #include <memory>
@@ -19,6 +20,7 @@
 
 #include "OrbitBase/ExecuteCommand.h"
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/Profiling.h"
 #include "OrbitBase/ReadFileToString.h"
 #include "OrbitGrpcServer.h"
 #include "OrbitVersion/OrbitVersion.h"
@@ -81,6 +83,14 @@ static void PrintInstanceVersions() {
       ERROR("Could not execute \"%s\"", kDriverVersionCommand);
     }
   }
+}
+
+// We try to determine the clock resolution and print out the determined value for
+// postmortem debugging purposes. The resolution should be fairly small (in my tests
+// it was ~35 nanoseconds).
+static void PrintClockResolution() {
+  LOG("%s",
+      absl::StrFormat("Clock resolution: %" PRIi64 " (ns)", orbit_base::EstimateClockResolution()));
 }
 
 static std::string ReadStdIn() {
@@ -148,6 +158,8 @@ void OrbitService::Run(std::atomic<bool>* exit_requested) {
   LOG("Orbit Service is running in DEBUG!");
   LOG("**********************************");
 #endif
+
+  PrintClockResolution();
 
   std::unique_ptr<OrbitGrpcServer> grpc_server = CreateGrpcServer(grpc_port_);
   if (grpc_server == nullptr) {


### PR DESCRIPTION
We measure and LOG clock resolution on start of OrbitService to be able
to potentially debug issues encountered by users in the wild.

Bug: http://b/180720516