### PR TITLE
Fix OrbitGgp Client and ClientTest

### DIFF
--- a/src/OrbitGgp/CMakeLists.txt
+++ b/src/OrbitGgp/CMakeLists.txt
@@ -67,4 +67,4 @@ target_link_libraries(OrbitGgpTests PRIVATE
 set_target_properties(OrbitGgpTests PROPERTIES AUTOMOC ON)
 set_target_properties(OrbitGgpTests PROPERTIES AUTOUIC ON)
 
-register_test(OrbitGgpTests PROPERTIES DISABLED TRUE)
+register_test(OrbitGgpTests)

--- a/src/OrbitGgp/Client.cpp
+++ b/src/OrbitGgp/Client.cpp
@@ -22,8 +22,6 @@ namespace orbit_ggp {
 
 namespace {
 
-constexpr int kAdditionalSynchronousTimeoutInMs = 20;
-
 void RunProcessWithTimeout(const QString& program, const QStringList& arguments,
                            std::chrono::milliseconds timeout, QObject* parent,
                            const std::function<void(outcome::result<QByteArray>)>& callback) {
@@ -35,12 +33,11 @@ void RunProcessWithTimeout(const QString& program, const QStringList& arguments,
 
   QObject::connect(timeout_timer, &QTimer::timeout, parent,
                    [process, timeout_timer, timeout, callback]() {
-                     if (process && !process->waitForFinished(kAdditionalSynchronousTimeoutInMs)) {
+                     if (process && process->state() != QProcess::NotRunning) {
                        ERROR("Process request timed out after %dms", timeout.count());
                        callback(Error::kRequestTimedOut);
                        if (process) {
                          process->terminate();
-                         process->waitForFinished();
                          process->deleteLater();
                        }
                      }

--- a/src/OrbitGgp/ClientTest.cpp
+++ b/src/OrbitGgp/ClientTest.cpp
@@ -25,7 +25,9 @@ TEST(OrbitGgpClient, CreateFailing) {
   {
     constexpr const char* kNonExistentProgram = "path/to/not/existing/program";
     auto client = Client::Create(nullptr, kNonExistentProgram);
-    EXPECT_THAT(client, HasError("No such file or directory"));
+    // The error messages on Windows and Linux are different, the only common part is the word
+    // "file".
+    EXPECT_THAT(client, HasError("file"));
   }
   {
     const std::filesystem::path mock_ggp_failing =

--- a/src/OrbitGgp/MockGgp/Working.cpp
+++ b/src/OrbitGgp/MockGgp/Working.cpp
@@ -65,7 +65,7 @@ int main(int argc, char* argv[]) {
   // 1. The ggp cli which this program is mocking, does have quite a bit of delay, hence having a
   // delay in this mock program, mimics the behaviour of the real ggp cli more closely
   // 2. To test the timeout functionaliy in OrbitGgp::Client
-  std::this_thread::sleep_for(std::chrono::milliseconds{30});
+  std::this_thread::sleep_for(std::chrono::milliseconds{50});
 
   switch (argc) {
     case 2:


### PR DESCRIPTION
Remove an additional second waiting time from RunProcessWithTimeout.
Increase the delay of MockGgpWorking by 20ms. Fix a test string in
ClientTest. (Re)Enable OrbitGgpTests

I let the test in question run extensively before I made this PR to make sure it is not flaky. 