### PR TITLE
Switch capture state to kStarted after recieving CaptureStarted event

### DIFF
--- a/src/CaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/src/CaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -62,7 +62,9 @@ class MyCaptureListener : public CaptureListener {
 DEFINE_PROTO_FUZZER(const CaptureResponse& response) {
   MyCaptureListener listener;
   auto processor = CaptureEventProcessor::CreateForCaptureListener(&listener, {});
-  processor->ProcessEvents(response.capture_events());
+  for (const auto& event : response.capture_events()) {
+    processor->ProcessEvent(event);
+  }
 }
 
 }  // namespace orbit_capture_client

--- a/src/CaptureClient/CaptureEventProcessorTest.cpp
+++ b/src/CaptureClient/CaptureEventProcessorTest.cpp
@@ -1063,7 +1063,9 @@ TEST(CaptureEventProcessor, CanHandleMultipleEvents) {
   LinuxAddressInfo actual_address_info;
   EXPECT_CALL(listener, OnAddressInfo).Times(1).WillOnce(SaveArg<0>(&actual_address_info));
 
-  event_processor->ProcessEvents(events);
+  for (const auto& event : events) {
+    event_processor->ProcessEvent(event);
+  }
 
   EXPECT_EQ(actual_address_info.absolute_address(), address_info->absolute_address());
   EXPECT_EQ(actual_address_info.function_name(), kFunctionName);

--- a/src/CaptureClient/include/CaptureClient/CaptureClient.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureClient.h
@@ -83,6 +83,10 @@ class CaptureClient {
       uint64_t memory_sampling_period_ms, bool enable_cgroup_memory,
       CaptureEventProcessor* capture_event_processor);
 
+  void ProcessEvents(
+      CaptureEventProcessor* capture_event_processor,
+      const google::protobuf::RepeatedPtrField<orbit_grpc_protos::ClientCaptureEvent>& events);
+
   [[nodiscard]] ErrorMessageOr<void> FinishCapture();
 
   std::unique_ptr<orbit_grpc_protos::CaptureService::Stub> capture_service_;

--- a/src/CaptureClient/include/CaptureClient/CaptureEventProcessor.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureEventProcessor.h
@@ -23,13 +23,6 @@ class CaptureEventProcessor {
 
   virtual void ProcessEvent(const orbit_grpc_protos::ClientCaptureEvent& event) = 0;
 
-  template <typename Iterable>
-  void ProcessEvents(const Iterable& events) {
-    for (const auto& event : events) {
-      ProcessEvent(event);
-    }
-  }
-
   static std::unique_ptr<CaptureEventProcessor> CreateForCaptureListener(
       CaptureListener* capture_listener, absl::flat_hash_set<uint64_t> frame_track_function_ids);
 


### PR DESCRIPTION
This fixes the problem with inconsistent CaptureClient state introduced
in 0f389fe00bac44a36287e31ef8c5f517fd09f398.

With this change Capture States switches from kStarting to kStarted
after CaptureEvent event is processed.

Bug: http://b/189803997
Test: introduce a delay on the service side, click start and stop
      capture very fast. Check that it does not crash.