### PR TITLE
Add Vulkan headers to conan dependencies.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,6 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 option(WITH_GUI "Setting this option will enable the Qt-based UI client." ON)
 option(WITH_CRASH_HANDLING "Setting this option will enable crash handling based on crashpad." ON)
-option(WITH_VULKAN_LAYER "Setting this option will enable the Vulkan layer for advanced GPU information." OFF)
 
 set(CRASHDUMP_SERVER "" CACHE STRING "Setting this option will enable uploading crash dumps to the url specified.")
 
@@ -107,8 +106,7 @@ endif()
 
 find_package(Filesystem REQUIRED)
 
-if(NOT WIN32 AND WITH_VULKAN_LAYER)
-  find_package(Vulkan REQUIRED)
+if(NOT WIN32)
   find_package(VulkanValidationLayers REQUIRED)
 endif()
 
@@ -135,14 +133,11 @@ else()
   add_subdirectory(src/OrbitCaptureGgpClient)
   add_subdirectory(src/OrbitCaptureGgpService)
   add_subdirectory(src/OrbitProducer)
+  add_subdirectory(src/OrbitTriggerCaptureVulkanLayer)
+  add_subdirectory(src/OrbitVulkanLayer)
   add_subdirectory(src/ProducerSideChannel)
   add_subdirectory(src/Service)
   add_subdirectory(src/UserSpaceInstrumentation)
-endif()
-
-if(WITH_VULKAN_LAYER)
-  add_subdirectory(src/OrbitTriggerCaptureVulkanLayer)
-  add_subdirectory(src/OrbitVulkanLayer)
 endif()
 
 add_subdirectory(src/CaptureFile)

--- a/bootstrap-orbit.ps1
+++ b/bootstrap-orbit.ps1
@@ -18,7 +18,7 @@ it available in the path.
 "@
   }
 
-  & $pip3.Path install conan==1.29.2
+  & $pip3.Path install conan==1.32.0
   if ($LastExitCode -ne 0) {
     Throw "Error while installing conan via pip3."
   }
@@ -40,14 +40,14 @@ You can call 'pip3 show -f conan' to figure out where conan.exe was placed.
   $conan_version_minor = $conan_version.split(".")[1] -as [int]
 
   $conan_version_major_required = 1
-  $conan_version_minor_min = 29
+  $conan_version_minor_min = 32
 
   if ($conan_version_major -eq $conan_version_major_required -and $conan_version_minor -lt $conan_version_minor_min) {
     Write-Host "Your conan version $conan_version is too old. Let's try to update it."
 
     Try {
       $pip3 = Get-Command pip3
-      & $pip3.Path install --upgrade conan==1.29.2
+      & $pip3.Path install --upgrade conan==1.32.0
     } Catch {
       Throw "Error while upgrading conan via pip3. Probably you have conan installed differently." + 
             " Please manually update conan to a at least version $conan_version_major_required.$conan_version_minor_min."

--- a/bootstrap-orbit.sh
+++ b/bootstrap-orbit.sh
@@ -26,8 +26,7 @@ done
 readonly REQUIRED_PACKAGES=( build-essential libglu1-mesa-dev mesa-common-dev \
                              libxmu-dev libxi-dev libopengl0 qtbase5-dev \
                              qtwebengine5-dev libqt5webchannel5-dev \
-                             libqt5websockets5-dev libxxf86vm-dev python3-pip \
-                             libvulkan-dev vulkan-validationlayers-dev )
+                             libqt5websockets5-dev libxxf86vm-dev python3-pip )
 
 function add_ubuntu_universe_repo {
   sudo add-apt-repository universe
@@ -80,7 +79,7 @@ echo "Checking if conan is available..."
 which conan >/dev/null
 if [ $? -ne 0 ]; then
   echo "Couldn't find conan. Trying to install via pip..."
-  pip3 install --user conan==1.29.2 || exit $?
+  pip3 install --user conan==1.32.0 || exit $?
 
   which conan >/dev/null
   if [ $? -ne 0 ]; then
@@ -100,11 +99,11 @@ else
   CONAN_VERSION_MINOR="$(echo "$CONAN_VERSION" | cut -d'.' -f2)"
 
   CONAN_VERSION_MAJOR_REQUIRED=1
-  CONAN_VERSION_MINOR_MIN=29
+  CONAN_VERSION_MINOR_MIN=32
 
   if [ "$CONAN_VERSION_MAJOR" -eq $CONAN_VERSION_MAJOR_REQUIRED -a "$CONAN_VERSION_MINOR" -lt $CONAN_VERSION_MINOR_MIN ]; then
     echo "Your conan version $CONAN_VERSION is too old. I will try to update..."
-    pip3 install --upgrade --user conan==1.29.2
+    pip3 install --upgrade --user conan==1.32.0
     if [ $? -ne 0 ]; then
       echo "The upgrade of your conan installation failed. Probably because conan was not installed by this script."
       echo "Please manually update conan to at least version $CONAN_VERSION_MAJOR_REQUIRED.$CONAN_VERSION_MINOR_MIN."

--- a/cmake/FindVulkanValidationLayers.cmake
+++ b/cmake/FindVulkanValidationLayers.cmake
@@ -2,21 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-find_path(VulkanValidationLayers_INCLUDE_DIR
-  NAMES vk_layer_dispatch_table.h 
-  PATH_SUFFIXES vulkan/
-  HINTS "$ENV{VULKAN_SDK}/include")
-
-set(VulkanValidationLayers_INCLUDE_DIRS ${VulkanValidationLayers_INCLUDE_DIR})
-
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(VulkanValidationLayers DEFAULT_MSG VulkanValidationLayers_INCLUDE_DIR)
-
-mark_as_advanced(VulkanValidationLayers_INCLUDE_DIR)
-
-if(VulkanValidationLayers_FOUND AND NOT TARGET Vulkan::ValidationLayers)
-  add_library(Vulkan::ValidationLayers INTERFACE IMPORTED)
-  set_target_properties(Vulkan::ValidationLayers PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${VulkanValidationLayers_INCLUDE_DIRS}")
-  target_link_libraries(Vulkan::ValidationLayers INTERFACE Vulkan::Vulkan)
-endif()
+add_library(Vulkan::ValidationLayers INTERFACE IMPORTED GLOBAL)
+target_include_directories(Vulkan::ValidationLayers SYSTEM
+                           INTERFACE third_party/vulkan)
+target_link_libraries(Vulkan::ValidationLayers INTERFACE CONAN_PKG::vulkan-headers)

--- a/conanfile.py
+++ b/conanfile.py
@@ -31,7 +31,6 @@ class OrbitConan(ConanFile):
                "with_crash_handling": [True, False],
                "run_tests": [True, False],
                "run_python_tests": [True, False],
-               "with_vulkan_layer": [True, False],
                "build_target": "ANY"}
     default_options = {"system_mesa": True,
                        "system_qt": True, "with_gui": True,
@@ -39,7 +38,6 @@ class OrbitConan(ConanFile):
                        "fPIC": True,
                        "crashdump_server": "",
                        "with_crash_handling": True,
-                       "with_vulkan_layer": False,
                        "run_tests": True,
                        "run_python_tests": False,
                        "build_target": None}
@@ -91,6 +89,7 @@ class OrbitConan(ConanFile):
         if self.settings.os != "Windows":
             self.requires(
                 "libunwindstack/80a734f14@{}#0".format(self._orbit_channel))
+            self.requires("vulkan-headers/1.1.114.0")
         self.requires("zlib/1.2.11#9e0c292b60ce77402bd9be60dd68266f")
 
         if self.options.with_gui and self.options.with_crash_handling:
@@ -152,7 +151,6 @@ class OrbitConan(ConanFile):
     def build(self):
         cmake = CMake(self)
         cmake.definitions["WITH_GUI"] = "ON" if self.options.with_gui else "OFF"
-        cmake.definitions["WITH_VULKAN_LAYER"] = "ON" if self.options.with_vulkan_layer else "OFF"
         if self.options.with_gui:
             if self.options.with_crash_handling:
                 cmake.definitions["WITH_CRASH_HANDLING"] = "ON"

--- a/kokoro/builds/build.sh
+++ b/kokoro/builds/build.sh
@@ -112,7 +112,7 @@ if [ -n "$1" ]; then
   # That's a temporary solution. The docker containers should have the
   # correct version of conan already preinstalled. This step will be removed
   # when the docker containers are restructured and versioned.
-  pip3 install conan==1.29.2
+  pip3 install conan==1.32.0
 
   echo "Installing conan configuration (profiles, settings, etc.)..."
   ${REPO_ROOT}/third_party/conan/configs/install.sh

--- a/src/OrbitTriggerCaptureVulkanLayer/CMakeLists.txt
+++ b/src/OrbitTriggerCaptureVulkanLayer/CMakeLists.txt
@@ -20,10 +20,10 @@ target_sources(OrbitTriggerCaptureVulkanLayer PRIVATE
         OrbitCaptureClientLayer.cpp)
 
 target_link_libraries(OrbitTriggerCaptureVulkanLayer PUBLIC
+        CONAN_PKG::vulkan-headers
         OrbitBase
         OrbitCaptureGgpClientLib
         OrbitTriggerCaptureVulkanLayerProtos
-        Vulkan::Vulkan
         Vulkan::ValidationLayers)
 
 project(OrbitTriggerCaptureVulkanLayerProtos)

--- a/src/OrbitVulkanLayer/CMakeLists.txt
+++ b/src/OrbitVulkanLayer/CMakeLists.txt
@@ -3,21 +3,15 @@
 # found in the LICENSE file.
 
 project(OrbitVulkanLayer)
-add_library(OrbitVulkanLayer SHARED)
 
-target_compile_options(OrbitVulkanLayer PRIVATE ${STRICT_COMPILE_FLAGS})
+add_library(OrbitVulkanLayerInterface STATIC)
 
-target_include_directories(OrbitVulkanLayer PUBLIC
-        ${CMAKE_CURRENT_LIST_DIR}/include)
+target_compile_options(OrbitVulkanLayerInterface PRIVATE ${STRICT_COMPILE_FLAGS})
 
-target_include_directories(OrbitVulkanLayer PRIVATE
-        ${CMAKE_CURRENT_LIST_DIR})
-
-target_sources(OrbitVulkanLayer PRIVATE
+target_sources(OrbitVulkanLayerInterface PRIVATE
         DeviceManager.h
         DispatchTable.cpp
         DispatchTable.h
-        EntryPoints.cpp
         QueueManager.cpp
         QueueManager.h
         SubmissionTracker.h
@@ -28,18 +22,27 @@ target_sources(OrbitVulkanLayer PRIVATE
         VulkanLayerProducerImpl.h
         VulkanWrapper.h)
 
-add_custom_command(TARGET OrbitVulkanLayer POST_BUILD COMMAND ${CMAKE_COMMAND}
-                   -E copy ${CMAKE_CURRENT_SOURCE_DIR}/resources/VkLayer_Orbit_implicit.json
-                   $<TARGET_FILE_DIR:OrbitVulkanLayer>/VkLayer_Orbit_implicit.json)
-
-target_link_libraries(OrbitVulkanLayer PUBLIC
+target_link_libraries(OrbitVulkanLayerInterface PUBLIC
+        CONAN_PKG::vulkan-headers
         GrpcProtos
         OrbitBase
         OrbitProducer
         ProducerSideChannel
-        Vulkan::Vulkan
         Vulkan::ValidationLayers)
 
+add_library(OrbitVulkanLayer SHARED)
+
+target_compile_options(OrbitVulkanLayer PRIVATE ${STRICT_COMPILE_FLAGS})
+
+target_sources(OrbitVulkanLayer PRIVATE
+        EntryPoints.cpp)
+
+add_custom_command(TARGET OrbitVulkanLayer POST_BUILD COMMAND ${CMAKE_COMMAND}
+                   -E copy ${CMAKE_CURRENT_SOURCE_DIR}/resources/VkLayer_Orbit_implicit.json
+                   $<TARGET_FILE_DIR:OrbitVulkanLayer>/VkLayer_Orbit_implicit.json)
+
+target_link_libraries(OrbitVulkanLayer PRIVATE
+        OrbitVulkanLayerInterface)
 
 strip_symbols(OrbitVulkanLayer)
 
@@ -58,7 +61,7 @@ target_sources(OrbitVulkanLayerTests PRIVATE
 
 target_link_libraries(
         OrbitVulkanLayerTests PRIVATE
-        OrbitVulkanLayer
+        OrbitVulkanLayerInterface
         GTest::Main)
 
 register_test(OrbitVulkanLayerTests)

--- a/src/OrbitVulkanLayer/DeviceManager.h
+++ b/src/OrbitVulkanLayer/DeviceManager.h
@@ -5,11 +5,12 @@
 #ifndef ORBIT_VULKAN_LAYER_DEVICE_MANAGER_H_
 #define ORBIT_VULKAN_LAYER_DEVICE_MANAGER_H_
 
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
+#include <absl/synchronization/mutex.h>
+#include <vulkan/vulkan.h>
+
 #include "OrbitBase/Logging.h"
-#include "absl/container/flat_hash_map.h"
-#include "absl/container/flat_hash_set.h"
-#include "absl/synchronization/mutex.h"
-#include "vulkan/vulkan.h"
 
 namespace orbit_vulkan_layer {
 

--- a/src/OrbitVulkanLayer/DeviceManagerTest.cpp
+++ b/src/OrbitVulkanLayer/DeviceManagerTest.cpp
@@ -2,9 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
 #include "DeviceManager.h"
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 
 using ::testing::Return;
 

--- a/src/OrbitVulkanLayer/DispatchTable.h
+++ b/src/OrbitVulkanLayer/DispatchTable.h
@@ -5,15 +5,16 @@
 #ifndef ORBIT_VULKAN_LAYER_DISPATCH_TABLE_H_
 #define ORBIT_VULKAN_LAYER_DISPATCH_TABLE_H_
 
+#include <absl/base/casts.h>
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
+#include <absl/synchronization/mutex.h>
+
 #include "OrbitBase/Logging.h"
-#include "absl/base/casts.h"
-#include "absl/container/flat_hash_map.h"
-#include "absl/container/flat_hash_set.h"
-#include "absl/synchronization/mutex.h"
 
 // clang-format off
-#include "vulkan/vulkan.h" // IWYU pragma: keep
-#include "vk_layer_dispatch_table.h" // IWYU pragma: keep
+#include <vulkan/vulkan.h> // IWYU pragma: keep
+#include <vk_layer_dispatch_table.h> // IWYU pragma: keep
 // clang-format on
 
 namespace orbit_vulkan_layer {

--- a/src/OrbitVulkanLayer/DispatchTableTest.cpp
+++ b/src/OrbitVulkanLayer/DispatchTableTest.cpp
@@ -2,8 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <gtest/gtest.h>
+
 #include "DispatchTable.h"
-#include "gtest/gtest.h"
 
 namespace orbit_vulkan_layer {
 

--- a/src/OrbitVulkanLayer/EntryPoints.cpp
+++ b/src/OrbitVulkanLayer/EntryPoints.cpp
@@ -2,6 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <absl/base/casts.h>
+#include <vulkan/vk_layer.h>
+#include <vulkan/vulkan.h>
+
 #include "DeviceManager.h"
 #include "DispatchTable.h"
 #include "QueueManager.h"
@@ -9,9 +13,6 @@
 #include "TimerQueryPool.h"
 #include "VulkanLayerController.h"
 #include "VulkanWrapper.h"
-#include "absl/base/casts.h"
-#include "vulkan/vk_layer.h"
-#include "vulkan/vulkan.h"
 
 /*
  * The big picture:

--- a/src/OrbitVulkanLayer/QueueManager.h
+++ b/src/OrbitVulkanLayer/QueueManager.h
@@ -5,9 +5,9 @@
 #ifndef ORBIT_VULKAN_LAYER_QUEUE_MANAGER_H_
 #define ORBIT_VULKAN_LAYER_QUEUE_MANAGER_H_
 
-#include "absl/container/flat_hash_map.h"
-#include "absl/synchronization/mutex.h"
-#include "vulkan/vulkan.h"
+#include <absl/container/flat_hash_map.h>
+#include <absl/synchronization/mutex.h>
+#include <vulkan/vulkan.h>
 
 namespace orbit_vulkan_layer {
 

--- a/src/OrbitVulkanLayer/QueueManagerTest.cpp
+++ b/src/OrbitVulkanLayer/QueueManagerTest.cpp
@@ -2,8 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <gtest/gtest.h>
+
 #include "QueueManager.h"
-#include "gtest/gtest.h"
 
 namespace orbit_vulkan_layer {
 

--- a/src/OrbitVulkanLayer/SubmissionTracker.h
+++ b/src/OrbitVulkanLayer/SubmissionTracker.h
@@ -5,6 +5,11 @@
 #ifndef ORBIT_VULKAN_LAYER_SUBMISSION_TRACKER_H_
 #define ORBIT_VULKAN_LAYER_SUBMISSION_TRACKER_H_
 
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
+#include <absl/synchronization/mutex.h>
+#include <vulkan/vulkan.h>
+
 #include <functional>
 #include <queue>
 #include <stack>
@@ -13,10 +18,6 @@
 #include "OrbitBase/Profiling.h"
 #include "OrbitBase/ThreadUtils.h"
 #include "VulkanLayerProducer.h"
-#include "absl/container/flat_hash_map.h"
-#include "absl/container/flat_hash_set.h"
-#include "absl/synchronization/mutex.h"
-#include "vulkan/vulkan.h"
 
 namespace orbit_vulkan_layer {
 

--- a/src/OrbitVulkanLayer/SubmissionTracker.h
+++ b/src/OrbitVulkanLayer/SubmissionTracker.h
@@ -476,9 +476,9 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
               }
               CHECK(marker.label_name.has_value());
               CHECK(marker.color.has_value());
-              MarkerState marker_state{.label_name = marker.label_name.value(),
+              MarkerState marker_state{.begin_info = submitted_marker,
+                                       .label_name = marker.label_name.value(),
                                        .color = marker.color.value(),
-                                       .begin_info = submitted_marker,
                                        .depth = markers.marker_stack.size(),
                                        .depth_exceeds_maximum = marker.cut_off};
               markers.marker_stack.push(std::move(marker_state));
@@ -505,13 +505,13 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
 
               if (queue_submission_optional.has_value() && marker.slot_index.has_value() &&
                   !marker_state.depth_exceeds_maximum) {
-                CHECK(submitted_marker.has_value());
                 queue_submission_optional->completed_markers.emplace_back(
                     SubmittedMarkerSlice{.begin_info = marker_state.begin_info,
                                          .end_info = submitted_marker.value(),
-                                         .depth = marker_state.depth,
+                                         .label_name = std::move(marker_state.label_name),
                                          .color = marker_state.color,
-                                         .label_name = std::move(marker_state.label_name)});
+                                         .depth = marker_state.depth});
+                CHECK(submitted_marker.has_value());
               }
 
               break;

--- a/src/OrbitVulkanLayer/SubmissionTrackerTest.cpp
+++ b/src/OrbitVulkanLayer/SubmissionTrackerTest.cpp
@@ -2,14 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <absl/base/casts.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
 #include <array>
 
 #include "OrbitBase/ThreadUtils.h"
 #include "SubmissionTracker.h"
 #include "VulkanLayerProducer.h"
-#include "absl/base/casts.h"
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 
 using ::testing::ElementsAre;
 using ::testing::Invoke;

--- a/src/OrbitVulkanLayer/TimerQueryPool.h
+++ b/src/OrbitVulkanLayer/TimerQueryPool.h
@@ -5,16 +5,17 @@
 #ifndef ORBIT_VULKAN_LAYER_TIMER_QUERY_POOL_H_
 #define ORBIT_VULKAN_LAYER_TIMER_QUERY_POOL_H_
 
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
+#include <absl/synchronization/mutex.h>
+#include <vulkan/vulkan.h>
+
 #include <fstream>
 #include <numeric>
 #include <vector>
 
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Profiling.h"
-#include "absl/container/flat_hash_map.h"
-#include "absl/container/flat_hash_set.h"
-#include "absl/synchronization/mutex.h"
-#include "vulkan/vulkan.h"
 
 namespace orbit_vulkan_layer {
 

--- a/src/OrbitVulkanLayer/TimerQueryPoolTest.cpp
+++ b/src/OrbitVulkanLayer/TimerQueryPoolTest.cpp
@@ -2,10 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <absl/container/flat_hash_set.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
 #include "TimerQueryPool.h"
-#include "absl/container/flat_hash_set.h"
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 
 using ::testing::Return;
 

--- a/src/OrbitVulkanLayer/VulkanLayerController.h
+++ b/src/OrbitVulkanLayer/VulkanLayerController.h
@@ -41,14 +41,11 @@ class VulkanLayerController {
   static constexpr uint32_t kLayerSpecVersion = VK_API_VERSION_1_1;
 
   static constexpr std::array<VkExtensionProperties, 1> kImplementedDeviceExtensions = {
-      VkExtensionProperties{.extensionName = VK_EXT_DEBUG_MARKER_EXTENSION_NAME,
-                            .specVersion = VK_EXT_DEBUG_MARKER_SPEC_VERSION}};
+      VkExtensionProperties{VK_EXT_DEBUG_MARKER_EXTENSION_NAME, VK_EXT_DEBUG_MARKER_SPEC_VERSION}};
 
   static constexpr std::array<VkExtensionProperties, 2> kImplementedInstanceExtensions = {
-      VkExtensionProperties{.extensionName = VK_EXT_DEBUG_UTILS_EXTENSION_NAME,
-                            .specVersion = VK_EXT_DEBUG_UTILS_SPEC_VERSION},
-      VkExtensionProperties{.extensionName = VK_EXT_DEBUG_REPORT_EXTENSION_NAME,
-                            .specVersion = VK_EXT_DEBUG_REPORT_SPEC_VERSION}};
+      VkExtensionProperties{VK_EXT_DEBUG_UTILS_EXTENSION_NAME, VK_EXT_DEBUG_UTILS_SPEC_VERSION},
+      VkExtensionProperties{VK_EXT_DEBUG_REPORT_EXTENSION_NAME, VK_EXT_DEBUG_REPORT_SPEC_VERSION}};
 
   VulkanLayerController()
       : device_manager_(&dispatch_table_),

--- a/src/OrbitVulkanLayer/VulkanLayerController.h
+++ b/src/OrbitVulkanLayer/VulkanLayerController.h
@@ -5,12 +5,13 @@
 #ifndef ORBIT_VULKAN_LAYER_VULKAN_LAYER_CONTROLLER_H_
 #define ORBIT_VULKAN_LAYER_VULKAN_LAYER_CONTROLLER_H_
 
+#include <absl/base/casts.h>
+#include <vulkan/vk_layer.h>
+#include <vulkan/vulkan.h>
+
 #include "OrbitBase/Logging.h"
 #include "ProducerSideChannel/ProducerSideChannel.h"
 #include "VulkanLayerProducerImpl.h"
-#include "absl/base/casts.h"
-#include "vulkan/vk_layer.h"
-#include "vulkan/vulkan.h"
 
 namespace orbit_vulkan_layer {
 

--- a/src/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
+++ b/src/OrbitVulkanLayer/VulkanLayerControllerTest.cpp
@@ -2,12 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 #include <vulkan/vk_layer.h>
 
 #include "VulkanLayerController.h"
 #include "VulkanLayerProducer.h"
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 
 using ::testing::A;
 using ::testing::AllOf;

--- a/src/OrbitVulkanLayer/VulkanLayerProducer.h
+++ b/src/OrbitVulkanLayer/VulkanLayerProducer.h
@@ -5,8 +5,9 @@
 #ifndef ORBIT_VULKAN_LAYER_VULKAN_LAYER_PRODUCER_H_
 #define ORBIT_VULKAN_LAYER_VULKAN_LAYER_PRODUCER_H_
 
+#include <grpcpp/grpcpp.h>
+
 #include "capture.pb.h"
-#include "grpcpp/grpcpp.h"
 
 namespace orbit_vulkan_layer {
 

--- a/src/OrbitVulkanLayer/VulkanLayerProducerImpl.h
+++ b/src/OrbitVulkanLayer/VulkanLayerProducerImpl.h
@@ -5,11 +5,11 @@
 #ifndef ORBIT_VULKAN_LAYER_VULKAN_LAYER_PRODUCER_IMPL_H_
 #define ORBIT_VULKAN_LAYER_VULKAN_LAYER_PRODUCER_IMPL_H_
 
+#include <absl/container/flat_hash_set.h>
 #include <google/protobuf/arena.h>
 
 #include "OrbitProducer/LockFreeBufferCaptureEventProducer.h"
 #include "VulkanLayerProducer.h"
-#include "absl/container/flat_hash_set.h"
 
 namespace orbit_vulkan_layer {
 

--- a/src/OrbitVulkanLayer/VulkanWrapper.h
+++ b/src/OrbitVulkanLayer/VulkanWrapper.h
@@ -5,7 +5,7 @@
 #ifndef ORBIT_VULKAN_LAYER_VULKAN_WRAPPER_H_
 #define ORBIT_VULKAN_LAYER_VULKAN_WRAPPER_H_
 
-#include "vulkan/vulkan.h"
+#include <vulkan/vulkan.h>
 
 namespace orbit_vulkan_layer {
 

--- a/third_party/conan/configs/linux/profiles/ggp_debug
+++ b/third_party/conan/configs/linux/profiles/ggp_debug
@@ -13,7 +13,6 @@ abseil:compiler=clang
 abseil:compiler.cppstd=17
 [options]
 OrbitProfiler:with_gui=False
-OrbitProfiler:with_vulkan_layer=True
 [build_requires]
 &: cmake_installer/3.16.3@conan/stable
 ggp_sdk/1.43.0.14282@orbitdeps/stable

--- a/third_party/conan/configs/linux/profiles/ggp_release
+++ b/third_party/conan/configs/linux/profiles/ggp_release
@@ -13,7 +13,6 @@ abseil:compiler=clang
 abseil:compiler.cppstd=17
 [options]
 OrbitProfiler:with_gui=False
-OrbitProfiler:with_vulkan_layer=True
 [build_requires]
 &: cmake_installer/3.16.3@conan/stable
 ggp_sdk/1.43.0.14282@orbitdeps/stable

--- a/third_party/conan/configs/linux/profiles/ggp_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/ggp_relwithdebinfo
@@ -13,7 +13,6 @@ abseil:compiler=clang
 abseil:compiler.cppstd=17
 [options]
 OrbitProfiler:with_gui=False
-OrbitProfiler:with_vulkan_layer=True
 [build_requires]
 &: cmake_installer/3.16.3@conan/stable
 ggp_sdk/1.43.0.14282@orbitdeps/stable

--- a/third_party/conan/configs/windows/profiles/ggp_debug
+++ b/third_party/conan/configs/windows/profiles/ggp_debug
@@ -16,7 +16,6 @@ abseil:compiler=clang
 abseil:compiler.cppstd=17
 [options]
 OrbitProfiler:with_gui=False
-OrbitProfiler:with_vulkan_layer=True
 [build_requires]
 &: cmake_installer/3.16.3@conan/stable
 ggp_sdk/1.43.0.14282@orbitdeps/stable

--- a/third_party/conan/configs/windows/profiles/ggp_release
+++ b/third_party/conan/configs/windows/profiles/ggp_release
@@ -16,7 +16,6 @@ abseil:compiler=clang
 abseil:compiler.cppstd=17
 [options]
 OrbitProfiler:with_gui=False
-OrbitProfiler:with_vulkan_layer=True
 [build_requires]
 &: cmake_installer/3.16.3@conan/stable
 ggp_sdk/1.43.0.14282@orbitdeps/stable

--- a/third_party/conan/configs/windows/profiles/ggp_relwithdebinfo
+++ b/third_party/conan/configs/windows/profiles/ggp_relwithdebinfo
@@ -16,7 +16,6 @@ abseil:compiler=clang
 abseil:compiler.cppstd=17
 [options]
 OrbitProfiler:with_gui=False
-OrbitProfiler:with_vulkan_layer=True
 [build_requires]
 &: cmake_installer/3.16.3@conan/stable
 ggp_sdk/1.43.0.14282@orbitdeps/stable

--- a/third_party/conan/lockfiles/base.lock
+++ b/third_party/conan/lockfiles/base.lock
@@ -15,22 +15,23 @@
      "27",
      "28",
      "29",
-     "5",
      "30",
+     "5",
      "31",
-     "33",
-     "34",
-     "60",
      "32",
+     "34",
+     "35",
      "61",
+     "33",
      "62",
-     "63"
+     "63",
+     "64"
     ],
     "build_requires": [
-     "80",
-     "82",
+     "81",
      "83",
-     "84"
+     "84",
+     "85"
     ],
     "path": "../../../conanfile.py",
     "context": "host"
@@ -315,217 +316,213 @@
     "context": "host"
    },
    "30": {
-    "ref": "crashpad/20200624@orbitdeps/stable#8c19cb575eb819de0b050cf7d1f317b6",
+    "ref": "vulkan-headers/1.1.114.0#916e0ecdc608715031a7b70078256c2c",
     "context": "host"
    },
    "31": {
+    "ref": "crashpad/20200624@orbitdeps/stable#8c19cb575eb819de0b050cf7d1f317b6",
+    "context": "host"
+   },
+   "32": {
     "ref": "freetype/2.10.0@bincrafters/stable#0",
     "requires": [
-     "32",
+     "33",
      "5",
      "2"
     ],
     "context": "host"
    },
-   "32": {
+   "33": {
     "ref": "libpng/1.6.37@bincrafters/stable#0",
     "requires": [
      "5"
     ],
     "context": "host"
    },
-   "33": {
+   "34": {
     "ref": "freetype-gl/8d9a97a@orbitdeps/stable#2836d28f3d91c308ec9652c2054015db",
     "requires": [
-     "34",
-     "31",
+     "35",
+     "32",
      "5"
     ],
     "context": "host"
    },
-   "34": {
-    "ref": "glew/2.1.0@orbitdeps/stable#0",
-    "requires": [
-     "35"
-    ],
-    "context": "host"
-   },
    "35": {
-    "ref": "mesa-glu/9.0.1@bincrafters/stable#0",
+    "ref": "glew/2.1.0@orbitdeps/stable#0",
     "requires": [
      "36"
     ],
     "context": "host"
    },
    "36": {
-    "ref": "mesa/19.3.1@bincrafters/stable#0",
+    "ref": "mesa-glu/9.0.1@bincrafters/stable#0",
     "requires": [
-     "5",
-     "37",
-     "38",
-     "40",
-     "41",
-     "43",
-     "53",
-     "54",
-     "55",
-     "46",
-     "56",
-     "57",
-     "58"
+     "37"
     ],
     "context": "host"
    },
    "37": {
-    "ref": "expat/2.2.9#9f476bdcbd34f15324d82b9bdfed2e99",
+    "ref": "mesa/19.3.1@bincrafters/stable#0",
+    "requires": [
+     "5",
+     "38",
+     "39",
+     "41",
+     "42",
+     "44",
+     "54",
+     "55",
+     "56",
+     "47",
+     "57",
+     "58",
+     "59"
+    ],
     "context": "host"
    },
    "38": {
-    "ref": "libdrm/2.4.100@bincrafters/stable#0",
-    "requires": [
-     "39"
-    ],
+    "ref": "expat/2.2.9#9f476bdcbd34f15324d82b9bdfed2e99",
     "context": "host"
    },
    "39": {
-    "ref": "libpciaccess/0.16@bincrafters/stable#0",
+    "ref": "libdrm/2.4.100@bincrafters/stable#0",
+    "requires": [
+     "40"
+    ],
     "context": "host"
    },
    "40": {
-    "ref": "libelf/0.8.13#db17656a3054ad46af79109ce012e28f",
+    "ref": "libpciaccess/0.16@bincrafters/stable#0",
     "context": "host"
    },
    "41": {
-    "ref": "libunwind/1.3.1#95020c9128fb7a26ecc442f0efecf719",
-    "requires": [
-     "42"
-    ],
+    "ref": "libelf/0.8.13#db17656a3054ad46af79109ce012e28f",
     "context": "host"
    },
    "42": {
-    "ref": "xz_utils/5.2.4#e9079f02e62fc6269417698d56410551",
+    "ref": "libunwind/1.3.1#95020c9128fb7a26ecc442f0efecf719",
+    "requires": [
+     "43"
+    ],
     "context": "host"
    },
    "43": {
-    "ref": "libx11/1.6.8@bincrafters/stable#0",
-    "requires": [
-     "44",
-     "45",
-     "46"
-    ],
+    "ref": "xz_utils/5.2.4#e9079f02e62fc6269417698d56410551",
     "context": "host"
    },
    "44": {
-    "ref": "xorgproto/2019.1@bincrafters/stable#0",
-    "context": "host"
-   },
-   "45": {
-    "ref": "xtrans/1.4.0@bincrafters/stable#0",
-    "context": "host"
-   },
-   "46": {
-    "ref": "libxcb/1.13.1@bincrafters/stable#0",
+    "ref": "libx11/1.6.8@bincrafters/stable#0",
     "requires": [
-     "47",
-     "48",
-     "49",
-     "50",
-     "51"
+     "45",
+     "46",
+     "47"
     ],
     "context": "host"
    },
+   "45": {
+    "ref": "xorgproto/2019.1@bincrafters/stable#0",
+    "context": "host"
+   },
+   "46": {
+    "ref": "xtrans/1.4.0@bincrafters/stable#0",
+    "context": "host"
+   },
    "47": {
-    "ref": "xcb-proto/1.13@bincrafters/stable#0",
+    "ref": "libxcb/1.13.1@bincrafters/stable#0",
+    "requires": [
+     "48",
+     "49",
+     "50",
+     "51",
+     "52"
+    ],
     "context": "host"
    },
    "48": {
-    "ref": "util-macros/1.19.2@bincrafters/stable#0",
+    "ref": "xcb-proto/1.13@bincrafters/stable#0",
     "context": "host"
    },
    "49": {
+    "ref": "util-macros/1.19.2@bincrafters/stable#0",
+    "context": "host"
+   },
+   "50": {
     "ref": "libxau/1.0.9@bincrafters/stable#0",
+    "requires": [
+     "45"
+    ],
+    "context": "host"
+   },
+   "51": {
+    "ref": "libpthread-stubs/0.1@bincrafters/stable#0",
+    "context": "host"
+   },
+   "52": {
+    "ref": "libxdmcp/1.1.3@bincrafters/stable#0",
+    "requires": [
+     "53"
+    ],
+    "context": "host"
+   },
+   "53": {
+    "ref": "xproto/7.0.31@bincrafters/stable#0",
+    "context": "host"
+   },
+   "54": {
+    "ref": "libxext/1.3.4@bincrafters/stable#0",
     "requires": [
      "44"
     ],
     "context": "host"
    },
-   "50": {
-    "ref": "libpthread-stubs/0.1@bincrafters/stable#0",
-    "context": "host"
-   },
-   "51": {
-    "ref": "libxdmcp/1.1.3@bincrafters/stable#0",
-    "requires": [
-     "52"
-    ],
-    "context": "host"
-   },
-   "52": {
-    "ref": "xproto/7.0.31@bincrafters/stable#0",
-    "context": "host"
-   },
-   "53": {
-    "ref": "libxext/1.3.4@bincrafters/stable#0",
-    "requires": [
-     "43"
-    ],
-    "context": "host"
-   },
-   "54": {
+   "55": {
     "ref": "libxdamage/1.1.5@bincrafters/stable#0",
     "requires": [
-     "55"
-    ],
-    "context": "host"
-   },
-   "55": {
-    "ref": "libxfixes/5.0.3@bincrafters/stable#0",
-    "requires": [
-     "43"
+     "56"
     ],
     "context": "host"
    },
    "56": {
-    "ref": "libxshmfence/1.3@bincrafters/stable#0",
+    "ref": "libxfixes/5.0.3@bincrafters/stable#0",
     "requires": [
-     "44",
-     "48"
+     "44"
     ],
     "context": "host"
    },
    "57": {
-    "ref": "libxxf86vm/1.1.4@bincrafters/stable#0",
+    "ref": "libxshmfence/1.3@bincrafters/stable#0",
     "requires": [
-     "43",
-     "53"
+     "45",
+     "49"
     ],
     "context": "host"
    },
    "58": {
-    "ref": "libxrandr/1.5.2@bincrafters/stable#0",
+    "ref": "libxxf86vm/1.1.4@bincrafters/stable#0",
     "requires": [
-     "59",
-     "53"
+     "44",
+     "54"
     ],
     "context": "host"
    },
    "59": {
-    "ref": "libxrender/0.9.10@bincrafters/stable#0",
+    "ref": "libxrandr/1.5.2@bincrafters/stable#0",
     "requires": [
-     "43"
+     "60",
+     "54"
     ],
     "context": "host"
    },
    "60": {
-    "ref": "imgui/1.69@bincrafters/stable#0",
+    "ref": "libxrender/0.9.10@bincrafters/stable#0",
+    "requires": [
+     "44"
+    ],
     "context": "host"
    },
    "61": {
-    "ref": "libxi/1.7.10@bincrafters/stable#0",
-    "requires": [
-     "53",
-     "55"
-    ],
+    "ref": "imgui/1.69@bincrafters/stable#0",
     "context": "host"
    },
    "62": {
@@ -537,28 +534,36 @@
     "context": "host"
    },
    "63": {
-    "ref": "qt/5.15.1@orbitdeps/stable#e659e981368e4baba1a201b75ddb89b6",
+    "ref": "libxi/1.7.10@bincrafters/stable#0",
     "requires": [
-     "5",
-     "6",
-     "64",
-     "65",
-     "70",
-     "31",
-     "71",
-     "73",
-     "74",
-     "75",
-     "32",
-     "76",
-     "77",
-     "37",
-     "78",
-     "79"
+     "54",
+     "56"
     ],
     "context": "host"
    },
    "64": {
+    "ref": "qt/5.15.1@orbitdeps/stable#e659e981368e4baba1a201b75ddb89b6",
+    "requires": [
+     "5",
+     "6",
+     "65",
+     "66",
+     "71",
+     "32",
+     "72",
+     "74",
+     "75",
+     "76",
+     "33",
+     "77",
+     "78",
+     "38",
+     "79",
+     "80"
+    ],
+    "context": "host"
+   },
+   "65": {
     "ref": "pcre2/10.33#54adea8f4f46f14720b65849988c274a",
     "requires": [
      "5",
@@ -566,23 +571,23 @@
     ],
     "context": "host"
    },
-   "65": {
+   "66": {
     "ref": "glib/2.64.0@bincrafters/stable#0",
     "requires": [
      "5",
-     "66",
      "67",
-     "40",
      "68",
-     "69"
+     "41",
+     "69",
+     "70"
     ],
     "context": "host"
    },
-   "66": {
+   "67": {
     "ref": "libffi/3.2.1#778fb4699ab6f90aed4141fddd75ca83",
     "context": "host"
    },
-   "67": {
+   "68": {
     "ref": "pcre/8.41#b1c67efc54f003e2c0d15593ef5ee473",
     "requires": [
      "2",
@@ -590,88 +595,89 @@
     ],
     "context": "host"
    },
-   "68": {
+   "69": {
     "ref": "libmount/2.33.1#5208204d4209a8619cda0879ab3f95f8",
     "context": "host"
    },
-   "69": {
+   "70": {
     "ref": "libselinux/2.9@bincrafters/stable#0",
     "requires": [
-     "64"
+     "65"
     ],
-    "context": "host"
-   },
-   "70": {
-    "ref": "double-conversion/3.1.5#bf7fceaa33f97d13a341039f49a5ec8f",
     "context": "host"
    },
    "71": {
-    "ref": "fontconfig/2.13.91#f352b873e84bdb407e9d26f10c4d5ace",
-    "requires": [
-     "31",
-     "37",
-     "72"
-    ],
+    "ref": "double-conversion/3.1.5#bf7fceaa33f97d13a341039f49a5ec8f",
     "context": "host"
    },
    "72": {
-    "ref": "libuuid/1.0.3#840ba593f58e204662dc518dc9158ea6",
-    "context": "host"
-   },
-   "73": {
-    "ref": "icu/64.2#8e5b14365280b23e74c951a6415bbef8",
-    "context": "host"
-   },
-   "74": {
-    "ref": "harfbuzz/2.6.8#5733395ae2752d74034dccb6a94e9be8",
+    "ref": "fontconfig/2.13.91#f352b873e84bdb407e9d26f10c4d5ace",
     "requires": [
-     "31"
+     "32",
+     "38",
+     "73"
     ],
     "context": "host"
    },
+   "73": {
+    "ref": "libuuid/1.0.3#840ba593f58e204662dc518dc9158ea6",
+    "context": "host"
+   },
+   "74": {
+    "ref": "icu/64.2#8e5b14365280b23e74c951a6415bbef8",
+    "context": "host"
+   },
    "75": {
-    "ref": "libjpeg/9d#9c2c46fd74c85f5e6058e14abcf985e4",
+    "ref": "harfbuzz/2.6.8#5733395ae2752d74034dccb6a94e9be8",
+    "requires": [
+     "32",
+     "66"
+    ],
     "context": "host"
    },
    "76": {
-    "ref": "xorg/system#313b5d45c4669424c20daa86289e0d2e",
+    "ref": "libjpeg/9d#9c2c46fd74c85f5e6058e14abcf985e4",
     "context": "host"
    },
    "77": {
-    "ref": "zstd/1.4.4#914f28f51eabce8d0120a09a7627376d",
+    "ref": "xorg/system#313b5d45c4669424c20daa86289e0d2e",
     "context": "host"
    },
    "78": {
-    "ref": "opus/1.3.1#bb9e103e40877d9a8123672d4fd7ae8d",
+    "ref": "zstd/1.4.4#914f28f51eabce8d0120a09a7627376d",
     "context": "host"
    },
    "79": {
-    "ref": "opengl/system#e59f5699a39ea3b426a4194bccd77fe9",
+    "ref": "opus/1.3.1#bb9e103e40877d9a8123672d4fd7ae8d",
     "context": "host"
    },
    "80": {
+    "ref": "opengl/system#e59f5699a39ea3b426a4194bccd77fe9",
+    "context": "host"
+   },
+   "81": {
     "ref": "protoc_installer/3.9.1@bincrafters/stable#0",
+    "requires": [
+     "82"
+    ],
+    "context": "host"
+   },
+   "82": {
+    "ref": "protobuf/3.9.1@bincrafters/stable#0",
+    "context": "host"
+   },
+   "83": {
+    "ref": "grpc_codegen/1.27.3@orbitdeps/stable#c6bf9ad213d71302cea8e565a62e37ea",
     "requires": [
      "81"
     ],
     "context": "host"
    },
-   "81": {
-    "ref": "protobuf/3.9.1@bincrafters/stable#0",
-    "context": "host"
-   },
-   "82": {
-    "ref": "grpc_codegen/1.27.3@orbitdeps/stable#c6bf9ad213d71302cea8e565a62e37ea",
-    "requires": [
-     "80"
-    ],
-    "context": "host"
-   },
-   "83": {
+   "84": {
     "ref": "gtest/1.10.0#ef88ba8e54f5ffad7d706062d0731a40",
     "context": "host"
    },
-   "84": {
+   "85": {
     "ref": "nodejs/13.6.0@orbitdeps/stable#d07f6d3db886419fa9d0f65495ca23eb",
     "context": "host"
    }

--- a/third_party/vulkan/vk_layer_dispatch_table.h
+++ b/third_party/vulkan/vk_layer_dispatch_table.h
@@ -1,0 +1,643 @@
+// *** THIS FILE IS GENERATED - DO NOT EDIT ***
+// See loader_extension_generator.py for modifications
+
+/*
+ * Copyright (c) 2015-2017 The Khronos Group Inc.
+ * Copyright (c) 2015-2017 Valve Corporation
+ * Copyright (c) 2015-2017 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Mark Lobodzinski <mark@lunarg.com>
+ * Author: Mark Young <marky@lunarg.com>
+ */
+
+#pragma once
+
+typedef PFN_vkVoidFunction(VKAPI_PTR* PFN_GetPhysicalDeviceProcAddr)(VkInstance instance,
+                                                                     const char* pName);
+
+// Instance function pointer dispatch table
+typedef struct VkLayerInstanceDispatchTable_ {
+  // Manually add in GetPhysicalDeviceProcAddr entry
+  PFN_GetPhysicalDeviceProcAddr GetPhysicalDeviceProcAddr;
+
+  // ---- Core 1_0 commands
+  PFN_vkCreateInstance CreateInstance;
+  PFN_vkDestroyInstance DestroyInstance;
+  PFN_vkEnumeratePhysicalDevices EnumeratePhysicalDevices;
+  PFN_vkGetPhysicalDeviceFeatures GetPhysicalDeviceFeatures;
+  PFN_vkGetPhysicalDeviceFormatProperties GetPhysicalDeviceFormatProperties;
+  PFN_vkGetPhysicalDeviceImageFormatProperties GetPhysicalDeviceImageFormatProperties;
+  PFN_vkGetPhysicalDeviceProperties GetPhysicalDeviceProperties;
+  PFN_vkGetPhysicalDeviceQueueFamilyProperties GetPhysicalDeviceQueueFamilyProperties;
+  PFN_vkGetPhysicalDeviceMemoryProperties GetPhysicalDeviceMemoryProperties;
+  PFN_vkGetInstanceProcAddr GetInstanceProcAddr;
+  PFN_vkCreateDevice CreateDevice;
+  PFN_vkEnumerateInstanceExtensionProperties EnumerateInstanceExtensionProperties;
+  PFN_vkEnumerateDeviceExtensionProperties EnumerateDeviceExtensionProperties;
+  PFN_vkEnumerateInstanceLayerProperties EnumerateInstanceLayerProperties;
+  PFN_vkEnumerateDeviceLayerProperties EnumerateDeviceLayerProperties;
+  PFN_vkGetPhysicalDeviceSparseImageFormatProperties GetPhysicalDeviceSparseImageFormatProperties;
+
+  // ---- Core 1_1 commands
+  PFN_vkEnumerateInstanceVersion EnumerateInstanceVersion;
+  PFN_vkEnumeratePhysicalDeviceGroups EnumeratePhysicalDeviceGroups;
+  PFN_vkGetPhysicalDeviceFeatures2 GetPhysicalDeviceFeatures2;
+  PFN_vkGetPhysicalDeviceProperties2 GetPhysicalDeviceProperties2;
+  PFN_vkGetPhysicalDeviceFormatProperties2 GetPhysicalDeviceFormatProperties2;
+  PFN_vkGetPhysicalDeviceImageFormatProperties2 GetPhysicalDeviceImageFormatProperties2;
+  PFN_vkGetPhysicalDeviceQueueFamilyProperties2 GetPhysicalDeviceQueueFamilyProperties2;
+  PFN_vkGetPhysicalDeviceMemoryProperties2 GetPhysicalDeviceMemoryProperties2;
+  PFN_vkGetPhysicalDeviceSparseImageFormatProperties2 GetPhysicalDeviceSparseImageFormatProperties2;
+  PFN_vkGetPhysicalDeviceExternalBufferProperties GetPhysicalDeviceExternalBufferProperties;
+  PFN_vkGetPhysicalDeviceExternalFenceProperties GetPhysicalDeviceExternalFenceProperties;
+  PFN_vkGetPhysicalDeviceExternalSemaphoreProperties GetPhysicalDeviceExternalSemaphoreProperties;
+
+  // ---- VK_KHR_surface extension commands
+  PFN_vkDestroySurfaceKHR DestroySurfaceKHR;
+  PFN_vkGetPhysicalDeviceSurfaceSupportKHR GetPhysicalDeviceSurfaceSupportKHR;
+  PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR GetPhysicalDeviceSurfaceCapabilitiesKHR;
+  PFN_vkGetPhysicalDeviceSurfaceFormatsKHR GetPhysicalDeviceSurfaceFormatsKHR;
+  PFN_vkGetPhysicalDeviceSurfacePresentModesKHR GetPhysicalDeviceSurfacePresentModesKHR;
+
+  // ---- VK_KHR_swapchain extension commands
+  PFN_vkGetPhysicalDevicePresentRectanglesKHR GetPhysicalDevicePresentRectanglesKHR;
+
+  // ---- VK_KHR_display extension commands
+  PFN_vkGetPhysicalDeviceDisplayPropertiesKHR GetPhysicalDeviceDisplayPropertiesKHR;
+  PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR GetPhysicalDeviceDisplayPlanePropertiesKHR;
+  PFN_vkGetDisplayPlaneSupportedDisplaysKHR GetDisplayPlaneSupportedDisplaysKHR;
+  PFN_vkGetDisplayModePropertiesKHR GetDisplayModePropertiesKHR;
+  PFN_vkCreateDisplayModeKHR CreateDisplayModeKHR;
+  PFN_vkGetDisplayPlaneCapabilitiesKHR GetDisplayPlaneCapabilitiesKHR;
+  PFN_vkCreateDisplayPlaneSurfaceKHR CreateDisplayPlaneSurfaceKHR;
+
+  // ---- VK_KHR_xlib_surface extension commands
+#ifdef VK_USE_PLATFORM_XLIB_KHR
+  PFN_vkCreateXlibSurfaceKHR CreateXlibSurfaceKHR;
+#endif  // VK_USE_PLATFORM_XLIB_KHR
+#ifdef VK_USE_PLATFORM_XLIB_KHR
+  PFN_vkGetPhysicalDeviceXlibPresentationSupportKHR GetPhysicalDeviceXlibPresentationSupportKHR;
+#endif  // VK_USE_PLATFORM_XLIB_KHR
+
+  // ---- VK_KHR_xcb_surface extension commands
+#ifdef VK_USE_PLATFORM_XCB_KHR
+  PFN_vkCreateXcbSurfaceKHR CreateXcbSurfaceKHR;
+#endif  // VK_USE_PLATFORM_XCB_KHR
+#ifdef VK_USE_PLATFORM_XCB_KHR
+  PFN_vkGetPhysicalDeviceXcbPresentationSupportKHR GetPhysicalDeviceXcbPresentationSupportKHR;
+#endif  // VK_USE_PLATFORM_XCB_KHR
+
+  // ---- VK_KHR_wayland_surface extension commands
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+  PFN_vkCreateWaylandSurfaceKHR CreateWaylandSurfaceKHR;
+#endif  // VK_USE_PLATFORM_WAYLAND_KHR
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+  PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR
+      GetPhysicalDeviceWaylandPresentationSupportKHR;
+#endif  // VK_USE_PLATFORM_WAYLAND_KHR
+
+  // ---- VK_KHR_android_surface extension commands
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+  PFN_vkCreateAndroidSurfaceKHR CreateAndroidSurfaceKHR;
+#endif  // VK_USE_PLATFORM_ANDROID_KHR
+
+  // ---- VK_KHR_win32_surface extension commands
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+  PFN_vkCreateWin32SurfaceKHR CreateWin32SurfaceKHR;
+#endif  // VK_USE_PLATFORM_WIN32_KHR
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+  PFN_vkGetPhysicalDeviceWin32PresentationSupportKHR GetPhysicalDeviceWin32PresentationSupportKHR;
+#endif  // VK_USE_PLATFORM_WIN32_KHR
+
+  // ---- VK_KHR_get_physical_device_properties2 extension commands
+  PFN_vkGetPhysicalDeviceFeatures2KHR GetPhysicalDeviceFeatures2KHR;
+  PFN_vkGetPhysicalDeviceProperties2KHR GetPhysicalDeviceProperties2KHR;
+  PFN_vkGetPhysicalDeviceFormatProperties2KHR GetPhysicalDeviceFormatProperties2KHR;
+  PFN_vkGetPhysicalDeviceImageFormatProperties2KHR GetPhysicalDeviceImageFormatProperties2KHR;
+  PFN_vkGetPhysicalDeviceQueueFamilyProperties2KHR GetPhysicalDeviceQueueFamilyProperties2KHR;
+  PFN_vkGetPhysicalDeviceMemoryProperties2KHR GetPhysicalDeviceMemoryProperties2KHR;
+  PFN_vkGetPhysicalDeviceSparseImageFormatProperties2KHR
+      GetPhysicalDeviceSparseImageFormatProperties2KHR;
+
+  // ---- VK_KHR_device_group_creation extension commands
+  PFN_vkEnumeratePhysicalDeviceGroupsKHR EnumeratePhysicalDeviceGroupsKHR;
+
+  // ---- VK_KHR_external_memory_capabilities extension commands
+  PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR GetPhysicalDeviceExternalBufferPropertiesKHR;
+
+  // ---- VK_KHR_external_semaphore_capabilities extension commands
+  PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR
+      GetPhysicalDeviceExternalSemaphorePropertiesKHR;
+
+  // ---- VK_KHR_external_fence_capabilities extension commands
+  PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR GetPhysicalDeviceExternalFencePropertiesKHR;
+
+  // ---- VK_KHR_get_surface_capabilities2 extension commands
+  PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR GetPhysicalDeviceSurfaceCapabilities2KHR;
+  PFN_vkGetPhysicalDeviceSurfaceFormats2KHR GetPhysicalDeviceSurfaceFormats2KHR;
+
+  // ---- VK_KHR_get_display_properties2 extension commands
+  PFN_vkGetPhysicalDeviceDisplayProperties2KHR GetPhysicalDeviceDisplayProperties2KHR;
+  PFN_vkGetPhysicalDeviceDisplayPlaneProperties2KHR GetPhysicalDeviceDisplayPlaneProperties2KHR;
+  PFN_vkGetDisplayModeProperties2KHR GetDisplayModeProperties2KHR;
+  PFN_vkGetDisplayPlaneCapabilities2KHR GetDisplayPlaneCapabilities2KHR;
+
+  // ---- VK_EXT_debug_report extension commands
+  PFN_vkCreateDebugReportCallbackEXT CreateDebugReportCallbackEXT;
+  PFN_vkDestroyDebugReportCallbackEXT DestroyDebugReportCallbackEXT;
+  PFN_vkDebugReportMessageEXT DebugReportMessageEXT;
+
+  // ---- VK_GGP_stream_descriptor_surface extension commands
+#ifdef VK_USE_PLATFORM_GGP
+  PFN_vkCreateStreamDescriptorSurfaceGGP CreateStreamDescriptorSurfaceGGP;
+#endif  // VK_USE_PLATFORM_GGP
+
+  // ---- VK_NV_external_memory_capabilities extension commands
+  PFN_vkGetPhysicalDeviceExternalImageFormatPropertiesNV
+      GetPhysicalDeviceExternalImageFormatPropertiesNV;
+
+  // ---- VK_NN_vi_surface extension commands
+#ifdef VK_USE_PLATFORM_VI_NN
+  PFN_vkCreateViSurfaceNN CreateViSurfaceNN;
+#endif  // VK_USE_PLATFORM_VI_NN
+
+  // ---- VK_NVX_device_generated_commands extension commands
+  PFN_vkGetPhysicalDeviceGeneratedCommandsPropertiesNVX
+      GetPhysicalDeviceGeneratedCommandsPropertiesNVX;
+
+  // ---- VK_EXT_direct_mode_display extension commands
+  PFN_vkReleaseDisplayEXT ReleaseDisplayEXT;
+
+  // ---- VK_EXT_acquire_xlib_display extension commands
+#ifdef VK_USE_PLATFORM_XLIB_XRANDR_EXT
+  PFN_vkAcquireXlibDisplayEXT AcquireXlibDisplayEXT;
+#endif  // VK_USE_PLATFORM_XLIB_XRANDR_EXT
+#ifdef VK_USE_PLATFORM_XLIB_XRANDR_EXT
+  PFN_vkGetRandROutputDisplayEXT GetRandROutputDisplayEXT;
+#endif  // VK_USE_PLATFORM_XLIB_XRANDR_EXT
+
+  // ---- VK_EXT_display_surface_counter extension commands
+  PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT GetPhysicalDeviceSurfaceCapabilities2EXT;
+
+  // ---- VK_MVK_ios_surface extension commands
+#ifdef VK_USE_PLATFORM_IOS_MVK
+  PFN_vkCreateIOSSurfaceMVK CreateIOSSurfaceMVK;
+#endif  // VK_USE_PLATFORM_IOS_MVK
+
+  // ---- VK_MVK_macos_surface extension commands
+#ifdef VK_USE_PLATFORM_MACOS_MVK
+  PFN_vkCreateMacOSSurfaceMVK CreateMacOSSurfaceMVK;
+#endif  // VK_USE_PLATFORM_MACOS_MVK
+
+  // ---- VK_EXT_debug_utils extension commands
+  PFN_vkCreateDebugUtilsMessengerEXT CreateDebugUtilsMessengerEXT;
+  PFN_vkDestroyDebugUtilsMessengerEXT DestroyDebugUtilsMessengerEXT;
+  PFN_vkSubmitDebugUtilsMessageEXT SubmitDebugUtilsMessageEXT;
+
+  // ---- VK_EXT_sample_locations extension commands
+  PFN_vkGetPhysicalDeviceMultisamplePropertiesEXT GetPhysicalDeviceMultisamplePropertiesEXT;
+
+  // ---- VK_EXT_calibrated_timestamps extension commands
+  PFN_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT GetPhysicalDeviceCalibrateableTimeDomainsEXT;
+
+  // ---- VK_FUCHSIA_imagepipe_surface extension commands
+#ifdef VK_USE_PLATFORM_FUCHSIA
+  PFN_vkCreateImagePipeSurfaceFUCHSIA CreateImagePipeSurfaceFUCHSIA;
+#endif  // VK_USE_PLATFORM_FUCHSIA
+
+  // ---- VK_EXT_metal_surface extension commands
+#ifdef VK_USE_PLATFORM_METAL_EXT
+  PFN_vkCreateMetalSurfaceEXT CreateMetalSurfaceEXT;
+#endif  // VK_USE_PLATFORM_METAL_EXT
+
+  // ---- VK_NV_cooperative_matrix extension commands
+  PFN_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV
+      GetPhysicalDeviceCooperativeMatrixPropertiesNV;
+
+  // ---- VK_NV_coverage_reduction_mode extension commands
+  PFN_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV
+      GetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV;
+
+  // ---- VK_EXT_full_screen_exclusive extension commands
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+  PFN_vkGetPhysicalDeviceSurfacePresentModes2EXT GetPhysicalDeviceSurfacePresentModes2EXT;
+#endif  // VK_USE_PLATFORM_WIN32_KHR
+
+  // ---- VK_EXT_headless_surface extension commands
+  PFN_vkCreateHeadlessSurfaceEXT CreateHeadlessSurfaceEXT;
+} VkLayerInstanceDispatchTable;
+
+// Device function pointer dispatch table
+typedef struct VkLayerDispatchTable_ {
+  // ---- Core 1_0 commands
+  PFN_vkGetDeviceProcAddr GetDeviceProcAddr;
+  PFN_vkDestroyDevice DestroyDevice;
+  PFN_vkGetDeviceQueue GetDeviceQueue;
+  PFN_vkQueueSubmit QueueSubmit;
+  PFN_vkQueueWaitIdle QueueWaitIdle;
+  PFN_vkDeviceWaitIdle DeviceWaitIdle;
+  PFN_vkAllocateMemory AllocateMemory;
+  PFN_vkFreeMemory FreeMemory;
+  PFN_vkMapMemory MapMemory;
+  PFN_vkUnmapMemory UnmapMemory;
+  PFN_vkFlushMappedMemoryRanges FlushMappedMemoryRanges;
+  PFN_vkInvalidateMappedMemoryRanges InvalidateMappedMemoryRanges;
+  PFN_vkGetDeviceMemoryCommitment GetDeviceMemoryCommitment;
+  PFN_vkBindBufferMemory BindBufferMemory;
+  PFN_vkBindImageMemory BindImageMemory;
+  PFN_vkGetBufferMemoryRequirements GetBufferMemoryRequirements;
+  PFN_vkGetImageMemoryRequirements GetImageMemoryRequirements;
+  PFN_vkGetImageSparseMemoryRequirements GetImageSparseMemoryRequirements;
+  PFN_vkQueueBindSparse QueueBindSparse;
+  PFN_vkCreateFence CreateFence;
+  PFN_vkDestroyFence DestroyFence;
+  PFN_vkResetFences ResetFences;
+  PFN_vkGetFenceStatus GetFenceStatus;
+  PFN_vkWaitForFences WaitForFences;
+  PFN_vkCreateSemaphore CreateSemaphore;
+  PFN_vkDestroySemaphore DestroySemaphore;
+  PFN_vkCreateEvent CreateEvent;
+  PFN_vkDestroyEvent DestroyEvent;
+  PFN_vkGetEventStatus GetEventStatus;
+  PFN_vkSetEvent SetEvent;
+  PFN_vkResetEvent ResetEvent;
+  PFN_vkCreateQueryPool CreateQueryPool;
+  PFN_vkDestroyQueryPool DestroyQueryPool;
+  PFN_vkGetQueryPoolResults GetQueryPoolResults;
+  PFN_vkCreateBuffer CreateBuffer;
+  PFN_vkDestroyBuffer DestroyBuffer;
+  PFN_vkCreateBufferView CreateBufferView;
+  PFN_vkDestroyBufferView DestroyBufferView;
+  PFN_vkCreateImage CreateImage;
+  PFN_vkDestroyImage DestroyImage;
+  PFN_vkGetImageSubresourceLayout GetImageSubresourceLayout;
+  PFN_vkCreateImageView CreateImageView;
+  PFN_vkDestroyImageView DestroyImageView;
+  PFN_vkCreateShaderModule CreateShaderModule;
+  PFN_vkDestroyShaderModule DestroyShaderModule;
+  PFN_vkCreatePipelineCache CreatePipelineCache;
+  PFN_vkDestroyPipelineCache DestroyPipelineCache;
+  PFN_vkGetPipelineCacheData GetPipelineCacheData;
+  PFN_vkMergePipelineCaches MergePipelineCaches;
+  PFN_vkCreateGraphicsPipelines CreateGraphicsPipelines;
+  PFN_vkCreateComputePipelines CreateComputePipelines;
+  PFN_vkDestroyPipeline DestroyPipeline;
+  PFN_vkCreatePipelineLayout CreatePipelineLayout;
+  PFN_vkDestroyPipelineLayout DestroyPipelineLayout;
+  PFN_vkCreateSampler CreateSampler;
+  PFN_vkDestroySampler DestroySampler;
+  PFN_vkCreateDescriptorSetLayout CreateDescriptorSetLayout;
+  PFN_vkDestroyDescriptorSetLayout DestroyDescriptorSetLayout;
+  PFN_vkCreateDescriptorPool CreateDescriptorPool;
+  PFN_vkDestroyDescriptorPool DestroyDescriptorPool;
+  PFN_vkResetDescriptorPool ResetDescriptorPool;
+  PFN_vkAllocateDescriptorSets AllocateDescriptorSets;
+  PFN_vkFreeDescriptorSets FreeDescriptorSets;
+  PFN_vkUpdateDescriptorSets UpdateDescriptorSets;
+  PFN_vkCreateFramebuffer CreateFramebuffer;
+  PFN_vkDestroyFramebuffer DestroyFramebuffer;
+  PFN_vkCreateRenderPass CreateRenderPass;
+  PFN_vkDestroyRenderPass DestroyRenderPass;
+  PFN_vkGetRenderAreaGranularity GetRenderAreaGranularity;
+  PFN_vkCreateCommandPool CreateCommandPool;
+  PFN_vkDestroyCommandPool DestroyCommandPool;
+  PFN_vkResetCommandPool ResetCommandPool;
+  PFN_vkAllocateCommandBuffers AllocateCommandBuffers;
+  PFN_vkFreeCommandBuffers FreeCommandBuffers;
+  PFN_vkBeginCommandBuffer BeginCommandBuffer;
+  PFN_vkEndCommandBuffer EndCommandBuffer;
+  PFN_vkResetCommandBuffer ResetCommandBuffer;
+  PFN_vkCmdBindPipeline CmdBindPipeline;
+  PFN_vkCmdSetViewport CmdSetViewport;
+  PFN_vkCmdSetScissor CmdSetScissor;
+  PFN_vkCmdSetLineWidth CmdSetLineWidth;
+  PFN_vkCmdSetDepthBias CmdSetDepthBias;
+  PFN_vkCmdSetBlendConstants CmdSetBlendConstants;
+  PFN_vkCmdSetDepthBounds CmdSetDepthBounds;
+  PFN_vkCmdSetStencilCompareMask CmdSetStencilCompareMask;
+  PFN_vkCmdSetStencilWriteMask CmdSetStencilWriteMask;
+  PFN_vkCmdSetStencilReference CmdSetStencilReference;
+  PFN_vkCmdBindDescriptorSets CmdBindDescriptorSets;
+  PFN_vkCmdBindIndexBuffer CmdBindIndexBuffer;
+  PFN_vkCmdBindVertexBuffers CmdBindVertexBuffers;
+  PFN_vkCmdDraw CmdDraw;
+  PFN_vkCmdDrawIndexed CmdDrawIndexed;
+  PFN_vkCmdDrawIndirect CmdDrawIndirect;
+  PFN_vkCmdDrawIndexedIndirect CmdDrawIndexedIndirect;
+  PFN_vkCmdDispatch CmdDispatch;
+  PFN_vkCmdDispatchIndirect CmdDispatchIndirect;
+  PFN_vkCmdCopyBuffer CmdCopyBuffer;
+  PFN_vkCmdCopyImage CmdCopyImage;
+  PFN_vkCmdBlitImage CmdBlitImage;
+  PFN_vkCmdCopyBufferToImage CmdCopyBufferToImage;
+  PFN_vkCmdCopyImageToBuffer CmdCopyImageToBuffer;
+  PFN_vkCmdUpdateBuffer CmdUpdateBuffer;
+  PFN_vkCmdFillBuffer CmdFillBuffer;
+  PFN_vkCmdClearColorImage CmdClearColorImage;
+  PFN_vkCmdClearDepthStencilImage CmdClearDepthStencilImage;
+  PFN_vkCmdClearAttachments CmdClearAttachments;
+  PFN_vkCmdResolveImage CmdResolveImage;
+  PFN_vkCmdSetEvent CmdSetEvent;
+  PFN_vkCmdResetEvent CmdResetEvent;
+  PFN_vkCmdWaitEvents CmdWaitEvents;
+  PFN_vkCmdPipelineBarrier CmdPipelineBarrier;
+  PFN_vkCmdBeginQuery CmdBeginQuery;
+  PFN_vkCmdEndQuery CmdEndQuery;
+  PFN_vkCmdResetQueryPool CmdResetQueryPool;
+  PFN_vkCmdWriteTimestamp CmdWriteTimestamp;
+  PFN_vkCmdCopyQueryPoolResults CmdCopyQueryPoolResults;
+  PFN_vkCmdPushConstants CmdPushConstants;
+  PFN_vkCmdBeginRenderPass CmdBeginRenderPass;
+  PFN_vkCmdNextSubpass CmdNextSubpass;
+  PFN_vkCmdEndRenderPass CmdEndRenderPass;
+  PFN_vkCmdExecuteCommands CmdExecuteCommands;
+
+  // ---- Core 1_1 commands
+  PFN_vkBindBufferMemory2 BindBufferMemory2;
+  PFN_vkBindImageMemory2 BindImageMemory2;
+  PFN_vkGetDeviceGroupPeerMemoryFeatures GetDeviceGroupPeerMemoryFeatures;
+  PFN_vkCmdSetDeviceMask CmdSetDeviceMask;
+  PFN_vkCmdDispatchBase CmdDispatchBase;
+  PFN_vkGetImageMemoryRequirements2 GetImageMemoryRequirements2;
+  PFN_vkGetBufferMemoryRequirements2 GetBufferMemoryRequirements2;
+  PFN_vkGetImageSparseMemoryRequirements2 GetImageSparseMemoryRequirements2;
+  PFN_vkTrimCommandPool TrimCommandPool;
+  PFN_vkGetDeviceQueue2 GetDeviceQueue2;
+  PFN_vkCreateSamplerYcbcrConversion CreateSamplerYcbcrConversion;
+  PFN_vkDestroySamplerYcbcrConversion DestroySamplerYcbcrConversion;
+  PFN_vkCreateDescriptorUpdateTemplate CreateDescriptorUpdateTemplate;
+  PFN_vkDestroyDescriptorUpdateTemplate DestroyDescriptorUpdateTemplate;
+  PFN_vkUpdateDescriptorSetWithTemplate UpdateDescriptorSetWithTemplate;
+  PFN_vkGetDescriptorSetLayoutSupport GetDescriptorSetLayoutSupport;
+
+  // ---- VK_KHR_swapchain extension commands
+  PFN_vkCreateSwapchainKHR CreateSwapchainKHR;
+  PFN_vkDestroySwapchainKHR DestroySwapchainKHR;
+  PFN_vkGetSwapchainImagesKHR GetSwapchainImagesKHR;
+  PFN_vkAcquireNextImageKHR AcquireNextImageKHR;
+  PFN_vkQueuePresentKHR QueuePresentKHR;
+  PFN_vkGetDeviceGroupPresentCapabilitiesKHR GetDeviceGroupPresentCapabilitiesKHR;
+  PFN_vkGetDeviceGroupSurfacePresentModesKHR GetDeviceGroupSurfacePresentModesKHR;
+  PFN_vkAcquireNextImage2KHR AcquireNextImage2KHR;
+
+  // ---- VK_KHR_display_swapchain extension commands
+  PFN_vkCreateSharedSwapchainsKHR CreateSharedSwapchainsKHR;
+
+  // ---- VK_KHR_device_group extension commands
+  PFN_vkGetDeviceGroupPeerMemoryFeaturesKHR GetDeviceGroupPeerMemoryFeaturesKHR;
+  PFN_vkCmdSetDeviceMaskKHR CmdSetDeviceMaskKHR;
+  PFN_vkCmdDispatchBaseKHR CmdDispatchBaseKHR;
+
+  // ---- VK_KHR_maintenance1 extension commands
+  PFN_vkTrimCommandPoolKHR TrimCommandPoolKHR;
+
+  // ---- VK_KHR_external_memory_win32 extension commands
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+  PFN_vkGetMemoryWin32HandleKHR GetMemoryWin32HandleKHR;
+#endif  // VK_USE_PLATFORM_WIN32_KHR
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+  PFN_vkGetMemoryWin32HandlePropertiesKHR GetMemoryWin32HandlePropertiesKHR;
+#endif  // VK_USE_PLATFORM_WIN32_KHR
+
+  // ---- VK_KHR_external_memory_fd extension commands
+  PFN_vkGetMemoryFdKHR GetMemoryFdKHR;
+  PFN_vkGetMemoryFdPropertiesKHR GetMemoryFdPropertiesKHR;
+
+  // ---- VK_KHR_external_semaphore_win32 extension commands
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+  PFN_vkImportSemaphoreWin32HandleKHR ImportSemaphoreWin32HandleKHR;
+#endif  // VK_USE_PLATFORM_WIN32_KHR
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+  PFN_vkGetSemaphoreWin32HandleKHR GetSemaphoreWin32HandleKHR;
+#endif  // VK_USE_PLATFORM_WIN32_KHR
+
+  // ---- VK_KHR_external_semaphore_fd extension commands
+  PFN_vkImportSemaphoreFdKHR ImportSemaphoreFdKHR;
+  PFN_vkGetSemaphoreFdKHR GetSemaphoreFdKHR;
+
+  // ---- VK_KHR_push_descriptor extension commands
+  PFN_vkCmdPushDescriptorSetKHR CmdPushDescriptorSetKHR;
+  PFN_vkCmdPushDescriptorSetWithTemplateKHR CmdPushDescriptorSetWithTemplateKHR;
+
+  // ---- VK_KHR_descriptor_update_template extension commands
+  PFN_vkCreateDescriptorUpdateTemplateKHR CreateDescriptorUpdateTemplateKHR;
+  PFN_vkDestroyDescriptorUpdateTemplateKHR DestroyDescriptorUpdateTemplateKHR;
+  PFN_vkUpdateDescriptorSetWithTemplateKHR UpdateDescriptorSetWithTemplateKHR;
+
+  // ---- VK_KHR_create_renderpass2 extension commands
+  PFN_vkCreateRenderPass2KHR CreateRenderPass2KHR;
+  PFN_vkCmdBeginRenderPass2KHR CmdBeginRenderPass2KHR;
+  PFN_vkCmdNextSubpass2KHR CmdNextSubpass2KHR;
+  PFN_vkCmdEndRenderPass2KHR CmdEndRenderPass2KHR;
+
+  // ---- VK_KHR_shared_presentable_image extension commands
+  PFN_vkGetSwapchainStatusKHR GetSwapchainStatusKHR;
+
+  // ---- VK_KHR_external_fence_win32 extension commands
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+  PFN_vkImportFenceWin32HandleKHR ImportFenceWin32HandleKHR;
+#endif  // VK_USE_PLATFORM_WIN32_KHR
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+  PFN_vkGetFenceWin32HandleKHR GetFenceWin32HandleKHR;
+#endif  // VK_USE_PLATFORM_WIN32_KHR
+
+  // ---- VK_KHR_external_fence_fd extension commands
+  PFN_vkImportFenceFdKHR ImportFenceFdKHR;
+  PFN_vkGetFenceFdKHR GetFenceFdKHR;
+
+  // ---- VK_KHR_get_memory_requirements2 extension commands
+  PFN_vkGetImageMemoryRequirements2KHR GetImageMemoryRequirements2KHR;
+  PFN_vkGetBufferMemoryRequirements2KHR GetBufferMemoryRequirements2KHR;
+  PFN_vkGetImageSparseMemoryRequirements2KHR GetImageSparseMemoryRequirements2KHR;
+
+  // ---- VK_KHR_sampler_ycbcr_conversion extension commands
+  PFN_vkCreateSamplerYcbcrConversionKHR CreateSamplerYcbcrConversionKHR;
+  PFN_vkDestroySamplerYcbcrConversionKHR DestroySamplerYcbcrConversionKHR;
+
+  // ---- VK_KHR_bind_memory2 extension commands
+  PFN_vkBindBufferMemory2KHR BindBufferMemory2KHR;
+  PFN_vkBindImageMemory2KHR BindImageMemory2KHR;
+
+  // ---- VK_KHR_maintenance3 extension commands
+  PFN_vkGetDescriptorSetLayoutSupportKHR GetDescriptorSetLayoutSupportKHR;
+
+  // ---- VK_KHR_draw_indirect_count extension commands
+  PFN_vkCmdDrawIndirectCountKHR CmdDrawIndirectCountKHR;
+  PFN_vkCmdDrawIndexedIndirectCountKHR CmdDrawIndexedIndirectCountKHR;
+
+  // ---- VK_EXT_debug_marker extension commands
+  PFN_vkDebugMarkerSetObjectTagEXT DebugMarkerSetObjectTagEXT;
+  PFN_vkDebugMarkerSetObjectNameEXT DebugMarkerSetObjectNameEXT;
+  PFN_vkCmdDebugMarkerBeginEXT CmdDebugMarkerBeginEXT;
+  PFN_vkCmdDebugMarkerEndEXT CmdDebugMarkerEndEXT;
+  PFN_vkCmdDebugMarkerInsertEXT CmdDebugMarkerInsertEXT;
+
+  // ---- VK_EXT_transform_feedback extension commands
+  PFN_vkCmdBindTransformFeedbackBuffersEXT CmdBindTransformFeedbackBuffersEXT;
+  PFN_vkCmdBeginTransformFeedbackEXT CmdBeginTransformFeedbackEXT;
+  PFN_vkCmdEndTransformFeedbackEXT CmdEndTransformFeedbackEXT;
+  PFN_vkCmdBeginQueryIndexedEXT CmdBeginQueryIndexedEXT;
+  PFN_vkCmdEndQueryIndexedEXT CmdEndQueryIndexedEXT;
+  PFN_vkCmdDrawIndirectByteCountEXT CmdDrawIndirectByteCountEXT;
+
+  // ---- VK_NVX_image_view_handle extension commands
+  PFN_vkGetImageViewHandleNVX GetImageViewHandleNVX;
+
+  // ---- VK_AMD_draw_indirect_count extension commands
+  PFN_vkCmdDrawIndirectCountAMD CmdDrawIndirectCountAMD;
+  PFN_vkCmdDrawIndexedIndirectCountAMD CmdDrawIndexedIndirectCountAMD;
+
+  // ---- VK_AMD_shader_info extension commands
+  PFN_vkGetShaderInfoAMD GetShaderInfoAMD;
+
+  // ---- VK_NV_external_memory_win32 extension commands
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+  PFN_vkGetMemoryWin32HandleNV GetMemoryWin32HandleNV;
+#endif  // VK_USE_PLATFORM_WIN32_KHR
+
+  // ---- VK_EXT_conditional_rendering extension commands
+  PFN_vkCmdBeginConditionalRenderingEXT CmdBeginConditionalRenderingEXT;
+  PFN_vkCmdEndConditionalRenderingEXT CmdEndConditionalRenderingEXT;
+
+  // ---- VK_NVX_device_generated_commands extension commands
+  PFN_vkCmdProcessCommandsNVX CmdProcessCommandsNVX;
+  PFN_vkCmdReserveSpaceForCommandsNVX CmdReserveSpaceForCommandsNVX;
+  PFN_vkCreateIndirectCommandsLayoutNVX CreateIndirectCommandsLayoutNVX;
+  PFN_vkDestroyIndirectCommandsLayoutNVX DestroyIndirectCommandsLayoutNVX;
+  PFN_vkCreateObjectTableNVX CreateObjectTableNVX;
+  PFN_vkDestroyObjectTableNVX DestroyObjectTableNVX;
+  PFN_vkRegisterObjectsNVX RegisterObjectsNVX;
+  PFN_vkUnregisterObjectsNVX UnregisterObjectsNVX;
+
+  // ---- VK_NV_clip_space_w_scaling extension commands
+  PFN_vkCmdSetViewportWScalingNV CmdSetViewportWScalingNV;
+
+  // ---- VK_EXT_display_control extension commands
+  PFN_vkDisplayPowerControlEXT DisplayPowerControlEXT;
+  PFN_vkRegisterDeviceEventEXT RegisterDeviceEventEXT;
+  PFN_vkRegisterDisplayEventEXT RegisterDisplayEventEXT;
+  PFN_vkGetSwapchainCounterEXT GetSwapchainCounterEXT;
+
+  // ---- VK_GOOGLE_display_timing extension commands
+  PFN_vkGetRefreshCycleDurationGOOGLE GetRefreshCycleDurationGOOGLE;
+  PFN_vkGetPastPresentationTimingGOOGLE GetPastPresentationTimingGOOGLE;
+
+  // ---- VK_EXT_discard_rectangles extension commands
+  PFN_vkCmdSetDiscardRectangleEXT CmdSetDiscardRectangleEXT;
+
+  // ---- VK_EXT_hdr_metadata extension commands
+  PFN_vkSetHdrMetadataEXT SetHdrMetadataEXT;
+
+  // ---- VK_EXT_debug_utils extension commands
+  PFN_vkSetDebugUtilsObjectNameEXT SetDebugUtilsObjectNameEXT;
+  PFN_vkSetDebugUtilsObjectTagEXT SetDebugUtilsObjectTagEXT;
+  PFN_vkQueueBeginDebugUtilsLabelEXT QueueBeginDebugUtilsLabelEXT;
+  PFN_vkQueueEndDebugUtilsLabelEXT QueueEndDebugUtilsLabelEXT;
+  PFN_vkQueueInsertDebugUtilsLabelEXT QueueInsertDebugUtilsLabelEXT;
+  PFN_vkCmdBeginDebugUtilsLabelEXT CmdBeginDebugUtilsLabelEXT;
+  PFN_vkCmdEndDebugUtilsLabelEXT CmdEndDebugUtilsLabelEXT;
+  PFN_vkCmdInsertDebugUtilsLabelEXT CmdInsertDebugUtilsLabelEXT;
+
+  // ---- VK_ANDROID_external_memory_android_hardware_buffer extension commands
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+  PFN_vkGetAndroidHardwareBufferPropertiesANDROID GetAndroidHardwareBufferPropertiesANDROID;
+#endif  // VK_USE_PLATFORM_ANDROID_KHR
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+  PFN_vkGetMemoryAndroidHardwareBufferANDROID GetMemoryAndroidHardwareBufferANDROID;
+#endif  // VK_USE_PLATFORM_ANDROID_KHR
+
+  // ---- VK_EXT_sample_locations extension commands
+  PFN_vkCmdSetSampleLocationsEXT CmdSetSampleLocationsEXT;
+
+  // ---- VK_EXT_image_drm_format_modifier extension commands
+  PFN_vkGetImageDrmFormatModifierPropertiesEXT GetImageDrmFormatModifierPropertiesEXT;
+
+  // ---- VK_EXT_validation_cache extension commands
+  PFN_vkCreateValidationCacheEXT CreateValidationCacheEXT;
+  PFN_vkDestroyValidationCacheEXT DestroyValidationCacheEXT;
+  PFN_vkMergeValidationCachesEXT MergeValidationCachesEXT;
+  PFN_vkGetValidationCacheDataEXT GetValidationCacheDataEXT;
+
+  // ---- VK_NV_shading_rate_image extension commands
+  PFN_vkCmdBindShadingRateImageNV CmdBindShadingRateImageNV;
+  PFN_vkCmdSetViewportShadingRatePaletteNV CmdSetViewportShadingRatePaletteNV;
+  PFN_vkCmdSetCoarseSampleOrderNV CmdSetCoarseSampleOrderNV;
+
+  // ---- VK_NV_ray_tracing extension commands
+  PFN_vkCreateAccelerationStructureNV CreateAccelerationStructureNV;
+  PFN_vkDestroyAccelerationStructureNV DestroyAccelerationStructureNV;
+  PFN_vkGetAccelerationStructureMemoryRequirementsNV GetAccelerationStructureMemoryRequirementsNV;
+  PFN_vkBindAccelerationStructureMemoryNV BindAccelerationStructureMemoryNV;
+  PFN_vkCmdBuildAccelerationStructureNV CmdBuildAccelerationStructureNV;
+  PFN_vkCmdCopyAccelerationStructureNV CmdCopyAccelerationStructureNV;
+  PFN_vkCmdTraceRaysNV CmdTraceRaysNV;
+  PFN_vkCreateRayTracingPipelinesNV CreateRayTracingPipelinesNV;
+  PFN_vkGetRayTracingShaderGroupHandlesNV GetRayTracingShaderGroupHandlesNV;
+  PFN_vkGetAccelerationStructureHandleNV GetAccelerationStructureHandleNV;
+  PFN_vkCmdWriteAccelerationStructuresPropertiesNV CmdWriteAccelerationStructuresPropertiesNV;
+  PFN_vkCompileDeferredNV CompileDeferredNV;
+
+  // ---- VK_EXT_external_memory_host extension commands
+  PFN_vkGetMemoryHostPointerPropertiesEXT GetMemoryHostPointerPropertiesEXT;
+
+  // ---- VK_AMD_buffer_marker extension commands
+  PFN_vkCmdWriteBufferMarkerAMD CmdWriteBufferMarkerAMD;
+
+  // ---- VK_EXT_calibrated_timestamps extension commands
+  PFN_vkGetCalibratedTimestampsEXT GetCalibratedTimestampsEXT;
+
+  // ---- VK_NV_mesh_shader extension commands
+  PFN_vkCmdDrawMeshTasksNV CmdDrawMeshTasksNV;
+  PFN_vkCmdDrawMeshTasksIndirectNV CmdDrawMeshTasksIndirectNV;
+  PFN_vkCmdDrawMeshTasksIndirectCountNV CmdDrawMeshTasksIndirectCountNV;
+
+  // ---- VK_NV_scissor_exclusive extension commands
+  PFN_vkCmdSetExclusiveScissorNV CmdSetExclusiveScissorNV;
+
+  // ---- VK_NV_device_diagnostic_checkpoints extension commands
+  PFN_vkCmdSetCheckpointNV CmdSetCheckpointNV;
+  PFN_vkGetQueueCheckpointDataNV GetQueueCheckpointDataNV;
+
+  // ---- VK_INTEL_performance_query extension commands
+  PFN_vkInitializePerformanceApiINTEL InitializePerformanceApiINTEL;
+  PFN_vkUninitializePerformanceApiINTEL UninitializePerformanceApiINTEL;
+  PFN_vkCmdSetPerformanceMarkerINTEL CmdSetPerformanceMarkerINTEL;
+  PFN_vkCmdSetPerformanceStreamMarkerINTEL CmdSetPerformanceStreamMarkerINTEL;
+  PFN_vkCmdSetPerformanceOverrideINTEL CmdSetPerformanceOverrideINTEL;
+  PFN_vkAcquirePerformanceConfigurationINTEL AcquirePerformanceConfigurationINTEL;
+  PFN_vkReleasePerformanceConfigurationINTEL ReleasePerformanceConfigurationINTEL;
+  PFN_vkQueueSetPerformanceConfigurationINTEL QueueSetPerformanceConfigurationINTEL;
+  PFN_vkGetPerformanceParameterINTEL GetPerformanceParameterINTEL;
+
+  // ---- VK_AMD_display_native_hdr extension commands
+  PFN_vkSetLocalDimmingAMD SetLocalDimmingAMD;
+
+  // ---- VK_EXT_buffer_device_address extension commands
+  PFN_vkGetBufferDeviceAddressEXT GetBufferDeviceAddressEXT;
+
+  // ---- VK_EXT_full_screen_exclusive extension commands
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+  PFN_vkAcquireFullScreenExclusiveModeEXT AcquireFullScreenExclusiveModeEXT;
+#endif  // VK_USE_PLATFORM_WIN32_KHR
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+  PFN_vkReleaseFullScreenExclusiveModeEXT ReleaseFullScreenExclusiveModeEXT;
+#endif  // VK_USE_PLATFORM_WIN32_KHR
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+  PFN_vkGetDeviceGroupSurfacePresentModes2EXT GetDeviceGroupSurfacePresentModes2EXT;
+#endif  // VK_USE_PLATFORM_WIN32_KHR
+
+  // ---- VK_EXT_host_query_reset extension commands
+  PFN_vkResetQueryPoolEXT ResetQueryPoolEXT;
+} VkLayerDispatchTable;


### PR DESCRIPTION
This adds the "vulkan-headers/1.1.77.0" requirement to the Linux
build.
Afterwards, gen_lockfile.sh was run and and the changed hashes
of existing entries were reset.

In order to run the gen_lockfile.sh, conan needed to be upgraded.