### PR TITLE
Handling of tracees interrupted in a syscall.

### DIFF
--- a/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
+++ b/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
@@ -10,8 +10,10 @@
 #include <sys/ptrace.h>
 #include <sys/wait.h>
 
+#include <chrono>
 #include <csignal>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "AccessTraceesMemory.h"
@@ -27,49 +29,9 @@
 
 namespace orbit_user_space_instrumentation {
 
-TEST(InjectLibraryInTraceeTest, FindFunctionAddress) {
-  pid_t pid = fork();
-  ASSERT_TRUE(pid != -1);
-  if (pid == 0) {
-    while (true) {
-    }
-  }
+namespace {
 
-  // Stop the child process using our tooling.
-  ASSERT_TRUE(AttachAndStopProcess(pid).has_value());
-
-  auto function_address_or_error = FindFunctionAddress(pid, "printf", "libc.so.6");
-  EXPECT_TRUE(function_address_or_error.has_value());
-
-  function_address_or_error = FindFunctionAddress(pid, "NOT_A_SYMBOL", "libc.so.6");
-  EXPECT_TRUE(function_address_or_error.has_error());
-  EXPECT_TRUE(absl::StrContains(function_address_or_error.error().message(),
-                                "Unable to locate function symbol"));
-
-  function_address_or_error = FindFunctionAddress(pid, "printf", "NOT_A_LIB-");
-  EXPECT_TRUE(function_address_or_error.has_error());
-  EXPECT_TRUE(absl::StrContains(function_address_or_error.error().message(),
-                                "There is no module \"NOT_A_LIB-\" in process"));
-
-  function_address_or_error = FindFunctionAddress(-1, "printf", "libc.so.6");
-  EXPECT_TRUE(function_address_or_error.has_error());
-  EXPECT_TRUE(
-      absl::StrContains(function_address_or_error.error().message(), "Unable to open file"));
-
-  // Detach and end child.
-  ASSERT_TRUE(DetachAndContinueProcess(pid).has_value());
-  kill(pid, SIGKILL);
-  waitpid(pid, NULL, 0);
-}
-
-TEST(InjectLibraryInTraceeTest, OpenUseCloseLibrary) {
-  pid_t pid = fork();
-  ASSERT_TRUE(pid != -1);
-  if (pid == 0) {
-    while (true) {
-    }
-  }
-
+void OpenUseAndCloseLibrary(pid_t pid) {
   // Stop the child process using our tooling.
   ASSERT_TRUE(AttachAndStopProcess(pid).has_value());
 
@@ -117,9 +79,13 @@ TEST(InjectLibraryInTraceeTest, OpenUseCloseLibrary) {
   ASSERT_FALSE(result_write_code.has_error());
 
   // Set rip to the code address and execute.
-  RegisterState registers_set_rip = original_registers;
-  registers_set_rip.GetGeneralPurposeRegisters()->x86_64.rip = address_code;
-  ASSERT_FALSE(registers_set_rip.RestoreRegisters().has_error());
+  RegisterState registers_for_execution = original_registers;
+  registers_for_execution.GetGeneralPurposeRegisters()->x86_64.rip = address_code;
+  const uint64_t old_rsp = original_registers.GetGeneralPurposeRegisters()->x86_64.rsp;
+  const uint64_t aligned_rsp_below_red_zone = (old_rsp - 128) / 16 * 16;
+  registers_for_execution.GetGeneralPurposeRegisters()->x86_64.rsp = aligned_rsp_below_red_zone;
+  registers_for_execution.GetGeneralPurposeRegisters()->x86_64.orig_rax = -1;
+  ASSERT_FALSE(registers_for_execution.RestoreRegisters().has_error());
   ASSERT_EQ(0, ptrace(PTRACE_CONT, pid, 0, 0));
   ASSERT_EQ(pid, waitpid(pid, nullptr, 0));
 
@@ -140,8 +106,74 @@ TEST(InjectLibraryInTraceeTest, OpenUseCloseLibrary) {
   ASSERT_TRUE(maps_after_close.has_value());
   EXPECT_FALSE(absl::StrContains(maps_after_close.value(), kLibName));
 
+  ASSERT_TRUE(DetachAndContinueProcess(pid).has_value());
+}
+
+}  // namespace
+
+TEST(InjectLibraryInTraceeTest, FindFunctionAddress) {
+  pid_t pid = fork();
+  ASSERT_TRUE(pid != -1);
+  if (pid == 0) {
+    while (true) {
+    }
+  }
+
+  // Stop the child process using our tooling.
+  ASSERT_TRUE(AttachAndStopProcess(pid).has_value());
+
+  auto function_address_or_error = FindFunctionAddress(pid, "printf", "libc.so.6");
+  EXPECT_TRUE(function_address_or_error.has_value());
+
+  function_address_or_error = FindFunctionAddress(pid, "NOT_A_SYMBOL", "libc.so.6");
+  EXPECT_TRUE(function_address_or_error.has_error());
+  EXPECT_TRUE(absl::StrContains(function_address_or_error.error().message(),
+                                "Unable to locate function symbol"));
+
+  function_address_or_error = FindFunctionAddress(pid, "printf", "NOT_A_LIB-");
+  EXPECT_TRUE(function_address_or_error.has_error());
+  EXPECT_TRUE(absl::StrContains(function_address_or_error.error().message(),
+                                "There is no module \"NOT_A_LIB-\" in process"));
+
+  function_address_or_error = FindFunctionAddress(-1, "printf", "libc.so.6");
+  EXPECT_TRUE(function_address_or_error.has_error());
+  EXPECT_TRUE(
+      absl::StrContains(function_address_or_error.error().message(), "Unable to open file"));
+
   // Detach and end child.
   ASSERT_TRUE(DetachAndContinueProcess(pid).has_value());
+  kill(pid, SIGKILL);
+  waitpid(pid, NULL, 0);
+}
+
+TEST(InjectLibraryInTraceeTest, OpenUseAndCloseLibraryInUserCode) {
+  pid_t pid = fork();
+  ASSERT_TRUE(pid != -1);
+  if (pid == 0) {
+    while (true) {
+    }
+  }
+
+  OpenUseAndCloseLibrary(pid);
+
+  // End child process.
+  kill(pid, SIGKILL);
+  waitpid(pid, NULL, 0);
+}
+
+TEST(InjectLibraryInTraceeTest, OpenUseAndCloseLibraryInSyscall) {
+  pid_t pid = fork();
+  ASSERT_TRUE(pid != -1);
+  if (pid == 0) {
+    while (true) {
+      // Child wil be stuck in syscall sys_clock_nanosleep.
+      std::this_thread::sleep_for(std::chrono::hours(1000000000));
+    }
+  }
+
+  OpenUseAndCloseLibrary(pid);
+
+  // End child process.
   kill(pid, SIGKILL);
   waitpid(pid, NULL, 0);
 }


### PR DESCRIPTION
Previously we ignored the special handling of the kernel when a
process gets interrupted during a syscall. We now inhibit that
special handling for the intermediate restarts.

Bug: http://b/184159315
Test: New unit test with tracee stuck in a syscall.