### PR TITLE
Import opengl32sw.dll with Orbit

### DIFF
--- a/third_party/conan/configs/windows/profiles/msvc2019_relwithdebinfo_ninja
+++ b/third_party/conan/configs/windows/profiles/msvc2019_relwithdebinfo_ninja
@@ -2,6 +2,9 @@ include(msvc2019_relwithdebinfo)
 
 [settings]
 ninja:build_type=Release
+llvmpipe:build_type=Release
+[options]
+OrbitProfiler:deploy_opengl_software_renderer=True
 [build_requires]
 &: ninja/1.10.2
 [env]

--- a/third_party/conan/recipes/llvmpipe/conandata.yml
+++ b/third_party/conan/recipes/llvmpipe/conandata.yml
@@ -1,0 +1,7 @@
+sources:
+  "21.0.3":
+    url: "https://archive.mesa3d.org/mesa-21.0.3.tar.xz"
+    sha256: "565c6f4bd2d5747b919454fc1d439963024fc78ca56fd05158c3b2cde2f6912b"
+patches:
+  "21.0.3":
+    - patch_file: "patches/21.0.3-llvm.patch"

--- a/third_party/conan/recipes/llvmpipe/conanfile.py
+++ b/third_party/conan/recipes/llvmpipe/conanfile.py
@@ -1,0 +1,42 @@
+from conans import ConanFile, Meson, tools
+
+
+class LlvmpipeConan(ConanFile):
+    name = "llvmpipe"
+    version = "21.0.3"
+    license = "MIT"
+    author = "Henning Becker"
+    description = "LLVMPIPE is an OpenGL software rasterizer"
+    settings = "os", "compiler", "build_type", "arch"
+    no_copy_source = True
+    generators = "pkg_config"
+    exports_sources = "patches/*"
+
+    requires = [("llvm-core/11.1.0@orbitdeps/stable", "private"),
+                ("zlib/1.2.11", "private")]
+    build_requires = "winflexbison/2.5.24", "pkgconf/1.7.3", "meson/0.57.2"
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+
+        for patch in self.conan_data.get('patches', {}).get(self.version, []):
+            tools.patch(**patch)
+
+    def build(self):
+        definitions  = {}
+        definitions["gallium-drivers"]="swrast"
+        definitions["llvm"]="enabled"
+        definitions["shared-llvm"]="disabled"
+        definitions["llvm-rtti"]="enabled" if self.options["llvm-core"].rtti else "disabled"
+
+        meson = Meson(self)
+        meson.configure(source_folder="mesa-{}".format(self.version), defs=definitions, args=["--debug"])
+        meson.build()
+        meson.install()
+
+    def package(self):
+        self.copy("*license.rst", keep_path=False)
+
+    def package_info(self):
+        self.cpp_info.libs = ["opengl32"]
+

--- a/third_party/conan/recipes/llvmpipe/patches/21.0.3-llvm.patch
+++ b/third_party/conan/recipes/llvmpipe/patches/21.0.3-llvm.patch
@@ -1,0 +1,20 @@
+--- a/mesa-21.0.3/meson.build	2021-04-21 19:41:10.486740600 +0200
++++ b/mesa-21.0.3/meson.build	2021-04-26 21:04:29.005757000 +0200
+@@ -1561,7 +1561,7 @@
+ with_llvm = false
+ if _llvm != 'disabled'
+   dep_llvm = dependency(
+-    'llvm',
++    'llvm-core',
+     version : _llvm_version,
+     modules : llvm_modules,
+     optional_modules : llvm_optional_modules,
+@@ -1592,7 +1592,7 @@
+     _rtti = subproject('llvm').get_variable('has_rtti', true)
+   else
+     # The CMake finder will return 'ON', the llvm-config will return 'YES'
+-    _rtti = ['ON', 'YES'].contains(dep_llvm.get_variable(cmake : 'LLVM_ENABLE_RTTI', configtool: 'has-rtti'))
++    _rtti = true
+   endif
+   if not _rtti
+     if with_gallium_nouveau


### PR DESCRIPTION
This is adding support for the LLVMPIPE OpenGL software renderer.

Our conan recipe has now an options which enables importing that
software renderer library such that it will be packaged with Orbit.

This also enables this option for the `msvc2019_relwithdebinfo_ninja`
which we use on the CI.