### PR TITLE
Add line highlighting support in CodeViewer

### DIFF
--- a/src/CodeViewer/Dialog.cpp
+++ b/src/CodeViewer/Dialog.cpp
@@ -50,7 +50,7 @@ void Dialog::SetEnableLineNumbers(bool enabled) { ui_->viewer->SetEnableLineNumb
 
 void Dialog::GoToLineNumber(size_t line_number) {
   const QTextBlock block =
-      ui_->viewer->document()->findBlockByLineNumber(static_cast<int>(line_number));
+      ui_->viewer->document()->findBlockByLineNumber(static_cast<int>(line_number) - 1);
   if (!block.isValid()) return;
 
   ui_->viewer->setTextCursor(QTextCursor{block});

--- a/src/CodeViewer/Dialog.cpp
+++ b/src/CodeViewer/Dialog.cpp
@@ -56,4 +56,10 @@ void Dialog::GoToLineNumber(size_t line_number) {
   ui_->viewer->setTextCursor(QTextCursor{block});
 }
 
+void Dialog::SetHighlightCurrentLine(bool enabled) {
+  ui_->viewer->SetHighlightCurrentLine(enabled);
+}
+
+bool Dialog::IsCurrentLineHighlighted() const { return ui_->viewer->IsCurrentLineHighlighted(); }
+
 }  // namespace orbit_code_viewer

--- a/src/CodeViewer/Viewer.cpp
+++ b/src/CodeViewer/Viewer.cpp
@@ -137,10 +137,10 @@ void Viewer::UpdateLeftSidebarWidth() {
   left_sidebar_widget_.SetSizeHint({overall_width_px, 0});
 }
 
-void Viewer::SetEnableLineNumbers(bool enabled) {
-  if (line_numbers_enabled_ == enabled) return;
+void Viewer::SetEnableLineNumbers(bool is_enabled) {
+  if (line_numbers_enabled_ == is_enabled) return;
 
-  line_numbers_enabled_ = enabled;
+  line_numbers_enabled_ = is_enabled;
   UpdateLeftSidebarWidth();
 }
 
@@ -163,6 +163,35 @@ void Viewer::SetHeatmapSource(HeatmapSource heatmap_source) {
 void Viewer::ClearHeatmapSource() {
   heatmap_source_ = {};
   UpdateLeftSidebarWidth();
+}
+
+void Viewer::SetHighlightCurrentLine(bool enabled) {
+  if (is_current_line_highlighted_ == enabled) return;
+
+  is_current_line_highlighted_ = enabled;
+
+  if (!is_current_line_highlighted_) {
+    QObject::disconnect(this, &Viewer::cursorPositionChanged, this, &Viewer::HighlightCurrentLine);
+    return;
+  }
+
+  QObject::connect(this, &Viewer::cursorPositionChanged, this, &Viewer::HighlightCurrentLine,
+                   Qt::UniqueConnection);
+  HighlightCurrentLine();
+}
+
+bool Viewer::IsCurrentLineHighlighted() const { return is_current_line_highlighted_; }
+
+void Viewer::HighlightCurrentLine() {
+  const QColor highlight_color = palette().base().color().lighter();
+
+  QTextEdit::ExtraSelection selection{};
+  selection.format.setBackground(highlight_color);
+  selection.format.setProperty(QTextFormat::FullWidthSelection, true);
+  selection.cursor = textCursor();
+  selection.cursor.clearSelection();
+
+  setExtraSelections({selection});
 }
 
 }  // namespace orbit_code_viewer

--- a/src/CodeViewer/include/CodeViewer/Dialog.h
+++ b/src/CodeViewer/include/CodeViewer/Dialog.h
@@ -58,6 +58,9 @@ class Dialog : public QDialog {
 
   void GoToLineNumber(size_t line_number);
 
+  void SetHighlightCurrentLine(bool enabled);
+  [[nodiscard]] bool IsCurrentLineHighlighted() const;
+
  private:
   std::unique_ptr<Ui::CodeViewerDialog> ui_;
   std::unique_ptr<QSyntaxHighlighter> syntax_highlighter_;

--- a/src/CodeViewer/include/CodeViewer/Viewer.h
+++ b/src/CodeViewer/include/CodeViewer/Viewer.h
@@ -58,11 +58,15 @@ class Viewer : public QPlainTextEdit {
   void SetHeatmapSource(HeatmapSource heatmap_source);
   void ClearHeatmapSource();
 
+  void SetHighlightCurrentLine(bool is_enabled);
+  [[nodiscard]] bool IsCurrentLineHighlighted() const;
+
  private:
   void resizeEvent(QResizeEvent* ev) override;
   void wheelEvent(QWheelEvent* ev) override;
   void DrawLineNumbers(QPaintEvent* event);
   void UpdateLeftSidebarWidth();
+  void HighlightCurrentLine();
 
   PlaceHolderWidget left_sidebar_widget_;
   bool line_numbers_enabled_ = false;
@@ -71,6 +75,8 @@ class Viewer : public QPlainTextEdit {
 
   FontSizeInEm heatmap_bar_width_ = FontSizeInEm{0.0f};
   HeatmapSource heatmap_source_;
+
+  bool is_current_line_highlighted_ = false;
 };
 
 // Determine how many pixels are needed to draw all possible line numbers for the given font

--- a/src/CodeViewerDemo/main.cpp
+++ b/src/CodeViewerDemo/main.cpp
@@ -25,6 +25,7 @@ int main(int argc, char* argv[]) {
 
   dialog.SetEnableLineNumbers(true);
   dialog.GoToLineNumber(10);
+  dialog.SetHighlightCurrentLine(true);
 
   return dialog.exec();
 }


### PR DESCRIPTION
This adds the possbility to highlight the current line. The current line
is the one with the cursor.

It's highlighted by making the background of that particular line lighter.

It works in conjunction with GoToLine.

There is also another commit adjusting the handling of line numbers. It seems
line numbers are always one-indexed, never zero-indexed. So let's change the API
to expect a one-indexed line number.

![Source code view with line number 51 highlighted](https://user-images.githubusercontent.com/43133967/108719587-0b110480-7520-11eb-84bc-5cfe5871eab6.png)
Example: Line number 51 is highlighted here!
