### PR TITLE
GlCanvas cleanup

### DIFF
--- a/src/OrbitGl/AccessibleThreadBar.cpp
+++ b/src/OrbitGl/AccessibleThreadBar.cpp
@@ -8,6 +8,7 @@
 #include "OrbitBase/Logging.h"
 #include "ThreadBar.h"
 #include "Track.h"
+#include "Viewport.h"
 
 namespace orbit_gl {
 
@@ -45,12 +46,12 @@ orbit_accessibility::AccessibilityRect orbit_gl::AccessibleThreadBar::Accessible
 
   GlCanvas* canvas = thread_bar_->GetCanvas();
   CHECK(canvas != nullptr);
+  const Viewport& viewport = canvas->GetViewport();
 
   return orbit_accessibility::AccessibilityRect(
-      canvas->GetViewport().WorldToScreenWidth(local_pos[0]),
-      canvas->GetViewport().WorldToScreenHeight(local_pos[1]),
-      canvas->GetViewport().WorldToScreenWidth(thread_bar_->GetSize()[0]),
-      canvas->GetViewport().WorldToScreenHeight(thread_bar_->GetSize()[1]));
+      viewport.WorldToScreenWidth(local_pos[0]), viewport.WorldToScreenHeight(local_pos[1]),
+      viewport.WorldToScreenWidth(thread_bar_->GetSize()[0]),
+      viewport.WorldToScreenHeight(thread_bar_->GetSize()[1]));
 }
 
 orbit_accessibility::AccessibilityState AccessibleThreadBar::AccessibleState() const {

--- a/src/OrbitGl/AccessibleThreadBar.cpp
+++ b/src/OrbitGl/AccessibleThreadBar.cpp
@@ -47,9 +47,10 @@ orbit_accessibility::AccessibilityRect orbit_gl::AccessibleThreadBar::Accessible
   CHECK(canvas != nullptr);
 
   return orbit_accessibility::AccessibilityRect(
-      canvas->WorldToScreenWidth(local_pos[0]), canvas->WorldToScreenHeight(local_pos[1]),
-      canvas->WorldToScreenWidth(thread_bar_->GetSize()[0]),
-      canvas->WorldToScreenHeight(thread_bar_->GetSize()[1]));
+      canvas->GetViewport().WorldToScreenWidth(local_pos[0]),
+      canvas->GetViewport().WorldToScreenHeight(local_pos[1]),
+      canvas->GetViewport().WorldToScreenWidth(thread_bar_->GetSize()[0]),
+      canvas->GetViewport().WorldToScreenHeight(thread_bar_->GetSize()[1]));
 }
 
 orbit_accessibility::AccessibilityState AccessibleThreadBar::AccessibleState() const {

--- a/src/OrbitGl/AccessibleTimeGraph.cpp
+++ b/src/OrbitGl/AccessibleTimeGraph.cpp
@@ -11,15 +11,19 @@
 #include "TimeGraph.h"
 #include "Track.h"
 #include "TrackManager.h"
+#include "Viewport.h"
 
 using orbit_accessibility::AccessibilityRect;
 using orbit_accessibility::AccessibilityState;
 using orbit_accessibility::AccessibleInterface;
 
+namespace orbit_gl {
+
 AccessibilityRect TimeGraphAccessibility::AccessibleLocalRect() const {
   GlCanvas* canvas = time_graph_->GetCanvas();
-  return AccessibilityRect(0, 0, canvas->GetViewport().GetWidth(),
-                           canvas->GetViewport().GetHeight());
+  const Viewport& viewport = canvas->GetViewport();
+
+  return AccessibilityRect(0, 0, viewport.GetScreenWidth(), viewport.GetScreenHeight());
 }
 
 AccessibilityState TimeGraphAccessibility::AccessibleState() const {
@@ -39,3 +43,5 @@ const AccessibleInterface* TimeGraphAccessibility::AccessibleChild(int index) co
 const AccessibleInterface* TimeGraphAccessibility::AccessibleParent() const {
   return time_graph_->GetCanvas()->GetOrCreateAccessibleInterface();
 }
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/AccessibleTimeGraph.cpp
+++ b/src/OrbitGl/AccessibleTimeGraph.cpp
@@ -18,7 +18,8 @@ using orbit_accessibility::AccessibleInterface;
 
 AccessibilityRect TimeGraphAccessibility::AccessibleLocalRect() const {
   GlCanvas* canvas = time_graph_->GetCanvas();
-  return AccessibilityRect(0, 0, canvas->GetWidth(), canvas->GetHeight());
+  return AccessibilityRect(0, 0, canvas->GetViewport().GetWidth(),
+                           canvas->GetViewport().GetHeight());
 }
 
 AccessibilityState TimeGraphAccessibility::AccessibleState() const {

--- a/src/OrbitGl/AccessibleTimeGraph.h
+++ b/src/OrbitGl/AccessibleTimeGraph.h
@@ -12,6 +12,8 @@
 
 class TimeGraph;
 
+namespace orbit_gl {
+
 class TimeGraphAccessibility : public orbit_accessibility::AccessibleInterface {
  public:
   explicit TimeGraphAccessibility(TimeGraph* time_graph) : time_graph_(time_graph) {
@@ -32,5 +34,7 @@ class TimeGraphAccessibility : public orbit_accessibility::AccessibleInterface {
  private:
   TimeGraph* time_graph_;
 };
+
+}  // namespace orbit_gl
 
 #endif

--- a/src/OrbitGl/AccessibleTrack.cpp
+++ b/src/OrbitGl/AccessibleTrack.cpp
@@ -184,8 +184,9 @@ AccessibilityRect AccessibleTrack::AccessibleLocalRect() const {
   // in a final result with width / height of 0.
 
   // First: Clamp bottom
-  if (screen_pos[1] + screen_height > canvas->GetHeight()) {
-    screen_height = std::max(0, canvas->GetHeight() - static_cast<int>(screen_pos[1]));
+  if (screen_pos[1] + screen_height > canvas->GetViewport().GetHeight()) {
+    screen_height =
+        std::max(0, canvas->GetViewport().GetHeight() - static_cast<int>(screen_pos[1]));
   }
   // Second: Clamp top
   if (screen_pos[1] < 0) {

--- a/src/OrbitGl/AccessibleTrack.cpp
+++ b/src/OrbitGl/AccessibleTrack.cpp
@@ -105,11 +105,12 @@ AccessibilityRect AccessibleTrackContent::AccessibleLocalRect() const {
   CHECK(track_ != nullptr);
 
   GlCanvas* canvas = track_->GetCanvas();
+  const Viewport& viewport = canvas->GetViewport();
 
-  return AccessibilityRect(canvas->GetViewport().WorldToScreenWidth(0),
-                           canvas->GetViewport().WorldToScreenHeight(layout_->GetTrackTabHeight()),
-                           canvas->GetViewport().WorldToScreenWidth(track_->GetSize()[0]),
-                           canvas->GetViewport().WorldToScreenHeight(track_->GetSize()[1]));
+  return AccessibilityRect(viewport.WorldToScreenWidth(0),
+                           viewport.WorldToScreenHeight(layout_->GetTrackTabHeight()),
+                           viewport.WorldToScreenWidth(track_->GetSize()[0]),
+                           viewport.WorldToScreenHeight(track_->GetSize()[1]));
 }
 
 AccessibilityState AccessibleTrackContent::AccessibleState() const {
@@ -135,11 +136,12 @@ AccessibilityRect AccessibleTrackTab::AccessibleLocalRect() const {
   CHECK(track_ != nullptr);
 
   GlCanvas* canvas = track_->GetCanvas();
+  const Viewport& viewport = canvas->GetViewport();
 
-  return AccessibilityRect(canvas->GetViewport().WorldToScreenWidth(layout_->GetTrackTabOffset()),
-                           canvas->GetViewport().WorldToScreenHeight(0),
-                           canvas->GetViewport().WorldToScreenWidth(layout_->GetTrackTabWidth()),
-                           canvas->GetViewport().WorldToScreenHeight(layout_->GetTrackTabHeight()));
+  return AccessibilityRect(viewport.WorldToScreenWidth(layout_->GetTrackTabOffset()),
+                           viewport.WorldToScreenHeight(0),
+                           viewport.WorldToScreenWidth(layout_->GetTrackTabWidth()),
+                           viewport.WorldToScreenHeight(layout_->GetTrackTabHeight()));
 }
 
 AccessibilityState AccessibleTrackTab::AccessibleState() const {
@@ -175,18 +177,19 @@ AccessibilityRect AccessibleTrack::AccessibleLocalRect() const {
   Vec2 size = track_->GetSize();
   size[1] += layout_->GetTrackTabHeight();
 
-  Vec2i screen_pos = canvas->GetViewport().WorldToScreenPos(pos);
-  int screen_width = canvas->GetViewport().WorldToScreenWidth(size[0]);
-  int screen_height = canvas->GetViewport().WorldToScreenHeight(size[1]);
+  const Viewport& viewport = canvas->GetViewport();
+
+  Vec2i screen_pos = viewport.WorldToScreenPos(pos);
+  int screen_width = viewport.WorldToScreenWidth(size[0]);
+  int screen_height = viewport.WorldToScreenHeight(size[1]);
 
   // Adjust the coordinates to clamp the result to an on-screen rect
   // This will "cut" any part that is offscreen due to scrolling, and may result
   // in a final result with width / height of 0.
 
   // First: Clamp bottom
-  if (screen_pos[1] + screen_height > canvas->GetViewport().GetHeight()) {
-    screen_height =
-        std::max(0, canvas->GetViewport().GetHeight() - static_cast<int>(screen_pos[1]));
+  if (screen_pos[1] + screen_height > viewport.GetScreenHeight()) {
+    screen_height = std::max(0, viewport.GetScreenHeight() - static_cast<int>(screen_pos[1]));
   }
   // Second: Clamp top
   if (screen_pos[1] < 0) {

--- a/src/OrbitGl/AccessibleTrack.cpp
+++ b/src/OrbitGl/AccessibleTrack.cpp
@@ -106,10 +106,10 @@ AccessibilityRect AccessibleTrackContent::AccessibleLocalRect() const {
 
   GlCanvas* canvas = track_->GetCanvas();
 
-  return AccessibilityRect(canvas->WorldToScreenWidth(0),
-                           canvas->WorldToScreenHeight(layout_->GetTrackTabHeight()),
-                           canvas->WorldToScreenWidth(track_->GetSize()[0]),
-                           canvas->WorldToScreenHeight(track_->GetSize()[1]));
+  return AccessibilityRect(canvas->GetViewport().WorldToScreenWidth(0),
+                           canvas->GetViewport().WorldToScreenHeight(layout_->GetTrackTabHeight()),
+                           canvas->GetViewport().WorldToScreenWidth(track_->GetSize()[0]),
+                           canvas->GetViewport().WorldToScreenHeight(track_->GetSize()[1]));
 }
 
 AccessibilityState AccessibleTrackContent::AccessibleState() const {
@@ -136,10 +136,10 @@ AccessibilityRect AccessibleTrackTab::AccessibleLocalRect() const {
 
   GlCanvas* canvas = track_->GetCanvas();
 
-  return AccessibilityRect(canvas->WorldToScreenWidth(layout_->GetTrackTabOffset()),
-                           canvas->WorldToScreenHeight(0),
-                           canvas->WorldToScreenWidth(layout_->GetTrackTabWidth()),
-                           canvas->WorldToScreenHeight(layout_->GetTrackTabHeight()));
+  return AccessibilityRect(canvas->GetViewport().WorldToScreenWidth(layout_->GetTrackTabOffset()),
+                           canvas->GetViewport().WorldToScreenHeight(0),
+                           canvas->GetViewport().WorldToScreenWidth(layout_->GetTrackTabWidth()),
+                           canvas->GetViewport().WorldToScreenHeight(layout_->GetTrackTabHeight()));
 }
 
 AccessibilityState AccessibleTrackTab::AccessibleState() const {
@@ -175,9 +175,9 @@ AccessibilityRect AccessibleTrack::AccessibleLocalRect() const {
   Vec2 size = track_->GetSize();
   size[1] += layout_->GetTrackTabHeight();
 
-  Vec2 screen_pos = canvas->WorldToScreen(pos);
-  int screen_width = canvas->WorldToScreenWidth(size[0]);
-  int screen_height = canvas->WorldToScreenHeight(size[1]);
+  Vec2i screen_pos = canvas->GetViewport().WorldToScreenPos(pos);
+  int screen_width = canvas->GetViewport().WorldToScreenWidth(size[0]);
+  int screen_height = canvas->GetViewport().WorldToScreenHeight(size[1]);
 
   // Adjust the coordinates to clamp the result to an on-screen rect
   // This will "cut" any part that is offscreen due to scrolling, and may result

--- a/src/OrbitGl/AccessibleTriangleToggle.cpp
+++ b/src/OrbitGl/AccessibleTriangleToggle.cpp
@@ -17,9 +17,11 @@ orbit_accessibility::AccessibilityRect AccessibleTriangleToggle::AccessibleLocal
   Vec2 pos = triangle_toggle_->GetPos();
   Vec2 size = triangle_toggle_->GetSize();
 
-  Vec2i screen_pos = canvas->GetViewport().WorldToScreenPos(pos);
-  int screen_width = canvas->GetViewport().WorldToScreenWidth(size[0]);
-  int screen_height = canvas->GetViewport().WorldToScreenHeight(size[1]);
+  const Viewport& viewport = canvas->GetViewport();
+
+  Vec2i screen_pos = viewport.WorldToScreenPos(pos);
+  int screen_width = viewport.WorldToScreenWidth(size[0]);
+  int screen_height = viewport.WorldToScreenHeight(size[1]);
 
   orbit_accessibility::AccessibilityRect parent_rect =
       parent_->GetOrCreateAccessibleInterface()->AccessibleLocalRect();

--- a/src/OrbitGl/AccessibleTriangleToggle.cpp
+++ b/src/OrbitGl/AccessibleTriangleToggle.cpp
@@ -17,16 +17,16 @@ orbit_accessibility::AccessibilityRect AccessibleTriangleToggle::AccessibleLocal
   Vec2 pos = triangle_toggle_->GetPos();
   Vec2 size = triangle_toggle_->GetSize();
 
-  Vec2 screen_pos = canvas->WorldToScreen(pos);
-  int screen_width = canvas->WorldToScreenWidth(size[0]);
-  int screen_height = canvas->WorldToScreenHeight(size[1]);
+  Vec2i screen_pos = canvas->GetViewport().WorldToScreenPos(pos);
+  int screen_width = canvas->GetViewport().WorldToScreenWidth(size[0]);
+  int screen_height = canvas->GetViewport().WorldToScreenHeight(size[1]);
 
   orbit_accessibility::AccessibilityRect parent_rect =
       parent_->GetOrCreateAccessibleInterface()->AccessibleLocalRect();
 
-  return orbit_accessibility::AccessibilityRect(static_cast<int>(screen_pos[0]) - parent_rect.left,
-                                                static_cast<int>(screen_pos[1]) - parent_rect.top,
-                                                screen_width, screen_height);
+  return orbit_accessibility::AccessibilityRect(screen_pos[0] - parent_rect.left,
+                                                screen_pos[1] - parent_rect.top, screen_width,
+                                                screen_height);
 }
 
 orbit_accessibility::AccessibilityState AccessibleTriangleToggle::AccessibleState() const {

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -72,7 +72,8 @@ target_sources(
          TrackManager.h
          TriangleToggle.h
          TracepointsDataView.h
-         TracepointThreadBar.h)
+         TracepointThreadBar.h
+         Viewport.h)
 
 target_sources(
   OrbitGl
@@ -126,7 +127,8 @@ target_sources(
           TrackManager.cpp
           TriangleToggle.cpp
           TracepointsDataView.cpp
-          TracepointThreadBar.cpp)
+          TracepointThreadBar.cpp
+          Viewport.cpp)
 
 target_include_directories(OrbitGl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -164,6 +166,7 @@ target_sources(OrbitGlTests PRIVATE
 target_sources(OrbitGlTests PRIVATE
                BatcherTest.cpp
                BlockChainTest.cpp
+               ClientFlags.cpp
                DataViewTest.cpp
                GlUtilsTest.cpp
                GpuTrackTest.cpp
@@ -172,7 +175,7 @@ target_sources(OrbitGlTests PRIVATE
                ScopeTreeTest.cpp
                SliderTest.cpp
                TimerInfosIteratorTest.cpp
-               ClientFlags.cpp)
+               ViewportTest.cpp)
 
 target_link_libraries(
   OrbitGlTests

--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -16,7 +16,7 @@ CaptureViewElement::CaptureViewElement(CaptureViewElement* parent, TimeGraph* ti
 }
 
 void CaptureViewElement::OnPick(int x, int y) {
-  canvas_->ScreenToWorld(x, y, mouse_pos_last_click_[0], mouse_pos_last_click_[1]);
+  mouse_pos_last_click_ = canvas_->GetViewport().ScreenToWorldPos(Vec2i(x, y));
   picking_offset_ = mouse_pos_last_click_ - pos_;
   mouse_pos_cur_ = mouse_pos_last_click_;
   picked_ = true;
@@ -28,7 +28,7 @@ void CaptureViewElement::OnRelease() {
 }
 
 void CaptureViewElement::OnDrag(int x, int y) {
-  canvas_->ScreenToWorld(x, y, mouse_pos_cur_[0], mouse_pos_cur_[1]);
+  mouse_pos_cur_ = canvas_->GetViewport().ScreenToWorldPos(Vec2i(x, y));
   time_graph_->RequestUpdatePrimitives();
 }
 

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -200,13 +200,6 @@ void CaptureWindow::PostRender() {
   }
 
   GlCanvas::PostRender();
-
-  // TODO: This should not be needed, but the extents of track heights may change after drawing
-  // This will re-request updatePrimitives() if the height changed.
-  if (time_graph_ != nullptr) {
-    viewport_.SetWorldExtents(viewport_.GetScreenWidth(),
-                              time_graph_->GetTrackManager()->GetTracksTotalHeight());
-  }
 }
 
 void CaptureWindow::RightDown(int x, int y) {
@@ -370,8 +363,6 @@ void CaptureWindow::Draw() {
   }
 
   if (time_graph_ != nullptr) {
-    viewport_.SetWorldExtents(viewport_.GetScreenWidth(),
-                              time_graph_->GetTrackManager()->GetTracksTotalHeight());
     if (viewport_.IsDirty()) {
       time_graph_->SetPos(0, 0);
       time_graph_->SetSize(viewport_.GetWorldExtents()[0], viewport_.GetWorldExtents()[1]);
@@ -379,6 +370,8 @@ void CaptureWindow::Draw() {
       time_graph_->RequestUpdatePrimitives();
     }
     time_graph_->Draw(this, picking_mode_);
+    viewport_.SetWorldExtents(viewport_.GetScreenWidth(),
+                              time_graph_->GetTrackManager()->GetTracksTotalHeight());
   }
 
   RenderSelectionOverlay();

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -203,11 +203,6 @@ void CaptureWindow::PostRender() {
   }
 }
 
-void CaptureWindow::Resize(int width, int height) {
-  GlCanvas::Resize(width, height);
-  RequestUpdatePrimitives();
-}
-
 bool CaptureWindow::RightUp() {
   if (time_graph_ != nullptr && is_selecting_ && (select_start_[0] != select_stop_[0]) &&
       ControlPressed()) {

--- a/src/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/CaptureWindow.h
@@ -25,34 +25,28 @@ class CaptureWindow : public GlCanvas {
  public:
   explicit CaptureWindow(OrbitApp* app);
 
-  void Initialize() override;
+  enum class ZoomDirection { kHorizontal, kVertical };
+
   void ZoomAll();
-  void Zoom(int delta);
+  void Zoom(ZoomDirection dir, int delta);
   void Pan(float ratio);
 
-  void UpdateWheelMomentum(float delta_time) override;
   void MouseMoved(int x, int y, bool left, bool right, bool middle) override;
-  void LeftDoubleClick() override;
   void LeftDown(int x, int y) override;
   void LeftUp() override;
-  void Pick();
-  void Pick(int x, int y);
-  void Pick(PickingId picking_id, int x, int y);
-  void Hover(int x, int y) override;
-  void RightDown(int x, int y) override;
   bool RightUp() override;
-  void MiddleDown(int x, int y) override;
-  void MiddleUp(int x, int y) override;
   void MouseWheelMoved(int x, int y, int delta, bool ctrl) override;
   void MouseWheelMovedHorizontally(int x, int y, int delta, bool ctrl) override;
   void KeyPressed(unsigned int key_code, bool ctrl, bool shift, bool alt) override;
-  void OnTimer() override;
+
   void Draw() override;
-  void DrawScreenSpace() override;
+  virtual void DrawScreenSpace();
+  virtual void RenderText(float layer);
+
   void RenderImGuiDebugUI() override;
-  void RenderText(float layer) override;
-  void PreRender() override;
+
   void PostRender() override;
+
   void Resize(int width, int height) override;
   void RenderHelpUi();
   void RenderTimeBar();
@@ -65,34 +59,33 @@ class CaptureWindow : public GlCanvas {
   void UpdateVerticalSliderFromWorld();
   void UpdateHorizontalSliderFromWorld();
   void UpdateWorldTopLeftY(float val) override;
+  void UpdateWorldTopLeftX(float val) override;
 
   void RequestUpdatePrimitives();
-  std::vector<std::string> GetContextMenu() override;
-  void OnContextMenu(const std::string& action, int menu_index) override;
+
   virtual void ToggleRecording();
   void ToggleDrawHelp();
   void set_draw_help(bool draw_help);
+
   [[nodiscard]] TimeGraph* GetTimeGraph() { return time_graph_.get(); }
   void CreateTimeGraph(const CaptureData* capture_data);
   void ClearTimeGraph() { time_graph_.reset(nullptr); }
 
   Batcher& GetBatcherById(BatcherId batcher_id);
 
- protected:
+ private:
   [[nodiscard]] virtual const char* GetHelpText() const;
   [[nodiscard]] virtual bool ShouldAutoZoom() const;
+  void HandlePickedElement(PickingMode picking_mode, PickingId picking_id, int x, int y) override;
 
- protected:
   std::unique_ptr<TimeGraph> time_graph_ = nullptr;
   bool draw_help_;
-  bool draw_filter_;
   std::shared_ptr<GlSlider> slider_;
   std::shared_ptr<GlSlider> vertical_slider_;
 
   bool click_was_drag_ = false;
   bool background_clicked_ = false;
 
- private:
   OrbitApp* app_ = nullptr;
   [[nodiscard]] std::unique_ptr<orbit_accessibility::AccessibleInterface>
   CreateAccessibleInterface() override;

--- a/src/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/CaptureWindow.h
@@ -58,8 +58,6 @@ class CaptureWindow : public GlCanvas {
   void UpdateHorizontalZoom(float normalized_start, float normalized_end);
   void UpdateVerticalSliderFromWorld();
   void UpdateHorizontalSliderFromWorld();
-  void UpdateWorldTopLeftY(float val) override;
-  void UpdateWorldTopLeftX(float val) override;
 
   void RequestUpdatePrimitives();
 

--- a/src/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/CaptureWindow.h
@@ -39,15 +39,29 @@ class CaptureWindow : public GlCanvas {
   void MouseWheelMovedHorizontally(int x, int y, int delta, bool ctrl) override;
   void KeyPressed(unsigned int key_code, bool ctrl, bool shift, bool alt) override;
 
+  void PostRender() override;
+  void RenderImGuiDebugUI() override;
+
+  void RequestUpdatePrimitives();
+
+  void ToggleDrawHelp();
+  void set_draw_help(bool draw_help);
+
+  [[nodiscard]] TimeGraph* GetTimeGraph() { return time_graph_.get(); }
+  void CreateTimeGraph(const CaptureData* capture_data);
+  void ClearTimeGraph() { time_graph_.reset(nullptr); }
+
+  Batcher& GetBatcherById(BatcherId batcher_id);
+
+ protected:
   void Draw() override;
+
   virtual void DrawScreenSpace();
   virtual void RenderText(float layer);
 
-  void RenderImGuiDebugUI() override;
+  virtual void ToggleRecording();
 
-  void PostRender() override;
-
-  void Resize(int width, int height) override;
+ private:
   void RenderHelpUi();
   void RenderTimeBar();
   void RenderSelectionOverlay();
@@ -59,19 +73,6 @@ class CaptureWindow : public GlCanvas {
   void UpdateVerticalSliderFromWorld();
   void UpdateHorizontalSliderFromWorld();
 
-  void RequestUpdatePrimitives();
-
-  virtual void ToggleRecording();
-  void ToggleDrawHelp();
-  void set_draw_help(bool draw_help);
-
-  [[nodiscard]] TimeGraph* GetTimeGraph() { return time_graph_.get(); }
-  void CreateTimeGraph(const CaptureData* capture_data);
-  void ClearTimeGraph() { time_graph_.reset(nullptr); }
-
-  Batcher& GetBatcherById(BatcherId batcher_id);
-
- private:
   [[nodiscard]] virtual const char* GetHelpText() const;
   [[nodiscard]] virtual bool ShouldAutoZoom() const;
   void HandlePickedElement(PickingMode picking_mode, PickingId picking_id, int x, int y) override;

--- a/src/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/CaptureWindow.h
@@ -34,6 +34,7 @@ class CaptureWindow : public GlCanvas {
   void MouseMoved(int x, int y, bool left, bool right, bool middle) override;
   void LeftDown(int x, int y) override;
   void LeftUp() override;
+  void RightDown(int x, int y) override;
   bool RightUp() override;
   void MouseWheelMoved(int x, int y, int delta, bool ctrl) override;
   void MouseWheelMovedHorizontally(int x, int y, int delta, bool ctrl) override;
@@ -81,6 +82,9 @@ class CaptureWindow : public GlCanvas {
   bool draw_help_;
   std::shared_ptr<GlSlider> slider_;
   std::shared_ptr<GlSlider> vertical_slider_;
+
+  uint64_t select_start_time_ = 0;
+  uint64_t select_stop_time_ = 0;
 
   bool click_was_drag_ = false;
   bool background_clicked_ = false;

--- a/src/OrbitGl/CoreMath.h
+++ b/src/OrbitGl/CoreMath.h
@@ -17,6 +17,10 @@ using Vec2 = gte::Vector2<float>;
 using Vec3 = gte::Vector3<float>;
 using Vec4 = gte::Vector4<float>;
 
+using Vec2i = gte::Vector2<int>;
+using Vec3i = gte::Vector3<int>;
+using Vec4i = gte::Vector4<int>;
+
 using Color = gte::Vector4<unsigned char>;
 
 template <class T>

--- a/src/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/GlCanvas.h
@@ -38,9 +38,10 @@ class GlCanvas {
   enum class CanvasType { kCaptureWindow, kIntrospectionWindow, kDebug };
   static std::unique_ptr<GlCanvas> Create(CanvasType canvas_type, OrbitApp* app);
 
-  virtual void Initialize();
-  virtual void Resize(int width, int height);
-  virtual void Render(int width, int height);
+  void Initialize();
+  void Resize(int width, int height);
+  void Render(int width, int height);
+
   virtual void PreRender();
   virtual void PostRender();
 
@@ -63,8 +64,6 @@ class GlCanvas {
   virtual void CharEvent(unsigned int character);
   virtual void KeyPressed(unsigned int key_code, bool ctrl, bool shift, bool alt);
   virtual void KeyReleased(unsigned int key_code, bool ctrl, bool shift, bool alt);
-  virtual void UpdateSpecialKeys(bool ctrl, bool shift, bool alt);
-  virtual bool ControlPressed();
 
   [[nodiscard]] virtual std::vector<std::string> GetContextMenu() {
     return std::vector<std::string>();
@@ -73,18 +72,14 @@ class GlCanvas {
 
   [[nodiscard]] TextRenderer& GetTextRenderer() { return text_renderer_; }
 
-  // TODO: Only needed for Graph labels
+  // Only needed for Graph labels - should we find a better way?
   [[nodiscard]] float GetMouseX() const { return mouse_world_[0]; }
 
-  // TODO: Could be removed when ImGui is removed
+  // The 3 methods below could be removed if ImGui is removed
   [[nodiscard]] float GetMousePosX() const { return static_cast<float>(mouse_screen_[0]); }
   [[nodiscard]] float GetMousePosY() const { return static_cast<float>(mouse_screen_[1]); }
-
-  void ResetHoverTimer();
-
   [[nodiscard]] float GetDeltaTimeSeconds() const { return delta_time_; }
 
-  virtual void Draw() {}
   virtual void RenderImGuiDebugUI() {}
 
   using RenderCallback = std::function<void()>;
@@ -138,7 +133,14 @@ class GlCanvas {
   static const Color kTabTextColorSelected;
 
  protected:
+  virtual void Draw() {}
+
   [[nodiscard]] PickingMode GetPickingMode();
+
+  void UpdateSpecialKeys(bool ctrl, bool shift, bool alt);
+  bool ControlPressed();
+
+  void ResetHoverTimer();
 
   Vec2 world_click_pos_ = Vec2(0, 0);
   Vec2 mouse_world_ = Vec2(0, 0);

--- a/src/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/GlCanvas.h
@@ -49,16 +49,6 @@ class GlCanvas {
   void PrepareGlState();
   static void CleanupGlState();
 
-  void ScreenToWorld(int x, int y, float& wx, float& wy) const;
-  [[nodiscard]] Vec2 ScreenToWorld(Vec2 screen_pos) const;
-  [[nodiscard]] float ScreenToWorldHeight(int height) const;
-  [[nodiscard]] float ScreenToWorldWidth(int width) const;
-
-  [[nodiscard]] Vec2 WorldToScreen(Vec2 world_pos) const;
-  [[nodiscard]] int WorldToScreenHeight(float height) const;
-  [[nodiscard]] int WorldToScreenWidth(float width) const;
-  [[nodiscard]] Vec2 QtScreenToGlScreen(Vec2 qt_pos) const;
-
   // events
   virtual void MouseMoved(int x, int y, bool left, bool right, bool middle);
   virtual void LeftDown(int x, int y);
@@ -83,10 +73,12 @@ class GlCanvas {
 
   [[nodiscard]] TextRenderer& GetTextRenderer() { return text_renderer_; }
 
-  [[nodiscard]] float GetMouseX() const { return mouse_world_x_; }
+  // TODO: Only needed for Graph labels
+  [[nodiscard]] float GetMouseX() const { return mouse_world_[0]; }
 
-  [[nodiscard]] float GetMousePosX() const { return static_cast<float>(mouse_screen_x_); }
-  [[nodiscard]] float GetMousePosY() const { return static_cast<float>(mouse_screen_y_); }
+  // TODO: Could be removed when ImGui is removed
+  [[nodiscard]] float GetMousePosX() const { return static_cast<float>(mouse_screen_[0]); }
+  [[nodiscard]] float GetMousePosY() const { return static_cast<float>(mouse_screen_[1]); }
 
   void ResetHoverTimer();
 
@@ -148,16 +140,12 @@ class GlCanvas {
  protected:
   [[nodiscard]] PickingMode GetPickingMode();
 
-  float world_click_x_;
-  float world_click_y_;
-  float mouse_world_x_;
-  float mouse_world_y_;
-  int mouse_screen_x_;
-  int mouse_screen_y_;
-  Vec2 select_start_;
-  Vec2 select_stop_;
-  int screen_click_x_;
-  int screen_click_y_;
+  Vec2 world_click_pos_ = Vec2(0, 0);
+  Vec2 mouse_world_ = Vec2(0, 0);
+  Vec2i mouse_screen_ = Vec2i(0, 0);
+  Vec2 select_start_ = Vec2(0, 0);
+  Vec2 select_stop_ = Vec2(0, 0);
+  Vec2i screen_click_;
   float delta_time_;
   bool is_selecting_;
   Timer hover_timer_;

--- a/src/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/GlCanvas.h
@@ -26,6 +26,7 @@
 #include "TextRenderer.h"
 #include "TimeGraph.h"
 #include "Timer.h"
+#include "Viewport.h"
 
 class OrbitApp;
 
@@ -42,9 +43,6 @@ class GlCanvas {
   virtual void Render(int width, int height);
   virtual void PreRender();
   virtual void PostRender();
-
-  [[nodiscard]] virtual int GetWidth() const;
-  [[nodiscard]] virtual int GetHeight() const;
 
   void Prepare2DViewport(int top_left_x, int top_left_y, int bottom_right_x, int bottom_right_y);
   void PrepareScreenSpaceViewport();
@@ -83,16 +81,6 @@ class GlCanvas {
   }
   virtual void OnContextMenu(const std::string& /*a_Action*/, int /*a_MenuIndex*/) {}
 
-  [[nodiscard]] float GetWorldWidth() const { return world_width_; }
-  [[nodiscard]] float GetWorldHeight() const { return world_height_; }
-  [[nodiscard]] float GetWorldMaxY() const { return world_max_y_; }
-  [[nodiscard]] float GetWorldTopLeftX() const { return world_top_left_x_; }
-  [[nodiscard]] float GetWorldTopLeftY() const { return world_top_left_y_; }
-
-  void UpdateWorldTopLeftY() { UpdateWorldTopLeftY(GetWorldTopLeftY()); }
-  virtual void UpdateWorldTopLeftY(float val) { world_top_left_y_ = val; }
-  virtual void UpdateWorldTopLeftX(float val) { world_top_left_x_ = val; }
-
   [[nodiscard]] TextRenderer& GetTextRenderer() { return text_renderer_; }
 
   [[nodiscard]] float GetMouseX() const { return mouse_world_x_; }
@@ -129,6 +117,9 @@ class GlCanvas {
     return accessibility_.get();
   }
 
+  [[nodiscard]] const orbit_gl::Viewport& GetViewport() const { return viewport_; }
+  [[nodiscard]] orbit_gl::Viewport& GetViewport() { return viewport_; }
+
   static float kZValueSlider;
   static float kZValueSliderBg;
   static float kZValueMargin;
@@ -157,14 +148,6 @@ class GlCanvas {
  protected:
   [[nodiscard]] PickingMode GetPickingMode();
 
-  int screen_width_;
-  int screen_height_;
-  float world_width_;
-  float world_height_;
-  float world_top_left_x_;
-  float world_top_left_y_;
-  float world_max_y_;
-  float world_min_width_;
   float world_click_x_;
   float world_click_y_;
   float mouse_world_x_;
@@ -191,6 +174,8 @@ class GlCanvas {
   bool control_key_;
   bool is_mouse_over_ = false;
   bool redraw_requested_;
+
+  orbit_gl::Viewport viewport_;
 
   // Batcher to draw elements in the UI.
   Batcher ui_batcher_;

--- a/src/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/GlCanvas.h
@@ -45,7 +45,7 @@ class GlCanvas {
   virtual void PreRender();
   virtual void PostRender();
 
-  void Prepare2DViewport(int top_left_x, int top_left_y, int bottom_right_x, int bottom_right_y);
+  void PrepareWorldSpaceViewport();
   void PrepareScreenSpaceViewport();
   void PrepareGlState();
   static void CleanupGlState();
@@ -72,12 +72,9 @@ class GlCanvas {
 
   [[nodiscard]] TextRenderer& GetTextRenderer() { return text_renderer_; }
 
-  // Only needed for Graph labels - should we find a better way?
-  [[nodiscard]] float GetMouseX() const { return mouse_world_[0]; }
+  [[nodiscard]] const Vec2i& GetMouseScreenPos() const { return mouse_move_pos_screen_; }
 
-  // The 3 methods below could be removed if ImGui is removed
-  [[nodiscard]] float GetMousePosX() const { return static_cast<float>(mouse_screen_[0]); }
-  [[nodiscard]] float GetMousePosY() const { return static_cast<float>(mouse_screen_[1]); }
+  // This could be removed if ImGui is removed
   [[nodiscard]] float GetDeltaTimeSeconds() const { return delta_time_; }
 
   virtual void RenderImGuiDebugUI() {}
@@ -135,31 +132,30 @@ class GlCanvas {
  protected:
   virtual void Draw() {}
 
-  [[nodiscard]] PickingMode GetPickingMode();
-
   void UpdateSpecialKeys(bool ctrl, bool shift, bool alt);
   bool ControlPressed();
 
   void ResetHoverTimer();
 
-  Vec2 world_click_pos_ = Vec2(0, 0);
-  Vec2 mouse_world_ = Vec2(0, 0);
-  Vec2i mouse_screen_ = Vec2i(0, 0);
-  Vec2 select_start_ = Vec2(0, 0);
-  Vec2 select_stop_ = Vec2(0, 0);
-  Vec2i screen_click_;
+  void SetPickingMode(PickingMode mode);
+
+  Vec2 mouse_click_pos_world_;
+  Vec2i mouse_move_pos_screen_ = Vec2i(0, 0);
+  Vec2 select_start_pos_world_ = Vec2(0, 0);
+  Vec2 select_stop_pos_world_ = Vec2(0, 0);
+
   float delta_time_;
   bool is_selecting_;
   Timer hover_timer_;
   int hover_delay_ms_;
-  bool is_hovering_;
   bool can_hover_;
+
+  PickingMode picking_mode_ = PickingMode::kNone;
 
   ImGuiContext* imgui_context_ = nullptr;
   double ref_time_click_;
   TextRenderer text_renderer_;
   PickingManager picking_manager_;
-  bool picking_;
   bool double_clicking_;
   bool control_key_;
   bool is_mouse_over_ = false;

--- a/src/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/GlCanvas.h
@@ -40,16 +40,11 @@ class GlCanvas {
   virtual void Initialize();
   virtual void Resize(int width, int height);
   virtual void Render(int width, int height);
-  virtual void PreRender(){};
-  virtual void PostRender() {}
+  virtual void PreRender();
+  virtual void PostRender();
 
   [[nodiscard]] virtual int GetWidth() const;
   [[nodiscard]] virtual int GetHeight() const;
-
-  virtual void SetMainWindowSize(int width, int height) {
-    m_MainWindowWidth = width;
-    m_MainWindowHeight = height;
-  }
 
   void Prepare2DViewport(int top_left_x, int top_left_y, int bottom_right_x, int bottom_right_y);
   void PrepareScreenSpaceViewport();
@@ -72,13 +67,11 @@ class GlCanvas {
   virtual void LeftUp();
   virtual void LeftDoubleClick();
   virtual void MouseWheelMoved(int x, int y, int delta, bool ctrl);
-  virtual void MouseWheelMovedHorizontally(int x, int y, int delta, bool ctrl) {
-    MouseWheelMoved(x, y, delta, ctrl);
-  }
+  virtual void MouseWheelMovedHorizontally(int /*x*/, int /*y*/, int /*delta*/, bool /*ctrl*/) {}
   virtual void RightDown(int x, int y);
   virtual bool RightUp();
-  virtual void MiddleDown(int /*x*/, int /*y*/) {}
-  virtual void MiddleUp(int /*x*/, int /*y*/) {}
+  virtual void MiddleDown(int x, int y) { RightDown(x, y); }
+  virtual void MiddleUp() { RightUp(); }
   virtual void CharEvent(unsigned int character);
   virtual void KeyPressed(unsigned int key_code, bool ctrl, bool shift, bool alt);
   virtual void KeyReleased(unsigned int key_code, bool ctrl, bool shift, bool alt);
@@ -95,13 +88,12 @@ class GlCanvas {
   [[nodiscard]] float GetWorldMaxY() const { return world_max_y_; }
   [[nodiscard]] float GetWorldTopLeftX() const { return world_top_left_x_; }
   [[nodiscard]] float GetWorldTopLeftY() const { return world_top_left_y_; }
+
   void UpdateWorldTopLeftY() { UpdateWorldTopLeftY(GetWorldTopLeftY()); }
   virtual void UpdateWorldTopLeftY(float val) { world_top_left_y_ = val; }
+  virtual void UpdateWorldTopLeftX(float val) { world_top_left_x_ = val; }
 
   [[nodiscard]] TextRenderer& GetTextRenderer() { return text_renderer_; }
-
-  virtual void UpdateWheelMomentum(float delta_time);
-  virtual void OnTimer();
 
   [[nodiscard]] float GetMouseX() const { return mouse_world_x_; }
 
@@ -113,11 +105,7 @@ class GlCanvas {
   [[nodiscard]] float GetDeltaTimeSeconds() const { return delta_time_; }
 
   virtual void Draw() {}
-  virtual void DrawScreenSpace() {}
   virtual void RenderImGuiDebugUI() {}
-  virtual void RenderText(float /*layer*/) {}
-
-  virtual void Hover(int /*X*/, int /*Y*/) {}
 
   using RenderCallback = std::function<void()>;
   void AddRenderCallback(RenderCallback callback) {
@@ -185,17 +173,10 @@ class GlCanvas {
   int mouse_screen_y_;
   Vec2 select_start_;
   Vec2 select_stop_;
-  uint64_t time_start_;
-  uint64_t time_stop_;
   int screen_click_x_;
   int screen_click_y_;
-  int min_wheel_delta_;
-  int max_wheel_delta_;
-  float wheel_momentum_;
   float delta_time_;
   bool is_selecting_;
-  double mouse_ratio_;
-  bool im_gui_active_;
   Timer hover_timer_;
   int hover_delay_ms_;
   bool is_hovering_;
@@ -204,15 +185,12 @@ class GlCanvas {
   ImGuiContext* imgui_context_ = nullptr;
   double ref_time_click_;
   TextRenderer text_renderer_;
-  Timer update_timer_;
   PickingManager picking_manager_;
   bool picking_;
   bool double_clicking_;
   bool control_key_;
   bool is_mouse_over_ = false;
   bool redraw_requested_;
-  int m_MainWindowWidth = 0;
-  int m_MainWindowHeight = 0;
 
   // Batcher to draw elements in the UI.
   Batcher ui_batcher_;
@@ -222,6 +200,10 @@ class GlCanvas {
   [[nodiscard]] virtual std::unique_ptr<orbit_accessibility::AccessibleInterface>
   CreateAccessibleInterface();
   std::unique_ptr<orbit_accessibility::AccessibleInterface> accessibility_;
+
+  void Pick(PickingMode picking_mode, int x, int y);
+  virtual void HandlePickedElement(PickingMode /*picking_mode*/, PickingId /*picking_id*/,
+                                   int /*x*/, int /*y*/) {}
 };
 
 #endif  // ORBIT_GL_GL_CANVAS_H_

--- a/src/OrbitGl/GlSlider.cpp
+++ b/src/OrbitGl/GlSlider.cpp
@@ -183,7 +183,7 @@ bool GlSlider::HandlePageScroll(float click_value) {
 void GlVerticalSlider::Draw(GlCanvas* canvas) {
   CHECK(canvas == canvas_);
 
-  float x = canvas_->GetViewport().GetWidth() - GetPixelHeight();
+  float x = canvas_->GetViewport().GetScreenWidth() - GetPixelHeight();
 
   float bar_pixel_len = GetBarPixelLength();
   float slider_height = ceilf(length_ratio_ * bar_pixel_len);
@@ -200,7 +200,7 @@ void GlVerticalSlider::Draw(GlCanvas* canvas) {
 }
 
 int GlVerticalSlider::GetBarPixelLength() const {
-  return canvas_->GetViewport().GetHeight() - GetOrthogonalSliderSize();
+  return canvas_->GetViewport().GetScreenHeight() - GetOrthogonalSliderSize();
 }
 
 void GlHorizontalSlider::Draw(GlCanvas* canvas) {
@@ -271,5 +271,5 @@ void GlHorizontalSlider::Draw(GlCanvas* canvas) {
 }
 
 int GlHorizontalSlider::GetBarPixelLength() const {
-  return canvas_->GetViewport().GetWidth() - GetOrthogonalSliderSize();
+  return canvas_->GetViewport().GetScreenWidth() - GetOrthogonalSliderSize();
 }

--- a/src/OrbitGl/GlSlider.cpp
+++ b/src/OrbitGl/GlSlider.cpp
@@ -183,7 +183,7 @@ bool GlSlider::HandlePageScroll(float click_value) {
 void GlVerticalSlider::Draw(GlCanvas* canvas) {
   CHECK(canvas == canvas_);
 
-  float x = canvas_->GetWidth() - GetPixelHeight();
+  float x = canvas_->GetViewport().GetWidth() - GetPixelHeight();
 
   float bar_pixel_len = GetBarPixelLength();
   float slider_height = ceilf(length_ratio_ * bar_pixel_len);
@@ -200,7 +200,7 @@ void GlVerticalSlider::Draw(GlCanvas* canvas) {
 }
 
 int GlVerticalSlider::GetBarPixelLength() const {
-  return canvas_->GetHeight() - GetOrthogonalSliderSize();
+  return canvas_->GetViewport().GetHeight() - GetOrthogonalSliderSize();
 }
 
 void GlHorizontalSlider::Draw(GlCanvas* canvas) {
@@ -271,5 +271,5 @@ void GlHorizontalSlider::Draw(GlCanvas* canvas) {
 }
 
 int GlHorizontalSlider::GetBarPixelLength() const {
-  return canvas_->GetWidth() - GetOrthogonalSliderSize();
+  return canvas_->GetViewport().GetWidth() - GetOrthogonalSliderSize();
 }

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -27,9 +27,9 @@ void GraphTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t 
                                   PickingMode picking_mode, float z_offset) {
   GlCanvas* canvas = time_graph_->GetCanvas();
 
-  float track_width = canvas->GetWorldWidth();
+  float track_width = canvas->GetViewport().GetWorldWidth();
   SetSize(track_width, GetHeight());
-  pos_[0] = canvas->GetWorldTopLeftX();
+  pos_[0] = canvas->GetViewport().GetWorldTopLeft()[0];
 
   Color color = GetBackgroundColor();
   const Color kLineColor(0, 128, 255, 128);
@@ -181,7 +181,7 @@ void GraphTrack::DrawLabel(GlCanvas* canvas, Vec2 target_pos, const std::string&
 
   float arrow_width = text_box_size[1] / 2.f;
   bool arrow_is_left_directed =
-      target_pos[0] < canvas->GetWorldTopLeftX() + text_box_size[0] + arrow_width;
+      target_pos[0] < canvas->GetViewport().GetWorldTopLeft()[0] + text_box_size[0] + arrow_width;
   Vec2 text_box_position(
       target_pos[0] + (arrow_is_left_directed ? arrow_width : -arrow_width - text_box_size[0]),
       target_pos[1] - text_box_size[1] / 2.f);

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -26,10 +26,11 @@ GraphTrack::GraphTrack(CaptureViewElement* parent, TimeGraph* time_graph, TimeGr
 void GraphTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                                   PickingMode picking_mode, float z_offset) {
   GlCanvas* canvas = time_graph_->GetCanvas();
+  const orbit_gl::Viewport& viewport = canvas->GetViewport();
 
-  float track_width = canvas->GetViewport().GetWorldWidth();
+  float track_width = viewport.GetVisibleWorldWidth();
   SetSize(track_width, GetHeight());
-  pos_[0] = canvas->GetViewport().GetWorldTopLeft()[0];
+  pos_[0] = viewport.GetWorldTopLeft()[0];
 
   Color color = GetBackgroundColor();
   const Color kLineColor(0, 128, 255, 128);

--- a/src/OrbitGl/ImGuiOrbit.cpp
+++ b/src/OrbitGl/ImGuiOrbit.cpp
@@ -643,9 +643,10 @@ void Orbit_ImGui_NewFrame(GlCanvas* a_Canvas) {
   }
 
   // Setup inputs
-  io.MousePos = ImVec2(a_Canvas->GetMousePosX(),
-                       a_Canvas->GetMousePosY());  // Mouse position in screen coordinates (set to
-                                                   // -1,-1 if no mouse / on another screen, etc.)
+  io.MousePos =
+      ImVec2(a_Canvas->GetMouseScreenPos()[0],
+             a_Canvas->GetMouseScreenPos()[1]);  // Mouse position in screen coordinates (set to
+                                                 // -1,-1 if no mouse / on another screen, etc.)
 
   for (int i = 0; i < 3; i++) {
     io.MouseDown[i] = g_MousePressed[i];

--- a/src/OrbitGl/ImGuiOrbit.cpp
+++ b/src/OrbitGl/ImGuiOrbit.cpp
@@ -630,10 +630,11 @@ void Orbit_ImGui_NewFrame(GlCanvas* a_Canvas) {
   if (!g_FontTexture) Orbit_ImGui_CreateDeviceObjects();
 
   ImGuiIO& io = ImGui::GetIO();
+  const orbit_gl::Viewport& viewport = a_Canvas->GetViewport();
 
   // Setup display size (every frame to accommodate for window resizing)
-  const int w = a_Canvas->GetViewport().GetWidth();
-  const int h = a_Canvas->GetViewport().GetHeight();
+  const int w = viewport.GetScreenWidth();
+  const int h = viewport.GetScreenHeight();
   io.DisplaySize = ImVec2(w, h);
 
   // Setup time step

--- a/src/OrbitGl/ImGuiOrbit.cpp
+++ b/src/OrbitGl/ImGuiOrbit.cpp
@@ -632,8 +632,8 @@ void Orbit_ImGui_NewFrame(GlCanvas* a_Canvas) {
   ImGuiIO& io = ImGui::GetIO();
 
   // Setup display size (every frame to accommodate for window resizing)
-  const int w = a_Canvas->GetWidth();
-  const int h = a_Canvas->GetHeight();
+  const int w = a_Canvas->GetViewport().GetWidth();
+  const int h = a_Canvas->GetViewport().GetHeight();
   io.DisplaySize = ImVec2(w, h);
 
   // Setup time step

--- a/src/OrbitGl/IntrospectionWindow.cpp
+++ b/src/OrbitGl/IntrospectionWindow.cpp
@@ -28,7 +28,7 @@ bool IntrospectionWindow::IsIntrospecting() const { return introspection_listene
 
 void IntrospectionWindow::StartIntrospection() {
   CHECK(!IsIntrospecting());
-  draw_help_ = false;
+  set_draw_help(false);
   CreateTimeGraph(nullptr);
   introspection_listener_ =
       std::make_unique<orbit_base::TracingListener>([this](const orbit_base::TracingScope& scope) {
@@ -45,7 +45,7 @@ void IntrospectionWindow::StartIntrospection() {
         timer_info.add_registers(scope.encoded_event.args[3]);
         timer_info.add_registers(scope.encoded_event.args[4]);
         timer_info.add_registers(scope.encoded_event.args[5]);
-        time_graph_->ProcessTimer(timer_info, /*FunctionInfo*/ nullptr);
+        GetTimeGraph()->ProcessTimer(timer_info, /*FunctionInfo*/ nullptr);
       });
 }
 void IntrospectionWindow::StopIntrospection() { introspection_listener_ = nullptr; }

--- a/src/OrbitGl/IntrospectionWindow.h
+++ b/src/OrbitGl/IntrospectionWindow.h
@@ -29,11 +29,10 @@ class IntrospectionWindow : public CaptureWindow {
   void DrawScreenSpace() override;
   void RenderText(float layer) override;
 
- protected:
+ private:
   [[nodiscard]] const char* GetHelpText() const override;
   [[nodiscard]] bool ShouldAutoZoom() const override;
 
- private:
   std::unique_ptr<orbit_base::TracingListener> introspection_listener_;
 };
 

--- a/src/OrbitGl/SliderTest.cpp
+++ b/src/OrbitGl/SliderTest.cpp
@@ -13,13 +13,6 @@
 #include "GlCanvas.h"
 #include "GlSlider.h"
 
-class MockCanvas : public GlCanvas {
- public:
-  MockCanvas() : GlCanvas() {}
-  MOCK_METHOD(int, GetWidth, (), (const, override));
-  MOCK_METHOD(int, GetHeight, (), (const, override));
-};
-
 template <int dim>
 void Pick(GlSlider& slider, int start, int other_dim = 0) {
   static_assert(dim >= 0 && dim <= 1);
@@ -58,11 +51,9 @@ void PickDragRelease(GlSlider& slider, int start, int end = -1, int other_dim = 
 }
 
 template <typename SliderClass>
-std::pair<std::unique_ptr<SliderClass>, std::unique_ptr<MockCanvas>> Setup() {
-  std::unique_ptr<MockCanvas> canvas = std::make_unique<MockCanvas>();
-  // Simulate a 1000x100 canvas
-  EXPECT_CALL(*canvas, GetWidth()).WillRepeatedly(::testing::Return(150));
-  EXPECT_CALL(*canvas, GetHeight()).WillRepeatedly(::testing::Return(1050));
+std::pair<std::unique_ptr<SliderClass>, std::unique_ptr<GlCanvas>> Setup() {
+  std::unique_ptr<GlCanvas> canvas = std::make_unique<GlCanvas>();
+  canvas->Resize(150, 1050);
 
   std::unique_ptr<SliderClass> slider = std::make_unique<SliderClass>();
   slider->SetCanvas(canvas.get());
@@ -73,8 +64,8 @@ std::pair<std::unique_ptr<SliderClass>, std::unique_ptr<MockCanvas>> Setup() {
   slider->SetNormalizedPosition(0.5f);
   slider->SetNormalizedLength(0.5f);
 
-  return std::make_pair<std::unique_ptr<SliderClass>, std::unique_ptr<MockCanvas>>(
-      std::move(slider), std::move(canvas));
+  return std::make_pair<std::unique_ptr<SliderClass>, std::unique_ptr<GlCanvas>>(std::move(slider),
+                                                                                 std::move(canvas));
 }
 
 const float kEpsilon = 0.01f;

--- a/src/OrbitGl/TextRenderer.cpp
+++ b/src/OrbitGl/TextRenderer.cpp
@@ -296,17 +296,18 @@ void TextRenderer::AddText(const char* text, float x, float y, float z, const Co
   vec2 out_screen_size;
   AddTextInternal(GetFont(font_size), text, ColorToVec4(color), &pen_, max_size, z, &out_screen_pos,
                   &out_screen_size);
+
+  const orbit_gl::Viewport& viewport = canvas_->GetViewport();
+
   if (out_text_pos) {
-    float inv_y = canvas_->GetViewport().GetHeight() - out_screen_pos.y;
-    (*out_text_pos) = canvas_->GetViewport().ScreenToWorldPos(
+    float inv_y = viewport.GetScreenHeight() - out_screen_pos.y;
+    (*out_text_pos) = viewport.ScreenToWorldPos(
         Vec2i(static_cast<int>(out_screen_pos.x), static_cast<int>(inv_y)));
   }
 
   if (out_text_size) {
-    (*out_text_size)[0] =
-        canvas_->GetViewport().ScreenToWorldWidth(static_cast<int>(out_screen_size.x));
-    (*out_text_size)[1] =
-        canvas_->GetViewport().ScreenToWorldHeight(static_cast<int>(out_screen_size.y));
+    (*out_text_size)[0] = viewport.ScreenToWorldWidth(static_cast<int>(out_screen_size.x));
+    (*out_text_size)[1] = viewport.ScreenToWorldHeight(static_cast<int>(out_screen_size.y));
   }
 }
 
@@ -436,17 +437,20 @@ std::vector<float> TextRenderer::GetLayers() const {
 };
 
 void TextRenderer::ToScreenSpace(float x, float y, float& o_x, float& o_y) {
-  float world_width = canvas_->GetViewport().GetWorldWidth();
-  float world_height = canvas_->GetViewport().GetWorldHeight();
-  float world_top_left_x = canvas_->GetViewport().GetWorldTopLeft()[0];
-  float world_min_left_y = canvas_->GetViewport().GetWorldTopLeft()[1] - world_height;
+  const orbit_gl::Viewport& viewport = canvas_->GetViewport();
 
-  o_x = ((x - world_top_left_x) / world_width) * canvas_->GetViewport().GetWidth();
-  o_y = ((y - world_min_left_y) / world_height) * canvas_->GetViewport().GetHeight();
+  float world_width = viewport.GetVisibleWorldWidth();
+  float world_height = viewport.GetVisibleWorldHeight();
+  float world_top_left_x = viewport.GetWorldTopLeft()[0];
+  float world_min_left_y = viewport.GetWorldTopLeft()[1] - world_height;
+
+  o_x = ((x - world_top_left_x) / world_width) * viewport.GetScreenWidth();
+  o_y = ((y - world_min_left_y) / world_height) * viewport.GetScreenHeight();
 }
 
 float TextRenderer::ToScreenSpace(float width) {
-  return (width / canvas_->GetViewport().GetWorldWidth()) * canvas_->GetViewport().GetWidth();
+  return (width / canvas_->GetViewport().GetVisibleWorldWidth()) *
+         canvas_->GetViewport().GetScreenWidth();
 }
 
 void TextRenderer::Clear() {

--- a/src/OrbitGl/TextRenderer.cpp
+++ b/src/OrbitGl/TextRenderer.cpp
@@ -298,12 +298,15 @@ void TextRenderer::AddText(const char* text, float x, float y, float z, const Co
                   &out_screen_size);
   if (out_text_pos) {
     float inv_y = canvas_->GetViewport().GetHeight() - out_screen_pos.y;
-    (*out_text_pos) = canvas_->ScreenToWorld(Vec2(out_screen_pos.x, inv_y));
+    (*out_text_pos) = canvas_->GetViewport().ScreenToWorldPos(
+        Vec2i(static_cast<int>(out_screen_pos.x), static_cast<int>(inv_y)));
   }
 
   if (out_text_size) {
-    (*out_text_size)[0] = canvas_->ScreenToWorldWidth(static_cast<int>(out_screen_size.x));
-    (*out_text_size)[1] = canvas_->ScreenToWorldHeight(static_cast<int>(out_screen_size.y));
+    (*out_text_size)[0] =
+        canvas_->GetViewport().ScreenToWorldWidth(static_cast<int>(out_screen_size.x));
+    (*out_text_size)[1] =
+        canvas_->GetViewport().ScreenToWorldHeight(static_cast<int>(out_screen_size.y));
   }
 }
 
@@ -378,11 +381,11 @@ float TextRenderer::AddTextTrailingCharsPrioritized(const char* text, float x, f
 }
 
 float TextRenderer::GetStringWidth(const char* text, uint32_t font_size) {
-  return canvas_->ScreenToWorldWidth(GetStringWidthScreenSpace(text, font_size));
+  return canvas_->GetViewport().ScreenToWorldWidth(GetStringWidthScreenSpace(text, font_size));
 }
 
 float TextRenderer::GetStringHeight(const char* text, uint32_t font_size) {
-  return canvas_->ScreenToWorldHeight(GetStringHeightScreenSpace(text, font_size));
+  return canvas_->GetViewport().ScreenToWorldHeight(GetStringHeightScreenSpace(text, font_size));
 }
 
 int TextRenderer::GetStringWidthScreenSpace(const char* text, uint32_t font_size) {

--- a/src/OrbitGl/TextRenderer.cpp
+++ b/src/OrbitGl/TextRenderer.cpp
@@ -297,7 +297,7 @@ void TextRenderer::AddText(const char* text, float x, float y, float z, const Co
   AddTextInternal(GetFont(font_size), text, ColorToVec4(color), &pen_, max_size, z, &out_screen_pos,
                   &out_screen_size);
   if (out_text_pos) {
-    float inv_y = canvas_->GetHeight() - out_screen_pos.y;
+    float inv_y = canvas_->GetViewport().GetHeight() - out_screen_pos.y;
     (*out_text_pos) = canvas_->ScreenToWorld(Vec2(out_screen_pos.x, inv_y));
   }
 
@@ -433,17 +433,17 @@ std::vector<float> TextRenderer::GetLayers() const {
 };
 
 void TextRenderer::ToScreenSpace(float x, float y, float& o_x, float& o_y) {
-  float world_width = canvas_->GetWorldWidth();
-  float world_height = canvas_->GetWorldHeight();
-  float world_top_left_x = canvas_->GetWorldTopLeftX();
-  float world_min_left_y = canvas_->GetWorldTopLeftY() - world_height;
+  float world_width = canvas_->GetViewport().GetWorldWidth();
+  float world_height = canvas_->GetViewport().GetWorldHeight();
+  float world_top_left_x = canvas_->GetViewport().GetWorldTopLeft()[0];
+  float world_min_left_y = canvas_->GetViewport().GetWorldTopLeft()[1] - world_height;
 
-  o_x = ((x - world_top_left_x) / world_width) * canvas_->GetWidth();
-  o_y = ((y - world_min_left_y) / world_height) * canvas_->GetHeight();
+  o_x = ((x - world_top_left_x) / world_width) * canvas_->GetViewport().GetWidth();
+  o_y = ((y - world_min_left_y) / world_height) * canvas_->GetViewport().GetHeight();
 }
 
 float TextRenderer::ToScreenSpace(float width) {
-  return (width / canvas_->GetWorldWidth()) * canvas_->GetWidth();
+  return (width / canvas_->GetViewport().GetWorldWidth()) * canvas_->GetViewport().GetWidth();
 }
 
 void TextRenderer::Clear() {

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -163,12 +163,13 @@ void ThreadStateBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint6
   ThreadBar::UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
 
   const GlCanvas* canvas = time_graph_->GetCanvas();
+  const orbit_gl::Viewport& viewport = canvas->GetViewport();
 
   const auto time_window_ns = static_cast<uint64_t>(1000 * time_graph_->GetTimeWindowUs());
-  const uint64_t pixel_delta_ns = time_window_ns / canvas->GetViewport().GetWidth();
+  const uint64_t pixel_delta_ns = time_window_ns / viewport.GetScreenWidth();
   const uint64_t min_time_graph_ns = time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
   const float pixel_width_in_world_coords =
-      canvas->GetViewport().GetWorldWidth() / static_cast<float>(canvas->GetViewport().GetWidth());
+      viewport.GetVisibleWorldWidth() / static_cast<float>(viewport.GetScreenWidth());
 
   uint64_t ignore_until_ns = 0;
 

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -165,10 +165,10 @@ void ThreadStateBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint6
   const GlCanvas* canvas = time_graph_->GetCanvas();
 
   const auto time_window_ns = static_cast<uint64_t>(1000 * time_graph_->GetTimeWindowUs());
-  const uint64_t pixel_delta_ns = time_window_ns / canvas->GetWidth();
+  const uint64_t pixel_delta_ns = time_window_ns / canvas->GetViewport().GetWidth();
   const uint64_t min_time_graph_ns = time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
   const float pixel_width_in_world_coords =
-      canvas->GetWorldWidth() / static_cast<float>(canvas->GetWidth());
+      canvas->GetViewport().GetWorldWidth() / static_cast<float>(canvas->GetViewport().GetWidth());
 
   uint64_t ignore_until_ns = 0;
 

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -276,17 +276,17 @@ void ThreadTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offse
   const float tracepoint_track_height = layout_->GetEventTrackHeight();
 
   if (!thread_state_bar_->IsEmpty()) {
-    thread_state_bar_->SetSize(canvas->GetWorldWidth(), thread_state_track_height);
+    thread_state_bar_->SetSize(canvas->GetViewport().GetWorldWidth(), thread_state_track_height);
     thread_state_bar_->Draw(canvas, picking_mode, z_offset);
   }
 
   if (!event_bar_->IsEmpty()) {
-    event_bar_->SetSize(canvas->GetWorldWidth(), event_track_height);
+    event_bar_->SetSize(canvas->GetViewport().GetWorldWidth(), event_track_height);
     event_bar_->Draw(canvas, picking_mode, z_offset);
   }
 
   if (!tracepoint_bar_->IsEmpty()) {
-    tracepoint_bar_->SetSize(canvas->GetWorldWidth(), tracepoint_track_height);
+    tracepoint_bar_->SetSize(canvas->GetViewport().GetWorldWidth(), tracepoint_track_height);
     tracepoint_bar_->Draw(canvas, picking_mode, z_offset);
   }
 }

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -274,19 +274,20 @@ void ThreadTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offse
   const float thread_state_track_height = layout_->GetThreadStateTrackHeight();
   const float event_track_height = layout_->GetEventTrackHeight();
   const float tracepoint_track_height = layout_->GetEventTrackHeight();
+  const float world_width = canvas->GetViewport().GetVisibleWorldWidth();
 
   if (!thread_state_bar_->IsEmpty()) {
-    thread_state_bar_->SetSize(canvas->GetViewport().GetWorldWidth(), thread_state_track_height);
+    thread_state_bar_->SetSize(world_width, thread_state_track_height);
     thread_state_bar_->Draw(canvas, picking_mode, z_offset);
   }
 
   if (!event_bar_->IsEmpty()) {
-    event_bar_->SetSize(canvas->GetViewport().GetWorldWidth(), event_track_height);
+    event_bar_->SetSize(world_width, event_track_height);
     event_bar_->Draw(canvas, picking_mode, z_offset);
   }
 
   if (!tracepoint_bar_->IsEmpty()) {
-    tracepoint_bar_->SetSize(canvas->GetViewport().GetWorldWidth(), tracepoint_track_height);
+    tracepoint_bar_->SetSize(world_width, tracepoint_track_height);
     tracepoint_bar_->Draw(canvas, picking_mode, z_offset);
   }
 }
@@ -443,7 +444,8 @@ static inline void ResizeTextBox(const internal::DrawData& draw_data, const Time
 [[nodiscard]] static inline uint64_t GetNextPixelBoundaryTimeNs(
     float world_x, const internal::DrawData& draw_data) {
   float normalized_x = (world_x - draw_data.world_start_x) / draw_data.world_width;
-  int pixel_x = static_cast<int>(ceil(normalized_x * draw_data.canvas->GetViewport().GetWidth()));
+  int pixel_x =
+      static_cast<int>(ceil(normalized_x * draw_data.canvas->GetViewport().GetScreenWidth()));
   return draw_data.min_tick + pixel_x * draw_data.ns_per_pixel;
 }
 

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -443,7 +443,7 @@ static inline void ResizeTextBox(const internal::DrawData& draw_data, const Time
 [[nodiscard]] static inline uint64_t GetNextPixelBoundaryTimeNs(
     float world_x, const internal::DrawData& draw_data) {
   float normalized_x = (world_x - draw_data.world_start_x) / draw_data.world_width;
-  int pixel_x = static_cast<int>(ceil(normalized_x * draw_data.canvas->GetWidth()));
+  int pixel_x = static_cast<int>(ceil(normalized_x * draw_data.canvas->GetViewport().GetWidth()));
   return draw_data.min_tick + pixel_x * draw_data.ns_per_pixel;
 }
 

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -689,7 +689,8 @@ const std::vector<CallstackEvent>& TimeGraph::GetSelectedCallstackEvents(int32_t
 
 void TimeGraph::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
   ORBIT_SCOPE("TimeGraph::Draw");
-  current_mouse_time_ns_ = GetTickFromWorld(canvas_->GetMouseX());
+  current_mouse_time_ns_ =
+      GetTickFromWorld(canvas->GetViewport().ScreenToWorldPos(canvas_->GetMouseScreenPos())[0]);
 
   const bool picking = picking_mode != PickingMode::kNone;
   if ((!picking && update_primitives_requested_) || picking) {

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -147,7 +147,7 @@ void TimeGraph::VerticalZoom(float zoom_value, float mouse_relative_position) {
 
   const float ratio = (zoom_value > 0) ? (1 + kIncrementRatio) : (1 / (1 + kIncrementRatio));
 
-  const float world_height = canvas_->GetViewport().GetWorldHeight();
+  const float world_height = canvas_->GetViewport().GetVisibleWorldHeight();
   const float y_mouse_position =
       canvas_->GetViewport().GetWorldTopLeft()[1] - mouse_relative_position * world_height;
   const float top_distance = canvas_->GetViewport().GetWorldTopLeft()[1] - y_mouse_position;
@@ -227,7 +227,7 @@ void TimeGraph::VerticallyMoveIntoView(Track& track) {
 
   float min_world_top_left_y = pos + layout_.GetTrackTabHeight();
   float max_world_top_left_y =
-      pos + canvas_->GetViewport().GetWorldHeight() - height - layout_.GetBottomMargin();
+      pos + canvas_->GetViewport().GetVisibleWorldHeight() - height - layout_.GetBottomMargin();
   canvas_->GetViewport().SetWorldTopLeftY(
       clamp(world_top_left_y, min_world_top_left_y, max_world_top_left_y));
 }
@@ -646,7 +646,7 @@ void TimeGraph::UpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/, ui
 
   time_window_us_ = max_time_us_ - min_time_us_;
   world_start_x_ = canvas_->GetViewport().GetWorldTopLeft()[0];
-  world_width_ = canvas_->GetViewport().GetWorldWidth();
+  world_width_ = canvas_->GetViewport().GetVisibleWorldWidth();
   uint64_t min_tick = GetTickFromUs(min_time_us_);
   uint64_t max_tick = GetTickFromUs(max_time_us_);
 
@@ -777,11 +777,13 @@ void TimeGraph::DrawOverlay(GlCanvas* canvas, PickingMode picking_mode) {
   std::vector<float> x_coords;
   x_coords.reserve(boxes.size());
 
-  float world_start_x = canvas->GetViewport().GetWorldTopLeft()[0];
-  float world_width = canvas->GetViewport().GetWorldWidth();
+  const orbit_gl::Viewport& viewport = canvas->GetViewport();
 
-  float world_start_y = canvas->GetViewport().GetWorldTopLeft()[1];
-  float world_height = canvas->GetViewport().GetWorldHeight();
+  float world_start_x = viewport.GetWorldTopLeft()[0];
+  float world_width = viewport.GetVisibleWorldWidth();
+
+  float world_start_y = viewport.GetWorldTopLeft()[1];
+  float world_height = viewport.GetVisibleWorldHeight();
 
   double inv_time_window = 1.0 / GetTimeWindowUs();
 
@@ -1030,5 +1032,5 @@ void TimeGraph::RemoveFrameTrack(uint64_t function_id) {
 }
 
 std::unique_ptr<orbit_accessibility::AccessibleInterface> TimeGraph::CreateAccessibleInterface() {
-  return std::make_unique<TimeGraphAccessibility>(this);
+  return std::make_unique<orbit_gl::TimeGraphAccessibility>(this);
 }

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -37,9 +37,9 @@ TimerTrack::TimerTrack(CaptureViewElement* parent, TimeGraph* time_graph, TimeGr
 
 void TimerTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
   float track_height = GetHeight();
-  float track_width = canvas->GetWorldWidth();
+  float track_width = canvas->GetViewport().GetWorldWidth();
 
-  SetPos(canvas->GetWorldTopLeftX(), pos_[1]);
+  SetPos(canvas->GetViewport().GetWorldTopLeft()[0], pos_[1]);
   SetSize(track_width, track_height);
 
   Track::Draw(canvas, picking_mode, z_offset);
@@ -160,7 +160,7 @@ bool TimerTrack::DrawTimer(const TextBox* prev_text_box, const TextBox* next_tex
     double text_x_end_us = end_or_next_start_us + (.25 * right_overlap_width_us);
 
     bool is_visible_width = ((text_x_end_us - text_x_start_us) * draw_data.inv_time_window *
-                             draw_data.canvas->GetWidth()) > 1;
+                             draw_data.canvas->GetViewport().GetWidth()) > 1;
     WorldXInfo world_x_info = ToWorldX(text_x_start_us, text_x_end_us, draw_data.inv_time_window,
                                        draw_data.world_start_x, draw_data.world_width);
 
@@ -183,7 +183,8 @@ bool TimerTrack::DrawTimer(const TextBox* prev_text_box, const TextBox* next_tex
 
   Color color = GetTimerColor(current_timer_info, is_selected, is_highlighted);
 
-  bool is_visible_width = elapsed_us * draw_data.inv_time_window * draw_data.canvas->GetWidth() > 1;
+  bool is_visible_width =
+      elapsed_us * draw_data.inv_time_window * draw_data.canvas->GetViewport().GetWidth() > 1;
 
   if (is_visible_width) {
     WorldXInfo world_x_info_left_overlap =
@@ -248,8 +249,8 @@ void TimerTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t 
   draw_data.batcher = batcher;
   draw_data.canvas = time_graph_->GetCanvas();
 
-  draw_data.world_start_x = draw_data.canvas->GetWorldTopLeftX();
-  draw_data.world_width = draw_data.canvas->GetWorldWidth();
+  draw_data.world_start_x = draw_data.canvas->GetViewport().GetWorldTopLeft()[0];
+  draw_data.world_width = draw_data.canvas->GetViewport().GetWorldWidth();
   draw_data.inv_time_window = 1.0 / time_graph_->GetTimeWindowUs();
   draw_data.is_collapsed = collapse_toggle_->IsCollapsed();
 
@@ -264,7 +265,7 @@ void TimerTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t 
   // enough that all events are drawn as boxes, this has no effect. When zoomed
   // out, many events will be discarded quickly.
   uint64_t time_window_ns = static_cast<uint64_t>(1000 * time_graph_->GetTimeWindowUs());
-  draw_data.ns_per_pixel = time_window_ns / draw_data.canvas->GetWidth();
+  draw_data.ns_per_pixel = time_window_ns / draw_data.canvas->GetViewport().GetWidth();
   draw_data.min_timegraph_tick = time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
 
   for (auto& chain : chains_by_depth) {

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -441,8 +441,8 @@ internal::DrawData TimerTrack::GetDrawData(uint64_t min_tick, uint64_t max_tick,
   draw_data.z_offset = z_offset;
   draw_data.batcher = batcher;
   draw_data.canvas = time_graph->GetCanvas();
-  draw_data.world_start_x = draw_data.canvas->GetWorldTopLeftX();
-  draw_data.world_width = draw_data.canvas->GetWorldWidth();
+  draw_data.world_start_x = draw_data.canvas->GetViewport().GetWorldTopLeft()[0];
+  draw_data.world_width = draw_data.canvas->GetViewport().GetWorldWidth();
   draw_data.inv_time_window = 1.0 / time_graph->GetTimeWindowUs();
   draw_data.is_collapsed = is_collapsed;
   draw_data.z = GlCanvas::kZValueBox + z_offset;
@@ -450,7 +450,7 @@ internal::DrawData TimerTrack::GetDrawData(uint64_t min_tick, uint64_t max_tick,
   draw_data.highlighted_function_id = highlighted_function_id;
 
   uint64_t time_window_ns = static_cast<uint64_t>(1000 * time_graph->GetTimeWindowUs());
-  draw_data.ns_per_pixel = time_window_ns / draw_data.canvas->GetWidth();
+  draw_data.ns_per_pixel = time_window_ns / draw_data.canvas->GetViewport().GetWidth();
   draw_data.min_timegraph_tick = time_graph->GetTickFromUs(time_graph->GetMinTimeUs());
   return draw_data;
 }

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -36,10 +36,11 @@ TimerTrack::TimerTrack(CaptureViewElement* parent, TimeGraph* time_graph, TimeGr
 }
 
 void TimerTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
+  const orbit_gl::Viewport& viewport = canvas->GetViewport();
   float track_height = GetHeight();
-  float track_width = canvas->GetViewport().GetWorldWidth();
+  float track_width = viewport.GetVisibleWorldWidth();
 
-  SetPos(canvas->GetViewport().GetWorldTopLeft()[0], pos_[1]);
+  SetPos(viewport.GetWorldTopLeft()[0], pos_[1]);
   SetSize(track_width, track_height);
 
   Track::Draw(canvas, picking_mode, z_offset);
@@ -160,7 +161,7 @@ bool TimerTrack::DrawTimer(const TextBox* prev_text_box, const TextBox* next_tex
     double text_x_end_us = end_or_next_start_us + (.25 * right_overlap_width_us);
 
     bool is_visible_width = ((text_x_end_us - text_x_start_us) * draw_data.inv_time_window *
-                             draw_data.canvas->GetViewport().GetWidth()) > 1;
+                             draw_data.canvas->GetViewport().GetScreenWidth()) > 1;
     WorldXInfo world_x_info = ToWorldX(text_x_start_us, text_x_end_us, draw_data.inv_time_window,
                                        draw_data.world_start_x, draw_data.world_width);
 
@@ -184,7 +185,7 @@ bool TimerTrack::DrawTimer(const TextBox* prev_text_box, const TextBox* next_tex
   Color color = GetTimerColor(current_timer_info, is_selected, is_highlighted);
 
   bool is_visible_width =
-      elapsed_us * draw_data.inv_time_window * draw_data.canvas->GetViewport().GetWidth() > 1;
+      elapsed_us * draw_data.inv_time_window * draw_data.canvas->GetViewport().GetScreenWidth() > 1;
 
   if (is_visible_width) {
     WorldXInfo world_x_info_left_overlap =
@@ -250,7 +251,7 @@ void TimerTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t 
   draw_data.canvas = time_graph_->GetCanvas();
 
   draw_data.world_start_x = draw_data.canvas->GetViewport().GetWorldTopLeft()[0];
-  draw_data.world_width = draw_data.canvas->GetViewport().GetWorldWidth();
+  draw_data.world_width = draw_data.canvas->GetViewport().GetVisibleWorldWidth();
   draw_data.inv_time_window = 1.0 / time_graph_->GetTimeWindowUs();
   draw_data.is_collapsed = collapse_toggle_->IsCollapsed();
 
@@ -265,7 +266,7 @@ void TimerTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t 
   // enough that all events are drawn as boxes, this has no effect. When zoomed
   // out, many events will be discarded quickly.
   uint64_t time_window_ns = static_cast<uint64_t>(1000 * time_graph_->GetTimeWindowUs());
-  draw_data.ns_per_pixel = time_window_ns / draw_data.canvas->GetViewport().GetWidth();
+  draw_data.ns_per_pixel = time_window_ns / draw_data.canvas->GetViewport().GetScreenWidth();
   draw_data.min_timegraph_tick = time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
 
   for (auto& chain : chains_by_depth) {
@@ -442,7 +443,7 @@ internal::DrawData TimerTrack::GetDrawData(uint64_t min_tick, uint64_t max_tick,
   draw_data.batcher = batcher;
   draw_data.canvas = time_graph->GetCanvas();
   draw_data.world_start_x = draw_data.canvas->GetViewport().GetWorldTopLeft()[0];
-  draw_data.world_width = draw_data.canvas->GetViewport().GetWorldWidth();
+  draw_data.world_width = draw_data.canvas->GetViewport().GetVisibleWorldWidth();
   draw_data.inv_time_window = 1.0 / time_graph->GetTimeWindowUs();
   draw_data.is_collapsed = is_collapsed;
   draw_data.z = GlCanvas::kZValueBox + z_offset;
@@ -450,7 +451,7 @@ internal::DrawData TimerTrack::GetDrawData(uint64_t min_tick, uint64_t max_tick,
   draw_data.highlighted_function_id = highlighted_function_id;
 
   uint64_t time_window_ns = static_cast<uint64_t>(1000 * time_graph->GetTimeWindowUs());
-  draw_data.ns_per_pixel = time_window_ns / draw_data.canvas->GetViewport().GetWidth();
+  draw_data.ns_per_pixel = time_window_ns / draw_data.canvas->GetViewport().GetScreenWidth();
   draw_data.min_timegraph_tick = time_graph->GetTickFromUs(time_graph->GetMinTimeUs());
   return draw_data;
 }

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -273,9 +273,9 @@ void TrackManager::UpdateTracks(Batcher* batcher, uint64_t min_tick, uint64_t ma
 
     const float z_offset = GlCanvas::kZOffsetPinnedTrack;
     if (!track->IsMoving()) {
-      track->SetPos(track->GetPos()[0], current_y + time_graph_->GetCanvas()->GetWorldTopLeftY() -
-                                            layout_->GetTopMargin() -
-                                            layout_->GetSchedulerTrackOffset());
+      track->SetPos(track->GetPos()[0],
+                    current_y + time_graph_->GetCanvas()->GetViewport().GetWorldTopLeft()[1] -
+                        layout_->GetTopMargin() - layout_->GetSchedulerTrackOffset());
     }
     track->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
     const float height = (track->GetHeight() + layout_->GetSpaceBetweenTracks());

--- a/src/OrbitGl/Viewport.cpp
+++ b/src/OrbitGl/Viewport.cpp
@@ -10,49 +10,50 @@
 
 namespace orbit_gl {
 
-Viewport::Viewport(int width, int height) : width_(width), height_(height) {
-  world_width_ = width;
-  world_height_ = height;
-  world_extents_ = Vec2(width, height);
-}
+Viewport::Viewport(int width, int height)
+    : screen_width_(width),
+      screen_height_(height),
+      visible_world_width_(width),
+      visible_world_height_(height),
+      world_extents_(Vec2(width, height)) {}
 
 void Viewport::Resize(int width, int height) {
   CHECK(width > 0);
   CHECK(height > 0);
 
-  if (width == width_ && height == height_) return;
+  if (width == screen_width_ && height == screen_height_) return;
 
-  width_ = width;
-  height_ = height;
+  screen_width_ = width;
+  screen_height_ = height;
   FlagAsDirty();
 }
 
-int Viewport::GetWidth() const { return width_; }
+int Viewport::GetScreenWidth() const { return screen_width_; }
 
-int Viewport::GetHeight() const { return height_; }
+int Viewport::GetScreenHeight() const { return screen_height_; }
 
-void Viewport::SetWorldWidth(float width) {
-  if (width == world_width_) return;
+void Viewport::SetVisibleWorldWidth(float width) {
+  if (width == visible_world_width_) return;
 
-  world_width_ = width;
-  // Recalculate required scrolling
+  visible_world_width_ = width;
+  // Recalculate required scrolling.
   SetWorldTopLeftX(world_top_left_[0]);
   FlagAsDirty();
 }
 
-float Viewport::GetWorldWidth() const { return world_width_; }
+float Viewport::GetVisibleWorldWidth() const { return visible_world_width_; }
 
-void Viewport::SetWorldHeight(float height) {
-  if (height == world_height_) return;
+void Viewport::SetVisibleWorldHeight(float height) {
+  if (height == visible_world_height_) return;
 
-  world_height_ = height;
-  // Recalculate required scrolling
+  visible_world_height_ = height;
+  // Recalculate required scrolling.
   SetWorldTopLeftY(world_top_left_[1]);
 
   FlagAsDirty();
 }
 
-float Viewport::GetWorldHeight() const { return world_height_; }
+float Viewport::GetVisibleWorldHeight() const { return visible_world_height_; }
 
 void Viewport::SetWorldExtents(float width, float height) {
   Vec2 size = Vec2(width, height);
@@ -60,17 +61,26 @@ void Viewport::SetWorldExtents(float width, float height) {
   if (size == world_extents_) return;
 
   world_extents_ = size;
-  // Recalculate required scrolling
+  // Recalculate required scrolling.
   SetWorldTopLeftX(world_top_left_[0]);
   SetWorldTopLeftY(world_top_left_[1]);
 
   FlagAsDirty();
 }
 
-Vec2 Viewport::GetWorldExtents() { return world_extents_; }
+const Vec2& Viewport::GetWorldExtents() { return world_extents_; }
+
+void Viewport::SetWorldMin(const Vec2& value) {
+  world_min_ = value;
+  SetWorldTopLeftX(world_top_left_[0]);
+  SetWorldTopLeftY(world_top_left_[1]);
+}
+
+const Vec2& Viewport::GetWorldMin() const { return world_min_; }
 
 void Viewport::SetWorldTopLeftY(float y) {
-  float clamped = std::min(std::max(y, world_height_ - world_extents_[1]), 0.f);
+  float clamped = std::min(std::max(y, visible_world_height_ - world_extents_[1] + world_min_[1]),
+                           world_min_[1]);
   if (world_top_left_[1] == clamped) return;
 
   world_top_left_[1] = clamped;
@@ -78,7 +88,8 @@ void Viewport::SetWorldTopLeftY(float y) {
 }
 
 void Viewport::SetWorldTopLeftX(float x) {
-  float clamped = std::max(std::min(x, world_extents_[0] - world_width_), 0.f);
+  float clamped = std::max(std::min(x, world_extents_[0] - visible_world_width_ + world_min_[0]),
+                           world_min_[0]);
   if (world_top_left_[0] == clamped) return;
 
   world_top_left_[0] = clamped;
@@ -89,41 +100,43 @@ const Vec2& Viewport::GetWorldTopLeft() const { return world_top_left_; }
 
 Vec2 Viewport::ScreenToWorldPos(const Vec2i& screen_pos) const {
   Vec2 world_pos;
-  world_pos[0] = world_top_left_[0] + screen_pos[0] / static_cast<float>(width_) * world_width_;
-  world_pos[1] = world_top_left_[1] - screen_pos[1] / static_cast<float>(height_) * world_height_;
+  world_pos[0] =
+      world_top_left_[0] + screen_pos[0] / static_cast<float>(screen_width_) * visible_world_width_;
+  world_pos[1] = world_top_left_[1] -
+                 screen_pos[1] / static_cast<float>(screen_height_) * visible_world_height_;
   return world_pos;
 }
 
 float Viewport::ScreenToWorldHeight(int height) const {
-  return (static_cast<float>(height) / static_cast<float>(height_)) * world_height_;
+  return (static_cast<float>(height) / static_cast<float>(screen_height_)) * visible_world_height_;
 }
 
 float Viewport::ScreenToWorldWidth(int width) const {
-  return (static_cast<float>(width) / static_cast<float>(width_)) * world_width_;
+  return (static_cast<float>(width) / static_cast<float>(screen_width_)) * visible_world_width_;
 }
 
 Vec2i Viewport::WorldToScreenPos(const Vec2& world_pos) const {
   Vec2i screen_pos;
-  screen_pos[0] =
-      static_cast<int>(floorf((world_pos[0] - world_top_left_[0]) / world_width_ * GetWidth()));
-  screen_pos[1] =
-      static_cast<int>(floorf((world_top_left_[1] - world_pos[1]) / world_height_ * GetHeight()));
+  screen_pos[0] = static_cast<int>(
+      floorf((world_pos[0] - world_top_left_[0]) / visible_world_width_ * GetScreenWidth()));
+  screen_pos[1] = static_cast<int>(
+      floorf((world_top_left_[1] - world_pos[1]) / visible_world_height_ * GetScreenHeight()));
   return screen_pos;
 }
 
 int Viewport::WorldToScreenHeight(float height) const {
-  return static_cast<int>(height / world_height_ * GetHeight());
+  return static_cast<int>(height / visible_world_height_ * GetScreenHeight());
 }
 
 int Viewport::WorldToScreenWidth(float width) const {
-  return static_cast<int>(width / world_width_ * GetWidth());
+  return static_cast<int>(width / visible_world_width_ * GetScreenWidth());
 }
 
 // TODO (b/177350599): Unify QtScreen and GlScreen
 // QtScreen(x,y) --> GlScreen(x,height-y)
 Vec2i Viewport::QtToGlScreenPos(const Vec2i& qt_pos) const {
   Vec2i gl_pos = qt_pos;
-  gl_pos[1] = height_ - qt_pos[1];
+  gl_pos[1] = screen_height_ - qt_pos[1];
   return gl_pos;
 }
 

--- a/src/OrbitGl/Viewport.cpp
+++ b/src/OrbitGl/Viewport.cpp
@@ -1,0 +1,130 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "Viewport.h"
+
+#include <algorithm>
+
+#include "OrbitBase/Logging.h"
+
+namespace orbit_gl {
+
+Viewport::Viewport(int width, int height) : width_(width), height_(height) {
+  world_width_ = width;
+  world_height_ = height;
+  world_extents_ = Vec2(width, height);
+}
+
+void Viewport::Resize(int width, int height) {
+  CHECK(width > 0);
+  CHECK(height > 0);
+
+  if (width == width_ && height == height_) return;
+
+  width_ = width;
+  height_ = height;
+  FlagAsDirty();
+}
+
+int Viewport::GetWidth() const { return width_; }
+
+int Viewport::GetHeight() const { return height_; }
+
+void Viewport::SetWorldWidth(float width) {
+  if (width == world_width_) return;
+
+  world_width_ = width;
+  // Recalculate required scrolling
+  SetWorldTopLeftX(world_top_left_[0]);
+  FlagAsDirty();
+}
+
+float Viewport::GetWorldWidth() const { return world_width_; }
+
+void Viewport::SetWorldHeight(float height) {
+  if (height == world_height_) return;
+
+  world_height_ = height;
+  // Recalculate required scrolling
+  SetWorldTopLeftY(world_top_left_[1]);
+
+  FlagAsDirty();
+}
+
+float Viewport::GetWorldHeight() const { return world_height_; }
+
+void Viewport::SetWorldExtents(float width, float height) {
+  Vec2 size = Vec2(width, height);
+
+  if (size == world_extents_) return;
+
+  world_extents_ = size;
+  // Recalculate required scrolling
+  SetWorldTopLeftX(world_top_left_[0]);
+  SetWorldTopLeftY(world_top_left_[1]);
+
+  FlagAsDirty();
+}
+
+Vec2 Viewport::GetWorldExtents() { return world_extents_; }
+
+void Viewport::SetWorldTopLeftY(float y) {
+  float clamped = std::min(std::max(y, world_height_ - world_extents_[1]), 0.f);
+  if (world_top_left_[1] == clamped) return;
+
+  world_top_left_[1] = clamped;
+  FlagAsDirty();
+}
+
+void Viewport::SetWorldTopLeftX(float x) {
+  float clamped = std::max(std::min(x, world_extents_[0] - world_width_), 0.f);
+  if (world_top_left_[0] == clamped) return;
+
+  world_top_left_[0] = clamped;
+  FlagAsDirty();
+}
+
+const Vec2& Viewport::GetWorldTopLeft() const { return world_top_left_; }
+
+Vec2 Viewport::ScreenToWorldPos(const Vec2i& screen_pos) const {
+  Vec2 world_pos;
+  world_pos[0] = world_top_left_[0] + screen_pos[0] / static_cast<float>(width_) * world_width_;
+  world_pos[1] = world_top_left_[1] - screen_pos[1] / static_cast<float>(height_) * world_height_;
+  return world_pos;
+}
+
+float Viewport::ScreenToWorldHeight(int height) const {
+  return (static_cast<float>(height) / static_cast<float>(height_)) * world_height_;
+}
+
+float Viewport::ScreenToWorldWidth(int width) const {
+  return (static_cast<float>(width) / static_cast<float>(width_)) * world_width_;
+}
+
+Vec2i Viewport::WorldToScreenPos(const Vec2& world_pos) const {
+  Vec2i screen_pos;
+  screen_pos[0] =
+      static_cast<int>(floorf((world_pos[0] - world_top_left_[0]) / world_width_ * GetWidth()));
+  screen_pos[1] =
+      static_cast<int>(floorf((world_top_left_[1] - world_pos[1]) / world_height_ * GetHeight()));
+  return screen_pos;
+}
+
+int Viewport::WorldToScreenHeight(float height) const {
+  return static_cast<int>(height / world_height_ * GetHeight());
+}
+
+int Viewport::WorldToScreenWidth(float width) const {
+  return static_cast<int>(width / world_width_ * GetWidth());
+}
+
+// TODO (b/177350599): Unify QtScreen and GlScreen
+// QtScreen(x,y) --> GlScreen(x,height-y)
+Vec2i Viewport::QtToGlScreenPos(const Vec2i& qt_pos) const {
+  Vec2i gl_pos = qt_pos;
+  gl_pos[1] = height_ - qt_pos[1];
+  return gl_pos;
+}
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/Viewport.h
+++ b/src/OrbitGl/Viewport.h
@@ -9,74 +9,96 @@
 
 namespace orbit_gl {
 
-/**
-Defines a mapping from a 2D screen into a 2D (!) world. Provides functionality to convert between
-coordinate systems, taking scrolling and scaling into account.
+// Defines a mapping from a 2D screen into a 2D (!) world. Provides functionality to convert between
+// coordinate systems, taking scrolling and scaling into account.
+//
+// Uses the following coordinate systems:
+//
+// World:
+//    +y
+//    ^
+//    |
+//    |
+//  (0, 0) ----> +x
+//
+// Screen:
+//  (0, 0) ----> +x
+//    |
+//    |
+//    v
+//    +y
+//
+// where world(0, 0) is initially anchored at screen(0, 0), i.e. top left (meaning basically all
+// world y coordinates are negative). Viewport clamps scrolling X values to be >= world_min, and
+// scrollingY values to be <= world_min.
+//
+// Viewport will indicate if any changes happened that require redraw of the contents in between
+// frames. See Viewport::IsDirty() for usage.
+//
+// NOTE: The screen coordinate system is different from what is referred to as "ScreenSpaceViewport"
+// in GlCanvas! See TODO(b/177350599): Unify QtScreen and GlScreen
 
-Uses the following coordinate systems:
-
-World:
-    ^
-    |
-    |
-  (0, 0) ---->
-
-Screen:
-  (0, 0) ---->
-    |
-    |
-    v
-
-where world(0, 0) is initially anchored at screen(0, 0), i.e. top left (meaning basically all world
-y coordinates are negative). Viewport clamps all X values to be >= 0, and all Y values to be <= 0.
-
-See TODO(b/177350599): Unify QtScreen and GlScreen
-**/
 class Viewport {
  public:
   explicit Viewport(int width, int height);
+  Viewport() = delete;
 
+  // Size of the screen.
   void Resize(int width, int height);
-  [[nodiscard]] int GetWidth() const;
-  [[nodiscard]] int GetHeight() const;
+  [[nodiscard]] int GetScreenWidth() const;
+  [[nodiscard]] int GetScreenHeight() const;
 
-  // Visible size of the world
-  void SetWorldWidth(float width);
-  void SetWorldHeight(float height);
-  [[nodiscard]] float GetWorldWidth() const;
-  [[nodiscard]] float GetWorldHeight() const;
+  // Visible size of the world.
+  void SetVisibleWorldWidth(float width);
+  void SetVisibleWorldHeight(float height);
+  [[nodiscard]] float GetVisibleWorldWidth() const;
+  [[nodiscard]] float GetVisibleWorldHeight() const;
 
-  // Absolute size of the world
+  // Absolute size of the world.
   void SetWorldExtents(float width, float height);
-  [[nodiscard]] Vec2 GetWorldExtents();
+  [[nodiscard]] const Vec2& GetWorldExtents();
 
-  void SetWorldTopLeftY(float y);
+  // Minimum values of the world.
+  void SetWorldMin(const Vec2& value);
+  [[nodiscard]] const Vec2& GetWorldMin() const;
+
+  // Position of world TopLeft anchored at (0, 0) ScreenSpace.
   void SetWorldTopLeftX(float x);
+  void SetWorldTopLeftY(float y);
   [[nodiscard]] const Vec2& GetWorldTopLeft() const;
 
   [[nodiscard]] Vec2 ScreenToWorldPos(const Vec2i& screen_pos) const;
-  [[nodiscard]] float ScreenToWorldHeight(int height) const;
+
+  // These methods to not take scrolling into account, use those if you need
+  // to convert sizes instead of positions.
   [[nodiscard]] float ScreenToWorldWidth(int width) const;
+  [[nodiscard]] float ScreenToWorldHeight(int height) const;
 
   [[nodiscard]] Vec2i WorldToScreenPos(const Vec2& world_pos) const;
-  [[nodiscard]] int WorldToScreenHeight(float height) const;
+
+  // These methods to not take scrolling into account, use those if you need
+  // to convert sizes instead of positions.
   [[nodiscard]] int WorldToScreenWidth(float width) const;
+  [[nodiscard]] int WorldToScreenHeight(float height) const;
 
   [[nodiscard]] Vec2i QtToGlScreenPos(const Vec2i& qt_pos) const;
 
+  // "Dirty" indicates that any action has been performed that requires redraw of
+  // the viewport contents. The flag must explicitely be cleared in each frame.
   [[nodiscard]] bool IsDirty() const { return is_dirty_; }
   void FlagAsDirty() { is_dirty_ = true; }
   void ClearDirtyFlag() { is_dirty_ = false; }
 
  private:
-  int width_;
-  int height_;
+  int screen_width_;
+  int screen_height_;
 
-  float world_width_;
-  float world_height_;
+  float visible_world_width_;
+  float visible_world_height_;
 
   Vec2 world_top_left_ = Vec2(0.f, 0.f);
   Vec2 world_extents_;
+  Vec2 world_min_ = Vec2(0.f, 0.f);
 
   bool is_dirty_ = true;
 };

--- a/src/OrbitGl/Viewport.h
+++ b/src/OrbitGl/Viewport.h
@@ -1,0 +1,85 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_VIEWPORT_H_
+#define ORBIT_GL_VIEWPORT_H_
+
+#include "CoreMath.h"
+
+namespace orbit_gl {
+
+/**
+Defines a mapping from a 2D screen into a 2D (!) world. Provides functionality to convert between
+coordinate systems, taking scrolling and scaling into account.
+
+Uses the following coordinate systems:
+
+World:
+    ^
+    |
+    |
+  (0, 0) ---->
+
+Screen:
+  (0, 0) ---->
+    |
+    |
+    v
+
+where world(0, 0) is initially anchored at screen(0, 0), i.e. top left (meaning basically all world
+y coordinates are negative). Viewport clamps all X values to be >= 0, and all Y values to be <= 0.
+
+See TODO(b/177350599): Unify QtScreen and GlScreen
+**/
+class Viewport {
+ public:
+  explicit Viewport(int width, int height);
+
+  void Resize(int width, int height);
+  [[nodiscard]] int GetWidth() const;
+  [[nodiscard]] int GetHeight() const;
+
+  // Visible size of the world
+  void SetWorldWidth(float width);
+  void SetWorldHeight(float height);
+  [[nodiscard]] float GetWorldWidth() const;
+  [[nodiscard]] float GetWorldHeight() const;
+
+  // Absolute size of the world
+  void SetWorldExtents(float width, float height);
+  [[nodiscard]] Vec2 GetWorldExtents();
+
+  void SetWorldTopLeftY(float y);
+  void SetWorldTopLeftX(float x);
+  [[nodiscard]] const Vec2& GetWorldTopLeft() const;
+
+  [[nodiscard]] Vec2 ScreenToWorldPos(const Vec2i& screen_pos) const;
+  [[nodiscard]] float ScreenToWorldHeight(int height) const;
+  [[nodiscard]] float ScreenToWorldWidth(int width) const;
+
+  [[nodiscard]] Vec2i WorldToScreenPos(const Vec2& world_pos) const;
+  [[nodiscard]] int WorldToScreenHeight(float height) const;
+  [[nodiscard]] int WorldToScreenWidth(float width) const;
+
+  [[nodiscard]] Vec2i QtToGlScreenPos(const Vec2i& qt_pos) const;
+
+  [[nodiscard]] bool IsDirty() const { return is_dirty_; }
+  void FlagAsDirty() { is_dirty_ = true; }
+  void ClearDirtyFlag() { is_dirty_ = false; }
+
+ private:
+  int width_;
+  int height_;
+
+  float world_width_;
+  float world_height_;
+
+  Vec2 world_top_left_ = Vec2(0.f, 0.f);
+  Vec2 world_extents_;
+
+  bool is_dirty_ = true;
+};
+}  // namespace orbit_gl
+
+#endif

--- a/src/OrbitGl/ViewportTest.cpp
+++ b/src/OrbitGl/ViewportTest.cpp
@@ -13,54 +13,55 @@ TEST(Viewport, ResizingAndDirty) {
   EXPECT_TRUE(viewport.IsDirty());
   viewport.ClearDirtyFlag();
 
-  // Test initial values
-  EXPECT_EQ(viewport.GetWidth(), 100);
-  EXPECT_EQ(viewport.GetHeight(), 200);
+  // Test initial values.
+  EXPECT_EQ(viewport.GetScreenWidth(), 100);
+  EXPECT_EQ(viewport.GetScreenHeight(), 200);
   EXPECT_EQ(viewport.GetWorldExtents(), Vec2(100, 200));
-  EXPECT_EQ(viewport.GetWorldWidth(), 100.f);
+  EXPECT_EQ(viewport.GetVisibleWorldWidth(), 100.f);
   EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(0.f, 0.f));
 
-  // Test: Resizing should not affect the world extents
+  // Test: Resizing should not affect the world extents.
   viewport.Resize(1000, 2000);
   EXPECT_TRUE(viewport.IsDirty());
   viewport.ClearDirtyFlag();
+  EXPECT_FALSE(viewport.IsDirty());
 
-  EXPECT_EQ(viewport.GetWidth(), 1000);
-  EXPECT_EQ(viewport.GetHeight(), 2000);
-  EXPECT_EQ(viewport.GetWorldWidth(), 100.f);
-  EXPECT_EQ(viewport.GetWorldHeight(), 200.f);
+  EXPECT_EQ(viewport.GetScreenWidth(), 1000);
+  EXPECT_EQ(viewport.GetScreenHeight(), 2000);
+  EXPECT_EQ(viewport.GetVisibleWorldWidth(), 100.f);
+  EXPECT_EQ(viewport.GetVisibleWorldHeight(), 200.f);
   EXPECT_EQ(viewport.GetWorldExtents(), Vec2(100, 200));
   EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(0.f, 0.f));
 
-  // Test: Changing the world width / height should not affect screen extents
-  viewport.SetWorldWidth(500.f);
+  // Test: Changing the world width / height should not affect screen extents.
+  viewport.SetVisibleWorldWidth(500.f);
   EXPECT_TRUE(viewport.IsDirty());
   viewport.ClearDirtyFlag();
 
-  viewport.SetWorldHeight(600.f);
+  viewport.SetVisibleWorldHeight(600.f);
   EXPECT_TRUE(viewport.IsDirty());
   viewport.ClearDirtyFlag();
 
-  EXPECT_EQ(viewport.GetWidth(), 1000);
-  EXPECT_EQ(viewport.GetHeight(), 2000);
-  EXPECT_EQ(viewport.GetWorldWidth(), 500.f);
-  EXPECT_EQ(viewport.GetWorldHeight(), 600.f);
+  EXPECT_EQ(viewport.GetScreenWidth(), 1000);
+  EXPECT_EQ(viewport.GetScreenHeight(), 2000);
+  EXPECT_EQ(viewport.GetVisibleWorldWidth(), 500.f);
+  EXPECT_EQ(viewport.GetVisibleWorldHeight(), 600.f);
   EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(0.f, 0.f));
   EXPECT_EQ(viewport.GetWorldExtents(), Vec2(100, 200));
 
-  // Test: Changing the world extent should not affect screen size and visible world size
+  // Test: Changing the world extent should not affect screen size and visible world size.
   viewport.SetWorldExtents(1000, 2000);
   EXPECT_TRUE(viewport.IsDirty());
   viewport.ClearDirtyFlag();
 
-  EXPECT_EQ(viewport.GetWidth(), 1000);
-  EXPECT_EQ(viewport.GetHeight(), 2000);
-  EXPECT_EQ(viewport.GetWorldWidth(), 500.f);
-  EXPECT_EQ(viewport.GetWorldHeight(), 600.f);
+  EXPECT_EQ(viewport.GetScreenWidth(), 1000);
+  EXPECT_EQ(viewport.GetScreenHeight(), 2000);
+  EXPECT_EQ(viewport.GetVisibleWorldWidth(), 500.f);
+  EXPECT_EQ(viewport.GetVisibleWorldHeight(), 600.f);
   EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(0.f, 0.f));
   EXPECT_EQ(viewport.GetWorldExtents(), Vec2(1000, 2000));
 
-  // Test: Scrolling (within correct range) should mark as dirty
+  // Test: Scrolling (within correct range) should mark as dirty.
   viewport.Resize(100, 200);
   viewport.ClearDirtyFlag();
 
@@ -74,10 +75,10 @@ TEST(Viewport, ResizingAndDirty) {
 
   EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(100.f, -50.f));
 
-  // Setting everything to the same values again should not mark the viewport as dirty
+  // Setting everything to the same values again should not mark the viewport as dirty.
   viewport.Resize(100, 200);
-  viewport.SetWorldWidth(500.f);
-  viewport.SetWorldHeight(600.f);
+  viewport.SetVisibleWorldWidth(500.f);
+  viewport.SetVisibleWorldHeight(600.f);
   viewport.SetWorldTopLeftX(100.f);
   viewport.SetWorldTopLeftY(-50.f);
   viewport.SetWorldExtents(1000, 2000);
@@ -100,21 +101,33 @@ TEST(Viewport, ScrollingWithoutZoom) {
   EXPECT_EQ(viewport.IsDirty(), true);
   viewport.ClearDirtyFlag();
 
-  // Scrolling further after clamping should not result in a dirty flag
+  // Scrolling further after clamping should not result in a dirty flag.
   viewport.SetWorldTopLeftX(200.f);
   viewport.SetWorldTopLeftY(-200.f);
   EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(100.f, -100.f));
   EXPECT_EQ(viewport.IsDirty(), false);
 
-  // Resizing should clamp
+  // Resizing should clamp.
   viewport.SetWorldExtents(150, 250);
   EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(50.f, -50.f));
+
+  // Changing world min should adjust current top left...
+  viewport.SetWorldMin(Vec2(100, -100));
+  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(100, -100));
+  viewport.SetWorldTopLeftX(0);
+  viewport.SetWorldTopLeftY(0);
+  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(100, -100));
+
+  // ... and is taken into account when scrolling.
+  viewport.SetWorldTopLeftX(500);
+  viewport.SetWorldTopLeftY(-500);
+  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(150, -150));
 }
 
 TEST(Viewport, ScrollingWithZoom) {
   Viewport viewport(100, 200);
-  viewport.SetWorldWidth(200);
-  viewport.SetWorldHeight(400);
+  viewport.SetVisibleWorldWidth(200);
+  viewport.SetVisibleWorldHeight(400);
   viewport.SetWorldExtents(400, 800);
 
   viewport.SetWorldTopLeftX(250.f);
@@ -129,13 +142,13 @@ TEST(Viewport, ScrollingWithZoom) {
   EXPECT_EQ(viewport.IsDirty(), true);
   viewport.ClearDirtyFlag();
 
-  // Scrolling further after clamping should not result in a dirty flag
+  // Scrolling further after clamping should not result in a dirty flag.
   viewport.SetWorldTopLeftX(350.f);
   viewport.SetWorldTopLeftY(-600.f);
   EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(200.f, -400.f));
   EXPECT_EQ(viewport.IsDirty(), false);
 
-  // Resizing should clamp
+  // Resizing should clamp.
   viewport.SetWorldExtents(250, 450);
   EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(50.f, -50.f));
 }
@@ -151,20 +164,26 @@ void VerifyConversion(Viewport& viewport, const Vec2i& screen_pos, const Vec2& w
   EXPECT_EQ(viewport.WorldToScreenWidth(world_size[0]), screen_pos[0]);
 
   EXPECT_EQ(viewport.QtToGlScreenPos(screen_pos),
-            Vec2i(screen_pos[0], viewport.GetHeight() - screen_pos[1]));
+            Vec2i(screen_pos[0], viewport.GetScreenHeight() - screen_pos[1]));
 }
 
 TEST(Viewport, CoordinateConversion) {
   Viewport viewport(10, 100);
-  // Extents are large enough to scroll
+  // Extents are large enough to scroll.
   viewport.SetWorldExtents(500, 500);
-  viewport.SetWorldWidth(20.f);
-  viewport.SetWorldHeight(50.f);
 
-  // NOTE: World space is y-down, but (0,0) is top left
   Vec2i screen_pos = Vec2i(8, 20);
-  Vec2 world_pos = Vec2(16.f, -10.f);
-  Vec2 world_size = Vec2(16.f, 10.f);
+  Vec2 world_pos = Vec2(8.f, -20.f);
+  Vec2 world_size = Vec2(8.f, 20.f);
+  VerifyConversion(viewport, screen_pos, world_pos, world_size);
+
+  // Change zoom: Zoom out to 200% horizontally, zoom in 50% vertically.
+  viewport.SetVisibleWorldWidth(20.f);
+  viewport.SetVisibleWorldHeight(50.f);
+
+  screen_pos = Vec2i(8, 20);
+  world_pos = Vec2(16.f, -10.f);
+  world_size = Vec2(16.f, 10.f);
   VerifyConversion(viewport, screen_pos, world_pos, world_size);
 
   viewport.SetWorldTopLeftX(10.f);

--- a/src/OrbitGl/ViewportTest.cpp
+++ b/src/OrbitGl/ViewportTest.cpp
@@ -1,0 +1,176 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "Viewport.h"
+
+namespace orbit_gl {
+
+TEST(Viewport, ResizingAndDirty) {
+  Viewport viewport(100, 200);
+  EXPECT_TRUE(viewport.IsDirty());
+  viewport.ClearDirtyFlag();
+
+  // Test initial values
+  EXPECT_EQ(viewport.GetWidth(), 100);
+  EXPECT_EQ(viewport.GetHeight(), 200);
+  EXPECT_EQ(viewport.GetWorldExtents(), Vec2(100, 200));
+  EXPECT_EQ(viewport.GetWorldWidth(), 100.f);
+  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(0.f, 0.f));
+
+  // Test: Resizing should not affect the world extents
+  viewport.Resize(1000, 2000);
+  EXPECT_TRUE(viewport.IsDirty());
+  viewport.ClearDirtyFlag();
+
+  EXPECT_EQ(viewport.GetWidth(), 1000);
+  EXPECT_EQ(viewport.GetHeight(), 2000);
+  EXPECT_EQ(viewport.GetWorldWidth(), 100.f);
+  EXPECT_EQ(viewport.GetWorldHeight(), 200.f);
+  EXPECT_EQ(viewport.GetWorldExtents(), Vec2(100, 200));
+  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(0.f, 0.f));
+
+  // Test: Changing the world width / height should not affect screen extents
+  viewport.SetWorldWidth(500.f);
+  EXPECT_TRUE(viewport.IsDirty());
+  viewport.ClearDirtyFlag();
+
+  viewport.SetWorldHeight(600.f);
+  EXPECT_TRUE(viewport.IsDirty());
+  viewport.ClearDirtyFlag();
+
+  EXPECT_EQ(viewport.GetWidth(), 1000);
+  EXPECT_EQ(viewport.GetHeight(), 2000);
+  EXPECT_EQ(viewport.GetWorldWidth(), 500.f);
+  EXPECT_EQ(viewport.GetWorldHeight(), 600.f);
+  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(0.f, 0.f));
+  EXPECT_EQ(viewport.GetWorldExtents(), Vec2(100, 200));
+
+  // Test: Changing the world extent should not affect screen size and visible world size
+  viewport.SetWorldExtents(1000, 2000);
+  EXPECT_TRUE(viewport.IsDirty());
+  viewport.ClearDirtyFlag();
+
+  EXPECT_EQ(viewport.GetWidth(), 1000);
+  EXPECT_EQ(viewport.GetHeight(), 2000);
+  EXPECT_EQ(viewport.GetWorldWidth(), 500.f);
+  EXPECT_EQ(viewport.GetWorldHeight(), 600.f);
+  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(0.f, 0.f));
+  EXPECT_EQ(viewport.GetWorldExtents(), Vec2(1000, 2000));
+
+  // Test: Scrolling (within correct range) should mark as dirty
+  viewport.Resize(100, 200);
+  viewport.ClearDirtyFlag();
+
+  viewport.SetWorldTopLeftX(100.f);
+  EXPECT_TRUE(viewport.IsDirty());
+  viewport.ClearDirtyFlag();
+
+  viewport.SetWorldTopLeftY(-50.f);
+  EXPECT_TRUE(viewport.IsDirty());
+  viewport.ClearDirtyFlag();
+
+  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(100.f, -50.f));
+
+  // Setting everything to the same values again should not mark the viewport as dirty
+  viewport.Resize(100, 200);
+  viewport.SetWorldWidth(500.f);
+  viewport.SetWorldHeight(600.f);
+  viewport.SetWorldTopLeftX(100.f);
+  viewport.SetWorldTopLeftY(-50.f);
+  viewport.SetWorldExtents(1000, 2000);
+  EXPECT_FALSE(viewport.IsDirty());
+}
+
+TEST(Viewport, ScrollingWithoutZoom) {
+  Viewport viewport(100, 200);
+  viewport.SetWorldExtents(200, 300);
+
+  viewport.SetWorldTopLeftX(100.f);
+  viewport.SetWorldTopLeftY(-50.f);
+
+  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(100.f, -50.f));
+
+  viewport.SetWorldTopLeftX(150.f);
+  viewport.SetWorldTopLeftY(-150.f);
+
+  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(100.f, -100.f));
+  EXPECT_EQ(viewport.IsDirty(), true);
+  viewport.ClearDirtyFlag();
+
+  // Scrolling further after clamping should not result in a dirty flag
+  viewport.SetWorldTopLeftX(200.f);
+  viewport.SetWorldTopLeftY(-200.f);
+  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(100.f, -100.f));
+  EXPECT_EQ(viewport.IsDirty(), false);
+
+  // Resizing should clamp
+  viewport.SetWorldExtents(150, 250);
+  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(50.f, -50.f));
+}
+
+TEST(Viewport, ScrollingWithZoom) {
+  Viewport viewport(100, 200);
+  viewport.SetWorldWidth(200);
+  viewport.SetWorldHeight(400);
+  viewport.SetWorldExtents(400, 800);
+
+  viewport.SetWorldTopLeftX(250.f);
+  viewport.SetWorldTopLeftY(-350.f);
+
+  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(200.f, -350.f));
+
+  viewport.SetWorldTopLeftX(300.f);
+  viewport.SetWorldTopLeftY(-450.f);
+
+  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(200.f, -400.f));
+  EXPECT_EQ(viewport.IsDirty(), true);
+  viewport.ClearDirtyFlag();
+
+  // Scrolling further after clamping should not result in a dirty flag
+  viewport.SetWorldTopLeftX(350.f);
+  viewport.SetWorldTopLeftY(-600.f);
+  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(200.f, -400.f));
+  EXPECT_EQ(viewport.IsDirty(), false);
+
+  // Resizing should clamp
+  viewport.SetWorldExtents(250, 450);
+  EXPECT_EQ(viewport.GetWorldTopLeft(), Vec2(50.f, -50.f));
+}
+
+void VerifyConversion(Viewport& viewport, const Vec2i& screen_pos, const Vec2& world_pos,
+                      const Vec2& world_size) {
+  EXPECT_EQ(viewport.ScreenToWorldPos(screen_pos), world_pos);
+  EXPECT_EQ(viewport.ScreenToWorldHeight(screen_pos[1]), world_size[1]);
+  EXPECT_EQ(viewport.ScreenToWorldWidth(screen_pos[0]), world_size[0]);
+
+  EXPECT_EQ(viewport.WorldToScreenPos(world_pos), screen_pos);
+  EXPECT_EQ(viewport.WorldToScreenHeight(world_size[1]), screen_pos[1]);
+  EXPECT_EQ(viewport.WorldToScreenWidth(world_size[0]), screen_pos[0]);
+
+  EXPECT_EQ(viewport.QtToGlScreenPos(screen_pos),
+            Vec2i(screen_pos[0], viewport.GetHeight() - screen_pos[1]));
+}
+
+TEST(Viewport, CoordinateConversion) {
+  Viewport viewport(10, 100);
+  // Extents are large enough to scroll
+  viewport.SetWorldExtents(500, 500);
+  viewport.SetWorldWidth(20.f);
+  viewport.SetWorldHeight(50.f);
+
+  // NOTE: World space is y-down, but (0,0) is top left
+  Vec2i screen_pos = Vec2i(8, 20);
+  Vec2 world_pos = Vec2(16.f, -10.f);
+  Vec2 world_size = Vec2(16.f, 10.f);
+  VerifyConversion(viewport, screen_pos, world_pos, world_size);
+
+  viewport.SetWorldTopLeftX(10.f);
+  viewport.SetWorldTopLeftY(-100.f);
+  world_pos = Vec2(26.f, -110.f);
+  VerifyConversion(viewport, screen_pos, world_pos, world_size);
+}
+
+}  // namespace orbit_gl

--- a/src/OrbitQt/orbitglwidget.cpp
+++ b/src/OrbitQt/orbitglwidget.cpp
@@ -243,7 +243,7 @@ void OrbitGLWidget::mouseReleaseEvent(QMouseEvent* event) {
     }
 
     if (event->button() == Qt::MiddleButton) {
-      gl_canvas_->MiddleUp(event->x(), event->y());
+      gl_canvas_->MiddleUp();
     }
   }
 

--- a/src/OrbitQt/orbitglwidget.cpp
+++ b/src/OrbitQt/orbitglwidget.cpp
@@ -190,7 +190,8 @@ void OrbitGLWidget::messageLogged(const QOpenGLDebugMessage& msg) {
 void OrbitGLWidget::resizeGL(int w, int h) {
   if (gl_canvas_) {
     gl_canvas_->Resize(w, h);
-    gl_canvas_->SetMainWindowSize(this->geometry().width(), this->geometry().height());
+    CHECK(this->geometry().width() == w);
+    CHECK(this->geometry().height() == h);
   }
 }
 


### PR DESCRIPTION
This is a first refactor of GlCanvas / CaptureWindow. Sorry for the large PR, I kept running into small inconsistencies during the refactor that made it hard to find a reasonable cutoff point, and I wanted to avoid submitting it half-done because I had to revisit and change previous commits quite a bit as my assumptions continued to be incorrect...

### Goals of this PR

**Remove the code duplication and inconsistent behavior of `GlCanvas` and `CaptureWindow`** 

A lot of functionality (e.g. picking) was partially implemented in `GlCanvas`, but only worked for `CaptureWindow`. Other functionality was implemented in `GlCanvas` and then reimplemented (sometimes with minor changes) in `CaptureWindow`. Now, `GlCanvas` fully takes care of picking and tracking mouse interactions, whereas `CaptureWindow` add all functionality related to `TimeGraph` and Scrollbars.

**Break down GlCanvas to improve Unit Test coverage**

As a first step, all functionality related to viewport sizes, coordinate conversion, and virtual "camera placement" (e.g. position of the screen within the 2D world) moved to a new class `Viewport`. This new class is properly unit tested.

### Next steps
* Pass `Batcher*` and `Viewport*` instead of `GlCanvas*` where possible. This will decouple most components from `GlCanvas`, and will decouple rendering from coordinate translation.
* Change horizontal scrolling and scaling to use the `Viewport` functionality. Currently, this is handled by `TimeGraph`, which is quite inconsistent (`Viewport::GetWorldTopLeft()[0]` is always 0!)
* Move the layering definitions into a separate class
* Move the actual "Renderpass" functionality into a new class that is linked to a viewport - so we get rid of the implicit assumptions that "some elements are drawn in screen space, others in world space", and remove the implicit 2nd renderpass that happens on picking, as this causes issues with state changes in between those two renderpasses.