### PR TITLE
Track refactoring

### DIFF
--- a/src/OrbitAccessibility/include/OrbitAccessibility/AccessibleInterface.h
+++ b/src/OrbitAccessibility/include/OrbitAccessibility/AccessibleInterface.h
@@ -92,7 +92,7 @@ class AccessibleInterface {
 
   [[nodiscard]] virtual std::string AccessibleName() const = 0;
   [[nodiscard]] virtual AccessibilityRole AccessibleRole() const = 0;
-  [[nodiscard]] virtual AccessibilityRect AccessibleLocalRect() const = 0;
+  [[nodiscard]] virtual AccessibilityRect AccessibleRect() const = 0;
   [[nodiscard]] virtual AccessibilityState AccessibleState() const = 0;
 };
 

--- a/src/OrbitAccessibility/include/OrbitAccessibility/AccessibleObjectFake.h
+++ b/src/OrbitAccessibility/include/OrbitAccessibility/AccessibleObjectFake.h
@@ -24,7 +24,7 @@ class AccessibleObjectFake : public AccessibleInterface {
   }
   [[nodiscard]] AccessibilityState AccessibleState() const override { return AccessibilityState(); }
 
-  [[nodiscard]] AccessibilityRect AccessibleLocalRect() const override {
+  [[nodiscard]] AccessibilityRect AccessibleRect() const override {
     AccessibilityRect result;
     if (parent_ == nullptr) {
       return result;

--- a/src/OrbitAccessibility/include/OrbitAccessibility/AccessibleWidgetBridge.h
+++ b/src/OrbitAccessibility/include/OrbitAccessibility/AccessibleWidgetBridge.h
@@ -29,7 +29,7 @@ class AccessibleWidgetBridge : public AccessibleInterface {
   [[nodiscard]] virtual AccessibilityRole AccessibleRole() const override {
     return AccessibilityRole::Grouping;
   }
-  [[nodiscard]] virtual AccessibilityRect AccessibleLocalRect() const override {
+  [[nodiscard]] virtual AccessibilityRect AccessibleRect() const override {
     return AccessibilityRect();
   }
   [[nodiscard]] virtual AccessibilityState AccessibleState() const override {

--- a/src/OrbitGl/AccessibleCaptureViewElement.cpp
+++ b/src/OrbitGl/AccessibleCaptureViewElement.cpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "AccessibleCaptureViewElement.h"
+
+#include "GlCanvas.h"
+#include "Viewport.h"
+
+namespace orbit_gl {
+const orbit_accessibility::AccessibleInterface* AccessibleCaptureViewElement::AccessibleParent()
+    const {
+  CaptureViewElement* parent = capture_view_element_->GetParent();
+  if (parent == nullptr) {
+    return nullptr;
+  }
+  return parent->GetOrCreateAccessibleInterface();
+}
+orbit_accessibility::AccessibilityRect AccessibleCaptureViewElement::AccessibleLocalRect() const {
+  Vec2 pos = capture_view_element_->GetPos();
+  Vec2 local_pos;
+
+  const CaptureViewElement* parent = capture_view_element_->GetParent();
+  // TODO(b/177350599): This could be cleaned up with clearer coordinate systems
+  if (parent != nullptr) {
+    Vec2 parent_pos = parent->GetPos();
+    local_pos = Vec2(pos[0] - parent_pos[0], parent_pos[1] - pos[1]);
+  } else {
+    local_pos = pos;
+  }
+
+  GlCanvas* canvas = capture_view_element_->GetCanvas();
+  CHECK(canvas != nullptr);
+  const Viewport& viewport = canvas->GetViewport();
+
+  return orbit_accessibility::AccessibilityRect(
+      viewport.WorldToScreenWidth(local_pos[0]), viewport.WorldToScreenHeight(local_pos[1]),
+      viewport.WorldToScreenWidth(capture_view_element_->GetSize()[0]),
+      viewport.WorldToScreenHeight(capture_view_element_->GetSize()[1]));
+}
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/AccessibleCaptureViewElement.cpp
+++ b/src/OrbitGl/AccessibleCaptureViewElement.cpp
@@ -16,27 +16,45 @@ const orbit_accessibility::AccessibleInterface* AccessibleCaptureViewElement::Ac
   }
   return parent->GetOrCreateAccessibleInterface();
 }
-orbit_accessibility::AccessibilityRect AccessibleCaptureViewElement::AccessibleLocalRect() const {
-  Vec2 pos = capture_view_element_->GetPos();
-  Vec2 local_pos;
-
-  const CaptureViewElement* parent = capture_view_element_->GetParent();
-  // TODO(b/177350599): This could be cleaned up with clearer coordinate systems
-  if (parent != nullptr) {
-    Vec2 parent_pos = parent->GetPos();
-    local_pos = Vec2(pos[0] - parent_pos[0], parent_pos[1] - pos[1]);
-  } else {
-    local_pos = pos;
-  }
-
+orbit_accessibility::AccessibilityRect AccessibleCaptureViewElement::AccessibleRect() const {
+  CHECK(capture_view_element_ != nullptr);
   GlCanvas* canvas = capture_view_element_->GetCanvas();
   CHECK(canvas != nullptr);
   const Viewport& viewport = canvas->GetViewport();
 
-  return orbit_accessibility::AccessibilityRect(
-      viewport.WorldToScreenWidth(local_pos[0]), viewport.WorldToScreenHeight(local_pos[1]),
-      viewport.WorldToScreenWidth(capture_view_element_->GetSize()[0]),
-      viewport.WorldToScreenHeight(capture_view_element_->GetSize()[1]));
+  Vec2 pos = capture_view_element_->GetPos();
+  Vec2 size = capture_view_element_->GetSize();
+
+  Vec2i screen_pos = viewport.WorldToScreenPos(pos);
+  int screen_width = viewport.WorldToScreenWidth(size[0]);
+  int screen_height = viewport.WorldToScreenHeight(size[1]);
+
+  // Adjust the coordinates to clamp the result to an on-screen rect
+  // This will "cut" any part that is offscreen due to scrolling, and may result
+  // in a final result with width / height of 0.
+
+  // First: Clamp bottom
+  if (screen_pos[1] + screen_height > viewport.GetScreenHeight()) {
+    screen_height = std::max(0, viewport.GetScreenHeight() - static_cast<int>(screen_pos[1]));
+  }
+  // Second: Clamp top
+  if (screen_pos[1] < 0) {
+    screen_height = std::max(0, static_cast<int>(screen_pos[1]) + screen_height);
+    screen_pos[1] = 0;
+  }
+  // Third: Clamp right
+  if (screen_pos[0] + screen_width > viewport.GetScreenWidth()) {
+    screen_width = std::max(0, viewport.GetScreenWidth() - static_cast<int>(screen_pos[0]));
+  }
+  // Fourth: Clamp left
+  if (screen_pos[0] < 0) {
+    screen_width = std::max(0, static_cast<int>(screen_pos[0]) + screen_width);
+    screen_pos[0] = 0;
+  }
+
+  return orbit_accessibility::AccessibilityRect(static_cast<int>(screen_pos[0]),
+                                                static_cast<int>(screen_pos[1]), screen_width,
+                                                screen_height);
 }
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/AccessibleCaptureViewElement.h
+++ b/src/OrbitGl/AccessibleCaptureViewElement.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_ACCESSIBLE_CAPTURE_VIEW_ELEMENT_H_
+#define ORBIT_GL_ACCESSIBLE_CAPTURE_VIEW_ELEMENT_H_
+
+#include "CaptureViewElement.h"
+#include "OrbitAccessibility/AccessibleInterface.h"
+
+namespace orbit_gl {
+class AccessibleCaptureViewElement : public orbit_accessibility::AccessibleInterface {
+ public:
+  explicit AccessibleCaptureViewElement(const CaptureViewElement* capture_view_element)
+      : capture_view_element_(capture_view_element) {
+    CHECK(capture_view_element != nullptr);
+  }
+
+  [[nodiscard]] const AccessibleInterface* AccessibleParent() const override;
+
+  [[nodiscard]] orbit_accessibility::AccessibilityRect AccessibleLocalRect() const override;
+  [[nodiscard]] orbit_accessibility::AccessibilityState AccessibleState() const override {
+    return orbit_accessibility::AccessibilityState::Normal;
+  }
+
+ private:
+  const CaptureViewElement* capture_view_element_;
+};
+
+}  // namespace orbit_gl
+
+#endif  // ORBIT_GL_ACCESSIBLE_CAPTURE_VIEW_ELEMENT_H_

--- a/src/OrbitGl/AccessibleCaptureViewElement.h
+++ b/src/OrbitGl/AccessibleCaptureViewElement.h
@@ -18,7 +18,7 @@ class AccessibleCaptureViewElement : public orbit_accessibility::AccessibleInter
 
   [[nodiscard]] const AccessibleInterface* AccessibleParent() const override;
 
-  [[nodiscard]] orbit_accessibility::AccessibilityRect AccessibleLocalRect() const override;
+  [[nodiscard]] orbit_accessibility::AccessibilityRect AccessibleRect() const override;
   [[nodiscard]] orbit_accessibility::AccessibilityState AccessibleState() const override {
     return orbit_accessibility::AccessibilityState::Normal;
   }

--- a/src/OrbitGl/AccessibleThreadBar.cpp
+++ b/src/OrbitGl/AccessibleThreadBar.cpp
@@ -12,47 +12,12 @@
 
 namespace orbit_gl {
 
+AccessibleThreadBar::AccessibleThreadBar(const ThreadBar* thread_bar)
+    : AccessibleCaptureViewElement(thread_bar), thread_bar_(thread_bar) {}
+
 int orbit_gl::AccessibleThreadBar::AccessibleChildCount() const { return 0; }
 
-const orbit_accessibility::AccessibleInterface* AccessibleThreadBar::AccessibleParent() const {
-  CHECK(thread_bar_ != nullptr);
-
-  if (thread_bar_->GetParent() == nullptr) return nullptr;
-  if (thread_bar_->GetParent()->GetAccessibleInterface() == nullptr) return nullptr;
-
-  // This relies on knowledge about AccessibleTrack: Accessibility is split into "virtual" controls
-  // that only exist as children in the accessibility tree. In particular, the track is split into
-  // a tab and a content area, and the thread bar is parented underneath the content area (child 1).
-  // This could be cleaned up by introducing "real" control elements for tab and content area.
-  return thread_bar_->GetParent()->GetAccessibleInterface()->AccessibleChild(1);
-}
-
 std::string AccessibleThreadBar::AccessibleName() const { return thread_bar_->GetName(); }
-
-orbit_accessibility::AccessibilityRect orbit_gl::AccessibleThreadBar::AccessibleLocalRect() const {
-  CHECK(thread_bar_ != nullptr);
-
-  Vec2 pos = thread_bar_->GetPos();
-  Vec2 local_pos;
-
-  const CaptureViewElement* parent = thread_bar_->GetParent();
-  // TODO(b/177350599): This could be cleaned up with clearer coordinate systems
-  if (parent != nullptr) {
-    Vec2 parent_pos = parent->GetPos();
-    local_pos = Vec2(pos[0] - parent_pos[0], parent_pos[1] - pos[1]);
-  } else {
-    local_pos = pos;
-  }
-
-  GlCanvas* canvas = thread_bar_->GetCanvas();
-  CHECK(canvas != nullptr);
-  const Viewport& viewport = canvas->GetViewport();
-
-  return orbit_accessibility::AccessibilityRect(
-      viewport.WorldToScreenWidth(local_pos[0]), viewport.WorldToScreenHeight(local_pos[1]),
-      viewport.WorldToScreenWidth(thread_bar_->GetSize()[0]),
-      viewport.WorldToScreenHeight(thread_bar_->GetSize()[1]));
-}
 
 orbit_accessibility::AccessibilityState AccessibleThreadBar::AccessibleState() const {
   return orbit_accessibility::AccessibilityState::Focusable;

--- a/src/OrbitGl/AccessibleThreadBar.h
+++ b/src/OrbitGl/AccessibleThreadBar.h
@@ -5,27 +5,26 @@
 #ifndef ORBIT_GL_ACCESSIBLE_THREAD_BAR_H_
 #define ORBIT_GL_ACCESSIBLE_THREAD_BAR_H_
 
+#include "AccessibleCaptureViewElement.h"
 #include "OrbitAccessibility/AccessibleInterface.h"
 
 namespace orbit_gl {
 
 class ThreadBar;
 
-class AccessibleThreadBar : public orbit_accessibility::AccessibleInterface {
+class AccessibleThreadBar : public AccessibleCaptureViewElement {
  public:
-  AccessibleThreadBar(const ThreadBar* thread_bar) : thread_bar_(thread_bar) {}
+  explicit AccessibleThreadBar(const ThreadBar* thread_bar);
 
   [[nodiscard]] int AccessibleChildCount() const override;
   [[nodiscard]] const AccessibleInterface* AccessibleChild(int /*index*/) const override {
     return nullptr;
   }
-  [[nodiscard]] const AccessibleInterface* AccessibleParent() const override;
 
   [[nodiscard]] std::string AccessibleName() const override;
   [[nodiscard]] orbit_accessibility::AccessibilityRole AccessibleRole() const override {
     return orbit_accessibility::AccessibilityRole::Pane;
   }
-  [[nodiscard]] orbit_accessibility::AccessibilityRect AccessibleLocalRect() const override;
   [[nodiscard]] orbit_accessibility::AccessibilityState AccessibleState() const override;
 
  private:

--- a/src/OrbitGl/AccessibleTimeGraph.cpp
+++ b/src/OrbitGl/AccessibleTimeGraph.cpp
@@ -19,7 +19,7 @@ using orbit_accessibility::AccessibleInterface;
 
 namespace orbit_gl {
 
-AccessibilityRect TimeGraphAccessibility::AccessibleLocalRect() const {
+AccessibilityRect TimeGraphAccessibility::AccessibleRect() const {
   GlCanvas* canvas = time_graph_->GetCanvas();
   const Viewport& viewport = canvas->GetViewport();
 

--- a/src/OrbitGl/AccessibleTimeGraph.h
+++ b/src/OrbitGl/AccessibleTimeGraph.h
@@ -28,7 +28,7 @@ class TimeGraphAccessibility : public orbit_accessibility::AccessibleInterface {
   [[nodiscard]] orbit_accessibility::AccessibilityRole AccessibleRole() const override {
     return orbit_accessibility::AccessibilityRole::Graphic;
   }
-  [[nodiscard]] orbit_accessibility::AccessibilityRect AccessibleLocalRect() const override;
+  [[nodiscard]] orbit_accessibility::AccessibilityRect AccessibleRect() const override;
   [[nodiscard]] orbit_accessibility::AccessibilityState AccessibleState() const override;
 
  private:

--- a/src/OrbitGl/AccessibleTrack.h
+++ b/src/OrbitGl/AccessibleTrack.h
@@ -15,32 +15,6 @@ class Track;
 namespace orbit_gl {
 
 /*
- * Accessibility implementation for the track content.
- * This is a "virtual" control and will be generated as a child of AccessibleTrack to split the
- * areas for the track title and the content.
- */
-class AccessibleTrackContent : public orbit_accessibility::AccessibleInterface {
- public:
-  AccessibleTrackContent(Track* track, TimeGraphLayout* layout);
-
-  [[nodiscard]] int AccessibleChildCount() const override;
-  [[nodiscard]] const AccessibleInterface* AccessibleChild(int /*index*/) const override;
-  [[nodiscard]] const AccessibleInterface* AccessibleParent() const override;
-
-  [[nodiscard]] std::string AccessibleName() const override;
-  [[nodiscard]] orbit_accessibility::AccessibilityRole AccessibleRole() const override {
-    return orbit_accessibility::AccessibilityRole::Grouping;
-  }
-  [[nodiscard]] orbit_accessibility::AccessibilityRect AccessibleLocalRect() const override;
-  [[nodiscard]] orbit_accessibility::AccessibilityState AccessibleState() const override;
-
- private:
-  Track* track_;
-  TimeGraphLayout* layout_;
-  std::unique_ptr<AccessibleInterface> timer_pane_;
-};
-
-/*
  * Accessibility implementation for the track tab.
  * This is a "virtual" control and will be generated as a child of AccessibleTrack to make the track
  * tab clickable.
@@ -49,7 +23,7 @@ class AccessibleTrackTab : public orbit_accessibility::AccessibleInterface {
  public:
   AccessibleTrackTab(Track* track, TimeGraphLayout* layout) : track_(track), layout_(layout){};
 
-  [[nodiscard]] int AccessibleChildCount() const override;
+  [[nodiscard]] int AccessibleChildCount() const override { return 1; }
   [[nodiscard]] const AccessibleInterface* AccessibleChild(int /*index*/) const override;
   [[nodiscard]] const AccessibleInterface* AccessibleParent() const override;
 
@@ -58,21 +32,53 @@ class AccessibleTrackTab : public orbit_accessibility::AccessibleInterface {
     return orbit_accessibility::AccessibilityRole::PageTab;
   }
   [[nodiscard]] orbit_accessibility::AccessibilityRect AccessibleLocalRect() const override;
-  [[nodiscard]] orbit_accessibility::AccessibilityState AccessibleState() const override;
+  [[nodiscard]] orbit_accessibility::AccessibilityState AccessibleState() const override {
+    return orbit_accessibility::AccessibilityState::Normal;
+  }
 
  private:
   Track* track_;
   TimeGraphLayout* layout_;
 };
 
+class AccessibleTimerPane : public orbit_accessibility::AccessibleInterface {
+ public:
+  explicit AccessibleTimerPane(orbit_accessibility::AccessibleInterface* parent)
+      : parent_(parent) {}
+
+  [[nodiscard]] int AccessibleChildCount() const override { return 0; }
+  [[nodiscard]] const orbit_accessibility::AccessibleInterface* AccessibleChild(
+      int /*index*/) const override {
+    return nullptr;
+  }
+  [[nodiscard]] const orbit_accessibility::AccessibleInterface* AccessibleParent() const override {
+    return parent_;
+  }
+
+  [[nodiscard]] std::string AccessibleName() const override { return "Timers"; }
+  [[nodiscard]] orbit_accessibility::AccessibilityRole AccessibleRole() const override {
+    return orbit_accessibility::AccessibilityRole::Pane;
+  }
+  [[nodiscard]] orbit_accessibility::AccessibilityRect AccessibleLocalRect() const override;
+
+  [[nodiscard]] orbit_accessibility::AccessibilityState AccessibleState() const override {
+    return orbit_accessibility::AccessibilityState::Normal;
+  }
+
+ private:
+  orbit_accessibility::AccessibleInterface* parent_;
+};
+
 /*
  * Accessibility information for the track.
- * This will return two "virtual" children to split the track tab and its content.
+ * This will return the two "virtual" controls for the title tab and the timers in addition to the
+ * actual children of the track.
+ * The title tab is the first child and the timers pane is the last child.
  */
 class AccessibleTrack : public orbit_accessibility::AccessibleInterface {
  public:
   AccessibleTrack(Track* track, TimeGraphLayout* layout)
-      : track_(track), layout_(layout), content_(track_, layout_), tab_(track_, layout_){};
+      : track_(track), layout_(layout), tab_(track_, layout_), timers_pane_(this){};
 
   [[nodiscard]] int AccessibleChildCount() const override;
   [[nodiscard]] const AccessibleInterface* AccessibleChild(int index) const override;
@@ -88,8 +94,8 @@ class AccessibleTrack : public orbit_accessibility::AccessibleInterface {
  private:
   Track* track_;
   TimeGraphLayout* layout_;
-  AccessibleTrackContent content_;
   AccessibleTrackTab tab_;
+  AccessibleTimerPane timers_pane_;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/AccessibleTrack.h
+++ b/src/OrbitGl/AccessibleTrack.h
@@ -7,6 +7,7 @@
 
 #include <string>
 
+#include "AccessibleCaptureViewElement.h"
 #include "OrbitAccessibility/AccessibleInterface.h"
 #include "TimeGraphLayout.h"
 
@@ -19,54 +20,36 @@ namespace orbit_gl {
  * This is a "virtual" control and will be generated as a child of AccessibleTrack to make the track
  * tab clickable.
  */
-class AccessibleTrackTab : public orbit_accessibility::AccessibleInterface {
+class AccessibleTrackTab : public AccessibleCaptureViewElement {
  public:
-  AccessibleTrackTab(Track* track, TimeGraphLayout* layout) : track_(track), layout_(layout){};
+  AccessibleTrackTab(CaptureViewElement* fake_track_tab, Track* track);
 
   [[nodiscard]] int AccessibleChildCount() const override { return 1; }
   [[nodiscard]] const AccessibleInterface* AccessibleChild(int /*index*/) const override;
-  [[nodiscard]] const AccessibleInterface* AccessibleParent() const override;
 
   [[nodiscard]] std::string AccessibleName() const override;
   [[nodiscard]] orbit_accessibility::AccessibilityRole AccessibleRole() const override {
     return orbit_accessibility::AccessibilityRole::PageTab;
   }
-  [[nodiscard]] orbit_accessibility::AccessibilityRect AccessibleLocalRect() const override;
-  [[nodiscard]] orbit_accessibility::AccessibilityState AccessibleState() const override {
-    return orbit_accessibility::AccessibilityState::Normal;
-  }
 
  private:
   Track* track_;
-  TimeGraphLayout* layout_;
 };
 
-class AccessibleTimerPane : public orbit_accessibility::AccessibleInterface {
+class AccessibleTimerPane : public AccessibleCaptureViewElement {
  public:
-  explicit AccessibleTimerPane(orbit_accessibility::AccessibleInterface* parent)
-      : parent_(parent) {}
+  explicit AccessibleTimerPane(CaptureViewElement* fake_timer_pane);
 
   [[nodiscard]] int AccessibleChildCount() const override { return 0; }
   [[nodiscard]] const orbit_accessibility::AccessibleInterface* AccessibleChild(
       int /*index*/) const override {
     return nullptr;
   }
-  [[nodiscard]] const orbit_accessibility::AccessibleInterface* AccessibleParent() const override {
-    return parent_;
-  }
 
   [[nodiscard]] std::string AccessibleName() const override { return "Timers"; }
   [[nodiscard]] orbit_accessibility::AccessibilityRole AccessibleRole() const override {
     return orbit_accessibility::AccessibilityRole::Pane;
   }
-  [[nodiscard]] orbit_accessibility::AccessibilityRect AccessibleLocalRect() const override;
-
-  [[nodiscard]] orbit_accessibility::AccessibilityState AccessibleState() const override {
-    return orbit_accessibility::AccessibilityState::Normal;
-  }
-
- private:
-  orbit_accessibility::AccessibleInterface* parent_;
 };
 
 /*
@@ -75,27 +58,23 @@ class AccessibleTimerPane : public orbit_accessibility::AccessibleInterface {
  * actual children of the track.
  * The title tab is the first child and the timers pane is the last child.
  */
-class AccessibleTrack : public orbit_accessibility::AccessibleInterface {
+class AccessibleTrack : public AccessibleCaptureViewElement {
  public:
-  AccessibleTrack(Track* track, TimeGraphLayout* layout)
-      : track_(track), layout_(layout), tab_(track_, layout_), timers_pane_(this){};
+  AccessibleTrack(Track* track, TimeGraphLayout* layout);
 
   [[nodiscard]] int AccessibleChildCount() const override;
   [[nodiscard]] const AccessibleInterface* AccessibleChild(int index) const override;
-  [[nodiscard]] const AccessibleInterface* AccessibleParent() const override;
 
   [[nodiscard]] std::string AccessibleName() const override;
   [[nodiscard]] orbit_accessibility::AccessibilityRole AccessibleRole() const override {
     return orbit_accessibility::AccessibilityRole::Grouping;
   }
-  [[nodiscard]] orbit_accessibility::AccessibilityRect AccessibleLocalRect() const override;
   [[nodiscard]] orbit_accessibility::AccessibilityState AccessibleState() const override;
 
  private:
   Track* track_;
-  TimeGraphLayout* layout_;
-  AccessibleTrackTab tab_;
-  AccessibleTimerPane timers_pane_;
+  std::unique_ptr<CaptureViewElement> fake_tab_;
+  std::unique_ptr<CaptureViewElement> fake_timers_pane_;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/AccessibleTriangleToggle.cpp
+++ b/src/OrbitGl/AccessibleTriangleToggle.cpp
@@ -9,27 +9,10 @@
 
 namespace orbit_gl {
 
-orbit_accessibility::AccessibilityRect AccessibleTriangleToggle::AccessibleLocalRect() const {
-  CHECK(triangle_toggle_ != nullptr);
-  CHECK(triangle_toggle_->GetCanvas() != nullptr);
-
-  GlCanvas* canvas = triangle_toggle_->GetCanvas();
-  Vec2 pos = triangle_toggle_->GetPos();
-  Vec2 size = triangle_toggle_->GetSize();
-
-  const Viewport& viewport = canvas->GetViewport();
-
-  Vec2i screen_pos = viewport.WorldToScreenPos(pos);
-  int screen_width = viewport.WorldToScreenWidth(size[0]);
-  int screen_height = viewport.WorldToScreenHeight(size[1]);
-
-  orbit_accessibility::AccessibilityRect parent_rect =
-      parent_->GetOrCreateAccessibleInterface()->AccessibleLocalRect();
-
-  return orbit_accessibility::AccessibilityRect(screen_pos[0] - parent_rect.left,
-                                                screen_pos[1] - parent_rect.top, screen_width,
-                                                screen_height);
-}
+AccessibleTriangleToggle::AccessibleTriangleToggle(TriangleToggle* triangle_toggle, Track* parent)
+    : AccessibleCaptureViewElement(triangle_toggle),
+      triangle_toggle_{triangle_toggle},
+      parent_{parent} {}
 
 orbit_accessibility::AccessibilityState AccessibleTriangleToggle::AccessibleState() const {
   if (triangle_toggle_->IsInactive()) {

--- a/src/OrbitGl/AccessibleTriangleToggle.h
+++ b/src/OrbitGl/AccessibleTriangleToggle.h
@@ -5,8 +5,8 @@
 #ifndef ORBIT_GL_ACCESSIBLE_TRIANGLE_TOGGLE_H_
 #define ORBIT_GL_ACCESSIBLE_TRIANGLE_TOGGLE_H_
 
+#include "AccessibleCaptureViewElement.h"
 #include "CaptureViewElement.h"
-#include "OrbitAccessibility/AccessibleInterface.h"
 #include "Track.h"
 
 class TriangleToggle;
@@ -18,24 +18,22 @@ namespace orbit_gl {
  * child of the track. It will be thus on the same level as the virtual elements for the tab and the
  * content (see `AccessibleTrack`).
  */
-class AccessibleTriangleToggle : public orbit_accessibility::AccessibleInterface {
+class AccessibleTriangleToggle : public AccessibleCaptureViewElement {
  public:
-  explicit AccessibleTriangleToggle(TriangleToggle* triangle_toggle, Track* parent)
-      : triangle_toggle_{triangle_toggle}, parent_{parent} {};
+  explicit AccessibleTriangleToggle(TriangleToggle* triangle_toggle, Track* parent);
 
   [[nodiscard]] int AccessibleChildCount() const override { return 0; };
   [[nodiscard]] const AccessibleInterface* AccessibleChild(int /*index*/) const override {
     return nullptr;
   }
-  [[nodiscard]] const AccessibleInterface* AccessibleParent() const override;
+
+  [[nodiscard]] const orbit_accessibility::AccessibleInterface* AccessibleParent() const override;
 
   [[nodiscard]] std::string AccessibleName() const override { return "TriangleToggle"; }
 
   [[nodiscard]] orbit_accessibility::AccessibilityRole AccessibleRole() const override {
     return orbit_accessibility::AccessibilityRole::Button;
   }
-
-  [[nodiscard]] orbit_accessibility::AccessibilityRect AccessibleLocalRect() const override;
   [[nodiscard]] orbit_accessibility::AccessibilityState AccessibleState() const override;
 
  private:

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -11,7 +11,8 @@ target_compile_options(OrbitGl PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(
   OrbitGl
-  PUBLIC AccessibleThreadBar.h
+  PUBLIC AccessibleCaptureViewElement.h
+         AccessibleThreadBar.h
          AccessibleTimeGraph.h
          AccessibleTrack.h
          AccessibleTriangleToggle.h
@@ -78,7 +79,8 @@ target_sources(
 
 target_sources(
   OrbitGl
-  PRIVATE AccessibleThreadBar.cpp
+  PRIVATE AccessibleCaptureViewElement.cpp
+          AccessibleThreadBar.cpp
           AccessibleTimeGraph.cpp
           AccessibleTrack.cpp
           AccessibleTriangleToggle.cpp

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -30,8 +30,9 @@ class CaptureViewElement : public Pickable {
   [[nodiscard]] TimeGraph* GetTimeGraph() { return time_graph_; }
 
   [[nodiscard]] GlCanvas* GetCanvas() const { return canvas_; }
+  void SetCanvas(GlCanvas* canvas) { canvas_ = canvas; }
 
-  virtual void SetPos(float x, float y) { pos_ = Vec2(x, y); }
+  void SetPos(float x, float y) { pos_ = Vec2(x, y); }
   [[nodiscard]] Vec2 GetPos() const { return pos_; }
   void SetSize(float width, float height) { size_ = Vec2(width, height); }
   [[nodiscard]] Vec2 GetSize() const { return size_; }

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -79,14 +79,14 @@ FrameTrack::FrameTrack(CaptureViewElement* parent, TimeGraph* time_graph, TimeGr
                              TriangleToggle::InitialStateUpdate::kReplaceInitialState);
 }
 
-float FrameTrack::GetHeaderHeight() const { return 0.f; }
+float FrameTrack::GetHeaderHeight() const { return layout_->GetTrackTabHeight(); }
 
 float FrameTrack::GetHeight() const {
-  return GetMaximumBoxHeight() + layout_->GetTrackBottomMargin();
+  return GetHeaderHeight() + GetMaximumBoxHeight() + layout_->GetTrackBottomMargin();
 }
 
 float FrameTrack::GetYFromTimer(const TimerInfo& /*timer_info*/) const {
-  return pos_[1] - GetMaximumBoxHeight();
+  return pos_[1] - GetHeaderHeight() - GetMaximumBoxHeight();
 }
 
 float FrameTrack::GetTextBoxHeight(const TimerInfo& timer_info) const {
@@ -234,7 +234,7 @@ void FrameTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset
   const Color kWhiteColor(255, 255, 255, 255);
   const Color kBlackColor(0, 0, 0, 255);
 
-  float y = pos_[1] - GetMaximumBoxHeight() + GetAverageBoxHeight();
+  float y = pos_[1] - GetHeaderHeight() - GetMaximumBoxHeight() + GetAverageBoxHeight();
   float x = pos_[0];
   Vec2 from(x, y);
   Vec2 to(x + size_[0], y);

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -167,7 +167,7 @@ float GpuTrack::GetYFromTimer(const TimerInfo& timer_info) const {
     adjusted_depth = 0.f;
   }
   if (timer_info.type() == TimerInfo::kGpuDebugMarker) {
-    return pos_[1] - layout_->GetTextBoxHeight() * (adjusted_depth + 1.f);
+    return pos_[1] - GetHeaderHeight() - layout_->GetTextBoxHeight() * (adjusted_depth + 1.f);
   }
   CHECK(timer_info.type() == TimerInfo::kGpuActivity ||
         timer_info.type() == TimerInfo::kGpuCommandBuffer);
@@ -190,7 +190,8 @@ float GpuTrack::GetYFromTimer(const TimerInfo& timer_info) const {
   if (timer_info.type() == TimerInfo::kGpuCommandBuffer) {
     adjusted_depth += 1.f;
   }
-  return pos_[1] - layout_->GetTextBoxHeight() * (adjusted_depth + 1.f) - gap_space;
+  return pos_[1] - GetHeaderHeight() - layout_->GetTextBoxHeight() * (adjusted_depth + 1.f) -
+         gap_space;
 }
 
 // When track is collapsed, only draw "hardware execution" timers and the root "debug markers".
@@ -242,8 +243,8 @@ float GpuTrack::GetHeight() const {
   if (has_vulkan_layer_command_buffer_timers_ && !collapsed) {
     depth *= 2;
   }
-  return layout_->GetTextBoxHeight() * depth + (num_gaps * layout_->GetSpaceBetweenGpuDepths()) +
-         layout_->GetTrackBottomMargin();
+  return GetHeaderHeight() + layout_->GetTextBoxHeight() * depth +
+         (num_gaps * layout_->GetSpaceBetweenGpuDepths()) + layout_->GetTrackBottomMargin();
 }
 
 const TextBox* GpuTrack::GetLeft(const TextBox* text_box) const {

--- a/src/OrbitGl/MemoryTrack.cpp
+++ b/src/OrbitGl/MemoryTrack.cpp
@@ -19,12 +19,18 @@ void MemoryTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offse
   Batcher* ui_batcher = canvas->GetBatcher();
   uint32_t font_size = layout_->CalculateZoomedFontSize();
 
+  float content_height =
+      (size_[1] - layout_->GetTrackTabHeight() - layout_->GetTrackBottomMargin());
+  Vec2 content_pos = pos_;
+  content_pos[1] -= layout_->GetTrackTabHeight();
+
   // Add warning threshold text box and line.
   if (warning_threshold_.has_value()) {
     const Color kThresholdColor(244, 67, 54, 255);
     double normalized_value = (warning_threshold_.value().second - min_) * inv_value_range_;
     float x = pos_[0];
-    float y = pos_[1] - size_[1] + static_cast<float>(normalized_value) * size_[1];
+    float y =
+        content_pos[1] - content_height + static_cast<float>(normalized_value) * content_height;
     Vec2 from(x, y);
     Vec2 to(x + size_[0], y);
 
@@ -51,7 +57,7 @@ void MemoryTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offse
     Vec2 text_box_size(string_width, layout_->GetTextBoxHeight());
     Vec2 text_box_position(pos_[0] + size_[0] - text_box_size[0] - layout_->GetRightMargin() -
                                layout_->GetSliderWidth(),
-                           pos_[1] - layout_->GetTextBoxHeight() / 2.f);
+                           content_pos[1] - layout_->GetTextBoxHeight() / 2.f);
     canvas->GetTextRenderer().AddText(text.c_str(), text_box_position[0],
                                       text_box_position[1] + layout_->GetTextOffset(), text_z,
                                       kWhite, font_size, text_box_size[0]);
@@ -64,7 +70,7 @@ void MemoryTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offse
     Vec2 text_box_size(string_width, layout_->GetTextBoxHeight());
     Vec2 text_box_position(pos_[0] + size_[0] - text_box_size[0] - layout_->GetRightMargin() -
                                layout_->GetSliderWidth(),
-                           pos_[1] - size_[1]);
+                           content_pos[1] - content_height);
     canvas->GetTextRenderer().AddText(text.c_str(), text_box_position[0],
                                       text_box_position[1] + layout_->GetTextOffset(), text_z,
                                       kWhite, font_size, text_box_size[0]);

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -41,8 +41,8 @@ void SchedulerTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
 
 float SchedulerTrack::GetHeight() const {
   uint32_t num_gaps = depth_ > 0 ? depth_ - 1 : 0;
-  return (depth_ * layout_->GetTextCoresHeight()) + (num_gaps * layout_->GetSpaceBetweenCores()) +
-         layout_->GetTrackBottomMargin();
+  return GetHeaderHeight() + (depth_ * layout_->GetTextCoresHeight()) +
+         (num_gaps * layout_->GetSpaceBetweenCores()) + layout_->GetTrackBottomMargin();
 }
 
 bool SchedulerTrack::IsTimerActive(const TimerInfo& timer_info) const {
@@ -71,7 +71,8 @@ Color SchedulerTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selecte
 
 float SchedulerTrack::GetYFromTimer(const TimerInfo& timer_info) const {
   uint32_t num_gaps = timer_info.depth();
-  return pos_[1] - (layout_->GetTextCoresHeight() * static_cast<float>(timer_info.depth() + 1)) -
+  return pos_[1] - GetHeaderHeight() -
+         (layout_->GetTextCoresHeight() * static_cast<float>(timer_info.depth() + 1)) -
          num_gaps * layout_->GetSpaceBetweenCores();
 }
 

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -242,7 +242,7 @@ void ThreadTrack::UpdatePositionOfSubtracks() {
   const float event_track_height = layout_->GetEventTrackHeight();
   const float space_between_subtracks = layout_->GetSpaceBetweenTracksAndThread();
 
-  float current_y = pos_[1];
+  float current_y = pos_[1] - layout_->GetTrackTabHeight();
 
   thread_state_bar_->SetPos(pos_[0], current_y);
   if (!thread_state_bar_->IsEmpty()) {
@@ -393,7 +393,7 @@ float ThreadTrack::GetHeaderHeight() const {
   const float tracepoint_track_height = layout_->GetEventTrackHeight();
   const float space_between_subtracks = layout_->GetSpaceBetweenTracksAndThread();
 
-  float header_height = 0.0f;
+  float header_height = layout_->GetTrackTabHeight();
   int track_count = 0;
   if (!thread_state_bar_->IsEmpty()) {
     header_height += thread_state_track_height;
@@ -412,6 +412,14 @@ float ThreadTrack::GetHeaderHeight() const {
 
   header_height += std::max(0, track_count - 1) * space_between_subtracks;
   return header_height;
+}
+
+float ThreadTrack::GetYFromDepth(uint32_t depth) const {
+  bool gap_between_tracks_and_timers =
+      !thread_state_bar_->IsEmpty() || !event_bar_->IsEmpty() || !tracepoint_bar_->IsEmpty();
+  return pos_[1] - GetHeaderHeight() -
+         (gap_between_tracks_and_timers ? layout_->GetSpaceBetweenTracksAndThread() : 0) -
+         box_height_ * static_cast<float>(depth + 1);
 }
 
 void ThreadTrack::OnTimer(const TimerInfo& timer_info) {

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -42,6 +42,7 @@ class ThreadTrack final : public TimerTrack {
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
+  [[nodiscard]] virtual float GetYFromDepth(uint32_t depth) const override;
 
   void OnPick(int x, int y) override;
 

--- a/src/OrbitGl/TimeGraphLayout.cpp
+++ b/src/OrbitGl/TimeGraphLayout.cpp
@@ -16,7 +16,7 @@ TimeGraphLayout::TimeGraphLayout() {
   track_top_margin_ = 5.f;
   space_between_cores_ = 2.f;
   space_between_gpu_depths_ = 2.f;
-  space_between_tracks_ = 40.f;
+  space_between_tracks_ = 10.f;
   space_between_tracks_and_thread_ = 5.f;
   space_between_thread_blocks_ = 35.f;
   track_label_offset_x_ = 30.f;

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -60,8 +60,7 @@ float TimerTrack::GetYFromTimer(const TimerInfo& timer_info) const {
 }
 
 float TimerTrack::GetYFromDepth(uint32_t depth) const {
-  return pos_[1] - GetHeaderHeight() - layout_->GetSpaceBetweenTracksAndThread() -
-         box_height_ * static_cast<float>(depth + 1);
+  return pos_[1] - GetHeaderHeight() - box_height_ * static_cast<float>(depth + 1);
 }
 
 void TimerTrack::UpdateBoxHeight() { box_height_ = layout_->GetTextBoxHeight(); }
@@ -340,9 +339,9 @@ float TimerTrack::GetHeight() const {
   bool is_collapsed = collapse_toggle_->IsCollapsed();
   uint32_t collapsed_depth = (GetNumTimers() == 0) ? 0 : 1;
   uint32_t depth = is_collapsed ? collapsed_depth : GetDepth();
-  return layout_->GetTextBoxHeight() * depth +
+  return GetHeaderHeight() + layout_->GetTextBoxHeight() * depth +
          (depth > 0 ? layout_->GetSpaceBetweenTracksAndThread() : 0) +
-         layout_->GetEventTrackHeight() + layout_->GetTrackBottomMargin();
+         layout_->GetTrackBottomMargin();
 }
 
 std::string TimerTrack::GetTooltip() const {
@@ -430,7 +429,7 @@ std::string TimerTrack::GetBoxTooltip(const Batcher& /*batcher*/, PickingId /*id
   return "";
 }
 
-float TimerTrack::GetHeaderHeight() const { return layout_->GetEventTrackHeight(); }
+float TimerTrack::GetHeaderHeight() const { return layout_->GetTrackTabHeight(); }
 
 internal::DrawData TimerTrack::GetDrawData(uint64_t min_tick, uint64_t max_tick, float z_offset,
                                            Batcher* batcher, TimeGraph* time_graph,

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -90,7 +90,7 @@ class TimerTrack : public Track {
   [[nodiscard]] virtual float GetTextBoxHeight(
       const orbit_client_protos::TimerInfo& /*timer_info*/) const;
   [[nodiscard]] virtual float GetYFromTimer(const orbit_client_protos::TimerInfo& timer_info) const;
-  [[nodiscard]] float GetYFromDepth(uint32_t depth) const;
+  [[nodiscard]] virtual float GetYFromDepth(uint32_t depth) const;
 
   [[nodiscard]] virtual float GetHeaderHeight() const;
 

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -54,7 +54,7 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   [[nodiscard]] virtual Type GetType() const = 0;
   [[nodiscard]] virtual bool Movable() { return !pinned_; }
 
-  [[nodiscard]] virtual float GetHeight() const { return 0.f; };
+  [[nodiscard]] virtual float GetHeight() const = 0;
   [[nodiscard]] bool GetVisible() const { return visible_; }
   void SetVisible(bool value) { visible_ = value; }
 

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -274,33 +274,10 @@ int TrackManager::FindMovingTrackIndex() {
 void TrackManager::UpdateTracks(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                                 PickingMode picking_mode) {
   // Make sure track tab fits in the viewport.
-  float current_y = -layout_->GetSchedulerTrackOffset() - layout_->GetTrackTabHeight();
-  float pinned_tracks_height = 0.f;
+  float current_y = -layout_->GetSchedulerTrackOffset();
 
-  // Draw pinned tracks
+  // Draw tracks
   for (auto& track : visible_tracks_) {
-    if (!track->IsPinned()) {
-      continue;
-    }
-
-    const float z_offset = GlCanvas::kZOffsetPinnedTrack;
-    if (!track->IsMoving()) {
-      track->SetPos(track->GetPos()[0],
-                    current_y + time_graph_->GetCanvas()->GetViewport().GetWorldTopLeft()[1] -
-                        layout_->GetTopMargin() - layout_->GetSchedulerTrackOffset());
-    }
-    track->UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
-    const float height = (track->GetHeight() + layout_->GetSpaceBetweenTracks());
-    current_y -= height;
-    pinned_tracks_height += height;
-  }
-
-  // Draw unpinned tracks
-  for (auto& track : visible_tracks_) {
-    if (track->IsPinned()) {
-      continue;
-    }
-
     const float z_offset = track->IsMoving() ? GlCanvas::kZOffsetMovingTack : 0.f;
     if (!track->IsMoving()) {
       track->SetPos(track->GetPos()[0], current_y);


### PR DESCRIPTION
### Adjust Positioning System of Tracks - Make it Self-contained.

CaptureViewElements have position and size information for their
appearance in the world coordinate system. This was only partially
used for tracks. The track's header/tab was not included by the
position/size of the track itself. Instead, the layout's gap size
between tracks contained the size of the header. The track relied
on this implicit space and drawn the header out of its scope.

This change adjusted the track's size. It is now the complete size
of a track.

Further, -- since there were bugs and it was unused -- this change
removes the handling for pinned tracks. The were drawn differently,
and remain untested.

Follow-up:
1. Simplify the Accessibility Interface (for tracks).
2. The nice thing about the state before this change, was that
   drawing the track's content did not required any knowledge about
   the header (and other margins). However, the clean solution would
   be to split the Track into a TrackHeader/Tab, (possibly multiple)
   TrackContentPane and TrackFooter.

Test: Take a capture including all types of tracks.


-----

### Introduce AccessibleCaptureViewElement as base class for accessibility.

With CaptureViewElement's following the same positioning (with
their pos/size set correctly) as well as adding knowledge about
their parent, this change extracts some computations for accessibility
into a base class.

Follow-ups:
1. Remove the need for virtual controls, by splitting Track into
   multiple CaptureViewElements.
2. Let the AccessibleCaptureViewElement take more parameters,
   instead of overriding for specialisations.

Test: Use AccessibilityInsights.

_____
### AccessibilityInterface now uses absolute positions for the rect.

Postions of CaptureViewElements as well as in AccessibilityAdapter::rect()
are absolute. Prior this change, we converted CaptureViewElement's position
to a relative one in order to convert it back to an absolute one.
This makes the AccessibilityInterfaces unnecessarily complicated.

This change switch also to absolute positions in the accessibility.
Further, it introduces FakeTimerPane and FakeTrackTab as capture view
elements. Now all position calculations for accessibility are done
by AccessibleCaptureViewElement.

Follow up: The fake classes should be actual children of a Track.
  This requires the actual drawing to be also moved to those classes.

Test: Take a capture and inspect with the AccessibilityInsights.