### PR TITLE
[FOR RELEASE] Fix timer label always showing 1s for loaded captures and empty captures.

### DIFF
--- a/src/OrbitQt/FilterPanelWidget.ui
+++ b/src/OrbitQt/FilterPanelWidget.ui
@@ -79,7 +79,7 @@
    <item>
     <widget class="QLabel" name="timerLabel">
      <property name="text">
-      <string>1s</string>
+      <string>0s</string>
      </property>
     </widget>
    </item>

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -522,6 +522,8 @@ void OrbitMainWindow::UpdateCaptureStateDependentWidgets() {
 
   hint_frame_->setVisible(!has_data);
 
+  filter_panel_action_->SetTimerLabelText(QString::fromStdString(app_->GetCaptureTime()));
+
   UpdateCaptureToolbarIconOpacity();
 }
 


### PR DESCRIPTION
Within #2031, we changed the main tick to only update the timer label
when capturing. For loaded captures, this update was never done.

Furthermore, the default value is 1s. For empty captures (not started
yet), this is actually wrong. So this changes the default also to
0s.

Test: Load a capture. Connect to a process. Check capture time label.
Bug: http://b/183203015