### PR TITLE
Add "emplace_back" method to BlockChain and TimerChain

### DIFF
--- a/src/OrbitGl/Batcher.cpp
+++ b/src/OrbitGl/Batcher.cpp
@@ -51,7 +51,7 @@ void Batcher::AddLine(Vec2 from, Vec2 to, float z, const Color& color, const Col
   line.end_point = Vec3(floorf(to[0]), floorf(to[1]), z);
   auto& buffer = primitive_buffers_by_layer_[z];
 
-  buffer.line_buffer.lines_.push_back(line);
+  buffer.line_buffer.lines_.emplace_back(line);
   buffer.line_buffer.colors_.push_back_n(color, 2);
   buffer.line_buffer.picking_colors_.push_back_n(picking_color, 2);
   user_data_.push_back(std::move(user_data));
@@ -196,7 +196,7 @@ void Batcher::AddBox(const Box& box, const std::array<Color, 4>& colors, const C
   }
   float layer_z_value = rounded_box.vertices[0][2];
   auto& buffer = primitive_buffers_by_layer_[layer_z_value];
-  buffer.box_buffer.boxes_.push_back(rounded_box);
+  buffer.box_buffer.boxes_.emplace_back(rounded_box);
   buffer.box_buffer.colors_.push_back(colors);
   buffer.box_buffer.picking_colors_.push_back_n(picking_color, 4);
   user_data_.push_back(std::move(user_data));
@@ -250,7 +250,7 @@ void Batcher::AddTriangle(const Triangle& triangle, const std::array<Color, 3>& 
   }
   float layer_z_value = rounded_tri.vertices[0][2];
   auto& buffer = primitive_buffers_by_layer_[layer_z_value];
-  buffer.triangle_buffer.triangles_.push_back(rounded_tri);
+  buffer.triangle_buffer.triangles_.emplace_back(rounded_tri);
   buffer.triangle_buffer.colors_.push_back(colors);
   buffer.triangle_buffer.picking_colors_.push_back_n(picking_color, 3);
   user_data_.push_back(std::move(user_data));

--- a/src/OrbitGl/BlockChainTest.cpp
+++ b/src/OrbitGl/BlockChainTest.cpp
@@ -51,8 +51,8 @@ TEST(BlockChain, AddCopyableTypes) {
 
   BlockChain<CopyableType, 1024> chain;
   EXPECT_EQ(chain.size(), 0);
-  chain.push_back(v1);
-  chain.push_back(v2);
+  chain.emplace_back(v1);
+  chain.emplace_back(v2);
   EXPECT_EQ(chain.size(), 2);
 
   v1.set_value("new v1");
@@ -63,7 +63,7 @@ TEST(BlockChain, AddCopyableTypes) {
 
   // Multi-block test
   for (int i = 0; i < 2000; ++i) {
-    chain.push_back(v1);
+    chain.emplace_back(v1);
   }
   EXPECT_EQ(chain.size(), 2002);
 }
@@ -73,18 +73,18 @@ TEST(BlockChain, Clear) {
   const std::string v2 = "or not";
 
   BlockChain<std::string, 1024> chain;
-  chain.push_back(v1);
+  chain.emplace_back(v1);
   EXPECT_GT(chain.size(), 0);
   chain.clear();
   EXPECT_EQ(chain.size(), 0);
 
-  chain.push_back(v2);
+  chain.emplace_back(v2);
   EXPECT_GT(chain.size(), 0);
   EXPECT_EQ(chain.root()->data()[0], v2);
 
   // Multi-block test
   for (int i = 0; i < 2000; ++i) {
-    chain.push_back(v1);
+    chain.emplace_back(v1);
   }
   chain.clear();
   EXPECT_EQ(chain.size(), 0);
@@ -97,9 +97,9 @@ TEST(BlockChain, ElementIteration) {
 
   BlockChain<int, 1024> chain;
 
-  chain.push_back(v1);
-  chain.push_back(v2);
-  chain.push_back(v3);
+  chain.emplace_back(v1);
+  chain.emplace_back(v2);
+  chain.emplace_back(v3);
 
   // Note that only the "++it" operator is supported
   auto it = chain.begin();
@@ -122,7 +122,7 @@ TEST(BlockChain, ElementIteration) {
   // Multi-block test
   chain.clear();
   for (int i = 0; i < 2000; ++i) {
-    chain.push_back(i);
+    chain.emplace_back(i);
   }
   it_count = 0;
 
@@ -197,8 +197,8 @@ TEST(BlockChain, Reset) {
 TEST(BlockChain, MovableType) {
   BlockChain<MovableType, 1024> chain;
   EXPECT_EQ(chain.size(), 0);
-  chain.push_back(MovableType("v1"));
-  chain.push_back(MovableType("v2"));
+  chain.emplace_back(MovableType("v1"));
+  chain.emplace_back(MovableType("v2"));
   EXPECT_EQ(chain.size(), 2);
 
   EXPECT_EQ(chain.root()->data()[0].value(), "v1");

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -203,9 +203,8 @@ void GraphTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
     timers_[kDepth] = timer_chain;
   }
 
-  TextBox text_box(Vec2(0, 0), Vec2(0, 0), "");
+  TextBox& text_box = timer_chain->emplace_back();
   text_box.SetTimerInfo(timer_info);
-  timer_chain->push_back(text_box);
 }
 
 std::vector<std::shared_ptr<TimerChain>> GraphTrack::GetAllChains() const {

--- a/src/OrbitGl/ScopeTree.h
+++ b/src/OrbitGl/ScopeTree.h
@@ -100,9 +100,8 @@ ScopeTree<ScopeT>::ScopeTree() {
 
 template <typename ScopeT>
 ScopeNode<ScopeT>* ScopeTree<ScopeT>::CreateNode(ScopeT* scope) {
-  nodes_.push_back(ScopeNodeT(scope));
-  ScopeNodeT* node = nodes_.Last();
-  return node;
+  ScopeNode<ScopeT>& new_node = nodes_.emplace_back(ScopeNodeT(scope));
+  return &new_node;
 }
 
 template <typename ScopeT>

--- a/src/OrbitGl/TextBox.h
+++ b/src/OrbitGl/TextBox.h
@@ -14,7 +14,7 @@ class TextRenderer;
 
 class TextBox {
  public:
-  TextBox() : pos_(Vec2::Zero()), size_(Vec2(100.f, 10.f)) {}
+  TextBox() : pos_(Vec2::Zero()), size_(Vec2::Zero()) {}
   TextBox(const Vec2& pos, const Vec2& size, std::string text = "")
       : pos_(pos), size_(size), text_(std::move(text)) {}
 

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -436,7 +436,7 @@ void ThreadTrack::OnTimer(const TimerInfo& timer_info) {
   }
 
   // Thread tracks use a ScopeTree so we don't need to create one TimerChain per depth.
-  // Allocate a single TimerChain into which all timers will.
+  // Allocate a single TimerChain into which all timers will be appended.
   std::shared_ptr<TimerChain>& timer_chain = timers_[0];
   if (timer_chain == nullptr) {
     timer_chain = std::make_shared<TimerChain>();

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -82,6 +82,7 @@ class ThreadTrack final : public TimerTrack {
 
   absl::Mutex scope_tree_mutex_;
   ScopeTree<TextBox> scope_tree_;
+  TimerChain* timer_chain_;
 };
 
 #endif  // ORBIT_GL_THREAD_TRACK_H_

--- a/src/OrbitGl/TimerChain.cpp
+++ b/src/OrbitGl/TimerChain.cpp
@@ -9,26 +9,6 @@
 #include "OrbitBase/Logging.h"
 #include "capture_data.pb.h"
 
-void TimerBlock::Add(const TextBox& item) {
-  if (size_ == kBlockSize) {
-    if (next_ == nullptr) {
-      next_ = new TimerBlock(chain_, this);
-    }
-
-    chain_->current_ = next_;
-    ++chain_->num_blocks_;
-    next_->Add(item);
-    return;
-  }
-
-  CHECK(size_ < kBlockSize);
-  data_[size_] = item;
-  ++size_;
-  ++chain_->num_items_;
-  min_timestamp_ = std::min(item.GetTimerInfo().start(), min_timestamp_);
-  max_timestamp_ = std::max(item.GetTimerInfo().end(), max_timestamp_);
-}
-
 bool TimerBlock::Intersects(uint64_t min, uint64_t max) const {
   return (min <= max_timestamp_ && max >= min_timestamp_);
 }

--- a/src/OrbitGl/TimerInfosIteratorTest.cpp
+++ b/src/OrbitGl/TimerInfosIteratorTest.cpp
@@ -28,8 +28,8 @@ TEST(TimerInfosIterator, Access) {
   // Need to set the end, as SetTimerInfo will refuse that timer otherwise.
   timer.set_end(1);
   box.SetTimerInfo(timer);
-  chain->push_back(box);
-  chains.push_back(chain);
+  chain->emplace_back(box);
+  chains.emplace_back(chain);
 
   // Just validate setting worked as expected
   EXPECT_EQ(1, timer.function_id());
@@ -50,8 +50,8 @@ TEST(TimerInfosIterator, Copy) {
   // Need to set the end, as SetTimerInfo will refuse that timer otherwise.
   timer.set_end(1);
   box.SetTimerInfo(timer);
-  chain->push_back(box);
-  chains.push_back(chain);
+  chain->emplace_back(box);
+  chains.emplace_back(chain);
 
   // Now create an iterator and test to access it
   TimerInfosIterator it(chains.begin(), chains.end());
@@ -83,8 +83,8 @@ TEST(TimerInfosIterator, Move) {
   // Need to set the end, as SetTimerInfo will refuse that timer otherwise.
   timer.set_end(1);
   box.SetTimerInfo(timer);
-  chain->push_back(box);
-  chains.push_back(chain);
+  chain->emplace_back(box);
+  chains.emplace_back(chain);
 
   // Now create an iterator and test to access it
   TimerInfosIterator it(chains.begin(), chains.end());
@@ -107,8 +107,8 @@ TEST(TimerInfosIterator, Equality) {
   timer.set_function_id(1);
   timer.set_end(1);
   box.SetTimerInfo(timer);
-  chain->push_back(box);
-  chains.push_back(chain);
+  chain->emplace_back(box);
+  chains.emplace_back(chain);
 
   // Now create an iterators and test equality
   TimerInfosIterator it1(chains.begin(), chains.end());
@@ -136,7 +136,7 @@ TEST(TimerInfosIterator, ForEachEmpty) {
 
   std::vector<uint64_t> result;
   for (auto it = it_begin; it != it_end; ++it) {
-    result.push_back(it->function_id());
+    result.emplace_back(it->function_id());
   }
   EXPECT_THAT(result, testing::ElementsAre());
 }
@@ -159,12 +159,12 @@ TEST(TimerInfosIterator, ForEachLarge) {
       timer.set_start(count);
       timer.set_end(count + 1);
       box.SetTimerInfo(timer);
-      chain->push_back(box);
-      expected.push_back(count);
+      chain->emplace_back(box);
+      expected.emplace_back(count);
       ++count;
     }
     max_timers *= 2;
-    chains.push_back(chain);
+    chains.emplace_back(chain);
   }
 
   TimerInfosIterator it_begin(chains.begin(), chains.end());
@@ -172,7 +172,7 @@ TEST(TimerInfosIterator, ForEachLarge) {
 
   std::vector<uint64_t> result;
   for (auto it = it_begin; it != it_end; ++it) {
-    result.push_back(it->function_id());
+    result.emplace_back(it->function_id());
   }
   EXPECT_THAT(result, testing::ElementsAreArray(expected));
 }

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -323,15 +323,14 @@ void TimerTrack::OnTimer(const TimerInfo& timer_info) {
     process_id_ = timer_info.process_id();
   }
 
-  TextBox text_box(Vec2(0, 0), Vec2(0, 0), "");
-  text_box.SetTimerInfo(timer_info);
-
   std::shared_ptr<TimerChain> timer_chain = timers_[timer_info.depth()];
   if (timer_chain == nullptr) {
     timer_chain = std::make_shared<TimerChain>();
     timers_[timer_info.depth()] = timer_chain;
   }
-  timer_chain->push_back(text_box);
+
+  TextBox& text_box = timer_chain->emplace_back();
+  text_box.SetTimerInfo(timer_info);
 
   ++num_timers_;
   if (timer_info.start() < min_time_) min_time_ = timer_info.start();


### PR DESCRIPTION
Remove "Add", "push_back" and "Last" in favor or "emplace_back" which
uses placement-new to avoid unnacessary copies when appending to
chains. Note that "emplace_back" returns a reference to the newly
appended element, which makes "Last" obsolete.