### PR TITLE
Improve OpenGL fallback mechanism

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -308,7 +308,7 @@ chmod -v 4775 /opt/developer/tools/OrbitService
 
         if not self.options.system_qt:
             orbit_executable = "Orbit.exe" if self.settings.os == "Windows" else "Orbit"
-            self.run("windeployqt --pdb {}".format(orbit_executable), cwd=os.path.join(self.package_folder, "bin"), run_environment=True)
+            self.run("windeployqt --pdb --no-angle {}".format(orbit_executable), cwd=os.path.join(self.package_folder, "bin"), run_environment=True)
 
             # Package Visual C++ and C Runtime
             vcvars = tools.vcvars_dict(self)

--- a/src/Orbit/CMakeLists.txt
+++ b/src/Orbit/CMakeLists.txt
@@ -30,7 +30,7 @@ if(WIN32)
     TARGET Orbit
     POST_BUILD
     COMMAND "${CMAKE_COMMAND}" -E env PATH="${_qt_bin_dir}"
-            "${WINDEPLOYQT_EXECUTABLE}" --pdb "$<TARGET_FILE:Orbit>"
+            "${WINDEPLOYQT_EXECUTABLE}" --pdb --no-angle "$<TARGET_FILE:Orbit>"
     COMMENT "Running windeployqt...")
 endif()
 

--- a/src/Orbit/main.cpp
+++ b/src/Orbit/main.cpp
@@ -379,13 +379,21 @@ int main(int argc, char* argv[]) {
 
   if (!open_gl_version) {
     DisplayErrorToUser(
-        "OpenGL support was not found. Please make sure you're not trying to "
-        "start Orbit in a remote session and make sure you have a recent "
-        "graphics driver installed. Then try again!");
+        "OpenGL support was not found. This usually indicates some DLLs are missing. "
+        "Please try to reinstall Orbit!");
     return -1;
   }
 
-  LOG("Detected OpenGL version: %i.%i", open_gl_version->major, open_gl_version->minor);
+  LOG("Detected OpenGL version: %i.%i %s", open_gl_version->major, open_gl_version->minor,
+      open_gl_version->is_opengl_es ? "OpenGL ES" : "OpenGL");
+
+  if (open_gl_version->is_opengl_es) {
+    DisplayErrorToUser(
+        "Orbit was only able to load OpenGL ES while Desktop OpenGL is required. Try to force "
+        "software rendering by starting Orbit with the environment variable QT_OPENGL=software "
+        "set.");
+    return -1;
+  }
 
   if (open_gl_version->major < 2) {
     DisplayErrorToUser(QString("The minimum required version of OpenGL is 2.0. But this machine "

--- a/src/Orbit/main.cpp
+++ b/src/Orbit/main.cpp
@@ -331,11 +331,6 @@ int main(int argc, char* argv[]) {
   QCoreApplication::setAttribute(Qt::AA_DontUseNativeDialogs);
 #endif
 
-  // Without this flag Qt will consider OpenGL ES as a fallback which can almost always be provided
-  // using ANGLE. But we want Qt to use the software rasterizer (opengl32sw.dll) as a fallback since
-  // we need OpenGL (non-ES) for the timegraph widget.
-  QCoreApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
-
   QApplication app(argc, argv);
   QApplication::setOrganizationName("The Orbit Authors");
   QApplication::setApplicationName("orbitprofiler");

--- a/src/OrbitQt/CMakeLists.txt
+++ b/src/OrbitQt/CMakeLists.txt
@@ -152,7 +152,7 @@ if(WIN32)
     TARGET OrbitQtTests
     POST_BUILD
     COMMAND "${CMAKE_COMMAND}" -E env PATH="${_qt_bin_dir}"
-            "${WINDEPLOYQT_EXECUTABLE}" --pdb "$<TARGET_FILE:OrbitQtTests>"
+            "${WINDEPLOYQT_EXECUTABLE}" --pdb --no-angle "$<TARGET_FILE:OrbitQtTests>"
     COMMENT "Running windeployqt...")
 endif()
 

--- a/src/OrbitQt/opengldetect.cpp
+++ b/src/OrbitQt/opengldetect.cpp
@@ -15,7 +15,6 @@ namespace orbit_qt {
 
 // Detects the supported version of Desktop OpenGL by requesting the most
 // recent version of OpenGL and checking what the system could provide.
-// OpenGL ES is automatically ignored.
 std::optional<OpenGlVersion> DetectOpenGlVersion() {
   QSurfaceFormat format{};
   format.setRenderableType(QSurfaceFormat::OpenGL);
@@ -34,12 +33,9 @@ std::optional<OpenGlVersion> DetectOpenGlVersion() {
   gl_context.create();
   gl_context.makeCurrent(&surface);
 
-  // We are trying to detect Desktop OpenGL. So if Qt falls back to OpenGL ES,
-  // Desktop OpenGL will not be available.
-  if (!gl_context.isValid() || gl_context.isOpenGLES()) {
-    return std::nullopt;
-  }
+  if (!gl_context.isValid()) return std::nullopt;
 
-  return OpenGlVersion{surface.format().majorVersion(), surface.format().minorVersion()};
+  return OpenGlVersion{gl_context.format().majorVersion(), gl_context.format().minorVersion(),
+                       gl_context.isOpenGLES()};
 }
 }  // namespace orbit_qt

--- a/src/OrbitQt/opengldetect.h
+++ b/src/OrbitQt/opengldetect.h
@@ -12,6 +12,7 @@ namespace orbit_qt {
 struct OpenGlVersion {
   int major;
   int minor;
+  bool is_opengl_es;
 };
 
 std::optional<OpenGlVersion> DetectOpenGlVersion();

--- a/src/WebUI/CMakeLists.txt
+++ b/src/WebUI/CMakeLists.txt
@@ -24,7 +24,7 @@ if(WIN32)
     TARGET QWebChannelExtractor
     POST_BUILD
     COMMAND "${CMAKE_COMMAND}" -E env PATH="${_qt_bin_dir}"
-            "${WINDEPLOYQT_EXECUTABLE}" --pdb "$<TARGET_FILE:QWebChannelExtractor>"
+            "${WINDEPLOYQT_EXECUTABLE}" --pdb --no-angle "$<TARGET_FILE:QWebChannelExtractor>"
     COMMENT "Running windeployqt for QWebChannelExtractor...")
 endif()
 


### PR DESCRIPTION
This is the result of testing on a variety of machines.

Not in all cases Qt has been falling back on software rendering. Sometimes Qt considered OpenGL 1.1 as good enough
which makes Orbit crash when loading the main window.

Detection works like this now:
1. Qt tries to load the library opengl32.dll. If it detects opengl version smaller than 2.0 it will be discarded. Otherwise we happily take it.
2. Qt tries to load ANGLE which only provides OpenGL ES. This can't be disabled but can be avoided by not shipping the ANGLE DLLs. That's what we do here so that fails.
3. Qt tries to load the library opengl32sw.dll. It will take it no matter which version of OpenGL is in there. But we have control over that since we ship that library with Orbit.

So this PR ensure this detection order (details in the commit messages) and also improves the error message of the opengl detection mechanism.
These errors should not occur when Orbit is installed via the Stadia SDK, so it's hard to give proper guidance to the user.
I tried to make them as helpful as possible under these circumstances.

if you have a better suggestion how to structure these error messages I'm all ears. We have to catch two potential problems
1. Qt didn't detect any version of OpenGL. Most likely cause: The software rendering DLL is missing.
2. Qt accidentally found working ANGLE libraries and fell back on OpenGL ES. (Unfortunately this can't be avoided programmatically) Most likely cause: Qt found the ANGLE DLLs from another Qt installation which are supposed to be private to each software package.

Test: Here is an E2E test that successfully ran without deploying opengl32.dll manually upfront: http://fusion/7c624412-f69b-43ce-a136-5b3c14f75b81