### PR TITLE
Also Expand Gpu-Subtracks

### DIFF
--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -11,7 +11,7 @@ namespace orbit_gl {
 
 CaptureViewElement::CaptureViewElement(CaptureViewElement* parent, TimeGraph* time_graph,
                                        orbit_gl::Viewport* viewport, TimeGraphLayout* layout)
-    : parent_(parent), viewport_(viewport), layout_(layout), time_graph_(time_graph) {
+    : viewport_(viewport), layout_(layout), time_graph_(time_graph), parent_(parent) {
   CHECK(layout != nullptr);
 }
 

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -45,10 +45,9 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   void OnDrag(int x, int y) override;
   [[nodiscard]] bool Draggable() override { return true; }
 
-  [[nodiscard]] CaptureViewElement* GetParent() const { return parent_; }
+  [[nodiscard]] virtual CaptureViewElement* GetParent() const { return parent_; }
 
  protected:
-  CaptureViewElement* parent_;
   orbit_gl::Viewport* viewport_;
   TimeGraphLayout* layout_;
 
@@ -60,6 +59,9 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   Vec2 mouse_pos_cur_;
   Vec2 picking_offset_ = Vec2(0, 0);
   bool picked_ = false;
+
+ private:
+  CaptureViewElement* parent_;
 };
 }  // namespace orbit_gl
 

--- a/src/OrbitGl/GpuDebugMarkerTrack.cpp
+++ b/src/OrbitGl/GpuDebugMarkerTrack.cpp
@@ -33,8 +33,8 @@ GpuDebugMarkerTrack::GpuDebugMarkerTrack(CaptureViewElement* parent, TimeGraph* 
   draw_background_ = false;
   string_manager_ = app->GetStringManager();
 
-  // Gpu tracks are collapsed by default.
-  collapse_toggle_->SetState(TriangleToggle::State::kCollapsed,
+  // Gpu subtracks are expanded by default, but are however not shown until the parent is collapsed.
+  collapse_toggle_->SetState(TriangleToggle::State::kExpanded,
                              TriangleToggle::InitialStateUpdate::kReplaceInitialState);
 }
 

--- a/src/OrbitGl/GpuDebugMarkerTrack.cpp
+++ b/src/OrbitGl/GpuDebugMarkerTrack.cpp
@@ -33,7 +33,7 @@ GpuDebugMarkerTrack::GpuDebugMarkerTrack(CaptureViewElement* parent, TimeGraph* 
   draw_background_ = false;
   string_manager_ = app->GetStringManager();
 
-  // Gpu subtracks are expanded by default, but are however not shown until the parent is collapsed.
+  // Gpu subtracks are expanded by default, but are however not shown while the parent is collapsed.
   collapse_toggle_->SetState(TriangleToggle::State::kExpanded,
                              TriangleToggle::InitialStateUpdate::kReplaceInitialState);
 }

--- a/src/OrbitGl/GpuSubmissionTrack.cpp
+++ b/src/OrbitGl/GpuSubmissionTrack.cpp
@@ -41,7 +41,7 @@ GpuSubmissionTrack::GpuSubmissionTrack(Track* parent, TimeGraph* time_graph,
   string_manager_ = app->GetStringManager();
   parent_ = parent;
 
-  // Gpu subtracks are expanded by default, but are however not shown until the parent is collapsed.
+  // Gpu subtracks are expanded by default, but are however not shown while the parent is collapsed.
   collapse_toggle_->SetState(TriangleToggle::State::kExpanded,
                              TriangleToggle::InitialStateUpdate::kReplaceInitialState);
 }
@@ -125,7 +125,7 @@ Color GpuSubmissionTrack::GetTimerColor(const TimerInfo& timer_info, bool is_sel
 
 float GpuSubmissionTrack::GetYFromTimer(const TimerInfo& timer_info) const {
   auto adjusted_depth = static_cast<float>(timer_info.depth());
-  if (IsCollapsed() || GetParent()->IsCollapsed()) {
+  if (ShouldShowCollapsed()) {
     adjusted_depth = 0.f;
   }
   CHECK(timer_info.type() == TimerInfo::kGpuActivity ||
@@ -155,7 +155,7 @@ float GpuSubmissionTrack::GetYFromTimer(const TimerInfo& timer_info) const {
 
 // When track or its parent is collapsed, only draw "hardware execution" timers.
 bool GpuSubmissionTrack::TimerFilter(const TimerInfo& timer_info) const {
-  if (IsCollapsed() || GetParent()->IsCollapsed()) {
+  if (ShouldShowCollapsed()) {
     std::string gpu_stage = string_manager_->Get(timer_info.user_data_key()).value_or("");
     return gpu_stage == kHwExecutionString;
   }
@@ -189,7 +189,7 @@ void GpuSubmissionTrack::SetTimesliceText(const TimerInfo& timer_info, float min
 }
 
 float GpuSubmissionTrack::GetHeight() const {
-  bool collapsed = IsCollapsed() || GetParent()->IsCollapsed();
+  bool collapsed = ShouldShowCollapsed();
   uint32_t depth = collapsed ? 1 : GetDepth();
   uint32_t num_gaps = depth > 0 ? depth - 1 : 0;
   if (has_vulkan_layer_command_buffer_timers_ && !collapsed) {

--- a/src/OrbitGl/GpuSubmissionTrack.h
+++ b/src/OrbitGl/GpuSubmissionTrack.h
@@ -81,6 +81,10 @@ class GpuSubmissionTrack : public TimerTrack {
       const orbit_client_protos::TimerInfo& timer_info) const;
   [[nodiscard]] std::string GetCommandBufferTooltip(
       const orbit_client_protos::TimerInfo& timer_info) const;
+
+  [[nodiscard]] bool ShouldShowCollapsed() const {
+    return IsCollapsed() || GetParent()->IsCollapsed();
+  }
 };
 
 #endif  // ORBIT_GL_GPU_SUBMISSION_TRACK_H_

--- a/src/OrbitGl/GpuSubmissionTrack.h
+++ b/src/OrbitGl/GpuSubmissionTrack.h
@@ -31,12 +31,13 @@ class TextRenderer;
 // This track is meant to be used as a subtrack of `GpuTrack`.
 class GpuSubmissionTrack : public TimerTrack {
  public:
-  explicit GpuSubmissionTrack(CaptureViewElement* parent, TimeGraph* time_graph,
-                              orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
-                              uint64_t timeline_hash, OrbitApp* app,
+  explicit GpuSubmissionTrack(Track* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
+                              TimeGraphLayout* layout, uint64_t timeline_hash, OrbitApp* app,
                               const orbit_client_model::CaptureData* capture_data,
                               uint32_t indentation_level);
   ~GpuSubmissionTrack() override = default;
+
+  [[nodiscard]] Track* GetParent() const override { return parent_; }
 
   // The type is currently only used by the TrackManger. We are moving towards removing it
   // completely. For subtracks there is no meaningful type and it should also not be exposed,
@@ -69,6 +70,8 @@ class GpuSubmissionTrack : public TimerTrack {
  private:
   uint64_t timeline_hash_;
   StringManager* string_manager_;
+  Track* parent_;
+
   bool has_vulkan_layer_command_buffer_timers_ = false;
   [[nodiscard]] std::string GetSwQueueTooltip(
       const orbit_client_protos::TimerInfo& timer_info) const;

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -269,25 +269,3 @@ const TextBox* GpuTrack::GetDown(const TextBox* textbox) const {
       UNREACHABLE();
   }
 }
-void GpuTrack::OnCollapseToggle(TriangleToggle::State state) {
-  // When being collapsed, we only show the submission track, and we want those timers also being
-  // collapsed. Further, when expanding the track the user likely wants to get more insights, thus
-  // we expand the subtracks.
-  if (state == TriangleToggle::State::kCollapsed) {
-    if (submission_track_->IsCollapsible()) {
-      submission_track_->Collapse();
-    }
-    if (marker_track_->IsCollapsed()) {
-      marker_track_->Collapse();
-    }
-  } else if (state == TriangleToggle::State::kExpanded) {
-    if (submission_track_->IsCollapsible()) {
-      submission_track_->Expand();
-    }
-    if (marker_track_->IsCollapsed()) {
-      marker_track_->Expand();
-    }
-  }
-
-  Track::OnCollapseToggle(state);
-}

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -270,10 +270,24 @@ const TextBox* GpuTrack::GetDown(const TextBox* textbox) const {
   }
 }
 void GpuTrack::OnCollapseToggle(TriangleToggle::State state) {
-  Track::OnCollapseToggle(state);
   // When being collapsed, we only show the submission track, and we want those timers also being
-  // collapsed. The marker track does not need to be touched, as it will not be drawn.
+  // collapsed. Further, when expanding the track the user likely wants to get more insights, thus
+  // we expand the subtracks.
   if (state == TriangleToggle::State::kCollapsed) {
-    submission_track_->Collapse();
+    if (submission_track_->IsCollapsible()) {
+      submission_track_->Collapse();
+    }
+    if (marker_track_->IsCollapsed()) {
+      marker_track_->Collapse();
+    }
+  } else if (state == TriangleToggle::State::kExpanded) {
+    if (submission_track_->IsCollapsible()) {
+      submission_track_->Expand();
+    }
+    if (marker_track_->IsCollapsed()) {
+      marker_track_->Expand();
+    }
   }
+
+  Track::OnCollapseToggle(state);
 }

--- a/src/OrbitGl/GpuTrack.h
+++ b/src/OrbitGl/GpuTrack.h
@@ -67,7 +67,6 @@ class GpuTrack : public Track {
     return submission_track_->IsEmpty() && marker_track_->IsEmpty();
   }
   [[nodiscard]] bool IsCollapsible() const override { return true; }
-  void OnCollapseToggle(TriangleToggle::State state) override;
 
  private:
   void UpdatePositionOfSubtracks();

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -100,6 +100,7 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
 
   [[nodiscard]] bool IsCollapsed() const { return collapse_toggle_->IsCollapsed(); }
   void Collapse() { collapse_toggle_->SetState(TriangleToggle::State::kCollapsed); }
+  void Expand() { collapse_toggle_->SetState(TriangleToggle::State::kExpanded); }
 
   [[nodiscard]] virtual std::vector<CaptureViewElement*> GetVisibleChildren() { return {}; }
   [[nodiscard]] virtual int GetVisiblePrimitiveCount() const { return 0; }

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -99,8 +99,6 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   [[nodiscard]] virtual bool IsTrackSelected() const { return false; }
 
   [[nodiscard]] bool IsCollapsed() const { return collapse_toggle_->IsCollapsed(); }
-  void Collapse() { collapse_toggle_->SetState(TriangleToggle::State::kCollapsed); }
-  void Expand() { collapse_toggle_->SetState(TriangleToggle::State::kExpanded); }
 
   [[nodiscard]] virtual std::vector<CaptureViewElement*> GetVisibleChildren() { return {}; }
   [[nodiscard]] virtual int GetVisiblePrimitiveCount() const { return 0; }


### PR DESCRIPTION
When expanding the GpuTrack, the user wants to look into the Gpu related information.
They will probably also be interessted in submissions and debug markers. So save them
a click and also expand those tracks.

Bug: http://b/187269015
Test: Take a capture with the Vulkan layer, and collapse/expand the Gpu track.