### PR TITLE
Update orbit_log_event.proto and Rename

### DIFF
--- a/src/MetricsUploader/CaptureMetric.cpp
+++ b/src/MetricsUploader/CaptureMetric.cpp
@@ -16,12 +16,12 @@ CaptureMetric::CaptureMetric(MetricsUploader* uploader, const CaptureStartData& 
   CHECK(uploader_ != nullptr);
   capture_data_.set_number_of_instrumented_functions(start_data.number_of_instrumented_functions);
   capture_data_.set_number_of_frame_tracks(start_data.number_of_frame_tracks);
-  capture_data_.set_number_of_manual_start_timers(start_data.number_of_manual_start_timers);
-  capture_data_.set_number_of_manual_stop_timers(start_data.number_of_manual_stop_timers);
-  capture_data_.set_number_of_manual_start_async_timers(
-      start_data.number_of_manual_start_async_timers);
-  capture_data_.set_number_of_manual_stop_async_timers(
-      start_data.number_of_manual_stop_async_timers);
+  capture_data_.set_number_of_manual_start_functions(start_data.number_of_manual_start_functions);
+  capture_data_.set_number_of_manual_stop_functions(start_data.number_of_manual_stop_functions);
+  capture_data_.set_number_of_manual_start_async_functions(
+      start_data.number_of_manual_start_async_functions);
+  capture_data_.set_number_of_manual_stop_async_functions(
+      start_data.number_of_manual_stop_async_functions);
   capture_data_.set_number_of_manual_tracked_values(start_data.number_of_manual_tracked_values);
   capture_data_.set_thread_states(start_data.thread_states);
   capture_data_.set_memory_information_sampling_period_ms(

--- a/src/MetricsUploader/CaptureMetricTest.cpp
+++ b/src/MetricsUploader/CaptureMetricTest.cpp
@@ -19,10 +19,10 @@ namespace {
 constexpr CaptureStartData kTestStartData{
     1 /*number_of_instrumented_functions*/,
     2 /*number_of_frame_tracks*/,
-    3 /*number_of_manual_start_timers*/,
-    4 /*number_of_manual_stop_timers*/,
-    5 /*number_of_manual_start_async_timers*/,
-    6 /*number_of_manual_stop_async_timers*/,
+    3 /*number_of_manual_start_functions*/,
+    4 /*number_of_manual_stop_functions*/,
+    5 /*number_of_manual_start_async_functions*/,
+    6 /*number_of_manual_stop_async_functions*/,
     7 /*number_of_manual_tracked_values*/,
     OrbitCaptureData_ThreadStates_THREAD_STATES_ENABLED /*thread_states*/,
     10 /*memory_information_sampling_period_ms*/,
@@ -43,12 +43,14 @@ bool HasSameCaptureStartData(const OrbitCaptureData& capture_data,
   return capture_data.number_of_instrumented_functions() ==
              start_data.number_of_instrumented_functions &&
          capture_data.number_of_frame_tracks() == start_data.number_of_frame_tracks &&
-         capture_data.number_of_manual_start_timers() == start_data.number_of_manual_start_timers &&
-         capture_data.number_of_manual_stop_timers() == start_data.number_of_manual_stop_timers &&
-         capture_data.number_of_manual_start_async_timers() ==
-             start_data.number_of_manual_start_async_timers &&
-         capture_data.number_of_manual_stop_async_timers() ==
-             start_data.number_of_manual_stop_async_timers &&
+         capture_data.number_of_manual_start_functions() ==
+             start_data.number_of_manual_start_functions &&
+         capture_data.number_of_manual_stop_functions() ==
+             start_data.number_of_manual_stop_functions &&
+         capture_data.number_of_manual_start_async_functions() ==
+             start_data.number_of_manual_start_async_functions &&
+         capture_data.number_of_manual_stop_async_functions() ==
+             start_data.number_of_manual_stop_async_functions &&
          capture_data.number_of_manual_tracked_values() ==
              start_data.number_of_manual_tracked_values &&
          capture_data.thread_states() == start_data.thread_states &&

--- a/src/MetricsUploader/include/MetricsUploader/CaptureMetric.h
+++ b/src/MetricsUploader/include/MetricsUploader/CaptureMetric.h
@@ -17,10 +17,10 @@ namespace orbit_metrics_uploader {
 struct CaptureStartData {
   int64_t number_of_instrumented_functions = 0;
   int64_t number_of_frame_tracks = 0;
-  int64_t number_of_manual_start_timers = 0;
-  int64_t number_of_manual_stop_timers = 0;
-  int64_t number_of_manual_start_async_timers = 0;
-  int64_t number_of_manual_stop_async_timers = 0;
+  int64_t number_of_manual_start_functions = 0;
+  int64_t number_of_manual_stop_functions = 0;
+  int64_t number_of_manual_start_async_functions = 0;
+  int64_t number_of_manual_stop_async_functions = 0;
   int64_t number_of_manual_tracked_values = 0;
   orbit_metrics_uploader::OrbitCaptureData_ThreadStates thread_states =
       orbit_metrics_uploader::OrbitCaptureData_ThreadStates_THREAD_STATES_UNKNOWN;

--- a/src/MetricsUploader/proto/orbit_log_event.proto
+++ b/src/MetricsUploader/proto/orbit_log_event.proto
@@ -69,7 +69,7 @@ message OrbitLogEvent {
 // instrumented functions and information that is available at capture stop,
 // like duration of the capture. It is sent when the user stops the capture, or
 // when the capture is aborted because of an error.
-// NextID: 18
+// NextID: 23
 message OrbitCaptureData {
   // Duration of the capture in milliseconds. This is a measure of time from
   // when the user started a capture until the user ends it.
@@ -83,20 +83,16 @@ message OrbitCaptureData {
   // Number of frame tracks the user added before the start of this capture.
   int64 number_of_frame_tracks = 3;
 
-  // Number of orbit_api::Start calls that Orbit found in the modules that have
-  // been manually instrumented.
+  // Total number of timers from orbit_api::Start() calls.
   int64 number_of_manual_start_timers = 4;
 
-  // Number of orbit_api::Stop calls that Orbit found in the modules that have
-  // been manually instrumented.
+  // Total number of timers from orbit_api::Stop() calls.
   int64 number_of_manual_stop_timers = 5;
 
-  // Number of orbit_api::StartAsync calls that Orbit found in the modules that
-  // have been manually instrumented.
+  // Total number of timers from orbit_api::StartAsync() calls.
   int64 number_of_manual_start_async_timers = 6;
 
-  // Number of orbit_api::StopAsync calls that Orbit found in the modules that
-  // have been manually instrumented.
+  // Total number of timers from orbit_api::StopAsync() calls.
   int64 number_of_manual_stop_async_timers = 7;
 
   // Number of orbit_api::TrackValue calls that Orbit found in the modules that
@@ -154,4 +150,23 @@ message OrbitCaptureData {
   // Value of the limit the user set for local marker depth per command buffer.
   // Only applicable if local_marker_depth_per_command_buffer is LIMITED.
   uint64 max_local_marker_depth_per_command_buffer = 17;
+
+  // Number of orbit_api::Start calls that Orbit found in the modules that have
+  // been manually instrumented.
+  int64 number_of_manual_start_functions = 18;
+
+  // Number of orbit_api::Stop calls that Orbit found in the modules that have
+  // been manually instrumented.
+  int64 number_of_manual_stop_functions = 19;
+
+  // Number of orbit_api::StartAsync calls that Orbit found in the modules that
+  // have been manually instrumented.
+  int64 number_of_manual_start_async_functions = 20;
+
+  // Number of orbit_api::StopAsync calls that Orbit found in the modules that
+  // have been manually instrumented.
+  int64 number_of_manual_stop_async_functions = 21;
+
+  // Total number of timers from manually tracked values.
+  int64 number_of_manual_tracked_value_timers = 22;
 }

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -184,16 +184,16 @@ orbit_metrics_uploader::CaptureStartData CreateCaptureStartData(
         capture_start_data.number_of_instrumented_functions++;
         break;
       case orbit_client_protos::FunctionInfo_OrbitType_kOrbitTimerStart:
-        capture_start_data.number_of_manual_start_timers++;
+        capture_start_data.number_of_manual_start_functions++;
         break;
       case orbit_client_protos::FunctionInfo_OrbitType_kOrbitTimerStop:
-        capture_start_data.number_of_manual_stop_timers++;
+        capture_start_data.number_of_manual_stop_functions++;
         break;
       case orbit_client_protos::FunctionInfo_OrbitType_kOrbitTimerStartAsync:
-        capture_start_data.number_of_manual_start_async_timers++;
+        capture_start_data.number_of_manual_start_async_functions++;
         break;
       case orbit_client_protos::FunctionInfo_OrbitType_kOrbitTimerStopAsync:
-        capture_start_data.number_of_manual_stop_async_timers++;
+        capture_start_data.number_of_manual_stop_async_functions++;
         break;
       case orbit_client_protos::FunctionInfo_OrbitType_kOrbitTrackValue:
         capture_start_data.number_of_manual_tracked_values++;


### PR DESCRIPTION
This updates orbit_log_event.proto from the source of truth. This update
included a rename for 4 fields from ..._timers to ..._functions. This
rename is also done for the corresponding counterparts in Orbit.