### PR TITLE
Add LockFreeApiEventProducer

### DIFF
--- a/src/Api/CMakeLists.txt
+++ b/src/Api/CMakeLists.txt
@@ -19,6 +19,7 @@ target_include_directories(Api PUBLIC
 
 target_sources(Api PUBLIC
         include/Api/EncodedEvent.h
+        include/Api/LockFreeApiEventProducer.h
         include/Api/Orbit.h)
 
 target_sources(Api PRIVATE

--- a/src/Api/Orbit.cpp
+++ b/src/Api/Orbit.cpp
@@ -6,21 +6,20 @@
 #include "Api/Orbit.h"
 
 #include "Api/EncodedEvent.h"
+#include "Api/LockFreeApiEventProducer.h"
 #include "OrbitBase/Profiling.h"
 #include "OrbitBase/ThreadUtils.h"
 
-// Temporary dummy function, proper implementation is in next PR.
-// See https://github.com/google/orbit/pull/1702 for fully working prototype.
-static void EnqueueIntermediateEvent(const orbit_api::ApiEvent& event) { (void)event; }
-
 static void EnqueueApiEvent(orbit_api::EventType type, const char* name = nullptr,
                             uint64_t data = 0, orbit_api_color color = kOrbitColorAuto) {
-  uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
+  static orbit_api::LockFreeApiEventBulkProducer producer;
   static pid_t pid = orbit_base::GetCurrentProcessId();
   thread_local pid_t tid = orbit_base::GetCurrentThreadId();
 
+  if (!producer.IsCapturing()) return;
+  uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
   orbit_api::ApiEvent api_event(pid, tid, timestamp_ns, type, name, data, color);
-  EnqueueIntermediateEvent(api_event);
+  producer.EnqueueIntermediateEvent(api_event);
 }
 
 extern "C" {

--- a/src/Api/include/Api/LockFreeApiEventProducer.h
+++ b/src/Api/include/Api/LockFreeApiEventProducer.h
@@ -1,0 +1,71 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_API_LOCK_FREE_API_EVENT_PRODUCER
+#define ORBIT_API_LOCK_FREE_API_EVENT_PRODUCER
+
+#include "Api/EncodedEvent.h"
+#include "EncodedEvent.h"
+#include "OrbitProducer/LockFreeBufferBulkCaptureEventProducer.h"
+#include "OrbitProducer/LockFreeBufferCaptureEventProducer.h"
+#include "ProducerSideChannel/ProducerSideChannel.h"
+#include "capture.pb.h"
+#include "grpcpp/grpcpp.h"
+
+namespace orbit_api {
+
+// NOTE: The two implementation below will be used for a performance investigation. Ultimately, only
+// one will prevail, but they will coexist for a short while.
+
+// This class is used to enqueue orbit_api::Api events from multiple threads and relay them to
+// OrbitService in the form of orbit_grpc_protos::ProducerCaptureEventCaptureEvent events.
+class LockFreeApiEventProducer
+    : public orbit_producer::LockFreeBufferCaptureEventProducer<orbit_api::ApiEvent> {
+ public:
+  LockFreeApiEventProducer() {
+    BuildAndStart(orbit_producer_side_channel::CreateProducerSideChannel());
+  }
+
+  ~LockFreeApiEventProducer() { ShutdownAndWait(); }
+
+ protected:
+  [[nodiscard]] orbit_grpc_protos::ProducerCaptureEvent* TranslateIntermediateEvent(
+      orbit_api::ApiEvent&& intermediate_event, google::protobuf::Arena* arena) override {
+    auto* capture_event =
+        google::protobuf::Arena::CreateMessage<orbit_grpc_protos::ProducerCaptureEvent>(arena);
+    auto* api_event = google::protobuf::Arena::CreateMessage<orbit_grpc_protos::ApiEvent>(arena);
+    api_event->set_num_raw_events(1);
+    api_event->set_raw_data(&intermediate_event, sizeof(orbit_api::ApiEvent));
+    *capture_event->mutable_api_event() = std::move(*api_event);
+    return capture_event;
+  }
+};
+
+// This class is used to enqueue orbit_api::Api events from multiple threads and relay them in
+// bulk to OrbitService in the form of orbit_grpc_protos::CaptureEvent events.
+class LockFreeApiEventBulkProducer
+    : public orbit_producer::LockFreeBufferBulkCaptureEventProducer<orbit_api::ApiEvent> {
+ public:
+  LockFreeApiEventBulkProducer() {
+    BuildAndStart(orbit_producer_side_channel::CreateProducerSideChannel());
+  }
+
+  ~LockFreeApiEventBulkProducer() { ShutdownAndWait(); }
+
+ protected:
+  [[nodiscard]] orbit_grpc_protos::ProducerCaptureEvent TranslateIntermediateEvents(
+      orbit_api::ApiEvent* intermediate_events, size_t size) override {
+    orbit_grpc_protos::ApiEvent api_event;
+    api_event.set_num_raw_events(size);
+    api_event.set_raw_data(intermediate_events, size * sizeof(orbit_api::ApiEvent));
+
+    orbit_grpc_protos::ProducerCaptureEvent capture_event;
+    *capture_event.mutable_api_event() = std::move(api_event);
+    return capture_event;
+  }
+};
+
+}  // namespace orbit_api
+
+#endif  // ORBIT_API_LOCK_FREE_API_EVENT_PRODUCER

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -92,6 +92,11 @@ message IntrospectionScope {
   repeated uint64 registers = 6;
 }
 
+message ApiEvent {
+  uint64 num_raw_events = 1;
+  bytes raw_data = 2;
+}
+
 message Callstack {
   repeated uint64 pcs = 1;
 }
@@ -275,6 +280,7 @@ message ClientCaptureEvent {
   oneof event {
     // Please keep these alphabetically ordered.
     AddressInfo address_info = 1;
+    ApiEvent api_event = 15;
     CallstackSample callstack_sample = 2;
     FunctionCall function_call = 3;
     GpuJob gpu_job = 4;
@@ -294,6 +300,7 @@ message ClientCaptureEvent {
 message ProducerCaptureEvent {
   oneof event {
     // Please keep these alphabetically ordered.
+    ApiEvent api_event = 15;
     CallstackSample callstack_sample = 1;
     FullCallstackSample full_callstack_sample = 2;
     FullAddressInfo full_address_info = 3;

--- a/src/LinuxTracing/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracing/LinuxTracingIntegrationTest.cpp
@@ -420,6 +420,9 @@ void VerifyOrderOfAllEvents(const std::vector<orbit_grpc_protos::ProducerCapture
         EXPECT_GE(event.module_update_event().timestamp_ns(), previous_event_timestamp_ns);
         previous_event_timestamp_ns = event.module_update_event().timestamp_ns();
         break;
+      case orbit_grpc_protos::ProducerCaptureEvent::kApiEvent:
+        UNREACHABLE();
+        break;
       case orbit_grpc_protos::ProducerCaptureEvent::EVENT_NOT_SET:
         UNREACHABLE();
     }

--- a/src/OrbitCaptureClient/CaptureEventProcessor.cpp
+++ b/src/OrbitCaptureClient/CaptureEventProcessor.cpp
@@ -79,6 +79,11 @@ void CaptureEventProcessor::ProcessEvent(const ClientCaptureEvent& event) {
     case ClientCaptureEvent::kModuleUpdateEvent:
       // TODO (http://b/168797897): Process module update events
       break;
+    case ClientCaptureEvent::kApiEvent:
+      // Will be enabled in next PR.
+      // api_event_processor_.ProcessApiEvent(event.api_event());
+      break;
+
     case ClientCaptureEvent::EVENT_NOT_SET:
       ERROR("CaptureEvent::EVENT_NOT_SET read from Capture's gRPC stream");
       break;

--- a/src/OrbitProducer/CMakeLists.txt
+++ b/src/OrbitProducer/CMakeLists.txt
@@ -10,6 +10,7 @@ target_compile_options(OrbitProducer PRIVATE ${STRICT_COMPILE_FLAGS})
 target_sources(OrbitProducer PUBLIC
         include/OrbitProducer/CaptureEventProducer.h
         include/OrbitProducer/FakeProducerSideService.h
+        include/OrbitProducer/LockFreeBufferBulkCaptureEventProducer.h
         include/OrbitProducer/LockFreeBufferCaptureEventProducer.h)
 
 target_sources(OrbitProducer PRIVATE

--- a/src/OrbitProducer/include/OrbitProducer/LockFreeBufferBulkCaptureEventProducer.h
+++ b/src/OrbitProducer/include/OrbitProducer/LockFreeBufferBulkCaptureEventProducer.h
@@ -1,0 +1,157 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_PRODUCER_LOCK_FREE_BUFFER_BULK_CAPTURE_EVENT_PRODUCER_H_
+#define ORBIT_PRODUCER_LOCK_FREE_BUFFER_BULK_CAPTURE_EVENT_PRODUCER_H_
+
+#include <chrono>
+#include <vector>
+
+#include "OrbitBase/Logging.h"
+#include "OrbitProducer/CaptureEventProducer.h"
+#include "concurrentqueue.h"
+
+namespace orbit_producer {
+
+// This still abstract implementation of CaptureEventProducer provides a lock-free queue
+// where to write events with low overhead from the fast path where they are produced.
+// The methods EnqueueIntermediateEvent(IfCapturing) allow to enqueue those events.
+//
+// Internally, a thread reads from the lock-free queue and sends CaptureEvents
+// to ProducerSideService using the methods provided by the superclass.
+//
+// Note that the events stored in the lock-free queue, whose type is specified by the
+// type parameter IntermediateEventT, don't need to be CaptureEvents, nor protobufs at all.
+// This is to allow enqueuing objects that are faster to produce than protobufs.
+// The translation from IntermediateEventT to CaptureEvent is done in bulk by
+// TranslateIntermediateEvents, which subclasses need to implement.
+template <typename IntermediateEventT>
+class LockFreeBufferBulkCaptureEventProducer : public CaptureEventProducer {
+ public:
+  void BuildAndStart(const std::shared_ptr<grpc::Channel>& channel) override {
+    CaptureEventProducer::BuildAndStart(channel);
+
+    forwarder_thread_ = std::thread{[this] { ForwarderThread(); }};
+  }
+
+  void ShutdownAndWait() override {
+    shutdown_requested_ = true;
+
+    CHECK(forwarder_thread_.joinable());
+    forwarder_thread_.join();
+
+    CaptureEventProducer::ShutdownAndWait();
+  }
+
+  void EnqueueIntermediateEvent(const IntermediateEventT& event) {
+    lock_free_queue_.enqueue(event);
+  }
+
+  void EnqueueIntermediateEvent(IntermediateEventT&& event) {
+    lock_free_queue_.enqueue(std::move(event));
+  }
+
+  bool EnqueueIntermediateEventIfCapturing(
+      const std::function<IntermediateEventT()>& event_builder_if_capturing) {
+    if (IsCapturing()) {
+      lock_free_queue_.enqueue(event_builder_if_capturing());
+      return true;
+    }
+    return false;
+  }
+
+ protected:
+  void OnCaptureStart(orbit_grpc_protos::CaptureOptions /*capture_options*/) override {
+    absl::MutexLock lock{&status_mutex_};
+    status_ = ProducerStatus::kShouldSendEvents;
+  }
+
+  void OnCaptureStop() override {
+    absl::MutexLock lock{&status_mutex_};
+    status_ = ProducerStatus::kShouldNotifyAllEventsSent;
+  }
+
+  void OnCaptureFinished() override {
+    absl::MutexLock lock{&status_mutex_};
+    status_ = ProducerStatus::kShouldDropEvents;
+  }
+
+  // Subclasses need to implement this method to convert an IntermediateEventT enqueued
+  // in the internal lock-free buffer to a CaptureEvent to be sent to ProducerSideService.
+  [[nodiscard]] virtual orbit_grpc_protos::ProducerCaptureEvent TranslateIntermediateEvents(
+      IntermediateEventT* intermediate_events, size_t size) = 0;
+
+ private:
+  void ForwarderThread() {
+    constexpr uint64_t kMaxEventsPerRequest = 10'000;
+    std::vector<IntermediateEventT> dequeued_events(kMaxEventsPerRequest);
+    while (!shutdown_requested_) {
+      while (true) {
+        size_t dequeued_event_count =
+            lock_free_queue_.try_dequeue_bulk(dequeued_events.begin(), kMaxEventsPerRequest);
+        bool queue_was_emptied = dequeued_event_count < kMaxEventsPerRequest;
+
+        ProducerStatus current_status;
+        {
+          absl::MutexLock lock{&status_mutex_};
+          current_status = status_;
+          if (status_ == ProducerStatus::kShouldNotifyAllEventsSent && queue_was_emptied) {
+            // We are about to send AllEventsSent: update status_ while we hold the mutex.
+            status_ = ProducerStatus::kShouldDropEvents;
+          }
+        }
+
+        if ((current_status == ProducerStatus::kShouldSendEvents ||
+             current_status == ProducerStatus::kShouldNotifyAllEventsSent) &&
+            dequeued_event_count > 0) {
+          orbit_grpc_protos::ReceiveCommandsAndSendEventsRequest send_request;
+          auto* capture_events =
+              send_request.mutable_buffered_capture_events()->mutable_capture_events();
+
+          orbit_grpc_protos::ProducerCaptureEvent* event = capture_events->Add();
+          *event = TranslateIntermediateEvents(dequeued_events.data(), dequeued_event_count);
+
+          if (!SendCaptureEvents(send_request)) {
+            ERROR("Forwarding %lu CaptureEvents", dequeued_event_count);
+            break;
+          }
+        }
+
+        if (current_status == ProducerStatus::kShouldNotifyAllEventsSent && queue_was_emptied) {
+          // lock_free_queue_ is now empty and status_ == kShouldNotifyAllEventsSent,
+          // send AllEventsSent. status_ has already been changed to kShouldDropEvents.
+          if (!NotifyAllEventsSent()) {
+            ERROR("Notifying that all CaptureEvents have been sent");
+          }
+          break;
+        }
+
+        // Note that if current_status == ProducerStatus::kShouldDropEvents
+        // the events extracted from the lock_free_queue_ will just be dropped.
+
+        if (queue_was_emptied) {
+          break;
+        }
+      }
+
+      static constexpr std::chrono::duration kSleepOnEmptyQueue = std::chrono::milliseconds{10};
+      // Wait for lock_free_queue_ to fill up with new CaptureEvents.
+      std::this_thread::sleep_for(kSleepOnEmptyQueue);
+    }
+  }
+
+ private:
+  moodycamel::ConcurrentQueue<IntermediateEventT> lock_free_queue_;
+
+  std::thread forwarder_thread_;
+  std::atomic<bool> shutdown_requested_ = false;
+
+  enum class ProducerStatus { kShouldSendEvents, kShouldNotifyAllEventsSent, kShouldDropEvents };
+  ProducerStatus status_ = ProducerStatus::kShouldDropEvents;
+  absl::Mutex status_mutex_;
+};
+
+}  // namespace orbit_producer
+
+#endif  // ORBIT_PRODUCER_LOCK_FREE_BUFFER_CAPTURE_EVENT_PRODUCER_H_


### PR DESCRIPTION
This is another piece of the new manual instrumentation change that uses the side-channel
to send event from the target process to OrbitService. In this PR, we define a simple ApiEvent 
capture event that wraps raw orbit_api::ApiEvent's. 

The LockFreeApiEventProducer and LockFreeApiEventBulkProducer are two variants of event
producers that will be used to compare the performance of different approaches for sending
events. They both push raw api events to a lockless queue from multiple threads and have a single
consumer thread that translates the raw events into capture events (protobufs). The difference is that
the "Bulk" version wraps multiple raw events into a single CaptureEvent to amortize the cost of 
creating protobufs. The goal will be to iterate on the non-bulk implementation to see how close we
can get in terms of performance to the bulk approach.

This PR focuses on the production and sending of events from the target process to OrbitService. 
The next PR will actually process those events.

Note that LockFreeBufferBulkCaptureEventProducer.h is basically a copy of the existing LockFreeBufferCaptureEventProducer.h with the minor modification of allowing to translate multiple
intermediate events at once. Maybe both classes could be merged as this could be an optimization 
even for the normal use case (instead of calling translate function once per event, we could call it
once for all the dequeued events).