### PR TITLE
Do not draw timer's text when collapsed.

### DIFF
--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -484,7 +484,9 @@ void ThreadTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t
       const Vec2& size = text_box.GetSize();
 
       if (text_box.Duration() > draw_data.ns_per_pixel) {
-        SetTimesliceText(text_box.GetTimerInfo(), draw_data.world_start_x, z_offset, &text_box);
+        if (collapse_toggle_->IsExpanded()) {
+          SetTimesliceText(text_box.GetTimerInfo(), draw_data.world_start_x, z_offset, &text_box);
+        }
         batcher->AddShadedBox(pos, size, draw_data.z, color, std::move(user_data));
       } else {
         batcher->AddVerticalLine(pos, box_height_, draw_data.z, color, std::move(user_data));


### PR DESCRIPTION
With the introduction of the scope tree datastructure,
ThreadTrack::UpdatePrimitives was reimplemented, overriding
the one in TimerTrack. However, before that change, the text
was not renedered on callapsed timers.

Test: Run with --devmode, collapse some tracks.
Bug: http://b/184938662