### PR TITLE
Fix scroll position not being updated after filtering

### DIFF
--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -579,7 +579,7 @@ void TimeGraph::UpdatePrimitives(PickingMode picking_mode) {
 
   track_manager_->SortTracks();
   track_manager_->UpdateMovingTrackSorting();
-  track_manager_->UpdateTracks(&batcher_, min_tick, max_tick, picking_mode);
+  track_manager_->UpdateTrackPrimitives(&batcher_, min_tick, max_tick, picking_mode);
 
   update_primitives_requested_ = false;
 }

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -49,8 +49,9 @@ class TrackManager {
   void SortTracks();
   void SetFilter(const std::string& filter);
 
-  void UpdateTracks(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                    PickingMode picking_mode);
+  void UpdateTrackPrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                             PickingMode picking_mode);
+
   [[nodiscard]] float GetTracksTotalHeight() const { return tracks_total_height_; }
 
   SchedulerTrack* GetOrCreateSchedulerTrack();
@@ -70,6 +71,8 @@ class TrackManager {
   void UpdateFilteredTrackList();
   [[nodiscard]] int FindMovingTrackIndex();
   [[nodiscard]] std::vector<ThreadTrack*> GetSortedThreadTracks();
+
+  void UpdateTrackPositions();
 
   mutable std::recursive_mutex mutex_;
 


### PR DESCRIPTION
The height and position of the tracks was only updated on rendering, but the overall height of the TimeGraph is needed to determine the extent of the scrollbar.

Changed the behavior to have the height / pos calculation independent of the rendering.

Bug: b/182978978
To verify:
1) Take a capture
2) Scroll down in the capture window
3) Filter tracks

Before, the vertical scroll position was not updated. Now, it's updated.