### PR TITLE
Add opengl renderer information to About dialog

### DIFF
--- a/src/OrbitQt/orbitaboutdialog.cpp
+++ b/src/OrbitQt/orbitaboutdialog.cpp
@@ -26,4 +26,13 @@ void OrbitAboutDialog::SetBuildInformation(const QString& build_info) {
   ui_->buildInformationEdit->setPlainText(build_info);
 }
 
+void OrbitAboutDialog::SetOpenGlRenderer(const QString& opengl_renderer, bool software_rendering) {
+  auto label = QString{"OpenGL Renderer: %1"}.arg(opengl_renderer);
+  if (software_rendering) {
+    label.append(" (Software Rendering)");
+  }
+
+  ui_->opengl_renderer_label->setText(label);
+}
+
 }  // namespace orbit_qt

--- a/src/OrbitQt/orbitaboutdialog.h
+++ b/src/OrbitQt/orbitaboutdialog.h
@@ -21,6 +21,7 @@ class OrbitAboutDialog : public QDialog {
   void SetLicenseText(const QString& text);
   void SetVersionString(const QString& version);
   void SetBuildInformation(const QString& build_info);
+  void SetOpenGlRenderer(const QString& opengl_renderer, bool software_rendering);
 
   ~OrbitAboutDialog() noexcept override = default;
 

--- a/src/OrbitQt/orbitaboutdialog.ui
+++ b/src/OrbitQt/orbitaboutdialog.ui
@@ -14,14 +14,7 @@
    <string>OrbitAboutDialog</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="0">
-    <widget class="QLabel" name="versionLabel">
-     <property name="text">
-      <string>Version 1.42</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
+   <item row="5" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
       <number>0</number>
@@ -77,7 +70,36 @@
      </widget>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="6" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="titleLanel">
+     <property name="font">
+      <font>
+       <pointsize>16</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Orbit Profiler</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="versionLabel">
+     <property name="text">
+      <string>Version 1.42</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -100,25 +122,10 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Close</set>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="titleLanel">
-     <property name="font">
-      <font>
-       <pointsize>16</pointsize>
-      </font>
-     </property>
+   <item row="3" column="0">
+    <widget class="QLabel" name="opengl_renderer_label">
      <property name="text">
-      <string>Orbit Profiler</string>
+      <string>OpenGL Renderer:</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Shows the currently used OpenGL implementation in the OpenGL dialog.

If a software renderer is detected, the text "(Software Renderer)" will be appended to the renderer's name and version.

![image](https://user-images.githubusercontent.com/43133967/116663479-73a0b580-a997-11eb-86d4-098f2f611fb1.png)

![image](https://user-images.githubusercontent.com/43133967/116663798-e14ce180-a997-11eb-8402-1b340d9f8b43.png)
