### PR TITLE
Introduce CaptureFinished message

### DIFF
--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -321,6 +321,16 @@ message ThreadNamesSnapshot {
   repeated ThreadName thread_names = 2;
 }
 
+message CaptureFinished {
+  enum Status {
+    kSuccessful = 0;
+    kFailed = 1;
+  };
+
+  Status status = 1;
+  string error_message = 2;
+}
+
 message CaptureStarted {
   int32 process_id = 1;
   string executable_path = 2;
@@ -344,6 +354,7 @@ message ClientCaptureEvent {
     AddressInfo address_info = 16;
     ApiEvent api_event = 9;
     CallstackSample callstack_sample = 1;
+    CaptureFinished capture_finished = 27;
     CaptureStarted capture_started = 24;
     FunctionCall function_call = 2;
     GpuJob gpu_job = 3;

--- a/src/OrbitCaptureClient/ApiEventProcessorTest.cpp
+++ b/src/OrbitCaptureClient/ApiEventProcessorTest.cpp
@@ -26,6 +26,7 @@ class EmptyCaptureListener : public CaptureListener {
  public:
   void OnCaptureStarted(const orbit_grpc_protos::CaptureStarted& /*capture_started*/,
                         absl::flat_hash_set<uint64_t> /*frame_track_function_ids*/) override {}
+  void OnCaptureFinished(const orbit_grpc_protos::CaptureFinished& /*capture_finished*/) override {}
   void OnTimer(const orbit_client_protos::TimerInfo&) override {}
   void OnSystemMemoryUsage(const orbit_grpc_protos::SystemMemoryUsage&) override {}
   void OnKeyAndString(uint64_t, std::string) override {}

--- a/src/OrbitCaptureClient/CaptureEventProcessor.cpp
+++ b/src/OrbitCaptureClient/CaptureEventProcessor.cpp
@@ -91,10 +91,12 @@ void CaptureEventProcessor::ProcessEvent(const ClientCaptureEvent& event) {
     case ClientCaptureEvent::kSystemMemoryUsage:
       ProcessSystemMemoryUsage(event.system_memory_usage());
       break;
-    case ClientCaptureEvent::kApiEvent: {
+    case ClientCaptureEvent::kApiEvent:
       api_event_processor_.ProcessApiEvent(event.api_event());
       break;
-    }
+    case ClientCaptureEvent::kCaptureFinished:
+      ProcessCaptureFinished(event.capture_finished());
+      break;
     case ClientCaptureEvent::EVENT_NOT_SET:
       ERROR("CaptureEvent::EVENT_NOT_SET read from Capture's gRPC stream");
       break;
@@ -104,6 +106,11 @@ void CaptureEventProcessor::ProcessEvent(const ClientCaptureEvent& event) {
 void CaptureEventProcessor::ProcessCaptureStarted(
     const orbit_grpc_protos::CaptureStarted& capture_started) {
   capture_listener_->OnCaptureStarted(capture_started, frame_track_function_ids_);
+}
+
+void CaptureEventProcessor::ProcessCaptureFinished(
+    const orbit_grpc_protos::CaptureFinished& capture_finished) {
+  capture_listener_->OnCaptureFinished(capture_finished);
 }
 
 void CaptureEventProcessor::ProcessSchedulingSlice(const SchedulingSlice& scheduling_slice) {

--- a/src/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/src/OrbitCaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -34,7 +34,8 @@ using orbit_client_protos::TimerInfo;
 class MyCaptureListener : public CaptureListener {
  private:
   void OnCaptureStarted(const orbit_grpc_protos::CaptureStarted& /*capture_started*/,
-                        absl::flat_hash_set<uint64_t> /* frame_track_function_ids */) override {}
+                        absl::flat_hash_set<uint64_t> /*frame_track_function_ids*/) override {}
+  void OnCaptureFinished(const orbit_grpc_protos::CaptureFinished& /*capture_finished*/) override {}
   void OnTimer(const TimerInfo&) override {}
   void OnSystemMemoryUsage(const orbit_grpc_protos::SystemMemoryUsage&) override {}
   void OnKeyAndString(uint64_t, std::string) override {}

--- a/src/OrbitCaptureClient/CaptureEventProcessorTest.cpp
+++ b/src/OrbitCaptureClient/CaptureEventProcessorTest.cpp
@@ -25,7 +25,6 @@
 #include "tracepoint.pb.h"
 
 using orbit_client_protos::CallstackEvent;
-using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::LinuxAddressInfo;
 using orbit_client_protos::ThreadStateSliceInfo;
 using orbit_client_protos::TimerInfo;
@@ -34,6 +33,7 @@ using orbit_client_protos::TracepointEventInfo;
 using orbit_grpc_protos::AddressInfo;
 using orbit_grpc_protos::Callstack;
 using orbit_grpc_protos::CallstackSample;
+using orbit_grpc_protos::CaptureFinished;
 using orbit_grpc_protos::CaptureStarted;
 using orbit_grpc_protos::ClientCaptureEvent;
 using orbit_grpc_protos::Color;
@@ -45,7 +45,6 @@ using orbit_grpc_protos::GpuJob;
 using orbit_grpc_protos::GpuQueueSubmission;
 using orbit_grpc_protos::GpuQueueSubmissionMetaInfo;
 using orbit_grpc_protos::GpuSubmitInfo;
-using orbit_grpc_protos::InstrumentedFunction;
 using orbit_grpc_protos::InternedCallstack;
 using orbit_grpc_protos::InternedString;
 using orbit_grpc_protos::InternedTracepointInfo;
@@ -69,6 +68,7 @@ class MockCaptureListener : public CaptureListener {
  public:
   MOCK_METHOD(void, OnCaptureStarted, (const CaptureStarted&, absl::flat_hash_set<uint64_t>),
               (override));
+  MOCK_METHOD(void, OnCaptureFinished, (const CaptureFinished&), (override));
   MOCK_METHOD(void, OnTimer, (const TimerInfo&), (override));
   MOCK_METHOD(void, OnSystemMemoryUsage, (const SystemMemoryUsage&), (override));
   MOCK_METHOD(void, OnKeyAndString, (uint64_t /*key*/, std::string), (override));

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureEventProcessor.h
@@ -37,6 +37,7 @@ class CaptureEventProcessor {
 
  private:
   void ProcessCaptureStarted(const orbit_grpc_protos::CaptureStarted& capture_started);
+  void ProcessCaptureFinished(const orbit_grpc_protos::CaptureFinished& capture_finished);
   void ProcessSchedulingSlice(const orbit_grpc_protos::SchedulingSlice& scheduling_slice);
   void ProcessInternedCallstack(orbit_grpc_protos::InternedCallstack interned_callstack);
   void ProcessCallstackSample(const orbit_grpc_protos::CallstackSample& callstack_sample);

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureListener.h
@@ -22,6 +22,7 @@ class CaptureListener {
 
   virtual void OnCaptureStarted(const orbit_grpc_protos::CaptureStarted& capture_started,
                                 absl::flat_hash_set<uint64_t> frame_track_function_ids) = 0;
+  virtual void OnCaptureFinished(const orbit_grpc_protos::CaptureFinished& capture_finished) = 0;
 
   virtual void OnTimer(const orbit_client_protos::TimerInfo& timer_info) = 0;
   virtual void OnSystemMemoryUsage(

--- a/src/OrbitClientGgp/ClientGgp.cpp
+++ b/src/OrbitClientGgp/ClientGgp.cpp
@@ -48,8 +48,8 @@ using orbit_client_protos::CallstackEvent;
 using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::LinuxAddressInfo;
 using orbit_client_protos::TimerInfo;
+using orbit_grpc_protos::CaptureFinished;
 using orbit_grpc_protos::CaptureStarted;
-using orbit_grpc_protos::InstrumentedFunction;
 using orbit_grpc_protos::ModuleInfo;
 using orbit_grpc_protos::ProcessInfo;
 using orbit_grpc_protos::UnwindingMethod;
@@ -309,6 +309,14 @@ void ClientGgp::ClearCapture() {
 void ClientGgp::ProcessTimer(const TimerInfo& timer_info) { timer_infos_.push_back(timer_info); }
 
 // CaptureListener implementation
+void ClientGgp::OnCaptureFinished(const CaptureFinished& capture_finished) {
+  if (capture_finished.status() == CaptureFinished::kFailed) {
+    ERROR("Capture finished with error: %s", capture_finished.error_message());
+  } else {
+    LOG("Capture finished successfully");
+  }
+}
+
 void ClientGgp::OnCaptureStarted(const CaptureStarted& capture_started,
                                  absl::flat_hash_set<uint64_t> frame_track_function_ids) {
   capture_data_ =

--- a/src/OrbitClientGgp/include/OrbitClientGgp/ClientGgp.h
+++ b/src/OrbitClientGgp/include/OrbitClientGgp/ClientGgp.h
@@ -49,6 +49,7 @@ class ClientGgp final : public CaptureListener {
   void UpdateCaptureFunctions(std::vector<std::string> capture_functions);
 
   // CaptureListener implementation
+  void OnCaptureFinished(const orbit_grpc_protos::CaptureFinished& capture_started) override;
   void OnCaptureStarted(const orbit_grpc_protos::CaptureStarted& capture_started,
                         absl::flat_hash_set<uint64_t> frame_track_function_ids) override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;

--- a/src/OrbitClientModel/CaptureDeserializerLoadFuzzer.cpp
+++ b/src/OrbitClientModel/CaptureDeserializerLoadFuzzer.cpp
@@ -24,6 +24,7 @@ class MockCaptureListener : public CaptureListener {
  public:
   void OnCaptureStarted(const orbit_grpc_protos::CaptureStarted&,
                         absl::flat_hash_set<uint64_t>) override {}
+  void OnCaptureFinished(const orbit_grpc_protos::CaptureFinished&) override {}
   void OnTimer(const orbit_client_protos::TimerInfo&) override {}
   void OnSystemMemoryUsage(const orbit_grpc_protos::SystemMemoryUsage&) override {}
   void OnKeyAndString(uint64_t, std::string) override {}

--- a/src/OrbitClientModel/CaptureDeserializerTest.cpp
+++ b/src/OrbitClientModel/CaptureDeserializerTest.cpp
@@ -43,6 +43,7 @@ using orbit_client_protos::ProcessInfo;
 using orbit_client_protos::ThreadStateSliceInfo;
 using orbit_client_protos::TimerInfo;
 using orbit_client_protos::TracepointEventInfo;
+using orbit_grpc_protos::CaptureFinished;
 using orbit_grpc_protos::CaptureStarted;
 using orbit_grpc_protos::ModuleInfo;
 using orbit_grpc_protos::SystemMemoryUsage;
@@ -66,6 +67,7 @@ class MockCaptureListener : public CaptureListener {
               (const CaptureStarted& /*capture_started*/,
                absl::flat_hash_set<uint64_t> /*frame_track_function_ids*/),
               (override));
+  MOCK_METHOD(void, OnCaptureFinished, (const CaptureFinished& /*capture_finished*/), (override));
   MOCK_METHOD(void, OnTimer, (const TimerInfo&), (override));
   MOCK_METHOD(void, OnSystemMemoryUsage, (const SystemMemoryUsage&), (override));
   MOCK_METHOD(void, OnKeyAndString, (uint64_t /*key*/, std::string), (override));

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -134,6 +134,7 @@ class OrbitApp final : public DataViewFactory, public CaptureListener {
 
   void OnCaptureStarted(const orbit_grpc_protos::CaptureStarted& capture_started,
                         absl::flat_hash_set<uint64_t> frame_track_function_ids) override;
+  void OnCaptureFinished(const orbit_grpc_protos::CaptureFinished& capture_finished) override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
   void OnKeyAndString(uint64_t key, std::string str) override;
   void OnUniqueCallStack(CallStack callstack) override;


### PR DESCRIPTION
This is last event sent for the capture. This
commit establishes the message and sends it at the
end of the capture. For now it is always a success.

Bug: http://b/185754690
Test: run capture in the client.