### PR TITLE
Report only executable segmetents in Module events

### DIFF
--- a/src/ClientData/FunctionUtils.cpp
+++ b/src/ClientData/FunctionUtils.cpp
@@ -63,7 +63,8 @@ std::optional<uint64_t> GetAbsoluteAddress(const orbit_client_protos::FunctionIn
 
   CHECK(!base_addresses.empty());
 
-  return func.address() + base_addresses.at(0) - module.load_bias();
+  return func.address() + base_addresses.at(0) - module.load_bias() -
+         module.executable_segment_offset();
 }
 
 bool IsOrbitFunctionFromType(const FunctionInfo::OrbitType& type) {

--- a/src/ClientData/ProcessData.cpp
+++ b/src/ClientData/ProcessData.cpp
@@ -59,8 +59,7 @@ const std::string& ProcessData::build_id() const {
   return process_info_.build_id();
 }
 
-[[maybe_unused]] static bool IsModuleMapValid(
-    const std::map<uint64_t, ModuleInMemory>& module_map) {
+static bool IsModuleMapValid(const std::map<uint64_t, ModuleInMemory>& module_map) {
   // Check that modules do not intersect in the address space.
   uint64_t last_end_address = 0;
   for (const auto& [unused_address, module_in_memory] : module_map) {
@@ -82,8 +81,7 @@ void ProcessData::UpdateModuleInfos(absl::Span<const ModuleInfo> module_infos) {
     CHECK(success);
   }
 
-  // TODO(b/191732187): Re-enable after the bug is properly fixed.
-  // CHECK(IsModuleMapValid(start_address_to_module_in_memory_));
+  CHECK(IsModuleMapValid(start_address_to_module_in_memory_));
 }
 
 std::vector<std::string> ProcessData::FindModuleBuildIdsByPath(
@@ -123,8 +121,7 @@ void ProcessData::AddOrUpdateModuleInfo(const ModuleInfo& module_info) {
   start_address_to_module_in_memory_.insert_or_assign(module_info.address_start(),
                                                       module_in_memory);
 
-  // TODO(b/191732187): Re-enable after the bug is properly fixed.
-  // CHECK(IsModuleMapValid(start_address_to_module_in_memory_));
+  CHECK(IsModuleMapValid(start_address_to_module_in_memory_));
 }
 
 ErrorMessageOr<ModuleInMemory> ProcessData::FindModuleByAddress(uint64_t absolute_address) const {

--- a/src/ClientData/include/ClientData/ModuleData.h
+++ b/src/ClientData/include/ClientData/ModuleData.h
@@ -33,6 +33,9 @@ class ModuleData final {
   [[nodiscard]] uint64_t file_size() const { return module_info_.file_size(); }
   [[nodiscard]] const std::string& build_id() const { return module_info_.build_id(); }
   [[nodiscard]] uint64_t load_bias() const { return module_info_.load_bias(); }
+  [[nodiscard]] uint64_t executable_segment_offset() const {
+    return module_info_.executable_segment_offset();
+  }
   [[nodiscard]] bool is_loaded() const;
   // Returns true of module was unloaded and false otherwise
   [[nodiscard]] bool UpdateIfChangedAndUnload(orbit_grpc_protos::ModuleInfo info);

--- a/src/FakeClient/FakeClientMain.cpp
+++ b/src/FakeClient/FakeClientMain.cpp
@@ -77,14 +77,14 @@ void ManipulateModuleManagerAndSelectedFunctionsToAddUprobeFromOffset(
   FAIL_IF(error_or_elf_file.has_error(), "%s", error_or_elf_file.error().message());
   std::unique_ptr<orbit_object_utils::ElfFile>& elf_file = error_or_elf_file.value();
   std::string build_id = elf_file->GetBuildId();
-  ErrorMessageOr<uint64_t> error_or_load_bias = elf_file->GetLoadBias();
-  FAIL_IF(error_or_load_bias.has_error(), "%s", error_or_load_bias.error().message());
-  uint64_t load_bias = error_or_load_bias.value();
+  uint64_t load_bias = elf_file->GetLoadBias();
+  uint64_t executable_segment_offset = elf_file->GetExecutableSegmentOffset();
 
   orbit_grpc_protos::ModuleInfo module_info;
   module_info.set_file_path(file_path);
   module_info.set_build_id(build_id);
   module_info.set_load_bias(load_bias);
+  module_info.set_executable_segment_offset(executable_segment_offset);
   CHECK(module_manager->AddOrUpdateModules({module_info}).empty());
 
   orbit_client_protos::FunctionInfo function_info;
@@ -104,14 +104,14 @@ void ManipulateModuleManagerAndSelectedFunctionsToAddUprobeFromFunctionName(
   FAIL_IF(error_or_elf_file.has_error(), "%s", error_or_elf_file.error().message());
   std::unique_ptr<orbit_object_utils::ElfFile>& elf_file = error_or_elf_file.value();
   std::string build_id = elf_file->GetBuildId();
-  ErrorMessageOr<uint64_t> error_or_load_bias = elf_file->GetLoadBias();
-  FAIL_IF(error_or_load_bias.has_error(), "%s", error_or_load_bias.error().message());
-  uint64_t load_bias = error_or_load_bias.value();
+  uint64_t load_bias = elf_file->GetLoadBias();
+  uint64_t executable_segment_offset = elf_file->GetExecutableSegmentOffset();
 
   orbit_grpc_protos::ModuleInfo module_info;
   module_info.set_file_path(file_path);
   module_info.set_build_id(build_id);
   module_info.set_load_bias(load_bias);
+  module_info.set_executable_segment_offset(executable_segment_offset);
   CHECK(module_manager->AddOrUpdateModules({module_info}).empty());
 
   ErrorMessageOr<orbit_grpc_protos::ModuleSymbols> symbols_or_error =

--- a/src/GrpcProtos/module.proto
+++ b/src/GrpcProtos/module.proto
@@ -9,13 +9,16 @@ package orbit_grpc_protos;
 message ModuleInfo {
   // General purpose name of the module, can be used as a pretty name in the UI.
   // If you need the ELF specific soname, use the field "soname" below.
+  // NextId: 10
   string name = 1;
   string file_path = 2;
   uint64 file_size = 3;
   uint64 address_start = 4;
   uint64 address_end = 5;
   string build_id = 6;
+
+  // ELF specific fields: load_bias, soname and executable_segment_offset.
   uint64 load_bias = 7;
-  // ELF specific soname.
+  uint64 executable_segment_offset = 8;
   string soname = 9;
 }

--- a/src/ObjectUtils/LinuxMapTest.cpp
+++ b/src/ObjectUtils/LinuxMapTest.cpp
@@ -197,8 +197,8 @@ TEST(LinuxMap, ParseMaps) {
     EXPECT_EQ(hello_module_info->name(), "hello_world_elf");
     EXPECT_EQ(hello_module_info->file_path(), hello_world_path);
     EXPECT_EQ(hello_module_info->file_size(), 16616);
-    EXPECT_EQ(hello_module_info->address_start(), 0x7f6874285000);
-    EXPECT_EQ(hello_module_info->address_end(), 0x7f6874290000);
+    EXPECT_EQ(hello_module_info->address_start(), 0x7f6874288000);
+    EXPECT_EQ(hello_module_info->address_end(), 0x7f687428c000);
     EXPECT_EQ(hello_module_info->build_id(), "d12d54bc5b72ccce54a408bdeda65e2530740ac8");
     EXPECT_EQ(hello_module_info->load_bias(), 0x0);
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -2191,7 +2191,8 @@ void OrbitApp::DeselectFunction(const orbit_client_protos::FunctionInfo& func) {
   const ModuleData* module = GetModuleByPathAndBuildId(module_path, module_build_id);
   if (module == nullptr) return false;
 
-  const uint64_t offset = absolute_address - module_base_address;
+  const uint64_t offset =
+      absolute_address - module_base_address + module->executable_segment_offset();
   const FunctionInfo* function = module->FindFunctionByOffset(offset, false);
   if (function == nullptr) return false;
 

--- a/src/UserSpaceInstrumentation/FindFunctionAddress.cpp
+++ b/src/UserSpaceInstrumentation/FindFunctionAddress.cpp
@@ -10,7 +10,6 @@
 
 #include "ObjectUtils/ElfFile.h"
 #include "ObjectUtils/LinuxMap.h"
-#include "OrbitBase/Logging.h"
 
 namespace orbit_user_space_instrumentation {
 
@@ -43,11 +42,12 @@ ErrorMessageOr<uint64_t> FindFunctionAddress(pid_t pid, std::string_view module_
 
   for (const orbit_grpc_protos::SymbolInfo& symbol : symbols.value().symbol_infos()) {
     if (symbol.name() == function_name) {
-      return symbol.address() + module_base_address - symbols.value().load_bias();
+      return symbol.address() + module_base_address - elf_file->GetLoadBias() -
+             elf_file->GetExecutableSegmentOffset();
     }
   }
 
-  return ErrorMessage(absl::StrFormat("Unable to locate function symbol \"%s\" in module \"%s\".",
+  return ErrorMessage(absl::StrFormat(R"(Unable to locate function symbol "%s" in module "%s".)",
                                       function_name, module_soname));
 }
 }  // namespace orbit_user_space_instrumentation


### PR DESCRIPTION
Since modules may end up being mapped between other modules,
and sometimes do (see http://b/191732187), we only report
now executable segment mappings for modules. This also brings
snapshot event data in line with module update data.

Since exectuable segment is located at the offset different
from 0 we need to take it into account while translating
absolute addresses to function address (and vice versa).
For this reason we introduce exectuable_segment_offset
to ModuleInfo

Bug: http://b/191732187
Test: Run orbit, intstrument a function, take a capture, go to
      Disassebly.