### PR TITLE
Simplify TriangleToggle State and Usage.

### DIFF
--- a/src/OrbitGl/AccessibleTriangleToggle.cpp
+++ b/src/OrbitGl/AccessibleTriangleToggle.cpp
@@ -15,7 +15,7 @@ AccessibleTriangleToggle::AccessibleTriangleToggle(TriangleToggle* triangle_togg
       parent_{parent} {}
 
 orbit_accessibility::AccessibilityState AccessibleTriangleToggle::AccessibleState() const {
-  if (triangle_toggle_->IsInactive()) {
+  if (triangle_toggle_->IsCollapsible()) {
     return orbit_accessibility::AccessibilityState::Disabled;
   }
   return orbit_accessibility::AccessibilityState::Normal;

--- a/src/OrbitGl/AccessibleTriangleToggle.cpp
+++ b/src/OrbitGl/AccessibleTriangleToggle.cpp
@@ -16,9 +16,9 @@ AccessibleTriangleToggle::AccessibleTriangleToggle(TriangleToggle* triangle_togg
 
 orbit_accessibility::AccessibilityState AccessibleTriangleToggle::AccessibleState() const {
   if (triangle_toggle_->IsCollapsible()) {
-    return orbit_accessibility::AccessibilityState::Disabled;
+    return orbit_accessibility::AccessibilityState::Normal;
   }
-  return orbit_accessibility::AccessibilityState::Normal;
+  return orbit_accessibility::AccessibilityState::Disabled;
 }
 
 const orbit_accessibility::AccessibleInterface* AccessibleTriangleToggle::AccessibleParent() const {

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -78,8 +78,7 @@ FrameTrack::FrameTrack(CaptureViewElement* parent, TimeGraph* time_graph,
   SetLabel(name);
 
   // Frame tracks are collapsed by default.
-  collapse_toggle_->SetState(TriangleToggle::State::kCollapsed,
-                             TriangleToggle::InitialStateUpdate::kReplaceInitialState);
+  collapse_toggle_->SetCollapsed(true);
 }
 
 float FrameTrack::GetHeaderHeight() const { return layout_->GetTrackTabHeight(); }

--- a/src/OrbitGl/GpuDebugMarkerTrack.cpp
+++ b/src/OrbitGl/GpuDebugMarkerTrack.cpp
@@ -6,6 +6,7 @@
 
 #include <absl/time/time.h>
 
+#include <algorithm>
 #include <memory>
 
 #include "App.h"
@@ -32,10 +33,6 @@ GpuDebugMarkerTrack::GpuDebugMarkerTrack(CaptureViewElement* parent, TimeGraph* 
   SetLabel("Debug Markers");
   draw_background_ = false;
   string_manager_ = app->GetStringManager();
-
-  // Gpu subtracks are expanded by default, but are however not shown while the parent is collapsed.
-  collapse_toggle_->SetState(TriangleToggle::State::kExpanded,
-                             TriangleToggle::InitialStateUpdate::kReplaceInitialState);
 }
 
 std::string GpuDebugMarkerTrack::GetTooltip() const {
@@ -129,7 +126,7 @@ float GpuDebugMarkerTrack::GetYFromTimer(const TimerInfo& timer_info) const {
 
 float GpuDebugMarkerTrack::GetHeight() const {
   bool collapsed = collapse_toggle_->IsCollapsed();
-  uint32_t depth = collapsed ? 1 : GetDepth();
+  uint32_t depth = collapsed ? std::min<uint32_t>(1, GetDepth()) : GetDepth();
   return layout_->GetTrackTabHeight() + layout_->GetTextBoxHeight() * depth +
          layout_->GetTrackBottomMargin();
 }

--- a/src/OrbitGl/GpuSubmissionTrack.cpp
+++ b/src/OrbitGl/GpuSubmissionTrack.cpp
@@ -40,10 +40,6 @@ GpuSubmissionTrack::GpuSubmissionTrack(Track* parent, TimeGraph* time_graph,
   timeline_hash_ = timeline_hash;
   string_manager_ = app->GetStringManager();
   parent_ = parent;
-
-  // Gpu subtracks are expanded by default, but are however not shown while the parent is collapsed.
-  collapse_toggle_->SetState(TriangleToggle::State::kExpanded,
-                             TriangleToggle::InitialStateUpdate::kReplaceInitialState);
 }
 
 std::string GpuSubmissionTrack::GetTooltip() const {

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -70,8 +70,9 @@ GpuTrack::GpuTrack(CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::
   submission_track_->SetName(absl::StrFormat("%s_submissions", timeline));
   marker_track_->SetName(absl::StrFormat("%s_marker", timeline));
 
-  collapse_toggle_->SetState(TriangleToggle::State::kCollapsed,
-                             TriangleToggle::InitialStateUpdate::kReplaceInitialState);
+  // Gpu are expanded by default. Their subtracks are expanded by default, but are however not shown
+  // while the Gpu track is collapsed.
+  collapse_toggle_->SetCollapsed(true);
 }
 
 void GpuTrack::OnTimer(const TimerInfo& timer_info) {

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -70,8 +70,8 @@ GpuTrack::GpuTrack(CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::
   submission_track_->SetName(absl::StrFormat("%s_submissions", timeline));
   marker_track_->SetName(absl::StrFormat("%s_marker", timeline));
 
-  // Gpu are expanded by default. Their subtracks are expanded by default, but are however not shown
-  // while the Gpu track is collapsed.
+  // Gpu are collapsed by default. Their subtracks are expanded by default, but are however not
+  // shown while the Gpu track is collapsed.
   collapse_toggle_->SetCollapsed(true);
 }
 

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -383,9 +383,8 @@ std::string ThreadTrack::GetTooltip() const {
 }
 
 float ThreadTrack::GetHeight() const {
-  const bool is_collapsed = collapse_toggle_->IsCollapsed();
-  const uint32_t collapsed_depth = (GetNumTimers() == 0) ? 0 : 1;
-  const uint32_t depth = is_collapsed ? collapsed_depth : GetDepth();
+  const uint32_t depth =
+      collapse_toggle_->IsCollapsed() ? std::min<uint32_t>(1, GetDepth()) : GetDepth();
 
   bool gap_between_tracks_and_timers =
       (!thread_state_bar_->IsEmpty() || !event_bar_->IsEmpty() || !tracepoint_bar_->IsEmpty()) &&

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -337,7 +337,8 @@ void TimerTrack::OnTimer(const TimerInfo& timer_info) {
 }
 
 float TimerTrack::GetHeight() const {
-  uint32_t depth = collapse_toggle_->IsCollapsed() ? std::min<uint32_t>(1, GetDepth()) : GetDepth();
+  uint32_t collapsed_depth = std::min<uint32_t>(1, GetDepth());
+  uint32_t depth = collapse_toggle_->IsCollapsed() ? collapsed_depth : GetDepth();
   return GetHeaderHeight() + layout_->GetTextBoxHeight() * depth +
          (depth > 0 ? layout_->GetSpaceBetweenTracksAndThread() : 0) +
          layout_->GetTrackBottomMargin();

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -337,9 +337,7 @@ void TimerTrack::OnTimer(const TimerInfo& timer_info) {
 }
 
 float TimerTrack::GetHeight() const {
-  bool is_collapsed = collapse_toggle_->IsCollapsed();
-  uint32_t collapsed_depth = (GetNumTimers() == 0) ? 0 : 1;
-  uint32_t depth = is_collapsed ? collapsed_depth : GetDepth();
+  uint32_t depth = collapse_toggle_->IsCollapsed() ? std::min<uint32_t>(1, GetDepth()) : GetDepth();
   return GetHeaderHeight() + layout_->GetTextBoxHeight() * depth +
          (depth > 0 ? layout_->GetSpaceBetweenTracksAndThread() : 0) +
          layout_->GetTrackBottomMargin();

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -31,7 +31,6 @@ Track::Track(CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::Viewpo
   constexpr uint32_t kMaxIndentationLevel = 5;
   uint32_t capped_indentation_level = std::min(indentation_level, kMaxIndentationLevel);
   collapse_toggle_ = std::make_shared<TriangleToggle>(
-      false /*is_collapsed*/, true /*is_collapsible*/,
       [this](bool is_collapsed) { OnCollapseToggle(is_collapsed); }, time_graph, viewport, layout,
       this, 10.f - capped_indentation_level);
 

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -31,9 +31,9 @@ Track::Track(CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::Viewpo
   constexpr uint32_t kMaxIndentationLevel = 5;
   uint32_t capped_indentation_level = std::min(indentation_level, kMaxIndentationLevel);
   collapse_toggle_ = std::make_shared<TriangleToggle>(
-      TriangleToggle::State::kExpanded,
-      [this](TriangleToggle::State state) { OnCollapseToggle(state); }, time_graph, viewport,
-      layout, this, 10.f - capped_indentation_level);
+      false /*is_collapsed*/, true /*is_collapsible*/,
+      [this](bool is_collapsed) { OnCollapseToggle(is_collapsed); }, time_graph, viewport, layout,
+      this, 10.f - capped_indentation_level);
 
   const Color kDarkGrey(50, 50, 50, 255);
   color_ = kDarkGrey;
@@ -161,11 +161,7 @@ void Track::Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current
   }
 
   // Collapse toggle state management.
-  if (!this->IsCollapsible()) {
-    collapse_toggle_->SetState(TriangleToggle::State::kInactive);
-  } else if (collapse_toggle_->IsInactive()) {
-    collapse_toggle_->ResetToInitialState();
-  }
+  collapse_toggle_->SetIsCollapsible(this->IsCollapsible());
 
   // Draw collapsing triangle.
   const float toggle_y_pos =
@@ -233,7 +229,7 @@ Color Track::GetTrackBackgroundColor() const {
   return color_;
 }
 
-void Track::OnCollapseToggle(TriangleToggle::State /*state*/) { RequestUpdate(); }
+void Track::OnCollapseToggle(bool /*is_collapsed*/) { RequestUpdate(); }
 
 void Track::OnDrag(int x, int y) {
   CaptureViewElement::OnDrag(x, y);

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -89,7 +89,7 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
 
   [[nodiscard]] virtual Color GetTrackBackgroundColor() const;
 
-  virtual void OnCollapseToggle(TriangleToggle::State state);
+  virtual void OnCollapseToggle(bool is_collapsed);
   [[nodiscard]] virtual bool IsCollapsible() const { return false; }
   TriangleToggle* GetTriangleToggle() const { return collapse_toggle_.get(); }
   [[nodiscard]] int32_t GetProcessId() const { return process_id_; }

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -16,13 +16,11 @@
 #include "TimeGraph.h"
 #include "Track.h"
 
-TriangleToggle::TriangleToggle(bool is_collapsed, bool is_collapsible, StateChangeHandler handler,
-                               TimeGraph* time_graph, orbit_gl::Viewport* viewport,
-                               TimeGraphLayout* layout, Track* track, float size)
+TriangleToggle::TriangleToggle(StateChangeHandler handler, TimeGraph* time_graph,
+                               orbit_gl::Viewport* viewport, TimeGraphLayout* layout, Track* track,
+                               float size)
     : CaptureViewElement(track, time_graph, viewport, layout),
       track_(track),
-      is_collapsed_(is_collapsed),
-      is_collapsible_(is_collapsible),
       handler_(std::move(handler)) {
   SetSize(size, size);
 }

--- a/src/OrbitGl/TriangleToggle.h
+++ b/src/OrbitGl/TriangleToggle.h
@@ -18,9 +18,9 @@ class TriangleToggle : public orbit_gl::CaptureViewElement,
                        public std::enable_shared_from_this<TriangleToggle> {
  public:
   using StateChangeHandler = std::function<void(bool)>;
-  explicit TriangleToggle(bool is_collapsed, bool is_collapsible, StateChangeHandler handler,
-                          TimeGraph* time_graph, orbit_gl::Viewport* viewport,
-                          TimeGraphLayout* layout, Track* track, float size);
+  explicit TriangleToggle(StateChangeHandler handler, TimeGraph* time_graph,
+                          orbit_gl::Viewport* viewport, TimeGraphLayout* layout, Track* track,
+                          float size);
   ~TriangleToggle() override = default;
 
   TriangleToggle() = delete;
@@ -49,8 +49,8 @@ class TriangleToggle : public orbit_gl::CaptureViewElement,
   // We require explicit knowledge about the parent.
   Track* track_;
 
-  bool is_collapsed_;
-  bool is_collapsible_;
+  bool is_collapsed_ = false;
+  bool is_collapsible_ = true;
 
   StateChangeHandler handler_;
 };

--- a/src/OrbitGl/TriangleToggle.h
+++ b/src/OrbitGl/TriangleToggle.h
@@ -17,13 +17,10 @@ class Track;
 class TriangleToggle : public orbit_gl::CaptureViewElement,
                        public std::enable_shared_from_this<TriangleToggle> {
  public:
-  enum class State { kInactive, kExpanded, kCollapsed };
-  enum class InitialStateUpdate { kKeepInitialState, kReplaceInitialState };
-
-  using StateChangeHandler = std::function<void(TriangleToggle::State)>;
-  explicit TriangleToggle(State initial_state, StateChangeHandler handler, TimeGraph* time_graph,
-                          orbit_gl::Viewport* viewport, TimeGraphLayout* layout, Track* track,
-                          float size);
+  using StateChangeHandler = std::function<void(bool)>;
+  explicit TriangleToggle(bool is_collapsed, bool is_collapsible, StateChangeHandler handler,
+                          TimeGraph* time_graph, orbit_gl::Viewport* viewport,
+                          TimeGraphLayout* layout, Track* track, float size);
   ~TriangleToggle() override = default;
 
   TriangleToggle() = delete;
@@ -38,13 +35,10 @@ class TriangleToggle : public orbit_gl::CaptureViewElement,
   // Pickable
   void OnRelease() override;
 
-  State GetState() const { return state_; }
-  void SetState(State state,
-                InitialStateUpdate update_initial_state = InitialStateUpdate::kKeepInitialState);
-  void ResetToInitialState() { state_ = initial_state_; }
-  bool IsCollapsed() const { return state_ == State::kCollapsed; }
-  bool IsExpanded() const { return state_ == State::kExpanded; }
-  bool IsInactive() const { return state_ == State::kInactive; }
+  void SetCollapsed(bool is_collapsed) { is_collapsed_ = is_collapsed; }
+  [[nodiscard]] bool IsCollapsed() const { return is_collapsed_; }
+  void SetIsCollapsible(bool is_collapsible) { is_collapsible_ = is_collapsible; }
+  [[nodiscard]] bool IsCollapsible() const { return is_collapsible_; }
 
  protected:
   std::unique_ptr<orbit_accessibility::AccessibleInterface> CreateAccessibleInterface() override;
@@ -55,8 +49,9 @@ class TriangleToggle : public orbit_gl::CaptureViewElement,
   // We require explicit knowledge about the parent.
   Track* track_;
 
-  State state_ = State::kInactive;
-  State initial_state_ = State::kInactive;
+  bool is_collapsed_;
+  bool is_collapsible_;
+
   StateChangeHandler handler_;
 };
 


### PR DESCRIPTION
Before this change, the track's triangle toggle had a tri-state,
expanded, collapsed, inactive (meanning not-collapsible). This
required the maintainance of the "initial state", but most
importantly, IsExpanded() was not !IsCollapsed(), which is
error-prone.

Now, similar to the track itself, the toggle can be collapsible
(or not) and independent of this, the toggle has is collapsed
(or not). The default is not collapsed, and (but) collapsible.

Test: Take a capture with all kinds of tracks. Collapse/uncollapse.
Bug: http://b/185465747