### PR TITLE
Fix the implementation of Vulkan extensions.

### DIFF
--- a/src/OrbitVulkanLayer/DispatchTable.cpp
+++ b/src/OrbitVulkanLayer/DispatchTable.cpp
@@ -19,11 +19,39 @@ void DispatchTable::CreateInstanceDispatchTable(
   dispatch_table.GetPhysicalDeviceProperties = absl::bit_cast<PFN_vkGetPhysicalDeviceProperties>(
       next_get_instance_proc_addr_function(instance, "vkGetPhysicalDeviceProperties"));
 
+  dispatch_table.CreateDebugUtilsMessengerEXT = absl::bit_cast<PFN_vkCreateDebugUtilsMessengerEXT>(
+      next_get_instance_proc_addr_function(instance, "vkCreateDebugUtilsMessengerEXT"));
+  dispatch_table.DestroyDebugUtilsMessengerEXT =
+      absl::bit_cast<PFN_vkDestroyDebugUtilsMessengerEXT>(
+          next_get_instance_proc_addr_function(instance, "vkDestroyDebugUtilsMessengerEXT"));
+  dispatch_table.SubmitDebugUtilsMessageEXT = absl::bit_cast<PFN_vkSubmitDebugUtilsMessageEXT>(
+      next_get_instance_proc_addr_function(instance, "vkSubmitDebugUtilsMessageEXT"));
+
+  dispatch_table.CreateDebugReportCallbackEXT = absl::bit_cast<PFN_vkCreateDebugReportCallbackEXT>(
+      next_get_instance_proc_addr_function(instance, "vkCreateDebugReportCallbackEXT"));
+  dispatch_table.DestroyDebugReportCallbackEXT =
+      absl::bit_cast<PFN_vkDestroyDebugReportCallbackEXT>(
+          next_get_instance_proc_addr_function(instance, "vkDestroyDebugReportCallbackEXT"));
+  dispatch_table.DebugReportMessageEXT = absl::bit_cast<PFN_vkDebugReportMessageEXT>(
+      next_get_instance_proc_addr_function(instance, "vkDebugReportMessageEXT"));
+
   void* key = GetDispatchTableKey(instance);
   {
     absl::WriterMutexLock lock(&mutex_);
     CHECK(!instance_dispatch_table_.contains(key));
     instance_dispatch_table_[key] = dispatch_table;
+
+    CHECK(!instance_supports_debug_utils_extension_.contains(key));
+    instance_supports_debug_utils_extension_[key] =
+        dispatch_table.CreateDebugUtilsMessengerEXT != nullptr &&
+        dispatch_table.DestroyDebugUtilsMessengerEXT != nullptr &&
+        dispatch_table.SubmitDebugUtilsMessageEXT != nullptr;
+
+    CHECK(!instance_supports_debug_report_extension_.contains(key));
+    instance_supports_debug_report_extension_[key] =
+        dispatch_table.CreateDebugReportCallbackEXT != nullptr &&
+        dispatch_table.DestroyDebugReportCallbackEXT != nullptr &&
+        dispatch_table.DebugReportMessageEXT != nullptr;
   }
 }
 
@@ -33,6 +61,12 @@ void DispatchTable::RemoveInstanceDispatchTable(VkInstance instance) {
     absl::WriterMutexLock lock(&mutex_);
     CHECK(instance_dispatch_table_.contains(key));
     instance_dispatch_table_.erase(key);
+
+    CHECK(instance_supports_debug_utils_extension_.contains(key));
+    instance_supports_debug_utils_extension_.erase(key);
+
+    CHECK(instance_supports_debug_report_extension_.contains(key));
+    instance_supports_debug_report_extension_.erase(key);
   }
 }
 
@@ -84,11 +118,31 @@ void DispatchTable::CreateDeviceDispatchTable(
       next_get_device_proc_addr_function(device, "vkCmdBeginDebugUtilsLabelEXT"));
   dispatch_table.CmdEndDebugUtilsLabelEXT = absl::bit_cast<PFN_vkCmdEndDebugUtilsLabelEXT>(
       next_get_device_proc_addr_function(device, "vkCmdEndDebugUtilsLabelEXT"));
+  dispatch_table.CmdInsertDebugUtilsLabelEXT = absl::bit_cast<PFN_vkCmdInsertDebugUtilsLabelEXT>(
+      next_get_device_proc_addr_function(device, "vkCmdInsertDebugUtilsLabelEXT"));
+  dispatch_table.SetDebugUtilsObjectNameEXT = absl::bit_cast<PFN_vkSetDebugUtilsObjectNameEXT>(
+      next_get_device_proc_addr_function(device, "vkSetDebugUtilsObjectNameEXT"));
+  dispatch_table.SetDebugUtilsObjectTagEXT = absl::bit_cast<PFN_vkSetDebugUtilsObjectTagEXT>(
+      next_get_device_proc_addr_function(device, "vkSetDebugUtilsObjectTagEXT"));
+  dispatch_table.QueueBeginDebugUtilsLabelEXT = absl::bit_cast<PFN_vkQueueBeginDebugUtilsLabelEXT>(
+      next_get_device_proc_addr_function(device, "vkQueueBeginDebugUtilsLabelEXT"));
+  dispatch_table.QueueEndDebugUtilsLabelEXT = absl::bit_cast<PFN_vkQueueEndDebugUtilsLabelEXT>(
+      next_get_device_proc_addr_function(device, "vkQueueEndDebugUtilsLabelEXT"));
+  dispatch_table.QueueInsertDebugUtilsLabelEXT =
+      absl::bit_cast<PFN_vkQueueInsertDebugUtilsLabelEXT>(
+          next_get_device_proc_addr_function(device, "vkQueueInsertDebugUtilsLabelEXT"));
 
   dispatch_table.CmdDebugMarkerBeginEXT = absl::bit_cast<PFN_vkCmdDebugMarkerBeginEXT>(
       next_get_device_proc_addr_function(device, "vkCmdDebugMarkerBeginEXT"));
   dispatch_table.CmdDebugMarkerEndEXT = absl::bit_cast<PFN_vkCmdDebugMarkerEndEXT>(
       next_get_device_proc_addr_function(device, "vkCmdDebugMarkerEndEXT"));
+
+  dispatch_table.DebugMarkerSetObjectTagEXT = absl::bit_cast<PFN_vkDebugMarkerSetObjectTagEXT>(
+      next_get_device_proc_addr_function(device, "vkDebugMarkerSetObjectTagEXT"));
+  dispatch_table.DebugMarkerSetObjectNameEXT = absl::bit_cast<PFN_vkDebugMarkerSetObjectNameEXT>(
+      next_get_device_proc_addr_function(device, "vkDebugMarkerSetObjectNameEXT"));
+  dispatch_table.CmdDebugMarkerInsertEXT = absl::bit_cast<PFN_vkCmdDebugMarkerInsertEXT>(
+      next_get_device_proc_addr_function(device, "vkCmdDebugMarkerInsertEXT"));
 
   void* key = GetDispatchTableKey(device);
   {
@@ -99,12 +153,21 @@ void DispatchTable::CreateDeviceDispatchTable(
     CHECK(!device_supports_debug_utils_extension_.contains(key));
     device_supports_debug_utils_extension_[key] =
         dispatch_table.CmdBeginDebugUtilsLabelEXT != nullptr &&
-        dispatch_table.CmdEndDebugUtilsLabelEXT != nullptr;
+        dispatch_table.CmdEndDebugUtilsLabelEXT != nullptr &&
+        dispatch_table.SetDebugUtilsObjectNameEXT != nullptr &&
+        dispatch_table.SetDebugUtilsObjectTagEXT != nullptr &&
+        dispatch_table.QueueBeginDebugUtilsLabelEXT != nullptr &&
+        dispatch_table.QueueEndDebugUtilsLabelEXT != nullptr &&
+        dispatch_table.QueueInsertDebugUtilsLabelEXT != nullptr &&
+        dispatch_table.CmdInsertDebugUtilsLabelEXT != nullptr;
 
     CHECK(!device_supports_debug_marker_extension_.contains(key));
     device_supports_debug_marker_extension_[key] =
         dispatch_table.CmdDebugMarkerBeginEXT != nullptr &&
-        dispatch_table.CmdDebugMarkerEndEXT != nullptr;
+        dispatch_table.CmdDebugMarkerEndEXT != nullptr &&
+        dispatch_table.DebugMarkerSetObjectTagEXT != nullptr &&
+        dispatch_table.DebugMarkerSetObjectNameEXT != nullptr &&
+        dispatch_table.CmdDebugMarkerInsertEXT != nullptr;
   }
 }
 

--- a/src/OrbitVulkanLayer/DispatchTable.h
+++ b/src/OrbitVulkanLayer/DispatchTable.h
@@ -264,6 +264,79 @@ class DispatchTable {
     }
   }
 
+  // ----------------------------------------------------------------------------
+  // Debug marker extension:
+  // ----------------------------------------------------------------------------
+  template <typename DispatchableType>
+  PFN_vkCmdDebugMarkerBeginEXT CmdDebugMarkerBeginEXT(DispatchableType dispatchable_object) {
+    void* key = GetDispatchTableKey(dispatchable_object);
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).CmdDebugMarkerBeginEXT != nullptr);
+      return device_dispatch_table_.at(key).CmdDebugMarkerBeginEXT;
+    }
+  }
+
+  template <typename DispatchableType>
+  PFN_vkCmdDebugMarkerEndEXT CmdDebugMarkerEndEXT(DispatchableType dispatchable_object) {
+    void* key = GetDispatchTableKey(dispatchable_object);
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).CmdDebugMarkerEndEXT != nullptr);
+      return device_dispatch_table_.at(key).CmdDebugMarkerEndEXT;
+    }
+  }
+
+  template <typename DispatchableType>
+  PFN_vkCmdDebugMarkerInsertEXT CmdDebugMarkerInsertEXT(DispatchableType dispatchable_object) {
+    void* key = GetDispatchTableKey(dispatchable_object);
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).CmdDebugMarkerInsertEXT != nullptr);
+      return device_dispatch_table_.at(key).CmdDebugMarkerInsertEXT;
+    }
+  }
+
+  template <typename DispatchableType>
+  PFN_vkDebugMarkerSetObjectTagEXT DebugMarkerSetObjectTagEXT(
+      DispatchableType dispatchable_object) {
+    void* key = GetDispatchTableKey(dispatchable_object);
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).DebugMarkerSetObjectTagEXT != nullptr);
+      return device_dispatch_table_.at(key).DebugMarkerSetObjectTagEXT;
+    }
+  }
+
+  template <typename DispatchableType>
+  PFN_vkDebugMarkerSetObjectNameEXT DebugMarkerSetObjectNameEXT(
+      DispatchableType dispatchable_object) {
+    void* key = GetDispatchTableKey(dispatchable_object);
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).DebugMarkerSetObjectNameEXT != nullptr);
+      return device_dispatch_table_.at(key).DebugMarkerSetObjectNameEXT;
+    }
+  }
+
+  template <typename DispatchableType>
+  bool IsDebugMarkerExtensionSupported(DispatchableType dispatchable_object) {
+    void* key = GetDispatchTableKey(dispatchable_object);
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_supports_debug_marker_extension_.contains(key));
+      return device_supports_debug_marker_extension_.at(key);
+    }
+  }
+
+  // ----------------------------------------------------------------------------
+  // Debug utils extension:
+  // ----------------------------------------------------------------------------
   template <typename DispatchableType>
   PFN_vkCmdBeginDebugUtilsLabelEXT CmdBeginDebugUtilsLabelEXT(
       DispatchableType dispatchable_object) {
@@ -288,34 +361,109 @@ class DispatchTable {
   }
 
   template <typename DispatchableType>
-  PFN_vkCmdDebugMarkerBeginEXT CmdDebugMarkerBeginEXT(DispatchableType dispatchable_object) {
+  PFN_vkCmdInsertDebugUtilsLabelEXT CmdInsertDebugUtilsLabelEXT(
+      DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
       CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).CmdDebugMarkerBeginEXT != nullptr);
-      return device_dispatch_table_.at(key).CmdDebugMarkerBeginEXT;
+      CHECK(device_dispatch_table_.at(key).CmdInsertDebugUtilsLabelEXT != nullptr);
+      return device_dispatch_table_.at(key).CmdInsertDebugUtilsLabelEXT;
     }
   }
 
   template <typename DispatchableType>
-  PFN_vkCmdDebugMarkerEndEXT CmdDebugMarkerEndEXT(DispatchableType dispatchable_object) {
+  PFN_vkSetDebugUtilsObjectNameEXT SetDebugUtilsObjectNameEXT(
+      DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
       CHECK(device_dispatch_table_.contains(key));
-      CHECK(device_dispatch_table_.at(key).CmdDebugMarkerEndEXT != nullptr);
-      return device_dispatch_table_.at(key).CmdDebugMarkerEndEXT;
+      CHECK(device_dispatch_table_.at(key).SetDebugUtilsObjectNameEXT != nullptr);
+      return device_dispatch_table_.at(key).SetDebugUtilsObjectNameEXT;
     }
   }
 
   template <typename DispatchableType>
-  bool IsDebugMarkerExtensionSupported(DispatchableType dispatchable_object) {
+  PFN_vkSetDebugUtilsObjectTagEXT SetDebugUtilsObjectTagEXT(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
       absl::ReaderMutexLock lock(&mutex_);
-      CHECK(device_supports_debug_marker_extension_.contains(key));
-      return device_supports_debug_marker_extension_.at(key);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).SetDebugUtilsObjectTagEXT != nullptr);
+      return device_dispatch_table_.at(key).SetDebugUtilsObjectTagEXT;
+    }
+  }
+
+  template <typename DispatchableType>
+  PFN_vkQueueBeginDebugUtilsLabelEXT QueueBeginDebugUtilsLabelEXT(
+      DispatchableType dispatchable_object) {
+    void* key = GetDispatchTableKey(dispatchable_object);
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).QueueBeginDebugUtilsLabelEXT != nullptr);
+      return device_dispatch_table_.at(key).QueueBeginDebugUtilsLabelEXT;
+    }
+  }
+
+  template <typename DispatchableType>
+  PFN_vkQueueEndDebugUtilsLabelEXT QueueEndDebugUtilsLabelEXT(
+      DispatchableType dispatchable_object) {
+    void* key = GetDispatchTableKey(dispatchable_object);
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).QueueEndDebugUtilsLabelEXT != nullptr);
+      return device_dispatch_table_.at(key).QueueEndDebugUtilsLabelEXT;
+    }
+  }
+
+  template <typename DispatchableType>
+  PFN_vkQueueInsertDebugUtilsLabelEXT QueueInsertDebugUtilsLabelEXT(
+      DispatchableType dispatchable_object) {
+    void* key = GetDispatchTableKey(dispatchable_object);
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).QueueInsertDebugUtilsLabelEXT != nullptr);
+      return device_dispatch_table_.at(key).QueueInsertDebugUtilsLabelEXT;
+    }
+  }
+
+  template <typename DispatchableType>
+  PFN_vkCreateDebugUtilsMessengerEXT CreateDebugUtilsMessengerEXT(
+      DispatchableType dispatchable_object) {
+    void* key = GetDispatchTableKey(dispatchable_object);
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(instance_dispatch_table_.contains(key));
+      CHECK(instance_dispatch_table_.at(key).CreateDebugUtilsMessengerEXT != nullptr);
+      return instance_dispatch_table_.at(key).CreateDebugUtilsMessengerEXT;
+    }
+  }
+
+  template <typename DispatchableType>
+  PFN_vkDestroyDebugUtilsMessengerEXT DestroyDebugUtilsMessengerEXT(
+      DispatchableType dispatchable_object) {
+    void* key = GetDispatchTableKey(dispatchable_object);
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(instance_dispatch_table_.contains(key));
+      CHECK(instance_dispatch_table_.at(key).DestroyDebugUtilsMessengerEXT != nullptr);
+      return instance_dispatch_table_.at(key).DestroyDebugUtilsMessengerEXT;
+    }
+  }
+
+  template <typename DispatchableType>
+  PFN_vkSubmitDebugUtilsMessageEXT SubmitDebugUtilsMessageEXT(
+      DispatchableType dispatchable_object) {
+    void* key = GetDispatchTableKey(dispatchable_object);
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(instance_dispatch_table_.contains(key));
+      CHECK(instance_dispatch_table_.at(key).SubmitDebugUtilsMessageEXT != nullptr);
+      return instance_dispatch_table_.at(key).SubmitDebugUtilsMessageEXT;
     }
   }
 
@@ -326,6 +474,62 @@ class DispatchTable {
       absl::ReaderMutexLock lock(&mutex_);
       CHECK(device_supports_debug_utils_extension_.contains(key));
       return device_supports_debug_utils_extension_.at(key);
+    }
+  }
+
+  bool IsDebugUtilsExtensionSupported(VkInstance instance) {
+    void* key = GetDispatchTableKey(instance);
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(instance_supports_debug_utils_extension_.contains(key));
+      return instance_supports_debug_utils_extension_.at(key);
+    }
+  }
+
+  // ----------------------------------------------------------------------------
+  // Debug report extension:
+  // ----------------------------------------------------------------------------
+  template <typename DispatchableType>
+  PFN_vkCreateDebugReportCallbackEXT CreateDebugReportCallbackEXT(
+      DispatchableType dispatchable_object) {
+    void* key = GetDispatchTableKey(dispatchable_object);
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(instance_dispatch_table_.contains(key));
+      CHECK(instance_dispatch_table_.at(key).CreateDebugReportCallbackEXT != nullptr);
+      return instance_dispatch_table_.at(key).CreateDebugReportCallbackEXT;
+    }
+  }
+
+  template <typename DispatchableType>
+  PFN_vkDestroyDebugReportCallbackEXT DestroyDebugReportCallbackEXT(
+      DispatchableType dispatchable_object) {
+    void* key = GetDispatchTableKey(dispatchable_object);
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(instance_dispatch_table_.contains(key));
+      CHECK(instance_dispatch_table_.at(key).DestroyDebugReportCallbackEXT != nullptr);
+      return instance_dispatch_table_.at(key).DestroyDebugReportCallbackEXT;
+    }
+  }
+
+  template <typename DispatchableType>
+  PFN_vkDebugReportMessageEXT DebugReportMessageEXT(DispatchableType dispatchable_object) {
+    void* key = GetDispatchTableKey(dispatchable_object);
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(instance_dispatch_table_.contains(key));
+      CHECK(instance_dispatch_table_.at(key).DebugReportMessageEXT != nullptr);
+      return instance_dispatch_table_.at(key).DebugReportMessageEXT;
+    }
+  }
+
+  bool IsDebugReportExtensionSupported(VkInstance instance) {
+    void* key = GetDispatchTableKey(instance);
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(instance_supports_debug_report_extension_.contains(key));
+      return instance_supports_debug_report_extension_.at(key);
     }
   }
 
@@ -350,6 +554,8 @@ class DispatchTable {
   absl::flat_hash_map<void*, VkLayerDispatchTable> device_dispatch_table_;
   absl::flat_hash_map<void*, bool> device_supports_debug_marker_extension_;
   absl::flat_hash_map<void*, bool> device_supports_debug_utils_extension_;
+  absl::flat_hash_map<void*, bool> instance_supports_debug_utils_extension_;
+  absl::flat_hash_map<void*, bool> instance_supports_debug_report_extension_;
 
   // Must protect access to dispatch tables above by mutex since the Vulkan
   // application may be calling these functions from different threads.

--- a/src/OrbitVulkanLayer/EntryPoints.cpp
+++ b/src/OrbitVulkanLayer/EntryPoints.cpp
@@ -128,6 +128,10 @@ VKAPI_ATTR VkResult VKAPI_CALL OrbitQueuePresentKHR(VkQueue queue,
   return controller.OnQueuePresentKHR(queue, present_info);
 }
 
+// ----------------------------------------------------------------------------
+// Implemented extension methods
+// ----------------------------------------------------------------------------
+
 VKAPI_ATTR void VKAPI_CALL OrbitCmdBeginDebugUtilsLabelEXT(VkCommandBuffer command_buffer,
                                                            const VkDebugUtilsLabelEXT* label_info) {
   controller.OnCmdBeginDebugUtilsLabelEXT(command_buffer, label_info);
@@ -146,6 +150,92 @@ VKAPI_ATTR void VKAPI_CALL OrbitCmdDebugMarkerEndEXT(VkCommandBuffer command_buf
   controller.OnCmdDebugMarkerEndEXT(command_buffer);
 }
 
+// ----------------------------------------------------------------------------
+// Unused but implemented extension methods (need to implement all methods of a
+// extension)
+// ----------------------------------------------------------------------------
+VKAPI_ATTR void VKAPI_CALL OrbitCmdInsertDebugUtilsLabelEXT(
+    VkCommandBuffer command_buffer, const VkDebugUtilsLabelEXT* label_info) {
+  controller.OnCmdInsertDebugUtilsLabelEXT(command_buffer, label_info);
+}
+
+VKAPI_ATTR void VKAPI_CALL OrbitCreateDebugUtilsMessengerEXT(
+    VkInstance instance, const VkDebugUtilsMessengerCreateInfoEXT* create_info,
+    const VkAllocationCallbacks* allocator, VkDebugUtilsMessengerEXT* messenger) {
+  controller.OnCreateDebugUtilsMessengerEXT(instance, create_info, allocator, messenger);
+}
+
+VKAPI_ATTR void VKAPI_CALL
+OrbitDestroyDebugUtilsMessengerEXT(VkInstance instance, VkDebugUtilsMessengerEXT messenger,
+                                   const VkAllocationCallbacks* allocator) {
+  controller.OnDestroyDebugUtilsMessengerEXT(instance, messenger, allocator);
+}
+
+VKAPI_ATTR void VKAPI_CALL
+OrbitQueueBeginDebugUtilsLabelEXT(VkQueue queue, const VkDebugUtilsLabelEXT* label_info) {
+  controller.OnQueueBeginDebugUtilsLabelEXT(queue, label_info);
+}
+
+VKAPI_ATTR void VKAPI_CALL OrbitQueueEndDebugUtilsLabelEXT(VkQueue queue) {
+  controller.OnQueueEndDebugUtilsLabelEXT(queue);
+}
+
+VKAPI_ATTR void VKAPI_CALL
+OrbitQueueInsertDebugUtilsLabelEXT(VkQueue queue, const VkDebugUtilsLabelEXT* label_info) {
+  controller.OnQueueInsertDebugUtilsLabelEXT(queue, label_info);
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL
+OrbitSetDebugUtilsObjectNameEXT(VkDevice device, const VkDebugUtilsObjectNameInfoEXT* name_info) {
+  return controller.OnSetDebugUtilsObjectNameEXT(device, name_info);
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL
+OrbitSetDebugUtilsObjectTagEXT(VkDevice device, const VkDebugUtilsObjectTagInfoEXT* tag_info) {
+  return controller.OnSetDebugUtilsObjectTagEXT(device, tag_info);
+}
+
+VKAPI_ATTR void VKAPI_CALL OrbitSubmitDebugUtilsMessageEXT(
+    VkInstance instance, VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
+    VkDebugUtilsMessageTypeFlagsEXT message_types,
+    const VkDebugUtilsMessengerCallbackDataEXT* callback_data) {
+  controller.OnSubmitDebugUtilsMessageEXT(instance, message_severity, message_types, callback_data);
+}
+
+VKAPI_ATTR void VKAPI_CALL OrbitCmdDebugMarkerInsertEXT(
+    VkCommandBuffer command_buffer, const VkDebugMarkerMarkerInfoEXT* marker_info) {
+  controller.OnCmdDebugMarkerInsertEXT(command_buffer, marker_info);
+}
+
+VKAPI_ATTR void VKAPI_CALL
+OrbitDebugMarkerSetObjectNameEXT(VkDevice device, const VkDebugMarkerObjectNameInfoEXT* name_info) {
+  controller.OnDebugMarkerSetObjectNameEXT(device, name_info);
+}
+
+VKAPI_ATTR void VKAPI_CALL
+OrbitDebugMarkerSetObjectTagEXT(VkDevice device, const VkDebugMarkerObjectTagInfoEXT* tag_info) {
+  controller.OnDebugMarkerSetObjectTagEXT(device, tag_info);
+}
+
+VKAPI_ATTR void VKAPI_CALL OrbitCreateDebugReportCallbackEXT(
+    VkInstance instance, const VkDebugReportCallbackCreateInfoEXT* create_info,
+    const VkAllocationCallbacks* allocator, VkDebugReportCallbackEXT* callback) {
+  controller.OnCreateDebugReportCallbackEXT(instance, create_info, allocator, callback);
+}
+
+VKAPI_ATTR void VKAPI_CALL
+OrbitDebugReportMessageEXT(VkInstance instance, VkDebugReportFlagsEXT flags,
+                           VkDebugReportObjectTypeEXT object_type, uint64_t object, size_t location,
+                           int32_t message_code, const char* layer_prefix, const char* message) {
+  controller.OnDebugReportMessageEXT(instance, flags, object_type, object, location, message_code,
+                                     layer_prefix, message);
+}
+
+VKAPI_ATTR void VKAPI_CALL
+OrbitDestroyDebugReportCallbackEXT(VkInstance instance, VkDebugReportCallbackEXT callback,
+                                   const VkAllocationCallbacks* allocator) {
+  controller.OnDestroyDebugReportCallbackEXT(instance, callback, allocator);
+}
 // ----------------------------------------------------------------------------
 // Layer enumeration functions
 // ----------------------------------------------------------------------------
@@ -214,6 +304,17 @@ OrbitGetDeviceProcAddr(VkDevice device, const char* name) {
   RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(CmdDebugMarkerBeginEXT);
   RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(CmdDebugMarkerEndEXT);
 
+  RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(SetDebugUtilsObjectNameEXT);
+  RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(SetDebugUtilsObjectTagEXT);
+  RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(QueueBeginDebugUtilsLabelEXT);
+  RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(QueueEndDebugUtilsLabelEXT);
+  RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(QueueInsertDebugUtilsLabelEXT);
+  RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(CmdInsertDebugUtilsLabelEXT);
+
+  RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(DebugMarkerSetObjectTagEXT);
+  RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(DebugMarkerSetObjectNameEXT);
+  RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(CmdDebugMarkerInsertEXT);
+
   return controller.ForwardGetDeviceProcAddr(device, name);
 }
 
@@ -225,6 +326,14 @@ OrbitGetInstanceProcAddr(VkInstance instance, const char* name) {
   RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(DestroyInstance);
   RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(EnumerateInstanceLayerProperties);
   RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(EnumerateInstanceExtensionProperties);
+
+  RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(CreateDebugUtilsMessengerEXT);
+  RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(DestroyDebugUtilsMessengerEXT);
+  RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(SubmitDebugUtilsMessageEXT);
+
+  RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(CreateDebugReportCallbackEXT);
+  RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(DestroyDebugReportCallbackEXT);
+  RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(DebugReportMessageEXT);
 
   // Functions available through GetInstanceProcAddr and GetDeviceProcAddr
   RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(GetDeviceProcAddr);
@@ -251,6 +360,17 @@ OrbitGetInstanceProcAddr(VkInstance instance, const char* name) {
   RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(CmdEndDebugUtilsLabelEXT);
   RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(CmdDebugMarkerBeginEXT);
   RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(CmdDebugMarkerEndEXT);
+
+  RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(SetDebugUtilsObjectNameEXT);
+  RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(SetDebugUtilsObjectTagEXT);
+  RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(QueueBeginDebugUtilsLabelEXT);
+  RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(QueueEndDebugUtilsLabelEXT);
+  RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(QueueInsertDebugUtilsLabelEXT);
+  RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(CmdInsertDebugUtilsLabelEXT);
+
+  RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(DebugMarkerSetObjectTagEXT);
+  RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(DebugMarkerSetObjectNameEXT);
+  RETURN_ORBIT_FUNCTION_IF_MATCHES_VK_FUNCTION(CmdDebugMarkerInsertEXT);
 
   return controller.ForwardGetInstanceProcAddr(instance, name);
 }

--- a/src/OrbitVulkanLayer/EntryPoints.cpp
+++ b/src/OrbitVulkanLayer/EntryPoints.cpp
@@ -207,20 +207,20 @@ VKAPI_ATTR void VKAPI_CALL OrbitCmdDebugMarkerInsertEXT(
   controller.OnCmdDebugMarkerInsertEXT(command_buffer, marker_info);
 }
 
-VKAPI_ATTR void VKAPI_CALL
+VKAPI_ATTR VkResult VKAPI_CALL
 OrbitDebugMarkerSetObjectNameEXT(VkDevice device, const VkDebugMarkerObjectNameInfoEXT* name_info) {
-  controller.OnDebugMarkerSetObjectNameEXT(device, name_info);
+  return controller.OnDebugMarkerSetObjectNameEXT(device, name_info);
 }
 
-VKAPI_ATTR void VKAPI_CALL
+VKAPI_ATTR VkResult VKAPI_CALL
 OrbitDebugMarkerSetObjectTagEXT(VkDevice device, const VkDebugMarkerObjectTagInfoEXT* tag_info) {
-  controller.OnDebugMarkerSetObjectTagEXT(device, tag_info);
+  return controller.OnDebugMarkerSetObjectTagEXT(device, tag_info);
 }
 
-VKAPI_ATTR void VKAPI_CALL OrbitCreateDebugReportCallbackEXT(
+VKAPI_ATTR VkResult VKAPI_CALL OrbitCreateDebugReportCallbackEXT(
     VkInstance instance, const VkDebugReportCallbackCreateInfoEXT* create_info,
     const VkAllocationCallbacks* allocator, VkDebugReportCallbackEXT* callback) {
-  controller.OnCreateDebugReportCallbackEXT(instance, create_info, allocator, callback);
+  return controller.OnCreateDebugReportCallbackEXT(instance, create_info, allocator, callback);
 }
 
 VKAPI_ATTR void VKAPI_CALL

--- a/src/OrbitVulkanLayer/EntryPoints.cpp
+++ b/src/OrbitVulkanLayer/EntryPoints.cpp
@@ -129,7 +129,7 @@ VKAPI_ATTR VkResult VKAPI_CALL OrbitQueuePresentKHR(VkQueue queue,
 }
 
 // ----------------------------------------------------------------------------
-// Implemented extension methods
+// Implemented and used extension methods
 // ----------------------------------------------------------------------------
 
 VKAPI_ATTR void VKAPI_CALL OrbitCmdBeginDebugUtilsLabelEXT(VkCommandBuffer command_buffer,
@@ -151,8 +151,8 @@ VKAPI_ATTR void VKAPI_CALL OrbitCmdDebugMarkerEndEXT(VkCommandBuffer command_buf
 }
 
 // ----------------------------------------------------------------------------
-// Unused but implemented extension methods (need to implement all methods of a
-// extension)
+// Unused but implemented extension methods (need to implement all methods of
+// an extension)
 // ----------------------------------------------------------------------------
 VKAPI_ATTR void VKAPI_CALL OrbitCmdInsertDebugUtilsLabelEXT(
     VkCommandBuffer command_buffer, const VkDebugUtilsLabelEXT* label_info) {

--- a/src/OrbitVulkanLayer/VulkanLayerController.h
+++ b/src/OrbitVulkanLayer/VulkanLayerController.h
@@ -388,28 +388,31 @@ class VulkanLayerController {
     }
   }
 
-  void OnDebugMarkerSetObjectNameEXT(VkDevice device,
-                                     const VkDebugMarkerObjectNameInfoEXT* name_info) {
+  VkResult OnDebugMarkerSetObjectNameEXT(VkDevice device,
+                                         const VkDebugMarkerObjectNameInfoEXT* name_info) {
     if (dispatch_table_.IsDebugMarkerExtensionSupported(device)) {
-      dispatch_table_.DebugMarkerSetObjectNameEXT(device)(device, name_info);
+      return dispatch_table_.DebugMarkerSetObjectNameEXT(device)(device, name_info);
     }
+    return VK_SUCCESS;
   }
 
-  void OnDebugMarkerSetObjectTagEXT(VkDevice device,
-                                    const VkDebugMarkerObjectTagInfoEXT* tag_info) {
+  VkResult OnDebugMarkerSetObjectTagEXT(VkDevice device,
+                                        const VkDebugMarkerObjectTagInfoEXT* tag_info) {
     if (dispatch_table_.IsDebugMarkerExtensionSupported(device)) {
-      dispatch_table_.DebugMarkerSetObjectTagEXT(device)(device, tag_info);
+      return dispatch_table_.DebugMarkerSetObjectTagEXT(device)(device, tag_info);
     }
+    return VK_SUCCESS;
   }
 
-  void OnCreateDebugReportCallbackEXT(VkInstance instance,
-                                      const VkDebugReportCallbackCreateInfoEXT* create_info,
-                                      const VkAllocationCallbacks* allocator,
-                                      VkDebugReportCallbackEXT* callback) {
+  VkResult OnCreateDebugReportCallbackEXT(VkInstance instance,
+                                          const VkDebugReportCallbackCreateInfoEXT* create_info,
+                                          const VkAllocationCallbacks* allocator,
+                                          VkDebugReportCallbackEXT* callback) {
     if (dispatch_table_.IsDebugReportExtensionSupported(instance)) {
-      dispatch_table_.CreateDebugReportCallbackEXT(instance)(instance, create_info, allocator,
-                                                             callback);
+      return dispatch_table_.CreateDebugReportCallbackEXT(instance)(instance, create_info,
+                                                                    allocator, callback);
     }
+    return VK_SUCCESS;
   }
 
   void OnDebugReportMessageEXT(VkInstance instance, VkDebugReportFlagsEXT flags,

--- a/src/OrbitVulkanLayer/VulkanLayerController.h
+++ b/src/OrbitVulkanLayer/VulkanLayerController.h
@@ -39,13 +39,15 @@ class VulkanLayerController {
   static constexpr uint32_t kLayerImplVersion = 1;
   static constexpr uint32_t kLayerSpecVersion = VK_API_VERSION_1_1;
 
-  static constexpr std::array<VkExtensionProperties, 3> kRequiredDeviceExtensions = {
+  static constexpr std::array<VkExtensionProperties, 1> kImplementedDeviceExtensions = {
       VkExtensionProperties{.extensionName = VK_EXT_DEBUG_MARKER_EXTENSION_NAME,
-                            .specVersion = VK_EXT_DEBUG_MARKER_SPEC_VERSION},
+                            .specVersion = VK_EXT_DEBUG_MARKER_SPEC_VERSION}};
+
+  static constexpr std::array<VkExtensionProperties, 2> kImplementedInstanceExtensions = {
       VkExtensionProperties{.extensionName = VK_EXT_DEBUG_UTILS_EXTENSION_NAME,
                             .specVersion = VK_EXT_DEBUG_UTILS_SPEC_VERSION},
-      VkExtensionProperties{.extensionName = VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME,
-                            .specVersion = VK_EXT_HOST_QUERY_RESET_SPEC_VERSION}};
+      VkExtensionProperties{.extensionName = VK_EXT_DEBUG_REPORT_EXTENSION_NAME,
+                            .specVersion = VK_EXT_DEBUG_REPORT_SPEC_VERSION}};
 
   VulkanLayerController()
       : device_manager_(&dispatch_table_),
@@ -307,6 +309,127 @@ class VulkanLayerController {
   }
 
   // ----------------------------------------------------------------------------
+  // Unused but implemented extension methods (need to implement all methods of a
+  // extension)
+  // ----------------------------------------------------------------------------
+  void OnCmdInsertDebugUtilsLabelEXT(VkCommandBuffer command_buffer,
+                                     const VkDebugUtilsLabelEXT* label_info) {
+    if (dispatch_table_.IsDebugUtilsExtensionSupported(command_buffer)) {
+      dispatch_table_.CmdInsertDebugUtilsLabelEXT(command_buffer)(command_buffer, label_info);
+    }
+  }
+
+  VkResult OnCreateDebugUtilsMessengerEXT(VkInstance instance,
+                                          const VkDebugUtilsMessengerCreateInfoEXT* create_info,
+                                          const VkAllocationCallbacks* allocator,
+                                          VkDebugUtilsMessengerEXT* messenger) {
+    if (dispatch_table_.IsDebugUtilsExtensionSupported(instance)) {
+      return dispatch_table_.CreateDebugUtilsMessengerEXT(instance)(instance, create_info,
+                                                                    allocator, messenger);
+    }
+    return VK_SUCCESS;
+  }
+
+  void OnDestroyDebugUtilsMessengerEXT(VkInstance instance, VkDebugUtilsMessengerEXT messenger,
+                                       const VkAllocationCallbacks* allocator) {
+    if (dispatch_table_.IsDebugUtilsExtensionSupported(instance)) {
+      dispatch_table_.DestroyDebugUtilsMessengerEXT(instance)(instance, messenger, allocator);
+    }
+  }
+
+  void OnQueueBeginDebugUtilsLabelEXT(VkQueue queue, const VkDebugUtilsLabelEXT* label_info) {
+    if (dispatch_table_.IsDebugUtilsExtensionSupported(queue)) {
+      dispatch_table_.QueueBeginDebugUtilsLabelEXT(queue)(queue, label_info);
+    }
+  }
+
+  void OnQueueEndDebugUtilsLabelEXT(VkQueue queue) {
+    if (dispatch_table_.IsDebugUtilsExtensionSupported(queue)) {
+      dispatch_table_.QueueEndDebugUtilsLabelEXT(queue)(queue);
+    }
+  }
+
+  void OnQueueInsertDebugUtilsLabelEXT(VkQueue queue, const VkDebugUtilsLabelEXT* label_info) {
+    if (dispatch_table_.IsDebugUtilsExtensionSupported(queue)) {
+      dispatch_table_.QueueInsertDebugUtilsLabelEXT(queue)(queue, label_info);
+    }
+  }
+
+  VkResult OnSetDebugUtilsObjectNameEXT(VkDevice device,
+                                        const VkDebugUtilsObjectNameInfoEXT* name_info) {
+    if (dispatch_table_.IsDebugUtilsExtensionSupported(device)) {
+      return dispatch_table_.SetDebugUtilsObjectNameEXT(device)(device, name_info);
+    }
+    return VK_SUCCESS;
+  }
+
+  VkResult OnSetDebugUtilsObjectTagEXT(VkDevice device,
+                                       const VkDebugUtilsObjectTagInfoEXT* tag_info) {
+    if (dispatch_table_.IsDebugUtilsExtensionSupported(device)) {
+      return dispatch_table_.SetDebugUtilsObjectTagEXT(device)(device, tag_info);
+    }
+    return VK_SUCCESS;
+  }
+
+  void OnSubmitDebugUtilsMessageEXT(VkInstance instance,
+                                    VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
+                                    VkDebugUtilsMessageTypeFlagsEXT message_types,
+                                    const VkDebugUtilsMessengerCallbackDataEXT* callback_data) {
+    if (dispatch_table_.IsDebugUtilsExtensionSupported(instance)) {
+      dispatch_table_.SubmitDebugUtilsMessageEXT(instance)(instance, message_severity,
+                                                           message_types, callback_data);
+    }
+  }
+
+  void OnCmdDebugMarkerInsertEXT(VkCommandBuffer command_buffer,
+                                 const VkDebugMarkerMarkerInfoEXT* marker_info) {
+    if (dispatch_table_.IsDebugMarkerExtensionSupported(command_buffer)) {
+      dispatch_table_.CmdDebugMarkerInsertEXT(command_buffer)(command_buffer, marker_info);
+    }
+  }
+
+  void OnDebugMarkerSetObjectNameEXT(VkDevice device,
+                                     const VkDebugMarkerObjectNameInfoEXT* name_info) {
+    if (dispatch_table_.IsDebugMarkerExtensionSupported(device)) {
+      dispatch_table_.DebugMarkerSetObjectNameEXT(device)(device, name_info);
+    }
+  }
+
+  void OnDebugMarkerSetObjectTagEXT(VkDevice device,
+                                    const VkDebugMarkerObjectTagInfoEXT* tag_info) {
+    if (dispatch_table_.IsDebugMarkerExtensionSupported(device)) {
+      dispatch_table_.DebugMarkerSetObjectTagEXT(device)(device, tag_info);
+    }
+  }
+
+  void OnCreateDebugReportCallbackEXT(VkInstance instance,
+                                      const VkDebugReportCallbackCreateInfoEXT* create_info,
+                                      const VkAllocationCallbacks* allocator,
+                                      VkDebugReportCallbackEXT* callback) {
+    if (dispatch_table_.IsDebugReportExtensionSupported(instance)) {
+      dispatch_table_.CreateDebugReportCallbackEXT(instance)(instance, create_info, allocator,
+                                                             callback);
+    }
+  }
+
+  void OnDebugReportMessageEXT(VkInstance instance, VkDebugReportFlagsEXT flags,
+                               VkDebugReportObjectTypeEXT object_type, uint64_t object,
+                               size_t location, int32_t message_code, const char* layer_prefix,
+                               const char* message) {
+    if (dispatch_table_.IsDebugReportExtensionSupported(instance)) {
+      dispatch_table_.DebugReportMessageEXT(instance)(
+          instance, flags, object_type, object, location, message_code, layer_prefix, message);
+    }
+  }
+
+  void OnDestroyDebugReportCallbackEXT(VkInstance instance, VkDebugReportCallbackEXT callback,
+                                       const VkAllocationCallbacks* allocator) {
+    if (dispatch_table_.IsDebugReportExtensionSupported(instance)) {
+      dispatch_table_.DestroyDebugReportCallbackEXT(instance)(instance, callback, allocator);
+    }
+  }
+
+  // ----------------------------------------------------------------------------
   // Layer enumeration functions
   // ----------------------------------------------------------------------------
 
@@ -326,19 +449,23 @@ class VulkanLayerController {
     return VK_SUCCESS;
   }
 
-  [[nodiscard]] VkResult OnEnumerateInstanceExtensionProperties(
-      const char* layer_name, uint32_t* property_count, VkExtensionProperties* /*properties*/) {
-    // Inform the client that we have no extension properties if this layer
-    // specifically is being queried.
-    if (layer_name != nullptr && strcmp(layer_name, kLayerName) == 0) {
-      if (property_count != nullptr) {
-        *property_count = 0;
-      }
-      return VK_SUCCESS;
+  [[nodiscard]] VkResult OnEnumerateInstanceExtensionProperties(const char* layer_name,
+                                                                uint32_t* property_count,
+                                                                VkExtensionProperties* properties) {
+    if (layer_name == nullptr || strcmp(layer_name, kLayerName) != 0) {
+      // Vulkan spec mandates returning this when this layer isn't being queried.
+      return VK_ERROR_LAYER_NOT_PRESENT;
     }
 
-    // Vulkan spec mandates returning this when this layer isn't being queried.
-    return VK_ERROR_LAYER_NOT_PRESENT;
+    CHECK(property_count != nullptr);
+    if (property_count != nullptr) {
+      *property_count = kImplementedInstanceExtensions.size();
+    }
+    if (properties != nullptr) {
+      memcpy(properties, kImplementedInstanceExtensions.data(),
+             kImplementedInstanceExtensions.size() * sizeof(VkExtensionProperties));
+    }
+    return VK_SUCCESS;
   }
 
   [[nodiscard]] VkResult OnEnumerateDeviceExtensionProperties(VkPhysicalDevice physical_device,
@@ -350,20 +477,20 @@ class VulkanLayerController {
     if (layer_name != nullptr && strcmp(layer_name, kLayerName) == 0) {
       // If properties == nullptr, only the number of extensions is queried.
       if (properties == nullptr) {
-        *property_count = kRequiredDeviceExtensions.size();
+        *property_count = kImplementedDeviceExtensions.size();
         return VK_SUCCESS;
       }
-      uint32_t num_extensions_to_copy = kRequiredDeviceExtensions.size();
+      uint32_t num_extensions_to_copy = kImplementedDeviceExtensions.size();
       // In the case that less extensions are queried then the layer uses, we copy on this number
       // and return VK_INCOMPLETE, according to the specification.
       if (*property_count < num_extensions_to_copy) {
         num_extensions_to_copy = *property_count;
       }
-      memcpy(properties, kRequiredDeviceExtensions.data(),
+      memcpy(properties, kImplementedDeviceExtensions.data(),
              num_extensions_to_copy * sizeof(VkExtensionProperties));
       *property_count = num_extensions_to_copy;
 
-      if (num_extensions_to_copy < kRequiredDeviceExtensions.size()) {
+      if (num_extensions_to_copy < kImplementedDeviceExtensions.size()) {
         return VK_INCOMPLETE;
       }
       return VK_SUCCESS;
@@ -393,7 +520,7 @@ class VulkanLayerController {
 
     // Append all of our extensions, that are not yet listed.
     // Note as this list of our extensions is very small, we are fine with O(N*M) runtime.
-    for (const auto& extension : kRequiredDeviceExtensions) {
+    for (const auto& extension : kImplementedDeviceExtensions) {
       bool already_present = false;
       for (const auto& other_extension : extensions) {
         if (strcmp(extension.extensionName, other_extension.extensionName) == 0) {

--- a/src/OrbitVulkanLayer/VulkanLayerController.h
+++ b/src/OrbitVulkanLayer/VulkanLayerController.h
@@ -309,8 +309,8 @@ class VulkanLayerController {
   }
 
   // ----------------------------------------------------------------------------
-  // Unused but implemented extension methods (need to implement all methods of a
-  // extension)
+  // Unused but implemented extension methods (need to implement all methods of
+  // an extension)
   // ----------------------------------------------------------------------------
   void OnCmdInsertDebugUtilsLabelEXT(VkCommandBuffer command_buffer,
                                      const VkDebugUtilsLabelEXT* label_info) {

--- a/src/OrbitVulkanLayer/resources/VkLayer_Orbit_implicit.json
+++ b/src/OrbitVulkanLayer/resources/VkLayer_Orbit_implicit.json
@@ -16,6 +16,29 @@
         "functions": {
             "vkGetInstanceProcAddr": "OrbitGetInstanceProcAddr",
             "vkGetDeviceProcAddr": "OrbitGetDeviceProcAddr"
-        }  
+        },
+        "instance_extensions": [
+            {
+                "name": "VK_EXT_debug_report",
+                "spec_version": "1"
+            },
+            {
+                "name": "VK_EXT_debug_utils",
+                "spec_version": "1"
+            }
+        ],
+        "device_extensions": [
+            {
+                "name": "VK_EXT_debug_marker",
+                "spec_version": "4",
+                "entrypoints": [
+                    "vkDebugMarkerSetObjectTagEXT",
+                    "vkDebugMarkerSetObjectNameEXT",
+                    "vkCmdDebugMarkerBeginEXT",
+                    "vkCmdDebugMarkerEndEXT",
+                    "vkCmdDebugMarkerInsertEXT"
+                ]
+            }
+    ]
     } 
 } 


### PR DESCRIPTION
On the Vulkan layer, we want the game to be able to call the debug
marker extension methods (which are actually 2 different extensions).
In order for a game to know which extensions are available (by layer),
Vulkan provides two mechanisms.
1) EnumerateInstance/DeviceExtensionProperties function.
2) Declare them in the manifest, such that the loader can decide
on a queried extension, without loading the layer.

Prior this change, we did not exposed any extension in the manifest.
Also, the DebugUtils extension is an instance extension (and not a
device extension), so this adjusts the enumeration functions. As we
do not want to intercept the ResetQueryPoolEXT function, this extension
is removed from the enumeration function.
Further, the DebugMarkers extension depends on the DebugReport extension.
Thus, we also need to implement this.
Vulkan also dictates, that a layer implements all functions of an
extension, if it decides to implement that extension. So, this change
adds all the "unused" functions of the three extensions we are exposing.
For those functions, we simply call into the next layer (if possible).

Follow-up (different PR): Similar to a game, a layer needs to tell
the ICD/driver which extensions it is going to use (in vkCreate...).
Thus, we need to add the host query pool reset extension here.

Test: Run tests + profile on Infiltrator.