### PR TITLE
Move thread_id_ member to ThreadTrack

### DIFF
--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -51,7 +51,7 @@ void CallstackThreadBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
                               const DrawContext& draw_context) {
   ThreadBar::Draw(batcher, text_renderer, draw_context);
 
-  if (thread_id_ == orbit_base::kAllThreadsOfAllProcessesTid) {
+  if (GetThreadId() == orbit_base::kAllThreadsOfAllProcessesTid) {
     return;
   }
 
@@ -100,7 +100,7 @@ void CallstackThreadBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, u
   ThreadBar::UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
 
   float z = GlCanvas::kZValueEvent + z_offset;
-  float track_height = layout_->GetEventTrackHeightFromTid(thread_id_);
+  float track_height = layout_->GetEventTrackHeightFromTid(GetThreadId());
   const bool picking = picking_mode != PickingMode::kNone;
 
   const Color kWhite(255, 255, 255, 255);
@@ -122,18 +122,18 @@ void CallstackThreadBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, u
       batcher->AddVerticalLine(pos, -track_height, z, color);
     };
 
-    if (thread_id_ == orbit_base::kAllProcessThreadsTid) {
+    if (GetThreadId() == orbit_base::kAllProcessThreadsTid) {
       capture_data_->GetCallstackData()->ForEachCallstackEventInTimeRange(
           min_tick, max_tick, action_on_callstack_events);
     } else {
       capture_data_->GetCallstackData()->ForEachCallstackEventOfTidInTimeRange(
-          thread_id_, min_tick, max_tick, action_on_callstack_events);
+          GetThreadId(), min_tick, max_tick, action_on_callstack_events);
     }
 
     // Draw selected events
     std::array<Color, 2> selected_color;
     selected_color.fill(kGreenSelection);
-    for (const CallstackEvent& event : time_graph_->GetSelectedCallstackEvents(thread_id_)) {
+    for (const CallstackEvent& event : time_graph_->GetSelectedCallstackEvents(GetThreadId())) {
       Vec2 pos(time_graph_->GetWorldFromTick(event.time()), pos_[1]);
       batcher->AddVerticalLine(pos, -track_height, z, kGreenSelection);
     }
@@ -154,12 +154,12 @@ void CallstackThreadBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, u
       user_data->custom_data_ = &event;
       batcher->AddShadedBox(pos, size, z, kGreenSelection, std::move(user_data));
     };
-    if (thread_id_ == orbit_base::kAllProcessThreadsTid) {
+    if (GetThreadId() == orbit_base::kAllProcessThreadsTid) {
       capture_data_->GetCallstackData()->ForEachCallstackEventInTimeRange(
           min_tick, max_tick, action_on_callstack_events);
     } else {
       capture_data_->GetCallstackData()->ForEachCallstackEventOfTidInTimeRange(
-          thread_id_, min_tick, max_tick, action_on_callstack_events);
+          GetThreadId(), min_tick, max_tick, action_on_callstack_events);
     }
   }
 }
@@ -171,14 +171,14 @@ void CallstackThreadBar::OnRelease() {
 
 void CallstackThreadBar::OnPick(int x, int y) {
   CaptureViewElement::OnPick(x, y);
-  app_->set_selected_thread_id(thread_id_);
+  app_->set_selected_thread_id(GetThreadId());
 }
 
 void CallstackThreadBar::SelectCallstacks() {
   Vec2& from = mouse_pos_last_click_;
   Vec2& to = mouse_pos_cur_;
 
-  time_graph_->SelectCallstacks(from[0], to[0], thread_id_);
+  time_graph_->SelectCallstacks(from[0], to[0], GetThreadId());
 }
 
 bool CallstackThreadBar::IsEmpty() const {
@@ -187,9 +187,9 @@ bool CallstackThreadBar::IsEmpty() const {
   }
 
   const uint32_t callstack_count =
-      (thread_id_ == orbit_base::kAllProcessThreadsTid)
+      (GetThreadId() == orbit_base::kAllProcessThreadsTid)
           ? capture_data_->GetCallstackData()->GetCallstackEventsCount()
-          : capture_data_->GetCallstackData()->GetCallstackEventsOfTidCount(thread_id_);
+          : capture_data_->GetCallstackData()->GetCallstackEventsOfTidCount(GetThreadId());
   return callstack_count == 0;
 }
 

--- a/src/OrbitGl/CallstackThreadBar.cpp
+++ b/src/OrbitGl/CallstackThreadBar.cpp
@@ -39,9 +39,9 @@ namespace orbit_gl {
 CallstackThreadBar::CallstackThreadBar(CaptureViewElement* parent, OrbitApp* app,
                                        TimeGraph* time_graph, orbit_gl::Viewport* viewport,
                                        TimeGraphLayout* layout, const CaptureData* capture_data,
-                                       ThreadID thread_id)
-    : ThreadBar(parent, app, time_graph, viewport, layout, capture_data, thread_id, "Callstacks"),
-      color_{0, 255, 0, 255} {}
+                                       ThreadID thread_id, const Color& color)
+    : ThreadBar(parent, app, time_graph, viewport, layout, capture_data, thread_id, "Callstacks",
+                color) {}
 
 std::string CallstackThreadBar::GetTooltip() const {
   return "Left-click and drag to select samples";
@@ -63,7 +63,7 @@ void CallstackThreadBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
                           ? GlCanvas::kZValueEventBarPicking
                           : GlCanvas::kZValueEventBar;
   event_bar_z += draw_context.z_offset;
-  Color color = color_;
+  Color color = GetColor();
   Box box(pos_, Vec2(size_[0], -size_[1]), event_bar_z);
   batcher.AddBox(box, color, shared_from_this());
 

--- a/src/OrbitGl/CallstackThreadBar.h
+++ b/src/OrbitGl/CallstackThreadBar.h
@@ -27,7 +27,7 @@ class CallstackThreadBar : public ThreadBar {
   explicit CallstackThreadBar(CaptureViewElement* parent, OrbitApp* app, TimeGraph* time_graph,
                               orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                               const orbit_client_model::CaptureData* capture_data,
-                              orbit_client_data::ThreadID thread_id);
+                              orbit_client_data::ThreadID thread_id, const Color& color);
 
   std::string GetTooltip() const override;
 
@@ -41,8 +41,6 @@ class CallstackThreadBar : public ThreadBar {
 
   [[nodiscard]] bool IsEmpty() const override;
 
-  void SetColor(const Color& color) { color_ = color; }
-
  private:
   void SelectCallstacks();
   [[nodiscard]] std::string SafeGetFormattedFunctionName(
@@ -53,8 +51,6 @@ class CallstackThreadBar : public ThreadBar {
       int max_lines = 20, int bottom_n_lines = 5) const;
 
   [[nodiscard]] std::string GetSampleTooltip(const Batcher& batcher, PickingId id) const;
-
-  Color color_;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -15,6 +15,7 @@
 
 #include "Geometry.h"
 #include "GlCanvas.h"
+#include "OrbitBase/ThreadConstants.h"
 #include "TextRenderer.h"
 #include "TimeGraph.h"
 #include "TimeGraphLayout.h"
@@ -37,8 +38,8 @@ float GraphTrack<Dimension>::GetHeight() const {
   float scale_factor = IsCollapsed() ? 1 : Dimension;
   float height = layout_->GetTrackTabHeight() + GetLegendHeight() +
                  layout_->GetTextBoxHeight() * scale_factor +
-                 layout_->GetSpaceBetweenTracksAndThread() +
-                 layout_->GetEventTrackHeightFromTid(thread_id_) + layout_->GetTrackBottomMargin();
+                 layout_->GetSpaceBetweenTracksAndThread() + layout_->GetEventTrackHeightFromTid() +
+                 layout_->GetTrackBottomMargin();
   return height;
 }
 

--- a/src/OrbitGl/ThreadBar.h
+++ b/src/OrbitGl/ThreadBar.h
@@ -22,12 +22,13 @@ class ThreadBar : public CaptureViewElement, public std::enable_shared_from_this
   explicit ThreadBar(CaptureViewElement* parent, OrbitApp* app, TimeGraph* time_graph,
                      orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                      const orbit_client_model::CaptureData* capture_data, int64_t thread_id,
-                     std::string name)
+                     std::string name, const Color& color)
       : CaptureViewElement(parent, time_graph, viewport, layout),
         app_(app),
         capture_data_(capture_data),
         thread_id_(thread_id),
-        name_(std::move(name)) {}
+        name_(std::move(name)),
+        color_(color) {}
 
   [[nodiscard]] virtual bool IsEmpty() const { return false; }
 
@@ -37,6 +38,7 @@ class ThreadBar : public CaptureViewElement, public std::enable_shared_from_this
   [[nodiscard]] std::unique_ptr<orbit_accessibility::AccessibleInterface>
   CreateAccessibleInterface() override;
   [[nodiscard]] int64_t GetThreadId() const { return thread_id_; }
+  [[nodiscard]] virtual Color GetColor() const { return color_; }
 
   OrbitApp* app_;
   const orbit_client_model::CaptureData* capture_data_;
@@ -44,6 +46,9 @@ class ThreadBar : public CaptureViewElement, public std::enable_shared_from_this
  private:
   int64_t thread_id_;
   std::string name_;
+  // TODO(http://b/194777907): Color could be deduced from thread_id after moving method outside
+  // TimeGraph.
+  Color color_;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/ThreadBar.h
+++ b/src/OrbitGl/ThreadBar.h
@@ -21,15 +21,14 @@ class ThreadBar : public CaptureViewElement, public std::enable_shared_from_this
  public:
   explicit ThreadBar(CaptureViewElement* parent, OrbitApp* app, TimeGraph* time_graph,
                      orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
-                     const orbit_client_model::CaptureData* capture_data,
-                     orbit_client_data::ThreadID thread_id, std::string name)
+                     const orbit_client_model::CaptureData* capture_data, int64_t thread_id,
+                     std::string name)
       : CaptureViewElement(parent, time_graph, viewport, layout),
-        thread_id_(thread_id),
         app_(app),
         capture_data_(capture_data),
+        thread_id_(thread_id),
         name_(std::move(name)) {}
 
-  void SetThreadId(orbit_client_data::ThreadID thread_id) { thread_id_ = thread_id; }
   [[nodiscard]] virtual bool IsEmpty() const { return false; }
 
   [[nodiscard]] virtual const std::string& GetName() const { return name_; }
@@ -37,11 +36,13 @@ class ThreadBar : public CaptureViewElement, public std::enable_shared_from_this
  protected:
   [[nodiscard]] std::unique_ptr<orbit_accessibility::AccessibleInterface>
   CreateAccessibleInterface() override;
+  [[nodiscard]] int64_t GetThreadId() const { return thread_id_; }
 
-  orbit_client_data::ThreadID thread_id_ = -1;
   OrbitApp* app_;
   const orbit_client_model::CaptureData* capture_data_;
 
+ private:
+  int64_t thread_id_;
   std::string name_;
 };
 

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -33,7 +33,7 @@ ThreadStateBar::ThreadStateBar(CaptureViewElement* parent, OrbitApp* app, TimeGr
 }
 
 bool ThreadStateBar::IsEmpty() const {
-  return capture_data_ == nullptr || !capture_data_->HasThreadStatesForThread(thread_id_);
+  return capture_data_ == nullptr || !capture_data_->HasThreadStatesForThread(GetThreadId());
 }
 
 void ThreadStateBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
@@ -176,7 +176,7 @@ void ThreadStateBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint6
 
   CHECK(capture_data_ != nullptr);
   capture_data_->ForEachThreadStateSliceIntersectingTimeRange(
-      thread_id_, min_tick, max_tick, [&](const ThreadStateSliceInfo& slice) {
+      GetThreadId(), min_tick, max_tick, [&](const ThreadStateSliceInfo& slice) {
         if (slice.end_timestamp_ns() <= ignore_until_ns) {
           // Reduce overdraw by not drawing slices whose entire width would only draw over a
           // previous slice. Similar to TimerTrack::UpdatePrimitives.
@@ -220,7 +220,7 @@ void ThreadStateBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, uint6
 
 void ThreadStateBar::OnPick(int x, int y) {
   ThreadBar::OnPick(x, y);
-  app_->set_selected_thread_id(thread_id_);
+  app_->set_selected_thread_id(GetThreadId());
 }
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/ThreadStateBar.cpp
+++ b/src/OrbitGl/ThreadStateBar.cpp
@@ -28,9 +28,9 @@ namespace orbit_gl {
 ThreadStateBar::ThreadStateBar(CaptureViewElement* parent, OrbitApp* app, TimeGraph* time_graph,
                                orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                                const orbit_client_model::CaptureData* capture_data,
-                               ThreadID thread_id)
-    : ThreadBar(parent, app, time_graph, viewport, layout, capture_data, thread_id, "ThreadState") {
-}
+                               ThreadID thread_id, const Color& color)
+    : ThreadBar(parent, app, time_graph, viewport, layout, capture_data, thread_id, "ThreadState",
+                color) {}
 
 bool ThreadStateBar::IsEmpty() const {
   return capture_data_ == nullptr || !capture_data_->HasThreadStatesForThread(GetThreadId());

--- a/src/OrbitGl/ThreadStateBar.h
+++ b/src/OrbitGl/ThreadStateBar.h
@@ -27,7 +27,7 @@ class ThreadStateBar final : public ThreadBar {
   explicit ThreadStateBar(CaptureViewElement* parent, OrbitApp* app, TimeGraph* time_graph,
                           orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                           const orbit_client_model::CaptureData* capture_data,
-                          orbit_client_data::ThreadID thread_id);
+                          orbit_client_data::ThreadID thread_id, const Color& color);
 
   void Draw(Batcher& batcher, TextRenderer& text_renderer,
             const DrawContext& draw_context) override;

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -42,17 +42,15 @@ ThreadTrack::ThreadTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                          ScopeTreeUpdateType scope_tree_update_type)
     : TimerTrack(parent, time_graph, viewport, layout, app, capture_data), thread_id_{thread_id} {
   InitializeNameAndLabel();
+  Color color = TimeGraph::GetThreadColor(thread_id);
+  thread_state_bar_ = std::make_shared<orbit_gl::ThreadStateBar>(
+      this, app_, time_graph, viewport, layout, capture_data, thread_id, color);
 
-  thread_state_bar_ = std::make_shared<orbit_gl::ThreadStateBar>(this, app_, time_graph, viewport,
-                                                                 layout, capture_data, thread_id);
-
-  event_bar_ = std::make_shared<orbit_gl::CallstackThreadBar>(this, app_, time_graph, viewport,
-                                                              layout, capture_data, thread_id);
+  event_bar_ = std::make_shared<orbit_gl::CallstackThreadBar>(
+      this, app_, time_graph, viewport, layout, capture_data, thread_id, color);
 
   tracepoint_bar_ = std::make_shared<orbit_gl::TracepointThreadBar>(
-      this, app_, time_graph, viewport, layout, capture_data, thread_id);
-  SetTrackColor(TimeGraph::GetThreadColor(thread_id));
-
+      this, app_, time_graph, viewport, layout, capture_data, thread_id, color);
   scope_tree_update_type_ = scope_tree_update_type;
 }
 
@@ -296,12 +294,6 @@ std::vector<orbit_gl::CaptureViewElement*> ThreadTrack::GetVisibleChildren() {
   }
 
   return result;
-}
-
-void ThreadTrack::SetTrackColor(Color color) {
-  absl::MutexLock lock(&mutex_);
-  event_bar_->SetColor(color);
-  tracepoint_bar_->SetColor(color);
 }
 
 std::string ThreadTrack::GetTimesliceText(const TimerInfo& timer_info) const {

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -51,7 +51,6 @@ class ThreadTrack final : public TimerTrack {
 
   void OnPick(int x, int y) override;
 
-  void SetTrackColor(Color color);
   [[nodiscard]] bool IsEmpty() const override;
 
   [[nodiscard]] std::vector<CaptureViewElement*> GetVisibleChildren() override;

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -32,7 +32,7 @@ class ThreadTrack final : public TimerTrack {
                        OrbitApp* app, const orbit_client_model::CaptureData* capture_data,
                        ScopeTreeUpdateType scope_tree_update_type);
 
-  void InitializeNameAndLabel(int32_t thread_id);
+  void InitializeNameAndLabel();
 
   [[nodiscard]] Type GetType() const override { return Type::kThreadTrack; }
   [[nodiscard]] std::string GetTooltip() const override;
@@ -60,6 +60,7 @@ class ThreadTrack final : public TimerTrack {
 
  protected:
   [[nodiscard]] std::string GetThreadNameFromTid(uint32_t tid);
+  [[nodiscard]] int64_t GetThreadId() const { return thread_id_; }
   [[nodiscard]] bool IsTimerActive(const orbit_client_protos::TimerInfo& timer) const override;
   [[nodiscard]] bool IsTrackSelected() const override;
 
@@ -79,6 +80,8 @@ class ThreadTrack final : public TimerTrack {
   void UpdatePrimitivesOfSubtracks(Batcher* batcher, uint64_t min_tick, uint64_t max_tick,
                                    PickingMode picking_mode, float z_offset);
   void UpdateMinMaxTimestamps();
+
+  int64_t thread_id_;
 
   std::shared_ptr<orbit_gl::ThreadStateBar> thread_state_bar_;
   std::shared_ptr<orbit_gl::CallstackThreadBar> event_bar_;

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -144,6 +144,7 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
                           const orbit_client_protos::TimerInfo*>
   GetMinMaxTimerInfoForFunction(uint64_t function_id) const;
 
+  // TODO(http://b/194777907): Move GetColor outside TimeGraph
   [[nodiscard]] static Color GetColor(uint32_t id) {
     constexpr unsigned char kAlpha = 255;
     static std::vector<Color> colors{

--- a/src/OrbitGl/TimeGraphLayout.h
+++ b/src/OrbitGl/TimeGraphLayout.h
@@ -10,6 +10,8 @@
 
 #include <algorithm>
 
+#include "OrbitBase/ThreadConstants.h"
+
 class TimeGraphLayout {
  public:
   TimeGraphLayout();
@@ -20,7 +22,7 @@ class TimeGraphLayout {
   float GetTextBoxHeight() const { return text_box_height_ * scale_; }
   float GetTextCoresHeight() const { return core_height_ * scale_; }
   float GetThreadStateTrackHeight() const { return thread_state_track_height_ * scale_; }
-  float GetEventTrackHeightFromTid(int32_t tid) const;
+  float GetEventTrackHeightFromTid(int32_t tid = orbit_base::kInvalidThreadTid) const;
   float GetVariableTrackHeight() const { return variable_track_height_ * scale_; }
   float GetTrackBottomMargin() const { return track_bottom_margin_ * scale_; }
   float GetTrackTopMargin() const { return track_top_margin_ * scale_; }

--- a/src/OrbitGl/TracepointThreadBar.cpp
+++ b/src/OrbitGl/TracepointThreadBar.cpp
@@ -32,9 +32,9 @@ TracepointThreadBar::TracepointThreadBar(CaptureViewElement* parent, OrbitApp* a
                                          TimeGraph* time_graph, orbit_gl::Viewport* viewport,
                                          TimeGraphLayout* layout,
                                          const orbit_client_model::CaptureData* capture_data,
-                                         int32_t thread_id)
-    : ThreadBar(parent, app, time_graph, viewport, layout, capture_data, thread_id, "Tracepoints"),
-      color_{255, 0, 0, 255} {}
+                                         int32_t thread_id, const Color& color)
+    : ThreadBar(parent, app, time_graph, viewport, layout, capture_data, thread_id, "Tracepoints",
+                color) {}
 
 void TracepointThreadBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
                                const DrawContext& draw_context) {
@@ -48,7 +48,7 @@ void TracepointThreadBar::Draw(Batcher& batcher, TextRenderer& text_renderer,
                           ? GlCanvas::kZValueEventBarPicking
                           : GlCanvas::kZValueEventBar;
   event_bar_z += draw_context.z_offset;
-  Color color = color_;
+  Color color = GetColor();
   Box box(pos_, Vec2(size_[0], -size_[1]), event_bar_z);
   batcher.AddBox(box, color, shared_from_this());
 }

--- a/src/OrbitGl/TracepointThreadBar.cpp
+++ b/src/OrbitGl/TracepointThreadBar.cpp
@@ -58,7 +58,7 @@ void TracepointThreadBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, 
   ThreadBar::UpdatePrimitives(batcher, min_tick, max_tick, picking_mode, z_offset);
 
   float z = GlCanvas::kZValueEvent + z_offset;
-  float track_height = layout_->GetEventTrackHeightFromTid(thread_id_);
+  float track_height = layout_->GetEventTrackHeightFromTid(GetThreadId());
   const bool picking = picking_mode != PickingMode::kNone;
 
   const Color kWhite(255, 255, 255, 255);
@@ -69,12 +69,12 @@ void TracepointThreadBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, 
 
   if (!picking) {
     capture_data_->ForEachTracepointEventOfThreadInTimeRange(
-        thread_id_, min_tick, max_tick,
+        GetThreadId(), min_tick, max_tick,
         [&](const orbit_client_protos::TracepointEventInfo& tracepoint) {
           uint64_t time = tracepoint.time();
           float radius = track_height / 4;
           Vec2 pos(time_graph_->GetWorldFromTick(time), pos_[1]);
-          if (thread_id_ == orbit_base::kAllThreadsOfAllProcessesTid) {
+          if (GetThreadId() == orbit_base::kAllThreadsOfAllProcessesTid) {
             const Color color = tracepoint.pid() == capture_data_->process_id() ? kGrey : kWhite;
             batcher->AddVerticalLine(pos, -track_height, z, color);
           } else {
@@ -91,7 +91,7 @@ void TracepointThreadBar::UpdatePrimitives(Batcher* batcher, uint64_t min_tick, 
     constexpr float kPickingBoxOffset = kPickingBoxWidth / 2.0f;
 
     capture_data_->ForEachTracepointEventOfThreadInTimeRange(
-        thread_id_, min_tick, max_tick,
+        GetThreadId(), min_tick, max_tick,
         [&](const orbit_client_protos::TracepointEventInfo& tracepoint) {
           uint64_t time = tracepoint.time();
           Vec2 pos(time_graph_->GetWorldFromTick(time) - kPickingBoxOffset,
@@ -121,7 +121,7 @@ std::string TracepointThreadBar::GetTracepointTooltip(Batcher* batcher, PickingI
   orbit_grpc_protos::TracepointInfo tracepoint_info =
       capture_data_->GetTracepointInfo(tracepoint_info_key);
 
-  if (thread_id_ == orbit_base::kAllThreadsOfAllProcessesTid) {
+  if (GetThreadId() == orbit_base::kAllThreadsOfAllProcessesTid) {
     return absl::StrFormat(
         "<b>%s : %s</b><br/>"
         "<i>Tracepoint event</i><br/>"
@@ -143,7 +143,8 @@ std::string TracepointThreadBar::GetTracepointTooltip(Batcher* batcher, PickingI
 }
 
 bool TracepointThreadBar::IsEmpty() const {
-  return capture_data_ == nullptr || capture_data_->GetNumTracepointsForThreadId(thread_id_) == 0;
+  return capture_data_ == nullptr ||
+         capture_data_->GetNumTracepointsForThreadId(GetThreadId()) == 0;
 }
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/TracepointThreadBar.h
+++ b/src/OrbitGl/TracepointThreadBar.h
@@ -20,7 +20,7 @@ class TracepointThreadBar : public ThreadBar {
   explicit TracepointThreadBar(CaptureViewElement* parent, OrbitApp* app, TimeGraph* time_graph,
                                orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                                const orbit_client_model::CaptureData* capture_data,
-                               int32_t thread_id);
+                               int32_t thread_id, const Color& color);
 
   void Draw(Batcher& batcher, TextRenderer& text_renderer,
             const DrawContext& draw_context) override;
@@ -30,12 +30,8 @@ class TracepointThreadBar : public ThreadBar {
 
   [[nodiscard]] bool IsEmpty() const override;
 
-  void SetColor(const Color& color) { color_ = color; }
-
  private:
   std::string GetTracepointTooltip(Batcher* batcher, PickingId id) const;
-
-  Color color_;
 };
 
 }  // namespace orbit_gl

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -24,7 +24,6 @@ Track::Track(CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::Viewpo
              TimeGraphLayout* layout, const orbit_client_model::CaptureData* capture_data)
     : CaptureViewElement(parent, time_graph, viewport, layout),
       num_prioritized_trailing_characters_{0},
-      thread_id_{orbit_base::kInvalidThreadTid},
       process_id_{-1},
       pinned_{false},
       layout_(layout),

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -114,7 +114,6 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   std::string name_;
   std::string label_;
   int num_prioritized_trailing_characters_;
-  int32_t thread_id_;
   int32_t process_id_;
   bool draw_background_ = true;
   bool visible_ = true;


### PR DESCRIPTION
Refactor to simplify Track interface (http://b/194504762).

 - We move thread_id_ to ThreadTrack class.
 - We start to use GetThreadId() to prepare to a possible future query.
 - A few refactor/cleanups.

Also we refactor color in ThreadBars.