### PR TITLE
Draw sample counts per line in source code

### DIFF
--- a/src/CodeViewer/Dialog.cpp
+++ b/src/CodeViewer/Dialog.cpp
@@ -48,6 +48,10 @@ void Dialog::SetLineNumberMargins(FontSizeInEm left, FontSizeInEm right) {
 
 void Dialog::SetEnableLineNumbers(bool enabled) { ui_->viewer->SetEnableLineNumbers(enabled); }
 
+void Dialog::SetEnableSampleCounters(bool enabled) {
+  ui_->viewer->SetEnableSampleCounters(enabled);
+}
+
 void Dialog::GoToLineNumber(size_t line_number) {
   const QTextBlock block =
       ui_->viewer->document()->findBlockByLineNumber(static_cast<int>(line_number) - 1);

--- a/src/CodeViewer/Dialog.ui
+++ b/src/CodeViewer/Dialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>663</width>
+    <width>886</width>
     <height>616</height>
    </rect>
   </property>

--- a/src/CodeViewer/Viewer.cpp
+++ b/src/CodeViewer/Viewer.cpp
@@ -14,6 +14,7 @@
 #include <QPlainTextEdit>
 #include <QRect>
 #include <QResizeEvent>
+#include <QScrollBar>
 #include <QString>
 #include <QStringList>
 #include <QTextBlock>
@@ -28,30 +29,45 @@ static const QColor kTextEditBackgroundColor{30, 30, 30};
 static const QColor kTextEditForegroundColor{189, 189, 189};
 static const QColor kHeatmapColor{Qt::red};
 
-int DetermineLineNumberWidthInPixels(const QFontMetrics& font_metrics, int max_line_number) {
-  return font_metrics.horizontalAdvance(QString::number(max_line_number));
+static int StringWidthInPixels(const QFontMetrics& font_metrics, QString string) {
+  return font_metrics.horizontalAdvance(string);
 }
 
-Viewer::Viewer(QWidget* parent) : QPlainTextEdit(parent), left_sidebar_widget_{this} {
-  UpdateLeftSidebarWidth();
-  QObject::connect(this, &QPlainTextEdit::blockCountChanged, this, &Viewer::UpdateLeftSidebarWidth);
+int DetermineLineNumberWidthInPixels(const QFontMetrics& font_metrics, int max_line_number) {
+  return StringWidthInPixels(font_metrics, QString::number(max_line_number));
+}
+
+Viewer::Viewer(QWidget* parent)
+    : QPlainTextEdit(parent), left_sidebar_widget_{this}, right_sidebar_widget_{this} {
+  UpdateSidebarsWidth();
+  QObject::connect(this, &QPlainTextEdit::blockCountChanged, this, &Viewer::UpdateSidebarsWidth);
 
   QObject::connect(&left_sidebar_widget_, &PlaceHolderWidget::PaintEventTriggered, this,
                    &Viewer::DrawLineNumbers);
 
-  const auto update_viewport_area = [&](const QRect& rect, int dy) {
-    const auto update_caused_by_scroll = [](int dy) { return dy != 0; };
+  QObject::connect(&right_sidebar_widget_, &PlaceHolderWidget::PaintEventTriggered, this,
+                   &Viewer::DrawSampleCounters);
 
-    if (update_caused_by_scroll(dy)) {
+  const auto update_viewport_area = [&](const QRect& rect, int dy) {
+    bool update_caused_by_scroll = (dy != 0);
+    if (update_caused_by_scroll) {
       left_sidebar_widget_.scroll(0, dy);
+      right_sidebar_widget_.scroll(0, dy);
     } else {
       QRect line_number_rect = rect;
+      QRect samples_info_rect = rect;
 
-      // We keep the (vertical) y-coordinates and adjust the horizontal x-coordinates for the line
-      // number area.
+      // We keep the (vertical) y-coordinates and adjust the horizontal x-coordinates for the each
+      // bar's area
       line_number_rect.setLeft(0);
       line_number_rect.setWidth(left_sidebar_widget_.sizeHint().width());
       left_sidebar_widget_.update(line_number_rect);
+
+      int total_width_without_scroll_bar = width() - verticalScrollBar()->width();
+      int right_sidebar_width = right_sidebar_widget_.sizeHint().width();
+      samples_info_rect.setLeft(total_width_without_scroll_bar - right_sidebar_width);
+      samples_info_rect.setWidth(right_sidebar_width);
+      right_sidebar_widget_.update(line_number_rect);
     }
   };
   QObject::connect(this, &QPlainTextEdit::updateRequest, this, update_viewport_area);
@@ -72,15 +88,14 @@ Viewer::Viewer(QWidget* parent) : QPlainTextEdit(parent), left_sidebar_widget_{t
 void Viewer::resizeEvent(QResizeEvent* ev) {
   QPlainTextEdit::resizeEvent(ev);
 
-  auto left_sidebar = contentsRect();
-  left_sidebar.setWidth(left_sidebar_widget_.sizeHint().width());
-  left_sidebar_widget_.setGeometry(left_sidebar);
+  UpdateSidebarPositions();
 }
 
 void Viewer::wheelEvent(QWheelEvent* ev) {
   QPlainTextEdit::wheelEvent(ev);
 
-  UpdateLeftSidebarWidth();
+  UpdateSidebarsWidth();
+  UpdateSidebarPositions();
 }
 
 void Viewer::DrawLineNumbers(QPaintEvent* event) {
@@ -128,47 +143,144 @@ void Viewer::DrawLineNumbers(QPaintEvent* event) {
   }
 }
 
-void Viewer::UpdateLeftSidebarWidth() {
+// For example, from a value = 0.5, we want to print "50.00 %"
+static QString DoubleToPercentageString(double v) {
+  v = std::clamp(v, 0., 1.);
+  return QString{"%1 %"}.arg(v * 100., 0, 'f', 2);
+}
+
+void Viewer::DrawSampleCounters(QPaintEvent* event) {
+  if (!sample_counters_enabled_) return;
+  QPainter painter{&right_sidebar_widget_};
+  painter.setFont(font());
+  painter.fillRect(event->rect(), kLineNumberBackgroundColor);
+
+  const auto top_of = [&](const QTextBlock& block) {
+    return static_cast<int>(
+        std::round(blockBoundingGeometry(block).translated(contentOffset()).top()));
+  };
+  const auto bottom_of = [&](const QTextBlock& block) {
+    return top_of(block) + static_cast<int>(std::round(blockBoundingRect(block).height()));
+  };
+
+  const int left = left_margin_.ToPixels(fontMetrics());
+  for (auto block = firstVisibleBlock(); block.isValid() && top_of(block) <= event->rect().bottom();
+       block = block.next()) {
+    if (!block.isVisible() || bottom_of(block) < event->rect().top()) continue;
+
+    auto maybe_num_samples_in_lines = code_report_->GetNumSamplesAtLine(block.blockNumber() + 1);
+    if (!maybe_num_samples_in_lines.has_value()) continue;
+
+    const uint32_t num_samples_in_line = maybe_num_samples_in_lines.value();
+    // Draw sample counter
+    int current = left;
+    {
+      const QRect bounding_box{current, top_of(block), WidthSampleCounterColumn(),
+                               fontMetrics().height()};
+      painter.setPen(kLineNumberForegroundColor);
+      painter.drawText(bounding_box, Qt::AlignRight, QString::number(num_samples_in_line));
+      current += WidthSampleCounterColumn() + WidthMarginBetweenColumns();
+    }
+
+    // Draw function percentage
+    {
+      const QRect bounding_box{current, top_of(block), WidthPercentageColumn(),
+                               fontMetrics().height()};
+      painter.setPen(kLineNumberForegroundColor);
+
+      painter.drawText(bounding_box, Qt::AlignRight,
+                       QString(DoubleToPercentageString(static_cast<double>(num_samples_in_line) /
+                                                        code_report_->GetNumSamplesInFunction())));
+      current += WidthPercentageColumn() + WidthMarginBetweenColumns();
+    }
+
+    // Draw total percentage
+    {
+      const QRect bounding_box{current, top_of(block), WidthPercentageColumn(),
+                               fontMetrics().height()};
+      painter.setPen(kLineNumberForegroundColor);
+      painter.drawText(bounding_box, Qt::AlignRight,
+                       QString(DoubleToPercentageString(static_cast<double>(num_samples_in_line) /
+                                                        code_report_->GetNumSamples())));
+      current += WidthPercentageColumn() + right_margin_.ToPixels(fontMetrics());
+    }
+  }
+}
+
+void Viewer::UpdateSidebarsWidth() {
   const int number_of_lines = blockCount();
 
-  int overall_width_px = heatmap_bar_width_.ToPixels(fontMetrics());
+  int overall_left_width_px = heatmap_bar_width_.ToPixels(fontMetrics());
 
   if (line_numbers_enabled_) {
-    overall_width_px += left_margin_.ToPixels(fontMetrics());
-    overall_width_px += DetermineLineNumberWidthInPixels(fontMetrics(), number_of_lines);
-    overall_width_px += right_margin_.ToPixels(fontMetrics());
+    overall_left_width_px += left_margin_.ToPixels(fontMetrics());
+    overall_left_width_px += DetermineLineNumberWidthInPixels(fontMetrics(), number_of_lines);
+    overall_left_width_px += right_margin_.ToPixels(fontMetrics());
   }
+  int overall_right_width_px = 0;
+  if (sample_counters_enabled_) {
+    overall_right_width_px += left_margin_.ToPixels(fontMetrics());
+    // Samples column
+    overall_right_width_px += WidthSampleCounterColumn();
+    overall_right_width_px += WidthMarginBetweenColumns();
+    // Function Column
+    overall_right_width_px += WidthPercentageColumn();
+    overall_right_width_px += WidthMarginBetweenColumns();
+    // Total Column
+    overall_right_width_px += WidthPercentageColumn();
+    overall_right_width_px += right_margin_.ToPixels(fontMetrics());
+  }
+  setViewportMargins(QMargins{overall_left_width_px, 0, overall_right_width_px, 0});
+  left_sidebar_widget_.SetSizeHint({overall_left_width_px, 0});
+  right_sidebar_widget_.SetSizeHint({overall_right_width_px, 0});
+}
 
-  setViewportMargins(QMargins{overall_width_px, 0, 0, 0});
-  left_sidebar_widget_.SetSizeHint({overall_width_px, 0});
+void Viewer::UpdateSidebarPositions() {
+  auto left_sidebar = contentsRect();
+  int total_width = left_sidebar.width();
+  left_sidebar.setWidth(left_sidebar_widget_.sizeHint().width());
+  left_sidebar_widget_.setGeometry(left_sidebar);
+
+  auto right_sidebar = contentsRect();
+  int right_sidebar_width = right_sidebar_widget_.sizeHint().width();
+  right_sidebar.moveLeft(total_width - verticalScrollBar()->width() - right_sidebar_width);
+  right_sidebar.setWidth(right_sidebar_width);
+  right_sidebar_widget_.setGeometry(right_sidebar);
 }
 
 void Viewer::SetEnableLineNumbers(bool is_enabled) {
   if (line_numbers_enabled_ == is_enabled) return;
 
   line_numbers_enabled_ = is_enabled;
-  UpdateLeftSidebarWidth();
+  UpdateSidebarsWidth();
+}
+
+void Viewer::SetEnableSampleCounters(bool is_enabled) {
+  if (sample_counters_enabled_ == is_enabled) return;
+
+  sample_counters_enabled_ = is_enabled;
+  UpdateSidebarsWidth();
 }
 
 void Viewer::SetLineNumberMargins(FontSizeInEm left, FontSizeInEm right) {
   left_margin_ = left;
   right_margin_ = right;
-  UpdateLeftSidebarWidth();
+  UpdateSidebarsWidth();
 }
 
 void Viewer::SetHeatmapBarWidth(FontSizeInEm width) {
   heatmap_bar_width_ = width;
-  UpdateLeftSidebarWidth();
+  UpdateSidebarsWidth();
 }
 
 void Viewer::SetHeatmapSource(const CodeReport* code_report) {
   code_report_ = code_report;
-  UpdateLeftSidebarWidth();
+  UpdateSidebarsWidth();
 }
 
 void Viewer::ClearHeatmapSource() {
   code_report_ = nullptr;
-  UpdateLeftSidebarWidth();
+  UpdateSidebarsWidth();
 }
 
 void Viewer::SetHighlightCurrentLine(bool enabled) {
@@ -198,6 +310,22 @@ void Viewer::HighlightCurrentLine() {
   selection.cursor.clearSelection();
 
   setExtraSelections({selection});
+}
+
+int Viewer::WidthPercentageColumn() const {
+  const QString kWidestPercentage = "100.00 %";
+  return StringWidthInPixels(fontMetrics(), kWidestPercentage);
+}
+
+int Viewer::WidthSampleCounterColumn() const {
+  const QString kSampleColumnTitle = "Samples";
+  return StringWidthInPixels(fontMetrics(),
+                             kSampleColumnTitle);  // TODO: titles might have smaller font
+}
+
+int Viewer::WidthMarginBetweenColumns() const {
+  const QString kTwoSpaces = "  ";
+  return StringWidthInPixels(fontMetrics(), kTwoSpaces);
 }
 
 }  // namespace orbit_code_viewer

--- a/src/CodeViewer/include/CodeViewer/Dialog.h
+++ b/src/CodeViewer/include/CodeViewer/Dialog.h
@@ -55,6 +55,8 @@ class Dialog : public QDialog {
   void ClearHeatmap();
 
   void SetEnableLineNumbers(bool enabled);
+  void SetEnableSampleCounters(bool enabled);
+
   void SetLineNumberMargins(FontSizeInEm left, FontSizeInEm right);
 
   void GoToLineNumber(size_t line_number);

--- a/src/CodeViewer/include/CodeViewer/Viewer.h
+++ b/src/CodeViewer/include/CodeViewer/Viewer.h
@@ -64,16 +64,19 @@ class Viewer : public QPlainTextEdit {
  private:
   void resizeEvent(QResizeEvent* ev) override;
   void wheelEvent(QWheelEvent* ev) override;
+  void DrawTopWidget(QPaintEvent* event);
   void DrawLineNumbers(QPaintEvent* event);
   void DrawSampleCounters(QPaintEvent* event);
 
-  void UpdateSidebarsWidth();
-  void UpdateSidebarPositions();
+  void UpdateBarsSize();
+  void UpdateBarsPosition();
   void HighlightCurrentLine();
   [[nodiscard]] int WidthPercentageColumn() const;
   [[nodiscard]] int WidthSampleCounterColumn() const;
   [[nodiscard]] int WidthMarginBetweenColumns() const;
+  [[nodiscard]] int TopWidgetHeight() const;
 
+  PlaceHolderWidget top_bar_widget_;
   PlaceHolderWidget left_sidebar_widget_;
   PlaceHolderWidget right_sidebar_widget_;
   bool line_numbers_enabled_ = false;

--- a/src/CodeViewer/include/CodeViewer/Viewer.h
+++ b/src/CodeViewer/include/CodeViewer/Viewer.h
@@ -50,6 +50,7 @@ class Viewer : public QPlainTextEdit {
   explicit Viewer(QWidget* parent);
 
   void SetEnableLineNumbers(bool enabled);
+  void SetEnableSampleCounters(bool is_enabled);
   void SetLineNumberMargins(FontSizeInEm left, FontSizeInEm right);
 
   void SetHeatmapBarWidth(FontSizeInEm width);
@@ -64,11 +65,19 @@ class Viewer : public QPlainTextEdit {
   void resizeEvent(QResizeEvent* ev) override;
   void wheelEvent(QWheelEvent* ev) override;
   void DrawLineNumbers(QPaintEvent* event);
-  void UpdateLeftSidebarWidth();
+  void DrawSampleCounters(QPaintEvent* event);
+
+  void UpdateSidebarsWidth();
+  void UpdateSidebarPositions();
   void HighlightCurrentLine();
+  [[nodiscard]] int WidthPercentageColumn() const;
+  [[nodiscard]] int WidthSampleCounterColumn() const;
+  [[nodiscard]] int WidthMarginBetweenColumns() const;
 
   PlaceHolderWidget left_sidebar_widget_;
+  PlaceHolderWidget right_sidebar_widget_;
   bool line_numbers_enabled_ = false;
+  bool sample_counters_enabled_ = false;
   FontSizeInEm left_margin_ = FontSizeInEm{0.3f};
   FontSizeInEm right_margin_ = FontSizeInEm{0.3f};
 

--- a/src/CodeViewerDemo/main.cpp
+++ b/src/CodeViewerDemo/main.cpp
@@ -37,6 +37,7 @@ int main(int argc, char* argv[]) {
   dialog.SetHeatmap(orbit_code_viewer::FontSizeInEm{1.2f}, &code_report);
 
   dialog.SetEnableLineNumbers(true);
+  dialog.SetEnableSampleCounters(true);
   dialog.GoToLineNumber(10);
   dialog.SetHighlightCurrentLine(true);
 

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -139,6 +139,7 @@ void OpenDisassembly(const std::string& assembly, const DisassemblyReport& repor
   orbit_code_viewer::Dialog dialog{};
   dialog.setWindowTitle("Orbit Disassembly");
   dialog.SetEnableLineNumbers(true);
+  dialog.SetEnableSampleCounters(true);
 
   auto syntax_highlighter = std::make_unique<orbit_syntax_highlighter::X86Assembly>();
   dialog.SetSourceCode(QString::fromStdString(assembly), std::move(syntax_highlighter));
@@ -1388,6 +1389,7 @@ void OrbitMainWindow::ShowSourceCode(const std::filesystem::path& file_path, siz
 
   if (maybe_code_report.has_value()) {
     CHECK(maybe_code_report->get() != nullptr);
+    code_viewer_dialog.SetEnableSampleCounters(true);
     code_viewer_dialog.SetHeatmap(kHeatmapAreaWidth, maybe_code_report->get());
   }
 


### PR DESCRIPTION
We want to include sample counts and percentages when showing source code
and disassembly view. This PR aims that. For that, we are creating a widget to 
be in the right, where we show that information. Also, we introduced a widget 
in the top with column titles.

This PR includes:

 - A right widget with information about sample counts 

 - A top-widget where we draw titles for every column ("Samples",
 "Function" & "Total").

 - Making the pop-up window wider

Related to http://b/159809330 from Source Code feature.

To test: Simply run CodeViewerDemo.

Screenshots with sample info, only to show how it looks:
Before:
<img width="500" alt="dialog before" src="https://user-images.githubusercontent.com/8610429/109789518-b69d1180-7c10-11eb-8a8f-50687b7a65b5.png">

After:
<img width="499" alt="source code" src="https://user-images.githubusercontent.com/8610429/109680968-4abd9900-7b7d-11eb-98c2-659cf5321cc1.png">