### PR TITLE
Refactor ModuleDataView to use origianl Memory Map

### DIFF
--- a/src/ClientData/ModuleManager.cpp
+++ b/src/ClientData/ModuleManager.cpp
@@ -5,11 +5,10 @@
 #include "ClientData/ModuleManager.h"
 
 #include <absl/container/flat_hash_map.h>
-#include <absl/container/node_hash_map.h>
-#include <absl/meta/type_traits.h>
 
 #include <algorithm>
 #include <filesystem>
+#include <map>
 #include <utility>
 #include <vector>
 
@@ -90,14 +89,12 @@ ModuleData* ModuleManager::GetMutableModuleByPathAndBuildId(const std::string& p
 
 std::vector<FunctionInfo> ModuleManager::GetOrbitFunctionsOfProcess(
     const ProcessData& process) const {
-  auto memory_map = process.GetMemoryMapCopy();
+  auto module_keys = process.GetUniqueModulesPathAndBuildId();
 
   absl::MutexLock lock(&mutex_);
-
   std::vector<FunctionInfo> result;
-
-  for (const auto& [module_path, module_in_memory] : memory_map) {
-    auto it = module_map_.find(std::make_pair(module_path, module_in_memory.build_id()));
+  for (const auto& module_key : module_keys) {
+    auto it = module_map_.find(module_key);
     CHECK(it != module_map_.end());
     const ModuleData* module = &it->second;
     CHECK(module != nullptr);

--- a/src/ClientData/include/ClientData/ProcessData.h
+++ b/src/ClientData/include/ClientData/ProcessData.h
@@ -75,11 +75,11 @@ class ProcessData final {
 
   // This function is deprecated since it relies on the fact that only one instance
   // of module is loaded in the process which is not always true.
-  std::optional<uint64_t> GetModuleBaseAddress(const std::string& module_path) const;
+  [[nodiscard]] std::optional<uint64_t> GetModuleBaseAddress(const std::string& module_path) const;
 
-  // This function is deprecated since it relies on the fact that only one instance
-  // of module is loaded in the process which is not always true.
-  absl::node_hash_map<std::string, ModuleInMemory> GetMemoryMapCopy() const;
+  [[nodiscard]] std::map<uint64_t, ModuleInMemory> GetMemoryMapCopy() const;
+  [[nodiscard]] std::vector<std::pair<std::string, std::string>> GetUniqueModulesPathAndBuildId()
+      const;
 
   // This function is deprecated since it relies on the fact that only one instance
   // of module is loaded in the process which is not always true.

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1876,10 +1876,9 @@ void OrbitApp::RefreshUIAfterModuleReload() {
   modules_data_view_->UpdateModules(GetMutableTargetProcess());
 
   functions_data_view_->ClearFunctions();
-  auto memory_map = GetTargetProcess()->GetMemoryMapCopy();
-  for (const auto& [module_path, module_in_memory] : memory_map) {
-    ModuleData* module =
-        module_manager_->GetMutableModuleByPathAndBuildId(module_path, module_in_memory.build_id());
+  auto module_keys = GetTargetProcess()->GetUniqueModulesPathAndBuildId();
+  for (const auto& [file_path, build_id] : module_keys) {
+    ModuleData* module = module_manager_->GetMutableModuleByPathAndBuildId(file_path, build_id);
     if (module->is_loaded()) {
       functions_data_view_->AddFunctions(module->GetFunctions());
     }

--- a/src/OrbitGl/ModulesDataView.h
+++ b/src/OrbitGl/ModulesDataView.h
@@ -34,7 +34,7 @@ class ModulesDataView : public DataView {
   bool GetDisplayColor(int row, int column, unsigned char& red, unsigned char& green,
                        unsigned char& blue) override;
   std::string GetLabel() override { return "Modules"; }
-  bool HasRefreshButton() const override { return true; }
+  [[nodiscard]] bool HasRefreshButton() const override { return true; }
   void OnRefreshButtonClicked() override;
   void UpdateModules(const orbit_client_data::ProcessData* process);
 
@@ -44,12 +44,12 @@ class ModulesDataView : public DataView {
 
  private:
   [[nodiscard]] orbit_client_data::ModuleData* GetModule(uint32_t row) const {
-    return modules_[indices_[row]];
+    return start_address_to_module_.at(indices_[row]);
   }
 
-  std::vector<orbit_client_data::ModuleData*> modules_;
-  absl::flat_hash_map<const orbit_client_data::ModuleData*, orbit_client_data::ModuleInMemory>
-      module_memory_;
+  absl::flat_hash_map<uint64_t, orbit_client_data::ModuleInMemory>
+      start_address_to_module_in_memory_;
+  absl::flat_hash_map<uint64_t, orbit_client_data::ModuleData*> start_address_to_module_;
 
   enum ColumnIndex {
     kColumnName,


### PR DESCRIPTION
This avoids a problem with not displaying a module if it was mapped
twice.

This change also introduces separate method to retrieve module
paths and build_ids from the process memory map.

Test: run unit-tests, Start Orbit and check that ModuleView works.
Bug: http://b/190805289