### PR TITLE
Fix Heap-use-after-free in GpuQueueSubmissionProcessor

### DIFF
--- a/src/CaptureClient/GpuQueueSubmissionProcessor.cpp
+++ b/src/CaptureClient/GpuQueueSubmissionProcessor.cpp
@@ -44,12 +44,16 @@ std::vector<TimerInfo> GpuQueueSubmissionProcessor::ProcessGpuQueueSubmission(
     return {};
   }
 
+  // Save the timestamp now, as after the call to `ProcessGpuQueueSubmissionWithMatchingGpuJob`,
+  // the matching_gpu_job may already be deleted.
+  uint64_t submission_cpu_timestamp = matching_gpu_job->amdgpu_cs_ioctl_time_ns();
+
   std::vector<TimerInfo> result = ProcessGpuQueueSubmissionWithMatchingGpuJob(
       gpu_queue_submission, *matching_gpu_job, string_intern_pool,
       get_string_hash_and_send_to_listener_if_necessary);
 
   if (!HasUnprocessedBeginMarkers(thread_id, post_submission_cpu_timestamp)) {
-    DeleteSavedGpuJob(thread_id, matching_gpu_job->amdgpu_cs_ioctl_time_ns());
+    DeleteSavedGpuJob(thread_id, submission_cpu_timestamp);
   }
   return result;
 }


### PR DESCRIPTION
Esentially, the `matching_gpu_job` can already get deleted by
the `ProcessGpuQueueSubmissionWithMatchingGpuJob`.

Bug: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34934
Test: Run the Fuzzer with the given input