### PR TITLE
Fix compiler flags in cross build

### DIFF
--- a/third_party/conan/configs/linux/profiles/ggp_common
+++ b/third_party/conan/configs/linux/profiles/ggp_common
@@ -19,11 +19,11 @@ abseil:compiler.cppstd=17
 
 [options]
 OrbitProfiler:with_gui=False
+ggp_sdk:extra_c_flags=$C_FLAGS
+ggp_sdk:extra_cxx_flags=$CXX_FLAGS
 
 [build_requires]
-ggp_sdk/1.43.0.14282@orbitdeps/stable
+ggp_sdk/1.43.0.14282@orbitdeps/stable#fd040bf6c348d57da36442df061faf4b
 
 [env]
-CFLAGS=$C_FLAGS
-CXXFLAGS=$CXX_FLAGS
 LDFLAGS=$LD_FLAGS

--- a/third_party/conan/configs/windows/profiles/ggp_common
+++ b/third_party/conan/configs/windows/profiles/ggp_common
@@ -20,9 +20,11 @@ abseil:compiler.cppstd=17
 
 [options]
 OrbitProfiler:with_gui=False
+ggp_sdk:extra_c_flags=$C_FLAGS
+ggp_sdk:extra_cxx_flags=$CXX_FLAGS
 
 [build_requires]
-ggp_sdk/1.43.0.14282@orbitdeps/stable
+ggp_sdk/1.43.0.14282@orbitdeps/stable#fd040bf6c348d57da36442df061faf4b
 
 [env]
 CONAN_CMAKE_GENERATOR=Ninja


### PR DESCRIPTION
Both the ggp_sdk package - which contains the compiler when compiling
for Stadia - and our profiles define C and C++ compiler flags. Both
lists of flags need to get merged to properly compile Orbit, but this is
currently not happening in all cases. Conan recipes that don't use CMake
(i.e. openssl) won't use the flags from the ggp_sdk package since they
get overwritten by the flags defined in the profile.

As a workaround we pass our compiler flags from the profile as a package
option to the ggp_sdk package. The package will merge the flags and set
them properly.