### PR TITLE
Make UpdateVisibleTrack run only in the main thread

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2085,6 +2085,7 @@ void OrbitApp::RefreshFrameTracks() {
     GetMutableTimeGraph()->RemoveFrameTrack(function_id);
     AddFrameTrackTimers(function_id);
   }
+  GetMutableTimeGraph()->GetTrackManager()->RequestTrackSorting();
 }
 
 void OrbitApp::AddFrameTrackTimers(uint64_t instrumented_function_id) {

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -47,6 +47,7 @@ class TrackManager {
   }
 
   void SortTracks();
+  void RequestTrackSorting() { sorting_invalidated_ = true; };
   void SetFilter(const std::string& filter);
 
   void UpdateTracks(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
@@ -98,6 +99,7 @@ class TrackManager {
 
   std::vector<Track*> sorted_tracks_;
   bool sorting_invalidated_ = false;
+  bool visible_track_list_needs_update_ = false;
   Timer last_thread_reorder_;
 
   std::string filter_;


### PR DESCRIPTION
We had sometimes a crash when starting a capture because
multi-threading (http://b/185459021). This only happened when
we had at least one FrameTrack enabled.

In this PR, instead of calling UpdateVisibleTrack when adding/removing a
FrameTrack we set a flag, so the main thread could update them.

For that, we also force SortTracks when we finish to process the
capture. This simplifies a little the logic of SortTracks, and we can
only actually sorting when the sorting is invalidated or when the
capture is running and we didn't make it in the last second.