### PR TITLE
Erase RequestUpdatePrimitives in Tracks

### DIFF
--- a/src/OrbitGl/CaptureViewElement.cpp
+++ b/src/OrbitGl/CaptureViewElement.cpp
@@ -24,12 +24,18 @@ void CaptureViewElement::OnPick(int x, int y) {
 
 void CaptureViewElement::OnRelease() {
   picked_ = false;
-  time_graph_->RequestUpdatePrimitives();
+  RequestUpdate();
 }
 
 void CaptureViewElement::OnDrag(int x, int y) {
   mouse_pos_cur_ = viewport_->ScreenToWorldPos(Vec2i(x, y));
-  time_graph_->RequestUpdatePrimitives();
+  RequestUpdate();
+}
+
+void CaptureViewElement::RequestUpdate() {
+  if (parent_ != nullptr) {
+    parent_->RequestUpdate();
+  }
 }
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -46,6 +46,7 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
   [[nodiscard]] bool Draggable() override { return true; }
 
   [[nodiscard]] virtual CaptureViewElement* GetParent() const { return parent_; }
+  virtual void RequestUpdate();
 
  protected:
   orbit_gl::Viewport* viewport_;

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -378,7 +378,7 @@ void CaptureWindow::Draw(bool viewport_was_dirty) {
       time_graph_->SetPos(0, 0);
       time_graph_->SetSize(viewport_.GetWorldExtents()[0], viewport_.GetWorldExtents()[1]);
 
-      time_graph_->RequestUpdatePrimitives();
+      time_graph_->RequestUpdate();
     }
     uint64_t timegraph_current_mouse_time_ns =
         time_graph_->GetTickFromWorld(viewport_.ScreenToWorldPos(GetMouseScreenPos())[0]);
@@ -575,7 +575,7 @@ Batcher& CaptureWindow::GetBatcherById(BatcherId batcher_id) {
 void CaptureWindow::RequestUpdatePrimitives() {
   redraw_requested_ = true;
   if (time_graph_ == nullptr) return;
-  time_graph_->RequestUpdatePrimitives();
+  time_graph_->RequestUpdate();
 }
 
 [[nodiscard]] bool CaptureWindow::IsRedrawNeeded() const {

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -56,20 +56,24 @@ ThreadTrack::ThreadTrack(CaptureViewElement* parent, TimeGraph* time_graph,
   SetTrackColor(TimeGraph::GetThreadColor(thread_id));
 }
 
+std::string ThreadTrack::GetThreadNameFromTid(uint32_t thread_id) {
+  const std::string kEmptyString;
+  return capture_data_ ? capture_data_->GetThreadName(thread_id) : kEmptyString;
+}
+
 void ThreadTrack::InitializeNameAndLabel(int32_t thread_id) {
   if (thread_id == orbit_base::kAllThreadsOfAllProcessesTid) {
     SetName("All tracepoint events");
     SetLabel("All tracepoint events");
   } else if (thread_id == orbit_base::kAllProcessThreadsTid) {
     // This is the process track.
-    const CaptureData& capture_data = app_->GetCaptureData();
-    std::string process_name = capture_data.process_name();
+    std::string process_name = capture_data_->process_name();
     SetName("All Threads");
     const std::string_view all_threads = " (all_threads)";
     SetLabel(process_name.append(all_threads));
     SetNumberOfPrioritizedTrailingCharacters(all_threads.size() - 1);
   } else {
-    const std::string& thread_name = time_graph_->GetThreadNameFromTid(thread_id);
+    const std::string& thread_name = GetThreadNameFromTid(thread_id);
     SetName(thread_name);
     std::string tid_str = std::to_string(thread_id);
     std::string track_label = absl::StrFormat("%s [%s]", thread_name, tid_str);

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -58,6 +58,7 @@ class ThreadTrack final : public TimerTrack {
   [[nodiscard]] std::vector<CaptureViewElement*> GetVisibleChildren() override;
 
  protected:
+  [[nodiscard]] std::string GetThreadNameFromTid(uint32_t tid);
   [[nodiscard]] bool IsTimerActive(const orbit_client_protos::TimerInfo& timer) const override;
   [[nodiscard]] bool IsTrackSelected() const override;
 

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -850,11 +850,6 @@ void TimeGraph::DrawOverlay(Batcher& batcher, TextRenderer& text_renderer,
   }
 }
 
-std::string TimeGraph::GetThreadNameFromTid(uint32_t tid) {
-  const std::string kEmptyString;
-  return capture_data_ ? capture_data_->GetThreadName(tid) : kEmptyString;
-}
-
 void TimeGraph::DrawTracks(Batcher& batcher, TextRenderer& text_renderer,
                            uint64_t current_mouse_time_ns, PickingMode picking_mode) {
   for (auto& track : track_manager_->GetVisibleTracks()) {

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -90,7 +90,7 @@ void TimeGraph::ZoomAll() {
   min_time_us_ = max_time_us_ - (GNumHistorySeconds * 1000 * 1000);
   if (min_time_us_ < 0) min_time_us_ = 0;
 
-  RequestUpdatePrimitives();
+  RequestUpdate();
 }
 
 void TimeGraph::Zoom(uint64_t min, uint64_t max) {
@@ -163,7 +163,7 @@ void TimeGraph::SetMinMax(double min_time_us, double max_time_us) {
   min_time_us_ = std::max(min_time_us, 0.0);
   max_time_us_ = std::min(min_time_us_ + desired_time_window, GetCaptureTimeSpanUs());
 
-  RequestUpdatePrimitives();
+  RequestUpdate();
 }
 
 void TimeGraph::PanTime(int initial_x, int current_x, int width, double initial_time) {
@@ -175,7 +175,7 @@ void TimeGraph::PanTime(int initial_x, int current_x, int width, double initial_
       clamp(current_time - initial_local_time, 0.0, GetCaptureTimeSpanUs() - time_window_us_);
   max_time_us_ = min_time_us_ + time_window_us_;
 
-  RequestUpdatePrimitives();
+  RequestUpdate();
 }
 
 void TimeGraph::HorizontallyMoveIntoView(VisibilityType vis_type, uint64_t min, uint64_t max,
@@ -203,7 +203,7 @@ void TimeGraph::HorizontallyMoveIntoView(VisibilityType vis_type, uint64_t min, 
 
   SetMinMax(mid - current_time_window_us * (1 - distance), mid + current_time_window_us * distance);
 
-  RequestUpdatePrimitives();
+  RequestUpdate();
 }
 
 void TimeGraph::HorizontallyMoveIntoView(VisibilityType vis_type, const TimerInfo& timer_info,
@@ -308,7 +308,7 @@ void TimeGraph::ProcessTimer(const TimerInfo& timer_info, const InstrumentedFunc
       UNREACHABLE();
   }
 
-  RequestUpdatePrimitives();
+  RequestUpdate();
 }
 
 void TimeGraph::ProcessOrbitFunctionTimer(FunctionInfo::OrbitType type,
@@ -616,7 +616,7 @@ const TextBox* TimeGraph::FindNextFunctionCall(uint64_t function_id, uint64_t cu
   return next_box;
 }
 
-void TimeGraph::RequestUpdatePrimitives() {
+void TimeGraph::RequestUpdate() {
   update_primitives_requested_ = true;
   RequestRedraw();
 }
@@ -671,7 +671,7 @@ void TimeGraph::SelectCallstacks(float world_start, float world_end, int32_t thr
 
   app_->SelectCallstackEvents(selected_callstack_events, thread_id);
 
-  RequestUpdatePrimitives();
+  RequestUpdate();
 }
 
 const std::vector<CallstackEvent>& TimeGraph::GetSelectedCallstackEvents(int32_t tid) {
@@ -865,7 +865,7 @@ void TimeGraph::DrawTracks(Batcher& batcher, TextRenderer& text_renderer,
 
 void TimeGraph::SetThreadFilter(const std::string& filter) {
   track_manager_->SetFilter(filter);
-  RequestUpdatePrimitives();
+  RequestUpdate();
 }
 
 void TimeGraph::SelectAndZoom(const TextBox* text_box) {
@@ -931,7 +931,7 @@ void TimeGraph::UpdateRightMargin(float margin) {
   {
     if (right_margin_ != margin) {
       right_margin_ = margin;
-      RequestUpdatePrimitives();
+      RequestUpdate();
     }
   }
 }
@@ -1012,7 +1012,7 @@ bool TimeGraph::HasFrameTrack(uint64_t function_id) const {
 
 void TimeGraph::RemoveFrameTrack(uint64_t function_id) {
   track_manager_->RemoveFrameTrack(function_id);
-  RequestUpdatePrimitives();
+  RequestUpdate();
 }
 
 std::unique_ptr<orbit_accessibility::AccessibleInterface> TimeGraph::CreateAccessibleInterface() {

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -173,7 +173,6 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
 
   [[nodiscard]] bool HasFrameTrack(uint64_t function_id) const;
   void RemoveFrameTrack(uint64_t function_id);
-  [[nodiscard]] std::string GetThreadNameFromTid(uint32_t tid);
 
   [[nodiscard]] AccessibleInterfaceProvider* GetAccessibleParent() const {
     return accessible_parent_;

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -55,7 +55,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
                        float text_box_y);
   void DrawText(float layer);
 
-  void RequestUpdatePrimitives();
+  void RequestUpdate() override;
   void UpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/, uint64_t /*max_tick*/,
                         PickingMode /*picking_mode*/, float /*z_offset*/ = 0) override;
   void SelectCallstacks(float world_start, float world_end, int32_t thread_id);

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -233,9 +233,7 @@ Color Track::GetTrackBackgroundColor() const {
   return color_;
 }
 
-void Track::OnCollapseToggle(TriangleToggle::State /*state*/) {
-  time_graph_->RequestUpdatePrimitives();
-}
+void Track::OnCollapseToggle(TriangleToggle::State /*state*/) { RequestUpdate(); }
 
 void Track::OnDrag(int x, int y) {
   CaptureViewElement::OnDrag(x, y);


### PR DESCRIPTION
We solve it by making every CaptureViewElement tell this parent that it need to be updated, so we don't need TimeGraph for that anymore.

Also moved GetThreadName to ThreadTrack.

http://b/176086740.

Test: Start/stop + Load a capture