### PR TITLE
Disable Orbit Api on capture stop

### DIFF
--- a/src/Api/CMakeLists.txt
+++ b/src/Api/CMakeLists.txt
@@ -45,10 +45,10 @@ target_compile_options(ApiLib PRIVATE ${STRICT_COMPILE_FLAGS})
 target_compile_features(ApiLib PUBLIC cxx_std_17)
 
 target_sources(ApiLib PUBLIC
-        include/Api/InitializeInTracee.h)
+        include/Api/EnableInTracee.h)
 
 target_sources(ApiLib PRIVATE
-        InitializeInTracee.cpp)
+        EnableInTracee.cpp)
 
 target_link_libraries(ApiLib PUBLIC
         ApiInterface

--- a/src/Api/Orbit.cpp
+++ b/src/Api/Orbit.cpp
@@ -102,10 +102,10 @@ static void orbit_api_initialize_v0(orbit_api_v0* api) {
   api->initialized = 1;
 }
 
-// The "orbit_api_enable" function is called remotely by OrbitService on every capture start for all
-// api function tables. It is also called on every capture stop to disable the api so that the api
-// calls early out at the call site.
-void orbit_api_enable(uint64_t address, uint64_t api_version, bool enabled) {
+// The "orbit_api_set_enabled" function is called remotely by OrbitService on every capture start
+// for all api function tables. It is also called on every capture stop to disable the api so that
+// the api calls early out at the call site.
+void orbit_api_set_enabled(uint64_t address, uint64_t api_version, bool enabled) {
   LOG("%s Orbit API at address %#x, version %u", enabled ? "Enabling" : "Disabling", address,
       api_version);
   if (api_version > kOrbitApiVersion) {

--- a/src/Api/include/Api/EnableInTracee.h
+++ b/src/Api/include/Api/EnableInTracee.h
@@ -10,8 +10,8 @@
 
 namespace orbit_api {
 
-ErrorMessageOr<void> EnableApiInTracee(const orbit_grpc_protos::CaptureOptions& capture_options,
-                                       bool enabled);
+ErrorMessageOr<void> EnableApiInTracee(const orbit_grpc_protos::CaptureOptions& capture_options);
+ErrorMessageOr<void> DisableApiInTracee(const orbit_grpc_protos::CaptureOptions& capture_options);
 
 }  // namespace orbit_api
 

--- a/src/Api/include/Api/EnableInTracee.h
+++ b/src/Api/include/Api/EnableInTracee.h
@@ -2,15 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef ORBIT_API_INITIALIZE_IN_TRACEE_H_
-#define ORBIT_API_INITIALIZE_IN_TRACEE_H_
+#ifndef ORBIT_API_ENABLE_IN_TRACEE_H_
+#define ORBIT_API_ENABLE_IN_TRACEE_H_
 
 #include "OrbitBase/Result.h"
 #include "capture.pb.h"
 
 namespace orbit_api {
 
-ErrorMessageOr<void> InitializeInTracee(const orbit_grpc_protos::CaptureOptions& capture_options);
+ErrorMessageOr<void> EnableApiInTracee(const orbit_grpc_protos::CaptureOptions& capture_options,
+                                       bool enabled);
 
 }  // namespace orbit_api
 

--- a/src/Api/include/Api/Orbit.h
+++ b/src/Api/include/Api/Orbit.h
@@ -293,7 +293,7 @@ typedef enum {
 enum { kOrbitApiVersion = 0 };
 
 struct orbit_api_v0 {
-  uint32_t active;
+  uint32_t enabled;
   uint32_t initialized;
   void (*start)(const char* name, orbit_api_color color);
   void (*stop)();
@@ -316,14 +316,14 @@ extern ORBIT_EXPORT void* orbit_api_get_function_table_address_v0();
   orbit_api_v0 g_orbit_api_v0; \
   void* orbit_api_get_function_table_address_v0() { return &g_orbit_api_v0; }
 
-inline bool orbit_api_active() {
-  bool active = g_orbit_api_v0.active;
+inline bool orbit_api_enabled() {
+  bool enabled = g_orbit_api_v0.initialized && g_orbit_api_v0.enabled;
   ORBIT_THREAD_FENCE_ACQUIRE();
-  return active;
+  return enabled;
 }
 
 #define ORBIT_CALL(function_name) \
-  if (orbit_api_active() && g_orbit_api_v0.function_name) g_orbit_api_v0.function_name
+  if (orbit_api_enabled() && g_orbit_api_v0.function_name) g_orbit_api_v0.function_name
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/Api/include/Api/Orbit.h
+++ b/src/Api/include/Api/Orbit.h
@@ -316,14 +316,14 @@ extern ORBIT_EXPORT void* orbit_api_get_function_table_address_v0();
   orbit_api_v0 g_orbit_api_v0; \
   void* orbit_api_get_function_table_address_v0() { return &g_orbit_api_v0; }
 
-inline bool orbit_api_enabled() {
-  bool enabled = g_orbit_api_v0.initialized && g_orbit_api_v0.enabled;
+inline bool orbit_api_active() {
+  bool initialized = g_orbit_api_v0.initialized;
   ORBIT_THREAD_FENCE_ACQUIRE();
-  return enabled;
+  return initialized && g_orbit_api_v0.enabled;
 }
 
 #define ORBIT_CALL(function_name) \
-  if (orbit_api_enabled() && g_orbit_api_v0.function_name) g_orbit_api_v0.function_name
+  if (orbit_api_active() && g_orbit_api_v0.function_name) g_orbit_api_v0.function_name
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/OrbitBase/Tracing.cpp
+++ b/src/OrbitBase/Tracing.cpp
@@ -200,9 +200,9 @@ void InitializeTracing() {
   g_orbit_api_v0.track_uint64 = &orbit_api_track_uint64;
   g_orbit_api_v0.track_float = &orbit_api_track_float;
   g_orbit_api_v0.track_double = &orbit_api_track_double;
-  g_orbit_api_v0.initialized = 1;
   std::atomic_thread_fence(std::memory_order_release);
-  g_orbit_api_v0.active = 1;
+  g_orbit_api_v0.initialized = 1;
+  g_orbit_api_v0.enabled = 1;
 }
 
 }  // namespace orbit_base

--- a/src/OrbitTest/OrbitTest.cpp
+++ b/src/OrbitTest/OrbitTest.cpp
@@ -127,7 +127,15 @@ static void ExecuteTask(uint32_t id) {
   ORBIT_STOP_ASYNC(id);
 }
 
+void OrbitTest::OutputOrbitApiState() {
+  while (!m_ExitRequested) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    LOG("g_orbit_api_v0.enabled = %u", g_orbit_api_v0.enabled);
+  }
+}
+
 void OrbitTest::ManualInstrumentationApiTest() {
+  thread_pool_->Schedule([this]() { OutputOrbitApiState(); });
   while (!m_ExitRequested) {
     ORBIT_SCOPE("ORBIT_SCOPE_TEST");
     ORBIT_SCOPE_WITH_COLOR("ORBIT_SCOPE_TEST_WITH_COLOR", orbit_api_color(0xff0000ff));

--- a/src/OrbitTest/OrbitTest.h
+++ b/src/OrbitTest/OrbitTest.h
@@ -27,6 +27,7 @@ class OrbitTest {
   void TestFunc2(uint32_t a_Depth = 0);
   void BusyWork(uint64_t microseconds);
   void ManualInstrumentationApiTest();
+  void OutputOrbitApiState();
 
  private:
   bool m_ExitRequested = false;

--- a/src/Service/CaptureServiceImpl.cpp
+++ b/src/Service/CaptureServiceImpl.cpp
@@ -266,7 +266,7 @@ grpc::Status CaptureServiceImpl::Capture(
 
   // Enable Orbit API in tracee.
   if (capture_options.enable_api()) {
-    auto result = orbit_api::EnableApiInTracee(capture_options, /*enabled=*/true);
+    auto result = orbit_api::EnableApiInTracee(capture_options);
     if (result.has_error()) ERROR("Enabling Orbit Api: %s", result.error().message());
   }
 
@@ -291,7 +291,7 @@ grpc::Status CaptureServiceImpl::Capture(
 
   // Disable Orbit API in tracee.
   if (capture_options.enable_api()) {
-    auto result = orbit_api::EnableApiInTracee(capture_options, /*enabled=*/false);
+    auto result = orbit_api::DisableApiInTracee(capture_options);
     if (result.has_error()) ERROR("Disabling Orbit Api: %s", result.error().message());
   }
 

--- a/src/Service/CaptureServiceImpl.cpp
+++ b/src/Service/CaptureServiceImpl.cpp
@@ -16,7 +16,7 @@
 #include <utility>
 #include <vector>
 
-#include "Api/InitializeInTracee.h"
+#include "Api/EnableInTracee.h"
 #include "CaptureEventBuffer.h"
 #include "CaptureEventSender.h"
 #include "ElfUtils/ElfFile.h"
@@ -264,11 +264,10 @@ grpc::Status CaptureServiceImpl::Capture(
 
   const CaptureOptions& capture_options = request.capture_options();
 
-  // Initialize Orbit API in tracee.
+  // Enable Orbit API in tracee.
   if (capture_options.enable_api()) {
-    if (auto result = orbit_api::InitializeInTracee(capture_options); result.has_error()) {
-      ERROR("Initializing Orbit Api: %s", result.error().message());
-    }
+    auto result = orbit_api::EnableApiInTracee(capture_options, /*enabled=*/true);
+    if (result.has_error()) ERROR("Enabling Orbit Api: %s", result.error().message());
   }
 
   uint64_t capture_start_timestamp_ns = orbit_base::CaptureTimestampNs();
@@ -289,6 +288,12 @@ grpc::Status CaptureServiceImpl::Capture(
   while (reader_writer->Read(&request)) {
   }
   LOG("Client finished writing on Capture's gRPC stream: stopping capture");
+
+  // Disable Orbit API in tracee.
+  if (capture_options.enable_api()) {
+    auto result = orbit_api::EnableApiInTracee(capture_options, /*enabled=*/false);
+    if (result.has_error()) ERROR("Disabling Orbit Api: %s", result.error().message());
+  }
 
   StopInternalProducersAndCaptureStartStopListenersInParallel(
       &tracing_handler, &memory_info_handler, &capture_start_stop_listeners_);


### PR DESCRIPTION
Make sure Orbit Api is fully disabled on capture stop by setting
the "enabled" flag to false which makes api functions early out
at call site. This change also makes it possible to disable the api
from the UI (it was only possible to turn it on, not off previously).

Test: Ran OrbitTest and verified that the "enabled" flag is indeed
set to false on capture stop and that we can toggle back and forth
with expected results.