### PR TITLE
Fix ModuleDataView use of dangling pointers

### DIFF
--- a/src/ClientData/include/ClientData/ProcessData.h
+++ b/src/ClientData/include/ClientData/ProcessData.h
@@ -30,7 +30,11 @@ namespace orbit_client_data {
 class ModuleInMemory {
  public:
   explicit ModuleInMemory(uint64_t start, uint64_t end, std::string file_path, std::string build_id)
-      : start_(start), end_(end), file_path_{file_path}, build_id_{std::move(build_id)} {}
+      : start_(start),
+        end_(end),
+        file_path_{std::move(file_path)},
+        build_id_{std::move(build_id)} {}
+
   [[nodiscard]] uint64_t start() const { return start_; }
   [[nodiscard]] uint64_t end() const { return end_; }
   [[nodiscard]] const std::string& file_path() const { return file_path_; }

--- a/src/OrbitGl/ModulesDataView.cpp
+++ b/src/OrbitGl/ModulesDataView.cpp
@@ -45,7 +45,7 @@ const std::vector<DataView::Column>& ModulesDataView::GetColumns() {
 
 std::string ModulesDataView::GetValue(int row, int col) {
   const ModuleData* module = GetModule(row);
-  const ModuleInMemory* memory_space = module_memory_.at(module);
+  const ModuleInMemory& memory_space = module_memory_.at(module);
 
   switch (col) {
     case kColumnName:
@@ -53,7 +53,7 @@ std::string ModulesDataView::GetValue(int row, int col) {
     case kColumnPath:
       return module->file_path();
     case kColumnAddressRange:
-      return memory_space->FormattedAddressRange();
+      return memory_space.FormattedAddressRange();
     case kColumnFileSize:
       return GetPrettySize(module->file_size());
     case kColumnLoaded:
@@ -68,10 +68,10 @@ std::string ModulesDataView::GetValue(int row, int col) {
     return orbit_core::Compare(modules_[a]->Member, modules_[b]->Member, ascending); \
   }
 
-#define ORBIT_MODULE_SPACE_SORT(Member)                                            \
-  [&](int a, int b) {                                                              \
-    return orbit_core::Compare(module_memory_.at(modules_[a])->Member,             \
-                               module_memory_.at(modules_[b])->Member, ascending); \
+#define ORBIT_MODULE_SPACE_SORT(Member)                                           \
+  [&](int a, int b) {                                                             \
+    return orbit_core::Compare(module_memory_.at(modules_[a]).Member,             \
+                               module_memory_.at(modules_[b]).Member, ascending); \
   }
 
 void ModulesDataView::DoSort() {
@@ -174,8 +174,8 @@ void ModulesDataView::DoFilter() {
 
   for (size_t i = 0; i < modules_.size(); ++i) {
     const ModuleData* module = modules_[i];
-    const ModuleInMemory* memory_space = module_memory_.at(module);
-    std::string module_string = absl::StrFormat("%s %s", memory_space->FormattedAddressRange(),
+    const ModuleInMemory& memory_space = module_memory_.at(module);
+    std::string module_string = absl::StrFormat("%s %s", memory_space.FormattedAddressRange(),
                                                 absl::AsciiStrToLower(module->file_path()));
 
     bool match = true;
@@ -203,7 +203,7 @@ void ModulesDataView::UpdateModules(const ProcessData* process) {
     ModuleData* module =
         app_->GetMutableModuleByPathAndBuildId(module_path, module_in_memory.build_id());
     modules_.push_back(module);
-    module_memory_[module] = &module_in_memory;
+    module_memory_.insert_or_assign(module, module_in_memory);
   }
 
   indices_.resize(modules_.size());

--- a/src/OrbitGl/ModulesDataView.h
+++ b/src/OrbitGl/ModulesDataView.h
@@ -48,8 +48,7 @@ class ModulesDataView : public DataView {
   }
 
   std::vector<orbit_client_data::ModuleData*> modules_;
-  absl::flat_hash_map<const orbit_client_data::ModuleData*,
-                      const orbit_client_data::ModuleInMemory*>
+  absl::flat_hash_map<const orbit_client_data::ModuleData*, orbit_client_data::ModuleInMemory>
       module_memory_;
 
   enum ColumnIndex {


### PR DESCRIPTION
Store a copy of module_in_memory instead of pointer to it.

Test: manual - run orbit check module data for sanity
Bug: http://b/189743255