### PR TITLE
Add build_id to module identification logic

### DIFF
--- a/src/ClientProtos/capture_data.proto
+++ b/src/ClientProtos/capture_data.proto
@@ -38,6 +38,7 @@ message FunctionInfo {
   string name = 1;
   string pretty_name = 2;
   string loaded_module_path = 3;
+  string loaded_module_build_id = 12;
   uint64 address = 5;
   uint64 size = 7;
   string file = 8;

--- a/src/ClientProtos/capture_data.proto
+++ b/src/ClientProtos/capture_data.proto
@@ -37,8 +37,8 @@ message FunctionInfo {
   reserved 4, 6, 11;
   string name = 1;
   string pretty_name = 2;
-  string loaded_module_path = 3;
-  string loaded_module_build_id = 12;
+  string module_path = 3;
+  string module_build_id = 12;
   uint64 address = 5;
   uint64 size = 7;
   string file = 8;

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -14,6 +14,7 @@ option cc_enable_arenas = true;
 
 message InstrumentedFunction {
   string file_path = 1;
+  string file_build_id = 6;
   uint64 file_offset = 2;
   uint64 function_id = 3;
 

--- a/src/OrbitCaptureClient/CaptureClient.cpp
+++ b/src/OrbitCaptureClient/CaptureClient.cpp
@@ -145,9 +145,11 @@ ErrorMessageOr<CaptureListener::CaptureOutcome> CaptureClient::CaptureSync(
   for (const auto& [function_id, function] : selected_functions) {
     InstrumentedFunction* instrumented_function = capture_options->add_instrumented_functions();
     instrumented_function->set_file_path(function.loaded_module_path());
-    const ModuleData* module = module_manager.GetModuleByPath(function.loaded_module_path());
+    const ModuleData* module = module_manager.GetModuleByPathAndBuildId(
+        function.loaded_module_path(), function.loaded_module_build_id());
     CHECK(module != nullptr);
     instrumented_function->set_file_offset(function_utils::Offset(function, *module));
+    instrumented_function->set_file_build_id(function.loaded_module_build_id());
     instrumented_function->set_function_id(function_id);
     instrumented_function->set_function_name(function.pretty_name());
     instrumented_function->set_function_type(

--- a/src/OrbitCaptureClient/CaptureClient.cpp
+++ b/src/OrbitCaptureClient/CaptureClient.cpp
@@ -144,12 +144,12 @@ ErrorMessageOr<CaptureListener::CaptureOutcome> CaptureClient::CaptureSync(
   absl::flat_hash_map<uint64_t, InstrumentedFunction> instrumented_functions;
   for (const auto& [function_id, function] : selected_functions) {
     InstrumentedFunction* instrumented_function = capture_options->add_instrumented_functions();
-    instrumented_function->set_file_path(function.loaded_module_path());
-    const ModuleData* module = module_manager.GetModuleByPathAndBuildId(
-        function.loaded_module_path(), function.loaded_module_build_id());
+    instrumented_function->set_file_path(function.module_path());
+    const ModuleData* module = module_manager.GetModuleByPathAndBuildId(function.module_path(),
+                                                                        function.module_build_id());
     CHECK(module != nullptr);
     instrumented_function->set_file_offset(function_utils::Offset(function, *module));
-    instrumented_function->set_file_build_id(function.loaded_module_build_id());
+    instrumented_function->set_file_build_id(function.module_build_id());
     instrumented_function->set_function_id(function_id);
     instrumented_function->set_function_name(function.pretty_name());
     instrumented_function->set_function_type(

--- a/src/OrbitClientData/FunctionInfoSetTest.cpp
+++ b/src/OrbitClientData/FunctionInfoSetTest.cpp
@@ -16,7 +16,8 @@ TEST(FunctionInfoSet, EqualFunctions) {
   FunctionInfo left;
   left.set_name("foo");
   left.set_pretty_name("void foo()");
-  left.set_loaded_module_path("/path/to/module");
+  left.set_module_path("/path/to/module");
+  left.set_module_build_id("buildid");
   left.set_address(12);
   left.set_size(16);
   left.set_file("file.cpp");
@@ -25,7 +26,8 @@ TEST(FunctionInfoSet, EqualFunctions) {
   FunctionInfo right;
   right.set_name("foo");
   right.set_pretty_name("void foo()");
-  right.set_loaded_module_path("/path/to/module");
+  right.set_module_path("/path/to/module");
+  right.set_module_build_id("buildid");
   right.set_address(12);
   right.set_size(16);
   right.set_file("file.cpp");
@@ -41,7 +43,8 @@ TEST(FunctionInfoSet, DifferentName) {
   FunctionInfo left;
   left.set_name("foo");
   left.set_pretty_name("void foo()");
-  left.set_loaded_module_path("/path/to/module");
+  left.set_module_path("/path/to/module");
+  left.set_module_build_id("buildid");
   left.set_address(12);
   left.set_size(16);
   left.set_file("file.cpp");
@@ -59,7 +62,8 @@ TEST(FunctionInfoSet, DifferentPrettyName) {
   FunctionInfo left;
   left.set_name("foo");
   left.set_pretty_name("void foo()");
-  left.set_loaded_module_path("/path/to/module");
+  left.set_module_path("/path/to/module");
+  left.set_module_build_id("buildid");
   left.set_address(12);
   left.set_size(16);
   left.set_file("file.cpp");
@@ -73,11 +77,12 @@ TEST(FunctionInfoSet, DifferentPrettyName) {
   EXPECT_TRUE(eq(left, right));
 }
 
-TEST(FunctionInfoSet, DifferentLoadedModulePath) {
+TEST(FunctionInfoSet, DifferentModulePath) {
   FunctionInfo left;
   left.set_name("foo");
   left.set_pretty_name("void foo()");
-  left.set_loaded_module_path("/path/to/module");
+  left.set_module_path("/path/to/module");
+  left.set_module_build_id("buildid");
   left.set_address(12);
   left.set_size(16);
   left.set_file("file.cpp");
@@ -85,7 +90,26 @@ TEST(FunctionInfoSet, DifferentLoadedModulePath) {
 
   FunctionInfo right;
   right.CopyFrom(left);
-  right.set_loaded_module_path("/path/to/other");
+  right.set_module_path("/path/to/other");
+
+  internal::EqualFunctionInfo eq;
+  EXPECT_FALSE(eq(left, right));
+}
+
+TEST(FunctionInfoSet, DifferentBuildId) {
+  FunctionInfo left;
+  left.set_name("foo");
+  left.set_pretty_name("void foo()");
+  left.set_module_path("/path/to/module");
+  left.set_module_build_id("buildid");
+  left.set_address(12);
+  left.set_size(16);
+  left.set_file("file.cpp");
+  left.set_line(13);
+
+  FunctionInfo right;
+  right.CopyFrom(left);
+  right.set_module_build_id("anotherbuildid");
 
   internal::EqualFunctionInfo eq;
   EXPECT_FALSE(eq(left, right));
@@ -95,7 +119,8 @@ TEST(FunctionInfoSet, DifferentAddress) {
   FunctionInfo left;
   left.set_name("foo");
   left.set_pretty_name("void foo()");
-  left.set_loaded_module_path("/path/to/module");
+  left.set_module_path("/path/to/module");
+  left.set_module_build_id("buildid");
   left.set_address(12);
   left.set_size(16);
   left.set_file("file.cpp");
@@ -113,7 +138,8 @@ TEST(FunctionInfoSet, DifferentSize) {
   FunctionInfo left;
   left.set_name("foo");
   left.set_pretty_name("void foo()");
-  left.set_loaded_module_path("/path/to/module");
+  left.set_module_path("/path/to/module");
+  left.set_module_build_id("buildid");
   left.set_address(12);
   left.set_size(16);
   left.set_file("file.cpp");
@@ -131,7 +157,8 @@ TEST(FunctionInfoSet, DifferentFile) {
   FunctionInfo left;
   left.set_name("foo");
   left.set_pretty_name("void foo()");
-  left.set_loaded_module_path("/path/to/module");
+  left.set_module_path("/path/to/module");
+  left.set_module_build_id("buildid");
   left.set_address(12);
   left.set_size(16);
   left.set_file("file.cpp");
@@ -149,7 +176,8 @@ TEST(FunctionInfoSet, DifferentLine) {
   FunctionInfo left;
   left.set_name("foo");
   left.set_pretty_name("void foo()");
-  left.set_loaded_module_path("/path/to/module");
+  left.set_module_path("/path/to/module");
+  left.set_module_build_id("buildid");
   left.set_address(12);
   left.set_size(16);
   left.set_file("file.cpp");
@@ -167,7 +195,8 @@ TEST(FunctionInfoSet, Insertion) {
   FunctionInfo function;
   function.set_name("foo");
   function.set_pretty_name("void foo()");
-  function.set_loaded_module_path("/path/to/module");
+  function.set_module_path("/path/to/module");
+  function.set_module_build_id("buildid");
   function.set_address(12);
   function.set_size(16);
   function.set_file("file.cpp");
@@ -187,7 +216,8 @@ TEST(FunctionInfoSet, Deletion) {
   FunctionInfo function;
   function.set_name("foo");
   function.set_pretty_name("void foo()");
-  function.set_loaded_module_path("/path/to/module");
+  function.set_module_path("/path/to/module");
+  function.set_module_build_id("buildid");
   function.set_address(12);
   function.set_size(16);
   function.set_file("file.cpp");

--- a/src/OrbitClientData/FunctionUtils.cpp
+++ b/src/OrbitClientData/FunctionUtils.cpp
@@ -26,7 +26,7 @@ using orbit_client_protos::FunctionInfo;
 using orbit_grpc_protos::SymbolInfo;
 
 std::string GetLoadedModuleName(const FunctionInfo& func) {
-  return GetLoadedModuleNameByPath(func.loaded_module_path());
+  return GetLoadedModuleNameByPath(func.module_path());
 }
 
 std::string GetLoadedModuleNameByPath(std::string_view module_path) {
@@ -58,8 +58,8 @@ std::unique_ptr<FunctionInfo> CreateFunctionInfo(const SymbolInfo& symbol_info,
   function_info->set_size(symbol_info.size());
   function_info->set_file("");
   function_info->set_line(0);
-  function_info->set_loaded_module_path(module_path);
-  function_info->set_loaded_module_build_id(module_build_id);
+  function_info->set_module_path(module_path);
+  function_info->set_module_build_id(module_build_id);
 
   SetOrbitTypeFromName(function_info.get());
   return function_info;

--- a/src/OrbitClientData/FunctionUtils.cpp
+++ b/src/OrbitClientData/FunctionUtils.cpp
@@ -48,7 +48,8 @@ bool IsOrbitFunctionFromName(const std::string& function_name) {
 }
 
 std::unique_ptr<FunctionInfo> CreateFunctionInfo(const SymbolInfo& symbol_info,
-                                                 const std::string& module_path) {
+                                                 const std::string& module_path,
+                                                 const std::string& module_build_id) {
   auto function_info = std::make_unique<FunctionInfo>();
 
   function_info->set_name(symbol_info.name());
@@ -58,6 +59,7 @@ std::unique_ptr<FunctionInfo> CreateFunctionInfo(const SymbolInfo& symbol_info,
   function_info->set_file("");
   function_info->set_line(0);
   function_info->set_loaded_module_path(module_path);
+  function_info->set_loaded_module_build_id(module_build_id);
 
   SetOrbitTypeFromName(function_info.get());
   return function_info;

--- a/src/OrbitClientData/ModuleDataTest.cpp
+++ b/src/OrbitClientData/ModuleDataTest.cpp
@@ -46,9 +46,11 @@ TEST(ModuleData, Constructor) {
 
 TEST(ModuleData, LoadSymbols) {
   // Setup ModuleData
+  constexpr const char* kBuildId = "build_id";
   std::string module_file_path = "/test/file/path";
   ModuleInfo module_info{};
   module_info.set_file_path(module_file_path);
+  module_info.set_build_id(kBuildId);
   ModuleData module{module_info};
 
   // Setup ModuleSymbols
@@ -73,7 +75,8 @@ TEST(ModuleData, LoadSymbols) {
   const FunctionInfo* function = module.GetFunctions()[0];
   EXPECT_EQ(function->name(), symbol_name);
   EXPECT_EQ(function->pretty_name(), symbol_pretty_name);
-  EXPECT_EQ(function->loaded_module_path(), module_file_path);
+  EXPECT_EQ(function->module_path(), module_file_path);
+  EXPECT_EQ(function->module_build_id(), kBuildId);
   EXPECT_EQ(function->address(), symbol_address);
   EXPECT_EQ(function->size(), symbol_size);
   EXPECT_EQ(function->file(), "");

--- a/src/OrbitClientData/UserDefinedCaptureDataTest.cpp
+++ b/src/OrbitClientData/UserDefinedCaptureDataTest.cpp
@@ -18,6 +18,7 @@ FunctionInfo CreateFunctionInfo(const std::string& function_name, uint64_t funct
   info.set_name(function_name);
   info.set_pretty_name(function_name);
   info.set_loaded_module_path("/path/to/module");
+  info.set_loaded_module_build_id("build id");
   info.set_address(function_address);
   info.set_size(16);
   info.set_file("file.cpp");

--- a/src/OrbitClientData/UserDefinedCaptureDataTest.cpp
+++ b/src/OrbitClientData/UserDefinedCaptureDataTest.cpp
@@ -17,8 +17,8 @@ FunctionInfo CreateFunctionInfo(const std::string& function_name, uint64_t funct
   FunctionInfo info;
   info.set_name(function_name);
   info.set_pretty_name(function_name);
-  info.set_loaded_module_path("/path/to/module");
-  info.set_loaded_module_build_id("build id");
+  info.set_module_path("/path/to/module");
+  info.set_module_build_id("build id");
   info.set_address(function_address);
   info.set_size(16);
   info.set_file("file.cpp");

--- a/src/OrbitClientData/include/OrbitClientData/FunctionInfoSet.h
+++ b/src/OrbitClientData/include/OrbitClientData/FunctionInfoSet.h
@@ -12,8 +12,10 @@
 namespace internal {
 struct HashFunctionInfo {
   size_t operator()(const orbit_client_protos::FunctionInfo& function) const {
-    return std::hash<uint64_t>{}(function.address()) * 37 +
-           std::hash<std::string>{}(function.loaded_module_path());
+    return (std::hash<uint64_t>{}(function.address()) * 37 +
+            std::hash<std::string>{}(function.module_build_id())) *
+               37 +
+           std::hash<std::string>{}(function.module_path());
   }
 };
 
@@ -21,8 +23,8 @@ struct HashFunctionInfo {
 struct EqualFunctionInfo {
   bool operator()(const orbit_client_protos::FunctionInfo& left,
                   const orbit_client_protos::FunctionInfo& right) const {
-    return left.loaded_module_path() == right.loaded_module_path() &&
-           left.address() == right.address();
+    return left.module_path() == right.module_path() &&
+           left.module_build_id() == right.module_build_id() && left.address() == right.address();
   }
 };
 

--- a/src/OrbitClientData/include/OrbitClientData/FunctionUtils.h
+++ b/src/OrbitClientData/include/OrbitClientData/FunctionUtils.h
@@ -33,8 +33,7 @@ namespace function_utils {
 [[nodiscard]] inline uint64_t GetAbsoluteAddress(const orbit_client_protos::FunctionInfo& func,
                                                  const ProcessData& process,
                                                  const ModuleData& module) {
-  return func.address() + process.GetModuleBaseAddress(func.loaded_module_path()) -
-         module.load_bias();
+  return func.address() + process.GetModuleBaseAddress(func.module_path()) - module.load_bias();
 }
 
 [[nodiscard]] bool IsOrbitFunctionFromType(

--- a/src/OrbitClientData/include/OrbitClientData/FunctionUtils.h
+++ b/src/OrbitClientData/include/OrbitClientData/FunctionUtils.h
@@ -43,7 +43,8 @@ namespace function_utils {
 [[nodiscard]] bool IsOrbitFunctionFromName(const std::string& function_name);
 
 [[nodiscard]] std::unique_ptr<orbit_client_protos::FunctionInfo> CreateFunctionInfo(
-    const orbit_grpc_protos::SymbolInfo& symbol_info, const std::string& module_path);
+    const orbit_grpc_protos::SymbolInfo& symbol_info, const std::string& module_path,
+    const std::string& module_build_id);
 
 [[nodiscard]] const absl::flat_hash_map<std::string, orbit_client_protos::FunctionInfo::OrbitType>&
 GetFunctionNameToOrbitTypeMap();

--- a/src/OrbitClientData/include/OrbitClientData/ModuleManager.h
+++ b/src/OrbitClientData/include/OrbitClientData/ModuleManager.h
@@ -21,8 +21,10 @@ class ModuleManager final {
  public:
   explicit ModuleManager() = default;
 
-  [[nodiscard]] const ModuleData* GetModuleByPath(const std::string& path) const;
-  [[nodiscard]] ModuleData* GetMutableModuleByPath(const std::string& path);
+  [[nodiscard]] const ModuleData* GetModuleByPathAndBuildId(const std::string& path,
+                                                            const std::string& build_id) const;
+  [[nodiscard]] ModuleData* GetMutableModuleByPathAndBuildId(const std::string& path,
+                                                             const std::string& build_id);
   // Add new modules for the module_infos that do not exist yet, and update the modules that do
   // exist. If the update changed the module in a way that symbols were not valid anymore, the
   // symbols are discarded aka the module is not loaded anymore. This method returns the list of
@@ -35,7 +37,8 @@ class ModuleManager final {
  private:
   mutable absl::Mutex mutex_;
   // We are sharing pointers to that entries and ensure reference stability by using node_hash_map
-  absl::node_hash_map<std::string, ModuleData> module_map_;
+  // Map of <path, build_id> -> ModuleData
+  absl::node_hash_map<std::pair<std::string, std::string>, ModuleData> module_map_;
 };
 
 }  // namespace orbit_client_data

--- a/src/OrbitClientModel/CaptureData.cpp
+++ b/src/OrbitClientModel/CaptureData.cpp
@@ -77,11 +77,11 @@ const InstrumentedFunction* CaptureData::GetInstrumentedFunctionById(uint64_t fu
 
 std::optional<uint64_t> CaptureData::FindInstrumentedFunctionIdSlow(
     const orbit_client_protos::FunctionInfo& function) const {
-  const ModuleData* module = module_manager_->GetModuleByPathAndBuildId(
-      function.loaded_module_path(), function.loaded_module_build_id());
+  const ModuleData* module = module_manager_->GetModuleByPathAndBuildId(function.module_path(),
+                                                                        function.module_build_id());
   for (const auto& it : instrumented_functions_) {
     const auto& target_function = it.second;
-    if (target_function.file_path() == function.loaded_module_path() &&
+    if (target_function.file_path() == function.module_path() &&
         target_function.file_offset() == function_utils::Offset(function, *module)) {
       return it.first;
     }
@@ -210,8 +210,8 @@ const FunctionInfo* CaptureData::FindFunctionByAddress(uint64_t absolute_address
 }
 
 uint64_t CaptureData::GetAbsoluteAddress(const orbit_client_protos::FunctionInfo& function) const {
-  const ModuleData* module = module_manager_->GetModuleByPathAndBuildId(
-      function.loaded_module_path(), function.loaded_module_build_id());
+  const ModuleData* module = module_manager_->GetModuleByPathAndBuildId(function.module_path(),
+                                                                        function.module_build_id());
   CHECK(module != nullptr);
   return function_utils::GetAbsoluteAddress(function, process_, *module);
 }

--- a/src/OrbitClientModel/CaptureDeserializer.cpp
+++ b/src/OrbitClientModel/CaptureDeserializer.cpp
@@ -160,15 +160,15 @@ ErrorMessageOr<CaptureListener::CaptureOutcome> LoadCaptureInfo(
     orbit_grpc_protos::InstrumentedFunction instrumented_function;
     instrumented_function.set_function_id(function.first);
     instrumented_function.set_function_name(function.second.pretty_name());
-    instrumented_function.set_file_path(function.second.loaded_module_path());
+    instrumented_function.set_file_path(function.second.module_path());
     const ModuleData* module_data = module_manager->GetModuleByPathAndBuildId(
-        function.second.loaded_module_path(), function.second.loaded_module_build_id());
+        function.second.module_path(), function.second.module_build_id());
 
     // In the case module_data was not found by build id check if FunctionInfo build_id is empty,
     // in which case assume this is capture saved with Orbit v1.61 and below try to get module
     // build id from path and do another lookup.
-    if (module_data == nullptr && function.second.loaded_module_build_id().empty()) {
-      const std::string& module_path = function.second.loaded_module_path();
+    if (module_data == nullptr && function.second.module_build_id().empty()) {
+      const std::string& module_path = function.second.module_path();
       CHECK(module_map.contains(module_path));
       const std::string& build_id = module_map.at(module_path).build_id();
       module_data = module_manager->GetModuleByPathAndBuildId(module_path, build_id);

--- a/src/OrbitClientModel/CaptureDeserializerTest.cpp
+++ b/src/OrbitClientModel/CaptureDeserializerTest.cpp
@@ -190,10 +190,12 @@ TEST(CaptureDeserializer, LoadCaptureInfoOnCaptureStarted) {
   process_info->set_name("process");
 
   constexpr uint64_t kLoadBias = 5;
+  constexpr const char* kModuleBuildId = "build_id";
   orbit_client_protos::ModuleInfo* module_info = capture_info.add_modules();
   module_info->set_load_bias(kLoadBias);
   module_info->set_name("module");
   module_info->set_file_path("path/to/module");
+  module_info->set_build_id(kModuleBuildId);
   module_info->set_address_start(10);
   module_info->set_address_end(123);
 
@@ -201,7 +203,8 @@ TEST(CaptureDeserializer, LoadCaptureInfoOnCaptureStarted) {
   FunctionInfo instrumented_function;
   instrumented_function.set_name("foo");
   instrumented_function.set_pretty_name("void foo()");
-  instrumented_function.set_loaded_module_path("path/to/module");
+  instrumented_function.set_module_path("path/to/module");
+  instrumented_function.set_module_build_id(kModuleBuildId);
   instrumented_function.set_address(21);
   instrumented_function.set_size(12);
   (*capture_info.mutable_instrumented_functions())[kInstrumentedFunctionId] = instrumented_function;
@@ -229,9 +232,8 @@ TEST(CaptureDeserializer, LoadCaptureInfoOnCaptureStarted) {
             actual_instrumented_functions.at(kInstrumentedFunctionId);
 
         EXPECT_EQ(actual_function_info.function_name(), instrumented_function.pretty_name());
-        EXPECT_EQ(actual_function_info.file_path(), instrumented_function.loaded_module_path());
-        EXPECT_EQ(actual_function_info.file_build_id(),
-                  instrumented_function.loaded_module_build_id());
+        EXPECT_EQ(actual_function_info.file_path(), instrumented_function.module_path());
+        EXPECT_EQ(actual_function_info.file_build_id(), instrumented_function.module_build_id());
         EXPECT_EQ(actual_function_info.file_offset(), instrumented_function.address() - load_bias);
       });
 

--- a/src/OrbitClientModel/CaptureSerializer.cpp
+++ b/src/OrbitClientModel/CaptureSerializer.cpp
@@ -138,7 +138,7 @@ CaptureInfo GenerateCaptureInfo(
     uint64_t absolute_function_address = capture_data.GetAbsoluteAddress(*function);
     const uint64_t offset = absolute_address - absolute_function_address;
     added_address_info->set_offset_in_function(offset);
-    added_address_info->set_module_path(function->loaded_module_path());
+    added_address_info->set_module_path(function->module_path());
   }
 
   const absl::flat_hash_map<uint64_t, FunctionStats>& functions_stats =

--- a/src/OrbitClientModel/CaptureSerializerTest.cpp
+++ b/src/OrbitClientModel/CaptureSerializerTest.cpp
@@ -89,10 +89,12 @@ TEST(CaptureSerializer, GenerateCaptureInfo) {
   ProcessData process(process_info);
 
   constexpr const char* kModulePath = "path/to/module";
+  constexpr const char* kModuleBuildId = "build_id_id";
 
   orbit_grpc_protos::ModuleInfo module_info;
   module_info.set_load_bias(0);
   module_info.set_file_path(kModulePath);
+  module_info.set_build_id(kModuleBuildId);
   module_info.set_address_start(15);
   module_info.set_address_end(1000);
 
@@ -100,7 +102,7 @@ TEST(CaptureSerializer, GenerateCaptureInfo) {
   process.UpdateModuleInfos(module_infos);
   ModuleManager module_manager;
   module_manager.AddOrUpdateModules(module_infos);
-  ModuleData* module = module_manager.GetMutableModuleByPath(kModulePath);
+  ModuleData* module = module_manager.GetMutableModuleByPathAndBuildId(kModulePath, kModuleBuildId);
   ASSERT_NE(module, nullptr);
 
   orbit_grpc_protos::ModuleSymbols symbols;
@@ -119,6 +121,7 @@ TEST(CaptureSerializer, GenerateCaptureInfo) {
   instrumented_function.set_function_name("void foo()");
   instrumented_function.set_file_offset(123);
   instrumented_function.set_file_path(kModulePath);
+  instrumented_function.set_file_build_id(kModuleBuildId);
   uint64_t selected_function_absolute_address = 123 + 15 - 0;
   instrumented_functions[kInstrumentedFunctionId] = instrumented_function;
 

--- a/src/OrbitClientModel/include/OrbitClientModel/CaptureData.h
+++ b/src/OrbitClientModel/include/OrbitClientModel/CaptureData.h
@@ -89,11 +89,14 @@ class CaptureData {
   [[nodiscard]] const std::string& GetFunctionNameByAddress(uint64_t absolute_address) const;
   [[nodiscard]] std::optional<uint64_t> FindFunctionAbsoluteAddressByAddress(
       uint64_t absolute_address) const;
-  [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionByModulePathAndOffset(
-      const std::string& module_path, uint64_t offset) const;
+  [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionByModulePathBuildIdAndOffset(
+      const std::string& module_path, const std::string& build_id, uint64_t offset) const;
   [[nodiscard]] const std::string& GetModulePathByAddress(uint64_t absolute_address) const;
-  [[nodiscard]] const ModuleData* GetModuleByPath(const std::string& module_path) const {
-    return module_manager_->GetModuleByPath(module_path);
+  [[nodiscard]] std::optional<std::string> FindModuleBuildIdByAddress(
+      uint64_t absolute_address) const;
+  [[nodiscard]] const ModuleData* GetModuleByPathAndBuildId(const std::string& module_path,
+                                                            const std::string& build_id) const {
+    return module_manager_->GetModuleByPathAndBuildId(module_path, build_id);
   }
 
   [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionByAddress(

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -532,8 +532,8 @@ void OrbitApp::RenderImGuiDebugUI() {
 
 void OrbitApp::Disassemble(int32_t pid, const FunctionInfo& function) {
   CHECK(process_ != nullptr);
-  const ModuleData* module = module_manager_->GetModuleByPathAndBuildId(
-      function.loaded_module_path(), function.loaded_module_build_id());
+  const ModuleData* module = module_manager_->GetModuleByPathAndBuildId(function.module_path(),
+                                                                        function.module_build_id());
   CHECK(module != nullptr);
   const bool is_64_bit = process_->is_64_bit();
   const uint64_t absolute_address =
@@ -566,8 +566,8 @@ void OrbitApp::Disassemble(int32_t pid, const FunctionInfo& function) {
 }
 
 void OrbitApp::ShowSourceCode(const orbit_client_protos::FunctionInfo& function) {
-  const ModuleData* module = module_manager_->GetModuleByPathAndBuildId(
-      function.loaded_module_path(), function.loaded_module_build_id());
+  const ModuleData* module = module_manager_->GetModuleByPathAndBuildId(function.module_path(),
+                                                                        function.module_build_id());
 
   auto loaded_module = RetrieveModuleWithDebugInfo(module);
 
@@ -789,13 +789,13 @@ ErrorMessageOr<void> OrbitApp::SavePreset(const std::string& filename) {
     CHECK(!function_utils::IsOrbitFunctionFromType(function.orbit_type()));
 
     uint64_t hash = function_utils::GetHash(function);
-    (*preset.mutable_path_to_module())[function.loaded_module_path()].add_function_hashes(hash);
+    (*preset.mutable_path_to_module())[function.module_path()].add_function_hashes(hash);
   }
 
   for (const auto& function : data_manager_->user_defined_capture_data().frame_track_functions()) {
     uint64_t hash = function_utils::GetHash(function);
-    (*preset.mutable_path_to_module())[function.loaded_module_path()]
-        .add_frame_track_function_hashes(hash);
+    (*preset.mutable_path_to_module())[function.module_path()].add_frame_track_function_hashes(
+        hash);
   }
 
   std::string filename_with_ext = filename;
@@ -954,7 +954,7 @@ void OrbitApp::StartCapture() {
   uint64_t function_id = 1;
   for (auto& function : selected_functions) {
     const ModuleData* module = module_manager_->GetModuleByPathAndBuildId(
-        function.loaded_module_path(), function.loaded_module_build_id());
+        function.module_path(), function.module_build_id());
     CHECK(module != nullptr);
     if (user_defined_capture_data.ContainsFrameTrack(function)) {
       frame_track_function_ids.insert(function_id);
@@ -1574,8 +1574,8 @@ orbit_base::Future<std::vector<ErrorMessageOr<void>>> OrbitApp::ReloadModules(
 
   absl::flat_hash_map<std::string, std::vector<uint64_t>> function_hashes_to_hook_map;
   for (const FunctionInfo& func : data_manager_->GetSelectedFunctions()) {
-    const ModuleData* module = module_manager_->GetModuleByPathAndBuildId(
-        func.loaded_module_path(), func.loaded_module_build_id());
+    const ModuleData* module =
+        module_manager_->GetModuleByPathAndBuildId(func.module_path(), func.module_build_id());
     // (A) deselect functions when the module is not loaded by the process anymore
     if (!process->IsModuleLoaded(module->file_path())) {
       data_manager_->DeselectFunction(func);
@@ -1589,8 +1589,8 @@ orbit_base::Future<std::vector<ErrorMessageOr<void>>> OrbitApp::ReloadModules(
   absl::flat_hash_map<std::string, std::vector<uint64_t>> frame_track_function_hashes_map;
   for (const FunctionInfo& func :
        data_manager_->user_defined_capture_data().frame_track_functions()) {
-    const ModuleData* module = module_manager_->GetModuleByPathAndBuildId(
-        func.loaded_module_path(), func.loaded_module_build_id());
+    const ModuleData* module =
+        module_manager_->GetModuleByPathAndBuildId(func.module_path(), func.module_build_id());
     // Frame tracks are only meaningful if the module for the underlying function is actually
     // loaded by the process.
     if (!process->IsModuleLoaded(module->file_path())) {
@@ -1648,7 +1648,7 @@ void OrbitApp::SetMaxLocalMarkerDepthPerCommandBuffer(
 
 void OrbitApp::SelectFunction(const orbit_client_protos::FunctionInfo& func) {
   LOG("Selected %s (address_=0x%" PRIx64 ", loaded_module_path_=%s)", func.pretty_name(),
-      func.address(), func.loaded_module_path());
+      func.address(), func.module_path());
   data_manager_->SelectFunction(func);
 }
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -355,11 +355,13 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   [[nodiscard]] ManualInstrumentationManager* GetManualInstrumentationManager() {
     return manual_instrumentation_manager_.get();
   }
-  [[nodiscard]] ModuleData* GetMutableModuleByPath(const std::string& path) const {
-    return module_manager_->GetMutableModuleByPath(path);
+  [[nodiscard]] ModuleData* GetMutableModuleByPathAndBuildId(const std::string& path,
+                                                             const std::string& build_id) const {
+    return module_manager_->GetMutableModuleByPathAndBuildId(path, build_id);
   }
-  [[nodiscard]] const ModuleData* GetModuleByPath(const std::string& path) const {
-    return module_manager_->GetModuleByPath(path);
+  [[nodiscard]] const ModuleData* GetModuleByPathAndBuildId(const std::string& path,
+                                                            const std::string& build_id) const {
+    return module_manager_->GetModuleByPathAndBuildId(path, build_id);
   }
 
   void SetCollectThreadStates(bool collect_thread_states);
@@ -438,7 +440,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   [[nodiscard]] bool HasFrameTrackInCaptureData(uint64_t instrumented_function_id) const;
 
  private:
-  void AddSymbols(const std::filesystem::path& module_file_path,
+  void AddSymbols(const std::filesystem::path& module_file_path, const std::string& module_build_id,
                   const orbit_grpc_protos::ModuleSymbols& symbols);
 
   [[nodiscard]] orbit_base::Future<ErrorMessageOr<std::filesystem::path>> RetrieveModuleFromRemote(
@@ -450,7 +452,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   ErrorMessageOr<std::filesystem::path> FindModuleLocally(const std::filesystem::path& module_path,
                                                           const std::string& build_id);
   [[nodiscard]] orbit_base::Future<ErrorMessageOr<void>> LoadSymbols(
-      const std::filesystem::path& symbols_path, const std::string& module_file_path);
+      const std::filesystem::path& symbols_path, const std::string& module_file_path,
+      const std::string& module_build_id);
 
   ErrorMessageOr<orbit_client_protos::PresetInfo> ReadPresetFromFile(
       const std::filesystem::path& filename);
@@ -510,9 +513,10 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   std::shared_ptr<SamplingReport> sampling_report_;
   std::shared_ptr<SamplingReport> selection_report_ = nullptr;
 
-  absl::flat_hash_map<std::string, orbit_base::Future<ErrorMessageOr<std::filesystem::path>>>
+  absl::flat_hash_map<std::pair<std::string, std::string>,
+                      orbit_base::Future<ErrorMessageOr<std::filesystem::path>>>
       modules_currently_loading_;
-  absl::flat_hash_map<std::string, orbit_base::Future<ErrorMessageOr<void>>>
+  absl::flat_hash_map<std::pair<std::string, std::string>, orbit_base::Future<ErrorMessageOr<void>>>
       symbols_currently_loading_;
 
   StringManager string_manager_;

--- a/src/OrbitGl/CallTreeView.h
+++ b/src/OrbitGl/CallTreeView.h
@@ -41,7 +41,8 @@ class CallTreeNode {
 
   [[nodiscard]] CallTreeFunction* AddAndGetFunction(uint64_t function_absolute_address,
                                                     std::string function_name,
-                                                    std::string module_path);
+                                                    std::string module_path,
+                                                    std::string module_build_id);
 
   [[nodiscard]] uint64_t sample_count() const { return sample_count_; }
 
@@ -80,17 +81,21 @@ class CallTreeNode {
 class CallTreeFunction : public CallTreeNode {
  public:
   explicit CallTreeFunction(uint64_t function_absolute_address, std::string function_name,
-                            std::string module_path, CallTreeNode* parent)
+                            std::string module_path, std::string module_build_id,
+                            CallTreeNode* parent)
       : CallTreeNode{parent},
         function_absolute_address_{function_absolute_address},
         function_name_{std::move(function_name)},
-        module_path_{std::move(module_path)} {}
+        module_path_{std::move(module_path)},
+        module_build_id_{std::move(module_build_id)} {}
 
   [[nodiscard]] uint64_t function_absolute_address() const { return function_absolute_address_; }
 
   [[nodiscard]] const std::string& function_name() const { return function_name_; }
 
   [[nodiscard]] const std::string& module_path() const { return module_path_; }
+
+  [[nodiscard]] const std::string& module_build_id() const { return module_build_id_; }
 
   [[nodiscard]] std::string GetModuleName() const {
     return std::filesystem::path(module_path()).filename().string();
@@ -100,6 +105,7 @@ class CallTreeFunction : public CallTreeNode {
   uint64_t function_absolute_address_;
   std::string function_name_;
   std::string module_path_;
+  std::string module_build_id_;
 };
 
 class CallTreeThread : public CallTreeNode {

--- a/src/OrbitGl/FunctionsDataView.cpp
+++ b/src/OrbitGl/FunctionsDataView.cpp
@@ -121,7 +121,8 @@ std::string FunctionsDataView::GetValue(int row, int column) {
         CHECK(!app_->IsCaptureConnected(capture_data));
       }
       CHECK(process != nullptr);
-      const ModuleData* module = app_->GetModuleByPath(function.loaded_module_path());
+      const ModuleData* module = app_->GetModuleByPathAndBuildId(function.loaded_module_path(),
+                                                                 function.loaded_module_build_id());
       CHECK(module != nullptr);
       return absl::StrFormat("0x%llx",
                              function_utils::GetAbsoluteAddress(function, *process, *module));

--- a/src/OrbitGl/FunctionsDataView.cpp
+++ b/src/OrbitGl/FunctionsDataView.cpp
@@ -121,8 +121,8 @@ std::string FunctionsDataView::GetValue(int row, int column) {
         CHECK(!app_->IsCaptureConnected(capture_data));
       }
       CHECK(process != nullptr);
-      const ModuleData* module = app_->GetModuleByPathAndBuildId(function.loaded_module_path(),
-                                                                 function.loaded_module_build_id());
+      const ModuleData* module =
+          app_->GetModuleByPathAndBuildId(function.module_path(), function.module_build_id());
       CHECK(module != nullptr);
       return absl::StrFormat("0x%llx",
                              function_utils::GetAbsoluteAddress(function, *process, *module));

--- a/src/OrbitGl/LiveFunctionsDataView.cpp
+++ b/src/OrbitGl/LiveFunctionsDataView.cpp
@@ -405,9 +405,11 @@ void LiveFunctionsDataView::OnDataChanged() {
 
   const absl::flat_hash_map<uint64_t, orbit_grpc_protos::InstrumentedFunction>&
       instrumented_functions = app_->GetCaptureData().instrumented_functions();
-  for (const auto& pair : instrumented_functions) {
-    const FunctionInfo* function_info = app_->GetCaptureData().FindFunctionByModulePathAndOffset(
-        pair.second.file_path(), pair.second.file_offset());
+  for (const auto& [function_id, instrumented_function] : instrumented_functions) {
+    const FunctionInfo* function_info =
+        app_->GetCaptureData().FindFunctionByModulePathBuildIdAndOffset(
+            instrumented_function.file_path(), instrumented_function.file_build_id(),
+            instrumented_function.file_offset());
 
     // Likely because module has not yet been updated - skip for now
     if (function_info == nullptr) {
@@ -418,8 +420,8 @@ void LiveFunctionsDataView::OnDataChanged() {
       continue;
     }
 
-    functions_.insert_or_assign(pair.first, *function_info);
-    indices_.push_back(pair.first);
+    functions_.insert_or_assign(function_id, *function_info);
+    indices_.push_back(function_id);
   }
 
   DataView::OnDataChanged();

--- a/src/OrbitGl/LiveFunctionsDataView.cpp
+++ b/src/OrbitGl/LiveFunctionsDataView.cpp
@@ -95,7 +95,7 @@ std::string LiveFunctionsDataView::GetValue(int row, int column) {
     case kColumnTimeMax:
       return GetPrettyTime(absl::Nanoseconds(stats.max_ns()));
     case kColumnModule:
-      return function.loaded_module_path();
+      return function.module_path();
     case kColumnAddress: {
       const CaptureData& capture_data = app_->GetCaptureData();
       return absl::StrFormat("0x%" PRIx64, capture_data.GetAbsoluteAddress(function));

--- a/src/OrbitGl/ModulesDataView.h
+++ b/src/OrbitGl/ModulesDataView.h
@@ -46,7 +46,7 @@ class ModulesDataView : public DataView {
   [[nodiscard]] ModuleData* GetModule(uint32_t row) const { return modules_[indices_[row]]; }
 
   std::vector<ModuleData*> modules_;
-  absl::flat_hash_map<const ModuleData*, const MemorySpace*> module_memory_;
+  absl::flat_hash_map<const ModuleData*, const ModuleInMemory*> module_memory_;
 
   enum ColumnIndex {
     kColumnName,

--- a/src/OrbitGl/SamplingReportDataView.h
+++ b/src/OrbitGl/SamplingReportDataView.h
@@ -51,8 +51,8 @@ class SamplingReportDataView : public DataView {
   SampledFunction& GetSampledFunction(unsigned int row);
   absl::flat_hash_set<const orbit_client_protos::FunctionInfo*> GetFunctionsFromIndices(
       const std::vector<int>& indices);
-  [[nodiscard]] absl::flat_hash_set<std::string> GetModulePathsFromIndices(
-      const std::vector<int>& indices) const;
+  [[nodiscard]] absl::flat_hash_set<std::pair<std::string, std::string>>
+  GetModulePathsAndBuildIdsFromIndices(const std::vector<int>& indices) const;
 
  private:
   void UpdateSelectedIndicesAndFunctionIds(const std::vector<int>& selected_indices);

--- a/src/OrbitQt/CallTreeViewItemModel.cpp
+++ b/src/OrbitQt/CallTreeViewItemModel.cpp
@@ -130,9 +130,19 @@ QVariant CallTreeViewItemModel::GetToolTipRoleData(const QModelIndex& index) con
 QVariant CallTreeViewItemModel::GetModulePathRoleData(const QModelIndex& index) const {
   CHECK(index.isValid());
   auto* item = static_cast<CallTreeNode*>(index.internalPointer());
-  auto function_item = dynamic_cast<CallTreeFunction*>(item);
+  auto* function_item = dynamic_cast<CallTreeFunction*>(item);
   if (function_item != nullptr) {
     return QString::fromStdString(function_item->module_path());
+  }
+  return QVariant();
+}
+
+QVariant CallTreeViewItemModel::GetModuleBuildIdRoleData(const QModelIndex& index) const {
+  CHECK(index.isValid());
+  auto* item = static_cast<CallTreeNode*>(index.internalPointer());
+  auto* function_item = dynamic_cast<CallTreeFunction*>(item);
+  if (function_item != nullptr) {
+    return QString::fromStdString(function_item->module_build_id());
   }
   return QVariant();
 }
@@ -152,6 +162,8 @@ QVariant CallTreeViewItemModel::data(const QModelIndex& index, int role) const {
       return GetToolTipRoleData(index);
     case kModulePathRole:
       return GetModulePathRoleData(index);
+    case kModuleBuildIdRole:
+      return GetModuleBuildIdRoleData(index);
   }
   return QVariant();
 }

--- a/src/OrbitQt/CallTreeViewItemModel.h
+++ b/src/OrbitQt/CallTreeViewItemModel.h
@@ -41,12 +41,14 @@ class CallTreeViewItemModel : public QAbstractItemModel {
   };
 
   static const int kModulePathRole = Qt::UserRole + 1;
+  static const int kModuleBuildIdRole = Qt::UserRole + 2;
 
  private:
   [[nodiscard]] QVariant GetDisplayRoleData(const QModelIndex& index) const;
   [[nodiscard]] QVariant GetEditRoleData(const QModelIndex& index) const;
   [[nodiscard]] QVariant GetToolTipRoleData(const QModelIndex& index) const;
   [[nodiscard]] QVariant GetModulePathRoleData(const QModelIndex& index) const;
+  [[nodiscard]] QVariant GetModuleBuildIdRoleData(const QModelIndex& index) const;
 
   std::unique_ptr<CallTreeView> call_tree_view_;
 };

--- a/src/OrbitQt/CallTreeWidget.cpp
+++ b/src/OrbitQt/CallTreeWidget.cpp
@@ -308,20 +308,20 @@ static void CollapseChildrenRecursively(QTreeView* tree_view, const QModelIndex&
 
 static std::vector<ModuleData*> GetModulesFromIndices(OrbitApp* app,
                                                       const std::vector<QModelIndex>& indices) {
-  std::set<std::string> unique_module_paths;
+  std::set<std::pair<std::string, std::string>> unique_module_paths_and_build_ids;
   for (const auto& index : indices) {
+    QModelIndex model_index =
+        index.model()->index(index.row(), CallTreeViewItemModel::kModule, index.parent());
     std::string module_path =
-        index.model()
-            ->index(index.row(), CallTreeViewItemModel::kModule, index.parent())
-            .data(CallTreeViewItemModel::kModulePathRole)
-            .toString()
-            .toStdString();
-    unique_module_paths.insert(module_path);
+        model_index.data(CallTreeViewItemModel::kModulePathRole).toString().toStdString();
+    std::string module_build_id =
+        model_index.data(CallTreeViewItemModel::kModuleBuildIdRole).toString().toStdString();
+    unique_module_paths_and_build_ids.emplace(module_path, module_build_id);
   }
 
   std::vector<ModuleData*> modules;
-  for (const std::string& module_path : unique_module_paths) {
-    ModuleData* module = app->GetMutableModuleByPath(module_path);
+  for (const auto& [module_path, module_build_id] : unique_module_paths_and_build_ids) {
+    ModuleData* module = app->GetMutableModuleByPathAndBuildId(module_path, module_build_id);
     if (module != nullptr) {
       modules.emplace_back(module);
     }


### PR DESCRIPTION
Modules are now identified by path and build_id instead of
being identified by path alone.

Bug: http://b/183381209
Bug: http://b/183380723
Test: Start orbit, instrument functions, caprue, inspect callstacks,
      callgraphs, frame tracks. Select/unselect functions.