### PR TITLE
Always hook vkQueuePresentKHR in FakeClient to output avg frame time

### DIFF
--- a/src/FakeClient/FakeCaptureEventProcessor.h
+++ b/src/FakeClient/FakeCaptureEventProcessor.h
@@ -10,43 +10,83 @@
 
 namespace orbit_fake_client {
 
-// This implementation of CaptureEventProcessor simply discards all the events it receives, but it
-// keeps track of their number and total size and then outputs these statistics to file.
+// This implementation of CaptureEventProcessor mostly discard all events it receives, except for:
+// - keeping track of their number and total size, and writing these statistics to file;
+// - keeping track of the calls to the frame boundary function, and possibly writing the average
+//   frame time to file;
 class FakeCaptureEventProcessor : public orbit_capture_client::CaptureEventProcessor {
  public:
   void ProcessEvent(const orbit_grpc_protos::ClientCaptureEvent& event) override {
     ++event_count_;
     byte_count_ += event.ByteSizeLong();
+
+    // Keep track of the number of calls to the frame boundary function, of the timestamp of the
+    // first call, and of the timestamp of the last call. Below, the average frame time is then
+    // naively computed as (max_timestamp - min_timestamp) / (call_count - 1).
+    if (!event.has_function_call()) {
+      return;
+    }
+    const orbit_grpc_protos::FunctionCall& function_call = event.function_call();
+    if (function_call.function_id() != kFrameBoundaryFunctionId) {
+      return;
+    }
+    ++frame_boundary_count_;
+    uint64_t start_timestamp_ns = function_call.end_timestamp_ns() - function_call.duration_ns();
+    frame_boundary_min_timestamp_ns_ =
+        std::min(frame_boundary_min_timestamp_ns_, start_timestamp_ns);
+    frame_boundary_max_timestamp_ns_ =
+        std::max(frame_boundary_max_timestamp_ns_, start_timestamp_ns);
   }
 
   ~FakeCaptureEventProcessor() override {
     {
       LOG("Events received: %u", event_count_);
-      auto event_count_write_result =
+      ErrorMessageOr<void> event_count_write_result =
           orbit_base::WriteStringToFile(kEventCountFilename, std::to_string(event_count_));
-      if (event_count_write_result.has_error()) {
-        FATAL("Writing to \"%s\": %s", kEventCountFilename,
+      FAIL_IF(event_count_write_result.has_error(), "Writing to \"%s\": %s", kEventCountFilename,
               event_count_write_result.error().message());
-      }
     }
 
     {
       LOG("Bytes received: %u", byte_count_);
-      auto byte_count_write_result =
+      ErrorMessageOr<void> byte_count_write_result =
           orbit_base::WriteStringToFile(kByteCountFilename, std::to_string(byte_count_));
-      if (byte_count_write_result.has_error()) {
-        FATAL("Writing to \"%s\": %s", kByteCountFilename,
+      FAIL_IF(byte_count_write_result.has_error(), "Writing to \"%s\": %s", kByteCountFilename,
               byte_count_write_result.error().message());
+    }
+
+    {
+      // If the average frame time is not available, just output an empty string to the file.
+      std::string frame_time_ms_string;
+      if (frame_boundary_count_ >= 2) {
+        double frame_time_ms = static_cast<double>(frame_boundary_max_timestamp_ns_ -
+                                                   frame_boundary_min_timestamp_ns_) /
+                               1'000'000.0 / static_cast<double>(frame_boundary_count_ - 1);
+        frame_time_ms_string = absl::StrFormat("%.3f", frame_time_ms);
+        LOG("Avg. frame time (ms): %s", frame_time_ms_string);
       }
+      ErrorMessageOr<void> frame_time_write_result =
+          orbit_base::WriteStringToFile(kFrameTimeFilename, frame_time_ms_string);
+      FAIL_IF(frame_time_write_result.has_error(), "Writing to \"%s\": %s", kFrameTimeFilename,
+              frame_time_write_result.error().message());
     }
   }
+
+  // Instrument a function with this function id in order for FakeCaptureEventProcessor to use it as
+  // frame boundary to compute the average CPU frame time.
+  static constexpr uint64_t kFrameBoundaryFunctionId = std::numeric_limits<uint64_t>::max();
 
  private:
   static constexpr const char* kEventCountFilename = "OrbitFakeClient.event_count.txt";
   static constexpr const char* kByteCountFilename = "OrbitFakeClient.byte_count.txt";
+  static constexpr const char* kFrameTimeFilename = "OrbitFakeClient.frame_time.txt";
 
   uint64_t event_count_ = 0;
   uint64_t byte_count_ = 0;
+
+  uint64_t frame_boundary_count_ = 0;
+  uint64_t frame_boundary_min_timestamp_ns_ = std::numeric_limits<uint64_t>::max();
+  uint64_t frame_boundary_max_timestamp_ns_ = std::numeric_limits<uint64_t>::min();
 };
 
 }  // namespace orbit_fake_client


### PR DESCRIPTION
But only if the target has loaded `libvulkan.so.1`.

This might slightly affect the existing metrics in `OrbitService` performance
testing, but it seems only within measurement error. See below.

Bug: http://b/187827094

Test:

Tried on Trata, Infiltrator, and a binary that doesn't to graphics.
With Trata and Infiltrator, compare results with Orbit UI's frame tracks and
with the "Frame rate rendered" of the Stadia extension.
Note that Infiltrator doesn't hit 60 fps.

Compared the results of the OrbitService performance testing on YHITI with the
previous and with this version of `OrbitFakeClient`.
Previous: http://sponge2/6cd37b5c-792f-47b1-84db-6c4240377e77
This change: http://sponge2/8114a173-2bc6-4e7f-a165-1f6658eb3150
There doesn't seem to be any relevant difference.