### PR TITLE
Fix regression in capture save

### DIFF
--- a/src/ClientModel/CaptureSerializer.cpp
+++ b/src/ClientModel/CaptureSerializer.cpp
@@ -138,13 +138,16 @@ CaptureInfo GenerateCaptureInfo(
     if (function == nullptr) {
       continue;
     }
+
     // Fix names/offset/module in address infos (some might only be in process):
     added_address_info->set_function_name(
         orbit_client_data::function_utils::GetDisplayName(*function));
-    const ModuleData* module = capture_data.GetModuleByPathAndBuildId(function->module_path(),
-                                                                      function->module_build_id());
-    const uint64_t offset = orbit_client_data::function_utils::Offset(*function, *module);
-    added_address_info->set_offset_in_function(offset);
+    auto absolute_function_address = capture_data.GetAbsoluteAddress(*function);
+    if (!absolute_function_address.has_value()) {
+      continue;
+    }
+
+    added_address_info->set_offset_in_function(absolute_address - *absolute_function_address);
     added_address_info->set_module_path(function->module_path());
   }
 


### PR DESCRIPTION
The regression was introduced in 0f389fe00bac44a36287e31ef8c5f517fd09f398
where offset in function was replaced with function offset.

Bug: http://b/187370534
Test: Run capture save->load compare sampling report with
      original capture.