### PR TITLE
Create CaptureData object in IntrospectionWindow

### DIFF
--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -181,7 +181,6 @@ void CallstackThreadBar::SelectCallstacks() {
 }
 
 bool CallstackThreadBar::IsEmpty() const {
-  if (capture_data_ == nullptr) return true;
   const uint32_t callstack_count =
       (thread_id_ == orbit_base::kAllProcessThreadsTid)
           ? capture_data_->GetCallstackData()->GetCallstackEventsCount()

--- a/src/OrbitGl/IntrospectionWindow.h
+++ b/src/OrbitGl/IntrospectionWindow.h
@@ -10,6 +10,7 @@
 #include <memory>
 
 #include "CaptureWindow.h"
+#include "ClientModel/CaptureData.h"
 #include "OrbitBase/Tracing.h"
 
 class OrbitApp;
@@ -36,6 +37,7 @@ class IntrospectionWindow : public CaptureWindow {
   [[nodiscard]] bool ShouldAutoZoom() const override;
 
   std::unique_ptr<orbit_base::TracingListener> introspection_listener_;
+  std::unique_ptr<orbit_client_model::CaptureData> capture_data_;
 };
 
 #endif  // ORBIT_GL_INTROSPECTION_WINDOW_H_

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -33,7 +33,6 @@ ThreadStateBar::ThreadStateBar(CaptureViewElement* parent, OrbitApp* app, TimeGr
 }
 
 bool ThreadStateBar::IsEmpty() const {
-  if (capture_data_ == nullptr) return true;
   return !capture_data_->HasThreadStatesForThread(thread_id_);
 }
 

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -60,8 +60,7 @@ ThreadTrack::ThreadTrack(CaptureViewElement* parent, TimeGraph* time_graph,
 }
 
 std::string ThreadTrack::GetThreadNameFromTid(uint32_t thread_id) {
-  const std::string kEmptyString;
-  return capture_data_ ? capture_data_->GetThreadName(thread_id) : kEmptyString;
+  return capture_data_->GetThreadName(thread_id);
 }
 
 void ThreadTrack::InitializeNameAndLabel(int32_t thread_id) {
@@ -112,8 +111,7 @@ std::string ThreadTrack::GetBoxTooltip(const Batcher& batcher, PickingId id) con
   const TimerInfo& timer_info = text_box->GetTimerInfo();
 
   const InstrumentedFunction* func =
-      capture_data_ ? capture_data_->GetInstrumentedFunctionById(timer_info.function_id())
-                    : nullptr;
+      capture_data_->GetInstrumentedFunctionById(timer_info.function_id());
 
   FunctionInfo::OrbitType type{FunctionInfo::kNone};
   if (func != nullptr) {
@@ -270,9 +268,6 @@ void ThreadTrack::UpdatePositionOfSubtracks() {
 }
 
 void ThreadTrack::UpdateMinMaxTimestamps() {
-  // Tracks in the introspection window don't have capture data.
-  if (capture_data_ == nullptr) return;
-
   min_time_ = std::min(min_time_.load(), capture_data_->GetCallstackData()->min_time());
   max_time_ = std::max(max_time_.load(), capture_data_->GetCallstackData()->max_time());
 }

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -631,12 +631,10 @@ void TimeGraph::UpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/, ui
   batcher_.StartNewFrame();
   text_renderer_static_.Clear();
 
-  if (capture_data_) {
-    capture_min_timestamp_ =
-        std::min(capture_min_timestamp_, capture_data_->GetCallstackData()->min_time());
-    capture_max_timestamp_ =
-        std::max(capture_max_timestamp_, capture_data_->GetCallstackData()->max_time());
-  }
+  capture_min_timestamp_ =
+      std::min(capture_min_timestamp_, capture_data_->GetCallstackData()->min_time());
+  capture_max_timestamp_ =
+      std::max(capture_max_timestamp_, capture_data_->GetCallstackData()->max_time());
 
   time_window_us_ = max_time_us_ - min_time_us_;
   world_start_x_ = viewport_->GetWorldTopLeft()[0];

--- a/src/OrbitGl/TracepointThreadBar.cpp
+++ b/src/OrbitGl/TracepointThreadBar.cpp
@@ -143,7 +143,6 @@ std::string TracepointThreadBar::GetTracepointTooltip(Batcher* batcher, PickingI
 }
 
 bool TracepointThreadBar::IsEmpty() const {
-  if (capture_data_ == nullptr) return true;
   return capture_data_->GetNumTracepointsForThreadId(thread_id_) == 0;
 }
 

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -223,7 +223,7 @@ void Track::UpdatePrimitives(Batcher* /*batcher*/, uint64_t /*t_min*/, uint64_t 
 void Track::SetPinned(bool value) { pinned_ = value; }
 
 Color Track::GetTrackBackgroundColor() const {
-  int32_t capture_process_id = capture_data_ ? capture_data_->process_id() : -1;
+  int32_t capture_process_id = capture_data_->process_id();
 
   if (process_id_ != -1 && process_id_ != capture_process_id) {
     const Color kExternalProcessColor(30, 30, 40, 255);

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -123,7 +123,7 @@ void TrackManager::SortTracks() {
   }
 
   // Separate "capture_pid" tracks from tracks that originate from other processes.
-  int32_t capture_pid = capture_data_ ? capture_data_->process_id() : 0;
+  int32_t capture_pid = capture_data_->process_id();
   std::vector<Track*> capture_pid_tracks;
   std::vector<Track*> external_pid_tracks;
   for (auto& track : all_processes_sorted_tracks) {
@@ -182,7 +182,7 @@ void TrackManager::UpdateVisibleTrackList() {
 std::vector<ThreadTrack*> TrackManager::GetSortedThreadTracks() {
   std::vector<ThreadTrack*> sorted_tracks;
   absl::flat_hash_map<ThreadTrack*, uint32_t> num_events_by_track;
-  const CallstackData* callstack_data = capture_data_ ? capture_data_->GetCallstackData() : nullptr;
+  const CallstackData* callstack_data = capture_data_->GetCallstackData();
 
   for (auto& [tid, track] : thread_tracks_) {
     if (tid == orbit_base::kAllProcessThreadsTid) {


### PR DESCRIPTION
This avoids null-checking "capture_data_" in introspection code
as the variable can't be "nullptr" anymore. It also makes sense for
introspection to have it's own capture data, especially if we add
sampling and scheduling information eventually.

This also fixes a crash when using the introspection window.