### PR TITLE
Fix actionOpenUserDataDirectory, add actionOpenAppDataDirectory

### DIFF
--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -829,11 +829,20 @@ void OrbitMainWindow::on_actionReport_Bug_triggered() {
 }
 
 void OrbitMainWindow::on_actionOpenUserDataDirectory_triggered() {
+  std::string user_data_dir = orbit_core::CreateOrGetOrbitUserDataDir().string();
+  QUrl user_data_url = QUrl::fromLocalFile(QString::fromStdString(user_data_dir));
+  if (!QDesktopServices::openUrl(user_data_url)) {
+    QMessageBox::critical(this, "Error opening directory",
+                          "Could not open Orbit user data directory");
+  }
+}
+
+void OrbitMainWindow::on_actionOpenAppDataDirectory_triggered() {
   std::string app_data_dir = orbit_core::CreateOrGetOrbitAppDataDir().string();
   QUrl app_data_url = QUrl::fromLocalFile(QString::fromStdString(app_data_dir));
   if (!QDesktopServices::openUrl(app_data_url)) {
     QMessageBox::critical(this, "Error opening directory",
-                          "Could not open Orbit user data directory");
+                          "Could not open Orbit app data directory");
   }
 }
 

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -121,6 +121,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
 
  private slots:
   void on_actionOpenUserDataDirectory_triggered();
+  void on_actionOpenAppDataDirectory_triggered();
   void on_actionAbout_triggered();
 
   void on_actionReport_Missing_Feature_triggered();

--- a/src/OrbitQt/orbitmainwindow.ui
+++ b/src/OrbitQt/orbitmainwindow.ui
@@ -306,6 +306,9 @@ QPushButton:disabled {
     <property name="title">
      <string>Help</string>
     </property>
+    <property name="toolTipsVisible">
+     <bool>true</bool>
+    </property>
     <addaction name="actionOpenUserDataDirectory"/>
     <addaction name="actionOpenAppDataDirectory"/>
     <addaction name="separator"/>
@@ -523,6 +526,9 @@ QPushButton:disabled {
    <property name="text">
     <string>Open User Data Directory...</string>
    </property>
+   <property name="toolTip">
+    <string>This location contains presets and autosaved captures.</string>
+   </property>
   </action>
   <action name="actionOpenAppDataDirectory">
    <property name="icon">
@@ -531,6 +537,11 @@ QPushButton:disabled {
    </property>
    <property name="text">
     <string>Open App Data Directory...</string>
+   </property>
+   <property name="toolTip">
+    <string>This location contains logs, crash dumps, the symbol file cache, and the configuration file that specifies where to search for symbol files (SymbolPaths.txt).
+
+It used to also contain captures and presets, but these were moved to the User Data directory.</string>
    </property>
   </action>
  </widget>

--- a/src/OrbitQt/orbitmainwindow.ui
+++ b/src/OrbitQt/orbitmainwindow.ui
@@ -307,6 +307,8 @@ QPushButton:disabled {
      <string>Help</string>
     </property>
     <addaction name="actionOpenUserDataDirectory"/>
+    <addaction name="actionOpenAppDataDirectory"/>
+    <addaction name="separator"/>
     <addaction name="actionAbout"/>
    </widget>
    <widget class="QMenu" name="menuFeedback">
@@ -520,6 +522,15 @@ QPushButton:disabled {
    </property>
    <property name="text">
     <string>Open User Data Directory...</string>
+   </property>
+  </action>
+  <action name="actionOpenAppDataDirectory">
+   <property name="icon">
+    <iconset resource="../../icons/orbiticons.qrc">
+     <normaloff>:/actions/folder</normaloff>:/actions/folder</iconset>
+   </property>
+   <property name="text">
+    <string>Open App Data Directory...</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
"Open User Data Directory..." still pointed to `%APPDATA%\OrbitProfiler`, fix it
to send the user to `Documents\Orbit`.
Add "Open App Data Directory" to still be able to easily reach
`%APPDATA%\OrbitProfiler`.

Bug: http://b/191121155