### PR TITLE
Fix an error in Highlighting m_variables

### DIFF
--- a/src/CodeViewerDemo/CodeExamples.h
+++ b/src/CodeViewerDemo/CodeExamples.h
@@ -28,6 +28,7 @@ inline const QString testing_example =
   m_PascalCase = 5;
   Track::SortTracks();
   class TrackManager {};
+  int pam_value; // not a class member
 
   // Function unit tests
   int my_function(void);

--- a/src/SyntaxHighlighter/Cpp.cpp
+++ b/src/SyntaxHighlighter/Cpp.cpp
@@ -51,7 +51,7 @@ const char* const kNamespaceVariablesRegex = "(?<=::)[A-Za-z_]\\w*(?=\\b)";
 const char* const kNamespaceRegex = "[A-Za-z_]\\w*::";
 const char* const kClassNameRegex = "\\b(?:class|concept|enum|namespace|struct|typename)\\s+(\\w+)";
 // Variables starting with lowercase and finishing with _ (e.g. tracks_) or starting with "m_"
-const char* const kClassMemberRegex = "\\b[a-z]\\w*\\_(?<=\\b)|m_\\w*";
+const char* const kClassMemberRegex = "\\b[a-z]\\w*\\_(?<=\\b)|(?<=\\b)m_\\w*";
 const char* const kPreprocessorRegex = "(^\\s*)#\\s*[A-Za-z_]\\w*";
 // Match with <word> after #include
 const char* const kIncludeFileRegex = "(?<=#include)\\s*<[^>]*>";


### PR DESCRIPTION
m_VariableName is widely used to refer to class members. Actually, we
used to have them in Orbit. There is an error in that regex, we should have a separator before that variable, because currently is matching for example with "pam_variable". This PR is fixing this.

Test: Run CodeViewerDemo.