### PR TITLE
Add capture metric

### DIFF
--- a/src/MetricsUploader/CMakeLists.txt
+++ b/src/MetricsUploader/CMakeLists.txt
@@ -15,11 +15,13 @@ target_compile_features(MetricsUploader PUBLIC cxx_std_17)
 target_include_directories(MetricsUploader PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include
                                            PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 
-target_sources(MetricsUploader PUBLIC include/MetricsUploader/MetricsUploader.h
+target_sources(MetricsUploader PUBLIC include/MetricsUploader/CaptureMetric.h
+                                      include/MetricsUploader/MetricsUploader.h
                                       include/MetricsUploader/MetricsUploaderStub.h
                                       include/MetricsUploader/Result.h
                                       include/MetricsUploader/ScopedMetric.h
-                               PRIVATE Result.cpp
+                               PRIVATE CaptureMetric.cpp
+                                       Result.cpp
                                        ScopedMetric.cpp)
 
 if (WIN32)
@@ -73,7 +75,8 @@ add_executable(MetricsUploaderTests)
 
 target_compile_options(MetricsUploaderTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
-target_sources(MetricsUploaderTests PRIVATE ScopedMetricTest.cpp)
+target_sources(MetricsUploaderTests PRIVATE CaptureMetricTest.cpp
+                                            ScopedMetricTest.cpp)
 
 if (WIN32)
 target_sources(MetricsUploaderTests PRIVATE MetricsUploaderWindowsTest.cpp)

--- a/src/MetricsUploader/CaptureMetric.cpp
+++ b/src/MetricsUploader/CaptureMetric.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "MetricsUploader/CaptureMetric.h"
+
+#include <chrono>
+
+#include "OrbitBase/Logging.h"
+#include "orbit_log_event.pb.h"
+
+namespace orbit_metrics_uploader {
+
+CaptureMetric::CaptureMetric(MetricsUploader* uploader, const CaptureStartData& start_data)
+    : uploader_(uploader), start_(std::chrono::steady_clock::now()) {
+  CHECK(uploader_ != nullptr);
+  capture_data_.set_number_of_instrumented_functions(start_data.number_of_instrumented_functions);
+  capture_data_.set_number_of_frame_tracks(start_data.number_of_frame_tracks);
+  capture_data_.set_number_of_manual_start_timers(start_data.number_of_manual_start_timers);
+  capture_data_.set_number_of_manual_stop_timers(start_data.number_of_manual_stop_timers);
+  capture_data_.set_number_of_manual_start_async_timers(
+      start_data.number_of_manual_start_async_timers);
+  capture_data_.set_number_of_manual_stop_async_timers(
+      start_data.number_of_manual_stop_async_timers);
+  capture_data_.set_number_of_manual_tracked_values(start_data.number_of_manual_tracked_values);
+}
+
+void CaptureMetric::SetCaptureFailed() {
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - start_);
+  capture_data_.set_duration_in_milliseconds(duration.count());
+  status_code_ = OrbitLogEvent_StatusCode_INTERNAL_ERROR;
+}
+
+void CaptureMetric::SetCaptureCancelled() {
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - start_);
+  capture_data_.set_duration_in_milliseconds(duration.count());
+  status_code_ = OrbitLogEvent_StatusCode_CANCELLED;
+}
+
+void CaptureMetric::SetCaptureComplete(const CaptureCompleteData& complete_data) {
+  capture_data_.set_duration_in_milliseconds(complete_data.duration_in_milliseconds.count());
+  status_code_ = OrbitLogEvent_StatusCode_SUCCESS;
+}
+
+bool CaptureMetric::Send() {
+  if (status_code_ == OrbitLogEvent_StatusCode_UNKNOWN_STATUS) return false;
+  return uploader_->SendCaptureEvent(capture_data_, status_code_);
+}
+
+}  // namespace orbit_metrics_uploader

--- a/src/MetricsUploader/CaptureMetricTest.cpp
+++ b/src/MetricsUploader/CaptureMetricTest.cpp
@@ -1,0 +1,163 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <thread>
+
+#include "MetricsUploader/CaptureMetric.h"
+#include "MetricsUploader/MetricsUploader.h"
+#include "orbit_log_event.pb.h"
+
+namespace orbit_metrics_uploader {
+
+namespace {
+
+constexpr CaptureStartData kTestStartData{
+    1 /*number_of_instrumented_functions*/,
+    2 /*number_of_frame_tracks*/,
+    3 /*number_of_manual_start_timers*/,
+    4 /*number_of_manual_stop_timers*/,
+    5 /*number_of_manual_start_async_timers*/,
+    6 /*number_of_manual_stop_async_timers*/,
+    7 /*number_of_manual_tracked_values*/
+};
+
+bool HasSameCaptureStartData(const OrbitCaptureData& capture_data,
+                             const CaptureStartData& start_data) {
+  return capture_data.number_of_instrumented_functions() ==
+             start_data.number_of_instrumented_functions &&
+         capture_data.number_of_frame_tracks() == start_data.number_of_frame_tracks &&
+         capture_data.number_of_manual_start_timers() == start_data.number_of_manual_start_timers &&
+         capture_data.number_of_manual_stop_timers() == start_data.number_of_manual_stop_timers &&
+         capture_data.number_of_manual_start_async_timers() ==
+             start_data.number_of_manual_start_async_timers &&
+         capture_data.number_of_manual_stop_async_timers() ==
+             start_data.number_of_manual_stop_async_timers &&
+         capture_data.number_of_manual_tracked_values() ==
+             start_data.number_of_manual_tracked_values;
+}
+
+}  // namespace
+
+using ::testing::_;
+using ::testing::Ge;
+
+class MockUploader : public MetricsUploader {
+ public:
+  MOCK_METHOD(bool, SendLogEvent, (OrbitLogEvent_LogEventType /*log_event_type*/), (override));
+  MOCK_METHOD(bool, SendLogEvent,
+              (OrbitLogEvent_LogEventType /*log_event_type*/,
+               std::chrono::milliseconds /*event_duration*/),
+              (override));
+  MOCK_METHOD(bool, SendLogEvent,
+              (OrbitLogEvent_LogEventType /*log_event_type*/,
+               std::chrono::milliseconds /*event_duration*/,
+               OrbitLogEvent_StatusCode /*status_code*/),
+              (override));
+  MOCK_METHOD(bool, SendCaptureEvent,
+              (OrbitCaptureData /*capture data*/, OrbitLogEvent_StatusCode /*status_code*/),
+              (override));
+};
+
+TEST(CaptureMetric, SendEmpty) {
+  MockUploader uploader{};
+  CaptureMetric metric{&uploader, kTestStartData};
+  EXPECT_FALSE(metric.Send());
+}
+
+TEST(CaptureMetric, SetCaptureFailedAndSend) {
+  MockUploader uploader{};
+
+  EXPECT_CALL(uploader, SendCaptureEvent(_, _))
+      .Times(1)
+      .WillOnce(
+          [](const OrbitCaptureData& capture_data, OrbitLogEvent_StatusCode status_code) -> bool {
+            EXPECT_EQ(status_code, OrbitLogEvent_StatusCode_INTERNAL_ERROR);
+            EXPECT_GE(capture_data.duration_in_milliseconds(), 5);
+            EXPECT_TRUE(HasSameCaptureStartData(capture_data, kTestStartData));
+            return true;
+          });
+
+  CaptureMetric metric{&uploader, kTestStartData};
+  std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  metric.SetCaptureFailed();
+  EXPECT_TRUE(metric.Send());
+}
+
+TEST(CaptureMetric, SetCaptureCancelledAndSend) {
+  MockUploader uploader{};
+
+  EXPECT_CALL(uploader, SendCaptureEvent(_, _))
+      .Times(1)
+      .WillOnce(
+          [](const OrbitCaptureData& capture_data, OrbitLogEvent_StatusCode status_code) -> bool {
+            EXPECT_EQ(status_code, OrbitLogEvent_StatusCode_CANCELLED);
+            EXPECT_GE(capture_data.duration_in_milliseconds(), 5);
+            EXPECT_TRUE(HasSameCaptureStartData(capture_data, kTestStartData));
+            return true;
+          });
+
+  CaptureMetric metric{&uploader, kTestStartData};
+  std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  metric.SetCaptureCancelled();
+  EXPECT_TRUE(metric.Send());
+}
+
+TEST(CaptureMetric, SetCaptureCompleteAndSend) {
+  MockUploader uploader{};
+
+  CaptureCompleteData complete_data{
+      std::chrono::milliseconds{51} /*duration_in_milliseconds*/
+  };
+
+  EXPECT_CALL(uploader, SendCaptureEvent(_, _))
+      .Times(1)
+      .WillOnce([complete_data](const OrbitCaptureData& capture_data,
+                                OrbitLogEvent_StatusCode status_code) -> bool {
+        EXPECT_EQ(status_code, OrbitLogEvent_StatusCode_SUCCESS);
+        EXPECT_EQ(capture_data.duration_in_milliseconds(),
+                  complete_data.duration_in_milliseconds.count());
+        EXPECT_TRUE(HasSameCaptureStartData(capture_data, kTestStartData));
+        return true;
+      });
+
+  CaptureMetric metric{&uploader, kTestStartData};
+  metric.SetCaptureComplete(complete_data);
+  EXPECT_TRUE(metric.Send());
+}
+
+TEST(CaptureMetric, MultipleSetAndSend) {
+  MockUploader uploader{};
+
+  CaptureCompleteData complete_data1{
+      std::chrono::milliseconds{51} /*duration_in_milliseconds*/
+  };
+
+  CaptureCompleteData complete_data2{
+      std::chrono::milliseconds{423} /*duration_in_milliseconds*/
+  };
+
+  EXPECT_CALL(uploader, SendCaptureEvent(_, _))
+      .Times(1)
+      .WillOnce([complete_data2](const OrbitCaptureData& capture_data,
+                                 OrbitLogEvent_StatusCode status_code) -> bool {
+        EXPECT_EQ(status_code, OrbitLogEvent_StatusCode_SUCCESS);
+        EXPECT_EQ(capture_data.duration_in_milliseconds(),
+                  complete_data2.duration_in_milliseconds.count());
+        EXPECT_TRUE(HasSameCaptureStartData(capture_data, kTestStartData));
+        return true;
+      });
+
+  CaptureMetric metric{&uploader, kTestStartData};
+  metric.SetCaptureComplete(complete_data1);
+  metric.SetCaptureFailed();
+  metric.SetCaptureCancelled();
+  metric.SetCaptureComplete(complete_data2);
+  EXPECT_TRUE(metric.Send());
+}
+
+}  // namespace orbit_metrics_uploader

--- a/src/MetricsUploader/MetricsUploaderWindows.cpp
+++ b/src/MetricsUploader/MetricsUploaderWindows.cpp
@@ -41,6 +41,8 @@ class MetricsUploaderImpl : public MetricsUploader {
   bool SendLogEvent(OrbitLogEvent_LogEventType log_event_type,
                     std::chrono::milliseconds event_duration,
                     OrbitLogEvent_StatusCode status_code) override;
+  bool SendCaptureEvent(OrbitCaptureData capture_data,
+                        OrbitLogEvent_StatusCode status_code) override;
 
  private:
   [[nodiscard]] bool FillAndSendLogEvent(OrbitLogEvent partial_filled_event) const;
@@ -241,6 +243,15 @@ bool MetricsUploaderImpl::SendLogEvent(OrbitLogEvent_LogEventType log_event_type
   OrbitLogEvent log_event;
   log_event.set_log_event_type(log_event_type);
   log_event.set_event_duration_milliseconds(event_duration.count());
+  log_event.set_status_code(status_code);
+  return FillAndSendLogEvent(log_event);
+}
+
+bool MetricsUploaderImpl::SendCaptureEvent(OrbitCaptureData capture_data,
+                                           OrbitLogEvent_StatusCode status_code) {
+  OrbitLogEvent log_event;
+  log_event.set_log_event_type(OrbitLogEvent_LogEventType_ORBIT_CAPTURE_END);
+  *log_event.mutable_orbit_capture_data() = std::move(capture_data);
   log_event.set_status_code(status_code);
   return FillAndSendLogEvent(log_event);
 }

--- a/src/MetricsUploader/MetricsUploaderWindowsTest.cpp
+++ b/src/MetricsUploader/MetricsUploaderWindowsTest.cpp
@@ -61,6 +61,14 @@ TEST(MetricsUploader, SendLogEvent) {
   EXPECT_TRUE(result);
 }
 
+TEST(MetricsUploader, SendCaptureEvent) {
+  auto metrics_uploader = MetricsUploader::CreateMetricsUploader("MetricsUploaderCompleteClient");
+  EXPECT_FALSE(IsMetricsUploaderStub(metrics_uploader));
+  bool result =
+      metrics_uploader->SendCaptureEvent(OrbitCaptureData{}, OrbitLogEvent_StatusCode_SUCCESS);
+  EXPECT_TRUE(result);
+}
+
 TEST(MetricsUploader, CreateTwoMetricsUploaders) {
   auto metrics_uploader1 = MetricsUploader::CreateMetricsUploader("MetricsUploaderCompleteClient");
   EXPECT_FALSE(IsMetricsUploaderStub(metrics_uploader1));

--- a/src/MetricsUploader/ScopedMetric.cpp
+++ b/src/MetricsUploader/ScopedMetric.cpp
@@ -6,8 +6,6 @@
 
 #include <chrono>
 
-#include "OrbitBase/Logging.h"
-
 namespace orbit_metrics_uploader {
 
 ScopedMetric::ScopedMetric(MetricsUploader* uploader, OrbitLogEvent_LogEventType log_event_type)

--- a/src/MetricsUploader/ScopedMetricTest.cpp
+++ b/src/MetricsUploader/ScopedMetricTest.cpp
@@ -28,6 +28,9 @@ class MockUploader : public MetricsUploader {
                std::chrono::milliseconds /*event_duration*/,
                OrbitLogEvent_StatusCode /*status_code*/),
               (override));
+  MOCK_METHOD(bool, SendCaptureEvent,
+              (OrbitCaptureData /*capture data*/, OrbitLogEvent_StatusCode /*status_code*/),
+              (override));
 };
 
 TEST(ScopedMetric, Constructor) {

--- a/src/MetricsUploader/include/MetricsUploader/CaptureMetric.h
+++ b/src/MetricsUploader/include/MetricsUploader/CaptureMetric.h
@@ -1,0 +1,52 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef METRICS_UPLOADER_CAPTURE_METRIC_H_
+#define METRICS_UPLOADER_CAPTURE_METRIC_H_
+
+#include <chrono>
+
+#include "MetricsUploader/MetricsUploader.h"
+#include "orbit_log_event.pb.h"
+
+namespace orbit_metrics_uploader {
+
+struct CaptureStartData {
+  int64_t number_of_instrumented_functions = 0;
+  int64_t number_of_frame_tracks = 0;
+  int64_t number_of_manual_start_timers = 0;
+  int64_t number_of_manual_stop_timers = 0;
+  int64_t number_of_manual_start_async_timers = 0;
+  int64_t number_of_manual_stop_async_timers = 0;
+  int64_t number_of_manual_tracked_values = 0;
+};
+
+struct CaptureCompleteData {
+  std::chrono::milliseconds duration_in_milliseconds = std::chrono::milliseconds{0};
+};
+
+class CaptureMetric {
+ public:
+  explicit CaptureMetric(MetricsUploader* uploader, const CaptureStartData& start_data);
+  CaptureMetric(const CaptureMetric& other) = delete;
+  CaptureMetric& operator=(const CaptureMetric& other) = delete;
+  CaptureMetric(CaptureMetric&& other) noexcept = default;
+  CaptureMetric& operator=(CaptureMetric&& other) noexcept = default;
+  ~CaptureMetric() = default;
+
+  void SetCaptureFailed();
+  void SetCaptureCancelled();
+  void SetCaptureComplete(const CaptureCompleteData& complete_data);
+  bool Send();
+
+ private:
+  MetricsUploader* uploader_;
+  OrbitCaptureData capture_data_;
+  OrbitLogEvent_StatusCode status_code_ = OrbitLogEvent_StatusCode_UNKNOWN_STATUS;
+  std::chrono::steady_clock::time_point start_;
+};
+
+}  // namespace orbit_metrics_uploader
+
+#endif  // METRICS_UPLOADER_CAPTURE_METRIC_H_

--- a/src/MetricsUploader/include/MetricsUploader/MetricsUploader.h
+++ b/src/MetricsUploader/include/MetricsUploader/MetricsUploader.h
@@ -57,6 +57,11 @@ class MetricsUploader {
   virtual bool SendLogEvent(OrbitLogEvent_LogEventType log_event_type,
                             std::chrono::milliseconds event_duration,
                             OrbitLogEvent_StatusCode status_code) = 0;
+
+  // Send a ORBIT_CAPTURE_END log event with an attached OrbitCaptureData message and a status code.
+  // Returns true on success and false otherwise
+  virtual bool SendCaptureEvent(OrbitCaptureData capture_data,
+                                OrbitLogEvent_StatusCode status_code) = 0;
 };
 
 [[nodiscard]] ErrorMessageOr<std::string> GenerateUUID();

--- a/src/MetricsUploader/include/MetricsUploader/MetricsUploaderStub.h
+++ b/src/MetricsUploader/include/MetricsUploader/MetricsUploaderStub.h
@@ -24,6 +24,10 @@ class MetricsUploaderStub : public MetricsUploader {
                     OrbitLogEvent_StatusCode /*status_code*/) override {
     return false;
   };
+  bool SendCaptureEvent(OrbitCaptureData /*capture_data*/,
+                        OrbitLogEvent_StatusCode /*status_code*/) override {
+    return false;
+  }
 };
 
 }  // namespace orbit_metrics_uploader

--- a/src/MetricsUploader/include/MetricsUploader/MetricsUploaderStub.h
+++ b/src/MetricsUploader/include/MetricsUploader/MetricsUploaderStub.h
@@ -14,12 +14,14 @@ class MetricsUploaderStub : public MetricsUploader {
   MetricsUploaderStub& operator=(const MetricsUploaderStub& other) = delete;
   MetricsUploaderStub& operator=(MetricsUploaderStub&& other) = default;
 
-  bool SendLogEvent(OrbitLogEvent_LogEventType) override { return false; };
-  bool SendLogEvent(OrbitLogEvent_LogEventType, std::chrono::milliseconds) override {
+  bool SendLogEvent(OrbitLogEvent_LogEventType /*log_event_type*/) override { return false; };
+  bool SendLogEvent(OrbitLogEvent_LogEventType /*log_event_type*/,
+                    std::chrono::milliseconds /*event_duration*/) override {
     return false;
   };
-  bool SendLogEvent(OrbitLogEvent_LogEventType, std::chrono::milliseconds,
-                    OrbitLogEvent_StatusCode) override {
+  bool SendLogEvent(OrbitLogEvent_LogEventType /*log_event_type*/,
+                    std::chrono::milliseconds /*event_duration*/,
+                    OrbitLogEvent_StatusCode /*status_code*/) override {
     return false;
   };
 };

--- a/src/MetricsUploader/include/MetricsUploader/ScopedMetric.h
+++ b/src/MetricsUploader/include/MetricsUploader/ScopedMetric.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef METRICS_UPLOADED_SCOPED_METRIC_H_
-#define METRICS_UPLOADED_SCOPED_METRIC_H_
+#ifndef METRICS_UPLOADER_SCOPED_METRIC_H_
+#define METRICS_UPLOADER_SCOPED_METRIC_H_
 
 #include <chrono>
 
@@ -32,4 +32,4 @@ class ScopedMetric {
 
 }  // namespace orbit_metrics_uploader
 
-#endif  // METRICS_UPLOADED_SCOPED_METRIC_H_
+#endif  // METRICS_UPLOADER_SCOPED_METRIC_H_

--- a/src/MetricsUploader/proto/orbit_log_event.proto
+++ b/src/MetricsUploader/proto/orbit_log_event.proto
@@ -10,11 +10,12 @@ package orbit_metrics_uploader;
 // client. Changing this proto requires changing the metrics uploader client
 // library accordingly.
 message OrbitLogEvent {
-  // NextID: 17
+  // NextID: 18
   enum LogEventType {
     UNKNOWN_EVENT_TYPE = 0;
     // go/keep-sorted start
     ORBIT_CAPTURE_DURATION = 2;
+    ORBIT_CAPTURE_END = 17;
     ORBIT_CAPTURE_LOAD = 4;
     ORBIT_CAPTURE_SAVE = 3;
     ORBIT_END_SESSION_CLICKED = 13;
@@ -58,4 +59,45 @@ message OrbitLogEvent {
   string session_uuid = 4;
   // Status code of the event
   StatusCode status_code = 5;
+  // Detailed information about a capture. Sent with ORBIT_CAPTURE_END.
+  OrbitCaptureData orbit_capture_data = 6;
+}
+
+// Holds data about a capture taken in Orbit. This includes data that was
+// available before the capture start, like the number of dynamically
+// instrumented functions and information that is available at capture stop,
+// like duration of the capture. It is sent when the user stops the capture, or
+// when the capture is aborted because of an error.
+message OrbitCaptureData {
+  // Duration of the capture in milliseconds. This is a measure of time from
+  // when the user started a capture until the user ends it.
+  int64 duration_in_milliseconds = 1;
+
+  // Number of functions the user dynamically instrumented (hooked) before the
+  // start of this capture. This does not include functions that are
+  // instrumented via the manual instrumentation api (Orbit.h).
+  int64 number_of_instrumented_functions = 2;
+
+  // Number of frame tracks the user added before the start of this capture.
+  int64 number_of_frame_tracks = 3;
+
+  // Number of orbit_api::Start calls that Orbit found in the modules that have
+  // been manually instrumented.
+  int64 number_of_manual_start_timers = 4;
+
+  // Number of orbit_api::Stop calls that Orbit found in the modules that have
+  // been manually instrumented.
+  int64 number_of_manual_stop_timers = 5;
+
+  // Number of orbit_api::StartAsync calls that Orbit found in the modules that
+  // have been manually instrumented.
+  int64 number_of_manual_start_async_timers = 6;
+
+  // Number of orbit_api::StopAsync calls that Orbit found in the modules that
+  // have been manually instrumented.
+  int64 number_of_manual_stop_async_timers = 7;
+
+  // Number of orbit_api::TrackValue calls that Orbit found in the modules that
+  // have been manually instrumented.
+  int64 number_of_manual_tracked_values = 8;
 }


### PR DESCRIPTION
Introduces CaptureMetric, which is sent after a capture ends. 
orbit_metrics_uploader::CaptureStartData and orbit_metrics_uploader::CaptureCompleteData will be extended to hold more values in the future. 

This can be reviewed now, since orbit_log_event.proto is highly unlikely to still change. Anyways, I will only merge this once  http://cl/371061415 is submitted