### PR TITLE
Enable saving memory tracks in capture files

### DIFF
--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -153,7 +153,8 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
     kFreeKb,
     kAvailableKb,
     kBuffersKb,
-    kCachedKb
+    kCachedKb,
+    kEnd
   };
   void OnSystemMemoryUsage(
       const orbit_grpc_protos::SystemMemoryUsage& system_memory_usage) override;

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -262,3 +262,24 @@ void GraphTrack::UpdateMinAndMax(double value) {
   max_ = std::max(max_, value);
   min_ = std::min(min_, value);
 }
+
+void GraphTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
+  constexpr uint32_t kDepth = 0;
+  std::shared_ptr<TimerChain> timer_chain = timers_[kDepth];
+  if (timer_chain == nullptr) {
+    timer_chain = std::make_shared<TimerChain>();
+    timers_[kDepth] = timer_chain;
+  }
+
+  TextBox text_box(Vec2(0, 0), Vec2(0, 0), "");
+  text_box.SetTimerInfo(timer_info);
+  timer_chain->push_back(text_box);
+}
+
+std::vector<std::shared_ptr<TimerChain>> GraphTrack::GetAllChains() const {
+  std::vector<std::shared_ptr<TimerChain>> chains;
+  for (const auto& pair : timers_) {
+    chains.push_back(pair.second);
+  }
+  return chains;
+}

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -41,6 +41,12 @@ class GraphTrack : public Track {
   void SetLabelUnitWhenEmpty(const std::string& label_unit);
   void SetValueDecimalDigitsWhenEmpty(uint8_t value_decimal_digits);
 
+  void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
+  std::vector<std::shared_ptr<TimerChain>> GetAllChains() const override;
+  std::vector<std::shared_ptr<TimerChain>> GetAllSerializableChains() const override {
+    return GetAllChains();
+  }
+
  protected:
   void DrawSquareDot(Batcher* batcher, Vec2 center, float radius, float z, const Color& color);
   void DrawLabel(GlCanvas* canvas, Vec2 target_pos, const std::string& text,

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -485,6 +485,7 @@ void TimeGraph::ProcessMemoryTrackingTimer(const TimerInfo& timer_info) {
     double used_mb =
         static_cast<double>(total_kb - unused_kb - buffers_kb - cached_kb) / kMegabytesToKilobytes;
     track->AddValue(used_mb, timer_info.start());
+    track->OnTimer(timer_info);
   }
 }
 

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -56,7 +56,7 @@ class TimerTrack : public Track {
 
   // Pickable
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
-  virtual void OnTimer(const orbit_client_protos::TimerInfo& timer_info);
+  void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
   [[nodiscard]] std::string GetTooltip() const override;
 
   // Track
@@ -128,7 +128,6 @@ class TimerTrack : public Track {
   TextRenderer* text_renderer_ = nullptr;
   uint32_t depth_ = 0;
   mutable absl::Mutex mutex_;
-  std::map<int, std::shared_ptr<TimerChain>> timers_;
   int visible_timer_count_ = 0;
 
   [[nodiscard]] virtual std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const;

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -68,12 +68,11 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
     return num_prioritized_trailing_characters_;
   }
 
+  virtual void OnTimer(const orbit_client_protos::TimerInfo& /*timer_info*/) {}
   [[nodiscard]] virtual std::vector<std::shared_ptr<TimerChain>> GetTimers() const { return {}; }
-  [[nodiscard]] virtual std::vector<std::shared_ptr<TimerChain>> GetAllChains() const { return {}; }
-  [[nodiscard]] virtual std::vector<std::shared_ptr<TimerChain>> GetAllSerializableChains() const {
-    return {};
-  }
-
+  [[nodiscard]] virtual std::vector<std::shared_ptr<TimerChain>> GetAllChains() const = 0;
+  [[nodiscard]] virtual std::vector<std::shared_ptr<TimerChain>> GetAllSerializableChains()
+      const = 0;
   [[nodiscard]] bool IsPinned() const { return pinned_; }
   void SetPinned(bool value);
 
@@ -113,6 +112,7 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   Color color_;
   bool visible_ = true;
   bool pinned_ = false;
+  std::map<int, std::shared_ptr<TimerChain>> timers_;
   std::atomic<uint32_t> num_timers_;
   std::atomic<uint64_t> min_time_;
   std::atomic<uint64_t> max_time_;


### PR DESCRIPTION
With this change, we enable saving the memory tracks in the capture file.

Bug: http://b/183172079
Test: Take a capture with enabling memory tracing and save the capture file, then open the saved capture file.
> - Taking a capture with enabling memory tracing
> ![Taking a capture with enabling memory tracing](https://user-images.githubusercontent.com/74234352/113671249-0490b380-96ae-11eb-8a9d-bf493c0430db.png)
> - Open the capture file with memory tracks
> ![Loading the capture file with memory tracks](https://user-images.githubusercontent.com/74234352/113671256-065a7700-96ae-11eb-9626-0ea5fc41e420.png)


