### PR TITLE
Increase the TimerQueryPool size.

### DIFF
--- a/src/OrbitVulkanLayer/VulkanLayerController.h
+++ b/src/OrbitVulkanLayer/VulkanLayerController.h
@@ -724,7 +724,7 @@ class VulkanLayerController {
   VulkanWrapper vulkan_wrapper_;
 
   // The number of timer query slots is chosen arbitrary such that it is large enough.
-  static constexpr uint32_t kNumTimerQuerySlots = 65536;
+  static constexpr uint32_t kNumTimerQuerySlots = 131072;
 };
 
 }  // namespace orbit_vulkan_layer


### PR DESCRIPTION
Based on experiments with Infiltrator, the previous size of
the timer query pool was a bit to small, as we were loosing
events at the beginning. This doubles to size.

Test: Run on Infiltrator from the beginning.