### PR TITLE
Implement ZeroCopyInputStream for file section

### DIFF
--- a/src/CaptureFile/CMakeLists.txt
+++ b/src/CaptureFile/CMakeLists.txt
@@ -19,7 +19,9 @@ target_sources(
   CaptureFile
   PRIVATE CaptureFileConstants.h
           CaptureFile.cpp
-          CaptureFileOutputStream.cpp)
+          CaptureFileOutputStream.cpp
+          FileFragmentInputStream.cpp
+          FileFragmentInputStream.h)
 
 target_include_directories(CaptureFile PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
 
@@ -36,6 +38,7 @@ target_compile_options(CaptureFileTests PRIVATE ${STRICT_COMPILE_FLAGS})
 target_sources(CaptureFileTests PRIVATE
   CaptureFileOutputStreamTest.cpp
   CaptureFileTest.cpp
+  FileFragmentInputStreamTest.cpp
 )
 
 target_link_libraries(

--- a/src/CaptureFile/FileFragmentInputStream.cpp
+++ b/src/CaptureFile/FileFragmentInputStream.cpp
@@ -1,0 +1,63 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "FileFragmentInputStream.h"
+
+namespace orbit_capture_file_internal {
+
+using orbit_base::ReadFullyAtOffset;
+
+bool FileFragmentInputStream::Next(const void** data, int* size) {
+  CHECK(data != nullptr);
+  CHECK(size != nullptr);
+
+  if (last_error_.has_value()) return false;
+
+  uint64_t bytes_to_read = std::min(buffer_.size(), file_fragments_end_ - current_position_);
+
+  auto bytes_read_or_error =
+      ReadFullyAtOffset(fd_, buffer_.data(), bytes_to_read, current_position_);
+  if (bytes_read_or_error.has_error()) {
+    last_error_ = std::move(bytes_read_or_error.error());
+    return false;
+  }
+
+  uint64_t bytes_read = bytes_read_or_error.value();
+  // Might happen in the case when file is truncated or
+  // file_fragments_end_ is beyond EOF for some reason.
+  if (bytes_read == 0) {
+    return false;
+  }
+
+  current_position_ += bytes_read;
+  (*data) = buffer_.data();
+  (*size) = static_cast<int>(bytes_read);
+
+  return true;
+}
+
+void FileFragmentInputStream::BackUp(int count) {
+  CHECK(count >= 0);
+  if (static_cast<size_t>(count) > current_position_) {
+    current_position_ = file_fragments_start_;
+    return;
+  }
+
+  current_position_ = std::max(file_fragments_start_, current_position_ - count);
+}
+
+bool FileFragmentInputStream::Skip(int count) {
+  CHECK(count >= 0);
+
+  if (last_error_.has_value()) return false;
+
+  current_position_ = std::min(file_fragments_end_, current_position_ + count);
+  return current_position_ < file_fragments_end_;
+}
+
+google::protobuf::int64 FileFragmentInputStream::ByteCount() const {
+  return current_position_ - file_fragments_start_;
+}
+
+}  // namespace orbit_capture_file_internal

--- a/src/CaptureFile/FileFragmentInputStream.h
+++ b/src/CaptureFile/FileFragmentInputStream.h
@@ -1,0 +1,57 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FILE_FRAGMENT_INPUT_STREAM_H_
+#define FILE_FRAGMENT_INPUT_STREAM_H_
+
+#include <google/protobuf/io/zero_copy_stream.h>
+
+#include <optional>
+
+#include "OrbitBase/File.h"
+
+namespace orbit_capture_file_internal {
+
+// ZeroCopyInputStream implementation for a file fragment with offset and size.
+// This class is used to read protos from capture file sections and makes sure
+// we do not overread into other sections of the file.
+// https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.io.zero_copy_stream
+class FileFragmentInputStream : public google::protobuf::io::ZeroCopyInputStream {
+ public:
+  explicit FileFragmentInputStream(const orbit_base::unique_fd& fd, uint64_t file_offset,
+                                   uint64_t size, size_t block_size = 1 << 16)
+      : fd_{fd},
+        file_fragments_start_{file_offset},
+        file_fragments_end_{file_offset + size},
+        buffer_(block_size),
+        current_position_{file_offset} {
+    CHECK(size > 0);
+  }
+
+  // Obtains a chunk of data from the stream.
+  // https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.io.zero_copy_stream#ZeroCopyInputStream.Next.details
+  bool Next(const void** data, int* size) override;
+  // Backs up a number of bytes, so that the next call to Next() returns data again that was already
+  // returned by the last call to Next().
+  // https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.io.zero_copy_stream#ZeroCopyInputStream.BackUp.details
+  void BackUp(int count) override;
+  // Skips a number of bytes.
+  // https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.io.zero_copy_stream#ZeroCopyInputStream.Skip.details
+  bool Skip(int count) override;
+  google::protobuf::int64 ByteCount() const override;
+
+  [[nodiscard]] std::optional<ErrorMessage> GetLastError() const { return last_error_; }
+
+ private:
+  const orbit_base::unique_fd& fd_;
+  const uint64_t file_fragments_start_;
+  const uint64_t file_fragments_end_;
+  std::vector<uint8_t> buffer_;
+  uint64_t current_position_;
+  std::optional<ErrorMessage> last_error_{};
+};
+
+}  // namespace orbit_capture_file_internal
+
+#endif  // FILE_FRAGMENT_INPUT_STREAM_H_

--- a/src/CaptureFile/FileFragmentInputStreamTest.cpp
+++ b/src/CaptureFile/FileFragmentInputStreamTest.cpp
@@ -1,0 +1,73 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "FileFragmentInputStream.h"
+#include "OrbitBase/TemporaryFile.h"
+
+namespace orbit_capture_file_internal {
+
+TEST(FileFragmentInputStream, ReadBlocksOfTen) {
+  auto temporary_file_or_error = orbit_base::TemporaryFile::Create();
+  ASSERT_TRUE(temporary_file_or_error.has_value()) << temporary_file_or_error.error().message();
+  orbit_base::TemporaryFile temporary_file = std::move(temporary_file_or_error.value());
+
+  auto write_result =
+      orbit_base::WriteFully(temporary_file.fd(),
+                             "Vestibulum euismod sapien eget urna molestie euismod. Etiam "
+                             "pellentesque porttitor ligula et facilisis.");
+  ASSERT_FALSE(write_result.has_error()) << write_result.error().message();
+
+  // The fragment is "urna molestie euismod. Etiam pellentesque"
+  FileFragmentInputStream input_stream{temporary_file.fd(), 31, 41, 10};
+  EXPECT_EQ(input_stream.ByteCount(), 0);
+
+  const void* bytes = nullptr;
+  int size = 0;
+  ASSERT_TRUE(input_stream.Next(&bytes, &size));
+  EXPECT_EQ((std::string_view{static_cast<const char*>(bytes), static_cast<size_t>(size)}),
+            "urna moles");
+  EXPECT_EQ(input_stream.ByteCount(), 10);
+  ASSERT_TRUE(input_stream.Skip(5));
+  EXPECT_EQ(input_stream.ByteCount(), 15);
+  ASSERT_TRUE(input_stream.Next(&bytes, &size));
+
+  EXPECT_EQ((std::string_view{static_cast<const char*>(bytes), static_cast<size_t>(size)}),
+            "uismod. Et");
+  // Make sure we do not go out of fragment boundary
+  input_stream.BackUp(100);
+  EXPECT_EQ(input_stream.ByteCount(), 0);
+
+  ASSERT_TRUE(input_stream.Next(&bytes, &size));
+  EXPECT_EQ((std::string_view{static_cast<const char*>(bytes), static_cast<size_t>(size)}),
+            "urna moles");
+  EXPECT_EQ(input_stream.ByteCount(), 10);
+
+  // Do not read past end of the fragment
+  ASSERT_TRUE(input_stream.Skip(30));
+  EXPECT_EQ(input_stream.ByteCount(), 40);
+
+  ASSERT_TRUE(input_stream.Next(&bytes, &size));
+  EXPECT_EQ((std::string_view{static_cast<const char*>(bytes), static_cast<size_t>(size)}), "e");
+  EXPECT_EQ(input_stream.ByteCount(), 41);
+
+  EXPECT_FALSE(input_stream.Next(&bytes, &size));
+
+  EXPECT_FALSE(input_stream.GetLastError().has_value());
+
+  // Let's read last 5 bytes again
+  input_stream.BackUp(5);
+
+  ASSERT_TRUE(input_stream.Next(&bytes, &size));
+  EXPECT_EQ((std::string_view{static_cast<const char*>(bytes), static_cast<size_t>(size)}),
+            "esque");
+  EXPECT_EQ(input_stream.ByteCount(), 41);
+
+  EXPECT_FALSE(input_stream.Next(&bytes, &size));
+
+  EXPECT_FALSE(input_stream.GetLastError().has_value());
+}
+
+}  // namespace orbit_capture_file_internal


### PR DESCRIPTION
This implementation is intended to be used for reading protos from
capture file sections.

Test: run CaptureFileTests