### PR TITLE
unique_fd is no longer unique_resource

### DIFF
--- a/src/OrbitBase/FileTest.cpp
+++ b/src/OrbitBase/FileTest.cpp
@@ -7,34 +7,80 @@
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/File.h"
 
+namespace orbit_base {
+
+TEST(File, DefaultUniqueFdIsInvalidDescriptor) {
+  unique_fd fd;
+  EXPECT_FALSE(fd.valid());
+  EXPECT_EQ(fd.get(), kInvalidFd);
+}
+
+TEST(File, EmptyUnuqueFdCanBeReleased) {
+  unique_fd fd;
+  fd.release();
+  EXPECT_FALSE(fd.valid());
+  EXPECT_EQ(fd.get(), kInvalidFd);
+}
+
+TEST(File, MoveAssingToExisingUniqueFd) {
+  unique_fd fd;
+
+  auto fd_or_error =
+      OpenFileForReading(GetExecutableDir() / "testdata" / "OrbitBase" / "textfile.bin");
+
+  ASSERT_TRUE(fd_or_error.has_value()) << fd_or_error.error().message();
+  fd = std::move(fd_or_error.value());
+  EXPECT_TRUE(fd.valid());
+  EXPECT_FALSE(fd_or_error.value().valid());
+}
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wself-move"
+
+TEST(File, UniqueFdSelfMove) {
+  auto fd_or_error =
+      OpenFileForReading(GetExecutableDir() / "testdata" / "OrbitBase" / "textfile.bin");
+  ASSERT_TRUE(fd_or_error.has_value()) << fd_or_error.error().message();
+  unique_fd valid_fd{std::move(fd_or_error.value())};
+
+  valid_fd = std::move(valid_fd);
+
+  ASSERT_TRUE(valid_fd.valid());
+}
+
+#pragma GCC diagnostic pop
+
 TEST(File, OpenFileForReadingInvalidFile) {
-  const auto result = orbit_base::OpenFileForReading("non/existing/filename");
-  ASSERT_TRUE(result.has_error());
+  const auto fd_or_error = OpenFileForReading("non/existing/filename");
+  ASSERT_TRUE(fd_or_error.has_error());
 }
 
 TEST(File, ReadFullySmoke) {
-  const auto open_result = orbit_base::OpenFileForReading(
-      orbit_base::GetExecutableDir() / "testdata" / "OrbitBase" / "textfile.bin");
-  ASSERT_FALSE(open_result.has_error()) << open_result.error().message();
-  const auto& fd = open_result.value();
+  const auto fd_or_error =
+      OpenFileForReading(GetExecutableDir() / "testdata" / "OrbitBase" / "textfile.bin");
+  ASSERT_FALSE(fd_or_error.has_error()) << fd_or_error.error().message();
+  const auto& fd = fd_or_error.value();
+  ASSERT_TRUE(fd.valid());
   std::array<char, 64> buf{};
 
-  ErrorMessageOr<size_t> result = orbit_base::ReadFully(fd, buf.data(), 5);
+  ErrorMessageOr<size_t> result = ReadFully(fd, buf.data(), 5);
   ASSERT_FALSE(result.has_error()) << result.error().message();
   EXPECT_EQ(result.value(), 5);
   EXPECT_STREQ(buf.data(), "conte");
 
   buf = {};
 
-  result = orbit_base::ReadFully(fd, buf.data(), buf.size());
+  result = ReadFully(fd, buf.data(), buf.size());
   ASSERT_FALSE(result.has_error()) << result.error().message();
   EXPECT_EQ(result.value(), 11);
   EXPECT_STREQ(buf.data(), "nt\nnew line");
 
   buf = {};
 
-  result = orbit_base::ReadFully(fd, buf.data(), buf.size());
+  result = ReadFully(fd, buf.data(), buf.size());
   ASSERT_FALSE(result.has_error()) << result.error().message();
   EXPECT_EQ(result.value(), 0);
   EXPECT_STREQ(buf.data(), "");
 }
+
+}  // namespace orbit_base

--- a/src/OrbitBase/ReadFileToString.cpp
+++ b/src/OrbitBase/ReadFileToString.cpp
@@ -40,13 +40,13 @@ ErrorMessageOr<std::string> ReadFileToString(const std::filesystem::path& file_n
 
   // We want to avoid memory reallocations in case the file is relatively large.
   struct stat st {};
-  if (fstat(fd, &st) != -1 && st.st_size > 0) {
+  if (fstat(fd.get(), &st) != -1 && st.st_size > 0) {
     result.reserve(st.st_size);
   }
 
   std::array<char, BUFSIZ> buf{};
   int64_t number_of_bytes;
-  while ((number_of_bytes = TEMP_FAILURE_RETRY(read(fd, buf.data(), buf.size()))) > 0) {
+  while ((number_of_bytes = TEMP_FAILURE_RETRY(read(fd.get(), buf.data(), buf.size()))) > 0) {
     result.append(buf.data(), number_of_bytes);
   }
 

--- a/src/OrbitClientModel/CaptureDeserializer.cpp
+++ b/src/OrbitClientModel/CaptureDeserializer.cpp
@@ -55,7 +55,7 @@ ErrorMessageOr<CaptureListener::CaptureOutcome> Load(const std::filesystem::path
     return fd_or_error.error();
   }
 
-  google::protobuf::io::FileInputStream input_stream(fd_or_error.value());
+  google::protobuf::io::FileInputStream input_stream(fd_or_error.value().get());
   google::protobuf::io::CodedInputStream coded_input(&input_stream);
 
   return Load(&coded_input, file_name, capture_listener, module_manager, cancellation_requested);

--- a/src/OrbitClientModel/include/OrbitClientModel/CaptureSerializer.h
+++ b/src/OrbitClientModel/include/OrbitClientModel/CaptureSerializer.h
@@ -75,7 +75,7 @@ ErrorMessageOr<void> Save(const std::filesystem::path& filename, const CaptureDa
     return fd_or_error.error();
   }
 
-  google::protobuf::io::FileOutputStream out_stream(fd_or_error.value());
+  google::protobuf::io::FileOutputStream out_stream(fd_or_error.value().get());
   google::protobuf::io::CodedOutputStream coded_output(&out_stream);
 
   {

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -774,16 +774,16 @@ ErrorMessageOr<void> OrbitApp::SavePreset(const std::string& filename) {
     filename_with_ext += ".opr";
   }
 
-  auto open_result = orbit_base::OpenFileForWriting(filename_with_ext);
-  if (open_result.has_error()) {
+  auto fd_or_error = orbit_base::OpenFileForWriting(filename_with_ext);
+  if (fd_or_error.has_error()) {
     std::string error_message = absl::StrFormat("Failed to open \"%s\": %s", filename_with_ext,
-                                                open_result.error().message());
+                                                fd_or_error.error().message());
     ERROR("%s", error_message);
     return ErrorMessage{error_message};
   }
 
   LOG("Saving preset to \"%s\"", filename_with_ext);
-  if (!preset.SerializeToFileDescriptor(open_result.value())) {
+  if (!preset.SerializeToFileDescriptor(fd_or_error.value().get())) {
     std::string error_message =
         absl::StrFormat("Failed to save preset to \"%s\"", filename_with_ext);
     ERROR("%s", error_message);
@@ -797,16 +797,16 @@ ErrorMessageOr<PresetInfo> OrbitApp::ReadPresetFromFile(const std::filesystem::p
   std::filesystem::path file_path =
       filename.is_absolute() ? filename : Path::CreateOrGetPresetDir() / filename;
 
-  auto open_result = orbit_base::OpenFileForReading(file_path);
-  if (open_result.has_error()) {
+  auto fd_or_error = orbit_base::OpenFileForReading(file_path);
+  if (fd_or_error.has_error()) {
     std::string error_message = absl::StrFormat("Failed to open \"%s\": %s", file_path.string(),
-                                                open_result.error().message());
+                                                fd_or_error.error().message());
     ERROR("%s", error_message);
     return ErrorMessage{error_message};
   }
 
   PresetInfo preset_info;
-  if (!preset_info.ParseFromFileDescriptor(open_result.value())) {
+  if (!preset_info.ParseFromFileDescriptor(fd_or_error.value().get())) {
     std::string error_message =
         absl::StrFormat("Failed to load preset from \"%s\"", file_path.string());
     ERROR("%s", error_message);


### PR DESCRIPTION
unique_fd can no longer be reset to another (int) fd. In can only be
constructed or moved from anther unique_fd.

Test: run OrbitBase unit-tests