### PR TITLE
Ensure to destroy the query pool when destroying the device.

### DIFF
--- a/src/OrbitVulkanLayer/DispatchTable.cpp
+++ b/src/OrbitVulkanLayer/DispatchTable.cpp
@@ -111,6 +111,8 @@ void DispatchTable::CreateDeviceDispatchTable(
 
   dispatch_table.CreateQueryPool = absl::bit_cast<PFN_vkCreateQueryPool>(
       next_get_device_proc_addr_function(device, "vkCreateQueryPool"));
+  dispatch_table.DestroyQueryPool = absl::bit_cast<PFN_vkDestroyQueryPool>(
+      next_get_device_proc_addr_function(device, "vkDestroyQueryPool"));
   dispatch_table.ResetQueryPoolEXT = absl::bit_cast<PFN_vkResetQueryPoolEXT>(
       next_get_device_proc_addr_function(device, "vkResetQueryPoolEXT"));
 

--- a/src/OrbitVulkanLayer/DispatchTable.h
+++ b/src/OrbitVulkanLayer/DispatchTable.h
@@ -232,6 +232,17 @@ class DispatchTable {
   }
 
   template <typename DispatchableType>
+  PFN_vkDestroyQueryPool DestroyQueryPool(DispatchableType dispatchable_object) {
+    void* key = GetDispatchTableKey(dispatchable_object);
+    {
+      absl::ReaderMutexLock lock(&mutex_);
+      CHECK(device_dispatch_table_.contains(key));
+      CHECK(device_dispatch_table_.at(key).DestroyQueryPool != nullptr);
+      return device_dispatch_table_.at(key).DestroyQueryPool;
+    }
+  }
+
+  template <typename DispatchableType>
   PFN_vkResetQueryPoolEXT ResetQueryPoolEXT(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {

--- a/src/OrbitVulkanLayer/TimerQueryPool.h
+++ b/src/OrbitVulkanLayer/TimerQueryPool.h
@@ -55,6 +55,19 @@ class TimerQueryPool {
     }
   }
 
+  // Destroys the VkQueryPool for the given device
+  void DestroyTimerQueryPool(VkDevice device) {
+    absl::WriterMutexLock lock(&mutex_);
+    CHECK(device_to_query_pool_.contains(device));
+    VkQueryPool query_pool = device_to_query_pool_.at(device);
+    device_to_query_slots_.erase(device);
+    device_to_potential_next_free_index_.erase(device);
+
+    dispatch_table_->DestroyQueryPool(device)(device, query_pool, nullptr);
+
+    device_to_query_pool_.erase(device);
+  }
+
   // Retrieves the query pool for a given device. Note that the pool must be initialized using
   // `InitializeTimerQueryPool` before.
   [[nodiscard]] VkQueryPool GetQueryPool(VkDevice device) {

--- a/src/OrbitVulkanLayer/VulkanLayerController.h
+++ b/src/OrbitVulkanLayer/VulkanLayerController.h
@@ -218,6 +218,7 @@ class VulkanLayerController {
     PFN_vkDestroyDevice destroy_device_function = dispatch_table_.DestroyDevice(device);
     CHECK(destroy_device_function != nullptr);
     device_manager_.UntrackLogicalDevice(device);
+    timer_query_pool_.DestroyTimerQueryPool(device);
     dispatch_table_.RemoveDeviceDispatchTable(device);
 
     destroy_device_function(device, allocator);

--- a/src/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
+++ b/src/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
@@ -93,6 +93,7 @@ class MockTimerQueryPool {
  public:
   explicit MockTimerQueryPool(MockDispatchTable* /*dispatch_table*/, uint32_t /*num_slots*/) {}
   MOCK_METHOD(void, InitializeTimerQueryPool, (VkDevice));
+  MOCK_METHOD(void, DestroyTimerQueryPool, (VkDevice));
 };
 
 struct Color {
@@ -718,6 +719,8 @@ TEST_F(VulkanLayerControllerTest, WillCleanUpOnDestroyDevice) {
   EXPECT_CALL(*dispatch_table, RemoveDeviceDispatchTable).Times(1);
   const MockDeviceManager* device_manager = controller_.device_manager();
   EXPECT_CALL(*device_manager, UntrackLogicalDevice).Times(1);
+  const MockTimerQueryPool* query_pool = controller_.timer_query_pool();
+  EXPECT_CALL(*query_pool, DestroyTimerQueryPool).Times(1);
 
   VkDevice device = {};
 


### PR DESCRIPTION
Test: Start and stop hello_ggp.
Bug: http://b/181097295