### PR TITLE
Move UserDefinedCaptureInfo message to a separate file

### DIFF
--- a/src/ClientProtos/CMakeLists.txt
+++ b/src/ClientProtos/CMakeLists.txt
@@ -10,7 +10,8 @@ add_library(ClientProtos STATIC)
 
 protobuf_generate(TARGET ClientProtos PROTOS
         capture_data.proto
-        preset.proto)
+        preset.proto
+        user_defined_capture_info.proto)
 
 target_include_directories(ClientProtos PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/src/ClientProtos/capture_data.proto
+++ b/src/ClientProtos/capture_data.proto
@@ -4,6 +4,8 @@
 
 syntax = "proto3";
 
+import "user_defined_capture_info.proto";
+
 package orbit_client_protos;
 
 message FunctionStats {
@@ -108,15 +110,6 @@ message LinuxAddressInfo {
 
 message CaptureHeader {
   string version = 1;
-}
-
-message FrameTracksInfo {
-  reserved 1;
-  repeated uint64 frame_track_function_ids = 2;
-}
-
-message UserDefinedCaptureInfo {
-  FrameTracksInfo frame_tracks_info = 1;
 }
 
 message CaptureInfo {

--- a/src/ClientProtos/user_defined_capture_info.proto
+++ b/src/ClientProtos/user_defined_capture_info.proto
@@ -1,0 +1,16 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+syntax = "proto3";
+
+package orbit_client_protos;
+
+message FrameTracksInfo {
+  reserved 1;
+  repeated uint64 frame_track_function_ids = 2;
+}
+
+message UserDefinedCaptureInfo {
+  FrameTracksInfo frame_tracks_info = 1;
+}


### PR DESCRIPTION
We are going to reuse it in new capture format.

Test: load previously saved capture.