### PR TITLE
Create AccessibleInterfaceProvider as a base class for Accessibility

### DIFF
--- a/src/OrbitGl/AccessibleCaptureViewElement.cpp
+++ b/src/OrbitGl/AccessibleCaptureViewElement.cpp
@@ -4,7 +4,6 @@
 
 #include "AccessibleCaptureViewElement.h"
 
-#include "GlCanvas.h"
 #include "Viewport.h"
 
 namespace orbit_gl {

--- a/src/OrbitGl/AccessibleInterfaceProvider.cpp
+++ b/src/OrbitGl/AccessibleInterfaceProvider.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "AccessibleInterfaceProvider.h"
+
+namespace orbit_gl {
+
+orbit_accessibility::AccessibleInterface*
+AccessibleInterfaceProvider::GetOrCreateAccessibleInterface() {
+  if (accessibility_ == nullptr) {
+    accessibility_ = CreateAccessibleInterface();
+  }
+  return accessibility_.get();
+}
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/AccessibleInterfaceProvider.h
+++ b/src/OrbitGl/AccessibleInterfaceProvider.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_ACCESSIBLE_INTERFACE_PROVIDER_H_
+#define ORBIT_GL_ACCESSIBLE_INTERFACE_PROVIDER_H_
+
+#include "OrbitAccessibility/AccessibleInterface.h"
+
+namespace orbit_gl {
+
+/* Base class to provide accessibility in the capture window. */
+class AccessibleInterfaceProvider {
+ public:
+  explicit AccessibleInterfaceProvider() {}
+
+  [[nodiscard]] orbit_accessibility::AccessibleInterface* GetOrCreateAccessibleInterface();
+  [[nodiscard]] const orbit_accessibility::AccessibleInterface* GetAccessibleInterface() const {
+    return accessibility_.get();
+  }
+
+ private:
+  [[nodiscard]] virtual std::unique_ptr<orbit_accessibility::AccessibleInterface>
+  CreateAccessibleInterface() = 0;
+  std::unique_ptr<orbit_accessibility::AccessibleInterface> accessibility_;
+};
+
+}  // namespace orbit_gl
+
+#endif

--- a/src/OrbitGl/AccessibleTimeGraph.cpp
+++ b/src/OrbitGl/AccessibleTimeGraph.cpp
@@ -6,8 +6,8 @@
 
 #include <vector>
 
+#include "AccessibleInterfaceProvider.h"
 #include "AccessibleTrack.h"
-#include "GlCanvas.h"
 #include "TimeGraph.h"
 #include "Track.h"
 #include "TrackManager.h"
@@ -40,7 +40,8 @@ const AccessibleInterface* TimeGraphAccessibility::AccessibleChild(int index) co
 }
 
 const AccessibleInterface* TimeGraphAccessibility::AccessibleParent() const {
-  return time_graph_->GetCanvas()->GetOrCreateAccessibleInterface();
+  // Special handling given than GlCanvas is not a CaptureViewElement.
+  return time_graph_->GetAccessibleParent()->GetOrCreateAccessibleInterface();
 }
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -12,6 +12,7 @@ target_compile_options(OrbitGl PRIVATE ${STRICT_COMPILE_FLAGS})
 target_sources(
   OrbitGl
   PUBLIC AccessibleCaptureViewElement.h
+         AccessibleInterfaceProvider.h
          AccessibleThreadBar.h
          AccessibleTimeGraph.h
          AccessibleTrack.h
@@ -81,6 +82,7 @@ target_sources(
 target_sources(
   OrbitGl
   PRIVATE AccessibleCaptureViewElement.cpp
+          AccessibleInterfaceProvider.cpp
           AccessibleThreadBar.cpp
           AccessibleTimeGraph.cpp
           AccessibleTrack.cpp

--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -32,11 +32,4 @@ void CaptureViewElement::OnDrag(int x, int y) {
   time_graph_->RequestUpdatePrimitives();
 }
 
-orbit_accessibility::AccessibleInterface* CaptureViewElement::GetOrCreateAccessibleInterface() {
-  if (accessibility_ == nullptr) {
-    accessibility_ = CreateAccessibleInterface();
-  }
-  return accessibility_.get();
-}
-
 }  // namespace orbit_gl

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -5,6 +5,7 @@
 #ifndef ORBIT_GL_CAPTURE_VIEW_ELEMENT_H_
 #define ORBIT_GL_CAPTURE_VIEW_ELEMENT_H_
 
+#include "AccessibleInterfaceProvider.h"
 #include "Batcher.h"
 #include "OrbitAccessibility/AccessibleInterface.h"
 #include "PickingManager.h"
@@ -17,7 +18,7 @@ class GlCanvas;
 namespace orbit_gl {
 
 /* Base class for UI elements drawn underneath the capture window. */
-class CaptureViewElement : public Pickable {
+class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
  public:
   explicit CaptureViewElement(CaptureViewElement* parent, TimeGraph* time_graph,
                               orbit_gl::Viewport* viewport, TimeGraphLayout* layout);
@@ -47,13 +48,7 @@ class CaptureViewElement : public Pickable {
   void OnDrag(int x, int y) override;
   [[nodiscard]] bool Draggable() override { return true; }
 
-  // Accessibility
-  [[nodiscard]] orbit_accessibility::AccessibleInterface* GetOrCreateAccessibleInterface();
-  [[nodiscard]] const orbit_accessibility::AccessibleInterface* GetAccessibleInterface() const {
-    return accessibility_.get();
-  }
-
-  [[nodiscard]] virtual CaptureViewElement* GetParent() const { return parent_; }
+  [[nodiscard]] CaptureViewElement* GetParent() const { return parent_; }
 
  protected:
   CaptureViewElement* parent_;
@@ -69,11 +64,6 @@ class CaptureViewElement : public Pickable {
   Vec2 mouse_pos_cur_;
   Vec2 picking_offset_ = Vec2(0, 0);
   bool picked_ = false;
-
- private:
-  [[nodiscard]] virtual std::unique_ptr<orbit_accessibility::AccessibleInterface>
-  CreateAccessibleInterface() = 0;
-  std::unique_ptr<orbit_accessibility::AccessibleInterface> accessibility_;
 };
 }  // namespace orbit_gl
 

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -553,7 +553,8 @@ void CaptureWindow::set_draw_help(bool draw_help) {
 }
 
 void CaptureWindow::CreateTimeGraph(const CaptureData* capture_data) {
-  time_graph_ = std::make_unique<TimeGraph>(app_, &text_renderer_, this, &viewport_, capture_data);
+  time_graph_ =
+      std::make_unique<TimeGraph>(this, app_, &text_renderer_, this, &viewport_, capture_data);
 }
 
 Batcher& CaptureWindow::GetBatcherById(BatcherId batcher_id) {

--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -10,6 +10,7 @@
 #include <limits.h>
 #include <math.h>
 
+#include "AccessibleInterfaceProvider.h"
 #include "App.h"
 #include "CaptureWindow.h"
 #include "GlUtils.h"
@@ -55,7 +56,12 @@ unsigned GlCanvas::kMaxNumberRealZLayers = kNumberOriginalLayers + kExtraLayersF
 const Color GlCanvas::kBackgroundColor = Color(67, 67, 67, 255);
 const Color GlCanvas::kTabTextColorSelected = Color(100, 181, 246, 255);
 
-GlCanvas::GlCanvas() : viewport_(0, 0), ui_batcher_(BatcherId::kUi, &picking_manager_) {
+GlCanvas::GlCanvas()
+    : AccessibleInterfaceProvider(),
+      viewport_(0, 0),
+      ui_batcher_(BatcherId::kUi, &picking_manager_) {
+  // Note that `GlCanvas` is the bridge to OpenGl content, and `GlCanvas`'s parent needs special
+  // handling for accessibility. Thus, we use `nullptr` here.
   text_renderer_.SetViewport(&viewport_);
 
   is_selecting_ = false;
@@ -354,11 +360,4 @@ void GlCanvas::Pick(PickingMode picking_mode, int x, int y) {
 
 std::unique_ptr<orbit_accessibility::AccessibleInterface> GlCanvas::CreateAccessibleInterface() {
   return std::make_unique<orbit_accessibility::AccessibleWidgetBridge>();
-}
-
-orbit_accessibility::AccessibleInterface* GlCanvas::GetOrCreateAccessibleInterface() {
-  if (accessibility_ == nullptr) {
-    accessibility_ = CreateAccessibleInterface();
-  }
-  return accessibility_.get();
 }

--- a/src/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/GlCanvas.h
@@ -15,6 +15,7 @@
 #include <utility>
 #include <vector>
 
+#include "AccessibleInterfaceProvider.h"
 #include "AccessibleTimeGraph.h"
 #include "Batcher.h"
 #include "CoreMath.h"
@@ -30,7 +31,7 @@
 
 class OrbitApp;
 
-class GlCanvas {
+class GlCanvas : public orbit_gl::AccessibleInterfaceProvider {
  public:
   explicit GlCanvas();
   virtual ~GlCanvas();
@@ -94,11 +95,6 @@ class GlCanvas {
   void SetIsMouseOver(bool value) { is_mouse_over_ = value; }
 
   [[nodiscard]] PickingManager& GetPickingManager() { return picking_manager_; }
-
-  [[nodiscard]] orbit_accessibility::AccessibleInterface* GetOrCreateAccessibleInterface();
-  [[nodiscard]] const orbit_accessibility::AccessibleInterface* GetAccessibleInterface() const {
-    return accessibility_.get();
-  }
 
   [[nodiscard]] const orbit_gl::Viewport& GetViewport() const { return viewport_; }
   [[nodiscard]] orbit_gl::Viewport& GetViewport() { return viewport_; }
@@ -168,9 +164,7 @@ class GlCanvas {
 
  private:
   [[nodiscard]] virtual std::unique_ptr<orbit_accessibility::AccessibleInterface>
-  CreateAccessibleInterface();
-  std::unique_ptr<orbit_accessibility::AccessibleInterface> accessibility_;
-
+  CreateAccessibleInterface() override;
   void Pick(PickingMode picking_mode, int x, int y);
   virtual void HandlePickedElement(PickingMode /*picking_mode*/, PickingId /*picking_id*/,
                                    int /*x*/, int /*y*/) {}

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -47,11 +47,14 @@ using orbit_gl::MemoryTrack;
 using orbit_grpc_protos::InstrumentedFunction;
 using orbit_grpc_protos::kMissingInfo;
 
-TimeGraph::TimeGraph(OrbitApp* app, TextRenderer* text_renderer, GlCanvas* canvas,
-                     orbit_gl::Viewport* viewport, const CaptureData* capture_data)
+TimeGraph::TimeGraph(AccessibleInterfaceProvider* parent, OrbitApp* app,
+                     TextRenderer* text_renderer, GlCanvas* canvas, orbit_gl::Viewport* viewport,
+                     const CaptureData* capture_data)
     // Note that `GlCanvas` and `TimeGraph` span the bridge to OpenGl content, and `TimeGraph`'s
-    // parent needs special handling for accessibility. Thus, we use `nullptr` here.
+    // parent needs special handling for accessibility. Thus, we use `nullptr` here and we save the
+    // parent in accessible_parent_ which doesn't need to be a CaptureViewElement.
     : orbit_gl::CaptureViewElement(nullptr, this, viewport, &layout_),
+      accessible_parent_{parent},
       text_renderer_{text_renderer},
       canvas_{canvas},
       batcher_(BatcherId::kTimeGraph),

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -14,6 +14,7 @@
 #include <string>
 #include <vector>
 
+#include "AccessibleInterfaceProvider.h"
 #include "AccessibleTimeGraph.h"
 #include "Batcher.h"
 #include "CallstackThreadBar.h"
@@ -38,8 +39,8 @@ class OrbitApp;
 
 class TimeGraph : public orbit_gl::CaptureViewElement {
  public:
-  explicit TimeGraph(OrbitApp* app, TextRenderer* text_renderer, GlCanvas* canvas,
-                     orbit_gl::Viewport* viewport,
+  explicit TimeGraph(AccessibleInterfaceProvider* parent, OrbitApp* app,
+                     TextRenderer* text_renderer, GlCanvas* canvas, orbit_gl::Viewport* viewport,
                      const orbit_client_model::CaptureData* capture_data);
   ~TimeGraph();
 
@@ -117,7 +118,6 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
 
   [[nodiscard]] int GetNumDrawnTextBoxes() { return num_drawn_text_boxes_; }
   [[nodiscard]] TextRenderer* GetTextRenderer() { return &text_renderer_static_; }
-  [[nodiscard]] GlCanvas* GetCanvas() { return canvas_; }
   [[nodiscard]] Batcher& GetBatcher() { return batcher_; }
   [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllTimerChains() const;
   [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllThreadTrackTimerChains() const;
@@ -173,6 +173,10 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
   void RemoveFrameTrack(uint64_t function_id);
   [[nodiscard]] std::string GetThreadNameFromTid(uint32_t tid);
 
+  [[nodiscard]] AccessibleInterfaceProvider* GetAccessibleParent() const {
+    return accessible_parent_;
+  }
+
  protected:
   [[nodiscard]] virtual std::unique_ptr<orbit_accessibility::AccessibleInterface>
   CreateAccessibleInterface() override;
@@ -187,6 +191,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
   void ProcessMemoryTrackingTimer(const orbit_client_protos::TimerInfo& timer_info);
 
  private:
+  AccessibleInterfaceProvider* accessible_parent_;
   TextRenderer text_renderer_static_;
   TextRenderer* text_renderer_ = nullptr;
   GlCanvas* canvas_ = nullptr;


### PR DESCRIPTION
In the process of erasing GlCanvas dependence, we are creating a common interface, so TimeGraph's doesn't have to know which type is its parent.

As a result GetCanvas() from TimeGraph is not used anymore.

https://b/185214650.