### PR TITLE
Recalculate standard deviation on capture complete

### DIFF
--- a/src/ClientModel/include/ClientModel/CaptureData.h
+++ b/src/ClientModel/include/ClientModel/CaptureData.h
@@ -26,6 +26,7 @@
 #include "ClientData/ModuleManager.h"
 #include "ClientData/PostProcessedSamplingData.h"
 #include "ClientData/ProcessData.h"
+#include "ClientData/TimerChain.h"
 #include "ClientData/TimestampIntervalSet.h"
 #include "ClientData/TracepointCustom.h"
 #include "ClientData/TracepointData.h"
@@ -143,6 +144,8 @@ class CaptureData {
       uint64_t instrumented_function_id) const;
 
   void UpdateFunctionStats(uint64_t instrumented_function_id, uint64_t elapsed_nanos);
+
+  void OnCaptureComplete(std::vector<orbit_client_data::TimerChain*> chains);
 
   [[nodiscard]] const orbit_client_data::CallstackData* GetCallstackData() const {
     return callstack_data_.get();

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -353,6 +353,7 @@ Future<void> OrbitApp::OnCaptureComplete() {
   for (ThreadTrack* thread_track : GetMutableTimeGraph()->GetTrackManager()->GetThreadTracks()) {
     thread_track->OnCaptureComplete();
   }
+  capture_data_->OnCaptureComplete(GetMutableTimeGraph()->GetAllThreadTrackTimerChains());
 
   GetMutableCaptureData().FilterBrokenCallstacks();
   PostProcessedSamplingData post_processed_sampling_data =


### PR DESCRIPTION
Holding a running calculation of standard deviation may introduce
errors; once the capture is complete, iterate over all the functions to
recalculate it.

Bug: http://b/184727547