### PR TITLE
[REBASE TO MAIN] Revert "Fix scroll position not being updated after filtering"

### DIFF
--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -567,7 +567,7 @@ void TimeGraph::UpdatePrimitives(PickingMode picking_mode) {
 
   track_manager_->SortTracks();
   track_manager_->UpdateMovingTrackSorting();
-  track_manager_->UpdateTrackPrimitives(&batcher_, min_tick, max_tick, picking_mode);
+  track_manager_->UpdateTracks(&batcher_, min_tick, max_tick, picking_mode);
 
   update_primitives_requested_ = false;
 }

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -169,8 +169,6 @@ void TrackManager::UpdateFilteredTrackList() {
       }
     }
   }
-
-  UpdateTrackPositions();
 }
 
 std::vector<ThreadTrack*> TrackManager::GetSortedThreadTracks() {
@@ -196,44 +194,6 @@ std::vector<ThreadTrack*> TrackManager::GetSortedThreadTracks() {
             });
 
   return sorted_tracks;
-}
-
-void TrackManager::UpdateTrackPositions() {
-  // Make sure track tab fits in the viewport.
-  float current_y = -layout_->GetSchedulerTrackOffset() - layout_->GetTrackTabHeight();
-  float pinned_tracks_height = 0.f;
-
-  // Update pinned tracks
-  for (auto& track : visible_tracks_) {
-    if (!track->IsPinned()) {
-      continue;
-    }
-
-    if (!track->IsMoving()) {
-      track->SetPos(track->GetPos()[0], current_y + time_graph_->GetCanvas()->GetWorldTopLeftY() -
-                                            layout_->GetTopMargin() -
-                                            layout_->GetSchedulerTrackOffset());
-    }
-    const float height = (track->GetHeight() + layout_->GetSpaceBetweenTracks());
-    current_y -= height;
-    pinned_tracks_height += height;
-  }
-
-  // Update unpinned tracks
-  for (auto& track : visible_tracks_) {
-    if (track->IsPinned()) {
-      continue;
-    }
-
-    if (!track->IsMoving()) {
-      track->SetPos(track->GetPos()[0], current_y);
-    }
-    current_y -= (track->GetHeight() + layout_->GetSpaceBetweenTracks());
-  }
-
-  // Tracks are drawn from 0 (top) to negative y-coordinates.
-  tracks_total_height_ = std::abs(current_y);
-  time_graph_->GetCanvas()->UpdateWorldTopLeftY(time_graph_->GetCanvas()->GetWorldTopLeftY());
 }
 
 void TrackManager::UpdateMovingTrackSorting() {
@@ -287,8 +247,6 @@ void TrackManager::UpdateMovingTrackSorting() {
           moving_track);
     }
   }
-
-  UpdateTrackPositions();
 }
 
 int TrackManager::FindMovingTrackIndex() {
@@ -301,17 +259,46 @@ int TrackManager::FindMovingTrackIndex() {
   return -1;
 }
 
-void TrackManager::UpdateTrackPrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                                         PickingMode picking_mode) {
+void TrackManager::UpdateTracks(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                                PickingMode picking_mode) {
+  // Make sure track tab fits in the viewport.
+  float current_y = -layout_->GetSchedulerTrackOffset() - layout_->GetTrackTabHeight();
+  float pinned_tracks_height = 0.f;
+
+  // Draw pinned tracks
   for (auto& track : visible_tracks_) {
-    float z_offset = 0.0f;
-    if (track->IsPinned()) {
-      z_offset = GlCanvas::kZOffsetPinnedTrack;
-    } else if (track->IsMoving()) {
-      z_offset = GlCanvas::kZOffsetMovingTack;
+    if (!track->IsPinned()) {
+      continue;
+    }
+
+    const float z_offset = GlCanvas::kZOffsetPinnedTrack;
+    if (!track->IsMoving()) {
+      track->SetPos(track->GetPos()[0], current_y + time_graph_->GetCanvas()->GetWorldTopLeftY() -
+                                            layout_->GetTopMargin() -
+                                            layout_->GetSchedulerTrackOffset());
     }
     track->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
+    const float height = (track->GetHeight() + layout_->GetSpaceBetweenTracks());
+    current_y -= height;
+    pinned_tracks_height += height;
   }
+
+  // Draw unpinned tracks
+  for (auto& track : visible_tracks_) {
+    if (track->IsPinned()) {
+      continue;
+    }
+
+    const float z_offset = track->IsMoving() ? GlCanvas::kZOffsetMovingTack : 0.f;
+    if (!track->IsMoving()) {
+      track->SetPos(track->GetPos()[0], current_y);
+    }
+    track->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
+    current_y -= (track->GetHeight() + layout_->GetSpaceBetweenTracks());
+  }
+
+  // Tracks are drawn from 0 (top) to negative y-coordinates.
+  tracks_total_height_ = std::abs(current_y);
 }
 
 void TrackManager::AddTrack(const std::shared_ptr<Track>& track) {

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -49,9 +49,8 @@ class TrackManager {
   void SortTracks();
   void SetFilter(const std::string& filter);
 
-  void UpdateTrackPrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                             PickingMode picking_mode);
-
+  void UpdateTracks(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                    PickingMode picking_mode);
   [[nodiscard]] float GetTracksTotalHeight() const { return tracks_total_height_; }
 
   [[nodiscard]] uint32_t GetNumTimers() const;


### PR DESCRIPTION
This reverts commit e036e247cf9d51f9658dd9b1749fcbca50c4590f.

We introduced the regression http://b/183201803 trying to solve a less important issue (http://b/182978978). We decided to revert the change while thinking for a cleaner solution of the issue.
Mirror from https://github.com/google/orbit/pull/2116.