### PR TITLE
Less restrictive remember checkbox

### DIFF
--- a/src/OrbitQt/ConnectToStadiaWidget.cpp
+++ b/src/OrbitQt/ConnectToStadiaWidget.cpp
@@ -74,7 +74,7 @@ ConnectToStadiaWidget::ConnectToStadiaWidget(QWidget* parent)
   QObject::connect(ui_->instancesTableView->selectionModel(), &QItemSelectionModel::currentChanged,
                    this, &ConnectToStadiaWidget::OnSelectionChanged);
   QObject::connect(ui_->rememberCheckBox, &QCheckBox::toggled, this,
-                   &ConnectToStadiaWidget::OnRememberCheckBoxToggled);
+                   &ConnectToStadiaWidget::UpdateRememberInstance);
   QObject::connect(ui_->refreshButton, &QPushButton::clicked, this,
                    [this]() { emit InstanceReloadRequested(); });
 
@@ -352,9 +352,9 @@ void ConnectToStadiaWidget::OnSelectionChanged(const QModelIndex& current) {
   emit InstanceSelected();
 }
 
-void ConnectToStadiaWidget::OnRememberCheckBoxToggled(bool checked) {
+void ConnectToStadiaWidget::UpdateRememberInstance(bool value) {
   QSettings settings;
-  if (checked) {
+  if (value) {
     CHECK(selected_instance_ != std::nullopt);
     settings.setValue(kRememberChosenInstance, selected_instance_->id);
   } else {

--- a/src/OrbitQt/ConnectToStadiaWidget.h
+++ b/src/OrbitQt/ConnectToStadiaWidget.h
@@ -62,7 +62,7 @@ class ConnectToStadiaWidget : public QWidget {
   void OnConnectToStadiaRadioButtonClicked(bool checked);
   void OnErrorOccurred(const QString& message);
   void OnSelectionChanged(const QModelIndex& current);
-  void OnRememberCheckBoxToggled(bool checked);
+  void UpdateRememberInstance(bool value);
 
  signals:
   void ErrorOccurred(const QString& message);

--- a/src/OrbitQt/ConnectToStadiaWidget.ui
+++ b/src/OrbitQt/ConnectToStadiaWidget.ui
@@ -231,7 +231,7 @@
                <item>
                 <widget class="QCheckBox" name="rememberCheckBox">
                  <property name="enabled">
-                  <bool>false</bool>
+                  <bool>true</bool>
                  </property>
                  <property name="toolTip">
                   <string>Connect to the selected instance on Orbits next start</string>


### PR DESCRIPTION
This enables the "Automatically connect to this instance next time" immediately after a selection was made. Before hand it was only enabled after the connection was established.