### PR TITLE
Connect error handler when reusing a connection

### DIFF
--- a/src/OrbitQt/ConnectToStadiaWidget.cpp
+++ b/src/OrbitQt/ConnectToStadiaWidget.cpp
@@ -96,6 +96,14 @@ void ConnectToStadiaWidget::SetConnection(StadiaConnection connection) {
   selected_instance_ = std::move(connection.instance_);
   service_deploy_manager_ = std::move(connection.service_deploy_manager_);
   grpc_channel_ = std::move(connection.grpc_channel_);
+
+  QObject::connect(
+      service_deploy_manager_.get(), &ServiceDeployManager::socketErrorOccurred, this,
+      [this](std::error_code error) {
+        emit ErrorOccurred(QString("The connection to instance %1 failed with error: %2")
+                               .arg(selected_instance_->display_name)
+                               .arg(QString::fromStdString(error.message())));
+      });
 }
 
 void ConnectToStadiaWidget::Start() {


### PR DESCRIPTION
http://b/186741866

Reproduce before:
1. Connect to instance
2. Select whatever process
3. Start Session
4. End Session
5. ssh into instance, kill OrbitService
6. No Error message appears, the list of processes just stops updating

After this change: A error message is displayed and the instances are loaded to start another connection