### PR TITLE
Fix ninja build requirement when cross compiling

### DIFF
--- a/third_party/conan/configs/windows/profiles/ggp_common
+++ b/third_party/conan/configs/windows/profiles/ggp_common
@@ -1,4 +1,5 @@
 include(cmake_common)
+include(ninja_common)
 
 C_FLAGS=-march=broadwell -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -D_FORTIFY_SOURCE=2 -fstack-protector-all
 CXX_FLAGS=-march=broadwell -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fsized-deallocation -D_FORTIFY_SOURCE=2 -fstack-protector-all -fno-exceptions
@@ -22,7 +23,6 @@ OrbitProfiler:with_gui=False
 
 [build_requires]
 ggp_sdk/1.43.0.14282@orbitdeps/stable
-ninja/1.9.0@
 
 [env]
 CONAN_CMAKE_GENERATOR=Ninja

--- a/third_party/conan/configs/windows/profiles/ninja_common
+++ b/third_party/conan/configs/windows/profiles/ninja_common
@@ -1,0 +1,9 @@
+[settings]
+ninja:os=Windows
+ninja:os_build=Windows
+ninja:arch=x86_64
+ninja:arch_build=x86_64
+ninja:build_type=Release
+
+[build_requires]
+ninja/1.9.0@


### PR DESCRIPTION
conan tries to cross-compile ninja for Linux when crosscompiling on
Windows. So we have to tell conan that ninja is a build tool and needs
to be built for the host platform, not for the target platform.