### PR TITLE
Add "-march" flags to linux profiles.

### DIFF
--- a/third_party/conan/configs/linux/profiles/clang7_debug
+++ b/third_party/conan/configs/linux/profiles/clang7_debug
@@ -1,7 +1,7 @@
 C_COMPILER=clang-7
 CXX_COMPILER=clang++-7
-C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/clang7_debug
+++ b/third_party/conan/configs/linux/profiles/clang7_debug
@@ -1,7 +1,7 @@
 C_COMPILER=clang-7
 CXX_COMPILER=clang++-7
-C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/clang7_release
+++ b/third_party/conan/configs/linux/profiles/clang7_release
@@ -1,7 +1,7 @@
 C_COMPILER=clang-7
 CXX_COMPILER=clang++-7
-C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/clang7_release
+++ b/third_party/conan/configs/linux/profiles/clang7_release
@@ -1,7 +1,7 @@
 C_COMPILER=clang-7
 CXX_COMPILER=clang++-7
-C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/clang7_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/clang7_relwithdebinfo
@@ -1,7 +1,7 @@
 C_COMPILER=clang-7
 CXX_COMPILER=clang++-7
-C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/clang7_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/clang7_relwithdebinfo
@@ -1,7 +1,7 @@
 C_COMPILER=clang-7
 CXX_COMPILER=clang++-7
-C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/clang8_debug
+++ b/third_party/conan/configs/linux/profiles/clang8_debug
@@ -1,7 +1,7 @@
 C_COMPILER=clang-8
 CXX_COMPILER=clang++-8
-C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/clang8_debug
+++ b/third_party/conan/configs/linux/profiles/clang8_debug
@@ -1,7 +1,7 @@
 C_COMPILER=clang-8
 CXX_COMPILER=clang++-8
-C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/clang8_release
+++ b/third_party/conan/configs/linux/profiles/clang8_release
@@ -1,7 +1,7 @@
 C_COMPILER=clang-8
 CXX_COMPILER=clang++-8
-C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/clang8_release
+++ b/third_party/conan/configs/linux/profiles/clang8_release
@@ -1,7 +1,7 @@
 C_COMPILER=clang-8
 CXX_COMPILER=clang++-8
-C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/clang8_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/clang8_relwithdebinfo
@@ -1,7 +1,7 @@
 C_COMPILER=clang-8
 CXX_COMPILER=clang++-8
-C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/clang8_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/clang8_relwithdebinfo
@@ -1,7 +1,7 @@
 C_COMPILER=clang-8
 CXX_COMPILER=clang++-8
-C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/clang9_debug
+++ b/third_party/conan/configs/linux/profiles/clang9_debug
@@ -1,7 +1,7 @@
 C_COMPILER=clang-9
 CXX_COMPILER=clang++-9
-C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/clang9_debug
+++ b/third_party/conan/configs/linux/profiles/clang9_debug
@@ -1,7 +1,7 @@
 C_COMPILER=clang-9
 CXX_COMPILER=clang++-9
-C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/clang9_release
+++ b/third_party/conan/configs/linux/profiles/clang9_release
@@ -1,7 +1,7 @@
 C_COMPILER=clang-9
 CXX_COMPILER=clang++-9
-C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/clang9_release
+++ b/third_party/conan/configs/linux/profiles/clang9_release
@@ -1,7 +1,7 @@
 C_COMPILER=clang-9
 CXX_COMPILER=clang++-9
-C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/clang9_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/clang9_relwithdebinfo
@@ -1,7 +1,7 @@
 C_COMPILER=clang-9
 CXX_COMPILER=clang++-9
-C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/clang9_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/clang9_relwithdebinfo
@@ -1,7 +1,7 @@
 C_COMPILER=clang-9
 CXX_COMPILER=clang++-9
-C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/gcc10_debug
+++ b/third_party/conan/configs/linux/profiles/gcc10_debug
@@ -1,7 +1,7 @@
 C_COMPILER=gcc-10
 CXX_COMPILER=g++-10
-C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/gcc10_debug
+++ b/third_party/conan/configs/linux/profiles/gcc10_debug
@@ -1,7 +1,7 @@
 C_COMPILER=gcc-10
 CXX_COMPILER=g++-10
-C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/gcc10_release
+++ b/third_party/conan/configs/linux/profiles/gcc10_release
@@ -1,7 +1,7 @@
 C_COMPILER=gcc-10
 CXX_COMPILER=g++-10
-C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/gcc10_release
+++ b/third_party/conan/configs/linux/profiles/gcc10_release
@@ -1,7 +1,7 @@
 C_COMPILER=gcc-10
 CXX_COMPILER=g++-10
-C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/gcc10_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/gcc10_relwithdebinfo
@@ -1,7 +1,7 @@
 C_COMPILER=gcc-10
 CXX_COMPILER=g++-10
-C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/gcc10_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/gcc10_relwithdebinfo
@@ -1,7 +1,7 @@
 C_COMPILER=gcc-10
 CXX_COMPILER=g++-10
-C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/gcc8_debug
+++ b/third_party/conan/configs/linux/profiles/gcc8_debug
@@ -1,7 +1,7 @@
 C_COMPILER=gcc-8
 CXX_COMPILER=g++-8
-C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/gcc8_debug
+++ b/third_party/conan/configs/linux/profiles/gcc8_debug
@@ -1,7 +1,7 @@
 C_COMPILER=gcc-8
 CXX_COMPILER=g++-8
-C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/gcc8_release
+++ b/third_party/conan/configs/linux/profiles/gcc8_release
@@ -1,7 +1,7 @@
 C_COMPILER=gcc-8
 CXX_COMPILER=g++-8
-C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/gcc8_release
+++ b/third_party/conan/configs/linux/profiles/gcc8_release
@@ -1,7 +1,7 @@
 C_COMPILER=gcc-8
 CXX_COMPILER=g++-8
-C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/gcc8_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/gcc8_relwithdebinfo
@@ -1,7 +1,7 @@
 C_COMPILER=gcc-8
 CXX_COMPILER=g++-8
-C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/gcc8_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/gcc8_relwithdebinfo
@@ -1,7 +1,7 @@
 C_COMPILER=gcc-8
 CXX_COMPILER=g++-8
-C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/gcc9_debug
+++ b/third_party/conan/configs/linux/profiles/gcc9_debug
@@ -1,7 +1,7 @@
 C_COMPILER=gcc-9
 CXX_COMPILER=g++-9
-C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/gcc9_debug
+++ b/third_party/conan/configs/linux/profiles/gcc9_debug
@@ -1,7 +1,7 @@
 C_COMPILER=gcc-9
 CXX_COMPILER=g++-9
-C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/gcc9_release
+++ b/third_party/conan/configs/linux/profiles/gcc9_release
@@ -1,7 +1,7 @@
 C_COMPILER=gcc-9
 CXX_COMPILER=g++-9
-C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/gcc9_release
+++ b/third_party/conan/configs/linux/profiles/gcc9_release
@@ -1,7 +1,7 @@
 C_COMPILER=gcc-9
 CXX_COMPILER=g++-9
-C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/gcc9_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/gcc9_relwithdebinfo
@@ -1,7 +1,7 @@
 C_COMPILER=gcc-9
 CXX_COMPILER=g++-9
-C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/gcc9_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/gcc9_relwithdebinfo
@@ -1,7 +1,7 @@
 C_COMPILER=gcc-9
 CXX_COMPILER=g++-9
-C_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXX_FLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+C_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXX_FLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LINKER_FLAGS= -Wl,-z,relro,-z,now,-z,noexecstack
 [settings]
 os=Linux

--- a/third_party/conan/configs/linux/profiles/ggp_debug
+++ b/third_party/conan/configs/linux/profiles/ggp_debug
@@ -18,6 +18,6 @@ OrbitProfiler:with_gui=False
 ggp_sdk/1.43.0.14282@orbitdeps/stable
 
 [env]
-CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CFLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXXFLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LDFLAGS= -Wl,-z,relro,-z,now,-z,noexecstack

--- a/third_party/conan/configs/linux/profiles/ggp_debug
+++ b/third_party/conan/configs/linux/profiles/ggp_debug
@@ -18,6 +18,6 @@ OrbitProfiler:with_gui=False
 ggp_sdk/1.43.0.14282@orbitdeps/stable
 
 [env]
-CFLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXXFLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CFLAGS= -march=broadwell -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXXFLAGS= -march=broadwell -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LDFLAGS= -Wl,-z,relro,-z,now,-z,noexecstack

--- a/third_party/conan/configs/linux/profiles/ggp_release
+++ b/third_party/conan/configs/linux/profiles/ggp_release
@@ -18,6 +18,6 @@ OrbitProfiler:with_gui=False
 ggp_sdk/1.43.0.14282@orbitdeps/stable
 
 [env]
-CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CFLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXXFLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LDFLAGS= -Wl,-z,relro,-z,now,-z,noexecstack

--- a/third_party/conan/configs/linux/profiles/ggp_release
+++ b/third_party/conan/configs/linux/profiles/ggp_release
@@ -18,6 +18,6 @@ OrbitProfiler:with_gui=False
 ggp_sdk/1.43.0.14282@orbitdeps/stable
 
 [env]
-CFLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXXFLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CFLAGS= -march=broadwell -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXXFLAGS= -march=broadwell -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LDFLAGS= -Wl,-z,relro,-z,now,-z,noexecstack

--- a/third_party/conan/configs/linux/profiles/ggp_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/ggp_relwithdebinfo
@@ -18,6 +18,6 @@ OrbitProfiler:with_gui=False
 ggp_sdk/1.43.0.14282@orbitdeps/stable
 
 [env]
-CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CFLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXXFLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LDFLAGS= -Wl,-z,relro,-z,now,-z,noexecstack

--- a/third_party/conan/configs/linux/profiles/ggp_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/ggp_relwithdebinfo
@@ -18,6 +18,6 @@ OrbitProfiler:with_gui=False
 ggp_sdk/1.43.0.14282@orbitdeps/stable
 
 [env]
-CFLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
-CXXFLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CFLAGS= -march=broadwell -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
+CXXFLAGS= -march=broadwell -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all
 LDFLAGS= -Wl,-z,relro,-z,now,-z,noexecstack

--- a/third_party/conan/configs/linux/profiles/libfuzzer_base
+++ b/third_party/conan/configs/linux/profiles/libfuzzer_base
@@ -1,8 +1,8 @@
 # This file is intended to be imported when building for oss-fuzz
 # Compiler and settings are auto-detected in that case, but we want to have
 # an upstream config file where settings can be changed.
-BASE_CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -D_FORTIFY_SOURCE=2 -fstack-protector-all -fPIC
-BASE_CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all -fPIC
+BASE_CFLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -D_FORTIFY_SOURCE=2 -fstack-protector-all -fPIC
+BASE_CXXFLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all -fPIC
 BASE_LDFLAGS=-Wl,-z,relro,-z,now,-z,noexecstack -pthread
 [settings]
 abseil:compiler=clang

--- a/third_party/conan/configs/linux/profiles/libfuzzer_base
+++ b/third_party/conan/configs/linux/profiles/libfuzzer_base
@@ -1,8 +1,8 @@
 # This file is intended to be imported when building for oss-fuzz
 # Compiler and settings are auto-detected in that case, but we want to have
 # an upstream config file where settings can be changed.
-BASE_CFLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -D_FORTIFY_SOURCE=2 -fstack-protector-all -fPIC
-BASE_CXXFLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all -fPIC
+BASE_CFLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -D_FORTIFY_SOURCE=2 -fstack-protector-all -fPIC
+BASE_CXXFLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all -fPIC
 BASE_LDFLAGS=-Wl,-z,relro,-z,now,-z,noexecstack -pthread
 [settings]
 abseil:compiler=clang

--- a/third_party/conan/configs/linux/profiles/libfuzzer_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/libfuzzer_relwithdebinfo
@@ -1,5 +1,5 @@
-CFLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -D_FORTIFY_SOURCE=2 -fstack-protector-all -fPIC
-CXXFLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all -fPIC
+CFLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -D_FORTIFY_SOURCE=2 -fstack-protector-all -fPIC
+CXXFLAGS= -march=sandybridge -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all -fPIC
 SANITIZE_CFLAGS=-fsanitize=fuzzer-no-link,address
 SANITIZE_CXXFLAGS=-fsanitize=fuzzer-no-link,address
 [settings]

--- a/third_party/conan/configs/linux/profiles/libfuzzer_relwithdebinfo
+++ b/third_party/conan/configs/linux/profiles/libfuzzer_relwithdebinfo
@@ -1,5 +1,5 @@
-CFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -D_FORTIFY_SOURCE=2 -fstack-protector-all -fPIC
-CXXFLAGS= -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all -fPIC
+CFLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -D_FORTIFY_SOURCE=2 -fstack-protector-all -fPIC
+CXXFLAGS= -mavx2 -mfma -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all -fPIC
 SANITIZE_CFLAGS=-fsanitize=fuzzer-no-link,address
 SANITIZE_CXXFLAGS=-fsanitize=fuzzer-no-link,address
 [settings]


### PR DESCRIPTION
I need avx support for a test (checking proper handling of m256
parameters in the context of user space instrumentation). This
could be handled in a way that only the test is affected and strictly
speaking I only need avx.
But I guess there should be pretty little reason not to add avx2
support globally.

Test: Compiled / ran unit tests with clang9 and gcc8. Let's see if the
CI works finds something.