### PR TITLE
[REBASE] Strip symbols of the Vulkan layer.

### DIFF
--- a/src/OrbitVulkanLayer/CMakeLists.txt
+++ b/src/OrbitVulkanLayer/CMakeLists.txt
@@ -40,6 +40,9 @@ target_link_libraries(OrbitVulkanLayer PUBLIC
         Vulkan::Vulkan
         Vulkan::ValidationLayers)
 
+
+strip_symbols(OrbitVulkanLayer)
+
 add_executable(OrbitVulkanLayerTests)
 
 target_compile_options(OrbitVulkanLayerTests PRIVATE ${STRICT_COMPILE_FLAGS})


### PR DESCRIPTION
Before: ~60MB
After: ~6MB

Original PR: #1998

Test: Compile and run on Infiltrator