### PR TITLE
Set status_code to SUCCESS by deault

### DIFF
--- a/src/MetricsUploader/MetricsUploaderWindows.cpp
+++ b/src/MetricsUploader/MetricsUploaderWindows.cpp
@@ -211,6 +211,7 @@ bool MetricsUploaderImpl::FillAndSendLogEvent(OrbitLogEvent partial_filled_event
 bool MetricsUploaderImpl::SendLogEvent(OrbitLogEvent_LogEventType log_event_type) {
   OrbitLogEvent log_event;
   log_event.set_log_event_type(log_event_type);
+  log_event.set_status_code(OrbitLogEvent_StatusCode_SUCCESS);
   return FillAndSendLogEvent(std::move(log_event));
 }
 
@@ -219,6 +220,7 @@ bool MetricsUploaderImpl::SendLogEvent(OrbitLogEvent_LogEventType log_event_type
   OrbitLogEvent log_event;
   log_event.set_log_event_type(log_event_type);
   log_event.set_event_duration_milliseconds(event_duration.count());
+  log_event.set_status_code(OrbitLogEvent_StatusCode_SUCCESS);
   return FillAndSendLogEvent(std::move(log_event));
 }
 


### PR DESCRIPTION
Previously sent logs had UNKNOWN_STATUS by default, but it's quite hard
to analyze if we want to understand amount of "failed" and "not failed"
events. In most cases we the actual status code is SUCCESS, so this
commit updates the default value.

Test: start Orbit, check that status_code in ORBIT_INITIALIZED event is
"SUCCESS".