### PR TITLE
Fix orders of production limit line & white label

### DIFF
--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -27,7 +27,8 @@ float GlCanvas::kZValueTrack = 0.01f;
 float GlCanvas::kZValueEventBar = 0.03f;
 float GlCanvas::kZValueBox = 0.05f;
 float GlCanvas::kZValueEvent = 0.07f;
-float GlCanvas::kZValueTrackText = 0.09f;
+float GlCanvas::kZValueTrackText = 0.08f;
+float GlCanvas::kZValueTrackLabel = 0.09f;
 float GlCanvas::kZValueOverlay = 0.43f;
 float GlCanvas::kZValueOverlayTextBackground = 0.45f;
 float GlCanvas::kZValueEventBarPicking = 0.49f;
@@ -43,9 +44,9 @@ float GlCanvas::kZValueSlider = 0.89f;
 float GlCanvas::kZOffsetMovingTack = 0.1f;
 float GlCanvas::kZOffsetPinnedTrack = 0.2f;
 
-constexpr unsigned kNumberOriginalLayers = 16;
-constexpr unsigned kExtraLayersForMovingTracks = 5;
-constexpr unsigned kExtraLayersForPinnedTracks = 5;
+constexpr unsigned kNumberOriginalLayers = 17;
+constexpr unsigned kExtraLayersForMovingTracks = 6;
+constexpr unsigned kExtraLayersForPinnedTracks = 6;
 constexpr unsigned kExtraLayersForSliderEpsilons = 4;
 unsigned GlCanvas::kMaxNumberRealZLayers = kNumberOriginalLayers + kExtraLayersForMovingTracks +
                                            kExtraLayersForPinnedTracks +

--- a/src/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/GlCanvas.h
@@ -149,6 +149,7 @@ class GlCanvas {
   static float kZValueOverlayTextBackground;
   static float kZValueOverlay;
   static float kZValueTrackText;
+  static float kZValueTrackLabel;
   static float kZValueEvent;
   static float kZValueBox;
   static float kZValueEventBar;

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -91,7 +91,8 @@ void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset
 
   const Color kBlack(0, 0, 0, 255);
   const Color kWhite(255, 255, 255, 255);
-  float text_z = GlCanvas::kZValueEvent + z_offset;
+  float text_z = GlCanvas::kZValueTrackText + z_offset;
+  float label_z = GlCanvas::kZValueTrackLabel + z_offset;
 
   // Add warning threshold text box and line.
   Batcher* ui_batcher = canvas->GetBatcher();
@@ -161,7 +162,7 @@ void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset
                          ? absl::StrFormat("%.*f", value_decimal_digits_.value(), value)
                          : std::to_string(value);
   absl::StrAppend(&text, label_unit_);
-  DrawLabel(canvas, Vec2(point_x, point_y), text, kBlack, kWhite, text_z);
+  DrawLabel(canvas, Vec2(point_x, point_y), text, kBlack, kWhite, label_z);
 }
 
 void GraphTrack::DrawSquareDot(Batcher* batcher, Vec2 center, float radius, float z,


### PR DESCRIPTION
The previous code puts the production limit line and the white label in
the same layer. As we draw primitives in the same layer in the order of
"Box --> Line --> Triangle", the red line of production limit appears
over the white label.

With this change, we fix the wrong ordering by putting the while label
in a different layer with the production limit.

Bug: http://b/183492649

Before the change:
<img width="552" alt="red line" src="https://user-images.githubusercontent.com/74234352/112281937-8203ff00-8c7e-11eb-9fe7-1fe088990510.png">

After:
![Screenshot 2021-03-24 085503](https://user-images.githubusercontent.com/74234352/112281964-892b0d00-8c7e-11eb-8c1e-6c4056ac871f.png)
