### PR TITLE
Add thread states to CapturreMetric

### DIFF
--- a/src/MetricsUploader/CaptureMetric.cpp
+++ b/src/MetricsUploader/CaptureMetric.cpp
@@ -23,6 +23,7 @@ CaptureMetric::CaptureMetric(MetricsUploader* uploader, const CaptureStartData& 
   capture_data_.set_number_of_manual_stop_async_timers(
       start_data.number_of_manual_stop_async_timers);
   capture_data_.set_number_of_manual_tracked_values(start_data.number_of_manual_tracked_values);
+  capture_data_.set_thread_states(start_data.thread_states);
 }
 
 void CaptureMetric::SetCaptureFailed() {

--- a/src/MetricsUploader/CaptureMetricTest.cpp
+++ b/src/MetricsUploader/CaptureMetricTest.cpp
@@ -23,7 +23,8 @@ constexpr CaptureStartData kTestStartData{
     4 /*number_of_manual_stop_timers*/,
     5 /*number_of_manual_start_async_timers*/,
     6 /*number_of_manual_stop_async_timers*/,
-    7 /*number_of_manual_tracked_values*/
+    7 /*number_of_manual_tracked_values*/,
+    OrbitCaptureData_ThreadStates_THREAD_STATES_ENABLED /*thread_states*/
 };
 
 bool HasSameCaptureStartData(const OrbitCaptureData& capture_data,
@@ -38,7 +39,8 @@ bool HasSameCaptureStartData(const OrbitCaptureData& capture_data,
          capture_data.number_of_manual_stop_async_timers() ==
              start_data.number_of_manual_stop_async_timers &&
          capture_data.number_of_manual_tracked_values() ==
-             start_data.number_of_manual_tracked_values;
+             start_data.number_of_manual_tracked_values &&
+         capture_data.thread_states() == start_data.thread_states;
 }
 
 }  // namespace

--- a/src/MetricsUploader/include/MetricsUploader/CaptureMetric.h
+++ b/src/MetricsUploader/include/MetricsUploader/CaptureMetric.h
@@ -20,6 +20,8 @@ struct CaptureStartData {
   int64_t number_of_manual_start_async_timers = 0;
   int64_t number_of_manual_stop_async_timers = 0;
   int64_t number_of_manual_tracked_values = 0;
+  orbit_metrics_uploader::OrbitCaptureData_ThreadStates thread_states =
+      orbit_metrics_uploader::OrbitCaptureData_ThreadStates_THREAD_STATES_UNKNOWN;
 };
 
 struct CaptureCompleteData {

--- a/src/MetricsUploader/proto/orbit_log_event.proto
+++ b/src/MetricsUploader/proto/orbit_log_event.proto
@@ -68,6 +68,7 @@ message OrbitLogEvent {
 // instrumented functions and information that is available at capture stop,
 // like duration of the capture. It is sent when the user stops the capture, or
 // when the capture is aborted because of an error.
+// NextID: 18
 message OrbitCaptureData {
   // Duration of the capture in milliseconds. This is a measure of time from
   // when the user started a capture until the user ends it.
@@ -100,4 +101,56 @@ message OrbitCaptureData {
   // Number of orbit_api::TrackValue calls that Orbit found in the modules that
   // have been manually instrumented.
   int64 number_of_manual_tracked_values = 8;
+
+  // Whether the collection of thread states is enabled or not.
+  enum ThreadStates {
+    THREAD_STATES_UNKNOWN = 0;
+    THREAD_STATES_ENABLED = 1;
+    THREAD_STATES_DISABLED = 2;
+  }
+  ThreadStates thread_states = 9;
+
+  // Memory information sampling period in milliseconds. The default value 0
+  // cannot be chosen by the user, hence it indicates the field was not set.
+  // Value -1 means memory information collection is turned off.
+  int64 memory_information_sampling_period_ms = 10;
+
+  // Total number of timers of all dynamically instrumented (hooked) functions
+  // that were recorded in this capture. This does not include anything from
+  // the manual instrumentation api (Orbit.h).
+  int64 number_of_instrumented_function_timers = 11;
+
+  // Total number of timers of type kGpuActivity.
+  int64 number_of_gpu_activity_timers = 12;
+
+  // Whether the custom Orbit Vulkan layer (libOrbitVulkanLayer.so) was loaded
+  // by the process or not.
+  enum LibOrbitVulkanLayer {
+    LIB_ORBIT_VULKAN_LAYER_UNKNOWN = 0;
+    LIB_LOADED = 1;
+    LIB_NOT_LOADED = 2;
+  }
+  LibOrbitVulkanLayer lib_orbit_vulkan_layer = 13;
+
+  // Total number of timers of type kGpuCommandBuffer. Only applicable if
+  // loaded_lib_orbit_vulkan_layer is LIB_LOADED.
+  int64 number_of_vulkan_layer_gpu_command_buffer_timers = 14;
+
+  // Total number of timers of type kGpuDebugBuffer. Only applicable if
+  // lib_orbit_vulkan_layer_loaded is LIB_LOADED.
+  int64 number_of_vulkan_layer_gpu_debug_marker_timers = 15;
+
+  // Whether or not the user enabled the limit for local marker depth per
+  // command buffer. When this is LIMITED, it means the user checked the option
+  // to limit the marker depth.
+  enum LocalMarkerDepthPerCommandBuffer {
+    LOCAL_MARKER_DEPTH_PER_COMMAND_BUFFER_UNKNOWN = 0;
+    LIMITED = 1;
+    UNLIMITED = 2;
+  }
+  LocalMarkerDepthPerCommandBuffer local_marker_depth_per_command_buffer = 16;
+
+  // Value of the limit the user set for local marker depth per command buffer.
+  // Only applicable if local_marker_depth_per_command_buffer is LIMITED.
+  uint64 max_local_marker_depth_per_command_buffer = 17;
 }

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -168,7 +168,8 @@ PresetLoadState GetPresetLoadStateForProcess(const PresetFile& preset, const Pro
 }
 
 orbit_metrics_uploader::CaptureStartData CreateCaptureStartData(
-    const std::vector<FunctionInfo>& all_instrumented_functions, int64_t number_of_frame_tracks) {
+    const std::vector<FunctionInfo>& all_instrumented_functions, int64_t number_of_frame_tracks,
+    bool thread_states) {
   orbit_metrics_uploader::CaptureStartData capture_start_data{};
 
   for (const auto& function : all_instrumented_functions) {
@@ -198,6 +199,9 @@ orbit_metrics_uploader::CaptureStartData CreateCaptureStartData(
   }
 
   capture_start_data.number_of_frame_tracks = number_of_frame_tracks;
+  capture_start_data.thread_states =
+      thread_states ? orbit_metrics_uploader::OrbitCaptureData_ThreadStates_THREAD_STATES_ENABLED
+                    : orbit_metrics_uploader::OrbitCaptureData_ThreadStates_THREAD_STATES_DISABLED;
   return capture_start_data;
 }
 
@@ -1113,7 +1117,8 @@ void OrbitApp::StartCapture() {
   CaptureMetric capture_metric{
       metrics_uploader_,
       CreateCaptureStartData(selected_functions,
-                             user_defined_capture_data.frame_track_functions().size())};
+                             user_defined_capture_data.frame_track_functions().size(),
+                             data_manager_->collect_thread_states())};
 
   absl::flat_hash_map<uint64_t, FunctionInfo> selected_functions_map;
   absl::flat_hash_set<uint64_t> frame_track_function_ids;


### PR DESCRIPTION
This updates orbit_log_event.proto from the source of truth and adds information about thread states to CaptureMetrics. 
Whether thread states are enabled or not is known when the user starts a capture

http://b/187914133

Simple Test: run unit tests. 
Extensive Test: download newest metrics_uploader_client.dll, start capture, check sherlog