### PR TITLE
Add checkbox in capture settings to turn on user space instrumentation.

### DIFF
--- a/src/CaptureClient/CaptureClient.cpp
+++ b/src/CaptureClient/CaptureClient.cpp
@@ -93,14 +93,15 @@ Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> CaptureClient::Capture(
        unwinding_method, collect_scheduling_info, collect_thread_state, collect_gpu_jobs,
        enable_api, enable_introspection, enable_user_space_instrumentation,
        max_local_marker_depth_per_command_buffer, collect_memory_info, memory_sampling_period_ms,
-       enable_cgroup_memory, capture_event_processor = std::move(capture_event_processor)]() mutable {
-        return CaptureSync(
-            process_id, module_manager, selected_functions, selected_tracepoints,
-            samples_per_second, stack_dump_size, unwinding_method, collect_scheduling_info,
-            collect_thread_state, collect_gpu_jobs, enable_api, enable_introspection,
-            enable_user_space_instrumentation, max_local_marker_depth_per_command_buffer,
-            collect_memory_info, memory_sampling_period_ms, enable_cgroup_memory,
-            capture_event_processor.get());
+       enable_cgroup_memory,
+       capture_event_processor = std::move(capture_event_processor)]() mutable {
+        return CaptureSync(process_id, module_manager, selected_functions, selected_tracepoints,
+                           samples_per_second, stack_dump_size, unwinding_method,
+                           collect_scheduling_info, collect_thread_state, collect_gpu_jobs,
+                           enable_api, enable_introspection, enable_user_space_instrumentation,
+                           max_local_marker_depth_per_command_buffer, collect_memory_info,
+                           memory_sampling_period_ms, enable_cgroup_memory,
+                           capture_event_processor.get());
       });
 
   return capture_result;

--- a/src/CaptureClient/CaptureClient.cpp
+++ b/src/CaptureClient/CaptureClient.cpp
@@ -74,8 +74,8 @@ Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> CaptureClient::Capture(
     TracepointInfoSet selected_tracepoints, double samples_per_second, uint16_t stack_dump_size,
     UnwindingMethod unwinding_method, bool collect_scheduling_info, bool collect_thread_state,
     bool collect_gpu_jobs, bool enable_api, bool enable_introspection,
-    uint64_t max_local_marker_depth_per_command_buffer, bool collect_memory_info,
-    uint64_t memory_sampling_period_ms, bool enable_cgroup_memory,
+    bool enable_user_space_instrumentation, uint64_t max_local_marker_depth_per_command_buffer,
+    bool collect_memory_info, uint64_t memory_sampling_period_ms, bool enable_cgroup_memory,
     std::unique_ptr<CaptureEventProcessor> capture_event_processor) {
   absl::MutexLock lock(&state_mutex_);
   if (state_ != State::kStopped) {
@@ -91,15 +91,16 @@ Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> CaptureClient::Capture(
       [this, process_id, &module_manager, selected_functions = std::move(selected_functions),
        selected_tracepoints = std::move(selected_tracepoints), samples_per_second, stack_dump_size,
        unwinding_method, collect_scheduling_info, collect_thread_state, collect_gpu_jobs,
-       enable_api, enable_introspection, max_local_marker_depth_per_command_buffer,
-       collect_memory_info, memory_sampling_period_ms, enable_cgroup_memory,
-       capture_event_processor = std::move(capture_event_processor)]() mutable {
+       enable_api, enable_introspection, enable_user_space_instrumentation,
+       max_local_marker_depth_per_command_buffer, collect_memory_info, memory_sampling_period_ms,
+       enable_cgroup_memory, capture_event_processor = std::move(capture_event_processor)]() mutable {
         return CaptureSync(
             process_id, module_manager, selected_functions, selected_tracepoints,
             samples_per_second, stack_dump_size, unwinding_method, collect_scheduling_info,
             collect_thread_state, collect_gpu_jobs, enable_api, enable_introspection,
-            max_local_marker_depth_per_command_buffer, collect_memory_info,
-            memory_sampling_period_ms, enable_cgroup_memory, capture_event_processor.get());
+            enable_user_space_instrumentation, max_local_marker_depth_per_command_buffer,
+            collect_memory_info, memory_sampling_period_ms, enable_cgroup_memory,
+            capture_event_processor.get());
       });
 
   return capture_result;
@@ -136,8 +137,8 @@ ErrorMessageOr<CaptureListener::CaptureOutcome> CaptureClient::CaptureSync(
     const TracepointInfoSet& selected_tracepoints, double samples_per_second,
     uint16_t stack_dump_size, UnwindingMethod unwinding_method, bool collect_scheduling_info,
     bool collect_thread_state, bool collect_gpu_jobs, bool enable_api, bool enable_introspection,
-    uint64_t max_local_marker_depth_per_command_buffer, bool collect_memory_info,
-    uint64_t memory_sampling_period_ms, bool enable_cgroup_memory,
+    bool enable_user_space_instrumentation, uint64_t max_local_marker_depth_per_command_buffer,
+    bool collect_memory_info, uint64_t memory_sampling_period_ms, bool enable_cgroup_memory,
     CaptureEventProcessor* capture_event_processor) {
   ORBIT_SCOPE_FUNCTION;
   writes_done_failed_ = false;
@@ -201,6 +202,7 @@ ErrorMessageOr<CaptureListener::CaptureOutcome> CaptureClient::CaptureSync(
 
   capture_options->set_enable_api(enable_api);
   capture_options->set_enable_introspection(enable_introspection);
+  capture_options->set_enable_user_space_instrumentation(enable_user_space_instrumentation);
 
   auto api_functions = FindApiFunctions(module_manager);
   *(capture_options->mutable_api_functions()) = {api_functions.begin(), api_functions.end()};

--- a/src/CaptureClient/include/CaptureClient/CaptureClient.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureClient.h
@@ -45,9 +45,9 @@ class CaptureClient {
       orbit_client_data::TracepointInfoSet selected_tracepoints, double samples_per_second,
       uint16_t stack_dump_size, orbit_grpc_protos::UnwindingMethod unwinding_method,
       bool collect_scheduling_info, bool collect_thread_state, bool collect_gpu_jobs,
-      bool enable_api, bool enable_introspection,
-      bool enable_user_space_instrumentation, uint64_t max_local_marker_depth_per_command_buffer,
-      bool collect_memory_info, uint64_t memory_sampling_period_ms, bool enable_cgroup_memory,
+      bool enable_api, bool enable_introspection, bool enable_user_space_instrumentation,
+      uint64_t max_local_marker_depth_per_command_buffer, bool collect_memory_info,
+      uint64_t memory_sampling_period_ms, bool enable_cgroup_memory,
       std::unique_ptr<CaptureEventProcessor> capture_event_processor);
 
   // Returns true if stop was initiated and false otherwise.

--- a/src/CaptureClient/include/CaptureClient/CaptureClient.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureClient.h
@@ -46,8 +46,8 @@ class CaptureClient {
       uint16_t stack_dump_size, orbit_grpc_protos::UnwindingMethod unwinding_method,
       bool collect_scheduling_info, bool collect_thread_state, bool collect_gpu_jobs,
       bool enable_api, bool enable_introspection,
-      uint64_t max_local_marker_depth_per_command_buffer, bool collect_memory_info,
-      uint64_t memory_sampling_period_ms, bool enable_cgroup_memory,
+      bool enable_user_space_instrumentation, uint64_t max_local_marker_depth_per_command_buffer,
+      bool collect_memory_info, uint64_t memory_sampling_period_ms, bool enable_cgroup_memory,
       std::unique_ptr<CaptureEventProcessor> capture_event_processor);
 
   // Returns true if stop was initiated and false otherwise.
@@ -80,7 +80,7 @@ class CaptureClient {
       const orbit_client_data::TracepointInfoSet& selected_tracepoints, double samples_per_second,
       uint16_t stack_dump_size, orbit_grpc_protos::UnwindingMethod unwinding_method,
       bool collect_scheduling_info, bool collect_thread_state, bool collect_gpu_jobs,
-      bool enable_api, bool enable_introspection,
+      bool enable_api, bool enable_introspection, bool enable_user_space_instrumentation,
       uint64_t max_local_marker_depth_per_command_buffer, bool collect_memory_info,
       uint64_t memory_sampling_period_ms, bool enable_cgroup_memory,
       CaptureEventProcessor* capture_event_processor);

--- a/src/FakeClient/FakeClientMain.cpp
+++ b/src/FakeClient/FakeClientMain.cpp
@@ -184,6 +184,7 @@ int main(int argc, char* argv[]) {
   LOG("collect_gpu_jobs=%d", collect_gpu_jobs);
   constexpr bool kEnableApi = false;
   constexpr bool kEnableIntrospection = false;
+  constexpr bool kEnableUserSpaceInstrumentation = false;
   constexpr uint64_t kMaxLocalMarkerDepthPerCommandBuffer = std::numeric_limits<uint64_t>::max();
   bool collect_memory_info = absl::GetFlag(FLAGS_memory_sampling_rate) > 0;
   LOG("collect_memory_info=%d", collect_memory_info);
@@ -243,8 +244,9 @@ int main(int argc, char* argv[]) {
       thread_pool.get(), process_id, module_manager, selected_functions,
       orbit_client_data::TracepointInfoSet{}, samples_per_second, kStackDumpSize, unwinding_method,
       collect_scheduling_info, collect_thread_state, collect_gpu_jobs, kEnableApi,
-      kEnableIntrospection, kMaxLocalMarkerDepthPerCommandBuffer, collect_memory_info,
-      memory_sampling_period_ms, enable_cgroup_memory, std::move(capture_event_processor));
+      kEnableIntrospection, kEnableUserSpaceInstrumentation, kMaxLocalMarkerDepthPerCommandBuffer,
+      collect_memory_info, memory_sampling_period_ms, enable_cgroup_memory,
+      std::move(capture_event_processor));
   LOG("Asked to start capture");
 
   uint32_t duration_s = absl::GetFlag(FLAGS_duration);

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -40,6 +40,7 @@ message ApiFunction {
   uint64 api_version = 5;
 }
 
+// NextId: 18
 message CaptureOptions {
   bool trace_context_switches = 1;
   int32 pid = 2;
@@ -53,6 +54,8 @@ message CaptureOptions {
     kDwarf = 2;
   }
   UnwindingMethod unwinding_method = 4;
+
+  bool enable_user_space_instrumentation = 17;
 
   repeated InstrumentedFunction instrumented_functions = 5;
 

--- a/src/OrbitClientGgp/ClientGgp.cpp
+++ b/src/OrbitClientGgp/ClientGgp.cpp
@@ -113,6 +113,7 @@ ErrorMessageOr<void> ClientGgp::RequestStartCapture(ThreadPool* thread_pool) {
   bool collect_gpu_jobs = true;
   bool enable_api = false;
   bool enable_introspection = false;
+  bool enable_user_space_instrumentation = false;
   uint64_t max_local_marker_depth_per_command_buffer =
       absl::GetFlag(FLAGS_max_local_marker_depth_per_command_buffer);
 
@@ -129,8 +130,8 @@ ErrorMessageOr<void> ClientGgp::RequestStartCapture(ThreadPool* thread_pool) {
       thread_pool, target_process_->pid(), module_manager_, selected_functions_,
       selected_tracepoints, options_.samples_per_second, options_.stack_dump_size, unwinding_method,
       collect_scheduling_info, collect_thread_state, collect_gpu_jobs, enable_api,
-      enable_introspection, max_local_marker_depth_per_command_buffer, false, 0, false,
-      std::move(event_processor));
+      enable_introspection, enable_user_space_instrumentation,
+      max_local_marker_depth_per_command_buffer, false, 0, false, std::move(event_processor));
 
   orbit_base::ImmediateExecutor executor;
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1317,6 +1317,7 @@ void OrbitApp::StartCapture() {
   bool collect_gpu_jobs = true;
   bool enable_api = data_manager_->get_enable_api();
   bool enable_introspection = IsDevMode() && data_manager_->get_enable_introspection();
+  bool enable_user_space_instrumentation = IsDevMode() && data_manager_->get_enable_user_space_instrumentation();
   double samples_per_second = data_manager_->samples_per_second();
   uint16_t stack_dump_size = data_manager_->stack_dump_size();
   UnwindingMethod unwinding_method = data_manager_->unwinding_method();
@@ -1370,8 +1371,8 @@ void OrbitApp::StartCapture() {
       thread_pool_.get(), process->pid(), *module_manager_, std::move(selected_functions_map),
       std::move(selected_tracepoints), samples_per_second, stack_dump_size, unwinding_method,
       collect_scheduling_info, collect_thread_states, collect_gpu_jobs, enable_api,
-      enable_introspection, max_local_marker_depth_per_command_buffer, collect_memory_info,
-      memory_sampling_period_ms, enable_cgroup_memory, std::move(capture_event_processor));
+      enable_introspection, enable_user_space_instrumentation, max_local_marker_depth_per_command_buffer,
+      collect_memory_info, memory_sampling_period_ms, enable_cgroup_memory, std::move(capture_event_processor));
 
   // TODO(b/187250643): Refactor this to be more readable and maybe remove parts that are not needed
   // here (capture cancelled)
@@ -2143,6 +2144,10 @@ void OrbitApp::SetEnableApi(bool enable_api) { data_manager_->set_enable_api(ena
 
 void OrbitApp::SetEnableIntrospection(bool enable_introspection) {
   data_manager_->set_enable_introspection(enable_introspection);
+}
+
+void OrbitApp::SetEnableUserSpaceInstrumentation(bool enable) {
+  data_manager_->set_enable_user_space_instrumentation(enable);
 }
 
 void OrbitApp::SetSamplesPerSecond(double samples_per_second) {

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1317,7 +1317,8 @@ void OrbitApp::StartCapture() {
   bool collect_gpu_jobs = true;
   bool enable_api = data_manager_->get_enable_api();
   bool enable_introspection = IsDevMode() && data_manager_->get_enable_introspection();
-  bool enable_user_space_instrumentation = IsDevMode() && data_manager_->get_enable_user_space_instrumentation();
+  bool enable_user_space_instrumentation =
+      IsDevMode() && data_manager_->get_enable_user_space_instrumentation();
   double samples_per_second = data_manager_->samples_per_second();
   uint16_t stack_dump_size = data_manager_->stack_dump_size();
   UnwindingMethod unwinding_method = data_manager_->unwinding_method();
@@ -1371,8 +1372,9 @@ void OrbitApp::StartCapture() {
       thread_pool_.get(), process->pid(), *module_manager_, std::move(selected_functions_map),
       std::move(selected_tracepoints), samples_per_second, stack_dump_size, unwinding_method,
       collect_scheduling_info, collect_thread_states, collect_gpu_jobs, enable_api,
-      enable_introspection, enable_user_space_instrumentation, max_local_marker_depth_per_command_buffer,
-      collect_memory_info, memory_sampling_period_ms, enable_cgroup_memory, std::move(capture_event_processor));
+      enable_introspection, enable_user_space_instrumentation,
+      max_local_marker_depth_per_command_buffer, collect_memory_info, memory_sampling_period_ms,
+      enable_cgroup_memory, std::move(capture_event_processor));
 
   // TODO(b/187250643): Refactor this to be more readable and maybe remove parts that are not needed
   // here (capture cancelled)

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -1318,7 +1318,7 @@ void OrbitApp::StartCapture() {
   bool enable_api = data_manager_->get_enable_api();
   bool enable_introspection = IsDevMode() && data_manager_->get_enable_introspection();
   bool enable_user_space_instrumentation =
-      IsDevMode() && data_manager_->get_enable_user_space_instrumentation();
+      IsDevMode() && data_manager_->enable_user_space_instrumentation();
   double samples_per_second = data_manager_->samples_per_second();
   uint16_t stack_dump_size = data_manager_->stack_dump_size();
   UnwindingMethod unwinding_method = data_manager_->unwinding_method();

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -387,6 +387,7 @@ class OrbitApp final : public DataViewFactory,
   void SetCollectThreadStates(bool collect_thread_states);
   void SetEnableApi(bool enable_api);
   void SetEnableIntrospection(bool enable_introspection);
+  void SetEnableUserSpaceInstrumentation(bool enable);
   void SetSamplesPerSecond(double samples_per_second);
   void SetStackDumpSize(uint16_t stack_dump_size);
   void SetUnwindingMethod(orbit_grpc_protos::UnwindingMethod unwinding_method);

--- a/src/OrbitGl/DataManager.h
+++ b/src/OrbitGl/DataManager.h
@@ -81,7 +81,9 @@ class DataManager final {
   }
   [[nodiscard]] bool get_enable_introspection() const { return enable_introspection_; }
 
-  void set_enable_user_space_instrumentation(bool enable) { enable_user_space_instrumentation_ = enable; }
+  void set_enable_user_space_instrumentation(bool enable) {
+    enable_user_space_instrumentation_ = enable;
+  }
   [[nodiscard]] bool get_enable_user_space_instrumentation() const {
     return enable_user_space_instrumentation_;
   }

--- a/src/OrbitGl/DataManager.h
+++ b/src/OrbitGl/DataManager.h
@@ -84,7 +84,7 @@ class DataManager final {
   void set_enable_user_space_instrumentation(bool enable) {
     enable_user_space_instrumentation_ = enable;
   }
-  [[nodiscard]] bool get_enable_user_space_instrumentation() const {
+  [[nodiscard]] bool enable_user_space_instrumentation() const {
     return enable_user_space_instrumentation_;
   }
 

--- a/src/OrbitGl/DataManager.h
+++ b/src/OrbitGl/DataManager.h
@@ -81,6 +81,11 @@ class DataManager final {
   }
   [[nodiscard]] bool get_enable_introspection() const { return enable_introspection_; }
 
+  void set_enable_user_space_instrumentation(bool enable) { enable_user_space_instrumentation_ = enable; }
+  [[nodiscard]] bool get_enable_user_space_instrumentation() const {
+    return enable_user_space_instrumentation_;
+  }
+
   void set_samples_per_second(double samples_per_second) {
     samples_per_second_ = samples_per_second;
   }
@@ -138,6 +143,7 @@ class DataManager final {
   bool collect_thread_states_ = false;
   bool enable_api_ = false;
   bool enable_introspection_ = false;
+  bool enable_user_space_instrumentation_ = false;
   uint64_t max_local_marker_depth_per_command_buffer_ = std::numeric_limits<uint64_t>::max();
   double samples_per_second_ = 0;
   uint16_t stack_dump_size_ = 0;

--- a/src/OrbitQt/CaptureOptionsDialog.cpp
+++ b/src/OrbitQt/CaptureOptionsDialog.cpp
@@ -44,6 +44,10 @@ CaptureOptionsDialog::CaptureOptionsDialog(QWidget* parent)
   if (!absl::GetFlag(FLAGS_devmode)) {
     ui_->introspectionCheckBox->hide();
   }
+
+  if (absl::GetFlag(FLAGS_devmode)) {
+    ui_->userspaceCheckBox->show();
+  }
 }
 
 bool CaptureOptionsDialog::GetCollectThreadStates() const {
@@ -66,6 +70,14 @@ void CaptureOptionsDialog::SetEnableIntrospection(bool enable_introspection) {
 
 bool CaptureOptionsDialog::GetEnableIntrospection() const {
   return ui_->introspectionCheckBox->isChecked();
+}
+
+void CaptureOptionsDialog::SetEnableUserSpaceInstrumentation(bool enable) {
+  ui_->userspaceCheckBox->setChecked(enable);
+}
+
+bool CaptureOptionsDialog::GetEnableUserSpaceInstrumentation() const {
+  return ui_->userspaceCheckBox->isChecked();
 }
 
 void CaptureOptionsDialog::SetLimitLocalMarkerDepthPerCommandBuffer(

--- a/src/OrbitQt/CaptureOptionsDialog.h
+++ b/src/OrbitQt/CaptureOptionsDialog.h
@@ -50,6 +50,8 @@ class CaptureOptionsDialog : public QDialog {
   [[nodiscard]] bool GetEnableApi() const;
   void SetEnableIntrospection(bool enable_introspection);
   [[nodiscard]] bool GetEnableIntrospection() const;
+  void SetEnableUserSpaceInstrumentation(bool enable);
+  [[nodiscard]] bool GetEnableUserSpaceInstrumentation() const;
   void SetLimitLocalMarkerDepthPerCommandBuffer(bool limit_local_marker_depth_per_command_buffer);
   [[nodiscard]] bool GetLimitLocalMarkerDepthPerCommandBuffer() const;
   void SetMaxLocalMarkerDepthPerCommandBuffer(uint64_t local_marker_depth_per_command_buffer);

--- a/src/OrbitQt/CaptureOptionsDialog.ui
+++ b/src/OrbitQt/CaptureOptionsDialog.ui
@@ -72,6 +72,16 @@
           </property>
          </widget>
         </item>
+        <item>
+         <widget class="QCheckBox" name="userspaceCheckBox">
+          <property name="text">
+           <string>Enable user space instrumentation</string>
+          </property>
+          <property name="visible">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>		
        </layout>
       </widget>
      </item>

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -997,7 +997,8 @@ const QString OrbitMainWindow::kCollectThreadStatesSettingKey{"CollectThreadStat
 const QString OrbitMainWindow::kCollectMemoryInfoSettingKey{"CollectMemoryInfo"};
 const QString OrbitMainWindow::kEnableApiSettingKey{"EnableApi"};
 const QString OrbitMainWindow::kEnableIntrospectionSettingKey{"EnableIntrospection"};
-const QString OrbitMainWindow::kEnableUserSpaceInstrumentationSettingKey{"EnableUserSpaceInstrumentation"};
+const QString OrbitMainWindow::kEnableUserSpaceInstrumentationSettingKey{
+    "EnableUserSpaceInstrumentation"};
 const QString OrbitMainWindow::kMemorySamplingPeriodMsSettingKey{"MemorySamplingPeriodMs"};
 const QString OrbitMainWindow::kMemoryWarningThresholdKbSettingKey{"MemoryWarningThresholdKb"};
 const QString OrbitMainWindow::kLimitLocalMarkerDepthPerCommandBufferSettingsKey{

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -997,6 +997,7 @@ const QString OrbitMainWindow::kCollectThreadStatesSettingKey{"CollectThreadStat
 const QString OrbitMainWindow::kCollectMemoryInfoSettingKey{"CollectMemoryInfo"};
 const QString OrbitMainWindow::kEnableApiSettingKey{"EnableApi"};
 const QString OrbitMainWindow::kEnableIntrospectionSettingKey{"EnableIntrospection"};
+const QString OrbitMainWindow::kEnableUserSpaceInstrumentationSettingKey{"EnableUserSpaceInstrumentation"};
 const QString OrbitMainWindow::kMemorySamplingPeriodMsSettingKey{"MemorySamplingPeriodMs"};
 const QString OrbitMainWindow::kMemoryWarningThresholdKbSettingKey{"MemoryWarningThresholdKb"};
 const QString OrbitMainWindow::kLimitLocalMarkerDepthPerCommandBufferSettingsKey{
@@ -1012,6 +1013,8 @@ void OrbitMainWindow::LoadCaptureOptionsIntoApp() {
   app_->SetCollectThreadStates(settings.value(kCollectThreadStatesSettingKey, false).toBool());
   app_->SetEnableApi(settings.value(kEnableApiSettingKey, true).toBool());
   app_->SetEnableIntrospection(settings.value(kEnableIntrospectionSettingKey, false).toBool());
+  app_->SetEnableUserSpaceInstrumentation(
+      settings.value(kEnableUserSpaceInstrumentationSettingKey, false).toBool());
 
   app_->SetCollectMemoryInfo(settings.value(kCollectMemoryInfoSettingKey, false).toBool());
   uint64_t memory_sampling_period_ms = kMemorySamplingPeriodMsDefaultValue;
@@ -1045,6 +1048,8 @@ void OrbitMainWindow::on_actionCaptureOptions_triggered() {
   dialog.SetCollectThreadStates(settings.value(kCollectThreadStatesSettingKey, false).toBool());
   dialog.SetEnableApi(settings.value(kEnableApiSettingKey, true).toBool());
   dialog.SetEnableIntrospection(settings.value(kEnableIntrospectionSettingKey, true).toBool());
+  dialog.SetEnableUserSpaceInstrumentation(
+      settings.value(kEnableUserSpaceInstrumentationSettingKey, false).toBool());
   dialog.SetCollectMemoryInfo(settings.value(kCollectMemoryInfoSettingKey, false).toBool());
   dialog.SetMemorySamplingPeriodMs(
       settings
@@ -1069,6 +1074,8 @@ void OrbitMainWindow::on_actionCaptureOptions_triggered() {
   settings.setValue(kCollectThreadStatesSettingKey, dialog.GetCollectThreadStates());
   settings.setValue(kEnableApiSettingKey, dialog.GetEnableApi());
   settings.setValue(kEnableIntrospectionSettingKey, dialog.GetEnableIntrospection());
+  settings.setValue(kEnableUserSpaceInstrumentationSettingKey,
+                    dialog.GetEnableUserSpaceInstrumentation());
   settings.setValue(kCollectMemoryInfoSettingKey, dialog.GetCollectMemoryInfo());
   settings.setValue(kMemorySamplingPeriodMsSettingKey,
                     QString::number(dialog.GetMemorySamplingPeriodMs()));

--- a/src/OrbitQt/orbitmainwindow.h
+++ b/src/OrbitQt/orbitmainwindow.h
@@ -181,6 +181,7 @@ class OrbitMainWindow final : public QMainWindow, public orbit_gl::MainWindowInt
   static const QString kCollectMemoryInfoSettingKey;
   static const QString kEnableApiSettingKey;
   static const QString kEnableIntrospectionSettingKey;
+  static const QString kEnableUserSpaceInstrumentationSettingKey;
   static const QString kMemorySamplingPeriodMsSettingKey;
   static const QString kMemoryWarningThresholdKbSettingKey;
   static const QString kLimitLocalMarkerDepthPerCommandBufferSettingsKey;


### PR DESCRIPTION
Checkbox only shows up in devmode. Currently it does nothing - the
integration of user space instrumentation is not done yet.

The checkbox state is forwarded to 'enable_user_space_instrumentation' field
in the capture proto and therefore available in the service for later use.

Test: Merely manual - stickyness works, hiding in devmode works, the bit shows
up in the service (tested with independently patched service).