### PR TITLE
Differentiate main content with annotating lines

### DIFF
--- a/src/CodeViewer/CMakeLists.txt
+++ b/src/CodeViewer/CMakeLists.txt
@@ -12,6 +12,7 @@ target_include_directories(CodeViewer PUBLIC include/)
 target_link_libraries(CodeViewer PUBLIC CodeReport
                                         OrbitBase
                                         OrbitGl
+                                        SyntaxHighlighter
                                         Qt5::Widgets)
 
 target_sources(CodeViewer PUBLIC include/CodeViewer/Dialog.h

--- a/src/CodeViewer/Viewer.cpp
+++ b/src/CodeViewer/Viewer.cpp
@@ -24,6 +24,8 @@
 #include <QWheelEvent>
 #include <cmath>
 
+#include "SyntaxHighlighter/HighlightingMetadata.h"
+
 namespace orbit_code_viewer {
 
 static const QColor kLineNumberBackgroundColor{50, 50, 50};
@@ -43,7 +45,7 @@ int DetermineLineNumberWidthInPixels(const QFontMetrics& font_metrics, int max_l
 }
 
 namespace {
-struct Metadata : QTextBlockUserData {
+struct Metadata : public orbit_syntax_highlighter::HighlightingMetadata {
   enum LineType { kMainContent, kAnnotatingLine };
 
   LineType line_type = kMainContent;
@@ -52,6 +54,8 @@ struct Metadata : QTextBlockUserData {
   explicit Metadata(LineType line_type, uint64_t line_number)
       : line_type(line_type), line_number(line_number) {}
   explicit Metadata() = default;
+
+  [[nodiscard]] bool IsMainContentLine() const override { return line_type == kMainContent; }
 };
 }  // namespace
 

--- a/src/SyntaxHighlighter/CMakeLists.txt
+++ b/src/SyntaxHighlighter/CMakeLists.txt
@@ -12,7 +12,9 @@ target_include_directories(SyntaxHighlighter PUBLIC include/)
 target_link_libraries(SyntaxHighlighter PUBLIC OrbitBase Qt5::Gui)
 set_target_properties(SyntaxHighlighter PROPERTIES AUTOMOC ON)
 
-target_sources(SyntaxHighlighter PUBLIC include/SyntaxHighlighter/X86Assembly.h)
-target_sources(SyntaxHighlighter PRIVATE X86Assembly.cpp)
-target_sources(SyntaxHighlighter PUBLIC include/SyntaxHighlighter/Cpp.h)
-target_sources(SyntaxHighlighter PRIVATE Cpp.cpp)
+target_sources(SyntaxHighlighter PUBLIC include/SyntaxHighlighter/Cpp.h
+                                        include/SyntaxHighlighter/HighlightingMetadata.h
+                                        include/SyntaxHighlighter/X86Assembly.h)
+
+target_sources(SyntaxHighlighter PRIVATE Cpp.cpp
+                                         X86Assembly.cpp)

--- a/src/SyntaxHighlighter/include/SyntaxHighlighter/HighlightingMetadata.h
+++ b/src/SyntaxHighlighter/include/SyntaxHighlighter/HighlightingMetadata.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef HIGHLIGHTING_METADATA_H_
+#define HIGHLIGHTING_METADATA_H_
+
+#include <QTextBlockUserData>
+
+namespace orbit_syntax_highlighter {
+
+class HighlightingMetadata : public QTextBlockUserData {
+ public:
+  [[nodiscard]] virtual bool IsMainContentLine() const = 0;
+};
+
+}  // namespace orbit_syntax_highlighter
+
+#endif

--- a/src/SyntaxHighlighter/include/SyntaxHighlighter/X86Assembly.h
+++ b/src/SyntaxHighlighter/include/SyntaxHighlighter/X86Assembly.h
@@ -28,8 +28,11 @@ class X86Assembly : public QSyntaxHighlighter {
   explicit X86Assembly();
 };
 
-void HighlightBlockAssembly(const QString& code,
-                            std::function<void(int, int, const QTextCharFormat&)> set_format);
+void HighlightBlockAssembly(
+    const QString& code, const std::function<void(int, int, const QTextCharFormat&)>& set_format);
+void HighlightAnnotatingBlock(
+    const QString& code, const std::function<void(int, int, const QTextCharFormat&)>& set_format,
+    const QColor& default_color = Qt::white);
 
 }  // namespace orbit_syntax_highlighter
 


### PR DESCRIPTION
In this PR we are setting annotating lines to have lighter text color and lighter background. Now we can differentiate them from the main_content.

Second step in http://b/187388546.

Tested by CodeViewerDemo.
<img width="852" alt="Syntax Highlighter combined" src="https://user-images.githubusercontent.com/8610429/118987663-c3641280-b980-11eb-94ac-f03a41e4b6de.png">
