### PR TITLE
Remove bincrafters repo and update bintray repo url

### DIFF
--- a/third_party/conan/configs/install.ps1
+++ b/third_party/conan/configs/install.ps1
@@ -5,7 +5,7 @@
 $conan = Get-Command conan -ErrorAction Stop
 
 function conan_disable_public_remotes() {
-  $remotes = "bintray", "conan-center", "bincrafters"
+  $remotes = "bintray", "conan-center"
   foreach ($remote in $remotes) {
     $process = Start-Process $conan.Path -Wait -NoNewWindow -ErrorAction Stop -PassThru -ArgumentList "remote","disable",$remote
     if ($process.ExitCode -ne 0) { Throw "Error while disabling conan-remote $remote." }

--- a/third_party/conan/configs/install.sh
+++ b/third_party/conan/configs/install.sh
@@ -7,7 +7,6 @@
 function conan_disable_public_remotes {
   conan remote disable bintray || return $?
   conan remote disable conan-center || return $?
-  conan remote disable bincrafters || return $?
   return 0
 }
 

--- a/third_party/conan/configs/linux/remotes.txt
+++ b/third_party/conan/configs/linux/remotes.txt
@@ -1,3 +1,2 @@
-bintray https://api.bintray.com/conan/hebecker/orbitdeps True 
+bintray https://orbit.jfrog.io/artifactory/api/conan/orbitdeps True
 conan-center https://conan.bintray.com True 
-bincrafters https://api.bintray.com/conan/bincrafters/public-conan True 

--- a/third_party/conan/configs/windows/remotes.txt
+++ b/third_party/conan/configs/windows/remotes.txt
@@ -1,3 +1,2 @@
-bintray https://api.bintray.com/conan/hebecker/orbitdeps True 
+bintray https://orbit.jfrog.io/artifactory/api/conan/orbitdeps True
 conan-center https://conan.bintray.com True 
-bincrafters https://api.bintray.com/conan/bincrafters/public-conan True 

--- a/third_party/conan/scripts/sync_dependencies.sh
+++ b/third_party/conan/scripts/sync_dependencies.sh
@@ -23,7 +23,6 @@ if [ "$1" ]; then
   conan remote enable bintray
   conan user -r bintray $BINTRAY_USERNAME -p $BINTRAY_API_KEY || exit $?
 
-  conan remote enable bincrafters
   conan remote enable conan-center
 
   for profile in $@; do


### PR DESCRIPTION
That's only the first step moving from the old bintray repo to JFrogs new repo offering for open source projects.

Due to missing bincrafters packages this won't work out of the box yet, but we're getting there.