### PR TITLE
Distinguish the "All Threads" event track

### DIFF
--- a/src/OrbitBase/include/OrbitBase/ThreadConstants.h
+++ b/src/OrbitBase/include/OrbitBase/ThreadConstants.h
@@ -19,6 +19,9 @@ static constexpr int32_t kAllThreadsOfAllProcessesTid = -2;
 // that are NOT in the current process.
 static constexpr int32_t kNotTargetProcessTid = -3;
 
+// Represents an invalid thread id.
+static constexpr int32_t kInvalidThreadTid = -4;
+
 }  // namespace orbit_base
 
 #endif  // ORBIT_BASE_THREAD_CONSTANTS_H

--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -99,7 +99,7 @@ void CallstackThreadBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, u
   ThreadBar::UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
 
   float z = GlCanvas::kZValueEvent + z_offset;
-  float track_height = layout_->GetEventTrackHeight();
+  float track_height = layout_->GetEventTrackHeightFromTid(thread_id_);
   const bool picking = picking_mode != PickingMode::kNone;
 
   const Color kWhite(255, 255, 255, 255);

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -38,8 +38,8 @@ float GraphTrack<Dimension>::GetHeight() const {
   float scale_factor = IsCollapsed() ? 1 : Dimension;
   float height = layout_->GetTrackTabHeight() + GetLegendHeight() +
                  layout_->GetTextBoxHeight() * scale_factor +
-                 layout_->GetSpaceBetweenTracksAndThread() + layout_->GetEventTrackHeight() +
-                 layout_->GetTrackBottomMargin();
+                 layout_->GetSpaceBetweenTracksAndThread() +
+                 layout_->GetEventTrackHeightFromTid(thread_id_) + layout_->GetTrackBottomMargin();
   return height;
 }
 

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -253,7 +253,7 @@ bool ThreadTrack::IsEmpty() const {
 
 void ThreadTrack::UpdatePositionOfSubtracks() {
   const float thread_state_track_height = layout_->GetThreadStateTrackHeight();
-  const float event_track_height = layout_->GetEventTrackHeight();
+  const float event_track_height = layout_->GetEventTrackHeightFromTid(thread_id_);
   const float space_between_subtracks = layout_->GetSpaceBetweenTracksAndThread();
 
   float current_y = pos_[1] - layout_->GetTrackTabHeight();
@@ -284,8 +284,8 @@ void ThreadTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
   UpdatePositionOfSubtracks();
 
   const float thread_state_track_height = layout_->GetThreadStateTrackHeight();
-  const float event_track_height = layout_->GetEventTrackHeight();
-  const float tracepoint_track_height = layout_->GetEventTrackHeight();
+  const float event_track_height = layout_->GetEventTrackHeightFromTid(thread_id_);
+  const float tracepoint_track_height = layout_->GetEventTrackHeightFromTid(thread_id_);
   const float world_width = viewport_->GetVisibleWorldWidth();
 
   if (!thread_state_bar_->IsEmpty()) {
@@ -383,8 +383,13 @@ void ThreadTrack::SetTimesliceText(const TimerInfo& timer_info, float min_x, flo
 }
 
 std::string ThreadTrack::GetTooltip() const {
-  return "Shows collected samples and timings from dynamically instrumented "
-         "functions";
+  if (thread_id_ == orbit_base::kAllProcessThreadsTid) {
+    return "Shows collected samples for all threads of process " + capture_data_->process_name() +
+           " " + std::to_string(capture_data_->process_id());
+  } else {
+    return "Shows collected samples and timings from dynamically instrumented "
+           "functions";
+  }
 }
 
 float ThreadTrack::GetHeight() const {
@@ -401,8 +406,8 @@ float ThreadTrack::GetHeight() const {
 
 float ThreadTrack::GetHeaderHeight() const {
   const float thread_state_track_height = layout_->GetThreadStateTrackHeight();
-  const float event_track_height = layout_->GetEventTrackHeight();
-  const float tracepoint_track_height = layout_->GetEventTrackHeight();
+  const float event_track_height = layout_->GetEventTrackHeightFromTid(thread_id_);
+  const float tracepoint_track_height = layout_->GetEventTrackHeightFromTid(thread_id_);
   const float space_between_subtracks = layout_->GetSpaceBetweenTracksAndThread();
 
   float header_height = layout_->GetTrackTabHeight();

--- a/src/OrbitGl/TimeGraphLayout.cpp
+++ b/src/OrbitGl/TimeGraphLayout.cpp
@@ -6,11 +6,14 @@
 
 #include <imgui.h>
 
+#include "OrbitBase/ThreadConstants.h"
+
 TimeGraphLayout::TimeGraphLayout() {
   text_box_height_ = 20.f;
   core_height_ = 10.f;
   thread_state_track_height_ = 4.0f;
   event_track_height_ = 10.f;
+  all_threads_event_track_scale_ = 2.f;
   variable_track_height_ = 20.f;
   track_bottom_margin_ = 5.f;
   track_top_margin_ = 5.f;
@@ -52,6 +55,7 @@ bool TimeGraphLayout::DrawProperties() {
   FLOAT_SLIDER(core_height_);
   FLOAT_SLIDER(thread_state_track_height_);
   FLOAT_SLIDER(event_track_height_);
+  FLOAT_SLIDER_MIN_MAX(all_threads_event_track_scale_, 0, 10.f);
   FLOAT_SLIDER(variable_track_height_);
   FLOAT_SLIDER(space_between_cores_);
   FLOAT_SLIDER(space_between_gpu_depths_);
@@ -85,4 +89,12 @@ float TimeGraphLayout::GetBottomMargin() const {
   // The bottom consists of the slider (where we have to take the width, as it
   // is rotated), and the time bar.
   return GetSliderWidth() + GetTimeBarHeight();
+}
+
+float TimeGraphLayout::GetEventTrackHeightFromTid(int32_t tid) const {
+  float height = GetEventTrackHeight();
+  if (tid == orbit_base::kAllProcessThreadsTid) {
+    height *= GetAllThreadsEventTrackScale();
+  }
+  return height;
 }

--- a/src/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/TimeGraphLayout.h
@@ -15,7 +15,7 @@ class TimeGraphLayout {
   float GetTextBoxHeight() const { return text_box_height_ * scale_; }
   float GetTextCoresHeight() const { return core_height_ * scale_; }
   float GetThreadStateTrackHeight() const { return thread_state_track_height_ * scale_; }
-  float GetEventTrackHeight() const { return event_track_height_ * scale_; }
+  float GetEventTrackHeightFromTid(int32_t tid) const;
   float GetVariableTrackHeight() const { return variable_track_height_ * scale_; }
   float GetTrackBottomMargin() const { return track_bottom_margin_ * scale_; }
   float GetTrackTopMargin() const { return track_top_margin_ * scale_; }
@@ -56,6 +56,7 @@ class TimeGraphLayout {
   float core_height_;
   float thread_state_track_height_;
   float event_track_height_;
+  float all_threads_event_track_scale_;
   float variable_track_height_;
   float track_bottom_margin_;
   float track_top_margin_;
@@ -88,6 +89,10 @@ class TimeGraphLayout {
 
   bool draw_properties_ = false;
   bool draw_track_background_ = true;
+
+ private:
+  float GetEventTrackHeight() const { return event_track_height_ * scale_; }
+  float GetAllThreadsEventTrackScale() const { return all_threads_event_track_scale_; }
 };
 
 #endif  // ORBIT_GL_TIME_GRAPH_LAYOUT_H_

--- a/src/OrbitGl/TracepointThreadBar.cpp
+++ b/src/OrbitGl/TracepointThreadBar.cpp
@@ -58,7 +58,7 @@ void TracepointThreadBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, 
   ThreadBar::UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
 
   float z = GlCanvas::kZValueEvent + z_offset;
-  float track_height = layout_->GetEventTrackHeight();
+  float track_height = layout_->GetEventTrackHeightFromTid(thread_id_);
   const bool picking = picking_mode != PickingMode::kNone;
 
   const Color kWhite(255, 255, 255, 255);

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -12,6 +12,7 @@
 #include "CoreMath.h"
 #include "Geometry.h"
 #include "GlCanvas.h"
+#include "OrbitBase/ThreadConstants.h"
 #include "TextRenderer.h"
 #include "TimeGraph.h"
 #include "TimeGraphLayout.h"
@@ -24,7 +25,7 @@ Track::Track(CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::Viewpo
              uint32_t indentation_level)
     : CaptureViewElement(parent, time_graph, viewport, layout),
       num_prioritized_trailing_characters_{0},
-      thread_id_{-1},
+      thread_id_{orbit_base::kInvalidThreadTid},
       process_id_{-1},
       pinned_{false},
       track_data_{std::make_unique<TrackData>()},


### PR DESCRIPTION
Increase the height of the "All Threads" event bar and modify the
tooltip to be more specific.

Bug: http://b/189304809