### PR TITLE
Follow .gnu_debuglink when looking for DWARF information

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -537,7 +537,7 @@ void OrbitApp::Disassemble(int32_t pid, const FunctionInfo& function) {
 void OrbitApp::ShowSourceCode(const orbit_client_protos::FunctionInfo& function) {
   const ModuleData* module = module_manager_->GetModuleByPath(function.loaded_module_path());
 
-  auto loaded_module = RetrieveModule(module);
+  auto loaded_module = RetrieveModuleWithDebugInfo(module);
 
   loaded_module
       .ThenIfSuccess(
@@ -545,15 +545,6 @@ void OrbitApp::ShowSourceCode(const orbit_client_protos::FunctionInfo& function)
           [this, module,
            function](const std::filesystem::path& local_file_path) -> ErrorMessageOr<void> {
             const auto elf_file = orbit_elf_utils::ElfFile::Create(local_file_path);
-
-            if (elf_file.has_error()) return elf_file.error();
-
-            if (!elf_file.value()->HasDebugInfo()) {
-              return ErrorMessage{absl::StrFormat(
-                  "Module \"%s\" does not include debug info. Other sources are not yet supported.",
-                  module->file_path())};
-            }
-
             const auto line_info = elf_file.value()->GetLineInfo(function.address());
 
             if (line_info.has_error()) {

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -291,8 +291,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
       absl::flat_hash_map<std::string, std::vector<uint64_t>> function_hashes_to_hook_map,
       absl::flat_hash_map<std::string, std::vector<uint64_t>> frame_track_function_hashes_map);
 
-  // LoadModule retrieves a module file and returns the local file path (potentially from the local
-  // cache). Symbols won't be loaded.
+  // RetrieveModule retrieves a module file and returns the local file path (potentially from the
+  // local cache). Only modules with a .symtab section will be considered.
   orbit_base::Future<ErrorMessageOr<std::filesystem::path>> RetrieveModule(
       const ModuleData* module);
   orbit_base::Future<ErrorMessageOr<std::filesystem::path>> RetrieveModule(
@@ -304,6 +304,13 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   // `LoadModule` and afterwards load the symbols by calling `LoadSymbols`.
   orbit_base::Future<ErrorMessageOr<void>> RetrieveModuleAndLoadSymbols(const ModuleData* module);
   orbit_base::Future<ErrorMessageOr<void>> RetrieveModuleAndLoadSymbols(
+      const std::string& module_path, const std::string& build_id);
+
+  // This method is pretty similar to `RetrieveModule`, but it also requires debug information to be
+  // present.
+  orbit_base::Future<ErrorMessageOr<std::filesystem::path>> RetrieveModuleWithDebugInfo(
+      const ModuleData* module);
+  orbit_base::Future<ErrorMessageOr<std::filesystem::path>> RetrieveModuleWithDebugInfo(
       const std::string& module_path, const std::string& build_id);
 
   // TODO(177304549): This is still the way it is because of the old UI. Refactor: clean this up (it


### PR DESCRIPTION
This ensures that we follow the .gnu_debuglink section when the original module contains symbols, but no debug (DWARF) information.