### PR TITLE
Eventtrack rename

### DIFF
--- a/contrib/automation_tests/core/common_controls.py
+++ b/contrib/automation_tests/core/common_controls.py
@@ -15,14 +15,14 @@ class Track:
         self._container = control
         self._name = control.texts()[0]
         self._title = find_control(control, 'TabItem')
-        self._events = find_control(control, 'Pane', 'Events', raise_on_failure=False)
+        self._callstacks = find_control(control, 'Pane', 'Callstacks', raise_on_failure=False)
         self._thread_states = find_control(control, 'Pane', 'ThreadStates', raise_on_failure=False)
         self._tracepoints = find_control(control, 'Pane', 'Tracepoints', raise_on_failure=False)
         self._timers = find_control(control, 'Pane', 'Timers', raise_on_failure=False)
 
     container = property(lambda self: self._container)
     title = property(lambda self: self._title)
-    events = property(lambda self: self._events)
+    callstacks = property(lambda self: self._callstacks)
     thread_states = property(lambda self: self._thread_states)
     tracepoints = property(lambda self: self._tracepoints)
     timers = property(lambda self: self._timers)

--- a/contrib/automation_tests/core/common_controls.py
+++ b/contrib/automation_tests/core/common_controls.py
@@ -16,7 +16,7 @@ class Track:
         self._name = control.texts()[0]
         self._title = find_control(control, 'TabItem')
         self._callstacks = find_control(control, 'Pane', 'Callstacks', raise_on_failure=False)
-        self._thread_states = find_control(control, 'Pane', 'ThreadStates', raise_on_failure=False)
+        self._thread_states = find_control(control, 'Pane', 'ThreadState', raise_on_failure=False)
         self._tracepoints = find_control(control, 'Pane', 'Tracepoints', raise_on_failure=False)
         self._timers = find_control(control, 'Pane', 'Timers', raise_on_failure=False)
 

--- a/contrib/automation_tests/orbit_instrument_function.py
+++ b/contrib/automation_tests/orbit_instrument_function.py
@@ -46,7 +46,7 @@ def main(argv):
         CheckTimers(track_name_contains="All Threads", expect_exists=False),
         CheckTimers(track_name_contains="hello_ggp_stand")
     ]
-    suite = E2ETestSuite(test_name="Connect & Capture", test_cases=test_cases)
+    suite = E2ETestSuite(test_name="Instrument Function", test_cases=test_cases)
     suite.execute()
 
 

--- a/contrib/automation_tests/test_cases/capture_window.py
+++ b/contrib/automation_tests/test_cases/capture_window.py
@@ -270,14 +270,14 @@ class CheckTimers(CaptureWindowE2ETestCaseBase):
                 self.expect_true(track.timers is None, 'Track "%s" has no timers pane' % track.name)
 
 
-class CheckEvents(CaptureWindowE2ETestCaseBase):
+class CheckCallstacks(CaptureWindowE2ETestCaseBase):
     def _execute(self, track_name_contains: str, expect_exists: bool = True):
         tracks = self._find_tracks(track_name_contains)
         self.expect_true(len(tracks) > 0, 'Found tracks matching "%s"' % track_name_contains)
-        logging.info('Checking for events in %s tracks', len(tracks))
+        logging.info('Checking for callstacks pane in %s tracks', len(tracks))
         for track in tracks:
             track = Track(track)
             if expect_exists:
-                self.expect_true(track.events is not None, 'Track "%s" has events pane' % track.name)
+                self.expect_true(track.callstacks is not None, 'Track "%s" has callstacks pane' % track.name)
             else:
-                self.expect_true(track.events is None, 'Track "%s" has no events pane' % track.name)
+                self.expect_true(track.callstacks is None, 'Track "%s" has no callstacks pane' % track.name)

--- a/src/OrbitGl/AsyncTrack.h
+++ b/src/OrbitGl/AsyncTrack.h
@@ -10,8 +10,8 @@
 #include <string>
 #include <vector>
 
+#include "CallstackThreadBar.h"
 #include "CoreMath.h"
-#include "EventTrack.h"
 #include "PickingManager.h"
 #include "TextBox.h"
 #include "TimerChain.h"

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -71,7 +71,7 @@ target_sources(
          TrackManager.h
          TriangleToggle.h
          TracepointsDataView.h
-         TracepointTrack.h)
+         TracepointThreadBar.h)
 
 target_sources(
   OrbitGl
@@ -124,7 +124,7 @@ target_sources(
           TrackManager.cpp
           TriangleToggle.cpp
           TracepointsDataView.cpp
-          TracepointTrack.cpp)
+          TracepointThreadBar.cpp)
 
 target_include_directories(OrbitGl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(
          Batcher.h
          BlockChain.h
          CallStackDataView.h
+         CallstackThreadBar.h
          CallTreeView.h
          CaptureWindow.h
          CaptureViewElement.h
@@ -28,7 +29,6 @@ target_sources(
          DataViewTypes.h
          Disassembler.h
          DisassemblyReport.h
-         EventTrack.h
          FramePointerValidatorClient.h
          FrameTrack.h
          FrameTrackOnlineProcessor.h
@@ -82,6 +82,7 @@ target_sources(
           AsyncTrack.cpp
           Batcher.cpp
           CallStackDataView.cpp
+          CallstackThreadBar.cpp
           CallTreeView.cpp
           CaptureWindow.cpp
           CaptureViewElement.cpp
@@ -89,7 +90,6 @@ target_sources(
           DataView.cpp
           Disassembler.cpp
           DisassemblyReport.cpp
-          EventTrack.cpp
           FramePointerValidatorClient.cpp
           FrameTrack.cpp
           FrameTrackOnlineProcessor.cpp

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -59,7 +59,7 @@ target_sources(
          TextBox.h
          TextRenderer.h
          ThreadBar.h
-         ThreadStateTrack.h
+         ThreadStateBar.h
          ThreadTrack.h
          TimeGraph.h
          TimeGraphLayout.h
@@ -118,7 +118,7 @@ target_sources(
           TimerInfosIterator.cpp
           TimerTrack.cpp
           ThreadBar.cpp
-          ThreadStateTrack.cpp
+          ThreadStateBar.cpp
           ThreadTrack.cpp
           Track.cpp
           TrackManager.cpp

--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "EventTrack.h"
+#include "CallstackThreadBar.h"
 
 #include <absl/strings/str_format.h>
 #include <stddef.h>
@@ -31,15 +31,17 @@ using orbit_client_protos::CallstackEvent;
 
 namespace orbit_gl {
 
-EventTrack::EventTrack(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
-                       const CaptureData* capture_data, ThreadID thread_id,
-                       CaptureViewElement* parent)
-    : ThreadBar(app, time_graph, layout, capture_data, thread_id, parent, "Events"),
+CallstackThreadBar::CallstackThreadBar(OrbitApp* app, TimeGraph* time_graph,
+                                       TimeGraphLayout* layout, const CaptureData* capture_data,
+                                       ThreadID thread_id, CaptureViewElement* parent)
+    : ThreadBar(app, time_graph, layout, capture_data, thread_id, parent, "Callstacks"),
       color_{0, 255, 0, 255} {}
 
-std::string EventTrack::GetTooltip() const { return "Left-click and drag to select samples"; }
+std::string CallstackThreadBar::GetTooltip() const {
+  return "Left-click and drag to select samples";
+}
 
-void EventTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
+void CallstackThreadBar::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
   ThreadBar::Draw(canvas, picking_mode, z_offset);
 
   if (thread_id_ == orbit_base::kAllThreadsOfAllProcessesTid) {
@@ -86,8 +88,8 @@ void EventTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset
   }
 }
 
-void EventTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                                  PickingMode picking_mode, float z_offset) {
+void CallstackThreadBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                                          PickingMode picking_mode, float z_offset) {
   ThreadBar::UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
 
   float z = GlCanvas::kZValueEvent + z_offset;
@@ -149,24 +151,24 @@ void EventTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t 
   }
 }
 
-void EventTrack::OnRelease() {
+void CallstackThreadBar::OnRelease() {
   CaptureViewElement::OnRelease();
-  SelectEvents();
+  SelectCallstacks();
 }
 
-void EventTrack::OnPick(int x, int y) {
+void CallstackThreadBar::OnPick(int x, int y) {
   CaptureViewElement::OnPick(x, y);
   app_->set_selected_thread_id(thread_id_);
 }
 
-void EventTrack::SelectEvents() {
+void CallstackThreadBar::SelectCallstacks() {
   Vec2& from = mouse_pos_last_click_;
   Vec2& to = mouse_pos_cur_;
 
-  time_graph_->SelectEvents(from[0], to[0], thread_id_);
+  time_graph_->SelectCallstacks(from[0], to[0], thread_id_);
 }
 
-bool EventTrack::IsEmpty() const {
+bool CallstackThreadBar::IsEmpty() const {
   if (capture_data_ == nullptr) return true;
   const uint32_t callstack_count =
       (thread_id_ == orbit_base::kAllProcessThreadsTid)
@@ -175,8 +177,8 @@ bool EventTrack::IsEmpty() const {
   return callstack_count == 0;
 }
 
-[[nodiscard]] std::string EventTrack::SafeGetFormattedFunctionName(uint64_t addr,
-                                                                   int max_line_length) const {
+[[nodiscard]] std::string CallstackThreadBar::SafeGetFormattedFunctionName(
+    uint64_t addr, int max_line_length) const {
   CHECK(capture_data_ != nullptr);
   const std::string& function_name = capture_data_->GetFunctionNameByAddress(addr);
   if (function_name == CaptureData::kUnknownFunctionOrModuleName) {
@@ -194,8 +196,9 @@ bool EventTrack::IsEmpty() const {
   return fn_name;
 }
 
-std::string EventTrack::FormatCallstackForTooltip(const CallStack& callstack, int max_line_length,
-                                                  int max_lines, int bottom_n_lines) const {
+std::string CallstackThreadBar::FormatCallstackForTooltip(const CallStack& callstack,
+                                                          int max_line_length, int max_lines,
+                                                          int bottom_n_lines) const {
   std::string result;
   int size = static_cast<int>(callstack.GetFramesCount());
   if (max_lines <= 0) {
@@ -217,7 +220,7 @@ std::string EventTrack::FormatCallstackForTooltip(const CallStack& callstack, in
   return result;
 }
 
-std::string EventTrack::GetSampleTooltip(const Batcher& batcher, PickingId id) const {
+std::string CallstackThreadBar::GetSampleTooltip(const Batcher& batcher, PickingId id) const {
   static const std::string unknown_return_text = "Function call information missing";
 
   auto user_data = batcher.GetUserData(id);

--- a/src/OrbitGl/CallstackThreadBar.h
+++ b/src/OrbitGl/CallstackThreadBar.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef ORBIT_GL_EVENT_TRACK_H_
-#define ORBIT_GL_EVENT_TRACK_H_
+#ifndef ORBIT_GL_CALLSTACK_THREAD_BAR_H_
+#define ORBIT_GL_CALLSTACK_THREAD_BAR_H_
 
 #include <GteVector.h>
 #include <stdint.h>
@@ -21,11 +21,11 @@ class OrbitApp;
 
 namespace orbit_gl {
 
-class EventTrack : public ThreadBar {
+class CallstackThreadBar : public ThreadBar {
  public:
-  explicit EventTrack(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
-                      const CaptureData* capture_data, ThreadID thread_id,
-                      CaptureViewElement* parent);
+  explicit CallstackThreadBar(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
+                              const CaptureData* capture_data, ThreadID thread_id,
+                              CaptureViewElement* parent);
 
   std::string GetTooltip() const override;
 
@@ -41,7 +41,7 @@ class EventTrack : public ThreadBar {
   void SetColor(const Color& color) { color_ = color; }
 
  protected:
-  void SelectEvents();
+  void SelectCallstacks();
   [[nodiscard]] std::string SafeGetFormattedFunctionName(uint64_t addr, int max_line_length) const;
   [[nodiscard]] std::string FormatCallstackForTooltip(const CallStack& callstack,
                                                       int max_line_length = 80, int max_lines = 20,

--- a/src/OrbitGl/FrameTrack.h
+++ b/src/OrbitGl/FrameTrack.h
@@ -11,8 +11,8 @@
 #include <string>
 #include <vector>
 
+#include "CallstackThreadBar.h"
 #include "CoreMath.h"
-#include "EventTrack.h"
 #include "PickingManager.h"
 #include "TextBox.h"
 #include "TimerChain.h"

--- a/src/OrbitGl/GpuTrack.h
+++ b/src/OrbitGl/GpuTrack.h
@@ -11,8 +11,8 @@
 #include <string>
 #include <string_view>
 
+#include "CallstackThreadBar.h"
 #include "CoreMath.h"
-#include "EventTrack.h"
 #include "PickingManager.h"
 #include "StringManager.h"
 #include "TextBox.h"

--- a/src/OrbitGl/SchedulerTrack.h
+++ b/src/OrbitGl/SchedulerTrack.h
@@ -7,8 +7,8 @@
 
 #include <string>
 
+#include "CallstackThreadBar.h"
 #include "CoreMath.h"
-#include "EventTrack.h"
 #include "PickingManager.h"
 #include "TimerTrack.h"
 #include "Track.h"

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "ThreadStateTrack.h"
+#include "ThreadStateBar.h"
 
 #include <absl/strings/str_format.h>
 
@@ -22,17 +22,17 @@ using orbit_client_protos::ThreadStateSliceInfo;
 
 namespace orbit_gl {
 
-ThreadStateTrack::ThreadStateTrack(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
-                                   const CaptureData* capture_data, ThreadID thread_id,
-                                   CaptureViewElement* parent)
+ThreadStateBar::ThreadStateBar(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
+                               const CaptureData* capture_data, ThreadID thread_id,
+                               CaptureViewElement* parent)
     : ThreadBar(app, time_graph, layout, capture_data, thread_id, parent, "ThreadState") {}
 
-bool ThreadStateTrack::IsEmpty() const {
+bool ThreadStateBar::IsEmpty() const {
   if (capture_data_ == nullptr) return true;
   return !capture_data_->HasThreadStatesForThread(thread_id_);
 }
 
-void ThreadStateTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
+void ThreadStateBar::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
   ThreadBar::Draw(canvas, picking_mode, z_offset);
 
   // Similarly to CallstackThreadBar::Draw, the thread state slices don't respond to clicks, but
@@ -140,7 +140,7 @@ static std::string GetThreadStateDescription(ThreadStateSliceInfo::ThreadState s
   }
 }
 
-std::string ThreadStateTrack::GetThreadStateSliceTooltip(Batcher* batcher, PickingId id) const {
+std::string ThreadStateBar::GetThreadStateSliceTooltip(Batcher* batcher, PickingId id) const {
   auto user_data = batcher->GetUserData(id);
   if (user_data == nullptr || user_data->custom_data_ == nullptr) {
     return "";
@@ -157,8 +157,8 @@ std::string ThreadStateTrack::GetThreadStateSliceTooltip(Batcher* batcher, Picki
       GetThreadStateDescription(thread_state_slice->thread_state()));
 }
 
-void ThreadStateTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                                        PickingMode picking_mode, float z_offset) {
+void ThreadStateBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                                      PickingMode picking_mode, float z_offset) {
   ThreadBar::UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
 
   const GlCanvas* canvas = time_graph_->GetCanvas();
@@ -215,7 +215,7 @@ void ThreadStateTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uin
       });
 }
 
-void ThreadStateTrack::OnPick(int x, int y) {
+void ThreadStateBar::OnPick(int x, int y) {
   ThreadBar::OnPick(x, y);
   app_->set_selected_thread_id(thread_id_);
 }

--- a/src/OrbitGl/ThreadStateBar.h
+++ b/src/OrbitGl/ThreadStateBar.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef ORBIT_GL_THREAD_STATE_TRACK_H_
-#define ORBIT_GL_THREAD_STATE_TRACK_H_
+#ifndef ORBIT_GL_THREAD_STATE_BAR_H_
+#define ORBIT_GL_THREAD_STATE_BAR_H_
 
 #include <GteVector.h>
 #include <stdint.h>
@@ -21,11 +21,11 @@ namespace orbit_gl {
 // It is a thin sub-track of ThreadTrack, added above the callstack track (EventTrack).
 // The colors are determined only by the states, not by the color assigned to the thread.
 
-class ThreadStateTrack final : public ThreadBar {
+class ThreadStateBar final : public ThreadBar {
  public:
-  explicit ThreadStateTrack(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
-                            const CaptureData* capture_data, ThreadID thread_id,
-                            CaptureViewElement* parent);
+  explicit ThreadStateBar(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
+                          const CaptureData* capture_data, ThreadID thread_id,
+                          CaptureViewElement* parent);
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,

--- a/src/OrbitGl/ThreadStateTrack.cpp
+++ b/src/OrbitGl/ThreadStateTrack.cpp
@@ -35,8 +35,8 @@ bool ThreadStateTrack::IsEmpty() const {
 void ThreadStateTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
   ThreadBar::Draw(canvas, picking_mode, z_offset);
 
-  // Similarly to EventTrack::Draw, the thread state slices don't respond to clicks, but have a
-  // tooltip. For picking, we want to draw the event bar over them if handling a click, and
+  // Similarly to CallstackThreadBar::Draw, the thread state slices don't respond to clicks, but
+  // have a tooltip. For picking, we want to draw the event bar over them if handling a click, and
   // underneath otherwise. This simulates "click-through" behavior.
   float thread_state_bar_z = picking_mode == PickingMode::kClick ? GlCanvas::kZValueEventBarPicking
                                                                  : GlCanvas::kZValueEventBar;

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -40,15 +40,15 @@ ThreadTrack::ThreadTrack(TimeGraph* time_graph, TimeGraphLayout* layout, int32_t
   thread_id_ = thread_id;
   InitializeNameAndLabel(thread_id);
 
-  thread_state_track_ = std::make_shared<orbit_gl::ThreadStateBar>(app_, time_graph, layout,
-                                                                   capture_data, thread_id_, this);
+  thread_state_bar_ = std::make_shared<orbit_gl::ThreadStateBar>(app_, time_graph, layout,
+                                                                 capture_data, thread_id_, this);
 
-  event_track_ = std::make_shared<orbit_gl::CallstackThreadBar>(app_, time_graph, layout,
-                                                                capture_data, thread_id_, this);
-  event_track_->SetThreadId(thread_id);
+  event_bar_ = std::make_shared<orbit_gl::CallstackThreadBar>(app_, time_graph, layout,
+                                                              capture_data, thread_id_, this);
+  event_bar_->SetThreadId(thread_id);
 
-  tracepoint_track_ = std::make_shared<orbit_gl::TracepointThreadBar>(
-      app_, time_graph, layout, capture_data, thread_id_, this);
+  tracepoint_bar_ = std::make_shared<orbit_gl::TracepointThreadBar>(app_, time_graph, layout,
+                                                                    capture_data, thread_id_, this);
   SetTrackColor(TimeGraph::GetThreadColor(thread_id));
 }
 
@@ -204,8 +204,8 @@ void ThreadTrack::UpdateBoxHeight() {
 }
 
 bool ThreadTrack::IsEmpty() const {
-  return thread_state_track_->IsEmpty() && event_track_->IsEmpty() &&
-         tracepoint_track_->IsEmpty() && (GetNumTimers() == 0);
+  return thread_state_bar_->IsEmpty() && event_bar_->IsEmpty() && tracepoint_bar_->IsEmpty() &&
+         (GetNumTimers() == 0);
 }
 
 void ThreadTrack::UpdatePositionOfSubtracks() {
@@ -215,17 +215,17 @@ void ThreadTrack::UpdatePositionOfSubtracks() {
 
   float current_y = pos_[1];
 
-  thread_state_track_->SetPos(pos_[0], current_y);
-  if (!thread_state_track_->IsEmpty()) {
+  thread_state_bar_->SetPos(pos_[0], current_y);
+  if (!thread_state_bar_->IsEmpty()) {
     current_y -= (space_between_subtracks + thread_state_track_height);
   }
 
-  event_track_->SetPos(pos_[0], current_y);
-  if (!event_track_->IsEmpty()) {
+  event_bar_->SetPos(pos_[0], current_y);
+  if (!event_bar_->IsEmpty()) {
     current_y -= (space_between_subtracks + event_track_height);
   }
 
-  tracepoint_track_->SetPos(pos_[0], current_y);
+  tracepoint_bar_->SetPos(pos_[0], current_y);
 }
 
 void ThreadTrack::UpdateMinMaxTimestamps() {
@@ -246,19 +246,19 @@ void ThreadTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offse
   const float event_track_height = layout_->GetEventTrackHeight();
   const float tracepoint_track_height = layout_->GetEventTrackHeight();
 
-  if (!thread_state_track_->IsEmpty()) {
-    thread_state_track_->SetSize(canvas->GetWorldWidth(), thread_state_track_height);
-    thread_state_track_->Draw(canvas, picking_mode, z_offset);
+  if (!thread_state_bar_->IsEmpty()) {
+    thread_state_bar_->SetSize(canvas->GetWorldWidth(), thread_state_track_height);
+    thread_state_bar_->Draw(canvas, picking_mode, z_offset);
   }
 
-  if (!event_track_->IsEmpty()) {
-    event_track_->SetSize(canvas->GetWorldWidth(), event_track_height);
-    event_track_->Draw(canvas, picking_mode, z_offset);
+  if (!event_bar_->IsEmpty()) {
+    event_bar_->SetSize(canvas->GetWorldWidth(), event_track_height);
+    event_bar_->Draw(canvas, picking_mode, z_offset);
   }
 
-  if (!tracepoint_track_->IsEmpty()) {
-    tracepoint_track_->SetSize(canvas->GetWorldWidth(), tracepoint_track_height);
-    tracepoint_track_->Draw(canvas, picking_mode, z_offset);
+  if (!tracepoint_bar_->IsEmpty()) {
+    tracepoint_bar_->SetSize(canvas->GetWorldWidth(), tracepoint_track_height);
+    tracepoint_bar_->Draw(canvas, picking_mode, z_offset);
   }
 }
 
@@ -271,14 +271,14 @@ void ThreadTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t
                                    PickingMode picking_mode, float z_offset) {
   UpdatePositionOfSubtracks();
 
-  if (!thread_state_track_->IsEmpty()) {
-    thread_state_track_->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
+  if (!thread_state_bar_->IsEmpty()) {
+    thread_state_bar_->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
   }
-  if (!event_track_->IsEmpty()) {
-    event_track_->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
+  if (!event_bar_->IsEmpty()) {
+    event_bar_->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
   }
-  if (!tracepoint_track_->IsEmpty()) {
-    tracepoint_track_->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
+  if (!tracepoint_bar_->IsEmpty()) {
+    tracepoint_bar_->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
   }
 
   TimerTrack::UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
@@ -286,16 +286,16 @@ void ThreadTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t
 
 std::vector<orbit_gl::CaptureViewElement*> ThreadTrack::GetVisibleChildren() {
   std::vector<CaptureViewElement*> result;
-  if (!thread_state_track_->IsEmpty()) {
-    result.push_back(thread_state_track_.get());
+  if (!thread_state_bar_->IsEmpty()) {
+    result.push_back(thread_state_bar_.get());
   }
 
-  if (!event_track_->IsEmpty()) {
-    result.push_back(event_track_.get());
+  if (!event_bar_->IsEmpty()) {
+    result.push_back(event_bar_.get());
   }
 
-  if (!tracepoint_track_->IsEmpty()) {
-    result.push_back(tracepoint_track_.get());
+  if (!tracepoint_bar_->IsEmpty()) {
+    result.push_back(tracepoint_bar_.get());
   }
 
   return result;
@@ -303,8 +303,8 @@ std::vector<orbit_gl::CaptureViewElement*> ThreadTrack::GetVisibleChildren() {
 
 void ThreadTrack::SetTrackColor(Color color) {
   absl::MutexLock lock(&mutex_);
-  event_track_->SetColor(color);
-  tracepoint_track_->SetColor(color);
+  event_bar_->SetColor(color);
+  tracepoint_bar_->SetColor(color);
 }
 
 void ThreadTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_us, float min_x,
@@ -361,8 +361,7 @@ float ThreadTrack::GetHeight() const {
   const uint32_t depth = is_collapsed ? collapsed_depth : GetDepth();
 
   bool gap_between_tracks_and_timers =
-      (!thread_state_track_->IsEmpty() || !event_track_->IsEmpty() ||
-       !tracepoint_track_->IsEmpty()) &&
+      (!thread_state_bar_->IsEmpty() || !event_bar_->IsEmpty() || !tracepoint_bar_->IsEmpty()) &&
       (depth > 0);
   return GetHeaderHeight() +
          (gap_between_tracks_and_timers ? layout_->GetSpaceBetweenTracksAndThread() : 0) +
@@ -377,17 +376,17 @@ float ThreadTrack::GetHeaderHeight() const {
 
   float header_height = 0.0f;
   int track_count = 0;
-  if (!thread_state_track_->IsEmpty()) {
+  if (!thread_state_bar_->IsEmpty()) {
     header_height += thread_state_track_height;
     ++track_count;
   }
 
-  if (!event_track_->IsEmpty()) {
+  if (!event_bar_->IsEmpty()) {
     header_height += event_track_height;
     ++track_count;
   }
 
-  if (!tracepoint_track_->IsEmpty()) {
+  if (!tracepoint_bar_->IsEmpty()) {
     header_height += tracepoint_track_height;
     ++track_count;
   }

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -40,8 +40,8 @@ ThreadTrack::ThreadTrack(TimeGraph* time_graph, TimeGraphLayout* layout, int32_t
   thread_id_ = thread_id;
   InitializeNameAndLabel(thread_id);
 
-  thread_state_track_ = std::make_shared<orbit_gl::ThreadStateTrack>(
-      app_, time_graph, layout, capture_data, thread_id_, this);
+  thread_state_track_ = std::make_shared<orbit_gl::ThreadStateBar>(app_, time_graph, layout,
+                                                                   capture_data, thread_id_, this);
 
   event_track_ = std::make_shared<orbit_gl::CallstackThreadBar>(app_, time_graph, layout,
                                                                 capture_data, thread_id_, this);

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -47,8 +47,8 @@ ThreadTrack::ThreadTrack(TimeGraph* time_graph, TimeGraphLayout* layout, int32_t
                                                                 capture_data, thread_id_, this);
   event_track_->SetThreadId(thread_id);
 
-  tracepoint_track_ = std::make_shared<orbit_gl::TracepointTrack>(app_, time_graph, layout,
-                                                                  capture_data, thread_id_, this);
+  tracepoint_track_ = std::make_shared<orbit_gl::TracepointThreadBar>(
+      app_, time_graph, layout, capture_data, thread_id_, this);
   SetTrackColor(TimeGraph::GetThreadColor(thread_id));
 }
 

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -43,8 +43,8 @@ ThreadTrack::ThreadTrack(TimeGraph* time_graph, TimeGraphLayout* layout, int32_t
   thread_state_track_ = std::make_shared<orbit_gl::ThreadStateTrack>(
       app_, time_graph, layout, capture_data, thread_id_, this);
 
-  event_track_ = std::make_shared<orbit_gl::EventTrack>(app_, time_graph, layout, capture_data,
-                                                        thread_id_, this);
+  event_track_ = std::make_shared<orbit_gl::CallstackThreadBar>(app_, time_graph, layout,
+                                                                capture_data, thread_id_, this);
   event_track_->SetThreadId(thread_id);
 
   tracepoint_track_ = std::make_shared<orbit_gl::TracepointTrack>(app_, time_graph, layout,

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -11,8 +11,8 @@
 #include <memory>
 #include <string>
 
+#include "CallstackThreadBar.h"
 #include "CoreMath.h"
-#include "EventTrack.h"
 #include "PickingManager.h"
 #include "TextBox.h"
 #include "ThreadStateTrack.h"
@@ -67,7 +67,7 @@ class ThreadTrack final : public TimerTrack {
   void UpdateMinMaxTimestamps();
 
   std::shared_ptr<orbit_gl::ThreadStateTrack> thread_state_track_;
-  std::shared_ptr<orbit_gl::EventTrack> event_track_;
+  std::shared_ptr<orbit_gl::CallstackThreadBar> event_track_;
   std::shared_ptr<orbit_gl::TracepointTrack> tracepoint_track_;
 };
 

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -17,7 +17,7 @@
 #include "TextBox.h"
 #include "ThreadStateTrack.h"
 #include "TimerTrack.h"
-#include "TracepointTrack.h"
+#include "TracepointThreadBar.h"
 #include "Track.h"
 #include "capture_data.pb.h"
 
@@ -68,7 +68,7 @@ class ThreadTrack final : public TimerTrack {
 
   std::shared_ptr<orbit_gl::ThreadStateTrack> thread_state_track_;
   std::shared_ptr<orbit_gl::CallstackThreadBar> event_track_;
-  std::shared_ptr<orbit_gl::TracepointTrack> tracepoint_track_;
+  std::shared_ptr<orbit_gl::TracepointThreadBar> tracepoint_track_;
 };
 
 #endif  // ORBIT_GL_THREAD_TRACK_H_

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -15,7 +15,7 @@
 #include "CoreMath.h"
 #include "PickingManager.h"
 #include "TextBox.h"
-#include "ThreadStateTrack.h"
+#include "ThreadStateBar.h"
 #include "TimerTrack.h"
 #include "TracepointThreadBar.h"
 #include "Track.h"
@@ -66,7 +66,7 @@ class ThreadTrack final : public TimerTrack {
   void UpdatePositionOfSubtracks();
   void UpdateMinMaxTimestamps();
 
-  std::shared_ptr<orbit_gl::ThreadStateTrack> thread_state_track_;
+  std::shared_ptr<orbit_gl::ThreadStateBar> thread_state_track_;
   std::shared_ptr<orbit_gl::CallstackThreadBar> event_track_;
   std::shared_ptr<orbit_gl::TracepointThreadBar> tracepoint_track_;
 };

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -66,9 +66,9 @@ class ThreadTrack final : public TimerTrack {
   void UpdatePositionOfSubtracks();
   void UpdateMinMaxTimestamps();
 
-  std::shared_ptr<orbit_gl::ThreadStateBar> thread_state_track_;
-  std::shared_ptr<orbit_gl::CallstackThreadBar> event_track_;
-  std::shared_ptr<orbit_gl::TracepointThreadBar> tracepoint_track_;
+  std::shared_ptr<orbit_gl::ThreadStateBar> thread_state_bar_;
+  std::shared_ptr<orbit_gl::CallstackThreadBar> event_bar_;
+  std::shared_ptr<orbit_gl::TracepointThreadBar> tracepoint_bar_;
 };
 
 #endif  // ORBIT_GL_THREAD_TRACK_H_

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -546,7 +546,7 @@ void TimeGraph::UpdatePrimitives(PickingMode picking_mode) {
   needs_update_primitives_ = false;
 }
 
-void TimeGraph::SelectEvents(float world_start, float world_end, int32_t thread_id) {
+void TimeGraph::SelectCallstacks(float world_start, float world_end, int32_t thread_id) {
   if (world_start > world_end) {
     std::swap(world_end, world_start);
   }

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -17,9 +17,9 @@
 
 #include "AccessibleTimeGraph.h"
 #include "Batcher.h"
+#include "CallstackThreadBar.h"
 #include "CoreMath.h"
 #include "CoreUtils.h"
-#include "EventTrack.h"
 #include "ManualInstrumentationManager.h"
 #include "OrbitClientModel/CaptureData.h"
 #include "PickingManager.h"
@@ -47,7 +47,7 @@ class TimeGraph {
 
   void NeedsUpdate();
   void UpdatePrimitives(PickingMode picking_mode);
-  void SelectEvents(float world_start, float world_end, int32_t thread_id);
+  void SelectCallstacks(float world_start, float world_end, int32_t thread_id);
   const std::vector<orbit_client_protos::CallstackEvent>& GetSelectedCallstackEvents(int32_t tid);
 
   void ProcessTimer(const orbit_client_protos::TimerInfo& timer_info,

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -21,7 +21,7 @@
 #include "TextBox.h"
 #include "TextRenderer.h"
 #include "TimerChain.h"
-#include "TracepointTrack.h"
+#include "TracepointThreadBar.h"
 #include "Track.h"
 #include "absl/synchronization/mutex.h"
 #include "capture_data.pb.h"

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -14,8 +14,8 @@
 #include <vector>
 
 #include "BlockChain.h"
+#include "CallstackThreadBar.h"
 #include "CoreMath.h"
-#include "EventTrack.h"
 #include "OrbitClientData/CallstackTypes.h"
 #include "PickingManager.h"
 #include "TextBox.h"

--- a/src/OrbitGl/TracepointThreadBar.cpp
+++ b/src/OrbitGl/TracepointThreadBar.cpp
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "TracepointTrack.h"
+#include "TracepointThreadBar.h"
 
 #include <GteVector.h>
 #include <absl/strings/str_format.h>
@@ -26,13 +26,13 @@
 
 namespace orbit_gl {
 
-TracepointTrack::TracepointTrack(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
-                                 const CaptureData* capture_data, int32_t thread_id,
-                                 CaptureViewElement* parent)
+TracepointThreadBar::TracepointThreadBar(OrbitApp* app, TimeGraph* time_graph,
+                                         TimeGraphLayout* layout, const CaptureData* capture_data,
+                                         int32_t thread_id, CaptureViewElement* parent)
     : ThreadBar(app, time_graph, layout, capture_data, thread_id, parent, "Tracepoints"),
       color_{255, 0, 0, 255} {}
 
-void TracepointTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
+void TracepointThreadBar::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
   ThreadBar::Draw(canvas, picking_mode, z_offset);
 
   if (IsEmpty()) {
@@ -49,8 +49,8 @@ void TracepointTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_o
   ui_batcher->AddBox(box, color, shared_from_this());
 }
 
-void TracepointTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                                       PickingMode picking_mode, float z_offset) {
+void TracepointThreadBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                                           PickingMode picking_mode, float z_offset) {
   ThreadBar::UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
 
   float z = GlCanvas::kZValueEvent + z_offset;
@@ -103,7 +103,7 @@ void TracepointTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint
   }
 }
 
-std::string TracepointTrack::GetTracepointTooltip(Batcher* batcher, PickingId id) const {
+std::string TracepointThreadBar::GetTracepointTooltip(Batcher* batcher, PickingId id) const {
   auto user_data = batcher->GetUserData(id);
   CHECK(user_data && user_data->custom_data_);
 
@@ -137,7 +137,7 @@ std::string TracepointTrack::GetTracepointTooltip(Batcher* batcher, PickingId id
   }
 }
 
-bool TracepointTrack::IsEmpty() const {
+bool TracepointThreadBar::IsEmpty() const {
   if (capture_data_ == nullptr) return true;
   return capture_data_->GetNumTracepointsForThreadId(thread_id_) == 0;
 }

--- a/src/OrbitGl/TracepointThreadBar.h
+++ b/src/OrbitGl/TracepointThreadBar.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef ORBIT_GL_TRACEPOINT_TRACK_H_
-#define ORBIT_GL_TRACEPOINT_TRACK_H_
+#ifndef ORBIT_GL_TRACEPOINT_THREAD_BAR_H_
+#define ORBIT_GL_TRACEPOINT_THREAD_BAR_H_
 
 #include <stdint.h>
 
@@ -13,11 +13,11 @@
 
 namespace orbit_gl {
 
-class TracepointTrack : public ThreadBar {
+class TracepointThreadBar : public ThreadBar {
  public:
-  explicit TracepointTrack(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
-                           const CaptureData* capture_data, int32_t thread_id,
-                           CaptureViewElement* parent);
+  explicit TracepointThreadBar(OrbitApp* app, TimeGraph* time_graph, TimeGraphLayout* layout,
+                               const CaptureData* capture_data, int32_t thread_id,
+                               CaptureViewElement* parent);
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
 


### PR DESCRIPTION
Rename EventTrack, TracepointTrack and ThreadStateTrack.
This also fixes a type in the E2E test for ThreadState that lead to a failure.