### PR TITLE
Replace most canvas dependences for viewport in Tracks 

### DIFF
--- a/src/OrbitGl/AccessibleCaptureViewElement.cpp
+++ b/src/OrbitGl/AccessibleCaptureViewElement.cpp
@@ -18,24 +18,22 @@ const orbit_accessibility::AccessibleInterface* AccessibleCaptureViewElement::Ac
 }
 orbit_accessibility::AccessibilityRect AccessibleCaptureViewElement::AccessibleRect() const {
   CHECK(capture_view_element_ != nullptr);
-  GlCanvas* canvas = capture_view_element_->GetCanvas();
-  CHECK(canvas != nullptr);
-  const Viewport& viewport = canvas->GetViewport();
+  const Viewport* viewport = capture_view_element_->GetViewport();
 
   Vec2 pos = capture_view_element_->GetPos();
   Vec2 size = capture_view_element_->GetSize();
 
-  Vec2i screen_pos = viewport.WorldToScreenPos(pos);
-  int screen_width = viewport.WorldToScreenWidth(size[0]);
-  int screen_height = viewport.WorldToScreenHeight(size[1]);
+  Vec2i screen_pos = viewport->WorldToScreenPos(pos);
+  int screen_width = viewport->WorldToScreenWidth(size[0]);
+  int screen_height = viewport->WorldToScreenHeight(size[1]);
 
   // Adjust the coordinates to clamp the result to an on-screen rect
   // This will "cut" any part that is offscreen due to scrolling, and may result
   // in a final result with width / height of 0.
 
   // First: Clamp bottom
-  if (screen_pos[1] + screen_height > viewport.GetScreenHeight()) {
-    screen_height = std::max(0, viewport.GetScreenHeight() - static_cast<int>(screen_pos[1]));
+  if (screen_pos[1] + screen_height > viewport->GetScreenHeight()) {
+    screen_height = std::max(0, viewport->GetScreenHeight() - static_cast<int>(screen_pos[1]));
   }
   // Second: Clamp top
   if (screen_pos[1] < 0) {
@@ -43,8 +41,8 @@ orbit_accessibility::AccessibilityRect AccessibleCaptureViewElement::AccessibleR
     screen_pos[1] = 0;
   }
   // Third: Clamp right
-  if (screen_pos[0] + screen_width > viewport.GetScreenWidth()) {
-    screen_width = std::max(0, viewport.GetScreenWidth() - static_cast<int>(screen_pos[0]));
+  if (screen_pos[0] + screen_width > viewport->GetScreenWidth()) {
+    screen_width = std::max(0, viewport->GetScreenWidth() - static_cast<int>(screen_pos[0]));
   }
   // Fourth: Clamp left
   if (screen_pos[0] < 0) {

--- a/src/OrbitGl/AccessibleTimeGraph.cpp
+++ b/src/OrbitGl/AccessibleTimeGraph.cpp
@@ -20,10 +20,9 @@ using orbit_accessibility::AccessibleInterface;
 namespace orbit_gl {
 
 AccessibilityRect TimeGraphAccessibility::AccessibleRect() const {
-  GlCanvas* canvas = time_graph_->GetCanvas();
-  const Viewport& viewport = canvas->GetViewport();
+  const Viewport* viewport = time_graph_->GetViewport();
 
-  return AccessibilityRect(0, 0, viewport.GetScreenWidth(), viewport.GetScreenHeight());
+  return AccessibilityRect(0, 0, viewport->GetScreenWidth(), viewport->GetScreenHeight());
 }
 
 AccessibilityState TimeGraphAccessibility::AccessibleState() const {

--- a/src/OrbitGl/AccessibleTrack.cpp
+++ b/src/OrbitGl/AccessibleTrack.cpp
@@ -15,6 +15,7 @@
 #include "OrbitBase/Logging.h"
 #include "TimeGraph.h"
 #include "Track.h"
+#include "Viewport.h"
 
 using orbit_accessibility::AccessibilityState;
 using orbit_accessibility::AccessibleInterface;
@@ -26,7 +27,8 @@ namespace {
 class FakeTrackTab : public CaptureViewElement {
  public:
   explicit FakeTrackTab(Track* track, TimeGraphLayout* layout)
-      : CaptureViewElement(track, track->GetTimeGraph(), layout), track_(track) {
+      : CaptureViewElement(track, track->GetTimeGraph(), track->GetViewport(), layout),
+        track_(track) {
     SetCanvas(track->GetCanvas());
 
     // Compute and set the size (which would usually be done by the parent). As the position may
@@ -51,7 +53,7 @@ class FakeTrackTab : public CaptureViewElement {
 class FakeTimerPane : public CaptureViewElement {
  public:
   explicit FakeTimerPane(Track* track, TimeGraphLayout* layout, CaptureViewElement* track_tab)
-      : CaptureViewElement(track, track->GetTimeGraph(), layout),
+      : CaptureViewElement(track, track->GetTimeGraph(), track->GetViewport(), layout),
         track_(track),
         track_tab_(track_tab) {
     SetCanvas(track->GetCanvas());

--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -25,15 +25,17 @@
 #include "TimeGraph.h"
 #include "TimeGraphLayout.h"
 #include "TriangleToggle.h"
+#include "Viewport.h"
 #include "capture_data.pb.h"
 
 using orbit_client_protos::TimerInfo;
 using orbit_grpc_protos::InstrumentedFunction;
 
-AsyncTrack::AsyncTrack(CaptureViewElement* parent, TimeGraph* time_graph, TimeGraphLayout* layout,
+AsyncTrack::AsyncTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                        const std::string& name, OrbitApp* app,
                        const orbit_client_model::CaptureData* capture_data)
-    : TimerTrack(parent, time_graph, layout, app, capture_data) {
+    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data) {
   SetName(name);
   SetLabel(name);
 }

--- a/src/OrbitGl/AsyncTrack.h
+++ b/src/OrbitGl/AsyncTrack.h
@@ -17,6 +17,7 @@
 #include "TimerChain.h"
 #include "TimerTrack.h"
 #include "Track.h"
+#include "Viewport.h"
 #include "absl/container/flat_hash_map.h"
 #include "capture_data.pb.h"
 
@@ -24,7 +25,8 @@ class OrbitApp;
 
 class AsyncTrack final : public TimerTrack {
  public:
-  explicit AsyncTrack(CaptureViewElement* parent, TimeGraph* time_graph, TimeGraphLayout* layout,
+  explicit AsyncTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+                      orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                       const std::string& name, OrbitApp* app,
                       const orbit_client_model::CaptureData* capture_data);
 

--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -25,6 +25,7 @@
 #include "PickingManager.h"
 #include "TimeGraph.h"
 #include "TimeGraphLayout.h"
+#include "Viewport.h"
 #include "capture_data.pb.h"
 
 using orbit_client_model::CaptureData;
@@ -33,9 +34,10 @@ using orbit_client_protos::CallstackEvent;
 namespace orbit_gl {
 
 CallstackThreadBar::CallstackThreadBar(CaptureViewElement* parent, OrbitApp* app,
-                                       TimeGraph* time_graph, TimeGraphLayout* layout,
-                                       const CaptureData* capture_data, ThreadID thread_id)
-    : ThreadBar(parent, app, time_graph, layout, capture_data, thread_id, "Callstacks"),
+                                       TimeGraph* time_graph, orbit_gl::Viewport* viewport,
+                                       TimeGraphLayout* layout, const CaptureData* capture_data,
+                                       ThreadID thread_id)
+    : ThreadBar(parent, app, time_graph, viewport, layout, capture_data, thread_id, "Callstacks"),
       color_{0, 255, 0, 255} {}
 
 std::string CallstackThreadBar::GetTooltip() const {

--- a/src/OrbitGl/CallstackThreadBar.h
+++ b/src/OrbitGl/CallstackThreadBar.h
@@ -16,6 +16,7 @@
 #include "OrbitClientData/Callstack.h"
 #include "OrbitClientData/CallstackTypes.h"
 #include "ThreadBar.h"
+#include "Viewport.h"
 
 class OrbitApp;
 
@@ -24,7 +25,7 @@ namespace orbit_gl {
 class CallstackThreadBar : public ThreadBar {
  public:
   explicit CallstackThreadBar(CaptureViewElement* parent, OrbitApp* app, TimeGraph* time_graph,
-                              TimeGraphLayout* layout,
+                              orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                               const orbit_client_model::CaptureData* capture_data,
                               ThreadID thread_id);
 

--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -4,19 +4,19 @@
 
 #include "CaptureViewElement.h"
 
-#include "GlCanvas.h"
 #include "TimeGraph.h"
+#include "Viewport.h"
 
 namespace orbit_gl {
 
 CaptureViewElement::CaptureViewElement(CaptureViewElement* parent, TimeGraph* time_graph,
-                                       TimeGraphLayout* layout)
-    : parent_(parent), layout_(layout), time_graph_(time_graph) {
+                                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout)
+    : parent_(parent), viewport_(viewport), layout_(layout), time_graph_(time_graph) {
   CHECK(layout != nullptr);
 }
 
 void CaptureViewElement::OnPick(int x, int y) {
-  mouse_pos_last_click_ = canvas_->GetViewport().ScreenToWorldPos(Vec2i(x, y));
+  mouse_pos_last_click_ = viewport_->ScreenToWorldPos(Vec2i(x, y));
   picking_offset_ = mouse_pos_last_click_ - pos_;
   mouse_pos_cur_ = mouse_pos_last_click_;
   picked_ = true;
@@ -28,7 +28,7 @@ void CaptureViewElement::OnRelease() {
 }
 
 void CaptureViewElement::OnDrag(int x, int y) {
-  mouse_pos_cur_ = canvas_->GetViewport().ScreenToWorldPos(Vec2i(x, y));
+  mouse_pos_cur_ = viewport_->ScreenToWorldPos(Vec2i(x, y));
   time_graph_->RequestUpdatePrimitives();
 }
 

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -9,6 +9,7 @@
 #include "OrbitAccessibility/AccessibleInterface.h"
 #include "PickingManager.h"
 #include "TimeGraphLayout.h"
+#include "Viewport.h"
 
 class TimeGraph;
 class GlCanvas;
@@ -19,7 +20,7 @@ namespace orbit_gl {
 class CaptureViewElement : public Pickable {
  public:
   explicit CaptureViewElement(CaptureViewElement* parent, TimeGraph* time_graph,
-                              TimeGraphLayout* layout);
+                              orbit_gl::Viewport* viewport, TimeGraphLayout* layout);
   virtual void Draw(GlCanvas* canvas, PickingMode /*picking_mode*/, float /*z_offset*/ = 0) {
     canvas_ = canvas;
   }
@@ -29,6 +30,7 @@ class CaptureViewElement : public Pickable {
 
   [[nodiscard]] TimeGraph* GetTimeGraph() { return time_graph_; }
 
+  [[nodiscard]] orbit_gl::Viewport* GetViewport() const { return viewport_; }
   [[nodiscard]] GlCanvas* GetCanvas() const { return canvas_; }
   void SetCanvas(GlCanvas* canvas) { canvas_ = canvas; }
 
@@ -55,6 +57,7 @@ class CaptureViewElement : public Pickable {
 
  protected:
   CaptureViewElement* parent_;
+  orbit_gl::Viewport* viewport_;
   TimeGraphLayout* layout_;
 
   GlCanvas* canvas_ = nullptr;

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -553,7 +553,7 @@ void CaptureWindow::set_draw_help(bool draw_help) {
 }
 
 void CaptureWindow::CreateTimeGraph(const CaptureData* capture_data) {
-  time_graph_ = std::make_unique<TimeGraph>(app_, &text_renderer_, this, capture_data);
+  time_graph_ = std::make_unique<TimeGraph>(app_, &text_renderer_, this, &viewport_, capture_data);
 }
 
 Batcher& CaptureWindow::GetBatcherById(BatcherId batcher_id) {

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -66,10 +66,12 @@ float FrameTrack::GetAverageBoxHeight() const {
   return box_height_ / box_height_normalizer;
 }
 
-FrameTrack::FrameTrack(CaptureViewElement* parent, TimeGraph* time_graph, TimeGraphLayout* layout,
+FrameTrack::FrameTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                        InstrumentedFunction function, OrbitApp* app,
                        const CaptureData* capture_data)
-    : TimerTrack(parent, time_graph, layout, app, capture_data), function_(std::move(function)) {
+    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data),
+      function_(std::move(function)) {
   // TODO(b/169554463): Support manual instrumentation.
   std::string name = absl::StrFormat("Frame track based on %s", function_.function_name());
   SetName(name);

--- a/src/OrbitGl/FrameTrack.h
+++ b/src/OrbitGl/FrameTrack.h
@@ -18,13 +18,15 @@
 #include "TimerChain.h"
 #include "TimerTrack.h"
 #include "Track.h"
+#include "Viewport.h"
 #include "capture_data.pb.h"
 
 class OrbitApp;
 
 class FrameTrack : public TimerTrack {
  public:
-  explicit FrameTrack(CaptureViewElement* parent, TimeGraph* time_graph, TimeGraphLayout* layout,
+  explicit FrameTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+                      orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                       orbit_grpc_protos::InstrumentedFunction function, OrbitApp* app,
                       const orbit_client_model::CaptureData* capture_data);
   [[nodiscard]] Type GetType() const override { return Type::kFrameTrack; }

--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -56,7 +56,7 @@ const Color GlCanvas::kBackgroundColor = Color(67, 67, 67, 255);
 const Color GlCanvas::kTabTextColorSelected = Color(100, 181, 246, 255);
 
 GlCanvas::GlCanvas() : viewport_(0, 0), ui_batcher_(BatcherId::kUi, &picking_manager_) {
-  text_renderer_.SetCanvas(this);
+  text_renderer_.SetViewport(&viewport_);
 
   is_selecting_ = false;
   double_clicking_ = false;

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -24,6 +24,7 @@
 #include "TimeGraphLayout.h"
 #include "TimerChain.h"
 #include "TriangleToggle.h"
+#include "Viewport.h"
 #include "absl/strings/str_format.h"
 
 using orbit_client_protos::TimerInfo;
@@ -65,10 +66,10 @@ std::string MapGpuTimelineToTrackLabel(std::string_view timeline) {
 
 }  // namespace orbit_gl
 
-GpuTrack::GpuTrack(CaptureViewElement* parent, TimeGraph* time_graph, TimeGraphLayout* layout,
-                   uint64_t timeline_hash, OrbitApp* app,
+GpuTrack::GpuTrack(CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
+                   TimeGraphLayout* layout, uint64_t timeline_hash, OrbitApp* app,
                    const orbit_client_model::CaptureData* capture_data)
-    : TimerTrack(parent, time_graph, layout, app, capture_data) {
+    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data) {
   text_renderer_ = time_graph->GetTextRenderer();
   timeline_hash_ = timeline_hash;
   string_manager_ = app->GetStringManager();

--- a/src/OrbitGl/GpuTrack.h
+++ b/src/OrbitGl/GpuTrack.h
@@ -18,6 +18,7 @@
 #include "TextBox.h"
 #include "TimerTrack.h"
 #include "Track.h"
+#include "Viewport.h"
 #include "capture_data.pb.h"
 
 class OrbitApp;
@@ -33,8 +34,8 @@ std::string MapGpuTimelineToTrackLabel(std::string_view timeline);
 
 class GpuTrack : public TimerTrack {
  public:
-  explicit GpuTrack(CaptureViewElement* parent, TimeGraph* time_graph, TimeGraphLayout* layout,
-                    uint64_t timeline_hash, OrbitApp* app,
+  explicit GpuTrack(CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
+                    TimeGraphLayout* layout, uint64_t timeline_hash, OrbitApp* app,
                     const orbit_client_model::CaptureData* capture_data);
   ~GpuTrack() override = default;
   [[nodiscard]] std::string GetTooltip() const override;

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -15,22 +15,21 @@
 #include "TextRenderer.h"
 #include "TimeGraph.h"
 #include "TimeGraphLayout.h"
+#include "Viewport.h"
 
-GraphTrack::GraphTrack(CaptureViewElement* parent, TimeGraph* time_graph, TimeGraphLayout* layout,
-                       const std::string& name, const orbit_client_model::CaptureData* capture_data)
-    : Track(parent, time_graph, layout, capture_data) {
+GraphTrack::GraphTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout, std::string name,
+                       const orbit_client_model::CaptureData* capture_data)
+    : Track(parent, time_graph, viewport, layout, capture_data) {
   SetName(name);
   SetLabel(name);
 }
 
 void GraphTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                                   PickingMode picking_mode, float z_offset) {
-  GlCanvas* canvas = time_graph_->GetCanvas();
-  const orbit_gl::Viewport& viewport = canvas->GetViewport();
-
-  float track_width = viewport.GetVisibleWorldWidth();
+  float track_width = viewport_->GetVisibleWorldWidth();
   SetSize(track_width, GetHeight());
-  pos_[0] = viewport.GetWorldTopLeft()[0];
+  pos_[0] = viewport_->GetWorldTopLeft()[0];
 
   Color color = GetBackgroundColor();
   const Color kLineColor(0, 128, 255, 128);

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -18,13 +18,15 @@
 #include "PickingManager.h"
 #include "Timer.h"
 #include "Track.h"
+#include "Viewport.h"
 
 class TimeGraph;
 
 class GraphTrack : public Track {
  public:
-  explicit GraphTrack(CaptureViewElement* parent, TimeGraph* time_graph, TimeGraphLayout* layout,
-                      const std::string& name, const orbit_client_model::CaptureData* capture_data);
+  explicit GraphTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+                      orbit_gl::Viewport* viewport, TimeGraphLayout* layout, std::string name,
+                      const orbit_client_model::CaptureData* capture_data);
   [[nodiscard]] Type GetType() const override { return Type::kGraphTrack; }
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,

--- a/src/OrbitGl/MemoryTrack.h
+++ b/src/OrbitGl/MemoryTrack.h
@@ -10,14 +10,16 @@
 
 #include "GraphTrack.h"
 #include "Track.h"
+#include "Viewport.h"
 
 namespace orbit_gl {
 
 class MemoryTrack final : public GraphTrack {
  public:
-  explicit MemoryTrack(CaptureViewElement* parent, TimeGraph* time_graph, TimeGraphLayout* layout,
-                       std::string name, const orbit_client_model::CaptureData* capture_data)
-      : GraphTrack(parent, time_graph, layout, std::move(name), capture_data) {}
+  explicit MemoryTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout, std::string name,
+                       const orbit_client_model::CaptureData* capture_data)
+      : GraphTrack(parent, time_graph, viewport, layout, name, capture_data) {}
   ~MemoryTrack() override = default;
   [[nodiscard]] Type GetType() const override { return Type::kMemoryTrack; }
 

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -15,6 +15,7 @@
 #include "TextBox.h"
 #include "TimeGraph.h"
 #include "TimeGraphLayout.h"
+#include "Viewport.h"
 
 using orbit_client_protos::TimerInfo;
 
@@ -22,9 +23,9 @@ const Color kInactiveColor(100, 100, 100, 255);
 const Color kSelectionColor(0, 128, 255, 255);
 
 SchedulerTrack::SchedulerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
-                               TimeGraphLayout* layout, OrbitApp* app,
+                               orbit_gl::Viewport* viewport, TimeGraphLayout* layout, OrbitApp* app,
                                const orbit_client_model::CaptureData* capture_data)
-    : TimerTrack(parent, time_graph, layout, app, capture_data) {
+    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data) {
   SetPinned(false);
   SetName("Scheduler");
   SetLabel("Scheduler (0 cores)");

--- a/src/OrbitGl/SchedulerTrack.h
+++ b/src/OrbitGl/SchedulerTrack.h
@@ -12,6 +12,7 @@
 #include "PickingManager.h"
 #include "TimerTrack.h"
 #include "Track.h"
+#include "Viewport.h"
 #include "capture_data.pb.h"
 
 class OrbitApp;
@@ -19,7 +20,7 @@ class OrbitApp;
 class SchedulerTrack final : public TimerTrack {
  public:
   explicit SchedulerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
-                          TimeGraphLayout* layout, OrbitApp* app,
+                          orbit_gl::Viewport* viewport, TimeGraphLayout* layout, OrbitApp* app,
                           const orbit_client_model::CaptureData* capture_data);
   ~SchedulerTrack() override = default;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;

--- a/src/OrbitGl/TextRenderer.h
+++ b/src/OrbitGl/TextRenderer.h
@@ -20,8 +20,8 @@
 
 #include "Batcher.h"
 #include "CoreMath.h"
-#include "Viewport.h"
 #include "PickingManager.h"
+#include "Viewport.h"
 
 namespace ftgl {
 struct vertex_buffer_t;

--- a/src/OrbitGl/TextRenderer.h
+++ b/src/OrbitGl/TextRenderer.h
@@ -20,14 +20,13 @@
 
 #include "Batcher.h"
 #include "CoreMath.h"
+#include "Viewport.h"
 #include "PickingManager.h"
 
 namespace ftgl {
 struct vertex_buffer_t;
 struct texture_font_t;
 }  // namespace ftgl
-
-class GlCanvas;
 
 class TextRenderer {
  public:
@@ -36,7 +35,7 @@ class TextRenderer {
 
   void Init();
   void Clear();
-  void SetCanvas(GlCanvas* canvas) { canvas_ = canvas; }
+  void SetViewport(orbit_gl::Viewport* viewport) { viewport_ = viewport; }
 
   void RenderLayer(Batcher* batcher, float layer);
   void RenderDebug(Batcher* batcher);
@@ -78,7 +77,7 @@ class TextRenderer {
   bool texture_atlas_changed_;
   std::unordered_map<float, ftgl::vertex_buffer_t*> vertex_buffers_by_layer_;
   std::map<uint32_t, ftgl::texture_font_t*> fonts_by_size_;
-  GlCanvas* canvas_;
+  orbit_gl::Viewport* viewport_;
   GLuint shader_;
   ftgl::mat4 model_;
   ftgl::mat4 view_;

--- a/src/OrbitGl/ThreadBar.h
+++ b/src/OrbitGl/ThreadBar.h
@@ -20,9 +20,10 @@ namespace orbit_gl {
 class ThreadBar : public CaptureViewElement, public std::enable_shared_from_this<ThreadBar> {
  public:
   explicit ThreadBar(CaptureViewElement* parent, OrbitApp* app, TimeGraph* time_graph,
-                     TimeGraphLayout* layout, const orbit_client_model::CaptureData* capture_data,
-                     ThreadID thread_id, std::string name)
-      : CaptureViewElement(parent, time_graph, layout),
+                     orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
+                     const orbit_client_model::CaptureData* capture_data, ThreadID thread_id,
+                     std::string name)
+      : CaptureViewElement(parent, time_graph, viewport, layout),
         thread_id_(thread_id),
         app_(app),
         capture_data_(capture_data),

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -17,6 +17,7 @@
 #include "GlCanvas.h"
 #include "OrbitBase/Logging.h"
 #include "TimeGraph.h"
+#include "Viewport.h"
 #include "capture_data.pb.h"
 
 using orbit_client_protos::ThreadStateSliceInfo;
@@ -24,10 +25,11 @@ using orbit_client_protos::ThreadStateSliceInfo;
 namespace orbit_gl {
 
 ThreadStateBar::ThreadStateBar(CaptureViewElement* parent, OrbitApp* app, TimeGraph* time_graph,
-                               TimeGraphLayout* layout,
+                               orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                                const orbit_client_model::CaptureData* capture_data,
                                ThreadID thread_id)
-    : ThreadBar(parent, app, time_graph, layout, capture_data, thread_id, "ThreadState") {}
+    : ThreadBar(parent, app, time_graph, viewport, layout, capture_data, thread_id, "ThreadState") {
+}
 
 bool ThreadStateBar::IsEmpty() const {
   if (capture_data_ == nullptr) return true;
@@ -163,14 +165,11 @@ void ThreadStateBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint6
                                       PickingMode picking_mode, float z_offset) {
   ThreadBar::UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
 
-  const GlCanvas* canvas = time_graph_->GetCanvas();
-  const orbit_gl::Viewport& viewport = canvas->GetViewport();
-
   const auto time_window_ns = static_cast<uint64_t>(1000 * time_graph_->GetTimeWindowUs());
-  const uint64_t pixel_delta_ns = time_window_ns / viewport.GetScreenWidth();
+  const uint64_t pixel_delta_ns = time_window_ns / viewport_->GetScreenWidth();
   const uint64_t min_time_graph_ns = time_graph_->GetTickFromUs(time_graph_->GetMinTimeUs());
   const float pixel_width_in_world_coords =
-      viewport.GetVisibleWorldWidth() / static_cast<float>(viewport.GetScreenWidth());
+      viewport_->GetVisibleWorldWidth() / static_cast<float>(viewport_->GetScreenWidth());
 
   uint64_t ignore_until_ns = 0;
 

--- a/src/OrbitGl/ThreadStateBar.h
+++ b/src/OrbitGl/ThreadStateBar.h
@@ -14,6 +14,7 @@
 #include "CaptureViewElement.h"
 #include "CoreMath.h"
 #include "ThreadBar.h"
+#include "Viewport.h"
 
 namespace orbit_gl {
 
@@ -25,7 +26,7 @@ namespace orbit_gl {
 class ThreadStateBar final : public ThreadBar {
  public:
   explicit ThreadStateBar(CaptureViewElement* parent, OrbitApp* app, TimeGraph* time_graph,
-                          TimeGraphLayout* layout,
+                          orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                           const orbit_client_model::CaptureData* capture_data, ThreadID thread_id);
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) override;

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -20,15 +20,16 @@
 #include "TimerTrack.h"
 #include "TracepointThreadBar.h"
 #include "Track.h"
+#include "Viewport.h"
 #include "capture_data.pb.h"
 
 class OrbitApp;
 
 class ThreadTrack final : public TimerTrack {
  public:
-  explicit ThreadTrack(CaptureViewElement* parent, TimeGraph* time_graph, TimeGraphLayout* layout,
-                       int32_t thread_id, OrbitApp* app,
-                       const orbit_client_model::CaptureData* capture_data);
+  explicit ThreadTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout, int32_t thread_id,
+                       OrbitApp* app, const orbit_client_model::CaptureData* capture_data);
   void InitializeNameAndLabel(int32_t thread_id);
 
   [[nodiscard]] int32_t GetThreadId() const { return thread_id_; }

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -48,7 +48,7 @@ using orbit_grpc_protos::InstrumentedFunction;
 using orbit_grpc_protos::kMissingInfo;
 
 TimeGraph::TimeGraph(OrbitApp* app, TextRenderer* text_renderer, GlCanvas* canvas,
-                     const CaptureData* capture_data)
+                     orbit_gl::Viewport* viewport, const CaptureData* capture_data)
     // Note that `GlCanvas` and `TimeGraph` span the bridge to OpenGl content, and `TimeGraph`'s
     // parent needs special handling for accessibility. Thus, we use `nullptr` here.
     : orbit_gl::CaptureViewElement(nullptr, this, &layout_),
@@ -57,8 +57,8 @@ TimeGraph::TimeGraph(OrbitApp* app, TextRenderer* text_renderer, GlCanvas* canva
       batcher_(BatcherId::kTimeGraph),
       capture_data_{capture_data},
       app_{app} {
-  text_renderer_->SetCanvas(canvas);
-  text_renderer_static_.SetCanvas(canvas);
+  text_renderer_->SetViewport(viewport);
+  text_renderer_static_.SetViewport(viewport);
   batcher_.SetPickingManager(&canvas->GetPickingManager());
   track_manager_ = std::make_unique<TrackManager>(this, &GetLayout(), app, capture_data);
 

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -51,7 +51,7 @@ TimeGraph::TimeGraph(OrbitApp* app, TextRenderer* text_renderer, GlCanvas* canva
                      orbit_gl::Viewport* viewport, const CaptureData* capture_data)
     // Note that `GlCanvas` and `TimeGraph` span the bridge to OpenGl content, and `TimeGraph`'s
     // parent needs special handling for accessibility. Thus, we use `nullptr` here.
-    : orbit_gl::CaptureViewElement(nullptr, this, &layout_),
+    : orbit_gl::CaptureViewElement(nullptr, this, viewport, &layout_),
       text_renderer_{text_renderer},
       canvas_{canvas},
       batcher_(BatcherId::kTimeGraph),
@@ -60,7 +60,7 @@ TimeGraph::TimeGraph(OrbitApp* app, TextRenderer* text_renderer, GlCanvas* canva
   text_renderer_->SetViewport(viewport);
   text_renderer_static_.SetViewport(viewport);
   batcher_.SetPickingManager(&canvas->GetPickingManager());
-  track_manager_ = std::make_unique<TrackManager>(this, &GetLayout(), app, capture_data);
+  track_manager_ = std::make_unique<TrackManager>(this, viewport_, &GetLayout(), app, capture_data);
 
   async_timer_info_listener_ =
       std::make_unique<ManualInstrumentationManager::AsyncTimerInfoListener>(
@@ -149,16 +149,16 @@ void TimeGraph::VerticalZoom(float zoom_value, float mouse_relative_position) {
 
   const float ratio = (zoom_value > 0) ? (1 + kIncrementRatio) : (1 / (1 + kIncrementRatio));
 
-  const float world_height = canvas_->GetViewport().GetVisibleWorldHeight();
+  const float world_height = viewport_->GetVisibleWorldHeight();
   const float y_mouse_position =
-      canvas_->GetViewport().GetWorldTopLeft()[1] - mouse_relative_position * world_height;
-  const float top_distance = canvas_->GetViewport().GetWorldTopLeft()[1] - y_mouse_position;
+      viewport_->GetWorldTopLeft()[1] - mouse_relative_position * world_height;
+  const float top_distance = viewport_->GetWorldTopLeft()[1] - y_mouse_position;
 
   const float new_y_mouse_position = y_mouse_position / ratio;
 
   float new_world_top_left_y = new_y_mouse_position + top_distance;
 
-  canvas_->GetViewport().SetWorldTopLeftY(new_world_top_left_y);
+  viewport_->SetWorldTopLeftY(new_world_top_left_y);
 
   // Finally, we have to scale every item in the layout.
   const float old_scale = layout_.GetScale();
@@ -225,13 +225,12 @@ void TimeGraph::VerticallyMoveIntoView(const TimerInfo& timer_info) {
 void TimeGraph::VerticallyMoveIntoView(Track& track) {
   float pos = track.GetPos()[1];
   float height = track.GetHeight();
-  float world_top_left_y = canvas_->GetViewport().GetWorldTopLeft()[1];
+  float world_top_left_y = viewport_->GetWorldTopLeft()[1];
 
   float min_world_top_left_y = pos + layout_.GetTrackTabHeight();
   float max_world_top_left_y =
-      pos + canvas_->GetViewport().GetVisibleWorldHeight() - height - layout_.GetBottomMargin();
-  canvas_->GetViewport().SetWorldTopLeftY(
-      clamp(world_top_left_y, min_world_top_left_y, max_world_top_left_y));
+      pos + viewport_->GetVisibleWorldHeight() - height - layout_.GetBottomMargin();
+  viewport_->SetWorldTopLeftY(clamp(world_top_left_y, min_world_top_left_y, max_world_top_left_y));
 }
 
 void TimeGraph::UpdateHorizontalScroll(float ratio) {
@@ -647,8 +646,8 @@ void TimeGraph::UpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/, ui
   }
 
   time_window_us_ = max_time_us_ - min_time_us_;
-  world_start_x_ = canvas_->GetViewport().GetWorldTopLeft()[0];
-  world_width_ = canvas_->GetViewport().GetVisibleWorldWidth();
+  world_start_x_ = viewport_->GetWorldTopLeft()[0];
+  world_width_ = viewport_->GetVisibleWorldWidth();
   uint64_t min_tick = GetTickFromUs(min_time_us_);
   uint64_t max_tick = GetTickFromUs(max_time_us_);
 
@@ -690,7 +689,7 @@ const std::vector<CallstackEvent>& TimeGraph::GetSelectedCallstackEvents(int32_t
 void TimeGraph::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
   ORBIT_SCOPE("TimeGraph::Draw");
   current_mouse_time_ns_ =
-      GetTickFromWorld(canvas->GetViewport().ScreenToWorldPos(canvas_->GetMouseScreenPos())[0]);
+      GetTickFromWorld(viewport_->ScreenToWorldPos(canvas_->GetMouseScreenPos())[0]);
 
   const bool picking = picking_mode != PickingMode::kNone;
   if ((!picking && update_primitives_requested_) || picking) {
@@ -777,13 +776,11 @@ void TimeGraph::DrawOverlay(GlCanvas* canvas, PickingMode picking_mode) {
   std::vector<float> x_coords;
   x_coords.reserve(boxes.size());
 
-  const orbit_gl::Viewport& viewport = canvas->GetViewport();
+  float world_start_x = viewport_->GetWorldTopLeft()[0];
+  float world_width = viewport_->GetVisibleWorldWidth();
 
-  float world_start_x = viewport.GetWorldTopLeft()[0];
-  float world_width = viewport.GetVisibleWorldWidth();
-
-  float world_start_y = viewport.GetWorldTopLeft()[1];
-  float world_height = viewport.GetVisibleWorldHeight();
+  float world_start_y = viewport_->GetWorldTopLeft()[1];
+  float world_height = viewport_->GetVisibleWorldHeight();
 
   double inv_time_window = 1.0 / GetTimeWindowUs();
 

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -30,6 +30,7 @@
 #include "TimerChain.h"
 #include "Track.h"
 #include "TrackManager.h"
+#include "Viewport.h"
 #include "absl/container/flat_hash_map.h"
 #include "capture_data.pb.h"
 
@@ -38,6 +39,7 @@ class OrbitApp;
 class TimeGraph : public orbit_gl::CaptureViewElement {
  public:
   explicit TimeGraph(OrbitApp* app, TextRenderer* text_renderer, GlCanvas* canvas,
+                     orbit_gl::Viewport* viewport,
                      const orbit_client_model::CaptureData* capture_data);
   ~TimeGraph();
 

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -24,6 +24,7 @@
 #include "TimerChain.h"
 #include "TracepointThreadBar.h"
 #include "Track.h"
+#include "Viewport.h"
 #include "absl/synchronization/mutex.h"
 #include "capture_data.pb.h"
 
@@ -38,7 +39,7 @@ struct DrawData {
   uint64_t ns_per_pixel;
   uint64_t min_timegraph_tick;
   Batcher* batcher;
-  GlCanvas* canvas;
+  orbit_gl::Viewport* viewport;
   const TextBox* selected_textbox;
   double inv_time_window;
   float world_start_x;
@@ -51,8 +52,9 @@ struct DrawData {
 
 class TimerTrack : public Track {
  public:
-  explicit TimerTrack(CaptureViewElement* parent, TimeGraph* time_graph, TimeGraphLayout* layout,
-                      OrbitApp* app, const orbit_client_model::CaptureData* capture_data);
+  explicit TimerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+                      orbit_gl::Viewport* viewport, TimeGraphLayout* layout, OrbitApp* app,
+                      const orbit_client_model::CaptureData* capture_data);
   ~TimerTrack() override = default;
 
   // Pickable
@@ -122,11 +124,10 @@ class TimerTrack : public Track {
   virtual void SetTimesliceText(const orbit_client_protos::TimerInfo& /*timer*/, float /*min_x*/,
                                 float /*z_offset*/, TextBox* /*text_box*/) {}
 
-  [[nodiscard]] static internal::DrawData GetDrawData(uint64_t min_tick, uint64_t max_tick,
-                                                      float z_offset, Batcher* batcher,
-                                                      TimeGraph* time_graph, bool is_collapsed,
-                                                      const TextBox* selected_textbox,
-                                                      uint64_t highlighted_function_id);
+  [[nodiscard]] static internal::DrawData GetDrawData(
+      uint64_t min_tick, uint64_t max_tick, float z_offset, Batcher* batcher, TimeGraph* time_graph,
+      orbit_gl::Viewport* viewport, bool is_collapsed, const TextBox* selected_textbox,
+      uint64_t highlighted_function_id);
 
   TextRenderer* text_renderer_ = nullptr;
   uint32_t depth_ = 0;

--- a/src/OrbitGl/TracepointThreadBar.cpp
+++ b/src/OrbitGl/TracepointThreadBar.cpp
@@ -22,16 +22,18 @@
 #include "OrbitBase/ThreadConstants.h"
 #include "TimeGraph.h"
 #include "TimeGraphLayout.h"
+#include "Viewport.h"
 #include "capture_data.pb.h"
 #include "tracepoint.pb.h"
 
 namespace orbit_gl {
 
 TracepointThreadBar::TracepointThreadBar(CaptureViewElement* parent, OrbitApp* app,
-                                         TimeGraph* time_graph, TimeGraphLayout* layout,
+                                         TimeGraph* time_graph, orbit_gl::Viewport* viewport,
+                                         TimeGraphLayout* layout,
                                          const orbit_client_model::CaptureData* capture_data,
                                          int32_t thread_id)
-    : ThreadBar(parent, app, time_graph, layout, capture_data, thread_id, "Tracepoints"),
+    : ThreadBar(parent, app, time_graph, viewport, layout, capture_data, thread_id, "Tracepoints"),
       color_{255, 0, 0, 255} {}
 
 void TracepointThreadBar::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {

--- a/src/OrbitGl/TracepointThreadBar.h
+++ b/src/OrbitGl/TracepointThreadBar.h
@@ -11,13 +11,14 @@
 
 #include "CaptureViewElement.h"
 #include "ThreadBar.h"
+#include "Viewport.h"
 
 namespace orbit_gl {
 
 class TracepointThreadBar : public ThreadBar {
  public:
   explicit TracepointThreadBar(CaptureViewElement* parent, OrbitApp* app, TimeGraph* time_graph,
-                               TimeGraphLayout* layout,
+                               orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                                const orbit_client_model::CaptureData* capture_data,
                                int32_t thread_id);
 

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -17,14 +17,15 @@
 #include "TextRenderer.h"
 #include "TimeGraph.h"
 #include "TimeGraphLayout.h"
+#include "Viewport.h"
 
-Track::Track(CaptureViewElement* parent, TimeGraph* time_graph, TimeGraphLayout* layout,
-             const orbit_client_model::CaptureData* capture_data)
-    : CaptureViewElement(parent, time_graph, layout),
+Track::Track(CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
+             TimeGraphLayout* layout, const orbit_client_model::CaptureData* capture_data)
+    : CaptureViewElement(parent, time_graph, viewport, layout),
       collapse_toggle_(std::make_shared<TriangleToggle>(
           TriangleToggle::State::kExpanded,
-          [this](TriangleToggle::State state) { OnCollapseToggle(state); }, time_graph, layout,
-          this)),
+          [this](TriangleToggle::State state) { OnCollapseToggle(state); }, time_graph, viewport,
+          layout, this)),
       layout_(layout),
       capture_data_(capture_data) {
   const Color kDarkGrey(50, 50, 50, 255);

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -25,6 +25,7 @@
 #include "TimeGraphLayout.h"
 #include "TimerChain.h"
 #include "TriangleToggle.h"
+#include "Viewport.h"
 #include "capture_data.pb.h"
 
 class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_from_this<Track> {
@@ -41,8 +42,9 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
     kUnknown,
   };
 
-  explicit Track(CaptureViewElement* parent, TimeGraph* time_graph, TimeGraphLayout* layout,
-                 const orbit_client_model::CaptureData* capture_data);
+  explicit Track(CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
+                 TimeGraphLayout* layout, const orbit_client_model::CaptureData* capture_data);
+
   ~Track() override = default;
 
   void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -26,6 +26,7 @@
 #include "ThreadTrack.h"
 #include "Timer.h"
 #include "Track.h"
+#include "Viewport.h"
 #include "capture_data.pb.h"
 
 class OrbitApp;
@@ -35,7 +36,8 @@ class Timegraph;
 // and sorting).
 class TrackManager {
  public:
-  explicit TrackManager(TimeGraph* time_graph, TimeGraphLayout* layout, OrbitApp* app,
+  explicit TrackManager(TimeGraph* time_graph, orbit_gl::Viewport* viewport,
+                        TimeGraphLayout* layout, OrbitApp* app,
                         const orbit_client_model::CaptureData* capture_data);
 
   [[nodiscard]] std::vector<Track*> GetAllTracks() const;
@@ -97,6 +99,7 @@ class TrackManager {
   ThreadTrack* tracepoints_system_wide_track_;
 
   TimeGraph* time_graph_;
+  orbit_gl::Viewport* viewport_;
   TimeGraphLayout* layout_;
 
   std::vector<Track*> sorted_tracks_;

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -17,8 +17,9 @@
 #include "Track.h"
 
 TriangleToggle::TriangleToggle(State initial_state, StateChangeHandler handler,
-                               TimeGraph* time_graph, TimeGraphLayout* layout, Track* track)
-    : CaptureViewElement(track, time_graph, layout),
+                               TimeGraph* time_graph, orbit_gl::Viewport* viewport,
+                               TimeGraphLayout* layout, Track* track)
+    : CaptureViewElement(track, time_graph, viewport, layout),
       track_(track),
       state_(initial_state),
       initial_state_(initial_state),

--- a/src/OrbitGl/TriangleToggle.h
+++ b/src/OrbitGl/TriangleToggle.h
@@ -10,6 +10,7 @@
 
 #include "CaptureViewElement.h"
 #include "CoreMath.h"
+#include "Viewport.h"
 
 class Track;
 
@@ -21,7 +22,7 @@ class TriangleToggle : public orbit_gl::CaptureViewElement,
 
   using StateChangeHandler = std::function<void(TriangleToggle::State)>;
   explicit TriangleToggle(State initial_state, StateChangeHandler handler, TimeGraph* time_graph,
-                          TimeGraphLayout* layout, Track* track);
+                          orbit_gl::Viewport* viewport, TimeGraphLayout* layout, Track* track);
   ~TriangleToggle() override = default;
 
   TriangleToggle() = delete;


### PR DESCRIPTION
In the way to make unit tests in OrbitGl we are replacing GlCanvas for Viewport which is easier to mock for Unit-tests (http://b/185214650).

There are following commits, but I want to merge this first because I'll have a lot of conflicts.

Tested by running a capture, stopping several times and loaded a capture.