### PR TITLE
Remove "intermediate" MetadataEvent proto

### DIFF
--- a/src/CaptureClient/ApiEventProcessorTest.cpp
+++ b/src/CaptureClient/ApiEventProcessorTest.cpp
@@ -47,7 +47,18 @@ class EmptyCaptureListener : public CaptureListener {
                               orbit_grpc_protos::TracepointInfo /*tracepoint_info*/) override {}
   void OnTracepointEvent(
       orbit_client_protos::TracepointEventInfo /*tracepoint_event_info*/) override {}
-  void OnMetadataEvent(const orbit_grpc_protos::MetadataEvent& /*metadata_event*/) override {}
+  void OnWarningEvent(orbit_grpc_protos::WarningEvent /*warning_event*/) override {}
+  void OnClockResolutionEvent(
+      orbit_grpc_protos::ClockResolutionEvent /*clock_resolution_event*/) override {}
+  void OnErrorsWithPerfEventOpenEvent(
+      orbit_grpc_protos::ErrorsWithPerfEventOpenEvent /*errors_with_perf_event_open_event*/)
+      override {}
+  void OnErrorEnablingOrbitApiEvent(
+      orbit_grpc_protos::ErrorEnablingOrbitApiEvent /*error_enabling_orbit_api_event*/) override {}
+  void OnLostPerfRecordsEvent(
+      orbit_grpc_protos::LostPerfRecordsEvent /*lost_perf_records_event*/) override {}
+  void OnOutOfOrderEventsDiscardedEvent(orbit_grpc_protos::OutOfOrderEventsDiscardedEvent
+                                        /*out_of_order_events_discarded_event*/) override {}
 };
 
 // Test CaptureListener used to validate TimerInfo data produced by api events.

--- a/src/CaptureClient/CaptureEventProcessor.cpp
+++ b/src/CaptureClient/CaptureEventProcessor.cpp
@@ -74,7 +74,17 @@ class CaptureEventProcessorForListener : public CaptureEventProcessor {
       orbit_grpc_protos::InternedTracepointInfo interned_tracepoint_info);
   void ProcessTracepointEvent(const orbit_grpc_protos::TracepointEvent& tracepoint_event);
   void ProcessGpuQueueSubmission(const orbit_grpc_protos::GpuQueueSubmission& gpu_queue_submission);
-  void ProcessMetadataEvent(const orbit_grpc_protos::MetadataEvent& metadata_event);
+  void ProcessWarningEvent(const orbit_grpc_protos::WarningEvent& warning_event);
+  void ProcessClockResolutionEvent(
+      const orbit_grpc_protos::ClockResolutionEvent& clock_resolution_event);
+  void ProcessErrorsWithPerfEventOpenEvent(
+      const orbit_grpc_protos::ErrorsWithPerfEventOpenEvent& errors_with_perf_event_open_event);
+  void ProcessErrorEnablingOrbitApiEvent(
+      const orbit_grpc_protos::ErrorEnablingOrbitApiEvent& error_enabling_orbit_api_event);
+  void ProcessLostPerfRecordsEvent(
+      const orbit_grpc_protos::LostPerfRecordsEvent& lost_perf_records_event);
+  void ProcessOutOfOrderEventsDiscardedEvent(
+      const orbit_grpc_protos::OutOfOrderEventsDiscardedEvent& out_of_order_events_discarded_event);
 
   void ProcessMemoryUsageEvent(const orbit_grpc_protos::MemoryUsageEvent& memory_usage_event);
   void ExtractAndProcessSystemMemoryTrackingTimer(
@@ -166,8 +176,23 @@ void CaptureEventProcessorForListener::ProcessEvent(const ClientCaptureEvent& ev
     case ClientCaptureEvent::kApiEvent:
       api_event_processor_.ProcessApiEvent(event.api_event());
       break;
-    case ClientCaptureEvent::kMetadataEvent:
-      ProcessMetadataEvent(event.metadata_event());
+    case ClientCaptureEvent::kWarningEvent:
+      ProcessWarningEvent(event.warning_event());
+      break;
+    case ClientCaptureEvent::kClockResolutionEvent:
+      ProcessClockResolutionEvent(event.clock_resolution_event());
+      break;
+    case ClientCaptureEvent::kErrorsWithPerfEventOpenEvent:
+      ProcessErrorsWithPerfEventOpenEvent(event.errors_with_perf_event_open_event());
+      break;
+    case ClientCaptureEvent::kErrorEnablingOrbitApiEvent:
+      ProcessErrorEnablingOrbitApiEvent(event.error_enabling_orbit_api_event());
+      break;
+    case ClientCaptureEvent::kLostPerfRecordsEvent:
+      ProcessLostPerfRecordsEvent(event.lost_perf_records_event());
+      break;
+    case ClientCaptureEvent::kOutOfOrderEventsDiscardedEvent:
+      ProcessOutOfOrderEventsDiscardedEvent(event.out_of_order_events_discarded_event());
       break;
     case ClientCaptureEvent::kCaptureFinished:
       ProcessCaptureFinished(event.capture_finished());
@@ -624,9 +649,34 @@ void CaptureEventProcessorForListener::ProcessTracepointEvent(
   capture_listener_->OnTracepointEvent(std::move(tracepoint_event_info));
 }
 
-void orbit_capture_client::CaptureEventProcessorForListener::ProcessMetadataEvent(
-    const orbit_grpc_protos::MetadataEvent& metadata_event) {
-  capture_listener_->OnMetadataEvent(metadata_event);
+void CaptureEventProcessorForListener::ProcessWarningEvent(
+    const orbit_grpc_protos::WarningEvent& warning_event) {
+  capture_listener_->OnWarningEvent(warning_event);
+}
+
+void CaptureEventProcessorForListener::ProcessClockResolutionEvent(
+    const orbit_grpc_protos::ClockResolutionEvent& clock_resolution_event) {
+  capture_listener_->OnClockResolutionEvent(clock_resolution_event);
+}
+
+void CaptureEventProcessorForListener::ProcessErrorsWithPerfEventOpenEvent(
+    const orbit_grpc_protos::ErrorsWithPerfEventOpenEvent& errors_with_perf_event_open_event) {
+  capture_listener_->OnErrorsWithPerfEventOpenEvent(errors_with_perf_event_open_event);
+}
+
+void CaptureEventProcessorForListener::ProcessErrorEnablingOrbitApiEvent(
+    const orbit_grpc_protos::ErrorEnablingOrbitApiEvent& error_enabling_orbit_api_event) {
+  capture_listener_->OnErrorEnablingOrbitApiEvent(error_enabling_orbit_api_event);
+}
+
+void CaptureEventProcessorForListener::ProcessLostPerfRecordsEvent(
+    const orbit_grpc_protos::LostPerfRecordsEvent& lost_perf_records_event) {
+  capture_listener_->OnLostPerfRecordsEvent(lost_perf_records_event);
+}
+
+void CaptureEventProcessorForListener::ProcessOutOfOrderEventsDiscardedEvent(
+    const orbit_grpc_protos::OutOfOrderEventsDiscardedEvent& out_of_order_events_discarded_event) {
+  capture_listener_->OnOutOfOrderEventsDiscardedEvent(out_of_order_events_discarded_event);
 }
 
 uint64_t CaptureEventProcessorForListener::GetStringHashAndSendToListenerIfNecessary(

--- a/src/CaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
+++ b/src/CaptureClient/CaptureEventProcessorProcessEventsFuzzer.cpp
@@ -55,7 +55,18 @@ class MyCaptureListener : public CaptureListener {
                       orbit_grpc_protos::ModuleInfo /*module_info*/) override {}
   void OnModulesSnapshot(uint64_t /*timestamp_ns*/,
                          std::vector<orbit_grpc_protos::ModuleInfo> /*module_infos*/) override {}
-  void OnMetadataEvent(const orbit_grpc_protos::MetadataEvent& /*metadata_event*/) override {}
+  void OnWarningEvent(orbit_grpc_protos::WarningEvent /*warning_event*/) override {}
+  void OnClockResolutionEvent(
+      orbit_grpc_protos::ClockResolutionEvent /*clock_resolution_event*/) override {}
+  void OnErrorsWithPerfEventOpenEvent(
+      orbit_grpc_protos::ErrorsWithPerfEventOpenEvent /*errors_with_perf_event_open_event*/)
+      override {}
+  void OnErrorEnablingOrbitApiEvent(
+      orbit_grpc_protos::ErrorEnablingOrbitApiEvent /*error_enabling_orbit_api_event*/) override {}
+  void OnLostPerfRecordsEvent(
+      orbit_grpc_protos::LostPerfRecordsEvent /*lost_perf_records_event*/) override {}
+  void OnOutOfOrderEventsDiscardedEvent(orbit_grpc_protos::OutOfOrderEventsDiscardedEvent
+                                        /*out_of_order_events_discarded_event*/) override {}
 };
 }  // namespace
 

--- a/src/CaptureClient/include/CaptureClient/CaptureListener.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureListener.h
@@ -41,7 +41,17 @@ class CaptureListener {
                                       orbit_grpc_protos::TracepointInfo tracepoint_info) = 0;
   virtual void OnTracepointEvent(
       orbit_client_protos::TracepointEventInfo tracepoint_event_info) = 0;
-  virtual void OnMetadataEvent(const orbit_grpc_protos::MetadataEvent& metadata_event) = 0;
+  virtual void OnWarningEvent(orbit_grpc_protos::WarningEvent warning_event) = 0;
+  virtual void OnClockResolutionEvent(
+      orbit_grpc_protos::ClockResolutionEvent clock_resolution_event) = 0;
+  virtual void OnErrorsWithPerfEventOpenEvent(
+      orbit_grpc_protos::ErrorsWithPerfEventOpenEvent errors_with_perf_event_open_event) = 0;
+  virtual void OnErrorEnablingOrbitApiEvent(
+      orbit_grpc_protos::ErrorEnablingOrbitApiEvent error_enabling_orbit_api_event) = 0;
+  virtual void OnLostPerfRecordsEvent(
+      orbit_grpc_protos::LostPerfRecordsEvent lost_perf_records_event) = 0;
+  virtual void OnOutOfOrderEventsDiscardedEvent(
+      orbit_grpc_protos::OutOfOrderEventsDiscardedEvent out_of_order_events_discarded_event) = 0;
 };
 
 }  // namespace orbit_capture_client

--- a/src/ClientModel/CaptureDeserializerLoadFuzzer.cpp
+++ b/src/ClientModel/CaptureDeserializerLoadFuzzer.cpp
@@ -45,7 +45,18 @@ class MockCaptureListener : public orbit_capture_client::CaptureListener {
                       orbit_grpc_protos::ModuleInfo /*module_info*/) override {}
   void OnModulesSnapshot(uint64_t /*timestamp_ns*/,
                          std::vector<orbit_grpc_protos::ModuleInfo> /*module_infos*/) override {}
-  void OnMetadataEvent(const orbit_grpc_protos::MetadataEvent& /*metadata_event*/) override {}
+  void OnWarningEvent(orbit_grpc_protos::WarningEvent /*warning_event*/) override {}
+  void OnClockResolutionEvent(
+      orbit_grpc_protos::ClockResolutionEvent /*clock_resolution_event*/) override {}
+  void OnErrorsWithPerfEventOpenEvent(
+      orbit_grpc_protos::ErrorsWithPerfEventOpenEvent /*errors_with_perf_event_open_event*/)
+      override {}
+  void OnErrorEnablingOrbitApiEvent(
+      orbit_grpc_protos::ErrorEnablingOrbitApiEvent /*error_enabling_orbit_api_event*/) override {}
+  void OnLostPerfRecordsEvent(
+      orbit_grpc_protos::LostPerfRecordsEvent /*lost_perf_records_event*/) override {}
+  void OnOutOfOrderEventsDiscardedEvent(orbit_grpc_protos::OutOfOrderEventsDiscardedEvent
+                                        /*out_of_order_events_discarded_event*/) override {}
 };
 
 void WriteMessage(const google::protobuf::Message* message,

--- a/src/ClientModel/CaptureDeserializerTest.cpp
+++ b/src/ClientModel/CaptureDeserializerTest.cpp
@@ -84,8 +84,23 @@ class MockCaptureListener : public CaptureListener {
   MOCK_METHOD(void, OnUniqueTracepointInfo, (uint64_t /*key*/, TracepointInfo /*tracepoint_info*/),
               (override));
   MOCK_METHOD(void, OnTracepointEvent, (TracepointEventInfo), (override));
-  MOCK_METHOD(void, OnMetadataEvent, (const orbit_grpc_protos::MetadataEvent& /*metadata_event*/),
+  MOCK_METHOD(void, OnWarningEvent, (orbit_grpc_protos::WarningEvent /*warning_event*/),
               (override));
+  MOCK_METHOD(void, OnClockResolutionEvent,
+              (orbit_grpc_protos::ClockResolutionEvent /*clock_resolution_event*/), (override));
+  MOCK_METHOD(
+      void, OnErrorsWithPerfEventOpenEvent,
+      (orbit_grpc_protos::ErrorsWithPerfEventOpenEvent /*errors_with_perf_event_open_event*/),
+      (override));
+  MOCK_METHOD(void, OnErrorEnablingOrbitApiEvent,
+              (orbit_grpc_protos::ErrorEnablingOrbitApiEvent /*error_enabling_orbit_api_event*/),
+              (override));
+  MOCK_METHOD(void, OnLostPerfRecordsEvent,
+              (orbit_grpc_protos::LostPerfRecordsEvent /*lost_perf_records_event*/), (override));
+  MOCK_METHOD(
+      void, OnOutOfOrderEventsDiscardedEvent,
+      (orbit_grpc_protos::OutOfOrderEventsDiscardedEvent /*out_of_order_events_discarded_event*/),
+      (override));
 };
 
 TEST(CaptureDeserializer, LoadFileNotExists) {

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -425,12 +425,6 @@ message WarningEvent {
   bytes message = 2;
 }
 
-message InfoEvent {
-  uint64 timestamp_ns = 1;
-  // This is a string, we use bytes to avoid UTF-8 validation.
-  bytes message = 2;
-}
-
 message ErrorEnablingOrbitApiEvent {
   uint64 timestamp_ns = 1;
   // This is a string, we use bytes to avoid UTF-8 validation.
@@ -458,20 +452,8 @@ message OutOfOrderEventsDiscardedEvent {
   uint64 end_timestamp_ns = 2;
 }
 
-message MetadataEvent {
-  oneof event {
-    WarningEvent warning_event = 1;
-    InfoEvent info_event = 2;
-    ErrorEnablingOrbitApiEvent error_enabling_orbit_api_event = 3;
-    ClockResolutionEvent clock_resolution_event = 4;
-    ErrorsWithPerfEventOpenEvent errors_with_perf_event_open_event = 5;
-    LostPerfRecordsEvent lost_perf_records_event = 6;
-    OutOfOrderEventsDiscardedEvent out_of_order_events_discarded_event = 7;
-  }
-}
-
 message ClientCaptureEvent {
-  reserved 23, 28, 29;
+  reserved 23, 28, 29, 30;
 
   oneof event {
     // Note that field numbers from 1-15 take only 1 byte to encode
@@ -479,6 +461,8 @@ message ClientCaptureEvent {
     // use them for high frequency events. For the rest please assign
     // numbers starting with 16.
     //
+    // Next high-frequency ID: 10
+    // Next lower-frequency ID: 38
     // Please keep these alphabetically ordered.
 
     // Even though AddressInfo is a high-frequency event
@@ -489,6 +473,9 @@ message ClientCaptureEvent {
     CallstackSample callstack_sample = 1;
     CaptureFinished capture_finished = 27;
     CaptureStarted capture_started = 24;
+    ClockResolutionEvent clock_resolution_event = 34;
+    ErrorEnablingOrbitApiEvent error_enabling_orbit_api_event = 33;
+    ErrorsWithPerfEventOpenEvent errors_with_perf_event_open_event = 35;
     FunctionCall function_call = 2;
     GpuJob gpu_job = 3;
     GpuQueueSubmission gpu_queue_submission = 4;
@@ -496,30 +483,38 @@ message ClientCaptureEvent {
     InternedString interned_string = 18;
     InternedTracepointInfo interned_tracepoint_info = 19;
     IntrospectionScope introspection_scope = 20;
+    LostPerfRecordsEvent lost_perf_records_event = 36;
     MemoryUsageEvent memory_usage_event = 31;
-    MetadataEvent metadata_event = 30;
     ModulesSnapshot modules_snapshot = 25;
     ModuleUpdateEvent module_update_event = 21;
+    OutOfOrderEventsDiscardedEvent out_of_order_events_discarded_event = 37;
     SchedulingSlice scheduling_slice = 6;
     ThreadName thread_name = 22;
     ThreadNamesSnapshot thread_names_snapshot = 26;
     ThreadStateSlice thread_state_slice = 7;
     TracepointEvent tracepoint_event = 8;
+    WarningEvent warning_event = 32;
   }
 }
 
 message ProducerCaptureEvent {
-  reserved 22, 26, 27;
+  reserved 22, 26, 27, 28;
   oneof event {
     // Note that field numbers from 1-15 take only 1 byte to encode
     // https://developers.google.com/protocol-buffers/docs/proto#assigning_field_numbers
     // use them for high frequency events. For the rest please assign
     // numbers starting with 16.
     //
+    // Next high-frequency ID: 11
+    // Next lower-frequency ID: 36
+    //
     // Please keep these alphabetically ordered.
     ApiEvent api_event = 10;
     CallstackSample callstack_sample = 1;
     CaptureStarted capture_started = 23;
+    ClockResolutionEvent clock_resolution_event = 32;
+    ErrorEnablingOrbitApiEvent error_enabling_orbit_api_event = 31;
+    ErrorsWithPerfEventOpenEvent errors_with_perf_event_open_event = 33;
     FullCallstackSample full_callstack_sample = 2;
 
     // Even though AddressInfo is a high-frequency event
@@ -533,13 +528,15 @@ message ProducerCaptureEvent {
     InternedCallstack interned_callstack = 7;
     InternedString interned_string = 18;
     IntrospectionScope introspection_scope = 19;
+    LostPerfRecordsEvent lost_perf_records_event = 34;
     MemoryUsageEvent memory_usage_event = 29;
-    MetadataEvent metadata_event = 28;
     ModulesSnapshot modules_snapshot = 25;
     ModuleUpdateEvent module_update_event = 20;
+    OutOfOrderEventsDiscardedEvent out_of_order_events_discarded_event = 35;
     SchedulingSlice scheduling_slice = 8;
     ThreadName thread_name = 21;
     ThreadNamesSnapshot thread_names_snapshot = 24;
     ThreadStateSlice thread_state_slice = 9;
+    WarningEvent warning_event = 30;
   }
 }

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -157,7 +157,17 @@ class OrbitApp final : public DataViewFactory,
   void OnModuleUpdate(uint64_t timestamp_ns, orbit_grpc_protos::ModuleInfo module_info) override;
   void OnModulesSnapshot(uint64_t timestamp_ns,
                          std::vector<orbit_grpc_protos::ModuleInfo> module_infos) override;
-  void OnMetadataEvent(const orbit_grpc_protos::MetadataEvent& metadata_event) override;
+  void OnWarningEvent(orbit_grpc_protos::WarningEvent warning_event) override;
+  void OnClockResolutionEvent(
+      orbit_grpc_protos::ClockResolutionEvent clock_resolution_event) override;
+  void OnErrorsWithPerfEventOpenEvent(
+      orbit_grpc_protos::ErrorsWithPerfEventOpenEvent errors_with_perf_event_open_event) override;
+  void OnErrorEnablingOrbitApiEvent(
+      orbit_grpc_protos::ErrorEnablingOrbitApiEvent error_enabling_orbit_api_event) override;
+  void OnLostPerfRecordsEvent(
+      orbit_grpc_protos::LostPerfRecordsEvent lost_perf_records_event) override;
+  void OnOutOfOrderEventsDiscardedEvent(orbit_grpc_protos::OutOfOrderEventsDiscardedEvent
+                                            out_of_order_events_discarded_event) override;
 
   void OnValidateFramePointers(
       std::vector<const orbit_client_data::ModuleData*> modules_to_validate);

--- a/src/Service/CaptureServiceImpl.cpp
+++ b/src/Service/CaptureServiceImpl.cpp
@@ -37,7 +37,6 @@ using orbit_grpc_protos::CaptureOptions;
 using orbit_grpc_protos::CaptureRequest;
 using orbit_grpc_protos::CaptureResponse;
 using orbit_grpc_protos::CaptureStarted;
-using orbit_grpc_protos::MetadataEvent;
 using orbit_grpc_protos::ProducerCaptureEvent;
 
 namespace {
@@ -237,9 +236,8 @@ static ProducerCaptureEvent CreateCaptureStartedEvent(const CaptureOptions& capt
 static ProducerCaptureEvent CreateClockResolutionEvent(uint64_t timestamp_ns,
                                                        uint64_t resolution_ns) {
   ProducerCaptureEvent event;
-  MetadataEvent* metadata_event = event.mutable_metadata_event();
   orbit_grpc_protos::ClockResolutionEvent* clock_resolution_event =
-      metadata_event->mutable_clock_resolution_event();
+      event.mutable_clock_resolution_event();
   clock_resolution_event->set_timestamp_ns(timestamp_ns);
   clock_resolution_event->set_clock_resolution_ns(resolution_ns);
   return event;
@@ -248,9 +246,8 @@ static ProducerCaptureEvent CreateClockResolutionEvent(uint64_t timestamp_ns,
 static ProducerCaptureEvent CreateErrorEnablingOrbitApiEvent(uint64_t timestamp_ns,
                                                              std::string message) {
   ProducerCaptureEvent event;
-  MetadataEvent* metadata_event = event.mutable_metadata_event();
   orbit_grpc_protos::ErrorEnablingOrbitApiEvent* error_enabling_orbit_api_event =
-      metadata_event->mutable_error_enabling_orbit_api_event();
+      event.mutable_error_enabling_orbit_api_event();
   error_enabling_orbit_api_event->set_timestamp_ns(timestamp_ns);
   error_enabling_orbit_api_event->set_message(std::move(message));
   return event;
@@ -258,8 +255,7 @@ static ProducerCaptureEvent CreateErrorEnablingOrbitApiEvent(uint64_t timestamp_
 
 static ProducerCaptureEvent CreateWarningEvent(uint64_t timestamp_ns, std::string message) {
   ProducerCaptureEvent event;
-  MetadataEvent* metadata_event = event.mutable_metadata_event();
-  orbit_grpc_protos::WarningEvent* warning_event = metadata_event->mutable_warning_event();
+  orbit_grpc_protos::WarningEvent* warning_event = event.mutable_warning_event();
   warning_event->set_timestamp_ns(timestamp_ns);
   warning_event->set_message(std::move(message));
   return event;

--- a/src/Service/LinuxTracingHandler.cpp
+++ b/src/Service/LinuxTracingHandler.cpp
@@ -144,23 +144,21 @@ void LinuxTracingHandler::OnModulesSnapshot(orbit_grpc_protos::ModulesSnapshot m
 void LinuxTracingHandler::OnErrorsWithPerfEventOpenEvent(
     orbit_grpc_protos::ErrorsWithPerfEventOpenEvent errors_with_perf_event_open_event) {
   ProducerCaptureEvent event;
-  *event.mutable_metadata_event()->mutable_errors_with_perf_event_open_event() =
-      std::move(errors_with_perf_event_open_event);
+  *event.mutable_errors_with_perf_event_open_event() = std::move(errors_with_perf_event_open_event);
   producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
 void LinuxTracingHandler::OnLostPerfRecordsEvent(
     orbit_grpc_protos::LostPerfRecordsEvent lost_perf_records_event) {
   orbit_grpc_protos::ProducerCaptureEvent event;
-  *event.mutable_metadata_event()->mutable_lost_perf_records_event() =
-      std::move(lost_perf_records_event);
+  *event.mutable_lost_perf_records_event() = std::move(lost_perf_records_event);
   producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
 void LinuxTracingHandler::OnOutOfOrderEventsDiscardedEvent(
     orbit_grpc_protos::OutOfOrderEventsDiscardedEvent out_of_order_events_discarded_event) {
   orbit_grpc_protos::ProducerCaptureEvent event;
-  *event.mutable_metadata_event()->mutable_out_of_order_events_discarded_event() =
+  *event.mutable_out_of_order_events_discarded_event() =
       std::move(out_of_order_events_discarded_event);
   producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }


### PR DESCRIPTION
Move contained events up, to `ProducerCaptureEvent` and `ClientCaptureEvent`.
Also removed unused `InfoEvent`.
This is mostly moving some code around, adding some trivial methods, and
adding tests for those methods (all similar to each other).

Note: We don't need to take care of backwards compatibility because
`MetadataEvent` was introduced *after* 1.65, so we are still in time to change
it before the 1.66 branch cut.

Bug: http://b/192857660

Test: Take some captures in conditions that generate some of the events
involved.