### PR TITLE
Add GetTracerPidOfProcess to detect existing "Tracer" process

### DIFF
--- a/src/OrbitBase/GetProcessIdsLinuxTest.cpp
+++ b/src/OrbitBase/GetProcessIdsLinuxTest.cpp
@@ -13,6 +13,7 @@
 
 #include "OrbitBase/GetProcessIds.h"
 #include "OrbitBase/Result.h"
+#include "OrbitBase/ThreadUtils.h"
 #include "absl/synchronization/mutex.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -63,6 +64,14 @@ TEST(GetProcessIdsLinux, GetTidsOfProcess) {
 
   std::vector<pid_t> expected_tids{main_tid, thread_tid};
   EXPECT_THAT(returned_tids, ::testing::UnorderedElementsAreArray(expected_tids));
+}
+
+TEST(GetProcessIdsLinux, GetTracerPidOfProcess) {
+  pid_t current_pid = orbit_base::GetCurrentProcessId();
+  auto pid_or_error = orbit_base::GetTracerPidOfProcess(current_pid);
+  EXPECT_FALSE(pid_or_error.has_error()) << pid_or_error.error().message();
+  constexpr int kNoTracerPid = 0;
+  EXPECT_EQ(pid_or_error.value(), kNoTracerPid);
 }
 
 }  // namespace orbit_base

--- a/src/OrbitBase/include/OrbitBase/GetProcessIds.h
+++ b/src/OrbitBase/include/OrbitBase/GetProcessIds.h
@@ -9,6 +9,8 @@
 
 #include <vector>
 
+#include "OrbitBase/Result.h"
+
 namespace orbit_base {
 
 #if defined(__linux)
@@ -17,6 +19,9 @@ std::vector<pid_t> GetAllPids();
 
 // Get the thread ids of all the threads belonging to process 'pid'.
 std::vector<pid_t> GetTidsOfProcess(pid_t pid);
+
+// Get the process id of the tracer process or 0 if no tracer is attached.
+ErrorMessageOr<pid_t> GetTracerPidOfProcess(pid_t pid);
 #endif
 
 }  // namespace orbit_base

--- a/src/UserSpaceInstrumentation/Attach.cpp
+++ b/src/UserSpaceInstrumentation/Attach.cpp
@@ -77,6 +77,14 @@ ErrorMessageOr<void> AttachAndStopProcess(pid_t pid) {
     return ErrorMessage(absl::StrFormat("There is no process with pid %d.", pid));
   }
 
+  OUTCOME_TRY(tracer_pid, orbit_base::GetTracerPidOfProcess(pid));
+  if (tracer_pid != 0) {
+    return ErrorMessage(
+        absl::StrFormat("Process %d is already being traced by %d. Please make sure no debugger is "
+                        "attached to the target process when profiling.",
+                        pid, tracer_pid));
+  }
+
   absl::flat_hash_set<pid_t> halted_tids;
   // Note that the process is still running - it can spawn and end threads at this point.
   while (process_tids.size() != halted_tids.size()) {


### PR DESCRIPTION
GetTracerPidOfProcess returns the pid of the attached tracer process
for the given pid. If no process is attached, the function returns 0.
Internally, the function reads the content of "/proc/<pid>/status" to
find the "TracerPid" entry and returns its value.

This functionality is used in the second commit, which makes sure that no
tracer process is present before attempting to attach to the target process.
    
Tested on instance with and without debugger attached with expected results.