### PR TITLE
Return 0 samples inside function

### DIFF
--- a/src/OrbitGl/SourceCodeReport.h
+++ b/src/OrbitGl/SourceCodeReport.h
@@ -9,6 +9,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <limits>
 #include <optional>
 #include <utility>
 
@@ -39,6 +40,8 @@ class SourceCodeReport : public CodeReport {
   absl::flat_hash_map<uint32_t, uint32_t> number_of_samples_per_line_;
   uint32_t total_samples_in_function_ = 0;
   uint32_t total_samples_in_capture_ = 0;
+  uint32_t min_line_number_ = std::numeric_limits<uint32_t>::max();
+  uint32_t max_line_number_ = std::numeric_limits<uint32_t>::min();
 };
 
 }  // namespace orbit_gl


### PR DESCRIPTION
`SourceCodeReport` used to return an empty optional for every line without a sample.

This commit changes the following: For every line inside of the function without samples 0 is returned. For every line outside of the function an empty optional is returned.