### PR TITLE
Fix Crashes on Misuse of Command Buffer Lifecycle.

### DIFF
--- a/src/OrbitVulkanLayer/SubmissionTracker.h
+++ b/src/OrbitVulkanLayer/SubmissionTracker.h
@@ -966,7 +966,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
       return;
     }
     CHECK(command_buffer_to_state_.contains(command_buffer));
-    CommandBufferState& state = command_buffer_to_state_.at(command_buffer);
+    const CommandBufferState& state = command_buffer_to_state_.at(command_buffer);
 
     for (const Marker& marker : state.markers) {
       std::optional<SubmittedMarker> submitted_marker = std::nullopt;

--- a/src/OrbitVulkanLayer/SubmissionTracker.h
+++ b/src/OrbitVulkanLayer/SubmissionTracker.h
@@ -986,9 +986,9 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
           }
           CHECK(marker.label_name.has_value());
           CHECK(marker.color.has_value());
-          MarkerState marker_state{.label_name = marker.label_name.value(),
+          MarkerState marker_state{.begin_info = submitted_marker,
+                                   .label_name = marker.label_name.value(),
                                    .color = marker.color.value(),
-                                   .begin_info = submitted_marker,
                                    .depth = markers->marker_stack.size(),
                                    .depth_exceeds_maximum = marker.cut_off};
           markers->marker_stack.push(std::move(marker_state));
@@ -1019,9 +1019,9 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
             queue_submission_optional->value().completed_markers.emplace_back(
                 SubmittedMarkerSlice{.begin_info = marker_state.begin_info,
                                      .end_info = submitted_marker.value(),
-                                     .depth = marker_state.depth,
+                                     .label_name = std::move(marker_state.label_name),
                                      .color = marker_state.color,
-                                     .label_name = std::move(marker_state.label_name)});
+                                     .depth = marker_state.depth});
           }
 
           break;

--- a/src/OrbitVulkanLayer/SubmissionTracker.h
+++ b/src/OrbitVulkanLayer/SubmissionTracker.h
@@ -213,7 +213,6 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
   }
 
   void MarkCommandBufferBegin(VkCommandBuffer command_buffer) {
-    LOG("Begin CB %p, tid: %d", command_buffer, orbit_base::GetCurrentThreadId());
     absl::WriterMutexLock lock(&mutex_);
     // Even when we are not capturing we create state for this command buffer to allow the
     // debug marker tracking. In order to compute the correct depth of a debug marker and being able

--- a/src/OrbitVulkanLayer/SubmissionTracker.h
+++ b/src/OrbitVulkanLayer/SubmissionTracker.h
@@ -375,9 +375,8 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
       for (uint32_t command_buffer_index = 0; command_buffer_index < submit_info.commandBufferCount;
            ++command_buffer_index) {
         VkCommandBuffer command_buffer = submit_info.pCommandBuffers[command_buffer_index];
-        PersistSingleCommandBufferOnSubmitUnsafe(device, command_buffer, &queue_submission,
-                                                 &submitted_submit_info,
-                                                 &query_slots_not_needed_to_read);
+        PersistSingleCommandBufferOnSubmit(device, command_buffer, &queue_submission,
+                                           &submitted_submit_info, &query_slots_not_needed_to_read);
       }
     }
 
@@ -433,7 +432,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
           CHECK(command_buffer_to_device_.contains(command_buffer));
           device = command_buffer_to_device_.at(command_buffer);
         }
-        PersistDebugMarkersOfASingleCommandBufferOnSubmitUnsafe(
+        PersistDebugMarkersOfASingleCommandBufferOnSubmit(
             command_buffer, &queue_submission_optional, &markers, &marker_slots_not_needed_to_read);
       }
     }

--- a/src/OrbitVulkanLayer/SubmissionTracker.h
+++ b/src/OrbitVulkanLayer/SubmissionTracker.h
@@ -250,10 +250,9 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
       return;
     }
     if (!command_buffer_to_state_.contains(command_buffer)) {
-      LogErrorOnce(
+      ERROR_ONCE(
           "Calling vkEndCommandBuffer on a command buffer that is in the initial state "
-          "(i.e. either freshly allocated or reset with vkResetCommandBuffer).",
-          &logged_end_when_initial_);
+          "(i.e. either freshly allocated or reset with vkResetCommandBuffer).");
       return;
     }
 
@@ -274,11 +273,10 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
     bool marker_depth_exceeds_maximum;
     {
       if (!command_buffer_to_state_.contains(command_buffer)) {
-        LogErrorOnce(
+        ERROR_ONCE(
             "Calling vkCmdDebugMarkerBeginEXT/vkCmdBeginDebugUtilsLabelEXT on a command buffer "
             "that is in the initial state (i.e. either freshly allocated or reset with "
-            "vkResetCommandBuffer).",
-            &logged_marker_begin_when_initial_);
+            "vkResetCommandBuffer).");
         return;
       }
       CHECK(command_buffer_to_state_.contains(command_buffer));
@@ -310,11 +308,10 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
     bool marker_depth_exceeds_maximum;
 
     if (!command_buffer_to_state_.contains(command_buffer)) {
-      LogErrorOnce(
+      ERROR_ONCE(
           "Calling vkCmdDebugMarkerEndEXT/vkCmdEndDebugUtilsLabelEXT on a command buffer "
           "that is in the initial state (i.e. either freshly allocated or reset with "
-          "vkResetCommandBuffer).",
-          &logged_marker_end_when_initial_);
+          "vkResetCommandBuffer).");
       return;
     }
     CHECK(command_buffer_to_state_.contains(command_buffer));
@@ -905,10 +902,9 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
     CHECK(query_slots_not_needed_to_read != nullptr);
 
     if (!command_buffer_to_state_.contains(command_buffer)) {
-      LogErrorOnce(
+      ERROR_ONCE(
           "Calling vkQueueSubmit on a command buffer that is in the initial state (i.e. "
-          "either freshly allocated or reset with vkResetCommandBuffer).",
-          &logged_submit_when_initial_);
+          "either freshly allocated or reset with vkResetCommandBuffer).");
       return;
     }
     CHECK(command_buffer_to_state_.contains(command_buffer));
@@ -962,10 +958,9 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
     CHECK(marker_slots_not_needed_to_read != nullptr);
 
     if (!command_buffer_to_state_.contains(command_buffer)) {
-      LogErrorOnce(
+      ERROR_ONCE(
           "Calling vkQueueSubmit on a command buffer that is in the initial state (i.e. "
-          "either freshly allocated or reset with vkResetCommandBuffer).",
-          &logged_submit_when_initial_);
+          "either freshly allocated or reset with vkResetCommandBuffer).");
       return;
     }
     CHECK(command_buffer_to_state_.contains(command_buffer));
@@ -1033,13 +1028,6 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
     }
   }
 
-  void LogErrorOnce(const std::string_view& error_string, bool* already_logged) {
-    if (!*already_logged) {
-      *already_logged = true;
-      ERROR("%s", error_string);
-    }
-  }
-
   absl::Mutex mutex_;
   absl::flat_hash_map<VkCommandPool, absl::flat_hash_set<VkCommandBuffer>> pool_to_command_buffers_;
   absl::flat_hash_map<VkCommandBuffer, VkDevice> command_buffer_to_device_;
@@ -1074,14 +1062,6 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
   // either in OnCaptureFinished or when completing submits. Note that calling
   // vulkan_layer_producer_->IsCapturing() is not a correct replacement for checking this boolean.
   bool is_capturing_ = false;
-
-  // The layer can handle some misuse of the Vulkan command buffer lifetime. The following bools
-  // are used to log errors on misuses only once and not spam the log.
-  bool logged_begin_when_not_initial_ = false;
-  bool logged_end_when_initial_ = false;
-  bool logged_marker_begin_when_initial_ = false;
-  bool logged_marker_end_when_initial_ = false;
-  bool logged_submit_when_initial_ = false;
 };
 
 }  // namespace orbit_vulkan_layer

--- a/src/OrbitVulkanLayer/SubmissionTracker.h
+++ b/src/OrbitVulkanLayer/SubmissionTracker.h
@@ -897,7 +897,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
                                           QueueSubmission* queue_submission,
                                           SubmitInfo* submitted_submit_info,
                                           std::vector<uint32_t>* query_slots_not_needed_to_read) {
-    mutex_.AssertReaderHeld();
+    mutex_.AssertHeld();
     CHECK(queue_submission != nullptr);
     CHECK(submitted_submit_info != nullptr);
     CHECK(query_slots_not_needed_to_read != nullptr);
@@ -954,7 +954,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
   void PersistDebugMarkersOfASingleCommandBufferOnSubmit(
       VkCommandBuffer command_buffer, std::optional<QueueSubmission>* queue_submission_optional,
       QueueMarkerState* markers, std::vector<uint32_t>* marker_slots_not_needed_to_read) {
-    mutex_.AssertReaderHeld();
+    mutex_.AssertHeld();
     CHECK(queue_submission_optional != nullptr);
     CHECK(markers != nullptr);
     CHECK(marker_slots_not_needed_to_read != nullptr);


### PR DESCRIPTION
We've seen some misuses of the command buffer lifecycle, such as
submit a command buffer right after reset.
This handles this gracefully, to not crash, but also not record
timestamps.

Further, this change will log the error message on misuses only once, to not spam the output.

Test: Run tests and Run on affected samples.
Bug: http://b/182282087.