### PR TITLE
Set pid of FullGpuJob, show it in GpuTrack's tooltips

### DIFF
--- a/src/LinuxTracing/GpuTracepointVisitor.cpp
+++ b/src/LinuxTracing/GpuTracepointVisitor.cpp
@@ -60,6 +60,7 @@ void GpuTracepointVisitor::CreateGpuJobAndSendToListenerIfComplete(const Key& ke
   }
 
   std::string timeline = cs_it->second.timeline;
+  pid_t pid = cs_it->second.pid;
   pid_t tid = cs_it->second.tid;
 
   // We assume that GPU jobs (command buffer submissions) immediately
@@ -91,6 +92,7 @@ void GpuTracepointVisitor::CreateGpuJobAndSendToListenerIfComplete(const Key& ke
   int depth =
       ComputeDepthForGpuJob(timeline, cs_it->second.timestamp_ns, dma_it->second.timestamp_ns);
   FullGpuJob gpu_job;
+  gpu_job.set_pid(pid);
   gpu_job.set_tid(tid);
   gpu_job.set_context(cs_it->second.context);
   gpu_job.set_seqno(cs_it->second.seqno);
@@ -128,8 +130,9 @@ void GpuTracepointVisitor::CreateGpuJobAndSendToListenerIfComplete(const Key& ke
 // created when all three types of GPU events have been received.
 
 void GpuTracepointVisitor::visit(AmdgpuCsIoctlPerfEvent* event) {
-  AmdgpuCsIoctlEvent internal_event{event->GetTid(), event->GetTimestamp(), event->GetContext(),
-                                    event->GetSeqno(), event->ExtractTimelineString()};
+  AmdgpuCsIoctlEvent internal_event{event->GetPid(),       event->GetTid(),
+                                    event->GetTimestamp(), event->GetContext(),
+                                    event->GetSeqno(),     event->ExtractTimelineString()};
   Key key = std::make_tuple(event->GetContext(), event->GetSeqno(), event->ExtractTimelineString());
 
   amdgpu_cs_ioctl_events_.emplace(key, std::move(internal_event));

--- a/src/LinuxTracing/GpuTracepointVisitor.h
+++ b/src/LinuxTracing/GpuTracepointVisitor.h
@@ -40,6 +40,7 @@ class GpuTracepointVisitor : public PerfEventVisitor {
   TracerListener* listener_ = nullptr;
 
   struct AmdgpuCsIoctlEvent {
+    pid_t pid;
     pid_t tid;
     uint64_t timestamp_ns;
     uint32_t context;

--- a/src/LinuxTracing/PerfEvent.h
+++ b/src/LinuxTracing/PerfEvent.h
@@ -472,6 +472,8 @@ class GpuPerfEvent : public TracepointPerfEvent {
     return std::string(&data_loc_data[0]);
   }
 
+  pid_t GetPid() const { return ring_buffer_record.sample_id.pid; }
+
   pid_t GetTid() const { return ring_buffer_record.sample_id.tid; }
 
   virtual uint32_t GetContext() const = 0;

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -301,8 +301,10 @@ std::string GpuTrack::GetSwQueueTooltip(const TimerInfo& timer_info) const {
       "amdgpu_sched_run_job (job scheduled)</i>"
       "<br/>"
       "<br/>"
+      "<b>Submitted from process:</b> %s [%d]<br/>"
       "<b>Submitted from thread:</b> %s [%d]<br/>"
       "<b>Time:</b> %s",
+      capture_data_->GetThreadName(timer_info.process_id()), timer_info.process_id(),
       capture_data_->GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
       GetPrettyTime(TicksToDuration(timer_info.start(), timer_info.end())).c_str());
 }
@@ -314,8 +316,10 @@ std::string GpuTrack::GetHwQueueTooltip(const TimerInfo& timer_info) const {
       "(job scheduled) and start of GPU execution</i>"
       "<br/>"
       "<br/>"
+      "<b>Submitted from process:</b> %s [%d]<br/>"
       "<b>Submitted from thread:</b> %s [%d]<br/>"
       "<b>Time:</b> %s",
+      capture_data_->GetThreadName(timer_info.process_id()), timer_info.process_id(),
       capture_data_->GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
       GetPrettyTime(TicksToDuration(timer_info.start(), timer_info.end())).c_str());
 }
@@ -328,8 +332,10 @@ std::string GpuTrack::GetHwExecutionTooltip(const TimerInfo& timer_info) const {
       "buffer submission</i>"
       "<br/>"
       "<br/>"
+      "<b>Submitted from process:</b> %s [%d]<br/>"
       "<b>Submitted from thread:</b> %s [%d]<br/>"
       "<b>Time:</b> %s",
+      capture_data_->GetThreadName(timer_info.process_id()), timer_info.process_id(),
       capture_data_->GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
       GetPrettyTime(TicksToDuration(timer_info.start(), timer_info.end())).c_str());
 }
@@ -343,8 +349,10 @@ std::string GpuTrack::GetCommandBufferTooltip(
       "submission.</i>"
       "<br/>"
       "<br/>"
+      "<b>Submitted from process:</b> %s [%d]<br/>"
       "<b>Submitted from thread:</b> %s [%d]<br/>"
       "<b>Time:</b> %s",
+      capture_data_->GetThreadName(timer_info.process_id()), timer_info.process_id(),
       app_->GetCaptureData().GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
       GetPrettyTime(TicksToDuration(timer_info.start(), timer_info.end())).c_str());
 }
@@ -360,9 +368,10 @@ std::string GpuTrack::GetDebugMarkerTooltip(
       "<br/>"
       "<br/>"
       "<b>Marker text:</b> %s<br/>"
+      "<b>Submitted from process:</b> %s [%d]<br/>"
       "<b>Submitted from thread:</b> %s [%d]<br/>"
       "<b>Time:</b> %s",
-      marker_text, app_->GetCaptureData().GetThreadName(timer_info.thread_id()),
-      timer_info.thread_id(),
+      marker_text, capture_data_->GetThreadName(timer_info.process_id()), timer_info.process_id(),
+      app_->GetCaptureData().GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
       GetPrettyTime(TicksToDuration(timer_info.start(), timer_info.end())).c_str());
 }


### PR DESCRIPTION
#### Set pid of FullGpuJob
`FullGpuJob` has a pid that `LinuxTracing` didn't set. But
`ProducerEventProcessor` copies that pid into `GpuJob` and
`CaptureEventProcessor` copies that pid into `TimerInfo`.

This was not a problem for the client as the pid is currently not shown.

As the frequency of these events is low and the impact on bandwidth is
negligible (the average number of bytes per event on a 10-second capture stays
around 25.0 in the range of measurement error), just set the pid.

I noticed this while adding tests for `GpuJob`s to
`LinuxTracingIntegrationTests`.

Bug: http://b/184942487

Test: Update unit tests. Capture Trata and see that gpu jobs in the timeline are
as usual.

#### Add "Submitted from process" to GpuTrack's tooltips
Since we now have the information from `GpuJob`s.
This can be relevant when GPU activity is caused by a process different than the
target.

Bug: http://b/185202201

Test: Capture Trata and see that the tooltips show the new information.
Also do the same with the Vulkan layer and verify the tooltips of command
buffers and debug markers.