### PR TITLE
Split module and symbole loading

### DIFF
--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -289,10 +289,19 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
       const std::vector<ModuleData*>& modules,
       absl::flat_hash_map<std::string, std::vector<uint64_t>> function_hashes_to_hook_map,
       absl::flat_hash_map<std::string, std::vector<uint64_t>> frame_track_function_hashes_map);
-  orbit_base::Future<ErrorMessageOr<void>> LoadModule(const ModuleData* module);
-  orbit_base::Future<ErrorMessageOr<void>> LoadModule(const std::string& module_path,
-                                                      const std::string& build_id);
+
+  // LoadModule retrieves a module file and returns the local file path (potentially from the local
+  // cache). Symbols won't be loaded.
+  orbit_base::Future<ErrorMessageOr<std::filesystem::path>> LoadModule(const ModuleData* module);
+  orbit_base::Future<ErrorMessageOr<std::filesystem::path>> LoadModule(
+      const std::string& module_path, const std::string& build_id);
   orbit_base::Future<void> LoadModules(absl::Span<const ModuleData* const> modules);
+
+  // LoadModuleAndSymbols is a helper function which first retrieves the module by calling
+  // `LoadModule` and afterwards load the symbols by calling `LoadSymbols`.
+  orbit_base::Future<ErrorMessageOr<void>> LoadModuleAndSymbols(const ModuleData* module);
+  orbit_base::Future<ErrorMessageOr<void>> LoadModuleAndSymbols(const std::string& module_path,
+                                                                const std::string& build_id);
 
   // TODO(177304549): This is still the way it is because of the old UI. Refactor: clean this up (it
   // should not be necessary to have an argument here, since OrbitApp will always only have one
@@ -478,7 +487,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   std::shared_ptr<SamplingReport> sampling_report_;
   std::shared_ptr<SamplingReport> selection_report_ = nullptr;
 
-  absl::flat_hash_map<std::string, orbit_base::Future<ErrorMessageOr<void>>>
+  absl::flat_hash_map<std::string, orbit_base::Future<ErrorMessageOr<std::filesystem::path>>>
       modules_currently_loading_;
 
   StringManager string_manager_;

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -292,16 +292,18 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
 
   // LoadModule retrieves a module file and returns the local file path (potentially from the local
   // cache). Symbols won't be loaded.
-  orbit_base::Future<ErrorMessageOr<std::filesystem::path>> LoadModule(const ModuleData* module);
-  orbit_base::Future<ErrorMessageOr<std::filesystem::path>> LoadModule(
+  orbit_base::Future<ErrorMessageOr<std::filesystem::path>> RetrieveModule(
+      const ModuleData* module);
+  orbit_base::Future<ErrorMessageOr<std::filesystem::path>> RetrieveModule(
       const std::string& module_path, const std::string& build_id);
-  orbit_base::Future<void> LoadModules(absl::Span<const ModuleData* const> modules);
+  orbit_base::Future<void> RetrieveModulesAndLoadSymbols(
+      absl::Span<const ModuleData* const> modules);
 
   // LoadModuleAndSymbols is a helper function which first retrieves the module by calling
   // `LoadModule` and afterwards load the symbols by calling `LoadSymbols`.
-  orbit_base::Future<ErrorMessageOr<void>> LoadModuleAndSymbols(const ModuleData* module);
-  orbit_base::Future<ErrorMessageOr<void>> LoadModuleAndSymbols(const std::string& module_path,
-                                                                const std::string& build_id);
+  orbit_base::Future<ErrorMessageOr<void>> RetrieveModuleAndLoadSymbols(const ModuleData* module);
+  orbit_base::Future<ErrorMessageOr<void>> RetrieveModuleAndLoadSymbols(
+      const std::string& module_path, const std::string& build_id);
 
   // TODO(177304549): This is still the way it is because of the old UI. Refactor: clean this up (it
   // should not be necessary to have an argument here, since OrbitApp will always only have one
@@ -416,10 +418,11 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
                    std::vector<uint64_t> function_hashes_to_hook,
                    std::vector<uint64_t> frame_track_function_hashes);
 
-  void LoadModuleOnRemote(ModuleData* module_data, std::vector<uint64_t> function_hashes_to_hook,
-                          std::vector<uint64_t> frame_track_function_hashes,
-                          std::string error_message_from_local);
-  [[nodiscard]] orbit_base::Future<ErrorMessageOr<std::filesystem::path>> LoadModuleOnRemote(
+  void RetrieveModuleFromRemote(ModuleData* module_data,
+                                std::vector<uint64_t> function_hashes_to_hook,
+                                std::vector<uint64_t> frame_track_function_hashes,
+                                std::string error_message_from_local);
+  [[nodiscard]] orbit_base::Future<ErrorMessageOr<std::filesystem::path>> RetrieveModuleFromRemote(
       const std::string& module_file_path);
 
   void SelectFunctionsFromHashes(const ModuleData* module,

--- a/src/OrbitGl/CallStackDataView.cpp
+++ b/src/OrbitGl/CallStackDataView.cpp
@@ -151,7 +151,7 @@ void CallStackDataView::OnContextMenu(const std::string& action, int menu_index,
         modules_to_load.push_back(module);
       }
     }
-    app_->LoadModules(modules_to_load);
+    app_->RetrieveModulesAndLoadSymbols(modules_to_load);
 
   } else if (action == kMenuActionSelect) {
     for (int i : item_indices) {

--- a/src/OrbitGl/ModulesDataView.cpp
+++ b/src/OrbitGl/ModulesDataView.cpp
@@ -138,7 +138,7 @@ void ModulesDataView::OnContextMenu(const std::string& action, int menu_index,
         modules_to_load.push_back(module_data);
       }
     }
-    app_->LoadModules(modules_to_load);
+    app_->RetrieveModulesAndLoadSymbols(modules_to_load);
 
   } else if (action == kMenuActionVerifyFramePointers) {
     std::vector<const ModuleData*> modules_to_validate;
@@ -160,7 +160,7 @@ void ModulesDataView::OnDoubleClicked(int index) {
   ModuleData* module_data = GetModule(index);
   if (!module_data->is_loaded()) {
     std::vector<ModuleData*> modules_to_load = {module_data};
-    app_->LoadModules(modules_to_load);
+    app_->RetrieveModulesAndLoadSymbols(modules_to_load);
   }
 }
 

--- a/src/OrbitGl/SamplingReportDataView.cpp
+++ b/src/OrbitGl/SamplingReportDataView.cpp
@@ -263,7 +263,7 @@ void SamplingReportDataView::OnContextMenu(const std::string& action, int menu_i
         modules_to_load.push_back(module);
       }
     }
-    app_->LoadModules(modules_to_load);
+    app_->RetrieveModulesAndLoadSymbols(modules_to_load);
   } else if (action == kMenuActionDisassembly) {
     int32_t pid = app_->GetCaptureData().process_id();
     for (const FunctionInfo* function : GetFunctionsFromIndices(item_indices)) {

--- a/src/OrbitQt/CallTreeWidget.cpp
+++ b/src/OrbitQt/CallTreeWidget.cpp
@@ -445,7 +445,7 @@ void CallTreeWidget::onCustomContextMenuRequested(const QPoint& point) {
   } else if (action->text() == kActionCollapseAll) {
     ui_->callTreeTreeView->collapseAll();
   } else if (action->text() == kActionLoadSymbols) {
-    app_->LoadModules(modules_to_load);
+    app_->RetrieveModulesAndLoadSymbols(modules_to_load);
   } else if (action->text() == kActionSelect) {
     for (const FunctionInfo* function : functions) {
       app_->SelectFunction(*function);


### PR DESCRIPTION
The function `OrbitApp::LoadModule` used to retrieve a module file and
then load its symbols automatically. This PR changes that by renaming
`LoadModule` to `LoadModuleAndSymbols`.

Furthermore it introduces a new function called `OrbitApp::LoadModule`
which only retrieves the module and ensure that it is available in a
local file path. Maybe nothing needs to be done, because it's in a local
search path, or it needs to be copied from the remote instance and put
in the local cache directory. Either way, `LoadModule` will take care of
it and return the local path, if successful.

Test: Manual test
Bug: http://b/179241832