### PR TITLE
Add clang9 debug job

### DIFF
--- a/kokoro/builds/linux/clang9_debug/common.cfg
+++ b/kokoro/builds/linux/clang9_debug/common.cfg
@@ -1,0 +1,12 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Location of the bash script. Should have value <github_scm.name>/<path_from_repository_root>.
+# github_scm.name is specified in the job configuration (next section).
+build_file: "orbitprofiler/kokoro/builds/build.sh"
+
+action {
+  define_artifacts {
+    regex: "github/orbitprofiler/build/testresults/*.xml"
+    strip_prefix: "github/orbitprofiler/build/package"
+  }
+}

--- a/kokoro/builds/linux/clang9_debug/presubmit.cfg
+++ b/kokoro/builds/linux/clang9_debug/presubmit.cfg
@@ -1,0 +1,1 @@
+# Format: //devtools/kokoro/config/proto/build.proto

--- a/src/ObjectUtils/CoffFile.cpp
+++ b/src/ObjectUtils/CoffFile.cpp
@@ -93,7 +93,10 @@ ErrorMessageOr<SymbolInfo> CoffFileImpl::CreateSymbolInfo(
   symbol_info.set_name(name);
   symbol_info.set_demangled_name(llvm::demangle(name));
   symbol_info.set_address(symbol_ref.getValue() + section_offset.value());
-  symbol_info.set_size(symbol_ref.getCommonSize());
+
+  llvm::object::COFFSymbolRef coff_symbol_ref = object_file_->getCOFFSymbol(symbol_ref);
+  symbol_info.set_size(coff_symbol_ref.getValue());
+
   return symbol_info;
 }
 


### PR DESCRIPTION
This is fixing a bug in our ObjectUtils code which is only triggered in a debug build. Furthermore it adds the job config for a debug-build presubmit job.