### PR TITLE
Make Track Manager manage their own sorting

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -673,8 +673,6 @@ void OrbitApp::MainTick() {
   GMainTimer.Restart();
 
   if (DoZoom && HasCaptureData()) {
-    // TODO (b/176077097): TrackManager has to manage sorting by their own.
-    GetMutableTimeGraph()->GetTrackManager()->SortTracks();
     capture_window_->ZoomAll();
     RequestUpdatePrimitives();
     DoZoom = false;

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -651,8 +651,6 @@ void TimeGraph::UpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/, ui
   uint64_t min_tick = GetTickFromUs(min_time_us_);
   uint64_t max_tick = GetTickFromUs(max_time_us_);
 
-  track_manager_->SortTracks();
-  track_manager_->UpdateMovingTrackSorting();
   track_manager_->UpdateTracks(&batcher_, min_tick, max_tick, picking_mode);
 
   update_primitives_requested_ = false;

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -47,7 +47,6 @@ class TrackManager {
     return tracepoints_system_wide_track_;
   }
 
-  void SortTracks();
   void RequestTrackSorting() { sorting_invalidated_ = true; };
   void SetFilter(const std::string& filter);
 
@@ -68,16 +67,17 @@ class TrackManager {
 
   void RemoveFrameTrack(uint64_t function_address);
 
-  void UpdateMovingTrackSorting();
 
  private:
-  void UpdateVisibleTrackList();
+  void UpdateTracksOrder();
   [[nodiscard]] int FindMovingTrackIndex();
+  void UpdateMovingTrackSorting();
+  void SortTracks();
   [[nodiscard]] std::vector<ThreadTrack*> GetSortedThreadTracks();
+  void UpdateVisibleTrackList();
 
   void AddTrack(const std::shared_ptr<Track>& track);
   void AddFrameTrack(const std::shared_ptr<FrameTrack>& frame_track);
-  void UpdateTrackPositions();
 
   // TODO(b/174655559): Use absl's mutex here.
   mutable std::recursive_mutex mutex_;


### PR DESCRIPTION
In this refactoring, we move the logic related to sorting the tracks to inside TrackManager.

We created a method (UpdateTracksOrder) to manage all the logic related to the order of the tracks.

http://b/176077097.