### PR TITLE
Rename redraw / update methods, fix tooltips

### DIFF
--- a/contrib/automation_tests/test_cases/capture_window.py
+++ b/contrib/automation_tests/test_cases/capture_window.py
@@ -116,7 +116,8 @@ class MoveTrack(CaptureWindowE2ETestCaseBase):
         track.title.drag_mouse_input((mouse_x, new_y + 5))
 
         index = self._find_tracks().index(track.container)
-        self.expect_eq(index, expected_new_index % track_count, "Expected track index after reordering")
+        self.expect_eq(index, expected_new_index % track_count, "Expected track index %s after reordering, got %s" %
+                       (expected_new_index, index))
 
 
 class MatchTracks(CaptureWindowE2ETestCaseBase):

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -451,7 +451,7 @@ void OrbitApp::ListPresets() {
 
 void OrbitApp::RefreshCaptureView() {
   ORBIT_SCOPE_FUNCTION;
-  NeedsRedraw();
+  RequestUpdatePrimitives();
   FireRefreshCallbacks();
   DoZoom = true;  // TODO: remove global, review logic
 }
@@ -501,7 +501,7 @@ void OrbitApp::RenderImGuiDebugUI() {
   ImGui::End();
 
   ImGui::Render();
-  debug_canvas_->NeedsRedraw();
+  debug_canvas_->RequestRedraw();
 }
 
 void OrbitApp::Disassemble(int32_t pid, const FunctionInfo& function) {
@@ -594,7 +594,7 @@ void OrbitApp::MainTick() {
     // TODO (b/176077097): TrackManager has to manage sorting by their own.
     GetMutableTimeGraph()->GetTrackManager()->SortTracks();
     capture_window_->ZoomAll();
-    NeedsRedraw();
+    RequestUpdatePrimitives();
     DoZoom = false;
   }
 }
@@ -623,9 +623,9 @@ void OrbitApp::StopIntrospection() {
   }
 }
 
-void OrbitApp::NeedsRedraw() {
+void OrbitApp::RequestUpdatePrimitives() {
   if (capture_window_ != nullptr) {
-    capture_window_->NeedsUpdate();
+    capture_window_->RequestUpdatePrimitives();
   }
 }
 
@@ -1676,7 +1676,7 @@ const FunctionInfo* OrbitApp::GetInstrumentedFunction(uint64_t function_id) cons
 
 void OrbitApp::SetVisibleFunctionIds(absl::flat_hash_set<uint64_t> visible_function_ids) {
   data_manager_->set_visible_function_ids(std::move(visible_function_ids));
-  NeedsRedraw();
+  RequestUpdatePrimitives();
 }
 
 bool OrbitApp::IsFunctionVisible(uint64_t function_address) {
@@ -1704,7 +1704,7 @@ uint64_t OrbitApp::highlighted_function_id() const {
 
 void OrbitApp::set_highlighted_function_id(uint64_t highlighted_function_id) {
   data_manager_->set_highlighted_function_id(highlighted_function_id);
-  NeedsRedraw();
+  RequestUpdatePrimitives();
 }
 
 ThreadID OrbitApp::selected_thread_id() const { return data_manager_->selected_thread_id(); }

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -283,7 +283,6 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void SendInfoToUi(const std::string& title, const std::string& text);
   void SendWarningToUi(const std::string& title, const std::string& text);
   void SendErrorToUi(const std::string& title, const std::string& text);
-  void NeedsRedraw();
   void RenderImGuiDebugUI();
 
   // RetrieveModule retrieves a module file and returns the local file path (potentially from the
@@ -446,6 +445,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void OnCaptureFailed(ErrorMessage error_message);
   void OnCaptureCancelled();
   void OnCaptureComplete();
+
+  void RequestUpdatePrimitives();
 
   std::atomic<bool> capture_loading_cancellation_requested_ = false;
 

--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -31,12 +31,12 @@ void CaptureViewElement::OnPick(int x, int y) {
 
 void CaptureViewElement::OnRelease() {
   picked_ = false;
-  time_graph_->NeedsUpdate();
+  time_graph_->RequestUpdatePrimitives();
 }
 
 void CaptureViewElement::OnDrag(int x, int y) {
   canvas_->ScreenToWorld(x, y, mouse_pos_cur_[0], mouse_pos_cur_[1]);
-  time_graph_->NeedsUpdate();
+  time_graph_->RequestUpdatePrimitives();
 }
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/CaptureWindow.h
@@ -66,7 +66,7 @@ class CaptureWindow : public GlCanvas {
   void UpdateHorizontalSliderFromWorld();
   void UpdateWorldTopLeftY(float val) override;
 
-  void NeedsUpdate();
+  void RequestUpdatePrimitives();
   std::vector<std::string> GetContextMenu() override;
   void OnContextMenu(const std::string& action, int menu_index) override;
   virtual void ToggleRecording();

--- a/src/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/GlCanvas.h
@@ -127,8 +127,8 @@ class GlCanvas {
   [[nodiscard]] ImGuiContext* GetImGuiContext() const { return imgui_context_; }
   [[nodiscard]] Batcher* GetBatcher() { return &ui_batcher_; }
 
-  [[nodiscard]] virtual bool GetNeedsRedraw() const { return m_NeedsRedraw; }
-  void NeedsRedraw() { m_NeedsRedraw = true; }
+  [[nodiscard]] virtual bool IsRedrawNeeded() const;
+  void RequestRedraw() { redraw_requested_ = true; }
 
   [[nodiscard]] bool GetIsMouseOver() const { return is_mouse_over_; }
   void SetIsMouseOver(bool value) { is_mouse_over_ = value; }
@@ -207,7 +207,7 @@ class GlCanvas {
   bool double_clicking_;
   bool control_key_;
   bool is_mouse_over_ = false;
-  bool m_NeedsRedraw;
+  bool redraw_requested_;
   int m_MainWindowWidth = 0;
   int m_MainWindowHeight = 0;
 

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -45,7 +45,7 @@ class TimeGraph {
   void DrawOverlay(GlCanvas* canvas, PickingMode picking_mode);
   void DrawText(GlCanvas* canvas, float layer);
 
-  void NeedsUpdate();
+  void RequestUpdatePrimitives();
   void UpdatePrimitives(PickingMode picking_mode);
   void SelectCallstacks(float world_start, float world_end, int32_t thread_id);
   const std::vector<orbit_client_protos::CallstackEvent>& GetSelectedCallstackEvents(int32_t tid);
@@ -100,8 +100,8 @@ class TimeGraph {
   void SelectAndZoom(const TextBox* text_box);
   [[nodiscard]] double GetCaptureTimeSpanUs() const;
   [[nodiscard]] double GetCurrentTimeSpanUs() const;
-  void NeedsRedraw() { needs_redraw_ = true; }
-  [[nodiscard]] bool IsRedrawNeeded() const { return needs_redraw_; }
+  void RequestRedraw();
+  [[nodiscard]] bool IsRedrawNeeded() const { return redraw_requested_; }
   void SetThreadFilter(const std::string& filter);
 
   [[nodiscard]] bool IsFullyVisible(uint64_t min, uint64_t max) const;
@@ -153,7 +153,7 @@ class TimeGraph {
       const absl::flat_hash_map<uint64_t, uint64_t>& iterator_id_to_function_id) {
     iterator_text_boxes_ = iterator_text_boxes;
     iterator_id_to_function_id_ = iterator_id_to_function_id;
-    NeedsRedraw();
+    RequestRedraw();
   }
 
   void DrawIteratorBox(GlCanvas* canvas, Vec2 pos, Vec2 size, const Color& color,
@@ -205,14 +205,14 @@ class TimeGraph {
   TimeGraphAccessibility accessibility_;
 
   // Be careful when directly changing these members without using the
-  // methods NeedsRedraw() or NeedsUpdate():
-  // needs_update_primitives_ should always imply needs_redraw_, that is
-  // needs_update_primitives_ => needs_redraw_ is an invariant of this
+  // methods RequestRedraw() or RequestUpdatePrimitives():
+  // update_primitives_requested_ should always imply redraw_requested_, that is
+  // update_primitives_requested_ => redraw_requested_ is an invariant of this
   // class. When updating the primitives, which computes the primitives
   // to be drawn and their coordinates, we always have to redraw the
   // timeline.
-  bool needs_update_primitives_ = false;
-  bool needs_redraw_ = false;
+  bool update_primitives_requested_ = false;
+  bool redraw_requested_ = false;
 
   bool draw_text_ = true;
 

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -198,7 +198,9 @@ Color Track::GetBackgroundColor() const {
   return color_;
 }
 
-void Track::OnCollapseToggle(TriangleToggle::State /*state*/) { time_graph_->NeedsUpdate(); }
+void Track::OnCollapseToggle(TriangleToggle::State /*state*/) {
+  time_graph_->RequestUpdatePrimitives();
+}
 
 void Track::OnDrag(int x, int y) {
   CaptureViewElement::OnDrag(x, y);

--- a/src/OrbitQt/orbitglwidget.cpp
+++ b/src/OrbitQt/orbitglwidget.cpp
@@ -49,7 +49,7 @@ bool OrbitGLWidget::eventFilter(QObject* /*object*/, QEvent* event) {
   if (event->type() == QEvent::Paint) {
     if (gl_canvas_) {
       gl_canvas_->PreRender();
-      if (!gl_canvas_->GetNeedsRedraw()) {
+      if (!gl_canvas_->IsRedrawNeeded()) {
         return true;
       }
     }

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -786,7 +786,7 @@ void OrbitMainWindow::OnTimer() {
   app_->MainTick();
 
   for (OrbitGLWidget* gl_widget : gl_widgets_) {
-    if (gl_widget->GetCanvas() != nullptr && gl_widget->GetCanvas()->GetNeedsRedraw()) {
+    if (gl_widget->GetCanvas() != nullptr && gl_widget->GetCanvas()->IsRedrawNeeded()) {
       gl_widget->update();
     }
   }


### PR DESCRIPTION
This cleans up the naming around NeedsUpdate / NeedsRedraw, and changes
the logic of "GetNeedsUpdate()": This now not only returns True if
explicitely requested, but also if required implicitely (in the current
case: if mouse hover needs to be evaluated).

The update behavior did not work for tooltips before: The need to update
on mouse hover was determined in `PreRender`, but this was never called
due to the early out on `GetNeedsUpdate` in the main timer.

The main change lies in the the logic behind the new `IsRedrawNeeded`,
sorry for mixing the renaming in there.