### PR TITLE
[release/1.61] Fix crash when calling ClearEdits() on invalid widget pointer

### DIFF
--- a/src/OrbitQt/FilterPanelWidgetAction.cpp
+++ b/src/OrbitQt/FilterPanelWidgetAction.cpp
@@ -12,20 +12,20 @@ FilterPanelWidgetAction::FilterPanelWidgetAction(QWidget* parent) : QWidgetActio
 
 QWidget* FilterPanelWidgetAction::createWidget(QWidget* parent) {
   filter_panel_ = new FilterPanelWidget(parent);
+
+  // Directly calling methods on FilterPanelWidget (e.g. to set timer text or clear the text),
+  // can cause access violations when the toolbar layout changes and the filter panel appears on the
+  // capture toolbar again. We therefore use the signal/slot system instead of calling methods
+  // directly on QWidgetAction.
   connect(filter_panel_, &FilterPanelWidget::FilterTracksTextChanged, this,
           &FilterPanelWidgetAction::FilterTracksTextChanged);
   connect(filter_panel_, &FilterPanelWidget::FilterFunctionsTextChanged, this,
           &FilterPanelWidgetAction::FilterFunctionsTextChanged);
-
-  // Directly call `FilterPanelWidget::SetTimerLabelText` from `OrbitMainWindow::OnTimer()` causes
-  // the access violation when the toolbar layout changes and the filter panel appears on the
-  // capture toolbar again. For the thread-safety consideration, using signal/slot system instead of
-  // calling functions for the QWidgetAction.
   connect(this, &FilterPanelWidgetAction::SetTimerLabelText, filter_panel_,
           &FilterPanelWidget::SetTimerLabelText);
   connect(this, &FilterPanelWidgetAction::SetFilterFunctionsText, filter_panel_,
           &FilterPanelWidget::SetFilterFunctionsText);
+  connect(this, &FilterPanelWidgetAction::ClearEdits, filter_panel_,
+          &FilterPanelWidget::ClearEdits);
   return filter_panel_;
 }
-
-void FilterPanelWidgetAction::ClearEdits() { filter_panel_->ClearEdits(); }

--- a/src/OrbitQt/FilterPanelWidgetAction.h
+++ b/src/OrbitQt/FilterPanelWidgetAction.h
@@ -26,13 +26,12 @@ class FilterPanelWidgetAction : public QWidgetAction {
   explicit FilterPanelWidgetAction(QWidget* parent);
   QWidget* createWidget(QWidget* parent);
 
-  void ClearEdits();
-
  signals:
   void FilterFunctionsTextChanged(const QString& text);
   void FilterTracksTextChanged(const QString& text);
   void SetTimerLabelText(const QString& text);
   void SetFilterFunctionsText(const QString& text);
+  void ClearEdits();
 
  private:
   FilterPanelWidget* filter_panel_ = nullptr;


### PR DESCRIPTION
As Qt is handling the lifecycle of widgets such as the track filter
panel, we cannot directly call methods on widgets such as
FilterPanelWidget. We use Qt's signal/slot mechanism to avoid a direct
call for ClearEdits(), which fixes a crash.

Tested: Manually ran Orbit multiple times and took captures. Also tested
if the filter text panels are actually cleared on starting a capture.
Bug: http://b/183199646