### PR TITLE
Ask to Install "clang-format" "pre-commit" Hook on Bootstrab

### DIFF
--- a/bootstrap-orbit.sh
+++ b/bootstrap-orbit.sh
@@ -141,13 +141,14 @@ function install_clang_format_pre_commit_hook {
   echo "source \"contrib/hooks/clang-format-pre-commit.sh\"" >> $PRE_COMMIT_HOOK_FILE
 }
 
-if  [ ! -f $PRE_COMMIT_HOOK_FILE ] || ! grep -q "contrib/hooks/clang-format-pre-commit.sh" .git/hooks/pre-commit ; then
-  while true; do
-    read -p "Do you want to install the clang-format pre-commit hook [y/n]? `echo $'\n> '`" yn
-    case $yn in
-      [Yy]* ) install_clang_format_pre_commit_hook; break;;
-      [Nn]* ) break;;
-    esac
-  done
+if [ -d .git ] ; then
+  if [ ! -f $PRE_COMMIT_HOOK_FILE ] || ! grep -q "contrib/hooks/clang-format-pre-commit.sh" .git/hooks/pre-commit ; then
+    while true; do
+      read -p "Do you want to install the clang-format pre-commit hook [y/n]? `echo $'\n> '`" yn
+      case $yn in
+        [Yy]* ) install_clang_format_pre_commit_hook; break;;
+        [Nn]* ) break;;
+      esac
+    done
+  fi
 fi
-

--- a/bootstrap-orbit.sh
+++ b/bootstrap-orbit.sh
@@ -131,3 +131,23 @@ if [[ $DONT_COMPILE != "yes" ]]; then
   fi
 fi
 
+PRE_COMMIT_HOOK_FILE=.git/hooks/pre-commit
+
+function install_clang_format_pre_commit_hook {
+  if [ ! -f $PRE_COMMIT_HOOK_FILE ] ; then
+    touch $PRE_COMMIT_HOOK_FILE
+    chmod +x $PRE_COMMIT_HOOK_FILE
+  fi
+  echo "source \"contrib/hooks/clang-format-pre-commit.sh\"" >> $PRE_COMMIT_HOOK_FILE
+}
+
+if  [ ! -f $PRE_COMMIT_HOOK_FILE ] || ! grep -q "contrib/hooks/clang-format-pre-commit.sh" .git/hooks/pre-commit ; then
+  while true; do
+    read -p "Do you want to install the clang-format pre-commit hook [y/n]? `echo $'\n> '`" yn
+    case $yn in
+      [Yy]* ) install_clang_format_pre_commit_hook; break;;
+      [Nn]* ) break;;
+    esac
+  done
+fi
+


### PR DESCRIPTION
This will ask the user that runs .bootstrap.sh if the new
clang-format pre-commit hook should be installed to the user's
hooks. It checks if the "pre-commit" script already exits, if not
it will be created. Further, it checks if the hook is already
installed. Only if it is not yet installed, the user will be asked.

Test: Run bootstrap.sh (tmp rename pre-commit file)