### PR TITLE
IntrospectionWindow scopes its own instrumented methods

### DIFF
--- a/src/OrbitGl/IntrospectionWindow.cpp
+++ b/src/OrbitGl/IntrospectionWindow.cpp
@@ -50,6 +50,21 @@ void IntrospectionWindow::StartIntrospection() {
 }
 void IntrospectionWindow::StopIntrospection() { introspection_listener_ = nullptr; }
 
+void IntrospectionWindow::Draw() {
+  ORBIT_SCOPE_FUNCTION;
+  CaptureWindow::Draw();
+}
+
+void IntrospectionWindow::DrawScreenSpace() {
+  ORBIT_SCOPE_FUNCTION;
+  CaptureWindow::DrawScreenSpace();
+}
+
+void IntrospectionWindow::RenderText(float layer) {
+  ORBIT_SCOPE_FUNCTION;
+  CaptureWindow::RenderText(layer);
+}
+
 void IntrospectionWindow::ToggleRecording() {
   if (!IsIntrospecting()) {
     StartIntrospection();

--- a/src/OrbitGl/IntrospectionWindow.h
+++ b/src/OrbitGl/IntrospectionWindow.h
@@ -25,6 +25,10 @@ class IntrospectionWindow : public CaptureWindow {
   void StartIntrospection();
   void StopIntrospection();
 
+  void Draw() override;
+  void DrawScreenSpace() override;
+  void RenderText(float layer) override;
+
  protected:
   [[nodiscard]] const char* GetHelpText() const override;
   [[nodiscard]] bool ShouldAutoZoom() const override;


### PR DESCRIPTION
I'm not sure if this was clear to everyone, but the introspection window reports
its own `Draw` and `UpdatePrimitives` methods in the same timeline, which makes 
it hard to figure out which calls you're actually interested in.

A quick fix: I've overloaded all methods that are instrumented in `CaptureWindow`
and added a scope on top of that in `IntrospectionWindow`.
This makes it obvious where the introspection window is reporting
performance about itself rather than the main window if you take a look at the hierarchy
of instrumented functions.

Example image: *Left* is a stack from the main capture window, *Right* is from the 
introspection.

![image](https://user-images.githubusercontent.com/63750742/110463782-a1bdf380-80d2-11eb-9e15-8cf9bf9490f8.png)
