### PR TITLE
Enable Drag and Drop support in SourcePathsMappingDialog

### DIFF
--- a/src/ConfigWidgets/SourcePathsMappingDialog.cpp
+++ b/src/ConfigWidgets/SourcePathsMappingDialog.cpp
@@ -81,7 +81,7 @@ void SourcePathsMappingDialog::OnSelectionChanged(const QItemSelection& selected
   if (!deselected.isEmpty()) {
     const auto* mapping = deselected.indexes().first().data(Qt::UserRole).value<const Mapping*>();
     const bool invalid_mapping_deselected = !mapping->IsValid();
-    if (invalid_mapping_deselected) model_.removeRows(deselected.indexes().first().row(), 1);
+    if (invalid_mapping_deselected) model_.RemoveRows(deselected.indexes().first().row(), 1);
   }
 }
 
@@ -110,6 +110,6 @@ void SourcePathsMappingDialog::OnTargetPathChanged(const QString& new_target) {
 void SourcePathsMappingDialog::OnRemoveSelectedMapping() {
   auto indexes = ui_->list_view->selectionModel()->selectedIndexes();
   auto idx = indexes.first();
-  model_.removeRows(idx.row(), 1);
+  model_.RemoveRows(idx.row(), 1);
 }
 }  // namespace orbit_config_widgets

--- a/src/ConfigWidgets/SourcePathsMappingDialog.ui
+++ b/src/ConfigWidgets/SourcePathsMappingDialog.ui
@@ -46,6 +46,9 @@
      <property name="dragEnabled">
       <bool>true</bool>
      </property>
+     <property name="dragDropOverwriteMode">
+      <bool>true</bool>
+     </property>
      <property name="dragDropMode">
       <enum>QAbstractItemView::InternalMove</enum>
      </property>

--- a/src/SourcePathsMapping/MappingItemModel.cpp
+++ b/src/SourcePathsMapping/MappingItemModel.cpp
@@ -27,6 +27,12 @@ void MappingItemModel::SetMappings(std::vector<Mapping> new_mappings) {
   }
 }
 
+Qt::ItemFlags MappingItemModel::flags(const QModelIndex& index) const {
+  if (index.isValid()) return QAbstractListModel::flags(index) | Qt::ItemIsDragEnabled;
+
+  return QAbstractListModel::flags(index) | Qt::ItemIsDropEnabled;
+}
+
 QVariant MappingItemModel::data(const QModelIndex& index, int role) const {
   CHECK(index.model() == this);
   CHECK(index.row() < static_cast<int>(mappings_.size()));
@@ -80,7 +86,7 @@ bool MappingItemModel::moveRows(const QModelIndex& source_parent, int source_row
   return true;
 }
 
-bool MappingItemModel::removeRows(int row, int count, const QModelIndex& parent) {
+bool MappingItemModel::RemoveRows(int row, int count, const QModelIndex& parent) {
   // We don't have a tree structure, so the parent can't be valid.
   if (parent.isValid()) return false;
   if (row >= rowCount()) return false;

--- a/src/SourcePathsMapping/include/SourcePathsMapping/MappingItemModel.h
+++ b/src/SourcePathsMapping/include/SourcePathsMapping/MappingItemModel.h
@@ -25,14 +25,20 @@ class MappingItemModel : public QAbstractListModel {
     return static_cast<int>(mappings_.size());
   }
 
+  [[nodiscard]] Qt::ItemFlags flags(const QModelIndex& index) const override;
   [[nodiscard]] QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
   [[nodiscard]] QVariant headerData(int section, Qt::Orientation orientation,
                                     int role = Qt::DisplayRole) const override;
   bool moveRows(const QModelIndex& source_parent, int source_row, int count,
                 const QModelIndex& destination_parent, int destination_child) override;
-  bool removeRows(int row, int count, const QModelIndex& parent = QModelIndex{}) override;
+
+  // TODO(b/181733946): This is not a Qt-overload. Calling it `removeRows` triggers an incosistency
+  // in Qt.
+  bool RemoveRows(int row, int count, const QModelIndex& parent = QModelIndex{});
 
   bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole) override;
+
+  [[nodiscard]] Qt::DropActions supportedDropActions() const override { return Qt::MoveAction; }
 
   void AppendNewEmptyMapping();
 


### PR DESCRIPTION
This was not enabled before due to an incosistency between Windows and
Linux. Not sure yet where it is coming from. Maybe different Qt
versions, or a bug.

This commit works around the problem by not implemented `removeRows`.

Bug: http://b/181733946
Test: Manual testing