### PR TITLE
Integrate Sample statistics in SourceCodeView

### DIFF
--- a/src/OrbitGl/MainWindowInterface.h
+++ b/src/OrbitGl/MainWindowInterface.h
@@ -8,7 +8,10 @@
 #include <stdint.h>
 
 #include <filesystem>
+#include <optional>
 #include <string_view>
+
+#include "CodeReport.h"
 
 namespace orbit_gl {
 
@@ -20,7 +23,8 @@ namespace orbit_gl {
 class MainWindowInterface {
  public:
   virtual void ShowTooltip(std::string_view message) = 0;
-  virtual void ShowSourceCode(const std::filesystem::path& file_path, size_t line_number) = 0;
+  virtual void ShowSourceCode(const std::filesystem::path& file_path, size_t line_number,
+                              std::optional<std::unique_ptr<CodeReport>> code_report) = 0;
 
   virtual ~MainWindowInterface() = default;
 };

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1370,7 +1370,8 @@ std::optional<QString> OrbitMainWindow::LoadSourceCode(const std::filesystem::pa
   return std::nullopt;
 }
 
-void OrbitMainWindow::ShowSourceCode(const std::filesystem::path& file_path, size_t line_number) {
+void OrbitMainWindow::ShowSourceCode(const std::filesystem::path& file_path, size_t line_number,
+                                     std::optional<std::unique_ptr<CodeReport>> maybe_code_report) {
   orbit_code_viewer::Dialog code_viewer_dialog{this};
 
   code_viewer_dialog.SetEnableLineNumbers(true);
@@ -1383,6 +1384,12 @@ void OrbitMainWindow::ShowSourceCode(const std::filesystem::path& file_path, siz
 
   auto syntax_highlighter = std::make_unique<orbit_syntax_highlighter::Cpp>();
   code_viewer_dialog.SetSourceCode(source_code.value(), std::move(syntax_highlighter));
+  constexpr orbit_code_viewer::FontSizeInEm kHeatmapAreaWidth{1.3f};
+
+  if (maybe_code_report.has_value()) {
+    CHECK(maybe_code_report->get() != nullptr);
+    code_viewer_dialog.SetHeatmap(kHeatmapAreaWidth, maybe_code_report->get());
+  }
 
   code_viewer_dialog.GoToLineNumber(line_number);
   code_viewer_dialog.exec();

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -99,7 +99,8 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   [[nodiscard]] orbit_qt::TargetConfiguration ClearTargetConfiguration();
 
   void ShowTooltip(std::string_view message) override;
-  void ShowSourceCode(const std::filesystem::path& file_path, size_t line_number) override;
+  void ShowSourceCode(const std::filesystem::path& file_path, size_t line_number,
+                      std::optional<std::unique_ptr<CodeReport>> maybe_code_report) override;
 
  protected:
   void closeEvent(QCloseEvent* event) override;


### PR DESCRIPTION
The integrates sample statistics for the source code view. This has already been there for the disassembly view for a very long time. Now it's also coming for the source code view.

For now the sample data will only fill the heatmap on the left. Pablo is working on bringing actual numbers to a right side bar.