### PR TITLE
Set Visual Studio startup project to Orbit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,7 +185,7 @@ endif()
 if(WIN32)
   # Startup Project
   set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT
-                                                              "OrbitQt")
+                                                              "Orbit")
 endif()
 
 # Collecting third-party licenses


### PR DESCRIPTION
This was forgotten when we changed the OrbitQt into a library target and
added a new executable target "Orbit".

So without that changes Visual Studio tries to executed the library
target which obviously fails.

This commit changes the default startup project to "Orbit" which is the
new name of the executable target.