### PR TITLE
Update bzip2 recipe

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -83,7 +83,7 @@ class OrbitConan(ConanFile):
             raise ConanInvalidConfiguration("The OpenGL software renderer cannot be deployed when using a system-provided Qt installation.")
 
         self.requires("abseil/20200923.3")
-        self.requires("bzip2/1.0.8@conan/stable#0")
+        self.requires("bzip2/1.0.8")
         self.requires("capstone/4.0.1@{}#0".format(self._orbit_channel))
         self.requires("grpc/1.27.3@{}".format(self._orbit_channel))
         self.requires("c-ares/1.15.0")

--- a/third_party/conan/lockfiles/base.lock
+++ b/third_party/conan/lockfiles/base.lock
@@ -42,7 +42,7 @@
     "context": "host"
    },
    "2": {
-    "ref": "bzip2/1.0.8@conan/stable#0",
+    "ref": "bzip2/1.0.8#9c8b632000a52af5af3f045d3a6db12f",
     "context": "host"
    },
    "3": {


### PR DESCRIPTION
The old one is not officially supported anymore,
so let's upgrade to the new one.