### PR TITLE
Make timebar lighter and opaque

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -490,8 +490,7 @@ void CaptureWindow::DrawScreenSpace() {
         Vec2(0, time_graph_->GetLayout().GetSliderWidth()),
         Vec2(viewport_.GetScreenWidth(), time_graph_->GetLayout().GetTimeBarHeight()),
         GlCanvas::kZValueTimeBarBg);
-    ui_batcher_.AddBox(background_box,
-                       Color(kBackgroundColor[0], kBackgroundColor[1], kBackgroundColor[2], 200));
+    ui_batcher_.AddBox(background_box, kTimeBarBackgroundColor);
   }
 }
 

--- a/src/OrbitGl/GlCanvas.cpp
+++ b/src/OrbitGl/GlCanvas.cpp
@@ -54,6 +54,7 @@ unsigned GlCanvas::kMaxNumberRealZLayers = kNumberOriginalLayers + kExtraLayersF
                                            kExtraLayersForSliderEpsilons;
 
 const Color GlCanvas::kBackgroundColor = Color(67, 67, 67, 255);
+const Color GlCanvas::kTimeBarBackgroundColor = Color(90, 90, 90, 255);
 const Color GlCanvas::kTabTextColorSelected = Color(100, 181, 246, 255);
 
 GlCanvas::GlCanvas()

--- a/src/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/GlCanvas.h
@@ -122,6 +122,7 @@ class GlCanvas : public orbit_gl::AccessibleInterfaceProvider {
   static unsigned kMaxNumberRealZLayers;
 
   static const Color kBackgroundColor;
+  static const Color kTimeBarBackgroundColor;
   static const Color kTabTextColorSelected;
 
  protected:

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -284,6 +284,9 @@ void TrackManager::UpdateTracks(Batcher* batcher, uint64_t min_tick, uint64_t ma
     current_y -= (track->GetHeight() + layout_->GetSpaceBetweenTracks());
   }
 
+  // TODO: This margin should be treated in a different way (http://b/192070555).
+  current_y -= layout_->GetBottomMargin();
+
   // Tracks are drawn from 0 (top) to negative y-coordinates.
   tracks_total_height_ = std::abs(current_y);
 }


### PR DESCRIPTION
Now tracks are not going to be drawn behind it. Also we fixed the fact
that the last track didn't fit in view (http://b/191335338).

I wanted to make a refactor but after speaking with @reichlfl, I decided to create a bug there.

![timebar lighter and opaque](https://user-images.githubusercontent.com/8610429/123460942-b1f9d000-d5e8-11eb-8643-d0cf341639d4.png)
