### PR TITLE
Move orbit_qt::EventLoop into QtUtils

### DIFF
--- a/src/OrbitQt/CMakeLists.txt
+++ b/src/OrbitQt/CMakeLists.txt
@@ -21,7 +21,6 @@ target_sources(
           DeploymentConfigurations.h
           ElidedLabel.h
           Error.h
-          EventLoop.h
           FilterPanelWidget.h
           FilterPanelWidgetAction.h
           orbitaboutdialog.h
@@ -126,11 +125,9 @@ target_compile_options(OrbitQtTests PRIVATE ${STRICT_COMPILE_FLAGS})
 target_sources(OrbitQtTests
         PRIVATE AccessibilityAdapter.h
                 CutoutWidget.h
-                EventLoop.h
                 TutorialOverlay.h)
 target_sources(OrbitQtTests
         PRIVATE AccessibilityAdapterTest.cpp
-                EventLoopTest.cpp
                 ProcessItemModelTest.cpp
                 StatusListenerImplTest.cpp
                 TargetLabelTest.cpp

--- a/src/QtUtils/CMakeLists.txt
+++ b/src/QtUtils/CMakeLists.txt
@@ -12,6 +12,7 @@ target_include_directories(QtUtils PUBLIC include/)
 target_link_libraries(QtUtils PUBLIC OrbitBase OrbitGl Qt5::Core CONAN_PKG::abseil GTest::GTest)
 
 target_sources(QtUtils PUBLIC include/QtUtils/AssertNoQtLogWarnings.h
+                              include/QtUtils/EventLoop.h
                               include/QtUtils/FutureWatcher.h
                               include/QtUtils/MainThreadExecutorImpl.h)
 
@@ -22,7 +23,8 @@ set_target_properties(QtUtils PROPERTIES AUTOMOC ON)
 
 add_executable(QtUtilsTests)
 target_compile_options(QtUtilsTests PRIVATE ${STRICT_COMPILE_FLAGS})
-target_sources(QtUtilsTests PRIVATE FutureWatcherTest.cpp
+target_sources(QtUtilsTests PRIVATE EventLoopTest.cpp
+                                    FutureWatcherTest.cpp
                                     MainThreadExecutorImplTest.cpp)
 target_link_libraries(QtUtilsTests PRIVATE QtUtils GTest::QtCoreMain)
 register_test(QtUtilsTests)

--- a/src/QtUtils/EventLoopTest.cpp
+++ b/src/QtUtils/EventLoopTest.cpp
@@ -4,20 +4,19 @@
 
 #include <gtest/gtest.h>
 
-#include <QApplication>
 #include <QMetaObject>
 #include <Qt>
 #include <memory>
 #include <outcome.hpp>
 #include <system_error>
 
-#include "EventLoop.h"
+#include "QtUtils/EventLoop.h"
 #include "gtest/gtest.h"
 
 TEST(EventLoop, exec) {
   // Case 1: The event loop finishes successfully
   {
-    orbit_qt::EventLoop loop{};
+    orbit_qt_utils::EventLoop loop{};
     ASSERT_FALSE(loop.isRunning());
 
     QMetaObject::invokeMethod(
@@ -36,7 +35,7 @@ TEST(EventLoop, exec) {
   // Case 2: The event loop returns an error that occured
   // while processing events/tasks.
   {
-    orbit_qt::EventLoop loop{};
+    orbit_qt_utils::EventLoop loop{};
     ASSERT_FALSE(loop.isRunning());
 
     QMetaObject::invokeMethod(
@@ -54,7 +53,7 @@ TEST(EventLoop, exec) {
 
   // Case 3: The event loop immediately returns due to a queued error.
   {
-    orbit_qt::EventLoop loop{};
+    orbit_qt_utils::EventLoop loop{};
     ASSERT_FALSE(loop.isRunning());
     loop.error(std::make_error_code(std::errc::bad_message));
 

--- a/src/QtUtils/include/QtUtils/EventLoop.h
+++ b/src/QtUtils/include/QtUtils/EventLoop.h
@@ -1,15 +1,15 @@
-// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef ORBIT_QT_EVENT_LOOP_H_
-#define ORBIT_QT_EVENT_LOOP_H_
+#ifndef QT_UTILS_EVENT_LOOP_H_
+#define QT_UTILS_EVENT_LOOP_H_
 
 #include <QEventLoop>
 #include <optional>
 #include <outcome.hpp>
 
-namespace orbit_qt {
+namespace orbit_qt_utils {
 
 /**
  * A wrapper around QEventLoop to allow returning a std::error_code instead of
@@ -68,6 +68,6 @@ class EventLoop : public QObject {
   QEventLoop loop_;
 };
 
-}  // namespace orbit_qt
+}  // namespace orbit_qt_utils
 
-#endif  // ORBIT_QT_EVENT_LOOP_H_
+#endif  // QT_UTILS_EVENT_LOOP_H_


### PR DESCRIPTION
EventLoop does not need to link against QtGUI, QtCore is enough. So by
moving this test into QtUtils the test will run on headless Windows
machines as well (like our CI machines).