### PR TITLE
Two tweaks to CaptureClient::Capture

### DIFF
--- a/src/OrbitCaptureClient/CaptureClient.cpp
+++ b/src/OrbitCaptureClient/CaptureClient.cpp
@@ -67,9 +67,9 @@ Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> CaptureClient::Capture(
     const orbit_client_data::ModuleManager& module_manager,
     absl::flat_hash_map<uint64_t, FunctionInfo> selected_functions,
     TracepointInfoSet selected_tracepoints, double samples_per_second,
-    UnwindingMethod unwinding_method, bool collect_thread_state, bool enable_introspection,
-    uint64_t max_local_marker_depth_per_command_buffer, bool collect_memory_info,
-    uint64_t memory_sampling_period_ns,
+    UnwindingMethod unwinding_method, bool collect_scheduling_info, bool collect_thread_state,
+    bool enable_introspection, uint64_t max_local_marker_depth_per_command_buffer,
+    bool collect_memory_info, uint64_t memory_sampling_period_ns,
     std::unique_ptr<CaptureEventProcessor> capture_event_processor) {
   absl::MutexLock lock(&state_mutex_);
   if (state_ != State::kStopped) {
@@ -81,17 +81,16 @@ Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> CaptureClient::Capture(
   state_ = State::kStarting;
 
   auto capture_result = thread_pool->Schedule(
-      [this, process_id, &module_manager,
-       selected_functions = std::move(selected_functions),
-       selected_tracepoints = std::move(selected_tracepoints), collect_thread_state,
-       samples_per_second, unwinding_method, enable_introspection,
+      [this, process_id, &module_manager, selected_functions = std::move(selected_functions),
+       selected_tracepoints = std::move(selected_tracepoints), collect_scheduling_info,
+       collect_thread_state, samples_per_second, unwinding_method, enable_introspection,
        max_local_marker_depth_per_command_buffer, collect_memory_info, memory_sampling_period_ns,
        capture_event_processor = std::move(capture_event_processor)]() mutable {
         return CaptureSync(process_id, module_manager, selected_functions, selected_tracepoints,
-                           samples_per_second, unwinding_method, collect_thread_state,
-                           enable_introspection, max_local_marker_depth_per_command_buffer,
-                           collect_memory_info, memory_sampling_period_ns,
-                           capture_event_processor.get());
+                           samples_per_second, unwinding_method, collect_scheduling_info,
+                           collect_thread_state, enable_introspection,
+                           max_local_marker_depth_per_command_buffer, collect_memory_info,
+                           memory_sampling_period_ns, capture_event_processor.get());
       });
 
   return capture_result;
@@ -126,9 +125,10 @@ ErrorMessageOr<CaptureListener::CaptureOutcome> CaptureClient::CaptureSync(
     int32_t process_id, const orbit_client_data::ModuleManager& module_manager,
     const absl::flat_hash_map<uint64_t, FunctionInfo>& selected_functions,
     const TracepointInfoSet& selected_tracepoints, double samples_per_second,
-    UnwindingMethod unwinding_method, bool collect_thread_state, bool enable_introspection,
-    uint64_t max_local_marker_depth_per_command_buffer, bool collect_memory_info,
-    uint64_t memory_sampling_period_ns, CaptureEventProcessor* capture_event_processor) {
+    UnwindingMethod unwinding_method, bool collect_scheduling_info, bool collect_thread_state,
+    bool enable_introspection, uint64_t max_local_marker_depth_per_command_buffer,
+    bool collect_memory_info, uint64_t memory_sampling_period_ns,
+    CaptureEventProcessor* capture_event_processor) {
   ORBIT_SCOPE_FUNCTION;
   writes_done_failed_ = false;
   try_abort_ = false;
@@ -142,7 +142,7 @@ ErrorMessageOr<CaptureListener::CaptureOutcome> CaptureClient::CaptureSync(
 
   CaptureRequest request;
   CaptureOptions* capture_options = request.mutable_capture_options();
-  capture_options->set_trace_context_switches(true);
+  capture_options->set_trace_context_switches(collect_scheduling_info);
   capture_options->set_pid(process_id);
   if (samples_per_second == 0) {
     capture_options->set_unwinding_method(CaptureOptions::kUndefined);

--- a/src/OrbitCaptureClient/CaptureClient.cpp
+++ b/src/OrbitCaptureClient/CaptureClient.cpp
@@ -63,7 +63,7 @@ InstrumentedFunction::FunctionType CaptureClient::InstrumentedFunctionTypeFromOr
 
 // TODO(vickyliu): This method contains a lot of arguments. Consider making it more structured.
 Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> CaptureClient::Capture(
-    ThreadPool* thread_pool, const ProcessData& process,
+    ThreadPool* thread_pool, int32_t process_id,
     const orbit_client_data::ModuleManager& module_manager,
     absl::flat_hash_map<uint64_t, FunctionInfo> selected_functions,
     TracepointInfoSet selected_tracepoints, double samples_per_second,
@@ -81,7 +81,7 @@ Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> CaptureClient::Capture(
   state_ = State::kStarting;
 
   auto capture_result = thread_pool->Schedule(
-      [this, process_id = process.pid(), &module_manager,
+      [this, process_id, &module_manager,
        selected_functions = std::move(selected_functions),
        selected_tracepoints = std::move(selected_tracepoints), collect_thread_state,
        samples_per_second, unwinding_method, enable_introspection,

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
@@ -41,9 +41,10 @@ class CaptureClient {
       const orbit_client_data::ModuleManager& module_manager,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints, double samples_per_second,
-      orbit_grpc_protos::UnwindingMethod unwinding_method, bool collect_thread_state,
-      bool enable_introspection, uint64_t max_local_marker_depth_per_command_buffer,
-      bool collect_memory_info, uint64_t memory_sampling_period_ns,
+      orbit_grpc_protos::UnwindingMethod unwinding_method, bool collect_scheduling_info,
+      bool collect_thread_state, bool enable_introspection,
+      uint64_t max_local_marker_depth_per_command_buffer, bool collect_memory_info,
+      uint64_t memory_sampling_period_ns,
       std::unique_ptr<CaptureEventProcessor> capture_event_processor);
 
   // Returns true if stop was initiated and false otherwise.
@@ -74,10 +75,10 @@ class CaptureClient {
       int32_t process_id, const orbit_client_data::ModuleManager& module_manager,
       const absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>& selected_functions,
       const TracepointInfoSet& selected_tracepoints, double samples_per_second,
-      orbit_grpc_protos::UnwindingMethod unwinding_method, bool collect_thread_state,
-      bool enable_introspection, uint64_t max_local_marker_depth_per_command_buffer,
-      bool collect_memory_info, uint64_t memory_sampling_period_ns,
-      CaptureEventProcessor* capture_event_processor);
+      orbit_grpc_protos::UnwindingMethod unwinding_method, bool collect_scheduling_info,
+      bool collect_thread_state, bool enable_introspection,
+      uint64_t max_local_marker_depth_per_command_buffer, bool collect_memory_info,
+      uint64_t memory_sampling_period_ns, CaptureEventProcessor* capture_event_processor);
 
   [[nodiscard]] ErrorMessageOr<void> FinishCapture();
 

--- a/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
+++ b/src/OrbitCaptureClient/include/OrbitCaptureClient/CaptureClient.h
@@ -37,7 +37,7 @@ class CaptureClient {
       : capture_service_{orbit_grpc_protos::CaptureService::NewStub(channel)} {}
 
   orbit_base::Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> Capture(
-      ThreadPool* thread_pool, const ProcessData& process,
+      ThreadPool* thread_pool, int32_t process_id,
       const orbit_client_data::ModuleManager& module_manager,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints, double samples_per_second,

--- a/src/OrbitClientGgp/ClientGgp.cpp
+++ b/src/OrbitClientGgp/ClientGgp.cpp
@@ -98,6 +98,7 @@ bool ClientGgp::RequestStartCapture(ThreadPool* thread_pool) {
 
   LOG("Capture pid %d", pid);
   TracepointInfoSet selected_tracepoints;
+  bool collect_scheduling_info = true;
   bool collect_thread_state = absl::GetFlag(FLAGS_thread_state);
   uint64_t max_local_marker_depth_per_command_buffer =
       absl::GetFlag(FLAGS_max_local_marker_depth_per_command_buffer);
@@ -107,10 +108,10 @@ bool ClientGgp::RequestStartCapture(ThreadPool* thread_pool) {
                                          : UnwindingMethod::kDwarfUnwinding;
 
   Future<ErrorMessageOr<CaptureOutcome>> result = capture_client_->Capture(
-      thread_pool, target_process_->pid(), module_manager_, selected_functions_, selected_tracepoints,
-      options_.samples_per_second, unwinding_method, collect_thread_state, enable_introspection,
-      max_local_marker_depth_per_command_buffer, false, 0,
-      CaptureEventProcessor::CreateForCaptureListener(this, absl::flat_hash_set<uint64_t>{}));
+      thread_pool, target_process_->pid(), module_manager_, selected_functions_,
+      selected_tracepoints, options_.samples_per_second, unwinding_method, collect_scheduling_info,
+      collect_thread_state, enable_introspection, max_local_marker_depth_per_command_buffer, false,
+      0, CaptureEventProcessor::CreateForCaptureListener(this, absl::flat_hash_set<uint64_t>{}));
 
   orbit_base::ImmediateExecutor executor;
   result.Then(&executor, [this](ErrorMessageOr<CaptureOutcome> result) {

--- a/src/OrbitClientGgp/ClientGgp.cpp
+++ b/src/OrbitClientGgp/ClientGgp.cpp
@@ -107,7 +107,7 @@ bool ClientGgp::RequestStartCapture(ThreadPool* thread_pool) {
                                          : UnwindingMethod::kDwarfUnwinding;
 
   Future<ErrorMessageOr<CaptureOutcome>> result = capture_client_->Capture(
-      thread_pool, *target_process_, module_manager_, selected_functions_, selected_tracepoints,
+      thread_pool, target_process_->pid(), module_manager_, selected_functions_, selected_tracepoints,
       options_.samples_per_second, unwinding_method, collect_thread_state, enable_introspection,
       max_local_marker_depth_per_command_buffer, false, 0,
       CaptureEventProcessor::CreateForCaptureListener(this, absl::flat_hash_set<uint64_t>{}));

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1016,6 +1016,7 @@ void OrbitApp::StartCapture() {
   }
 
   TracepointInfoSet selected_tracepoints = data_manager_->selected_tracepoints();
+  bool collect_scheduling_info = true;
   bool collect_thread_states = data_manager_->collect_thread_states();
   bool enable_introspection = absl::GetFlag(FLAGS_devmode);
   double samples_per_second = data_manager_->samples_per_second();
@@ -1033,9 +1034,10 @@ void OrbitApp::StartCapture() {
 
   Future<ErrorMessageOr<CaptureOutcome>> capture_result = capture_client_->Capture(
       thread_pool_.get(), process->pid(), *module_manager_, std::move(selected_functions_map),
-      std::move(selected_tracepoints), samples_per_second, unwinding_method, collect_thread_states,
-      enable_introspection, max_local_marker_depth_per_command_buffer, collect_memory_info,
-      memory_sampling_period_ns, std::move(capture_event_processor));
+      std::move(selected_tracepoints), samples_per_second, unwinding_method,
+      collect_scheduling_info, collect_thread_states, enable_introspection,
+      max_local_marker_depth_per_command_buffer, collect_memory_info, memory_sampling_period_ns,
+      std::move(capture_event_processor));
 
   capture_result.Then(main_thread_executor_, [this](ErrorMessageOr<CaptureOutcome> capture_result) {
     if (capture_result.has_error()) {

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1032,7 +1032,7 @@ void OrbitApp::StartCapture() {
       CaptureEventProcessor::CreateForCaptureListener(this, std::move(frame_track_function_ids));
 
   Future<ErrorMessageOr<CaptureOutcome>> capture_result = capture_client_->Capture(
-      thread_pool_.get(), *process, *module_manager_, std::move(selected_functions_map),
+      thread_pool_.get(), process->pid(), *module_manager_, std::move(selected_functions_map),
       std::move(selected_tracepoints), samples_per_second, unwinding_method, collect_thread_states,
       enable_introspection, max_local_marker_depth_per_command_buffer, collect_memory_info,
       memory_sampling_period_ns, std::move(capture_event_processor));


### PR DESCRIPTION
#### Pass process_id instead of process to CaptureClient::Capture
For simplicity reasons, as the methods only needs the pid.

Test: Take a simple capture with Trata and verify that the capture is as
expected.
#### Add collect_scheduling_info parameter to CaptureClient::Capture
So that `CaptureClient` can be used with scheduling information collection off.
I will need it for performance testing of OrbitService in different
configurations.

Test: Capture Trata and verify that the capture still looks in order.