### PR TITLE
 Show unwinding errors in the capture timeline

### DIFF
--- a/src/CaptureClient/CaptureEventProcessor.cpp
+++ b/src/CaptureClient/CaptureEventProcessor.cpp
@@ -200,6 +200,12 @@ void CaptureEventProcessorForListener::ProcessCallstackSample(
   uint64_t callstack_id = callstack_sample.callstack_id();
   Callstack callstack = callstack_intern_pool[callstack_id];
 
+  // TODO(b/188178748): Remove this early return and correctly populate CallstackEvent once
+  //  non-kComplete Callstacks are also supported by the client and its protos.
+  if (callstack.type() != Callstack::kComplete) {
+    return;
+  }
+
   SendCallstackToListenerIfNecessary(callstack_id, callstack);
 
   CallstackEvent callstack_event;

--- a/src/CaptureFile/FORMAT.md
+++ b/src/CaptureFile/FORMAT.md
@@ -32,8 +32,8 @@ sections appearing in any particular order.
 | Additional Section List Offset | 8    | May be 0 if there are no additional sections in this file |
 
 ### Capture Section
-Capture section is a sequence of `orbit_grpc_proto::ClientCaptureEvent` messages. The first message is
-always `orbit_grpc_proto::CaptureStarted` and the last one is `orbit_grpc_proto::CapureFinished`.
+Capture section is a sequence of `orbit_grpc_protos::ClientCaptureEvent` messages. The first message is
+always `orbit_grpc_protos::CaptureStarted` and the last one is `orbit_grpc_protos::CapureFinished`.
 
 ### Additional Section List
 The following is a format of Additional Section List

--- a/src/ClientData/CallstackDataTest.cpp
+++ b/src/ClientData/CallstackDataTest.cpp
@@ -13,11 +13,14 @@
 #include "ClientData/CallstackData.h"
 #include "capture_data.pb.h"
 
+using orbit_client_protos::CallstackEvent;
+using orbit_client_protos::CallstackInfo;
+
 namespace orbit_client_data {
 
 MATCHER(CallstackEventEq, "") {
-  const orbit_client_protos::CallstackEvent& a = std::get<0>(arg);
-  const orbit_client_protos::CallstackEvent& b = std::get<1>(arg);
+  const CallstackEvent& a = std::get<0>(arg);
+  const CallstackEvent& b = std::get<1>(arg);
   return a.time() == b.time() && a.callstack_id() == b.callstack_id() &&
          a.thread_id() == b.thread_id();
 }
@@ -26,99 +29,137 @@ TEST(CallstackData, FilterCallstackEventsBasedOnMajorityStart) {
   CallstackData callstack_data;
 
   const int32_t tid = 42;
-  const int32_t tid_with_broken_only = 43;
+  const int32_t tid_with_no_complete = 43;
   const int32_t tid_without_supermajority = 44;
 
   const uint64_t cs1_id = 12;
   const uint64_t cs1_outer = 0x10;
   const uint64_t cs1_inner = 0x11;
-  orbit_client_protos::CallstackInfo cs1;
+  CallstackInfo cs1;
   cs1.add_frames(cs1_inner);
   cs1.add_frames(cs1_outer);
+  cs1.set_type(CallstackInfo::kComplete);
   callstack_data.AddUniqueCallstack(cs1_id, cs1);
 
   const uint64_t cs2_id = 13;
   const uint64_t cs2_outer = 0x10;
   const uint64_t cs2_inner = 0x21;
-  orbit_client_protos::CallstackInfo cs2;
+  CallstackInfo cs2;
   cs2.add_frames(cs2_inner);
   cs2.add_frames(cs2_outer);
+  cs2.set_type(CallstackInfo::kComplete);
   callstack_data.AddUniqueCallstack(cs2_id, cs2);
 
   const uint64_t broken_cs_id = 81;
   const uint64_t broken_cs_outer = 0x30;
   const uint64_t broken_cs_inner = 0x31;
-  orbit_client_protos::CallstackInfo broken_cs;
+  CallstackInfo broken_cs;
   broken_cs.add_frames(broken_cs_inner);
   broken_cs.add_frames(broken_cs_outer);
+  broken_cs.set_type(CallstackInfo::kComplete);
   callstack_data.AddUniqueCallstack(broken_cs_id, broken_cs);
 
-  const uint64_t time1 = 100;
-  orbit_client_protos::CallstackEvent event1;
+  const uint64_t non_complete_cs_id = 91;
+  const uint64_t non_complete_cs_outer = 0x40;
+  const uint64_t non_complete_cs_inner = 0x41;
+  CallstackInfo non_complete_cs;
+  non_complete_cs.add_frames(non_complete_cs_inner);
+  non_complete_cs.add_frames(non_complete_cs_outer);
+  non_complete_cs.set_type(CallstackInfo::kDwarfUnwindingError);
+  callstack_data.AddUniqueCallstack(non_complete_cs_id, non_complete_cs);
+
+  const uint64_t time1 = 142;
+  CallstackEvent event1;
   event1.set_time(time1);
   event1.set_thread_id(tid);
   event1.set_callstack_id(cs1_id);
   callstack_data.AddCallstackEvent(event1);
 
-  const uint64_t time2 = 200;
-  orbit_client_protos::CallstackEvent event2;
+  const uint64_t time2 = 242;
+  CallstackEvent event2;
   event2.set_time(time2);
   event2.set_thread_id(tid);
   event2.set_callstack_id(broken_cs_id);
   callstack_data.AddCallstackEvent(event2);
 
-  const uint64_t time3 = 300;
-  orbit_client_protos::CallstackEvent event3;
+  const uint64_t time3 = 342;
+  CallstackEvent event3;
   event3.set_time(time3);
   event3.set_thread_id(tid);
   event3.set_callstack_id(cs2_id);
   callstack_data.AddCallstackEvent(event3);
 
-  const uint64_t time4 = 400;
-  orbit_client_protos::CallstackEvent event4;
+  const uint64_t time4 = 442;
+  CallstackEvent event4;
   event4.set_time(time4);
   event4.set_thread_id(tid);
   event4.set_callstack_id(cs1_id);
   callstack_data.AddCallstackEvent(event4);
 
-  const uint64_t time5 = 500;
-  orbit_client_protos::CallstackEvent event5;
+  const uint64_t time5 = 542;
+  CallstackEvent event5;
   event5.set_time(time5);
-  event5.set_thread_id(tid_with_broken_only);
-  event5.set_callstack_id(broken_cs_id);
+  event5.set_thread_id(tid);
+  event5.set_callstack_id(non_complete_cs_id);
   callstack_data.AddCallstackEvent(event5);
 
-  const uint64_t time6 = 600;
-  orbit_client_protos::CallstackEvent event6;
+  const uint64_t time6 = 143;
+  CallstackEvent event6;
   event6.set_time(time6);
-  event6.set_thread_id(tid_without_supermajority);
-  event6.set_callstack_id(cs1_id);
+  event6.set_thread_id(tid_with_no_complete);
+  event6.set_callstack_id(broken_cs_id);
   callstack_data.AddCallstackEvent(event6);
 
-  const uint64_t time7 = 700;
-  orbit_client_protos::CallstackEvent event7;
+  const uint64_t time7 = 243;
+  CallstackEvent event7;
   event7.set_time(time7);
-  event7.set_thread_id(tid_without_supermajority);
-  event7.set_callstack_id(broken_cs_id);
+  event7.set_thread_id(tid_with_no_complete);
+  event7.set_callstack_id(non_complete_cs_id);
   callstack_data.AddCallstackEvent(event7);
 
-  callstack_data.FilterCallstackEventsBasedOnMajorityStart();
+  const uint64_t time8 = 144;
+  CallstackEvent event8;
+  event8.set_time(time8);
+  event8.set_thread_id(tid_without_supermajority);
+  event8.set_callstack_id(cs1_id);
+  callstack_data.AddCallstackEvent(event8);
+
+  const uint64_t time9 = 244;
+  CallstackEvent event9;
+  event9.set_time(time9);
+  event9.set_thread_id(tid_without_supermajority);
+  event9.set_callstack_id(broken_cs_id);
+  callstack_data.AddCallstackEvent(event9);
+
+  const uint64_t time10 = 344;
+  CallstackEvent event10;
+  event10.set_time(time10);
+  event10.set_thread_id(tid_without_supermajority);
+  event10.set_callstack_id(non_complete_cs_id);
+  callstack_data.AddCallstackEvent(event10);
+
+  callstack_data.UpdateCallstackTypeBasedOnMajorityStart();
+
+  EXPECT_EQ(callstack_data.GetCallstack(cs1_id)->type(), CallstackInfo::kComplete);
+  EXPECT_EQ(callstack_data.GetCallstack(cs2_id)->type(), CallstackInfo::kComplete);
+  EXPECT_EQ(callstack_data.GetCallstack(broken_cs_id)->type(),
+            CallstackInfo::kFilteredByMajorityOutermostFrame);
+  EXPECT_EQ(callstack_data.GetCallstack(non_complete_cs_id)->type(),
+            CallstackInfo::kDwarfUnwindingError);
+
+  EXPECT_THAT(callstack_data.GetCallstackEventsOfTidInTimeRange(
+                  tid, 0, std::numeric_limits<uint64_t>::max()),
+              testing::Pointwise(CallstackEventEq(), std::vector<CallstackEvent>{
+                                                         event1, event2, event3, event4, event5}));
+
+  EXPECT_THAT(callstack_data.GetCallstackEventsOfTidInTimeRange(
+                  tid_with_no_complete, 0, std::numeric_limits<uint64_t>::max()),
+              testing::Pointwise(CallstackEventEq(), std::vector<CallstackEvent>{event6, event7}));
 
   EXPECT_THAT(
-      callstack_data.GetCallstackEventsOfTidInTimeRange(tid, 0,
+      callstack_data.GetCallstackEventsOfTidInTimeRange(tid_without_supermajority, 0,
                                                         std::numeric_limits<uint64_t>::max()),
-      testing::Pointwise(CallstackEventEq(),
-                         std::vector<orbit_client_protos::CallstackEvent>{event1, event3, event4}));
-
-  EXPECT_THAT(callstack_data.GetCallstackEventsOfTidInTimeRange(
-                  tid_with_broken_only, 0, std::numeric_limits<uint64_t>::max()),
-              testing::Pointwise(CallstackEventEq(),
-                                 std::vector<orbit_client_protos::CallstackEvent>{event5}));
-
-  EXPECT_THAT(callstack_data.GetCallstackEventsOfTidInTimeRange(
-                  tid_without_supermajority, 0, std::numeric_limits<uint64_t>::max()),
-              testing::Pointwise(CallstackEventEq(),
-                                 std::vector<orbit_client_protos::CallstackEvent>{event6, event7}));
+      testing::Pointwise(CallstackEventEq(), std::vector<CallstackEvent>{event8, event9, event10}));
 }
 
 }  // namespace orbit_client_data

--- a/src/ClientData/include/ClientData/CallstackData.h
+++ b/src/ClientData/include/ClientData/CallstackData.h
@@ -92,9 +92,10 @@ class CallstackData {
   GetUniqueCallstacksCopy() const;
 
   // Assuming that, for each thread, the outermost frame of each callstack is always the same,
-  // filters out all the callstacks that have the outermost frame not matching the majority
-  // outermost frame. This is a way to filter unwinding errors that were not reported as such.
-  void FilterCallstackEventsBasedOnMajorityStart();
+  // update the type of all the kComplete callstacks that have the outermost frame not matching the
+  // majority outermost frame. This is a way to filter unwinding errors that were not reported as
+  // such.
+  void UpdateCallstackTypeBasedOnMajorityStart();
 
  private:
   [[nodiscard]] std::shared_ptr<orbit_client_protos::CallstackInfo> GetCallstackPtr(

--- a/src/ClientModel/CaptureDeserializerTest.cpp
+++ b/src/ClientModel/CaptureDeserializerTest.cpp
@@ -528,10 +528,7 @@ TEST(CaptureDeserializer, LoadCaptureInfoCallstacks) {
   callstack_1.add_frames(1);
   callstack_1.add_frames(2);
   callstack_1.add_frames(3);
-
-  CallstackInfo callstack_info_1;
-  *callstack_info_1.mutable_frames() = {callstack_1.frames().begin(), callstack_1.frames().end()};
-  (*capture_info.mutable_callstacks())[callstack_id_1] = callstack_info_1;
+  (*capture_info.mutable_callstacks())[callstack_id_1] = callstack_1;
 
   CallstackEvent* callstack_event_1_1 = capture_info.add_callstack_events();
   callstack_event_1_1->set_thread_id(1);
@@ -548,10 +545,7 @@ TEST(CaptureDeserializer, LoadCaptureInfoCallstacks) {
   CallstackInfo callstack_2;
   callstack_2.add_frames(4);
   callstack_2.add_frames(5);
-
-  CallstackInfo callstack_info_2;
-  *callstack_info_2.mutable_frames() = {callstack_2.frames().begin(), callstack_2.frames().end()};
-  (*capture_info.mutable_callstacks())[callstack_id_2] = callstack_info_2;
+  (*capture_info.mutable_callstacks())[callstack_id_2] = callstack_2;
 
   CallstackEvent* callstack_event_2 = capture_info.add_callstack_events();
   callstack_event_2->set_thread_id(2);

--- a/src/ClientModel/CaptureDeserializerTest.cpp
+++ b/src/ClientModel/CaptureDeserializerTest.cpp
@@ -528,6 +528,7 @@ TEST(CaptureDeserializer, LoadCaptureInfoCallstacks) {
   callstack_1.add_frames(1);
   callstack_1.add_frames(2);
   callstack_1.add_frames(3);
+  callstack_1.set_type(CallstackInfo::kComplete);
   (*capture_info.mutable_callstacks())[callstack_id_1] = callstack_1;
 
   CallstackEvent* callstack_event_1_1 = capture_info.add_callstack_events();
@@ -545,6 +546,7 @@ TEST(CaptureDeserializer, LoadCaptureInfoCallstacks) {
   CallstackInfo callstack_2;
   callstack_2.add_frames(4);
   callstack_2.add_frames(5);
+  callstack_2.set_type(CallstackInfo::kDwarfUnwindingError);
   (*capture_info.mutable_callstacks())[callstack_id_2] = callstack_2;
 
   CallstackEvent* callstack_event_2 = capture_info.add_callstack_events();
@@ -614,10 +616,12 @@ TEST(CaptureDeserializer, LoadCaptureInfoCallstacks) {
   EXPECT_EQ(
       std::vector<uint64_t>(actual_callstack_1.frames().begin(), actual_callstack_1.frames().end()),
       std::vector<uint64_t>(callstack_1.frames().begin(), callstack_1.frames().end()));
+  EXPECT_EQ(actual_callstack_1.type(), callstack_1.type());
   EXPECT_EQ(actual_callstack_id_2, callstack_id_2);
   EXPECT_EQ(
       std::vector<uint64_t>(actual_callstack_2.frames().begin(), actual_callstack_2.frames().end()),
       std::vector<uint64_t>(callstack_2.frames().begin(), callstack_2.frames().end()));
+  EXPECT_EQ(actual_callstack_2.type(), callstack_2.type());
 
   EXPECT_TRUE(hash_added_1);
   EXPECT_TRUE(hash_added_2);

--- a/src/ClientModel/SamplingDataPostProcessor.cpp
+++ b/src/ClientModel/SamplingDataPostProcessor.cpp
@@ -4,15 +4,10 @@
 
 #include "ClientModel/SamplingDataPostProcessor.h"
 
-#include <absl/meta/type_traits.h>
-
 #include <algorithm>
 #include <cstdint>
-#include <iterator>
-#include <map>
 #include <memory>
 #include <optional>
-#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -52,7 +47,7 @@ class SamplingDataPostProcessor {
  private:
   void SortByThreadUsage();
 
-  void ResolveCallstacks(const CallstackData& callstack_data, const CaptureData& callstack);
+  void ResolveCallstacks(const CallstackData& callstack_data, const CaptureData& capture_data);
 
   void MapAddressToFunctionAddress(uint64_t absolute_address, const CaptureData& capture_data);
 

--- a/src/ClientModel/include/ClientModel/CaptureData.h
+++ b/src/ClientModel/include/ClientModel/CaptureData.h
@@ -173,7 +173,7 @@ class CaptureData {
     callstack_data_->AddCallstackEvent(std::move(callstack_event));
   }
 
-  void FilterBrokenCallstacks() { callstack_data_->FilterCallstackEventsBasedOnMajorityStart(); }
+  void FilterBrokenCallstacks() { callstack_data_->UpdateCallstackTypeBasedOnMajorityStart(); }
 
   void AddUniqueTracepointEventInfo(uint64_t key,
                                     orbit_grpc_protos::TracepointInfo tracepoint_info) {

--- a/src/ClientProtos/capture_data.proto
+++ b/src/ClientProtos/capture_data.proto
@@ -63,6 +63,19 @@ message CallstackEvent {
 
 message CallstackInfo {
   repeated uint64 frames = 1;
+
+  enum CallstackType {
+    // Keep these in sync with orbit_grpc_protos::Callstack::CallstackType.
+    kComplete = 0;
+    kDwarfUnwindingError = 1;
+    kFramePointerUnwindingError = 2;
+    kInUprobes = 3;
+    kUprobesPatchingFailed = 4;
+    // These are set by the client and are in addition to the ones in
+    // Callstack::CallstackType.
+    kFilteredByMajorityOutermostFrame = 100;
+  }
+  CallstackType type = 2;
 }
 
 message ThreadStateSliceInfo {

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -132,6 +132,17 @@ message ApiEvent {
 
 message Callstack {
   repeated uint64 pcs = 1;
+
+  // This enum describes whether the corresponding stack sample was unwound
+  // successfully (kComplete), or the (likely) reason for failure.
+  enum CallstackType {
+    kComplete = 0;
+    kDwarfUnwindingError = 1;
+    kFramePointerUnwindingError = 2;
+    kInUprobes = 3;
+    kUprobesPatchingFailed = 4;
+  }
+  CallstackType type = 2;
 }
 
 message InternedCallstack {

--- a/src/LinuxTracing/LibunwindstackUnwinder.cpp
+++ b/src/LinuxTracing/LibunwindstackUnwinder.cpp
@@ -73,7 +73,7 @@ class LibunwindstackUnwinderImpl : public LibunwindstackUnwinder {
  private:
   static constexpr size_t kMaxFrames = 1024;  // This is arbitrary.
 
-  static const std::array<size_t, unwindstack::X86_64_REG_LAST> kUunwindstackRegsToPerfRegs;
+  static const std::array<size_t, unwindstack::X86_64_REG_LAST> kUnwindstackRegsToPerfRegs;
 
   static std::string LibunwindstackErrorString(unwindstack::ErrorCode error_code) {
     static const std::vector<const char*> kErrorNames{
@@ -85,7 +85,7 @@ class LibunwindstackUnwinderImpl : public LibunwindstackUnwinder {
 };
 
 const std::array<size_t, unwindstack::X86_64_REG_LAST>
-    LibunwindstackUnwinderImpl::kUunwindstackRegsToPerfRegs{
+    LibunwindstackUnwinderImpl::kUnwindstackRegsToPerfRegs{
         PERF_REG_X86_AX,  PERF_REG_X86_DX,  PERF_REG_X86_CX,  PERF_REG_X86_BX,  PERF_REG_X86_SI,
         PERF_REG_X86_DI,  PERF_REG_X86_BP,  PERF_REG_X86_SP,  PERF_REG_X86_R8,  PERF_REG_X86_R9,
         PERF_REG_X86_R10, PERF_REG_X86_R11, PERF_REG_X86_R12, PERF_REG_X86_R13, PERF_REG_X86_R14,
@@ -97,7 +97,7 @@ std::vector<unwindstack::FrameData> LibunwindstackUnwinderImpl::Unwind(
     const void* stack_dump, uint64_t stack_dump_size) {
   unwindstack::RegsX86_64 regs{};
   for (size_t perf_reg = 0; perf_reg < unwindstack::X86_64_REG_LAST; ++perf_reg) {
-    regs[perf_reg] = perf_regs.at(kUunwindstackRegsToPerfRegs[perf_reg]);
+    regs[perf_reg] = perf_regs.at(kUnwindstackRegsToPerfRegs[perf_reg]);
   }
 
   std::shared_ptr<unwindstack::Memory> memory = StackAndProcessMemory::Create(

--- a/src/LinuxTracing/TracerThread.cpp
+++ b/src/LinuxTracing/TracerThread.cpp
@@ -112,7 +112,7 @@ void TracerThread::InitUprobesEventVisitor() {
       &function_call_manager_, &return_address_manager_, maps_.get(), unwinder_.get());
   uprobes_unwinding_visitor_->SetListener(listener_);
   uprobes_unwinding_visitor_->SetUnwindErrorsAndDiscardedSamplesCounters(
-      &stats_.unwind_error_count, &stats_.discarded_samples_in_uretprobes_count);
+      &stats_.unwind_error_count, &stats_.samples_in_uretprobes_count);
   event_processor_.AddVisitor(uprobes_unwinding_visitor_.get());
 }
 
@@ -1144,8 +1144,8 @@ void TracerThread::PrintStatsIfTimerElapsed() {
   uint64_t unwind_error_count = stats_.unwind_error_count;
   LOG("  unwind errors: %.0f/s (%lu) [%.1f%%])", unwind_error_count / actual_window_s,
       unwind_error_count, 100.0 * unwind_error_count / stats_.sample_count);
-  uint64_t discarded_samples_in_uretprobes_count = stats_.discarded_samples_in_uretprobes_count;
-  LOG("  discarded samples in u(ret)probes: %.0f/s (%lu) [%.1f%%]",
+  uint64_t discarded_samples_in_uretprobes_count = stats_.samples_in_uretprobes_count;
+  LOG("  samples in u(ret)probes: %.0f/s (%lu) [%.1f%%]",
       discarded_samples_in_uretprobes_count / actual_window_s,
       discarded_samples_in_uretprobes_count,
       100.0 * discarded_samples_in_uretprobes_count / stats_.sample_count);

--- a/src/LinuxTracing/TracerThread.h
+++ b/src/LinuxTracing/TracerThread.h
@@ -178,7 +178,7 @@ class TracerThread {
       lost_count_per_buffer.clear();
       discarded_out_of_order_count = 0;
       unwind_error_count = 0;
-      discarded_samples_in_uretprobes_count = 0;
+      samples_in_uretprobes_count = 0;
       thread_state_count = 0;
     }
 
@@ -191,7 +191,7 @@ class TracerThread {
     absl::flat_hash_map<PerfEventRingBuffer*, uint64_t> lost_count_per_buffer{};
     std::atomic<uint64_t> discarded_out_of_order_count = 0;
     std::atomic<uint64_t> unwind_error_count = 0;
-    std::atomic<uint64_t> discarded_samples_in_uretprobes_count = 0;
+    std::atomic<uint64_t> samples_in_uretprobes_count = 0;
     std::atomic<uint64_t> thread_state_count = 0;
   };
 

--- a/src/LinuxTracing/UprobesReturnAddressManager.h
+++ b/src/LinuxTracing/UprobesReturnAddressManager.h
@@ -88,10 +88,10 @@ class UprobesReturnAddressManager {
     }
 
     if (!tid_uprobes_stacks_.contains(tid)) {
-      // In there are no uprobes, but the callchain needs to be patched, we need
+      // If there are no uprobes, but the callchain needs to be patched, we need
       // to discard the sample.
       // There are two situations where this may happen:
-      //  1. At the beginning of a capture, where we missed the first uprobes
+      //  1. At the beginning of a capture, where we missed the first uprobes;
       //  2. When some events are lost or processed out of order.
       if (!frames_to_patch.empty()) {
         ERROR("Discarding sample in a uprobe as uprobe records are missing.");
@@ -145,7 +145,7 @@ class UprobesReturnAddressManager {
     bool skip_last_uprobes = num_unique_uprobes == frames_to_patch.size() + 1;
 
     // On tail-call optimization, when instrumenting the caller and the callee,
-    // the correct call-stack will only contain the callee.
+    // the correct callstack will only contain the callee.
     // However, there are two uprobe records (with the same stack pointer),
     // where the first one (the caller's) contains the correct return address.
     prev_uprobe_stack_pointer = -1;

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -30,10 +30,7 @@ using orbit_grpc_protos::FunctionCall;
 
 void UprobesUnwindingVisitor::visit(StackSamplePerfEvent* event) {
   CHECK(listener_ != nullptr);
-
-  if (current_maps_ == nullptr) {
-    return;
-  }
+  CHECK(current_maps_ != nullptr);
 
   return_address_manager_->PatchSample(event->GetTid(), event->GetRegisters()[PERF_REG_X86_SP],
                                        event->GetStackData(), event->GetStackSize());
@@ -93,10 +90,7 @@ void UprobesUnwindingVisitor::visit(StackSamplePerfEvent* event) {
 
 void UprobesUnwindingVisitor::visit(CallchainSamplePerfEvent* event) {
   CHECK(listener_ != nullptr);
-
-  if (current_maps_ == nullptr) {
-    return;
-  }
+  CHECK(current_maps_ != nullptr);
 
   // TODO(b/179976268): When a sample falls on the first (push rbp) or second (mov rbp,rsp)
   //  instruction of the current function, frame-pointer unwinding skips the caller's frame,
@@ -218,6 +212,7 @@ void UprobesUnwindingVisitor::visit(UretprobesPerfEvent* event) {
 
 void UprobesUnwindingVisitor::visit(MmapPerfEvent* event) {
   CHECK(listener_ != nullptr);
+  CHECK(current_maps_ != nullptr);
 
   // Obviously the uprobes map cannot be successfully processed by orbit_object_utils::CreateModule,
   // but it's important that current_maps_ contain it.

--- a/src/LinuxTracing/UprobesUnwindingVisitor.h
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.h
@@ -69,9 +69,9 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
 
   void SetUnwindErrorsAndDiscardedSamplesCounters(
       std::atomic<uint64_t>* unwind_error_counter,
-      std::atomic<uint64_t>* discarded_samples_in_uretprobes_counter) {
+      std::atomic<uint64_t>* samples_in_uretprobes_counter) {
     unwind_error_counter_ = unwind_error_counter;
-    discarded_samples_in_uretprobes_counter_ = discarded_samples_in_uretprobes_counter;
+    samples_in_uretprobes_counter_ = samples_in_uretprobes_counter;
   }
 
   void visit(StackSamplePerfEvent* event) override;
@@ -89,7 +89,7 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   TracerListener* listener_ = nullptr;
 
   std::atomic<uint64_t>* unwind_error_counter_ = nullptr;
-  std::atomic<uint64_t>* discarded_samples_in_uretprobes_counter_ = nullptr;
+  std::atomic<uint64_t>* samples_in_uretprobes_counter_ = nullptr;
 
   absl::flat_hash_map<pid_t, std::vector<std::tuple<uint64_t, uint64_t, uint32_t>>>
       uprobe_sps_ips_cpus_per_thread_{};

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -309,7 +309,7 @@ void OrbitApp::OnCaptureStarted(const CaptureStarted& capture_started,
 }
 
 Future<void> OrbitApp::OnCaptureComplete() {
-  for (auto thread_track : GetMutableTimeGraph()->GetTrackManager()->GetThreadTracks()) {
+  for (ThreadTrack* thread_track : GetMutableTimeGraph()->GetTrackManager()->GetThreadTracks()) {
     thread_track->OnCaptureComplete();
   }
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -842,8 +842,9 @@ void OrbitApp::SetSelectionReport(
 void OrbitApp::SetTopDownView(const CaptureData& capture_data) {
   ORBIT_SCOPE_FUNCTION;
   CHECK(top_down_view_callback_);
-  std::unique_ptr<CallTreeView> top_down_view = CallTreeView::CreateTopDownViewFromSamplingProfiler(
-      capture_data.post_processed_sampling_data(), capture_data);
+  std::unique_ptr<CallTreeView> top_down_view =
+      CallTreeView::CreateTopDownViewFromPostProcessedSamplingData(
+          capture_data.post_processed_sampling_data(), capture_data);
   top_down_view_callback_(std::move(top_down_view));
 }
 
@@ -857,8 +858,8 @@ void OrbitApp::SetSelectionTopDownView(
     const CaptureData& capture_data) {
   CHECK(selection_top_down_view_callback_);
   std::unique_ptr<CallTreeView> selection_top_down_view =
-      CallTreeView::CreateTopDownViewFromSamplingProfiler(selection_post_processed_data,
-                                                          capture_data);
+      CallTreeView::CreateTopDownViewFromPostProcessedSamplingData(selection_post_processed_data,
+                                                                   capture_data);
   selection_top_down_view_callback_(std::move(selection_top_down_view));
 }
 
@@ -871,7 +872,7 @@ void OrbitApp::SetBottomUpView(const CaptureData& capture_data) {
   ORBIT_SCOPE_FUNCTION;
   CHECK(bottom_up_view_callback_);
   std::unique_ptr<CallTreeView> bottom_up_view =
-      CallTreeView::CreateBottomUpViewFromSamplingProfiler(
+      CallTreeView::CreateBottomUpViewFromPostProcessedSamplingData(
           capture_data.post_processed_sampling_data(), capture_data);
   bottom_up_view_callback_(std::move(bottom_up_view));
 }
@@ -886,8 +887,8 @@ void OrbitApp::SetSelectionBottomUpView(
     const CaptureData& capture_data) {
   CHECK(selection_bottom_up_view_callback_);
   std::unique_ptr<CallTreeView> selection_bottom_up_view =
-      CallTreeView::CreateBottomUpViewFromSamplingProfiler(selection_post_processed_data,
-                                                           capture_data);
+      CallTreeView::CreateBottomUpViewFromPostProcessedSamplingData(selection_post_processed_data,
+                                                                    capture_data);
   selection_bottom_up_view_callback_(std::move(selection_bottom_up_view));
 }
 

--- a/src/OrbitGl/CallTreeView.cpp
+++ b/src/OrbitGl/CallTreeView.cpp
@@ -130,7 +130,7 @@ static void AddCallstackToTopDownThread(CallTreeThread* thread_node,
   return thread_node;
 }
 
-std::unique_ptr<CallTreeView> CallTreeView::CreateTopDownViewFromSamplingProfiler(
+std::unique_ptr<CallTreeView> CallTreeView::CreateTopDownViewFromPostProcessedSamplingData(
     const PostProcessedSamplingData& post_processed_sampling_data,
     const CaptureData& capture_data) {
   auto top_down_view = std::make_unique<CallTreeView>();
@@ -175,7 +175,7 @@ std::unique_ptr<CallTreeView> CallTreeView::CreateTopDownViewFromSamplingProfile
   return current_node;
 }
 
-std::unique_ptr<CallTreeView> CallTreeView::CreateBottomUpViewFromSamplingProfiler(
+std::unique_ptr<CallTreeView> CallTreeView::CreateBottomUpViewFromPostProcessedSamplingData(
     const PostProcessedSamplingData& post_processed_sampling_data,
     const CaptureData& capture_data) {
   auto bottom_up_view = std::make_unique<CallTreeView>();

--- a/src/OrbitGl/CallTreeView.cpp
+++ b/src/OrbitGl/CallTreeView.cpp
@@ -146,6 +146,8 @@ std::unique_ptr<CallTreeView> CallTreeView::CreateTopDownViewFromPostProcessedSa
     for (const auto& callstack_id_and_count : thread_sample_data.sampled_callstack_id_to_count) {
       const CallstackInfo& resolved_callstack =
           post_processed_sampling_data.GetResolvedCallstack(callstack_id_and_count.first);
+      // TODO(b/188496245): Include aggregated statistics on unwinding errors.
+      CHECK(resolved_callstack.type() == CallstackInfo::kComplete);
       const uint64_t sample_count = callstack_id_and_count.second;
       // Don't count samples from the all-thread case again.
       if (tid != orbit_base::kAllProcessThreadsTid) {
@@ -193,6 +195,8 @@ std::unique_ptr<CallTreeView> CallTreeView::CreateBottomUpViewFromPostProcessedS
          thread_sample_data.sampled_callstack_id_to_count) {
       const CallstackInfo& resolved_callstack =
           post_processed_sampling_data.GetResolvedCallstack(callstack_id);
+      // TODO(b/188496245): Include aggregated statistics on unwinding errors.
+      CHECK(resolved_callstack.type() == CallstackInfo::kComplete);
       bottom_up_view->IncreaseSampleCount(sample_count);
 
       CallTreeNode* last_node = AddReversedCallstackToBottomUpViewAndReturnLastFunction(

--- a/src/OrbitGl/CallTreeView.h
+++ b/src/OrbitGl/CallTreeView.h
@@ -124,11 +124,12 @@ class CallTreeThread : public CallTreeNode {
 
 class CallTreeView : public CallTreeNode {
  public:
-  [[nodiscard]] static std::unique_ptr<CallTreeView> CreateTopDownViewFromSamplingProfiler(
+  [[nodiscard]] static std::unique_ptr<CallTreeView> CreateTopDownViewFromPostProcessedSamplingData(
       const orbit_client_data::PostProcessedSamplingData& post_processed_sampling_data,
       const orbit_client_model::CaptureData& capture_data);
 
-  [[nodiscard]] static std::unique_ptr<CallTreeView> CreateBottomUpViewFromSamplingProfiler(
+  [[nodiscard]] static std::unique_ptr<CallTreeView>
+  CreateBottomUpViewFromPostProcessedSamplingData(
       const orbit_client_data::PostProcessedSamplingData& post_processed_sampling_data,
       const orbit_client_model::CaptureData& capture_data);
 

--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -109,6 +109,12 @@ void CallstackThreadBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, u
   if (!picking) {
     // Sampling Events
     auto action_on_callstack_events = [=](const CallstackEvent& event) {
+      // TODO(b/188496243): Also show unwinding errors in the timeline.
+      if (capture_data_->GetCallstackData()->GetCallstack(event.callstack_id())->type() !=
+          CallstackInfo::kComplete) {
+        return;
+      }
+
       const uint64_t time = event.time();
       CHECK(time >= min_tick && time <= max_tick);
       Vec2 pos(time_graph_->GetWorldFromTick(time), pos_[1]);
@@ -137,6 +143,12 @@ void CallstackThreadBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, u
     constexpr const float kPickingBoxOffset = (kPickingBoxWidth - 1.0f) / 2.0f;
 
     auto action_on_callstack_events = [=](const CallstackEvent& event) {
+      // TODO(b/188496243): Also show unwinding errors in the timeline.
+      if (capture_data_->GetCallstackData()->GetCallstack(event.callstack_id())->type() !=
+          CallstackInfo::kComplete) {
+        return;
+      }
+
       const uint64_t time = event.time();
       CHECK(time >= min_tick && time <= max_tick);
       Vec2 pos(time_graph_->GetWorldFromTick(time) - kPickingBoxOffset, pos_[1] - track_height + 1);

--- a/src/OrbitGl/CallstackThreadBar.h
+++ b/src/OrbitGl/CallstackThreadBar.h
@@ -43,9 +43,11 @@ class CallstackThreadBar : public ThreadBar {
 
   void SetColor(const Color& color) { color_ = color; }
 
- protected:
+ private:
   void SelectCallstacks();
-  [[nodiscard]] std::string SafeGetFormattedFunctionName(uint64_t addr, int max_line_length) const;
+  [[nodiscard]] std::string SafeGetFormattedFunctionName(
+      const orbit_client_protos::CallstackInfo& callstack, int frame_index,
+      int max_line_length) const;
   [[nodiscard]] std::string FormatCallstackForTooltip(
       const orbit_client_protos::CallstackInfo& callstack, int max_line_length = 80,
       int max_lines = 20, int bottom_n_lines = 5) const;

--- a/src/OrbitGl/SamplingReport.h
+++ b/src/OrbitGl/SamplingReport.h
@@ -45,7 +45,7 @@ class SamplingReport {
   [[nodiscard]] std::string GetSelectedCallstackString() const;
   void SetUiRefreshFunc(std::function<void()> func) { ui_refresh_func_ = std::move(func); };
   [[nodiscard]] bool HasCallstacks() const { return selected_sorted_callstack_report_ != nullptr; };
-  [[nodiscard]] bool HasSamples() const { return !unique_callstacks_.empty(); }
+  [[nodiscard]] bool HasSamples() const { return !thread_reports_.empty(); }
   [[nodiscard]] bool has_summary() const { return has_summary_; }
   void ClearReport();
 

--- a/src/Service/ProducerEventProcessorTest.cpp
+++ b/src/Service/ProducerEventProcessorTest.cpp
@@ -153,7 +153,7 @@ TEST(ProducerEventProcessor, OneInternedCallstack) {
   EXPECT_EQ(actual_interned_callstack.intern().pcs()[2], 3);
 }
 
-TEST(ProducerEventProcessor, TwoInternedCallstacskDifferentProducersSameKey) {
+TEST(ProducerEventProcessor, TwoInternedCallstacksDifferentProducersSameKey) {
   MockCaptureEventBuffer buffer;
   auto producer_event_processor = ProducerEventProcessor::Create(&buffer);
 
@@ -450,23 +450,23 @@ TEST(ProducerEventProcessor, FullCallstackSampleDifferentCallstacks) {
   callstack2->add_pcs(8);
 
   ClientCaptureEvent interned_callstack_event1;
-  ClientCaptureEvent callstack_sameple_event1;
+  ClientCaptureEvent callstack_sample_event1;
   ClientCaptureEvent interned_callstack_event2;
-  ClientCaptureEvent callstack_sameple_event2;
+  ClientCaptureEvent callstack_sample_event2;
   EXPECT_CALL(buffer, AddEvent)
       .Times(4)
       .WillOnce(SaveArg<0>(&interned_callstack_event1))
-      .WillOnce(SaveArg<0>(&callstack_sameple_event1))
+      .WillOnce(SaveArg<0>(&callstack_sample_event1))
       .WillOnce(SaveArg<0>(&interned_callstack_event2))
-      .WillOnce(SaveArg<0>(&callstack_sameple_event2));
+      .WillOnce(SaveArg<0>(&callstack_sample_event2));
 
   producer_event_processor->ProcessEvent(1, event1);
   producer_event_processor->ProcessEvent(1, event2);
 
   ASSERT_EQ(interned_callstack_event1.event_case(), ClientCaptureEvent::kInternedCallstack);
   ASSERT_EQ(interned_callstack_event2.event_case(), ClientCaptureEvent::kInternedCallstack);
-  ASSERT_EQ(callstack_sameple_event1.event_case(), ClientCaptureEvent::kCallstackSample);
-  ASSERT_EQ(callstack_sameple_event2.event_case(), ClientCaptureEvent::kCallstackSample);
+  ASSERT_EQ(callstack_sample_event1.event_case(), ClientCaptureEvent::kCallstackSample);
+  ASSERT_EQ(callstack_sample_event2.event_case(), ClientCaptureEvent::kCallstackSample);
 
   const InternedCallstack& interned_callstack1 = interned_callstack_event1.interned_callstack();
   EXPECT_NE(interned_callstack1.key(), orbit_grpc_protos::kInvalidInternId);
@@ -484,13 +484,13 @@ TEST(ProducerEventProcessor, FullCallstackSampleDifferentCallstacks) {
   EXPECT_EQ(interned_callstack2.intern().pcs(2), 7);
   EXPECT_EQ(interned_callstack2.intern().pcs(3), 8);
 
-  const CallstackSample& callstack_sample1 = callstack_sameple_event1.callstack_sample();
+  const CallstackSample& callstack_sample1 = callstack_sample_event1.callstack_sample();
   EXPECT_EQ(callstack_sample1.pid(), kPid1);
   EXPECT_EQ(callstack_sample1.tid(), kTid1);
   EXPECT_EQ(callstack_sample1.timestamp_ns(), kTimestampNs1);
   EXPECT_EQ(callstack_sample1.callstack_id(), interned_callstack1.key());
 
-  const CallstackSample& callstack_sample2 = callstack_sameple_event2.callstack_sample();
+  const CallstackSample& callstack_sample2 = callstack_sample_event2.callstack_sample();
   EXPECT_EQ(callstack_sample2.pid(), kPid2);
   EXPECT_EQ(callstack_sample2.tid(), kTid2);
   EXPECT_EQ(callstack_sample2.timestamp_ns(), kTimestampNs2);
@@ -524,20 +524,20 @@ TEST(ProducerEventProcessor, FullCallstackSamplesSameCallstack) {
   callstack2->add_pcs(4);
 
   ClientCaptureEvent interned_callstack_event1;
-  ClientCaptureEvent callstack_sameple_event1;
-  ClientCaptureEvent callstack_sameple_event2;
+  ClientCaptureEvent callstack_sample_event1;
+  ClientCaptureEvent callstack_sample_event2;
   EXPECT_CALL(buffer, AddEvent)
       .Times(3)
       .WillOnce(SaveArg<0>(&interned_callstack_event1))
-      .WillOnce(SaveArg<0>(&callstack_sameple_event1))
-      .WillOnce(SaveArg<0>(&callstack_sameple_event2));
+      .WillOnce(SaveArg<0>(&callstack_sample_event1))
+      .WillOnce(SaveArg<0>(&callstack_sample_event2));
 
   producer_event_processor->ProcessEvent(1, event1);
   producer_event_processor->ProcessEvent(1, event2);
 
   ASSERT_EQ(interned_callstack_event1.event_case(), ClientCaptureEvent::kInternedCallstack);
-  ASSERT_EQ(callstack_sameple_event1.event_case(), ClientCaptureEvent::kCallstackSample);
-  ASSERT_EQ(callstack_sameple_event2.event_case(), ClientCaptureEvent::kCallstackSample);
+  ASSERT_EQ(callstack_sample_event1.event_case(), ClientCaptureEvent::kCallstackSample);
+  ASSERT_EQ(callstack_sample_event2.event_case(), ClientCaptureEvent::kCallstackSample);
 
   const InternedCallstack& interned_callstack1 = interned_callstack_event1.interned_callstack();
   EXPECT_NE(interned_callstack1.key(), orbit_grpc_protos::kInvalidInternId);
@@ -547,13 +547,13 @@ TEST(ProducerEventProcessor, FullCallstackSamplesSameCallstack) {
   EXPECT_EQ(interned_callstack1.intern().pcs(2), 3);
   EXPECT_EQ(interned_callstack1.intern().pcs(3), 4);
 
-  const CallstackSample& callstack_sample1 = callstack_sameple_event1.callstack_sample();
+  const CallstackSample& callstack_sample1 = callstack_sample_event1.callstack_sample();
   EXPECT_EQ(callstack_sample1.pid(), kPid1);
   EXPECT_EQ(callstack_sample1.tid(), kTid1);
   EXPECT_EQ(callstack_sample1.timestamp_ns(), kTimestampNs1);
   EXPECT_EQ(callstack_sample1.callstack_id(), interned_callstack1.key());
 
-  const CallstackSample& callstack_sample2 = callstack_sameple_event2.callstack_sample();
+  const CallstackSample& callstack_sample2 = callstack_sample_event2.callstack_sample();
   EXPECT_EQ(callstack_sample2.pid(), kPid2);
   EXPECT_EQ(callstack_sample2.tid(), kTid2);
   EXPECT_EQ(callstack_sample2.timestamp_ns(), kTimestampNs2);


### PR DESCRIPTION
#### _Various small tweaks collected while going through the code_
#### Make LibunwindstackUnwinder::Unwind return LibunwindstackResult
#### Add CallstackType type to orbit_grpc_protos::Callstack
And add support for it on the service.

Bug: http://b/188178748
Bug: http://b/188498204

Test: Update affected tests. Capture Trata and verify samples. Run
`LinuxTracingIntegrationTests` 1000 times.
#### Add CallstackType type to orbit_client_protos::CallstackInfo
Note that the logic of
`CallstackData::FilterCallstackEventsBasedOnMajorityStart` had to be slightly
changed (the method was renamed accordingly): instead of throwing away
`CallstackEvent`s, we now change the type of the referenced `CallstackInfo`.

Bug: http://b/188178748
Bug: http://b/188498206

Test: Update affected unit tests. Capture Trata and verify callstacks (the ones
that are not unwinding errors) are in order in the timeline and in the
aggregated views. Play around with selections to verify that non-`kComplete`
callstacks don't end up in them.
#### Show unwinding errors in the timeline 
Bug: http://b/188496243

Test: Capture Trata, look for unwinding errors in the timeline, check their
tooltips. One way to get a lot of them is to instrument a function called
frequently, as all the samples falling directly inside uprobes will be
errors.

Screenshot from Linux:
<img width="338" alt="Screenshot from 2021-05-20 13-04-11_mod" src="https://user-images.githubusercontent.com/58685940/118968885-b89f8280-b96c-11eb-8a44-9f9d8cd27f82.png">
