### PR TITLE
Fix manual instrumentation in development setup on Linux

### DIFF
--- a/src/UserSpaceInstrumentation/InjectLibraryInTracee.cpp
+++ b/src/UserSpaceInstrumentation/InjectLibraryInTracee.cpp
@@ -60,6 +60,11 @@ ErrorMessageOr<uint64_t> FindFunctionAddressWithFallback(pid_t pid, std::string_
 
 [[nodiscard]] ErrorMessageOr<void*> DlopenInTracee(pid_t pid, std::filesystem::path path,
                                                    uint32_t flag) {
+  // Make sure file exists.
+  if (!std::filesystem::exists(path)) {
+    return ErrorMessage(absl::StrFormat("File not found (\"%s\")", path));
+  }
+
   // Figure out address of dlopen.
   OUTCOME_TRY(dlopen_address, FindFunctionAddressWithFallback(pid, kLibdlSoname, kDlopenInLibdl,
                                                               kLibcSoname, kDlopenInLibc));

--- a/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
+++ b/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
@@ -29,6 +29,7 @@ namespace orbit_user_space_instrumentation {
 
 namespace {
 
+using orbit_base::HasError;
 using orbit_base::HasNoError;
 
 void OpenUseAndCloseLibrary(pid_t pid) {
@@ -139,7 +140,7 @@ TEST(InjectLibraryInTraceeTest, NonExistingLibrary) {
   // Try to load non existing dynamic lib into tracee.
   const std::string kNonExistingLibName = "libNotFound.so";
   auto library_handle_or_error = DlopenInTracee(pid, kNonExistingLibName, RTLD_NOW);
-  ASSERT_TRUE(library_handle_or_error.has_error());
+  ASSERT_THAT(library_handle_or_error, HasError("File not found"));
 
   // Continue child process.
   CHECK(!DetachAndContinueProcess(pid).has_error());


### PR DESCRIPTION
Add a search directory for liborbit.so. When packaged, it is found
alongside OrbitService. In development however, it is found in ../lib, 
relative to OrbitService.

Also, Make sure DlopenInTracee returns an errror if the library is not found.