### PR TITLE
Stable track order when adding/removing FrameTrack

### DIFF
--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -142,17 +142,17 @@ void TrackManager::SortTracks() {
 
     last_thread_reorder_.Restart();
 
-    UpdateFilteredTrackList();
+    UpdateVisibleTrackList();
   }
   sorting_invalidated_ = false;
 }
 
 void TrackManager::SetFilter(const std::string& filter) {
   filter_ = absl::AsciiStrToLower(filter);
-  UpdateFilteredTrackList();
+  UpdateVisibleTrackList();
 }
 
-void TrackManager::UpdateFilteredTrackList() {
+void TrackManager::UpdateVisibleTrackList() {
   if (filter_.empty()) {
     visible_tracks_ = sorted_tracks_;
     return;
@@ -306,12 +306,23 @@ void TrackManager::AddTrack(const std::shared_ptr<Track>& track) {
   sorting_invalidated_ = true;
 }
 
+void TrackManager::AddFrameTrack(const std::shared_ptr<FrameTrack>& frame_track) {
+  frame_tracks_[frame_track->GetFunctionId()] = frame_track;
+  auto scheduler_track_pos =
+      find(sorted_tracks_.begin(), sorted_tracks_.end(), scheduler_track_.get());
+  if (scheduler_track_pos != sorted_tracks_.end()) {
+    sorted_tracks_.insert(++scheduler_track_pos, frame_track.get());
+  } else {
+    sorted_tracks_.push_back(frame_track.get());
+  }
+  UpdateVisibleTrackList();
+}
+
 void TrackManager::RemoveFrameTrack(uint64_t function_id) {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
+  std::remove(sorted_tracks_.begin(), sorted_tracks_.end(), frame_tracks_[function_id].get());
   frame_tracks_.erase(function_id);
-  sorting_invalidated_ = true;
-  // We need to do SortTracks again to have visible_tracks_ updated
-  SortTracks();
+  UpdateVisibleTrackList();
 }
 
 SchedulerTrack* TrackManager::GetOrCreateSchedulerTrack() {
@@ -383,9 +394,9 @@ FrameTrack* TrackManager::GetOrCreateFrameTrack(
   auto track = std::make_shared<FrameTrack>(time_graph_, layout_, function, app_, capture_data_);
 
   // Normally we would call AddTrack(track) here, but frame tracks are removable by users
-  // and therefore cannot be simply thrown into the flat vector of tracks.
-  sorting_invalidated_ = true;
-  frame_tracks_[function.function_id()] = track;
+  // and therefore cannot be simply thrown into the flat vector of tracks. Also, we don't want to
+  // trigger a sorting in all the tracks.
+  AddFrameTrack(track);
 
   return track.get();
 }

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -63,16 +63,17 @@ class TrackManager {
   AsyncTrack* GetOrCreateAsyncTrack(const std::string& name);
   FrameTrack* GetOrCreateFrameTrack(const orbit_grpc_protos::InstrumentedFunction& function);
 
-  void AddTrack(const std::shared_ptr<Track>& track);
   void RemoveFrameTrack(uint64_t function_address);
 
   void UpdateMovingTrackSorting();
 
  private:
-  void UpdateFilteredTrackList();
+  void UpdateVisibleTrackList();
   [[nodiscard]] int FindMovingTrackIndex();
   [[nodiscard]] std::vector<ThreadTrack*> GetSortedThreadTracks();
 
+  void AddTrack(const std::shared_ptr<Track>& track);
+  void AddFrameTrack(const std::shared_ptr<FrameTrack>& frame_track);
   void UpdateTrackPositions();
 
   // TODO(b/174655559): Use absl's mutex here.


### PR DESCRIPTION
This PR make the track order stable after both adding and removing a
FrameTrack. As discussed in a daily meeting, the Frame Track is added
after the Scheduler one.

Also, we rename a method (UpdateVisibleTrackList).

Solved the quick-win http://b/175534459.

Test: Load a capture, add/remove a FrameTrack. Also start/stop a
capture.