### PR TITLE
Update crashpad recipe

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -103,8 +103,7 @@ class OrbitConan(ConanFile):
         self.requires("zlib/1.2.11#9e0c292b60ce77402bd9be60dd68266f")
 
         if self.options.with_gui and self.options.with_crash_handling:
-            self.requires(
-                "crashpad/20200624@{}#8c19cb575eb819de0b050cf7d1f317b6".format(self._orbit_channel))
+            self.requires("crashpad/20200624@{}".format(self._orbit_channel))
 
         if self.options.with_gui:
             self.requires("freetype/2.10.0@bincrafters/stable#0")

--- a/third_party/conan/lockfiles/base.lock
+++ b/third_party/conan/lockfiles/base.lock
@@ -329,7 +329,7 @@
     "context": "host"
    },
    "32": {
-    "ref": "crashpad/20200624@orbitdeps/stable#8c19cb575eb819de0b050cf7d1f317b6",
+    "ref": "crashpad/20200624@orbitdeps/stable#e6bbf1b8d0e51618a84f8e1cbe045fbd",
     "context": "host"
    },
    "33": {

--- a/third_party/conan/recipes/crashpad/conanfile.py
+++ b/third_party/conan/recipes/crashpad/conanfile.py
@@ -33,7 +33,7 @@ class CrashpadConan(ConanFile):
         return os.path.join(self._crashpad_source_base(), "crashpad")
 
     def build_requirements(self):
-        self.build_requires("depot_tools_installer/20200515@bincrafters/stable")
+        self.build_requires("depot_tools/cci.20201009")
         self.build_requires("ninja/1.9.0")
         if self.settings.os == "Linux":
             self.build_requires("openssl/1.1.1d@orbitdeps/stable")


### PR DESCRIPTION
This PR updates a dependency in the crashpad recipe.

The "depot_tools_installer" package which used to be a build requirement for the crashpad recipe does not exist anymore.
It was replaced by the "depot_tools" package.