### PR TITLE
Disable filter panels when no capture is present

### DIFF
--- a/src/OrbitQt/FilterPanelWidget.cpp
+++ b/src/OrbitQt/FilterPanelWidget.cpp
@@ -32,3 +32,8 @@ void FilterPanelWidget::SetFilterFunctionsText(const QString& text) {
 }
 
 void FilterPanelWidget::SetTimerLabelText(const QString& text) { ui->timerLabel->setText(text); }
+
+void FilterPanelWidget::ClearEdits() {
+  ui->filterFunctions->clear();
+  ui->filterTracks->clear();
+}

--- a/src/OrbitQt/FilterPanelWidget.h
+++ b/src/OrbitQt/FilterPanelWidget.h
@@ -25,6 +25,8 @@ class FilterPanelWidget : public QFrame {
   void SetFilterFunctionsText(const QString& text);
   void SetTimerLabelText(const QString& text);
 
+  void ClearEdits();
+
  signals:
   void FilterTracksTextChanged(const QString& text);
   void FilterFunctionsTextChanged(const QString& text);

--- a/src/OrbitQt/FilterPanelWidgetAction.cpp
+++ b/src/OrbitQt/FilterPanelWidgetAction.cpp
@@ -27,3 +27,5 @@ QWidget* FilterPanelWidgetAction::createWidget(QWidget* parent) {
           &FilterPanelWidget::SetFilterFunctionsText);
   return filter_panel_;
 }
+
+void FilterPanelWidgetAction::ClearEdits() { filter_panel_->ClearEdits(); }

--- a/src/OrbitQt/FilterPanelWidgetAction.h
+++ b/src/OrbitQt/FilterPanelWidgetAction.h
@@ -26,6 +26,8 @@ class FilterPanelWidgetAction : public QWidgetAction {
   explicit FilterPanelWidgetAction(QWidget* parent);
   QWidget* createWidget(QWidget* parent);
 
+  void ClearEdits();
+
  signals:
   void FilterFunctionsTextChanged(const QString& text);
   void FilterTracksTextChanged(const QString& text);

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -207,6 +207,7 @@ void OrbitMainWindow::SetupMainWindow() {
 
   app_->SetCaptureStartedCallback([this] {
     UpdateCaptureStateDependentWidgets();
+    ClearCaptureFilters();
     setWindowTitle({});
   });
 
@@ -548,6 +549,8 @@ void OrbitMainWindow::UpdateProcessConnectionStateDependentWidgets() {
 
   UpdateCaptureToolbarIconOpacity();
 }
+
+void OrbitMainWindow::ClearCaptureFilters() { filter_panel_action_->ClearEdits(); }
 
 void OrbitMainWindow::UpdateActiveTabsAfterSelection(bool selection_has_samples) {
   const QTabWidget* capture_parent = FindParentTabWidget(ui->CaptureTab);

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -517,6 +517,8 @@ void OrbitMainWindow::UpdateCaptureStateDependentWidgets() {
   ui->actionOpen_Preset->setEnabled(!is_capturing && is_connected_);
   ui->actionSave_Preset_As->setEnabled(!is_capturing);
 
+  filter_panel_action_->setEnabled(has_data);
+
   hint_frame_->setVisible(!has_data);
 
   UpdateCaptureToolbarIconOpacity();

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -156,6 +156,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   void CreateTabBarContextMenu(QTabWidget* tab_widget, int tab_index, const QPoint pos);
   void UpdateCaptureStateDependentWidgets();
   void UpdateProcessConnectionStateDependentWidgets();
+  void ClearCaptureFilters();
 
   void UpdateActiveTabsAfterSelection(bool selection_has_samples);
 


### PR DESCRIPTION
Bug: b/183111923

Filtering in the capture window causes a crash when no capture data is present. Solved by disabling the filtering panel before taking a capture as there is no use for it, and this avoids getting us into an inconsistent state.

In addition, this clears the filters when restarting a capture. This was a bug before:
1) Start a capture
2) Filter tracks
3) Restart capture

This leaves the filter in place, but it does not affect the displayed tracks.