### PR TITLE
Track visibility by type

### DIFF
--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -194,6 +194,7 @@ target_sources(OrbitGlTests PRIVATE
                ShortenStringWithEllipsisTest.cpp
                StringManagerTest.cpp
                TimerInfosIteratorTest.cpp
+               TrackManagerTest.cpp
                ViewportTest.cpp)
 
 target_link_libraries(

--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -181,6 +181,10 @@ void CallstackThreadBar::SelectCallstacks() {
 }
 
 bool CallstackThreadBar::IsEmpty() const {
+  if (capture_data_ == nullptr) {
+    return true;
+  }
+
   const uint32_t callstack_count =
       (thread_id_ == orbit_base::kAllProcessThreadsTid)
           ? capture_data_->GetCallstackData()->GetCallstackEventsCount()

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -33,7 +33,7 @@ ThreadStateBar::ThreadStateBar(CaptureViewElement* parent, OrbitApp* app, TimeGr
 }
 
 bool ThreadStateBar::IsEmpty() const {
-  return !capture_data_->HasThreadStatesForThread(thread_id_);
+  return capture_data_ == nullptr || !capture_data_->HasThreadStatesForThread(thread_id_);
 }
 
 void ThreadStateBar::Draw(Batcher& batcher, TextRenderer& text_renderer,

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -66,6 +66,7 @@ TimeGraph::TimeGraph(AccessibleInterfaceProvider* parent, OrbitApp* app,
   text_renderer_static_.SetViewport(viewport);
   batcher_.SetPickingManager(picking_manager);
   track_manager_ = std::make_unique<TrackManager>(this, viewport_, &GetLayout(), app, capture_data);
+  track_manager_->GetOrCreateSchedulerTrack();
 
   async_timer_info_listener_ =
       std::make_unique<ManualInstrumentationManager::AsyncTimerInfoListener>(
@@ -716,7 +717,8 @@ void TimeGraph::UpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/, ui
   uint64_t min_tick = GetTickFromUs(min_time_us_);
   uint64_t max_tick = GetTickFromUs(max_time_us_);
 
-  track_manager_->UpdateTracks(&batcher_, min_tick, max_tick, picking_mode);
+  track_manager_->UpdateTracksForRendering();
+  track_manager_->UpdateTrackPrimitives(&batcher_, min_tick, max_tick, picking_mode);
 
   update_primitives_requested_ = false;
 }

--- a/src/OrbitGl/TracepointThreadBar.cpp
+++ b/src/OrbitGl/TracepointThreadBar.cpp
@@ -143,7 +143,7 @@ std::string TracepointThreadBar::GetTracepointTooltip(Batcher* batcher, PickingI
 }
 
 bool TracepointThreadBar::IsEmpty() const {
-  return capture_data_->GetNumTracepointsForThreadId(thread_id_) == 0;
+  return capture_data_ == nullptr || capture_data_->GetNumTracepointsForThreadId(thread_id_) == 0;
 }
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -104,8 +104,6 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   [[nodiscard]] virtual std::vector<CaptureViewElement*> GetVisibleChildren() { return {}; }
   [[nodiscard]] virtual int GetVisiblePrimitiveCount() const { return 0; }
 
-  [[nodiscard]] virtual uint32_t GetIntent() const { return indentation_level_; }
-
  protected:
   // Returns the y-position of the triangle.
   float DrawCollapsingTriangle(Batcher& batcher, TextRenderer& text_renderer,

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -43,6 +43,11 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
     kUnknown,
   };
 
+  static constexpr std::initializer_list<Type> kAllTrackTypes = {
+      Type::kTimerTrack,  Type::kThreadTrack, Type::kFrameTrack,     Type::kVariableTrack,
+      Type::kGpuTrack,    Type::kGraphTrack,  Type::kSchedulerTrack, Type::kAsyncTrack,
+      Type::kMemoryTrack, Type::kUnknown};
+
   explicit Track(CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
                  TimeGraphLayout* layout, const orbit_client_model::CaptureData* capture_data,
                  uint32_t indentation_level);

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -171,14 +171,20 @@ void TrackManager::SetFilter(const std::string& filter) {
 }
 
 void TrackManager::UpdateVisibleTrackList() {
+  visible_tracks_.clear();
+
   if (filter_.empty()) {
-    visible_tracks_ = sorted_tracks_;
+    std::copy_if(sorted_tracks_.begin(), sorted_tracks_.end(), std::back_inserter(visible_tracks_),
+                 [](const Track* track) { return track->GetVisible(); });
     return;
   }
 
-  visible_tracks_.clear();
   std::vector<std::string> filters = absl::StrSplit(filter_, ' ', absl::SkipWhitespace());
   for (const auto& track : sorted_tracks_) {
+    if (!track->GetVisible()) {
+      continue;
+    }
+
     std::string lower_case_label = absl::AsciiStrToLower(track->GetLabel());
     for (auto& filter : filters) {
       if (absl::StrContains(lower_case_label, filter)) {

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -46,15 +46,12 @@ class TrackManager {
   [[nodiscard]] std::vector<ThreadTrack*> GetThreadTracks() const;
   [[nodiscard]] std::vector<FrameTrack*> GetFrameTracks() const;
 
-  [[nodiscard]] ThreadTrack* GetTracepointsSystemWideTrack() const {
-    return tracepoints_system_wide_track_;
-  }
-
   void RequestTrackSorting() { sorting_invalidated_ = true; };
   void SetFilter(const std::string& filter);
 
-  void UpdateTracks(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
-                    PickingMode picking_mode);
+  void UpdateTracksForRendering();
+  void UpdateTrackPrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
+                             PickingMode picking_mode);
   [[nodiscard]] float GetTracksTotalHeight() const { return tracks_total_height_; }
 
   [[nodiscard]] uint32_t GetNumTimers() const;
@@ -83,7 +80,6 @@ class TrackManager {
   void RemoveFrameTrack(uint64_t function_address);
 
  private:
-  void UpdateTracksOrder();
   [[nodiscard]] int FindMovingTrackIndex();
   void UpdateMovingTrackPositionInVisibleTracks();
   void SortTracks();
@@ -108,7 +104,6 @@ class TrackManager {
   // TODO(b/175865913): Use Function info instead of their address as key to FrameTracks
   std::map<uint64_t, std::shared_ptr<FrameTrack>> frame_tracks_;
   std::shared_ptr<SchedulerTrack> scheduler_track_;
-  ThreadTrack* tracepoints_system_wide_track_;
   std::shared_ptr<orbit_gl::SystemMemoryTrack> system_memory_track_;
   std::shared_ptr<orbit_gl::CGroupAndProcessMemoryTrack> cgroup_and_process_memory_track_;
 

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -79,6 +79,9 @@ class TrackManager {
 
   void RemoveFrameTrack(uint64_t function_address);
 
+  void SetTrackTypeVisibility(Track::Type type, bool value);
+  [[nodiscard]] bool GetTrackTypeVisibility(Track::Type type) const;
+
  private:
   [[nodiscard]] int FindMovingTrackIndex();
   void UpdateMovingTrackPositionInVisibleTracks();
@@ -125,6 +128,7 @@ class TrackManager {
   OrbitApp* app_ = nullptr;
 
   bool data_from_saved_capture_ = false;
+  absl::flat_hash_map<Track::Type, bool> track_type_visibility_;
 };
 
 #endif  // ORBIT_GL_TRACK_MANAGER_H_

--- a/src/OrbitGl/TrackManagerTest.cpp
+++ b/src/OrbitGl/TrackManagerTest.cpp
@@ -83,6 +83,8 @@ class UnitTestTrack : public Track {
 class TrackManagerTest : public ::testing::Test {
  public:
   static const size_t kNumTracks = 2;
+  static const size_t kNumThreadTracks = 1;
+  static const size_t kNumSchedulerTracks = 1;
 
  protected:
   void SetUp() override {
@@ -152,6 +154,29 @@ TEST_F(TrackManagerTest, NonVisibleTracksAreNotInTheList) {
   track_manager_->GetOrCreateSchedulerTrack()->SetVisible(false);
   track_manager_->UpdateTracksForRendering();
   EXPECT_EQ(kNumTracks - 1, track_manager_->GetVisibleTracks().size());
+}
+
+TEST_F(TrackManagerTest, TrackTypeVisibilityAffectsVisibleTrackList) {
+  CreateAndFillTracks();
+
+  track_manager_->SetTrackTypeVisibility(Track::Type::kSchedulerTrack, false);
+  track_manager_->UpdateTracksForRendering();
+  EXPECT_EQ(kNumTracks - kNumSchedulerTracks, track_manager_->GetVisibleTracks().size());
+
+  track_manager_->SetTrackTypeVisibility(Track::Type::kThreadTrack, false);
+  track_manager_->UpdateTracksForRendering();
+  EXPECT_EQ(kNumTracks - kNumThreadTracks - kNumSchedulerTracks,
+            track_manager_->GetVisibleTracks().size());
+
+  track_manager_->GetOrCreateSchedulerTrack()->SetVisible(false);
+  track_manager_->SetTrackTypeVisibility(Track::Type::kSchedulerTrack, true);
+  track_manager_->UpdateTracksForRendering();
+  EXPECT_EQ(kNumTracks - kNumThreadTracks - kNumSchedulerTracks,
+            track_manager_->GetVisibleTracks().size());
+
+  track_manager_->GetOrCreateSchedulerTrack()->SetVisible(true);
+  track_manager_->UpdateTracksForRendering();
+  EXPECT_EQ(kNumTracks - kNumThreadTracks, track_manager_->GetVisibleTracks().size());
 }
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/TrackManagerTest.cpp
+++ b/src/OrbitGl/TrackManagerTest.cpp
@@ -1,0 +1,135 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+#include <gtest/gtest.h>
+
+#include "ClientData/ModuleManager.h"
+#include "ClientModel/CaptureData.h"
+#include "TimeGraph.h"
+#include "Track.h"
+#include "TrackManager.h"
+#include "capture.pb.h"
+#include "capture_data.pb.h"
+
+using orbit_client_protos::TimerInfo;
+
+constexpr uint64_t kCallstackId = 1;
+constexpr uint64_t kFunctionAbsoluteAddress = 0x30;
+constexpr uint64_t kInstructionAbsoluteAddress = 0x31;
+constexpr int32_t kThreadId = 42;
+constexpr const char* kFunctionName = "example function";
+constexpr const char* kModuleName = "example module";
+constexpr const char* kThreadName = "example thread";
+
+namespace {
+
+// This is copied from CallTreeViewItemModelTest.cpp, we may want to supply this in a header,
+// but it is not clear what we want to be testing here in the future.
+std::unique_ptr<orbit_client_model::CaptureData> GenerateTestCaptureData() {
+  auto capture_data = std::make_unique<orbit_client_model::CaptureData>(
+      nullptr, orbit_grpc_protos::CaptureStarted{}, std::nullopt, absl::flat_hash_set<uint64_t>{});
+
+  // AddressInfo
+  orbit_client_protos::LinuxAddressInfo address_info;
+  address_info.set_absolute_address(kInstructionAbsoluteAddress);
+  address_info.set_offset_in_function(kInstructionAbsoluteAddress - kFunctionAbsoluteAddress);
+  address_info.set_function_name(kFunctionName);
+  address_info.set_module_path(kModuleName);
+  capture_data->InsertAddressInfo(address_info);
+
+  // CallstackInfo
+  const std::vector<uint64_t> callstack_frames{kInstructionAbsoluteAddress};
+  orbit_client_protos::CallstackInfo callstack_info;
+  *callstack_info.mutable_frames() = {callstack_frames.begin(), callstack_frames.end()};
+  callstack_info.set_type(orbit_client_protos::CallstackInfo_CallstackType_kComplete);
+  capture_data->AddUniqueCallstack(kCallstackId, std::move(callstack_info));
+
+  // CallstackEvent
+  orbit_client_protos::CallstackEvent callstack_event;
+  callstack_event.set_callstack_id(kCallstackId);
+  callstack_event.set_thread_id(kThreadId);
+  capture_data->AddCallstackEvent(std::move(callstack_event));
+
+  capture_data->AddOrAssignThreadName(kThreadId, kThreadName);
+
+  return capture_data;
+}
+
+}  // namespace
+
+namespace orbit_gl {
+
+class UnitTestTrack : public Track {
+ public:
+  explicit UnitTestTrack(TimeGraphLayout* layout, Track::Type type, const std::string& name)
+      : Track(nullptr, nullptr, nullptr, layout, nullptr, 0), name_(name), type_(type){};
+
+  [[nodiscard]] Type GetType() const override { return type_; }
+  [[nodiscard]] float GetHeight() const override { return 100.f; }
+  [[nodiscard]] bool IsEmpty() const override { return false; }
+
+  [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllChains() const override {
+    return {};
+  }
+  [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllSerializableChains() const override {
+    return {};
+  }
+
+ private:
+  std::string name_;
+  Type type_;
+};  // namespace orbit_gl
+
+class TrackManagerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    capture_data_ = GenerateTestCaptureData();
+    track_manager_ =
+        std::make_unique<TrackManager>(nullptr, nullptr, &layout_, nullptr, capture_data_.get());
+  }
+
+  void CreateAndFillTracks() {
+    auto* scheduler_track = track_manager_->GetOrCreateSchedulerTrack();
+    auto* thread_track = track_manager_->GetOrCreateThreadTrack(kThreadId);
+
+    TimerInfo timer;
+    timer.set_start(0);
+    timer.set_end(100);
+    timer.set_thread_id(kThreadId);
+    timer.set_processor(0);
+    timer.set_depth(0);
+    timer.set_type(TimerInfo::kCoreActivity);
+
+    scheduler_track->OnTimer(timer);
+    timer.set_type(TimerInfo::kCoreActivity);
+    thread_track->OnTimer(timer);
+  }
+
+  TimeGraphLayout layout_;
+  std::unique_ptr<orbit_client_model::CaptureData> capture_data_;
+  std::unique_ptr<TrackManager> track_manager_;
+};
+
+TEST_F(TrackManagerTest, GetOrCreateCreatesTracks) {
+  EXPECT_EQ(0ull, track_manager_->GetAllTracks().size());
+
+  track_manager_->GetOrCreateSchedulerTrack();
+  EXPECT_EQ(1ull, track_manager_->GetAllTracks().size());
+  track_manager_->GetOrCreateThreadTrack(42);
+  EXPECT_EQ(2ull, track_manager_->GetAllTracks().size());
+}
+
+TEST_F(TrackManagerTest, EmptyTracksAreNotVisible) {
+  TrackManagerTest_GetOrCreateCreatesTracks_Test();
+  EXPECT_EQ(0ull, track_manager_->GetVisibleTracks().size());
+  track_manager_->UpdateTracksForRendering();
+  EXPECT_EQ(0ull, track_manager_->GetVisibleTracks().size());
+}
+
+TEST_F(TrackManagerTest, NonEmptyTracksAreVisible) {
+  CreateAndFillTracks();
+  track_manager_->UpdateTracksForRendering();
+  EXPECT_EQ(2ull, track_manager_->GetVisibleTracks().size());
+}
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/TrackManagerTest.cpp
+++ b/src/OrbitGl/TrackManagerTest.cpp
@@ -81,6 +81,9 @@ class UnitTestTrack : public Track {
 };  // namespace orbit_gl
 
 class TrackManagerTest : public ::testing::Test {
+ public:
+  static const size_t kNumTracks = 2;
+
  protected:
   void SetUp() override {
     capture_data_ = GenerateTestCaptureData();
@@ -130,6 +133,25 @@ TEST_F(TrackManagerTest, NonEmptyTracksAreVisible) {
   CreateAndFillTracks();
   track_manager_->UpdateTracksForRendering();
   EXPECT_EQ(2ull, track_manager_->GetVisibleTracks().size());
+}
+
+// TODO(b/181671054): Once the scheduler track stays visible, this needs to be adjusted
+TEST_F(TrackManagerTest, SimpleFiltering) {
+  CreateAndFillTracks();
+  track_manager_->SetFilter("example thread");
+  track_manager_->UpdateTracksForRendering();
+  EXPECT_EQ(1ull, track_manager_->GetVisibleTracks().size());
+
+  track_manager_->SetFilter("nonsense");
+  track_manager_->UpdateTracksForRendering();
+  EXPECT_EQ(0ull, track_manager_->GetVisibleTracks().size());
+}
+
+TEST_F(TrackManagerTest, NonVisibleTracksAreNotInTheList) {
+  CreateAndFillTracks();
+  track_manager_->GetOrCreateSchedulerTrack()->SetVisible(false);
+  track_manager_->UpdateTracksForRendering();
+  EXPECT_EQ(kNumTracks - 1, track_manager_->GetVisibleTracks().size());
 }
 
 }  // namespace orbit_gl


### PR DESCRIPTION
This change adds functionality to `TrackManager` to show and hide tracks by type on top of controlling the visibility for each individual track. UI to use the functionality will follow in a later PR.

The main change is in the last two commits. Everything before that is preparational work to add the first unit tests for `TrackManager`.