### PR TITLE
Quote all fields in exported CSV files

### DIFF
--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -164,6 +164,7 @@ target_sources(OrbitGlTests PRIVATE
 target_sources(OrbitGlTests PRIVATE
                BatcherTest.cpp
                BlockChainTest.cpp
+               DataViewTest.cpp
                GlUtilsTest.cpp
                GpuTrackTest.cpp
                PickingManagerTest.cpp

--- a/src/OrbitGl/DataView.cpp
+++ b/src/OrbitGl/DataView.cpp
@@ -4,11 +4,23 @@
 
 #include "DataView.h"
 
+#include <absl/strings/str_replace.h>
+
 #include <memory>
 
 #include "App.h"
 #include "OrbitBase/File.h"
 #include "OrbitBase/Logging.h"
+
+namespace orbit_gl {
+std::string FormatValueForCsv(std::string_view value) {
+  std::string result;
+  result.append("\"");
+  result.append(absl::StrReplaceAll(value, {{"\"", "\"\""}}));
+  result.append("\"");
+  return result;
+}
+}  // namespace orbit_gl
 
 void DataView::InitSortingOrders() {
   sorting_orders_.clear();
@@ -105,7 +117,7 @@ ErrorMessageOr<void> DataView::ExportCSV(const std::filesystem::path& file_path)
   {
     std::string header_line;
     for (size_t i = 0; i < num_columns; ++i) {
-      header_line.append(GetColumns()[i].header);
+      header_line.append(orbit_gl::FormatValueForCsv(GetColumns()[i].header));
       if (i < num_columns - 1) header_line.append(", ");
     }
 
@@ -122,7 +134,7 @@ ErrorMessageOr<void> DataView::ExportCSV(const std::filesystem::path& file_path)
   for (size_t i = 0; i < num_elements; ++i) {
     std::string line;
     for (size_t j = 0; j < num_columns; ++j) {
-      line.append(GetValue(i, j));
+      line.append(orbit_gl::FormatValueForCsv(GetValue(i, j)));
       if (j < num_columns - 1) line.append(", ");
     }
     line.append("\r\n");

--- a/src/OrbitGl/DataView.h
+++ b/src/OrbitGl/DataView.h
@@ -5,6 +5,7 @@
 #ifndef ORBIT_GL_DATA_VIEW_H_
 #define ORBIT_GL_DATA_VIEW_H_
 
+#include <absl/container/flat_hash_set.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -19,11 +20,18 @@
 #include "DataViewTypes.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
-#include "absl/container/flat_hash_set.h"
 
 class OrbitApp;
 
 enum class RefreshMode { kOnFilter, kOnSort, kOther };
+
+namespace orbit_gl {
+// Values in the dataview may contain commas, for example, functions with arguments. We quote all
+// values in the output and also escape quotes (with a second quote) in values to ensure the CSV
+// files can be imported correctly in spreadsheet applications. The formatting follows the
+// specification in https://tools.ietf.org/html/rfc4180.
+std::string FormatValueForCsv(std::string_view value);
+}  // namespace orbit_gl
 
 class DataView {
  public:

--- a/src/OrbitGl/DataViewTest.cpp
+++ b/src/OrbitGl/DataViewTest.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "DataView.h"
+
+using orbit_gl::FormatValueForCsv;
+
+TEST(DataView, FormatValueForCsvQuotesEmptyString) { EXPECT_EQ("\"\"", FormatValueForCsv("")); }
+
+TEST(DataView, FormatValueForCsvQuotesString) {
+  EXPECT_EQ("\"string\"", FormatValueForCsv("string"));
+}
+
+TEST(DataView, FormatValueForCsvEscapesQuotesInString) {
+  constexpr std::string_view kInput("string\"with\"quotes");
+  constexpr std::string_view kExpectedResult("\"string\"\"with\"\"quotes\"");
+  EXPECT_EQ(kExpectedResult, FormatValueForCsv(kInput));
+}


### PR DESCRIPTION
Fields in our exported CSV files may contain commas, for example,
strings that represent functions with arguments. To ensure that these
CSV files can be correctly imported in spreadsheet applications, values
for these fields need to be quoted. We also escape any existing quotes
in values. Added a unit test to ensure correctness of the formatting 
code. 

Tested: Exported CSV file from sampled callstack, imported in Google
Sheets. Unit test.
Bug: http://b/181847321