### PR TITLE
Introduce generic Executor base class and add tests

### DIFF
--- a/src/FakeClient/FakeClientMain.cpp
+++ b/src/FakeClient/FakeClientMain.cpp
@@ -204,7 +204,7 @@ int main(int argc, char* argv[]) {
   InstallSigintHandler();
 
   orbit_capture_client::CaptureClient capture_client{grpc_channel};
-  std::unique_ptr<ThreadPool> thread_pool = ThreadPool::Create(1, 1, absl::Seconds(1));
+  std::shared_ptr<ThreadPool> thread_pool = ThreadPool::Create(1, 1, absl::Seconds(1));
 
   orbit_client_data::ModuleManager module_manager;
   absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions;

--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -39,6 +39,7 @@ target_sources(OrbitBase PRIVATE
         include/OrbitBase/ReadFileToString.h
         include/OrbitBase/SafeStrerror.h
         include/OrbitBase/SharedState.h
+        include/OrbitBase/SimpleExecutor.h
         include/OrbitBase/TemporaryFile.h
         include/OrbitBase/ThreadConstants.h
         include/OrbitBase/ThreadPool.h
@@ -56,6 +57,7 @@ target_sources(OrbitBase PRIVATE
         Profiling.cpp
         ReadFileToString.cpp
         SafeStrerror.cpp
+        SimpleExecutor.cpp
         TemporaryFile.cpp
         ThreadPool.cpp
         Tracing.cpp
@@ -100,6 +102,7 @@ target_sources(OrbitBaseTests PRIVATE
         PromiseTest.cpp
         PromiseHelpersTest.cpp
         ReadFileToStringTest.cpp
+        SimpleExecutorTest.cpp
         TemporaryFileTest.cpp
         ThreadUtilsTest.cpp
         TracingTest.cpp

--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -25,6 +25,7 @@ target_sources(OrbitBase PRIVATE
         include/OrbitBase/CrashHandler.h
         include/OrbitBase/ExecutablePath.h
         include/OrbitBase/ExecuteCommand.h
+        include/OrbitBase/Executor.h
         include/OrbitBase/File.h
         include/OrbitBase/Future.h
         include/OrbitBase/FutureHelpers.h
@@ -87,6 +88,7 @@ target_sources(OrbitBaseTests PRIVATE
         AnyInvocableTest.cpp
         AnyMovableTest.cpp
         ExecutablePathTest.cpp
+        ExecutorTest.cpp
         FileTest.cpp
         FutureTest.cpp
         FutureHelpersTest.cpp

--- a/src/OrbitBase/ExecutorTest.cpp
+++ b/src/OrbitBase/ExecutorTest.cpp
@@ -1,0 +1,199 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "OrbitBase/Action.h"
+#include "OrbitBase/Executor.h"
+
+namespace {
+class MockExecutor : public orbit_base::Executor {
+ public:
+  MOCK_METHOD(void, ScheduleImpl, (std::unique_ptr<Action> action), (override));
+
+  [[nodiscard]] static std::shared_ptr<MockExecutor> Create() {
+    return std::make_shared<MockExecutor>();
+  }
+};
+
+// Since testing::SaveArg can't deal with move-only arguments we define our own helper here.
+template <typename T>
+auto SaveUniquePtr(std::unique_ptr<T>* destination) {
+  return [destination](std::unique_ptr<T> arg) { *destination = std::move(arg); };
+}
+}  // namespace
+
+namespace orbit_base {
+
+TEST(Executor, ScheduledTaskShouldBeCalledSimpleWithVoid) {
+  auto executor = MockExecutor::Create();
+  std::unique_ptr<Action> action;
+  EXPECT_CALL(*executor, ScheduleImpl(testing::_)).Times(1).WillOnce(SaveUniquePtr(&action));
+
+  bool called = false;
+  auto future = executor->Schedule([&called]() { called = true; });
+  ASSERT_NE(action, nullptr);
+  EXPECT_FALSE(called);
+  EXPECT_FALSE(future.IsFinished());
+  action->Execute();
+  EXPECT_TRUE(called);
+  EXPECT_TRUE(future.IsFinished());
+}
+
+TEST(Executor, ScheduledTaskShouldBeCalledSimpleWithInt) {
+  auto executor = MockExecutor::Create();
+  std::unique_ptr<Action> action;
+  EXPECT_CALL(*executor, ScheduleImpl(testing::_)).Times(1).WillOnce(SaveUniquePtr(&action));
+
+  bool called = false;
+  auto future = executor->Schedule([&called]() {
+    called = true;
+    return 42;
+  });
+
+  ASSERT_NE(action, nullptr);
+  EXPECT_FALSE(called);
+  action->Execute();
+  EXPECT_TRUE(called);
+  ASSERT_TRUE(future.IsFinished());
+  EXPECT_EQ(future.Get(), 42);
+}
+
+TEST(Executor, ChainedTaskedShouldBeCalledSimple) {
+  auto executor = MockExecutor::Create();
+  std::unique_ptr<Action> action;
+  EXPECT_CALL(*executor, ScheduleImpl(testing::_)).Times(1).WillOnce(SaveUniquePtr(&action));
+
+  Promise<void> promise{};
+  auto future = promise.GetFuture();
+  auto chained_future = executor->ScheduleAfter(future, []() {});
+  EXPECT_EQ(action, nullptr);
+  EXPECT_FALSE(chained_future.IsFinished());
+
+  promise.MarkFinished();
+  ASSERT_NE(action, nullptr);
+  action->Execute();
+  EXPECT_TRUE(chained_future.IsFinished());
+}
+
+TEST(Executor, ScheduleAfterIfSuccessShortCircuitOnErrorVoid) {
+  auto executor = MockExecutor::Create();
+  std::unique_ptr<Action> action;
+  EXPECT_CALL(*executor, ScheduleImpl(testing::_)).Times(1).WillOnce(SaveUniquePtr(&action));
+
+  Promise<ErrorMessageOr<void>> promise{};
+  auto future = promise.GetFuture();
+  auto chained_future = executor->ScheduleAfterIfSuccess(future, []() {});
+  EXPECT_FALSE(chained_future.IsFinished());
+
+  constexpr const char* const kErrorMessage{"Error"};
+  promise.SetResult(ErrorMessage{kErrorMessage});
+  ASSERT_TRUE(chained_future.IsFinished());
+  EXPECT_TRUE(chained_future.Get().has_error());
+  EXPECT_EQ(chained_future.Get().error().message(), kErrorMessage);
+
+  EXPECT_EQ(executor->GetNumberOfWaitingContinuations(), 1);
+  ASSERT_NE(action, nullptr);
+  action->Execute();
+  EXPECT_EQ(executor->GetNumberOfWaitingContinuations(), 0);
+}
+
+TEST(Executor, ScheduleAfterIfSuccessShortCircuitOnErrorInt) {
+  auto executor = MockExecutor::Create();
+  std::unique_ptr<Action> action;
+  EXPECT_CALL(*executor, ScheduleImpl(testing::_)).Times(1).WillOnce(SaveUniquePtr(&action));
+
+  Promise<ErrorMessageOr<int>> promise{};
+  auto future = promise.GetFuture();
+  auto chained_future = executor->ScheduleAfterIfSuccess(future, [](int value) {
+    EXPECT_EQ(value, 42);
+    return 1 + value;
+  });
+  EXPECT_FALSE(chained_future.IsFinished());
+
+  constexpr const char* const kErrorMessage{"Error"};
+  promise.SetResult(ErrorMessage{kErrorMessage});
+  ASSERT_TRUE(chained_future.IsFinished());
+  EXPECT_TRUE(chained_future.Get().has_error());
+  EXPECT_EQ(chained_future.Get().error().message(), kErrorMessage);
+
+  EXPECT_EQ(executor->GetNumberOfWaitingContinuations(), 1);
+  ASSERT_NE(action, nullptr);
+  action->Execute();
+  EXPECT_EQ(executor->GetNumberOfWaitingContinuations(), 0);
+}
+
+TEST(Executor, ScheduleAfterIfSuccessCallOnSuccessVoid) {
+  auto executor = MockExecutor::Create();
+  std::unique_ptr<Action> action;
+  EXPECT_CALL(*executor, ScheduleImpl(testing::_)).Times(1).WillOnce(SaveUniquePtr(&action));
+
+  Promise<ErrorMessageOr<void>> promise{};
+  auto future = promise.GetFuture();
+  auto chained_future = executor->ScheduleAfterIfSuccess(future, []() {});
+  EXPECT_EQ(action, nullptr);
+  EXPECT_FALSE(chained_future.IsFinished());
+
+  promise.SetResult(outcome::success());
+  ASSERT_NE(action, nullptr);
+  action->Execute();
+  ASSERT_TRUE(chained_future.IsFinished());
+  EXPECT_FALSE(chained_future.Get().has_error());
+}
+
+TEST(Executor, ScheduleAfterIfSuccessCallOnSuccessInt) {
+  auto executor = MockExecutor::Create();
+  std::unique_ptr<Action> action;
+  EXPECT_CALL(*executor, ScheduleImpl(testing::_)).Times(1).WillOnce(SaveUniquePtr(&action));
+
+  Promise<ErrorMessageOr<int>> promise{};
+  auto future = promise.GetFuture();
+  auto chained_future = executor->ScheduleAfterIfSuccess(future, [](int value) {
+    EXPECT_EQ(value, 42);
+    return 1 + value;
+  });
+
+  EXPECT_EQ(action, nullptr);
+  EXPECT_FALSE(chained_future.IsFinished());
+
+  promise.SetResult(42);
+  ASSERT_NE(action, nullptr);
+  EXPECT_FALSE(chained_future.IsFinished());
+
+  action->Execute();
+  ASSERT_TRUE(chained_future.IsFinished());
+  EXPECT_FALSE(chained_future.Get().has_error());
+  EXPECT_EQ(chained_future.Get().value(), 43);
+}
+
+TEST(Executor, TryScheduleFailing) {
+  std::weak_ptr<Executor> executor{};
+
+  bool called = false;
+  std::optional<orbit_base::Future<void>> result =
+      TrySchedule(executor, [&called]() { called = true; });
+
+  EXPECT_FALSE(result.has_value());
+  EXPECT_FALSE(called);
+}
+
+TEST(Executor, TrySchedule) {
+  auto executor = MockExecutor::Create();
+  std::unique_ptr<Action> action;
+  EXPECT_CALL(*executor, ScheduleImpl(testing::_)).Times(1).WillOnce(SaveUniquePtr(&action));
+
+  bool called = false;
+  auto future_or_nullopt = TrySchedule(executor->weak_from_this(), [&called]() { called = true; });
+  ASSERT_TRUE(future_or_nullopt.has_value());
+  EXPECT_FALSE(future_or_nullopt->IsFinished());
+
+  ASSERT_NE(action, nullptr);
+  EXPECT_FALSE(called);
+  action->Execute();
+  EXPECT_TRUE(called);
+
+  EXPECT_TRUE(future_or_nullopt->IsFinished());
+}
+}  // namespace orbit_base

--- a/src/OrbitBase/SimpleExecutor.cpp
+++ b/src/OrbitBase/SimpleExecutor.cpp
@@ -1,0 +1,33 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "OrbitBase/SimpleExecutor.h"
+
+#include <memory>
+
+namespace orbit_base {
+void SimpleExecutor::ScheduleImpl(std::unique_ptr<Action> action) {
+  scheduled_tasks_.emplace_back(std::move(action));
+}
+
+void SimpleExecutor::ExecuteScheduledTasks() {
+  // Since each task can append to the list of scheduled tasks we have to make sure not to rely on
+  // unstable iterators.
+  absl::MutexLock lock{&mutex_};
+  while (!scheduled_tasks_.empty()) {
+    Action* action = scheduled_tasks_.front().get();
+    {
+      mutex_.Unlock();
+      action->Execute();
+      mutex_.Lock();
+    }
+    scheduled_tasks_.pop_front();
+  }
+}
+
+std::shared_ptr<SimpleExecutor> SimpleExecutor::Create() {
+  // NOLINTNEXTLINE
+  return std::shared_ptr<SimpleExecutor>{new SimpleExecutor{}};
+}
+}  // namespace orbit_base

--- a/src/OrbitBase/SimpleExecutorTest.cpp
+++ b/src/OrbitBase/SimpleExecutorTest.cpp
@@ -1,0 +1,129 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "OrbitBase/SimpleExecutor.h"
+
+namespace orbit_base {
+
+TEST(SimpleExecutor, ScheduledTaskShouldBeCalledSimpleWithVoid) {
+  auto executor = SimpleExecutor::Create();
+  bool called = false;
+  auto future = executor->Schedule([&called]() { called = true; });
+  executor->ExecuteScheduledTasks();
+  EXPECT_TRUE(called);
+  EXPECT_TRUE(future.IsFinished());
+}
+
+TEST(SimpleExecutor, ScheduledTaskShouldBeCalledSimpleWithInt) {
+  auto executor = SimpleExecutor::Create();
+  bool called = false;
+  auto future = executor->Schedule([&called]() {
+    called = true;
+    return 42;
+  });
+  executor->ExecuteScheduledTasks();
+  EXPECT_TRUE(called);
+  ASSERT_TRUE(future.IsFinished());
+  EXPECT_EQ(future.Get(), 42);
+}
+
+TEST(SimpleExecutor, ChainedTaskedShouldBeCalledSimple) {
+  auto executor = SimpleExecutor::Create();
+  bool called = false;
+  Promise<void> promise{};
+  auto future = promise.GetFuture();
+  auto chained_future = executor->ScheduleAfter(future, [&called]() { called = true; });
+  EXPECT_FALSE(called);
+  EXPECT_FALSE(chained_future.IsFinished());
+  promise.MarkFinished();
+  executor->ExecuteScheduledTasks();
+  EXPECT_TRUE(called);
+  EXPECT_TRUE(chained_future.IsFinished());
+}
+
+TEST(SimpleExecutor, ScheduleAfterIfSuccessShortCircuitOnErrorVoid) {
+  auto executor = SimpleExecutor::Create();
+  bool called = false;
+  Promise<ErrorMessageOr<void>> promise{};
+  auto future = promise.GetFuture();
+  auto chained_future = executor->ScheduleAfterIfSuccess(future, [&called]() { called = true; });
+  EXPECT_FALSE(called);
+  EXPECT_FALSE(chained_future.IsFinished());
+
+  constexpr const char* const kErrorMessage{"Error"};
+  promise.SetResult(ErrorMessage{kErrorMessage});
+  EXPECT_TRUE(chained_future.IsFinished());
+
+  executor->ExecuteScheduledTasks();
+  EXPECT_FALSE(called);
+  ASSERT_TRUE(chained_future.IsFinished());
+  EXPECT_TRUE(chained_future.Get().has_error());
+  EXPECT_EQ(chained_future.Get().error().message(), kErrorMessage);
+}
+
+TEST(SimpleExecutor, ScheduleAfterIfSuccessShortCircuitOnErrorInt) {
+  auto executor = SimpleExecutor::Create();
+  bool called = false;
+  Promise<ErrorMessageOr<int>> promise{};
+  auto future = promise.GetFuture();
+  auto chained_future = executor->ScheduleAfterIfSuccess(future, [&called](int value) {
+    EXPECT_EQ(value, 42);
+    called = true;
+    return 1 + value;
+  });
+  executor->ExecuteScheduledTasks();
+  EXPECT_FALSE(called);
+  EXPECT_FALSE(chained_future.IsFinished());
+
+  constexpr const char* const kErrorMessage{"Error"};
+  promise.SetResult(ErrorMessage{kErrorMessage});
+  executor->ExecuteScheduledTasks();
+  EXPECT_FALSE(called);
+  ASSERT_TRUE(chained_future.IsFinished());
+  EXPECT_TRUE(chained_future.Get().has_error());
+  EXPECT_EQ(chained_future.Get().error().message(), kErrorMessage);
+}
+
+TEST(SimpleExecutor, ScheduleAfterIfSuccessCallOnSuccessVoid) {
+  auto executor = SimpleExecutor::Create();
+  bool called = false;
+  Promise<ErrorMessageOr<void>> promise{};
+  auto future = promise.GetFuture();
+  auto chained_future = executor->ScheduleAfterIfSuccess(future, [&called]() { called = true; });
+  executor->ExecuteScheduledTasks();
+  EXPECT_FALSE(called);
+  EXPECT_FALSE(chained_future.IsFinished());
+
+  promise.SetResult(outcome::success());
+  executor->ExecuteScheduledTasks();
+  EXPECT_TRUE(called);
+  ASSERT_TRUE(chained_future.IsFinished());
+  EXPECT_FALSE(chained_future.Get().has_error());
+}
+
+TEST(SimpleExecutor, ScheduleAfterIfSuccessCallOnSuccessInt) {
+  auto executor = SimpleExecutor::Create();
+  bool called = false;
+  Promise<ErrorMessageOr<int>> promise{};
+  auto future = promise.GetFuture();
+  auto chained_future = executor->ScheduleAfterIfSuccess(future, [&called](int value) {
+    EXPECT_EQ(value, 42);
+    called = true;
+    return 1 + value;
+  });
+  executor->ExecuteScheduledTasks();
+  EXPECT_FALSE(called);
+  EXPECT_FALSE(chained_future.IsFinished());
+
+  promise.SetResult(42);
+  executor->ExecuteScheduledTasks();
+  EXPECT_TRUE(called);
+  ASSERT_TRUE(chained_future.IsFinished());
+  EXPECT_FALSE(chained_future.Get().has_error());
+  EXPECT_EQ(chained_future.Get().value(), 43);
+}
+
+}  // namespace orbit_base

--- a/src/OrbitBase/ThreadPool.cpp
+++ b/src/OrbitBase/ThreadPool.cpp
@@ -138,7 +138,9 @@ bool ThreadPoolImpl::ActionsAvailableOrShutdownInitiated() {
 std::unique_ptr<Action> ThreadPoolImpl::TakeAction() {
   while (true) {
     if (mutex_.AwaitWithTimeout(
-            absl::Condition(this, &ThreadPoolImpl::ActionsAvailableOrShutdownInitiated),
+            absl::Condition(
+                +[](ThreadPoolImpl* self) { return self->ActionsAvailableOrShutdownInitiated(); },
+                this),
             thread_ttl_)) {
       break;
     }

--- a/src/OrbitBase/ThreadPoolTest.cpp
+++ b/src/OrbitBase/ThreadPoolTest.cpp
@@ -18,7 +18,7 @@ TEST(ThreadPool, Smoke) {
   constexpr size_t kThreadPoolMinSize = 1;
   constexpr size_t kThreadPoolMaxSize = 2;
   constexpr absl::Duration kThreadTtl = absl::Milliseconds(5);
-  std::unique_ptr<ThreadPool> thread_pool =
+  std::shared_ptr<ThreadPool> thread_pool =
       ThreadPool::Create(kThreadPoolMinSize, kThreadPoolMaxSize, kThreadTtl);
 
   absl::Mutex mutex;
@@ -50,7 +50,7 @@ TEST(ThreadPool, QueuedActionsExecutedOnShutdown) {
   constexpr size_t kThreadPoolMinSize = 1;
   constexpr size_t kThreadPoolMaxSize = 2;
   constexpr absl::Duration kThreadTtl = absl::Milliseconds(5);
-  std::unique_ptr<ThreadPool> thread_pool =
+  std::shared_ptr<ThreadPool> thread_pool =
       ThreadPool::Create(kThreadPoolMinSize, kThreadPoolMaxSize, kThreadTtl);
 
   absl::Mutex mutex;
@@ -79,7 +79,7 @@ TEST(ThreadPool, CheckTtl) {
   constexpr size_t kThreadPoolMinSize = 1;
   constexpr size_t kThreadPoolMaxSize = 5;
   constexpr size_t kThreadTtlMillis = 5;
-  std::unique_ptr<ThreadPool> thread_pool = ThreadPool::Create(
+  std::shared_ptr<ThreadPool> thread_pool = ThreadPool::Create(
       kThreadPoolMinSize, kThreadPoolMaxSize, absl::Milliseconds(kThreadTtlMillis));
 
   absl::Mutex actions_started_mutex;
@@ -133,7 +133,7 @@ TEST(ThreadPool, ExtendThreadPool) {
   constexpr size_t kThreadPoolMinSize = 1;
   constexpr size_t kThreadPoolMaxSize = 5;
   constexpr size_t kThreadTtlMillis = 5;
-  std::unique_ptr<ThreadPool> thread_pool = ThreadPool::Create(
+  std::shared_ptr<ThreadPool> thread_pool = ThreadPool::Create(
       kThreadPoolMinSize, kThreadPoolMaxSize, absl::Milliseconds(kThreadTtlMillis));
 
   absl::Mutex actions_started_mutex;
@@ -257,7 +257,7 @@ TEST(ThreadPool, CheckGetNumberOfBusyThreads) {
   constexpr size_t kThreadPoolMaxSize = 2;
   constexpr size_t kThreadTtlMillis = 5;
 
-  std::unique_ptr<ThreadPool> thread_pool = ThreadPool::Create(
+  std::shared_ptr<ThreadPool> thread_pool = ThreadPool::Create(
       kThreadPoolMinSize, kThreadPoolMaxSize, absl::Milliseconds(kThreadTtlMillis));
 
   EXPECT_EQ(thread_pool->GetNumberOfBusyThreads(), 0);
@@ -358,7 +358,7 @@ TEST(ThreadPool, ScheduleAfterShutdown) {
         constexpr size_t kThreadPoolMinSize = 1;
         constexpr size_t kThreadPoolMaxSize = 2;
         constexpr absl::Duration kThreadTtl = absl::Milliseconds(5);
-        std::unique_ptr<ThreadPool> thread_pool =
+        std::shared_ptr<ThreadPool> thread_pool =
             ThreadPool::Create(kThreadPoolMinSize, kThreadPoolMaxSize, kThreadTtl);
 
         thread_pool->Shutdown();
@@ -373,7 +373,7 @@ TEST(ThreadPool, WaitWithoutShutdown) {
         constexpr size_t kThreadPoolMinSize = 1;
         constexpr size_t kThreadPoolMaxSize = 2;
         constexpr absl::Duration kThreadTtl = absl::Milliseconds(5);
-        std::unique_ptr<ThreadPool> thread_pool =
+        std::shared_ptr<ThreadPool> thread_pool =
             ThreadPool::Create(kThreadPoolMinSize, kThreadPoolMaxSize, kThreadTtl);
 
         thread_pool->Wait();
@@ -385,7 +385,7 @@ TEST(ThreadPool, FutureBasic) {
   constexpr size_t kThreadPoolMinSize = 1;
   constexpr size_t kThreadPoolMaxSize = 2;
   constexpr absl::Duration kThreadTtl = absl::Milliseconds(5);
-  std::unique_ptr<ThreadPool> thread_pool =
+  std::shared_ptr<ThreadPool> thread_pool =
       ThreadPool::Create(kThreadPoolMinSize, kThreadPoolMaxSize, kThreadTtl);
 
   absl::Mutex mutex;
@@ -420,7 +420,7 @@ TEST(ThreadPool, FutureContinuation) {
   constexpr size_t kThreadPoolMinSize = 1;
   constexpr size_t kThreadPoolMaxSize = 2;
   constexpr absl::Duration kThreadTtl = absl::Milliseconds(5);
-  std::unique_ptr<ThreadPool> thread_pool =
+  std::shared_ptr<ThreadPool> thread_pool =
       ThreadPool::Create(kThreadPoolMinSize, kThreadPoolMaxSize, kThreadTtl);
 
   absl::Mutex mutex;
@@ -467,7 +467,7 @@ TEST(ThreadPool, FutureWithMoveOnlyResult) {
   constexpr size_t kThreadPoolMinSize = 1;
   constexpr size_t kThreadPoolMaxSize = 2;
   constexpr absl::Duration kThreadTtl = absl::Milliseconds(5);
-  std::unique_ptr<ThreadPool> thread_pool =
+  std::shared_ptr<ThreadPool> thread_pool =
       ThreadPool::Create(kThreadPoolMinSize, kThreadPoolMaxSize, kThreadTtl);
 
   absl::Mutex mutex;

--- a/src/OrbitBase/include/OrbitBase/Executor.h
+++ b/src/OrbitBase/include/OrbitBase/Executor.h
@@ -1,0 +1,174 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_BASE_EXECUTOR_H_
+#define ORBIT_BASE_EXECUTOR_H_
+
+#include <list>
+#include <memory>
+
+#include "OrbitBase/Action.h"
+#include "OrbitBase/AnyMovable.h"
+#include "OrbitBase/Future.h"
+#include "OrbitBase/FutureHelpers.h"
+#include "OrbitBase/Promise.h"
+#include "OrbitBase/PromiseHelpers.h"
+
+namespace orbit_base {
+
+// Executor is a common base class for ThreadPool and MainThreadExecutor.
+// Check out these two for details.
+class Executor : public std::enable_shared_from_this<Executor> {
+  // Schedules the action to be performed on the executor.
+  virtual void ScheduleImpl(std::unique_ptr<Action> action) = 0;
+
+ public:
+  virtual ~Executor() = default;
+
+  // Schedule schedules the function object `functor` to be executed on `*this`. The execution
+  // occures asynchronously, meaning this function call will only push the function object to a
+  // queue. It will be picked up by an event loop cycle.
+  //
+  // Note: The function object is only executed if `*this` is still alive when the event loop picks
+  // up the scheduled task.
+  template <typename F>
+  auto Schedule(F&& functor) -> orbit_base::Future<std::decay_t<decltype(functor())>> {
+    using ReturnType = std::decay_t<decltype(functor())>;
+
+    orbit_base::Promise<ReturnType> promise;
+    orbit_base::Future<ReturnType> future = promise.GetFuture();
+
+    auto function_wrapper = [functor = std::forward<F>(functor),
+                             promise = std::move(promise)]() mutable {
+      orbit_base::CallTaskAndSetResultInPromise<ReturnType> helper{&promise};
+      helper.Call(functor);
+    };
+    ScheduleImpl(CreateAction(std::move(function_wrapper)));
+
+    return future;
+  }
+
+  // ScheduleAfter schedules the continuation `functor` to be executed on `*this` after `future` has
+  // completed.
+  //
+  // Note: The continuation is only executed if `*this` is still alive when `future` completes.
+  template <typename T, typename F>
+  auto ScheduleAfter(const orbit_base::Future<T>& future, F&& functor) {
+    CHECK(future.IsValid());
+
+    using ReturnType = typename orbit_base::ContinuationReturnType<T, F>::Type;
+
+    orbit_base::Promise<ReturnType> promise{};
+    orbit_base::Future<ReturnType> resulting_future = promise.GetFuture();
+
+    waiting_continuations_.emplace_front(std::forward<F>(functor));
+    auto function_reference = waiting_continuations_.begin();
+
+    auto continuation = [this, function_reference, executor_weak_ptr = weak_from_this(),
+                         promise = std::move(promise)](auto&&... argument) mutable {
+      auto executor = executor_weak_ptr.lock();
+      if (executor == nullptr) return;
+
+      auto function_wrapper =
+          [this, function_reference, promise = std::move(promise),
+           argument = std::make_tuple(std::forward<decltype(argument)>(argument)...)]() mutable {
+            orbit_base::CallTaskAndSetResultInPromise<ReturnType> helper{&promise};
+
+            // We don't have to worry about `function_reference` being invalid. It's a stable
+            // iterator under the hood and this lambda will only be executed if the executor is
+            // still alive.
+            auto functor = orbit_base::any_movable_cast<std::decay_t<F>>(&*function_reference);
+            CHECK(functor != nullptr);
+            std::apply([&](auto... args) { helper.Call(*functor, args...); }, std::move(argument));
+            waiting_continuations_.erase(function_reference);
+          };
+      executor->ScheduleImpl(CreateAction(std::move(function_wrapper)));
+    };
+
+    const orbit_base::FutureRegisterContinuationResult result =
+        future.RegisterContinuation(std::move(continuation));
+
+    if (result != orbit_base::FutureRegisterContinuationResult::kSuccessfullyRegistered) {
+      // If the future has already been finished, we call the continuation here.
+      // Keep in mind, this will not run the task synchronously. This will only
+      // SCHEDULE the task synchronously.
+      orbit_base::GetResultFromFutureAndCallContinuation<T> helper{&future};
+      helper.Call(continuation);
+    }
+
+    return resulting_future;
+  }
+
+  // ScheduleAfterIfSuccess schedules the continuation `functor` to be executed on `*this` after
+  // `future` has completed, and only if `future` returns a non-error result.
+  //
+  // Note: The continuation is only executed if `*this` is still alive when `future` completes.
+  template <typename T, typename F>
+  auto ScheduleAfterIfSuccess(const orbit_base::Future<ErrorMessageOr<T>>& future, F&& functor) {
+    CHECK(future.IsValid());
+
+    using ContinuationReturnType = typename orbit_base::ContinuationReturnType<T, F>::Type;
+    using PromiseReturnType =
+        typename orbit_base::EnsureWrappedInErrorMessageOr<ContinuationReturnType>::Type;
+
+    orbit_base::Promise<PromiseReturnType> promise{};
+    orbit_base::Future<PromiseReturnType> resulting_future = promise.GetFuture();
+
+    waiting_continuations_.emplace_front(std::forward<F>(functor));
+    auto function_reference = waiting_continuations_.begin();
+
+    auto continuation = [this, function_reference, executor_weak_ptr = weak_from_this(),
+                         promise = std::move(promise)](const ErrorMessageOr<T>& argument) mutable {
+      auto executor = executor_weak_ptr.lock();
+      if (executor == nullptr) return;
+
+      // If the future returns a non-success ErrorMessageOr-type, we will short-circuit and won't
+      // call the continutation. But we still have to schedule an action, that destroys the
+      // continuation in the executor's context (think main thread). The continuation's destructor
+      // might do things that need synchronization and can't happen in a different context (like a
+      // thread pool), i.e. when the continuation owns a ScopedStatus.
+      if (argument.has_error()) {
+        promise.SetResult(outcome::failure(argument.error()));
+        executor->ScheduleImpl(CreateAction(
+            [this, function_reference]() { waiting_continuations_.erase(function_reference); }));
+        return;
+      }
+
+      auto success_function_wrapper = [this, function_reference, promise = std::move(promise),
+                                       argument]() mutable {
+        auto functor = orbit_base::any_movable_cast<std::decay_t<F>>(&*function_reference);
+        CHECK(functor != nullptr);
+
+        orbit_base::HandleErrorAndSetResultInPromise<PromiseReturnType> helper{&promise};
+        helper.Call(*functor, argument);
+
+        waiting_continuations_.erase(function_reference);
+      };
+      executor->ScheduleImpl(CreateAction(std::move(success_function_wrapper)));
+    };
+
+    orbit_base::RegisterContinuationOrCallDirectly(future, std::move(continuation));
+    return resulting_future;
+  }
+
+  [[nodiscard]] size_t GetNumberOfWaitingContinuations() const {
+    return waiting_continuations_.size();
+  }
+
+ private:
+  std::list<orbit_base::AnyMovable> waiting_continuations_;
+};
+
+template <typename F>
+auto TrySchedule(const std::weak_ptr<Executor>& executor, F&& function_object)
+    -> std::optional<decltype(std::declval<Executor>().Schedule(function_object))> {
+  auto executor_ptr = executor.lock();
+  if (executor_ptr == nullptr) return std::nullopt;
+
+  return std::make_optional(executor_ptr->Schedule(std::forward<F>(function_object)));
+}
+
+}  // namespace orbit_base
+
+#endif  // ORBIT_BASE_EXECUTOR_H_

--- a/src/OrbitBase/include/OrbitBase/SimpleExecutor.h
+++ b/src/OrbitBase/include/OrbitBase/SimpleExecutor.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_BASE_SIMPLE_EXECUTOR_H_
+#define ORBIT_BASE_SIMPLE_EXECUTOR_H_
+
+#include <absl/base/internal/thread_annotations.h>
+#include <absl/synchronization/mutex.h>
+
+#include <deque>
+#include <memory>
+
+#include "OrbitBase/Action.h"
+#include "OrbitBase/Executor.h"
+
+namespace orbit_base {
+
+// This is a simple implementation of Executor.
+// It's mainly intended to be used in tests.
+//
+// The user can schedule tasks which get stored in SimpleExecutor
+// until they call `ExecuteScheduledTasks` which will synchronously
+// execute waiting tasks.
+class SimpleExecutor : public Executor {
+  explicit SimpleExecutor() = default;
+
+  void ScheduleImpl(std::unique_ptr<Action> action) override;
+
+ public:
+  void ExecuteScheduledTasks();
+
+  [[nodiscard]] static std::shared_ptr<SimpleExecutor> Create();
+
+ private:
+  absl::Mutex mutex_;
+  std::deque<std::unique_ptr<Action>> scheduled_tasks_ GUARDED_BY(mutex_);
+};
+
+}  // namespace orbit_base
+
+#endif  // ORBIT_BASE_SIMPLE_EXECUTOR_H_

--- a/src/OrbitBase/include/OrbitBase/Tracing.h
+++ b/src/OrbitBase/include/OrbitBase/Tracing.h
@@ -42,7 +42,7 @@ class TracingListener {
 
  private:
   TracingTimerCallback user_callback_ = nullptr;
-  std::unique_ptr<ThreadPool> thread_pool_ = {};
+  std::shared_ptr<ThreadPool> thread_pool_ = {};
   inline static bool active_ = false;
   inline static bool shutdown_initiated_ = true;
 };

--- a/src/OrbitCaptureGgpService/OrbitCaptureGgpServiceImpl.h
+++ b/src/OrbitCaptureGgpService/OrbitCaptureGgpServiceImpl.h
@@ -41,7 +41,7 @@ class CaptureClientGgpServiceImpl final
 
  private:
   std::unique_ptr<ClientGgp> client_ggp_;
-  std::unique_ptr<ThreadPool> thread_pool_;
+  std::shared_ptr<ThreadPool> thread_pool_;
   std::atomic<bool> shutdown_finished_{false};
 
   void InitClientGgp();

--- a/src/OrbitClientGgp/main.cpp
+++ b/src/OrbitClientGgp/main.cpp
@@ -82,7 +82,7 @@ int main(int argc, char** argv) {
 
   // The request is done in a separate thread to avoid blocking main()
   // It is needed to provide a thread pool
-  std::unique_ptr<ThreadPool> thread_pool = ThreadPool::Create(1, 1, absl::Seconds(1));
+  std::shared_ptr<ThreadPool> thread_pool = ThreadPool::Create(1, 1, absl::Seconds(1));
   auto start_capture_result = client_ggp.RequestStartCapture(thread_pool.get());
   if (start_capture_result.has_error()) {
     thread_pool->ShutdownAndWait();

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -557,7 +557,7 @@ class OrbitApp final : public DataViewFactory, public orbit_capture_client::Capt
   orbit_gl::MainWindowInterface* main_window_ = nullptr;
   MainThreadExecutor* main_thread_executor_;
   std::thread::id main_thread_id_;
-  std::unique_ptr<ThreadPool> thread_pool_;
+  std::shared_ptr<ThreadPool> thread_pool_;
   std::unique_ptr<orbit_capture_client::CaptureClient> capture_client_;
   orbit_client_services::ProcessManager* process_manager_ = nullptr;
   std::unique_ptr<orbit_client_data::ModuleManager> module_manager_;

--- a/src/OrbitGl/MainThreadExecutor.h
+++ b/src/OrbitGl/MainThreadExecutor.h
@@ -8,18 +8,9 @@
 #include <absl/types/span.h>
 
 #include <chrono>
-#include <list>
-#include <memory>
-#include <thread>
-#include <type_traits>
-#include <utility>
 
-#include "OrbitBase/Action.h"
-#include "OrbitBase/AnyMovable.h"
+#include "OrbitBase/Executor.h"
 #include "OrbitBase/Future.h"
-#include "OrbitBase/FutureHelpers.h"
-#include "OrbitBase/Promise.h"
-#include "OrbitBase/PromiseHelpers.h"
 
 // This class implements a mechanism for landing
 // actions to the main thread. As a general rule
@@ -37,141 +28,8 @@
 // manager->Schedule(CreateAction([data]{
 //   UpdateSomethingWith(data);
 // }));
-class MainThreadExecutor : public std::enable_shared_from_this<MainThreadExecutor> {
+class MainThreadExecutor : public orbit_base::Executor {
  public:
-  MainThreadExecutor() = default;
-  virtual ~MainThreadExecutor() = default;
-
-  // Schedules the action to be performed on the main thread.
-  virtual void Schedule(std::unique_ptr<Action> action) = 0;
-
-  // Schedule schedules the function object `functor` to be executed
-  // on `*this`. The execution occures asynchronously, meaning this
-  // function call will only push the function object to a queue. It
-  // will be picked up by an event loop cycle.
-  //
-  // Note: The function object is only executed if `*this` is still alive when the event loop picks
-  // up the scheduled task.
-  template <typename F>
-  auto Schedule(F&& functor) -> orbit_base::Future<std::decay_t<decltype(functor())>> {
-    using ReturnType = std::decay_t<decltype(functor())>;
-
-    orbit_base::Promise<ReturnType> promise;
-    orbit_base::Future<ReturnType> future = promise.GetFuture();
-
-    auto function_wrapper = [functor = std::forward<F>(functor),
-                             promise = std::move(promise)]() mutable {
-      orbit_base::CallTaskAndSetResultInPromise<ReturnType> helper{&promise};
-      helper.Call(functor);
-    };
-    Schedule(CreateAction(std::move(function_wrapper)));
-
-    return future;
-  }
-
-  // ScheduleAfter schedules the continuation `functor` to be executed
-  // on `*this` after `future` has completed.
-  //
-  // Note: The continuation is only executed if `*this` is still alive when `future` completes.
-  template <typename T, typename F>
-  auto ScheduleAfter(const orbit_base::Future<T>& future, F&& functor) {
-    CHECK(future.IsValid());
-
-    using ReturnType = typename orbit_base::ContinuationReturnType<T, F>::Type;
-
-    orbit_base::Promise<ReturnType> promise{};
-    orbit_base::Future<ReturnType> resulting_future = promise.GetFuture();
-
-    waiting_continuations_.emplace_front(std::forward<F>(functor));
-    auto function_reference = waiting_continuations_.begin();
-
-    auto continuation = [this, function_reference, executor_weak_ptr = weak_from_this(),
-                         promise = std::move(promise)](auto&&... argument) mutable {
-      auto executor = executor_weak_ptr.lock();
-      if (executor == nullptr) return;
-
-      auto function_wrapper =
-          [this, function_reference, promise = std::move(promise),
-           argument = std::make_tuple(std::forward<decltype(argument)>(argument)...)]() mutable {
-            orbit_base::CallTaskAndSetResultInPromise<ReturnType> helper{&promise};
-
-            // We don't have to worry about `function_reference` being invalid. It's a stable
-            // iterator under the hood and this lambda will only be executed if the executor is
-            // still alive.
-            auto functor = orbit_base::any_movable_cast<std::decay_t<F>>(&*function_reference);
-            CHECK(functor != nullptr);
-            std::apply([&](auto... args) { helper.Call(*functor, args...); }, std::move(argument));
-            waiting_continuations_.erase(function_reference);
-          };
-      executor->Schedule(CreateAction(std::move(function_wrapper)));
-    };
-
-    const orbit_base::FutureRegisterContinuationResult result =
-        future.RegisterContinuation(std::move(continuation));
-
-    if (result != orbit_base::FutureRegisterContinuationResult::kSuccessfullyRegistered) {
-      // If the future has already been finished, we call the continuation here.
-      // Keep in mind, this will not run the task synchronously. This will only
-      // SCHEDULE the task synchronously.
-      orbit_base::GetResultFromFutureAndCallContinuation<T> helper{&future};
-      helper.Call(continuation);
-    }
-
-    return resulting_future;
-  }
-
-  // ScheduleAfterIfSuccess schedules the continuation `functor` to be executed
-  // on `*this` after `future` has completed, and only if `future` returns a non-error result.
-  //
-  // Note: The continuation is only executed if `*this` is still alive when `future` completes.
-  template <typename T, typename F>
-  auto ScheduleAfterIfSuccess(const orbit_base::Future<ErrorMessageOr<T>>& future, F&& functor) {
-    CHECK(future.IsValid());
-
-    using ContinuationReturnType = typename orbit_base::ContinuationReturnType<T, F>::Type;
-    using PromiseReturnType =
-        typename orbit_base::EnsureWrappedInErrorMessageOr<ContinuationReturnType>::Type;
-
-    orbit_base::Promise<PromiseReturnType> promise{};
-    orbit_base::Future<PromiseReturnType> resulting_future = promise.GetFuture();
-
-    waiting_continuations_.emplace_front(std::forward<F>(functor));
-    auto function_reference = waiting_continuations_.begin();
-
-    auto continuation = [this, function_reference, executor_weak_ptr = weak_from_this(),
-                         promise = std::move(promise)](const ErrorMessageOr<T>& argument) mutable {
-      auto executor = executor_weak_ptr.lock();
-      if (executor == nullptr) return;
-
-      // If the future returns a non-success ErrorMessageOr-type, we will short-circuit and won't
-      // call the continutation. But we still have to schedule an action, that destroys the
-      // continuation in the executor's context (think main thread). The continuation's destructor
-      // might do things that need synchronization and can't happen in a different context (like a
-      // thread pool), i.e. when the continuation owns a ScopedStatus.
-      if (argument.has_error()) {
-        promise.SetResult(outcome::failure(argument.error()));
-        executor->Schedule(CreateAction(
-            [this, function_reference]() { waiting_continuations_.erase(function_reference); }));
-        return;
-      }
-
-      auto sucess_function_wrapper = [this, function_reference, promise = std::move(promise),
-                                      argument]() mutable {
-        auto functor = orbit_base::any_movable_cast<std::decay_t<F>>(&*function_reference);
-        CHECK(functor != nullptr);
-
-        orbit_base::HandleErrorAndSetResultInPromise<PromiseReturnType> helper{&promise};
-        helper.Call(*functor, argument);
-
-        waiting_continuations_.erase(function_reference);
-      };
-      executor->Schedule(CreateAction(std::move(sucess_function_wrapper)));
-    };
-
-    orbit_base::RegisterContinuationOrCallDirectly(future, std::move(continuation));
-    return resulting_future;
-  }
-
   enum class WaitResult { kCompleted, kTimedOut, kAborted };
   [[nodiscard]] virtual WaitResult WaitFor(const orbit_base::Future<void>& future,
                                            std::chrono::milliseconds timeout) = 0;
@@ -184,22 +42,6 @@ class MainThreadExecutor : public std::enable_shared_from_this<MainThreadExecuto
   [[nodiscard]] virtual WaitResult WaitForAll(absl::Span<orbit_base::Future<void>> futures) = 0;
 
   virtual void AbortWaitingJobs() = 0;
-
-  [[nodiscard]] size_t GetNumberOfWaitingContinuations() const {
-    return waiting_continuations_.size();
-  }
-
- private:
-  std::list<orbit_base::AnyMovable> waiting_continuations_;
 };
-
-template <typename F>
-auto TrySchedule(const std::weak_ptr<MainThreadExecutor>& executor, F&& function_object)
-    -> std::optional<decltype(std::declval<MainThreadExecutor>().Schedule(function_object))> {
-  auto executor_ptr = executor.lock();
-  if (executor_ptr == nullptr) return std::nullopt;
-
-  return std::make_optional(executor_ptr->Schedule(std::forward<F>(function_object)));
-}
 
 #endif  // ORBIT_GL_MAIN_THREAD_EXECUTOR_H_

--- a/src/OrbitTest/OrbitTest.h
+++ b/src/OrbitTest/OrbitTest.h
@@ -35,5 +35,5 @@ class OrbitTest {
   uint32_t num_threads_ = 10;
   uint32_t recurse_depth_ = 10;
   uint32_t sleep_us_ = 100'000;
-  std::unique_ptr<ThreadPool> thread_pool_;
+  std::shared_ptr<ThreadPool> thread_pool_;
 };

--- a/src/QtUtils/FutureWatcherTest.cpp
+++ b/src/QtUtils/FutureWatcherTest.cpp
@@ -66,7 +66,7 @@ TEST(FutureWatcher, WaitForWithThreadPool) {
   constexpr size_t kThreadPoolMinSize = 1;
   constexpr size_t kThreadPoolMaxSize = 2;
   constexpr absl::Duration kThreadTtl = absl::Milliseconds(5);
-  std::unique_ptr<ThreadPool> thread_pool =
+  std::shared_ptr<ThreadPool> thread_pool =
       ThreadPool::Create(kThreadPoolMinSize, kThreadPoolMaxSize, kThreadTtl);
 
   absl::Mutex mutex;
@@ -94,7 +94,7 @@ TEST(FutureWatcher, WaitForWithThreadPoolAndTimeout) {
   constexpr size_t kThreadPoolMinSize = 1;
   constexpr size_t kThreadPoolMaxSize = 2;
   constexpr absl::Duration kThreadTtl = absl::Milliseconds(5);
-  std::unique_ptr<ThreadPool> thread_pool =
+  std::shared_ptr<ThreadPool> thread_pool =
       ThreadPool::Create(kThreadPoolMinSize, kThreadPoolMaxSize, kThreadTtl);
 
   absl::Mutex mutex;
@@ -120,7 +120,7 @@ TEST(FutureWatcher, WaitForAllWithThreadPool) {
   constexpr size_t kThreadPoolMinSize = 1;
   constexpr size_t kThreadPoolMaxSize = 2;
   constexpr absl::Duration kThreadTtl = absl::Milliseconds(5);
-  std::unique_ptr<ThreadPool> thread_pool =
+  std::shared_ptr<ThreadPool> thread_pool =
       ThreadPool::Create(kThreadPoolMinSize, kThreadPoolMaxSize, kThreadTtl);
 
   absl::Mutex mutex;
@@ -152,7 +152,7 @@ TEST(FutureWatcher, WaitForAllWithThreadPoolAndTimeout) {
   constexpr size_t kThreadPoolMinSize = 1;
   constexpr size_t kThreadPoolMaxSize = 2;
   constexpr absl::Duration kThreadTtl = absl::Milliseconds(5);
-  std::unique_ptr<ThreadPool> thread_pool =
+  std::shared_ptr<ThreadPool> thread_pool =
       ThreadPool::Create(kThreadPoolMinSize, kThreadPoolMaxSize, kThreadTtl);
 
   absl::Mutex mutex;

--- a/src/QtUtils/MainThreadExecutorImpl.cpp
+++ b/src/QtUtils/MainThreadExecutorImpl.cpp
@@ -17,7 +17,7 @@
 
 namespace orbit_qt_utils {
 
-void MainThreadExecutorImpl::Schedule(std::unique_ptr<Action> action) {
+void MainThreadExecutorImpl::ScheduleImpl(std::unique_ptr<Action> action) {
   QMetaObject::invokeMethod(
       this,
       [action = std::move(action)]() {

--- a/src/QtUtils/include/QtUtils/MainThreadExecutorImpl.h
+++ b/src/QtUtils/include/QtUtils/MainThreadExecutorImpl.h
@@ -17,13 +17,12 @@ class MainThreadExecutorImpl : public QObject, public MainThreadExecutor {
   Q_OBJECT
   explicit MainThreadExecutorImpl(QObject* parent = nullptr) : QObject(parent) {}
 
+  void ScheduleImpl(std::unique_ptr<Action> action) override;
+
  public:
   [[nodiscard]] static std::shared_ptr<MainThreadExecutorImpl> Create() {
     return std::shared_ptr<MainThreadExecutorImpl>{new MainThreadExecutorImpl{}};
   }
-
-  using MainThreadExecutor::Schedule;
-  void Schedule(std::unique_ptr<Action> action) override;
 
   WaitResult WaitFor(const orbit_base::Future<void>& future,
                      std::chrono::milliseconds timeout) override;


### PR DESCRIPTION
This is moving around a lot of stuff regarding executors.

1. There is now a new base class `orbit_base::Executor` which implements `Schedule`, `ScheduleAfter` and `ScheduleAfterIfSuccess`.
2. `MainThreadExecutor` and `ThreadPool` inherit from `Executor`.
3. There are now tests for Executor
4. There is now a `SimpleExecutor` which also implements `Executor` and can be used in tests. It's different to `ImmediateExecutor` in the sense that scheduled actions are stored until the user executes them manually by calling `ExecuteScheduledTasks`.