### PR TITLE
Show [unknown@address] instead of "???" in CallstackThreadBar

### DIFF
--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -200,7 +200,7 @@ bool CallstackThreadBar::IsEmpty() const {
   const uint64_t addr = callstack.frames(frame_index);
   const std::string& function_name = capture_data_->GetFunctionNameByAddress(addr);
   if (function_name == CaptureData::kUnknownFunctionOrModuleName) {
-    return std::string("<i>") + function_name + "</i>";
+    return std::string("<i>") + absl::StrFormat("[unknown@%#x]", addr) + "</i>";
   }
 
   std::string fn_name =


### PR DESCRIPTION
"???" provides no information, but when the function name is not known, we can
at least show the virtual address.
This is the same format as used in the top-down and bottom-up view.

Test: Cause several unwinding errors by instrumenting a function called very
frequently. Hover over one of those in the timeline.