### PR TITLE
Fix segfault in SubmissionTracker::SetVulkanLayerProducer

### DIFF
--- a/src/OrbitVulkanLayer/SubmissionTracker.h
+++ b/src/OrbitVulkanLayer/SubmissionTracker.h
@@ -143,11 +143,14 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
   // We will also register ourselves as CaptureStatusListener, in order to get notified on
   // capture finish (OnCaptureFinished). That's when we will reset the open query slots.
   void SetVulkanLayerProducer(VulkanLayerProducer* vulkan_layer_producer) {
+    // De-register from the previous VulkanLayerProducer.
+    if (vulkan_layer_producer_ != nullptr) {
+      vulkan_layer_producer_->SetCaptureStatusListener(nullptr);
+    }
     vulkan_layer_producer_ = vulkan_layer_producer;
+    // Register to the new VulkanLayerProducer.
     if (vulkan_layer_producer_ != nullptr) {
       vulkan_layer_producer_->SetCaptureStatusListener(this);
-    } else {
-      vulkan_layer_producer->SetCaptureStatusListener(nullptr);
     }
   }
 
@@ -974,7 +977,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
   [[nodiscard]] bool IsCapturing() {
     return vulkan_layer_producer_ != nullptr && vulkan_layer_producer_->IsCapturing();
   }
-  VulkanLayerProducer* vulkan_layer_producer_;
+  VulkanLayerProducer* vulkan_layer_producer_ = nullptr;
 };
 
 }  // namespace orbit_vulkan_layer

--- a/src/OrbitVulkanLayer/SubmissionTrackerTest.cpp
+++ b/src/OrbitVulkanLayer/SubmissionTrackerTest.cpp
@@ -112,6 +112,12 @@ class SubmissionTrackerTest : public ::testing::Test {
         .WillRepeatedly(Return(dummy_write_timestamp_function));
   }
 
+  void TearDown() override {
+    EXPECT_CALL(*producer_, SetCaptureStatusListener(nullptr)).Times(1);
+    tracker_.SetVulkanLayerProducer(nullptr);
+    producer_.reset();
+  }
+
   MockDispatchTable dispatch_table_;
   MockTimerQueryPool timer_query_pool_;
   MockDeviceManager device_manager_;

--- a/src/OrbitVulkanLayer/VulkanLayerController.h
+++ b/src/OrbitVulkanLayer/VulkanLayerController.h
@@ -637,8 +637,8 @@ class VulkanLayerController {
       //  CreateInstance.
       LOG("Taking down VulkanLayerProducer");
       vulkan_layer_producer_->TakeDown();
-      vulkan_layer_producer_.reset();
       submission_tracker_.SetVulkanLayerProducer(nullptr);
+      vulkan_layer_producer_.reset();
     }
   }
 


### PR DESCRIPTION
Bug: http://b/181234480 (Infiltrator reports segfault on VkDestroyInstance)

Test: Update unit tests. Run Infiltrator with the layer and verify that no crash
is reported.