### PR TITLE
Make Track's TriangleToggle Accessible.

### DIFF
--- a/src/OrbitGl/AccessibleTrack.cpp
+++ b/src/OrbitGl/AccessibleTrack.cpp
@@ -146,12 +146,21 @@ AccessibilityState AccessibleTrackTab::AccessibleState() const {
   return AccessibilityState::Normal;
 }
 
-int AccessibleTrack::AccessibleChildCount() const { return 2; }
+int AccessibleTrack::AccessibleChildCount() const {
+  int child_count = track_->GetVisibleChildren().size();
+  return child_count + 2;
+}
 
 const AccessibleInterface* AccessibleTrack::AccessibleChild(int index) const {
-  if (index == 0) {
+  int child_count = track_->GetVisibleChildren().size();
+  std::vector<orbit_gl::CaptureViewElement*> children = track_->GetVisibleChildren();
+  if (index < child_count) {
+    return children[index]->GetAccessibleInterface();
+  }
+  if (index == child_count) {
     return &tab_;
   }
+  CHECK(index == child_count + 1);
   return &content_;
 }
 

--- a/src/OrbitGl/AccessibleTriangleToggle.cpp
+++ b/src/OrbitGl/AccessibleTriangleToggle.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "AccessibleTriangleToggle.h"
+
+#include "CoreMath.h"
+#include "GlCanvas.h"
+
+namespace orbit_gl {
+
+orbit_accessibility::AccessibilityRect AccessibleTriangleToggle::AccessibleLocalRect() const {
+  CHECK(triangle_toggle_ != nullptr);
+  CHECK(triangle_toggle_->GetCanvas() != nullptr);
+
+  GlCanvas* canvas = triangle_toggle_->GetCanvas();
+  Vec2 pos = triangle_toggle_->GetPos();
+  Vec2 size = triangle_toggle_->GetSize();
+
+  Vec2 screen_pos = canvas->WorldToScreen(pos);
+  int screen_width = canvas->WorldToScreenWidth(size[0]);
+  int screen_height = canvas->WorldToScreenHeight(size[1]);
+
+  // Adjust the coordinates to clamp the result to an on-screen rect
+  // This will "cut" any part that is offscreen due to scrolling, and may result
+  // in a final result with width / height of 0.
+
+  // First: Clamp bottom
+  if (screen_pos[1] + screen_height > canvas->GetHeight()) {
+    screen_height = std::max(0, canvas->GetHeight() - static_cast<int>(screen_pos[1]));
+  }
+  // Second: Clamp top
+  if (screen_pos[1] < 0) {
+    screen_height = std::max(0, static_cast<int>(screen_pos[1]) + screen_height);
+    screen_pos[1] = 0;
+  }
+
+  orbit_accessibility::AccessibilityRect parent_rect =
+      parent_->GetOrCreateAccessibleInterface()->AccessibleLocalRect();
+
+  return orbit_accessibility::AccessibilityRect(static_cast<int>(screen_pos[0]) - parent_rect.left,
+                                                static_cast<int>(screen_pos[1]) - parent_rect.top,
+                                                screen_width, screen_height);
+}
+
+orbit_accessibility::AccessibilityState AccessibleTriangleToggle::AccessibleState() const {
+  if (triangle_toggle_->IsInactive()) {
+    return orbit_accessibility::AccessibilityState::Disabled;
+  }
+  return orbit_accessibility::AccessibilityState::Normal;
+}
+
+const orbit_accessibility::AccessibleInterface* AccessibleTriangleToggle::AccessibleParent() const {
+  return parent_->GetOrCreateAccessibleInterface();
+}
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/AccessibleTriangleToggle.h
+++ b/src/OrbitGl/AccessibleTriangleToggle.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_ACCESSIBLE_TRIANGLE_TOGGLE_H_
+#define ORBIT_GL_ACCESSIBLE_TRIANGLE_TOGGLE_H_
+
+#include "CaptureViewElement.h"
+#include "OrbitAccessibility/AccessibleInterface.h"
+
+class TriangleToggle;
+
+namespace orbit_gl {
+
+/*
+ * Accessibility implementation for (a track's) triangle toggle. The `TriangleToggle` is a visible
+ * child of the track. It will be thus on the same level as the virtual elements for the tab and the
+ * content (see `AccessibleTrack`).
+ */
+class AccessibleTriangleToggle : public orbit_accessibility::AccessibleInterface {
+ public:
+  explicit AccessibleTriangleToggle(TriangleToggle* triangle_toggle, CaptureViewElement* parent)
+      : triangle_toggle_{triangle_toggle}, parent_{parent} {};
+
+  [[nodiscard]] int AccessibleChildCount() const override { return 0; };
+  [[nodiscard]] const AccessibleInterface* AccessibleChild(int /*index*/) const override {
+    return nullptr;
+  }
+  [[nodiscard]] const AccessibleInterface* AccessibleParent() const override;
+
+  [[nodiscard]] std::string AccessibleName() const override { return "TriangleToggle"; }
+
+  [[nodiscard]] orbit_accessibility::AccessibilityRole AccessibleRole() const override {
+    return orbit_accessibility::AccessibilityRole::Graphic;
+  }
+
+  [[nodiscard]] orbit_accessibility::AccessibilityRect AccessibleLocalRect() const override;
+  [[nodiscard]] orbit_accessibility::AccessibilityState AccessibleState() const override;
+
+ private:
+  TriangleToggle* triangle_toggle_;
+  CaptureViewElement* parent_;
+};
+
+}  // namespace orbit_gl
+
+#endif  // ORBIT_GL_ACCESSIBLE_TRIANGLE_TOGGLE_H_

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(
   PUBLIC AccessibleThreadBar.h
          AccessibleTimeGraph.h
          AccessibleTrack.h
+         AccessibleTriangleToggle.h
          App.h
          AsyncTrack.h
          Batcher.h
@@ -78,6 +79,7 @@ target_sources(
   PRIVATE AccessibleThreadBar.cpp
           AccessibleTimeGraph.cpp
           AccessibleTrack.cpp
+          AccessibleTriangleToggle.cpp
           App.cpp
           AsyncTrack.cpp
           Batcher.cpp

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -22,7 +22,8 @@ Track::Track(TimeGraph* time_graph, TimeGraphLayout* layout, const CaptureData* 
     : CaptureViewElement(time_graph, layout),
       collapse_toggle_(std::make_shared<TriangleToggle>(
           TriangleToggle::State::kExpanded,
-          [this](TriangleToggle::State state) { OnCollapseToggle(state); }, time_graph, layout)),
+          [this](TriangleToggle::State state) { OnCollapseToggle(state); }, time_graph, layout,
+          this)),
       layout_(layout),
       capture_data_(capture_data) {
   const Color kDarkGrey(50, 50, 50, 255);
@@ -207,4 +208,12 @@ void Track::OnDrag(int x, int y) {
 
   pos_[1] = mouse_pos_cur_[1] - picking_offset_[1];
   time_graph_->VerticallyMoveIntoView(*this);
+}
+
+std::vector<orbit_gl::CaptureViewElement*> Track::GetVisibleChildren() {
+  std::vector<CaptureViewElement*> result;
+
+  result.push_back(collapse_toggle_.get());
+
+  return result;
 }

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -95,7 +95,7 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
 
   [[nodiscard]] bool IsCollapsed() const { return collapse_toggle_->IsCollapsed(); }
 
-  [[nodiscard]] virtual std::vector<CaptureViewElement*> GetVisibleChildren() { return {}; }
+  [[nodiscard]] virtual std::vector<CaptureViewElement*> GetVisibleChildren();
   [[nodiscard]] virtual int GetVisiblePrimitiveCount() const { return 0; }
 
  protected:

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -9,17 +9,22 @@
 
 #include <utility>
 
+#include "AccessibleTriangleToggle.h"
 #include "Batcher.h"
 #include "Geometry.h"
 #include "GlCanvas.h"
 #include "TimeGraph.h"
 
 TriangleToggle::TriangleToggle(State initial_state, StateChangeHandler handler,
-                               TimeGraph* time_graph, TimeGraphLayout* layout)
+                               TimeGraph* time_graph, TimeGraphLayout* layout,
+                               orbit_gl::CaptureViewElement* parent)
     : CaptureViewElement(time_graph, layout),
+      parent_(parent),
       state_(initial_state),
       initial_state_(initial_state),
-      handler_(std::move(handler)) {}
+      handler_(std::move(handler)) {
+        SetSize(10.f, 10.f);
+      }
 
 void TriangleToggle::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
   CaptureViewElement::Draw(canvas, picking_mode, z_offset);
@@ -34,7 +39,7 @@ void TriangleToggle::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_of
 
   // Draw triangle.
   static float half_sqrt_three = 0.5f * sqrtf(3.f);
-  float half_w = 0.5f * size_;
+  float half_w = 0.5f * size_[0];
   float half_h = half_sqrt_three * half_w;
 
   if (!picking) {
@@ -75,4 +80,9 @@ void TriangleToggle::SetState(State state, InitialStateUpdate behavior) {
   if (behavior == InitialStateUpdate::kReplaceInitialState) {
     initial_state_ = state;
   }
+}
+
+std::unique_ptr<orbit_accessibility::AccessibleInterface>
+TriangleToggle::CreateAccessibleInterface() {
+  return std::make_unique<orbit_gl::AccessibleTriangleToggle>(this, parent_);
 }

--- a/src/OrbitGl/TriangleToggle.h
+++ b/src/OrbitGl/TriangleToggle.h
@@ -19,7 +19,7 @@ class TriangleToggle : public orbit_gl::CaptureViewElement,
 
   using StateChangeHandler = std::function<void(TriangleToggle::State)>;
   explicit TriangleToggle(State initial_state, StateChangeHandler handler, TimeGraph* time_graph,
-                          TimeGraphLayout* layout);
+                          TimeGraphLayout* layout, orbit_gl::CaptureViewElement* parent);
   ~TriangleToggle() override = default;
 
   TriangleToggle() = delete;
@@ -41,11 +41,15 @@ class TriangleToggle : public orbit_gl::CaptureViewElement,
   bool IsExpanded() const { return state_ == State::kExpanded; }
   bool IsInactive() const { return state_ == State::kInactive; }
 
+ protected:
+  std::unique_ptr<orbit_accessibility::AccessibleInterface> CreateAccessibleInterface() override;
+
  private:
+  orbit_gl::CaptureViewElement* parent_;
+
   State state_ = State::kInactive;
   State initial_state_ = State::kInactive;
   StateChangeHandler handler_;
-  float size_ = 10.f;
 };
 
 #endif  // ORBIT_GL_TRIANGLE_TOGGLE_H_


### PR DESCRIPTION
This exposes the `TriangleToggle` class to the accessibility
interface.
Thereby it introduces the `AccessibleTriangleToggle` class,
makes the toggle a direct child of `Track` and fixes
using the correct size for the toggle.

Test: Run Orbit with Accessibility Insights

Current Issue: The "TriangleToggle" appears only after clicking
on the track (not the tab).