### PR TITLE
Make UprobesUnwindingVisitor Testable

### DIFF
--- a/src/LinuxTracing/CMakeLists.txt
+++ b/src/LinuxTracing/CMakeLists.txt
@@ -29,6 +29,8 @@ target_sources(LinuxTracing PRIVATE
         GpuTracepointVisitor.h
         GpuTracepointVisitor.cpp
         KernelTracepoints.h
+        LibunwindstackMaps.cpp
+        LibunwindstackMaps.h
         LibunwindstackUnwinder.cpp
         LibunwindstackUnwinder.h
         LinuxTracingUtils.h
@@ -79,7 +81,8 @@ target_sources(LinuxTracingTests PRIVATE
         PerfEventQueueTest.cpp
         ThreadStateManagerTest.cpp
         UprobesFunctionCallManagerTest.cpp
-        UprobesReturnAddressManagerTest.cpp)
+        UprobesReturnAddressManagerTest.cpp
+        UprobesUnwindingVisitorTest.cpp)
 
 target_link_libraries(LinuxTracingTests PRIVATE
         LinuxTracing

--- a/src/LinuxTracing/LibunwindstackMaps.cpp
+++ b/src/LinuxTracing/LibunwindstackMaps.cpp
@@ -12,6 +12,7 @@ class LibunwindstackMapsImpl : public LibunwindstackMaps {
  public:
   explicit LibunwindstackMapsImpl(std::unique_ptr<unwindstack::BufferMaps> maps)
       : maps_{std::move(maps)} {}
+
   unwindstack::MapInfo* Find(uint64_t pc) override { return maps_->Find(pc); }
 
   unwindstack::Maps* Get() override { return maps_.get(); }

--- a/src/LinuxTracing/LibunwindstackMaps.cpp
+++ b/src/LinuxTracing/LibunwindstackMaps.cpp
@@ -17,12 +17,11 @@ class LibunwindstackMapsImpl : public LibunwindstackMaps {
 
   unwindstack::Maps* Get() override { return maps_.get(); }
 
-  void Add(uint64_t start, uint64_t end, uint64_t offset, uint64_t flags, const std::string& name,
-           uint64_t load_bias) override {
+  void AddAndSort(uint64_t start, uint64_t end, uint64_t offset, uint64_t flags,
+                  const std::string& name, uint64_t load_bias) override {
     maps_->Add(start, end, offset, flags, name, load_bias);
+    maps_->Sort();
   }
-
-  void Sort() override { maps_->Sort(); }
 
  private:
   std::unique_ptr<unwindstack::BufferMaps> maps_;

--- a/src/LinuxTracing/LibunwindstackMaps.cpp
+++ b/src/LinuxTracing/LibunwindstackMaps.cpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "LibunwindstackMaps.h"
+
+namespace orbit_linux_tracing {
+
+namespace {
+
+class LibunwindstackMapsImpl : public LibunwindstackMaps {
+ public:
+  explicit LibunwindstackMapsImpl(std::unique_ptr<unwindstack::BufferMaps> maps)
+      : maps_{std::move(maps)} {}
+  unwindstack::MapInfo* Find(uint64_t pc) override { return maps_->Find(pc); }
+
+  unwindstack::Maps* Get() override { return maps_.get(); }
+
+  void Add(uint64_t start, uint64_t end, uint64_t offset, uint64_t flags, const std::string& name,
+           uint64_t load_bias) override {
+    maps_->Add(start, end, offset, flags, name, load_bias);
+  }
+
+  void Sort() override { maps_->Sort(); }
+
+ private:
+  std::unique_ptr<unwindstack::BufferMaps> maps_;
+};
+}  // namespace
+
+std::unique_ptr<LibunwindstackMaps> LibunwindstackMaps::ParseMaps(const std::string& maps_buffer) {
+  auto maps = std::make_unique<unwindstack::BufferMaps>(maps_buffer.c_str());
+  if (!maps->Parse()) {
+    return nullptr;
+  }
+  return std::make_unique<LibunwindstackMapsImpl>(std::move(maps));
+}
+
+}  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/LibunwindstackMaps.h
+++ b/src/LinuxTracing/LibunwindstackMaps.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LINUX_TRACING_LIBUNWINDSTACK_MAPS_H_
+#define LINUX_TRACING_LIBUNWINDSTACK_MAPS_H_
+
+#include <unwindstack/MapInfo.h>
+#include <unwindstack/Maps.h>
+
+namespace orbit_linux_tracing {
+
+class LibunwindstackMaps {
+ public:
+  virtual ~LibunwindstackMaps() = default;
+
+  static std::unique_ptr<LibunwindstackMaps> ParseMaps(const std::string& maps_buffer);
+
+  virtual unwindstack::MapInfo* Find(uint64_t pc) = 0;
+  virtual unwindstack::Maps* Get() = 0;
+  virtual void Add(uint64_t start, uint64_t end, uint64_t offset, uint64_t flags,
+                   const std::string& name, uint64_t load_bias) = 0;
+
+  virtual void Sort() = 0;
+};
+
+}  // namespace orbit_linux_tracing
+
+#endif  // LINUX_TRACING_LIBUNWINDSTACK_MAPS_H_

--- a/src/LinuxTracing/LibunwindstackMaps.h
+++ b/src/LinuxTracing/LibunwindstackMaps.h
@@ -14,14 +14,14 @@ class LibunwindstackMaps {
  public:
   virtual ~LibunwindstackMaps() = default;
 
-  static std::unique_ptr<LibunwindstackMaps> ParseMaps(const std::string& maps_buffer);
-
   virtual unwindstack::MapInfo* Find(uint64_t pc) = 0;
   virtual unwindstack::Maps* Get() = 0;
   virtual void Add(uint64_t start, uint64_t end, uint64_t offset, uint64_t flags,
                    const std::string& name, uint64_t load_bias) = 0;
 
   virtual void Sort() = 0;
+
+  static std::unique_ptr<LibunwindstackMaps> ParseMaps(const std::string& maps_buffer);
 };
 
 }  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/LibunwindstackMaps.h
+++ b/src/LinuxTracing/LibunwindstackMaps.h
@@ -16,10 +16,8 @@ class LibunwindstackMaps {
 
   virtual unwindstack::MapInfo* Find(uint64_t pc) = 0;
   virtual unwindstack::Maps* Get() = 0;
-  virtual void Add(uint64_t start, uint64_t end, uint64_t offset, uint64_t flags,
-                   const std::string& name, uint64_t load_bias) = 0;
-
-  virtual void Sort() = 0;
+  virtual void AddAndSort(uint64_t start, uint64_t end, uint64_t offset, uint64_t flags,
+                          const std::string& name, uint64_t load_bias) = 0;
 
   static std::unique_ptr<LibunwindstackMaps> ParseMaps(const std::string& maps_buffer);
 };

--- a/src/LinuxTracing/LibunwindstackUnwinder.cpp
+++ b/src/LinuxTracing/LibunwindstackUnwinder.cpp
@@ -73,7 +73,7 @@ class LibunwindstackUnwinderImpl : public LibunwindstackUnwinder {
  private:
   static constexpr size_t kMaxFrames = 1024;  // This is arbitrary.
 
-  static const std::array<size_t, unwindstack::X86_64_REG_LAST> UNWINDSTACK_REGS_TO_PERF_REGS;
+  static const std::array<size_t, unwindstack::X86_64_REG_LAST> kUunwindstackRegsToPerfRegs;
 
   static std::string LibunwindstackErrorString(unwindstack::ErrorCode error_code) {
     static const std::vector<const char*> kErrorNames{
@@ -83,14 +83,9 @@ class LibunwindstackUnwinderImpl : public LibunwindstackUnwinder {
     return kErrorNames[error_code];
   }
 };
-}  // namespace
-
-std::unique_ptr<LibunwindstackUnwinder> LibunwindstackUnwinder::Create() {
-  return std::make_unique<LibunwindstackUnwinderImpl>();
-}
 
 const std::array<size_t, unwindstack::X86_64_REG_LAST>
-    LibunwindstackUnwinderImpl::UNWINDSTACK_REGS_TO_PERF_REGS{
+    LibunwindstackUnwinderImpl::kUunwindstackRegsToPerfRegs{
         PERF_REG_X86_AX,  PERF_REG_X86_DX,  PERF_REG_X86_CX,  PERF_REG_X86_BX,  PERF_REG_X86_SI,
         PERF_REG_X86_DI,  PERF_REG_X86_BP,  PERF_REG_X86_SP,  PERF_REG_X86_R8,  PERF_REG_X86_R9,
         PERF_REG_X86_R10, PERF_REG_X86_R11, PERF_REG_X86_R12, PERF_REG_X86_R13, PERF_REG_X86_R14,
@@ -102,7 +97,7 @@ std::vector<unwindstack::FrameData> LibunwindstackUnwinderImpl::Unwind(
     const void* stack_dump, uint64_t stack_dump_size) {
   unwindstack::RegsX86_64 regs{};
   for (size_t perf_reg = 0; perf_reg < unwindstack::X86_64_REG_LAST; ++perf_reg) {
-    regs[perf_reg] = perf_regs.at(UNWINDSTACK_REGS_TO_PERF_REGS[perf_reg]);
+    regs[perf_reg] = perf_regs.at(kUunwindstackRegsToPerfRegs[perf_reg]);
   }
 
   std::shared_ptr<unwindstack::Memory> memory = StackAndProcessMemory::Create(
@@ -123,6 +118,11 @@ std::vector<unwindstack::FrameData> LibunwindstackUnwinderImpl::Unwind(
   }
 
   return unwinder.frames();
+}
+}  // namespace
+
+std::unique_ptr<LibunwindstackUnwinder> LibunwindstackUnwinder::Create() {
+  return std::make_unique<LibunwindstackUnwinderImpl>();
 }
 
 }  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/LibunwindstackUnwinder.h
+++ b/src/LinuxTracing/LibunwindstackUnwinder.h
@@ -22,25 +22,14 @@ namespace orbit_linux_tracing {
 
 class LibunwindstackUnwinder {
  public:
-  static std::unique_ptr<unwindstack::BufferMaps> ParseMaps(const std::string& maps_buffer);
+  virtual ~LibunwindstackUnwinder() = default;
 
-  std::vector<unwindstack::FrameData> Unwind(
+  static std::unique_ptr<LibunwindstackUnwinder> Create();
+
+  virtual std::vector<unwindstack::FrameData> Unwind(
       pid_t pid, unwindstack::Maps* maps,
       const std::array<uint64_t, PERF_REG_X86_64_MAX>& perf_regs, const void* stack_dump,
-      uint64_t stack_dump_size);
-
- private:
-  static constexpr size_t MAX_FRAMES = 1024;  // This is arbitrary.
-
-  static const std::array<size_t, unwindstack::X86_64_REG_LAST> UNWINDSTACK_REGS_TO_PERF_REGS;
-
-  static std::string LibunwindstackErrorString(unwindstack::ErrorCode error_code) {
-    static const std::vector<const char*> ERROR_NAMES{
-        "ERROR_NONE",           "ERROR_MEMORY_INVALID", "ERROR_UNWIND_INFO",
-        "ERROR_UNSUPPORTED",    "ERROR_INVALID_MAP",    "ERROR_MAX_FRAMES_EXCEEDED",
-        "ERROR_REPEATED_FRAME", "ERROR_INVALID_ELF"};
-    return ERROR_NAMES[error_code];
-  }
+      uint64_t stack_dump_size) = 0;
 };
 }  // namespace orbit_linux_tracing
 

--- a/src/LinuxTracing/LibunwindstackUnwinder.h
+++ b/src/LinuxTracing/LibunwindstackUnwinder.h
@@ -24,12 +24,12 @@ class LibunwindstackUnwinder {
  public:
   virtual ~LibunwindstackUnwinder() = default;
 
-  static std::unique_ptr<LibunwindstackUnwinder> Create();
-
   virtual std::vector<unwindstack::FrameData> Unwind(
       pid_t pid, unwindstack::Maps* maps,
       const std::array<uint64_t, PERF_REG_X86_64_MAX>& perf_regs, const void* stack_dump,
       uint64_t stack_dump_size) = 0;
+
+  static std::unique_ptr<LibunwindstackUnwinder> Create();
 };
 }  // namespace orbit_linux_tracing
 

--- a/src/LinuxTracing/TracerThread.h
+++ b/src/LinuxTracing/TracerThread.h
@@ -157,6 +157,8 @@ class TracerThread {
   std::atomic<bool> stop_deferred_thread_ = false;
   std::vector<std::unique_ptr<PerfEvent>> deferred_events_;
   std::mutex deferred_events_mutex_;
+  std::unique_ptr<LibunwindstackMaps> maps_;
+  std::unique_ptr<LibunwindstackUnwinder> unwinder_;
   std::unique_ptr<UprobesUnwindingVisitor> uprobes_unwinding_visitor_;
   std::unique_ptr<SwitchesStatesNamesVisitor> switches_states_names_visitor_;
   std::unique_ptr<GpuTracepointVisitor> gpu_event_visitor_;

--- a/src/LinuxTracing/UprobesReturnAddressManagerTest.cpp
+++ b/src/LinuxTracing/UprobesReturnAddressManagerTest.cpp
@@ -13,6 +13,7 @@
 #include <string>
 #include <vector>
 
+#include "LibunwindstackMaps.h"
 #include "LibunwindstackUnwinder.h"
 #include "UprobesReturnAddressManager.h"
 
@@ -481,7 +482,7 @@ const std::string maps_string =
     "7fffffffe000-7ffffffff000 --xp 00000000 00:00 0                          "
     "[uprobes]";
 
-std::unique_ptr<unwindstack::BufferMaps> maps = LibunwindstackUnwinder::ParseMaps(maps_string);
+std::unique_ptr<LibunwindstackMaps> maps = LibunwindstackMaps::ParseMaps(maps_string);
 
 TEST(UprobesReturnAddressManager, CallchainNoUprobes) {
   UprobesReturnAddressManager return_address_manager;
@@ -499,7 +500,7 @@ TEST(UprobesReturnAddressManager, CallchainNoUprobes) {
                                          0x5541D68949564100lu};
 
   EXPECT_TRUE(return_address_manager.PatchCallchain(1, callchain_sample.data(),
-                                                    callchain_sample.size(), maps.get()));
+                                                    callchain_sample.size(), maps->Get()));
   EXPECT_THAT(callchain_sample, testing::ElementsAreArray(expected_callchain));
 }
 
@@ -521,7 +522,7 @@ TEST(UprobesReturnAddressManager, CallchainOneUprobe) {
                                          0x5541D68949564100lu};
 
   EXPECT_TRUE(return_address_manager.PatchCallchain(1, callchain_sample.data(),
-                                                    callchain_sample.size(), maps.get()));
+                                                    callchain_sample.size(), maps->Get()));
   EXPECT_THAT(callchain_sample, testing::ElementsAreArray(expected_callchain));
 }
 
@@ -543,7 +544,7 @@ TEST(UprobesReturnAddressManager, CallchainTwoUprobes) {
                                          0x5541D68949564100lu};
 
   EXPECT_TRUE(return_address_manager.PatchCallchain(1, callchain_sample.data(),
-                                                    callchain_sample.size(), maps.get()));
+                                                    callchain_sample.size(), maps->Get()));
   EXPECT_THAT(callchain_sample, testing::ElementsAreArray(expected_callchain));
 }
 
@@ -559,7 +560,7 @@ TEST(UprobesReturnAddressManager, CallchainTwoUprobesMissingOne) {
                                          0x5541D68949564100lu};
 
   EXPECT_FALSE(return_address_manager.PatchCallchain(1, callchain_sample.data(),
-                                                     callchain_sample.size(), maps.get()));
+                                                     callchain_sample.size(), maps->Get()));
 }
 
 TEST(UprobesReturnAddressManager, CallchainTwoConsecutiveUprobes) {
@@ -582,7 +583,7 @@ TEST(UprobesReturnAddressManager, CallchainTwoConsecutiveUprobes) {
                                          0x5541D68949564100lu};
 
   EXPECT_TRUE(return_address_manager.PatchCallchain(1, callchain_sample.data(),
-                                                    callchain_sample.size(), maps.get()));
+                                                    callchain_sample.size(), maps->Get()));
   EXPECT_THAT(callchain_sample, testing::ElementsAreArray(expected_callchain));
 }
 
@@ -604,7 +605,7 @@ TEST(UprobesReturnAddressManager, CallchainBeforeInjectionByUprobe) {
                                          0x5541D68949564100lu};
 
   EXPECT_TRUE(return_address_manager.PatchCallchain(1, callchain_sample.data(),
-                                                    callchain_sample.size(), maps.get()));
+                                                    callchain_sample.size(), maps->Get()));
   EXPECT_THAT(callchain_sample, testing::ElementsAreArray(expected_callchain));
 }
 
@@ -618,7 +619,7 @@ TEST(UprobesReturnAddressManager, CallchainWithoutUprobeRecord) {
                                          0x5541D68949564100lu};
 
   EXPECT_FALSE(return_address_manager.PatchCallchain(1, callchain_sample.data(),
-                                                     callchain_sample.size(), maps.get()));
+                                                     callchain_sample.size(), maps->Get()));
 }
 
 TEST(UprobesReturnAddressManager, CallchainOfTailcall) {
@@ -638,7 +639,7 @@ TEST(UprobesReturnAddressManager, CallchainOfTailcall) {
                                          0x00007FE90B8B9E0Blu, 0x5541D68949564100lu};
 
   EXPECT_TRUE(return_address_manager.PatchCallchain(1, callchain_sample.data(),
-                                                    callchain_sample.size(), maps.get()));
+                                                    callchain_sample.size(), maps->Get()));
   EXPECT_THAT(callchain_sample, testing::ElementsAreArray(expected_callchain));
 }
 }  // namespace

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -4,7 +4,6 @@
 
 #include "UprobesUnwindingVisitor.h"
 
-#include <absl/container/flat_hash_map.h>
 #include <asm/perf_regs.h>
 #include <llvm/Demangle/Demangle.h>
 #include <sys/mman.h>
@@ -12,7 +11,6 @@
 #include <unwindstack/Unwinder.h>
 
 #include <algorithm>
-#include <array>
 #include <optional>
 #include <utility>
 
@@ -20,7 +18,6 @@
 #include "Function.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
-#include "PerfEventRecords.h"
 #include "capture.pb.h"
 #include "module.pb.h"
 
@@ -42,8 +39,8 @@ void UprobesUnwindingVisitor::visit(StackSamplePerfEvent* event) {
                                       event->GetStackData(), event->GetStackSize());
 
   const std::vector<unwindstack::FrameData>& libunwindstack_callstack =
-      unwinder_.Unwind(event->GetPid(), current_maps_.get(), event->GetRegisters(),
-                       event->GetStackData(), event->GetStackSize());
+      unwinder_->Unwind(event->GetPid(), current_maps_->Get(), event->GetRegisters(),
+                        event->GetStackData(), event->GetStackSize());
 
   // LibunwindstackUnwinder::Unwind signals an unwinding error with an empty callstack.
   if (libunwindstack_callstack.empty()) {
@@ -106,7 +103,7 @@ void UprobesUnwindingVisitor::visit(CallchainSamplePerfEvent* event) {
   //  because rbp hasn't yet been updated to rsp. Drop the sample in this case?
 
   if (!return_address_manager_.PatchCallchain(event->GetTid(), event->GetCallchain(),
-                                              event->GetCallchainSize(), current_maps_.get())) {
+                                              event->GetCallchainSize(), current_maps_->Get())) {
     return;
   }
 

--- a/src/LinuxTracing/UprobesUnwindingVisitor.h
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.h
@@ -17,6 +17,7 @@
 #include <tuple>
 #include <vector>
 
+#include "LibunwindstackMaps.h"
 #include "LibunwindstackUnwinder.h"
 #include "LinuxTracing/TracerListener.h"
 #include "PerfEvent.h"
@@ -44,8 +45,12 @@ namespace orbit_linux_tracing {
 
 class UprobesUnwindingVisitor : public PerfEventVisitor {
  public:
-  explicit UprobesUnwindingVisitor(const std::string& initial_maps)
-      : current_maps_{LibunwindstackUnwinder::ParseMaps(initial_maps)} {}
+  explicit UprobesUnwindingVisitor(LibunwindstackMaps* initial_maps,
+                                   LibunwindstackUnwinder* unwinder)
+      : current_maps_{initial_maps}, unwinder_{unwinder} {
+    CHECK(current_maps_ != nullptr);
+    CHECK(unwinder_ != nullptr);
+  }
 
   UprobesUnwindingVisitor(const UprobesUnwindingVisitor&) = delete;
   UprobesUnwindingVisitor& operator=(const UprobesUnwindingVisitor&) = delete;
@@ -71,8 +76,8 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
  private:
   UprobesFunctionCallManager function_call_manager_{};
   UprobesReturnAddressManager return_address_manager_{};
-  std::unique_ptr<unwindstack::BufferMaps> current_maps_;
-  LibunwindstackUnwinder unwinder_{};
+  LibunwindstackMaps* current_maps_;
+  LibunwindstackUnwinder* unwinder_;
 
   TracerListener* listener_ = nullptr;
 

--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -119,7 +119,13 @@ TEST_F(UprobesUnwindingVisitorTest, VisitValidStackSampleWithoutUprobesEmitsEven
   constexpr uint64_t kStackSize = 13;
   StackSamplePerfEvent event{kStackSize};
   perf_event_sample_id_tid_time_streamid_cpu sample_id{
-      .pid = kPid, .tid = 11, .time = 15, .stream_id = 12, .cpu = 0, .res = 0};
+      .pid = kPid,
+      .tid = 11,
+      .time = 15,
+      .stream_id = 12,
+      .cpu = 0,
+      .res = 0,
+  };
   event.ring_buffer_record->sample_id = sample_id;
 
   EXPECT_CALL(maps_, Get).Times(1).WillOnce(Return(nullptr));
@@ -183,7 +189,13 @@ TEST_F(UprobesUnwindingVisitorTest, VisitInvalidStackSampleWithoutUprobesLeadsTo
   constexpr uint64_t kStackSize = 13;
   StackSamplePerfEvent event{kStackSize};
   perf_event_sample_id_tid_time_streamid_cpu sample_id{
-      .pid = kPid, .tid = 11, .time = 15, .stream_id = 12, .cpu = 0, .res = 0};
+      .pid = kPid,
+      .tid = 11,
+      .time = 15,
+      .stream_id = 12,
+      .cpu = 0,
+      .res = 0,
+  };
   event.ring_buffer_record->sample_id = sample_id;
 
   EXPECT_CALL(maps_, Get).Times(1).WillOnce(Return(nullptr));

--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -132,13 +132,25 @@ TEST_F(UprobesUnwindingVisitorTest, VisitValidStackSampleWithoutUprobesEmitsEven
   std::vector<unwindstack::FrameData> libunwindstack_callstack;
 
   unwindstack::FrameData frame_1{
-      .pc = kTargetAddress1, .function_name = "foo", .function_offset = 0, .map_name = kTargetName};
+      .pc = kTargetAddress1,
+      .function_name = "foo",
+      .function_offset = 0,
+      .map_name = kTargetName,
+  };
   libunwindstack_callstack.push_back(frame_1);
   unwindstack::FrameData frame_2{
-      .pc = kTargetAddress2, .function_name = "bar", .function_offset = 0, .map_name = kTargetName};
+      .pc = kTargetAddress2,
+      .function_name = "bar",
+      .function_offset = 0,
+      .map_name = kTargetName,
+  };
   libunwindstack_callstack.push_back(frame_2);
   unwindstack::FrameData frame_3{
-      .pc = kTargetAddress3, .function_name = "baz", .function_offset = 0, .map_name = kTargetName};
+      .pc = kTargetAddress3,
+      .function_name = "baz",
+      .function_offset = 0,
+      .map_name = kTargetName,
+  };
   libunwindstack_callstack.push_back(frame_3);
   EXPECT_CALL(unwinder_, Unwind(kPid, nullptr, _, _, kStackSize))
       .Times(1)
@@ -232,7 +244,11 @@ TEST_F(UprobesUnwindingVisitorTest,
 
   std::vector<unwindstack::FrameData> incomplete_callstack;
   unwindstack::FrameData frame_1{
-      .pc = kTargetAddress1, .function_name = "foo", .function_offset = 0, .map_name = kTargetName};
+      .pc = kTargetAddress1,
+      .function_name = "foo",
+      .function_offset = 0,
+      .map_name = kTargetName,
+  };
   incomplete_callstack.push_back(frame_1);
 
   EXPECT_CALL(unwinder_, Unwind(kPid, nullptr, _, _, kStackSize))

--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -1,0 +1,211 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <sys/mman.h>
+
+#include "LibunwindstackMaps.h"
+#include "LibunwindstackUnwinder.h"
+#include "UprobesUnwindingVisitor.h"
+
+using ::testing::_;
+using ::testing::AllOf;
+using ::testing::ElementsAre;
+using ::testing::Ge;
+using ::testing::Invoke;
+using ::testing::Lt;
+using ::testing::Property;
+using ::testing::Return;
+using ::testing::SaveArg;
+using ::testing::UnorderedElementsAre;
+
+namespace orbit_linux_tracing {
+
+namespace {
+
+class MockLibunwindstackMaps : public LibunwindstackMaps {
+ public:
+  MOCK_METHOD(unwindstack::MapInfo*, Find, (uint64_t), (override));
+  MOCK_METHOD(unwindstack::Maps*, Get, (), (override));
+  MOCK_METHOD(void, Add, (uint64_t, uint64_t, uint64_t, uint64_t, const std::string&, uint64_t),
+              (override));
+  MOCK_METHOD(void, Sort, (), (override));
+};
+
+class MockLibunwindstackUnwinder : public LibunwindstackUnwinder {
+ public:
+  MOCK_METHOD(std::vector<unwindstack::FrameData>, Unwind,
+              (pid_t, unwindstack::Maps*, (const std::array<uint64_t, PERF_REG_X86_64_MAX>&),
+               const void*, uint64_t),
+              (override));
+};
+
+class MockTracerListener : public TracerListener {
+ public:
+  MOCK_METHOD(void, OnSchedulingSlice, (orbit_grpc_protos::SchedulingSlice), (override));
+  MOCK_METHOD(void, OnCallstackSample, (orbit_grpc_protos::FullCallstackSample), (override));
+  MOCK_METHOD(void, OnFunctionCall, (orbit_grpc_protos::FunctionCall), (override));
+  MOCK_METHOD(void, OnIntrospectionScope, (orbit_grpc_protos::IntrospectionScope), (override));
+  MOCK_METHOD(void, OnGpuJob, (orbit_grpc_protos::FullGpuJob), (override));
+  MOCK_METHOD(void, OnThreadName, (orbit_grpc_protos::ThreadName), (override));
+  MOCK_METHOD(void, OnThreadNamesSnapshot, (orbit_grpc_protos::ThreadNamesSnapshot), (override));
+  MOCK_METHOD(void, OnThreadStateSlice, (orbit_grpc_protos::ThreadStateSlice), (override));
+  MOCK_METHOD(void, OnAddressInfo, (orbit_grpc_protos::FullAddressInfo), (override));
+  MOCK_METHOD(void, OnTracepointEvent, (orbit_grpc_protos::FullTracepointEvent), (override));
+  MOCK_METHOD(void, OnModulesSnapshot, (orbit_grpc_protos::ModulesSnapshot), (override));
+  MOCK_METHOD(void, OnModuleUpdate, (orbit_grpc_protos::ModuleUpdateEvent), (override));
+};
+
+class UprobesUnwindingVisitorTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    visitor_ = std::make_unique<UprobesUnwindingVisitor>(&maps_, &unwinder_);
+    visitor_->SetListener(&listener_);
+
+    EXPECT_CALL(maps_, Find(AllOf(Ge(kUprobesMapsStart), Lt(kUprobesMapsEnd))))
+        .WillRepeatedly(Return(&kUprobesMapInfo));
+
+    EXPECT_CALL(maps_, Find(AllOf(Ge(kTargetMapsStart), Lt(kTargetMapsEnd))))
+        .WillRepeatedly(Return(&kTargetMapInfo));
+
+    EXPECT_CALL(maps_, Find(AllOf(Ge(kNonExecutableMapsStart), Lt(kNonExecutableMapsEnd))))
+        .WillRepeatedly(Return(&non_executable_map_info_));
+  }
+
+  void TearDown() override { visitor_.reset(); }
+
+  MockLibunwindstackMaps maps_;
+  MockLibunwindstackUnwinder unwinder_;
+  MockTracerListener listener_;
+
+  std::unique_ptr<UprobesUnwindingVisitor> visitor_ = nullptr;
+
+  static constexpr uint64_t kUprobesMapsStart = 42;
+  static constexpr uint64_t kUprobesMapsEnd = 84;
+
+  static constexpr uint64_t kTargetMapsStart = 100;
+  static constexpr uint64_t kTargetMapsEnd = 200;
+
+  static constexpr uint64_t kNonExecutableMapsStart = 500;
+  static constexpr uint64_t kNonExecutableMapsEnd = 600;
+
+  static constexpr uint64_t kTargetAddress1 = 100;
+  //  static constexpr uint64_t kUprobesAddress = 42;
+  static constexpr uint64_t kTargetAddress2 = 200;
+  static constexpr uint64_t kTargetAddress3 = 300;
+  //  static constexpr uint64_t kNonExecutableAddress3 = 500;
+
+  static inline const std::string kUprobesName = "[uprobes]";
+  static inline const std::string kTargetName = "target";
+  static inline const std::string kNonExecutableName = "data";
+
+  static inline unwindstack::MapInfo kUprobesMapInfo{
+      nullptr, kUprobesMapsStart, kUprobesMapsEnd, 0, PROT_EXEC | PROT_READ, kUprobesName};
+
+  static inline unwindstack::MapInfo kTargetMapInfo{nullptr, kTargetMapsStart,      kTargetMapsEnd,
+                                                    0,       PROT_EXEC | PROT_READ, kTargetName};
+
+  static inline unwindstack::MapInfo non_executable_map_info_{
+      nullptr, kNonExecutableMapsStart, kNonExecutableMapsEnd,
+      0,       PROT_EXEC | PROT_READ,   kNonExecutableName};
+};
+
+}  // namespace
+
+TEST_F(UprobesUnwindingVisitorTest, VisitValidStackSampleWithoutUprobesEmitsEvents) {
+  constexpr uint32_t kPid = 10;
+  constexpr uint64_t kStackSize = 13;
+  StackSamplePerfEvent event{kStackSize};
+  perf_event_sample_id_tid_time_streamid_cpu sample_id{
+      .pid = kPid, .tid = 11, .time = 15, .stream_id = 12, .cpu = 0, .res = 0};
+  event.ring_buffer_record->sample_id = sample_id;
+
+  EXPECT_CALL(maps_, Get).Times(1).WillOnce(Return(nullptr));
+
+  std::vector<unwindstack::FrameData> libunwindstack_callstack;
+
+  unwindstack::FrameData frame_1{
+      .pc = kTargetAddress1, .function_name = "foo", .function_offset = 0, .map_name = kTargetName};
+  libunwindstack_callstack.push_back(frame_1);
+  unwindstack::FrameData frame_2{
+      .pc = kTargetAddress2, .function_name = "bar", .function_offset = 0, .map_name = kTargetName};
+  libunwindstack_callstack.push_back(frame_2);
+  unwindstack::FrameData frame_3{
+      .pc = kTargetAddress3, .function_name = "baz", .function_offset = 0, .map_name = kTargetName};
+  libunwindstack_callstack.push_back(frame_3);
+  EXPECT_CALL(unwinder_, Unwind(kPid, nullptr, _, _, kStackSize))
+      .Times(1)
+      .WillOnce(Return(libunwindstack_callstack));
+
+  orbit_grpc_protos::FullCallstackSample actual_callstack_sample;
+  EXPECT_CALL(listener_, OnCallstackSample).Times(1).WillOnce(SaveArg<0>(&actual_callstack_sample));
+
+  std::vector<orbit_grpc_protos::FullAddressInfo> actual_address_infos;
+  auto save_address_info =
+      [&actual_address_infos](orbit_grpc_protos::FullAddressInfo actual_address_info) {
+        actual_address_infos.push_back(std::move(actual_address_info));
+      };
+  EXPECT_CALL(listener_, OnAddressInfo).Times(3).WillRepeatedly(Invoke(save_address_info));
+
+  std::atomic<uint64_t> unwinding_errors = 0;
+  std::atomic<uint64_t> discarded_samples_in_uretprobes_counter = 0;
+  visitor_->SetUnwindErrorsAndDiscardedSamplesCounters(&unwinding_errors,
+                                                       &discarded_samples_in_uretprobes_counter);
+
+  visitor_->visit(&event);
+
+  EXPECT_THAT(actual_callstack_sample.callstack().pcs(),
+              ElementsAre(kTargetAddress1, kTargetAddress2, kTargetAddress3));
+  EXPECT_THAT(
+      actual_address_infos,
+      UnorderedElementsAre(
+          AllOf(Property(&orbit_grpc_protos::FullAddressInfo::absolute_address, kTargetAddress1),
+                Property(&orbit_grpc_protos::FullAddressInfo::function_name, "foo"),
+                Property(&orbit_grpc_protos::FullAddressInfo::offset_in_function, 0),
+                Property(&orbit_grpc_protos::FullAddressInfo::module_name, kTargetName)),
+          AllOf(Property(&orbit_grpc_protos::FullAddressInfo::absolute_address, kTargetAddress2),
+                Property(&orbit_grpc_protos::FullAddressInfo::function_name, "bar"),
+                Property(&orbit_grpc_protos::FullAddressInfo::offset_in_function, 0),
+                Property(&orbit_grpc_protos::FullAddressInfo::module_name, kTargetName)),
+          AllOf(Property(&orbit_grpc_protos::FullAddressInfo::absolute_address, kTargetAddress3),
+                Property(&orbit_grpc_protos::FullAddressInfo::function_name, "baz"),
+                Property(&orbit_grpc_protos::FullAddressInfo::offset_in_function, 0),
+                Property(&orbit_grpc_protos::FullAddressInfo::module_name, kTargetName))));
+
+  EXPECT_EQ(unwinding_errors, 0);
+  EXPECT_EQ(discarded_samples_in_uretprobes_counter, 0);
+}
+
+TEST_F(UprobesUnwindingVisitorTest, VisitInvalidStackSampleWithoutUprobesLeadsToUnwindingError) {
+  constexpr uint32_t kPid = 10;
+  constexpr uint64_t kStackSize = 13;
+  StackSamplePerfEvent event{kStackSize};
+  perf_event_sample_id_tid_time_streamid_cpu sample_id{
+      .pid = kPid, .tid = 11, .time = 15, .stream_id = 12, .cpu = 0, .res = 0};
+  event.ring_buffer_record->sample_id = sample_id;
+
+  EXPECT_CALL(maps_, Get).Times(1).WillOnce(Return(nullptr));
+
+  std::vector<unwindstack::FrameData> empty_callstack;
+
+  EXPECT_CALL(unwinder_, Unwind(kPid, nullptr, _, _, kStackSize))
+      .Times(1)
+      .WillOnce(Return(empty_callstack));
+
+  EXPECT_CALL(listener_, OnCallstackSample).Times(0);
+  EXPECT_CALL(listener_, OnAddressInfo).Times(0);
+
+  std::atomic<uint64_t> unwinding_errors = 0;
+  std::atomic<uint64_t> discarded_samples_in_uretprobes_counter = 0;
+  visitor_->SetUnwindErrorsAndDiscardedSamplesCounters(&unwinding_errors,
+                                                       &discarded_samples_in_uretprobes_counter);
+
+  visitor_->visit(&event);
+
+  EXPECT_EQ(unwinding_errors, 1);
+  EXPECT_EQ(discarded_samples_in_uretprobes_counter, 0);
+}
+
+}  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -29,9 +29,8 @@ class MockLibunwindstackMaps : public LibunwindstackMaps {
  public:
   MOCK_METHOD(unwindstack::MapInfo*, Find, (uint64_t), (override));
   MOCK_METHOD(unwindstack::Maps*, Get, (), (override));
-  MOCK_METHOD(void, Add, (uint64_t, uint64_t, uint64_t, uint64_t, const std::string&, uint64_t),
-              (override));
-  MOCK_METHOD(void, Sort, (), (override));
+  MOCK_METHOD(void, AddAndSort,
+              (uint64_t, uint64_t, uint64_t, uint64_t, const std::string&, uint64_t), (override));
 };
 
 class MockLibunwindstackUnwinder : public LibunwindstackUnwinder {


### PR DESCRIPTION
This change allows to exchange the implementation of LibunwindstackUnwinder
and libunwindstack's Maps by mocks in the tests, so that we do not need
to construct actual unwindable stacks and matching maps entries.

Also add the first actual tests demonstrating the usage. More to come though.

Test: Run tests
Bug: http://b/185088047