### PR TITLE
Fix GGP and fuzz-testing build

### DIFF
--- a/contrib/jupyter/build.py
+++ b/contrib/jupyter/build.py
@@ -5,7 +5,6 @@ found in the LICENSE file.
 """
 
 import os, sys
-import build
 import subprocess
 
 def install_orbitutils():


### PR DESCRIPTION
The file `contrib/jupyter/build.py` is imported into `conanfile.py`
which is all good. But `contrib/jupyter/build.py` imports the package
`build` which is not available on all machines as it seems.

Since this package is not used in the file, I believe the proper fix is
to remove the `import` statement.