### PR TITLE
Move ORBIT_CRASH_HANDLING macro definition

### DIFF
--- a/src/Orbit/CMakeLists.txt
+++ b/src/Orbit/CMakeLists.txt
@@ -9,6 +9,11 @@ target_compile_options(Orbit PRIVATE ${STRICT_COMPILE_FLAGS})
 target_link_libraries(Orbit PRIVATE OrbitQt)
 target_include_directories(Orbit PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+if(WITH_CRASH_HANDLING)
+  target_link_libraries(Orbit PRIVATE CrashHandler)
+  target_compile_definitions(Orbit PRIVATE ORBIT_CRASH_HANDLING)
+endif()
+
 if(WIN32)
   set_target_properties(Orbit PROPERTIES WIN32_EXECUTABLE ON)
 

--- a/src/OrbitQt/CMakeLists.txt
+++ b/src/OrbitQt/CMakeLists.txt
@@ -114,11 +114,6 @@ target_link_libraries(
           SyntaxHighlighter
           qtpropertybrowser::qtpropertybrowser)
 
-if(WITH_CRASH_HANDLING)
-  target_link_libraries(OrbitQt PRIVATE CrashHandler)
-  target_compile_definitions(OrbitQt PRIVATE ORBIT_CRASH_HANDLING)
-endif()
-
 set_target_properties(OrbitQt PROPERTIES AUTOMOC ON)
 set_target_properties(OrbitQt PROPERTIES AUTOUIC ON)
 set_target_properties(OrbitQt PROPERTIES AUTORCC ON)


### PR DESCRIPTION
When moving `OrbitQt/main.cpp` to `Orbit/main.cpp` I missed also moving
the macro definition of `ORBIT_CRASH_HANDLING` which lead to crash
handling never be enabled.