### PR TITLE
Compare FunctionInfo by address and module_path

### DIFF
--- a/src/OrbitClientData/FunctionInfoSetTest.cpp
+++ b/src/OrbitClientData/FunctionInfoSetTest.cpp
@@ -52,7 +52,7 @@ TEST(FunctionInfoSet, DifferentName) {
   right.set_name("bar");
 
   internal::EqualFunctionInfo eq;
-  EXPECT_FALSE(eq(left, right));
+  EXPECT_TRUE(eq(left, right));
 }
 
 TEST(FunctionInfoSet, DifferentPrettyName) {
@@ -70,7 +70,7 @@ TEST(FunctionInfoSet, DifferentPrettyName) {
   right.set_pretty_name("void bar()");
 
   internal::EqualFunctionInfo eq;
-  EXPECT_FALSE(eq(left, right));
+  EXPECT_TRUE(eq(left, right));
 }
 
 TEST(FunctionInfoSet, DifferentLoadedModulePath) {
@@ -124,7 +124,7 @@ TEST(FunctionInfoSet, DifferentSize) {
   right.set_size(15);
 
   internal::EqualFunctionInfo eq;
-  EXPECT_FALSE(eq(left, right));
+  EXPECT_TRUE(eq(left, right));
 }
 
 TEST(FunctionInfoSet, DifferentFile) {
@@ -142,7 +142,7 @@ TEST(FunctionInfoSet, DifferentFile) {
   right.set_file("other.cpp");
 
   internal::EqualFunctionInfo eq;
-  EXPECT_FALSE(eq(left, right));
+  EXPECT_TRUE(eq(left, right));
 }
 
 TEST(FunctionInfoSet, DifferentLine) {
@@ -160,7 +160,7 @@ TEST(FunctionInfoSet, DifferentLine) {
   right.set_line(12);
 
   internal::EqualFunctionInfo eq;
-  EXPECT_FALSE(eq(left, right));
+  EXPECT_TRUE(eq(left, right));
 }
 
 TEST(FunctionInfoSet, Insertion) {

--- a/src/OrbitClientData/include/OrbitClientData/FunctionInfoSet.h
+++ b/src/OrbitClientData/include/OrbitClientData/FunctionInfoSet.h
@@ -12,18 +12,17 @@
 namespace internal {
 struct HashFunctionInfo {
   size_t operator()(const orbit_client_protos::FunctionInfo& function) const {
-    return std::hash<uint64_t>{}(function.address()) * 37 + std::hash<uint64_t>{}(function.size());
+    return std::hash<uint64_t>{}(function.address()) * 37 +
+           std::hash<std::string>{}(function.loaded_module_path());
   }
 };
 
+// Compare functions by module path and address
 struct EqualFunctionInfo {
   bool operator()(const orbit_client_protos::FunctionInfo& left,
                   const orbit_client_protos::FunctionInfo& right) const {
-    return left.size() == right.size() && left.name() == right.name() &&
-           left.pretty_name() == right.pretty_name() &&
-           left.loaded_module_path() == right.loaded_module_path() &&
-           left.address() == right.address() && left.file().compare(right.file()) == 0 &&
-           left.line() == right.line();
+    return left.loaded_module_path() == right.loaded_module_path() &&
+           left.address() == right.address();
   }
 };
 


### PR DESCRIPTION
We are going to end up in the situation where function_info is not fully
populated for instrumented function when loading capture from current file version.

This is done to preserve compatibility until flip a switch to new
capture format.

Test: run OrbitClientDataTests