### PR TITLE
[RELEASE] Fix text position update

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -359,14 +359,14 @@ std::unique_ptr<AccessibleInterface> CaptureWindow::CreateAccessibleInterface() 
   return std::make_unique<AccessibleCaptureWindow>(this);
 }
 
-void CaptureWindow::Draw() {
+void CaptureWindow::Draw(bool viewport_was_dirty) {
   ORBIT_SCOPE("CaptureWindow::Draw");
   if (ShouldAutoZoom()) {
     ZoomAll();
   }
 
   if (time_graph_ != nullptr) {
-    if (viewport_.IsDirty()) {
+    if (viewport_was_dirty) {
       time_graph_->SetPos(0, 0);
       time_graph_->SetSize(viewport_.GetWorldExtents()[0], viewport_.GetWorldExtents()[1]);
 

--- a/src/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/CaptureWindow.h
@@ -55,7 +55,7 @@ class CaptureWindow : public GlCanvas {
   Batcher& GetBatcherById(BatcherId batcher_id);
 
  protected:
-  void Draw() override;
+  void Draw(bool viewport_was_dirty) override;
 
   virtual void DrawScreenSpace();
   virtual void RenderText(float layer);

--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -300,7 +300,10 @@ void GlCanvas::Render(int width, int height) {
   // Reset picking manager before each draw.
   picking_manager_.Reset();
 
-  Draw();
+  bool viewport_was_dirty = viewport_.IsDirty();
+  // Clear viewport dirty flag so it can be set again during rendering if needed
+  viewport_.ClearDirtyFlag();
+  Draw(viewport_was_dirty);
 
   if (picking_mode_ == PickingMode::kNone) {
     for (const auto& render_callback : render_callbacks_) {
@@ -338,8 +341,6 @@ void GlCanvas::PostRender() {
     Pick(prev_picking_mode, mouse_move_pos_screen_[0], mouse_move_pos_screen_[1]);
     GlCanvas::Render(viewport_.GetScreenWidth(), viewport_.GetScreenHeight());
   }
-
-  viewport_.ClearDirtyFlag();
 }
 
 void GlCanvas::Resize(int width, int height) {

--- a/src/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/GlCanvas.h
@@ -130,7 +130,7 @@ class GlCanvas {
   static const Color kTabTextColorSelected;
 
  protected:
-  virtual void Draw() {}
+  virtual void Draw(bool /*viewport_was_dirty*/) {}
 
   void UpdateSpecialKeys(bool ctrl, bool shift, bool alt);
   bool ControlPressed();

--- a/src/OrbitGl/IntrospectionWindow.cpp
+++ b/src/OrbitGl/IntrospectionWindow.cpp
@@ -50,9 +50,9 @@ void IntrospectionWindow::StartIntrospection() {
 }
 void IntrospectionWindow::StopIntrospection() { introspection_listener_ = nullptr; }
 
-void IntrospectionWindow::Draw() {
+void IntrospectionWindow::Draw(bool viewport_was_dirty) {
   ORBIT_SCOPE_FUNCTION;
-  CaptureWindow::Draw();
+  CaptureWindow::Draw(viewport_was_dirty);
 }
 
 void IntrospectionWindow::DrawScreenSpace() {

--- a/src/OrbitGl/IntrospectionWindow.h
+++ b/src/OrbitGl/IntrospectionWindow.h
@@ -25,7 +25,7 @@ class IntrospectionWindow : public CaptureWindow {
   void StartIntrospection();
   void StopIntrospection();
 
-  void Draw() override;
+  void Draw(bool viewport_was_dirty) override;
   void DrawScreenSpace() override;
   void RenderText(float layer) override;
 


### PR DESCRIPTION
This allows the GlCanvas::Draw() method to update the viewport, which
will correctly mark it as dirty again and trigger a new rendering next
frame.

This is required because we change the height of tracks during TimeGraph::UpdatePrimitives(),
but in the same method, text is rendered that relies on the extents of the viewport
that have been calculated before.

To reproduce, take a look at the description in this bug: b/185363608