### PR TITLE
Make ShowSourceCode work in LiveFunctionsDataView::OnContextMenu

### DIFF
--- a/src/OrbitGl/LiveFunctionsDataView.cpp
+++ b/src/OrbitGl/LiveFunctionsDataView.cpp
@@ -273,7 +273,7 @@ void LiveFunctionsDataView::OnContextMenu(const std::string& action, int menu_in
                                           const std::vector<int>& item_indices) {
   const CaptureData& capture_data = app_->GetCaptureData();
   if (action == kMenuActionSelect || action == kMenuActionUnselect ||
-      action == kMenuActionDisassembly) {
+      action == kMenuActionDisassembly || action == kMenuActionSourceCode) {
     for (int i : item_indices) {
       const FunctionInfo selected_function = GetInstrumentedFunction(i);
       if (action == kMenuActionSelect) {


### PR DESCRIPTION
`LiveFunctionsDataView::OnContextMenu` was never calling
`ShowSourceCode` since the action is checked twice in two nested if's.

Only the second if was taking the source code view into account. No need
to say that this needs to be refactored.