### PR TITLE
Make CodeReport::NumSamplesAtLine return an optional

### DIFF
--- a/src/CodeViewer/Viewer.cpp
+++ b/src/CodeViewer/Viewer.cpp
@@ -104,10 +104,12 @@ void Viewer::DrawLineNumbers(QPaintEvent* event) {
       const QRect heatmap_rect{0, top_of(block), heatmap_bar_width_.ToPixels(fontMetrics()),
                                fontMetrics().height()};
 
-      const size_t num_samples_in_line = code_report_->GetNumSamplesAtLine(block.blockNumber() + 1);
-      const size_t num_samples_in_function = code_report_->GetNumSamplesInFunction();
-      const float intensity =
-          std::clamp(static_cast<float>(num_samples_in_line) / num_samples_in_function, 0.0f, 1.0f);
+      const uint32_t num_samples_in_line =
+          code_report_->GetNumSamplesAtLine(block.blockNumber() + 1).value_or(0);
+      const uint32_t num_samples_in_function = code_report_->GetNumSamplesInFunction();
+      const float intensity = std::clamp(
+          static_cast<float>(num_samples_in_line) / static_cast<float>(num_samples_in_function),
+          0.0f, 1.0f);
       const auto scaled_intensity = static_cast<int>(std::sqrt(intensity) * 255);
       QColor color = kHeatmapColor;
       color.setAlpha(scaled_intensity);

--- a/src/CodeViewerDemo/main.cpp
+++ b/src/CodeViewerDemo/main.cpp
@@ -14,7 +14,9 @@ class DummyCodeReport : public CodeReport {
 
   [[nodiscard]] uint32_t GetNumSamplesInFunction() const override { return num_samples_; }
   [[nodiscard]] uint32_t GetNumSamples() const override { return num_samples_; }
-  [[nodiscard]] uint32_t GetNumSamplesAtLine(size_t line) const override { return line; }
+  [[nodiscard]] std::optional<uint32_t> GetNumSamplesAtLine(size_t line) const override {
+    return line;
+  }
 
  private:
   uint32_t num_samples_ = 0;

--- a/src/OrbitGl/CodeReport.h
+++ b/src/OrbitGl/CodeReport.h
@@ -8,12 +8,16 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <optional>
+
 class CodeReport {
  public:
   virtual ~CodeReport() = default;
   [[nodiscard]] virtual uint32_t GetNumSamplesInFunction() const = 0;
   [[nodiscard]] virtual uint32_t GetNumSamples() const = 0;
-  [[nodiscard]] virtual uint32_t GetNumSamplesAtLine(size_t line) const = 0;
+
+  // A returned empty optional means there is no data available for this line.
+  [[nodiscard]] virtual std::optional<uint32_t> GetNumSamplesAtLine(size_t line) const = 0;
 };
 
 #endif  // ORBIT_GL_CODE_REPORT_H_

--- a/src/OrbitGl/DisassemblyReport.cpp
+++ b/src/OrbitGl/DisassemblyReport.cpp
@@ -4,12 +4,15 @@
 
 #include "DisassemblyReport.h"
 
-uint32_t DisassemblyReport::GetNumSamplesAtLine(size_t line) const {
-  if (function_count_ == 0) {
-    return 0;
-  }
+std::optional<uint32_t> DisassemblyReport::GetNumSamplesAtLine(size_t line) const {
   uint64_t address = disasm_.GetAddressAtLine(line);
   if (address == 0) {
+    // We return an empty optional when there is no data available for the current line.
+    // That allows the user to differentiate between a line without samples and a line without data.
+    return std::nullopt;
+  }
+
+  if (function_count_ == 0) {
     return 0;
   }
 

--- a/src/OrbitGl/DisassemblyReport.h
+++ b/src/OrbitGl/DisassemblyReport.h
@@ -29,7 +29,7 @@ class DisassemblyReport : public CodeReport {
 
   [[nodiscard]] uint32_t GetNumSamplesInFunction() const override { return function_count_; }
   [[nodiscard]] uint32_t GetNumSamples() const override { return samples_count_; }
-  [[nodiscard]] uint32_t GetNumSamplesAtLine(size_t line) const override;
+  [[nodiscard]] std::optional<uint32_t> GetNumSamplesAtLine(size_t line) const override;
 
  private:
   const Disassembler disasm_;

--- a/src/OrbitGl/SourceCodeReport.cpp
+++ b/src/OrbitGl/SourceCodeReport.cpp
@@ -4,6 +4,8 @@
 
 #include "SourceCodeReport.h"
 
+#include <optional>
+
 #include "OrbitBase/Logging.h"
 #include "OrbitClientData/PostProcessedSamplingData.h"
 
@@ -42,8 +44,8 @@ SourceCodeReport::SourceCodeReport(std::string_view source_file,
   }
 }
 
-uint32_t SourceCodeReport::GetNumSamplesAtLine(size_t line) const {
-  if (!number_of_samples_per_line_.contains(line)) return 0;
+std::optional<uint32_t> SourceCodeReport::GetNumSamplesAtLine(size_t line) const {
+  if (!number_of_samples_per_line_.contains(line)) return std::nullopt;
   return number_of_samples_per_line_.at(line);
 }
 

--- a/src/OrbitGl/SourceCodeReport.h
+++ b/src/OrbitGl/SourceCodeReport.h
@@ -33,7 +33,7 @@ class SourceCodeReport : public CodeReport {
     return total_samples_in_function_;
   }
   [[nodiscard]] uint32_t GetNumSamples() const override { return total_samples_in_capture_; }
-  [[nodiscard]] uint32_t GetNumSamplesAtLine(size_t line) const override;
+  [[nodiscard]] std::optional<uint32_t> GetNumSamplesAtLine(size_t line) const override;
 
  private:
   absl::flat_hash_map<uint32_t, uint32_t> number_of_samples_per_line_;


### PR DESCRIPTION
This way we can differentiate between lines without any samples and
lines without any data.

The latter occurs in source code files. We always show the whole file
but there is only data available for a single function (might change in
the future). Hence we need a way to indicate to the user whether data is
available or not.