### PR TITLE
Fix Pos/Size of FakeTrackTab & FakeTimersPane

### DIFF
--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -33,9 +33,11 @@ class CaptureViewElement : public Pickable {
   void SetCanvas(GlCanvas* canvas) { canvas_ = canvas; }
 
   void SetPos(float x, float y) { pos_ = Vec2(x, y); }
-  [[nodiscard]] Vec2 GetPos() const { return pos_; }
+  // TODO(b/185854980): This should not be virtual as soon as we have meaningful track children.
+  [[nodiscard]] virtual Vec2 GetPos() const { return pos_; }
   void SetSize(float width, float height) { size_ = Vec2(width, height); }
-  [[nodiscard]] Vec2 GetSize() const { return size_; }
+  // TODO(b/185854980): This should not be virtual as soon as we have meaningful track children.
+  [[nodiscard]] virtual Vec2 GetSize() const { return size_; }
 
   // Pickable
   void OnPick(int x, int y) override;


### PR DESCRIPTION
The `FakeTrackTabs`'s width is `layout_->GetTrackTabWidth` rather
than the complete width of the track. This resulted in the e2e
tests not being able to interact with the track tab.

Further, the size/pos was not updated when the actual track changed.

Test: Run affected e2e test locally.