### PR TITLE
Solve 2 vertical-scaling issues

### DIFF
--- a/src/OrbitGl/TimeGraph.cpp
+++ b/src/OrbitGl/TimeGraph.cpp
@@ -152,20 +152,23 @@ void TimeGraph::VerticalZoom(float zoom_value, float mouse_relative_position) {
 
   const float ratio = (zoom_value > 0) ? (1 + kIncrementRatio) : (1 / (1 + kIncrementRatio));
 
+  // We have to scale every item in the layout.
+  const float old_scale = layout_.GetScale();
+  layout_.SetScale(old_scale / ratio);
+
+  // We are limiting the maximum and minimum zoom-level, so the real ratio could be different.
+  const float capped_ratio = old_scale / layout_.GetScale();
+
   const float world_height = viewport_->GetVisibleWorldHeight();
   const float y_mouse_position =
       viewport_->GetWorldTopLeft()[1] - mouse_relative_position * world_height;
   const float top_distance = viewport_->GetWorldTopLeft()[1] - y_mouse_position;
 
-  const float new_y_mouse_position = y_mouse_position / ratio;
+  const float new_y_mouse_position = y_mouse_position / capped_ratio;
 
   float new_world_top_left_y = new_y_mouse_position + top_distance;
 
   viewport_->SetWorldTopLeftY(new_world_top_left_y);
-
-  // Finally, we have to scale every item in the layout.
-  const float old_scale = layout_.GetScale();
-  layout_.SetScale(old_scale / ratio);
 }
 
 void TimeGraph::SetMinMax(double min_time_us, double max_time_us) {

--- a/src/OrbitGl/TimeGraphLayout.cpp
+++ b/src/OrbitGl/TimeGraphLayout.cpp
@@ -84,15 +84,19 @@ bool TimeGraphLayout::DrawProperties() {
   FLOAT_SLIDER_MIN_MAX(track_top_margin_, 0, 20.f);
   FLOAT_SLIDER(toolbar_icon_height_);
   FLOAT_SLIDER(generic_fixed_spacer_width_);
-  FLOAT_SLIDER_MIN_MAX(scale_, 0.05f, 20.f);
+  FLOAT_SLIDER_MIN_MAX(scale_, kMinScale, kMaxScale);
   ImGui::Checkbox("Draw Track Background", &draw_track_background_);
 
   return needs_redraw;
 }
 
 float TimeGraphLayout::GetCollapseButtonSize(int indentation_level) const {
-  return collapse_button_size_ -
-         collapse_button_decrease_per_indentation_ * static_cast<float>(indentation_level);
+  float button_size_without_scaling =
+      collapse_button_size_ -
+      collapse_button_decrease_per_indentation_ * static_cast<float>(indentation_level);
+
+  // We want the button to scale slower than other elements, so we use sqrt() function.
+  return button_size_without_scaling * sqrt(scale_);
 }
 
 float TimeGraphLayout::GetBottomMargin() const {

--- a/src/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/TimeGraphLayout.h
@@ -8,9 +8,14 @@
 #include <math.h>
 #include <stdint.h>
 
+#include <algorithm>
+
 class TimeGraphLayout {
  public:
   TimeGraphLayout();
+
+  const float kMinScale = 0.333f;
+  const float kMaxScale = 3.f;
 
   float GetTextBoxHeight() const { return text_box_height_ * scale_; }
   float GetTextCoresHeight() const { return core_height_ * scale_; }
@@ -43,7 +48,7 @@ class TimeGraphLayout {
   float GetToolbarIconHeight() const { return toolbar_icon_height_; }
   float GetGenericFixedSpacerWidth() const { return generic_fixed_spacer_width_; }
   float GetScale() const { return scale_; }
-  void SetScale(float value) { scale_ = value; }
+  void SetScale(float value) { scale_ = std::clamp(value, kMinScale, kMaxScale); }
   void SetDrawProperties(bool value) { draw_properties_ = value; }
   bool DrawProperties();
   bool GetDrawTrackBackground() const { return draw_track_background_; }


### PR DESCRIPTION
Now the triangle toggle (button to expand/collapse) is scaling with the
rest of the CaptureViewElements when vertical zooming. We choose to
scale it slower because it seems nicer.

Also, we limit the maximum and minimum vertical-scaling ratio.

Initial Zoom: https://screenshot.googleplex.com/Bpo25VonA6YtFU9
Max-Zoom: https://screenshot.googleplex.com/9shUvngBt3afDFa
Min-Zoom: https://screenshot.googleplex.com/B8eEhs5VR3W4avA

Related bugs:
http://b/172562960
http://b/193605868

Test: Zoom-in/out vertically several times.