### PR TITLE
Add a clang-format script to be invoked as pre-commit hook.

### DIFF
--- a/contrib/hooks/clang-format-pre-commit.sh
+++ b/contrib/hooks/clang-format-pre-commit.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# A pre-commit hook that applies clang-format-9 to all the changes
+# (staged and unstaged).
+# After the formatting has been applied, it will ask you which changes should
+
+echo "Formatting all changed files now..."
+git clang-format-9 -f
+# Only show this to the user of there are unstaged changes.
+if ! (git diff -- --quiet)
+then
+  exec < /dev/tty
+  echo "\n\n"
+  echo "Please select the changes to be included in this commit ('a' in include all):"
+  git add -p .
+fi
+


### PR DESCRIPTION
This is a first step into having an automated formatting upon commits.
It adds a script that can be executed from the pre-commit hook directly.

All the files touched by the commit will be formatted completely and
the complete file will be added to the commit. Thus it does not work
with hunks.

Test: Add "source path/to/file/" to the pre-commit hook script.