### PR TITLE
Fix the crash when loading capture files with memory tracks

### DIFF
--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -442,7 +442,6 @@ void TimeGraph::ProcessMemoryTrackingTimer(const TimerInfo& timer_info) {
   constexpr uint64_t kKilobytesToBytes = 1024;
   constexpr double kMegabytesToKilobytes = 1024.0;
 
-  CHECK(app_->GetCollectMemoryInfo());
   uint64_t warning_threshold_kb = app_->GetMemoryWarningThresholdKb();
   std::string warning_threshold_pretty_size =
       GetPrettySize(warning_threshold_kb * kKilobytesToBytes);


### PR DESCRIPTION
With this change, we fix the crash when loading capture files with memory tracks.

If the user deselect "Collect system-wide memory usage information" in the capture option dialog and then load a capture file with memory tracks, orbit crashes because of a redundant check in `TimeGraph::ProcessMemoryTrackingTimer`.

Bug: http://b/186738639
Test: 1) deselect "Collect system-wide memory usage information" in the capture option dialog, and then 2) load a capture file with memory tracks.