### PR TITLE
Fix crash related with wrongly used erase

### DIFF
--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -326,7 +326,8 @@ void TrackManager::AddFrameTrack(const std::shared_ptr<FrameTrack>& frame_track)
 void TrackManager::RemoveFrameTrack(uint64_t function_id) {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
   sorted_tracks_.erase(
-      std::remove(sorted_tracks_.begin(), sorted_tracks_.end(), frame_tracks_[function_id].get()));
+      std::remove(sorted_tracks_.begin(), sorted_tracks_.end(), frame_tracks_[function_id].get()),
+      sorted_tracks_.end());
   frame_tracks_.erase(function_id);
   UpdateVisibleTrackList();
 }


### PR DESCRIPTION
We were always erasing one Frame Track, and this crashed when the Frame
Track function has no samples, because there is no FrameTrack. Now it is
fixed.

Fixed: http://b/185448604.