### PR TITLE
Remove some `unique_ptr`s from some `PerfEvent`s

### DIFF
--- a/src/LinuxTracing/KernelTracepoints.h
+++ b/src/LinuxTracing/KernelTracepoints.h
@@ -23,7 +23,10 @@ struct __attribute__((__packed__)) task_newtask_tracepoint {
   char comm[16];
   uint64_t clone_flags;
   int16_t oom_score_adj;
+  char reserved[14];  // These bytes are not documented in the format file.
 };
+
+static_assert(sizeof(task_newtask_tracepoint) == 52);
 
 struct __attribute__((__packed__)) task_rename_tracepoint {
   tracepoint_common common;
@@ -31,7 +34,10 @@ struct __attribute__((__packed__)) task_rename_tracepoint {
   char oldcomm[16];
   char newcomm[16];
   int16_t oom_score_adj;
+  char reserved[6];  // These bytes are not documented in the format file.
 };
+
+static_assert(sizeof(task_rename_tracepoint) == 52);
 
 struct __attribute__((__packed__)) sched_switch_tracepoint {
   tracepoint_common common;
@@ -42,8 +48,10 @@ struct __attribute__((__packed__)) sched_switch_tracepoint {
   char next_comm[16];
   int32_t next_pid;
   int32_t next_prio;
-  uint32_t reserved;  // These four bytes are not documented in the format file.
+  char reserved[4];  // These bytes are not documented in the format file.
 };
+
+static_assert(sizeof(sched_switch_tracepoint) == 68);
 
 struct __attribute__((__packed__)) sched_wakeup_tracepoint {
   tracepoint_common common;
@@ -52,7 +60,10 @@ struct __attribute__((__packed__)) sched_wakeup_tracepoint {
   int32_t prio;
   int32_t success;
   int32_t target_cpu;
+  char reserved[4];  // These bytes are not documented in the format file.
 };
+
+static_assert(sizeof(sched_wakeup_tracepoint) == 44);
 
 struct __attribute__((__packed__)) amdgpu_cs_ioctl_tracepoint {
   tracepoint_common common;

--- a/src/LinuxTracing/PerfEvent.h
+++ b/src/LinuxTracing/PerfEvent.h
@@ -225,8 +225,6 @@ class StackSamplePerfEvent : public PerfEvent {
   const char* GetStackData() const { return ring_buffer_record.stack.data.get(); }
   char* GetStackData() { return ring_buffer_record.stack.data.get(); }
   uint64_t GetStackSize() const { return ring_buffer_record.stack.dyn_size; }
-
- private:
 };
 
 class CallchainSamplePerfEvent : public PerfEvent {

--- a/src/LinuxTracing/PerfEvent.h
+++ b/src/LinuxTracing/PerfEvent.h
@@ -203,29 +203,28 @@ struct dynamically_sized_perf_event_stack_sample {
 
 class StackSamplePerfEvent : public PerfEvent {
  public:
-  std::unique_ptr<dynamically_sized_perf_event_stack_sample> ring_buffer_record;
+  dynamically_sized_perf_event_stack_sample ring_buffer_record;
 
-  explicit StackSamplePerfEvent(uint64_t dyn_size)
-      : ring_buffer_record{std::make_unique<dynamically_sized_perf_event_stack_sample>(dyn_size)} {}
+  explicit StackSamplePerfEvent(uint64_t dyn_size) : ring_buffer_record{dyn_size} {}
 
-  uint64_t GetTimestamp() const override { return ring_buffer_record->sample_id.time; }
+  uint64_t GetTimestamp() const override { return ring_buffer_record.sample_id.time; }
 
   void Accept(PerfEventVisitor* visitor) override;
 
-  pid_t GetPid() const { return ring_buffer_record->sample_id.pid; }
-  pid_t GetTid() const { return ring_buffer_record->sample_id.tid; }
+  pid_t GetPid() const { return ring_buffer_record.sample_id.pid; }
+  pid_t GetTid() const { return ring_buffer_record.sample_id.tid; }
 
-  uint64_t GetStreamId() const { return ring_buffer_record->sample_id.stream_id; }
+  uint64_t GetStreamId() const { return ring_buffer_record.sample_id.stream_id; }
 
-  uint32_t GetCpu() const { return ring_buffer_record->sample_id.cpu; }
+  uint32_t GetCpu() const { return ring_buffer_record.sample_id.cpu; }
 
   std::array<uint64_t, PERF_REG_X86_64_MAX> GetRegisters() const {
-    return perf_event_sample_regs_user_all_to_register_array(ring_buffer_record->regs);
+    return perf_event_sample_regs_user_all_to_register_array(ring_buffer_record.regs);
   }
 
-  const char* GetStackData() const { return ring_buffer_record->stack.data.get(); }
-  char* GetStackData() { return ring_buffer_record->stack.data.get(); }
-  uint64_t GetStackSize() const { return ring_buffer_record->stack.dyn_size; }
+  const char* GetStackData() const { return ring_buffer_record.stack.data.get(); }
+  char* GetStackData() { return ring_buffer_record.stack.data.get(); }
+  uint64_t GetStackSize() const { return ring_buffer_record.stack.dyn_size; }
 
  private:
 };

--- a/src/LinuxTracing/PerfEventReaders.cpp
+++ b/src/LinuxTracing/PerfEventReaders.cpp
@@ -141,12 +141,12 @@ std::unique_ptr<StackSamplePerfEvent> ConsumeStackSamplePerfEvent(PerfEventRingB
   ring_buffer->ReadValueAtOffset(&dyn_size, offset_of_dyn_size);
 
   auto event = std::make_unique<StackSamplePerfEvent>(dyn_size);
-  event->ring_buffer_record->header = header;
-  ring_buffer->ReadValueAtOffset(&event->ring_buffer_record->sample_id,
+  event->ring_buffer_record.header = header;
+  ring_buffer->ReadValueAtOffset(&event->ring_buffer_record.sample_id,
                                  offsetof(perf_event_stack_sample_fixed, sample_id));
-  ring_buffer->ReadValueAtOffset(&event->ring_buffer_record->regs,
+  ring_buffer->ReadValueAtOffset(&event->ring_buffer_record.regs,
                                  offsetof(perf_event_stack_sample_fixed, regs));
-  ring_buffer->ReadRawAtOffset(event->ring_buffer_record->stack.data.get(), offset_of_data,
+  ring_buffer->ReadRawAtOffset(event->ring_buffer_record.stack.data.get(), offset_of_data,
                                dyn_size);
   ring_buffer->SkipRecord(header);
   return event;

--- a/src/LinuxTracing/PerfEventReaders.h
+++ b/src/LinuxTracing/PerfEventReaders.h
@@ -47,9 +47,10 @@ std::unique_ptr<GenericTracepointPerfEvent> ConsumeGenericTracepointPerfEvent(
 std::unique_ptr<MmapPerfEvent> ConsumeMmapPerfEvent(PerfEventRingBuffer* ring_buffer,
                                                     const perf_event_header& header);
 
-template <typename T, typename = std::enable_if_t<std::is_base_of_v<TracepointPerfEvent, T>>>
-std::unique_ptr<T> ConsumeTracepointPerfEvent(PerfEventRingBuffer* ring_buffer,
-                                              const perf_event_header& header) {
+template <typename T,
+          typename = std::enable_if_t<std::is_base_of_v<VariableSizeTracepointPerfEvent, T>>>
+std::unique_ptr<T> ConsumeVariableSizeTracepointPerfEvent(PerfEventRingBuffer* ring_buffer,
+                                                          const perf_event_header& header) {
   uint32_t tracepoint_size;
   ring_buffer->ReadValueAtOffset(&tracepoint_size, offsetof(perf_event_raw_sample_fixed, size));
   auto event = std::make_unique<T>(tracepoint_size);

--- a/src/LinuxTracing/PerfEventRecords.h
+++ b/src/LinuxTracing/PerfEventRecords.h
@@ -127,6 +127,14 @@ struct __attribute__((__packed__)) perf_event_ax_sample {
   perf_event_sample_regs_user_ax regs;
 };
 
+template <typename TracepointT>
+struct __attribute__((__packed__)) perf_event_raw_sample {
+  perf_event_header header;
+  perf_event_sample_id_tid_time_streamid_cpu sample_id;
+  uint32_t size;
+  TracepointT data;
+};
+
 struct __attribute__((__packed__)) perf_event_raw_sample_fixed {
   perf_event_header header;
   perf_event_sample_id_tid_time_streamid_cpu sample_id;

--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -185,7 +185,7 @@ TEST_F(UprobesUnwindingVisitorTest,
       .cpu = 0,
       .res = 0,
   };
-  event.ring_buffer_record->sample_id = sample_id;
+  event.ring_buffer_record.sample_id = sample_id;
 
   EXPECT_CALL(return_address_manager_, PatchSample).Times(1).WillOnce(Return());
   EXPECT_CALL(maps_, Get).Times(1).WillOnce(Return(nullptr));
@@ -253,7 +253,7 @@ TEST_F(UprobesUnwindingVisitorTest, VisitEmptyStackSampleWithoutUprobesDoesNothi
       .cpu = 0,
       .res = 0,
   };
-  event.ring_buffer_record->sample_id = sample_id;
+  event.ring_buffer_record.sample_id = sample_id;
 
   EXPECT_CALL(return_address_manager_, PatchSample).Times(1).WillOnce(Return());
   EXPECT_CALL(maps_, Get).Times(1).WillOnce(Return(nullptr));
@@ -293,7 +293,7 @@ TEST_F(UprobesUnwindingVisitorTest,
       .cpu = 0,
       .res = 0,
   };
-  event.ring_buffer_record->sample_id = sample_id;
+  event.ring_buffer_record.sample_id = sample_id;
 
   EXPECT_CALL(return_address_manager_, PatchSample).Times(1).WillRepeatedly(Return());
   EXPECT_CALL(maps_, Get).Times(1).WillOnce(Return(nullptr));
@@ -352,7 +352,7 @@ TEST_F(UprobesUnwindingVisitorTest,
       .cpu = 0,
       .res = 0,
   };
-  event.ring_buffer_record->sample_id = sample_id;
+  event.ring_buffer_record.sample_id = sample_id;
 
   EXPECT_CALL(return_address_manager_, PatchSample).Times(1).WillOnce(Return());
   EXPECT_CALL(maps_, Get).Times(1).WillOnce(Return(nullptr));
@@ -408,7 +408,7 @@ TEST_F(UprobesUnwindingVisitorTest, VisitStackSampleWithinUprobeSendsInUprobesCa
       .cpu = 0,
       .res = 0,
   };
-  event.ring_buffer_record->sample_id = sample_id;
+  event.ring_buffer_record.sample_id = sample_id;
 
   EXPECT_CALL(return_address_manager_, PatchSample).Times(1).WillOnce(Return());
   EXPECT_CALL(maps_, Get).Times(1).WillOnce(Return(nullptr));


### PR DESCRIPTION
#### Remove unique_ptr for StackSamplePerfEvent::ring_buffer_record
Let's get rid of the extra indirection (which comes with an unnecessary extra
allocation).
#### Distinguish between FixedSize and VariableSizeTracepointPerfEvents
`FixedSizeTracepointPerfEvent`s now save one indirection by not needing the
`std::unique_ptr`, which is relevant for scheduling-related and
thread-state-related tracepoints.

They also follow the format of the simpler `PerfEvent`s that have one field
`ring_buffer_record` read with `PerfEventRingBuffer::ConsumeRecord`.

This saves around one percentage point of CPU utilization of `OrbitService` on
a standard capture of Trata (as far as I could see).

Test: Run `LinuxTracingIntegrationTest`. Capture Trata.