### PR TITLE
Clean up usage of GTest and GMock

### DIFF
--- a/src/ClientData/TracepointDataTest.cpp
+++ b/src/ClientData/TracepointDataTest.cpp
@@ -13,7 +13,6 @@
 #include "ClientData/TracepointData.h"
 #include "OrbitBase/ThreadConstants.h"
 #include "capture_data.pb.h"
-#include "gtest/gtest.h"
 #include "tracepoint.pb.h"
 
 using ::testing::UnorderedElementsAre;

--- a/src/ClientModel/CaptureSerializationTestMatchers.h
+++ b/src/ClientModel/CaptureSerializationTestMatchers.h
@@ -5,7 +5,7 @@
 #ifndef CLIENT_MODEL_CAPTURE_SERIALIZATION_TEST_MATCHERS_H_
 #define CLIENT_MODEL_CAPTURE_SERIALIZATION_TEST_MATCHERS_H_
 
-#include <gmock/gmock-generated-matchers.h>
+#include <gmock/gmock.h>
 
 #include "capture_data.pb.h"
 

--- a/src/CodeReport/DisassemblyReportTest.cpp
+++ b/src/CodeReport/DisassemblyReportTest.cpp
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <gmock/gmock-actions.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/src/CodeReport/SourceCodeReportTest.cpp
+++ b/src/CodeReport/SourceCodeReportTest.cpp
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <gmock/gmock-actions.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/src/CodeViewer/ViewerTest.cpp
+++ b/src/CodeViewer/ViewerTest.cpp
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <gtest/gtest.h>
+
 #include <QApplication>
 #include <QFont>
 #include <QFontDatabase>
@@ -13,7 +15,6 @@
 #include <limits>
 
 #include "CodeViewer/Viewer.h"
-#include "gtest/gtest.h"
 
 namespace orbit_code_viewer {
 

--- a/src/DataViews/PresetsDataViewTest.cpp
+++ b/src/DataViews/PresetsDataViewTest.cpp
@@ -3,9 +3,7 @@
 // found in the LICENSE file.
 
 #include <absl/strings/str_split.h>
-#include <gmock/gmock-actions.h>
-#include <gmock/gmock-cardinalities.h>
-#include <gmock/gmock-matchers.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <filesystem>

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
@@ -7,7 +7,6 @@
 #include <absl/strings/numbers.h>
 #include <absl/synchronization/mutex.h>
 #include <absl/time/clock.h>
-#include <gmock/gmock-matchers.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <stdint.h>

--- a/src/OrbitBase/FileTest.cpp
+++ b/src/OrbitBase/FileTest.cpp
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 #include <absl/strings/str_join.h>
-#include <gmock/gmock-matchers.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "OrbitBase/ExecutablePath.h"

--- a/src/OrbitBase/GetProcessIdsLinuxTest.cpp
+++ b/src/OrbitBase/GetProcessIdsLinuxTest.cpp
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 #include <sys/types.h>
 #include <syscall.h>
 
@@ -15,8 +17,6 @@
 #include "OrbitBase/Result.h"
 #include "OrbitBase/ThreadUtils.h"
 #include "absl/synchronization/mutex.h"
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 
 namespace orbit_base {
 

--- a/src/OrbitGgp/ClientTest.cpp
+++ b/src/OrbitGgp/ClientTest.cpp
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <gmock/gmock-matchers.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <QCoreApplication>

--- a/src/OrbitQt/StatusListenerImplTest.cpp
+++ b/src/OrbitQt/StatusListenerImplTest.cpp
@@ -10,7 +10,6 @@
 
 #include "StatusListener.h"
 #include "StatusListenerImpl.h"
-#include "gtest/gtest.h"
 
 TEST(StatusListenerImpl, ShowAndClearOneMessage) {
   auto status_bar = std::make_unique<QStatusBar>(nullptr);

--- a/src/OrbitQt/TutorialOverlayTest.cpp
+++ b/src/OrbitQt/TutorialOverlayTest.cpp
@@ -15,7 +15,6 @@
 #include <utility>
 
 #include "TutorialOverlay.h"
-#include "gtest/gtest.h"
 
 // TODO: These tests use the actual Tutorial UI and can be broken
 // by updating this UI... it should use a dedicated unit testing UI

--- a/src/QtUtils/EventLoopTest.cpp
+++ b/src/QtUtils/EventLoopTest.cpp
@@ -11,7 +11,6 @@
 #include <system_error>
 
 #include "QtUtils/EventLoop.h"
-#include "gtest/gtest.h"
 
 TEST(EventLoop, exec) {
   // Case 1: The event loop finishes successfully

--- a/src/Service/ProcessListTest.cpp
+++ b/src/Service/ProcessListTest.cpp
@@ -13,7 +13,6 @@
 #include "OrbitBase/Result.h"
 #include "ProcessList.h"
 #include "ServiceUtils.h"
-#include "gtest/gtest.h"
 
 namespace orbit_service {
 

--- a/src/Service/ProcessTest.cpp
+++ b/src/Service/ProcessTest.cpp
@@ -10,7 +10,6 @@
 #include <string_view>
 
 #include "Process.h"
-#include "gtest/gtest.h"
 
 constexpr size_t kTaskCommLength = 16;
 

--- a/src/Service/ServiceUtilsTest.cpp
+++ b/src/Service/ServiceUtilsTest.cpp
@@ -19,7 +19,6 @@
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Result.h"
 #include "ServiceUtils.h"
-#include "gtest/gtest.h"
 #include "tracepoint.pb.h"
 
 namespace orbit_service::utils {

--- a/src/SourcePathsMapping/MappingItemModelTest.cpp
+++ b/src/SourcePathsMapping/MappingItemModelTest.cpp
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <gmock/gmock-matchers.h>
-#include <gmock/gmock-more-matchers.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <QAbstractItemModelTester>

--- a/src/Symbols/SymbolHelperTest.cpp
+++ b/src/Symbols/SymbolHelperTest.cpp
@@ -3,8 +3,6 @@
 // found in the LICENSE file.
 
 #include <absl/strings/ascii.h>
-#include <gmock/gmock-matchers.h>
-#include <gmock/gmock-more-matchers.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 

--- a/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
+++ b/src/UserSpaceInstrumentation/AccessTraceesMemoryTest.cpp
@@ -5,7 +5,7 @@
 #include <absl/strings/match.h>
 #include <absl/strings/numbers.h>
 #include <absl/strings/str_split.h>
-#include <gmock/gmock-matchers.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <stdint.h>
 #include <sys/ptrace.h>


### PR DESCRIPTION
For both GTest there is only one public header file each - `gtest.h`
and `gmock.h`. All the other header files should be considered internal
headers.

This change replaces all includes of `gmock/gmock-*.h` by
`gmock/gmock.h` and `gtest/gtest-*.h` by `gtest/gtest.h`.

Test: Compiles