### PR TITLE
Allow instrumenting a function with OrbitFakeClient

### DIFF
--- a/src/FakeClient/CMakeLists.txt
+++ b/src/FakeClient/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(OrbitFakeClient PRIVATE
         CONAN_PKG::abseil
         CaptureClient
         ClientProtos
+        ElfUtils
         GrpcProtos
         OrbitBase
         OrbitClientData)


### PR DESCRIPTION
Bug: http://b/187177718

Test: Use `OrbitFakeClient` and Orbit UI to instrument
`eva::graphics::rendering::spatial_geometry::world_sphere() const`
(path: `/srv/game/assets/benchmark`, load bias: `0x200000`, address: `0x6ed730`,
offset: `0x4ed730`). Notice how OrbitService reports a similar number of
instrumentation events.