### PR TITLE
Rename LinuxTracingHandler to TracingHandler

### DIFF
--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
@@ -461,7 +461,7 @@ void VerifyOrderOfAllEvents(const std::vector<orbit_grpc_protos::ProducerCapture
   for (const auto& event : events) {
     switch (event.event_case()) {
       case orbit_grpc_protos::ProducerCaptureEvent::kCaptureStarted:
-        // LinuxTracingHandler does not send this event.
+        // TracingHandler does not send this event.
         UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kSchedulingSlice:
         EXPECT_GE(event.scheduling_slice().out_timestamp_ns(), previous_event_timestamp_ns);

--- a/src/Service/CMakeLists.txt
+++ b/src/Service/CMakeLists.txt
@@ -20,8 +20,6 @@ target_sources(ServiceLib PRIVATE
         CrashServiceImpl.h
         FramePointerValidatorServiceImpl.cpp
         FramePointerValidatorServiceImpl.h
-        LinuxTracingHandler.cpp
-        LinuxTracingHandler.h
         MemoryInfoHandler.cpp
         MemoryInfoHandler.h
         OrbitGrpcServer.cpp
@@ -42,6 +40,8 @@ target_sources(ServiceLib PRIVATE
         ProducerSideServiceImpl.h
         TracepointServiceImpl.h
         TracepointServiceImpl.cpp
+        TracingHandler.cpp
+        TracingHandler.h
         ServiceUtils.cpp
         ServiceUtils.h)
 

--- a/src/Service/TracingHandler.cpp
+++ b/src/Service/TracingHandler.cpp
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "LinuxTracingHandler.h"
+#include "TracingHandler.h"
 
 #include <absl/synchronization/mutex.h>
 #include <unistd.h>
@@ -27,7 +27,7 @@ using orbit_grpc_protos::ThreadStateSlice;
 
 using orbit_grpc_protos::kLinuxTracingProducerId;
 
-void LinuxTracingHandler::Start(CaptureOptions capture_options) {
+void TracingHandler::Start(CaptureOptions capture_options) {
   CHECK(tracer_ == nullptr);
   bool enable_introspection = capture_options.enable_introspection();
 
@@ -40,7 +40,7 @@ void LinuxTracingHandler::Start(CaptureOptions capture_options) {
   }
 }
 
-void LinuxTracingHandler::SetupIntrospection() {
+void TracingHandler::SetupIntrospection() {
   orbit_tracing_listener_ = std::make_unique<orbit_introspection::TracingListener>(
       [this](const orbit_introspection::TracingScope& scope) {
         IntrospectionScope introspection_scope;
@@ -60,102 +60,101 @@ void LinuxTracingHandler::SetupIntrospection() {
       });
 }
 
-void LinuxTracingHandler::Stop() {
+void TracingHandler::Stop() {
   CHECK(tracer_ != nullptr);
   tracer_->Stop();
   tracer_.reset();
 }
 
-void LinuxTracingHandler::OnSchedulingSlice(SchedulingSlice scheduling_slice) {
+void TracingHandler::OnSchedulingSlice(SchedulingSlice scheduling_slice) {
   ProducerCaptureEvent event;
   *event.mutable_scheduling_slice() = std::move(scheduling_slice);
   producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
-void LinuxTracingHandler::OnCallstackSample(FullCallstackSample callstack_sample) {
+void TracingHandler::OnCallstackSample(FullCallstackSample callstack_sample) {
   ProducerCaptureEvent event;
   *event.mutable_full_callstack_sample() = std::move(callstack_sample);
   producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
-void LinuxTracingHandler::OnFunctionCall(FunctionCall function_call) {
+void TracingHandler::OnFunctionCall(FunctionCall function_call) {
   ProducerCaptureEvent event;
   *event.mutable_function_call() = std::move(function_call);
   producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
-void LinuxTracingHandler::OnIntrospectionScope(
+void TracingHandler::OnIntrospectionScope(
     orbit_grpc_protos::IntrospectionScope introspection_scope) {
   ProducerCaptureEvent event;
   *event.mutable_introspection_scope() = std::move(introspection_scope);
   producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
-void LinuxTracingHandler::OnGpuJob(FullGpuJob full_gpu_job) {
+void TracingHandler::OnGpuJob(FullGpuJob full_gpu_job) {
   ProducerCaptureEvent event;
   *event.mutable_full_gpu_job() = std::move(full_gpu_job);
   producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
-void LinuxTracingHandler::OnThreadName(ThreadName thread_name) {
+void TracingHandler::OnThreadName(ThreadName thread_name) {
   ProducerCaptureEvent event;
   *event.mutable_thread_name() = std::move(thread_name);
   producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
-void LinuxTracingHandler::OnThreadNamesSnapshot(
+void TracingHandler::OnThreadNamesSnapshot(
     orbit_grpc_protos::ThreadNamesSnapshot thread_names_snapshot) {
   ProducerCaptureEvent event;
   *event.mutable_thread_names_snapshot() = std::move(thread_names_snapshot);
   producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
-void LinuxTracingHandler::OnThreadStateSlice(ThreadStateSlice thread_state_slice) {
+void TracingHandler::OnThreadStateSlice(ThreadStateSlice thread_state_slice) {
   ProducerCaptureEvent event;
   *event.mutable_thread_state_slice() = std::move(thread_state_slice);
   producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
-void LinuxTracingHandler::OnAddressInfo(FullAddressInfo full_address_info) {
+void TracingHandler::OnAddressInfo(FullAddressInfo full_address_info) {
   ProducerCaptureEvent event;
   *event.mutable_full_address_info() = std::move(full_address_info);
   producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
-void LinuxTracingHandler::OnTracepointEvent(
-    orbit_grpc_protos::FullTracepointEvent tracepoint_event) {
+void TracingHandler::OnTracepointEvent(orbit_grpc_protos::FullTracepointEvent tracepoint_event) {
   ProducerCaptureEvent event;
   *event.mutable_full_tracepoint_event() = std::move(tracepoint_event);
   producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
-void LinuxTracingHandler::OnModuleUpdate(orbit_grpc_protos::ModuleUpdateEvent module_update_event) {
+void TracingHandler::OnModuleUpdate(orbit_grpc_protos::ModuleUpdateEvent module_update_event) {
   ProducerCaptureEvent event;
   *event.mutable_module_update_event() = std::move(module_update_event);
   producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
-void LinuxTracingHandler::OnModulesSnapshot(orbit_grpc_protos::ModulesSnapshot modules_snapshot) {
+void TracingHandler::OnModulesSnapshot(orbit_grpc_protos::ModulesSnapshot modules_snapshot) {
   ProducerCaptureEvent event;
   *event.mutable_modules_snapshot() = std::move(modules_snapshot);
   producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
-void LinuxTracingHandler::OnErrorsWithPerfEventOpenEvent(
+void TracingHandler::OnErrorsWithPerfEventOpenEvent(
     orbit_grpc_protos::ErrorsWithPerfEventOpenEvent errors_with_perf_event_open_event) {
   ProducerCaptureEvent event;
   *event.mutable_errors_with_perf_event_open_event() = std::move(errors_with_perf_event_open_event);
   producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
-void LinuxTracingHandler::OnLostPerfRecordsEvent(
+void TracingHandler::OnLostPerfRecordsEvent(
     orbit_grpc_protos::LostPerfRecordsEvent lost_perf_records_event) {
   orbit_grpc_protos::ProducerCaptureEvent event;
   *event.mutable_lost_perf_records_event() = std::move(lost_perf_records_event);
   producer_event_processor_->ProcessEvent(kLinuxTracingProducerId, std::move(event));
 }
 
-void LinuxTracingHandler::OnOutOfOrderEventsDiscardedEvent(
+void TracingHandler::OnOutOfOrderEventsDiscardedEvent(
     orbit_grpc_protos::OutOfOrderEventsDiscardedEvent out_of_order_events_discarded_event) {
   orbit_grpc_protos::ProducerCaptureEvent event;
   *event.mutable_out_of_order_events_discarded_event() =

--- a/src/Service/TracingHandler.h
+++ b/src/Service/TracingHandler.h
@@ -22,16 +22,16 @@
 
 namespace orbit_service {
 
-class LinuxTracingHandler : public orbit_tracing_interface::TracerListener {
+class TracingHandler : public orbit_tracing_interface::TracerListener {
  public:
-  explicit LinuxTracingHandler(ProducerEventProcessor* producer_event_processor)
+  explicit TracingHandler(ProducerEventProcessor* producer_event_processor)
       : producer_event_processor_{producer_event_processor} {}
 
-  ~LinuxTracingHandler() override = default;
-  LinuxTracingHandler(const LinuxTracingHandler&) = delete;
-  LinuxTracingHandler& operator=(const LinuxTracingHandler&) = delete;
-  LinuxTracingHandler(LinuxTracingHandler&&) = delete;
-  LinuxTracingHandler& operator=(LinuxTracingHandler&&) = delete;
+  ~TracingHandler() override = default;
+  TracingHandler(const TracingHandler&) = delete;
+  TracingHandler& operator=(const TracingHandler&) = delete;
+  TracingHandler(TracingHandler&&) = delete;
+  TracingHandler& operator=(TracingHandler&&) = delete;
 
   void Start(orbit_grpc_protos::CaptureOptions capture_options);
   void Stop();
@@ -57,7 +57,7 @@ class LinuxTracingHandler : public orbit_tracing_interface::TracerListener {
 
  private:
   ProducerEventProcessor* producer_event_processor_;
-  std::unique_ptr<orbit_linux_tracing::Tracer> tracer_;
+  std::unique_ptr<orbit_tracing_interface::Tracer> tracer_;
 
   // Manual instrumentation tracing listener.
   std::unique_ptr<orbit_introspection::TracingListener> orbit_tracing_listener_;


### PR DESCRIPTION
This is in preparation of having OrbitService running on Windows.
The class can be reused as is on both platforms, the only platform-
specific code will be the instantiation of the Tracer, which is now of
type std::unique_ptr<orbit_tracing_interface::Tracer>