### PR TITLE
Relocate instructions.

### DIFF
--- a/src/UserSpaceInstrumentation/MachineCode.cpp
+++ b/src/UserSpaceInstrumentation/MachineCode.cpp
@@ -4,6 +4,8 @@
 
 #include "MachineCode.h"
 
+#include <absl/base/casts.h>
+
 namespace orbit_user_space_instrumentation {
 
 MachineCode& MachineCode::AppendBytes(const std::vector<uint8_t>& data) {
@@ -24,6 +26,15 @@ MachineCode& MachineCode::AppendImmediate32(uint32_t data) {
     data_.push_back(data & 0xff);
     data = data >> 8;
   }
+  return *this;
+}
+
+MachineCode& MachineCode::AppendImmediate32(int32_t data) {
+  return AppendImmediate32(absl::bit_cast<uint32_t>(data));
+}
+
+MachineCode& MachineCode::AppendImmediate8(int8_t data) {
+  data_.push_back(absl::bit_cast<uint8_t>(data));
   return *this;
 }
 

--- a/src/UserSpaceInstrumentation/MachineCode.h
+++ b/src/UserSpaceInstrumentation/MachineCode.h
@@ -25,6 +25,8 @@ class MachineCode {
   MachineCode& AppendBytes(const std::vector<uint8_t>& data);
   MachineCode& AppendImmediate64(uint64_t data);
   MachineCode& AppendImmediate32(uint32_t data);
+  MachineCode& AppendImmediate32(int32_t data);
+  MachineCode& AppendImmediate8(int8_t data);
   const std::vector<uint8_t>& GetResultAsVector() const { return data_; }
 
  private:

--- a/src/UserSpaceInstrumentation/MachineCodeTest.cpp
+++ b/src/UserSpaceInstrumentation/MachineCodeTest.cpp
@@ -12,7 +12,7 @@ namespace orbit_user_space_instrumentation {
 
 TEST(MachineCodeTest, BuildCode) {
   MachineCode code;
-  uint32_t kSigned8 = 0x08;
+  int8_t kSigned8 = 0x08;
   uint32_t kUnsigned32 = 0x42;
   int32_t kSigned32 = -1;
   uint64_t kUnsigned64 = 0x54;

--- a/src/UserSpaceInstrumentation/MachineCodeTest.cpp
+++ b/src/UserSpaceInstrumentation/MachineCodeTest.cpp
@@ -12,11 +12,19 @@ namespace orbit_user_space_instrumentation {
 
 TEST(MachineCodeTest, BuildCode) {
   MachineCode code;
-  code.AppendBytes({0x48, 0xc7, 0xc3}).AppendImmediate32(0x42).AppendImmediate64(0x54);
+  uint32_t kSigned8 = 0x08;
+  uint32_t kUnsigned32 = 0x42;
+  int32_t kSigned32 = -1;
+  uint64_t kUnsigned64 = 0x54;
+  code.AppendBytes({0x48, 0xc7, 0xc3})
+      .AppendImmediate8(kSigned8)
+      .AppendImmediate32(kUnsigned32)
+      .AppendImmediate32(kSigned32)
+      .AppendImmediate64(kUnsigned64);
 
   EXPECT_EQ(code.GetResultAsVector(),
-            std::vector<uint8_t>({0x48, 0xc7, 0xc3, 0x42, 0x00, 0x00, 0x00, 0x54, 0x00, 0x00, 0x00,
-                                  0x00, 0x00, 0x00, 0x00}));
+            std::vector<uint8_t>({0x48, 0xc7, 0xc3, 0x08, 0x42, 0x00, 0x00, 0x00, 0xff, 0xff,
+                                  0xff, 0xff, 0x54, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}));
 }
 
 }  // namespace orbit_user_space_instrumentation

--- a/src/UserSpaceInstrumentation/MachineCodeTest.cpp
+++ b/src/UserSpaceInstrumentation/MachineCodeTest.cpp
@@ -12,19 +12,19 @@ namespace orbit_user_space_instrumentation {
 
 TEST(MachineCodeTest, BuildCode) {
   MachineCode code;
-  int8_t kSigned8 = 0x08;
-  uint32_t kUnsigned32 = 0x42;
-  int32_t kSigned32 = -1;
-  uint64_t kUnsigned64 = 0x54;
+  constexpr int8_t kInt8 = 0x08;
+  constexpr uint32_t kUInt32 = 0x32;
+  constexpr int32_t kInt32 = -1;
+  constexpr uint64_t kUInt64 = 0x64;
   code.AppendBytes({0x48, 0xc7, 0xc3})
-      .AppendImmediate8(kSigned8)
-      .AppendImmediate32(kUnsigned32)
-      .AppendImmediate32(kSigned32)
-      .AppendImmediate64(kUnsigned64);
+      .AppendImmediate8(kInt8)
+      .AppendImmediate32(kUInt32)
+      .AppendImmediate32(kInt32)
+      .AppendImmediate64(kUInt64);
 
   EXPECT_EQ(code.GetResultAsVector(),
-            std::vector<uint8_t>({0x48, 0xc7, 0xc3, 0x08, 0x42, 0x00, 0x00, 0x00, 0xff, 0xff,
-                                  0xff, 0xff, 0x54, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}));
+            std::vector<uint8_t>({0x48, 0xc7, 0xc3, 0x08, 0x32, 0x00, 0x00, 0x00, 0xff, 0xff,
+                                  0xff, 0xff, 0x64, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}));
 }
 
 }  // namespace orbit_user_space_instrumentation

--- a/src/UserSpaceInstrumentation/Trampoline.cpp
+++ b/src/UserSpaceInstrumentation/Trampoline.cpp
@@ -4,6 +4,7 @@
 
 #include "Trampoline.h"
 
+#include <absl/base/casts.h>
 #include <absl/strings/numbers.h>
 #include <absl/strings/str_format.h>
 #include <absl/strings/str_split.h>
@@ -13,6 +14,7 @@
 #include <string>
 
 #include "AllocateInTracee.h"
+#include "MachineCode.h"
 #include "OrbitBase/ExecuteCommand.h"
 #include "OrbitBase/GetProcessIds.h"
 #include "OrbitBase/Logging.h"
@@ -22,8 +24,21 @@
 
 namespace orbit_user_space_instrumentation {
 
+namespace {
+
 using absl::numbers_internal::safe_strtou64_base;
 using orbit_base::ReadFileToString;
+
+std::string InstructionBytesAsString(cs_insn* instruction) {
+  std::string result;
+  for (int i = 0; i < instruction->size; i++) {
+    result = absl::StrCat(result, i == 0 ? absl::StrFormat("%#0.2x", instruction->bytes[i])
+                                         : absl::StrFormat(" %0.2x", instruction->bytes[i]));
+  }
+  return result;
+}
+
+}  // namespace
 
 bool DoAddressRangesOverlap(const AddressRange& a, const AddressRange& b) {
   return !(b.end <= a.start || b.start >= a.end);
@@ -159,6 +174,126 @@ ErrorMessageOr<uint64_t> AllocateMemoryForTrampolines(pid_t pid, const AddressRa
   OUTCOME_TRY(unavailable_ranges, GetUnavailableAddressRanges(pid));
   OUTCOME_TRY(address_range, FindAddressRangeForTrampoline(unavailable_ranges, code_range, size));
   return AllocateInTracee(pid, address_range.start, size);
+}
+
+ErrorMessageOr<int32_t> AddressDifferenceAsInt32(uint64_t a, uint64_t b) {
+  const uint64_t abs_diff = (a > b) ? (a - b) : (b - a);
+  constexpr uint64_t kAbsMaxInt32AsUint64 =
+      static_cast<uint64_t>(std::numeric_limits<int32_t>::max());
+  constexpr uint64_t kAbsMinInt32AsUint64 =
+      static_cast<uint64_t>(-static_cast<int64_t>(std::numeric_limits<int32_t>::min()));
+  if ((a > b && abs_diff > kAbsMaxInt32AsUint64) || (b > a && abs_diff > kAbsMinInt32AsUint64)) {
+    return ErrorMessage("Difference is larger than +-2GB.");
+  }
+  return a - b;
+}
+
+ErrorMessageOr<RelocatedInstruction> RelocateInstruction(cs_insn* instruction, uint64_t old_address,
+                                                         uint64_t new_address) {
+  RelocatedInstruction result;
+  if ((instruction->detail->x86.modrm & 0xC7) == 0x05) {
+    // The modrm byte can encode a memory operand as a signed 32 bit displacement on the rip. See
+    // "Intel 64 and IA-32 Architectures Software Developer’s Manual Vol. 2A" Chapter 2.1.
+    // Specifically table 2-2.
+    const int32_t old_displacement = *absl::bit_cast<int32_t*>(
+        instruction->bytes + instruction->detail->x86.encoding.disp_offset);
+    const uint64_t old_absolute_address = old_address + instruction->size + old_displacement;
+    ErrorMessageOr<int32_t> new_displacement_or_error =
+        AddressDifferenceAsInt32(old_absolute_address, new_address + instruction->size);
+    if (new_displacement_or_error.has_error()) {
+      return ErrorMessage(absl::StrFormat(
+          "While trying to relocate an instruction with rip relative addressing the target was out "
+          "of range from the trampoline. old address: %#x, new address :%#x instruction: %s",
+          old_address, new_address, InstructionBytesAsString(instruction)));
+    }
+    result.code.resize(instruction->size);
+    memcpy(result.code.data(), instruction->bytes, instruction->size);
+    *absl::bit_cast<int32_t*>(result.code.data() + instruction->detail->x86.encoding.disp_offset) =
+        new_displacement_or_error.value();
+  } else if (instruction->detail->x86.opcode[0] == 0xeb ||
+             instruction->detail->x86.opcode[0] == 0xe9) {
+    // Unconditional jump to relative immediate parameter (32 bit or 8 bit).
+    // We compute the absolute address and jump there:
+    // jmp [rip + 0]                ff 25 00 00 00 00
+    // .byte absolute_address       01 02 03 04 05 06 07 08
+    const int32_t immediate =
+        (instruction->detail->x86.opcode[0] == 0xe9)
+            ? *absl::bit_cast<int32_t*>(instruction->bytes +
+                                        instruction->detail->x86.encoding.imm_offset)
+            : *absl::bit_cast<int8_t*>(instruction->bytes +
+                                       instruction->detail->x86.encoding.imm_offset);
+    const uint64_t absolute_address = old_address + instruction->size + immediate;
+    MachineCode code;
+    code.AppendBytes({0xff, 0x25}).AppendImmediate32(0x0000000).AppendImmediate64(absolute_address);
+    result.code = code.GetResultAsVector();
+    result.position_of_absolute_address = 6;
+  } else if (instruction->detail->x86.opcode[0] == 0xe8) {
+    // Call function at relative immediate parameter.
+    // We compute the absolute address of the called function and call it like this:
+    // Call [rip+2]                 ff 15 02 00 00 00
+    // jmp label;                   eb 08
+    // .byte absolute_address       01 02 03 04 05 06 07 08
+    // label:
+    const int32_t immediate = *absl::bit_cast<int32_t*>(
+        instruction->bytes + instruction->detail->x86.encoding.imm_offset);
+    const uint64_t absolute_address = old_address + instruction->size + immediate;
+    MachineCode code;
+    code.AppendBytes({0xff, 0x15})
+        .AppendImmediate32(0x00000002)
+        .AppendBytes({0xeb, 0x08})
+        .AppendImmediate64(absolute_address);
+    result.code = code.GetResultAsVector();
+    result.position_of_absolute_address = 8;
+  } else if ((instruction->detail->x86.opcode[0] & 0xf0) == 0x70) {
+    // 0x7? are conditional jumps to an 8 bit immediate.
+    // We invert the condition of the jump and construct the following code sequence.
+    // j(!cc) 0x0e                  7? 0e
+    // jmp [rip + 0]                ff 25 00 00 00 00
+    // .byte absolute_address       01 02 03 04 05 06 07 08
+    const int8_t immediate =
+        *absl::bit_cast<int8_t*>(instruction->bytes + instruction->detail->x86.encoding.imm_offset);
+    const uint64_t absolute_address = old_address + instruction->size + immediate;
+    MachineCode code;
+    // Inverting the last bit negates the condidion for the jump (e.g. 0x74 is "jump if equal", 0x75
+    // is "jump if not equal").
+    const uint8_t opcode = 0x01 ^ instruction->detail->x86.opcode[0];
+    code.AppendBytes({opcode, 0x0e})
+        .AppendBytes({0xff, 0x25, 0x00, 0x00, 0x00, 0x00})
+        .AppendImmediate64(absolute_address);
+    result.code = code.GetResultAsVector();
+    result.position_of_absolute_address = 8;
+  } else if (instruction->detail->x86.opcode[0] == 0x0f &&
+             (instruction->detail->x86.opcode[1] & 0xf0) == 0x80) {
+    // 0x0f 0x8? are conditional jumps to a 32 bit immediate
+    // We invert the condition of the jump and construct the following code sequence.
+    // j(!cc) 0x0e                  7? 0e
+    // jmp [rip + 0]                ff 25 00 00 00 00
+    // .byte absolute_address       01 02 03 04 05 06 07 08
+    const int32_t immediate = *absl::bit_cast<int32_t*>(
+        instruction->bytes + instruction->detail->x86.encoding.imm_offset);
+    const uint64_t absolute_address = old_address + instruction->size + immediate;
+    MachineCode code;
+    // Inverting the last bit negates the condidion for the jump. We need a jump to an eight bit
+    // immediate (opcode 0x7?).
+    const uint8_t opcode = 0x70 | (0x01 ^ (instruction->detail->x86.opcode[1] & 0x0f));
+    code.AppendBytes({opcode, 0x0e})
+        .AppendBytes({0xff, 0x25, 0x00, 0x00, 0x00, 0x00})
+        .AppendImmediate64(absolute_address);
+    result.code = code.GetResultAsVector();
+    result.position_of_absolute_address = 8;
+  } else if ((instruction->detail->x86.opcode[0] & 0xfc) == 0xe0) {
+    // 0xe{0, 1, 2, 3} loops to an 8 bit immediate. These instructions are not used by modern
+    // compilers. Depending on whether we ever see them we might implement something eventually.
+    return ErrorMessage(
+        absl::StrFormat("Relocating a loop instruction is not supported. Instruction: %s",
+                        InstructionBytesAsString(instruction)));
+  } else {
+    // All other instructions can just be copied.
+    result.code.resize(instruction->size);
+    memcpy(result.code.data(), instruction->bytes, instruction->size);
+  }
+
+  return result;
 }
 
 }  // namespace orbit_user_space_instrumentation

--- a/src/UserSpaceInstrumentation/Trampoline.cpp
+++ b/src/UserSpaceInstrumentation/Trampoline.cpp
@@ -220,7 +220,7 @@ ErrorMessageOr<RelocatedInstruction> RelocateInstruction(cs_insn* instruction, u
   } else if (instruction->detail->x86.opcode[0] == 0xeb ||
              instruction->detail->x86.opcode[0] == 0xe9) {
     // This handles unconditional jump to relative immediate parameter (32 bit or 8 bit).
-    // Examples of original code 
+    // Examples of original code
     // (endless loop doing nothing)
     // nop                          90
     // jmp 0xfc                     eb fc
@@ -239,7 +239,9 @@ ErrorMessageOr<RelocatedInstruction> RelocateInstruction(cs_insn* instruction, u
                                        instruction->detail->x86.encoding.imm_offset);
     const uint64_t absolute_address = old_address + instruction->size + immediate;
     MachineCode code;
-    code.AppendBytes({0xff, 0x25}).AppendImmediate32(0x00000000).AppendImmediate64(absolute_address);
+    code.AppendBytes({0xff, 0x25})
+        .AppendImmediate32(0x00000000)
+        .AppendImmediate64(absolute_address);
     result.code = code.GetResultAsVector();
     result.position_of_absolute_address = 6;
   } else if (instruction->detail->x86.opcode[0] == 0xe8) {

--- a/src/UserSpaceInstrumentation/Trampoline.h
+++ b/src/UserSpaceInstrumentation/Trampoline.h
@@ -65,13 +65,14 @@ namespace orbit_user_space_instrumentation {
 // Merely serves as a return value for the function below.
 struct RelocatedInstruction {
   // Machine code of the relocated instruction. Might contain multiple instructions to emulate what
-  // the original instruction acchieved.
+  // the original instruction achieved.
   std::vector<uint8_t> code;
 
-  // Some relocated instructions contain an absolute address that needs to be adjusted once all the
-  // relocations are done. The position of this absolute address is stored here.
-  // Example: A conditional jump to a forward position needs to know the position of a instruction
-  // not yet processed.
+  // Some relocated instructions contain an absolute address stored in the 'code' above. That
+  // address needs to be adjusted once all the relocations are done. The position of this absolute
+  // address in 'code' is what is stored here.
+  // Example: A conditional jump to a forward position needs to know the
+  // position of an instruction not yet processed.
   //
   // Original code does the following: condition cc is true -> InstructionB,
   // otherwise -> InstructionA, InstructionB

--- a/src/UserSpaceInstrumentation/Trampoline.h
+++ b/src/UserSpaceInstrumentation/Trampoline.h
@@ -58,6 +58,57 @@ namespace orbit_user_space_instrumentation {
                                                                     const AddressRange& code_range,
                                                                     uint64_t size);
 
+// Returns the signed 32 bit difference (a-b) between two absolute virtual 64 bit addresses or an
+// error if the difference is too large.
+[[nodiscard]] ErrorMessageOr<int32_t> AddressDifferenceAsInt32(uint64_t a, uint64_t b);
+
+// Merely serves as a return value for the function below.
+struct RelocatedInstruction {
+  // Machine code of the relocated instruction. Might contain multiple instructions to emulate what
+  // the original instruction acchieved.
+  std::vector<uint8_t> code;
+
+  // Some relocated instructions contain an absolute address that needs to be adjusted once all the
+  // relocations are done. The position of this absolute address is stored here.
+  // Example: A conditional jump to a forward position needs to know the position of a instruction
+  // not yet processed.
+  //
+  // Original code does the following: condition cc is true -> InstructionB,
+  // otherwise -> InstructionA, InstructionB
+  //
+  // 0x0100: jcc rip+2 (==0x0104)
+  // 0x0102: InstructionA
+  // 0x0104: InstructionB
+  //
+  // -> relocate ->
+  //
+  // 0x0200: j(!cc) rip+08 (== 0x0210)
+  // 0x0202: jmp [rip+0] (== [0x0208])
+  // 0x0208: 8 byte destination address == address of relocated InstructionB == 0x0217
+  // 0x0210: InstructionA'
+  // 0x0217: InstructionB'
+  //
+  // The conditional jump at 0x0100 is translated into the first three lines of the result. The
+  // address (at 0x0208) of InstructionB' is not yet known at the point of the translation. So it
+  // needs to be recorded and handled later. In this case the `position_of_absolute_address` below
+  // would be 8.
+  std::optional<size_t> position_of_absolute_address = std::nullopt;
+};
+
+// Relocate `instruction` from `old_address` to `new_address`.
+// For many instructions the machine code can just be copied into the return value. The interesting
+// cases that need handling are relative jumps and calls, loop instructions and instructions that
+// use instruction pointer relative addressing (the implementation contains more detailed comments
+// for all the cases).
+// Returns the translated code and, optionally, a position in the code that might require an address
+// translation (details in the comment above).
+// Note that not all instructions can be handled (for various reasons, see the comments in the
+// implemention). At least in the current implementation it might not be possible to instrument some
+// functions.
+[[nodiscard]] ErrorMessageOr<RelocatedInstruction> RelocateInstruction(cs_insn* instruction,
+                                                                       uint64_t old_address,
+                                                                       uint64_t new_address);
+
 }  // namespace orbit_user_space_instrumentation
 
 #endif  // USER_SPACE_INSTRUMENTATION_TRAMPOLINE_H_

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -4,6 +4,7 @@
 
 #include <absl/strings/numbers.h>
 #include <absl/strings/str_split.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <cstdint>
@@ -12,9 +13,11 @@
 #include <vector>
 
 #include "AllocateInTracee.h"
+#include "MachineCode.h"
 #include "ObjectUtils/LinuxMap.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ReadFileToString.h"
+#include "OrbitBase/TestUtils.h"
 #include "RegisterState.h"
 #include "Trampoline.h"
 #include "UserSpaceInstrumentation/Attach.h"
@@ -24,7 +27,11 @@ namespace orbit_user_space_instrumentation {
 namespace {
 
 using absl::numbers_internal::safe_strtou64_base;
+using orbit_base::HasError;
+using orbit_base::HasNoError;
+using orbit_base::HasValue;
 using orbit_base::ReadFileToString;
+using testing::ElementsAreArray;
 
 extern "C" __attribute__((noinline)) int DoubleAndIncrement(int i) {
   i = 2 * i;
@@ -255,6 +262,215 @@ TEST(TrampolineTest, AllocateMemoryForTrampolines) {
   CHECK(DetachAndContinueProcess(pid).has_value());
   kill(pid, SIGKILL);
   waitpid(pid, nullptr, 0);
+}
+
+TEST(TrampolineTest, AddressDifferenceAsInt32) {
+  // Result of the difference is negative; in the first case it just fits the second case overflows.
+  const uint64_t kAddr1 = 0x6012345612345678;
+  const uint64_t kAddr2Larger = kAddr1 - std::numeric_limits<int32_t>::min();
+  auto result = AddressDifferenceAsInt32(kAddr1, kAddr2Larger);
+  ASSERT_THAT(result, HasNoError());
+  EXPECT_EQ(std::numeric_limits<int32_t>::min(), result.value());
+  result = AddressDifferenceAsInt32(kAddr1, kAddr2Larger + 1);
+  EXPECT_THAT(result, HasError("Difference is larger than +-2GB"));
+
+  // Result of the difference is positive; in the first case it just fits the second case overflows.
+  const uint64_t kAddr2Smaller = kAddr1 - std::numeric_limits<int32_t>::max();
+  result = AddressDifferenceAsInt32(kAddr1, kAddr2Smaller);
+  ASSERT_THAT(result, HasNoError());
+  EXPECT_EQ(std::numeric_limits<int32_t>::max(), result.value());
+  result = AddressDifferenceAsInt32(kAddr1, kAddr2Smaller - 1);
+  EXPECT_THAT(result, HasError("Difference is larger than +-2GB"));
+
+  // Result of the difference does not even fit into a int64. We handle that gracefully as well.
+  const uint64_t kAddrHigh = 0xf234567812345678;
+  const uint64_t kAddrLow = kAddrHigh - 0xe234567812345678;
+  result = AddressDifferenceAsInt32(kAddrHigh, kAddrLow);
+  EXPECT_THAT(result, HasError("Difference is larger than +-2GB"));
+  result = AddressDifferenceAsInt32(kAddrLow, kAddrHigh);
+  EXPECT_THAT(result, HasError("Difference is larger than +-2GB"));
+}
+
+class RelocateInstructionTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    CHECK(cs_open(CS_ARCH_X86, CS_MODE_64, &capstone_handle_) == CS_ERR_OK);
+    CHECK(cs_option(capstone_handle_, CS_OPT_DETAIL, CS_OPT_ON) == CS_ERR_OK);
+    instruction_ = cs_malloc(capstone_handle_);
+    CHECK(instruction_ != nullptr);
+  }
+
+  void Disassemble(const MachineCode& code) {
+    const uint8_t* code_pointer = code.GetResultAsVector().data();
+    size_t code_size = code.GetResultAsVector().size();
+    uint64_t disassemble_address = 0;
+    CHECK(cs_disasm_iter(capstone_handle_, &code_pointer, &code_size, &disassemble_address,
+                         instruction_));
+  }
+
+  void TearDown() override {
+    cs_free(instruction_, 1);
+    cs_close(&capstone_handle_);
+  }
+
+  cs_insn* instruction_ = nullptr;
+
+ private:
+  csh capstone_handle_ = 0;
+};
+
+TEST_F(RelocateInstructionTest, TrivialTranslation) {
+  MachineCode code;
+  // nop
+  code.AppendBytes({0x90});
+  Disassemble(code);
+
+  ErrorMessageOr<RelocatedInstruction> result =
+      RelocateInstruction(instruction_, 0x0100000000, 0x0200000000);
+  ASSERT_THAT(result, HasValue());
+  EXPECT_THAT(result.value().code, ElementsAreArray({0x90}));
+  EXPECT_FALSE(result.value().position_of_absolute_address.has_value());
+}
+
+TEST_F(RelocateInstructionTest, RipRelativeAddressing) {
+  MachineCode code;
+  constexpr int32_t kOffset = 0x969433;
+  // add qword ptr [rip + kOffset], 1
+  code.AppendBytes({0x48, 0x83, 0x05}).AppendImmediate32(kOffset).AppendBytes({0x01});
+  Disassemble(code);
+
+  uint64_t kOriginalAddress = 0x0100000000;
+  ErrorMessageOr<RelocatedInstruction> result =
+      RelocateInstruction(instruction_, kOriginalAddress, kOriginalAddress + kOffset - 0x123456);
+  ASSERT_THAT(result, HasValue());
+  EXPECT_THAT(result.value().code,
+              ElementsAreArray({0x48, 0x83, 0x05, 0x56, 0x34, 0x12, 0x00, 0x01}));
+  EXPECT_FALSE(result.value().position_of_absolute_address.has_value());
+
+  result =
+      RelocateInstruction(instruction_, kOriginalAddress, kOriginalAddress + kOffset + 0x123456);
+  ASSERT_THAT(result, HasValue());
+  // -0x123456 == 0xffedcbaa
+  EXPECT_THAT(result.value().code,
+              ElementsAreArray({0x48, 0x83, 0x05, 0xaa, 0xcb, 0xed, 0xff, 0x01}));
+  EXPECT_FALSE(result.value().position_of_absolute_address.has_value());
+
+  result = RelocateInstruction(instruction_, kOriginalAddress, kOriginalAddress - 0x7fff0000);
+  EXPECT_THAT(result,
+              HasError("While trying to relocate an instruction with rip relative addressing the "
+                       "target was out of range from the trampoline."));
+}
+
+TEST_F(RelocateInstructionTest, UnconditionalJumpTo8BitImmediate) {
+  MachineCode code;
+  constexpr int8_t kOffset = 0x08;
+  // jmp [rip + kOffset]
+  code.AppendBytes({0xeb}).AppendImmediate8(kOffset);
+  Disassemble(code);
+
+  ErrorMessageOr<RelocatedInstruction> result =
+      RelocateInstruction(instruction_, 0x0100000000, 0x0200000000);
+  ASSERT_THAT(result, HasValue());
+  // jmp  [rip + 0]               ff 25 00 00 00 00
+  // absolute_address             0a 00 00 00 01 00 00 00
+  // original jump instruction ends on 0x0100000000 + 0x02. Adding kOffset (=8) yields 0x010000000a.
+  EXPECT_THAT(result.value().code, ElementsAreArray({0xff, 0x25, 0x00, 0x00, 0x00, 0x00, 0x0a, 0x00,
+                                                     0x00, 0x00, 0x01, 0x00, 0x00, 0x00}));
+  ASSERT_TRUE(result.value().position_of_absolute_address.has_value());
+  EXPECT_EQ(6, result.value().position_of_absolute_address.value());
+}
+
+TEST_F(RelocateInstructionTest, UnconditionalJumpTo32BitImmediate) {
+  MachineCode code;
+  constexpr int32_t kOffset = 0x01020304;
+  // jmp [rip + kOffset]
+  code.AppendBytes({0xe9}).AppendImmediate32(kOffset);
+  Disassemble(code);
+
+  ErrorMessageOr<RelocatedInstruction> result =
+      RelocateInstruction(instruction_, 0x0100000000, 0x0200000000);
+  ASSERT_THAT(result, HasValue());
+  // jmp  [rip + 0]               ff 25 00 00 00 00
+  // absolute_address             09 03 02 01 01 00 00 00
+  // original jump instruction end on 0x0100000000 + 0x05. Adding kOffset yields 0x0101020309.
+  EXPECT_THAT(result.value().code, ElementsAreArray({0xff, 0x25, 0x00, 0x00, 0x00, 0x00, 0x09, 0x03,
+                                                     0x02, 0x01, 0x01, 0x00, 0x00, 0x00}));
+  ASSERT_TRUE(result.value().position_of_absolute_address.has_value());
+  EXPECT_EQ(6, result.value().position_of_absolute_address.value());
+}
+
+TEST_F(RelocateInstructionTest, CallToImmediateAddress) {
+  MachineCode code;
+  constexpr int32_t kOffset = 0x01020304;
+  // call [rip + kOffset]
+  code.AppendBytes({0xe8}).AppendImmediate32(kOffset);
+  Disassemble(code);
+
+  ErrorMessageOr<RelocatedInstruction> result =
+      RelocateInstruction(instruction_, 0x0100000000, 0x0200000000);
+  ASSERT_THAT(result, HasValue());
+  // Call [rip + 2]               ff 15 02 00 00 00
+  // jmp  [rip + 8]               eb 08
+  // absolute_address             09 03 02 01 01 00 00 00
+  EXPECT_THAT(result.value().code,
+              ElementsAreArray({0xff, 0x15, 0x02, 0x00, 0x00, 0x00, 0xeb, 0x08, 0x09, 0x03, 0x02,
+                                0x01, 0x01, 0x00, 0x00, 0x00}));
+  ASSERT_TRUE(result.value().position_of_absolute_address.has_value());
+  EXPECT_EQ(8, result.value().position_of_absolute_address.value());
+}
+
+TEST_F(RelocateInstructionTest, ConditionalJumpTo8BitImmediate) {
+  MachineCode code;
+  constexpr int8_t kOffset = 0x40;
+  // jno rip + kOffset
+  code.AppendBytes({0x71}).AppendImmediate8(kOffset);
+  Disassemble(code);
+
+  ErrorMessageOr<RelocatedInstruction> result =
+      RelocateInstruction(instruction_, 0x0100000000, 0x0200000000);
+  ASSERT_THAT(result, HasValue());
+  // jo rip + 16                  70 0e
+  // jmp [rip + 6]                ff 25 00 00 00 00
+  // absolute_address             42 00 00 00 01 00 00 00
+  // original jump instruction ends on 0x0100000002 + 0x40 (kOffset) == 0x0100000042.
+  EXPECT_THAT(result.value().code,
+              ElementsAreArray({0x70, 0x0e, 0xff, 0x25, 0x00, 0x00, 0x00, 0x00, 0x42, 0x00, 0x00,
+                                0x00, 0x01, 0x00, 0x00, 0x00}));
+  ASSERT_TRUE(result.value().position_of_absolute_address.has_value());
+  EXPECT_EQ(8, result.value().position_of_absolute_address.value());
+}
+
+TEST_F(RelocateInstructionTest, ConditionalJumpTo32BitImmediate) {
+  MachineCode code;
+  constexpr int32_t kOffset = 0x12345678;
+  // jno rip + kOffset           0f 80 78 56 34 12
+  code.AppendBytes({0x0f, 0x80}).AppendImmediate32(kOffset);
+  Disassemble(code);
+
+  ErrorMessageOr<RelocatedInstruction> result =
+      RelocateInstruction(instruction_, 0x0100000000, 0x0200000000);
+  ASSERT_TRUE(result.has_value());
+  // jo rip + 16                  71 0e
+  // jmp [rip +6]                 ff 25 00 00 00 00
+  // absolute_address             7a 56 34 12 01 00 00 00
+  // original jump instruction ends on 0x0100000006 + 0x12345678 (kOffset) == 0x011234567e.
+  EXPECT_THAT(result.value().code,
+              ElementsAreArray({0x71, 0x0e, 0xff, 0x25, 0x00, 0x00, 0x00, 0x00, 0x7e, 0x56, 0x34,
+                                0x12, 0x01, 0x00, 0x00, 0x00}));
+  ASSERT_TRUE(result.value().position_of_absolute_address.has_value());
+  EXPECT_EQ(8, result.value().position_of_absolute_address.value());
+}
+
+TEST_F(RelocateInstructionTest, LoopIsUnsupported) {
+  MachineCode code;
+  constexpr int8_t kOffset = 0x40;
+  // loopz rip + kOffset
+  code.AppendBytes({0xe1}).AppendImmediate8(kOffset);
+  Disassemble(code);
+
+  ErrorMessageOr<RelocatedInstruction> result =
+      RelocateInstruction(instruction_, 0x0100000000, 0x0200000000);
+  EXPECT_THAT(result, HasError("Relocating a loop instruction is not supported."));
 }
 
 }  // namespace orbit_user_space_instrumentation

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -273,7 +273,7 @@ TEST(TrampolineTest, AddressDifferenceAsInt32) {
   ASSERT_THAT(result, HasNoError());
   EXPECT_EQ(std::numeric_limits<int32_t>::min(), result.value());
   result = AddressDifferenceAsInt32(kAddr1, kAddr2Larger + 1);
-  EXPECT_THAT(result, HasError("Difference is larger than +-2GB"));
+  EXPECT_THAT(result, HasError("Difference is larger than -2GB"));
 
   // Result of the difference is positive; in the first case it just fits, the second case
   // overflows.
@@ -282,15 +282,15 @@ TEST(TrampolineTest, AddressDifferenceAsInt32) {
   ASSERT_THAT(result, HasNoError());
   EXPECT_EQ(std::numeric_limits<int32_t>::max(), result.value());
   result = AddressDifferenceAsInt32(kAddr1, kAddr2Smaller - 1);
-  EXPECT_THAT(result, HasError("Difference is larger than +-2GB"));
+  EXPECT_THAT(result, HasError("Difference is larger than +2GB"));
 
   // Result of the difference does not even fit into a int64. We handle that gracefully as well.
   const uint64_t kAddrHigh = 0xf234567812345678;
   const uint64_t kAddrLow = kAddrHigh - 0xe234567812345678;
   result = AddressDifferenceAsInt32(kAddrHigh, kAddrLow);
-  EXPECT_THAT(result, HasError("Difference is larger than +-2GB"));
+  EXPECT_THAT(result, HasError("Difference is larger than +2GB"));
   result = AddressDifferenceAsInt32(kAddrLow, kAddrHigh);
-  EXPECT_THAT(result, HasError("Difference is larger than +-2GB"));
+  EXPECT_THAT(result, HasError("Difference is larger than -2GB"));
 }
 
 class RelocateInstructionTest : public testing::Test {

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -334,7 +334,7 @@ TEST_F(RelocateInstructionTest, RipRelativeAddressing) {
       RelocateInstruction(instruction_, kOriginalAddress, kOriginalAddress + kOffset - 0x123456);
   ASSERT_THAT(result, HasValue());
   // add qword ptr [rip + new_offset], 1      48 83 05 56 34 12 00 01
-  // new_offset is computed as 
+  // new_offset is computed as
   // old_absolute_address - new_address
   // == (old_address + old_displacement) - (old_address + old_displacement - 0x123456)
   // == 0x123456
@@ -346,7 +346,7 @@ TEST_F(RelocateInstructionTest, RipRelativeAddressing) {
       RelocateInstruction(instruction_, kOriginalAddress, kOriginalAddress + kOffset + 0x123456);
   ASSERT_THAT(result, HasValue());
   // add qword ptr [rip + new_offset], 1      48 83 05 aa cb ed ff 01
-  // new_offset is computed as 
+  // new_offset is computed as
   // old_absolute_address - new_address
   // == (old_address + old_displacement) - (old_address + old_displacement + 0x123456)
   // == -0x123456 == 0xffedcbaa


### PR DESCRIPTION
Tooling to move instructions in memory. Interesting instructions are
e.g. relative jumps or instructions using ip relative addressing.

In order to keep the size of the PR limited this contains only the
code to move one individual instruction so there are no tests yet
that actually run the relocated instruction. This will follow in the
next PR.

Bug: http://b/183113989
Test: Unit tests in PR