### PR TITLE
Remove enable_source_code_view flag

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -98,7 +98,6 @@
 ABSL_DECLARE_FLAG(bool, devmode);
 ABSL_DECLARE_FLAG(bool, local);
 ABSL_DECLARE_FLAG(bool, enable_tracepoint_feature);
-ABSL_DECLARE_FLAG(bool, enable_source_code_view);
 ABSL_DECLARE_FLAG(bool, enable_capture_autosave);
 ABSL_DECLARE_FLAG(bool, enable_cgroup_memory);
 

--- a/src/OrbitGl/CallstackDataView.cpp
+++ b/src/OrbitGl/CallstackDataView.cpp
@@ -26,8 +26,6 @@ using orbit_client_model::CaptureData;
 using orbit_client_protos::CallstackInfo;
 using orbit_client_protos::FunctionInfo;
 
-ABSL_DECLARE_FLAG(bool, enable_source_code_view);
-
 CallstackDataView::CallstackDataView(OrbitApp* app)
     : orbit_data_views::DataView(orbit_data_views::DataViewType::kCallstack, app), app_{app} {}
 
@@ -124,7 +122,7 @@ std::vector<std::string> CallstackDataView::GetContextMenu(
       enable_select |= !app_->IsFunctionSelected(*function);
       enable_unselect |= app_->IsFunctionSelected(*function);
       enable_disassembly = true;
-      enable_source_code = absl::GetFlag(FLAGS_enable_source_code_view);
+      enable_source_code = true;
     } else if (module != nullptr && !module->is_loaded()) {
       enable_load = true;
     }

--- a/src/OrbitGl/ClientFlags.cpp
+++ b/src/OrbitGl/ClientFlags.cpp
@@ -46,9 +46,6 @@ ABSL_FLAG(bool, show_return_values, false, "Show return values on time slices");
 ABSL_FLAG(bool, enable_tracepoint_feature, false,
           "Enable the setting of the panel of kernel tracepoints");
 
-// TODO(b/181736566): Remove this flag entirely
-ABSL_FLAG(bool, enable_source_code_view, true, "Enable the experimental source code view");
-
 // TODO(b/185099421): Remove this flag once we have a clear explanation of the memory warning
 // threshold (i.e., production limit).
 ABSL_FLAG(bool, enable_warning_threshold, false,

--- a/src/OrbitGl/FunctionsDataView.cpp
+++ b/src/OrbitGl/FunctionsDataView.cpp
@@ -34,8 +34,6 @@ using orbit_client_data::ProcessData;
 using orbit_client_model::CaptureData;
 using orbit_client_protos::FunctionInfo;
 
-ABSL_DECLARE_FLAG(bool, enable_source_code_view);
-
 FunctionsDataView::FunctionsDataView(OrbitApp* app)
     : orbit_data_views::DataView(orbit_data_views::DataViewType::kFunctions, app), app_{app} {}
 
@@ -205,7 +203,7 @@ std::vector<std::string> FunctionsDataView::GetContextMenu(
   if (enable_enable_frame_track) menu.emplace_back(kMenuActionEnableFrameTrack);
   if (enable_disable_frame_track) menu.emplace_back(kMenuActionDisableFrameTrack);
   menu.emplace_back(kMenuActionDisassembly);
-  if (absl::GetFlag(FLAGS_enable_source_code_view)) menu.emplace_back(kMenuActionSourceCode);
+  menu.emplace_back(kMenuActionSourceCode);
   Append(menu, DataView::GetContextMenu(clicked_index, selected_indices));
   return menu;
 }

--- a/src/OrbitGl/LiveFunctionsDataView.cpp
+++ b/src/OrbitGl/LiveFunctionsDataView.cpp
@@ -33,8 +33,6 @@ using orbit_client_protos::FunctionInfo;
 using orbit_client_protos::FunctionStats;
 using orbit_grpc_protos::InstrumentedFunction;
 
-ABSL_DECLARE_FLAG(bool, enable_source_code_view);
-
 LiveFunctionsDataView::LiveFunctionsDataView(
     LiveFunctionsController* live_functions, OrbitApp* app,
     orbit_metrics_uploader::MetricsUploader* metrics_uploader)
@@ -220,7 +218,7 @@ std::vector<std::string> LiveFunctionsDataView::GetContextMenu(
       enable_select |= !app_->IsFunctionSelected(instrumented_function);
       enable_unselect |= app_->IsFunctionSelected(instrumented_function);
       enable_disassembly = true;
-      enable_source_code = absl::GetFlag(FLAGS_enable_source_code_view);
+      enable_source_code = true;
     }
 
     const FunctionStats& stats = capture_data.GetFunctionStatsOrDefault(instrumented_function_id);

--- a/src/OrbitGl/SamplingReportDataView.cpp
+++ b/src/OrbitGl/SamplingReportDataView.cpp
@@ -38,8 +38,6 @@ using orbit_client_data::ThreadID;
 using orbit_client_model::CaptureData;
 using orbit_client_protos::FunctionInfo;
 
-ABSL_DECLARE_FLAG(bool, enable_source_code_view);
-
 SamplingReportDataView::SamplingReportDataView(OrbitApp* app)
     : orbit_data_views::DataView(orbit_data_views::DataViewType::kSampling, app),
       callstack_data_view_(nullptr),
@@ -221,8 +219,7 @@ std::vector<std::string> SamplingReportDataView::GetContextMenu(
         GetFunctionsFromIndices(selected_indices);
 
     enable_disassembly = !selected_functions.empty();
-    enable_source_code =
-        !selected_functions.empty() && absl::GetFlag(FLAGS_enable_source_code_view);
+    enable_source_code = !selected_functions.empty();
 
     for (const FunctionInfo* function : selected_functions) {
       enable_select |= !app_->IsFunctionSelected(*function);

--- a/src/OrbitQt/CallTreeWidget.cpp
+++ b/src/OrbitQt/CallTreeWidget.cpp
@@ -47,8 +47,6 @@ using orbit_client_data::ModuleData;
 using orbit_client_model::CaptureData;
 using orbit_client_protos::FunctionInfo;
 
-ABSL_DECLARE_FLAG(bool, enable_source_code_view);
-
 CallTreeWidget::CallTreeWidget(QWidget* parent)
     : QWidget{parent}, ui_{std::make_unique<Ui::CallTreeWidget>()} {
   ui_->setupUi(this);
@@ -403,7 +401,7 @@ void CallTreeWidget::onCustomContextMenuRequested(const QPoint& point) {
       enable_select |= !app_->IsFunctionSelected(*function);
       enable_deselect |= app_->IsFunctionSelected(*function);
       enable_disassembly = true;
-      enable_source_code = absl::GetFlag(FLAGS_enable_source_code_view);
+      enable_source_code = true;
     }
   }
 


### PR DESCRIPTION
The flag was defaulted to true more than two releases ago, so let's
finally remove the flag.