### PR TITLE
Add the MemoryTrack class for memory tracks

### DIFF
--- a/src/OrbitGl/AsyncTrack.h
+++ b/src/OrbitGl/AsyncTrack.h
@@ -27,7 +27,7 @@ class AsyncTrack final : public TimerTrack {
   explicit AsyncTrack(CaptureViewElement* parent, TimeGraph* time_graph, TimeGraphLayout* layout,
                       const std::string& name, OrbitApp* app, const CaptureData* capture_data);
 
-  [[nodiscard]] Type GetType() const override { return kAsyncTrack; };
+  [[nodiscard]] Type GetType() const override { return Type::kAsyncTrack; };
   [[nodiscard]] std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const override;
   [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllSerializableChains() const override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -46,6 +46,7 @@ target_sources(
          LiveFunctionsController.h
          LiveFunctionsDataView.h
          ManualInstrumentationManager.h
+         MemoryTrack.h
          ModulesDataView.h
          OpenGl.h
          PickingManager.h
@@ -107,6 +108,7 @@ target_sources(
           IntrospectionWindow.cpp
           LiveFunctionsDataView.cpp
           ManualInstrumentationManager.cpp
+          MemoryTrack.cpp
           ModulesDataView.cpp
           PickingManager.cpp
           PresetsDataView.cpp

--- a/src/OrbitGl/FrameTrack.h
+++ b/src/OrbitGl/FrameTrack.h
@@ -27,7 +27,7 @@ class FrameTrack : public TimerTrack {
   explicit FrameTrack(CaptureViewElement* parent, TimeGraph* time_graph, TimeGraphLayout* layout,
                       orbit_grpc_protos::InstrumentedFunction function, OrbitApp* app,
                       const CaptureData* capture_data);
-  [[nodiscard]] Type GetType() const override { return kFrameTrack; }
+  [[nodiscard]] Type GetType() const override { return Type::kFrameTrack; }
   [[nodiscard]] uint64_t GetFunctionId() const { return function_.function_id(); }
   [[nodiscard]] bool IsCollapsible() const override { return GetMaximumScaleFactor() > 0.f; }
 

--- a/src/OrbitGl/GpuTrack.h
+++ b/src/OrbitGl/GpuTrack.h
@@ -37,7 +37,7 @@ class GpuTrack : public TimerTrack {
                     uint64_t timeline_hash, OrbitApp* app, const CaptureData* capture_data);
   ~GpuTrack() override = default;
   [[nodiscard]] std::string GetTooltip() const override;
-  [[nodiscard]] Type GetType() const override { return kGpuTrack; }
+  [[nodiscard]] Type GetType() const override { return Type::kGpuTrack; }
   [[nodiscard]] float GetHeight() const override;
 
   [[nodiscard]] const TextBox* GetLeft(const TextBox* text_box) const override;

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -92,61 +92,7 @@ void GraphTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset
 
   const Color kBlack(0, 0, 0, 255);
   const Color kWhite(255, 255, 255, 255);
-  float text_z = GlCanvas::kZValueTrackText + z_offset;
   float label_z = GlCanvas::kZValueTrackLabel + z_offset;
-
-  // Add warning threshold text box and line.
-  Batcher* ui_batcher = canvas->GetBatcher();
-  uint32_t font_size = layout_->CalculateZoomedFontSize();
-  if (warning_threshold_.has_value()) {
-    const Color kThresholdColor(244, 67, 54, 255);
-
-    double normalized_value = (warning_threshold_.value().second - min_) * inv_value_range_;
-    float x = pos_[0];
-    float y = pos_[1] - size_[1] + static_cast<float>(normalized_value) * size_[1];
-    Vec2 from(x, y);
-    Vec2 to(x + size_[0], y);
-
-    std::string text = warning_threshold_.value().first;
-    float string_width = canvas->GetTextRenderer().GetStringWidth(text.c_str(), font_size);
-    Vec2 text_box_size(string_width, layout_->GetTextBoxHeight());
-    Vec2 text_box_position(pos_[0] + layout_->GetRightMargin(),
-                           y - layout_->GetTextBoxHeight() / 2.f);
-    canvas->GetTextRenderer().AddText(text.c_str(), text_box_position[0],
-                                      text_box_position[1] + layout_->GetTextOffset(), text_z,
-                                      kThresholdColor, font_size, text_box_size[0]);
-
-    ui_batcher->AddLine(from, from + Vec2(layout_->GetRightMargin() / 2.f, 0), text_z,
-                        kThresholdColor);
-    ui_batcher->AddLine(Vec2(text_box_position[0] + text_box_size[0], y), to, text_z,
-                        kThresholdColor);
-  }
-
-  // Add value upper bound text box (e.g., the "Memory Total" text box for the memory tracks).
-  if (value_upper_bound_.has_value()) {
-    std::string text = value_upper_bound_.value().first;
-    float string_width = canvas->GetTextRenderer().GetStringWidth(text.c_str(), font_size);
-    Vec2 text_box_size(string_width, layout_->GetTextBoxHeight());
-    Vec2 text_box_position(pos_[0] + size_[0] - text_box_size[0] - layout_->GetRightMargin() -
-                               layout_->GetSliderWidth(),
-                           pos_[1] - layout_->GetTextBoxHeight() / 2.f);
-    canvas->GetTextRenderer().AddText(text.c_str(), text_box_position[0],
-                                      text_box_position[1] + layout_->GetTextOffset(), text_z,
-                                      kWhite, font_size, text_box_size[0]);
-  }
-
-  // Add value lower bound text box.
-  if (value_lower_bound_.has_value()) {
-    std::string text = value_lower_bound_.value().first;
-    float string_width = canvas->GetTextRenderer().GetStringWidth(text.c_str(), font_size);
-    Vec2 text_box_size(string_width, layout_->GetTextBoxHeight());
-    Vec2 text_box_position(pos_[0] + size_[0] - text_box_size[0] - layout_->GetRightMargin() -
-                               layout_->GetSliderWidth(),
-                           pos_[1] - size_[1]);
-    canvas->GetTextRenderer().AddText(text.c_str(), text_box_position[0],
-                                      text_box_position[1] + layout_->GetTextOffset(), text_z,
-                                      kWhite, font_size, text_box_size[0]);
-  }
 
   // Draw label
   uint64_t current_mouse_time_ns = time_graph_->GetCurrentMouseTimeNs();
@@ -232,23 +178,6 @@ float GraphTrack::GetHeight() const {
   return height;
 }
 
-void GraphTrack::SetWarningThresholdWhenEmpty(const std::string& pretty_label, double raw_value) {
-  if (warning_threshold_.has_value()) return;
-  warning_threshold_ = std::make_pair(pretty_label, raw_value);
-  UpdateMinAndMax(raw_value);
-}
-
-void GraphTrack::SetValueUpperBoundWhenEmpty(const std::string& pretty_label, double raw_value) {
-  if (value_upper_bound_.has_value()) return;
-  value_upper_bound_ = std::make_pair(pretty_label, raw_value);
-  UpdateMinAndMax(raw_value);
-}
-void GraphTrack::SetValueLowerBoundWhenEmpty(const std::string& pretty_label, double raw_value) {
-  if (value_lower_bound_.has_value()) return;
-  value_lower_bound_ = std::make_pair(pretty_label, raw_value);
-  UpdateMinAndMax(raw_value);
-}
-
 void GraphTrack::SetLabelUnitWhenEmpty(const std::string& label_unit) {
   if (!label_unit_.empty()) return;
   label_unit_ = label_unit;
@@ -257,11 +186,6 @@ void GraphTrack::SetLabelUnitWhenEmpty(const std::string& label_unit) {
 void GraphTrack::SetValueDecimalDigitsWhenEmpty(uint8_t value_decimal_digits) {
   if (value_decimal_digits_.has_value()) return;
   value_decimal_digits_ = value_decimal_digits;
-}
-
-void GraphTrack::UpdateMinAndMax(double value) {
-  max_ = std::max(max_, value);
-  min_ = std::min(min_, value);
 }
 
 void GraphTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -35,9 +35,6 @@ class GraphTrack : public Track {
       uint64_t time) const;
   [[nodiscard]] bool IsEmpty() const override { return values_.empty(); }
 
-  void SetWarningThresholdWhenEmpty(const std::string& pretty_label, double raw_value);
-  void SetValueUpperBoundWhenEmpty(const std::string& pretty_label, double raw_value);
-  void SetValueLowerBoundWhenEmpty(const std::string& pretty_label, double raw_value);
   void SetLabelUnitWhenEmpty(const std::string& label_unit);
   void SetValueDecimalDigitsWhenEmpty(uint8_t value_decimal_digits);
 
@@ -51,16 +48,12 @@ class GraphTrack : public Track {
   void DrawSquareDot(Batcher* batcher, Vec2 center, float radius, float z, const Color& color);
   void DrawLabel(GlCanvas* canvas, Vec2 target_pos, const std::string& text,
                  const Color& text_color, const Color& font_color, float z);
-  void UpdateMinAndMax(double value);
 
   std::map<uint64_t, double> values_;
   double min_ = std::numeric_limits<double>::max();
   double max_ = std::numeric_limits<double>::lowest();
   double value_range_ = 0;
   double inv_value_range_ = 0;
-  std::optional<std::pair<std::string, double>> warning_threshold_ = std::nullopt;
-  std::optional<std::pair<std::string, double>> value_upper_bound_ = std::nullopt;
-  std::optional<std::pair<std::string, double>> value_lower_bound_ = std::nullopt;
   std::optional<uint8_t> value_decimal_digits_ = std::nullopt;
   std::string label_unit_;
 };

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -25,7 +25,7 @@ class GraphTrack : public Track {
  public:
   explicit GraphTrack(CaptureViewElement* parent, TimeGraph* time_graph, TimeGraphLayout* layout,
                       std::string name, const CaptureData* capture_data);
-  [[nodiscard]] Type GetType() const override { return kGraphTrack; }
+  [[nodiscard]] Type GetType() const override { return Type::kGraphTrack; }
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;

--- a/src/OrbitGl/MemoryTrack.cpp
+++ b/src/OrbitGl/MemoryTrack.cpp
@@ -1,0 +1,96 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "MemoryTrack.h"
+
+#include <algorithm>
+
+#include "GlCanvas.h"
+
+namespace orbit_gl {
+
+void MemoryTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
+  GraphTrack::Draw(canvas, picking_mode, z_offset);
+
+  if (values_.empty() || picking_mode != PickingMode::kNone) return;
+
+  float text_z = GlCanvas::kZValueTrackText + z_offset;
+  Batcher* ui_batcher = canvas->GetBatcher();
+  uint32_t font_size = layout_->CalculateZoomedFontSize();
+
+  // Add warning threshold text box and line.
+  if (warning_threshold_.has_value()) {
+    const Color kThresholdColor(244, 67, 54, 255);
+    double normalized_value = (warning_threshold_.value().second - min_) * inv_value_range_;
+    float x = pos_[0];
+    float y = pos_[1] - size_[1] + static_cast<float>(normalized_value) * size_[1];
+    Vec2 from(x, y);
+    Vec2 to(x + size_[0], y);
+
+    std::string text = warning_threshold_.value().first;
+    float string_width = canvas->GetTextRenderer().GetStringWidth(text.c_str(), font_size);
+    Vec2 text_box_size(string_width, layout_->GetTextBoxHeight());
+    Vec2 text_box_position(pos_[0] + layout_->GetRightMargin(),
+                           y - layout_->GetTextBoxHeight() / 2.f);
+    canvas->GetTextRenderer().AddText(text.c_str(), text_box_position[0],
+                                      text_box_position[1] + layout_->GetTextOffset(), text_z,
+                                      kThresholdColor, font_size, text_box_size[0]);
+
+    ui_batcher->AddLine(from, from + Vec2(layout_->GetRightMargin() / 2.f, 0), text_z,
+                        kThresholdColor);
+    ui_batcher->AddLine(Vec2(text_box_position[0] + text_box_size[0], y), to, text_z,
+                        kThresholdColor);
+  }
+
+  // Add value upper bound text box (e.g., the "System Memory Total" text box for memory tracks).
+  const Color kWhite(255, 255, 255, 255);
+  if (value_upper_bound_.has_value()) {
+    std::string text = value_upper_bound_.value().first;
+    float string_width = canvas->GetTextRenderer().GetStringWidth(text.c_str(), font_size);
+    Vec2 text_box_size(string_width, layout_->GetTextBoxHeight());
+    Vec2 text_box_position(pos_[0] + size_[0] - text_box_size[0] - layout_->GetRightMargin() -
+                               layout_->GetSliderWidth(),
+                           pos_[1] - layout_->GetTextBoxHeight() / 2.f);
+    canvas->GetTextRenderer().AddText(text.c_str(), text_box_position[0],
+                                      text_box_position[1] + layout_->GetTextOffset(), text_z,
+                                      kWhite, font_size, text_box_size[0]);
+  }
+
+  // Add value lower bound text box.
+  if (value_lower_bound_.has_value()) {
+    std::string text = value_lower_bound_.value().first;
+    float string_width = canvas->GetTextRenderer().GetStringWidth(text.c_str(), font_size);
+    Vec2 text_box_size(string_width, layout_->GetTextBoxHeight());
+    Vec2 text_box_position(pos_[0] + size_[0] - text_box_size[0] - layout_->GetRightMargin() -
+                               layout_->GetSliderWidth(),
+                           pos_[1] - size_[1]);
+    canvas->GetTextRenderer().AddText(text.c_str(), text_box_position[0],
+                                      text_box_position[1] + layout_->GetTextOffset(), text_z,
+                                      kWhite, font_size, text_box_size[0]);
+  }
+}
+
+void MemoryTrack::SetWarningThresholdWhenEmpty(const std::string& pretty_label, double raw_value) {
+  if (warning_threshold_.has_value()) return;
+  warning_threshold_ = std::make_pair(pretty_label, raw_value);
+  UpdateMinAndMax(raw_value);
+}
+
+void MemoryTrack::SetValueUpperBoundWhenEmpty(const std::string& pretty_label, double raw_value) {
+  if (value_upper_bound_.has_value()) return;
+  value_upper_bound_ = std::make_pair(pretty_label, raw_value);
+  UpdateMinAndMax(raw_value);
+}
+void MemoryTrack::SetValueLowerBoundWhenEmpty(const std::string& pretty_label, double raw_value) {
+  if (value_lower_bound_.has_value()) return;
+  value_lower_bound_ = std::make_pair(pretty_label, raw_value);
+  UpdateMinAndMax(raw_value);
+}
+
+void MemoryTrack::UpdateMinAndMax(double value) {
+  max_ = std::max(max_, value);
+  min_ = std::min(min_, value);
+}
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/MemoryTrack.h
+++ b/src/OrbitGl/MemoryTrack.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_MEMORY_TRACK_H_
+#define ORBIT_GL_MEMORY_TRACK_H_
+
+#include <string>
+
+#include "GraphTrack.h"
+#include "Track.h"
+
+namespace orbit_gl {
+
+class MemoryTrack final : public GraphTrack {
+ public:
+  explicit MemoryTrack(CaptureViewElement* parent, TimeGraph* time_graph, TimeGraphLayout* layout,
+                       std::string name, const CaptureData* capture_data)
+      : GraphTrack(parent, time_graph, layout, name, capture_data) {}
+  ~MemoryTrack() override = default;
+  [[nodiscard]] Type GetType() const override { return kMemoryTrack; }
+
+  void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
+
+  void SetWarningThresholdWhenEmpty(const std::string& pretty_label, double raw_value);
+  void SetValueUpperBoundWhenEmpty(const std::string& pretty_label, double raw_value);
+  void SetValueLowerBoundWhenEmpty(const std::string& pretty_label, double raw_value);
+
+ private:
+  void UpdateMinAndMax(double value);
+
+  std::optional<std::pair<std::string, double>> warning_threshold_ = std::nullopt;
+  std::optional<std::pair<std::string, double>> value_upper_bound_ = std::nullopt;
+  std::optional<std::pair<std::string, double>> value_lower_bound_ = std::nullopt;
+};
+
+}  // namespace orbit_gl
+
+#endif  // ORBIT_GL_MEMORY_TRACK_H_

--- a/src/OrbitGl/MemoryTrack.h
+++ b/src/OrbitGl/MemoryTrack.h
@@ -18,7 +18,7 @@ class MemoryTrack final : public GraphTrack {
                        std::string name, const CaptureData* capture_data)
       : GraphTrack(parent, time_graph, layout, name, capture_data) {}
   ~MemoryTrack() override = default;
-  [[nodiscard]] Type GetType() const override { return kMemoryTrack; }
+  [[nodiscard]] Type GetType() const override { return Type::kMemoryTrack; }
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
 

--- a/src/OrbitGl/SchedulerTrack.h
+++ b/src/OrbitGl/SchedulerTrack.h
@@ -23,7 +23,7 @@ class SchedulerTrack final : public TimerTrack {
   ~SchedulerTrack() override = default;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
 
-  [[nodiscard]] Type GetType() const override { return kSchedulerTrack; }
+  [[nodiscard]] Type GetType() const override { return Type::kSchedulerTrack; }
   [[nodiscard]] std::string GetTooltip() const override;
 
   [[nodiscard]] float GetHeight() const override;

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -32,7 +32,7 @@ class ThreadTrack final : public TimerTrack {
 
   [[nodiscard]] int32_t GetThreadId() const { return thread_id_; }
 
-  [[nodiscard]] Type GetType() const override { return kThreadTrack; }
+  [[nodiscard]] Type GetType() const override { return Type::kThreadTrack; }
   [[nodiscard]] std::string GetTooltip() const override;
 
   [[nodiscard]] const TextBox* GetLeft(const TextBox* textbox) const override;

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -63,7 +63,7 @@ class TimerTrack : public Track {
   // Track
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode /*picking_mode*/, float z_offset = 0) override;
-  [[nodiscard]] Type GetType() const override { return kTimerTrack; }
+  [[nodiscard]] Type GetType() const override { return Type::kTimerTrack; }
 
   [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetTimers() const override;
   [[nodiscard]] uint32_t GetDepth() const { return depth_; }

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -37,6 +37,7 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
     kGpuTrack,
     kSchedulerTrack,
     kAsyncTrack,
+    kMemoryTrack,
     kUnknown,
   };
 

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -29,7 +29,7 @@
 
 class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_from_this<Track> {
  public:
-  enum Type {
+  enum class Type {
     kTimerTrack,
     kThreadTrack,
     kFrameTrack,
@@ -118,7 +118,7 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   std::atomic<uint32_t> num_timers_;
   std::atomic<uint64_t> min_time_;
   std::atomic<uint64_t> max_time_;
-  Type type_ = kUnknown;
+  Type type_ = Type::kUnknown;
   std::shared_ptr<TriangleToggle> collapse_toggle_;
 
   TimeGraphLayout* layout_;

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -323,9 +323,9 @@ void TrackManager::AddFrameTrack(const std::shared_ptr<FrameTrack>& frame_track)
   // (and also after the Scheduler one).
   auto last_frame_or_scheduler_track_pos =
       find_if(sorted_tracks_.rbegin(), sorted_tracks_.rend(), [frame_track](Track* track) {
-        return (track->GetType() == Track::kFrameTrack &&
+        return (track->GetType() == Track::Type::kFrameTrack &&
                 frame_track->GetFunctionId() > static_cast<FrameTrack*>(track)->GetFunctionId()) ||
-               track->GetType() == Track::kSchedulerTrack;
+               track->GetType() == Track::Type::kSchedulerTrack;
       });
   if (last_frame_or_scheduler_track_pos != sorted_tracks_.rend()) {
     sorted_tracks_.insert(last_frame_or_scheduler_track_pos.base(), frame_track.get());

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -31,6 +31,7 @@
 #include "TimeGraphLayout.h"
 
 using orbit_client_protos::FunctionInfo;
+using orbit_gl::MemoryTrack;
 
 TrackManager::TrackManager(TimeGraph* time_graph, TimeGraphLayout* layout, OrbitApp* app,
                            const CaptureData* capture_data)
@@ -89,6 +90,11 @@ void TrackManager::SortTracks() {
     // Graph tracks.
     for (const auto& graph_track : graph_tracks_) {
       all_processes_sorted_tracks.push_back(graph_track.second.get());
+    }
+
+    // Memory tracks.
+    for (const auto& memory_track : memory_tracks_) {
+      all_processes_sorted_tracks.push_back(memory_track.second.get());
     }
 
     // Async tracks.
@@ -383,6 +389,17 @@ GraphTrack* TrackManager::GetOrCreateGraphTrack(const std::string& name) {
     track = std::make_shared<GraphTrack>(time_graph_, time_graph_, layout_, name, capture_data_);
     AddTrack(track);
     graph_tracks_[name] = track;
+  }
+  return track.get();
+}
+
+MemoryTrack* TrackManager::GetOrCreateMemoryTrack(const std::string& name) {
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  std::shared_ptr<MemoryTrack> track = memory_tracks_[name];
+  if (track == nullptr) {
+    track = std::make_shared<MemoryTrack>(time_graph_, time_graph_, layout_, name, capture_data_);
+    AddTrack(track);
+    memory_tracks_[name] = track;
   }
   return track.get();
 }

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -19,6 +19,7 @@
 #include "FrameTrack.h"
 #include "GpuTrack.h"
 #include "GraphTrack.h"
+#include "MemoryTrack.h"
 #include "PickingManager.h"
 #include "SchedulerTrack.h"
 #include "StringManager.h"
@@ -61,6 +62,7 @@ class TrackManager {
   ThreadTrack* GetOrCreateThreadTrack(int32_t tid);
   GpuTrack* GetOrCreateGpuTrack(uint64_t timeline_hash);
   GraphTrack* GetOrCreateGraphTrack(const std::string& name);
+  orbit_gl::MemoryTrack* GetOrCreateMemoryTrack(const std::string& name);
   AsyncTrack* GetOrCreateAsyncTrack(const std::string& name);
   FrameTrack* GetOrCreateFrameTrack(const orbit_grpc_protos::InstrumentedFunction& function);
 
@@ -84,6 +86,7 @@ class TrackManager {
   absl::flat_hash_map<int32_t, std::shared_ptr<ThreadTrack>> thread_tracks_;
   std::map<std::string, std::shared_ptr<AsyncTrack>> async_tracks_;
   std::map<std::string, std::shared_ptr<GraphTrack>> graph_tracks_;
+  std::map<std::string, std::shared_ptr<orbit_gl::MemoryTrack>> memory_tracks_;
   // Mapping from timeline to GPU tracks. Timeline name is used for stable ordering. In particular
   // we want the marker tracks next to their queue track. E.g. "gfx" and "gfx_markers" should appear
   // next to each other.


### PR DESCRIPTION
With this change, we add the `MemoryTrack` class such that the memory tracks can be treated separately from the general `GraphTrack`.

More specifically, the setting and drawing of `warning_threshold_`, `value_upper_bound_` and `value_lower_bound_` are moved to the `MemoryTrack`, while the setting of `label_unit_` and `value_decimal_digits_` (i.e., label value digits) still remain in the `GraphTrack`.

Bug: http://b/185204557
Test: take a capture with memory tracks

Follow up tasks can be found in [Memory feature task list](https://docs.google.com/spreadsheets/d/1PdYLwV4tvEDghWQP1jJDdOIUXaDAbczbh6p-VVebINw/edit#gid=894146394).