### PR TITLE
Revert "Stable track order when adding/removing FrameTrack"

### DIFF
--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -142,17 +142,17 @@ void TrackManager::SortTracks() {
 
     last_thread_reorder_.Restart();
 
-    UpdateVisibleTrackList();
+    UpdateFilteredTrackList();
   }
   sorting_invalidated_ = false;
 }
 
 void TrackManager::SetFilter(const std::string& filter) {
   filter_ = absl::AsciiStrToLower(filter);
-  UpdateVisibleTrackList();
+  UpdateFilteredTrackList();
 }
 
-void TrackManager::UpdateVisibleTrackList() {
+void TrackManager::UpdateFilteredTrackList() {
   if (filter_.empty()) {
     visible_tracks_ = sorted_tracks_;
     return;
@@ -306,23 +306,12 @@ void TrackManager::AddTrack(const std::shared_ptr<Track>& track) {
   sorting_invalidated_ = true;
 }
 
-void TrackManager::AddFrameTrack(const std::shared_ptr<FrameTrack>& frame_track) {
-  frame_tracks_[frame_track->GetFunctionId()] = frame_track;
-  auto scheduler_track_pos =
-      find(sorted_tracks_.begin(), sorted_tracks_.end(), scheduler_track_.get());
-  if (scheduler_track_pos != sorted_tracks_.end()) {
-    sorted_tracks_.insert(++scheduler_track_pos, frame_track.get());
-  } else {
-    sorted_tracks_.push_back(frame_track.get());
-  }
-  UpdateVisibleTrackList();
-}
-
 void TrackManager::RemoveFrameTrack(uint64_t function_id) {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
-  std::remove(sorted_tracks_.begin(), sorted_tracks_.end(), frame_tracks_[function_id].get());
   frame_tracks_.erase(function_id);
-  UpdateVisibleTrackList();
+  sorting_invalidated_ = true;
+  // We need to do SortTracks again to have visible_tracks_ updated
+  SortTracks();
 }
 
 SchedulerTrack* TrackManager::GetOrCreateSchedulerTrack() {
@@ -399,9 +388,9 @@ FrameTrack* TrackManager::GetOrCreateFrameTrack(
                                             capture_data_);
 
   // Normally we would call AddTrack(track) here, but frame tracks are removable by users
-  // and therefore cannot be simply thrown into the flat vector of tracks. Also, we don't want to
-  // trigger a sorting in all the tracks.
-  AddFrameTrack(track);
+  // and therefore cannot be simply thrown into the flat vector of tracks.
+  sorting_invalidated_ = true;
+  frame_tracks_[function.function_id()] = track;
 
   return track.get();
 }

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -63,17 +63,16 @@ class TrackManager {
   AsyncTrack* GetOrCreateAsyncTrack(const std::string& name);
   FrameTrack* GetOrCreateFrameTrack(const orbit_grpc_protos::InstrumentedFunction& function);
 
+  void AddTrack(const std::shared_ptr<Track>& track);
   void RemoveFrameTrack(uint64_t function_address);
 
   void UpdateMovingTrackSorting();
 
  private:
-  void UpdateVisibleTrackList();
+  void UpdateFilteredTrackList();
   [[nodiscard]] int FindMovingTrackIndex();
   [[nodiscard]] std::vector<ThreadTrack*> GetSortedThreadTracks();
 
-  void AddTrack(const std::shared_ptr<Track>& track);
-  void AddFrameTrack(const std::shared_ptr<FrameTrack>& frame_track);
   void UpdateTrackPositions();
 
   // TODO(b/174655559): Use absl's mutex here.


### PR DESCRIPTION
This reverts commit 7854e6de4de0cf9a769d52d3e6aa564ba619b877.

The commit produced regressions (http://b/184939724) and a one-time reproducible crash. Will prepare a new PR.