### PR TITLE
Make OpenDisassembly a main window member function

### DIFF
--- a/src/CodeViewer/OwningDialog.cpp
+++ b/src/CodeViewer/OwningDialog.cpp
@@ -26,10 +26,10 @@ void OwningDialog::ClearOwningHeatmap() {
   code_report_.reset();
 }
 
-void OpenAndDeleteOnClose(std::unique_ptr<OwningDialog> dialog) {
+QPointer<OwningDialog> OpenAndDeleteOnClose(std::unique_ptr<OwningDialog> dialog) {
   dialog->open();
   dialog->setAttribute(Qt::WA_DeleteOnClose);
-  (void)dialog.release();
+  return QPointer{dialog.release()};
 }
 
 }  // namespace orbit_code_viewer

--- a/src/CodeViewer/include/CodeViewer/OwningDialog.h
+++ b/src/CodeViewer/include/CodeViewer/OwningDialog.h
@@ -5,6 +5,7 @@
 #ifndef CODE_VIEWER_OWNING_DIALOG_H_
 #define CODE_VIEWER_OWNING_DIALOG_H_
 
+#include <QPointer>
 #include <memory>
 #include <optional>
 #include <variant>
@@ -43,7 +44,7 @@ class OwningDialog : public Dialog {
 // This function opens the given dialog and ensures it is deleted when closed.
 // Note, this function returns immediately after opening the dialog, NOT when it is closed. Use
 // `QDialog::exec` to wait for the dialog.
-void OpenAndDeleteOnClose(std::unique_ptr<OwningDialog> dialog);
+QPointer<OwningDialog> OpenAndDeleteOnClose(std::unique_ptr<OwningDialog> dialog);
 }  // namespace orbit_code_viewer
 
 #endif  // CODE_VIEWER_OWNING_DIALOG_H_

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1305,8 +1305,7 @@ bool OrbitApp::IsDevMode() const { return absl::GetFlag(FLAGS_devmode); }
 void OrbitApp::SendDisassemblyToUi(std::string disassembly, DisassemblyReport report) {
   main_thread_executor_->Schedule(
       [this, disassembly = std::move(disassembly), report = std::move(report)]() mutable {
-        CHECK(disassembly_callback_);
-        disassembly_callback_(std::move(disassembly), std::move(report));
+        main_window_->ShowDisassembly(disassembly, std::move(report));
       });
 }
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -232,10 +232,6 @@ class OrbitApp final : public DataViewFactory, public orbit_capture_client::Capt
   void SetSelectLiveTabCallback(SelectLiveTabCallback callback) {
     select_live_tab_callback_ = std::move(callback);
   }
-  using DisassemblyCallback = std::function<void(std::string, DisassemblyReport)>;
-  void SetDisassemblyCallback(DisassemblyCallback callback) {
-    disassembly_callback_ = std::move(callback);
-  }
   using ErrorMessageCallback = std::function<void(const std::string&, const std::string&)>;
   void SetErrorMessageCallback(ErrorMessageCallback callback) {
     error_message_callback_ = std::move(callback);
@@ -499,7 +495,6 @@ class OrbitApp final : public DataViewFactory, public orbit_capture_client::Capt
   CaptureFailedCallback capture_failed_callback_;
   CaptureClearedCallback capture_cleared_callback_;
   SelectLiveTabCallback select_live_tab_callback_;
-  DisassemblyCallback disassembly_callback_;
   ErrorMessageCallback error_message_callback_;
   WarningMessageCallback warning_message_callback_;
   InfoMessageCallback info_message_callback_;

--- a/src/OrbitGl/MainWindowInterface.h
+++ b/src/OrbitGl/MainWindowInterface.h
@@ -12,6 +12,7 @@
 #include <string_view>
 
 #include "CodeReport.h"
+#include "DisassemblyReport.h"
 
 namespace orbit_gl {
 
@@ -25,6 +26,7 @@ class MainWindowInterface {
   virtual void ShowTooltip(std::string_view message) = 0;
   virtual void ShowSourceCode(const std::filesystem::path& file_path, size_t line_number,
                               std::optional<std::unique_ptr<CodeReport>> code_report) = 0;
+  virtual void ShowDisassembly(const std::string& assembly, DisassemblyReport report) = 0;
 
   virtual ~MainWindowInterface() = default;
 };

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -270,7 +270,7 @@ void OrbitMainWindow::SetupMainWindow() {
 
   app_->SetSelectLiveTabCallback([this] { ui->RightTabWidget->setCurrentWidget(ui->liveTab); });
   app_->SetDisassemblyCallback([this](const std::string& assembly, DisassemblyReport report) {
-    OpenDisassembly(assembly, std::move(report));
+    ShowDisassembly(assembly, std::move(report));
   });
   app_->SetErrorMessageCallback([this](const std::string& title, const std::string& text) {
     QMessageBox::critical(this, QString::fromStdString(title), QString::fromStdString(text));
@@ -1476,7 +1476,7 @@ void OrbitMainWindow::ShowSourceCode(const std::filesystem::path& file_path, siz
   orbit_code_viewer::OpenAndDeleteOnClose(std::move(code_viewer_dialog));
 }
 
-void OrbitMainWindow::OpenDisassembly(const std::string& assembly, DisassemblyReport report) {
+void OrbitMainWindow::ShowDisassembly(const std::string& assembly, DisassemblyReport report) {
   auto dialog = std::make_unique<orbit_code_viewer::OwningDialog>();
   dialog->setWindowTitle("Orbit Disassembly");
   dialog->SetLineNumberTypes(orbit_code_viewer::Dialog::LineNumberTypes::kOnlyMainContent);

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -138,8 +138,6 @@ constexpr int kHintFramePosX = 21;
 constexpr int kHintFramePosY = 47;
 constexpr int kHintFrameWidth = 140;
 constexpr int kHintFrameHeight = 45;
-
-void OpenDisassembly(const std::string& assembly, DisassemblyReport report);
 }  // namespace
 
 OrbitMainWindow::OrbitMainWindow(orbit_qt::TargetConfiguration target_configuration,
@@ -271,7 +269,9 @@ void OrbitMainWindow::SetupMainWindow() {
       });
 
   app_->SetSelectLiveTabCallback([this] { ui->RightTabWidget->setCurrentWidget(ui->liveTab); });
-  app_->SetDisassemblyCallback(&OpenDisassembly);
+  app_->SetDisassemblyCallback([this](const std::string& assembly, DisassemblyReport report) {
+    OpenDisassembly(assembly, std::move(report));
+  });
   app_->SetErrorMessageCallback([this](const std::string& title, const std::string& text) {
     QMessageBox::critical(this, QString::fromStdString(title), QString::fromStdString(text));
   });
@@ -1476,8 +1476,7 @@ void OrbitMainWindow::ShowSourceCode(const std::filesystem::path& file_path, siz
   orbit_code_viewer::OpenAndDeleteOnClose(std::move(code_viewer_dialog));
 }
 
-namespace {
-void OpenDisassembly(const std::string& assembly, DisassemblyReport report) {
+void OrbitMainWindow::OpenDisassembly(const std::string& assembly, DisassemblyReport report) {
   auto dialog = std::make_unique<orbit_code_viewer::OwningDialog>();
   dialog->setWindowTitle("Orbit Disassembly");
   dialog->SetLineNumberTypes(orbit_code_viewer::Dialog::LineNumberTypes::kOnlyMainContent);
@@ -1495,4 +1494,3 @@ void OpenDisassembly(const std::string& assembly, DisassemblyReport report) {
 
   orbit_code_viewer::OpenAndDeleteOnClose(std::move(dialog));
 }
-}  // namespace

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -139,24 +139,7 @@ constexpr int kHintFramePosY = 47;
 constexpr int kHintFrameWidth = 140;
 constexpr int kHintFrameHeight = 45;
 
-void OpenDisassembly(const std::string& assembly, DisassemblyReport report) {
-  auto dialog = std::make_unique<orbit_code_viewer::OwningDialog>();
-  dialog->setWindowTitle("Orbit Disassembly");
-  dialog->SetLineNumberTypes(orbit_code_viewer::Dialog::LineNumberTypes::kOnlyMainContent);
-  dialog->SetHighlightCurrentLine(true);
-
-  auto syntax_highlighter = std::make_unique<orbit_syntax_highlighter::X86Assembly>();
-  dialog->SetMainContent(QString::fromStdString(assembly), std::move(syntax_highlighter));
-
-  if (report.GetNumSamples() > 0) {
-    constexpr orbit_code_viewer::FontSizeInEm kHeatmapAreaWidth{1.3f};
-    dialog->SetOwningHeatmap(kHeatmapAreaWidth,
-                             std::make_unique<DisassemblyReport>(std::move(report)));
-    dialog->SetEnableSampleCounters(true);
-  }
-
-  orbit_code_viewer::OpenAndDeleteOnClose(std::move(dialog));
-}
+void OpenDisassembly(const std::string& assembly, DisassemblyReport report);
 }  // namespace
 
 OrbitMainWindow::OrbitMainWindow(orbit_qt::TargetConfiguration target_configuration,
@@ -1492,3 +1475,24 @@ void OrbitMainWindow::ShowSourceCode(const std::filesystem::path& file_path, siz
   code_viewer_dialog->GoToLineNumber(line_number);
   orbit_code_viewer::OpenAndDeleteOnClose(std::move(code_viewer_dialog));
 }
+
+namespace {
+void OpenDisassembly(const std::string& assembly, DisassemblyReport report) {
+  auto dialog = std::make_unique<orbit_code_viewer::OwningDialog>();
+  dialog->setWindowTitle("Orbit Disassembly");
+  dialog->SetLineNumberTypes(orbit_code_viewer::Dialog::LineNumberTypes::kOnlyMainContent);
+  dialog->SetHighlightCurrentLine(true);
+
+  auto syntax_highlighter = std::make_unique<orbit_syntax_highlighter::X86Assembly>();
+  dialog->SetMainContent(QString::fromStdString(assembly), std::move(syntax_highlighter));
+
+  if (report.GetNumSamples() > 0) {
+    constexpr orbit_code_viewer::FontSizeInEm kHeatmapAreaWidth{1.3f};
+    dialog->SetOwningHeatmap(kHeatmapAreaWidth,
+                             std::make_unique<DisassemblyReport>(std::move(report)));
+    dialog->SetEnableSampleCounters(true);
+  }
+
+  orbit_code_viewer::OpenAndDeleteOnClose(std::move(dialog));
+}
+}  // namespace

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -269,9 +269,6 @@ void OrbitMainWindow::SetupMainWindow() {
       });
 
   app_->SetSelectLiveTabCallback([this] { ui->RightTabWidget->setCurrentWidget(ui->liveTab); });
-  app_->SetDisassemblyCallback([this](const std::string& assembly, DisassemblyReport report) {
-    ShowDisassembly(assembly, std::move(report));
-  });
   app_->SetErrorMessageCallback([this](const std::string& title, const std::string& text) {
     QMessageBox::critical(this, QString::fromStdString(title), QString::fromStdString(text));
   });

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -101,6 +101,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   void ShowTooltip(std::string_view message) override;
   void ShowSourceCode(const std::filesystem::path& file_path, size_t line_number,
                       std::optional<std::unique_ptr<CodeReport>> maybe_code_report) override;
+  void OpenDisassembly(const std::string& assembly, DisassemblyReport report);
 
  protected:
   void closeEvent(QCloseEvent* event) override;

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -101,7 +101,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   void ShowTooltip(std::string_view message) override;
   void ShowSourceCode(const std::filesystem::path& file_path, size_t line_number,
                       std::optional<std::unique_ptr<CodeReport>> maybe_code_report) override;
-  void OpenDisassembly(const std::string& assembly, DisassemblyReport report);
+  void ShowDisassembly(const std::string& assembly, DisassemblyReport report);
 
  protected:
   void closeEvent(QCloseEvent* event) override;

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -101,7 +101,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   void ShowTooltip(std::string_view message) override;
   void ShowSourceCode(const std::filesystem::path& file_path, size_t line_number,
                       std::optional<std::unique_ptr<CodeReport>> maybe_code_report) override;
-  void ShowDisassembly(const std::string& assembly, DisassemblyReport report);
+  void ShowDisassembly(const std::string& assembly, DisassemblyReport report) override;
 
  protected:
   void closeEvent(QCloseEvent* event) override;


### PR DESCRIPTION
This is mainly moving code around in preparation of the combined source code view.

No functional changes in here.