### PR TITLE
Get rid of ProcessData::module_memory_map_

### DIFF
--- a/src/ClientData/include/ClientData/ProcessData.h
+++ b/src/ClientData/include/ClientData/ProcessData.h
@@ -82,13 +82,11 @@ class ProcessData final {
   [[nodiscard]] std::vector<std::pair<std::string, std::string>> GetUniqueModulesPathAndBuildId()
       const;
 
-  // This function is deprecated since it relies on the fact that only one instance
-  // of module is loaded in the process which is not always true.
-  [[nodiscard]] std::optional<ModuleInMemory> FindModuleByPath(
+  [[nodiscard]] std::vector<std::string> FindModuleBuildIdsByPath(
       const std::string& module_path) const;
 
   [[nodiscard]] bool IsModuleLoadedByProcess(const std::string& module_path) const {
-    return FindModuleByPath(module_path).has_value();
+    return !FindModuleBuildIdsByPath(module_path).empty();
   }
 
   [[nodiscard]] bool IsModuleLoadedByProcess(const ModuleData* module) const;
@@ -97,8 +95,6 @@ class ProcessData final {
   mutable absl::Mutex mutex_;
   orbit_grpc_protos::ProcessInfo process_info_;
 
-  // This is a map from module_path to the space in memory where that module is loaded
-  absl::node_hash_map<std::string, ModuleInMemory> module_memory_map_;
   std::map<uint64_t, ModuleInMemory> start_address_to_module_in_memory_;
 };
 

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -340,7 +340,7 @@ class OrbitApp final : public DataViewFactory,
   void UpdateAfterCaptureCleared();
 
   orbit_base::Future<ErrorMessageOr<void>> LoadPresetModule(
-      const std::string& module_path, const orbit_preset_file::PresetFile& preset_file);
+      const std::filesystem::path& module_path, const orbit_preset_file::PresetFile& preset_file);
   void LoadPreset(const orbit_preset_file::PresetFile& preset) override;
   [[nodiscard]] orbit_data_views::PresetLoadState GetPresetLoadState(
       const orbit_preset_file::PresetFile& preset) const override;
@@ -468,8 +468,8 @@ class OrbitApp final : public DataViewFactory,
       absl::Span<const orbit_grpc_protos::ModuleInfo> module_infos);
   void AddSymbols(const std::filesystem::path& module_file_path, const std::string& module_build_id,
                   const orbit_grpc_protos::ModuleSymbols& symbols);
-  ErrorMessageOr<const orbit_client_data::ModuleData*> GetLoadedModuleByPath(
-      const std::string& module_path);
+  ErrorMessageOr<std::vector<const orbit_client_data::ModuleData*>> GetLoadedModulesByPath(
+      const std::filesystem::path& module_path);
   ErrorMessageOr<void> ConvertPresetToNewFormatIfNecessary(
       const orbit_preset_file::PresetFile& preset_file);
 


### PR DESCRIPTION
Also modify FindModuleByPath to return vector of build_ids
instead since this is what the callers need.

Bug: http://b/190805289
Test: Start Orbit - load a preset.