### PR TITLE
Add and expose enable_api and enable_introspection capture options

### DIFF
--- a/src/CaptureClient/CaptureClient.cpp
+++ b/src/CaptureClient/CaptureClient.cpp
@@ -70,7 +70,7 @@ Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> CaptureClient::Capture(
     absl::flat_hash_map<uint64_t, FunctionInfo> selected_functions,
     TracepointInfoSet selected_tracepoints, double samples_per_second,
     UnwindingMethod unwinding_method, bool collect_scheduling_info, bool collect_thread_state,
-    bool enable_introspection, bool enable_api, uint64_t max_local_marker_depth_per_command_buffer,
+    bool enable_api, bool enable_introspection, uint64_t max_local_marker_depth_per_command_buffer,
     bool collect_memory_info, uint64_t memory_sampling_period_ns,
     std::unique_ptr<CaptureEventProcessor> capture_event_processor) {
   absl::MutexLock lock(&state_mutex_);
@@ -85,12 +85,12 @@ Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> CaptureClient::Capture(
   auto capture_result = thread_pool->Schedule(
       [this, process_id, &module_manager, selected_functions = std::move(selected_functions),
        selected_tracepoints = std::move(selected_tracepoints), collect_scheduling_info,
-       collect_thread_state, samples_per_second, unwinding_method, enable_introspection, enable_api,
+       collect_thread_state, samples_per_second, unwinding_method, enable_api, enable_introspection,
        max_local_marker_depth_per_command_buffer, collect_memory_info, memory_sampling_period_ns,
        capture_event_processor = std::move(capture_event_processor)]() mutable {
         return CaptureSync(process_id, module_manager, selected_functions, selected_tracepoints,
                            samples_per_second, unwinding_method, collect_scheduling_info,
-                           collect_thread_state, enable_introspection, enable_api,
+                           collect_thread_state, enable_api, enable_introspection,
                            max_local_marker_depth_per_command_buffer, collect_memory_info,
                            memory_sampling_period_ns, capture_event_processor.get());
       });
@@ -128,7 +128,7 @@ ErrorMessageOr<CaptureListener::CaptureOutcome> CaptureClient::CaptureSync(
     const absl::flat_hash_map<uint64_t, FunctionInfo>& selected_functions,
     const TracepointInfoSet& selected_tracepoints, double samples_per_second,
     UnwindingMethod unwinding_method, bool collect_scheduling_info, bool collect_thread_state,
-    bool enable_introspection, bool enable_api, uint64_t max_local_marker_depth_per_command_buffer,
+    bool enable_api, bool enable_introspection, uint64_t max_local_marker_depth_per_command_buffer,
     bool collect_memory_info, uint64_t memory_sampling_period_ns,
     CaptureEventProcessor* capture_event_processor) {
   ORBIT_SCOPE_FUNCTION;
@@ -186,8 +186,8 @@ ErrorMessageOr<CaptureListener::CaptureOutcome> CaptureClient::CaptureSync(
     instrumented_tracepoint->set_name(tracepoint.name());
   }
 
-  capture_options->set_enable_introspection(enable_introspection);
   capture_options->set_enable_api(enable_api);
+  capture_options->set_enable_introspection(enable_introspection);
 
   auto api_functions = FindApiFunctions(module_manager);
   *(capture_options->mutable_api_functions()) = {api_functions.begin(), api_functions.end()};

--- a/src/CaptureClient/CaptureClient.cpp
+++ b/src/CaptureClient/CaptureClient.cpp
@@ -70,7 +70,7 @@ Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> CaptureClient::Capture(
     absl::flat_hash_map<uint64_t, FunctionInfo> selected_functions,
     TracepointInfoSet selected_tracepoints, double samples_per_second,
     UnwindingMethod unwinding_method, bool collect_scheduling_info, bool collect_thread_state,
-    bool enable_introspection, uint64_t max_local_marker_depth_per_command_buffer,
+    bool enable_introspection, bool enable_api, uint64_t max_local_marker_depth_per_command_buffer,
     bool collect_memory_info, uint64_t memory_sampling_period_ns,
     std::unique_ptr<CaptureEventProcessor> capture_event_processor) {
   absl::MutexLock lock(&state_mutex_);
@@ -85,12 +85,12 @@ Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> CaptureClient::Capture(
   auto capture_result = thread_pool->Schedule(
       [this, process_id, &module_manager, selected_functions = std::move(selected_functions),
        selected_tracepoints = std::move(selected_tracepoints), collect_scheduling_info,
-       collect_thread_state, samples_per_second, unwinding_method, enable_introspection,
+       collect_thread_state, samples_per_second, unwinding_method, enable_introspection, enable_api,
        max_local_marker_depth_per_command_buffer, collect_memory_info, memory_sampling_period_ns,
        capture_event_processor = std::move(capture_event_processor)]() mutable {
         return CaptureSync(process_id, module_manager, selected_functions, selected_tracepoints,
                            samples_per_second, unwinding_method, collect_scheduling_info,
-                           collect_thread_state, enable_introspection,
+                           collect_thread_state, enable_introspection, enable_api,
                            max_local_marker_depth_per_command_buffer, collect_memory_info,
                            memory_sampling_period_ns, capture_event_processor.get());
       });
@@ -128,7 +128,7 @@ ErrorMessageOr<CaptureListener::CaptureOutcome> CaptureClient::CaptureSync(
     const absl::flat_hash_map<uint64_t, FunctionInfo>& selected_functions,
     const TracepointInfoSet& selected_tracepoints, double samples_per_second,
     UnwindingMethod unwinding_method, bool collect_scheduling_info, bool collect_thread_state,
-    bool enable_introspection, uint64_t max_local_marker_depth_per_command_buffer,
+    bool enable_introspection, bool enable_api, uint64_t max_local_marker_depth_per_command_buffer,
     bool collect_memory_info, uint64_t memory_sampling_period_ns,
     CaptureEventProcessor* capture_event_processor) {
   ORBIT_SCOPE_FUNCTION;
@@ -187,6 +187,7 @@ ErrorMessageOr<CaptureListener::CaptureOutcome> CaptureClient::CaptureSync(
   }
 
   capture_options->set_enable_introspection(enable_introspection);
+  capture_options->set_enable_api(enable_api);
 
   auto api_functions = FindApiFunctions(module_manager);
   *(capture_options->mutable_api_functions()) = {api_functions.begin(), api_functions.end()};

--- a/src/CaptureClient/include/CaptureClient/CaptureClient.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureClient.h
@@ -78,7 +78,7 @@ class CaptureClient {
       const absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>& selected_functions,
       const TracepointInfoSet& selected_tracepoints, double samples_per_second,
       orbit_grpc_protos::UnwindingMethod unwinding_method, bool collect_scheduling_info,
-      bool collect_thread_state, bool enable_introspection, bool enable_api,
+      bool collect_thread_state, bool enable_api, bool enable_introspection,
       uint64_t max_local_marker_depth_per_command_buffer, bool collect_memory_info,
       uint64_t memory_sampling_period_ns, CaptureEventProcessor* capture_event_processor);
 

--- a/src/CaptureClient/include/CaptureClient/CaptureClient.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureClient.h
@@ -44,7 +44,7 @@ class CaptureClient {
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints, double samples_per_second,
       orbit_grpc_protos::UnwindingMethod unwinding_method, bool collect_scheduling_info,
-      bool collect_thread_state, bool enable_introspection, bool enable_api,
+      bool collect_thread_state, bool enable_api, bool enable_introspection,
       uint64_t max_local_marker_depth_per_command_buffer, bool collect_memory_info,
       uint64_t memory_sampling_period_ns,
       std::unique_ptr<CaptureEventProcessor> capture_event_processor);

--- a/src/CaptureClient/include/CaptureClient/CaptureClient.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureClient.h
@@ -44,7 +44,7 @@ class CaptureClient {
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints, double samples_per_second,
       orbit_grpc_protos::UnwindingMethod unwinding_method, bool collect_scheduling_info,
-      bool collect_thread_state, bool enable_introspection,
+      bool collect_thread_state, bool enable_introspection, bool enable_api,
       uint64_t max_local_marker_depth_per_command_buffer, bool collect_memory_info,
       uint64_t memory_sampling_period_ns,
       std::unique_ptr<CaptureEventProcessor> capture_event_processor);
@@ -78,7 +78,7 @@ class CaptureClient {
       const absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>& selected_functions,
       const TracepointInfoSet& selected_tracepoints, double samples_per_second,
       orbit_grpc_protos::UnwindingMethod unwinding_method, bool collect_scheduling_info,
-      bool collect_thread_state, bool enable_introspection,
+      bool collect_thread_state, bool enable_introspection, bool enable_api,
       uint64_t max_local_marker_depth_per_command_buffer, bool collect_memory_info,
       uint64_t memory_sampling_period_ns, CaptureEventProcessor* capture_event_processor);
 

--- a/src/FakeClient/FakeClientMain.cpp
+++ b/src/FakeClient/FakeClientMain.cpp
@@ -115,7 +115,7 @@ int main(int argc, char* argv[]) {
       thread_pool.get(), process_id, module_manager,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>{}, TracepointInfoSet{},
       samples_per_second, unwinding_method, collect_scheduling_info, collect_thread_state,
-      /*enable_introspection=*/false,
+      /*enable_introspection=*/false, /*enable_api=*/false,
       /*max_local_marker_depth_per_command_buffer=*/0, collect_memory_info,
       memory_sampling_period_ns, std::move(capture_event_processor));
   LOG("Asked to start capture");

--- a/src/FakeClient/FakeClientMain.cpp
+++ b/src/FakeClient/FakeClientMain.cpp
@@ -115,7 +115,7 @@ int main(int argc, char* argv[]) {
       thread_pool.get(), process_id, module_manager,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>{}, TracepointInfoSet{},
       samples_per_second, unwinding_method, collect_scheduling_info, collect_thread_state,
-      /*enable_introspection=*/false, /*enable_api=*/false,
+      /*enable_api=*/false, /*enable_introspection=*/false,
       /*max_local_marker_depth_per_command_buffer=*/0, collect_memory_info,
       memory_sampling_period_ns, std::move(capture_event_processor));
   LOG("Asked to start capture");

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -67,6 +67,8 @@ message CaptureOptions {
   uint64 memory_sampling_period_ns = 12;
 
   repeated ApiFunction api_functions = 13;
+
+  bool enable_api = 14;
 }
 
 // For CaptureEvents with a duration, excluding for now GPU-related ones, we

--- a/src/OrbitClientGgp/ClientGgp.cpp
+++ b/src/OrbitClientGgp/ClientGgp.cpp
@@ -105,8 +105,8 @@ bool ClientGgp::RequestStartCapture(ThreadPool* thread_pool) {
   bool collect_thread_state = absl::GetFlag(FLAGS_thread_state);
   uint64_t max_local_marker_depth_per_command_buffer =
       absl::GetFlag(FLAGS_max_local_marker_depth_per_command_buffer);
-  bool enable_introspection = false;
   bool enable_api = false;
+  bool enable_introspection = false;
   UnwindingMethod unwinding_method = options_.use_framepointer_unwinding
                                          ? UnwindingMethod::kFramePointerUnwinding
                                          : UnwindingMethod::kDwarfUnwinding;
@@ -114,7 +114,7 @@ bool ClientGgp::RequestStartCapture(ThreadPool* thread_pool) {
   Future<ErrorMessageOr<CaptureOutcome>> result = capture_client_->Capture(
       thread_pool, target_process_->pid(), module_manager_, selected_functions_,
       selected_tracepoints, options_.samples_per_second, unwinding_method, collect_scheduling_info,
-      collect_thread_state, enable_introspection, enable_api,
+      collect_thread_state, enable_api, enable_introspection,
       max_local_marker_depth_per_command_buffer, false, 0,
       CaptureEventProcessor::CreateForCaptureListener(this, absl::flat_hash_set<uint64_t>{}));
 

--- a/src/OrbitClientGgp/ClientGgp.cpp
+++ b/src/OrbitClientGgp/ClientGgp.cpp
@@ -106,6 +106,7 @@ bool ClientGgp::RequestStartCapture(ThreadPool* thread_pool) {
   uint64_t max_local_marker_depth_per_command_buffer =
       absl::GetFlag(FLAGS_max_local_marker_depth_per_command_buffer);
   bool enable_introspection = false;
+  bool enable_api = false;
   UnwindingMethod unwinding_method = options_.use_framepointer_unwinding
                                          ? UnwindingMethod::kFramePointerUnwinding
                                          : UnwindingMethod::kDwarfUnwinding;
@@ -113,8 +114,9 @@ bool ClientGgp::RequestStartCapture(ThreadPool* thread_pool) {
   Future<ErrorMessageOr<CaptureOutcome>> result = capture_client_->Capture(
       thread_pool, target_process_->pid(), module_manager_, selected_functions_,
       selected_tracepoints, options_.samples_per_second, unwinding_method, collect_scheduling_info,
-      collect_thread_state, enable_introspection, max_local_marker_depth_per_command_buffer, false,
-      0, CaptureEventProcessor::CreateForCaptureListener(this, absl::flat_hash_set<uint64_t>{}));
+      collect_thread_state, enable_introspection, enable_api,
+      max_local_marker_depth_per_command_buffer, false, 0,
+      CaptureEventProcessor::CreateForCaptureListener(this, absl::flat_hash_set<uint64_t>{}));
 
   orbit_base::ImmediateExecutor executor;
   result.Then(&executor, [this](ErrorMessageOr<CaptureOutcome> result) {

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1027,6 +1027,7 @@ void OrbitApp::StartCapture() {
   bool collect_scheduling_info = true;
   bool collect_thread_states = data_manager_->collect_thread_states();
   bool enable_introspection = IsDevMode();
+  bool enable_api = true;
   double samples_per_second = data_manager_->samples_per_second();
   UnwindingMethod unwinding_method = data_manager_->unwinding_method();
   uint64_t max_local_marker_depth_per_command_buffer =
@@ -1043,7 +1044,7 @@ void OrbitApp::StartCapture() {
   Future<ErrorMessageOr<CaptureOutcome>> capture_result = capture_client_->Capture(
       thread_pool_.get(), process->pid(), *module_manager_, std::move(selected_functions_map),
       std::move(selected_tracepoints), samples_per_second, unwinding_method,
-      collect_scheduling_info, collect_thread_states, enable_introspection,
+      collect_scheduling_info, collect_thread_states, enable_introspection, enable_api,
       max_local_marker_depth_per_command_buffer, collect_memory_info, memory_sampling_period_ns,
       std::move(capture_event_processor));
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1026,8 +1026,8 @@ void OrbitApp::StartCapture() {
   TracepointInfoSet selected_tracepoints = data_manager_->selected_tracepoints();
   bool collect_scheduling_info = true;
   bool collect_thread_states = data_manager_->collect_thread_states();
-  bool enable_introspection = IsDevMode();
-  bool enable_api = true;
+  bool enable_api = data_manager_->get_enable_api();
+  bool enable_introspection = data_manager_->get_enable_introspection();
   double samples_per_second = data_manager_->samples_per_second();
   UnwindingMethod unwinding_method = data_manager_->unwinding_method();
   uint64_t max_local_marker_depth_per_command_buffer =
@@ -1044,7 +1044,7 @@ void OrbitApp::StartCapture() {
   Future<ErrorMessageOr<CaptureOutcome>> capture_result = capture_client_->Capture(
       thread_pool_.get(), process->pid(), *module_manager_, std::move(selected_functions_map),
       std::move(selected_tracepoints), samples_per_second, unwinding_method,
-      collect_scheduling_info, collect_thread_states, enable_introspection, enable_api,
+      collect_scheduling_info, collect_thread_states, enable_api, enable_introspection,
       max_local_marker_depth_per_command_buffer, collect_memory_info, memory_sampling_period_ns,
       std::move(capture_event_processor));
 
@@ -1713,6 +1713,12 @@ orbit_base::Future<std::vector<ErrorMessageOr<void>>> OrbitApp::ReloadModules(
 
 void OrbitApp::SetCollectThreadStates(bool collect_thread_states) {
   data_manager_->set_collect_thread_states(collect_thread_states);
+}
+
+void OrbitApp::SetEnableApi(bool enable_api) { data_manager_->set_enable_api(enable_api); }
+
+void OrbitApp::SetEnableIntrospection(bool enable_introspection) {
+  data_manager_->set_enable_introspection(enable_introspection);
 }
 
 void OrbitApp::SetSamplesPerSecond(double samples_per_second) {

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1027,7 +1027,7 @@ void OrbitApp::StartCapture() {
   bool collect_scheduling_info = true;
   bool collect_thread_states = data_manager_->collect_thread_states();
   bool enable_api = data_manager_->get_enable_api();
-  bool enable_introspection = data_manager_->get_enable_introspection();
+  bool enable_introspection = IsDevMode() && data_manager_->get_enable_introspection();
   double samples_per_second = data_manager_->samples_per_second();
   UnwindingMethod unwinding_method = data_manager_->unwinding_method();
   uint64_t max_local_marker_depth_per_command_buffer =

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -371,6 +371,8 @@ class OrbitApp final : public DataViewFactory, public orbit_capture_client::Capt
   }
 
   void SetCollectThreadStates(bool collect_thread_states);
+  void SetEnableApi(bool enable_api);
+  void SetEnableIntrospection(bool enable_introspection);
   void SetSamplesPerSecond(double samples_per_second);
   void SetUnwindingMethod(orbit_grpc_protos::UnwindingMethod unwinding_method);
   void SetMaxLocalMarkerDepthPerCommandBuffer(uint64_t max_local_marker_depth_per_command_buffer);

--- a/src/OrbitGl/DataManager.h
+++ b/src/OrbitGl/DataManager.h
@@ -72,6 +72,14 @@ class DataManager final {
   }
   [[nodiscard]] bool collect_thread_states() const { return collect_thread_states_; }
 
+  void set_enable_api(bool enable_api) { enable_api_ = enable_api; }
+  [[nodiscard]] bool get_enable_api() const { return enable_api_; }
+
+  void set_enable_introspection(bool enable_introspection) {
+    enable_introspection_ = enable_introspection;
+  }
+  [[nodiscard]] bool get_enable_introspection() const { return enable_introspection_; }
+
   void set_samples_per_second(double samples_per_second) {
     samples_per_second_ = samples_per_second;
   }
@@ -124,6 +132,8 @@ class DataManager final {
   UserDefinedCaptureData user_defined_capture_data_;
 
   bool collect_thread_states_ = false;
+  bool enable_api_ = false;
+  bool enable_introspection_ = false;
   uint64_t max_local_marker_depth_per_command_buffer_ = std::numeric_limits<uint64_t>::max();
   double samples_per_second_ = 0;
   orbit_grpc_protos::UnwindingMethod unwinding_method_{};

--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -17,6 +17,7 @@
 #include "SourcePathsMapping/MappingManager.h"
 #include "ui_CaptureOptionsDialog.h"
 
+ABSL_DECLARE_FLAG(bool, devmode);
 ABSL_DECLARE_FLAG(bool, enable_warning_threshold);
 
 namespace orbit_qt {
@@ -38,6 +39,10 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
   if (!absl::GetFlag(FLAGS_enable_warning_threshold)) {
     ui_->memoryWarningThresholdKbLabel->hide();
     ui_->memoryWarningThresholdKbLineEdit->hide();
+  }
+
+  if (!absl::GetFlag(FLAGS_devmode)) {
+    ui_->introspectionCheckBox->hide();
   }
 }
 

--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -49,6 +49,20 @@ void CaptureOptionsDialog::SetCollectThreadStates(bool collect_thread_state) {
   ui_->threadStateCheckBox->setChecked(collect_thread_state);
 }
 
+void CaptureOptionsDialog::SetEnableApi(bool enable_api) {
+  ui_->apiCheckBox->setChecked(enable_api);
+}
+
+bool CaptureOptionsDialog::GetEnableApi() const { return ui_->apiCheckBox->isChecked(); }
+
+void CaptureOptionsDialog::SetEnableIntrospection(bool enable_introspection) {
+  ui_->introspectionCheckBox->setChecked(enable_introspection);
+}
+
+bool CaptureOptionsDialog::GetEnableIntrospection() const {
+  return ui_->introspectionCheckBox->isChecked();
+}
+
 void CaptureOptionsDialog::SetLimitLocalMarkerDepthPerCommandBuffer(
     bool limit_local_marker_depth_per_command_buffer) {
   ui_->localMarkerDepthCheckBox->setChecked(limit_local_marker_depth_per_command_buffer);

--- a/src/OrbitQt/CaptureOptionsDialog.h
+++ b/src/OrbitQt/CaptureOptionsDialog.h
@@ -46,6 +46,10 @@ class CaptureOptionsDialog : public QDialog {
 
   void SetCollectThreadStates(bool collect_thread_state);
   [[nodiscard]] bool GetCollectThreadStates() const;
+  void SetEnableApi(bool enable_api);
+  [[nodiscard]] bool GetEnableApi() const;
+  void SetEnableIntrospection(bool enable_introspection);
+  [[nodiscard]] bool GetEnableIntrospection() const;
   void SetLimitLocalMarkerDepthPerCommandBuffer(bool limit_local_marker_depth_per_command_buffer);
   [[nodiscard]] bool GetLimitLocalMarkerDepthPerCommandBuffer() const;
   void SetMaxLocalMarkerDepthPerCommandBuffer(uint64_t local_marker_depth_per_command_buffer);

--- a/src/OrbitQt/CaptureOptionsDialog.ui
+++ b/src/OrbitQt/CaptureOptionsDialog.ui
@@ -58,6 +58,20 @@
           </property>
          </widget>
         </item>
+        <item>
+         <widget class="QCheckBox" name="apiCheckBox">
+          <property name="text">
+           <string>Enable Orbit Api in target</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="introspectionCheckBox">
+          <property name="text">
+           <string>Enable introspection</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </widget>
      </item>
@@ -87,7 +101,7 @@
            <widget class="QLineEdit" name="memorySamplingPeriodMsLineEdit">
             <property name="accessibleName">
              <string>MemorySamplingPeriodEdit</string>
-            </property>           
+            </property>
             <property name="enabled">
              <bool>false</bool>
             </property>

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -879,6 +879,8 @@ void OrbitMainWindow::on_actionToggle_Capture_triggered() { app_->ToggleCapture(
 
 const QString OrbitMainWindow::kCollectThreadStatesSettingKey{"CollectThreadStates"};
 const QString OrbitMainWindow::kCollectMemoryInfoSettingKey{"CollectMemoryInfo"};
+const QString OrbitMainWindow::kEnableApiSettingKey{"EnableApi"};
+const QString OrbitMainWindow::kEnableIntrospectionSettingKey{"EnableIntrospection"};
 const QString OrbitMainWindow::kMemorySamplingPeriodMsSettingKey{"MemorySamplingPeriodMs"};
 const QString OrbitMainWindow::kMemoryWarningThresholdKbSettingKey{"MemoryWarningThresholdKb"};
 const QString OrbitMainWindow::kLimitLocalMarkerDepthPerCommandBufferSettingsKey{
@@ -893,6 +895,8 @@ constexpr uint64_t kMilliSecondsToNanoSeconds = 1000'000;
 void OrbitMainWindow::LoadCaptureOptionsIntoApp() {
   QSettings settings;
   app_->SetCollectThreadStates(settings.value(kCollectThreadStatesSettingKey, false).toBool());
+  app_->SetEnableApi(settings.value(kEnableApiSettingKey, false).toBool());
+  app_->SetEnableIntrospection(settings.value(kEnableIntrospectionSettingKey, false).toBool());
 
   app_->SetCollectMemoryInfo(settings.value(kCollectMemoryInfoSettingKey, false).toBool());
   uint64_t memory_sampling_period_ns =
@@ -926,6 +930,8 @@ void OrbitMainWindow::on_actionCaptureOptions_triggered() {
 
   orbit_qt::CaptureOptionsDialog dialog{this};
   dialog.SetCollectThreadStates(settings.value(kCollectThreadStatesSettingKey, false).toBool());
+  dialog.SetEnableApi(settings.value(kEnableApiSettingKey, false).toBool());
+  dialog.SetEnableIntrospection(settings.value(kEnableIntrospectionSettingKey, false).toBool());
   dialog.SetCollectMemoryInfo(settings.value(kCollectMemoryInfoSettingKey, false).toBool());
   dialog.SetMemorySamplingPeriodMs(
       settings
@@ -948,6 +954,8 @@ void OrbitMainWindow::on_actionCaptureOptions_triggered() {
   }
 
   settings.setValue(kCollectThreadStatesSettingKey, dialog.GetCollectThreadStates());
+  settings.setValue(kEnableApiSettingKey, dialog.GetEnableApi());
+  settings.setValue(kEnableIntrospectionSettingKey, dialog.GetEnableIntrospection());
   settings.setValue(kCollectMemoryInfoSettingKey, dialog.GetCollectMemoryInfo());
   settings.setValue(kMemorySamplingPeriodMsSettingKey,
                     QString::number(dialog.GetMemorySamplingPeriodMs()));

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -930,8 +930,8 @@ void OrbitMainWindow::on_actionCaptureOptions_triggered() {
 
   orbit_qt::CaptureOptionsDialog dialog{this};
   dialog.SetCollectThreadStates(settings.value(kCollectThreadStatesSettingKey, false).toBool());
-  dialog.SetEnableApi(settings.value(kEnableApiSettingKey, false).toBool());
-  dialog.SetEnableIntrospection(settings.value(kEnableIntrospectionSettingKey, false).toBool());
+  dialog.SetEnableApi(settings.value(kEnableApiSettingKey, true).toBool());
+  dialog.SetEnableIntrospection(settings.value(kEnableIntrospectionSettingKey, true).toBool());
   dialog.SetCollectMemoryInfo(settings.value(kCollectMemoryInfoSettingKey, false).toBool());
   dialog.SetMemorySamplingPeriodMs(
       settings

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -170,6 +170,8 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
 
   static const QString kCollectThreadStatesSettingKey;
   static const QString kCollectMemoryInfoSettingKey;
+  static const QString kEnableApiSettingKey;
+  static const QString kEnableIntrospectionSettingKey;
   static const QString kMemorySamplingPeriodMsSettingKey;
   static const QString kMemoryWarningThresholdKbSettingKey;
   static const QString kLimitLocalMarkerDepthPerCommandBufferSettingsKey;

--- a/src/Service/CaptureServiceImpl.cpp
+++ b/src/Service/CaptureServiceImpl.cpp
@@ -265,8 +265,10 @@ grpc::Status CaptureServiceImpl::Capture(
   const CaptureOptions& capture_options = request.capture_options();
 
   // Initialize Orbit API in tracee.
-  if (auto result = orbit_api::InitializeInTracee(capture_options); result.has_error()) {
-    ERROR("Initializing Orbit Api: %s", result.error().message());
+  if (capture_options.enable_api()) {
+    if (auto result = orbit_api::InitializeInTracee(capture_options); result.has_error()) {
+      ERROR("Initializing Orbit Api: %s", result.error().message());
+    }
   }
 
   uint64_t capture_start_timestamp_ns = orbit_base::CaptureTimestampNs();


### PR DESCRIPTION
Add option to toggle introspection and manual instrumentation from the capture settings UI.

Note that the api toggle works only from disabled to enabled, we can't go from enabled to 
disabled yet. This will come in a subsequent PR.

Test: toggle introspection, toggle api from disabled to enabled.