### PR TITLE
Switch to new c-ares package

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -77,8 +77,8 @@ class OrbitConan(ConanFile):
         self.requires("abseil/20200923.3")
         self.requires("bzip2/1.0.8@conan/stable#0")
         self.requires("capstone/4.0.1@{}#0".format(self._orbit_channel))
-        self.requires(
-            "grpc/1.27.3@{}".format(self._orbit_channel))
+        self.requires("grpc/1.27.3@{}".format(self._orbit_channel))
+        self.requires("c-ares/1.15.0")
         self.requires("llvm_object/9.0.1-3@orbitdeps/stable")
         self.requires("llvm_symbolize/9.0.1-3@orbitdeps/stable")
         self.requires("lzma_sdk/19.00@orbitdeps/stable#a7bc173325d7463a0757dee5b08bf7fd")

--- a/third_party/conan/lockfiles/base.lock
+++ b/third_party/conan/lockfiles/base.lock
@@ -8,6 +8,7 @@
      "2",
      "3",
      "4",
+     "8",
      "9",
      "23",
      "26",
@@ -76,7 +77,7 @@
     "context": "host"
    },
    "8": {
-    "ref": "c-ares/1.15.0@conan/stable#0",
+    "ref": "c-ares/1.15.0#c527ace6e98705612ec5ee943c6c0bf7",
     "context": "host"
    },
    "9": {


### PR DESCRIPTION
The old package does not exist anymore, so this change overrides
it in the conanfile.