### PR TITLE
Add missing entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,18 @@
 build*/
 /.idea/
 /cmake-build*/
-.clangd/
 compile_commands.json
-corpora/
 /.vscode/
-__pycache__
 /conan.log
 
 # Ignore generated Python code
 *_pb2.py
 *.egg-info
+__pycache__
+
+# clangd
+.clangd/
+/.cache/
+
+# Visual Studio
+/.vs/

--- a/contrib/automation_tests/.gitignore
+++ b/contrib/automation_tests/.gitignore
@@ -1,0 +1,4 @@
+# Ignore common names of virtual environments
+.env
+env
+venv


### PR DESCRIPTION
The E2E tests require a virtual environment. So let's ignore that.

Furthermore Visual Studio creates a directory .vs/ with user settings
which we should ignore.

clangd creates a folder .cache/ when started with the background index
option. Its contents is not relevant for git as well.