### PR TITLE
Make Disassembly and SourceCode view non-modal

### DIFF
--- a/src/CodeViewer/CMakeLists.txt
+++ b/src/CodeViewer/CMakeLists.txt
@@ -13,12 +13,14 @@ target_link_libraries(CodeViewer PUBLIC OrbitBase OrbitGl Qt5::Widgets)
 
 target_sources(CodeViewer PUBLIC include/CodeViewer/Dialog.h
                                  include/CodeViewer/FontSizeInEm.h
+                                 include/CodeViewer/OwningDialog.h
                                  include/CodeViewer/Viewer.h
                                  include/CodeViewer/PlaceHolderWidget.h)
 
 target_sources(CodeViewer PRIVATE Dialog.cpp 
                                   Dialog.ui
                                   FontSizeInEm.cpp
+                                  OwningDialog.cpp
                                   PlaceHolderWidget.cpp
                                   Viewer.cpp)
 

--- a/src/CodeViewer/OwningDialog.cpp
+++ b/src/CodeViewer/OwningDialog.cpp
@@ -1,0 +1,35 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "CodeViewer/OwningDialog.h"
+
+#include <variant>
+
+namespace orbit_code_viewer {
+
+OwningDialog::~OwningDialog() noexcept {
+  // `code_report_` is deleted before the base class is deleted, so we have to clear the code report
+  // pointer from the base class first.
+  ClearHeatmap();
+}
+
+void OwningDialog::SetOwningHeatmap(FontSizeInEm heatmap_bar_width,
+                                    std::unique_ptr<CodeReport> code_report) {
+  ClearHeatmap();
+  code_report_ = std::move(code_report);
+  SetHeatmap(heatmap_bar_width, code_report_.get());
+}
+
+void OwningDialog::ClearOwningHeatmap() {
+  ClearHeatmap();
+  code_report_.reset();
+}
+
+void OpenAndDeleteOnClose(std::unique_ptr<OwningDialog> dialog) {
+  dialog->open();
+  dialog->setAttribute(Qt::WA_DeleteOnClose);
+  (void)dialog.release();
+}
+
+}  // namespace orbit_code_viewer

--- a/src/CodeViewer/include/CodeViewer/OwningDialog.h
+++ b/src/CodeViewer/include/CodeViewer/OwningDialog.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CODE_VIEWER_OWNING_DIALOG_H_
+#define CODE_VIEWER_OWNING_DIALOG_H_
+
+#include <memory>
+#include <optional>
+#include <variant>
+
+#include "CodeReport.h"
+#include "CodeViewer/Dialog.h"
+#include "CodeViewer/FontSizeInEm.h"
+
+namespace orbit_code_viewer {
+
+/*
+  This owning version of `Dialog` is meant to be "self-sustaining",
+  meaning it owns all the resources needed.
+
+  It is meant to be used in conjunction with `OpenAndDeleteOnClose`, example:
+
+  auto dialog = std::make_unique<orbit_code_viewer::OwningDialog>();
+  dialog->SetSourceCode(...);
+  dialog->SetOwningHeatmap(kSidebarWidth, std::move(disassembly_report));
+  orbit_code_viewer::OpenAndDeleteOnClose(std::move(dialog));
+*/
+class OwningDialog : public Dialog {
+  Q_OBJECT
+
+ public:
+  using Dialog::Dialog;
+  ~OwningDialog() noexcept override;
+
+  void SetOwningHeatmap(FontSizeInEm heatmap_bar_width, std::unique_ptr<CodeReport> code_report);
+  void ClearOwningHeatmap();
+
+ private:
+  std::unique_ptr<CodeReport> code_report_;
+};
+
+// This function opens the given dialog and ensures it is deleted when closed.
+// Note, this function returns immediately after opening the dialog, NOT when it is closed. Use
+// `QDialog::exec` to wait for the dialog.
+void OpenAndDeleteOnClose(std::unique_ptr<OwningDialog> dialog);
+}  // namespace orbit_code_viewer
+
+#endif  // CODE_VIEWER_OWNING_DIALOG_H_

--- a/src/OrbitGl/DisassemblyReport.h
+++ b/src/OrbitGl/DisassemblyReport.h
@@ -32,10 +32,10 @@ class DisassemblyReport : public CodeReport {
   [[nodiscard]] std::optional<uint32_t> GetNumSamplesAtLine(size_t line) const override;
 
  private:
-  const Disassembler disasm_;
-  const std::optional<PostProcessedSamplingData> post_processed_sampling_data_;
-  const uint32_t function_count_;
-  const uint32_t samples_count_;
+  Disassembler disasm_;
+  std::optional<PostProcessedSamplingData> post_processed_sampling_data_;
+  uint32_t function_count_;
+  uint32_t samples_count_;
 };
 
 #endif  // ORBIT_GL_DISASSEMBLY_REPORT_H_


### PR DESCRIPTION
As requested by users, the code views should be non-modal such that the user can interact with Orbit while one or multiple code views are open in the background or on a different screen.

To make this happen, the code viewer dialog needs to own all its required resources. And it needs to delete itself when the dialog is closed.

The former is solved by introducing `orbit_code_viewer::OwningDialog`, a variant of `orbit_code_viewer::Dialog` that owns all its resources.

The latter can solved by Qt which offers the attribute `Qt::WA_DeleteOnClose` for a classes inheriting from `QWidget`. To make this somehow safe to handle, I introduced a free function `OpenAndDeleteOnClose`. It takes a unique pointer to an OwningDialog by value. It will open the dialog, ensure it will be deleted on close, and will release the unique pointer.