### PR TITLE
Add MSVC2019 kokoro build configuration

### DIFF
--- a/kokoro/builds/build.sh
+++ b/kokoro/builds/build.sh
@@ -94,6 +94,9 @@ if [ -n "$1" ]; then
   if [[ $CONAN_PROFILE == "msvc2017_relwithdebinfo" ]]; then
     CONAN_PROFILE="msvc2017_relwithdebinfo_ninja"
   fi
+  if [[ $CONAN_PROFILE == "msvc2019_relwithdebinfo" ]]; then
+    CONAN_PROFILE="msvc2019_relwithdebinfo_ninja"
+  fi
 
   echo "Using conan profile ${CONAN_PROFILE} and performing a ${BUILD_TYPE} build."
 

--- a/kokoro/builds/windows/msvc2019_relwithdebinfo/common.cfg
+++ b/kokoro/builds/windows/msvc2019_relwithdebinfo/common.cfg
@@ -1,0 +1,12 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Location of the bash script. Should have value <github_scm.name>/<path_from_repository_root>.
+# github_scm.name is specified in the job configuration (next section).
+build_file: "orbitprofiler/kokoro/builds/build.bat"
+
+action {
+  define_artifacts {
+    regex: "github/orbitprofiler/build/testresults/*.xml"
+    strip_prefix: "github/orbitprofiler/build/package"
+  }
+}

--- a/kokoro/builds/windows/msvc2019_relwithdebinfo/continuous.cfg
+++ b/kokoro/builds/windows/msvc2019_relwithdebinfo/continuous.cfg
@@ -1,0 +1,20 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74938
+      keyname: "orbitprofiler_artifactory_access_token"
+      key_type: RAW
+      backend_type: FASTCONFIGPUSH
+    }
+  }
+}
+
+action {
+  define_artifacts {
+    regex: "github/orbitprofiler/build/package/**"
+    strip_prefix: "github/orbitprofiler/build/package"
+  }
+}
+

--- a/kokoro/builds/windows/msvc2019_relwithdebinfo/continuous_on_release_branch.cfg
+++ b/kokoro/builds/windows/msvc2019_relwithdebinfo/continuous_on_release_branch.cfg
@@ -1,0 +1,26 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74938
+      keyname: "orbitprofiler_artifactory_access_token"
+      key_type: RAW
+      backend_type: FASTCONFIGPUSH
+    }
+    keystore_resource {
+      keystore_config_id: 74938
+      keyname: "orbitprofiler_crashdump_collection_server"
+      key_type: RAW
+      backend_type: FASTCONFIGPUSH
+    }
+  }
+}
+
+action {
+  define_artifacts {
+    regex: "github/orbitprofiler/build/package/**"
+    strip_prefix: "github/orbitprofiler/build/package"
+  }
+}
+

--- a/kokoro/builds/windows/msvc2019_relwithdebinfo/nightly.cfg
+++ b/kokoro/builds/windows/msvc2019_relwithdebinfo/nightly.cfg
@@ -1,0 +1,26 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74938
+      keyname: "orbitprofiler_artifactory_access_token"
+      key_type: RAW
+      backend_type: FASTCONFIGPUSH
+    }
+    keystore_resource {
+      keystore_config_id: 74938
+      keyname: "orbitprofiler_crashdump_collection_server"
+      key_type: RAW
+      backend_type: FASTCONFIGPUSH
+    }
+  }
+}
+
+action {
+  define_artifacts {
+    regex: "github/orbitprofiler/build/package/**"
+    strip_prefix: "github/orbitprofiler/build/package"
+  }
+}
+

--- a/kokoro/builds/windows/msvc2019_relwithdebinfo/presubmit.cfg
+++ b/kokoro/builds/windows/msvc2019_relwithdebinfo/presubmit.cfg
@@ -1,0 +1,2 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+

--- a/kokoro/builds/windows/msvc2019_relwithdebinfo/release.cfg
+++ b/kokoro/builds/windows/msvc2019_relwithdebinfo/release.cfg
@@ -1,0 +1,25 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 74938
+      keyname: "orbitprofiler_artifactory_access_token"
+      key_type: RAW
+      backend_type: FASTCONFIGPUSH
+    }
+    keystore_resource {
+      keystore_config_id: 74938
+      keyname: "orbitprofiler_crashdump_collection_server"
+      key_type: RAW
+      backend_type: FASTCONFIGPUSH
+    }
+  }
+}
+
+action {
+  define_artifacts {
+    regex: "github/orbitprofiler/build/package/**"
+    strip_prefix: "github/orbitprofiler/build/package"
+  }
+}

--- a/third_party/conan/configs/windows/profiles/msvc2019_relwithdebinfo_ninja
+++ b/third_party/conan/configs/windows/profiles/msvc2019_relwithdebinfo_ninja
@@ -1,0 +1,8 @@
+include(msvc2019_relwithdebinfo)
+
+[settings]
+ninja:build_type=Release
+[build_requires]
+&: ninja/1.10.2
+[env]
+CONAN_CMAKE_GENERATOR=Ninja


### PR DESCRIPTION
This adds the missing msvc2019 build configuration.

I manually triggered a msvc2019 job which succeeded (see checks below).