### PR TITLE
Tooling for trampolines.

### DIFF
--- a/src/UserSpaceInstrumentation/CMakeLists.txt
+++ b/src/UserSpaceInstrumentation/CMakeLists.txt
@@ -46,7 +46,8 @@ target_sources(UserSpaceInstrumentation PRIVATE
 target_link_libraries(UserSpaceInstrumentation PUBLIC
         LinuxTracing
         OrbitBase
-        CONAN_PKG::abseil)
+        CONAN_PKG::abseil
+        CONAN_PKG::capstone)
 
 # This test lib is merely used in UserSpaceInstrumentationTests below. The
 # binary libUserSpaceInstrumentationTestLib.so created from this target is used
@@ -90,6 +91,7 @@ target_link_libraries(UserSpaceInstrumentationTests PRIVATE
         LinuxTracing
         UserSpaceInstrumentation
         CONAN_PKG::abseil
+        CONAN_PKG::capstone
         GTest::GTest
         GTest::Main)
 

--- a/src/UserSpaceInstrumentation/Trampoline.cpp
+++ b/src/UserSpaceInstrumentation/Trampoline.cpp
@@ -172,8 +172,8 @@ ErrorMessageOr<absl::flat_hash_set<uint64_t>> GetInstructionPointersFromProcess(
   return result;
 }
 
-std::optional<int> LengthOfOverriddenInstructions(csh handle, const std::vector<uint8_t>& code,
-                                                  int bytes_to_override) {
+std::optional<int> LengthOfOverwrittenInstructions(csh handle, const std::vector<uint8_t>& code,
+                                                   int bytes_to_overwrite) {
   cs_insn* instruction = cs_malloc(handle);
   CHECK(instruction != nullptr);
   orbit_base::unique_resource scope_exit{instruction,
@@ -185,11 +185,11 @@ std::optional<int> LengthOfOverriddenInstructions(csh handle, const std::vector<
   int length = 0;
   while (cs_disasm_iter(handle, &code_pointer, &code_size, &address, instruction)) {
     length += instruction->size;
-    if (length >= bytes_to_override) break;
+    if (length >= bytes_to_overwrite) break;
   }
 
   // Function too short?
-  if (length < bytes_to_override) {
+  if (length < bytes_to_overwrite) {
     return std::nullopt;
   }
   return length;

--- a/src/UserSpaceInstrumentation/Trampoline.h
+++ b/src/UserSpaceInstrumentation/Trampoline.h
@@ -62,31 +62,31 @@ namespace orbit_user_space_instrumentation {
 [[nodiscard]] ErrorMessageOr<absl::flat_hash_set<uint64_t>> GetInstructionPointersFromProcess(
     pid_t pid);
 
-// When overriding instructions at the beginning of a function we need to know the number of bytes
+// When overwriting instructions at the beginning of a function we need to know the number of bytes
 // taken up by the instructions we hit with the write operation. Example:
 //
-// Beginning of the code we want to override:
+// Beginning of the code we want to overwrite:
 // 0x5583ba2837a0: push         rbp
 // 0x5583ba2837a1: mov          rbp, rsp
 // 0x5583ba2837a4: sub          rsp, 0x10
 // 0x5583ba2837a8: mov          rax, qword ptr fs:[0x28]
 //
-// We'd like to override from 0x5583ba2837a0 with a jmp which is five bytes long:
+// We'd like to overwrite from 0x5583ba2837a0 with a jmp which is five bytes long:
 // 0x5583ba2837a0: jmp          0x5583ba0bf000
 // 0x5583ba2837a5: (last three bytes of the encoding of `sub rsp, 0x10`)
 //
 // Since the instruction lengths do not align we end up with three bytes of garbage, the next intact
-// instruction starts at 0x5583ba2837a8. So LengthOfOverriddenInstructions would return eight.
+// instruction starts at 0x5583ba2837a8. So LengthOfOverwrittenInstructions would return eight.
 //
-// `handle` is a handle to the capstone library returned by cs_open. `code` contains  the machine
-// code of the function that should be overridden. `bytes_to_override` is the number of bytes to
-// override at the beginning of `code`.
-// The return value is either the number of bytes as described above or unset if there was a problem
-// with the function. That might either be that the function is too short or that we were unable to
-// disassemble enough code to cover `bytes_to_override` bytes.
-[[nodiscard]] std::optional<int> LengthOfOverriddenInstructions(csh handle,
-                                                                const std::vector<uint8_t>& code,
-                                                                int bytes_to_override);
+// `handle` is a handle to the capstone library returned by cs_open. `code` contains the machine
+// code of the function that should be overwritten. `bytes_to_overwrite` is the number of bytes to
+// overwrite at the beginning of `code`.
+// The return value is either the number of bytes as described above or nullopt if there was a
+// problem with the function. That might either be that the function is too short or that we were
+// unable to disassemble enough code to cover `bytes_to_overwrite` bytes.
+[[nodiscard]] std::optional<int> LengthOfOverwrittenInstructions(csh handle,
+                                                                 const std::vector<uint8_t>& code,
+                                                                 int bytes_to_overwrite);
 
 }  // namespace orbit_user_space_instrumentation
 

--- a/src/UserSpaceInstrumentation/Trampoline.h
+++ b/src/UserSpaceInstrumentation/Trampoline.h
@@ -5,6 +5,8 @@
 #ifndef USER_SPACE_INSTRUMENTATION_TRAMPOLINE_H_
 #define USER_SPACE_INSTRUMENTATION_TRAMPOLINE_H_
 
+#include <absl/container/flat_hash_set.h>
+#include <capstone/capstone.h>
 #include <sys/types.h>
 
 #include <cstdint>
@@ -55,6 +57,35 @@ namespace orbit_user_space_instrumentation {
 [[nodiscard]] ErrorMessageOr<uint64_t> AllocateMemoryForTrampolines(pid_t pid,
                                                                     const AddressRange& code_range,
                                                                     uint64_t size);
+
+// Returns the set of the instruction pointers from all the threads of a halted tracee.
+[[nodiscard]] ErrorMessageOr<absl::flat_hash_set<uint64_t>> AllInstructionPointersFromProcess(
+    pid_t pid);
+
+// When overriding instructions at the beginning of a function we need to know the number of bytes
+// taken up by the instructions we hit with the write operation. Example:
+//
+// Beginning of the code we want to override:
+// 0x5583ba2837a0: push         rbp
+// 0x5583ba2837a1: mov          rbp, rsp
+// 0x5583ba2837a4: sub          rsp, 0x10
+// 0x5583ba2837a8: mov          rax, qword ptr fs:[0x28]
+//
+// We'd like to override from 0x5583ba2837a0 with a jmp which is five bytes long:
+// 0x5583ba2837a0: jmp          0x5583ba0bf000
+// 0x5583ba2837a5: XYZ
+//
+// Since the instruction lengths do not align we end up with three bytes of garbage, the next intact
+// instruction starts at 0x5583ba2837a8. So LengthOfOverriddenInstructions would return eight.
+//
+// `handle` is a handle to the capstone library returned by cs_open. `code` contains  the machine
+// code of the function that should be overridden. `bytes_to_override` is the number of bytes to
+// override at the beginning of `code`.
+// The return value is either the number of bytes as described above or unset if the function was
+// too short to be overridden by `bytes_to_override` bytes.
+[[nodiscard]] std::optional<int> LengthOfOverriddenInstructions(csh handle,
+                                                                const std::vector<uint8_t>& code,
+                                                                int bytes_to_override);
 
 }  // namespace orbit_user_space_instrumentation
 

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -257,7 +257,7 @@ TEST(TrampolineTest, AllocateMemoryForTrampolines) {
   waitpid(pid, nullptr, 0);
 }
 
-TEST(TrampolineTest, AllInstructionPointersFromProcess) {
+TEST(TrampolineTest, GetInstructionPointersFromProcess) {
   pid_t pid = fork();
   CHECK(pid != -1);
   if (pid == 0) {
@@ -268,7 +268,7 @@ TEST(TrampolineTest, AllInstructionPointersFromProcess) {
   // Stop the process using our tooling.
   CHECK(AttachAndStopProcess(pid).has_value());
 
-  auto rips_or_error = AllInstructionPointersFromProcess(pid);
+  auto rips_or_error = GetInstructionPointersFromProcess(pid);
   ASSERT_FALSE(rips_or_error.has_error());
   EXPECT_EQ(1, rips_or_error.value().size());
 
@@ -297,6 +297,10 @@ TEST(TrampolineTest, LengthOfOverriddenInstructions) {
 
   const std::vector<uint8_t> kFourNops{0x90, 0x90, 0x90, 0x90};
   result = LengthOfOverriddenInstructions(handle, kFourNops, kBytesToOverride);
+  ASSERT_FALSE(result.has_value());
+
+  const std::vector<uint8_t> kIllegalInstructions{0x06, 0x06, 0x06, 0x06, 0x06, 0x06, 0x06};
+  result = LengthOfOverriddenInstructions(handle, kIllegalInstructions, kBytesToOverride);
   ASSERT_FALSE(result.has_value());
 
   cs_close(&handle);


### PR DESCRIPTION
AllInstructionPointersFromProcess returns the set of the instruction
pointers from all the threads of a halted tracee.

LengthOfOverriddenInstructions returns the number of bytes occupied by
the instructions that got hit when overriding a given number of bytes in
the beginning of a piece of code. (Proper documentation in the header)

Bug: http://b/185933738, http://b/185935100
Test: Unit tests in PR.