### PR TITLE
Add if(WIN32) to GrpcProtos/CMakeLists.txt

### DIFF
--- a/src/GrpcProtos/CMakeLists.txt
+++ b/src/GrpcProtos/CMakeLists.txt
@@ -8,8 +8,11 @@ project(GrpcProtos)
 
 add_library(GrpcProtos STATIC)
 target_compile_options(GrpcProtos PRIVATE ${STRICT_COMPILE_FLAGS})
-target_compile_definitions(GrpcProtos PUBLIC -D_WIN32_WINNT=0x0700)
-target_compile_definitions(GrpcProtos PUBLIC -DNTDDI_VERSION=0x06030000)
+
+if(WIN32)
+    target_compile_definitions(GrpcProtos PUBLIC -D_WIN32_WINNT=0x0700)
+    target_compile_definitions(GrpcProtos PUBLIC -DNTDDI_VERSION=0x06030000)
+endif()
 
 target_include_directories(GrpcProtos PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/include)


### PR DESCRIPTION
This terribly confused CLion's inspections even if the build succeeded.