### PR TITLE
Log and potentially warn about low clock resolution on the client

### DIFF
--- a/src/OrbitBase/Profiling.cpp
+++ b/src/OrbitBase/Profiling.cpp
@@ -19,8 +19,10 @@ uint64_t EstimateClockResolution() {
   while (duration_ns < kMaximumDurationNs) {
     // Count to limit the number of iterations in the while loop below. Note that the loop
     // below will terminate within one quantum of the clock used. For the unlikely (broken?)
-    // case that the clock does not increase, this additional limit is checked.
-    constexpr int kSafetyNetCount = 100'000;
+    // case that the clock does not increase, this additional limit is checked. However, this
+    // value also needs to be sufficiently large so that the loop will actually hit an
+    // increase of the clock.
+    constexpr int kSafetyNetCount = 1'000'000;
 
     uint64_t resolution = 0;
     int safety_net_counter = 0;

--- a/src/Service/OrbitService.cpp
+++ b/src/Service/OrbitService.cpp
@@ -89,8 +89,7 @@ static void PrintInstanceVersions() {
 // postmortem debugging purposes. The resolution should be fairly small (in my tests
 // it was ~35 nanoseconds).
 static void PrintClockResolution() {
-  LOG("%s",
-      absl::StrFormat("Clock resolution: %" PRIi64 " (ns)", orbit_base::EstimateClockResolution()));
+  LOG("%s", absl::StrFormat("Clock resolution: %d (ns)", orbit_base::EstimateClockResolution()));
 }
 
 static std::string ReadStdIn() {


### PR DESCRIPTION
We had seen an issue where low clock resolution on our Windows client
led to highly inaccurate introspection timings (resolution was 1ms). We
now log and (in devmode) warn users when the estimated clock resolution
is low and hence timings may be inaccurate.

I tested this with the Windows clock we used previously and indeed
had to adjust some constants in the clock resolution estimation to even
get the right resolution.

Tested: Manually ran Orbit with -devmode to check if the warning
appears with the clock we used previously on Windows.
Bug: http://b/180995185