### PR TITLE
Add CI specific conan profiles

### DIFF
--- a/kokoro/builds/build.sh
+++ b/kokoro/builds/build.sh
@@ -90,14 +90,6 @@ if [ -n "$1" ]; then
   }
   trap cleanup EXIT
 
-  # TODO(b/179358697): Temporary Ninja hack - will be removed when we move to Ninja in general
-  if [[ $CONAN_PROFILE == "msvc2017_relwithdebinfo" ]]; then
-    CONAN_PROFILE="msvc2017_relwithdebinfo_ninja"
-  fi
-  if [[ $CONAN_PROFILE == "msvc2019_relwithdebinfo" ]]; then
-    CONAN_PROFILE="msvc2019_relwithdebinfo_ninja"
-  fi
-
   echo "Using conan profile ${CONAN_PROFILE} and performing a ${BUILD_TYPE} build."
 
   set +e

--- a/third_party/conan/configs/install.ps1
+++ b/third_party/conan/configs/install.ps1
@@ -40,6 +40,12 @@ if (Test-Path Env:ORBIT_OVERRIDE_ARTIFACTORY_URL) {
     if ($process.ExitCode -ne 0) { Throw "Error while adding conan remote." }
 
     conan_disable_public_remotes
+
+    if (Test-Path -Path "$PSScriptRoot\windows_ci") {
+      Write-Host "Found CI-specific Conan config. Installing that as well..."
+      $process = Start-Process $conan.Path -Wait -NoNewWindow -ErrorAction Stop -PassThru -ArgumentList "config", "install", "$PSScriptRoot\windows_ci"
+      if ($process.ExitCode -ne 0) { Throw "Error while installing conan config." }
+    }
   } catch {
     try {
       $response = Invoke-WebRequest -URI http://orbit-artifactory/ -ErrorAction Ignore -MaximumRedirection 0 -UseBasicParsing

--- a/third_party/conan/configs/install.sh
+++ b/third_party/conan/configs/install.sh
@@ -49,6 +49,11 @@ else
     echo "CI machine detected. Adjusting remotes..."
     conan remote add -i 0 -f artifactory "http://artifactory.internal/artifactory/api/conan/conan" || exit $?
     conan_disable_public_remotes || exit $?
+
+    if [ -d "${DIR}/${OS}_ci" ]; then
+      echo "Found CI-specific Conan config. Installing that as well..."
+      conan config install "${DIR}/${OS}_ci" || exit $?
+    fi
   else
     LOCATION="$(curl -sI http://orbit-artifactory/ 2>/dev/null)"
 

--- a/third_party/conan/configs/windows_ci/profiles/msvc2019_relwithdebinfo
+++ b/third_party/conan/configs/windows_ci/profiles/msvc2019_relwithdebinfo
@@ -1,6 +1,7 @@
-include(msvc2019_relwithdebinfo)
+include(msvc2019_common)
 
 [settings]
+build_type=RelWithDebInfo
 ninja:build_type=Release
 llvmpipe:build_type=Release
 


### PR DESCRIPTION
This is adding a generic mechanism to have CI-specific conan configurations which differ from the settings we use for developer builds.

Of course in general we want to keep CI-builds as close to dev-builds as possible. But there are two use-cases which make this viable:

- We use Ninja for Windows builds on the CI because it's faster than MSBuild. We can't move (yet) to Ninja for dev-builds because that breaks the Visual Studio development workflow.
- We need to deploy the MESA llvmpipe OpenGL software rendering library with Orbit releases. This is done by conan - but only in CI builds.

Test: Checked CI logfile. The new config is found and installed and the build is done with Ninja, etc.