### PR TITLE
Collect args on uprobes and return values on uretprobes only when needed

### DIFF
--- a/src/CaptureClient/include/CaptureClient/CaptureClient.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureClient.h
@@ -42,6 +42,7 @@ class CaptureClient {
       ThreadPool* thread_pool, int32_t process_id,
       const orbit_client_data::ModuleManager& module_manager,
       absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo> selected_functions,
+      bool always_record_arguments, bool record_return_values,
       orbit_client_data::TracepointInfoSet selected_tracepoints, double samples_per_second,
       uint16_t stack_dump_size, orbit_grpc_protos::UnwindingMethod unwinding_method,
       bool collect_scheduling_info, bool collect_thread_state, bool collect_gpu_jobs,
@@ -77,6 +78,7 @@ class CaptureClient {
   ErrorMessageOr<CaptureListener::CaptureOutcome> CaptureSync(
       int32_t process_id, const orbit_client_data::ModuleManager& module_manager,
       const absl::flat_hash_map<uint64_t, orbit_client_protos::FunctionInfo>& selected_functions,
+      bool always_record_arguments, bool record_return_values,
       const orbit_client_data::TracepointInfoSet& selected_tracepoints, double samples_per_second,
       uint16_t stack_dump_size, orbit_grpc_protos::UnwindingMethod unwinding_method,
       bool collect_scheduling_info, bool collect_thread_state, bool collect_gpu_jobs,

--- a/src/FakeClient/FakeClientMain.cpp
+++ b/src/FakeClient/FakeClientMain.cpp
@@ -175,6 +175,8 @@ int main(int argc, char* argv[]) {
     LOG("file_path=%s", file_path);
     LOG("file_offset=%#x", file_offset);
   }
+  constexpr bool kAlwaysRecordArguments = false;
+  constexpr bool kRecordReturnValues = false;
   bool collect_scheduling_info = absl::GetFlag(FLAGS_scheduling);
   LOG("collect_scheduling_info=%d", collect_scheduling_info);
   bool collect_thread_state = absl::GetFlag(FLAGS_thread_state);
@@ -238,11 +240,12 @@ int main(int argc, char* argv[]) {
   auto capture_event_processor = std::make_unique<orbit_fake_client::FakeCaptureEventProcessor>();
 
   auto capture_outcome_future = capture_client.Capture(
-      thread_pool.get(), process_id, module_manager, selected_functions,
-      orbit_client_data::TracepointInfoSet{}, samples_per_second, kStackDumpSize, unwinding_method,
-      collect_scheduling_info, collect_thread_state, collect_gpu_jobs, kEnableApi,
-      kEnableIntrospection, kEnableUserSpaceInstrumentation, kMaxLocalMarkerDepthPerCommandBuffer,
-      collect_memory_info, memory_sampling_period_ms, std::move(capture_event_processor));
+      thread_pool.get(), process_id, module_manager, selected_functions, kAlwaysRecordArguments,
+      kRecordReturnValues, orbit_client_data::TracepointInfoSet{}, samples_per_second,
+      kStackDumpSize, unwinding_method, collect_scheduling_info, collect_thread_state,
+      collect_gpu_jobs, kEnableApi, kEnableIntrospection, kEnableUserSpaceInstrumentation,
+      kMaxLocalMarkerDepthPerCommandBuffer, collect_memory_info, memory_sampling_period_ms,
+      std::move(capture_event_processor));
   LOG("Asked to start capture");
 
   uint32_t duration_s = absl::GetFlag(FLAGS_duration);

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -26,6 +26,9 @@ message InstrumentedFunction {
   }
   FunctionType function_type = 4;
   string function_name = 5;
+
+  bool record_arguments = 8;
+  bool record_return_value = 9;
 }
 
 // Api functions are declared in Orbit.h. They are implemented in user code

--- a/src/LinuxTracing/Function.h
+++ b/src/LinuxTracing/Function.h
@@ -13,22 +13,31 @@
 namespace orbit_linux_tracing {
 class Function {
  public:
-  Function(uint64_t function_id, std::string file_path, uint64_t file_offset)
-      : function_id_{function_id}, file_path_{std::move(file_path)}, file_offset_{file_offset} {}
+  Function(uint64_t function_id, std::string file_path, uint64_t file_offset, bool record_arguments,
+           bool record_return_value)
+      : function_id_{function_id},
+        file_path_{std::move(file_path)},
+        file_offset_{file_offset},
+        record_arguments_{record_arguments},
+        record_return_value_{record_return_value} {}
 
   [[nodiscard]] uint64_t function_id() const { return function_id_; }
   [[nodiscard]] const std::string& file_path() const { return file_path_; }
   [[nodiscard]] uint64_t file_offset() const { return file_offset_; }
-
-  bool operator==(const Function& other) {
-    return (this->file_offset_ == other.file_offset_) && (this->file_path_ == other.file_path_);
-  }
+  [[nodiscard]] bool record_arguments() const { return record_arguments_; }
+  [[nodiscard]] bool record_return_value() const { return record_return_value_; }
 
  private:
   uint64_t function_id_;
   std::string file_path_;
   uint64_t file_offset_;
+  bool record_arguments_;
+  bool record_return_value_;
 };
+
+inline bool operator==(const Function& lhs, const Function& rhs) {
+  return (lhs.file_path() == rhs.file_path()) && (lhs.file_offset() == rhs.file_offset());
+}
 
 template <typename H>
 H AbslHashValue(H state, const Function& function) {

--- a/src/LinuxTracing/PerfEvent.cpp
+++ b/src/LinuxTracing/PerfEvent.cpp
@@ -57,7 +57,11 @@ void CallchainSamplePerfEvent::Accept(PerfEventVisitor* visitor) { visitor->Visi
 
 void UprobesPerfEvent::Accept(PerfEventVisitor* visitor) { visitor->Visit(this); }
 
+void UprobesWithArgumentsPerfEvent::Accept(PerfEventVisitor* visitor) { visitor->Visit(this); }
+
 void UretprobesPerfEvent::Accept(PerfEventVisitor* visitor) { visitor->Visit(this); }
+
+void UretprobesWithReturnValuePerfEvent::Accept(PerfEventVisitor* visitor) { visitor->Visit(this); }
 
 void LostPerfEvent::Accept(PerfEventVisitor* visitor) { visitor->Visit(this); }
 

--- a/src/LinuxTracing/PerfEventOpen.cpp
+++ b/src/LinuxTracing/PerfEventOpen.cpp
@@ -109,13 +109,23 @@ int callchain_sample_event_open(uint64_t period_ns, pid_t pid, int32_t cpu,
 int uprobes_retaddr_event_open(const char* module, uint64_t function_offset, pid_t pid,
                                int32_t cpu) {
   perf_event_attr pe = uprobe_event_attr(module, function_offset);
-  pe.config = 0;
+  pe.config &= ~1ULL;
+  pe.sample_type |= PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER;
+  pe.sample_regs_user = SAMPLE_REGS_USER_SP_IP;
+
+  // Only get the very top of the stack, where the return address has been pushed.
+  // We record it as it is about to be hijacked by the installation of the uretprobe.
+  pe.sample_stack_user = SAMPLE_STACK_USER_SIZE_8BYTES;
+
+  return generic_event_open(&pe, pid, cpu);
+}
+
+int uprobes_retaddr_args_event_open(const char* module, uint64_t function_offset, pid_t pid,
+                                    int32_t cpu) {
+  perf_event_attr pe = uprobe_event_attr(module, function_offset);
+  pe.config &= ~1ULL;
   pe.sample_type |= PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER;
   pe.sample_regs_user = SAMPLE_REGS_USER_SP_IP_ARGUMENTS;
-
-  // Only get the very top of the stack, where the return address has been
-  // pushed. We record it as it is about to be hijacked by the installation of
-  // the uretprobe.
   pe.sample_stack_user = SAMPLE_STACK_USER_SIZE_8BYTES;
 
   return generic_event_open(&pe, pid, cpu);
@@ -123,7 +133,15 @@ int uprobes_retaddr_event_open(const char* module, uint64_t function_offset, pid
 
 int uretprobes_event_open(const char* module, uint64_t function_offset, pid_t pid, int32_t cpu) {
   perf_event_attr pe = uprobe_event_attr(module, function_offset);
-  pe.config = 1;  // Set bit 0 of config for uretprobe.
+  pe.config |= 1;  // Set bit 0 of config for uretprobe.
+
+  return generic_event_open(&pe, pid, cpu);
+}
+
+int uretprobes_retval_event_open(const char* module, uint64_t function_offset, pid_t pid,
+                                 int32_t cpu) {
+  perf_event_attr pe = uprobe_event_attr(module, function_offset);
+  pe.config |= 1;  // Set bit 0 of config for uretprobe.
 
   pe.sample_type |= PERF_SAMPLE_REGS_USER;
   pe.sample_regs_user = SAMPLE_REGS_USER_AX;

--- a/src/LinuxTracing/PerfEventOpen.h
+++ b/src/LinuxTracing/PerfEventOpen.h
@@ -84,6 +84,11 @@ static constexpr uint64_t SAMPLE_REGS_USER_ALL =
 // PerfEventRecords.h.
 static constexpr uint64_t SAMPLE_REGS_USER_AX = (1lu << PERF_REG_X86_AX);
 
+// This must be in sync with struct perf_event_sample_regs_user_sp_ip
+// in PerfEventRecords.h.
+static constexpr uint64_t SAMPLE_REGS_USER_SP_IP =
+    (1lu << PERF_REG_X86_SP) | (1lu << PERF_REG_X86_IP);
+
 // This must be in sync with struct perf_event_sample_regs_user_sp_ip_arguments
 // in PerfEventRecords.h.
 static constexpr uint64_t SAMPLE_REGS_USER_SP_IP_ARGUMENTS =
@@ -120,7 +125,13 @@ int callchain_sample_event_open(uint64_t period_ns, pid_t pid, int32_t cpu,
 int uprobes_retaddr_event_open(const char* module, uint64_t function_offset, pid_t pid,
                                int32_t cpu);
 
+int uprobes_retaddr_args_event_open(const char* module, uint64_t function_offset, pid_t pid,
+                                    int32_t cpu);
+
 int uretprobes_event_open(const char* module, uint64_t function_offset, pid_t pid, int32_t cpu);
+
+int uretprobes_retval_event_open(const char* module, uint64_t function_offset, pid_t pid,
+                                 int32_t cpu);
 
 // Create the ring buffer to use perf_event_open in sampled mode.
 void* perf_event_open_mmap_ring_buffer(int fd, uint64_t mmap_length);

--- a/src/LinuxTracing/PerfEventRecords.h
+++ b/src/LinuxTracing/PerfEventRecords.h
@@ -72,6 +72,14 @@ struct __attribute__((__packed__)) perf_event_sample_regs_user_ax {
   uint64_t ax;
 };
 
+// This struct must be in sync with the SAMPLE_REGS_USER_SP_IP in
+// PerfEventOpen.h.
+struct __attribute__((__packed__)) perf_event_sample_regs_user_sp_ip {
+  uint64_t abi;
+  uint64_t sp;
+  uint64_t ip;
+};
+
 // This struct must be in sync with the SAMPLE_REGS_USER_SP_IP_ARGUMENTS in
 // PerfEventOpen.h.
 struct __attribute__((__packed__)) perf_event_sample_regs_user_sp_ip_arguments {
@@ -108,7 +116,7 @@ struct __attribute__((__packed__)) perf_event_callchain_sample_fixed {
   uint64_t nr;
   // Following this field there are the following fields, which we read dynamically:
   // uint64_t[nr] ips;
-  // perf_event_sample_regs_user_sp_ip_arguments regs;
+  // perf_event_sample_regs_user_all regs;
   // uint64_t size;
   // char data[size];
   // uint64_t dyn_size;
@@ -119,6 +127,18 @@ struct __attribute__((__packed__)) perf_event_sp_ip_arguments_8bytes_sample {
   perf_event_sample_id_tid_time_streamid_cpu sample_id;
   perf_event_sample_regs_user_sp_ip_arguments regs;
   perf_event_sample_stack_user_8bytes stack;
+};
+
+struct __attribute__((__packed__)) perf_event_sp_ip_8bytes_sample {
+  perf_event_header header;
+  perf_event_sample_id_tid_time_streamid_cpu sample_id;
+  perf_event_sample_regs_user_sp_ip regs;
+  perf_event_sample_stack_user_8bytes stack;
+};
+
+struct __attribute__((__packed__)) perf_event_empty_sample {
+  perf_event_header header;
+  perf_event_sample_id_tid_time_streamid_cpu sample_id;
 };
 
 struct __attribute__((__packed__)) perf_event_ax_sample {

--- a/src/LinuxTracing/PerfEventVisitor.h
+++ b/src/LinuxTracing/PerfEventVisitor.h
@@ -20,7 +20,9 @@ class PerfEventVisitor {
   virtual void Visit(StackSamplePerfEvent* /*event*/) {}
   virtual void Visit(CallchainSamplePerfEvent* /*event*/) {}
   virtual void Visit(UprobesPerfEvent* /*event*/) {}
+  virtual void Visit(UprobesWithArgumentsPerfEvent* /*event*/) {}
   virtual void Visit(UretprobesPerfEvent* /*event*/) {}
+  virtual void Visit(UretprobesWithReturnValuePerfEvent* /*event*/) {}
   virtual void Visit(LostPerfEvent* /*event*/) {}
   virtual void Visit(DiscardedPerfEvent* /*event*/) {}
   virtual void Visit(MmapPerfEvent* /*event*/) {}

--- a/src/LinuxTracing/TracerThread.cpp
+++ b/src/LinuxTracing/TracerThread.cpp
@@ -77,6 +77,7 @@ TracerThread::TracerThread(const CaptureOptions& capture_options)
   for (const InstrumentedFunction& instrumented_function :
        capture_options.instrumented_functions()) {
     uint64_t function_id = instrumented_function.function_id();
+    // TODO(b/193759921): Use record_arguments and record_return_value.
     instrumented_functions_.emplace_back(function_id, instrumented_function.file_path(),
                                          instrumented_function.file_offset());
 

--- a/src/LinuxTracing/TracerThread.h
+++ b/src/LinuxTracing/TracerThread.h
@@ -152,7 +152,9 @@ class TracerThread {
 
   absl::flat_hash_map<uint64_t, const Function*> uprobes_uretprobes_ids_to_function_;
   absl::flat_hash_set<uint64_t> uprobes_ids_;
+  absl::flat_hash_set<uint64_t> uprobes_with_args_ids_;
   absl::flat_hash_set<uint64_t> uretprobes_ids_;
+  absl::flat_hash_set<uint64_t> uretprobes_with_retval_ids_;
   absl::flat_hash_set<uint64_t> stack_sampling_ids_;
   absl::flat_hash_set<uint64_t> callchain_sampling_ids_;
   absl::flat_hash_set<uint64_t> task_newtask_ids_;
@@ -212,7 +214,6 @@ class TracerThread {
   static constexpr uint64_t EVENT_STATS_WINDOW_S = 5;
   EventStats stats_{};
 
-  static constexpr uint64_t NS_PER_MILLISECOND = 1'000'000;
   static constexpr uint64_t NS_PER_SECOND = 1'000'000'000;
 };
 

--- a/src/LinuxTracing/UprobesReturnAddressManager.h
+++ b/src/LinuxTracing/UprobesReturnAddressManager.h
@@ -16,6 +16,7 @@
 #include "OrbitBase/Logging.h"
 
 namespace orbit_linux_tracing {
+
 // Keeps a stack, for every thread, of the return addresses at the top of the
 // stack when uprobes are hit, before they are hijacked by uretprobes. Patches
 // them into samples so that unwinding can continue past

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -242,7 +242,10 @@ void UprobesUnwindingVisitor::Visit(CallchainSamplePerfEvent* event) {
   listener_->OnCallstackSample(std::move(sample));
 }
 
-void UprobesUnwindingVisitor::Visit(UprobesPerfEvent* event) {
+void UprobesUnwindingVisitor::OnUprobes(
+    uint64_t timestamp_ns, pid_t tid, uint32_t cpu, uint64_t sp, uint64_t ip,
+    uint64_t return_address, std::optional<perf_event_sample_regs_user_sp_ip_arguments> registers,
+    uint64_t function_id) {
   CHECK(listener_ != nullptr);
 
   // We are seeing that, on thread migration, uprobe events can sometimes be
@@ -255,52 +258,66 @@ void UprobesUnwindingVisitor::Visit(UprobesPerfEvent* event) {
   // pointers (the stack grows towards lower addresses).
 
   // Duplicate uprobe detection.
-  uint64_t uprobe_sp = event->GetSp();
-  uint64_t uprobe_ip = event->GetIp();
-  uint32_t uprobe_cpu = event->GetCpu();
   std::vector<std::tuple<uint64_t, uint64_t, uint32_t>>& uprobe_sps_ips_cpus =
-      uprobe_sps_ips_cpus_per_thread_[event->GetTid()];
+      uprobe_sps_ips_cpus_per_thread_[tid];
   if (!uprobe_sps_ips_cpus.empty()) {
     uint64_t last_uprobe_sp = std::get<0>(uprobe_sps_ips_cpus.back());
     uint64_t last_uprobe_ip = std::get<1>(uprobe_sps_ips_cpus.back());
     uint32_t last_uprobe_cpu = std::get<2>(uprobe_sps_ips_cpus.back());
     uprobe_sps_ips_cpus.pop_back();
-    if (uprobe_sp > last_uprobe_sp) {
+    if (sp > last_uprobe_sp) {
       ERROR("MISSING URETPROBE OR DUPLICATE UPROBE");
       return;
     }
-    if (uprobe_sp == last_uprobe_sp && uprobe_ip == last_uprobe_ip &&
-        uprobe_cpu != last_uprobe_cpu) {
+    if (sp == last_uprobe_sp && ip == last_uprobe_ip && cpu != last_uprobe_cpu) {
       ERROR("Duplicate uprobe on thread migration");
       return;
     }
   }
-  uprobe_sps_ips_cpus.emplace_back(uprobe_sp, uprobe_ip, uprobe_cpu);
+  uprobe_sps_ips_cpus.emplace_back(sp, ip, cpu);
 
-  function_call_manager_->ProcessUprobes(event->GetTid(), event->GetFunction()->function_id(),
-                                         event->GetTimestamp(), event->ring_buffer_record.regs);
+  function_call_manager_->ProcessUprobes(tid, function_id, timestamp_ns, registers);
 
-  return_address_manager_->ProcessUprobes(event->GetTid(), event->GetSp(),
-                                          event->GetReturnAddress());
+  return_address_manager_->ProcessUprobes(tid, sp, return_address);
 }
 
-void UprobesUnwindingVisitor::Visit(UretprobesPerfEvent* event) {
+void UprobesUnwindingVisitor::Visit(UprobesPerfEvent* event) {
+  OnUprobes(event->GetTimestamp(), event->GetTid(), event->GetCpu(), event->GetSp(), event->GetIp(),
+            event->GetReturnAddress(), /*registers=*/std::nullopt,
+            event->GetFunction()->function_id());
+}
+
+void UprobesUnwindingVisitor::Visit(UprobesWithArgumentsPerfEvent* event) {
+  OnUprobes(event->GetTimestamp(), event->GetTid(), event->GetCpu(), event->GetSp(), event->GetIp(),
+            event->GetReturnAddress(), event->GetRegisters(), event->GetFunction()->function_id());
+}
+
+void UprobesUnwindingVisitor::OnUretprobes(uint64_t timestamp_ns, pid_t pid, pid_t tid,
+                                           std::optional<uint64_t> ax) {
   CHECK(listener_ != nullptr);
 
   // Duplicate uprobe detection.
   std::vector<std::tuple<uint64_t, uint64_t, uint32_t>>& uprobe_sps_ips_cpus =
-      uprobe_sps_ips_cpus_per_thread_[event->GetTid()];
+      uprobe_sps_ips_cpus_per_thread_[tid];
   if (!uprobe_sps_ips_cpus.empty()) {
     uprobe_sps_ips_cpus.pop_back();
   }
 
-  std::optional<FunctionCall> function_call = function_call_manager_->ProcessUretprobes(
-      event->GetPid(), event->GetTid(), event->GetTimestamp(), event->GetAx());
+  std::optional<FunctionCall> function_call =
+      function_call_manager_->ProcessUretprobes(pid, tid, timestamp_ns, ax);
   if (function_call.has_value()) {
     listener_->OnFunctionCall(std::move(function_call.value()));
   }
 
-  return_address_manager_->ProcessUretprobes(event->GetTid());
+  return_address_manager_->ProcessUretprobes(tid);
+}
+
+void UprobesUnwindingVisitor::Visit(UretprobesPerfEvent* event) {
+  OnUretprobes(event->GetTimestamp(), event->GetPid(), event->GetTid(), /*ax=*/std::nullopt);
+}
+
+void UprobesUnwindingVisitor::Visit(UretprobesWithReturnValuePerfEvent* event) {
+  OnUretprobes(event->GetTimestamp(), event->GetPid(), event->GetTid(), event->GetAx());
 }
 
 void UprobesUnwindingVisitor::Visit(MmapPerfEvent* event) {

--- a/src/LinuxTracing/UprobesUnwindingVisitor.h
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.h
@@ -82,10 +82,18 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   void Visit(StackSamplePerfEvent* event) override;
   void Visit(CallchainSamplePerfEvent* event) override;
   void Visit(UprobesPerfEvent* event) override;
+  void Visit(UprobesWithArgumentsPerfEvent* event) override;
   void Visit(UretprobesPerfEvent* event) override;
+  void Visit(UretprobesWithReturnValuePerfEvent* event) override;
   void Visit(MmapPerfEvent* event) override;
 
  private:
+  void OnUprobes(uint64_t timestamp_ns, pid_t tid, uint32_t cpu, uint64_t sp, uint64_t ip,
+                 uint64_t return_address,
+                 std::optional<perf_event_sample_regs_user_sp_ip_arguments> registers,
+                 uint64_t function_id);
+  void OnUretprobes(uint64_t timestamp_ns, pid_t pid, pid_t tid, std::optional<uint64_t> ax);
+
   TracerListener* listener_;
 
   UprobesFunctionCallManager* function_call_manager_;

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
@@ -626,6 +626,7 @@ void AddOuterAndInnerFunctionToCaptureOptions(orbit_grpc_protos::CaptureOptions*
       instrumented_function.set_file_offset(symbol.address() - module_symbols.load_bias());
       instrumented_function.set_function_id(outer_function_id);
       instrumented_function.set_function_name(symbol.name());
+      instrumented_function.set_record_return_value(true);
       capture_options->mutable_instrumented_functions()->Add(std::move(instrumented_function));
     }
 
@@ -637,6 +638,7 @@ void AddOuterAndInnerFunctionToCaptureOptions(orbit_grpc_protos::CaptureOptions*
       instrumented_function.set_file_offset(symbol.address() - module_symbols.load_bias());
       instrumented_function.set_function_id(inner_function_id);
       instrumented_function.set_function_name(symbol.name());
+      instrumented_function.set_record_arguments(true);
       capture_options->mutable_instrumented_functions()->Add(std::move(instrumented_function));
     }
   }
@@ -679,6 +681,8 @@ void VerifyFunctionCallsOfOuterAndInnerFunction(
                   function_calls[function_call_index - 1].end_timestamp_ns());
       }
       EXPECT_EQ(function_call.depth(), 1);
+      EXPECT_EQ(function_call.return_value(), 0);
+      EXPECT_THAT(function_call.registers(), testing::ElementsAre(1, 2, 3, 4, 5, 6));
       ++function_call_index;
     }
 
@@ -691,6 +695,8 @@ void VerifyFunctionCallsOfOuterAndInnerFunction(
                   function_calls[function_call_index - 1].end_timestamp_ns());
       }
       EXPECT_EQ(function_call.depth(), 0);
+      EXPECT_EQ(function_call.return_value(), PuppetConstants::kOuterFunctionReturnValue);
+      EXPECT_EQ(function_call.registers_size(), 0);
       ++function_call_index;
     }
   }

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTestPuppet.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTestPuppet.cpp
@@ -31,7 +31,10 @@ static void SleepRepeatedly() {
   }
 }
 
-extern "C" __attribute__((noinline)) double InnerFunctionToInstrument() {
+extern "C" __attribute__((noinline)) double InnerFunctionToInstrument(uint64_t di, uint64_t si,
+                                                                      uint64_t dx, uint64_t cx,
+                                                                      uint64_t r8, uint64_t r9) {
+  LOG("InnerFunctionToInstrument called with args: %u, %u, %u, %u, %u, %u", di, si, dx, cx, r8, r9);
   double result = 1;
   for (size_t i = 0; i < 1'000'000; ++i) {
     result = 1 / (2 + result);
@@ -39,15 +42,22 @@ extern "C" __attribute__((noinline)) double InnerFunctionToInstrument() {
   return 1 + result;
 }
 
-extern "C" __attribute__((noinline)) void OuterFunctionToInstrument() {
+extern "C" __attribute__((noinline)) uint64_t OuterFunctionToInstrument() {
   for (uint64_t i = 0; i < PuppetConstants::kInnerFunctionCallCount; ++i) {
-    LOG("InnerFunctionToInstrument returned: %f", InnerFunctionToInstrument());
+    LOG("InnerFunctionToInstrument returned: %f",
+        InnerFunctionToInstrument(
+            PuppetConstants::kInnerFunctionCallArgs[0], PuppetConstants::kInnerFunctionCallArgs[1],
+            PuppetConstants::kInnerFunctionCallArgs[2], PuppetConstants::kInnerFunctionCallArgs[3],
+            PuppetConstants::kInnerFunctionCallArgs[4],
+            PuppetConstants::kInnerFunctionCallArgs[5]));
   }
+  return PuppetConstants::kOuterFunctionReturnValue;
 }
 
 static void CallOuterFunctionToInstrument() {
   for (uint64_t i = 0; i < PuppetConstants::kOuterFunctionCallCount; ++i) {
-    OuterFunctionToInstrument();
+    uint64_t result = OuterFunctionToInstrument();
+    LOG("OuterFunctionToInstrument returned: %#x", result);
   }
 }
 

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTestPuppet.h
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTestPuppet.h
@@ -7,6 +7,8 @@
 
 #include <stdint.h>
 
+#include <array>
+
 namespace orbit_linux_tracing_integration_tests {
 
 struct LinuxTracingIntegrationTestPuppetConstants {
@@ -15,8 +17,10 @@ struct LinuxTracingIntegrationTestPuppetConstants {
   constexpr static uint64_t kSleepCount = 1000;
 
   constexpr static uint64_t kOuterFunctionCallCount = 2;
+  constexpr static uint64_t kOuterFunctionReturnValue = 0x0123456789ABCDEF;
   constexpr static const char* kOuterFunctionName = "OuterFunctionToInstrument";
   constexpr static uint64_t kInnerFunctionCallCount = 3;
+  constexpr static std::array<uint64_t, 6> kInnerFunctionCallArgs = {1, 2, 3, 4, 5, 6};
   constexpr static const char* kInnerFunctionName = "InnerFunctionToInstrument";
 
   constexpr static const char* kNewThreadName = "Thread Name";

--- a/src/OrbitClientGgp/ClientGgp.cpp
+++ b/src/OrbitClientGgp/ClientGgp.cpp
@@ -128,10 +128,12 @@ ErrorMessageOr<void> ClientGgp::RequestStartCapture(ThreadPool* thread_pool) {
 
   Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> result = capture_client_->Capture(
       thread_pool, target_process_->pid(), module_manager_, selected_functions_,
-      selected_tracepoints, options_.samples_per_second, options_.stack_dump_size, unwinding_method,
+      /*always_record_arguments=*/false, /*record_return_values=*/false, selected_tracepoints,
+      options_.samples_per_second, options_.stack_dump_size, unwinding_method,
       collect_scheduling_info, collect_thread_state, collect_gpu_jobs, enable_api,
       enable_introspection, enable_user_space_instrumentation,
-      max_local_marker_depth_per_command_buffer, false, 0, std::move(event_processor));
+      max_local_marker_depth_per_command_buffer, /*collect_memory_info=*/false, 0,
+      std::move(event_processor));
 
   orbit_base::ImmediateExecutor executor;
 

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -92,6 +92,7 @@
 ABSL_DECLARE_FLAG(bool, devmode);
 ABSL_DECLARE_FLAG(bool, local);
 ABSL_DECLARE_FLAG(bool, enable_tracepoint_feature);
+ABSL_DECLARE_FLAG(bool, show_return_values);
 
 using orbit_base::Future;
 
@@ -1365,6 +1366,7 @@ void OrbitApp::StartCapture() {
 
   Future<ErrorMessageOr<CaptureOutcome>> capture_result = capture_client_->Capture(
       thread_pool_.get(), process->pid(), *module_manager_, std::move(selected_functions_map),
+      /*always_record_arguments=*/false, absl::GetFlag(FLAGS_show_return_values),
       std::move(selected_tracepoints), samples_per_second, stack_dump_size, unwinding_method,
       collect_scheduling_info, collect_thread_states, collect_gpu_jobs, enable_api,
       enable_introspection, enable_user_space_instrumentation,


### PR DESCRIPTION
#### Add record_{arguments,return_value} to InstrumentedFunction proto
This is not doing anything yet, service-side change to follow.

Bug: http://b/193759921

Test: Builds.
#### Collect args on uprobes and return values on uretprobes only when needed
We need to distinguish between to types of `UprobesPerfEvent`s and two types of
`UretprobesPerfEvent`s.

Capture Trata for a minute instrumenting
`eva::graphics::rendering::spatial_geometry::world_sphere() const` (the one used
by the YHITI performance testing): total data transferred goes down from 711 MB
(52.8 B per event) to 327 MB (23.7 B per event). Also CPU utilization of
`OrbitService` in this case goes down from around 75% to around 65%.

Bug: http://b/193759921

Test:
- Update/expand unit tests.
- Update `LinuxTracingIntegrationTests`.
- Capture `OrbitTestLegacyApi` to verify old uprobes-based manual
  instrumentation still works.
- Capture Trata, e.g., as described above.
- Capture Trata with `--show_return_values`.