### PR TITLE
Integrate COFF object file support

### DIFF
--- a/src/ObjectUtils/CMakeLists.txt
+++ b/src/ObjectUtils/CMakeLists.txt
@@ -17,7 +17,7 @@ target_sources(
 
 target_sources(
   ObjectUtils
-  PRIVATE CoffFile.cpp ElfFile.cpp)
+  PRIVATE CoffFile.cpp ElfFile.cpp ObjectFile.cpp)
 
 if (NOT WIN32)
 target_sources(ObjectUtils PRIVATE LinuxMap.cpp)
@@ -39,6 +39,7 @@ add_executable(ObjectUtilsTests)
 target_sources(ObjectUtilsTests PRIVATE
     CoffFileTest.cpp
     ElfFileTest.cpp
+    ObjectFileTest.cpp
 )
 
 if (NOT WIN32)

--- a/src/ObjectUtils/CoffFile.cpp
+++ b/src/ObjectUtils/CoffFile.cpp
@@ -29,6 +29,8 @@ class CoffFileImpl : public CoffFile {
   [[nodiscard]] bool HasDebugSymbols() const override;
   [[nodiscard]] std::string GetName() const override;
   [[nodiscard]] const std::filesystem::path& GetFilePath() const override;
+  [[nodiscard]] bool IsElf() const override;
+  [[nodiscard]] bool IsCoff() const override;
 
  private:
   ErrorMessageOr<uint64_t> GetSectionOffsetForSymbol(const llvm::object::SymbolRef& symbol_ref);
@@ -123,6 +125,9 @@ bool CoffFileImpl::HasDebugSymbols() const { return has_symbol_table_; }
 const std::filesystem::path& CoffFileImpl::GetFilePath() const { return file_path_; }
 
 std::string CoffFileImpl::GetName() const { return file_path_.filename().string(); }
+
+bool CoffFileImpl::IsElf() const { return false; }
+bool CoffFileImpl::IsCoff() const { return true; }
 
 }  // namespace
 

--- a/src/ObjectUtils/CoffFileTest.cpp
+++ b/src/ObjectUtils/CoffFileTest.cpp
@@ -11,9 +11,11 @@
 
 #include "ObjectUtils/CoffFile.h"
 #include "OrbitBase/ExecutablePath.h"
+#include "OrbitBase/TestUtils.h"
 #include "absl/strings/ascii.h"
 #include "symbol.pb.h"
 
+using orbit_base::HasNoError;
 using orbit_grpc_protos::SymbolInfo;
 using orbit_object_utils::CoffFile;
 using orbit_object_utils::CreateCoffFile;
@@ -22,11 +24,11 @@ TEST(CoffFile, LoadDebugSymbols) {
   std::filesystem::path file_path = orbit_base::GetExecutableDir() / "testdata" / "libtest.dll";
 
   auto coff_file_result = CreateCoffFile(file_path);
-  ASSERT_TRUE(coff_file_result.has_value()) << coff_file_result.error().message();
+  ASSERT_THAT(coff_file_result, HasNoError());
   std::unique_ptr<CoffFile> coff_file = std::move(coff_file_result.value());
 
   const auto symbols_result = coff_file->LoadDebugSymbols();
-  ASSERT_TRUE(symbols_result.has_value()) << symbols_result.error().message();
+  ASSERT_THAT(symbols_result, HasNoError());
 
   EXPECT_EQ(symbols_result.value().symbols_file_path(), file_path);
 
@@ -51,7 +53,7 @@ TEST(CoffFile, HasDebugSymbols) {
   std::filesystem::path file_path = orbit_base::GetExecutableDir() / "testdata" / "libtest.dll";
 
   auto coff_file_result = CreateCoffFile(file_path);
-  ASSERT_TRUE(coff_file_result.has_value()) << coff_file_result.error().message();
+  ASSERT_THAT(coff_file_result, HasNoError());
 
   EXPECT_TRUE(coff_file_result.value()->HasDebugSymbols());
 }
@@ -60,7 +62,7 @@ TEST(CoffFile, GetFilePath) {
   std::filesystem::path file_path = orbit_base::GetExecutableDir() / "testdata" / "libtest.dll";
 
   auto coff_file_result = CreateCoffFile(file_path);
-  ASSERT_TRUE(coff_file_result.has_value()) << coff_file_result.error().message();
+  ASSERT_THAT(coff_file_result, HasNoError());
 
   EXPECT_EQ(coff_file_result.value()->GetFilePath(), file_path);
 }

--- a/src/ObjectUtils/ElfFile.cpp
+++ b/src/ObjectUtils/ElfFile.cpp
@@ -63,6 +63,8 @@ class ElfFileImpl : public ElfFile {
   [[nodiscard]] bool HasDebugInfo() const override;
   [[nodiscard]] bool HasGnuDebuglink() const override;
   [[nodiscard]] bool Is64Bit() const override;
+  [[nodiscard]] bool IsElf() const override;
+  [[nodiscard]] bool IsCoff() const override;
   [[nodiscard]] std::string GetBuildId() const override;
   [[nodiscard]] std::string GetName() const override;
   [[nodiscard]] std::string GetSoname() const override;
@@ -500,6 +502,16 @@ bool ElfFileImpl<llvm::object::ELF64LE>::Is64Bit() const {
 template <>
 bool ElfFileImpl<llvm::object::ELF32LE>::Is64Bit() const {
   return false;
+}
+
+template <typename ElfT>
+bool ElfFileImpl<ElfT>::IsCoff() const {
+  return false;
+}
+
+template <typename ElfT>
+bool ElfFileImpl<ElfT>::IsElf() const {
+  return true;
 }
 
 template <typename ElfT>

--- a/src/ObjectUtils/ObjectFile.cpp
+++ b/src/ObjectUtils/ObjectFile.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ObjectUtils/ObjectFile.h"
+
+#include <absl/strings/str_format.h>
+#include <llvm/Object/Binary.h>
+#include <llvm/Object/ObjectFile.h>
+
+#include <filesystem>
+#include <memory>
+#include <string>
+
+#include "ObjectUtils/CoffFile.h"
+#include "ObjectUtils/ElfFile.h"
+#include "OrbitBase/Result.h"
+#include "symbol.pb.h"
+
+namespace orbit_object_utils {
+
+ErrorMessageOr<std::unique_ptr<ObjectFile>> CreateObjectFile(
+    const std::filesystem::path& file_path) {
+  // TODO(hebecker): Remove this explicit construction of StringRef when we switch to LLVM10.
+  const std::string file_path_str = file_path.string();
+  const llvm::StringRef file_path_llvm{file_path_str};
+
+  llvm::Expected<llvm::object::OwningBinary<llvm::object::ObjectFile>> object_file_or_error =
+      llvm::object::ObjectFile::createObjectFile(file_path_llvm);
+
+  if (!object_file_or_error) {
+    return ErrorMessage(absl::StrFormat("Unable to load ELF file \"%s\": %s", file_path.string(),
+                                        llvm::toString(object_file_or_error.takeError())));
+  }
+
+  llvm::object::OwningBinary<llvm::object::ObjectFile>& file = object_file_or_error.get();
+
+  if (file.getBinary()->isELF()) {
+    auto elf_file_or_error = CreateElfFile(file_path, std::move(file));
+    if (elf_file_or_error.has_error()) {
+      return ErrorMessage(absl::StrFormat("Unable to load object file as ELF file: %s",
+                                          elf_file_or_error.error().message()));
+    }
+    return std::move(elf_file_or_error.value());
+  }
+  if (file.getBinary()->isCOFF()) {
+    auto coff_file_or_error = CreateCoffFile(file_path, std::move(file));
+    if (coff_file_or_error.has_error()) {
+      return ErrorMessage(absl::StrFormat("Unable to load object file as COFF file: %s",
+                                          coff_file_or_error.error().message()));
+    }
+    return std::move(coff_file_or_error.value());
+  }
+
+  return ErrorMessage("Unknown object file type.");
+}
+
+}  // namespace orbit_object_utils

--- a/src/ObjectUtils/ObjectFileTest.cpp
+++ b/src/ObjectUtils/ObjectFileTest.cpp
@@ -1,0 +1,88 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "ObjectUtils/ObjectFile.h"
+#include "OrbitBase/ExecutablePath.h"
+#include "OrbitBase/TestUtils.h"
+
+using ::orbit_base::HasNoError;
+using ::orbit_object_utils::CreateObjectFile;
+
+// Only tests methods that are in the interface for ObjectFile itself. More detailed tests
+// specific to ElfFile and CoffFile are in their own tests.
+
+TEST(ObjectFile, CorrectObjectTypeForElf) {
+  std::filesystem::path file_path =
+      orbit_base::GetExecutableDir() / "testdata" / "hello_world_elf_with_debug_info";
+
+  auto object_file = CreateObjectFile(file_path);
+  ASSERT_THAT(object_file, HasNoError());
+
+  EXPECT_TRUE(object_file.value()->IsElf());
+  EXPECT_FALSE(object_file.value()->IsCoff());
+}
+
+TEST(ObjectFile, CorrectObjectTypeForCoff) {
+  std::filesystem::path file_path = orbit_base::GetExecutableDir() / "testdata" / "libtest.dll";
+
+  auto object_file = CreateObjectFile(file_path);
+  ASSERT_THAT(object_file, HasNoError());
+
+  EXPECT_TRUE(object_file.value()->IsCoff());
+  EXPECT_FALSE(object_file.value()->IsElf());
+}
+
+TEST(ObjectFile, LoadsCoffFileWithSymbols) {
+  std::filesystem::path file_path = orbit_base::GetExecutableDir() / "testdata" / "libtest.dll";
+
+  auto object_file = CreateObjectFile(file_path);
+  ASSERT_THAT(object_file, HasNoError());
+
+  EXPECT_TRUE(object_file.value()->HasDebugSymbols());
+  const auto symbols_result = object_file.value()->LoadDebugSymbols();
+  ASSERT_TRUE(symbols_result.has_value()) << symbols_result.error().message();
+}
+
+TEST(ObjectFile, LoadsElfFileWithSymbols) {
+  std::filesystem::path file_path =
+      orbit_base::GetExecutableDir() / "testdata" / "hello_world_elf_with_debug_info";
+
+  auto object_file = CreateObjectFile(file_path);
+  ASSERT_THAT(object_file, HasNoError());
+
+  EXPECT_TRUE(object_file.value()->HasDebugSymbols());
+  const auto symbols_result = object_file.value()->LoadDebugSymbols();
+  ASSERT_TRUE(symbols_result.has_value()) << symbols_result.error().message();
+}
+
+TEST(ObjectFile, LoadsElfFileWithoutSymbols) {
+  std::filesystem::path file_path = orbit_base::GetExecutableDir() / "testdata" / "no_symbols_elf";
+
+  auto object_file = CreateObjectFile(file_path);
+  ASSERT_THAT(object_file, HasNoError());
+
+  EXPECT_FALSE(object_file.value()->HasDebugSymbols());
+}
+
+TEST(ObjectFile, UsesFilenameAsName) {
+  std::filesystem::path file_path = orbit_base::GetExecutableDir() / "testdata" / "libtest.dll";
+
+  auto object_file = CreateObjectFile(file_path);
+  ASSERT_THAT(object_file, HasNoError());
+
+  EXPECT_EQ(object_file.value()->GetName(), "libtest.dll");
+}
+
+TEST(ObjectFile, UsesSonameAsNameForElfIfSonameIsPresent) {
+  const std::filesystem::path file_path =
+      orbit_base::GetExecutableDir() / "testdata" / "libtest-1.0.so";
+
+  auto object_file = CreateObjectFile(file_path);
+  ASSERT_THAT(object_file, HasNoError());
+
+  EXPECT_EQ(object_file.value()->GetName(), "libtest.so");
+}

--- a/src/ObjectUtils/include/ObjectUtils/CoffFile.h
+++ b/src/ObjectUtils/include/ObjectUtils/CoffFile.h
@@ -5,13 +5,14 @@
 #ifndef OBJECT_UTILS_COFF_FILE_H_
 #define OBJECT_UTILS_COFF_FILE_H_
 
+#include <llvm/Object/Binary.h>
+#include <llvm/Object/ObjectFile.h>
+
 #include <filesystem>
 #include <memory>
 
 #include "ObjectUtils/ObjectFile.h"
 #include "OrbitBase/Result.h"
-#include "llvm/Object/Binary.h"
-#include "llvm/Object/ObjectFile.h"
 #include "symbol.pb.h"
 
 namespace orbit_object_utils {

--- a/src/ObjectUtils/include/ObjectUtils/ObjectFile.h
+++ b/src/ObjectUtils/include/ObjectUtils/ObjectFile.h
@@ -5,6 +5,7 @@
 #ifndef OBJECT_UTILS_OBJECT_FILE_H_
 #define OBJECT_UTILS_OBJECT_FILE_H_
 
+#include <llvm/Object/Binary.h>
 #include <llvm/Object/ObjectFile.h>
 
 #include <filesystem>
@@ -12,7 +13,6 @@
 #include <string>
 
 #include "OrbitBase/Result.h"
-#include "llvm/Object/Binary.h"
 #include "symbol.pb.h"
 
 namespace orbit_object_utils {
@@ -26,7 +26,12 @@ class ObjectFile {
   [[nodiscard]] virtual bool HasDebugSymbols() const = 0;
   [[nodiscard]] virtual std::string GetName() const = 0;
   [[nodiscard]] virtual const std::filesystem::path& GetFilePath() const = 0;
+  [[nodiscard]] virtual bool IsElf() const = 0;
+  [[nodiscard]] virtual bool IsCoff() const = 0;
 };
+
+ErrorMessageOr<std::unique_ptr<ObjectFile>> CreateObjectFile(
+    const std::filesystem::path& file_path);
 
 }  // namespace orbit_object_utils
 

--- a/src/OrbitCore/SymbolHelper.h
+++ b/src/OrbitCore/SymbolHelper.h
@@ -5,8 +5,12 @@
 #ifndef SYMBOL_HELPER_H_
 #define SYMBOL_HELPER_H_
 
+#include <llvm/Object/Binary.h>
+#include <llvm/Object/ObjectFile.h>
+
 #include <filesystem>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 

--- a/src/OrbitCore/SymbolHelperTest.cpp
+++ b/src/OrbitCore/SymbolHelperTest.cpp
@@ -169,7 +169,7 @@ TEST(SymbolHelper, VerifySymbolsFile) {
     const auto result = SymbolHelper::VerifySymbolsFile(symbols_file, build_id);
     EXPECT_TRUE(result.has_error());
     EXPECT_THAT(absl::AsciiStrToLower(result.error().message()),
-                testing::HasSubstr("unable to load elf file"));
+                testing::HasSubstr("unable to load object file"));
   }
 }
 


### PR DESCRIPTION
COFF object file support is integrated into our tracing backend to
allow reading symbols from symbol tables in COFF files.

Bug: https://b/187665628
Tested: Unit tests; manually checked if loading of symbols is possible.