### PR TITLE
Eventtrack accessibility update

### DIFF
--- a/contrib/automation_tests/core/common_controls.py
+++ b/contrib/automation_tests/core/common_controls.py
@@ -13,12 +13,20 @@ from core.orbit_e2e import find_control
 class Track:
     def __init__(self, control: BaseWrapper):
         self._container = control
+        self._name = control.texts()[0]
         self._title = find_control(control, 'TabItem')
-        self._content = find_control(control, 'Group')
+        self._events = find_control(control, 'Pane', 'Events', raise_on_failure=False)
+        self._thread_states = find_control(control, 'Pane', 'ThreadStates', raise_on_failure=False)
+        self._tracepoints = find_control(control, 'Pane', 'Tracepoints', raise_on_failure=False)
+        self._timers = find_control(control, 'Pane', 'Timers', raise_on_failure=False)
 
     container = property(lambda self: self._container)
     title = property(lambda self: self._title)
-    content = property(lambda self: self._content)
+    events = property(lambda self: self._events)
+    thread_states = property(lambda self: self._thread_states)
+    tracepoints = property(lambda self: self._tracepoints)
+    timers = property(lambda self: self._timers)
+    name = property(lambda self: self._name)
 
 
 class DataViewPanel:

--- a/contrib/automation_tests/orbit_create_frame_track.py
+++ b/contrib/automation_tests/orbit_create_frame_track.py
@@ -8,7 +8,7 @@ from absl import app
 
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
-from test_cases.capture_window import Capture
+from test_cases.capture_window import Capture, FilterTracks, CheckTimers
 from test_cases.symbols_tab import LoadSymbols, FilterAndHookFunction
 from test_cases.live_tab import AddFrameTrack
 
@@ -38,7 +38,9 @@ def main(argv):
         LoadSymbols(module_search_string="hello_ggp"),
         FilterAndHookFunction(function_search_string='DrawFrame'),
         Capture(),
-        AddFrameTrack(function_name="DrawFrame")
+        AddFrameTrack(function_name="DrawFrame"),
+        FilterTracks(filter_string="Frame", expected_count=1),   # Verify there's exactly one frame track
+        CheckTimers(track_name_contains='Frame track')  # Verify the frame track has timers
     ]
     suite = E2ETestSuite(test_name="Add Frame Track", test_cases=test_cases)
     suite.execute()

--- a/contrib/automation_tests/orbit_instrument_function.py
+++ b/contrib/automation_tests/orbit_instrument_function.py
@@ -6,9 +6,9 @@ found in the LICENSE file.
 
 from absl import app
 
-from core.orbit_e2e import E2ETestSuite, E2ETestCase
+from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
-from test_cases.capture_window import Capture
+from test_cases.capture_window import Capture, CheckTimers
 from test_cases.symbols_tab import LoadSymbols, FilterAndHookFunction
 from test_cases.live_tab import VerifyFunctionCallCount
 
@@ -35,9 +35,16 @@ def main(argv):
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter='hello_'),
         LoadSymbols(module_search_string="hello_ggp"),
+        Capture(),
+        CheckTimers(track_name_contains='Scheduler'),
+        CheckTimers(track_name_contains='gfx'),
+        CheckTimers(track_name_contains="All Threads", expect_exists=False),
+        CheckTimers(track_name_contains="hello_ggp_stand", expect_exists=False),
         FilterAndHookFunction(function_search_string='DrawFrame'),
         Capture(),
-        VerifyFunctionCallCount(function_name='DrawFrame', min_calls=30, max_calls=3000)
+        VerifyFunctionCallCount(function_name='DrawFrame', min_calls=30, max_calls=3000),
+        CheckTimers(track_name_contains="All Threads", expect_exists=False),
+        CheckTimers(track_name_contains="hello_ggp_stand")
     ]
     suite = E2ETestSuite(test_name="Connect & Capture", test_cases=test_cases)
     suite.execute()

--- a/contrib/automation_tests/orbit_thread_state.py
+++ b/contrib/automation_tests/orbit_thread_state.py
@@ -8,7 +8,7 @@ from absl import app
 
 from core.orbit_e2e import E2ETestSuite
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
-from test_cases.capture_window import Capture
+from test_cases.capture_window import Capture, CheckThreadStates
 
 """Smoke test for thread state collection.
 
@@ -21,7 +21,10 @@ def main(argv):
     test_cases = [
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter='hello_'),
-        Capture(collect_thread_states=True)
+        Capture(collect_thread_states=True),
+        CheckThreadStates(track_name_contains='hello_ggp'),
+        Capture(collect_thread_states=False),
+        CheckThreadStates(track_name_contains='hello_ggp', expect_exists=False),
     ]
     suite = E2ETestSuite(test_name="Collect Thread States", test_cases=test_cases)
     suite.execute()

--- a/contrib/automation_tests/orbit_tracks.py
+++ b/contrib/automation_tests/orbit_tracks.py
@@ -18,7 +18,7 @@ def main(argv):
         Capture(),
         # "sdma0" is not present on the DevKits, instead there is "vce0", so this tests for "sdma0 or vce0"
         MatchTracks(expected_names=[
-            "Scheduler", ("sdma0", "vce0"), "gfx", "hello_ggp_stand", "hello_ggp_stand"],
+            "Scheduler", ("sdma0", "vce0"), "gfx", "All Threads", "hello_ggp_stand"],
             allow_additional_tracks=True),
         SelectTrack(track_index=5),
         DeselectTrack(),
@@ -29,9 +29,9 @@ def main(argv):
         # TODO: The numbers below are very pessimistic, but it's not assured additional tracks like
         # GgpSwapChain, GgpVideoIpcRead etc are present - GgpSwapChain is missing on the DevKit, others
         # depend on the samples that have been taken
-        FilterTracks(filter_string="hello", expected_count=2),
-        FilterTracks(filter_string="Hello", expected_count=2),
-        FilterTracks(filter_string="ggp", expected_count=2, allow_additional_tracks=True),
+        FilterTracks(filter_string="hello", expected_count=1),
+        FilterTracks(filter_string="Hello", expected_count=1),
+        FilterTracks(filter_string="ggp", expected_count=1, allow_additional_tracks=True),
         FilterTracks(filter_string="", expected_count=4, allow_additional_tracks=True)]
     suite = E2ETestSuite(test_name="Track Interaction", test_cases=test_cases)
     suite.execute()

--- a/contrib/automation_tests/test_cases/capture_window.py
+++ b/contrib/automation_tests/test_cases/capture_window.py
@@ -28,8 +28,11 @@ class CaptureWindowE2ETestCaseBase(E2ETestCase):
         self._time_graph = self.find_control('Image', name='TimeGraph', parent=suite.top_window())
         super().execute(suite=suite)
 
-    def _find_tracks(self):
-        return self._time_graph.children()
+    def _find_tracks(self, name_contains: str = None):
+        tracks = self._time_graph.children()
+        if name_contains is not None:
+            tracks = filter(lambda track: name_contains in track.texts()[0], tracks)
+        return list(tracks)
 
 
 class SelectTrack(CaptureWindowE2ETestCaseBase):
@@ -239,3 +242,42 @@ class Capture(E2ETestCase):
         self._set_capture_options(collect_thread_states)
         self._take_capture(length_in_seconds)
         self._verify_existence_of_tracks()
+
+
+class CheckThreadStates(CaptureWindowE2ETestCaseBase):
+    def _execute(self, track_name_contains: str, expect_exists: bool = True):
+        tracks = self._find_tracks(track_name_contains)
+        self.expect_true(len(tracks) > 0, 'Found tracks matching %s' % track_name_contains)
+        logging.info('Checking for thread states in %s tracks', len(tracks))
+        for track in tracks:
+            track = Track(track)
+            if expect_exists:
+                self.expect_true(track.thread_states is not None, 'Track %s has a thread state pane' % track.name)
+            else:
+                self.expect_true(track.thread_states is None, 'Track %s has a no thread state pane' % track.name)
+
+
+class CheckTimers(CaptureWindowE2ETestCaseBase):
+    def _execute(self, track_name_contains: str, expect_exists: bool = True):
+        tracks = self._find_tracks(track_name_contains)
+        self.expect_true(len(tracks) > 0, 'Found tracks matching "%s"' % track_name_contains)
+        logging.info('Checking for timers in %s tracks', len(tracks))
+        for track in tracks:
+            track = Track(track)
+            if expect_exists:
+                self.expect_true(track.timers is not None, 'Track "%s" has timers pane' % track.name)
+            else:
+                self.expect_true(track.timers is None, 'Track "%s" has no timers pane' % track.name)
+
+
+class CheckEvents(CaptureWindowE2ETestCaseBase):
+    def _execute(self, track_name_contains: str, expect_exists: bool = True):
+        tracks = self._find_tracks(track_name_contains)
+        self.expect_true(len(tracks) > 0, 'Found tracks matching "%s"' % track_name_contains)
+        logging.info('Checking for events in %s tracks', len(tracks))
+        for track in tracks:
+            track = Track(track)
+            if expect_exists:
+                self.expect_true(track.events is not None, 'Track "%s" has events pane' % track.name)
+            else:
+                self.expect_true(track.events is None, 'Track "%s" has no events pane' % track.name)

--- a/contrib/automation_tests/test_cases/live_tab.py
+++ b/contrib/automation_tests/test_cases/live_tab.py
@@ -11,7 +11,7 @@ from pywinauto.base_wrapper import BaseWrapper
 
 from core.orbit_e2e import E2ETestCase, wait_for_condition
 
-from test_cases.capture_window import MatchTracks
+from test_cases.capture_window import MatchTracks, CheckTimers
 
 
 class LiveTabTestCase(E2ETestCase):
@@ -69,6 +69,9 @@ class AddFrameTrack(LiveTabTestCase):
         match_tracks = MatchTracks(expected_names=["Frame track based on %s" % function_name],
                                    allow_additional_tracks=True)
         match_tracks.execute(self.suite)
+
+        check_timers = CheckTimers(track_name_contains=function_name)
+        check_timers.execute(self.suite)
 
 
 class VerifyFunctionCallCount(LiveTabTestCase):

--- a/src/OrbitGl/AccessibleThreadBar.cpp
+++ b/src/OrbitGl/AccessibleThreadBar.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "AccessibleThreadBar.h"
+
+#include "GlCanvas.h"
+#include "OrbitBase/Logging.h"
+#include "ThreadBar.h"
+#include "Track.h"
+
+namespace orbit_gl {
+
+int orbit_gl::AccessibleThreadBar::AccessibleChildCount() const { return 0; }
+
+const orbit_accessibility::AccessibleInterface* AccessibleThreadBar::AccessibleParent() const {
+  CHECK(thread_bar_ != nullptr);
+
+  if (thread_bar_->GetParent() == nullptr) return nullptr;
+  if (thread_bar_->GetParent()->GetAccessibleInterface() == nullptr) return nullptr;
+
+  // This relies on knowledge about AccessibleTrack: Accessibility is split into "virtual" controls
+  // that only exist as children in the accessibility tree. In particular, the track is split into
+  // a tab and a content area, and the thread bar is parented underneath the content area (child 1).
+  // This could be cleaned up by introducing "real" control elements for tab and content area.
+  return thread_bar_->GetParent()->GetAccessibleInterface()->AccessibleChild(1);
+}
+
+std::string AccessibleThreadBar::AccessibleName() const { return thread_bar_->GetName(); }
+
+orbit_accessibility::AccessibilityRect orbit_gl::AccessibleThreadBar::AccessibleLocalRect() const {
+  CHECK(thread_bar_ != nullptr);
+
+  Vec2 pos = thread_bar_->GetPos();
+  Vec2 local_pos;
+
+  // TODO(b/177350599): This could be cleaned up with clearer coordinate systems
+  if (thread_bar_->GetParent() != nullptr) {
+    Vec2 parent_pos = thread_bar_->GetParent()->GetPos();
+    local_pos = Vec2(pos[0] - parent_pos[0], parent_pos[1] - pos[1]);
+  } else {
+    local_pos = pos;
+  }
+
+  GlCanvas* canvas = thread_bar_->GetCanvas();
+  CHECK(canvas != nullptr);
+
+  return orbit_accessibility::AccessibilityRect(
+      canvas->WorldToScreenWidth(local_pos[0]), canvas->WorldToScreenHeight(local_pos[1]),
+      canvas->WorldToScreenWidth(thread_bar_->GetSize()[0]),
+      canvas->WorldToScreenHeight(thread_bar_->GetSize()[1]));
+}
+
+orbit_accessibility::AccessibilityState AccessibleThreadBar::AccessibleState() const {
+  return orbit_accessibility::AccessibilityState::Focusable;
+}
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/AccessibleThreadBar.h
+++ b/src/OrbitGl/AccessibleThreadBar.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_ACCESSIBLE_THREAD_BAR_H_
+#define ORBIT_GL_ACCESSIBLE_THREAD_BAR_H_
+
+#include "OrbitAccessibility/AccessibleInterface.h"
+
+namespace orbit_gl {
+
+class ThreadBar;
+
+class AccessibleThreadBar : public orbit_accessibility::AccessibleInterface {
+ public:
+  AccessibleThreadBar(const ThreadBar* thread_bar) : thread_bar_(thread_bar) {}
+
+  [[nodiscard]] int AccessibleChildCount() const override;
+  [[nodiscard]] const AccessibleInterface* AccessibleChild(int /*index*/) const override {
+    return nullptr;
+  }
+  [[nodiscard]] const AccessibleInterface* AccessibleParent() const override;
+
+  [[nodiscard]] std::string AccessibleName() const override;
+  [[nodiscard]] orbit_accessibility::AccessibilityRole AccessibleRole() const override {
+    return orbit_accessibility::AccessibilityRole::Pane;
+  }
+  [[nodiscard]] orbit_accessibility::AccessibilityRect AccessibleLocalRect() const override;
+  [[nodiscard]] orbit_accessibility::AccessibilityState AccessibleState() const override;
+
+ private:
+  const ThreadBar* thread_bar_;
+};
+
+}  // namespace orbit_gl
+
+#endif

--- a/src/OrbitGl/AccessibleTimeGraph.cpp
+++ b/src/OrbitGl/AccessibleTimeGraph.cpp
@@ -30,7 +30,9 @@ int TimeGraphAccessibility::AccessibleChildCount() const {
 }
 
 const AccessibleInterface* TimeGraphAccessibility::AccessibleChild(int index) const {
-  return time_graph_->GetTrackManager()->GetVisibleTracks()[index]->AccessibilityInterface();
+  return time_graph_->GetTrackManager()
+      ->GetVisibleTracks()[index]
+      ->GetOrCreateAccessibleInterface();
 }
 
 const AccessibleInterface* TimeGraphAccessibility::AccessibleParent() const {

--- a/src/OrbitGl/AccessibleTimeGraph.cpp
+++ b/src/OrbitGl/AccessibleTimeGraph.cpp
@@ -6,10 +6,10 @@
 
 #include <vector>
 
+#include "AccessibleTrack.h"
 #include "GlCanvas.h"
 #include "TimeGraph.h"
 #include "Track.h"
-#include "TrackAccessibility.h"
 #include "TrackManager.h"
 
 using orbit_accessibility::AccessibilityRect;

--- a/src/OrbitGl/AccessibleTrack.cpp
+++ b/src/OrbitGl/AccessibleTrack.cpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 
+#include "AccessibleThreadBar.h"
 #include "AccessibleTimeGraph.h"
 #include "CoreMath.h"
 #include "GlCanvas.h"
@@ -28,7 +29,7 @@ const AccessibleInterface* AccessibleTrackContent::AccessibleChild(int /*index*/
 }
 
 const AccessibleInterface* AccessibleTrackContent::AccessibleParent() const {
-  return track_->AccessibilityInterface();
+  return track_->GetOrCreateAccessibleInterface();
 }
 
 std::string AccessibleTrackContent::AccessibleName() const {
@@ -58,7 +59,7 @@ const AccessibleInterface* AccessibleTrackTab::AccessibleChild(int /*index*/) co
 }
 
 const AccessibleInterface* AccessibleTrackTab::AccessibleParent() const {
-  return track_->AccessibilityInterface();
+  return track_->GetOrCreateAccessibleInterface();
 }
 
 std::string AccessibleTrackTab::AccessibleName() const {

--- a/src/OrbitGl/AccessibleTrack.cpp
+++ b/src/OrbitGl/AccessibleTrack.cpp
@@ -17,25 +17,33 @@
 #include "Track.h"
 
 using orbit_accessibility::AccessibilityRect;
+using orbit_accessibility::AccessibilityRole;
 using orbit_accessibility::AccessibilityState;
 using orbit_accessibility::AccessibleInterface;
 
 namespace orbit_gl {
 
-int AccessibleTrackContent::AccessibleChildCount() const { return 0; }
+int AccessibleTrackContent::AccessibleChildCount() const {
+  return static_cast<int>(track_->GetVisibleChildren().size());
+}
 
-const AccessibleInterface* AccessibleTrackContent::AccessibleChild(int /*index*/) const {
-  return nullptr;
+const AccessibleInterface* AccessibleTrackContent::AccessibleChild(int index) const {
+  if (index < 0) {
+    return nullptr;
+  }
+
+  auto children = track_->GetVisibleChildren();
+  if (static_cast<size_t>(index) >= children.size()) {
+    return nullptr;
+  }
+  return children[index]->GetOrCreateAccessibleInterface();
 }
 
 const AccessibleInterface* AccessibleTrackContent::AccessibleParent() const {
   return track_->GetOrCreateAccessibleInterface();
 }
 
-std::string AccessibleTrackContent::AccessibleName() const {
-  CHECK(track_ != nullptr);
-  return track_->GetName() + "_content";
-}
+std::string AccessibleTrackContent::AccessibleName() const { return "Content"; }
 
 AccessibilityRect AccessibleTrackContent::AccessibleLocalRect() const {
   CHECK(track_ != nullptr);
@@ -136,7 +144,7 @@ AccessibilityRect AccessibleTrack::AccessibleLocalRect() const {
 AccessibilityState AccessibleTrack::AccessibleState() const {
   CHECK(track_ != nullptr);
 
-  using State = orbit_accessibility::AccessibilityState;
+  using State = AccessibilityState;
 
   State result = State::Normal | State::Focusable | State::Movable;
   if (track_->IsTrackSelected()) {

--- a/src/OrbitGl/AccessibleTrack.cpp
+++ b/src/OrbitGl/AccessibleTrack.cpp
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "TrackAccessibility.h"
+#include "AccessibleTrack.h"
 
 #include <GteVector.h>
 

--- a/src/OrbitGl/AccessibleTrack.h
+++ b/src/OrbitGl/AccessibleTrack.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef ORBIT_GL_TRACK_ACCESSIBILITY_H_
-#define ORBIT_GL_TRACK_ACCESSIBILITY_H_
+#ifndef ORBIT_GL_ACCESSIBLE_TRACK_H_
+#define ORBIT_GL_ACCESSIBLE_TRACK_H_
 
 #include <string>
 

--- a/src/OrbitGl/AccessibleTrack.h
+++ b/src/OrbitGl/AccessibleTrack.h
@@ -21,7 +21,7 @@ namespace orbit_gl {
  */
 class AccessibleTrackContent : public orbit_accessibility::AccessibleInterface {
  public:
-  AccessibleTrackContent(Track* track, TimeGraphLayout* layout) : track_(track), layout_(layout){};
+  AccessibleTrackContent(Track* track, TimeGraphLayout* layout);
 
   [[nodiscard]] int AccessibleChildCount() const override;
   [[nodiscard]] const AccessibleInterface* AccessibleChild(int /*index*/) const override;
@@ -37,6 +37,7 @@ class AccessibleTrackContent : public orbit_accessibility::AccessibleInterface {
  private:
   Track* track_;
   TimeGraphLayout* layout_;
+  std::unique_ptr<AccessibleInterface> timer_pane_;
 };
 
 /*

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -11,7 +11,8 @@ target_compile_options(OrbitGl PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(
   OrbitGl
-  PUBLIC AccessibleTimeGraph.h
+  PUBLIC AccessibleThreadBar.h
+         AccessibleTimeGraph.h
          AccessibleTrack.h
          App.h
          AsyncTrack.h
@@ -74,7 +75,8 @@ target_sources(
 
 target_sources(
   OrbitGl
-  PRIVATE AccessibleTimeGraph.cpp
+  PRIVATE AccessibleThreadBar.cpp
+          AccessibleTimeGraph.cpp
           AccessibleTrack.cpp
           App.cpp
           AsyncTrack.cpp
@@ -115,6 +117,7 @@ target_sources(
           TimerChain.cpp
           TimerInfosIterator.cpp
           TimerTrack.cpp
+          ThreadBar.cpp
           ThreadStateTrack.cpp
           ThreadTrack.cpp
           Track.cpp

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -12,6 +12,7 @@ target_compile_options(OrbitGl PRIVATE ${STRICT_COMPILE_FLAGS})
 target_sources(
   OrbitGl
   PUBLIC AccessibleTimeGraph.h
+         AccessibleTrack.h
          App.h
          AsyncTrack.h
          Batcher.h
@@ -66,7 +67,6 @@ target_sources(
          TimerInfosIterator.h
          TimerTrack.h
          Track.h
-         TrackAccessibility.h
          TrackManager.h
          TriangleToggle.h
          TracepointsDataView.h
@@ -75,6 +75,7 @@ target_sources(
 target_sources(
   OrbitGl
   PRIVATE AccessibleTimeGraph.cpp
+          AccessibleTrack.cpp
           App.cpp
           AsyncTrack.cpp
           Batcher.cpp
@@ -117,7 +118,6 @@ target_sources(
           ThreadStateTrack.cpp
           ThreadTrack.cpp
           Track.cpp
-          TrackAccessibility.cpp
           TrackManager.cpp
           TriangleToggle.cpp
           TracepointsDataView.cpp

--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -14,6 +14,14 @@ CaptureViewElement::CaptureViewElement(TimeGraph* time_graph, TimeGraphLayout* l
   CHECK(layout != nullptr);
 }
 
+orbit_accessibility::AccessibleInterface* CaptureViewElement::GetOrCreateAccessibleInterface() {
+  if (accessible_interface_ == nullptr) {
+    accessible_interface_ = CreateAccessibleInterface();
+  }
+
+  return accessible_interface_.get();
+}
+
 void CaptureViewElement::OnPick(int x, int y) {
   canvas_->ScreenToWorld(x, y, mouse_pos_last_click_[0], mouse_pos_last_click_[1]);
   picking_offset_ = mouse_pos_last_click_ - pos_;

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -6,6 +6,7 @@
 #define ORBIT_GL_CAPTURE_VIEW_ELEMENT_H_
 
 #include "Batcher.h"
+#include "OrbitAccessibility/AccessibleInterface.h"
 #include "PickingManager.h"
 #include "TimeGraphLayout.h"
 
@@ -25,7 +26,6 @@ class CaptureViewElement : public Pickable {
   virtual void UpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/, uint64_t /*max_tick*/,
                                 PickingMode /*picking_mode*/, float /*z_offset*/ = 0){};
 
-  void SetTimeGraph(TimeGraph* timegraph) { time_graph_ = timegraph; }
   [[nodiscard]] TimeGraph* GetTimeGraph() { return time_graph_; }
 
   [[nodiscard]] GlCanvas* GetCanvas() const { return canvas_; }
@@ -35,6 +35,11 @@ class CaptureViewElement : public Pickable {
   void SetSize(float width, float height) { size_ = Vec2(width, height); }
   [[nodiscard]] Vec2 GetSize() const { return size_; }
 
+  [[nodiscard]] orbit_accessibility::AccessibleInterface* GetOrCreateAccessibleInterface();
+  [[nodiscard]] const orbit_accessibility::AccessibleInterface* GetAccessibleInterface() const {
+    return accessible_interface_.get();
+  }
+
   // Pickable
   void OnPick(int x, int y) override;
   void OnRelease() override;
@@ -43,6 +48,10 @@ class CaptureViewElement : public Pickable {
 
  protected:
   TimeGraphLayout* layout_;
+  virtual std::unique_ptr<orbit_accessibility::AccessibleInterface> CreateAccessibleInterface() {
+    return {};
+  };
+
   GlCanvas* canvas_ = nullptr;
   TimeGraph* time_graph_;
   Vec2 pos_ = Vec2(0, 0);
@@ -52,6 +61,8 @@ class CaptureViewElement : public Pickable {
   Vec2 mouse_pos_cur_;
   Vec2 picking_offset_ = Vec2(0, 0);
   bool picked_ = false;
+
+  std::unique_ptr<orbit_accessibility::AccessibleInterface> accessible_interface_;
 };
 }  // namespace orbit_gl
 

--- a/src/OrbitGl/EventTrack.cpp
+++ b/src/OrbitGl/EventTrack.cpp
@@ -32,8 +32,10 @@ using orbit_client_protos::CallstackEvent;
 namespace orbit_gl {
 
 EventTrack::EventTrack(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
-                       const CaptureData* capture_data, ThreadID thread_id)
-    : ThreadBar(app, time_graph, layout, capture_data, thread_id), color_{0, 255, 0, 255} {}
+                       const CaptureData* capture_data, ThreadID thread_id,
+                       CaptureViewElement* parent)
+    : ThreadBar(app, time_graph, layout, capture_data, thread_id, parent, "Events"),
+      color_{0, 255, 0, 255} {}
 
 std::string EventTrack::GetTooltip() const { return "Left-click and drag to select samples"; }
 

--- a/src/OrbitGl/EventTrack.h
+++ b/src/OrbitGl/EventTrack.h
@@ -24,7 +24,8 @@ namespace orbit_gl {
 class EventTrack : public ThreadBar {
  public:
   explicit EventTrack(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
-                      const CaptureData* capture_data, ThreadID thread_id);
+                      const CaptureData* capture_data, ThreadID thread_id,
+                      CaptureViewElement* parent);
 
   std::string GetTooltip() const override;
 

--- a/src/OrbitGl/SchedulerTrack.h
+++ b/src/OrbitGl/SchedulerTrack.h
@@ -33,6 +33,8 @@ class SchedulerTrack final : public TimerTrack {
   [[nodiscard]] float GetYFromTimer(
       const orbit_client_protos::TimerInfo& timer_info) const override;
 
+  [[nodiscard]] Color GetBackgroundColor() const override { return color_; }
+
  protected:
   [[nodiscard]] bool IsTimerActive(const orbit_client_protos::TimerInfo& timer_info) const override;
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,

--- a/src/OrbitGl/ThreadBar.cpp
+++ b/src/OrbitGl/ThreadBar.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ThreadBar.h"
+
+#include "AccessibleThreadBar.h"
+#include "Track.h"
+
+namespace orbit_gl {
+
+std::unique_ptr<orbit_accessibility::AccessibleInterface> ThreadBar::CreateAccessibleInterface() {
+  return std::make_unique<AccessibleThreadBar>(this);
+}
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/ThreadBar.h
+++ b/src/OrbitGl/ThreadBar.h
@@ -19,19 +19,33 @@ namespace orbit_gl {
 class ThreadBar : public CaptureViewElement, public std::enable_shared_from_this<ThreadBar> {
  public:
   explicit ThreadBar(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
-                     const CaptureData* capture_data, ThreadID thread_id)
+                     const CaptureData* capture_data, ThreadID thread_id,
+                     CaptureViewElement* parent, std::string name)
       : CaptureViewElement(time_graph, layout),
         thread_id_(thread_id),
         app_(app),
-        capture_data_(capture_data){};
+        capture_data_(capture_data),
+        parent_(parent),
+        name_(name) {}
 
   void SetThreadId(ThreadID thread_id) { thread_id_ = thread_id; }
   [[nodiscard]] virtual bool IsEmpty() const { return false; }
 
+  [[nodiscard]] virtual const std::string& GetName() const { return name_; }
+
+  [[nodiscard]] const CaptureViewElement* GetParent() const { return parent_; }
+
  protected:
+  [[nodiscard]] std::unique_ptr<orbit_accessibility::AccessibleInterface>
+  CreateAccessibleInterface() override;
+
   ThreadID thread_id_ = -1;
   OrbitApp* app_;
   const CaptureData* capture_data_;
+
+  CaptureViewElement* parent_;
+
+  std::string name_;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/ThreadStateTrack.cpp
+++ b/src/OrbitGl/ThreadStateTrack.cpp
@@ -23,8 +23,9 @@ using orbit_client_protos::ThreadStateSliceInfo;
 namespace orbit_gl {
 
 ThreadStateTrack::ThreadStateTrack(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
-                                   const CaptureData* capture_data, ThreadID thread_id)
-    : ThreadBar(app, time_graph, layout, capture_data, thread_id) {}
+                                   const CaptureData* capture_data, ThreadID thread_id,
+                                   CaptureViewElement* parent)
+    : ThreadBar(app, time_graph, layout, capture_data, thread_id, parent, "ThreadState") {}
 
 bool ThreadStateTrack::IsEmpty() const {
   if (capture_data_ == nullptr) return true;

--- a/src/OrbitGl/ThreadStateTrack.h
+++ b/src/OrbitGl/ThreadStateTrack.h
@@ -24,7 +24,8 @@ namespace orbit_gl {
 class ThreadStateTrack final : public ThreadBar {
  public:
   explicit ThreadStateTrack(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
-                            const CaptureData* capture_data, ThreadID thread_id);
+                            const CaptureData* capture_data, ThreadID thread_id,
+                            CaptureViewElement* parent);
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -284,6 +284,23 @@ void ThreadTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t
   TimerTrack::UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
 }
 
+std::vector<orbit_gl::CaptureViewElement*> ThreadTrack::GetVisibleChildren() {
+  std::vector<CaptureViewElement*> result;
+  if (!thread_state_track_->IsEmpty()) {
+    result.push_back(thread_state_track_.get());
+  }
+
+  if (!event_track_->IsEmpty()) {
+    result.push_back(event_track_.get());
+  }
+
+  if (!tracepoint_track_->IsEmpty()) {
+    result.push_back(tracepoint_track_.get());
+  }
+
+  return result;
+}
+
 void ThreadTrack::SetTrackColor(Color color) {
   absl::MutexLock lock(&mutex_);
   event_track_->SetColor(color);

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -60,7 +60,7 @@ void ThreadTrack::InitializeNameAndLabel(int32_t thread_id) {
     // This is the process track.
     const CaptureData& capture_data = app_->GetCaptureData();
     std::string process_name = capture_data.process_name();
-    SetName(process_name);
+    SetName("All Threads");
     const std::string_view all_threads = " (all_threads)";
     SetLabel(process_name.append(all_threads));
     SetNumberOfPrioritizedTrailingCharacters(all_threads.size() - 1);

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -40,15 +40,15 @@ ThreadTrack::ThreadTrack(TimeGraph* time_graph, TimeGraphLayout* layout, int32_t
   thread_id_ = thread_id;
   InitializeNameAndLabel(thread_id);
 
-  thread_state_track_ = std::make_shared<orbit_gl::ThreadStateTrack>(app_, time_graph, layout,
-                                                                     capture_data, thread_id_);
+  thread_state_track_ = std::make_shared<orbit_gl::ThreadStateTrack>(
+      app_, time_graph, layout, capture_data, thread_id_, this);
 
-  event_track_ =
-      std::make_shared<orbit_gl::EventTrack>(app_, time_graph, layout, capture_data, thread_id_);
+  event_track_ = std::make_shared<orbit_gl::EventTrack>(app_, time_graph, layout, capture_data,
+                                                        thread_id_, this);
   event_track_->SetThreadId(thread_id);
 
   tracepoint_track_ = std::make_shared<orbit_gl::TracepointTrack>(app_, time_graph, layout,
-                                                                  capture_data, thread_id_);
+                                                                  capture_data, thread_id_, this);
   SetTrackColor(TimeGraph::GetThreadColor(thread_id));
 }
 

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -48,6 +48,8 @@ class ThreadTrack final : public TimerTrack {
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;
 
+  [[nodiscard]] std::vector<CaptureViewElement*> GetVisibleChildren() override;
+
  protected:
   [[nodiscard]] bool IsTimerActive(const orbit_client_protos::TimerInfo& timer) const override;
   [[nodiscard]] bool IsTrackSelected() const override;

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -92,6 +92,8 @@ class TimerTrack : public Track {
 
   [[nodiscard]] virtual float GetHeaderHeight() const;
 
+  [[nodiscard]] int GetVisiblePrimitiveCount() const override { return visible_timer_count_; }
+
  protected:
   [[nodiscard]] virtual bool IsTimerActive(
       const orbit_client_protos::TimerInfo& /*timer_info*/) const {
@@ -104,9 +106,9 @@ class TimerTrack : public Track {
     return true;
   }
 
-  void DrawTimer(const TextBox* prev_text_box, const TextBox* next_text_box,
-                 const internal::DrawData& draw_data, TextBox* current_text_box,
-                 uint64_t* min_ignore, uint64_t* max_ignore);
+  [[nodiscard]] bool DrawTimer(const TextBox* prev_text_box, const TextBox* next_text_box,
+                               const internal::DrawData& draw_data, TextBox* current_text_box,
+                               uint64_t* min_ignore, uint64_t* max_ignore);
 
   void UpdateDepth(uint32_t depth) {
     if (depth > depth_) depth_ = depth;
@@ -120,6 +122,7 @@ class TimerTrack : public Track {
   uint32_t depth_ = 0;
   mutable absl::Mutex mutex_;
   std::map<int, std::shared_ptr<TimerChain>> timers_;
+  int visible_timer_count_ = 0;
 
   [[nodiscard]] virtual std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const;
   float GetHeight() const override;

--- a/src/OrbitGl/TracepointTrack.cpp
+++ b/src/OrbitGl/TracepointTrack.cpp
@@ -27,8 +27,10 @@
 namespace orbit_gl {
 
 TracepointTrack::TracepointTrack(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
-                                 const CaptureData* capture_data, int32_t thread_id)
-    : ThreadBar(app, time_graph, layout, capture_data, thread_id), color_{255, 0, 0, 255} {}
+                                 const CaptureData* capture_data, int32_t thread_id,
+                                 CaptureViewElement* parent)
+    : ThreadBar(app, time_graph, layout, capture_data, thread_id, parent, "Tracepoints"),
+      color_{255, 0, 0, 255} {}
 
 void TracepointTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
   ThreadBar::Draw(canvas, picking_mode, z_offset);

--- a/src/OrbitGl/TracepointTrack.h
+++ b/src/OrbitGl/TracepointTrack.h
@@ -16,7 +16,8 @@ namespace orbit_gl {
 class TracepointTrack : public ThreadBar {
  public:
   explicit TracepointTrack(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
-                           const CaptureData* capture_data, int32_t thread_id);
+                           const CaptureData* capture_data, int32_t thread_id,
+                           CaptureViewElement* parent);
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
 

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -23,7 +23,7 @@ Track::Track(TimeGraph* time_graph, TimeGraphLayout* layout, const CaptureData* 
       collapse_toggle_(std::make_shared<TriangleToggle>(
           TriangleToggle::State::kExpanded,
           [this](TriangleToggle::State state) { OnCollapseToggle(state); }, time_graph, layout)),
-      accessibility_(this, layout),
+      layout_(layout),
       capture_data_(capture_data) {
   const Color kDarkGrey(50, 50, 50, 255);
   color_ = kDarkGrey;
@@ -84,7 +84,7 @@ void Track::DrawTriangleFan(Batcher* batcher, const std::vector<Vec2>& points, c
 }
 
 std::unique_ptr<orbit_accessibility::AccessibleInterface> Track::CreateAccessibleInterface() {
-  return std::make_unique<orbit_gl::AccessibleTrack>(this, &time_graph_->GetLayout());
+  return std::make_unique<orbit_gl::AccessibleTrack>(this, layout_);
 }
 
 void Track::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -189,9 +189,7 @@ void Track::SetPinned(bool value) { pinned_ = value; }
 
 Color Track::GetBackgroundColor() const {
   int32_t capture_process_id = capture_data_ ? capture_data_->process_id() : -1;
-  if (GetType() == kSchedulerTrack) {
-    return color_;
-  }
+
   if (process_id_ != -1 && process_id_ != capture_process_id) {
     const Color kExternalProcessColor(30, 30, 40, 255);
     return kExternalProcessColor;

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -9,6 +9,7 @@
 
 #include <limits>
 
+#include "AccessibleTrack.h"
 #include "CoreMath.h"
 #include "Geometry.h"
 #include "GlCanvas.h"
@@ -80,6 +81,10 @@ void Track::DrawTriangleFan(Batcher* batcher, const std::vector<Vec2>& points, c
     Triangle triangle(pivot, vertices[i % 2], vertices[(i + 1) % 2]);
     batcher->AddTriangle(triangle, color, shared_from_this());
   }
+}
+
+std::unique_ptr<orbit_accessibility::AccessibleInterface> Track::CreateAccessibleInterface() {
+  return std::make_unique<orbit_gl::AccessibleTrack>(this, &time_graph_->GetLayout());
 }
 
 void Track::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -96,6 +96,7 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   [[nodiscard]] bool IsCollapsed() const { return collapse_toggle_->IsCollapsed(); }
 
   [[nodiscard]] virtual std::vector<CaptureViewElement*> GetVisibleChildren() { return {}; }
+  [[nodiscard]] virtual int GetVisiblePrimitiveCount() const { return 0; }
 
  protected:
   void DrawTriangleFan(Batcher* batcher, const std::vector<Vec2>& points, const Vec2& pos,

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -95,6 +95,8 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
 
   [[nodiscard]] bool IsCollapsed() const { return collapse_toggle_->IsCollapsed(); }
 
+  [[nodiscard]] virtual std::vector<CaptureViewElement*> GetVisibleChildren() { return {}; }
+
  protected:
   void DrawTriangleFan(Batcher* batcher, const std::vector<Vec2>& points, const Vec2& pos,
                        const Color& color, float rotation, float z);
@@ -114,6 +116,8 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   std::atomic<uint64_t> max_time_;
   Type type_ = kUnknown;
   std::shared_ptr<TriangleToggle> collapse_toggle_;
+
+  TimeGraphLayout* layout_;
 
   const CaptureData* capture_data_ = nullptr;
 };

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -15,6 +15,7 @@
 #include <string>
 #include <vector>
 
+#include "AccessibleTrack.h"
 #include "Batcher.h"
 #include "BlockChain.h"
 #include "CaptureViewElement.h"
@@ -24,7 +25,6 @@
 #include "TextRenderer.h"
 #include "TimeGraphLayout.h"
 #include "TimerChain.h"
-#include "TrackAccessibility.h"
 #include "TriangleToggle.h"
 #include "capture_data.pb.h"
 

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -15,7 +15,6 @@
 #include <string>
 #include <vector>
 
-#include "AccessibleTrack.h"
 #include "Batcher.h"
 #include "BlockChain.h"
 #include "CaptureViewElement.h"
@@ -88,7 +87,6 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
 
   [[nodiscard]] Color GetBackgroundColor() const;
 
-  void AddChild(const std::shared_ptr<Track>& track) { children_.emplace_back(track); }
   virtual void OnCollapseToggle(TriangleToggle::State state);
   [[nodiscard]] virtual bool IsCollapsible() const { return false; }
   [[nodiscard]] int32_t GetProcessId() const { return process_id_; }
@@ -99,14 +97,11 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
 
   [[nodiscard]] bool IsCollapsed() const { return collapse_toggle_->IsCollapsed(); }
 
-  // Accessibility
-  [[nodiscard]] const orbit_gl::AccessibleTrack* AccessibilityInterface() const {
-    return &accessibility_;
-  }
-
  protected:
   void DrawTriangleFan(Batcher* batcher, const std::vector<Vec2>& points, const Vec2& pos,
                        const Color& color, float rotation, float z);
+
+  std::unique_ptr<orbit_accessibility::AccessibleInterface> CreateAccessibleInterface() override;
 
   std::string name_;
   std::string label_;
@@ -120,10 +115,8 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   std::atomic<uint64_t> min_time_;
   std::atomic<uint64_t> max_time_;
   Type type_ = kUnknown;
-  std::vector<std::shared_ptr<Track>> children_;
   std::shared_ptr<TriangleToggle> collapse_toggle_;
 
-  orbit_gl::AccessibleTrack accessibility_;
   const CaptureData* capture_data_ = nullptr;
 };
 

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -32,13 +32,11 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   enum Type {
     kTimerTrack,
     kThreadTrack,
-    kEventTrack,
     kFrameTrack,
     kGraphTrack,
     kGpuTrack,
     kSchedulerTrack,
     kAsyncTrack,
-    kThreadStateTrack,
     kUnknown,
   };
 
@@ -85,7 +83,7 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   void SetLabel(const std::string& label) { label_ = label; }
   [[nodiscard]] const std::string& GetLabel() const { return label_; }
 
-  [[nodiscard]] Color GetBackgroundColor() const;
+  [[nodiscard]] virtual Color GetBackgroundColor() const;
 
   virtual void OnCollapseToggle(TriangleToggle::State state);
   [[nodiscard]] virtual bool IsCollapsible() const { return false; }

--- a/src/OrbitQt/AccessibilityAdapter.cpp
+++ b/src/OrbitQt/AccessibilityAdapter.cpp
@@ -190,6 +190,10 @@ int AccessibilityAdapter::indexOfChild(const QAccessibleInterface* child) const 
 QAccessibleInterface* AccessibilityAdapter::childAt(int x, int y) const {
   for (int i = 0; i < childCount(); ++i) {
     QAccessibleInterface* child_iface = child(i);
+    if (child_iface == nullptr) {
+      continue;
+    }
+
     QRect rect = child_iface->rect();
     if (x >= rect.x() && x < rect.x() + rect.width() && y >= rect.y() &&
         y < rect.y() + rect.height()) {


### PR DESCRIPTION
This PR enables basic accessibility information for the thread bars (EventTrack, TracepointTrack, ThreadStateTrack), and updates E2E tests to verify the newly available information:

- Tracks now report the existence and locations of thread bars underneath, but not individual samples
- Tracks expose the existence of timers: an additional TimerPane is reported if at lease one timer is visible in the current viewport, but no individual timers are reported
- The E2E tests for thread states, instrument function and frame track check for the respective content in the capture window

Suggest to go through it commit by commit as the first few commits lay some ground work.