### PR TITLE
Add custom unwindstack::Memory to support unwinding vDSO samples

### DIFF
--- a/src/LinuxTracing/LibunwindstackUnwinder.h
+++ b/src/LinuxTracing/LibunwindstackUnwinder.h
@@ -25,8 +25,9 @@ class LibunwindstackUnwinder {
   static std::unique_ptr<unwindstack::BufferMaps> ParseMaps(const std::string& maps_buffer);
 
   std::vector<unwindstack::FrameData> Unwind(
-      unwindstack::Maps* maps, const std::array<uint64_t, PERF_REG_X86_64_MAX>& perf_regs,
-      const void* stack_dump, uint64_t stack_dump_size);
+      pid_t pid, unwindstack::Maps* maps,
+      const std::array<uint64_t, PERF_REG_X86_64_MAX>& perf_regs, const void* stack_dump,
+      uint64_t stack_dump_size);
 
  private:
   static constexpr size_t MAX_FRAMES = 1024;  // This is arbitrary.


### PR DESCRIPTION
`StackAndProcessMemory` still carries the stack sample collected with
`perf_event_open` like done before with `CreateOfflineMemory`, but it also
allows to read online from the memory of the process.
This allows to unwind callstacks that involve virtual modules.
It really brings down the number of unwinding errors, on Trata from ~0.8 % to
almost zero, on Infiltrator from ~2.5% to ~0.3%.

Bug: http://b/182895433

Test: Tested on Trata and Infiltrator to see that callstacks still look good,
and that we get a reasonable number of `[vdso]` callstacks now (relatively a lot
of them on Infiltrator, actually).