### PR TITLE
Erase 2 member of Track + Refactor

### DIFF
--- a/src/OrbitGl/AnnotationTrack.cpp
+++ b/src/OrbitGl/AnnotationTrack.cpp
@@ -13,8 +13,8 @@ const Color kThresholdColor(244, 67, 54, 255);
 }  // namespace
 
 void AnnotationTrack::DrawAnnotation(Batcher& batcher, TextRenderer& text_renderer,
-                                     TimeGraphLayout* layout, float z) {
-  uint32_t font_size = GetAnnotationFontSize();
+                                     TimeGraphLayout* layout, int indentation_level, float z) {
+  uint32_t font_size = GetAnnotationFontSize(indentation_level);
   Vec2 track_size = GetAnnotatedTrackSize();
   Vec2 track_pos = GetAnnotatedTrackPosition();
 

--- a/src/OrbitGl/AnnotationTrack.h
+++ b/src/OrbitGl/AnnotationTrack.h
@@ -36,13 +36,13 @@ class AnnotationTrack {
   }
 
   void DrawAnnotation(Batcher& batcher, TextRenderer& text_renderer, TimeGraphLayout* layout,
-                      float z);
+                      int indentation_level, float z);
 
  private:
   [[nodiscard]] virtual float GetAnnotatedTrackContentHeight() const = 0;
   [[nodiscard]] virtual Vec2 GetAnnotatedTrackPosition() const = 0;
   [[nodiscard]] virtual Vec2 GetAnnotatedTrackSize() const = 0;
-  [[nodiscard]] virtual uint32_t GetAnnotationFontSize() const = 0;
+  [[nodiscard]] virtual uint32_t GetAnnotationFontSize(int indentation_level) const = 0;
   [[nodiscard]] virtual std::string GetValueUpperBoundTooltip() const { return ""; }
 
   std::optional<std::pair<std::string, double>> warning_threshold_ = std::nullopt;

--- a/src/OrbitGl/AnnotationTrack.h
+++ b/src/OrbitGl/AnnotationTrack.h
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "Batcher.h"
+#include "CaptureViewElement.h"
 #include "CoreMath.h"
 #include "TextRenderer.h"
 #include "TimeGraphLayout.h"

--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -34,9 +34,8 @@ using orbit_grpc_protos::InstrumentedFunction;
 AsyncTrack::AsyncTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                        orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                        const std::string& name, OrbitApp* app,
-                       const orbit_client_model::CaptureData* capture_data,
-                       uint32_t indentation_level)
-    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data, indentation_level) {
+                       const orbit_client_model::CaptureData* capture_data)
+    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data) {
   SetName(name);
   SetLabel(name);
 }

--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -72,13 +72,6 @@ AsyncTrack::AsyncTrack(CaptureViewElement* parent, TimeGraph* time_graph,
           TicksToDuration(timer_info->start(), timer_info->end())));
 }
 
-void AsyncTrack::UpdateBoxHeight() {
-  box_height_ = layout_->GetTextBoxHeight();
-  if (collapse_toggle_->IsCollapsed() && depth_ > 0) {
-    box_height_ /= static_cast<float>(depth_);
-  }
-}
-
 void AsyncTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
   // Find the first row that that can receive the new timeslice with no overlap.
   // If none of the existing rows works, add a new row.
@@ -89,6 +82,14 @@ void AsyncTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
   orbit_client_protos::TimerInfo new_timer_info = timer_info;
   new_timer_info.set_depth(depth);
   TimerTrack::OnTimer(new_timer_info);
+}
+
+float AsyncTrack::GetDefaultBoxHeight() const {
+  auto box_height = layout_->GetTextBoxHeight();
+  if (collapse_toggle_->IsCollapsed() && depth_ > 0) {
+    return box_height / static_cast<float>(depth_);
+  }
+  return box_height;
 }
 
 std::string AsyncTrack::GetTimesliceText(const TimerInfo& timer_info) const {

--- a/src/OrbitGl/AsyncTrack.h
+++ b/src/OrbitGl/AsyncTrack.h
@@ -27,8 +27,7 @@ class AsyncTrack final : public TimerTrack {
   explicit AsyncTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                       const std::string& name, OrbitApp* app,
-                      const orbit_client_model::CaptureData* capture_data,
-                      uint32_t indentation_level = 0);
+                      const orbit_client_model::CaptureData* capture_data);
 
   [[nodiscard]] Type GetType() const override { return Type::kAsyncTrack; };
   [[nodiscard]] std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const override;

--- a/src/OrbitGl/AsyncTrack.h
+++ b/src/OrbitGl/AsyncTrack.h
@@ -33,9 +33,9 @@ class AsyncTrack final : public TimerTrack {
   [[nodiscard]] Type GetType() const override { return Type::kAsyncTrack; };
   [[nodiscard]] std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
-  void UpdateBoxHeight() override;
 
  protected:
+  [[nodiscard]] virtual float GetDefaultBoxHeight() const override;
   [[nodiscard]] std::string GetTimesliceText(
       const orbit_client_protos::TimerInfo& timer) const override;
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,

--- a/src/OrbitGl/BasicPageFaultsTrack.cpp
+++ b/src/OrbitGl/BasicPageFaultsTrack.cpp
@@ -22,12 +22,10 @@ BasicPageFaultsTrack::BasicPageFaultsTrack(Track* parent, TimeGraph* time_graph,
                                            orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                                            const std::string& name, const std::string& cgroup_name,
                                            uint64_t memory_sampling_period_ms,
-                                           const orbit_client_model::CaptureData* capture_data,
-                                           uint32_t indentation_level)
+                                           const orbit_client_model::CaptureData* capture_data)
     : LineGraphTrack<kBasicPageFaultsTrackDimension>(
           parent, time_graph, viewport, layout, name,
-          CreateSeriesName(cgroup_name, capture_data->process_name()), capture_data,
-          indentation_level),
+          CreateSeriesName(cgroup_name, capture_data->process_name()), capture_data),
       AnnotationTrack(),
       cgroup_name_(cgroup_name),
       memory_sampling_period_ms_(memory_sampling_period_ms),
@@ -73,12 +71,12 @@ void BasicPageFaultsTrack::AddValuesAndUpdateAnnotations(
 
 void BasicPageFaultsTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
                                 uint64_t current_mouse_time_ns, PickingMode picking_mode,
-                                float z_offset) {
+                                uint32_t indentation_level, float z_offset) {
   LineGraphTrack<kBasicPageFaultsTrackDimension>::Draw(
-      batcher, text_renderer, current_mouse_time_ns, picking_mode, z_offset);
+      batcher, text_renderer, current_mouse_time_ns, picking_mode, indentation_level, z_offset);
 
   if (picking_mode != PickingMode::kNone || IsCollapsed()) return;
-  AnnotationTrack::DrawAnnotation(batcher, text_renderer, layout_,
+  AnnotationTrack::DrawAnnotation(batcher, text_renderer, layout_, indentation_level,
                                   GlCanvas::kZValueTrackText + z_offset);
 }
 

--- a/src/OrbitGl/BasicPageFaultsTrack.cpp
+++ b/src/OrbitGl/BasicPageFaultsTrack.cpp
@@ -70,14 +70,12 @@ void BasicPageFaultsTrack::AddValuesAndUpdateAnnotations(
 }
 
 void BasicPageFaultsTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
-                                uint64_t current_mouse_time_ns, PickingMode picking_mode,
-                                uint32_t indentation_level, float z_offset) {
-  LineGraphTrack<kBasicPageFaultsTrackDimension>::Draw(
-      batcher, text_renderer, current_mouse_time_ns, picking_mode, indentation_level, z_offset);
+                                const DrawContext& draw_context) {
+  LineGraphTrack<kBasicPageFaultsTrackDimension>::Draw(batcher, text_renderer, draw_context);
 
-  if (picking_mode != PickingMode::kNone || IsCollapsed()) return;
-  AnnotationTrack::DrawAnnotation(batcher, text_renderer, layout_, indentation_level,
-                                  GlCanvas::kZValueTrackText + z_offset);
+  if (draw_context.picking_mode != PickingMode::kNone || IsCollapsed()) return;
+  AnnotationTrack::DrawAnnotation(batcher, text_renderer, layout_, draw_context.indentation_level,
+                                  GlCanvas::kZValueTrackText + draw_context.z_offset);
 }
 
 void BasicPageFaultsTrack::DrawSingleSeriesEntry(

--- a/src/OrbitGl/BasicPageFaultsTrack.h
+++ b/src/OrbitGl/BasicPageFaultsTrack.h
@@ -37,8 +37,8 @@ class BasicPageFaultsTrack : public LineGraphTrack<kBasicPageFaultsTrackDimensio
   void AddValuesAndUpdateAnnotations(
       uint64_t timestamp_ns, const std::array<double, kBasicPageFaultsTrackDimension>& values);
 
-  void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-            PickingMode picking_mode, uint32_t indentation_level, float z_offset = 0) override;
+  void Draw(Batcher& batcher, TextRenderer& text_renderer,
+            const DrawContext& draw_context) override;
 
   enum class SeriesIndex { kProcess = 0, kCGroup = 1, kSystem = 2 };
 

--- a/src/OrbitGl/BasicPageFaultsTrack.h
+++ b/src/OrbitGl/BasicPageFaultsTrack.h
@@ -25,8 +25,7 @@ class BasicPageFaultsTrack : public LineGraphTrack<kBasicPageFaultsTrackDimensio
   explicit BasicPageFaultsTrack(Track* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
                                 TimeGraphLayout* layout, const std::string& name,
                                 const std::string& cgroup_name, uint64_t memory_sampling_period_ms,
-                                const orbit_client_model::CaptureData* capture_data,
-                                uint32_t indentation_level = 0);
+                                const orbit_client_model::CaptureData* capture_data);
 
   [[nodiscard]] Track* GetParent() const override { return parent_; }
   // For subtracks there is no meaningful type and it should also not be exposed, though we use the
@@ -39,7 +38,7 @@ class BasicPageFaultsTrack : public LineGraphTrack<kBasicPageFaultsTrackDimensio
       uint64_t timestamp_ns, const std::array<double, kBasicPageFaultsTrackDimension>& values);
 
   void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-            PickingMode picking_mode, float z_offset = 0) override;
+            PickingMode picking_mode, uint32_t indentation_level, float z_offset = 0) override;
 
   enum class SeriesIndex { kProcess = 0, kCGroup = 1, kSystem = 2 };
 
@@ -62,7 +61,9 @@ class BasicPageFaultsTrack : public LineGraphTrack<kBasicPageFaultsTrackDimensio
   [[nodiscard]] float GetAnnotatedTrackContentHeight() const override;
   [[nodiscard]] Vec2 GetAnnotatedTrackPosition() const override { return pos_; };
   [[nodiscard]] Vec2 GetAnnotatedTrackSize() const override { return size_; };
-  [[nodiscard]] uint32_t GetAnnotationFontSize() const override { return GetLegendFontSize(); }
+  [[nodiscard]] uint32_t GetAnnotationFontSize(int indentation_level) const override {
+    return GetLegendFontSize(indentation_level);
+  }
 
   Track* parent_;
   std::optional<std::pair<uint64_t, std::array<double, kBasicPageFaultsTrackDimension>>>

--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -48,10 +48,8 @@ std::string CallstackThreadBar::GetTooltip() const {
 }
 
 void CallstackThreadBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
-                              uint64_t current_mouse_time_ns, PickingMode picking_mode,
-                              uint32_t indentation_level, float z_offset) {
-  ThreadBar::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, indentation_level,
-                  z_offset);
+                              const DrawContext& draw_context) {
+  ThreadBar::Draw(batcher, text_renderer, draw_context);
 
   if (thread_id_ == orbit_base::kAllThreadsOfAllProcessesTid) {
     return;
@@ -61,9 +59,10 @@ void CallstackThreadBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
   // have a tooltip. For picking, we want to draw the event bar over them if
   // handling a click, and underneath otherwise.
   // This simulates "click-through" behavior.
-  float event_bar_z = picking_mode == PickingMode::kClick ? GlCanvas::kZValueEventBarPicking
-                                                          : GlCanvas::kZValueEventBar;
-  event_bar_z += z_offset;
+  float event_bar_z = draw_context.picking_mode == PickingMode::kClick
+                          ? GlCanvas::kZValueEventBarPicking
+                          : GlCanvas::kZValueEventBar;
+  event_bar_z += draw_context.z_offset;
   Color color = color_;
   Box box(pos_, Vec2(size_[0], -size_[1]), event_bar_z);
   batcher.AddBox(box, color, shared_from_this());
@@ -90,7 +89,8 @@ void CallstackThreadBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
     y1 = y0 - size_[1];
 
     Color picked_color(0, 128, 255, 128);
-    Box picked_box(Vec2(x0, y0), Vec2(x1 - x0, -size_[1]), GlCanvas::kZValueUi + z_offset);
+    Box picked_box(Vec2(x0, y0), Vec2(x1 - x0, -size_[1]),
+                   GlCanvas::kZValueUi + draw_context.z_offset);
     batcher.AddBox(picked_box, picked_color, shared_from_this());
   }
 }

--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -49,8 +49,9 @@ std::string CallstackThreadBar::GetTooltip() const {
 
 void CallstackThreadBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
                               uint64_t current_mouse_time_ns, PickingMode picking_mode,
-                              float z_offset) {
-  ThreadBar::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, z_offset);
+                              uint32_t indentation_level, float z_offset) {
+  ThreadBar::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, indentation_level,
+                  z_offset);
 
   if (thread_id_ == orbit_base::kAllThreadsOfAllProcessesTid) {
     return;

--- a/src/OrbitGl/CallstackThreadBar.h
+++ b/src/OrbitGl/CallstackThreadBar.h
@@ -31,8 +31,8 @@ class CallstackThreadBar : public ThreadBar {
 
   std::string GetTooltip() const override;
 
-  void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-            PickingMode picking_mode, uint32_t indentation_level, float z_offset = 0) override;
+  void Draw(Batcher& batcher, TextRenderer& text_renderer,
+            const DrawContext& draw_context) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;
 

--- a/src/OrbitGl/CallstackThreadBar.h
+++ b/src/OrbitGl/CallstackThreadBar.h
@@ -32,7 +32,7 @@ class CallstackThreadBar : public ThreadBar {
   std::string GetTooltip() const override;
 
   void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-            PickingMode picking_mode, float z_offset = 0) override;
+            PickingMode picking_mode, uint32_t indentation_level, float z_offset = 0) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;
 

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -24,7 +24,7 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
                               orbit_gl::Viewport* viewport, TimeGraphLayout* layout);
   virtual void Draw(Batcher& /*batcher*/, TextRenderer& /*text_renderer*/,
                     uint64_t /*current_mouse_time_ns*/, PickingMode /*picking_mode*/,
-                    float /*z_offset*/ = 0) {}
+                    uint32_t /*indentation_level*/ = 0, float /*z_offset*/ = 0) {}
 
   virtual void UpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/, uint64_t /*max_tick*/,
                                 PickingMode /*picking_mode*/, float /*z_offset*/ = 0){};

--- a/src/OrbitGl/CaptureViewElement.h
+++ b/src/OrbitGl/CaptureViewElement.h
@@ -22,9 +22,28 @@ class CaptureViewElement : public Pickable, public AccessibleInterfaceProvider {
  public:
   explicit CaptureViewElement(CaptureViewElement* parent, TimeGraph* time_graph,
                               orbit_gl::Viewport* viewport, TimeGraphLayout* layout);
+
+  struct DrawContext {
+    constexpr const static uint32_t kMaxIndentationLevel = 5;
+    uint64_t current_mouse_time_ns;
+    PickingMode picking_mode;
+    uint32_t indentation_level;
+    float z_offset = 0;
+
+    [[nodiscard]] DrawContext IncreasedIndentationLevel() const {
+      auto copy = *this;
+      copy.indentation_level = std::min(kMaxIndentationLevel, copy.indentation_level + 1);
+      return copy;
+    };
+
+    [[nodiscard]] DrawContext UpdatedZOffset(float z_offset) const {
+      auto copy = *this;
+      copy.z_offset = z_offset;
+      return copy;
+    }
+  };
   virtual void Draw(Batcher& /*batcher*/, TextRenderer& /*text_renderer*/,
-                    uint64_t /*current_mouse_time_ns*/, PickingMode /*picking_mode*/,
-                    uint32_t /*indentation_level*/ = 0, float /*z_offset*/ = 0) {}
+                    const DrawContext& /*draw_context*/) {}
 
   virtual void UpdatePrimitives(Batcher* /*batcher*/, uint64_t /*min_tick*/, uint64_t /*max_tick*/,
                                 PickingMode /*picking_mode*/, float /*z_offset*/ = 0){};

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -19,6 +19,7 @@
 
 #include "AccessibleTimeGraph.h"
 #include "App.h"
+#include "CaptureViewElement.h"
 #include "ClientData/CallstackData.h"
 #include "ClientModel/CaptureData.h"
 #include "CoreMath.h"
@@ -396,8 +397,8 @@ void CaptureWindow::Draw(bool viewport_was_dirty) {
     }
     uint64_t timegraph_current_mouse_time_ns =
         time_graph_->GetTickFromWorld(viewport_.ScreenToWorldPos(GetMouseScreenPos())[0]);
-    time_graph_->Draw(GetBatcher(), GetTextRenderer(), timegraph_current_mouse_time_ns,
-                      picking_mode_, 0);
+    time_graph_->Draw(GetBatcher(), GetTextRenderer(),
+                      {timegraph_current_mouse_time_ns, picking_mode_, 0, 0});
     viewport_.SetWorldExtents(viewport_.GetScreenWidth(),
                               time_graph_->GetTrackManager()->GetTracksTotalHeight());
   }

--- a/src/OrbitGl/CaptureWindow.cpp
+++ b/src/OrbitGl/CaptureWindow.cpp
@@ -397,7 +397,7 @@ void CaptureWindow::Draw(bool viewport_was_dirty) {
     uint64_t timegraph_current_mouse_time_ns =
         time_graph_->GetTickFromWorld(viewport_.ScreenToWorldPos(GetMouseScreenPos())[0]);
     time_graph_->Draw(GetBatcher(), GetTextRenderer(), timegraph_current_mouse_time_ns,
-                      picking_mode_);
+                      picking_mode_, 0);
     viewport_.SetWorldExtents(viewport_.GetScreenWidth(),
                               time_graph_->GetTrackManager()->GetTracksTotalHeight());
   }

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -52,7 +52,7 @@ float FrameTrack::GetMaximumBoxHeight() const {
   if (scale_factor == 0.f) {
     return 0.f;
   }
-  return scale_factor * box_height_ / box_height_normalizer;
+  return scale_factor * GetDefaultBoxHeight() / box_height_normalizer;
 }
 
 float FrameTrack::GetAverageBoxHeight() const {
@@ -62,7 +62,7 @@ float FrameTrack::GetAverageBoxHeight() const {
   if (scale_factor == 0.f) {
     return 0.f;
   }
-  return box_height_ / box_height_normalizer;
+  return GetDefaultBoxHeight() / box_height_normalizer;
 }
 
 FrameTrack::FrameTrack(CaptureViewElement* parent, TimeGraph* time_graph,
@@ -90,7 +90,11 @@ float FrameTrack::GetYFromTimer(const TimerInfo& /*timer_info*/) const {
   return pos_[1] - GetHeaderHeight() - GetMaximumBoxHeight();
 }
 
-float FrameTrack::GetBoxHeight(const TimerInfo& timer_info) const {
+float FrameTrack::GetDefaultBoxHeight() const {
+  return kBoxHeightMultiplier * layout_->GetTextBoxHeight();
+}
+
+float FrameTrack::GetDynamicBoxHeight(const TimerInfo& timer_info) const {
   uint64_t timer_duration_ns = timer_info.end() - timer_info.start();
   if (stats_.average_time_ns() == 0) {
     return 0.f;
@@ -242,8 +246,4 @@ void FrameTrack::Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t cu
   text_renderer.AddText(label.c_str(), white_text_box_position[0],
                         white_text_box_position[1] + layout_->GetTextOffset(), text_z, kWhiteColor,
                         font_size, white_text_box_size[0]);
-}
-
-void FrameTrack::UpdateBoxHeight() {
-  box_height_ = kBoxHeightMultiplier * layout_->GetTextBoxHeight();
 }

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -68,8 +68,8 @@ float FrameTrack::GetAverageBoxHeight() const {
 FrameTrack::FrameTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                        orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                        InstrumentedFunction function, OrbitApp* app,
-                       const CaptureData* capture_data, uint32_t indentation_level)
-    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data, indentation_level),
+                       const CaptureData* capture_data)
+    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data),
       function_(std::move(function)) {
   // TODO(b/169554463): Support manual instrumentation.
   std::string name = absl::StrFormat("Frame track based on %s", function_.function_name());
@@ -218,8 +218,9 @@ std::string FrameTrack::GetBoxTooltip(const Batcher& batcher, PickingId id) cons
 }
 
 void FrameTrack::Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-                      PickingMode picking_mode, float z_offset) {
-  TimerTrack::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, z_offset);
+                      PickingMode picking_mode, uint32_t indentation_level, float z_offset) {
+  TimerTrack::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, indentation_level,
+                   z_offset);
 
   const Color kWhiteColor(255, 255, 255, 255);
   const Color kBlackColor(0, 0, 0, 255);

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -217,10 +217,9 @@ std::string FrameTrack::GetBoxTooltip(const Batcher& batcher, PickingId id) cons
           TicksToDuration(timer_info->start(), timer_info->end())));
 }
 
-void FrameTrack::Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-                      PickingMode picking_mode, uint32_t indentation_level, float z_offset) {
-  TimerTrack::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, indentation_level,
-                   z_offset);
+void FrameTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
+                      const DrawContext& draw_context) {
+  TimerTrack::Draw(batcher, text_renderer, draw_context);
 
   const Color kWhiteColor(255, 255, 255, 255);
   const Color kBlackColor(0, 0, 0, 255);
@@ -229,7 +228,7 @@ void FrameTrack::Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t cu
   float x = pos_[0];
   Vec2 from(x, y);
   Vec2 to(x + size_[0], y);
-  float text_z = GlCanvas::kZValueTrackText + z_offset;
+  float text_z = GlCanvas::kZValueTrackText + draw_context.z_offset;
 
   std::string avg_time =
       orbit_display_formats::GetDisplayTime(absl::Nanoseconds(stats_.average_time_ns()));

--- a/src/OrbitGl/FrameTrack.h
+++ b/src/OrbitGl/FrameTrack.h
@@ -47,8 +47,8 @@ class FrameTrack : public TimerTrack {
   [[nodiscard]] std::string GetTooltip() const override;
   [[nodiscard]] std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const override;
 
-  void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-            PickingMode picking_mode, uint32_t indentation_level, float z_offset = 0) override;
+  void Draw(Batcher& batcher, TextRenderer& text_renderer,
+            const DrawContext& draw_context) override;
 
  protected:
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,

--- a/src/OrbitGl/FrameTrack.h
+++ b/src/OrbitGl/FrameTrack.h
@@ -31,7 +31,9 @@ class FrameTrack : public TimerTrack {
 
   [[nodiscard]] Type GetType() const override { return Type::kFrameTrack; }
   [[nodiscard]] uint64_t GetFunctionId() const { return function_.function_id(); }
-  [[nodiscard]] bool IsCollapsible() const override { return GetMaximumScaleFactor() > 0.f; }
+  [[nodiscard]] bool IsCollapsible() const override {
+    return GetCappedMaximumToAverageRatio() > 0.f;
+  }
 
   [[nodiscard]] float GetYFromTimer(
       const orbit_client_protos::TimerInfo& timer_info) const override;
@@ -56,7 +58,7 @@ class FrameTrack : public TimerTrack {
   [[nodiscard]] float GetHeight() const override;
 
  private:
-  [[nodiscard]] float GetMaximumScaleFactor() const;
+  [[nodiscard]] float GetCappedMaximumToAverageRatio() const;
   [[nodiscard]] float GetMaximumBoxHeight() const;
   [[nodiscard]] float GetAverageBoxHeight() const;
 

--- a/src/OrbitGl/FrameTrack.h
+++ b/src/OrbitGl/FrameTrack.h
@@ -27,8 +27,7 @@ class FrameTrack : public TimerTrack {
   explicit FrameTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                       orbit_grpc_protos::InstrumentedFunction function, OrbitApp* app,
-                      const orbit_client_model::CaptureData* capture_data,
-                      uint32_t indentation_level = 0);
+                      const orbit_client_model::CaptureData* capture_data);
 
   [[nodiscard]] Type GetType() const override { return Type::kFrameTrack; }
   [[nodiscard]] uint64_t GetFunctionId() const { return function_.function_id(); }
@@ -49,7 +48,7 @@ class FrameTrack : public TimerTrack {
   [[nodiscard]] std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const override;
 
   void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-            PickingMode picking_mode, float z_offset = 0) override;
+            PickingMode picking_mode, uint32_t indentation_level, float z_offset = 0) override;
 
  protected:
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,

--- a/src/OrbitGl/FrameTrack.h
+++ b/src/OrbitGl/FrameTrack.h
@@ -38,7 +38,9 @@ class FrameTrack : public TimerTrack {
       const orbit_client_protos::TimerInfo& timer_info) const override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
 
-  [[nodiscard]] float GetBoxHeight(const orbit_client_protos::TimerInfo& timer_info) const override;
+  [[nodiscard]] float GetDefaultBoxHeight() const override;
+  [[nodiscard]] float GetDynamicBoxHeight(
+      const orbit_client_protos::TimerInfo& timer_info) const override;
   [[nodiscard]] float GetHeaderHeight() const override;
 
   [[nodiscard]] std::string GetTimesliceText(
@@ -48,8 +50,6 @@ class FrameTrack : public TimerTrack {
 
   void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
             PickingMode picking_mode, float z_offset = 0) override;
-
-  void UpdateBoxHeight() override;
 
  protected:
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,

--- a/src/OrbitGl/GpuDebugMarkerTrack.cpp
+++ b/src/OrbitGl/GpuDebugMarkerTrack.cpp
@@ -27,9 +27,8 @@ using orbit_client_protos::TimerInfo;
 GpuDebugMarkerTrack::GpuDebugMarkerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                                          orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                                          OrbitApp* app,
-                                         const orbit_client_model::CaptureData* capture_data,
-                                         uint32_t indentation_level)
-    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data, indentation_level) {
+                                         const orbit_client_model::CaptureData* capture_data)
+    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data) {
   SetLabel("Debug Markers");
   draw_background_ = false;
   string_manager_ = app->GetStringManager();

--- a/src/OrbitGl/GpuDebugMarkerTrack.h
+++ b/src/OrbitGl/GpuDebugMarkerTrack.h
@@ -28,8 +28,7 @@ class GpuDebugMarkerTrack : public TimerTrack {
  public:
   explicit GpuDebugMarkerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                                orbit_gl::Viewport* viewport, TimeGraphLayout* layout, OrbitApp* app,
-                               const orbit_client_model::CaptureData* capture_data,
-                               uint32_t indentation_level);
+                               const orbit_client_model::CaptureData* capture_data);
 
   ~GpuDebugMarkerTrack() override = default;
 

--- a/src/OrbitGl/GpuSubmissionTrack.cpp
+++ b/src/OrbitGl/GpuSubmissionTrack.cpp
@@ -32,9 +32,8 @@ constexpr const char* kCmdBufferString = "command buffer";
 GpuSubmissionTrack::GpuSubmissionTrack(Track* parent, TimeGraph* time_graph,
                                        orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                                        uint64_t timeline_hash, OrbitApp* app,
-                                       const orbit_client_model::CaptureData* capture_data,
-                                       uint32_t indentation_level)
-    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data, indentation_level) {
+                                       const orbit_client_model::CaptureData* capture_data)
+    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data) {
   SetLabel("Submissions");
   draw_background_ = false;
   text_renderer_ = time_graph->GetTextRenderer();

--- a/src/OrbitGl/GpuSubmissionTrack.h
+++ b/src/OrbitGl/GpuSubmissionTrack.h
@@ -31,8 +31,7 @@ class GpuSubmissionTrack : public TimerTrack {
  public:
   explicit GpuSubmissionTrack(Track* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
                               TimeGraphLayout* layout, uint64_t timeline_hash, OrbitApp* app,
-                              const orbit_client_model::CaptureData* capture_data,
-                              uint32_t indentation_level);
+                              const orbit_client_model::CaptureData* capture_data);
   ~GpuSubmissionTrack() override = default;
 
   [[nodiscard]] Track* GetParent() const override { return parent_; }

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -121,8 +121,8 @@ float GpuTrack::GetHeight() const {
   return height;
 }
 
-void GpuTrack::Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-                    PickingMode picking_mode, uint32_t indentation_level, float z_offset) {
+void GpuTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
+                    const DrawContext& draw_context) {
   UpdatePositionOfSubtracks();
   // If being collapsed, the gpu track will show a collapsed version of the submission subtrack.
   // Hence, the height of submission subtrack should always be updated as long as the subtrack is
@@ -131,22 +131,19 @@ void GpuTrack::Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t curr
     submission_track_->SetSize(size_[0], submission_track_->GetHeight());
   }
 
-  Track::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, indentation_level,
-              z_offset);
+  Track::Draw(batcher, text_renderer, draw_context);
 
   if (collapse_toggle_->IsCollapsed()) {
     return;
   }
-
+  const DrawContext sub_track_draw_context = draw_context.IncreasedIndentationLevel();
   if (!submission_track_->IsEmpty()) {
-    submission_track_->Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode,
-                            indentation_level + 1, z_offset);
+    submission_track_->Draw(batcher, text_renderer, sub_track_draw_context);
   }
 
   if (!marker_track_->IsEmpty()) {
     marker_track_->SetSize(size_[0], marker_track_->GetHeight());
-    marker_track_->Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode,
-                        indentation_level + 1, z_offset);
+    marker_track_->Draw(batcher, text_renderer, sub_track_draw_context);
   }
 }
 

--- a/src/OrbitGl/GpuTrack.h
+++ b/src/OrbitGl/GpuTrack.h
@@ -56,8 +56,8 @@ class GpuTrack : public Track {
   [[nodiscard]] std::string GetTooltip() const override;
   [[nodiscard]] float GetHeight() const override;
 
-  void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-            PickingMode picking_mode, uint32_t indentation_level = 0, float z_offset = 0) override;
+  void Draw(Batcher& batcher, TextRenderer& text_renderer,
+            const DrawContext& draw_context) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;
   [[nodiscard]] std::vector<CaptureViewElement*> GetVisibleChildren() override;

--- a/src/OrbitGl/GpuTrack.h
+++ b/src/OrbitGl/GpuTrack.h
@@ -39,8 +39,7 @@ class GpuTrack : public Track {
  public:
   explicit GpuTrack(CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
                     TimeGraphLayout* layout, uint64_t timeline_hash, OrbitApp* app,
-                    const orbit_client_model::CaptureData* capture_data,
-                    uint32_t indentation_level = 0);
+                    const orbit_client_model::CaptureData* capture_data);
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
 
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetLeft(
@@ -58,7 +57,7 @@ class GpuTrack : public Track {
   [[nodiscard]] float GetHeight() const override;
 
   void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-            PickingMode picking_mode, float z_offset = 0) override;
+            PickingMode picking_mode, uint32_t indentation_level = 0, float z_offset = 0) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;
   [[nodiscard]] std::vector<CaptureViewElement*> GetVisibleChildren() override;

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -36,8 +36,8 @@ class GraphTrack : public Track {
   [[nodiscard]] bool IsCollapsible() const override { return true; }
   [[nodiscard]] bool IsEmpty() const override { return series_.IsEmpty(); }
 
-  void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-            PickingMode picking_mode, uint32_t indentation_level, float z_offset = 0) override;
+  void Draw(Batcher& batcher, TextRenderer& text_renderer,
+            const DrawContext& draw_context) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;
 
@@ -79,12 +79,13 @@ class GraphTrack : public Track {
       const std::array<double, Dimension>& values) const;
   [[nodiscard]] uint32_t GetLegendFontSize(uint32_t indentation_level = 0) const;
 
-  virtual void DrawLabel(Batcher& batcher, TextRenderer& text_renderer, Vec2 target_pos,
-                         const std::string& text, const Color& text_color, const Color& font_color,
-                         uint32_t indentation_level, float z);
+  virtual void DrawLabel(Batcher& batcher, TextRenderer& text_renderer,
+                         const DrawContext& draw_context, Vec2 target_pos, const std::string& text,
+                         const Color& text_color, const Color& font_color);
   virtual void DrawLegend(Batcher& batcher, TextRenderer& text_renderer,
+                          const DrawContext& draw_context,
                           const std::array<std::string, Dimension>& series_names,
-                          const Color& legend_text_color, uint32_t indentation_level, float z);
+                          const Color& legend_text_color);
   virtual void DrawSeries(Batcher* batcher, uint64_t min_tick, uint64_t max_tick, float z);
 
   [[nodiscard]] double RoundPrecision(double value) {

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -24,8 +24,7 @@ class GraphTrack : public Track {
   explicit GraphTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                       const std::string& name, std::array<std::string, Dimension> series_names,
-                      const orbit_client_model::CaptureData* capture_data,
-                      uint32_t indentation_level = 0);
+                      const orbit_client_model::CaptureData* capture_data);
 
   [[nodiscard]] Type GetType() const override { return Type::kGraphTrack; }
   [[nodiscard]] float GetHeight() const override;
@@ -38,7 +37,7 @@ class GraphTrack : public Track {
   [[nodiscard]] bool IsEmpty() const override { return series_.IsEmpty(); }
 
   void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-            PickingMode picking_mode, float z_offset = 0) override;
+            PickingMode picking_mode, uint32_t indentation_level, float z_offset = 0) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;
 
@@ -78,14 +77,14 @@ class GraphTrack : public Track {
       const std::array<double, Dimension>& values) const;
   [[nodiscard]] virtual std::string GetLabelTextFromValues(
       const std::array<double, Dimension>& values) const;
-  [[nodiscard]] uint32_t GetLegendFontSize() const;
+  [[nodiscard]] uint32_t GetLegendFontSize(uint32_t indentation_level = 0) const;
 
   virtual void DrawLabel(Batcher& batcher, TextRenderer& text_renderer, Vec2 target_pos,
                          const std::string& text, const Color& text_color, const Color& font_color,
-                         float z);
+                         uint32_t indentation_level, float z);
   virtual void DrawLegend(Batcher& batcher, TextRenderer& text_renderer,
                           const std::array<std::string, Dimension>& series_names,
-                          const Color& legend_text_color, float z);
+                          const Color& legend_text_color, uint32_t indentation_level, float z);
   virtual void DrawSeries(Batcher* batcher, uint64_t min_tick, uint64_t max_tick, float z);
 
   [[nodiscard]] double RoundPrecision(double value) {

--- a/src/OrbitGl/LineGraphTrack.h
+++ b/src/OrbitGl/LineGraphTrack.h
@@ -20,10 +20,9 @@ class LineGraphTrack : public GraphTrack<Dimension> {
   explicit LineGraphTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                           orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                           const std::string& name, std::array<std::string, Dimension> series_names,
-                          const orbit_client_model::CaptureData* capture_data,
-                          uint32_t indentation_level = 0)
+                          const orbit_client_model::CaptureData* capture_data)
       : GraphTrack<Dimension>(parent, time_graph, viewport, layout, name, series_names,
-                              capture_data, indentation_level) {}
+                              capture_data) {}
   ~LineGraphTrack() override = default;
 
  protected:

--- a/src/OrbitGl/MajorPageFaultsTrack.cpp
+++ b/src/OrbitGl/MajorPageFaultsTrack.cpp
@@ -11,10 +11,9 @@ MajorPageFaultsTrack::MajorPageFaultsTrack(Track* parent, TimeGraph* time_graph,
                                            orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                                            const std::string& cgroup_name,
                                            uint64_t memory_sampling_period_ms,
-                                           const orbit_client_model::CaptureData* capture_data,
-                                           uint32_t indentation_level)
+                                           const orbit_client_model::CaptureData* capture_data)
     : BasicPageFaultsTrack(parent, time_graph, viewport, layout, "Page Faults: Major", cgroup_name,
-                           memory_sampling_period_ms, capture_data, indentation_level) {
+                           memory_sampling_period_ms, capture_data) {
   index_of_series_to_highlight_ = static_cast<size_t>(SeriesIndex::kProcess);
 }
 

--- a/src/OrbitGl/MajorPageFaultsTrack.h
+++ b/src/OrbitGl/MajorPageFaultsTrack.h
@@ -17,8 +17,7 @@ class MajorPageFaultsTrack final : public BasicPageFaultsTrack {
   explicit MajorPageFaultsTrack(Track* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
                                 TimeGraphLayout* layout, const std::string& cgroup_name,
                                 uint64_t memory_sampling_period_ms,
-                                const orbit_client_model::CaptureData* capture_data,
-                                uint32_t indentation_level = 0);
+                                const orbit_client_model::CaptureData* capture_data);
 
   [[nodiscard]] std::string GetTooltip() const override;
 

--- a/src/OrbitGl/MemoryTrack.cpp
+++ b/src/OrbitGl/MemoryTrack.cpp
@@ -14,12 +14,12 @@ namespace orbit_gl {
 template <size_t Dimension>
 void MemoryTrack<Dimension>::Draw(Batcher& batcher, TextRenderer& text_renderer,
                                   uint64_t current_mouse_time_ns, PickingMode picking_mode,
-                                  float z_offset) {
+                                  uint32_t indentation_level, float z_offset) {
   GraphTrack<Dimension>::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode,
-                              z_offset);
+                              indentation_level, z_offset);
 
   if (this->collapse_toggle_->IsCollapsed()) return;
-  AnnotationTrack::DrawAnnotation(batcher, text_renderer, this->layout_,
+  AnnotationTrack::DrawAnnotation(batcher, text_renderer, this->layout_, indentation_level,
                                   GlCanvas::kZValueTrackText + z_offset);
 }
 

--- a/src/OrbitGl/MemoryTrack.cpp
+++ b/src/OrbitGl/MemoryTrack.cpp
@@ -13,14 +13,13 @@ namespace orbit_gl {
 
 template <size_t Dimension>
 void MemoryTrack<Dimension>::Draw(Batcher& batcher, TextRenderer& text_renderer,
-                                  uint64_t current_mouse_time_ns, PickingMode picking_mode,
-                                  uint32_t indentation_level, float z_offset) {
-  GraphTrack<Dimension>::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode,
-                              indentation_level, z_offset);
+                                  const CaptureViewElement::DrawContext& draw_context) {
+  GraphTrack<Dimension>::Draw(batcher, text_renderer, draw_context);
 
   if (this->collapse_toggle_->IsCollapsed()) return;
-  AnnotationTrack::DrawAnnotation(batcher, text_renderer, this->layout_, indentation_level,
-                                  GlCanvas::kZValueTrackText + z_offset);
+  AnnotationTrack::DrawAnnotation(batcher, text_renderer, this->layout_,
+                                  draw_context.indentation_level,
+                                  GlCanvas::kZValueTrackText + draw_context.z_offset);
 }
 
 template <size_t Dimension>

--- a/src/OrbitGl/MemoryTrack.h
+++ b/src/OrbitGl/MemoryTrack.h
@@ -31,7 +31,7 @@ class MemoryTrack : public GraphTrack<Dimension>, public AnnotationTrack {
   ~MemoryTrack() override = default;
   [[nodiscard]] Track::Type GetType() const override { return Track::Type::kMemoryTrack; }
   void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-            PickingMode picking_mode, float z_offset = 0) override;
+            PickingMode picking_mode, uint32_t indentation_level, float z_offset = 0) override;
 
   void TrySetValueUpperBound(const std::string& pretty_label, double raw_value);
   void TrySetValueLowerBound(const std::string& pretty_label, double raw_value);
@@ -46,8 +46,8 @@ class MemoryTrack : public GraphTrack<Dimension>, public AnnotationTrack {
   }
   [[nodiscard]] Vec2 GetAnnotatedTrackPosition() const override { return this->pos_; };
   [[nodiscard]] Vec2 GetAnnotatedTrackSize() const override { return this->size_; };
-  [[nodiscard]] uint32_t GetAnnotationFontSize() const override {
-    return this->GetLegendFontSize();
+  [[nodiscard]] uint32_t GetAnnotationFontSize(int indentation_level) const override {
+    return this->GetLegendFontSize(indentation_level);
   }
 };
 

--- a/src/OrbitGl/MemoryTrack.h
+++ b/src/OrbitGl/MemoryTrack.h
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "AnnotationTrack.h"
+#include "CaptureViewElement.h"
 #include "GraphTrack.h"
 #include "Track.h"
 #include "Viewport.h"
@@ -30,8 +31,8 @@ class MemoryTrack : public GraphTrack<Dimension>, public AnnotationTrack {
   }
   ~MemoryTrack() override = default;
   [[nodiscard]] Track::Type GetType() const override { return Track::Type::kMemoryTrack; }
-  void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-            PickingMode picking_mode, uint32_t indentation_level, float z_offset = 0) override;
+  void Draw(Batcher& batcher, TextRenderer& text_renderer,
+            const CaptureViewElement::DrawContext& draw_context) override;
 
   void TrySetValueUpperBound(const std::string& pretty_label, double raw_value);
   void TrySetValueLowerBound(const std::string& pretty_label, double raw_value);

--- a/src/OrbitGl/MinorPageFaultsTrack.h
+++ b/src/OrbitGl/MinorPageFaultsTrack.h
@@ -17,11 +17,9 @@ class MinorPageFaultsTrack final : public BasicPageFaultsTrack {
   explicit MinorPageFaultsTrack(Track* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
                                 TimeGraphLayout* layout, const std::string& cgroup_name,
                                 uint64_t memory_sampling_period_ms,
-                                const orbit_client_model::CaptureData* capture_data,
-                                uint32_t indentation_level = 0)
+                                const orbit_client_model::CaptureData* capture_data)
       : BasicPageFaultsTrack(parent, time_graph, viewport, layout, "Page Faults: Minor",
-                             cgroup_name, memory_sampling_period_ms, capture_data,
-                             indentation_level) {}
+                             cgroup_name, memory_sampling_period_ms, capture_data) {}
 
   [[nodiscard]] std::string GetTooltip() const override;
 

--- a/src/OrbitGl/PageFaultsTrack.cpp
+++ b/src/OrbitGl/PageFaultsTrack.cpp
@@ -23,15 +23,14 @@ using orbit_grpc_protos::kMissingInfo;
 PageFaultsTrack::PageFaultsTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                                  orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                                  const std::string& cgroup_name, uint64_t memory_sampling_period_ms,
-                                 const orbit_client_model::CaptureData* capture_data,
-                                 uint32_t indentation_level)
-    : Track(parent, time_graph, viewport, layout, capture_data, indentation_level),
-      major_page_faults_track_{std::make_shared<MajorPageFaultsTrack>(
-          this, time_graph, viewport, layout, cgroup_name, memory_sampling_period_ms, capture_data,
-          indentation_level + 1)},
-      minor_page_faults_track_{std::make_shared<MinorPageFaultsTrack>(
-          this, time_graph, viewport, layout, cgroup_name, memory_sampling_period_ms, capture_data,
-          indentation_level + 1)} {
+                                 const orbit_client_model::CaptureData* capture_data)
+    : Track(parent, time_graph, viewport, layout, capture_data),
+      major_page_faults_track_{
+          std::make_shared<MajorPageFaultsTrack>(this, time_graph, viewport, layout, cgroup_name,
+                                                 memory_sampling_period_ms, capture_data)},
+      minor_page_faults_track_{
+          std::make_shared<MinorPageFaultsTrack>(this, time_graph, viewport, layout, cgroup_name,
+                                                 memory_sampling_period_ms, capture_data)} {
   const std::string kTrackName = "Page Faults";
   SetName(kTrackName);
   SetLabel(kTrackName);
@@ -72,7 +71,7 @@ std::string PageFaultsTrack::GetTooltip() const {
 
 void PageFaultsTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
                            uint64_t current_mouse_time_ns, PickingMode picking_mode,
-                           float z_offset) {
+                           uint32_t indentation_level, float z_offset) {
   SetLabel(collapse_toggle_->IsCollapsed() ? major_page_faults_track_->GetName() : GetName());
 
   UpdatePositionOfSubtracks();
@@ -83,19 +82,20 @@ void PageFaultsTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
     major_page_faults_track_->SetSize(size_[0], major_page_faults_track_->GetHeight());
   }
 
-  Track::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, z_offset);
+  Track::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, indentation_level,
+              z_offset);
 
   if (collapse_toggle_->IsCollapsed()) return;
 
   if (!major_page_faults_track_->IsEmpty()) {
     major_page_faults_track_->Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode,
-                                   z_offset);
+                                   indentation_level + 1, z_offset);
   }
 
   if (!minor_page_faults_track_->IsEmpty()) {
     minor_page_faults_track_->SetSize(size_[0], minor_page_faults_track_->GetHeight());
     minor_page_faults_track_->Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode,
-                                   z_offset);
+                                   indentation_level + 1, z_offset);
   }
 }
 

--- a/src/OrbitGl/PageFaultsTrack.cpp
+++ b/src/OrbitGl/PageFaultsTrack.cpp
@@ -70,8 +70,7 @@ std::string PageFaultsTrack::GetTooltip() const {
 }
 
 void PageFaultsTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
-                           uint64_t current_mouse_time_ns, PickingMode picking_mode,
-                           uint32_t indentation_level, float z_offset) {
+                           const DrawContext& draw_context) {
   SetLabel(collapse_toggle_->IsCollapsed() ? major_page_faults_track_->GetName() : GetName());
 
   UpdatePositionOfSubtracks();
@@ -82,20 +81,18 @@ void PageFaultsTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
     major_page_faults_track_->SetSize(size_[0], major_page_faults_track_->GetHeight());
   }
 
-  Track::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, indentation_level,
-              z_offset);
+  Track::Draw(batcher, text_renderer, draw_context);
 
   if (collapse_toggle_->IsCollapsed()) return;
 
+  const DrawContext sub_track_draw_context = draw_context.IncreasedIndentationLevel();
   if (!major_page_faults_track_->IsEmpty()) {
-    major_page_faults_track_->Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode,
-                                   indentation_level + 1, z_offset);
+    major_page_faults_track_->Draw(batcher, text_renderer, sub_track_draw_context);
   }
 
   if (!minor_page_faults_track_->IsEmpty()) {
     minor_page_faults_track_->SetSize(size_[0], minor_page_faults_track_->GetHeight());
-    minor_page_faults_track_->Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode,
-                                   indentation_level + 1, z_offset);
+    minor_page_faults_track_->Draw(batcher, text_renderer, sub_track_draw_context);
   }
 }
 

--- a/src/OrbitGl/PageFaultsTrack.h
+++ b/src/OrbitGl/PageFaultsTrack.h
@@ -34,8 +34,8 @@ class PageFaultsTrack : public Track {
   }
   [[nodiscard]] bool IsCollapsible() const override { return true; }
 
-  void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-            PickingMode picking_mode, uint32_t indentation_level, float z_offset = 0) override;
+  void Draw(Batcher& batcher, TextRenderer& text_renderer,
+            const DrawContext& draw_context) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;
 

--- a/src/OrbitGl/PageFaultsTrack.h
+++ b/src/OrbitGl/PageFaultsTrack.h
@@ -22,8 +22,7 @@ class PageFaultsTrack : public Track {
   explicit PageFaultsTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                            orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                            const std::string& cgroup_name, uint64_t memory_sampling_period_ms,
-                           const orbit_client_model::CaptureData* capture_data,
-                           uint32_t indentation_level = 0);
+                           const orbit_client_model::CaptureData* capture_data);
 
   [[nodiscard]] Type GetType() const override { return Type::kPageFaultsTrack; }
   [[nodiscard]] float GetHeight() const override;
@@ -36,7 +35,7 @@ class PageFaultsTrack : public Track {
   [[nodiscard]] bool IsCollapsible() const override { return true; }
 
   void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-            PickingMode picking_mode, float z_offset = 0) override;
+            PickingMode picking_mode, uint32_t indentation_level, float z_offset = 0) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;
 

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -24,9 +24,8 @@ const Color kSelectionColor(0, 128, 255, 255);
 
 SchedulerTrack::SchedulerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                                orbit_gl::Viewport* viewport, TimeGraphLayout* layout, OrbitApp* app,
-                               const orbit_client_model::CaptureData* capture_data,
-                               uint32_t indentation_level)
-    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data, indentation_level) {
+                               const orbit_client_model::CaptureData* capture_data)
+    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data) {
   SetPinned(false);
   SetName("Scheduler");
   SetLabel("Scheduler (0 cores)");

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -82,8 +82,6 @@ std::string SchedulerTrack::GetTooltip() const {
   return "Shows scheduling information for CPU cores";
 }
 
-void SchedulerTrack::UpdateBoxHeight() { box_height_ = layout_->GetTextCoresHeight(); }
-
 std::string SchedulerTrack::GetBoxTooltip(const Batcher& batcher, PickingId id) const {
   const orbit_client_protos::TimerInfo* timer_info = batcher.GetTimerInfo(id);
   if (!timer_info) {

--- a/src/OrbitGl/SchedulerTrack.h
+++ b/src/OrbitGl/SchedulerTrack.h
@@ -21,8 +21,7 @@ class SchedulerTrack final : public TimerTrack {
  public:
   explicit SchedulerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                           orbit_gl::Viewport* viewport, TimeGraphLayout* layout, OrbitApp* app,
-                          const orbit_client_model::CaptureData* capture_data,
-                          uint32_t indentation_level = 0);
+                          const orbit_client_model::CaptureData* capture_data);
   ~SchedulerTrack() override = default;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
 

--- a/src/OrbitGl/SchedulerTrack.h
+++ b/src/OrbitGl/SchedulerTrack.h
@@ -32,7 +32,7 @@ class SchedulerTrack final : public TimerTrack {
   [[nodiscard]] float GetHeight() const override;
   [[nodiscard]] bool IsCollapsible() const override { return false; }
 
-  void UpdateBoxHeight() override;
+  [[nodiscard]] float GetDefaultBoxHeight() const override { return layout_->GetTextCoresHeight(); }
   [[nodiscard]] float GetYFromTimer(
       const orbit_client_protos::TimerInfo& timer_info) const override;
 

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -37,17 +37,16 @@ bool ThreadStateBar::IsEmpty() const {
 }
 
 void ThreadStateBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
-                          uint64_t current_mouse_time_ns, PickingMode picking_mode,
-                          uint32_t indentation_level, float z_offset) {
-  ThreadBar::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, indentation_level,
-                  z_offset);
+                          const DrawContext& draw_context) {
+  ThreadBar::Draw(batcher, text_renderer, draw_context);
 
   // Similarly to CallstackThreadBar::Draw, the thread state slices don't respond to clicks, but
   // have a tooltip. For picking, we want to draw the event bar over them if handling a click, and
   // underneath otherwise. This simulates "click-through" behavior.
-  float thread_state_bar_z = picking_mode == PickingMode::kClick ? GlCanvas::kZValueEventBarPicking
-                                                                 : GlCanvas::kZValueEventBar;
-  thread_state_bar_z += z_offset;
+  float thread_state_bar_z = draw_context.picking_mode == PickingMode::kClick
+                                 ? GlCanvas::kZValueEventBarPicking
+                                 : GlCanvas::kZValueEventBar;
+  thread_state_bar_z += draw_context.z_offset;
 
   // Draw a transparent track just for clicking.
   Box box(pos_, Vec2(size_[0], -size_[1]), thread_state_bar_z);

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -38,8 +38,9 @@ bool ThreadStateBar::IsEmpty() const {
 
 void ThreadStateBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
                           uint64_t current_mouse_time_ns, PickingMode picking_mode,
-                          float z_offset) {
-  ThreadBar::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, z_offset);
+                          uint32_t indentation_level, float z_offset) {
+  ThreadBar::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, indentation_level,
+                  z_offset);
 
   // Similarly to CallstackThreadBar::Draw, the thread state slices don't respond to clicks, but
   // have a tooltip. For picking, we want to draw the event bar over them if handling a click, and

--- a/src/OrbitGl/ThreadStateBar.h
+++ b/src/OrbitGl/ThreadStateBar.h
@@ -30,7 +30,7 @@ class ThreadStateBar final : public ThreadBar {
                           orbit_client_data::ThreadID thread_id);
 
   void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-            PickingMode picking_mode, float z_offset) override;
+            PickingMode picking_mode, uint32_t indentation_level, float z_offset) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset) override;
 

--- a/src/OrbitGl/ThreadStateBar.h
+++ b/src/OrbitGl/ThreadStateBar.h
@@ -29,8 +29,8 @@ class ThreadStateBar final : public ThreadBar {
                           const orbit_client_model::CaptureData* capture_data,
                           orbit_client_data::ThreadID thread_id);
 
-  void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-            PickingMode picking_mode, uint32_t indentation_level, float z_offset) override;
+  void Draw(Batcher& batcher, TextRenderer& text_renderer,
+            const DrawContext& draw_context) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset) override;
 

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -268,10 +268,8 @@ void ThreadTrack::UpdateMinMaxTimestamps() {
 }
 
 void ThreadTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
-                       uint64_t current_mouse_time_ns, PickingMode picking_mode,
-                       uint32_t indentation_level, float z_offset) {
-  TimerTrack::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, indentation_level,
-                   z_offset);
+                       const DrawContext& draw_context) {
+  TimerTrack::Draw(batcher, text_renderer, draw_context);
 
   UpdateMinMaxTimestamps();
   UpdatePositionOfSubtracks();
@@ -281,22 +279,21 @@ void ThreadTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
   const float tracepoint_track_height = layout_->GetEventTrackHeightFromTid(thread_id_);
   const float track_width = size_[0];
 
+  DrawContext inner_draw_context = draw_context.IncreasedIndentationLevel();
+
   if (!thread_state_bar_->IsEmpty()) {
     thread_state_bar_->SetSize(track_width, thread_state_track_height);
-    thread_state_bar_->Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode,
-                            indentation_level + 1, z_offset);
+    thread_state_bar_->Draw(batcher, text_renderer, inner_draw_context);
   }
 
   if (!event_bar_->IsEmpty()) {
     event_bar_->SetSize(track_width, event_track_height);
-    event_bar_->Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode,
-                     indentation_level + 1, z_offset);
+    event_bar_->Draw(batcher, text_renderer, inner_draw_context);
   }
 
   if (!tracepoint_bar_->IsEmpty()) {
     tracepoint_bar_->SetSize(track_width, tracepoint_track_height);
-    tracepoint_bar_->Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode,
-                          indentation_level + 1, z_offset);
+    tracepoint_bar_->Draw(batcher, text_renderer, inner_draw_context);
   }
 }
 

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -38,9 +38,9 @@ using orbit_grpc_protos::InstrumentedFunction;
 
 ThreadTrack::ThreadTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                          orbit_gl::Viewport* viewport, TimeGraphLayout* layout, int32_t thread_id,
-                         OrbitApp* app, const CaptureData* capture_data,
-                         ScopeTreeUpdateType scope_tree_update_type, uint32_t indentation_level)
-    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data, indentation_level) {
+                         OrbitApp* app, const orbit_client_model::CaptureData* capture_data,
+                         ScopeTreeUpdateType scope_tree_update_type)
+    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data) {
   thread_id_ = thread_id;
   InitializeNameAndLabel(thread_id);
 
@@ -268,8 +268,10 @@ void ThreadTrack::UpdateMinMaxTimestamps() {
 }
 
 void ThreadTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
-                       uint64_t current_mouse_time_ns, PickingMode picking_mode, float z_offset) {
-  TimerTrack::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, z_offset);
+                       uint64_t current_mouse_time_ns, PickingMode picking_mode,
+                       uint32_t indentation_level, float z_offset) {
+  TimerTrack::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, indentation_level,
+                   z_offset);
 
   UpdateMinMaxTimestamps();
   UpdatePositionOfSubtracks();
@@ -281,17 +283,20 @@ void ThreadTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
 
   if (!thread_state_bar_->IsEmpty()) {
     thread_state_bar_->SetSize(track_width, thread_state_track_height);
-    thread_state_bar_->Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, z_offset);
+    thread_state_bar_->Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode,
+                            indentation_level + 1, z_offset);
   }
 
   if (!event_bar_->IsEmpty()) {
     event_bar_->SetSize(track_width, event_track_height);
-    event_bar_->Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, z_offset);
+    event_bar_->Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode,
+                     indentation_level + 1, z_offset);
   }
 
   if (!tracepoint_bar_->IsEmpty()) {
     tracepoint_bar_->SetSize(track_width, tracepoint_track_height);
-    tracepoint_bar_->Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, z_offset);
+    tracepoint_bar_->Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode,
+                          indentation_level + 1, z_offset);
   }
 }
 

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -42,8 +42,8 @@ class ThreadTrack final : public TimerTrack {
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetRight(
       const orbit_client_protos::TimerInfo& timer_info) const override;
 
-  void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-            PickingMode picking_mode, uint32_t indentation_level, float z_offset = 0) override;
+  void Draw(Batcher& batcher, TextRenderer& text_renderer,
+            const DrawContext& draw_context) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -51,7 +51,6 @@ class ThreadTrack final : public TimerTrack {
 
   void OnPick(int x, int y) override;
 
-  void UpdateBoxHeight() override;
   void SetTrackColor(Color color);
   [[nodiscard]] bool IsEmpty() const override;
 
@@ -64,6 +63,7 @@ class ThreadTrack final : public TimerTrack {
   [[nodiscard]] bool IsTimerActive(const orbit_client_protos::TimerInfo& timer) const override;
   [[nodiscard]] bool IsTrackSelected() const override;
 
+  [[nodiscard]] float GetDefaultBoxHeight() const override;
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer, bool is_selected,
                                     bool is_highlighted) const override;
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -30,7 +30,7 @@ class ThreadTrack final : public TimerTrack {
   explicit ThreadTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                        orbit_gl::Viewport* viewport, TimeGraphLayout* layout, int32_t thread_id,
                        OrbitApp* app, const orbit_client_model::CaptureData* capture_data,
-                       ScopeTreeUpdateType scope_tree_update_type, uint32_t indentation_level = 0);
+                       ScopeTreeUpdateType scope_tree_update_type);
 
   void InitializeNameAndLabel(int32_t thread_id);
 
@@ -43,7 +43,7 @@ class ThreadTrack final : public TimerTrack {
       const orbit_client_protos::TimerInfo& timer_info) const override;
 
   void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-            PickingMode picking_mode, float z_offset = 0) override;
+            PickingMode picking_mode, uint32_t indentation_level, float z_offset = 0) override;
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;

--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -647,7 +647,7 @@ const std::vector<CallstackEvent>& TimeGraph::GetSelectedCallstackEvents(int32_t
 }
 
 void TimeGraph::Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-                     PickingMode picking_mode, float z_offset) {
+                     PickingMode picking_mode, uint32_t, float z_offset) {
   ORBIT_SCOPE("TimeGraph::Draw");
 
   const bool picking = picking_mode != PickingMode::kNone;
@@ -896,7 +896,7 @@ void TimeGraph::DrawTracks(Batcher& batcher, TextRenderer& text_renderer,
     } else if (track->IsMoving()) {
       z_offset = GlCanvas::kZOffsetMovingTrack;
     }
-    track->Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, z_offset);
+    track->Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, 0, z_offset);
   }
 }
 

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -44,7 +44,8 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
   ~TimeGraph() override;
 
   void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-            PickingMode picking_mode = PickingMode::kNone, float z_offset = 0) override;
+            PickingMode picking_mode = PickingMode::kNone, uint32_t /*indentation_level*/ = 0,
+            float z_offset = 0) override;
   void DrawTracks(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
                   PickingMode picking_mode = PickingMode::kNone);
   void DrawOverlay(Batcher& batcher, TextRenderer& text_renderer, PickingMode picking_mode);

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -43,11 +43,9 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
                      PickingManager* picking_manager);
   ~TimeGraph() override;
 
-  void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-            PickingMode picking_mode = PickingMode::kNone, uint32_t /*indentation_level*/ = 0,
-            float z_offset = 0) override;
-  void DrawTracks(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-                  PickingMode picking_mode = PickingMode::kNone);
+  void Draw(Batcher& batcher, TextRenderer& text_renderer,
+            const DrawContext& draw_context) override;
+  void DrawTracks(Batcher& batcher, TextRenderer& text_renderer, const DrawContext& draw_context);
   void DrawOverlay(Batcher& batcher, TextRenderer& text_renderer, PickingMode picking_mode);
   void DrawIteratorBox(Batcher& batcher, TextRenderer& text_renderer, Vec2 pos, Vec2 size,
                        const Color& color, const std::string& label, const std::string& time,

--- a/src/OrbitGl/TimeGraphLayout.cpp
+++ b/src/OrbitGl/TimeGraphLayout.cpp
@@ -30,6 +30,8 @@ TimeGraphLayout::TimeGraphLayout() {
   track_tab_offset_ = 0.f;
   track_intent_offset_ = 5.f;
   collapse_button_offset_ = 15.f;
+  collapse_button_size_ = 10.f;
+  collapse_button_decrease_per_indentation_ = 2.f;
   rounding_radius_ = 8.f;
   rounding_num_sides_ = 16;
   text_offset_ = 5.f;
@@ -68,6 +70,9 @@ bool TimeGraphLayout::DrawProperties() {
   FLOAT_SLIDER(track_tab_height_);
   FLOAT_SLIDER(track_tab_offset_);
   FLOAT_SLIDER(track_intent_offset_);
+  FLOAT_SLIDER(collapse_button_size_);
+  FLOAT_SLIDER(collapse_button_decrease_per_indentation_);
+
   FLOAT_SLIDER(collapse_button_offset_);
   FLOAT_SLIDER(rounding_radius_);
   FLOAT_SLIDER(rounding_num_sides_);
@@ -83,6 +88,11 @@ bool TimeGraphLayout::DrawProperties() {
   ImGui::Checkbox("Draw Track Background", &draw_track_background_);
 
   return needs_redraw;
+}
+
+float TimeGraphLayout::GetCollapseButtonSize(int indentation_level) const {
+  return collapse_button_size_ -
+         collapse_button_decrease_per_indentation_ * static_cast<float>(indentation_level);
 }
 
 float TimeGraphLayout::GetBottomMargin() const {

--- a/src/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/TimeGraphLayout.h
@@ -26,6 +26,7 @@ class TimeGraphLayout {
   float GetTrackTabHeight() const { return track_tab_height_ * scale_; }
   float GetTrackTabOffset() const { return track_tab_offset_; }
   float GetTrackIntentOffset() const { return track_intent_offset_; }
+  float GetCollapseButtonSize(int indentation_level) const;
   float GetCollapseButtonOffset() const { return collapse_button_offset_; }
   float GetRoundingRadius() const { return rounding_radius_ * scale_; }
   float GetRoundingNumSides() const { return rounding_num_sides_; }
@@ -68,6 +69,8 @@ class TimeGraphLayout {
   float track_tab_offset_;
   float track_intent_offset_;
   float collapse_button_offset_;
+  float collapse_button_size_;
+  float collapse_button_decrease_per_indentation_;
   float rounding_radius_;
   float rounding_num_sides_;
   float text_offset_;

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -35,9 +35,8 @@ const Color TimerTrack::kHighlightColor = Color(100, 181, 246, 255);
 
 TimerTrack::TimerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                        orbit_gl::Viewport* viewport, TimeGraphLayout* layout, OrbitApp* app,
-                       const orbit_client_model::CaptureData* capture_data,
-                       uint32_t indentation_level)
-    : Track(parent, time_graph, viewport, layout, capture_data, indentation_level),
+                       const orbit_client_model::CaptureData* capture_data)
+    : Track(parent, time_graph, viewport, layout, capture_data),
       text_renderer_{time_graph->GetTextRenderer()},
       app_{app},
       track_data_{std::make_unique<TrackData>()} {}

--- a/src/OrbitGl/TimerTrack.cpp
+++ b/src/OrbitGl/TimerTrack.cpp
@@ -56,12 +56,8 @@ float TimerTrack::GetYFromTimer(const TimerInfo& timer_info) const {
 }
 
 float TimerTrack::GetYFromDepth(uint32_t depth) const {
-  return pos_[1] - GetHeaderHeight() - box_height_ * static_cast<float>(depth + 1);
+  return pos_[1] - GetHeaderHeight() - GetDefaultBoxHeight() * static_cast<float>(depth + 1);
 }
-
-void TimerTrack::UpdateBoxHeight() { box_height_ = layout_->GetTextBoxHeight(); }
-
-float TimerTrack::GetBoxHeight(const TimerInfo& /*timer_info*/) const { return box_height_; }
 
 namespace {
 struct WorldXInfo {
@@ -124,7 +120,7 @@ bool TimerTrack::DrawTimer(const TimerInfo* prev_timer_info, const TimerInfo* ne
   double end_or_next_start_us = end_us;
 
   float world_timer_y = GetYFromTimer(*current_timer_info);
-  float box_height = GetBoxHeight(*current_timer_info);
+  float box_height = GetDynamicBoxHeight(*current_timer_info);
 
   // Check if the previous timer overlaps with the current one, and if so draw the overlap
   // as triangles rather than as overlapping rectangles.
@@ -178,7 +174,7 @@ bool TimerTrack::DrawTimer(const TimerInfo* prev_timer_info, const TimerInfo* ne
 
     if (is_visible_width) {
       Vec2 pos{world_x_info.world_x_start, world_timer_y};
-      Vec2 size{world_x_info.world_x_width, GetBoxHeight(*current_timer_info)};
+      Vec2 size{world_x_info.world_x_width, GetDynamicBoxHeight(*current_timer_info)};
 
       DrawTimesliceText(*current_timer_info, draw_data.track_start_x, draw_data.z_offset, pos,
                         size);
@@ -227,8 +223,8 @@ bool TimerTrack::DrawTimer(const TimerInfo* prev_timer_info, const TimerInfo* ne
                                        draw_data.track_start_x, draw_data.track_width);
 
     Vec2 pos(world_x_info.world_x_start, world_timer_y);
-    draw_data.batcher->AddVerticalLine(pos, GetBoxHeight(*current_timer_info), draw_data.z, color,
-                                       std::move(user_data));
+    draw_data.batcher->AddVerticalLine(pos, GetDynamicBoxHeight(*current_timer_info), draw_data.z,
+                                       color, std::move(user_data));
     // For lines, we can ignore the entire pixel into which this event
     // falls. We align this precisely on the pixel x-coordinate of the
     // current line being drawn (in ticks). If ns_per_pixel is
@@ -248,8 +244,6 @@ bool TimerTrack::DrawTimer(const TimerInfo* prev_timer_info, const TimerInfo* ne
 
 void TimerTrack::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                                   PickingMode /*picking_mode*/, float z_offset) {
-  UpdateBoxHeight();
-
   visible_timer_count_ = 0;
 
   internal::DrawData draw_data{};

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -95,9 +95,11 @@ class TimerTrack : public Track {
 
   [[nodiscard]] bool IsCollapsible() const override { return depth_ > 1; }
 
-  virtual void UpdateBoxHeight();
-  [[nodiscard]] virtual float GetBoxHeight(
-      const orbit_client_protos::TimerInfo& /*timer_info*/) const;
+  [[nodiscard]] virtual float GetDefaultBoxHeight() const { return layout_->GetTextBoxHeight(); }
+  [[nodiscard]] virtual float GetDynamicBoxHeight(
+      const orbit_client_protos::TimerInfo& /*timer_info*/) const {
+    return GetDefaultBoxHeight();
+  }
   [[nodiscard]] virtual float GetYFromTimer(const orbit_client_protos::TimerInfo& timer_info) const;
   [[nodiscard]] virtual float GetYFromDepth(uint32_t depth) const;
 
@@ -162,8 +164,6 @@ class TimerTrack : public Track {
     return std::make_unique<PickingUserData>(
         &timer_info, [this, &batcher](PickingId id) { return this->GetBoxTooltip(batcher, id); });
   }
-
-  float box_height_ = 0.0f;
 
   static const Color kHighlightColor;
 

--- a/src/OrbitGl/TimerTrack.h
+++ b/src/OrbitGl/TimerTrack.h
@@ -53,8 +53,7 @@ class TimerTrack : public Track {
  public:
   explicit TimerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout, OrbitApp* app,
-                      const orbit_client_model::CaptureData* capture_data,
-                      uint32_t indentation_level = 0);
+                      const orbit_client_model::CaptureData* capture_data);
   ~TimerTrack() override = default;
 
   // Pickable

--- a/src/OrbitGl/TracepointThreadBar.cpp
+++ b/src/OrbitGl/TracepointThreadBar.cpp
@@ -37,18 +37,17 @@ TracepointThreadBar::TracepointThreadBar(CaptureViewElement* parent, OrbitApp* a
       color_{255, 0, 0, 255} {}
 
 void TracepointThreadBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
-                               uint64_t current_mouse_time_ns, PickingMode picking_mode,
-                               uint32_t indentation_level, float z_offset) {
-  ThreadBar::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, indentation_level,
-                  z_offset);
+                               const DrawContext& draw_context) {
+  ThreadBar::Draw(batcher, text_renderer, draw_context);
 
   if (IsEmpty()) {
     return;
   }
 
-  float event_bar_z = picking_mode == PickingMode::kClick ? GlCanvas::kZValueEventBarPicking
-                                                          : GlCanvas::kZValueEventBar;
-  event_bar_z += z_offset;
+  float event_bar_z = draw_context.picking_mode == PickingMode::kClick
+                          ? GlCanvas::kZValueEventBarPicking
+                          : GlCanvas::kZValueEventBar;
+  event_bar_z += draw_context.z_offset;
   Color color = color_;
   Box box(pos_, Vec2(size_[0], -size_[1]), event_bar_z);
   batcher.AddBox(box, color, shared_from_this());

--- a/src/OrbitGl/TracepointThreadBar.cpp
+++ b/src/OrbitGl/TracepointThreadBar.cpp
@@ -38,8 +38,9 @@ TracepointThreadBar::TracepointThreadBar(CaptureViewElement* parent, OrbitApp* a
 
 void TracepointThreadBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
                                uint64_t current_mouse_time_ns, PickingMode picking_mode,
-                               float z_offset) {
-  ThreadBar::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, z_offset);
+                               uint32_t indentation_level, float z_offset) {
+  ThreadBar::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, indentation_level,
+                  z_offset);
 
   if (IsEmpty()) {
     return;

--- a/src/OrbitGl/TracepointThreadBar.h
+++ b/src/OrbitGl/TracepointThreadBar.h
@@ -23,7 +23,7 @@ class TracepointThreadBar : public ThreadBar {
                                int32_t thread_id);
 
   void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-            PickingMode picking_mode, float z_offset = 0) override;
+            PickingMode picking_mode, uint32_t indentation_level, float z_offset = 0) override;
 
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;

--- a/src/OrbitGl/TracepointThreadBar.h
+++ b/src/OrbitGl/TracepointThreadBar.h
@@ -22,8 +22,8 @@ class TracepointThreadBar : public ThreadBar {
                                const orbit_client_model::CaptureData* capture_data,
                                int32_t thread_id);
 
-  void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-            PickingMode picking_mode, uint32_t indentation_level, float z_offset = 0) override;
+  void Draw(Batcher& batcher, TextRenderer& text_renderer,
+            const DrawContext& draw_context) override;
 
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -88,17 +88,15 @@ std::unique_ptr<orbit_accessibility::AccessibleInterface> Track::CreateAccessibl
   return std::make_unique<orbit_gl::AccessibleTrack>(this, layout_);
 }
 
-void Track::Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-                 PickingMode picking_mode, uint32_t indentation_level, float z_offset) {
-  CaptureViewElement::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode,
-                           indentation_level, z_offset);
+void Track::Draw(Batcher& batcher, TextRenderer& text_renderer, const DrawContext& draw_context) {
+  CaptureViewElement::Draw(batcher, text_renderer, draw_context);
 
-  const bool picking = picking_mode != PickingMode::kNone;
+  const bool picking = draw_context.picking_mode != PickingMode::kNone;
 
   float x0 = pos_[0];
   float y0 = pos_[1];
-  float track_z = GlCanvas::kZValueTrack + z_offset;
-  float text_z = GlCanvas::kZValueTrackText + z_offset;
+  float track_z = GlCanvas::kZValueTrack + draw_context.z_offset;
+  float text_z = GlCanvas::kZValueTrackText + draw_context.z_offset;
   float top_margin = layout_->GetTrackTopMargin();
 
   Color track_background_color = GetTrackBackgroundColor();
@@ -113,7 +111,8 @@ void Track::Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current
   float half_label_width = 0.5f * label_width;
   float tab_x0 = x0 + layout_->GetTrackTabOffset();
 
-  const float indentation_x0 = tab_x0 + (indentation_level * layout_->GetTrackIntentOffset());
+  const float indentation_x0 =
+      tab_x0 + (draw_context.indentation_level * layout_->GetTrackIntentOffset());
   Box box(Vec2(indentation_x0, y0), Vec2(label_width, -label_height), track_z);
   batcher.AddBox(box, track_background_color, shared_from_this());
 
@@ -154,8 +153,7 @@ void Track::Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current
   collapse_toggle_->SetIsCollapsible(this->IsCollapsible());
 
   // Draw collapsing triangle.
-  const float toggle_y_pos = DrawCollapsingTriangle(batcher, text_renderer, current_mouse_time_ns,
-                                                    picking_mode, z_offset, 0);
+  const float toggle_y_pos = DrawCollapsingTriangle(batcher, text_renderer, draw_context);
 
   // Draw label.
   if (!picking) {
@@ -163,7 +161,8 @@ void Track::Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current
     // For the first 5 indentations, we decrease the font_size by 10 percent points (per
     // indentation).
     constexpr uint32_t kMaxIndentationLevel = 5;
-    uint32_t capped_indentation_level = std::min(indentation_level, kMaxIndentationLevel);
+    uint32_t capped_indentation_level =
+        std::min(draw_context.indentation_level, kMaxIndentationLevel);
     font_size = (font_size * (10 - capped_indentation_level)) / 10;
     float label_offset_x = layout_->GetTrackLabelOffsetX();
     float label_offset_y = text_renderer.GetStringHeight("o", font_size) / 2.f;
@@ -188,19 +187,18 @@ void Track::Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current
 }
 
 float Track::DrawCollapsingTriangle(Batcher& batcher, TextRenderer& text_renderer,
-                                    uint64_t current_mouse_time_ns, PickingMode picking_mode,
-                                    float z_offset, int indentation_level) {
+                                    const DrawContext& draw_context) {
   const float label_height = layout_->GetTrackTabHeight();
   const float half_label_height = 0.5f * label_height;
   const float x0 = pos_[0];
   const float tab_x0 = x0 + layout_->GetTrackTabOffset();
-  const float intent_x0 = tab_x0 + (indentation_level * layout_->GetTrackIntentOffset());
+  const float intent_x0 =
+      tab_x0 + (draw_context.indentation_level * layout_->GetTrackIntentOffset());
   const float button_offset = layout_->GetCollapseButtonOffset();
   const float toggle_y_pos = pos_[1] - half_label_height;
   Vec2 toggle_pos = Vec2(intent_x0 + button_offset, toggle_y_pos);
   collapse_toggle_->SetPos(toggle_pos[0], toggle_pos[1]);
-  collapse_toggle_->Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode,
-                         indentation_level, z_offset);
+  collapse_toggle_->Draw(batcher, text_renderer, draw_context);
   return toggle_y_pos;
 }
 

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -53,8 +53,8 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
                  TimeGraphLayout* layout, const orbit_client_model::CaptureData* capture_data);
   ~Track() override = default;
 
-  void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-            PickingMode picking_mode, uint32_t indentation_level, float z_offset = 0) override;
+  void Draw(Batcher& batcher, TextRenderer& text_renderer,
+            const DrawContext& draw_context) override;
 
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;
@@ -105,8 +105,7 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
  protected:
   // Returns the y-position of the triangle.
   float DrawCollapsingTriangle(Batcher& batcher, TextRenderer& text_renderer,
-                               uint64_t current_mouse_time_ns, PickingMode picking_mode,
-                               float z_offset, int indentation_level);
+                               const DrawContext& draw_context);
   void DrawTriangleFan(Batcher& batcher, const std::vector<Vec2>& points, const Vec2& pos,
                        const Color& color, float rotation, float z);
 

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -50,12 +50,11 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
       Type::kMemoryTrack, Type::kPageFaultsTrack, Type::kUnknown};
 
   explicit Track(CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
-                 TimeGraphLayout* layout, const orbit_client_model::CaptureData* capture_data,
-                 uint32_t indentation_level);
+                 TimeGraphLayout* layout, const orbit_client_model::CaptureData* capture_data);
   ~Track() override = default;
 
   void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-            PickingMode picking_mode, float z_offset = 0) override;
+            PickingMode picking_mode, uint32_t indentation_level, float z_offset = 0) override;
 
   void UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                         PickingMode picking_mode, float z_offset = 0) override;
@@ -102,13 +101,12 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
 
   [[nodiscard]] virtual std::vector<CaptureViewElement*> GetVisibleChildren() { return {}; }
   [[nodiscard]] virtual int GetVisiblePrimitiveCount() const { return 0; }
-  [[nodiscard]] virtual uint32_t GetIndent() const { return indentation_level_; }
 
  protected:
   // Returns the y-position of the triangle.
   float DrawCollapsingTriangle(Batcher& batcher, TextRenderer& text_renderer,
                                uint64_t current_mouse_time_ns, PickingMode picking_mode,
-                               float z_offset = 0);
+                               float z_offset, int indentation_level);
   void DrawTriangleFan(Batcher& batcher, const std::vector<Vec2>& points, const Vec2& pos,
                        const Color& color, float rotation, float z);
 
@@ -128,9 +126,6 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   TimeGraphLayout* layout_;
 
   const orbit_client_model::CaptureData* capture_data_ = nullptr;
-
- private:
-  const uint32_t indentation_level_;
 };
 
 #endif

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -17,18 +17,16 @@
 #include "Track.h"
 
 TriangleToggle::TriangleToggle(StateChangeHandler handler, TimeGraph* time_graph,
-                               orbit_gl::Viewport* viewport, TimeGraphLayout* layout, Track* track,
-                               float size)
+                               orbit_gl::Viewport* viewport, TimeGraphLayout* layout, Track* track)
     : CaptureViewElement(track, time_graph, viewport, layout),
       track_(track),
-      handler_(std::move(handler)) {
-  SetSize(size, size);
-}
+      handler_(std::move(handler)) {}
 
 void TriangleToggle::Draw(Batcher& batcher, TextRenderer& text_renderer,
                           uint64_t current_mouse_time_ns, PickingMode picking_mode,
-                          float z_offset) {
-  CaptureViewElement::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode, z_offset);
+                          uint32_t indentation_level, float z_offset) {
+  CaptureViewElement::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode,
+                           indentation_level, z_offset);
 
   const float z = GlCanvas::kZValueTrack + z_offset;
 
@@ -39,7 +37,7 @@ void TriangleToggle::Draw(Batcher& batcher, TextRenderer& text_renderer,
 
   // Draw triangle.
   static float half_sqrt_three = 0.5f * sqrtf(3.f);
-  float half_w = 0.5f * size_[0];
+  float half_w = 0.5f * layout_->GetCollapseButtonSize(indentation_level);
   float half_h = half_sqrt_three * half_w;
 
   if (!picking) {

--- a/src/OrbitGl/TriangleToggle.cpp
+++ b/src/OrbitGl/TriangleToggle.cpp
@@ -23,21 +23,19 @@ TriangleToggle::TriangleToggle(StateChangeHandler handler, TimeGraph* time_graph
       handler_(std::move(handler)) {}
 
 void TriangleToggle::Draw(Batcher& batcher, TextRenderer& text_renderer,
-                          uint64_t current_mouse_time_ns, PickingMode picking_mode,
-                          uint32_t indentation_level, float z_offset) {
-  CaptureViewElement::Draw(batcher, text_renderer, current_mouse_time_ns, picking_mode,
-                           indentation_level, z_offset);
+                          const DrawContext& draw_context) {
+  CaptureViewElement::Draw(batcher, text_renderer, draw_context);
 
-  const float z = GlCanvas::kZValueTrack + z_offset;
+  const float z = GlCanvas::kZValueTrack + draw_context.z_offset;
 
-  const bool picking = picking_mode != PickingMode::kNone;
+  const bool picking = draw_context.picking_mode != PickingMode::kNone;
   const Color kWhite(255, 255, 255, 255);
   const Color kGrey(100, 100, 100, 255);
   Color color = is_collapsible_ ? kWhite : kGrey;
 
   // Draw triangle.
   static float half_sqrt_three = 0.5f * sqrtf(3.f);
-  float half_w = 0.5f * layout_->GetCollapseButtonSize(indentation_level);
+  float half_w = 0.5f * layout_->GetCollapseButtonSize(draw_context.indentation_level);
   float half_h = half_sqrt_three * half_w;
 
   if (!picking) {

--- a/src/OrbitGl/TriangleToggle.h
+++ b/src/OrbitGl/TriangleToggle.h
@@ -28,8 +28,8 @@ class TriangleToggle : public orbit_gl::CaptureViewElement,
   TriangleToggle(TriangleToggle&&) = delete;
   TriangleToggle& operator=(TriangleToggle&&) = delete;
 
-  void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-            PickingMode picking_mode, uint32_t indentation_level = 0, float z_offset = 0) override;
+  void Draw(Batcher& batcher, TextRenderer& text_renderer,
+            const DrawContext& draw_context) override;
 
   // Pickable
   void OnRelease() override;

--- a/src/OrbitGl/TriangleToggle.h
+++ b/src/OrbitGl/TriangleToggle.h
@@ -19,8 +19,7 @@ class TriangleToggle : public orbit_gl::CaptureViewElement,
  public:
   using StateChangeHandler = std::function<void(bool)>;
   explicit TriangleToggle(StateChangeHandler handler, TimeGraph* time_graph,
-                          orbit_gl::Viewport* viewport, TimeGraphLayout* layout, Track* track,
-                          float size);
+                          orbit_gl::Viewport* viewport, TimeGraphLayout* layout, Track* track);
   ~TriangleToggle() override = default;
 
   TriangleToggle() = delete;
@@ -30,7 +29,7 @@ class TriangleToggle : public orbit_gl::CaptureViewElement,
   TriangleToggle& operator=(TriangleToggle&&) = delete;
 
   void Draw(Batcher& batcher, TextRenderer& text_renderer, uint64_t current_mouse_time_ns,
-            PickingMode picking_mode, float z_offset = 0) override;
+            PickingMode picking_mode, uint32_t indentation_level = 0, float z_offset = 0) override;
 
   // Pickable
   void OnRelease() override;

--- a/src/OrbitGl/VariableTrack.h
+++ b/src/OrbitGl/VariableTrack.h
@@ -22,11 +22,10 @@ class VariableTrack final : public LineGraphTrack<kVariableTrackDimension> {
   explicit VariableTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                          orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                          const std::string& name,
-                         const orbit_client_model::CaptureData* capture_data,
-                         uint32_t indentation_level = 0)
+                         const orbit_client_model::CaptureData* capture_data)
       : LineGraphTrack<kVariableTrackDimension>(parent, time_graph, viewport, layout, name,
                                                 std::array<std::string, kVariableTrackDimension>{},
-                                                capture_data, indentation_level) {
+                                                capture_data) {
     SetSeriesColors(kVariableTrackColor);
   }
 


### PR DESCRIPTION
In the process of moving track member variables to TrackData to split data with UI elements, this PR simplify two members, box_height_ and indentation_level_. Also I refactor a little bit the Draw() method.

Bug related: http://b/194504762

Test: Start/Stop a capture. Load a Capture where there are different Tracks to test the refactor.