### PR TITLE
Fixes to CaptureFileOutputStream

### DIFF
--- a/src/CaptureFile/CaptureFileOutputStream.cpp
+++ b/src/CaptureFile/CaptureFileOutputStream.cpp
@@ -29,6 +29,7 @@ class CaptureFileOutputStreamImpl final : public CaptureFileOutputStream {
   [[nodiscard]] ErrorMessageOr<void> WriteCaptureEvent(
       const orbit_grpc_protos::ClientCaptureEvent& event) override;
   void Close() noexcept override;
+  [[nodiscard]] bool IsOpen() noexcept override;
 
  private:
   [[nodiscard]] ErrorMessageOr<void> WriteHeader();
@@ -71,6 +72,8 @@ void CaptureFileOutputStreamImpl::Close() noexcept {
   file_output_stream_.reset();
   fd_.release();
 }
+
+bool CaptureFileOutputStreamImpl::IsOpen() noexcept { return fd_.valid(); }
 
 void CaptureFileOutputStreamImpl::CloseAndTryRemoveFileAfterError() {
   Close();

--- a/src/CaptureFile/CaptureFileOutputStreamTest.cpp
+++ b/src/CaptureFile/CaptureFileOutputStreamTest.cpp
@@ -38,6 +38,8 @@ TEST(CaptureFileOutputStream, Smoke) {
   std::unique_ptr<CaptureFileOutputStream> output_stream =
       std::move(output_stream_or_error.value());
 
+  EXPECT_TRUE(output_stream->IsOpen());
+
   orbit_grpc_protos::ClientCaptureEvent event = CreateInternedStringCaptureEvent();
 
   auto write_result = output_stream->WriteCaptureEvent(event);
@@ -81,7 +83,11 @@ TEST(CaptureFileOutputStream, WriteAfterClose) {
   std::unique_ptr<CaptureFileOutputStream> output_stream =
       std::move(output_stream_or_error.value());
 
+  EXPECT_TRUE(output_stream->IsOpen());
+
   output_stream->Close();
+
+  EXPECT_FALSE(output_stream->IsOpen());
 
   orbit_grpc_protos::ClientCaptureEvent event = CreateInternedStringCaptureEvent();
 

--- a/src/CaptureFile/include/CaptureFile/CaptureFileOutputStream.h
+++ b/src/CaptureFile/include/CaptureFile/CaptureFileOutputStream.h
@@ -48,6 +48,8 @@ class CaptureFileOutputStream {
       const orbit_grpc_protos::ClientCaptureEvent& event) = 0;
   virtual void Close() noexcept = 0;
 
+  [[nodiscard]] virtual bool IsOpen() noexcept = 0;
+
   // Create new capture file output stream. If the file exists it is going to be
   // overwritten.
   [[nodiscard]] static ErrorMessageOr<std::unique_ptr<CaptureFileOutputStream>> Create(

--- a/src/CaptureFile/include/CaptureFile/CaptureFileOutputStream.h
+++ b/src/CaptureFile/include/CaptureFile/CaptureFileOutputStream.h
@@ -46,7 +46,7 @@ class CaptureFileOutputStream {
   virtual ~CaptureFileOutputStream() noexcept = default;
   [[nodiscard]] virtual ErrorMessageOr<void> WriteCaptureEvent(
       const orbit_grpc_protos::ClientCaptureEvent& event) = 0;
-  virtual void Close() noexcept = 0;
+  virtual ErrorMessageOr<void> Close() noexcept = 0;
 
   [[nodiscard]] virtual bool IsOpen() noexcept = 0;
 


### PR DESCRIPTION
Add IsOpen method, improve error handling on Close. Fix logic for writing multiple messages, we need a size there in order to correctly read them. Fix the test accordingly.