### PR TITLE
Proper handling of function_id in the trampolines.

### DIFF
--- a/src/UserSpaceInstrumentation/Trampoline.cpp
+++ b/src/UserSpaceInstrumentation/Trampoline.cpp
@@ -211,8 +211,8 @@ void AppendCallToEntryPayloadAndOverwriteReturnAddress(uint64_t entry_payload_fu
   // This fails if the code for the trampoline was changed - see the comment at the declaration of
   // kOffsetOfFunctionIdInCallToEntryPayload above.
   CHECK(trampoline.GetResultAsVector().size() == kOffsetOfFunctionIdInCallToEntryPayload);
-  // The value of function id will be overwritten by every call to `InstrumentFunction`. The zero
-  // here is just a placeholder.
+  // The value of function id will be overwritten by every call to `InstrumentFunction`. This is
+  // just a placeholder.
   trampoline.AppendImmediate64(0xDEADBEEFDEADBEEF)
       .AppendBytes({0x48, 0xb8})
       .AppendImmediate64(entry_payload_function_address)

--- a/src/UserSpaceInstrumentation/Trampoline.cpp
+++ b/src/UserSpaceInstrumentation/Trampoline.cpp
@@ -44,6 +44,13 @@ size_t kSizeOfJmp = 5;
 // generous) upper bound.
 size_t kMaxRelocatedPrologueSize = kSizeOfJmp * 16;
 
+// This constant is the offset of the function id in the trampolines. Since the id of a function
+// changes from one profiling run to the next we need to patch every trampoline with the current id
+// before each run. This happens in `InstrumentFunction`. Whenever the code of the trampoline is
+// changed this constant needs to be adjusted as well. There is a CHECK in the code below to make
+// sure this number is correct.
+constexpr uint64_t kOffsetOfFunctiunIdInCallToEntryPayload = 105;
+
 [[nodiscard]] std::string InstructionBytesAsString(cs_insn* instruction) {
   std::string result;
   for (int i = 0; i < instruction->size; i++) {
@@ -180,12 +187,10 @@ void AppendBackupCode(MachineCode& trampoline) {
   }
 }
 
-// Call the entry payload function with the return address and the address of the
-// instrumented function as parameters. Then overwrite the return address with
-// `return_trampoline_address`.
+// Call the entry payload function with the return address and the id of the instrumented function
+// as parameters. Then overwrite the return address with `return_trampoline_address`.
 void AppendCallToEntryPayloadAndOverwriteReturnAddress(uint64_t entry_payload_function_address,
                                                        uint64_t return_trampoline_address,
-                                                       uint64_t function_address,
                                                        MachineCode& trampoline) {
   // At this point rax is the rsp after pushing the general purpose registers, so adding 0x40 gets
   // us the location of the return address (see above in `AppendBackupCode`).
@@ -193,7 +198,7 @@ void AppendCallToEntryPayloadAndOverwriteReturnAddress(uint64_t entry_payload_fu
   // add rax, 0x40                                   48 83 c0 40
   // push rax                                        50
   // mov rdi, (rax)                                  48 8b 38
-  // mov rsi, function_address                       48 be addr
+  // mov rsi, function_id                            48 be function_id
   // mov rax, entry_payload_function_address         48 b8 addr
   // call rax                                        ff d0
   // pop rax                                         58
@@ -202,8 +207,13 @@ void AppendCallToEntryPayloadAndOverwriteReturnAddress(uint64_t entry_payload_fu
   trampoline.AppendBytes({0x48, 0x83, 0xc0, 0x40})
       .AppendBytes({0x50})
       .AppendBytes({0x48, 0x8b, 0x38})
-      .AppendBytes({0x48, 0xbe})
-      .AppendImmediate64(function_address)
+      .AppendBytes({0x48, 0xbe});
+  // This fails if the code for the trampoline was changed - see the comment at the declaration of
+  // kOffsetOfFunctiunIdInCallToEntryPayload above.
+  CHECK(trampoline.GetResultAsVector().size() == kOffsetOfFunctiunIdInCallToEntryPayload);
+  // The value of function id will be overwritten by every call to `InstrumentFunction`. The zero
+  // here is just a placeholder.
+  trampoline.AppendImmediate64(0)
       .AppendBytes({0x48, 0xb8})
       .AppendImmediate64(entry_payload_function_address)
       .AppendBytes({0xff, 0xd0})
@@ -743,8 +753,7 @@ uint64_t GetMaxTrampolineSize() {
     MachineCode unused_code;
     AppendBackupCode(unused_code);
     AppendCallToEntryPayloadAndOverwriteReturnAddress(/*entry_payload_function_address=*/0,
-                                                      /*return_trampoline_address=*/0,
-                                                      /*function_address=*/0, unused_code);
+                                                      /*return_trampoline_address=*/0, unused_code);
     AppendRestoreCode(unused_code);
     unused_code.AppendBytes(std::vector<uint8_t>(kMaxRelocatedPrologueSize, 0));
     auto result =
@@ -768,8 +777,8 @@ ErrorMessageOr<uint64_t> CreateTrampoline(pid_t pid, uint64_t function_address,
   MachineCode trampoline;
   // Add code to backup register state, execute the payload and restore the register state.
   AppendBackupCode(trampoline);
-  AppendCallToEntryPayloadAndOverwriteReturnAddress(
-      entry_payload_function_address, return_trampoline_address, function_address, trampoline);
+  AppendCallToEntryPayloadAndOverwriteReturnAddress(entry_payload_function_address,
+                                                    return_trampoline_address, trampoline);
   AppendRestoreCode(trampoline);
 
   // Relocate prologue into trampoline.
@@ -815,7 +824,7 @@ ErrorMessageOr<void> CreateReturnTrampoline(pid_t pid, uint64_t exit_payload_fun
   return outcome::success();
 }
 
-ErrorMessageOr<void> InstrumentFunction(pid_t pid, uint64_t function_address,
+ErrorMessageOr<void> InstrumentFunction(pid_t pid, uint64_t function_address, uint64_t function_id,
                                         uint64_t address_after_prologue,
                                         uint64_t trampoline_address) {
   MachineCode jump;
@@ -836,10 +845,14 @@ ErrorMessageOr<void> InstrumentFunction(pid_t pid, uint64_t function_address,
   while (jump.GetResultAsVector().size() < address_after_prologue - function_address) {
     jump.AppendBytes({0x90});
   }
-  auto write_result_or_error = WriteTraceesMemory(pid, function_address, jump.GetResultAsVector());
-  if (write_result_or_error.has_error()) {
-    return write_result_or_error.error();
-  }
+  OUTCOME_TRY(WriteTraceesMemory(pid, function_address, jump.GetResultAsVector()));
+
+  // Patch the trampoline to hand over the current function_id to the entry payload.
+  MachineCode function_id_as_bytes;
+  function_id_as_bytes.AppendImmediate64(function_id);
+  OUTCOME_TRY(WriteTraceesMemory(pid, trampoline_address + kOffsetOfFunctiunIdInCallToEntryPayload,
+                                 function_id_as_bytes.GetResultAsVector()));
+
   return outcome::success();
 }
 

--- a/src/UserSpaceInstrumentation/Trampoline.h
+++ b/src/UserSpaceInstrumentation/Trampoline.h
@@ -117,7 +117,7 @@ struct RelocatedInstruction {
 // Creates a trampoline for the function at `function_address`. The trampoline is built at
 // `trampoline_address`. The trampoline will call `entry_payload_function_address` with
 // `return_address` and a function id as a parameter. The function id is written into the
-// trampoline by `InstrumentFunction`. This is necessary since the function id is not stable accross
+// trampoline by `InstrumentFunction`. This is necessary since the function id is not stable across
 // multiple profiling runs.
 // `function` contains the beginning of the function (kMaxFunctionPrologueBackupSize bytes or less
 // if the function shorter). `capstone_handle` is a handle to the capstone disassembler library

--- a/src/UserSpaceInstrumentation/Trampoline.h
+++ b/src/UserSpaceInstrumentation/Trampoline.h
@@ -115,17 +115,19 @@ struct RelocatedInstruction {
 [[nodiscard]] uint64_t GetMaxTrampolineSize();
 
 // Creates a trampoline for the function at `function_address`. The trampoline is built at
-// `trampoline_address`. The trampoline will call `payload_address` with `function_address` as a
-// parameter. `function` contains the beginning of the function (kMaxFunctionPrologueBackupSize
-// bytes or less if the function shorter). `capstone_handle` is a handle to the capstone
-// disassembler library returned by cs_open. The function returns an error if it was not possible to
-// instrument the function. For details on that see the comments at AppendRelocatedPrologueCode. If
-// the function is successful it will insert an address pair into `relocation_map` for each
-// instruction it relocated from the beginning of the function into the trampoline (needed for
-// moving instruction pointers away from the overwritten bytes at the beginning of the function,
-// compare MoveInstructionPointersOutOfOverwrittenCode below). The return value is the address of
-// the first instruction not relocated into the trampoline (i.e. the address the trampoline jump
-// back to).
+// `trampoline_address`. The trampoline will call `entry_payload_function_address` with
+// `return_address` and a function id as a parameter. The function id is written into the
+// trampoline by `InstrumentFunction`. This is necessary since the function id is not stable accross
+// multiple profiling runs.
+// `function` contains the beginning of the function (kMaxFunctionPrologueBackupSize bytes or less
+// if the function shorter). `capstone_handle` is a handle to the capstone disassembler library
+// returned by cs_open. The function returns an error if it was not possible to instrument the
+// function. For details on that see the comments at AppendRelocatedPrologueCode. If the function is
+// successful it will insert an address pair into `relocation_map` for each instruction it relocated
+// from the beginning of the function into the trampoline (needed for moving instruction pointers
+// away from the overwritten bytes at the beginning of the function, compare
+// MoveInstructionPointersOutOfOverwrittenCode below). The return value is the address of the first
+// instruction not relocated into the trampoline (i.e. the address the trampoline jump back to).
 [[nodiscard]] ErrorMessageOr<uint64_t> CreateTrampoline(
     pid_t pid, uint64_t function_address, const std::vector<uint8_t>& function,
     uint64_t trampoline_address, uint64_t entry_payload_function_address,
@@ -150,8 +152,10 @@ struct RelocatedInstruction {
 
 // Instrument function at `function_address` in process `pid`. This simply overwrites the beginning
 // of the fuction with a jump to `trampoline_address`. The trampoline needs to be constructed with
-// `CreateTrampoline` above.
+// `CreateTrampoline` above. The trampoline gets patched such that it hands over the current
+// `function_id` to the entry payload.
 [[nodiscard]] ErrorMessageOr<void> InstrumentFunction(pid_t pid, uint64_t function_address,
+                                                      uint64_t function_id,
                                                       uint64_t address_of_instruction_after_jump,
                                                       uint64_t trampoline_address);
 

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -709,8 +709,9 @@ TEST_F(InstrumentFunctionTest, DoSomething) {
       pid_, function_address_, function_code_, trampoline_address_, entry_payload_function_address_,
       return_trampoline_address_, capstone_handle_, relocation_map_);
   EXPECT_THAT(address_after_prologue_or_error, HasNoError());
-  ErrorMessageOr<void> result = InstrumentFunction(
-      pid_, function_address_, address_after_prologue_or_error.value(), trampoline_address_);
+  ErrorMessageOr<void> result =
+      InstrumentFunction(pid_, function_address_, /*function_id=*/0,
+                         address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
 }
@@ -762,8 +763,9 @@ TEST_F(InstrumentFunctionTest, LongEnough) {
       pid_, function_address_, function_code_, trampoline_address_, entry_payload_function_address_,
       return_trampoline_address_, capstone_handle_, relocation_map_);
   EXPECT_THAT(address_after_prologue_or_error, HasNoError());
-  ErrorMessageOr<void> result = InstrumentFunction(
-      pid_, function_address_, address_after_prologue_or_error.value(), trampoline_address_);
+  ErrorMessageOr<void> result =
+      InstrumentFunction(pid_, function_address_, /*function_id=*/0,
+                         address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
 }
@@ -788,8 +790,9 @@ TEST_F(InstrumentFunctionTest, RipRelativeAddressing) {
       pid_, function_address_, function_code_, trampoline_address_, entry_payload_function_address_,
       return_trampoline_address_, capstone_handle_, relocation_map_);
   EXPECT_THAT(address_after_prologue_or_error, HasNoError());
-  ErrorMessageOr<void> result = InstrumentFunction(
-      pid_, function_address_, address_after_prologue_or_error.value(), trampoline_address_);
+  ErrorMessageOr<void> result =
+      InstrumentFunction(pid_, function_address_, /*function_id=*/0,
+                         address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
 }
@@ -815,8 +818,9 @@ TEST_F(InstrumentFunctionTest, UnconditionalJump8BitOffset) {
       pid_, function_address_, function_code_, trampoline_address_, entry_payload_function_address_,
       return_trampoline_address_, capstone_handle_, relocation_map_);
   EXPECT_THAT(address_after_prologue_or_error, HasNoError());
-  ErrorMessageOr<void> result = InstrumentFunction(
-      pid_, function_address_, address_after_prologue_or_error.value(), trampoline_address_);
+  ErrorMessageOr<void> result =
+      InstrumentFunction(pid_, function_address_, /*function_id=*/0,
+                         address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
 }
@@ -840,8 +844,9 @@ TEST_F(InstrumentFunctionTest, UnconditionalJump32BitOffset) {
       pid_, function_address_, function_code_, trampoline_address_, entry_payload_function_address_,
       return_trampoline_address_, capstone_handle_, relocation_map_);
   EXPECT_THAT(address_after_prologue_or_error, HasNoError());
-  ErrorMessageOr<void> result = InstrumentFunction(
-      pid_, function_address_, address_after_prologue_or_error.value(), trampoline_address_);
+  ErrorMessageOr<void> result =
+      InstrumentFunction(pid_, function_address_, /*function_id=*/0,
+                         address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
 }
@@ -866,8 +871,9 @@ TEST_F(InstrumentFunctionTest, CallFunction) {
       pid_, function_address_, function_code_, trampoline_address_, entry_payload_function_address_,
       return_trampoline_address_, capstone_handle_, relocation_map_);
   EXPECT_THAT(address_after_prologue_or_error, HasNoError());
-  ErrorMessageOr<void> result = InstrumentFunction(
-      pid_, function_address_, address_after_prologue_or_error.value(), trampoline_address_);
+  ErrorMessageOr<void> result =
+      InstrumentFunction(pid_, function_address_, /*function_id=*/0,
+                         address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
 }
@@ -893,8 +899,9 @@ TEST_F(InstrumentFunctionTest, ConditionalJump8BitOffset) {
       pid_, function_address_, function_code_, trampoline_address_, entry_payload_function_address_,
       return_trampoline_address_, capstone_handle_, relocation_map_);
   EXPECT_THAT(address_after_prologue_or_error, HasNoError());
-  ErrorMessageOr<void> result = InstrumentFunction(
-      pid_, function_address_, address_after_prologue_or_error.value(), trampoline_address_);
+  ErrorMessageOr<void> result =
+      InstrumentFunction(pid_, function_address_, /*function_id=*/0,
+                         address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
 }
@@ -921,8 +928,9 @@ TEST_F(InstrumentFunctionTest, ConditionalJump32BitOffset) {
       pid_, function_address_, function_code_, trampoline_address_, entry_payload_function_address_,
       return_trampoline_address_, capstone_handle_, relocation_map_);
   EXPECT_THAT(address_after_prologue_or_error, HasNoError());
-  ErrorMessageOr<void> result = InstrumentFunction(
-      pid_, function_address_, address_after_prologue_or_error.value(), trampoline_address_);
+  ErrorMessageOr<void> result =
+      InstrumentFunction(pid_, function_address_, /*function_id=*/0,
+                         address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
 }
@@ -978,8 +986,9 @@ TEST_F(InstrumentFunctionTest, CheckIntParameters) {
       pid_, function_address_, function_code_, trampoline_address_, entry_payload_function_address_,
       return_trampoline_address_, capstone_handle_, relocation_map_);
   EXPECT_THAT(address_after_prologue_or_error, HasNoError());
-  ErrorMessageOr<void> result = InstrumentFunction(
-      pid_, function_address_, address_after_prologue_or_error.value(), trampoline_address_);
+  ErrorMessageOr<void> result =
+      InstrumentFunction(pid_, function_address_, /*function_id=*/0,
+                         address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
 }
@@ -1007,8 +1016,9 @@ TEST_F(InstrumentFunctionTest, CheckFloatParameters) {
       pid_, function_address_, function_code_, trampoline_address_, entry_payload_function_address_,
       return_trampoline_address_, capstone_handle_, relocation_map_);
   EXPECT_THAT(address_after_prologue_or_error, HasNoError());
-  ErrorMessageOr<void> result = InstrumentFunction(
-      pid_, function_address_, address_after_prologue_or_error.value(), trampoline_address_);
+  ErrorMessageOr<void> result =
+      InstrumentFunction(pid_, function_address_, /*function_id=*/0,
+                         address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
 }
@@ -1041,8 +1051,9 @@ TEST_F(InstrumentFunctionTest, CheckM256iParameters) {
       pid_, function_address_, function_code_, trampoline_address_, entry_payload_function_address_,
       return_trampoline_address_, capstone_handle_, relocation_map_);
   EXPECT_THAT(address_after_prologue_or_error, HasNoError());
-  ErrorMessageOr<void> result = InstrumentFunction(
-      pid_, function_address_, address_after_prologue_or_error.value(), trampoline_address_);
+  ErrorMessageOr<void> result =
+      InstrumentFunction(pid_, function_address_, /*function_id=*/0,
+                         address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
 }

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -710,7 +710,7 @@ TEST_F(InstrumentFunctionTest, DoSomething) {
       return_trampoline_address_, capstone_handle_, relocation_map_);
   EXPECT_THAT(address_after_prologue_or_error, HasNoError());
   ErrorMessageOr<void> result =
-      InstrumentFunction(pid_, function_address_, /*function_id=*/0,
+      InstrumentFunction(pid_, function_address_, /*function_id=*/42,
                          address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
@@ -764,7 +764,7 @@ TEST_F(InstrumentFunctionTest, LongEnough) {
       return_trampoline_address_, capstone_handle_, relocation_map_);
   EXPECT_THAT(address_after_prologue_or_error, HasNoError());
   ErrorMessageOr<void> result =
-      InstrumentFunction(pid_, function_address_, /*function_id=*/0,
+      InstrumentFunction(pid_, function_address_, /*function_id=*/42,
                          address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
@@ -791,7 +791,7 @@ TEST_F(InstrumentFunctionTest, RipRelativeAddressing) {
       return_trampoline_address_, capstone_handle_, relocation_map_);
   EXPECT_THAT(address_after_prologue_or_error, HasNoError());
   ErrorMessageOr<void> result =
-      InstrumentFunction(pid_, function_address_, /*function_id=*/0,
+      InstrumentFunction(pid_, function_address_, /*function_id=*/42,
                          address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
@@ -819,7 +819,7 @@ TEST_F(InstrumentFunctionTest, UnconditionalJump8BitOffset) {
       return_trampoline_address_, capstone_handle_, relocation_map_);
   EXPECT_THAT(address_after_prologue_or_error, HasNoError());
   ErrorMessageOr<void> result =
-      InstrumentFunction(pid_, function_address_, /*function_id=*/0,
+      InstrumentFunction(pid_, function_address_, /*function_id=*/42,
                          address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
@@ -845,7 +845,7 @@ TEST_F(InstrumentFunctionTest, UnconditionalJump32BitOffset) {
       return_trampoline_address_, capstone_handle_, relocation_map_);
   EXPECT_THAT(address_after_prologue_or_error, HasNoError());
   ErrorMessageOr<void> result =
-      InstrumentFunction(pid_, function_address_, /*function_id=*/0,
+      InstrumentFunction(pid_, function_address_, /*function_id=*/42,
                          address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
@@ -872,7 +872,7 @@ TEST_F(InstrumentFunctionTest, CallFunction) {
       return_trampoline_address_, capstone_handle_, relocation_map_);
   EXPECT_THAT(address_after_prologue_or_error, HasNoError());
   ErrorMessageOr<void> result =
-      InstrumentFunction(pid_, function_address_, /*function_id=*/0,
+      InstrumentFunction(pid_, function_address_, /*function_id=*/42,
                          address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
@@ -900,7 +900,7 @@ TEST_F(InstrumentFunctionTest, ConditionalJump8BitOffset) {
       return_trampoline_address_, capstone_handle_, relocation_map_);
   EXPECT_THAT(address_after_prologue_or_error, HasNoError());
   ErrorMessageOr<void> result =
-      InstrumentFunction(pid_, function_address_, /*function_id=*/0,
+      InstrumentFunction(pid_, function_address_, /*function_id=*/42,
                          address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
@@ -929,7 +929,7 @@ TEST_F(InstrumentFunctionTest, ConditionalJump32BitOffset) {
       return_trampoline_address_, capstone_handle_, relocation_map_);
   EXPECT_THAT(address_after_prologue_or_error, HasNoError());
   ErrorMessageOr<void> result =
-      InstrumentFunction(pid_, function_address_, /*function_id=*/0,
+      InstrumentFunction(pid_, function_address_, /*function_id=*/42,
                          address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
@@ -987,7 +987,7 @@ TEST_F(InstrumentFunctionTest, CheckIntParameters) {
       return_trampoline_address_, capstone_handle_, relocation_map_);
   EXPECT_THAT(address_after_prologue_or_error, HasNoError());
   ErrorMessageOr<void> result =
-      InstrumentFunction(pid_, function_address_, /*function_id=*/0,
+      InstrumentFunction(pid_, function_address_, /*function_id=*/42,
                          address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
@@ -1017,7 +1017,7 @@ TEST_F(InstrumentFunctionTest, CheckFloatParameters) {
       return_trampoline_address_, capstone_handle_, relocation_map_);
   EXPECT_THAT(address_after_prologue_or_error, HasNoError());
   ErrorMessageOr<void> result =
-      InstrumentFunction(pid_, function_address_, /*function_id=*/0,
+      InstrumentFunction(pid_, function_address_, /*function_id=*/42,
                          address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();
@@ -1052,7 +1052,7 @@ TEST_F(InstrumentFunctionTest, CheckM256iParameters) {
       return_trampoline_address_, capstone_handle_, relocation_map_);
   EXPECT_THAT(address_after_prologue_or_error, HasNoError());
   ErrorMessageOr<void> result =
-      InstrumentFunction(pid_, function_address_, /*function_id=*/0,
+      InstrumentFunction(pid_, function_address_, /*function_id=*/42,
                          address_after_prologue_or_error.value(), trampoline_address_);
   EXPECT_THAT(result, HasNoError());
   RestartAndRemoveInstrumentation();

--- a/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.cpp
+++ b/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.cpp
@@ -47,7 +47,7 @@ uint64_t ExitPayload() {
     if (skipped > 0) {
       printf(" ( %lu skipped events )\n", skipped);
     }
-    printf("Returned from function with id %#lx\n", current_return_address.function_id);
+    printf("Returned from function with id %lu\n", current_return_address.function_id);
     last_logged_event = now;
     skipped = 0;
   } else {

--- a/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.cpp
+++ b/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.cpp
@@ -13,10 +13,10 @@
 namespace {
 
 struct ReturnAddressOfFunction {
-  ReturnAddressOfFunction(uint64_t return_address, uint64_t function_address)
-      : return_address(return_address), function_address(function_address) {}
+  ReturnAddressOfFunction(uint64_t return_address, uint64_t function_id)
+      : return_address(return_address), function_id(function_id) {}
   uint64_t return_address;
-  uint64_t function_address;
+  uint64_t function_id;
 };
 
 thread_local std::stack<ReturnAddressOfFunction> return_addresses;
@@ -29,8 +29,8 @@ uint64_t TrivialSum(uint64_t p0, uint64_t p1, uint64_t p2, uint64_t p3, uint64_t
   return p0 + p1 + p2 + p3 + p4 + p5;
 }
 
-void EntryPayload(uint64_t return_address, uint64_t function_address) {
-  return_addresses.emplace(return_address, function_address);
+void EntryPayload(uint64_t return_address, uint64_t function_id) {
+  return_addresses.emplace(return_address, function_id);
 }
 
 uint64_t ExitPayload() {
@@ -47,7 +47,7 @@ uint64_t ExitPayload() {
     if (skipped > 0) {
       printf(" ( %lu skipped events )\n", skipped);
     }
-    printf("Returned from function %#lx\n", current_return_address.function_address);
+    printf("Returned from function with id %#lx\n", current_return_address.function_id);
     last_logged_event = now;
     skipped = 0;
   } else {
@@ -58,8 +58,8 @@ uint64_t ExitPayload() {
 }
 
 // rdi, rsi, rdx, rcx, r8, r9, rax, r10
-void EntryPayloadClobberParameterRegisters(uint64_t return_address, uint64_t function_address) {
-  return_addresses.emplace(return_address, function_address);
+void EntryPayloadClobberParameterRegisters(uint64_t return_address, uint64_t function_id) {
+  return_addresses.emplace(return_address, function_id);
   __asm__ __volatile__(
       "mov $0xffffffffffffffff, %%rdi\n\t"
       "mov $0xffffffffffffffff, %%rsi\n\t"
@@ -74,8 +74,8 @@ void EntryPayloadClobberParameterRegisters(uint64_t return_address, uint64_t fun
       :);
 }
 
-void EntryPayloadClobberXmmRegisters(uint64_t return_address, uint64_t function_address) {
-  return_addresses.emplace(return_address, function_address);
+void EntryPayloadClobberXmmRegisters(uint64_t return_address, uint64_t function_id) {
+  return_addresses.emplace(return_address, function_id);
   __asm__ __volatile__(
       "movdqu 0x3a(%%rip), %%xmm0\n\t"
       "movdqu 0x32(%%rip), %%xmm1\n\t"
@@ -93,8 +93,8 @@ void EntryPayloadClobberXmmRegisters(uint64_t return_address, uint64_t function_
       :);
 }
 
-void EntryPayloadClobberYmmRegisters(uint64_t return_address, uint64_t function_address) {
-  return_addresses.emplace(return_address, function_address);
+void EntryPayloadClobberYmmRegisters(uint64_t return_address, uint64_t function_id) {
+  return_addresses.emplace(return_address, function_id);
   __asm__ __volatile__(
       "vmovdqu 0x3a(%%rip), %%ymm0\n\t"
       "vmovdqu 0x32(%%rip), %%ymm1\n\t"

--- a/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.h
+++ b/src/UserSpaceInstrumentation/UserSpaceInstrumentationTestLib.h
@@ -18,9 +18,9 @@ extern "C" uint64_t TrivialSum(uint64_t p0, uint64_t p1, uint64_t p2, uint64_t p
                                uint64_t p5);
 
 // Payload called on entry of an instrumented function. Needs to record the return address of the
-// function (in order to have it available in `ExitPayload`). `function_address` is the address of
-// the instrumented function.
-extern "C" void EntryPayload(uint64_t return_address, uint64_t function_address);
+// function (in order to have it available in `ExitPayload`). `function_id` is the id of the
+// instrumented function.
+extern "C" void EntryPayload(uint64_t return_address, uint64_t function_id);
 
 // Payload called on exit of an instrumented function. Needs to return the actual return address of
 // the function such that the execution can be continued there.
@@ -31,8 +31,8 @@ extern "C" uint64_t ExitPayload();
 // properly. The two functions below do the same thing for SSE/AVX registers that can be used to
 // hand over floating point parameters.
 extern "C" void EntryPayloadClobberParameterRegisters(uint64_t return_address,
-                                                      uint64_t function_address);
-extern "C" void EntryPayloadClobberXmmRegisters(uint64_t return_address, uint64_t function_address);
-extern "C" void EntryPayloadClobberYmmRegisters(uint64_t return_address, uint64_t function_address);
+                                                      uint64_t function_id);
+extern "C" void EntryPayloadClobberXmmRegisters(uint64_t return_address, uint64_t function_id);
+extern "C" void EntryPayloadClobberYmmRegisters(uint64_t return_address, uint64_t function_id);
 
 #endif  // USER_SPACE_INSTRUMENTATION_TEST_LIB_H_


### PR DESCRIPTION
Previously trampolines handed over the function address to the entry
payload. Since Orbit expects the functions to be identified by a
the function_id this PR changes the name of this parameter to
function_id.
There is an additional complication however: The function_id is not
stable accross multiple profiling runs. Therefore the trampolines
need to get patched with the current function_id before each run. This
is done in `InstrumentFunction`. The offset at which the function_id
needs to be inserted is a compile time constant (gets verified during
the construction of the trampoline code).