### PR TITLE
Add collect_gpu_jobs to CaptureClient and flag to OrbitFakeClient

### DIFF
--- a/src/CaptureClient/include/CaptureClient/CaptureClient.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureClient.h
@@ -44,7 +44,7 @@ class CaptureClient {
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
       TracepointInfoSet selected_tracepoints, double samples_per_second,
       orbit_grpc_protos::UnwindingMethod unwinding_method, bool collect_scheduling_info,
-      bool collect_thread_state, bool enable_api, bool enable_introspection,
+      bool collect_thread_state, bool collect_gpu_jobs, bool enable_api, bool enable_introspection,
       uint64_t max_local_marker_depth_per_command_buffer, bool collect_memory_info,
       uint64_t memory_sampling_period_ns,
       std::unique_ptr<CaptureEventProcessor> capture_event_processor);
@@ -78,7 +78,7 @@ class CaptureClient {
       const absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>& selected_functions,
       const TracepointInfoSet& selected_tracepoints, double samples_per_second,
       orbit_grpc_protos::UnwindingMethod unwinding_method, bool collect_scheduling_info,
-      bool collect_thread_state, bool enable_api, bool enable_introspection,
+      bool collect_thread_state, bool collect_gpu_jobs, bool enable_api, bool enable_introspection,
       uint64_t max_local_marker_depth_per_command_buffer, bool collect_memory_info,
       uint64_t memory_sampling_period_ns, CaptureEventProcessor* capture_event_processor);
 

--- a/src/FakeClient/FakeClientMain.cpp
+++ b/src/FakeClient/FakeClientMain.cpp
@@ -34,6 +34,7 @@ ABSL_FLAG(uint16_t, sampling_rate, 1000,
 ABSL_FLAG(bool, frame_pointers, false, "Use frame pointers for unwinding");
 ABSL_FLAG(bool, scheduling, true, "Collect scheduling information");
 ABSL_FLAG(bool, thread_state, false, "Collect thread state information");
+ABSL_FLAG(bool, gpu_jobs, true, "Collect GPU jobs");
 ABSL_FLAG(uint16_t, memory_sampling_rate, 0,
           "Memory usage sampling rate in samples per second (0: no sampling)");
 
@@ -88,6 +89,8 @@ int main(int argc, char* argv[]) {
   LOG("collect_scheduling_info=%d", collect_scheduling_info);
   bool collect_thread_state = absl::GetFlag(FLAGS_thread_state);
   LOG("collect_thread_state=%d", collect_thread_state);
+  bool collect_gpu_jobs = absl::GetFlag(FLAGS_gpu_jobs);
+  LOG("collect_gpu_jobs=%d", collect_gpu_jobs);
   constexpr bool kEnableApi = false;
   constexpr bool kEnableIntrospection = false;
   constexpr uint64_t kMaxLocalMarkerDepthPerCommandBuffer = std::numeric_limits<uint64_t>::max();
@@ -118,8 +121,8 @@ int main(int argc, char* argv[]) {
       thread_pool.get(), process_id, module_manager,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>{}, TracepointInfoSet{},
       samples_per_second, unwinding_method, collect_scheduling_info, collect_thread_state,
-      kEnableApi, kEnableIntrospection, kMaxLocalMarkerDepthPerCommandBuffer, collect_memory_info,
-      memory_sampling_period_ns, std::move(capture_event_processor));
+      collect_gpu_jobs, kEnableApi, kEnableIntrospection, kMaxLocalMarkerDepthPerCommandBuffer,
+      collect_memory_info, memory_sampling_period_ns, std::move(capture_event_processor));
   LOG("Asked to start capture");
 
   uint32_t duration_s = absl::GetFlag(FLAGS_duration);

--- a/src/OrbitClientGgp/ClientGgp.cpp
+++ b/src/OrbitClientGgp/ClientGgp.cpp
@@ -101,20 +101,21 @@ bool ClientGgp::RequestStartCapture(ThreadPool* thread_pool) {
 
   LOG("Capture pid %d", pid);
   TracepointInfoSet selected_tracepoints;
-  bool collect_scheduling_info = true;
-  bool collect_thread_state = absl::GetFlag(FLAGS_thread_state);
-  uint64_t max_local_marker_depth_per_command_buffer =
-      absl::GetFlag(FLAGS_max_local_marker_depth_per_command_buffer);
-  bool enable_api = false;
-  bool enable_introspection = false;
   UnwindingMethod unwinding_method = options_.use_framepointer_unwinding
                                          ? UnwindingMethod::kFramePointerUnwinding
                                          : UnwindingMethod::kDwarfUnwinding;
+  bool collect_scheduling_info = true;
+  bool collect_thread_state = absl::GetFlag(FLAGS_thread_state);
+  bool collect_gpu_jobs = true;
+  bool enable_api = false;
+  bool enable_introspection = false;
+  uint64_t max_local_marker_depth_per_command_buffer =
+      absl::GetFlag(FLAGS_max_local_marker_depth_per_command_buffer);
 
   Future<ErrorMessageOr<CaptureOutcome>> result = capture_client_->Capture(
       thread_pool, target_process_->pid(), module_manager_, selected_functions_,
       selected_tracepoints, options_.samples_per_second, unwinding_method, collect_scheduling_info,
-      collect_thread_state, enable_api, enable_introspection,
+      collect_thread_state, collect_gpu_jobs, enable_api, enable_introspection,
       max_local_marker_depth_per_command_buffer, false, 0,
       CaptureEventProcessor::CreateForCaptureListener(this, absl::flat_hash_set<uint64_t>{}));
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1027,6 +1027,7 @@ void OrbitApp::StartCapture() {
   TracepointInfoSet selected_tracepoints = data_manager_->selected_tracepoints();
   bool collect_scheduling_info = true;
   bool collect_thread_states = data_manager_->collect_thread_states();
+  bool collect_gpu_jobs = true;
   bool enable_api = data_manager_->get_enable_api();
   bool enable_introspection = IsDevMode() && data_manager_->get_enable_introspection();
   double samples_per_second = data_manager_->samples_per_second();
@@ -1045,9 +1046,9 @@ void OrbitApp::StartCapture() {
   Future<ErrorMessageOr<CaptureOutcome>> capture_result = capture_client_->Capture(
       thread_pool_.get(), process->pid(), *module_manager_, std::move(selected_functions_map),
       std::move(selected_tracepoints), samples_per_second, unwinding_method,
-      collect_scheduling_info, collect_thread_states, enable_api, enable_introspection,
-      max_local_marker_depth_per_command_buffer, collect_memory_info, memory_sampling_period_ns,
-      std::move(capture_event_processor));
+      collect_scheduling_info, collect_thread_states, collect_gpu_jobs, enable_api,
+      enable_introspection, max_local_marker_depth_per_command_buffer, collect_memory_info,
+      memory_sampling_period_ns, std::move(capture_event_processor));
 
   capture_result.Then(main_thread_executor_, [this](ErrorMessageOr<CaptureOutcome> capture_result) {
     if (capture_result.has_error()) {


### PR DESCRIPTION
I want `OrbitFakeClient` to be able to disable collection of (almost) every
event.

Bug: http://b/187168022

Test:
- Take a capture -> GpuJobs still in order.
- Capture with `OrbitFakeClient` with all options off, and a capture with all
  options off except `-gpu_jobs`, notice the difference in number of events.