### PR TITLE
Fix long running unit test.

### DIFF
--- a/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
@@ -42,7 +42,7 @@ TEST(AccessTraceesMemoryTest, ReadWriteRestore) {
   auto result_backup = ReadTraceesMemory(pid, address_start, kMemorySize);
   CHECK(result_backup.has_value());
 
-  std::vector<uint8_t> new_data(result_backup.value().size());
+  std::vector<uint8_t> new_data(kMemorySize);
   std::mt19937 engine{std::random_device()()};
   std::uniform_int_distribution<uint8_t> distribution{0x00, 0xff};
   std::generate(std::begin(new_data), std::end(new_data),

--- a/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
@@ -9,6 +9,7 @@
 #include <sys/wait.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <functional>
 #include <iterator>
 #include <random>
@@ -36,9 +37,9 @@ TEST(AccessTraceesMemoryTest, ReadWriteRestore) {
   auto result_memory_region = GetFirstExecutableMemoryRegion(pid);
   CHECK(result_memory_region.has_value());
   const uint64_t address_start = result_memory_region.value().first;
-  const uint64_t address_end = result_memory_region.value().second;
 
-  auto result_backup = ReadTraceesMemory(pid, address_start, address_end - address_start);
+  constexpr uint64_t kMemorySize = 4 * 1024;
+  auto result_backup = ReadTraceesMemory(pid, address_start, kMemorySize);
   CHECK(result_backup.has_value());
 
   std::vector<uint8_t> new_data(result_backup.value().size());
@@ -49,7 +50,7 @@ TEST(AccessTraceesMemoryTest, ReadWriteRestore) {
 
   CHECK(!WriteTraceesMemory(pid, address_start, new_data).has_error());
 
-  auto result_read_back = ReadTraceesMemory(pid, address_start, address_end - address_start);
+  auto result_read_back = ReadTraceesMemory(pid, address_start, kMemorySize);
   CHECK(result_read_back.has_value());
 
   EXPECT_EQ(new_data, result_read_back.value());


### PR DESCRIPTION
AccessTraceesMemoryTest potentially accesses a lot of memory (6mb in one
run I checked). Since the access is done word by word with context
switches inbetween this takes too long for a unit test.

The test works just as well with limiting the memory access to 4kb.

If this should ever become a bottleneck there is a way of accessing
memory via a file system interface.

Bug: http://b/181880672
Test: Ran unit test locally.