### PR TITLE
Avoid passing through 0 color values from the Vulkan layer

### DIFF
--- a/src/OrbitVulkanLayer/SubmissionTracker.h
+++ b/src/OrbitVulkanLayer/SubmissionTracker.h
@@ -958,8 +958,14 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
         marker_proto->set_text_key(
             vulkan_layer_producer_->InternStringIfNecessaryAndGetKey(marker_state.label_name));
       }
-      if (marker_state.color.red != 0.0f || marker_state.color.green != 0.0f ||
-          marker_state.color.blue != 0.0f || marker_state.color.alpha != 0.0f) {
+
+      auto quantize = [](float value) { return static_cast<uint8_t>(value * 255.f); };
+
+      // We have seen near 0.f color values in all four components "in the wild", so we check if the
+      // quantized values are not zero here to make sure these markers are rendered with an actual
+      // color.
+      if (quantize(marker_state.color.red) != 0 || quantize(marker_state.color.green) != 0 ||
+          quantize(marker_state.color.blue) != 0 || quantize(marker_state.color.alpha) != 0) {
         auto color = marker_proto->mutable_color();
         color->set_red(marker_state.color.red);
         color->set_green(marker_state.color.green);


### PR DESCRIPTION
We don't want to render 0 color values in our GPU tracks, as they are
invisible (simply because alpha is 0). However, we have only checked
for colors being not 0.f in all components. This made it possible that
really small values, close to 0.f, were still passed through by the
layer, and rendered as quanitize (0, 0, 0, 0) in 8 bit precision.

We now check the color values against 0 after quantizing to 8 bits. This
fixes the issue of "invisible" debug markers.

The fix is debatable, because it might be user intention to actually
use those values, but the same is true for exactly (0.f, 0.f, 0.f 0.f).

Tested: Manually ran layer with example application.
Bug: http://b/181747686