### PR TITLE
Add ORBIT_DONT_MOVE_FROM_APPDATA env var to avoid moving from %APPDATA%

### DIFF
--- a/src/MoveFilesToDocuments/MoveFilesToDocuments.cpp
+++ b/src/MoveFilesToDocuments/MoveFilesToDocuments.cpp
@@ -12,6 +12,7 @@
 #include "MoveFilesProcess.h"
 #include "OrbitBase/File.h"
 #include "Path.h"
+#include "absl/strings/ascii.h"
 #include "absl/strings/str_format.h"
 
 namespace orbit_move_files_to_documents {
@@ -39,6 +40,12 @@ static bool IsDirectoryEmpty(const std::filesystem::path& directory) {
 }
 
 void TryMoveSavedDataLocationIfNeeded() {
+  constexpr const char* kEnvDontMoveData = "ORBIT_DONT_MOVE_FROM_APPDATA";
+  if (char* value = std::getenv(kEnvDontMoveData);
+      value != nullptr && value != std::string{"0"} && absl::AsciiStrToLower(value) != "false") {
+    return;
+  }
+
   if (IsDirectoryEmpty(orbit_core::GetPresetDirPriorTo1_66()) &&
       IsDirectoryEmpty(orbit_core::GetCaptureDirPriorTo1_66())) {
     return;


### PR DESCRIPTION
Bug: http://b/189887834

Test: Move presets and captures back to %APPDATA%, set
`ORBIT_DONT_MOVE_FROM_APPDATA`, start Orbit, verify that no move happened.