### PR TITLE
Fixed copyright year in project files

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 ---

--- a/CMakeGraphVizOptions.cmake
+++ b/CMakeGraphVizOptions.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2020 The Orbit Authors. All rights reserved.
+Copyright (c) 2021 The Orbit Authors. All rights reserved.
 
 BSD 2-Clause License
 

--- a/bootstrap-orbit-ggp.ps1
+++ b/bootstrap-orbit-ggp.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/bootstrap-orbit-ggp.sh
+++ b/bootstrap-orbit-ggp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/bootstrap-orbit.ps1
+++ b/bootstrap-orbit.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/cmake/FindVulkanValidationLayers.cmake
+++ b/cmake/FindVulkanValidationLayers.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/cmake/Findgte.cmake
+++ b/cmake/Findgte.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/cmake/Findmulticore.cmake
+++ b/cmake/Findmulticore.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/cmake/Findoqpi.cmake
+++ b/cmake/Findoqpi.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/cmake/Findqtpropertybrowser.cmake
+++ b/cmake/Findqtpropertybrowser.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/cmake/Findstb.cmake
+++ b/cmake/Findstb.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/cmake/FindxxHash.cmake
+++ b/cmake/FindxxHash.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/cmake/collect_licenses.cmake
+++ b/cmake/collect_licenses.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/cmake/fuzzing.cmake
+++ b/cmake/fuzzing.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/cmake/grpc_helper.cmake
+++ b/cmake/grpc_helper.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved. Use of this source
+# Copyright (c) 2021 The Orbit Authors. All rights reserved. Use of this source
 # code is governed by a BSD-style license that can be found in the LICENSE file.
 
 cmake_minimum_required(VERSION 3.12)

--- a/cmake/iwyu.cmake
+++ b/cmake/iwyu.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/cmake/strip.cmake
+++ b/cmake/strip.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 
 """
-Copyright (c) 2020 The Orbit Authors. All rights reserved.
+Copyright (c) 2021 The Orbit Authors. All rights reserved.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 """

--- a/contrib/automation_tests/core/__init__.py
+++ b/contrib/automation_tests/core/__init__.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2020 The Orbit Authors. All rights reserved.
+Copyright (c) 2021 The Orbit Authors. All rights reserved.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 """

--- a/contrib/automation_tests/core/common_controls.py
+++ b/contrib/automation_tests/core/common_controls.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2020 The Orbit Authors. All rights reserved.
+Copyright (c) 2021 The Orbit Authors. All rights reserved.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 """

--- a/contrib/automation_tests/core/orbit_e2e.py
+++ b/contrib/automation_tests/core/orbit_e2e.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2020 The Orbit Authors. All rights reserved.
+Copyright (c) 2021 The Orbit Authors. All rights reserved.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 """

--- a/contrib/automation_tests/orbit_add_iterator.py
+++ b/contrib/automation_tests/orbit_add_iterator.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2020 The Orbit Authors. All rights reserved.
+Copyright (c) 2021 The Orbit Authors. All rights reserved.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 """

--- a/contrib/automation_tests/orbit_bottom_up.py
+++ b/contrib/automation_tests/orbit_bottom_up.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2020 The Orbit Authors. All rights reserved.
+Copyright (c) 2021 The Orbit Authors. All rights reserved.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 """

--- a/contrib/automation_tests/orbit_create_frame_track.py
+++ b/contrib/automation_tests/orbit_create_frame_track.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2020 The Orbit Authors. All rights reserved.
+Copyright (c) 2021 The Orbit Authors. All rights reserved.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 """

--- a/contrib/automation_tests/orbit_instrument_function.py
+++ b/contrib/automation_tests/orbit_instrument_function.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2020 The Orbit Authors. All rights reserved.
+Copyright (c) 2021 The Orbit Authors. All rights reserved.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 """

--- a/contrib/automation_tests/orbit_load_presets.py
+++ b/contrib/automation_tests/orbit_load_presets.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2020 The Orbit Authors. All rights reserved.
+Copyright (c) 2021 The Orbit Authors. All rights reserved.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 """

--- a/contrib/automation_tests/orbit_move_tabs.py
+++ b/contrib/automation_tests/orbit_move_tabs.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2020 The Orbit Authors. All rights reserved.
+Copyright (c) 2021 The Orbit Authors. All rights reserved.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 """

--- a/contrib/automation_tests/orbit_thread_state.py
+++ b/contrib/automation_tests/orbit_thread_state.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2020 The Orbit Authors. All rights reserved.
+Copyright (c) 2021 The Orbit Authors. All rights reserved.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 """

--- a/contrib/automation_tests/orbit_top_down.py
+++ b/contrib/automation_tests/orbit_top_down.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2020 The Orbit Authors. All rights reserved.
+Copyright (c) 2021 The Orbit Authors. All rights reserved.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 """

--- a/contrib/automation_tests/orbit_tracks.py
+++ b/contrib/automation_tests/orbit_tracks.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2020 The Orbit Authors. All rights reserved.
+Copyright (c) 2021 The Orbit Authors. All rights reserved.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 """

--- a/contrib/automation_tests/test_cases/__init__.py
+++ b/contrib/automation_tests/test_cases/__init__.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2020 The Orbit Authors. All rights reserved.
+Copyright (c) 2021 The Orbit Authors. All rights reserved.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 """

--- a/contrib/automation_tests/test_cases/bottom_up_tab.py
+++ b/contrib/automation_tests/test_cases/bottom_up_tab.py
@@ -1,8 +1,9 @@
 """
-Copyright (c) 2020 The Orbit Authors. All rights reserved.
+Copyright (c) 2021 The Orbit Authors. All rights reserved.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 """
+
 import logging
 
 from core.orbit_e2e import E2ETestCase, find_control

--- a/contrib/automation_tests/test_cases/capture_window.py
+++ b/contrib/automation_tests/test_cases/capture_window.py
@@ -1,8 +1,9 @@
 """
-Copyright (c) 2020 The Orbit Authors. All rights reserved.
+Copyright (c) 2021 The Orbit Authors. All rights reserved.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 """
+
 
 import logging
 import time

--- a/contrib/automation_tests/test_cases/connection_window.py
+++ b/contrib/automation_tests/test_cases/connection_window.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2020 The Orbit Authors. All rights reserved.
+Copyright (c) 2021 The Orbit Authors. All rights reserved.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 """

--- a/contrib/automation_tests/test_cases/live_tab.py
+++ b/contrib/automation_tests/test_cases/live_tab.py
@@ -1,8 +1,9 @@
 """
-Copyright (c) 2020 The Orbit Authors. All rights reserved.
+Copyright (c) 2021 The Orbit Authors. All rights reserved.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 """
+
 
 import logging
 from typing import Tuple

--- a/contrib/automation_tests/test_cases/main_window.py
+++ b/contrib/automation_tests/test_cases/main_window.py
@@ -1,8 +1,9 @@
 """
-Copyright (c) 2020 The Orbit Authors. All rights reserved.
+Copyright (c) 2021 The Orbit Authors. All rights reserved.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 """
+
 
 import logging
 

--- a/contrib/automation_tests/test_cases/symbols_tab.py
+++ b/contrib/automation_tests/test_cases/symbols_tab.py
@@ -1,8 +1,9 @@
 """
-Copyright (c) 2020 The Orbit Authors. All rights reserved.
+Copyright (c) 2021 The Orbit Authors. All rights reserved.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 """
+
 
 import logging
 

--- a/contrib/automation_tests/test_cases/top_down_tab.py
+++ b/contrib/automation_tests/test_cases/top_down_tab.py
@@ -1,8 +1,9 @@
 """
-Copyright (c) 2020 The Orbit Authors. All rights reserved.
+Copyright (c) 2021 The Orbit Authors. All rights reserved.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 """
+
 import logging
 
 from core.orbit_e2e import E2ETestCase, find_control

--- a/contrib/python/__init__.py
+++ b/contrib/python/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/contrib/python/conan_helpers.py
+++ b/contrib/python/conan_helpers.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 
 """
-Copyright (c) 2020 The Orbit Authors. All rights reserved.
+Copyright (c) 2021 The Orbit Authors. All rights reserved.
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 """

--- a/contrib/unit_test_coverage/generate_coverage_report.sh
+++ b/contrib/unit_test_coverage/generate_coverage_report.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/kokoro/checks/clang_format/check.sh
+++ b/kokoro/checks/clang_format/check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/kokoro/checks/clang_format/presubmit.cfg
+++ b/kokoro/checks/clang_format/presubmit.cfg
@@ -1,6 +1,6 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 #
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/run_clang_format.sh
+++ b/run_clang_format.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/run_client_ssh.ps1
+++ b/run_client_ssh.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/run_service.sh
+++ b/run_service.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/run_service_ssh.sh
+++ b/run_service_ssh.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/ClientProtos/CMakeLists.txt
+++ b/src/ClientProtos/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/ClientProtos/capture_data.proto
+++ b/src/ClientProtos/capture_data.proto
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/ClientProtos/preset.proto
+++ b/src/ClientProtos/preset.proto
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/CodeViewer/CMakeLists.txt
+++ b/src/CodeViewer/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/CodeViewer/Dialog.cpp
+++ b/src/CodeViewer/Dialog.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/CodeViewer/FontSizeInEm.cpp
+++ b/src/CodeViewer/FontSizeInEm.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/CodeViewer/FontSizeInEmTest.cpp
+++ b/src/CodeViewer/FontSizeInEmTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/CodeViewer/FontSizeInEmTest.cpp~4c65a40e (Rename Em tests to FontSizeInEm)
+++ b/src/CodeViewer/FontSizeInEmTest.cpp~4c65a40e (Rename Em tests to FontSizeInEm)
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/CodeViewer/PlaceHolderWidget.cpp
+++ b/src/CodeViewer/PlaceHolderWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/CodeViewer/Viewer.cpp
+++ b/src/CodeViewer/Viewer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/CodeViewer/ViewerTest.cpp
+++ b/src/CodeViewer/ViewerTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/CodeViewer/include/CodeViewer/Dialog.h
+++ b/src/CodeViewer/include/CodeViewer/Dialog.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/CodeViewer/include/CodeViewer/FontSizeInEm.h
+++ b/src/CodeViewer/include/CodeViewer/FontSizeInEm.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/CodeViewer/include/CodeViewer/PlaceHolderWidget.h
+++ b/src/CodeViewer/include/CodeViewer/PlaceHolderWidget.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/CodeViewer/include/CodeViewer/Viewer.h
+++ b/src/CodeViewer/include/CodeViewer/Viewer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/CodeViewerDemo/CMakeLists.txt
+++ b/src/CodeViewerDemo/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/CodeViewerDemo/main.cpp
+++ b/src/CodeViewerDemo/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/CrashHandler/CrashHandler.cpp
+++ b/src/CrashHandler/CrashHandler.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/CrashHandler/CrashOptions.cpp.in
+++ b/src/CrashHandler/CrashOptions.cpp.in
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/CrashHandler/include/CrashHandler/CrashHandler.h
+++ b/src/CrashHandler/include/CrashHandler/CrashHandler.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/CrashHandler/include/CrashHandler/CrashOptions.h
+++ b/src/CrashHandler/include/CrashHandler/CrashOptions.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/ElfUtils/CMakeLists.txt
+++ b/src/ElfUtils/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/ElfUtils/ElfFile.cpp
+++ b/src/ElfUtils/ElfFile.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/ElfUtils/ElfFileLoadSymbolsFuzzer.cpp
+++ b/src/ElfUtils/ElfFileLoadSymbolsFuzzer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/ElfUtils/ElfFileTest.cpp
+++ b/src/ElfUtils/ElfFileTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/ElfUtils/LinuxMap.cpp
+++ b/src/ElfUtils/LinuxMap.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/ElfUtils/LinuxMapTest.cpp
+++ b/src/ElfUtils/LinuxMapTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/ElfUtils/include/ElfUtils/ElfFile.h
+++ b/src/ElfUtils/include/ElfUtils/ElfFile.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/ElfUtils/include/ElfUtils/LinuxMap.h
+++ b/src/ElfUtils/include/ElfUtils/LinuxMap.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/FramePointerValidator/FramePointerValidator.cpp
+++ b/src/FramePointerValidator/FramePointerValidator.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/FramePointerValidator/FramePointerValidatorTest.cpp
+++ b/src/FramePointerValidator/FramePointerValidatorTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/FramePointerValidator/FunctionFramePointerValidator.cpp
+++ b/src/FramePointerValidator/FunctionFramePointerValidator.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/FramePointerValidator/FunctionFramePointerValidatorTest.cpp
+++ b/src/FramePointerValidator/FunctionFramePointerValidatorTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/FramePointerValidator/include/FramePointerValidator/FramePointerValidator.h
+++ b/src/FramePointerValidator/include/FramePointerValidator/FramePointerValidator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/FramePointerValidator/include/FramePointerValidator/FunctionFramePointerValidator.h
+++ b/src/FramePointerValidator/include/FramePointerValidator/FunctionFramePointerValidator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/GrpcProtos/CMakeLists.txt
+++ b/src/GrpcProtos/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/GrpcProtos/code_block.proto
+++ b/src/GrpcProtos/code_block.proto
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/GrpcProtos/module.proto
+++ b/src/GrpcProtos/module.proto
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/GrpcProtos/process.proto
+++ b/src/GrpcProtos/process.proto
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/GrpcProtos/producer_side_services.proto
+++ b/src/GrpcProtos/producer_side_services.proto
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/GrpcProtos/services.proto
+++ b/src/GrpcProtos/services.proto
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/GrpcProtos/services_ggp.proto
+++ b/src/GrpcProtos/services_ggp.proto
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/GrpcProtos/symbol.proto
+++ b/src/GrpcProtos/symbol.proto
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/GrpcProtos/tracepoint.proto
+++ b/src/GrpcProtos/tracepoint.proto
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/LinuxTracing/CMakeLists.txt
+++ b/src/LinuxTracing/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/LinuxTracing/ContextSwitchManager.cpp
+++ b/src/LinuxTracing/ContextSwitchManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/LinuxTracing/ContextSwitchManager.h
+++ b/src/LinuxTracing/ContextSwitchManager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/LinuxTracing/ContextSwitchManagerTest.cpp
+++ b/src/LinuxTracing/ContextSwitchManagerTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/LinuxTracing/Function.h
+++ b/src/LinuxTracing/Function.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/LinuxTracing/GpuTracepointVisitor.cpp
+++ b/src/LinuxTracing/GpuTracepointVisitor.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/LinuxTracing/GpuTracepointVisitor.h
+++ b/src/LinuxTracing/GpuTracepointVisitor.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/LinuxTracing/GpuTracepointVisitorTest.cpp
+++ b/src/LinuxTracing/GpuTracepointVisitorTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/LinuxTracing/KernelTracepoints.h
+++ b/src/LinuxTracing/KernelTracepoints.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef LINUX_TRACING_TRACEPOINTS_H_
 #define LINUX_TRACING_TRACEPOINTS_H_

--- a/src/LinuxTracing/LibunwindstackUnwinder.cpp
+++ b/src/LinuxTracing/LibunwindstackUnwinder.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "LibunwindstackUnwinder.h"
 

--- a/src/LinuxTracing/LibunwindstackUnwinder.h
+++ b/src/LinuxTracing/LibunwindstackUnwinder.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef LINUX_TRACING_LIBUNWINDSTACK_UNWINDER_H_
 #define LINUX_TRACING_LIBUNWINDSTACK_UNWINDER_H_

--- a/src/LinuxTracing/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracing/LinuxTracingIntegrationTest.cpp
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+
 #include <absl/container/flat_hash_set.h>
 #include <absl/strings/numbers.h>
 #include <absl/synchronization/mutex.h>

--- a/src/LinuxTracing/LinuxTracingIntegrationTestPuppet.cpp
+++ b/src/LinuxTracing/LinuxTracingIntegrationTestPuppet.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "LinuxTracingIntegrationTestPuppet.h"
 

--- a/src/LinuxTracing/LinuxTracingIntegrationTestPuppetSharedObject.cpp
+++ b/src/LinuxTracing/LinuxTracingIntegrationTestPuppetSharedObject.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <stddef.h>
 

--- a/src/LinuxTracing/LinuxTracingUtils.cpp
+++ b/src/LinuxTracing/LinuxTracingUtils.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <absl/strings/numbers.h>
 #include <absl/strings/str_format.h>

--- a/src/LinuxTracing/LinuxTracingUtils.h
+++ b/src/LinuxTracing/LinuxTracingUtils.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef LINUX_TRACING_LINUX_TRACING_UTILS_H_
 #define LINUX_TRACING_LINUX_TRACING_UTILS_H_

--- a/src/LinuxTracing/LinuxTracingUtilsTest.cpp
+++ b/src/LinuxTracing/LinuxTracingUtilsTest.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <absl/strings/str_format.h>
 #include <absl/synchronization/mutex.h>

--- a/src/LinuxTracing/ManualInstrumentationConfig.h
+++ b/src/LinuxTracing/ManualInstrumentationConfig.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef LINUX_TRACING_MANUAL_INSTRUMENTATION_CONFIG_H_
 #define LINUX_TRACING_MANUAL_INSTRUMENTATION_CONFIG_H_

--- a/src/LinuxTracing/PerfEvent.cpp
+++ b/src/LinuxTracing/PerfEvent.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "PerfEvent.h"
 

--- a/src/LinuxTracing/PerfEvent.h
+++ b/src/LinuxTracing/PerfEvent.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef LINUX_TRACING_PERF_EVENT_H_
 #define LINUX_TRACING_PERF_EVENT_H_

--- a/src/LinuxTracing/PerfEventOpen.cpp
+++ b/src/LinuxTracing/PerfEventOpen.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/LinuxTracing/PerfEventProcessor.cpp
+++ b/src/LinuxTracing/PerfEventProcessor.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "PerfEventProcessor.h"
 

--- a/src/LinuxTracing/PerfEventProcessor.h
+++ b/src/LinuxTracing/PerfEventProcessor.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef LINUX_TRACING_PERF_EVENT_PROCESSOR_H_
 #define LINUX_TRACING_PERF_EVENT_PROCESSOR_H_

--- a/src/LinuxTracing/PerfEventProcessorTest.cpp
+++ b/src/LinuxTracing/PerfEventProcessorTest.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/src/LinuxTracing/PerfEventQueue.cpp
+++ b/src/LinuxTracing/PerfEventQueue.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/LinuxTracing/PerfEventQueue.h
+++ b/src/LinuxTracing/PerfEventQueue.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef LINUX_TRACING_PERF_EVENT_QUEUE_H_
 #define LINUX_TRACING_PERF_EVENT_QUEUE_H_

--- a/src/LinuxTracing/PerfEventQueueTest.cpp
+++ b/src/LinuxTracing/PerfEventQueueTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/LinuxTracing/PerfEventReaders.cpp
+++ b/src/LinuxTracing/PerfEventReaders.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "PerfEventReaders.h"
 

--- a/src/LinuxTracing/PerfEventReaders.h
+++ b/src/LinuxTracing/PerfEventReaders.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/LinuxTracing/PerfEventRecords.h
+++ b/src/LinuxTracing/PerfEventRecords.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef LINUX_TRACING_PERF_EVENT_RECORDS_H_
 #define LINUX_TRACING_PERF_EVENT_RECORDS_H_

--- a/src/LinuxTracing/PerfEventRingBuffer.cpp
+++ b/src/LinuxTracing/PerfEventRingBuffer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/LinuxTracing/PerfEventRingBuffer.h
+++ b/src/LinuxTracing/PerfEventRingBuffer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/LinuxTracing/PerfEventVisitor.h
+++ b/src/LinuxTracing/PerfEventVisitor.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef LINUX_TRACING_PERF_EVENT_VISITOR_H_
 #define LINUX_TRACING_PERF_EVENT_VISITOR_H_

--- a/src/LinuxTracing/SwitchesStatesNamesVisitor.h
+++ b/src/LinuxTracing/SwitchesStatesNamesVisitor.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/LinuxTracing/ThreadStateManager.cpp
+++ b/src/LinuxTracing/ThreadStateManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/LinuxTracing/ThreadStateManager.h
+++ b/src/LinuxTracing/ThreadStateManager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/LinuxTracing/ThreadStateManagerTest.cpp
+++ b/src/LinuxTracing/ThreadStateManagerTest.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <gtest/gtest.h>
 #include <sys/types.h>

--- a/src/LinuxTracing/TracerThread.cpp
+++ b/src/LinuxTracing/TracerThread.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "TracerThread.h"
 

--- a/src/LinuxTracing/TracerThread.h
+++ b/src/LinuxTracing/TracerThread.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/LinuxTracing/UprobesFunctionCallManagerTest.cpp
+++ b/src/LinuxTracing/UprobesFunctionCallManagerTest.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <gtest/gtest.h>
 #include <sys/types.h>

--- a/src/LinuxTracing/UprobesReturnAddressManager.h
+++ b/src/LinuxTracing/UprobesReturnAddressManager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/LinuxTracing/UprobesReturnAddressManagerTest.cpp
+++ b/src/LinuxTracing/UprobesReturnAddressManagerTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/LinuxTracing/UprobesUnwindingVisitor.h
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/LinuxTracing/include/LinuxTracing/Tracer.h
+++ b/src/LinuxTracing/include/LinuxTracing/Tracer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/LinuxTracing/include/LinuxTracing/TracerListener.h
+++ b/src/LinuxTracing/include/LinuxTracing/TracerListener.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/MetricsUploader/MetricsUploaderLinux.cpp
+++ b/src/MetricsUploader/MetricsUploaderLinux.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "MetricsUploader/MetricsUploader.h"
 #include "OrbitBase/Result.h"

--- a/src/MetricsUploader/MetricsUploaderWindows.cpp
+++ b/src/MetricsUploader/MetricsUploaderWindows.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <Rpc.h>
 #include <absl/memory/memory.h>

--- a/src/MetricsUploader/MetricsUploaderWindowsTest.cpp
+++ b/src/MetricsUploader/MetricsUploaderWindowsTest.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <gtest/gtest.h>
 

--- a/src/MetricsUploader/Result.cpp
+++ b/src/MetricsUploader/Result.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/MetricsUploader/TestClients/ClientWithoutSendEvent.cpp
+++ b/src/MetricsUploader/TestClients/ClientWithoutSendEvent.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "MetricsUploader/Result.h"
 

--- a/src/MetricsUploader/TestClients/ClientWithoutSetup.cpp
+++ b/src/MetricsUploader/TestClients/ClientWithoutSetup.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/MetricsUploader/TestClients/ClientWithoutShutdown.cpp
+++ b/src/MetricsUploader/TestClients/ClientWithoutShutdown.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/MetricsUploader/TestClients/CompleteClient.cpp
+++ b/src/MetricsUploader/TestClients/CompleteClient.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <cstdint>
 

--- a/src/MetricsUploader/TestClients/SetupWithErrorClient.cpp
+++ b/src/MetricsUploader/TestClients/SetupWithErrorClient.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/MetricsUploader/include/MetricsUploader/MetricsUploader.h
+++ b/src/MetricsUploader/include/MetricsUploader/MetricsUploader.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/MetricsUploader/include/MetricsUploader/Result.h
+++ b/src/MetricsUploader/include/MetricsUploader/Result.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_METRICS_UPLOADER_RESULT_H_
 #define ORBIT_METRICS_UPLOADER_RESULT_H_

--- a/src/MetricsUploader/proto/orbit_log_event.proto
+++ b/src/MetricsUploader/proto/orbit_log_event.proto
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/Orbit.h
+++ b/src/Orbit.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_H_
 #define ORBIT_H_

--- a/src/OrbitAccessibility/AccessibleInterface.cpp
+++ b/src/OrbitAccessibility/AccessibleInterface.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitAccessibility/AccessibleInterfaceRegistry.cpp
+++ b/src/OrbitAccessibility/AccessibleInterfaceRegistry.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitAccessibility/AccessibleInterfaceRegistryTest.cpp
+++ b/src/OrbitAccessibility/AccessibleInterfaceRegistryTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitAccessibility/CMakeLists.txt
+++ b/src/OrbitAccessibility/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/OrbitAccessibility/include/OrbitAccessibility/AccessibleInterfaceRegistry.h
+++ b/src/OrbitAccessibility/include/OrbitAccessibility/AccessibleInterfaceRegistry.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_ACCESSIBILITY_ACCESSIBLE_INTERFACE_REGISTRY_H_
 #define ORBIT_ACCESSIBILITY_ACCESSIBLE_INTERFACE_REGISTRY_H_

--- a/src/OrbitAccessibility/include/OrbitAccessibility/AccessibleObjectFake.h
+++ b/src/OrbitAccessibility/include/OrbitAccessibility/AccessibleObjectFake.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitAccessibility/include/OrbitAccessibility/AccessibleWidgetBridge.h
+++ b/src/OrbitAccessibility/include/OrbitAccessibility/AccessibleWidgetBridge.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_ACCESSIBILITY_ACCESSIBLE_WIDGET_BRIDGE_H_
 #define ORBIT_ACCESSIBILITY_ACCESSIBLE_WIDGET_BRIDGE_H_

--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/OrbitBase/ExecutablePath.cpp
+++ b/src/OrbitBase/ExecutablePath.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitBase/ExecutablePathLinux.cpp
+++ b/src/OrbitBase/ExecutablePathLinux.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <errno.h>
 #include <limits.h>

--- a/src/OrbitBase/ExecutablePathLinuxTest.cpp
+++ b/src/OrbitBase/ExecutablePathLinuxTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitBase/ExecutablePathTest.cpp
+++ b/src/OrbitBase/ExecutablePathTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitBase/ExecutablePathWindows.cpp
+++ b/src/OrbitBase/ExecutablePathWindows.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitBase/Logging.cpp
+++ b/src/OrbitBase/Logging.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "OrbitBase/Logging.h"
 

--- a/src/OrbitBase/OrbitApiTest.cpp
+++ b/src/OrbitBase/OrbitApiTest.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <gtest/gtest.h>
 #include <stdint.h>

--- a/src/OrbitBase/ProfilingTest.cpp
+++ b/src/OrbitBase/ProfilingTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitBase/ReadFileToString.cpp
+++ b/src/OrbitBase/ReadFileToString.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "OrbitBase/ReadFileToString.h"
 

--- a/src/OrbitBase/ReadFileToStringTest.cpp
+++ b/src/OrbitBase/ReadFileToStringTest.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <gtest/gtest.h>
 

--- a/src/OrbitBase/SafeStrerror.cpp
+++ b/src/OrbitBase/SafeStrerror.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitBase/ThreadPool.cpp
+++ b/src/OrbitBase/ThreadPool.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitBase/ThreadPoolTest.cpp
+++ b/src/OrbitBase/ThreadPoolTest.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <absl/time/time.h>
 #include <gtest/gtest.h>

--- a/src/OrbitBase/ThreadUtilsLinux.cpp
+++ b/src/OrbitBase/ThreadUtilsLinux.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <absl/strings/str_format.h>
 #include <pthread.h>

--- a/src/OrbitBase/ThreadUtilsTest.cpp
+++ b/src/OrbitBase/ThreadUtilsTest.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <absl/synchronization/mutex.h>
 #include <gtest/gtest.h>

--- a/src/OrbitBase/ThreadUtilsWindows.cpp
+++ b/src/OrbitBase/ThreadUtilsWindows.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitBase/Tracing.cpp
+++ b/src/OrbitBase/Tracing.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "OrbitBase/Tracing.h"
 

--- a/src/OrbitBase/TracingTest.cpp
+++ b/src/OrbitBase/TracingTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitBase/UniqueResourceTest.cpp
+++ b/src/OrbitBase/UniqueResourceTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitBase/WriteStringToFile.cpp
+++ b/src/OrbitBase/WriteStringToFile.cpp
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+
 #include "OrbitBase/WriteStringToFile.h"
 
 #include <absl/strings/str_format.h>

--- a/src/OrbitBase/include/OrbitBase/Action.h
+++ b/src/OrbitBase/include/OrbitBase/Action.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_BASE_ACTION_H_
 #define ORBIT_BASE_ACTION_H_

--- a/src/OrbitBase/include/OrbitBase/ExecutablePath.h
+++ b/src/OrbitBase/include/OrbitBase/ExecutablePath.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_BASE_PATH_H_
 #define ORBIT_BASE_PATH_H_

--- a/src/OrbitBase/include/OrbitBase/Logging.h
+++ b/src/OrbitBase/include/OrbitBase/Logging.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_BASE_LOGGING_H_
 #define ORBIT_BASE_LOGGING_H_

--- a/src/OrbitBase/include/OrbitBase/MakeUniqueForOverwrite.h
+++ b/src/OrbitBase/include/OrbitBase/MakeUniqueForOverwrite.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitBase/include/OrbitBase/Profiling.h
+++ b/src/OrbitBase/include/OrbitBase/Profiling.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitBase/include/OrbitBase/ReadFileToString.h
+++ b/src/OrbitBase/include/OrbitBase/ReadFileToString.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_BASE_READ_FILE_TO_STRING_H_
 #define ORBIT_BASE_READ_FILE_TO_STRING_H_

--- a/src/OrbitBase/include/OrbitBase/Result.h
+++ b/src/OrbitBase/include/OrbitBase/Result.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitBase/include/OrbitBase/SafeStrerror.h
+++ b/src/OrbitBase/include/OrbitBase/SafeStrerror.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_BASE_SAFE_STRERROR_H_
 #define ORBIT_BASE_SAFE_STRERROR_H_

--- a/src/OrbitBase/include/OrbitBase/ThreadConstants.h
+++ b/src/OrbitBase/include/OrbitBase/ThreadConstants.h
@@ -1,6 +1,8 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+
 #ifndef ORBIT_BASE_THREAD_CONSTANTS_H
 #define ORBIT_BASE_THREAD_CONSTANTS_H
 

--- a/src/OrbitBase/include/OrbitBase/ThreadPool.h
+++ b/src/OrbitBase/include/OrbitBase/ThreadPool.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitBase/include/OrbitBase/ThreadUtils.h
+++ b/src/OrbitBase/include/OrbitBase/ThreadUtils.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_BASE_THREAD_UTILS_H_
 #define ORBIT_BASE_THREAD_UTILS_H_

--- a/src/OrbitBase/include/OrbitBase/Tracing.h
+++ b/src/OrbitBase/include/OrbitBase/Tracing.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_BASE_TRACING_H_
 #define ORBIT_BASE_TRACING_H_

--- a/src/OrbitBase/include/OrbitBase/UniqueResource.h
+++ b/src/OrbitBase/include/OrbitBase/UniqueResource.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_BASE_UNIQUE_RESOURCE_H_
 #define ORBIT_BASE_UNIQUE_RESOURCE_H_

--- a/src/OrbitCaptureClient/CMakeLists.txt
+++ b/src/OrbitCaptureClient/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/OrbitCaptureClient/CaptureClient.cpp
+++ b/src/OrbitCaptureClient/CaptureClient.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitCaptureClient/CaptureEventProcessor.cpp
+++ b/src/OrbitCaptureClient/CaptureEventProcessor.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/src/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <absl/container/flat_hash_map.h>
 #include <libfuzzer/libfuzzer_macro.h>

--- a/src/OrbitCaptureClient/CaptureEventProcessorTest.cpp
+++ b/src/OrbitCaptureClient/CaptureEventProcessorTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitCaptureClient/GpuQueueSubmissionProcessor.cpp
+++ b/src/OrbitCaptureClient/GpuQueueSubmissionProcessor.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_CAPTURE_CLIENT_CAPTURE_CLIENT_H_
 #define ORBIT_CAPTURE_CLIENT_CAPTURE_CLIENT_H_

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/GpuQueueSubmissionProcessor.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/GpuQueueSubmissionProcessor.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_CAPTURE_CLIENT_GPU_QUEUE_SUBMISSION_PROCESSOR_H_
 #define ORBIT_CAPTURE_CLIENT_GPU_QUEUE_SUBMISSION_PROCESSOR_H_

--- a/src/OrbitCaptureGgpClient/CMakeLists.txt
+++ b/src/OrbitCaptureGgpClient/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/OrbitCaptureGgpClient/include/OrbitCaptureGgpClient/OrbitCaptureGgpClient.h
+++ b/src/OrbitCaptureGgpClient/include/OrbitCaptureGgpClient/OrbitCaptureGgpClient.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitCaptureGgpClient/main.cpp
+++ b/src/OrbitCaptureGgpClient/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitCaptureGgpService/CMakeLists.txt
+++ b/src/OrbitCaptureGgpService/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/OrbitCaptureGgpService/OrbitCaptureGgpService.cpp
+++ b/src/OrbitCaptureGgpService/OrbitCaptureGgpService.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "OrbitCaptureGgpService.h"
 

--- a/src/OrbitCaptureGgpService/OrbitCaptureGgpService.h
+++ b/src/OrbitCaptureGgpService/OrbitCaptureGgpService.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_CAPTURE_GGP_SERVICE_ORBIT_CAPTURE_GGP_SERVICE_H_
 #define ORBIT_CAPTURE_GGP_SERVICE_ORBIT_CAPTURE_GGP_SERVICE_H_

--- a/src/OrbitCaptureGgpService/OrbitCaptureGgpServiceImpl.cpp
+++ b/src/OrbitCaptureGgpService/OrbitCaptureGgpServiceImpl.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitCaptureGgpService/OrbitCaptureGgpServiceImpl.h
+++ b/src/OrbitCaptureGgpService/OrbitCaptureGgpServiceImpl.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitCaptureGgpService/main.cpp
+++ b/src/OrbitCaptureGgpService/main.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <stdint.h>
 

--- a/src/OrbitClientData/CMakeLists.txt
+++ b/src/OrbitClientData/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/OrbitClientData/CallstackData.cpp
+++ b/src/OrbitClientData/CallstackData.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "OrbitClientData/CallstackData.h"
 

--- a/src/OrbitClientData/CallstackDataTest.cpp
+++ b/src/OrbitClientData/CallstackDataTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitClientData/FunctionInfoSetTest.cpp
+++ b/src/OrbitClientData/FunctionInfoSetTest.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <absl/container/flat_hash_map.h>
 #include <gtest/gtest.h>

--- a/src/OrbitClientData/FunctionUtils.cpp
+++ b/src/OrbitClientData/FunctionUtils.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "OrbitClientData/FunctionUtils.h"
 

--- a/src/OrbitClientData/ModuleData.cpp
+++ b/src/OrbitClientData/ModuleData.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitClientData/ModuleDataTest.cpp
+++ b/src/OrbitClientData/ModuleDataTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitClientData/ModuleManager.cpp
+++ b/src/OrbitClientData/ModuleManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitClientData/ModuleManagerTest.cpp
+++ b/src/OrbitClientData/ModuleManagerTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitClientData/ProcessData.cpp
+++ b/src/OrbitClientData/ProcessData.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "OrbitClientData/ProcessData.h"
 

--- a/src/OrbitClientData/ProcessDataTest.cpp
+++ b/src/OrbitClientData/ProcessDataTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitClientData/TracepointData.cpp
+++ b/src/OrbitClientData/TracepointData.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitClientData/TracepointDataTest.cpp
+++ b/src/OrbitClientData/TracepointDataTest.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/src/OrbitClientData/UserDefinedCaptureData.cpp
+++ b/src/OrbitClientData/UserDefinedCaptureData.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitClientData/UserDefinedCaptureDataTest.cpp
+++ b/src/OrbitClientData/UserDefinedCaptureDataTest.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <gtest/gtest.h>
 #include <stdint.h>

--- a/src/OrbitClientData/include/OrbitClientData/Callstack.h
+++ b/src/OrbitClientData/include/OrbitClientData/Callstack.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitClientData/include/OrbitClientData/CallstackData.h
+++ b/src/OrbitClientData/include/OrbitClientData/CallstackData.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_CORE_CALLSTACK_DATA_H_
 #define ORBIT_CORE_CALLSTACK_DATA_H_

--- a/src/OrbitClientData/include/OrbitClientData/CallstackTypes.h
+++ b/src/OrbitClientData/include/OrbitClientData/CallstackTypes.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitClientData/include/OrbitClientData/FunctionInfoSet.h
+++ b/src/OrbitClientData/include/OrbitClientData/FunctionInfoSet.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_CLIENT_DATA_FUNCTION_INFO_SET_H_
 #define ORBIT_CLIENT_DATA_FUNCTION_INFO_SET_H_

--- a/src/OrbitClientData/include/OrbitClientData/FunctionUtils.h
+++ b/src/OrbitClientData/include/OrbitClientData/FunctionUtils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitClientData/include/OrbitClientData/ModuleData.h
+++ b/src/OrbitClientData/include/OrbitClientData/ModuleData.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitClientData/include/OrbitClientData/ModuleManager.h
+++ b/src/OrbitClientData/include/OrbitClientData/ModuleManager.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_CLIENT_DATA_MODULE_MANAGER_H_
 #define ORBIT_CLIENT_DATA_MODULE_MANAGER_H_

--- a/src/OrbitClientData/include/OrbitClientData/PostProcessedSamplingData.h
+++ b/src/OrbitClientData/include/OrbitClientData/PostProcessedSamplingData.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitClientData/include/OrbitClientData/ProcessData.h
+++ b/src/OrbitClientData/include/OrbitClientData/ProcessData.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_CLIENT_DATA_PROCESS_DATA_H_
 #define ORBIT_CLIENT_DATA_PROCESS_DATA_H_

--- a/src/OrbitClientData/include/OrbitClientData/TracepointCustom.h
+++ b/src/OrbitClientData/include/OrbitClientData/TracepointCustom.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_CORE_TRACEPOINT_CUSTOM_H_
 #define ORBIT_CORE_TRACEPOINT_CUSTOM_H_

--- a/src/OrbitClientData/include/OrbitClientData/TracepointData.h
+++ b/src/OrbitClientData/include/OrbitClientData/TracepointData.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_CORE_TRACEPOINT_EVENT_BUFFER_H_
 #define ORBIT_CORE_TRACEPOINT_EVENT_BUFFER_H_

--- a/src/OrbitClientData/include/OrbitClientData/UserDefinedCaptureData.h
+++ b/src/OrbitClientData/include/OrbitClientData/UserDefinedCaptureData.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_CORE_USER_DEFINED_CAPTURE_DATA_H_
 #define ORBIT_CORE_USER_DEFINED_CAPTURE_DATA_H_

--- a/src/OrbitClientGgp/CMakeLists.txt
+++ b/src/OrbitClientGgp/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/OrbitClientGgp/ClientGgp.cpp
+++ b/src/OrbitClientGgp/ClientGgp.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "OrbitClientGgp/ClientGgp.h"
 

--- a/src/OrbitClientGgp/include/OrbitClientGgp/ClientGgp.h
+++ b/src/OrbitClientGgp/include/OrbitClientGgp/ClientGgp.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitClientGgp/include/OrbitClientGgp/ClientGgpOptions.h
+++ b/src/OrbitClientGgp/include/OrbitClientGgp/ClientGgpOptions.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_CLIENT_GGP_CLIENT_GGP_OPTIONS_H_
 #define ORBIT_CLIENT_GGP_CLIENT_GGP_OPTIONS_H_

--- a/src/OrbitClientGgp/main.cpp
+++ b/src/OrbitClientGgp/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitClientModel/CMakeLists.txt
+++ b/src/OrbitClientModel/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/OrbitClientModel/CaptureData.cpp
+++ b/src/OrbitClientModel/CaptureData.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "OrbitClientModel/CaptureData.h"
 

--- a/src/OrbitClientModel/CaptureDeserializer.cpp
+++ b/src/OrbitClientModel/CaptureDeserializer.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "OrbitClientModel/CaptureDeserializer.h"
 

--- a/src/OrbitClientModel/CaptureDeserializerLoadFuzzer.cpp
+++ b/src/OrbitClientModel/CaptureDeserializerLoadFuzzer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitClientModel/CaptureDeserializerTest.cpp
+++ b/src/OrbitClientModel/CaptureDeserializerTest.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>

--- a/src/OrbitClientModel/CaptureSerializationTestMatchers.h
+++ b/src/OrbitClientModel/CaptureSerializationTestMatchers.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitClientModel/CaptureSerializer.cpp
+++ b/src/OrbitClientModel/CaptureSerializer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitClientModel/CaptureSerializerTest.cpp
+++ b/src/OrbitClientModel/CaptureSerializerTest.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <gmock/gmock.h>
 #include <google/protobuf/stubs/port.h>

--- a/src/OrbitClientModel/SamplingDataPostProcessor.cpp
+++ b/src/OrbitClientModel/SamplingDataPostProcessor.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitClientModel/include/OrbitClientModel/CaptureData.h
+++ b/src/OrbitClientModel/include/OrbitClientModel/CaptureData.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitClientModel/include/OrbitClientModel/CaptureDeserializer.h
+++ b/src/OrbitClientModel/include/OrbitClientModel/CaptureDeserializer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitClientModel/include/OrbitClientModel/CaptureSerializer.h
+++ b/src/OrbitClientModel/include/OrbitClientModel/CaptureSerializer.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_CLIENT_MODEL_CAPTURE_SERIALIZER_H_
 #define ORBIT_CLIENT_MODEL_CAPTURE_SERIALIZER_H_

--- a/src/OrbitClientModel/include/OrbitClientModel/SamplingDataPostProcessor.h
+++ b/src/OrbitClientModel/include/OrbitClientModel/SamplingDataPostProcessor.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitClientServices/CMakeLists.txt
+++ b/src/OrbitClientServices/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/OrbitClientServices/CrashManager.cpp
+++ b/src/OrbitClientServices/CrashManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitClientServices/ProcessClient.cpp
+++ b/src/OrbitClientServices/ProcessClient.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitClientServices/ProcessManager.cpp
+++ b/src/OrbitClientServices/ProcessManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitClientServices/TracepointServiceClient.cpp
+++ b/src/OrbitClientServices/TracepointServiceClient.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitClientServices/include/OrbitClientServices/CrashManager.h
+++ b/src/OrbitClientServices/include/OrbitClientServices/CrashManager.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_CLIENT_SERVICES_CRASH_MANAGER_H_
 #define ORBIT_CLIENT_SERVICES_CRASH_MANAGER_H_

--- a/src/OrbitClientServices/include/OrbitClientServices/ProcessClient.h
+++ b/src/OrbitClientServices/include/OrbitClientServices/ProcessClient.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitClientServices/include/OrbitClientServices/ProcessManager.h
+++ b/src/OrbitClientServices/include/OrbitClientServices/ProcessManager.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_CLIENT_SERVICES_PROCESS_MANAGER_H_
 #define ORBIT_CLIENT_SERVICES_PROCESS_MANAGER_H_

--- a/src/OrbitClientServices/include/OrbitClientServices/TracepointServiceClient.h
+++ b/src/OrbitClientServices/include/OrbitClientServices/TracepointServiceClient.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitCore/CMakeLists.txt
+++ b/src/OrbitCore/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/OrbitCore/CoreUtils.cpp
+++ b/src/OrbitCore/CoreUtils.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitCore/CoreUtils.h
+++ b/src/OrbitCore/CoreUtils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitCore/CoreUtilsTest.cpp
+++ b/src/OrbitCore/CoreUtilsTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitCore/ModuleLoadSymbolsFuzzer.cpp
+++ b/src/OrbitCore/ModuleLoadSymbolsFuzzer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitCore/Path.cpp
+++ b/src/OrbitCore/Path.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitCore/Path.h
+++ b/src/OrbitCore/Path.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitCore/PathTest.cpp
+++ b/src/OrbitCore/PathTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitCore/StringManager.cpp
+++ b/src/OrbitCore/StringManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitCore/StringManager.h
+++ b/src/OrbitCore/StringManager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitCore/StringManagerTest.cpp
+++ b/src/OrbitCore/StringManagerTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitCore/SymbolHelper.cpp
+++ b/src/OrbitCore/SymbolHelper.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitCore/SymbolHelper.h
+++ b/src/OrbitCore/SymbolHelper.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitCore/SymbolHelperTest.cpp
+++ b/src/OrbitCore/SymbolHelperTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGgp/CMakeLists.txt
+++ b/src/OrbitGgp/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/OrbitGgp/Client.cpp
+++ b/src/OrbitGgp/Client.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGgp/Error.cpp
+++ b/src/OrbitGgp/Error.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGgp/Instance.cpp
+++ b/src/OrbitGgp/Instance.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "OrbitGgp/Instance.h"
 

--- a/src/OrbitGgp/InstanceItemModel.cpp
+++ b/src/OrbitGgp/InstanceItemModel.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "OrbitGgp/InstanceItemModel.h"
 

--- a/src/OrbitGgp/InstanceItemModelTests.cpp
+++ b/src/OrbitGgp/InstanceItemModelTests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGgp/InstanceTests.cpp
+++ b/src/OrbitGgp/InstanceTests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGgp/SshInfo.cpp
+++ b/src/OrbitGgp/SshInfo.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGgp/SshInfoTests.cpp
+++ b/src/OrbitGgp/SshInfoTests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGgp/include/OrbitGgp/Client.h
+++ b/src/OrbitGgp/include/OrbitGgp/Client.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGgp/include/OrbitGgp/Error.h
+++ b/src/OrbitGgp/include/OrbitGgp/Error.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGgp/include/OrbitGgp/Instance.h
+++ b/src/OrbitGgp/include/OrbitGgp/Instance.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGgp/include/OrbitGgp/InstanceItemModel.h
+++ b/src/OrbitGgp/include/OrbitGgp/InstanceItemModel.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGgp/include/OrbitGgp/SshInfo.h
+++ b/src/OrbitGgp/include/OrbitGgp/SshInfo.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/AccessibleTimeGraph.cpp
+++ b/src/OrbitGl/AccessibleTimeGraph.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/AccessibleTimeGraph.h
+++ b/src/OrbitGl/AccessibleTimeGraph.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "App.h"
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "AsyncTrack.h"
 

--- a/src/OrbitGl/AsyncTrack.h
+++ b/src/OrbitGl/AsyncTrack.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/Batcher.cpp
+++ b/src/OrbitGl/Batcher.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "Batcher.h"
 

--- a/src/OrbitGl/Batcher.h
+++ b/src/OrbitGl/Batcher.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/BatcherTest.cpp
+++ b/src/OrbitGl/BatcherTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/BlockChain.h
+++ b/src/OrbitGl/BlockChain.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/BlockChainTest.cpp
+++ b/src/OrbitGl/BlockChainTest.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <gtest/gtest.h>
 

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/OrbitGl/CallStackDataView.cpp
+++ b/src/OrbitGl/CallStackDataView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/CallStackDataView.h
+++ b/src/OrbitGl/CallStackDataView.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_GL_CALLSTACK_DATA_VIEW_H_
 #define ORBIT_GL_CALLSTACK_DATA_VIEW_H_

--- a/src/OrbitGl/CallTreeView.cpp
+++ b/src/OrbitGl/CallTreeView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/CallTreeView.h
+++ b/src/OrbitGl/CallTreeView.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_GL_CALL_TREE_VIEW_H_
 #define ORBIT_GL_CALL_TREE_VIEW_H_

--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/CaptureWindow.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_GL_CAPTURE_WINDOW_H_
 #define ORBIT_GL_CAPTURE_WINDOW_H_

--- a/src/OrbitGl/ClientFlags.cpp
+++ b/src/OrbitGl/ClientFlags.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/CodeReport.h
+++ b/src/OrbitGl/CodeReport.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/CoreMath.h
+++ b/src/OrbitGl/CoreMath.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/DataManager.cpp
+++ b/src/OrbitGl/DataManager.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "DataManager.h"
 

--- a/src/OrbitGl/DataManager.h
+++ b/src/OrbitGl/DataManager.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_GL_DATA_MANAGER_H_
 #define ORBIT_GL_DATA_MANAGER_H_

--- a/src/OrbitGl/DataView.cpp
+++ b/src/OrbitGl/DataView.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "DataView.h"
 

--- a/src/OrbitGl/DataView.h
+++ b/src/OrbitGl/DataView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/DataViewFactory.h
+++ b/src/OrbitGl/DataViewFactory.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_GL_DATA_VIEW_FACTORY_H_
 #define ORBIT_GL_DATA_VIEW_FACTORY_H_

--- a/src/OrbitGl/DataViewTypes.h
+++ b/src/OrbitGl/DataViewTypes.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_GL_DATA_VIEW_TYPES_H_
 #define ORBIT_GL_DATA_VIEW_TYPES_H_

--- a/src/OrbitGl/Disassembler.cpp
+++ b/src/OrbitGl/Disassembler.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "Disassembler.h"
 

--- a/src/OrbitGl/Disassembler.h
+++ b/src/OrbitGl/Disassembler.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/DisassemblyReport.cpp
+++ b/src/OrbitGl/DisassemblyReport.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/DisassemblyReport.h
+++ b/src/OrbitGl/DisassemblyReport.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_GL_DISASSEMBLY_REPORT_H_
 #define ORBIT_GL_DISASSEMBLY_REPORT_H_

--- a/src/OrbitGl/EventTrack.cpp
+++ b/src/OrbitGl/EventTrack.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/EventTrack.h
+++ b/src/OrbitGl/EventTrack.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_GL_EVENT_TRACK_H_
 #define ORBIT_GL_EVENT_TRACK_H_

--- a/src/OrbitGl/FramePointerValidatorClient.cpp
+++ b/src/OrbitGl/FramePointerValidatorClient.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "FramePointerValidatorClient.h"
 

--- a/src/OrbitGl/FramePointerValidatorClient.h
+++ b/src/OrbitGl/FramePointerValidatorClient.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/FrameTrack.h
+++ b/src/OrbitGl/FrameTrack.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/FrameTrackOnlineProcessor.cpp
+++ b/src/OrbitGl/FrameTrackOnlineProcessor.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "FrameTrackOnlineProcessor.h"
 

--- a/src/OrbitGl/FrameTrackOnlineProcessor.h
+++ b/src/OrbitGl/FrameTrackOnlineProcessor.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_GL_FRAME_TRACK_ONLINE_PROCESSOR_H_
 #define ORBIT_GL_FRAME_TRACK_ONLINE_PROCESSOR_H_

--- a/src/OrbitGl/FunctionsDataView.cpp
+++ b/src/OrbitGl/FunctionsDataView.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "FunctionsDataView.h"
 

--- a/src/OrbitGl/FunctionsDataView.h
+++ b/src/OrbitGl/FunctionsDataView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/Geometry.h
+++ b/src/OrbitGl/Geometry.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/GlCanvas.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_GL_GL_CANVAS_H_
 #define ORBIT_GL_GL_CANVAS_H_

--- a/src/OrbitGl/GlSlider.cpp
+++ b/src/OrbitGl/GlSlider.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "GlSlider.h"
 

--- a/src/OrbitGl/GlSlider.h
+++ b/src/OrbitGl/GlSlider.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_GL_GL_SLIDER_H_
 #define ORBIT_GL_GL_SLIDER_H_

--- a/src/OrbitGl/GlUtils.cpp
+++ b/src/OrbitGl/GlUtils.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/GlUtils.h
+++ b/src/OrbitGl/GlUtils.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_GL_GL_UTILS_H_
 #define ORBIT_GL_GL_UTILS_H_

--- a/src/OrbitGl/GlUtilsTest.cpp
+++ b/src/OrbitGl/GlUtilsTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "GpuTrack.h"
 

--- a/src/OrbitGl/GpuTrack.h
+++ b/src/OrbitGl/GpuTrack.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_GL_GPU_TRACK_H_
 #define ORBIT_GL_GPU_TRACK_H_

--- a/src/OrbitGl/GpuTrackTest.cpp
+++ b/src/OrbitGl/GpuTrackTest.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 #include <gtest/gtest.h>
 
 #include "GpuTrack.h"

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "GraphTrack.h"
 

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_GL_GRAPH_TRACK_H_
 #define ORBIT_GL_GRAPH_TRACK_H_

--- a/src/OrbitGl/ImGuiOrbit.cpp
+++ b/src/OrbitGl/ImGuiOrbit.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 // ImGui GLFW binding with OpenGL
 // You can copy and use unmodified imgui_impl_* files in your project. See

--- a/src/OrbitGl/ImGuiOrbit.h
+++ b/src/OrbitGl/ImGuiOrbit.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #pragma once
 

--- a/src/OrbitGl/Images.h
+++ b/src/OrbitGl/Images.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 /* GIMP RGBA C-Source image dump (inject.c) */
 

--- a/src/OrbitGl/IntrospectionWindow.cpp
+++ b/src/OrbitGl/IntrospectionWindow.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "IntrospectionWindow.h"
 

--- a/src/OrbitGl/IntrospectionWindow.h
+++ b/src/OrbitGl/IntrospectionWindow.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_GL_INTROSPECTION_WINDOW_H_
 #define ORBIT_GL_INTROSPECTION_WINDOW_H_

--- a/src/OrbitGl/LiveFunctionsController.cpp
+++ b/src/OrbitGl/LiveFunctionsController.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/LiveFunctionsController.h
+++ b/src/OrbitGl/LiveFunctionsController.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/LiveFunctionsDataView.cpp
+++ b/src/OrbitGl/LiveFunctionsDataView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/LiveFunctionsDataView.h
+++ b/src/OrbitGl/LiveFunctionsDataView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/MainThreadExecutor.h
+++ b/src/OrbitGl/MainThreadExecutor.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/MainWindowInterface.h
+++ b/src/OrbitGl/MainWindowInterface.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/ManualInstrumentationManager.cpp
+++ b/src/OrbitGl/ManualInstrumentationManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/ManualInstrumentationManager.h
+++ b/src/OrbitGl/ManualInstrumentationManager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/ModulesDataView.cpp
+++ b/src/OrbitGl/ModulesDataView.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/ModulesDataView.h
+++ b/src/OrbitGl/ModulesDataView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/OpenGl.h
+++ b/src/OrbitGl/OpenGl.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #pragma once
 

--- a/src/OrbitGl/PickingManager.cpp
+++ b/src/OrbitGl/PickingManager.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "PickingManager.h"
 

--- a/src/OrbitGl/PickingManager.h
+++ b/src/OrbitGl/PickingManager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/PickingManagerTest.cpp
+++ b/src/OrbitGl/PickingManagerTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/PickingManagerTest.h
+++ b/src/OrbitGl/PickingManagerTest.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_GL_TESTS_PICKING_MANAGER_TEST_H_
 #define ORBIT_GL_TESTS_PICKING_MANAGER_TEST_H_

--- a/src/OrbitGl/PresetLoadState.h
+++ b/src/OrbitGl/PresetLoadState.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/PresetsDataView.cpp
+++ b/src/OrbitGl/PresetsDataView.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "PresetsDataView.h"
 

--- a/src/OrbitGl/PresetsDataView.h
+++ b/src/OrbitGl/PresetsDataView.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_GL_PRESET_DATA_VIEW_H_
 #define ORBIT_GL_PRESET_DATA_VIEW_H_

--- a/src/OrbitGl/SamplingReport.cpp
+++ b/src/OrbitGl/SamplingReport.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/SamplingReport.h
+++ b/src/OrbitGl/SamplingReport.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/SamplingReportDataView.cpp
+++ b/src/OrbitGl/SamplingReportDataView.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "SamplingReportDataView.h"
 

--- a/src/OrbitGl/SamplingReportDataView.h
+++ b/src/OrbitGl/SamplingReportDataView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/SchedulerTrack.h
+++ b/src/OrbitGl/SchedulerTrack.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_GL_SCHEDULER_TRACK_H_
 #define ORBIT_GL_SCHEDULER_TRACK_H_

--- a/src/OrbitGl/ScopedStatus.h
+++ b/src/OrbitGl/ScopedStatus.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_GL_SCOPED_STATUS_H_
 #define ORBIT_GL_SCOPED_STATUS_H_

--- a/src/OrbitGl/ScopedStatusTest.cpp
+++ b/src/OrbitGl/ScopedStatusTest.cpp
@@ -1,7 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
+  
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/src/OrbitGl/SliderTest.cpp
+++ b/src/OrbitGl/SliderTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/StatusListener.h
+++ b/src/OrbitGl/StatusListener.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_GL_STATUS_LISTENER_H_
 #define ORBIT_GL_STATUS_LISTENER_H_

--- a/src/OrbitGl/TextBox.h
+++ b/src/OrbitGl/TextBox.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_GL_TEXT_BOX_H_
 #define ORBIT_GL_TEXT_BOX_H_

--- a/src/OrbitGl/TextRenderer.cpp
+++ b/src/OrbitGl/TextRenderer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/TextRenderer.h
+++ b/src/OrbitGl/TextRenderer.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_GL_TEXT_RENDERER_H_
 #define ORBIT_GL_TEXT_RENDERER_H_

--- a/src/OrbitGl/ThreadBar.h
+++ b/src/OrbitGl/ThreadBar.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/ThreadStateTrack.cpp
+++ b/src/OrbitGl/ThreadStateTrack.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "ThreadStateTrack.h"
 

--- a/src/OrbitGl/ThreadStateTrack.h
+++ b/src/OrbitGl/ThreadStateTrack.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_GL_THREAD_TRACK_H_
 #define ORBIT_GL_THREAD_TRACK_H_

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/TimeGraphLayout.cpp
+++ b/src/OrbitGl/TimeGraphLayout.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "TimeGraphLayout.h"
 

--- a/src/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/TimeGraphLayout.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/Timer.h
+++ b/src/OrbitGl/Timer.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_GL_TIMER_H_
 #define ORBIT_GL_TIMER_H_

--- a/src/OrbitGl/TimerChain.cpp
+++ b/src/OrbitGl/TimerChain.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/TimerChain.h
+++ b/src/OrbitGl/TimerChain.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_GL_TIMER_CHAIN_H_
 #define ORBIT_GL_TIMER_CHAIN_H_

--- a/src/OrbitGl/TimerInfosIterator.cpp
+++ b/src/OrbitGl/TimerInfosIterator.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/TimerInfosIterator.h
+++ b/src/OrbitGl/TimerInfosIterator.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/TimerInfosIteratorTest.cpp
+++ b/src/OrbitGl/TimerInfosIteratorTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "TimerTrack.h"
 

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/TracepointTrack.cpp
+++ b/src/OrbitGl/TracepointTrack.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "TracepointTrack.h"
 

--- a/src/OrbitGl/TracepointTrack.h
+++ b/src/OrbitGl/TracepointTrack.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/TracepointsDataView.cpp
+++ b/src/OrbitGl/TracepointsDataView.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "TracepointsDataView.h"
 

--- a/src/OrbitGl/TracepointsDataView.h
+++ b/src/OrbitGl/TracepointsDataView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_GL_TRACK_H_
 #define ORBIT_GL_TRACK_H_

--- a/src/OrbitGl/TrackAccessibility.cpp
+++ b/src/OrbitGl/TrackAccessibility.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "TrackAccessibility.h"
 

--- a/src/OrbitGl/TrackAccessibility.h
+++ b/src/OrbitGl/TrackAccessibility.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_GL_TRACK_MANAGER_H_
 #define ORBIT_GL_TRACK_MANAGER_H_

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitGl/TriangleToggle.h
+++ b/src/OrbitGl/TriangleToggle.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_GL_TRIANGLE_TOGGLE_H_
 #define ORBIT_GL_TRIANGLE_TOGGLE_H_

--- a/src/OrbitGl/UnitTestMockEnvironment.cpp
+++ b/src/OrbitGl/UnitTestMockEnvironment.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <absl/flags/flag.h>
 

--- a/src/OrbitProducer/CMakeLists.txt
+++ b/src/OrbitProducer/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/OrbitProducer/CaptureEventProducer.cpp
+++ b/src/OrbitProducer/CaptureEventProducer.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "OrbitProducer/CaptureEventProducer.h"
 

--- a/src/OrbitProducer/CaptureEventProducerTest.cpp
+++ b/src/OrbitProducer/CaptureEventProducerTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitProducer/LockFreeBufferCaptureEventProducerTest.cpp
+++ b/src/OrbitProducer/LockFreeBufferCaptureEventProducerTest.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <gmock/gmock.h>
 #include <google/protobuf/arena.h>

--- a/src/OrbitProducer/include/OrbitProducer/CaptureEventProducer.h
+++ b/src/OrbitProducer/include/OrbitProducer/CaptureEventProducer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitProducer/include/OrbitProducer/FakeProducerSideService.h
+++ b/src/OrbitProducer/include/OrbitProducer/FakeProducerSideService.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_PRODUCER_FAKE_PRODUCER_SIDE_SERVICE_H_
 #define ORBIT_PRODUCER_FAKE_PRODUCER_SIDE_SERVICE_H_

--- a/src/OrbitProducer/include/OrbitProducer/LockFreeBufferCaptureEventProducer.h
+++ b/src/OrbitProducer/include/OrbitProducer/LockFreeBufferCaptureEventProducer.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_PRODUCER_LOCK_FREE_BUFFER_CAPTURE_EVENT_PRODUCER_H_
 #define ORBIT_PRODUCER_LOCK_FREE_BUFFER_CAPTURE_EVENT_PRODUCER_H_

--- a/src/OrbitQt/AccessibilityAdapter.cpp
+++ b/src/OrbitQt/AccessibilityAdapter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/AccessibilityAdapter.h
+++ b/src/OrbitQt/AccessibilityAdapter.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 /*
  * Bridging accessibility from OrbitQt and OrbitGl.

--- a/src/OrbitQt/AccessibilityAdapterTest.cpp
+++ b/src/OrbitQt/AccessibilityAdapterTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/CMakeLists.txt
+++ b/src/OrbitQt/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/OrbitQt/CallTreeViewItemModel.cpp
+++ b/src/OrbitQt/CallTreeViewItemModel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/CallTreeViewItemModel.h
+++ b/src/OrbitQt/CallTreeViewItemModel.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/CallTreeWidget.cpp
+++ b/src/OrbitQt/CallTreeWidget.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "CallTreeWidget.h"
 

--- a/src/OrbitQt/CallTreeWidget.h
+++ b/src/OrbitQt/CallTreeWidget.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/CaptureOptionsDialog.h
+++ b/src/OrbitQt/CaptureOptionsDialog.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/ConnectToStadiaWidget.cpp
+++ b/src/OrbitQt/ConnectToStadiaWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/ConnectToStadiaWidget.h
+++ b/src/OrbitQt/ConnectToStadiaWidget.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/Connections.h
+++ b/src/OrbitQt/Connections.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/CopyKeySequenceEnabledTreeView.h
+++ b/src/OrbitQt/CopyKeySequenceEnabledTreeView.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/CutoutWidget.h
+++ b/src/OrbitQt/CutoutWidget.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_QT_CUTOUT_WIDGET_
 #define ORBIT_QT_CUTOUT_WIDGET_

--- a/src/OrbitQt/DeploymentConfigurations.cpp
+++ b/src/OrbitQt/DeploymentConfigurations.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/DeploymentConfigurations.h
+++ b/src/OrbitQt/DeploymentConfigurations.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/ElidedLabel.cpp
+++ b/src/OrbitQt/ElidedLabel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/ElidedLabel.h
+++ b/src/OrbitQt/ElidedLabel.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/Error.cpp
+++ b/src/OrbitQt/Error.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/Error.h
+++ b/src/OrbitQt/Error.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_QT_ERROR_H_
 #define ORBIT_QT_ERROR_H_

--- a/src/OrbitQt/EventLoop.h
+++ b/src/OrbitQt/EventLoop.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/EventLoopTest.cpp
+++ b/src/OrbitQt/EventLoopTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/FilterPanelWidget.cpp
+++ b/src/OrbitQt/FilterPanelWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/FilterPanelWidget.h
+++ b/src/OrbitQt/FilterPanelWidget.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/FilterPanelWidgetAction.cpp
+++ b/src/OrbitQt/FilterPanelWidgetAction.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "FilterPanelWidgetAction.h"
 

--- a/src/OrbitQt/FilterPanelWidgetAction.h
+++ b/src/OrbitQt/FilterPanelWidgetAction.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/OverlayWidget.cpp
+++ b/src/OrbitQt/OverlayWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/OverlayWidget.h
+++ b/src/OrbitQt/OverlayWidget.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/ProcessItemModel.cpp
+++ b/src/OrbitQt/ProcessItemModel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/ProcessItemModel.h
+++ b/src/OrbitQt/ProcessItemModel.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/ProcessItemModelTest.cpp
+++ b/src/OrbitQt/ProcessItemModelTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/ProfilingTargetDialog.cpp
+++ b/src/OrbitQt/ProfilingTargetDialog.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "ProfilingTargetDialog.h"
 

--- a/src/OrbitQt/ProfilingTargetDialog.h
+++ b/src/OrbitQt/ProfilingTargetDialog.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_QT_PROFILING_TARGET_DIALOG_H_
 #define ORBIT_QT_PROFILING_TARGET_DIALOG_H_

--- a/src/OrbitQt/StatusListenerImpl.cpp
+++ b/src/OrbitQt/StatusListenerImpl.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/StatusListenerImpl.h
+++ b/src/OrbitQt/StatusListenerImpl.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_QT_STATUS_LISTENER_IMPL_H_
 #define ORBIT_QT_STATUS_LISTENER_IMPL_H_

--- a/src/OrbitQt/StatusListenerImplTest.cpp
+++ b/src/OrbitQt/StatusListenerImplTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/TargetConfiguration.h
+++ b/src/OrbitQt/TargetConfiguration.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/TutorialContent.cpp
+++ b/src/OrbitQt/TutorialContent.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/TutorialContent.h
+++ b/src/OrbitQt/TutorialContent.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/TutorialOverlay.cpp
+++ b/src/OrbitQt/TutorialOverlay.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "TutorialOverlay.h"
 

--- a/src/OrbitQt/TutorialOverlay.h
+++ b/src/OrbitQt/TutorialOverlay.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/TutorialOverlayTest.cpp
+++ b/src/OrbitQt/TutorialOverlayTest.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <gtest/gtest.h>
 

--- a/src/OrbitQt/main.cpp
+++ b/src/OrbitQt/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/opengldetect.cpp
+++ b/src/OrbitQt/opengldetect.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "opengldetect.h"
 

--- a/src/OrbitQt/opengldetect.h
+++ b/src/OrbitQt/opengldetect.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/orbitaboutdialog.cpp
+++ b/src/OrbitQt/orbitaboutdialog.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "orbitaboutdialog.h"
 

--- a/src/OrbitQt/orbitaboutdialog.h
+++ b/src/OrbitQt/orbitaboutdialog.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/orbitdataviewpanel.cpp
+++ b/src/OrbitQt/orbitdataviewpanel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/orbitdataviewpanel.h
+++ b/src/OrbitQt/orbitdataviewpanel.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/orbiteventiterator.cpp
+++ b/src/OrbitQt/orbiteventiterator.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/orbiteventiterator.h
+++ b/src/OrbitQt/orbiteventiterator.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_QT_ORBIT_EVENT_ITERATOR_H_
 #define ORBIT_QT_ORBIT_EVENT_ITERATOR_H_

--- a/src/OrbitQt/orbitglwidget.cpp
+++ b/src/OrbitQt/orbitglwidget.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/orbitglwidget.h
+++ b/src/OrbitQt/orbitglwidget.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/orbitlivefunctions.cpp
+++ b/src/OrbitQt/orbitlivefunctions.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "orbitlivefunctions.h"
 

--- a/src/OrbitQt/orbitlivefunctions.h
+++ b/src/OrbitQt/orbitlivefunctions.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "orbitmainwindow.h"
 

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_QT_ORBIT_MAIN_WINDOW_H_
 #define ORBIT_QT_ORBIT_MAIN_WINDOW_H_

--- a/src/OrbitQt/orbitsamplingreport.cpp
+++ b/src/OrbitQt/orbitsamplingreport.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/orbitsamplingreport.h
+++ b/src/OrbitQt/orbitsamplingreport.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_QT_ORBIT_SAMPLING_REPORT_H_
 #define ORBIT_QT_ORBIT_SAMPLING_REPORT_H_

--- a/src/OrbitQt/orbittablemodel.cpp
+++ b/src/OrbitQt/orbittablemodel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/orbittablemodel.h
+++ b/src/OrbitQt/orbittablemodel.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/orbittreeview.cpp
+++ b/src/OrbitQt/orbittreeview.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/orbittreeview.h
+++ b/src/OrbitQt/orbittreeview.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitQt/servicedeploymanager.cpp
+++ b/src/OrbitQt/servicedeploymanager.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "servicedeploymanager.h"
 

--- a/src/OrbitQt/servicedeploymanager.h
+++ b/src/OrbitQt/servicedeploymanager.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_QT_SERVICE_DEPLOY_MANAGER_H_
 #define ORBIT_QT_SERVICE_DEPLOY_MANAGER_H_

--- a/src/OrbitQt/types.h
+++ b/src/OrbitQt/types.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitSsh/CMakeLists.txt
+++ b/src/OrbitSsh/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/OrbitSsh/Channel.cpp
+++ b/src/OrbitSsh/Channel.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "OrbitSsh/Channel.h"
 

--- a/src/OrbitSsh/Context.cpp
+++ b/src/OrbitSsh/Context.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "OrbitSsh/Context.h"
 

--- a/src/OrbitSsh/ContextTests.cpp
+++ b/src/OrbitSsh/ContextTests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitSsh/Error.cpp
+++ b/src/OrbitSsh/Error.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "OrbitSsh/Error.h"
 

--- a/src/OrbitSsh/KnownHostsError.cpp
+++ b/src/OrbitSsh/KnownHostsError.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "OrbitSsh/KnownHostsError.h"
 

--- a/src/OrbitSsh/LibSsh2Utils.cpp
+++ b/src/OrbitSsh/LibSsh2Utils.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "LibSsh2Utils.h"
 

--- a/src/OrbitSsh/LibSsh2Utils.h
+++ b/src/OrbitSsh/LibSsh2Utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitSsh/LinuxSocket.cpp
+++ b/src/OrbitSsh/LinuxSocket.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitSsh/Session.cpp
+++ b/src/OrbitSsh/Session.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "OrbitSsh/Session.h"
 

--- a/src/OrbitSsh/Sftp.cpp
+++ b/src/OrbitSsh/Sftp.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitSsh/SftpFile.cpp
+++ b/src/OrbitSsh/SftpFile.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitSsh/Socket.cpp
+++ b/src/OrbitSsh/Socket.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "OrbitSsh/Socket.h"
 

--- a/src/OrbitSsh/SocketTests.cpp
+++ b/src/OrbitSsh/SocketTests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitSsh/WindowsSocket.cpp
+++ b/src/OrbitSsh/WindowsSocket.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "OrbitBase/Logging.h"
 #include "OrbitSsh/Error.h"

--- a/src/OrbitSsh/include/OrbitSsh/AddrAndPort.h
+++ b/src/OrbitSsh/include/OrbitSsh/AddrAndPort.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitSsh/include/OrbitSsh/Channel.h
+++ b/src/OrbitSsh/include/OrbitSsh/Channel.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_SSH_CHANNEL_H_
 #define ORBIT_SSH_CHANNEL_H_

--- a/src/OrbitSsh/include/OrbitSsh/Context.h
+++ b/src/OrbitSsh/include/OrbitSsh/Context.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitSsh/include/OrbitSsh/Error.h
+++ b/src/OrbitSsh/include/OrbitSsh/Error.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_SSH_ERROR_H_
 #define ORBIT_SSH_ERROR_H_

--- a/src/OrbitSsh/include/OrbitSsh/KnownHostsError.h
+++ b/src/OrbitSsh/include/OrbitSsh/KnownHostsError.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitSsh/include/OrbitSsh/Session.h
+++ b/src/OrbitSsh/include/OrbitSsh/Session.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_SSH_SESSION_H_
 #define ORBIT_SSH_SESSION_H_

--- a/src/OrbitSsh/include/OrbitSsh/Sftp.h
+++ b/src/OrbitSsh/include/OrbitSsh/Sftp.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitSsh/include/OrbitSsh/SftpFile.h
+++ b/src/OrbitSsh/include/OrbitSsh/SftpFile.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_SSH_SFTP_FILE_H_
 #define ORBIT_SSH_SFTP_FILE_H_

--- a/src/OrbitSsh/include/OrbitSsh/Socket.h
+++ b/src/OrbitSsh/include/OrbitSsh/Socket.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitSshQt/CMakeLists.txt
+++ b/src/OrbitSshQt/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/OrbitSshQt/Error.cpp
+++ b/src/OrbitSshQt/Error.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitSshQt/IntegrationTests.cpp
+++ b/src/OrbitSshQt/IntegrationTests.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <absl/strings/str_format.h>
 #include <gtest/gtest.h>

--- a/src/OrbitSshQt/Session.cpp
+++ b/src/OrbitSshQt/Session.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitSshQt/SftpChannel.cpp
+++ b/src/OrbitSshQt/SftpChannel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitSshQt/SftpCopyToLocalOperation.cpp
+++ b/src/OrbitSshQt/SftpCopyToLocalOperation.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "OrbitSshQt/SftpCopyToLocalOperation.h"
 

--- a/src/OrbitSshQt/SftpCopyToRemoteOperation.cpp
+++ b/src/OrbitSshQt/SftpCopyToRemoteOperation.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "OrbitSshQt/SftpCopyToRemoteOperation.h"
 

--- a/src/OrbitSshQt/Task.cpp
+++ b/src/OrbitSshQt/Task.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "OrbitSshQt/Task.h"
 

--- a/src/OrbitSshQt/Tunnel.cpp
+++ b/src/OrbitSshQt/Tunnel.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitSshQt/include/OrbitSshQt/Error.h
+++ b/src/OrbitSshQt/include/OrbitSshQt/Error.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitSshQt/include/OrbitSshQt/ScopedConnection.h
+++ b/src/OrbitSshQt/include/OrbitSshQt/ScopedConnection.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitSshQt/include/OrbitSshQt/Session.h
+++ b/src/OrbitSshQt/include/OrbitSshQt/Session.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_SSH_QT_SESSION_H_
 #define ORBIT_SSH_QT_SESSION_H_

--- a/src/OrbitSshQt/include/OrbitSshQt/SftpChannel.h
+++ b/src/OrbitSshQt/include/OrbitSshQt/SftpChannel.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_SSH_QT_SFTP_CHANNEL_H_
 #define ORBIT_SSH_QT_SFTP_CHANNEL_H_

--- a/src/OrbitSshQt/include/OrbitSshQt/SftpCopyToLocalOperation.h
+++ b/src/OrbitSshQt/include/OrbitSshQt/SftpCopyToLocalOperation.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitSshQt/include/OrbitSshQt/SftpCopyToRemoteOperation.h
+++ b/src/OrbitSshQt/include/OrbitSshQt/SftpCopyToRemoteOperation.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitSshQt/include/OrbitSshQt/StateMachineHelper.h
+++ b/src/OrbitSshQt/include/OrbitSshQt/StateMachineHelper.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitSshQt/include/OrbitSshQt/Task.h
+++ b/src/OrbitSshQt/include/OrbitSshQt/Task.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitSshQt/include/OrbitSshQt/Tunnel.h
+++ b/src/OrbitSshQt/include/OrbitSshQt/Tunnel.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitSshQt/run_integration_test.sh
+++ b/src/OrbitSshQt/run_integration_test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/OrbitTest/CMakeLists.txt
+++ b/src/OrbitTest/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/OrbitTest/OrbitTest.cpp
+++ b/src/OrbitTest/OrbitTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitTest/OrbitTest.h
+++ b/src/OrbitTest/OrbitTest.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitTest/main.cpp
+++ b/src/OrbitTest/main.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <stdint.h>
 #include <stdio.h>

--- a/src/OrbitTest/main_short_lived_threads.cpp
+++ b/src/OrbitTest/main_short_lived_threads.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitTriggerCaptureVulkanLayer/CMakeLists.txt
+++ b/src/OrbitTriggerCaptureVulkanLayer/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/OrbitTriggerCaptureVulkanLayer/DispatchTable.cpp
+++ b/src/OrbitTriggerCaptureVulkanLayer/DispatchTable.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "DispatchTable.h"
 

--- a/src/OrbitTriggerCaptureVulkanLayer/LayerLogic.cpp
+++ b/src/OrbitTriggerCaptureVulkanLayer/LayerLogic.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitTriggerCaptureVulkanLayer/LayerLogic.h
+++ b/src/OrbitTriggerCaptureVulkanLayer/LayerLogic.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_TRIGGER_CAPTURE_VULKAN_LAYER_LAYER_LOGIC_H_
 #define ORBIT_TRIGGER_CAPTURE_VULKAN_LAYER_LAYER_LOGIC_H_

--- a/src/OrbitTriggerCaptureVulkanLayer/LayerOptions.cpp
+++ b/src/OrbitTriggerCaptureVulkanLayer/LayerOptions.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitTriggerCaptureVulkanLayer/LayerOptions.h
+++ b/src/OrbitTriggerCaptureVulkanLayer/LayerOptions.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitTriggerCaptureVulkanLayer/OrbitCaptureClientLayer.cpp
+++ b/src/OrbitTriggerCaptureVulkanLayer/OrbitCaptureClientLayer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitTriggerCaptureVulkanLayer/layer_config.proto
+++ b/src/OrbitTriggerCaptureVulkanLayer/layer_config.proto
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitTriggerCaptureVulkanLayer/orbit_trigger_capture_vulkan_layer_config.pb.txt
+++ b/src/OrbitTriggerCaptureVulkanLayer/orbit_trigger_capture_vulkan_layer_config.pb.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 #

--- a/src/OrbitVersion/CMakeLists.txt
+++ b/src/OrbitVersion/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/OrbitVersion/OrbitVersion.cpp.in
+++ b/src/OrbitVersion/OrbitVersion.cpp.in
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitVersion/include/OrbitVersion/OrbitVersion.h
+++ b/src/OrbitVersion/include/OrbitVersion/OrbitVersion.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitVulkanLayer/CMakeLists.txt
+++ b/src/OrbitVulkanLayer/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/OrbitVulkanLayer/DeviceManager.h
+++ b/src/OrbitVulkanLayer/DeviceManager.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_VULKAN_LAYER_DEVICE_MANAGER_H_
 #define ORBIT_VULKAN_LAYER_DEVICE_MANAGER_H_

--- a/src/OrbitVulkanLayer/DeviceManagerTest.cpp
+++ b/src/OrbitVulkanLayer/DeviceManagerTest.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "DeviceManager.h"
 #include "gmock/gmock.h"

--- a/src/OrbitVulkanLayer/DispatchTable.cpp
+++ b/src/OrbitVulkanLayer/DispatchTable.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitVulkanLayer/DispatchTable.h
+++ b/src/OrbitVulkanLayer/DispatchTable.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitVulkanLayer/DispatchTableTest.cpp
+++ b/src/OrbitVulkanLayer/DispatchTableTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitVulkanLayer/EntryPoints.cpp
+++ b/src/OrbitVulkanLayer/EntryPoints.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "DeviceManager.h"
 #include "DispatchTable.h"

--- a/src/OrbitVulkanLayer/QueueManager.cpp
+++ b/src/OrbitVulkanLayer/QueueManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitVulkanLayer/QueueManager.h
+++ b/src/OrbitVulkanLayer/QueueManager.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_VULKAN_LAYER_QUEUE_MANAGER_H_
 #define ORBIT_VULKAN_LAYER_QUEUE_MANAGER_H_

--- a/src/OrbitVulkanLayer/QueueManagerTest.cpp
+++ b/src/OrbitVulkanLayer/QueueManagerTest.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+.
 
 #include "QueueManager.h"
 #include "gtest/gtest.h"

--- a/src/OrbitVulkanLayer/SubmissionTracker.h
+++ b/src/OrbitVulkanLayer/SubmissionTracker.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_VULKAN_LAYER_SUBMISSION_TRACKER_H_
 #define ORBIT_VULKAN_LAYER_SUBMISSION_TRACKER_H_

--- a/src/OrbitVulkanLayer/SubmissionTrackerTest.cpp
+++ b/src/OrbitVulkanLayer/SubmissionTrackerTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitVulkanLayer/TimerQueryPool.h
+++ b/src/OrbitVulkanLayer/TimerQueryPool.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitVulkanLayer/TimerQueryPoolTest.cpp
+++ b/src/OrbitVulkanLayer/TimerQueryPoolTest.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "TimerQueryPool.h"
 #include "absl/container/flat_hash_set.h"

--- a/src/OrbitVulkanLayer/VulkanLayerController.h
+++ b/src/OrbitVulkanLayer/VulkanLayerController.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_VULKAN_LAYER_VULKAN_LAYER_CONTROLLER_H_
 #define ORBIT_VULKAN_LAYER_VULKAN_LAYER_CONTROLLER_H_

--- a/src/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
+++ b/src/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitVulkanLayer/VulkanLayerProducer.h
+++ b/src/OrbitVulkanLayer/VulkanLayerProducer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitVulkanLayer/VulkanLayerProducerImpl.cpp
+++ b/src/OrbitVulkanLayer/VulkanLayerProducerImpl.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/OrbitVulkanLayer/VulkanLayerProducerImpl.h
+++ b/src/OrbitVulkanLayer/VulkanLayerProducerImpl.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_VULKAN_LAYER_VULKAN_LAYER_PRODUCER_IMPL_H_
 #define ORBIT_VULKAN_LAYER_VULKAN_LAYER_PRODUCER_IMPL_H_

--- a/src/OrbitVulkanLayer/VulkanLayerProducerImplTest.cpp
+++ b/src/OrbitVulkanLayer/VulkanLayerProducerImplTest.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/src/ProducerSideChannel/CMakeLists.txt
+++ b/src/ProducerSideChannel/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/ProducerSideChannel/include/ProducerSideChannel/ProducerSideChannel.h
+++ b/src/ProducerSideChannel/include/ProducerSideChannel/ProducerSideChannel.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/QtUtils/CMakeLists.txt
+++ b/src/QtUtils/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/QtUtils/MainThreadExecutorImpl.cpp
+++ b/src/QtUtils/MainThreadExecutorImpl.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "QtUtils/MainThreadExecutorImpl.h"
 

--- a/src/QtUtils/MainThreadExecutorImplTest.cpp
+++ b/src/QtUtils/MainThreadExecutorImplTest.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <gtest/gtest.h>
 

--- a/src/QtUtils/include/QtUtils/MainThreadExecutorImpl.h
+++ b/src/QtUtils/include/QtUtils/MainThreadExecutorImpl.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_QT_MAIN_THREAD_EXECUTOR_IMPL_H_
 #define ORBIT_QT_MAIN_THREAD_EXECUTOR_IMPL_H_

--- a/src/Service/CMakeLists.txt
+++ b/src/Service/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/Service/CaptureEventBuffer.h
+++ b/src/Service/CaptureEventBuffer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/Service/CaptureEventSender.h
+++ b/src/Service/CaptureEventSender.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_SERVICE_CAPTURE_EVENT_SENDER_H_
 #define ORBIT_SERVICE_CAPTURE_EVENT_SENDER_H_

--- a/src/Service/CaptureServiceImpl.cpp
+++ b/src/Service/CaptureServiceImpl.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "CaptureServiceImpl.h"
 

--- a/src/Service/CaptureServiceImpl.h
+++ b/src/Service/CaptureServiceImpl.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/Service/CaptureStartStopListener.h
+++ b/src/Service/CaptureStartStopListener.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_SERVICE_CAPTURE_START_STOP_LISTENER_H_
 #define ORBIT_SERVICE_CAPTURE_START_STOP_LISTENER_H_

--- a/src/Service/CrashServiceImpl.cpp
+++ b/src/Service/CrashServiceImpl.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/Service/CrashServiceImpl.h
+++ b/src/Service/CrashServiceImpl.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_SERVICE_CRASH_SERVICE_IMPL_H_
 #define ORBIT_SERVICE_CRASH_SERVICE_IMPL_H_

--- a/src/Service/FramePointerValidatorServiceImpl.cpp
+++ b/src/Service/FramePointerValidatorServiceImpl.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "FramePointerValidatorServiceImpl.h"
 

--- a/src/Service/FramePointerValidatorServiceImpl.h
+++ b/src/Service/FramePointerValidatorServiceImpl.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_CORE_FRAME_POINTER_VALIDATOR_SERVICE_H_
 #define ORBIT_CORE_FRAME_POINTER_VALIDATOR_SERVICE_H_

--- a/src/Service/LinuxTracingHandler.cpp
+++ b/src/Service/LinuxTracingHandler.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "LinuxTracingHandler.h"
 

--- a/src/Service/LinuxTracingHandler.h
+++ b/src/Service/LinuxTracingHandler.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_SERVICE_LINUX_TRACING_HANDLER_H_
 #define ORBIT_SERVICE_LINUX_TRACING_HANDLER_H_

--- a/src/Service/MemoryInfoHandler.cpp
+++ b/src/Service/MemoryInfoHandler.cpp
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+
 #include "MemoryInfoHandler.h"
 
 #include "GrpcProtos/Constants.h"

--- a/src/Service/OrbitGrpcServer.cpp
+++ b/src/Service/OrbitGrpcServer.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "OrbitGrpcServer.h"
 

--- a/src/Service/OrbitGrpcServer.h
+++ b/src/Service/OrbitGrpcServer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/Service/OrbitService.h
+++ b/src/Service/OrbitService.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/Service/OrbitServiceUtilsFindSymbolsFilePathFuzzer.cpp
+++ b/src/Service/OrbitServiceUtilsFindSymbolsFilePathFuzzer.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/Service/Process.cpp
+++ b/src/Service/Process.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "Process.h"
 

--- a/src/Service/Process.h
+++ b/src/Service/Process.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_SERVICE_PROCESS_H_
 #define ORBIT_SERVICE_PROCESS_H_

--- a/src/Service/ProcessList.cpp
+++ b/src/Service/ProcessList.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/Service/ProcessListTest.cpp
+++ b/src/Service/ProcessListTest.cpp
@@ -1,7 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-//
+
 
 #include <gtest/gtest.h>
 #include <unistd.h>

--- a/src/Service/ProcessServiceImpl.h
+++ b/src/Service/ProcessServiceImpl.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/Service/ProcessTest.cpp
+++ b/src/Service/ProcessTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/Service/ProducerSideServer.h
+++ b/src/Service/ProducerSideServer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/Service/ProducerSideServiceImpl.cpp
+++ b/src/Service/ProducerSideServiceImpl.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "ProducerSideServiceImpl.h"
 

--- a/src/Service/ProducerSideServiceImplTest.cpp
+++ b/src/Service/ProducerSideServiceImplTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/Service/ServiceUtils.cpp
+++ b/src/Service/ServiceUtils.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "ServiceUtils.h"
 

--- a/src/Service/ServiceUtils.h
+++ b/src/Service/ServiceUtils.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef ORBIT_SERVICE_SERVICE_UTILS_H_
 #define ORBIT_SERVICE_SERVICE_UTILS_H_

--- a/src/Service/ServiceUtilsTest.cpp
+++ b/src/Service/ServiceUtilsTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/Service/TracepointServiceImpl.cpp
+++ b/src/Service/TracepointServiceImpl.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "TracepointServiceImpl.h"
 

--- a/src/Service/TracepointServiceImpl.h
+++ b/src/Service/TracepointServiceImpl.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/Service/main.cpp
+++ b/src/Service/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/SourcePathsMappingDialogDemo/main.cpp
+++ b/src/SourcePathsMappingDialogDemo/main.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <QApplication>
 

--- a/src/SyntaxHighlighter/CMakeLists.txt
+++ b/src/SyntaxHighlighter/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/SyntaxHighlighter/X86Assembly.cpp
+++ b/src/SyntaxHighlighter/X86Assembly.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "SyntaxHighlighter/X86Assembly.h"
 

--- a/src/SyntaxHighlighter/include/SyntaxHighlighter/X86Assembly.h
+++ b/src/SyntaxHighlighter/include/SyntaxHighlighter/X86Assembly.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/WebEngine/Dialog.cpp
+++ b/src/WebEngine/Dialog.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/WebEngine/JsonTransport.cpp
+++ b/src/WebEngine/JsonTransport.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include "JsonTransport.h"
 

--- a/src/WebEngine/JsonTransport.h
+++ b/src/WebEngine/JsonTransport.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/WebEngine/include/WebEngine/DeleteLaterDeleter.h
+++ b/src/WebEngine/include/WebEngine/DeleteLaterDeleter.h
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #ifndef WEB_ENGINE_DELETE_LATER_DELETER_H_
 #define WEB_ENGINE_DELETE_LATER_DELETER_H_

--- a/src/WebEngine/include/WebEngine/Dialog.h
+++ b/src/WebEngine/include/WebEngine/Dialog.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/src/WebUI/CMakeLists.txt
+++ b/src/WebUI/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 The Orbit Authors. All rights reserved.
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/src/WebUI/QWebChannelExtractor.cpp
+++ b/src/WebUI/QWebChannelExtractor.cpp
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 #include <QByteArray>
 #include <QDebug>

--- a/src/WebUI/plugins/minimize-writes.js
+++ b/src/WebUI/plugins/minimize-writes.js
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 const fs = require('fs').promises;
 const path = require('path');

--- a/src/WebUI/plugins/qrc-generator.js
+++ b/src/WebUI/plugins/qrc-generator.js
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 /*
   The QrcGeneratorPlugin for Webpack generates a Qt resource file

--- a/src/WebUI/src/dummy.js
+++ b/src/WebUI/src/dummy.js
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 import QWebChannel from 'qtwebchannel/qwebchannel';
 

--- a/src/WebUI/webpack.config.js
+++ b/src/WebUI/webpack.config.js
@@ -1,6 +1,7 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 
 const path = require("path");
 const process = require("process");


### PR DESCRIPTION
Some of the project files have a 2021 copyright year, while the others have a 2020 copyright year. I've went through each file, and updated the files with an old copyright year.

I hope this helped :)

Also this might be one of the biggest pull requests, I'm not sure. (626 changed files)