### PR TITLE
[Rebase] Reset the default value of memory sampling period

### DIFF
--- a/src/OrbitGl/DataManager.h
+++ b/src/OrbitGl/DataManager.h
@@ -129,7 +129,7 @@ class DataManager final {
   orbit_grpc_protos::UnwindingMethod unwinding_method_{};
 
   bool collect_memory_info_ = false;
-  uint64_t memory_sampling_period_ns_ = 100'000'000;
+  uint64_t memory_sampling_period_ns_ = 10'000'000;
   uint64_t memory_warning_threshold_kb_ = 1024 * 1024 * 8;
 };
 

--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -104,7 +104,7 @@ void CaptureOptionsDialog::SetMemorySamplingPeriodMs(uint64_t memory_sampling_pe
 void CaptureOptionsDialog::ResetMemorySamplingPeriodMsLineEditWhenEmpty() {
   if (!ui_->memorySamplingPeriodMsLineEdit->text().isEmpty()) return;
 
-  constexpr uint64_t kMemorySamplingPeriodMsDefaultValue = 100;
+  constexpr uint64_t kMemorySamplingPeriodMsDefaultValue = 10;
   ui_->memorySamplingPeriodMsLineEdit->setText(
       QString::number(kMemorySamplingPeriodMsDefaultValue));
 }

--- a/src/OrbitQt/CaptureOptionsDialog.ui
+++ b/src/OrbitQt/CaptureOptionsDialog.ui
@@ -92,7 +92,7 @@
              <set>Qt::ImhDigitsOnly</set>
             </property>
             <property name="text">
-             <string>100</string>
+             <string>10</string>
             </property>
            </widget>
           </item>

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -880,7 +880,7 @@ const QString OrbitMainWindow::kLimitLocalMarkerDepthPerCommandBufferSettingsKey
 const QString OrbitMainWindow::kMaxLocalMarkerDepthPerCommandBufferSettingsKey{
     "MaxLocalMarkerDepthPerCommandBuffer"};
 
-constexpr uint64_t kMemorySamplingPeriodMsDefaultValue = 100;
+constexpr uint64_t kMemorySamplingPeriodMsDefaultValue = 10;
 constexpr uint64_t kMemoryWarningThresholdKbDefaultValue = 1024 * 1024 * 8;  // 8Gb
 constexpr uint64_t kMilliSecondsToNanoSeconds = 1000'000;
 


### PR DESCRIPTION
When the memory sampling period is set to a high number, e.g., 1000 ms,
the update in the capture window looks to be "stuck". This is because
update of events in the other tracks might be lagging far behind the
update of events in memory tracks.

When the memory sampling period is set to 10 ms, the capture window
updates smoothly and the performance on the service side is affected
very slightly. Hence, in this change, we change the default value of the
sampling period to be 10ms.

Bug: http://b/185473068