### PR TITLE
Refactor memory tracks and add tooltips

### DIFF
--- a/src/OrbitGl/AnnotationTrack.cpp
+++ b/src/OrbitGl/AnnotationTrack.cpp
@@ -7,6 +7,7 @@
 namespace {
 
 const Color kWhite(255, 255, 255, 255);
+const Color kFullyTransparent(255, 255, 255, 0);
 const Color kThresholdColor(244, 67, 54, 255);
 
 }  // namespace
@@ -32,6 +33,13 @@ void AnnotationTrack::DrawAnnotation(Batcher& batcher, TextRenderer& text_render
     text_renderer.AddText(text.c_str(), text_box_position[0],
                           text_box_position[1] + layout->GetTextOffset(), z, kWhite, font_size,
                           text_box_size[0]);
+
+    if (!GetValueUpperBoundTooltip().empty()) {
+      auto user_data = std::make_unique<PickingUserData>(
+          nullptr, [&](PickingId /*id*/) { return this->GetValueUpperBoundTooltip(); });
+      batcher.AddShadedBox(text_box_position, text_box_size, z, kFullyTransparent,
+                           std::move(user_data));
+    }
   }
 
   // Add value lower bound text box.

--- a/src/OrbitGl/AnnotationTrack.h
+++ b/src/OrbitGl/AnnotationTrack.h
@@ -43,6 +43,7 @@ class AnnotationTrack {
   [[nodiscard]] virtual Vec2 GetAnnotatedTrackPosition() const = 0;
   [[nodiscard]] virtual Vec2 GetAnnotatedTrackSize() const = 0;
   [[nodiscard]] virtual uint32_t GetAnnotationFontSize() const = 0;
+  [[nodiscard]] virtual std::string GetValueUpperBoundTooltip() const { return ""; }
 
   std::optional<std::pair<std::string, double>> warning_threshold_ = std::nullopt;
   std::optional<std::pair<std::string, double>> value_upper_bound_ = std::nullopt;

--- a/src/OrbitGl/App.h
+++ b/src/OrbitGl/App.h
@@ -399,6 +399,9 @@ class OrbitApp final : public DataViewFactory,
   void SetMemorySamplingPeriodMs(uint64_t memory_sampling_period_ms) {
     data_manager_->set_memory_sampling_period_ms(memory_sampling_period_ms);
   }
+  [[nodiscard]] uint64_t GetMemorySamplingPeriodMs() const {
+    return data_manager_->memory_sampling_period_ms();
+  }
   void SetMemoryWarningThresholdKb(uint64_t memory_warning_threshold_kb) {
     data_manager_->set_memory_warning_threshold_kb(memory_warning_threshold_kb);
   }

--- a/src/OrbitGl/BasicPagefaultTrack.cpp
+++ b/src/OrbitGl/BasicPagefaultTrack.cpp
@@ -21,6 +21,7 @@ static std::array<std::string, kBasicPagefaultTrackDimension> CreateSeriesName(
 BasicPagefaultTrack::BasicPagefaultTrack(Track* parent, TimeGraph* time_graph,
                                          orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                                          const std::string& name, const std::string& cgroup_name,
+                                         uint64_t memory_sampling_period_ms,
                                          const orbit_client_model::CaptureData* capture_data,
                                          uint32_t indentation_level)
     : LineGraphTrack<kBasicPagefaultTrackDimension>(
@@ -29,6 +30,7 @@ BasicPagefaultTrack::BasicPagefaultTrack(Track* parent, TimeGraph* time_graph,
           indentation_level),
       AnnotationTrack(),
       cgroup_name_(cgroup_name),
+      memory_sampling_period_ms_(memory_sampling_period_ms),
       parent_(parent) {
   draw_background_ = false;
 
@@ -55,13 +57,17 @@ void BasicPagefaultTrack::AddValuesAndUpdateAnnotations(
   double updated_max = GetGraphMaxValue();
   std::optional<std::pair<std::string, double>> value_upper_bound = GetValueUpperBound();
   if (!value_upper_bound.has_value() || value_upper_bound.value().second < updated_max) {
-    SetValueUpperBound(absl::StrFormat("Maximum count: %.0f", updated_max), updated_max);
+    SetValueUpperBound(
+        absl::StrFormat("Maximum Rate: %.0f per %d MS", updated_max, memory_sampling_period_ms_),
+        updated_max);
   }
 
   double updated_min = GetGraphMinValue();
   std::optional<std::pair<std::string, double>> value_lower_bound = GetValueLowerBound();
   if (!value_lower_bound.has_value() || value_lower_bound.value().second > updated_min) {
-    SetValueLowerBound(absl::StrFormat("Minimum count: %.0f", updated_min), updated_min);
+    SetValueLowerBound(
+        absl::StrFormat("Minimum Rate: %.0f per %d MS", updated_min, memory_sampling_period_ms_),
+        updated_min);
   }
 }
 

--- a/src/OrbitGl/BasicPagefaultTrack.h
+++ b/src/OrbitGl/BasicPagefaultTrack.h
@@ -19,12 +19,12 @@ constexpr size_t kBasicPagefaultTrackDimension = 3;
 
 // This is a implementation of `LineGraphTrack` to display major or minor pagefault information,
 // used in the `PagefaultTrack`.
-class BasicPagefaultTrack final : public LineGraphTrack<kBasicPagefaultTrackDimension>,
-                                  public AnnotationTrack {
+class BasicPagefaultTrack : public LineGraphTrack<kBasicPagefaultTrackDimension>,
+                            public AnnotationTrack {
  public:
   explicit BasicPagefaultTrack(Track* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
-                               TimeGraphLayout* layout, std::string name,
-                               std::array<std::string, kBasicPagefaultTrackDimension> series_names,
+                               TimeGraphLayout* layout, const std::string& name,
+                               const std::string& cgroup_name,
                                const orbit_client_model::CaptureData* capture_data,
                                uint32_t indentation_level = 0);
 
@@ -38,10 +38,10 @@ class BasicPagefaultTrack final : public LineGraphTrack<kBasicPagefaultTrackDime
   void AddValuesAndUpdateAnnotations(
       uint64_t timestamp_ns, const std::array<double, kBasicPagefaultTrackDimension>& values);
 
-  void SetIndexOfSeriesToHighlight(size_t series_index);
-
   void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
             PickingMode picking_mode, float z_offset = 0) override;
+
+  enum class SeriesIndex { kProcess = 0, kCGroup = 1, kSystem = 2 };
 
  protected:
   void DrawSingleSeriesEntry(
@@ -49,6 +49,12 @@ class BasicPagefaultTrack final : public LineGraphTrack<kBasicPagefaultTrackDime
       const std::array<float, kBasicPagefaultTrackDimension>& current_normalized_values,
       const std::array<float, kBasicPagefaultTrackDimension>& next_normalized_values, float z,
       bool is_last) override;
+
+  // Once this is set, if values[index_of_series_to_highlight_] > 0 in the sampling window t, we
+  // will draw a colored box in this sampling window to highlight the occurrence of pagefault
+  // series_name[index_of_series_to_highlight_].
+  std::optional<size_t> index_of_series_to_highlight_ = std::nullopt;
+  std::string cgroup_name_;
 
  private:
   [[nodiscard]] bool IsCollapsed() const override;
@@ -60,10 +66,6 @@ class BasicPagefaultTrack final : public LineGraphTrack<kBasicPagefaultTrackDime
   Track* parent_;
   std::optional<std::pair<uint64_t, std::array<double, kBasicPagefaultTrackDimension>>>
       previous_time_and_values_ = std::nullopt;
-  // Once this is set, if values[index_of_series_to_highlight_] > 0 in the sampling window t, we
-  // will draw a colored box in this sampling window to highlight the occurrence of pagefault
-  // series_name[index_of_series_to_highlight_].
-  std::optional<size_t> index_of_series_to_highlight_ = std::nullopt;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/BasicPagefaultTrack.h
+++ b/src/OrbitGl/BasicPagefaultTrack.h
@@ -24,7 +24,7 @@ class BasicPagefaultTrack : public LineGraphTrack<kBasicPagefaultTrackDimension>
  public:
   explicit BasicPagefaultTrack(Track* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
                                TimeGraphLayout* layout, const std::string& name,
-                               const std::string& cgroup_name,
+                               const std::string& cgroup_name, uint64_t memory_sampling_period_ms,
                                const orbit_client_model::CaptureData* capture_data,
                                uint32_t indentation_level = 0);
 
@@ -55,6 +55,7 @@ class BasicPagefaultTrack : public LineGraphTrack<kBasicPagefaultTrackDimension>
   // series_name[index_of_series_to_highlight_].
   std::optional<size_t> index_of_series_to_highlight_ = std::nullopt;
   std::string cgroup_name_;
+  uint64_t memory_sampling_period_ms_;
 
  private:
   [[nodiscard]] bool IsCollapsed() const override;

--- a/src/OrbitGl/CGroupAndProcessMemoryTrack.cpp
+++ b/src/OrbitGl/CGroupAndProcessMemoryTrack.cpp
@@ -103,4 +103,15 @@ std::string CGroupAndProcessMemoryTrack::GetLegendTooltips(size_t legend_index) 
   }
 }
 
+std::string CGroupAndProcessMemoryTrack::GetValueUpperBoundTooltip() const {
+  const std::string kGameCGroupName = "game";
+  constexpr float kGameCGroupLimitGB = 7;
+
+  if (cgroup_name_ != kGameCGroupName) return "";
+  return absl::StrFormat(
+      "<b>The memory production limit of the %s cgroup is %.2fGB</b>.<br/><br/>"
+      "<i>To launch game with the production cgroup limits, add the flag "
+      "'--enforce-production-ram' to the 'ggp run' command</i>.",
+      kGameCGroupName, kGameCGroupLimitGB);
+}
 }  // namespace orbit_gl

--- a/src/OrbitGl/CGroupAndProcessMemoryTrack.cpp
+++ b/src/OrbitGl/CGroupAndProcessMemoryTrack.cpp
@@ -48,10 +48,10 @@ CGroupAndProcessMemoryTrack::CGroupAndProcessMemoryTrack(
   // Use reddish colors for different used memories, yellowish colors for different cached memories
   // and greenish colors for different unused memories.
   const std::array<Color, kCGroupAndProcessMemoryTrackDimension> kCGroupAndProcessMemoryTrackColors{
-      Color(231, 68, 53, 255),   // red
-      Color(249, 96, 111, 255),  // warm red
-      Color(246, 196, 0, 255),   // orange
-      Color(87, 166, 74, 255)    // green
+      Color(231, 68, 53, 255),    // red
+      Color(185, 117, 181, 255),  // purple
+      Color(246, 196, 0, 255),    // orange
+      Color(87, 166, 74, 255)     // green
   };
   SetSeriesColors(kCGroupAndProcessMemoryTrackColors);
 

--- a/src/OrbitGl/CGroupAndProcessMemoryTrack.cpp
+++ b/src/OrbitGl/CGroupAndProcessMemoryTrack.cpp
@@ -1,0 +1,106 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "CGroupAndProcessMemoryTrack.h"
+
+#include <absl/strings/str_format.h>
+#include <absl/strings/substitute.h>
+
+#include "DisplayFormats/DisplayFormats.h"
+
+namespace orbit_gl {
+
+namespace {
+
+const std::string kTrackValueLabelUnit = "MB";
+const std::string kTrackName = absl::StrFormat("CGroup Memory Usage (%s)", kTrackValueLabelUnit);
+
+static std::array<std::string, kCGroupAndProcessMemoryTrackDimension> CreateSeriesName(
+    const std::string& cgroup_name, const std::string& process_name) {
+  return {absl::StrFormat("Process [%s] RssAnon", process_name), "Other Processes RssAnon",
+          absl::StrFormat("CGroup [%s] Mapped File", cgroup_name),
+          absl::StrFormat("CGroup [%s] Unused", cgroup_name)};
+}
+
+}  // namespace
+
+CGroupAndProcessMemoryTrack::CGroupAndProcessMemoryTrack(
+    CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
+    TimeGraphLayout* layout, const std::string& cgroup_name,
+    const orbit_client_model::CaptureData* capture_data)
+    : MemoryTrack<kCGroupAndProcessMemoryTrackDimension>(
+          parent, time_graph, viewport, layout, kTrackName,
+          CreateSeriesName(cgroup_name, capture_data->process_name()), capture_data),
+      cgroup_name_(cgroup_name) {
+  SetLabelUnit(kTrackValueLabelUnit);
+
+  constexpr uint8_t kTrackValueDecimalDigits = 2;
+  SetNumberOfDecimalDigits(kTrackValueDecimalDigits);
+
+  // Colors are selected from https://convertingcolors.com/list/avery.html.
+  // Use reddish colors for different used memories, yellowish colors for different cached memories
+  // and greenish colors for different unused memories.
+  const std::array<Color, kCGroupAndProcessMemoryTrackDimension> kCGroupAndProcessMemoryTrackColors{
+      Color(231, 68, 53, 255),   // red
+      Color(249, 96, 111, 255),  // warm red
+      Color(246, 196, 0, 255),   // orange
+      Color(87, 166, 74, 255)    // green
+  };
+  SetSeriesColors(kCGroupAndProcessMemoryTrackColors);
+
+  const std::string kValueLowerBoundLabel = "Minimum: 0 GB";
+  constexpr double kValueLowerBoundRawValue = 0.0;
+  TrySetValueLowerBound(kValueLowerBoundLabel, kValueLowerBoundRawValue);
+}
+
+std::string CGroupAndProcessMemoryTrack::GetTooltip() const {
+  return "Shows memory usage information for the target process and the memory cgroup it belongs "
+         "to. The target process will be killed when the overall used memory approaches the cgroup "
+         "limit.";
+}
+
+void CGroupAndProcessMemoryTrack::TrySetValueUpperBound(double cgroup_limit_mb) {
+  const std::string kValueUpperBoundLabel =
+      absl::StrFormat("CGroup [%s] Memory Limit", cgroup_name_);
+  constexpr uint64_t kMegabytesToBytes = 1024 * 1024;
+  std::string pretty_size = orbit_display_formats::GetDisplaySize(
+      static_cast<uint64_t>(cgroup_limit_mb * kMegabytesToBytes));
+  std::string pretty_label = absl::StrFormat("%s: %s", kValueUpperBoundLabel, pretty_size);
+  MemoryTrack<kCGroupAndProcessMemoryTrackDimension>::TrySetValueUpperBound(pretty_label,
+                                                                            cgroup_limit_mb);
+}
+
+std::string CGroupAndProcessMemoryTrack::GetLegendTooltips(size_t legend_index) const {
+  switch (static_cast<SeriesIndex>(legend_index)) {
+    case SeriesIndex::kProcessRssAnonMb:
+      return absl::Substitute(
+          "<b>Resident anonymous memory of the target process $0.</b><br/><br/>"
+          "Derived from the <i>RssAnon</i> field in file <i>/proc/$1/status</i>",
+          capture_data_->process_name(), capture_data_->process_id());
+    case SeriesIndex::kOtherRssAnonMb:
+      return absl::Substitute(
+          "<b>Resident anonymous memory of other processes in the $0 cgroup.</b><br/><br/>"
+          "Derived from the cgroup anonymous memory - 'Process [$1] RssAnon',<br/>"
+          "where the cgroup anonymous memory is extracted from the <i>rss</i> field in file "
+          "<i>/sys/fs/cgroup/memory/$0/memory.stat</i>",
+          cgroup_name_, capture_data_->process_name());
+    case SeriesIndex::kCGroupMappedFileMb:
+      return absl::Substitute(
+          "<b>Resident file mapping of the $0 cgroup.</b><br/><br/>"
+          "Derived from the <i>mapped_file</i> field in file<br/>"
+          "<i>/sys/fs/cgroup/memory/$0/memory.stat</i>",
+          cgroup_name_);
+    case SeriesIndex::kUnusedMb:
+      return absl::Substitute(
+          "<b>Unused memory in the $0 cgroup.</b><br/><br/>"
+          "Derived from cgroup memory limit - cgroup rss - cgroup mapped_file.<br/> "
+          "The cgroup memory limit is extracted from file "
+          "<i>/sys/fs/cgroup/memory/$0/memory.limit_in_bytes</i>",
+          cgroup_name_);
+    default:
+      UNREACHABLE();
+  }
+}
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/CGroupAndProcessMemoryTrack.h
+++ b/src/OrbitGl/CGroupAndProcessMemoryTrack.h
@@ -35,6 +35,7 @@ class CGroupAndProcessMemoryTrack final
 
  private:
   [[nodiscard]] std::string GetLegendTooltips(size_t legend_index) const override;
+  [[nodiscard]] std::string GetValueUpperBoundTooltip() const override;
   std::string cgroup_name_;
 };
 

--- a/src/OrbitGl/CGroupAndProcessMemoryTrack.h
+++ b/src/OrbitGl/CGroupAndProcessMemoryTrack.h
@@ -26,6 +26,8 @@ class CGroupAndProcessMemoryTrack final
 
   void TrySetValueUpperBound(double cgroup_limit_mb);
 
+  void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
+
   enum class SeriesIndex {
     kProcessRssAnonMb = 0,
     kOtherRssAnonMb = 1,

--- a/src/OrbitGl/CGroupAndProcessMemoryTrack.h
+++ b/src/OrbitGl/CGroupAndProcessMemoryTrack.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2020 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_CGROUP_AND_PROCESS_MEMORY_TRACK_H_
+#define ORBIT_GL_CGROUP_AND_PROCESS_MEMORY_TRACK_H_
+
+#include <string>
+#include <utility>
+
+#include "MemoryTrack.h"
+
+namespace orbit_gl {
+
+constexpr size_t kCGroupAndProcessMemoryTrackDimension = 4;
+
+class CGroupAndProcessMemoryTrack final
+    : public MemoryTrack<kCGroupAndProcessMemoryTrackDimension> {
+ public:
+  explicit CGroupAndProcessMemoryTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+                                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
+                                       const std::string& cgroup_name,
+                                       const orbit_client_model::CaptureData* capture_data);
+
+  [[nodiscard]] std::string GetTooltip() const override;
+
+  void TrySetValueUpperBound(double cgroup_limit_mb);
+
+  enum class SeriesIndex {
+    kProcessRssAnonMb = 0,
+    kOtherRssAnonMb = 1,
+    kCGroupMappedFileMb = 2,
+    kUnusedMb = 3
+  };
+
+ private:
+  [[nodiscard]] std::string GetLegendTooltips(size_t legend_index) const override;
+  std::string cgroup_name_;
+};
+
+}  // namespace orbit_gl
+
+#endif  // ORBIT_GL_CGROUP_AND_PROCESS_MEMORY_TRACK_H_

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -49,7 +49,9 @@ target_sources(
          LiveFunctionsController.h
          LiveFunctionsDataView.h
          ManualInstrumentationManager.h
+         MajorPagefaultTrack.h
          MemoryTrack.h
+         MinorPagefaultTrack.h
          ModulesDataView.h
          MultivariateTimeSeries.h
          PagefaultTrack.h
@@ -120,7 +122,9 @@ target_sources(
           LineGraphTrack.cpp
           LiveFunctionsDataView.cpp
           ManualInstrumentationManager.cpp
+          MajorPagefaultTrack.cpp
           MemoryTrack.cpp
+          MinorPagefaultTrack.cpp
           ModulesDataView.cpp
           PagefaultTrack.cpp
           PickingManager.cpp

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -29,6 +29,7 @@ target_sources(
          CaptureStats.h
          CaptureViewElement.h
          CaptureWindow.h
+         CGroupAndProcessMemoryTrack.h
          CoreMath.h
          FramePointerValidatorClient.h
          FrameTrack.h
@@ -100,6 +101,7 @@ target_sources(
           CaptureStats.cpp
           CaptureViewElement.cpp
           CaptureWindow.cpp
+          CGroupAndProcessMemoryTrack.cpp
           CompareAscendingOrDescending.h
           DataManager.cpp
           FramePointerValidatorClient.cpp

--- a/src/OrbitGl/CMakeLists.txt
+++ b/src/OrbitGl/CMakeLists.txt
@@ -60,6 +60,7 @@ target_sources(
          ScopeTree.h
          ShortenStringWithEllipsis.h
          StatusListener.h
+         SystemMemoryTrack.h
          TextBox.h
          TextRenderer.h
          ThreadBar.h
@@ -127,6 +128,7 @@ target_sources(
           SchedulingStats.cpp
           StringManager.cpp
           StringManager.h
+          SystemMemoryTrack.cpp
           TextRenderer.cpp
           TimeGraph.cpp
           TimeGraphLayout.cpp

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -65,7 +65,7 @@ void GraphTrack<Dimension>::Draw(Batcher& batcher, TextRenderer& text_renderer,
   float point_y = GetLabelYFromValues(values);
   std::string text = GetLabelTextFromValues(values);
   const Color kBlack(0, 0, 0, 255);
-  const Color kTransparentWhite(255, 255, 255, 100);
+  const Color kTransparentWhite(255, 255, 255, 180);
   float label_z = GlCanvas::kZValueTrackLabel + z_offset;
   DrawLabel(batcher, text_renderer, Vec2(point_x, point_y), text, kBlack, kTransparentWhite,
             label_z);

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -54,9 +54,7 @@ void GraphTrack<Dimension>::Draw(Batcher& batcher, TextRenderer& text_renderer,
                                  uint64_t current_mouse_time_ns, PickingMode picking_mode,
                                  float z_offset) {
   Track::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, z_offset);
-  if (IsEmpty() || picking_mode != PickingMode::kNone) return;
-
-  if (IsCollapsed()) return;
+  if (IsEmpty() || IsCollapsed()) return;
 
   // Draw label
   const std::array<double, Dimension>& values =
@@ -230,6 +228,7 @@ void GraphTrack<Dimension>::DrawLegend(Batcher& batcher, TextRenderer& text_rend
   float x0 = pos_[0] + layout_->GetRightMargin();
   float y0 = pos_[1] - layout_->GetTrackTabHeight() - layout_->GetTextBoxHeight() / 2.f;
   uint32_t font_size = GetLegendFontSize();
+  const Color kFullyTransparent(255, 255, 255, 0);
 
   for (size_t i = 0; i < Dimension; ++i) {
     batcher.AddShadedBox(Vec2(x0, y0 - legend_symbol_height / 2.f),
@@ -243,6 +242,11 @@ void GraphTrack<Dimension>::DrawLegend(Batcher& batcher, TextRenderer& text_rend
                           legend_text_box_position[1] + layout_->GetTextOffset(), z,
                           legend_text_color, font_size, legend_text_box_size[0]);
     x0 += legend_text_width + kSpaceBetweenLegendEntries;
+
+    auto user_data = std::make_unique<PickingUserData>(
+        nullptr, [&, i](PickingId /*id*/) { return this->GetLegendTooltips(i); });
+    batcher.AddShadedBox(legend_text_box_position, legend_text_box_size, z, kFullyTransparent,
+                         std::move(user_data));
   }
 }
 

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -90,6 +90,12 @@ class GraphTrack : public Track {
                           const Color& legend_text_color, float z);
   virtual void DrawSeries(Batcher* batcher, uint64_t min_tick, uint64_t max_tick, float z);
 
+  [[nodiscard]] double RoundPrecision(double value) {
+    CHECK(GetNumberOfDecimalDigits().has_value());
+    return std::round(value * std::pow(10, GetNumberOfDecimalDigits().value())) /
+           std::pow(10, GetNumberOfDecimalDigits().value());
+  }
+
   MultivariateTimeSeries<Dimension> series_;
 
  private:

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -93,6 +93,7 @@ class GraphTrack : public Track {
   MultivariateTimeSeries<Dimension> series_;
 
  private:
+  [[nodiscard]] virtual std::string GetLegendTooltips(size_t /*legend_index*/) const { return ""; }
   void DrawSingleSeriesEntry(Batcher* batcher, uint64_t start_tick, uint64_t end_tick,
                              const std::array<float, Dimension>& normalized_values, float z);
 

--- a/src/OrbitGl/LineGraphTrack.cpp
+++ b/src/OrbitGl/LineGraphTrack.cpp
@@ -100,7 +100,7 @@ void LineGraphTrack<Dimension>::DrawSingleSeriesEntry(
   float content_height = this->GetGraphContentHeight();
   float base_y = this->GetGraphContentBaseY();
 
-  for (size_t i = 0; i < Dimension; ++i) {
+  for (size_t i = Dimension; i-- > 0;) {
     float y0 = base_y + current_normalized_values[i] * content_height;
     DrawSquareDot(batcher, Vec2(x0, y0), kDotRadius, z, this->GetColor(i));
     batcher->AddLine(Vec2(x0, y0), Vec2(x1, y0), z, this->GetColor(i));

--- a/src/OrbitGl/MajorPagefaultTrack.cpp
+++ b/src/OrbitGl/MajorPagefaultTrack.cpp
@@ -1,0 +1,50 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "MajorPagefaultTrack.h"
+
+#include <absl/strings/substitute.h>
+
+namespace orbit_gl {
+MajorPagefaultTrack::MajorPagefaultTrack(Track* parent, TimeGraph* time_graph,
+                                         orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
+                                         const std::string& cgroup_name,
+                                         const orbit_client_model::CaptureData* capture_data,
+                                         uint32_t indentation_level)
+    : BasicPagefaultTrack(parent, time_graph, viewport, layout, "Major Pagefault Track",
+                          cgroup_name, capture_data, indentation_level) {
+  index_of_series_to_highlight_ = static_cast<size_t>(SeriesIndex::kProcess);
+}
+
+std::string MajorPagefaultTrack::GetTooltip() const {
+  return "Shows major pagefault statistics. A major pagefault occurs when the requested page does "
+         "not reside in the main memory or CPU cache, and has to be swapped from an external "
+         "storage. The major pagefaults might cause slow performance of the target process.";
+}
+
+std::string MajorPagefaultTrack::GetLegendTooltips(size_t legend_index) const {
+  switch (static_cast<SeriesIndex>(legend_index)) {
+    case SeriesIndex::kProcess:
+      return absl::Substitute(
+          "<b># of major pagefaults incurred by the $0 process during the sampling "
+          "period.</b><br/><br/>"
+          "Derived from the <i>majflt</i> field in file <i>/proc/$1/stat</i>.",
+          capture_data_->process_name(), capture_data_->process_id());
+    case SeriesIndex::kCGroup:
+      return absl::Substitute(
+          "<b># of major pagefaults incurred by the $0 cgroup during the sampling "
+          "period.</b><br/><br/>"
+          "Derived from the <i>pgmajfault</i> field in file "
+          "<i>/sys/fs/cgroup/memory/$0/memory.stat</i>.",
+          cgroup_name_);
+    case SeriesIndex::kSystem:
+      return "<b># of system-wide major pagefaults occurred durning the sampling "
+             "period.</b><br/><br/>"
+             "Derived from the <i>pgmajfault</i> field in file <i>/proc/vmstat</i>.";
+    default:
+      UNREACHABLE();
+  }
+}
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/MajorPagefaultTrack.cpp
+++ b/src/OrbitGl/MajorPagefaultTrack.cpp
@@ -10,38 +10,41 @@ namespace orbit_gl {
 MajorPagefaultTrack::MajorPagefaultTrack(Track* parent, TimeGraph* time_graph,
                                          orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                                          const std::string& cgroup_name,
+                                         uint64_t memory_sampling_period_ms,
                                          const orbit_client_model::CaptureData* capture_data,
                                          uint32_t indentation_level)
     : BasicPagefaultTrack(parent, time_graph, viewport, layout, "Major Pagefault Track",
-                          cgroup_name, capture_data, indentation_level) {
+                          cgroup_name, memory_sampling_period_ms, capture_data, indentation_level) {
   index_of_series_to_highlight_ = static_cast<size_t>(SeriesIndex::kProcess);
 }
 
 std::string MajorPagefaultTrack::GetTooltip() const {
   return "Shows major pagefault statistics. A major pagefault occurs when the requested page does "
          "not reside in the main memory or CPU cache, and has to be swapped from an external "
-         "storage. The major pagefaults might cause slow performance of the target process.";
+         "storage.<br/> The major pagefaults might cause slow performance of the target process.";
 }
 
 std::string MajorPagefaultTrack::GetLegendTooltips(size_t legend_index) const {
   switch (static_cast<SeriesIndex>(legend_index)) {
     case SeriesIndex::kProcess:
       return absl::Substitute(
-          "<b># of major pagefaults incurred by the $0 process during the sampling "
-          "period.</b><br/><br/>"
+          "<b>Number of major pagefaults incurred by the $0 process during the sampling "
+          "period ($2 ms).</b><br/><br/>"
           "Derived from the <i>majflt</i> field in file <i>/proc/$1/stat</i>.",
-          capture_data_->process_name(), capture_data_->process_id());
+          capture_data_->process_name(), capture_data_->process_id(), memory_sampling_period_ms_);
     case SeriesIndex::kCGroup:
       return absl::Substitute(
-          "<b># of major pagefaults incurred by the $0 cgroup during the sampling "
-          "period.</b><br/><br/>"
+          "<b>Number of major pagefaults incurred by the $0 cgroup during the sampling "
+          "period ($1 ms).</b><br/><br/>"
           "Derived from the <i>pgmajfault</i> field in file "
           "<i>/sys/fs/cgroup/memory/$0/memory.stat</i>.",
-          cgroup_name_);
+          cgroup_name_, memory_sampling_period_ms_);
     case SeriesIndex::kSystem:
-      return "<b># of system-wide major pagefaults occurred durning the sampling "
-             "period.</b><br/><br/>"
-             "Derived from the <i>pgmajfault</i> field in file <i>/proc/vmstat</i>.";
+      return absl::Substitute(
+          "<b>Number of system-wide major pagefaults occurred during the sampling "
+          "period ($0 ms).</b><br/><br/>"
+          "Derived from the <i>pgmajfault</i> field in file <i>/proc/vmstat</i>.",
+          memory_sampling_period_ms_);
     default:
       UNREACHABLE();
   }

--- a/src/OrbitGl/MajorPagefaultTrack.h
+++ b/src/OrbitGl/MajorPagefaultTrack.h
@@ -16,6 +16,7 @@ class MajorPagefaultTrack final : public BasicPagefaultTrack {
  public:
   explicit MajorPagefaultTrack(Track* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
                                TimeGraphLayout* layout, const std::string& cgroup_name,
+                               uint64_t memory_sampling_period_ms,
                                const orbit_client_model::CaptureData* capture_data,
                                uint32_t indentation_level = 0);
 

--- a/src/OrbitGl/MajorPagefaultTrack.h
+++ b/src/OrbitGl/MajorPagefaultTrack.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_MAJOR_PAGEFAULT_TRACK_H_
+#define ORBIT_GL_MAJOR_PAGEFAULT_TRACK_H_
+
+#include <string>
+#include <utility>
+
+#include "BasicPagefaultTrack.h"
+
+namespace orbit_gl {
+
+class MajorPagefaultTrack final : public BasicPagefaultTrack {
+ public:
+  explicit MajorPagefaultTrack(Track* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
+                               TimeGraphLayout* layout, const std::string& cgroup_name,
+                               const orbit_client_model::CaptureData* capture_data,
+                               uint32_t indentation_level = 0);
+
+  [[nodiscard]] std::string GetTooltip() const override;
+
+ private:
+  [[nodiscard]] std::string GetLegendTooltips(size_t legend_index) const override;
+};
+
+}  // namespace orbit_gl
+
+#endif  // ORBIT_GL_MAJOR_PAGEFAULT_TRACK_H_

--- a/src/OrbitGl/MemoryTrack.cpp
+++ b/src/OrbitGl/MemoryTrack.cpp
@@ -18,7 +18,7 @@ void MemoryTrack<Dimension>::Draw(Batcher& batcher, TextRenderer& text_renderer,
   GraphTrack<Dimension>::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode,
                               z_offset);
 
-  if (picking_mode != PickingMode::kNone || this->collapse_toggle_->IsCollapsed()) return;
+  if (this->collapse_toggle_->IsCollapsed()) return;
   AnnotationTrack::DrawAnnotation(batcher, text_renderer, this->layout_,
                                   GlCanvas::kZValueTrackText + z_offset);
 }

--- a/src/OrbitGl/MemoryTrack.h
+++ b/src/OrbitGl/MemoryTrack.h
@@ -16,7 +16,7 @@
 namespace orbit_gl {
 
 template <size_t Dimension>
-class MemoryTrack final : public GraphTrack<Dimension>, public AnnotationTrack {
+class MemoryTrack : public GraphTrack<Dimension>, public AnnotationTrack {
  public:
   explicit MemoryTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                        orbit_gl::Viewport* viewport, TimeGraphLayout* layout, std::string name,
@@ -48,20 +48,8 @@ class MemoryTrack final : public GraphTrack<Dimension>, public AnnotationTrack {
   }
 };
 
-constexpr size_t kSystemMemoryTrackDimension = 3;
-using SystemMemoryTrack = MemoryTrack<kSystemMemoryTrackDimension>;
-
 constexpr size_t kCGroupAndProcessMemoryTrackDimension = 4;
 using CGroupAndProcessMemoryTrack = MemoryTrack<kCGroupAndProcessMemoryTrackDimension>;
-
-// Colors are selected from https://convertingcolors.com/list/avery.html.
-// Use reddish colors for different used memories, yellowish colors for different cached memories
-// and greenish colors for different unused memories.
-const std::array<Color, kSystemMemoryTrackDimension> kSystemMemoryTrackColors{
-    Color(231, 68, 53, 255),  // red
-    Color(246, 196, 0, 255),  // orange
-    Color(87, 166, 74, 255)   // green
-};
 
 const std::array<Color, kCGroupAndProcessMemoryTrackDimension> kCGroupAndProcessMemoryTrackColors{
     Color(231, 68, 53, 255),   // red

--- a/src/OrbitGl/MemoryTrack.h
+++ b/src/OrbitGl/MemoryTrack.h
@@ -48,16 +48,6 @@ class MemoryTrack : public GraphTrack<Dimension>, public AnnotationTrack {
   }
 };
 
-constexpr size_t kCGroupAndProcessMemoryTrackDimension = 4;
-using CGroupAndProcessMemoryTrack = MemoryTrack<kCGroupAndProcessMemoryTrackDimension>;
-
-const std::array<Color, kCGroupAndProcessMemoryTrackDimension> kCGroupAndProcessMemoryTrackColors{
-    Color(231, 68, 53, 255),   // red
-    Color(249, 96, 111, 255),  // warm red
-    Color(246, 196, 0, 255),   // orange
-    Color(87, 166, 74, 255)    // green
-};
-
 }  // namespace orbit_gl
 
 #endif  // ORBIT_GL_MEMORY_TRACK_H_

--- a/src/OrbitGl/MinorPagefaultTrack.cpp
+++ b/src/OrbitGl/MinorPagefaultTrack.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "MinorPagefaultTrack.h"
+
+#include <absl/strings/substitute.h>
+
+namespace orbit_gl {
+
+std::string MinorPagefaultTrack::GetTooltip() const {
+  return "Shows minor pagefault statistics. A minor pagefault occurs when the requested page "
+         "resides in main memory but the process cannot access it.";
+}
+
+std::string MinorPagefaultTrack::GetLegendTooltips(size_t legend_index) const {
+  switch (static_cast<SeriesIndex>(legend_index)) {
+    case SeriesIndex::kProcess:
+      return absl::Substitute(
+          "<b># of minor pagefaults incurred by the $0 process during the sampling "
+          "period.</b><br/><br/>"
+          "Derived from the <i>minflt</i> field in file <i>/proc/$1/stat</i>.",
+          capture_data_->process_name(), capture_data_->process_id());
+    case SeriesIndex::kCGroup:
+      return absl::Substitute(
+          "<b># of minor pagefaults incurred by the $0 cgroup during the sampling "
+          "period.</b><br/><br/>"
+          "Derived from <i>pgfault - pgmajfault</i>,"
+          "which are two fields in file <i>/sys/fs/cgroup/memory/$0/memory.stat</i>.",
+          cgroup_name_);
+    case SeriesIndex::kSystem:
+      return "<b># of system-wide minor pagefaults occurred during the sampling "
+             "period.</b><br/><br/>"
+             "Derived from <i>pgfault - pgmajfault</i>, which are two fields in file "
+             "<i>/proc/vmstat</i>.";
+    default:
+      UNREACHABLE();
+  }
+}
+
+}  // namespace orbit_gl

--- a/src/OrbitGl/MinorPagefaultTrack.cpp
+++ b/src/OrbitGl/MinorPagefaultTrack.cpp
@@ -17,22 +17,24 @@ std::string MinorPagefaultTrack::GetLegendTooltips(size_t legend_index) const {
   switch (static_cast<SeriesIndex>(legend_index)) {
     case SeriesIndex::kProcess:
       return absl::Substitute(
-          "<b># of minor pagefaults incurred by the $0 process during the sampling "
-          "period.</b><br/><br/>"
+          "<b>Number of minor pagefaults incurred by the $0 process during the sampling "
+          "period ($2 ms).</b><br/><br/>"
           "Derived from the <i>minflt</i> field in file <i>/proc/$1/stat</i>.",
-          capture_data_->process_name(), capture_data_->process_id());
+          capture_data_->process_name(), capture_data_->process_id(), memory_sampling_period_ms_);
     case SeriesIndex::kCGroup:
       return absl::Substitute(
-          "<b># of minor pagefaults incurred by the $0 cgroup during the sampling "
-          "period.</b><br/><br/>"
+          "<b>Number of minor pagefaults incurred by the $0 cgroup during the sampling "
+          "period ($1 ms).</b><br/><br/>"
           "Derived from <i>pgfault - pgmajfault</i>,"
           "which are two fields in file <i>/sys/fs/cgroup/memory/$0/memory.stat</i>.",
-          cgroup_name_);
+          cgroup_name_, memory_sampling_period_ms_);
     case SeriesIndex::kSystem:
-      return "<b># of system-wide minor pagefaults occurred during the sampling "
-             "period.</b><br/><br/>"
-             "Derived from <i>pgfault - pgmajfault</i>, which are two fields in file "
-             "<i>/proc/vmstat</i>.";
+      return absl::Substitute(
+          "<b>Number of system-wide minor pagefaults occurred during the sampling "
+          "period ($0 ms).</b><br/><br/>"
+          "Derived from <i>pgfault - pgmajfault</i>, which are two fields in file "
+          "<i>/proc/vmstat</i>.",
+          memory_sampling_period_ms_);
     default:
       UNREACHABLE();
   }

--- a/src/OrbitGl/MinorPagefaultTrack.h
+++ b/src/OrbitGl/MinorPagefaultTrack.h
@@ -16,10 +16,12 @@ class MinorPagefaultTrack final : public BasicPagefaultTrack {
  public:
   explicit MinorPagefaultTrack(Track* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
                                TimeGraphLayout* layout, const std::string& cgroup_name,
+                               uint64_t memory_sampling_period_ms,
                                const orbit_client_model::CaptureData* capture_data,
                                uint32_t indentation_level = 0)
       : BasicPagefaultTrack(parent, time_graph, viewport, layout, "Minor Pagefault Track",
-                            cgroup_name, capture_data, indentation_level) {}
+                            cgroup_name, memory_sampling_period_ms, capture_data,
+                            indentation_level) {}
 
   [[nodiscard]] std::string GetTooltip() const override;
 

--- a/src/OrbitGl/MinorPagefaultTrack.h
+++ b/src/OrbitGl/MinorPagefaultTrack.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_MINOR_PAGEFAULT_TRACK_H_
+#define ORBIT_GL_MINOR_PAGEFAULT_TRACK_H_
+
+#include <string>
+#include <utility>
+
+#include "BasicPagefaultTrack.h"
+
+namespace orbit_gl {
+
+class MinorPagefaultTrack final : public BasicPagefaultTrack {
+ public:
+  explicit MinorPagefaultTrack(Track* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
+                               TimeGraphLayout* layout, const std::string& cgroup_name,
+                               const orbit_client_model::CaptureData* capture_data,
+                               uint32_t indentation_level = 0)
+      : BasicPagefaultTrack(parent, time_graph, viewport, layout, "Minor Pagefault Track",
+                            cgroup_name, capture_data, indentation_level) {}
+
+  [[nodiscard]] std::string GetTooltip() const override;
+
+ private:
+  [[nodiscard]] std::string GetLegendTooltips(size_t legend_index) const override;
+};
+
+}  // namespace orbit_gl
+
+#endif  // ORBIT_GL_MINOR_PAGEFAULT_TRACK_H_

--- a/src/OrbitGl/PagefaultTrack.h
+++ b/src/OrbitGl/PagefaultTrack.h
@@ -5,7 +5,8 @@
 #ifndef ORBIT_GL_PAGEFAULT_TRACK_H_
 #define ORBIT_GL_PAGEFAULT_TRACK_H_
 
-#include "BasicPagefaultTrack.h"
+#include "MajorPagefaultTrack.h"
+#include "MinorPagefaultTrack.h"
 #include "Timer.h"
 #include "Track.h"
 #include "Viewport.h"
@@ -20,13 +21,14 @@ class PagefaultTrack : public Track {
  public:
   explicit PagefaultTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                           orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
-                          std::array<std::string, kBasicPagefaultTrackDimension> series_names,
+                          const std::string& cgroup_name,
                           const orbit_client_model::CaptureData* capture_data,
                           uint32_t indentation_level = 0);
 
   [[nodiscard]] Type GetType() const override { return Type::kPagefaultTrack; }
   [[nodiscard]] float GetHeight() const override;
   [[nodiscard]] std::vector<CaptureViewElement*> GetVisibleChildren() override;
+  [[nodiscard]] std::string GetTooltip() const override;
 
   [[nodiscard]] bool IsEmpty() const override {
     return major_pagefault_track_->IsEmpty() && minor_pagefault_track_->IsEmpty();
@@ -52,19 +54,12 @@ class PagefaultTrack : public Track {
       uint64_t timestamp_ns, const std::array<double, kBasicPagefaultTrackDimension>& values) {
     minor_pagefault_track_->AddValuesAndUpdateAnnotations(timestamp_ns, values);
   }
-  void SetNumberOfDecimalDigits(uint8_t value_decimal_digits) {
-    major_pagefault_track_->SetNumberOfDecimalDigits(value_decimal_digits);
-    minor_pagefault_track_->SetNumberOfDecimalDigits(value_decimal_digits);
-  }
-  void SetIndexOfSeriesToHighlightForMajorPagefaultTrack(size_t series_index) {
-    major_pagefault_track_->SetIndexOfSeriesToHighlight(series_index);
-  }
 
  private:
   void UpdatePositionOfSubtracks();
 
-  std::shared_ptr<BasicPagefaultTrack> major_pagefault_track_;
-  std::shared_ptr<BasicPagefaultTrack> minor_pagefault_track_;
+  std::shared_ptr<MajorPagefaultTrack> major_pagefault_track_;
+  std::shared_ptr<MinorPagefaultTrack> minor_pagefault_track_;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/PagefaultTrack.h
+++ b/src/OrbitGl/PagefaultTrack.h
@@ -21,7 +21,7 @@ class PagefaultTrack : public Track {
  public:
   explicit PagefaultTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                           orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
-                          const std::string& cgroup_name,
+                          const std::string& cgroup_name, uint64_t memory_sampling_period_ms,
                           const orbit_client_model::CaptureData* capture_data,
                           uint32_t indentation_level = 0);
 
@@ -54,6 +54,7 @@ class PagefaultTrack : public Track {
       uint64_t timestamp_ns, const std::array<double, kBasicPagefaultTrackDimension>& values) {
     minor_pagefault_track_->AddValuesAndUpdateAnnotations(timestamp_ns, values);
   }
+  void SetMemorySamplingPeriodMs(uint64_t memory_sampling_period_ms);
 
  private:
   void UpdatePositionOfSubtracks();

--- a/src/OrbitGl/SystemMemoryTrack.h
+++ b/src/OrbitGl/SystemMemoryTrack.h
@@ -25,6 +25,8 @@ class SystemMemoryTrack final : public MemoryTrack<kSystemMemoryTrackDimension> 
   void TrySetValueUpperBound(double total_mb);
   void SetWarningThreshold(double warning_threshold_mb);
 
+  void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
+
   enum class SeriesIndex { kUsedMb = 0, kBuffersOrCachedMb = 1, kUnusedMb = 2 };
 
  private:

--- a/src/OrbitGl/SystemMemoryTrack.h
+++ b/src/OrbitGl/SystemMemoryTrack.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_GL_SYSTEM_MEMORY_TRACK_H_
+#define ORBIT_GL_SYSTEM_MEMORY_TRACK_H_
+
+#include <string>
+#include <utility>
+
+#include "MemoryTrack.h"
+
+namespace orbit_gl {
+
+constexpr size_t kSystemMemoryTrackDimension = 3;
+
+class SystemMemoryTrack final : public MemoryTrack<kSystemMemoryTrackDimension> {
+ public:
+  explicit SystemMemoryTrack(CaptureViewElement* parent, TimeGraph* time_graph,
+                             orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
+                             const orbit_client_model::CaptureData* capture_data);
+
+  [[nodiscard]] std::string GetTooltip() const override;
+
+  void TrySetValueUpperBound(double total_mb);
+  void SetWarningThreshold(double warning_threshold_mb);
+
+  enum class SeriesIndex { kUsedMb = 0, kBuffersOrCachedMb = 1, kUnusedMb = 2 };
+
+ private:
+  [[nodiscard]] std::string GetLegendTooltips(size_t legend_index) const override;
+};
+
+}  // namespace orbit_gl
+
+#endif  // ORBIT_GL_SYSTEM_MEMORY_TRACK_H_

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -487,11 +487,13 @@ CGroupAndProcessMemoryTrack* TrackManager::CreateAndGetCGroupAndProcessMemoryTra
   return GetCGroupAndProcessMemoryTrack();
 }
 
-PagefaultTrack* TrackManager::CreateAndGetPagefaultTrack(const std::string& cgroup_name) {
+PagefaultTrack* TrackManager::CreateAndGetPagefaultTrack(const std::string& cgroup_name,
+                                                         uint64_t memory_sampling_period_ms) {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
   if (pagefault_track_ == nullptr) {
-    pagefault_track_ = std::make_shared<PagefaultTrack>(time_graph_, time_graph_, viewport_,
-                                                        layout_, cgroup_name, capture_data_);
+    pagefault_track_ =
+        std::make_shared<PagefaultTrack>(time_graph_, time_graph_, viewport_, layout_, cgroup_name,
+                                         memory_sampling_period_ms, capture_data_);
     AddTrack(pagefault_track_);
   }
   return GetPagefaultTrack();

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -35,7 +35,6 @@
 
 using orbit_client_data::CallstackData;
 using orbit_gl::CGroupAndProcessMemoryTrack;
-using orbit_gl::MemoryTrack;
 using orbit_gl::PagefaultTrack;
 using orbit_gl::SystemMemoryTrack;
 using orbit_gl::VariableTrack;
@@ -477,19 +476,11 @@ SystemMemoryTrack* TrackManager::CreateAndGetSystemMemoryTrack() {
 }
 
 CGroupAndProcessMemoryTrack* TrackManager::CreateAndGetCGroupAndProcessMemoryTrack(
-    const std::array<std::string, orbit_gl::kCGroupAndProcessMemoryTrackDimension>& series_names) {
+    const std::string& cgroup_name) {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
   if (cgroup_and_process_memory_track_ == nullptr) {
-    constexpr uint8_t kTrackValueDecimalDigits = 2;
-    const std::string kTrackValueLabelUnit = "MB";
-    const std::string kTrackName =
-        absl::StrFormat("CGroup Memory Usage (%s)", kTrackValueLabelUnit);
-
     cgroup_and_process_memory_track_ = std::make_shared<CGroupAndProcessMemoryTrack>(
-        time_graph_, time_graph_, viewport_, layout_, kTrackName, series_names, capture_data_);
-    cgroup_and_process_memory_track_->SetLabelUnit(kTrackValueLabelUnit);
-    cgroup_and_process_memory_track_->SetNumberOfDecimalDigits(kTrackValueDecimalDigits);
-    cgroup_and_process_memory_track_->SetSeriesColors(orbit_gl::kCGroupAndProcessMemoryTrackColors);
+        time_graph_, time_graph_, viewport_, layout_, cgroup_name, capture_data_);
     AddTrack(cgroup_and_process_memory_track_);
   }
 

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -487,14 +487,11 @@ CGroupAndProcessMemoryTrack* TrackManager::CreateAndGetCGroupAndProcessMemoryTra
   return GetCGroupAndProcessMemoryTrack();
 }
 
-PagefaultTrack* TrackManager::CreateAndGetPagefaultTrack(
-    const std::array<std::string, orbit_gl::kBasicPagefaultTrackDimension>& series_names) {
+PagefaultTrack* TrackManager::CreateAndGetPagefaultTrack(const std::string& cgroup_name) {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
   if (pagefault_track_ == nullptr) {
-    constexpr uint8_t kTrackValueDecimalDigits = 0;
     pagefault_track_ = std::make_shared<PagefaultTrack>(time_graph_, time_graph_, viewport_,
-                                                        layout_, series_names, capture_data_);
-    pagefault_track_->SetNumberOfDecimalDigits(kTrackValueDecimalDigits);
+                                                        layout_, cgroup_name, capture_data_);
     AddTrack(pagefault_track_);
   }
   return GetPagefaultTrack();

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -465,20 +465,11 @@ FrameTrack* TrackManager::GetOrCreateFrameTrack(
   return track.get();
 }
 
-SystemMemoryTrack* TrackManager::CreateAndGetSystemMemoryTrack(
-    const std::array<std::string, orbit_gl::kSystemMemoryTrackDimension>& series_names) {
+SystemMemoryTrack* TrackManager::CreateAndGetSystemMemoryTrack() {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
   if (system_memory_track_ == nullptr) {
-    constexpr uint8_t kTrackValueDecimalDigits = 2;
-    const std::string kTrackValueLabelUnit = "MB";
-    const std::string kTrackName =
-        absl::StrFormat("System Memory Usage (%s)", kTrackValueLabelUnit);
-
-    system_memory_track_ = std::make_shared<SystemMemoryTrack>(
-        time_graph_, time_graph_, viewport_, layout_, kTrackName, series_names, capture_data_);
-    system_memory_track_->SetLabelUnit(kTrackValueLabelUnit);
-    system_memory_track_->SetNumberOfDecimalDigits(kTrackValueDecimalDigits);
-    system_memory_track_->SetSeriesColors(orbit_gl::kSystemMemoryTrackColors);
+    system_memory_track_ = std::make_shared<SystemMemoryTrack>(time_graph_, time_graph_, viewport_,
+                                                               layout_, capture_data_);
     AddTrack(system_memory_track_);
   }
 

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -16,10 +16,10 @@
 #include <vector>
 
 #include "AsyncTrack.h"
+#include "CGroupAndProcessMemoryTrack.h"
 #include "FrameTrack.h"
 #include "GpuTrack.h"
 #include "GraphTrack.h"
-#include "MemoryTrack.h"
 #include "PagefaultTrack.h"
 #include "PickingManager.h"
 #include "SchedulerTrack.h"
@@ -73,7 +73,7 @@ class TrackManager {
     return cgroup_and_process_memory_track_.get();
   }
   [[nodiscard]] orbit_gl::CGroupAndProcessMemoryTrack* CreateAndGetCGroupAndProcessMemoryTrack(
-      const std::array<std::string, orbit_gl::kCGroupAndProcessMemoryTrackDimension>& series_names);
+      const std::string& cgroup_name);
   orbit_gl::PagefaultTrack* GetPagefaultTrack() const { return pagefault_track_.get(); }
   orbit_gl::PagefaultTrack* CreateAndGetPagefaultTrack(
       const std::array<std::string, orbit_gl::kBasicPagefaultTrackDimension>& series_names);

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -24,6 +24,7 @@
 #include "PickingManager.h"
 #include "SchedulerTrack.h"
 #include "StringManager.h"
+#include "SystemMemoryTrack.h"
 #include "ThreadTrack.h"
 #include "Timer.h"
 #include "Track.h"
@@ -67,8 +68,7 @@ class TrackManager {
   [[nodiscard]] orbit_gl::SystemMemoryTrack* GetSystemMemoryTrack() const {
     return system_memory_track_.get();
   }
-  [[nodiscard]] orbit_gl::SystemMemoryTrack* CreateAndGetSystemMemoryTrack(
-      const std::array<std::string, orbit_gl::kSystemMemoryTrackDimension>& series_names);
+  [[nodiscard]] orbit_gl::SystemMemoryTrack* CreateAndGetSystemMemoryTrack();
   [[nodiscard]] orbit_gl::CGroupAndProcessMemoryTrack* GetCGroupAndProcessMemoryTrack() const {
     return cgroup_and_process_memory_track_.get();
   }

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -75,8 +75,7 @@ class TrackManager {
   [[nodiscard]] orbit_gl::CGroupAndProcessMemoryTrack* CreateAndGetCGroupAndProcessMemoryTrack(
       const std::string& cgroup_name);
   orbit_gl::PagefaultTrack* GetPagefaultTrack() const { return pagefault_track_.get(); }
-  orbit_gl::PagefaultTrack* CreateAndGetPagefaultTrack(
-      const std::array<std::string, orbit_gl::kBasicPagefaultTrackDimension>& series_names);
+  orbit_gl::PagefaultTrack* CreateAndGetPagefaultTrack(const std::string& cgroup_name);
 
   [[nodiscard]] bool GetIsDataFromSavedCapture() const { return data_from_saved_capture_; }
   void SetIsDataFromSavedCapture(bool value) { data_from_saved_capture_ = value; }

--- a/src/OrbitGl/TrackManager.h
+++ b/src/OrbitGl/TrackManager.h
@@ -75,7 +75,8 @@ class TrackManager {
   [[nodiscard]] orbit_gl::CGroupAndProcessMemoryTrack* CreateAndGetCGroupAndProcessMemoryTrack(
       const std::string& cgroup_name);
   orbit_gl::PagefaultTrack* GetPagefaultTrack() const { return pagefault_track_.get(); }
-  orbit_gl::PagefaultTrack* CreateAndGetPagefaultTrack(const std::string& cgroup_name);
+  orbit_gl::PagefaultTrack* CreateAndGetPagefaultTrack(const std::string& cgroup_name,
+                                                       uint64_t memory_sampling_period_ms);
 
   [[nodiscard]] bool GetIsDataFromSavedCapture() const { return data_from_saved_capture_; }
   void SetIsDataFromSavedCapture(bool value) { data_from_saved_capture_ = value; }


### PR DESCRIPTION
With this change, we add the following tooltips to the memory tracks and pagefault tracks:

Tooltips for the track tab: When moving the mouse over the track tab, a tooltip box pops up and shows the purpose of the track;
Tooltips for the legends: When moving the mouse over the legend text box, a tooltip box pops up and shows the meaning of the data and how we collect the data;
Tooltip for the value upper bound text box in the cgroup memory track: If the target process belongs to the game cgroup, when moving the mouse over the text box "CGroup [game] Memory Limit", a tooltip box pops and shows information about the production limit.

Also, the track initialization parts (e.g., track name, value label unit and the series names) are moved from the TimeGraph and TrackManager to the track constructor.

Related bugs: http://b/183161865, http://b/189759500, http://b/192235976

Screenshots for the SystemMemoryTrack tooltips:
https://screen/Mx6pMw9MHo6hw6r
https://screen/7QYLuc3HeJsBP3F
https://screen/3x4FMzPvrG77GzH
https://screen/AvqaPfaJk8Mge2b

Screenshot for the CGroupMemoryTrack tooltips:
https://screen/A83FXsND6QiGGym
https://screen/5HxRAvywaJu8pCp
https://screen/6GegtCZ2zfQiZ5W
https://screen/6eppH43czo2TeWf
https://screen/3B9opCuRAg6pimC

Screenshot for the PagefaultTrack tooltips:
https://screen/692dnUqA8FRUb8U
https://screen/6YukhRxEHrKhXfc
https://screen/Av6qNDUm9geHyK6
https://screen/3gEVHqLKsuVjak4
https://screen/4JWqgkEeMPbz3Hn
https://screen/4BZjFqd3BadnV5E
https://screen/wDpNU8Xpibr639Y
https://screen/RGbpvvQjvxCa8yq

Screenshot for the cgroup production limit tooltips:
https://screen/BXTz9uhnjxFmtYN