### PR TITLE
Add utility methods to collect cgroup & process memory usage information

### DIFF
--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -325,6 +325,24 @@ message SystemMemoryUsage {
   int64 cached_kb = 6;
 }
 
+message ProcessMemoryUsage {
+  uint32 pid = 1;
+  uint64 timestamp_ns = 2;
+  // These fields are retrieved from /proc/<pid>/status.
+  int64 vm_rss_kb = 3;
+}
+
+message CGroupMemoryUsage {
+  string cgroup_name = 1;
+  uint64 timestamp_ns = 2;
+  // This field is retrieved from
+  // /sys/fs/cgroup/memory/<cgroup_name>/memory.stat.
+  int64 rss_bytes = 3;
+  // This field is retrieved from
+  // /sys/fs/cgroup/memory/<cgroup_name>/memory.limit_in_bytes.
+  int64 limit_bytes = 4;
+}
+
 message ModulesSnapshot {
   int32 pid = 1;
   uint64 timestamp_ns = 2;

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -323,13 +323,18 @@ message SystemMemoryUsage {
   int64 available_kb = 4;
   int64 buffers_kb = 5;
   int64 cached_kb = 6;
+  // These fields are retrieved from /proc/vmstat.
+  int64 pgfault = 7;
+  int64 pgmajfault = 8;
 }
 
 message ProcessMemoryUsage {
   uint32 pid = 1;
   uint64 timestamp_ns = 2;
-  // These fields are retrieved from /proc/<pid>/status.
-  int64 vm_rss_kb = 3;
+  // These fields are retrieved from /proc/<pid>/stat.
+  int64 rss_pages = 3;
+  int64 minflt = 4;
+  int64 majflt = 5;
 }
 
 message CGroupMemoryUsage {
@@ -342,6 +347,8 @@ message CGroupMemoryUsage {
   // /sys/fs/cgroup/memory/<cgroup_name>/memory.stat.
   int64 rss_bytes = 4;
   int64 mapped_file_bytes = 5;
+  int64 pgfault = 6;
+  int64 pgmajfault = 7;
 }
 
 message ModulesSnapshot {

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -336,11 +336,12 @@ message CGroupMemoryUsage {
   string cgroup_name = 1;
   uint64 timestamp_ns = 2;
   // This field is retrieved from
-  // /sys/fs/cgroup/memory/<cgroup_name>/memory.stat.
-  int64 rss_bytes = 3;
-  // This field is retrieved from
   // /sys/fs/cgroup/memory/<cgroup_name>/memory.limit_in_bytes.
-  int64 limit_bytes = 4;
+  int64 limit_bytes = 3;
+  // These fields are retrieved from
+  // /sys/fs/cgroup/memory/<cgroup_name>/memory.stat.
+  int64 rss_bytes = 4;
+  int64 mapped_file_bytes = 5;
 }
 
 message ModulesSnapshot {

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -317,13 +317,15 @@ message ModuleUpdateEvent {
 
 message SystemMemoryUsage {
   uint64 timestamp_ns = 1;
-  // These fields are retrieved from /proc/meminfo.
+  // These fields are retrieved from /proc/meminfo. See
+  // https://man7.org/linux/man-pages/man5/proc.5.html for the documentation.
   int64 total_kb = 2;
   int64 free_kb = 3;
   int64 available_kb = 4;
   int64 buffers_kb = 5;
   int64 cached_kb = 6;
-  // These fields are retrieved from /proc/vmstat.
+  // These fields are retrieved from /proc/vmstat. See
+  // https://man7.org/linux/man-pages/man5/proc.5.html for the documentation.
   int64 pgfault = 7;
   int64 pgmajfault = 8;
 }
@@ -331,7 +333,8 @@ message SystemMemoryUsage {
 message ProcessMemoryUsage {
   uint32 pid = 1;
   uint64 timestamp_ns = 2;
-  // These fields are retrieved from /proc/<pid>/stat.
+  // These fields are retrieved from /proc/<pid>/stat. See
+  // https://man7.org/linux/man-pages/man5/proc.5.html for the documentation.
   int64 rss_pages = 3;
   int64 minflt = 4;
   int64 majflt = 5;
@@ -341,14 +344,23 @@ message CGroupMemoryUsage {
   string cgroup_name = 1;
   uint64 timestamp_ns = 2;
   // This field is retrieved from
-  // /sys/fs/cgroup/memory/<cgroup_name>/memory.limit_in_bytes.
+  // /sys/fs/cgroup/memory/<cgroup_name>/memory.limit_in_bytes. See
+  // https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt for the
+  // documentation.
   int64 limit_bytes = 3;
   // These fields are retrieved from
-  // /sys/fs/cgroup/memory/<cgroup_name>/memory.stat.
+  // /sys/fs/cgroup/memory/<cgroup_name>/memory.stat. See
+  // https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt section 5.2
+  // for the documentation.
   int64 rss_bytes = 4;
   int64 mapped_file_bytes = 5;
   int64 pgfault = 6;
   int64 pgmajfault = 7;
+  int64 unevictable_bytes = 8;
+  int64 inactive_anon_bytes = 9;
+  int64 active_anon_bytes = 10;
+  int64 inactive_file_bytes = 11;
+  int64 active_file_bytes = 12;
 }
 
 message ModulesSnapshot {

--- a/src/MemoryTracing/MemoryInfoProducer.cpp
+++ b/src/MemoryTracing/MemoryInfoProducer.cpp
@@ -44,11 +44,10 @@ void MemoryInfoProducer::Run() {
 }
 
 void MemoryInfoProducer::ProduceSystemMemoryUsageAndSendToListener() {
-  std::optional<SystemMemoryUsage> system_memory_usage;
   absl::Time scheduled_time = absl::Now();
   absl::MutexLock lock(&exit_requested_mutex_);
   while (!exit_requested_) {
-    system_memory_usage = GetSystemMemoryUsage();
+    ErrorMessageOr<SystemMemoryUsage> system_memory_usage = GetSystemMemoryUsage();
     if (system_memory_usage.has_value()) {
       listener_->OnSystemMemoryUsage(system_memory_usage.value());
     }

--- a/src/MemoryTracing/MemoryTracingUtils.cpp
+++ b/src/MemoryTracing/MemoryTracingUtils.cpp
@@ -5,6 +5,7 @@
 #include "MemoryTracingUtils.h"
 
 #include <absl/strings/numbers.h>
+#include <absl/strings/str_format.h>
 #include <absl/strings/str_split.h>
 #include <stdlib.h>
 
@@ -18,15 +19,12 @@
 
 namespace orbit_memory_tracing {
 
+using orbit_grpc_protos::CGroupMemoryUsage;
 using orbit_grpc_protos::kMissingInfo;
+using orbit_grpc_protos::ProcessMemoryUsage;
 using orbit_grpc_protos::SystemMemoryUsage;
 
-std::optional<SystemMemoryUsage> ParseMemInfo(const std::string& meminfo_content) {
-  if (meminfo_content.empty()) return std::nullopt;
-
-  std::vector<std::string> lines = absl::StrSplit(meminfo_content, '\n');
-  if (lines.empty()) return std::nullopt;
-
+SystemMemoryUsage ParseMemInfo(std::string_view meminfo_content) {
   SystemMemoryUsage memory_info;
   memory_info.set_total_kb(kMissingInfo);
   memory_info.set_free_kb(kMissingInfo);
@@ -34,21 +32,24 @@ std::optional<SystemMemoryUsage> ParseMemInfo(const std::string& meminfo_content
   memory_info.set_buffers_kb(kMissingInfo);
   memory_info.set_cached_kb(kMissingInfo);
 
+  if (meminfo_content.empty()) return memory_info;
+
+  std::vector<std::string> lines = absl::StrSplit(meminfo_content, '\n');
+  if (lines.empty()) return memory_info;
+
   constexpr size_t kNumLines = 5;
   std::vector<std::string> top_lines(
       lines.begin(), lines.begin() + (lines.size() > kNumLines ? kNumLines : lines.size()));
-  for (const std::string& line : top_lines) {
+  for (std::string_view line : top_lines) {
     // Each line of the /proc/meminfo file consists of a parameter name, followed by a colon, the
-    // value of the parameter, and an option unit of measurement (e.g., "kB").
+    // value of the parameter, and an option unit of measurement (e.g., "kB"). According to the
+    // kernel code https://github.com/torvalds/linux/blob/master/fs/proc/meminfo.c, the size unit in
+    // /proc/meminfo is fixed to "kB", which implies 1024 Bytes. And this is different from the
+    // definition in http://en.wikipedia.org/wiki/Kilobyte. We keep consistent with the definition
+    // in /proc/meminfo: we report in "kB" and consider 1 kB = 1 KiloBytes = 1024 Bytes.
+    // If the line format is wrong or the unit size isn't "kB", SystemMemoryUsage won't be updated.
     std::vector<std::string> splits = absl::StrSplit(line, ' ', absl::SkipWhitespace{});
-    if (splits.size() < 3) continue;
-
-    // According to the kernel code https://github.com/torvalds/linux/blob/master/fs/proc/meminfo.c,
-    // the size unit in the file /proc/meminfo is fixed to "kB", which implies 1024 Bytes. And this
-    // is different from the definitions in http://en.wikipedia.org/wiki/Kilobyte. We keep
-    // consistent with the definition in /proc/meminfo: we report in "kB" and consider 1 kB = 1
-    // KiloBytes = 1024 Bytes.
-    CHECK(splits[2] == "kB");
+    if (splits.size() < 3 || splits[2] != "kB") continue;
 
     int64_t memory_size_value;
     if (!absl::SimpleAtoi(splits[1], &memory_size_value)) continue;
@@ -69,20 +70,154 @@ std::optional<SystemMemoryUsage> ParseMemInfo(const std::string& meminfo_content
   return memory_info;
 }
 
-std::optional<SystemMemoryUsage> GetSystemMemoryUsage() noexcept {
+ErrorMessageOr<SystemMemoryUsage> GetSystemMemoryUsage() noexcept {
   uint64_t current_timestamp_ns = orbit_base::CaptureTimestampNs();
 
   ErrorMessageOr<std::string> reading_result = orbit_base::ReadFileToString("/proc/meminfo");
-  if (!reading_result.has_value()) {
+  if (reading_result.has_error()) {
     ERROR("%s", reading_result.error().message());
-    return std::nullopt;
+    return reading_result.error();
   }
 
-  std::optional<SystemMemoryUsage> parsing_result = ParseMemInfo(reading_result.value());
-  if (parsing_result.has_value()) {
-    parsing_result.value().set_timestamp_ns(current_timestamp_ns);
-  }
+  SystemMemoryUsage parsing_result = ParseMemInfo(reading_result.value());
+  parsing_result.set_timestamp_ns(current_timestamp_ns);
   return parsing_result;
+}
+
+int64_t GetVmRssFromProcessStatus(std::string_view status_content) {
+  if (status_content.empty()) return kMissingInfo;
+
+  std::vector<std::string> lines = absl::StrSplit(status_content, '\n');
+  if (lines.empty()) return kMissingInfo;
+
+  for (std::string_view line : lines) {
+    if (absl::StartsWith(line, "VmRSS")) {
+      std::vector<std::string> splits = absl::StrSplit(line, ' ', absl::SkipWhitespace{});
+      // According to the kernel code
+      // https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/fs/proc/task_mmu.c,
+      // the size unit of the VmRSS field in the /proc/<PID>/status file is fixed to "kB", which
+      // implies 1024 Bytes. We report in "KB" in ProcessSystemUsage.
+      int64_t rss_kb;
+      if (splits.size() == 3 && splits[2] == "kB" && absl::SimpleAtoi(splits[1], &rss_kb)) {
+        return rss_kb;
+      }
+      return kMissingInfo;
+    }
+  }
+
+  return kMissingInfo;
+}
+
+ErrorMessageOr<ProcessMemoryUsage> GetProcessMemoryUsage(uint32_t pid) noexcept {
+  uint64_t current_timestamp_ns = orbit_base::CaptureTimestampNs();
+
+  // Extract the VmRSS value in kilobytes from the /proc/<pid>/status file.
+  ErrorMessageOr<std::string> reading_result =
+      orbit_base::ReadFileToString(absl::StrFormat("/proc/%d/status", pid));
+  if (reading_result.has_error()) {
+    ERROR("%s", reading_result.error().message());
+    return reading_result.error();
+  }
+  int64_t vm_rss_kb = GetVmRssFromProcessStatus(reading_result.value());
+
+  ProcessMemoryUsage process_memory_usage;
+  process_memory_usage.set_pid(pid);
+  process_memory_usage.set_timestamp_ns(current_timestamp_ns);
+  process_memory_usage.set_vm_rss_kb(vm_rss_kb);
+
+  return process_memory_usage;
+}
+
+std::string GetProcessMemoryCGroupName(std::string_view cgroup_content) {
+  if (cgroup_content.empty()) return "";
+
+  std::vector<std::string> lines = absl::StrSplit(cgroup_content, '\n');
+  if (lines.empty()) return "";
+
+  for (std::string_view line : lines) {
+    std::vector<std::string> splits = absl::StrSplit(line, absl::MaxSplits(':', 2));
+    // If find the memory cgroup, return the cgroup name without the leading "/".
+    if (splits.size() == 3 && splits[1] == "memory") return splits[2].substr(1);
+  }
+
+  return "";
+}
+
+int64_t GetCGroupMemoryLimitInBytes(std::string_view memory_limit_in_bytes_content) {
+  if (memory_limit_in_bytes_content.empty()) return kMissingInfo;
+
+  // The memory.limit_in_bytes file use "bytes" as the size unit.
+  int64_t memory_limit_in_bytes;
+  if (absl::SimpleAtoi(memory_limit_in_bytes_content, &memory_limit_in_bytes)) {
+    return memory_limit_in_bytes;
+  }
+
+  return kMissingInfo;
+}
+
+int64_t GetRssFromCGroupMemoryStat(std::string_view memory_stat_content) {
+  if (memory_stat_content.empty()) return kMissingInfo;
+
+  std::vector<std::string> lines = absl::StrSplit(memory_stat_content, '\n');
+  if (lines.empty()) return kMissingInfo;
+
+  for (std::string_view line : lines) {
+    std::vector<std::string> splits = absl::StrSplit(line, ' ', absl::SkipWhitespace{});
+    if (splits.size() == 2 && splits[0] == "rss") {
+      // According to the document https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt,
+      // the memory.stat file use "bytes" as the size unit.
+      int64_t rss_in_bytes;
+      if (absl::SimpleAtoi(splits[1], &rss_in_bytes)) return rss_in_bytes;
+      return kMissingInfo;
+    }
+  }
+
+  return kMissingInfo;
+}
+
+ErrorMessageOr<CGroupMemoryUsage> GetCGroupMemoryUsage(uint32_t pid) noexcept {
+  uint64_t current_timestamp_ns = orbit_base::CaptureTimestampNs();
+
+  // Extract cgroup name from the /proc/<pid>/cgroup file.
+  ErrorMessageOr<std::string> reading_result =
+      orbit_base::ReadFileToString(absl::StrFormat("/proc/%d/cgroup", pid));
+  if (reading_result.has_error()) {
+    ERROR("%s", reading_result.error().message());
+    return reading_result.error();
+  }
+  std::string cgroup_name = GetProcessMemoryCGroupName(reading_result.value());
+  if (cgroup_name.empty()) {
+    std::string error_message =
+        absl::StrFormat("Fail to extract the cgroup name of the target process %d.", pid);
+    ERROR("%s", error_message);
+    return ErrorMessage{std::move(error_message)};
+  }
+
+  // Extract cgroup memory limit from /sys/fs/cgroup/memory/<cgroup_name>/memory.limit_in_bytes.
+  reading_result = orbit_base::ReadFileToString(
+      absl::StrFormat("/sys/fs/cgroup/memory/%s/memory.limit_in_bytes", cgroup_name));
+  if (reading_result.has_error()) {
+    ERROR("%s", reading_result.error().message());
+    return reading_result.error();
+  }
+  int64_t cgroup_memory_limit_in_bytes = GetCGroupMemoryLimitInBytes(reading_result.value());
+
+  // Extract cgroup memory usage from the /sys/fs/cgroup/memory/<cgroup_name>/memory.stat file.
+  reading_result = orbit_base::ReadFileToString(
+      absl::StrFormat("/sys/fs/cgroup/memory/%s/memory.stat", cgroup_name));
+  if (reading_result.has_error()) {
+    ERROR("%s", reading_result.error().message());
+    return reading_result.error();
+  }
+  int64_t cgroup_rss_in_bytes = GetRssFromCGroupMemoryStat(reading_result.value());
+
+  CGroupMemoryUsage cgroup_memory_usage;
+  cgroup_memory_usage.set_cgroup_name(cgroup_name);
+  cgroup_memory_usage.set_timestamp_ns(current_timestamp_ns);
+  cgroup_memory_usage.set_limit_bytes(cgroup_memory_limit_in_bytes);
+  cgroup_memory_usage.set_rss_bytes(cgroup_rss_in_bytes);
+
+  return cgroup_memory_usage;
 }
 
 }  // namespace orbit_memory_tracing

--- a/src/MemoryTracing/MemoryTracingUtils.h
+++ b/src/MemoryTracing/MemoryTracingUtils.h
@@ -12,12 +12,14 @@
 
 namespace orbit_memory_tracing {
 
-// If the file format is incorrect or the unit size doesn't match "kB", this method returns a
-// SystemMemoryUsage with value fields set to kMissingInfo.
-[[nodiscard]] orbit_grpc_protos::SystemMemoryUsage ParseMemInfo(std::string_view meminfo_content);
+void GetValuesFromMemInfo(std::string_view meminfo_content,
+                          orbit_grpc_protos::SystemMemoryUsage* system_memory_usage);
+void GetValuesFromVmStat(std::string_view vmstat_content,
+                         orbit_grpc_protos::SystemMemoryUsage* system_memory_usage);
 [[nodiscard]] ErrorMessageOr<orbit_grpc_protos::SystemMemoryUsage> GetSystemMemoryUsage() noexcept;
 
-[[nodiscard]] int64_t GetVmRssFromProcessStatus(std::string_view status_content);
+void GetValuesFromProcessStat(std::string_view stat_content,
+                              orbit_grpc_protos::ProcessMemoryUsage* process_memory_usage);
 [[nodiscard]] ErrorMessageOr<orbit_grpc_protos::ProcessMemoryUsage> GetProcessMemoryUsage(
     uint32_t pid) noexcept;
 

--- a/src/MemoryTracing/MemoryTracingUtils.h
+++ b/src/MemoryTracing/MemoryTracingUtils.h
@@ -22,8 +22,10 @@ namespace orbit_memory_tracing {
     uint32_t pid) noexcept;
 
 [[nodiscard]] std::string GetProcessMemoryCGroupName(std::string_view cgroup_content);
-[[nodiscard]] int64_t GetCGroupMemoryLimitInBytes(std::string_view memory_limit_in_bytes_content);
-[[nodiscard]] int64_t GetRssFromCGroupMemoryStat(std::string_view memory_stat_content);
+void GetCGroupMemoryLimitInBytes(std::string_view memory_limit_in_bytes_content,
+                                 orbit_grpc_protos::CGroupMemoryUsage* cgroup_memory_usage);
+void GetValuesFromCGroupMemoryStat(std::string_view memory_stat_content,
+                                   orbit_grpc_protos::CGroupMemoryUsage* cgroup_memory_usage);
 [[nodiscard]] ErrorMessageOr<orbit_grpc_protos::CGroupMemoryUsage> GetCGroupMemoryUsage(
     uint32_t pid) noexcept;
 

--- a/src/MemoryTracing/MemoryTracingUtils.h
+++ b/src/MemoryTracing/MemoryTracingUtils.h
@@ -12,17 +12,24 @@
 
 namespace orbit_memory_tracing {
 
+[[nodiscard]] orbit_grpc_protos::SystemMemoryUsage CreateAndInitializeSystemMemoryUsage();
+// All the following GetValues methods only update the input memory proto when the input file
+// content format is correct. Before calling the GetValues methods, the memory proto fields that
+// need to be updated should be initialized to kMissingInfo, (e.g., with the CreateAndInitialize
+// method).
 void GetValuesFromMemInfo(std::string_view meminfo_content,
                           orbit_grpc_protos::SystemMemoryUsage* system_memory_usage);
 void GetValuesFromVmStat(std::string_view vmstat_content,
                          orbit_grpc_protos::SystemMemoryUsage* system_memory_usage);
 [[nodiscard]] ErrorMessageOr<orbit_grpc_protos::SystemMemoryUsage> GetSystemMemoryUsage() noexcept;
 
+[[nodiscard]] orbit_grpc_protos::ProcessMemoryUsage CreateAndInitializeProcessMemoryUsage();
 void GetValuesFromProcessStat(std::string_view stat_content,
                               orbit_grpc_protos::ProcessMemoryUsage* process_memory_usage);
 [[nodiscard]] ErrorMessageOr<orbit_grpc_protos::ProcessMemoryUsage> GetProcessMemoryUsage(
     uint32_t pid) noexcept;
 
+[[nodiscard]] orbit_grpc_protos::CGroupMemoryUsage CreateAndInitializeCGroupMemoryUsage();
 [[nodiscard]] std::string GetProcessMemoryCGroupName(std::string_view cgroup_content);
 void GetCGroupMemoryLimitInBytes(std::string_view memory_limit_in_bytes_content,
                                  orbit_grpc_protos::CGroupMemoryUsage* cgroup_memory_usage);

--- a/src/MemoryTracing/MemoryTracingUtils.h
+++ b/src/MemoryTracing/MemoryTracingUtils.h
@@ -5,13 +5,27 @@
 #ifndef MEMORY_TRACING_MEMORY_TRACING_UTILS_H_
 #define MEMORY_TRACING_MEMORY_TRACING_UTILS_H_
 
+#include <string_view>
+
+#include "OrbitBase/Result.h"
 #include "capture.pb.h"
 
 namespace orbit_memory_tracing {
 
-std::optional<orbit_grpc_protos::SystemMemoryUsage> ParseMemInfo(
-    const std::string& meminfo_content);
-std::optional<orbit_grpc_protos::SystemMemoryUsage> GetSystemMemoryUsage() noexcept;
+// If the file format is incorrect or the unit size doesn't match "kB", this method returns a
+// SystemMemoryUsage with value fields set to kMissingInfo.
+[[nodiscard]] orbit_grpc_protos::SystemMemoryUsage ParseMemInfo(std::string_view meminfo_content);
+[[nodiscard]] ErrorMessageOr<orbit_grpc_protos::SystemMemoryUsage> GetSystemMemoryUsage() noexcept;
+
+[[nodiscard]] int64_t GetVmRssFromProcessStatus(std::string_view status_content);
+[[nodiscard]] ErrorMessageOr<orbit_grpc_protos::ProcessMemoryUsage> GetProcessMemoryUsage(
+    uint32_t pid) noexcept;
+
+[[nodiscard]] std::string GetProcessMemoryCGroupName(std::string_view cgroup_content);
+[[nodiscard]] int64_t GetCGroupMemoryLimitInBytes(std::string_view memory_limit_in_bytes_content);
+[[nodiscard]] int64_t GetRssFromCGroupMemoryStat(std::string_view memory_stat_content);
+[[nodiscard]] ErrorMessageOr<orbit_grpc_protos::CGroupMemoryUsage> GetCGroupMemoryUsage(
+    uint32_t pid) noexcept;
 
 }  // namespace orbit_memory_tracing
 

--- a/src/MemoryTracing/MemoryTracingUtils.h
+++ b/src/MemoryTracing/MemoryTracingUtils.h
@@ -13,28 +13,30 @@
 namespace orbit_memory_tracing {
 
 [[nodiscard]] orbit_grpc_protos::SystemMemoryUsage CreateAndInitializeSystemMemoryUsage();
-// All the following GetValues methods only update the input memory proto when the input file
-// content format is correct. Before calling the GetValues methods, the memory proto fields that
+// All the following Update methods only update the input memory proto when the input file
+// content format is correct. Before calling the Update methods, the memory proto fields that
 // need to be updated should be initialized to kMissingInfo, (e.g., with the CreateAndInitialize
 // method).
-void GetValuesFromMemInfo(std::string_view meminfo_content,
-                          orbit_grpc_protos::SystemMemoryUsage* system_memory_usage);
-void GetValuesFromVmStat(std::string_view vmstat_content,
-                         orbit_grpc_protos::SystemMemoryUsage* system_memory_usage);
+[[nodiscard]] ErrorMessageOr<void> UpdateSystemMemoryUsageFromMemInfo(
+    std::string_view meminfo_content, orbit_grpc_protos::SystemMemoryUsage* system_memory_usage);
+[[nodiscard]] ErrorMessageOr<void> UpdateSystemMemoryUsageFromVmStat(
+    std::string_view vmstat_content, orbit_grpc_protos::SystemMemoryUsage* system_memory_usage);
 [[nodiscard]] ErrorMessageOr<orbit_grpc_protos::SystemMemoryUsage> GetSystemMemoryUsage() noexcept;
 
 [[nodiscard]] orbit_grpc_protos::ProcessMemoryUsage CreateAndInitializeProcessMemoryUsage();
-void GetValuesFromProcessStat(std::string_view stat_content,
-                              orbit_grpc_protos::ProcessMemoryUsage* process_memory_usage);
+[[nodiscard]] ErrorMessageOr<void> UpdateProcessMemoryUsageFromProcessStat(
+    std::string_view stat_content, orbit_grpc_protos::ProcessMemoryUsage* process_memory_usage);
 [[nodiscard]] ErrorMessageOr<orbit_grpc_protos::ProcessMemoryUsage> GetProcessMemoryUsage(
     uint32_t pid) noexcept;
 
 [[nodiscard]] orbit_grpc_protos::CGroupMemoryUsage CreateAndInitializeCGroupMemoryUsage();
 [[nodiscard]] std::string GetProcessMemoryCGroupName(std::string_view cgroup_content);
-void GetCGroupMemoryLimitInBytes(std::string_view memory_limit_in_bytes_content,
-                                 orbit_grpc_protos::CGroupMemoryUsage* cgroup_memory_usage);
-void GetValuesFromCGroupMemoryStat(std::string_view memory_stat_content,
-                                   orbit_grpc_protos::CGroupMemoryUsage* cgroup_memory_usage);
+[[nodiscard]] ErrorMessageOr<void> UpdateCGroupMemoryUsageFromMemoryLimitInBytes(
+    std::string_view memory_limit_in_bytes_content,
+    orbit_grpc_protos::CGroupMemoryUsage* cgroup_memory_usage);
+[[nodiscard]] ErrorMessageOr<void> UpdateCGroupMemoryUsageFromMemoryStat(
+    std::string_view memory_stat_content,
+    orbit_grpc_protos::CGroupMemoryUsage* cgroup_memory_usage);
 [[nodiscard]] ErrorMessageOr<orbit_grpc_protos::CGroupMemoryUsage> GetCGroupMemoryUsage(
     uint32_t pid) noexcept;
 

--- a/src/MemoryTracing/MemoryTracingUtilsTest.cpp
+++ b/src/MemoryTracing/MemoryTracingUtilsTest.cpp
@@ -13,41 +13,73 @@
 
 using orbit_grpc_protos::CGroupMemoryUsage;
 using orbit_grpc_protos::kMissingInfo;
+using orbit_grpc_protos::ProcessMemoryUsage;
 using orbit_grpc_protos::SystemMemoryUsage;
 
 namespace {
 
+void ResetSystemMemoryUsage(SystemMemoryUsage* system_memory_usage) {
+  system_memory_usage->set_total_kb(kMissingInfo);
+  system_memory_usage->set_free_kb(kMissingInfo);
+  system_memory_usage->set_available_kb(kMissingInfo);
+  system_memory_usage->set_buffers_kb(kMissingInfo);
+  system_memory_usage->set_cached_kb(kMissingInfo);
+  system_memory_usage->set_pgfault(kMissingInfo);
+  system_memory_usage->set_pgmajfault(kMissingInfo);
+}
+
 void ExpectSystemMemoryUsageEq(const SystemMemoryUsage& system_memory_usage,
-                               int expected_total = kMissingInfo, int expected_free = kMissingInfo,
-                               int expected_available = kMissingInfo,
-                               int expected_buffers = kMissingInfo,
-                               int expected_cached = kMissingInfo) {
-  EXPECT_EQ(system_memory_usage.total_kb(), expected_total);
-  EXPECT_EQ(system_memory_usage.free_kb(), expected_free);
-  EXPECT_EQ(system_memory_usage.available_kb(), expected_available);
-  EXPECT_EQ(system_memory_usage.buffers_kb(), expected_buffers);
-  EXPECT_EQ(system_memory_usage.cached_kb(), expected_cached);
+                               int total_kb = kMissingInfo, int free_kb = kMissingInfo,
+                               int available_kb = kMissingInfo, int buffers_kb = kMissingInfo,
+                               int cached_kb = kMissingInfo, int pgfault = kMissingInfo,
+                               int pgmajfault = kMissingInfo) {
+  EXPECT_EQ(system_memory_usage.total_kb(), total_kb);
+  EXPECT_EQ(system_memory_usage.free_kb(), free_kb);
+  EXPECT_EQ(system_memory_usage.available_kb(), available_kb);
+  EXPECT_EQ(system_memory_usage.buffers_kb(), buffers_kb);
+  EXPECT_EQ(system_memory_usage.cached_kb(), cached_kb);
+  EXPECT_EQ(system_memory_usage.pgfault(), pgfault);
+  EXPECT_EQ(system_memory_usage.pgmajfault(), pgmajfault);
+}
+
+void ResetProcessMemoryUsage(ProcessMemoryUsage* process_memory_usage) {
+  process_memory_usage->set_rss_pages(kMissingInfo);
+  process_memory_usage->set_minflt(kMissingInfo);
+  process_memory_usage->set_majflt(kMissingInfo);
+}
+
+void ExpectProcessMemoryUsageEq(const ProcessMemoryUsage& process_memory_usage,
+                                int rss_pages = kMissingInfo, int minflt = kMissingInfo,
+                                int majflt = kMissingInfo) {
+  EXPECT_EQ(process_memory_usage.rss_pages(), rss_pages);
+  EXPECT_EQ(process_memory_usage.minflt(), minflt);
+  EXPECT_EQ(process_memory_usage.majflt(), majflt);
 }
 
 void ResetCGroupMemoryUsage(CGroupMemoryUsage* cgroup_memory_usage) {
   cgroup_memory_usage->set_limit_bytes(kMissingInfo);
   cgroup_memory_usage->set_rss_bytes(kMissingInfo);
   cgroup_memory_usage->set_mapped_file_bytes(kMissingInfo);
+  cgroup_memory_usage->set_pgfault(kMissingInfo);
+  cgroup_memory_usage->set_pgmajfault(kMissingInfo);
 }
 
 void ExpectCGroupMemoryUsageEq(const CGroupMemoryUsage& cgroup_memory_usage,
                                int limit_bytes = kMissingInfo, int rss_bytes = kMissingInfo,
-                               int mapped_file_bytes = kMissingInfo) {
+                               int mapped_file_bytes = kMissingInfo, int pgfault = kMissingInfo,
+                               int pgmajfault = kMissingInfo) {
   EXPECT_EQ(cgroup_memory_usage.limit_bytes(), limit_bytes);
   EXPECT_EQ(cgroup_memory_usage.rss_bytes(), rss_bytes);
   EXPECT_EQ(cgroup_memory_usage.mapped_file_bytes(), mapped_file_bytes);
+  EXPECT_EQ(cgroup_memory_usage.pgfault(), pgfault);
+  EXPECT_EQ(cgroup_memory_usage.pgmajfault(), pgmajfault);
 }
 
 }  // namespace
 
 namespace orbit_memory_tracing {
 
-TEST(MemoryUtils, ParseMemInfo) {
+TEST(MemoryUtils, GetValuesFromMemInfo) {
   const int kMemTotal = 16396576;
   const int kMemFree = 11493816;
   const int kMemAvailable = 14378752;
@@ -115,89 +147,224 @@ SwapCached:      0 kB)",
 
   const std::string kEmptyMeminfo = "";
 
-  SystemMemoryUsage parsing_result = ParseMemInfo(kValidMeminfo);
-  ExpectSystemMemoryUsageEq(parsing_result, kMemTotal, kMemFree, kMemAvailable, kBuffers, kCached);
+  SystemMemoryUsage system_memory_usage;
+  ResetSystemMemoryUsage(&system_memory_usage);
+  GetValuesFromMemInfo(kValidMeminfo, &system_memory_usage);
+  ExpectSystemMemoryUsageEq(system_memory_usage, kMemTotal, kMemFree, kMemAvailable, kBuffers,
+                            kCached);
 
-  parsing_result = ParseMemInfo(kPartialMeminfo);
-  ExpectSystemMemoryUsageEq(parsing_result, kMemTotal, kMemFree);
+  ResetSystemMemoryUsage(&system_memory_usage);
+  GetValuesFromMemInfo(kPartialMeminfo, &system_memory_usage);
+  ExpectSystemMemoryUsageEq(system_memory_usage, kMemTotal, kMemFree);
 
-  parsing_result = ParseMemInfo(kEmptyMeminfo);
-  ExpectSystemMemoryUsageEq(parsing_result);
+  ResetSystemMemoryUsage(&system_memory_usage);
+  GetValuesFromMemInfo(kEmptyMeminfo, &system_memory_usage);
+  ExpectSystemMemoryUsageEq(system_memory_usage);
 }
 
-TEST(MemoryUtils, GetVmRssFromProcessStatus) {
-  const int kVmRSS = 11268;
+TEST(MemoryUtils, GetValuesFromVmStat) {
+  const int kPageFaults = 123456789;
+  const int kMajorPageFaults = 123456;
 
-  const std::string kValidProcessStatus = absl::Substitute(R"(Name:	java
-Umask:	0027
-State:	S (sleeping)
-Tgid:	816242
-Ngid:	0
-Pid:	816242
-PPid:	816101
-TracerPid:	0
-Uid:	475321	475321	475321	475321
-Gid:	89939	89939	89939	89939
-FDSize:	1024
-Groups:	4 20 24 25 44 46 109 129 997 5000 66688 70967 70970 74990 75209
-NStgid:	816242
-NSpid:	816242
-NSpgid:	981
-NSsid:	981
-VmPeak:	 9700792 kB
-VmSize:	 9654768 kB
-VmLck:	      16 kB
-VmPin:	       0 kB
-VmHWM:	 1945972 kB
-VmRSS:	 $0 kB
-RssAnon:	 1598556 kB
-RssFile:	   47672 kB
-RssShmem:	     224 kB
-VmData:	 2178668 kB
-VmStk:	     136 kB
-VmExe:	       4 kB
-VmLib:	  155960 kB
-VmPTE:	    4744 kB
-VmSwap:	  248780 kB
-HugetlbPages:	       0 kB
-CoreDumping:	0
-THP_enabled:	1
-Threads:	76
-SigQ:	0/63711
-SigPnd:	0000000000000000
-ShdPnd:	0000000000000000
-SigBlk:	0000000000000000
-SigIgn:	0000000000000000
-SigCgt:	2000000181005ccf
-CapInh:	0000000000000000
-CapPrm:	0000000000000000
-CapEff:	0000000000000000
-CapBnd:	000001ffffffffff
-CapAmb:	0000000000000000
-NoNewPrivs:	0
-Seccomp:	0
-Seccomp_filters:	0
-Speculation_Store_Bypass:	thread vulnerable
-Cpus_allowed:	f
-Cpus_allowed_list:	0-3
-Mems_allowed:	00000000,00000000,00000000,00000001
-Mems_allowed_list:	0
-voluntary_ctxt_switches:	1
-nonvoluntary_ctxt_switches:	3)",
-                                                           kVmRSS);
-  const std::string kPartialProcessStatus = R"(Name:   java
-Umask:  0027)";
+  const std::string kValidProcVmStat = absl::Substitute(R"(nr_free_pages 2258933
+nr_zone_inactive_anon 655781
+nr_zone_active_anon 265654
+nr_zone_inactive_file 103608
+nr_zone_active_file 682986
+nr_zone_unevictable 14789
+nr_zone_write_pending 504
+nr_mlock 14789
+nr_page_table_pages 14006
+nr_bounce 0
+nr_zspages 0
+nr_free_cma 0
+numa_hit 1640599383
+numa_miss 0
+numa_foreign 0
+numa_interleave 61517
+numa_local 1640599383
+numa_other 0
+nr_inactive_anon 655795
+nr_active_anon 265654
+nr_inactive_file 103608
+nr_active_file 682986
+nr_unevictable 14789
+nr_slab_reclaimable 39573
+nr_slab_unreclaimable 29913
+nr_isolated_anon 0
+nr_isolated_file 0
+workingset_nodes 10052
+workingset_refault_anon 482478
+workingset_refault_file 4691743
+workingset_activate_anon 83978
+workingset_activate_file 3712979
+workingset_restore_anon 31279
+workingset_restore_file 2506434
+workingset_nodereclaim 23964
+nr_anon_pages 779841
+nr_mapped 238243
+nr_file_pages 882760
+nr_dirty 480
+nr_writeback 0
+nr_writeback_temp 0
+nr_shmem 66116
+nr_shmem_hugepages 0
+nr_shmem_pmdmapped 0
+nr_file_hugepages 0
+nr_file_pmdmapped 0
+nr_anon_transparent_hugepages 755
+nr_vmscan_write 1246151
+nr_vmscan_immediate_reclaim 732
+nr_dirtied 110747698
+nr_written 96424883
+nr_kernel_misc_reclaimable 0
+nr_foll_pin_acquired 0
+nr_foll_pin_released 0
+nr_kernel_stack 39280
+nr_dirty_threshold 600497
+nr_dirty_background_threshold 299882
+pgpgin 70153910
+pgpgout 478359020
+pswpin 482479
+pswpout 1226100
+pgalloc_dma 0
+pgalloc_dma32 206502602
+pgalloc_normal 2867571518
+pgalloc_movable 0
+allocstall_dma 0
+allocstall_dma32 0
+allocstall_normal 61
+allocstall_movable 574
+pgskip_dma 0
+pgskip_dma32 0
+pgskip_normal 255855
+pgskip_movable 0
+pgfree 3077305458
+pgactivate 59489152
+pgdeactivate 13444038
+pglazyfree 176961
+pgfault $0
+pgmajfault $1
+pglazyfreed 86974
+pgrefill 14648260
+pgreuse 150268511
+pgsteal_kswapd 25809003
+pgsteal_direct 109534
+pgscan_kswapd 42547232
+pgscan_direct 182478
+pgscan_direct_throttle 0
+pgscan_anon 16823270
+pgscan_file 25906440
+pgsteal_anon 1236888
+pgsteal_file 24681649
+zone_reclaim_failed 0
+pginodesteal 7256
+slabs_scanned 15016420
+kswapd_inodesteal 8299045
+kswapd_low_wmark_hit_quickly 3520
+kswapd_high_wmark_hit_quickly 1113
+pageoutrun 5198
+pgrotated 1183212
+drop_pagecache 0
+drop_slab 0
+oom_kill 0
+numa_pte_updates 0
+numa_huge_pte_updates 78
+numa_hint_faults 0
+numa_hint_faults_local 0
+numa_pages_migrated 0
+pgmigrate_success 835315
+pgmigrate_fail 141734
+thp_migration_success 0
+thp_migration_fail 0
+thp_migration_split 0
+compact_migrate_scanned 22847132
+compact_free_scanned 22310540
+compact_isolated 1850479
+compact_stall 209
+compact_fail 7
+compact_success 202
+compact_daemon_wake 1419
+compact_daemon_migrate_scanned 333848
+compact_daemon_free_scanned 6526252
+htlb_buddy_alloc_success 0
+htlb_buddy_alloc_fail 0
+unevictable_pgs_culled 207448
+unevictable_pgs_scanned 0
+unevictable_pgs_rescued 133162
+unevictable_pgs_mlocked 160277
+unevictable_pgs_munlocked 133138
+unevictable_pgs_cleared 5564
+unevictable_pgs_stranded 5534
+thp_fault_alloc 2578050
+thp_fault_fallback 2462
+thp_fault_fallback_charge 0
+thp_collapse_alloc 59381
+thp_collapse_alloc_failed 2
+thp_file_alloc 0
+thp_file_fallback 0
+thp_file_fallback_charge 0
+thp_file_mapped 0
+thp_split_page 1816
+thp_split_page_failed 0
+thp_deferred_split_page 224583
+thp_split_pmd 660273
+thp_split_pud 0
+thp_zero_page_alloc 1
+thp_zero_page_alloc_failed 0
+thp_swpout 0
+thp_swpout_fallback 782
+balloon_inflate 209231935
+balloon_deflate 209231935
+balloon_migrate 3482
+swap_ra 277950
+swap_ra_hit 207052
+nr_unstable 0)",
+                                                        kPageFaults, kMajorPageFaults);
 
-  const std::string kEmptyProcessStatus = "";
+  const std::string kPartialProcVmStat = absl::Substitute(R"(pgfault $0)", kPageFaults);
 
-  int64_t parsing_result = GetVmRssFromProcessStatus(kValidProcessStatus);
-  EXPECT_EQ(parsing_result, kVmRSS);
+  const std::string kEmptyProcVmStat = "";
 
-  parsing_result = GetVmRssFromProcessStatus(kPartialProcessStatus);
-  EXPECT_EQ(parsing_result, kMissingInfo);
+  SystemMemoryUsage system_memory_usage;
+  ResetSystemMemoryUsage(&system_memory_usage);
+  GetValuesFromVmStat(kValidProcVmStat, &system_memory_usage);
+  ExpectSystemMemoryUsageEq(system_memory_usage, kMissingInfo, kMissingInfo, kMissingInfo,
+                            kMissingInfo, kMissingInfo, kPageFaults, kMajorPageFaults);
 
-  parsing_result = GetVmRssFromProcessStatus(kEmptyProcessStatus);
-  EXPECT_EQ(parsing_result, kMissingInfo);
+  ResetSystemMemoryUsage(&system_memory_usage);
+  GetValuesFromVmStat(kPartialProcVmStat, &system_memory_usage);
+  ExpectSystemMemoryUsageEq(system_memory_usage, kMissingInfo, kMissingInfo, kMissingInfo,
+                            kMissingInfo, kMissingInfo, kPageFaults);
+
+  ResetSystemMemoryUsage(&system_memory_usage);
+  GetValuesFromVmStat(kEmptyProcVmStat, &system_memory_usage);
+  ExpectSystemMemoryUsageEq(system_memory_usage);
+}
+
+TEST(MemoryUtils, GetValuesFromProcessStat) {
+  const int kRssPages = 2793;
+  const int kMinorPageFaults = 20;
+  const int kMajorPageFaults = 1;
+
+  const std::string kValidProcessStat = absl::Substitute(
+      R"(9562 (TargetProcess) S 9561 9561 9561 0 -1 123456789 $1 3173 $2 0 7 18 1 7 20 0 10 0 123456789 123456789 $0 123456789 1 1 0 0 0 0 0 0 2 0 0 0 17 6 0 0 0 0 0 0 0 0 0 0 0 0 0)",
+      kRssPages, kMinorPageFaults, kMajorPageFaults);
+  const std::string kPartialProcessStat = R"(9562 (TargetProcess) S 9561 9561 9561)";
+  const std::string kEmptyProcessStat = "";
+
+  ProcessMemoryUsage process_memory_usage;
+  ResetProcessMemoryUsage(&process_memory_usage);
+  GetValuesFromProcessStat(kValidProcessStat, &process_memory_usage);
+  ExpectProcessMemoryUsageEq(process_memory_usage, kRssPages, kMinorPageFaults, kMajorPageFaults);
+
+  ResetProcessMemoryUsage(&process_memory_usage);
+  GetValuesFromProcessStat(kPartialProcessStat, &process_memory_usage);
+  ExpectProcessMemoryUsageEq(process_memory_usage);
+
+  ResetProcessMemoryUsage(&process_memory_usage);
+  GetValuesFromProcessStat(kEmptyProcessStat, &process_memory_usage);
+  ExpectProcessMemoryUsageEq(process_memory_usage);
 }
 
 TEST(MemoryUtil, GetProcessMemoryCGroupName) {
@@ -250,8 +417,11 @@ TEST(MemoryUtils, GetCGroupMemoryLimitInBytes) {
 TEST(MemoryUtils, GetValuesFromCGroupMemoryStat) {
   const int kRssInBytes = 245760;
   const int KMappedFileInBytes = 1234;
+  const int kPageFaults = 1425;
+  const int kMajorPageFaults = 1;
 
-  const std::string kValidCGroupMemoryStatus = absl::Substitute(R"(cache 36864
+  const std::string kValidCGroupMemoryStatus =
+      absl::Substitute(R"(cache 36864
 rss $0
 rss_huge 0
 shmem 0
@@ -260,8 +430,8 @@ dirty 135168
 writeback 0
 pgpgin 299
 pgpgout 230
-pgfault 1425
-pgmajfault 0
+pgfault $2
+pgmajfault $3
 inactive_anon 16384
 active_anon 253952
 inactive_file 0
@@ -278,13 +448,13 @@ total_writeback 0
 total_pgpgin 299
 total_pgpgout 230
 total_pgfault 1425
-total_pgmajfault 0
+total_pgmajfault 1
 total_inactive_anon 16384
 total_active_anon 253952
 total_inactive_file 0
 total_active_file 12288
 total_unevictable 0)",
-                                                                kRssInBytes, KMappedFileInBytes);
+                       kRssInBytes, KMappedFileInBytes, kPageFaults, kMajorPageFaults);
 
   const std::string kPartialCGroupMemoryStatus = R"(cache 36864
 rss_huge 0)";
@@ -294,7 +464,8 @@ rss_huge 0)";
   CGroupMemoryUsage cgroup_memory_usage;
   ResetCGroupMemoryUsage(&cgroup_memory_usage);
   GetValuesFromCGroupMemoryStat(kValidCGroupMemoryStatus, &cgroup_memory_usage);
-  ExpectCGroupMemoryUsageEq(cgroup_memory_usage, kMissingInfo, kRssInBytes, KMappedFileInBytes);
+  ExpectCGroupMemoryUsageEq(cgroup_memory_usage, kMissingInfo, kRssInBytes, KMappedFileInBytes,
+                            kPageFaults, kMajorPageFaults);
 
   ResetCGroupMemoryUsage(&cgroup_memory_usage);
   GetValuesFromCGroupMemoryStat(kPartialCGroupMemoryStatus, &cgroup_memory_usage);


### PR DESCRIPTION
With this change, we add utility methods to collect the following cgroup & process memory usage information:
* Basic memory usage information (collected for the memory track): 
  - process memory usage retrieved from the `rss` field in the `/proc/<pid>/stat` file;
  - cgroup memory limit retrieved from the `/sys/fs/cgroup/memory/<cgroup_name>/memory.limit_in_bytes` file;
  - cgroup memory usage retrieved from the `rss`  and `mapped_file` fields in the `/sys/fs/cgroup/memory/<cgroup_name>/memory.stat` file.
* Page fault statistics (collected for the page fault track):
  - system page fault statistics retrieved from the `minflt` and `majflt` fields in the `/proc/vmstat` file;
  - process page fault statistics retrieved from the `pgfault` and `pgmajfault` fields in the `/proc/<pid>stat` file;
  - cgroup page fault statistics retrieved from the  `pgfault` and `pgmajfault` fields in the `/sys/fs/cgroup/memory/<cgroup_name>/memory.stat` file.
* Detailed cgroup memory usage (collected for the memory track tooltips):
  - values retrieved from the `unevictable`, `inactive_anon`, `active_anon`, `inactive_file`, `active_file` fields.

Relevant bugs: http://b/185107554, http://b/185107588, http://b/187918073.
