### PR TITLE
Load capture in new file format

### DIFF
--- a/src/CaptureFile/include/CaptureFile/CaptureFile.h
+++ b/src/CaptureFile/include/CaptureFile/CaptureFile.h
@@ -7,10 +7,13 @@
 
 #include <filesystem>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "CaptureFile/CaptureFileSection.h"
 #include "CaptureFile/CaptureSectionInputStream.h"
+#include "OrbitBase/Logging.h"
+#include "OrbitBase/MakeUniqueForOverwrite.h"
 #include "OrbitBase/Result.h"
 
 namespace orbit_capture_file {
@@ -26,12 +29,16 @@ class CaptureFile {
 
   // Get current additional section list. Section number is the index for the section in the vector.
   [[nodiscard]] virtual const std::vector<CaptureFileSection>& GetSectionList() const = 0;
+
+  // Returns the index for the first section with specified type.
+  [[nodiscard]] virtual std::optional<uint64_t> FindSectionByType(uint64_t section_type) const = 0;
+
   // Adds a section, returns added section number. Sections are always added to the end of the list.
   // The file layout is adjusted accordingly. In case of an I/O error the format consistency is
   // preserved, but the file size could still end up being changed (for example if updated section
   // list was successfully written to file and space for the section was successfully reserved
   // but the function has failed to update file header with the new position of the section list).
-  virtual ErrorMessageOr<uint16_t> AddSection(uint64_t section_type, uint64_t section_size) = 0;
+  virtual ErrorMessageOr<uint64_t> AddSection(uint64_t section_type, uint64_t section_size) = 0;
 
   // Write data from the buffer to the section with specified offset. The data must be in bound
   // of the section. The function will CHECK fail if it is not.
@@ -42,6 +49,17 @@ class CaptureFile {
   // this function will CHECK fail.
   virtual ErrorMessageOr<void> ReadFromSection(uint64_t section_number, uint64_t section_offset,
                                                void* data, size_t size) = 0;
+
+  template <typename T>
+  ErrorMessageOr<T> ReadSectionAsProto(uint64_t section_number) {
+    auto section_info = GetSectionList()[section_number];
+    auto buf = make_unique_for_overwrite<uint8_t[]>(section_info.size);
+    OUTCOME_TRY(ReadFromSection(section_number, 0, buf.get(), section_info.size));
+
+    T message;
+    CHECK(message.ParseFromArray(buf.get(), section_info.size));
+    return message;
+  }
 
   virtual std::unique_ptr<CaptureSectionInputStream> CreateCaptureSectionInputStream() = 0;
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -29,6 +29,7 @@
 #include "CallTreeView.h"
 #include "CaptureClient/CaptureClient.h"
 #include "CaptureClient/CaptureListener.h"
+#include "CaptureFile/CaptureFile.h"
 #include "CaptureWindow.h"
 #include "ClientModel/CaptureData.h"
 #include "ClientServices/CrashManager.h"
@@ -101,7 +102,7 @@ class OrbitApp final : public DataViewFactory, public orbit_capture_client::Capt
   ErrorMessageOr<void> OnLoadPreset(const std::string& file_name);
   ErrorMessageOr<void> OnSaveCapture(const std::filesystem::path& file_name);
   orbit_base::Future<ErrorMessageOr<CaptureOutcome>> LoadCaptureFromFile(
-      const std::string& file_name);
+      const std::filesystem::path& file_path);
   void OnLoadCaptureCancelRequested();
 
   [[nodiscard]] orbit_capture_client::CaptureClient::State GetCaptureState() const;


### PR DESCRIPTION
With this change loading capture first tries to load from the new
capture file format and then falls back to the old capture file format.

Test: Open automatically saved capture - visually compare it to original
      capture.