### PR TITLE
Fix the memory tracing e2e test

### DIFF
--- a/contrib/automation_tests/orbit_memory_tracing.py
+++ b/contrib/automation_tests/orbit_memory_tracing.py
@@ -29,7 +29,7 @@ def main(argv):
         SetAndCheckMemorySamplingPeriod(memory_sampling_period='ab'),
         SetAndCheckMemorySamplingPeriod(memory_sampling_period='0'),
         Capture(collect_system_memory_usage=True),
-        FilterTracks(filter_string="Memory", expected_count=2),
+        FilterTracks(filter_string="Memory", expected_count=1),
         Capture(),
         FilterTracks(filter_string="Memory", expected_count=0)
     ]


### PR DESCRIPTION
In our latest change of memory track (https://github.com/google/orbit/pull/2422), we changed to visualize all the system memory usage related information in a single `MemoryTrack` with multivariate stacked graph. This change will update the e2e test accordingly.


Bug: http://b/191840564