### PR TITLE
Add new tests for build_id mechanics

### DIFF
--- a/src/OrbitClientData/ModuleData.cpp
+++ b/src/OrbitClientData/ModuleData.cpp
@@ -78,6 +78,16 @@ const FunctionInfo* ModuleData::FindFunctionByElfAddress(uint64_t elf_address,
   return function;
 }
 
+void ModuleData::AddFunctionInfoWithBuildId(const FunctionInfo& function_info,
+                                            const std::string& module_build_id) {
+  absl::MutexLock lock(&mutex_);
+  CHECK(functions_.find(function_info.address()) == functions_.end());
+  auto value = std::make_unique<FunctionInfo>(function_info);
+  value->set_module_build_id(module_build_id);
+  functions_.insert_or_assign(function_info.address(), std::move(value));
+  is_loaded_ = true;
+}
+
 void ModuleData::AddSymbols(const orbit_grpc_protos::ModuleSymbols& module_symbols) {
   absl::MutexLock lock(&mutex_);
   CHECK(!is_loaded_);
@@ -124,7 +134,7 @@ const orbit_client_protos::FunctionInfo* ModuleData::FindFunctionFromHash(uint64
   return hash_to_function_map_.contains(hash) ? hash_to_function_map_.at(hash) : nullptr;
 }
 
-const std::vector<const FunctionInfo*> ModuleData::GetFunctions() const {
+std::vector<const FunctionInfo*> ModuleData::GetFunctions() const {
   absl::MutexLock lock(&mutex_);
   std::vector<const FunctionInfo*> result;
   result.reserve(functions_.size());

--- a/src/OrbitClientData/include/OrbitClientData/ModuleData.h
+++ b/src/OrbitClientData/include/OrbitClientData/ModuleData.h
@@ -40,8 +40,10 @@ class ModuleData final {
   [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionByElfAddress(
       uint64_t elf_address, bool is_exact) const;
   void AddSymbols(const orbit_grpc_protos::ModuleSymbols& module_symbols);
+  void AddFunctionInfoWithBuildId(const orbit_client_protos::FunctionInfo& function_info,
+                                  const std::string& module_build_id);
   [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionFromHash(uint64_t hash) const;
-  [[nodiscard]] const std::vector<const orbit_client_protos::FunctionInfo*> GetFunctions() const;
+  [[nodiscard]] std::vector<const orbit_client_protos::FunctionInfo*> GetFunctions() const;
   [[nodiscard]] std::vector<orbit_client_protos::FunctionInfo> GetOrbitFunctions() const;
 
  private:


### PR DESCRIPTION
This commit adds new tests for ModuleManager and CaptureDeserializer

Test: run OrbitClientModel/Data unit-tests