### PR TITLE
Add "unwind errors" stats to "Sampling", "Top-down", "Bottom-up"

### DIFF
--- a/src/ClientData/include/ClientData/PostProcessedSamplingData.h
+++ b/src/ClientData/include/ClientData/PostProcessedSamplingData.h
@@ -29,6 +29,8 @@ struct SampledFunction {
   float exclusive_percent = 0.f;
   uint32_t inclusive = 0;
   float inclusive_percent = 0.f;
+  uint32_t unwind_errors = 0;
+  float unwind_errors_percent = 0.f;
   uint64_t absolute_address = 0;
   const orbit_client_protos::FunctionInfo* function = nullptr;
 };
@@ -42,6 +44,7 @@ struct ThreadSampleData {
   absl::flat_hash_map<uint64_t, uint32_t> sampled_address_to_count;
   absl::flat_hash_map<uint64_t, uint32_t> resolved_address_to_count;
   absl::flat_hash_map<uint64_t, uint32_t> resolved_address_to_exclusive_count;
+  absl::flat_hash_map<uint64_t, uint32_t> resolved_address_to_error_count;
   std::multimap<uint32_t, uint64_t> sorted_count_to_resolved_address;
   std::vector<SampledFunction> sampled_functions;
 

--- a/src/ClientModel/SamplingDataPostProcessor.cpp
+++ b/src/ClientModel/SamplingDataPostProcessor.cpp
@@ -122,6 +122,7 @@ PostProcessedSamplingData SamplingDataPostProcessor::ProcessSamples(
       const CallstackInfo& resolved_callstack = id_to_resolved_callstack_[resolved_callstack_id];
 
       // exclusive stat
+      CHECK(!resolved_callstack.frames().empty());
       thread_sample_data->resolved_address_to_exclusive_count[resolved_callstack.frames(0)] +=
           callstack_count;
 

--- a/src/ClientModel/SamplingDataPostProcessorTest.cpp
+++ b/src/ClientModel/SamplingDataPostProcessorTest.cpp
@@ -897,6 +897,16 @@ TEST_F(SamplingDataPostProcessorTest, EmptyCallstackDataWithSummary) {
   VerifyEmptySortedCallstackReport(kThreadIdNotSampled);
 }
 
+TEST_F(SamplingDataPostProcessorTest, CallstackEventOfEmptyCallstack) {
+  AddAllAddressInfos();
+
+  static constexpr uint64_t kEmptyCallstackId = 99;
+  AddCallstackInfo(kEmptyCallstackId, {}, CallstackInfo::kComplete);
+  AddCallstackEvent(kEmptyCallstackId, kThreadId1);
+
+  EXPECT_DEATH(CreatePostProcessedSamplingDataWithSummary(), "Check failed");
+}
+
 TEST_F(SamplingDataPostProcessorTest, CallstackInfosButNoCallstackEvents) {
   AddAllAddressInfos();
   AddAllCallstackInfos(CallstackInfo::kComplete);

--- a/src/ClientModel/SamplingDataPostProcessorTest.cpp
+++ b/src/ClientModel/SamplingDataPostProcessorTest.cpp
@@ -38,7 +38,8 @@ namespace {
 
 SampledFunction MakeSampledFunction(std::string name, std::string module_path, uint32_t exclusive,
                                     float exclusive_percent, uint32_t inclusive,
-                                    float inclusive_percent, uint64_t absolute_address) {
+                                    float inclusive_percent, uint32_t unwind_errors,
+                                    float unwind_errors_percent, uint64_t absolute_address) {
   SampledFunction sampled_function;
   sampled_function.name = std::move(name);
   sampled_function.module_path = std::move(module_path);
@@ -46,6 +47,8 @@ SampledFunction MakeSampledFunction(std::string name, std::string module_path, u
   sampled_function.exclusive_percent = exclusive_percent;
   sampled_function.inclusive = inclusive;
   sampled_function.inclusive_percent = inclusive_percent;
+  sampled_function.unwind_errors = unwind_errors;
+  sampled_function.unwind_errors_percent = unwind_errors_percent;
   sampled_function.absolute_address = absolute_address;
   sampled_function.function = nullptr;
   return sampled_function;
@@ -55,6 +58,8 @@ bool SampledFunctionsAreEqual(const SampledFunction& lhs, const SampledFunction&
   return lhs.name == rhs.name && lhs.module_path == rhs.module_path &&
          lhs.exclusive == rhs.exclusive && lhs.exclusive_percent == rhs.exclusive_percent &&
          lhs.inclusive == rhs.inclusive && lhs.inclusive_percent == rhs.inclusive_percent &&
+         lhs.unwind_errors == rhs.unwind_errors &&
+         lhs.unwind_errors_percent == rhs.unwind_errors_percent &&
          lhs.absolute_address == rhs.absolute_address && lhs.function == rhs.function;
 }
 
@@ -262,6 +267,14 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
     AddCallstackInfo(kCallstack4Id, kCallstack4Frames, callstack_type);
   }
 
+  void AddAllCallstackInfosWithMixedCallstackTypes() {
+    AddCallstackInfo(kCallstack1Id, kCallstack1Frames, CallstackInfo::kDwarfUnwindingError);
+    AddCallstackInfo(kCallstack2Id, kCallstack2Frames, CallstackInfo::kComplete);
+    AddCallstackInfo(kCallstack3Id, kCallstack3Frames, CallstackInfo::kComplete);
+    AddCallstackInfo(kCallstack4Id, kCallstack4Frames,
+                     CallstackInfo::kFilteredByMajorityOutermostFrame);
+  }
+
   static constexpr int32_t kThreadId1 = 42;
   static constexpr int32_t kThreadId2 = 43;
   static constexpr int32_t kThreadIdNotSampled = 99;
@@ -273,7 +286,7 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
     // C  = kFunction3Instruction1AbsoluteAddress,
     // C' = kFunction3Instruction2AbsoluteAddress,
     // D  = kFunction4Instruction1AbsoluteAddress.
-    // There are the CallstackEvents that are added, innermost frame at the top. Note that:
+    // These are the CallstackEvents that are added, innermost frame at the top. Note that:
     //   - the first and second CallstackEvents have the same Callstack;
     //   - the last CallstackEvent has two identical frames;
     //   - the number under each CallstackEvent is the callstack id.
@@ -281,7 +294,19 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
     // C    C    C    C'   C
     // B    B    B    C    C
     // A    A    A    A    A
+    // ---------------------
     // 1    1    2    3    4
+    //
+    // Note that when the CallstackInfos are added with AddAllCallstackInfosWithMixedCallstackTypes,
+    // for statistics and selection the added CallstackEvents are effectively the following. The 'E'
+    // indicates which CallstackEvents refer to a non-kComplete CallstackInfo.
+    //           D
+    //           C    C'
+    //           B    C
+    // C    C    A    A    C
+    // ---------------------
+    // 1    1    2    3    4
+    // E    E              E
     AddCallstackEvent(kCallstack1Id, kThreadId1);
     AddCallstackEvent(kCallstack1Id,
                       kThreadId1);  // Intentionally two CallstackEvents with the same CallstackInfo
@@ -297,7 +322,18 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
     // C    C     |     C    C'   C
     // B    B     |     B    C    C
     // A    A     |     A    A    A
+    // ----------------------------
     // 1    2     |     1    3    4
+    //
+    // When the CallstackInfos are added with AddAllCallstackInfosWithMixedCallstackTypes:
+    // kThreadId1 |     kThreadId2
+    //      D
+    //      C     |          C'
+    //      B     |          C
+    // C    A     |     C    A    C
+    // ----------------------------
+    // 1    2     |     1    3    4
+    // E          |     E         E
     AddCallstackEvent(kCallstack1Id, kThreadId1);
     AddCallstackEvent(kCallstack2Id, kThreadId1);
 
@@ -352,6 +388,36 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
           ppsd_.GetResolvedCallstack(kCallstack4Id);
       EXPECT_THAT(resolved_callstack_4.frames(), Pointwise(Eq(), kCallstack4ResolvedFrames));
       EXPECT_EQ(resolved_callstack_4.type(), expected_callstack_type);
+    }
+  }
+
+  void VerifyAllCallstackInfosWithMixedCallstackTypes() {
+    {
+      const orbit_client_protos::CallstackInfo& resolved_callstack_1 =
+          ppsd_.GetResolvedCallstack(kCallstack1Id);
+      EXPECT_THAT(resolved_callstack_1.frames(), Pointwise(Eq(), kCallstack1ResolvedFrames));
+      EXPECT_EQ(resolved_callstack_1.type(), CallstackInfo::kDwarfUnwindingError);
+    }
+
+    {
+      const orbit_client_protos::CallstackInfo& resolved_callstack_2 =
+          ppsd_.GetResolvedCallstack(kCallstack2Id);
+      EXPECT_THAT(resolved_callstack_2.frames(), Pointwise(Eq(), kCallstack2ResolvedFrames));
+      EXPECT_EQ(resolved_callstack_2.type(), CallstackInfo::kComplete);
+    }
+
+    {
+      const orbit_client_protos::CallstackInfo& resolved_callstack_3 =
+          ppsd_.GetResolvedCallstack(kCallstack3Id);
+      EXPECT_THAT(resolved_callstack_3.frames(), Pointwise(Eq(), kCallstack3ResolvedFrames));
+      EXPECT_EQ(resolved_callstack_3.type(), CallstackInfo::kComplete);
+    }
+
+    {
+      const orbit_client_protos::CallstackInfo& resolved_callstack_4 =
+          ppsd_.GetResolvedCallstack(kCallstack4Id);
+      EXPECT_THAT(resolved_callstack_4.frames(), Pointwise(Eq(), kCallstack4ResolvedFrames));
+      EXPECT_EQ(resolved_callstack_4.type(), CallstackInfo::kFilteredByMajorityOutermostFrame);
     }
   }
 
@@ -413,16 +479,88 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
                                      std::make_pair(3, kFunction2StartAbsoluteAddress),
                                      std::make_pair(5, kFunction3StartAbsoluteAddress),
                                      std::make_pair(1, kFunction4StartAbsoluteAddress)));
-    EXPECT_THAT(actual_thread_sample_data.sampled_functions,
-                UnorderedElementsAre(
-                    SampledFunctionEq(MakeSampledFunction(kFunction1Name, kModulePath, 0, 0.0f, 5,
-                                                          100.0f, kFunction1StartAbsoluteAddress)),
-                    SampledFunctionEq(MakeSampledFunction(kFunction2Name, kModulePath, 0, 0.0f, 3,
-                                                          60.0f, kFunction2StartAbsoluteAddress)),
-                    SampledFunctionEq(MakeSampledFunction(kFunction3Name, kModulePath, 4, 80.0f, 5,
-                                                          100.0f, kFunction3StartAbsoluteAddress)),
-                    SampledFunctionEq(MakeSampledFunction(kFunction4Name, kModulePath, 1, 20.0f, 1,
-                                                          20.0f, kFunction4StartAbsoluteAddress))));
+    EXPECT_THAT(
+        actual_thread_sample_data.sampled_functions,
+        UnorderedElementsAre(
+            SampledFunctionEq(MakeSampledFunction(kFunction1Name, kModulePath, 0, 0.0f, 5, 100.0f,
+                                                  0, 0.0f, kFunction1StartAbsoluteAddress)),
+            SampledFunctionEq(MakeSampledFunction(kFunction2Name, kModulePath, 0, 0.0f, 3, 60.0f, 0,
+                                                  0.0f, kFunction2StartAbsoluteAddress)),
+            SampledFunctionEq(MakeSampledFunction(kFunction3Name, kModulePath, 4, 80.0f, 5, 100.0f,
+                                                  0, 0.0f, kFunction3StartAbsoluteAddress)),
+            SampledFunctionEq(MakeSampledFunction(kFunction4Name, kModulePath, 1, 20.0f, 1, 20.0f,
+                                                  0, 0.0f, kFunction4StartAbsoluteAddress))));
+  }
+
+  static void VerifyThreadSampleDataForCallstackEventsAllInTheSameThreadWithMixedCallstackTypes(
+      const ThreadSampleData& actual_thread_sample_data, int32_t expected_thread_id) {
+    EXPECT_EQ(actual_thread_sample_data.thread_id, expected_thread_id);
+    EXPECT_EQ(actual_thread_sample_data.samples_count, 5);
+    EXPECT_THAT(
+        actual_thread_sample_data.sampled_callstack_id_to_count,
+        UnorderedElementsAre(std::make_pair(kCallstack1Id, 2), std::make_pair(kCallstack2Id, 1),
+                             std::make_pair(kCallstack3Id, 1), std::make_pair(kCallstack4Id, 1)));
+    EXPECT_THAT(actual_thread_sample_data.sampled_address_to_count,
+                UnorderedElementsAre(std::make_pair(kFunction1Instruction1AbsoluteAddress, 2),
+                                     std::make_pair(kFunction2Instruction1AbsoluteAddress, 1),
+                                     std::make_pair(kFunction3Instruction1AbsoluteAddress, 5),
+                                     std::make_pair(kFunction3Instruction2AbsoluteAddress, 1),
+                                     std::make_pair(kFunction4Instruction1AbsoluteAddress, 1)));
+    EXPECT_THAT(actual_thread_sample_data.resolved_address_to_count,
+                UnorderedElementsAre(std::make_pair(kFunction1StartAbsoluteAddress, 2),
+                                     std::make_pair(kFunction2StartAbsoluteAddress, 1),
+                                     std::make_pair(kFunction3StartAbsoluteAddress, 5),
+                                     std::make_pair(kFunction4StartAbsoluteAddress, 1)));
+    EXPECT_THAT(actual_thread_sample_data.resolved_address_to_exclusive_count,
+                UnorderedElementsAre(std::make_pair(kFunction3StartAbsoluteAddress, 4),
+                                     std::make_pair(kFunction4StartAbsoluteAddress, 1)));
+    EXPECT_THAT(actual_thread_sample_data.sorted_count_to_resolved_address,
+                UnorderedElementsAre(std::make_pair(2, kFunction1StartAbsoluteAddress),
+                                     std::make_pair(1, kFunction2StartAbsoluteAddress),
+                                     std::make_pair(5, kFunction3StartAbsoluteAddress),
+                                     std::make_pair(1, kFunction4StartAbsoluteAddress)));
+    EXPECT_THAT(
+        actual_thread_sample_data.sampled_functions,
+        UnorderedElementsAre(
+            SampledFunctionEq(MakeSampledFunction(kFunction1Name, kModulePath, 0, 0.0f, 2, 40.0f, 0,
+                                                  0.0f, kFunction1StartAbsoluteAddress)),
+            SampledFunctionEq(MakeSampledFunction(kFunction2Name, kModulePath, 0, 0.0f, 1, 20.0f, 0,
+                                                  0.0f, kFunction2StartAbsoluteAddress)),
+            SampledFunctionEq(MakeSampledFunction(kFunction3Name, kModulePath, 4, 80.0f, 5, 100.0f,
+                                                  3, 60.0f, kFunction3StartAbsoluteAddress)),
+            SampledFunctionEq(MakeSampledFunction(kFunction4Name, kModulePath, 1, 20.0f, 1, 20.0f,
+                                                  0, 0.0f, kFunction4StartAbsoluteAddress))));
+  }
+
+  static void
+  VerifyThreadSampleDataForCallstackEventsAllInTheSameThreadWithOnlyNonCompleteCallstackInfos(
+      const ThreadSampleData& actual_thread_sample_data, int32_t expected_thread_id) {
+    EXPECT_EQ(actual_thread_sample_data.thread_id, expected_thread_id);
+    EXPECT_EQ(actual_thread_sample_data.samples_count, 5);
+    EXPECT_THAT(
+        actual_thread_sample_data.sampled_callstack_id_to_count,
+        UnorderedElementsAre(std::make_pair(kCallstack1Id, 2), std::make_pair(kCallstack2Id, 1),
+                             std::make_pair(kCallstack3Id, 1), std::make_pair(kCallstack4Id, 1)));
+    EXPECT_THAT(actual_thread_sample_data.sampled_address_to_count,
+                UnorderedElementsAre(std::make_pair(kFunction3Instruction1AbsoluteAddress, 3),
+                                     std::make_pair(kFunction3Instruction2AbsoluteAddress, 1),
+                                     std::make_pair(kFunction4Instruction1AbsoluteAddress, 1)));
+    EXPECT_THAT(actual_thread_sample_data.resolved_address_to_count,
+                UnorderedElementsAre(std::make_pair(kFunction3StartAbsoluteAddress, 4),
+                                     std::make_pair(kFunction4StartAbsoluteAddress, 1)));
+    EXPECT_THAT(actual_thread_sample_data.resolved_address_to_exclusive_count,
+                UnorderedElementsAre(std::make_pair(kFunction3StartAbsoluteAddress, 4),
+                                     std::make_pair(kFunction4StartAbsoluteAddress, 1)));
+    EXPECT_THAT(actual_thread_sample_data.sorted_count_to_resolved_address,
+                UnorderedElementsAre(std::make_pair(4, kFunction3StartAbsoluteAddress),
+                                     std::make_pair(1, kFunction4StartAbsoluteAddress)));
+    EXPECT_THAT(
+        actual_thread_sample_data.sampled_functions,
+        UnorderedElementsAre(
+            SampledFunctionEq(MakeSampledFunction(kFunction3Name, kModulePath, 4, 80.0f, 4, 80.0f,
+                                                  4, 80.0f, kFunction3StartAbsoluteAddress)),
+            SampledFunctionEq(MakeSampledFunction(kFunction4Name, kModulePath, 1, 20.0f, 1, 20.0f,
+                                                  1, 20.0f, kFunction4StartAbsoluteAddress))));
   }
 
   static void VerifyThreadSampleDataForCallstackEventsAllInTheSameThreadWithoutAddressInfos(
@@ -459,23 +597,23 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
                 UnorderedElementsAre(SampledFunctionEq(MakeSampledFunction(
                                          CaptureData::kUnknownFunctionOrModuleName,
                                          CaptureData::kUnknownFunctionOrModuleName, 0, 0.0f, 5,
-                                         100.0f, kFunction1Instruction1AbsoluteAddress)),
+                                         100.0f, 0, 0.0f, kFunction1Instruction1AbsoluteAddress)),
                                      SampledFunctionEq(MakeSampledFunction(
                                          CaptureData::kUnknownFunctionOrModuleName,
                                          CaptureData::kUnknownFunctionOrModuleName, 0, 0.0f, 3,
-                                         60.0f, kFunction2Instruction1AbsoluteAddress)),
+                                         60.0f, 0, 0.0f, kFunction2Instruction1AbsoluteAddress)),
                                      SampledFunctionEq(MakeSampledFunction(
                                          CaptureData::kUnknownFunctionOrModuleName,
                                          CaptureData::kUnknownFunctionOrModuleName, 3, 60.0f, 5,
-                                         100.0f, kFunction3Instruction1AbsoluteAddress)),
+                                         100.0f, 0, 0.0f, kFunction3Instruction1AbsoluteAddress)),
                                      SampledFunctionEq(MakeSampledFunction(
                                          CaptureData::kUnknownFunctionOrModuleName,
                                          CaptureData::kUnknownFunctionOrModuleName, 1, 20.0f, 1,
-                                         20.0f, kFunction3Instruction2AbsoluteAddress)),
+                                         20.0f, 0, 0.0f, kFunction3Instruction2AbsoluteAddress)),
                                      SampledFunctionEq(MakeSampledFunction(
                                          CaptureData::kUnknownFunctionOrModuleName,
                                          CaptureData::kUnknownFunctionOrModuleName, 1, 20.0f, 1,
-                                         20.0f, kFunction4Instruction1AbsoluteAddress))));
+                                         20.0f, 0, 0.0f, kFunction4Instruction1AbsoluteAddress))));
   }
 
   static void VerifyThreadSampleDataForCallstackEventsInThreadId1(
@@ -503,16 +641,17 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
                                      std::make_pair(2, kFunction2StartAbsoluteAddress),
                                      std::make_pair(2, kFunction3StartAbsoluteAddress),
                                      std::make_pair(1, kFunction4StartAbsoluteAddress)));
-    EXPECT_THAT(actual_thread_sample_data.sampled_functions,
-                UnorderedElementsAre(
-                    SampledFunctionEq(MakeSampledFunction(kFunction1Name, kModulePath, 0, 0.0f, 2,
-                                                          100.0f, kFunction1StartAbsoluteAddress)),
-                    SampledFunctionEq(MakeSampledFunction(kFunction2Name, kModulePath, 0, 0.0f, 2,
-                                                          100.0f, kFunction2StartAbsoluteAddress)),
-                    SampledFunctionEq(MakeSampledFunction(kFunction3Name, kModulePath, 1, 50.0f, 2,
-                                                          100.0f, kFunction3StartAbsoluteAddress)),
-                    SampledFunctionEq(MakeSampledFunction(kFunction4Name, kModulePath, 1, 50.0f, 1,
-                                                          50.0f, kFunction4StartAbsoluteAddress))));
+    EXPECT_THAT(
+        actual_thread_sample_data.sampled_functions,
+        UnorderedElementsAre(
+            SampledFunctionEq(MakeSampledFunction(kFunction1Name, kModulePath, 0, 0.0f, 2, 100.0f,
+                                                  0, 0.0f, kFunction1StartAbsoluteAddress)),
+            SampledFunctionEq(MakeSampledFunction(kFunction2Name, kModulePath, 0, 0.0f, 2, 100.0f,
+                                                  0, 0.0f, kFunction2StartAbsoluteAddress)),
+            SampledFunctionEq(MakeSampledFunction(kFunction3Name, kModulePath, 1, 50.0f, 2, 100.0f,
+                                                  0, 0.0f, kFunction3StartAbsoluteAddress)),
+            SampledFunctionEq(MakeSampledFunction(kFunction4Name, kModulePath, 1, 50.0f, 1, 50.0f,
+                                                  0, 0.0f, kFunction4StartAbsoluteAddress))));
   }
 
   static void VerifyThreadSampleDataForCallstackEventsInThreadId2(
@@ -542,17 +681,109 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
         actual_thread_sample_data.sampled_functions,
         UnorderedElementsAre(
             SampledFunctionEq(MakeSampledFunction(kFunction1Name, kModulePath, 0, 0.0f, 3, 100.0f,
-                                                  kFunction1StartAbsoluteAddress)),
+                                                  0, 0.0f, kFunction1StartAbsoluteAddress)),
             SampledFunctionEq(MakeSampledFunction(kFunction2Name, kModulePath, 0, 0.0f, 1,
-                                                  100.0f / 3, kFunction2StartAbsoluteAddress)),
+                                                  100.0f / 3, 0, 0.0f,
+                                                  kFunction2StartAbsoluteAddress)),
             SampledFunctionEq(MakeSampledFunction(kFunction3Name, kModulePath, 3, 100.0f, 3, 100.0f,
-                                                  kFunction3StartAbsoluteAddress))));
+                                                  0, 0.0f, kFunction3StartAbsoluteAddress))));
+  }
+
+  static void VerifyThreadSampleDataForCallstackEventsInThreadId1WithMixedCallstackTypes(
+      const ThreadSampleData& actual_thread_sample_data) {
+    EXPECT_EQ(actual_thread_sample_data.thread_id, kThreadId1);
+    EXPECT_EQ(actual_thread_sample_data.samples_count, 2);
+    EXPECT_THAT(
+        actual_thread_sample_data.sampled_callstack_id_to_count,
+        UnorderedElementsAre(std::make_pair(kCallstack1Id, 1), std::make_pair(kCallstack2Id, 1)));
+    EXPECT_THAT(actual_thread_sample_data.sampled_address_to_count,
+                UnorderedElementsAre(std::make_pair(kFunction1Instruction1AbsoluteAddress, 1),
+                                     std::make_pair(kFunction2Instruction1AbsoluteAddress, 1),
+                                     std::make_pair(kFunction3Instruction1AbsoluteAddress, 2),
+                                     std::make_pair(kFunction4Instruction1AbsoluteAddress, 1)));
+    EXPECT_THAT(actual_thread_sample_data.resolved_address_to_count,
+                UnorderedElementsAre(std::make_pair(kFunction1StartAbsoluteAddress, 1),
+                                     std::make_pair(kFunction2StartAbsoluteAddress, 1),
+                                     std::make_pair(kFunction3StartAbsoluteAddress, 2),
+                                     std::make_pair(kFunction4StartAbsoluteAddress, 1)));
+    EXPECT_THAT(actual_thread_sample_data.resolved_address_to_exclusive_count,
+                UnorderedElementsAre(std::make_pair(kFunction3StartAbsoluteAddress, 1),
+                                     std::make_pair(kFunction4StartAbsoluteAddress, 1)));
+    EXPECT_THAT(actual_thread_sample_data.sorted_count_to_resolved_address,
+                UnorderedElementsAre(std::make_pair(1, kFunction1StartAbsoluteAddress),
+                                     std::make_pair(1, kFunction2StartAbsoluteAddress),
+                                     std::make_pair(2, kFunction3StartAbsoluteAddress),
+                                     std::make_pair(1, kFunction4StartAbsoluteAddress)));
+    EXPECT_THAT(
+        actual_thread_sample_data.sampled_functions,
+        UnorderedElementsAre(
+            SampledFunctionEq(MakeSampledFunction(kFunction1Name, kModulePath, 0, 0.0f, 1, 50.0f, 0,
+                                                  0.0f, kFunction1StartAbsoluteAddress)),
+            SampledFunctionEq(MakeSampledFunction(kFunction2Name, kModulePath, 0, 0.0f, 1, 50.0f, 0,
+                                                  0.0f, kFunction2StartAbsoluteAddress)),
+            SampledFunctionEq(MakeSampledFunction(kFunction3Name, kModulePath, 1, 50.0f, 2, 100.0f,
+                                                  1, 50.0f, kFunction3StartAbsoluteAddress)),
+            SampledFunctionEq(MakeSampledFunction(kFunction4Name, kModulePath, 1, 50.0f, 1, 50.0f,
+                                                  0, 0.0f, kFunction4StartAbsoluteAddress))));
+  }
+
+  static void VerifyThreadSampleDataForCallstackEventsInThreadId2WithMixedCallstackTypes(
+      const ThreadSampleData& actual_thread_sample_data) {
+    EXPECT_EQ(actual_thread_sample_data.thread_id, kThreadId2);
+    EXPECT_EQ(actual_thread_sample_data.samples_count, 3);
+    EXPECT_THAT(
+        actual_thread_sample_data.sampled_callstack_id_to_count,
+        UnorderedElementsAre(std::make_pair(kCallstack1Id, 1), std::make_pair(kCallstack3Id, 1),
+                             std::make_pair(kCallstack4Id, 1)));
+    EXPECT_THAT(actual_thread_sample_data.sampled_address_to_count,
+                UnorderedElementsAre(std::make_pair(kFunction1Instruction1AbsoluteAddress, 1),
+                                     std::make_pair(kFunction3Instruction1AbsoluteAddress, 3),
+                                     std::make_pair(kFunction3Instruction2AbsoluteAddress, 1)));
+    EXPECT_THAT(actual_thread_sample_data.resolved_address_to_count,
+                UnorderedElementsAre(std::make_pair(kFunction1StartAbsoluteAddress, 1),
+                                     std::make_pair(kFunction3StartAbsoluteAddress, 3)));
+    EXPECT_THAT(actual_thread_sample_data.resolved_address_to_exclusive_count,
+                ElementsAre(std::make_pair(kFunction3StartAbsoluteAddress, 3)));
+    EXPECT_THAT(actual_thread_sample_data.sorted_count_to_resolved_address,
+                UnorderedElementsAre(std::make_pair(1, kFunction1StartAbsoluteAddress),
+                                     std::make_pair(3, kFunction3StartAbsoluteAddress)));
+    EXPECT_THAT(actual_thread_sample_data.sampled_functions,
+                UnorderedElementsAre(SampledFunctionEq(MakeSampledFunction(
+                                         kFunction1Name, kModulePath, 0, 0.0f, 1, 100.0f / 3, 0,
+                                         0.0f, kFunction1StartAbsoluteAddress)),
+                                     SampledFunctionEq(MakeSampledFunction(
+                                         kFunction3Name, kModulePath, 3, 100.0f, 3, 100.0f, 2,
+                                         2 * 100.0f / 3, kFunction3StartAbsoluteAddress))));
   }
 
   void VerifyGetCountOfFunction() {
     EXPECT_EQ(ppsd_.GetCountOfFunction(kFunction1StartAbsoluteAddress), 5);
     EXPECT_EQ(ppsd_.GetCountOfFunction(kFunction1Instruction1AbsoluteAddress), 0);
     EXPECT_EQ(ppsd_.GetCountOfFunction(kFunction2StartAbsoluteAddress), 3);
+    EXPECT_EQ(ppsd_.GetCountOfFunction(kFunction2Instruction1AbsoluteAddress), 0);
+    EXPECT_EQ(ppsd_.GetCountOfFunction(kFunction3StartAbsoluteAddress), 5);
+    EXPECT_EQ(ppsd_.GetCountOfFunction(kFunction3Instruction1AbsoluteAddress), 0);
+    EXPECT_EQ(ppsd_.GetCountOfFunction(kFunction3Instruction2AbsoluteAddress), 0);
+    EXPECT_EQ(ppsd_.GetCountOfFunction(kFunction4StartAbsoluteAddress), 1);
+    EXPECT_EQ(ppsd_.GetCountOfFunction(kFunction4Instruction1AbsoluteAddress), 0);
+  }
+
+  void VerifyGetCountOfFunctionWithOnlyNonCompleteCallstackInfos() {
+    EXPECT_EQ(ppsd_.GetCountOfFunction(kFunction1StartAbsoluteAddress), 0);
+    EXPECT_EQ(ppsd_.GetCountOfFunction(kFunction1Instruction1AbsoluteAddress), 0);
+    EXPECT_EQ(ppsd_.GetCountOfFunction(kFunction2StartAbsoluteAddress), 0);
+    EXPECT_EQ(ppsd_.GetCountOfFunction(kFunction2Instruction1AbsoluteAddress), 0);
+    EXPECT_EQ(ppsd_.GetCountOfFunction(kFunction3StartAbsoluteAddress), 4);
+    EXPECT_EQ(ppsd_.GetCountOfFunction(kFunction3Instruction1AbsoluteAddress), 0);
+    EXPECT_EQ(ppsd_.GetCountOfFunction(kFunction3Instruction2AbsoluteAddress), 0);
+    EXPECT_EQ(ppsd_.GetCountOfFunction(kFunction4StartAbsoluteAddress), 1);
+    EXPECT_EQ(ppsd_.GetCountOfFunction(kFunction4Instruction1AbsoluteAddress), 0);
+  }
+
+  void VerifyGetCountOfFunctionWithMixedCallstackTypes() {
+    EXPECT_EQ(ppsd_.GetCountOfFunction(kFunction1StartAbsoluteAddress), 2);
+    EXPECT_EQ(ppsd_.GetCountOfFunction(kFunction1Instruction1AbsoluteAddress), 0);
+    EXPECT_EQ(ppsd_.GetCountOfFunction(kFunction2StartAbsoluteAddress), 1);
     EXPECT_EQ(ppsd_.GetCountOfFunction(kFunction2Instruction1AbsoluteAddress), 0);
     EXPECT_EQ(ppsd_.GetCountOfFunction(kFunction3StartAbsoluteAddress), 5);
     EXPECT_EQ(ppsd_.GetCountOfFunction(kFunction3Instruction1AbsoluteAddress), 0);
@@ -634,6 +865,113 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
                     {kFunction2StartAbsoluteAddress}, thread_id),
                 SortedCallstackReportEq(
                     MakeSortedCallstackReport({{2, kCallstack1Id}, {1, kCallstack2Id}})));
+    EXPECT_THAT(
+        *ppsd_.GetSortedCallstackReportFromFunctionAddresses({kFunction3StartAbsoluteAddress},
+                                                             thread_id),
+        SortedCallstackReportEq(MakeSortedCallstackReport(
+            {{2, kCallstack1Id}, {1, kCallstack2Id}, {1, kCallstack3Id}, {1, kCallstack4Id}})));
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction4StartAbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({{1, kCallstack2Id}})));
+
+    EXPECT_THAT(
+        *ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+            {kFunction1StartAbsoluteAddress, kFunction2StartAbsoluteAddress,
+             kFunction3StartAbsoluteAddress, kFunction4StartAbsoluteAddress},
+            thread_id),
+        SortedCallstackReportEq(MakeSortedCallstackReport(
+            {{2, kCallstack1Id}, {1, kCallstack2Id}, {1, kCallstack3Id}, {1, kCallstack4Id}})));
+
+    // Also test the non-"Start" addresses.
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction1Instruction1AbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction2Instruction1AbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction3Instruction1AbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction3Instruction2AbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction4Instruction1AbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction1Instruction1AbsoluteAddress, kFunction2Instruction1AbsoluteAddress,
+                     kFunction3Instruction1AbsoluteAddress, kFunction3Instruction2AbsoluteAddress,
+                     kFunction4Instruction1AbsoluteAddress},
+                    thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+  }
+
+  void
+  VerifySortedCallstackReportForCallstackEventsAllInTheSameThreadWithOnlyNonCompleteCallstackInfos(
+      int32_t thread_id) {
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses({}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction1StartAbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction2StartAbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction3StartAbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport(
+                    {{2, kCallstack1Id}, {1, kCallstack3Id}, {1, kCallstack4Id}})));
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction4StartAbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({{1, kCallstack2Id}})));
+
+    EXPECT_THAT(
+        *ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+            {kFunction1StartAbsoluteAddress, kFunction2StartAbsoluteAddress,
+             kFunction3StartAbsoluteAddress, kFunction4StartAbsoluteAddress},
+            thread_id),
+        SortedCallstackReportEq(MakeSortedCallstackReport(
+            {{2, kCallstack1Id}, {1, kCallstack2Id}, {1, kCallstack3Id}, {1, kCallstack4Id}})));
+
+    // Also test the non-"Start" addresses.
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction1Instruction1AbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction2Instruction1AbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction3Instruction1AbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction3Instruction2AbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction4Instruction1AbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction1Instruction1AbsoluteAddress, kFunction2Instruction1AbsoluteAddress,
+                     kFunction3Instruction1AbsoluteAddress, kFunction3Instruction2AbsoluteAddress,
+                     kFunction4Instruction1AbsoluteAddress},
+                    thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+  }
+
+  void VerifySortedCallstackReportForCallstackEventsAllInTheSameThreadWithMixedCallstackTypes(
+      int32_t thread_id) {
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses({}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction1StartAbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(
+                    MakeSortedCallstackReport({{1, kCallstack2Id}, {1, kCallstack3Id}})));
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction2StartAbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({{1, kCallstack2Id}})));
     EXPECT_THAT(
         *ppsd_.GetSortedCallstackReportFromFunctionAddresses({kFunction3StartAbsoluteAddress},
                                                              thread_id),
@@ -839,6 +1177,110 @@ class SamplingDataPostProcessorTest : public ::testing::Test {
                 SortedCallstackReportEq(MakeSortedCallstackReport({})));
   }
 
+  void VerifySortedCallstackReportForCallstackEventsInThreadId1WithMixedCallstackTypes() {
+    int32_t thread_id = kThreadId1;
+
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses({}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction1StartAbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({{1, kCallstack2Id}})));
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction2StartAbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({{1, kCallstack2Id}})));
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction3StartAbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(
+                    MakeSortedCallstackReport({{1, kCallstack1Id}, {1, kCallstack2Id}})));
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction4StartAbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({{1, kCallstack2Id}})));
+
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction1StartAbsoluteAddress, kFunction2StartAbsoluteAddress,
+                     kFunction3StartAbsoluteAddress, kFunction4StartAbsoluteAddress},
+                    thread_id),
+                SortedCallstackReportEq(
+                    MakeSortedCallstackReport({{1, kCallstack1Id}, {1, kCallstack2Id}})));
+
+    // Also test the non-"Start" addresses.
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction1Instruction1AbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction2Instruction1AbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction3Instruction1AbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction3Instruction2AbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction4Instruction1AbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction1Instruction1AbsoluteAddress, kFunction2Instruction1AbsoluteAddress,
+                     kFunction3Instruction1AbsoluteAddress, kFunction3Instruction2AbsoluteAddress,
+                     kFunction4Instruction1AbsoluteAddress},
+                    thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+  }
+
+  void VerifySortedCallstackReportForCallstackEventsInThreadId2WithMixedCallstackTypes() {
+    int32_t thread_id = kThreadId2;
+
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses({}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction1StartAbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({{1, kCallstack3Id}})));
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction2StartAbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction3StartAbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport(
+                    {{1, kCallstack1Id}, {1, kCallstack3Id}, {1, kCallstack4Id}})));
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction4StartAbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction1StartAbsoluteAddress, kFunction2StartAbsoluteAddress,
+                     kFunction3StartAbsoluteAddress, kFunction4StartAbsoluteAddress},
+                    thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport(
+                    {{1, kCallstack1Id}, {1, kCallstack3Id}, {1, kCallstack4Id}})));
+
+    // Also test the non-"Start" addresses.
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction1Instruction1AbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction2Instruction1AbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction3Instruction1AbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction3Instruction2AbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction4Instruction1AbsoluteAddress}, thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+
+    EXPECT_THAT(*ppsd_.GetSortedCallstackReportFromFunctionAddresses(
+                    {kFunction1Instruction1AbsoluteAddress, kFunction2Instruction1AbsoluteAddress,
+                     kFunction3Instruction1AbsoluteAddress, kFunction3Instruction2AbsoluteAddress,
+                     kFunction4Instruction1AbsoluteAddress},
+                    thread_id),
+                SortedCallstackReportEq(MakeSortedCallstackReport({})));
+  }
+
  private:
   uint64_t current_callstack_timestamp_ns_ = 0;
 };
@@ -922,23 +1364,6 @@ TEST_F(SamplingDataPostProcessorTest, CallstackInfosButNoCallstackEvents) {
   VerifyEmptySortedCallstackReport(kThreadIdNotSampled);
 }
 
-TEST_F(SamplingDataPostProcessorTest, OnlyCallstackEventsOfNonCompleteCallstackInfos) {
-  AddAllAddressInfos();
-  AddAllCallstackInfos(CallstackInfo::kDwarfUnwindingError);
-
-  AddCallstackEventsAllInThreadId1();
-
-  CreatePostProcessedSamplingDataWithSummary();
-
-  VerifyNoCallstackInfos();
-
-  EXPECT_EQ(ppsd_.GetThreadSampleData().size(), 0);
-  EXPECT_EQ(ppsd_.GetSummary(), nullptr);
-
-  VerifyEmptySortedCallstackReport(orbit_base::kAllProcessThreadsTid);
-  VerifyEmptySortedCallstackReport(kThreadIdNotSampled);
-}
-
 TEST_F(SamplingDataPostProcessorTest, OneThreadWithoutSummary) {
   AddAllCallstackInfos(CallstackInfo::kComplete);
   AddAllAddressInfos();
@@ -998,6 +1423,106 @@ TEST_F(SamplingDataPostProcessorTest, OneThreadWithSummary) {
   VerifySortedCallstackReportForCallstackEventsAllInTheSameThread(
       orbit_base::kAllProcessThreadsTid);
   VerifySortedCallstackReportForCallstackEventsAllInTheSameThread(kThreadId1);
+  VerifyEmptySortedCallstackReport(kThreadIdNotSampled);
+}
+
+TEST_F(SamplingDataPostProcessorTest, OneThreadWithSummaryWithOnlyNonCompleteCallstackInfos) {
+  AddAllAddressInfos();
+  AddAllCallstackInfos(CallstackInfo::kDwarfUnwindingError);
+
+  AddCallstackEventsAllInThreadId1();
+
+  CreatePostProcessedSamplingDataWithSummary();
+
+  VerifyAllCallstackInfos(CallstackInfo::kDwarfUnwindingError);
+
+  EXPECT_EQ(ppsd_.GetThreadSampleData().size(), 2);
+  ASSERT_NE(ppsd_.GetSummary(), nullptr);
+
+  ASSERT_NE(ppsd_.GetThreadSampleDataByThreadId(orbit_base::kAllProcessThreadsTid), nullptr);
+  ASSERT_NE(ppsd_.GetThreadSampleDataByThreadId(kThreadId1), nullptr);
+  EXPECT_EQ(ppsd_.GetSummary(),
+            ppsd_.GetThreadSampleDataByThreadId(orbit_base::kAllProcessThreadsTid));
+  EXPECT_THAT(
+      ppsd_.GetThreadSampleData(),
+      UnorderedElementsAre(ThreadSampleDataEq(*ppsd_.GetSummary()),
+                           ThreadSampleDataEq(*ppsd_.GetThreadSampleDataByThreadId(kThreadId1))));
+
+  VerifyThreadSampleDataForCallstackEventsAllInTheSameThreadWithOnlyNonCompleteCallstackInfos(
+      *ppsd_.GetSummary(), orbit_base::kAllProcessThreadsTid);
+  VerifyThreadSampleDataForCallstackEventsAllInTheSameThreadWithOnlyNonCompleteCallstackInfos(
+      *ppsd_.GetThreadSampleDataByThreadId(kThreadId1), kThreadId1);
+
+  VerifyGetCountOfFunctionWithOnlyNonCompleteCallstackInfos();
+
+  VerifySortedCallstackReportForCallstackEventsAllInTheSameThreadWithOnlyNonCompleteCallstackInfos(
+      orbit_base::kAllProcessThreadsTid);
+  VerifySortedCallstackReportForCallstackEventsAllInTheSameThreadWithOnlyNonCompleteCallstackInfos(
+      kThreadId1);
+  VerifyEmptySortedCallstackReport(kThreadIdNotSampled);
+}
+
+TEST_F(SamplingDataPostProcessorTest, OneThreadWithoutSummaryWithMixedCallstackTypes) {
+  AddAllCallstackInfosWithMixedCallstackTypes();
+  AddAllAddressInfos();
+
+  AddCallstackEventsAllInThreadId1();
+
+  CreatePostProcessedSamplingDataWithoutSummary();
+
+  VerifyAllCallstackInfosWithMixedCallstackTypes();
+
+  EXPECT_EQ(ppsd_.GetThreadSampleData().size(), 1);
+  EXPECT_EQ(ppsd_.GetSummary(), nullptr);
+
+  ASSERT_NE(ppsd_.GetThreadSampleDataByThreadId(kThreadId1), nullptr);
+  EXPECT_THAT(ppsd_.GetThreadSampleData(),
+              ElementsAre(ThreadSampleDataEq(*ppsd_.GetThreadSampleDataByThreadId(kThreadId1))));
+
+  VerifyThreadSampleDataForCallstackEventsAllInTheSameThreadWithMixedCallstackTypes(
+      *ppsd_.GetThreadSampleDataByThreadId(kThreadId1), kThreadId1);
+
+  VerifyGetCountOfFunctionWithMixedCallstackTypes();
+
+  VerifyEmptySortedCallstackReport(orbit_base::kAllProcessThreadsTid);
+  VerifySortedCallstackReportForCallstackEventsAllInTheSameThreadWithMixedCallstackTypes(
+      kThreadId1);
+  VerifyEmptySortedCallstackReport(kThreadIdNotSampled);
+}
+
+TEST_F(SamplingDataPostProcessorTest, OneThreadWithSummaryWithMixedCallstackTypes) {
+  AddAllCallstackInfosWithMixedCallstackTypes();
+  AddAllAddressInfos();
+
+  AddCallstackEventsAllInThreadId1();
+
+  CreatePostProcessedSamplingDataWithSummary();
+
+  VerifyAllCallstackInfosWithMixedCallstackTypes();
+
+  EXPECT_EQ(ppsd_.GetThreadSampleData().size(), 2);
+  ASSERT_NE(ppsd_.GetSummary(), nullptr);
+
+  ASSERT_NE(ppsd_.GetThreadSampleDataByThreadId(orbit_base::kAllProcessThreadsTid), nullptr);
+  ASSERT_NE(ppsd_.GetThreadSampleDataByThreadId(kThreadId1), nullptr);
+  EXPECT_EQ(ppsd_.GetSummary(),
+            ppsd_.GetThreadSampleDataByThreadId(orbit_base::kAllProcessThreadsTid));
+  EXPECT_THAT(
+      ppsd_.GetThreadSampleData(),
+      UnorderedElementsAre(ThreadSampleDataEq(*ppsd_.GetSummary()),
+                           ThreadSampleDataEq(*ppsd_.GetThreadSampleDataByThreadId(kThreadId1))));
+
+  VerifyThreadSampleDataForCallstackEventsAllInTheSameThreadWithMixedCallstackTypes(
+      *ppsd_.GetSummary(), orbit_base::kAllProcessThreadsTid);
+  VerifyThreadSampleDataForCallstackEventsAllInTheSameThreadWithMixedCallstackTypes(
+      *ppsd_.GetThreadSampleDataByThreadId(kThreadId1), kThreadId1);
+
+  VerifyGetCountOfFunctionWithMixedCallstackTypes();
+
+  VerifySortedCallstackReportForCallstackEventsAllInTheSameThreadWithMixedCallstackTypes(
+      orbit_base::kAllProcessThreadsTid);
+  VerifySortedCallstackReportForCallstackEventsAllInTheSameThreadWithMixedCallstackTypes(
+      kThreadId1);
   VerifyEmptySortedCallstackReport(kThreadIdNotSampled);
 }
 
@@ -1101,6 +1626,74 @@ TEST_F(SamplingDataPostProcessorTest, TwoThreadsWithSummary) {
       orbit_base::kAllProcessThreadsTid);
   VerifySortedCallstackReportForCallstackEventsInThreadId1();
   VerifySortedCallstackReportForCallstackEventsInThreadId2();
+  VerifyEmptySortedCallstackReport(kThreadIdNotSampled);
+}
+
+TEST_F(SamplingDataPostProcessorTest, TwoThreadsWithoutSummaryWithMixedCallstackTypes) {
+  AddAllCallstackInfosWithMixedCallstackTypes();
+  AddAllAddressInfos();
+
+  AddCallstackEventsInThreadId1And2();
+
+  CreatePostProcessedSamplingDataWithoutSummary();
+
+  VerifyAllCallstackInfosWithMixedCallstackTypes();
+
+  EXPECT_EQ(ppsd_.GetThreadSampleData().size(), 2);
+  EXPECT_EQ(ppsd_.GetSummary(), nullptr);
+
+  ASSERT_NE(ppsd_.GetThreadSampleDataByThreadId(kThreadId1), nullptr);
+  ASSERT_NE(ppsd_.GetThreadSampleDataByThreadId(kThreadId2), nullptr);
+  EXPECT_THAT(ppsd_.GetThreadSampleData(),
+              ElementsAre(ThreadSampleDataEq(*ppsd_.GetThreadSampleDataByThreadId(kThreadId2)),
+                          ThreadSampleDataEq(*ppsd_.GetThreadSampleDataByThreadId(kThreadId1))));
+
+  VerifyThreadSampleDataForCallstackEventsInThreadId1WithMixedCallstackTypes(
+      *ppsd_.GetThreadSampleDataByThreadId(kThreadId1));
+  VerifyThreadSampleDataForCallstackEventsInThreadId2WithMixedCallstackTypes(
+      *ppsd_.GetThreadSampleDataByThreadId(kThreadId2));
+
+  VerifyGetCountOfFunctionWithMixedCallstackTypes();
+
+  VerifyEmptySortedCallstackReport(orbit_base::kAllProcessThreadsTid);
+  VerifySortedCallstackReportForCallstackEventsInThreadId1WithMixedCallstackTypes();
+  VerifySortedCallstackReportForCallstackEventsInThreadId2WithMixedCallstackTypes();
+  VerifyEmptySortedCallstackReport(kThreadIdNotSampled);
+}
+
+TEST_F(SamplingDataPostProcessorTest, TwoThreadsWithSummaryWithMixedCallstackTypes) {
+  AddAllCallstackInfosWithMixedCallstackTypes();
+  AddAllAddressInfos();
+
+  AddCallstackEventsInThreadId1And2();
+
+  CreatePostProcessedSamplingDataWithSummary();
+
+  VerifyAllCallstackInfosWithMixedCallstackTypes();
+
+  EXPECT_EQ(ppsd_.GetThreadSampleData().size(), 3);
+  ASSERT_NE(ppsd_.GetSummary(), nullptr);
+
+  ASSERT_NE(ppsd_.GetThreadSampleDataByThreadId(kThreadId1), nullptr);
+  ASSERT_NE(ppsd_.GetThreadSampleDataByThreadId(kThreadId2), nullptr);
+  EXPECT_THAT(ppsd_.GetThreadSampleData(),
+              ElementsAre(ThreadSampleDataEq(*ppsd_.GetSummary()),
+                          ThreadSampleDataEq(*ppsd_.GetThreadSampleDataByThreadId(kThreadId2)),
+                          ThreadSampleDataEq(*ppsd_.GetThreadSampleDataByThreadId(kThreadId1))));
+
+  VerifyThreadSampleDataForCallstackEventsAllInTheSameThreadWithMixedCallstackTypes(
+      *ppsd_.GetSummary(), orbit_base::kAllProcessThreadsTid);
+  VerifyThreadSampleDataForCallstackEventsInThreadId1WithMixedCallstackTypes(
+      *ppsd_.GetThreadSampleDataByThreadId(kThreadId1));
+  VerifyThreadSampleDataForCallstackEventsInThreadId2WithMixedCallstackTypes(
+      *ppsd_.GetThreadSampleDataByThreadId(kThreadId2));
+
+  VerifyGetCountOfFunctionWithMixedCallstackTypes();
+
+  VerifySortedCallstackReportForCallstackEventsAllInTheSameThreadWithMixedCallstackTypes(
+      orbit_base::kAllProcessThreadsTid);
+  VerifySortedCallstackReportForCallstackEventsInThreadId1WithMixedCallstackTypes();
+  VerifySortedCallstackReportForCallstackEventsInThreadId2WithMixedCallstackTypes();
   VerifyEmptySortedCallstackReport(kThreadIdNotSampled);
 }
 

--- a/src/OrbitGl/SamplingReportDataView.cpp
+++ b/src/OrbitGl/SamplingReportDataView.cpp
@@ -48,11 +48,12 @@ const std::vector<DataView::Column>& SamplingReportDataView::GetColumns() {
     std::vector<Column> columns;
     columns.resize(kNumColumns);
     columns[kColumnSelected] = {"Hooked", .0f, SortingOrder::kDescending};
-    columns[kColumnFunctionName] = {"Name", .5f, SortingOrder::kAscending};
+    columns[kColumnFunctionName] = {"Name", .4f, SortingOrder::kAscending};
     columns[kColumnExclusive] = {"Exclusive", .0f, SortingOrder::kDescending};
     columns[kColumnInclusive] = {"Inclusive", .0f, SortingOrder::kDescending};
     columns[kColumnModuleName] = {"Module", .0f, SortingOrder::kAscending};
     columns[kColumnAddress] = {"Address", .0f, SortingOrder::kAscending};
+    columns[kColumnUnwindErrors] = {"Unwind errors", .0f, SortingOrder::kDescending};
     return columns;
   }();
   return columns;
@@ -75,6 +76,10 @@ std::string SamplingReportDataView::GetValue(int row, int column) {
       return std::filesystem::path(func.module_path).filename().string();
     case kColumnAddress:
       return absl::StrFormat("%#llx", func.absolute_address);
+    case kColumnUnwindErrors:
+      return (func.unwind_errors > 0)
+                 ? absl::StrFormat("%.2f%% (%d)", func.unwind_errors_percent, func.unwind_errors)
+                 : "";
     default:
       return "";
   }
@@ -121,6 +126,9 @@ void SamplingReportDataView::DoSort() {
       break;
     case kColumnAddress:
       sorter = ORBIT_PROC_SORT(absolute_address);
+      break;
+    case kColumnUnwindErrors:
+      sorter = ORBIT_PROC_SORT(unwind_errors);
       break;
     default:
       break;

--- a/src/OrbitGl/SamplingReportDataView.h
+++ b/src/OrbitGl/SamplingReportDataView.h
@@ -76,6 +76,7 @@ class SamplingReportDataView : public DataView {
     kColumnInclusive,
     kColumnModuleName,
     kColumnAddress,
+    kColumnUnwindErrors,
     kNumColumns
   };
 

--- a/src/OrbitQt/CallTreeViewItemModel.cpp
+++ b/src/OrbitQt/CallTreeViewItemModel.cpp
@@ -24,8 +24,8 @@ CallTreeViewItemModel::CallTreeViewItemModel(std::unique_ptr<CallTreeView> call_
 QVariant CallTreeViewItemModel::GetDisplayRoleData(const QModelIndex& index) const {
   CHECK(index.isValid());
   auto* item = static_cast<CallTreeNode*>(index.internalPointer());
-  auto thread_item = dynamic_cast<CallTreeThread*>(item);
-  auto function_item = dynamic_cast<CallTreeFunction*>(item);
+  auto* thread_item = dynamic_cast<CallTreeThread*>(item);
+  auto* function_item = dynamic_cast<CallTreeFunction*>(item);
   if (thread_item != nullptr) {
     switch (index.column()) {
       case kThreadOrFunction:
@@ -79,8 +79,8 @@ QVariant CallTreeViewItemModel::GetDisplayRoleData(const QModelIndex& index) con
 QVariant CallTreeViewItemModel::GetEditRoleData(const QModelIndex& index) const {
   CHECK(index.isValid());
   auto* item = static_cast<CallTreeNode*>(index.internalPointer());
-  auto thread_item = dynamic_cast<CallTreeThread*>(item);
-  auto function_item = dynamic_cast<CallTreeFunction*>(item);
+  auto* thread_item = dynamic_cast<CallTreeThread*>(item);
+  auto* function_item = dynamic_cast<CallTreeFunction*>(item);
   if (thread_item != nullptr) {
     switch (index.column()) {
       case kThreadOrFunction:
@@ -115,7 +115,7 @@ QVariant CallTreeViewItemModel::GetEditRoleData(const QModelIndex& index) const 
 QVariant CallTreeViewItemModel::GetToolTipRoleData(const QModelIndex& index) const {
   CHECK(index.isValid());
   auto* item = static_cast<CallTreeNode*>(index.internalPointer());
-  auto function_item = dynamic_cast<CallTreeFunction*>(item);
+  auto* function_item = dynamic_cast<CallTreeFunction*>(item);
   if (function_item != nullptr) {
     switch (index.column()) {
       case kThreadOrFunction:

--- a/src/OrbitQt/CallTreeViewItemModel.h
+++ b/src/OrbitQt/CallTreeViewItemModel.h
@@ -47,6 +47,7 @@ class CallTreeViewItemModel : public QAbstractItemModel {
   [[nodiscard]] QVariant GetDisplayRoleData(const QModelIndex& index) const;
   [[nodiscard]] QVariant GetEditRoleData(const QModelIndex& index) const;
   [[nodiscard]] QVariant GetToolTipRoleData(const QModelIndex& index) const;
+  [[nodiscard]] QVariant GetForegroundRoleData(const QModelIndex& index) const;
   [[nodiscard]] QVariant GetModulePathRoleData(const QModelIndex& index) const;
   [[nodiscard]] QVariant GetModuleBuildIdRoleData(const QModelIndex& index) const;
 

--- a/src/OrbitQt/CallTreeWidget.cpp
+++ b/src/OrbitQt/CallTreeWidget.cpp
@@ -604,7 +604,7 @@ void CallTreeWidget::ProgressBarItemDelegate::paint(QPainter* painter,
   option_progress_bar.palette.setColor(QPalette::Base, bar_background_color);
 
   const QColor palette_highlight_color = option.palette.color(QPalette::Highlight);
-  static const float kBarColorValueReductionFactor = .3f / .4f;
+  static constexpr float kBarColorValueReductionFactor = .3f / .4f;
   const QColor bar_foreground_color = QColor::fromHsv(
       palette_highlight_color.hue(), palette_highlight_color.saturation(),
       static_cast<int>(round(palette_highlight_color.value() * kBarColorValueReductionFactor)));


### PR DESCRIPTION
#### Don't send callstacks with no frames at all, they're kind of meaningless
For the unexpected cases where we really have no frame: do nothing instead of
sending an unwinding error. Again, these cases are unexpected and we haven't
observed them, but we don't want to just crash.
For the samples falling inside uprobes: include the frame we have, even if it's
inside uprobes code.

Test: Take some captures with Trata, with and without frame pointers, with and
without dynamic instrumentation of a very frequent function. Check for crashes.
#### Add "Unwind errors" column to "Sampling" tab
The delicate part is updating `PostProcessedSamplingData` and
`SamplingDataPostProcessor`.

Note that the top-down and bottom-up views still don't show that information,
but instead they simply not add the non-`kComplete` callstacks. This means that
the number of samples in the "Sampling" tab is actually different from the
number of samples in the top-down and bottom-up views. Worry not, this is all
tackled in the next commit.

Possibly distinguishing between different error types will come at a later
time.

Bug: http://b/188496245
Bug: http://b/189824181

Test: Update `SamplingDataPostProcessorTest`.
Capture Trata a few times, waiting for unwinding errors. A way to get a high
percentage of them is to instrument a function that is called very frequently.
Verify numbers make sense and callstacks are in order, including the ones
corresponding to errors.
#### Add [unwind errors] statistics to top-down and bottom-up views
This is how the top-down tree looks now when there are unwinding errors in a
thread (or in the "(all threads)" tree):
```
- thread [1234]
  - clone
    + start_thread
  - [unwind errors]
      foo
```

Here is an example for the bottom-up view when there are unwinding errors for a
function:
```
- foo
  - bar
    + main
  - [unwind errors]
      thread [1234]
      other_thread [1235]
```

I made the "[unwind errors]" string red (only that, not the whole row). I don't
think it's distracting, it doesn't appear often.

Possibly breaking down the statistics by error type will come at a later time.

Bug: http://188496245
Bug: http://189823771
Bug: http://189824607

Test: Played around with it quite a bit with Trata and Infiltrator, with and
without instrumenting a function called very frequently. Tried selections,
context menus, searches, copies.