### PR TITLE
Collect RssAnon instead of Rss for the process

### DIFF
--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -347,13 +347,16 @@ message SystemMemoryUsage {
 }
 
 message ProcessMemoryUsage {
+  reserved 3;
   int32 pid = 1;
   uint64 timestamp_ns = 2;
   // These fields are retrieved from /proc/<pid>/stat. See
   // https://man7.org/linux/man-pages/man5/proc.5.html for the documentation.
-  int64 rss_pages = 3;
   int64 minflt = 4;
   int64 majflt = 5;
+  // This field is retrieved from /proc/<pid>/status. See
+  // https://man7.org/linux/man-pages/man5/proc.5.html for the documentation.
+  int64 rss_anon_kb = 6;
 }
 
 message CGroupMemoryUsage {

--- a/src/MemoryTracing/MemoryTracingIntegrationTest.cpp
+++ b/src/MemoryTracing/MemoryTracingIntegrationTest.cpp
@@ -187,7 +187,7 @@ void VerifyOrderAndContentOfEvents(const std::vector<ProducerCaptureEvent>& even
                   previous_process_memory_event_timestamp_ns);
 
         // Verify whether the contents of events are valid.
-        EXPECT_TRUE(event.process_memory_usage().rss_pages() >= 0);
+        EXPECT_TRUE(event.process_memory_usage().rss_anon_kb() >= 0);
         EXPECT_TRUE(event.process_memory_usage().minflt() >= 0);
         EXPECT_TRUE(event.process_memory_usage().majflt() >= 0);
 

--- a/src/MemoryTracing/MemoryTracingUtils.h
+++ b/src/MemoryTracing/MemoryTracingUtils.h
@@ -26,6 +26,8 @@ namespace orbit_memory_tracing {
 [[nodiscard]] orbit_grpc_protos::ProcessMemoryUsage CreateAndInitializeProcessMemoryUsage();
 [[nodiscard]] ErrorMessageOr<void> UpdateProcessMemoryUsageFromProcessStat(
     std::string_view stat_content, orbit_grpc_protos::ProcessMemoryUsage* process_memory_usage);
+[[nodiscard]] ErrorMessageOr<void> UpdateProcessMemoryUsageFromProcessStatus(
+    std::string_view status_content, orbit_grpc_protos::ProcessMemoryUsage* process_memory_usage);
 [[nodiscard]] ErrorMessageOr<orbit_grpc_protos::ProcessMemoryUsage> GetProcessMemoryUsage(
     int32_t pid) noexcept;
 

--- a/src/MemoryTracing/MemoryTracingUtils.h
+++ b/src/MemoryTracing/MemoryTracingUtils.h
@@ -26,8 +26,8 @@ namespace orbit_memory_tracing {
 [[nodiscard]] orbit_grpc_protos::ProcessMemoryUsage CreateAndInitializeProcessMemoryUsage();
 [[nodiscard]] ErrorMessageOr<void> UpdateProcessMemoryUsageFromProcessStat(
     std::string_view stat_content, orbit_grpc_protos::ProcessMemoryUsage* process_memory_usage);
-[[nodiscard]] ErrorMessageOr<void> UpdateProcessMemoryUsageFromProcessStatus(
-    std::string_view status_content, orbit_grpc_protos::ProcessMemoryUsage* process_memory_usage);
+[[nodiscard]] ErrorMessageOr<int64_t> ExtractRssAnonFromProcessStatus(
+    std::string_view status_content);
 [[nodiscard]] ErrorMessageOr<orbit_grpc_protos::ProcessMemoryUsage> GetProcessMemoryUsage(
     int32_t pid) noexcept;
 


### PR DESCRIPTION
With this change, we collect the size of resident anonymous memory `RssAnon`
rather than the resident set size `Rss` for the process memory usage.

`Rss` = `RssAnon` + `RssFile` + `RssShmem` and `RssFile` counts the shared files.
However the cgroup memory usage counts a mapped file only if the memory 
cgroup is the owner. Using `Rss` as the process memory usage will result in the case
that process memory usage is larger than the cgroup memory usage.

More detailed discussion can be found in http://b/191758791.

Bug: http://b/191758791
Test: Covered by unit test.