### PR TITLE
Fix crash when running out of slots and discarding the submission.

### DIFF
--- a/src/OrbitCaptureClient/GpuQueueSubmissionProcessor.cpp
+++ b/src/OrbitCaptureClient/GpuQueueSubmissionProcessor.cpp
@@ -347,7 +347,8 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuDebugMarkers(
             begin_marker_thread_id, begin_marker_post_submission_cpu_timestamp);
         // Note that we receive submissions of a single queue in order (by CPU submission time).
         // However, if we are out of timer slot indices, we might discard submissions (if it
-        // contains no command buffer timers).
+        // contains no command buffer timers). If we don't have a matching submission for the
+        // "begin" marker, we have to discard the entire marker.
         if (matching_begin_submission == nullptr) {
           ERROR("Discarding debug marker timer.");
           continue;


### PR DESCRIPTION
If we run out of timer slots, it may happen that we have not single
command buffer timer slot, and thus discard the submission (even
if that contained a valid "begin marker").

If the submission containing the "end marker" is not discarded,
we ran into a CHECK on the UI. This will discard the debug marker
on the UI.

Test: Capture Infiltrator for a long time since beginning.
Bug: http://177652631