### PR TITLE
Fix crash on debug markers across multiple submissions.

### DIFF
--- a/src/OrbitCaptureClient/CaptureEventProcessorTest.cpp
+++ b/src/OrbitCaptureClient/CaptureEventProcessorTest.cpp
@@ -892,8 +892,6 @@ TEST(CaptureEventProcessor, CanHandleGpuDebugMarkersWithNoBeginJobRecorded) {
 
   event_processor.ProcessEvent(queue_submission_event_1);
 
-  testing::Mock::VerifyAndClearExpectations(&listener);
-
   uint64_t actual_command_buffer_key;
   EXPECT_CALL(listener, OnKeyAndString(_, "command buffer"))
       .Times(1)

--- a/src/OrbitCaptureClient/CaptureEventProcessorTest.cpp
+++ b/src/OrbitCaptureClient/CaptureEventProcessorTest.cpp
@@ -852,6 +852,81 @@ TEST(CaptureEventProcessor, CanHandleGpuDebugMarkersWithNoBeginRecorded) {
                            actual_marker_key);
 }
 
+TEST(CaptureEventProcessor, CanHandleGpuDebugMarkersWithNoBeginJobRecorded) {
+  MockCaptureListener listener;
+  CaptureEventProcessor event_processor(&listener);
+
+  ClientCaptureEvent timeline_string = CreateInternedStringEvent(kTimelineKey, kTimelineString);
+
+  ClientCaptureEvent gpu_job_event_2;
+  GpuJob* gpu_job_2 = CreateGpuJob(&gpu_job_event_2, kTimelineKey, 50, 60, 70, 80);
+
+  ClientCaptureEvent marker_string_event = CreateInternedStringEvent(42, "marker");
+
+  ClientCaptureEvent queue_submission_event_1;
+  GpuQueueSubmission* submission_1 = queue_submission_event_1.mutable_gpu_queue_submission();
+  GpuQueueSubmissionMetaInfo* meta_info_1 = CreateGpuQueueSubmissionMetaInfo(submission_1, 9, 11);
+  GpuSubmitInfo* submit_info_1 = submission_1->add_submit_infos();
+  AddGpuCommandBufferToGpuSubmitInfo(submit_info_1, 115, 119);
+  AddGpuCommandBufferToGpuSubmitInfo(submit_info_1, 120, 124);
+  submission_1->set_num_begin_markers(1);
+
+  ClientCaptureEvent queue_submission_event_2;
+  GpuQueueSubmission* submission_2 = queue_submission_event_2.mutable_gpu_queue_submission();
+  CreateGpuQueueSubmissionMetaInfo(submission_2, 49, 51);
+  GpuSubmitInfo* submit_info_2 = submission_2->add_submit_infos();
+  AddGpuCommandBufferToGpuSubmitInfo(submit_info_2, 145, 154);
+  AddGpuDebugMarkerToGpuQueueSubmission(submission_2, meta_info_1, 42, 116, 153);
+
+  EXPECT_CALL(listener, OnKeyAndString(kTimelineKey, kTimelineString)).Times(1);
+  EXPECT_CALL(listener, OnKeyAndString(_, "sw queue")).Times(1);
+  EXPECT_CALL(listener, OnKeyAndString(_, "hw queue")).Times(1);
+  EXPECT_CALL(listener, OnKeyAndString(_, "hw execution")).Times(1);
+
+  EXPECT_CALL(listener, OnTimer).Times(3);
+
+  event_processor.ProcessEvent(timeline_string);
+  event_processor.ProcessEvent(gpu_job_event_2);
+
+  testing::Mock::VerifyAndClearExpectations(&listener);
+
+  event_processor.ProcessEvent(queue_submission_event_1);
+
+  testing::Mock::VerifyAndClearExpectations(&listener);
+
+  uint64_t actual_command_buffer_key;
+  EXPECT_CALL(listener, OnKeyAndString(_, "command buffer"))
+      .Times(1)
+      .WillOnce(SaveArg<0>(&actual_command_buffer_key));
+
+  TimerInfo command_buffer_timer_3;
+  TimerInfo debug_marker_timer;
+  EXPECT_CALL(listener, OnTimer)
+      .Times(2)
+      .WillOnce(SaveArg<0>(&command_buffer_timer_3))
+      .WillOnce(SaveArg<0>(&debug_marker_timer));
+
+  uint64_t actual_marker_timeline_key = 0;
+  EXPECT_CALL(listener, OnKeyAndString(_, "timeline_marker"))
+      .Times(1)
+      .WillOnce(SaveArg<0>(&actual_marker_timeline_key));
+  uint64_t actual_marker_key = 0;
+  EXPECT_CALL(listener, OnKeyAndString(_, "marker"))
+      .Times(1)
+      .WillOnce(SaveArg<0>(&actual_marker_key));
+
+  event_processor.ProcessEvent(marker_string_event);
+  event_processor.ProcessEvent(queue_submission_event_2);
+  testing::Mock::VerifyAndClearExpectations(&listener);
+
+  ExpectCommandBufferTimerEq(command_buffer_timer_3, *gpu_job_2, 70, 79, kTimelineKey,
+                             actual_command_buffer_key);
+
+  // We expect the begin timestamp to be approximated by the first known timestamp.
+  ExpectDebugMarkerTimerEq(debug_marker_timer, 50, 78, gpu_job_2->tid(), 1,
+                           actual_marker_timeline_key, actual_marker_key);
+}
+
 TEST(CaptureEventProcessor, CanHandleThreadStateSlices) {
   MockCaptureListener listener;
   CaptureEventProcessor event_processor(&listener);

--- a/src/OrbitCaptureClient/GpuQueueSubmissionProcessor.cpp
+++ b/src/OrbitCaptureClient/GpuQueueSubmissionProcessor.cpp
@@ -211,8 +211,8 @@ void GpuQueueSubmissionProcessor::DeleteSavedGpuJob(int32_t thread_id,
   if (!tid_to_submission_time_to_gpu_job_.contains(thread_id)) {
     return;
   }
-  // This method might be called if the "capture start" falls directly inside a GpuJob, and we thus
-  // don't have the job present in the map.
+  // This method might be called even when the "capture start" falls directly inside a GpuJob, and
+  // we thus don't have the job present in the map.
   // For simplicity we "erase" it anyways (insert and remove it again).
   auto& submission_time_to_gpu_job = tid_to_submission_time_to_gpu_job_[thread_id];
   submission_time_to_gpu_job.erase(submission_timestamp);

--- a/src/OrbitCaptureClient/GpuQueueSubmissionProcessor.cpp
+++ b/src/OrbitCaptureClient/GpuQueueSubmissionProcessor.cpp
@@ -360,7 +360,7 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuDebugMarkers(
         marker_timer.set_start(completed_marker.begin_marker().gpu_timestamp_ns() +
                                matching_begin_job->gpu_hardware_start_time_ns() -
                                begin_submission_first_command_buffer->begin_gpu_timestamp_ns());
-        matching_begin_job->amdgpu_cs_ioctl_time_ns();
+        begin_submission_time_ns = matching_begin_job->amdgpu_cs_ioctl_time_ns();
       } else {
         marker_timer.set_start(begin_capture_time_ns_);
       }

--- a/src/OrbitCaptureClient/GpuQueueSubmissionProcessor.cpp
+++ b/src/OrbitCaptureClient/GpuQueueSubmissionProcessor.cpp
@@ -10,7 +10,6 @@ using orbit_client_protos::Color;
 using orbit_client_protos::TimerInfo;
 
 using orbit_grpc_protos::GpuCommandBuffer;
-using orbit_grpc_protos::GpuDebugMarker;
 using orbit_grpc_protos::GpuJob;
 using orbit_grpc_protos::GpuQueueSubmission;
 
@@ -212,7 +211,10 @@ void GpuQueueSubmissionProcessor::DeleteSavedGpuJob(int32_t thread_id,
   if (!tid_to_submission_time_to_gpu_job_.contains(thread_id)) {
     return;
   }
-  auto& submission_time_to_gpu_job = tid_to_submission_time_to_gpu_job_.at(thread_id);
+  // This method might be also called if the the last Gpu Job that was was not part of the capture,
+  // and is thus not present in the map. For simplicity we "erase" it anyways (insert and remove it
+  // again).
+  auto& submission_time_to_gpu_job = tid_to_submission_time_to_gpu_job_[thread_id];
   submission_time_to_gpu_job.erase(submission_timestamp);
   if (submission_time_to_gpu_job.empty()) {
     tid_to_submission_time_to_gpu_job_.erase(thread_id);
@@ -348,25 +350,31 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuDebugMarkers(
       const GpuJob* matching_begin_job = FindMatchingGpuJob(
           begin_marker_thread_id, begin_marker_meta_info.pre_submission_cpu_timestamp(),
           begin_marker_post_submission_cpu_timestamp);
-      CHECK(matching_begin_job != nullptr);
 
-      // Convert the GPU time to CPU time, based on the CPU time of the HW execution begin and the
-      // GPU timestamp of the begin of the first command buffer. Note that we will assume that the
-      // first command buffer starts execution right away as an approximation.
-      marker_timer.set_start(completed_marker.begin_marker().gpu_timestamp_ns() +
-                             matching_begin_job->gpu_hardware_start_time_ns() -
-                             begin_submission_first_command_buffer->begin_gpu_timestamp_ns());
+      uint64_t begin_submission_time_ns = 0;
+      // We might have bad luck and captured the "begin" submission, but not the matching job.
+      if (matching_begin_job != nullptr) {
+        // Convert the GPU time to CPU time, based on the CPU time of the HW execution begin and the
+        // GPU timestamp of the begin of the first command buffer. Note that we will assume that the
+        // first command buffer starts execution right away as an approximation.
+        marker_timer.set_start(completed_marker.begin_marker().gpu_timestamp_ns() +
+                               matching_begin_job->gpu_hardware_start_time_ns() -
+                               begin_submission_first_command_buffer->begin_gpu_timestamp_ns());
+        matching_begin_job->amdgpu_cs_ioctl_time_ns();
+      } else {
+        marker_timer.set_start(begin_capture_time_ns_);
+      }
+
       if (begin_marker_thread_id == gpu_queue_submission.meta_info().tid()) {
         marker_timer.set_thread_id(begin_marker_thread_id);
       } else {
         marker_timer.set_thread_id(kUnknownThreadId);
       }
 
-      // Remember, it would not be safe to decrement (and thus possible erese) the "begin marker"
+      // Remember, it would not be safe to decrement (and thus possible erase) the "begin marker"
       // here right away, as its begin submission might be the same as "gpu_queue_submission",
       // which we still use afterwards.
-      begin_markers_to_decrement.emplace_back(begin_marker_thread_id,
-                                              matching_begin_job->amdgpu_cs_ioctl_time_ns(),
+      begin_markers_to_decrement.emplace_back(begin_marker_thread_id, begin_submission_time_ns,
                                               begin_marker_post_submission_cpu_timestamp);
     } else {
       marker_timer.set_start(begin_capture_time_ns_);


### PR DESCRIPTION
If debug markers are across different submissions, and we captured
the "begin" marker in the Vulkan layer, but missed a tracepoint
for the "GpuJobs, we end up in a situation where we do have
the "begin" submission, but not the "begin" job.

We now handle this gracefully (similar to the case where we do not
have the "begin" submission), but using the begin capture time
as approximation.

Test: Use Vulkan layer on Infiltrator.