### PR TITLE
Rework on the graph track line drawing

### DIFF
--- a/src/OrbitGl/Batcher.cpp
+++ b/src/OrbitGl/Batcher.cpp
@@ -47,8 +47,11 @@ void Batcher::AddVerticalLine(Vec2 pos, float size, float z, const Color& color,
 void Batcher::AddLine(Vec2 from, Vec2 to, float z, const Color& color, const Color& picking_color,
                       std::unique_ptr<PickingUserData> user_data) {
   Line line;
-  line.start_point = Vec3(floorf(from[0]), floorf(from[1]), z);
-  line.end_point = Vec3(floorf(to[0]), floorf(to[1]), z);
+  // We had the issue that some horizontal lines in graph tracks are missing when they are drawn
+  // at the margin of pixels. The problem can be addressed, in most cases, by drawing lines at the
+  // center of pixels.
+  line.start_point = Vec3(floorf(from[0]), floorf(from[1]) + 0.5f, z);
+  line.end_point = Vec3(floorf(to[0]), floorf(to[1]) + 0.5f, z);
   auto& buffer = primitive_buffers_by_layer_[z];
 
   buffer.line_buffer.lines_.emplace_back(line);
@@ -380,7 +383,6 @@ void Batcher::DrawLayer(float layer, bool picking) const {
   glEnableClientState(GL_VERTEX_ARRAY);
   glEnableClientState(GL_COLOR_ARRAY);
   glEnable(GL_TEXTURE_2D);
-  glLineWidth(2.0f);
 
   DrawBoxBuffer(layer, picking);
   DrawLineBuffer(layer, picking);

--- a/src/OrbitGl/LineGraphTrack.cpp
+++ b/src/OrbitGl/LineGraphTrack.cpp
@@ -94,7 +94,7 @@ void LineGraphTrack<Dimension>::DrawSingleSeriesEntry(
     Batcher* batcher, uint64_t start_tick, uint64_t end_tick,
     const std::array<float, Dimension>& current_normalized_values,
     const std::array<float, Dimension>& next_normalized_values, float z, bool is_last) {
-  constexpr float kDotRadius = 3.f;
+  constexpr float kDotRadius = 2.f;
   float x0 = this->time_graph_->GetWorldFromTick(start_tick);
   float x1 = this->time_graph_->GetWorldFromTick(end_tick);
   float content_height = this->GetGraphContentHeight();


### PR DESCRIPTION
We had the issue that some horizontal lines in the graph track are
missing when we are drawn at the margin of pixels.

This was fixed previously (#2506)
by increasing the line width from 1px to 2px.
However, this affects the other tracks, which is not expected.
We change to draw lines at the center of pixels. This suppose to fix the
missing line issue in most cases.