### PR TITLE
Fix SourceCodeView E2E test after non-modal change

### DIFF
--- a/contrib/automation_tests/test_cases/symbols_tab.py
+++ b/contrib/automation_tests/test_cases/symbols_tab.py
@@ -237,10 +237,8 @@ class ShowSourceCode(E2ETestCase):
     def _handle_source_code_dialog(self):
         logging.info("Waiting for the source code dialog.")
 
-        def get_source_code_dialog():
-            return self.find_control(control_type="Window", name="main.c", parent=self.suite.top_window(), recurse=False)
-        wait_for_condition(lambda: get_source_code_dialog().is_visible())
-        source_code_dialog = get_source_code_dialog()
+        source_code_dialog = self.suite.application.window(auto_id="CodeViewerDialog")
+        source_code_dialog.wait('visible')
 
         logging.info("Found source code dialog. Checking contents...")
         source_code_edit = self.find_control(


### PR DESCRIPTION
The code viewer dialog is not a modal dialog anymore. That means it will
appear as a top level window in the accessibility tree, instead of as a
child element of the main window.

This commit adjusts the E2E test accordingly.