### PR TITLE
Increase ggp command timeout

### DIFF
--- a/src/OrbitGgp/Client.cpp
+++ b/src/OrbitGgp/Client.cpp
@@ -4,6 +4,8 @@
 
 #include "OrbitGgp/Client.h"
 
+#include <absl/flags/flag.h>
+
 #include <QByteArray>
 #include <QIODevice>
 #include <QPointer>
@@ -17,6 +19,8 @@
 #include "OrbitGgp/Error.h"
 #include "OrbitGgp/Instance.h"
 #include "OrbitGgp/SshInfo.h"
+
+ABSL_FLAG(uint32_t, ggp_timeout_seconds, 20, "Timeout for Ggp commands in seconds");
 
 namespace orbit_ggp {
 
@@ -146,6 +150,12 @@ void Client::GetSshInfoAsync(const Instance& ggp_instance,
                             callback(SshInfo::CreateFromJson(result.value()));
                           }
                         });
+}
+
+std::chrono::milliseconds Client::GetDefaultTimeoutMs() {
+  static const uint32_t timeout_seconds = absl::GetFlag(FLAGS_ggp_timeout_seconds);
+  static const std::chrono::milliseconds default_timeout_ms(1'000 * timeout_seconds);
+  return default_timeout_ms;
 }
 
 }  // namespace orbit_ggp

--- a/src/OrbitGgp/include/OrbitGgp/Client.h
+++ b/src/OrbitGgp/include/OrbitGgp/Client.h
@@ -21,7 +21,6 @@
 namespace orbit_ggp {
 
 constexpr const char* kDefaultGgpProgram{"ggp"};
-constexpr std::chrono::milliseconds kDefaultTimeout{10'000};
 
 class Client : public QObject {
   Q_OBJECT
@@ -29,7 +28,7 @@ class Client : public QObject {
  public:
   static ErrorMessageOr<QPointer<Client>> Create(
       QObject* parent, QString ggp_program = kDefaultGgpProgram,
-      std::chrono::milliseconds timeout = kDefaultTimeout);
+      std::chrono::milliseconds timeout = GetDefaultTimeoutMs());
 
   void GetInstancesAsync(const std::function<void(outcome::result<QVector<Instance>>)>& callback,
                          int retry = 3);
@@ -39,6 +38,7 @@ class Client : public QObject {
  private:
   explicit Client(QObject* parent, QString ggp_program, std::chrono::milliseconds timeout)
       : QObject(parent), ggp_program_(std::move(ggp_program)), timeout_(timeout) {}
+  static std::chrono::milliseconds GetDefaultTimeoutMs();
 
   const QString ggp_program_;
   const std::chrono::milliseconds timeout_;


### PR DESCRIPTION
Ggp commands can sometimes take more than 10 seconds to complete.
Increase the timeout to 20 seconds and expose it through a new
ggp_timeout_seconds flag.