### PR TITLE
Fix strange jump after double-clicking gpu timer

### DIFF
--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -194,9 +194,8 @@ void CaptureWindow::SelectTextBox(const TextBox* text_box) {
   const TimerInfo& timer_info = text_box->GetTimerInfo();
 
   if (double_clicking_) {
-    // Zoom and center the text_box into the screen and make its track fully visible.
+    // Zoom and center the text_box into the screen.
     time_graph_->Zoom(timer_info);
-    time_graph_->SelectAndMakeVisible(text_box);
   }
 }
 


### PR DESCRIPTION
We are aligning vertically after double-clicking which doesn't have
sense anymore. We should only do it when doing a jumping to a function
call.

In this PR only zoom after a double-click in any event in the
CaptureWindow.

Bug: http://b/193649351
Test: Load a capture, start a capture.