### PR TITLE
[Rebase on main of dimitry's] Explicitly use int64_t instead of off_t

### DIFF
--- a/src/CaptureFile/CaptureFile.cpp
+++ b/src/CaptureFile/CaptureFile.cpp
@@ -84,7 +84,11 @@ constexpr uint64_t AlignUp(uint64_t value) {
 }
 
 ErrorMessageOr<uint64_t> GetEndOfFileOffset(const unique_fd& fd) {
-  off_t end_of_file = lseek(fd.get(), 0, SEEK_END);
+#if defined(_WIN32)
+  int64_t end_of_file = _lseeki64(fd.get(), 0, SEEK_END);
+#else
+  int64_t end_of_file = lseek64(fd.get(), 0, SEEK_END);
+#endif
   if (end_of_file == -1) {
     return ErrorMessage{SafeStrerror(errno)};
   }

--- a/src/OrbitBase/File.cpp
+++ b/src/OrbitBase/File.cpp
@@ -25,32 +25,32 @@ using ssize_t = int64_t;
 
 // There is no implementation for pread and pwrite in 'io.h' so we implement them on top of lseek,
 // read and write here.
-ssize_t pread(int fd, void* buffer, size_t size, off_t offset) {
-  off_t old_position = lseek(fd, 0, SEEK_CUR);
+ssize_t pread(int fd, void* buffer, size_t size, int64_t offset) {
+  int64_t old_position = _lseeki64(fd, 0, SEEK_CUR);
   if (old_position == -1) {
     return -1;
   }
-  if (lseek(fd, offset, SEEK_SET) == -1) {
+  if (_lseeki64(fd, offset, SEEK_SET) == -1) {
     return -1;
   }
   ssize_t bytes_read = read(fd, buffer, size);
-  if ((lseek(fd, old_position, SEEK_SET)) == -1) {
+  if ((_lseeki64(fd, old_position, SEEK_SET)) == -1) {
     return -1;
   }
   return bytes_read;
 }
 
-ssize_t pwrite(int fd, const void* buffer, size_t size, off_t offset) {
-  off_t cpos, opos;
-  off_t old_position = lseek(fd, 0, SEEK_CUR);
+ssize_t pwrite(int fd, const void* buffer, size_t size, int64_t offset) {
+  int64_t cpos, opos;
+  int64_t old_position = _lseeki64(fd, 0, SEEK_CUR);
   if (old_position == -1) {
     return -1;
   }
-  if (lseek(fd, offset, SEEK_SET) == -1) {
+  if (_lseeki64(fd, offset, SEEK_SET) == -1) {
     return -1;
   }
   ssize_t bytes_written = write(fd, buffer, size);
-  if (lseek(fd, old_position, SEEK_SET) == -1) {
+  if (_lseeki64(fd, old_position, SEEK_SET) == -1) {
     return -1;
   }
   return bytes_written;
@@ -144,7 +144,7 @@ ErrorMessageOr<void> WriteFully(const unique_fd& fd, std::string_view content) {
 }
 
 ErrorMessageOr<void> WriteFullyAtOffset(const unique_fd& fd, const void* buffer, size_t size,
-                                        off_t offset) {
+                                        int64_t offset) {
   const char* current_position = static_cast<const char*>(buffer);
 
   while (size > 0) {
@@ -181,7 +181,7 @@ ErrorMessageOr<size_t> ReadFully(const unique_fd& fd, void* buffer, size_t size)
 }
 
 ErrorMessageOr<size_t> ReadFullyAtOffset(const unique_fd& fd, void* buffer, size_t size,
-                                         off_t offset) {
+                                         int64_t offset) {
   uint8_t* current_position = static_cast<uint8_t*>(buffer);
   size_t bytes_read = 0;
   while (bytes_read < size) {

--- a/src/OrbitBase/FileTest.cpp
+++ b/src/OrbitBase/FileTest.cpp
@@ -157,6 +157,19 @@ TEST(File, WriteFullyAtOffsetSmoke) {
   EXPECT_STREQ(read_back.data(), "ab\nef\n");
 }
 
+TEST(File, WriteFullyAtOffset2GOffset) {
+  constexpr uint64_t kLargeOffset = (1LL << 31) + 5;  // 2G + 5bytes
+  auto temporary_file_or_error = TemporaryFile::Create();
+  ASSERT_THAT(temporary_file_or_error, HasNoError());
+  TemporaryFile temporary_file = std::move(temporary_file_or_error.value());
+
+  // Write at the beginning of the previously empty file.
+  std::array<char, 64> buffer{'a', 'b', '\n', 'c', 'd', '\n'};
+  ErrorMessageOr<void> write_result_or_error =
+      WriteFullyAtOffset(temporary_file.fd(), buffer.data(), 6, kLargeOffset);
+  ASSERT_THAT(write_result_or_error, HasNoError());
+}
+
 TEST(File, ReadFullySmoke) {
   const auto fd_or_error =
       OpenFileForReading(GetExecutableDir() / "testdata" / "OrbitBase" / "textfile.bin");
@@ -246,7 +259,7 @@ TEST(File, ReadStructureAtOffset) {
 
   auto fd = std::move(fd_or_error.value());
 
-  constexpr const off_t kOffset = 42;
+  constexpr const int64_t kOffset = 42;
   constexpr uint64_t kU64Value = 1121;
   constexpr const char* kCharArray = "abcdefg";
 

--- a/src/OrbitBase/include/OrbitBase/File.h
+++ b/src/OrbitBase/include/OrbitBase/File.h
@@ -86,7 +86,7 @@ ErrorMessageOr<void> WriteFully(const unique_fd& fd, const void* data, size_t si
 ErrorMessageOr<void> WriteFully(const unique_fd& fd, std::string_view content);
 
 ErrorMessageOr<void> WriteFullyAtOffset(const unique_fd& fd, const void* buffer, size_t size,
-                                        off_t offset);
+                                        int64_t offset);
 
 // Tries to read 'size' bytes from the file to the buffer, returns actual
 // number of bytes read. Note that the return value is less then size in
@@ -99,10 +99,10 @@ ErrorMessageOr<size_t> ReadFully(const unique_fd& fd, void* buffer, size_t size)
 // Same as above but tries to read from an offset. The file referenced by fd must be capable of
 // seeking. The same limitation for non-blocking reads as above applies here.
 ErrorMessageOr<size_t> ReadFullyAtOffset(const unique_fd& fd, void* buffer, size_t size,
-                                         off_t offset);
+                                         int64_t offset);
 
 template <typename T>
-ErrorMessageOr<T> ReadFullyAtOffset(const unique_fd& fd, off_t offset) {
+ErrorMessageOr<T> ReadFullyAtOffset(const unique_fd& fd, int64_t offset) {
   T value;
   auto size_or_error = ReadFullyAtOffset(fd, &value, sizeof(value), offset);
   if (size_or_error.has_error()) {


### PR DESCRIPTION
On windows off_t is int32_t. Since Windows does not
define off64_t switch code to expliclty use int64_t
instead of using off_t.

This also removes calls to lseek, since on windows lseek
uses 32bit off_t.

Bug: http://b/193624501
Test: run unit-tests for OrbitBase