### PR TITLE
[Rebase on 1.63] Re-add header of "Address" column in "Live" tab

### DIFF
--- a/src/OrbitGl/LiveFunctionsDataView.cpp
+++ b/src/OrbitGl/LiveFunctionsDataView.cpp
@@ -63,6 +63,7 @@ const std::vector<DataView::Column>& LiveFunctionsDataView::GetColumns() {
     columns[kColumnTimeMin] = {"Min", .075f, SortingOrder::kDescending};
     columns[kColumnTimeMax] = {"Max", .075f, SortingOrder::kDescending};
     columns[kColumnModule] = {"Module", .1f, SortingOrder::kAscending};
+    columns[kColumnAddress] = {"Address", .0f, SortingOrder::kAscending};
     return columns;
   }();
   return columns;


### PR DESCRIPTION
This was removed by 9f69e6783056895249194dbbdafdb7e470142347 but I don't know
if there's a reason (as the column is still there).

Bug: http://b/187178875

Test: Capture Trata with a function instrumented.

---

Reviewed in https://github.com/google/orbit/pull/2278.