### PR TITLE
Replace GUARDED_BY by ABSL_GUARDED_BY

### DIFF
--- a/src/ClientData/include/ClientData/TrackData.h
+++ b/src/ClientData/include/ClientData/TrackData.h
@@ -5,6 +5,7 @@
 #ifndef CLIENT_DATA_TRACK_DATA_H_
 #define CLIENT_DATA_TRACK_DATA_H_
 
+#include <absl/base/thread_annotations.h>
 #include <absl/synchronization/mutex.h>
 
 #include "ClientData/TimerChain.h"
@@ -75,7 +76,7 @@ class TrackData {
   }
 
   mutable absl::Mutex mutex_;
-  std::map<uint64_t, std::unique_ptr<TimerChain>> timers_ GUARDED_BY(mutex_);
+  std::map<uint64_t, std::unique_ptr<TimerChain>> timers_ ABSL_GUARDED_BY(mutex_);
   std::atomic<size_t> num_timers_{0};
   std::atomic<uint64_t> min_time_{std::numeric_limits<uint64_t>::max()};
   std::atomic<uint64_t> max_time_{std::numeric_limits<uint64_t>::min()};

--- a/src/MemoryTracing/include/MemoryTracing/MemoryInfoListener.h
+++ b/src/MemoryTracing/include/MemoryTracing/MemoryInfoListener.h
@@ -40,7 +40,7 @@ class MemoryInfoListener {
   virtual void OnMemoryUsageEvent(orbit_grpc_protos::MemoryUsageEvent memory_usage_event) = 0;
 
   absl::flat_hash_map<uint64_t, orbit_grpc_protos::MemoryUsageEvent>
-      in_progress_memory_usage_events_ GUARDED_BY(in_progress_memory_usage_events_mutex_);
+      in_progress_memory_usage_events_ ABSL_GUARDED_BY(in_progress_memory_usage_events_mutex_);
   absl::Mutex in_progress_memory_usage_events_mutex_;
   uint64_t sampling_start_timestamp_ns_;
   uint64_t sampling_period_ns_;

--- a/src/OrbitBase/include/OrbitBase/SimpleExecutor.h
+++ b/src/OrbitBase/include/OrbitBase/SimpleExecutor.h
@@ -5,7 +5,7 @@
 #ifndef ORBIT_BASE_SIMPLE_EXECUTOR_H_
 #define ORBIT_BASE_SIMPLE_EXECUTOR_H_
 
-#include <absl/base/internal/thread_annotations.h>
+#include <absl/base/thread_annotations.h>
 #include <absl/synchronization/mutex.h>
 
 #include <deque>
@@ -34,7 +34,7 @@ class SimpleExecutor : public Executor {
 
  private:
   absl::Mutex mutex_;
-  std::deque<std::unique_ptr<Action>> scheduled_tasks_ GUARDED_BY(mutex_);
+  std::deque<std::unique_ptr<Action>> scheduled_tasks_ ABSL_GUARDED_BY(mutex_);
 };
 
 }  // namespace orbit_base

--- a/third_party/VulkanTutorial/include/VulkanTutorial/OffscreenRenderingVulkanTutorial.h
+++ b/third_party/VulkanTutorial/include/VulkanTutorial/OffscreenRenderingVulkanTutorial.h
@@ -76,7 +76,7 @@ class OffscreenRenderingVulkanTutorial {
   VkFence fence_ = VK_NULL_HANDLE;
 
   absl::Mutex stop_requested_mutex_;
-  bool stop_requested_ GUARDED_BY(stop_requested_mutex_) = false;
+  bool stop_requested_ ABSL_GUARDED_BY(stop_requested_mutex_) = false;
 };
 
 }  // namespace orbit_vulkan_tutorial


### PR DESCRIPTION
The old non-namespaced `GUARDED_BY` is deprecated and should be replaced
by `ABSL_GUARDED_BY`.