### PR TITLE
Update Live functions while loading capture from disk

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -438,11 +438,13 @@ void OrbitApp::UpdateModulesAbortCaptureIfModuleWithoutBuildIdNeedsReload(
 void OrbitApp::OnModuleUpdate(uint64_t /*timestamp_ns*/, ModuleInfo module_info) {
   UpdateModulesAbortCaptureIfModuleWithoutBuildIdNeedsReload({module_info});
   GetMutableCaptureData().mutable_process()->AddOrUpdateModuleInfo(module_info);
+  main_thread_executor_->Schedule([this]() { FireRefreshCallbacks(DataViewType::kLiveFunctions); });
 }
 
 void OrbitApp::OnModulesSnapshot(uint64_t /*timestamp_ns*/, std::vector<ModuleInfo> module_infos) {
   UpdateModulesAbortCaptureIfModuleWithoutBuildIdNeedsReload(module_infos);
   GetMutableCaptureData().mutable_process()->UpdateModuleInfos(module_infos);
+  main_thread_executor_->Schedule([this]() { FireRefreshCallbacks(DataViewType::kLiveFunctions); });
 }
 
 void OrbitApp::OnValidateFramePointers(std::vector<const ModuleData*> modules_to_validate) {

--- a/src/OrbitGl/LiveFunctionsDataView.h
+++ b/src/OrbitGl/LiveFunctionsDataView.h
@@ -56,6 +56,9 @@ class LiveFunctionsDataView : public DataView {
   [[nodiscard]] const orbit_client_protos::FunctionInfo& GetInstrumentedFunction(
       uint32_t row) const;
   [[nodiscard]] std::pair<TextBox*, TextBox*> GetMinMax(uint64_t function_id) const;
+  [[nodiscard]] std::optional<orbit_client_protos::FunctionInfo>
+  CreateFunctionInfoFromInstrumentedFunction(
+      const orbit_grpc_protos::InstrumentedFunction& instrumented_function);
 
   absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> functions_{};
 


### PR DESCRIPTION
This also fixes a case with updating live function list if
a module gets loaded after the live capture is started.

Bug: http://b/187463865
Test: load capture from disk see that live function tab is populated and
      updated while the capture is loading.