### PR TITLE
Fix clang-format presubmit check

### DIFF
--- a/kokoro/checks/clang_format/check.sh
+++ b/kokoro/checks/clang_format/check.sh
@@ -18,7 +18,7 @@ if [ "$0" == "$SCRIPT" ]; then
   echo -e "> but changes outside of the scope of your PR won't affect the outcome"
   echo -e "> of this presubmit check.\n"
   while read line; do
-    if clang-format --output-replacements-xml $line | grep '<replacement ' > /dev/null; then
+    if clang-format-9 --output-replacements-xml $line | grep '<replacement ' > /dev/null; then
       echo $line
     fi
   done <<< $(find /mnt -name '*.cpp' -o -name '*.h' \


### PR DESCRIPTION
I half-broke the check when updating the docker containers. The new
docker container does not have a symlink from `clang-format` to
`clang-format-9`, so we have to call `clang-format-9` instead.

This was already correct for the `clang-format-diff-9` call - that's why
it was only half-broken.