### PR TITLE
Add "process_name" parameter

### DIFF
--- a/src/OrbitGl/ClientFlags.cpp
+++ b/src/OrbitGl/ClientFlags.cpp
@@ -19,6 +19,9 @@ ABSL_FLAG(uint16_t, grpc_port, 44765,
           "The service's GRPC server port (use default value if unsure)");
 ABSL_FLAG(bool, local, false, "Connects to local instance of OrbitService");
 
+ABSL_FLAG(std::string, process_name, "",
+          "Automatically select and connect to the specified process");
+
 ABSL_FLAG(bool, enable_tutorials_feature, false, "Enable tutorials");
 
 // TODO(b/160549506): Remove this flag once it can be specified in the ui.

--- a/src/OrbitQt/ProfilingTargetDialog.h
+++ b/src/OrbitQt/ProfilingTargetDialog.h
@@ -96,7 +96,7 @@ class ProfilingTargetDialog : public QDialog {
   void SetupLocalStates();
   void SetStateMachineInitialStateFromTarget(TargetConfiguration config);
   void SetStateMachineInitialState();
-  [[nodiscard]] bool TrySelectProcess(const ProcessData& process);
+  [[nodiscard]] bool TrySelectProcess(const std::string& process);
   void OnProcessListUpdate(std::vector<orbit_grpc_protos::ProcessInfo> process_list);
   void SetupProcessManager(const std::shared_ptr<grpc::Channel>& grpc_channel);
   void SetTargetAndStateMachineInitialState(StadiaTarget target);


### PR DESCRIPTION
When specified, Orbit will automatically connect to this process and
open the main window after instance connection is established.

When combined with automatic instance connection, this lets Orbit go
through the complete connection process automatically.

I've mainly added this to speed up my own iterations - which in hindsight
wasn't needed had I known about local ssh tunneling, but IMO this is a neat
addition and a first step towards automatically connecting to the last
process, WDYT?