### PR TITLE
Erase canvas in TimeGraph

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -556,8 +556,8 @@ void CaptureWindow::set_draw_help(bool draw_help) {
 }
 
 void CaptureWindow::CreateTimeGraph(const CaptureData* capture_data) {
-  time_graph_ =
-      std::make_unique<TimeGraph>(this, app_, &text_renderer_, this, &viewport_, capture_data);
+  time_graph_ = std::make_unique<TimeGraph>(this, app_, &text_renderer_, &viewport_, capture_data,
+                                            &GetPickingManager());
 }
 
 Batcher& CaptureWindow::GetBatcherById(BatcherId batcher_id) {
@@ -576,6 +576,10 @@ void CaptureWindow::RequestUpdatePrimitives() {
   redraw_requested_ = true;
   if (time_graph_ == nullptr) return;
   time_graph_->RequestUpdatePrimitives();
+}
+
+[[nodiscard]] bool CaptureWindow::IsRedrawNeeded() const {
+  return GlCanvas::IsRedrawNeeded() || (time_graph_ != nullptr && time_graph_->IsRedrawNeeded());
 }
 
 void CaptureWindow::RenderImGuiDebugUI() {

--- a/src/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/CaptureWindow.h
@@ -45,6 +45,7 @@ class CaptureWindow : public GlCanvas {
   void RenderImGuiDebugUI() override;
 
   void RequestUpdatePrimitives();
+  [[nodiscard]] bool IsRedrawNeeded() const override;
 
   void ToggleDrawHelp();
   void set_draw_help(bool draw_help);

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -40,8 +40,9 @@ class OrbitApp;
 class TimeGraph : public orbit_gl::CaptureViewElement {
  public:
   explicit TimeGraph(AccessibleInterfaceProvider* parent, OrbitApp* app,
-                     TextRenderer* text_renderer, GlCanvas* canvas, orbit_gl::Viewport* viewport,
-                     const orbit_client_model::CaptureData* capture_data);
+                     TextRenderer* text_renderer, orbit_gl::Viewport* viewport,
+                     const orbit_client_model::CaptureData* capture_data,
+                     PickingManager* picking_manager);
   ~TimeGraph();
 
   void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
@@ -112,7 +113,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
   void SelectAndZoom(const TextBox* text_box);
   [[nodiscard]] double GetCaptureTimeSpanUs() const;
   [[nodiscard]] double GetCurrentTimeSpanUs() const;
-  void RequestRedraw();
+  void RequestRedraw() { redraw_requested_ = true; }
   [[nodiscard]] bool IsRedrawNeeded() const { return redraw_requested_; }
   void SetThreadFilter(const std::string& filter);
 


### PR DESCRIPTION
In this PR we finally erase canvas from TimeGraph.

 - Now CaptureWindow is also checking is time_graph needs a redraw to draw.
 - We pass the PickingManager (needed for the timegraph's batcher in TimeGraph constructor)

Test: Start/stop a capture. Load a capture