### PR TITLE
Fixes to GPU-related tooltips

### DIFF
--- a/src/OrbitGl/GpuDebugMarkerTrack.cpp
+++ b/src/OrbitGl/GpuDebugMarkerTrack.cpp
@@ -95,7 +95,7 @@ void GpuDebugMarkerTrack::SetTimesliceText(const TimerInfo& timer_info, float mi
 
 std::string GpuDebugMarkerTrack::GetBoxTooltip(const Batcher& batcher, PickingId id) const {
   const TextBox* text_box = batcher.GetTextBox(id);
-  if (text_box != nullptr) {
+  if (text_box == nullptr) {
     return "";
   }
 

--- a/src/OrbitGl/GpuDebugMarkerTrack.cpp
+++ b/src/OrbitGl/GpuDebugMarkerTrack.cpp
@@ -111,10 +111,11 @@ std::string GpuDebugMarkerTrack::GetBoxTooltip(const Batcher& batcher, PickingId
       "<br/>"
       "<br/>"
       "<b>Marker text:</b> %s<br/>"
+      "<b>Submitted from process:</b> %s [%d]<br/>"
       "<b>Submitted from thread:</b> %s [%d]<br/>"
       "<b>Time:</b> %s",
-      marker_text, app_->GetCaptureData().GetThreadName(timer_info.thread_id()),
-      timer_info.thread_id(),
+      marker_text, capture_data_->GetThreadName(timer_info.process_id()), timer_info.process_id(),
+      capture_data_->GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
       GetPrettyTime(TicksToDuration(timer_info.start(), timer_info.end())).c_str());
 }
 

--- a/src/OrbitGl/GpuSubmissionTrack.cpp
+++ b/src/OrbitGl/GpuSubmissionTrack.cpp
@@ -251,8 +251,10 @@ std::string GpuSubmissionTrack::GetSwQueueTooltip(const TimerInfo& timer_info) c
       "amdgpu_sched_run_job (job scheduled)</i>"
       "<br/>"
       "<br/>"
+      "<b>Submitted from process:</b> %s [%d]<br/>"
       "<b>Submitted from thread:</b> %s [%d]<br/>"
       "<b>Time:</b> %s",
+      capture_data_->GetThreadName(timer_info.process_id()), timer_info.process_id(),
       capture_data_->GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
       GetPrettyTime(TicksToDuration(timer_info.start(), timer_info.end())).c_str());
 }
@@ -264,8 +266,10 @@ std::string GpuSubmissionTrack::GetHwQueueTooltip(const TimerInfo& timer_info) c
       "(job scheduled) and start of GPU execution</i>"
       "<br/>"
       "<br/>"
+      "<b>Submitted from process:</b> %s [%d]<br/>"
       "<b>Submitted from thread:</b> %s [%d]<br/>"
       "<b>Time:</b> %s",
+      capture_data_->GetThreadName(timer_info.process_id()), timer_info.process_id(),
       capture_data_->GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
       GetPrettyTime(TicksToDuration(timer_info.start(), timer_info.end())).c_str());
 }
@@ -278,8 +282,10 @@ std::string GpuSubmissionTrack::GetHwExecutionTooltip(const TimerInfo& timer_inf
       "buffer submission</i>"
       "<br/>"
       "<br/>"
+      "<b>Submitted from process:</b> %s [%d]<br/>"
       "<b>Submitted from thread:</b> %s [%d]<br/>"
       "<b>Time:</b> %s",
+      capture_data_->GetThreadName(timer_info.process_id()), timer_info.process_id(),
       capture_data_->GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
       GetPrettyTime(TicksToDuration(timer_info.start(), timer_info.end())).c_str());
 }
@@ -293,8 +299,10 @@ std::string GpuSubmissionTrack::GetCommandBufferTooltip(
       "submission.</i>"
       "<br/>"
       "<br/>"
+      "<b>Submitted from process:</b> %s [%d]<br/>"
       "<b>Submitted from thread:</b> %s [%d]<br/>"
       "<b>Time:</b> %s",
-      app_->GetCaptureData().GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
+      capture_data_->GetThreadName(timer_info.process_id()), timer_info.process_id(),
+      capture_data_->GetThreadName(timer_info.thread_id()), timer_info.thread_id(),
       GetPrettyTime(TicksToDuration(timer_info.start(), timer_info.end())).c_str());
 }


### PR DESCRIPTION
#### Re-add "Submitted from process" in GpuSubmissionTrack
And add it to `GpuDebugMarkerTrack`.
It was removed by 492c5e7 but I'm not sure why.

Bug: http://b/188185866

Test: Capture Trata with the Vulkan layer, check tooltips.
#### Fix showing tooltips of GpuDebugMarkerTrack 
Bug: http://b/188187889

Test: Capture Trata with the Vulkan layer, check tooltips.