### PR TITLE
Use fixed font only for the source code contents

### DIFF
--- a/src/CodeViewer/Dialog.cpp
+++ b/src/CodeViewer/Dialog.cpp
@@ -23,6 +23,7 @@ Dialog::~Dialog() noexcept = default;
 void Dialog::SetMainContent(const QString& code) {
   ui_->viewer->setPlainText(code);
   syntax_highlighter_.reset();
+  ui_->viewer->document()->setDefaultFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
 }
 
 void Dialog::SetMainContent(const QString& code,

--- a/src/CodeViewer/Viewer.cpp
+++ b/src/CodeViewer/Viewer.cpp
@@ -106,8 +106,6 @@ Viewer::Viewer(QWidget* parent)
   };
   QObject::connect(this, &QPlainTextEdit::updateRequest, this, update_viewport_area);
 
-  setFont(QFontDatabase::systemFont(QFontDatabase::SystemFont::FixedFont));
-
   constexpr int kTabStopInWhitespaces = 4;
   setTabStopDistance(fontMetrics().horizontalAdvance(' ') * kTabStopInWhitespaces);
 
@@ -126,7 +124,15 @@ void Viewer::resizeEvent(QResizeEvent* ev) {
 }
 
 void Viewer::wheelEvent(QWheelEvent* ev) {
+  QFont document_default_font = document()->defaultFont();
+
   QPlainTextEdit::wheelEvent(ev);
+
+  // QPlainTextEdit::wheelEvent updates the default font to adjust the size.
+  // We respect the size change but stick to the user's default font.
+  const QFont wrong_font_with_correct_size = document()->defaultFont();
+  document_default_font.setPointSize(wrong_font_with_correct_size.pointSize());
+  document()->setDefaultFont(document_default_font);
 
   UpdateBarsSize();
   UpdateBarsPosition();


### PR DESCRIPTION
orbit_code_viewer::Viewer used to show line numbers and sample numbers
in fixed font. With this change, only the actual source code is shown
in fixed font.

This is how it looks like now (zoomed in to make the different fonts more obvious):
![image](https://user-images.githubusercontent.com/43133967/118777848-cdefb080-b889-11eb-9f46-ddd23418f696.png)

EDIT: Yes, I know, this is not fixing the out-of-line bug. Line numbers are still a little bit too low.