### PR TITLE
Add missing return-keywords

### DIFF
--- a/src/UserSpaceInstrumentation/AccessTraceesMemory.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemory.cpp
@@ -48,7 +48,7 @@ using orbit_base::ReadFileToString;
     uint64_t data = 0;
     std::memcpy(&data, bytes.data() + pos, sizeof(uint64_t));
     if (ptrace(PTRACE_POKEDATA, pid, address_start + pos, data) == -1) {
-      ErrorMessage(absl::StrFormat("Failed to PTRACE_POKEDATA for pid: %d.", pid));
+      return ErrorMessage(absl::StrFormat("Failed to PTRACE_POKEDATA for pid: %d.", pid));
     }
     pos += sizeof(uint64_t);
   } while (pos < bytes.size());

--- a/src/UserSpaceInstrumentation/RegisterState.cpp
+++ b/src/UserSpaceInstrumentation/RegisterState.cpp
@@ -137,7 +137,7 @@ ErrorMessageOr<void> RegisterState::RestoreRegisters() {
   iov.iov_base = xsave_area_.data();
   result = ptrace(PTRACE_SETREGSET, tid_, NT_X86_XSTATE, &iov);
   if (result == -1) {
-    ErrorMessage(
+    return ErrorMessage(
         absl::StrFormat("PTRACE_SETREGSET failed to write NT_X86_XSTATE with errno: %d: \"%s\"",
                         errno, SafeStrerror(errno)));
   }


### PR DESCRIPTION
The oss-fuzz build complained about unused values and I assumed they were meant to be returned.