### PR TITLE
Allocate memory on behave of a stopped process.

### DIFF
--- a/src/UserSpaceInstrumentation/AllocateInTracee.cpp
+++ b/src/UserSpaceInstrumentation/AllocateInTracee.cpp
@@ -45,8 +45,8 @@ using orbit_base::ReadFileToString;
     if (tokens.size() < 2 || tokens[1].size() != 4 || tokens[1][2] != 'x') continue;
     const std::vector<std::string> addresses = absl::StrSplit(tokens[0], '-');
     if (addresses.size() != 2) continue;
-    *addr_start = std::stoull(addresses[0], nullptr, 16);
-    *addr_end = std::stoull(addresses[1], nullptr, 16);
+    if (!absl::numbers_internal::safe_strtou64_base(addresses[0], addr_start, 16)) continue;
+    if (!absl::numbers_internal::safe_strtou64_base(addresses[1], addr_end, 16)) continue;
     return outcome::success();
   }
   return ErrorMessage(absl::StrFormat("Unable to locate executable memory area in pid: %d", pid));

--- a/src/UserSpaceInstrumentation/AllocateInTracee.cpp
+++ b/src/UserSpaceInstrumentation/AllocateInTracee.cpp
@@ -1,0 +1,186 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "AllocateInTracee.h"
+
+#include <absl/strings/numbers.h>
+#include <absl/strings/str_format.h>
+#include <absl/strings/str_split.h>
+#include <errno.h>
+#include <sys/mman.h>
+#include <sys/ptrace.h>
+#include <sys/wait.h>
+
+#include <string>
+#include <vector>
+
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/ReadFileToString.h"
+#include "OrbitBase/SafeStrerror.h"
+#include "UserSpaceInstrumentation/RegisterState.h"
+
+namespace orbit_user_space_instrumentation {
+
+namespace {
+
+using orbit_base::ReadFileToString;
+
+// Returns the address range of the first executable memory region. In every case I encountered this
+// was the second line in the `maps` file corresponding to the code of the process we look at.
+// However we don't really care. So keeping it general and just search for a executable region is
+// probalby helping stability.
+[[nodiscard]] ErrorMessageOr<void> GetFirstExecutableMemoryRegion(pid_t pid, uint64_t* addr_start,
+                                                                  uint64_t* addr_end) {
+  auto result_read_maps = ReadFileToString(absl::StrFormat("/proc/%d/maps", pid));
+  if (!result_read_maps) {
+    return result_read_maps.error();
+  }
+  const std::vector<std::string> lines =
+      absl::StrSplit(result_read_maps.value(), '\n', absl::SkipEmpty());
+  for (const auto& line : lines) {
+    const std::vector<std::string> tokens = absl::StrSplit(line, ' ', absl::SkipEmpty());
+    if (tokens.size() < 2 || tokens[1].size() != 4 || tokens[1][2] != 'x') continue;
+    const std::vector<std::string> addresses = absl::StrSplit(tokens[0], '-');
+    if (addresses.size() != 2) continue;
+    *addr_start = std::stoull(addresses[0], nullptr, 16);
+    *addr_end = std::stoull(addresses[1], nullptr, 16);
+    return outcome::success();
+  }
+  return ErrorMessage(absl::StrFormat("Unable to locate executable memory area in pid: %d", pid));
+}
+
+// Write `bytes` into memory of thread `tid` starting from `address_start`.
+// Note that we write multiples of eight bytes at once. If length of `bytes` is not a multiple of
+// eight the remaining bytes are zeroed out.
+void WriteBytesIntoTraceesMemory(pid_t tid, uint64_t address_start,
+                                 const std::vector<uint8_t>& bytes) {
+  size_t pos = 0;
+  do {
+    // Pack 8 byte for writing into `data`.
+    uint64_t data = 0;
+    for (size_t i = 0; i < 8 && pos + i < bytes.size(); i++) {
+      uint64_t t = bytes[pos + i];
+      data |= t << (8 * i);
+    }
+    CHECK(ptrace(PTRACE_POKEDATA, tid, address_start + pos, data) != -1);
+    pos += 8;
+  } while (pos < bytes.size());
+}
+
+// Execute a single syscall instruction in tracee `pid`. `syscall` identifies the
+[[nodiscard]] ErrorMessageOr<uint64_t> SyscallInTracee(pid_t pid, uint64_t syscall, uint64_t arg_0,
+                                                       uint64_t arg_1 = 0, uint64_t arg_2 = 0,
+                                                       uint64_t arg_3 = 0, uint64_t arg_4 = 0,
+                                                       uint64_t arg_5 = 0) {
+  RegisterState original_registers;
+  auto result_backup = original_registers.BackupRegisters(pid);
+  if (!result_backup) {
+    return ErrorMessage(absl::StrFormat("Failed to backup original register state: \"%s\"",
+                                        result_backup.error().message()));
+  }
+  if (original_registers.GetBitness() != RegisterState::Bitness::k64Bit) {
+    return ErrorMessage(
+        "Tried to invoke syscall in 32 bit process. This is currently not supported.");
+  }
+
+  // Get an executable memory region.
+  uint64_t address_start = 0;
+  uint64_t address_end = 0;
+  auto result_memory_region = GetFirstExecutableMemoryRegion(pid, &address_start, &address_end);
+  if (!result_memory_region) {
+    return ErrorMessage(absl::StrFormat("Failed to find executable memory region: \"%s\"",
+                                        result_memory_region.error().message()));
+  }
+
+  // Backup first 8 bytes.
+  const uint64_t backup_module_code = ptrace(PTRACE_PEEKDATA, pid, address_start, NULL);
+  if (errno) {
+    return ErrorMessage(absl::StrFormat("Failed to PTRACE_PEEKDATA with errno: %d \"%s\"", errno,
+                                        SafeStrerror(errno)));
+  }
+
+  // Write `syscall` into memory. Machine code is `0x0f05`.
+  WriteBytesIntoTraceesMemory(pid, address_start, std::vector<uint8_t>{0x0f, 0x05});
+
+  // Move instruction pointer to the `syscall` and fill registers with parameters.
+  RegisterState registers_for_syscall = original_registers;
+  registers_for_syscall.GetGeneralPurposeRegisters()->x86_64.rip = address_start;
+  registers_for_syscall.GetGeneralPurposeRegisters()->x86_64.rax = syscall;
+  // The six arguments to syscall go intp these registers: rdi, rsi, rdx, r10, r8, r9.
+  registers_for_syscall.GetGeneralPurposeRegisters()->x86_64.rdi = arg_0;
+  registers_for_syscall.GetGeneralPurposeRegisters()->x86_64.rsi = arg_1;
+  registers_for_syscall.GetGeneralPurposeRegisters()->x86_64.rdx = arg_2;
+  registers_for_syscall.GetGeneralPurposeRegisters()->x86_64.r10 = arg_3;
+  registers_for_syscall.GetGeneralPurposeRegisters()->x86_64.r8 = arg_4;
+  registers_for_syscall.GetGeneralPurposeRegisters()->x86_64.r9 = arg_5;
+  auto result_restore_registers = registers_for_syscall.RestoreRegisters();
+  if (!result_restore_registers) {
+    return ErrorMessage(absl::StrFormat("Failed to set registers with syscall parameters: \"%s\"",
+                                        result_restore_registers.error().message()));
+  }
+
+  // Single step to execute the syscall.
+  if (ptrace(PTRACE_SINGLESTEP, pid, 0, 0) != 0) {
+    return ErrorMessage("Failed to execute syscall with PTRACE_SINGLESTEP.");
+  }
+  int status = 0;
+  pid_t waited = waitpid(pid, &status, 0);
+  if (waited != pid || !WIFSTOPPED(status) || WSTOPSIG(status) != SIGTRAP) {
+    return ErrorMessage("Failed to wait for PTRACE_SINGLESTEP to execute.");
+  }
+
+  // Return value of syscalls is in rax.
+  RegisterState return_value;
+  auto result_backup_return_value = return_value.BackupRegisters(pid);
+  if (!result_backup_return_value) {
+    return ErrorMessage(absl::StrFormat("Failed to get registers with mmap result: \"%s\"",
+                                        result_backup_return_value.error().message()));
+  }
+  const uint64_t result = return_value.GetGeneralPurposeRegisters()->x86_64.rax;
+  // Syscalls return -4095, ..., -1 on failure.
+  if (result >= 0xfffffffffffff001) {
+    return ErrorMessage(absl::StrFormat("syscall failed. Return value: %u", result));
+  }
+
+  // Clean up memory and registers.
+  auto result_restore_memory = ptrace(PTRACE_POKEDATA, pid, address_start, backup_module_code);
+  if (result_restore_memory == -1) {
+    FATAL("Unable to restore memory state of tracee");
+  }
+  result_restore_registers = original_registers.RestoreRegisters();
+  if (!result_restore_registers) {
+    FATAL("Unable to restore register state of tracee : \"%s\"",
+          result_restore_registers.error().message());
+  }
+
+  return result;
+}
+
+}  // namespace
+
+[[nodiscard]] ErrorMessageOr<uint64_t> AllocateInTracee(pid_t pid, uint64_t size) {
+  // Syscall will equivalent to:
+  // `mmap(NULL, size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0)`
+  auto result_or_error =
+      SyscallInTracee(pid, 9, static_cast<uint64_t>(NULL), size, PROT_READ | PROT_WRITE | PROT_EXEC,
+                      MAP_PRIVATE | MAP_ANONYMOUS, static_cast<uint64_t>(-1), 0);
+  if (!result_or_error) {
+    ErrorMessage(
+        absl::StrFormat("Failed to do mmap syscall: \"%s\"", result_or_error.error().message()));
+  }
+  return result_or_error.value();
+}
+
+[[nodiscard]] ErrorMessageOr<void> FreeInTracee(pid_t pid, uint64_t address, uint64_t size) {
+  // Syscall will equivalent to:
+  // `munmap(address, size)`
+  auto result_or_error = SyscallInTracee(pid, 11, address, size);
+  if (!result_or_error) {
+    ErrorMessage(
+        absl::StrFormat("Failed to do munmap syscall: \"%s\"", result_or_error.error().message()));
+  }
+  return outcome::success();
+}
+
+}  // namespace orbit_user_space_instrumentation

--- a/src/UserSpaceInstrumentation/AllocateInTracee.cpp
+++ b/src/UserSpaceInstrumentation/AllocateInTracee.cpp
@@ -4,6 +4,7 @@
 
 #include "AllocateInTracee.h"
 
+#include <absl/base/casts.h>
 #include <absl/strings/numbers.h>
 #include <absl/strings/str_format.h>
 #include <absl/strings/str_split.h>
@@ -144,7 +145,7 @@ void WriteBytesIntoTraceesMemory(pid_t pid, uint64_t address_start,
   }
   const uint64_t result = return_value.GetGeneralPurposeRegisters()->x86_64.rax;
   // Syscalls return -4095, ..., -1 on failure.
-  const int64_t result_as_int = reinterpret_cast<uint64_t>(result);
+  const int64_t result_as_int = absl::bit_cast<uint64_t>(result);
   if (result_as_int > -4096 && result_as_int < 0) {
     return ErrorMessage(absl::StrFormat("syscall failed. Return value: %u", result));
   }

--- a/src/UserSpaceInstrumentation/AllocateInTracee.cpp
+++ b/src/UserSpaceInstrumentation/AllocateInTracee.cpp
@@ -68,7 +68,10 @@ void WriteBytesIntoTraceesMemory(pid_t tid, uint64_t address_start,
   } while (pos < bytes.size());
 }
 
-// Execute a single syscall instruction in tracee `pid`. `syscall` identifies the
+// Execute a single syscall instruction in tracee `pid`. `syscall` identifies the syscall as in this
+// list: https://github.com/torvalds/linux/blob/master/arch/x86/entry/syscalls/syscall_64.tbl
+// The parameters and the ordering is the same as in the c wrapper:
+// https://man7.org/linux/man-pages/dir_section_2.html
 [[nodiscard]] ErrorMessageOr<uint64_t> SyscallInTracee(pid_t pid, uint64_t syscall, uint64_t arg_0,
                                                        uint64_t arg_1 = 0, uint64_t arg_2 = 0,
                                                        uint64_t arg_3 = 0, uint64_t arg_4 = 0,
@@ -107,7 +110,8 @@ void WriteBytesIntoTraceesMemory(pid_t tid, uint64_t address_start,
   RegisterState registers_for_syscall = original_registers;
   registers_for_syscall.GetGeneralPurposeRegisters()->x86_64.rip = address_start;
   registers_for_syscall.GetGeneralPurposeRegisters()->x86_64.rax = syscall;
-  // The six arguments to syscall go intp these registers: rdi, rsi, rdx, r10, r8, r9.
+  // Register list for arguments can be found e.g. in the glibc wrapper:
+  // https://github.com/bminor/glibc/blob/master/sysdeps/unix/sysv/linux/x86_64/syscall.S#L30
   registers_for_syscall.GetGeneralPurposeRegisters()->x86_64.rdi = arg_0;
   registers_for_syscall.GetGeneralPurposeRegisters()->x86_64.rsi = arg_1;
   registers_for_syscall.GetGeneralPurposeRegisters()->x86_64.rdx = arg_2;

--- a/src/UserSpaceInstrumentation/AllocateInTracee.h
+++ b/src/UserSpaceInstrumentation/AllocateInTracee.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef USER_SPACE_INSTRUMENTATION_ALLOCATE_IN_TRACEe_H_
+#define USER_SPACE_INSTRUMENTATION_ALLOCATE_IN_TRACEe_H_
+
+#include <sys/types.h>
+
+#include <cstdint>
+
+#include "OrbitBase/Result.h"
+
+namespace orbit_user_space_instrumentation {
+
+// Allocate `size` bytes of memory in the tracee's address space using mmap. The memory will have
+// read, write, and execute permissions.
+// Assumes we are already attached to the tracee `pid` e.g. using `AttachAndStopProcess`.
+[[nodiscard]] ErrorMessageOr<uint64_t> AllocateInTracee(pid_t pid, uint64_t size);
+
+// Free address range previously allocated with AllocateInTracee using munmap.
+// Assumes we are already attached to the tracee `pid` e.g. using `AttachAndStopProcess`.
+[[nodiscard]] ErrorMessageOr<void> FreeInTracee(pid_t pid, uint64_t address, uint64_t size);
+
+}  // namespace orbit_user_space_instrumentation
+
+#endif  // USER_SPACE_INSTRUMENTATION_ALLOCATE_IN_TRACEe_H_

--- a/src/UserSpaceInstrumentation/AllocateInTracee.h
+++ b/src/UserSpaceInstrumentation/AllocateInTracee.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef USER_SPACE_INSTRUMENTATION_ALLOCATE_IN_TRACEe_H_
-#define USER_SPACE_INSTRUMENTATION_ALLOCATE_IN_TRACEe_H_
+#ifndef USER_SPACE_INSTRUMENTATION_ALLOCATE_IN_TRACEE_H_
+#define USER_SPACE_INSTRUMENTATION_ALLOCATE_IN_TRACEE_H_
 
 #include <sys/types.h>
 
@@ -24,4 +24,4 @@ namespace orbit_user_space_instrumentation {
 
 }  // namespace orbit_user_space_instrumentation
 
-#endif  // USER_SPACE_INSTRUMENTATION_ALLOCATE_IN_TRACEe_H_
+#endif  // USER_SPACE_INSTRUMENTATION_ALLOCATE_IN_TRACEE_H_

--- a/src/UserSpaceInstrumentation/AllocateInTraceeTest.cpp
+++ b/src/UserSpaceInstrumentation/AllocateInTraceeTest.cpp
@@ -18,7 +18,6 @@
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ReadFileToString.h"
-#include "OrbitBase/WriteStringToFile.h"
 #include "UserSpaceInstrumentation/Attach.h"
 
 namespace orbit_user_space_instrumentation {
@@ -26,10 +25,9 @@ namespace orbit_user_space_instrumentation {
 namespace {
 
 using orbit_base::ReadFileToString;
-using orbit_base::WriteStringToFile;
 
 // Returns true if `pid` has a readable, writeable, and executable memory segment at `address`.
-bool ProcessHasRwxMapAtAddress(pid_t pid, uint64_t address) {
+[[nodiscard]] bool ProcessHasRwxMapAtAddress(pid_t pid, uint64_t address) {
   auto result_read_maps = ReadFileToString(absl::StrFormat("/proc/%d/maps", pid));
   CHECK(result_read_maps.has_value());
   std::vector<std::string> lines =

--- a/src/UserSpaceInstrumentation/AllocateInTraceeTest.cpp
+++ b/src/UserSpaceInstrumentation/AllocateInTraceeTest.cpp
@@ -27,8 +27,8 @@ namespace {
 using orbit_base::ReadFileToString;
 using orbit_base::WriteStringToFile;
 
-// Let the parent trace us, write address of "go_on" into file, then enter a breakpoint. While the
-// child is stopped the parent can modify "go_on" in which case the child exits the endless loop
+// Let the parent trace us, write address of `go_on` into file, then enter a breakpoint. While the
+// child is stopped the parent can modify `go_on` in which case the child exits the endless loop
 // when continued.
 void Child(std::filesystem::path p) {
   CHECK(ptrace(PTRACE_TRACEME, 0, NULL, 0) != -1);
@@ -78,7 +78,7 @@ TEST(AllocateInTraceeTest, AllocateAndFree) {
     Child(p);
   }
 
-  // Wait for child to break and get the address of the "go_on" variable on the child side.
+  // Wait for child to break and get the address of the `go_on` variable on the child side.
   waitpid(pid, NULL, 0);
   auto result_go_on = ReadFileToString(p);
   CHECK(result_go_on);
@@ -101,7 +101,7 @@ TEST(AllocateInTraceeTest, AllocateAndFree) {
 
   EXPECT_FALSE(DoesAddressRangeExit(pid, result_allocate.value()));
 
-  // Alter "go_on" so that the child will exit, continue, and wait for the exit to happen.
+  // Alter `go_on` so that the child will exit, continue, and wait for the exit to happen.
   CHECK(ptrace(PTRACE_POKEDATA, pid, address_go_on, 54) != -1);
   CHECK(DetachAndContinueProcess(pid));
   waitpid(pid, NULL, 0);

--- a/src/UserSpaceInstrumentation/AllocateInTraceeTest.cpp
+++ b/src/UserSpaceInstrumentation/AllocateInTraceeTest.cpp
@@ -1,0 +1,110 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <absl/strings/str_format.h>
+#include <absl/strings/str_split.h>
+#include <gtest/gtest.h>
+#include <sys/ptrace.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "AllocateInTracee.h"
+#include "OrbitBase/ExecutablePath.h"
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/ReadFileToString.h"
+#include "OrbitBase/WriteStringToFile.h"
+#include "UserSpaceInstrumentation/Attach.h"
+
+namespace orbit_user_space_instrumentation {
+
+namespace {
+
+using orbit_base::ReadFileToString;
+using orbit_base::WriteStringToFile;
+
+// Let the parent trace us, write address of "go_on" into file, then enter a breakpoint. While the
+// child is stopped the parent can modify "go_on" in which case the child exits the endless loop
+// when continued.
+void Child(std::filesystem::path p) {
+  CHECK(ptrace(PTRACE_TRACEME, 0, NULL, 0) != -1);
+  volatile uint64_t go_on = 42;
+  std::string s = absl::StrFormat("%p", &go_on);
+  CHECK(WriteStringToFile(p, s));
+
+  __asm__ __volatile__("int3\n\t");
+
+  uint64_t data = 0;
+  while (go_on == 42) {
+    data++;
+  }
+  exit(0);
+}
+
+// Returns true if `tid` has a readable, writeable, and executable memory segment at `address`.
+bool DoesAddressRangeExit(pid_t tid, uint64_t address) {
+  auto result_read_maps = ReadFileToString(absl::StrFormat("/proc/%d/maps", tid));
+  CHECK(result_read_maps);
+  std::vector<std::string> lines =
+      absl::StrSplit(result_read_maps.value(), '\n', absl::SkipEmpty());
+  for (const auto& line : lines) {
+    std::vector<std::string> tokens = absl::StrSplit(line, ' ', absl::SkipEmpty());
+    if (tokens.size() < 2 || tokens[1].size() != 4 || tokens[1][0] != 'r' || tokens[1][1] != 'w' ||
+        tokens[1][2] != 'x') {
+      continue;
+    }
+    std::vector<std::string> addresses = absl::StrSplit(tokens[0], '-');
+    if (addresses.size() != 2) {
+      continue;
+    }
+    if (std::stoull(addresses[0], nullptr, 16) == address) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace
+
+TEST(AllocateInTraceeTest, AllocateAndFree) {
+  std::filesystem::path p = std::tmpnam(nullptr);
+  pid_t pid = fork();
+  CHECK(pid != -1);
+  if (pid == 0) {
+    Child(p);
+  }
+
+  // Wait for child to break and get the address of the "go_on" variable on the child side.
+  waitpid(pid, NULL, 0);
+  auto result_go_on = ReadFileToString(p);
+  CHECK(result_go_on);
+  const uint64_t address_go_on = std::stoull(result_go_on.value(), nullptr, 16);
+  
+  // Continue child by detaching.
+  CHECK(ptrace(PTRACE_DETACH, pid, nullptr, nullptr) != -1);
+
+  // Stop the process again using our tooling.
+  CHECK(AttachAndStopProcess(pid));
+
+  // Allocate a megabyte in the tracee.
+  uint64_t kMemorySize = 1024 * 1024;
+  auto result_allocate = AllocateInTracee(pid, kMemorySize);
+  CHECK(result_allocate);
+
+  EXPECT_TRUE(DoesAddressRangeExit(pid, result_allocate.value()));
+
+  CHECK(FreeInTracee(pid, result_allocate.value(), kMemorySize));
+
+  EXPECT_FALSE(DoesAddressRangeExit(pid, result_allocate.value()));
+
+  // Alter "go_on" so that the child will exit, continue, and wait for the exit to happen.
+  CHECK(ptrace(PTRACE_POKEDATA, pid, address_go_on, 54) != -1);
+  CHECK(DetachAndContinueProcess(pid));
+  waitpid(pid, NULL, 0);
+}
+
+}  // namespace orbit_user_space_instrumentation

--- a/src/UserSpaceInstrumentation/AllocateInTraceeTest.cpp
+++ b/src/UserSpaceInstrumentation/AllocateInTraceeTest.cpp
@@ -83,7 +83,7 @@ TEST(AllocateInTraceeTest, AllocateAndFree) {
   auto result_go_on = ReadFileToString(p);
   CHECK(result_go_on);
   const uint64_t address_go_on = std::stoull(result_go_on.value(), nullptr, 16);
-  
+
   // Continue child by detaching.
   CHECK(ptrace(PTRACE_DETACH, pid, nullptr, nullptr) != -1);
 

--- a/src/UserSpaceInstrumentation/CMakeLists.txt
+++ b/src/UserSpaceInstrumentation/CMakeLists.txt
@@ -47,7 +47,6 @@ target_sources(UserSpaceInstrumentationTests PRIVATE
         TestProcess.cpp)
 
 target_link_libraries(UserSpaceInstrumentationTests PRIVATE
-        ElfUtils
         LinuxTracing
         UserSpaceInstrumentation
         CONAN_PKG::abseil

--- a/src/UserSpaceInstrumentation/CMakeLists.txt
+++ b/src/UserSpaceInstrumentation/CMakeLists.txt
@@ -24,6 +24,8 @@ target_sources(UserSpaceInstrumentation PUBLIC
 
 target_sources(UserSpaceInstrumentation PRIVATE
         Attach.cpp
+        AllocateInTracee.cpp
+        AllocateInTracee.h
         RegisterState.cpp)
 
 target_link_libraries(UserSpaceInstrumentation PUBLIC
@@ -40,10 +42,12 @@ target_include_directories(UserSpaceInstrumentationTests PRIVATE
 
 target_sources(UserSpaceInstrumentationTests PRIVATE
         AttachTest.cpp
+        AllocateInTraceeTest.cpp
         RegisterStateTest.cpp
         TestProcess.cpp)
 
 target_link_libraries(UserSpaceInstrumentationTests PRIVATE
+        ElfUtils
         LinuxTracing
         UserSpaceInstrumentation
         CONAN_PKG::abseil


### PR DESCRIPTION
Override some executable memory with a syscall to mmap, single step
execute the syscall and restore the memory and register state.
Same for munmap.

Bug: http://b/181302591
Test: Unit test in PR.