### PR TITLE
Simplify `CompleteSubmits` by using a priority queue.

### DIFF
--- a/src/OrbitVulkanLayer/SubmissionTracker.h
+++ b/src/OrbitVulkanLayer/SubmissionTracker.h
@@ -528,7 +528,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
     }
 
     if (!queue_to_submission_priority_queue_.contains(queue)) {
-      queue_to_submission_priority_queue_.emplace(queue, kPreSubmissionCPUTimestampComparator);
+      queue_to_submission_priority_queue_.emplace(queue, kPreSubmissionCpuTimestampComparator);
     }
 
     queue_to_submission_priority_queue_.at(queue).emplace(
@@ -981,7 +981,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
 
   absl::flat_hash_map<VkCommandBuffer, CommandBufferState> command_buffer_to_state_;
 
-  static constexpr auto kPreSubmissionCPUTimestampComparator =
+  static constexpr auto kPreSubmissionCpuTimestampComparator =
       [](const QueueSubmission& lhs, const QueueSubmission& rhs) -> bool {
     return lhs.meta_information.pre_submission_cpu_timestamp >
            rhs.meta_information.pre_submission_cpu_timestamp;

--- a/src/OrbitVulkanLayer/SubmissionTrackerTest.cpp
+++ b/src/OrbitVulkanLayer/SubmissionTrackerTest.cpp
@@ -138,8 +138,8 @@ class SubmissionTrackerTest : public ::testing::Test {
   VkQueue queue_ = {};
   VkSubmitInfo submit_info_ = {.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
                                .pNext = nullptr,
-                               .pCommandBuffers = &command_buffer_,
-                               .commandBufferCount = 1};
+                               .commandBufferCount = 1,
+                               .pCommandBuffers = &command_buffer_};
 
   static constexpr uint32_t kSlotIndex1 = 32;
   static constexpr uint32_t kSlotIndex2 = 33;
@@ -577,10 +577,7 @@ TEST_F(SubmissionTrackerTest, WillRetryCompletingSubmissionsWhenTimestampQueryFa
 
   ExpectFourNextReadyQuerySlotCalls();
   EXPECT_CALL(dispatch_table_, GetQueryPoolResults)
-      // First two calls should succeed in PullCompletedSubmissions.
-      .WillOnce(Return(mock_get_query_pool_results_function_all_ready_))
-      .WillOnce(Return(mock_get_query_pool_results_function_all_ready_))
-      // Next two calls should succeed to complete the first submission.
+      // The first two calls should succeed to complete the first submission.
       .WillOnce(Return(mock_get_query_pool_results_function_all_ready_))
       .WillOnce(Return(mock_get_query_pool_results_function_all_ready_))
       // Fail on the second submission so that we retry on the second call.
@@ -622,12 +619,12 @@ TEST_F(SubmissionTrackerTest, WillRetryCompletingSubmissionsWhenTimestampQueryFa
 
   std::array<VkSubmitInfo, 2> submit_infos{VkSubmitInfo{.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
                                                         .pNext = nullptr,
-                                                        .pCommandBuffers = &command_buffers[0],
-                                                        .commandBufferCount = 1},
+                                                        .commandBufferCount = 1,
+                                                        .pCommandBuffers = &command_buffers[0]},
                                            VkSubmitInfo{.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO,
                                                         .pNext = nullptr,
-                                                        .pCommandBuffers = &command_buffers[1],
-                                                        .commandBufferCount = 1}};
+                                                        .commandBufferCount = 1,
+                                                        .pCommandBuffers = &command_buffers[1]}};
 
   pid_t tid = orbit_base::GetCurrentThreadId();
   pid_t pid = orbit_base::GetCurrentProcessId();


### PR DESCRIPTION
Prior to this change, `CompleteSubmits` (which gets called
on `vkQueuePresetKHR`) started by calling `PullCompletedSubmissions`,
which estimated which submissions were finished (by inspecting the
last command buffer in there). However, it could still be
that those submissions were not actually finished, so
we implemented a push back mechanism. Also, we needed to sort
the result every time in `PullCompletedSubmissions`.

This change simplifies this logic, by maintaining a priority
queue, sorted (inverse) by the cpu timestamps.
In `CompleteSubmits`, we now iterate over that queue (starting
by the oldest submission), and immediately stop as soon as
the first timestamp is not ready. This way the code is less
complex and also we don't query results twice.

Test: Run tests & take captures on Infiltrator/Trata