### PR TITLE
Fix Tracing.Scopes test -- avoid missing events at the end.

### DIFF
--- a/src/OrbitBase/TracingTest.cpp
+++ b/src/OrbitBase/TracingTest.cpp
@@ -32,7 +32,7 @@ TEST(Tracing, Scopes) {
 
   absl::flat_hash_map<uint32_t, std::vector<TracingScope>> scopes_by_thread_id;
   std::once_flag thread_id_set_flag;
-  uint32_t callback_thread_id = -1;
+  uint32_t callback_thread_id = 0;
   {
     TracingListener tracing_listener([&scopes_by_thread_id, &thread_id_set_flag,
                                       &callback_thread_id](const TracingScope& scope) {

--- a/src/OrbitBase/TracingTest.cpp
+++ b/src/OrbitBase/TracingTest.cpp
@@ -32,7 +32,7 @@ TEST(Tracing, Scopes) {
 
   absl::flat_hash_map<uint32_t, std::vector<TracingScope>> scopes_by_thread_id;
   std::once_flag thread_id_set_flag;
-  pid_t callback_thread_id = -1;
+  uint32_t callback_thread_id = -1;
   {
     TracingListener tracing_listener([&scopes_by_thread_id, &thread_id_set_flag,
                                       &callback_thread_id](const TracingScope& scope) {

--- a/src/OrbitBase/TracingTest.cpp
+++ b/src/OrbitBase/TracingTest.cpp
@@ -5,11 +5,9 @@
 #include <gtest/gtest.h>
 #include <stddef.h>
 
-#include <algorithm>
 #include <cstdint>
 #include <memory>
 #include <thread>
-#include <utility>
 #include <vector>
 
 #include "OrbitBase/ThreadUtils.h"
@@ -33,10 +31,15 @@ TEST(Tracing, Scopes) {
   constexpr size_t kNumExpectedScopesPerThread = 4;
 
   absl::flat_hash_map<uint32_t, std::vector<TracingScope>> scopes_by_thread_id;
+  std::once_flag thread_id_set_flag;
+  pid_t callback_thread_id = -1;
   {
-    TracingListener tracing_listener([&scopes_by_thread_id](const TracingScope& scope) {
+    TracingListener tracing_listener([&scopes_by_thread_id, &thread_id_set_flag,
+                                      &callback_thread_id](const TracingScope& scope) {
       // Check that callback is called from a single thread.
-      static auto callback_thread_id = orbit_base::GetCurrentThreadId();
+      std::call_once(thread_id_set_flag, [&callback_thread_id] {
+        callback_thread_id = orbit_base::GetCurrentThreadId();
+      });
       EXPECT_EQ(orbit_base::GetCurrentThreadId(), callback_thread_id);
       scopes_by_thread_id[scope.tid].emplace_back(scope);
     });

--- a/src/OrbitBase/include/OrbitBase/Tracing.h
+++ b/src/OrbitBase/include/OrbitBase/Tracing.h
@@ -38,11 +38,13 @@ class TracingListener {
 
   static void DeferScopeProcessing(const TracingScope& scope);
   [[nodiscard]] inline static bool IsActive() { return active_; }
+  [[nodiscard]] inline static bool IsShutdownInitiated() { return shutdown_initiated_; }
 
  private:
   TracingTimerCallback user_callback_ = nullptr;
   std::unique_ptr<ThreadPool> thread_pool_ = {};
   inline static bool active_ = false;
+  inline static bool shutdown_initiated_ = true;
 };
 
 }  // namespace orbit_base


### PR DESCRIPTION
With the fix of #2182 it can happen that introspection events
at the very end of a capture get lost. However, we've been a
bit restrictive here, as we also dropped scopes that have already
been scheduled on the thread pool, before this was shut down.

This can be improved (and in fact the Tracing.Scopes test relies on
this), by separating out an `IsShutdownInstantiated` out of `IsActive`.
This way, we only schedule scopes to the thread pool, when the thread
pool, has not yet started to be shut down, but scheduled scopes are
only aborted if the listener itself is not active anymore.

Further, this fixes the thread id check in the test itself for multiple
tests runs. The static variable was assigned only once, and not once
per test.

Test: Run test 1000 times.
Bug: http://b/185455477