### PR TITLE
Fix PerfEventQueue::TopEvent,PopEvent returning different events

### DIFF
--- a/src/LinuxTracing/PerfEventQueueTest.cpp
+++ b/src/LinuxTracing/PerfEventQueueTest.cpp
@@ -251,4 +251,22 @@ TEST(PerfEventQueue, OrderedFdsAndNotOrderedInAnyFileDescriptor) {
   EXPECT_DEATH(event_queue.PopEvent(), "");
 }
 
+TEST(
+    PerfEventQueue,
+    TopEventAndPopEventReturnTheSameWhenAnEventOrderedByFdAndAnEventNotOrderedInAnyFdHaveTheSameTimestamp) {
+  PerfEventQueue event_queue;
+  constexpr uint64_t kCommonTimestamp = 100;
+
+  event_queue.PushEvent(MakeTestEvent(11, kCommonTimestamp));
+  event_queue.PushEvent(MakeTestEvent(PerfEvent::kNotOrderedInAnyFileDescriptor, kCommonTimestamp));
+
+  PerfEvent* top_event = event_queue.TopEvent();
+  std::unique_ptr<PerfEvent> popped_event = event_queue.PopEvent();
+  EXPECT_EQ(top_event, popped_event.get());
+  EXPECT_EQ(popped_event->GetOrderedInFileDescriptor(), PerfEvent::kNotOrderedInAnyFileDescriptor);
+
+  popped_event = event_queue.PopEvent();
+  EXPECT_EQ(popped_event->GetOrderedInFileDescriptor(), 11);
+}
+
 }  // namespace orbit_linux_tracing


### PR DESCRIPTION
When the `PerfEvent` at the top of `priority_queue_of_events_not_ordered_by_fd_`
and the `PerfEvent` at the top of `heap_of_queues_of_events_ordered_by_fd_` have
the exact same timestamp, `TopEvent` was returning the former, while `PopEvent`
was popping and returning the latter. This was particularly problematic when
`PopEvent` is called based on the result of `TopEvent`.

Bug: http://b/181840879

Test: Follow instructions in the bug and verify it's fixed. Add unit test that
was previously failing and now succeeds.