### PR TITLE
Add LOG_ONCE and ERROR_ONCE macros.

### DIFF
--- a/src/OrbitBase/include/OrbitBase/Logging.h
+++ b/src/OrbitBase/include/OrbitBase/Logging.h
@@ -48,6 +48,17 @@ constexpr const char* kLogTimeFormat = "%Y-%m-%dT%H:%M:%E6S";
 
 #define ERROR(format, ...) LOG("Error: " format, ##__VA_ARGS__)
 
+#define LOG_ONCE(format, ...)           \
+  do {                                  \
+    static bool already_logged = false; \
+    if (!already_logged) {              \
+      already_logged = true;            \
+      LOG(format, ##__VA_ARGS__);       \
+    }                                   \
+  } while (0)
+
+#define ERROR_ONCE(format, ...) LOG_ONCE("Error: " format, ##__VA_ARGS__)
+
 #define FATAL(format, ...)                \
   do {                                    \
     LOG("Fatal: " format, ##__VA_ARGS__); \

--- a/src/OrbitBase/include/OrbitBase/Logging.h
+++ b/src/OrbitBase/include/OrbitBase/Logging.h
@@ -12,6 +12,7 @@
 
 #include <cstdio>
 #include <filesystem>
+#include <mutex>
 #include <string>
 
 #ifdef _WIN32
@@ -48,13 +49,10 @@ constexpr const char* kLogTimeFormat = "%Y-%m-%dT%H:%M:%E6S";
 
 #define ERROR(format, ...) LOG("Error: " format, ##__VA_ARGS__)
 
-#define LOG_ONCE(format, ...)           \
-  do {                                  \
-    static bool already_logged = false; \
-    if (!already_logged) {              \
-      already_logged = true;            \
-      LOG(format, ##__VA_ARGS__);       \
-    }                                   \
+#define LOG_ONCE(format, ...)                                                  \
+  do {                                                                         \
+    static std::once_flag already_logged_flag;                                 \
+    std::call_once(already_logged_flag, []() { LOG(format, ##__VA_ARGS__); }); \
   } while (0)
 
 #define ERROR_ONCE(format, ...) LOG_ONCE("Error: " format, ##__VA_ARGS__)

--- a/src/OrbitBase/include/OrbitBase/Logging.h
+++ b/src/OrbitBase/include/OrbitBase/Logging.h
@@ -49,10 +49,10 @@ constexpr const char* kLogTimeFormat = "%Y-%m-%dT%H:%M:%E6S";
 
 #define ERROR(format, ...) LOG("Error: " format, ##__VA_ARGS__)
 
-#define LOG_ONCE(format, ...)                                                  \
-  do {                                                                         \
-    static std::once_flag already_logged_flag;                                 \
-    std::call_once(already_logged_flag, []() { LOG(format, ##__VA_ARGS__); }); \
+#define LOG_ONCE(format, ...)                                                   \
+  do {                                                                          \
+    static std::once_flag already_logged_flag;                                  \
+    std::call_once(already_logged_flag, [&]() { LOG(format, ##__VA_ARGS__); }); \
   } while (0)
 
 #define ERROR_ONCE(format, ...) LOG_ONCE("Error: " format, ##__VA_ARGS__)

--- a/src/OrbitVulkanLayer/SubmissionTracker.h
+++ b/src/OrbitVulkanLayer/SubmissionTracker.h
@@ -221,7 +221,8 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
     // other than the debug markers then.
     {
       if (command_buffer_to_state_.contains(command_buffer)) {
-        ERROR("Calling vkBeginCommandBuffer on a command buffer that is not in the initial state.");
+        ERROR_ONCE(
+            "Calling vkBeginCommandBuffer on a command buffer that is not in the initial state.");
         // We end up in this case, if we have used the command buffer before and want to write new
         // commands to it without resetting the command buffer. This is prohibited by the
         // specification. However, we've seen this in the wild. The "vkBeginCommandBuffer" will,


### PR DESCRIPTION
This only logs once on each Macro definition.

```
LOG_ONCE("FOO");
LOG_ONCE("FOO");
```
Will print "FOO" twice.

Test: Manually insert the Macro and check the output.