### PR TITLE
Ensure to request required extension on vkCreateInstance/Device.

### DIFF
--- a/src/OrbitVulkanLayer/CMakeLists.txt
+++ b/src/OrbitVulkanLayer/CMakeLists.txt
@@ -25,7 +25,8 @@ target_sources(OrbitVulkanLayer PRIVATE
         VulkanLayerController.h
         VulkanLayerProducer.h
         VulkanLayerProducerImpl.cpp
-        VulkanLayerProducerImpl.h)
+        VulkanLayerProducerImpl.h
+        VulkanWrapper.h)
 
 add_custom_command(TARGET OrbitVulkanLayer POST_BUILD COMMAND ${CMAKE_COMMAND}
                    -E copy ${CMAKE_CURRENT_SOURCE_DIR}/resources/VkLayer_Orbit_implicit.json

--- a/src/OrbitVulkanLayer/EntryPoints.cpp
+++ b/src/OrbitVulkanLayer/EntryPoints.cpp
@@ -8,6 +8,7 @@
 #include "SubmissionTracker.h"
 #include "TimerQueryPool.h"
 #include "VulkanLayerController.h"
+#include "VulkanWrapper.h"
 #include "absl/base/casts.h"
 #include "vulkan/vk_layer.h"
 #include "vulkan/vulkan.h"
@@ -42,7 +43,7 @@ using TimerQueryPoolImpl = TimerQueryPool<DispatchTable>;
 using SubmissionTrackerImpl =
     SubmissionTracker<DispatchTable, DeviceMangerImpl, TimerQueryPoolImpl>;
 static VulkanLayerController<DispatchTable, QueueManager, DeviceMangerImpl, TimerQueryPoolImpl,
-                             SubmissionTrackerImpl>
+                             SubmissionTrackerImpl, VulkanWrapper>
     controller;
 
 // ----------------------------------------------------------------------------

--- a/src/OrbitVulkanLayer/VulkanLayerController.h
+++ b/src/OrbitVulkanLayer/VulkanLayerController.h
@@ -95,8 +95,7 @@ class VulkanLayerController {
         create_info->ppEnabledExtensionNames,
         create_info->ppEnabledExtensionNames + create_info->enabledExtensionCount);
 
-    // To the extensions, requested by the game, add our required extension (if not already
-    // present).
+    // Add our required extension (if not already present), to the extensions requested by the game.
     AddRequiredInstanceExtensionNameIfMissing(
         create_info, VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, &all_extension_names);
 
@@ -158,8 +157,7 @@ class VulkanLayerController {
         create_info->ppEnabledExtensionNames,
         create_info->ppEnabledExtensionNames + create_info->enabledExtensionCount);
 
-    // To the extensions, requested by the game, add our required extension (if not already
-    // present).
+    // Add our required extension (if not already present), to the extensions requested by the game.
     AddRequiredDeviceExtensionNameIfMissing(
         create_info, physical_device, next_get_instance_proc_addr_function,
         VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME, &all_extension_names);

--- a/src/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
+++ b/src/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
@@ -332,6 +332,12 @@ TEST_F(VulkanLayerControllerTest, InitializationFailsOnCreateInstanceWithNoInfo)
   EXPECT_EQ(result, VK_ERROR_INITIALIZATION_FAILED);
 }
 
+// This will test the good case of a call to CreateInstance.
+// It ensures, that the dispatch table and the producer are created. Further, it checks that the
+// linkage in the VkLayerInstanceCreateInfo chain gets advanced, such that the next layer does not
+// need to process all the previous layers.
+// It tests that the required extensions are enabled in the actual call to the next
+// vkCreateInstance. In this case, the game does not already requested the extensions.
 TEST_F(
     VulkanLayerControllerTest,
     WillCreateDispatchTableAndVulkanLayerProducerAndAdvanceLinkageOnCreateInstanceWithGameNotEnablingRequiredExtensions) {
@@ -407,6 +413,9 @@ TEST_F(
   EXPECT_EQ(actual_producer, nullptr);
 }
 
+// This will test the good case of a call to CreateInstance. Similar to the test case above, but
+// this time the game already requested the required extensions. We still ensure that those are
+// requested in the next layer's vkCreateInstance.
 TEST_F(
     VulkanLayerControllerTest,
     WillCreateDispatchTableAndVulkanLayerProducerOnCreateInstanceWithGameAlreadyEnablingRequiredExtensions) {
@@ -504,6 +513,12 @@ TEST_F(VulkanLayerControllerTest, CallInDispatchTableOnGetDeviceProcAddr) {
   EXPECT_EQ(result, kExpectedFunction);
 }
 
+// This will test the good case of a call to CreateDevice.
+// It ensures, that the dispatch tableis created and checks that the
+// linkage in the VkLayerDeviceCreateInfo chain gets advanced, such that the next layer does not
+// need to process all the previous layers.
+// It tests that the required extensions are enabled in the actual call to the next
+// vkCreateDevice. In this case, the game does not already requested the extensions.
 TEST_F(
     VulkanLayerControllerTest,
     WillCreateDispatchTableAndVulkanLayerProducerAndAdvanceLinkageOnCreateDeviceWithGameNotEnablingRequiredExtensions) {
@@ -575,7 +590,9 @@ TEST_F(
   EXPECT_EQ(result, VK_SUCCESS);
   EXPECT_EQ(layer_create_info.u.pLayerInfo, &layer_link_1);
 }
-
+// This will test the good case of a call to CreateDevice. Similar to the test case above, but
+// this time the game already requested the required extensions. We still ensure that those are
+// requested in the next layer's vkCreateDevice.
 TEST_F(VulkanLayerControllerTest,
        WillCreateDispatchTableOnCreateDeviceWithGameAlreadyEnablingRequiredExtensions) {
   const MockDispatchTable* dispatch_table = controller_.dispatch_table();

--- a/src/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
+++ b/src/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
@@ -333,11 +333,11 @@ TEST_F(VulkanLayerControllerTest, InitializationFailsOnCreateInstanceWithNoInfo)
 }
 
 // This will test the good case of a call to CreateInstance.
-// It ensures, that the dispatch table and the producer are created. Further, it checks that the
+// It ensures that the dispatch table and the producer are created. Further, it checks that the
 // linkage in the VkLayerInstanceCreateInfo chain gets advanced, such that the next layer does not
 // need to process all the previous layers.
 // It tests that the required extensions are enabled in the actual call to the next
-// vkCreateInstance. In this case, the game does not already requested the extensions.
+// vkCreateInstance. In this case, the game has not already requested the extensions.
 TEST_F(
     VulkanLayerControllerTest,
     WillCreateDispatchTableAndVulkanLayerProducerAndAdvanceLinkageOnCreateInstanceWithGameNotEnablingRequiredExtensions) {
@@ -514,11 +514,11 @@ TEST_F(VulkanLayerControllerTest, CallInDispatchTableOnGetDeviceProcAddr) {
 }
 
 // This will test the good case of a call to CreateDevice.
-// It ensures, that the dispatch tableis created and checks that the
+// It ensures that the dispatch table is created and checks that the
 // linkage in the VkLayerDeviceCreateInfo chain gets advanced, such that the next layer does not
 // need to process all the previous layers.
 // It tests that the required extensions are enabled in the actual call to the next
-// vkCreateDevice. In this case, the game does not already requested the extensions.
+// vkCreateDevice. In this case, the game has not already requested the extensions.
 TEST_F(
     VulkanLayerControllerTest,
     WillCreateDispatchTableAndVulkanLayerProducerAndAdvanceLinkageOnCreateDeviceWithGameNotEnablingRequiredExtensions) {
@@ -590,6 +590,7 @@ TEST_F(
   EXPECT_EQ(result, VK_SUCCESS);
   EXPECT_EQ(layer_create_info.u.pLayerInfo, &layer_link_1);
 }
+
 // This will test the good case of a call to CreateDevice. Similar to the test case above, but
 // this time the game already requested the required extensions. We still ensure that those are
 // requested in the next layer's vkCreateDevice.

--- a/src/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
+++ b/src/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
@@ -11,6 +11,7 @@
 
 using ::testing::AllOf;
 using ::testing::Field;
+using ::testing::Invoke;
 using ::testing::IsSubsetOf;
 using ::testing::Matcher;
 using ::testing::Return;
@@ -103,9 +104,15 @@ class MockSubmissionTracker {
   MOCK_METHOD(void, MarkDebugMarkerEnd, (VkCommandBuffer));
 };
 
+class MockVulkanWrapper {
+ public:
+  MOCK_METHOD(VkResult, CallVkEnumerateInstanceExtensionProperties,
+              (const char*, uint32_t*, VkExtensionProperties*));
+};
+
 using VulkanLayerControllerImpl =
     VulkanLayerController<MockDispatchTable, MockQueueManager, MockDeviceManager,
-                          MockTimerQueryPool, MockSubmissionTracker>;
+                          MockTimerQueryPool, MockSubmissionTracker, MockVulkanWrapper>;
 
 Matcher<VkExtensionProperties> VkExtensionPropertiesAreEqual(
     const VkExtensionProperties& expected) {
@@ -325,18 +332,45 @@ TEST_F(VulkanLayerControllerTest, InitializationFailsOnCreateInstanceWithNoInfo)
   EXPECT_EQ(result, VK_ERROR_INITIALIZATION_FAILED);
 }
 
-TEST_F(VulkanLayerControllerTest,
-       WillCreateDispatchTableAndVulkanLayerProducerAndAdvanceLinkageOnCreateInstance) {
+TEST_F(
+    VulkanLayerControllerTest,
+    WillCreateDispatchTableAndVulkanLayerProducerAndAdvanceLinkageOnCreateInstanceWithGameNotEnablingRequiredExtensions) {
   std::unique_ptr<VulkanLayerControllerImpl> controller =
       std::make_unique<VulkanLayerControllerImpl>();
   const MockDispatchTable* dispatch_table = controller->dispatch_table();
   const MockSubmissionTracker* submission_tracker = controller->submission_tracker();
+  const MockVulkanWrapper* vulkan_wrapper = controller->vulkan_wrapper();
   EXPECT_CALL(*dispatch_table, CreateInstanceDispatchTable).Times(1);
   EXPECT_CALL(*submission_tracker, SetVulkanLayerProducer).Times(1);
 
+  EXPECT_CALL(*vulkan_wrapper, CallVkEnumerateInstanceExtensionProperties)
+      .Times(2)
+      .WillRepeatedly(Invoke([](const char* /*layer_name*/, uint32_t* property_count,
+                                VkExtensionProperties* properties) -> VkResult {
+        CHECK(property_count != nullptr);
+        if (properties == nullptr) {
+          *property_count = 1;
+          return VK_SUCCESS;
+        }
+        *properties = {.extensionName = VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME,
+                       .specVersion = VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_SPEC_VERSION};
+        return VK_SUCCESS;
+      }));
+
   static constexpr PFN_vkCreateInstance kMockDriverCreateInstance =
-      +[](const VkInstanceCreateInfo* /*create_info*/, const VkAllocationCallbacks* /*allocator*/,
-          VkInstance* /*instance*/) { return VK_SUCCESS; };
+      +[](const VkInstanceCreateInfo* create_info, const VkAllocationCallbacks* /*allocator*/,
+          VkInstance* /*instance*/) {
+        bool requested_get_physical_device_properties_extension = false;
+        for (uint32_t i = 0; i < create_info->enabledExtensionCount; ++i) {
+          if (strcmp(create_info->ppEnabledExtensionNames[i],
+                     VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME) == 0) {
+            requested_get_physical_device_properties_extension = true;
+            break;
+          }
+        }
+        EXPECT_TRUE(requested_get_physical_device_properties_extension);
+        return VK_SUCCESS;
+      };
 
   PFN_vkGetInstanceProcAddr fake_get_instance_proc_addr =
       +[](VkInstance /*instance*/, const char* name) -> PFN_vkVoidFunction {
@@ -354,12 +388,90 @@ TEST_F(VulkanLayerControllerTest,
       .function = VK_LAYER_LINK_INFO,
       .u.pLayerInfo = &layer_link_2};
   VkInstanceCreateInfo create_info{.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
-                                   .pNext = &layer_create_info};
+                                   .pNext = &layer_create_info,
+                                   .enabledExtensionCount = 0,
+                                   .ppEnabledExtensionNames = nullptr};
+
   VkInstance created_instance;
   VkResult result = controller->OnCreateInstance(&create_info, nullptr, &created_instance);
   EXPECT_EQ(result, VK_SUCCESS);
   EXPECT_EQ(layer_create_info.u.pLayerInfo, &layer_link_1);
 
+  ::testing::Mock::VerifyAndClearExpectations(absl::bit_cast<void*>(submission_tracker));
+  // There will be a call in the destructor.
+  auto actual_producer = absl::bit_cast<VulkanLayerProducer*>(static_cast<uintptr_t>(0xdeadbeef));
+  EXPECT_CALL(*submission_tracker, SetVulkanLayerProducer)
+      .Times(1)
+      .WillOnce(SaveArg<0>(&actual_producer));
+  controller.reset();
+  EXPECT_EQ(actual_producer, nullptr);
+}
+
+TEST_F(
+    VulkanLayerControllerTest,
+    WillCreateDispatchTableAndVulkanLayerProducerOnCreateInstanceWithGameAlreadyEnablingRequiredExtensions) {
+  std::unique_ptr<VulkanLayerControllerImpl> controller =
+      std::make_unique<VulkanLayerControllerImpl>();
+  const MockDispatchTable* dispatch_table = controller->dispatch_table();
+  const MockSubmissionTracker* submission_tracker = controller->submission_tracker();
+  const MockVulkanWrapper* vulkan_wrapper = controller->vulkan_wrapper();
+  EXPECT_CALL(*dispatch_table, CreateInstanceDispatchTable).Times(1);
+  EXPECT_CALL(*submission_tracker, SetVulkanLayerProducer).Times(1);
+
+  EXPECT_CALL(*vulkan_wrapper, CallVkEnumerateInstanceExtensionProperties)
+      .Times(2)
+      .WillRepeatedly(Invoke([](const char* /*layer_name*/, uint32_t* property_count,
+                                VkExtensionProperties* properties) -> VkResult {
+        CHECK(property_count != nullptr);
+        if (properties == nullptr) {
+          *property_count = 1;
+          return VK_SUCCESS;
+        }
+        *properties = {.extensionName = VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME,
+                       .specVersion = VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_SPEC_VERSION};
+        return VK_SUCCESS;
+      }));
+
+  static constexpr PFN_vkCreateInstance kMockDriverCreateInstance =
+      +[](const VkInstanceCreateInfo* create_info, const VkAllocationCallbacks* /*allocator*/,
+          VkInstance* /*instance*/) {
+        bool requested_get_physical_device_properties_extension = false;
+        for (uint32_t i = 0; i < create_info->enabledExtensionCount; ++i) {
+          if (strcmp(create_info->ppEnabledExtensionNames[i],
+                     VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME) == 0) {
+            requested_get_physical_device_properties_extension = true;
+            break;
+          }
+        }
+        EXPECT_TRUE(requested_get_physical_device_properties_extension);
+        return VK_SUCCESS;
+      };
+
+  PFN_vkGetInstanceProcAddr fake_get_instance_proc_addr =
+      +[](VkInstance /*instance*/, const char* name) -> PFN_vkVoidFunction {
+    if (strcmp(name, "vkCreateInstance") == 0) {
+      return absl::bit_cast<PFN_vkVoidFunction>(kMockDriverCreateInstance);
+    }
+    return nullptr;
+  };
+
+  std::string requested_extension_name = VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME;
+  std::vector<const char*> requested_extensions{};
+  requested_extensions.push_back(requested_extension_name.c_str());
+
+  VkLayerInstanceLink layer_link_1 = {.pfnNextGetInstanceProcAddr = fake_get_instance_proc_addr};
+  VkLayerInstanceCreateInfo layer_create_info{
+      .sType = VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO,
+      .function = VK_LAYER_LINK_INFO,
+      .u.pLayerInfo = &layer_link_1};
+  VkInstanceCreateInfo create_info{.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
+                                   .pNext = &layer_create_info,
+                                   .enabledExtensionCount = 1,
+                                   .ppEnabledExtensionNames = requested_extensions.data()};
+
+  VkInstance created_instance;
+  VkResult result = controller->OnCreateInstance(&create_info, nullptr, &created_instance);
+  EXPECT_EQ(result, VK_SUCCESS);
   ::testing::Mock::VerifyAndClearExpectations(absl::bit_cast<void*>(submission_tracker));
   // There will be a call in the destructor.
   auto actual_producer = absl::bit_cast<VulkanLayerProducer*>(static_cast<uintptr_t>(0xdeadbeef));
@@ -392,8 +504,9 @@ TEST_F(VulkanLayerControllerTest, CallInDispatchTableOnGetDeviceProcAddr) {
   EXPECT_EQ(result, kExpectedFunction);
 }
 
-TEST_F(VulkanLayerControllerTest,
-       WillCreateDispatchTableAndVulkanLayerProducerAndAdvanceLinkageOnCreateDevice) {
+TEST_F(
+    VulkanLayerControllerTest,
+    WillCreateDispatchTableAndVulkanLayerProducerAndAdvanceLinkageOnCreateDeviceWithGameNotEnablingRequiredExtensions) {
   const MockDispatchTable* dispatch_table = controller_.dispatch_table();
   EXPECT_CALL(*dispatch_table, CreateDeviceDispatchTable).Times(1);
   const MockDeviceManager* device_manager = controller_.device_manager();
@@ -402,9 +515,32 @@ TEST_F(VulkanLayerControllerTest,
   EXPECT_CALL(*timer_query_pool, InitializeTimerQueryPool).Times(1);
 
   static constexpr PFN_vkCreateDevice kMockDriverCreateDevice =
-      +[](VkPhysicalDevice /*physical_device*/, const VkDeviceCreateInfo* /*create_info*/,
-          const VkAllocationCallbacks* /*allocator*/,
-          VkDevice* /*instance*/) { return VK_SUCCESS; };
+      +[](VkPhysicalDevice /*physical_device*/, const VkDeviceCreateInfo* create_info,
+          const VkAllocationCallbacks* /*allocator*/, VkDevice* /*instance*/) {
+        bool requested_host_extension = false;
+        for (uint32_t i = 0; i < create_info->enabledExtensionCount; ++i) {
+          if (strcmp(create_info->ppEnabledExtensionNames[i],
+                     VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME) == 0) {
+            requested_host_extension = true;
+            break;
+          }
+        }
+        EXPECT_TRUE(requested_host_extension);
+        return VK_SUCCESS;
+      };
+  static constexpr PFN_vkEnumerateDeviceExtensionProperties
+      kFakeEnumerateDeviceExtensionProperties =
+          +[](VkPhysicalDevice /*physical_device*/, const char* /*layer_name*/,
+              uint32_t* property_count, VkExtensionProperties* properties) -> VkResult {
+    CHECK(property_count != nullptr);
+    if (properties == nullptr) {
+      *property_count = 1;
+      return VK_SUCCESS;
+    }
+    *properties = {.extensionName = VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME,
+                   .specVersion = VK_EXT_HOST_QUERY_RESET_SPEC_VERSION};
+    return VK_SUCCESS;
+  };
 
   PFN_vkGetDeviceProcAddr fake_get_device_proc_addr =
       +[](VkDevice /*device*/, const char * /*name*/) -> PFN_vkVoidFunction { return nullptr; };
@@ -413,6 +549,9 @@ TEST_F(VulkanLayerControllerTest,
       +[](VkInstance /*instance*/, const char* name) -> PFN_vkVoidFunction {
     if (strcmp(name, "vkCreateDevice") == 0) {
       return absl::bit_cast<PFN_vkVoidFunction>(kMockDriverCreateDevice);
+    }
+    if (strcmp(name, "vkEnumerateDeviceExtensionProperties") == 0) {
+      return absl::bit_cast<PFN_vkVoidFunction>(kFakeEnumerateDeviceExtensionProperties);
     }
     return nullptr;
   };
@@ -426,13 +565,85 @@ TEST_F(VulkanLayerControllerTest,
                                             .function = VK_LAYER_LINK_INFO,
                                             .u.pLayerInfo = &layer_link_2};
   VkDeviceCreateInfo create_info{.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
-                                 .pNext = &layer_create_info};
+                                 .pNext = &layer_create_info,
+                                 .enabledExtensionCount = 0,
+                                 .ppEnabledExtensionNames = nullptr};
   VkDevice created_device;
   VkPhysicalDevice physical_device = {};
   VkResult result =
       controller_.OnCreateDevice(physical_device, &create_info, nullptr, &created_device);
   EXPECT_EQ(result, VK_SUCCESS);
   EXPECT_EQ(layer_create_info.u.pLayerInfo, &layer_link_1);
+}
+
+TEST_F(VulkanLayerControllerTest,
+       WillCreateDispatchTableOnCreateDeviceWithGameAlreadyEnablingRequiredExtensions) {
+  const MockDispatchTable* dispatch_table = controller_.dispatch_table();
+  EXPECT_CALL(*dispatch_table, CreateDeviceDispatchTable).Times(1);
+  const MockDeviceManager* device_manager = controller_.device_manager();
+  EXPECT_CALL(*device_manager, TrackLogicalDevice).Times(1);
+  const MockTimerQueryPool* timer_query_pool = controller_.timer_query_pool();
+  EXPECT_CALL(*timer_query_pool, InitializeTimerQueryPool).Times(1);
+
+  static constexpr PFN_vkCreateDevice kMockDriverCreateDevice =
+      +[](VkPhysicalDevice /*physical_device*/, const VkDeviceCreateInfo* create_info,
+          const VkAllocationCallbacks* /*allocator*/, VkDevice* /*instance*/) {
+        bool requested_host_extension = false;
+        for (uint32_t i = 0; i < create_info->enabledExtensionCount; ++i) {
+          if (strcmp(create_info->ppEnabledExtensionNames[i],
+                     VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME) == 0) {
+            requested_host_extension = true;
+            break;
+          }
+        }
+        EXPECT_TRUE(requested_host_extension);
+        return VK_SUCCESS;
+      };
+  static constexpr PFN_vkEnumerateDeviceExtensionProperties
+      kFakeEnumerateDeviceExtensionProperties =
+          +[](VkPhysicalDevice /*physical_device*/, const char* /*layer_name*/,
+              uint32_t* property_count, VkExtensionProperties* properties) -> VkResult {
+    CHECK(property_count != nullptr);
+    if (properties == nullptr) {
+      *property_count = 1;
+      return VK_SUCCESS;
+    }
+    *properties = {.extensionName = VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME,
+                   .specVersion = VK_EXT_HOST_QUERY_RESET_SPEC_VERSION};
+    return VK_SUCCESS;
+  };
+
+  PFN_vkGetDeviceProcAddr fake_get_device_proc_addr =
+      +[](VkDevice /*device*/, const char * /*name*/) -> PFN_vkVoidFunction { return nullptr; };
+
+  PFN_vkGetInstanceProcAddr fake_get_instance_proc_addr =
+      +[](VkInstance /*instance*/, const char* name) -> PFN_vkVoidFunction {
+    if (strcmp(name, "vkCreateDevice") == 0) {
+      return absl::bit_cast<PFN_vkVoidFunction>(kMockDriverCreateDevice);
+    }
+    if (strcmp(name, "vkEnumerateDeviceExtensionProperties") == 0) {
+      return absl::bit_cast<PFN_vkVoidFunction>(kFakeEnumerateDeviceExtensionProperties);
+    }
+    return nullptr;
+  };
+
+  VkLayerDeviceLink layer_link_1 = {.pfnNextGetDeviceProcAddr = fake_get_device_proc_addr,
+                                    .pfnNextGetInstanceProcAddr = fake_get_instance_proc_addr};
+  VkLayerDeviceCreateInfo layer_create_info{.sType = VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO,
+                                            .function = VK_LAYER_LINK_INFO,
+                                            .u.pLayerInfo = &layer_link_1};
+  std::string requested_extension_name = VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME;
+  std::vector<const char*> requested_extensions{};
+  requested_extensions.push_back(requested_extension_name.c_str());
+  VkDeviceCreateInfo create_info{.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
+                                 .pNext = &layer_create_info,
+                                 .enabledExtensionCount = 1,
+                                 .ppEnabledExtensionNames = requested_extensions.data()};
+  VkDevice created_device;
+  VkPhysicalDevice physical_device = {};
+  VkResult result =
+      controller_.OnCreateDevice(physical_device, &create_info, nullptr, &created_device);
+  EXPECT_EQ(result, VK_SUCCESS);
 }
 
 TEST_F(VulkanLayerControllerTest, CallInDispatchTableOnGetInstanceProcAddr) {

--- a/src/OrbitVulkanLayer/VulkanWrapper.h
+++ b/src/OrbitVulkanLayer/VulkanWrapper.h
@@ -11,8 +11,8 @@ namespace orbit_vulkan_layer {
 
 // This class provides a wrapper for calls directly into the Vulkan loader.
 // It is used, such that we can fake the called Vulkan functions in the tests.
-
-// Note, in most cases we use the function pointers returned by "GetDevice/InstanceProcAddr",
+//
+// Note: in most cases we use the function pointers returned by "GetDevice/InstanceProcAddr",
 // which directly point to the implementation in the next layer or ICD. So most used Vulkan
 // functions don't need to show up here.
 // See `DispatchTable` and `VulkanLayerController`.

--- a/src/OrbitVulkanLayer/VulkanWrapper.h
+++ b/src/OrbitVulkanLayer/VulkanWrapper.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+#ifndef ORBIT_VULKAN_LAYER_VULKAN_WRAPPER_H_
+#define ORBIT_VULKAN_LAYER_VULKAN_WRAPPER_H_
+
+#include "vulkan/vulkan.h"
+
+namespace orbit_vulkan_layer {
+class VulkanWrapper {
+ public:
+  VkResult CallVkEnumerateInstanceExtensionProperties(const char* layer_name,
+                                                      uint32_t* property_count,
+                                                      VkExtensionProperties* properties) {
+    return vkEnumerateInstanceExtensionProperties(layer_name, property_count, properties);
+  }
+};
+}  //  namespace orbit_vulkan_layer
+#endif  // ORBIT_VULKAN_LAYER_VULKAN_WRAPPER_H_

--- a/src/OrbitVulkanLayer/VulkanWrapper.h
+++ b/src/OrbitVulkanLayer/VulkanWrapper.h
@@ -1,12 +1,21 @@
 // Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 #ifndef ORBIT_VULKAN_LAYER_VULKAN_WRAPPER_H_
 #define ORBIT_VULKAN_LAYER_VULKAN_WRAPPER_H_
 
 #include "vulkan/vulkan.h"
 
 namespace orbit_vulkan_layer {
+
+// This class provides a wrapper for calls directly into the Vulkan loader.
+// It is used, such that we can fake the called Vulkan functions in the tests.
+
+// Note, in most cases we use the function pointers returned by "GetDevice/InstanceProcAddr",
+// which directly point to the implementation in the next layer or ICD. So most used Vulkan
+// functions don't need to show up here.
+// See `DispatchTable` and `VulkanLayerController`.
 class VulkanWrapper {
  public:
   VkResult CallVkEnumerateInstanceExtensionProperties(const char* layer_name,
@@ -16,4 +25,5 @@ class VulkanWrapper {
   }
 };
 }  //  namespace orbit_vulkan_layer
+
 #endif  // ORBIT_VULKAN_LAYER_VULKAN_WRAPPER_H_


### PR DESCRIPTION
We use Vulkan's  host query reset extension. When creating a
device, this extension must be querried using the .ppEnabledExtensionNames
field of the create info. Before this, we were just lucky, as
most games also use that extension.
Similar the get physical device properties extension is required
transitively (via the host extension).

In order to be able to test
(i.e. exchange the vkEnumerateInstanceExtensionProperties), this change
introduces a "VulkanWrapper", which calls into the Vulkan loader
functions. Note, that we can't call the instance enumeration function
using the usual vkGetInstanceProcAddr, as this is a special function
by the Vulkan loader, where the calls directly into layers will fail,
as the loader collect all the extensions for all layers/ICDs.

Test: Run on hello_ggp_standalone & run tests.