### PR TITLE
Fix expected counts of tracks after filtering

### DIFF
--- a/contrib/automation_tests/orbit_tracks.py
+++ b/contrib/automation_tests/orbit_tracks.py
@@ -20,18 +20,18 @@ def main(argv):
         MatchTracks(expected_names=[
             "Scheduler", ("sdma0", "vce0"), "gfx", "All Threads", "hello_ggp_stand"],
             allow_additional_tracks=True),
-        SelectTrack(track_index=5),
+        SelectTrack(track_index=4),
         DeselectTrack(),
         SelectTrack(track_index=0, expect_failure=True),   # Scheduler track cannot be selected
-        MoveTrack(track_index=5, new_index=0),
+        MoveTrack(track_index=4, new_index=0),
         MoveTrack(track_index=0, new_index=3),
-        MoveTrack(track_index=3, new_index=5),
+        MoveTrack(track_index=3, new_index=4),
         # TODO: The numbers below are very pessimistic, but it's not assured additional tracks like
         # GgpSwapChain, GgpVideoIpcRead etc are present - GgpSwapChain is missing on the DevKit, others
         # depend on the samples that have been taken
-        FilterTracks(filter_string="hello", expected_count=1),
-        FilterTracks(filter_string="Hello", expected_count=1),
-        FilterTracks(filter_string="ggp", expected_count=1, allow_additional_tracks=True),
+        FilterTracks(filter_string="hello", expected_count=2),
+        FilterTracks(filter_string="Hello", expected_count=2),
+        FilterTracks(filter_string="ggp", expected_count=2, allow_additional_tracks=True),
         FilterTracks(filter_string="", expected_count=4, allow_additional_tracks=True)]
     suite = E2ETestSuite(test_name="Track Interaction", test_cases=test_cases)
     suite.execute()


### PR DESCRIPTION
This fixes newly introduced issues in the E2E test "orbit_tracks":

1) The expected count after filtering was wrong - the "all_threads" thread was renamed to report its name as "All Threads" instead of the process name, but this does not affect filtering, so the expected # of tracks matching "hello_ggp_" in the E2E test is still 2...
2) The E2E test expects a minimum of 5 tracks, but proceeds to test movement for track with zero-based index 5. This could potentially fail.