### PR TITLE
Remove unused code from test library.

### DIFF
--- a/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.cpp
+++ b/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.cpp
@@ -4,47 +4,4 @@
 
 #include "UserSpaceInstrumentationTestLib.h"
 
-#include <cstdio>
-#include <filesystem>
-#include <fstream>
-#include <iostream>
-
-namespace {
-
-std::filesystem::path GetTmpFilePath() {
-  static std::filesystem::path p = std::tmpnam(nullptr);
-  return p;
-}
-
-}  // namespace
-
-void InitTestLib() {
-  auto p = GetTmpFilePath();
-  std::cout << "Init Lib. Tmp file is: " << p << std::endl;
-}
-
-void UseTestLib(const char* s) {
-  auto p = GetTmpFilePath();
-  std::ofstream ofs;
-  ofs.open(p, std::ofstream::out | std::ofstream::app);
-  ofs << s << std::endl;
-  ofs.close();
-}
-
-void CloseTestLib() {
-  auto p = GetTmpFilePath();
-
-  std::cout << "Close Lib. Content of " << p << std::endl;
-
-  std::ifstream tmp_file(p);
-  std::string line;
-  while (std::getline(tmp_file, line)) {
-    std::cout << line << std::endl;
-  }
-  tmp_file.close();
-  std::cout << std::endl << std::endl;
-
-  std::remove(p.c_str());
-}
-
 int TrivialFunction() { return 42; }

--- a/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.h
+++ b/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.h
@@ -5,18 +5,8 @@
 #ifndef USER_SPACE_INSTRUMENTATION_TEST_LIB_H_
 #define USER_SPACE_INSTRUMENTATION_TEST_LIB_H_
 
-// Library functions for some trivial logging. This library is merely used in tests: The test
-// injects a binary produced by this code into its child.
-
-// Call first to initialize the library.
-extern "C" void InitTestLib();
-
-// Log a string into a temporary file.
-extern "C" void UseTestLib(const char* s);
-
-// Call to end using the library. Prints the entire log to standard output and removes the
-// temporary log file.
-extern "C" void CloseTestLib();
+// This library is merely used in tests: The test  injects a binary produced by this code into its
+// child.
 
 // Returns 42.
 extern "C" int TrivialFunction();


### PR DESCRIPTION
This caused headaches when removing std::tmpnam from the code. Since the
functionality is not used at all let's get rid of it and solve this in
case it is really needed.