### PR TITLE
[REBASE] Fix not showing timer's text on inactive tracks.

### DIFF
--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -486,7 +486,7 @@ void ThreadTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t
       const Vec2& size = text_box.GetSize();
 
       if (text_box.Duration() > draw_data.ns_per_pixel) {
-        if (collapse_toggle_->IsExpanded()) {
+        if (!collapse_toggle_->IsCollapsed()) {
           SetTimesliceText(text_box.GetTimerInfo(), draw_data.world_start_x, z_offset, &text_box);
         }
         batcher->AddShadedBox(pos, size, draw_data.z, color, std::move(user_data));


### PR DESCRIPTION
A timer's text slice is currently only drawn on expanded tracks
(for ThreadTracks). However, tracks having just one depth of
timers are not "expanded", but "inactive". Thus, the check needs
to be "not collapsed".

Test: Take a capture with one function hooked.
Bug: http://b/185362423