### PR TITLE
Metrics next

### DIFF
--- a/src/MetricsUploader/MetricsUploaderWindows.cpp
+++ b/src/MetricsUploader/MetricsUploaderWindows.cpp
@@ -42,7 +42,7 @@ class MetricsUploaderImpl : public MetricsUploader {
                     OrbitLogEvent_StatusCode status_code) override;
 
  private:
-  bool FillAndSendLogEvent(OrbitLogEvent partial_filled_event);
+  [[nodiscard]] bool FillAndSendLogEvent(OrbitLogEvent partial_filled_event) const;
 
   HMODULE metrics_uploader_client_dll_;
   Result (*send_log_event_addr_)(const uint8_t*, int) = nullptr;
@@ -186,7 +186,7 @@ ErrorMessageOr<std::string> GenerateUUID() {
   return uuid_string;
 }
 
-bool MetricsUploaderImpl::FillAndSendLogEvent(OrbitLogEvent partial_filled_event) {
+bool MetricsUploaderImpl::FillAndSendLogEvent(OrbitLogEvent partial_filled_event) const {
   if (send_log_event_addr_ == nullptr) {
     ERROR("Unable to send metric, send_log_event_addr_ is nullptr");
     return false;

--- a/src/MetricsUploader/proto/orbit_log_event.proto
+++ b/src/MetricsUploader/proto/orbit_log_event.proto
@@ -20,6 +20,7 @@ message OrbitLogEvent {
     ORBIT_PRESET_LOAD = 6;
     ORBIT_PRESET_DELETE = 7;
     ORBIT_ITERATOR_ADD = 8;
+    ORBIT_ITERATOR_REMOVE = 9;
   }
   enum StatusCode {
     UNKNOWN_STATUS = 0;

--- a/src/MetricsUploader/proto/orbit_log_event.proto
+++ b/src/MetricsUploader/proto/orbit_log_event.proto
@@ -19,6 +19,7 @@ message OrbitLogEvent {
     ORBIT_PRESET_SAVE = 5;
     ORBIT_PRESET_LOAD = 6;
     ORBIT_PRESET_DELETE = 7;
+    ORBIT_ITERATOR_ADD = 8;
   }
   enum StatusCode {
     UNKNOWN_STATUS = 0;

--- a/src/MetricsUploader/proto/orbit_log_event.proto
+++ b/src/MetricsUploader/proto/orbit_log_event.proto
@@ -18,6 +18,7 @@ message OrbitLogEvent {
     ORBIT_CAPTURE_LOAD = 4;
     ORBIT_PRESET_SAVE = 5;
     ORBIT_PRESET_LOAD = 6;
+    ORBIT_PRESET_DELETE = 7;
   }
   enum StatusCode {
     UNKNOWN_STATUS = 0;

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1854,7 +1854,7 @@ DataView* OrbitApp::GetOrCreateDataView(DataViewType type) {
 
     case DataViewType::kPresets:
       if (!presets_data_view_) {
-        presets_data_view_ = std::make_unique<PresetsDataView>(this);
+        presets_data_view_ = std::make_unique<PresetsDataView>(this, metrics_uploader_);
         panels_.push_back(presets_data_view_.get());
       }
       return presets_data_view_.get();

--- a/src/OrbitGl/LiveFunctionsController.cpp
+++ b/src/OrbitGl/LiveFunctionsController.cpp
@@ -179,6 +179,11 @@ void LiveFunctionsController::OnPreviousButton(uint64_t id) {
 void LiveFunctionsController::OnDeleteButton(uint64_t id) {
   current_textboxes_.erase(id);
   iterator_id_to_function_id_.erase(id);
+  if (metrics_uploader_ != nullptr) {
+    metrics_uploader_->SendLogEvent(
+        orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_ITERATOR_REMOVE);
+  }
+
   // If we erase the iterator that was last used by the user, then
   // we need to switch last_id_pressed_ to an existing id.
   if (id == id_to_select_ && !current_textboxes_.empty()) {

--- a/src/OrbitGl/LiveFunctionsController.h
+++ b/src/OrbitGl/LiveFunctionsController.h
@@ -9,6 +9,7 @@
 #include <functional>
 
 #include "LiveFunctionsDataView.h"
+#include "MetricsUploader/MetricsUploader.h"
 #include "OrbitBase/Profiling.h"
 #include "TextBox.h"
 #include "absl/container/flat_hash_map.h"
@@ -18,8 +19,11 @@ class OrbitApp;
 
 class LiveFunctionsController {
  public:
-  explicit LiveFunctionsController(OrbitApp* app)
-      : live_functions_data_view_(this, app), app_{app} {}
+  explicit LiveFunctionsController(OrbitApp* app,
+                                   orbit_metrics_uploader::MetricsUploader* metrics_uploader)
+      : live_functions_data_view_(this, app, metrics_uploader),
+        app_{app},
+        metrics_uploader_(metrics_uploader) {}
 
   LiveFunctionsDataView& GetDataView() { return live_functions_data_view_; }
 
@@ -59,6 +63,7 @@ class LiveFunctionsController {
   uint64_t id_to_select_ = 0;
 
   OrbitApp* app_ = nullptr;
+  orbit_metrics_uploader::MetricsUploader* metrics_uploader_;
 };
 
 #endif  // LIVE_FUNCTIONS_H_

--- a/src/OrbitGl/LiveFunctionsDataView.h
+++ b/src/OrbitGl/LiveFunctionsDataView.h
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "DataView.h"
+#include "MetricsUploader/MetricsUploader.h"
 #include "TextBox.h"
 #include "TimerChain.h"
 #include "capture_data.pb.h"
@@ -23,7 +24,8 @@ class OrbitApp;
 
 class LiveFunctionsDataView : public DataView {
  public:
-  explicit LiveFunctionsDataView(LiveFunctionsController* live_functions, OrbitApp* app);
+  explicit LiveFunctionsDataView(LiveFunctionsController* live_functions, OrbitApp* app,
+                                 orbit_metrics_uploader::MetricsUploader* metrics_uploader);
 
   const std::vector<Column>& GetColumns() override;
   int GetDefaultSortingColumn() override { return kColumnCount; }
@@ -83,6 +85,9 @@ class LiveFunctionsDataView : public DataView {
   static const std::string kMenuActionIterate;
   static const std::string kMenuActionEnableFrameTrack;
   static const std::string kMenuActionDisableFrameTrack;
+
+ private:
+  orbit_metrics_uploader::MetricsUploader* metrics_uploader_;
 };
 
 #endif  // ORBIT_GL_LIVE_FUNCTIONS_DATA_VIEW_H_

--- a/src/OrbitGl/PresetsDataView.h
+++ b/src/OrbitGl/PresetsDataView.h
@@ -13,13 +13,15 @@
 #include <vector>
 
 #include "DataView.h"
+#include "MetricsUploader/MetricsUploader.h"
 #include "preset.pb.h"
 
 class OrbitApp;
 
 class PresetsDataView : public DataView {
  public:
-  explicit PresetsDataView(OrbitApp* app);
+  explicit PresetsDataView(OrbitApp* app,
+                           orbit_metrics_uploader::MetricsUploader* metrics_uploader);
 
   const std::vector<Column>& GetColumns() override;
   int GetDefaultSortingColumn() override { return kColumnPresetName; }
@@ -68,6 +70,9 @@ class PresetsDataView : public DataView {
 
   static const std::string kMenuActionLoad;
   static const std::string kMenuActionDelete;
+
+ private:
+  orbit_metrics_uploader::MetricsUploader* metrics_uploader_;
 };
 
 #endif  // ORBIT_GL_PRESET_DATA_VIEW_H_

--- a/src/OrbitQt/orbitlivefunctions.cpp
+++ b/src/OrbitQt/orbitlivefunctions.cpp
@@ -19,6 +19,7 @@
 #include "App.h"
 #include "DataView.h"
 #include "LiveFunctionsDataView.h"
+#include "MetricsUploader/MetricsUploader.h"
 #include "orbitdataviewpanel.h"
 #include "orbittablemodel.h"
 #include "orbittreeview.h"
@@ -33,9 +34,11 @@ OrbitLiveFunctions::OrbitLiveFunctions(QWidget* parent)
 
 OrbitLiveFunctions::~OrbitLiveFunctions() { delete ui; }
 
-void OrbitLiveFunctions::Initialize(OrbitApp* app, SelectionType selection_type, FontType font_type,
+void OrbitLiveFunctions::Initialize(OrbitApp* app,
+                                    orbit_metrics_uploader::MetricsUploader* metrics_uploader,
+                                    SelectionType selection_type, FontType font_type,
                                     bool is_main_instance) {
-  live_functions_.emplace(app);
+  live_functions_.emplace(app, metrics_uploader);
   DataView* data_view = &live_functions_->GetDataView();
   ui->data_view_panel_->Initialize(data_view, selection_type, font_type, is_main_instance);
 

--- a/src/OrbitQt/orbitlivefunctions.h
+++ b/src/OrbitQt/orbitlivefunctions.h
@@ -33,8 +33,8 @@ class OrbitLiveFunctions : public QWidget {
   explicit OrbitLiveFunctions(QWidget* parent = nullptr);
   ~OrbitLiveFunctions() override;
 
-  void Initialize(OrbitApp* app, SelectionType selection_type, FontType font_type,
-                  bool is_main_instance = true);
+  void Initialize(OrbitApp* app, orbit_metrics_uploader::MetricsUploader* metrics_uploader,
+                  SelectionType selection_type, FontType font_type, bool is_main_instance = true);
   void Deinitialize();
   void Refresh();
   void OnDataChanged();

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -160,7 +160,7 @@ OrbitMainWindow::OrbitMainWindow(orbit_qt::TargetConfiguration target_configurat
       ui(new Ui::OrbitMainWindow),
       command_line_flags_(command_line_flags),
       target_configuration_(std::move(target_configuration)) {
-  SetupMainWindow();
+  SetupMainWindow(metrics_uploader);
 
   SetupTargetLabel();
   SetupHintFrame();
@@ -186,7 +186,7 @@ OrbitMainWindow::OrbitMainWindow(orbit_qt::TargetConfiguration target_configurat
   LoadCaptureOptionsIntoApp();
 }
 
-void OrbitMainWindow::SetupMainWindow() {
+void OrbitMainWindow::SetupMainWindow(orbit_metrics_uploader::MetricsUploader* metrics_uploader) {
   DataViewFactory* data_view_factory = app_.get();
 
   ui->setupUi(this);
@@ -322,7 +322,8 @@ void OrbitMainWindow::SetupMainWindow() {
 
   StartMainTimer();
 
-  ui->liveFunctions->Initialize(app_.get(), SelectionType::kExtended, FontType::kDefault);
+  ui->liveFunctions->Initialize(app_.get(), metrics_uploader, SelectionType::kExtended,
+                                FontType::kDefault);
 
   connect(ui->liveFunctions->GetFilterLineEdit(), &QLineEdit::textChanged, this,
           [this](const QString& text) { OnLiveTabFunctionsFilterTextChanged(text); });

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -145,7 +145,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
  private:
   void StartMainTimer();
   void SetupCaptureToolbar();
-  void SetupMainWindow();
+  void SetupMainWindow(orbit_metrics_uploader::MetricsUploader* metrics_uploader);
   void SetupHintFrame();
   void SetupTargetLabel();
 


### PR DESCRIPTION
This PR does multiple things, they are properly separated into commits. 

1. Make `MetricsUploader.SendLogEvent` return `void` instead of `bool`. The return type was not used at all, only in tests. And there is also no need to return anything when an event cannot be sent. An error message should be printed, but the user should not be bothered. That is what happens and the test checks if that error is printed.
2. Refactor MetricsUploader to use more const. Also touches OrbitApp and OrbitMainWindow. 
3. Presets delete metric (http://b/181648088)
4. Iterator Add & Remove metric (http://b/181649379)