### PR TITLE
Correct function order in UpdateTrackOrder

### DIFF
--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -204,7 +204,7 @@ std::vector<ThreadTrack*> TrackManager::GetSortedThreadTracks() {
   return sorted_tracks;
 }
 
-void TrackManager::UpdateMovingTrackSorting() {
+void TrackManager::UpdateMovingTrackPositionInVisibleTracks() {
   // This updates the position of the currently moving track in both the sorted_tracks_
   // and the visible_tracks_ array. The moving track is inserted after the first track
   // with a value of top + height smaller than the current mouse position.
@@ -295,12 +295,13 @@ void TrackManager::UpdateTracksOrder() {
     SortTracks();
   }
 
-  // Update position of a track which is currently being moved.
-  UpdateMovingTrackSorting();
-
+  // Update visible track list from the sorted one based on the filter.
   if (visible_track_list_needs_update_) {
     UpdateVisibleTrackList();
   }
+
+  // Update position of a track which is currently being moved.
+  UpdateMovingTrackPositionInVisibleTracks();
 }
 
 void TrackManager::AddTrack(const std::shared_ptr<Track>& track) {

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -75,7 +75,7 @@ class TrackManager {
  private:
   void UpdateTracksOrder();
   [[nodiscard]] int FindMovingTrackIndex();
-  void UpdateMovingTrackSorting();
+  void UpdateMovingTrackPositionInVisibleTracks();
   void SortTracks();
   [[nodiscard]] std::vector<ThreadTrack*> GetSortedThreadTracks();
   void UpdateVisibleTrackList();


### PR DESCRIPTION
Regression from 1.63 (more precisely from https://github.com/google/orbit/pull/2221).

In that PR we alter the order by mistake of the functions "UpdateMovingTrackSorting" and "UpdateVisibleTrackList".

This PR we are reverting that change and renaming UpdateMovingTrackSorting to a name which explicit the fact that we are updating the position in the visible tracks.

It solved the crash http://b/188521605.

TODO: I'm updating my linux machine to test the crash there.