### PR TITLE
Clear StringManager at start of a capture.

### DIFF
--- a/src/OrbitCore/StringManager.cpp
+++ b/src/OrbitCore/StringManager.cpp
@@ -8,11 +8,13 @@
 #include <absl/strings/string_view.h>
 #include <absl/synchronization/mutex.h>
 
-#include <utility>
+#include "OrbitBase/Logging.h"
 
+// TODO(b/181207737): Make this assert that it is not present and rename to "Add".
 bool StringManager::AddIfNotPresent(uint64_t key, std::string_view str) {
   absl::MutexLock lock{&mutex_};
   if (key_to_string_.contains(key)) {
+    ERROR("String collision for key: %ul and string: %s.", key, str);
     return false;
   }
   key_to_string_.emplace(key, str);

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -823,7 +823,6 @@ Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> OrbitApp::LoadCaptureFro
     capture_window_->set_draw_help(false);
   }
   ClearCapture();
-  string_manager_.Clear();
   auto load_future = thread_pool_->Schedule([this, file_name]() mutable {
     capture_loading_cancellation_requested_ = false;
 
@@ -949,6 +948,9 @@ void OrbitApp::ClearCapture() {
     capture_window_->ClearTimeGraph();
   }
   capture_data_.reset();
+
+  string_manager_.Clear();
+
   set_selected_thread_id(orbit_base::kAllProcessThreadsTid);
   SelectTextBox(nullptr);
 


### PR DESCRIPTION
With switching to non-hashes as string id's, we can't rely on
collision-resistence anymore. For every capture, string id's
would be used for different strings, thus resulting in showing
wrong strings in the UI.

This fixes the issue, by clearing StringManager in ClearCapture.
This was already be done for loaded captures.

Test: Take several captures, look at the GPU Track names.