### PR TITLE
Add support for annotating content to orbit_code_viewer::Viewer

### DIFF
--- a/src/CodeViewer/Dialog.cpp
+++ b/src/CodeViewer/Dialog.cpp
@@ -68,4 +68,8 @@ void Dialog::SetHighlightCurrentLine(bool enabled) {
 
 bool Dialog::IsCurrentLineHighlighted() const { return ui_->viewer->IsCurrentLineHighlighted(); }
 
+void Dialog::SetAnnotatingContent(absl::Span<const AnnotatingLine> annotating_lines) {
+  ui_->viewer->SetAnnotatingContent(annotating_lines);
+}
+
 }  // namespace orbit_code_viewer

--- a/src/CodeViewer/Dialog.cpp
+++ b/src/CodeViewer/Dialog.cpp
@@ -46,7 +46,9 @@ void Dialog::SetLineNumberMargins(FontSizeInEm left, FontSizeInEm right) {
   ui_->viewer->SetLineNumberMargins(left, right);
 }
 
-void Dialog::SetEnableLineNumbers(bool enabled) { ui_->viewer->SetEnableLineNumbers(enabled); }
+void Dialog::SetLineNumberTypes(LineNumberTypes line_number_types) {
+  ui_->viewer->SetLineNumberTypes(line_number_types);
+}
 
 void Dialog::SetEnableSampleCounters(bool enabled) {
   ui_->viewer->SetEnableSampleCounters(enabled);

--- a/src/CodeViewer/Dialog.cpp
+++ b/src/CodeViewer/Dialog.cpp
@@ -20,14 +20,14 @@ Dialog::Dialog(QWidget* parent) : QDialog{parent}, ui_{std::make_unique<Ui::Code
 
 Dialog::~Dialog() noexcept = default;
 
-void Dialog::SetSourceCode(const QString& code) {
+void Dialog::SetMainContent(const QString& code) {
   ui_->viewer->setPlainText(code);
   syntax_highlighter_.reset();
 }
 
-void Dialog::SetSourceCode(const QString& code,
-                           std::unique_ptr<QSyntaxHighlighter> syntax_highlighter) {
-  SetSourceCode(code);
+void Dialog::SetMainContent(const QString& code,
+                            std::unique_ptr<QSyntaxHighlighter> syntax_highlighter) {
+  SetMainContent(code);
   syntax_highlighter_ = std::move(syntax_highlighter);
   syntax_highlighter_->setDocument(ui_->viewer->document());
 }

--- a/src/CodeViewer/ViewerTest.cpp
+++ b/src/CodeViewer/ViewerTest.cpp
@@ -6,6 +6,8 @@
 #include <QFont>
 #include <QFontDatabase>
 #include <QFontMetrics>
+#include <QTextBlock>
+#include <QTextDocument>
 #include <array>
 #include <limits>
 
@@ -39,4 +41,222 @@ TEST(Viewer, DetermineLineNumberWidthInPixels) {
   (void)app;
 }
 
+TEST(Viewer, SetAnnotatingContentInDocumentEmpty) {
+  QTextDocument doc{};
+  constexpr int kNumberOfLines = 3;
+  doc.setPlainText("first line\nsecond line\nthird line");
+  ASSERT_EQ(doc.blockCount(), kNumberOfLines);
+
+  const LargestOccuringLineNumbers max_line_numbers =
+      SetAnnotatingContentInDocument(&doc, absl::Span<const AnnotatingLine>{});
+
+  ASSERT_TRUE(max_line_numbers.main_content.has_value());
+  ASSERT_EQ(max_line_numbers.main_content.value(), 3);
+
+  ASSERT_FALSE(max_line_numbers.annotating_lines.has_value());
+  EXPECT_EQ(doc.blockCount(), kNumberOfLines);
+
+  for (auto current_block = doc.begin(); current_block != doc.end();
+       current_block = current_block.next()) {
+    EXPECT_NE(current_block.userData(), nullptr);
+  }
+}
+
+TEST(Viewer, SetAnnotatingContentInDocumentFirst) {
+  QTextDocument doc{};
+  constexpr int kNumberOfLines = 3;
+  doc.setPlainText("first line\nsecond line\nthird line");
+  ASSERT_EQ(doc.blockCount(), kNumberOfLines);
+
+  std::array<AnnotatingLine, 1> lines{};
+  lines[0].reference_line = 1;
+  lines[0].line_contents = "first annotation";
+  lines[0].line_number = 42;
+
+  const LargestOccuringLineNumbers max_line_numbers = SetAnnotatingContentInDocument(&doc, lines);
+
+  ASSERT_TRUE(max_line_numbers.main_content.has_value());
+  ASSERT_EQ(max_line_numbers.main_content.value(), kNumberOfLines);
+
+  ASSERT_TRUE(max_line_numbers.annotating_lines.has_value());
+  ASSERT_EQ(max_line_numbers.annotating_lines.value(), 42);
+
+  for (auto current_block = doc.begin(); current_block != doc.end();
+       current_block = current_block.next()) {
+    EXPECT_NE(current_block.userData(), nullptr);
+  }
+
+  EXPECT_EQ(doc.begin().text().toStdString(), "first annotation");
+}
+
+TEST(Viewer, SetAnnotatingContentInDocumentConsecutive) {
+  QTextDocument doc{};
+  constexpr int kNumberOfLines = 3;
+  doc.setPlainText("first line\nsecond line\nthird line");
+  ASSERT_EQ(doc.blockCount(), kNumberOfLines);
+
+  std::array<AnnotatingLine, 2> lines{};
+  lines[0].reference_line = 1;
+  lines[0].line_contents = "first annotation";
+  lines[0].line_number = 42;
+  lines[1].reference_line = 2;
+  lines[1].line_contents = "second annotation";
+  lines[1].line_number = 43;
+
+  const LargestOccuringLineNumbers max_line_numbers = SetAnnotatingContentInDocument(&doc, lines);
+
+  ASSERT_TRUE(max_line_numbers.main_content.has_value());
+  ASSERT_EQ(max_line_numbers.main_content.value(), kNumberOfLines);
+
+  ASSERT_TRUE(max_line_numbers.annotating_lines.has_value());
+  ASSERT_EQ(max_line_numbers.annotating_lines.value(), 43);
+
+  EXPECT_EQ(doc.blockCount(), 5);
+
+  for (auto current_block = doc.begin(); current_block != doc.end();
+       current_block = current_block.next()) {
+    EXPECT_NE(current_block.userData(), nullptr);
+  }
+
+  EXPECT_EQ(doc.begin().text().toStdString(), "first annotation");
+  EXPECT_EQ(doc.begin().next().text().toStdString(), "first line");
+  EXPECT_EQ(doc.begin().next().next().text().toStdString(), "second annotation");
+  EXPECT_EQ(doc.begin().next().next().next().text().toStdString(), "second line");
+  EXPECT_EQ(doc.begin().next().next().next().next().text().toStdString(), "third line");
+}
+
+TEST(Viewer, SetAnnotatingContentInDocumentSecond) {
+  QTextDocument doc{};
+  constexpr int kNumberOfLines = 3;
+  doc.setPlainText("first line\nsecond line\nthird line");
+  ASSERT_EQ(doc.blockCount(), kNumberOfLines);
+
+  std::array<AnnotatingLine, 1> lines{};
+  lines[0].reference_line = 2;
+  lines[0].line_contents = "first annotation";
+  lines[0].line_number = 42;
+
+  const LargestOccuringLineNumbers max_line_numbers = SetAnnotatingContentInDocument(&doc, lines);
+
+  ASSERT_TRUE(max_line_numbers.main_content.has_value());
+  ASSERT_EQ(max_line_numbers.main_content.value(), 3);
+
+  ASSERT_TRUE(max_line_numbers.annotating_lines.has_value());
+  ASSERT_EQ(max_line_numbers.annotating_lines.value(), 42);
+
+  for (auto current_block = doc.begin(); current_block != doc.end();
+       current_block = current_block.next()) {
+    EXPECT_NE(current_block.userData(), nullptr);
+  }
+
+  EXPECT_EQ(doc.begin().text().toStdString(), "first line");
+  EXPECT_EQ(doc.begin().next().text().toStdString(), "first annotation");
+  EXPECT_EQ(doc.begin().next().next().text().toStdString(), "second line");
+}
+
+TEST(Viewer, SetAnnotatingContentInDocumentLast) {
+  QTextDocument doc{};
+  constexpr int kNumberOfLines = 3;
+  doc.setPlainText("first line\nsecond line\nthird line");
+  ASSERT_EQ(doc.blockCount(), kNumberOfLines);
+
+  std::array<AnnotatingLine, 1> lines{};
+  lines[0].reference_line = 3;
+  lines[0].line_contents = "first annotation";
+  lines[0].line_number = 42;
+
+  const LargestOccuringLineNumbers max_line_numbers = SetAnnotatingContentInDocument(&doc, lines);
+
+  ASSERT_TRUE(max_line_numbers.main_content.has_value());
+  ASSERT_EQ(max_line_numbers.main_content.value(), kNumberOfLines);
+
+  ASSERT_TRUE(max_line_numbers.annotating_lines.has_value());
+  ASSERT_EQ(max_line_numbers.annotating_lines.value(), 42);
+
+  for (auto current_block = doc.begin(); current_block != doc.end();
+       current_block = current_block.next()) {
+    EXPECT_NE(current_block.userData(), nullptr);
+  }
+
+  EXPECT_EQ(doc.begin().text().toStdString(), "first line");
+  EXPECT_EQ(doc.begin().next().text().toStdString(), "second line");
+  EXPECT_EQ(doc.begin().next().next().text().toStdString(), "first annotation");
+  EXPECT_EQ(doc.begin().next().next().next().text().toStdString(), "third line");
+}
+
+TEST(Viewer, SetAnnotatingContentInDocumentInvalid) {
+  QTextDocument doc{};
+  constexpr int kNumberOfLines = 3;
+  doc.setPlainText("first line\nsecond line\nthird line");
+  ASSERT_EQ(doc.blockCount(), kNumberOfLines);
+
+  std::array<AnnotatingLine, 1> lines{};
+  lines[0].reference_line = 4;  // Does not exist
+  lines[0].line_contents = "first annotation";
+  lines[0].line_number = 42;
+
+  const LargestOccuringLineNumbers max_line_numbers = SetAnnotatingContentInDocument(&doc, lines);
+
+  ASSERT_TRUE(max_line_numbers.main_content.has_value());
+  ASSERT_EQ(max_line_numbers.main_content.value(), kNumberOfLines);
+
+  ASSERT_FALSE(max_line_numbers.annotating_lines.has_value());
+
+  for (auto current_block = doc.begin(); current_block != doc.end();
+       current_block = current_block.next()) {
+    EXPECT_NE(current_block.userData(), nullptr);
+  }
+
+  EXPECT_EQ(doc.begin().text().toStdString(), "first line");
+  EXPECT_EQ(doc.begin().next().text().toStdString(), "second line");
+  EXPECT_EQ(doc.begin().next().next().text().toStdString(), "third line");
+}
+
+TEST(Viewer, SetAnnotatingContentInDocumentFirstTwice) {
+  QTextDocument doc{};
+  constexpr int kNumberOfLines = 3;
+  doc.setPlainText("first line\nsecond line\nthird line");
+  ASSERT_EQ(doc.blockCount(), kNumberOfLines);
+
+  std::array<AnnotatingLine, 1> lines{};
+  lines[0].reference_line = 1;
+  lines[0].line_contents = "first annotation";
+  lines[0].line_number = 42;
+
+  {
+    const LargestOccuringLineNumbers max_line_numbers = SetAnnotatingContentInDocument(&doc, lines);
+
+    ASSERT_TRUE(max_line_numbers.main_content.has_value());
+    ASSERT_EQ(max_line_numbers.main_content.value(), kNumberOfLines);
+
+    ASSERT_TRUE(max_line_numbers.annotating_lines.has_value());
+    ASSERT_EQ(max_line_numbers.annotating_lines.value(), 42);
+
+    for (auto current_block = doc.begin(); current_block != doc.end();
+         current_block = current_block.next()) {
+      EXPECT_NE(current_block.userData(), nullptr);
+    }
+
+    EXPECT_EQ(doc.begin().text().toStdString(), "first annotation");
+    EXPECT_EQ(doc.begin().next().text().toStdString(), "first line");
+  }
+
+  {
+    const LargestOccuringLineNumbers max_line_numbers = SetAnnotatingContentInDocument(&doc, lines);
+
+    ASSERT_TRUE(max_line_numbers.main_content.has_value());
+    ASSERT_EQ(max_line_numbers.main_content.value(), kNumberOfLines);
+
+    ASSERT_TRUE(max_line_numbers.annotating_lines.has_value());
+    ASSERT_EQ(max_line_numbers.annotating_lines.value(), 42);
+
+    for (auto current_block = doc.begin(); current_block != doc.end();
+         current_block = current_block.next()) {
+      EXPECT_NE(current_block.userData(), nullptr);
+    }
+
+    EXPECT_EQ(doc.begin().text().toStdString(), "first annotation");
+    EXPECT_EQ(doc.begin().next().text().toStdString(), "first line");
+  }
+}
 }  // namespace orbit_code_viewer

--- a/src/CodeViewer/include/CodeViewer/Dialog.h
+++ b/src/CodeViewer/include/CodeViewer/Dialog.h
@@ -45,6 +45,8 @@ class Dialog : public QDialog {
   Q_OBJECT
 
  public:
+  using LineNumberTypes = Viewer::LineNumberTypes;
+
   explicit Dialog(QWidget* parent = nullptr);
   ~Dialog() noexcept override;
 
@@ -54,7 +56,7 @@ class Dialog : public QDialog {
   void SetHeatmap(FontSizeInEm heatmap_bar_width, const CodeReport* code_report);
   void ClearHeatmap();
 
-  void SetEnableLineNumbers(bool enabled);
+  void SetLineNumberTypes(LineNumberTypes line_number_types);
   void SetEnableSampleCounters(bool enabled);
 
   void SetLineNumberMargins(FontSizeInEm left, FontSizeInEm right);

--- a/src/CodeViewer/include/CodeViewer/Dialog.h
+++ b/src/CodeViewer/include/CodeViewer/Dialog.h
@@ -27,7 +27,7 @@ namespace orbit_code_viewer {
   which blocks until the dialog is closed:
 
   orbit_code_viewer::Dialog dialog{};
-  dialog.SetSourceCode(source_code);
+  dialog.SetMainContent(source_code);
   dialog.exec();
 
   Optionally a syntax highlighter can be provided with the source code.
@@ -35,7 +35,7 @@ namespace orbit_code_viewer {
   Example:
 
   orbit_code_viewer::Dialog dialog{};
-  dialog.SetSourceCode(source_code, std::make_unique<orbit_syntax_highlighter::X86Assembly>());
+  dialog.SetMainContent(source_code, std::make_unique<orbit_syntax_highlighter::X86Assembly>());
   dialog.exec();
 
   Check out orbit_code_viewer::Viewer if you don't need a dialog but rather a widget
@@ -48,8 +48,8 @@ class Dialog : public QDialog {
   explicit Dialog(QWidget* parent = nullptr);
   ~Dialog() noexcept override;
 
-  void SetSourceCode(const QString& code);
-  void SetSourceCode(const QString& code, std::unique_ptr<QSyntaxHighlighter> syntax_highlighter);
+  void SetMainContent(const QString& code);
+  void SetMainContent(const QString& code, std::unique_ptr<QSyntaxHighlighter> syntax_highlighter);
 
   void SetHeatmap(FontSizeInEm heatmap_bar_width, const CodeReport* code_report);
   void ClearHeatmap();

--- a/src/CodeViewer/include/CodeViewer/Dialog.h
+++ b/src/CodeViewer/include/CodeViewer/Dialog.h
@@ -53,6 +53,9 @@ class Dialog : public QDialog {
   void SetMainContent(const QString& code);
   void SetMainContent(const QString& code, std::unique_ptr<QSyntaxHighlighter> syntax_highlighter);
 
+  using AnnotatingLine = Viewer::AnnotatingLine;
+  void SetAnnotatingContent(absl::Span<const AnnotatingLine> annotating_lines);
+
   void SetHeatmap(FontSizeInEm heatmap_bar_width, const CodeReport* code_report);
   void ClearHeatmap();
 

--- a/src/CodeViewer/include/CodeViewer/Dialog.h
+++ b/src/CodeViewer/include/CodeViewer/Dialog.h
@@ -53,7 +53,6 @@ class Dialog : public QDialog {
   void SetMainContent(const QString& code);
   void SetMainContent(const QString& code, std::unique_ptr<QSyntaxHighlighter> syntax_highlighter);
 
-  using AnnotatingLine = Viewer::AnnotatingLine;
   void SetAnnotatingContent(absl::Span<const AnnotatingLine> annotating_lines);
 
   void SetHeatmap(FontSizeInEm heatmap_bar_width, const CodeReport* code_report);

--- a/src/CodeViewer/include/CodeViewer/OwningDialog.h
+++ b/src/CodeViewer/include/CodeViewer/OwningDialog.h
@@ -22,7 +22,7 @@ namespace orbit_code_viewer {
   It is meant to be used in conjunction with `OpenAndDeleteOnClose`, example:
 
   auto dialog = std::make_unique<orbit_code_viewer::OwningDialog>();
-  dialog->SetSourceCode(...);
+  dialog->SetMainContent(...);
   dialog->SetOwningHeatmap(kSidebarWidth, std::move(disassembly_report));
   orbit_code_viewer::OpenAndDeleteOnClose(std::move(dialog));
 */

--- a/src/CodeViewer/include/CodeViewer/Viewer.h
+++ b/src/CodeViewer/include/CodeViewer/Viewer.h
@@ -98,6 +98,13 @@ class Viewer : public QPlainTextEdit {
   const CodeReport* code_report_ = nullptr;
 
   bool is_current_line_highlighted_ = false;
+
+  // These are only used when SetAnnotatingContent was called and the line numbers deviate from
+  // simple counting.
+  std::optional<uint64_t> largest_occuring_line_number_main_content_;
+  std::optional<uint64_t> largest_occuring_line_number_annotating_lines_;
+
+  [[nodiscard]] uint64_t LargestOccuringLineNumber() const;
 };
 
 // Determine how many pixels are needed to draw all possible line numbers for the given font

--- a/src/CodeViewer/include/CodeViewer/Viewer.h
+++ b/src/CodeViewer/include/CodeViewer/Viewer.h
@@ -5,6 +5,8 @@
 #ifndef CODE_VIEWER_VIEWER_H_
 #define CODE_VIEWER_VIEWER_H_
 
+#include <absl/types/span.h>
+
 #include <QPlainTextEdit>
 #include <QPointer>
 #include <QResizeEvent>
@@ -61,6 +63,13 @@ class Viewer : public QPlainTextEdit {
 
   void SetHighlightCurrentLine(bool is_enabled);
   [[nodiscard]] bool IsCurrentLineHighlighted() const;
+
+  struct AnnotatingLine {
+    uint64_t reference_line;
+    uint64_t line_number;
+    std::string line_contents;
+  };
+  void SetAnnotatingContent(absl::Span<const AnnotatingLine> annotating_lines);
 
  private:
   void resizeEvent(QResizeEvent* ev) override;

--- a/src/CodeViewer/include/CodeViewer/Viewer.h
+++ b/src/CodeViewer/include/CodeViewer/Viewer.h
@@ -19,6 +19,20 @@
 
 namespace orbit_code_viewer {
 
+// Combines metadata and contents for a line that annotates another line. The current implementation
+// of Viewer inserts the annotating line above the annotated(reference) line. The association is
+// done via line numbers. Both line number fields are one-indexed.
+struct AnnotatingLine {
+  uint64_t reference_line;
+  uint64_t line_number;
+  std::string line_contents;
+};
+
+struct LargestOccuringLineNumbers {
+  std::optional<uint64_t> main_content;
+  std::optional<uint64_t> annotating_lines;
+};
+
 /*
   Viewer is a for displaying source code. It derives from a QPlainTextEdit
   and adds some additional features like a left sidebar for displaying
@@ -64,11 +78,6 @@ class Viewer : public QPlainTextEdit {
   void SetHighlightCurrentLine(bool is_enabled);
   [[nodiscard]] bool IsCurrentLineHighlighted() const;
 
-  struct AnnotatingLine {
-    uint64_t reference_line;
-    uint64_t line_number;
-    std::string line_contents;
-  };
   void SetAnnotatingContent(absl::Span<const AnnotatingLine> annotating_lines);
 
  private:
@@ -101,8 +110,7 @@ class Viewer : public QPlainTextEdit {
 
   // These are only used when SetAnnotatingContent was called and the line numbers deviate from
   // simple counting.
-  std::optional<uint64_t> largest_occuring_line_number_main_content_;
-  std::optional<uint64_t> largest_occuring_line_number_annotating_lines_;
+  LargestOccuringLineNumbers largest_occuring_line_numbers_;
 
   [[nodiscard]] uint64_t LargestOccuringLineNumber() const;
 };
@@ -111,6 +119,10 @@ class Viewer : public QPlainTextEdit {
 [[nodiscard]] int DetermineLineNumberWidthInPixels(const QFontMetrics& font_metrics,
                                                    int max_line_number);
 
+// Add a list of annoating lines to a document. The list of annotating lines need to be ordered by
+// `.reference_line`.
+[[nodiscard]] LargestOccuringLineNumbers SetAnnotatingContentInDocument(
+    QTextDocument* document, absl::Span<const AnnotatingLine> annotating_lines);
 }  // namespace orbit_code_viewer
 
 #endif  // CODE_VIEWER_VIEWER_H_

--- a/src/CodeViewer/include/CodeViewer/Viewer.h
+++ b/src/CodeViewer/include/CodeViewer/Viewer.h
@@ -49,7 +49,8 @@ class Viewer : public QPlainTextEdit {
  public:
   explicit Viewer(QWidget* parent);
 
-  void SetEnableLineNumbers(bool enabled);
+  enum class LineNumberTypes { kNone, kOnlyMainContent, kOnlyAnnotatingLines, kBoth };
+  void SetLineNumberTypes(LineNumberTypes line_number_types);
   void SetEnableSampleCounters(bool is_enabled);
   void SetLineNumberMargins(FontSizeInEm left, FontSizeInEm right);
 
@@ -79,7 +80,7 @@ class Viewer : public QPlainTextEdit {
   PlaceHolderWidget top_bar_widget_;
   PlaceHolderWidget left_sidebar_widget_;
   PlaceHolderWidget right_sidebar_widget_;
-  bool line_numbers_enabled_ = false;
+  LineNumberTypes line_number_types_ = LineNumberTypes::kNone;
   bool sample_counters_enabled_ = false;
   FontSizeInEm left_margin_ = FontSizeInEm{0.3f};
   FontSizeInEm right_margin_ = FontSizeInEm{0.3f};

--- a/src/CodeViewerDemo/main.cpp
+++ b/src/CodeViewerDemo/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char* argv[]) {
   const DummyCodeReport code_report{static_cast<uint32_t>(line_numbers)};
   dialog.SetHeatmap(orbit_code_viewer::FontSizeInEm{1.2f}, &code_report);
 
-  dialog.SetEnableLineNumbers(true);
+  dialog.SetLineNumberTypes(orbit_code_viewer::Dialog::LineNumberTypes::kOnlyMainContent);
   dialog.SetEnableSampleCounters(true);
   dialog.GoToLineNumber(10);
   dialog.SetHighlightCurrentLine(true);

--- a/src/CodeViewerDemo/main.cpp
+++ b/src/CodeViewerDemo/main.cpp
@@ -6,7 +6,7 @@
 
 #include "CodeExamples.h"
 #include "CodeViewer/Dialog.h"
-#include "SyntaxHighlighter/Cpp.h"
+#include "SyntaxHighlighter/X86Assembly.h"
 
 class DummyCodeReport : public CodeReport {
  public:
@@ -28,15 +28,28 @@ int main(int argc, char* argv[]) {
   orbit_code_viewer::Dialog dialog{};
 
   // Example file
-  const QString content = testing_example;
+  const QString content = x86Assembly_example;
 
-  dialog.SetMainContent(content, std::make_unique<orbit_syntax_highlighter::Cpp>());
+  dialog.SetMainContent(content, std::make_unique<orbit_syntax_highlighter::X86Assembly>());
+
+  std::vector<orbit_code_viewer::AnnotatingLine> lines{};
+  lines.emplace_back();
+  lines.back().reference_line = 9;
+  lines.back().line_number = 42;
+  lines.back().line_contents = "void main() {";
+
+  lines.emplace_back();
+  lines.back().reference_line = 14;
+  lines.back().line_number = 43;
+  lines.back().line_contents = "echo \"Hello World!\";";
+
+  dialog.SetAnnotatingContent(lines);
 
   const auto line_numbers = content.count('\n');
   const DummyCodeReport code_report{static_cast<uint32_t>(line_numbers)};
   dialog.SetHeatmap(orbit_code_viewer::FontSizeInEm{1.2f}, &code_report);
 
-  dialog.SetLineNumberTypes(orbit_code_viewer::Dialog::LineNumberTypes::kOnlyMainContent);
+  dialog.SetLineNumberTypes(orbit_code_viewer::Dialog::LineNumberTypes::kOnlyAnnotatingLines);
   dialog.SetEnableSampleCounters(true);
   dialog.GoToLineNumber(10);
   dialog.SetHighlightCurrentLine(true);

--- a/src/CodeViewerDemo/main.cpp
+++ b/src/CodeViewerDemo/main.cpp
@@ -30,7 +30,7 @@ int main(int argc, char* argv[]) {
   // Example file
   const QString content = testing_example;
 
-  dialog.SetSourceCode(content, std::make_unique<orbit_syntax_highlighter::Cpp>());
+  dialog.SetMainContent(content, std::make_unique<orbit_syntax_highlighter::Cpp>());
 
   const auto line_numbers = content.count('\n');
   const DummyCodeReport code_report{static_cast<uint32_t>(line_numbers)};

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -142,7 +142,7 @@ constexpr int kHintFrameHeight = 45;
 void OpenDisassembly(const std::string& assembly, DisassemblyReport report) {
   auto dialog = std::make_unique<orbit_code_viewer::OwningDialog>();
   dialog->setWindowTitle("Orbit Disassembly");
-  dialog->SetEnableLineNumbers(true);
+  dialog->SetLineNumberTypes(orbit_code_viewer::Dialog::LineNumberTypes::kOnlyMainContent);
   dialog->SetHighlightCurrentLine(true);
 
   auto syntax_highlighter = std::make_unique<orbit_syntax_highlighter::X86Assembly>();
@@ -1470,7 +1470,8 @@ void OrbitMainWindow::ShowSourceCode(const std::filesystem::path& file_path, siz
                                      std::optional<std::unique_ptr<CodeReport>> maybe_code_report) {
   auto code_viewer_dialog = std::make_unique<orbit_code_viewer::OwningDialog>();
 
-  code_viewer_dialog->SetEnableLineNumbers(true);
+  code_viewer_dialog->SetLineNumberTypes(
+      orbit_code_viewer::Dialog::LineNumberTypes::kOnlyMainContent);
   code_viewer_dialog->SetHighlightCurrentLine(true);
   code_viewer_dialog->setWindowTitle(QString::fromStdString(file_path.filename().string()));
 

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -146,7 +146,7 @@ void OpenDisassembly(const std::string& assembly, DisassemblyReport report) {
   dialog->SetHighlightCurrentLine(true);
 
   auto syntax_highlighter = std::make_unique<orbit_syntax_highlighter::X86Assembly>();
-  dialog->SetSourceCode(QString::fromStdString(assembly), std::move(syntax_highlighter));
+  dialog->SetMainContent(QString::fromStdString(assembly), std::move(syntax_highlighter));
 
   if (report.GetNumSamples() > 0) {
     constexpr orbit_code_viewer::FontSizeInEm kHeatmapAreaWidth{1.3f};
@@ -1479,7 +1479,7 @@ void OrbitMainWindow::ShowSourceCode(const std::filesystem::path& file_path, siz
   if (!source_code.has_value()) return;
 
   auto syntax_highlighter = std::make_unique<orbit_syntax_highlighter::Cpp>();
-  code_viewer_dialog->SetSourceCode(source_code.value(), std::move(syntax_highlighter));
+  code_viewer_dialog->SetMainContent(source_code.value(), std::move(syntax_highlighter));
   constexpr orbit_code_viewer::FontSizeInEm kHeatmapAreaWidth{1.3f};
 
   if (maybe_code_report.has_value()) {


### PR DESCRIPTION
This PR adds support for a second type of content to the code viewer widget.

We now differentiate between main content and annotating content. Annotating content
is a list of lines where each lines refers to a line in the main content (identified by line number).

The widget will display each annotating line above the reference line from the main content.