### PR TITLE
[Rebase on main] Correctly handle errors when unable to open the file.

### DIFF
--- a/src/CaptureClient/ApiEventProcessorTest.cpp
+++ b/src/CaptureClient/ApiEventProcessorTest.cpp
@@ -70,7 +70,7 @@ class ApiTester {
   ApiTester()
       : api_event_processor_{&api_event_listener_},
         capture_event_processor_{CaptureEventProcessor::CreateForCaptureListener(
-            &capture_event_listener_, std::filesystem::path{}, {})} {}
+            &capture_event_listener_, std::nullopt, {})} {}
 
   ApiTester& Start(const char* name = nullptr, orbit_api_color color = kOrbitColorAuto) {
     EnqueueApiEvent(orbit_api::kScopeStart, name, 0, color);

--- a/src/CaptureClient/CaptureEventProcessor.cpp
+++ b/src/CaptureClient/CaptureEventProcessor.cpp
@@ -43,7 +43,7 @@ namespace {
 class CaptureEventProcessorForListener : public CaptureEventProcessor {
  public:
   explicit CaptureEventProcessorForListener(CaptureListener* capture_listener,
-                                            std::filesystem::path file_path,
+                                            std::optional<std::filesystem::path> file_path,
                                             absl::flat_hash_set<uint64_t> frame_track_function_ids)
       : file_path_{std::move(file_path)},
         frame_track_function_ids_(std::move(frame_track_function_ids)),
@@ -77,7 +77,7 @@ class CaptureEventProcessorForListener : public CaptureEventProcessor {
   void ProcessGpuQueueSubmission(const orbit_grpc_protos::GpuQueueSubmission& gpu_queue_submission);
   void ProcessSystemMemoryUsage(const orbit_grpc_protos::SystemMemoryUsage& system_memory_usage);
 
-  std::filesystem::path file_path_;
+  std::optional<std::filesystem::path> file_path_;
   absl::flat_hash_set<uint64_t> frame_track_function_ids_;
 
   absl::flat_hash_map<uint64_t, orbit_grpc_protos::Callstack> callstack_intern_pool;
@@ -514,7 +514,7 @@ uint64_t CaptureEventProcessorForListener::GetStringHashAndSendToListenerIfNeces
 }  // namespace
 
 std::unique_ptr<CaptureEventProcessor> CaptureEventProcessor::CreateForCaptureListener(
-    CaptureListener* capture_listener, std::filesystem::path file_path,
+    CaptureListener* capture_listener, std::optional<std::filesystem::path> file_path,
     absl::flat_hash_set<uint64_t> frame_track_function_ids) {
   return std::make_unique<CaptureEventProcessorForListener>(capture_listener, std::move(file_path),
                                                             std::move(frame_track_function_ids));

--- a/src/CaptureClient/include/CaptureClient/CaptureEventProcessor.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureEventProcessor.h
@@ -24,7 +24,7 @@ class CaptureEventProcessor {
   virtual void ProcessEvent(const orbit_grpc_protos::ClientCaptureEvent& event) = 0;
 
   static std::unique_ptr<CaptureEventProcessor> CreateForCaptureListener(
-      CaptureListener* capture_listener, std::filesystem::path file_path,
+      CaptureListener* capture_listener, std::optional<std::filesystem::path> file_path,
       absl::flat_hash_set<uint64_t> frame_track_function_ids);
 
   static ErrorMessageOr<std::unique_ptr<CaptureEventProcessor>> CreateSaveToFileProcessor(

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1106,7 +1106,7 @@ static std::unique_ptr<CaptureEventProcessor> CreateCaptureEventProcessor(
     absl::flat_hash_set<uint64_t> frame_track_function_ids,
     const std::function<void(const ErrorMessage&)>& error_handler) {
   if (!absl::GetFlag(FLAGS_enable_capture_autosave)) {
-    return CaptureEventProcessor::CreateForCaptureListener(listener, std::filesystem::path{},
+    return CaptureEventProcessor::CreateForCaptureListener(listener, std::nullopt,
                                                            std::move(frame_track_function_ids));
   }
 
@@ -1121,7 +1121,7 @@ static std::unique_ptr<CaptureEventProcessor> CreateCaptureEventProcessor(
     error_handler(ErrorMessage{
         absl::StrFormat("Unable to set up automatic capture saving to \"%s\": %s",
                         file_path.string(), save_to_file_processor_or_error.error().message())});
-    return CaptureEventProcessor::CreateForCaptureListener(listener, std::filesystem::path{},
+    return CaptureEventProcessor::CreateForCaptureListener(listener, std::nullopt,
                                                            std::move(frame_track_function_ids));
   }
 
@@ -1217,6 +1217,7 @@ void OrbitApp::StartCapture() {
       this, process->name(), frame_track_function_ids, [this](const ErrorMessage& error) {
         capture_data_->reset_file_path();
         SendErrorToUi("Error saving capture", error.message());
+        ERROR("%s", error.message());
       });
 
   Future<ErrorMessageOr<CaptureOutcome>> capture_result = capture_client_->Capture(


### PR DESCRIPTION
Making file_path_ std::optional lets us to correctly set
file_path in capture data when Orbit was unable to open it.

Bug: http://b/191247811
Test: Trigger the error by clicking stop-start very fast for some
      time. Finish capture after the error and see that there are
      no errors.