### PR TITLE
Slider mouseover events

### DIFF
--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -155,6 +155,7 @@ target_link_libraries(
          OrbitAccessibility
          OrbitPaths
          PresetFile
+         Qt5::Gui
          Symbols
          CONAN_PKG::Outcome
          CONAN_PKG::freetype-gl
@@ -181,6 +182,7 @@ target_sources(OrbitGlTests PRIVATE
                BatcherTest.cpp
                BlockChainTest.cpp
                CaptureStatsTest.cpp
+               CaptureWindowTest.cpp
                ClientFlags.cpp
                GlUtilsTest.cpp
                GpuTrackTest.cpp

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -174,7 +174,8 @@ add_executable(OrbitGlTests)
 target_compile_options(OrbitGlTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(OrbitGlTests PRIVATE
-               PickingManagerTest.h)
+               PickingManagerTest.h
+               UnitTestSlider.h)
 
 target_sources(OrbitGlTests PRIVATE
                BatcherTest.cpp

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -370,9 +370,11 @@ void CaptureWindow::KeyPressed(unsigned int key_code, bool ctrl, bool shift, boo
 
 void CaptureWindow::SetIsMouseOver(bool value) {
   GlCanvas::SetIsMouseOver(value);
+
   if (!value && last_mouseover_slider_ != nullptr) {
     last_mouseover_slider_->OnMouseLeave();
     last_mouseover_slider_ = nullptr;
+    RequestRedraw();
   }
 }
 

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -70,8 +70,8 @@ using orbit_client_protos::TimerInfo;
 CaptureWindow::CaptureWindow(OrbitApp* app) : GlCanvas(), app_{app} {
   draw_help_ = true;
 
-  slider_ = std::make_shared<GlHorizontalSlider>();
-  vertical_slider_ = std::make_shared<GlVerticalSlider>();
+  slider_ = std::make_shared<orbit_gl::GlHorizontalSlider>(viewport_);
+  vertical_slider_ = std::make_shared<orbit_gl::GlVerticalSlider>(viewport_);
 
   slider_->SetDragCallback([&](float ratio) {
     this->UpdateHorizontalScroll(ratio);
@@ -81,13 +81,11 @@ CaptureWindow::CaptureWindow(OrbitApp* app) : GlCanvas(), app_{app} {
     this->UpdateHorizontalZoom(normalized_start, normalized_end);
     RequestUpdatePrimitives();
   });
-  slider_->SetCanvas(this);
 
   vertical_slider_->SetDragCallback([&](float ratio) {
     this->UpdateVerticalScroll(ratio);
     RequestUpdatePrimitives();
   });
-  vertical_slider_->SetCanvas(this);
 
   vertical_slider_->SetOrthogonalSliderPixelHeight(slider_->GetPixelHeight());
   slider_->SetOrthogonalSliderPixelHeight(vertical_slider_->GetPixelHeight());
@@ -466,11 +464,12 @@ void CaptureWindow::DrawScreenSpace() {
 
   if (time_span > 0) {
     UpdateHorizontalSliderFromWorld();
-    slider_->Draw(this);
+    slider_->Draw(ui_batcher_, picking_manager_.IsThisElementPicked(slider_.get()));
 
     UpdateVerticalSliderFromWorld();
     if (vertical_slider_->GetLengthRatio() < 1.f) {
-      vertical_slider_->Draw(this);
+      vertical_slider_->Draw(ui_batcher_,
+                             picking_manager_.IsThisElementPicked(vertical_slider_.get()));
       int slider_width = static_cast<int>(time_graph_->GetLayout().GetSliderWidth());
       right_margin += slider_width;
     }

--- a/src/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/CaptureWindow.h
@@ -83,8 +83,8 @@ class CaptureWindow : public GlCanvas {
 
   std::unique_ptr<TimeGraph> time_graph_ = nullptr;
   bool draw_help_;
-  std::shared_ptr<GlSlider> slider_;
-  std::shared_ptr<GlSlider> vertical_slider_;
+  std::shared_ptr<orbit_gl::GlSlider> slider_;
+  std::shared_ptr<orbit_gl::GlSlider> vertical_slider_;
 
   uint64_t select_start_time_ = 0;
   uint64_t select_stop_time_ = 0;

--- a/src/OrbitGl/CaptureWindow.h
+++ b/src/OrbitGl/CaptureWindow.h
@@ -41,6 +41,8 @@ class CaptureWindow : public GlCanvas {
   void MouseWheelMovedHorizontally(int x, int y, int delta, bool ctrl) override;
   void KeyPressed(unsigned int key_code, bool ctrl, bool shift, bool alt) override;
 
+  void SetIsMouseOver(bool value) override;
+
   void PostRender() override;
   void RenderImGuiDebugUI() override;
 
@@ -65,7 +67,8 @@ class CaptureWindow : public GlCanvas {
 
   virtual void ToggleRecording();
 
- private:
+  orbit_gl::GlSlider* FindSliderUnderMouseCursor(int x, int y);
+
   void RenderHelpUi();
   void RenderTimeBar();
   void RenderSelectionOverlay();
@@ -77,6 +80,8 @@ class CaptureWindow : public GlCanvas {
   void UpdateVerticalSliderFromWorld();
   void UpdateHorizontalSliderFromWorld();
 
+  void ProcessSliderMouseMoveEvents(int x, int y);
+
   [[nodiscard]] virtual const char* GetHelpText() const;
   [[nodiscard]] virtual bool ShouldAutoZoom() const;
   void HandlePickedElement(PickingMode picking_mode, PickingId picking_id, int x, int y) override;
@@ -85,6 +90,7 @@ class CaptureWindow : public GlCanvas {
   bool draw_help_;
   std::shared_ptr<orbit_gl::GlSlider> slider_;
   std::shared_ptr<orbit_gl::GlSlider> vertical_slider_;
+  orbit_gl::GlSlider* last_mouseover_slider_ = nullptr;
 
   uint64_t select_start_time_ = 0;
   uint64_t select_stop_time_ = 0;

--- a/src/OrbitGl/CaptureWindowTest.cpp
+++ b/src/OrbitGl/CaptureWindowTest.cpp
@@ -1,0 +1,76 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "CaptureWindow.h"
+#include "UnitTestSlider.h"
+
+namespace orbit_gl {
+
+class UnitTestCaptureWindow : public CaptureWindow, public testing::Test {
+ public:
+  explicit UnitTestCaptureWindow() : CaptureWindow(nullptr) {
+    slider_ = std::make_unique<UnitTestSlider>(viewport_, false);
+    vertical_slider_ = std::make_unique<UnitTestSlider>(viewport_, true);
+  }
+};
+
+TEST_F(UnitTestCaptureWindow, SlidersRespondToMouseOver) {
+  Resize(100, 200);
+
+  GlSlider* slider = FindSliderUnderMouseCursor(50, 50);
+  EXPECT_EQ(nullptr, slider);
+  slider = FindSliderUnderMouseCursor(95, 10);
+  EXPECT_EQ(vertical_slider_.get(), slider);
+  slider = FindSliderUnderMouseCursor(5, 195);
+  EXPECT_EQ(slider_.get(), slider);
+  slider = FindSliderUnderMouseCursor(95, 195);
+  EXPECT_EQ(nullptr, slider);
+
+  UnitTestSlider* unit_test_slider = dynamic_cast<UnitTestSlider*>(slider_.get());
+  UnitTestSlider* unit_test_vertical_slider = dynamic_cast<UnitTestSlider*>(vertical_slider_.get());
+
+  MouseMoved(95, 10, false, false, false);
+  EXPECT_TRUE(unit_test_vertical_slider->IsMouseOver());
+
+  MouseMoved(5, 195, false, false, false);
+  EXPECT_FALSE(unit_test_vertical_slider->IsMouseOver());
+  EXPECT_TRUE(unit_test_slider->IsMouseOver());
+
+  MouseMoved(50, 50, false, false, false);
+  EXPECT_FALSE(dynamic_cast<UnitTestSlider*>(vertical_slider_.get())->IsMouseOver());
+  EXPECT_FALSE(unit_test_slider->IsMouseOver());
+}
+
+TEST_F(UnitTestCaptureWindow, SlidersBehaveCorrectlyWithMouseDown) {
+  Resize(100, 200);
+  MouseMoved(5, 195, true, false, false);
+
+  UnitTestSlider* unit_test_slider = dynamic_cast<UnitTestSlider*>(slider_.get());
+  UnitTestSlider* unit_test_vertical_slider = dynamic_cast<UnitTestSlider*>(vertical_slider_.get());
+
+  EXPECT_FALSE(unit_test_vertical_slider->IsMouseOver());
+  EXPECT_FALSE(unit_test_slider->IsMouseOver());
+
+  MouseMoved(95, 10, false, false, false);
+  LeftDown(95, 10);
+  EXPECT_TRUE(unit_test_vertical_slider->IsMouseOver());
+  MouseMoved(50, 50, true, false, false);
+  EXPECT_TRUE(unit_test_vertical_slider->IsMouseOver());
+  LeftUp();
+  EXPECT_FALSE(unit_test_vertical_slider->IsMouseOver());
+}
+
+TEST_F(UnitTestCaptureWindow, SlidersRespondToMouseLeave) {
+  Resize(100, 200);
+  MouseMoved(95, 10, false, false, false);
+
+  UnitTestSlider* unit_test_vertical_slider = dynamic_cast<UnitTestSlider*>(vertical_slider_.get());
+  EXPECT_TRUE(unit_test_vertical_slider->IsMouseOver());
+  SetIsMouseOver(false);
+  EXPECT_FALSE(unit_test_vertical_slider->IsMouseOver());
+}
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/GlCanvas.h
+++ b/src/OrbitGl/GlCanvas.h
@@ -92,7 +92,7 @@ class GlCanvas : public orbit_gl::AccessibleInterfaceProvider {
   void RequestRedraw() { redraw_requested_ = true; }
 
   [[nodiscard]] bool GetIsMouseOver() const { return is_mouse_over_; }
-  void SetIsMouseOver(bool value) { is_mouse_over_ = value; }
+  virtual void SetIsMouseOver(bool value) { is_mouse_over_ = value; }
 
   [[nodiscard]] PickingManager& GetPickingManager() { return picking_manager_; }
 

--- a/src/OrbitGl/GlSlider.cpp
+++ b/src/OrbitGl/GlSlider.cpp
@@ -38,6 +38,11 @@ void GlSlider::OnMouseEnter() { is_mouse_over_ = true; }
 
 void GlSlider::OnMouseLeave() { is_mouse_over_ = false; }
 
+bool GlSlider::ContainsScreenSpacePoint(int x, int y) const {
+  return x >= GetPos()[0] && x <= GetPos()[0] + GetSize()[0] && y >= GetPos()[1] &&
+         y <= GetPos()[1] + GetSize()[1];
+}
+
 GlSlider::GlSlider(Viewport& viewport, bool is_vertical)
     : is_vertical_(is_vertical),
       viewport_(viewport),

--- a/src/OrbitGl/GlSlider.h
+++ b/src/OrbitGl/GlSlider.h
@@ -62,6 +62,7 @@ class GlSlider : public Pickable, public std::enable_shared_from_this<GlSlider> 
   void OnMouseEnter();
   void OnMouseLeave();
   virtual void OnMouseMove(int /*x*/, int /*y*/) {}
+  [[nodiscard]] bool ContainsScreenSpacePoint(int x, int y) const;
 
  protected:
   explicit GlSlider(Viewport& viewport, bool is_vertical);

--- a/src/OrbitGl/GlSlider.h
+++ b/src/OrbitGl/GlSlider.h
@@ -61,7 +61,7 @@ class GlSlider : public Pickable, public std::enable_shared_from_this<GlSlider> 
 
   void OnMouseEnter();
   void OnMouseLeave();
-  virtual void OnMouseMove(int /*x*/, int /*y*/) {}
+  void OnMouseMove(int x, int y);
   [[nodiscard]] bool ContainsScreenSpacePoint(int x, int y) const;
 
  protected:
@@ -91,6 +91,7 @@ class GlSlider : public Pickable, public std::enable_shared_from_this<GlSlider> 
   static const float kGradientFactor;
   const bool is_vertical_;
   bool is_mouse_over_ = false;
+  Vec2i mouse_pos_ = Vec2i(-1, -1);
 
   Viewport& viewport_;
 

--- a/src/OrbitGl/SliderTest.cpp
+++ b/src/OrbitGl/SliderTest.cpp
@@ -326,4 +326,11 @@ TEST(Slider, MouseEnterAndLeave) {
   EXPECT_FALSE(slider.IsMouseOver());
 }
 
+TEST(Slider, ContainsScreenSpacePoint) {
+  Viewport viewport(100, 100);
+  GlVerticalSlider slider(viewport);
+  EXPECT_TRUE(slider.ContainsScreenSpacePoint(95, 50));
+  EXPECT_FALSE(slider.ContainsScreenSpacePoint(50, 50));
+}
+
 }  // namespace orbit_gl

--- a/src/OrbitGl/UnitTestSlider.h
+++ b/src/OrbitGl/UnitTestSlider.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_UNIT_TEST_SLIDER_H_
+#define ORBIT_GL_UNIT_TEST_SLIDER_H_
+
+#include "Batcher.h"
+#include "GlSlider.h"
+#include "Viewport.h"
+
+namespace orbit_gl {
+
+class UnitTestSlider : public GlSlider {
+ public:
+  explicit UnitTestSlider(Viewport& viewport, bool is_vertical) : GlSlider(viewport, is_vertical){};
+  void Draw(Batcher& /*batcher*/, bool /*is_picked*/) override{};
+
+  bool IsMouseOver() { return is_mouse_over_; }
+
+ protected:
+  [[nodiscard]] virtual int GetBarPixelLength() const { return 0; }
+};
+
+}  // namespace orbit_gl
+
+#endif

--- a/src/OrbitGl/UnitTestSlider.h
+++ b/src/OrbitGl/UnitTestSlider.h
@@ -19,7 +19,7 @@ class UnitTestSlider : public GlSlider {
   bool IsMouseOver() { return is_mouse_over_; }
 
  protected:
-  [[nodiscard]] virtual int GetBarPixelLength() const { return 0; }
+  [[nodiscard]] virtual int GetBarPixelLength() const override { return 0; }
 };
 
 }  // namespace orbit_gl


### PR DESCRIPTION
Implements mouse-over behavior for our scrollbars:

- When moving the mouse over the slider, the scrollbar changes color
- When moving over the resizing area to the left and right end of the scrollbar, the cursor is adjusted

The cursor change introduces Qt as a dependency to OrbitGl. As this is a very local change for now, I added a DEFINE to easily remove this again. It is up for discussion if this is useful or if it will prompt others to follow my pattern in more complex integrations.

This PR also fully removes `GlCanvas*` from the sliders and replaces it with `Viewport`.

**Note**

There will be a refactoring of this in the near future. My plan is to move the mouse enter / leave / move functionality into `Pickable`, move the tracking of the current element under the mouse into the `PickingManager`, and implement the same functionality in `CaptureViewElement` (which already inherits from `Pickable`). In the long run, this allows us to combine pixel-perfect picking and this simple bounding-box check (hierarchically for `CaptureViewElement`), but this will be a bigger change. I wanted to use the scrollbars as a first test and decided to already merge this and refactor later.