### PR TITLE
Handle errors when exporting to CSV

### DIFF
--- a/src/OrbitGl/DataView.h
+++ b/src/OrbitGl/DataView.h
@@ -17,6 +17,7 @@
 
 #include "DataViewTypes.h"
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/Result.h"
 #include "absl/container/flat_hash_set.h"
 
 class OrbitApp;
@@ -88,7 +89,7 @@ class DataView {
   virtual void LinkDataView(DataView* /*data_view*/) {}
   virtual bool ScrollToBottom() { return false; }
   virtual bool SkipTimer() { return false; }
-  virtual void ExportCSV(const std::string& file_path);
+  virtual ErrorMessageOr<void> ExportCSV(const std::filesystem::path& file_path);
   virtual void CopySelection(const std::vector<int>& selection);
 
   int GetUpdatePeriodMs() const { return update_period_ms_; }

--- a/src/OrbitGl/DataView.h
+++ b/src/OrbitGl/DataView.h
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <filesystem>
 #include <functional>
 #include <memory>
 #include <optional>


### PR DESCRIPTION
This change also gets rid of ofstream in favor of OrbitBase/File.h
which does not throw exceptions.

Also according to RCF CSV lines should end with CRLF.

Test: export a table to CSV - open in google drive