### PR TITLE
Fix absolute function address calculation in the case when executable segment offset is not page-aligned

### DIFF
--- a/src/ApiLoader/EnableInTracee.cpp
+++ b/src/ApiLoader/EnableInTracee.cpp
@@ -10,8 +10,8 @@
 
 #include <functional>
 
+#include "ObjectUtils/Address.h"
 #include "ObjectUtils/LinuxMap.h"
-#include "OrbitBase/Align.h"
 #include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/UniqueResource.h"

--- a/src/ClientData/CMakeLists.txt
+++ b/src/ClientData/CMakeLists.txt
@@ -44,6 +44,8 @@ target_sources(ClientData PRIVATE
 target_link_libraries(ClientData PUBLIC
         ClientProtos
         GrpcProtos
+         # TODO(b/191248550): Remove ObjectUtils once GetAbsoluteAddress is removed
+        ObjectUtils
         OrbitBase
         xxHash::xxHash)
 

--- a/src/ClientData/FunctionUtils.cpp
+++ b/src/ClientData/FunctionUtils.cpp
@@ -8,7 +8,6 @@
 #include <absl/strings/str_join.h>
 
 #include <filesystem>
-#include <utility>
 
 #include "ObjectUtils/Address.h"
 #include "OrbitBase/Logging.h"
@@ -16,18 +15,16 @@
 #include "absl/strings/match.h"
 #include "xxhash.h"
 
-namespace orbit_client_data {
+namespace orbit_client_data::function_utils {
+
+using orbit_client_protos::FunctionInfo;
+using orbit_grpc_protos::SymbolInfo;
 
 namespace {
 uint64_t StringHash(const std::string& string) {
   return XXH64(string.data(), string.size(), 0xBADDCAFEDEAD10CC);
 }
 }  // namespace
-
-namespace function_utils {
-
-using orbit_client_protos::FunctionInfo;
-using orbit_grpc_protos::SymbolInfo;
 
 std::string GetLoadedModuleName(const FunctionInfo& func) {
   return GetLoadedModuleNameByPath(func.module_path());
@@ -38,7 +35,6 @@ std::string GetLoadedModuleNameByPath(std::string_view module_path) {
 }
 
 uint64_t GetHash(const FunctionInfo& func) { return StringHash(func.pretty_name()); }
-uint64_t GetHash(std::string_view function_name) { return StringHash(std::string(function_name)); }
 
 uint64_t Offset(const FunctionInfo& func, const ModuleData& module) {
   return func.address() - module.load_bias();
@@ -95,7 +91,7 @@ std::unique_ptr<FunctionInfo> CreateFunctionInfo(const SymbolInfo& symbol_info,
 }
 
 const absl::flat_hash_map<std::string, FunctionInfo::OrbitType>& GetFunctionNameToOrbitTypeMap() {
-  const char* kStubParams =
+  constexpr const char* kStubParams =
       "(unsigned long, unsigned long, unsigned long, unsigned long, unsigned long, unsigned long)";
   static absl::flat_hash_map<std::string, FunctionInfo::OrbitType> function_name_to_type_map{
       {absl::StrCat("orbit_api::Start", kStubParams), FunctionInfo::kOrbitTimerStart},
@@ -124,6 +120,4 @@ void SetOrbitTypeFromName(FunctionInfo* func) {
   func->set_orbit_type(GetOrbitTypeByName(GetDisplayName(*func)));
 }
 
-}  // namespace function_utils
-
-}  // namespace orbit_client_data
+}  // namespace orbit_client_data::function_utils

--- a/src/ClientData/include/ClientData/FunctionUtils.h
+++ b/src/ClientData/include/ClientData/FunctionUtils.h
@@ -16,9 +16,7 @@
 #include "capture_data.pb.h"
 #include "symbol.pb.h"
 
-namespace orbit_client_data {
-
-namespace function_utils {
+namespace orbit_client_data::function_utils {
 
 [[nodiscard]] inline const std::string& GetDisplayName(
     const orbit_client_protos::FunctionInfo& func) {
@@ -28,7 +26,6 @@ namespace function_utils {
 [[nodiscard]] std::string GetLoadedModuleNameByPath(std::string_view module_path);
 [[nodiscard]] std::string GetLoadedModuleName(const orbit_client_protos::FunctionInfo& func);
 [[nodiscard]] uint64_t GetHash(const orbit_client_protos::FunctionInfo& func);
-[[nodiscard]] uint64_t GetHash(std::string_view function_name);
 
 // Calculates and returns the absolute address of the function.
 [[nodiscard]] uint64_t Offset(const orbit_client_protos::FunctionInfo& func,
@@ -58,8 +55,6 @@ GetFunctionNameToOrbitTypeMap();
     const std::string& function_name);
 void SetOrbitTypeFromName(orbit_client_protos::FunctionInfo* func);
 
-}  // namespace function_utils
-
-}  // namespace orbit_client_data
+}  // namespace orbit_client_data::function_utils
 
 #endif  // CLIENT_DATA_FUNCTION_UTILS_H_

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
@@ -20,6 +20,7 @@
 
 #include "LinuxTracing/Tracer.h"
 #include "LinuxTracingIntegrationTestPuppet.h"
+#include "ObjectUtils/Address.h"
 #include "ObjectUtils/ElfFile.h"
 #include "ObjectUtils/LinuxMap.h"
 #include "OrbitBase/ExecutablePath.h"

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
@@ -737,14 +737,18 @@ GetOuterAndInnerFunctionVirtualAddressRanges(pid_t pid) {
     if (symbol.name() == PuppetConstants::kOuterFunctionName) {
       CHECK(outer_function_virtual_address_start == 0 && outer_function_virtual_address_end == 0);
       outer_function_virtual_address_start =
-          module_info.address_start() - module_info.executable_segment_offset() + symbol.address();
+          orbit_object_utils::SymbolVirtualAddressToAbsoluteAddress(
+              symbol.address(), module_info.address_start(), module_info.load_bias(),
+              module_info.executable_segment_offset());
       outer_function_virtual_address_end = outer_function_virtual_address_start + symbol.size() - 1;
     }
 
     if (symbol.name() == PuppetConstants::kInnerFunctionName) {
       CHECK(inner_function_virtual_address_start == 0 && inner_function_virtual_address_end == 0);
       inner_function_virtual_address_start =
-          module_info.address_start() - module_info.executable_segment_offset() + symbol.address();
+          orbit_object_utils::SymbolVirtualAddressToAbsoluteAddress(
+              symbol.address(), module_info.address_start(), module_info.load_bias(),
+              module_info.executable_segment_offset());
       inner_function_virtual_address_end = inner_function_virtual_address_start + symbol.size() - 1;
     }
   }

--- a/src/ObjectUtils/Address.cpp
+++ b/src/ObjectUtils/Address.cpp
@@ -30,4 +30,12 @@ uint64_t SymbolVirtualAddressToAbsoluteAddress(uint64_t symbol_address,
          orbit_base::AlignDown<kPageSize>(module_executable_section_offset);
 }
 
+uint64_t SymbolAbsoluteAddressToOffset(uint64_t absolute_address, uint64_t module_base_address,
+                                       uint64_t module_executable_section_offset) {
+  CHECK((module_base_address % kPageSize) == 0);
+  CHECK(absolute_address >= (module_base_address + module_executable_section_offset % kPageSize));
+  return absolute_address - module_base_address +
+         orbit_base::AlignDown<kPageSize>(module_executable_section_offset);
+}
+
 }  // namespace orbit_object_utils

--- a/src/ObjectUtils/Address.cpp
+++ b/src/ObjectUtils/Address.cpp
@@ -1,0 +1,33 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "ObjectUtils/Address.h"
+
+#include <absl/strings/str_format.h>
+
+#include <algorithm>
+#include <filesystem>
+#include <memory>
+#include <string>
+
+#include "OrbitBase/Align.h"
+#include "OrbitBase/Logging.h"
+
+namespace orbit_object_utils {
+
+// Since this module is used on the client and on the service side and we do not currently
+// report page size in capture this is hardcoded here.
+static constexpr uint64_t kPageSize = 0x1000;
+
+uint64_t SymbolVirtualAddressToAbsoluteAddress(uint64_t symbol_address,
+                                               uint64_t module_base_address,
+                                               uint64_t module_load_bias,
+                                               uint64_t module_executable_section_offset) {
+  CHECK((module_base_address % kPageSize) == 0);
+  CHECK((module_load_bias % kPageSize) == 0);
+  return symbol_address + module_base_address - module_load_bias -
+         orbit_base::AlignDown<kPageSize>(module_executable_section_offset);
+}
+
+}  // namespace orbit_object_utils

--- a/src/ObjectUtils/AddressTest.cpp
+++ b/src/ObjectUtils/AddressTest.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "ObjectUtils/Address.h"
+
+namespace orbit_object_utils {
+
+TEST(Address, SymbolVirtualAddressToAbsoluteAddress) {
+  EXPECT_EQ(SymbolVirtualAddressToAbsoluteAddress(0x10, 0x1000, 0, 0), 0x1010);
+  EXPECT_EQ(SymbolVirtualAddressToAbsoluteAddress(0x1010, 0x2000, 0x1000, 0), 0x2010);
+  EXPECT_EQ(SymbolVirtualAddressToAbsoluteAddress(0x100, 0x1000, 0, 0xFF), 0x1100);
+  EXPECT_EQ(SymbolVirtualAddressToAbsoluteAddress(0x1100, 0x5000, 0x1000, 0x10FF), 0x4100);
+
+  // Invalid input
+  EXPECT_DEATH(SymbolVirtualAddressToAbsoluteAddress(0x1100, 0x5001, 0x1000, 0x10FF),
+               "Check failed");
+  EXPECT_DEATH(SymbolVirtualAddressToAbsoluteAddress(0x1100, 0x5001, 0x1001, 0x10FF),
+               "Check failed");
+  EXPECT_DEATH(SymbolVirtualAddressToAbsoluteAddress(0x1100, 0x5000, 0x1001, 0x10FF),
+               "Check failed");
+}
+
+}  // namespace orbit_object_utils

--- a/src/ObjectUtils/AddressTest.cpp
+++ b/src/ObjectUtils/AddressTest.cpp
@@ -27,4 +27,16 @@ TEST(Address, SymbolVirtualAddressToAbsoluteAddress) {
                "Check failed");
 }
 
+TEST(Address, SymbolAbsoluteAddressToOffset) {
+  EXPECT_EQ(SymbolAbsoluteAddressToOffset(0x10005, 0x10000, 0xE001), 0xE005);
+  EXPECT_EQ(SymbolAbsoluteAddressToOffset(0x10005, 0x10000, 0xE000), 0xE005);
+  EXPECT_EQ(SymbolAbsoluteAddressToOffset(0x10005, 0x10000, 0x1), 0x5);
+  EXPECT_EQ(SymbolAbsoluteAddressToOffset(0x10005, 0x10000, 0x0), 0x5);
+
+  // Invalid input
+  EXPECT_DEATH(SymbolAbsoluteAddressToOffset(0xE005, 0x10000, 0x0), "Check failed");
+  EXPECT_DEATH(SymbolAbsoluteAddressToOffset(0x1E005, 0x10020, 0x0), "Check failed");
+  EXPECT_DEATH(SymbolAbsoluteAddressToOffset(0x10005, 0x10000, 0x1010), "Check failed");
+}
+
 }  // namespace orbit_object_utils

--- a/src/ObjectUtils/CMakeLists.txt
+++ b/src/ObjectUtils/CMakeLists.txt
@@ -12,13 +12,18 @@ target_compile_features(ObjectUtils PUBLIC cxx_std_17)
 
 target_sources(
   ObjectUtils
-  PUBLIC include/ObjectUtils/CoffFile.h
+  PUBLIC include/ObjectUtils/Address.h
+         include/ObjectUtils/CoffFile.h
          include/ObjectUtils/ElfFile.h
          include/ObjectUtils/LinuxMap.h)
 
 target_sources(
   ObjectUtils
-  PRIVATE CoffFile.cpp ElfFile.cpp ObjectFile.cpp)
+  PRIVATE
+        Address.cpp
+        CoffFile.cpp
+        ElfFile.cpp
+        ObjectFile.cpp)
 
 if (NOT WIN32)
 target_sources(ObjectUtils PRIVATE LinuxMap.cpp)
@@ -36,9 +41,10 @@ target_link_libraries(
 add_executable(ObjectUtilsTests)
 
 target_sources(ObjectUtilsTests PRIVATE
-    CoffFileTest.cpp
-    ElfFileTest.cpp
-    ObjectFileTest.cpp
+        AddressTest.cpp
+        CoffFileTest.cpp
+        ElfFileTest.cpp
+        ObjectFileTest.cpp
 )
 
 if (NOT WIN32)

--- a/src/ObjectUtils/LinuxMap.cpp
+++ b/src/ObjectUtils/LinuxMap.cpp
@@ -19,6 +19,7 @@
 
 #include "ObjectUtils/ElfFile.h"
 #include "ObjectUtils/ObjectFile.h"
+#include "OrbitBase/Align.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/ReadFileToString.h"
 #include "OrbitBase/Result.h"
@@ -116,6 +117,17 @@ ErrorMessageOr<std::vector<ModuleInfo>> ParseMaps(std::string_view proc_maps_dat
   }
 
   return result;
+}
+
+uint64_t SymbolVirtualAddressToAbsoluteAddress(uint64_t symbol_address,
+                                               uint64_t module_base_address,
+                                               uint64_t module_load_bias,
+                                               uint64_t module_executable_section_offset) {
+  static const uint64_t page_size = sysconf(_SC_PAGESIZE);
+  CHECK((module_base_address % page_size) == 0);
+  CHECK((module_load_bias % page_size) == 0);
+  return symbol_address + module_base_address - module_load_bias -
+         orbit_base::AlignDown(module_executable_section_offset, page_size);
 }
 
 }  // namespace orbit_object_utils

--- a/src/ObjectUtils/LinuxMap.cpp
+++ b/src/ObjectUtils/LinuxMap.cpp
@@ -119,15 +119,4 @@ ErrorMessageOr<std::vector<ModuleInfo>> ParseMaps(std::string_view proc_maps_dat
   return result;
 }
 
-uint64_t SymbolVirtualAddressToAbsoluteAddress(uint64_t symbol_address,
-                                               uint64_t module_base_address,
-                                               uint64_t module_load_bias,
-                                               uint64_t module_executable_section_offset) {
-  static const uint64_t page_size = sysconf(_SC_PAGESIZE);
-  CHECK((module_base_address % page_size) == 0);
-  CHECK((module_load_bias % page_size) == 0);
-  return symbol_address + module_base_address - module_load_bias -
-         orbit_base::AlignDown(module_executable_section_offset, page_size);
-}
-
 }  // namespace orbit_object_utils

--- a/src/ObjectUtils/LinuxMapTest.cpp
+++ b/src/ObjectUtils/LinuxMapTest.cpp
@@ -205,19 +205,4 @@ TEST(LinuxMap, ParseMaps) {
   }
 }
 
-TEST(LinuxMap, SymbolVirtualAddressToAbsoluteAddress) {
-  EXPECT_EQ(SymbolVirtualAddressToAbsoluteAddress(0x10, 0x1000, 0, 0), 0x1010);
-  EXPECT_EQ(SymbolVirtualAddressToAbsoluteAddress(0x1010, 0x2000, 0x1000, 0), 0x2010);
-  EXPECT_EQ(SymbolVirtualAddressToAbsoluteAddress(0x100, 0x1000, 0, 0xFF), 0x1100);
-  EXPECT_EQ(SymbolVirtualAddressToAbsoluteAddress(0x1100, 0x5000, 0x1000, 0x10FF), 0x4100);
-
-  // Invalid input
-  EXPECT_DEATH(SymbolVirtualAddressToAbsoluteAddress(0x1100, 0x5001, 0x1000, 0x10FF),
-               "Check failed");
-  EXPECT_DEATH(SymbolVirtualAddressToAbsoluteAddress(0x1100, 0x5001, 0x1001, 0x10FF),
-               "Check failed");
-  EXPECT_DEATH(SymbolVirtualAddressToAbsoluteAddress(0x1100, 0x5000, 0x1001, 0x10FF),
-               "Check failed");
-}
-
 }  // namespace orbit_object_utils

--- a/src/ObjectUtils/include/ObjectUtils/Address.h
+++ b/src/ObjectUtils/include/ObjectUtils/Address.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef OBJECT_UTILS_ADDRESS_H_
+#define OBJECT_UTILS_ADDRESS_H_
+
+#include <stdint.h>
+
+namespace orbit_object_utils {
+
+uint64_t SymbolVirtualAddressToAbsoluteAddress(uint64_t symbol_address,
+                                               uint64_t module_base_address,
+                                               uint64_t module_load_bias,
+                                               uint64_t module_executable_section_offset);
+
+}  // namespace orbit_object_utils
+
+#endif  // OBJECT_UTILS_ADDRESS_H_

--- a/src/ObjectUtils/include/ObjectUtils/Address.h
+++ b/src/ObjectUtils/include/ObjectUtils/Address.h
@@ -14,6 +14,9 @@ uint64_t SymbolVirtualAddressToAbsoluteAddress(uint64_t symbol_address,
                                                uint64_t module_load_bias,
                                                uint64_t module_executable_section_offset);
 
+uint64_t SymbolAbsoluteAddressToOffset(uint64_t absolute_address, uint64_t module_base_address,
+                                       uint64_t module_executable_section_offset);
+
 }  // namespace orbit_object_utils
 
 #endif  // OBJECT_UTILS_ADDRESS_H_

--- a/src/ObjectUtils/include/ObjectUtils/LinuxMap.h
+++ b/src/ObjectUtils/include/ObjectUtils/LinuxMap.h
@@ -26,6 +26,11 @@ ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> ReadModules(int32_t p
 ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> ParseMaps(
     std::string_view proc_maps_data);
 
+uint64_t SymbolVirtualAddressToAbsoluteAddress(uint64_t symbol_address,
+                                               uint64_t module_base_address,
+                                               uint64_t module_load_bias,
+                                               uint64_t module_executable_section_offset);
+
 }  // namespace orbit_object_utils
 
 #endif  // defined(__linux)

--- a/src/ObjectUtils/include/ObjectUtils/LinuxMap.h
+++ b/src/ObjectUtils/include/ObjectUtils/LinuxMap.h
@@ -26,11 +26,6 @@ ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> ReadModules(int32_t p
 ErrorMessageOr<std::vector<orbit_grpc_protos::ModuleInfo>> ParseMaps(
     std::string_view proc_maps_data);
 
-uint64_t SymbolVirtualAddressToAbsoluteAddress(uint64_t symbol_address,
-                                               uint64_t module_base_address,
-                                               uint64_t module_load_bias,
-                                               uint64_t module_executable_section_offset);
-
 }  // namespace orbit_object_utils
 
 #endif  // defined(__linux)

--- a/src/OrbitBase/AlignTest.cpp
+++ b/src/OrbitBase/AlignTest.cpp
@@ -1,0 +1,19 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include "OrbitBase/Align.h"
+
+namespace orbit_base {
+
+TEST(Align, AlignUpSmoke) {
+  EXPECT_EQ(AlignUp<4>(0), 0);
+  EXPECT_EQ(AlignUp<4>(1), 4);
+  EXPECT_EQ(AlignUp<4>(3), 4);
+  EXPECT_EQ(AlignUp<4>(4), 4);
+  EXPECT_EQ(AlignUp<16>(17), 32);
+}
+
+}  // namespace orbit_base

--- a/src/OrbitBase/AlignTest.cpp
+++ b/src/OrbitBase/AlignTest.cpp
@@ -22,6 +22,15 @@ TEST(Align, AlignDownSmoke) {
   EXPECT_EQ(AlignDown<4>(3), 0);
   EXPECT_EQ(AlignDown<4>(4), 4);
   EXPECT_EQ(AlignDown<16>(17), 16);
+
+  EXPECT_EQ(AlignDown(0, 4), 0);
+  EXPECT_EQ(AlignDown(1, 4), 0);
+  EXPECT_EQ(AlignDown(3, 4), 0);
+  EXPECT_EQ(AlignDown(4, 4), 4);
+  EXPECT_EQ(AlignDown(17, 16), 16);
+
+  // Not a power of 2
+  EXPECT_DEATH(AlignDown(10, 12), "Check failed");
 }
 
 }  // namespace orbit_base

--- a/src/OrbitBase/AlignTest.cpp
+++ b/src/OrbitBase/AlignTest.cpp
@@ -16,4 +16,12 @@ TEST(Align, AlignUpSmoke) {
   EXPECT_EQ(AlignUp<16>(17), 32);
 }
 
+TEST(Align, AlignDownSmoke) {
+  EXPECT_EQ(AlignDown<4>(0), 0);
+  EXPECT_EQ(AlignDown<4>(1), 0);
+  EXPECT_EQ(AlignDown<4>(3), 0);
+  EXPECT_EQ(AlignDown<4>(4), 4);
+  EXPECT_EQ(AlignDown<16>(17), 16);
+}
+
 }  // namespace orbit_base

--- a/src/OrbitBase/AlignTest.cpp
+++ b/src/OrbitBase/AlignTest.cpp
@@ -22,15 +22,6 @@ TEST(Align, AlignDownSmoke) {
   EXPECT_EQ(AlignDown<4>(3), 0);
   EXPECT_EQ(AlignDown<4>(4), 4);
   EXPECT_EQ(AlignDown<16>(17), 16);
-
-  EXPECT_EQ(AlignDown(0, 4), 0);
-  EXPECT_EQ(AlignDown(1, 4), 0);
-  EXPECT_EQ(AlignDown(3, 4), 0);
-  EXPECT_EQ(AlignDown(4, 4), 4);
-  EXPECT_EQ(AlignDown(17, 16), 16);
-
-  // Not a power of 2
-  EXPECT_DEATH(AlignDown(10, 12), "Check failed");
 }
 
 }  // namespace orbit_base

--- a/src/OrbitBase/CMakeLists.txt
+++ b/src/OrbitBase/CMakeLists.txt
@@ -20,6 +20,7 @@ target_include_directories(OrbitBase PRIVATE
 
 target_sources(OrbitBase PRIVATE
         include/OrbitBase/Action.h
+        include/OrbitBase/Align.h
         include/OrbitBase/AnyInvocable.h
         include/OrbitBase/AnyMovable.h
         include/OrbitBase/Append.h
@@ -85,6 +86,7 @@ add_executable(OrbitBaseTests)
 target_compile_options(OrbitBaseTests PRIVATE ${STRICT_COMPILE_FLAGS})
 
 target_sources(OrbitBaseTests PRIVATE
+        AlignTest.cpp
         AnyInvocableTest.cpp
         AnyMovableTest.cpp
         AppendTest.cpp

--- a/src/OrbitBase/include/OrbitBase/Align.h
+++ b/src/OrbitBase/include/OrbitBase/Align.h
@@ -14,6 +14,13 @@ constexpr uint64_t AlignUp(uint64_t value) {
   return (value + (alignment - 1)) & ~(alignment - 1);
 }
 
+// alignment must be a power of 2
+template <uint64_t alignment>
+constexpr uint64_t AlignDown(uint64_t value) {
+  static_assert((alignment & (alignment - 1)) == 0);
+  return value & ~(alignment - 1);
+}
+
 }  // namespace orbit_base
 
 #endif  // ORBIT_BASE_ALIGN_H_

--- a/src/OrbitBase/include/OrbitBase/Align.h
+++ b/src/OrbitBase/include/OrbitBase/Align.h
@@ -5,8 +5,6 @@
 #ifndef ORBIT_BASE_ALIGN_H_
 #define ORBIT_BASE_ALIGN_H_
 
-#include "OrbitBase/Logging.h"
-
 namespace orbit_base {
 
 // alignment must be a power of 2
@@ -20,12 +18,6 @@ constexpr uint64_t AlignUp(uint64_t value) {
 template <uint64_t alignment>
 constexpr uint64_t AlignDown(uint64_t value) {
   static_assert((alignment & (alignment - 1)) == 0);
-  return value & ~(alignment - 1);
-}
-
-// alignment must be a power of 2
-inline uint64_t AlignDown(uint64_t value, uint64_t alignment) {
-  CHECK((alignment & (alignment - 1)) == 0);
   return value & ~(alignment - 1);
 }
 

--- a/src/OrbitBase/include/OrbitBase/Align.h
+++ b/src/OrbitBase/include/OrbitBase/Align.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef ORBIT_BASE_ALIGN_H_
+#define ORBIT_BASE_ALIGN_H_
+
+namespace orbit_base {
+
+// alignment must be a power of 2
+template <uint64_t alignment>
+constexpr uint64_t AlignUp(uint64_t value) {
+  static_assert((alignment & (alignment - 1)) == 0);
+  return (value + (alignment - 1)) & ~(alignment - 1);
+}
+
+}  // namespace orbit_base
+
+#endif  // ORBIT_BASE_ALIGN_H_

--- a/src/OrbitBase/include/OrbitBase/Align.h
+++ b/src/OrbitBase/include/OrbitBase/Align.h
@@ -5,6 +5,8 @@
 #ifndef ORBIT_BASE_ALIGN_H_
 #define ORBIT_BASE_ALIGN_H_
 
+#include "OrbitBase/Logging.h"
+
 namespace orbit_base {
 
 // alignment must be a power of 2
@@ -18,6 +20,12 @@ constexpr uint64_t AlignUp(uint64_t value) {
 template <uint64_t alignment>
 constexpr uint64_t AlignDown(uint64_t value) {
   static_assert((alignment & (alignment - 1)) == 0);
+  return value & ~(alignment - 1);
+}
+
+// alignment must be a power of 2
+inline uint64_t AlignDown(uint64_t value, uint64_t alignment) {
+  CHECK((alignment & (alignment - 1)) == 0);
   return value & ~(alignment - 1);
 }
 

--- a/src/OrbitBase/include/OrbitBase/Logging.h
+++ b/src/OrbitBase/include/OrbitBase/Logging.h
@@ -80,12 +80,12 @@ constexpr const char* kLogTimeFormat = "%Y-%m-%dT%H:%M:%E6S";
     }                                   \
   } while (0)
 
-#define CHECK(assertion)                \
-  do {                                  \
-    if (UNLIKELY(!(assertion))) {       \
-      LOG("Check failed: " #assertion); \
-      PLATFORM_ABORT();                 \
-    }                                   \
+#define CHECK(assertion)                   \
+  do {                                     \
+    if (UNLIKELY(!(assertion))) {          \
+      LOG("Check failed: %s", #assertion); \
+      PLATFORM_ABORT();                    \
+    }                                      \
   } while (0)
 
 #ifndef NDEBUG

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -15,26 +15,21 @@
 #include <absl/time/time.h>
 #include <imgui.h>
 
-#include <algorithm>
 #include <chrono>
 #include <cinttypes>
 #include <cstddef>
-#include <cstdint>
-#include <exception>
 #include <limits>
 #include <memory>
 #include <optional>
 #include <ratio>
 #include <string>
 #include <thread>
-#include <type_traits>
 #include <utility>
 
 #include "CallstackDataView.h"
 #include "CaptureClient/CaptureListener.h"
 #include "CaptureFile/CaptureFile.h"
 #include "CaptureFile/CaptureFileHelpers.h"
-#include "CaptureFileInfo/Manager.h"
 #include "CaptureWindow.h"
 #include "ClientData/CallstackData.h"
 #include "ClientData/FunctionUtils.h"
@@ -65,6 +60,7 @@
 #include "MetricsUploader/MetricsUploader.h"
 #include "MetricsUploader/ScopedMetric.h"
 #include "ModulesDataView.h"
+#include "ObjectUtils/Address.h"
 #include "ObjectUtils/ElfFile.h"
 #include "OrbitBase/File.h"
 #include "OrbitBase/Future.h"
@@ -79,7 +75,6 @@
 #include "SamplingReport.h"
 #include "Symbols/SymbolHelper.h"
 #include "TimeGraph.h"
-#include "Timer.h"
 #include "capture.pb.h"
 #include "capture_data.pb.h"
 #include "module.pb.h"
@@ -2195,8 +2190,8 @@ void OrbitApp::DeselectFunction(const orbit_client_protos::FunctionInfo& func) {
   const ModuleData* module = GetModuleByPathAndBuildId(module_path, module_build_id);
   if (module == nullptr) return false;
 
-  const uint64_t offset =
-      absolute_address - module_base_address + module->executable_segment_offset();
+  const uint64_t offset = orbit_object_utils::SymbolAbsoluteAddressToOffset(
+      absolute_address, module_base_address, module->executable_segment_offset());
   const FunctionInfo* function = module->FindFunctionByOffset(offset, false);
   if (function == nullptr) return false;
 

--- a/src/UserSpaceInstrumentation/FindFunctionAddress.cpp
+++ b/src/UserSpaceInstrumentation/FindFunctionAddress.cpp
@@ -8,6 +8,7 @@
 
 #include <string>
 
+#include "ObjectUtils/Address.h"
 #include "ObjectUtils/ElfFile.h"
 #include "ObjectUtils/LinuxMap.h"
 

--- a/src/UserSpaceInstrumentation/FindFunctionAddress.cpp
+++ b/src/UserSpaceInstrumentation/FindFunctionAddress.cpp
@@ -42,8 +42,9 @@ ErrorMessageOr<uint64_t> FindFunctionAddress(pid_t pid, std::string_view module_
 
   for (const orbit_grpc_protos::SymbolInfo& symbol : symbols.value().symbol_infos()) {
     if (symbol.name() == function_name) {
-      return symbol.address() + module_base_address - elf_file->GetLoadBias() -
-             elf_file->GetExecutableSegmentOffset();
+      return orbit_object_utils::SymbolVirtualAddressToAbsoluteAddress(
+          symbol.address(), module_base_address, elf_file->GetLoadBias(),
+          elf_file->GetExecutableSegmentOffset());
     }
   }
 

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -585,8 +585,9 @@ class InstrumentFunctionTest : public testing::Test {
     uint64_t size = 0;
     for (const auto& sym : syms.value().symbol_infos()) {
       if (sym.name() == function_name_) {
-        address = sym.address() + address_range_code.start - syms.value().load_bias() -
-                  elf_file.value()->GetExecutableSegmentOffset();
+        address = orbit_object_utils::SymbolVirtualAddressToAbsoluteAddress(
+            sym.address(), address_range_code.start, syms.value().load_bias(),
+            elf_file.value()->GetExecutableSegmentOffset());
         size = sym.size();
       }
     }
@@ -599,7 +600,7 @@ class InstrumentFunctionTest : public testing::Test {
     CHECK(AttachAndStopProcess(pid_).has_value());
 
     // Inject the payload for the instrumentation.
-    const std::string kLibName = "libUserSpaceInstrumentationTestLib.so";
+    constexpr std::string_view kLibName = "libUserSpaceInstrumentationTestLib.so";
     const std::string library_path = orbit_base::GetExecutableDir() / ".." / "lib" / kLibName;
     auto library_handle_or_error = DlopenInTracee(pid_, library_path, RTLD_NOW);
     CHECK(library_handle_or_error.has_value());

--- a/src/UserSpaceInstrumentation/TrampolineTest.cpp
+++ b/src/UserSpaceInstrumentation/TrampolineTest.cpp
@@ -26,6 +26,7 @@
 #include "AccessTraceesMemory.h"
 #include "AllocateInTracee.h"
 #include "MachineCode.h"
+#include "ObjectUtils/Address.h"
 #include "ObjectUtils/ElfFile.h"
 #include "ObjectUtils/LinuxMap.h"
 #include "OrbitBase/ExecutablePath.h"


### PR DESCRIPTION
Test: OrbitBaseTests, run and capture on app from the bug, also look at disassembly of couple of function and check that they are correct.
Bug: http://b/194278190