### PR TITLE
Make source code view work for modules with integrated debuginfo

### DIFF
--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -39,6 +39,7 @@
 #include "GlCanvas.h"
 #include "IntrospectionWindow.h"
 #include "MainThreadExecutor.h"
+#include "MainWindowInterface.h"
 #include "ManualInstrumentationManager.h"
 #include "MetricsUploader/MetricsUploader.h"
 #include "ModulesDataView.h"
@@ -78,13 +79,15 @@
 
 class OrbitApp final : public DataViewFactory, public CaptureListener {
  public:
-  explicit OrbitApp(MainThreadExecutor* main_thread_executor,
+  explicit OrbitApp(orbit_gl::MainWindowInterface* main_window,
+                    MainThreadExecutor* main_thread_executor,
                     const orbit_base::CrashHandler* crash_handler,
                     orbit_metrics_uploader::MetricsUploader* metrics_uploader = nullptr);
   ~OrbitApp() override;
 
   static std::unique_ptr<OrbitApp> Create(
-      MainThreadExecutor* main_thread_executor, const orbit_base::CrashHandler* crash_handler,
+      orbit_gl::MainWindowInterface* main_window, MainThreadExecutor* main_thread_executor,
+      const orbit_base::CrashHandler* crash_handler,
       orbit_metrics_uploader::MetricsUploader* metrics_uploader = nullptr);
 
   void PostInit(bool is_connected);
@@ -225,8 +228,6 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void SetInfoMessageCallback(InfoMessageCallback callback) {
     info_message_callback_ = std::move(callback);
   }
-  using TooltipCallback = std::function<void(const std::string&)>;
-  void SetTooltipCallback(TooltipCallback callback) { tooltip_callback_ = std::move(callback); }
   using RefreshCallback = std::function<void(DataViewType type)>;
   void SetRefreshCallback(RefreshCallback callback) { refresh_callback_ = std::move(callback); }
 
@@ -460,7 +461,6 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   ErrorMessageCallback error_message_callback_;
   WarningMessageCallback warning_message_callback_;
   InfoMessageCallback info_message_callback_;
-  TooltipCallback tooltip_callback_;
   RefreshCallback refresh_callback_;
   SamplingReportCallback sampling_reports_callback_;
   SamplingReportCallback selection_report_callback_;
@@ -496,6 +496,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   StringManager string_manager_;
   std::shared_ptr<grpc::Channel> grpc_channel_;
 
+  orbit_gl::MainWindowInterface* main_window_ = nullptr;
   MainThreadExecutor* main_thread_executor_;
   std::thread::id main_thread_id_;
   std::unique_ptr<ThreadPool> thread_pool_;

--- a/src/OrbitGl/MainWindowInterface.h
+++ b/src/OrbitGl/MainWindowInterface.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_MAIN_WINDOW_INTERFACE_H_
+#define ORBIT_GL_MAIN_WINDOW_INTERFACE_H_
+
+#include <string_view>
+
+namespace orbit_gl {
+
+// This abstract base class is an attempt to simplify callbacks
+// in OrbitApp and make it easier to refactor things in the future.
+//
+// OrbitMainWindow and Mocks can derive from this and offer a fixed interface
+// to OrbitApp.
+class MainWindowInterface {
+ public:
+  virtual void ShowTooltip(std::string_view message) = 0;
+
+  virtual ~MainWindowInterface() = default;
+};
+
+}  // namespace orbit_gl
+
+#endif  // ORBIT_GL_MAIN_WINDOW_INTERFACE_H_

--- a/src/OrbitGl/MainWindowInterface.h
+++ b/src/OrbitGl/MainWindowInterface.h
@@ -5,6 +5,9 @@
 #ifndef ORBIT_GL_MAIN_WINDOW_INTERFACE_H_
 #define ORBIT_GL_MAIN_WINDOW_INTERFACE_H_
 
+#include <stdint.h>
+
+#include <filesystem>
 #include <string_view>
 
 namespace orbit_gl {
@@ -17,6 +20,7 @@ namespace orbit_gl {
 class MainWindowInterface {
  public:
   virtual void ShowTooltip(std::string_view message) = 0;
+  virtual void ShowSourceCode(const std::filesystem::path& file_path, size_t line_number) = 0;
 
   virtual ~MainWindowInterface() = default;
 };

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -157,7 +157,7 @@ OrbitMainWindow::OrbitMainWindow(orbit_qt::TargetConfiguration target_configurat
                                  const QStringList& command_line_flags)
     : QMainWindow(nullptr),
       main_thread_executor_{orbit_qt_utils::MainThreadExecutorImpl::Create()},
-      app_{OrbitApp::Create(main_thread_executor_.get(), crash_handler, metrics_uploader)},
+      app_{OrbitApp::Create(this, main_thread_executor_.get(), crash_handler, metrics_uploader)},
       ui(new Ui::OrbitMainWindow),
       command_line_flags_(command_line_flags),
       target_configuration_(std::move(target_configuration)) {
@@ -279,9 +279,6 @@ void OrbitMainWindow::SetupMainWindow() {
   });
   app_->SetInfoMessageCallback([this](const std::string& title, const std::string& text) {
     QMessageBox::information(this, QString::fromStdString(title), QString::fromStdString(text));
-  });
-  app_->SetTooltipCallback([this](const std::string& tooltip) {
-    QToolTip::showText(QCursor::pos(), QString::fromStdString(tooltip), this);
   });
   app_->SetSaveFileCallback(
       [this](const std::string& extension) { return this->OnGetSaveFileName(extension); });
@@ -1270,4 +1267,9 @@ orbit_qt::TargetConfiguration OrbitMainWindow::ClearTargetConfiguration() {
         ->SetProcessListUpdateListener(nullptr);
   }
   return std::move(target_configuration_);
+}
+
+void OrbitMainWindow::ShowTooltip(std::string_view message) {
+  QToolTip::showText(QCursor::pos(),
+                     QString::fromUtf8(message.data(), static_cast<int>(message.size())), this);
 }

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -51,7 +51,7 @@ namespace Ui {
 class OrbitMainWindow;
 }
 
-class OrbitMainWindow : public QMainWindow {
+class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInterface {
   Q_OBJECT
 
  public:
@@ -97,6 +97,8 @@ class OrbitMainWindow : public QMainWindow {
   void RestoreDefaultTabLayout();
 
   [[nodiscard]] orbit_qt::TargetConfiguration ClearTargetConfiguration();
+
+  void ShowTooltip(std::string_view message) override;
 
  protected:
   void closeEvent(QCloseEvent* event) override;

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -99,6 +99,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   [[nodiscard]] orbit_qt::TargetConfiguration ClearTargetConfiguration();
 
   void ShowTooltip(std::string_view message) override;
+  void ShowSourceCode(const std::filesystem::path& file_path, size_t line_number) override;
 
  protected:
   void closeEvent(QCloseEvent* event) override;


### PR DESCRIPTION
This enabled the source code view for the very simple use case, when code, symbols, and debuginfo are in the same file.