### PR TITLE
Backup, modify and restore register state.

### DIFF
--- a/src/UserSpaceInstrumentation/CMakeLists.txt
+++ b/src/UserSpaceInstrumentation/CMakeLists.txt
@@ -19,10 +19,12 @@ target_include_directories(UserSpaceInstrumentation PRIVATE
         ${CMAKE_CURRENT_LIST_DIR})
 
 target_sources(UserSpaceInstrumentation PUBLIC
-        include/UserSpaceInstrumentation/Attach.h)
+        include/UserSpaceInstrumentation/Attach.h
+        include/UserSpaceInstrumentation/RegisterState.h)
 
 target_sources(UserSpaceInstrumentation PRIVATE
-        Attach.cpp)
+        Attach.cpp
+        RegisterState.cpp)
 
 target_link_libraries(UserSpaceInstrumentation PUBLIC
         LinuxTracing
@@ -38,6 +40,7 @@ target_include_directories(UserSpaceInstrumentationTests PRIVATE
 
 target_sources(UserSpaceInstrumentationTests PRIVATE
         AttachTest.cpp
+        RegisterStateTest.cpp
         TestProcess.cpp)
 
 target_link_libraries(UserSpaceInstrumentationTests PRIVATE

--- a/src/UserSpaceInstrumentation/RegisterState.cpp
+++ b/src/UserSpaceInstrumentation/RegisterState.cpp
@@ -1,0 +1,140 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "UserSpaceInstrumentation/RegisterState.h"
+
+#include <cpuid.h>
+#include <elf.h>
+#include <errno.h>
+#include <sys/ptrace.h>
+#include <sys/uio.h>
+
+#include <string>
+
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/SafeStrerror.h"
+#include "absl/strings/str_format.h"
+
+namespace orbit_user_space_instrumentation {
+
+namespace {
+
+// Return the size of the XSave area on this cpu.
+[[nodiscard]] ErrorMessageOr<size_t> GetXSaveAreaSize() {
+  uint32_t eax = 0;
+  uint32_t ebx = 0;
+  uint32_t ecx = 0;
+  uint32_t edx = 0;
+  if (!__get_cpuid(1, &eax, &ebx, &ecx, &edx) || !(ecx & bit_XSAVE)) {
+    return ErrorMessage("XSAVE is not supported by Cpu.");
+  }
+  if (!__get_cpuid_count(0x0d, 0x00, &eax, &ebx, &ecx, &edx)) {
+    return ErrorMessage("XSAVE is not supported by Cpu.");
+  }
+  return static_cast<size_t>(ecx);
+}
+
+// Return offset of the YMMx registers inside the extended section of the XSave area.
+[[nodiscard]] ErrorMessageOr<size_t> GetAvxOffset() {
+  uint32_t eax = 0;
+  uint32_t ebx = 0;
+  uint32_t ecx = 0;
+  uint32_t edx = 0;
+  if (!__get_cpuid(0x01, &eax, &ebx, &ecx, &edx) || !(ecx & bit_AVX)) {
+    return ErrorMessage("AVX is not supported by Cpu.");
+  }
+  if (!__get_cpuid_count(0x0d, 0x02, &eax, &ebx, &ecx, &edx)) {
+    return ErrorMessage("AVX offset query failed.");
+  }
+  return static_cast<size_t>(ebx);
+}
+
+}  // namespace
+
+bool RegisterState::Hasx87DataStored() {
+  return (static_cast<uint64_t>(GetXSaveHeader()->xstate_bv) &
+          static_cast<uint64_t>(XSaveHeader::StateComponents::kX87)) != 0;
+}
+
+bool RegisterState::HasSseDataStored() {
+  return (static_cast<uint64_t>(GetXSaveHeader()->xstate_bv) &
+          static_cast<uint64_t>(XSaveHeader::StateComponents::kSse)) != 0;
+}
+
+bool RegisterState::HasAvxDataStored() {
+  return (static_cast<uint64_t>(GetXSaveHeader()->xstate_bv) &
+          static_cast<uint64_t>(XSaveHeader::StateComponents::kAvx)) != 0;
+}
+
+[[nodiscard]] ErrorMessageOr<void> RegisterState::BackupRegisters(pid_t tid) {
+  tid_ = tid;
+
+  iovec iov;
+  iov.iov_base = &general_purpose_registers_;
+  iov.iov_len = sizeof(GeneralPurposeRegisters);
+  auto result = ptrace(PTRACE_GETREGSET, tid, NT_PRSTATUS, &iov);
+  if (result == -1) {
+    return ErrorMessage(absl::StrFormat("PTRACE_GETREGS, NT_PRSTATUS failed with errno: %d: \"%s\"",
+                                        errno, SafeStrerror(errno)));
+  }
+
+  if (iov.iov_len == sizeof(GeneralPurposeRegisters32)) {
+    bitness_ = Bitness::k32Bit;
+  } else if (iov.iov_len == sizeof(GeneralPurposeRegisters64)) {
+    bitness_ = Bitness::k64Bit;
+  } else {
+    CHECK(false);
+  }
+
+  auto xsave_area_size = GetXSaveAreaSize();
+  if (xsave_area_size.has_error()) {
+    return xsave_area_size.error();
+  }
+  xsave_area_.resize(xsave_area_size.value());
+
+  iov.iov_len = xsave_area_.size();
+  iov.iov_base = xsave_area_.data();
+  result = ptrace(PTRACE_GETREGSET, tid, NT_X86_XSTATE, &iov);
+  if (result == -1) {
+    return ErrorMessage(absl::StrFormat(
+        "PTRACE_GETREGS, NT_X86_XSTATE failed with errno: %d: \"%s\"", errno, SafeStrerror(errno)));
+  }
+
+  auto avx_offset = GetAvxOffset();
+  if (!avx_offset.has_error()) {
+    avx_offset_ = avx_offset.value();
+  } else {
+    avx_offset_ = 0;
+  }
+
+  return outcome::success();
+}
+
+[[nodiscard]] ErrorMessageOr<void> RegisterState::RestoreRegisters() {
+  // BackupRegisters needs to be called before RestoreRegisters.
+  CHECK(tid_ != -1);
+
+  iovec iov;
+  iov.iov_base = &general_purpose_registers_;
+  iov.iov_len = bitness_ == Bitness::k32Bit ? sizeof(GeneralPurposeRegisters32)
+                                            : sizeof(GeneralPurposeRegisters64);
+  auto result = ptrace(PTRACE_SETREGSET, tid_, NT_PRSTATUS, &iov);
+  if (result == -1) {
+    return ErrorMessage(
+        absl::StrFormat("PTRACE_SETREGSET failed to write NT_PRSTATUS with errno: %d: \"%s\"",
+                        errno, SafeStrerror(errno)));
+  }
+
+  iov.iov_len = xsave_area_.size();
+  iov.iov_base = xsave_area_.data();
+  result = ptrace(PTRACE_SETREGSET, tid_, NT_X86_XSTATE, &iov);
+  if (result == -1) {
+    ErrorMessage(
+        absl::StrFormat("PTRACE_SETREGSET failed to write NT_X86_XSTATE with errno: %d: \"%s\"",
+                        errno, SafeStrerror(errno)));
+  }
+  return outcome::success();
+}
+
+}  // namespace orbit_user_space_instrumentation

--- a/src/UserSpaceInstrumentation/RegisterState.cpp
+++ b/src/UserSpaceInstrumentation/RegisterState.cpp
@@ -21,11 +21,12 @@ namespace orbit_user_space_instrumentation {
 namespace {
 
 // Some notes reguarding the calls to cpuid below:
-// Cpuid takes one parameter in eax. In Intel's terminology, this is called the Cpuid "leaf". Some
-// leaves have "sub-leafs" i.e. they take a second paramter in ecx. The sub-leaf is sometimes called
-// "count". The return values end up in registers eax, ... , edx.
-// The wrappers from cpuid.h simplify error and parameter handling. cpuid.h also has some defines
-// and useful comments to figure out what can be queried. More comprehensive info:
+// Cpuid can be used to query all sorts of information about the cpu (presence of features,
+// specifications, ...). Cpuid takes one parameter in eax. In Intel's terminology, this is called
+// the Cpuid "leaf". Some leaves have "sub-leafs" i.e. they take a second paramter in ecx. The
+// sub-leaf is sometimes called "count". The return values end up in registers eax, ... , edx. The
+// wrappers from cpuid.h simplify error and parameter handling. cpuid.h also has some defines and
+// useful comments to figure out what can be queried. More comprehensive info:
 // https://www.sandpile.org/x86/cpuid.htm
 
 // Return the size of the XSave area on this cpu.

--- a/src/UserSpaceInstrumentation/RegisterStateTest.cpp
+++ b/src/UserSpaceInstrumentation/RegisterStateTest.cpp
@@ -1,0 +1,96 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+#include <stdint.h>
+#include <sys/ptrace.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include "OrbitBase/Logging.h"
+#include "UserSpaceInstrumentation/RegisterState.h"
+
+namespace orbit_user_space_instrumentation {
+
+namespace {
+
+// Let the parent trace us, write into rax and ymm0, then break. While the child is breaked the
+// parent modifies the register and continues the child. The child then reads back the registers and
+// verifies the modifications done by the parent. The exit code indicates the outcome of that
+// verification.
+void Child() {
+  CHECK(ptrace(PTRACE_TRACEME, 0, NULL, 0) != -1);
+
+  uint64_t rax = 0xaabbccdd;
+  uint8_t avx_bytes[32];
+  for (int i = 0; i < 32; ++i) {
+    avx_bytes[i] = i;
+  }
+  __asm__ __volatile__(
+      "mov (%0), %%rax\n\t"
+      "vmovups (%1), %%ymm0\n\t"
+      "int3\n\t"
+      "mov %%rax, (%0)\n\t"
+      "vmovups %%ymm0, (%1)\n\t"
+      :
+      : "r"(&rax), "b"(avx_bytes)
+      : "%rax", "%ymm0", "memory");
+
+  if (rax != 0xaabbccdd + 0x11223344) {
+    exit(1);
+  }
+  for (int i = 0; i < 32; ++i) {
+    if (avx_bytes[i] != 0x10 + i) {
+      exit(1);
+    }
+  }
+  exit(0);
+}
+
+}  // namespace
+
+TEST(RegisterStateTest, BackupModifyRestore) {
+  pid_t pid = fork();
+  CHECK(pid != -1);
+  if (pid == 0) {
+    Child();
+  }
+
+  // Wait for child to break.
+  int status = 0;
+  pid_t waited = waitpid(pid, &status, 0);
+  CHECK(waited == pid);
+  CHECK(WIFSTOPPED(status));
+  CHECK(WSTOPSIG(status) == SIGTRAP);
+
+  // Read child's registers and check values.
+  RegisterState s;
+  EXPECT_TRUE(s.BackupRegisters(pid));
+  EXPECT_EQ(s.GetGeneralPurposeRegisters()->x86_64.rax, 0xaabbccdd);
+  EXPECT_TRUE(s.HasSseDataStored());
+  EXPECT_TRUE(s.HasAvxDataStored());
+  for (int i = 0; i < 16; ++i) {
+    EXPECT_EQ(s.GetFxSave()->xmm[0].bytes[i], i);
+    EXPECT_EQ(s.GetAvxHiRegisters()->ymm[0].bytes[i], i + 16);
+  }
+
+  // Modify rax and ymm0 and write them back to the child.
+  s.GetGeneralPurposeRegisters()->x86_64.rax += 0x11223344;
+  for (int i = 0; i < 16; ++i) {
+    s.GetFxSave()->xmm[0].bytes[i] += 0x10;
+    s.GetAvxHiRegisters()->ymm[0].bytes[i] += 0x10;
+  }
+  EXPECT_TRUE(s.RestoreRegisters());
+
+  // Continue child.
+  CHECK(ptrace(PT_CONTINUE, pid, 1, 0) == 0);
+
+  // Wait for the child to exit. Exit status is zero if the modified register could be verified.
+  waited = waitpid(pid, &status, 0);
+  CHECK(waited == pid);
+  CHECK(WIFEXITED(status));
+  EXPECT_EQ(WEXITSTATUS(status), 0);
+}
+
+}  // namespace orbit_user_space_instrumentation

--- a/src/UserSpaceInstrumentation/RegisterStateTest.cpp
+++ b/src/UserSpaceInstrumentation/RegisterStateTest.cpp
@@ -16,7 +16,7 @@ namespace orbit_user_space_instrumentation {
 namespace {
 
 // Let the parent trace us, write into rax and ymm0, then enter a breakpoint. While the child is
-// stopped the parent modifies the register and continues the child. The child then reads back the
+// stopped the parent modifies the registers and continues the child. The child then reads back the
 // registers and verifies the modifications done by the parent. The exit code indicates the outcome
 // of that verification.
 void Child() {
@@ -27,9 +27,9 @@ void Child() {
   for (int i = 0; i < 32; ++i) {
     avx_bytes[i] = i;
   }
-  // The first two lines move the memory to the registers. The "%0" and "%1" refer to the adresses
+  // The first two lines move the memory to the registers. The "%0" and "%1" refer to the addresses
   // of "rax" and "avx_bytes" given in the second line from the bottom. "int3" just is the
-  // breakpoint. The parent does "waitpid" for that. line four and five move the registers back into
+  // breakpoint. The parent does "waitpid" for that. Line four and five move the registers back into
   // memory so they are available for verification below.
   __asm__ __volatile__(
       "mov (%0), %%rax\n\t"

--- a/src/UserSpaceInstrumentation/RegisterStateTest.cpp
+++ b/src/UserSpaceInstrumentation/RegisterStateTest.cpp
@@ -86,7 +86,7 @@ TEST(RegisterStateTest, BackupModifyRestore) {
   // Continue child.
   CHECK(ptrace(PT_CONTINUE, pid, 1, 0) == 0);
 
-  // Wait for the child to exit. Exit status is zero if the modified register could be verified.
+  // Wait for the child to exit. Exit status is zero if the modified registers could be verified.
   waited = waitpid(pid, &status, 0);
   CHECK(waited == pid);
   CHECK(WIFEXITED(status));

--- a/src/UserSpaceInstrumentation/TestProcess.h
+++ b/src/UserSpaceInstrumentation/TestProcess.h
@@ -36,5 +36,4 @@ class TestProcess {
   std::filesystem::path flag_file_run_child_;
   std::filesystem::path flag_file_child_started_;
 };
-
 }  // namespace orbit_user_space_instrumentation

--- a/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/RegisterState.h
+++ b/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/RegisterState.h
@@ -92,7 +92,7 @@ struct MmsRegister {
 static_assert(sizeof(MmsRegister) == 16, "MmsRegister is not 16 bytes of size");
 
 struct XmmRegister {
-  uint8_t bytes[16];
+  std::array<uint8_t, 16> bytes;
 };
 
 // Legacy Region of the XSave area stores the Fpu, Mmx, Sse state of the Cpu.
@@ -147,17 +147,29 @@ struct YmmHi {
 };
 PACKED_END
 
+#undef PACKED_START
+#undef PACKED_END
+
 // Backup, modify and restore register state of a halted thread.
 //
 // Requires the XSave extension (added around 2008) to be supported by the Cpu otherwise
-// "BackupRegisters" will return an error. RegisterState requires to be initialized by a call to
-// "BackupRegisters" before anything else can be called on the object. RegisterState stores the
-// general purpose registers as well as all floating point and vector registers.
+// "BackupRegisters" will return an error. The XSave feature set includes instructions that save and
+// restore the XSave managed "state components" to and from memory. These state components
+// correspond to sets of registers introduced for different processor features (e.g. Avx, Avx-512,
+// ...). The processor organizes the state components in a region of memory called an XSave area.
+// The XSave area comprises the legacy region (roughly: storing everything up to SSE2), the XSave
+// header (roughly: flags indicating what is in the xtended region) and the extended region itself
+// (roughly: storing everything from Avx onwards).
+// We don't invoke the XSave instruction ourselfs but call ptrace to have the kernel do that for us.
+//
+// RegisterState requires to be initialized by a call to "BackupRegisters" before anything else can
+// be called on the object. RegisterState stores the general purpose registers as well as all
+// floating point and vector registers.
 //
 // Access to the stored data is provided by somewhat forcefully casting the memory blocks returned
 // by the kernel to the structs above.
 //
-// For the general purpose registers this is somewhat straightforward with the only complication
+// For the general purpose registers this is quite straightforward with the only complication
 // of bitness of the process. Users of this class should query the bitness of the process using
 // "GetBitness" and only access the respective member of the union returned by
 // "GetGeneralPurposeRegisters".
@@ -166,8 +178,10 @@ PACKED_END
 // found in [1]. A good, readable introduction can be found here: [2].
 // Different registers may or may not be present on a specific Cpu (e.g. the Cpu may or may not
 // support Avx). Even if the Cpu has the respective registers they might not have been saved by
-// "BackupRegisters" since they are in their initial state. Hence every meaningful access to this
-// data needs to call the "Has*DataStored" functions first.
+// "BackupRegisters" since they are in their initial state (e.g. Avx registers are initialized with
+// zeros on process startup; if the process makes no use of Avx storing these registers is skipped
+// as an optimization). Hence every meaningful access to this data needs to call the
+// "Has*DataStored" functions first.
 //
 // The fpu, mmx, sse registers can be accessed via the "GetFxSave" call using the structs defined
 // above. Note that the fpu and the mmx registers share the same memory since their usage is
@@ -222,10 +236,10 @@ class RegisterState {
   // Structure access to the different parts of the XSave area. Detail, again, can be found at
   // "Intel 64 and IA-32 Architectures Software Developer’s Manual, Volume 1", section 13.
   // "GetFxSave" can be used to access fpu, mmx, sse registers. "GetAvxHiRegisters" give access to
-  // the upper half of the avx registers (lower half in store in the sse registers).
-  FxSave* GetFxSave() { return reinterpret_cast<FxSave*>(xsave_area_.data()); }
-  XSaveHeader* GetXSaveHeader() { return reinterpret_cast<XSaveHeader*>(xsave_area_.data() + 512); }
-  YmmHi* GetAvxHiRegisters() { return reinterpret_cast<YmmHi*>(xsave_area_.data() + avx_offset_); }
+  // the upper half of the avx registers (lower half is stored in the sse registers).
+  [[nodiscard]] FxSave* GetFxSave() { return reinterpret_cast<FxSave*>(xsave_area_.data()); }
+  [[nodiscard]] XSaveHeader* GetXSaveHeader() { return reinterpret_cast<XSaveHeader*>(xsave_area_.data() + 512); }
+  [[nodiscard]] YmmHi* GetAvxHiRegisters() { return reinterpret_cast<YmmHi*>(xsave_area_.data() + avx_offset_); }
 
  private:
   pid_t tid_ = -1;

--- a/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/RegisterState.h
+++ b/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/RegisterState.h
@@ -1,0 +1,240 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef USER_SPACE_INSTRUMENTATION_REGISTER_STATE_H_
+#define USER_SPACE_INSTRUMENTATION_REGISTER_STATE_H_
+
+#include <stdint.h>
+
+#include <array>
+#include <vector>
+
+#include "OrbitBase/Result.h"
+
+namespace orbit_user_space_instrumentation {
+
+// The structs below are defined to match the memory layout of the binary blobs containing the
+// register state of the cpu (as returned by the kernel). They should not used directly - see
+// comment on class "RegisterState" below.
+#define PACKED_START _Pragma("pack(push, 1)")
+#define PACKED_END _Pragma("pack(pop)")
+
+PACKED_START
+struct GeneralPurposeRegisters32 {
+  uint32_t ebx;
+  uint32_t ecx;
+  uint32_t edx;
+  uint32_t esi;
+  uint32_t edi;
+  uint32_t ebp;
+  uint32_t eax;
+  uint32_t xds;
+  uint32_t xes;
+  uint32_t xfs;
+  uint32_t xgs;
+  uint32_t orig_eax;
+  uint32_t eip;
+  uint32_t xcs;
+  uint32_t eflags;
+  uint32_t esp;
+  uint32_t xss;
+};
+
+struct GeneralPurposeRegisters64 {
+  uint64_t r15;
+  uint64_t r14;
+  uint64_t r13;
+  uint64_t r12;
+  uint64_t rbp;
+  uint64_t rbx;
+  uint64_t r11;
+  uint64_t r10;
+  uint64_t r9;
+  uint64_t r8;
+  uint64_t rax;
+  uint64_t rcx;
+  uint64_t rdx;
+  uint64_t rsi;
+  uint64_t rdi;
+  uint64_t orig_rax;
+  uint64_t rip;
+  uint64_t cs;
+  uint64_t rflags;
+  uint64_t rsp;
+  uint64_t ss;
+  uint64_t fs_base;
+  uint64_t gs_base;
+  uint64_t ds;
+  uint64_t es;
+  uint64_t fs;
+  uint64_t gs;
+};
+
+union GeneralPurposeRegisters {
+  GeneralPurposeRegisters32 x86_32;
+  GeneralPurposeRegisters64 x86_64;
+};
+
+struct MmsAs80BitFloat {
+  uint64_t mantissa;
+  uint16_t sign_exp;
+};
+static_assert(sizeof(MmsAs80BitFloat) == 10, "MmsAsFloat is not 10 bytes of size");
+
+struct MmsRegister {
+  union {
+    std::array<uint8_t, 10> bytes;
+    MmsAs80BitFloat as_float;
+  };
+  std::array<uint8_t, 6> reserved;
+};
+static_assert(sizeof(MmsRegister) == 16, "MmsRegister is not 16 bytes of size");
+
+struct XmmRegister {
+  uint8_t bytes[16];
+};
+
+// Legacy Region of the XSave area stores the Fpu, Mmx, Sse state of the Cpu.
+// Compare "Intel 64 and IA-32 Architectures Software Developer’s Manual, Volume 1" section 13.4.1.
+struct FxSave {
+  uint16_t fcw;
+  uint16_t fsw;
+  uint16_t ftw;
+  uint16_t fop;
+  uint64_t fip;
+  uint64_t fdp;
+  uint32_t mxcsr;
+  uint32_t mxcsr_mask;
+  std::array<MmsRegister, 8> stmm;
+  std::array<XmmRegister, 16> xmm;
+  std::array<uint8_t, 48> padding1;
+  uint64_t xcr0;
+  std::array<uint8_t, 40> padding2;
+};
+static_assert(sizeof(FxSave) == 512, "FxSave is not 512 bytes of size");
+
+// XSave header contains information about what is present in the extended region of an XSAVE area.
+// Compare "Intel 64 and IA-32 Architectures Software Developer’s Manual, Volume 1" section 13.4.2.
+// and 13.4.3..
+struct XSaveHeader {
+  enum class StateComponents : uint64_t {
+    kX87 = 1,
+    kSse = 2,
+    kAvx = 4,
+    kBndRegs = 8,
+    kBndCsr = 16,
+    kOpMask = 32,
+    kZmmHi256 = 64,
+    kHi16Zmm = 128,
+    kPt = 256,
+    kPkru = 512,
+  };
+  uint64_t xstate_bv;
+  uint64_t xcomp_bv;
+  std::array<uint64_t, 6> reserved;
+};
+static_assert(sizeof(XSaveHeader) == 64, "XSaveHeader layout incorrect");
+
+// The upper 128 bit of a single YMMx register.
+struct YmmHiRegister {
+  std::array<uint8_t, 16> bytes;
+};
+
+// The upper 128 bit of the YMM0..15 registers. The lower bits are shared with XMM registers above.
+struct YmmHi {
+  std::array<YmmHiRegister, 16> ymm;
+};
+PACKED_END
+
+// Backup, modify and restore register state of a halted thread.
+//
+// Requires the XSave extension (added around 2008) to be supported by the Cpu otherwise
+// "BackupRegisters" will return an error. RegisterState requires to be initialized by a call to
+// "BackupRegisters" before anything else can be called on the object. RegisterState stores the
+// general purpose registers as well as all floating point and vector registers.
+//
+// Access to the stored data is provided by somewhat forcefully casting the memory blocks returned
+// by the kernel to the structs above.
+//
+// For the general purpose registers this is somewhat straightforward with the only complication
+// of bitness of the process. Users of this class should query the bitness of the process using
+// "GetBitness" and only access the respective member of the union returned by
+// "GetGeneralPurposeRegisters".
+//
+// For fpu / vector data the situation is slightly more complicated. A comprehensive write-up can be
+// found in [1]. A good, readable introduction can be found here: [2].
+// Different registers may or may not be present on a specific Cpu (e.g. the Cpu may or may not
+// support Avx). Even if the Cpu has the respective registers they might not have been saved by
+// "BackupRegisters" since they are in their initial state. Hence every meaningful access to this
+// data needs to call the "Has*DataStored" functions first.
+//
+// The fpu, mmx, sse registers can be accessed via the "GetFxSave" call using the structs defined
+// above. Note that the fpu and the mmx registers share the same memory since their usage is
+// mutually exclusive. The upper half of the avx registers can be accessed via "GetAvxHiRegisters"
+// (low half is shared with sse registers).
+//
+// There are more additional registers that get backed up and restored by this class (if the cpu
+// supports them and backup is necessary) but no accessors are defined to alter that data (e.g.
+// Avx-512, Mpx registers, ...). It should be straightforward to add support for these if that
+// should become necessary. Details again can be found in [1].
+//
+// [1]: "Intel 64 and IA-32 Architectures Software Developer’s Manual, Volume 1", section 13
+// [2]: https://www.moritz.systems/blog/how-debuggers-work-getting-and-setting-x86-registers-part-2/
+//
+// Example usage:
+//
+//    // Wait for some thread to be halted.
+//    waitpid(pid, &status, 0);
+//
+//    // Alter Avx state if applicable.
+//    RegisterState s;
+//    auto result_backup = s.BackupRegisters(pid);
+//    if (s.HasAvxDataStored()){
+//      s.GetAvxHiRegisters()->ymm[0].bytes[0] = 42;
+//    }
+//    auto result_restore = s.RestoreRegisters();
+//
+//    // Continue thread with altered state.
+//    ptrace(PT_CONTINUE, pid, 1, 0);
+class RegisterState {
+ public:
+  [[nodiscard]] ErrorMessageOr<void> BackupRegisters(pid_t tid);
+  [[nodiscard]] ErrorMessageOr<void> RestoreRegisters();
+
+  enum class Bitness {
+    k32Bit,
+    k64Bit,
+  };
+  Bitness GetBitness() const { return bitness_; }
+
+  // Returns a pointer to a union of 32 and 64 bit general purpose registers. Call "GetBitness" to
+  // determine which member of the union is valid.
+  GeneralPurposeRegisters* GetGeneralPurposeRegisters() { return &general_purpose_registers_; }
+
+  // Some registers do not get stored in RegisterState. The Cpu might not support them or they might
+  // be in their initial state. So before accessing this data one needs to call the "Has*DataStored"
+  // methods first.
+  bool Hasx87DataStored();
+  bool HasSseDataStored();
+  bool HasAvxDataStored();
+
+  // Structure access to the different parts of the XSave area. Detail, again, can be found at
+  // "Intel 64 and IA-32 Architectures Software Developer’s Manual, Volume 1", section 13.
+  // "GetFxSave" can be used to access fpu, mmx, sse registers. "GetAvxHiRegisters" give access to
+  // the upper half of the avx registers (lower half in store in the sse registers).
+  FxSave* GetFxSave() { return reinterpret_cast<FxSave*>(xsave_area_.data()); }
+  XSaveHeader* GetXSaveHeader() { return reinterpret_cast<XSaveHeader*>(xsave_area_.data() + 512); }
+  YmmHi* GetAvxHiRegisters() { return reinterpret_cast<YmmHi*>(xsave_area_.data() + avx_offset_); }
+
+ private:
+  pid_t tid_ = -1;
+  GeneralPurposeRegisters general_purpose_registers_;
+  std::vector<uint8_t> xsave_area_;
+  Bitness bitness_;
+  size_t avx_offset_ = 0;
+};
+
+}  // namespace orbit_user_space_instrumentation
+
+#endif

--- a/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/RegisterState.h
+++ b/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/RegisterState.h
@@ -220,18 +220,20 @@ class RegisterState {
     k32Bit,
     k64Bit,
   };
-  Bitness GetBitness() const { return bitness_; }
+  [[nodiscard]] Bitness GetBitness() const { return bitness_; }
 
   // Returns a pointer to a union of 32 and 64 bit general purpose registers. Call "GetBitness" to
   // determine which member of the union is valid.
-  GeneralPurposeRegisters* GetGeneralPurposeRegisters() { return &general_purpose_registers_; }
+  [[nodiscard]] GeneralPurposeRegisters* GetGeneralPurposeRegisters() {
+    return &general_purpose_registers_;
+  }
 
   // Some registers do not get stored in RegisterState. The Cpu might not support them or they might
   // be in their initial state. So before accessing this data one needs to call the "Has*DataStored"
   // methods first.
-  bool Hasx87DataStored();
-  bool HasSseDataStored();
-  bool HasAvxDataStored();
+  [[nodiscard]] bool Hasx87DataStored();
+  [[nodiscard]] bool HasSseDataStored();
+  [[nodiscard]] bool HasAvxDataStored();
 
   // Structure access to the different parts of the XSave area. Details, again, can be found at
   // "Intel 64 and IA-32 Architectures Software Developer’s Manual, Volume 1", section 13.

--- a/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/RegisterState.h
+++ b/src/UserSpaceInstrumentation/include/UserSpaceInstrumentation/RegisterState.h
@@ -158,7 +158,7 @@ PACKED_END
 // correspond to sets of registers introduced for different processor features (e.g. Avx, Avx-512,
 // ...). The processor organizes the state components in a region of memory called an XSave area.
 // The XSave area comprises the legacy region (roughly: storing everything up to SSE2), the XSave
-// header (roughly: flags indicating what is in the xtended region) and the extended region itself
+// header (roughly: flags indicating what is in the extended region) and the extended region itself
 // (roughly: storing everything from Avx onwards).
 // We don't invoke the XSave instruction ourselfs but call ptrace to have the kernel do that for us.
 //
@@ -179,7 +179,7 @@ PACKED_END
 // Different registers may or may not be present on a specific Cpu (e.g. the Cpu may or may not
 // support Avx). Even if the Cpu has the respective registers they might not have been saved by
 // "BackupRegisters" since they are in their initial state (e.g. Avx registers are initialized with
-// zeros on process startup; if the process makes no use of Avx storing these registers is skipped
+// zeros on process startup; if the process makes no use of Avx storing these registers are skipped
 // as an optimization). Hence every meaningful access to this data needs to call the
 // "Has*DataStored" functions first.
 //
@@ -233,13 +233,17 @@ class RegisterState {
   bool HasSseDataStored();
   bool HasAvxDataStored();
 
-  // Structure access to the different parts of the XSave area. Detail, again, can be found at
+  // Structure access to the different parts of the XSave area. Details, again, can be found at
   // "Intel 64 and IA-32 Architectures Software Developer’s Manual, Volume 1", section 13.
   // "GetFxSave" can be used to access fpu, mmx, sse registers. "GetAvxHiRegisters" give access to
   // the upper half of the avx registers (lower half is stored in the sse registers).
   [[nodiscard]] FxSave* GetFxSave() { return reinterpret_cast<FxSave*>(xsave_area_.data()); }
-  [[nodiscard]] XSaveHeader* GetXSaveHeader() { return reinterpret_cast<XSaveHeader*>(xsave_area_.data() + 512); }
-  [[nodiscard]] YmmHi* GetAvxHiRegisters() { return reinterpret_cast<YmmHi*>(xsave_area_.data() + avx_offset_); }
+  [[nodiscard]] XSaveHeader* GetXSaveHeader() {
+    return reinterpret_cast<XSaveHeader*>(xsave_area_.data() + 512);
+  }
+  [[nodiscard]] YmmHi* GetAvxHiRegisters() {
+    return reinterpret_cast<YmmHi*>(xsave_area_.data() + avx_offset_);
+  }
 
  private:
   pid_t tid_ = -1;


### PR DESCRIPTION
Register state of a halted thread can be read, modified, and written
back to the halted thread.

bug: http://b/181117089
test: unit test.