### PR TITLE
Improvements in target selection window

### DIFF
--- a/src/OrbitQt/ConnectToStadiaWidget.h
+++ b/src/OrbitQt/ConnectToStadiaWidget.h
@@ -12,6 +12,7 @@
 #include <QModelIndex>
 #include <QObject>
 #include <QPointer>
+#include <QSortFilterProxyModel>
 #include <QState>
 #include <QStateMachine>
 #include <QString>
@@ -79,7 +80,10 @@ class ConnectToStadiaWidget : public QWidget {
  private:
   void showEvent(QShowEvent* event) override;
   std::unique_ptr<Ui::ConnectToStadiaWidget> ui_;
+
   orbit_ggp::InstanceItemModel instance_model_;
+  QSortFilterProxyModel instance_proxy_model_;
+
   SshConnectionArtifacts* ssh_connection_artifacts_ = nullptr;
   std::optional<orbit_ggp::Instance> selected_instance_;
   std::unique_ptr<ServiceDeployManager> service_deploy_manager_;

--- a/src/OrbitQt/ProfilingTargetDialog.ui
+++ b/src/OrbitQt/ProfilingTargetDialog.ui
@@ -316,12 +316,12 @@
                  <height>30</height>
                 </rect>
                </property>
+               <property name="visible">
+                <bool>false</bool>
+               </property>
                <property name="accessibleName">
                 <string>ProcessListOverlay</string>
                </property>
-			   <property name="visible">
-                 <bool>false</bool>
-                </property>
               </widget>
              </widget>
             </item>
@@ -358,8 +358,7 @@
          </spacer>
         </item>
         <item>
-         <widget class="orbit_qt::TargetLabel" name="targetLabel">
-         </widget>
+         <widget class="orbit_qt::TargetLabel" name="targetLabel" native="true"/>
         </item>
         <item>
          <widget class="QPushButton" name="confirmButton">
@@ -380,15 +379,15 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>orbit_qt::ConnectToStadiaWidget</class>
-   <extends>QWidget</extends>
-   <header>ConnectToStadiaWidget.h</header>
-  </customwidget>
-  <customwidget>
    <class>orbit_qt::OverlayWidget</class>
    <extends>QWidget</extends>
    <header>OverlayWidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>orbit_qt::ConnectToStadiaWidget</class>
+   <extends>QWidget</extends>
+   <header>ConnectToStadiaWidget.h</header>
   </customwidget>
   <customwidget>
    <class>orbit_qt::TargetLabel</class>
@@ -399,5 +398,22 @@
  <resources>
   <include location="../../icons/orbiticons.qrc"/>
  </resources>
- <connections/>
+ <connections>
+  <connection>
+   <sender>processFilterLineEdit</sender>
+   <signal>returnPressed()</signal>
+   <receiver>confirmButton</receiver>
+   <slot>click()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>1106</x>
+     <y>64</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>1229</x>
+     <y>693</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>


### PR DESCRIPTION
Two small improvements to the target selection:

1) Pressing "enter" in the process filter will start the session (b/183942482)
2) Instance list can now be sorted (b/187412728)

Tests:
1) Type a filter string in the process filter, press Enter
2) With 2 reserved instances, tested if sorting in all columns works, if the correct instance is connected afterwards, and if "Remember this instance" works correctly