### PR TITLE
Cleanup: Rename variable.

### DIFF
--- a/src/UserSpaceInstrumentation/AccessTraceesMemory.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemory.cpp
@@ -24,14 +24,14 @@ namespace orbit_user_space_instrumentation {
 using orbit_base::ReadFileToString;
 
 [[nodiscard]] ErrorMessageOr<std::vector<uint8_t>> ReadTraceesMemory(pid_t pid,
-                                                                     uint64_t address_start,
+                                                                     uint64_t start_address,
                                                                      uint64_t length) {
   CHECK(length != 0);
 
   OUTCOME_TRY(fd, orbit_base::OpenFileForReading(absl::StrFormat("/proc/%d/mem", pid)));
 
   std::vector<uint8_t> bytes(length);
-  OUTCOME_TRY(result, ReadFullyAtOffset(fd, bytes.data(), length, address_start));
+  OUTCOME_TRY(result, ReadFullyAtOffset(fd, bytes.data(), length, start_address));
 
   if (result < length) {
     return ErrorMessage(absl::StrFormat(
@@ -42,13 +42,13 @@ using orbit_base::ReadFileToString;
   return bytes;
 }
 
-[[nodiscard]] ErrorMessageOr<void> WriteTraceesMemory(pid_t pid, uint64_t address_start,
+[[nodiscard]] ErrorMessageOr<void> WriteTraceesMemory(pid_t pid, uint64_t start_address,
                                                       const std::vector<uint8_t>& bytes) {
   CHECK(!bytes.empty());
 
   OUTCOME_TRY(fd, orbit_base::OpenFileForWriting(absl::StrFormat("/proc/%d/mem", pid)));
 
-  OUTCOME_TRY(WriteFullyAtOffset(fd, bytes.data(), bytes.size(), address_start));
+  OUTCOME_TRY(WriteFullyAtOffset(fd, bytes.data(), bytes.size(), start_address));
 
   return outcome::success();
 }

--- a/src/UserSpaceInstrumentation/AccessTraceesMemory.h
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemory.h
@@ -14,15 +14,15 @@
 
 namespace orbit_user_space_instrumentation {
 
-// Read `length` bytes from process `pid` starting at `address_start`.
+// Read `length` bytes from process `pid` starting at `start_address`.
 // Assumes we are already attached to the tracee `pid` e.g. using `AttachAndStopProcess`.
 [[nodiscard]] ErrorMessageOr<std::vector<uint8_t>> ReadTraceesMemory(pid_t pid,
-                                                                     uint64_t address_start,
+                                                                     uint64_t start_address,
                                                                      uint64_t length);
 
-// Write `bytes` into memory of process `pid` starting from `address_start`.
+// Write `bytes` into memory of process `pid` starting from `start_address`.
 // Assumes we are already attached to the tracee `pid` e.g. using `AttachAndStopProcess`.
-[[nodiscard]] ErrorMessageOr<void> WriteTraceesMemory(pid_t pid, uint64_t address_start,
+[[nodiscard]] ErrorMessageOr<void> WriteTraceesMemory(pid_t pid, uint64_t start_address,
                                                       const std::vector<uint8_t>& bytes);
 
 // Returns the address range of the first executable memory region. In every case I encountered this

--- a/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
@@ -31,11 +31,11 @@ namespace {
 
 using ::testing::HasSubstr;
 
-AddressRange AddressRangeFromString(const std::string& address_string) {
+AddressRange AddressRangeFromString(const std::string& string_address) {
   AddressRange result;
-  const std::vector<std::string> addresses = absl::StrSplit(address_string, '-');
+  const std::vector<std::string> addresses = absl::StrSplit(string_address, '-');
   if (addresses.size() != 2) {
-    FATAL("Not an address range: %s", address_string);
+    FATAL("Not an address range: %s", string_address);
   }
   if (!absl::numbers_internal::safe_strtou64_base(addresses[0], &result.first, 16)) {
     FATAL("Not a number: %s", addresses[0]);

--- a/src/UserSpaceInstrumentation/AttachTest.cpp
+++ b/src/UserSpaceInstrumentation/AttachTest.cpp
@@ -30,8 +30,8 @@ TEST(AttachTest, AttachAndStopProcess) {
   EXPECT_EQ(std::set<pid_t>(tids.begin(), tids.end()),
             std::set<pid_t>(tids_new.begin(), tids_new.end()));
 
-  const auto result_detach = DetachAndContinueProcess(pid);
-  ASSERT_FALSE(result_detach.has_error()) << result_detach.error().message();
+  const auto detach_result = DetachAndContinueProcess(pid);
+  ASSERT_FALSE(detach_result.has_error()) << detach_result.error().message();
 }
 
 }  // namespace orbit_user_space_instrumentation

--- a/src/UserSpaceInstrumentation/ExecuteMachineCode.cpp
+++ b/src/UserSpaceInstrumentation/ExecuteMachineCode.cpp
@@ -37,16 +37,16 @@ uint64_t GetReturnValueOrDie(pid_t pid) {
 
 }  // namespace
 
-ErrorMessageOr<uint64_t> ExecuteMachineCode(pid_t pid, uint64_t address_code,
+ErrorMessageOr<uint64_t> ExecuteMachineCode(pid_t pid, uint64_t code_address,
                                             const MachineCode& code) {
-  OUTCOME_TRY(WriteTraceesMemory(pid, address_code, code.GetResultAsVector()));
+  OUTCOME_TRY(WriteTraceesMemory(pid, code_address, code.GetResultAsVector()));
 
   // Backup registers.
   RegisterState original_registers;
   OUTCOME_TRY(original_registers.BackupRegisters(pid));
 
   RegisterState registers_for_execution = original_registers;
-  registers_for_execution.GetGeneralPurposeRegisters()->x86_64.rip = address_code;
+  registers_for_execution.GetGeneralPurposeRegisters()->x86_64.rip = code_address;
   // The calling convention for x64 assumes the 128 bytes below rsp to be usable as a scratch pad
   // for the current function. This area is called the 'red zone'. The function we interrupted might
   // have stored temporary data in the red zone and the function we are about to execute might do

--- a/src/UserSpaceInstrumentation/ExecuteMachineCode.h
+++ b/src/UserSpaceInstrumentation/ExecuteMachineCode.h
@@ -14,11 +14,11 @@
 
 namespace orbit_user_space_instrumentation {
 
-// Copies `code` to `address_code` in the tracee and executes it. The memory at `address_code` needs
+// Copies `code` to `code_address` in the tracee and executes it. The memory at `code_address` needs
 // to be allocated using AllocateInTracee. The code segment has to end with an `int3`. Takes care of
 // backup and restore of register state in the tracee.
 // The return value is the content of rax after the execution finished.
-[[nodiscard]] ErrorMessageOr<uint64_t> ExecuteMachineCode(pid_t pid, uint64_t address_code,
+[[nodiscard]] ErrorMessageOr<uint64_t> ExecuteMachineCode(pid_t pid, uint64_t code_address,
                                                           const MachineCode& code);
 
 }  // namespace orbit_user_space_instrumentation

--- a/src/UserSpaceInstrumentation/MachineCode.h
+++ b/src/UserSpaceInstrumentation/MachineCode.h
@@ -18,7 +18,7 @@ namespace orbit_user_space_instrumentation {
 //     .AppendBytes({0xff, 0xd0})
 //     .AppendBytes({0xcc});
 //
-// WriteTraceesMemory(pid, address_code, code.GetResultAsVector());
+// WriteTraceesMemory(pid, code_address, code.GetResultAsVector());
 //
 class MachineCode {
  public:

--- a/src/UserSpaceInstrumentation/Trampoline.cpp
+++ b/src/UserSpaceInstrumentation/Trampoline.cpp
@@ -103,17 +103,17 @@ ErrorMessageOr<AddressRange> FindAddressRangeForTrampoline(
   }
   while (optional_range_index.value() > 0) {
     // Place directly to the left of the take interval we are in...
-    uint64_t address_trampoline = unavailable_ranges[optional_range_index.value()].start - size;
+    uint64_t trampoline_address = unavailable_ranges[optional_range_index.value()].start - size;
     // ... but round down to page boundary.
-    address_trampoline = (address_trampoline / page_size) * page_size;
-    AddressRange range_trampoline = {address_trampoline, address_trampoline + size};
-    optional_range_index = LowestIntersectingAddressRange(unavailable_ranges, range_trampoline);
+    trampoline_address = (trampoline_address / page_size) * page_size;
+    AddressRange trampoline_range = {trampoline_address, trampoline_address + size};
+    optional_range_index = LowestIntersectingAddressRange(unavailable_ranges, trampoline_range);
     if (!optional_range_index) {
       // We do not intersect any taken interval. Check if we are close enough to code_range:
-      // code_range is above range_trampoline we will need to jmp back and forth in these ranges
+      // code_range is above trampoline_range we will need to jmp back and forth in these ranges
       // with 32 bit offsets. If no distance is greater than 0x7fffffff this is safe.
-      if (code_range.end - range_trampoline.start <= kMax32BitOffset) {
-        return range_trampoline;
+      if (code_range.end - trampoline_range.start <= kMax32BitOffset) {
+        return trampoline_range;
       }
       // If we are already beyond the close range there is no need to go any further.
       break;
@@ -127,21 +127,21 @@ ErrorMessageOr<AddressRange> FindAddressRangeForTrampoline(
                                         code_range.start, code_range.end));
   }
   do {
-    const uint64_t address_trampoline =
+    const uint64_t trampoline_address =
         ((unavailable_ranges[optional_range_index.value()].end + (page_size - 1)) / page_size) *
         page_size;
     // Check if we ran out of address space.
-    if (address_trampoline >= kMax64BitAdress - size) {
+    if (trampoline_address >= kMax64BitAdress - size) {
       break;
     }
-    AddressRange range_trampoline = {address_trampoline, address_trampoline + size};
-    optional_range_index = HighestIntersectingAddressRange(unavailable_ranges, range_trampoline);
+    AddressRange trampoline_range = {trampoline_address, trampoline_address + size};
+    optional_range_index = HighestIntersectingAddressRange(unavailable_ranges, trampoline_range);
     if (!optional_range_index) {
       // We do not intersect any taken interval. Check if we are close enough to code_range:
-      // code_range is below range_trampoline we will need to jump back and forth in these ranges
+      // code_range is below trampoline_range we will need to jump back and forth in these ranges
       // with 32 bit offsets. If no distance is greater than 0x7fffffff this is safe.
-      if (range_trampoline.end - code_range.start <= kMax32BitOffset) {
-        return range_trampoline;
+      if (trampoline_range.end - code_range.start <= kMax32BitOffset) {
+        return trampoline_range;
       }
       // If we are already beyond the close range there is no need to go any further.
       break;


### PR DESCRIPTION
Restricted this PR to more or less trivial, mechanical changes.
e.g. `address_code` -> `code_address`. There might be more occurrences
but this should cover most of the issue.

Bug: http://b/185254470
Test: unit test.