### PR TITLE
Erase Text Renderer in TimeGraph constructor

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -556,8 +556,8 @@ void CaptureWindow::set_draw_help(bool draw_help) {
 }
 
 void CaptureWindow::CreateTimeGraph(const CaptureData* capture_data) {
-  time_graph_ = std::make_unique<TimeGraph>(this, app_, &text_renderer_, &viewport_, capture_data,
-                                            &GetPickingManager());
+  time_graph_ =
+      std::make_unique<TimeGraph>(this, app_, &viewport_, capture_data, &GetPickingManager());
 }
 
 Batcher& CaptureWindow::GetBatcherById(BatcherId batcher_id) {

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -48,18 +48,16 @@ using orbit_grpc_protos::InstrumentedFunction;
 using orbit_grpc_protos::kMissingInfo;
 
 TimeGraph::TimeGraph(AccessibleInterfaceProvider* parent, OrbitApp* app,
-                     TextRenderer* text_renderer, orbit_gl::Viewport* viewport,
-                     const CaptureData* capture_data, PickingManager* picking_manager)
+                     orbit_gl::Viewport* viewport, const CaptureData* capture_data,
+                     PickingManager* picking_manager)
     // Note that `GlCanvas` and `TimeGraph` span the bridge to OpenGl content, and `TimeGraph`'s
     // parent needs special handling for accessibility. Thus, we use `nullptr` here and we save the
     // parent in accessible_parent_ which doesn't need to be a CaptureViewElement.
     : orbit_gl::CaptureViewElement(nullptr, this, viewport, &layout_),
       accessible_parent_{parent},
-      text_renderer_{text_renderer},
       batcher_(BatcherId::kTimeGraph),
       capture_data_{capture_data},
       app_{app} {
-  text_renderer_->SetViewport(viewport);
   text_renderer_static_.SetViewport(viewport);
   batcher_.SetPickingManager(picking_manager);
   track_manager_ = std::make_unique<TrackManager>(this, viewport_, &GetLayout(), app, capture_data);

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -40,7 +40,7 @@ class OrbitApp;
 class TimeGraph : public orbit_gl::CaptureViewElement {
  public:
   explicit TimeGraph(AccessibleInterfaceProvider* parent, OrbitApp* app,
-                     TextRenderer* text_renderer, orbit_gl::Viewport* viewport,
+                     orbit_gl::Viewport* viewport,
                      const orbit_client_model::CaptureData* capture_data,
                      PickingManager* picking_manager);
   ~TimeGraph();
@@ -195,7 +195,6 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
  private:
   AccessibleInterfaceProvider* accessible_parent_;
   TextRenderer text_renderer_static_;
-  TextRenderer* text_renderer_ = nullptr;
   int num_drawn_text_boxes_ = 0;
 
   // First member is id.


### PR DESCRIPTION
After the refactor it isn't needed anymore.