### PR TITLE
Extend DisassemblyReport

### DIFF
--- a/src/CodeReport/Disassembler.cpp
+++ b/src/CodeReport/Disassembler.cpp
@@ -59,10 +59,18 @@ uint64_t Disassembler::GetAddressAtLine(size_t line) const {
   return line_to_address_[line];
 }
 
-void Disassembler::AddLine(std::string line, uint64_t address) {
+std::optional<size_t> Disassembler::GetLineAtAddress(uint64_t address) const {
+  const auto it = address_to_line_.find(address);
+  if (it == address_to_line_.end()) return std::nullopt;
+  return it->second;
+}
+
+void Disassembler::AddLine(std::string line, std::optional<uint64_t> address) {
+  if (address.has_value()) address_to_line_[*address] = line_to_address_.size();
+  line_to_address_.push_back(address.value_or(0ul));
+
   // Remove any new line character.
   line = absl::StrReplaceAll(line, {{"\n", ""}});
-  line_to_address_.push_back(address);
   result_ += absl::StrFormat("%s\n", line);
 }
 }  // namespace orbit_code_report

--- a/src/CodeReport/DisassemblerTest.cpp
+++ b/src/CodeReport/DisassemblerTest.cpp
@@ -69,4 +69,12 @@ TEST(Disassembler, Disassemble) {
   EXPECT_EQ(disassembler.GetAddressAtLine(28), 0);
   EXPECT_EQ(disassembler.GetAddressAtLine(29), 0);  // 29 is the first invalid line index.
   EXPECT_EQ(disassembler.GetAddressAtLine(1024), 0);
+
+  EXPECT_FALSE(disassembler.GetLineAtAddress(0x0).has_value());
+  EXPECT_FALSE(disassembler.GetLineAtAddress(0x40102c).has_value());
+  EXPECT_EQ(disassembler.GetLineAtAddress(0x40102d).value_or(0), 4);
+  EXPECT_EQ(disassembler.GetLineAtAddress(0x40103b).value_or(0), 12);
+  EXPECT_EQ(disassembler.GetLineAtAddress(0x401057).value_or(0), 24);
+  EXPECT_FALSE(disassembler.GetLineAtAddress(0x4010ff).has_value());
+  EXPECT_FALSE(disassembler.GetLineAtAddress(0x0).has_value());
 }

--- a/src/CodeReport/DisassemblyReport.cpp
+++ b/src/CodeReport/DisassemblyReport.cpp
@@ -46,4 +46,7 @@ std::optional<uint32_t> DisassemblyReport::GetNumSamplesAtLine(size_t line) cons
   return count;
 }
 
+std::optional<size_t> DisassemblyReport::GetLineAtAddress(uint64_t address) const {
+  return disasm_.GetLineAtAddress(address);
+}
 }  // namespace orbit_code_report

--- a/src/CodeReport/include/CodeReport/Disassembler.h
+++ b/src/CodeReport/include/CodeReport/Disassembler.h
@@ -8,22 +8,26 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <optional>
 #include <string>
 #include <vector>
 
-#include "absl/strings/str_format.h"
+#include "absl/container/flat_hash_map.h"
 
 namespace orbit_code_report {
 class Disassembler {
  public:
   void Disassemble(const void* machine_code, size_t size, uint64_t address, bool is_64bit);
-  void AddLine(std::string, uint64_t address = 0);
+  void AddLine(std::string, std::optional<uint64_t> address = std::nullopt);
+
   [[nodiscard]] const std::string& GetResult() const { return result_; }
   [[nodiscard]] uint64_t GetAddressAtLine(size_t line) const;
+  [[nodiscard]] std::optional<size_t> GetLineAtAddress(uint64_t address) const;
 
  private:
   std::string result_;
   std::vector<uint64_t> line_to_address_;
+  absl::flat_hash_map<uint64_t, size_t> address_to_line_;
 };
 }  // namespace orbit_code_report
 

--- a/src/CodeReport/include/CodeReport/DisassemblyReport.h
+++ b/src/CodeReport/include/CodeReport/DisassemblyReport.h
@@ -18,16 +18,21 @@
 namespace orbit_code_report {
 class DisassemblyReport : public orbit_code_report::CodeReport {
  public:
-  DisassemblyReport(Disassembler disasm, uint64_t function_address,
+  DisassemblyReport(Disassembler disasm, uint64_t absolute_function_address,
                     orbit_client_data::PostProcessedSamplingData post_processed_sampling_data,
                     uint32_t samples_count)
       : disasm_{std::move(disasm)},
         post_processed_sampling_data_{std::move(post_processed_sampling_data)},
-        function_count_{post_processed_sampling_data_->GetCountOfFunction(function_address)},
-        samples_count_(samples_count) {}
+        function_count_{
+            post_processed_sampling_data_->GetCountOfFunction(absolute_function_address)},
+        samples_count_(samples_count),
+        absolute_function_address_{absolute_function_address} {}
 
-  explicit DisassemblyReport(Disassembler disasm)
-      : disasm_{std::move(disasm)}, function_count_{0}, samples_count_{0} {};
+  explicit DisassemblyReport(Disassembler disasm, uint64_t absolute_function_address)
+      : disasm_{std::move(disasm)},
+        function_count_{0},
+        samples_count_{0},
+        absolute_function_address_{absolute_function_address} {};
 
   [[nodiscard]] uint32_t GetNumSamplesInFunction() const override { return function_count_; }
   [[nodiscard]] uint32_t GetNumSamples() const override { return samples_count_; }
@@ -35,11 +40,14 @@ class DisassemblyReport : public orbit_code_report::CodeReport {
 
   [[nodiscard]] std::optional<size_t> GetLineAtAddress(uint64_t address) const;
 
+  [[nodiscard]] uint64_t GetAbsoluteFunctionAddress() const { return absolute_function_address_; }
+
  private:
   Disassembler disasm_;
   std::optional<orbit_client_data::PostProcessedSamplingData> post_processed_sampling_data_;
   uint32_t function_count_;
   uint32_t samples_count_;
+  uint64_t absolute_function_address_;
 };
 
 }  // namespace orbit_code_report

--- a/src/CodeReport/include/CodeReport/DisassemblyReport.h
+++ b/src/CodeReport/include/CodeReport/DisassemblyReport.h
@@ -33,6 +33,8 @@ class DisassemblyReport : public orbit_code_report::CodeReport {
   [[nodiscard]] uint32_t GetNumSamples() const override { return samples_count_; }
   [[nodiscard]] std::optional<uint32_t> GetNumSamplesAtLine(size_t line) const override;
 
+  [[nodiscard]] std::optional<size_t> GetLineAtAddress(uint64_t address) const;
+
  private:
   Disassembler disasm_;
   std::optional<orbit_client_data::PostProcessedSamplingData> post_processed_sampling_data_;

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -663,7 +663,7 @@ void OrbitApp::Disassemble(int32_t pid, const FunctionInfo& function) {
                                    orbit_client_data::function_utils::GetDisplayName(function)));
     disasm.Disassemble(memory.data(), memory.size(), absolute_address, is_64_bit);
     if (!HasCaptureData() || !GetCaptureData().has_post_processed_sampling_data()) {
-      orbit_code_report::DisassemblyReport empty_report(disasm);
+      orbit_code_report::DisassemblyReport empty_report(disasm, absolute_address);
       SendDisassemblyToUi(function, disasm.GetResult(), std::move(empty_report));
       return;
     }

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -295,7 +295,8 @@ class OrbitApp final : public DataViewFactory, public orbit_capture_client::Capt
 
   void SetStatusListener(StatusListener* listener) { status_listener_ = listener; }
 
-  void SendDisassemblyToUi(std::string disassembly, orbit_code_report::DisassemblyReport report);
+  void SendDisassemblyToUi(const orbit_client_protos::FunctionInfo& function_info,
+                           std::string disassembly, orbit_code_report::DisassemblyReport report);
   void SendTooltipToUi(const std::string& tooltip);
   void SendInfoToUi(const std::string& title, const std::string& text);
   void SendWarningToUi(const std::string& title, const std::string& text);

--- a/src/OrbitGl/MainWindowInterface.h
+++ b/src/OrbitGl/MainWindowInterface.h
@@ -13,6 +13,7 @@
 
 #include "CodeReport/CodeReport.h"
 #include "CodeReport/DisassemblyReport.h"
+#include "capture_data.pb.h"
 
 namespace orbit_gl {
 
@@ -27,7 +28,8 @@ class MainWindowInterface {
   virtual void ShowSourceCode(
       const std::filesystem::path& file_path, size_t line_number,
       std::optional<std::unique_ptr<orbit_code_report::CodeReport>> code_report) = 0;
-  virtual void ShowDisassembly(const std::string& assembly,
+  virtual void ShowDisassembly(const orbit_client_protos::FunctionInfo& function_info,
+                               const std::string& assembly,
                                orbit_code_report::DisassemblyReport report) = 0;
 
   virtual ~MainWindowInterface() = default;

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -100,6 +100,7 @@
 #include "absl/flags/flag.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_format.h"
+#include "capture_data.pb.h"
 #include "orbitaboutdialog.h"
 #include "orbitdataviewpanel.h"
 #include "orbitglwidget.h"
@@ -1474,7 +1475,8 @@ void OrbitMainWindow::ShowSourceCode(
   orbit_code_viewer::OpenAndDeleteOnClose(std::move(code_viewer_dialog));
 }
 
-void OrbitMainWindow::ShowDisassembly(const std::string& assembly,
+void OrbitMainWindow::ShowDisassembly(const orbit_client_protos::FunctionInfo& /*function_info*/,
+                                      const std::string& assembly,
                                       orbit_code_report::DisassemblyReport report) {
   auto dialog = std::make_unique<orbit_code_viewer::OwningDialog>();
   dialog->setWindowTitle("Orbit Disassembly");

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -101,7 +101,8 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   void ShowSourceCode(
       const std::filesystem::path& file_path, size_t line_number,
       std::optional<std::unique_ptr<orbit_code_report::CodeReport>> maybe_code_report) override;
-  void ShowDisassembly(const std::string& assembly,
+  void ShowDisassembly(const orbit_client_protos::FunctionInfo& function_info,
+                       const std::string& assembly,
                        orbit_code_report::DisassemblyReport report) override;
 
  protected:


### PR DESCRIPTION
This is doing two things which are needed for the combined source code view:

1. Extend `Disassembler` and `DisassemblyReport` to allow address to line number lookups. A hash map is used under the hood. I tried to implement binary search on top of the existing line number to address mapping but that doesn't work well since lines might not map to any address.
2. Add `FunctionInfo` as a parameter to `ShowDisassembly`. This will also be needed for the combined source code view in a later step.