### PR TITLE
Save capture in new format on the client side.

### DIFF
--- a/src/CaptureClient/CompositeEventProcessor.cpp
+++ b/src/CaptureClient/CompositeEventProcessor.cpp
@@ -10,8 +10,9 @@ namespace {
 
 class CompositeEventProcessor : public CaptureEventProcessor {
  public:
-  explicit CompositeEventProcessor(absl::Span<CaptureEventProcessor* const> event_processors)
-      : event_processors_(event_processors.begin(), event_processors.end()) {}
+  explicit CompositeEventProcessor(
+      std::vector<std::unique_ptr<CaptureEventProcessor>> event_processors)
+      : event_processors_{std::move(event_processors)} {}
 
   void ProcessEvent(const orbit_grpc_protos::ClientCaptureEvent& event) override {
     for (auto& event_processor : event_processors_) {
@@ -20,14 +21,14 @@ class CompositeEventProcessor : public CaptureEventProcessor {
   }
 
  private:
-  std::vector<CaptureEventProcessor*> event_processors_;
+  std::vector<std::unique_ptr<CaptureEventProcessor>> event_processors_;
 };
 
 }  // namespace
 
 std::unique_ptr<CaptureEventProcessor> CaptureEventProcessor::CreateCompositeProcessor(
-    absl::Span<CaptureEventProcessor* const> event_processors) {
-  return std::make_unique<CompositeEventProcessor>(event_processors);
+    std::vector<std::unique_ptr<CaptureEventProcessor>> event_processors) {
+  return std::make_unique<CompositeEventProcessor>(std::move(event_processors));
 }
 
 }  // namespace orbit_capture_client

--- a/src/CaptureClient/SaveToFileEventProcessorTest.cpp
+++ b/src/CaptureClient/SaveToFileEventProcessorTest.cpp
@@ -47,6 +47,8 @@ TEST(SaveToFileEventProcessor, SaveAndLoadSimpleCaptureWithFrameTracks) {
 
   auto error_handler = [](const ErrorMessage& error) { FAIL() << error.message(); };
 
+  temporary_file.CloseAndRemove();
+
   auto capture_event_processor_or_error = CaptureEventProcessor::CreateSaveToFileProcessor(
       temporary_file.file_path(), frame_track_function_ids, error_handler);
   ASSERT_TRUE(capture_event_processor_or_error.has_value())

--- a/src/CaptureClient/include/CaptureClient/CaptureEventProcessor.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureEventProcessor.h
@@ -39,7 +39,7 @@ class CaptureEventProcessor {
       std::function<void(const ErrorMessage&)> error_handler);
 
   static std::unique_ptr<CaptureEventProcessor> CreateCompositeProcessor(
-      absl::Span<CaptureEventProcessor* const> event_processors);
+      std::vector<std::unique_ptr<CaptureEventProcessor>> event_processors);
 };
 
 }  // namespace orbit_capture_client

--- a/src/CaptureFile/CaptureFileOutputStream.cpp
+++ b/src/CaptureFile/CaptureFileOutputStream.cpp
@@ -54,7 +54,7 @@ CaptureFileOutputStreamImpl::~CaptureFileOutputStreamImpl() noexcept {
 }
 
 ErrorMessageOr<void> CaptureFileOutputStreamImpl::Initialize() {
-  auto fd_or_error = orbit_base::OpenFileForWriting(path_);
+  auto fd_or_error = orbit_base::OpenNewFileForWriting(path_);
   if (fd_or_error.has_error()) {
     return fd_or_error.error();
   }

--- a/src/CaptureFile/CaptureFileOutputStreamTest.cpp
+++ b/src/CaptureFile/CaptureFileOutputStreamTest.cpp
@@ -33,6 +33,7 @@ TEST(CaptureFileOutputStream, Smoke) {
   ASSERT_TRUE(temporary_file_or_error.has_value()) << temporary_file_or_error.error().message();
   orbit_base::TemporaryFile temporary_file = std::move(temporary_file_or_error.value());
 
+  temporary_file.CloseAndRemove();
   std::string temp_file_name = temporary_file.file_path().string();
 
   auto output_stream_or_error = CaptureFileOutputStream::Create(temp_file_name);
@@ -98,6 +99,7 @@ TEST(CaptureFileOutputStream, WriteAfterClose) {
   orbit_base::TemporaryFile temporary_file = std::move(temporary_file_or_error.value());
 
   std::string temp_file_name = temporary_file.file_path().string();
+  temporary_file.CloseAndRemove();
 
   auto output_stream_or_error = CaptureFileOutputStream::Create(temp_file_name);
   ASSERT_TRUE(output_stream_or_error.has_value()) << output_stream_or_error.error().message();

--- a/src/CaptureFile/CaptureFileTest.cpp
+++ b/src/CaptureFile/CaptureFileTest.cpp
@@ -37,6 +37,7 @@ TEST(CaptureFile, CreateCaptureFileAndReadMainSection) {
   orbit_base::TemporaryFile temporary_file = std::move(temporary_file_or_error.value());
 
   std::string temp_file_name = temporary_file.file_path().string();
+  temporary_file.CloseAndRemove();
 
   auto output_stream_or_error = CaptureFileOutputStream::Create(temp_file_name);
   ASSERT_TRUE(output_stream_or_error.has_value()) << output_stream_or_error.error().message();
@@ -87,6 +88,7 @@ TEST(CaptureFile, CreateCaptureFileWriteAdditionalSectionAndReadMainSection) {
   orbit_base::TemporaryFile temporary_file = std::move(temporary_file_or_error.value());
 
   std::string temp_file_name = temporary_file.file_path().string();
+  temporary_file.CloseAndRemove();
 
   auto output_stream_or_error = CaptureFileOutputStream::Create(temp_file_name);
   ASSERT_TRUE(output_stream_or_error.has_value()) << output_stream_or_error.error().message();
@@ -147,6 +149,7 @@ TEST(CaptureFile, CreateCaptureFileAndAddSection) {
   orbit_base::TemporaryFile temporary_file = std::move(temporary_file_or_error.value());
 
   std::string temp_file_name = temporary_file.file_path().string();
+  temporary_file.CloseAndRemove();
 
   auto output_stream_or_error = CaptureFileOutputStream::Create(temp_file_name);
   ASSERT_TRUE(output_stream_or_error.has_value()) << output_stream_or_error.error().message();

--- a/src/OrbitBase/File.cpp
+++ b/src/OrbitBase/File.cpp
@@ -92,6 +92,17 @@ ErrorMessageOr<unique_fd> OpenFileForWriting(const std::filesystem::path& path) 
   return OpenFile(path, kOpenFlags, kOpenMode);
 }
 
+ErrorMessageOr<unique_fd> OpenNewFileForWriting(const std::filesystem::path& path) {
+#if defined(__linux)
+  constexpr int kOpenFlags = O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC;
+  constexpr int kOpenMode = 0600;
+#elif defined(_WIN32)
+  constexpr int kOpenFlags = O_WRONLY | O_CREAT | O_EXCL | O_BINARY;
+  constexpr int kOpenMode = _S_IREAD | _S_IWRITE;
+#endif  // defined(__linux)
+  return OpenFile(path, kOpenFlags, kOpenMode);
+}
+
 ErrorMessageOr<unique_fd> OpenNewFileForReadWrite(const std::filesystem::path& path) {
 #if defined(__linux)
   constexpr int kOpenFlags = O_RDWR | O_CREAT | O_EXCL | O_CLOEXEC;

--- a/src/OrbitBase/include/OrbitBase/File.h
+++ b/src/OrbitBase/include/OrbitBase/File.h
@@ -75,6 +75,8 @@ ErrorMessageOr<unique_fd> OpenFileForReading(const std::filesystem::path& path);
 
 ErrorMessageOr<unique_fd> OpenFileForWriting(const std::filesystem::path& path);
 
+ErrorMessageOr<unique_fd> OpenNewFileForWriting(const std::filesystem::path& path);
+
 ErrorMessageOr<unique_fd> OpenNewFileForReadWrite(const std::filesystem::path& path);
 
 ErrorMessageOr<unique_fd> OpenExistingFileForReadWrite(const std::filesystem::path& path);

--- a/src/OrbitGl/ClientFlags.cpp
+++ b/src/OrbitGl/ClientFlags.cpp
@@ -46,3 +46,6 @@ ABSL_FLAG(bool, enable_source_code_view, true, "Enable the experimental source c
 // threshold (i.e., production limit).
 ABSL_FLAG(bool, enable_warning_threshold, false,
           "Enable setting and showing the memory warning threshold");
+
+// TODO(b/187388305): Set default to true in 1.65, remove the flag in 1.66
+ABSL_FLAG(bool, enable_capture_autosave, false, "Enable automatic saving of capture");


### PR DESCRIPTION
At the moment it is feature behind the enable_capture_autosave flag.

Also CompositeEventProcessor now assumes ownership over
CaptureEventProcessors.

Test: Manual - start Orbit with --enable_capture_autosave check the
      created file using hexdump -C (mostly header and some strings)