### PR TITLE
CaptureClient no longer relies on FLAGS

### DIFF
--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -29,7 +29,7 @@ message InstrumentedFunction {
 message CaptureOptions {
   bool trace_context_switches = 1;
   int32 pid = 2;
-  double sampling_rate = 3;
+  double samples_per_second = 3;
 
   enum UnwindingMethod {
     kUndefined = 0;

--- a/src/GrpcProtos/include/GrpcProtos/Constants.h
+++ b/src/GrpcProtos/include/GrpcProtos/Constants.h
@@ -17,6 +17,8 @@ constexpr int kMissingInfo = -1;
 constexpr uint64_t kLinuxTracingProducerId = 0;
 constexpr uint64_t kMemoryInfoProducerId = 1;
 constexpr uint64_t kExternalProducerStartingId = 1024;
+
+enum class UnwindingMethod { kDwarfUnwinding, kFramePointerUnwinding };
 }  // namespace orbit_grpc_protos
 
 #endif  // GRPC_PROTOS_CONSTANTS_H_

--- a/src/LinuxTracing/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracing/LinuxTracingIntegrationTest.cpp
@@ -276,7 +276,7 @@ class LinuxTracingIntegrationTestFixture {
     orbit_grpc_protos::CaptureOptions capture_options;
     capture_options.set_trace_context_switches(true);
     capture_options.set_pid(puppet_.GetChildPid());
-    capture_options.set_sampling_rate(1000.0);
+    capture_options.set_samples_per_second(1000.0);
     capture_options.set_unwinding_method(orbit_grpc_protos::CaptureOptions::kDwarf);
     capture_options.set_trace_thread_state(true);
     capture_options.set_trace_gpu_driver(true);
@@ -753,7 +753,7 @@ TEST(LinuxTracingIntegrationTest, CallstackSamplesAndAddressInfos) {
   const std::filesystem::path& executable_path = GetExecutableBinaryPath(fixture.GetPuppetPid());
 
   orbit_grpc_protos::CaptureOptions capture_options = fixture.BuildDefaultCaptureOptions();
-  const double sampling_rate = capture_options.sampling_rate();
+  const double samples_per_second = capture_options.samples_per_second();
 
   std::vector<orbit_grpc_protos::ProducerCaptureEvent> events =
       TraceAndGetEvents(&fixture, PuppetConstants::kCallOuterFunctionCommand, capture_options);
@@ -767,7 +767,7 @@ TEST(LinuxTracingIntegrationTest, CallstackSamplesAndAddressInfos) {
 
   VerifyCallstackSamplesWithOuterAndInnerFunctionForDwarfUnwinding(
       events, fixture.GetPuppetPid(), outer_function_virtual_address_range,
-      inner_function_virtual_address_range, sampling_rate, &address_infos_received);
+      inner_function_virtual_address_range, samples_per_second, &address_infos_received);
 }
 
 TEST(LinuxTracingIntegrationTest, CallstackSamplesTogetherWithFunctionCalls) {
@@ -785,7 +785,7 @@ TEST(LinuxTracingIntegrationTest, CallstackSamplesTogetherWithFunctionCalls) {
   constexpr uint64_t kInnerFunctionId = 2;
   AddOuterAndInnerFunctionToCaptureOptions(&capture_options, fixture.GetPuppetPid(),
                                            kOuterFunctionId, kInnerFunctionId);
-  const double sampling_rate = capture_options.sampling_rate();
+  const double sampling_rate = capture_options.samples_per_second();
 
   std::vector<orbit_grpc_protos::ProducerCaptureEvent> events =
       TraceAndGetEvents(&fixture, PuppetConstants::kCallOuterFunctionCommand, capture_options);
@@ -822,7 +822,7 @@ TEST(LinuxTracingIntegrationTest, CallstackSamplesWithFramePointers) {
 
   orbit_grpc_protos::CaptureOptions capture_options = fixture.BuildDefaultCaptureOptions();
   capture_options.set_unwinding_method(orbit_grpc_protos::CaptureOptions::kFramePointers);
-  const double sampling_rate = capture_options.sampling_rate();
+  const double sampling_rate = capture_options.samples_per_second();
 
   std::vector<orbit_grpc_protos::ProducerCaptureEvent> events =
       TraceAndGetEvents(&fixture, PuppetConstants::kCallOuterFunctionCommand, capture_options);
@@ -854,7 +854,7 @@ TEST(LinuxTracingIntegrationTest, CallstackSamplesWithFramePointersTogetherWithF
   constexpr uint64_t kInnerFunctionId = 2;
   AddOuterAndInnerFunctionToCaptureOptions(&capture_options, fixture.GetPuppetPid(),
                                            kOuterFunctionId, kInnerFunctionId);
-  const double sampling_rate = capture_options.sampling_rate();
+  const double sampling_rate = capture_options.samples_per_second();
 
   std::vector<orbit_grpc_protos::ProducerCaptureEvent> events =
       TraceAndGetEvents(&fixture, PuppetConstants::kCallOuterFunctionCommand, capture_options);

--- a/src/LinuxTracing/TracerThread.cpp
+++ b/src/LinuxTracing/TracerThread.cpp
@@ -49,9 +49,9 @@ TracerThread::TracerThread(const CaptureOptions& capture_options)
       trace_gpu_driver_{capture_options.trace_gpu_driver()} {
   if (unwinding_method_ != CaptureOptions::kUndefined) {
     std::optional<uint64_t> sampling_period_ns =
-        ComputeSamplingPeriodNs(capture_options.sampling_rate());
+        ComputeSamplingPeriodNs(capture_options.samples_per_second());
     FAIL_IF(!sampling_period_ns.has_value(), "Invalid sampling rate: %.1f",
-            capture_options.sampling_rate());
+            capture_options.samples_per_second());
     sampling_period_ns_ = sampling_period_ns.value();
   } else {
     sampling_period_ns_ = 0;

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
@@ -6,6 +6,7 @@
 #define ORBIT_CAPTURE_CLIENT_CAPTURE_CLIENT_H_
 
 #include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
 #include <absl/synchronization/mutex.h>
 #include <grpcpp/grpcpp.h>
 #include <stdint.h>
@@ -14,6 +15,7 @@
 #include <memory>
 
 #include "CaptureListener.h"
+#include "GrpcProtos/Constants.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
 #include "OrbitBase/ThreadPool.h"
@@ -21,7 +23,6 @@
 #include "OrbitClientData/ProcessData.h"
 #include "OrbitClientData/TracepointCustom.h"
 #include "OrbitClientData/UserDefinedCaptureData.h"
-#include "absl/container/flat_hash_set.h"
 #include "capture_data.pb.h"
 #include "grpcpp/channel.h"
 #include "services.grpc.pb.h"
@@ -43,7 +44,8 @@ class CaptureClient {
       const orbit_client_data::ModuleManager& module_manager,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints,
-      absl::flat_hash_set<uint64_t> frame_track_function_ids, bool collect_thread_state,
+      absl::flat_hash_set<uint64_t> frame_track_function_ids, double samples_per_second,
+      orbit_grpc_protos::UnwindingMethod unwinding_method, bool collect_thread_state,
       bool enable_introspection, uint64_t max_local_marker_depth_per_command_buffer);
 
   // Returns true if stop was initiated and false otherwise.
@@ -71,7 +73,8 @@ class CaptureClient {
       ProcessData&& process, const orbit_client_data::ModuleManager& module_manager,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints,
-      absl::flat_hash_set<uint64_t> frame_track_function_ids, bool collect_thread_state,
+      absl::flat_hash_set<uint64_t> frame_track_function_ids, double samples_per_second,
+      orbit_grpc_protos::UnwindingMethod unwinding_method, bool collect_thread_state,
       bool enable_introspection, uint64_t max_local_marker_depth_per_command_buffer);
 
   [[nodiscard]] ErrorMessageOr<void> FinishCapture();

--- a/src/OrbitClientGgp/ClientGgp.cpp
+++ b/src/OrbitClientGgp/ClientGgp.cpp
@@ -4,7 +4,10 @@
 
 #include "OrbitClientGgp/ClientGgp.h"
 
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
 #include <absl/flags/declare.h>
+#include <absl/flags/flag.h>
 #include <absl/strings/str_format.h>
 #include <grpcpp/create_channel.h>
 #include <grpcpp/security/credentials.h>
@@ -19,6 +22,7 @@
 #include <type_traits>
 #include <vector>
 
+#include "GrpcProtos/Constants.h"
 #include "OrbitBase/Future.h"
 #include "OrbitBase/ImmediateExecutor.h"
 #include "OrbitBase/Logging.h"
@@ -32,9 +36,6 @@
 #include "OrbitClientModel/SamplingDataPostProcessor.h"
 #include "StringManager.h"
 #include "SymbolHelper.h"
-#include "absl/container/flat_hash_map.h"
-#include "absl/container/flat_hash_set.h"
-#include "absl/flags/flag.h"
 #include "capture_data.pb.h"
 #include "module.pb.h"
 #include "process.pb.h"
@@ -49,6 +50,7 @@ using orbit_client_protos::LinuxAddressInfo;
 using orbit_client_protos::TimerInfo;
 using orbit_grpc_protos::ModuleInfo;
 using orbit_grpc_protos::ProcessInfo;
+using orbit_grpc_protos::UnwindingMethod;
 
 bool ClientGgp::InitClient() {
   if (options_.grpc_server_address.empty()) {
@@ -98,13 +100,16 @@ bool ClientGgp::RequestStartCapture(ThreadPool* thread_pool) {
   uint64_t max_local_marker_depth_per_command_buffer =
       absl::GetFlag(FLAGS_max_local_marker_depth_per_command_buffer);
   bool enable_introspection = false;
+  UnwindingMethod unwinding_method = options_.use_framepointer_unwinding
+                                         ? UnwindingMethod::kFramePointerUnwinding
+                                         : UnwindingMethod::kDwarfUnwinding;
   Future<ErrorMessageOr<CaptureOutcome>> result = capture_client_->Capture(
       thread_pool, target_process_, module_manager_, selected_functions_, selected_tracepoints,
-      absl::flat_hash_set<uint64_t>{}, collect_thread_state, enable_introspection,
-      max_local_marker_depth_per_command_buffer);
+      absl::flat_hash_set<uint64_t>{}, options_.samples_per_second, unwinding_method,
+      collect_thread_state, enable_introspection, max_local_marker_depth_per_command_buffer);
 
-  orbit_base::ImmediateExecutor executer;
-  result.Then(&executer, [this](ErrorMessageOr<CaptureOutcome> result) {
+  orbit_base::ImmediateExecutor executor;
+  result.Then(&executor, [this](ErrorMessageOr<CaptureOutcome> result) {
     if (!result.has_value()) {
       ClearCapture();
       ERROR("Capture failed: %s", result.error().message());

--- a/src/OrbitClientGgp/include/OrbitClientGgp/ClientGgpOptions.h
+++ b/src/OrbitClientGgp/include/OrbitClientGgp/ClientGgpOptions.h
@@ -17,6 +17,8 @@ struct ClientGgpOptions {
   std::vector<std::string> capture_functions;
   std::string capture_file_name;
   std::string capture_file_directory;
+  double samples_per_second;
+  bool use_framepointer_unwinding;
 };
 
 #endif  // ORBIT_CLIENT_GGP_CLIENT_GGP_OPTIONS_H_

--- a/src/OrbitClientGgp/main.cpp
+++ b/src/OrbitClientGgp/main.cpp
@@ -72,6 +72,8 @@ int main(int argc, char** argv) {
   options.capture_functions = absl::GetFlag(FLAGS_functions);
   options.capture_file_name = absl::GetFlag(FLAGS_file_name);
   options.capture_file_directory = absl::GetFlag(FLAGS_file_directory);
+  options.samples_per_second = absl::GetFlag(FLAGS_sampling_rate);
+  options.use_framepointer_unwinding = absl::GetFlag(FLAGS_frame_pointer_unwinding);
 
   ClientGgp client_ggp(std::move(options));
   if (!client_ggp.InitClient()) {

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -355,6 +355,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   }
 
   void SetCollectThreadStates(bool collect_thread_states);
+  void SetSamplesPerSecond(double samples_per_second);
+  void SetUnwindingMethod(orbit_grpc_protos::UnwindingMethod unwinding_method);
   void SetMaxLocalMarkerDepthPerCommandBuffer(uint64_t max_local_marker_depth_per_command_buffer);
 
   // TODO(kuebler): Move them to a separate controler at some point

--- a/src/OrbitGl/DataManager.h
+++ b/src/OrbitGl/DataManager.h
@@ -72,6 +72,16 @@ class DataManager final {
   }
   [[nodiscard]] bool collect_thread_states() const { return collect_thread_states_; }
 
+  void set_samples_per_second(double samples_per_second) {
+    samples_per_second_ = samples_per_second;
+  }
+  [[nodiscard]] double samples_per_second() const { return samples_per_second_; }
+
+  void set_unwinding_method(orbit_grpc_protos::UnwindingMethod method) {
+    unwinding_method_ = method;
+  }
+  orbit_grpc_protos::UnwindingMethod unwinding_method() const { return unwinding_method_; }
+
   void set_max_local_marker_depth_per_command_buffer(
       uint64_t max_local_marker_depth_per_command_buffer) {
     max_local_marker_depth_per_command_buffer_ = max_local_marker_depth_per_command_buffer;
@@ -98,6 +108,8 @@ class DataManager final {
 
   bool collect_thread_states_ = false;
   uint64_t max_local_marker_depth_per_command_buffer_ = std::numeric_limits<uint64_t>::max();
+  double samples_per_second_ = 0;
+  orbit_grpc_protos::UnwindingMethod unwinding_method_{};
 };
 
 #endif  // ORBIT_GL_DATA_MANAGER_H_

--- a/src/OrbitProducer/CaptureEventProducerTest.cpp
+++ b/src/OrbitProducer/CaptureEventProducerTest.cpp
@@ -89,7 +89,7 @@ constexpr std::chrono::duration kWaitMessagesSentDuration = std::chrono::millise
 const orbit_grpc_protos::CaptureOptions kFakeCaptureOptions = [] {
   orbit_grpc_protos::CaptureOptions capture_options;
   capture_options.set_pid(42);
-  capture_options.set_sampling_rate(1234.0);
+  capture_options.set_samples_per_second(1234.0);
   return capture_options;
 }();
 

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -111,6 +111,8 @@
 ABSL_DECLARE_FLAG(bool, devmode);
 ABSL_DECLARE_FLAG(bool, enable_tracepoint_feature);
 ABSL_DECLARE_FLAG(bool, enable_tutorials_feature);
+ABSL_DECLARE_FLAG(uint16_t, sampling_rate);
+ABSL_DECLARE_FLAG(bool, frame_pointer_unwinding);
 
 using orbit_grpc_protos::CrashOrbitServiceRequest_CrashType;
 using orbit_grpc_protos::CrashOrbitServiceRequest_CrashType_CHECK_FALSE;
@@ -181,6 +183,11 @@ OrbitMainWindow::OrbitMainWindow(orbit_qt::TargetConfiguration target_configurat
   std::visit([this](const auto& target) { SetTarget(target); }, target_configuration_);
 
   app_->PostInit(is_connected_);
+
+  app_->SetSamplesPerSecond(absl::GetFlag(FLAGS_sampling_rate));
+  app_->SetUnwindingMethod(absl::GetFlag(FLAGS_frame_pointer_unwinding)
+                               ? orbit_grpc_protos::UnwindingMethod::kFramePointerUnwinding
+                               : orbit_grpc_protos::UnwindingMethod::kDwarfUnwinding);
 
   SaveCurrentTabLayoutAsDefaultInMemory();
 

--- a/src/OrbitVulkanLayer/VulkanLayerProducerImplTest.cpp
+++ b/src/OrbitVulkanLayer/VulkanLayerProducerImplTest.cpp
@@ -85,7 +85,7 @@ constexpr std::chrono::duration kWaitMessagesSentDuration = std::chrono::millise
 const orbit_grpc_protos::CaptureOptions kFakeCaptureOptions = [] {
   orbit_grpc_protos::CaptureOptions capture_options;
   capture_options.set_pid(42);
-  capture_options.set_sampling_rate(1234.0);
+  capture_options.set_samples_per_second(1234.0);
   return capture_options;
 }();
 

--- a/src/Service/ProducerSideServiceImplTest.cpp
+++ b/src/Service/ProducerSideServiceImplTest.cpp
@@ -167,7 +167,7 @@ void ExpectDurationBetweenMs(const std::function<void(void)>& action, uint64_t m
 const orbit_grpc_protos::CaptureOptions kFakeCaptureOptions = [] {
   orbit_grpc_protos::CaptureOptions capture_options;
   capture_options.set_pid(42);
-  capture_options.set_sampling_rate(1234.0);
+  capture_options.set_samples_per_second(1234.0);
   return capture_options;
 }();
 


### PR DESCRIPTION
samples_per_second and unwinding_method are now passed to Capture
method by callers.

Test: Start Orbit, take capture, perform sanity check.