### PR TITLE
VkFreeCommandBuffers also rollback the timer slots and remove the state.

### DIFF
--- a/src/OrbitVulkanLayer/SubmissionTracker.h
+++ b/src/OrbitVulkanLayer/SubmissionTracker.h
@@ -182,6 +182,11 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
       VkCommandBuffer command_buffer = command_buffers[i];
       associated_command_buffers.erase(command_buffer);
 
+      // vkFreeCommandBuffers (and thus this method) can be also called on command bufers in
+      // "recording" or executable state and has similar effect as vkResetCommandBuffer has.
+      // In `OnCaptureFinished`, we reset all the timer slots left in `command_buffer_to_state_`.
+      // If we would not reset them here and clear the state, we would try to reset those command
+      // buffers there. However, the mapping to the device (which is needed) would be missing.
       if (command_buffer_to_state_.contains(command_buffer)) {
         ResetCommandBufferUnsafe(command_buffer);
 

--- a/src/OrbitVulkanLayer/SubmissionTracker.h
+++ b/src/OrbitVulkanLayer/SubmissionTracker.h
@@ -188,6 +188,9 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
       // If we would not reset them here and clear the state, we would try to reset those command
       // buffers there. However, the mapping to the device (which is needed) would be missing.
       if (command_buffer_to_state_.contains(command_buffer)) {
+        // Note: This will "rollback" the slot indices (rather then actually resetting them on the
+        // Gpu). This is fine, as we remove the command buffer state right after submission. Thus,
+        // There can not be a value in the respective slot.
         ResetCommandBufferUnsafe(command_buffer);
 
         command_buffer_to_state_.erase(command_buffer);


### PR DESCRIPTION
A command buffer can actually also be "free"ed while it is in
recording or executable state. On free, we remove the command
buffer from our internal maps, but not from the state map.

This leads to a crash in OnCaptureStopped, as the device mapping
is gone, but the state remains.

This change prevents this, by also resetting the slots on Free
and erasing the state.

Bug: http://b/181217248
Test: Run tests or stop a capture at the end of infiltrator (when
the gpu is done)