### PR TITLE
Remove handling of confirmation dialog in E2E tests

### DIFF
--- a/contrib/automation_tests/core/orbit_e2e.py
+++ b/contrib/automation_tests/core/orbit_e2e.py
@@ -89,8 +89,6 @@ class CloseOrbit(E2ETestCase):
         # self.find_control("Button", "Close").click_input()
         # ... so just send Alt + F4
         send_keys('%{F4}')
-        # Click Yes on the "Are you sure you want to continue" dialog to actually close Orbit
-        self.find_control('Button', 'Yes').click_input()
         logging.info('Closed Orbit.')
 
 


### PR DESCRIPTION
The E2E tests used to expect a confirmation dialog when closing Orbit.
This dialog does not exist anymore and the check breaks the tests. This
should fix it.