### PR TITLE
Create trampoline and instrument function.

### DIFF
--- a/src/UserSpaceInstrumentation/Trampoline.cpp
+++ b/src/UserSpaceInstrumentation/Trampoline.cpp
@@ -62,7 +62,7 @@ size_t kMaxRelocatedPrologSize = kSizeOfJmp * 16;
 [[nodiscard]] std::string BytesAsString(const std::vector<uint8_t>& code) {
   std::string result;
   for (const auto& c : code) {
-    result = absl::StrCat(result, absl::StrFormat("%0.2x ", c));
+    result.append(absl::StrFormat("%0.2x ", c));
   }
   return result;
 }
@@ -688,7 +688,7 @@ ErrorMessageOr<void> InstrumentFunction(pid_t pid, uint64_t function_address,
         function_address, trampoline_address));
   }
   jump.AppendImmediate32(offset_or_error.value());
-  // Overwrite the remaining byte to the next instruction with 'nop's. This is not strictly needed
+  // Overwrite the remaining bytes to the next instruction with 'nop's. This is not strictly needed
   // but helps with debugging/disassembling.
   while (jump.GetResultAsVector().size() < address_after_prolog - function_address) {
     jump.AppendBytes({0x90});
@@ -707,7 +707,7 @@ void MoveInstructionPointersOutOfOverwrittenCode(
     RegisterState registers;
     ErrorMessageOr<void> backup_or_error = registers.BackupRegisters(tid);
     FAIL_IF(backup_or_error.has_error(),
-            "Failed to read registers in MoveInstructionPointersOutOfOverwrittenCode: /'%s/'",
+            "Failed to read registers in MoveInstructionPointersOutOfOverwrittenCode: \"%s\"",
             backup_or_error.error().message());
     const uint64_t rip = registers.GetGeneralPurposeRegisters()->x86_64.rip;
     auto relocation = relocation_map.find(rip);
@@ -715,7 +715,7 @@ void MoveInstructionPointersOutOfOverwrittenCode(
       registers.GetGeneralPurposeRegisters()->x86_64.rip = relocation->second;
       ErrorMessageOr<void> restore_or_error = registers.RestoreRegisters();
       FAIL_IF(restore_or_error.has_error(),
-              "Failed to write registers in MoveInstructionPointersOutOfOverwrittenCode: /'%s/'",
+              "Failed to write registers in MoveInstructionPointersOutOfOverwrittenCode: \"%s\"",
               restore_or_error.error().message());
     }
   }

--- a/src/UserSpaceInstrumentation/Trampoline.cpp
+++ b/src/UserSpaceInstrumentation/Trampoline.cpp
@@ -8,11 +8,13 @@
 #include <absl/strings/numbers.h>
 #include <absl/strings/str_format.h>
 #include <absl/strings/str_split.h>
+#include <cpuid.h>
 #include <unistd.h>
 
 #include <cstdint>
 #include <string>
 
+#include "AccessTraceesMemory.h"
 #include "AllocateInTracee.h"
 #include "MachineCode.h"
 #include "OrbitBase/ExecuteCommand.h"
@@ -29,6 +31,18 @@ namespace {
 using absl::numbers_internal::safe_strtou64_base;
 using orbit_base::ReadFileToString;
 
+// Number of bytes to overwrite at the beginning of the function. Relative jump to a signed 32 bit
+// offset looks like this:
+// jmp 01020304         e9 04 03 02 01
+size_t kSizeOfJmp = 5;
+
+// We relocate most `kSizeOfJmp` instructions. When relocating for each instruction we are either
+// copying that instruction or we add a small sequence of instruction and data (see
+// RelocateInstruction below). The longest possible instruction in x64 is 16 bytes; the longest
+// sequence added in RelocateInstruction is also 16 bytes. So we get this (very generous) upper
+// bound.
+size_t kMaxRelocatedPrologSize = kSizeOfJmp * 16;
+
 [[nodiscard]] std::string InstructionBytesAsString(cs_insn* instruction) {
   std::string result;
   for (int i = 0; i < instruction->size; i++) {
@@ -36,6 +50,280 @@ using orbit_base::ReadFileToString;
                                          : absl::StrFormat(" %0.2x", instruction->bytes[i]));
   }
   return result;
+}
+
+[[nodiscard]] bool HasAvx() {
+  uint32_t eax = 0;
+  uint32_t ebx = 0;
+  uint32_t ecx = 0;
+  uint32_t edx = 0;
+  return __get_cpuid(0x01, &eax, &ebx, &ecx, &edx) && (ecx & bit_AVX);
+}
+
+[[nodiscard]] std::string BytesAsString(const std::vector<uint8_t>& code) {
+  std::string result;
+  for (const auto& c : code) {
+    result = absl::StrCat(result, absl::StrFormat("%0.2x ", c));
+  }
+  return result;
+}
+
+void AppendBackupCode(MachineCode& trampoline) {
+  // This code is executed immediatly after the control is passed to the instrumented function. The
+  // top of the stack contains the return address. Above that are the parameters passed via the
+  // stack.
+  // Some of the general purpose and vector registers contain the parameters for the
+  // instrumented function not passed via the stack.
+
+  // TODO(dfenner): mention status words (mxcsr, ...)
+
+  // Compare section "3.2 Function Calling Sequence" in "System V Application Binary Interface"
+  // https://refspecs.linuxfoundation.org/elf/x86_64-abi-0.99.pdf
+
+  // General purpose registers used for passing parameters are rdi, rsi, rdx, rcx, r8, r9
+  // in that order. rax is used to indicate the number of vector arguments passed to a function
+  // requiring a variable number of arguments. r10 is used for passing a function’s static chain
+  // pointer. All of these need to be backed up:
+  // push rdi      57
+  // push rsi      56
+  // push rdx      52
+  // push rcx      51
+  // push r8       41 50
+  // push r9       41 51
+  // push rax      50
+  // push r10      41 52
+  trampoline.AppendBytes({0x57})
+      .AppendBytes({0x56})
+      .AppendBytes({0x52})
+      .AppendBytes({0x51})
+      .AppendBytes({0x41, 0x50})
+      .AppendBytes({0x41, 0x51})
+      .AppendBytes({0x50})
+      .AppendBytes({0x41, 0x52});
+
+  // We align the stack to 32 bytes first: round down to a multiple of 32, subtract another 24 and
+  // then push 8 byte original rsp. So we are 32 byte aligned after these commands and we can 'pop
+  // rsp' later to undo this.
+  // mov rax, rsp
+  // and rsp, $0xffffffffffffffe0
+  // sub rsp, 0x18
+  // push rax
+  trampoline.AppendBytes({0x48, 0x89, 0xe0})
+      .AppendBytes({0x48, 0x83, 0xe4, 0xe0})
+      .AppendBytes({0x48, 0x83, 0xec, 0x18})
+      .AppendBytes({0x50});
+
+  // Backup vector registers on the stack. They are used to pass float parameters so they need to be
+  // preserved. If Avx is supported backup ymm{0,..,8} (which include the xmm{0,..,8} registers as
+  // their lower half).
+  if (HasAvx()) {
+    // sub       rsp, 32
+    // vmovdqa   (rsp), ymm0
+    // ...
+    // sub       rsp, 32
+    // vmovdqa   (rsp), ymm7
+    trampoline.AppendBytes({0x48, 0x83, 0xec, 0x20})
+        .AppendBytes({0xc5, 0xfd, 0x7f, 0x04, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x20})
+        .AppendBytes({0xc5, 0xfd, 0x7f, 0x0c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x20})
+        .AppendBytes({0xc5, 0xfd, 0x7f, 0x14, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x20})
+        .AppendBytes({0xc5, 0xfd, 0x7f, 0x1c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x20})
+        .AppendBytes({0xc5, 0xfd, 0x7f, 0x24, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x20})
+        .AppendBytes({0xc5, 0xfd, 0x7f, 0x2c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x20})
+        .AppendBytes({0xc5, 0xfd, 0x7f, 0x34, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x20})
+        .AppendBytes({0xc5, 0xfd, 0x7f, 0x3c, 0x24});
+  } else {
+    // sub     rsp, 16
+    // movdqa  (rsp), xmm0,
+    // ...
+    // sub     rsp, 16
+    // movdqa  (rsp), xmm7
+    trampoline.AppendBytes({0x48, 0x83, 0xec, 0x10})
+        .AppendBytes({0x66, 0x0f, 0x7f, 0x04, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x10})
+        .AppendBytes({0x66, 0x0f, 0x7f, 0x0c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x10})
+        .AppendBytes({0x66, 0x0f, 0x7f, 0x14, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x10})
+        .AppendBytes({0x66, 0x0f, 0x7f, 0x1c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x10})
+        .AppendBytes({0x66, 0x0f, 0x7f, 0x24, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x10})
+        .AppendBytes({0x66, 0x0f, 0x7f, 0x2c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x10})
+        .AppendBytes({0x66, 0x0f, 0x7f, 0x34, 0x24})
+        .AppendBytes({0x48, 0x83, 0xec, 0x10})
+        .AppendBytes({0x66, 0x0f, 0x7f, 0x3c, 0x24});
+  }
+}
+
+void AppendPayloadCode(uint64_t payload_address, uint64_t function_address,
+                       MachineCode& trampoline) {
+  // mov rax, payload_address
+  // mov rdi, function_address
+  // call rax
+  trampoline.AppendBytes({0x48, 0xb8})
+      .AppendImmediate64(payload_address)
+      .AppendBytes({0x48, 0xbf})
+      .AppendImmediate64(function_address)
+      .AppendBytes({0xff, 0xd0});
+}
+
+void AppendRestoreCode(MachineCode& trampoline) {
+  // Restore vector registers (see comment on AppendBackupCode above).
+  if (HasAvx()) {
+    // vmovdqa   ymm7, (esp)
+    // add       esp, 32
+    // ...
+    // vmovdqa   ymm0, (esp)
+    // add       esp, 32
+    trampoline.AppendBytes({0xc5, 0xfd, 0x6f, 0x3c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x20})
+        .AppendBytes({0xc5, 0xfd, 0x6f, 0x34, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x20})
+        .AppendBytes({0xc5, 0xfd, 0x6f, 0x2c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x20})
+        .AppendBytes({0xc5, 0xfd, 0x6f, 0x24, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x20})
+        .AppendBytes({0xc5, 0xfd, 0x6f, 0x1c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x20})
+        .AppendBytes({0xc5, 0xfd, 0x6f, 0x14, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x20})
+        .AppendBytes({0xc5, 0xfd, 0x6f, 0x0c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x20})
+        .AppendBytes({0xc5, 0xfd, 0x6f, 0x04, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x20});
+  } else {
+    // movdqa   xmm7, (esp)
+    // add esp, $0x10
+    //...
+    // movdqa   xmm0, (esp)
+    // add esp, $0x10
+    trampoline.AppendBytes({0x66, 0x0f, 0x6f, 0x3c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x10})
+        .AppendBytes({0x66, 0x0f, 0x6f, 0x34, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x10})
+        .AppendBytes({0x66, 0x0f, 0x6f, 0x2c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x10})
+        .AppendBytes({0x66, 0x0f, 0x6f, 0x24, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x10})
+        .AppendBytes({0x66, 0x0f, 0x6f, 0x1c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x10})
+        .AppendBytes({0x66, 0x0f, 0x6f, 0x14, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x10})
+        .AppendBytes({0x66, 0x0f, 0x6f, 0x0c, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x10})
+        .AppendBytes({0x66, 0x0f, 0x6f, 0x04, 0x24})
+        .AppendBytes({0x48, 0x83, 0xc4, 0x10});
+  }
+
+  // Undo the 32 byte alignment (see comment on AppendBackupCode above).
+  // pop rsp
+  trampoline.AppendBytes({0x5c});
+
+  // Restore the general purpose registers (see comment on AppendBackupCode above).
+  // pop r10
+  // pop rax
+  // pop r9
+  // pop r8
+  // pop rcx
+  // pop  rdx
+  // pop  rsi
+  // pop  rdi
+  trampoline.AppendBytes({0x41, 0x5a})
+      .AppendBytes({0x58})
+      .AppendBytes({0x41, 0x59})
+      .AppendBytes({0x41, 0x58})
+      .AppendBytes({0x59})
+      .AppendBytes({0x5a})
+      .AppendBytes({0x5e})
+      .AppendBytes({0x5f});
+}
+
+// Relocates instructions beginning at `function_address` into the trampoline until `kSizeOfJmp`
+// bytes at the beginning of the function are cleared.
+// Returns a mapping from old instruction start addresses in the function to new addresses in the
+// trampoline. The map is meant to be used to move instruction pointers inside the overwritten areas
+// into the correct positions in the trampoline. Therefore only the instructions after the first one
+// are included (function_address will contain a valid instruction - the jump into the trampoline -
+// when we are done).
+[[nodiscard]] ErrorMessageOr<uint64_t> AppendRelocatedPrologCode(
+    uint64_t function_address, const std::vector<uint8_t>& function, uint64_t trampoline_address,
+    csh capstone_handle, absl::flat_hash_map<uint64_t, uint64_t>& global_relocation_map,
+    MachineCode& trampoline) {
+  cs_insn* instruction = cs_malloc(capstone_handle);
+  FAIL_IF(instruction == nullptr, "Failed to allocate memory for capstone disassembler.");
+  orbit_base::unique_resource scope_exit{instruction,
+                                         [](cs_insn* instruction) { cs_free(instruction, 1); }};
+  std::vector<uint8_t> trampoline_code;
+  const uint8_t* code_pointer = function.data();
+  size_t code_size = function.size();
+  uint64_t disassemble_address = function_address;
+  std::vector<size_t> relocateable_addresses;
+  absl::flat_hash_map<uint64_t, uint64_t> relocation_map;
+  while ((disassemble_address - function_address < kSizeOfJmp) &&
+         cs_disasm_iter(capstone_handle, &code_pointer, &code_size, &disassemble_address,
+                        instruction)) {
+    const uint64_t original_instruction_address = disassemble_address - instruction->size;
+    const uint64_t relocated_instruction_address =
+        trampoline_address + trampoline.GetResultAsVector().size() + trampoline_code.size();
+    relocation_map.insert_or_assign(original_instruction_address, relocated_instruction_address);
+    OUTCOME_TRY(relocated_instruction,
+                RelocateInstruction(instruction, original_instruction_address,
+                                    relocated_instruction_address));
+    if (relocated_instruction.position_of_absolute_address.has_value()) {
+      const size_t offset = relocated_instruction.position_of_absolute_address.value();
+      const size_t instruction_address = trampoline_code.size();
+      relocateable_addresses.push_back(instruction_address + offset);
+    }
+    trampoline_code.insert(trampoline_code.end(), relocated_instruction.code.begin(),
+                           relocated_instruction.code.end());
+  }
+
+  if (disassemble_address - function_address < kSizeOfJmp) {
+    return ErrorMessage(
+        absl::StrFormat("Unable to disassemble enough of the function to instrument it. Code: %s",
+                        BytesAsString(function)));
+  }
+
+  // Relocate addresses encoded in the trampoline.
+  for (size_t pos : relocateable_addresses) {
+    const uint64_t address_in_trampoline = *absl::bit_cast<uint64_t*>(trampoline_code.data() + pos);
+    auto it = relocation_map.find(address_in_trampoline);
+    if (it != relocation_map.end()) {
+      *absl::bit_cast<uint64_t*>(trampoline_code.data() + pos) = it->second;
+    }
+  }
+
+  trampoline.AppendBytes(trampoline_code);
+  global_relocation_map.insert(relocation_map.begin(), relocation_map.end());
+  return disassemble_address;
+}
+
+[[nodiscard]] ErrorMessageOr<void> AppendJumpBackCode(uint64_t address_after_prolog,
+                                                      uint64_t trampoline_address,
+                                                      MachineCode& trampoline) {
+  const uint64_t address_after_jmp =
+      trampoline_address + trampoline.GetResultAsVector().size() + kSizeOfJmp;
+  trampoline.AppendBytes({0xe9});
+  ErrorMessageOr<int32_t> new_offset_or_error =
+      AddressDifferenceAsInt32(address_after_prolog, address_after_jmp);
+  // This should not happen since the trampoline is allocated such that it is located in the +-2GB
+  // range of the instrumented code.
+  if (new_offset_or_error.has_error()) {
+    return ErrorMessage(absl::StrFormat(
+        "Unable to jump back to instrumented function since the instrumented function and the "
+        "trampoline are more then +-2GB apart. address_after_prolog: %#x trampoline_address: %#x",
+        address_after_prolog, trampoline_address));
+  }
+  trampoline.AppendImmediate32(new_offset_or_error.value());
+  return outcome::success();
 }
 
 }  // namespace
@@ -318,6 +606,104 @@ ErrorMessageOr<RelocatedInstruction> RelocateInstruction(cs_insn* instruction, u
   }
 
   return result;
+}
+
+uint64_t GetMaxTrampolineSize() {
+  // The maximum size of a trampoline is constant. So the calculation can be cached on first call.
+  static const uint64_t trampoline_size = []() -> uint64_t {
+    MachineCode unused_code;
+    AppendBackupCode(unused_code);
+    AppendPayloadCode(0 /* payload_address*/, 0 /* function address */, unused_code);
+    AppendRestoreCode(unused_code);
+    unused_code.AppendBytes(std::vector<uint8_t>(kMaxRelocatedPrologSize, 0));
+    auto result =
+        AppendJumpBackCode(0 /*address_after_prolog*/, 0 /*trampoline_address*/, unused_code);
+    CHECK(!result.has_error());
+
+    // Round up to the next multiple of 32 so we get aligned jump targets at the beginning of the
+    // each trampoline.
+    return static_cast<uint64_t>(((unused_code.GetResultAsVector().size() + 31) / 32) * 32);
+  }();
+
+  return trampoline_size;
+}
+
+ErrorMessageOr<uint64_t> CreateTrampoline(pid_t pid, uint64_t function_address,
+                                          const std::vector<uint8_t>& function,
+                                          uint64_t trampoline_address, uint64_t payload_address,
+                                          csh capstone_handle,
+                                          absl::flat_hash_map<uint64_t, uint64_t>& relocation_map) {
+  MachineCode trampoline;
+  // Add code to backup register state, execute the payload and restore the register state.
+  AppendBackupCode(trampoline);
+  AppendPayloadCode(payload_address, function_address, trampoline);
+  AppendRestoreCode(trampoline);
+
+  // Relocate prolog into trampoline.
+  OUTCOME_TRY(address_after_prolog,
+              AppendRelocatedPrologCode(function_address, function, trampoline_address,
+                                        capstone_handle, relocation_map, trampoline));
+
+  // Add code for jump from trampoline back into function.
+  OUTCOME_TRY(AppendJumpBackCode(address_after_prolog, trampoline_address, trampoline));
+
+  // Copy trampoline into tracee.
+  auto write_result_or_error =
+      WriteTraceesMemory(pid, trampoline_address, trampoline.GetResultAsVector());
+  if (write_result_or_error.has_error()) {
+    return write_result_or_error.error();
+  }
+
+  return address_after_prolog;
+}
+
+ErrorMessageOr<void> InstrumentFunction(pid_t pid, uint64_t function_address,
+                                        uint64_t address_after_prolog,
+                                        uint64_t trampoline_address) {
+  MachineCode jump;
+  jump.AppendBytes({0xe9});
+  ErrorMessageOr<int32_t> offset_or_error =
+      AddressDifferenceAsInt32(trampoline_address, function_address + kSizeOfJmp);
+  // This should not happen since the trampoline is allocated such that it is located in the +-2GB
+  // range of the instrumented code.
+  if (offset_or_error.has_error()) {
+    return ErrorMessage(absl::StrFormat(
+        "Unable to jump from instrumented function into trampoline since the locations are more "
+        "then +-2GB apart. function_address: %#x trampoline_address: %#x",
+        function_address, trampoline_address));
+  }
+  jump.AppendImmediate32(offset_or_error.value());
+  // Overwrite the remaining byte to the next instruction with 'nop's. This is not strictly needed
+  // but helps with debugging/disassembling.
+  while (jump.GetResultAsVector().size() < address_after_prolog - function_address) {
+    jump.AppendBytes({0x90});
+  }
+  auto write_result_or_error = WriteTraceesMemory(pid, function_address, jump.GetResultAsVector());
+  if (write_result_or_error.has_error()) {
+    return write_result_or_error.error();
+  }
+  return outcome::success();
+}
+
+void MoveInstructionPointersOutOfOverwrittenCode(
+    pid_t pid, const absl::flat_hash_map<uint64_t, uint64_t>& relocation_map) {
+  std::vector<pid_t> tids = orbit_base::GetTidsOfProcess(pid);
+  for (pid_t tid : tids) {
+    RegisterState registers;
+    ErrorMessageOr<void> backup_or_error = registers.BackupRegisters(tid);
+    FAIL_IF(backup_or_error.has_error(),
+            "Failed to read registers in MoveInstructionPointersOutOfOverwrittenCode: /'%s/'",
+            backup_or_error.error().message());
+    const uint64_t rip = registers.GetGeneralPurposeRegisters()->x86_64.rip;
+    auto relocation = relocation_map.find(rip);
+    if (relocation != relocation_map.end()) {
+      registers.GetGeneralPurposeRegisters()->x86_64.rip = relocation->second;
+      ErrorMessageOr<void> restore_or_error = registers.RestoreRegisters();
+      FAIL_IF(restore_or_error.has_error(),
+              "Failed to write registers in MoveInstructionPointersOutOfOverwrittenCode: /'%s/'",
+              restore_or_error.error().message());
+    }
+  }
 }
 
 }  // namespace orbit_user_space_instrumentation

--- a/src/UserSpaceInstrumentation/Trampoline.cpp
+++ b/src/UserSpaceInstrumentation/Trampoline.cpp
@@ -36,11 +36,10 @@ using orbit_base::ReadFileToString;
 // jmp 01020304         e9 04 03 02 01
 size_t kSizeOfJmp = 5;
 
-// We relocate most `kSizeOfJmp` instructions. When relocating for each instruction we are either
+// We relocate at most `kSizeOfJmp` instructions. When relocating for each instruction we are either
 // copying that instruction or we add a small sequence of instruction and data (see
-// RelocateInstruction below). The longest possible instruction in x64 is 16 bytes; the longest
-// sequence added in RelocateInstruction is also 16 bytes. So we get this (very generous) upper
-// bound.
+// RelocateInstruction below). Per instruction we add at most 16 bytes. So we get this (very
+// generous) upper bound.
 size_t kMaxRelocatedPrologSize = kSizeOfJmp * 16;
 
 [[nodiscard]] std::string InstructionBytesAsString(cs_insn* instruction) {

--- a/src/UserSpaceInstrumentation/Trampoline.h
+++ b/src/UserSpaceInstrumentation/Trampoline.h
@@ -115,7 +115,7 @@ struct RelocatedInstruction {
 // here since this captures every change to the code constructing the trampoline.
 [[nodiscard]] uint64_t GetMaxTrampolineSize();
 
-// Creates a trampoline for the function at `function_address`. The trampoline is build at
+// Creates a trampoline for the function at `function_address`. The trampoline is built at
 // `trampoline_address`. The trampoline will call `payload_address` with `function_address` as a
 // parameter. `function` contains the beginning of the function (kMaxFunctionPrologBackupSize bytes
 // or less if the function shorter). `capstone_handle` is a handle to the capstone disassembler

--- a/src/UserSpaceInstrumentation/Trampoline.h
+++ b/src/UserSpaceInstrumentation/Trampoline.h
@@ -112,8 +112,7 @@ struct RelocatedInstruction {
                                                                        uint64_t new_address);
 
 // Strictly speaking the max tempoline size is a compile time constant, but we prefer to compute it
-// here since this captures every change to the constant caused by a change to the code constructing
-// the trampoline.
+// here since this captures every change to the code constructing the trampoline.
 [[nodiscard]] uint64_t GetMaxTrampolineSize();
 
 // Creates a trampoline for the function at `function_address`. The trampoline is build at
@@ -133,7 +132,7 @@ struct RelocatedInstruction {
     uint64_t trampoline_address, uint64_t payload_address, csh capstone_handle,
     absl::flat_hash_map<uint64_t, uint64_t>& relocation_map);
 
-// Instrument function at 'function_address' in rocess 'pid'. This simply overwrites the beginning
+// Instrument function at 'function_address' in process 'pid'. This simply overwrites the beginning
 // of the fuction with a jump to 'trampoline_address'. The trampoline needs to be constructed with
 // 'CreateTrampoline' above.
 [[nodiscard]] ErrorMessageOr<void> InstrumentFunction(pid_t pid, uint64_t function_address,

--- a/src/UserSpaceInstrumentation/Trampoline.h
+++ b/src/UserSpaceInstrumentation/Trampoline.h
@@ -5,6 +5,7 @@
 #ifndef USER_SPACE_INSTRUMENTATION_TRAMPOLINE_H_
 #define USER_SPACE_INSTRUMENTATION_TRAMPOLINE_H_
 
+#include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
 #include <capstone/capstone.h>
 #include <sys/types.h>
@@ -109,6 +110,40 @@ struct RelocatedInstruction {
 [[nodiscard]] ErrorMessageOr<RelocatedInstruction> RelocateInstruction(cs_insn* instruction,
                                                                        uint64_t old_address,
                                                                        uint64_t new_address);
+
+// Strictly speaking the max tempoline size is a compile time constant, but we prefer to compute it
+// here since this captures every change to the constant caused by a change to the code constructing
+// the trampoline.
+[[nodiscard]] uint64_t GetMaxTrampolineSize();
+
+// Creates a trampoline for the function at `function_address`. The trampoline is build at
+// `trampoline_address`. The trampoline will call `payload_address` with `function_address` as a
+// parameter. `function` contains the beginning of the function (kMaxFunctionPrologBackupSize bytes
+// or less if the function shorter). `capstone_handle` is a handle to the capstone disassembler
+// library returned by cs_open.
+// The function returns an error if it was no possible to instrument the function. For details on
+// that see the comments at AppendRelocatedPrologCode. If the function is successful it will insert
+// an address pair into `relocation_map` for each instruction it relocated from the beginning of the
+// function into the trampoline (needed for moving instruction pointers away from the overwritten
+// bytes at the beginning of the function).
+// The return value is the address of the first instruction not relocated into the trampoline (i.e.
+// the address the trampoline jump back to).
+[[nodiscard]] ErrorMessageOr<uint64_t> CreateTrampoline(
+    pid_t pid, uint64_t function_address, const std::vector<uint8_t>& function,
+    uint64_t trampoline_address, uint64_t payload_address, csh capstone_handle,
+    absl::flat_hash_map<uint64_t, uint64_t>& relocation_map);
+
+// Instrument function at 'function_address' in rocess 'pid'. This simply overwrites the beginning
+// of the fuction with a jump to 'trampoline_address'. The trampoline needs to be constructed with
+// 'CreateTrampoline' above.
+[[nodiscard]] ErrorMessageOr<void> InstrumentFunction(pid_t pid, uint64_t function_address,
+                                                      uint64_t address_of_instruction_after_jump,
+                                                      uint64_t trampoline_address);
+
+// Move every instruction pointer that was in the middle of an overwritten function prolog to
+// the corresponding place in the trampoline.
+void MoveInstructionPointersOutOfOverwrittenCode(
+    pid_t pid, const absl::flat_hash_map<uint64_t, uint64_t>& relocation_map);
 
 }  // namespace orbit_user_space_instrumentation
 

--- a/src/UserSpaceInstrumentation/Trampoline.h
+++ b/src/UserSpaceInstrumentation/Trampoline.h
@@ -120,11 +120,12 @@ struct RelocatedInstruction {
 // parameter. `function` contains the beginning of the function (kMaxFunctionPrologBackupSize bytes
 // or less if the function shorter). `capstone_handle` is a handle to the capstone disassembler
 // library returned by cs_open.
-// The function returns an error if it was no possible to instrument the function. For details on
+// The function returns an error if it was not possible to instrument the function. For details on
 // that see the comments at AppendRelocatedPrologCode. If the function is successful it will insert
 // an address pair into `relocation_map` for each instruction it relocated from the beginning of the
 // function into the trampoline (needed for moving instruction pointers away from the overwritten
-// bytes at the beginning of the function).
+// bytes at the beginning of the function, compare MoveInstructionPointersOutOfOverwrittenCode
+// below).
 // The return value is the address of the first instruction not relocated into the trampoline (i.e.
 // the address the trampoline jump back to).
 [[nodiscard]] ErrorMessageOr<uint64_t> CreateTrampoline(

--- a/src/UserSpaceInstrumentation/Trampoline.h
+++ b/src/UserSpaceInstrumentation/Trampoline.h
@@ -117,17 +117,16 @@ struct RelocatedInstruction {
 
 // Creates a trampoline for the function at `function_address`. The trampoline is built at
 // `trampoline_address`. The trampoline will call `payload_address` with `function_address` as a
-// parameter. `function` contains the beginning of the function (kMaxFunctionPrologBackupSize bytes
-// or less if the function shorter). `capstone_handle` is a handle to the capstone disassembler
-// library returned by cs_open.
-// The function returns an error if it was not possible to instrument the function. For details on
-// that see the comments at AppendRelocatedPrologCode. If the function is successful it will insert
-// an address pair into `relocation_map` for each instruction it relocated from the beginning of the
-// function into the trampoline (needed for moving instruction pointers away from the overwritten
-// bytes at the beginning of the function, compare MoveInstructionPointersOutOfOverwrittenCode
-// below).
-// The return value is the address of the first instruction not relocated into the trampoline (i.e.
-// the address the trampoline jump back to).
+// parameter. `function` contains the beginning of the function (kMaxFunctionPrologueBackupSize
+// bytes or less if the function shorter). `capstone_handle` is a handle to the capstone
+// disassembler library returned by cs_open. The function returns an error if it was not possible to
+// instrument the function. For details on that see the comments at AppendRelocatedPrologueCode. If
+// the function is successful it will insert an address pair into `relocation_map` for each
+// instruction it relocated from the beginning of the function into the trampoline (needed for
+// moving instruction pointers away from the overwritten bytes at the beginning of the function,
+// compare MoveInstructionPointersOutOfOverwrittenCode below). The return value is the address of
+// the first instruction not relocated into the trampoline (i.e. the address the trampoline jump
+// back to).
 [[nodiscard]] ErrorMessageOr<uint64_t> CreateTrampoline(
     pid_t pid, uint64_t function_address, const std::vector<uint8_t>& function,
     uint64_t trampoline_address, uint64_t payload_address, csh capstone_handle,
@@ -140,7 +139,7 @@ struct RelocatedInstruction {
                                                       uint64_t address_of_instruction_after_jump,
                                                       uint64_t trampoline_address);
 
-// Move every instruction pointer that was in the middle of an overwritten function prolog to
+// Move every instruction pointer that was in the middle of an overwritten function prologue to
 // the corresponding place in the trampoline.
 void MoveInstructionPointersOutOfOverwrittenCode(
     pid_t pid, const absl::flat_hash_map<uint64_t, uint64_t>& relocation_map);

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -615,12 +615,14 @@ class InstrumentFunctionTest : public testing::Test {
     cs_close(&capstone_handle_);
 
     // Detach and end child.
-    CHECK(!DetachAndContinueProcess(pid_).has_error());
-    kill(pid_, SIGKILL);
-    waitpid(pid_, NULL, 0);
+    if (pid_ != -1) {
+      CHECK(!DetachAndContinueProcess(pid_).has_error());
+      kill(pid_, SIGKILL);
+      waitpid(pid_, NULL, 0);
+    }
   }
 
-  pid_t pid_;
+  pid_t pid_ = -1;
   cs_insn* instruction_ = nullptr;
   csh capstone_handle_ = 0;
   uint64_t max_trampoline_size_ = 0;
@@ -674,6 +676,10 @@ extern "C" __attribute__((naked)) int TooShort() {
 }
 
 TEST_F(InstrumentFunctionTest, TooShort) {
+#ifdef ORBIT_COVERAGE_BUILD
+    GTEST_SKIP() << "Skipping since g++ is not handing __attribute__((naked)) appropriatly which "
+                    "is required for these tests.";
+#endif
   RunChild(&TooShort, "TooShort");
   PrepareInstrumentation("TrivialLog");
   ErrorMessageOr<uint64_t> result =
@@ -882,6 +888,10 @@ extern "C" __attribute__((naked)) int Loop() {
 }
 
 TEST_F(InstrumentFunctionTest, Loop) {
+#ifdef ORBIT_COVERAGE_BUILD
+    GTEST_SKIP() << "Skipping since g++ is not handing __attribute__((naked)) appropriatly which "
+                    "is required for these tests.";
+#endif
   RunChild(&Loop, "Loop");
   PrepareInstrumentation("TrivialLog");
   ErrorMessageOr<uint64_t> result =

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -586,8 +586,8 @@ class InstrumentFunctionTest : public testing::Test {
     trampoline_address_ = trampoline_or_error.value();
 
     // Copy the beginning of the function over into this process.
-    constexpr uint64_t kMaxFunctionPrologBackupSize = 20;
-    const uint64_t bytes_to_copy = std::min(size_of_function, kMaxFunctionPrologBackupSize);
+    constexpr uint64_t kMaxFunctionPrologueBackupSize = 20;
+    const uint64_t bytes_to_copy = std::min(size_of_function, kMaxFunctionPrologueBackupSize);
     ErrorMessageOr<std::vector<uint8_t>> function_backup =
         ReadTraceesMemory(pid_, function_address_, bytes_to_copy);
     CHECK(function_backup.has_value());
@@ -635,10 +635,10 @@ class InstrumentFunctionTest : public testing::Test {
   std::vector<uint8_t> function_code_;
 };
 
-// Function with an ordinary compiler-synthesised prolog; performs some arithmetics. Most real world
-// functions will look like this (starting with pushing the stack frame...). Most functions below
-// are declared "naked", i.e. without the prolog and implemented entirely in assembly. This is done
-// to also cover edge cases.
+// Function with an ordinary compiler-synthesised prologue; performs some arithmetics. Most real
+// world functions will look like this (starting with pushing the stack frame...). Most functions
+// below are declared "naked", i.e. without the prologue and implemented entirely in assembly. This
+// is done to also cover edge cases.
 extern "C" int DoSomething() {
   std::random_device rd;
   std::mt19937 gen(rd());
@@ -652,12 +652,12 @@ extern "C" int DoSomething() {
 TEST_F(InstrumentFunctionTest, DoSomething) {
   RunChild(&DoSomething, "DoSomething");
   PrepareInstrumentation("TrivialLog");
-  ErrorMessageOr<uint64_t> address_after_prolog_or_error =
+  ErrorMessageOr<uint64_t> address_after_prologue_or_error =
       CreateTrampoline(pid_, function_address_, function_code_, trampoline_address_,
                        payload_function_address_, capstone_handle_, relocation_map_);
-  EXPECT_THAT(address_after_prolog_or_error, HasNoError());
+  EXPECT_THAT(address_after_prologue_or_error, HasNoError());
   ErrorMessageOr<void> result = InstrumentFunction(
-      pid_, function_address_, address_after_prolog_or_error.value(), trampoline_address_);
+      pid_, function_address_, address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
 }
@@ -705,12 +705,12 @@ extern "C" __attribute__((naked)) int LongEnough() {
 TEST_F(InstrumentFunctionTest, LongEnough) {
   RunChild(&LongEnough, "LongEnough");
   PrepareInstrumentation("TrivialLog");
-  ErrorMessageOr<uint64_t> address_after_prolog_or_error =
+  ErrorMessageOr<uint64_t> address_after_prologue_or_error =
       CreateTrampoline(pid_, function_address_, function_code_, trampoline_address_,
                        payload_function_address_, capstone_handle_, relocation_map_);
-  EXPECT_THAT(address_after_prolog_or_error, HasNoError());
+  EXPECT_THAT(address_after_prologue_or_error, HasNoError());
   ErrorMessageOr<void> result = InstrumentFunction(
-      pid_, function_address_, address_after_prolog_or_error.value(), trampoline_address_);
+      pid_, function_address_, address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
 }
@@ -731,12 +731,12 @@ extern "C" __attribute__((naked)) int RipRelativeAddressing() {
 TEST_F(InstrumentFunctionTest, RipRelativeAddressing) {
   RunChild(&RipRelativeAddressing, "RipRelativeAddressing");
   PrepareInstrumentation("TrivialLog");
-  ErrorMessageOr<uint64_t> address_after_prolog_or_error =
+  ErrorMessageOr<uint64_t> address_after_prologue_or_error =
       CreateTrampoline(pid_, function_address_, function_code_, trampoline_address_,
                        payload_function_address_, capstone_handle_, relocation_map_);
-  EXPECT_THAT(address_after_prolog_or_error, HasNoError());
+  EXPECT_THAT(address_after_prologue_or_error, HasNoError());
   ErrorMessageOr<void> result = InstrumentFunction(
-      pid_, function_address_, address_after_prolog_or_error.value(), trampoline_address_);
+      pid_, function_address_, address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
 }
@@ -758,12 +758,12 @@ extern "C" __attribute__((naked)) int UnconditionalJump8BitOffset() {
 TEST_F(InstrumentFunctionTest, UnconditionalJump8BitOffset) {
   RunChild(&UnconditionalJump8BitOffset, "UnconditionalJump8BitOffset");
   PrepareInstrumentation("TrivialLog");
-  ErrorMessageOr<uint64_t> address_after_prolog_or_error =
+  ErrorMessageOr<uint64_t> address_after_prologue_or_error =
       CreateTrampoline(pid_, function_address_, function_code_, trampoline_address_,
                        payload_function_address_, capstone_handle_, relocation_map_);
-  EXPECT_THAT(address_after_prolog_or_error, HasNoError());
+  EXPECT_THAT(address_after_prologue_or_error, HasNoError());
   ErrorMessageOr<void> result = InstrumentFunction(
-      pid_, function_address_, address_after_prolog_or_error.value(), trampoline_address_);
+      pid_, function_address_, address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
 }
@@ -783,12 +783,12 @@ extern "C" __attribute__((naked)) int UnconditionalJump32BitOffset() {
 TEST_F(InstrumentFunctionTest, UnconditionalJump32BitOffset) {
   RunChild(&UnconditionalJump32BitOffset, "UnconditionalJump32BitOffset");
   PrepareInstrumentation("TrivialLog");
-  ErrorMessageOr<uint64_t> address_after_prolog_or_error =
+  ErrorMessageOr<uint64_t> address_after_prologue_or_error =
       CreateTrampoline(pid_, function_address_, function_code_, trampoline_address_,
                        payload_function_address_, capstone_handle_, relocation_map_);
-  EXPECT_THAT(address_after_prolog_or_error, HasNoError());
+  EXPECT_THAT(address_after_prologue_or_error, HasNoError());
   ErrorMessageOr<void> result = InstrumentFunction(
-      pid_, function_address_, address_after_prolog_or_error.value(), trampoline_address_);
+      pid_, function_address_, address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
 }
@@ -809,12 +809,12 @@ extern "C" __attribute__((naked)) int CallFunction() {
 TEST_F(InstrumentFunctionTest, CallFunction) {
   RunChild(&CallFunction, "CallFunction");
   PrepareInstrumentation("TrivialLog");
-  ErrorMessageOr<uint64_t> address_after_prolog_or_error =
+  ErrorMessageOr<uint64_t> address_after_prologue_or_error =
       CreateTrampoline(pid_, function_address_, function_code_, trampoline_address_,
                        payload_function_address_, capstone_handle_, relocation_map_);
-  EXPECT_THAT(address_after_prolog_or_error, HasNoError());
+  EXPECT_THAT(address_after_prologue_or_error, HasNoError());
   ErrorMessageOr<void> result = InstrumentFunction(
-      pid_, function_address_, address_after_prolog_or_error.value(), trampoline_address_);
+      pid_, function_address_, address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
 }
@@ -836,12 +836,12 @@ extern "C" __attribute__((naked)) int ConditionalJump8BitOffset() {
 TEST_F(InstrumentFunctionTest, ConditionalJump8BitOffset) {
   RunChild(&ConditionalJump8BitOffset, "ConditionalJump8BitOffset");
   PrepareInstrumentation("TrivialLog");
-  ErrorMessageOr<uint64_t> address_after_prolog_or_error =
+  ErrorMessageOr<uint64_t> address_after_prologue_or_error =
       CreateTrampoline(pid_, function_address_, function_code_, trampoline_address_,
                        payload_function_address_, capstone_handle_, relocation_map_);
-  EXPECT_THAT(address_after_prolog_or_error, HasNoError());
+  EXPECT_THAT(address_after_prologue_or_error, HasNoError());
   ErrorMessageOr<void> result = InstrumentFunction(
-      pid_, function_address_, address_after_prolog_or_error.value(), trampoline_address_);
+      pid_, function_address_, address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
 }
@@ -864,12 +864,12 @@ extern "C" __attribute__((naked)) int ConditionalJump32BitOffset() {
 TEST_F(InstrumentFunctionTest, ConditionalJump32BitOffset) {
   RunChild(&ConditionalJump32BitOffset, "ConditionalJump32BitOffset");
   PrepareInstrumentation("TrivialLog");
-  ErrorMessageOr<uint64_t> address_after_prolog_or_error =
+  ErrorMessageOr<uint64_t> address_after_prologue_or_error =
       CreateTrampoline(pid_, function_address_, function_code_, trampoline_address_,
                        payload_function_address_, capstone_handle_, relocation_map_);
-  EXPECT_THAT(address_after_prolog_or_error, HasNoError());
+  EXPECT_THAT(address_after_prologue_or_error, HasNoError());
   ErrorMessageOr<void> result = InstrumentFunction(
-      pid_, function_address_, address_after_prolog_or_error.value(), trampoline_address_);
+      pid_, function_address_, address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
 }
@@ -921,12 +921,12 @@ TEST_F(InstrumentFunctionTest, CheckIntParameters) {
     }
   }
   PrepareInstrumentation("ClobberParameterRegisters");
-  ErrorMessageOr<uint64_t> address_after_prolog_or_error =
+  ErrorMessageOr<uint64_t> address_after_prologue_or_error =
       CreateTrampoline(pid_, function_address_, function_code_, trampoline_address_,
                        payload_function_address_, capstone_handle_, relocation_map_);
-  EXPECT_THAT(address_after_prolog_or_error, HasNoError());
+  EXPECT_THAT(address_after_prologue_or_error, HasNoError());
   ErrorMessageOr<void> result = InstrumentFunction(
-      pid_, function_address_, address_after_prolog_or_error.value(), trampoline_address_);
+      pid_, function_address_, address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
 }
@@ -950,12 +950,12 @@ TEST_F(InstrumentFunctionTest, CheckFloatParameters) {
     }
   }
   PrepareInstrumentation("ClobberXmmRegisters");
-  ErrorMessageOr<uint64_t> address_after_prolog_or_error =
+  ErrorMessageOr<uint64_t> address_after_prologue_or_error =
       CreateTrampoline(pid_, function_address_, function_code_, trampoline_address_,
                        payload_function_address_, capstone_handle_, relocation_map_);
-  EXPECT_THAT(address_after_prolog_or_error, HasNoError());
+  EXPECT_THAT(address_after_prologue_or_error, HasNoError());
   ErrorMessageOr<void> result = InstrumentFunction(
-      pid_, function_address_, address_after_prolog_or_error.value(), trampoline_address_);
+      pid_, function_address_, address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
 }
@@ -984,12 +984,12 @@ TEST_F(InstrumentFunctionTest, CheckM256iParameters) {
     }
   }
   PrepareInstrumentation("ClobberYmmRegisters");
-  ErrorMessageOr<uint64_t> address_after_prolog_or_error =
+  ErrorMessageOr<uint64_t> address_after_prologue_or_error =
       CreateTrampoline(pid_, function_address_, function_code_, trampoline_address_,
                        payload_function_address_, capstone_handle_, relocation_map_);
-  EXPECT_THAT(address_after_prolog_or_error, HasNoError());
+  EXPECT_THAT(address_after_prologue_or_error, HasNoError());
   ErrorMessageOr<void> result = InstrumentFunction(
-      pid_, function_address_, address_after_prolog_or_error.value(), trampoline_address_);
+      pid_, function_address_, address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
 }

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -677,8 +677,8 @@ extern "C" __attribute__((naked)) int TooShort() {
 
 TEST_F(InstrumentFunctionTest, TooShort) {
 #ifdef ORBIT_COVERAGE_BUILD
-    GTEST_SKIP() << "Skipping since g++ is not handing __attribute__((naked)) appropriatly which "
-                    "is required for these tests.";
+  GTEST_SKIP() << "Skipping since g++ is not handing __attribute__((naked)) appropriatly which "
+                  "is required for these tests.";
 #endif
   RunChild(&TooShort, "TooShort");
   PrepareInstrumentation("TrivialLog");
@@ -889,8 +889,8 @@ extern "C" __attribute__((naked)) int Loop() {
 
 TEST_F(InstrumentFunctionTest, Loop) {
 #ifdef ORBIT_COVERAGE_BUILD
-    GTEST_SKIP() << "Skipping since g++ is not handing __attribute__((naked)) appropriatly which "
-                    "is required for these tests.";
+  GTEST_SKIP() << "Skipping since g++ is not handing __attribute__((naked)) appropriatly which "
+                  "is required for these tests.";
 #endif
   RunChild(&Loop, "Loop");
   PrepareInstrumentation("TrivialLog");

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -633,7 +633,7 @@ class InstrumentFunctionTest : public testing::Test {
   std::vector<uint8_t> function_code_;
 };
 
-// Function with an ordinary compiler synthesised prolog; performs some arithmetics. Most real world
+// Function with an ordinary compiler-synthesised prolog; performs some arithmetics. Most real world
 // functions will look like this (starting with pushing the stack frame...). Most functions below
 // are declared "naked", i.e. without the prolog and implemented entirely in assembly. This is done
 // to also cover edge cases.
@@ -898,9 +898,10 @@ extern "C" int CheckIntParameters(u_int64_t p0, u_int64_t p1, u_int64_t p2, u_in
   return 0;
 }
 
-// This test and the two tests below check for proper handling of parameters handed of the
+// This test and the two tests below check for proper handling of parameters handed to the
 // instrumented function. The payload that is called before the instrumented function is executed
-// clobbers
+// clobbers the respective set of registers. So the Check*Parameter methods can check if the backup
+// worked correctly.
 TEST_F(InstrumentFunctionTest, CheckIntParameters) {
   function_name_ = "CheckIntParameters";
   pid_ = fork();

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -535,7 +535,7 @@ class InstrumentFunctionTest : public testing::Test {
     auto modules = orbit_object_utils::ReadModules(pid_);
     CHECK(!modules.has_error());
     std::string module_file_path;
-    AddressRange address_range_code;
+    AddressRange address_range_code(0, 0);
     for (const auto& m : modules.value()) {
       if (m.name() == "UserSpaceInstrumentationTests") {
         module_file_path = m.file_path();
@@ -543,6 +543,7 @@ class InstrumentFunctionTest : public testing::Test {
         address_range_code.end = m.address_end();
       }
     }
+    CHECK(!module_file_path.empty());
     auto elf_file = orbit_object_utils::CreateElfFile(module_file_path);
     CHECK(!elf_file.has_error());
     auto syms = elf_file.value()->LoadDebugSymbols();

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -676,9 +676,8 @@ extern "C" __attribute__((naked)) int TooShort() {
 }
 
 TEST_F(InstrumentFunctionTest, TooShort) {
-#ifdef ORBIT_COVERAGE_BUILD
-  GTEST_SKIP() << "Skipping since g++ is not handing __attribute__((naked)) appropriatly which "
-                  "is required for these tests.";
+#if defined(ORBIT_COVERAGE_BUILD) || (__GNUC__ == 9)
+  GTEST_SKIP();
 #endif
   RunChild(&TooShort, "TooShort");
   PrepareInstrumentation("TrivialLog");
@@ -888,9 +887,8 @@ extern "C" __attribute__((naked)) int Loop() {
 }
 
 TEST_F(InstrumentFunctionTest, Loop) {
-#ifdef ORBIT_COVERAGE_BUILD
-  GTEST_SKIP() << "Skipping since g++ is not handing __attribute__((naked)) appropriatly which "
-                  "is required for these tests.";
+#if defined(ORBIT_COVERAGE_BUILD) || (__GNUC__ == 9)
+  GTEST_SKIP();
 #endif
   RunChild(&Loop, "Loop");
   PrepareInstrumentation("TrivialLog");

--- a/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.cpp
+++ b/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.cpp
@@ -69,7 +69,7 @@ void TrivialLog(uint64_t function_address) {
   constexpr std::chrono::duration<int, std::ratio<1, 1000000>> k500Microseconds(500);
   static system_clock::time_point last_logged_event = system_clock::now() - 2 * k500Microseconds;
   static uint64_t skipped = 0;
-  // Rate limit log output to once every three milliseconds.
+  // Rate limit log output to once every 500 microseconds.
   const system_clock::time_point now = system_clock::now();
   if (now - last_logged_event > k500Microseconds) {
     if (skipped > 0) {

--- a/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.cpp
+++ b/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.cpp
@@ -4,8 +4,81 @@
 
 #include "UserSpaceInstrumentationTestLib.h"
 
+#include <stdio.h>
+
+#include <chrono>
+
 int TrivialFunction() { return 42; }
 
 uint64_t TrivialSum(uint64_t p0, uint64_t p1, uint64_t p2, uint64_t p3, uint64_t p4, uint64_t p5) {
   return p0 + p1 + p2 + p3 + p4 + p5;
+}
+
+// rdi, rsi, rdx, rcx, r8, r9, rax, r10
+void ClobberParameterRegisters(uint64_t) {
+  __asm__ __volatile__(
+      "mov $0xffffffffffffffff, %%rdi\n\t"
+      "mov $0xffffffffffffffff, %%rsi\n\t"
+      "mov $0xffffffffffffffff, %%rdx\n\t"
+      "mov $0xffffffffffffffff, %%rcx\n\t"
+      "mov $0xffffffffffffffff, %%r8\n\t"
+      "mov $0xffffffffffffffff, %%r9\n\t"
+      "mov $0xffffffffffffffff, %%rax\n\t"
+      "mov $0xffffffffffffffff, %%r10\n\t"
+      :
+      :
+      :);
+}
+
+void ClobberXmmRegisters(uint64_t) {
+  __asm__ __volatile__(
+      "movdqu 0x3a(%%rip), %%xmm0\n\t"
+      "movdqu 0x32(%%rip), %%xmm1\n\t"
+      "movdqu 0x2a(%%rip), %%xmm2\n\t"
+      "movdqu 0x22(%%rip), %%xmm3\n\t"
+      "movdqu 0x1a(%%rip), %%xmm4\n\t"
+      "movdqu 0x12(%%rip), %%xmm5\n\t"
+      "movdqu 0x0a(%%rip), %%xmm6\n\t"
+      "movdqu 0x02(%%rip), %%xmm7\n\t"
+      "jmp .+0x12 \n\t"
+      ".quad 0xffffffffffffffff, 0xffffffffffffffff \n\t"
+      :
+      :
+      :);
+}
+
+void ClobberYmmRegisters(uint64_t) {
+  __asm__ __volatile__(
+      "vmovdqu 0x3a(%%rip), %%ymm0\n\t"
+      "vmovdqu 0x32(%%rip), %%ymm1\n\t"
+      "vmovdqu 0x2a(%%rip), %%ymm2\n\t"
+      "vmovdqu 0x22(%%rip), %%ymm3\n\t"
+      "vmovdqu 0x1a(%%rip), %%ymm4\n\t"
+      "vmovdqu 0x12(%%rip), %%ymm5\n\t"
+      "vmovdqu 0x0a(%%rip), %%ymm6\n\t"
+      "vmovdqu 0x02(%%rip), %%ymm7\n\t"
+      "jmp .+0x22 \n\t"
+      ".quad 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff \n\t"
+      :
+      :
+      :);
+}
+
+void TrivialLog(uint64_t function_address) {
+  using std::chrono::system_clock;
+  constexpr std::chrono::duration<int, std::ratio<1, 1000000>> k500Microseconds(500);
+  static system_clock::time_point last_logged_event = system_clock::now() - 2 * k500Microseconds;
+  static uint64_t skipped = 0;
+  // Rate limit log output to once every three milliseconds.
+  const system_clock::time_point now = system_clock::now();
+  if (now - last_logged_event > k500Microseconds) {
+    if (skipped > 0) {
+      printf(" ( %lu skipped events )\n", skipped);
+    }
+    printf("Called function at %#lx\n", function_address);
+    last_logged_event = now;
+    skipped = 0;
+  } else {
+    skipped++;
+  }
 }

--- a/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.h
+++ b/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.h
@@ -8,7 +8,7 @@
 #include <cstdint>
 
 // This library is merely used in tests: The tests inject a binary produced by this code into its
-// child and uses the functions defined here.
+// child and use the functions defined here.
 
 // Returns 42.
 extern "C" int TrivialFunction();
@@ -19,7 +19,7 @@ extern "C" uint64_t TrivialSum(uint64_t p0, uint64_t p1, uint64_t p2, uint64_t p
 
 // Overwrites rdi, rsi, rdx, rcx, r8, r9, rax, r10. These registers are used to hand over parameters
 // to a called function. This function is used to assert our backup of these registers works
-// properly. The two functions bleow do the same thing for SSE/AVX registers that can be used to
+// properly. The two functions below do the same thing for SSE/AVX registers that can be used to
 // hand over floating point parameters.
 extern "C" void ClobberParameterRegisters(uint64_t);
 extern "C" void ClobberXmmRegisters(uint64_t);

--- a/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.h
+++ b/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.h
@@ -7,8 +7,8 @@
 
 #include <cstdint>
 
-// This library is merely used in tests: The test  injects a binary produced by this code into its
-// child.
+// This library is merely used in tests: The tests inject a binary produced by this code into its
+// child and uses the functions defined here.
 
 // Returns 42.
 extern "C" int TrivialFunction();
@@ -16,5 +16,16 @@ extern "C" int TrivialFunction();
 // Returns sum of the parameters.
 extern "C" uint64_t TrivialSum(uint64_t p0, uint64_t p1, uint64_t p2, uint64_t p3, uint64_t p4,
                                uint64_t p5);
+
+// Overwrites rdi, rsi, rdx, rcx, r8, r9, rax, r10. These registers are used to hand over parameters
+// to a called function. This function is used to assert our backup of these registers works
+// properly. The two functions bleow do the same thing for SSE/AVX registers that can be used to
+// hand over floating point parameters.
+extern "C" void ClobberParameterRegisters(uint64_t);
+extern "C" void ClobberXmmRegisters(uint64_t);
+extern "C" void ClobberYmmRegisters(uint64_t);
+
+// Uses printf to log.
+extern "C" void TrivialLog(uint64_t function_address);
 
 #endif  // USER_SPACE_INSTRUMENTATION_TEST_LIB_H_

--- a/third_party/conan/configs/linux/profiles/coverage_clang9
+++ b/third_party/conan/configs/linux/profiles/coverage_clang9
@@ -1,5 +1,5 @@
 include(clang9_relwithdebinfo)
 
 [env]
-CFLAGS=$C_FLAGS -fprofile-instr-generate="%m.profraw" -fcoverage-mapping
-CXXFLAGS=$CXX_FLAGS -fprofile-instr-generate="%m.profraw" -fcoverage-mapping
+CFLAGS=$C_FLAGS -fprofile-instr-generate="%m.profraw" -fcoverage-mapping -DORBIT_COVERAGE_BUILD
+CXXFLAGS=$CXX_FLAGS -fprofile-instr-generate="%m.profraw" -fcoverage-mapping -DORBIT_COVERAGE_BUILD


### PR DESCRIPTION
Implements 'CreateTrampoline' to create the code segment that inserts a
call to some payload before a specified function. 'InstrumentFunction'
then overwrites the beginning of the function with a jump into this
trampoline.

Bug: http://b/181304263
Test: Unit tests in PR.