### PR TITLE
Add Track::IsFilterable() method to allow non-filterable tracks

### DIFF
--- a/src/OrbitGl/SchedulerTrack.h
+++ b/src/OrbitGl/SchedulerTrack.h
@@ -28,6 +28,7 @@ class SchedulerTrack final : public TimerTrack {
 
   [[nodiscard]] float GetHeight() const override;
   [[nodiscard]] bool IsCollapsible() const override { return false; }
+  [[nodiscard]] bool IsFilterable() const override { return false; }
 
   void UpdateBoxHeight() override;
   [[nodiscard]] float GetYFromTimer(

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -87,6 +87,7 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
 
   virtual void OnCollapseToggle(TriangleToggle::State state);
   [[nodiscard]] virtual bool IsCollapsible() const { return false; }
+  [[nodiscard]] virtual bool IsFilterable() const { return !pinned_; }
   TriangleToggle* GetTriangleToggle() const { return collapse_toggle_.get(); }
   [[nodiscard]] int32_t GetProcessId() const { return process_id_; }
   void SetProcessId(uint32_t pid) { process_id_ = pid; }

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -161,9 +161,13 @@ void TrackManager::UpdateFilteredTrackList() {
   visible_tracks_.clear();
   std::vector<std::string> filters = absl::StrSplit(filter_, ' ', absl::SkipWhitespace());
   for (const auto& track : sorted_tracks_) {
+    if (!track->IsFilterable()) {
+      visible_tracks_.push_back(track);
+      continue;
+    }
     std::string lower_case_label = absl::AsciiStrToLower(track->GetLabel());
     for (auto& filter : filters) {
-      if (!track->IsFilterable() || absl::StrContains(lower_case_label, filter)) {
+      if (absl::StrContains(lower_case_label, filter)) {
         visible_tracks_.push_back(track);
         break;
       }

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -163,7 +163,7 @@ void TrackManager::UpdateFilteredTrackList() {
   for (const auto& track : sorted_tracks_) {
     std::string lower_case_label = absl::AsciiStrToLower(track->GetLabel());
     for (auto& filter : filters) {
-      if (absl::StrContains(lower_case_label, filter)) {
+      if (!track->IsFilterable() || absl::StrContains(lower_case_label, filter)) {
         visible_tracks_.push_back(track);
         break;
       }


### PR DESCRIPTION
Scheduler track is now always visible (b/181671054). 
"Pinned" tracks are also not be filterable.