### PR TITLE
Enable ScopeTree data structure in ThreadTrack

### DIFF
--- a/src/OrbitBase/Tracing.cpp
+++ b/src/OrbitBase/Tracing.cpp
@@ -60,12 +60,25 @@ TracingListener::~TracingListener() {
 
 }  // namespace orbit_base
 
+namespace {
+struct ScopeToggle {
+  ScopeToggle() = delete;
+  ScopeToggle(bool* value, bool initial_value) : toggle(value) { *toggle = initial_value; }
+  ~ScopeToggle() { *toggle = !*toggle; }
+  bool* toggle = nullptr;
+};
+}  // namespace
+
 void TracingListener::DeferScopeProcessing(const TracingScope& scope) {
-  // User callback is called from a worker thread to
-  // minimize contention on the instrumented threads.
+  // Prevent reentry to avoid feedback loop.
+  thread_local bool is_internal_update = false;
+  if (is_internal_update) return;
+
+  // User callback is called from a worker thread to minimize contention on instrumented threads.
   absl::MutexLock lock(&global_tracing_mutex);
   if (!IsActive()) return;
   global_tracing_listener->thread_pool_->Schedule([scope]() {
+    ScopeToggle scope_toggle(&is_internal_update, true);
     absl::MutexLock lock(&global_tracing_mutex);
     if (!IsActive()) return;
     global_tracing_listener->user_callback_(scope);

--- a/src/OrbitClientData/FunctionUtils.cpp
+++ b/src/OrbitClientData/FunctionUtils.cpp
@@ -79,7 +79,6 @@ FunctionInfo::OrbitType GetOrbitTypeByName(const std::string& function_name) {
   if (absl::StartsWith(function_name, "orbit_api::")) {
     for (const auto& pair : GetFunctionNameToOrbitTypeMap()) {
       if (absl::StrContains(function_name, pair.first)) {
-        LOG("Found orbit_api function: %s", function_name);
         return pair.second;
       }
     }

--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -93,9 +93,9 @@ void AsyncTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
   TimerTrack::OnTimer(new_timer_info);
 }
 
-void AsyncTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_us, float min_x,
-                                  float z_offset, TextBox* text_box) {
-  std::string time = GetPrettyTime(absl::Microseconds(elapsed_us));
+void AsyncTrack::SetTimesliceText(const TimerInfo& timer_info, float min_x, float z_offset,
+                                  TextBox* text_box) {
+  std::string time = GetPrettyTime(absl::Nanoseconds(timer_info.end() - timer_info.start()));
   text_box->SetElapsedTimeTextLength(time.length());
 
   orbit_api::Event event = ManualInstrumentationManager::ApiEventFromTimerInfo(timer_info);

--- a/src/OrbitGl/AsyncTrack.h
+++ b/src/OrbitGl/AsyncTrack.h
@@ -34,8 +34,8 @@ class AsyncTrack final : public TimerTrack {
   void UpdateBoxHeight() override;
 
  protected:
-  void SetTimesliceText(const orbit_client_protos::TimerInfo& timer, double elapsed_us, float min_x,
-                        float z_offset, TextBox* text_box) override;
+  void SetTimesliceText(const orbit_client_protos::TimerInfo& timer, float min_x, float z_offset,
+                        TextBox* text_box) override;
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
                                     bool is_selected, bool is_highlighted) const override;
 

--- a/src/OrbitGl/Batcher.h
+++ b/src/OrbitGl/Batcher.h
@@ -26,11 +26,12 @@
 using TooltipCallback = std::function<std::string(PickingId)>;
 
 struct PickingUserData {
-  TextBox* text_box_;
+  const TextBox* text_box_;
   TooltipCallback generate_tooltip_;
   const void* custom_data_ = nullptr;
 
-  explicit PickingUserData(TextBox* text_box = nullptr, TooltipCallback generate_tooltip = nullptr)
+  explicit PickingUserData(const TextBox* text_box = nullptr,
+                           TooltipCallback generate_tooltip = nullptr)
       : text_box_(text_box), generate_tooltip_(std::move(generate_tooltip)) {}
 };
 

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -156,10 +156,10 @@ void FrameTrack::OnTimer(const TimerInfo& timer_info) {
   TimerTrack::OnTimer(timer_info);
 }
 
-void FrameTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_us, float min_x,
-                                  float z_offset, TextBox* text_box) {
+void FrameTrack::SetTimesliceText(const TimerInfo& timer_info, float min_x, float z_offset,
+                                  TextBox* text_box) {
   if (text_box->GetText().empty()) {
-    std::string time = GetPrettyTime(absl::Microseconds(elapsed_us));
+    std::string time = GetPrettyTime(absl::Nanoseconds(timer_info.end() - timer_info.start()));
     text_box->SetElapsedTimeTextLength(time.length());
 
     std::string text = absl::StrFormat("Frame #%u: %s", timer_info.user_data_key(), time.c_str());

--- a/src/OrbitGl/FrameTrack.h
+++ b/src/OrbitGl/FrameTrack.h
@@ -39,8 +39,8 @@ class FrameTrack : public TimerTrack {
       const orbit_client_protos::TimerInfo& timer_info) const override;
   [[nodiscard]] float GetHeaderHeight() const override;
 
-  void SetTimesliceText(const orbit_client_protos::TimerInfo& timer, double elapsed_us, float min_x,
-                        float z_offset, TextBox* text_box) override;
+  void SetTimesliceText(const orbit_client_protos::TimerInfo& timer, float min_x, float z_offset,
+                        TextBox* text_box) override;
   [[nodiscard]] std::string GetTooltip() const override;
   [[nodiscard]] std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const override;
 

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -200,10 +200,10 @@ bool GpuTrack::TimerFilter(const TimerInfo& timer_info) const {
   return true;
 }
 
-void GpuTrack::SetTimesliceText(const TimerInfo& timer_info, double elapsed_us, float min_x,
-                                float z_offset, TextBox* text_box) {
+void GpuTrack::SetTimesliceText(const TimerInfo& timer_info, float min_x, float z_offset,
+                                TextBox* text_box) {
   if (text_box->GetText().empty()) {
-    std::string time = GetPrettyTime(absl::Microseconds(elapsed_us));
+    std::string time = GetPrettyTime(absl::Nanoseconds(timer_info.end() - timer_info.start()));
 
     text_box->SetElapsedTimeTextLength(time.length());
 

--- a/src/OrbitGl/GpuTrack.h
+++ b/src/OrbitGl/GpuTrack.h
@@ -57,8 +57,8 @@ class GpuTrack : public TimerTrack {
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer, bool is_selected,
                                     bool is_highlighted) const override;
   [[nodiscard]] bool TimerFilter(const orbit_client_protos::TimerInfo& timer) const override;
-  void SetTimesliceText(const orbit_client_protos::TimerInfo& timer, double elapsed_us, float min_x,
-                        float z_offset, TextBox* text_box) override;
+  void SetTimesliceText(const orbit_client_protos::TimerInfo& timer, float min_x, float z_offset,
+                        TextBox* text_box) override;
   [[nodiscard]] std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const override;
 
  private:

--- a/src/OrbitGl/ScopeTree.h
+++ b/src/OrbitGl/ScopeTree.h
@@ -47,6 +47,7 @@ class ScopeNode {
   [[nodiscard]] size_t CountNodesInSubtree() const;
   [[nodiscard]] std::set<const ScopeNode*> GetAllNodesInSubtree() const;
   void SetDepth(uint32_t depth) { depth_ = depth; }
+  ScopeT* GetScope() { return scope_; }
 
  private:
   [[nodiscard]] ScopeNode* FindDeepestParentForNode(const ScopeNode* node);

--- a/src/OrbitGl/ScopeTree.h
+++ b/src/OrbitGl/ScopeTree.h
@@ -169,6 +169,7 @@ uint32_t ScopeNode<ScopeT>::Height() const {
 template <typename ScopeT>
 void ScopeNode<ScopeT>::FindHeight(const ScopeNode* node, uint32_t* height,
                                    uint32_t current_height) {
+  ORBIT_SCOPE_FUNCTION;
   *height = std::max(*height, current_height);
   for (auto& [unused_time, child_node] : node->children_by_start_time_) {
     FindHeight(child_node, height, current_height + 1);
@@ -250,6 +251,8 @@ std::vector<ScopeNode<ScopeT>*> ScopeNode<ScopeT>::GetChildrenInRange(uint64_t s
 
 template <typename ScopeT>
 void ScopeNode<ScopeT>::Insert(ScopeNode<ScopeT>* node) {
+  ORBIT_SCOPE_FUNCTION;
+
   // Find deepest parent and set depth on node to insert. The depth of descendants will be updated
   // in ScopeTree::UpdateDepthInSubtree as the tree also needs to update another data structure.
   ScopeNode* parent_node = FindDeepestParentForNode(node);

--- a/src/OrbitGl/ScopeTree.h
+++ b/src/OrbitGl/ScopeTree.h
@@ -169,7 +169,6 @@ uint32_t ScopeNode<ScopeT>::Height() const {
 template <typename ScopeT>
 void ScopeNode<ScopeT>::FindHeight(const ScopeNode* node, uint32_t* height,
                                    uint32_t current_height) {
-  ORBIT_SCOPE_FUNCTION;
   *height = std::max(*height, current_height);
   for (auto& [unused_time, child_node] : node->children_by_start_time_) {
     FindHeight(child_node, height, current_height + 1);
@@ -251,8 +250,6 @@ std::vector<ScopeNode<ScopeT>*> ScopeNode<ScopeT>::GetChildrenInRange(uint64_t s
 
 template <typename ScopeT>
 void ScopeNode<ScopeT>::Insert(ScopeNode<ScopeT>* node) {
-  ORBIT_SCOPE_FUNCTION;
-
   // Find deepest parent and set depth on node to insert. The depth of descendants will be updated
   // in ScopeTree::UpdateDepthInSubtree as the tree also needs to update another data structure.
   ScopeNode* parent_node = FindDeepestParentForNode(node);

--- a/src/OrbitGl/TextBox.h
+++ b/src/OrbitGl/TextBox.h
@@ -20,6 +20,10 @@ class TextBox {
 
   void SetSize(const Vec2& size) { size_ = size; }
   void SetPos(const Vec2& pos) { pos_ = pos; }
+  void SetPosAndSize(const Vec2& pos, const Vec2& size) {
+    pos_ = pos;
+    size_ = size;
+  }
 
   const Vec2& GetSize() const { return size_; }
   const Vec2& GetPos() const { return pos_; }

--- a/src/OrbitGl/TextBox.h
+++ b/src/OrbitGl/TextBox.h
@@ -45,6 +45,7 @@ class TextBox {
   // Start() and End() are required in order to be used as node in a ScopeTree.
   uint64_t Start() const { return timer_info_.start(); }
   uint64_t End() const { return timer_info_.end(); }
+  uint64_t Duration() const { return End() - Start(); }
 
  protected:
   Vec2 pos_;

--- a/src/OrbitGl/TextBox.h
+++ b/src/OrbitGl/TextBox.h
@@ -20,10 +20,6 @@ class TextBox {
 
   void SetSize(const Vec2& size) { size_ = size; }
   void SetPos(const Vec2& pos) { pos_ = pos; }
-  void SetPosAndSize(const Vec2& pos, const Vec2& size) {
-    pos_ = pos;
-    size_ = size;
-  }
 
   const Vec2& GetSize() const { return size_; }
   const Vec2& GetPos() const { return pos_; }

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -417,7 +417,7 @@ void ThreadTrack::OnTimer(const TimerInfo& timer_info) {
   CHECK(timer_chain != nullptr);
   {
     absl::MutexLock lock(&scope_tree_mutex_);
-    scope_tree_.Insert(timer_chain->Last());
+    scope_tree_.Insert(timer_chain->GetLast());
   }
 }
 
@@ -453,13 +453,13 @@ void ThreadTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t
   UpdatePrimitivesOfSubtracks(batcher, min_tick, max_tick, picking_mode, z_offset);
   UpdateBoxHeight();
 
-  internal::DrawData draw_data = GetDrawData(
+  const internal::DrawData draw_data = GetDrawData(
       min_tick, max_tick, z_offset, batcher, time_graph_, collapse_toggle_->IsCollapsed(),
       app_->selected_text_box(), app_->GetFunctionIdToHighlight());
 
   absl::MutexLock lock(&scope_tree_mutex_);
 
-  for (auto& [depth, ordered_nodes] : scope_tree_.GetOrderedNodesByDepth()) {
+  for (const auto& [depth, ordered_nodes] : scope_tree_.GetOrderedNodesByDepth()) {
     auto first_node_to_draw = ordered_nodes.lower_bound(min_tick);
     if (first_node_to_draw != ordered_nodes.begin()) --first_node_to_draw;
 

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -102,12 +102,16 @@ std::string ThreadTrack::GetBoxTooltip(const Batcher& batcher, PickingId id) con
   const TimerInfo& timer_info = text_box->GetTimerInfo();
 
   const InstrumentedFunction* func =
-      capture_data_
-          ? capture_data_->GetInstrumentedFunctionById(timer_info.function_id())
-          : nullptr;
+      capture_data_ ? capture_data_->GetInstrumentedFunctionById(timer_info.function_id())
+                    : nullptr;
+
+  FunctionInfo::OrbitType type{FunctionInfo::kNone};
+  if (func != nullptr) {
+    type = function_utils::GetOrbitTypeByName(func->function_name());
+  }
 
   std::string function_name;
-  bool is_manual = (func != nullptr && func->orbit_type() == FunctionInfo::kOrbitTimerStart) ||
+  bool is_manual = (func != nullptr && type == FunctionInfo::kOrbitTimerStart) ||
                    timer_info.type() == TimerInfo::kApiEvent;
 
   if (!func && !is_manual) {
@@ -122,7 +126,7 @@ std::string ThreadTrack::GetBoxTooltip(const Batcher& batcher, PickingId id) con
   }
 
   std::string module_name =
-      func != nullptr ? function_utils::GetLoadedModuleName(*func->file_path()) : "unknown";
+      func != nullptr ? function_utils::GetLoadedModuleNameByPath(func->file_path()) : "unknown";
 
   return absl::StrFormat(
       "<b>%s</b><br/>"

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -38,15 +38,15 @@ class ThreadTrack final : public TimerTrack {
   [[nodiscard]] const TextBox* GetRight(const TextBox* textbox) const override;
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
+  void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                        PickingMode picking_mode, float z_offset = 0) override;
+  void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
 
   void OnPick(int x, int y) override;
 
   void UpdateBoxHeight() override;
   void SetTrackColor(Color color);
   [[nodiscard]] bool IsEmpty() const override;
-
-  void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                        PickingMode picking_mode, float z_offset = 0) override;
 
   [[nodiscard]] std::vector<CaptureViewElement*> GetVisibleChildren() override;
 
@@ -56,19 +56,25 @@ class ThreadTrack final : public TimerTrack {
 
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer, bool is_selected,
                                     bool is_highlighted) const override;
-  void SetTimesliceText(const orbit_client_protos::TimerInfo& timer, double elapsed_us, float min_x,
-                        float z_offset, TextBox* text_box) override;
+  [[nodiscard]] Color GetTimerColor(const TextBox& text_box, const internal::DrawData& draw_data);
+  void SetTimesliceText(const orbit_client_protos::TimerInfo& timer, float min_x, float z_offset,
+                        TextBox* text_box) override;
   [[nodiscard]] std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const override;
 
   [[nodiscard]] float GetHeight() const override;
   [[nodiscard]] float GetHeaderHeight() const override;
 
   void UpdatePositionOfSubtracks();
+  void UpdatePrimitivesOfSubtracks(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                                   PickingMode picking_mode, float z_offset);
   void UpdateMinMaxTimestamps();
 
   std::shared_ptr<orbit_gl::ThreadStateBar> thread_state_bar_;
   std::shared_ptr<orbit_gl::CallstackThreadBar> event_bar_;
   std::shared_ptr<orbit_gl::TracepointThreadBar> tracepoint_bar_;
+
+  absl::Mutex scope_tree_mutex_;
+  ScopeTree<TextBox> scope_tree_;
 };
 
 #endif  // ORBIT_GL_THREAD_TRACK_H_

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -14,6 +14,7 @@
 #include "CallstackThreadBar.h"
 #include "CoreMath.h"
 #include "PickingManager.h"
+#include "ScopeTree.h"
 #include "TextBox.h"
 #include "ThreadStateBar.h"
 #include "TimerTrack.h"

--- a/src/OrbitGl/TimerChain.h
+++ b/src/OrbitGl/TimerChain.h
@@ -11,6 +11,7 @@
 #include <iosfwd>
 #include <limits>
 
+#include "OrbitBase/Logging.h"
 #include "TextBox.h"
 
 static constexpr int kBlockSize = 1024;
@@ -38,6 +39,11 @@ class TimerBlock {
   // Adds an item to the block. If capacity of this block is reached, a new
   // blocked is allocated and the item is added to the new block.
   void Add(const TextBox& item);
+  [[nodiscard]] TextBox* Last() {
+    CHECK(size_ > 0);
+    CHECK(size_ <= kBlockSize);
+    return &data_[size_ - 1];
+  }
 
   // Tests if [min, max] intersects with [min_timestamp, max_timestamp], where
   // {min, max}_timestamp are the minimum and maximum timestamp of the timers
@@ -108,6 +114,7 @@ class TimerChain {
   ~TimerChain();
 
   void push_back(const TextBox& item) { current_->Add(item); }
+  [[nodiscard]] TextBox* Last() { return current_->Last(); }
   [[nodiscard]] bool empty() const { return num_items_ == 0; }
   [[nodiscard]] uint64_t size() const { return num_items_; }
 

--- a/src/OrbitGl/TimerChain.h
+++ b/src/OrbitGl/TimerChain.h
@@ -39,7 +39,7 @@ class TimerBlock {
   // Adds an item to the block. If capacity of this block is reached, a new
   // blocked is allocated and the item is added to the new block.
   void Add(const TextBox& item);
-  [[nodiscard]] TextBox* Last() {
+  [[nodiscard]] TextBox* GetLast() {
     CHECK(size_ > 0);
     CHECK(size_ <= kBlockSize);
     return &data_[size_ - 1];
@@ -114,7 +114,6 @@ class TimerChain {
   ~TimerChain();
 
   void push_back(const TextBox& item) { current_->Add(item); }
-  [[nodiscard]] TextBox* Last() { return current_->Last(); }
   [[nodiscard]] bool empty() const { return num_items_ == 0; }
   [[nodiscard]] uint64_t size() const { return num_items_; }
 
@@ -123,6 +122,8 @@ class TimerChain {
   [[nodiscard]] TextBox* GetElementAfter(const TextBox* element) const;
 
   [[nodiscard]] TextBox* GetElementBefore(const TextBox* element) const;
+
+  [[nodiscard]] TextBox* GetLast() { return current_->GetLast(); }
 
   [[nodiscard]] TimerChainIterator begin() { return TimerChainIterator(root_); }
 

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -59,8 +59,7 @@ float TimerTrack::GetYFromTimer(const TimerInfo& timer_info) const {
 }
 
 float TimerTrack::GetYFromDepth(uint32_t depth) const {
-  const TimeGraphLayout& layout = time_graph_->GetLayout();
-  return pos_[1] - GetHeaderHeight() - layout.GetSpaceBetweenTracksAndThread() -
+  return pos_[1] - GetHeaderHeight() - layout_->GetSpaceBetweenTracksAndThread() -
          box_height_ * static_cast<float>(depth + 1);
 }
 

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -204,12 +204,8 @@ bool TimerTrack::DrawTimer(const TextBox* prev_text_box, const TextBox* next_tex
         world_x_info_right_overlap.world_x_start + world_x_info_right_overlap.world_x_width,
         world_timer_y, draw_data.z);
     Batcher* batcher = draw_data.batcher;
-    draw_data.batcher->AddShadedTrapezium(
-        top_left, bottom_left, bottom_right, top_right, color,
-        std::make_unique<PickingUserData>(current_text_box, [&, batcher](PickingId id) {
-          return this->GetBoxTooltip(*batcher, id);
-        }));
-
+    draw_data.batcher->AddShadedTrapezium(top_left, bottom_left, bottom_right, top_right, color,
+                                          CreatePickingUserData(*batcher, *current_text_box));
   } else {
     Batcher* batcher = draw_data.batcher;
     auto user_data = std::make_unique<PickingUserData>(

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -46,13 +46,6 @@ struct DrawData {
   float z;
   bool is_collapsed;
 };
-
-struct Rect {
-  Rect(float pos_x, float pos_y, float size_x, float size_y)
-      : pos(pos_x, pos_y), size(size_x, size_y) {}
-  Vec2 pos;
-  Vec2 size;
-};
 }  // namespace internal
 
 class TimerTrack : public Track {
@@ -139,6 +132,12 @@ class TimerTrack : public Track {
   int visible_timer_count_ = 0;
 
   [[nodiscard]] virtual std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const;
+  [[nodiscard]] std::unique_ptr<PickingUserData> CreatePickingUserData(const Batcher& batcher,
+                                                                       const TextBox& text_box) {
+    return std::make_unique<PickingUserData>(
+        &text_box, [this, &batcher](PickingId id) { return this->GetBoxTooltip(batcher, id); });
+  }
+
   float GetHeight() const override;
   float box_height_ = 0.0f;
 

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -18,7 +18,6 @@
 #include "CoreMath.h"
 #include "OrbitClientData/CallstackTypes.h"
 #include "PickingManager.h"
-#include "ScopeTree.h"
 #include "TextBox.h"
 #include "TextRenderer.h"
 #include "TimerChain.h"


### PR DESCRIPTION
The new manual instrumentation requires the use of the ScopeTree data
structure to merge scope data coming from different sources. Add a
ThreadTrack specific "UpdatePrimitives" method that takes advantage of
the ScopeTree's sorted scopes for rendering timeslices.

Note: The ScopeTree was added at the ThreadTrack level because not all 
TimerTracks support it (the AsyncTrack for example does not have 
hierarchical relationship between scopes).

The UpdatePrimitives in ThreadTrack is similar to the one we had before 
the GPU overlap change. I tried to clean it up as much as possible for 
readability. The min_ignore/max_ignore were merged into a single 
next_pixel_start_time_ns value. @ronaldfw , please let me know if it respects
the spirit of the initial optimization.

Tested with a mix of manual and dynamic instrumentation (OrbitTest, Unreal)

I'd like to do a bit more profiling before this goes into a release.