### PR TITLE
Erase Canvas in the Track::Draw methods

### DIFF
--- a/src/OrbitGl/AccessibleTrack.cpp
+++ b/src/OrbitGl/AccessibleTrack.cpp
@@ -11,7 +11,6 @@
 #include "AccessibleThreadBar.h"
 #include "AccessibleTimeGraph.h"
 #include "CoreMath.h"
-#include "GlCanvas.h"
 #include "OrbitBase/Logging.h"
 #include "TimeGraph.h"
 #include "Track.h"
@@ -29,7 +28,6 @@ class FakeTrackTab : public CaptureViewElement {
   explicit FakeTrackTab(Track* track, TimeGraphLayout* layout)
       : CaptureViewElement(track, track->GetTimeGraph(), track->GetViewport(), layout),
         track_(track) {
-    SetCanvas(track->GetCanvas());
 
     // Compute and set the size (which would usually be done by the parent). As the position may
     // change, we override the GetPos() function.
@@ -56,7 +54,6 @@ class FakeTimerPane : public CaptureViewElement {
       : CaptureViewElement(track, track->GetTimeGraph(), track->GetViewport(), layout),
         track_(track),
         track_tab_(track_tab) {
-    SetCanvas(track->GetCanvas());
   }
 
   std::unique_ptr<AccessibleInterface> CreateAccessibleInterface() override {

--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -44,14 +44,14 @@ std::string CallstackThreadBar::GetTooltip() const {
   return "Left-click and drag to select samples";
 }
 
-void CallstackThreadBar::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
-  ThreadBar::Draw(canvas, picking_mode, z_offset);
+void CallstackThreadBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
+                              uint64_t current_mouse_time_ns, PickingMode picking_mode,
+                              float z_offset) {
+  ThreadBar::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, z_offset);
 
   if (thread_id_ == orbit_base::kAllThreadsOfAllProcessesTid) {
     return;
   }
-
-  Batcher* ui_batcher = canvas->GetBatcher();
 
   // The sample indicators are at z == 0 and do not respond to clicks, but
   // have a tooltip. For picking, we want to draw the event bar over them if
@@ -62,9 +62,9 @@ void CallstackThreadBar::Draw(GlCanvas* canvas, PickingMode picking_mode, float 
   event_bar_z += z_offset;
   Color color = color_;
   Box box(pos_, Vec2(size_[0], -size_[1]), event_bar_z);
-  ui_batcher->AddBox(box, color, shared_from_this());
+  batcher.AddBox(box, color, shared_from_this());
 
-  if (canvas->GetPickingManager().IsThisElementPicked(this)) {
+  if (batcher.GetPickingManager()->IsThisElementPicked(this)) {
     color = Color(255, 255, 255, 255);
   }
 
@@ -73,8 +73,8 @@ void CallstackThreadBar::Draw(GlCanvas* canvas, PickingMode picking_mode, float 
   float x1 = x0 + size_[0];
   float y1 = y0 - size_[1];
 
-  ui_batcher->AddLine(pos_, Vec2(x1, y0), event_bar_z, color, shared_from_this());
-  ui_batcher->AddLine(Vec2(x1, y1), Vec2(x0, y1), event_bar_z, color, shared_from_this());
+  batcher.AddLine(pos_, Vec2(x1, y0), event_bar_z, color, shared_from_this());
+  batcher.AddLine(Vec2(x1, y1), Vec2(x0, y1), event_bar_z, color, shared_from_this());
 
   if (picked_) {
     Vec2& from = mouse_pos_last_click_;
@@ -87,7 +87,7 @@ void CallstackThreadBar::Draw(GlCanvas* canvas, PickingMode picking_mode, float 
 
     Color picked_color(0, 128, 255, 128);
     Box picked_box(Vec2(x0, y0), Vec2(x1 - x0, -size_[1]), GlCanvas::kZValueUi + z_offset);
-    ui_batcher->AddBox(picked_box, picked_color, shared_from_this());
+    batcher.AddBox(picked_box, picked_color, shared_from_this());
   }
 }
 

--- a/src/OrbitGl/CallstackThreadBar.h
+++ b/src/OrbitGl/CallstackThreadBar.h
@@ -31,7 +31,8 @@ class CallstackThreadBar : public ThreadBar {
 
   std::string GetTooltip() const override;
 
-  void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
+  void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
+            PickingMode picking_mode, float z_offset = 0) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;
 

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -13,7 +13,6 @@
 #include "Viewport.h"
 
 class TimeGraph;
-class GlCanvas;
 
 namespace orbit_gl {
 
@@ -22,9 +21,9 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
  public:
   explicit CaptureViewElement(CaptureViewElement* parent, TimeGraph* time_graph,
                               orbit_gl::Viewport* viewport, TimeGraphLayout* layout);
-  virtual void Draw(GlCanvas* canvas, PickingMode /*picking_mode*/, float /*z_offset*/ = 0) {
-    canvas_ = canvas;
-  }
+  virtual void Draw(Batcher& /*batcher*/, TextRenderer& /*text_renderer*/,
+                    uint64_t /*current_mouse_time_ns*/, PickingMode /*picking_mode*/,
+                    float /*z_offset*/ = 0) {}
 
   virtual void UpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/, uint64_t /*max_tick*/,
                                 PickingMode /*picking_mode*/, float /*z_offset*/ = 0){};
@@ -32,8 +31,6 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   [[nodiscard]] TimeGraph* GetTimeGraph() { return time_graph_; }
 
   [[nodiscard]] orbit_gl::Viewport* GetViewport() const { return viewport_; }
-  [[nodiscard]] GlCanvas* GetCanvas() const { return canvas_; }
-  void SetCanvas(GlCanvas* canvas) { canvas_ = canvas; }
 
   void SetPos(float x, float y) { pos_ = Vec2(x, y); }
   // TODO(b/185854980): This should not be virtual as soon as we have meaningful track children.
@@ -55,7 +52,6 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   orbit_gl::Viewport* viewport_;
   TimeGraphLayout* layout_;
 
-  GlCanvas* canvas_ = nullptr;
   TimeGraph* time_graph_;
   Vec2 pos_ = Vec2(0, 0);
   Vec2 size_ = Vec2(0, 0);

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -380,7 +380,10 @@ void CaptureWindow::Draw(bool viewport_was_dirty) {
 
       time_graph_->RequestUpdatePrimitives();
     }
-    time_graph_->Draw(this, picking_mode_);
+    uint64_t timegraph_current_mouse_time_ns =
+        time_graph_->GetTickFromWorld(viewport_.ScreenToWorldPos(GetMouseScreenPos())[0]);
+    time_graph_->Draw(GetBatcher(), GetTextRenderer(), timegraph_current_mouse_time_ns,
+                      picking_mode_);
     viewport_.SetWorldExtents(viewport_.GetScreenWidth(),
                               time_graph_->GetTrackManager()->GetTracksTotalHeight());
   }
@@ -438,7 +441,7 @@ void CaptureWindow::Draw(bool viewport_was_dirty) {
     PrepareScreenSpaceViewport();
     // Text needs to be drawn in screen space.
     if (picking_mode_ == PickingMode::kNone) {
-      text_renderer_.RenderLayer(&ui_batcher_, layer);
+      text_renderer_.RenderLayer(layer);
       RenderText(layer);
     }
   }
@@ -632,7 +635,7 @@ void CaptureWindow::RenderText(float layer) {
   ORBIT_SCOPE_FUNCTION;
   if (time_graph_ == nullptr) return;
   if (picking_mode_ == PickingMode::kNone) {
-    time_graph_->DrawText(this, layer);
+    time_graph_->DrawText(layer);
   }
 }
 

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -231,8 +231,9 @@ std::string FrameTrack::GetBoxTooltip(const Batcher& batcher, PickingId id) cons
           TicksToDuration(text_box->GetTimerInfo().start(), text_box->GetTimerInfo().end())));
 }
 
-void FrameTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
-  TimerTrack::Draw(canvas, picking_mode, z_offset);
+void FrameTrack::Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
+                      PickingMode picking_mode, float z_offset) {
+  TimerTrack::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, z_offset);
 
   const Color kWhiteColor(255, 255, 255, 255);
   const Color kBlackColor(0, 0, 0, 255);
@@ -246,19 +247,18 @@ void FrameTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset
   std::string avg_time = GetPrettyTime(absl::Nanoseconds(stats_.average_time_ns()));
   std::string label = absl::StrFormat("Avg: %s", avg_time);
   uint32_t font_size = layout_->CalculateZoomedFontSize();
-  float string_width = canvas->GetTextRenderer().GetStringWidth(label.c_str(), font_size);
+  float string_width = text_renderer.GetStringWidth(label.c_str(), font_size);
   Vec2 white_text_box_size(string_width, layout_->GetTextBoxHeight());
   Vec2 white_text_box_position(pos_[0] + layout_->GetRightMargin(),
                                y - layout_->GetTextBoxHeight() / 2.f);
 
-  Batcher* ui_batcher = canvas->GetBatcher();
-  ui_batcher->AddLine(from, from + Vec2(layout_->GetRightMargin() / 2.f, 0), text_z, kWhiteColor);
-  ui_batcher->AddLine(Vec2(white_text_box_position[0] + white_text_box_size[0], y), to, text_z,
-                      kWhiteColor);
+  batcher.AddLine(from, from + Vec2(layout_->GetRightMargin() / 2.f, 0), text_z, kWhiteColor);
+  batcher.AddLine(Vec2(white_text_box_position[0] + white_text_box_size[0], y), to, text_z,
+                  kWhiteColor);
 
-  canvas->GetTextRenderer().AddText(label.c_str(), white_text_box_position[0],
-                                    white_text_box_position[1] + layout_->GetTextOffset(), text_z,
-                                    kWhiteColor, font_size, white_text_box_size[0]);
+  text_renderer.AddText(label.c_str(), white_text_box_position[0],
+                        white_text_box_position[1] + layout_->GetTextOffset(), text_z, kWhiteColor,
+                        font_size, white_text_box_size[0]);
 }
 
 void FrameTrack::UpdateBoxHeight() {

--- a/src/OrbitGl/FrameTrack.h
+++ b/src/OrbitGl/FrameTrack.h
@@ -48,7 +48,8 @@ class FrameTrack : public TimerTrack {
   [[nodiscard]] std::string GetTooltip() const override;
   [[nodiscard]] std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const override;
 
-  void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
+  void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
+            PickingMode picking_mode, float z_offset = 0) override;
 
   void UpdateBoxHeight() override;
 

--- a/src/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/GlCanvas.h
@@ -86,7 +86,7 @@ class GlCanvas : public orbit_gl::AccessibleInterfaceProvider {
 
   void EnableImGui();
   [[nodiscard]] ImGuiContext* GetImGuiContext() const { return imgui_context_; }
-  [[nodiscard]] Batcher* GetBatcher() { return &ui_batcher_; }
+  [[nodiscard]] Batcher& GetBatcher() { return ui_batcher_; }
 
   [[nodiscard]] virtual bool IsRedrawNeeded() const;
   void RequestRedraw() { redraw_requested_ = true; }

--- a/src/OrbitGl/GlSlider.cpp
+++ b/src/OrbitGl/GlSlider.cpp
@@ -119,20 +119,20 @@ void GlSlider::OnPick(int x, int y) {
 }
 
 void GlSlider::DrawBackground(GlCanvas* canvas, float x, float y, float width, float height) {
-  Batcher* batcher = canvas->GetBatcher();
+  Batcher& batcher = canvas->GetBatcher();
   const Color dark_border_color = GetDarkerColor(bar_color_);
   const float kEpsilon = 0.0001f;
 
   Box border_box(Vec2(x, y), Vec2(width, height), GlCanvas::kZValueSliderBg - kEpsilon);
-  batcher->AddBox(border_box, dark_border_color, shared_from_this());
+  batcher.AddBox(border_box, dark_border_color, shared_from_this());
 
   Box bar_box(Vec2(x + 1.f, y + 1.f), Vec2(width - 2.f, height - 2.f), GlCanvas::kZValueSliderBg);
-  batcher->AddBox(bar_box, bar_color_, shared_from_this());
+  batcher.AddBox(bar_box, bar_color_, shared_from_this());
 }
 
 void GlSlider::DrawSlider(GlCanvas* canvas, float x, float y, float width, float height,
                           ShadingDirection shading_direction) {
-  Batcher* batcher = canvas->GetBatcher();
+  Batcher& batcher = canvas->GetBatcher();
   Color color =
       canvas->GetPickingManager().IsThisElementPicked(this) && drag_type_ == DragType::kPan
           ? selected_color_
@@ -143,16 +143,16 @@ void GlSlider::DrawSlider(GlCanvas* canvas, float x, float y, float width, float
 
   Box dark_border_box(Vec2(x, y), Vec2(width, height), GlCanvas::kZValueSlider - 2 * kEpsilon);
 
-  batcher->AddBox(dark_border_box, dark_border_color, shared_from_this());
+  batcher.AddBox(dark_border_box, dark_border_color, shared_from_this());
 
   Box light_border_box(Vec2(x + 1.f, y + 1.f), Vec2(width - 2.f, height - 2.f),
                        GlCanvas::kZValueSlider - kEpsilon);
 
-  batcher->AddBox(light_border_box, light_border_color, shared_from_this());
+  batcher.AddBox(light_border_box, light_border_color, shared_from_this());
 
   // Slider itself
-  batcher->AddShadedBox(Vec2(x + 2.f, y + 2.f), Vec2(width - 4.f, height - 4.f),
-                        GlCanvas::kZValueSlider, color, shared_from_this(), shading_direction);
+  batcher.AddShadedBox(Vec2(x + 2.f, y + 2.f), Vec2(width - 4.f, height - 4.f),
+                       GlCanvas::kZValueSlider, color, shared_from_this(), shading_direction);
 }
 
 bool GlSlider::HandlePageScroll(float click_value) {
@@ -223,7 +223,7 @@ void GlHorizontalSlider::Draw(GlCanvas* canvas) {
 
   DrawSlider(canvas, start, y, slider_width, GetPixelHeight(), ShadingDirection::kTopToBottom);
 
-  Batcher* batcher = canvas->GetBatcher();
+  Batcher& batcher = canvas->GetBatcher();
   const float kEpsilon = 0.0001f;
 
   // Left / right resize arrows and separator
@@ -239,33 +239,32 @@ void GlHorizontalSlider::Draw(GlCanvas* canvas) {
   const float x = start;
   const float width = slider_width;
 
-  batcher->AddTriangle(
+  batcher.AddTriangle(
       Triangle(Vec3(x + width - tri_size - 2.f, kHeightFactor * tri_size + tri_y_offset, z),
                Vec3(x + width - 2.f, tri_y_offset + kHeightFactor / 2.f * tri_size, z),
                Vec3(x + width - tri_size - 2.f, tri_y_offset, z)),
       kWhite, shared_from_this());
-  batcher->AddVerticalLine(Vec2(x + width - slider_resize_pixel_margin_, 2.f), pixel_height_ - 4.f,
-                           z, kWhite, shared_from_this());
+  batcher.AddVerticalLine(Vec2(x + width - slider_resize_pixel_margin_, 2.f), pixel_height_ - 4.f,
+                          z, kWhite, shared_from_this());
 
-  batcher->AddTriangle(
-      Triangle(Vec3(x + tri_size + 2.f, kHeightFactor * tri_size + tri_y_offset, z),
-               Vec3(x + tri_size + 2.f, tri_y_offset, z),
-               Vec3(x + 2.f, tri_y_offset + kHeightFactor / 2.f * tri_size, z)),
-      kWhite, shared_from_this());
-  batcher->AddVerticalLine(Vec2(x + slider_resize_pixel_margin_ + 1, 2.f), pixel_height_ - 4.f, z,
-                           kWhite, shared_from_this());
+  batcher.AddTriangle(Triangle(Vec3(x + tri_size + 2.f, kHeightFactor * tri_size + tri_y_offset, z),
+                               Vec3(x + tri_size + 2.f, tri_y_offset, z),
+                               Vec3(x + 2.f, tri_y_offset + kHeightFactor / 2.f * tri_size, z)),
+                      kWhite, shared_from_this());
+  batcher.AddVerticalLine(Vec2(x + slider_resize_pixel_margin_ + 1, 2.f), pixel_height_ - 4.f, z,
+                          kWhite, shared_from_this());
 
   // Highlight the scale part of the slider
   if (canvas->GetPickingManager().IsThisElementPicked(this)) {
     if (drag_type_ == DragType::kScaleMax) {
-      batcher->AddShadedBox(Vec2(x + width - slider_resize_pixel_margin_, 2),
-                            Vec2(slider_resize_pixel_margin_ - 2, pixel_height_ - 4),
-                            GlCanvas::kZValueSlider + kEpsilon, selected_color_,
-                            ShadingDirection::kTopToBottom);
+      batcher.AddShadedBox(Vec2(x + width - slider_resize_pixel_margin_, 2),
+                           Vec2(slider_resize_pixel_margin_ - 2, pixel_height_ - 4),
+                           GlCanvas::kZValueSlider + kEpsilon, selected_color_,
+                           ShadingDirection::kTopToBottom);
     } else if (drag_type_ == DragType::kScaleMin) {
-      batcher->AddShadedBox(
-          Vec2(x + 2, 2), Vec2(slider_resize_pixel_margin_ - 2, pixel_height_ - 4),
-          GlCanvas::kZValueSlider + kEpsilon, selected_color_, ShadingDirection::kTopToBottom);
+      batcher.AddShadedBox(Vec2(x + 2, 2), Vec2(slider_resize_pixel_margin_ - 2, pixel_height_ - 4),
+                           GlCanvas::kZValueSlider + kEpsilon, selected_color_,
+                           ShadingDirection::kTopToBottom);
     }
   }
 }

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -146,30 +146,30 @@ float GpuTrack::GetHeight() const {
   return height;
 }
 
-void GpuTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
+void GpuTrack::Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
+                    PickingMode picking_mode, float z_offset) {
   float track_height = GetHeight();
-  const orbit_gl::Viewport& viewport = canvas->GetViewport();
-  float track_width = viewport.GetVisibleWorldWidth();
+  float track_width = viewport_->GetVisibleWorldWidth();
 
-  SetPos(viewport.GetWorldTopLeft()[0], pos_[1]);
+  SetPos(viewport_->GetWorldTopLeft()[0], pos_[1]);
   SetSize(track_width, track_height);
 
   UpdatePositionOfSubtracks();
 
-  Track::Draw(canvas, picking_mode, z_offset);
+  Track::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, z_offset);
 
   if (collapse_toggle_->IsCollapsed()) {
     return;
   }
 
   if (!submission_track_->IsEmpty()) {
-    submission_track_->SetSize(viewport.GetVisibleWorldWidth(), submission_track_->GetHeight());
-    submission_track_->Draw(canvas, picking_mode, z_offset);
+    submission_track_->SetSize(viewport_->GetVisibleWorldWidth(), submission_track_->GetHeight());
+    submission_track_->Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, z_offset);
   }
 
   if (!marker_track_->IsEmpty()) {
-    marker_track_->SetSize(viewport.GetVisibleWorldWidth(), marker_track_->GetHeight());
-    marker_track_->Draw(canvas, picking_mode, z_offset);
+    marker_track_->SetSize(viewport_->GetVisibleWorldWidth(), marker_track_->GetHeight());
+    marker_track_->Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, z_offset);
   }
 }
 

--- a/src/OrbitGl/GpuTrack.h
+++ b/src/OrbitGl/GpuTrack.h
@@ -54,7 +54,8 @@ class GpuTrack : public Track {
   [[nodiscard]] std::string GetTooltip() const override;
   [[nodiscard]] float GetHeight() const override;
 
-  void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
+  void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
+            PickingMode picking_mode, float z_offset = 0) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;
   [[nodiscard]] std::vector<CaptureViewElement*> GetVisibleChildren() override;

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -30,7 +30,8 @@ class GraphTrack : public Track {
                       uint32_t indentation_level = 0);
 
   [[nodiscard]] Type GetType() const override { return Type::kGraphTrack; }
-  void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
+  void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
+            PickingMode picking_mode, float z_offset = 0) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;
   [[nodiscard]] float GetHeight() const override;
@@ -50,8 +51,9 @@ class GraphTrack : public Track {
 
  protected:
   void DrawSquareDot(Batcher* batcher, Vec2 center, float radius, float z, const Color& color);
-  void DrawLabel(GlCanvas* canvas, Vec2 target_pos, const std::string& text,
-                 const Color& text_color, const Color& font_color, float z);
+  void DrawLabel(Batcher& batcher, TextRenderer& text_renderer, Vec2 target_pos,
+                 const std::string& text, const Color& text_color, const Color& font_color,
+                 float z);
 
   std::map<uint64_t, double> values_;
   double min_ = std::numeric_limits<double>::max();

--- a/src/OrbitGl/MemoryTrack.cpp
+++ b/src/OrbitGl/MemoryTrack.cpp
@@ -10,13 +10,13 @@
 
 namespace orbit_gl {
 
-void MemoryTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
-  GraphTrack::Draw(canvas, picking_mode, z_offset);
+void MemoryTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
+                       uint64_t current_mouse_time_ns, PickingMode picking_mode, float z_offset) {
+  GraphTrack::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, z_offset);
 
   if (values_.empty() || picking_mode != PickingMode::kNone) return;
 
   float text_z = GlCanvas::kZValueTrackText + z_offset;
-  Batcher* ui_batcher = canvas->GetBatcher();
   uint32_t font_size = layout_->CalculateZoomedFontSize();
 
   float content_height =
@@ -35,45 +35,43 @@ void MemoryTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offse
     Vec2 to(x + size_[0], y);
 
     std::string text = warning_threshold_.value().first;
-    float string_width = canvas->GetTextRenderer().GetStringWidth(text.c_str(), font_size);
+    float string_width = text_renderer.GetStringWidth(text.c_str(), font_size);
     Vec2 text_box_size(string_width, layout_->GetTextBoxHeight());
     Vec2 text_box_position(pos_[0] + layout_->GetRightMargin(),
                            y - layout_->GetTextBoxHeight() / 2.f);
-    canvas->GetTextRenderer().AddText(text.c_str(), text_box_position[0],
-                                      text_box_position[1] + layout_->GetTextOffset(), text_z,
-                                      kThresholdColor, font_size, text_box_size[0]);
+    text_renderer.AddText(text.c_str(), text_box_position[0],
+                          text_box_position[1] + layout_->GetTextOffset(), text_z, kThresholdColor,
+                          font_size, text_box_size[0]);
 
-    ui_batcher->AddLine(from, from + Vec2(layout_->GetRightMargin() / 2.f, 0), text_z,
-                        kThresholdColor);
-    ui_batcher->AddLine(Vec2(text_box_position[0] + text_box_size[0], y), to, text_z,
-                        kThresholdColor);
+    batcher.AddLine(from, from + Vec2(layout_->GetRightMargin() / 2.f, 0), text_z, kThresholdColor);
+    batcher.AddLine(Vec2(text_box_position[0] + text_box_size[0], y), to, text_z, kThresholdColor);
   }
 
   // Add value upper bound text box (e.g., the "System Memory Total" text box for memory tracks).
   const Color kWhite(255, 255, 255, 255);
   if (value_upper_bound_.has_value()) {
     std::string text = value_upper_bound_.value().first;
-    float string_width = canvas->GetTextRenderer().GetStringWidth(text.c_str(), font_size);
+    float string_width = text_renderer.GetStringWidth(text.c_str(), font_size);
     Vec2 text_box_size(string_width, layout_->GetTextBoxHeight());
     Vec2 text_box_position(pos_[0] + size_[0] - text_box_size[0] - layout_->GetRightMargin() -
                                layout_->GetSliderWidth(),
                            content_pos[1] - layout_->GetTextBoxHeight() / 2.f);
-    canvas->GetTextRenderer().AddText(text.c_str(), text_box_position[0],
-                                      text_box_position[1] + layout_->GetTextOffset(), text_z,
-                                      kWhite, font_size, text_box_size[0]);
+    text_renderer.AddText(text.c_str(), text_box_position[0],
+                          text_box_position[1] + layout_->GetTextOffset(), text_z, kWhite,
+                          font_size, text_box_size[0]);
   }
 
   // Add value lower bound text box.
   if (value_lower_bound_.has_value()) {
     std::string text = value_lower_bound_.value().first;
-    float string_width = canvas->GetTextRenderer().GetStringWidth(text.c_str(), font_size);
+    float string_width = text_renderer.GetStringWidth(text.c_str(), font_size);
     Vec2 text_box_size(string_width, layout_->GetTextBoxHeight());
     Vec2 text_box_position(pos_[0] + size_[0] - text_box_size[0] - layout_->GetRightMargin() -
                                layout_->GetSliderWidth(),
                            content_pos[1] - content_height);
-    canvas->GetTextRenderer().AddText(text.c_str(), text_box_position[0],
-                                      text_box_position[1] + layout_->GetTextOffset(), text_z,
-                                      kWhite, font_size, text_box_size[0]);
+    text_renderer.AddText(text.c_str(), text_box_position[0],
+                          text_box_position[1] + layout_->GetTextOffset(), text_z, kWhite,
+                          font_size, text_box_size[0]);
   }
 }
 

--- a/src/OrbitGl/MemoryTrack.h
+++ b/src/OrbitGl/MemoryTrack.h
@@ -23,7 +23,8 @@ class MemoryTrack final : public GraphTrack {
   ~MemoryTrack() override = default;
   [[nodiscard]] Type GetType() const override { return Type::kMemoryTrack; }
 
-  void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
+  void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
+            PickingMode picking_mode, float z_offset = 0) override;
 
   void SetWarningThresholdWhenEmpty(const std::string& pretty_label, double raw_value);
   void SetValueUpperBoundWhenEmpty(const std::string& pretty_label, double raw_value);

--- a/src/OrbitGl/TextRenderer.cpp
+++ b/src/OrbitGl/TextRenderer.cpp
@@ -126,7 +126,7 @@ ftgl::texture_glyph_t* TextRenderer::MaybeLoadAndGetGlyph(ftgl::texture_font_t* 
   return texture_font_get_glyph(font, character);
 }
 
-void TextRenderer::RenderLayer(Batcher* /*batcher*/, float layer) {
+void TextRenderer::RenderLayer(float layer) {
   ORBIT_SCOPE_FUNCTION;
   if (vertex_buffers_by_layer_.count(layer) == 0) return;
   auto& buffer = vertex_buffers_by_layer_.at(layer);

--- a/src/OrbitGl/TextRenderer.h
+++ b/src/OrbitGl/TextRenderer.h
@@ -37,7 +37,7 @@ class TextRenderer {
   void Clear();
   void SetViewport(orbit_gl::Viewport* viewport) { viewport_ = viewport; }
 
-  void RenderLayer(Batcher* batcher, float layer);
+  void RenderLayer(float layer);
   void RenderDebug(Batcher* batcher);
   [[nodiscard]] std::vector<float> GetLayers() const;
 

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -36,8 +36,10 @@ bool ThreadStateBar::IsEmpty() const {
   return !capture_data_->HasThreadStatesForThread(thread_id_);
 }
 
-void ThreadStateBar::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
-  ThreadBar::Draw(canvas, picking_mode, z_offset);
+void ThreadStateBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
+                          uint64_t current_mouse_time_ns, PickingMode picking_mode,
+                          float z_offset) {
+  ThreadBar::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, z_offset);
 
   // Similarly to CallstackThreadBar::Draw, the thread state slices don't respond to clicks, but
   // have a tooltip. For picking, we want to draw the event bar over them if handling a click, and
@@ -47,10 +49,9 @@ void ThreadStateBar::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_of
   thread_state_bar_z += z_offset;
 
   // Draw a transparent track just for clicking.
-  Batcher* ui_batcher = canvas->GetBatcher();
   Box box(pos_, Vec2(size_[0], -size_[1]), thread_state_bar_z);
   static const Color kTransparent{0, 0, 0, 0};
-  ui_batcher->AddBox(box, kTransparent, shared_from_this());
+  batcher.AddBox(box, kTransparent, shared_from_this());
 }
 
 static Color GetThreadStateColor(ThreadStateSliceInfo::ThreadState state) {

--- a/src/OrbitGl/ThreadStateBar.h
+++ b/src/OrbitGl/ThreadStateBar.h
@@ -29,7 +29,8 @@ class ThreadStateBar final : public ThreadBar {
                           orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                           const orbit_client_model::CaptureData* capture_data, ThreadID thread_id);
 
-  void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) override;
+  void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
+            PickingMode picking_mode, float z_offset) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset) override;
 

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -268,8 +268,9 @@ void ThreadTrack::UpdateMinMaxTimestamps() {
   max_time_ = std::max(max_time_.load(), capture_data_->GetCallstackData()->max_time());
 }
 
-void ThreadTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
-  TimerTrack::Draw(canvas, picking_mode, z_offset);
+void ThreadTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
+                       uint64_t current_mouse_time_ns, PickingMode picking_mode, float z_offset) {
+  TimerTrack::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, z_offset);
 
   UpdateMinMaxTimestamps();
   UpdatePositionOfSubtracks();
@@ -277,21 +278,21 @@ void ThreadTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offse
   const float thread_state_track_height = layout_->GetThreadStateTrackHeight();
   const float event_track_height = layout_->GetEventTrackHeight();
   const float tracepoint_track_height = layout_->GetEventTrackHeight();
-  const float world_width = canvas->GetViewport().GetVisibleWorldWidth();
+  const float world_width = viewport_->GetVisibleWorldWidth();
 
   if (!thread_state_bar_->IsEmpty()) {
     thread_state_bar_->SetSize(world_width, thread_state_track_height);
-    thread_state_bar_->Draw(canvas, picking_mode, z_offset);
+    thread_state_bar_->Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, z_offset);
   }
 
   if (!event_bar_->IsEmpty()) {
     event_bar_->SetSize(world_width, event_track_height);
-    event_bar_->Draw(canvas, picking_mode, z_offset);
+    event_bar_->Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, z_offset);
   }
 
   if (!tracepoint_bar_->IsEmpty()) {
     tracepoint_bar_->SetSize(world_width, tracepoint_track_height);
-    tracepoint_bar_->Draw(canvas, picking_mode, z_offset);
+    tracepoint_bar_->Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, z_offset);
   }
 }
 

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -42,7 +42,8 @@ class ThreadTrack final : public TimerTrack {
   [[nodiscard]] const TextBox* GetLeft(const TextBox* textbox) const override;
   [[nodiscard]] const TextBox* GetRight(const TextBox* textbox) const override;
 
-  void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
+  void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
+            PickingMode picking_mode, float z_offset = 0) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -44,11 +44,15 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
                      const orbit_client_model::CaptureData* capture_data);
   ~TimeGraph();
 
-  void Draw(GlCanvas* canvas, PickingMode picking_mode = PickingMode::kNone,
-            float /*z_offset*/ = 0) override;
-  void DrawTracks(GlCanvas* canvas, PickingMode picking_mode = PickingMode::kNone);
-  void DrawOverlay(GlCanvas* canvas, PickingMode picking_mode);
-  void DrawText(GlCanvas* canvas, float layer);
+  void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
+            PickingMode picking_mode = PickingMode::kNone, float /*z_offset*/ = 0) override;
+  void DrawTracks(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
+                  PickingMode picking_mode = PickingMode::kNone);
+  void DrawOverlay(Batcher& batcher, TextRenderer& text_renderer, PickingMode picking_mode);
+  void DrawIteratorBox(Batcher& batcher, TextRenderer& text_renderer, Vec2 pos, Vec2 size,
+                       const Color& color, const std::string& label, const std::string& time,
+                       float text_box_y);
+  void DrawText(float layer);
 
   void RequestUpdatePrimitives();
   void UpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/, uint64_t /*max_tick*/,
@@ -161,9 +165,6 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
     iterator_id_to_function_id_ = iterator_id_to_function_id;
     RequestRedraw();
   }
-
-  void DrawIteratorBox(GlCanvas* canvas, Vec2 pos, Vec2 size, const Color& color,
-                       const std::string& label, const std::string& time, float text_box_y);
 
   [[nodiscard]] uint64_t GetCaptureMin() const { return capture_min_timestamp_; }
   [[nodiscard]] uint64_t GetCaptureMax() const { return capture_max_timestamp_; }

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -38,15 +38,15 @@ TimerTrack::TimerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
   text_renderer_ = time_graph->GetTextRenderer();
 }
 
-void TimerTrack::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
-  const orbit_gl::Viewport& viewport = canvas->GetViewport();
+void TimerTrack::Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
+                      PickingMode picking_mode, float z_offset) {
   float track_height = GetHeight();
-  float track_width = viewport.GetVisibleWorldWidth();
+  float track_width = viewport_->GetVisibleWorldWidth();
 
-  SetPos(viewport.GetWorldTopLeft()[0], pos_[1]);
+  SetPos(viewport_->GetWorldTopLeft()[0], pos_[1]);
   SetSize(track_width, track_height);
 
-  Track::Draw(canvas, picking_mode, z_offset);
+  Track::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, z_offset);
 }
 
 std::string TimerTrack::GetExtraInfo(const TimerInfo& timer_info) {

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -29,7 +29,6 @@
 #include "capture_data.pb.h"
 
 class OrbitApp;
-class TextRenderer;
 
 namespace internal {
 struct DrawData {
@@ -59,7 +58,8 @@ class TimerTrack : public Track {
   ~TimerTrack() override = default;
 
   // Pickable
-  void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
+  void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
+            PickingMode picking_mode, float z_offset = 0) override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
   [[nodiscard]] std::string GetTooltip() const override;
 

--- a/src/OrbitGl/TracepointThreadBar.cpp
+++ b/src/OrbitGl/TracepointThreadBar.cpp
@@ -36,21 +36,21 @@ TracepointThreadBar::TracepointThreadBar(CaptureViewElement* parent, OrbitApp* a
     : ThreadBar(parent, app, time_graph, viewport, layout, capture_data, thread_id, "Tracepoints"),
       color_{255, 0, 0, 255} {}
 
-void TracepointThreadBar::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
-  ThreadBar::Draw(canvas, picking_mode, z_offset);
+void TracepointThreadBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
+                               uint64_t current_mouse_time_ns, PickingMode picking_mode,
+                               float z_offset) {
+  ThreadBar::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, z_offset);
 
   if (IsEmpty()) {
     return;
   }
-
-  Batcher* ui_batcher = canvas->GetBatcher();
 
   float event_bar_z = picking_mode == PickingMode::kClick ? GlCanvas::kZValueEventBarPicking
                                                           : GlCanvas::kZValueEventBar;
   event_bar_z += z_offset;
   Color color = color_;
   Box box(pos_, Vec2(size_[0], -size_[1]), event_bar_z);
-  ui_batcher->AddBox(box, color, shared_from_this());
+  batcher.AddBox(box, color, shared_from_this());
 }
 
 void TracepointThreadBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,

--- a/src/OrbitGl/TracepointThreadBar.h
+++ b/src/OrbitGl/TracepointThreadBar.h
@@ -22,7 +22,8 @@ class TracepointThreadBar : public ThreadBar {
                                const orbit_client_model::CaptureData* capture_data,
                                int32_t thread_id);
 
-  void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
+  void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
+            PickingMode picking_mode, float z_offset = 0) override;
 
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -47,7 +47,8 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
                  uint32_t indentation_level);
   ~Track() override = default;
 
-  void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
+  void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
+            PickingMode picking_mode, float z_offset = 0) override;
 
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;
@@ -107,8 +108,10 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
 
  protected:
   // Returns the y-position of the triangle.
-  float DrawCollapsingTriangle(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0);
-  void DrawTriangleFan(Batcher* batcher, const std::vector<Vec2>& points, const Vec2& pos,
+  float DrawCollapsingTriangle(Batcher& batcher, TextRenderer& text_renderer,
+                               uint64_t current_mouse_time_ns, PickingMode picking_mode,
+                               float z_offset = 0);
+  void DrawTriangleFan(Batcher& batcher, const std::vector<Vec2>& points, const Vec2& pos,
                        const Color& color, float rotation, float z);
 
   std::unique_ptr<orbit_accessibility::AccessibleInterface> CreateAccessibleInterface() override;

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -27,10 +27,11 @@ TriangleToggle::TriangleToggle(State initial_state, StateChangeHandler handler,
   SetSize(size, size);
 }
 
-void TriangleToggle::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset) {
-  CaptureViewElement::Draw(canvas, picking_mode, z_offset);
+void TriangleToggle::Draw(Batcher& batcher, TextRenderer& text_renderer,
+                          uint64_t current_mouse_time_ns, PickingMode picking_mode,
+                          float z_offset) {
+  CaptureViewElement::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, z_offset);
 
-  Batcher* ui_batcher = canvas->GetBatcher();
   const float z = GlCanvas::kZValueTrack + z_offset;
 
   const bool picking = picking_mode != PickingMode::kNone;
@@ -54,14 +55,14 @@ void TriangleToggle::Draw(GlCanvas* canvas, PickingMode picking_mode, float z_of
       triangle = Triangle(position + Vec3(half_w, half_h, z), position + Vec3(-half_w, half_h, z),
                           position + Vec3(0.f, -half_w, z));
     }
-    ui_batcher->AddTriangle(triangle, color, shared_from_this());
+    batcher.AddTriangle(triangle, color, shared_from_this());
   } else {
     // When picking, draw a big square for easier picking.
     float original_width = 2 * half_w;
     float large_width = 2 * original_width;
     Box box(Vec2(pos_[0] - original_width, pos_[1] - original_width),
             Vec2(large_width, large_width), z);
-    ui_batcher->AddBox(box, color, shared_from_this());
+    batcher.AddBox(box, color, shared_from_this());
   }
 }
 

--- a/src/OrbitGl/TriangleToggle.h
+++ b/src/OrbitGl/TriangleToggle.h
@@ -32,7 +32,8 @@ class TriangleToggle : public orbit_gl::CaptureViewElement,
   TriangleToggle(TriangleToggle&&) = delete;
   TriangleToggle& operator=(TriangleToggle&&) = delete;
 
-  void Draw(GlCanvas* canvas, PickingMode picking_mode, float z_offset = 0) override;
+  void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
+            PickingMode picking_mode, float z_offset = 0) override;
 
   // Pickable
   void OnRelease() override;


### PR DESCRIPTION
In this PR, we are erasing canvas dependence from the Tracks.

For that, we are mainly replacing it in the Draw methods for a Batcher and a TextRenderer (both needed to draw) and also we are including the mouse_time (needed in the GraphTrack). There are also a few more modifications that I had to include in the same commit. Sorry for that.

With this we achieved 3 goals:
 - The dependences in Draw are easier to understand and to refactor in the future
 - canvas_ is not needed as a member in CaptureViewElements
 - Only 2 canvas references left in TimeGraph (one about the PickingManager which will be passed as a parameter in a future PR) and one to force a Redraw in GlCanvas (which should be managed in the opposite direction).

Focusing:
https://b/185214650.

Small TODO: Make the same in UpdatePrimitives and give a reference of the batcher instead of a pointer.

Test:
Run a capture and load a capture.