### PR TITLE
Add manual timers to CaptureMetric

### DIFF
--- a/src/MetricsUploader/CaptureMetric.cpp
+++ b/src/MetricsUploader/CaptureMetric.cpp
@@ -41,6 +41,14 @@ void CaptureMetric::SetCaptureCompleteData(const CaptureCompleteData& complete_d
       complete_data.number_of_vulkan_layer_gpu_command_buffer_timers);
   capture_data_.set_number_of_vulkan_layer_gpu_debug_marker_timers(
       complete_data.number_of_vulkan_layer_gpu_debug_marker_timers);
+  capture_data_.set_number_of_manual_start_timers(complete_data.number_of_manual_start_timers);
+  capture_data_.set_number_of_manual_stop_timers(complete_data.number_of_manual_stop_timers);
+  capture_data_.set_number_of_manual_start_async_timers(
+      complete_data.number_of_manual_start_async_timers);
+  capture_data_.set_number_of_manual_stop_async_timers(
+      complete_data.number_of_manual_stop_async_timers);
+  capture_data_.set_number_of_manual_tracked_value_timers(
+      complete_data.number_of_manual_tracked_value_timers);
 }
 
 bool CaptureMetric::SendCaptureFailed() {

--- a/src/MetricsUploader/CaptureMetricTest.cpp
+++ b/src/MetricsUploader/CaptureMetricTest.cpp
@@ -33,9 +33,15 @@ constexpr CaptureStartData kTestStartData{
 };
 
 constexpr CaptureCompleteData kTestCompleteData{
-    101 /*number_of_instrumented_function_timers*/, 102 /*number_of_gpu_activity_timers*/,
+    101 /*number_of_instrumented_function_timers*/,
+    102 /*number_of_gpu_activity_timers*/,
     103 /*number_of_vulkan_layer_gpu_command_buffer_timers*/,
-    104 /*number_of_vulkan_layer_gpu_debug_marker_timers*/
+    104 /*number_of_vulkan_layer_gpu_debug_marker_timers*/,
+    105 /*number_of_manual_start_timers*/,
+    106 /*number_of_manual_stop_timers*/,
+    107 /*number_of_manual_start_async_timers*/,
+    108 /*number_of_manual_stop_async_timers*/,
+    109 /*number_of_manual_tracked_value_timers*/
 };
 
 bool HasSameCaptureStartData(const OrbitCaptureData& capture_data,
@@ -67,7 +73,17 @@ bool HasSameCaptureCompleteData(const OrbitCaptureData& capture_data,
          capture_data.number_of_vulkan_layer_gpu_command_buffer_timers() ==
              complete_data.number_of_vulkan_layer_gpu_command_buffer_timers &&
          capture_data.number_of_vulkan_layer_gpu_debug_marker_timers() ==
-             complete_data.number_of_vulkan_layer_gpu_debug_marker_timers;
+             complete_data.number_of_vulkan_layer_gpu_debug_marker_timers &&
+         capture_data.number_of_manual_start_timers() ==
+             complete_data.number_of_manual_start_timers &&
+         capture_data.number_of_manual_stop_timers() ==
+             complete_data.number_of_manual_stop_timers &&
+         capture_data.number_of_manual_start_async_timers() ==
+             complete_data.number_of_manual_start_async_timers &&
+         capture_data.number_of_manual_stop_async_timers() ==
+             complete_data.number_of_manual_stop_async_timers &&
+         capture_data.number_of_manual_tracked_value_timers() ==
+             complete_data.number_of_manual_tracked_value_timers;
 }
 
 }  // namespace

--- a/src/MetricsUploader/include/MetricsUploader/CaptureMetric.h
+++ b/src/MetricsUploader/include/MetricsUploader/CaptureMetric.h
@@ -38,6 +38,11 @@ struct CaptureCompleteData {
   int64_t number_of_gpu_activity_timers = 0;
   int64_t number_of_vulkan_layer_gpu_command_buffer_timers = 0;
   int64_t number_of_vulkan_layer_gpu_debug_marker_timers = 0;
+  int64_t number_of_manual_start_timers = 0;
+  int64_t number_of_manual_stop_timers = 0;
+  int64_t number_of_manual_start_async_timers = 0;
+  int64_t number_of_manual_stop_async_timers = 0;
+  int64_t number_of_manual_tracked_value_timers = 0;
 };
 
 class CaptureMetric {

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2487,7 +2487,45 @@ void OrbitApp::CaptureMetricProcessTimer(const orbit_client_protos::TimerInfo& t
     case orbit_client_protos::TimerInfo_Type_kGpuDebugMarker:
       metrics_capture_complete_data_.number_of_vulkan_layer_gpu_debug_marker_timers++;
       break;
+    case orbit_client_protos::TimerInfo_Type_kApiEvent:
+      CaptureMetricProcessApiTimer(timer);
+      break;
     default:
       break;
+  }
+}
+
+void OrbitApp::CaptureMetricProcessApiTimer(const orbit_client_protos::TimerInfo& timer) {
+  orbit_api::Event api_event = ManualInstrumentationManager::ApiEventFromTimerInfo(timer);
+  switch (api_event.type) {
+    case orbit_api::kScopeStart:
+      metrics_capture_complete_data_.number_of_manual_start_timers++;
+      break;
+    case orbit_api::kScopeStop:
+      metrics_capture_complete_data_.number_of_manual_stop_timers++;
+      break;
+    case orbit_api::kScopeStartAsync:
+      metrics_capture_complete_data_.number_of_manual_start_async_timers++;
+      break;
+    case orbit_api::kScopeStopAsync:
+      metrics_capture_complete_data_.number_of_manual_stop_async_timers++;
+      break;
+    case orbit_api::kTrackInt:
+      [[fallthrough]];
+    case orbit_api::kTrackInt64:
+      [[fallthrough]];
+    case orbit_api::kTrackUint:
+      [[fallthrough]];
+    case orbit_api::kTrackUint64:
+      [[fallthrough]];
+    case orbit_api::kTrackFloat:
+      [[fallthrough]];
+    case orbit_api::kTrackDouble:
+      metrics_capture_complete_data_.number_of_manual_tracked_value_timers++;
+      break;
+    case orbit_api::kString:
+      break;
+    case orbit_api::kNone:
+      UNREACHABLE();
   }
 }

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -497,6 +497,8 @@ class OrbitApp final : public DataViewFactory, public orbit_capture_client::Capt
 
   // Only call from the capture thread
   void CaptureMetricProcessTimer(const orbit_client_protos::TimerInfo& timer);
+  // Only call from the capture thread
+  void CaptureMetricProcessApiTimer(const orbit_client_protos::TimerInfo& timer);
 
   std::atomic<bool> capture_loading_cancellation_requested_ = false;
   std::atomic<bool> is_loading_capture_{false};


### PR DESCRIPTION
This adds 5 fields for total manual instrumentation timers to
CaptureCompleteData and the corresponding tracking in OrbitApp.

http://b/181649376
http://b/181648670
http://b/181648665