### PR TITLE
Collapse memory related tracks by default

### DIFF
--- a/src/OrbitGl/MemoryTrack.h
+++ b/src/OrbitGl/MemoryTrack.h
@@ -24,7 +24,10 @@ class MemoryTrack : public GraphTrack<Dimension>, public AnnotationTrack {
                        const orbit_client_model::CaptureData* capture_data)
       : GraphTrack<Dimension>(parent, time_graph, viewport, layout, name, series_names,
                               capture_data),
-        AnnotationTrack() {}
+        AnnotationTrack() {
+    // Memory tracks are collapsed by default.
+    this->collapse_toggle_->SetCollapsed(true);
+  }
   ~MemoryTrack() override = default;
   [[nodiscard]] Track::Type GetType() const override { return Track::Type::kMemoryTrack; }
   void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,

--- a/src/OrbitGl/PagefaultTrack.cpp
+++ b/src/OrbitGl/PagefaultTrack.cpp
@@ -35,6 +35,10 @@ PagefaultTrack::PagefaultTrack(CaptureViewElement* parent, TimeGraph* time_graph
   const std::string kTrackName = "Pagefault Track";
   SetName(kTrackName);
   SetLabel(kTrackName);
+
+  // Pagefault track is collapsed by default. The major and minor pagefault subtracks are expanded
+  // by default, but not shown while the pagefault track is collapsed.
+  collapse_toggle_->SetCollapsed(true);
 }
 
 float PagefaultTrack::GetHeight() const {


### PR DESCRIPTION
Memory tracks and pagefault tracks take too much space. They should be
collapsed by default.