### PR TITLE
[Release] Remove the selection overlay when zooming in

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -221,6 +221,9 @@ bool CaptureWindow::RightUp() {
         TicksToMicroseconds(time_graph_->GetCaptureMin(), time_graph_->GetTickFromWorld(max_world));
 
     time_graph_->SetMinMax(new_min, new_max);
+
+    // Clear the selection display
+    select_stop_pos_world_ = select_start_pos_world_;
   }
 
   return GlCanvas::RightUp();


### PR DESCRIPTION
This was introduced with my Viewport changes: When using right-click / drag to zoom (hold CTRL), the green overlay should not be rendered after zooming is done.

Test: Hold Ctrl + Right-click drag, the green overlay disappears.
Bug: b/185440963