### PR TITLE
[RELEASE] Fix track type visibility & filtering

### DIFF
--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -181,6 +181,7 @@ void TrackManager::SetFilter(const std::string& filter) {
 }
 
 void TrackManager::UpdateVisibleTrackList() {
+  visible_track_list_needs_update_ = false;
   visible_tracks_.clear();
 
   auto track_should_be_shown = [this](const Track* track) {
@@ -207,7 +208,6 @@ void TrackManager::UpdateVisibleTrackList() {
       }
     }
   }
-  visible_track_list_needs_update_ = false;
 }
 
 std::vector<ThreadTrack*> TrackManager::GetSortedThreadTracks() {
@@ -372,6 +372,7 @@ void TrackManager::SetTrackTypeVisibility(Track::Type type, bool value) {
   if (time_graph_ != nullptr) {
     time_graph_->RequestUpdate();
   }
+  visible_track_list_needs_update_ = true;
 }
 
 bool TrackManager::GetTrackTypeVisibility(Track::Type type) const {

--- a/src/OrbitGl/TrackManagerTest.cpp
+++ b/src/OrbitGl/TrackManagerTest.cpp
@@ -115,12 +115,32 @@ TEST_F(TrackManagerTest, NonVisibleTracksAreNotInTheList) {
   EXPECT_EQ(kNumTracks - 1, track_manager_.GetVisibleTracks().size());
 }
 
-TEST_F(TrackManagerTest, FiltersAndVisibilityWorkTogether) {
+TEST_F(TrackManagerTest, FiltersAndTrackVisibilityWorkTogether) {
   CreateAndFillTracks();
   track_manager_.GetOrCreateThreadTrack(TrackTestData::kThreadId)->SetVisible(false);
   track_manager_.SetFilter("thread");
   track_manager_.UpdateTracksForRendering();
   EXPECT_EQ(kNumThreadTracks - 1, track_manager_.GetVisibleTracks().size());
+}
+
+TEST_F(TrackManagerTest, FiltersAndTrackTypeVisibilityWorkTogether) {
+  CreateAndFillTracks();
+  track_manager_.SetTrackTypeVisibility(Track::Type::kThreadTrack, false);
+  track_manager_.SetFilter("thread");
+  track_manager_.UpdateTracksForRendering();
+  EXPECT_EQ(0, track_manager_.GetVisibleTracks().size());
+
+  track_manager_.SetTrackTypeVisibility(Track::Type::kThreadTrack, true);
+  track_manager_.UpdateTracksForRendering();
+  EXPECT_EQ(kNumThreadTracks, track_manager_.GetVisibleTracks().size());
+
+  track_manager_.SetFilter("");
+  EXPECT_EQ(kNumTracks, track_manager_.GetVisibleTracks().size());
+
+  track_manager_.SetFilter("thread");
+  track_manager_.SetTrackTypeVisibility(Track::Type::kThreadTrack, false);
+  track_manager_.UpdateTracksForRendering();
+  EXPECT_EQ(0, track_manager_.GetVisibleTracks().size());
 }
 
 TEST_F(TrackManagerTest, TrackTypeVisibilityAffectsVisibleTrackList) {


### PR DESCRIPTION
See http://b/193604448

@dpallotti This is not a breaking bug or a regression because it only affects a new feature, but it is definitely not the intended behavior and may confuse users that try the new feature. We can discuss if it should actually go into the release or just on main.

Change was introduced here: https://github.com/google/orbit/pull/2496