### PR TITLE
Remove TimeGraph dependency from LiveFunctionsDataView

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2355,6 +2355,33 @@ bool OrbitApp::HasFrameTrackInCaptureData(uint64_t instrumented_function_id) con
   return GetTimeGraph()->HasFrameTrack(instrumented_function_id);
 }
 
+void OrbitApp::JumpToTextBoxAndZoom(uint64_t function_id, JumpToTextBoxMode selection_mode) {
+  switch (selection_mode) {
+    case JumpToTextBoxMode::kFirst: {
+      const auto* first_box = GetTimeGraph()->FindNextFunctionCall(
+          function_id, std::numeric_limits<uint64_t>::lowest());
+      if (first_box != nullptr) GetMutableTimeGraph()->SelectAndZoom(first_box);
+      break;
+    }
+    case JumpToTextBoxMode::kLast: {
+      const auto* last_box = GetTimeGraph()->FindPreviousFunctionCall(
+          function_id, std::numeric_limits<uint64_t>::max());
+      if (last_box != nullptr) GetMutableTimeGraph()->SelectAndZoom(last_box);
+      break;
+    }
+    case JumpToTextBoxMode::kMin: {
+      auto [min_box, unused_max_box] = GetTimeGraph()->GetMinMaxTextBoxForFunction(function_id);
+      if (min_box != nullptr) GetMutableTimeGraph()->SelectAndZoom(min_box);
+      break;
+    }
+    case JumpToTextBoxMode::kMax: {
+      auto [unused_min_box, max_box] = GetTimeGraph()->GetMinMaxTextBoxForFunction(function_id);
+      if (max_box != nullptr) GetMutableTimeGraph()->SelectAndZoom(max_box);
+      break;
+    }
+  }
+}
+
 void OrbitApp::RefreshFrameTracks() {
   CHECK(HasCaptureData());
   CHECK(std::this_thread::get_id() == main_thread_id_);

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -452,6 +452,9 @@ class OrbitApp final : public DataViewFactory, public orbit_capture_client::Capt
 
   [[nodiscard]] bool HasFrameTrackInCaptureData(uint64_t instrumented_function_id) const;
 
+  enum class JumpToTextBoxMode { kFirst, kLast, kMin, kMax };
+  void JumpToTextBoxAndZoom(uint64_t function_id, JumpToTextBoxMode selection_mode);
+
  private:
   void UpdateModulesAbortCaptureIfModuleWithoutBuildIdNeedsReload(
       absl::Span<const orbit_grpc_protos::ModuleInfo> module_infos);

--- a/src/OrbitGl/LiveFunctionsDataView.cpp
+++ b/src/OrbitGl/LiveFunctionsDataView.cpp
@@ -293,33 +293,19 @@ void LiveFunctionsDataView::OnContextMenu(const std::string& action, int menu_in
   } else if (action == kMenuActionJumpToFirst) {
     CHECK(item_indices.size() == 1);
     auto function_id = GetInstrumentedFunctionId(item_indices[0]);
-    const auto* first_box = app_->GetTimeGraph()->FindNextFunctionCall(
-        function_id, std::numeric_limits<uint64_t>::lowest());
-    if (first_box != nullptr) {
-      app_->GetMutableTimeGraph()->SelectAndZoom(first_box);
-    }
+    app_->JumpToTextBoxAndZoom(function_id, OrbitApp::JumpToTextBoxMode::kFirst);
   } else if (action == kMenuActionJumpToLast) {
     CHECK(item_indices.size() == 1);
     auto function_id = GetInstrumentedFunctionId(item_indices[0]);
-    const auto* last_box = app_->GetTimeGraph()->FindPreviousFunctionCall(
-        function_id, std::numeric_limits<uint64_t>::max());
-    if (last_box != nullptr) {
-      app_->GetMutableTimeGraph()->SelectAndZoom(last_box);
-    }
+    app_->JumpToTextBoxAndZoom(function_id, OrbitApp::JumpToTextBoxMode::kLast);
   } else if (action == kMenuActionJumpToMin) {
     CHECK(item_indices.size() == 1);
     uint64_t function_id = GetInstrumentedFunctionId(item_indices[0]);
-    auto [min_box, _] = app_->GetTimeGraph()->GetMinMaxTextBoxForFunction(function_id);
-    if (min_box != nullptr) {
-      app_->GetMutableTimeGraph()->SelectAndZoom(min_box);
-    }
+    app_->JumpToTextBoxAndZoom(function_id, OrbitApp::JumpToTextBoxMode::kMin);
   } else if (action == kMenuActionJumpToMax) {
     CHECK(item_indices.size() == 1);
     uint64_t function_id = GetInstrumentedFunctionId(item_indices[0]);
-    auto [_, max_box] = app_->GetTimeGraph()->GetMinMaxTextBoxForFunction(function_id);
-    if (max_box != nullptr) {
-      app_->GetMutableTimeGraph()->SelectAndZoom(max_box);
-    }
+    app_->JumpToTextBoxAndZoom(function_id, OrbitApp::JumpToTextBoxMode::kMax);
   } else if (action == kMenuActionIterate) {
     for (int i : item_indices) {
       uint64_t instrumented_function_id = GetInstrumentedFunctionId(i);

--- a/src/OrbitGl/LiveFunctionsDataView.cpp
+++ b/src/OrbitGl/LiveFunctionsDataView.cpp
@@ -20,7 +20,6 @@
 #include "App.h"
 #include "ClientData/FunctionUtils.h"
 #include "ClientModel/CaptureData.h"
-#include "CoreUtils.h"
 #include "DataViewTypes.h"
 #include "FunctionsDataView.h"
 #include "GrpcProtos/Constants.h"

--- a/src/OrbitGl/LiveFunctionsDataView.h
+++ b/src/OrbitGl/LiveFunctionsDataView.h
@@ -15,8 +15,6 @@
 
 #include "DataView.h"
 #include "MetricsUploader/MetricsUploader.h"
-#include "TextBox.h"
-#include "TimerChain.h"
 #include "capture.pb.h"
 #include "capture_data.pb.h"
 
@@ -55,7 +53,6 @@ class LiveFunctionsDataView : public DataView {
   [[nodiscard]] uint64_t GetInstrumentedFunctionId(uint32_t row) const;
   [[nodiscard]] const orbit_client_protos::FunctionInfo& GetInstrumentedFunction(
       uint32_t row) const;
-  [[nodiscard]] std::pair<const TextBox*, const TextBox*> GetMinMax(uint64_t function_id) const;
   [[nodiscard]] std::optional<orbit_client_protos::FunctionInfo>
   CreateFunctionInfoFromInstrumentedFunction(
       const orbit_grpc_protos::InstrumentedFunction& instrumented_function);

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -982,16 +982,16 @@ std::pair<const TextBox*, const TextBox*> TimeGraph::GetMinMaxTextBoxForFunction
     for (auto& block : *chain) {
       for (size_t i = 0; i < block.size(); i++) {
         const TextBox& box = block[i];
-        if (box.GetTimerInfo().function_id() == function_id) {
-          uint64_t elapsed_nanos = box.GetTimerInfo().end() - box.GetTimerInfo().start();
-          if (min_box == nullptr ||
-              elapsed_nanos < (min_box->GetTimerInfo().end() - min_box->GetTimerInfo().start())) {
-            min_box = &box;
-          }
-          if (max_box == nullptr ||
-              elapsed_nanos > (max_box->GetTimerInfo().end() - max_box->GetTimerInfo().start())) {
-            max_box = &box;
-          }
+        if (box.GetTimerInfo().function_id() != function_id) continue;
+
+        uint64_t elapsed_nanos = box.GetTimerInfo().end() - box.GetTimerInfo().start();
+        if (min_box == nullptr ||
+            elapsed_nanos < (min_box->GetTimerInfo().end() - min_box->GetTimerInfo().start())) {
+          min_box = &box;
+        }
+        if (max_box == nullptr ||
+            elapsed_nanos > (max_box->GetTimerInfo().end() - max_box->GetTimerInfo().start())) {
+          max_box = &box;
         }
       }
     }

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -140,6 +140,8 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
   [[nodiscard]] const TextBox* FindNext(const TextBox* from);
   [[nodiscard]] const TextBox* FindTop(const TextBox* from);
   [[nodiscard]] const TextBox* FindDown(const TextBox* from);
+  [[nodiscard]] std::pair<const TextBox*, const TextBox*> GetMinMaxTextBoxForFunction(
+      uint64_t function_id) const;
 
   [[nodiscard]] static Color GetColor(uint32_t id) {
     constexpr unsigned char kAlpha = 255;


### PR DESCRIPTION
Eventually LiveFunctionsDataView should be moved into a separate DataView module to make testing easier.
For this to happen all the DataViews may not depend on TimeGraph anymore.

So this PR removes TimeGraph dependency from LiveFunctionsDataView.