### PR TITLE
Fix crash in vkCreateDevice.

### DIFF
--- a/src/OrbitVulkanLayer/DispatchTable.cpp
+++ b/src/OrbitVulkanLayer/DispatchTable.cpp
@@ -52,6 +52,9 @@ void DispatchTable::CreateInstanceDispatchTable(
         dispatch_table.CreateDebugReportCallbackEXT != nullptr &&
         dispatch_table.DestroyDebugReportCallbackEXT != nullptr &&
         dispatch_table.DebugReportMessageEXT != nullptr;
+
+    CHECK(!instance_dispatchable_object_to_instance_.contains(key));
+    instance_dispatchable_object_to_instance_[key] = instance;
   }
 }
 
@@ -67,6 +70,9 @@ void DispatchTable::RemoveInstanceDispatchTable(VkInstance instance) {
 
     CHECK(instance_supports_debug_report_extension_.contains(key));
     instance_supports_debug_report_extension_.erase(key);
+
+    CHECK(instance_dispatchable_object_to_instance_.contains(key));
+    instance_dispatchable_object_to_instance_.erase(key);
   }
 }
 

--- a/src/OrbitVulkanLayer/DispatchTable.h
+++ b/src/OrbitVulkanLayer/DispatchTable.h
@@ -533,6 +533,16 @@ class DispatchTable {
     }
   }
 
+  template <typename DispatchableType>
+  VkInstance GetInstance(DispatchableType instance_dispatchable_object) {
+    void* key = GetDispatchTableKey(instance_dispatchable_object);
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(instance_dispatchable_object_to_instance_.contains(key));
+      return instance_dispatchable_object_to_instance_.at(key);
+    }
+  }
+
  private:
   // Vulkan has the concept of "dispatchable types". Basically every Vulkan type whose objects can
   // be associated with a VkInstance or VkDevice are "dispatchable". As an example, both a device
@@ -552,10 +562,13 @@ class DispatchTable {
   // layer in the dispatch chain among our handling of functions we intercept.
   absl::flat_hash_map<void*, VkLayerInstanceDispatchTable> instance_dispatch_table_;
   absl::flat_hash_map<void*, VkLayerDispatchTable> device_dispatch_table_;
+
   absl::flat_hash_map<void*, bool> device_supports_debug_marker_extension_;
   absl::flat_hash_map<void*, bool> device_supports_debug_utils_extension_;
   absl::flat_hash_map<void*, bool> instance_supports_debug_utils_extension_;
   absl::flat_hash_map<void*, bool> instance_supports_debug_report_extension_;
+
+  absl::flat_hash_map<void*, VkInstance> instance_dispatchable_object_to_instance_;
 
   // Must protect access to dispatch tables above by mutex since the Vulkan
   // application may be calling these functions from different threads.

--- a/src/OrbitVulkanLayer/DispatchTableTest.cpp
+++ b/src/OrbitVulkanLayer/DispatchTableTest.cpp
@@ -21,6 +21,7 @@ TEST(DispatchTable, CanInitializeInstance) {
 
   DispatchTable dispatch_table = {};
   dispatch_table.CreateInstanceDispatchTable(instance, next_get_instance_proc_addr_function);
+  EXPECT_EQ(instance, dispatch_table.GetInstance(instance));
 }
 
 TEST(DispatchTable, CannotInitializeInstanceTwice) {

--- a/src/OrbitVulkanLayer/VulkanLayerController.h
+++ b/src/OrbitVulkanLayer/VulkanLayerController.h
@@ -686,8 +686,9 @@ class VulkanLayerController {
       PFN_vkGetInstanceProcAddr next_get_instance_proc_addr_function, const char* extension_name,
       std::vector<std::string>* output) {
     auto raw_enumerate_device_extension_properties_function =
+        // Pass a valid instance, as following the spec. we are not allowed to use nullptr here.
         absl::bit_cast<PFN_vkEnumerateDeviceExtensionProperties>(
-            next_get_instance_proc_addr_function(VK_NULL_HANDLE,
+            next_get_instance_proc_addr_function(dispatch_table_.GetInstance(physical_device),
                                                  "vkEnumerateDeviceExtensionProperties"));
     auto enumerate_device_extension_properties =
         [&raw_enumerate_device_extension_properties_function, physical_device](

--- a/src/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
+++ b/src/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
@@ -73,6 +73,7 @@ class MockDispatchTable {
   MOCK_METHOD(PFN_vkCreateDebugReportCallbackEXT, CreateDebugReportCallbackEXT, (VkInstance));
   MOCK_METHOD(PFN_vkDebugReportMessageEXT, DebugReportMessageEXT, (VkInstance));
   MOCK_METHOD(PFN_vkDestroyDebugReportCallbackEXT, DestroyDebugReportCallbackEXT, (VkInstance));
+  MOCK_METHOD(VkInstance, GetInstance, (VkPhysicalDevice), (const));
 };
 
 class MockDeviceManager {


### PR DESCRIPTION
In order to check if our required extensions are available,
we use our next layer's "vkGetInstanceProcAddr" to query for
the "vkEnumerateDeviceExtensionProperties". Unlike the "Instance"
version of the enumeration function, this can not be called with
nullptr as instance (see: https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetInstanceProcAddr.html).

This establishes a mapping from dispatchable object to instance
in the dispatch table (created on "vkCreateInstance").

Test: Run Infiltrator and Trata with the layer.