### PR TITLE
Factor out methods to access memory in tracee.

### DIFF
--- a/src/UserSpaceInstrumentation/AccessTraceesMemory.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemory.cpp
@@ -14,8 +14,8 @@
 #include <string>
 
 #include "OrbitBase/Logging.h"
-#include "OrbitBase/SafeStrerror.h"
 #include "OrbitBase/ReadFileToString.h"
+#include "OrbitBase/SafeStrerror.h"
 
 namespace orbit_user_space_instrumentation {
 
@@ -43,7 +43,7 @@ using orbit_base::ReadFileToString;
   do {
     // Pack 8 byte for writing into `data`.
     uint64_t data = 0;
-    std::memcpy(&data, bytes.data() + pos , sizeof(uint64_t));
+    std::memcpy(&data, bytes.data() + pos, sizeof(uint64_t));
     if (ptrace(PTRACE_POKEDATA, pid, address_start + pos, data) == -1) {
       ErrorMessage(absl::StrFormat("Unable to write data into tracees (pid: %d) memory.", pid));
     }

--- a/src/UserSpaceInstrumentation/AccessTraceesMemory.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemory.cpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "AccessTraceesMemory.h"
+
+#include <absl/strings/numbers.h>
+#include <absl/strings/str_format.h>
+#include <absl/strings/str_split.h>
+#include <sys/ptrace.h>
+
+#include <cerrno>
+#include <cstring>
+#include <string>
+
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/SafeStrerror.h"
+#include "OrbitBase/ReadFileToString.h"
+
+namespace orbit_user_space_instrumentation {
+
+using orbit_base::ReadFileToString;
+
+[[nodiscard]] ErrorMessageOr<void> ReadTraceesMemory(pid_t pid, uint64_t address_start,
+                                                     uint64_t length, std::vector<uint8_t>* bytes) {
+  // Round up length to next multiple of eight.
+  length = ((length + 7) / 8) * 8;
+  bytes->resize(length);
+  for (size_t i = 0; i < length / 8; i++) {
+    const uint64_t data = ptrace(PTRACE_PEEKDATA, pid, address_start + i * 8, NULL);
+    if (errno) {
+      return ErrorMessage(absl::StrFormat("Failed to PTRACE_PEEKDATA with errno %d: \"%s\"", errno,
+                                          SafeStrerror(errno)));
+    }
+    std::memcpy(bytes->data() + (i * sizeof(uint64_t)), &data, 8);
+  }
+  return outcome::success();
+}
+
+[[nodiscard]] ErrorMessageOr<void> WriteTraceesMemory(pid_t pid, uint64_t address_start,
+                                                      const std::vector<uint8_t>& bytes) {
+  size_t pos = 0;
+  do {
+    // Pack 8 byte for writing into `data`.
+    uint64_t data = 0;
+    for (size_t i = 0; i < sizeof(data) && pos + i < bytes.size(); i++) {
+      uint64_t t = bytes[pos + i];
+      data |= t << (8 * i);
+    }
+    if (ptrace(PTRACE_POKEDATA, pid, address_start + pos, data) == -1) {
+      ErrorMessage(absl::StrFormat("Unable to write data into tracees (pid: %d) memory.", pid));
+    }
+    pos += 8;
+  } while (pos < bytes.size());
+  return outcome::success();
+}
+
+[[nodiscard]] ErrorMessageOr<void> GetFirstExecutableMemoryRegion(pid_t pid, uint64_t* addr_start,
+                                                                  uint64_t* addr_end) {
+  auto result_read_maps = ReadFileToString(absl::StrFormat("/proc/%d/maps", pid));
+  if (result_read_maps.has_error()) {
+    return result_read_maps.error();
+  }
+  const std::vector<std::string> lines =
+      absl::StrSplit(result_read_maps.value(), '\n', absl::SkipEmpty());
+  for (const auto& line : lines) {
+    const std::vector<std::string> tokens = absl::StrSplit(line, ' ', absl::SkipEmpty());
+    if (tokens.size() < 2 || tokens[1].size() != 4 || tokens[1][2] != 'x') continue;
+    const std::vector<std::string> addresses = absl::StrSplit(tokens[0], '-');
+    if (addresses.size() != 2) continue;
+    if (!absl::numbers_internal::safe_strtou64_base(addresses[0], addr_start, 16)) continue;
+    if (!absl::numbers_internal::safe_strtou64_base(addresses[1], addr_end, 16)) continue;
+    return outcome::success();
+  }
+  return ErrorMessage(absl::StrFormat("Unable to locate executable memory area in pid: %d", pid));
+}
+
+}  // namespace orbit_user_space_instrumentation

--- a/src/UserSpaceInstrumentation/AccessTraceesMemory.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemory.cpp
@@ -4,6 +4,7 @@
 
 #include "AccessTraceesMemory.h"
 
+#include <absl/base/casts.h>
 #include <absl/strings/numbers.h>
 #include <absl/strings/str_format.h>
 #include <absl/strings/str_split.h>
@@ -21,31 +22,33 @@ namespace orbit_user_space_instrumentation {
 
 using orbit_base::ReadFileToString;
 
-[[nodiscard]] ErrorMessageOr<void> ReadTraceesMemory(pid_t pid, uint64_t address_start,
-                                                     uint64_t length, std::vector<uint8_t>* bytes) {
+[[nodiscard]] ErrorMessageOr<std::vector<uint8_t>> ReadTraceesMemory(pid_t pid,
+                                                                     uint64_t address_start,
+                                                                     uint64_t length) {
   // Round up length to next multiple of eight.
   length = ((length + 7) / 8) * 8;
-  bytes->resize(length);
+  std::vector<uint8_t> bytes(length);
   for (size_t i = 0; i < length / 8; i++) {
     const uint64_t data = ptrace(PTRACE_PEEKDATA, pid, address_start + i * 8, NULL);
     if (errno) {
-      return ErrorMessage(absl::StrFormat("Failed to PTRACE_PEEKDATA with errno %d: \"%s\"", errno,
-                                          SafeStrerror(errno)));
+      return ErrorMessage(
+          absl::StrFormat("Failed to PTRACE_PEEKDATA for pid: %d with errno %d: \"%s\"", pid, errno,
+                          SafeStrerror(errno)));
     }
-    std::memcpy(bytes->data() + (i * sizeof(uint64_t)), &data, 8);
+    std::memcpy(bytes.data() + (i * sizeof(uint64_t)), &data, 8);
   }
-  return outcome::success();
+  return bytes;
 }
 
 [[nodiscard]] ErrorMessageOr<void> WriteTraceesMemory(pid_t pid, uint64_t address_start,
                                                       const std::vector<uint8_t>& bytes) {
   size_t pos = 0;
   do {
-    // Pack 8 byte for writing into `data`.
+    // Pack 8 bytes for writing into `data`.
     uint64_t data = 0;
     std::memcpy(&data, bytes.data() + pos, sizeof(uint64_t));
     if (ptrace(PTRACE_POKEDATA, pid, address_start + pos, data) == -1) {
-      ErrorMessage(absl::StrFormat("Unable to write data into tracees (pid: %d) memory.", pid));
+      ErrorMessage(absl::StrFormat("Failed to PTRACE_POKEDATA for pid: %d.", pid));
     }
     pos += sizeof(uint64_t);
   } while (pos < bytes.size());

--- a/src/UserSpaceInstrumentation/AccessTraceesMemory.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemory.cpp
@@ -43,14 +43,11 @@ using orbit_base::ReadFileToString;
   do {
     // Pack 8 byte for writing into `data`.
     uint64_t data = 0;
-    for (size_t i = 0; i < sizeof(data) && pos + i < bytes.size(); i++) {
-      uint64_t t = bytes[pos + i];
-      data |= t << (8 * i);
-    }
+    std::memcpy(&data, bytes.data() + pos , sizeof(uint64_t));
     if (ptrace(PTRACE_POKEDATA, pid, address_start + pos, data) == -1) {
       ErrorMessage(absl::StrFormat("Unable to write data into tracees (pid: %d) memory.", pid));
     }
-    pos += 8;
+    pos += sizeof(uint64_t);
   } while (pos < bytes.size());
   return outcome::success();
 }

--- a/src/UserSpaceInstrumentation/AccessTraceesMemory.h
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemory.h
@@ -32,8 +32,8 @@ namespace orbit_user_space_instrumentation {
 // was the second line in the `maps` file corresponding to the code of the process we look at.
 // However we don't really care. So keeping it general and just searching for an executable region
 // is probably helping stability.
-[[nodiscard]] ErrorMessageOr<void> GetFirstExecutableMemoryRegion(pid_t pid, uint64_t* addr_start,
-                                                                  uint64_t* addr_end);
+using AddressRange = std::pair<uint64_t, uint64_t>;
+[[nodiscard]] ErrorMessageOr<AddressRange> GetFirstExecutableMemoryRegion(pid_t pid);
 
 }  // namespace orbit_user_space_instrumentation
 

--- a/src/UserSpaceInstrumentation/AccessTraceesMemory.h
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemory.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef USER_SPACE_INSTRUMENTATION_WRITE_INTO_TRACEES_MEMORY_H_
+#define USER_SPACE_INSTRUMENTATION_WRITE_INTO_TRACEES_MEMORY_H_
+
+#include <sys/types.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "OrbitBase/Result.h"
+
+namespace orbit_user_space_instrumentation {
+
+// Read `length` bytes from process `pid` starting at `address_start`. `length` will be rounded up
+// to a multiple of eight. The data is returned in `bytes`.
+// Assumes we are already attached to the tracee `pid` e.g. using `AttachAndStopProcess`.
+[[nodiscard]] ErrorMessageOr<void> ReadTraceesMemory(pid_t pid, uint64_t address_start,
+                                                     uint64_t length, std::vector<uint8_t>* bytes);
+
+// Write `bytes` into memory of process `pid` starting from `address_start`.
+// Note that we write multiples of eight bytes at once. If length of `bytes` is not a multiple of
+// eight the remaining bytes are zeroed out.
+// Assumes we are already attached to the tracee `pid` e.g. using `AttachAndStopProcess`.
+[[nodiscard]] ErrorMessageOr<void> WriteTraceesMemory(pid_t pid, uint64_t address_start,
+                                                      const std::vector<uint8_t>& bytes);
+
+// Returns the address range of the first executable memory region. In every case I encountered this
+// was the second line in the `maps` file corresponding to the code of the process we look at.
+// However we don't really care. So keeping it general and just searching for an executable region
+// is probably helping stability.
+[[nodiscard]] ErrorMessageOr<void> GetFirstExecutableMemoryRegion(pid_t pid, uint64_t* addr_start,
+                                                                  uint64_t* addr_end);
+
+}  // namespace orbit_user_space_instrumentation
+
+#endif  // USER_SPACE_INSTRUMENTATION_WRITE_INTO_TRACEES_MEMORY_H_

--- a/src/UserSpaceInstrumentation/AccessTraceesMemory.h
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemory.h
@@ -15,10 +15,11 @@
 namespace orbit_user_space_instrumentation {
 
 // Read `length` bytes from process `pid` starting at `address_start`. `length` will be rounded up
-// to a multiple of eight. The data is returned in `bytes`.
+// to a multiple of eight.
 // Assumes we are already attached to the tracee `pid` e.g. using `AttachAndStopProcess`.
-[[nodiscard]] ErrorMessageOr<void> ReadTraceesMemory(pid_t pid, uint64_t address_start,
-                                                     uint64_t length, std::vector<uint8_t>* bytes);
+[[nodiscard]] ErrorMessageOr<std::vector<uint8_t>> ReadTraceesMemory(pid_t pid,
+                                                                     uint64_t address_start,
+                                                                     uint64_t length);
 
 // Write `bytes` into memory of process `pid` starting from `address_start`.
 // Note that we write multiples of eight bytes at once. If length of `bytes` is not a multiple of

--- a/src/UserSpaceInstrumentation/AccessTraceesMemory.h
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemory.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef USER_SPACE_INSTRUMENTATION_WRITE_INTO_TRACEES_MEMORY_H_
-#define USER_SPACE_INSTRUMENTATION_WRITE_INTO_TRACEES_MEMORY_H_
+#ifndef USER_SPACE_INSTRUMENTATION_ACCESS_TRACEES_MEMORY_H_
+#define USER_SPACE_INSTRUMENTATION_ACCESS_TRACEES_MEMORY_H_
 
 #include <sys/types.h>
 
@@ -36,4 +36,4 @@ namespace orbit_user_space_instrumentation {
 
 }  // namespace orbit_user_space_instrumentation
 
-#endif  // USER_SPACE_INSTRUMENTATION_WRITE_INTO_TRACEES_MEMORY_H_
+#endif  // USER_SPACE_INSTRUMENTATION_ACCESS_TRACEES_MEMORY_H_

--- a/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
@@ -19,7 +19,7 @@ namespace orbit_user_space_instrumentation {
 
 namespace {}  // namespace
 
-TEST(AccessTraceesMemory, ReadWriteRestore) {
+TEST(AccessTraceesMemoryTest, ReadWriteRestore) {
   pid_t pid = fork();
   CHECK(pid != -1);
   if (pid == 0) {

--- a/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
@@ -8,6 +8,10 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
+#include <algorithm>
+#include <functional>
+#include <iterator>
+#include <random>
 #include <vector>
 
 #include "AccessTraceesMemory.h"
@@ -39,7 +43,12 @@ TEST(AccessTraceesMemoryTest, ReadWriteRestore) {
   std::vector<uint8_t> original;
   CHECK(ReadTraceesMemory(pid, address_start, address_end - address_start, &original).has_value());
 
-  std::vector<uint8_t> new_data(original.size(), 42);
+  std::vector<uint8_t> new_data(original.size());
+  std::mt19937 engine{std::random_device()()};
+  std::uniform_int_distribution<uint8_t> distribution{0x00, 0xff};
+  std::generate(std::begin(new_data), std::end(new_data),
+                [&distribution, &engine]() { return distribution(engine); });
+
   CHECK(WriteTraceesMemory(pid, address_start, new_data).has_value());
 
   std::vector<uint8_t> read_back;

--- a/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+#include <stdint.h>
+#include <sys/ptrace.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include <vector>
+
+#include "AccessTraceesMemory.h"
+#include "OrbitBase/Logging.h"
+#include "UserSpaceInstrumentation/Attach.h"
+#include "UserSpaceInstrumentation/RegisterState.h"
+
+namespace orbit_user_space_instrumentation {
+
+namespace {}  // namespace
+
+TEST(AccessTraceesMemory, ReadWriteRestore) {
+  pid_t pid = fork();
+  CHECK(pid != -1);
+  if (pid == 0) {
+    // Child just runs an endless loop.
+    while (true) {
+    }
+  }
+
+  // Stop the child process using our tooling.
+  CHECK(AttachAndStopProcess(pid).has_value());
+
+  uint64_t address_start = 0;
+  uint64_t address_end = 0;
+  auto result_memory_region = GetFirstExecutableMemoryRegion(pid, &address_start, &address_end);
+  CHECK(result_memory_region.has_value());
+
+  std::vector<uint8_t> original;
+  CHECK(ReadTraceesMemory(pid, address_start, address_end - address_start, &original).has_value());
+
+  std::vector<uint8_t> new_data(original.size(), 42);
+  CHECK(WriteTraceesMemory(pid, address_start, new_data).has_value());
+
+  std::vector<uint8_t> read_back;
+  CHECK(ReadTraceesMemory(pid, address_start, address_end - address_start, &read_back).has_value());
+
+  EXPECT_EQ(new_data, read_back);
+
+  CHECK(WriteTraceesMemory(pid, address_start, original).has_value());
+
+  // Detach and end child.
+  CHECK(DetachAndContinueProcess(pid).has_value());
+  kill(pid, SIGKILL);
+  waitpid(pid, NULL, 0);
+}
+
+}  // namespace orbit_user_space_instrumentation

--- a/src/UserSpaceInstrumentation/AllocateInTracee.cpp
+++ b/src/UserSpaceInstrumentation/AllocateInTracee.cpp
@@ -46,26 +46,25 @@ namespace {
   }
 
   // Get an executable memory region.
-  uint64_t address_start = 0;
-  uint64_t address_end = 0;
-  auto result_memory_region = GetFirstExecutableMemoryRegion(pid, &address_start, &address_end);
+  auto result_memory_region = GetFirstExecutableMemoryRegion(pid);
   if (result_memory_region.has_error()) {
     return ErrorMessage(absl::StrFormat("Failed to find executable memory region: \"%s\"",
                                         result_memory_region.error().message()));
   }
+  const uint64_t address_start = result_memory_region.value().first;
 
   // Backup first 8 bytes.
   auto result_backup_code = ReadTraceesMemory(pid, address_start, 8);
   if (result_backup_code.has_error()) {
-    return ErrorMessage(absl::StrFormat("Failed to read from tracee: \"%s\"",
+    return ErrorMessage(absl::StrFormat("Failed to read from tracee's memory: \"%s\"",
                                         result_backup_code.error().message()));
   }
 
   // Write `syscall` into memory. Machine code is `0x0f05`.
   auto result_write_code = WriteTraceesMemory(pid, address_start, std::vector<uint8_t>{0x0f, 0x05});
   if (result_write_code.has_error()) {
-    return ErrorMessage(
-        absl::StrFormat("Failed to write to tracee: \"%s\"", result_write_code.error().message()));
+    return ErrorMessage(absl::StrFormat("Failed to write to tracee's memory: \"%s\"",
+                                        result_write_code.error().message()));
   }
 
   // Move instruction pointer to the `syscall` and fill registers with parameters.

--- a/src/UserSpaceInstrumentation/AllocateInTracee.cpp
+++ b/src/UserSpaceInstrumentation/AllocateInTracee.cpp
@@ -17,58 +17,14 @@
 #include <string>
 #include <vector>
 
+#include "AccessTraceesMemory.h"
 #include "OrbitBase/Logging.h"
-#include "OrbitBase/ReadFileToString.h"
 #include "OrbitBase/SafeStrerror.h"
 #include "UserSpaceInstrumentation/RegisterState.h"
 
 namespace orbit_user_space_instrumentation {
 
 namespace {
-
-using orbit_base::ReadFileToString;
-
-// Returns the address range of the first executable memory region. In every case I encountered this
-// was the second line in the `maps` file corresponding to the code of the process we look at.
-// However we don't really care. So keeping it general and just searching for an executable region
-// is probably helping stability.
-[[nodiscard]] ErrorMessageOr<void> GetFirstExecutableMemoryRegion(pid_t pid, uint64_t* addr_start,
-                                                                  uint64_t* addr_end) {
-  auto result_read_maps = ReadFileToString(absl::StrFormat("/proc/%d/maps", pid));
-  if (result_read_maps.has_error()) {
-    return result_read_maps.error();
-  }
-  const std::vector<std::string> lines =
-      absl::StrSplit(result_read_maps.value(), '\n', absl::SkipEmpty());
-  for (const auto& line : lines) {
-    const std::vector<std::string> tokens = absl::StrSplit(line, ' ', absl::SkipEmpty());
-    if (tokens.size() < 2 || tokens[1].size() != 4 || tokens[1][2] != 'x') continue;
-    const std::vector<std::string> addresses = absl::StrSplit(tokens[0], '-');
-    if (addresses.size() != 2) continue;
-    if (!absl::numbers_internal::safe_strtou64_base(addresses[0], addr_start, 16)) continue;
-    if (!absl::numbers_internal::safe_strtou64_base(addresses[1], addr_end, 16)) continue;
-    return outcome::success();
-  }
-  return ErrorMessage(absl::StrFormat("Unable to locate executable memory area in pid: %d", pid));
-}
-
-// Write `bytes` into memory of process `pid` starting from `address_start`.
-// Note that we write multiples of eight bytes at once. If length of `bytes` is not a multiple of
-// eight the remaining bytes are zeroed out.
-void WriteBytesIntoTraceesMemory(pid_t pid, uint64_t address_start,
-                                 const std::vector<uint8_t>& bytes) {
-  size_t pos = 0;
-  do {
-    // Pack 8 byte for writing into `data`.
-    uint64_t data = 0;
-    for (size_t i = 0; i < sizeof(data) && pos + i < bytes.size(); i++) {
-      uint64_t t = bytes[pos + i];
-      data |= t << (8 * i);
-    }
-    CHECK(ptrace(PTRACE_POKEDATA, pid, address_start + pos, data) != -1);
-    pos += 8;
-  } while (pos < bytes.size());
-}
 
 // Execute a single syscall instruction in tracee `pid`. `syscall` identifies the syscall as in this
 // list: https://github.com/torvalds/linux/blob/master/arch/x86/entry/syscalls/syscall_64.tbl
@@ -99,14 +55,19 @@ void WriteBytesIntoTraceesMemory(pid_t pid, uint64_t address_start,
   }
 
   // Backup first 8 bytes.
-  const uint64_t backup_module_code = ptrace(PTRACE_PEEKDATA, pid, address_start, NULL);
-  if (errno) {
-    return ErrorMessage(absl::StrFormat("Failed to PTRACE_PEEKDATA with errno %d: \"%s\"", errno,
-                                        SafeStrerror(errno)));
+  std::vector<uint8_t> original_data;
+  auto result_backup_code = ReadTraceesMemory(pid, address_start, 8, &original_data);
+  if (result_backup_code.has_error()) {
+    return ErrorMessage(absl::StrFormat("Failed to read from tracees: \"%s\"",
+                                        result_backup_code.error().message()));
   }
 
   // Write `syscall` into memory. Machine code is `0x0f05`.
-  WriteBytesIntoTraceesMemory(pid, address_start, std::vector<uint8_t>{0x0f, 0x05});
+  auto result_write_code = WriteTraceesMemory(pid, address_start, std::vector<uint8_t>{0x0f, 0x05});
+  if (result_write_code.has_error()) {
+    return ErrorMessage(
+        absl::StrFormat("Failed to write to tracees: \"%s\"", result_write_code.error().message()));
+  }
 
   // Move instruction pointer to the `syscall` and fill registers with parameters.
   RegisterState registers_for_syscall = original_registers;
@@ -151,13 +112,14 @@ void WriteBytesIntoTraceesMemory(pid_t pid, uint64_t address_start,
   }
 
   // Clean up memory and registers.
-  auto result_restore_memory = ptrace(PTRACE_POKEDATA, pid, address_start, backup_module_code);
-  if (result_restore_memory == -1) {
-    FATAL("Unable to restore memory state of tracee");
+  auto result_restore_memory = WriteTraceesMemory(pid, address_start, original_data);
+  if (result_restore_memory.has_error()) {
+    FATAL("Unable to restore memory state of tracee: \"%s\"",
+          result_restore_memory.error().message());
   }
   result_restore_registers = original_registers.RestoreRegisters();
   if (result_restore_registers.has_error()) {
-    FATAL("Unable to restore register state of tracee : \"%s\"",
+    FATAL("Unable to restore register state of tracee: \"%s\"",
           result_restore_registers.error().message());
   }
 

--- a/src/UserSpaceInstrumentation/AllocateInTracee.cpp
+++ b/src/UserSpaceInstrumentation/AllocateInTracee.cpp
@@ -55,10 +55,9 @@ namespace {
   }
 
   // Backup first 8 bytes.
-  std::vector<uint8_t> original_data;
-  auto result_backup_code = ReadTraceesMemory(pid, address_start, 8, &original_data);
+  auto result_backup_code = ReadTraceesMemory(pid, address_start, 8);
   if (result_backup_code.has_error()) {
-    return ErrorMessage(absl::StrFormat("Failed to read from tracees: \"%s\"",
+    return ErrorMessage(absl::StrFormat("Failed to read from tracee: \"%s\"",
                                         result_backup_code.error().message()));
   }
 
@@ -66,7 +65,7 @@ namespace {
   auto result_write_code = WriteTraceesMemory(pid, address_start, std::vector<uint8_t>{0x0f, 0x05});
   if (result_write_code.has_error()) {
     return ErrorMessage(
-        absl::StrFormat("Failed to write to tracees: \"%s\"", result_write_code.error().message()));
+        absl::StrFormat("Failed to write to tracee: \"%s\"", result_write_code.error().message()));
   }
 
   // Move instruction pointer to the `syscall` and fill registers with parameters.
@@ -112,7 +111,7 @@ namespace {
   }
 
   // Clean up memory and registers.
-  auto result_restore_memory = WriteTraceesMemory(pid, address_start, original_data);
+  auto result_restore_memory = WriteTraceesMemory(pid, address_start, result_backup_code.value());
   if (result_restore_memory.has_error()) {
     FATAL("Unable to restore memory state of tracee: \"%s\"",
           result_restore_memory.error().message());

--- a/src/UserSpaceInstrumentation/CMakeLists.txt
+++ b/src/UserSpaceInstrumentation/CMakeLists.txt
@@ -23,9 +23,11 @@ target_sources(UserSpaceInstrumentation PUBLIC
         include/UserSpaceInstrumentation/RegisterState.h)
 
 target_sources(UserSpaceInstrumentation PRIVATE
-        Attach.cpp
+        AccessTraceesMemory.cpp
+        AccessTraceesMemory.h
         AllocateInTracee.cpp
         AllocateInTracee.h
+        Attach.cpp
         RegisterState.cpp)
 
 target_link_libraries(UserSpaceInstrumentation PUBLIC
@@ -41,10 +43,12 @@ target_include_directories(UserSpaceInstrumentationTests PRIVATE
         ${CMAKE_CURRENT_LIST_DIR})
 
 target_sources(UserSpaceInstrumentationTests PRIVATE
-        AttachTest.cpp
+        AccessTraceesMemoryTest.cpp
         AllocateInTraceeTest.cpp
+        AttachTest.cpp
         RegisterStateTest.cpp
-        TestProcess.cpp)
+        TestProcess.cpp
+        TestProcess.h)
 
 target_link_libraries(UserSpaceInstrumentationTests PRIVATE
         LinuxTracing


### PR DESCRIPTION
Previously these lived in the unnamed namespace of the AllocateInTracee
implementation. Turns out I'll need these again for injecting a dynamic
lib. So they are moved into a separate file and written in a slightly
more general way.

bug: http://b/181304023
test: Unit test in PR.