### PR TITLE
Show exclusive/inclusive count in addition to % in "Sampling" tab

### DIFF
--- a/src/ClientData/include/ClientData/PostProcessedSamplingData.h
+++ b/src/ClientData/include/ClientData/PostProcessedSamplingData.h
@@ -25,8 +25,10 @@ struct SampledFunction {
 
   std::string name;
   std::string module_path;
-  float exclusive = 0;
-  float inclusive = 0;
+  uint32_t exclusive = 0;
+  float exclusive_percent = 0.f;
+  uint32_t inclusive = 0;
+  float inclusive_percent = 0.f;
   uint64_t absolute_address = 0;
   const orbit_client_protos::FunctionInfo* function = nullptr;
 };

--- a/src/ClientModel/SamplingDataPostProcessor.cpp
+++ b/src/ClientModel/SamplingDataPostProcessor.cpp
@@ -234,16 +234,21 @@ void SamplingDataPostProcessor::FillThreadSampleDataSampleReports(const CaptureD
          sorted_it != thread_sample_data->sorted_count_to_resolved_address.rend(); ++sorted_it) {
       uint32_t num_occurrences = sorted_it->first;
       uint64_t absolute_address = sorted_it->second;
-      float inclusive_percent = 100.f * num_occurrences / thread_sample_data->samples_count;
 
       SampledFunction function;
       function.name = capture_data.GetFunctionNameByAddress(absolute_address);
-      function.inclusive = inclusive_percent;
-      function.exclusive = 0.f;
+
+      function.inclusive = num_occurrences;
+      function.inclusive_percent = 100.f * num_occurrences / thread_sample_data->samples_count;
+
+      function.exclusive = 0;
+      function.exclusive_percent = 0.f;
       auto it = thread_sample_data->resolved_address_to_exclusive_count.find(absolute_address);
       if (it != thread_sample_data->resolved_address_to_exclusive_count.end()) {
-        function.exclusive = 100.f * it->second / thread_sample_data->samples_count;
+        function.exclusive = it->second;
+        function.exclusive_percent = 100.f * it->second / thread_sample_data->samples_count;
       }
+
       function.absolute_address = absolute_address;
       function.module_path = capture_data.GetModulePathByAddress(absolute_address);
 

--- a/src/OrbitGl/SamplingReportDataView.cpp
+++ b/src/OrbitGl/SamplingReportDataView.cpp
@@ -68,9 +68,9 @@ std::string SamplingReportDataView::GetValue(int row, int column) {
     case kColumnFunctionName:
       return func.name;
     case kColumnExclusive:
-      return absl::StrFormat("%.2f", func.exclusive);
+      return absl::StrFormat("%.2f%% (%u)", func.exclusive_percent, func.exclusive);
     case kColumnInclusive:
-      return absl::StrFormat("%.2f", func.inclusive);
+      return absl::StrFormat("%.2f%% (%u)", func.inclusive_percent, func.inclusive);
     case kColumnModuleName:
       return std::filesystem::path(func.module_path).filename().string();
     case kColumnAddress:

--- a/src/OrbitQt/orbitsamplingreport.h
+++ b/src/OrbitQt/orbitsamplingreport.h
@@ -41,9 +41,9 @@ class OrbitSamplingReport : public QWidget {
   void OnCurrentThreadTabChanged(int current_tab_index);
 
  private:
-  Ui::OrbitSamplingReport* ui;
-  std::shared_ptr<SamplingReport> m_SamplingReport;
-  std::vector<OrbitDataViewPanel*> m_OrbitDataViews;
+  Ui::OrbitSamplingReport* ui_;
+  std::shared_ptr<SamplingReport> sampling_report_;
+  std::vector<OrbitDataViewPanel*> orbit_data_views_;
 };
 
 #endif  // ORBIT_QT_ORBIT_SAMPLING_REPORT_H_


### PR DESCRIPTION
Similarly to the top-down and bottom-up view.

Bug: http://b/189808486

Test: Update `SamplingDataPostProcessorTest`.
Capture Trata and verify the numbers make sense.

---

Plus "Renamings in OrbitQt/orbitsamplingreport".