### PR TITLE
Pass function name for instrumetned functions

### DIFF
--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -12,6 +12,20 @@ import "tracepoint.proto";
 // This is needed by LockFreeBufferCaptureEventProducer.
 option cc_enable_arenas = true;
 
+message InstrumentedFunction {
+  string file_path = 1;
+  uint64 file_offset = 2;
+  uint64 function_id = 3;
+
+  enum FunctionType {
+    kRegular = 0;
+    kTimerStart = 1;
+    kTimerStop = 2;
+  }
+  FunctionType function_type = 4;
+  string function_name = 5;
+}
+
 message CaptureOptions {
   bool trace_context_switches = 1;
   int32 pid = 2;
@@ -23,19 +37,6 @@ message CaptureOptions {
     kDwarf = 2;
   }
   UnwindingMethod unwinding_method = 4;
-
-  message InstrumentedFunction {
-    string file_path = 1;
-    uint64 file_offset = 2;
-    uint64 function_id = 3;
-
-    enum FunctionType {
-      kRegular = 0;
-      kTimerStart = 1;
-      kTimerStop = 2;
-    }
-    FunctionType function_type = 4;
-  }
 
   repeated InstrumentedFunction instrumented_functions = 5;
 

--- a/src/LinuxTracing/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracing/LinuxTracingIntegrationTest.cpp
@@ -481,20 +481,22 @@ void AddOuterAndInnerFunctionToCaptureOptions(orbit_grpc_protos::CaptureOptions*
     if (symbol.name() == PuppetConstants::kOuterFunctionName) {
       CHECK(!outer_function_symbol_found);
       outer_function_symbol_found = true;
-      orbit_grpc_protos::CaptureOptions::InstrumentedFunction instrumented_function;
+      orbit_grpc_protos::InstrumentedFunction instrumented_function;
       instrumented_function.set_file_path(executable_path);
       instrumented_function.set_file_offset(symbol.address() - module_symbols.load_bias());
       instrumented_function.set_function_id(outer_function_id);
+      instrumented_function.set_function_name(symbol.name());
       capture_options->mutable_instrumented_functions()->Add(std::move(instrumented_function));
     }
 
     if (symbol.name() == PuppetConstants::kInnerFunctionName) {
       CHECK(!inner_function_symbol_found);
       inner_function_symbol_found = true;
-      orbit_grpc_protos::CaptureOptions::InstrumentedFunction instrumented_function;
+      orbit_grpc_protos::InstrumentedFunction instrumented_function;
       instrumented_function.set_file_path(executable_path);
       instrumented_function.set_file_offset(symbol.address() - module_symbols.load_bias());
       instrumented_function.set_function_id(inner_function_id);
+      instrumented_function.set_function_name(symbol.name());
       capture_options->mutable_instrumented_functions()->Add(std::move(instrumented_function));
     }
   }

--- a/src/LinuxTracing/TracerThread.cpp
+++ b/src/LinuxTracing/TracerThread.cpp
@@ -38,7 +38,7 @@ namespace orbit_linux_tracing {
 using orbit_base::GetAllPids;
 using orbit_base::GetTidsOfProcess;
 using orbit_grpc_protos::CaptureOptions;
-using orbit_grpc_protos::CaptureOptions_InstrumentedFunction;
+using orbit_grpc_protos::InstrumentedFunction;
 using orbit_grpc_protos::ThreadName;
 
 TracerThread::TracerThread(const CaptureOptions& capture_options)
@@ -59,17 +59,16 @@ TracerThread::TracerThread(const CaptureOptions& capture_options)
 
   instrumented_functions_.reserve(capture_options.instrumented_functions_size());
 
-  for (const CaptureOptions::InstrumentedFunction& instrumented_function :
+  for (const InstrumentedFunction& instrumented_function :
        capture_options.instrumented_functions()) {
     uint64_t function_id = instrumented_function.function_id();
     instrumented_functions_.emplace_back(function_id, instrumented_function.file_path(),
                                          instrumented_function.file_offset());
 
     // Manual instrumentation.
-    if (instrumented_function.function_type() == CaptureOptions_InstrumentedFunction::kTimerStart) {
+    if (instrumented_function.function_type() == InstrumentedFunction::kTimerStart) {
       manual_instrumentation_config_.AddTimerStartFunctionId(function_id);
-    } else if (instrumented_function.function_type() ==
-               CaptureOptions_InstrumentedFunction::kTimerStop) {
+    } else if (instrumented_function.function_type() == InstrumentedFunction::kTimerStop) {
       manual_instrumentation_config_.AddTimerStopFunctionId(function_id);
     }
   }

--- a/src/OrbitCaptureClient/CaptureClient.cpp
+++ b/src/OrbitCaptureClient/CaptureClient.cpp
@@ -36,22 +36,23 @@ using orbit_client_protos::FunctionInfo;
 using orbit_grpc_protos::CaptureOptions;
 using orbit_grpc_protos::CaptureRequest;
 using orbit_grpc_protos::CaptureResponse;
+using orbit_grpc_protos::InstrumentedFunction;
 using orbit_grpc_protos::TracepointInfo;
 
 using orbit_base::Future;
 
-static CaptureOptions::InstrumentedFunction::FunctionType InstrumentedFunctionTypeFromOrbitType(
+static InstrumentedFunction::FunctionType InstrumentedFunctionTypeFromOrbitType(
     FunctionInfo::OrbitType orbit_type) {
   switch (orbit_type) {
     case FunctionInfo::kOrbitTimerStart:
     case FunctionInfo::kOrbitTimerStartAsync:
-      return CaptureOptions::InstrumentedFunction::kTimerStart;
+      return InstrumentedFunction::kTimerStart;
     case FunctionInfo::kOrbitTimerStop:
     case FunctionInfo::kOrbitTimerStopAsync:
-      return CaptureOptions::InstrumentedFunction::kTimerStop;
+      return InstrumentedFunction::kTimerStop;
     case FunctionInfo::kOrbitTrackValue:
     case FunctionInfo::kNone:
-      return CaptureOptions::InstrumentedFunction::kRegular;
+      return InstrumentedFunction::kRegular;
     case orbit_client_protos::
         FunctionInfo_OrbitType_FunctionInfo_OrbitType_INT_MIN_SENTINEL_DO_NOT_USE_:
     case orbit_client_protos::
@@ -135,13 +136,13 @@ ErrorMessageOr<CaptureListener::CaptureOutcome> CaptureClient::CaptureSync(
   capture_options->set_max_local_marker_depth_per_command_buffer(
       max_local_marker_depth_per_command_buffer);
   for (const auto& [function_id, function] : selected_functions) {
-    CaptureOptions::InstrumentedFunction* instrumented_function =
-        capture_options->add_instrumented_functions();
+    InstrumentedFunction* instrumented_function = capture_options->add_instrumented_functions();
     instrumented_function->set_file_path(function.loaded_module_path());
     const ModuleData* module = module_manager.GetModuleByPath(function.loaded_module_path());
     CHECK(module != nullptr);
     instrumented_function->set_file_offset(function_utils::Offset(function, *module));
     instrumented_function->set_function_id(function_id);
+    instrumented_function->set_function_name(function.pretty_name());
     instrumented_function->set_function_type(
         InstrumentedFunctionTypeFromOrbitType(function.orbit_type()));
   }


### PR DESCRIPTION
The name is used in new capture file format when saving on the service
side. It is not directly used in capture.

Test: run integration test/unit tests