### PR TITLE
Update CaptureWindow position after filtering

### DIFF
--- a/src/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/GlCanvas.h
@@ -95,6 +95,7 @@ class GlCanvas {
   [[nodiscard]] float GetWorldMaxY() const { return world_max_y_; }
   [[nodiscard]] float GetWorldTopLeftX() const { return world_top_left_x_; }
   [[nodiscard]] float GetWorldTopLeftY() const { return world_top_left_y_; }
+  void UpdateWorldTopLeftY() { UpdateWorldTopLeftY(GetWorldTopLeftY()); }
   virtual void UpdateWorldTopLeftY(float val) { world_top_left_y_ = val; }
 
   [[nodiscard]] TextRenderer& GetTextRenderer() { return text_renderer_; }

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -643,6 +643,9 @@ void TimeGraph::UpdatePrimitives(PickingMode picking_mode) {
   track_manager_->SortTracks();
   track_manager_->UpdateMovingTrackSorting();
   track_manager_->UpdateTracks(&batcher_, min_tick, max_tick, picking_mode);
+  // Coordinates from CaptureWindows could need an update if we modified the vertical size of some
+  // track.
+  GetCanvas()->UpdateWorldTopLeftY();
 
   update_primitives_requested_ = false;
 }


### PR DESCRIPTION
We had the issue that after filtering sometimes the capture windows
doesn't show anything because as we are not showing some tracks anymore,
the old position doesn't have any track. In this PR we ask for an update
after updating tracks position, so the view y-position is clamped for the
new top-y and bottom-y coordinates.

Something to consider:
 - I don't like TrackManager asking CaptureWindows to update position.
 We should have a better way to do this (CaptureWindows updating its
 position after drawing, but as it wasn't that simple) I left as it is
 now.

 - I overloaded the method UpdateWorldTopLeftY because I feel that it is
 nicer (can be convinced about the opposite)

 - This solution came from the idea in
 https://github.com/google/orbit/pull/2089 (almost copy-paste) but without splitting
 UpdateTrackPosition and UpdateTrackPrimitives

Solve http://b/182978978.
Test: Load a capture, move the screen, filter.