### PR TITLE
Implement CaptureSaveToFileProcessor

### DIFF
--- a/src/CaptureClient/CMakeLists.txt
+++ b/src/CaptureClient/CMakeLists.txt
@@ -24,9 +24,11 @@ target_sources(CaptureClient PRIVATE
         ApiEventProcessor.cpp
         CaptureClient.cpp
         CaptureEventProcessor.cpp
-        GpuQueueSubmissionProcessor.cpp)
+        GpuQueueSubmissionProcessor.cpp
+        SaveToFileCaptureEventProcessor.cpp)
 
 target_link_libraries(CaptureClient PUBLIC
+        CaptureFile
         GrpcProtos
         OrbitCore)
 
@@ -41,7 +43,8 @@ target_compile_options(CaptureClientTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(CaptureClientTests PRIVATE
         ApiEventProcessorTest.cpp
-        CaptureEventProcessorTest.cpp)
+        CaptureEventProcessorTest.cpp
+        SaveToFileCaptureEventProcessorTest.cpp)
 
 target_link_libraries(
         CaptureClientTests PRIVATE

--- a/src/CaptureClient/CaptureEventProcessorTest.cpp
+++ b/src/CaptureClient/CaptureEventProcessorTest.cpp
@@ -21,7 +21,6 @@
 #include "OrbitClientData/UserDefinedCaptureData.h"
 #include "capture.pb.h"
 #include "capture_data.pb.h"
-#include "gtest/gtest.h"
 #include "tracepoint.pb.h"
 
 namespace orbit_capture_client {

--- a/src/CaptureClient/SaveToFileCaptureEventProcessor.cpp
+++ b/src/CaptureClient/SaveToFileCaptureEventProcessor.cpp
@@ -1,0 +1,141 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "CaptureClient/CaptureEventProcessor.h"
+#include "CaptureFile/CaptureFile.h"
+#include "CaptureFile/CaptureFileOutputStream.h"
+#include "OrbitBase/MakeUniqueForOverwrite.h"
+#include "capture_data.pb.h"
+
+using orbit_capture_file::CaptureFile;
+using orbit_capture_file::CaptureFileOutputStream;
+using orbit_client_protos::UserDefinedCaptureInfo;
+using orbit_grpc_protos::ClientCaptureEvent;
+
+namespace orbit_capture_client {
+
+namespace {
+
+class SaveToFileCaptureEventProcessor : public CaptureEventProcessor {
+ public:
+  explicit SaveToFileCaptureEventProcessor(std::filesystem::path file_path,
+                                           absl::flat_hash_set<uint64_t> frame_track_function_ids,
+                                           std::function<void(const ErrorMessage&)> error_handler)
+      : frame_track_function_ids_(std::move(frame_track_function_ids)),
+        file_path_{std::move(file_path)},
+        error_handler_{std::move(error_handler)},
+        state_{State::kProcessing} {}
+  ~SaveToFileCaptureEventProcessor() override = default;
+
+  ErrorMessageOr<void> Initialize();
+  void ProcessEvent(const ClientCaptureEvent& event) override;
+
+ private:
+  enum class State {
+    kProcessing,
+    kCaptureFinished,
+    kErrorReported,
+  };
+
+  ErrorMessageOr<void> WriteUserData();
+  void ReportError(const ErrorMessage& error);
+
+  absl::flat_hash_set<uint64_t> frame_track_function_ids_;
+  std::filesystem::path file_path_;
+  std::function<void(const ErrorMessage&)> error_handler_;
+  std::unique_ptr<CaptureFileOutputStream> output_stream_;
+  State state_;
+};
+
+ErrorMessageOr<void> SaveToFileCaptureEventProcessor::Initialize() {
+  auto stream_or_error = CaptureFileOutputStream::Create(file_path_);
+  if (stream_or_error.has_error()) {
+    return ErrorMessage{absl::StrFormat("Failed to initialize CaptureSaveToFileProcessor: %s",
+                                        stream_or_error.error().message())};
+  }
+
+  output_stream_ = std::move(stream_or_error.value());
+
+  return outcome::success();
+}
+
+void SaveToFileCaptureEventProcessor::ReportError(const ErrorMessage& error) {
+  error_handler_(error);
+  state_ = State::kErrorReported;
+}
+
+void SaveToFileCaptureEventProcessor::ProcessEvent(const ClientCaptureEvent& event) {
+  CHECK(output_stream_ != nullptr);
+
+  if (state_ == State::kCaptureFinished) {
+    ReportError(ErrorMessage{"Unexpected event after CaptureFinished event"});
+    return;
+  }
+
+  if (state_ == State::kErrorReported) return;
+
+  CHECK(output_stream_->IsOpen());
+
+  auto write_result = output_stream_->WriteCaptureEvent(event);
+  if (write_result.has_error()) {
+    ReportError(write_result.error());
+    return;
+  }
+
+  if (event.event_case() == ClientCaptureEvent::kCaptureFinished) {
+    // We are done - close the stream.
+    auto close_result = output_stream_->Close();
+    if (close_result.has_error()) {
+      ReportError(close_result.error());
+      return;
+    }
+
+    auto write_user_data_result = WriteUserData();
+    if (write_user_data_result.has_error()) {
+      ReportError(write_user_data_result.error());
+      return;
+    }
+
+    state_ = State::kCaptureFinished;
+  }
+}
+
+ErrorMessageOr<void> SaveToFileCaptureEventProcessor::WriteUserData() {
+  OUTCOME_TRY(capture_file, CaptureFile::OpenForReadWrite(file_path_));
+  UserDefinedCaptureInfo user_defined_capture_data;
+  for (uint64_t function_id : frame_track_function_ids_) {
+    user_defined_capture_data.mutable_frame_tracks_info()->add_frame_track_function_ids(
+        function_id);
+  }
+
+  size_t message_size = user_defined_capture_data.ByteSizeLong();
+  auto buf = make_unique_for_overwrite<uint8_t[]>(message_size);
+  // SerializeToArray returns false if the size of the buffer is too small or too big
+  // https://github.com/protocolbuffers/protobuf/blob/5e84a6169cf0f9716c9285c95c860bcb355dbdc1/src/google/protobuf/message_lite.cc#L484
+  CHECK(user_defined_capture_data.SerializeToArray(buf.get(), message_size));
+
+  OUTCOME_TRY(section_number,
+              capture_file->AddSection(orbit_capture_file::kSectionTypeUserData, message_size));
+  OUTCOME_TRY(capture_file->WriteToSection(section_number, 0, buf.get(), message_size));
+
+  return outcome::success();
+}
+
+}  // namespace
+
+ErrorMessageOr<std::unique_ptr<CaptureEventProcessor>>
+CaptureEventProcessor::CreateSaveToFileProcessor(
+    const std::filesystem::path& file_path, absl::flat_hash_set<uint64_t> frame_track_function_ids,
+    std::function<void(const ErrorMessage&)> error_handler) {
+  auto processor = std::make_unique<SaveToFileCaptureEventProcessor>(
+      file_path, std::move(frame_track_function_ids), std::move(error_handler));
+  auto init_or_error = processor->Initialize();
+  if (init_or_error.has_error()) {
+    return init_or_error.error();
+  }
+
+  return processor;
+}
+
+}  // namespace orbit_capture_client

--- a/src/CaptureClient/SaveToFileCaptureEventProcessorTest.cpp
+++ b/src/CaptureClient/SaveToFileCaptureEventProcessorTest.cpp
@@ -1,0 +1,129 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <absl/container/flat_hash_set.h>
+#include <gtest/gtest.h>
+#include <stdint.h>
+
+#include <vector>
+
+#include "CaptureClient/CaptureEventProcessor.h"
+#include "CaptureFile/CaptureFile.h"
+#include "OrbitBase/Result.h"
+#include "OrbitBase/TemporaryFile.h"
+#include "OrbitBase/TestUtils.h"
+
+namespace orbit_capture_client {
+
+using orbit_base::HasValue;
+using orbit_base::TemporaryFile;
+using orbit_capture_file::CaptureFile;
+using orbit_client_protos::UserDefinedCaptureInfo;
+using orbit_grpc_protos::CaptureFinished;
+using orbit_grpc_protos::ClientCaptureEvent;
+
+static ClientCaptureEvent CreateInternedStringEvent(uint64_t key, const char* intern) {
+  ClientCaptureEvent event;
+  event.mutable_interned_string()->set_key(key);
+  event.mutable_interned_string()->set_intern(intern);
+
+  return event;
+}
+
+static ClientCaptureEvent CreateCaptureFinishedEvent() {
+  ClientCaptureEvent event;
+  event.mutable_capture_finished()->set_status(CaptureFinished::kSuccessful);
+  return event;
+}
+
+TEST(SaveToFileCaptureEventProcessor, SaveAndLoadSimpleCaptureWithFrameTracks) {
+  auto temporary_file_or_error = TemporaryFile::Create();
+  ASSERT_TRUE(temporary_file_or_error.has_value()) << temporary_file_or_error.error().message();
+  TemporaryFile temporary_file = std::move(temporary_file_or_error.value());
+  absl::flat_hash_set<uint64_t> frame_track_function_ids;
+  constexpr uint64_t kFrameTrackFunctionId = 17;
+  frame_track_function_ids.insert(kFrameTrackFunctionId);
+
+  auto error_handler = [](const ErrorMessage& error) { FAIL() << error.message(); };
+
+  auto capture_event_processor_or_error = CaptureEventProcessor::CreateSaveToFileProcessor(
+      temporary_file.file_path(), frame_track_function_ids, error_handler);
+  ASSERT_TRUE(capture_event_processor_or_error.has_value())
+      << capture_event_processor_or_error.error().message();
+
+  std::unique_ptr<CaptureEventProcessor> capture_event_processor =
+      std::move(capture_event_processor_or_error.value());
+  capture_event_processor->ProcessEvent(CreateInternedStringEvent(1, "1"));
+  capture_event_processor->ProcessEvent(CreateInternedStringEvent(2, "2"));
+  capture_event_processor->ProcessEvent(CreateInternedStringEvent(3, "3"));
+  capture_event_processor->ProcessEvent(CreateCaptureFinishedEvent());
+
+  capture_event_processor.reset();
+
+  auto capture_file_or_error = CaptureFile::OpenForReadWrite(temporary_file.file_path());
+  ASSERT_THAT(capture_event_processor_or_error, HasValue());
+  auto capture_file = std::move(capture_file_or_error.value());
+
+  auto capture_section_input_stream = capture_file->CreateCaptureSectionInputStream();
+
+  {
+    auto event_or_error = capture_section_input_stream->ReadEvent();
+    ASSERT_THAT(event_or_error, HasValue());
+    const auto& event = event_or_error.value();
+    ASSERT_EQ(event.event_case(), ClientCaptureEvent::kInternedString);
+    EXPECT_EQ(event.interned_string().key(), 1);
+    EXPECT_EQ(event.interned_string().intern(), "1");
+  }
+
+  {
+    auto event_or_error = capture_section_input_stream->ReadEvent();
+    ASSERT_THAT(event_or_error, HasValue());
+    const auto& event = event_or_error.value();
+    ASSERT_EQ(event.event_case(), ClientCaptureEvent::kInternedString);
+    EXPECT_EQ(event.interned_string().key(), 2);
+    EXPECT_EQ(event.interned_string().intern(), "2");
+  }
+
+  {
+    auto event_or_error = capture_section_input_stream->ReadEvent();
+    ASSERT_THAT(event_or_error, HasValue());
+    const auto& event = event_or_error.value();
+    ASSERT_EQ(event.event_case(), ClientCaptureEvent::kInternedString);
+    EXPECT_EQ(event.interned_string().key(), 3);
+    EXPECT_EQ(event.interned_string().intern(), "3");
+  }
+
+  {
+    auto event_or_error = capture_section_input_stream->ReadEvent();
+    ASSERT_THAT(event_or_error, HasValue());
+    const auto& event = event_or_error.value();
+    ASSERT_EQ(event.event_case(), ClientCaptureEvent::kCaptureFinished);
+    EXPECT_EQ(event.capture_finished().status(), CaptureFinished::kSuccessful);
+  }
+
+  const auto& sections = capture_file->GetSectionList();
+  ASSERT_GE(sections.size(), 1);
+
+  std::optional<size_t> user_data_section;
+  for (size_t i = 0; i < sections.size(); i++) {
+    if (sections[i].type == orbit_capture_file::kSectionTypeUserData) {
+      user_data_section = i;
+      break;
+    }
+  }
+
+  ASSERT_TRUE(user_data_section.has_value());
+
+  std::vector<uint8_t> buf(sections[user_data_section.value()].size);
+  ASSERT_THAT(capture_file->ReadFromSection(user_data_section.value(), 0, buf.data(), buf.size()),
+              HasValue());
+
+  UserDefinedCaptureInfo capture_info;
+  capture_info.ParseFromArray(buf.data(), buf.size());
+
+  ASSERT_EQ(capture_info.frame_tracks_info().frame_track_function_ids_size(), 1);
+  EXPECT_EQ(capture_info.frame_tracks_info().frame_track_function_ids(0), kFrameTrackFunctionId);
+}
+
+}  // namespace orbit_capture_client

--- a/src/CaptureClient/include/CaptureClient/CaptureEventProcessor.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureEventProcessor.h
@@ -32,6 +32,10 @@ class CaptureEventProcessor {
 
   static std::unique_ptr<CaptureEventProcessor> CreateForCaptureListener(
       CaptureListener* capture_listener, absl::flat_hash_set<uint64_t> frame_track_function_ids);
+  static ErrorMessageOr<std::unique_ptr<CaptureEventProcessor>> CreateSaveToFileProcessor(
+      const std::filesystem::path& file_path,
+      absl::flat_hash_set<uint64_t> frame_track_function_ids,
+      std::function<void(const ErrorMessage&)> error_handler);
 };
 
 }  // namespace orbit_capture_client

--- a/src/CaptureFile/include/CaptureFile/CaptureFileSection.h
+++ b/src/CaptureFile/include/CaptureFile/CaptureFileSection.h
@@ -9,6 +9,8 @@
 
 namespace orbit_capture_file {
 
+constexpr uint64_t kSectionTypeUserData = 1;
+
 struct CaptureFileSection {
   uint64_t type;
   uint64_t offset;


### PR DESCRIPTION
This implementation of CaptureEventProcessor saves
events to main section of the capture file. It also
saves frame_tracks to USER_DATA section of the file.

Test: run CaptureClientTests
