### PR TITLE
Faster access to memory of tracee.

### DIFF
--- a/src/OrbitBase/File.cpp
+++ b/src/OrbitBase/File.cpp
@@ -15,8 +15,11 @@
 #endif
 
 #if defined(_WIN32)
+
 // Windows never returns EINTR - so there is no need for TEMP_FAILURE_RETRY implementation
 #define TEMP_FAILURE_RETRY(expression) (expression)
+
+namespace {
 
 using ssize_t = int64_t;
 
@@ -52,6 +55,9 @@ ssize_t pwrite(int fd, const void* buffer, size_t size, off_t offset) {
   }
   return bytes_written;
 }
+
+}  // namespace
+
 #endif
 
 namespace orbit_base {

--- a/src/OrbitBase/File.cpp
+++ b/src/OrbitBase/File.cpp
@@ -76,6 +76,24 @@ ErrorMessageOr<void> WriteFully(const unique_fd& fd, std::string_view content) {
   return outcome::success();
 }
 
+ErrorMessageOr<void> WriteFullyAtOffset(const unique_fd& fd, const void* buffer, size_t size,
+                                        off_t offset) {
+  const char* current_position = static_cast<const char*>(buffer);
+
+  while (size > 0) {
+    int64_t bytes_written = TEMP_FAILURE_RETRY(pwrite(fd.get(), current_position, size, offset));
+    if (bytes_written == -1) {
+      return ErrorMessage{SafeStrerror(errno)};
+    }
+    current_position += bytes_written;
+    offset += bytes_written;
+    size -= bytes_written;
+  }
+
+  CHECK(size == 0);
+  return outcome::success();
+}
+
 ErrorMessageOr<size_t> ReadFully(const unique_fd& fd, void* buffer, size_t size) {
   size_t bytes_left = size;
   auto current_position = static_cast<uint8_t*>(buffer);
@@ -92,6 +110,27 @@ ErrorMessageOr<size_t> ReadFully(const unique_fd& fd, void* buffer, size_t size)
   }
 
   return size - bytes_left;
+}
+
+ErrorMessageOr<size_t> ReadFullyAtOffset(const unique_fd& fd, void* buffer, size_t size,
+                                         off_t offset) {
+  uint8_t* current_position = static_cast<uint8_t*>(buffer);
+  size_t bytes_received = 0;
+  while (bytes_received < size) {
+    int64_t pread_result = TEMP_FAILURE_RETRY(pread(fd.get(), current_position, size, offset));
+    if (pread_result == -1) {
+      return ErrorMessage{SafeStrerror(errno)};
+    }
+    if (pread_result == 0) {
+      return bytes_received;
+    }
+    bytes_received += pread_result;
+    current_position += pread_result;
+    size -= pread_result;
+    offset += pread_result;
+  }
+
+  return bytes_received;
 }
 
 }  // namespace orbit_base

--- a/src/OrbitBase/File.cpp
+++ b/src/OrbitBase/File.cpp
@@ -79,7 +79,7 @@ ErrorMessageOr<void> WriteFully(const unique_fd& fd, std::string_view content) {
 ErrorMessageOr<void> WriteFullyAtOffset(const unique_fd& fd, const void* buffer, size_t size,
                                         off_t offset) {
 #if defined(_WIN32)
-  FATAL("Not implemented on Windows.")
+  FATAL("Not implemented on Windows.");
 #elif defined(__linux)
   const char* current_position = static_cast<const char*>(buffer);
 
@@ -120,7 +120,7 @@ ErrorMessageOr<size_t> ReadFully(const unique_fd& fd, void* buffer, size_t size)
 ErrorMessageOr<size_t> ReadFullyAtOffset(const unique_fd& fd, void* buffer, size_t size,
                                          off_t offset) {
 #if defined(_WIN32)
-  FATAL("Not implemented on Windows.")
+  FATAL("Not implemented on Windows.");
 #elif defined(__linux)
   uint8_t* current_position = static_cast<uint8_t*>(buffer);
   size_t bytes_read = 0;

--- a/src/OrbitBase/File.cpp
+++ b/src/OrbitBase/File.cpp
@@ -78,6 +78,9 @@ ErrorMessageOr<void> WriteFully(const unique_fd& fd, std::string_view content) {
 
 ErrorMessageOr<void> WriteFullyAtOffset(const unique_fd& fd, const void* buffer, size_t size,
                                         off_t offset) {
+#if defined(_WIN32)
+  FATAL("Not implemented on Windows.")
+#elif defined(__linux)
   const char* current_position = static_cast<const char*>(buffer);
 
   while (size > 0) {
@@ -92,6 +95,7 @@ ErrorMessageOr<void> WriteFullyAtOffset(const unique_fd& fd, const void* buffer,
 
   CHECK(size == 0);
   return outcome::success();
+#endif
 }
 
 ErrorMessageOr<size_t> ReadFully(const unique_fd& fd, void* buffer, size_t size) {
@@ -114,6 +118,9 @@ ErrorMessageOr<size_t> ReadFully(const unique_fd& fd, void* buffer, size_t size)
 
 ErrorMessageOr<size_t> ReadFullyAtOffset(const unique_fd& fd, void* buffer, size_t size,
                                          off_t offset) {
+#if defined(_WIN32)
+  FATAL("Not implemented on Windows.")
+#elif defined(__linux)
   uint8_t* current_position = static_cast<uint8_t*>(buffer);
   size_t bytes_received = 0;
   while (bytes_received < size) {
@@ -131,6 +138,7 @@ ErrorMessageOr<size_t> ReadFullyAtOffset(const unique_fd& fd, void* buffer, size
   }
 
   return bytes_received;
+#endif
 }
 
 }  // namespace orbit_base

--- a/src/OrbitBase/FileTest.cpp
+++ b/src/OrbitBase/FileTest.cpp
@@ -83,6 +83,65 @@ TEST(File, OpenNewFileForReadWrite) {
   ASSERT_TRUE(fd_or_error.has_value()) << fd_or_error.error().message();
 }
 
+TEST(File, WriteFullySmoke) {
+  auto temporary_file_or_error = TemporaryFile::Create();
+  ASSERT_TRUE(temporary_file_or_error.has_value()) << temporary_file_or_error.error().message();
+  TemporaryFile temporary_file = std::move(temporary_file_or_error.value());
+
+  // Write buffer into file.
+  const std::string buffer = "blub\nbla\n";
+  ErrorMessageOr<void> write_result_or_error = WriteFully(temporary_file.fd(), buffer);
+  ASSERT_FALSE(write_result_or_error.has_error()) << write_result_or_error.error().message();
+
+  // Read back and compare content.
+  ErrorMessageOr<unique_fd> fd_or_error = OpenFileForReading(temporary_file.file_path().string());
+  ASSERT_FALSE(fd_or_error.has_error()) << fd_or_error.error().message();
+  std::array<char, 64> read_back = {};
+  ErrorMessageOr<size_t> result_or_error = ReadFully(fd_or_error.value(), read_back.data(), 9);
+  ASSERT_FALSE(result_or_error.has_error()) << result_or_error.error().message();
+  EXPECT_EQ(result_or_error.value(), 9);
+  EXPECT_STREQ(read_back.data(), buffer.c_str());
+
+  temporary_file.CloseAndRemove();
+}
+
+TEST(File, WriteFullyAtOffsetSmoke) {
+  auto temporary_file_or_error = TemporaryFile::Create();
+  ASSERT_TRUE(temporary_file_or_error.has_value()) << temporary_file_or_error.error().message();
+  TemporaryFile temporary_file = std::move(temporary_file_or_error.value());
+
+  // Write at the beginning of the previously empty file.
+  std::array<char, 64> buffer{'a', 'b', '\n', 'c', 'd', '\n'};
+  ErrorMessageOr<void> write_result_or_error =
+      WriteFullyAtOffset(temporary_file.fd(), buffer.data(), 6, 0);
+  ASSERT_FALSE(write_result_or_error.has_error()) << write_result_or_error.error().message();
+
+  // Read back and compare content.
+  std::array<char, 64> read_back = {};
+  ErrorMessageOr<unique_fd> fd_or_error = OpenFileForReading(temporary_file.file_path().string());
+  ASSERT_FALSE(fd_or_error.has_error()) << fd_or_error.error().message();
+  ErrorMessageOr<size_t> result_or_error = ReadFully(fd_or_error.value(), read_back.data(), 64);
+  ASSERT_FALSE(result_or_error.has_error()) << result_or_error.error().message();
+  EXPECT_EQ(result_or_error.value(), 6);
+  EXPECT_STREQ(read_back.data(), buffer.data());
+
+  // Overrride at a given offset.
+  buffer = {'e', 'f'};
+  write_result_or_error = WriteFullyAtOffset(temporary_file.fd(), buffer.data(), 2, 3);
+  ASSERT_FALSE(write_result_or_error.has_error()) << write_result_or_error.error().message();
+
+  // Read back and compare content.
+  read_back = {};
+  fd_or_error = OpenFileForReading(temporary_file.file_path().string());
+  ASSERT_FALSE(fd_or_error.has_error()) << fd_or_error.error().message();
+  result_or_error = ReadFully(fd_or_error.value(), read_back.data(), 64);
+  ASSERT_FALSE(result_or_error.has_error()) << result_or_error.error().message();
+  EXPECT_EQ(result_or_error.value(), 6);
+  EXPECT_STREQ(read_back.data(), "ab\nef\n");
+
+  temporary_file.CloseAndRemove();
+}
+
 TEST(File, ReadFullySmoke) {
   const auto fd_or_error =
       OpenFileForReading(GetExecutableDir() / "testdata" / "OrbitBase" / "textfile.bin");
@@ -106,6 +165,53 @@ TEST(File, ReadFullySmoke) {
   buf = {};
 
   result = ReadFully(fd, buf.data(), buf.size());
+  ASSERT_FALSE(result.has_error()) << result.error().message();
+  EXPECT_EQ(result.value(), 0);
+  EXPECT_STREQ(buf.data(), "");
+}
+
+TEST(File, ReadFullyAtOffsetSmoke) {
+  const auto fd_or_error =
+      OpenFileForReading(GetExecutableDir() / "testdata" / "OrbitBase" / "textfile.bin");
+  ASSERT_FALSE(fd_or_error.has_error()) << fd_or_error.error().message();
+  const auto& fd = fd_or_error.value();
+  ASSERT_TRUE(fd.valid());
+  std::array<char, 64> buf{};
+
+  // Read at beginning of file.
+  ErrorMessageOr<size_t> result = ReadFullyAtOffset(fd, buf.data(), 5, 0);
+  ASSERT_FALSE(result.has_error()) << result.error().message();
+  EXPECT_EQ(result.value(), 5);
+  EXPECT_STREQ(buf.data(), "conte");
+
+  buf = {};
+
+  // Read entire file (even past the end of the file).
+  result = ReadFullyAtOffset(fd, buf.data(), 64, 0);
+  ASSERT_FALSE(result.has_error()) << result.error().message();
+  EXPECT_EQ(result.value(), 16);
+  EXPECT_STREQ(buf.data(), "content\nnew line");
+
+  buf = {};
+
+  // Read entire rest of the file (even past the end of the file) starting from an offset.
+  result = ReadFullyAtOffset(fd, buf.data(), 64, 5);
+  ASSERT_FALSE(result.has_error()) << result.error().message();
+  EXPECT_EQ(result.value(), 11);
+  EXPECT_STREQ(buf.data(), "nt\nnew line");
+
+  buf = {};
+
+  // Read something in the middle of the file.
+  result = ReadFullyAtOffset(fd, buf.data(), 2, 7);
+  ASSERT_FALSE(result.has_error()) << result.error().message();
+  EXPECT_EQ(result.value(), 2);
+  EXPECT_STREQ(buf.data(), "\nn");
+
+  buf = {};
+
+  // Read something after the end of the file.
+  result = ReadFullyAtOffset(fd, buf.data(), 1, 16);
   ASSERT_FALSE(result.has_error()) << result.error().message();
   EXPECT_EQ(result.value(), 0);
   EXPECT_STREQ(buf.data(), "");

--- a/src/OrbitBase/FileTest.cpp
+++ b/src/OrbitBase/FileTest.cpp
@@ -85,7 +85,7 @@ TEST(File, OpenNewFileForReadWrite) {
 
 TEST(File, WriteFullySmoke) {
   auto temporary_file_or_error = TemporaryFile::Create();
-  ASSERT_TRUE(temporary_file_or_error.has_value()) << temporary_file_or_error.error().message();
+  CHECK(temporary_file_or_error.has_value());
   TemporaryFile temporary_file = std::move(temporary_file_or_error.value());
 
   // Write buffer into file.
@@ -97,17 +97,16 @@ TEST(File, WriteFullySmoke) {
   ErrorMessageOr<unique_fd> fd_or_error = OpenFileForReading(temporary_file.file_path().string());
   ASSERT_FALSE(fd_or_error.has_error()) << fd_or_error.error().message();
   std::array<char, 64> read_back = {};
-  ErrorMessageOr<size_t> result_or_error = ReadFully(fd_or_error.value(), read_back.data(), 9);
+  ErrorMessageOr<size_t> result_or_error =
+      ReadFully(fd_or_error.value(), read_back.data(), buffer.size() + 3);
   ASSERT_FALSE(result_or_error.has_error()) << result_or_error.error().message();
-  EXPECT_EQ(result_or_error.value(), 9);
+  EXPECT_EQ(result_or_error.value(), buffer.size());
   EXPECT_STREQ(read_back.data(), buffer.c_str());
-
-  temporary_file.CloseAndRemove();
 }
 
 TEST(File, WriteFullyAtOffsetSmoke) {
   auto temporary_file_or_error = TemporaryFile::Create();
-  ASSERT_TRUE(temporary_file_or_error.has_value()) << temporary_file_or_error.error().message();
+  CHECK(temporary_file_or_error.has_value());
   TemporaryFile temporary_file = std::move(temporary_file_or_error.value());
 
   // Write at the beginning of the previously empty file.
@@ -138,8 +137,6 @@ TEST(File, WriteFullyAtOffsetSmoke) {
   ASSERT_FALSE(result_or_error.has_error()) << result_or_error.error().message();
   EXPECT_EQ(result_or_error.value(), 6);
   EXPECT_STREQ(read_back.data(), "ab\nef\n");
-
-  temporary_file.CloseAndRemove();
 }
 
 TEST(File, ReadFullySmoke) {
@@ -173,9 +170,9 @@ TEST(File, ReadFullySmoke) {
 TEST(File, ReadFullyAtOffsetSmoke) {
   const auto fd_or_error =
       OpenFileForReading(GetExecutableDir() / "testdata" / "OrbitBase" / "textfile.bin");
-  ASSERT_FALSE(fd_or_error.has_error()) << fd_or_error.error().message();
+  CHECK(!fd_or_error.has_error());
   const auto& fd = fd_or_error.value();
-  ASSERT_TRUE(fd.valid());
+  CHECK(fd.valid());
   std::array<char, 64> buf{};
 
   // Read at beginning of file.

--- a/src/OrbitBase/include/OrbitBase/File.h
+++ b/src/OrbitBase/include/OrbitBase/File.h
@@ -90,6 +90,8 @@ ErrorMessageOr<void> WriteFullyAtOffset(const unique_fd& fd, const void* buffer,
 // used for non-blocking reads from sockets/pipes - it does not handle EAGAIN.
 ErrorMessageOr<size_t> ReadFully(const unique_fd& fd, void* buffer, size_t size);
 
+// Same as above but tries to read from an offset. The file referenced by fd must be capable of
+// seeking. The same limitation for non-blocking reads as above applies here.
 ErrorMessageOr<size_t> ReadFullyAtOffset(const unique_fd& fd, void* buffer, size_t size,
                                          off_t offset);
 

--- a/src/OrbitBase/include/OrbitBase/File.h
+++ b/src/OrbitBase/include/OrbitBase/File.h
@@ -79,6 +79,9 @@ ErrorMessageOr<unique_fd> OpenNewFileForReadWrite(const std::filesystem::path& p
 
 ErrorMessageOr<void> WriteFully(const unique_fd& fd, std::string_view content);
 
+ErrorMessageOr<void> WriteFullyAtOffset(const unique_fd& fd, const void* buffer, size_t size,
+                                        off_t offset);
+
 // Tries to read 'size' bytes from the file to the buffer, returns actual
 // number of bytes read. Note that the return value is less then size in
 // the case when end of file was encountered.
@@ -86,6 +89,9 @@ ErrorMessageOr<void> WriteFully(const unique_fd& fd, std::string_view content);
 // Use this function only for reading from files. This function is not supposed to be
 // used for non-blocking reads from sockets/pipes - it does not handle EAGAIN.
 ErrorMessageOr<size_t> ReadFully(const unique_fd& fd, void* buffer, size_t size);
+
+ErrorMessageOr<size_t> ReadFullyAtOffset(const unique_fd& fd, void* buffer, size_t size,
+                                         off_t offset);
 
 }  // namespace orbit_base
 

--- a/src/UserSpaceInstrumentation/AccessTraceesMemory.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemory.cpp
@@ -35,8 +35,8 @@ using orbit_base::ReadFileToString;
 
   if (result < length) {
     return ErrorMessage(absl::StrFormat(
-        "Failed to read %u bytes from memory file of process pid %d. Only got %d bytes.", length,
-        pid, result));
+        "Failed to read %u bytes from memory file of process %d. Only got %d bytes.", length, pid,
+        result));
   }
 
   return bytes;

--- a/src/UserSpaceInstrumentation/AccessTraceesMemory.h
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemory.h
@@ -14,16 +14,13 @@
 
 namespace orbit_user_space_instrumentation {
 
-// Read `length` bytes from process `pid` starting at `address_start`. `length` will be rounded up
-// to a multiple of eight.
+// Read `length` bytes from process `pid` starting at `address_start`.
 // Assumes we are already attached to the tracee `pid` e.g. using `AttachAndStopProcess`.
 [[nodiscard]] ErrorMessageOr<std::vector<uint8_t>> ReadTraceesMemory(pid_t pid,
                                                                      uint64_t address_start,
                                                                      uint64_t length);
 
 // Write `bytes` into memory of process `pid` starting from `address_start`.
-// Note that we write multiples of eight bytes at once. If length of `bytes` is not a multiple of
-// eight the remaining bytes are zeroed out.
 // Assumes we are already attached to the tracee `pid` e.g. using `AttachAndStopProcess`.
 [[nodiscard]] ErrorMessageOr<void> WriteTraceesMemory(pid_t pid, uint64_t address_start,
                                                       const std::vector<uint8_t>& bytes);

--- a/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <absl/strings/match.h>
+#include <absl/strings/numbers.h>
+#include <absl/strings/str_split.h>
 #include <gtest/gtest.h>
 #include <stdint.h>
 #include <sys/ptrace.h>
@@ -18,13 +21,45 @@
 #include "AccessTraceesMemory.h"
 #include "Attach.h"
 #include "OrbitBase/Logging.h"
+#include "OrbitBase/ReadFileToString.h"
 #include "RegisterState.h"
 
 namespace orbit_user_space_instrumentation {
 
-TEST(AccessTraceesMemoryTest, ReadWriteRestore) {
+namespace {
+
+// Get the adress range of the first consecutive mappings. We can read this range but not more.
+[[nodiscard]] ErrorMessageOr<AddressRange> GetFirstContinuesAdressRange(pid_t pid) {
+  OUTCOME_TRY(maps_or_error, orbit_base::ReadFileToString(absl::StrFormat("/proc/%d/maps", pid)));
+  const std::vector<std::string> lines = absl::StrSplit(maps_or_error, '\n', absl::SkipEmpty());
+  bool is_first = true;
+  AddressRange result;
+  for (const auto& line : lines) {
+    const std::vector<std::string> tokens = absl::StrSplit(line, ' ', absl::SkipEmpty());
+    if (tokens.size() < 2 || tokens[1].size() != 4) continue;
+    const std::vector<std::string> addresses = absl::StrSplit(tokens[0], '-');
+    if (addresses.size() != 2) continue;
+    if (is_first) {
+      if (!absl::numbers_internal::safe_strtou64_base(addresses[0], &result.first, 16)) continue;
+      if (!absl::numbers_internal::safe_strtou64_base(addresses[1], &result.second, 16)) continue;
+      is_first = false;
+    } else {
+      AddressRange current;
+      if (!absl::numbers_internal::safe_strtou64_base(addresses[0], &current.first, 16)) continue;
+      if (!absl::numbers_internal::safe_strtou64_base(addresses[1], &current.second, 16)) continue;
+      if (current.first == result.second) {
+        result.second = current.second;
+      }
+    }
+  }
+  return result;
+}
+
+}  // namespace
+
+TEST(AccessTraceesMemoryTest, ReadFailures) {
   pid_t pid = fork();
-  CHECK(pid != -1);
+  ASSERT_TRUE(pid != -1);
   if (pid == 0) {
     // Child just runs an endless loop.
     while (true) {
@@ -32,15 +67,119 @@ TEST(AccessTraceesMemoryTest, ReadWriteRestore) {
   }
 
   // Stop the child process using our tooling.
-  CHECK(AttachAndStopProcess(pid).has_value());
+  ASSERT_TRUE(AttachAndStopProcess(pid).has_value());
 
-  auto result_memory_region = GetFirstExecutableMemoryRegion(pid);
-  CHECK(result_memory_region.has_value());
-  const uint64_t address_start = result_memory_region.value().first;
+  auto continues_range_or_error = GetFirstContinuesAdressRange(pid);
+  ASSERT_TRUE(continues_range_or_error.has_value());
+  const auto continues_range = continues_range_or_error.value();
+  const uint64_t address = continues_range.first;
+  const uint64_t length = continues_range.second - continues_range.first;
+
+  // Good read.
+  auto result = ReadTraceesMemory(pid, address, length);
+  EXPECT_TRUE(result.has_value());
+
+  // Process does not exist.
+  result = ReadTraceesMemory(-1, address, length);
+  ASSERT_TRUE(result.has_error());
+  EXPECT_TRUE(absl::StrContains(result.error().message(), "Unable to open file"));
+
+  // Read 0 bytes.
+  result = ReadTraceesMemory(pid, address, 0);
+  ASSERT_TRUE(result.has_error());
+  EXPECT_TRUE(absl::StrContains(result.error().message(), "Tried to read 0 bytes."));
+
+  // Read past the end of the mappings.
+  result = ReadTraceesMemory(pid, address, length + 1);
+  ASSERT_TRUE(result.has_error());
+  EXPECT_TRUE(absl::StrContains(result.error().message(), "Only got"));
+
+  // Read from bad address.
+  result = ReadTraceesMemory(pid, 0, length);
+  ASSERT_TRUE(result.has_error());
+  EXPECT_TRUE(
+      absl::StrContains(result.error().message(), "Failed to read from memory file of process"));
+
+  // Detach and end child.
+  ASSERT_TRUE(!DetachAndContinueProcess(pid).has_error());
+  kill(pid, SIGKILL);
+  waitpid(pid, NULL, 0);
+}
+
+TEST(AccessTraceesMemoryTest, WriteFailures) {
+  pid_t pid = fork();
+  ASSERT_TRUE(pid != -1);
+  if (pid == 0) {
+    // Child just runs an endless loop.
+    while (true) {
+    }
+  }
+
+  // Stop the child process using our tooling.
+  ASSERT_TRUE(AttachAndStopProcess(pid).has_value());
+
+  auto continues_range_or_error = GetFirstContinuesAdressRange(pid);
+  ASSERT_TRUE(continues_range_or_error.has_value());
+  const auto continues_range = continues_range_or_error.value();
+  const uint64_t address = continues_range.first;
+  const uint64_t length = continues_range.second - continues_range.first;
+
+  // Backup.
+  auto backup = ReadTraceesMemory(pid, address, length);
+  ASSERT_TRUE(backup.has_value());
+
+  // Good write.
+  std::vector<uint8_t> bytes(length, 0);
+  auto result = WriteTraceesMemory(pid, address, bytes);
+  EXPECT_FALSE(result.has_error());
+
+  // Process does not exist.
+  result = WriteTraceesMemory(-1, address, bytes);
+  ASSERT_TRUE(result.has_error());
+  EXPECT_TRUE(absl::StrContains(result.error().message(), "Unable to open file"));
+
+  // Write 0 bytes.
+  result = WriteTraceesMemory(pid, address, std::vector<uint8_t>());
+  ASSERT_TRUE(result.has_error());
+  EXPECT_TRUE(absl::StrContains(result.error().message(), "Tried to write 0 bytes."));
+
+  // Read past the end of the mappings.
+  bytes.push_back(0);
+  result = WriteTraceesMemory(pid, address, bytes);
+  ASSERT_TRUE(result.has_error());
+  EXPECT_TRUE(absl::StrContains(result.error().message(), "Only wrote"));
+
+  // Read from bad address.
+  result = WriteTraceesMemory(pid, 0, bytes);
+  ASSERT_TRUE(result.has_error());
+  EXPECT_TRUE(absl::StrContains(result.error().message(), "Failed to write to memory file"));
+
+  // Restore, detach and end child.
+  EXPECT_FALSE(WriteTraceesMemory(pid, address, backup.value()).has_error());
+  ASSERT_TRUE(!DetachAndContinueProcess(pid).has_error());
+  kill(pid, SIGKILL);
+  waitpid(pid, NULL, 0);
+}
+
+TEST(AccessTraceesMemoryTest, ReadWriteRestore) {
+  pid_t pid = fork();
+  ASSERT_TRUE(pid != -1);
+  if (pid == 0) {
+    // Child just runs an endless loop.
+    while (true) {
+    }
+  }
+
+  // Stop the child process using our tooling.
+  ASSERT_TRUE(AttachAndStopProcess(pid).has_value());
+
+  auto memory_region_or_error = GetFirstExecutableMemoryRegion(pid);
+  ASSERT_TRUE(memory_region_or_error.has_value());
+  const uint64_t address = memory_region_or_error.value().first;
 
   constexpr uint64_t kMemorySize = 4 * 1024;
-  auto result_backup = ReadTraceesMemory(pid, address_start, kMemorySize);
-  CHECK(result_backup.has_value());
+  auto backup = ReadTraceesMemory(pid, address, kMemorySize);
+  ASSERT_TRUE(backup.has_value());
 
   std::vector<uint8_t> new_data(kMemorySize);
   std::mt19937 engine{std::random_device()()};
@@ -48,17 +187,15 @@ TEST(AccessTraceesMemoryTest, ReadWriteRestore) {
   std::generate(std::begin(new_data), std::end(new_data),
                 [&distribution, &engine]() { return distribution(engine); });
 
-  CHECK(!WriteTraceesMemory(pid, address_start, new_data).has_error());
+  ASSERT_FALSE(WriteTraceesMemory(pid, address, new_data).has_error());
 
-  auto result_read_back = ReadTraceesMemory(pid, address_start, kMemorySize);
-  CHECK(result_read_back.has_value());
+  auto read_back_or_error = ReadTraceesMemory(pid, address, kMemorySize);
+  ASSERT_TRUE(read_back_or_error.has_value());
+  EXPECT_EQ(new_data, read_back_or_error.value());
 
-  EXPECT_EQ(new_data, result_read_back.value());
-
-  CHECK(WriteTraceesMemory(pid, address_start, result_backup.value()).has_value());
-
-  // Detach and end child.
-  CHECK(!DetachAndContinueProcess(pid).has_error());
+  // Restore, detach and end child.
+  ASSERT_TRUE(WriteTraceesMemory(pid, address, backup.value()).has_value());
+  ASSERT_FALSE(DetachAndContinueProcess(pid).has_error());
   kill(pid, SIGKILL);
   waitpid(pid, NULL, 0);
 }

--- a/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
@@ -111,7 +111,7 @@ TEST(AccessTraceesMemoryTest, ReadFailures) {
       absl::StrContains(result.error().message(), "Failed to read from memory file of process"));
 
   // Detach and end child.
-  ASSERT_TRUE(!DetachAndContinueProcess(pid).has_error());
+  ASSERT_FALSE(DetachAndContinueProcess(pid).has_error());
   kill(pid, SIGKILL);
   waitpid(pid, NULL, 0);
 }
@@ -165,8 +165,8 @@ TEST(AccessTraceesMemoryTest, WriteFailures) {
   EXPECT_TRUE(absl::StrContains(result.error().message(), "Failed to write to memory file"));
 
   // Restore, detach and end child.
-  EXPECT_FALSE(WriteTraceesMemory(pid, address, backup.value()).has_error());
-  ASSERT_TRUE(!DetachAndContinueProcess(pid).has_error());
+  ASSERT_FALSE(WriteTraceesMemory(pid, address, backup.value()).has_error());
+  ASSERT_FALSE(DetachAndContinueProcess(pid).has_error());
   kill(pid, SIGKILL);
   waitpid(pid, NULL, 0);
 }


### PR DESCRIPTION
Previously we used the PTRACE_PEEKDATA / PTRACE_POKEDATA interface to
access the tracees's memory. This is slow since we can only access eight
byte at a time and an access requires two context switches. Also the
access can only happen in multiples of eight bytes which complicates
things.

The filesystem based interface in /proc/pid/mem is both faster and more
convenient.

Bug: http://b/183115358
Test: Existing unit tests.