### PR TITLE
Fix CMake dev warning in iwyu.cmake

### DIFF
--- a/cmake/iwyu.cmake
+++ b/cmake/iwyu.cmake
@@ -17,7 +17,7 @@ if(NOT WIN32)
     # Create a custom version of compile_commands.json which does not include any compilation units from third_party
     # or any generated cpp-files. This will be used by include-what-you-use.
     add_custom_command(OUTPUT iwyu_commands.json
-      COMMAND jq 'map(select(.file | test(\"third_party|/build_|/build/\") != true))' > iwyu_commands.json < compile_commands.json
+      COMMAND jq 'map(select(.file | test(\"third_party|/build_|/build/\") != true)) ' > iwyu_commands.json < compile_commands.json
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     )
 


### PR DESCRIPTION
This gets rid of the following CMake warning that I was always getting in CLion:

```
CMake Warning (dev) at cmake/iwyu.cmake:20:
  Syntax Warning in cmake code at column 85

  Argument not separated from preceding token by whitespace.
Call Stack (most recent call first):
  CMakeLists.txt:119 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

Test: Run IWYU before and after and see that the resulting `iwyu.diff`s are
identical.