### PR TITLE
Fix broken timers when command buffer begin timestamp is missing.

### DIFF
--- a/src/OrbitCaptureClient/GpuQueueSubmissionProcessor.cpp
+++ b/src/OrbitCaptureClient/GpuQueueSubmissionProcessor.cpp
@@ -159,6 +159,13 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuQueueSubmissionWit
   std::optional<GpuCommandBuffer> first_command_buffer =
       ExtractFirstCommandBuffer(gpu_queue_submission);
 
+  // The first command buffer acts as our reference needed to align GPU time based events in the
+  // CPU timeline. If we have no result for it -- which is the case if we started capturing within
+  // its execution -- we need to give up for this.
+  if (first_command_buffer.has_value() && first_command_buffer->begin_gpu_timestamp_ns() == 0) {
+    return result;
+  }
+
   std::vector<TimerInfo> command_buffer_timers =
       ProcessGpuCommandBuffers(gpu_queue_submission, matching_gpu_job, first_command_buffer,
                                timeline_key, get_string_hash_and_send_to_listener_if_necessary);

--- a/src/OrbitCaptureClient/GpuQueueSubmissionProcessor.cpp
+++ b/src/OrbitCaptureClient/GpuQueueSubmissionProcessor.cpp
@@ -161,7 +161,7 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuQueueSubmissionWit
 
   // The first command buffer acts as our reference needed to align GPU time based events in the
   // CPU timeline. If we have no result for it -- which is the case if we started capturing within
-  // its execution -- we need to give up for this.
+  // its execution -- we need to discard the submission.
   if (first_command_buffer.has_value() && first_command_buffer->begin_gpu_timestamp_ns() == 0) {
     return result;
   }

--- a/src/OrbitCaptureClient/GpuQueueSubmissionProcessor.cpp
+++ b/src/OrbitCaptureClient/GpuQueueSubmissionProcessor.cpp
@@ -160,8 +160,8 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuQueueSubmissionWit
       ExtractFirstCommandBuffer(gpu_queue_submission);
 
   // The first command buffer acts as our reference needed to align GPU time based events in the
-  // CPU timeline. If we have no result for it -- which is the case if we started capturing within
-  // its execution -- we need to discard the submission.
+  // CPU timeline. If we are missing the first timestamp of the submission -- which is the case if
+  // we started capturing within its execution -- we need to discard the submission.
   if (first_command_buffer.has_value() && first_command_buffer->begin_gpu_timestamp_ns() == 0) {
     return result;
   }


### PR DESCRIPTION
If we miss a command buffer's begin -- as we were not already
capturing -- we send "0" as special timestamp. However,
we use the first command buffer of a submission as a reference
to align the Gpu timestamps to our Cpu timeline. If this timestamp
was missing, we failed and resulted in timers with length of days.

This fixes this (for now) on the client site by discarding the
complete submission if the first command buffer has no begin
marker affected. Note that the "align" debug markers to the
begin of capture if their "begin" info is missing, remains working.

Follow up: We should re-consider sending incomplete submissions.

Test: Take a capture in the first actual frames of infiltrator.
Bug: http://b/181195585