### PR TITLE
Fix the selection behavior after loading symbols

### DIFF
--- a/src/OrbitGl/SamplingReportDataView.h
+++ b/src/OrbitGl/SamplingReportDataView.h
@@ -36,7 +36,6 @@ class SamplingReportDataView : public DataView {
   void OnRefresh(const std::vector<int>& visible_selected_indices,
                  const RefreshMode& mode) override;
 
-  void UpdateSelectedAddressesAndTid(const std::vector<int>& indices);
   void LinkDataView(DataView* data_view) override;
   void SetSamplingReport(class SamplingReport* sampling_report) {
     sampling_report_ = sampling_report;
@@ -56,7 +55,15 @@ class SamplingReportDataView : public DataView {
       const std::vector<int>& indices) const;
 
  private:
+  void UpdateSelectedIndicesAndFunctionIds(const std::vector<int>& selected_indices);
+  void RestoreSelectedIndicesAfterFunctionsChanged();
+  // The callstack view will be updated according to the visible selected addresses and thread id.
+  void UpdateVisibleSelectedAddressesAndTid(const std::vector<int>& visible_selected_indices);
+
   std::vector<SampledFunction> functions_;
+  // We need to keep user's selected function ids such that if functions_ changes, the
+  // selected_indices_ can be updated according to the selected function ids.
+  absl::flat_hash_set<uint64_t> selected_function_ids_;
   ThreadID tid_ = -1;
   std::string name_;
   CallStackDataView* callstack_data_view_;


### PR DESCRIPTION
The current sampling tab does not correctly restore the selection after right-clicking loading symbols.

This is because both `SamplingReportDataview::functions_` and `SamplingReportDataview::indices_` are changed after loading symbols. Therefore, the mapping relationship between functions in `SamplingReportDataview::functions_`  and rows in the sampling tab is also changed. If still using `selected_indices_` to keep user's previous selections in the sampling tab, the re-selections will be made based on previous mapping relationship between functions and rows.

We fixed this problem by replacing `selected_indices_` with `selected_function_ids_` in the sampling tab. Also, as the
`selected_indices_` is not used anywhere else, we removed it from the DataView.

Bug: http://b/181549382
Test: In the sampling tab, select one or more functions and right click "Load Symbol". Check whether the selections in the sampling tab are correctly restored after loading symbols.