### PR TITLE
Integrate SourcePathsMapping into source code loading

### DIFF
--- a/src/OrbitQt/CMakeLists.txt
+++ b/src/OrbitQt/CMakeLists.txt
@@ -105,6 +105,7 @@ target_link_libraries(
           OrbitSshQt
           OrbitVersion
           QtUtils
+          SourcePathsMapping
           Qt5::Widgets
           Qt5::Core
           SyntaxHighlighter

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -178,6 +178,8 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
 
   void UpdateCaptureToolbarIconOpacity();
 
+  std::optional<QString> LoadSourceCode(const std::filesystem::path& file_path);
+
  private:
   std::shared_ptr<MainThreadExecutor> main_thread_executor_;
   std::unique_ptr<OrbitApp> app_;


### PR DESCRIPTION
This adds the source paths mapping step to the show source code process.

When the path found in debuginfo is not found locally, the source paths
mappings will be loaded and tried to apply. If no mapping succeeds the
user will be prompted to choose the file via the file open dialog.