### PR TITLE
Fix margin's size after zoom in CodeViewer

### DIFF
--- a/src/CodeViewer/Viewer.cpp
+++ b/src/CodeViewer/Viewer.cpp
@@ -390,6 +390,6 @@ int Viewer::WidthMarginBetweenColumns() const {
   return StringWidthInPixels(fontMetrics(), kTwoSpaces);
 }
 
-int Viewer::TopWidgetHeight() const { return top_bar_widget_.fontMetrics().height(); }
+int Viewer::TopWidgetHeight() const { return fontMetrics().height(); }
 
 }  // namespace orbit_code_viewer


### PR DESCRIPTION
We were using fontsize from TopWidget but we weren't updated it after
every zoom. So, as we are using the same font size in the entire
CodeViewer, we took it from there.

[b/181837657](http://b/181837657)