### PR TITLE
Add Tracing interface project in preparation for Windows tracing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,7 @@ add_subdirectory(src/OrbitTest)
 add_subdirectory(src/OrbitVersion)
 add_subdirectory(src/PresetFile)
 add_subdirectory(src/Symbols)
+add_subdirectory(src/TracingInterface)
 add_subdirectory(src/Test)
 
 if(WITH_GUI)

--- a/src/LinuxTracing/CMakeLists.txt
+++ b/src/LinuxTracing/CMakeLists.txt
@@ -19,8 +19,7 @@ target_include_directories(LinuxTracing PRIVATE
         ${CMAKE_CURRENT_LIST_DIR})
 
 target_sources(LinuxTracing PUBLIC
-        include/LinuxTracing/Tracer.h
-        include/LinuxTracing/TracerListener.h)
+        include/LinuxTracing/Tracer.h)
 
 target_sources(LinuxTracing PRIVATE
         ContextSwitchManager.cpp
@@ -70,6 +69,7 @@ target_link_libraries(LinuxTracing PUBLIC
         Introspection
         ObjectUtils
         OrbitBase
+        TracingInterface
         CONAN_PKG::abseil
         CONAN_PKG::libunwindstack)
 
@@ -92,6 +92,7 @@ target_sources(LinuxTracingTests PRIVATE
 
 target_link_libraries(LinuxTracingTests PRIVATE
         LinuxTracing
+        TracingInterface
         GTest::GTest
         GTest::Main)
 

--- a/src/LinuxTracing/GpuTracepointVisitor.h
+++ b/src/LinuxTracing/GpuTracepointVisitor.h
@@ -14,15 +14,16 @@
 #include <tuple>
 #include <vector>
 
-#include "LinuxTracing/TracerListener.h"
 #include "PerfEvent.h"
 #include "PerfEventVisitor.h"
+#include "TracingInterface/TracerListener.h"
 
 namespace orbit_linux_tracing {
 
 class GpuTracepointVisitor : public PerfEventVisitor {
  public:
-  explicit GpuTracepointVisitor(TracerListener* listener) : listener_{listener} {
+  explicit GpuTracepointVisitor(orbit_tracing_interface::TracerListener* listener)
+      : listener_{listener} {
     CHECK(listener_ != nullptr);
   }
 
@@ -39,7 +40,7 @@ class GpuTracepointVisitor : public PerfEventVisitor {
 
   void CreateGpuJobAndSendToListenerIfComplete(const Key& key);
 
-  TracerListener* listener_;
+  orbit_tracing_interface::TracerListener* listener_;
 
   struct AmdgpuCsIoctlEvent {
     pid_t pid;

--- a/src/LinuxTracing/GpuTracepointVisitorTest.cpp
+++ b/src/LinuxTracing/GpuTracepointVisitorTest.cpp
@@ -15,17 +15,17 @@
 
 #include "GpuTracepointVisitor.h"
 #include "KernelTracepoints.h"
-#include "LinuxTracing/TracerListener.h"
 #include "OrbitBase/Logging.h"
 #include "PerfEvent.h"
 #include "PerfEventRecords.h"
+#include "TracingInterface/TracerListener.h"
 #include "capture.pb.h"
 
 namespace orbit_linux_tracing {
 
 namespace {
 
-class MockTracerListener : public TracerListener {
+class MockTracerListener : public orbit_tracing_interface::TracerListener {
  public:
   MOCK_METHOD(void, OnSchedulingSlice, (orbit_grpc_protos::SchedulingSlice), (override));
   MOCK_METHOD(void, OnCallstackSample, (orbit_grpc_protos::FullCallstackSample), (override));

--- a/src/LinuxTracing/LostAndDiscardedEventVisitor.h
+++ b/src/LinuxTracing/LostAndDiscardedEventVisitor.h
@@ -5,9 +5,9 @@
 #ifndef LINUX_TRACING_LOST_AND_DISCARDED_EVENT_VISITOR_H_
 #define LINUX_TRACING_LOST_AND_DISCARDED_EVENT_VISITOR_H_
 
-#include "LinuxTracing/TracerListener.h"
 #include "PerfEvent.h"
 #include "PerfEventVisitor.h"
+#include "TracingInterface/TracerListener.h"
 #include "capture.pb.h"
 
 namespace orbit_linux_tracing {
@@ -16,7 +16,8 @@ namespace orbit_linux_tracing {
 // MetadataEvents to the TracerListener.
 class LostAndDiscardedEventVisitor : public PerfEventVisitor {
  public:
-  explicit LostAndDiscardedEventVisitor(TracerListener* listener) : listener_{listener} {
+  explicit LostAndDiscardedEventVisitor(orbit_tracing_interface::TracerListener* listener)
+      : listener_{listener} {
     CHECK(listener_ != nullptr);
   }
 
@@ -40,7 +41,7 @@ class LostAndDiscardedEventVisitor : public PerfEventVisitor {
   }
 
  private:
-  TracerListener* listener_;
+  orbit_tracing_interface::TracerListener* listener_;
 };
 
 }  // namespace orbit_linux_tracing

--- a/src/LinuxTracing/LostAndDiscardedEventVisitorTest.cpp
+++ b/src/LinuxTracing/LostAndDiscardedEventVisitorTest.cpp
@@ -10,17 +10,17 @@
 #include <string>
 #include <utility>
 
-#include "LinuxTracing/TracerListener.h"
 #include "LostAndDiscardedEventVisitor.h"
 #include "OrbitBase/Logging.h"
 #include "PerfEvent.h"
+#include "TracingInterface/TracerListener.h"
 #include "capture.pb.h"
 
 namespace orbit_linux_tracing {
 
 namespace {
 
-class MockTracerListener : public TracerListener {
+class MockTracerListener : public orbit_tracing_interface::TracerListener {
  public:
   MOCK_METHOD(void, OnSchedulingSlice, (orbit_grpc_protos::SchedulingSlice), (override));
   MOCK_METHOD(void, OnCallstackSample, (orbit_grpc_protos::FullCallstackSample), (override));

--- a/src/LinuxTracing/SwitchesStatesNamesVisitor.cpp
+++ b/src/LinuxTracing/SwitchesStatesNamesVisitor.cpp
@@ -10,8 +10,8 @@
 #include <utility>
 #include <vector>
 
-#include "LinuxTracing/TracerListener.h"
 #include "OrbitBase/Logging.h"
+#include "TracingInterface/TracerListener.h"
 
 namespace orbit_linux_tracing {
 

--- a/src/LinuxTracing/SwitchesStatesNamesVisitor.h
+++ b/src/LinuxTracing/SwitchesStatesNamesVisitor.h
@@ -15,10 +15,10 @@
 #include <vector>
 
 #include "ContextSwitchManager.h"
-#include "LinuxTracing/TracerListener.h"
 #include "PerfEvent.h"
 #include "PerfEventVisitor.h"
 #include "ThreadStateManager.h"
+#include "TracingInterface/TracerListener.h"
 #include "capture.pb.h"
 
 namespace orbit_linux_tracing {
@@ -37,7 +37,8 @@ namespace orbit_linux_tracing {
 // profiling). For this we also need the system-wide association between tids and pids.
 class SwitchesStatesNamesVisitor : public PerfEventVisitor {
  public:
-  explicit SwitchesStatesNamesVisitor(TracerListener* listener) : listener_{listener} {
+  explicit SwitchesStatesNamesVisitor(orbit_tracing_interface::TracerListener* listener)
+      : listener_{listener} {
     CHECK(listener_ != nullptr);
   }
 
@@ -67,7 +68,7 @@ class SwitchesStatesNamesVisitor : public PerfEventVisitor {
       char c);
   static orbit_grpc_protos::ThreadStateSlice::ThreadState GetThreadStateFromBits(uint64_t bits);
 
-  TracerListener* listener_;
+  orbit_tracing_interface::TracerListener* listener_;
   std::atomic<uint64_t>* thread_state_counter_ = nullptr;
 
   bool produce_scheduling_slices_ = false;

--- a/src/LinuxTracing/Tracer.cpp
+++ b/src/LinuxTracing/Tracer.cpp
@@ -9,8 +9,8 @@
 #include <atomic>
 #include <memory>
 
-#include "LinuxTracing/TracerListener.h"
 #include "TracerThread.h"
+#include "TracingInterface/TracerListener.h"
 #include "capture.pb.h"
 
 namespace orbit_linux_tracing {

--- a/src/LinuxTracing/TracerThread.cpp
+++ b/src/LinuxTracing/TracerThread.cpp
@@ -25,7 +25,6 @@
 #include "Introspection/Introspection.h"
 #include "LibunwindstackMaps.h"
 #include "LibunwindstackUnwinder.h"
-#include "LinuxTracing/TracerListener.h"
 #include "LinuxTracingUtils.h"
 #include "ObjectUtils/LinuxMap.h"
 #include "OrbitBase/ExecutablePath.h"
@@ -36,6 +35,7 @@
 #include "PerfEventOpen.h"
 #include "PerfEventReaders.h"
 #include "PerfEventRecords.h"
+#include "TracingInterface/TracerListener.h"
 #include "tracepoint.pb.h"
 
 namespace orbit_linux_tracing {

--- a/src/LinuxTracing/TracerThread.h
+++ b/src/LinuxTracing/TracerThread.h
@@ -22,7 +22,6 @@
 #include "ContextSwitchManager.h"
 #include "Function.h"
 #include "GpuTracepointVisitor.h"
-#include "LinuxTracing/TracerListener.h"
 #include "LinuxTracingUtils.h"
 #include "LostAndDiscardedEventVisitor.h"
 #include "ManualInstrumentationConfig.h"
@@ -31,6 +30,7 @@
 #include "PerfEventProcessor.h"
 #include "PerfEventRingBuffer.h"
 #include "SwitchesStatesNamesVisitor.h"
+#include "TracingInterface/TracerListener.h"
 #include "UprobesUnwindingVisitor.h"
 #include "capture.pb.h"
 
@@ -45,7 +45,7 @@ class TracerThread {
   TracerThread(TracerThread&&) = delete;
   TracerThread& operator=(TracerThread&&) = delete;
 
-  void SetListener(TracerListener* listener) { listener_ = listener; }
+  void SetListener(orbit_tracing_interface::TracerListener* listener) { listener_ = listener; }
 
   void Run(const std::shared_ptr<std::atomic<bool>>& exit_requested);
 
@@ -144,7 +144,7 @@ class TracerThread {
   bool trace_gpu_driver_;
   std::vector<orbit_grpc_protos::TracepointInfo> instrumented_tracepoints_;
 
-  TracerListener* listener_ = nullptr;
+  orbit_tracing_interface::TracerListener* listener_ = nullptr;
 
   std::vector<int> tracing_fds_;
   std::vector<PerfEventRingBuffer> ring_buffers_;

--- a/src/LinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.cpp
@@ -28,6 +28,8 @@ using orbit_grpc_protos::FullAddressInfo;
 using orbit_grpc_protos::FullCallstackSample;
 using orbit_grpc_protos::FunctionCall;
 
+using orbit_tracing_interface::TracerListener;
+
 static void SendFullAddressInfoToListener(TracerListener* listener,
                                           const unwindstack::FrameData& libunwindstack_frame) {
   CHECK(listener != nullptr);

--- a/src/LinuxTracing/UprobesUnwindingVisitor.h
+++ b/src/LinuxTracing/UprobesUnwindingVisitor.h
@@ -20,9 +20,9 @@
 #include "LeafFunctionCallManager.h"
 #include "LibunwindstackMaps.h"
 #include "LibunwindstackUnwinder.h"
-#include "LinuxTracing/TracerListener.h"
 #include "PerfEvent.h"
 #include "PerfEventVisitor.h"
+#include "TracingInterface/TracerListener.h"
 #include "UprobesFunctionCallManager.h"
 #include "UprobesReturnAddressManager.h"
 
@@ -46,7 +46,7 @@ namespace orbit_linux_tracing {
 
 class UprobesUnwindingVisitor : public PerfEventVisitor {
  public:
-  explicit UprobesUnwindingVisitor(TracerListener* listener,
+  explicit UprobesUnwindingVisitor(orbit_tracing_interface::TracerListener* listener,
                                    UprobesFunctionCallManager* function_call_manager,
                                    UprobesReturnAddressManager* uprobes_return_address_manager,
                                    LibunwindstackMaps* initial_maps,
@@ -94,7 +94,7 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
                  uint64_t function_id);
   void OnUretprobes(uint64_t timestamp_ns, pid_t pid, pid_t tid, std::optional<uint64_t> ax);
 
-  TracerListener* listener_;
+  orbit_tracing_interface::TracerListener* listener_;
 
   UprobesFunctionCallManager* function_call_manager_;
   UprobesReturnAddressManager* return_address_manager_;

--- a/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorTest.cpp
@@ -44,7 +44,7 @@ class MockLibunwindstackUnwinder : public LibunwindstackUnwinder {
               (override));
 };
 
-class MockTracerListener : public TracerListener {
+class MockTracerListener : public orbit_tracing_interface::TracerListener {
  public:
   MOCK_METHOD(void, OnSchedulingSlice, (orbit_grpc_protos::SchedulingSlice), (override));
   MOCK_METHOD(void, OnCallstackSample, (orbit_grpc_protos::FullCallstackSample), (override));

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
@@ -20,7 +20,6 @@
 #include <utility>
 
 #include "LinuxTracing/Tracer.h"
-#include "LinuxTracing/TracerListener.h"
 #include "LinuxTracingIntegrationTestPuppet.h"
 #include "ObjectUtils/ElfFile.h"
 #include "ObjectUtils/LinuxMap.h"
@@ -28,6 +27,7 @@
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ReadFileToString.h"
 #include "OrbitBase/ThreadUtils.h"
+#include "TracingInterface/TracerListener.h"
 #include "capture.pb.h"
 
 namespace orbit_linux_tracing_integration_tests {
@@ -162,7 +162,7 @@ class ChildProcess {
   int writing_fd_ = -1;
 };
 
-class BufferTracerListener : public orbit_linux_tracing::TracerListener {
+class BufferTracerListener : public orbit_tracing_interface::TracerListener {
  public:
   void OnSchedulingSlice(orbit_grpc_protos::SchedulingSlice scheduling_slice) override {
     orbit_grpc_protos::ProducerCaptureEvent event;

--- a/src/Service/LinuxTracingHandler.h
+++ b/src/Service/LinuxTracingHandler.h
@@ -14,15 +14,15 @@
 
 #include "Introspection/Introspection.h"
 #include "LinuxTracing/Tracer.h"
-#include "LinuxTracing/TracerListener.h"
 #include "OrbitBase/Logging.h"
 #include "ProducerEventProcessor.h"
+#include "TracingInterface/TracerListener.h"
 #include "capture.pb.h"
 #include "tracepoint.pb.h"
 
 namespace orbit_service {
 
-class LinuxTracingHandler : public orbit_linux_tracing::TracerListener {
+class LinuxTracingHandler : public orbit_tracing_interface::TracerListener {
  public:
   explicit LinuxTracingHandler(ProducerEventProcessor* producer_event_processor)
       : producer_event_processor_{producer_event_processor} {}

--- a/src/TracingInterface/CMakeLists.txt
+++ b/src/TracingInterface/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+project(TracingInterface)
+
+add_library(TracingInterface INTERFACE)
+
+target_sources(TracingInterface INTERFACE
+        include/TracingInterface/Tracer.h
+        include/TracingInterface/TracerListener.h)
+
+target_include_directories(TracingInterface INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+target_link_libraries(TracingInterface INTERFACE
+        GrpcProtos)

--- a/src/TracingInterface/include/TracingInterface/Tracer.h
+++ b/src/TracingInterface/include/TracingInterface/Tracer.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef TRACING_INTERFACE_TRACER_H_
+#define TRACING_INTERFACE_TRACER_H_
+
+#include "TracerListener.h"
+#include "capture.pb.h"
+
+namespace orbit_tracing_interface {
+
+// Interface for starting/stopping a trace and relaying information to the provided TracerListener.
+// Platform specific implementations exist in "<Platform>Tracing" projects.
+
+class Tracer {
+ public:
+  explicit Tracer(orbit_grpc_protos::CaptureOptions capture_options)
+      : capture_options_{std::move(capture_options)} {}
+
+  virtual ~Tracer() = default;
+
+  void SetListener(TracerListener* listener) { listener_ = listener; }
+
+  virtual void Start() = 0;
+  virtual void Stop() = 0;
+
+ protected:
+  orbit_grpc_protos::CaptureOptions capture_options_;
+
+  TracerListener* listener_ = nullptr;
+};
+
+}  // namespace orbit_tracing_interface
+
+#endif  // TRACING_INTERFACE_TRACER_H_

--- a/src/TracingInterface/include/TracingInterface/TracerListener.h
+++ b/src/TracingInterface/include/TracingInterface/TracerListener.h
@@ -2,12 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef LINUX_TRACING_TRACER_LISTENER_H_
-#define LINUX_TRACING_TRACER_LISTENER_H_
+#ifndef TRACING_TRACER_LISTENER_H_
+#define TRACING_TRACER_LISTENER_H_
 
 #include "capture.pb.h"
 
-namespace orbit_linux_tracing {
+namespace orbit_tracing_interface {
 
 class TracerListener {
  public:
@@ -33,6 +33,6 @@ class TracerListener {
       orbit_grpc_protos::OutOfOrderEventsDiscardedEvent out_of_order_events_discarded_event) = 0;
 };
 
-}  // namespace orbit_linux_tracing
+}  // namespace orbit_tracing_interface
 
-#endif  // LINUX_TRACING_TRACER_LISTENER_H_
+#endif  // TRACING_TRACER_LISTENER_H_


### PR DESCRIPTION
Extract an interface from LinuxTracing/Tracer.h to the new Tracing/Tracer.h and
make LinuxTracing/Tracer.h use it. Also, move LinuxTracing/TraceListener.h to the new
"Tracing' project. There is no functional change here. This is done as a first step
towards Windows profiling revival.

Tests: Profiled OrbitTest with dynamic and manual instrumentation.