### PR TITLE
Integrate Source Paths Mapping Editor

### DIFF
--- a/src/OrbitQt/CMakeLists.txt
+++ b/src/OrbitQt/CMakeLists.txt
@@ -97,6 +97,7 @@ target_include_directories(OrbitQt PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(
   OrbitQt
   PRIVATE CodeViewer
+          ConfigWidgets
           MetricsUploader
           OrbitAccessibility
           OrbitCore

--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -4,11 +4,14 @@
 
 #include "CaptureOptionsDialog.h"
 
+#include <QAbstractButton>
 #include <QDialog>
 #include <QDialogButtonBox>
 #include <QWidget>
 #include <QtGui/QValidator>
 
+#include "ConfigWidgets/SourcePathsMappingDialog.h"
+#include "SourcePathsMapping/MappingManager.h"
 #include "ui_CaptureOptionsDialog.h"
 
 namespace orbit_qt {
@@ -21,6 +24,9 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
   QObject::connect(ui_->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
 
   ui_->localMarkerDepthLineEdit->setValidator(&uint64_validator_);
+
+  QObject::connect(ui_->openSourcePathsMappingDialog, &QAbstractButton::clicked, this,
+                   &CaptureOptionsDialog::ShowSourcePathsMappingEditor);
 }
 
 bool CaptureOptionsDialog::GetCollectThreadStates() const {
@@ -56,6 +62,18 @@ uint64_t CaptureOptionsDialog::GetMaxLocalMarkerDepthPerCommandBuffer() const {
 void CaptureOptionsDialog::ResetLocalMarkerDepthLineEdit() {
   if (ui_->localMarkerDepthLineEdit->text().isEmpty()) {
     ui_->localMarkerDepthLineEdit->setText(QString::number(0));
+  }
+}
+
+void CaptureOptionsDialog::ShowSourcePathsMappingEditor() {
+  orbit_source_paths_mapping::MappingManager manager{};
+
+  orbit_config_widgets::SourcePathsMappingDialog dialog{this};
+  dialog.SetMappings(manager.GetMappings());
+  const int result_code = dialog.exec();
+
+  if (result_code == QDialog::Accepted) {
+    manager.SetMappings(dialog.GetMappings());
   }
 }
 

--- a/src/OrbitQt/CaptureOptionsDialog.h
+++ b/src/OrbitQt/CaptureOptionsDialog.h
@@ -48,6 +48,7 @@ class CaptureOptionsDialog : public QDialog {
 
  public slots:
   void ResetLocalMarkerDepthLineEdit();
+  void ShowSourcePathsMappingEditor();
 
  private:
   std::unique_ptr<Ui::CaptureOptionsDialog> ui_;

--- a/src/OrbitQt/CaptureOptionsDialog.ui
+++ b/src/OrbitQt/CaptureOptionsDialog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>480</width>
-    <height>260</height>
+    <height>379</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -102,18 +102,72 @@ Setting the value to &quot;0&quot; will disable Vulkan debug marker tracking.</s
       </widget>
      </item>
      <item>
-      <spacer name="verticalSpacer">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>These settings above will only apply starting from your next capture.</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="verticalSpacer_2">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Minimum</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>20</height>
+        </size>
        </property>
       </spacer>
      </item>
      <item>
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>These settings will only apply starting from your next capture.</string>
+      <widget class="QGroupBox" name="groupBox_3">
+       <property name="title">
+        <string>Source Paths Mappings</string>
        </property>
+       <layout class="QGridLayout" name="gridLayout_2">
+        <item row="0" column="0">
+         <widget class="QPushButton" name="openSourcePathsMappingDialog">
+          <property name="toolTip">
+           <string>Source Paths Mappings are applied to source paths from debug information if the given paths are not found locally. It is needed for showing source code inside of Orbit.</string>
+          </property>
+          <property name="text">
+           <string>Open Source Paths Mappings Editor</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
       </widget>
+     </item>
+     <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+      </spacer>
      </item>
     </layout>
    </item>


### PR DESCRIPTION
The PRs adds the source paths mappings editor to Orbit. It allows users to change source paths mappings which have been
automatically infered and it also allows them to add new ones, remove old ones, etc.

The editor can be launched from the capture options dialog:
![CaptureOptions](https://user-images.githubusercontent.com/43133967/109674123-f0b9d500-7b76-11eb-851c-fd4e4ca1e2b3.PNG)

The editor looks like this:
![SourcePathsMappings](https://user-images.githubusercontent.com/43133967/109674125-f1526b80-7b76-11eb-8c03-9437ffcdb6c4.PNG)
