### PR TITLE
Remove `TextBox::SetTimerInfo`, pass to the constructor instead

### DIFF
--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -9,6 +9,7 @@
 #include "Batcher.h"
 #include "OrbitAccessibility/AccessibleInterface.h"
 #include "PickingManager.h"
+#include "TextRenderer.h"
 #include "TimeGraphLayout.h"
 #include "Viewport.h"
 

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -203,8 +203,7 @@ void GraphTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
     timers_[kDepth] = timer_chain;
   }
 
-  TextBox& text_box = timer_chain->emplace_back();
-  text_box.SetTimerInfo(timer_info);
+  timer_chain->emplace_back(timer_info);
 }
 
 std::vector<std::shared_ptr<TimerChain>> GraphTrack::GetAllChains() const {

--- a/src/OrbitGl/LiveFunctionsDataView.cpp
+++ b/src/OrbitGl/LiveFunctionsDataView.cpp
@@ -460,16 +460,17 @@ const FunctionInfo& LiveFunctionsDataView::GetInstrumentedFunction(uint32_t row)
   return functions_.at(indices_[row]);
 }
 
-std::pair<TextBox*, TextBox*> LiveFunctionsDataView::GetMinMax(uint64_t function_id) const {
-  TextBox* min_box = nullptr;
-  TextBox* max_box = nullptr;
+std::pair<const TextBox*, const TextBox*> LiveFunctionsDataView::GetMinMax(
+    uint64_t function_id) const {
+  const TextBox* min_box = nullptr;
+  const TextBox* max_box = nullptr;
   std::vector<std::shared_ptr<TimerChain>> chains =
       app_->GetTimeGraph()->GetAllThreadTrackTimerChains();
   for (auto& chain : chains) {
     if (!chain) continue;
     for (auto& block : *chain) {
       for (size_t i = 0; i < block.size(); i++) {
-        TextBox& box = block[i];
+        const TextBox& box = block[i];
         if (box.GetTimerInfo().function_id() == function_id) {
           uint64_t elapsed_nanos = box.GetTimerInfo().end() - box.GetTimerInfo().start();
           if (min_box == nullptr ||
@@ -495,6 +496,7 @@ std::optional<int> LiveFunctionsDataView::GetRowFromFunctionId(uint64_t function
   }
   return std::nullopt;
 }
+
 std::optional<FunctionInfo> LiveFunctionsDataView::CreateFunctionInfoFromInstrumentedFunction(
     const InstrumentedFunction& instrumented_function) {
   const ModuleData* module_data = app_->GetModuleByPathAndBuildId(

--- a/src/OrbitGl/LiveFunctionsDataView.h
+++ b/src/OrbitGl/LiveFunctionsDataView.h
@@ -55,7 +55,7 @@ class LiveFunctionsDataView : public DataView {
   [[nodiscard]] uint64_t GetInstrumentedFunctionId(uint32_t row) const;
   [[nodiscard]] const orbit_client_protos::FunctionInfo& GetInstrumentedFunction(
       uint32_t row) const;
-  [[nodiscard]] std::pair<TextBox*, TextBox*> GetMinMax(uint64_t function_id) const;
+  [[nodiscard]] std::pair<const TextBox*, const TextBox*> GetMinMax(uint64_t function_id) const;
   [[nodiscard]] std::optional<orbit_client_protos::FunctionInfo>
   CreateFunctionInfoFromInstrumentedFunction(
       const orbit_grpc_protos::InstrumentedFunction& instrumented_function);

--- a/src/OrbitGl/SchedulingStats.cpp
+++ b/src/OrbitGl/SchedulingStats.cpp
@@ -5,7 +5,6 @@
 #include "SchedulingStats.h"
 
 #include "CaptureWindow.h"
-#include "OrbitBase/Tracing.h"
 #include "absl/strings/str_format.h"
 #include "capture_data.pb.h"
 
@@ -25,7 +24,7 @@ SchedulingStats::SchedulingStats(const std::vector<const TextBox*>& scheduling_s
     uint64_t clipped_end_ns = std::min(end_ns, timer_info.end());
     uint64_t timer_duration_ns = clipped_end_ns - clipped_start_ns;
 
-    time_on_core_ns += timer_duration_ns;
+    time_on_core_ns_ += timer_duration_ns;
     time_on_core_ns_by_core_[timer_info.processor()] += timer_duration_ns;
 
     ProcessStats& process_stats = process_stats_by_pid_[timer_info.process_id()];
@@ -64,8 +63,8 @@ std::string SchedulingStats::ToString() const {
   std::string summary;
 
   // Core occupancy.
-  if (time_on_core_ns_by_core_.size()) summary += "Core occupancy: \n";
-  for (auto& [core, time_on_core_ns] : time_on_core_ns_by_core_) {
+  if (!time_on_core_ns_by_core_.empty()) summary += "Core occupancy: \n";
+  for (const auto& [core, time_on_core_ns] : time_on_core_ns_by_core_) {
     double time_on_core_ms = static_cast<double>(time_on_core_ns) * kNsToMs;
     summary +=
         absl::StrFormat("cpu[%u] : %.2f%%\n", core, 100.0 * time_on_core_ms / time_range_ms_);

--- a/src/OrbitGl/SchedulingStats.h
+++ b/src/OrbitGl/SchedulingStats.h
@@ -56,7 +56,7 @@ class SchedulingStats {
   };
 
   double GetTimeRangeMs() const { return time_range_ms_; }
-  uint64_t GetTimeOnCoreNs() const { return time_on_core_ns; }
+  uint64_t GetTimeOnCoreNs() const { return time_on_core_ns_; }
   const std::map<int32_t, uint64_t>& GetTimeOnCoreNsByCore() const {
     return time_on_core_ns_by_core_;
   }
@@ -69,7 +69,7 @@ class SchedulingStats {
 
  private:
   double time_range_ms_ = 0;
-  uint64_t time_on_core_ns = 0;
+  uint64_t time_on_core_ns_ = 0;
   std::map<int32_t, uint64_t> time_on_core_ns_by_core_;
   std::map<int32_t, ProcessStats> process_stats_by_pid_;
   std::vector<ProcessStats*> process_stats_sorted_by_time_on_core_;

--- a/src/OrbitGl/TextBox.h
+++ b/src/OrbitGl/TextBox.h
@@ -10,13 +10,14 @@
 #include "CoreMath.h"
 #include "capture_data.pb.h"
 
-class TextRenderer;
-
 class TextBox {
  public:
-  TextBox() : pos_(Vec2::Zero()), size_(Vec2::Zero()) {}
-  TextBox(const Vec2& pos, const Vec2& size, std::string text = "")
-      : pos_(pos), size_(size), text_(std::move(text)) {}
+  TextBox() = default;
+  explicit TextBox(orbit_client_protos::TimerInfo timer_info)
+      : timer_info_{std::move(timer_info)} {}
+  TextBox(orbit_client_protos::TimerInfo timer_info, const Vec2& pos, const Vec2& size,
+          std::string text = "")
+      : timer_info_{std::move(timer_info)}, pos_{pos}, size_{size}, text_{std::move(text)} {}
 
   void SetSize(const Vec2& size) { size_ = size; }
   void SetPos(const Vec2& pos) { pos_ = pos; }
@@ -27,14 +28,7 @@ class TextBox {
   const std::string& GetText() const { return text_; }
   void SetText(std::string text) { text_ = std::move(text); }
 
-  void SetTimerInfo(const orbit_client_protos::TimerInfo& timer_info) {
-    if (timer_info.end() == 0 && timer_info.start() == 0) {
-      return;
-    }
-    timer_info_ = timer_info;
-  }
   const orbit_client_protos::TimerInfo& GetTimerInfo() const { return timer_info_; }
-  orbit_client_protos::TimerInfo& GetMutableTimerInfo() { return timer_info_; }
 
   void SetElapsedTimeTextLength(size_t length) { elapsed_time_text_length_ = length; }
   size_t GetElapsedTimeTextLength() const { return elapsed_time_text_length_; }
@@ -45,10 +39,10 @@ class TextBox {
   uint64_t Duration() const { return End() - Start(); }
 
  protected:
-  Vec2 pos_;
-  Vec2 size_;
-  std::string text_;
   orbit_client_protos::TimerInfo timer_info_;
+  Vec2 pos_ = Vec2::Zero();
+  Vec2 size_ = Vec2::Zero();
+  std::string text_;
   size_t elapsed_time_text_length_ = 0;
 };
 

--- a/src/OrbitGl/TextBox.h
+++ b/src/OrbitGl/TextBox.h
@@ -19,6 +19,14 @@ class TextBox {
           std::string text = "")
       : timer_info_{std::move(timer_info)}, pos_{pos}, size_{size}, text_{std::move(text)} {}
 
+  // Delete the copy- and move-assignment operators, while keeping the copy- and move- constructors.
+  // This is so that an element in TimerChain cannot just be re-assigned, which would break the
+  // invariance on TimerBlock::min_timestamp_ and max_timestamp_.
+  TextBox(const TextBox& other) = default;
+  TextBox& operator=(const TextBox& other) = delete;
+  TextBox(TextBox&& other) = default;
+  TextBox& operator=(TextBox&& other) = delete;
+
   void SetSize(const Vec2& size) { size_ = size; }
   void SetPos(const Vec2& pos) { pos_ = pos; }
 

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -449,8 +449,7 @@ void ThreadTrack::OnTimer(const TimerInfo& timer_info) {
     timer_chain = std::make_shared<TimerChain>();
   }
 
-  TextBox& text_box = timer_chain->emplace_back();
-  text_box.SetTimerInfo(timer_info);
+  TextBox& text_box = timer_chain->emplace_back(timer_info);
   ++num_timers_;
 
   if (timer_info.start() < min_time_) min_time_ = timer_info.start();

--- a/src/OrbitGl/TimerChain.cpp
+++ b/src/OrbitGl/TimerChain.cpp
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 
-#include "OrbitBase/Logging.h"
 #include "capture_data.pb.h"
 
 bool TimerBlock::Intersects(uint64_t min, uint64_t max) const {
@@ -15,10 +14,12 @@ bool TimerBlock::Intersects(uint64_t min, uint64_t max) const {
 
 TimerChain::~TimerChain() {
   // Find last block in chain
-  while (current_->next_) current_ = current_->next_;
+  while (current_->next_ != nullptr) {
+    current_ = current_->next_;
+  }
 
   TimerBlock* prev = current_;
-  while (prev) {
+  while (prev != nullptr) {
     prev = current_->prev_;
     delete current_;
     current_ = prev;
@@ -27,7 +28,7 @@ TimerChain::~TimerChain() {
 
 TimerBlock* TimerChain::GetBlockContaining(const TextBox* element) const {
   TimerBlock* block = root_;
-  while (block) {
+  while (block != nullptr) {
     uint32_t size = block->size_;
     if (size != 0) {
       TextBox* begin = &block->data_[0];
@@ -43,14 +44,14 @@ TimerBlock* TimerChain::GetBlockContaining(const TextBox* element) const {
 }
 
 TextBox* TimerChain::GetElementAfter(const TextBox* element) const {
-  auto block = GetBlockContaining(element);
-  if (block) {
+  TimerBlock* block = GetBlockContaining(element);
+  if (block != nullptr) {
     TextBox* begin = &block->data_[0];
     uint32_t index = element - begin;
     if (index < block->size_ - 1) {
       return &block->data_[++index];
     }
-    if (block->next_ && block->next_->size_) {
+    if (block->next_ != nullptr && block->next_->size_ != 0) {
       return &block->next_->data_[0];
     }
   }
@@ -58,14 +59,16 @@ TextBox* TimerChain::GetElementAfter(const TextBox* element) const {
 }
 
 TextBox* TimerChain::GetElementBefore(const TextBox* element) const {
-  auto block = GetBlockContaining(element);
-  if (block) {
+  TimerBlock* block = GetBlockContaining(element);
+  if (block != nullptr) {
     TextBox* begin = &block->data_[0];
     uint32_t index = element - begin;
     if (index > 0) {
       return &block->data_[--index];
     }
-    if (block->prev_) return &block->prev_->data_[block->prev_->size_ - 1];
+    if (block->prev_ != nullptr) {
+      return &block->prev_->data_[block->prev_->size_ - 1];
+    }
   }
   return nullptr;
 }

--- a/src/OrbitGl/TimerChain.h
+++ b/src/OrbitGl/TimerChain.h
@@ -27,7 +27,7 @@ class TimerBlock {
   friend class TimerChainIterator;
 
  public:
-  TimerBlock(TimerBlock* prev)
+  explicit TimerBlock(TimerBlock* prev)
       : prev_(prev),
         next_(nullptr),
         size_(0),
@@ -60,7 +60,7 @@ class TimerBlock {
   TimerBlock* prev_;
   TimerBlock* next_;
   uint64_t size_;
-  TextBox data_[kBlockSize];
+  std::array<TextBox, kBlockSize> data_;
 
   uint64_t min_timestamp_;
   uint64_t max_timestamp_;
@@ -103,11 +103,6 @@ class TimerChainIterator {
 // individually stored elements.
 class TimerChain {
  public:
-  TimerChain() : num_blocks_(1), num_items_(0) {
-    root_ = new TimerBlock(/*prev=*/nullptr);
-    current_ = root_;
-  }
-
   ~TimerChain();
 
   // Append an item to the end of the current block. If capacity of the current block is reached, a
@@ -141,10 +136,10 @@ class TimerChain {
     ++num_blocks_;
   }
 
-  TimerBlock* root_;
-  TimerBlock* current_;
-  uint64_t num_blocks_;
-  uint64_t num_items_;
+  TimerBlock* root_ = new TimerBlock(/*prev=*/nullptr);
+  TimerBlock* current_ = root_;
+  uint64_t num_blocks_ = 1;
+  uint64_t num_items_ = 0;
 };
 
 #endif  // ORBIT_GL_TIMER_CHAIN_H_

--- a/src/OrbitGl/TimerChain.h
+++ b/src/OrbitGl/TimerChain.h
@@ -72,8 +72,8 @@ class TimerBlock {
 class TimerChainIterator {
  public:
   explicit TimerChainIterator(TimerBlock* block) : block_(block) {}
-  TimerChainIterator& operator=(const TimerChainIterator& other) = default;
   TimerChainIterator(const TimerChainIterator& other) = default;
+  TimerChainIterator& operator=(const TimerChainIterator& other) = default;
   TimerChainIterator(TimerChainIterator&& other) = default;
   TimerChainIterator& operator=(TimerChainIterator&& other) = default;
 
@@ -85,8 +85,8 @@ class TimerChainIterator {
     return *this;
   }
 
-  const TimerBlock& operator*() const { return *block_; }
   TimerBlock& operator*() { return *block_; }
+  const TimerBlock& operator*() const { return *block_; }
 
   TimerBlock* operator->() { return block_; }
   const TimerBlock* operator->() const { return block_; }

--- a/src/OrbitGl/TimerInfosIteratorTest.cpp
+++ b/src/OrbitGl/TimerInfosIteratorTest.cpp
@@ -22,12 +22,9 @@ using orbit_client_protos::TimerInfo;
 TEST(TimerInfosIterator, Access) {
   std::vector<std::shared_ptr<TimerChain>> chains;
   std::shared_ptr<TimerChain> chain = std::make_shared<TimerChain>();
-  TextBox box;
   TimerInfo timer;
   timer.set_function_id(1);
-  // Need to set the end, as SetTimerInfo will refuse that timer otherwise.
-  timer.set_end(1);
-  box.SetTimerInfo(timer);
+  TextBox box{timer};
   chain->emplace_back(box);
   chains.emplace_back(chain);
 
@@ -44,12 +41,9 @@ TEST(TimerInfosIterator, Access) {
 TEST(TimerInfosIterator, Copy) {
   std::vector<std::shared_ptr<TimerChain>> chains;
   std::shared_ptr<TimerChain> chain = std::make_shared<TimerChain>();
-  TextBox box;
   TimerInfo timer;
   timer.set_function_id(1);
-  // Need to set the end, as SetTimerInfo will refuse that timer otherwise.
-  timer.set_end(1);
-  box.SetTimerInfo(timer);
+  TextBox box{timer};
   chain->emplace_back(box);
   chains.emplace_back(chain);
 
@@ -77,12 +71,9 @@ TEST(TimerInfosIterator, Copy) {
 TEST(TimerInfosIterator, Move) {
   std::vector<std::shared_ptr<TimerChain>> chains;
   std::shared_ptr<TimerChain> chain = std::make_shared<TimerChain>();
-  TextBox box;
   TimerInfo timer;
   timer.set_function_id(1);
-  // Need to set the end, as SetTimerInfo will refuse that timer otherwise.
-  timer.set_end(1);
-  box.SetTimerInfo(timer);
+  TextBox box{timer};
   chain->emplace_back(box);
   chains.emplace_back(chain);
 
@@ -102,11 +93,9 @@ TEST(TimerInfosIterator, Move) {
 TEST(TimerInfosIterator, Equality) {
   std::vector<std::shared_ptr<TimerChain>> chains;
   std::shared_ptr<TimerChain> chain = std::make_shared<TimerChain>();
-  TextBox box;
   TimerInfo timer;
   timer.set_function_id(1);
-  timer.set_end(1);
-  box.SetTimerInfo(timer);
+  TextBox box{timer};
   chain->emplace_back(box);
   chains.emplace_back(chain);
 
@@ -153,12 +142,11 @@ TEST(TimerInfosIterator, ForEachLarge) {
   for (size_t chain_count = 0; chain_count < 12; ++chain_count) {
     std::shared_ptr<TimerChain> chain = std::make_shared<TimerChain>();
     for (size_t box_count = 0; box_count < max_timers; ++box_count) {
-      TextBox box;
       TimerInfo timer;
       timer.set_function_id(count);
       timer.set_start(count);
       timer.set_end(count + 1);
-      box.SetTimerInfo(timer);
+      TextBox box{timer};
       chain->emplace_back(box);
       expected.emplace_back(count);
       ++count;

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -329,8 +329,7 @@ void TimerTrack::OnTimer(const TimerInfo& timer_info) {
     timers_[timer_info.depth()] = timer_chain;
   }
 
-  TextBox& text_box = timer_chain->emplace_back();
-  text_box.SetTimerInfo(timer_info);
+  timer_chain->emplace_back(timer_info);
 
   ++num_timers_;
   if (timer_info.start() < min_time_) min_time_ = timer_info.start();


### PR DESCRIPTION
#### Remove `TextBox::SetTimerInfo`, pass to the constructor instead
`TimerChain` needs the added `TextBox` to already have the `TimerInfo` set, to
correctly update the `min_timestamp_` and `max_timestamp` of a `TimerBlock`.
Also addressing some lint warnings as there's too much yellow in my IDE.

Bug: http://b/188375720

Test: Capture Trata with Vulkan layer and instrumented functions: notice that
scheduler and GPU tracks are now filled. Also enable a frame track and notice
that it also now works, although sometimes affected by the unrelated crash
http://b/188521605.
#### Change some TextBox* to const TextBox*, TextBox& to const TextBox&
#### Delete copy- and move- assignment of `TextBox`
As discussed, so that elements of `TimerChain` cannot be reassigned.

Bug: http://b/188375720