### PR TITLE
[rebase on main] Fix a crash caused by wrongly used mutex

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -765,7 +765,7 @@ void CaptureWindow::RenderImGuiDebugUI() {
     IMGUI_VAR_TO_TEXT(mouse_world_y_);
     if (time_graph_ != nullptr) {
       IMGUI_VAR_TO_TEXT(time_graph_->GetNumDrawnTextBoxes());
-      IMGUI_VAR_TO_TEXT(time_graph_->GetNumTimers());
+      IMGUI_VAR_TO_TEXT(time_graph_->GetTrackManager()->GetNumTimers());
       IMGUI_VAR_TO_TEXT(time_graph_->GetTrackManager()->GetAllTracks().size());
       IMGUI_VAR_TO_TEXT(time_graph_->GetTrackManager()->GetTracksTotalHeight());
       IMGUI_VAR_TO_TEXT(time_graph_->GetMinTimeUs());

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -219,9 +219,6 @@ class TimeGraph {
 
   Batcher batcher_;
 
-  // TODO(b/174655559): Use absl's mutex here.
-  mutable std::recursive_mutex mutex_;
-
   std::unique_ptr<TrackManager> track_manager_;
 
   absl::flat_hash_map<int32_t, std::vector<orbit_client_protos::CallstackEvent>>

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -403,3 +403,31 @@ FrameTrack* TrackManager::GetOrCreateFrameTrack(uint64_t function_id,
 
   return track.get();
 }
+
+uint32_t TrackManager::GetNumTimers() const {
+  uint32_t num_timers = 0;
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  for (const auto& track : GetAllTracks()) {
+    num_timers += track->GetNumTimers();
+  }
+  // Frame tracks are removable by users and cannot simply be thrown into the
+  // tracks_ vector.
+  for (const auto& track : GetFrameTracks()) {
+    num_timers += track->GetNumTimers();
+  }
+  return num_timers;
+}
+
+std::pair<uint64_t, uint64_t> TrackManager::GetTracksMinMaxTimestamps() const {
+  uint64_t min_time = std::numeric_limits<uint64_t>::max();
+  uint64_t max_time = std::numeric_limits<uint64_t>::min();
+
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  for (auto& track : GetAllTracks()) {
+    if (!track->IsEmpty()) {
+      min_time = std::min(min_time, track->GetMinTime());
+      max_time = std::max(max_time, track->GetMaxTime());
+    }
+  }
+  return std::make_pair(min_time, max_time);
+}

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -54,6 +54,9 @@ class TrackManager {
 
   [[nodiscard]] float GetTracksTotalHeight() const { return tracks_total_height_; }
 
+  [[nodiscard]] uint32_t GetNumTimers() const;
+  [[nodiscard]] std::pair<uint64_t, uint64_t> GetTracksMinMaxTimestamps() const;
+
   SchedulerTrack* GetOrCreateSchedulerTrack();
   ThreadTrack* GetOrCreateThreadTrack(int32_t tid);
   GpuTrack* GetOrCreateGpuTrack(uint64_t timeline_hash);
@@ -74,6 +77,7 @@ class TrackManager {
 
   void UpdateTrackPositions();
 
+  // TODO(b/174655559): Use absl's mutex here.
   mutable std::recursive_mutex mutex_;
 
   std::vector<std::shared_ptr<Track>> all_tracks_;


### PR DESCRIPTION
We used to have an only mutex in TimeGraph and we splitted into two when
we create TrackManager. In this PR, we moved the problematic functions
(GetNumTimers and GetTracksMinMaxTimestamps) to TrackManager to mutex
them properly.

Solve http://b/179467994.

Rebasing https://github.com/google/orbit/pull/2102 from the release branch.