### PR TITLE
Fix filtering in ModulesDataView

### DIFF
--- a/src/OrbitGl/ModulesDataView.cpp
+++ b/src/OrbitGl/ModulesDataView.cpp
@@ -179,8 +179,7 @@ void ModulesDataView::DoFilter() {
   std::vector<uint64_t> indices;
   std::vector<std::string> tokens = absl::StrSplit(absl::AsciiStrToLower(filter_), ' ');
 
-  for (uint64_t start_address : indices_) {
-    const ModuleInMemory& memory_space = start_address_to_module_in_memory_.at(start_address);
+  for (const auto& [start_address, memory_space] : start_address_to_module_in_memory_) {
     std::string module_string = absl::StrFormat("%s %s", memory_space.FormattedAddressRange(),
                                                 absl::AsciiStrToLower(memory_space.file_path()));
 


### PR DESCRIPTION
We used to filter the same indices over and over again which
means the module list cannot get longer anymore.

Bug: http://b/192928050