### PR TITLE
Add and integrate LoadCaptureWidget and CaptureFileInfo Manager

### DIFF
--- a/src/CaptureFileInfo/CMakeLists.txt
+++ b/src/CaptureFileInfo/CMakeLists.txt
@@ -13,23 +13,28 @@ target_sources(
   CaptureFileInfo
   PUBLIC  include/CaptureFileInfo/CaptureFileInfo.h
           include/CaptureFileInfo/ItemModel.h
-          include/CaptureFileInfo/Manager.h)
+          include/CaptureFileInfo/Manager.h
+          include/CaptureFileInfo/LoadCaptureWidget.h)
+
+target_include_directories(CaptureFileInfo PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
 
 target_sources(
   CaptureFileInfo
   PRIVATE CaptureFileInfo.cpp
           ItemModel.cpp
-          Manager.cpp)
+          Manager.cpp
+          LoadCaptureWidget.cpp
+          LoadCaptureWidget.ui)
 
-target_include_directories(CaptureFileInfo PUBLIC include/)
 
 target_link_libraries(
   CaptureFileInfo
   PUBLIC  OrbitBase
           OrbitCore
-          Qt5::Core)
+          Qt5::Widgets)
 
 set_target_properties(CaptureFileInfo PROPERTIES AUTOMOC ON)
+set_target_properties(CaptureFileInfo PROPERTIES AUTOUIC ON)
 
 add_executable(CaptureFileInfoTests)
 

--- a/src/CaptureFileInfo/LoadCaptureWidget.cpp
+++ b/src/CaptureFileInfo/LoadCaptureWidget.cpp
@@ -1,0 +1,130 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "CaptureFileInfo/LoadCaptureWidget.h"
+
+#include <QFileDialog>
+#include <QHeaderView>
+#include <QMenu>
+#include <QObject>
+#include <QPushButton>
+#include <QRadioButton>
+#include <memory>
+
+#include "CaptureFileInfo/Manager.h"
+#include "OrbitBase/Logging.h"
+#include "Path.h"
+#include "ui_LoadCaptureWidget.h"
+
+constexpr int kRowHeight = 19;
+
+namespace orbit_capture_file_info {
+
+// The destructor needs to be defined here because it needs to see the type
+// `Ui::LoadCaptureWidget`. The header file only contains a forward declaration.
+LoadCaptureWidget::~LoadCaptureWidget() noexcept = default;
+
+LoadCaptureWidget::LoadCaptureWidget(QWidget* parent)
+    : QWidget(parent), ui_(std::make_unique<Ui::LoadCaptureWidget>()) {
+  Manager manager;
+
+  if (manager.GetCaptureFileInfos().empty()) {
+    (void)manager.FillFromDirectory(orbit_core::CreateOrGetCaptureDir());
+  }
+
+  item_model_.SetCaptureFileInfos(manager.GetCaptureFileInfos());
+
+  proxy_item_model_.setSourceModel(&item_model_);
+  proxy_item_model_.setSortRole(Qt::DisplayRole);
+
+  ui_->setupUi(this);
+  ui_->tableView->setModel(&proxy_item_model_);
+  ui_->tableView->setSortingEnabled(true);
+  ui_->tableView->sortByColumn(static_cast<int>(ItemModel::Column::kLastUsed),
+                               Qt::SortOrder::DescendingOrder);
+  ui_->tableView->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
+  ui_->tableView->verticalHeader()->setDefaultSectionSize(kRowHeight);
+
+  // The following is to make the radiobutton behave as if it was part of an exclusive button group
+  // in the parent widget (ProfilingTargetDialog). If a user clicks on the radiobutton and it was
+  // not checked before, it is checked afterwards and this widget sends the activation signal.
+  // ProfilingTargetDialog reacts to the signal and deactivates the other widgets belonging to that
+  // button group. If a user clicks on a radio button that is already checked, nothing happens, the
+  // button does not get unchecked.
+  QObject::connect(ui_->radioButton, &QRadioButton::clicked, this, [this](bool checked) {
+    if (checked) {
+      emit Activated();
+    } else {
+      ui_->radioButton->setChecked(true);
+    }
+  });
+
+  QObject::connect(ui_->selectFileButton, &QPushButton::clicked, this,
+                   &LoadCaptureWidget::SelectViaFilePicker);
+
+  QObject::connect(ui_->tableView->selectionModel(), &QItemSelectionModel::selectionChanged, this,
+                   [this](const QItemSelection& selected, const QItemSelection& /*deselected*/) {
+                     if (selected.empty()) return;
+
+                     // Since always a whole row is selected, indexes is of size 3, one for each
+                     // column. The column does not matter, so column 0 is used.
+                     const QModelIndex index = selected.indexes().at(0);
+
+                     CHECK(index.data(Qt::UserRole).canConvert<QString>());
+
+                     emit FileSelected(index.data(Qt::UserRole).value<QString>().toStdString());
+                   });
+
+  QObject::connect(ui_->tableView, &QTableView::doubleClicked, this,
+                   [this]() { emit SelectionConfirmed(); });
+}
+
+bool LoadCaptureWidget::IsActive() const { return ui_->contentFrame->isEnabled(); }
+
+void LoadCaptureWidget::SetActive(bool value) {
+  ui_->contentFrame->setEnabled(value);
+  ui_->radioButton->setChecked(value);
+}
+
+void LoadCaptureWidget::DetachRadioButton() {
+  ui_->titleBarLayout->removeWidget(ui_->radioButton);
+  ui_->radioButton->setParent(ui_->mainFrame);
+  int left = 0;
+  int top = 0;
+  ui_->mainFrame->layout()->getContentsMargins(&left, &top, nullptr, nullptr);
+  int frame_border_width = ui_->mainFrame->lineWidth();
+  ui_->radioButton->move(left + frame_border_width, top + frame_border_width);
+  ui_->radioButton->show();
+}
+
+void LoadCaptureWidget::showEvent(QShowEvent* event) {
+  QWidget::showEvent(event);
+  // It is important that the call to DetachRadioButton is done here and not during construction.
+  // For high dpi display settings in Windows (scaling) the the actual width and height of the radio
+  // button is not known during construction. Hence the call is done when the widget is shown, not
+  // when its constructed.
+  DetachRadioButton();
+}
+
+void LoadCaptureWidget::SelectViaFilePicker() {
+  QFileDialog file_picker(this, "Open Capture...",
+                          QString::fromStdString(orbit_core::CreateOrGetCaptureDir().string()),
+                          "*.orbit");
+  file_picker.setFileMode(QFileDialog::ExistingFile);
+  file_picker.setLabelText(QFileDialog::Accept, "Start Session");
+
+  int rc = file_picker.exec();
+  if (rc == 0) return;
+
+  // Since QFileDialog::ExistingFile (instead of ExistingFile*s*) is used, it will always be exactly
+  // one selected file.
+  const QString file_path = file_picker.selectedFiles()[0];
+
+  ui_->tableView->clearSelection();
+
+  emit FileSelected(file_path.toStdString());
+  emit SelectionConfirmed();
+}
+
+}  // namespace orbit_capture_file_info

--- a/src/CaptureFileInfo/LoadCaptureWidget.ui
+++ b/src/CaptureFileInfo/LoadCaptureWidget.ui
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>LoadCaptureWidget</class>
+ <widget class="QWidget" name="LoadCaptureWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>623</width>
+    <height>540</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item row="0" column="0">
+    <widget class="QFrame" name="mainFrame">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0">
+       <widget class="QFrame" name="contentFrame">
+        <property name="lineWidth">
+         <number>0</number>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_3">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item row="0" column="0">
+          <layout class="QVBoxLayout" name="titleBarLayout">
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout">
+             <item>
+              <widget class="QRadioButton" name="radioButton">
+               <property name="font">
+                <font>
+                 <pointsize>12</pointsize>
+                </font>
+               </property>
+               <property name="accessibleName">
+                <string>LoadCapture</string>
+               </property>
+               <property name="text">
+                <string>Load a capture</string>
+               </property>
+               <property name="checked">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QPushButton" name="selectFileButton">
+               <property name="text">
+                <string>...</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,1">
+             <item>
+              <spacer name="horizontalSpacer_2">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QTableView" name="tableView">
+               <property name="focusPolicy">
+                <enum>Qt::NoFocus</enum>
+               </property>
+               <property name="accessibleName">
+                <string>CaptureFileList</string>
+               </property>
+               <property name="alternatingRowColors">
+                <bool>true</bool>
+               </property>
+               <property name="selectionMode">
+                <enum>QAbstractItemView::SingleSelection</enum>
+               </property>
+               <property name="selectionBehavior">
+                <enum>QAbstractItemView::SelectRows</enum>
+               </property>
+               <property name="showGrid">
+                <bool>false</bool>
+               </property>
+               <property name="wordWrap">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/CaptureFileInfo/include/CaptureFileInfo/LoadCaptureWidget.h
+++ b/src/CaptureFileInfo/include/CaptureFileInfo/LoadCaptureWidget.h
@@ -1,0 +1,51 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CAPTURE_FILE_INFO_LOAD_CAPTURE_WIDGET_H_
+#define CAPTURE_FILE_INFO_LOAD_CAPTURE_WIDGET_H_
+
+#include <QEvent>
+#include <QSortFilterProxyModel>
+#include <QWidget>
+#include <memory>
+
+#include "CaptureFileInfo/ItemModel.h"
+
+namespace Ui {
+class LoadCaptureWidget;  // IWYU pragma: keep
+}
+
+namespace orbit_capture_file_info {
+
+class LoadCaptureWidget : public QWidget {
+  Q_OBJECT
+  Q_PROPERTY(bool active READ IsActive WRITE SetActive)
+
+ public:
+  explicit LoadCaptureWidget(QWidget* parent = nullptr);
+  ~LoadCaptureWidget() noexcept override;
+
+  [[nodiscard]] bool IsActive() const;
+
+ public slots:
+  void SetActive(bool value);
+
+ signals:
+  void Activated();
+  void FileSelected(std::filesystem::path file_path);
+  void SelectionConfirmed();
+
+ private:
+  std::unique_ptr<Ui::LoadCaptureWidget> ui_;
+  ItemModel item_model_;
+  QSortFilterProxyModel proxy_item_model_;
+
+  void showEvent(QShowEvent* event) override;
+  void DetachRadioButton();
+  void SelectViaFilePicker();
+};
+
+}  // namespace orbit_capture_file_info
+
+#endif  // CAPTURE_FILE_INFO_LOAD_CAPTURE_WIDGET_H_

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -30,6 +30,7 @@
 #include "CaptureClient/CaptureClient.h"
 #include "CaptureClient/CaptureListener.h"
 #include "CaptureFile/CaptureFile.h"
+#include "CaptureFileInfo/Manager.h"
 #include "CaptureWindow.h"
 #include "ClientData/CallstackTypes.h"
 #include "ClientData/ModuleData.h"
@@ -587,6 +588,8 @@ class OrbitApp final : public DataViewFactory, public orbit_capture_client::Capt
   // the capture thread. After the capture is finished its read by the main thread again. This is
   // similar to how capture_data is used.
   orbit_metrics_uploader::CaptureCompleteData metrics_capture_complete_data_;
+
+  orbit_capture_file_info::Manager capture_file_info_manager_{};
 };
 
 #endif  // ORBIT_GL_APP_H_

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -141,6 +141,7 @@ target_include_directories(OrbitGl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(
   OrbitGl
   PUBLIC CaptureClient
+         CaptureFileInfo
          ClientData
          ClientModel
          ClientServices

--- a/src/OrbitQt/CMakeLists.txt
+++ b/src/OrbitQt/CMakeLists.txt
@@ -107,7 +107,8 @@ target_include_directories(OrbitQt PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 target_link_libraries(
   OrbitQt
-  PUBLIC  CodeViewer
+  PUBLIC  CaptureFileInfo
+          CodeViewer
           ConfigWidgets
           MetricsUploader
           OrbitAccessibility

--- a/src/OrbitQt/ProfilingTargetDialog.cpp
+++ b/src/OrbitQt/ProfilingTargetDialog.cpp
@@ -39,6 +39,7 @@
 #include <variant>
 #include <vector>
 
+#include "CaptureFileInfo/LoadCaptureWidget.h"
 #include "ClientServices/ProcessManager.h"
 #include "ConnectToStadiaWidget.h"
 #include "Connections.h"
@@ -60,6 +61,7 @@ constexpr int kProcessesRowHeight = 19;
 
 namespace orbit_qt {
 
+using orbit_capture_file_info::LoadCaptureWidget;
 using orbit_grpc_protos::ProcessInfo;
 
 ProfilingTargetDialog::ProfilingTargetDialog(
@@ -120,16 +122,8 @@ ProfilingTargetDialog::ProfilingTargetDialog(
     ui_->localFrame->setVisible(true);
   }
 
-  QObject::connect(ui_->selectFileButton, &QPushButton::clicked, this,
-                   &ProfilingTargetDialog::SelectFile);
-  // This and the next connect makes the radiobuttons behave as if they were in a exclusive button
-  // group. If a user clicks on one of these and it was not checked before, it is checked afterwards
-  // and the state machine transitions into the correct state, which "unchecks" the other buttons.
-  // If a user clicks on a radio button that is already checked, simply nothing happens, the button
-  // does not get unchecked.
-  QObject::connect(ui_->loadCaptureRadioButton, &QRadioButton::clicked, this, [this](bool checked) {
-    if (!checked) ui_->loadCaptureRadioButton->setChecked(true);
-  });
+  // If a user clicks on the localProfilingRadioButton when it is already checked, it will not
+  // become unchecked.
   QObject::connect(ui_->localProfilingRadioButton, &QRadioButton::clicked, this,
                    [this](bool checked) {
                      if (!checked) ui_->localProfilingRadioButton->setChecked(true);
@@ -140,6 +134,10 @@ ProfilingTargetDialog::ProfilingTargetDialog(
   QObject::connect(ui_->processFilterLineEdit, &QLineEdit::textChanged, &process_proxy_model_,
                    &QSortFilterProxyModel::setFilterFixedString);
   QObject::connect(ui_->confirmButton, &QPushButton::clicked, this, &QDialog::accept);
+  QObject::connect(ui_->loadCaptureWidget, &LoadCaptureWidget::FileSelected, this,
+                   [this](std::filesystem::path path) { selected_file_path_ = std::move(path); });
+  QObject::connect(ui_->loadCaptureWidget, &LoadCaptureWidget::SelectionConfirmed, this,
+                   &QDialog::accept);
 
   if (target_configuration_opt.has_value()) {
     TargetConfiguration config = std::move(target_configuration_opt.value());
@@ -229,7 +227,7 @@ void ProfilingTargetDialog::SetupStadiaStates() {
   state_stadia_.assignProperty(ui_->confirmButton, "toolTip",
                                "Please connect to an instance and select a process.");
   state_stadia_.assignProperty(ui_->stadiaWidget, "active", true);
-  state_stadia_.assignProperty(ui_->loadCaptureRadioButton, "checked", false);
+  state_stadia_.assignProperty(ui_->loadCaptureWidget, "active", false);
   state_stadia_.assignProperty(ui_->localProfilingRadioButton, "checked", false);
 
   // STATE state_stadia_connecting_
@@ -247,9 +245,8 @@ void ProfilingTargetDialog::SetupStadiaStates() {
 
   // TRANSITIONS (and entered/exit events)
   // STATE state_stadia_
-  state_stadia_.addTransition(ui_->loadCaptureRadioButton, &QRadioButton::clicked,
+  state_stadia_.addTransition(ui_->loadCaptureWidget, &LoadCaptureWidget::Activated,
                               &state_file_history_);
-  state_stadia_.addTransition(this, &ProfilingTargetDialog::FileSelected, &state_file_selected_);
   state_stadia_.addTransition(ui_->localProfilingRadioButton, &QRadioButton::clicked,
                               &state_local_history_);
   state_stadia_.addTransition(ui_->stadiaWidget, &ConnectToStadiaWidget::Disconnected,
@@ -307,7 +304,7 @@ void ProfilingTargetDialog::SetupLocalStates() {
       "Please have a OrbitService run on the local machine and select a process.");
   state_local_.assignProperty(ui_->localProfilingRadioButton, "checked", true);
   state_local_.assignProperty(ui_->stadiaWidget, "active", false);
-  state_local_.assignProperty(ui_->loadCaptureRadioButton, "checked", false);
+  state_local_.assignProperty(ui_->loadCaptureWidget, "active", false);
 
   // STATE state_local_connecting_
   state_local_connecting_.assignProperty(ui_->localProfilingStatusMessage, "text", "Connecting...");
@@ -333,9 +330,8 @@ void ProfilingTargetDialog::SetupLocalStates() {
   // STATE state_local_
   state_local_.addTransition(ui_->stadiaWidget, &ConnectToStadiaWidget::Activated,
                              &state_stadia_history_);
-  state_local_.addTransition(ui_->loadCaptureRadioButton, &QRadioButton::clicked,
+  state_local_.addTransition(ui_->loadCaptureWidget, &LoadCaptureWidget::Activated,
                              &state_file_history_);
-  state_local_.addTransition(this, &ProfilingTargetDialog::FileSelected, &state_file_selected_);
 
   // STATE state_local_connecting_
   state_local_connecting_.addTransition(this, &ProfilingTargetDialog::ProcessListUpdated,
@@ -378,7 +374,7 @@ void ProfilingTargetDialog::SetupFileStates() {
   state_file_.assignProperty(ui_->confirmButton, "enabled", false);
   state_file_.assignProperty(ui_->confirmButton, "toolTip", "Please select a capture to load");
   state_file_.assignProperty(ui_->stadiaWidget, "active", false);
-  state_file_.assignProperty(ui_->loadCaptureRadioButton, "checked", true);
+  state_file_.assignProperty(ui_->loadCaptureWidget, "active", true);
   state_file_.assignProperty(ui_->processesFrame, "enabled", false);
   state_file_.assignProperty(ui_->localProfilingRadioButton, "checked", false);
 
@@ -392,19 +388,12 @@ void ProfilingTargetDialog::SetupFileStates() {
                             &state_stadia_history_);
   state_file_.addTransition(ui_->localProfilingRadioButton, &QRadioButton::clicked,
                             &state_local_history_);
-  state_file_.addTransition(this, &ProfilingTargetDialog::FileSelected, &state_file_selected_);
-
-  // STATE state_file_no_selection_
-  QObject::connect(&state_file_no_selection_, &QState::entered, this, [this] {
-    if (selected_file_path_.empty()) SelectFile();
-  });
+  state_file_.addTransition(ui_->loadCaptureWidget, &LoadCaptureWidget::FileSelected,
+                            &state_file_selected_);
 
   // STATE state_file_selected_
-  QObject::connect(&state_file_selected_, &QState::entered, this, [this] {
-    QString filename = QString::fromStdString(selected_file_path_.filename().string());
-    ui_->selectedFileLabel->setText(filename);
-    ui_->targetLabel->ChangeToFileTarget(selected_file_path_);
-  });
+  QObject::connect(&state_file_selected_, &QState::entered, this,
+                   [this] { ui_->targetLabel->ChangeToFileTarget(selected_file_path_); });
   QObject::connect(&state_file_selected_, &QState::exited, ui_->targetLabel, &TargetLabel::Clear);
 }
 
@@ -432,17 +421,6 @@ void ProfilingTargetDialog::SetupProcessManager(
 
 void ProfilingTargetDialog::SetupStadiaProcessManager() {
   SetupProcessManager(ui_->stadiaWidget->GetGrpcChannel());
-}
-
-void ProfilingTargetDialog::SelectFile() {
-  const QString file = QFileDialog::getOpenFileName(
-      this, "Open Capture...", QString::fromStdString(orbit_core::CreateOrGetCaptureDir().string()),
-      "*.orbit");
-  if (!file.isEmpty()) {
-    selected_file_path_ = std::filesystem::path(file.toStdString());
-
-    emit FileSelected();
-  }
 }
 
 bool ProfilingTargetDialog::TrySelectProcessByName(const std::string& process_name) {

--- a/src/OrbitQt/ProfilingTargetDialog.h
+++ b/src/OrbitQt/ProfilingTargetDialog.h
@@ -46,7 +46,6 @@ class ProfilingTargetDialog : public QDialog {
 
   [[nodiscard]] std::optional<TargetConfiguration> Exec();
  private slots:
-  void SelectFile();
   void SetupStadiaProcessManager();
   void SetupLocalProcessManager();
   void TearDownProcessManager();
@@ -54,7 +53,6 @@ class ProfilingTargetDialog : public QDialog {
   void ConnectToLocal();
 
  signals:
-  void FileSelected();
   void ProcessSelected();
   void NoProcessSelected();
   void StadiaIsConnected();

--- a/src/OrbitQt/ProfilingTargetDialog.ui
+++ b/src/OrbitQt/ProfilingTargetDialog.ui
@@ -223,6 +223,9 @@
                  <property name="enabled">
                   <bool>true</bool>
                  </property>
+                 <property name="focusPolicy">
+                  <enum>Qt::NoFocus</enum>
+                 </property>
                  <property name="accessibleName">
                   <string>ProcessList</string>
                  </property>

--- a/src/OrbitQt/ProfilingTargetDialog.ui
+++ b/src/OrbitQt/ProfilingTargetDialog.ui
@@ -61,7 +61,7 @@
        <widget class="QFrame" name="frame">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
+          <horstretch>3</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
@@ -74,7 +74,7 @@
         <property name="lineWidth">
          <number>0</number>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0,0">
+        <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0,1">
          <property name="rightMargin">
           <number>0</number>
          </property>
@@ -132,80 +132,14 @@
           </widget>
          </item>
          <item>
-          <widget class="QFrame" name="captureFrame">
-           <property name="frameShape">
-            <enum>QFrame::StyledPanel</enum>
-           </property>
-           <property name="frameShadow">
-            <enum>QFrame::Raised</enum>
-           </property>
-           <layout class="QHBoxLayout" name="horizontalLayout_2">
-            <item>
-             <widget class="QRadioButton" name="loadCaptureRadioButton">
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>23</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>12</pointsize>
-               </font>
-              </property>
-              <property name="accessibleName">
-               <string>LoadCapture</string>
-              </property>
-              <property name="text">
-               <string>Load a capture</string>
-              </property>
-              <property name="checked">
-               <bool>false</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_2">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>454</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QLabel" name="selectedFileLabel">
-              <property name="visible">
-               <bool>false</bool>
-              </property>
-              <property name="text">
-               <string/>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="selectFileButton">
-              <property name="enabled">
-               <bool>true</bool>
-              </property>
-              <property name="text">
-               <string>...</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
+          <widget class="orbit_capture_file_info::LoadCaptureWidget" name="loadCaptureWidget" native="true"/>
          </item>
         </layout>
        </widget>
        <widget class="QFrame" name="frame_4">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
+          <horstretch>2</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
@@ -388,6 +322,11 @@
    <class>orbit_qt::ConnectToStadiaWidget</class>
    <extends>QWidget</extends>
    <header>ConnectToStadiaWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>orbit_capture_file_info::LoadCaptureWidget</class>
+   <extends>QWidget</extends>
+   <header>CaptureFileInfo/LoadCaptureWidget.h</header>
   </customwidget>
   <customwidget>
    <class>orbit_qt::TargetLabel</class>


### PR DESCRIPTION
The first commit adds the LoadCaptureWidget
The second commit integrates the LoadCaptureWidget into the ProfilingTargetWindow and wires CaptureFileInfo Manager into OrbitApp. 
http://b/178379643

There are several things we talked about that are not part of this PR. For example context menus to delete capture files. This will come in later PRs.