### PR TITLE
Add tooltips for memory tracks and pagefault tracks

### DIFF
--- a/src/OrbitGl/AnnotationTrack.cpp
+++ b/src/OrbitGl/AnnotationTrack.cpp
@@ -7,6 +7,7 @@
 namespace {
 
 const Color kWhite(255, 255, 255, 255);
+const Color kTransparentWhite(255, 255, 255, 0);
 const Color kThresholdColor(244, 67, 54, 255);
 
 }  // namespace
@@ -32,6 +33,13 @@ void AnnotationTrack::DrawAnnotation(Batcher& batcher, TextRenderer& text_render
     text_renderer.AddText(text.c_str(), text_box_position[0],
                           text_box_position[1] + layout->GetTextOffset(), z, kWhite, font_size,
                           text_box_size[0]);
+
+    if (!value_upper_bound_tooltips_.empty()) {
+      auto user_data = std::make_unique<PickingUserData>(
+          nullptr, [&](PickingId /*id*/) { return this->GetValueUpperBoundTooltips(); });
+      batcher.AddShadedBox(text_box_position, text_box_size, z, kTransparentWhite,
+                           std::move(user_data));
+    }
   }
 
   // Add value lower bound text box.

--- a/src/OrbitGl/AnnotationTrack.h
+++ b/src/OrbitGl/AnnotationTrack.h
@@ -34,6 +34,13 @@ class AnnotationTrack {
   virtual void SetValueLowerBound(const std::string& pretty_label, double raw_value) {
     value_lower_bound_ = std::make_pair(pretty_label, raw_value);
   }
+  void SetValueUpperBoundTooltips(std::string value_upper_bound_tooltips) {
+    value_upper_bound_tooltips_ = std::move(value_upper_bound_tooltips);
+  }
+
+  [[nodiscard]] std::string GetValueUpperBoundTooltips() const {
+    return value_upper_bound_tooltips_;
+  }
 
   void DrawAnnotation(Batcher& batcher, TextRenderer& text_renderer, TimeGraphLayout* layout,
                       float z);
@@ -47,6 +54,8 @@ class AnnotationTrack {
   std::optional<std::pair<std::string, double>> warning_threshold_ = std::nullopt;
   std::optional<std::pair<std::string, double>> value_upper_bound_ = std::nullopt;
   std::optional<std::pair<std::string, double>> value_lower_bound_ = std::nullopt;
+
+  std::string value_upper_bound_tooltips_;
 };
 
 #endif  // ORBIT_GL_ANNOTATION_TRACK_H_

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -54,9 +54,7 @@ void GraphTrack<Dimension>::Draw(Batcher& batcher, TextRenderer& text_renderer,
                                  uint64_t current_mouse_time_ns, PickingMode picking_mode,
                                  float z_offset) {
   Track::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, z_offset);
-  if (IsEmpty() || picking_mode != PickingMode::kNone) return;
-
-  if (IsCollapsed()) return;
+  if (IsEmpty() || IsCollapsed()) return;
 
   // Draw label
   const std::array<double, Dimension>& values =
@@ -230,6 +228,7 @@ void GraphTrack<Dimension>::DrawLegend(Batcher& batcher, TextRenderer& text_rend
   float x0 = pos_[0] + layout_->GetRightMargin();
   float y0 = pos_[1] - layout_->GetTrackTabHeight() - layout_->GetTextBoxHeight() / 2.f;
   uint32_t font_size = GetLegendFontSize();
+  const Color kTransparentWhite(255, 255, 255, 0);
 
   for (size_t i = 0; i < Dimension; ++i) {
     batcher.AddShadedBox(Vec2(x0, y0 - legend_symbol_height / 2.f),
@@ -242,7 +241,13 @@ void GraphTrack<Dimension>::DrawLegend(Batcher& batcher, TextRenderer& text_rend
     text_renderer.AddText(series_names[i].c_str(), legend_text_box_position[0],
                           legend_text_box_position[1] + layout_->GetTextOffset(), z,
                           legend_text_color, font_size, legend_text_box_size[0]);
+
     x0 += legend_text_width + kSpaceBetweenLegendEntries;
+
+    auto user_data = std::make_unique<PickingUserData>(
+        nullptr, [&, i](PickingId /*id*/) { return this->GetLegendTooltips(i); });
+    batcher.AddShadedBox(legend_text_box_position, legend_text_box_size, z, kTransparentWhite,
+                         std::move(user_data));
   }
 }
 

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -52,6 +52,13 @@ class GraphTrack : public Track {
   void SetSeriesColors(const std::array<Color, Dimension>& series_colors) {
     series_colors_ = series_colors;
   }
+  void SetLegendTooltips(std::array<std::string, Dimension> legend_tooltips) {
+    legend_tooltips_ = std::move(legend_tooltips);
+  }
+  [[nodiscard]] std::string GetLegendTooltips(size_t i) const {
+    CHECK(i < Dimension);
+    return legend_tooltips_[i];
+  }
 
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
   [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllChains() const override;
@@ -97,6 +104,7 @@ class GraphTrack : public Track {
                              const std::array<float, Dimension>& normalized_values, float z);
 
   std::optional<std::array<Color, Dimension>> series_colors_;
+  std::array<std::string, Dimension> legend_tooltips_;
 };
 
 #endif  // ORBIT_GL_GRAPH_TRACK_H_

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -52,6 +52,7 @@ class GraphTrack : public Track {
   void SetSeriesColors(const std::array<Color, Dimension>& series_colors) {
     series_colors_ = series_colors;
   }
+
   void SetLegendTooltips(std::array<std::string, Dimension> legend_tooltips) {
     legend_tooltips_ = std::move(legend_tooltips);
   }
@@ -59,6 +60,11 @@ class GraphTrack : public Track {
     CHECK(i < Dimension);
     return legend_tooltips_[i];
   }
+
+  void SetTrackTabTooltip(std::string track_tab_tooltip) {
+    track_tab_tooltip_ = std::move(track_tab_tooltip);
+  }
+  [[nodiscard]] std::string GetTooltip() const override { return track_tab_tooltip_; }
 
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
   [[nodiscard]] std::vector<std::shared_ptr<TimerChain>> GetAllChains() const override;
@@ -105,6 +111,7 @@ class GraphTrack : public Track {
 
   std::optional<std::array<Color, Dimension>> series_colors_;
   std::array<std::string, Dimension> legend_tooltips_;
+  std::string track_tab_tooltip_;
 };
 
 #endif  // ORBIT_GL_GRAPH_TRACK_H_

--- a/src/OrbitGl/MemoryTrack.cpp
+++ b/src/OrbitGl/MemoryTrack.cpp
@@ -18,7 +18,7 @@ void MemoryTrack<Dimension>::Draw(Batcher& batcher, TextRenderer& text_renderer,
   GraphTrack<Dimension>::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode,
                               z_offset);
 
-  if (picking_mode != PickingMode::kNone || this->collapse_toggle_->IsCollapsed()) return;
+  if (this->collapse_toggle_->IsCollapsed()) return;
   AnnotationTrack::DrawAnnotation(batcher, text_renderer, this->layout_,
                                   GlCanvas::kZValueTrackText + z_offset);
 }

--- a/src/OrbitGl/PagefaultTrack.cpp
+++ b/src/OrbitGl/PagefaultTrack.cpp
@@ -26,6 +26,17 @@ PagefaultTrack::PagefaultTrack(CaptureViewElement* parent, TimeGraph* time_graph
           indentation_level + 1)} {
   SetName("Pagefault Track");
   SetLabel("Pagefault Track");
+
+  const std::string kMajorPagefaultSubtrackTabTooltip =
+      "Shows major pagefault statistics. A major pagefault occurs when the requested page does "
+      "not reside in the main memory or CPU cache, and has to be swapped from an external "
+      "storage. The major pagefaults might cause slow performance of the target process.";
+  major_pagefault_track_->SetTrackTabTooltip(kMajorPagefaultSubtrackTabTooltip);
+
+  const std::string kMinorPagefaultSubtrackTabTooltip =
+      "Shows minor pagefault statistics. A minor pagefault occurs when the requested page "
+      "resides in main memory but the process cannot access it.";
+  minor_pagefault_track_->SetTrackTabTooltip(kMinorPagefaultSubtrackTabTooltip);
 }
 
 float PagefaultTrack::GetHeight() const {
@@ -50,6 +61,11 @@ std::vector<orbit_gl::CaptureViewElement*> PagefaultTrack::GetVisibleChildren() 
   if (!major_pagefault_track_->IsEmpty()) result.push_back(major_pagefault_track_.get());
   if (!minor_pagefault_track_->IsEmpty()) result.push_back(minor_pagefault_track_.get());
   return result;
+}
+
+std::string PagefaultTrack::GetTooltip() const {
+  if (collapse_toggle_->IsCollapsed()) return major_pagefault_track_->GetTooltip();
+  return "Shows the minor and major pagefault statistics.";
 }
 
 void PagefaultTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,

--- a/src/OrbitGl/PagefaultTrack.h
+++ b/src/OrbitGl/PagefaultTrack.h
@@ -59,6 +59,14 @@ class PagefaultTrack : public Track {
   void SetIndexOfSeriesToHighlightForMajorPagefaultTrack(size_t series_index) {
     major_pagefault_track_->SetIndexOfSeriesToHighlight(series_index);
   }
+  void SetLegendTooltipsForMajorPagefaultSubtrack(
+      std::array<std::string, kBasicPagefaultTrackDimension> tooltips) {
+    major_pagefault_track_->SetLegendTooltips(std::move(tooltips));
+  }
+  void SetLegendTooltipsForMinorPagefaultSubtrack(
+      std::array<std::string, kBasicPagefaultTrackDimension> tooltips) {
+    minor_pagefault_track_->SetLegendTooltips(std::move(tooltips));
+  }
 
  private:
   void UpdatePositionOfSubtracks();

--- a/src/OrbitGl/PagefaultTrack.h
+++ b/src/OrbitGl/PagefaultTrack.h
@@ -27,6 +27,7 @@ class PagefaultTrack : public Track {
   [[nodiscard]] Type GetType() const override { return Type::kPagefaultTrack; }
   [[nodiscard]] float GetHeight() const override;
   [[nodiscard]] std::vector<CaptureViewElement*> GetVisibleChildren() override;
+  [[nodiscard]] std::string GetTooltip() const override;
 
   [[nodiscard]] bool IsEmpty() const override {
     return major_pagefault_track_->IsEmpty() && minor_pagefault_track_->IsEmpty();

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -629,6 +629,43 @@ void TimeGraph::ProcessPagefaultTrackingTimer(const orbit_client_protos::TimerIn
         absl::StrFormat("CGroup [%s]", cgroup_name), "System"};
     track = track_manager_->CreateAndGetPagefaultTrack(kSeriesNames);
     track->SetIndexOfSeriesToHighlightForMajorPagefaultTrack(0);
+
+    const std::string kProcessMajorPagefaultTooltips = absl::StrFormat(
+        "<b># of major pagefaults incurred by the %s process during the sampling "
+        "period.</b><br/><br/>"
+        "Derived from the <i>majflt</i> field in file <i>/proc/%d/stat</i>.",
+        capture_data_->process_name(), timer_info.process_id());
+    const std::string kCGroupMajorPagefaultTooltips = absl::StrFormat(
+        "<b># of major pagefaults incurred by the %s cgroup during the sampling "
+        "period.</b><br/><br/>"
+        "Derived from the <i>pgmajfault</i> field in file "
+        "<i>/sys/fs/cgroup/memory/%s/memory.stat</i>.",
+        cgroup_name, cgroup_name);
+    const std::string kSystemMajorPagefaultTooltips =
+        "<b># of system-wide major pagefaults occurred durning the sampling period.</b><br/><br/>"
+        "Derived from the <i>pgmajfault</i> field in file <i>/proc/vmstat</i>.";
+    track->SetLegendTooltipsForMajorPagefaultSubtrack({kProcessMajorPagefaultTooltips,
+                                                       kCGroupMajorPagefaultTooltips,
+                                                       kSystemMajorPagefaultTooltips});
+
+    const std::string kProcessMinorPagefaultTooltips = absl::StrFormat(
+        "<b># of minor pagefaults incurred by the %s process during the sampling "
+        "period.</b><br/><br/>"
+        "Derived from the <i>minflt</i> field in file <i>/proc/%d/stat</i>.",
+        capture_data_->process_name(), timer_info.process_id());
+    const std::string kCGroupMinorPagefaultTooltips = absl::StrFormat(
+        "<b># of minor pagefaults incurred by the %s cgroup during the sampling "
+        "period.</b><br/><br/>"
+        "Derived from <i>pgfault - pgmajfault</i>,"
+        "which are two fields in file <i>/sys/fs/cgroup/memory/%s/memory.stat</i>.",
+        cgroup_name, cgroup_name);
+    const std::string kSystemMinorPagefaultTooltips =
+        "<b># of system-wide minor pagefaults occurred during the sampling period.</b><br/><br/>"
+        "Derived from <i>pgfault - pgmajfault</i>, which are two fields in file "
+        "<i>/proc/vmstat</i>.";
+    track->SetLegendTooltipsForMinorPagefaultSubtrack({kProcessMinorPagefaultTooltips,
+                                                       kCGroupMinorPagefaultTooltips,
+                                                       kSystemMinorPagefaultTooltips});
   }
   CHECK(track != nullptr);
 

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -568,6 +568,17 @@ void TimeGraph::ProcessCGroupAndProcessMemoryTrackingTimer(const TimerInfo& time
         cgroup_name, cgroup_name);
     track->SetLegendTooltips({kProcessRssAnonTooltips, kOtherRssAnonTooltips,
                               kCGroupMappedFileTooltips, kUnusedTooltips});
+
+    const std::string kGameCGroupName = "game";
+    constexpr float kGameCGroupLimitGB = 7;
+    if (cgroup_name == kGameCGroupName) {
+      const std::string kValueUpperBoundTooltips = absl::StrFormat(
+          "<b>The memory production limit of the %s cgroup is %.2fGB</b>.<br/><br/>"
+          "<i>To launch game with the production cgroup limits, add the flag "
+          "'--enforce-production-ram' to the 'ggp run' command</i>.",
+          kGameCGroupName, kGameCGroupLimitGB);
+      track->SetValueUpperBoundTooltips(kValueUpperBoundTooltips);
+    }
   }
 
   CHECK(track->GetNumberOfDecimalDigits().has_value());

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -470,12 +470,14 @@ SystemMemoryTrack* TrackManager::CreateAndGetSystemMemoryTrack(
     const std::string kTrackValueLabelUnit = "MB";
     const std::string kTrackName =
         absl::StrFormat("System Memory Usage (%s)", kTrackValueLabelUnit);
+    const std::string kTrackTabTooltip = "Shows system-wide memory usage information.";
 
     system_memory_track_ = std::make_shared<SystemMemoryTrack>(
         time_graph_, time_graph_, viewport_, layout_, kTrackName, series_names, capture_data_);
     system_memory_track_->SetLabelUnit(kTrackValueLabelUnit);
     system_memory_track_->SetNumberOfDecimalDigits(kTrackValueDecimalDigits);
     system_memory_track_->SetSeriesColors(orbit_gl::kSystemMemoryTrackColors);
+    system_memory_track_->SetTrackTabTooltip(kTrackTabTooltip);
     AddTrack(system_memory_track_);
   }
 
@@ -490,12 +492,17 @@ CGroupAndProcessMemoryTrack* TrackManager::CreateAndGetCGroupAndProcessMemoryTra
     const std::string kTrackValueLabelUnit = "MB";
     const std::string kTrackName =
         absl::StrFormat("CGroup Memory Usage (%s)", kTrackValueLabelUnit);
+    const std::string kTrackTabTooltip =
+        "Shows memory usage information for the target process and the memory cgroup it belongs "
+        "to. The target process will be killed when the overall used memory approaches the cgroup "
+        "limit.";
 
     cgroup_and_process_memory_track_ = std::make_shared<CGroupAndProcessMemoryTrack>(
         time_graph_, time_graph_, viewport_, layout_, kTrackName, series_names, capture_data_);
     cgroup_and_process_memory_track_->SetLabelUnit(kTrackValueLabelUnit);
     cgroup_and_process_memory_track_->SetNumberOfDecimalDigits(kTrackValueDecimalDigits);
     cgroup_and_process_memory_track_->SetSeriesColors(orbit_gl::kCGroupAndProcessMemoryTrackColors);
+    cgroup_and_process_memory_track_->SetTrackTabTooltip(kTrackTabTooltip);
     AddTrack(cgroup_and_process_memory_track_);
   }
 


### PR DESCRIPTION
With this change, we add the following tooltips to the memory tracks and pagefault tracks:
* Tooltips for the track tab: When moving the mouse over the track tab, a tooltip box pops up and shows the purpose of the track;
* Tooltips for the legends: When moving the mouse over the legend text box, a tooltip box pops up and shows the meaning of the data and how we collect the data;
* Tooltip for the value upper bound text box in the cgroup memory track: If the target process belongs to the `game` cgroup, when moving the mouse over the text box "CGroup [game] Memory Limit", a tooltip box pops and shows information about the production limit.