### PR TITLE
Remove manual crashes via nullptr dereferencing.

### DIFF
--- a/src/GrpcProtos/services.proto
+++ b/src/GrpcProtos/services.proto
@@ -98,7 +98,6 @@ service FramePointerValidatorService {
 message CrashOrbitServiceRequest {
   enum CrashType {
     CHECK_FALSE = 0;
-    NULL_POINTER_DEREFERENCE = 1;
     STACK_OVERFLOW = 2;
   }
   CrashType crash_type = 1;

--- a/src/GrpcProtos/services.proto
+++ b/src/GrpcProtos/services.proto
@@ -98,6 +98,7 @@ service FramePointerValidatorService {
 message CrashOrbitServiceRequest {
   enum CrashType {
     CHECK_FALSE = 0;
+	NULL_POINTER_DEREFERENCE = 1 [deprecated = true];
     STACK_OVERFLOW = 2;
   }
   CrashType crash_type = 1;

--- a/src/GrpcProtos/services.proto
+++ b/src/GrpcProtos/services.proto
@@ -98,7 +98,7 @@ service FramePointerValidatorService {
 message CrashOrbitServiceRequest {
   enum CrashType {
     CHECK_FALSE = 0;
-	NULL_POINTER_DEREFERENCE = 1 [deprecated = true];
+    NULL_POINTER_DEREFERENCE = 1 [deprecated = true];
     STACK_OVERFLOW = 2;
   }
   CrashType crash_type = 1;

--- a/src/GrpcProtos/services.proto
+++ b/src/GrpcProtos/services.proto
@@ -98,7 +98,7 @@ service FramePointerValidatorService {
 message CrashOrbitServiceRequest {
   enum CrashType {
     CHECK_FALSE = 0;
-    NULL_POINTER_DEREFERENCE = 1 [deprecated = true];
+    OBSOLETE_NULL_POINTER_DEREFERENCE = 1;
     STACK_OVERFLOW = 2;
   }
   CrashType crash_type = 1;

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -126,7 +126,6 @@ using orbit_capture_client::CaptureListener;
 
 using orbit_grpc_protos::CrashOrbitServiceRequest_CrashType;
 using orbit_grpc_protos::CrashOrbitServiceRequest_CrashType_CHECK_FALSE;
-using orbit_grpc_protos::CrashOrbitServiceRequest_CrashType_NULL_POINTER_DEREFERENCE;
 using orbit_grpc_protos::CrashOrbitServiceRequest_CrashType_STACK_OVERFLOW;
 
 using orbit_qt::ServiceDeployManager;
@@ -1110,11 +1109,6 @@ void OrbitMainWindow::OpenCapture(const std::string& filepath) {
 
 void OrbitMainWindow::on_actionCheckFalse_triggered() { CHECK(false); }
 
-void OrbitMainWindow::on_actionNullPointerDereference_triggered() {
-  int* null_pointer = nullptr;
-  *null_pointer = 0;
-}
-
 void InfiniteRecursion(int num) {
   if (num != 1) {
     InfiniteRecursion(num);
@@ -1127,10 +1121,6 @@ void OrbitMainWindow::on_actionStackOverflow_triggered() { InfiniteRecursion(0);
 
 void OrbitMainWindow::on_actionServiceCheckFalse_triggered() {
   app_->CrashOrbitService(CrashOrbitServiceRequest_CrashType_CHECK_FALSE);
-}
-
-void OrbitMainWindow::on_actionServiceNullPointerDereference_triggered() {
-  app_->CrashOrbitService(CrashOrbitServiceRequest_CrashType_NULL_POINTER_DEREFERENCE);
 }
 
 void OrbitMainWindow::on_actionServiceStackOverflow_triggered() {

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -135,10 +135,8 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   void on_actionIntrospection_triggered();
 
   void on_actionCheckFalse_triggered();
-  void on_actionNullPointerDereference_triggered();
   void on_actionStackOverflow_triggered();
   void on_actionServiceCheckFalse_triggered();
-  void on_actionServiceNullPointerDereference_triggered();
   void on_actionServiceStackOverflow_triggered();
 
   void OnTimerSelectionChanged(const orbit_client_protos::TimerInfo* timer_info);

--- a/src/OrbitQt/orbitmainwindow.ui
+++ b/src/OrbitQt/orbitmainwindow.ui
@@ -288,10 +288,8 @@ QPushButton:disabled {
       <string>Crash Test</string>
      </property>
      <addaction name="actionCheckFalse"/>
-     <addaction name="actionNullPointerDereference"/>
      <addaction name="actionStackOverflow"/>
      <addaction name="actionServiceCheckFalse"/>
-     <addaction name="actionServiceNullPointerDereference"/>
      <addaction name="actionServiceStackOverflow"/>
     </widget>
     <addaction name="menuCrash"/>
@@ -459,11 +457,6 @@ QPushButton:disabled {
     <string>Check False</string>
    </property>
   </action>
-  <action name="actionNullPointerDereference">
-   <property name="text">
-    <string>Null Pointer Dereference</string>
-   </property>
-  </action>
   <action name="actionStackOverflow">
    <property name="text">
     <string>Stack Overflow</string>
@@ -472,11 +465,6 @@ QPushButton:disabled {
   <action name="actionServiceCheckFalse">
    <property name="text">
     <string>[Service] Check False</string>
-   </property>
-  </action>
-  <action name="actionServiceNullPointerDereference">
-   <property name="text">
-    <string>[Service] Null Pointer Dereference</string>
    </property>
   </action>
   <action name="actionServiceStackOverflow">

--- a/src/Service/CrashServiceImpl.cpp
+++ b/src/Service/CrashServiceImpl.cpp
@@ -13,7 +13,6 @@ using grpc::ServerContext;
 using grpc::Status;
 using orbit_grpc_protos::CrashOrbitServiceRequest;
 using orbit_grpc_protos::CrashOrbitServiceRequest_CrashType_CHECK_FALSE;
-using orbit_grpc_protos::CrashOrbitServiceRequest_CrashType_NULL_POINTER_DEREFERENCE;
 using orbit_grpc_protos::CrashOrbitServiceRequest_CrashType_STACK_OVERFLOW;
 using orbit_grpc_protos::CrashOrbitServiceResponse;
 
@@ -29,11 +28,6 @@ Status CrashServiceImpl::CrashOrbitService(ServerContext*, const CrashOrbitServi
   switch (request->crash_type()) {
     case CrashOrbitServiceRequest_CrashType_CHECK_FALSE: {
       CHECK(false);
-      break;
-    }
-    case CrashOrbitServiceRequest_CrashType_NULL_POINTER_DEREFERENCE: {
-      int* null_pointer = nullptr;
-      *null_pointer = 0;
       break;
     }
     case CrashOrbitServiceRequest_CrashType_STACK_OVERFLOW: {


### PR DESCRIPTION
Depending on the compiler this is translated into an illegal opcode. It doesn't
add much to the functionality so we just get rid of it.