### PR TITLE
Manage memory in tracee via unique_resource.

### DIFF
--- a/src/FramePointerValidator/FramePointerValidator.cpp
+++ b/src/FramePointerValidator/FramePointerValidator.cpp
@@ -33,7 +33,7 @@ std::optional<std::vector<CodeBlock>> FramePointerValidator::GetFpoFunctions(
   }
   orbit_base::unique_resource handle{temp_handle, [](csh handle) { cs_close(&handle); }};
 
-  cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
+  cs_option(handle.get(), CS_OPT_DETAIL, CS_OPT_ON);
 
   ErrorMessageOr<std::string> binary_or_error = orbit_base::ReadFileToString(file_name);
   if (binary_or_error.has_error()) {
@@ -48,7 +48,7 @@ std::optional<std::vector<CodeBlock>> FramePointerValidator::GetFpoFunctions(
     }
 
     const std::string& content = binary_or_error.value();
-    FunctionFramePointerValidator validator{handle, content.data() + function.offset(),
+    FunctionFramePointerValidator validator{handle.get(), content.data() + function.offset(),
                                             static_cast<size_t>(function.size())};
 
     if (!validator.Validate()) {

--- a/src/OrbitBase/UniqueResourceTest.cpp
+++ b/src/OrbitBase/UniqueResourceTest.cpp
@@ -20,7 +20,7 @@ TEST(UniqueResource, Construct) {
   {
     orbit_base::unique_resource ur{123, [&was_deleted](size_t) { was_deleted++; }};
     ASSERT_TRUE(static_cast<bool>(ur));
-    ASSERT_TRUE(static_cast<size_t>(ur) == 123);
+    ASSERT_TRUE(static_cast<size_t>(ur.get()) == 123);
   }
   ASSERT_EQ(was_deleted, 1);
 }

--- a/src/OrbitBase/include/OrbitBase/UniqueResource.h
+++ b/src/OrbitBase/include/OrbitBase/UniqueResource.h
@@ -59,7 +59,6 @@ class unique_resource {
   void release() noexcept { resource_ = std::nullopt; }
 
   explicit operator bool() const noexcept { return resource_.has_value(); }
-  operator Resource() const { return resource_.value(); }
 
   void reset(Resource resource) {
     RunDeleter();

--- a/src/UserSpaceInstrumentation/AllocateInTracee.cpp
+++ b/src/UserSpaceInstrumentation/AllocateInTracee.cpp
@@ -173,8 +173,10 @@ AllocateInTraceeAsUniqueResource(pid_t pid, uint64_t address, uint64_t size) {
   OUTCOME_TRY(allocated_address, AllocateInTracee(pid, address, size));
   std::function<void(uint64_t)> deleter = [pid, size](uint64_t address) {
     auto result = FreeInTracee(pid, address, size);
-    FAIL_IF(result.has_error(), "Unable to free previously allocated memory in tracee: \"%s\"",
+    if (result.has_error()) {
+      ERROR("Unable to free previously allocated memory in tracee: \"%s\"",
             result.error().message());
+    }
   };
   return orbit_base::unique_resource(allocated_address, deleter);
 }

--- a/src/UserSpaceInstrumentation/AllocateInTracee.h
+++ b/src/UserSpaceInstrumentation/AllocateInTracee.h
@@ -28,7 +28,7 @@ namespace orbit_user_space_instrumentation {
 // Assumes we are already attached to the tracee `pid` e.g. using `AttachAndStopProcess`.
 [[nodiscard]] ErrorMessageOr<void> FreeInTracee(pid_t pid, uint64_t address, uint64_t size);
 
-// Same as `AllocateInTracee` above but wraps the memory in a unique_resource that handle
+// Same as `AllocateInTracee` above but wraps the memory in a unique_resource that handles
 // deallocating the memory. Note that we still need to be attached (or attached again) to the tracee
 // when the unique_resource goes out of scope.
 [[nodiscard]] ErrorMessageOr<orbit_base::unique_resource<uint64_t, std::function<void(uint64_t)>>>

--- a/src/UserSpaceInstrumentation/AllocateInTracee.h
+++ b/src/UserSpaceInstrumentation/AllocateInTracee.h
@@ -8,8 +8,10 @@
 #include <sys/types.h>
 
 #include <cstdint>
+#include <functional>
 
 #include "OrbitBase/Result.h"
+#include "OrbitBase/UniqueResource.h"
 
 namespace orbit_user_space_instrumentation {
 
@@ -25,6 +27,12 @@ namespace orbit_user_space_instrumentation {
 // Free address range previously allocated with AllocateInTracee using munmap.
 // Assumes we are already attached to the tracee `pid` e.g. using `AttachAndStopProcess`.
 [[nodiscard]] ErrorMessageOr<void> FreeInTracee(pid_t pid, uint64_t address, uint64_t size);
+
+// Same as `AllocateInTracee` above but wraps the memory in a unique_resource that handle
+// deallocating the memory. Note that we still need to be attached (or attached again) to the tracee
+// when the unique_resource goes out of scope.
+[[nodiscard]] ErrorMessageOr<orbit_base::unique_resource<uint64_t, std::function<void(uint64_t)>>>
+AllocateInTraceeAsUniqueResource(pid_t pid, uint64_t address, uint64_t size);
 
 }  // namespace orbit_user_space_instrumentation
 

--- a/src/UserSpaceInstrumentation/AllocateInTraceeTest.cpp
+++ b/src/UserSpaceInstrumentation/AllocateInTraceeTest.cpp
@@ -86,6 +86,16 @@ TEST(AllocateInTraceeTest, AllocateAndFree) {
   ASSERT_FALSE(FreeInTracee(pid, address_or_error.value(), kMemorySize).has_error());
   EXPECT_FALSE(ProcessHasRwxMapAtAddress(pid, address_or_error.value()));
 
+  // Allocate as unique resource.
+  uint64_t address = 0;
+  {
+    auto unique_resource_or_error = AllocateInTraceeAsUniqueResource(pid, 0, kMemorySize);
+    ASSERT_TRUE(unique_resource_or_error.has_value());
+    address = unique_resource_or_error.value();
+    EXPECT_TRUE(ProcessHasRwxMapAtAddress(pid, address));
+  }
+  EXPECT_FALSE(ProcessHasRwxMapAtAddress(pid, address));
+
   // Detach and end child.
   CHECK(!DetachAndContinueProcess(pid).has_error());
   kill(pid, SIGKILL);

--- a/src/UserSpaceInstrumentation/AllocateInTraceeTest.cpp
+++ b/src/UserSpaceInstrumentation/AllocateInTraceeTest.cpp
@@ -91,7 +91,7 @@ TEST(AllocateInTraceeTest, AllocateAndFree) {
   {
     auto unique_resource_or_error = AllocateInTraceeAsUniqueResource(pid, 0, kMemorySize);
     ASSERT_TRUE(unique_resource_or_error.has_value());
-    address = unique_resource_or_error.value();
+    address = unique_resource_or_error.value().get();
     EXPECT_TRUE(ProcessHasRwxMapAtAddress(pid, address));
   }
   EXPECT_FALSE(ProcessHasRwxMapAtAddress(pid, address));

--- a/src/UserSpaceInstrumentation/ExecuteInProcess.cpp
+++ b/src/UserSpaceInstrumentation/ExecuteInProcess.cpp
@@ -53,11 +53,9 @@ ErrorMessageOr<uint64_t> ExecuteInProcess(pid_t pid, void* function_address, uin
       .AppendBytes({0xff, 0xd0})
       .AppendBytes({0xcc});
 
-  OUTCOME_TRY(address, AllocateInTracee(pid, 0, kCodeScratchPadSize));
+  OUTCOME_TRY(address, AllocateInTraceeAsUniqueResource(pid, 0, kCodeScratchPadSize));
 
   OUTCOME_TRY(return_value, ExecuteMachineCode(pid, address, code));
-
-  OUTCOME_TRY(FreeInTracee(pid, address, kCodeScratchPadSize));
 
   return return_value;
 }

--- a/src/UserSpaceInstrumentation/ExecuteInProcess.cpp
+++ b/src/UserSpaceInstrumentation/ExecuteInProcess.cpp
@@ -55,7 +55,7 @@ ErrorMessageOr<uint64_t> ExecuteInProcess(pid_t pid, void* function_address, uin
 
   OUTCOME_TRY(address, AllocateInTraceeAsUniqueResource(pid, 0, kCodeScratchPadSize));
 
-  OUTCOME_TRY(return_value, ExecuteMachineCode(pid, address, code));
+  OUTCOME_TRY(return_value, ExecuteMachineCode(pid, address.get(), code));
 
   return return_value;
 }

--- a/src/UserSpaceInstrumentation/ExecuteMachineCode.cpp
+++ b/src/UserSpaceInstrumentation/ExecuteMachineCode.cpp
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include "AccessTraceesMemory.h"
-#include "AllocateInTracee.h"
 #include "OrbitBase/Logging.h"
 #include "RegisterState.h"
 

--- a/src/UserSpaceInstrumentation/ExecuteMachineCodeTest.cpp
+++ b/src/UserSpaceInstrumentation/ExecuteMachineCodeTest.cpp
@@ -33,7 +33,7 @@ TEST(ExecuteMachineCodeTest, ExecuteMachineCode) {
     constexpr uint64_t kScratchPadSize = 1024;
     auto address_or_error = AllocateInTraceeAsUniqueResource(pid, 0, kScratchPadSize);
     CHECK(address_or_error.has_value());
-    const uint64_t address = address_or_error.value();
+    const uint64_t address = address_or_error.value().get();
 
     // This code moves a constant into rax and enters a breakpoint. The value in rax is interpreted
     // as a return value.

--- a/src/UserSpaceInstrumentation/ExecuteMachineCodeTest.cpp
+++ b/src/UserSpaceInstrumentation/ExecuteMachineCodeTest.cpp
@@ -28,24 +28,25 @@ TEST(ExecuteMachineCodeTest, ExecuteMachineCode) {
   // Stop the child process using our tooling.
   CHECK(!AttachAndStopProcess(pid).has_error());
 
-  // Allocate a small chunk of memory.
-  constexpr uint64_t kScratchPadSize = 1024;
-  ErrorMessageOr<uint64_t> address_or_error = AllocateInTracee(pid, 0, kScratchPadSize);
-  CHECK(address_or_error.has_value());
-  const uint64_t address = address_or_error.value();
+  {
+    // Allocate a small chunk of memory.
+    constexpr uint64_t kScratchPadSize = 1024;
+    auto address_or_error = AllocateInTraceeAsUniqueResource(pid, 0, kScratchPadSize);
+    CHECK(address_or_error.has_value());
+    const uint64_t address = address_or_error.value();
 
-  // This code moves a constant into rax and enters a breakpoint. The value in rax is interpreted as
-  // a return value.
-  // movabs rax, 0x4242424242424242     48 b8 0x4242424242424242
-  // int 3                              cc
-  MachineCode code;
-  code.AppendBytes({0x48, 0xb8}).AppendImmediate64(0x4242424242424242).AppendBytes({0xcc});
-  ErrorMessageOr<uint64_t> result_or_error = ExecuteMachineCode(pid, address, code);
-  ASSERT_FALSE(result_or_error.has_error()) << result_or_error.error().message();
-  EXPECT_EQ(0x4242424242424242, result_or_error.value());
+    // This code moves a constant into rax and enters a breakpoint. The value in rax is interpreted
+    // as a return value.
+    // movabs rax, 0x4242424242424242     48 b8 0x4242424242424242
+    // int 3 cc
+    MachineCode code;
+    code.AppendBytes({0x48, 0xb8}).AppendImmediate64(0x4242424242424242).AppendBytes({0xcc});
+    ErrorMessageOr<uint64_t> result_or_error = ExecuteMachineCode(pid, address, code);
+    ASSERT_FALSE(result_or_error.has_error()) << result_or_error.error().message();
+    EXPECT_EQ(0x4242424242424242, result_or_error.value());
+  }
 
   // Cleanup, end child process.
-  CHECK(!FreeInTracee(pid, address, kScratchPadSize).has_error());
   CHECK(!DetachAndContinueProcess(pid).has_error());
   kill(pid, SIGKILL);
   waitpid(pid, NULL, 0);

--- a/src/UserSpaceInstrumentation/InjectLibraryInTracee.cpp
+++ b/src/UserSpaceInstrumentation/InjectLibraryInTracee.cpp
@@ -72,7 +72,7 @@ ErrorMessageOr<uint64_t> FindFunctionAddressWithFallback(pid_t pid, std::string_
   // Write the name of the .so into memory at code_address with offset of kCodeScratchPadSize.
   std::vector<uint8_t> path_as_vector(path_length);
   memcpy(path_as_vector.data(), path.c_str(), path_length);
-  const uint64_t so_path_address = code_address + kCodeScratchPadSize;
+  const uint64_t so_path_address = code_address.get() + kCodeScratchPadSize;
   auto write_memory_result = WriteTraceesMemory(pid, so_path_address, path_as_vector);
   if (write_memory_result.has_error()) {
     return write_memory_result.error();
@@ -100,7 +100,7 @@ ErrorMessageOr<uint64_t> FindFunctionAddressWithFallback(pid_t pid, std::string_
       .AppendBytes({0xff, 0xd0})
       .AppendBytes({0xcc});
 
-  OUTCOME_TRY(return_value, ExecuteMachineCode(pid, code_address, code));
+  OUTCOME_TRY(return_value, ExecuteMachineCode(pid, code_address.get(), code));
 
   return absl::bit_cast<void*>(return_value);
 }
@@ -119,7 +119,7 @@ ErrorMessageOr<uint64_t> FindFunctionAddressWithFallback(pid_t pid, std::string_
   // Write the name of symbol into memory at code_address with offset of kCodeScratchPadSize.
   std::vector<uint8_t> symbol_name_as_vector(symbol_name_length, 0);
   memcpy(symbol_name_as_vector.data(), symbol.data(), symbol.length());
-  const uint64_t symbol_name_address = code_address + kCodeScratchPadSize;
+  const uint64_t symbol_name_address = code_address.get() + kCodeScratchPadSize;
   auto write_memory_result = WriteTraceesMemory(pid, symbol_name_address, symbol_name_as_vector);
   if (write_memory_result.has_error()) {
     return write_memory_result.error();
@@ -147,7 +147,7 @@ ErrorMessageOr<uint64_t> FindFunctionAddressWithFallback(pid_t pid, std::string_
       .AppendBytes({0xff, 0xd0})
       .AppendBytes({0xcc});
 
-  OUTCOME_TRY(return_value, ExecuteMachineCode(pid, code_address, code));
+  OUTCOME_TRY(return_value, ExecuteMachineCode(pid, code_address.get(), code));
 
   return absl::bit_cast<void*>(return_value);
 }
@@ -178,7 +178,7 @@ ErrorMessageOr<uint64_t> FindFunctionAddressWithFallback(pid_t pid, std::string_
       .AppendBytes({0xff, 0xd0})
       .AppendBytes({0xcc});
 
-  auto return_value_or_error = ExecuteMachineCode(pid, code_address, code);
+  auto return_value_or_error = ExecuteMachineCode(pid, code_address.get(), code);
   if (return_value_or_error.has_error()) {
     return return_value_or_error.error();
   }

--- a/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
+++ b/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
@@ -53,26 +53,26 @@ void OpenUseAndCloseLibrary(pid_t pid) {
   ASSERT_TRUE(dlsym_or_error.has_value());
   const uint64_t function_address = absl::bit_cast<uint64_t>(dlsym_or_error.value());
 
-  // Write machine code to call "TrivialFunction" from the dynamic lib.
-  constexpr uint64_t kScratchPadSize = 1024;
-  auto address_or_error = AllocateInTracee(pid, 0, kScratchPadSize);
-  ASSERT_TRUE(address_or_error.has_value());
-  const uint64_t address = address_or_error.value();
-  // Move function's address to rax, do the call, and hit a breakpoint:
-  // movabs rax, function_address     48 b8 function_address
-  // call rax                         ff d0
-  // int3                             cc
-  MachineCode code;
-  code.AppendBytes({0x48, 0xb8})
-      .AppendImmediate64(function_address)
-      .AppendBytes({0xff, 0xd0})
-      .AppendBytes({0xcc});
+  {
+    // Write machine code to call "TrivialFunction" from the dynamic lib.
+    constexpr uint64_t kScratchPadSize = 1024;
+    auto address_or_error = AllocateInTraceeAsUniqueResource(pid, 0, kScratchPadSize);
+    ASSERT_TRUE(address_or_error.has_value());
+    const uint64_t address = address_or_error.value();
+    // Move function's address to rax, do the call, and hit a breakpoint:
+    // movabs rax, function_address     48 b8 function_address
+    // call rax                         ff d0
+    // int3                             cc
+    MachineCode code;
+    code.AppendBytes({0x48, 0xb8})
+        .AppendImmediate64(function_address)
+        .AppendBytes({0xff, 0xd0})
+        .AppendBytes({0xcc});
 
-  auto result_or_error = ExecuteMachineCode(pid, address, code);
-  ASSERT_FALSE(result_or_error.has_error());
-  EXPECT_EQ(42, result_or_error.value());
-
-  ASSERT_FALSE(FreeInTracee(pid, address, kScratchPadSize).has_error());
+    auto result_or_error = ExecuteMachineCode(pid, address, code);
+    ASSERT_FALSE(result_or_error.has_error());
+    EXPECT_EQ(42, result_or_error.value());
+  }
 
   // Close the library.
   auto result_dlclose = DlcloseInTracee(pid, library_handle_or_error.value());

--- a/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
+++ b/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
@@ -58,7 +58,7 @@ void OpenUseAndCloseLibrary(pid_t pid) {
     constexpr uint64_t kScratchPadSize = 1024;
     auto address_or_error = AllocateInTraceeAsUniqueResource(pid, 0, kScratchPadSize);
     ASSERT_TRUE(address_or_error.has_value());
-    const uint64_t address = address_or_error.value();
+    const uint64_t address = address_or_error.value().get();
     // Move function's address to rax, do the call, and hit a breakpoint:
     // movabs rax, function_address     48 b8 function_address
     // call rax                         ff d0


### PR DESCRIPTION
Added method AllocateInTraceeAsUniqueResource returning the memory
address wrapped in a unique_resource. Replaced almost all occurrences of
AllocateInTracee by AllocateInTraceeAsUniqueResource.
The only exception is AllocateMemoryForTrampolines: It is not obvious
yet if it is preferable to automatically free the memory or have this
done manually. Note that the memory for the trampolines stays allocated
after DetachAndContinueProcess.

Bug: http://b/185315205
Test: Unit tests.