### PR TITLE
Add flag for the memory warning threshold

### DIFF
--- a/src/OrbitGl/ClientFlags.cpp
+++ b/src/OrbitGl/ClientFlags.cpp
@@ -41,3 +41,8 @@ ABSL_FLAG(bool, enable_tracepoint_feature, false,
 
 // TODO(b/181736566): Remove this flag entirely
 ABSL_FLAG(bool, enable_source_code_view, true, "Enable the experimental source code view");
+
+// TODO(b/185099421): Remove this flag once we have a clear explanation of the memory warning
+// threshold (i.e., production limit).
+ABSL_FLAG(bool, enable_warning_threshold, false,
+          "Enable setting and showing the memory warning threshold");

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -36,6 +36,8 @@
 #include "TrackManager.h"
 #include "absl/strings/str_format.h"
 
+ABSL_DECLARE_FLAG(bool, enable_warning_threshold);
+
 using orbit_client_protos::CallstackEvent;
 using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::TimerInfo;
@@ -480,8 +482,10 @@ void TimeGraph::ProcessMemoryTrackingTimer(const TimerInfo& timer_info) {
     track = track_manager_->GetOrCreateGraphTrack(kUsedLabel);
     track->SetValueUpperBoundWhenEmpty(total_pretty_label, total_raw_value);
     track->SetValueLowerBoundWhenEmpty(kValueLowerBoundLabel, kValueLowerBoundRawValue);
-    track->SetWarningThresholdWhenEmpty(warning_threshold_pretty_label,
-                                        warning_threshold_raw_value);
+    if (absl::GetFlag(FLAGS_enable_warning_threshold)) {
+      track->SetWarningThresholdWhenEmpty(warning_threshold_pretty_label,
+                                          warning_threshold_raw_value);
+    }
     track->SetLabelUnitWhenEmpty(kTrackValueLabelUnit);
     track->SetValueDecimalDigitsWhenEmpty(kTrackValueDecimalDigits);
     double used_mb =

--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -4,6 +4,9 @@
 
 #include "CaptureOptionsDialog.h"
 
+#include <absl/flags/declare.h>
+#include <absl/flags/flag.h>
+
 #include <QAbstractButton>
 #include <QDialog>
 #include <QDialogButtonBox>
@@ -13,6 +16,8 @@
 #include "ConfigWidgets/SourcePathsMappingDialog.h"
 #include "SourcePathsMapping/MappingManager.h"
 #include "ui_CaptureOptionsDialog.h"
+
+ABSL_DECLARE_FLAG(bool, enable_warning_threshold);
 
 namespace orbit_qt {
 
@@ -29,6 +34,11 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
 
   QObject::connect(ui_->openSourcePathsMappingDialog, &QAbstractButton::clicked, this,
                    &CaptureOptionsDialog::ShowSourcePathsMappingEditor);
+
+  if (!absl::GetFlag(FLAGS_enable_warning_threshold)) {
+    ui_->memoryWarningThresholdKbLabel->hide();
+    ui_->memoryWarningThresholdKbLineEdit->hide();
+  }
 }
 
 bool CaptureOptionsDialog::GetCollectThreadStates() const {


### PR DESCRIPTION
With this change, we add the feature flag for the memory warning
threshold (i.e., the production limit) and set the default value as
false. This will be remove once we have a clear explanation of the
production limit.