### PR TITLE
[REBASE on main] Syncronize ProcessData

### DIFF
--- a/src/OrbitClientData/ModuleManager.cpp
+++ b/src/OrbitClientData/ModuleManager.cpp
@@ -89,11 +89,13 @@ ModuleData* ModuleManager::GetMutableModuleByPathAndBuildId(const std::string& p
 
 std::vector<FunctionInfo> ModuleManager::GetOrbitFunctionsOfProcess(
     const ProcessData& process) const {
+  auto memory_map = process.GetMemoryMapCopy();
+
   absl::MutexLock lock(&mutex_);
 
   std::vector<FunctionInfo> result;
 
-  for (const auto& [module_path, module_in_memory] : process.GetMemoryMap()) {
+  for (const auto& [module_path, module_in_memory] : memory_map) {
     auto it = module_map_.find(std::make_pair(module_path, module_in_memory.build_id()));
     CHECK(it != module_map_.end());
     const ModuleData* module = &it->second;

--- a/src/OrbitClientData/ProcessDataTest.cpp
+++ b/src/OrbitClientData/ProcessDataTest.cpp
@@ -86,8 +86,8 @@ TEST(ProcessData, UpdateModuleInfos) {
     ProcessData process(ProcessInfo{});
     process.UpdateModuleInfos(module_infos);
 
-    const absl::node_hash_map<std::string, ModuleInMemory>& module_memory_map =
-        process.GetMemoryMap();
+    const absl::node_hash_map<std::string, ModuleInMemory> module_memory_map =
+        process.GetMemoryMapCopy();
 
     EXPECT_EQ(module_memory_map.size(), 2);
 
@@ -180,9 +180,9 @@ TEST(ProcessData, IsModuleLoaded) {
   ProcessData process(ProcessInfo{});
   process.UpdateModuleInfos(module_infos);
 
-  EXPECT_NE(process.FindModuleByPath(file_path_1), nullptr);
-  EXPECT_NE(process.FindModuleByPath(file_path_2), nullptr);
-  EXPECT_EQ(process.FindModuleByPath("not/loaded/module"), nullptr);
+  EXPECT_TRUE(process.FindModuleByPath(file_path_1).has_value());
+  EXPECT_TRUE(process.FindModuleByPath(file_path_2).has_value());
+  EXPECT_FALSE(process.FindModuleByPath("not/loaded/module").has_value());
 }
 
 TEST(ProcessData, GetModuleBaseAddress) {
@@ -214,29 +214,6 @@ TEST(ProcessData, GetModuleBaseAddress) {
   ASSERT_TRUE(file_2_base_address.has_value());
   EXPECT_EQ(file_2_base_address.value(), start_address_2);
   EXPECT_FALSE(process.GetModuleBaseAddress("does/not/exist").has_value());
-}
-
-TEST(ProcessData, CreateCopy) {
-  const std::string process_name = "Test Name";
-  const std::string module_path = "test/file/path";
-  uint64_t start_address = 0x100;
-
-  ProcessInfo info;
-  info.set_name(process_name);
-  ProcessData process(info);
-
-  ModuleInfo module_info;
-  module_info.set_file_path(module_path);
-  module_info.set_address_start(start_address);
-
-  process.UpdateModuleInfos({module_info});
-
-  ProcessData process_copy = process;
-
-  EXPECT_EQ(process_copy.name(), process_name);
-  EXPECT_NE(process_copy.FindModuleByPath(module_path), nullptr);
-  ASSERT_EQ(process_copy.GetMemoryMap().size(), 1);
-  EXPECT_EQ(process_copy.GetMemoryMap().at(module_path).start(), start_address);
 }
 
 TEST(ProcessData, FindModuleByAddress) {

--- a/src/OrbitClientGgp/include/OrbitClientGgp/ClientGgp.h
+++ b/src/OrbitClientGgp/include/OrbitClientGgp/ClientGgp.h
@@ -69,26 +69,26 @@ class ClientGgp final : public CaptureListener {
 
  private:
   [[nodiscard]] CaptureData& GetMutableCaptureData() {
-    CHECK(capture_data_.has_value());
-    return capture_data_.value();
+    CHECK(capture_data_ != nullptr);
+    return *capture_data_;
   }
   [[nodiscard]] const CaptureData& GetCaptureData() const {
-    CHECK(capture_data_.has_value());
-    return capture_data_.value();
+    CHECK(capture_data_ != nullptr);
+    return *capture_data_;
   }
   ClientGgpOptions options_;
   std::shared_ptr<grpc::Channel> grpc_channel_;
-  ProcessData target_process_;
+  std::unique_ptr<ProcessData> target_process_;
   orbit_client_data::ModuleManager module_manager_;
   absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions_;
   ModuleData* main_module_;
   std::shared_ptr<StringManager> string_manager_;
   std::unique_ptr<CaptureClient> capture_client_;
   std::unique_ptr<ProcessClient> process_client_;
-  std::optional<CaptureData> capture_data_;
+  std::unique_ptr<CaptureData> capture_data_;
   std::vector<orbit_client_protos::TimerInfo> timer_infos_;
 
-  ErrorMessageOr<ProcessData> GetOrbitProcessByPid(int32_t pid);
+  ErrorMessageOr<std::unique_ptr<ProcessData>> GetOrbitProcessByPid(int32_t pid);
   bool InitCapture();
   void ClearCapture();
   ErrorMessageOr<void> LoadModuleAndSymbols();

--- a/src/OrbitClientModel/CaptureSerializer.cpp
+++ b/src/OrbitClientModel/CaptureSerializer.cpp
@@ -83,7 +83,9 @@ CaptureInfo GenerateCaptureInfo(
   process->set_command_line(capture_data.process()->command_line());
   process->set_is_64_bit(capture_data.process()->is_64_bit());
 
-  for (const auto& [module_path, module_in_memory] : capture_data.process()->GetMemoryMap()) {
+  auto memory_map = capture_data.process()->GetMemoryMapCopy();
+
+  for (const auto& [module_path, module_in_memory] : memory_map) {
     const ModuleData* module =
         capture_data.GetModuleByPathAndBuildId(module_path, module_in_memory.build_id());
     CHECK(module != nullptr);

--- a/src/OrbitClientModel/include/OrbitClientModel/CaptureData.h
+++ b/src/OrbitClientModel/include/OrbitClientModel/CaptureData.h
@@ -45,8 +45,8 @@ class CaptureData {
   CaptureData& operator=(const CaptureData& other) = delete;
   CaptureData(const CaptureData& other) = delete;
 
-  CaptureData(CaptureData&& other) = default;
-  CaptureData& operator=(CaptureData&& other) = default;
+  CaptureData(CaptureData&& other) = delete;
+  CaptureData& operator=(CaptureData&& other) = delete;
 
   [[nodiscard]] const absl::flat_hash_map<uint64_t, orbit_grpc_protos::InstrumentedFunction>&
   instrumented_functions() const {

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -111,14 +111,14 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   void StopCapture();
   void AbortCapture();
   void ClearCapture();
-  [[nodiscard]] bool HasCaptureData() const { return capture_data_.has_value(); }
+  [[nodiscard]] bool HasCaptureData() const { return capture_data_ != nullptr; }
   [[nodiscard]] CaptureData& GetMutableCaptureData() {
-    CHECK(capture_data_.has_value());
-    return capture_data_.value();
+    CHECK(capture_data_ != nullptr);
+    return *capture_data_;
   }
   [[nodiscard]] const CaptureData& GetCaptureData() const {
-    CHECK(capture_data_.has_value());
-    return capture_data_.value();
+    CHECK(capture_data_ != nullptr);
+    return *capture_data_;
   }
 
   [[nodiscard]] bool HasSampleSelection() const {
@@ -547,7 +547,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
   // TODO(kuebler): This is mostly written during capture by the capture thread on the
   //  CaptureListener parts of App, but may be read also during capturing by all threads.
   //  Currently, it is not properly synchronized (and thus it can't live at DataManager).
-  std::optional<CaptureData> capture_data_;
+  std::unique_ptr<CaptureData> capture_data_;
 
   orbit_gl::FrameTrackOnlineProcessor frame_track_online_processor_;
 

--- a/src/OrbitGl/ModulesDataView.cpp
+++ b/src/OrbitGl/ModulesDataView.cpp
@@ -194,7 +194,8 @@ void ModulesDataView::DoFilter() {
 void ModulesDataView::UpdateModules(const ProcessData* process) {
   modules_.clear();
   module_memory_.clear();
-  for (const auto& [module_path, module_in_memory] : process->GetMemoryMap()) {
+  auto memory_map = process->GetMemoryMapCopy();
+  for (const auto& [module_path, module_in_memory] : memory_map) {
     ModuleData* module =
         app_->GetMutableModuleByPathAndBuildId(module_path, module_in_memory.build_id());
     modules_.push_back(module);


### PR DESCRIPTION
Since memory_map in process data can be accessed from
capture thread we need to syncronize this structure.

Note that absl::Mutex renders ProcessData uncopiable and
unmovable so all the refernces changed from std::optional<>
to std::unique_ptr<>

Test: start oribit, start and stop capture 4-5 times.
Bug: http://b/185490447