### PR TITLE
Patch Callstacks of Leaf Function Samples.

### DIFF
--- a/src/CaptureClient/CaptureEventProcessor.cpp
+++ b/src/CaptureClient/CaptureEventProcessor.cpp
@@ -463,8 +463,11 @@ void CaptureEventProcessorForListener::SendCallstackToListenerIfNecessary(
     case orbit_grpc_protos::Callstack::kUprobesPatchingFailed:
       callstack_info.set_type(CallstackInfo::kUprobesPatchingFailed);
       break;
-    case orbit_grpc_protos::Callstack::kFramePointerDwarfStackTooSmallError:
-      callstack_info.set_type(CallstackInfo::kFramePointerDwarfStackTooSmallError);
+    case orbit_grpc_protos::Callstack::kStackTopForDwarfUnwindingTooSmall:
+      callstack_info.set_type(CallstackInfo::kStackTopForDwarfUnwindingTooSmall);
+      break;
+    case orbit_grpc_protos::Callstack::kStackTopDwarfUnwindingError:
+      callstack_info.set_type(CallstackInfo::kStackTopDwarfUnwindingError);
       break;
     case orbit_grpc_protos::
         Callstack_CallstackType_Callstack_CallstackType_INT_MIN_SENTINEL_DO_NOT_USE_:

--- a/src/CaptureClient/CaptureEventProcessor.cpp
+++ b/src/CaptureClient/CaptureEventProcessor.cpp
@@ -463,6 +463,9 @@ void CaptureEventProcessorForListener::SendCallstackToListenerIfNecessary(
     case orbit_grpc_protos::Callstack::kUprobesPatchingFailed:
       callstack_info.set_type(CallstackInfo::kUprobesPatchingFailed);
       break;
+    case orbit_grpc_protos::Callstack::kFramePointerDwarfStackTooSmallError:
+      callstack_info.set_type(CallstackInfo::kFramePointerDwarfStackTooSmallError);
+      break;
     case orbit_grpc_protos::
         Callstack_CallstackType_Callstack_CallstackType_INT_MIN_SENTINEL_DO_NOT_USE_:
       [[fallthrough]];

--- a/src/CaptureClient/CaptureEventProcessorTest.cpp
+++ b/src/CaptureClient/CaptureEventProcessorTest.cpp
@@ -162,6 +162,9 @@ static void ExpectCallstackSamplesEqual(const CallstackEvent& actual_callstack_e
     case Callstack::kUprobesPatchingFailed:
       EXPECT_EQ(actual_callstack.type(), CallstackInfo::kUprobesPatchingFailed);
       break;
+    case Callstack::kFramePointerDwarfStackTooSmallError:
+      EXPECT_EQ(actual_callstack.type(), CallstackInfo::kFramePointerDwarfStackTooSmallError);
+      break;
     case orbit_grpc_protos::
         Callstack_CallstackType_Callstack_CallstackType_INT_MIN_SENTINEL_DO_NOT_USE_:
       [[fallthrough]];
@@ -210,6 +213,7 @@ TEST(CaptureEventProcessor, CanHandleOneNonCompleteCallstackSample) {
   CanHandleOneCallstackSampleOfType(Callstack::kFramePointerUnwindingError);
   CanHandleOneCallstackSampleOfType(Callstack::kInUprobes);
   CanHandleOneCallstackSampleOfType(Callstack::kUprobesPatchingFailed);
+  CanHandleOneCallstackSampleOfType(Callstack::kFramePointerDwarfStackTooSmallError);
 }
 
 TEST(CaptureEventProcessor, WillOnlyHandleUniqueCallstacksOnce) {

--- a/src/CaptureClient/CaptureEventProcessorTest.cpp
+++ b/src/CaptureClient/CaptureEventProcessorTest.cpp
@@ -162,8 +162,11 @@ static void ExpectCallstackSamplesEqual(const CallstackEvent& actual_callstack_e
     case Callstack::kUprobesPatchingFailed:
       EXPECT_EQ(actual_callstack.type(), CallstackInfo::kUprobesPatchingFailed);
       break;
-    case Callstack::kFramePointerDwarfStackTooSmallError:
-      EXPECT_EQ(actual_callstack.type(), CallstackInfo::kFramePointerDwarfStackTooSmallError);
+    case Callstack::kStackTopDwarfUnwindingError:
+      EXPECT_EQ(actual_callstack.type(), CallstackInfo::kStackTopDwarfUnwindingError);
+      break;
+    case Callstack::kStackTopForDwarfUnwindingTooSmall:
+      EXPECT_EQ(actual_callstack.type(), CallstackInfo::kStackTopForDwarfUnwindingTooSmall);
       break;
     case orbit_grpc_protos::
         Callstack_CallstackType_Callstack_CallstackType_INT_MIN_SENTINEL_DO_NOT_USE_:
@@ -213,7 +216,8 @@ TEST(CaptureEventProcessor, CanHandleOneNonCompleteCallstackSample) {
   CanHandleOneCallstackSampleOfType(Callstack::kFramePointerUnwindingError);
   CanHandleOneCallstackSampleOfType(Callstack::kInUprobes);
   CanHandleOneCallstackSampleOfType(Callstack::kUprobesPatchingFailed);
-  CanHandleOneCallstackSampleOfType(Callstack::kFramePointerDwarfStackTooSmallError);
+  CanHandleOneCallstackSampleOfType(Callstack::kStackTopDwarfUnwindingError);
+  CanHandleOneCallstackSampleOfType(Callstack::kStackTopForDwarfUnwindingTooSmall);
 }
 
 TEST(CaptureEventProcessor, WillOnlyHandleUniqueCallstacksOnce) {

--- a/src/ClientProtos/capture_data.proto
+++ b/src/ClientProtos/capture_data.proto
@@ -71,6 +71,7 @@ message CallstackInfo {
     kFramePointerUnwindingError = 2;
     kInUprobes = 3;
     kUprobesPatchingFailed = 4;
+    kFramePointerDwarfStackTooSmallError = 5;
     // These are set by the client and are in addition to the ones in
     // Callstack::CallstackType.
     kFilteredByMajorityOutermostFrame = 100;

--- a/src/ClientProtos/capture_data.proto
+++ b/src/ClientProtos/capture_data.proto
@@ -71,7 +71,8 @@ message CallstackInfo {
     kFramePointerUnwindingError = 2;
     kInUprobes = 3;
     kUprobesPatchingFailed = 4;
-    kFramePointerDwarfStackTooSmallError = 5;
+    kStackTopForDwarfUnwindingTooSmall = 5;
+    kStackTopDwarfUnwindingError = 6;
     // These are set by the client and are in addition to the ones in
     // Callstack::CallstackType.
     kFilteredByMajorityOutermostFrame = 100;

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -142,7 +142,8 @@ message Callstack {
     kFramePointerUnwindingError = 2;
     kInUprobes = 3;
     kUprobesPatchingFailed = 4;
-    kFramePointerDwarfStackTooSmallError = 5;
+    kStackTopForDwarfUnwindingTooSmall = 5;
+    kStackTopDwarfUnwindingError = 6;
   }
   CallstackType type = 2;
 }

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -142,6 +142,7 @@ message Callstack {
     kFramePointerUnwindingError = 2;
     kInUprobes = 3;
     kUprobesPatchingFailed = 4;
+    kFramePointerDwarfStackTooSmallError = 5;
   }
   CallstackType type = 2;
 }

--- a/src/LinuxTracing/CMakeLists.txt
+++ b/src/LinuxTracing/CMakeLists.txt
@@ -29,6 +29,8 @@ target_sources(LinuxTracing PRIVATE
         GpuTracepointVisitor.h
         GpuTracepointVisitor.cpp
         KernelTracepoints.h
+        LeafFunctionCallManager.h
+        LeafFunctionCallManager.cpp
         LibunwindstackMaps.cpp
         LibunwindstackMaps.h
         LibunwindstackUnwinder.cpp
@@ -76,6 +78,7 @@ target_compile_options(LinuxTracingTests PRIVATE ${STRICT_COMPILE_FLAGS})
 target_sources(LinuxTracingTests PRIVATE
         ContextSwitchManagerTest.cpp
         GpuTracepointVisitorTest.cpp
+        LeafFunctionCallManagerTest.cpp
         LinuxTracingUtilsTest.cpp
         PerfEventProcessorTest.cpp
         PerfEventQueueTest.cpp

--- a/src/LinuxTracing/LeafFunctionCallManager.cpp
+++ b/src/LinuxTracing/LeafFunctionCallManager.cpp
@@ -39,7 +39,7 @@ Callstack::CallstackType LeafFunctionCallManager::PatchLeafFunctionCaller(
 
   uint64_t stack_size =
       event->GetRegisters()[PERF_REG_X86_BP] - event->GetRegisters()[PERF_REG_X86_SP];
-  if (stack_size > SAMPLE_STACK_USER_SIZE_128BYTES) {
+  if (stack_size > SAMPLE_STACK_USER_SIZE_512BYTES) {
     return Callstack::kFramePointerDwarfStackTooSmallError;
   }
 

--- a/src/LinuxTracing/LeafFunctionCallManager.cpp
+++ b/src/LinuxTracing/LeafFunctionCallManager.cpp
@@ -1,0 +1,112 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "LeafFunctionCallManager.h"
+
+#include <sys/mman.h>
+
+#include <vector>
+
+#include "OrbitBase/Logging.h"
+
+namespace orbit_linux_tracing {
+
+// Let's unwind the stack from $rsp to $rbp using libunwindstack. If $rbp points to the current
+// frame, this will only include the locals and not the return address, so libunwindstack will
+// only be able to unwind one frame (the instruction pointer). If $rpb points to the previous frame,
+// as the leaf function does not contain frame pointers, the region from $rsp to $rbp will contain
+// the complete innermost frame, plus the locals of the caller's frame (but not the return address).
+// Therefore, libunwindstack will be able to compute two frames, where the outer one is the missing
+// caller and needs to be patched in.
+// As libunwindstack will try to unwind even further, unwinding errors will always be reported.
+// We need to fallback to plausibility checks to detect actual unwinding errors (such as are the
+// frames executable).
+// Note, that we can not simply set libunwindstack to unwind always two frames and compare the outer
+// frame with the respective one in the perf_event_open event, as in case of uprobes overriding the
+// return addresses, both addresses would be identical even if the actual addresses (after uprobe
+// patching) are not.
+// More (internal) documentation on this in: go/stadia-orbit-leaf-frame-pointer
+bool LeafFunctionCallManager::PatchLeafFunctionCaller(CallchainSamplePerfEvent* event,
+                                                      LibunwindstackMaps* current_maps,
+                                                      LibunwindstackUnwinder* unwinder) {
+  CHECK(event != nullptr);
+  CHECK(current_maps != nullptr);
+  CHECK(unwinder != nullptr);
+  CHECK(event->GetCallchainSize() > 2);
+
+  uint64_t stack_size =
+      event->GetRegisters()[PERF_REG_X86_BP] - event->GetRegisters()[PERF_REG_X86_SP];
+  if (stack_size > SAMPLE_STACK_USER_SIZE_128BYTES) {
+    ERROR("Discarding sample where the stack dump is to small (required %lu bytes, got %lu bytes)",
+          stack_size, SAMPLE_STACK_USER_SIZE_128BYTES);
+    return false;
+  }
+
+  const LibunwindstackResult& libunwindstack_result =
+      unwinder->Unwind(event->GetPid(), current_maps->Get(), event->GetRegisters(),
+                       event->GetStackData(), stack_size, true);
+  const std::vector<unwindstack::FrameData>& libunwindstack_callstack =
+      libunwindstack_result.frames();
+
+  if (libunwindstack_callstack.empty()) {
+    ERROR(
+        "Discarding sample as DWARF-based unwinding resulted in empty callstack (error code: %s).",
+        LibunwindstackUnwinder::LibunwindstackErrorString(libunwindstack_result.error_code()));
+    return false;
+  }
+
+  // In case of an intact frame pointer, the region from $rsp to $rbp will only include the locals
+  // of the current frame, and NOT the return address. Thus, unwinding will only report one frame
+  // (the instruction pointer) and we know that the original callchain is already correct.
+  if (libunwindstack_callstack.size() == 1) {
+    return true;
+  }
+
+  // If unwinding results in more than two frames, $rbp was also not set correctly by the caller,
+  // thus frame pointers are not in all non-leaf functions, and our assumptions do not hold.
+  if (libunwindstack_callstack.size() > 2) {
+    ERROR(
+        "Discarding sample as DWARF-based unwinding resulted in more than two frames, indicating "
+        "the absence of frame pointers.");
+    return false;
+  }
+
+  const std::vector<uint64_t> original_callchain = event->ips;
+  CHECK(original_callchain.size() > 2);
+
+  std::vector<uint64_t> result;
+  result.reserve(original_callchain.size() + 1);
+  for (size_t i = 0; i < 2; ++i) {
+    result.push_back(original_callchain[i]);
+  }
+
+  CHECK(libunwindstack_callstack.size() == 2);
+  uint64_t libunwindstack_leaf_caller_pc = libunwindstack_callstack[1].pc;
+
+  // If the caller is not executable, we have an unwinding error.
+  unwindstack::MapInfo* map_info = current_maps->Find(libunwindstack_leaf_caller_pc);
+  if (map_info == nullptr || (map_info->flags & PROT_EXEC) == 0) {
+    ERROR(
+        "Discarding sample as DWARF-based unwounded caller with address 0x%x does not point to "
+        "executable code (error code: %s).",
+        libunwindstack_leaf_caller_pc,
+        LibunwindstackUnwinder::LibunwindstackErrorString(libunwindstack_result.error_code()));
+    return false;
+  }
+
+  // perf_event_open's callstack always contains the return address. Libunwindstack has already
+  // decreased the address by one. To not mix them, increase the address again.
+  result.push_back(libunwindstack_leaf_caller_pc + 1);
+
+  for (size_t i = 2; i < original_callchain.size(); ++i) {
+    result.push_back(original_callchain[i]);
+  }
+
+  event->ring_buffer_record.nr = result.size();
+  event->ips = std::move(result);
+
+  return true;
+}
+
+}  //  namespace orbit_linux_tracing

--- a/src/LinuxTracing/LeafFunctionCallManager.h
+++ b/src/LinuxTracing/LeafFunctionCallManager.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef LINUX_TRACING_LEAF_FUNCTION_UTILS_H_
-#define LINUX_TRACING_LEAF_FUNCTION_UTILS_H_
+#ifndef LINUX_TRACING_LEAF_FUNCTION_CALL_MANAGER_H_
+#define LINUX_TRACING_LEAF_FUNCTION_CALL_MANAGER_H_
 
 #include <capture.pb.h>
 
@@ -13,9 +13,9 @@
 
 namespace orbit_linux_tracing {
 
-// This class provides the `PatchLeafFunctionCaller` method to fix a frame-pointer based callchain,
-// where the leaf function does not have frame-pointers.
-// Note that, this is wrapped in a class to allow tests to mock this implementation.
+// This class provides the `PatchCallerOfLeafFunction` method to fix a frame-pointer based
+// callchain, where the leaf function does not have frame-pointers. Note that this is wrapped in a
+// class to allow tests to mock this implementation.
 class LeafFunctionCallManager {
  public:
   virtual ~LeafFunctionCallManager() = default;
@@ -26,16 +26,16 @@ class LeafFunctionCallManager {
   // callchain), the respective `CallstackType` will be returned and the event remains untouched.
   // If the innermost frame has frame-pointers, this function will return `kComplete` and keeps the
   // callchain event untouched.
-  // Otherwise, that is the caller of the leaf function is missing and there are no unwinding
+  // Otherwise, that is if the caller of the leaf function is missing and there are no unwinding
   // errors, the callchain event gets updated, such that it contains the missing caller, and
   // `kComplete` will be returned.
   // Note that the address of the caller address is computed by decreasing the return address by
   // one in libunwindstack, to match the format of perf_event_open.
-  virtual orbit_grpc_protos::Callstack::CallstackType PatchLeafFunctionCaller(
+  virtual orbit_grpc_protos::Callstack::CallstackType PatchCallerOfLeafFunction(
       CallchainSamplePerfEvent* event, LibunwindstackMaps* current_maps,
       LibunwindstackUnwinder* unwinder);
 };
 
 }  //  namespace orbit_linux_tracing
 
-#endif  // LINUX_TRACING_LEAF_FUNCTION_UTILS_H_
+#endif  // LINUX_TRACING_LEAF_FUNCTION_CALL_MANAGER_H_

--- a/src/LinuxTracing/LeafFunctionCallManager.h
+++ b/src/LinuxTracing/LeafFunctionCallManager.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LINUX_TRACING_LEAF_FUNCTION_UTILS_H_
+#define LINUX_TRACING_LEAF_FUNCTION_UTILS_H_
+
+#include "LibunwindstackMaps.h"
+#include "LibunwindstackUnwinder.h"
+#include "PerfEvent.h"
+
+namespace orbit_linux_tracing {
+
+// This class provides the `PatchLeafFunctionCaller` method to fix a frame-pointer based callchain,
+// where the leaf function does not have frame-pointers.
+// Note that, this is wrapped in a class to allow tests to mock this implementation.
+class LeafFunctionCallManager {
+ public:
+  virtual ~LeafFunctionCallManager() = default;
+
+  // Computes the actual caller of a leaf function (that may not have frame-pointers) based on
+  // libunwindstack and modifies the given callchain event, if needed.
+  // In case of any unwinding error (either from libunwindstack or in the frame-pointer based
+  // callchain), `false` will be returned and the event remains untouched.
+  // If the innermost frame has frame-pointers, this function will return `true` and keeps the
+  // callchain event untouched.
+  // Otherwise, that is the caller of the leaf function is missing and there are no unwinding
+  // errors, the callchain event gets updated, such that it contains the missing caller, and `true`
+  // will be returned.
+  // Note that, the address of the caller address is computed by decreasing the return address by
+  // one in libunwindstack, to match the format of perf_event_open.
+  virtual bool PatchLeafFunctionCaller(CallchainSamplePerfEvent* event,
+                                       LibunwindstackMaps* current_maps,
+                                       LibunwindstackUnwinder* unwinder);
+};
+
+}  //  namespace orbit_linux_tracing
+
+#endif  // LINUX_TRACING_LEAF_FUNCTION_UTILS_H_

--- a/src/LinuxTracing/LeafFunctionCallManager.h
+++ b/src/LinuxTracing/LeafFunctionCallManager.h
@@ -5,6 +5,8 @@
 #ifndef LINUX_TRACING_LEAF_FUNCTION_UTILS_H_
 #define LINUX_TRACING_LEAF_FUNCTION_UTILS_H_
 
+#include <capture.pb.h>
+
 #include "LibunwindstackMaps.h"
 #include "LibunwindstackUnwinder.h"
 #include "PerfEvent.h"
@@ -21,17 +23,17 @@ class LeafFunctionCallManager {
   // Computes the actual caller of a leaf function (that may not have frame-pointers) based on
   // libunwindstack and modifies the given callchain event, if needed.
   // In case of any unwinding error (either from libunwindstack or in the frame-pointer based
-  // callchain), `false` will be returned and the event remains untouched.
-  // If the innermost frame has frame-pointers, this function will return `true` and keeps the
+  // callchain), the respective `CallstackType` will be returned and the event remains untouched.
+  // If the innermost frame has frame-pointers, this function will return `kComplete` and keeps the
   // callchain event untouched.
   // Otherwise, that is the caller of the leaf function is missing and there are no unwinding
-  // errors, the callchain event gets updated, such that it contains the missing caller, and `true`
-  // will be returned.
-  // Note that, the address of the caller address is computed by decreasing the return address by
+  // errors, the callchain event gets updated, such that it contains the missing caller, and
+  // `kComplete` will be returned.
+  // Note that the address of the caller address is computed by decreasing the return address by
   // one in libunwindstack, to match the format of perf_event_open.
-  virtual bool PatchLeafFunctionCaller(CallchainSamplePerfEvent* event,
-                                       LibunwindstackMaps* current_maps,
-                                       LibunwindstackUnwinder* unwinder);
+  virtual orbit_grpc_protos::Callstack::CallstackType PatchLeafFunctionCaller(
+      CallchainSamplePerfEvent* event, LibunwindstackMaps* current_maps,
+      LibunwindstackUnwinder* unwinder);
 };
 
 }  //  namespace orbit_linux_tracing

--- a/src/LinuxTracing/LeafFunctionCallManagerTest.cpp
+++ b/src/LinuxTracing/LeafFunctionCallManagerTest.cpp
@@ -140,7 +140,7 @@ TEST_F(LeafFunctionCallManagerTest, PatchLeafFunctionCallerReturnsErrorOnSmallSt
   event.ring_buffer_record.sample_id = sample_id;
   event.ips = callchain;
 
-  event.regs.bp = 2 * SAMPLE_STACK_USER_SIZE_128BYTES;
+  event.regs.bp = 2 * SAMPLE_STACK_USER_SIZE_512BYTES;
   event.regs.sp = 0;
 
   EXPECT_EQ(Callstack::kFramePointerDwarfStackTooSmallError,
@@ -170,13 +170,13 @@ TEST_F(LeafFunctionCallManagerTest, PatchLeafFunctionCallerReturnsErrorOnUnwindi
   };
   event.ring_buffer_record.sample_id = sample_id;
   event.ips = callchain;
-  event.regs.bp = SAMPLE_STACK_USER_SIZE_128BYTES;
+  event.regs.bp = SAMPLE_STACK_USER_SIZE_512BYTES;
   event.regs.sp = 10;
 
   EXPECT_CALL(maps_, Get).WillRepeatedly(Return(nullptr));
 
   // Unwinding errors could result in empty callstacks:
-  EXPECT_CALL(unwinder_, Unwind(kPid, nullptr, _, _, SAMPLE_STACK_USER_SIZE_128BYTES - 10, _, _))
+  EXPECT_CALL(unwinder_, Unwind(kPid, nullptr, _, _, SAMPLE_STACK_USER_SIZE_512BYTES - 10, _, _))
       .Times(1)
       .WillOnce(Return(LibunwindstackResult{{}, unwindstack::ErrorCode::ERROR_INVALID_MAP}));
 
@@ -191,7 +191,7 @@ TEST_F(LeafFunctionCallManagerTest, PatchLeafFunctionCallerReturnsErrorOnUnwindi
   libunwindstack_callstack.push_back(kFrame1);
   libunwindstack_callstack.push_back(kNonExecutableFrame);
 
-  EXPECT_CALL(unwinder_, Unwind(kPid, nullptr, _, _, SAMPLE_STACK_USER_SIZE_128BYTES - 10, _, _))
+  EXPECT_CALL(unwinder_, Unwind(kPid, nullptr, _, _, SAMPLE_STACK_USER_SIZE_512BYTES - 10, _, _))
       .Times(1)
       .WillOnce(Return(LibunwindstackResult{libunwindstack_callstack,
                                             unwindstack::ErrorCode::ERROR_INVALID_MAP}));
@@ -227,7 +227,7 @@ TEST_F(LeafFunctionCallManagerTest, PatchLeafFunctionCallerReturnsErrorOnNoFrame
   };
   event.ring_buffer_record.sample_id = sample_id;
   event.ips = callchain;
-  event.regs.bp = SAMPLE_STACK_USER_SIZE_128BYTES;
+  event.regs.bp = SAMPLE_STACK_USER_SIZE_512BYTES;
   event.regs.sp = 10;
 
   EXPECT_CALL(maps_, Get).WillRepeatedly(Return(nullptr));
@@ -238,7 +238,7 @@ TEST_F(LeafFunctionCallManagerTest, PatchLeafFunctionCallerReturnsErrorOnNoFrame
   libunwindstack_callstack.push_back(kFrame2);
   libunwindstack_callstack.push_back(kFrame3);
 
-  EXPECT_CALL(unwinder_, Unwind(kPid, nullptr, _, _, SAMPLE_STACK_USER_SIZE_128BYTES - 10, _, _))
+  EXPECT_CALL(unwinder_, Unwind(kPid, nullptr, _, _, SAMPLE_STACK_USER_SIZE_512BYTES - 10, _, _))
       .Times(1)
       .WillOnce(Return(LibunwindstackResult{libunwindstack_callstack,
                                             unwindstack::ErrorCode::ERROR_INVALID_MAP}));
@@ -271,7 +271,7 @@ TEST_F(LeafFunctionCallManagerTest,
   };
   event.ring_buffer_record.sample_id = sample_id;
   event.ips = callchain;
-  event.regs.bp = SAMPLE_STACK_USER_SIZE_128BYTES;
+  event.regs.bp = SAMPLE_STACK_USER_SIZE_512BYTES;
   event.regs.sp = 10;
 
   EXPECT_CALL(maps_, Get).WillRepeatedly(Return(nullptr));
@@ -281,7 +281,7 @@ TEST_F(LeafFunctionCallManagerTest,
   std::vector<unwindstack::FrameData> libunwindstack_callstack;
   libunwindstack_callstack.push_back(kFrame1);
 
-  EXPECT_CALL(unwinder_, Unwind(kPid, nullptr, _, _, SAMPLE_STACK_USER_SIZE_128BYTES - 10, _, _))
+  EXPECT_CALL(unwinder_, Unwind(kPid, nullptr, _, _, SAMPLE_STACK_USER_SIZE_512BYTES - 10, _, _))
       .Times(1)
       .WillOnce(Return(LibunwindstackResult{libunwindstack_callstack,
                                             unwindstack::ErrorCode::ERROR_INVALID_MAP}));
@@ -313,7 +313,7 @@ TEST_F(LeafFunctionCallManagerTest,
   };
   event.ring_buffer_record.sample_id = sample_id;
   event.ips = callchain;
-  event.regs.bp = SAMPLE_STACK_USER_SIZE_128BYTES;
+  event.regs.bp = SAMPLE_STACK_USER_SIZE_512BYTES;
   event.regs.sp = 10;
 
   EXPECT_CALL(maps_, Get).WillRepeatedly(Return(nullptr));
@@ -322,7 +322,7 @@ TEST_F(LeafFunctionCallManagerTest,
   libunwindstack_callstack.push_back(kFrame1);
   libunwindstack_callstack.push_back(kFrame2);
 
-  EXPECT_CALL(unwinder_, Unwind(kPid, nullptr, _, _, SAMPLE_STACK_USER_SIZE_128BYTES - 10, _, _))
+  EXPECT_CALL(unwinder_, Unwind(kPid, nullptr, _, _, SAMPLE_STACK_USER_SIZE_512BYTES - 10, _, _))
       .Times(1)
       .WillOnce(Return(LibunwindstackResult{libunwindstack_callstack,
                                             unwindstack::ErrorCode::ERROR_INVALID_MAP}));

--- a/src/LinuxTracing/LeafFunctionCallManagerTest.cpp
+++ b/src/LinuxTracing/LeafFunctionCallManagerTest.cpp
@@ -1,0 +1,333 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <sys/mman.h>
+
+#include "LeafFunctionCallManager.h"
+
+using ::testing::_;
+using ::testing::AllOf;
+using ::testing::ElementsAre;
+using ::testing::ElementsAreArray;
+using ::testing::Ge;
+using ::testing::Lt;
+using ::testing::Return;
+
+namespace orbit_linux_tracing {
+
+namespace {
+
+class MockLibunwindstackMaps : public LibunwindstackMaps {
+ public:
+  MOCK_METHOD(unwindstack::MapInfo*, Find, (uint64_t), (override));
+  MOCK_METHOD(unwindstack::Maps*, Get, (), (override));
+  MOCK_METHOD(void, AddAndSort,
+              (uint64_t, uint64_t, uint64_t, uint64_t, const std::string&, uint64_t), (override));
+};
+
+class MockLibunwindstackUnwinder : public LibunwindstackUnwinder {
+ public:
+  MOCK_METHOD(LibunwindstackResult, Unwind,
+              (pid_t, unwindstack::Maps*, (const std::array<uint64_t, PERF_REG_X86_64_MAX>&),
+               const void*, uint64_t, bool, size_t),
+              (override));
+};
+
+class LeafFunctionCallManagerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    EXPECT_CALL(maps_, Find(AllOf(Ge(kUprobesMapsStart), Lt(kUprobesMapsEnd))))
+        .WillRepeatedly(Return(&kUprobesMapInfo));
+
+    EXPECT_CALL(maps_, Find(AllOf(Ge(kTargetMapsStart), Lt(kTargetMapsEnd))))
+        .WillRepeatedly(Return(&kTargetMapInfo));
+
+    EXPECT_CALL(maps_, Find(AllOf(Ge(kNonExecutableMapsStart), Lt(kNonExecutableMapsEnd))))
+        .WillRepeatedly(Return(&kNonExecutableMapInfo));
+  }
+
+  void TearDown() override {}
+  MockLibunwindstackMaps maps_;
+  MockLibunwindstackUnwinder unwinder_;
+
+  LeafFunctionCallManager leaf_function_call_manager_;
+
+  static constexpr uint64_t kUprobesMapsStart = 42;
+  static constexpr uint64_t kUprobesMapsEnd = 84;
+
+  static constexpr uint64_t kTargetMapsStart = 100;
+  static constexpr uint64_t kTargetMapsEnd = 200;
+
+  static constexpr uint64_t kNonExecutableMapsStart = 500;
+  static constexpr uint64_t kNonExecutableMapsEnd = 600;
+
+  static constexpr uint64_t kKernelAddress = 11;
+
+  static constexpr uint64_t kTargetAddress1 = 100;
+  //  static constexpr uint64_t kUprobesAddress = 42;
+  static constexpr uint64_t kTargetAddress2 = 200;
+  static constexpr uint64_t kTargetAddress3 = 300;
+  //  static constexpr uint64_t kNonExecutableAddress3 = 500;
+
+  static inline const std::string kUprobesName = "[uprobes]";
+  static inline const std::string kTargetName = "target";
+  static inline const std::string kNonExecutableName = "data";
+
+  static inline unwindstack::MapInfo kUprobesMapInfo{
+      nullptr, kUprobesMapsStart, kUprobesMapsEnd, 0, PROT_EXEC | PROT_READ, kUprobesName};
+
+  static inline unwindstack::MapInfo kTargetMapInfo{nullptr, kTargetMapsStart,      kTargetMapsEnd,
+                                                    0,       PROT_EXEC | PROT_READ, kTargetName};
+
+  static inline unwindstack::MapInfo kNonExecutableMapInfo{
+      nullptr, kNonExecutableMapsStart, kNonExecutableMapsEnd, 0, PROT_READ, kNonExecutableName};
+
+  static inline unwindstack::FrameData kFrame1{
+      .pc = kTargetAddress1,
+      .function_name = "foo",
+      .function_offset = 0,
+      .map_name = kTargetName,
+  };
+
+  static inline unwindstack::FrameData kFrame2{
+      .pc = kTargetAddress2,
+      .function_name = "bar",
+      .function_offset = 0,
+      .map_name = kTargetName,
+  };
+
+  static inline unwindstack::FrameData kFrame3{
+      .pc = kTargetAddress3,
+      .function_name = "baz",
+      .function_offset = 0,
+      .map_name = kTargetName,
+  };
+
+  static inline unwindstack::FrameData kNonExecutableFrame{
+      .pc = kNonExecutableMapsStart,
+      .function_name = "???",
+      .function_offset = 0,
+      .map_name = kNonExecutableName,
+  };
+};
+
+}  // namespace
+
+TEST_F(LeafFunctionCallManagerTest, PatchLeafFunctionCallerReturnsFalseOnSmallStackSamples) {
+  constexpr uint32_t kPid = 10;
+  constexpr uint64_t kStackSize = 13;
+
+  std::vector<uint64_t> callchain;
+  callchain.push_back(kKernelAddress);
+  callchain.push_back(kTargetAddress1);
+  // Increment by one as the return address is the next address.
+  callchain.push_back(kTargetAddress2 + 1);
+  callchain.push_back(kTargetAddress3 + 1);
+
+  CallchainSamplePerfEvent event{callchain.size(), kStackSize};
+  perf_event_sample_id_tid_time_streamid_cpu sample_id{
+      .pid = kPid,
+      .tid = 11,
+      .time = 15,
+      .stream_id = 12,
+      .cpu = 0,
+      .res = 0,
+  };
+  event.ring_buffer_record.sample_id = sample_id;
+  event.ips = callchain;
+
+  event.regs.bp = 2 * SAMPLE_STACK_USER_SIZE_128BYTES;
+  event.regs.sp = 0;
+
+  EXPECT_FALSE(leaf_function_call_manager_.PatchLeafFunctionCaller(&event, &maps_, &unwinder_));
+  EXPECT_THAT(event.ips, ElementsAreArray(callchain));
+}
+
+TEST_F(LeafFunctionCallManagerTest, PatchLeafFunctionCallerReturnsFalseOnUnwindingErrors) {
+  constexpr uint32_t kPid = 10;
+  constexpr uint64_t kStackSize = 13;
+
+  std::vector<uint64_t> callchain;
+  callchain.push_back(kKernelAddress);
+  callchain.push_back(kTargetAddress1);
+  // Increment by one as the return address is the next address.
+  callchain.push_back(kTargetAddress2 + 1);
+  callchain.push_back(kTargetAddress3 + 1);
+
+  CallchainSamplePerfEvent event{callchain.size(), kStackSize};
+  perf_event_sample_id_tid_time_streamid_cpu sample_id{
+      .pid = kPid,
+      .tid = 11,
+      .time = 15,
+      .stream_id = 12,
+      .cpu = 0,
+      .res = 0,
+  };
+  event.ring_buffer_record.sample_id = sample_id;
+  event.ips = callchain;
+  event.regs.bp = SAMPLE_STACK_USER_SIZE_128BYTES;
+  event.regs.sp = 10;
+
+  EXPECT_CALL(maps_, Get).WillRepeatedly(Return(nullptr));
+
+  // Unwinding errors could result in empty callstacks:
+  EXPECT_CALL(unwinder_, Unwind(kPid, nullptr, _, _, SAMPLE_STACK_USER_SIZE_128BYTES - 10, _, _))
+      .Times(1)
+      .WillOnce(Return(LibunwindstackResult{{}, unwindstack::ErrorCode::ERROR_INVALID_MAP}));
+
+  EXPECT_FALSE(leaf_function_call_manager_.PatchLeafFunctionCaller(&event, &maps_, &unwinder_));
+  EXPECT_THAT(event.ips, ElementsAreArray(callchain));
+
+  ::testing::Mock::VerifyAndClearExpectations(&unwinder_);
+
+  // Unwinding errors could also result in non-executable code:
+  std::vector<unwindstack::FrameData> libunwindstack_callstack;
+  libunwindstack_callstack.push_back(kFrame1);
+  libunwindstack_callstack.push_back(kNonExecutableFrame);
+
+  EXPECT_CALL(unwinder_, Unwind(kPid, nullptr, _, _, SAMPLE_STACK_USER_SIZE_128BYTES - 10, _, _))
+      .Times(1)
+      .WillOnce(Return(LibunwindstackResult{libunwindstack_callstack,
+                                            unwindstack::ErrorCode::ERROR_INVALID_MAP}));
+
+  EXPECT_CALL(maps_, Find(kNonExecutableMapsStart))
+      .Times(1)
+      .WillOnce(Return(&kNonExecutableMapInfo));
+
+  EXPECT_FALSE(leaf_function_call_manager_.PatchLeafFunctionCaller(&event, &maps_, &unwinder_));
+  EXPECT_THAT(event.ips, ElementsAreArray(callchain));
+}
+
+TEST_F(LeafFunctionCallManagerTest, PatchLeafFunctionCallerReturnsFalseOnNoFramePointers) {
+  constexpr uint32_t kPid = 10;
+  constexpr uint64_t kStackSize = 13;
+
+  std::vector<uint64_t> callchain;
+  callchain.push_back(kKernelAddress);
+  callchain.push_back(kTargetAddress1);
+  // Increment by one as the return address is the next address.
+  callchain.push_back(kTargetAddress2 + 1);
+  callchain.push_back(kTargetAddress3 + 1);
+
+  CallchainSamplePerfEvent event{callchain.size(), kStackSize};
+  perf_event_sample_id_tid_time_streamid_cpu sample_id{
+      .pid = kPid,
+      .tid = 11,
+      .time = 15,
+      .stream_id = 12,
+      .cpu = 0,
+      .res = 0,
+  };
+  event.ring_buffer_record.sample_id = sample_id;
+  event.ips = callchain;
+  event.regs.bp = SAMPLE_STACK_USER_SIZE_128BYTES;
+  event.regs.sp = 10;
+
+  EXPECT_CALL(maps_, Get).WillRepeatedly(Return(nullptr));
+
+  // When libunwindstack reports more than two frames, there are no frame pointers.
+  std::vector<unwindstack::FrameData> libunwindstack_callstack;
+  libunwindstack_callstack.push_back(kFrame1);
+  libunwindstack_callstack.push_back(kFrame2);
+  libunwindstack_callstack.push_back(kFrame3);
+
+  EXPECT_CALL(unwinder_, Unwind(kPid, nullptr, _, _, SAMPLE_STACK_USER_SIZE_128BYTES - 10, _, _))
+      .Times(1)
+      .WillOnce(Return(LibunwindstackResult{libunwindstack_callstack,
+                                            unwindstack::ErrorCode::ERROR_INVALID_MAP}));
+
+  EXPECT_FALSE(leaf_function_call_manager_.PatchLeafFunctionCaller(&event, &maps_, &unwinder_));
+  EXPECT_THAT(event.ips, ElementsAreArray(callchain));
+}
+
+TEST_F(LeafFunctionCallManagerTest,
+       PatchLeafFunctionCallerReturnsTrueAndKeepsCallchainUntouchedOnNonLeafFunctions) {
+  constexpr uint32_t kPid = 10;
+  constexpr uint64_t kStackSize = 13;
+
+  std::vector<uint64_t> callchain;
+  callchain.push_back(kKernelAddress);
+  callchain.push_back(kTargetAddress1);
+  // Increment by one as the return address is the next address.
+  callchain.push_back(kTargetAddress2 + 1);
+  callchain.push_back(kTargetAddress3 + 1);
+
+  CallchainSamplePerfEvent event{callchain.size(), kStackSize};
+  perf_event_sample_id_tid_time_streamid_cpu sample_id{
+      .pid = kPid,
+      .tid = 11,
+      .time = 15,
+      .stream_id = 12,
+      .cpu = 0,
+      .res = 0,
+  };
+  event.ring_buffer_record.sample_id = sample_id;
+  event.ips = callchain;
+  event.regs.bp = SAMPLE_STACK_USER_SIZE_128BYTES;
+  event.regs.sp = 10;
+
+  EXPECT_CALL(maps_, Get).WillRepeatedly(Return(nullptr));
+
+  // When libunwindstack reports exactly one frame (the ip), the innermost function has frame
+  // pointers.
+  std::vector<unwindstack::FrameData> libunwindstack_callstack;
+  libunwindstack_callstack.push_back(kFrame1);
+
+  EXPECT_CALL(unwinder_, Unwind(kPid, nullptr, _, _, SAMPLE_STACK_USER_SIZE_128BYTES - 10, _, _))
+      .Times(1)
+      .WillOnce(Return(LibunwindstackResult{libunwindstack_callstack,
+                                            unwindstack::ErrorCode::ERROR_INVALID_MAP}));
+
+  EXPECT_TRUE(leaf_function_call_manager_.PatchLeafFunctionCaller(&event, &maps_, &unwinder_));
+  EXPECT_THAT(event.ips, ElementsAreArray(callchain));
+}
+
+TEST_F(LeafFunctionCallManagerTest,
+       PatchLeafFunctionCallerReturnsTrueAndPatchesCallchainOnLeafFunctions) {
+  constexpr uint32_t kPid = 10;
+  constexpr uint64_t kStackSize = 13;
+
+  std::vector<uint64_t> callchain;
+  callchain.push_back(kKernelAddress);
+  callchain.push_back(kTargetAddress1);
+  // Increment by one as the return address is the next address.
+  callchain.push_back(kTargetAddress3 + 1);
+
+  CallchainSamplePerfEvent event{callchain.size(), kStackSize};
+  perf_event_sample_id_tid_time_streamid_cpu sample_id{
+      .pid = kPid,
+      .tid = 11,
+      .time = 15,
+      .stream_id = 12,
+      .cpu = 0,
+      .res = 0,
+  };
+  event.ring_buffer_record.sample_id = sample_id;
+  event.ips = callchain;
+  event.regs.bp = SAMPLE_STACK_USER_SIZE_128BYTES;
+  event.regs.sp = 10;
+
+  EXPECT_CALL(maps_, Get).WillRepeatedly(Return(nullptr));
+
+  // When libunwindstack reports exactly one frame (the ip), the innermost function has frame
+  // pointers.
+  std::vector<unwindstack::FrameData> libunwindstack_callstack;
+  libunwindstack_callstack.push_back(kFrame1);
+  libunwindstack_callstack.push_back(kFrame2);
+
+  EXPECT_CALL(unwinder_, Unwind(kPid, nullptr, _, _, SAMPLE_STACK_USER_SIZE_128BYTES - 10, _, _))
+      .Times(1)
+      .WillOnce(Return(LibunwindstackResult{libunwindstack_callstack,
+                                            unwindstack::ErrorCode::ERROR_INVALID_MAP}));
+
+  EXPECT_CALL(maps_, Find(_)).WillRepeatedly(Return(&kTargetMapInfo));
+
+  EXPECT_TRUE(leaf_function_call_manager_.PatchLeafFunctionCaller(&event, &maps_, &unwinder_));
+  EXPECT_THAT(event.ips, ElementsAre(kKernelAddress, kTargetAddress1, kTargetAddress2 + 1,
+                                     kTargetAddress3 + 1));
+  EXPECT_EQ(event.GetCallchainSize(), callchain.size() + 1);
+}
+}  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/LeafFunctionCallManagerTest.cpp
+++ b/src/LinuxTracing/LeafFunctionCallManagerTest.cpp
@@ -117,7 +117,7 @@ class LeafFunctionCallManagerTest : public ::testing::Test {
 
 }  // namespace
 
-TEST_F(LeafFunctionCallManagerTest, PatchLeafFunctionCallerReturnsErrorOnSmallStackSamples) {
+TEST_F(LeafFunctionCallManagerTest, PatchCallerOfLeafFunctionReturnsErrorOnSmallStackSamples) {
   constexpr uint32_t kPid = 10;
   constexpr uint64_t kStackSize = 13;
 
@@ -148,7 +148,7 @@ TEST_F(LeafFunctionCallManagerTest, PatchLeafFunctionCallerReturnsErrorOnSmallSt
   EXPECT_THAT(event.ips, ElementsAreArray(callchain));
 }
 
-TEST_F(LeafFunctionCallManagerTest, PatchLeafFunctionCallerReturnsErrorOnUnwindingErrors) {
+TEST_F(LeafFunctionCallManagerTest, PatchCallerOfLeafFunctionReturnsErrorOnUnwindingErrors) {
   constexpr uint32_t kPid = 10;
   constexpr uint64_t kStackSize = 13;
 
@@ -206,7 +206,7 @@ TEST_F(LeafFunctionCallManagerTest, PatchLeafFunctionCallerReturnsErrorOnUnwindi
   EXPECT_THAT(event.ips, ElementsAreArray(callchain));
 }
 
-TEST_F(LeafFunctionCallManagerTest, PatchLeafFunctionCallerReturnsErrorOnNoFramePointers) {
+TEST_F(LeafFunctionCallManagerTest, PatchCallerOfLeafFunctionReturnsErrorOnNoFramePointers) {
   constexpr uint32_t kPid = 10;
   constexpr uint64_t kStackSize = 13;
 
@@ -250,7 +250,7 @@ TEST_F(LeafFunctionCallManagerTest, PatchLeafFunctionCallerReturnsErrorOnNoFrame
 }
 
 TEST_F(LeafFunctionCallManagerTest,
-       PatchLeafFunctionCallerReturnsSuccessAndKeepsCallchainUntouchedOnNonLeafFunctions) {
+       PatchCallerOfLeafFunctionReturnsSuccessAndKeepsCallchainUntouchedOnNonLeafFunctions) {
   constexpr uint32_t kPid = 10;
   constexpr uint64_t kStackSize = 13;
 
@@ -293,7 +293,7 @@ TEST_F(LeafFunctionCallManagerTest,
 }
 
 TEST_F(LeafFunctionCallManagerTest,
-       PatchLeafFunctionCallerReturnsSuccessAndPatchesCallchainOnLeafFunctions) {
+       PatchCallerOfLeafFunctionReturnsSuccessAndPatchesCallchainOnLeafFunctions) {
   constexpr uint32_t kPid = 10;
   constexpr uint64_t kStackSize = 13;
 

--- a/src/LinuxTracing/LibunwindstackUnwinder.cpp
+++ b/src/LinuxTracing/LibunwindstackUnwinder.cpp
@@ -69,11 +69,9 @@ class LibunwindstackUnwinderImpl : public LibunwindstackUnwinder {
                               const std::array<uint64_t, PERF_REG_X86_64_MAX>& perf_regs,
                               const void* stack_dump, uint64_t stack_dump_size,
                               bool offline_memory_only = false,
-                              size_t max_frames = kMaxFrames) override;
+                              size_t max_frames = kDefaultMaxFrames) override;
 
  private:
-  static constexpr size_t kMaxFrames = 1024;  // This is arbitrary.
-
   static const std::array<size_t, unwindstack::X86_64_REG_LAST> kUnwindstackRegsToPerfRegs;
 };
 

--- a/src/LinuxTracing/LibunwindstackUnwinder.h
+++ b/src/LinuxTracing/LibunwindstackUnwinder.h
@@ -45,9 +45,15 @@ class LibunwindstackUnwinder {
 
   virtual LibunwindstackResult Unwind(pid_t pid, unwindstack::Maps* maps,
                                       const std::array<uint64_t, PERF_REG_X86_64_MAX>& perf_regs,
-                                      const void* stack_dump, uint64_t stack_dump_size) = 0;
+                                      const void* stack_dump, uint64_t stack_dump_size,
+                                      bool offline_memory = false,
+                                      size_t max_frames = kMaxFrames) = 0;
 
   static std::unique_ptr<LibunwindstackUnwinder> Create();
+  static std::string LibunwindstackErrorString(unwindstack::ErrorCode error_code);
+
+ protected:
+  static constexpr size_t kMaxFrames = 1024;  // This is arbitrary.
 };
 }  // namespace orbit_linux_tracing
 

--- a/src/LinuxTracing/LibunwindstackUnwinder.h
+++ b/src/LinuxTracing/LibunwindstackUnwinder.h
@@ -47,13 +47,13 @@ class LibunwindstackUnwinder {
                                       const std::array<uint64_t, PERF_REG_X86_64_MAX>& perf_regs,
                                       const void* stack_dump, uint64_t stack_dump_size,
                                       bool offline_memory_only = false,
-                                      size_t max_frames = kMaxFrames) = 0;
+                                      size_t max_frames = kDefaultMaxFrames) = 0;
 
   static std::unique_ptr<LibunwindstackUnwinder> Create();
   static std::string LibunwindstackErrorString(unwindstack::ErrorCode error_code);
 
  protected:
-  static constexpr size_t kMaxFrames = 1024;  // This is arbitrary.
+  static constexpr size_t kDefaultMaxFrames = 1024;  // This is arbitrary.
 };
 }  // namespace orbit_linux_tracing
 

--- a/src/LinuxTracing/LibunwindstackUnwinder.h
+++ b/src/LinuxTracing/LibunwindstackUnwinder.h
@@ -46,7 +46,7 @@ class LibunwindstackUnwinder {
   virtual LibunwindstackResult Unwind(pid_t pid, unwindstack::Maps* maps,
                                       const std::array<uint64_t, PERF_REG_X86_64_MAX>& perf_regs,
                                       const void* stack_dump, uint64_t stack_dump_size,
-                                      bool offline_memory = false,
+                                      bool offline_memory_only = false,
                                       size_t max_frames = kMaxFrames) = 0;
 
   static std::unique_ptr<LibunwindstackUnwinder> Create();

--- a/src/LinuxTracing/PerfEventOpen.cpp
+++ b/src/LinuxTracing/PerfEventOpen.cpp
@@ -99,7 +99,7 @@ int callchain_sample_event_open(uint64_t period_ns, pid_t pid, int32_t cpu) {
   // leaf functions. This is done by unwinding the first two frame using DWARF.
   pe.sample_type |= PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER;
   pe.sample_regs_user = SAMPLE_REGS_USER_ALL;
-  pe.sample_stack_user = SAMPLE_STACK_USER_SIZE_128BYTES;
+  pe.sample_stack_user = SAMPLE_STACK_USER_SIZE_512BYTES;
 
   return generic_event_open(&pe, pid, cpu);
 }

--- a/src/LinuxTracing/PerfEventOpen.cpp
+++ b/src/LinuxTracing/PerfEventOpen.cpp
@@ -91,6 +91,9 @@ int callchain_sample_event_open(uint64_t period_ns, pid_t pid, int32_t cpu) {
   // TODO(kuebler): Read this from /proc/sys/kernel/perf_event_max_stack
   pe.sample_max_stack = 127;
   pe.exclude_callchain_kernel = true;
+  // Exclude all samples that fall into the kernel. In particular this will discard samples falling
+  // into the int3 triggered uprobe code, which we could otherwise not really detect.
+  pe.exclude_kernel = true;
 
   // Also capture a small part of the stack and the registers to allow patching the callers of
   // leaf functions. This is done by unwinding the first two frame using DWARF.

--- a/src/LinuxTracing/PerfEventOpen.h
+++ b/src/LinuxTracing/PerfEventOpen.h
@@ -105,7 +105,7 @@ static constexpr uint16_t SAMPLE_STACK_USER_SIZE = 65000;
 
 // Arbitrary small value, that should be large enough to contain the complete last frame.
 // Note that we don't have any guarantee that the sample is large enough.
-static constexpr uint16_t SAMPLE_STACK_USER_SIZE_128BYTES = 128;
+static constexpr uint16_t SAMPLE_STACK_USER_SIZE_512BYTES = 512;
 
 static_assert(sizeof(void*) == 8);
 static constexpr uint16_t SAMPLE_STACK_USER_SIZE_8BYTES = 8;

--- a/src/LinuxTracing/PerfEventRecords.h
+++ b/src/LinuxTracing/PerfEventRecords.h
@@ -98,9 +98,9 @@ struct __attribute__((__packed__)) perf_event_sample_stack_user_8bytes {
   uint64_t dyn_size;
 };
 
-struct __attribute__((__packed__)) perf_event_sample_stack_user_128bytes {
+struct __attribute__((__packed__)) perf_event_sample_stack_user_512bytes {
   uint64_t size;
-  char data[SAMPLE_STACK_USER_SIZE_128BYTES];
+  char data[SAMPLE_STACK_USER_SIZE_512BYTES];
   uint64_t dyn_size;
 };
 
@@ -118,7 +118,7 @@ struct __attribute__((__packed__)) perf_event_callchain_sample_fixed {
   // Following this field there are the following fields, which we read dynamically:
   // uint64_t[nr] ips;
   // perf_event_sample_regs_user_sp_ip_arguments regs;
-  // perf_event_sample_stack_user_128bytes stack;
+  // perf_event_sample_stack_user_512bytes stack;
 };
 
 struct __attribute__((__packed__)) perf_event_sp_ip_arguments_8bytes_sample {

--- a/src/LinuxTracing/TracerThread.cpp
+++ b/src/LinuxTracing/TracerThread.cpp
@@ -108,8 +108,10 @@ void TracerThread::InitUprobesEventVisitor() {
   ORBIT_SCOPE_FUNCTION;
   maps_ = LibunwindstackMaps::ParseMaps(ReadMaps(target_pid_));
   unwinder_ = LibunwindstackUnwinder::Create();
+  leaf_function_call_manager_ = std::make_unique<LeafFunctionCallManager>();
   uprobes_unwinding_visitor_ = std::make_unique<UprobesUnwindingVisitor>(
-      &function_call_manager_, &return_address_manager_, maps_.get(), unwinder_.get());
+      &function_call_manager_, &return_address_manager_, maps_.get(), unwinder_.get(),
+      leaf_function_call_manager_.get());
   uprobes_unwinding_visitor_->SetListener(listener_);
   uprobes_unwinding_visitor_->SetUnwindErrorsAndDiscardedSamplesCounters(
       &stats_.unwind_error_count, &stats_.samples_in_uretprobes_count);

--- a/src/LinuxTracing/TracerThread.h
+++ b/src/LinuxTracing/TracerThread.h
@@ -162,6 +162,7 @@ class TracerThread {
   UprobesReturnAddressManager return_address_manager_;
   std::unique_ptr<LibunwindstackMaps> maps_;
   std::unique_ptr<LibunwindstackUnwinder> unwinder_;
+  std::unique_ptr<LeafFunctionCallManager> leaf_function_call_manager_;
   std::unique_ptr<UprobesUnwindingVisitor> uprobes_unwinding_visitor_;
   std::unique_ptr<SwitchesStatesNamesVisitor> switches_states_names_visitor_;
   std::unique_ptr<GpuTracepointVisitor> gpu_event_visitor_;

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -15,6 +15,7 @@
 #include <utility>
 
 #include "Function.h"
+#include "LeafFunctionCallManager.h"
 #include "ObjectUtils/LinuxMap.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
@@ -154,20 +155,22 @@ void UprobesUnwindingVisitor::visit(CallchainSamplePerfEvent* event) {
 
   Callstack* callstack = sample.mutable_callstack();
 
-  // TODO(b/179976268): When a sample falls on the first (push rbp) or second (mov rbp,rsp)
-  //  instruction of the current function, frame-pointer unwinding skips the caller's frame,
-  //  because rbp hasn't yet been updated to rsp. Drop the sample in this case?
-
-  if (!return_address_manager_->PatchCallchain(event->GetTid(), event->GetCallchain(),
-                                               event->GetCallchainSize(), current_maps_)) {
+  // Callstacks with only two frames (the first is in the kernel, the second is the sampled address)
+  // are unwinding errors.
+  // Note that this doesn't exclude samples inside the main function of any thread as the main
+  // function is never the outermost frame. For example, for the main thread the outermost function
+  // is _start, followed by __libc_start_main. For other threads, the outermost function is clone.
+  if (event->GetCallchainSize() == 2) {
+    ERROR("Callchain has only %lu frames", event->GetCallchainSize());
     if (unwind_error_counter_ != nullptr) {
       ++(*unwind_error_counter_);
     }
-    callstack->set_type(Callstack::kUprobesPatchingFailed);
+    callstack->set_type(Callstack::kFramePointerUnwindingError);
     callstack->add_pcs(event->GetCallchain()[1]);
     listener_->OnCallstackSample(std::move(sample));
     return;
   }
+  
 
   uint64_t top_ip = event->GetCallchain()[1];
   unwindstack::MapInfo* top_ip_map_info = current_maps_->Find(top_ip);
@@ -179,6 +182,47 @@ void UprobesUnwindingVisitor::visit(CallchainSamplePerfEvent* event) {
       ++(*samples_in_uretprobes_counter_);
     }
     callstack->set_type(Callstack::kInUprobes);
+    callstack->add_pcs(top_ip);
+    listener_->OnCallstackSample(std::move(sample));
+    return;
+  }
+
+  // The leaf function is not guaranteed to have the frame pointer for all our targets. Though, we
+  // assume that $rbp remains untouched by the leaf functions, such that we can rely on
+  // perf_event_open to give us "almost" correct callstacks (the caller of the leaf function will be
+  // missing). We do a plausibility check for this assumption by checking if the callstack only
+  // contains executable code.
+  // TODO(b/187690455): As soon as we actually have frame pointers in all non-leaf functions, we can
+  //  "discard" the sample. Till that point this check will always fail, because the caller of
+  //  __libc_start_main will be invalid since libc doesn't have frame-pointers.
+  //  Note that, that at this point in time, we don't want to actually throw the sample away, but
+  //  rather report it as "broken".
+  for (uint64_t frame_index = 1; frame_index < event->GetCallchainSize(); ++frame_index) {
+    unwindstack::MapInfo* map_info = current_maps_->Find(event->GetCallchain()[frame_index]);
+    if (map_info == nullptr || (map_info->flags & PROT_EXEC) == 0) {
+      ERROR(
+          "Unwinding failed, $rbp was likely modified in the leaf-function and no longer pointer "
+          "to a frame.");
+      break;
+    }
+  }
+
+  if (!leaf_function_call_manager_->PatchLeafFunctionCaller(event, current_maps_, unwinder_)) {
+    if (unwind_error_counter_ != nullptr) {
+      ++(*unwind_error_counter_);
+    }
+    callstack->set_type(Callstack::kFramePointerUnwindingError);
+    callstack->add_pcs(top_ip);
+    listener_->OnCallstackSample(std::move(sample));
+    return;
+  }
+
+  if (!return_address_manager_->PatchCallchain(event->GetTid(), event->GetCallchain(),
+                                               event->GetCallchainSize(), current_maps_)) {
+    if (unwind_error_counter_ != nullptr) {
+      ++(*unwind_error_counter_);
+    }
+    callstack->set_type(Callstack::kUprobesPatchingFailed);
     callstack->add_pcs(top_ip);
     listener_->OnCallstackSample(std::move(sample));
     return;

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -195,8 +195,6 @@ void UprobesUnwindingVisitor::visit(CallchainSamplePerfEvent* event) {
   //  caller of __libc_start_main will be invalid since libc doesn't have frame-pointers. This
   //  prevents us from testing the current implementation, which will have "almost" correct
   //  callstack.
-  //  Note that, at this point in time, we don't want to actually throw the sample away, but rather
-  //  report it as "broken".
   for (uint64_t frame_index = 1; frame_index < event->GetCallchainSize(); ++frame_index) {
     unwindstack::MapInfo* map_info = current_maps_->Find(event->GetCallchain()[frame_index]);
     if (map_info == nullptr || (map_info->flags & PROT_EXEC) == 0) {

--- a/src/LinuxTracing/UprobesUnwindingVisitor.h
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.h
@@ -17,6 +17,7 @@
 #include <tuple>
 #include <vector>
 
+#include "LeafFunctionCallManager.h"
 #include "LibunwindstackMaps.h"
 #include "LibunwindstackUnwinder.h"
 #include "LinuxTracing/TracerListener.h"
@@ -48,15 +49,18 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   explicit UprobesUnwindingVisitor(UprobesFunctionCallManager* function_call_manager,
                                    UprobesReturnAddressManager* uprobes_return_address_manager,
                                    LibunwindstackMaps* initial_maps,
-                                   LibunwindstackUnwinder* unwinder)
+                                   LibunwindstackUnwinder* unwinder,
+                                   LeafFunctionCallManager* leaf_function_call_manager)
       : function_call_manager_{function_call_manager},
         return_address_manager_{uprobes_return_address_manager},
         current_maps_{initial_maps},
-        unwinder_{unwinder} {
+        unwinder_{unwinder},
+        leaf_function_call_manager_{leaf_function_call_manager} {
     CHECK(function_call_manager_ != nullptr);
     CHECK(return_address_manager_ != nullptr);
     CHECK(current_maps_ != nullptr);
     CHECK(unwinder_ != nullptr);
+    CHECK(leaf_function_call_manager_ != nullptr);
   }
 
   UprobesUnwindingVisitor(const UprobesUnwindingVisitor&) = delete;
@@ -85,6 +89,7 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   UprobesReturnAddressManager* return_address_manager_;
   LibunwindstackMaps* current_maps_;
   LibunwindstackUnwinder* unwinder_;
+  LeafFunctionCallManager* leaf_function_call_manager_;
 
   TracerListener* listener_ = nullptr;
 

--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -714,9 +714,10 @@ TEST_F(UprobesUnwindingVisitorTest,
   EXPECT_CALL(maps_, Find).WillRepeatedly(Return(&kTargetMapInfo));
   EXPECT_CALL(return_address_manager_, PatchCallchain).Times(1).WillRepeatedly(Return(true));
 
-  auto fake_patch_leaf_function_caller =
-      [](CallchainSamplePerfEvent* event, LibunwindstackMaps* /*maps*/,
-         orbit_linux_tracing::LibunwindstackUnwinder* /*unwinder*/) -> bool {
+  auto fake_patch_leaf_function_caller = [](CallchainSamplePerfEvent* event,
+                                            LibunwindstackMaps* /*maps*/,
+                                            orbit_linux_tracing::LibunwindstackUnwinder *
+                                            /*unwinder*/) -> bool {
     CHECK(event != nullptr);
     std::vector<uint64_t> patched_callchain;
     EXPECT_THAT(event->ips, ElementsAre(kKernelAddress, kTargetAddress1, kTargetAddress3 + 1));

--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -611,7 +611,7 @@ TEST_F(UprobesUnwindingVisitorTest, VisitCallchainSampleWithUprobeSendsCompleteC
 
   EXPECT_CALL(maps_, Find).WillRepeatedly(Return(&kTargetMapInfo));
   auto fake_patch_callchain = [](pid_t /*tid*/, uint64_t* callchain, uint64_t callchain_size,
-                                 orbit_linux_tracing::LibunwindstackMaps*
+                                 orbit_linux_tracing::LibunwindstackMaps *
                                  /*maps*/) -> bool {
     CHECK(callchain != nullptr);
     CHECK(callchain_size == 4);
@@ -724,7 +724,7 @@ TEST_F(UprobesUnwindingVisitorTest,
 
   auto fake_patch_leaf_function_caller = [](CallchainSamplePerfEvent* event,
                                             LibunwindstackMaps* /*maps*/,
-                                            orbit_linux_tracing::LibunwindstackUnwinder*
+                                            orbit_linux_tracing::LibunwindstackUnwinder *
                                             /*unwinder*/) -> Callstack::CallstackType {
     CHECK(event != nullptr);
     std::vector<uint64_t> patched_callchain;

--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -70,7 +70,7 @@ class MockUprobesReturnAddressManager : public UprobesReturnAddressManager {
 
 class MockLeafFunctionCallManager : public LeafFunctionCallManager {
  public:
-  MOCK_METHOD(Callstack::CallstackType, PatchLeafFunctionCaller,
+  MOCK_METHOD(Callstack::CallstackType, PatchCallerOfLeafFunction,
               (CallchainSamplePerfEvent*, LibunwindstackMaps*, LibunwindstackUnwinder*),
               (override));
 };
@@ -480,7 +480,7 @@ TEST_F(UprobesUnwindingVisitorTest, VisitValidCallchainSampleWithoutUprobesSends
 
   EXPECT_CALL(maps_, Find).WillRepeatedly(Return(&kTargetMapInfo));
   EXPECT_CALL(return_address_manager_, PatchCallchain).Times(1).WillOnce(Return(true));
-  EXPECT_CALL(leaf_function_call_manager_, PatchLeafFunctionCaller)
+  EXPECT_CALL(leaf_function_call_manager_, PatchCallerOfLeafFunction)
       .Times(1)
       .WillOnce(Return(Callstack::kComplete));
 
@@ -522,7 +522,7 @@ TEST_F(UprobesUnwindingVisitorTest, VisitSingleFrameCallchainSampleDoesNothing) 
 
   EXPECT_CALL(maps_, Find).WillRepeatedly(Return(&kTargetMapInfo));
   EXPECT_CALL(return_address_manager_, PatchCallchain).Times(0);
-  EXPECT_CALL(leaf_function_call_manager_, PatchLeafFunctionCaller).Times(0);
+  EXPECT_CALL(leaf_function_call_manager_, PatchCallerOfLeafFunction).Times(0);
 
   EXPECT_CALL(listener_, OnCallstackSample).Times(0);
 
@@ -565,7 +565,7 @@ TEST_F(UprobesUnwindingVisitorTest, VisitCallchainSampleInsideUprobeCodeSendsInU
   EXPECT_CALL(maps_, Find(_)).WillRepeatedly(Return(&kTargetMapInfo));
   EXPECT_CALL(maps_, Find(kUprobesMapsStart)).WillRepeatedly(Return(&kUprobesMapInfo));
   EXPECT_CALL(return_address_manager_, PatchCallchain).Times(0);
-  EXPECT_CALL(leaf_function_call_manager_, PatchLeafFunctionCaller).Times(0);
+  EXPECT_CALL(leaf_function_call_manager_, PatchCallerOfLeafFunction).Times(0);
 
   orbit_grpc_protos::FullCallstackSample actual_callstack_sample;
   EXPECT_CALL(listener_, OnCallstackSample).Times(1).WillOnce(SaveArg<0>(&actual_callstack_sample));
@@ -622,7 +622,7 @@ TEST_F(UprobesUnwindingVisitorTest, VisitCallchainSampleWithUprobeSendsCompleteC
       .Times(1)
       .WillOnce(Invoke(fake_patch_callchain));
 
-  EXPECT_CALL(leaf_function_call_manager_, PatchLeafFunctionCaller)
+  EXPECT_CALL(leaf_function_call_manager_, PatchCallerOfLeafFunction)
       .Times(1)
       .WillOnce(Return(Callstack::kComplete));
 
@@ -671,7 +671,7 @@ TEST_F(UprobesUnwindingVisitorTest,
   event.ips = callchain;
 
   EXPECT_CALL(maps_, Find).WillRepeatedly(Return(&kTargetMapInfo));
-  EXPECT_CALL(leaf_function_call_manager_, PatchLeafFunctionCaller)
+  EXPECT_CALL(leaf_function_call_manager_, PatchCallerOfLeafFunction)
       .Times(1)
       .WillOnce(Return(Callstack::kComplete));
   EXPECT_CALL(return_address_manager_, PatchCallchain).Times(1).WillOnce(Return(false));
@@ -738,7 +738,7 @@ TEST_F(UprobesUnwindingVisitorTest,
     event->ips = std::move(patched_callchain);
     return Callstack::kComplete;
   };
-  EXPECT_CALL(leaf_function_call_manager_, PatchLeafFunctionCaller)
+  EXPECT_CALL(leaf_function_call_manager_, PatchCallerOfLeafFunction)
       .Times(1)
       .WillOnce(Invoke(fake_patch_leaf_function_caller));
 
@@ -761,7 +761,7 @@ TEST_F(UprobesUnwindingVisitorTest,
 
 TEST_F(
     UprobesUnwindingVisitorTest,
-    VisitLeafCallOptimizedCallchainSampleWherePatchingLeafFunctionCallerSendsFramePointerUnwindingErrorCallstack) {
+    VisitLeafCallOptimizedCallchainSampleWherePatchingLeafFunctionCallerFailsSendsFramePointerUnwindingErrorCallstack) {
   constexpr uint32_t kPid = 10;
   constexpr uint64_t kStackSize = 13;
 
@@ -786,7 +786,7 @@ TEST_F(
   EXPECT_CALL(maps_, Find).WillRepeatedly(Return(&kTargetMapInfo));
   EXPECT_CALL(return_address_manager_, PatchCallchain).Times(0);
 
-  EXPECT_CALL(leaf_function_call_manager_, PatchLeafFunctionCaller)
+  EXPECT_CALL(leaf_function_call_manager_, PatchCallerOfLeafFunction)
       .Times(1)
       .WillOnce(Return(Callstack::kFramePointerUnwindingError));
 

--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -607,7 +607,7 @@ TEST_F(UprobesUnwindingVisitorTest, VisitCallchainSampleWithUprobeSendsCompleteC
 
   EXPECT_CALL(maps_, Find).WillRepeatedly(Return(&kTargetMapInfo));
   auto fake_patch_callchain = [](pid_t /*tid*/, uint64_t* callchain, uint64_t callchain_size,
-                                 orbit_linux_tracing::LibunwindstackMaps *
+                                 orbit_linux_tracing::LibunwindstackMaps*
                                  /*maps*/) -> bool {
     CHECK(callchain != nullptr);
     CHECK(callchain_size == 4);
@@ -716,7 +716,7 @@ TEST_F(UprobesUnwindingVisitorTest,
 
   auto fake_patch_leaf_function_caller = [](CallchainSamplePerfEvent* event,
                                             LibunwindstackMaps* /*maps*/,
-                                            orbit_linux_tracing::LibunwindstackUnwinder *
+                                            orbit_linux_tracing::LibunwindstackUnwinder*
                                             /*unwinder*/) -> bool {
     CHECK(event != nullptr);
     std::vector<uint64_t> patched_callchain;

--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -722,7 +722,7 @@ TEST_F(UprobesUnwindingVisitorTest,
   EXPECT_CALL(maps_, Find).WillRepeatedly(Return(&kTargetMapInfo));
   EXPECT_CALL(return_address_manager_, PatchCallchain).Times(1).WillRepeatedly(Return(true));
 
-  auto fake_patch_leaf_function_caller = [](CallchainSamplePerfEvent* event,
+  auto fake_patch_caller_of_leaf_function = [](CallchainSamplePerfEvent* event,
                                             LibunwindstackMaps* /*maps*/,
                                             orbit_linux_tracing::LibunwindstackUnwinder *
                                             /*unwinder*/) -> Callstack::CallstackType {
@@ -740,7 +740,7 @@ TEST_F(UprobesUnwindingVisitorTest,
   };
   EXPECT_CALL(leaf_function_call_manager_, PatchCallerOfLeafFunction)
       .Times(1)
-      .WillOnce(Invoke(fake_patch_leaf_function_caller));
+      .WillOnce(Invoke(fake_patch_caller_of_leaf_function));
 
   orbit_grpc_protos::FullCallstackSample actual_callstack_sample;
   EXPECT_CALL(listener_, OnCallstackSample).Times(1).WillOnce(SaveArg<0>(&actual_callstack_sample));

--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -723,9 +723,9 @@ TEST_F(UprobesUnwindingVisitorTest,
   EXPECT_CALL(return_address_manager_, PatchCallchain).Times(1).WillRepeatedly(Return(true));
 
   auto fake_patch_caller_of_leaf_function = [](CallchainSamplePerfEvent* event,
-                                            LibunwindstackMaps* /*maps*/,
-                                            orbit_linux_tracing::LibunwindstackUnwinder *
-                                            /*unwinder*/) -> Callstack::CallstackType {
+                                               LibunwindstackMaps* /*maps*/,
+                                               orbit_linux_tracing::LibunwindstackUnwinder *
+                                               /*unwinder*/) -> Callstack::CallstackType {
     CHECK(event != nullptr);
     std::vector<uint64_t> patched_callchain;
     EXPECT_THAT(event->ips, ElementsAre(kKernelAddress, kTargetAddress1, kTargetAddress3 + 1));

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
@@ -758,14 +758,6 @@ void VerifyCallstackSamplesWithOuterAndInnerFunction(
       // address and the caller address should match the "outer" function's address.
       if (callstack.pcs(pc_index) >= inner_function_virtual_address_range.first &&
           callstack.pcs(pc_index) <= inner_function_virtual_address_range.second) {
-        // Frame-pointer unwinding skips the second innermost frame if the sample fell on `push rbp`
-        // (which is one byte) or `mov rbp,rsp`. Disregard such samples. See b/179376436#comment4.
-        if (pc_index == 0 && unwound_with_frame_pointers &&
-            (callstack.pcs(pc_index) == inner_function_virtual_address_range.first ||
-             callstack.pcs(pc_index) == inner_function_virtual_address_range.first + 1)) {
-          continue;
-        }
-
         if (address_infos_received != nullptr) {
           // Verify that we got the AddressInfo for this virtual address of the "inner" function.
           EXPECT_TRUE(address_infos_received->contains(callstack.pcs(pc_index)));

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
@@ -734,11 +734,19 @@ void VerifyCallstackSamplesWithOuterAndInnerFunction(
     previous_callstack_timestamp_ns = callstack_sample.timestamp_ns();
 
     // We don't expect other reasons for broken callstacks other than these.
-    const std::vector<orbit_grpc_protos::Callstack::CallstackType> expected_callstack_types{
-        {orbit_grpc_protos::Callstack::kComplete,
-         unwound_with_frame_pointers ? orbit_grpc_protos::Callstack::kFramePointerUnwindingError
-                                     : orbit_grpc_protos::Callstack::kDwarfUnwindingError,
-         orbit_grpc_protos::Callstack::kInUprobes}};
+    std::vector<orbit_grpc_protos::Callstack::CallstackType> expected_callstack_types;
+    if (unwound_with_frame_pointers) {
+      expected_callstack_types = {
+          orbit_grpc_protos::Callstack::kComplete,
+          orbit_grpc_protos::Callstack::kFramePointerUnwindingError,
+          orbit_grpc_protos::Callstack::kDwarfUnwindingError,
+          orbit_grpc_protos::Callstack::kFramePointerDwarfStackTooSmallError,
+          orbit_grpc_protos::Callstack::kInUprobes};
+    } else {
+      expected_callstack_types = {orbit_grpc_protos::Callstack::kComplete,
+                                  orbit_grpc_protos::Callstack::kDwarfUnwindingError,
+                                  orbit_grpc_protos::Callstack::kInUprobes};
+    }
     EXPECT_THAT(expected_callstack_types, ::testing::Contains(callstack_sample.callstack().type()));
 
     // We are only sampling the puppet.

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
@@ -736,12 +736,11 @@ void VerifyCallstackSamplesWithOuterAndInnerFunction(
     // We don't expect other reasons for broken callstacks other than these.
     std::vector<orbit_grpc_protos::Callstack::CallstackType> expected_callstack_types;
     if (unwound_with_frame_pointers) {
-      expected_callstack_types = {
-          orbit_grpc_protos::Callstack::kComplete,
-          orbit_grpc_protos::Callstack::kFramePointerUnwindingError,
-          orbit_grpc_protos::Callstack::kDwarfUnwindingError,
-          orbit_grpc_protos::Callstack::kFramePointerDwarfStackTooSmallError,
-          orbit_grpc_protos::Callstack::kInUprobes};
+      expected_callstack_types = {orbit_grpc_protos::Callstack::kComplete,
+                                  orbit_grpc_protos::Callstack::kFramePointerUnwindingError,
+                                  orbit_grpc_protos::Callstack::kStackTopForDwarfUnwindingTooSmall,
+                                  orbit_grpc_protos::Callstack::kStackTopDwarfUnwindingError,
+                                  orbit_grpc_protos::Callstack::kInUprobes};
     } else {
       expected_callstack_types = {orbit_grpc_protos::Callstack::kComplete,
                                   orbit_grpc_protos::Callstack::kDwarfUnwindingError,


### PR DESCRIPTION
In leaf functions (or samples that hit the prologue/epilogue),
`$rbp` might not point to the beginning of the frame. In those cases
perf_event_open will miss the sample's direct caller in the resulting
callstack (on frame-pointer-based unwinding).

This change will in addition to perf_event_open, unwind the first
two frames with libunwindstack, and if the sample's caller is
different, we know the missing pc. We will patch the sample in this
case.

Now that we handle the case that our sample falls inside the prologue,
the test does not need to discard those samples anymore.

Test: Compile a target with -momit-leaf-frame-pointer, inspect the
      callstack. Further, run the integration and unit tests.

Bug: http://b/160399871