### PR TITLE
Add MetrcicsUploaderStub

### DIFF
--- a/src/MetricsUploader/CMakeLists.txt
+++ b/src/MetricsUploader/CMakeLists.txt
@@ -16,6 +16,7 @@ target_include_directories(MetricsUploader PUBLIC ${CMAKE_CURRENT_LIST_DIR}/incl
                                            PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 
 target_sources(MetricsUploader PUBLIC include/MetricsUploader/MetricsUploader.h
+                                      include/MetricsUploader/MetricsUploaderStub.h
                                       include/MetricsUploader/Result.h
                                       include/MetricsUploader/ScopedMetric.h
                                PRIVATE Result.cpp

--- a/src/MetricsUploader/MetricsUploaderLinux.cpp
+++ b/src/MetricsUploader/MetricsUploaderLinux.cpp
@@ -3,13 +3,15 @@
 // found in the LICENSE file.
 
 #include "MetricsUploader/MetricsUploader.h"
+#include "MetricsUploader/MetricsUploaderStub.h"
+#include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
 
 namespace orbit_metrics_uploader {
 
-ErrorMessageOr<std::unique_ptr<MetricsUploader>> MetricsUploader::CreateMetricsUploader(
-    std::string) {
-  return ErrorMessage("MetricsUploader is not implemented on Linux");
+std::unique_ptr<MetricsUploader> MetricsUploader::CreateMetricsUploader(std::string) {
+  ERROR("MetricsUploader is not implemented on Linux");
+  return std::make_unique<MetricsUploaderStub>();
 }
 
 ErrorMessageOr<std::string> GenerateUUID() {

--- a/src/MetricsUploader/include/MetricsUploader/MetricsUploader.h
+++ b/src/MetricsUploader/include/MetricsUploader/MetricsUploader.h
@@ -40,9 +40,9 @@ class MetricsUploader {
   virtual ~MetricsUploader() = default;
 
   // Create a MetricsUploader instance, load metrics uploader client library if available and starts
-  // metrics uploader client when called first time. Return the instance if there are no errors and
-  // ErrorMessage otherwise.
-  [[nodiscard]] static ErrorMessageOr<std::unique_ptr<MetricsUploader>> CreateMetricsUploader(
+  // metrics uploader client when called first time. Return the MetricsUploaderImpl if there are no
+  // errors and MetricsUploaderStub otherwise.
+  [[nodiscard]] static std::unique_ptr<MetricsUploader> CreateMetricsUploader(
       std::string client_name = kMetricsUploaderClientDllName);
 
   // Send a log event to the server using metrics_uploader. Returns true on success and false

--- a/src/MetricsUploader/include/MetricsUploader/MetricsUploaderStub.h
+++ b/src/MetricsUploader/include/MetricsUploader/MetricsUploaderStub.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "MetricsUploader/MetricsUploader.h"
+
+namespace orbit_metrics_uploader {
+
+class MetricsUploaderStub : public MetricsUploader {
+ public:
+  MetricsUploaderStub() = default;
+  MetricsUploaderStub(const MetricsUploaderStub& other) = delete;
+  MetricsUploaderStub(MetricsUploaderStub&& other) = default;
+  MetricsUploaderStub& operator=(const MetricsUploaderStub& other) = delete;
+  MetricsUploaderStub& operator=(MetricsUploaderStub&& other) = default;
+
+  bool SendLogEvent(OrbitLogEvent_LogEventType) override { return false; };
+  bool SendLogEvent(OrbitLogEvent_LogEventType, std::chrono::milliseconds) override {
+    return false;
+  };
+  bool SendLogEvent(OrbitLogEvent_LogEventType, std::chrono::milliseconds,
+                    OrbitLogEvent_StatusCode) override {
+    return false;
+  };
+};
+
+}  // namespace orbit_metrics_uploader

--- a/src/Orbit/main.cpp
+++ b/src/Orbit/main.cpp
@@ -93,16 +93,10 @@ void RunUiInstance(const DeploymentConfiguration& deployment_configuration,
 
   std::optional<orbit_qt::TargetConfiguration> target_config;
 
-  std::unique_ptr<orbit_metrics_uploader::MetricsUploader> metrics_uploader;
-  auto metrics_uploader_result = orbit_metrics_uploader::MetricsUploader::CreateMetricsUploader();
-  if (metrics_uploader_result.has_value()) {
-    metrics_uploader = std::move(metrics_uploader_result.value());
-    LOG("MetricsUploader was initialized successfully");
-    metrics_uploader->SendLogEvent(
-        orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_METRICS_UPLOADER_START);
-  } else {
-    ERROR("%s", metrics_uploader_result.error().message());
-  }
+  std::unique_ptr<orbit_metrics_uploader::MetricsUploader> metrics_uploader =
+      orbit_metrics_uploader::MetricsUploader::CreateMetricsUploader();
+  metrics_uploader->SendLogEvent(
+      orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_METRICS_UPLOADER_START);
 
   orbit_metrics_uploader::ScopedMetric(
       metrics_uploader.get(), orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_EXIT);

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1004,13 +1004,11 @@ void OrbitApp::StopCapture() {
     return;
   }
 
-  if (metrics_uploader_ != nullptr) {
-    auto capture_time_us =
-        std::chrono::duration<double, std::micro>(GetTimeGraph()->GetCaptureTimeSpanUs());
-    auto capture_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(capture_time_us);
-    metrics_uploader_->SendLogEvent(
-        orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_CAPTURE_DURATION, capture_time_ms);
-  }
+  auto capture_time_us =
+      std::chrono::duration<double, std::micro>(GetTimeGraph()->GetCaptureTimeSpanUs());
+  auto capture_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(capture_time_us);
+  metrics_uploader_->SendLogEvent(
+      orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_CAPTURE_DURATION, capture_time_ms);
 
   CHECK(capture_stop_requested_callback_);
   capture_stop_requested_callback_();

--- a/src/OrbitGl/LiveFunctionsController.cpp
+++ b/src/OrbitGl/LiveFunctionsController.cpp
@@ -179,10 +179,8 @@ void LiveFunctionsController::OnPreviousButton(uint64_t id) {
 void LiveFunctionsController::OnDeleteButton(uint64_t id) {
   current_textboxes_.erase(id);
   iterator_id_to_function_id_.erase(id);
-  if (metrics_uploader_ != nullptr) {
-    metrics_uploader_->SendLogEvent(
-        orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_ITERATOR_REMOVE);
-  }
+  metrics_uploader_->SendLogEvent(
+      orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_ITERATOR_REMOVE);
 
   // If we erase the iterator that was last used by the user, then
   // we need to switch last_id_pressed_ to an existing id.

--- a/src/OrbitGl/LiveFunctionsDataView.cpp
+++ b/src/OrbitGl/LiveFunctionsDataView.cpp
@@ -331,10 +331,8 @@ void LiveFunctionsDataView::OnContextMenu(const std::string& action, int menu_in
           app_->GetCaptureData().GetFunctionStatsOrDefault(instrumented_function_id);
       if (stats.count() > 0) {
         live_functions_->AddIterator(instrumented_function_id, &instrumented_function);
-        if (metrics_uploader_ != nullptr) {
-          metrics_uploader_->SendLogEvent(
-              orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_ITERATOR_ADD);
-        }
+        metrics_uploader_->SendLogEvent(
+            orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_ITERATOR_ADD);
       }
     }
   } else if (action == kMenuActionEnableFrameTrack) {

--- a/src/OrbitQt/ProfilingTargetDialog.cpp
+++ b/src/OrbitQt/ProfilingTargetDialog.cpp
@@ -150,10 +150,8 @@ ProfilingTargetDialog::ProfilingTargetDialog(
     SetStateMachineInitialState();
   }
 
-  if (metrics_uploader_ != nullptr) {
-    metrics_uploader_->SendLogEvent(
-        orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_SESSION_SETUP_WINDOW_OPEN);
-  }
+  metrics_uploader_->SendLogEvent(
+      orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_SESSION_SETUP_WINDOW_OPEN);
 }
 
 void ProfilingTargetDialog::SetStateMachineInitialState() {
@@ -182,10 +180,8 @@ std::optional<TargetConfiguration> ProfilingTargetDialog::Exec() {
   int rc = QDialog::exec();
   state_machine_.stop();
 
-  if (metrics_uploader_ != nullptr) {
-    metrics_uploader_->SendLogEvent(
-        orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_SESSION_SETUP_WINDOW_CLOSE);
-  }
+  metrics_uploader_->SendLogEvent(
+      orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_SESSION_SETUP_WINDOW_CLOSE);
 
   if (rc != QDialog::Accepted) return std::nullopt;
 

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -195,10 +195,8 @@ OrbitMainWindow::OrbitMainWindow(orbit_qt::TargetConfiguration target_configurat
 
   LoadCaptureOptionsIntoApp();
 
-  if (metrics_uploader_ != nullptr) {
-    metrics_uploader_->SendLogEvent(
-        orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_MAIN_WINDOW_OPEN);
-  }
+  metrics_uploader_->SendLogEvent(
+      orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_MAIN_WINDOW_OPEN);
 }
 
 void OrbitMainWindow::SetupMainWindow() {
@@ -1211,10 +1209,8 @@ void OrbitMainWindow::Exit(int return_code) {
     introspection_widget_->close();
   }
 
-  if (metrics_uploader_ != nullptr) {
-    metrics_uploader_->SendLogEvent(
-        orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_MAIN_WINDOW_CLOSE);
-  }
+  metrics_uploader_->SendLogEvent(
+      orbit_metrics_uploader::OrbitLogEvent_LogEventType_ORBIT_MAIN_WINDOW_CLOSE);
 
   QApplication::exit(return_code);
 }


### PR DESCRIPTION
With MetricsUploaderStub we will always return a valid result from
CreateMetricsUploader(): MetricsUploaderImpl or MetricsUploaderStub. It
allows us to avoid nullptr checks every time when we want to call
MetricsUploader::SendLogEvent().
The stub is returned on Linux, or in case of errors on Windows.

Bug: http://b/183177789
Test: start Orbit with and without dll.