### PR TITLE
Adjust namespace of the LinuxTracingIntegrationTests module

### DIFF
--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
@@ -27,7 +27,7 @@
 #include "OrbitBase/ThreadUtils.h"
 #include "capture.pb.h"
 
-namespace orbit_linux_tracing {
+namespace orbit_linux_tracing_integration_tests {
 namespace {
 
 [[nodiscard]] bool IsRunningAsRoot() { return geteuid() == 0; }
@@ -142,7 +142,7 @@ class ChildProcess {
   int writing_fd_ = -1;
 };
 
-class BufferTracerListener : public TracerListener {
+class BufferTracerListener : public orbit_linux_tracing::TracerListener {
  public:
   void OnSchedulingSlice(orbit_grpc_protos::SchedulingSlice scheduling_slice) override {
     orbit_grpc_protos::ProducerCaptureEvent event;
@@ -311,7 +311,7 @@ class LinuxTracingIntegrationTestFixture {
 
  private:
   ChildProcess puppet_;
-  std::optional<Tracer> tracer_ = std::nullopt;
+  std::optional<orbit_linux_tracing::Tracer> tracer_ = std::nullopt;
   std::optional<BufferTracerListener> listener_ = std::nullopt;
 };
 
@@ -1003,4 +1003,4 @@ TEST(LinuxTracingIntegrationTest, ModuleUpdateOnDlopen) {
 }
 
 }  // namespace
-}  // namespace orbit_linux_tracing
+}  // namespace orbit_linux_tracing_integration_tests

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTestPuppet.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTestPuppet.cpp
@@ -18,9 +18,9 @@
 #include "OrbitBase/Logging.h"
 
 // This executable is used by LinuxTracingIntegrationTest to test the generation of specific
-// perf_event_open event. The behavior is controlled by commands sent on standard input.
+// perf_event_open events. The behavior is controlled by commands sent on standard input.
 
-namespace orbit_linux_tracing {
+namespace orbit_linux_tracing_integration_tests {
 
 using PuppetConstants = LinuxTracingIntegrationTestPuppetConstants;
 
@@ -110,4 +110,4 @@ int LinuxTracingIntegrationTestPuppetMain() {
   return 0;
 }
 
-}  // namespace orbit_linux_tracing
+}  // namespace orbit_linux_tracing_integration_tests

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTestPuppet.h
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTestPuppet.h
@@ -7,7 +7,7 @@
 
 #include <stdint.h>
 
-namespace orbit_linux_tracing {
+namespace orbit_linux_tracing_integration_tests {
 
 struct LinuxTracingIntegrationTestPuppetConstants {
   LinuxTracingIntegrationTestPuppetConstants() = delete;
@@ -34,6 +34,6 @@ struct LinuxTracingIntegrationTestPuppetConstants {
 
 int LinuxTracingIntegrationTestPuppetMain();
 
-}  // namespace orbit_linux_tracing
+}  // namespace orbit_linux_tracing_integration_tests
 
 #endif  // LINUX_TRACING_INTEGRATION_TEST_PUPPET_H_


### PR DESCRIPTION
I forgot about it in the previous change.

Test: Build and run LinuxTracingIntegrationTests.