### PR TITLE
Define pid_t on Windows

### DIFF
--- a/src/OrbitBase/ThreadUtilsWindows.cpp
+++ b/src/OrbitBase/ThreadUtilsWindows.cpp
@@ -22,12 +22,12 @@ static FunctionPrototypeT GetProcAddress(const std::string& library, const std::
   return reinterpret_cast<FunctionPrototypeT>(::GetProcAddress(module_handle, procedure.c_str()));
 }
 
-uint32_t GetCurrentThreadId() {
-  thread_local uint32_t current_tid = ::GetCurrentThreadId();
+pid_t GetCurrentThreadId() {
+  thread_local pid_t current_tid = ::GetCurrentThreadId();
   return current_tid;
 }
 
-std::string GetThreadName(uint32_t tid) {
+std::string GetThreadName(pid_t tid) {
   static const std::string kEmptyString;
 
   // Find "GetThreadDescription" procedure.
@@ -68,6 +68,6 @@ void SetCurrentThreadName(const char* name) {
   }
 }
 
-uint32_t GetCurrentProcessId() { return ::GetCurrentProcessId(); }
+pid_t GetCurrentProcessId() { return ::GetCurrentProcessId(); }
 
 }  // namespace orbit_base

--- a/src/OrbitBase/include/OrbitBase/ThreadUtils.h
+++ b/src/OrbitBase/include/OrbitBase/ThreadUtils.h
@@ -14,17 +14,18 @@
 
 #include <string>
 
+#ifdef _WIN32
+// We define pid_t on Windows to ease cross-platform development. On Windows, GetCurrentThreadId()
+// and GetCurrentProcessId() both return a DWORD, an unsigned 32-bit type. Note that on Linux, pid_t
+// is a signed 32-bit type. This type aliasing matches that of absl/base/internal/sysinfo.h.
+using pid_t = uint32_t;
+#endif
+
 namespace orbit_base {
 
-#ifdef _WIN32
-[[nodiscard]] uint32_t GetCurrentThreadId();
-[[nodiscard]] std::string GetThreadName(uint32_t tid);
-[[nodiscard]] uint32_t GetCurrentProcessId();
-#else
 [[nodiscard]] pid_t GetCurrentThreadId();
 [[nodiscard]] std::string GetThreadName(pid_t tid);
 [[nodiscard]] pid_t GetCurrentProcessId();
-#endif
 
 void SetCurrentThreadName(const char* thread_name);
 


### PR DESCRIPTION
To simplify cross-platform code, define pid_t as uint32_t on Windows.
This is exactly what abseil does in absl\base\internal\sysinfo.h.