### PR TITLE
[CHERRY-PICK] Avoid LoadSymbols in parallel

### DIFF
--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -499,6 +499,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
 
   absl::flat_hash_map<std::string, orbit_base::Future<ErrorMessageOr<std::filesystem::path>>>
       modules_currently_loading_;
+  absl::flat_hash_map<std::string, orbit_base::Future<ErrorMessageOr<void>>>
+      symbols_currently_loading_;
 
   StringManager string_manager_;
   std::shared_ptr<grpc::Channel> grpc_channel_;


### PR DESCRIPTION
We used to check whether symbols are already loaded by checking
`module->is_loaded`, but that flag doesn't tell whether symbols are
currently being loaded. And this might lead to a race condition where
two competing `LoadSymbols` calls have been scheduled at the same time.

We avoid this by doing the same that we also do for module. We do
bookkeeping in a hash map about which module are currently being symbols
loaded for.