### PR TITLE
Cleanup identifying modules in tracee.

### DIFF
--- a/src/UserSpaceInstrumentation/InjectLibraryInTracee.cpp
+++ b/src/UserSpaceInstrumentation/InjectLibraryInTracee.cpp
@@ -33,14 +33,14 @@ using orbit_elf_utils::ReadModules;
 // Size of the small amount of memory we need in the tracee to write machine code into.
 constexpr uint64_t kCodeScratchPadSize = 1024;
 
-constexpr char kLibcSoname[] = "libc.so.6";
-constexpr char kLibdlSoname[] = "libdl.so.2";
-constexpr char kDlopenInLibdl[] = "dlopen";
-constexpr char kDlopenInLibc[] = "__libc_dlopen_mode";
-constexpr char kDlsymInLibdl[] = "dlsym";
-constexpr char kDlsymInLibc[] = "__libc_dlsym";
-constexpr char kDlcloseInLibdl[] = "dlclose";
-constexpr char kDlcloseInLibc[] = "__libc_dlclose";
+constexpr const char* kLibcSoname = "libc.so.6";
+constexpr const char* kLibdlSoname = "libdl.so.2";
+constexpr const char* kDlopenInLibdl = "dlopen";
+constexpr const char* kDlopenInLibc = "__libc_dlopen_mode";
+constexpr const char* kDlsymInLibdl = "dlsym";
+constexpr const char* kDlsymInLibc = "__libc_dlsym";
+constexpr const char* kDlcloseInLibdl = "dlclose";
+constexpr const char* kDlcloseInLibc = "__libc_dlclose";
 
 // In certain error conditions the tracee is damaged and we don't try to recover from that. We just
 // abort with a fatal log message. None of these errors are expected to occur in operation

--- a/src/UserSpaceInstrumentation/InjectLibraryInTracee.h
+++ b/src/UserSpaceInstrumentation/InjectLibraryInTracee.h
@@ -25,12 +25,12 @@ namespace orbit_user_space_instrumentation {
 
 // Returns the absolute virtual address of a function in a module of a process as resolved by the
 // dynsym section of the file that module is associated with.
-// The function name has to match the symbol name exactly. The module name needs start with the
-// given string and only have version numbering, dashes, and the suffix `so` after that. This is
-// done to allow for different versions of a library to be matched.
+// The function name has to match the symbol name exactly. The module name needs match the soname
+// (compare https://tldp.org/HOWTO/Program-Library-HOWTO/shared-libraries.html) of the module
+// exactly.
 [[nodiscard]] ErrorMessageOr<uint64_t> FindFunctionAddress(pid_t pid,
                                                            std::string_view function_name,
-                                                           std::string_view module_prefix);
+                                                           std::string_view module_soname);
 
 }  // namespace orbit_user_space_instrumentation
 

--- a/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
+++ b/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
@@ -41,9 +41,6 @@ TEST(InjectLibraryInTraceeTest, FindFunctionAddress) {
   auto function_address_or_error = FindFunctionAddress(pid, "printf", "libc.so.6");
   EXPECT_TRUE(function_address_or_error.has_value());
 
-  function_address_or_error = FindFunctionAddress(pid, "dlclose", "libdl.so.2");
-  EXPECT_TRUE(function_address_or_error.has_value());
-
   function_address_or_error = FindFunctionAddress(pid, "NOT_A_SYMBOL", "libc.so.6");
   EXPECT_TRUE(function_address_or_error.has_error());
   EXPECT_TRUE(absl::StrContains(function_address_or_error.error().message(),

--- a/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
+++ b/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
@@ -38,10 +38,13 @@ TEST(InjectLibraryInTraceeTest, FindFunctionAddress) {
   // Stop the child process using our tooling.
   ASSERT_TRUE(AttachAndStopProcess(pid).has_value());
 
-  auto function_address_or_error = FindFunctionAddress(pid, "printf", "libc");
+  auto function_address_or_error = FindFunctionAddress(pid, "printf", "libc.so.6");
   EXPECT_TRUE(function_address_or_error.has_value());
 
-  function_address_or_error = FindFunctionAddress(pid, "NOT_A_SYMBOL", "libc");
+  function_address_or_error = FindFunctionAddress(pid, "dlclose", "libdl.so.2");
+  EXPECT_TRUE(function_address_or_error.has_value());
+
+  function_address_or_error = FindFunctionAddress(pid, "NOT_A_SYMBOL", "libc.so.6");
   EXPECT_TRUE(function_address_or_error.has_error());
   EXPECT_TRUE(absl::StrContains(function_address_or_error.error().message(),
                                 "Unable to locate function symbol"));
@@ -51,7 +54,7 @@ TEST(InjectLibraryInTraceeTest, FindFunctionAddress) {
   EXPECT_TRUE(absl::StrContains(function_address_or_error.error().message(),
                                 "There is no module \"NOT_A_LIB-\" in process"));
 
-  function_address_or_error = FindFunctionAddress(-1, "printf", "libc");
+  function_address_or_error = FindFunctionAddress(-1, "printf", "libc.so.6");
   EXPECT_TRUE(function_address_or_error.has_error());
   EXPECT_TRUE(
       absl::StrContains(function_address_or_error.error().message(), "Unable to open file"));


### PR DESCRIPTION
We now match the soname of libc / libdl exactly to find the modules.
This gets rid of the regular expression used before and removes all
ambiguities.

Bug: http://b/181304023
Test: Unit tests in PR.