### PR TITLE
Combine Gpu debug marker and submission tracks into one.

### DIFF
--- a/contrib/automation_tests/orbit_vulkan_layer.py
+++ b/contrib/automation_tests/orbit_vulkan_layer.py
@@ -7,7 +7,7 @@ found in the LICENSE file.
 from absl import app
 
 from core.orbit_e2e import E2ETestSuite
-from test_cases.capture_window import MatchTracks, Capture, ExpandTrack, CollapseTrack
+from test_cases.capture_window import MatchTracks, Capture, CheckTimers, ExpandTrack, CollapseTrack
 from test_cases.connection_window import FilterAndSelectFirstProcess, ConnectToStadiaInstance
 
 """Basic smoke test for the Vulkan layer functionality using pywinauto.
@@ -31,8 +31,10 @@ def main(argv):
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter="UE4Game"),
         Capture(),
-        MatchTracks(expected_names=["gfx", "gfx_marker"], allow_additional_tracks=True),
+        MatchTracks(expected_names=["gfx"], allow_additional_tracks=True),
         ExpandTrack(expected_name="gfx"),
+        CheckTimers(track_name_filter='gfx_submissions', recursive=True),
+        CheckTimers(track_name_filter='gfx_marker', recursive=True),
         CollapseTrack(expected_name="gfx")]
     suite = E2ETestSuite(test_name="Vulkan Layer", test_cases=test_cases)
     suite.execute()

--- a/src/CaptureClient/CaptureEventProcessorTest.cpp
+++ b/src/CaptureClient/CaptureEventProcessorTest.cpp
@@ -595,10 +595,7 @@ TEST(CaptureEventProcessor, CanHandleGpuSubmissionAfterGpuJob) {
 
   testing::Mock::VerifyAndClearExpectations(&listener);
 
-  uint64_t actual_marker_timeline_key;
-  EXPECT_CALL(listener, OnKeyAndString(_, "timeline_marker"))
-      .Times(1)
-      .WillOnce(SaveArg<0>(&actual_marker_timeline_key));
+  EXPECT_CALL(listener, OnKeyAndString(_, "timeline")).Times(0);
   uint64_t actual_marker_key;
   EXPECT_CALL(listener, OnKeyAndString(_, "marker"))
       .Times(1)
@@ -628,7 +625,7 @@ TEST(CaptureEventProcessor, CanHandleGpuSubmissionAfterGpuJob) {
                              actual_command_buffer_key);
 
   ExpectDebugMarkerTimerEq(debug_marker_timer, 31, 36, gpu_job->tid(), gpu_job->pid(), 1,
-                           actual_marker_timeline_key, actual_marker_key);
+                           kTimelineKey, actual_marker_key);
 }
 
 TEST(CaptureEventProcessor, CanHandleGpuSubmissionReceivedBeforeGpuJob) {
@@ -665,10 +662,7 @@ TEST(CaptureEventProcessor, CanHandleGpuSubmissionReceivedBeforeGpuJob) {
   EXPECT_CALL(listener, OnKeyAndString(_, "hw queue")).Times(1);
   EXPECT_CALL(listener, OnKeyAndString(_, "hw execution")).Times(1);
 
-  uint64_t actual_marker_timeline_key;
-  EXPECT_CALL(listener, OnKeyAndString(_, "timeline_marker"))
-      .Times(1)
-      .WillOnce(SaveArg<0>(&actual_marker_timeline_key));
+  EXPECT_CALL(listener, OnKeyAndString(_, "timeline")).Times(0);
 
   uint64_t actual_command_buffer_key;
   EXPECT_CALL(listener, OnKeyAndString(_, "command buffer"))
@@ -703,7 +697,7 @@ TEST(CaptureEventProcessor, CanHandleGpuSubmissionReceivedBeforeGpuJob) {
                              actual_command_buffer_key);
 
   ExpectDebugMarkerTimerEq(debug_marker_timer, 31, 36, gpu_job->tid(), gpu_job->pid(), 1,
-                           actual_marker_timeline_key, actual_marker_key);
+                           kTimelineKey, actual_marker_key);
 }
 
 TEST(CaptureEventProcessor, CanHandleGpuDebugMarkersSpreadAcrossSubmissions) {
@@ -776,10 +770,7 @@ TEST(CaptureEventProcessor, CanHandleGpuDebugMarkersSpreadAcrossSubmissions) {
       .WillOnce(SaveArg<0>(&command_buffer_timer_3))
       .WillOnce(SaveArg<0>(&debug_marker_timer));
 
-  uint64_t actual_marker_timeline_key = 0;
-  EXPECT_CALL(listener, OnKeyAndString(_, "timeline_marker"))
-      .Times(1)
-      .WillOnce(SaveArg<0>(&actual_marker_timeline_key));
+  EXPECT_CALL(listener, OnKeyAndString(_, "timeline")).Times(0);
   uint64_t actual_marker_key = 0;
   EXPECT_CALL(listener, OnKeyAndString(_, "marker"))
       .Times(1)
@@ -793,7 +784,7 @@ TEST(CaptureEventProcessor, CanHandleGpuDebugMarkersSpreadAcrossSubmissions) {
                              actual_command_buffer_key);
 
   ExpectDebugMarkerTimerEq(debug_marker_timer, 31, 78, gpu_job_2->tid(), gpu_job_2->pid(), 1,
-                           actual_marker_timeline_key, actual_marker_key);
+                           kTimelineKey, actual_marker_key);
 }
 
 TEST(CaptureEventProcessor, CanHandleGpuDebugMarkersWithNoBeginRecorded) {
@@ -839,10 +830,7 @@ TEST(CaptureEventProcessor, CanHandleGpuDebugMarkersWithNoBeginRecorded) {
       .Times(1)
       .WillOnce(SaveArg<0>(&actual_command_buffer_key));
 
-  uint64_t actual_marker_timeline_key = 0;
-  EXPECT_CALL(listener, OnKeyAndString(_, "timeline_marker"))
-      .Times(1)
-      .WillOnce(SaveArg<0>(&actual_marker_timeline_key));
+  EXPECT_CALL(listener, OnKeyAndString(_, "timeline")).Times(0);
   uint64_t actual_marker_key = 0;
   EXPECT_CALL(listener, OnKeyAndString(_, "marker"))
       .Times(1)
@@ -857,8 +845,8 @@ TEST(CaptureEventProcessor, CanHandleGpuDebugMarkersWithNoBeginRecorded) {
 
   // We expect the begin timestamp to be approximated by the first known timestamp. Also as we don't
   // know the thread id of the begin submission, the timer should state -1 as thread id.
-  ExpectDebugMarkerTimerEq(debug_marker_timer, 50, 78, -1, gpu_job_2->pid(), 1,
-                           actual_marker_timeline_key, actual_marker_key);
+  ExpectDebugMarkerTimerEq(debug_marker_timer, 50, 78, -1, gpu_job_2->pid(), 1, kTimelineKey,
+                           actual_marker_key);
 }
 
 TEST(CaptureEventProcessor, CanHandleGpuDebugMarkersWithNoBeginJobRecorded) {
@@ -913,10 +901,7 @@ TEST(CaptureEventProcessor, CanHandleGpuDebugMarkersWithNoBeginJobRecorded) {
       .WillOnce(SaveArg<0>(&command_buffer_timer_3))
       .WillOnce(SaveArg<0>(&debug_marker_timer));
 
-  uint64_t actual_marker_timeline_key = 0;
-  EXPECT_CALL(listener, OnKeyAndString(_, "timeline_marker"))
-      .Times(1)
-      .WillOnce(SaveArg<0>(&actual_marker_timeline_key));
+  EXPECT_CALL(listener, OnKeyAndString(_, "timeline")).Times(0);
   uint64_t actual_marker_key = 0;
   EXPECT_CALL(listener, OnKeyAndString(_, "marker"))
       .Times(1)
@@ -931,7 +916,7 @@ TEST(CaptureEventProcessor, CanHandleGpuDebugMarkersWithNoBeginJobRecorded) {
 
   // We expect the begin timestamp to be approximated by the first known timestamp.
   ExpectDebugMarkerTimerEq(debug_marker_timer, 50, 78, gpu_job_2->tid(), gpu_job_2->pid(), 1,
-                           actual_marker_timeline_key, actual_marker_key);
+                           kTimelineKey, actual_marker_key);
 }
 
 TEST(CaptureEventProcessor, CanHandleThreadStateSlices) {

--- a/src/CaptureClient/GpuQueueSubmissionProcessor.cpp
+++ b/src/CaptureClient/GpuQueueSubmissionProcessor.cpp
@@ -175,8 +175,7 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuQueueSubmissionWit
   result.insert(result.end(), command_buffer_timers.begin(), command_buffer_timers.end());
 
   std::vector<TimerInfo> debug_marker_timers =
-      ProcessGpuDebugMarkers(gpu_queue_submission, matching_gpu_job, first_command_buffer, timeline,
-                             get_string_hash_and_send_to_listener_if_necessary);
+      ProcessGpuDebugMarkers(gpu_queue_submission, matching_gpu_job, first_command_buffer);
 
   result.insert(result.end(), debug_marker_timers.begin(), debug_marker_timers.end());
 
@@ -286,16 +285,11 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuCommandBuffers(
 
 std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuDebugMarkers(
     const GpuQueueSubmission& gpu_queue_submission, const GpuJob& matching_gpu_job,
-    const std::optional<GpuCommandBuffer>& first_command_buffer, const std::string& timeline,
-    const std::function<uint64_t(const std::string& str)>&
-        get_string_hash_and_send_to_listener_if_necessary) {
+    const std::optional<GpuCommandBuffer>& first_command_buffer) {
   if (gpu_queue_submission.completed_markers_size() == 0) {
     return {};
   }
   std::vector<TimerInfo> result;
-  std::string timeline_marker = timeline + "_marker";
-  uint64_t timeline_marker_hash =
-      get_string_hash_and_send_to_listener_if_necessary(timeline_marker);
 
   const auto& submission_meta_info = gpu_queue_submission.meta_info();
   const int32_t submission_thread_id = submission_meta_info.tid();
@@ -400,7 +394,7 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuDebugMarkers(
 
     marker_timer.set_process_id(submission_process_id);
     marker_timer.set_depth(completed_marker.depth());
-    marker_timer.set_timeline_hash(timeline_marker_hash);
+    marker_timer.set_timeline_hash(matching_gpu_job.timeline_key());
     marker_timer.set_processor(-1);
     marker_timer.set_type(TimerInfo::kGpuDebugMarker);
     marker_timer.set_end(completed_marker.end_gpu_timestamp_ns() -

--- a/src/CaptureClient/include/CaptureClient/GpuQueueSubmissionProcessor.h
+++ b/src/CaptureClient/include/CaptureClient/GpuQueueSubmissionProcessor.h
@@ -79,10 +79,7 @@ class GpuQueueSubmissionProcessor {
   [[nodiscard]] std::vector<orbit_client_protos::TimerInfo> ProcessGpuDebugMarkers(
       const orbit_grpc_protos::GpuQueueSubmission& gpu_queue_submission,
       const orbit_grpc_protos::GpuJob& matching_gpu_job,
-      const std::optional<orbit_grpc_protos::GpuCommandBuffer>& first_command_buffer,
-      const std::string& timeline,
-      const std::function<uint64_t(const std::string& str)>&
-          get_string_hash_and_send_to_listener_if_necessary);
+      const std::optional<orbit_grpc_protos::GpuCommandBuffer>& first_command_buffer);
 
   [[nodiscard]] static std::optional<orbit_grpc_protos::GpuCommandBuffer> ExtractFirstCommandBuffer(
       const orbit_grpc_protos::GpuQueueSubmission& gpu_queue_submission);

--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -34,8 +34,9 @@ using orbit_grpc_protos::InstrumentedFunction;
 AsyncTrack::AsyncTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                        orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                        const std::string& name, OrbitApp* app,
-                       const orbit_client_model::CaptureData* capture_data)
-    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data) {
+                       const orbit_client_model::CaptureData* capture_data,
+                       uint32_t indentation_level)
+    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data, indentation_level) {
   SetName(name);
   SetLabel(name);
 }

--- a/src/OrbitGl/AsyncTrack.h
+++ b/src/OrbitGl/AsyncTrack.h
@@ -28,7 +28,8 @@ class AsyncTrack final : public TimerTrack {
   explicit AsyncTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                       const std::string& name, OrbitApp* app,
-                      const orbit_client_model::CaptureData* capture_data);
+                      const orbit_client_model::CaptureData* capture_data,
+                      uint32_t indentation_level = 0);
 
   [[nodiscard]] Type GetType() const override { return Type::kAsyncTrack; };
   [[nodiscard]] std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const override;

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -40,6 +40,8 @@ target_sources(
          GlCanvas.h
          GlSlider.h
          GlUtils.h
+         GpuDebugMarkerTrack.h
+         GpuSubmissionTrack.h
          GpuTrack.h
          GraphTrack.h
          Images.h
@@ -106,6 +108,8 @@ target_sources(
           GlCanvas.cpp
           GlSlider.cpp
           GlUtils.cpp
+          GpuDebugMarkerTrack.cpp
+          GpuSubmissionTrack.cpp
           GpuTrack.cpp
           GraphTrack.cpp
           ImGuiOrbit.cpp

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -69,8 +69,8 @@ float FrameTrack::GetAverageBoxHeight() const {
 FrameTrack::FrameTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                        orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                        InstrumentedFunction function, OrbitApp* app,
-                       const CaptureData* capture_data)
-    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data),
+                       const CaptureData* capture_data, uint32_t indentation_level)
+    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data, indentation_level),
       function_(std::move(function)) {
   // TODO(b/169554463): Support manual instrumentation.
   std::string name = absl::StrFormat("Frame track based on %s", function_.function_name());

--- a/src/OrbitGl/FrameTrack.h
+++ b/src/OrbitGl/FrameTrack.h
@@ -28,7 +28,9 @@ class FrameTrack : public TimerTrack {
   explicit FrameTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                       orbit_grpc_protos::InstrumentedFunction function, OrbitApp* app,
-                      const orbit_client_model::CaptureData* capture_data);
+                      const orbit_client_model::CaptureData* capture_data,
+                      uint32_t indentation_level = 0);
+
   [[nodiscard]] Type GetType() const override { return Type::kFrameTrack; }
   [[nodiscard]] uint64_t GetFunctionId() const { return function_.function_id(); }
   [[nodiscard]] bool IsCollapsible() const override { return GetMaximumScaleFactor() > 0.f; }

--- a/src/OrbitGl/GpuDebugMarkerTrack.cpp
+++ b/src/OrbitGl/GpuDebugMarkerTrack.cpp
@@ -1,0 +1,141 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "GpuDebugMarkerTrack.h"
+
+#include <absl/time/time.h>
+
+#include <memory>
+
+#include "App.h"
+#include "Batcher.h"
+#include "CoreUtils.h"
+#include "GlCanvas.h"
+#include "GlUtils.h"
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/ThreadConstants.h"
+#include "TimeGraph.h"
+#include "TimeGraphLayout.h"
+#include "TimerChain.h"
+#include "TriangleToggle.h"
+#include "absl/strings/str_format.h"
+
+using orbit_client_protos::TimerInfo;
+
+GpuDebugMarkerTrack::GpuDebugMarkerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+                                         orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
+                                         OrbitApp* app,
+                                         const orbit_client_model::CaptureData* capture_data,
+                                         uint32_t indentation_level)
+    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data, indentation_level) {
+  SetLabel("Debug Markers");
+  draw_background_ = false;
+  string_manager_ = app->GetStringManager();
+
+  // Gpu tracks are collapsed by default.
+  collapse_toggle_->SetState(TriangleToggle::State::kCollapsed,
+                             TriangleToggle::InitialStateUpdate::kReplaceInitialState);
+}
+
+std::string GpuDebugMarkerTrack::GetTooltip() const {
+  return "Shows execution times for Vulkan debug markers";
+}
+
+Color GpuDebugMarkerTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected,
+                                         bool is_highlighted) const {
+  CHECK(timer_info.type() == TimerInfo::kGpuDebugMarker);
+  const Color kInactiveColor(100, 100, 100, 255);
+  const Color kSelectionColor(0, 128, 255, 255);
+  if (is_highlighted) {
+    return TimerTrack::kHighlightColor;
+  }
+  if (is_selected) {
+    return kSelectionColor;
+  }
+  if (!IsTimerActive(timer_info)) {
+    return kInactiveColor;
+  }
+  if (timer_info.has_color()) {
+    CHECK(timer_info.color().red() < 256);
+    CHECK(timer_info.color().green() < 256);
+    CHECK(timer_info.color().blue() < 256);
+    CHECK(timer_info.color().alpha() < 256);
+    return Color(static_cast<uint8_t>(timer_info.color().red()),
+                 static_cast<uint8_t>(timer_info.color().green()),
+                 static_cast<uint8_t>(timer_info.color().blue()),
+                 static_cast<uint8_t>(timer_info.color().alpha()));
+  }
+  std::string marker_text = string_manager_->Get(timer_info.user_data_key()).value_or("");
+  return TimeGraph::GetColor(marker_text);
+}
+
+void GpuDebugMarkerTrack::SetTimesliceText(const TimerInfo& timer_info, float min_x, float z_offset,
+                                           TextBox* text_box) {
+  CHECK(timer_info.type() == TimerInfo::kGpuDebugMarker);
+
+  if (text_box->GetText().empty()) {
+    std::string time = GetPrettyTime(absl::Nanoseconds(timer_info.end() - timer_info.start()));
+    text_box->SetElapsedTimeTextLength(time.length());
+    std::string text = absl::StrFormat(
+        "%s  %s", string_manager_->Get(timer_info.user_data_key()).value_or(""), time.c_str());
+    text_box->SetText(text);
+  }
+
+  const Color kTextWhite(255, 255, 255, 255);
+  const Vec2& box_pos = text_box->GetPos();
+  const Vec2& box_size = text_box->GetSize();
+  float pos_x = std::max(box_pos[0], min_x);
+  float max_size = box_pos[0] + box_size[0] - pos_x;
+  text_renderer_->AddTextTrailingCharsPrioritized(
+      text_box->GetText().c_str(), pos_x, text_box->GetPos()[1] + layout_->GetTextOffset(),
+      GlCanvas::kZValueBox + z_offset, kTextWhite, text_box->GetElapsedTimeTextLength(),
+      layout_->CalculateZoomedFontSize(), max_size);
+}
+
+std::string GpuDebugMarkerTrack::GetBoxTooltip(const Batcher& batcher, PickingId id) const {
+  const TextBox* text_box = batcher.GetTextBox(id);
+  if (text_box != nullptr) {
+    return "";
+  }
+
+  const TimerInfo& timer_info = text_box->GetTimerInfo();
+  CHECK(timer_info.type() == TimerInfo::kGpuDebugMarker);
+
+  std::string marker_text = string_manager_->Get(timer_info.user_data_key()).value_or("");
+  return absl::StrFormat(
+      "<b>Vulkan Debug Marker</b><br/>"
+      "<i>At the marker's begin and end `vkCmdWriteTimestamp`s have been "
+      "inserted. The GPU timestamps get aligned with the corresponding hardware execution of the "
+      "submission.</i>"
+      "<br/>"
+      "<br/>"
+      "<b>Marker text:</b> %s<br/>"
+      "<b>Submitted from thread:</b> %s [%d]<br/>"
+      "<b>Time:</b> %s",
+      marker_text, app_->GetCaptureData().GetThreadName(timer_info.thread_id()),
+      timer_info.thread_id(),
+      GetPrettyTime(TicksToDuration(timer_info.start(), timer_info.end())).c_str());
+}
+
+float GpuDebugMarkerTrack::GetYFromTimer(const TimerInfo& timer_info) const {
+  uint32_t depth = timer_info.depth();
+  if (collapse_toggle_->IsCollapsed()) {
+    depth = 0;
+  }
+  return pos_[1] - layout_->GetTrackTabHeight() - layout_->GetTextBoxHeight() * (depth + 1.f);
+}
+
+float GpuDebugMarkerTrack::GetHeight() const {
+  bool collapsed = collapse_toggle_->IsCollapsed();
+  uint32_t depth = collapsed ? 1 : GetDepth();
+  return layout_->GetTrackTabHeight() + layout_->GetTextBoxHeight() * depth +
+         layout_->GetTrackBottomMargin();
+}
+
+bool GpuDebugMarkerTrack::TimerFilter(const TimerInfo& timer_info) const {
+  if (collapse_toggle_->IsCollapsed()) {
+    return timer_info.depth() == 0;
+  }
+  return true;
+}

--- a/src/OrbitGl/GpuDebugMarkerTrack.h
+++ b/src/OrbitGl/GpuDebugMarkerTrack.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_GPU_DEBUG_MARKER_TRACK_H_
+#define ORBIT_GL_GPU_DEBUG_MARKER_TRACK_H_
+
+#include <stdint.h>
+
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "CallstackThreadBar.h"
+#include "CoreMath.h"
+#include "PickingManager.h"
+#include "StringManager.h"
+#include "TextBox.h"
+#include "TimerTrack.h"
+#include "Track.h"
+#include "capture_data.pb.h"
+
+class OrbitApp;
+class TextRenderer;
+
+// This is a thin implementation of a `TimerTrack` to display Vulkan debug markers, used in the
+// `GpuTrack`.
+class GpuDebugMarkerTrack : public TimerTrack {
+ public:
+  explicit GpuDebugMarkerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+                               orbit_gl::Viewport* viewport, TimeGraphLayout* layout, OrbitApp* app,
+                               const orbit_client_model::CaptureData* capture_data,
+                               uint32_t indentation_level);
+
+  ~GpuDebugMarkerTrack() override = default;
+
+  // The type is currently only used by the TrackManger. We are moving towards removing it
+  // completely. For subtracks there is no meaningful type and it should also not be exposed,
+  // though we use the unknown type.
+  [[nodiscard]] Type GetType() const override { return Type::kUnknown; }
+  [[nodiscard]] std::string GetTooltip() const override;
+
+  [[nodiscard]] float GetHeight() const override;
+
+  [[nodiscard]] float GetYFromTimer(
+      const orbit_client_protos::TimerInfo& timer_info) const override;
+  [[nodiscard]] bool TimerFilter(const orbit_client_protos::TimerInfo& timer) const override;
+  [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer, bool is_selected,
+                                    bool is_highlighted) const override;
+  void SetTimesliceText(const orbit_client_protos::TimerInfo& timer, float min_x, float z_offset,
+                        TextBox* text_box) override;
+
+  [[nodiscard]] std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const override;
+
+ private:
+  StringManager* string_manager_;
+};
+
+#endif  // ORBIT_GL_GPU_DEBUG_MARKER_TRACK_H_

--- a/src/OrbitGl/GpuSubmissionTrack.cpp
+++ b/src/OrbitGl/GpuSubmissionTrack.cpp
@@ -1,0 +1,299 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "GpuSubmissionTrack.h"
+
+#include <absl/time/time.h>
+
+#include <memory>
+
+#include "App.h"
+#include "Batcher.h"
+#include "CoreUtils.h"
+#include "GlCanvas.h"
+#include "GlUtils.h"
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/ThreadConstants.h"
+#include "TimeGraph.h"
+#include "TimeGraphLayout.h"
+#include "TimerChain.h"
+#include "TriangleToggle.h"
+#include "absl/strings/str_format.h"
+
+using orbit_client_protos::TimerInfo;
+
+constexpr const char* kSwQueueString = "sw queue";
+constexpr const char* kHwQueueString = "hw queue";
+constexpr const char* kHwExecutionString = "hw execution";
+constexpr const char* kCmdBufferString = "command buffer";
+
+GpuSubmissionTrack::GpuSubmissionTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+                                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
+                                       uint64_t timeline_hash, OrbitApp* app,
+                                       const orbit_client_model::CaptureData* capture_data,
+                                       uint32_t indentation_level)
+    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data, indentation_level) {
+  SetLabel("Submissions");
+  draw_background_ = false;
+  text_renderer_ = time_graph->GetTextRenderer();
+  timeline_hash_ = timeline_hash;
+  string_manager_ = app->GetStringManager();
+
+  // Gpu tracks are collapsed by default.
+  collapse_toggle_->SetState(TriangleToggle::State::kCollapsed,
+                             TriangleToggle::InitialStateUpdate::kReplaceInitialState);
+}
+
+std::string GpuSubmissionTrack::GetTooltip() const {
+  return "Shows scheduling and execution times for selected GPU job "
+         "submissions";
+}
+
+void GpuSubmissionTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
+  // In case of having command buffer timers, we need to double the depth of the GPU timers (as we
+  // are drawing the corresponding command buffer timers below them). Therefore, we watch out for
+  // those timers.
+  if (timer_info.type() == TimerInfo::kGpuCommandBuffer) {
+    has_vulkan_layer_command_buffer_timers_ = true;
+  }
+  TimerTrack::OnTimer(timer_info);
+}
+
+bool GpuSubmissionTrack::IsTimerActive(const TimerInfo& timer_info) const {
+  bool is_same_tid_as_selected = timer_info.thread_id() == app_->selected_thread_id();
+  // We do not properly track the PID for GPU jobs and we still want to show
+  // all jobs as active when no thread is selected, so this logic is a bit
+  // different than SchedulerTrack::IsTimerActive.
+  bool no_thread_selected = app_->selected_thread_id() == orbit_base::kAllProcessThreadsTid;
+
+  return is_same_tid_as_selected || no_thread_selected;
+}
+
+Color GpuSubmissionTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected,
+                                        bool is_highlighted) const {
+  const Color kInactiveColor(100, 100, 100, 255);
+  const Color kSelectionColor(0, 128, 255, 255);
+  if (is_highlighted) {
+    return TimerTrack::kHighlightColor;
+  }
+  if (is_selected) {
+    return kSelectionColor;
+  }
+  if (!IsTimerActive(timer_info)) {
+    return kInactiveColor;
+  }
+  if (timer_info.has_color()) {
+    CHECK(timer_info.color().red() < 256);
+    CHECK(timer_info.color().green() < 256);
+    CHECK(timer_info.color().blue() < 256);
+    CHECK(timer_info.color().alpha() < 256);
+    return Color(static_cast<uint8_t>(timer_info.color().red()),
+                 static_cast<uint8_t>(timer_info.color().green()),
+                 static_cast<uint8_t>(timer_info.color().blue()),
+                 static_cast<uint8_t>(timer_info.color().alpha()));
+  }
+
+  // We color code the timeslices for GPU activity using the color
+  // of the CPU thread track that submitted the job.
+  Color color = TimeGraph::GetThreadColor(timer_info.thread_id());
+
+  // We disambiguate the different types of GPU activity based on the
+  // string that is displayed on their timeslice.
+  float coeff = 1.0f;
+  std::string gpu_stage = string_manager_->Get(timer_info.user_data_key()).value_or("");
+  if (gpu_stage == kSwQueueString) {
+    coeff = 0.5f;
+  } else if (gpu_stage == kHwQueueString) {
+    coeff = 0.75f;
+  } else if (gpu_stage == kHwExecutionString) {
+    coeff = 1.0f;
+  }
+
+  color[0] = static_cast<uint8_t>(coeff * color[0]);
+  color[1] = static_cast<uint8_t>(coeff * color[1]);
+  color[2] = static_cast<uint8_t>(coeff * color[2]);
+
+  constexpr uint8_t kOddAlpha = 210;
+  if ((timer_info.depth() & 0x1) == 0u) {
+    color[3] = kOddAlpha;
+  }
+
+  return color;
+}
+
+float GpuSubmissionTrack::GetYFromTimer(const TimerInfo& timer_info) const {
+  auto adjusted_depth = static_cast<float>(timer_info.depth());
+  if (collapse_toggle_->IsCollapsed()) {
+    adjusted_depth = 0.f;
+  }
+  CHECK(timer_info.type() == TimerInfo::kGpuActivity ||
+        timer_info.type() == TimerInfo::kGpuCommandBuffer);
+
+  // We are drawing a small gap between each depth, for visualization purposes.
+  // There won't be a gap between "hw execution"timers and command buffer timers, which
+  // is why the gap space needs to be calculated before adjusting the depth further (see below).
+  float gap_space = adjusted_depth * layout_->GetSpaceBetweenGpuDepths();
+
+  // Command buffer timers are drawn underneath the matching "hw execution" timer, which has the
+  // same depth value as the command buffer timer. Therefore, we need to double the depth in the
+  // case that we have command buffer timers.
+  if (has_vulkan_layer_command_buffer_timers_) {
+    adjusted_depth *= 2.f;
+  }
+
+  // Command buffer timers have the same depth value as their matching "hw execution" timer.
+  // As we want to draw command buffers underneath the hw execution timers, we need to increase
+  // the depth by one.
+  if (timer_info.type() == TimerInfo::kGpuCommandBuffer) {
+    adjusted_depth += 1.f;
+  }
+  return pos_[1] - layout_->GetTrackTabHeight() -
+         layout_->GetTextBoxHeight() * (adjusted_depth + 1.f) - gap_space;
+}
+
+// When track is collapsed, only draw "hardware execution" timers.
+bool GpuSubmissionTrack::TimerFilter(const TimerInfo& timer_info) const {
+  if (collapse_toggle_->IsCollapsed()) {
+    std::string gpu_stage = string_manager_->Get(timer_info.user_data_key()).value_or("");
+    return gpu_stage == kHwExecutionString;
+  }
+  return true;
+}
+
+void GpuSubmissionTrack::SetTimesliceText(const TimerInfo& timer_info, float min_x, float z_offset,
+                                          TextBox* text_box) {
+  if (text_box->GetText().empty()) {
+    std::string time = GetPrettyTime(absl::Nanoseconds(timer_info.end() - timer_info.start()));
+
+    text_box->SetElapsedTimeTextLength(time.length());
+
+    CHECK(timer_info.type() == TimerInfo::kGpuActivity ||
+          timer_info.type() == TimerInfo::kGpuCommandBuffer);
+
+    std::string text = absl::StrFormat(
+        "%s  %s", string_manager_->Get(timer_info.user_data_key()).value_or(""), time.c_str());
+    text_box->SetText(text);
+  }
+
+  const Color kTextWhite(255, 255, 255, 255);
+  const Vec2& box_pos = text_box->GetPos();
+  const Vec2& box_size = text_box->GetSize();
+  float pos_x = std::max(box_pos[0], min_x);
+  float max_size = box_pos[0] + box_size[0] - pos_x;
+  text_renderer_->AddTextTrailingCharsPrioritized(
+      text_box->GetText().c_str(), pos_x, text_box->GetPos()[1] + layout_->GetTextOffset(),
+      GlCanvas::kZValueBox + z_offset, kTextWhite, text_box->GetElapsedTimeTextLength(),
+      layout_->CalculateZoomedFontSize(), max_size);
+}
+
+float GpuSubmissionTrack::GetHeight() const {
+  bool collapsed = collapse_toggle_->IsCollapsed();
+  uint32_t depth = collapsed ? 1 : GetDepth();
+  uint32_t num_gaps = depth > 0 ? depth - 1 : 0;
+  if (has_vulkan_layer_command_buffer_timers_ && !collapsed) {
+    depth *= 2;
+  }
+  return layout_->GetTrackTabHeight() + layout_->GetTextBoxHeight() * depth +
+         (num_gaps * layout_->GetSpaceBetweenGpuDepths()) + layout_->GetTrackBottomMargin();
+}
+
+const TextBox* GpuSubmissionTrack::GetLeft(const TextBox* text_box) const {
+  const TimerInfo& timer_info = text_box->GetTimerInfo();
+  uint64_t timeline_hash = timer_info.user_data_key();
+  if (timeline_hash == timeline_hash_) {
+    std::shared_ptr<TimerChain> timers = GetTimers(timer_info.depth());
+    if (timers) return timers->GetElementBefore(text_box);
+  }
+  return nullptr;
+}
+
+const TextBox* GpuSubmissionTrack::GetRight(const TextBox* text_box) const {
+  const TimerInfo& timer_info = text_box->GetTimerInfo();
+  uint64_t timeline_hash = timer_info.user_data_key();
+  if (timeline_hash == timeline_hash_) {
+    std::shared_ptr<TimerChain> timers = GetTimers(timer_info.depth());
+    if (timers) return timers->GetElementAfter(text_box);
+  }
+  return nullptr;
+}
+
+std::string GpuSubmissionTrack::GetBoxTooltip(const Batcher& batcher, PickingId id) const {
+  const TextBox* text_box = batcher.GetTextBox(id);
+  if ((text_box == nullptr) || text_box->GetTimerInfo().type() == TimerInfo::kCoreActivity) {
+    return "";
+  }
+
+  std::string gpu_stage =
+      string_manager_->Get(text_box->GetTimerInfo().user_data_key()).value_or("");
+  if (gpu_stage == kSwQueueString) {
+    return GetSwQueueTooltip(text_box->GetTimerInfo());
+  }
+  if (gpu_stage == kHwQueueString) {
+    return GetHwQueueTooltip(text_box->GetTimerInfo());
+  }
+  if (gpu_stage == kHwExecutionString) {
+    return GetHwExecutionTooltip(text_box->GetTimerInfo());
+  }
+  if (gpu_stage == kCmdBufferString) {
+    return GetCommandBufferTooltip(text_box->GetTimerInfo());
+  }
+
+  return "";
+}
+
+std::string GpuSubmissionTrack::GetSwQueueTooltip(const TimerInfo& timer_info) const {
+  CHECK(capture_data_ != nullptr);
+  return absl::StrFormat(
+      "<b>Software Queue</b><br/>"
+      "<i>Time between amdgpu_cs_ioctl (job submitted) and "
+      "amdgpu_sched_run_job (job scheduled)</i>"
+      "<br/>"
+      "<br/>"
+      "<b>Submitted from thread:</b> %s [%d]<br/>"
+      "<b>Time:</b> %s",
+      capture_data_->GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
+      GetPrettyTime(TicksToDuration(timer_info.start(), timer_info.end())).c_str());
+}
+
+std::string GpuSubmissionTrack::GetHwQueueTooltip(const TimerInfo& timer_info) const {
+  CHECK(capture_data_ != nullptr);
+  return absl::StrFormat(
+      "<b>Hardware Queue</b><br/><i>Time between amdgpu_sched_run_job "
+      "(job scheduled) and start of GPU execution</i>"
+      "<br/>"
+      "<br/>"
+      "<b>Submitted from thread:</b> %s [%d]<br/>"
+      "<b>Time:</b> %s",
+      capture_data_->GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
+      GetPrettyTime(TicksToDuration(timer_info.start(), timer_info.end())).c_str());
+}
+
+std::string GpuSubmissionTrack::GetHwExecutionTooltip(const TimerInfo& timer_info) const {
+  CHECK(capture_data_ != nullptr);
+  return absl::StrFormat(
+      "<b>Harware Execution</b><br/>"
+      "<i>End is marked by \"dma_fence_signaled\" event for this command "
+      "buffer submission</i>"
+      "<br/>"
+      "<br/>"
+      "<b>Submitted from thread:</b> %s [%d]<br/>"
+      "<b>Time:</b> %s",
+      capture_data_->GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
+      GetPrettyTime(TicksToDuration(timer_info.start(), timer_info.end())).c_str());
+}
+
+std::string GpuSubmissionTrack::GetCommandBufferTooltip(
+    const orbit_client_protos::TimerInfo& timer_info) const {
+  return absl::StrFormat(
+      "<b>Command Buffer Execution</b><br/>"
+      "<i>At `vkBeginCommandBuffer` and `vkEndCommandBuffer` `vkCmdWriteTimestamp`s have been "
+      "inserted. The GPU timestamps get aligned with the corresponding hardware execution of the "
+      "submission.</i>"
+      "<br/>"
+      "<br/>"
+      "<b>Submitted from thread:</b> %s [%d]<br/>"
+      "<b>Time:</b> %s",
+      app_->GetCaptureData().GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
+      GetPrettyTime(TicksToDuration(timer_info.start(), timer_info.end())).c_str());
+}

--- a/src/OrbitGl/GpuSubmissionTrack.h
+++ b/src/OrbitGl/GpuSubmissionTrack.h
@@ -1,0 +1,83 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_GPU_SUBMISSION_TRACK_H_
+#define ORBIT_GL_GPU_SUBMISSION_TRACK_H_
+
+#include <stdint.h>
+
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "CallstackThreadBar.h"
+#include "CoreMath.h"
+#include "GpuDebugMarkerTrack.h"
+#include "PickingManager.h"
+#include "StringManager.h"
+#include "TextBox.h"
+#include "TimerTrack.h"
+#include "Track.h"
+#include "capture_data.pb.h"
+
+class OrbitApp;
+class TextRenderer;
+
+// This track displays the "vkQueueSubmit"s including its hardware execution times and -- if
+// available -- command buffer timings on a certain command queue. In order to visually separate
+// different submissions that would overlap, they are displayed on a different depth with a thin gap
+// between them.
+// This track is meant to be used as a subtrack of `GpuTrack`.
+class GpuSubmissionTrack : public TimerTrack {
+ public:
+  explicit GpuSubmissionTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+                              orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
+                              uint64_t timeline_hash, OrbitApp* app,
+                              const orbit_client_model::CaptureData* capture_data,
+                              uint32_t indentation_level);
+  ~GpuSubmissionTrack() override = default;
+
+  // The type is currently only used by the TrackManger. We are moving towards removing it
+  // completely. For subtracks there is no meaningful type and it should also not be exposed,
+  // though we use the unknown type.
+  [[nodiscard]] Type GetType() const override { return Type::kUnknown; }
+  [[nodiscard]] std::string GetTooltip() const override;
+  [[nodiscard]] float GetHeight() const override;
+
+  [[nodiscard]] const TextBox* GetLeft(const TextBox* text_box) const override;
+  [[nodiscard]] const TextBox* GetRight(const TextBox* text_box) const override;
+
+  [[nodiscard]] float GetYFromTimer(
+      const orbit_client_protos::TimerInfo& timer_info) const override;
+
+  void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
+
+  [[nodiscard]] bool IsCollapsible() const override {
+    return depth_ > 1 || has_vulkan_layer_command_buffer_timers_;
+  }
+
+ protected:
+  [[nodiscard]] bool IsTimerActive(const orbit_client_protos::TimerInfo& timer) const override;
+  [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer, bool is_selected,
+                                    bool is_highlighted) const override;
+  [[nodiscard]] bool TimerFilter(const orbit_client_protos::TimerInfo& timer) const override;
+  void SetTimesliceText(const orbit_client_protos::TimerInfo& timer, float min_x, float z_offset,
+                        TextBox* text_box) override;
+  [[nodiscard]] std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const override;
+
+ private:
+  uint64_t timeline_hash_;
+  StringManager* string_manager_;
+  bool has_vulkan_layer_command_buffer_timers_ = false;
+  [[nodiscard]] std::string GetSwQueueTooltip(
+      const orbit_client_protos::TimerInfo& timer_info) const;
+  [[nodiscard]] std::string GetHwQueueTooltip(
+      const orbit_client_protos::TimerInfo& timer_info) const;
+  [[nodiscard]] std::string GetHwExecutionTooltip(
+      const orbit_client_protos::TimerInfo& timer_info) const;
+  [[nodiscard]] std::string GetCommandBufferTooltip(
+      const orbit_client_protos::TimerInfo& timer_info) const;
+};
+
+#endif  // ORBIT_GL_GPU_SUBMISSION_TRACK_H_

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -4,22 +4,17 @@
 
 #include "GpuTrack.h"
 
-#include <GteVector.h>
 #include <absl/time/time.h>
 
 #include <algorithm>
 #include <memory>
-#include <optional>
 
 #include "App.h"
 #include "Batcher.h"
 #include "ClientModel/CaptureData.h"
-#include "CoreUtils.h"
 #include "GlCanvas.h"
-#include "GlUtils.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ThreadConstants.h"
-#include "TextRenderer.h"
 #include "TimeGraph.h"
 #include "TimeGraphLayout.h"
 #include "TimerChain.h"
@@ -28,11 +23,6 @@
 #include "absl/strings/str_format.h"
 
 using orbit_client_protos::TimerInfo;
-
-constexpr const char* kSwQueueString = "sw queue";
-constexpr const char* kHwQueueString = "hw queue";
-constexpr const char* kHwExecutionString = "hw execution";
-constexpr const char* kCmdBufferString = "command buffer";
 
 namespace orbit_gl {
 
@@ -55,326 +45,235 @@ std::string MapGpuTimelineToTrackLabel(std::string_view timeline) {
     queue_pretty_name = "Video Coding Engine";
     timeline_label = absl::StrFormat(" (%s)", timeline);
   }
-  std::string debug_marker_label;
-  if (timeline.find("_marker") != std::string::npos) {
-    // Space at start is intentional as we want that space between the queue name
-    // and "debug markers". This makes constructing the string simpler.
-    debug_marker_label = " debug markers";
-  }
-  return absl::StrFormat("%s%s%s", queue_pretty_name, debug_marker_label, timeline_label);
+  return absl::StrFormat("%s%s", queue_pretty_name, timeline_label);
 }
 
 }  // namespace orbit_gl
 
 GpuTrack::GpuTrack(CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
                    TimeGraphLayout* layout, uint64_t timeline_hash, OrbitApp* app,
-                   const orbit_client_model::CaptureData* capture_data)
-    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data) {
-  text_renderer_ = time_graph->GetTextRenderer();
+                   const orbit_client_model::CaptureData* capture_data, uint32_t indentation_level)
+    : Track(parent, time_graph, viewport, layout, capture_data, indentation_level),
+      submission_track_{std::make_shared<GpuSubmissionTrack>(this, time_graph, viewport, layout,
+                                                             timeline_hash, app, capture_data,
+                                                             indentation_level + 1)},
+      marker_track_{std::make_shared<GpuDebugMarkerTrack>(this, time_graph, viewport, layout, app,
+                                                          capture_data, indentation_level + 1)} {
   timeline_hash_ = timeline_hash;
-  string_manager_ = app->GetStringManager();
 
   std::string timeline =
-      app_->GetStringManager()->Get(timeline_hash).value_or(std::to_string(timeline_hash));
+      app->GetStringManager()->Get(timeline_hash).value_or(std::to_string(timeline_hash));
   std::string label = orbit_gl::MapGpuTimelineToTrackLabel(timeline);
   SetName(timeline);
   SetLabel(label);
-  // This min combine two cases, label == timeline and when label includes timeline
-  SetNumberOfPrioritizedTrailingCharacters(std::min(label.size(), timeline.size() + 2));
 
-  // Gpu tracks are collapsed by default.
+  submission_track_->SetName(absl::StrFormat("%s_submissions", timeline));
+  marker_track_->SetName(absl::StrFormat("%s_marker", timeline));
+
   collapse_toggle_->SetState(TriangleToggle::State::kCollapsed,
                              TriangleToggle::InitialStateUpdate::kReplaceInitialState);
 }
 
-void GpuTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
-  // In case of having command buffer timers, we need to double the depth of the GPU timers (as we
-  // are drawing the corresponding command buffer timers below them). Therefore, we watch out for
-  // those timers.
-  if (timer_info.type() == TimerInfo::kGpuCommandBuffer) {
-    has_vulkan_layer_command_buffer_timers_ = true;
+void GpuTrack::OnTimer(const TimerInfo& timer_info) {
+  ++num_timers_;
+  if (timer_info.start() < min_time_) min_time_ = timer_info.start();
+  if (timer_info.end() > max_time_) max_time_ = timer_info.end();
+
+  switch (timer_info.type()) {
+    case TimerInfo::kGpuActivity:
+      [[fallthrough]];
+    case TimerInfo::kGpuCommandBuffer:
+      submission_track_->OnTimer(timer_info);
+      break;
+    case TimerInfo::kGpuDebugMarker:
+      marker_track_->OnTimer(timer_info);
+      break;
+    default:
+      UNREACHABLE();
   }
-  TimerTrack::OnTimer(timer_info);
 }
 
-bool GpuTrack::IsTimerActive(const TimerInfo& timer_info) const {
-  bool is_same_tid_as_selected = timer_info.thread_id() == app_->selected_thread_id();
-  // We do not properly track the PID for GPU jobs and we still want to show
-  // all jobs as active when no thread is selected, so this logic is a bit
-  // different than SchedulerTrack::IsTimerActive.
-  bool no_thread_selected = app_->selected_thread_id() == orbit_base::kAllProcessThreadsTid;
-
-  return is_same_tid_as_selected || no_thread_selected;
+std::vector<std::shared_ptr<TimerChain>> GpuTrack::GetAllChains() const {
+  std::vector<std::shared_ptr<TimerChain>> all_chains = submission_track_->GetAllChains();
+  std::vector<std::shared_ptr<TimerChain>> marker_chains = marker_track_->GetAllChains();
+  all_chains.insert(all_chains.begin(), marker_chains.begin(), marker_chains.end());
+  return all_chains;
 }
 
-Color GpuTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected,
-                              bool is_highlighted) const {
-  const Color kInactiveColor(100, 100, 100, 255);
-  const Color kSelectionColor(0, 128, 255, 255);
-  if (is_highlighted) {
-    return TimerTrack::kHighlightColor;
-  }
-  if (is_selected) {
-    return kSelectionColor;
-  }
-  if (!IsTimerActive(timer_info)) {
-    return kInactiveColor;
-  }
-  if (timer_info.has_color()) {
-    CHECK(timer_info.color().red() < 256);
-    CHECK(timer_info.color().green() < 256);
-    CHECK(timer_info.color().blue() < 256);
-    CHECK(timer_info.color().alpha() < 256);
-    return Color(static_cast<uint8_t>(timer_info.color().red()),
-                 static_cast<uint8_t>(timer_info.color().green()),
-                 static_cast<uint8_t>(timer_info.color().blue()),
-                 static_cast<uint8_t>(timer_info.color().alpha()));
-  }
-  if (timer_info.type() == TimerInfo::kGpuDebugMarker) {
-    std::string marker_text = string_manager_->Get(timer_info.user_data_key()).value_or("");
-    return TimeGraph::GetColor(marker_text);
-  }
-
-  // We color code the timeslices for GPU activity using the color
-  // of the CPU thread track that submitted the job.
-  Color color = TimeGraph::GetThreadColor(timer_info.thread_id());
-
-  // We disambiguate the different types of GPU activity based on the
-  // string that is displayed on their timeslice.
-  float coeff = 1.0f;
-  std::string gpu_stage = string_manager_->Get(timer_info.user_data_key()).value_or("");
-  if (gpu_stage == kSwQueueString) {
-    coeff = 0.5f;
-  } else if (gpu_stage == kHwQueueString) {
-    coeff = 0.75f;
-  } else if (gpu_stage == kHwExecutionString) {
-    coeff = 1.0f;
-  }
-
-  color[0] = static_cast<uint8_t>(coeff * color[0]);
-  color[1] = static_cast<uint8_t>(coeff * color[1]);
-  color[2] = static_cast<uint8_t>(coeff * color[2]);
-
-  constexpr uint8_t kOddAlpha = 210;
-  if (!(timer_info.depth() & 0x1)) {
-    color[3] = kOddAlpha;
-  }
-
-  return color;
+std::vector<std::shared_ptr<TimerChain>> GpuTrack::GetAllSerializableChains() const {
+  std::vector<std::shared_ptr<TimerChain>> all_chains =
+      submission_track_->GetAllSerializableChains();
+  std::vector<std::shared_ptr<TimerChain>> marker_chains =
+      marker_track_->GetAllSerializableChains();
+  all_chains.insert(all_chains.begin(), marker_chains.begin(), marker_chains.end());
+  return all_chains;
 }
 
-float GpuTrack::GetYFromTimer(const TimerInfo& timer_info) const {
-  auto adjusted_depth = static_cast<float>(timer_info.depth());
+void GpuTrack::UpdatePositionOfSubtracks() {
   if (collapse_toggle_->IsCollapsed()) {
-    adjusted_depth = 0.f;
+    submission_track_->SetPos(pos_[0], pos_[1]);
+    return;
   }
-  if (timer_info.type() == TimerInfo::kGpuDebugMarker) {
-    return pos_[1] - GetHeaderHeight() - layout_->GetTextBoxHeight() * (adjusted_depth + 1.f);
+  float current_y = pos_[1] - layout_->GetTrackTabHeight();
+  if (!submission_track_->IsEmpty()) {
+    current_y -= layout_->GetSpaceBetweenGpuSubtracks();
   }
-  CHECK(timer_info.type() == TimerInfo::kGpuActivity ||
-        timer_info.type() == TimerInfo::kGpuCommandBuffer);
-
-  // We are drawing a small gap between each depths, as the timers of different depths do not
-  // correlate. There won't be a gap between "hw execution"timers and command buffer timers, which
-  // is why the gap space needs to be calculated before adjusting the depth further (see below).
-  float gap_space = adjusted_depth * layout_->GetSpaceBetweenGpuDepths();
-
-  // Command buffer timers are drawn underneath the matching "hw execution" timer, which has the
-  // same depth value as the command buffer timer. Therefore, we need to double the depth in the
-  // case that we have command buffer timers.
-  if (has_vulkan_layer_command_buffer_timers_) {
-    adjusted_depth *= 2.f;
+  submission_track_->SetPos(pos_[0], current_y);
+  if (!marker_track_->IsEmpty()) {
+    current_y -= (layout_->GetSpaceBetweenGpuSubtracks() + submission_track_->GetHeight());
   }
 
-  // Command buffer timers have the same depth value as their matching "hw execution" timer.
-  // As we want to draw command buffers underneath the hw execution timers, we need to increase
-  // the depth by one.
-  if (timer_info.type() == TimerInfo::kGpuCommandBuffer) {
-    adjusted_depth += 1.f;
-  }
-  return pos_[1] - GetHeaderHeight() - layout_->GetTextBoxHeight() * (adjusted_depth + 1.f) -
-         gap_space;
+  marker_track_->SetPos(pos_[0], current_y);
 }
 
-// When track is collapsed, only draw "hardware execution" timers and the root "debug markers".
-bool GpuTrack::TimerFilter(const TimerInfo& timer_info) const {
+float GpuTrack::GetHeight() const {
   if (collapse_toggle_->IsCollapsed()) {
-    std::string gpu_stage = string_manager_->Get(timer_info.user_data_key()).value_or("");
-    return gpu_stage == kHwExecutionString ||
-           (timer_info.type() == TimerInfo::kGpuDebugMarker && timer_info.depth() == 0);
+    return submission_track_->GetHeight();
   }
-  return true;
+  float height = layout_->GetTrackTabHeight();
+  if (!submission_track_->IsEmpty()) {
+    height += submission_track_->GetHeight();
+  }
+  if (!marker_track_->IsEmpty()) {
+    height += marker_track_->GetHeight();
+  }
+  if (!submission_track_->IsEmpty() && !marker_track_->IsEmpty()) {
+    height += layout_->GetSpaceBetweenGpuSubtracks();
+  }
+  if (!(submission_track_->IsEmpty() && marker_track_->IsEmpty())) {
+    height += layout_->GetSpaceBetweenGpuSubtracks();
+  }
+  return height;
 }
 
-void GpuTrack::SetTimesliceText(const TimerInfo& timer_info, float min_x, float z_offset,
-                                TextBox* text_box) {
-  if (text_box->GetText().empty()) {
-    std::string time = GetPrettyTime(absl::Nanoseconds(timer_info.end() - timer_info.start()));
+void GpuTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
+  float track_height = GetHeight();
+  const orbit_gl::Viewport& viewport = canvas->GetViewport();
+  float track_width = viewport.GetVisibleWorldWidth();
 
-    text_box->SetElapsedTimeTextLength(time.length());
+  SetPos(viewport.GetWorldTopLeft()[0], pos_[1]);
+  SetSize(track_width, track_height);
 
-    CHECK(timer_info.type() == TimerInfo::kGpuActivity ||
-          timer_info.type() == TimerInfo::kGpuCommandBuffer ||
-          timer_info.type() == TimerInfo::kGpuDebugMarker);
+  UpdatePositionOfSubtracks();
 
-    std::string text = absl::StrFormat(
-        "%s  %s", string_manager_->Get(timer_info.user_data_key()).value_or(""), time.c_str());
-    text_box->SetText(text);
+  Track::Draw(canvas, picking_mode, z_offset);
+
+  if (collapse_toggle_->IsCollapsed()) {
+    return;
   }
 
-  const Color kTextWhite(255, 255, 255, 255);
-  const Vec2& box_pos = text_box->GetPos();
-  const Vec2& box_size = text_box->GetSize();
-  float pos_x = std::max(box_pos[0], min_x);
-  float max_size = box_pos[0] + box_size[0] - pos_x;
-  text_renderer_->AddTextTrailingCharsPrioritized(
-      text_box->GetText().c_str(), pos_x, text_box->GetPos()[1] + layout_->GetTextOffset(),
-      GlCanvas::kZValueBox + z_offset, kTextWhite, text_box->GetElapsedTimeTextLength(),
-      layout_->CalculateZoomedFontSize(), max_size);
+  if (!submission_track_->IsEmpty()) {
+    submission_track_->SetSize(viewport.GetVisibleWorldWidth(), submission_track_->GetHeight());
+    submission_track_->Draw(canvas, picking_mode, z_offset);
+  }
+
+  if (!marker_track_->IsEmpty()) {
+    marker_track_->SetSize(viewport.GetVisibleWorldWidth(), marker_track_->GetHeight());
+    marker_track_->Draw(canvas, picking_mode, z_offset);
+  }
+}
+
+void GpuTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                                PickingMode picking_mode, float z_offset) {
+  UpdatePositionOfSubtracks();
+
+  const bool is_collapsed = collapse_toggle_->IsCollapsed();
+
+  if (!submission_track_->IsEmpty()) {
+    submission_track_->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
+  }
+
+  if (is_collapsed) {
+    return;
+  }
+
+  if (!marker_track_->IsEmpty()) {
+    marker_track_->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
+  }
+}
+
+std::vector<orbit_gl::CaptureViewElement*> GpuTrack::GetVisibleChildren() {
+  std::vector<CaptureViewElement*> result;
+
+  if (collapse_toggle_->IsCollapsed()) {
+    return result;
+  }
+
+  if (!submission_track_->IsEmpty()) {
+    result.push_back(submission_track_.get());
+  }
+
+  if (!marker_track_->IsEmpty()) {
+    result.push_back(marker_track_.get());
+  }
+  return result;
 }
 
 std::string GpuTrack::GetTooltip() const {
   return "Shows scheduling and execution times for selected GPU job "
-         "submissions";
+         "submissions and debug markers";
 }
 
-float GpuTrack::GetHeight() const {
-  bool collapsed = collapse_toggle_->IsCollapsed();
-  uint32_t depth = collapsed ? 1 : GetDepth();
-  uint32_t num_gaps = depth > 0 ? depth - 1 : 0;
-  if (has_vulkan_layer_command_buffer_timers_ && !collapsed) {
-    depth *= 2;
+const TextBox* GpuTrack::GetLeft(const TextBox* textbox) const {
+  const TimerInfo& timer_info = textbox->GetTimerInfo();
+  switch (timer_info.type()) {
+    case TimerInfo::kGpuActivity:
+      [[fallthrough]];
+    case TimerInfo::kGpuCommandBuffer:
+      return submission_track_->GetLeft(textbox);
+    case TimerInfo::kGpuDebugMarker:
+      return marker_track_->GetLeft(textbox);
+    default:
+      UNREACHABLE();
   }
-  return GetHeaderHeight() + layout_->GetTextBoxHeight() * depth +
-         (num_gaps * layout_->GetSpaceBetweenGpuDepths()) + layout_->GetTrackBottomMargin();
 }
 
-const TextBox* GpuTrack::GetLeft(const TextBox* text_box) const {
-  const TimerInfo& timer_info = text_box->GetTimerInfo();
-  uint64_t timeline_hash = timer_info.user_data_key();
-  if (timeline_hash == timeline_hash_) {
-    std::shared_ptr<TimerChain> timers = GetTimers(timer_info.depth());
-    if (timers) return timers->GetElementBefore(text_box);
+const TextBox* GpuTrack::GetRight(const TextBox* textbox) const {
+  const TimerInfo& timer_info = textbox->GetTimerInfo();
+  switch (timer_info.type()) {
+    case TimerInfo::kGpuActivity:
+      [[fallthrough]];
+    case TimerInfo::kGpuCommandBuffer:
+      return submission_track_->GetRight(textbox);
+    case TimerInfo::kGpuDebugMarker:
+      return marker_track_->GetRight(textbox);
+    default:
+      UNREACHABLE();
   }
-  return nullptr;
 }
 
-const TextBox* GpuTrack::GetRight(const TextBox* text_box) const {
-  const TimerInfo& timer_info = text_box->GetTimerInfo();
-  uint64_t timeline_hash = timer_info.user_data_key();
-  if (timeline_hash == timeline_hash_) {
-    std::shared_ptr<TimerChain> timers = GetTimers(timer_info.depth());
-    if (timers) return timers->GetElementAfter(text_box);
+const TextBox* GpuTrack::GetUp(const TextBox* textbox) const {
+  const TimerInfo& timer_info = textbox->GetTimerInfo();
+  switch (timer_info.type()) {
+    case TimerInfo::kGpuActivity:
+      [[fallthrough]];
+    case TimerInfo::kGpuCommandBuffer:
+      return submission_track_->GetUp(textbox);
+    case TimerInfo::kGpuDebugMarker:
+      return marker_track_->GetUp(textbox);
+    default:
+      UNREACHABLE();
   }
-  return nullptr;
 }
 
-std::string GpuTrack::GetBoxTooltip(const Batcher& batcher, PickingId id) const {
-  const TextBox* text_box = batcher.GetTextBox(id);
-  if (!text_box || text_box->GetTimerInfo().type() == TimerInfo::kCoreActivity) {
-    return "";
+const TextBox* GpuTrack::GetDown(const TextBox* textbox) const {
+  const TimerInfo& timer_info = textbox->GetTimerInfo();
+  switch (timer_info.type()) {
+    case TimerInfo::kGpuActivity:
+      [[fallthrough]];
+    case TimerInfo::kGpuCommandBuffer:
+      return submission_track_->GetDown(textbox);
+    case TimerInfo::kGpuDebugMarker:
+      return marker_track_->GetDown(textbox);
+    default:
+      UNREACHABLE();
   }
-
-  std::string gpu_stage =
-      string_manager_->Get(text_box->GetTimerInfo().user_data_key()).value_or("");
-  if (gpu_stage == kSwQueueString) {
-    return GetSwQueueTooltip(text_box->GetTimerInfo());
-  }
-  if (gpu_stage == kHwQueueString) {
-    return GetHwQueueTooltip(text_box->GetTimerInfo());
-  }
-  if (gpu_stage == kHwExecutionString) {
-    return GetHwExecutionTooltip(text_box->GetTimerInfo());
-  }
-  if (gpu_stage == kCmdBufferString) {
-    return GetCommandBufferTooltip(text_box->GetTimerInfo());
-  }
-  if (text_box->GetTimerInfo().type() == TimerInfo::kGpuDebugMarker) {
-    return GetDebugMarkerTooltip(text_box->GetTimerInfo());
-  }
-
-  return "";
 }
-
-std::string GpuTrack::GetSwQueueTooltip(const TimerInfo& timer_info) const {
-  CHECK(capture_data_ != nullptr);
-  return absl::StrFormat(
-      "<b>Software Queue</b><br/>"
-      "<i>Time between amdgpu_cs_ioctl (job submitted) and "
-      "amdgpu_sched_run_job (job scheduled)</i>"
-      "<br/>"
-      "<br/>"
-      "<b>Submitted from process:</b> %s [%d]<br/>"
-      "<b>Submitted from thread:</b> %s [%d]<br/>"
-      "<b>Time:</b> %s",
-      capture_data_->GetThreadName(timer_info.process_id()), timer_info.process_id(),
-      capture_data_->GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
-      GetPrettyTime(TicksToDuration(timer_info.start(), timer_info.end())).c_str());
-}
-
-std::string GpuTrack::GetHwQueueTooltip(const TimerInfo& timer_info) const {
-  CHECK(capture_data_ != nullptr);
-  return absl::StrFormat(
-      "<b>Hardware Queue</b><br/><i>Time between amdgpu_sched_run_job "
-      "(job scheduled) and start of GPU execution</i>"
-      "<br/>"
-      "<br/>"
-      "<b>Submitted from process:</b> %s [%d]<br/>"
-      "<b>Submitted from thread:</b> %s [%d]<br/>"
-      "<b>Time:</b> %s",
-      capture_data_->GetThreadName(timer_info.process_id()), timer_info.process_id(),
-      capture_data_->GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
-      GetPrettyTime(TicksToDuration(timer_info.start(), timer_info.end())).c_str());
-}
-
-std::string GpuTrack::GetHwExecutionTooltip(const TimerInfo& timer_info) const {
-  CHECK(capture_data_ != nullptr);
-  return absl::StrFormat(
-      "<b>Harware Execution</b><br/>"
-      "<i>End is marked by \"dma_fence_signaled\" event for this command "
-      "buffer submission</i>"
-      "<br/>"
-      "<br/>"
-      "<b>Submitted from process:</b> %s [%d]<br/>"
-      "<b>Submitted from thread:</b> %s [%d]<br/>"
-      "<b>Time:</b> %s",
-      capture_data_->GetThreadName(timer_info.process_id()), timer_info.process_id(),
-      capture_data_->GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
-      GetPrettyTime(TicksToDuration(timer_info.start(), timer_info.end())).c_str());
-}
-
-std::string GpuTrack::GetCommandBufferTooltip(
-    const orbit_client_protos::TimerInfo& timer_info) const {
-  return absl::StrFormat(
-      "<b>Command Buffer Execution</b><br/>"
-      "<i>At `vkBeginCommandBuffer` and `vkEndCommandBuffer` `vkCmdWriteTimestamp`s have been "
-      "inserted. The GPU timestamps get aligned with the corresponding hardware execution of the "
-      "submission.</i>"
-      "<br/>"
-      "<br/>"
-      "<b>Submitted from process:</b> %s [%d]<br/>"
-      "<b>Submitted from thread:</b> %s [%d]<br/>"
-      "<b>Time:</b> %s",
-      capture_data_->GetThreadName(timer_info.process_id()), timer_info.process_id(),
-      app_->GetCaptureData().GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
-      GetPrettyTime(TicksToDuration(timer_info.start(), timer_info.end())).c_str());
-}
-
-std::string GpuTrack::GetDebugMarkerTooltip(
-    const orbit_client_protos::TimerInfo& timer_info) const {
-  std::string marker_text = string_manager_->Get(timer_info.user_data_key()).value_or("");
-  return absl::StrFormat(
-      "<b>Vulkan Debug Marker</b><br/>"
-      "<i>At the marker's begin and end `vkCmdWriteTimestamp`s have been "
-      "inserted. The GPU timestamps get aligned with the corresponding hardware execution of the "
-      "submission.</i>"
-      "<br/>"
-      "<br/>"
-      "<b>Marker text:</b> %s<br/>"
-      "<b>Submitted from process:</b> %s [%d]<br/>"
-      "<b>Submitted from thread:</b> %s [%d]<br/>"
-      "<b>Time:</b> %s",
-      marker_text, capture_data_->GetThreadName(timer_info.process_id()), timer_info.process_id(),
-      app_->GetCaptureData().GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
-      GetPrettyTime(TicksToDuration(timer_info.start(), timer_info.end())).c_str());
+void GpuTrack::OnCollapseToggle(TriangleToggle::State state) {
+  Track::OnCollapseToggle(state);
+  // When being collapsed, we only show the submission track, and we want those timers also being
+  // collapsed. The marker track does not need to be touched, as it will not be drawn.
+  if (state == TriangleToggle::State::kCollapsed) {
+    submission_track_->Collapse();
+  }
 }

--- a/src/OrbitGl/GpuTrackTest.cpp
+++ b/src/OrbitGl/GpuTrackTest.cpp
@@ -20,23 +20,6 @@ TEST(GpuTrack, MapGpuTimelineToTrackLabelMapsRegularQueuesCorrectly) {
   EXPECT_EQ("Video Coding Engine (vce1)", MapGpuTimelineToTrackLabel("vce1"));
 }
 
-TEST(GpuTrack, MapGpuTimelineToTrackLabelMapsDebugMarkerQueuesCorrectly) {
-  EXPECT_EQ("Graphics queue debug markers (gfx_marker)", MapGpuTimelineToTrackLabel("gfx_marker"));
-
-  EXPECT_EQ("DMA queue debug markers (sdma0_marker)", MapGpuTimelineToTrackLabel("sdma0_marker"));
-  EXPECT_EQ("DMA queue debug markers (sdma1_marker)", MapGpuTimelineToTrackLabel("sdma1_marker"));
-
-  EXPECT_EQ("Compute queue debug markers (comp_1.0.0_marker)",
-            MapGpuTimelineToTrackLabel("comp_1.0.0_marker"));
-  EXPECT_EQ("Compute queue debug markers (comp_1.1.0_marker)",
-            MapGpuTimelineToTrackLabel("comp_1.1.0_marker"));
-
-  EXPECT_EQ("Video Coding Engine debug markers (vce0_marker)",
-            MapGpuTimelineToTrackLabel("vce0_marker"));
-  EXPECT_EQ("Video Coding Engine debug markers (vce1_marker)",
-            MapGpuTimelineToTrackLabel("vce1_marker"));
-}
-
 TEST(GpuTrack, MapGpuTimelineToTrackLabelIgnoresUnknownTimelines) {
   EXPECT_EQ("unknown_timeline", MapGpuTimelineToTrackLabel("unknown_timeline"));
 }

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -19,8 +19,9 @@
 
 GraphTrack::GraphTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                        orbit_gl::Viewport* viewport, TimeGraphLayout* layout, std::string name,
-                       const orbit_client_model::CaptureData* capture_data)
-    : Track(parent, time_graph, viewport, layout, capture_data) {
+                       const orbit_client_model::CaptureData* capture_data,
+                       uint32_t indentation_level)
+    : Track(parent, time_graph, viewport, layout, capture_data, indentation_level) {
   SetName(name);
   SetLabel(name);
 }

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -26,7 +26,9 @@ class GraphTrack : public Track {
  public:
   explicit GraphTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout, std::string name,
-                      const orbit_client_model::CaptureData* capture_data);
+                      const orbit_client_model::CaptureData* capture_data,
+                      uint32_t indentation_level = 0);
+
   [[nodiscard]] Type GetType() const override { return Type::kGraphTrack; }
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -24,8 +24,9 @@ const Color kSelectionColor(0, 128, 255, 255);
 
 SchedulerTrack::SchedulerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                                orbit_gl::Viewport* viewport, TimeGraphLayout* layout, OrbitApp* app,
-                               const orbit_client_model::CaptureData* capture_data)
-    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data) {
+                               const orbit_client_model::CaptureData* capture_data,
+                               uint32_t indentation_level)
+    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data, indentation_level) {
   SetPinned(false);
   SetName("Scheduler");
   SetLabel("Scheduler (0 cores)");

--- a/src/OrbitGl/SchedulerTrack.h
+++ b/src/OrbitGl/SchedulerTrack.h
@@ -21,7 +21,8 @@ class SchedulerTrack final : public TimerTrack {
  public:
   explicit SchedulerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                           orbit_gl::Viewport* viewport, TimeGraphLayout* layout, OrbitApp* app,
-                          const orbit_client_model::CaptureData* capture_data);
+                          const orbit_client_model::CaptureData* capture_data,
+                          uint32_t indentation_level = 0);
   ~SchedulerTrack() override = default;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
 

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -39,8 +39,8 @@ using orbit_grpc_protos::InstrumentedFunction;
 
 ThreadTrack::ThreadTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                          orbit_gl::Viewport* viewport, TimeGraphLayout* layout, int32_t thread_id,
-                         OrbitApp* app, const CaptureData* capture_data)
-    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data) {
+                         OrbitApp* app, const CaptureData* capture_data, uint32_t indentation_level)
+    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data, indentation_level) {
   thread_id_ = thread_id;
   InitializeNameAndLabel(thread_id);
 

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -29,7 +29,9 @@ class ThreadTrack final : public TimerTrack {
  public:
   explicit ThreadTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                        orbit_gl::Viewport* viewport, TimeGraphLayout* layout, int32_t thread_id,
-                       OrbitApp* app, const orbit_client_model::CaptureData* capture_data);
+                       OrbitApp* app, const orbit_client_model::CaptureData* capture_data,
+                       uint32_t indentation_level = 0);
+
   void InitializeNameAndLabel(int32_t thread_id);
 
   [[nodiscard]] int32_t GetThreadId() const { return thread_id_; }

--- a/src/OrbitGl/TimeGraphLayout.cpp
+++ b/src/OrbitGl/TimeGraphLayout.cpp
@@ -18,12 +18,14 @@ TimeGraphLayout::TimeGraphLayout() {
   space_between_gpu_depths_ = 2.f;
   space_between_tracks_ = 10.f;
   space_between_tracks_and_thread_ = 5.f;
+  space_between_gpu_subtracks_ = -5.f;
   space_between_thread_blocks_ = 35.f;
   track_label_offset_x_ = 30.f;
   slider_width_ = 15.f;
   track_tab_width_ = 350.f;
   track_tab_height_ = 30.f;
   track_tab_offset_ = 0.f;
+  track_intent_offset_ = 5.f;
   collapse_button_offset_ = 15.f;
   rounding_radius_ = 8.f;
   rounding_num_sides_ = 16;
@@ -54,11 +56,13 @@ bool TimeGraphLayout::DrawProperties() {
   FLOAT_SLIDER(space_between_gpu_depths_);
   FLOAT_SLIDER(space_between_tracks_);
   FLOAT_SLIDER(space_between_tracks_and_thread_);
+  FLOAT_SLIDER(space_between_gpu_subtracks_);
   FLOAT_SLIDER(space_between_thread_blocks_);
   FLOAT_SLIDER(slider_width_);
   FLOAT_SLIDER(time_bar_height_);
   FLOAT_SLIDER(track_tab_height_);
   FLOAT_SLIDER(track_tab_offset_);
+  FLOAT_SLIDER(track_intent_offset_);
   FLOAT_SLIDER(collapse_button_offset_);
   FLOAT_SLIDER(rounding_radius_);
   FLOAT_SLIDER(rounding_num_sides_);

--- a/src/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/TimeGraphLayout.h
@@ -25,6 +25,7 @@ class TimeGraphLayout {
   float GetTrackTabWidth() const { return track_tab_width_; }
   float GetTrackTabHeight() const { return track_tab_height_ * scale_; }
   float GetTrackTabOffset() const { return track_tab_offset_; }
+  float GetTrackIntentOffset() const { return track_intent_offset_; }
   float GetCollapseButtonOffset() const { return collapse_button_offset_; }
   float GetRoundingRadius() const { return rounding_radius_ * scale_; }
   float GetRoundingNumSides() const { return rounding_num_sides_; }
@@ -37,6 +38,7 @@ class TimeGraphLayout {
   float GetSpaceBetweenCores() const { return space_between_cores_ * scale_; }
   float GetSpaceBetweenGpuDepths() const { return space_between_gpu_depths_ * scale_; }
   float GetSpaceBetweenTracksAndThread() const { return space_between_tracks_and_thread_ * scale_; }
+  float GetSpaceBetweenGpuSubtracks() const { return space_between_gpu_subtracks_ * scale_; }
   float GetToolbarIconHeight() const { return toolbar_icon_height_; }
   float GetScale() const { return scale_; }
   void SetScale(float value) { scale_ = value; }
@@ -62,6 +64,7 @@ class TimeGraphLayout {
   float track_tab_width_;
   float track_tab_height_;
   float track_tab_offset_;
+  float track_intent_offset_;
   float collapse_button_offset_;
   float rounding_radius_;
   float rounding_num_sides_;
@@ -75,6 +78,7 @@ class TimeGraphLayout {
   float space_between_gpu_depths_;
   float space_between_tracks_;
   float space_between_tracks_and_thread_;
+  float space_between_gpu_subtracks_;
   float space_between_thread_blocks_;
 
   float toolbar_icon_height_;

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -32,8 +32,9 @@ const Color TimerTrack::kHighlightColor = Color(100, 181, 246, 255);
 
 TimerTrack::TimerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                        orbit_gl::Viewport* viewport, TimeGraphLayout* layout, OrbitApp* app,
-                       const orbit_client_model::CaptureData* capture_data)
-    : Track(parent, time_graph, viewport, layout, capture_data), app_{app} {
+                       const orbit_client_model::CaptureData* capture_data,
+                       uint32_t indentation_level)
+    : Track(parent, time_graph, viewport, layout, capture_data, indentation_level), app_{app} {
   text_renderer_ = time_graph->GetTextRenderer();
 }
 

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -54,7 +54,8 @@ class TimerTrack : public Track {
  public:
   explicit TimerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout, OrbitApp* app,
-                      const orbit_client_model::CaptureData* capture_data);
+                      const orbit_client_model::CaptureData* capture_data,
+                      uint32_t indentation_level = 0);
   ~TimerTrack() override = default;
 
   // Pickable
@@ -100,6 +101,8 @@ class TimerTrack : public Track {
 
   [[nodiscard]] int GetVisiblePrimitiveCount() const override { return visible_timer_count_; }
 
+  float GetHeight() const override;
+
  protected:
   [[nodiscard]] virtual bool IsTimerActive(
       const orbit_client_protos::TimerInfo& /*timer_info*/) const {
@@ -141,7 +144,6 @@ class TimerTrack : public Track {
         &text_box, [this, &batcher](PickingId id) { return this->GetBoxTooltip(batcher, id); });
   }
 
-  float GetHeight() const override;
   float box_height_ = 0.0f;
 
   static const Color kHighlightColor;

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -43,8 +43,8 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   };
 
   explicit Track(CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
-                 TimeGraphLayout* layout, const orbit_client_model::CaptureData* capture_data);
-
+                 TimeGraphLayout* layout, const orbit_client_model::CaptureData* capture_data,
+                 uint32_t indentation_level);
   ~Track() override = default;
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
@@ -98,11 +98,16 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   [[nodiscard]] virtual bool IsTrackSelected() const { return false; }
 
   [[nodiscard]] bool IsCollapsed() const { return collapse_toggle_->IsCollapsed(); }
+  void Collapse() { collapse_toggle_->SetState(TriangleToggle::State::kCollapsed); }
 
   [[nodiscard]] virtual std::vector<CaptureViewElement*> GetVisibleChildren() { return {}; }
   [[nodiscard]] virtual int GetVisiblePrimitiveCount() const { return 0; }
 
+  [[nodiscard]] virtual uint32_t GetIntent() const { return indentation_level_; }
+
  protected:
+  // Returns the y-position of the triangle.
+  float DrawCollapsingTriangle(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0);
   void DrawTriangleFan(Batcher* batcher, const std::vector<Vec2>& points, const Vec2& pos,
                        const Color& color, float rotation, float z);
 
@@ -114,6 +119,7 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   int32_t thread_id_;
   int32_t process_id_;
   Color color_;
+  bool draw_background_ = true;
   bool visible_ = true;
   bool pinned_ = false;
   std::map<int, std::shared_ptr<TimerChain>> timers_;
@@ -126,6 +132,9 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   TimeGraphLayout* layout_;
 
   const orbit_client_model::CaptureData* capture_data_ = nullptr;
+
+ private:
+  const uint32_t indentation_level_;
 };
 
 #endif

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -18,13 +18,13 @@
 
 TriangleToggle::TriangleToggle(State initial_state, StateChangeHandler handler,
                                TimeGraph* time_graph, orbit_gl::Viewport* viewport,
-                               TimeGraphLayout* layout, Track* track)
+                               TimeGraphLayout* layout, Track* track, float size)
     : CaptureViewElement(track, time_graph, viewport, layout),
       track_(track),
       state_(initial_state),
       initial_state_(initial_state),
       handler_(std::move(handler)) {
-  SetSize(10.f, 10.f);
+  SetSize(size, size);
 }
 
 void TriangleToggle::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {

--- a/src/OrbitGl/TriangleToggle.h
+++ b/src/OrbitGl/TriangleToggle.h
@@ -22,7 +22,8 @@ class TriangleToggle : public orbit_gl::CaptureViewElement,
 
   using StateChangeHandler = std::function<void(TriangleToggle::State)>;
   explicit TriangleToggle(State initial_state, StateChangeHandler handler, TimeGraph* time_graph,
-                          orbit_gl::Viewport* viewport, TimeGraphLayout* layout, Track* track);
+                          orbit_gl::Viewport* viewport, TimeGraphLayout* layout, Track* track,
+                          float size);
   ~TriangleToggle() override = default;
 
   TriangleToggle() = delete;


### PR DESCRIPTION
    Combine Gpu debug marker and submission tracks into one.
    
    Prior this, we had two Gpu tracks per queue (when the Vulkan layer
    was enabled). However, those belong tightly together.
    
    This change makes `GpuTrack` being a composed track of `GpuDebugMarkerTrack`
    and `GpuSubmissionTrack`. It refactors out the logic of each kind of
    prior GpuTrack.
    
    In order to do so, tracks can be now transparent and may have an intent.
    
    Test: Take a capture with the Vulkan layer.
    Bug: http://b/182751932.


![Screenshot 2021-03-19 at 14 55 30](https://user-images.githubusercontent.com/2725914/111791080-28d54d80-88c3-11eb-869a-8f818bd6b5ec.png)
![Screenshot 2021-03-19 at 14 56 43](https://user-images.githubusercontent.com/2725914/111791253-54583800-88c3-11eb-823f-13a0ecbed402.png)
