### PR TITLE
Make usage of directory_iterators exception-free

### DIFF
--- a/src/OrbitBase/GetProcessIdsLinux.cpp
+++ b/src/OrbitBase/GetProcessIdsLinux.cpp
@@ -51,8 +51,8 @@ std::vector<pid_t> GetAllPids() {
 
   for (auto it = fs::begin(proc), end = fs::end(proc); it != end; it.increment(error)) {
     if (error) {
-      ERROR("directory_iterator::increment failed with: %s (will ignore)", error.message());
-      continue;
+      ERROR("directory_iterator::increment failed with: %s (stopping)", error.message());
+      break;
     }
     auto pid = ProcEntryToPid(*it);
     if (pid.has_value()) {
@@ -76,8 +76,8 @@ std::vector<pid_t> GetTidsOfProcess(pid_t pid) {
   for (auto it = fs::begin(proc_pid_task), end = fs::end(proc_pid_task); it != end;
        it.increment(error)) {
     if (error) {
-      ERROR("directory_iterator::increment failed with: %s (will ignore)", error.message());
-      continue;
+      ERROR("directory_iterator::increment failed with: %s (stopping)", error.message());
+      break;
     }
     if (auto tid = ProcEntryToPid(*it); tid.has_value()) {
       tids.emplace_back(tid.value());

--- a/src/OrbitBase/LoggingUtils.cpp
+++ b/src/OrbitBase/LoggingUtils.cpp
@@ -35,10 +35,11 @@ std::vector<std::filesystem::path> ListFilesRecursivelyIgnoreErrors(
             end = std::filesystem::end(directory_iterator);
        it != end; it.increment(error)) {
     if (error) {
-      ERROR("directory_iterator::increment failed for \"%s\": %s (will ignore)", dir.string(),
+      ERROR("directory_iterator::increment failed for \"%s\": %s (stopping)", dir.string(),
             error.message());
-      continue;
+      break;
     }
+
     bool is_regular_file = it->is_regular_file(error);
     if (error) {
       ERROR("Unable to stat \"%s\": %s (will ignore)", it->path().string(), error.message());


### PR DESCRIPTION
This change also handles it.increment failure by stopping
iterations instead of retrying them.

Test: Start Orbit -> connect to instance, check that presets are populated