### PR TITLE
Make zooming in Dialog's sidebars works as expected

### DIFF
--- a/src/CodeViewer/PlaceHolderWidget.cpp
+++ b/src/CodeViewer/PlaceHolderWidget.cpp
@@ -5,9 +5,12 @@
 #include "CodeViewer/PlaceHolderWidget.h"
 
 #include <QPaintEvent>
+#include <QWheelEvent>
 
 namespace orbit_code_viewer {
 
 void PlaceHolderWidget::paintEvent(QPaintEvent* event) { emit PaintEventTriggered(event); }
+
+void PlaceHolderWidget::wheelEvent(QWheelEvent* event) { emit WheelEventTriggered(event); }
 
 }  // namespace orbit_code_viewer

--- a/src/CodeViewer/Viewer.cpp
+++ b/src/CodeViewer/Viewer.cpp
@@ -48,12 +48,18 @@ Viewer::Viewer(QWidget* parent)
 
   QObject::connect(&top_bar_widget_, &PlaceHolderWidget::PaintEventTriggered, this,
                    &Viewer::DrawTopWidget);
+  QObject::connect(&top_bar_widget_, &PlaceHolderWidget::WheelEventTriggered, this,
+                   &Viewer::wheelEvent);
 
   QObject::connect(&left_sidebar_widget_, &PlaceHolderWidget::PaintEventTriggered, this,
                    &Viewer::DrawLineNumbers);
+  QObject::connect(&left_sidebar_widget_, &PlaceHolderWidget::WheelEventTriggered, this,
+                   &Viewer::wheelEvent);
 
   QObject::connect(&right_sidebar_widget_, &PlaceHolderWidget::PaintEventTriggered, this,
                    &Viewer::DrawSampleCounters);
+  QObject::connect(&right_sidebar_widget_, &PlaceHolderWidget::WheelEventTriggered, this,
+                   &Viewer::wheelEvent);
 
   const auto update_viewport_area = [&](const QRect& rect, int dy) {
     bool update_caused_by_scroll = (dy != 0);

--- a/src/CodeViewer/include/CodeViewer/PlaceHolderWidget.h
+++ b/src/CodeViewer/include/CodeViewer/PlaceHolderWidget.h
@@ -48,9 +48,11 @@ class PlaceHolderWidget : public QWidget {
   QSize size_hint_;
 
   void paintEvent(QPaintEvent* event) override;
+  void wheelEvent(QWheelEvent* ev) override;
 
  signals:
   void PaintEventTriggered(QPaintEvent* event);
+  void WheelEventTriggered(QWheelEvent* event);
 };
 
 }  // namespace orbit_code_viewer


### PR DESCRIPTION
Currently, we can't zoom-in/out in Code Source Dialog when your mouse
is on the sidebars. This is an issue if you zoom-in a lot because user
is not able to come back to the original zooming-level. Also it isn't
intuitive at all because sidebars seem to be part of the dialog, instead
of a margin.

This PR makes zooming in the sidebar works as expected.

[b/181838868](http://b/181838868)

Tested using CodeViewerDialog.