### PR TITLE
Represent chunks of memory in the tracee by a class.

### DIFF
--- a/src/UserSpaceInstrumentation/AllocateInTracee.cpp
+++ b/src/UserSpaceInstrumentation/AllocateInTracee.cpp
@@ -130,56 +130,133 @@ namespace {
 
 }  // namespace
 
-[[nodiscard]] ErrorMessageOr<uint64_t> AllocateInTracee(pid_t pid, uint64_t address,
-                                                        uint64_t size) {
+ErrorMessageOr<std::unique_ptr<MemoryInTracee>> MemoryInTracee::Create(pid_t pid, uint64_t address,
+                                                                       uint64_t size) {
   // Syscall will be equivalent to:
-  // `mmap(address, size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0)`
+  // `mmap(address, size, PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0)`
+  // We just set `PROT_WRITE` but this permits also read access (on x86) although the read flag will
+  // not show up in /proc/pid/maps. Setting `PROT_READ` explicitly would be clearer but under some
+  // circumstances (personality setting READ_IMPLIES_EXEC) `PROT_READ` sets the flag permitting
+  // execution and we want to avoid that.
   constexpr uint64_t kSyscallNumberMmap = 9;
-  auto result_or_error = SyscallInTracee(
-      pid, kSyscallNumberMmap, address, size, PROT_READ | PROT_WRITE | PROT_EXEC,
-      MAP_PRIVATE | MAP_ANONYMOUS, static_cast<uint64_t>(-1), 0, /*exclude_address=*/0);
+  auto result_or_error = SyscallInTracee(pid, kSyscallNumberMmap, address, size, PROT_WRITE,
+                                         MAP_PRIVATE | MAP_ANONYMOUS, static_cast<uint64_t>(-1), 0,
+                                         /*exclude_address=*/0);
   if (result_or_error.has_error()) {
     return ErrorMessage(absl::StrFormat(
         "Failed to execute mmap syscall with parameters address=%#x size=%u: \"%s\"", address, size,
         result_or_error.error().message()));
   }
-  const uint64_t result = result_or_error.value();
-  if (address != 0 && result != address) {
-    auto free_memory_result = FreeInTracee(pid, result, size);
+
+  std::unique_ptr<MemoryInTracee> result(
+      new MemoryInTracee(pid, result_or_error.value(), size, MemoryInTracee::State::kWritable));
+
+  if (address != 0 && result->GetAddress() != address) {
+    auto free_memory_result = result->Free();
     FAIL_IF(free_memory_result.has_error(), "Unable to free proviously allocated memory: \"%s\"",
             free_memory_result.error().message());
     return ErrorMessage(
-        absl::StrFormat("AllocateInTracee wanted to allocate memory at %#x but got memory at a "
+        absl::StrFormat("MemoryInTracee wanted to allocate memory at %#x but got memory at a "
                         "different adress: %#x. The memory has been freed again.",
-                        address, result));
+                        address, result->GetAddress()));
   }
+
   return result;
 }
 
-[[nodiscard]] ErrorMessageOr<void> FreeInTracee(pid_t pid, uint64_t address, uint64_t size) {
+ErrorMessageOr<void> MemoryInTracee::Free() {
   // Syscall will be equivalent to:
   // `munmap(address, size)`
   constexpr uint64_t kSyscallNumberMunmap = 11;
   auto result_or_error =
-      SyscallInTracee(pid, kSyscallNumberMunmap, address, size, 0, 0, 0, 0, address);
+      SyscallInTracee(pid_, kSyscallNumberMunmap, address_, size_, 0, 0, 0, 0, address_);
   if (result_or_error.has_error()) {
     return ErrorMessage(absl::StrFormat("Failed to execute munmap syscall: \"%s\"",
                                         result_or_error.error().message()));
   }
+  pid_ = -1;
+  address_ = 0;
+  size_ = 0;
+  state_ = State::kWritable;
   return outcome::success();
 }
 
-ErrorMessageOr<orbit_base::unique_resource<uint64_t, std::function<void(uint64_t)>>>
-AllocateInTraceeAsUniqueResource(pid_t pid, uint64_t address, uint64_t size) {
-  OUTCOME_TRY(auto&& allocated_address, AllocateInTracee(pid, address, size));
-  std::function<void(uint64_t)> deleter = [pid, size](uint64_t address) {
-    auto result = FreeInTracee(pid, address, size);
-    if (result.has_error()) {
-      ERROR("Unable to free previously allocated memory in tracee: \"%s\"",
-            result.error().message());
-    }
-  };
-  return orbit_base::unique_resource(allocated_address, deleter);
+ErrorMessageOr<void> MemoryInTracee::EnsureMemoryExecutable() {
+  if (state_ == State::kExecutable) {
+    return outcome::success();
+  }
+
+  constexpr uint64_t kSyscallNumberMprotect = 10;
+  auto result_or_error =
+      SyscallInTracee(pid_, kSyscallNumberMprotect, address_, size_, PROT_EXEC, 0, 0, 0, 0);
+  if (result_or_error.has_error()) {
+    return ErrorMessage(absl::StrFormat(
+        "Failed to execute mprotect syscall with parameters address=%#x size=%u: \"%s\"", address_,
+        size_, result_or_error.error().message()));
+  }
+
+  state_ = State::kExecutable;
+  return outcome::success();
+}
+
+ErrorMessageOr<void> MemoryInTracee::EnsureMemoryWritable() {
+  if (state_ == State::kWritable) {
+    return outcome::success();
+  }
+
+  constexpr uint64_t kSyscallNumberMprotect = 10;
+  auto result_or_error =
+      SyscallInTracee(pid_, kSyscallNumberMprotect, address_, size_, PROT_WRITE, 0, 0, 0, 0);
+  if (result_or_error.has_error()) {
+    return ErrorMessage(absl::StrFormat(
+        "Failed to execute mprotect syscall with parameters address=%#x size=%u: \"%s\"", address_,
+        size_, result_or_error.error().message()));
+  }
+
+  state_ = State::kWritable;
+  return outcome::success();
+}
+
+ErrorMessageOr<std::unique_ptr<AutomaticMemoryInTracee>> AutomaticMemoryInTracee::Create(
+    pid_t pid, uint64_t address, uint64_t size) {
+  // Syscall will be equivalent to:
+  // `mmap(address, size, PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0)`
+  // We just set `PROT_WRITE` but this permits also read access (on x86) although the read flag will
+  // not show up in /proc/pid/maps. Setting `PROT_READ` explicitly would be clearer but under some
+  // circumstances (personality setting READ_IMPLIES_EXEC) `PROT_READ` sets the flag permitting
+  // execution and we want to avoid that.
+  constexpr uint64_t kSyscallNumberMmap = 9;
+  auto result_or_error = SyscallInTracee(pid, kSyscallNumberMmap, address, size, PROT_WRITE,
+                                         MAP_PRIVATE | MAP_ANONYMOUS, static_cast<uint64_t>(-1), 0,
+                                         /*exclude_address=*/0);
+  if (result_or_error.has_error()) {
+    return ErrorMessage(absl::StrFormat(
+        "Failed to execute mmap syscall with parameters address=%#x size=%u: \"%s\"", address, size,
+        result_or_error.error().message()));
+  }
+
+  std::unique_ptr<AutomaticMemoryInTracee> result(new AutomaticMemoryInTracee(
+      pid, result_or_error.value(), size, AutomaticMemoryInTracee::State::kWritable));
+
+  if (address != 0 && result->GetAddress() != address) {
+    auto free_memory_result = result->Free();
+    FAIL_IF(free_memory_result.has_error(), "Unable to free proviously allocated memory: \"%s\"",
+            free_memory_result.error().message());
+    return ErrorMessage(absl::StrFormat(
+        "AutomaticMemoryInTracee wanted to allocate memory at %#x but got memory at a "
+        "different adress: %#x. The memory has been freed again.",
+        address, result->GetAddress()));
+  }
+
+  return result;
+}
+
+AutomaticMemoryInTracee::~AutomaticMemoryInTracee() {
+  if (pid_ == -1) return;  // Freed manually already.
+  auto result = Free();
+  if (result.has_error()) {
+    ERROR("Unable to free memory in tracee: %s", result.error().message());
+  }
 }
 
 }  // namespace orbit_user_space_instrumentation

--- a/src/UserSpaceInstrumentation/AllocateInTracee.h
+++ b/src/UserSpaceInstrumentation/AllocateInTracee.h
@@ -9,30 +9,94 @@
 
 #include <cstdint>
 #include <functional>
+#include <memory>
 
+#include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
 #include "OrbitBase/UniqueResource.h"
 
 namespace orbit_user_space_instrumentation {
 
-// Allocate `size` bytes of memory in the tracee's address space using mmap. The memory will have
-// read, write, and execute permissions. The memory allocated will start at `address`. `address`
-// needs to be aligned to page boundaries. If the memory mapping can not be placed at `address` an
-// error is returned.
-// If `address` is zero the placement of memory will be arbitray (compare the documenation of mmap:
-// https://man7.org/linux/man-pages/man2/mmap.2.html). Assumes we are already attached to the tracee
-// `pid` e.g. using `AttachAndStopProcess`.
-[[nodiscard]] ErrorMessageOr<uint64_t> AllocateInTracee(pid_t pid, uint64_t address, uint64_t size);
+// Represents a chunk of memory in the tracee.
+// The only way to instantiate the class is via the factory function `Create`. We move around
+// MemoryInTracee exclusively in unique_ptr. This way we can store instances inside stl containers.
+// The memory gets allocated in writable state. In case one wants to execute code in the segment, it
+// needs to be made executable with `EnsureMemoryExecutable` later. `Free` deallocates the memory.
+// This needs to be done manually - if MemoryInTracee goes out of scope without being freed the
+// memory inthe tracee will leak.
+// Note that for each of the non-const member functions we need to execute code in the tracee. So we
+// need to be attached; the tracee needs to be stopped.
+class MemoryInTracee {
+ public:
+  // We move around MemoryInTracee exclusively in unique_ptr so we don't need it to be copyable or
+  // movable. The only way to create a MemoryInTracee is to use the factory function below which
+  // uses the private constructor.
+  MemoryInTracee() = delete;
+  MemoryInTracee(const MemoryInTracee&) = delete;
+  MemoryInTracee(MemoryInTracee&&) = delete;
+  MemoryInTracee& operator=(const MemoryInTracee&) = delete;
+  MemoryInTracee& operator=(MemoryInTracee&&) = delete;
 
-// Free address range previously allocated with AllocateInTracee using munmap.
-// Assumes we are already attached to the tracee `pid` e.g. using `AttachAndStopProcess`.
-[[nodiscard]] ErrorMessageOr<void> FreeInTracee(pid_t pid, uint64_t address, uint64_t size);
+  virtual ~MemoryInTracee() = default;
 
-// Same as `AllocateInTracee` above but wraps the memory in a unique_resource that handles
-// deallocating the memory. Note that we still need to be attached (or attached again) to the tracee
-// when the unique_resource goes out of scope.
-[[nodiscard]] ErrorMessageOr<orbit_base::unique_resource<uint64_t, std::function<void(uint64_t)>>>
-AllocateInTraceeAsUniqueResource(pid_t pid, uint64_t address, uint64_t size);
+  // Allocate `size` bytes of memory in the tracee's address space using mmap. The memory will have
+  // write permissions. The memory allocated will start at `address`. `address` needs to be aligned
+  // to page boundaries. If the memory mapping can not be placed at `address` an error is returned.
+  // If `address` is zero the placement of memory will be arbitrary (compare the documentation of
+  // mmap: https://man7.org/linux/man-pages/man2/mmap.2.html). Assumes we are already attached to
+  // the tracee `pid` using `AttachAndStopProcess`.
+  [[nodiscard]] static ErrorMessageOr<std::unique_ptr<MemoryInTracee>> Create(pid_t pid,
+                                                                              uint64_t address,
+                                                                              uint64_t size);
+
+  // Free address range previously allocated with AllocateInTracee using munmap.
+  // Assumes we are already attached to the tracee using `AttachAndStopProcess`.
+  [[nodiscard]] ErrorMessageOr<void> Free();
+
+  [[nodiscard]] pid_t GetPid() const { return pid_; }
+  [[nodiscard]] uint64_t GetAddress() const { return address_; }
+  [[nodiscard]] uint64_t GetSize() const { return size_; }
+  // Returns the protection state of the memory. The memory gets allocated as writeable and can be
+  // made executable (and writable again) with the methods below.
+  enum class State { kWritable, kExecutable };
+  [[nodiscard]] State GetState() const { return state_; }
+
+  // Sets the read and execute permission for the memory. Removes the write permission. Assumes we
+  // are already attached to the tracee using `AttachAndStopProcess`.
+  [[nodiscard]] ErrorMessageOr<void> EnsureMemoryExecutable();
+  // Set the write permission for the memory. Removes the read and execute permissions. Assumes we
+  // are already attached to the tracee using `AttachAndStopProcess`.
+  [[nodiscard]] ErrorMessageOr<void> EnsureMemoryWritable();
+
+ protected:
+  MemoryInTracee(pid_t pid, uint64_t address, uint64_t size, State state)
+      : pid_(pid), address_(address), size_(size), state_(state) {}
+
+  pid_t pid_ = -1;
+  uint64_t address_ = 0;
+  uint64_t size_ = 0;
+  State state_ = State::kWritable;
+};
+
+// Same as `MemoryInTracee` above but deallocates memory in the destructor. Note that we still need
+// to be attached (or attached again) to the tracee when `AutomaticMemoryInTracee` goes out of
+// scope.
+class AutomaticMemoryInTracee : public MemoryInTracee {
+ public:
+  AutomaticMemoryInTracee() = delete;
+  AutomaticMemoryInTracee(const AutomaticMemoryInTracee&) = delete;
+  AutomaticMemoryInTracee(AutomaticMemoryInTracee&&) = delete;
+  AutomaticMemoryInTracee& operator=(const AutomaticMemoryInTracee&) = delete;
+  AutomaticMemoryInTracee& operator=(AutomaticMemoryInTracee&&) = delete;
+
+  [[nodiscard]] static ErrorMessageOr<std::unique_ptr<AutomaticMemoryInTracee>> Create(
+      pid_t pid, uint64_t address, uint64_t size);
+
+  ~AutomaticMemoryInTracee() override;
+
+ protected:
+  using MemoryInTracee::MemoryInTracee;
+};
 
 }  // namespace orbit_user_space_instrumentation
 

--- a/src/UserSpaceInstrumentation/AllocateInTraceeTest.cpp
+++ b/src/UserSpaceInstrumentation/AllocateInTraceeTest.cpp
@@ -27,18 +27,27 @@ namespace orbit_user_space_instrumentation {
 namespace {
 
 using orbit_base::HasError;
+using orbit_base::HasNoError;
 using orbit_base::ReadFileToString;
 
-// Returns true if `pid` has a readable, writeable, and executable memory segment at `address`.
-[[nodiscard]] bool ProcessHasRwxMapAtAddress(pid_t pid, uint64_t address) {
+enum class ProtState { kWrite, kExec, kAny };
+
+// Returns true if the target process has a writeable (or executable; depending on `state`) memory
+// segment at `address`.
+[[nodiscard]] bool ProcessHasMapAtAddress(pid_t pid, uint64_t address, ProtState state) {
   auto maps_or_error = ReadFileToString(absl::StrFormat("/proc/%d/maps", pid));
   CHECK(maps_or_error.has_value());
   std::vector<std::string> lines = absl::StrSplit(maps_or_error.value(), '\n', absl::SkipEmpty());
   for (const auto& line : lines) {
     std::vector<std::string> tokens = absl::StrSplit(line, ' ', absl::SkipEmpty());
-    if (tokens.size() < 2 || tokens[1].size() != 4 || tokens[1][0] != 'r' || tokens[1][1] != 'w' ||
-        tokens[1][2] != 'x') {
-      continue;
+    if (state == ProtState::kWrite) {
+      if (tokens.size() < 2 || tokens[1].size() < 2 || tokens[1][1] != 'w') {
+        continue;
+      }
+    } else if (state == ProtState::kExec) {
+      if (tokens.size() < 2 || tokens[1].size() < 3 || tokens[1][2] != 'x') {
+        continue;
+      }
     }
     std::vector<std::string> addresses = absl::StrSplit(tokens[0], '-');
     if (addresses.size() != 2) {
@@ -49,6 +58,12 @@ using orbit_base::ReadFileToString;
     }
   }
   return false;
+}
+
+// Returns true if the target process has a writeable (or executable; depending on `state`) memory
+// segment at the address of `memory`.
+[[nodiscard]] bool ProcessHasMapAtAddress(const MemoryInTracee& memory, ProtState state) {
+  return ProcessHasMapAtAddress(memory.GetPid(), memory.GetAddress(), state);
 }
 
 }  // namespace
@@ -67,48 +82,76 @@ TEST(AllocateInTraceeTest, AllocateAndFree) {
 
   // Allocation fails for invalid process.
   constexpr uint64_t kMemorySize = 1024 * 1024;
-  auto address_or_error = AllocateInTracee(-1, 0, kMemorySize);
-  EXPECT_THAT(address_or_error, HasError("No such process"));
+  auto my_memory_or_error = MemoryInTracee::Create(-1, 0, kMemorySize);
+  EXPECT_THAT(my_memory_or_error, HasError("No such process"));
 
   // Allocation fails for non page aligned address.
-  address_or_error = AllocateInTracee(pid, 1, kMemorySize);
-  EXPECT_THAT(address_or_error, HasError("but got memory at a different adress"));
+  my_memory_or_error = MemoryInTracee::Create(pid, 1, kMemorySize);
+  EXPECT_THAT(my_memory_or_error, HasError("but got memory at a different adress"));
 
   // Allocation fails for ridiculous size.
-  address_or_error = AllocateInTracee(pid, 0, 1ull << 63);
-  EXPECT_THAT(address_or_error, HasError("Syscall failed. Return value: Cannot allocate memory"));
+  my_memory_or_error = MemoryInTracee::Create(pid, 1, 1ull << 63);
+  EXPECT_THAT(my_memory_or_error, HasError("Syscall failed. Return value: Cannot allocate memory"));
 
   // Allocate a megabyte in the tracee.
-  address_or_error = AllocateInTracee(pid, 0, kMemorySize);
-  ASSERT_TRUE(address_or_error.has_value());
-  EXPECT_TRUE(ProcessHasRwxMapAtAddress(pid, address_or_error.value()));
+  my_memory_or_error = MemoryInTracee::Create(pid, 0, kMemorySize);
+  ASSERT_THAT(my_memory_or_error, HasNoError());
+  EXPECT_TRUE(ProcessHasMapAtAddress(*my_memory_or_error.value(), ProtState::kWrite));
 
   // Free the memory.
-  ASSERT_FALSE(FreeInTracee(pid, address_or_error.value(), kMemorySize).has_error());
-  EXPECT_FALSE(ProcessHasRwxMapAtAddress(pid, address_or_error.value()));
+  ASSERT_THAT(my_memory_or_error.value()->Free(), HasNoError());
 
   // Allocate a megabyte at a low memory position.
   auto mmap_min_addr_or_error = ReadFileToString("/proc/sys/vm/mmap_min_addr");
   CHECK(mmap_min_addr_or_error.has_value());
   uint64_t mmap_min_addr = 0;
   CHECK(absl::SimpleAtoi(mmap_min_addr_or_error.value(), &mmap_min_addr));
-  address_or_error = AllocateInTracee(pid, mmap_min_addr, kMemorySize);
-  ASSERT_TRUE(address_or_error.has_value());
-  EXPECT_TRUE(ProcessHasRwxMapAtAddress(pid, address_or_error.value()));
+  my_memory_or_error = MemoryInTracee::Create(pid, mmap_min_addr, kMemorySize);
+  ASSERT_THAT(my_memory_or_error, HasNoError());
+  auto my_memory = std::move(my_memory_or_error.value());
+  EXPECT_TRUE(ProcessHasMapAtAddress(*my_memory, ProtState::kWrite));
+
+  // Make memory executable.
+  ASSERT_THAT(my_memory->EnsureMemoryExecutable(), HasNoError());
+  EXPECT_TRUE(ProcessHasMapAtAddress(*my_memory, ProtState::kExec));
+
+  // Make memory writable again.
+  ASSERT_THAT(my_memory->EnsureMemoryWritable(), HasNoError());
+  EXPECT_TRUE(ProcessHasMapAtAddress(*my_memory, ProtState::kWrite));
 
   // Free the memory.
-  ASSERT_FALSE(FreeInTracee(pid, address_or_error.value(), kMemorySize).has_error());
-  EXPECT_FALSE(ProcessHasRwxMapAtAddress(pid, address_or_error.value()));
+  uint64_t address = my_memory->GetAddress();
+  ASSERT_THAT(my_memory->Free(), HasNoError());
+  EXPECT_FALSE(ProcessHasMapAtAddress(pid, address, ProtState::kAny));
 
-  // Allocate as unique resource.
+  // Detach and end child.
+  CHECK(!DetachAndContinueProcess(pid).has_error());
+  kill(pid, SIGKILL);
+  waitpid(pid, nullptr, 0);
+}
+
+TEST(AllocateInTraceeTest, AutomaticAllocateAndFree) {
+  pid_t pid = fork();
+  CHECK(pid != -1);
+  if (pid == 0) {
+    // Child just runs an endless loop.
+    while (true) {
+    }
+  }
+
+  // Stop the process using our tooling.
+  CHECK(!AttachAndStopProcess(pid).has_error());
+
+  constexpr uint64_t kMemorySize = 1024 * 1024;
   uint64_t address = 0;
   {
-    auto unique_resource_or_error = AllocateInTraceeAsUniqueResource(pid, 0, kMemorySize);
-    ASSERT_TRUE(unique_resource_or_error.has_value());
-    address = unique_resource_or_error.value().get();
-    EXPECT_TRUE(ProcessHasRwxMapAtAddress(pid, address));
+    auto automatic_memory_or_error = AutomaticMemoryInTracee::Create(pid, 0, kMemorySize);
+    ASSERT_THAT(automatic_memory_or_error, HasNoError());
+    auto automatic_memory = std::move(automatic_memory_or_error.value());
+    EXPECT_TRUE(ProcessHasMapAtAddress(*automatic_memory, ProtState::kWrite));
+    address = automatic_memory->GetAddress();
   }
-  EXPECT_FALSE(ProcessHasRwxMapAtAddress(pid, address));
+  EXPECT_FALSE(ProcessHasMapAtAddress(pid, address, ProtState::kAny));
 
   // Detach and end child.
   CHECK(!DetachAndContinueProcess(pid).has_error());

--- a/src/UserSpaceInstrumentation/ExecuteInProcess.cpp
+++ b/src/UserSpaceInstrumentation/ExecuteInProcess.cpp
@@ -53,7 +53,6 @@ ErrorMessageOr<uint64_t> ExecuteInProcess(pid_t pid, void* function_address, uin
       .AppendBytes({0xff, 0xd0})
       .AppendBytes({0xcc});
 
-
   OUTCOME_TRY(auto&& memory, AutomaticMemoryInTracee::Create(pid, 0, kCodeScratchPadSize));
 
   OUTCOME_TRY(auto&& return_value, ExecuteMachineCode(*memory, code));

--- a/src/UserSpaceInstrumentation/ExecuteInProcess.cpp
+++ b/src/UserSpaceInstrumentation/ExecuteInProcess.cpp
@@ -53,9 +53,10 @@ ErrorMessageOr<uint64_t> ExecuteInProcess(pid_t pid, void* function_address, uin
       .AppendBytes({0xff, 0xd0})
       .AppendBytes({0xcc});
 
-  OUTCOME_TRY(auto&& address, AllocateInTraceeAsUniqueResource(pid, 0, kCodeScratchPadSize));
 
-  OUTCOME_TRY(auto&& return_value, ExecuteMachineCode(pid, address.get(), code));
+  OUTCOME_TRY(auto&& memory, AutomaticMemoryInTracee::Create(pid, 0, kCodeScratchPadSize));
+
+  OUTCOME_TRY(auto&& return_value, ExecuteMachineCode(*memory, code));
 
   return return_value;
 }

--- a/src/UserSpaceInstrumentation/ExecuteMachineCode.cpp
+++ b/src/UserSpaceInstrumentation/ExecuteMachineCode.cpp
@@ -36,16 +36,19 @@ uint64_t GetReturnValueOrDie(pid_t pid) {
 
 }  // namespace
 
-ErrorMessageOr<uint64_t> ExecuteMachineCode(pid_t pid, uint64_t code_address,
-                                            const MachineCode& code) {
-  OUTCOME_TRY(WriteTraceesMemory(pid, code_address, code.GetResultAsVector()));
+ErrorMessageOr<uint64_t> ExecuteMachineCode(MemoryInTracee& code_memory, const MachineCode& code) {
+  const pid_t pid = code_memory.GetPid();
+
+  OUTCOME_TRY(WriteTraceesMemory(pid, code_memory.GetAddress(), code.GetResultAsVector()));
+
+  OUTCOME_TRY(code_memory.EnsureMemoryExecutable());
 
   // Backup registers.
   RegisterState original_registers;
   OUTCOME_TRY(original_registers.BackupRegisters(pid));
 
   RegisterState registers_for_execution = original_registers;
-  registers_for_execution.GetGeneralPurposeRegisters()->x86_64.rip = code_address;
+  registers_for_execution.GetGeneralPurposeRegisters()->x86_64.rip = code_memory.GetAddress();
   // The calling convention for x64 assumes the 128 bytes below rsp to be usable as a scratch pad
   // for the current function. This area is called the 'red zone'. The function we interrupted might
   // have stored temporary data in the red zone and the function we are about to execute might do

--- a/src/UserSpaceInstrumentation/ExecuteMachineCode.h
+++ b/src/UserSpaceInstrumentation/ExecuteMachineCode.h
@@ -9,16 +9,17 @@
 
 #include <cstdint>
 
+#include "AllocateInTracee.h"
 #include "MachineCode.h"
 #include "OrbitBase/Result.h"
 
 namespace orbit_user_space_instrumentation {
 
-// Copies `code` to `code_address` in the tracee and executes it. The memory at `code_address` needs
+// Copies `code` to `code_memory` in the tracee and executes it. The memory at `code_memory` needs
 // to be allocated using AllocateInTracee. The code segment has to end with an `int3`. Takes care of
 // backup and restore of register state in the tracee.
 // The return value is the content of rax after the execution finished.
-[[nodiscard]] ErrorMessageOr<uint64_t> ExecuteMachineCode(pid_t pid, uint64_t code_address,
+[[nodiscard]] ErrorMessageOr<uint64_t> ExecuteMachineCode(MemoryInTracee& code_memory,
                                                           const MachineCode& code);
 
 }  // namespace orbit_user_space_instrumentation

--- a/src/UserSpaceInstrumentation/ExecuteMachineCodeTest.cpp
+++ b/src/UserSpaceInstrumentation/ExecuteMachineCodeTest.cpp
@@ -35,9 +35,9 @@ TEST(ExecuteMachineCodeTest, ExecuteMachineCode) {
   {
     // Allocate a small chunk of memory.
     constexpr uint64_t kScratchPadSize = 1024;
-    auto address_or_error = AllocateInTraceeAsUniqueResource(pid, 0, kScratchPadSize);
-    CHECK(address_or_error.has_value());
-    const uint64_t address = address_or_error.value().get();
+    auto memory_or_error = AutomaticMemoryInTracee::Create(pid, 0, kScratchPadSize);
+    CHECK(memory_or_error.has_value());
+    auto memory = std::move(memory_or_error.value());
 
     // This code moves a constant into rax and enters a breakpoint. The value in rax is interpreted
     // as a return value.
@@ -45,12 +45,9 @@ TEST(ExecuteMachineCodeTest, ExecuteMachineCode) {
     // int 3 cc
     MachineCode code;
     code.AppendBytes({0x48, 0xb8}).AppendImmediate64(0x4242424242424242).AppendBytes({0xcc});
-    ErrorMessageOr<uint64_t> result_or_error = ExecuteMachineCode(pid, address, code);
+    ErrorMessageOr<uint64_t> result_or_error = ExecuteMachineCode(*memory, code);
     ASSERT_THAT(result_or_error, HasNoError());
     EXPECT_EQ(0x4242424242424242, result_or_error.value());
-
-    result_or_error = ExecuteMachineCode(-1, address, code);
-    EXPECT_THAT(result_or_error, HasError("Unable to open file"));
   }
 
   // Cleanup, end child process.

--- a/src/UserSpaceInstrumentation/InjectLibraryInTracee.cpp
+++ b/src/UserSpaceInstrumentation/InjectLibraryInTracee.cpp
@@ -80,17 +80,17 @@ ErrorMessageOr<uint64_t> FindFunctionAddressWithFallback(pid_t pid, std::string_
   // Allocate small memory area in the tracee. This is used for the code and the path name.
   const uint64_t path_length = path.string().length() + 1;  // Include terminating zero.
   const uint64_t memory_size = kCodeScratchPadSize + path_length;
-  auto code_address_or_error = AllocateInTraceeAsUniqueResource(pid, 0, memory_size);
-  if (code_address_or_error.has_error()) {
+  auto code_memory_or_error = AutomaticMemoryInTracee::Create(pid, 0, memory_size);
+  if (code_memory_or_error.has_error()) {
     return ErrorMessage(absl::StrFormat("Failed to allocate memory in tracee: %s",
-                                        code_address_or_error.error().message()));
+                                        code_memory_or_error.error().message()));
   }
-  auto code_address = std::move(code_address_or_error.value());
+  auto code_memory = std::move(code_memory_or_error.value());
 
-  // Write the name of the .so into memory at code_address with offset of kCodeScratchPadSize.
+  // Write the name of the .so into memory at code_memory with offset of kCodeScratchPadSize.
   std::vector<uint8_t> path_as_vector(path_length);
   memcpy(path_as_vector.data(), path.c_str(), path_length);
-  const uint64_t so_path_address = code_address.get() + kCodeScratchPadSize;
+  const uint64_t so_path_address = code_memory->GetAddress() + kCodeScratchPadSize;
   auto write_memory_result = WriteTraceesMemory(pid, so_path_address, path_as_vector);
   if (write_memory_result.has_error()) {
     return write_memory_result.error();
@@ -118,7 +118,7 @@ ErrorMessageOr<uint64_t> FindFunctionAddressWithFallback(pid_t pid, std::string_
       .AppendBytes({0xff, 0xd0})
       .AppendBytes({0xcc});
 
-  OUTCOME_TRY(auto&& return_value, ExecuteMachineCode(pid, code_address.get(), code));
+  OUTCOME_TRY(auto&& return_value, ExecuteMachineCode(*code_memory, code));
 
   return absl::bit_cast<void*>(return_value);
 }
@@ -133,17 +133,17 @@ ErrorMessageOr<uint64_t> FindFunctionAddressWithFallback(pid_t pid, std::string_
   // Allocate small memory area in the tracee. This is used for the code and the symbol name.
   const size_t symbol_name_length = symbol.length() + 1;  // include terminating zero
   const uint64_t memory_size = kCodeScratchPadSize + symbol_name_length;
-  auto code_address_or_error = AllocateInTraceeAsUniqueResource(pid, 0, memory_size);
-  if (code_address_or_error.has_error()) {
+  auto code_memory_or_error = AutomaticMemoryInTracee::Create(pid, 0, memory_size);
+  if (code_memory_or_error.has_error()) {
     return ErrorMessage(absl::StrFormat("Failed to allocate memory in tracee: %s",
-                                        code_address_or_error.error().message()));
+                                        code_memory_or_error.error().message()));
   }
-  auto code_address = std::move(code_address_or_error.value());
+  auto code_memory = std::move(code_memory_or_error.value());
 
-  // Write the name of symbol into memory at code_address with offset of kCodeScratchPadSize.
+  // Write the name of symbol into memory at code_memory with offset of kCodeScratchPadSize.
   std::vector<uint8_t> symbol_name_as_vector(symbol_name_length, 0);
   memcpy(symbol_name_as_vector.data(), symbol.data(), symbol.length());
-  const uint64_t symbol_name_address = code_address.get() + kCodeScratchPadSize;
+  const uint64_t symbol_name_address = code_memory->GetAddress() + kCodeScratchPadSize;
   auto write_memory_result = WriteTraceesMemory(pid, symbol_name_address, symbol_name_as_vector);
   if (write_memory_result.has_error()) {
     return write_memory_result.error();
@@ -171,7 +171,7 @@ ErrorMessageOr<uint64_t> FindFunctionAddressWithFallback(pid_t pid, std::string_
       .AppendBytes({0xff, 0xd0})
       .AppendBytes({0xcc});
 
-  OUTCOME_TRY(auto&& return_value, ExecuteMachineCode(pid, code_address.get(), code));
+  OUTCOME_TRY(auto&& return_value, ExecuteMachineCode(*code_memory, code));
 
   return absl::bit_cast<void*>(return_value);
 }
@@ -183,12 +183,12 @@ ErrorMessageOr<uint64_t> FindFunctionAddressWithFallback(pid_t pid, std::string_
                                               kDlcloseInLibc));
 
   // Allocate small memory area in the tracee.
-  auto code_address_or_error = AllocateInTraceeAsUniqueResource(pid, 0, kCodeScratchPadSize);
-  if (code_address_or_error.has_error()) {
+  auto code_memory_or_error = AutomaticMemoryInTracee::Create(pid, 0, kCodeScratchPadSize);
+  if (code_memory_or_error.has_error()) {
     return ErrorMessage(absl::StrFormat("Failed to allocate memory in tracee: %s",
-                                        code_address_or_error.error().message()));
+                                        code_memory_or_error.error().message()));
   }
-  auto code_address = std::move(code_address_or_error.value());
+  auto code_memory = std::move(code_memory_or_error.value());
 
   // We want to do the following in the tracee:
   // dlclose(handle);
@@ -208,7 +208,7 @@ ErrorMessageOr<uint64_t> FindFunctionAddressWithFallback(pid_t pid, std::string_
       .AppendBytes({0xff, 0xd0})
       .AppendBytes({0xcc});
 
-  OUTCOME_TRY(ExecuteMachineCode(pid, code_address.get(), code));
+  OUTCOME_TRY(ExecuteMachineCode(*code_memory, code));
 
   return outcome::success();
 }

--- a/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
+++ b/src/UserSpaceInstrumentation/InjectLibraryInTraceeTest.cpp
@@ -60,9 +60,8 @@ void OpenUseAndCloseLibrary(pid_t pid) {
   {
     // Write machine code to call "TrivialFunction" from the dynamic lib.
     constexpr uint64_t kScratchPadSize = 1024;
-    auto address_or_error = AllocateInTraceeAsUniqueResource(pid, 0, kScratchPadSize);
-    ASSERT_TRUE(address_or_error.has_value());
-    const uint64_t address = address_or_error.value().get();
+    auto memory_or_error = AutomaticMemoryInTracee::Create(pid, 0, kScratchPadSize);
+    ASSERT_TRUE(memory_or_error.has_value());
     // Move function's address to rax, do the call, and hit a breakpoint:
     // movabs rax, function_address     48 b8 function_address
     // call rax                         ff d0
@@ -73,7 +72,7 @@ void OpenUseAndCloseLibrary(pid_t pid) {
         .AppendBytes({0xff, 0xd0})
         .AppendBytes({0xcc});
 
-    auto result_or_error = ExecuteMachineCode(pid, address, code);
+    auto result_or_error = ExecuteMachineCode(*memory_or_error.value(), code);
     ASSERT_THAT(result_or_error, HasNoError());
     EXPECT_EQ(42, result_or_error.value());
   }

--- a/src/UserSpaceInstrumentation/Trampoline.cpp
+++ b/src/UserSpaceInstrumentation/Trampoline.cpp
@@ -596,11 +596,11 @@ ErrorMessageOr<AddressRange> FindAddressRangeForTrampoline(
                                       code_range.start, code_range.end));
 }
 
-
 ErrorMessageOr<std::unique_ptr<MemoryInTracee>> AllocateMemoryForTrampolines(
     pid_t pid, const AddressRange& code_range, uint64_t size) {
   OUTCOME_TRY(auto&& unavailable_ranges, GetUnavailableAddressRanges(pid));
-  OUTCOME_TRY(auto&& address_range, FindAddressRangeForTrampoline(unavailable_ranges, code_range, size));
+  OUTCOME_TRY(auto&& address_range,
+              FindAddressRangeForTrampoline(unavailable_ranges, code_range, size));
   OUTCOME_TRY(auto&& memory, MemoryInTracee::Create(pid, address_range.start, size));
   return std::move(memory);
 }

--- a/src/UserSpaceInstrumentation/Trampoline.cpp
+++ b/src/UserSpaceInstrumentation/Trampoline.cpp
@@ -596,12 +596,13 @@ ErrorMessageOr<AddressRange> FindAddressRangeForTrampoline(
                                       code_range.start, code_range.end));
 }
 
-ErrorMessageOr<uint64_t> AllocateMemoryForTrampolines(pid_t pid, const AddressRange& code_range,
-                                                      uint64_t size) {
+
+ErrorMessageOr<std::unique_ptr<MemoryInTracee>> AllocateMemoryForTrampolines(
+    pid_t pid, const AddressRange& code_range, uint64_t size) {
   OUTCOME_TRY(auto&& unavailable_ranges, GetUnavailableAddressRanges(pid));
-  OUTCOME_TRY(auto&& address_range,
-              FindAddressRangeForTrampoline(unavailable_ranges, code_range, size));
-  return AllocateInTracee(pid, address_range.start, size);
+  OUTCOME_TRY(auto&& address_range, FindAddressRangeForTrampoline(unavailable_ranges, code_range, size));
+  OUTCOME_TRY(auto&& memory, MemoryInTracee::Create(pid, address_range.start, size));
+  return std::move(memory);
 }
 
 ErrorMessageOr<int32_t> AddressDifferenceAsInt32(uint64_t a, uint64_t b) {

--- a/src/UserSpaceInstrumentation/Trampoline.h
+++ b/src/UserSpaceInstrumentation/Trampoline.h
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "AddressRange.h"
+#include "AllocateInTracee.h"
 #include "OrbitBase/Result.h"
 
 namespace orbit_user_space_instrumentation {
@@ -54,9 +55,8 @@ namespace orbit_user_space_instrumentation {
 // Allocates `size` bytes in the tracee close to `code_range`. The memory segment will be placed
 // such that we can jump from any position in the memory segment to any position in `code_range`
 // (and vice versa) by relative jumps using 32 bit offsets.
-[[nodiscard]] ErrorMessageOr<uint64_t> AllocateMemoryForTrampolines(pid_t pid,
-                                                                    const AddressRange& code_range,
-                                                                    uint64_t size);
+[[nodiscard]] ErrorMessageOr<std::unique_ptr<MemoryInTracee>> AllocateMemoryForTrampolines(
+    pid_t pid, const AddressRange& code_range, uint64_t size);
 
 // Returns the signed 32 bit difference (a-b) between two absolute virtual 64 bit addresses or an
 // error if the difference is too large.

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -16,6 +16,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <limits>
+#include <memory>
 #include <numeric>
 #include <random>
 #include <string>
@@ -290,14 +291,14 @@ TEST(TrampolineTest, AllocateMemoryForTrampolines) {
 
   // Allocate one megabyte in the tracee. The memory will be close to `code_range`.
   constexpr uint64_t kTrampolineSize = 1024 * 1024;
-  auto address_or_error = AllocateMemoryForTrampolines(pid, code_range, kTrampolineSize);
-  ASSERT_FALSE(address_or_error.has_error());
+  auto memory_or_error = AllocateMemoryForTrampolines(pid, code_range, kTrampolineSize);
+  ASSERT_FALSE(memory_or_error.has_error());
 
   // Check that the tracee is functional: Continue, stop again, free the allocated memory, then run
   // briefly again.
   CHECK(DetachAndContinueProcess(pid).has_value());
   CHECK(AttachAndStopProcess(pid).has_value());
-  ASSERT_FALSE(FreeInTracee(pid, address_or_error.value(), kTrampolineSize).has_error());
+  ASSERT_THAT(memory_or_error.value()->Free(), HasNoError());
   CHECK(DetachAndContinueProcess(pid).has_value());
   CHECK(AttachAndStopProcess(pid).has_value());
 
@@ -626,15 +627,17 @@ class InstrumentFunctionTest : public testing::Test {
     auto trampoline_or_error =
         AllocateMemoryForTrampolines(pid_, address_range_code, max_trampoline_size_);
     CHECK(!trampoline_or_error.has_error());
-    trampoline_address_ = trampoline_or_error.value();
+    trampoline_memory_ = std::move(trampoline_or_error.value());
+    trampoline_address_ = trampoline_memory_->GetAddress();
 
     // Get memory for return trampoline and create the return trampoline.
-    auto return_trampoline_or_error = AllocateInTracee(pid_, 0, GetReturnTrampolineSize());
+    auto return_trampoline_or_error = MemoryInTracee::Create(pid_, 0, GetReturnTrampolineSize());
     CHECK(!return_trampoline_or_error.has_error());
-    return_trampoline_address_ = return_trampoline_or_error.value();
-    auto result = CreateReturnTrampoline(pid_, exit_payload_function_address_,
-                                         return_trampoline_or_error.value());
+    return_trampoline_address_ = return_trampoline_or_error.value()->GetAddress();
+    auto result =
+        CreateReturnTrampoline(pid_, exit_payload_function_address_, return_trampoline_address_);
     CHECK(!result.has_error());
+    CHECK(!return_trampoline_or_error.value()->EnsureMemoryExecutable().has_error());
 
     // Copy the beginning of the function over into this process.
     constexpr uint64_t kMaxFunctionPrologueBackupSize = 20;
@@ -648,6 +651,8 @@ class InstrumentFunctionTest : public testing::Test {
   // Runs the child for a millisecond to assert it is still working fine, stops it, removes the
   // instrumentation, restarts and stops it again.
   void RestartAndRemoveInstrumentation() {
+    CHECK(!trampoline_memory_->EnsureMemoryExecutable().has_error());
+
     MoveInstructionPointersOutOfOverwrittenCode(pid_, relocation_map_);
 
     CHECK(!DetachAndContinueProcess(pid_).has_error());
@@ -676,6 +681,7 @@ class InstrumentFunctionTest : public testing::Test {
   pid_t pid_ = -1;
   csh capstone_handle_ = 0;
   uint64_t max_trampoline_size_ = 0;
+  std::unique_ptr<MemoryInTracee> trampoline_memory_;
   uint64_t trampoline_address_;
   uint64_t return_trampoline_address_;
   uint64_t entry_payload_function_address_;


### PR DESCRIPTION
Previously we only handed out pointers (in the form of uint64_t's).
Going forward we will also need the size and some book keeping
information since we'll need to adjust the access protection while
the program is running. The memory will get allocated with write
permissions and will be made executable (and non-writable) when
needed.

This change is more or less a no-op in such that it merely replaces
the old system with the new class without using any new functionality.