### PR TITLE
Move files to new more visible location

### DIFF
--- a/src/OrbitCore/Path.cpp
+++ b/src/OrbitCore/Path.cpp
@@ -60,14 +60,18 @@ std::filesystem::path CreateOrGetCacheDir() {
   return cache_dir;
 }
 
+std::filesystem::path GetPresetDirPriorTo1_65() { return CreateOrGetOrbitAppDataDir() / "presets"; }
+
+std::filesystem::path GetCaptureDirPriorTo1_65() { return CreateOrGetOrbitAppDataDir() / "output"; }
+
 std::filesystem::path CreateOrGetPresetDir() {
-  std::filesystem::path preset_dir = CreateOrGetOrbitAppDataDir() / "presets";
+  std::filesystem::path preset_dir = CreateOrGetOrbitUserDataDir() / "presets";
   CreateDirectoryOrDie(preset_dir);
   return preset_dir;
 }
 
 std::filesystem::path CreateOrGetCaptureDir() {
-  std::filesystem::path capture_dir = CreateOrGetOrbitAppDataDir() / "output";
+  std::filesystem::path capture_dir = CreateOrGetOrbitUserDataDir() / "captures";
   CreateDirectoryOrDie(capture_dir);
   return capture_dir;
 }
@@ -84,6 +88,18 @@ std::filesystem::path CreateOrGetOrbitAppDataDir() {
 #else
   std::filesystem::path path = std::filesystem::path(GetEnvVar("HOME")) / ".orbitprofiler";
 #endif
+  CreateDirectoryOrDie(path);
+  return path;
+}
+
+std::filesystem::path CreateOrGetOrbitUserDataDir() {
+#ifdef WIN32
+  std::filesystem::path path = std::filesystem::path(GetEnvVar("USERPROFILE"));
+#else
+  std::filesystem::path path = std::filesystem::path(GetEnvVar("HOME"));
+#endif
+  path = path / "Documents" / "Orbit";
+  const auto mkdir_result = orbit_base::CreateDirectory(path);
   CreateDirectoryOrDie(path);
   return path;
 }

--- a/src/OrbitCore/Path.h
+++ b/src/OrbitCore/Path.h
@@ -14,6 +14,10 @@ namespace orbit_core {
 [[nodiscard]] std::filesystem::path CreateOrGetCaptureDir();
 [[nodiscard]] std::filesystem::path CreateOrGetDumpDir();
 [[nodiscard]] std::filesystem::path CreateOrGetOrbitAppDataDir();
+[[nodiscard]] std::filesystem::path CreateOrGetOrbitUserDataDir();
 [[nodiscard]] std::filesystem::path CreateOrGetLogDir();
 [[nodiscard]] std::filesystem::path GetLogFilePath();
+
+[[nodiscard]] std::filesystem::path GetPresetDirPriorTo1_65();
+[[nodiscard]] std::filesystem::path GetCaptureDirPriorTo1_65();
 };  // namespace orbit_core

--- a/src/OrbitQt/CMakeLists.txt
+++ b/src/OrbitQt/CMakeLists.txt
@@ -10,6 +10,10 @@ target_compile_options(OrbitQt PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(
   OrbitQt
+  PUBLIC include/OrbitQt/MoveFilesProcess.h)
+
+target_sources(
+  OrbitQt
   PRIVATE AccessibilityAdapter.h
           CallTreeViewItemModel.h
           CallTreeWidget.h
@@ -58,6 +62,9 @@ target_sources(
           ElidedLabel.cpp
           FilterPanelWidget.cpp
           FilterPanelWidgetAction.cpp
+          MoveFilesDialog.cpp
+          MoveFilesDialog.ui
+          MoveFilesProcess.cpp
           StatusListenerImpl.cpp
           DeploymentConfigurations.cpp
           orbitaboutdialog.cpp
@@ -95,6 +102,7 @@ target_sources(
           ../OrbitGl/ClientFlags.cpp)
 
 target_include_directories(OrbitQt PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(OrbitQt PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 target_link_libraries(
   OrbitQt

--- a/src/OrbitQt/MoveFilesDialog.cpp
+++ b/src/OrbitQt/MoveFilesDialog.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "OrbitQt/MoveFilesDialog.h"
+
+#include <QPlainTextEdit>
+#include <QString>
+
+#include "ui_MoveFilesDialog.h"
+
+namespace orbit_qt {
+
+MoveFilesDialog::MoveFilesDialog() : QDialog(nullptr), ui_(new Ui::MoveFilesDialog) {
+  ui_->setupUi(this);
+}
+
+MoveFilesDialog::~MoveFilesDialog() noexcept = default;
+
+void MoveFilesDialog::AddText(std::string_view text) {
+  ui_->log->append(QString::fromUtf8(text.data(), text.size()));
+}
+
+void MoveFilesDialog::EnableCloseButton() { ui_->closeButton->setEnabled(true); }
+
+}  // namespace orbit_qt

--- a/src/OrbitQt/MoveFilesDialog.ui
+++ b/src/OrbitQt/MoveFilesDialog.ui
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MoveFilesDialog</class>
+ <widget class="QDialog" name="MoveFilesDialog">
+  <property name="windowModality">
+   <enum>Qt::ApplicationModal</enum>
+  </property>
+  <property name="enabled">
+   <bool>true</bool>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>471</width>
+    <height>260</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>471</width>
+    <height>260</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>471</width>
+    <height>260</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Moving files</string>
+  </property>
+  <property name="layoutDirection">
+   <enum>Qt::LeftToRight</enum>
+  </property>
+  <widget class="QPushButton" name="closeButton">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="geometry">
+    <rect>
+     <x>380</x>
+     <y>230</y>
+     <width>80</width>
+     <height>23</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Close</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label">
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>10</y>
+     <width>168</width>
+     <height>16</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Moving files to new location</string>
+   </property>
+  </widget>
+  <widget class="QTextEdit" name="log">
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>30</y>
+     <width>451</width>
+     <height>192</height>
+    </rect>
+   </property>
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
+   <property name="readOnly">
+    <bool>true</bool>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>closeButton</sender>
+   <signal>clicked()</signal>
+   <receiver>MoveFilesDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>360</x>
+     <y>194</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>251</x>
+     <y>195</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/OrbitQt/MoveFilesProcess.cpp
+++ b/src/OrbitQt/MoveFilesProcess.cpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "OrbitQt/MoveFilesProcess.h"
+
+#include "OrbitBase/File.h"
+#include "OrbitBase/Logging.h"
+#include "Path.h"
+
+namespace orbit_qt {
+
+MoveFilesProcess::MoveFilesProcess() : QObject(nullptr) {
+  background_thread_.start();
+  moveToThread(&background_thread_);
+}
+
+MoveFilesProcess::~MoveFilesProcess() noexcept {
+  background_thread_.quit();
+  background_thread_.wait();
+}
+
+void MoveFilesProcess::Start() {
+  QMetaObject::invokeMethod(this, [this]() { Run(); });
+}
+
+void MoveFilesProcess::ReportError(const std::string& error_message) {
+  ERROR("%s", error_message);
+  emit generalError(error_message);
+}
+
+void MoveFilesProcess::TryMoveFilesAndRemoveDirIfNeeded(const std::filesystem::path& src_dir,
+                                                        const std::filesystem::path& dest_dir) {
+  auto file_exists_or_error = orbit_base::FileExists(src_dir);
+  if (file_exists_or_error.has_error()) {
+    ReportError(absl::StrFormat("Unable to stat \"%s\": %s", src_dir.string(),
+                                file_exists_or_error.error().message()));
+  } else if (!file_exists_or_error.value()) {
+    return;
+  }
+
+  auto files_or_error = orbit_base::ListFilesInDirectory(src_dir);
+  if (files_or_error.has_error()) {
+    ReportError(absl::StrFormat("Unable to list files in \"%s\": %s", src_dir.string(),
+                                files_or_error.error().message()));
+    return;
+  }
+
+  emit moveStarted(src_dir, dest_dir, files_or_error.value().size());
+  for (const auto& file_path : files_or_error.value()) {
+    const auto& file_name = file_path.filename();
+    const auto& new_file_path = dest_dir / file_name;
+    LOG("Moving \"%s\" to \"%s\"...", file_path.string(), new_file_path.string());
+    auto move_result = orbit_base::MoveFile(file_path, new_file_path);
+    if (move_result.has_error()) {
+      ReportError(absl::StrFormat(R"(Unable to move "%s" to "%s": %s)", file_path.string(),
+                                  new_file_path.string(), move_result.error().message()));
+    }
+  }
+  emit moveDone();
+
+  auto remove_result = orbit_base::RemoveFile(src_dir);
+  if (remove_result.has_error()) {
+    ReportError(absl::StrFormat("Unable to remove \"%s\": %s", src_dir.string(),
+                                remove_result.error().message()));
+  }
+}
+
+void MoveFilesProcess::Run() {
+  CHECK(QThread::currentThread() == thread());
+  TryMoveFilesAndRemoveDirIfNeeded(orbit_core::GetCaptureDirPriorTo1_65(),
+                                   orbit_core::CreateOrGetCaptureDir());
+  TryMoveFilesAndRemoveDirIfNeeded(orbit_core::GetPresetDirPriorTo1_65(),
+                                   orbit_core::CreateOrGetPresetDir());
+  emit processFinished();
+}
+
+}  // namespace orbit_qt

--- a/src/OrbitQt/include/OrbitQt/MoveFilesDialog.h
+++ b/src/OrbitQt/include/OrbitQt/MoveFilesDialog.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_QT_MOVE_FILES_DIALOG_H_
+#define ORBIT_QT_MOVE_FILES_DIALOG_H_
+
+#include <QCloseEvent>
+#include <QDialog>
+#include <QWidget>
+#include <memory>
+
+namespace Ui {
+// forward declaration of class with same name in a different namespace
+class MoveFilesDialog;  // NOLINT
+}  // namespace Ui
+
+namespace orbit_qt {
+
+class MoveFilesDialog : public QDialog {
+ public:
+  explicit MoveFilesDialog();
+  ~MoveFilesDialog() noexcept override;
+
+  void AddText(std::string_view text);
+  void EnableCloseButton();
+
+ private:
+  std::unique_ptr<class Ui::MoveFilesDialog> ui_;
+};
+
+}  // namespace orbit_qt
+
+#endif  // ORBIT_QT_MOVE_FILES_DIALOG_H_

--- a/src/OrbitQt/include/OrbitQt/MoveFilesProcess.h
+++ b/src/OrbitQt/include/OrbitQt/MoveFilesProcess.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_QT_MOVE_FILES_PROCESS_H_
+#define ORBIT_QT_MOVE_FILES_PROCESS_H_
+
+#include <QObject>
+#include <QThread>
+#include <filesystem>
+
+namespace orbit_qt {
+
+class MoveFilesProcess : public QObject {
+  Q_OBJECT
+
+ public:
+  explicit MoveFilesProcess();
+  ~MoveFilesProcess() noexcept override;
+
+  void Start();
+
+ signals:
+  void moveStarted(const std::filesystem::path& from_dir, const std::filesystem::path& to_dir,
+                   size_t number_of_files);
+  void moveDone();
+  void processFinished();
+  // Called if something goes wrong before or after all files are moved.
+  void generalError(const std::string& error_message);
+
+ private:
+  void Run();
+  void TryMoveFilesAndRemoveDirIfNeeded(const std::filesystem::path& src_dir,
+                                        const std::filesystem::path& dest_dir);
+
+  void ReportError(const std::string& error_message);
+
+  QThread background_thread_;
+};
+
+}  // namespace orbit_qt
+#endif  // ORBIT_QT_MOVE_FILES_PROCESS_H_

--- a/src/OrbitQt/servicedeploymanager.h
+++ b/src/OrbitQt/servicedeploymanager.h
@@ -43,7 +43,7 @@ class ServiceDeployManager : public QObject {
                                 const orbit_ssh::Context* context, orbit_ssh::Credentials creds,
                                 const GrpcPort& grpc_port, QObject* parent = nullptr);
 
-  ~ServiceDeployManager() noexcept;
+  ~ServiceDeployManager() noexcept override;
 
   outcome::result<GrpcPort> Exec();
 


### PR DESCRIPTION
    On Orbit start move captures and presets from the old
    location to the new one. From now on we save presets
    and capture files in %HOME%/Documents/Google/Orbit
    
    Test: Start orbit - see that it moved files to new location
    Bug: http://b/159605581
