### PR TITLE
Lengthen sleep in LinuxTracingIntegrationTestPuppet's SleepRepeatedly

### DIFF
--- a/src/LinuxTracing/LinuxTracingIntegrationTestPuppet.cpp
+++ b/src/LinuxTracing/LinuxTracingIntegrationTestPuppet.cpp
@@ -27,7 +27,7 @@ using PuppetConstants = LinuxTracingIntegrationTestPuppetConstants;
 
 static void SleepRepeatedly() {
   for (uint64_t i = 0; i < PuppetConstants::kSleepCount; ++i) {
-    absl::SleepFor(absl::Microseconds(10));
+    absl::SleepFor(absl::Microseconds(100));
   }
 }
 


### PR DESCRIPTION
The previous value of 10 microseconds seems to not be enough to cause a
consistent number of thread state slices. See also http://b/183229462#comment4.

Bug: http://b/183229462

Test: Run LinuxTracingIntegrationTest.ThreadStateSlices a few thousand times
to see that the flakiness is gone...