### PR TITLE
Fix tests in debug build.

### DIFF
--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -676,7 +676,7 @@ extern "C" __attribute__((naked)) int TooShort() {
 }
 
 TEST_F(InstrumentFunctionTest, TooShort) {
-#if defined(ORBIT_COVERAGE_BUILD) || (__GNUC__ == 9)
+#if defined(ORBIT_COVERAGE_BUILD) || (__GNUC__ == 9) || !defined(NDEBUG)
   GTEST_SKIP();
 #endif
   RunChild(&TooShort, "TooShort");

--- a/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.cpp
+++ b/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.cpp
@@ -40,8 +40,9 @@ void ClobberXmmRegisters(uint64_t) {
       "movdqu 0x12(%%rip), %%xmm5\n\t"
       "movdqu 0x0a(%%rip), %%xmm6\n\t"
       "movdqu 0x02(%%rip), %%xmm7\n\t"
-      "jmp .+0x12 \n\t"
+      "jmp label_clobber_xmm_after_data\n\t"
       ".quad 0xffffffffffffffff, 0xffffffffffffffff \n\t"
+      "label_clobber_xmm_after_data:\n\t"
       :
       :
       :);
@@ -57,8 +58,9 @@ void ClobberYmmRegisters(uint64_t) {
       "vmovdqu 0x12(%%rip), %%ymm5\n\t"
       "vmovdqu 0x0a(%%rip), %%ymm6\n\t"
       "vmovdqu 0x02(%%rip), %%ymm7\n\t"
-      "jmp .+0x22 \n\t"
+      "jmp label_clobber_ymm_after_data\n\t"
       ".quad 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff \n\t"
+      "label_clobber_ymm_after_data:\n\t"
       :
       :
       :);


### PR DESCRIPTION
Deactivated InstrumentFunctionTest.TooShort for debug builds. The
test depends on the length of the code emitted by the compiler (this
isn't great but it is exactly what I want to test here). In debug
mode an additional ud2 instruction is added at the end of the
function (to guard against unwanted continuation of execution I
guess).

CheckFloatParameters and CheckM256iParameters tests where using inline
assembly that implicitly relied on the specific variant of the jmp
instruction being picked by the compiler. The debug configuration
picked the unexpected variant. The code is altered such that it works
fine reguardless of what the compiler chooses to emit.