### PR TITLE
Add CaptureFileInfo Manager class and tests

### DIFF
--- a/src/CaptureFileInfo/CMakeLists.txt
+++ b/src/CaptureFileInfo/CMakeLists.txt
@@ -11,11 +11,13 @@ target_compile_options(CaptureFileInfo PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(
   CaptureFileInfo
-  PUBLIC  include/CaptureFileInfo/CaptureFileInfo.h)
+  PUBLIC  include/CaptureFileInfo/CaptureFileInfo.h
+          include/CaptureFileInfo/Manager.h)
 
 target_sources(
   CaptureFileInfo
-  PRIVATE CaptureFileInfo.cpp)
+  PRIVATE CaptureFileInfo.cpp
+          Manager.cpp)
 
 target_include_directories(CaptureFileInfo PUBLIC include/)
 
@@ -29,7 +31,8 @@ target_compile_options(CaptureFileInfoTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(
   CaptureFileInfoTests 
-  PRIVATE CaptureFileInfoTest.cpp)
+  PRIVATE CaptureFileInfoTest.cpp
+          ManagerTest.cpp)
 
 target_link_libraries(
   CaptureFileInfoTests

--- a/src/CaptureFileInfo/Manager.cpp
+++ b/src/CaptureFileInfo/Manager.cpp
@@ -1,0 +1,80 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "CaptureFileInfo/Manager.h"
+
+#include <QDateTime>
+#include <QSettings>
+#include <algorithm>
+
+#include "CaptureFileInfo/CaptureFileInfo.h"
+
+constexpr const char* kCaptureFileInfoArrayKey = "capture_file_infos";
+constexpr const char* kCaptureFileInfoPathKey = "capture_file_info_path";
+constexpr const char* kCaptureFileInfoLastUsedKey = "capture_file_info_last_used";
+
+namespace orbit_capture_file_info {
+
+Manager::Manager() {
+  LoadCaptureFileInfos();
+  PurgeNonExistingFiles();
+}
+
+void Manager::LoadCaptureFileInfos() {
+  QSettings settings{};
+  const int size = settings.beginReadArray(kCaptureFileInfoArrayKey);
+  capture_file_infos_.clear();
+  capture_file_infos_.reserve(size);
+
+  for (int i = 0; i < size; ++i) {
+    settings.setArrayIndex(i);
+    QString path = settings.value(kCaptureFileInfoPathKey).toString();
+    QDateTime last_used(settings.value(kCaptureFileInfoLastUsedKey).toDateTime());
+    capture_file_infos_.emplace_back(path, std::move(last_used));
+  }
+  settings.endArray();
+}
+
+void Manager::SaveCaptureFileInfos() {
+  QSettings settings{};
+  settings.beginWriteArray(kCaptureFileInfoArrayKey, static_cast<int>(capture_file_infos_.size()));
+  for (size_t i = 0; i < capture_file_infos_.size(); ++i) {
+    settings.setArrayIndex(i);
+    const CaptureFileInfo& capture_file_info = capture_file_infos_[i];
+    settings.setValue(kCaptureFileInfoPathKey, capture_file_info.FilePath());
+    settings.setValue(kCaptureFileInfoLastUsedKey, capture_file_info.LastUsed());
+  }
+  settings.endArray();
+}
+
+void Manager::AddOrTouchCaptureFile(const QString& path) {
+  auto it = std::find_if(capture_file_infos_.begin(), capture_file_infos_.end(),
+                         [&](const CaptureFileInfo& capture_file_info) {
+                           return capture_file_info.FilePath() == path;
+                         });
+
+  if (it == capture_file_infos_.end()) {
+    capture_file_infos_.emplace_back(path);
+  } else {
+    it->Touch();
+  }
+
+  SaveCaptureFileInfos();
+}
+
+void Manager::Clear() {
+  capture_file_infos_.clear();
+  SaveCaptureFileInfos();
+}
+
+void Manager::PurgeNonExistingFiles() {
+  capture_file_infos_.erase(std::remove_if(capture_file_infos_.begin(), capture_file_infos_.end(),
+                                           [](const CaptureFileInfo& capture_file_info) {
+                                             return !capture_file_info.FileExists();
+                                           }),
+                            capture_file_infos_.end());
+  SaveCaptureFileInfos();
+}
+
+}  // namespace orbit_capture_file_info

--- a/src/CaptureFileInfo/ManagerTest.cpp
+++ b/src/CaptureFileInfo/ManagerTest.cpp
@@ -1,0 +1,147 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <QCoreApplication>
+#include <QDateTime>
+#include <chrono>
+#include <filesystem>
+#include <thread>
+
+#include "CaptureFileInfo/Manager.h"
+#include "OrbitBase/ExecutablePath.h"
+
+namespace orbit_capture_file_info {
+
+constexpr const char* kOrgName = "The Orbit Authors";
+
+TEST(CaptureFileInfoManager, Clear) {
+  QCoreApplication::setOrganizationName(kOrgName);
+  QCoreApplication::setApplicationName("CaptureFileInfo.Manager.Clear");
+
+  Manager manager;
+
+  manager.Clear();
+  EXPECT_TRUE(manager.GetCaptureFileInfos().empty());
+
+  manager.AddOrTouchCaptureFile("test/path1");
+  EXPECT_FALSE(manager.GetCaptureFileInfos().empty());
+
+  manager.Clear();
+  EXPECT_TRUE(manager.GetCaptureFileInfos().empty());
+
+  manager.AddOrTouchCaptureFile("test/path1");
+  EXPECT_FALSE(manager.GetCaptureFileInfos().empty());
+  manager.AddOrTouchCaptureFile("test/path2");
+  EXPECT_FALSE(manager.GetCaptureFileInfos().empty());
+
+  manager.Clear();
+  EXPECT_TRUE(manager.GetCaptureFileInfos().empty());
+}
+
+TEST(CaptureFileInfoManager, AddOrTouchCaptureFile) {
+  QCoreApplication::setOrganizationName(kOrgName);
+  QCoreApplication::setApplicationName("CaptureFileInfo.Manager.AddOrTouchCaptureFile");
+
+  Manager manager;
+  manager.Clear();
+  ASSERT_TRUE(manager.GetCaptureFileInfos().empty());
+
+  // Add 1st file
+  const QString path1 = "path/to/file1";
+  manager.AddOrTouchCaptureFile(path1);
+  ASSERT_EQ(manager.GetCaptureFileInfos().size(), 1);
+
+  const CaptureFileInfo& capture_file_info_1 = manager.GetCaptureFileInfos()[0];
+  EXPECT_EQ(capture_file_info_1.FilePath(), path1);
+  // last used was before (or at the same time) than now_time_stamp.
+  const QDateTime now_time_stamp = QDateTime::currentDateTime();
+  EXPECT_LE(capture_file_info_1.LastUsed(), now_time_stamp);
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+  // Touch 1st file
+  manager.AddOrTouchCaptureFile(path1);
+  ASSERT_EQ(manager.GetCaptureFileInfos().size(), 1);
+
+  // last used was after now_time_stamp
+  EXPECT_GT(capture_file_info_1.LastUsed(), now_time_stamp);
+
+  // Add 2nd file
+  const QString path2 = "path/to/file2";
+  manager.AddOrTouchCaptureFile(path2);
+  ASSERT_EQ(manager.GetCaptureFileInfos().size(), 2);
+  const CaptureFileInfo& capture_file_info_2 = manager.GetCaptureFileInfos()[1];
+  EXPECT_EQ(capture_file_info_2.FilePath(), path2);
+
+  // clean up
+  manager.Clear();
+}
+
+TEST(CaptureFileInfoManager, PurgeNonExistingFiles) {
+  QCoreApplication::setOrganizationName(kOrgName);
+  QCoreApplication::setApplicationName("CaptureFileInfo.Manager.PurgeNonExistingFiles");
+
+  Manager manager;
+  manager.Clear();
+  EXPECT_TRUE(manager.GetCaptureFileInfos().empty());
+
+  manager.AddOrTouchCaptureFile("non/existing/path");
+  EXPECT_FALSE(manager.GetCaptureFileInfos().empty());
+
+  manager.PurgeNonExistingFiles();
+  EXPECT_TRUE(manager.GetCaptureFileInfos().empty());
+
+  const std::filesystem::path existing_file =
+      orbit_base::GetExecutableDir() / "testdata" / "test_file.txt";
+  manager.AddOrTouchCaptureFile(QString::fromStdString(existing_file.string()));
+  EXPECT_FALSE(manager.GetCaptureFileInfos().empty());
+
+  manager.PurgeNonExistingFiles();
+  EXPECT_FALSE(manager.GetCaptureFileInfos().empty());
+
+  // clean up
+  manager.Clear();
+}
+
+TEST(CaptureFileInfoManager, Persistency) {
+  QCoreApplication::setOrganizationName(kOrgName);
+  QCoreApplication::setApplicationName("CaptureFileInfo.Manager.Persistency");
+
+  {  // clean setup
+    Manager manager;
+    manager.Clear();
+  }
+
+  {
+    Manager manager;
+    EXPECT_TRUE(manager.GetCaptureFileInfos().empty());
+  }
+
+  const std::filesystem::path existing_file =
+      orbit_base::GetExecutableDir() / "testdata" / "test_file.txt";
+  {
+    Manager manager;
+    manager.AddOrTouchCaptureFile(QString::fromStdString(existing_file.string()));
+    EXPECT_EQ(manager.GetCaptureFileInfos().size(), 1);
+  }
+
+  {
+    Manager manager;
+    ASSERT_EQ(manager.GetCaptureFileInfos().size(), 1);
+    const CaptureFileInfo capture_file_info = manager.GetCaptureFileInfos()[0];
+
+    std::filesystem::path saved_path = capture_file_info.FilePath().toStdString();
+
+    EXPECT_EQ(saved_path, existing_file);
+  }
+
+  {  // clean up
+    Manager manager;
+    manager.Clear();
+  }
+}
+
+}  // namespace orbit_capture_file_info

--- a/src/CaptureFileInfo/include/CaptureFileInfo/Manager.h
+++ b/src/CaptureFileInfo/include/CaptureFileInfo/Manager.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CAPTURE_FILE_INFO_MANAGER_H_
+#define CAPTURE_FILE_INFO_MANAGER_H_
+
+#include <vector>
+
+#include "CaptureFileInfo/CaptureFileInfo.h"
+
+namespace orbit_capture_file_info {
+
+class Manager {
+ public:
+  explicit Manager();
+  [[nodiscard]] const std::vector<CaptureFileInfo>& GetCaptureFileInfos() const {
+    return capture_file_infos_;
+  }
+
+  void AddOrTouchCaptureFile(const QString& path);
+  void Clear();
+  void PurgeNonExistingFiles();
+
+ private:
+  void SaveCaptureFileInfos();
+  void LoadCaptureFileInfos();
+
+  std::vector<CaptureFileInfo> capture_file_infos_;
+};
+
+}  // namespace orbit_capture_file_info
+
+#endif  // CAPTURE_FILE_INFO_MANAGER_H_


### PR DESCRIPTION
http://b/178379643

I naively named the class `Manager`, because it is in the namespace `orbit_capture_file_info` and the naming `orbit_capture_file_info::CaptureFileInfoManager` seemed a bit verbose. But the name `Manager` is very generic, so maybe its not a good idea. Please let me know what you think. 

