### PR TITLE
Show error message when updating a loaded module with no build_id during capture.

### DIFF
--- a/src/OrbitClientData/ModuleDataTest.cpp
+++ b/src/OrbitClientData/ModuleDataTest.cpp
@@ -212,15 +212,15 @@ TEST(ModuleData, UpdateIfChanged) {
   EXPECT_TRUE(module.GetFunctions().empty());
 
   module_info.set_name("different name");
-  module.UpdateIfChanged(module_info);
+  EXPECT_FALSE(module.UpdateIfChangedAndUnload(module_info));
   EXPECT_EQ(module.name(), module_info.name());
 
   module_info.set_file_size(1002);
-  module.UpdateIfChanged(module_info);
+  EXPECT_FALSE(module.UpdateIfChangedAndUnload(module_info));
   EXPECT_EQ(module.file_size(), module_info.file_size());
 
   module_info.set_load_bias(4010);
-  module.UpdateIfChanged(module_info);
+  EXPECT_FALSE(module.UpdateIfChangedAndUnload(module_info));
   EXPECT_EQ(module.load_bias(), module_info.load_bias());
 
   // add symbols, then change module; symbols are deleted
@@ -229,16 +229,16 @@ TEST(ModuleData, UpdateIfChanged) {
   EXPECT_TRUE(module.is_loaded());
 
   module_info.set_file_size(1003);
-  module.UpdateIfChanged(module_info);
+  EXPECT_TRUE(module.UpdateIfChangedAndUnload(module_info));
   EXPECT_EQ(module.file_size(), module_info.file_size());
 
   // file_path is not allowed to be changed
   module_info.set_file_path("changed/path");
-  EXPECT_DEATH(module.UpdateIfChanged(module_info), "Check failed");
+  EXPECT_DEATH((void)module.UpdateIfChangedAndUnload(module_info), "Check failed");
 
   // as well as build_id
   module_info.set_build_id("yet another build id");
-  EXPECT_DEATH(module.UpdateIfChanged(module_info), "Check failed");
+  EXPECT_DEATH((void)module.UpdateIfChangedAndUnload(module_info), "Check failed");
 }
 
 TEST(ModuleData, UpdateIfChangedWithBuildId) {
@@ -267,7 +267,7 @@ TEST(ModuleData, UpdateIfChangedWithBuildId) {
 
   // We cannot change a module with non-empty build_id
   module_info.set_name("different name");
-  EXPECT_DEATH(module.UpdateIfChanged(module_info), "Check failed");
+  EXPECT_DEATH((void)module.UpdateIfChangedAndUnload(module_info), "Check failed");
 
   // adding symbols should work.
   ModuleSymbols symbols;

--- a/src/OrbitClientData/ModuleDataTest.cpp
+++ b/src/OrbitClientData/ModuleDataTest.cpp
@@ -241,6 +241,61 @@ TEST(ModuleData, UpdateIfChanged) {
   EXPECT_DEATH((void)module.UpdateIfChangedAndUnload(module_info), "Check failed");
 }
 
+TEST(ModuleData, UpdateIfChangedAndNotLoaded) {
+  std::string name = "Example Name";
+  std::string file_path = "/test/file/path";
+  uint64_t file_size = 1000;
+  std::string build_id{};
+  uint64_t load_bias = 4000;
+
+  ModuleInfo module_info{};
+  module_info.set_name(name);
+  module_info.set_file_path(file_path);
+  module_info.set_file_size(file_size);
+  module_info.set_build_id(build_id);
+  module_info.set_load_bias(load_bias);
+
+  ModuleData module{module_info};
+
+  EXPECT_EQ(module.name(), name);
+  EXPECT_EQ(module.file_path(), file_path);
+  EXPECT_EQ(module.file_size(), file_size);
+  EXPECT_EQ(module.build_id(), build_id);
+  EXPECT_EQ(module.load_bias(), load_bias);
+  EXPECT_FALSE(module.is_loaded());
+  EXPECT_TRUE(module.GetFunctions().empty());
+
+  module_info.set_name("different name");
+  EXPECT_TRUE(module.UpdateIfChangedAndNotLoaded(module_info));
+  EXPECT_EQ(module.name(), module_info.name());
+
+  module_info.set_file_size(1002);
+  EXPECT_TRUE(module.UpdateIfChangedAndNotLoaded(module_info));
+  EXPECT_EQ(module.file_size(), module_info.file_size());
+
+  module_info.set_load_bias(4010);
+  EXPECT_TRUE(module.UpdateIfChangedAndNotLoaded(module_info));
+  EXPECT_EQ(module.load_bias(), module_info.load_bias());
+
+  // add symbols, then change module; symbols are deleted
+  ModuleSymbols symbols;
+  module.AddSymbols(symbols);
+  EXPECT_TRUE(module.is_loaded());
+
+  module_info.set_file_size(1003);
+  EXPECT_FALSE(module.UpdateIfChangedAndNotLoaded(module_info));
+  EXPECT_NE(module.file_size(), module_info.file_size());
+  EXPECT_TRUE(module.is_loaded());
+
+  // file_path is not allowed to be changed
+  module_info.set_file_path("changed/path");
+  EXPECT_DEATH((void)module.UpdateIfChangedAndNotLoaded(module_info), "Check failed");
+
+  // as well as build_id
+  module_info.set_build_id("yet another build id");
+  EXPECT_DEATH((void)module.UpdateIfChangedAndNotLoaded(module_info), "Check failed");
+}
+
 TEST(ModuleData, UpdateIfChangedWithBuildId) {
   std::string name = "Example Name";
   std::string file_path = "/test/file/path";
@@ -268,6 +323,7 @@ TEST(ModuleData, UpdateIfChangedWithBuildId) {
   // We cannot change a module with non-empty build_id
   module_info.set_name("different name");
   EXPECT_DEATH((void)module.UpdateIfChangedAndUnload(module_info), "Check failed");
+  EXPECT_DEATH((void)module.UpdateIfChangedAndNotLoaded(module_info), "Check failed");
 
   // adding symbols should work.
   ModuleSymbols symbols;

--- a/src/OrbitClientData/ModuleManager.cpp
+++ b/src/OrbitClientData/ModuleManager.cpp
@@ -35,9 +35,7 @@ std::vector<ModuleData*> ModuleManager::AddOrUpdateModules(
       CHECK(success);
     } else {
       ModuleData& module = module_it->second;
-      bool was_loaded = module.is_loaded();
-      module.UpdateIfChanged(module_info);
-      if (was_loaded && !module.is_loaded()) {
+      if (module.UpdateIfChangedAndUnload(module_info)) {
         unloaded_modules.push_back(&module);
       }
     }

--- a/src/OrbitClientData/include/OrbitClientData/ModuleData.h
+++ b/src/OrbitClientData/include/OrbitClientData/ModuleData.h
@@ -34,6 +34,10 @@ class ModuleData final {
   [[nodiscard]] bool is_loaded() const;
   // Returns true of module was unloaded and false otherwise
   [[nodiscard]] bool UpdateIfChangedAndUnload(orbit_grpc_protos::ModuleInfo info);
+  // This method does not update module_data in case it needs update and was not loaded.
+  // returns true if update was successful or no update was needed and false if module
+  // cannot be updated because it was loaded.
+  [[nodiscard]] bool UpdateIfChangedAndNotLoaded(orbit_grpc_protos::ModuleInfo info);
   // relative_address here is the absolute address minus the address this module was loaded at by
   // the process (module base address)
   [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionByRelativeAddress(
@@ -48,6 +52,8 @@ class ModuleData final {
   [[nodiscard]] std::vector<orbit_client_protos::FunctionInfo> GetOrbitFunctions() const;
 
  private:
+  [[nodiscard]] bool NeedsUpdate(const orbit_grpc_protos::ModuleInfo& info) const;
+
   mutable absl::Mutex mutex_;
   orbit_grpc_protos::ModuleInfo module_info_;
   bool is_loaded_;

--- a/src/OrbitClientData/include/OrbitClientData/ModuleData.h
+++ b/src/OrbitClientData/include/OrbitClientData/ModuleData.h
@@ -32,7 +32,8 @@ class ModuleData final {
   [[nodiscard]] const std::string& build_id() const { return module_info_.build_id(); }
   [[nodiscard]] uint64_t load_bias() const { return module_info_.load_bias(); }
   [[nodiscard]] bool is_loaded() const;
-  void UpdateIfChanged(orbit_grpc_protos::ModuleInfo info);
+  // Returns true of module was unloaded and false otherwise
+  [[nodiscard]] bool UpdateIfChangedAndUnload(orbit_grpc_protos::ModuleInfo info);
   // relative_address here is the absolute address minus the address this module was loaded at by
   // the process (module base address)
   [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionByRelativeAddress(

--- a/src/OrbitClientData/include/OrbitClientData/ModuleManager.h
+++ b/src/OrbitClientData/include/OrbitClientData/ModuleManager.h
@@ -31,6 +31,12 @@ class ModuleManager final {
   // modules that used to be loaded before the call and are not loaded anymore after the call.
   [[nodiscard]] std::vector<ModuleData*> AddOrUpdateModules(
       absl::Span<const orbit_grpc_protos::ModuleInfo> module_infos);
+
+  // Similar to AddOrUpdateModules except it does not update loaded modules.
+  // Retuns the list of modules that it did not update.
+  [[nodiscard]] std::vector<ModuleData*> AddOrUpdateNotLoadedModules(
+      absl::Span<const orbit_grpc_protos::ModuleInfo> module_infos);
+
   [[nodiscard]] std::vector<orbit_client_protos::FunctionInfo> GetOrbitFunctionsOfProcess(
       const ProcessData& process) const;
 

--- a/src/OrbitClientGgp/ClientGgp.cpp
+++ b/src/OrbitClientGgp/ClientGgp.cpp
@@ -370,11 +370,11 @@ void ClientGgp::OnTracepointEvent(orbit_client_protos::TracepointEventInfo trace
 }
 
 void ClientGgp::OnModuleUpdate(uint64_t /*timestamp_ns*/, ModuleInfo module_info) {
-  CHECK(module_manager_.AddOrUpdateModules({module_info}).empty());
+  CHECK(module_manager_.AddOrUpdateNotLoadedModules({module_info}).empty());
   GetMutableCaptureData().mutable_process()->AddOrUpdateModuleInfo(module_info);
 }
 
 void ClientGgp::OnModulesSnapshot(uint64_t /*timestamp_ns*/, std::vector<ModuleInfo> module_infos) {
-  CHECK(module_manager_.AddOrUpdateModules(module_infos).empty());
+  CHECK(module_manager_.AddOrUpdateNotLoadedModules(module_infos).empty());
   GetMutableCaptureData().mutable_process()->UpdateModuleInfos(module_infos);
 }

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -345,13 +345,13 @@ void OrbitApp::OnTracepointEvent(orbit_client_protos::TracepointEventInfo tracep
       is_same_pid_as_target);
 }
 
-void OrbitApp::UpdateModulesAbortIfModuleWithoutBuildIdReloader(
+void OrbitApp::UpdateModulesAbortCaptureIfModuleWithoutBuildIdNeedsReload(
     absl::Span<const ModuleInfo> module_infos) {
-  auto updated_modules = module_manager_->AddOrUpdateModules(module_infos);
+  auto not_updated_modules = module_manager_->AddOrUpdateNotLoadedModules(module_infos);
 
-  if (!updated_modules.empty()) {
+  if (!not_updated_modules.empty()) {
     std::string module_paths;
-    for (const auto* updated_module : updated_modules) {
+    for (const auto* updated_module : not_updated_modules) {
       if (!module_paths.empty()) module_paths += ", ";
       module_paths += updated_module->file_path();
     }
@@ -369,12 +369,12 @@ void OrbitApp::UpdateModulesAbortIfModuleWithoutBuildIdReloader(
 }
 
 void OrbitApp::OnModuleUpdate(uint64_t /*timestamp_ns*/, ModuleInfo module_info) {
-  UpdateModulesAbortIfModuleWithoutBuildIdReloader({module_info});
+  UpdateModulesAbortCaptureIfModuleWithoutBuildIdNeedsReload({module_info});
   GetMutableCaptureData().mutable_process()->AddOrUpdateModuleInfo(module_info);
 }
 
 void OrbitApp::OnModulesSnapshot(uint64_t /*timestamp_ns*/, std::vector<ModuleInfo> module_infos) {
-  UpdateModulesAbortIfModuleWithoutBuildIdReloader(module_infos);
+  UpdateModulesAbortCaptureIfModuleWithoutBuildIdNeedsReload(module_infos);
   GetMutableCaptureData().mutable_process()->UpdateModuleInfos(module_infos);
 }
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -354,13 +354,17 @@ void OrbitApp::UpdateModulesAbortIfModuleWithoutBuildIdReloader(
     for (const auto* updated_module : updated_modules) {
       if (!module_paths.empty()) module_paths += ", ";
       module_paths += updated_module->file_path();
-      FATAL(
-          "Following modules have been updated during the capture: \"%s\", since they do not have "
-          "build_id, this will likely result in undefined behaviour/incorrect data being produced, "
-          "please recompile these modules with build_id support by adding \"-Wl,--build-id\" to "
-          "compile flags.",
-          module_paths);
     }
+
+    std::string error_message = absl::StrFormat(
+        "Following modules have been updated during the capture: \"%s\", since they do not have "
+        "build_id, this will likely result in undefined behaviour/incorrect data being produced, "
+        "please recompile these modules with build_id support by adding \"-Wl,--build-id\" to "
+        "compile flags (or removing \"-Wl,--build-id=none\" from them).",
+        module_paths);
+    SendErrorToUi("Capture Error", error_message);
+    LOG("%s", error_message);
+    main_thread_executor_->Schedule([this] { AbortCapture(); });
   }
 }
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -441,7 +441,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   [[nodiscard]] bool HasFrameTrackInCaptureData(uint64_t instrumented_function_id) const;
 
  private:
-  void UpdateModulesAbortIfModuleWithoutBuildIdReloader(
+  void UpdateModulesAbortCaptureIfModuleWithoutBuildIdNeedsReload(
       absl::Span<const orbit_grpc_protos::ModuleInfo> module_infos);
   void AddSymbols(const std::filesystem::path& module_file_path, const std::string& module_build_id,
                   const orbit_grpc_protos::ModuleSymbols& symbols);


### PR DESCRIPTION
Replace FATAL with error dialog and log message. Do not unload any modules on module updates during capture.

Test: run OrbitClientDataUnitTests