### PR TITLE
Remove most of usages of GetAbsoluteAddress

### DIFF
--- a/src/ClientData/ModuleData.cpp
+++ b/src/ClientData/ModuleData.cpp
@@ -73,9 +73,9 @@ bool ModuleData::UpdateIfChangedAndNotLoaded(orbit_grpc_protos::ModuleInfo info)
   return true;
 }
 
-const orbit_client_protos::FunctionInfo* ModuleData::FindFunctionByRelativeAddress(
-    uint64_t relative_address, bool is_exact) const {
-  uint64_t elf_address = relative_address + load_bias();
+const orbit_client_protos::FunctionInfo* ModuleData::FindFunctionByOffset(uint64_t offset,
+                                                                          bool is_exact) const {
+  uint64_t elf_address = offset + load_bias();
   return FindFunctionByElfAddress(elf_address, is_exact);
 }
 

--- a/src/ClientData/ModuleDataTest.cpp
+++ b/src/ClientData/ModuleDataTest.cpp
@@ -83,7 +83,7 @@ TEST(ModuleData, LoadSymbols) {
   EXPECT_EQ(function->size(), symbol_size);
 }
 
-TEST(ModuleData, FindFunctionByRelativeAddress) {
+TEST(ModuleData, FindFunctionByOffset) {
   uint64_t address1 = 100;
   std::string name1 = "Name 1";
   std::string demangled_name_1 = "Pretty Name 1";
@@ -112,51 +112,51 @@ TEST(ModuleData, FindFunctionByRelativeAddress) {
   // Find exact
   {
     // address 1
-    const FunctionInfo* result = module.FindFunctionByRelativeAddress(address1, true);
+    const FunctionInfo* result = module.FindFunctionByOffset(address1, true);
     ASSERT_NE(result, nullptr);
     EXPECT_EQ(result->name(), name1);
   }
   {
     // address 2
-    const FunctionInfo* result = module.FindFunctionByRelativeAddress(address2, true);
+    const FunctionInfo* result = module.FindFunctionByOffset(address2, true);
     ASSERT_NE(result, nullptr);
     EXPECT_EQ(result->name(), name2);
   }
   {
     // wrong address (larger)
-    const FunctionInfo* result = module.FindFunctionByRelativeAddress(address1 + 1, true);
+    const FunctionInfo* result = module.FindFunctionByOffset(address1 + 1, true);
     EXPECT_EQ(result, nullptr);
   }
   {
     // wrong address (smaller)
-    const FunctionInfo* result = module.FindFunctionByRelativeAddress(address1 - 1, true);
+    const FunctionInfo* result = module.FindFunctionByOffset(address1 - 1, true);
     EXPECT_EQ(result, nullptr);
   }
 
   // Find not exact
   {
     // at address 1
-    const FunctionInfo* result = module.FindFunctionByRelativeAddress(address1, false);
+    const FunctionInfo* result = module.FindFunctionByOffset(address1, false);
     ASSERT_NE(result, nullptr);
     EXPECT_EQ(result->name(), name1);
   }
   {
     // at address 1 + offset (offset < size)
     uint64_t offset = 5;
-    const FunctionInfo* result = module.FindFunctionByRelativeAddress(address1 + offset, false);
+    const FunctionInfo* result = module.FindFunctionByOffset(address1 + offset, false);
     ASSERT_NE(result, nullptr);
     EXPECT_EQ(result->name(), name1);
   }
   {
     // at address 1 + offset (offset > size)
     uint64_t offset = 15;
-    const FunctionInfo* result = module.FindFunctionByRelativeAddress(address1 + offset, false);
+    const FunctionInfo* result = module.FindFunctionByOffset(address1 + offset, false);
     EXPECT_EQ(result, nullptr);
   }
   {
     // at address 1 - offset
     uint64_t offset = 5;
-    const FunctionInfo* result = module.FindFunctionByRelativeAddress(address1 - offset, false);
+    const FunctionInfo* result = module.FindFunctionByOffset(address1 - offset, false);
     EXPECT_EQ(result, nullptr);
   }
 }

--- a/src/ClientData/ProcessData.cpp
+++ b/src/ClientData/ProcessData.cpp
@@ -123,12 +123,16 @@ ErrorMessageOr<ModuleInMemory> ProcessData::FindModuleByAddress(uint64_t absolut
   return module_in_memory;
 }
 
-std::optional<uint64_t> ProcessData::GetModuleBaseAddress(const std::string& module_path) const {
+std::vector<uint64_t> ProcessData::GetModuleBaseAddresses(const std::string& module_path,
+                                                          const std::string& build_id) const {
   absl::MutexLock lock(&mutex_);
-  if (!module_memory_map_.contains(module_path)) {
-    return std::nullopt;
+  std::vector<uint64_t> result;
+  for (const auto& [start_address, module_in_memory] : start_address_to_module_in_memory_) {
+    if (module_in_memory.file_path() == module_path && module_in_memory.build_id() == build_id) {
+      result.emplace_back(start_address);
+    }
   }
-  return module_memory_map_.at(module_path).start();
+  return result;
 }
 
 std::map<uint64_t, ModuleInMemory> ProcessData::GetMemoryMapCopy() const {

--- a/src/ClientData/include/ClientData/FunctionUtils.h
+++ b/src/ClientData/include/ClientData/FunctionUtils.h
@@ -34,7 +34,12 @@ namespace function_utils {
 [[nodiscard]] uint64_t Offset(const orbit_client_protos::FunctionInfo& func,
                               const ModuleData& module);
 
-[[nodiscard]] std::optional<uint64_t> GetAbsoluteAddress(
+// This function should not be used, since it could return incomplete or invalid
+// result in the case when one module is mapped two or more times. Try to find another way
+// of solving the problem, for example by converting an absolute address to a module offset and
+// then operating on that.
+// TODO(b/191248550): Disassemble from file instead of doing it from process memory.
+[[nodiscard, deprecated]] std::optional<uint64_t> GetAbsoluteAddress(
     const orbit_client_protos::FunctionInfo& func, const ProcessData& process,
     const ModuleData& module);
 

--- a/src/ClientData/include/ClientData/ModuleData.h
+++ b/src/ClientData/include/ClientData/ModuleData.h
@@ -40,10 +40,10 @@ class ModuleData final {
   // returns true if update was successful or no update was needed and false if module
   // cannot be updated because it was loaded.
   [[nodiscard]] bool UpdateIfChangedAndNotLoaded(orbit_grpc_protos::ModuleInfo info);
-  // relative_address here is the absolute address minus the address this module was loaded at by
+  // offset here is the absolute address minus the address this module was loaded at by
   // the process (module base address)
-  [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionByRelativeAddress(
-      uint64_t relative_address, bool is_exact) const;
+  [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionByOffset(uint64_t offset,
+                                                                              bool is_exact) const;
   [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionByElfAddress(
       uint64_t elf_address, bool is_exact) const;
   void AddSymbols(const orbit_grpc_protos::ModuleSymbols& module_symbols);

--- a/src/ClientData/include/ClientData/ProcessData.h
+++ b/src/ClientData/include/ClientData/ProcessData.h
@@ -73,9 +73,10 @@ class ProcessData final {
 
   [[nodiscard]] ErrorMessageOr<ModuleInMemory> FindModuleByAddress(uint64_t absolute_address) const;
 
-  // This function is deprecated since it relies on the fact that only one instance
-  // of module is loaded in the process which is not always true.
-  [[nodiscard]] std::optional<uint64_t> GetModuleBaseAddress(const std::string& module_path) const;
+  // Returns module base addresses. Note that the same module could be mapped twice in which case
+  // this function returns two base addresses. If no module found the function returns empty vector.
+  [[nodiscard]] std::vector<uint64_t> GetModuleBaseAddresses(const std::string& module_path,
+                                                             const std::string& build_id) const;
 
   [[nodiscard]] std::map<uint64_t, ModuleInMemory> GetMemoryMapCopy() const;
   [[nodiscard]] std::vector<std::pair<std::string, std::string>> GetUniqueModulesPathAndBuildId()

--- a/src/ClientModel/SamplingDataPostProcessor.cpp
+++ b/src/ClientModel/SamplingDataPostProcessor.cpp
@@ -304,7 +304,7 @@ void SamplingDataPostProcessor::MapAddressToFunctionAddress(uint64_t absolute_ad
   // address held by exact_address_to_function_address_, otherwise each address is considered a
   // different function. We are storing this mapping for faster lookup.
   std::optional<uint64_t> absolute_function_address_option =
-      capture_data.FindFunctionAbsoluteAddressByAddress(absolute_address);
+      capture_data.FindFunctionAbsoluteAddressByInstructionAbsoluteAddress(absolute_address);
   uint64_t absolute_function_address = absolute_function_address_option.value_or(absolute_address);
 
   exact_address_to_function_address_[absolute_address] = absolute_function_address;

--- a/src/ClientModel/include/ClientModel/CaptureData.h
+++ b/src/ClientModel/include/ClientModel/CaptureData.h
@@ -79,7 +79,7 @@ class CaptureData {
   void InsertAddressInfo(orbit_client_protos::LinuxAddressInfo address_info);
 
   [[nodiscard]] const std::string& GetFunctionNameByAddress(uint64_t absolute_address) const;
-  [[nodiscard]] std::optional<uint64_t> FindFunctionAbsoluteAddressByAddress(
+  [[nodiscard]] std::optional<uint64_t> FindFunctionAbsoluteAddressByInstructionAbsoluteAddress(
       uint64_t absolute_address) const;
   [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionByModulePathBuildIdAndOffset(
       const std::string& module_path, const std::string& build_id, uint64_t offset) const;
@@ -94,8 +94,6 @@ class CaptureData {
   [[nodiscard]] const orbit_client_protos::FunctionInfo* FindFunctionByAddress(
       uint64_t absolute_address, bool is_exact) const;
   [[nodiscard]] orbit_client_data::ModuleData* FindModuleByAddress(uint64_t absolute_address) const;
-  [[nodiscard]] std::optional<uint64_t> GetAbsoluteAddress(
-      const orbit_client_protos::FunctionInfo& function) const;
 
   static const std::string kUnknownFunctionOrModuleName;
 
@@ -228,6 +226,13 @@ class CaptureData {
   }
 
  private:
+  [[nodiscard]] std::optional<uint64_t>
+  FindFunctionAbsoluteAddressByInstructionAbsoluteAddressUsingModulesInMemory(
+      uint64_t absolute_address) const;
+  [[nodiscard]] std::optional<uint64_t>
+  FindFunctionAbsoluteAddressByInstructionAbsoluteAddressUsingAddressInfo(
+      uint64_t absolute_address) const;
+
   orbit_client_data::ProcessData process_;
   orbit_client_data::ModuleManager* module_manager_;
   absl::flat_hash_map<uint64_t, orbit_grpc_protos::InstrumentedFunction> instrumented_functions_;

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2023,8 +2023,8 @@ void OrbitApp::DeselectFunction(const orbit_client_protos::FunctionInfo& func) {
   const ModuleData* module = GetModuleByPathAndBuildId(module_path, module_build_id);
   if (module == nullptr) return false;
 
-  const uint64_t relative_address = absolute_address - module_base_address;
-  const FunctionInfo* function = module->FindFunctionByRelativeAddress(relative_address, false);
+  const uint64_t offset = absolute_address - module_base_address;
+  const FunctionInfo* function = module->FindFunctionByOffset(offset, false);
   if (function == nullptr) return false;
 
   return data_manager_->IsFunctionSelected(*function);

--- a/src/OrbitGl/CallstackDataView.cpp
+++ b/src/OrbitGl/CallstackDataView.cpp
@@ -232,7 +232,7 @@ void CallstackDataView::SetFunctionsToHighlight(
   for (int index : indices_) {
     CallstackDataViewFrame frame = GetFrameFromIndex(index);
     std::optional<uint64_t> callstack_function_absolute_address =
-        capture_data.FindFunctionAbsoluteAddressByAddress(frame.address);
+        capture_data.FindFunctionAbsoluteAddressByInstructionAbsoluteAddress(frame.address);
     if (callstack_function_absolute_address.has_value() &&
         absolute_addresses.contains(callstack_function_absolute_address.value())) {
       functions_to_highlight_.insert(frame.address);

--- a/src/OrbitGl/FunctionsDataView.h
+++ b/src/OrbitGl/FunctionsDataView.h
@@ -27,7 +27,7 @@ class FunctionsDataView : public DataView {
                                                 const orbit_client_protos::FunctionInfo& function);
 
   const std::vector<Column>& GetColumns() override;
-  int GetDefaultSortingColumn() override { return kColumnAddress; }
+  int GetDefaultSortingColumn() override { return kColumnAddressInModule; }
   std::vector<std::string> GetContextMenu(int clicked_index,
                                           const std::vector<int>& selected_indices) override;
   std::string GetValue(int row, int column) override;
@@ -53,7 +53,7 @@ class FunctionsDataView : public DataView {
     kColumnName,
     kColumnSize,
     kColumnModule,
-    kColumnAddress,
+    kColumnAddressInModule,
     kNumColumns
   };
 

--- a/src/OrbitGl/LiveFunctionsDataView.cpp
+++ b/src/OrbitGl/LiveFunctionsDataView.cpp
@@ -93,10 +93,8 @@ std::string LiveFunctionsDataView::GetValue(int row, int column) {
       return GetPrettyTime(absl::Nanoseconds(stats.max_ns()));
     case kColumnModule:
       return function.module_path();
-    case kColumnAddress: {
-      const CaptureData& capture_data = app_->GetCaptureData();
-      return absl::StrFormat("0x%" PRIx64, capture_data.GetAbsoluteAddress(function).value_or(0));
-    }
+    case kColumnAddress:
+      return absl::StrFormat("%#" PRIx64, function.address());
     default:
       return "";
   }


### PR DESCRIPTION
This change removes almost all usages of GetAbsoluteAddress and
deprecates the function. We have left with disassebly use-case still
relying on absolute addresses. Since it requires service-side support
this part is left for the follow-up PRs.

Bug: http://b/190805289
Test: Start Orbit, instrument a function and take a capture.