### PR TITLE
Don't discard data symbols when parsing elf file

### DIFF
--- a/src/GrpcProtos/symbol.proto
+++ b/src/GrpcProtos/symbol.proto
@@ -10,6 +10,7 @@ message ModuleSymbols {
   uint64 load_bias = 1;
   string symbols_file_path = 2;
   repeated SymbolInfo symbol_infos = 3;
+  repeated SymbolInfo data_symbol_infos = 4;
 }
 
 message SymbolInfo {

--- a/src/OrbitClientData/ModuleManager.cpp
+++ b/src/OrbitClientData/ModuleManager.cpp
@@ -106,4 +106,12 @@ std::vector<FunctionInfo> ModuleManager::GetOrbitFunctionsOfProcess(
   return result;
 }
 
+std::vector<const ModuleData*> ModuleManager::GetAllModuleData() const {
+  std::vector<const ModuleData*> result;
+  for (const auto& [unused_pair, module_data] : module_map_) {
+    result.push_back(&module_data);
+  }
+  return result;
+}
+
 }  // namespace orbit_client_data

--- a/src/OrbitClientData/include/OrbitClientData/ModuleData.h
+++ b/src/OrbitClientData/include/OrbitClientData/ModuleData.h
@@ -50,6 +50,8 @@ class ModuleData final {
   [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionFromHash(uint64_t hash) const;
   [[nodiscard]] std::vector<const orbit_client_protos::FunctionInfo*> GetFunctions() const;
   [[nodiscard]] std::vector<orbit_client_protos::FunctionInfo> GetOrbitFunctions() const;
+  [[nodiscard]] std::vector<const orbit_grpc_protos::SymbolInfo*> GetDataSymbolsFromName(
+      std::string_view name) const;
 
  private:
   [[nodiscard]] bool NeedsUpdate(const orbit_grpc_protos::ModuleInfo& info) const;
@@ -58,6 +60,7 @@ class ModuleData final {
   orbit_grpc_protos::ModuleInfo module_info_;
   bool is_loaded_;
   std::map<uint64_t, std::unique_ptr<orbit_client_protos::FunctionInfo>> functions_;
+  std::vector<orbit_grpc_protos::SymbolInfo> data_symbols_;
   // TODO(168799822) This is a map of hash to function used for preset loading. Currently presets
   // are based on a hash of the functions pretty name. This should be changed to not use hashes
   // anymore.

--- a/src/OrbitClientData/include/OrbitClientData/ModuleManager.h
+++ b/src/OrbitClientData/include/OrbitClientData/ModuleManager.h
@@ -40,6 +40,8 @@ class ModuleManager final {
   [[nodiscard]] std::vector<orbit_client_protos::FunctionInfo> GetOrbitFunctionsOfProcess(
       const ProcessData& process) const;
 
+  [[nodiscard]] std::vector<const ModuleData*> GetAllModuleData() const;
+
  private:
   mutable absl::Mutex mutex_;
   // We are sharing pointers to that entries and ensure reference stability by using node_hash_map


### PR DESCRIPTION
In order to have access to global variables, don't discard data
symbols when parsing elf file.

For a bit of context:
This is a somewhat naive implementation. What I'd like to have
is the ability to query all modules for the presence of a particular
global variable, without populating all the debug information. This
will be used to discover the Orbit api function table in different 
modules so we can punch in the proper function pointers from 
Orbit.

See https://github.com/google/orbit/pull/2140 for full usage.