### PR TITLE
Make Scheduler and Gpu Timers appear again

### DIFF
--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -331,6 +331,7 @@ void TimerTrack::OnTimer(const TimerInfo& timer_info) {
 
   TextBox& text_box = timer_chain->emplace_back();
   text_box.SetTimerInfo(timer_info);
+  timer_chain->emplace_back(text_box);
 
   ++num_timers_;
   if (timer_info.start() < min_time_) min_time_ = timer_info.start();


### PR DESCRIPTION
In https://github.com/google/orbit/pull/2319 we switched to emplace_back but in the process we forgot to add the text_box to the TimerChain.

Solved https://b/188375720.

Test: Start/stop a capture. Load an old one.