### PR TITLE
Use DWARF's subroutine information to determine the beginning of a function in source code

### DIFF
--- a/src/ElfUtils/ElfFileTest.cpp
+++ b/src/ElfUtils/ElfFileTest.cpp
@@ -361,3 +361,20 @@ TEST(ElfFile, GetSonameForFileWithoutSoname) {
 
   EXPECT_EQ(elf_file_or_error.value()->GetSoname(), "");
 }
+
+TEST(ElfFile, GetDeclarationLocationOfFunction) {
+  const std::filesystem::path file_path =
+      orbit_base::GetExecutableDir() / "testdata" / "line_info_test_binary";
+
+  auto program = ElfFile::Create(file_path);
+  ASSERT_TRUE(program.has_value()) << program.error().message();
+
+  constexpr uint64_t kAddressOfMainFunction = 0x401140;
+  ErrorMessageOr<orbit_grpc_protos::LineInfo> decl_line_info =
+      program.value()->GetDeclarationLocationOfFunction(kAddressOfMainFunction);
+  ASSERT_TRUE(decl_line_info.has_value()) << decl_line_info.error().message();
+
+  EXPECT_EQ(decl_line_info.value().source_line(), 12);
+  EXPECT_EQ(std::filesystem::path{decl_line_info.value().source_file()}.filename().string(),
+            "LineInfoTestBinary.cpp");
+}

--- a/src/ElfUtils/include/ElfUtils/ElfFile.h
+++ b/src/ElfUtils/include/ElfUtils/ElfFile.h
@@ -64,6 +64,8 @@ class ElfFile {
   [[nodiscard]] virtual std::filesystem::path GetFilePath() const = 0;
   [[nodiscard]] virtual ErrorMessageOr<orbit_grpc_protos::LineInfo> GetLineInfo(
       uint64_t address) = 0;
+  [[nodiscard]] virtual ErrorMessageOr<orbit_grpc_protos::LineInfo>
+  GetDeclarationLocationOfFunction(uint64_t address) = 0;
   [[nodiscard]] virtual std::optional<GnuDebugLinkInfo> GetGnuDebugLinkInfo() const = 0;
 
   [[nodiscard]] static ErrorMessageOr<std::unique_ptr<ElfFile>> Create(

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -549,15 +549,16 @@ void OrbitApp::ShowSourceCode(const orbit_client_protos::FunctionInfo& function)
           [this, module,
            function](const std::filesystem::path& local_file_path) -> ErrorMessageOr<void> {
             const auto elf_file = orbit_elf_utils::ElfFile::Create(local_file_path);
-            const auto first_line_info_or_error = elf_file.value()->GetLineInfo(function.address());
+            const auto decl_line_info_or_error =
+                elf_file.value()->GetDeclarationLocationOfFunction(function.address());
 
-            if (first_line_info_or_error.has_error()) {
+            if (decl_line_info_or_error.has_error()) {
               return ErrorMessage{absl::StrFormat(
-                  "Could not find source code line info for function \"%s\" in module \"%s\": %s",
+                  "Could not find source code location of function \"%s\" in module \"%s\": %s",
                   function.pretty_name(), module->file_path(),
-                  first_line_info_or_error.error().message())};
+                  decl_line_info_or_error.error().message())};
             }
-            const auto& line_info = first_line_info_or_error.value();
+            const auto& line_info = decl_line_info_or_error.value();
             auto source_file_path =
                 std::filesystem::path{line_info.source_file()}.lexically_normal();
 


### PR DESCRIPTION
We used to use the line number of the first instruction to determine the beginning of a function. This can obviously go wrong and might not even be close to the beginning of a function in source code.

So this PR changes that and reads the subroutine attributions DW_AT_DECL_LINE and DW_AT_DECL_FILE to determine the actual beginning of a function in source.

This information is used to jump to the correct line in the source code view.