### PR TITLE
Capture 128 Bytes of the Stack and Registers on FP-based unwinding.

### DIFF
--- a/src/LinuxTracing/PerfEvent.cpp
+++ b/src/LinuxTracing/PerfEvent.cpp
@@ -8,6 +8,37 @@
 
 namespace orbit_linux_tracing {
 
+std::array<uint64_t, PERF_REG_X86_64_MAX> perf_event_sample_regs_user_all_to_register_array(
+    const perf_event_sample_regs_user_all& regs) {
+  std::array<uint64_t, PERF_REG_X86_64_MAX> registers{};
+  registers[PERF_REG_X86_AX] = regs.ax;
+  registers[PERF_REG_X86_BX] = regs.bx;
+  registers[PERF_REG_X86_CX] = regs.cx;
+  registers[PERF_REG_X86_DX] = regs.dx;
+  registers[PERF_REG_X86_SI] = regs.si;
+  registers[PERF_REG_X86_DI] = regs.di;
+  registers[PERF_REG_X86_BP] = regs.bp;
+  registers[PERF_REG_X86_SP] = regs.sp;
+  registers[PERF_REG_X86_IP] = regs.ip;
+  registers[PERF_REG_X86_FLAGS] = regs.flags;
+  registers[PERF_REG_X86_CS] = regs.cs;
+  registers[PERF_REG_X86_SS] = regs.ss;
+  // Registers ds, es, fs, gs do not actually exist.
+  registers[PERF_REG_X86_DS] = 0ul;
+  registers[PERF_REG_X86_ES] = 0ul;
+  registers[PERF_REG_X86_FS] = 0ul;
+  registers[PERF_REG_X86_GS] = 0ul;
+  registers[PERF_REG_X86_R8] = regs.r8;
+  registers[PERF_REG_X86_R9] = regs.r9;
+  registers[PERF_REG_X86_R10] = regs.r10;
+  registers[PERF_REG_X86_R11] = regs.r11;
+  registers[PERF_REG_X86_R12] = regs.r12;
+  registers[PERF_REG_X86_R13] = regs.r13;
+  registers[PERF_REG_X86_R14] = regs.r14;
+  registers[PERF_REG_X86_R15] = regs.r15;
+  return registers;
+}
+
 // These cannot be implemented in the header PerfEvent.h, because there
 // PerfEventVisitor needs to be an incomplete type to avoid the circular
 // dependency between PerfEvent.h and PerfEventVisitor.h.

--- a/src/LinuxTracing/PerfEvent.h
+++ b/src/LinuxTracing/PerfEvent.h
@@ -46,38 +46,8 @@ class PerfEvent {
   int ordered_in_file_descriptor_ = kNotOrderedInAnyFileDescriptor;
 };
 
-namespace {
 std::array<uint64_t, PERF_REG_X86_64_MAX> perf_event_sample_regs_user_all_to_register_array(
-    const perf_event_sample_regs_user_all& regs) {
-  std::array<uint64_t, PERF_REG_X86_64_MAX> registers{};
-  registers[PERF_REG_X86_AX] = regs.ax;
-  registers[PERF_REG_X86_BX] = regs.bx;
-  registers[PERF_REG_X86_CX] = regs.cx;
-  registers[PERF_REG_X86_DX] = regs.dx;
-  registers[PERF_REG_X86_SI] = regs.si;
-  registers[PERF_REG_X86_DI] = regs.di;
-  registers[PERF_REG_X86_BP] = regs.bp;
-  registers[PERF_REG_X86_SP] = regs.sp;
-  registers[PERF_REG_X86_IP] = regs.ip;
-  registers[PERF_REG_X86_FLAGS] = regs.flags;
-  registers[PERF_REG_X86_CS] = regs.cs;
-  registers[PERF_REG_X86_SS] = regs.ss;
-  // Registers ds, es, fs, gs do not actually exist.
-  registers[PERF_REG_X86_DS] = 0ul;
-  registers[PERF_REG_X86_ES] = 0ul;
-  registers[PERF_REG_X86_FS] = 0ul;
-  registers[PERF_REG_X86_GS] = 0ul;
-  registers[PERF_REG_X86_R8] = regs.r8;
-  registers[PERF_REG_X86_R9] = regs.r9;
-  registers[PERF_REG_X86_R10] = regs.r10;
-  registers[PERF_REG_X86_R11] = regs.r11;
-  registers[PERF_REG_X86_R12] = regs.r12;
-  registers[PERF_REG_X86_R13] = regs.r13;
-  registers[PERF_REG_X86_R14] = regs.r14;
-  registers[PERF_REG_X86_R15] = regs.r15;
-  return registers;
-}
-}  // namespace
+    const perf_event_sample_regs_user_all& regs);
 
 class ContextSwitchPerfEvent : public PerfEvent {
  public:
@@ -240,7 +210,7 @@ class CallchainSamplePerfEvent : public PerfEvent {
   dynamically_sized_perf_event_sample_stack_user stack;
 
   explicit CallchainSamplePerfEvent(uint64_t callchain_size, uint64_t dyn_stack_size)
-      : ips(callchain_size), stack{dyn_stack_size} {
+      : ips(callchain_size), stack(dyn_stack_size) {
     ring_buffer_record.nr = callchain_size;
   }
 

--- a/src/LinuxTracing/PerfEvent.h
+++ b/src/LinuxTracing/PerfEvent.h
@@ -46,6 +46,39 @@ class PerfEvent {
   int ordered_in_file_descriptor_ = kNotOrderedInAnyFileDescriptor;
 };
 
+namespace {
+std::array<uint64_t, PERF_REG_X86_64_MAX> perf_event_sample_regs_user_all_to_register_array(
+    const perf_event_sample_regs_user_all& regs) {
+  std::array<uint64_t, PERF_REG_X86_64_MAX> registers{};
+  registers[PERF_REG_X86_AX] = regs.ax;
+  registers[PERF_REG_X86_BX] = regs.bx;
+  registers[PERF_REG_X86_CX] = regs.cx;
+  registers[PERF_REG_X86_DX] = regs.dx;
+  registers[PERF_REG_X86_SI] = regs.si;
+  registers[PERF_REG_X86_DI] = regs.di;
+  registers[PERF_REG_X86_BP] = regs.bp;
+  registers[PERF_REG_X86_SP] = regs.sp;
+  registers[PERF_REG_X86_IP] = regs.ip;
+  registers[PERF_REG_X86_FLAGS] = regs.flags;
+  registers[PERF_REG_X86_CS] = regs.cs;
+  registers[PERF_REG_X86_SS] = regs.ss;
+  // Registers ds, es, fs, gs do not actually exist.
+  registers[PERF_REG_X86_DS] = 0ul;
+  registers[PERF_REG_X86_ES] = 0ul;
+  registers[PERF_REG_X86_FS] = 0ul;
+  registers[PERF_REG_X86_GS] = 0ul;
+  registers[PERF_REG_X86_R8] = regs.r8;
+  registers[PERF_REG_X86_R9] = regs.r9;
+  registers[PERF_REG_X86_R10] = regs.r10;
+  registers[PERF_REG_X86_R11] = regs.r11;
+  registers[PERF_REG_X86_R12] = regs.r12;
+  registers[PERF_REG_X86_R13] = regs.r13;
+  registers[PERF_REG_X86_R14] = regs.r14;
+  registers[PERF_REG_X86_R15] = regs.r15;
+  return registers;
+}
+}  // namespace
+
 class ContextSwitchPerfEvent : public PerfEvent {
  public:
   perf_event_context_switch ring_buffer_record;
@@ -153,15 +186,15 @@ class LostPerfEvent : public PerfEvent {
   uint32_t GetCpu() const { return ring_buffer_record.sample_id.cpu; }
 };
 
+struct dynamically_sized_perf_event_sample_stack_user {
+  uint64_t dyn_size;
+  std::unique_ptr<char[]> data;
+
+  explicit dynamically_sized_perf_event_sample_stack_user(uint64_t dyn_size)
+      : dyn_size{dyn_size}, data{make_unique_for_overwrite<char[]>(dyn_size)} {}
+};
+
 struct dynamically_sized_perf_event_stack_sample {
-  struct dynamically_sized_perf_event_sample_stack_user {
-    uint64_t dyn_size;
-    std::unique_ptr<char[]> data;
-
-    explicit dynamically_sized_perf_event_sample_stack_user(uint64_t dyn_size)
-        : dyn_size{dyn_size}, data{make_unique_for_overwrite<char[]>(dyn_size)} {}
-  };
-
   perf_event_header header;
   perf_event_sample_id_tid_time_streamid_cpu sample_id;
   perf_event_sample_regs_user_all regs;
@@ -197,43 +230,17 @@ class StackSamplePerfEvent : public PerfEvent {
   uint64_t GetStackSize() const { return ring_buffer_record->stack.dyn_size; }
 
  private:
-  static std::array<uint64_t, PERF_REG_X86_64_MAX>
-  perf_event_sample_regs_user_all_to_register_array(const perf_event_sample_regs_user_all& regs) {
-    std::array<uint64_t, PERF_REG_X86_64_MAX> registers{};
-    registers[PERF_REG_X86_AX] = regs.ax;
-    registers[PERF_REG_X86_BX] = regs.bx;
-    registers[PERF_REG_X86_CX] = regs.cx;
-    registers[PERF_REG_X86_DX] = regs.dx;
-    registers[PERF_REG_X86_SI] = regs.si;
-    registers[PERF_REG_X86_DI] = regs.di;
-    registers[PERF_REG_X86_BP] = regs.bp;
-    registers[PERF_REG_X86_SP] = regs.sp;
-    registers[PERF_REG_X86_IP] = regs.ip;
-    registers[PERF_REG_X86_FLAGS] = regs.flags;
-    registers[PERF_REG_X86_CS] = regs.cs;
-    registers[PERF_REG_X86_SS] = regs.ss;
-    // Registers ds, es, fs, gs do not actually exist.
-    registers[PERF_REG_X86_DS] = 0ul;
-    registers[PERF_REG_X86_ES] = 0ul;
-    registers[PERF_REG_X86_FS] = 0ul;
-    registers[PERF_REG_X86_GS] = 0ul;
-    registers[PERF_REG_X86_R8] = regs.r8;
-    registers[PERF_REG_X86_R9] = regs.r9;
-    registers[PERF_REG_X86_R10] = regs.r10;
-    registers[PERF_REG_X86_R11] = regs.r11;
-    registers[PERF_REG_X86_R12] = regs.r12;
-    registers[PERF_REG_X86_R13] = regs.r13;
-    registers[PERF_REG_X86_R14] = regs.r14;
-    registers[PERF_REG_X86_R15] = regs.r15;
-    return registers;
-  }
 };
 
 class CallchainSamplePerfEvent : public PerfEvent {
  public:
   perf_event_callchain_sample_fixed ring_buffer_record;
   std::vector<uint64_t> ips;
-  explicit CallchainSamplePerfEvent(uint64_t callchain_size) : ips(callchain_size) {
+  perf_event_sample_regs_user_all regs;
+  dynamically_sized_perf_event_sample_stack_user stack;
+
+  explicit CallchainSamplePerfEvent(uint64_t callchain_size, uint64_t dyn_stack_size)
+      : ips(callchain_size), stack{dyn_stack_size} {
     ring_buffer_record.nr = callchain_size;
   }
 
@@ -252,6 +259,14 @@ class CallchainSamplePerfEvent : public PerfEvent {
   const uint64_t* GetCallchain() const { return ips.data(); }
 
   uint64_t GetCallchainSize() const { return ring_buffer_record.nr; }
+
+  [[nodiscard]] std::array<uint64_t, PERF_REG_X86_64_MAX> GetRegisters() const {
+    return perf_event_sample_regs_user_all_to_register_array(regs);
+  }
+
+  [[nodiscard]] const char* GetStackData() const { return stack.data.get(); }
+  [[nodiscard]] char* GetStackData() { return stack.data.get(); }
+  [[nodiscard]] uint64_t GetStackSize() const { return stack.dyn_size; }
 };
 
 class AbstractUprobesPerfEvent {

--- a/src/LinuxTracing/PerfEventOpen.cpp
+++ b/src/LinuxTracing/PerfEventOpen.cpp
@@ -93,7 +93,7 @@ int callchain_sample_event_open(uint64_t period_ns, pid_t pid, int32_t cpu) {
   pe.exclude_callchain_kernel = true;
 
   // Also capture a small part of the stack and the registers to allow patching the callers of
-  // leaf functions. This is done by unwinding the first frame using DWARF.
+  // leaf functions. This is done by unwinding the first two frame using DWARF.
   pe.sample_type |= PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER;
   pe.sample_regs_user = SAMPLE_REGS_USER_ALL;
   pe.sample_stack_user = SAMPLE_STACK_USER_SIZE_128BYTES;

--- a/src/LinuxTracing/PerfEventOpen.cpp
+++ b/src/LinuxTracing/PerfEventOpen.cpp
@@ -92,10 +92,11 @@ int callchain_sample_event_open(uint64_t period_ns, pid_t pid, int32_t cpu) {
   pe.sample_max_stack = 127;
   pe.exclude_callchain_kernel = true;
 
-  // Also capture a small part of the stack and the registers to allow patching leaf functions.
+  // Also capture a small part of the stack and the registers to allow patching the callers of
+  // leaf functions. This is done by unwinding the first frame using DWARF.
   pe.sample_type |= PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER;
   pe.sample_regs_user = SAMPLE_REGS_USER_ALL;
-  pe.sample_stack_user = SAMPLE_STACK_USER_SIZE_ON_CALLCHAINS;
+  pe.sample_stack_user = SAMPLE_STACK_USER_SIZE_128BYTES;
 
   return generic_event_open(&pe, pid, cpu);
 }

--- a/src/LinuxTracing/PerfEventOpen.cpp
+++ b/src/LinuxTracing/PerfEventOpen.cpp
@@ -92,7 +92,7 @@ int callchain_sample_event_open(uint64_t period_ns, pid_t pid, int32_t cpu) {
   pe.sample_max_stack = 127;
   pe.exclude_callchain_kernel = true;
 
-  // Also capture a small part of the stack to allow patching leaf functions.
+  // Also capture a small part of the stack and the registers to allow patching leaf functions.
   pe.sample_type |= PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER;
   pe.sample_regs_user = SAMPLE_REGS_USER_ALL;
   pe.sample_stack_user = SAMPLE_STACK_USER_SIZE_ON_CALLCHAINS;

--- a/src/LinuxTracing/PerfEventOpen.cpp
+++ b/src/LinuxTracing/PerfEventOpen.cpp
@@ -92,6 +92,11 @@ int callchain_sample_event_open(uint64_t period_ns, pid_t pid, int32_t cpu) {
   pe.sample_max_stack = 127;
   pe.exclude_callchain_kernel = true;
 
+  // Also capture a small part of the stack to allow patching leaf functions.
+  pe.sample_type |= PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER;
+  pe.sample_regs_user = SAMPLE_REGS_USER_ALL;
+  pe.sample_stack_user = SAMPLE_STACK_USER_SIZE_ON_CALLCHAINS;
+
   return generic_event_open(&pe, pid, cpu);
 }
 

--- a/src/LinuxTracing/PerfEventOpen.h
+++ b/src/LinuxTracing/PerfEventOpen.h
@@ -103,7 +103,7 @@ static constexpr uint64_t SAMPLE_REGS_USER_SP_IP_ARGUMENTS =
 //  some setting.
 static constexpr uint16_t SAMPLE_STACK_USER_SIZE = 65000;
 
-// Arbitrary small value, that is should be large enough to contain the complete last frame.
+// Arbitrary small value, that should be large enough to contain the complete last frame.
 // Note that we don't have any guarantee that the sample is large enough.
 static constexpr uint16_t SAMPLE_STACK_USER_SIZE_128BYTES = 128;
 

--- a/src/LinuxTracing/PerfEventOpen.h
+++ b/src/LinuxTracing/PerfEventOpen.h
@@ -102,6 +102,7 @@ static constexpr uint64_t SAMPLE_REGS_USER_SP_IP_ARGUMENTS =
 //  sample, this constant should be a parameters and should be made available in
 //  some setting.
 static constexpr uint16_t SAMPLE_STACK_USER_SIZE = 65000;
+static constexpr uint16_t SAMPLE_STACK_USER_SIZE_ON_CALLCHAINS = 128;
 
 static_assert(sizeof(void*) == 8);
 static constexpr uint16_t SAMPLE_STACK_USER_SIZE_8BYTES = 8;

--- a/src/LinuxTracing/PerfEventOpen.h
+++ b/src/LinuxTracing/PerfEventOpen.h
@@ -103,8 +103,9 @@ static constexpr uint64_t SAMPLE_REGS_USER_SP_IP_ARGUMENTS =
 //  some setting.
 static constexpr uint16_t SAMPLE_STACK_USER_SIZE = 65000;
 
-// Arbitrary small value, that is still large enough to contain the complete last frame.
-static constexpr uint16_t SAMPLE_STACK_USER_SIZE_ON_CALLCHAINS = 128;
+// Arbitrary small value, that is should be large enough to contain the complete last frame.
+// Note that we don't have any guarantee that the sample is large enough.
+static constexpr uint16_t SAMPLE_STACK_USER_SIZE_128BYTES = 128;
 
 static_assert(sizeof(void*) == 8);
 static constexpr uint16_t SAMPLE_STACK_USER_SIZE_8BYTES = 8;

--- a/src/LinuxTracing/PerfEventOpen.h
+++ b/src/LinuxTracing/PerfEventOpen.h
@@ -102,6 +102,8 @@ static constexpr uint64_t SAMPLE_REGS_USER_SP_IP_ARGUMENTS =
 //  sample, this constant should be a parameters and should be made available in
 //  some setting.
 static constexpr uint16_t SAMPLE_STACK_USER_SIZE = 65000;
+
+// Arbitrary small value, that is still large enough to contain the complete last frame.
 static constexpr uint16_t SAMPLE_STACK_USER_SIZE_ON_CALLCHAINS = 128;
 
 static_assert(sizeof(void*) == 8);

--- a/src/LinuxTracing/PerfEventReaders.cpp
+++ b/src/LinuxTracing/PerfEventReaders.cpp
@@ -121,46 +121,50 @@ std::unique_ptr<CallchainSamplePerfEvent> ConsumeCallchainSamplePerfEvent(
   uint64_t nr = 0;
   ring_buffer->ReadValueAtOffset(&nr, offsetof(perf_event_callchain_sample_fixed, nr));
 
-  uint64_t size_in_bytes = nr * sizeof(uint64_t) / sizeof(char);
+  uint64_t size_of_ips_in_bytes = nr * sizeof(uint64_t) / sizeof(char);
 
   // We expect the following layout of the perf event:
   //  struct {
   //    struct perf_event_header header;
-  //    u64 sample_id; /* if PERF_SAMPLE_IDENTIFIER */
-  //    u32 pid, tid;  /* if PERF_SAMPLE_TID */
-  //    u64 time;      /* if PERF_SAMPLE_TIME */
-  //    u64 stream_id; /* if PERF_SAMPLE_STREAM_ID */
-  //    u32 cpu, res;  /* if PERF_SAMPLE_CPU */
-  //    u64 nr;          /* if PERF_SAMPLE_CALLCHAIN */
-  //    u64 ips[nr];     /* if PERF_SAMPLE_CALLCHAIN */
-  //    u64 abi; /* if PERF_SAMPLE_REGS_USER */
-  //    u64 regs[weight(mask)];
-  //    u64 size;        /* if PERF_SAMPLE_STACK_USER */
-  //    char data[size]; /* if PERF_SAMPLE_STACK_USER */
-  //    u64 dyn_size;    /* if PERF_SAMPLE_STACK_USER &&
-  //                        size != 0 */
+  //    u64 sample_id;          /* if PERF_SAMPLE_IDENTIFIER */
+  //    u32 pid, tid;           /* if PERF_SAMPLE_TID */
+  //    u64 time;               /* if PERF_SAMPLE_TIME */
+  //    u64 stream_id;          /* if PERF_SAMPLE_STREAM_ID */
+  //    u32 cpu, res;           /* if PERF_SAMPLE_CPU */
+  //    u64 nr;                 /* if PERF_SAMPLE_CALLCHAIN */
+  //    u64 ips[nr];            /* if PERF_SAMPLE_CALLCHAIN */
+  //    u64 abi;                /* if PERF_SAMPLE_REGS_USER */
+  //    u64 regs[weight(mask)]; /* if PERF_SAMPLE_REGS_USER */
+  //    u64 size;               /* if PERF_SAMPLE_STACK_USER */
+  //    char data[size];        /* if PERF_SAMPLE_STACK_USER */
+  //    u64 dyn_size;           /* if PERF_SAMPLE_STACK_USER && size != 0 */
   //  };
   // Unfortunately, the number of `ips` is dynamic, so we need to compute the offsets by hand,
   // rather than relying on a struct.
 
   auto offset_of_ips = offsetof(perf_event_callchain_sample_fixed, nr) +
                        sizeof(perf_event_callchain_sample_fixed::nr);
-  auto offset_of_regs_user = offset_of_ips + size_in_bytes;
-  auto offset_of_size = offset_of_regs_user + sizeof(perf_event_sample_regs_user_all);
-  auto offset_of_data = offset_of_regs_user + sizeof(perf_event_sample_regs_user_all);
+  auto offset_of_regs_user_struct = offset_of_ips + size_of_ips_in_bytes;
+  auto offset_of_size = offset_of_regs_user_struct + sizeof(perf_event_sample_regs_user_all);
+  auto offset_of_data = offset_of_size + sizeof(uint64_t);
 
-  uint64_t dyn_stack_size = 0;
-  ring_buffer->ReadRawAtOffset(&dyn_stack_size, offset_of_size, sizeof(uint64_t));
-  auto event = std::make_unique<CallchainSamplePerfEvent>(nr, dyn_stack_size);
+  uint64_t size = 0;
+  ring_buffer->ReadRawAtOffset(&size, offset_of_size, sizeof(uint64_t));
+
+  auto offset_of_dyn_size = offset_of_data + (size * sizeof(char));
+
+  uint64_t dyn_size = 0;
+  ring_buffer->ReadRawAtOffset(&dyn_size, offset_of_dyn_size, sizeof(uint64_t));
+  auto event = std::make_unique<CallchainSamplePerfEvent>(nr, dyn_size);
   event->ring_buffer_record.header = header;
   ring_buffer->ReadValueAtOffset(&event->ring_buffer_record.sample_id,
                                  offsetof(perf_event_callchain_sample_fixed, sample_id));
 
-  ring_buffer->ReadRawAtOffset(event->ips.data(), offset_of_ips, size_in_bytes);
+  ring_buffer->ReadRawAtOffset(event->ips.data(), offset_of_ips, size_of_ips_in_bytes);
 
-  ring_buffer->ReadRawAtOffset(&event->regs, offset_of_regs_user,
+  ring_buffer->ReadRawAtOffset(&event->regs, offset_of_regs_user_struct,
                                sizeof(perf_event_sample_regs_user_all));
-  ring_buffer->ReadRawAtOffset(event->stack.data.get(), offset_of_data, dyn_stack_size);
+  ring_buffer->ReadRawAtOffset(event->stack.data.get(), offset_of_data, dyn_size);
   ring_buffer->SkipRecord(header);
   return event;
 }

--- a/src/LinuxTracing/PerfEventReaders.cpp
+++ b/src/LinuxTracing/PerfEventReaders.cpp
@@ -142,16 +142,16 @@ std::unique_ptr<CallchainSamplePerfEvent> ConsumeCallchainSamplePerfEvent(
   // Unfortunately, the number of `ips` is dynamic, so we need to compute the offsets by hand,
   // rather than relying on a struct.
 
-  auto offset_of_ips = offsetof(perf_event_callchain_sample_fixed, nr) +
-                       sizeof(perf_event_callchain_sample_fixed::nr);
-  auto offset_of_regs_user_struct = offset_of_ips + size_of_ips_in_bytes;
-  auto offset_of_size = offset_of_regs_user_struct + sizeof(perf_event_sample_regs_user_all);
-  auto offset_of_data = offset_of_size + sizeof(uint64_t);
+  size_t offset_of_ips = offsetof(perf_event_callchain_sample_fixed, nr) +
+                         sizeof(perf_event_callchain_sample_fixed::nr);
+  size_t offset_of_regs_user_struct = offset_of_ips + size_of_ips_in_bytes;
+  size_t offset_of_size = offset_of_regs_user_struct + sizeof(perf_event_sample_regs_user_all);
+  size_t offset_of_data = offset_of_size + sizeof(uint64_t);
 
   uint64_t size = 0;
   ring_buffer->ReadRawAtOffset(&size, offset_of_size, sizeof(uint64_t));
 
-  auto offset_of_dyn_size = offset_of_data + (size * sizeof(char));
+  size_t offset_of_dyn_size = offset_of_data + (size * sizeof(char));
 
   uint64_t dyn_size = 0;
   ring_buffer->ReadRawAtOffset(&dyn_size, offset_of_dyn_size, sizeof(uint64_t));

--- a/src/LinuxTracing/PerfEventRecords.h
+++ b/src/LinuxTracing/PerfEventRecords.h
@@ -98,6 +98,12 @@ struct __attribute__((__packed__)) perf_event_sample_stack_user_8bytes {
   uint64_t dyn_size;
 };
 
+struct __attribute__((__packed__)) perf_event_sample_stack_user_128bytes {
+  uint64_t size;
+  char data[SAMPLE_STACK_USER_SIZE];
+  uint64_t dyn_size;
+};
+
 struct __attribute__((__packed__)) perf_event_stack_sample {
   perf_event_header header;
   perf_event_sample_id_tid_time_streamid_cpu sample_id;
@@ -110,6 +116,9 @@ struct __attribute__((__packed__)) perf_event_callchain_sample_fixed {
   perf_event_sample_id_tid_time_streamid_cpu sample_id;
   uint64_t nr;
   // The rest of the sample is a uint64_t[nr] that we read dynamically.
+  // Following this there is:
+  // perf_event_sample_regs_user_sp_ip_arguments regs;
+  // perf_event_sample_stack_user_8bytes stack;
 };
 
 struct __attribute__((__packed__)) perf_event_sp_ip_arguments_8bytes_sample {

--- a/src/LinuxTracing/PerfEventRecords.h
+++ b/src/LinuxTracing/PerfEventRecords.h
@@ -100,7 +100,7 @@ struct __attribute__((__packed__)) perf_event_sample_stack_user_8bytes {
 
 struct __attribute__((__packed__)) perf_event_sample_stack_user_128bytes {
   uint64_t size;
-  char data[SAMPLE_STACK_USER_SIZE];
+  char data[SAMPLE_STACK_USER_SIZE_ON_CALLCHAINS];
   uint64_t dyn_size;
 };
 
@@ -115,8 +115,8 @@ struct __attribute__((__packed__)) perf_event_callchain_sample_fixed {
   perf_event_header header;
   perf_event_sample_id_tid_time_streamid_cpu sample_id;
   uint64_t nr;
-  // The rest of the sample is a uint64_t[nr] that we read dynamically.
-  // Following this there is:
+  // Following this field there are the following fields, which we read dynamically:
+  // uint64_t[nr] ips;
   // perf_event_sample_regs_user_sp_ip_arguments regs;
   // perf_event_sample_stack_user_8bytes stack;
 };

--- a/src/LinuxTracing/PerfEventRecords.h
+++ b/src/LinuxTracing/PerfEventRecords.h
@@ -100,7 +100,7 @@ struct __attribute__((__packed__)) perf_event_sample_stack_user_8bytes {
 
 struct __attribute__((__packed__)) perf_event_sample_stack_user_128bytes {
   uint64_t size;
-  char data[SAMPLE_STACK_USER_SIZE_ON_CALLCHAINS];
+  char data[SAMPLE_STACK_USER_SIZE_128BYTES];
   uint64_t dyn_size;
 };
 
@@ -118,7 +118,7 @@ struct __attribute__((__packed__)) perf_event_callchain_sample_fixed {
   // Following this field there are the following fields, which we read dynamically:
   // uint64_t[nr] ips;
   // perf_event_sample_regs_user_sp_ip_arguments regs;
-  // perf_event_sample_stack_user_8bytes stack;
+  // perf_event_sample_stack_user_128bytes stack;
 };
 
 struct __attribute__((__packed__)) perf_event_sp_ip_arguments_8bytes_sample {


### PR DESCRIPTION
In order to patch callchains of leaf functions resulting from
frame-pointer-based unwinding, we will need the top of the stack
to unwind the second-last frame. Further, the register content
will be required.

This prepares this change, by adding 128 bytes of the stack as well
as the register content.

Test: LinuxTracingIntegrationTest does not get broken.