### PR TITLE
Add -readability-function-cognitive-complexity to .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -26,6 +26,7 @@ Checks: >
   performance-*,
   -performance-noexcept-move-constructor,
   readability-*,
+  -readability-function-cognitive-complexity,
   -readability-magic-numbers,
   -readability-non-const-parameter,
   -readability-uppercase-literal-suffix,


### PR DESCRIPTION
After updating CLion, this caused way too many warnings.