### PR TITLE
fix Werror=stringop-truncation in gcc10

### DIFF
--- a/src/Orbit.h
+++ b/src/Orbit.h
@@ -306,7 +306,7 @@ union EncodedEvent {
     event.type = static_cast<uint8_t>(type);
     memset(event.name, 0, kMaxEventStringSize);
     if (name != nullptr) {
-      std::strncpy(event.name, name, kMaxEventStringSize - 1);
+      std::strncpy(event.name, name, kMaxEventStringSize);
       event.name[kMaxEventStringSize - 1] = 0;
     }
     event.data = data;


### PR DESCRIPTION
resolves #1624

Its seems gcc considers this safe only if the specific pattern is met.
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=87028

```
strncpy(dst, src, size)
dst[size - 1] = 0;
```