### PR TITLE
Set FunctionInfo::orbit_type in CreateFunctionInfoFromInstrumentedFun…

### DIFF
--- a/src/OrbitGl/LiveFunctionsDataView.cpp
+++ b/src/OrbitGl/LiveFunctionsDataView.cpp
@@ -510,6 +510,7 @@ std::optional<FunctionInfo> LiveFunctionsDataView::CreateFunctionInfoFromInstrum
   result.set_module_build_id(instrumented_function.file_build_id());
   result.set_address(module_data->load_bias() + instrumented_function.file_offset());
   // size is unknown
+  orbit_client_data::function_utils::SetOrbitTypeFromName(&result);
 
   return result;
 }


### PR DESCRIPTION
…ction

This is done in the same way as in
`orbit_client_data::function_utils::CreateFunctionInfo`.

Bug: http://b/189293461