### PR TITLE
Some simple optimizations to OrbitService

### DIFF
--- a/src/CaptureClient/CMakeLists.txt
+++ b/src/CaptureClient/CMakeLists.txt
@@ -33,7 +33,8 @@ target_link_libraries(CaptureClient PUBLIC
         CaptureFile
         ClientData
         GrpcProtos
-        Introspection)
+        Introspection
+        CONAN_PKG::llvm_object)
 
 add_fuzzer(CaptureEventProcessorProcessEventsFuzzer CaptureEventProcessorProcessEventsFuzzer.cpp)
 target_link_libraries(

--- a/src/CaptureClient/CaptureEventProcessor.cpp
+++ b/src/CaptureClient/CaptureEventProcessor.cpp
@@ -6,7 +6,7 @@
 
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
-#include <google/protobuf/stubs/port.h>
+#include <llvm/Demangle/Demangle.h>
 
 #include <string>
 #include <utility>
@@ -581,7 +581,7 @@ void CaptureEventProcessorForListener::ProcessAddressInfo(const AddressInfo& add
   LinuxAddressInfo linux_address_info;
   linux_address_info.set_absolute_address(address_info.absolute_address());
   linux_address_info.set_module_path(module_name);
-  linux_address_info.set_function_name(function_name);
+  linux_address_info.set_function_name(llvm::demangle(function_name));
   linux_address_info.set_offset_in_function(address_info.offset_in_function());
   capture_listener_->OnAddressInfo(linux_address_info);
 }

--- a/src/LinuxTracing/TracerThread.cpp
+++ b/src/LinuxTracing/TracerThread.cpp
@@ -791,7 +791,6 @@ void TracerThread::Run(const std::shared_ptr<std::atomic<bool>>& exit_requested)
 
       // Sleep if there was no new event in the last iteration so that we are
       // not constantly polling. Don't sleep so long that ring buffers overflow.
-      // TODO: Refine this sleeping pattern, possibly using exponential backoff.
       {
         ORBIT_SCOPE("Sleep");
         usleep(IDLE_TIME_ON_EMPTY_RING_BUFFERS_US);

--- a/src/LinuxTracing/TracerThread.h
+++ b/src/LinuxTracing/TracerThread.h
@@ -130,7 +130,7 @@ class TracerThread {
   static constexpr uint64_t GPU_TRACING_RING_BUFFER_SIZE_KB = 256;
   static constexpr uint64_t INSTRUMENTED_TRACEPOINTS_RING_BUFFER_SIZE_KB = 8 * 1024;
 
-  static constexpr uint32_t IDLE_TIME_ON_EMPTY_RING_BUFFERS_US = 100;
+  static constexpr uint32_t IDLE_TIME_ON_EMPTY_RING_BUFFERS_US = 1000;
   static constexpr uint32_t IDLE_TIME_ON_EMPTY_DEFERRED_EVENTS_US = 1000;
 
   bool trace_context_switches_;

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -5,7 +5,6 @@
 #include "UprobesUnwindingVisitor.h"
 
 #include <asm/perf_regs.h>
-#include <llvm/Demangle/Demangle.h>
 #include <sys/mman.h>
 #include <unwindstack/MapInfo.h>
 #include <unwindstack/Unwinder.h>
@@ -35,7 +34,7 @@ static void SendFullAddressInfoToListener(TracerListener* listener,
 
   FullAddressInfo address_info;
   address_info.set_absolute_address(libunwindstack_frame.pc);
-  address_info.set_function_name(llvm::demangle(libunwindstack_frame.function_name));
+  address_info.set_function_name(libunwindstack_frame.function_name);
   address_info.set_offset_in_function(libunwindstack_frame.function_offset);
   address_info.set_module_name(libunwindstack_frame.map_name);
 


### PR DESCRIPTION
#### Increase IDLE_TIME_ON_EMPTY_RING_BUFFERS_US from 0.1 ms to 1 ms
Even when capturing basically nothing (no scheduling, no sampling, no GPU
tracepoins), the thread running `TracerThread::Run` still takes ~5 % of CPU,
spent simply calling `usleep`/`nanosleep`. This brings it down to ~1 %.

With a "standard" capture, this has an even bigger impact, as it brings CPU
utilization of OrbitService down from ~40% to ~33%.
One of the reasons of the bigger impact is for example that `OrbitService` now
causes fewer context switches, which is also good in general.

This effectively reverts 29412bb from a long
time ago.

As the comment a few lines above says, our ring buffers should be large enough
for the case when `TracerThread::Run` is not scheduled for tens of milliseconds,
so polling the ring buffers every 0.1 ms doesn't really help.

Also remove old TODO not backed by bug.

Test: Capture Trata with `execute_task` instrumented before and after this
commit, notice how sometimes losing events for buffer overflow can happen
regardless of this change.
#### Use set_allocated instead of *mutable()=move() in ProducerEventProcessor
When transferring a sub-message from a `ProducerCaptureEvent` to a
`ClientCaptureEvent`, the pattern
```
ClientCaptureEvent event;
*event.mutable_foo() = std::move(*my_foo);
```
is replaced where possible by
```
ClientCaptureEvent event;
event.set_allocated_foo(my_foo);
```

This is because `mutable_foo()` causes the allocation of a new sub-message,
before this is moved to. The source sub-message is then deallocated with the
`ProducerCaptureEvent`. Instead, we can directly "steal" the sub-message from
the source, using `release_foo` followed by `set_allocated_foo`.

Methods that do this are renamed to `...AndTransferOwnership`, to make clear
that the argument must not have an owner before being used with `set_allocated`,
and `release_foo` instead of `mutable_foo` needs to be passed as parameter.

This is not a huge performance improvement, but it is measurable. When capturing
Trata while instrumenting
`eva::graphics::rendering::spatial_geometry::world_sphere() const` (the same
used in the automated performance testing), at the beginning of the loop the
CPU utilization of `OrbitService` goes from 80/85% (after the previous commit)
down to 75/80%.
#### Move llvm::demangle from ProducerEventProcessor to the client
In particular, to `CaptureEventProcessorForListener`.

When taking a standard capture of Trata, the `Proc.Def.Events` thread was
spending more than 10% of its time in `llvm::demangle`. Move this processing to
the client. `OrbitService`'s CPU utilization in such a standard capture of Trata
is now down 2/3 percentage points (~33% down to ~31%).

Regarding backwards compatibility, we have no issues, as this is actually an
improvement of capture loading, as now the client supports `AddressInfo`s with
both mangled and demangled names (updating an old capture would mean mangling
the function names, which makes no sense). `llvm::demangle` will just return
"copy of the input string if no demangling occurred".

Note, thought, that this means that from now on `AddressInfo`s in saved captures
will contain mangled names.

Test: Update unit test. Load a capture taken before this change and verify
function names. Take a capture after this change and verify function names.