### PR TITLE
Main timer checks the dirty flag before updates

### DIFF
--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -782,10 +782,14 @@ void OrbitMainWindow::OnTimer() {
   app_->MainTick();
 
   for (OrbitGLWidget* gl_widget : gl_widgets_) {
-    gl_widget->update();
+    if (gl_widget->GetCanvas() != nullptr && gl_widget->GetCanvas()->GetNeedsRedraw()) {
+      gl_widget->update();
+    }
   }
 
-  filter_panel_action_->SetTimerLabelText(QString::fromStdString(app_->GetCaptureTime()));
+  if (app_->IsCapturing()) {
+    filter_panel_action_->SetTimerLabelText(QString::fromStdString(app_->GetCaptureTime()));
+  }
 }
 
 void OrbitMainWindow::OnFilterFunctionsTextChanged(const QString& text) {


### PR DESCRIPTION
Reduces the GPU resources required in idle mode from 3% to 0.1% - see b/179978894

To reproduce: Start Orbit without taking a capture, open the task manager. There's a few percent of GPU utilization before this fix which should disappear afterwards.

Tests: Redraws and interaction with the capture window, debug window and introspection window work fine afterwards.