### PR TITLE
Move screen vertically after double clicking in an event 

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -191,7 +191,9 @@ void CaptureWindow::SelectTextBox(const TextBox* text_box) {
   const TimerInfo& timer_info = text_box->GetTimerInfo();
 
   if (double_clicking_) {
+    // Zoom and center the text_box into the screen and make its track fully visible.
     time_graph_->Zoom(timer_info);
+    time_graph_->SelectAndMakeVisible(text_box);
   }
 }
 

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -215,12 +215,13 @@ void TimeGraph::VerticallyMoveIntoView(const TimerInfo& timer_info) {
   VerticallyMoveIntoView(*track_manager_->GetOrCreateThreadTrack(timer_info.thread_id()));
 }
 
+// Move vertically the view to make a Track fully visible.
 void TimeGraph::VerticallyMoveIntoView(Track& track) {
   float pos = track.GetPos()[1];
   float height = track.GetHeight();
   float world_top_left_y = viewport_->GetWorldTopLeft()[1];
 
-  float min_world_top_left_y = pos + layout_.GetTrackTabHeight();
+  float min_world_top_left_y = pos;
   float max_world_top_left_y =
       pos + viewport_->GetVisibleWorldHeight() - height - layout_.GetBottomMargin();
   viewport_->SetWorldTopLeftY(

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -561,7 +561,9 @@ void TimeGraph::GetWorldMinMax(float& min, float& max) const {
   max = GetWorldFromTick(capture_max_timestamp_);
 }
 
-void TimeGraph::Select(const TextBox* text_box) {
+// Select a text_box. Also move the view in order to assure that the text_box and its track are
+// visible.
+void TimeGraph::SelectAndMakeVisible(const TextBox* text_box) {
   CHECK(text_box != nullptr);
   app_->SelectTextBox(text_box);
   const TimerInfo& timer_info = text_box->GetTimerInfo();
@@ -870,7 +872,7 @@ void TimeGraph::SetThreadFilter(const std::string& filter) {
 void TimeGraph::SelectAndZoom(const TextBox* text_box) {
   CHECK(text_box);
   Zoom(text_box->GetTimerInfo());
-  Select(text_box);
+  SelectAndMakeVisible(text_box);
 }
 
 void TimeGraph::JumpToNeighborBox(const TextBox* from, JumpDirection jump_direction,
@@ -922,7 +924,7 @@ void TimeGraph::JumpToNeighborBox(const TextBox* from, JumpDirection jump_direct
     goal = FindDown(from);
   }
   if (goal) {
-    Select(goal);
+    SelectAndMakeVisible(goal);
   }
 }
 

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -100,7 +100,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
   void VerticallyMoveIntoView(Track& track);
 
   [[nodiscard]] double GetTime(double ratio) const;
-  void Select(const TextBox* text_box);
+  void SelectAndMakeVisible(const TextBox* text_box);
   enum class JumpScope { kGlobal, kSameDepth, kSameThread, kSameFunction, kSameThreadSameFunction };
   enum class JumpDirection { kPrevious, kNext, kTop, kDown };
   void JumpToNeighborBox(const TextBox* from, JumpDirection jump_direction, JumpScope jump_scope);


### PR DESCRIPTION
Move the screen accordingly to assure that the event and its track are fully visible. Also rename Select method to make it more clear and fix an issue with the vertical alignment (http://b/190463784).

Solve http://b/174304405.

Test: Start a capture, stop, make some jumps, double click in some timers.