### PR TITLE
Rewrite of OrbitApp::UpdateProcessAndModuleList

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1116,30 +1116,6 @@ orbit_base::Future<ErrorMessageOr<std::filesystem::path>> OrbitApp::RetrieveModu
   return check_file_on_remote.Then(main_thread_executor_, std::move(download_file));
 }
 
-void OrbitApp::LoadModules(
-    const std::vector<ModuleData*>& modules,
-    absl::flat_hash_map<std::string, std::vector<uint64_t>> function_hashes_to_hook_map,
-    absl::flat_hash_map<std::string, std::vector<uint64_t>> frame_track_function_hashes_map) {
-  // This overload will be removed in a subsequent commit
-
-  for (const auto& module : modules) {
-    auto handle_hooks_and_frame_tracks =
-        [this, module, select_functions = function_hashes_to_hook_map[module->file_path()],
-         frame_tracks = frame_track_function_hashes_map[module->file_path()]](
-            const ErrorMessageOr<void>& result) {
-          if (result.has_error()) {
-            error_message_callback_("Error loading symbols", result.error().message());
-            return;
-          }
-
-          SelectFunctionsFromHashes(module, select_functions);
-          EnableFrameTracksFromHashes(module, frame_tracks);
-        };
-    RetrieveModuleAndLoadSymbols(module).Then(main_thread_executor_,
-                                              std::move(handle_hooks_and_frame_tracks));
-  }
-}
-
 orbit_base::Future<void> OrbitApp::RetrieveModulesAndLoadSymbols(
     absl::Span<const ModuleData* const> modules) {
   std::vector<orbit_base::Future<void>> futures;

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -345,7 +345,7 @@ void OrbitApp::PostInit(bool is_connected) {
     capture_client_ = std::make_unique<CaptureClient>(grpc_channel_, this);
 
     if (GetTargetProcess() != nullptr) {
-      UpdateProcessAndModuleList(GetTargetProcess()->pid());
+      UpdateProcessAndModuleList();
     }
 
     frame_pointer_validator_client_ =
@@ -1525,7 +1525,8 @@ void OrbitApp::LoadPreset(const std::shared_ptr<PresetFile>& preset_file) {
   });
 }
 
-void OrbitApp::UpdateProcessAndModuleList(int32_t pid) {
+void OrbitApp::UpdateProcessAndModuleList() {
+  const int32_t pid = GetTargetProcess()->pid();
   thread_pool_->Schedule([pid, this] {
     ErrorMessageOr<std::vector<ModuleInfo>> result = GetProcessManager()->LoadModuleList(pid);
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -314,6 +314,9 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
       const std::string& module_path, const std::string& build_id);
 
   void UpdateProcessAndModuleList();
+  orbit_base::Future<std::vector<ErrorMessageOr<void>>> ReloadModules(
+      absl::Span<const orbit_grpc_protos::ModuleInfo> module_infos);
+  void RefreshUIAfterModuleReload();
 
   void UpdateAfterSymbolLoading();
   void UpdateAfterCaptureCleared();

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -295,8 +295,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   orbit_base::Future<void> RetrieveModulesAndLoadSymbols(
       absl::Span<const ModuleData* const> modules);
 
-  // LoadModuleAndSymbols is a helper function which first retrieves the module by calling
-  // `LoadModule` and afterwards load the symbols by calling `LoadSymbols`.
+  // RetrieveModuleAndSymbols is a helper function which first retrieves the module by calling
+  // `RetrieveModule` and afterwards load the symbols by calling `LoadSymbols`.
   orbit_base::Future<ErrorMessageOr<void>> RetrieveModuleAndLoadSymbols(const ModuleData* module);
   orbit_base::Future<ErrorMessageOr<void>> RetrieveModuleAndLoadSymbols(
       const std::string& module_path, const std::string& build_id);

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -313,10 +313,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   orbit_base::Future<ErrorMessageOr<std::filesystem::path>> RetrieveModuleWithDebugInfo(
       const std::string& module_path, const std::string& build_id);
 
-  // TODO(177304549): This is still the way it is because of the old UI. Refactor: clean this up (it
-  // should not be necessary to have an argument here, since OrbitApp will always only have one
-  // process associated)
-  void UpdateProcessAndModuleList(int32_t pid);
+  void UpdateProcessAndModuleList();
 
   void UpdateAfterSymbolLoading();
   void UpdateAfterCaptureCleared();

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -286,11 +286,6 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void NeedsRedraw();
   void RenderImGuiDebugUI();
 
-  void LoadModules(
-      const std::vector<ModuleData*>& modules,
-      absl::flat_hash_map<std::string, std::vector<uint64_t>> function_hashes_to_hook_map,
-      absl::flat_hash_map<std::string, std::vector<uint64_t>> frame_track_function_hashes_map);
-
   // RetrieveModule retrieves a module file and returns the local file path (potentially from the
   // local cache). Only modules with a .symtab section will be considered.
   orbit_base::Future<ErrorMessageOr<std::filesystem::path>> RetrieveModule(

--- a/src/OrbitGl/ModulesDataView.cpp
+++ b/src/OrbitGl/ModulesDataView.cpp
@@ -214,7 +214,7 @@ void ModulesDataView::OnRefreshButtonClicked() {
     LOG("Unable to refresh module list, no process selected");
     return;
   }
-  app_->UpdateProcessAndModuleList(process->pid());
+  app_->UpdateProcessAndModuleList();
 }
 
 bool ModulesDataView::GetDisplayColor(int row, int /*column*/, unsigned char& red,


### PR DESCRIPTION
This is the last step from the symbol loading refactoring.

The method `OrbitApp::UpdateProcessAndModuleList` still used to use the old API
which is changed by this PR.

This also allows to delete some old overloads which are not needed anymore.

Test: Manual testing