### PR TITLE
Use effective_capture_start_timestamp_ns_ for the initial ThreadNames

### DIFF
--- a/src/LinuxTracing/TracerThread.cpp
+++ b/src/LinuxTracing/TracerThread.cpp
@@ -598,11 +598,11 @@ void TracerThread::Run(const std::shared_ptr<std::atomic<bool>>& exit_requested)
   RetrieveInitialThreadNamesSystemWideAndNotifyListener(effective_capture_start_timestamp_ns_);
 
   // Get the initial association of tids to pids and pass it to switches_states_names_visitor_.
-  RetrieveTidToPidAssociationSystemWide();
+  RetrieveInitialTidToPidAssociationSystemWide();
 
   if (trace_thread_state_) {
     // Get the initial thread states and pass them to switches_states_names_visitor_.
-    RetrieveThreadStatesOfTarget();
+    RetrieveInitialThreadStatesOfTarget();
   }
 
   stats_.Reset();
@@ -1011,7 +1011,7 @@ void TracerThread::RetrieveInitialThreadNamesSystemWideAndNotifyListener(
   }
 }
 
-void TracerThread::RetrieveTidToPidAssociationSystemWide() {
+void TracerThread::RetrieveInitialTidToPidAssociationSystemWide() {
   for (pid_t pid : GetAllPids()) {
     for (pid_t tid : GetTidsOfProcess(pid)) {
       switches_states_names_visitor_->ProcessInitialTidToPidAssociation(tid, pid);
@@ -1019,7 +1019,7 @@ void TracerThread::RetrieveTidToPidAssociationSystemWide() {
   }
 }
 
-void TracerThread::RetrieveThreadStatesOfTarget() {
+void TracerThread::RetrieveInitialThreadStatesOfTarget() {
   for (pid_t tid : GetTidsOfProcess(target_pid_)) {
     uint64_t timestamp_ns = orbit_base::CaptureTimestampNs();
     std::optional<char> state = GetThreadState(tid);

--- a/src/LinuxTracing/TracerThread.h
+++ b/src/LinuxTracing/TracerThread.h
@@ -95,7 +95,7 @@ class TracerThread {
   std::vector<std::unique_ptr<PerfEvent>> ConsumeDeferredEvents();
   void ProcessDeferredEvents();
 
-  void RetrieveThreadNamesSystemWide();
+  void RetrieveInitialThreadNamesSystemWideAndNotifyListener(uint64_t initial_timestamp_ns);
   void RetrieveTidToPidAssociationSystemWide();
   void RetrieveThreadStatesOfTarget();
 

--- a/src/LinuxTracing/TracerThread.h
+++ b/src/LinuxTracing/TracerThread.h
@@ -96,8 +96,8 @@ class TracerThread {
   void ProcessDeferredEvents();
 
   void RetrieveInitialThreadNamesSystemWideAndNotifyListener(uint64_t initial_timestamp_ns);
-  void RetrieveTidToPidAssociationSystemWide();
-  void RetrieveThreadStatesOfTarget();
+  void RetrieveInitialTidToPidAssociationSystemWide();
+  void RetrieveInitialThreadStatesOfTarget();
 
   void PrintStatsIfTimerElapsed();
 


### PR DESCRIPTION
This makes sure that no event that follows the initial `ThreadName`s has a lower
timestamp. This was caught by `LinuxTracingIntegrationTest` failing, albeit very
rarely. Note that this is basically the same as what was already done, but
previously a new timestamp was taken at the beginning of
`RetrieveThreadNamesSystemWide`.