### PR TITLE
Use InstrumentedFunction instead of FunctionInfo where appropriate

### DIFF
--- a/src/OrbitCaptureClient/ApiEventProcessorTest.cpp
+++ b/src/OrbitCaptureClient/ApiEventProcessorTest.cpp
@@ -25,7 +25,7 @@ namespace {
 class EmptyCaptureListener : public CaptureListener {
  public:
   void OnCaptureStarted(ProcessData&&,
-                        absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>,
+                        absl::flat_hash_map<uint64_t, orbit_grpc_protos::InstrumentedFunction>,
                         TracepointInfoSet, absl::flat_hash_set<uint64_t>) override {}
   void OnTimer(const orbit_client_protos::TimerInfo&) override {}
   void OnKeyAndString(uint64_t, std::string) override {}

--- a/src/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/src/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -34,7 +34,8 @@ class MyCaptureListener : public CaptureListener {
  private:
   void OnCaptureStarted(
       ProcessData&& /*process*/,
-      absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> /*selected_functions*/,
+      absl::flat_hash_map<uint64_t,
+                          orbit_grpc_protos::InstrumentedFunction> /*instrumented_functions*/,
       TracepointInfoSet /*selected_tracepoints*/,
       absl::flat_hash_set<uint64_t> /*frame_track_function_ids*/) override {}
   void OnTimer(const TimerInfo&) override {}

--- a/src/OrbitCaptureClient/CaptureEventProcessorTest.cpp
+++ b/src/OrbitCaptureClient/CaptureEventProcessorTest.cpp
@@ -44,6 +44,7 @@ using orbit_grpc_protos::GpuJob;
 using orbit_grpc_protos::GpuQueueSubmission;
 using orbit_grpc_protos::GpuQueueSubmissionMetaInfo;
 using orbit_grpc_protos::GpuSubmitInfo;
+using orbit_grpc_protos::InstrumentedFunction;
 using orbit_grpc_protos::InternedCallstack;
 using orbit_grpc_protos::InternedString;
 using orbit_grpc_protos::InternedTracepointInfo;
@@ -63,13 +64,12 @@ namespace {
 
 class MockCaptureListener : public CaptureListener {
  public:
-  MOCK_METHOD(
-      void, OnCaptureStarted,
-      (ProcessData&& /*process*/,
-       (absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>)/*selected_functions*/,
-       TracepointInfoSet /*selected_tracepoints*/,
-       absl::flat_hash_set<uint64_t> /*frame_track_function_ids*/),
-      (override));
+  MOCK_METHOD(void, OnCaptureStarted,
+              (ProcessData&& /*process*/,
+               (absl::flat_hash_map<uint64_t, InstrumentedFunction>)/*instrumented_functions*/,
+               TracepointInfoSet /*selected_tracepoints*/,
+               absl::flat_hash_set<uint64_t> /*frame_track_function_ids*/),
+              (override));
   MOCK_METHOD(void, OnTimer, (const TimerInfo&), (override));
   MOCK_METHOD(void, OnKeyAndString, (uint64_t /*key*/, std::string), (override));
   MOCK_METHOD(void, OnUniqueCallStack, (CallStack), (override));

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
@@ -69,7 +69,7 @@ class CaptureClient {
  private:
   ErrorMessageOr<CaptureListener::CaptureOutcome> CaptureSync(
       ProcessData&& process, const orbit_client_data::ModuleManager& module_manager,
-      absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
+      const absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>& selected_functions,
       TracepointInfoSet selected_tracepoints,
       absl::flat_hash_set<uint64_t> frame_track_function_ids, bool collect_thread_state,
       bool enable_introspection, uint64_t max_local_marker_depth_per_command_buffer);

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
@@ -11,6 +11,7 @@
 #include "OrbitClientData/TracepointCustom.h"
 #include "OrbitClientData/UserDefinedCaptureData.h"
 #include "absl/container/flat_hash_set.h"
+#include "capture.pb.h"
 #include "capture_data.pb.h"
 
 class CaptureListener {
@@ -22,7 +23,7 @@ class CaptureListener {
   // Called after capture started but before the first event arrived.
   virtual void OnCaptureStarted(
       ProcessData&& process,
-      absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> instrumented_functions,
+      absl::flat_hash_map<uint64_t, orbit_grpc_protos::InstrumentedFunction> instrumented_functions,
       TracepointInfoSet selected_tracepoints,
       absl::flat_hash_set<uint64_t> frame_track_function_ids) = 0;
 

--- a/src/OrbitClientData/ModuleData.cpp
+++ b/src/OrbitClientData/ModuleData.cpp
@@ -138,7 +138,7 @@ std::vector<FunctionInfo> ModuleData::GetOrbitFunctions() const {
   CHECK(is_loaded_);
   std::vector<FunctionInfo> result;
   for (const auto& [_, function] : functions_) {
-    if (function_utils::IsOrbitFunc(*function)) {
+    if (function_utils::IsOrbitFunctionFromType(function->orbit_type())) {
       result.emplace_back(*function);
     }
   }

--- a/src/OrbitClientData/include/OrbitClientData/FunctionUtils.h
+++ b/src/OrbitClientData/include/OrbitClientData/FunctionUtils.h
@@ -23,6 +23,7 @@ namespace function_utils {
   return func.pretty_name().empty() ? func.name() : func.pretty_name();
 }
 
+[[nodiscard]] std::string GetLoadedModuleNameByPath(std::string_view module_path);
 [[nodiscard]] std::string GetLoadedModuleName(const orbit_client_protos::FunctionInfo& func);
 [[nodiscard]] uint64_t GetHash(const orbit_client_protos::FunctionInfo& func);
 
@@ -36,14 +37,19 @@ namespace function_utils {
          module.load_bias();
 }
 
-[[nodiscard]] bool IsOrbitFunc(const orbit_client_protos::FunctionInfo& func);
+[[nodiscard]] bool IsOrbitFunctionFromType(
+    const orbit_client_protos::FunctionInfo::OrbitType& type);
+
+[[nodiscard]] bool IsOrbitFunctionFromName(const std::string& function_name);
 
 [[nodiscard]] std::unique_ptr<orbit_client_protos::FunctionInfo> CreateFunctionInfo(
     const orbit_grpc_protos::SymbolInfo& symbol_info, const std::string& module_path);
 
 [[nodiscard]] const absl::flat_hash_map<std::string, orbit_client_protos::FunctionInfo::OrbitType>&
 GetFunctionNameToOrbitTypeMap();
-bool SetOrbitTypeFromName(orbit_client_protos::FunctionInfo* func);
+[[nodiscard]] orbit_client_protos::FunctionInfo::OrbitType GetOrbitTypeByName(
+    const std::string& function_name);
+void SetOrbitTypeFromName(orbit_client_protos::FunctionInfo* func);
 
 }  // namespace function_utils
 

--- a/src/OrbitClientGgp/include/OrbitClientGgp/ClientGgp.h
+++ b/src/OrbitClientGgp/include/OrbitClientGgp/ClientGgp.h
@@ -50,7 +50,7 @@ class ClientGgp final : public CaptureListener {
   // CaptureListener implementation
   void OnCaptureStarted(
       ProcessData&& process,
-      absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
+      absl::flat_hash_map<uint64_t, orbit_grpc_protos::InstrumentedFunction> instrumented_functions,
       TracepointInfoSet selected_tracepoints,
       absl::flat_hash_set<uint64_t> frame_track_function_ids) override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;

--- a/src/OrbitClientModel/CaptureDeserializerLoadFuzzer.cpp
+++ b/src/OrbitClientModel/CaptureDeserializerLoadFuzzer.cpp
@@ -22,7 +22,7 @@ namespace {
 class MockCaptureListener : public CaptureListener {
  public:
   void OnCaptureStarted(ProcessData&&,
-                        absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>,
+                        absl::flat_hash_map<uint64_t, orbit_grpc_protos::InstrumentedFunction>,
                         TracepointInfoSet, absl::flat_hash_set<uint64_t>) override {}
 
   void OnTimer(const orbit_client_protos::TimerInfo&) override {}

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -134,7 +134,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
 
   void OnCaptureStarted(
       ProcessData&& process,
-      absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
+      absl::flat_hash_map<uint64_t, orbit_grpc_protos::InstrumentedFunction> instrumented_functions,
       TracepointInfoSet selected_tracepoints,
       absl::flat_hash_set<uint64_t> frame_track_function_ids) override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
@@ -363,7 +363,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   [[nodiscard]] bool IsFunctionSelected(const orbit_client_protos::FunctionInfo& func) const;
   [[nodiscard]] bool IsFunctionSelected(const SampledFunction& func) const;
   [[nodiscard]] bool IsFunctionSelected(uint64_t absolute_address) const;
-  [[nodiscard]] const orbit_client_protos::FunctionInfo* GetInstrumentedFunction(
+  [[nodiscard]] const orbit_grpc_protos::InstrumentedFunction* GetInstrumentedFunction(
       uint64_t function_id) const;
 
   void SetVisibleFunctionIds(absl::flat_hash_set<uint64_t> visible_functions);

--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -27,8 +27,8 @@
 #include "TriangleToggle.h"
 #include "capture_data.pb.h"
 
-using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::TimerInfo;
+using orbit_grpc_protos::InstrumentedFunction;
 
 AsyncTrack::AsyncTrack(TimeGraph* time_graph, TimeGraphLayout* layout, const std::string& name,
                        OrbitApp* app, const CaptureData* capture_data)
@@ -46,13 +46,13 @@ AsyncTrack::AsyncTrack(TimeGraph* time_graph, TimeGraphLayout* layout, const std
 
   // The FunctionInfo here corresponds to one of the automatically instrumented empty stubs from
   // Orbit.h. Use it to retrieve the module from which the manually instrumented scope originated.
-  const FunctionInfo* func =
+  const InstrumentedFunction* func =
       capture_data_
           ? capture_data_->GetInstrumentedFunctionById(text_box->GetTimerInfo().function_id())
           : nullptr;
   CHECK(func || timer_info.type() == TimerInfo::kIntrospection);
   std::string module_name =
-      func != nullptr ? function_utils::GetLoadedModuleName(*func) : "unknown";
+      func != nullptr ? function_utils::GetLoadedModuleNameByPath(func->file_path()) : "unknown";
   const uint64_t event_id = event.data;
   std::string function_name = manual_inst_manager->GetString(event_id);
 

--- a/src/OrbitGl/FrameTrack.h
+++ b/src/OrbitGl/FrameTrack.h
@@ -24,11 +24,11 @@ class OrbitApp;
 
 class FrameTrack : public TimerTrack {
  public:
-  explicit FrameTrack(TimeGraph* time_graph, TimeGraphLayout* layout, uint64_t function_id,
-                      orbit_client_protos::FunctionInfo function, OrbitApp* app,
+  explicit FrameTrack(TimeGraph* time_graph, TimeGraphLayout* layout,
+                      orbit_grpc_protos::InstrumentedFunction function, OrbitApp* app,
                       const CaptureData* capture_data);
   [[nodiscard]] Type GetType() const override { return kFrameTrack; }
-  [[nodiscard]] uint64_t GetFunctionId() const { return function_id_; }
+  [[nodiscard]] uint64_t GetFunctionId() const { return function_.function_id(); }
   [[nodiscard]] bool IsCollapsible() const override { return GetMaximumScaleFactor() > 0.f; }
 
   [[nodiscard]] float GetYFromTimer(
@@ -60,8 +60,7 @@ class FrameTrack : public TimerTrack {
   [[nodiscard]] float GetMaximumBoxHeight() const;
   [[nodiscard]] float GetAverageBoxHeight() const;
 
-  uint64_t function_id_;
-  orbit_client_protos::FunctionInfo function_;
+  orbit_grpc_protos::InstrumentedFunction function_;
   orbit_client_protos::FunctionStats stats_;
 };
 

--- a/src/OrbitGl/FrameTrackOnlineProcessor.cpp
+++ b/src/OrbitGl/FrameTrackOnlineProcessor.cpp
@@ -41,8 +41,9 @@ FrameTrackOnlineProcessor::FrameTrackOnlineProcessor(const CaptureData& capture_
   }
 }
 
-void FrameTrackOnlineProcessor::ProcessTimer(const orbit_client_protos::TimerInfo& timer_info,
-                                             const orbit_client_protos::FunctionInfo& function) {
+void FrameTrackOnlineProcessor::ProcessTimer(
+    const orbit_client_protos::TimerInfo& timer_info,
+    const orbit_grpc_protos::InstrumentedFunction& function) {
   uint64_t function_id = timer_info.function_id();
   if (!current_frame_track_function_ids_.contains(function_id)) {
     return;

--- a/src/OrbitGl/FrameTrackOnlineProcessor.h
+++ b/src/OrbitGl/FrameTrackOnlineProcessor.h
@@ -9,6 +9,7 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
+#include "capture.pb.h"
 #include "capture_data.pb.h"
 
 class CaptureData;
@@ -25,7 +26,7 @@ class FrameTrackOnlineProcessor {
   FrameTrackOnlineProcessor() = default;
   FrameTrackOnlineProcessor(const CaptureData& capture_data, TimeGraph* time_graph);
   void ProcessTimer(const orbit_client_protos::TimerInfo& timer_info,
-                    const orbit_client_protos::FunctionInfo& function);
+                    const orbit_grpc_protos::InstrumentedFunction& function);
 
   void AddFrameTrack(uint64_t function_id);
   void RemoveFrameTrack(uint64_t function_id);

--- a/src/OrbitGl/LiveFunctionsDataView.h
+++ b/src/OrbitGl/LiveFunctionsDataView.h
@@ -17,6 +17,7 @@
 #include "MetricsUploader/MetricsUploader.h"
 #include "TextBox.h"
 #include "TimerChain.h"
+#include "capture.pb.h"
 #include "capture_data.pb.h"
 
 class LiveFunctionsController;
@@ -56,7 +57,7 @@ class LiveFunctionsDataView : public DataView {
       uint32_t row) const;
   [[nodiscard]] std::pair<TextBox*, TextBox*> GetMinMax(uint64_t function_id) const;
 
-  absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> functions_;
+  absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> functions_{};
 
   LiveFunctionsController* live_functions_;
   uint64_t selected_function_id_;

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -51,7 +51,7 @@ class TimeGraph {
   const std::vector<orbit_client_protos::CallstackEvent>& GetSelectedCallstackEvents(int32_t tid);
 
   void ProcessTimer(const orbit_client_protos::TimerInfo& timer_info,
-                    const orbit_client_protos::FunctionInfo* function);
+                    const orbit_grpc_protos::InstrumentedFunction* function);
 
   // TODO (b/176056427): TimeGraph should not store nor expose CaptureData.
   [[nodiscard]] const CaptureData* GetCaptureData() const { return capture_data_; }

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -385,21 +385,20 @@ AsyncTrack* TrackManager::GetOrCreateAsyncTrack(const std::string& name) {
   return track.get();
 }
 
-FrameTrack* TrackManager::GetOrCreateFrameTrack(uint64_t function_id,
-                                                const FunctionInfo& function) {
+FrameTrack* TrackManager::GetOrCreateFrameTrack(
+    const orbit_grpc_protos::InstrumentedFunction& function) {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
-  auto track_it = frame_tracks_.find(function_id);
+  auto track_it = frame_tracks_.find(function.function_id());
   if (track_it != frame_tracks_.end()) {
     return track_it->second.get();
   }
 
-  auto track = std::make_shared<FrameTrack>(time_graph_, layout_, function_id, function, app_,
-                                            capture_data_);
+  auto track = std::make_shared<FrameTrack>(time_graph_, layout_, function, app_, capture_data_);
 
   // Normally we would call AddTrack(track) here, but frame tracks are removable by users
   // and therefore cannot be simply thrown into the flat vector of tracks.
   sorting_invalidated_ = true;
-  frame_tracks_[function_id] = track;
+  frame_tracks_[function.function_id()] = track;
 
   return track.get();
 }

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -59,8 +59,7 @@ class TrackManager {
   GpuTrack* GetOrCreateGpuTrack(uint64_t timeline_hash);
   GraphTrack* GetOrCreateGraphTrack(const std::string& name);
   AsyncTrack* GetOrCreateAsyncTrack(const std::string& name);
-  FrameTrack* GetOrCreateFrameTrack(uint64_t function_id,
-                                    const orbit_client_protos::FunctionInfo& function);
+  FrameTrack* GetOrCreateFrameTrack(const orbit_grpc_protos::InstrumentedFunction& function);
 
   void AddTrack(const std::shared_ptr<Track>& track);
   void RemoveFrameTrack(uint64_t function_address);


### PR DESCRIPTION
This change switches from FunctionInfo to InstrumentedFucntion in
CaptureData. It also does it for tracks and some other places.

LiveFunctionsDataView probably deserves another look, for now
it is still using FunctionInfo mostly because of selection/track
logic in DataManager.

Test: run orbit, instrument functions, take capture.