### PR TITLE
Unify behaviour of Disassembly and source code view

### DIFF
--- a/src/CodeViewer/Viewer.cpp
+++ b/src/CodeViewer/Viewer.cpp
@@ -207,6 +207,8 @@ void Viewer::DrawSampleCounters(QPaintEvent* event) {
   painter.setFont(font());
   painter.fillRect(event->rect(), kLineNumberBackgroundColor);
 
+  if (code_report_ == nullptr) return;
+
   const auto top_of = [&](const QTextBlock& block) {
     return static_cast<int>(
         std::round(blockBoundingGeometry(block).translated(contentOffset()).top()));

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -139,13 +139,17 @@ void OpenDisassembly(const std::string& assembly, const DisassemblyReport& repor
   orbit_code_viewer::Dialog dialog{};
   dialog.setWindowTitle("Orbit Disassembly");
   dialog.SetEnableLineNumbers(true);
-  dialog.SetEnableSampleCounters(true);
+  dialog.SetHighlightCurrentLine(true);
 
   auto syntax_highlighter = std::make_unique<orbit_syntax_highlighter::X86Assembly>();
   dialog.SetSourceCode(QString::fromStdString(assembly), std::move(syntax_highlighter));
 
-  constexpr orbit_code_viewer::FontSizeInEm kHeatmapAreaWidth{1.3f};
-  dialog.SetHeatmap(kHeatmapAreaWidth, &report);
+  if (report.GetNumSamples() > 0) {
+    constexpr orbit_code_viewer::FontSizeInEm kHeatmapAreaWidth{1.3f};
+    dialog.SetHeatmap(kHeatmapAreaWidth, &report);
+    dialog.SetEnableSampleCounters(true);
+  }
+
   dialog.exec();
 }
 }  // namespace


### PR DESCRIPTION
- Current lines are now highlighted in both views
- The right sidebar is hidden when no capture was taken in both views

Furthermore there is a fix for a potential crash.