### PR TITLE
Always enable file select

### DIFF
--- a/src/OrbitQt/ProfilingTargetDialog.cpp
+++ b/src/OrbitQt/ProfilingTargetDialog.cpp
@@ -232,6 +232,7 @@ void ProfilingTargetDialog::SetupStadiaStates() {
   // STATE state_stadia_
   state_stadia_.addTransition(ui_->loadCaptureRadioButton, &QRadioButton::clicked,
                               &state_file_history_);
+  state_stadia_.addTransition(this, &ProfilingTargetDialog::FileSelected, &state_file_selected_);
   state_stadia_.addTransition(ui_->localProfilingRadioButton, &QRadioButton::clicked,
                               &state_local_history_);
   state_stadia_.addTransition(ui_->stadiaWidget, &ConnectToStadiaWidget::Disconnected,
@@ -317,6 +318,7 @@ void ProfilingTargetDialog::SetupLocalStates() {
                              &state_stadia_history_);
   state_local_.addTransition(ui_->loadCaptureRadioButton, &QRadioButton::clicked,
                              &state_file_history_);
+  state_local_.addTransition(this, &ProfilingTargetDialog::FileSelected, &state_file_selected_);
 
   // STATE state_local_connecting_
   state_local_connecting_.addTransition(this, &ProfilingTargetDialog::ProcessListUpdated,
@@ -372,7 +374,6 @@ void ProfilingTargetDialog::SetupFileStates() {
   state_file_.assignProperty(ui_->stadiaWidget, "active", false);
   state_file_.assignProperty(ui_->loadCaptureRadioButton, "checked", true);
   state_file_.assignProperty(ui_->processesFrame, "enabled", false);
-  state_file_.assignProperty(ui_->selectFileButton, "enabled", true);
   state_file_.assignProperty(ui_->localProfilingRadioButton, "checked", false);
   state_file_.assignProperty(ui_->targetLabel, "text", "");
 

--- a/src/OrbitQt/ProfilingTargetDialog.cpp
+++ b/src/OrbitQt/ProfilingTargetDialog.cpp
@@ -118,7 +118,7 @@ ProfilingTargetDialog::ProfilingTargetDialog(
     ui_->localFrame->setVisible(true);
   }
 
-  QObject::connect(ui_->loadFromFileButton, &QPushButton::clicked, this,
+  QObject::connect(ui_->selectFileButton, &QPushButton::clicked, this,
                    &ProfilingTargetDialog::SelectFile);
   // This and the next connect makes the radiobuttons behave as if they were in a exclusive button
   // group. If a user clicks on one of these and it was not checked before, it is checked afterwards
@@ -372,7 +372,7 @@ void ProfilingTargetDialog::SetupFileStates() {
   state_file_.assignProperty(ui_->stadiaWidget, "active", false);
   state_file_.assignProperty(ui_->loadCaptureRadioButton, "checked", true);
   state_file_.assignProperty(ui_->processesFrame, "enabled", false);
-  state_file_.assignProperty(ui_->loadFromFileButton, "enabled", true);
+  state_file_.assignProperty(ui_->selectFileButton, "enabled", true);
   state_file_.assignProperty(ui_->localProfilingRadioButton, "checked", false);
   state_file_.assignProperty(ui_->targetLabel, "text", "");
 

--- a/src/OrbitQt/ProfilingTargetDialog.ui
+++ b/src/OrbitQt/ProfilingTargetDialog.ui
@@ -188,7 +188,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QPushButton" name="loadFromFileButton">
+             <widget class="QPushButton" name="selectFileButton">
               <property name="enabled">
                <bool>false</bool>
               </property>

--- a/src/OrbitQt/ProfilingTargetDialog.ui
+++ b/src/OrbitQt/ProfilingTargetDialog.ui
@@ -190,7 +190,7 @@
             <item>
              <widget class="QPushButton" name="selectFileButton">
               <property name="enabled">
-               <bool>false</bool>
+               <bool>true</bool>
               </property>
               <property name="text">
                <string>...</string>


### PR DESCRIPTION
This always enable the file selection button ( ... ) for loading captures from the session setup window 