### PR TITLE
Fix ConnectToStadiaWidget scaling

### DIFF
--- a/src/OrbitQt/ConnectToStadiaWidget.cpp
+++ b/src/OrbitQt/ConnectToStadiaWidget.cpp
@@ -59,8 +59,6 @@ ConnectToStadiaWidget::ConnectToStadiaWidget(QWidget* parent)
   ui_->setupUi(this);
   ui_->instancesTableOverlay->raise();
 
-  DetachRadioButton();
-
   QSettings settings;
   if (settings.contains(kRememberChosenInstance)) {
     remembered_instance_id_ = settings.value(kRememberChosenInstance).toString();
@@ -145,6 +143,7 @@ void ConnectToStadiaWidget::DetachRadioButton() {
   ui_->mainFrame->layout()->getContentsMargins(&left, &top, nullptr, nullptr);
   int frame_border_width = ui_->mainFrame->lineWidth();
   ui_->radioButton->move(left + frame_border_width, top + frame_border_width);
+  ui_->radioButton->show();
 }
 
 void ConnectToStadiaWidget::SetupStateMachine() {
@@ -433,6 +432,11 @@ void ConnectToStadiaWidget::TrySelectRememberedInstance() {
   } else {
     ui_->rememberCheckBox->setChecked(false);
   }
+}
+
+void ConnectToStadiaWidget::showEvent(QShowEvent* event) {
+  QWidget::showEvent(event);
+  DetachRadioButton();
 }
 
 }  // namespace orbit_qt

--- a/src/OrbitQt/ConnectToStadiaWidget.h
+++ b/src/OrbitQt/ConnectToStadiaWidget.h
@@ -77,6 +77,7 @@ class ConnectToStadiaWidget : public QWidget {
   void InstanceReloadRequested();
 
  private:
+  void showEvent(QShowEvent* event) override;
   std::unique_ptr<Ui::ConnectToStadiaWidget> ui_;
   orbit_ggp::InstanceItemModel instance_model_;
   SshConnectionArtifacts* ssh_connection_artifacts_ = nullptr;

--- a/src/OrbitQt/ConnectToStadiaWidget.ui
+++ b/src/OrbitQt/ConnectToStadiaWidget.ui
@@ -66,18 +66,6 @@
              <property name="enabled">
               <bool>true</bool>
              </property>
-             <property name="minimumSize">
-              <size>
-               <width>280</width>
-               <height>23</height>
-              </size>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>23</height>
-              </size>
-             </property>
              <property name="font">
               <font>
                <pointsize>12</pointsize>
@@ -118,16 +106,10 @@
                <height>23</height>
               </size>
              </property>
-             <property name="maximumSize">
+             <property name="baseSize">
               <size>
                <width>23</width>
                <height>23</height>
-              </size>
-             </property>
-             <property name="baseSize">
-              <size>
-               <width>0</width>
-               <height>0</height>
               </size>
              </property>
              <property name="toolTip">


### PR DESCRIPTION
The label of the radiobutton of ConnectToStadiaWidget used to be cut off
in high dpi scaling modes. This change fixes that by detaching the
radiobutton right after the first draw instead of during construction.

To fix http://b/177500652

Before at 175% scaling:
![175% before](https://user-images.githubusercontent.com/7501835/110510635-b2d32880-8103-11eb-9e94-7573af7f57e1.PNG)


After at 175% scaling:
![175% after](https://user-images.githubusercontent.com/7501835/110510650-b5358280-8103-11eb-8ce3-6cde880dcf13.PNG)


Proof that no scaling still works:
![100%](https://user-images.githubusercontent.com/7501835/110510659-b6ff4600-8103-11eb-8d33-3a3c59626212.PNG)


Linux still looks normal
![linux](https://user-images.githubusercontent.com/7501835/110510685-bebeea80-8103-11eb-8ad1-6de9cfaa751d.png)

