### PR TITLE
Metrics Capture & Preset, load & save

### DIFF
--- a/src/MetricsUploader/CMakeLists.txt
+++ b/src/MetricsUploader/CMakeLists.txt
@@ -17,7 +17,9 @@ target_include_directories(MetricsUploader PUBLIC ${CMAKE_CURRENT_LIST_DIR}/incl
 
 target_sources(MetricsUploader PUBLIC include/MetricsUploader/MetricsUploader.h
                                       include/MetricsUploader/Result.h
-                               PRIVATE Result.cpp)
+                                      include/MetricsUploader/ScopedMetric.h
+                               PRIVATE Result.cpp
+                                       ScopedMetric.cpp)
 
 if (WIN32)
 target_sources(MetricsUploader PRIVATE MetricsUploaderWindows.cpp)
@@ -63,16 +65,21 @@ add_library(MetricsUploaderSetupWithErrorClient SHARED TestClients/SetupWithErro
 target_link_libraries(MetricsUploaderSetupWithErrorClient PRIVATE MetricsUploader)
 set_target_properties(MetricsUploaderSetupWithErrorClient PROPERTIES FOLDER "MetricsUploaderTestClients")
 
+endif()
+
 # add tests
 add_executable(MetricsUploaderTests)
 
 target_compile_options(MetricsUploaderTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
+target_sources(MetricsUploaderTests PRIVATE ScopedMetricTest.cpp)
+
+if (WIN32)
 target_sources(MetricsUploaderTests PRIVATE MetricsUploaderWindowsTest.cpp)
+endif()
 
 target_link_libraries(MetricsUploaderTests PRIVATE MetricsUploader
                                                    GTest::GTest
                                                    GTest::Main)
 
 register_test(MetricsUploaderTests)
-endif()

--- a/src/MetricsUploader/MetricsUploaderWindowsTest.cpp
+++ b/src/MetricsUploader/MetricsUploaderWindowsTest.cpp
@@ -48,6 +48,10 @@ TEST(MetricsUploader, SendLogEvent) {
   result = metrics_uploader.value()->SendLogEvent(OrbitLogEvent_LogEventType_ORBIT_CAPTURE_DURATION,
                                                   std::chrono::milliseconds(100));
   EXPECT_TRUE(result);
+  result = metrics_uploader.value()->SendLogEvent(OrbitLogEvent_LogEventType_ORBIT_INITIALIZED,
+                                                  std::chrono::milliseconds(0),
+                                                  OrbitLogEvent_StatusCode_SUCCESS);
+  EXPECT_TRUE(result);
 }
 
 TEST(MetricsUploader, CreateTwoMetricsUploaders) {

--- a/src/MetricsUploader/Result.cpp
+++ b/src/MetricsUploader/Result.cpp
@@ -27,6 +27,10 @@ std::string GetErrorMessage(Result result) {
       return "Connection to metrics uploader wasn't closed";
     case kNoError:
       return "No errors";
+    case kUnknownStatusCode:
+      return "Unknown status code (metrics_uploader_client.dll does not know the status code)";
+    case kStatusCodeMismatch:
+      return "The sent status code cannot be matched to an internal status code";
     default:
       return "Unexpected error occured. See metrics_uploader_client log for details";
   }

--- a/src/MetricsUploader/ScopedMetric.cpp
+++ b/src/MetricsUploader/ScopedMetric.cpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "MetricsUploader/ScopedMetric.h"
+
+#include <chrono>
+
+#include "OrbitBase/Logging.h"
+
+namespace orbit_metrics_uploader {
+
+ScopedMetric::ScopedMetric(MetricsUploader* uploader, OrbitLogEvent_LogEventType log_event_type)
+    : uploader_(uploader),
+      log_event_type_(log_event_type),
+      start_(std::chrono::steady_clock::now()) {}
+
+ScopedMetric::~ScopedMetric() {
+  if (uploader_ == nullptr) return;
+
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - start_);
+  uploader_->SendLogEvent(log_event_type_, duration, status_code_);
+}
+
+ScopedMetric::ScopedMetric(ScopedMetric&& other) noexcept
+    : uploader_(other.uploader_),
+      log_event_type_(other.log_event_type_),
+      status_code_(other.status_code_),
+      start_(other.start_) {
+  other.uploader_ = nullptr;
+}
+
+ScopedMetric& ScopedMetric::operator=(ScopedMetric&& other) noexcept {
+  if (&other == this) {
+    return *this;
+  }
+
+  uploader_ = other.uploader_;
+  other.uploader_ = nullptr;
+  log_event_type_ = other.log_event_type_;
+  status_code_ = other.status_code_;
+  start_ = other.start_;
+
+  return *this;
+}
+
+}  // namespace orbit_metrics_uploader

--- a/src/MetricsUploader/ScopedMetricTest.cpp
+++ b/src/MetricsUploader/ScopedMetricTest.cpp
@@ -1,0 +1,90 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <thread>
+
+#include "MetricsUploader/MetricsUploader.h"
+#include "MetricsUploader/ScopedMetric.h"
+
+namespace orbit_metrics_uploader {
+
+using ::testing::_;
+using ::testing::Ge;
+
+class MockUploader : public MetricsUploader {
+ public:
+  MOCK_METHOD(bool, SendLogEvent, (OrbitLogEvent_LogEventType /*log_event_type*/), (override));
+  MOCK_METHOD(bool, SendLogEvent,
+              (OrbitLogEvent_LogEventType /*log_event_type*/,
+               std::chrono::milliseconds /*event_duration*/),
+              (override));
+  MOCK_METHOD(bool, SendLogEvent,
+              (OrbitLogEvent_LogEventType /*log_event_type*/,
+               std::chrono::milliseconds /*event_duration*/,
+               OrbitLogEvent_StatusCode /*status_code*/),
+              (override));
+};
+
+TEST(ScopedMetric, Constructor) {
+  { ScopedMetric metric{nullptr, OrbitLogEvent_LogEventType_ORBIT_INITIALIZED}; }
+
+  MockUploader uploader{};
+
+  EXPECT_CALL(uploader, SendLogEvent(OrbitLogEvent_LogEventType_ORBIT_INITIALIZED, _,
+                                     OrbitLogEvent_StatusCode_SUCCESS))
+      .Times(1);
+
+  { ScopedMetric metric{&uploader, OrbitLogEvent_LogEventType_ORBIT_INITIALIZED}; }
+}
+
+TEST(ScopedMetric, SetStatusCode) {
+  MockUploader uploader{};
+
+  EXPECT_CALL(uploader, SendLogEvent(OrbitLogEvent_LogEventType_ORBIT_INITIALIZED, _,
+                                     OrbitLogEvent_StatusCode_CANCELLED))
+      .Times(1);
+
+  {
+    ScopedMetric metric{&uploader, OrbitLogEvent_LogEventType_ORBIT_INITIALIZED};
+    metric.SetStatusCode(OrbitLogEvent_StatusCode_CANCELLED);
+  }
+}
+
+TEST(ScopedMetric, Sleep) {
+  MockUploader uploader{};
+
+  std::chrono::milliseconds sleep_time{1};
+
+  EXPECT_CALL(uploader, SendLogEvent(OrbitLogEvent_LogEventType_ORBIT_INITIALIZED, Ge(sleep_time),
+                                     OrbitLogEvent_StatusCode_SUCCESS))
+      .Times(1);
+
+  {
+    ScopedMetric metric{&uploader, OrbitLogEvent_LogEventType_ORBIT_INITIALIZED};
+    std::this_thread::sleep_for(sleep_time);
+  }
+}
+
+TEST(ScopedMetric, MoveAndSleep) {
+  MockUploader uploader{};
+
+  std::chrono::milliseconds sleep_time{1};
+
+  EXPECT_CALL(uploader, SendLogEvent(OrbitLogEvent_LogEventType_ORBIT_INITIALIZED,
+                                     Ge(sleep_time * 2), OrbitLogEvent_StatusCode_SUCCESS))
+      .Times(1);
+
+  {
+    ScopedMetric metric{&uploader, OrbitLogEvent_LogEventType_ORBIT_INITIALIZED};
+    std::this_thread::sleep_for(sleep_time);
+
+    [metric = std::move(metric), sleep_time]() { std::this_thread::sleep_for(sleep_time); }();
+  }
+}
+
+}  // namespace orbit_metrics_uploader

--- a/src/MetricsUploader/include/MetricsUploader/MetricsUploader.h
+++ b/src/MetricsUploader/include/MetricsUploader/MetricsUploader.h
@@ -45,11 +45,18 @@ class MetricsUploader {
   [[nodiscard]] static ErrorMessageOr<std::unique_ptr<MetricsUploader>> CreateMetricsUploader(
       std::string client_name = kMetricsUploaderClientDllName);
 
-  // Send log events to the server using metrics_uploader.
-  // Returns true on success and false otherwise.
-  virtual bool SendLogEvent(
-      OrbitLogEvent_LogEventType log_event_type,
-      std::chrono::milliseconds event_duration = std::chrono::milliseconds::zero()) = 0;
+  // Send a log event to the server using metrics_uploader. Returns true on success and false
+  // otherwise.
+  virtual bool SendLogEvent(OrbitLogEvent_LogEventType log_event_type) = 0;
+  // Send a log event with an associated duration using metrics_uploader. Returns true on success
+  // and false otherwise.
+  virtual bool SendLogEvent(OrbitLogEvent_LogEventType log_event_type,
+                            std::chrono::milliseconds event_duration) = 0;
+  // Send a log event with an associated duration and status code using metrics_uploader. Returns
+  // true on success and false otherwise.
+  virtual bool SendLogEvent(OrbitLogEvent_LogEventType log_event_type,
+                            std::chrono::milliseconds event_duration,
+                            OrbitLogEvent_StatusCode status_code) = 0;
 };
 
 [[nodiscard]] ErrorMessageOr<std::string> GenerateUUID();

--- a/src/MetricsUploader/include/MetricsUploader/Result.h
+++ b/src/MetricsUploader/include/MetricsUploader/Result.h
@@ -21,7 +21,9 @@ enum Result {
   kConnectionNotInitialized,
   kCannotUnmarshalLogEvent,
   kCannotCloseConnection,
-  kOtherError
+  kOtherError,
+  kUnknownStatusCode,
+  kStatusCodeMismatch
 };
 
 std::string GetErrorMessage(Result result);

--- a/src/MetricsUploader/include/MetricsUploader/ScopedMetric.h
+++ b/src/MetricsUploader/include/MetricsUploader/ScopedMetric.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef METRICS_UPLOADED_SCOPED_METRIC_H_
+#define METRICS_UPLOADED_SCOPED_METRIC_H_
+
+#include <chrono>
+
+#include "MetricsUploader/MetricsUploader.h"
+#include "orbit_log_event.pb.h"
+
+namespace orbit_metrics_uploader {
+
+class ScopedMetric {
+ public:
+  explicit ScopedMetric(MetricsUploader* uploader, OrbitLogEvent_LogEventType log_event_type);
+  ScopedMetric(const ScopedMetric& other) = delete;
+  ScopedMetric& operator=(const ScopedMetric& other) = delete;
+  ScopedMetric(ScopedMetric&& other) noexcept;
+  ScopedMetric& operator=(ScopedMetric&& other) noexcept;
+  ~ScopedMetric();
+
+  void SetStatusCode(OrbitLogEvent_StatusCode status_code) { status_code_ = status_code; }
+
+ private:
+  MetricsUploader* uploader_;
+  OrbitLogEvent_LogEventType log_event_type_;
+  OrbitLogEvent_StatusCode status_code_ = OrbitLogEvent_StatusCode_SUCCESS;
+  std::chrono::steady_clock::time_point start_;
+};
+
+}  // namespace orbit_metrics_uploader
+
+#endif  // METRICS_UPLOADED_SCOPED_METRIC_H_

--- a/src/MetricsUploader/proto/orbit_log_event.proto
+++ b/src/MetricsUploader/proto/orbit_log_event.proto
@@ -15,9 +15,16 @@ message OrbitLogEvent {
     ORBIT_INITIALIZED = 1;
     ORBIT_CAPTURE_DURATION = 2;
   }
+  enum StatusCode {
+    UNKNOWN_STATUS = 0;
+    SUCCESS = 1;
+    CANCELLED = 2;
+    INTERNAL_ERROR = 3;
+  }
   LogEventType log_event_type = 1;
 
   string orbit_version = 2;
   int64 event_duration_milliseconds = 3;
   string session_uuid = 4;
+  StatusCode status_code = 5;
 }

--- a/src/MetricsUploader/proto/orbit_log_event.proto
+++ b/src/MetricsUploader/proto/orbit_log_event.proto
@@ -17,6 +17,7 @@ message OrbitLogEvent {
     ORBIT_CAPTURE_SAVE = 3;
     ORBIT_CAPTURE_LOAD = 4;
     ORBIT_PRESET_SAVE = 5;
+    ORBIT_PRESET_LOAD = 6;
   }
   enum StatusCode {
     UNKNOWN_STATUS = 0;

--- a/src/MetricsUploader/proto/orbit_log_event.proto
+++ b/src/MetricsUploader/proto/orbit_log_event.proto
@@ -14,6 +14,7 @@ message OrbitLogEvent {
     UNKNOWN_EVENT_TYPE = 0;
     ORBIT_INITIALIZED = 1;
     ORBIT_CAPTURE_DURATION = 2;
+    ORBIT_CAPTURE_SAVE = 3;
   }
   enum StatusCode {
     UNKNOWN_STATUS = 0;

--- a/src/MetricsUploader/proto/orbit_log_event.proto
+++ b/src/MetricsUploader/proto/orbit_log_event.proto
@@ -15,6 +15,7 @@ message OrbitLogEvent {
     ORBIT_INITIALIZED = 1;
     ORBIT_CAPTURE_DURATION = 2;
     ORBIT_CAPTURE_SAVE = 3;
+    ORBIT_CAPTURE_LOAD = 4;
   }
   enum StatusCode {
     UNKNOWN_STATUS = 0;

--- a/src/MetricsUploader/proto/orbit_log_event.proto
+++ b/src/MetricsUploader/proto/orbit_log_event.proto
@@ -16,6 +16,7 @@ message OrbitLogEvent {
     ORBIT_CAPTURE_DURATION = 2;
     ORBIT_CAPTURE_SAVE = 3;
     ORBIT_CAPTURE_LOAD = 4;
+    ORBIT_PRESET_SAVE = 5;
   }
   enum StatusCode {
     UNKNOWN_STATUS = 0;

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -44,6 +44,7 @@
 #include "GrpcProtos/Constants.h"
 #include "ImGuiOrbit.h"
 #include "MainThreadExecutor.h"
+#include "MetricsUploader/ScopedMetric.h"
 #include "ModulesDataView.h"
 #include "OrbitBase/File.h"
 #include "OrbitBase/Future.h"
@@ -106,6 +107,8 @@ using orbit_grpc_protos::ModuleInfo;
 using orbit_grpc_protos::TracepointInfo;
 
 using orbit_base::Future;
+
+using orbit_metrics_uploader::ScopedMetric;
 
 namespace {
 PresetLoadState GetPresetLoadStateForProcess(
@@ -805,6 +808,8 @@ PresetLoadState OrbitApp::GetPresetLoadState(
 }
 
 ErrorMessageOr<void> OrbitApp::OnSaveCapture(const std::filesystem::path& file_name) {
+  ScopedMetric metric{metrics_uploader_,
+                      orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_CAPTURE_SAVE};
   const auto& key_to_string_map = string_manager_.GetKeyToStringMap();
 
   std::vector<std::shared_ptr<TimerChain>> chains = GetTimeGraph()->GetAllSerializableTimerChains();
@@ -813,8 +818,13 @@ ErrorMessageOr<void> OrbitApp::OnSaveCapture(const std::filesystem::path& file_n
   TimerInfosIterator timers_it_end(chains.end(), chains.end());
   const CaptureData& capture_data = GetCaptureData();
 
-  return capture_serializer::Save(file_name, capture_data, key_to_string_map, timers_it_begin,
-                                  timers_it_end);
+  auto save_result = capture_serializer::Save(file_name, capture_data, key_to_string_map,
+                                              timers_it_begin, timers_it_end);
+  if (save_result.has_error()) {
+    metric.SetStatusCode(orbit_metrics_uploader::OrbitLogEvent_StatusCode_INTERNAL_ERROR);
+  }
+
+  return save_result;
 }
 
 Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> OrbitApp::LoadCaptureFromFile(

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1482,6 +1482,8 @@ void OrbitApp::EnableFrameTracksFromHashes(const ModuleData* module,
 }
 
 void OrbitApp::LoadPreset(const std::shared_ptr<PresetFile>& preset_file) {
+  ScopedMetric metric{metrics_uploader_,
+                      orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_PRESET_LOAD};
   std::vector<orbit_base::Future<std::string>> load_module_results{};
   load_module_results.reserve(preset_file->preset_info().path_to_module().size());
 
@@ -1504,7 +1506,8 @@ void OrbitApp::LoadPreset(const std::shared_ptr<PresetFile>& preset_file) {
   // Then - when all modules are loaded or failed to load - we update the UI and potentially show an
   // error message.
   auto results = orbit_base::JoinFutures(absl::MakeConstSpan(load_module_results));
-  results.Then(main_thread_executor_, [this](std::vector<std::string> module_paths_not_found) {
+  results.Then(main_thread_executor_, [this, metric = std::move(metric)](
+                                          std::vector<std::string> module_paths_not_found) mutable {
     size_t tried_to_load_amount = module_paths_not_found.size();
     module_paths_not_found.erase(
         std::remove_if(module_paths_not_found.begin(), module_paths_not_found.end(),
@@ -1512,6 +1515,7 @@ void OrbitApp::LoadPreset(const std::shared_ptr<PresetFile>& preset_file) {
         module_paths_not_found.end());
 
     if (tried_to_load_amount == module_paths_not_found.size()) {
+      metric.SetStatusCode(orbit_metrics_uploader::OrbitLogEvent_StatusCode_INTERNAL_ERROR);
       SendErrorToUi("Preset loading failed",
                     absl::StrFormat("None of the modules of the preset were loaded:\n* %s",
                                     absl::StrJoin(module_paths_not_found, "\n* ")));

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -723,7 +723,13 @@ void OrbitApp::SetClipboard(const std::string& text) {
 }
 
 ErrorMessageOr<void> OrbitApp::OnSavePreset(const std::string& filename) {
-  OUTCOME_TRY(SavePreset(filename));
+  ScopedMetric metric{metrics_uploader_,
+                      orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_PRESET_SAVE};
+  auto save_result = SavePreset(filename);
+  if (save_result.has_error()) {
+    metric.SetStatusCode(orbit_metrics_uploader::OrbitLogEvent_StatusCode_INTERNAL_ERROR);
+    return save_result.error();
+  }
   ListPresets();
   Refresh(DataViewType::kPresets);
   return outcome::success();


### PR DESCRIPTION
This is redoing PR #1907.

It now introduces ScopedMetric and uses it for capture and preset loading and saving metrics. 
The comments from the last PR are also addressed.