### PR TITLE
Change track name matching to perfect match

### DIFF
--- a/contrib/automation_tests/orbit_create_frame_track.py
+++ b/contrib/automation_tests/orbit_create_frame_track.py
@@ -40,7 +40,7 @@ def main(argv):
         Capture(),
         AddFrameTrack(function_name="DrawFrame"),
         FilterTracks(filter_string="Frame", expected_count=1),   # Verify there's exactly one frame track
-        CheckTimers(track_name_contains='Frame track')  # Verify the frame track has timers
+        CheckTimers(track_name_filter='Frame track*')  # Verify the frame track has timers
     ]
     suite = E2ETestSuite(test_name="Add Frame Track", test_cases=test_cases)
     suite.execute()

--- a/contrib/automation_tests/orbit_instrument_function.py
+++ b/contrib/automation_tests/orbit_instrument_function.py
@@ -36,15 +36,15 @@ def main(argv):
         FilterAndSelectFirstProcess(process_filter='hello_'),
         LoadSymbols(module_search_string="hello_ggp"),
         Capture(),
-        CheckTimers(track_name_contains='Scheduler'),
-        CheckTimers(track_name_contains='gfx'),
-        CheckTimers(track_name_contains="All Threads", expect_exists=False),
-        CheckTimers(track_name_contains="hello_ggp_stand", expect_exists=False),
+        CheckTimers(track_name_filter='Scheduler'),
+        CheckTimers(track_name_filter='gfx'),
+        CheckTimers(track_name_filter="All Threads", expect_exists=False),
+        CheckTimers(track_name_filter="hello_ggp_stand", expect_exists=False),
         FilterAndHookFunction(function_search_string='DrawFrame'),
         Capture(),
         VerifyFunctionCallCount(function_name='DrawFrame', min_calls=30, max_calls=3000),
-        CheckTimers(track_name_contains="All Threads", expect_exists=False),
-        CheckTimers(track_name_contains="hello_ggp_stand")
+        CheckTimers(track_name_filter="All Threads", expect_exists=False),
+        CheckTimers(track_name_filter="hello_ggp_stand")
     ]
     suite = E2ETestSuite(test_name="Instrument Function", test_cases=test_cases)
     suite.execute()

--- a/contrib/automation_tests/orbit_thread_state.py
+++ b/contrib/automation_tests/orbit_thread_state.py
@@ -22,9 +22,9 @@ def main(argv):
         ConnectToStadiaInstance(),
         FilterAndSelectFirstProcess(process_filter='hello_'),
         Capture(collect_thread_states=True),
-        CheckThreadStates(track_name_contains='hello_ggp'),
+        CheckThreadStates(track_name_filter='hello_ggp_stand'),
         Capture(collect_thread_states=False),
-        CheckThreadStates(track_name_contains='hello_ggp', expect_exists=False),
+        CheckThreadStates(track_name_filter='hello_ggp_stand', expect_exists=False),
     ]
     suite = E2ETestSuite(test_name="Collect Thread States", test_cases=test_cases)
     suite.execute()

--- a/contrib/automation_tests/orbit_tracks.py
+++ b/contrib/automation_tests/orbit_tracks.py
@@ -18,7 +18,7 @@ def main(argv):
         Capture(),
         # "sdma0" is not present on the DevKits, instead there is "vce0", so this tests for "sdma0 or vce0"
         MatchTracks(expected_names=[
-            "Scheduler", ("sdma0", "vce0"), "gfx", "All Threads", "hello_ggp_stand"],
+            "Scheduler", ("*sdma0*", "*vce0*"), "gfx", "All Threads", "hello_ggp_stand"],
             allow_additional_tracks=True),
         SelectTrack(track_index=4),
         DeselectTrack(),

--- a/contrib/automation_tests/test_cases/capture_window.py
+++ b/contrib/automation_tests/test_cases/capture_window.py
@@ -6,6 +6,7 @@ found in the LICENSE file.
 
 import logging
 import time
+from fnmatch import fnmatch
 
 from typing import Tuple, List, Iterable
 
@@ -28,10 +29,10 @@ class CaptureWindowE2ETestCaseBase(E2ETestCase):
         self._time_graph = self.find_control('Image', name='TimeGraph', parent=suite.top_window())
         super().execute(suite=suite)
 
-    def _find_tracks(self, name_contains: str = None):
+    def _find_tracks(self, name_filter: str = None):
         tracks = self._time_graph.children()
-        if name_contains is not None:
-            tracks = filter(lambda track: name_contains in track.texts()[0], tracks)
+        if name_filter is not None:
+            tracks = filter(lambda track: fnmatch(track.texts()[0], name_filter), tracks)
         return list(tracks)
 
 
@@ -169,10 +170,10 @@ class MatchTracks(CaptureWindowE2ETestCaseBase):
     @staticmethod
     def _match(expected_name: str or Iterable[str], found_name: str) -> bool:
         if isinstance(expected_name, str):
-            return found_name in expected_name
+            return fnmatch(found_name, expected_name)
         else:
             for option in expected_name:
-                if found_name in option:
+                if fnmatch(found_name, option):
                     return True
         return False
 
@@ -253,9 +254,9 @@ class Capture(E2ETestCase):
 
 
 class CheckThreadStates(CaptureWindowE2ETestCaseBase):
-    def _execute(self, track_name_contains: str, expect_exists: bool = True):
-        tracks = self._find_tracks(track_name_contains)
-        self.expect_true(len(tracks) > 0, 'Found tracks matching %s' % track_name_contains)
+    def _execute(self, track_name_filter: str, expect_exists: bool = True):
+        tracks = self._find_tracks(track_name_filter)
+        self.expect_true(len(tracks) > 0, 'Found tracks matching %s' % track_name_filter)
         logging.info('Checking for thread states in %s tracks', len(tracks))
         for track in tracks:
             track = Track(track)
@@ -266,9 +267,9 @@ class CheckThreadStates(CaptureWindowE2ETestCaseBase):
 
 
 class CheckTimers(CaptureWindowE2ETestCaseBase):
-    def _execute(self, track_name_contains: str, expect_exists: bool = True):
-        tracks = self._find_tracks(track_name_contains)
-        self.expect_true(len(tracks) > 0, 'Found tracks matching "%s"' % track_name_contains)
+    def _execute(self, track_name_filter: str, expect_exists: bool = True):
+        tracks = self._find_tracks(track_name_filter)
+        self.expect_true(len(tracks) > 0, 'Found tracks matching "%s"' % track_name_filter)
         logging.info('Checking for timers in %s tracks', len(tracks))
         for track in tracks:
             track = Track(track)
@@ -279,9 +280,9 @@ class CheckTimers(CaptureWindowE2ETestCaseBase):
 
 
 class CheckCallstacks(CaptureWindowE2ETestCaseBase):
-    def _execute(self, track_name_contains: str, expect_exists: bool = True):
-        tracks = self._find_tracks(track_name_contains)
-        self.expect_true(len(tracks) > 0, 'Found tracks matching "%s"' % track_name_contains)
+    def _execute(self, track_name_filter: str, expect_exists: bool = True):
+        tracks = self._find_tracks(track_name_filter)
+        self.expect_true(len(tracks) > 0, 'Found tracks matching "%s"' % track_name_filter)
         logging.info('Checking for callstacks pane in %s tracks', len(tracks))
         for track in tracks:
             track = Track(track)

--- a/contrib/automation_tests/test_cases/live_tab.py
+++ b/contrib/automation_tests/test_cases/live_tab.py
@@ -66,11 +66,12 @@ class AddFrameTrack(LiveTabTestCase):
         wait_for_condition(lambda: "F" in tree_view.children()[index - 1].window_text())
 
         logging.info("Verifying existence of track in the Capture window")
-        match_tracks = MatchTracks(expected_names=["Frame track based on %s" % function_name],
+        track_name = "Frame track based on %s" % function_name
+        match_tracks = MatchTracks(expected_names=[track_name],
                                    allow_additional_tracks=True)
         match_tracks.execute(self.suite)
 
-        check_timers = CheckTimers(track_name_contains=function_name)
+        check_timers = CheckTimers(track_name_filter=track_name)
         check_timers.execute(self.suite)
 
 
@@ -90,7 +91,8 @@ class VerifyFunctionCallCount(LiveTabTestCase):
         self.expect_true(min_calls <= call_count <= max_calls,
                          'Call count for function "%s" expected to be between %s and %s, was %s'
                          % (function_name, min_calls, max_calls, call_count))
-                         
+
+
 class VerifyOneFunctionWasCalled(LiveTabTestCase):
     """
     Verify that at least one of the functions matching the function name has 
@@ -106,4 +108,4 @@ class VerifyOneFunctionWasCalled(LiveTabTestCase):
                                  children[i].window_text(), call_count)
                     return
         
-        raise RuntimeError('No function matching "%s" has received the required hit count' % (function_name))
+        raise RuntimeError('No function matching "%s" has received the required hit count' % (function_name_contains))


### PR DESCRIPTION
All functions that match track names now require a perfect match with
the expected search string. Wildcards (*) are allowed to achieve the
previous functionality.

Affected tests have been adjusted accordingly.