### PR TITLE
Support for loading symbols from virtual modules

### DIFF
--- a/src/ElfUtils/LinuxMap.cpp
+++ b/src/ElfUtils/LinuxMap.cpp
@@ -83,8 +83,8 @@ ErrorMessageOr<ModuleInfo> CreateModuleFromBuffer(std::string module_name, std::
   ErrorMessageOr<std::unique_ptr<ElfFile>> elf_file_or_error =
       ElfFile::CreateFromBuffer({}, buffer.data(), buffer.size());
   if (elf_file_or_error.has_error()) {
-    return ErrorMessage(
-        absl::StrFormat("Unable to load module: %s", elf_file_or_error.error().message()));
+    return ErrorMessage(absl::StrFormat("Unable to load module \"%s\": %s", module_name,
+                                        elf_file_or_error.error().message()));
   }
 
   ErrorMessageOr<uint64_t> load_bias_or_error = elf_file_or_error.value()->GetLoadBias();

--- a/src/ElfUtils/LinuxMap.cpp
+++ b/src/ElfUtils/LinuxMap.cpp
@@ -21,6 +21,7 @@
 #include "ElfUtils/ElfFile.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ReadFileToString.h"
+#include "OrbitBase/Result.h"
 
 namespace orbit_elf_utils {
 
@@ -72,6 +73,11 @@ ErrorMessageOr<ModuleInfo> CreateModuleFromFile(const std::filesystem::path& mod
   return module_info;
 }
 
+ErrorMessageOr<orbit_grpc_protos::ModuleInfo> CreateModuleFromFile(const MapEntry& map_entry) {
+  return CreateModuleFromFile(map_entry.module_path, map_entry.start_address,
+                              map_entry.end_address);
+}
+
 ErrorMessageOr<ModuleInfo> CreateModuleFromBuffer(std::string module_name, std::string_view buffer,
                                                   uint64_t start_address, uint64_t end_address) {
   ErrorMessageOr<std::unique_ptr<ElfFile>> elf_file_or_error =
@@ -100,61 +106,88 @@ ErrorMessageOr<ModuleInfo> CreateModuleFromBuffer(std::string module_name, std::
   return module_info;
 }
 
-ErrorMessageOr<std::vector<ModuleInfo>> ReadModules(int32_t pid) {
-  std::filesystem::path proc_maps_path{absl::StrFormat("/proc/%d/maps", pid)};
-  OUTCOME_TRY(proc_maps_data, orbit_base::ReadFileToString(proc_maps_path));
-  return ParseMaps(proc_maps_data);
+ErrorMessageOr<orbit_grpc_protos::ModuleInfo> CreateModuleFromBuffer(const MapEntry& map_entry,
+                                                                     std::string_view buffer) {
+  return CreateModuleFromBuffer(map_entry.module_path, buffer, map_entry.start_address,
+                                map_entry.end_address);
 }
 
-ErrorMessageOr<std::vector<ModuleInfo>> ParseMaps(std::string_view proc_maps_data) {
-  struct AddressRange {
-    uint64_t start_address;
-    uint64_t end_address;
-    bool is_executable;
-  };
+ErrorMessageOr<std::string> ReadProcMapsFile(int32_t pid) {
+  std::filesystem::path proc_maps_path{absl::StrFormat("/proc/%d/maps", pid)};
+  return orbit_base::ReadFileToString(proc_maps_path);
+}
 
-  const std::vector<std::string> proc_maps = absl::StrSplit(proc_maps_data, '\n');
+ErrorMessageOr<std::vector<ModuleInfo>> ReadModules(int32_t pid) {
+  const auto proc_maps_data = ReadProcMapsFile(pid);
+  if (proc_maps_data.has_error()) return proc_maps_data.error();
 
-  std::map<std::string, AddressRange> address_map;
-  for (const std::string& line : proc_maps) {
-    std::vector<std::string> tokens = absl::StrSplit(line, ' ', absl::SkipEmpty());
-    // tokens[4] is the inode column. If inode equals 0, then the memory is not
-    // mapped to a file (might be heap, stack or something else)
-    if (tokens.size() != 6 || tokens[4] == "0") continue;
-
-    const std::string& module_path = tokens[5];
-
-    std::vector<std::string> addresses = absl::StrSplit(tokens[0], '-');
-    if (addresses.size() != 2) continue;
-
-    uint64_t start = std::stoull(addresses[0], nullptr, 16);
-    uint64_t end = std::stoull(addresses[1], nullptr, 16);
-    bool is_executable = tokens[1].size() == 4 && tokens[1][2] == 'x';
-
-    auto iter = address_map.find(module_path);
-    if (iter == address_map.end()) {
-      address_map[module_path] = {start, end, is_executable};
-    } else {
-      AddressRange& address_range = iter->second;
-      address_range.start_address = std::min(address_range.start_address, start);
-      address_range.end_address = std::max(address_range.end_address, end);
-      address_range.is_executable |= is_executable;
-    }
-  }
+  const auto map_entries = ParseMaps(proc_maps_data.value());
 
   std::vector<ModuleInfo> result;
-  for (const auto& [module_path, address_range] : address_map) {
-    // Filter out entries which are not executable
-    if (!address_range.is_executable) continue;
+  result.reserve(map_entries.size());
 
-    ErrorMessageOr<ModuleInfo> module_info_or_error =
-        CreateModuleFromFile(module_path, address_range.start_address, address_range.end_address);
+  for (const MapEntry& entry : map_entries) {
+    if (entry.inode == 0 || !entry.is_executable) continue;
+
+    auto module_info_or_error = CreateModuleFromFile(entry);
     if (module_info_or_error.has_error()) {
       ERROR("Unable to create module: %s", module_info_or_error.error().message());
       continue;
     }
 
-    result.push_back(std::move(module_info_or_error.value()));
+    result.emplace_back(std::move(module_info_or_error.value()));
+  }
+
+  return result;
+}
+
+std::optional<MapEntry> ParseMapEntry(std::string_view proc_maps_line) {
+  std::vector<std::string_view> tokens = absl::StrSplit(proc_maps_line, ' ', absl::SkipEmpty());
+  if (tokens.size() != 6) return std::nullopt;
+
+  std::vector<std::string> addresses = absl::StrSplit(tokens[0], '-');
+  if (addresses.size() != 2) return std::nullopt;
+
+  MapEntry entry{};
+  entry.module_path = tokens[5];
+  entry.start_address = std::stoull(addresses[0], nullptr, 16);
+  entry.end_address = std::stoull(addresses[1], nullptr, 16);
+  entry.is_executable = tokens[1].size() == 4 && tokens[1][2] == 'x';
+
+  // tokens[4] is the inode column. If inode equals 0, then the memory is not
+  // mapped to a file (might be heap, stack or something else)
+  entry.inode = std::stoull(std::string{tokens[4]}, nullptr, 10);
+  return entry;
+}
+
+std::vector<MapEntry> ParseMaps(std::string_view proc_maps_data) {
+  const std::vector<std::string> proc_maps = absl::StrSplit(proc_maps_data, '\n');
+
+  std::map<std::string, MapEntry> address_map;
+  for (const std::string& line : proc_maps) {
+    const std::optional<MapEntry> maybe_map_entry = ParseMapEntry(line);
+
+    if (!maybe_map_entry.has_value()) continue;
+    const auto& map_entry = maybe_map_entry.value();
+
+    auto iter = address_map.find(map_entry.module_path);
+    if (iter == address_map.end()) {
+      address_map[map_entry.module_path] = map_entry;
+    } else {
+      MapEntry& existing_map_entry = iter->second;
+      existing_map_entry.start_address =
+          std::min(existing_map_entry.start_address, map_entry.start_address);
+      existing_map_entry.end_address =
+          std::max(existing_map_entry.end_address, map_entry.end_address);
+      existing_map_entry.is_executable |= map_entry.is_executable;
+    }
+  }
+
+  std::vector<MapEntry> result;
+  result.reserve(address_map.size());
+
+  for (const auto& [module_path, map_entry] : address_map) {
+    result.push_back(map_entry);
   }
 
   return result;

--- a/src/ElfUtils/LinuxMapTest.cpp
+++ b/src/ElfUtils/LinuxMapTest.cpp
@@ -232,7 +232,7 @@ TEST(LinuxMap, CreateModuleFromBufferHelloWorld) {
   constexpr uint64_t kStartAddress = 23;
   constexpr uint64_t kEndAddress = 8004;
   auto buffer_or_error = orbit_base::ReadFileToString(hello_world_path);
-  ASSERT_TRUE(buffer_or_error.has_value());
+  ASSERT_TRUE(buffer_or_error.has_value()) << buffer_or_error.error().message();
   const auto& buffer = buffer_or_error.value();
 
   auto result = CreateModuleFromBuffer(hello_world_path.filename().string(), buffer, kStartAddress,

--- a/src/ElfUtils/include/ElfUtils/LinuxMap.h
+++ b/src/ElfUtils/include/ElfUtils/LinuxMap.h
@@ -19,9 +19,12 @@
 
 namespace orbit_elf_utils {
 
-ErrorMessageOr<orbit_grpc_protos::ModuleInfo> CreateModule(const std::filesystem::path& module_path,
-                                                           uint64_t start_address,
-                                                           uint64_t end_address);
+ErrorMessageOr<orbit_grpc_protos::ModuleInfo> CreateModuleFromFile(
+    const std::filesystem::path& module_path, uint64_t start_address, uint64_t end_address);
+ErrorMessageOr<orbit_grpc_protos::ModuleInfo> CreateModuleFromBuffer(std::string module_name,
+                                                                     std::string_view buffer,
+                                                                     uint64_t start_address,
+                                                                     uint64_t end_address);
 ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> ReadModules(int32_t pid);
 ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> ParseMaps(
     std::string_view proc_maps_data);

--- a/src/ElfUtils/include/ElfUtils/LinuxMap.h
+++ b/src/ElfUtils/include/ElfUtils/LinuxMap.h
@@ -19,15 +19,34 @@
 
 namespace orbit_elf_utils {
 
+// MapEntry combines all the (needed) fields of a single line (mapping) from a Linux
+// /proc/<pid>/maps file.
+//
+// It is the result type of `ParseMapEntry`.
+struct MapEntry {
+  std::string module_path;
+  uint64_t start_address;
+  uint64_t end_address;
+  uint64_t inode;
+  bool is_executable;
+};
+
 ErrorMessageOr<orbit_grpc_protos::ModuleInfo> CreateModuleFromFile(
     const std::filesystem::path& module_path, uint64_t start_address, uint64_t end_address);
+ErrorMessageOr<orbit_grpc_protos::ModuleInfo> CreateModuleFromFile(const MapEntry& map_entry);
+
 ErrorMessageOr<orbit_grpc_protos::ModuleInfo> CreateModuleFromBuffer(std::string module_name,
                                                                      std::string_view buffer,
                                                                      uint64_t start_address,
                                                                      uint64_t end_address);
+ErrorMessageOr<orbit_grpc_protos::ModuleInfo> CreateModuleFromBuffer(const MapEntry& map_entry,
+                                                                     std::string_view buffer);
+
+ErrorMessageOr<std::string> ReadProcMapsFile(int32_t pid);
 ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> ReadModules(int32_t pid);
-ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> ParseMaps(
-    std::string_view proc_maps_data);
+
+std::optional<MapEntry> ParseMapEntry(std::string_view proc_maps_line);
+std::vector<MapEntry> ParseMaps(std::string_view proc_maps_data);
 
 }  // namespace orbit_elf_utils
 

--- a/src/GrpcProtos/module.proto
+++ b/src/GrpcProtos/module.proto
@@ -14,4 +14,5 @@ message ModuleInfo {
   uint64 address_end = 5;
   string build_id = 6;
   uint64 load_bias = 7;
+  bool is_virtual_module = 8;
 }

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -231,8 +231,8 @@ void UprobesUnwindingVisitor::visit(MmapPerfEvent* event) {
   }
 
   ErrorMessageOr<orbit_grpc_protos::ModuleInfo> module_info_or_error =
-      orbit_elf_utils::CreateModule(event->filename(), event->address(),
-                                    event->address() + event->length());
+      orbit_elf_utils::CreateModuleFromFile(event->filename(), event->address(),
+                                            event->address() + event->length());
   if (module_info_or_error.has_error()) {
     ERROR("Unable to create module: %s", module_info_or_error.error().message());
     return;

--- a/src/OrbitClientData/include/OrbitClientData/ModuleData.h
+++ b/src/OrbitClientData/include/OrbitClientData/ModuleData.h
@@ -32,6 +32,10 @@ class ModuleData final {
   [[nodiscard]] const std::string& build_id() const { return module_info_.build_id(); }
   [[nodiscard]] uint64_t load_bias() const { return module_info_.load_bias(); }
   [[nodiscard]] bool is_loaded() const;
+  [[nodiscard]] bool is_virtual_module() const { return module_info_.is_virtual_module(); }
+  [[nodiscard]] uint64_t address_start() const { return module_info_.address_start(); }
+  [[nodiscard]] uint64_t address_end() const { return module_info_.address_end(); }
+
   void UpdateIfChanged(orbit_grpc_protos::ModuleInfo info);
   // relative_address here is the absolute address minus the address this module was loaded at by
   // the process (module base address)

--- a/src/OrbitCore/SymbolHelper.h
+++ b/src/OrbitCore/SymbolHelper.h
@@ -29,7 +29,7 @@ class SymbolHelper {
   [[nodiscard]] ErrorMessageOr<fs::path> FindSymbolsInCache(const fs::path& module_path,
                                                             const std::string& build_id) const;
   [[nodiscard]] static ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> LoadSymbolsFromFile(
-      const fs::path& file_path);
+      const fs::path& file_path, bool also_consider_dynsym = false);
   [[nodiscard]] static ErrorMessageOr<void> VerifySymbolsFile(const fs::path& symbols_path,
                                                               const std::string& build_id);
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1128,11 +1128,10 @@ orbit_base::Future<ErrorMessageOr<std::filesystem::path>> OrbitApp::RetrieveVirt
 
   const auto size = module_data->address_end() - module_data->address_start();
 
-  // 8 MiB - That's also the limit that we support in the `ReadProcessMemory` gRPC endpoint.
-  // It's more than enough for reading [vdso] which is typically around 8 KiB.
-  if (size > 8 * 1024 * 1024) {
+  // 3 MiB - That's more than enough for reading [vdso] which is typically around 8 KiB
+  if (size > 3 * 1024 * 1024) {
     return ErrorMessage{absl::StrFormat(
-        "Module \"%s\" has a size of %d bytes (> 8MiB) and is too large to be read.",
+        "Module \"%s\" has a size of %d bytes (> 3MiB) and is too large to be read.",
         module_data->file_path(), size)};
   }
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -422,6 +422,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
 
   [[nodiscard]] orbit_base::Future<ErrorMessageOr<std::filesystem::path>> RetrieveModuleFromRemote(
       const std::string& module_file_path);
+  [[nodiscard]] orbit_base::Future<ErrorMessageOr<std::filesystem::path>>
+  RetrieveVirtualModuleFromRemote(const ModuleData* module_data);
 
   void SelectFunctionsFromHashes(const ModuleData* module,
                                  absl::Span<const uint64_t> function_hashes);

--- a/src/Service/CMakeLists.txt
+++ b/src/Service/CMakeLists.txt
@@ -34,6 +34,8 @@ target_sources(ServiceLib PRIVATE
         ProcessList.h
         ProcessServiceImpl.cpp
         ProcessServiceImpl.h
+        ProcessUtils.cpp
+        ProcessUtils.h
         ProducerEventProcessor.cpp
         ProducerEventProcessor.h
         ProducerSideServer.cpp
@@ -73,6 +75,7 @@ target_compile_options(ServiceTests PRIVATE ${STRICT_COMPILE_FLAGS})
 target_sources(ServiceTests PRIVATE
         ProcessListTest.cpp
         ProcessTest.cpp
+        ProcessUtilsTest.cpp
         ProducerEventProcessorTest.cpp
         ProducerSideServiceImplTest.cpp
         ServiceUtilsTest.cpp)

--- a/src/Service/ProcessServiceImpl.cpp
+++ b/src/Service/ProcessServiceImpl.cpp
@@ -82,10 +82,10 @@ Status ProcessServiceImpl::GetProcessMemory(ServerContext*, const GetProcessMemo
                                             GetProcessMemoryResponse* response) {
   uint64_t size = std::min(request->size(), kMaxGetProcessMemoryResponseSize);
   response->mutable_memory()->resize(size);
-  uint64_t num_bytes_read = 0;
-  if (utils::ReadProcessMemory(request->pid(), request->address(),
-                               response->mutable_memory()->data(), size, &num_bytes_read)) {
-    response->mutable_memory()->resize(num_bytes_read);
+  const auto result = utils::ReadProcessMemory(request->pid(), request->address(),
+                                               response->mutable_memory()->data(), size);
+  if (result.has_value()) {
+    response->mutable_memory()->resize(result.value());
     return Status::OK;
   }
 

--- a/src/Service/ProcessServiceImpl.cpp
+++ b/src/Service/ProcessServiceImpl.cpp
@@ -17,6 +17,7 @@
 #include "ElfUtils/LinuxMap.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
+#include "ProcessUtils.h"
 #include "ServiceUtils.h"
 #include "module.pb.h"
 #include "process.pb.h"
@@ -66,7 +67,7 @@ Status ProcessServiceImpl::GetModuleList(ServerContext* /*context*/,
   int32_t pid = request->process_id();
   LOG("Sending modules for process %d", pid);
 
-  const auto module_infos = orbit_elf_utils::ReadModules(pid);
+  const auto module_infos = orbit_service::ReadModulesFromProcMaps(pid);
   if (module_infos.has_error()) {
     return Status(StatusCode::NOT_FOUND, module_infos.error().message());
   }

--- a/src/Service/ProcessUtils.cpp
+++ b/src/Service/ProcessUtils.cpp
@@ -49,11 +49,10 @@ ErrorMessageOr<orbit_grpc_protos::ModuleInfo> CreateModuleFromProcessMemory(
 
   const auto size = map_entry.end_address - map_entry.start_address;
 
-  // 8 MiB - That's also the limit that we support in the `ReadProcessMemory` gRPC endpoint.
-  // It's more than enough for reading [vdso] which is typically around 8 KiB.
-  if (size > 8 * 1024 * 1024) {
+  // 3 MiB - It's more than enough for reading [vdso] which is typically around 8 KiB.
+  if (size > 3 * 1024 * 1024) {
     return ErrorMessage{absl::StrFormat(
-        "Module \"%s\" has a size of %d bytes (> 8MiB) and is too large to be read.",
+        "Module \"%s\" has a size of %d bytes (> 3MiB) and is too large to be read.",
         map_entry.module_path, size)};
   }
 

--- a/src/Service/ProcessUtils.cpp
+++ b/src/Service/ProcessUtils.cpp
@@ -1,0 +1,71 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ProcessUtils.h"
+
+#include "OrbitBase/Logging.h"
+#include "ServiceUtils.h"
+
+namespace orbit_service {
+
+ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> ReadModulesFromProcMaps(int32_t pid) {
+  const auto proc_maps_data = orbit_elf_utils::ReadProcMapsFile(pid);
+  if (proc_maps_data.has_error()) return proc_maps_data.error();
+
+  const auto map_entries = orbit_elf_utils::ParseMaps(proc_maps_data.value());
+
+  std::vector<orbit_grpc_protos::ModuleInfo> result;
+  result.reserve(map_entries.size());
+
+  for (const orbit_elf_utils::MapEntry& entry : map_entries) {
+    if (!entry.is_executable) continue;
+
+    ErrorMessageOr<orbit_grpc_protos::ModuleInfo> module_info_or_error = ErrorMessage{};
+
+    if (entry.inode != 0) {
+      module_info_or_error = CreateModuleFromFile(entry);
+    } else {
+      module_info_or_error = CreateModuleFromProcessMemory(pid, entry);
+    }
+
+    if (module_info_or_error.has_error()) {
+      ERROR("Unable to create module: %s", module_info_or_error.error().message());
+      continue;
+    }
+
+    result.emplace_back(std::move(module_info_or_error.value()));
+  }
+
+  return result;
+}
+
+ErrorMessageOr<orbit_grpc_protos::ModuleInfo> CreateModuleFromProcessMemory(
+    int32_t pid, const orbit_elf_utils::MapEntry& map_entry) {
+  if (map_entry.end_address <= map_entry.start_address) {
+    return ErrorMessage{
+        absl::StrFormat("Invalid address range for module \"%s\".", map_entry.module_path)};
+  }
+
+  const auto size = map_entry.end_address - map_entry.start_address;
+
+  // 8 MiB - That's also the limit that we support in the `ReadProcessMemory` gRPC endpoint.
+  // It's more than enough for reading [vdso] which is typically around 8 KiB.
+  if (size > 8 * 1024 * 1024) {
+    return ErrorMessage{absl::StrFormat(
+        "Module \"%s\" has a size of %d bytes (> 8MiB) and is too large to be read.",
+        map_entry.module_path, size)};
+  }
+
+  std::string buffer(size, '\0');
+  const auto result =
+      utils::ReadProcessMemory(pid, map_entry.start_address, buffer.data(), buffer.size());
+
+  if (result.has_error()) {
+    return ErrorMessage{absl::StrFormat("Failed to read process memory for module \"%s\": %s",
+                                        map_entry.module_path, result.error().message())};
+  }
+
+  return orbit_elf_utils::CreateModuleFromBuffer(map_entry, buffer);
+}
+}  // namespace orbit_service

--- a/src/Service/ProcessUtils.h
+++ b/src/Service/ProcessUtils.h
@@ -17,7 +17,7 @@ namespace orbit_service {
 // into account.
 ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> ReadModulesFromProcMaps(int32_t pid);
 
-// CreateProcessMemoryBackedModuleFromMapEntry can create a ModuleInfo object by reading the ELF
+// CreateModuleFromProcessMemory can create a ModuleInfo object by reading the ELF
 // file from the mapped section in the target process. This is handy for modules which don't exist
 // on the filesystem like the [vdso] module.
 ErrorMessageOr<orbit_grpc_protos::ModuleInfo> CreateModuleFromProcessMemory(

--- a/src/Service/ProcessUtils.h
+++ b/src/Service/ProcessUtils.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_SERVICE_PROCESS_UTILS_H_
+#define ORBIT_SERVICE_PROCESS_UTILS_H_
+
+#include <stdint.h>
+
+#include "ElfUtils/LinuxMap.h"
+#include "OrbitBase/Result.h"
+#include "module.pb.h"
+
+namespace orbit_service {
+
+// This function is similar to orbit_elf_utils::ReadModules, but it also takes virtual modules
+// into account.
+ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> ReadModulesFromProcMaps(int32_t pid);
+
+// CreateProcessMemoryBackedModuleFromMapEntry can create a ModuleInfo object by reading the ELF
+// file from the mapped section in the target process. This is handy for modules which don't exist
+// on the filesystem like the [vdso] module.
+ErrorMessageOr<orbit_grpc_protos::ModuleInfo> CreateModuleFromProcessMemory(
+    int32_t pid, const orbit_elf_utils::MapEntry& map_entry);
+
+}  // namespace orbit_service
+
+#endif  // ORBIT_SERVICE_PROCESS_UTILS_H_

--- a/src/Service/ProcessUtilsTest.cpp
+++ b/src/Service/ProcessUtilsTest.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <absl/strings/str_format.h>
+#include <absl/strings/str_split.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+
+#include "ElfUtils/LinuxMap.h"
+#include "OrbitBase/ExecutablePath.h"
+#include "ProcessUtils.h"
+#include "module.pb.h"
+
+TEST(ProcessUtils, CreateProcessMemoryBackedModuleFromMapEntry) {
+  const auto maps_data = orbit_elf_utils::ReadProcMapsFile(getpid());
+  ASSERT_TRUE(maps_data.has_value());
+
+  const auto maps = orbit_elf_utils::ParseMaps(maps_data.value());
+
+  const auto is_vdso = [](const orbit_elf_utils::MapEntry& entry) {
+    return entry.module_path == "[vdso]";
+  };
+
+  const auto it = std::find_if(maps.begin(), maps.end(), is_vdso);
+
+  if (it == maps.end()) {
+    GTEST_SKIP() << "The test process has no [vdso] module, so we can't test loading it.";
+  }
+
+  const auto module = orbit_service::CreateModuleFromProcessMemory(getpid(), *it);
+  if (module.has_error() &&
+      absl::StrContains(module.error().message(), "Operation not permitted")) {
+    GTEST_SKIP() << absl::StrFormat("Can't perform the test due to missing PTRACE privileges: %s",
+                                    module.error().message());
+  }
+  ASSERT_FALSE(module.has_error()) << module.error().message();
+
+  EXPECT_EQ(module.value().name(), "[vdso]");
+  EXPECT_EQ(module.value().load_bias(), 0x0);
+}
+
+TEST(ProcessUtils, ReadModulesFromProcMaps) {
+  const auto modules_or_error = orbit_service::ReadModulesFromProcMaps(getpid());
+  ASSERT_FALSE(modules_or_error.has_error()) << modules_or_error.error().message();
+
+  const auto& modules = modules_or_error.value();
+  EXPECT_GE(modules.size(), 2);  // At least the test-executable, and libc.
+
+  bool has_test_executable = false;
+  bool has_libc = false;
+
+  for (const orbit_grpc_protos::ModuleInfo& module : modules) {
+    if (module.name() == orbit_base::GetExecutablePath().filename().string()) {
+      has_test_executable = true;
+      continue;
+    }
+    if (absl::StartsWith(module.name(), "libc")) {
+      has_libc = true;
+      continue;
+    }
+  }
+
+  EXPECT_TRUE(has_test_executable);
+  EXPECT_TRUE(has_libc);
+}

--- a/src/Service/ProcessUtilsTest.cpp
+++ b/src/Service/ProcessUtilsTest.cpp
@@ -13,7 +13,7 @@
 #include "ProcessUtils.h"
 #include "module.pb.h"
 
-TEST(ProcessUtils, CreateProcessMemoryBackedModuleFromMapEntry) {
+TEST(ProcessUtils, CreateModuleFromProcessMemory) {
   const auto maps_data = orbit_elf_utils::ReadProcMapsFile(getpid());
   ASSERT_TRUE(maps_data.has_value());
 

--- a/src/Service/ServiceUtils.h
+++ b/src/Service/ServiceUtils.h
@@ -49,8 +49,9 @@ ErrorMessageOr<std::filesystem::path> FindSymbolsFilePath(
         "/home/cloudcast/", "/home/cloudcast/debug_symbols/", "/mnt/developer/",
         "/mnt/developer/debug_symbols/", "/srv/game/assets/",
         "/srv/game/assets/debug_symbols/"}) noexcept;
-bool ReadProcessMemory(int32_t pid, uintptr_t address, void* buffer, uint64_t size,
-                       uint64_t* num_bytes_read) noexcept;
+
+ErrorMessageOr<uint64_t> ReadProcessMemory(int32_t pid, uintptr_t address, void* buffer,
+                                           uint64_t size) noexcept;
 }  // namespace orbit_service::utils
 
 #endif  // ORBIT_SERVICE_SERVICE_UTILS_H_


### PR DESCRIPTION
Adds support for loading symbols from virtual modules in Orbit by doing the following steps:

1. Add a function that can create `ModuleInfo` by reading the ELF file from a buffer, instead of a file
2. Changing the `/proc/<pid>/maps` parsing code to consider all executable maps at first. When creating `ModuleInfo` objects, we will filter out all maps that aren't mapped ELF files in memory. Handling of file-backed maps stay the same. They are still read from filesystem
3. Extend `SymbolHelper` to allow considering the `.dynsym` section as a fallback symbol source.
4. Add function `OrbitApp::RetrieveVirtualModuleFromRemote` which can load virtual modules by using the `ReadProcessMemory` gRPC call which is currently used for the disassembly view as well. The resulting ELF will be written into the symbol cache and can be considered a regular ELF file from that point on.
5. Wire all those extra functions into the normal `LoadSymbols`-code path.