### PR TITLE
Add timeline visualization for the memory information

### DIFF
--- a/src/ClientProtos/capture_data.proto
+++ b/src/ClientProtos/capture_data.proto
@@ -152,6 +152,7 @@ message TimerInfo {
     kGpuCommandBuffer = 5;
     kGpuDebugMarker = 6;
     kApiEvent = 7;
+    kSystemMemoryUsage = 8;
   }
   Type type = 6;
 

--- a/src/OrbitCaptureClient/ApiEventProcessorTest.cpp
+++ b/src/OrbitCaptureClient/ApiEventProcessorTest.cpp
@@ -28,6 +28,7 @@ class EmptyCaptureListener : public CaptureListener {
                         absl::flat_hash_map<uint64_t, orbit_grpc_protos::InstrumentedFunction>,
                         TracepointInfoSet, absl::flat_hash_set<uint64_t>) override {}
   void OnTimer(const orbit_client_protos::TimerInfo&) override {}
+  void OnSystemMemoryUsage(const orbit_grpc_protos::SystemMemoryUsage&) override {}
   void OnKeyAndString(uint64_t, std::string) override {}
   void OnUniqueCallStack(CallStack) override {}
   void OnCallstackEvent(orbit_client_protos::CallstackEvent) override {}

--- a/src/OrbitCaptureClient/CaptureEventProcessor.cpp
+++ b/src/OrbitCaptureClient/CaptureEventProcessor.cpp
@@ -80,7 +80,7 @@ void CaptureEventProcessor::ProcessEvent(const ClientCaptureEvent& event) {
       // TODO (http://b/168797897): Process module update events
       break;
     case ClientCaptureEvent::kSystemMemoryUsage:
-      // TODO (http://b/179000848): Process the system memory usage information.
+      ProcessSystemMemoryUsage(event.system_memory_usage());
       break;
     case ClientCaptureEvent::kApiEvent: {
       api_event_processor_.ProcessApiEvent(event.api_event());
@@ -256,6 +256,11 @@ void CaptureEventProcessor::ProcessGpuQueueSubmission(
   for (const TimerInfo& timer : vulkan_related_timers) {
     capture_listener_->OnTimer(timer);
   }
+}
+
+void CaptureEventProcessor::ProcessSystemMemoryUsage(
+    const orbit_grpc_protos::SystemMemoryUsage& system_memory_usage) {
+  capture_listener_->OnSystemMemoryUsage(system_memory_usage);
 }
 
 void CaptureEventProcessor::ProcessThreadName(const ThreadName& thread_name) {

--- a/src/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/src/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -16,6 +16,7 @@
 #include "OrbitClientData/TracepointCustom.h"
 #include "OrbitClientData/UserDefinedCaptureData.h"
 #include "absl/flags/flag.h"
+#include "capture.pb.h"
 #include "capture_data.pb.h"
 #include "services.pb.h"
 #include "tracepoint.pb.h"
@@ -39,6 +40,7 @@ class MyCaptureListener : public CaptureListener {
       TracepointInfoSet /*selected_tracepoints*/,
       absl::flat_hash_set<uint64_t> /*frame_track_function_ids*/) override {}
   void OnTimer(const TimerInfo&) override {}
+  void OnSystemMemoryUsage(const orbit_grpc_protos::SystemMemoryUsage&) override {}
   void OnKeyAndString(uint64_t, std::string) override {}
   void OnUniqueCallStack(CallStack) override {}
   void OnCallstackEvent(CallstackEvent) override {}

--- a/src/OrbitCaptureClient/CaptureEventProcessorTest.cpp
+++ b/src/OrbitCaptureClient/CaptureEventProcessorTest.cpp
@@ -50,6 +50,7 @@ using orbit_grpc_protos::InternedString;
 using orbit_grpc_protos::InternedTracepointInfo;
 using orbit_grpc_protos::IntrospectionScope;
 using orbit_grpc_protos::SchedulingSlice;
+using orbit_grpc_protos::SystemMemoryUsage;
 using orbit_grpc_protos::ThreadName;
 using orbit_grpc_protos::ThreadStateSlice;
 using orbit_grpc_protos::TracepointEvent;
@@ -71,6 +72,7 @@ class MockCaptureListener : public CaptureListener {
                absl::flat_hash_set<uint64_t> /*frame_track_function_ids*/),
               (override));
   MOCK_METHOD(void, OnTimer, (const TimerInfo&), (override));
+  MOCK_METHOD(void, OnSystemMemoryUsage, (const SystemMemoryUsage&), (override));
   MOCK_METHOD(void, OnKeyAndString, (uint64_t /*key*/, std::string), (override));
   MOCK_METHOD(void, OnUniqueCallStack, (CallStack), (override));
   MOCK_METHOD(void, OnCallstackEvent, (CallstackEvent), (override));

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
@@ -46,7 +46,8 @@ class CaptureClient {
       TracepointInfoSet selected_tracepoints,
       absl::flat_hash_set<uint64_t> frame_track_function_ids, double samples_per_second,
       orbit_grpc_protos::UnwindingMethod unwinding_method, bool collect_thread_state,
-      bool enable_introspection, uint64_t max_local_marker_depth_per_command_buffer);
+      bool enable_introspection, uint64_t max_local_marker_depth_per_command_buffer,
+      bool collect_memory_info = false, uint64_t memory_sampling_period_ns = 0);
 
   // Returns true if stop was initiated and false otherwise.
   // The latter can happen if for example the stop was already
@@ -75,7 +76,8 @@ class CaptureClient {
       TracepointInfoSet selected_tracepoints,
       absl::flat_hash_set<uint64_t> frame_track_function_ids, double samples_per_second,
       orbit_grpc_protos::UnwindingMethod unwinding_method, bool collect_thread_state,
-      bool enable_introspection, uint64_t max_local_marker_depth_per_command_buffer);
+      bool enable_introspection, uint64_t max_local_marker_depth_per_command_buffer,
+      bool collect_memory_info, uint64_t memory_sampling_period_ns);
 
   [[nodiscard]] ErrorMessageOr<void> FinishCapture();
 

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
@@ -47,6 +47,7 @@ class CaptureEventProcessor {
       orbit_grpc_protos::InternedTracepointInfo interned_tracepoint_info);
   void ProcessTracepointEvent(const orbit_grpc_protos::TracepointEvent& tracepoint_event);
   void ProcessGpuQueueSubmission(const orbit_grpc_protos::GpuQueueSubmission& gpu_command_buffer);
+  void ProcessSystemMemoryUsage(const orbit_grpc_protos::SystemMemoryUsage& system_memory_usage);
 
   absl::flat_hash_map<uint64_t, orbit_grpc_protos::Callstack> callstack_intern_pool;
   absl::flat_hash_map<uint64_t, std::string> string_intern_pool_;

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
@@ -28,6 +28,8 @@ class CaptureListener {
       absl::flat_hash_set<uint64_t> frame_track_function_ids) = 0;
 
   virtual void OnTimer(const orbit_client_protos::TimerInfo& timer_info) = 0;
+  virtual void OnSystemMemoryUsage(
+      const orbit_grpc_protos::SystemMemoryUsage& system_memory_usage) = 0;
   virtual void OnKeyAndString(uint64_t key, std::string str) = 0;
   virtual void OnUniqueCallStack(CallStack callstack) = 0;
   virtual void OnCallstackEvent(orbit_client_protos::CallstackEvent callstack_event) = 0;

--- a/src/OrbitClientGgp/include/OrbitClientGgp/ClientGgp.h
+++ b/src/OrbitClientGgp/include/OrbitClientGgp/ClientGgp.h
@@ -30,6 +30,7 @@
 #include "OrbitClientModel/CaptureData.h"
 #include "OrbitClientServices/ProcessClient.h"
 #include "StringManager.h"
+#include "capture.pb.h"
 #include "capture_data.pb.h"
 #include "grpcpp/grpcpp.h"
 #include "tracepoint.pb.h"
@@ -54,6 +55,8 @@ class ClientGgp final : public CaptureListener {
       TracepointInfoSet selected_tracepoints,
       absl::flat_hash_set<uint64_t> frame_track_function_ids) override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
+  void OnSystemMemoryUsage(
+      const orbit_grpc_protos::SystemMemoryUsage& /*system_memory_usage*/) override {}
   void OnKeyAndString(uint64_t key, std::string str) override;
   void OnUniqueCallStack(CallStack callstack) override;
   void OnCallstackEvent(orbit_client_protos::CallstackEvent callstack_event) override;

--- a/src/OrbitClientModel/CaptureDeserializerLoadFuzzer.cpp
+++ b/src/OrbitClientModel/CaptureDeserializerLoadFuzzer.cpp
@@ -26,6 +26,7 @@ class MockCaptureListener : public CaptureListener {
                         TracepointInfoSet, absl::flat_hash_set<uint64_t>) override {}
 
   void OnTimer(const orbit_client_protos::TimerInfo&) override {}
+  void OnSystemMemoryUsage(const orbit_grpc_protos::SystemMemoryUsage&) override {}
   void OnKeyAndString(uint64_t, std::string) override {}
   void OnUniqueCallStack(CallStack) override {}
   void OnCallstackEvent(orbit_client_protos::CallstackEvent) override {}

--- a/src/OrbitClientModel/CaptureDeserializerTest.cpp
+++ b/src/OrbitClientModel/CaptureDeserializerTest.cpp
@@ -47,6 +47,7 @@ using orbit_client_protos::ThreadStateSliceInfo;
 using orbit_client_protos::TimerInfo;
 using orbit_client_protos::TracepointEventInfo;
 using orbit_grpc_protos::InstrumentedFunction;
+using orbit_grpc_protos::SystemMemoryUsage;
 using orbit_grpc_protos::TracepointInfo;
 
 using ::testing::_;
@@ -71,6 +72,7 @@ class MockCaptureListener : public CaptureListener {
                absl::flat_hash_set<uint64_t> /*frame_track_function_ids*/),
               (override));
   MOCK_METHOD(void, OnTimer, (const TimerInfo&), (override));
+  MOCK_METHOD(void, OnSystemMemoryUsage, (const SystemMemoryUsage&), (override));
   MOCK_METHOD(void, OnKeyAndString, (uint64_t /*key*/, std::string), (override));
   MOCK_METHOD(void, OnUniqueCallStack, (CallStack), (override));
   MOCK_METHOD(void, OnCallstackEvent, (CallstackEvent), (override));

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -967,12 +967,15 @@ void OrbitApp::StartCapture() {
   uint64_t max_local_marker_depth_per_command_buffer =
       data_manager_->max_local_marker_depth_per_command_buffer();
 
+  bool collect_memory_info = data_manager_->collect_memory_info();
+  uint64_t memory_sampling_period_ns = data_manager_->memory_sampling_period_ns();
+
   CHECK(capture_client_ != nullptr);
   Future<ErrorMessageOr<CaptureOutcome>> capture_result = capture_client_->Capture(
       thread_pool_.get(), *process, *module_manager_, std::move(selected_functions_map),
       std::move(selected_tracepoints), std::move(frame_track_function_ids), samples_per_second,
       unwinding_method, collect_thread_states, enable_introspection,
-      max_local_marker_depth_per_command_buffer);
+      max_local_marker_depth_per_command_buffer, collect_memory_info, memory_sampling_period_ns);
 
   capture_result.Then(main_thread_executor_, [this](ErrorMessageOr<CaptureOutcome> capture_result) {
     if (capture_result.has_error()) {

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -284,6 +284,32 @@ void OrbitApp::OnTimer(const TimerInfo& timer_info) {
   frame_track_online_processor_.ProcessTimer(timer_info, func);
 }
 
+void OrbitApp::OnSystemMemoryUsage(
+    const orbit_grpc_protos::SystemMemoryUsage& system_memory_usage) {
+  TimerInfo timer_info;
+  timer_info.set_type(TimerInfo::kSystemMemoryUsage);
+  timer_info.set_start(system_memory_usage.timestamp_ns());
+  timer_info.set_end(system_memory_usage.timestamp_ns());
+
+  constexpr size_t kNumOfEncodedValues = 5;
+  timer_info.mutable_registers()->Reserve(kNumOfEncodedValues);
+  timer_info.mutable_registers()->Set(static_cast<size_t>(SystemMemoryUsageEncodingIndex::kTotalKb),
+                                      orbit_api::Encode<uint64_t>(system_memory_usage.total_kb()));
+  timer_info.mutable_registers()->Set(static_cast<size_t>(SystemMemoryUsageEncodingIndex::kFreeKb),
+                                      orbit_api::Encode<uint64_t>(system_memory_usage.free_kb()));
+  timer_info.mutable_registers()->Set(
+      static_cast<size_t>(SystemMemoryUsageEncodingIndex::kAvailableKb),
+      orbit_api::Encode<uint64_t>(system_memory_usage.available_kb()));
+  timer_info.mutable_registers()->Set(
+      static_cast<size_t>(SystemMemoryUsageEncodingIndex::kBuffersKb),
+      orbit_api::Encode<uint64_t>(system_memory_usage.buffers_kb()));
+  timer_info.mutable_registers()->Set(
+      static_cast<size_t>(SystemMemoryUsageEncodingIndex::kCachedKb),
+      orbit_api::Encode<uint64_t>(system_memory_usage.cached_kb()));
+
+  GetMutableTimeGraph()->ProcessTimer(timer_info, nullptr);
+}
+
 void OrbitApp::OnKeyAndString(uint64_t key, std::string str) {
   string_manager_.AddIfNotPresent(key, std::move(str));
 }

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -367,6 +367,20 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void SetUnwindingMethod(orbit_grpc_protos::UnwindingMethod unwinding_method);
   void SetMaxLocalMarkerDepthPerCommandBuffer(uint64_t max_local_marker_depth_per_command_buffer);
 
+  void SetCollectMemoryInfo(bool collect_memory_info) {
+    data_manager_->set_collect_memory_info(collect_memory_info);
+  }
+  [[nodiscard]] bool GetCollectMemoryInfo() const { return data_manager_->collect_memory_info(); }
+  void SetMemorySamplingPeriodNs(uint64_t memory_sampling_period_ns) {
+    data_manager_->set_memory_sampling_period_ns(memory_sampling_period_ns);
+  }
+  void SetMemoryWarningThresholdKb(uint64_t memory_warning_threshold_kb) {
+    data_manager_->set_memory_warning_threshold_kb(memory_warning_threshold_kb);
+  }
+  [[nodiscard]] uint64_t GetMemoryWarningThresholdKb() const {
+    return data_manager_->memory_warning_threshold_kb();
+  }
+
   // TODO(kuebler): Move them to a separate controler at some point
   void SelectFunction(const orbit_client_protos::FunctionInfo& func);
   void DeselectFunction(const orbit_client_protos::FunctionInfo& func);

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -71,6 +71,7 @@
 #include "SymbolHelper.h"
 #include "TextBox.h"
 #include "TracepointsDataView.h"
+#include "capture.pb.h"
 #include "capture_data.pb.h"
 #include "preset.pb.h"
 #include "services.pb.h"
@@ -146,6 +147,16 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void OnUniqueTracepointInfo(uint64_t key,
                               orbit_grpc_protos::TracepointInfo tracepoint_info) override;
   void OnTracepointEvent(orbit_client_protos::TracepointEventInfo tracepoint_event_info) override;
+
+  enum class SystemMemoryUsageEncodingIndex {
+    kTotalKb,
+    kFreeKb,
+    kAvailableKb,
+    kBuffersKb,
+    kCachedKb
+  };
+  void OnSystemMemoryUsage(
+      const orbit_grpc_protos::SystemMemoryUsage& system_memory_usage) override;
 
   void OnValidateFramePointers(std::vector<const ModuleData*> modules_to_validate);
 

--- a/src/OrbitGl/DataManager.h
+++ b/src/OrbitGl/DataManager.h
@@ -91,6 +91,23 @@ class DataManager final {
     return max_local_marker_depth_per_command_buffer_;
   }
 
+  void set_collect_memory_info(bool collect_memory_info) {
+    collect_memory_info_ = collect_memory_info;
+  }
+  [[nodiscard]] bool collect_memory_info() const { return collect_memory_info_; }
+
+  void set_memory_sampling_period_ns(uint64_t memory_sampling_period_ns) {
+    memory_sampling_period_ns_ = memory_sampling_period_ns;
+  }
+  [[nodiscard]] uint64_t memory_sampling_period_ns() const { return memory_sampling_period_ns_; }
+
+  void set_memory_warning_threshold_kb(uint64_t memory_warning_threshold_kb) {
+    memory_warning_threshold_kb_ = memory_warning_threshold_kb;
+  }
+  [[nodiscard]] uint64_t memory_warning_threshold_kb() const {
+    return memory_warning_threshold_kb_;
+  }
+
  private:
   const std::thread::id main_thread_id_;
   FunctionInfoSet selected_functions_;
@@ -110,6 +127,10 @@ class DataManager final {
   uint64_t max_local_marker_depth_per_command_buffer_ = std::numeric_limits<uint64_t>::max();
   double samples_per_second_ = 0;
   orbit_grpc_protos::UnwindingMethod unwinding_method_{};
+
+  bool collect_memory_info_ = false;
+  uint64_t memory_sampling_period_ns_ = 100'000'000;
+  uint64_t memory_warning_threshold_kb_ = 1024 * 1024 * 8;
 };
 
 #endif  // ORBIT_GL_DATA_MANAGER_H_

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -230,23 +230,26 @@ float GraphTrack::GetHeight() const {
   return height;
 }
 
-void GraphTrack::SetWarningThresholdWhenEmpty(
-    const std::optional<std::pair<std::string, double>>& warning_threshold) {
-  if (warning_threshold_.has_value() || !warning_threshold.has_value()) return;
-  warning_threshold_ = warning_threshold;
-  UpdateMinAndMax(warning_threshold_.value().second);
+void GraphTrack::SetWarningThresholdWhenEmpty(const std::string& pretty_label, double raw_value) {
+  if (warning_threshold_.has_value()) return;
+  warning_threshold_ = std::make_pair(pretty_label, raw_value);
+  UpdateMinAndMax(raw_value);
 }
 
-void GraphTrack::SetValueUpperBoundWhenEmpty(
-    const std::optional<std::pair<std::string, double>>& value_upper_bound) {
-  if (value_upper_bound_.has_value() || !value_upper_bound.has_value()) return;
-  value_upper_bound_ = value_upper_bound;
-  UpdateMinAndMax(value_upper_bound_.value().second);
+void GraphTrack::SetValueUpperBoundWhenEmpty(const std::string& pretty_label, double raw_value) {
+  if (value_upper_bound_.has_value()) return;
+  value_upper_bound_ = std::make_pair(pretty_label, raw_value);
+  UpdateMinAndMax(raw_value);
 }
-void GraphTrack::SetValueLowerBoundWhenEmpty(
-    const std::optional<std::pair<std::string, double>>& value_lower_bound) {
-  value_lower_bound_ = value_lower_bound;
-  UpdateMinAndMax(value_lower_bound_.value().second);
+void GraphTrack::SetValueLowerBoundWhenEmpty(const std::string& pretty_label, double raw_value) {
+  if (value_lower_bound_.has_value()) return;
+  value_lower_bound_ = std::make_pair(pretty_label, raw_value);
+  UpdateMinAndMax(raw_value);
+}
+
+void GraphTrack::SetLabelUnitWhenEmpty(const std::string& label_unit) {
+  if (!label_unit_.empty()) return;
+  label_unit_ = label_unit;
 }
 
 void GraphTrack::SetValueDecimalDigitsWhenEmpty(uint8_t value_decimal_digits) {

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -131,6 +131,20 @@ void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset
                      kThresholdColor);
     batcher->AddLine(Vec2(text_box_position[0] + text_box_size[0], y), to, text_z, kThresholdColor);
   }
+
+  // Add value upper bound text box (e.g., the "Memory Total" text box for the memory tracks).
+  if (value_upper_bound_.has_value()) {
+    std::string text = absl::StrFormat("%s: %f", value_upper_bound_.value().first,
+                                       value_upper_bound_.value().second);
+    uint32_t font_size = layout_->CalculateZoomedFontSize();
+    float string_width = canvas->GetTextRenderer().GetStringWidth(text.c_str(), font_size);
+    Vec2 text_box_size(string_width, layout_->GetTextBoxHeight());
+    Vec2 text_box_position(pos_[0] + size_[0] - text_box_size[0],
+                           pos_[1] - layout_->GetTextBoxHeight() / 2.f);
+    canvas->GetTextRenderer().AddText(text.c_str(), text_box_position[0],
+                                      text_box_position[1] + layout_->GetTextOffset(), text_z,
+                                      kWhite, font_size, text_box_size[0]);
+  }
 }
 
 void GraphTrack::DrawSquareDot(Batcher* batcher, Vec2 center, float radius, float z,

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -157,7 +157,11 @@ void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset
   float point_x = time_graph_->GetWorldFromTick(label_time);
   double normalized_value = (value - min_) * inv_value_range_;
   float point_y = pos_[1] - size_[1] * (1.f - static_cast<float>(normalized_value));
-  DrawLabel(canvas, Vec2(point_x, point_y), std::to_string(value), kBlack, kWhite, text_z);
+  std::string text = value_decimal_digits_.has_value()
+                         ? absl::StrFormat("%.*f", value_decimal_digits_.value(), value)
+                         : std::to_string(value);
+  absl::StrAppend(&text, label_unit_);
+  DrawLabel(canvas, Vec2(point_x, point_y), text, kBlack, kWhite, text_z);
 }
 
 void GraphTrack::DrawSquareDot(Batcher* batcher, Vec2 center, float radius, float z,
@@ -243,6 +247,11 @@ void GraphTrack::SetValueLowerBoundWhenEmpty(
     const std::optional<std::pair<std::string, double>>& value_lower_bound) {
   value_lower_bound_ = value_lower_bound;
   UpdateMinAndMax(value_lower_bound_.value().second);
+}
+
+void GraphTrack::SetValueDecimalDigitsWhenEmpty(uint8_t value_decimal_digits) {
+  if (value_decimal_digits_.has_value()) return;
+  value_decimal_digits_ = value_decimal_digits;
 }
 
 void GraphTrack::UpdateMinAndMax(double value) {

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -36,22 +36,18 @@ class GraphTrack : public Track {
   [[nodiscard]] bool IsEmpty() const override { return values_.empty(); }
 
   void SetWarningThresholdWhenEmpty(
-      const std::optional<std::pair<std::string, double>>& warning_threshold) {
-    if (warning_threshold_.has_value() || !warning_threshold.has_value()) return;
-    warning_threshold_ = warning_threshold;
-    max_ = std::max(max_, warning_threshold.value().second);
-    min_ = std::min(min_, warning_threshold.value().second);
-  }
+      const std::optional<std::pair<std::string, double>>& warning_threshold);
   void SetValueUpperBoundWhenEmpty(
-      const std::optional<std::pair<std::string, double>>& value_upper_bound) {
-    if (value_upper_bound_.has_value() || !value_upper_bound.has_value()) return;
-    value_upper_bound_ = value_upper_bound;
-  }
+      const std::optional<std::pair<std::string, double>>& value_upper_bound);
+  void SetValueLowerBoundWhenEmpty(
+      const std::optional<std::pair<std::string, double>>& value_lower_bound);
 
  protected:
   void DrawSquareDot(Batcher* batcher, Vec2 center, float radius, float z, const Color& color);
   void DrawLabel(GlCanvas* canvas, Vec2 target_pos, const std::string& text,
                  const Color& text_color, const Color& font_color, float z);
+  void UpdateMinAndMax(double value);
+
   std::map<uint64_t, double> values_;
   double min_ = std::numeric_limits<double>::max();
   double max_ = std::numeric_limits<double>::lowest();
@@ -59,6 +55,7 @@ class GraphTrack : public Track {
   double inv_value_range_ = 0;
   std::optional<std::pair<std::string, double>> warning_threshold_ = std::nullopt;
   std::optional<std::pair<std::string, double>> value_upper_bound_ = std::nullopt;
+  std::optional<std::pair<std::string, double>> value_lower_bound_ = std::nullopt;
 };
 
 #endif  // ORBIT_GL_GRAPH_TRACK_H_

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -41,6 +41,8 @@ class GraphTrack : public Track {
       const std::optional<std::pair<std::string, double>>& value_upper_bound);
   void SetValueLowerBoundWhenEmpty(
       const std::optional<std::pair<std::string, double>>& value_lower_bound);
+  void SetLabelUnit(const std::string& label_unit) { label_unit_ = label_unit; }
+  void SetValueDecimalDigitsWhenEmpty(uint8_t value_decimal_digits);
 
  protected:
   void DrawSquareDot(Batcher* batcher, Vec2 center, float radius, float z, const Color& color);
@@ -56,6 +58,8 @@ class GraphTrack : public Track {
   std::optional<std::pair<std::string, double>> warning_threshold_ = std::nullopt;
   std::optional<std::pair<std::string, double>> value_upper_bound_ = std::nullopt;
   std::optional<std::pair<std::string, double>> value_lower_bound_ = std::nullopt;
+  std::optional<uint8_t> value_decimal_digits_ = std::nullopt;
+  std::string label_unit_;
 };
 
 #endif  // ORBIT_GL_GRAPH_TRACK_H_

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -35,13 +35,10 @@ class GraphTrack : public Track {
       uint64_t time) const;
   [[nodiscard]] bool IsEmpty() const override { return values_.empty(); }
 
-  void SetWarningThresholdWhenEmpty(
-      const std::optional<std::pair<std::string, double>>& warning_threshold);
-  void SetValueUpperBoundWhenEmpty(
-      const std::optional<std::pair<std::string, double>>& value_upper_bound);
-  void SetValueLowerBoundWhenEmpty(
-      const std::optional<std::pair<std::string, double>>& value_lower_bound);
-  void SetLabelUnit(const std::string& label_unit) { label_unit_ = label_unit; }
+  void SetWarningThresholdWhenEmpty(const std::string& pretty_label, double raw_value);
+  void SetValueUpperBoundWhenEmpty(const std::string& pretty_label, double raw_value);
+  void SetValueLowerBoundWhenEmpty(const std::string& pretty_label, double raw_value);
+  void SetLabelUnitWhenEmpty(const std::string& label_unit);
   void SetValueDecimalDigitsWhenEmpty(uint8_t value_decimal_digits);
 
  protected:

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -31,9 +31,20 @@ class GraphTrack : public Track {
                         PickingMode picking_mode, float z_offset = 0) override;
   [[nodiscard]] float GetHeight() const override;
   void AddValue(double value, uint64_t time);
-  [[nodiscard]] std::optional<std::pair<uint64_t, double> > GetPreviousValueAndTime(
+  [[nodiscard]] std::optional<std::pair<uint64_t, double>> GetPreviousValueAndTime(
       uint64_t time) const;
   [[nodiscard]] bool IsEmpty() const override { return values_.empty(); }
+
+  void SetWarningThreshold(const std::optional<std::pair<std::string, double>>& warning_threshold) {
+    warning_threshold_ = warning_threshold;
+    max_ = std::max(max_, warning_threshold.value().second);
+    min_ = std::min(min_, warning_threshold.value().second);
+  }
+  void SetValueUpperBound(const std::optional<std::pair<std::string, double>>& value_upper_bound) {
+    value_upper_bound_ = value_upper_bound;
+  }
+  bool WarningThresholdSetHasValue() { return warning_threshold_.has_value(); }
+  bool ValueUpperBoundHasValue() { return value_upper_bound_.has_value(); }
 
  protected:
   void DrawSquareDot(Batcher* batcher, Vec2 center, float radius, float z, const Color& color);
@@ -44,6 +55,8 @@ class GraphTrack : public Track {
   double max_ = std::numeric_limits<double>::lowest();
   double value_range_ = 0;
   double inv_value_range_ = 0;
+  std::optional<std::pair<std::string, double>> warning_threshold_ = std::nullopt;
+  std::optional<std::pair<std::string, double>> value_upper_bound_ = std::nullopt;
 };
 
 #endif  // ORBIT_GL_GRAPH_TRACK_H_

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -35,16 +35,18 @@ class GraphTrack : public Track {
       uint64_t time) const;
   [[nodiscard]] bool IsEmpty() const override { return values_.empty(); }
 
-  void SetWarningThreshold(const std::optional<std::pair<std::string, double>>& warning_threshold) {
+  void SetWarningThresholdWhenEmpty(
+      const std::optional<std::pair<std::string, double>>& warning_threshold) {
+    if (warning_threshold_.has_value() || !warning_threshold.has_value()) return;
     warning_threshold_ = warning_threshold;
     max_ = std::max(max_, warning_threshold.value().second);
     min_ = std::min(min_, warning_threshold.value().second);
   }
-  void SetValueUpperBound(const std::optional<std::pair<std::string, double>>& value_upper_bound) {
+  void SetValueUpperBoundWhenEmpty(
+      const std::optional<std::pair<std::string, double>>& value_upper_bound) {
+    if (value_upper_bound_.has_value() || !value_upper_bound.has_value()) return;
     value_upper_bound_ = value_upper_bound;
   }
-  bool WarningThresholdSetHasValue() { return warning_threshold_.has_value(); }
-  bool ValueUpperBoundHasValue() { return value_upper_bound_.has_value(); }
 
  protected:
   void DrawSquareDot(Batcher* batcher, Vec2 center, float radius, float z, const Color& color);

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -455,14 +455,6 @@ void TimeGraph::ProcessMemoryTrackingTimer(const TimerInfo& timer_info) {
   GraphTrack* track;
   int64_t unused_kb = orbit_api::Decode<int64_t>(
       timer_info.registers(static_cast<size_t>(OrbitApp::SystemMemoryUsageEncodingIndex::kFreeKb)));
-  if (unused_kb != kMissingInfo) {
-    track = track_manager_->GetOrCreateGraphTrack(kUnusedLabel);
-    track->SetValueUpperBoundWhenEmpty(total_pretty_name_and_raw_value);
-    track->SetValueLowerBoundWhenEmpty(minimum_pretty_name_and_raw_value);
-    double unused_mb = static_cast<double>(unused_kb) / kMegabytesToKilobytes;
-    track->AddValue(unused_mb, timer_info.start());
-  }
-
   int64_t buffers_kb = orbit_api::Decode<int64_t>(timer_info.registers(
       static_cast<size_t>(OrbitApp::SystemMemoryUsageEncodingIndex::kBuffersKb)));
   int64_t cached_kb = orbit_api::Decode<int64_t>(timer_info.registers(

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -454,8 +454,8 @@ void TimeGraph::ProcessMemoryTrackingTimer(const TimerInfo& timer_info) {
   int64_t unused_kb = orbit_api::Decode<int64_t>(
       timer_info.registers(static_cast<size_t>(OrbitApp::SystemMemoryUsageEncodingIndex::kFreeKb)));
   if (unused_kb != kMissingInfo) {
-    track = track_manager_->GetOrCreateGraphTrack(kUnusedLabel, std::nullopt,
-                                                  total_pretty_name_and_raw_value);
+    track = track_manager_->GetOrCreateGraphTrack(kUnusedLabel);
+    track->SetValueUpperBoundWhenEmpty(total_pretty_name_and_raw_value);
     double unused_mb = static_cast<double>(unused_kb) / kMegabytesToKilobytes;
     track->AddValue(unused_mb, timer_info.start());
   }
@@ -465,8 +465,8 @@ void TimeGraph::ProcessMemoryTrackingTimer(const TimerInfo& timer_info) {
   int64_t cached_kb = orbit_api::Decode<int64_t>(timer_info.registers(
       static_cast<size_t>(OrbitApp::SystemMemoryUsageEncodingIndex::kCachedKb)));
   if (buffers_kb != kMissingInfo && cached_kb != kMissingInfo) {
-    track = track_manager_->GetOrCreateGraphTrack(kBuffersOrCachedLabel, std::nullopt,
-                                                  total_pretty_name_and_raw_value);
+    track = track_manager_->GetOrCreateGraphTrack(kBuffersOrCachedLabel);
+    track->SetValueUpperBoundWhenEmpty(total_pretty_name_and_raw_value);
     double buffers_or_cached_mb =
         static_cast<double>(buffers_kb + cached_kb) / kMegabytesToKilobytes;
     track->AddValue(buffers_or_cached_mb, timer_info.start());
@@ -474,8 +474,9 @@ void TimeGraph::ProcessMemoryTrackingTimer(const TimerInfo& timer_info) {
 
   if (total_kb != kMissingInfo && unused_kb != kMissingInfo && buffers_kb != kMissingInfo &&
       cached_kb != kMissingInfo) {
-    track = track_manager_->GetOrCreateGraphTrack(
-        kUsedLabel, warning_threshold_pretty_name_and_raw_value, total_pretty_name_and_raw_value);
+    track = track_manager_->GetOrCreateGraphTrack(kUsedLabel);
+    track->SetWarningThresholdWhenEmpty(warning_threshold_pretty_name_and_raw_value);
+    track->SetValueUpperBoundWhenEmpty(total_pretty_name_and_raw_value);
     double used_mb =
         static_cast<double>(total_kb - unused_kb - buffers_kb - cached_kb) / kMegabytesToKilobytes;
     track->AddValue(used_mb, timer_info.start());

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -449,6 +449,8 @@ void TimeGraph::ProcessMemoryTrackingTimer(const TimerInfo& timer_info) {
     double raw_value = static_cast<double>(total_kb) / kMegabytesToKilobytes;
     total_pretty_name_and_raw_value = std::make_pair(pretty_name, raw_value);
   }
+  std::pair<std::string, int64_t> minimum_pretty_name_and_raw_value =
+      std::make_pair("Minimum: 0 GB", 0);
 
   GraphTrack* track;
   int64_t unused_kb = orbit_api::Decode<int64_t>(
@@ -456,6 +458,7 @@ void TimeGraph::ProcessMemoryTrackingTimer(const TimerInfo& timer_info) {
   if (unused_kb != kMissingInfo) {
     track = track_manager_->GetOrCreateGraphTrack(kUnusedLabel);
     track->SetValueUpperBoundWhenEmpty(total_pretty_name_and_raw_value);
+    track->SetValueLowerBoundWhenEmpty(minimum_pretty_name_and_raw_value);
     double unused_mb = static_cast<double>(unused_kb) / kMegabytesToKilobytes;
     track->AddValue(unused_mb, timer_info.start());
   }
@@ -467,6 +470,7 @@ void TimeGraph::ProcessMemoryTrackingTimer(const TimerInfo& timer_info) {
   if (buffers_kb != kMissingInfo && cached_kb != kMissingInfo) {
     track = track_manager_->GetOrCreateGraphTrack(kBuffersOrCachedLabel);
     track->SetValueUpperBoundWhenEmpty(total_pretty_name_and_raw_value);
+    track->SetValueLowerBoundWhenEmpty(minimum_pretty_name_and_raw_value);
     double buffers_or_cached_mb =
         static_cast<double>(buffers_kb + cached_kb) / kMegabytesToKilobytes;
     track->AddValue(buffers_or_cached_mb, timer_info.start());
@@ -476,6 +480,7 @@ void TimeGraph::ProcessMemoryTrackingTimer(const TimerInfo& timer_info) {
       cached_kb != kMissingInfo) {
     track = track_manager_->GetOrCreateGraphTrack(kUsedLabel);
     track->SetWarningThresholdWhenEmpty(warning_threshold_pretty_name_and_raw_value);
+    track->SetValueLowerBoundWhenEmpty(minimum_pretty_name_and_raw_value);
     track->SetValueUpperBoundWhenEmpty(total_pretty_name_and_raw_value);
     double used_mb =
         static_cast<double>(total_kb - unused_kb - buffers_kb - cached_kb) / kMegabytesToKilobytes;

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -426,6 +426,8 @@ void TimeGraph::ProcessMemoryTrackingTimer(const TimerInfo& timer_info) {
   const std::string kBuffersOrCachedLabel = "System Memory Buffers / Cached (MB)";
   const std::string kUsedLabel = "System Memory Used (MB)";
   const std::string kWarningThresholdLabel = "Production Limit";
+  const std::string kTrackValueLabelUnit = "MB";
+  constexpr uint8_t kTrackValueDecimalDigits = 2;
 
   std::optional<std::pair<std::string, uint64_t>> warning_threshold_pretty_name_and_raw_value =
       std::nullopt;
@@ -463,6 +465,8 @@ void TimeGraph::ProcessMemoryTrackingTimer(const TimerInfo& timer_info) {
     track = track_manager_->GetOrCreateGraphTrack(kBuffersOrCachedLabel);
     track->SetValueUpperBoundWhenEmpty(total_pretty_name_and_raw_value);
     track->SetValueLowerBoundWhenEmpty(minimum_pretty_name_and_raw_value);
+    track->SetLabelUnit(kTrackValueLabelUnit);
+    track->SetValueDecimalDigitsWhenEmpty(kTrackValueDecimalDigits);
     double buffers_or_cached_mb =
         static_cast<double>(buffers_kb + cached_kb) / kMegabytesToKilobytes;
     track->AddValue(buffers_or_cached_mb, timer_info.start());
@@ -474,6 +478,8 @@ void TimeGraph::ProcessMemoryTrackingTimer(const TimerInfo& timer_info) {
     track->SetWarningThresholdWhenEmpty(warning_threshold_pretty_name_and_raw_value);
     track->SetValueLowerBoundWhenEmpty(minimum_pretty_name_and_raw_value);
     track->SetValueUpperBoundWhenEmpty(total_pretty_name_and_raw_value);
+    track->SetLabelUnit(kTrackValueLabelUnit);
+    track->SetValueDecimalDigitsWhenEmpty(kTrackValueDecimalDigits);
     double used_mb =
         static_cast<double>(total_kb - unused_kb - buffers_kb - cached_kb) / kMegabytesToKilobytes;
     track->AddValue(used_mb, timer_info.start());

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -288,6 +288,9 @@ void TimeGraph::ProcessTimer(const TimerInfo& timer_info, const InstrumentedFunc
       scheduler_track->OnTimer(timer_info);
       break;
     }
+    case TimerInfo::kSystemMemoryUsage: {
+      break;
+    }
     case TimerInfo::kNone: {
       ThreadTrack* track = track_manager_->GetOrCreateThreadTrack(timer_info.thread_id());
       track->OnTimer(timer_info);

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -179,6 +179,7 @@ class TimeGraph {
   void ProcessValueTrackingTimer(const orbit_client_protos::TimerInfo& timer_info);
   void ProcessAsyncTimer(const std::string& track_name,
                          const orbit_client_protos::TimerInfo& timer_info);
+  void ProcessMemoryTrackingTimer(const orbit_client_protos::TimerInfo& timer_info);
 
  private:
   TextRenderer text_renderer_static_;

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -349,9 +349,7 @@ GpuTrack* TrackManager::GetOrCreateGpuTrack(uint64_t timeline_hash) {
   return track.get();
 }
 
-GraphTrack* TrackManager::GetOrCreateGraphTrack(
-    const std::string& name, const std::optional<std::pair<std::string, double>>& warning_threshold,
-    const std::optional<std::pair<std::string, double>>& value_upper_bound) {
+GraphTrack* TrackManager::GetOrCreateGraphTrack(const std::string& name) {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
   std::shared_ptr<GraphTrack> track = graph_tracks_[name];
   if (track == nullptr) {
@@ -359,14 +357,6 @@ GraphTrack* TrackManager::GetOrCreateGraphTrack(
     AddTrack(track);
     graph_tracks_[name] = track;
   }
-
-  if (!track->WarningThresholdSetHasValue() && warning_threshold.has_value()) {
-    track->SetWarningThreshold(warning_threshold);
-  }
-  if (!track->ValueUpperBoundHasValue() && value_upper_bound.has_value()) {
-    track->SetValueUpperBound(value_upper_bound);
-  }
-
   return track.get();
 }
 

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -349,7 +349,9 @@ GpuTrack* TrackManager::GetOrCreateGpuTrack(uint64_t timeline_hash) {
   return track.get();
 }
 
-GraphTrack* TrackManager::GetOrCreateGraphTrack(const std::string& name) {
+GraphTrack* TrackManager::GetOrCreateGraphTrack(
+    const std::string& name, const std::optional<std::pair<std::string, double>>& warning_threshold,
+    const std::optional<std::pair<std::string, double>>& value_upper_bound) {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
   std::shared_ptr<GraphTrack> track = graph_tracks_[name];
   if (track == nullptr) {
@@ -357,6 +359,14 @@ GraphTrack* TrackManager::GetOrCreateGraphTrack(const std::string& name) {
     AddTrack(track);
     graph_tracks_[name] = track;
   }
+
+  if (!track->WarningThresholdSetHasValue() && warning_threshold.has_value()) {
+    track->SetWarningThreshold(warning_threshold);
+  }
+  if (!track->ValueUpperBoundHasValue() && value_upper_bound.has_value()) {
+    track->SetValueUpperBound(value_upper_bound);
+  }
+
   return track.get();
 }
 

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -59,7 +59,10 @@ class TrackManager {
   SchedulerTrack* GetOrCreateSchedulerTrack();
   ThreadTrack* GetOrCreateThreadTrack(int32_t tid);
   GpuTrack* GetOrCreateGpuTrack(uint64_t timeline_hash);
-  GraphTrack* GetOrCreateGraphTrack(const std::string& name);
+  GraphTrack* GetOrCreateGraphTrack(
+      const std::string& name,
+      const std::optional<std::pair<std::string, double>>& warning_threshold = std::nullopt,
+      const std::optional<std::pair<std::string, double>>& value_upper_bound = std::nullopt);
   AsyncTrack* GetOrCreateAsyncTrack(const std::string& name);
   FrameTrack* GetOrCreateFrameTrack(const orbit_grpc_protos::InstrumentedFunction& function);
 

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -59,10 +59,7 @@ class TrackManager {
   SchedulerTrack* GetOrCreateSchedulerTrack();
   ThreadTrack* GetOrCreateThreadTrack(int32_t tid);
   GpuTrack* GetOrCreateGpuTrack(uint64_t timeline_hash);
-  GraphTrack* GetOrCreateGraphTrack(
-      const std::string& name,
-      const std::optional<std::pair<std::string, double>>& warning_threshold = std::nullopt,
-      const std::optional<std::pair<std::string, double>>& value_upper_bound = std::nullopt);
+  GraphTrack* GetOrCreateGraphTrack(const std::string& name);
   AsyncTrack* GetOrCreateAsyncTrack(const std::string& name);
   FrameTrack* GetOrCreateFrameTrack(const orbit_grpc_protos::InstrumentedFunction& function);
 

--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -24,7 +24,7 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
   QObject::connect(ui_->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
 
   ui_->localMarkerDepthLineEdit->setValidator(&uint64_validator_);
-  ui_->memorySamplingPeriodNsLineEdit->setValidator(&uint64_validator_);
+  ui_->memorySamplingPeriodMsLineEdit->setValidator(new UInt64Validator(1));
   ui_->memoryWarningThresholdKbLineEdit->setValidator(&uint64_validator_);
 
   QObject::connect(ui_->openSourcePathsMappingDialog, &QAbstractButton::clicked, this,
@@ -87,20 +87,37 @@ bool CaptureOptionsDialog::GetCollectMemoryInfo() const {
   return ui_->collectMemoryInfoCheckBox->isChecked();
 }
 
-void CaptureOptionsDialog::SetMemorySamplingPeriodNs(uint64_t memory_sampling_period_ns) {
-  ui_->memorySamplingPeriodNsLineEdit->setText(QString::number(memory_sampling_period_ns));
+void CaptureOptionsDialog::SetMemorySamplingPeriodMs(uint64_t memory_sampling_period_ms) {
+  ui_->memorySamplingPeriodMsLineEdit->setText(QString::number(memory_sampling_period_ms));
 }
 
-uint64_t CaptureOptionsDialog::GetMemorySamplingPeriodNs() const {
-  CHECK(!ui_->memorySamplingPeriodNsLineEdit->text().isEmpty());
+void CaptureOptionsDialog::ResetMemorySamplingPeriodMsLineEditWhenEmpty() {
+  if (!ui_->memorySamplingPeriodMsLineEdit->text().isEmpty()) return;
+
+  constexpr uint64_t kMemorySamplingPeriodMsDefaultValue = 100;
+  ui_->memorySamplingPeriodMsLineEdit->setText(
+      QString::number(kMemorySamplingPeriodMsDefaultValue));
+}
+
+uint64_t CaptureOptionsDialog::GetMemorySamplingPeriodMs() const {
+  CHECK(!ui_->memorySamplingPeriodMsLineEdit->text().isEmpty());
   bool valid = false;
-  uint64_t result = ui_->memorySamplingPeriodNsLineEdit->text().toULongLong(&valid);
+  uint64_t memory_sampling_period_ms =
+      ui_->memorySamplingPeriodMsLineEdit->text().toULongLong(&valid);
   CHECK(valid);
-  return result;
+  return memory_sampling_period_ms;
 }
 
 void CaptureOptionsDialog::SetMemoryWarningThresholdKb(uint64_t memory_warning_threshold_kb) {
   ui_->memoryWarningThresholdKbLineEdit->setText(QString::number(memory_warning_threshold_kb));
+}
+
+void CaptureOptionsDialog::ResetMemoryWarningThresholdKbLineEditWhenEmpty() {
+  if (!ui_->memoryWarningThresholdKbLineEdit->text().isEmpty()) return;
+
+  constexpr uint64_t kMemoryWarningThresholdKbDefaultValue = 1024 * 1024 * 8;
+  ui_->memoryWarningThresholdKbLineEdit->setText(
+      QString::number(kMemoryWarningThresholdKbDefaultValue));
 }
 
 uint64_t CaptureOptionsDialog::GetMemoryWarningThresholdKb() const {

--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -24,6 +24,8 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
   QObject::connect(ui_->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
 
   ui_->localMarkerDepthLineEdit->setValidator(&uint64_validator_);
+  ui_->memorySamplingPeriodNsLineEdit->setValidator(&uint64_validator_);
+  ui_->memoryWarningThresholdKbLineEdit->setValidator(&uint64_validator_);
 
   QObject::connect(ui_->openSourcePathsMappingDialog, &QAbstractButton::clicked, this,
                    &CaptureOptionsDialog::ShowSourcePathsMappingEditor);
@@ -75,6 +77,38 @@ void CaptureOptionsDialog::ShowSourcePathsMappingEditor() {
   if (result_code == QDialog::Accepted) {
     manager.SetMappings(dialog.GetMappings());
   }
+}
+
+void CaptureOptionsDialog::SetCollectMemoryInfo(bool collect_memory_info) {
+  ui_->collectMemoryInfoCheckBox->setChecked(collect_memory_info);
+}
+
+bool CaptureOptionsDialog::GetCollectMemoryInfo() const {
+  return ui_->collectMemoryInfoCheckBox->isChecked();
+}
+
+void CaptureOptionsDialog::SetMemorySamplingPeriodNs(uint64_t memory_sampling_period_ns) {
+  ui_->memorySamplingPeriodNsLineEdit->setText(QString::number(memory_sampling_period_ns));
+}
+
+uint64_t CaptureOptionsDialog::GetMemorySamplingPeriodNs() const {
+  CHECK(!ui_->memorySamplingPeriodNsLineEdit->text().isEmpty());
+  bool valid = false;
+  uint64_t result = ui_->memorySamplingPeriodNsLineEdit->text().toULongLong(&valid);
+  CHECK(valid);
+  return result;
+}
+
+void CaptureOptionsDialog::SetMemoryWarningThresholdKb(uint64_t memory_warning_threshold_kb) {
+  ui_->memoryWarningThresholdKbLineEdit->setText(QString::number(memory_warning_threshold_kb));
+}
+
+uint64_t CaptureOptionsDialog::GetMemoryWarningThresholdKb() const {
+  CHECK(!ui_->memoryWarningThresholdKbLineEdit->text().isEmpty());
+  bool valid = false;
+  uint64_t result = ui_->memoryWarningThresholdKbLineEdit->text().toULongLong(&valid);
+  CHECK(valid);
+  return result;
 }
 
 }  // namespace orbit_qt

--- a/src/OrbitQt/CaptureOptionsDialog.h
+++ b/src/OrbitQt/CaptureOptionsDialog.h
@@ -46,6 +46,13 @@ class CaptureOptionsDialog : public QDialog {
   void SetMaxLocalMarkerDepthPerCommandBuffer(uint64_t local_marker_depth_per_command_buffer);
   [[nodiscard]] uint64_t GetMaxLocalMarkerDepthPerCommandBuffer() const;
 
+  void SetCollectMemoryInfo(bool collect_memory_info);
+  [[nodiscard]] bool GetCollectMemoryInfo() const;
+  void SetMemorySamplingPeriodNs(uint64_t memory_sampling_period_ns);
+  [[nodiscard]] uint64_t GetMemorySamplingPeriodNs() const;
+  void SetMemoryWarningThresholdKb(uint64_t memory_warning_threshold_kb);
+  [[nodiscard]] uint64_t GetMemoryWarningThresholdKb() const;
+
  public slots:
   void ResetLocalMarkerDepthLineEdit();
   void ShowSourcePathsMappingEditor();

--- a/src/OrbitQt/CaptureOptionsDialog.h
+++ b/src/OrbitQt/CaptureOptionsDialog.h
@@ -20,17 +20,22 @@ namespace orbit_qt {
 class UInt64Validator : public QValidator {
  public:
   explicit UInt64Validator(QObject* parent = nullptr) : QValidator(parent) {}
+  explicit UInt64Validator(uint64_t minimum, QObject* parent = nullptr)
+      : QValidator(parent), minimum_(minimum) {}
   QValidator::State validate(QString& input, int& /*pos*/) const override {
     if (input.isEmpty()) {
       return QValidator::State::Acceptable;
     }
     bool valid = false;
-    input.toULongLong(&valid);
-    if (valid) {
+    uint64_t input_value = input.toULongLong(&valid);
+    if (valid && input_value >= minimum_) {
       return QValidator::State::Acceptable;
     }
     return QValidator::State::Invalid;
   }
+
+ private:
+  uint64_t minimum_ = 0;
 };
 
 class CaptureOptionsDialog : public QDialog {
@@ -48,13 +53,15 @@ class CaptureOptionsDialog : public QDialog {
 
   void SetCollectMemoryInfo(bool collect_memory_info);
   [[nodiscard]] bool GetCollectMemoryInfo() const;
-  void SetMemorySamplingPeriodNs(uint64_t memory_sampling_period_ns);
-  [[nodiscard]] uint64_t GetMemorySamplingPeriodNs() const;
+  void SetMemorySamplingPeriodMs(uint64_t memory_sampling_period_ms);
+  [[nodiscard]] uint64_t GetMemorySamplingPeriodMs() const;
   void SetMemoryWarningThresholdKb(uint64_t memory_warning_threshold_kb);
   [[nodiscard]] uint64_t GetMemoryWarningThresholdKb() const;
 
  public slots:
   void ResetLocalMarkerDepthLineEdit();
+  void ResetMemorySamplingPeriodMsLineEditWhenEmpty();
+  void ResetMemoryWarningThresholdKbLineEditWhenEmpty();
   void ShowSourcePathsMappingEditor();
 
  private:

--- a/src/OrbitQt/CaptureOptionsDialog.ui
+++ b/src/OrbitQt/CaptureOptionsDialog.ui
@@ -77,14 +77,14 @@
         <item>
          <layout class="QHBoxLayout" name="memoryHorizontalLayout">
           <item>
-           <widget class="QLabel" name="memorySamplingPeriodNsLabel">
+           <widget class="QLabel" name="memorySamplingPeriodMsLabel">
             <property name="text">
-             <string>Sampling period (ns):</string>
+             <string>Sampling period (ms):</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QLineEdit" name="memorySamplingPeriodNsLineEdit">
+           <widget class="QLineEdit" name="memorySamplingPeriodMsLineEdit">
             <property name="enabled">
              <bool>false</bool>
             </property>
@@ -92,7 +92,7 @@
              <set>Qt::ImhDigitsOnly</set>
             </property>
             <property name="text">
-             <string>100000000</string>
+             <string>100</string>
             </property>
            </widget>
           </item>
@@ -286,7 +286,7 @@ Setting the value to &quot;0&quot; will disable Vulkan debug marker tracking.</s
   <connection>
    <sender>collectMemoryInfoCheckBox</sender>
    <signal>toggled(bool)</signal>
-   <receiver>memorySamplingPeriodNsLineEdit</receiver>
+   <receiver>memorySamplingPeriodMsLineEdit</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -315,8 +315,42 @@ Setting the value to &quot;0&quot; will disable Vulkan debug marker tracking.</s
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>memorySamplingPeriodMsLineEdit</sender>
+   <signal>editingFinished()</signal>
+   <receiver>CaptureOptionsDialog</receiver>
+   <slot>ResetMemorySamplingPeriodMsLineEditWhenEmpty()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>174</x>
+     <y>128</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>239</x>
+     <y>203</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>memoryWarningThresholdKbLineEdit</sender>
+   <signal>editingFinished()</signal>
+   <receiver>CaptureOptionsDialog</receiver>
+   <slot>ResetMemoryWarningThresholdKbLineEditWhenEmpty()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>413</x>
+     <y>128</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>239</x>
+     <y>203</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <slot>ResetLocalMarkerDepthLineEdit()</slot>
+  <slot>ResetMemorySamplingPeriodMsLineEditWhenEmpty()</slot>
+  <slot>ResetMemoryWarningThresholdKbLineEditWhenEmpty()</slot>
  </slots>
 </ui>

--- a/src/OrbitQt/CaptureOptionsDialog.ui
+++ b/src/OrbitQt/CaptureOptionsDialog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>480</width>
-    <height>379</height>
+    <height>408</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -57,6 +57,82 @@
            <string>Collect thread states</string>
           </property>
          </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="groupBox_4">
+       <property name="title">
+        <string>Memory tracing</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_5">
+        <item>
+         <widget class="QCheckBox" name="collectMemoryInfoCheckBox">
+          <property name="text">
+           <string>Collect system-wide memory usage information</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="memoryHorizontalLayout">
+          <item>
+           <widget class="QLabel" name="memorySamplingPeriodNsLabel">
+            <property name="text">
+             <string>Sampling period (ns):</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="memorySamplingPeriodNsLineEdit">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="inputMethodHints">
+             <set>Qt::ImhDigitsOnly</set>
+            </property>
+            <property name="text">
+             <string>100000000</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>60</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QLabel" name="memoryWarningThresholdKbLabel">
+            <property name="text">
+             <string>Warning threshold (kb):</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="memoryWarningThresholdKbLineEdit">
+            <property name="toolTip">
+             <string>The default value is 8388608 KB, i.e., 8GB.</string>
+            </property>
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="inputMethodHints">
+             <set>Qt::ImhDigitsOnly</set>
+            </property>
+            <property name="text">
+             <string>8388608</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
        </layout>
       </widget>
@@ -204,6 +280,38 @@ Setting the value to &quot;0&quot; will disable Vulkan debug marker tracking.</s
     <hint type="destinationlabel">
      <x>219</x>
      <y>129</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>collectMemoryInfoCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>memorySamplingPeriodNsLineEdit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>239</x>
+     <y>103</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>173</x>
+     <y>128</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>collectMemoryInfoCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>memoryWarningThresholdKbLineEdit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>239</x>
+     <y>103</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>413</x>
+     <y>128</y>
     </hint>
    </hints>
   </connection>

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -875,28 +875,31 @@ void OrbitMainWindow::on_actionToggle_Capture_triggered() { app_->ToggleCapture(
 
 const QString OrbitMainWindow::kCollectThreadStatesSettingKey{"CollectThreadStates"};
 const QString OrbitMainWindow::kCollectMemoryInfoSettingKey{"CollectMemoryInfo"};
-const QString OrbitMainWindow::kMemorySamplingPeriodNsSettingKey{"MemorySamplingPeriodNs"};
+const QString OrbitMainWindow::kMemorySamplingPeriodMsSettingKey{"MemorySamplingPeriodMs"};
 const QString OrbitMainWindow::kMemoryWarningThresholdKbSettingKey{"MemoryWarningThresholdKb"};
 const QString OrbitMainWindow::kLimitLocalMarkerDepthPerCommandBufferSettingsKey{
     "LimitLocalMarkerDepthPerCommandBuffer"};
 const QString OrbitMainWindow::kMaxLocalMarkerDepthPerCommandBufferSettingsKey{
     "MaxLocalMarkerDepthPerCommandBuffer"};
 
-constexpr uint64_t kMemorySamplingPeriodNsDefaultValue = 100'000'000;        // 100ms
+constexpr uint64_t kMemorySamplingPeriodMsDefaultValue = 100;
 constexpr uint64_t kMemoryWarningThresholdKbDefaultValue = 1024 * 1024 * 8;  // 8Gb
+constexpr uint64_t kMilliSecondsToNanoSeconds = 1000'000;
 
 void OrbitMainWindow::LoadCaptureOptionsIntoApp() {
   QSettings settings;
   app_->SetCollectThreadStates(settings.value(kCollectThreadStatesSettingKey, false).toBool());
 
   app_->SetCollectMemoryInfo(settings.value(kCollectMemoryInfoSettingKey, false).toBool());
-  uint64_t memory_sampling_period_ns = kMemorySamplingPeriodNsDefaultValue;
+  uint64_t memory_sampling_period_ns =
+      kMemorySamplingPeriodMsDefaultValue * kMilliSecondsToNanoSeconds;
   uint64_t memory_warning_threshold_kb = kMemoryWarningThresholdKbDefaultValue;
   if (app_->GetCollectMemoryInfo()) {
     memory_sampling_period_ns = settings
-                                    .value(kMemorySamplingPeriodNsSettingKey,
-                                           QVariant::fromValue(kMemorySamplingPeriodNsDefaultValue))
-                                    .toULongLong();
+                                    .value(kMemorySamplingPeriodMsSettingKey,
+                                           QVariant::fromValue(kMemorySamplingPeriodMsDefaultValue))
+                                    .toULongLong() *
+                                kMilliSecondsToNanoSeconds;
     memory_warning_threshold_kb =
         settings
             .value(kMemoryWarningThresholdKbSettingKey,
@@ -920,10 +923,10 @@ void OrbitMainWindow::on_actionCaptureOptions_triggered() {
   orbit_qt::CaptureOptionsDialog dialog{this};
   dialog.SetCollectThreadStates(settings.value(kCollectThreadStatesSettingKey, false).toBool());
   dialog.SetCollectMemoryInfo(settings.value(kCollectMemoryInfoSettingKey, false).toBool());
-  dialog.SetMemorySamplingPeriodNs(
+  dialog.SetMemorySamplingPeriodMs(
       settings
-          .value(kMemorySamplingPeriodNsSettingKey,
-                 QVariant::fromValue(kMemorySamplingPeriodNsDefaultValue))
+          .value(kMemorySamplingPeriodMsSettingKey,
+                 QVariant::fromValue(kMemorySamplingPeriodMsDefaultValue))
           .toULongLong());
   dialog.SetMemoryWarningThresholdKb(
       settings
@@ -942,8 +945,8 @@ void OrbitMainWindow::on_actionCaptureOptions_triggered() {
 
   settings.setValue(kCollectThreadStatesSettingKey, dialog.GetCollectThreadStates());
   settings.setValue(kCollectMemoryInfoSettingKey, dialog.GetCollectMemoryInfo());
-  settings.setValue(kMemorySamplingPeriodNsSettingKey,
-                    QString::number(dialog.GetMemorySamplingPeriodNs()));
+  settings.setValue(kMemorySamplingPeriodMsSettingKey,
+                    QString::number(dialog.GetMemorySamplingPeriodMs()));
   settings.setValue(kMemoryWarningThresholdKbSettingKey,
                     QString::number(dialog.GetMemoryWarningThresholdKb()));
   settings.setValue(kLimitLocalMarkerDepthPerCommandBufferSettingsKey,

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -170,7 +170,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
 
   static const QString kCollectThreadStatesSettingKey;
   static const QString kCollectMemoryInfoSettingKey;
-  static const QString kMemorySamplingPeriodNsSettingKey;
+  static const QString kMemorySamplingPeriodMsSettingKey;
   static const QString kMemoryWarningThresholdKbSettingKey;
   static const QString kLimitLocalMarkerDepthPerCommandBufferSettingsKey;
   static const QString kMaxLocalMarkerDepthPerCommandBufferSettingsKey;

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -169,6 +169,9 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   void OnProcessListUpdated(const std::vector<orbit_grpc_protos::ProcessInfo>& processes);
 
   static const QString kCollectThreadStatesSettingKey;
+  static const QString kCollectMemoryInfoSettingKey;
+  static const QString kMemorySamplingPeriodNsSettingKey;
+  static const QString kMemoryWarningThresholdKbSettingKey;
   static const QString kLimitLocalMarkerDepthPerCommandBufferSettingsKey;
   static const QString kMaxLocalMarkerDepthPerCommandBufferSettingsKey;
   void LoadCaptureOptionsIntoApp();


### PR DESCRIPTION
We would like to add the timeline visualization for the system memory usage information and make it obvious when the used memory exceeds the production limit threshold.

This PR includes:
* Processing the `SystemMemoryUsage` events received on the Orbit Client side and encoding it into a `TimerInfo` with the type of `kSystemUsage`;
* Adding `warning_threshold_`, `value_upper_bound_` and some relevant methods to the `GraphTrack` so we can visualize those values when they are provided;
* Create three memory graph tracks (i.e., "Memory used (kb)", "Memory buffers or cached (kb)" and "Memory unused") with total memory size as `value_upper_bound_` and the production limit as `warning_threshold_`;
* Draw text box and line to visualize the production limit and draw text box to visualize the total memory size;
* Update the CaptureOptionsDialog for supporting input the memory tracing parameters.

Other things might be done in this PR:
* Removing the "Memory Unused" track given the fact that Memory Total = Used + Unused + Buffers or cached;
* Enable hiding & showing memory tracks;
* (If not ship) Hide the memory tracing behind the flag.

Bugs: http://b/178999638, http://b/179000848.

After the change:
![Screenshot 2021-03-16 115941](https://user-images.githubusercontent.com/74234352/111298747-07682d80-8647-11eb-87ee-93439bd83920.png)
![Screenshot 2021-03-16 120005](https://user-images.githubusercontent.com/74234352/111298749-0800c400-8647-11eb-94e5-83335ced7579.png)
