### PR TITLE
Allocate memory suitable for trampolines.

### DIFF
--- a/src/UserSpaceInstrumentation/AccessTraceesMemory.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemory.cpp
@@ -55,7 +55,8 @@ using orbit_base::ReadFileToString;
   return outcome::success();
 }
 
-[[nodiscard]] ErrorMessageOr<AddressRange> GetFirstExecutableMemoryRegion(pid_t pid) {
+[[nodiscard]] ErrorMessageOr<AddressRange> GetFirstExecutableMemoryRegion(
+    pid_t pid, uint64_t exclude_address) {
   auto result_read_maps = ReadFileToString(absl::StrFormat("/proc/%d/maps", pid));
   if (result_read_maps.has_error()) {
     return result_read_maps.error();
@@ -70,6 +71,7 @@ using orbit_base::ReadFileToString;
     AddressRange result;
     if (!absl::numbers_internal::safe_strtou64_base(addresses[0], &result.first, 16)) continue;
     if (!absl::numbers_internal::safe_strtou64_base(addresses[1], &result.second, 16)) continue;
+    if (exclude_address >= result.first && exclude_address < result.second) continue;
     return result;
   }
   return ErrorMessage(absl::StrFormat("Unable to locate executable memory area in pid: %d", pid));

--- a/src/UserSpaceInstrumentation/AccessTraceesMemory.h
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemory.h
@@ -32,8 +32,11 @@ namespace orbit_user_space_instrumentation {
 // was the second line in the `maps` file corresponding to the code of the process we look at.
 // However we don't really care. So keeping it general and just searching for an executable region
 // is probably helping stability.
+// Optionally one can specify `exclude_address`. This prevents the method from returning an address
+// range containing `exclude_address`.
 using AddressRange = std::pair<uint64_t, uint64_t>;
-[[nodiscard]] ErrorMessageOr<AddressRange> GetFirstExecutableMemoryRegion(pid_t pid);
+[[nodiscard]] ErrorMessageOr<AddressRange> GetFirstExecutableMemoryRegion(
+    pid_t pid, uint64_t exclude_address = 0);
 
 }  // namespace orbit_user_space_instrumentation
 

--- a/src/UserSpaceInstrumentation/AllocateInTracee.cpp
+++ b/src/UserSpaceInstrumentation/AllocateInTracee.cpp
@@ -133,15 +133,16 @@ namespace {
 [[nodiscard]] ErrorMessageOr<uint64_t> AllocateInTracee(pid_t pid, uint64_t address,
                                                         uint64_t size) {
   // Syscall will be equivalent to:
-  // `mmap(address, size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0)`
-  // unless address it 0 in which case it will be (without the `MAP_FIXED`): 
+  // `mmap(address, size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS |
+  // MAP_FIXED, -1, 0)`
+  // Unless address it 0 in which case it will be (without the `MAP_FIXED`):
   // `mmap(0, size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0)`
   const int flags =
       (address == 0) ? (MAP_PRIVATE | MAP_ANONYMOUS) : (MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED);
   constexpr uint64_t kSyscallNumberMmap = 9;
   auto result_or_error =
       SyscallInTracee(pid, kSyscallNumberMmap, address, size, PROT_READ | PROT_WRITE | PROT_EXEC,
-                      flags, static_cast<uint64_t>(-1), 0, /*exclude_address=*/ 0);
+                      flags, static_cast<uint64_t>(-1), 0, /*exclude_address=*/0);
   if (result_or_error.has_error()) {
     return ErrorMessage(absl::StrFormat("Failed to execute mmap syscall: \"%s\"",
                                         result_or_error.error().message()));

--- a/src/UserSpaceInstrumentation/AllocateInTracee.cpp
+++ b/src/UserSpaceInstrumentation/AllocateInTracee.cpp
@@ -144,8 +144,9 @@ namespace {
   }
   const uint64_t result = result_or_error.value();
   if (address != 0 && result != address) {
-    FAIL_IF(FreeInTracee(pid, result, size).has_error(),
-            "Unable to free proviously allocated memory.");
+    auto error_or_void = FreeInTracee(pid, result, size);
+    FAIL_IF(error_or_void.has_error(), "Unable to free proviously allocated memory: \"%s\"",
+            error_or_void.error().message());
     return ErrorMessage(
         absl::StrFormat("AllocateInTracee wanted to allocate memory at %#x but got memory at a "
                         "different adress: %#x. The memory has been freed again.",

--- a/src/UserSpaceInstrumentation/AllocateInTracee.cpp
+++ b/src/UserSpaceInstrumentation/AllocateInTracee.cpp
@@ -135,9 +135,9 @@ namespace {
   // Syscall will be equivalent to:
   // `mmap(address, size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0)`
   constexpr uint64_t kSyscallNumberMmap = 9;
-  auto result_or_error =
-      SyscallInTracee(pid, kSyscallNumberMmap, address, size, PROT_READ | PROT_WRITE | PROT_EXEC,
-                      MAP_PRIVATE | MAP_ANONYMOUS, static_cast<uint64_t>(-1), 0, /*exclude_address=*/0);
+  auto result_or_error = SyscallInTracee(
+      pid, kSyscallNumberMmap, address, size, PROT_READ | PROT_WRITE | PROT_EXEC,
+      MAP_PRIVATE | MAP_ANONYMOUS, static_cast<uint64_t>(-1), 0, /*exclude_address=*/0);
   if (result_or_error.has_error()) {
     return ErrorMessage(absl::StrFormat("Failed to execute mmap syscall: \"%s\"",
                                         result_or_error.error().message()));

--- a/src/UserSpaceInstrumentation/AllocateInTracee.cpp
+++ b/src/UserSpaceInstrumentation/AllocateInTracee.cpp
@@ -133,21 +133,25 @@ namespace {
 [[nodiscard]] ErrorMessageOr<uint64_t> AllocateInTracee(pid_t pid, uint64_t address,
                                                         uint64_t size) {
   // Syscall will be equivalent to:
-  // `mmap(address, size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS |
-  // MAP_FIXED, -1, 0)`
-  // Unless address it 0 in which case it will be (without the `MAP_FIXED`):
-  // `mmap(0, size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0)`
-  const int flags =
-      (address == 0) ? (MAP_PRIVATE | MAP_ANONYMOUS) : (MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED);
+  // `mmap(address, size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0)`
   constexpr uint64_t kSyscallNumberMmap = 9;
   auto result_or_error =
       SyscallInTracee(pid, kSyscallNumberMmap, address, size, PROT_READ | PROT_WRITE | PROT_EXEC,
-                      flags, static_cast<uint64_t>(-1), 0, /*exclude_address=*/0);
+                      MAP_PRIVATE | MAP_ANONYMOUS, static_cast<uint64_t>(-1), 0, /*exclude_address=*/0);
   if (result_or_error.has_error()) {
     return ErrorMessage(absl::StrFormat("Failed to execute mmap syscall: \"%s\"",
                                         result_or_error.error().message()));
   }
-  return result_or_error.value();
+  const uint64_t result = result_or_error.value();
+  if (address != 0 && result != address) {
+    FAIL_IF(FreeInTracee(pid, result, size).has_error(),
+            "Unable to free proviously allocated memory.");
+    return ErrorMessage(
+        absl::StrFormat("AllocateInTracee wanted to allocate memory at %#x but got memory at a "
+                        "different adress: %#x. The memory has been freed again.",
+                        address, result));
+  }
+  return result;
 }
 
 [[nodiscard]] ErrorMessageOr<void> FreeInTracee(pid_t pid, uint64_t address, uint64_t size) {

--- a/src/UserSpaceInstrumentation/AllocateInTracee.h
+++ b/src/UserSpaceInstrumentation/AllocateInTracee.h
@@ -14,9 +14,13 @@
 namespace orbit_user_space_instrumentation {
 
 // Allocate `size` bytes of memory in the tracee's address space using mmap. The memory will have
-// read, write, and execute permissions.
-// Assumes we are already attached to the tracee `pid` e.g. using `AttachAndStopProcess`.
-[[nodiscard]] ErrorMessageOr<uint64_t> AllocateInTracee(pid_t pid, uint64_t size);
+// read, write, and execute permissions. The memory allocated will start at `address`. `address`
+// needs to be aligned to page boundaries. Make sure the requested memory range is available;
+// otherwise the overlapped part of existing mappings will be discarded.
+// If `address` is zero the placement of memory will be arbitray (compare the documenation of mmap:
+// https://man7.org/linux/man-pages/man2/mmap.2.html). Assumes we are already attached to the tracee
+// `pid` e.g. using `AttachAndStopProcess`.
+[[nodiscard]] ErrorMessageOr<uint64_t> AllocateInTracee(pid_t pid, uint64_t address, uint64_t size);
 
 // Free address range previously allocated with AllocateInTracee using munmap.
 // Assumes we are already attached to the tracee `pid` e.g. using `AttachAndStopProcess`.

--- a/src/UserSpaceInstrumentation/AllocateInTracee.h
+++ b/src/UserSpaceInstrumentation/AllocateInTracee.h
@@ -15,8 +15,8 @@ namespace orbit_user_space_instrumentation {
 
 // Allocate `size` bytes of memory in the tracee's address space using mmap. The memory will have
 // read, write, and execute permissions. The memory allocated will start at `address`. `address`
-// needs to be aligned to page boundaries. Make sure the requested memory range is available;
-// otherwise the overlapped part of existing mappings will be discarded.
+// needs to be aligned to page boundaries. If the memory mapping can not be placed at `address` an
+// error is returned.
 // If `address` is zero the placement of memory will be arbitray (compare the documenation of mmap:
 // https://man7.org/linux/man-pages/man2/mmap.2.html). Assumes we are already attached to the tracee
 // `pid` e.g. using `AttachAndStopProcess`.

--- a/src/UserSpaceInstrumentation/CMakeLists.txt
+++ b/src/UserSpaceInstrumentation/CMakeLists.txt
@@ -30,7 +30,9 @@ target_sources(UserSpaceInstrumentation PRIVATE
         MachineCode.cpp
         MachineCode.h
         RegisterState.cpp
-        RegisterState.h)
+        RegisterState.h
+        Trampoline.cpp
+        Trampoline.h)
 
 target_link_libraries(UserSpaceInstrumentation PUBLIC
         LinuxTracing
@@ -68,7 +70,8 @@ target_sources(UserSpaceInstrumentationTests PRIVATE
         MachineCodeTest.cpp
         RegisterStateTest.cpp
         TestProcess.cpp
-        TestProcess.h)
+        TestProcess.h
+        TrampolineTest.cpp)
 
 target_link_libraries(UserSpaceInstrumentationTests PRIVATE
         LinuxTracing

--- a/src/UserSpaceInstrumentation/InjectLibraryInTracee.cpp
+++ b/src/UserSpaceInstrumentation/InjectLibraryInTracee.cpp
@@ -138,7 +138,7 @@ ErrorMessageOr<uint64_t> FindFunctionAddressWithFallback(pid_t pid, std::string_
   // Allocate small memory area in the tracee. This is used for the code and the path name.
   const uint64_t path_length = path.string().length() + 1;  // Include terminating zero.
   const uint64_t memory_size = kCodeScratchPadSize + path_length;
-  OUTCOME_TRY(address_code, AllocateInTracee(pid, memory_size));
+  OUTCOME_TRY(address_code, AllocateInTracee(pid, 0, memory_size));
 
   // Write the name of the .so into memory at address_code with offset of kCodeScratchPadSize.
   std::vector<uint8_t> path_as_vector(path_length);
@@ -189,7 +189,7 @@ ErrorMessageOr<uint64_t> FindFunctionAddressWithFallback(pid_t pid, std::string_
   // Allocate small memory area in the tracee. This is used for the code and the symbol name.
   const size_t symbol_name_length = symbol.length() + 1;  // include terminating zero
   const uint64_t memory_size = kCodeScratchPadSize + symbol_name_length;
-  OUTCOME_TRY(address_code, AllocateInTracee(pid, memory_size));
+  OUTCOME_TRY(address_code, AllocateInTracee(pid, 0, memory_size));
 
   // Write the name of symbol into memory at address_code with offset of kCodeScratchPadSize.
   std::vector<uint8_t> symbol_name_as_vector(symbol_name_length, 0);
@@ -238,7 +238,7 @@ ErrorMessageOr<uint64_t> FindFunctionAddressWithFallback(pid_t pid, std::string_
                                                                kDlcloseInLibc, kLibcSoname));
 
   // Allocate small memory area in the tracee.
-  OUTCOME_TRY(address_code, AllocateInTracee(pid, kCodeScratchPadSize));
+  OUTCOME_TRY(address_code, AllocateInTracee(pid, 0, kCodeScratchPadSize));
 
   // We want to do the following in the tracee:
   // dlclose(handle);

--- a/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
+++ b/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
@@ -101,7 +101,7 @@ TEST(InjectLibraryInTraceeTest, OpenUseCloseLibrary) {
   RegisterState original_registers;
   ASSERT_FALSE(original_registers.BackupRegisters(pid).has_error());
   constexpr uint64_t kScratchPadSize = 1024;
-  auto result_address_code = AllocateInTracee(pid, kScratchPadSize);
+  auto result_address_code = AllocateInTracee(pid, 0, kScratchPadSize);
   ASSERT_TRUE(result_address_code.has_value());
   const uint64_t address_code = result_address_code.value();
   // Move function's address to rax, do the call, and hit a breakpoint:

--- a/src/UserSpaceInstrumentation/Trampoline.cpp
+++ b/src/UserSpaceInstrumentation/Trampoline.cpp
@@ -1,0 +1,155 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "Trampoline.h"
+
+#include <absl/strings/numbers.h>
+#include <absl/strings/str_format.h>
+#include <absl/strings/str_split.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <string>
+
+#include "AllocateInTracee.h"
+#include "OrbitBase/ExecuteCommand.h"
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/ReadFileToString.h"
+
+namespace orbit_user_space_instrumentation {
+
+using absl::numbers_internal::safe_strtou64_base;
+using orbit_base::ReadFileToString;
+
+bool DoAddressRangesOverlap(const AddressRange& a, const AddressRange& b) {
+  return !(b.end <= a.start || b.start >= a.end);
+}
+
+std::optional<size_t> LowestIntersectingAddressRange(const std::vector<AddressRange>& all_ranges,
+                                                     const AddressRange& range) {
+  for (size_t i = 0; i < all_ranges.size(); i++) {
+    if (DoAddressRangesOverlap(all_ranges[i], range)) {
+      return i;
+    }
+  }
+  return std::nullopt;
+}
+
+std::optional<size_t> HighestIntersectingAddressRange(const std::vector<AddressRange>& all_ranges,
+                                                      const AddressRange& range) {
+  for (int i = all_ranges.size() - 1; i >= 0; i--) {
+    if (DoAddressRangesOverlap(all_ranges[i], range)) {
+      return i;
+    }
+  }
+  return std::nullopt;
+}
+
+ErrorMessageOr<std::vector<AddressRange>> GetTakenAddressRanges(pid_t pid) {
+  std::vector<AddressRange> result;
+  OUTCOME_TRY(mmap_min_addr, ReadFileToString("/proc/sys/vm/mmap_min_addr"));
+  uint64_t mmap_min_addr_as_uint64 = 0;
+  if (!absl::SimpleAtoi(mmap_min_addr, &mmap_min_addr_as_uint64)) {
+    return ErrorMessage("Failed to read/proc/sys/vm/mmap_min_addr");
+  }
+  result.emplace_back(0, mmap_min_addr_as_uint64);
+
+  OUTCOME_TRY(maps, ReadFileToString(absl::StrFormat("/proc/%d/maps", pid)));
+  std::vector<std::string> lines = absl::StrSplit(maps, '\n', absl::SkipEmpty());
+  for (const auto& line : lines) {
+    std::vector<std::string> tokens = absl::StrSplit(line, ' ', absl::SkipEmpty());
+    if (tokens.size() < 1) {
+      continue;
+    }
+    std::vector<std::string> addresses = absl::StrSplit(tokens[0], '-');
+    if (addresses.size() != 2) {
+      continue;
+    }
+    uint64_t address_begin = 0;
+    uint64_t address_end = 0;
+    if (!safe_strtou64_base(addresses[0], &address_begin, 16) ||
+        !safe_strtou64_base(addresses[1], &address_end, 16)) {
+      continue;
+    }
+    CHECK(address_begin < address_end);
+    // Join with previous segment ...
+    if (result.back().end == address_begin) {
+      result.back().end = address_end;
+      continue;
+    }
+    // ... or append as new segment.
+    result.emplace_back(address_begin, address_end);
+  }
+  return result;
+}
+
+ErrorMessageOr<AddressRange> FindAddressRangeForTrampoline(
+    const std::vector<AddressRange>& taken_ranges, const AddressRange& code_range, uint64_t size) {
+  constexpr uint64_t kMax32BitOffset = 0x7fffffff;
+  const uint64_t page_size = sysconf(_SC_PAGE_SIZE);
+
+  // Try to fit an interval of length `size` below `code_range`.
+  auto optional_range_index = LowestIntersectingAddressRange(taken_ranges, code_range);
+  if (!optional_range_index) {
+    return ErrorMessage(absl::StrFormat("code_range %#x-%#x is not in taken_ranges.",
+                                        code_range.start, code_range.end));
+  }
+  while (optional_range_index.value() > 0) {
+    // Place directly to the left of the take interval we are in...
+    uint64_t address_trampoline = taken_ranges[optional_range_index.value()].start - size;
+    // ... but round down to the previous page boundary.
+    address_trampoline = (address_trampoline / page_size) * page_size;
+    AddressRange range_trampoline = {address_trampoline, address_trampoline + size};
+    optional_range_index = LowestIntersectingAddressRange(taken_ranges, range_trampoline);
+    if (!optional_range_index) {
+      // We do not intersect any taken interval. Check if we are close enough to code_range:
+      // code_range is above range_trampoline we will need to jmp back and forth in these ranges
+      // with 32 bit offsets. If no distance is greater than 0x7fffffff this is safe.
+      if (code_range.end - range_trampoline.start <= kMax32BitOffset) {
+        return range_trampoline;
+      }
+      // If we are already beyond the close range there is no need to go any further.
+      break;
+    }
+  }
+
+  // Try to fit an interval of length `size` above `code_range`.
+  optional_range_index = HighestIntersectingAddressRange(taken_ranges, code_range);
+  if (!optional_range_index) {
+    return ErrorMessage(absl::StrFormat("code_range %#x-%#x is not in taken_ranges.",
+                                        code_range.start, code_range.end));
+  }
+  do {
+    const uint64_t address_trampoline =
+        ((taken_ranges[optional_range_index.value()].end + (page_size - 1)) / page_size) *
+        page_size;
+    // Check if we ran out of address space.
+    if (address_trampoline >= 0xffffffffffffffff - size) {
+      break;
+    }
+    AddressRange range_trampoline = {address_trampoline, address_trampoline + size};
+    optional_range_index = HighestIntersectingAddressRange(taken_ranges, range_trampoline);
+    if (!optional_range_index) {
+      // We do not intersect any taken interval. Check if we are close enough to code_range:
+      // code_range is below range_trampoline we will need to jump back and forth in these ranges
+      // with 32 bit offsets. If no distance is greater than 0x7fffffff this is safe.
+      if (range_trampoline.end - code_range.start <= kMax32BitOffset) {
+        return range_trampoline;
+      }
+      // If we are already beyond the close range there is no need to go any further.
+      break;
+    }
+  } while (optional_range_index.value() < taken_ranges.size());
+  return ErrorMessage(absl::StrFormat("No place to fit %u bytes close to code range %#x-%#x.", size,
+                                      code_range.start, code_range.end));
+}
+
+ErrorMessageOr<uint64_t> AllocateMemoryForTrampolines(pid_t pid, const AddressRange& code_range,
+                                                      uint64_t size) {
+  OUTCOME_TRY(taken_ranges, GetTakenAddressRanges(pid));
+  OUTCOME_TRY(address_range, FindAddressRangeForTrampoline(taken_ranges, code_range, size));
+  return AllocateInTracee(pid, address_range.start, size);
+}
+
+}  // namespace orbit_user_space_instrumentation

--- a/src/UserSpaceInstrumentation/Trampoline.cpp
+++ b/src/UserSpaceInstrumentation/Trampoline.cpp
@@ -26,20 +26,20 @@ bool DoAddressRangesOverlap(const AddressRange& a, const AddressRange& b) {
   return !(b.end <= a.start || b.start >= a.end);
 }
 
-std::optional<size_t> LowestIntersectingAddressRange(const std::vector<AddressRange>& all_ranges,
+std::optional<size_t> LowestIntersectingAddressRange(const std::vector<AddressRange>& ranges_sorted,
                                                      const AddressRange& range) {
-  for (size_t i = 0; i < all_ranges.size(); i++) {
-    if (DoAddressRangesOverlap(all_ranges[i], range)) {
+  for (size_t i = 0; i < ranges_sorted.size(); i++) {
+    if (DoAddressRangesOverlap(ranges_sorted[i], range)) {
       return i;
     }
   }
   return std::nullopt;
 }
 
-std::optional<size_t> HighestIntersectingAddressRange(const std::vector<AddressRange>& all_ranges,
-                                                      const AddressRange& range) {
-  for (int i = all_ranges.size() - 1; i >= 0; i--) {
-    if (DoAddressRangesOverlap(all_ranges[i], range)) {
+std::optional<size_t> HighestIntersectingAddressRange(
+    const std::vector<AddressRange>& ranges_sorted, const AddressRange& range) {
+  for (int i = ranges_sorted.size() - 1; i >= 0; i--) {
+    if (DoAddressRangesOverlap(ranges_sorted[i], range)) {
       return i;
     }
   }

--- a/src/UserSpaceInstrumentation/Trampoline.cpp
+++ b/src/UserSpaceInstrumentation/Trampoline.cpp
@@ -87,8 +87,8 @@ ErrorMessageOr<std::vector<AddressRange>> GetUnavailableAddressRanges(pid_t pid)
 ErrorMessageOr<AddressRange> FindAddressRangeForTrampoline(
     const std::vector<AddressRange>& unavailable_ranges, const AddressRange& code_range,
     uint64_t size) {
-  constexpr uint64_t kMax32BitOffset = 0x7fffffff;
-  constexpr uint64_t kMax64BitAdress = 0xffffffffffffffff;
+  constexpr uint64_t kMax32BitOffset = INT32_MAX;
+  constexpr uint64_t kMax64BitAdress = UINT64_MAX;
   const uint64_t page_size = sysconf(_SC_PAGE_SIZE);
 
   FAIL_IF(unavailable_ranges.size() == 0 || unavailable_ranges[0].start != 0,

--- a/src/UserSpaceInstrumentation/Trampoline.h
+++ b/src/UserSpaceInstrumentation/Trampoline.h
@@ -29,27 +29,31 @@ struct AddressRange {
 
 // Returns the index of the lowest range in `ranges_sorted` that is intersecting with `range`.
 // `ranges_sorted` needs to contain non-overlapping ranges in ascending order (as provided by
-// `GetTakenAddressRanges`).
+// `GetUnavailableAddressRanges`).
 [[nodiscard]] std::optional<size_t> LowestIntersectingAddressRange(
     const std::vector<AddressRange>& ranges_sorted, const AddressRange& range);
 
 // Returns the index of the highest range in `ranges_sorted` that is intersecting with `range`.
 // `ranges_sorted` needs to contain non-overlapping ranges in ascending order (as provided by
-// `GetTakenAddressRanges`).
+// `GetUnavailableAddressRanges`).
 [[nodiscard]] std::optional<size_t> HighestIntersectingAddressRange(
     const std::vector<AddressRange>& ranges_sorted, const AddressRange& range);
 
 // Parses the /proc/pid/maps file of a process and returns all the taken address ranges (joining
 // directly neighboring ones). We also add a range [0, /proc/sys/vm/mmap_min_addr] to block the
 // lowest addresses in the process space which mmap cannot use.
-[[nodiscard]] ErrorMessageOr<std::vector<AddressRange>> GetTakenAddressRanges(pid_t pid);
+[[nodiscard]] ErrorMessageOr<std::vector<AddressRange>> GetUnavailableAddressRanges(pid_t pid);
 
-// Finds an empty address range not overlapping with anything in `taken_ranges` of a given `size`
-// suitable to allocate the trampolines close to `code_range`. "Close to" in this context means that
-// the trampolines can't be more than a 32 bit offset away from the `code_range` (+-2GB) such that
-// we can jump back and forth from the trampolines to the code using relative 32 bit addresses.
+// Finds an empty address range not overlapping with anything in `unavailable_ranges` of a given
+// `size` suitable to allocate the trampolines close to `code_range`. "Close to" in this context
+// means that the trampolines can't be more than a 32 bit offset away from the `code_range` (+-2GB)
+// such that we can jump back and forth from the trampolines to the code using relative 32 bit
+// addresses.
+// `unavailable_ranges` needs to contain non-overlapping ranges in ascending order; the smallest
+// range needs to start at zero (as provided by `GetUnavailableAddressRanges`).
 [[nodiscard]] ErrorMessageOr<AddressRange> FindAddressRangeForTrampoline(
-    const std::vector<AddressRange>& taken_ranges, const AddressRange& code_range, uint64_t size);
+    const std::vector<AddressRange>& unavailable_ranges, const AddressRange& code_range,
+    uint64_t size);
 
 // Allocates `size` bytes in the tracee close to `code_range`. The memory segment will be placed
 // such that we can jump from any position in the memory segment to any position in `code_range`

--- a/src/UserSpaceInstrumentation/Trampoline.h
+++ b/src/UserSpaceInstrumentation/Trampoline.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef USER_SPACE_INSTRUMENTATION_TRAMPOLINE_H_
+#define USER_SPACE_INSTRUMENTATION_TRAMPOLINE_H_
+
+#include <sys/types.h>
+
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "OrbitBase/Result.h"
+
+namespace orbit_user_space_instrumentation {
+
+struct AddressRange {
+  AddressRange() = default;
+  AddressRange(uint64_t s, uint64_t e) : start(s), end(e) {}
+  uint64_t start;
+  uint64_t end;
+};
+
+// Returns true if the ranges overlap (touching ranges do not count as overlapping). Assumes that
+// the ranges are well formed (.first < .second).
+[[nodiscard]] bool DoAddressRangesOverlap(const AddressRange& a, const AddressRange& b);
+
+// Returns the index of the lowest range in `all_ranges` that is intersecting with `range`.
+[[nodiscard]] std::optional<size_t> LowestIntersectingAddressRange(
+    const std::vector<AddressRange>& all_ranges, const AddressRange& range);
+
+// Returns the index of the highest range in `all_ranges` that is intersecting with `range`.
+[[nodiscard]] std::optional<size_t> HighestIntersectingAddressRange(
+    const std::vector<AddressRange>& all_ranges, const AddressRange& range);
+
+// Parses the /proc/pid/maps file of a process and returns all the taken address ranges (joining
+// directly neighboring ones). We also add a range [0, /proc/sys/vm/mmap_min_addr] to block the
+// lowest addresses in the process space which mmap cannot use.
+[[nodiscard]] ErrorMessageOr<std::vector<AddressRange>> GetTakenAddressRanges(pid_t pid);
+
+// Finds an empty address range not overlapping with anything in `taken_ranges` of a given `size`
+// suitable to allocate the trampolines close to `code_range`. "Close to" in this context means that
+// the trampolines can't be more than a 32 bit offset away from the `code_range` (+-2GB) such that
+// we can jump back and forth from the trampolines to the code using relative 32 bit addresses.
+[[nodiscard]] ErrorMessageOr<AddressRange> FindAddressRangeForTrampoline(
+    const std::vector<AddressRange>& taken_ranges, const AddressRange& code_range, uint64_t size);
+
+// Allocates `size` bytes in the tracee close to `code_range`. The memory segment will be placed
+// such that we can jump from any position in the memory segment to any position in `code_range`
+// (and vice versa) by relative jumps using 32 bit offsets.
+[[nodiscard]] ErrorMessageOr<uint64_t> AllocateMemoryForTrampolines(pid_t pid,
+                                                                    const AddressRange& code_range,
+                                                                    uint64_t size);
+
+}  // namespace orbit_user_space_instrumentation
+
+#endif  // USER_SPACE_INSTRUMENTATION_TRAMPOLINE_H_

--- a/src/UserSpaceInstrumentation/Trampoline.h
+++ b/src/UserSpaceInstrumentation/Trampoline.h
@@ -27,13 +27,17 @@ struct AddressRange {
 // the ranges are well formed (.first < .second).
 [[nodiscard]] bool DoAddressRangesOverlap(const AddressRange& a, const AddressRange& b);
 
-// Returns the index of the lowest range in `all_ranges` that is intersecting with `range`.
+// Returns the index of the lowest range in `ranges_sorted` that is intersecting with `range`.
+// `ranges_sorted` needs to contain non-overlapping ranges in ascending order (as provided by
+// `GetTakenAddressRanges`).
 [[nodiscard]] std::optional<size_t> LowestIntersectingAddressRange(
-    const std::vector<AddressRange>& all_ranges, const AddressRange& range);
+    const std::vector<AddressRange>& ranges_sorted, const AddressRange& range);
 
-// Returns the index of the highest range in `all_ranges` that is intersecting with `range`.
+// Returns the index of the highest range in `ranges_sorted` that is intersecting with `range`.
+// `ranges_sorted` needs to contain non-overlapping ranges in ascending order (as provided by
+// `GetTakenAddressRanges`).
 [[nodiscard]] std::optional<size_t> HighestIntersectingAddressRange(
-    const std::vector<AddressRange>& all_ranges, const AddressRange& range);
+    const std::vector<AddressRange>& ranges_sorted, const AddressRange& range);
 
 // Parses the /proc/pid/maps file of a process and returns all the taken address ranges (joining
 // directly neighboring ones). We also add a range [0, /proc/sys/vm/mmap_min_addr] to block the

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -103,63 +103,63 @@ TEST(TrampolineTest, FindAddressRangeForTrampoline) {
   constexpr uint64_t kOneGb = 0x40000000;
 
   // Trivial placement to the left.
-  const std::vector<AddressRange> kTakenRanges1 = {
+  const std::vector<AddressRange> kUnavailableRanges1 = {
       {0, k64Kb}, {kOneGb, 2 * kOneGb}, {3 * kOneGb, 4 * kOneGb}};
   auto address_range_or_error =
-      FindAddressRangeForTrampoline(kTakenRanges1, {kOneGb, 2 * kOneGb}, k256Mb);
+      FindAddressRangeForTrampoline(kUnavailableRanges1, {kOneGb, 2 * kOneGb}, k256Mb);
   ASSERT_FALSE(address_range_or_error.has_error());
   EXPECT_EQ(kOneGb - k256Mb, address_range_or_error.value().start);
 
   // Placement to the left just fits.
-  const std::vector<AddressRange> kTakenRanges2 = {
+  const std::vector<AddressRange> kUnavailableRanges2 = {
       {0, k64Kb}, {k256Mb, kOneGb}, {3 * kOneGb, 4 * kOneGb}};
   address_range_or_error =
-      FindAddressRangeForTrampoline(kTakenRanges2, {k256Mb, kOneGb}, k256Mb - k64Kb);
+      FindAddressRangeForTrampoline(kUnavailableRanges2, {k256Mb, kOneGb}, k256Mb - k64Kb);
   ASSERT_FALSE(address_range_or_error.has_error());
   EXPECT_EQ(k64Kb, address_range_or_error.value().start);
 
   // Placement to the left fails due to page alignment. So we place to the right which fits
   // trivially.
-  const std::vector<AddressRange> kTakenRanges3 = {
+  const std::vector<AddressRange> kUnavailableRanges3 = {
       {0, k64Kb + 1}, {k256Mb, kOneGb}, {3 * kOneGb, 4 * kOneGb}};
   address_range_or_error =
-      FindAddressRangeForTrampoline(kTakenRanges3, {k256Mb, kOneGb}, k256Mb - k64Kb - 5);
+      FindAddressRangeForTrampoline(kUnavailableRanges3, {k256Mb, kOneGb}, k256Mb - k64Kb - 5);
   ASSERT_FALSE(address_range_or_error.has_error());
   EXPECT_EQ(kOneGb, address_range_or_error.value().start);
 
   // Placement to the left just fits but only after a few hops.
-  const std::vector<AddressRange> kTakenRanges4 = {{0, k64Kb},  // this is the gap that just fits
+  const std::vector<AddressRange> kUnavailableRanges4 = {{0, k64Kb},  // this is the gap that just fits
                                                    {k64Kb + kOneMb, 6 * kOneMb},
                                                    {6 * kOneMb + kOneMb - 1, 7 * kOneMb},
                                                    {7 * kOneMb + kOneMb - 1, 8 * kOneMb},
                                                    {8 * kOneMb + kOneMb - 1, 9 * kOneMb}};
   address_range_or_error =
-      FindAddressRangeForTrampoline(kTakenRanges4, {8 * kOneMb + kOneMb - 1, 9 * kOneMb}, kOneMb);
+      FindAddressRangeForTrampoline(kUnavailableRanges4, {8 * kOneMb + kOneMb - 1, 9 * kOneMb}, kOneMb);
   ASSERT_FALSE(address_range_or_error.has_error());
   EXPECT_EQ(k64Kb, address_range_or_error.value().start);
 
   // No space to the left but trivial placement to the right.
-  const std::vector<AddressRange> kTakenRanges5 = {
+  const std::vector<AddressRange> kUnavailableRanges5 = {
       {0, k64Kb}, {kOneMb, kOneGb}, {5 * kOneGb, 6 * kOneGb}};
-  address_range_or_error = FindAddressRangeForTrampoline(kTakenRanges5, {kOneMb, kOneGb}, kOneMb);
+  address_range_or_error = FindAddressRangeForTrampoline(kUnavailableRanges5, {kOneMb, kOneGb}, kOneMb);
   ASSERT_FALSE(address_range_or_error.has_error()) << address_range_or_error.error().message();
   EXPECT_EQ(kOneGb, address_range_or_error.value().start);
 
   // No space to the left but placement to the right works after a few hops.
-  const std::vector<AddressRange> kTakenRanges6 = {
+  const std::vector<AddressRange> kUnavailableRanges6 = {
       {0, k64Kb},
       {kOneMb, kOneGb},
       {kOneGb + 0x01 * kOneMb - 1, kOneGb + 0x10 * kOneMb},
       {kOneGb + 0x11 * kOneMb - 1, kOneGb + 0x20 * kOneMb},
       {kOneGb + 0x21 * kOneMb - 1, kOneGb + 0x30 * kOneMb},
       {kOneGb + 0x31 * kOneMb - 1, kOneGb + 0x40 * kOneMb}};
-  address_range_or_error = FindAddressRangeForTrampoline(kTakenRanges6, {kOneMb, kOneGb}, kOneMb);
+  address_range_or_error = FindAddressRangeForTrampoline(kUnavailableRanges6, {kOneMb, kOneGb}, kOneMb);
   ASSERT_FALSE(address_range_or_error.has_error()) << address_range_or_error.error().message();
   EXPECT_EQ(kOneGb + 0x40 * kOneMb, address_range_or_error.value().start);
 
   // No space to the left and the last segment nearly fills up the 64 bit address space. So no
   // placement is possible.
-  const std::vector<AddressRange> kTakenRanges7 = {
+  const std::vector<AddressRange> kUnavailableRanges7 = {
       {0, k64Kb},
       {kOneMb, k256Mb},
       {1 * k256Mb + kOneMb - 1, 2 * k256Mb},
@@ -167,19 +167,19 @@ TEST(TrampolineTest, FindAddressRangeForTrampoline) {
       {3 * k256Mb + kOneMb - 1, 4 * k256Mb + 1},  // this gap is large but alignment doesn't fit
       {4 * k256Mb + kOneMb + 2, 5 * k256Mb},
       {5 * k256Mb + kOneMb - 1, 0xffffffffffffffff - kOneMb / 2}};
-  address_range_or_error = FindAddressRangeForTrampoline(kTakenRanges7, {kOneMb, k256Mb}, kOneMb);
+  address_range_or_error = FindAddressRangeForTrampoline(kUnavailableRanges7, {kOneMb, k256Mb}, kOneMb);
   ASSERT_TRUE(address_range_or_error.has_error());
 
   // There is no sufficiently large gap in the mappings in the 2GB below the code segment. So the
   // trampoline is placed above the code segment. Also we test that the trampoline starts at the
   // next memory page above last taken segment.
-  const std::vector<AddressRange> kTakenRanges8 = {
+  const std::vector<AddressRange> kUnavailableRanges8 = {
       {0, k64Kb},  // huge gap here, but it's too far away
       {0x10 * kOneGb, 0x11 * kOneGb},
       {0x11 * kOneGb + kOneMb - 1, 0x12 * kOneGb},
       {0x12 * kOneGb + kOneMb - 1, 0x12 * kOneGb + 2 * kOneMb + 42}};
   address_range_or_error = FindAddressRangeForTrampoline(
-      kTakenRanges8, {0x12 * kOneGb + kOneMb - 1, 0x12 * kOneGb + 2 * kOneMb}, kOneMb);
+      kUnavailableRanges8, {0x12 * kOneGb + kOneMb - 1, 0x12 * kOneGb + 2 * kOneMb}, kOneMb);
   ASSERT_FALSE(address_range_or_error.has_error()) << address_range_or_error.error().message();
   constexpr uint64_t kPageSize = 4096;
   constexpr uint64_t kNextPage =
@@ -188,7 +188,7 @@ TEST(TrampolineTest, FindAddressRangeForTrampoline) {
 
   // There is no sufficiently large gap in the mappings in the 2GB below the code segment. And there
   // also is no gap large enough in the 2GB above the code segment. So no placement is possible.
-  const std::vector<AddressRange> kTakenRanges9 = {
+  const std::vector<AddressRange> kUnavailableRanges9 = {
       {0, k64Kb},  // huge gap here, but it's too far away
       {0x10 * kOneGb + kOneMb - 1, 0x11 * kOneGb},
       {0x11 * kOneGb + kOneMb - 1, 0x12 * kOneGb},
@@ -196,8 +196,14 @@ TEST(TrampolineTest, FindAddressRangeForTrampoline) {
       {0x12 * kOneGb + 3 * kOneMb - 1, 0x13 * kOneGb + 1},
       {0x13 * kOneGb + kOneMb + 42, 0x14 * kOneGb}};
   address_range_or_error = FindAddressRangeForTrampoline(
-      kTakenRanges9, {0x12 * kOneGb + kOneMb - 1, 0x12 * kOneGb + 2 * kOneMb}, kOneMb);
+      kUnavailableRanges9, {0x12 * kOneGb + kOneMb - 1, 0x12 * kOneGb + 2 * kOneMb}, kOneMb);
   ASSERT_TRUE(address_range_or_error.has_error());
+
+  // Fail on malformed into: first address range does not start at zero.
+  const std::vector<AddressRange> kUnavailableRanges10 = {{k64Kb, kOneGb}};
+  EXPECT_DEATH(
+      auto result = FindAddressRangeForTrampoline(kUnavailableRanges10, {k64Kb, kOneGb}, kOneMb),
+      "needs to start at zero");
 }
 
 TEST(TrampolineTest, AllocateMemoryForTrampolines) {

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -1,0 +1,249 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <absl/strings/numbers.h>
+#include <absl/strings/str_split.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "AllocateInTracee.h"
+#include "Attach.h"
+#include "ElfUtils/LinuxMap.h"
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/ReadFileToString.h"
+#include "Trampoline.h"
+
+namespace orbit_user_space_instrumentation {
+
+namespace {
+
+using absl::numbers_internal::safe_strtou64_base;
+using orbit_base::ReadFileToString;
+
+extern "C" __attribute__((noinline)) int DoubleAndIncrease(int i) {
+  i = 2 * i;
+  return i + 1;
+}
+
+}  // namespace
+
+TEST(TrampolineTest, DoAddressRangesOverlap) {
+  AddressRange a = {3, 7};
+  AddressRange b1 = {1, 2};
+  EXPECT_FALSE(DoAddressRangesOverlap(a, b1));
+  AddressRange b2 = {1, 3};
+  EXPECT_FALSE(DoAddressRangesOverlap(a, b2));
+  AddressRange b3 = {1, 4};
+  EXPECT_TRUE(DoAddressRangesOverlap(a, b3));
+  AddressRange b4 = {1, 9};
+  EXPECT_TRUE(DoAddressRangesOverlap(a, b4));
+  AddressRange b5 = {4, 5};
+  EXPECT_TRUE(DoAddressRangesOverlap(a, b5));
+  AddressRange b6 = {4, 9};
+  EXPECT_TRUE(DoAddressRangesOverlap(a, b6));
+  AddressRange b7 = {7, 9};
+  EXPECT_FALSE(DoAddressRangesOverlap(a, b7));
+  AddressRange b8 = {8, 9};
+  EXPECT_FALSE(DoAddressRangesOverlap(a, b8));
+}
+
+TEST(TrampolineTest, LowestIntersectingAddressRange) {
+  const std::vector<AddressRange> kAllRanges = {{0, 5}, {20, 30}, {40, 60}};
+
+  EXPECT_FALSE(LowestIntersectingAddressRange({}, {0, 60}).has_value());
+
+  EXPECT_EQ(0, LowestIntersectingAddressRange(kAllRanges, {1, 2}));
+  EXPECT_EQ(1, LowestIntersectingAddressRange(kAllRanges, {21, 22}));
+  EXPECT_EQ(2, LowestIntersectingAddressRange(kAllRanges, {51, 52}));
+
+  EXPECT_EQ(0, LowestIntersectingAddressRange(kAllRanges, {3, 6}));
+  EXPECT_EQ(1, LowestIntersectingAddressRange(kAllRanges, {19, 22}));
+  EXPECT_EQ(2, LowestIntersectingAddressRange(kAllRanges, {30, 52}));
+
+  EXPECT_EQ(0, LowestIntersectingAddressRange(kAllRanges, {4, 72}));
+  EXPECT_EQ(1, LowestIntersectingAddressRange(kAllRanges, {29, 52}));
+  EXPECT_EQ(2, LowestIntersectingAddressRange(kAllRanges, {59, 72}));
+
+  EXPECT_FALSE(LowestIntersectingAddressRange(kAllRanges, {5, 20}).has_value());
+  EXPECT_FALSE(LowestIntersectingAddressRange(kAllRanges, {30, 40}).has_value());
+  EXPECT_FALSE(LowestIntersectingAddressRange(kAllRanges, {60, 80}).has_value());
+}
+
+TEST(TrampolineTest, HighestIntersectingAddressRange) {
+  std::vector<AddressRange> kAllRanges = {{0, 5}, {20, 30}, {40, 60}};
+
+  EXPECT_FALSE(HighestIntersectingAddressRange({}, {0, 60}).has_value());
+
+  EXPECT_EQ(0, HighestIntersectingAddressRange(kAllRanges, {1, 2}));
+  EXPECT_EQ(1, HighestIntersectingAddressRange(kAllRanges, {21, 22}));
+  EXPECT_EQ(2, HighestIntersectingAddressRange(kAllRanges, {51, 52}));
+
+  EXPECT_EQ(0, HighestIntersectingAddressRange(kAllRanges, {3, 6}));
+  EXPECT_EQ(1, HighestIntersectingAddressRange(kAllRanges, {19, 22}));
+  EXPECT_EQ(2, HighestIntersectingAddressRange(kAllRanges, {30, 52}));
+
+  EXPECT_EQ(2, HighestIntersectingAddressRange(kAllRanges, {4, 72}));
+  EXPECT_EQ(2, HighestIntersectingAddressRange(kAllRanges, {29, 52}));
+  EXPECT_EQ(2, HighestIntersectingAddressRange(kAllRanges, {59, 72}));
+
+  EXPECT_FALSE(HighestIntersectingAddressRange(kAllRanges, {5, 20}).has_value());
+  EXPECT_FALSE(HighestIntersectingAddressRange(kAllRanges, {30, 40}).has_value());
+  EXPECT_FALSE(HighestIntersectingAddressRange(kAllRanges, {60, 80}).has_value());
+}
+
+TEST(TrampolineTest, FindAddressRangeForTrampoline) {
+  constexpr uint64_t k64Kb = 0x10000;
+  constexpr uint64_t kOneMb = 0x100000;
+  constexpr uint64_t k256Mb = 0x10000000;
+  constexpr uint64_t kOneGb = 0x40000000;
+
+  // Trivial placement to the left.
+  const std::vector<AddressRange> kTakenRanges1 = {
+      {0, k64Kb}, {kOneGb, 2 * kOneGb}, {3 * kOneGb, 4 * kOneGb}};
+  auto address_range_or_error =
+      FindAddressRangeForTrampoline(kTakenRanges1, {kOneGb, 2 * kOneGb}, k256Mb);
+  ASSERT_FALSE(address_range_or_error.has_error());
+  EXPECT_EQ(kOneGb - k256Mb, address_range_or_error.value().start);
+
+  // Placement to the left just fits.
+  const std::vector<AddressRange> kTakenRanges2 = {
+      {0, k64Kb}, {k256Mb, kOneGb}, {3 * kOneGb, 4 * kOneGb}};
+  address_range_or_error =
+      FindAddressRangeForTrampoline(kTakenRanges2, {k256Mb, kOneGb}, k256Mb - k64Kb);
+  ASSERT_FALSE(address_range_or_error.has_error());
+  EXPECT_EQ(k64Kb, address_range_or_error.value().start);
+
+  // Placement to the left fails due to page alignment. So we place to the right which fits
+  // trivially.
+  const std::vector<AddressRange> kTakenRanges3 = {
+      {0, k64Kb + 1}, {k256Mb, kOneGb}, {3 * kOneGb, 4 * kOneGb}};
+  address_range_or_error =
+      FindAddressRangeForTrampoline(kTakenRanges3, {k256Mb, kOneGb}, k256Mb - k64Kb - 5);
+  ASSERT_FALSE(address_range_or_error.has_error());
+  EXPECT_EQ(kOneGb, address_range_or_error.value().start);
+
+  // Placement to the left just fits but only after a few hops.
+  const std::vector<AddressRange> kTakenRanges4 = {{0, k64Kb},  // this is the gap that just fits
+                                                   {k64Kb + kOneMb, 6 * kOneMb},
+                                                   {6 * kOneMb + kOneMb - 1, 7 * kOneMb},
+                                                   {7 * kOneMb + kOneMb - 1, 8 * kOneMb},
+                                                   {8 * kOneMb + kOneMb - 1, 9 * kOneMb}};
+  address_range_or_error =
+      FindAddressRangeForTrampoline(kTakenRanges4, {8 * kOneMb + kOneMb - 1, 9 * kOneMb}, kOneMb);
+  ASSERT_FALSE(address_range_or_error.has_error());
+  EXPECT_EQ(k64Kb, address_range_or_error.value().start);
+
+  // No space to the left but trivial placement to the right.
+  const std::vector<AddressRange> kTakenRanges5 = {
+      {0, k64Kb}, {kOneMb, kOneGb}, {5 * kOneGb, 6 * kOneGb}};
+  address_range_or_error = FindAddressRangeForTrampoline(kTakenRanges5, {kOneMb, kOneGb}, kOneMb);
+  ASSERT_FALSE(address_range_or_error.has_error()) << address_range_or_error.error().message();
+  EXPECT_EQ(kOneGb, address_range_or_error.value().start);
+
+  // No space to the left but placement to the right works after a few hops.
+  const std::vector<AddressRange> kTakenRanges6 = {
+      {0, k64Kb},
+      {kOneMb, kOneGb},
+      {kOneGb + 0x01 * kOneMb - 1, kOneGb + 0x10 * kOneMb},
+      {kOneGb + 0x11 * kOneMb - 1, kOneGb + 0x20 * kOneMb},
+      {kOneGb + 0x21 * kOneMb - 1, kOneGb + 0x30 * kOneMb},
+      {kOneGb + 0x31 * kOneMb - 1, kOneGb + 0x40 * kOneMb}};
+  address_range_or_error = FindAddressRangeForTrampoline(kTakenRanges6, {kOneMb, kOneGb}, kOneMb);
+  ASSERT_FALSE(address_range_or_error.has_error()) << address_range_or_error.error().message();
+  EXPECT_EQ(kOneGb + 0x40 * kOneMb, address_range_or_error.value().start);
+
+  // No space to the left and the last segment nearly fills up the 64 bit address space. So no
+  // placement is possible.
+  const std::vector<AddressRange> kTakenRanges7 = {
+      {0, k64Kb},
+      {kOneMb, k256Mb},
+      {1 * k256Mb + kOneMb - 1, 2 * k256Mb},
+      {2 * k256Mb + kOneMb - 1, 3 * k256Mb},
+      {3 * k256Mb + kOneMb - 1, 4 * k256Mb + 1},  // this gap is large but alignment doesn't fit
+      {4 * k256Mb + kOneMb + 2, 5 * k256Mb},
+      {5 * k256Mb + kOneMb - 1, 0xffffffffffffffff - kOneMb / 2}};
+  address_range_or_error = FindAddressRangeForTrampoline(kTakenRanges7, {kOneMb, k256Mb}, kOneMb);
+  ASSERT_TRUE(address_range_or_error.has_error());
+
+  // There is no sufficiently large gap in the mappings in the 2GB below the code segment. So the
+  // trampoline is placed above the code segment. Also we test that the trampoline starts at the
+  // next memory page above last taken segment.
+  const std::vector<AddressRange> kTakenRanges8 = {
+      {0, k64Kb},  // huge gap here, but it's too far away
+      {0x10 * kOneGb, 0x11 * kOneGb},
+      {0x11 * kOneGb + kOneMb - 1, 0x12 * kOneGb},
+      {0x12 * kOneGb + kOneMb - 1, 0x12 * kOneGb + 2 * kOneMb + 42}};
+  address_range_or_error = FindAddressRangeForTrampoline(
+      kTakenRanges8, {0x12 * kOneGb + kOneMb - 1, 0x12 * kOneGb + 2 * kOneMb}, kOneMb);
+  ASSERT_FALSE(address_range_or_error.has_error()) << address_range_or_error.error().message();
+  constexpr uint64_t kPageSize = 4096;
+  constexpr uint64_t kNextPage =
+      (((0x12 * kOneGb + 2 * kOneMb + 42) + (kPageSize - 1)) / kPageSize) * kPageSize;
+  EXPECT_EQ(kNextPage, address_range_or_error.value().start);
+
+  // There is no sufficiently large gap in the mappings in the 2GB below the code segment. And there
+  // also is no gap large enough in the 2GB above the code segment. So no placement is possible.
+  const std::vector<AddressRange> kTakenRanges9 = {
+      {0, k64Kb},  // huge gap here, but it's too far away
+      {0x10 * kOneGb + kOneMb - 1, 0x11 * kOneGb},
+      {0x11 * kOneGb + kOneMb - 1, 0x12 * kOneGb},
+      {0x12 * kOneGb + kOneMb - 1, 0x12 * kOneGb + 2 * kOneMb},
+      {0x12 * kOneGb + 3 * kOneMb - 1, 0x13 * kOneGb + 1},
+      {0x13 * kOneGb + kOneMb + 42, 0x14 * kOneGb}};
+  address_range_or_error = FindAddressRangeForTrampoline(
+      kTakenRanges9, {0x12 * kOneGb + kOneMb - 1, 0x12 * kOneGb + 2 * kOneMb}, kOneMb);
+  ASSERT_TRUE(address_range_or_error.has_error());
+}
+
+TEST(TrampolineTest, AllocateMemoryForTrampolines) {
+  pid_t pid = fork();
+  CHECK(pid != -1);
+  if (pid == 0) {
+    uint64_t sum = 0;
+    int i = 0;
+    while (true) {
+      i = (i + 1) & 3;
+      sum += DoubleAndIncrease(i);
+    }
+  }
+
+  // Stop the process using our tooling.
+  CHECK(AttachAndStopProcess(pid).has_value());
+
+  // Find the address range of the code for `DoubleAndIncrease`. For the purpose of this test we
+  // just take the entire address space taken up by `UserSpaceInstrumentationTests`.
+  AddressRange code_range;
+  auto modules = orbit_elf_utils::ReadModules(pid);
+  CHECK(!modules.has_error());
+  for (const auto& m : modules.value()) {
+    if (m.name() == "UserSpaceInstrumentationTests") {
+      code_range.start = m.address_start();
+      code_range.end = m.address_end();
+    }
+  }
+
+  // Allocate one megabyte in the tracee. The memory will be close to `code_range`.
+  constexpr uint64_t kTrampolineSize = 1024 * 1024;
+  auto address_or_error = AllocateMemoryForTrampolines(pid, code_range, kTrampolineSize);
+  ASSERT_FALSE(address_or_error.has_error());
+
+  // Check that the tracee is functional: Continue, stop again, free the allocated memory, then run
+  // briefly again.
+  CHECK(DetachAndContinueProcess(pid).has_value());
+  CHECK(AttachAndStopProcess(pid).has_value());
+  ASSERT_FALSE(FreeInTracee(pid, address_or_error.value(), kTrampolineSize).has_error());
+  CHECK(DetachAndContinueProcess(pid).has_value());
+  CHECK(AttachAndStopProcess(pid).has_value());
+
+  // Detach and end child.
+  CHECK(DetachAndContinueProcess(pid).has_value());
+  kill(pid, SIGKILL);
+  waitpid(pid, nullptr, 0);
+}
+
+}  // namespace orbit_user_space_instrumentation

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -25,7 +25,7 @@ namespace {
 using absl::numbers_internal::safe_strtou64_base;
 using orbit_base::ReadFileToString;
 
-extern "C" __attribute__((noinline)) int DoubleAndIncrease(int i) {
+extern "C" __attribute__((noinline)) int DoubleAndIncrement(int i) {
   i = 2 * i;
   return i + 1;
 }
@@ -208,14 +208,14 @@ TEST(TrampolineTest, AllocateMemoryForTrampolines) {
     int i = 0;
     while (true) {
       i = (i + 1) & 3;
-      sum += DoubleAndIncrease(i);
+      sum += DoubleAndIncrement(i);
     }
   }
 
   // Stop the process using our tooling.
   CHECK(AttachAndStopProcess(pid).has_value());
 
-  // Find the address range of the code for `DoubleAndIncrease`. For the purpose of this test we
+  // Find the address range of the code for `DoubleAndIncrement`. For the purpose of this test we
   // just take the entire address space taken up by `UserSpaceInstrumentationTests`.
   AddressRange code_range;
   auto modules = orbit_elf_utils::ReadModules(pid);

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -128,20 +128,22 @@ TEST(TrampolineTest, FindAddressRangeForTrampoline) {
   EXPECT_EQ(kOneGb, address_range_or_error.value().start);
 
   // Placement to the left just fits but only after a few hops.
-  const std::vector<AddressRange> kUnavailableRanges4 = {{0, k64Kb},  // this is the gap that just fits
-                                                   {k64Kb + kOneMb, 6 * kOneMb},
-                                                   {6 * kOneMb + kOneMb - 1, 7 * kOneMb},
-                                                   {7 * kOneMb + kOneMb - 1, 8 * kOneMb},
-                                                   {8 * kOneMb + kOneMb - 1, 9 * kOneMb}};
-  address_range_or_error =
-      FindAddressRangeForTrampoline(kUnavailableRanges4, {8 * kOneMb + kOneMb - 1, 9 * kOneMb}, kOneMb);
+  const std::vector<AddressRange> kUnavailableRanges4 = {
+      {0, k64Kb},  // this is the gap that just fits
+      {k64Kb + kOneMb, 6 * kOneMb},
+      {6 * kOneMb + kOneMb - 1, 7 * kOneMb},
+      {7 * kOneMb + kOneMb - 1, 8 * kOneMb},
+      {8 * kOneMb + kOneMb - 1, 9 * kOneMb}};
+  address_range_or_error = FindAddressRangeForTrampoline(
+      kUnavailableRanges4, {8 * kOneMb + kOneMb - 1, 9 * kOneMb}, kOneMb);
   ASSERT_FALSE(address_range_or_error.has_error());
   EXPECT_EQ(k64Kb, address_range_or_error.value().start);
 
   // No space to the left but trivial placement to the right.
   const std::vector<AddressRange> kUnavailableRanges5 = {
       {0, k64Kb}, {kOneMb, kOneGb}, {5 * kOneGb, 6 * kOneGb}};
-  address_range_or_error = FindAddressRangeForTrampoline(kUnavailableRanges5, {kOneMb, kOneGb}, kOneMb);
+  address_range_or_error =
+      FindAddressRangeForTrampoline(kUnavailableRanges5, {kOneMb, kOneGb}, kOneMb);
   ASSERT_FALSE(address_range_or_error.has_error()) << address_range_or_error.error().message();
   EXPECT_EQ(kOneGb, address_range_or_error.value().start);
 
@@ -153,7 +155,8 @@ TEST(TrampolineTest, FindAddressRangeForTrampoline) {
       {kOneGb + 0x11 * kOneMb - 1, kOneGb + 0x20 * kOneMb},
       {kOneGb + 0x21 * kOneMb - 1, kOneGb + 0x30 * kOneMb},
       {kOneGb + 0x31 * kOneMb - 1, kOneGb + 0x40 * kOneMb}};
-  address_range_or_error = FindAddressRangeForTrampoline(kUnavailableRanges6, {kOneMb, kOneGb}, kOneMb);
+  address_range_or_error =
+      FindAddressRangeForTrampoline(kUnavailableRanges6, {kOneMb, kOneGb}, kOneMb);
   ASSERT_FALSE(address_range_or_error.has_error()) << address_range_or_error.error().message();
   EXPECT_EQ(kOneGb + 0x40 * kOneMb, address_range_or_error.value().start);
 
@@ -167,7 +170,8 @@ TEST(TrampolineTest, FindAddressRangeForTrampoline) {
       {3 * k256Mb + kOneMb - 1, 4 * k256Mb + 1},  // this gap is large but alignment doesn't fit
       {4 * k256Mb + kOneMb + 2, 5 * k256Mb},
       {5 * k256Mb + kOneMb - 1, 0xffffffffffffffff - kOneMb / 2}};
-  address_range_or_error = FindAddressRangeForTrampoline(kUnavailableRanges7, {kOneMb, k256Mb}, kOneMb);
+  address_range_or_error =
+      FindAddressRangeForTrampoline(kUnavailableRanges7, {kOneMb, k256Mb}, kOneMb);
   ASSERT_TRUE(address_range_or_error.has_error());
 
   // There is no sufficiently large gap in the mappings in the 2GB below the code segment. So the


### PR DESCRIPTION
Previously the allocation in the tracee happened at arbitrary memory
positions. For the trampolines we need chunks of memory in a 32 bit
offset range of the executable code segments of the trace.

This change contains:

a) Changes to facilitate allocation of memory at a specified position
(compare AllocateInTracee.h) and follow up changes to this.

b) The logic to determine the position of the memory chunk for the
trampolines (compare Trampoline.h) and the code doing the actual
allocation.

c) Fix for a glitch in FreeInTracee: Previously it was possible that
FreeInTracee used the memory segment it was meant to unmap as an
intermediate working area (which causes a crash).