### PR TITLE
Remove intersecting modules on AddOrUpdateModuleInfo

### DIFF
--- a/src/ClientData/include/ClientData/ProcessData.h
+++ b/src/ClientData/include/ClientData/ProcessData.h
@@ -69,7 +69,12 @@ class ProcessData final {
   [[nodiscard]] const std::string& build_id() const;
 
   void UpdateModuleInfos(absl::Span<const orbit_grpc_protos::ModuleInfo> module_infos);
-  void AddOrUpdateModuleInfo(const orbit_grpc_protos::ModuleInfo& module_infos);
+
+  // This method removes all modules with addresses intersecting with module_info.
+  // Some background on this. The service currently does not send any unmap event
+  // to the client, which means that if the client receives a module with mapping
+  // intersecting with exiting mapping the old module was likely unloaded.
+  void AddOrUpdateModuleInfo(const orbit_grpc_protos::ModuleInfo& module_info);
 
   [[nodiscard]] ErrorMessageOr<ModuleInMemory> FindModuleByAddress(uint64_t absolute_address) const;
 


### PR DESCRIPTION
Also fix a bug where module was incorrectly found when looking
for it by the end address. Note that end address could be
another module start address.

Test: run ClientDataTests
Bug: http://b/190805289