### PR TITLE
Offer command line option to clear source paths mappings

### DIFF
--- a/src/SourcePathsMapping/MappingManagerTest.cpp
+++ b/src/SourcePathsMapping/MappingManagerTest.cpp
@@ -43,7 +43,7 @@ TEST(MappingManager, Append) {
   EXPECT_EQ(manager.GetMappings(), mappings);
 }
 
-TEST(MappingManager, SaveAndLoad) {
+TEST(MappingManager, SaveLoadAndClear) {
   QCoreApplication::setOrganizationName(kOrgName);
   QCoreApplication::setApplicationName("MappingManager.SaveAndLoad");
 
@@ -56,6 +56,12 @@ TEST(MappingManager, SaveAndLoad) {
   {
     MappingManager manager{};
     EXPECT_EQ(manager.GetMappings(), mappings);
+    manager.SetMappings({});
+  }
+
+  {
+    MappingManager manager{};
+    EXPECT_TRUE(manager.GetMappings().empty());
   }
 }
 }  // namespace orbit_source_paths_mapping


### PR DESCRIPTION
This is a prerequisite to fix the failing E2E test. It fails because a source paths mapping already exists, while test expects an error message to pop up.

The solution: We clear all existing source paths mappings prior to starting Orbit. This could be done by directly deleting keys from the registry, but the nicer solution is in this PR: Let Orbit offer a command line option to clear this setting which means we don't have to worry in the E2E tests how and where the mappings are persisted.