### PR TITLE
Add protos for extended manual instrumentation.

### DIFF
--- a/src/CaptureClient/CaptureEventProcessor.cpp
+++ b/src/CaptureClient/CaptureEventProcessor.cpp
@@ -176,6 +176,28 @@ void CaptureEventProcessorForListener::ProcessEvent(const ClientCaptureEvent& ev
     case ClientCaptureEvent::kApiEvent:
       api_event_processor_.ProcessApiEvent(event.api_event());
       break;
+    case ClientCaptureEvent::kApiScopeStart:
+      UNREACHABLE();
+    case ClientCaptureEvent::kApiScopeStartAsync:
+      UNREACHABLE();
+    case ClientCaptureEvent::kApiScopeStop:
+      UNREACHABLE();
+    case ClientCaptureEvent::kApiScopeStopAsync:
+      UNREACHABLE();
+    case ClientCaptureEvent::kApiStringEvent:
+      UNREACHABLE();
+    case ClientCaptureEvent::kApiTrackDouble:
+      UNREACHABLE();
+    case ClientCaptureEvent::kApiTrackFloat:
+      UNREACHABLE();
+    case ClientCaptureEvent::kApiTrackInt:
+      UNREACHABLE();
+    case ClientCaptureEvent::kApiTrackInt64:
+      UNREACHABLE();
+    case ClientCaptureEvent::kApiTrackUint:
+      UNREACHABLE();
+    case ClientCaptureEvent::kApiTrackUint64:
+      UNREACHABLE();
     case ClientCaptureEvent::kWarningEvent:
       ProcessWarningEvent(event.warning_event());
       break;

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -148,7 +148,7 @@ message ApiScopeStart {
 
   // We encode the first 64 characters of the scope's name/label using fixed64
   // values, in order to avoid an additional allocation (for the internal
-  // vector) for short strings. Those allocations has shown a huge performance
+  // vector) for short strings. Those allocations have shown a huge performance
   // impact.
   // If the name exceeds the 64 characters, the `encoded_name_additional` will
   // be used to encode the additional characters.
@@ -162,7 +162,8 @@ message ApiScopeStart {
   fixed64 encoded_name_8 = 11;
   bytes encoded_name_additional = 12;
 
-  Color color = 13;
+  // "rgba" syntax.
+  uint32 color = 13;
   uint64 group_id = 14;
   uint64 address_in_function = 15;
 }
@@ -182,7 +183,7 @@ message ApiScopeStartAsync {
 
   // We encode the first 64 characters of the scope's name/label using fixed64
   // values, in order to avoid an additional allocation (for the internal
-  // vector) for short strings. Those allocations has shown a huge performance
+  // vector) for short strings. Those allocations have shown a huge performance
   // impact.
   // If the name exceeds the 64 characters, the `encoded_name_additional` will
   // be used to encode the additional characters.
@@ -196,7 +197,8 @@ message ApiScopeStartAsync {
   fixed64 encoded_name_8 = 11;
   bytes encoded_name_additional = 12;
 
-  Color color = 13;
+  // "rgba" syntax.
+  uint32 color = 13;
   uint64 id = 14;
   uint64 address_in_function = 15;
 }
@@ -216,7 +218,7 @@ message ApiStringEvent {
 
   // We encode the first 64 characters of the scope's name/label using fixed64
   // values, in order to avoid an additional allocation (for the internal
-  // vector) for short strings. Those allocations has shown a huge performance
+  // vector) for short strings. Those allocations have shown a huge performance
   // impact.
   // If the name exceeds the 64 characters, the `encoded_name_additional` will
   // be used to encode the additional characters.

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -140,10 +140,18 @@ message ApiEvent {
 }
 
 message ApiScopeStart {
+  // NextID: 16
+
   int32 pid = 1;
   int32 tid = 2;
   uint64 timestamp_ns = 3;
 
+  // We encode the first 64 characters of the scope's name/label using fixed64
+  // values, in order to avoid an additional allocation (for the internal
+  // vector) for short strings. Those allocations has shown a huge performance
+  // impact.
+  // If the name exceeds the 64 characters, the `additional_encode_name` will
+  // be used to encode the additional characters.
   fixed64 encoded_name_01 = 4;
   fixed64 encoded_name_02 = 5;
   fixed64 encoded_name_03 = 6;
@@ -152,20 +160,11 @@ message ApiScopeStart {
   fixed64 encoded_name_06 = 9;
   fixed64 encoded_name_07 = 10;
   fixed64 encoded_name_08 = 11;
-  fixed64 encoded_name_09 = 12;
-  fixed64 encoded_name_10 = 13;
-  fixed64 encoded_name_11 = 14;
-  fixed64 encoded_name_12 = 15;
-  fixed64 encoded_name_13 = 16;
-  fixed64 encoded_name_14 = 17;
-  fixed64 encoded_name_15 = 18;
-  fixed64 encoded_name_16 = 19;
+  bytes additional_encoded_name = 12;
 
-  bytes additional_encoded_name = 20;
-
-  Color color = 21;
-  uint64 group_id = 22;
-  uint64 address_in_function = 23;
+  Color color = 13;
+  uint64 group_id = 14;
+  uint64 address_in_function = 15;
 }
 
 message ApiScopeStop {
@@ -175,10 +174,18 @@ message ApiScopeStop {
 }
 
 message ApiScopeStartAsync {
+  // NextID: 16
+
   int32 pid = 1;
   int32 tid = 2;
   uint64 timestamp_ns = 3;
 
+  // We encode the first 64 characters of the scope's name/label using fixed64
+  // values, in order to avoid an additional allocation (for the internal
+  // vector) for short strings. Those allocations has shown a huge performance
+  // impact.
+  // If the name exceeds the 64 characters, the `additional_encode_name` will
+  // be used to encode the additional characters.
   fixed64 encoded_name_01 = 4;
   fixed64 encoded_name_02 = 5;
   fixed64 encoded_name_03 = 6;
@@ -187,20 +194,11 @@ message ApiScopeStartAsync {
   fixed64 encoded_name_06 = 9;
   fixed64 encoded_name_07 = 10;
   fixed64 encoded_name_08 = 11;
-  fixed64 encoded_name_09 = 12;
-  fixed64 encoded_name_10 = 13;
-  fixed64 encoded_name_11 = 14;
-  fixed64 encoded_name_12 = 15;
-  fixed64 encoded_name_13 = 16;
-  fixed64 encoded_name_14 = 17;
-  fixed64 encoded_name_15 = 18;
-  fixed64 encoded_name_16 = 19;
+  bytes additional_encoded_name = 12;
 
-  bytes additional_encoded_name = 20;
-
-  Color color = 21;
-  uint64 id = 22;
-  uint64 address_in_function = 23;
+  Color color = 13;
+  uint64 id = 14;
+  uint64 address_in_function = 15;
 }
 
 message ApiScopeStopAsync {
@@ -210,10 +208,18 @@ message ApiScopeStopAsync {
 }
 
 message ApiStringEvent {
+  // NextID: 14
+
   int32 pid = 1;
   int32 tid = 2;
   uint64 timestamp_ns = 3;
 
+  // We encode the first 64 characters of the scope's name/label using fixed64
+  // values, in order to avoid an additional allocation (for the internal
+  // vector) for short strings. Those allocations has shown a huge performance
+  // impact.
+  // If the name exceeds the 64 characters, the `additional_encode_name` will
+  // be used to encode the additional characters.
   fixed64 encoded_name_01 = 4;
   fixed64 encoded_name_02 = 5;
   fixed64 encoded_name_03 = 6;
@@ -222,17 +228,9 @@ message ApiStringEvent {
   fixed64 encoded_name_06 = 9;
   fixed64 encoded_name_07 = 10;
   fixed64 encoded_name_08 = 11;
-  fixed64 encoded_name_09 = 12;
-  fixed64 encoded_name_10 = 13;
-  fixed64 encoded_name_11 = 14;
-  fixed64 encoded_name_12 = 15;
-  fixed64 encoded_name_13 = 16;
-  fixed64 encoded_name_14 = 17;
-  fixed64 encoded_name_15 = 18;
-  fixed64 encoded_name_16 = 19;
+  bytes additional_encoded_name = 12;
 
-  bytes additional_encoded_name = 20;
-  uint64 id = 21;
+  uint64 id = 13;
 }
 
 message ApiTrackInt {
@@ -311,7 +309,12 @@ message CallstackSample {
   uint64 callstack_id = 3;
   uint64 timestamp_ns = 4;
 }
-
+// We encode the first 64 characters of the scope's name/label using fixed64
+// values, in order to avoid an additional allocation (for the internal
+// vector) for short strings. Those allocations has shown a huge performance
+// impact.
+// If the name exceeds the 64 characters, the `additional_encode_name` will
+// be used to encode the additional characters.
 message FullCallstackSample {
   int32 pid = 1;
   int32 tid = 2;

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -139,6 +139,150 @@ message ApiEvent {
   fixed64 r5 = 9;
 }
 
+message ApiScopeStart {
+  int32 pid = 1;
+  int32 tid = 2;
+  uint64 timestamp_ns = 3;
+
+  fixed64 encoded_name_01 = 4;
+  fixed64 encoded_name_02 = 5;
+  fixed64 encoded_name_03 = 6;
+  fixed64 encoded_name_04 = 7;
+  fixed64 encoded_name_05 = 8;
+  fixed64 encoded_name_06 = 9;
+  fixed64 encoded_name_07 = 10;
+  fixed64 encoded_name_08 = 11;
+  fixed64 encoded_name_09 = 12;
+  fixed64 encoded_name_10 = 13;
+  fixed64 encoded_name_11 = 14;
+  fixed64 encoded_name_12 = 15;
+  fixed64 encoded_name_13 = 16;
+  fixed64 encoded_name_14 = 17;
+  fixed64 encoded_name_15 = 18;
+  fixed64 encoded_name_16 = 19;
+
+  bytes additional_encoded_name = 20;
+
+  Color color = 21;
+  uint64 group_id = 22;
+  uint64 address_in_function = 23;
+}
+
+message ApiScopeStop {
+  int32 pid = 1;
+  int32 tid = 2;
+  uint64 timestamp_ns = 3;
+}
+
+message ApiScopeStartAsync {
+  int32 pid = 1;
+  int32 tid = 2;
+  uint64 timestamp_ns = 3;
+
+  fixed64 encoded_name_01 = 4;
+  fixed64 encoded_name_02 = 5;
+  fixed64 encoded_name_03 = 6;
+  fixed64 encoded_name_04 = 7;
+  fixed64 encoded_name_05 = 8;
+  fixed64 encoded_name_06 = 9;
+  fixed64 encoded_name_07 = 10;
+  fixed64 encoded_name_08 = 11;
+  fixed64 encoded_name_09 = 12;
+  fixed64 encoded_name_10 = 13;
+  fixed64 encoded_name_11 = 14;
+  fixed64 encoded_name_12 = 15;
+  fixed64 encoded_name_13 = 16;
+  fixed64 encoded_name_14 = 17;
+  fixed64 encoded_name_15 = 18;
+  fixed64 encoded_name_16 = 19;
+
+  bytes additional_encoded_name = 20;
+
+  Color color = 21;
+  uint64 id = 22;
+  uint64 address_in_function = 23;
+}
+
+message ApiScopeStopAsync {
+  int32 pid = 1;
+  int32 tid = 2;
+  uint64 timestamp_ns = 3;
+}
+
+message ApiStringEvent {
+  int32 pid = 1;
+  int32 tid = 2;
+  uint64 timestamp_ns = 3;
+
+  fixed64 encoded_name_01 = 4;
+  fixed64 encoded_name_02 = 5;
+  fixed64 encoded_name_03 = 6;
+  fixed64 encoded_name_04 = 7;
+  fixed64 encoded_name_05 = 8;
+  fixed64 encoded_name_06 = 9;
+  fixed64 encoded_name_07 = 10;
+  fixed64 encoded_name_08 = 11;
+  fixed64 encoded_name_09 = 12;
+  fixed64 encoded_name_10 = 13;
+  fixed64 encoded_name_11 = 14;
+  fixed64 encoded_name_12 = 15;
+  fixed64 encoded_name_13 = 16;
+  fixed64 encoded_name_14 = 17;
+  fixed64 encoded_name_15 = 18;
+  fixed64 encoded_name_16 = 19;
+
+  bytes additional_encoded_name = 20;
+  uint64 id = 21;
+}
+
+message ApiTrackInt {
+  int32 pid = 1;
+  int32 tid = 2;
+  uint64 timestamp_ns = 3;
+
+  int32 data = 4;
+}
+
+message ApiTrackInt64 {
+  int32 pid = 1;
+  int32 tid = 2;
+  uint64 timestamp_ns = 3;
+
+  int64 data = 4;
+}
+
+message ApiTrackUint {
+  int32 pid = 1;
+  int32 tid = 2;
+  uint64 timestamp_ns = 3;
+
+  uint32 data = 4;
+}
+
+message ApiTrackUint64 {
+  int32 pid = 1;
+  int32 tid = 2;
+  uint64 timestamp_ns = 3;
+
+  uint64 data = 4;
+}
+
+message ApiTrackFloat {
+  int32 pid = 1;
+  int32 tid = 2;
+  uint64 timestamp_ns = 3;
+
+  float data = 4;
+}
+
+message ApiTrackDouble {
+  int32 pid = 1;
+  int32 tid = 2;
+  uint64 timestamp_ns = 3;
+
+  double data = 4;
+}
+
 message Callstack {
   repeated uint64 pcs = 1;
 
@@ -467,8 +611,8 @@ message ClientCaptureEvent {
     // use them for high frequency events. For the rest please assign
     // numbers starting with 16.
     //
-    // Next high-frequency ID: 10
-    // Next lower-frequency ID: 38
+    // Next high-frequency ID: -- out of numbers
+    // Next lower-frequency ID: 43
     // Please keep these alphabetically ordered.
 
     // Even though AddressInfo is a high-frequency event
@@ -476,6 +620,17 @@ message ClientCaptureEvent {
     // frame-pointer based unwinding.
     AddressInfo address_info = 16;
     ApiEvent api_event = 9;
+    ApiScopeStart api_scope_start = 10;
+    ApiScopeStartAsync api_scope_start_async = 11;
+    ApiScopeStart api_scope_stop = 12;
+    ApiScopeStartAsync api_scope_stop_async = 13;
+    ApiStringEvent api_string_event = 14;
+    ApiTrackDouble api_track_double = 15;
+    ApiTrackFloat api_track_float = 38;
+    ApiTrackInt api_track_int = 39;
+    ApiTrackInt64 api_track_int64 = 40;
+    ApiTrackUint api_track_uint = 41;
+    ApiTrackUint64 api_track_uint64 = 42;
     CallstackSample callstack_sample = 1;
     CaptureFinished capture_finished = 27;
     CaptureStarted capture_started = 24;
@@ -511,11 +666,22 @@ message ProducerCaptureEvent {
     // use them for high frequency events. For the rest please assign
     // numbers starting with 16.
     //
-    // Next high-frequency ID: 11
-    // Next lower-frequency ID: 36
+    // Next high-frequency ID: -- out of numbers
+    // Next lower-frequency ID: 44
     //
     // Please keep these alphabetically ordered.
     ApiEvent api_event = 10;
+    ApiScopeStart api_scope_start = 11;
+    ApiScopeStartAsync api_scope_start_async = 12;
+    ApiScopeStart api_scope_stop = 13;
+    ApiScopeStartAsync api_scope_stop_async = 14;
+    ApiStringEvent api_string_event = 15;
+    ApiTrackDouble api_track_double = 38;
+    ApiTrackFloat api_track_float = 39;
+    ApiTrackInt api_track_int = 40;
+    ApiTrackInt64 api_track_int64 = 41;
+    ApiTrackUint api_track_uint = 42;
+    ApiTrackUint64 api_track_uint64 = 43;
     CallstackSample callstack_sample = 1;
     CaptureStarted capture_started = 23;
     ClockResolutionEvent clock_resolution_event = 32;

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -625,8 +625,8 @@ message ClientCaptureEvent {
     ApiEvent api_event = 9;
     ApiScopeStart api_scope_start = 10;
     ApiScopeStartAsync api_scope_start_async = 11;
-    ApiScopeStart api_scope_stop = 12;
-    ApiScopeStartAsync api_scope_stop_async = 13;
+    ApiScopeStop api_scope_stop = 12;
+    ApiScopeStopAsync api_scope_stop_async = 13;
     ApiStringEvent api_string_event = 14;
     ApiTrackDouble api_track_double = 15;
     ApiTrackFloat api_track_float = 38;
@@ -676,8 +676,8 @@ message ProducerCaptureEvent {
     ApiEvent api_event = 10;
     ApiScopeStart api_scope_start = 11;
     ApiScopeStartAsync api_scope_start_async = 12;
-    ApiScopeStart api_scope_stop = 13;
-    ApiScopeStartAsync api_scope_stop_async = 14;
+    ApiScopeStop api_scope_stop = 13;
+    ApiScopeStopAsync api_scope_stop_async = 14;
     ApiStringEvent api_string_event = 15;
     ApiTrackDouble api_track_double = 38;
     ApiTrackFloat api_track_float = 39;

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -150,17 +150,17 @@ message ApiScopeStart {
   // values, in order to avoid an additional allocation (for the internal
   // vector) for short strings. Those allocations has shown a huge performance
   // impact.
-  // If the name exceeds the 64 characters, the `additional_encode_name` will
+  // If the name exceeds the 64 characters, the `encoded_name_additional` will
   // be used to encode the additional characters.
-  fixed64 encoded_name_01 = 4;
-  fixed64 encoded_name_02 = 5;
-  fixed64 encoded_name_03 = 6;
-  fixed64 encoded_name_04 = 7;
-  fixed64 encoded_name_05 = 8;
-  fixed64 encoded_name_06 = 9;
-  fixed64 encoded_name_07 = 10;
-  fixed64 encoded_name_08 = 11;
-  bytes additional_encoded_name = 12;
+  fixed64 encoded_name_1 = 4;
+  fixed64 encoded_name_2 = 5;
+  fixed64 encoded_name_3 = 6;
+  fixed64 encoded_name_4 = 7;
+  fixed64 encoded_name_5 = 8;
+  fixed64 encoded_name_6 = 9;
+  fixed64 encoded_name_7 = 10;
+  fixed64 encoded_name_8 = 11;
+  bytes encoded_name_additional = 12;
 
   Color color = 13;
   uint64 group_id = 14;
@@ -184,17 +184,17 @@ message ApiScopeStartAsync {
   // values, in order to avoid an additional allocation (for the internal
   // vector) for short strings. Those allocations has shown a huge performance
   // impact.
-  // If the name exceeds the 64 characters, the `additional_encode_name` will
+  // If the name exceeds the 64 characters, the `encoded_name_additional` will
   // be used to encode the additional characters.
-  fixed64 encoded_name_01 = 4;
-  fixed64 encoded_name_02 = 5;
-  fixed64 encoded_name_03 = 6;
-  fixed64 encoded_name_04 = 7;
-  fixed64 encoded_name_05 = 8;
-  fixed64 encoded_name_06 = 9;
-  fixed64 encoded_name_07 = 10;
-  fixed64 encoded_name_08 = 11;
-  bytes additional_encoded_name = 12;
+  fixed64 encoded_name_1 = 4;
+  fixed64 encoded_name_2 = 5;
+  fixed64 encoded_name_3 = 6;
+  fixed64 encoded_name_4 = 7;
+  fixed64 encoded_name_5 = 8;
+  fixed64 encoded_name_6 = 9;
+  fixed64 encoded_name_7 = 10;
+  fixed64 encoded_name_8 = 11;
+  bytes encoded_name_additional = 12;
 
   Color color = 13;
   uint64 id = 14;
@@ -218,17 +218,17 @@ message ApiStringEvent {
   // values, in order to avoid an additional allocation (for the internal
   // vector) for short strings. Those allocations has shown a huge performance
   // impact.
-  // If the name exceeds the 64 characters, the `additional_encode_name` will
+  // If the name exceeds the 64 characters, the `encoded_name_additional` will
   // be used to encode the additional characters.
-  fixed64 encoded_name_01 = 4;
-  fixed64 encoded_name_02 = 5;
-  fixed64 encoded_name_03 = 6;
-  fixed64 encoded_name_04 = 7;
-  fixed64 encoded_name_05 = 8;
-  fixed64 encoded_name_06 = 9;
-  fixed64 encoded_name_07 = 10;
-  fixed64 encoded_name_08 = 11;
-  bytes additional_encoded_name = 12;
+  fixed64 encoded_name_1 = 4;
+  fixed64 encoded_name_2 = 5;
+  fixed64 encoded_name_3 = 6;
+  fixed64 encoded_name_4 = 7;
+  fixed64 encoded_name_5 = 8;
+  fixed64 encoded_name_6 = 9;
+  fixed64 encoded_name_7 = 10;
+  fixed64 encoded_name_8 = 11;
+  bytes encoded_name_additional = 12;
 
   uint64 id = 13;
 }
@@ -309,12 +309,7 @@ message CallstackSample {
   uint64 callstack_id = 3;
   uint64 timestamp_ns = 4;
 }
-// We encode the first 64 characters of the scope's name/label using fixed64
-// values, in order to avoid an additional allocation (for the internal
-// vector) for short strings. Those allocations has shown a huge performance
-// impact.
-// If the name exceeds the 64 characters, the `additional_encode_name` will
-// be used to encode the additional characters.
+
 message FullCallstackSample {
   int32 pid = 1;
   int32 tid = 2;
@@ -614,8 +609,8 @@ message ClientCaptureEvent {
     // use them for high frequency events. For the rest please assign
     // numbers starting with 16.
     //
-    // Next high-frequency ID: -- out of numbers
-    // Next lower-frequency ID: 43
+    // Next high-frequency ID: 12
+    // Next lower-frequency ID: 47
     // Please keep these alphabetically ordered.
 
     // Even though AddressInfo is a high-frequency event
@@ -624,16 +619,16 @@ message ClientCaptureEvent {
     AddressInfo address_info = 16;
     ApiEvent api_event = 9;
     ApiScopeStart api_scope_start = 10;
-    ApiScopeStartAsync api_scope_start_async = 11;
-    ApiScopeStop api_scope_stop = 12;
-    ApiScopeStopAsync api_scope_stop_async = 13;
-    ApiStringEvent api_string_event = 14;
-    ApiTrackDouble api_track_double = 15;
-    ApiTrackFloat api_track_float = 38;
-    ApiTrackInt api_track_int = 39;
-    ApiTrackInt64 api_track_int64 = 40;
-    ApiTrackUint api_track_uint = 41;
-    ApiTrackUint64 api_track_uint64 = 42;
+    ApiScopeStartAsync api_scope_start_async = 38;
+    ApiScopeStop api_scope_stop = 11;
+    ApiScopeStopAsync api_scope_stop_async = 39;
+    ApiStringEvent api_string_event = 40;
+    ApiTrackDouble api_track_double = 41;
+    ApiTrackFloat api_track_float = 42;
+    ApiTrackInt api_track_int = 43;
+    ApiTrackInt64 api_track_int64 = 44;
+    ApiTrackUint api_track_uint = 45;
+    ApiTrackUint64 api_track_uint64 = 46;
     CallstackSample callstack_sample = 1;
     CaptureFinished capture_finished = 27;
     CaptureStarted capture_started = 24;
@@ -669,22 +664,22 @@ message ProducerCaptureEvent {
     // use them for high frequency events. For the rest please assign
     // numbers starting with 16.
     //
-    // Next high-frequency ID: -- out of numbers
-    // Next lower-frequency ID: 44
+    // Next high-frequency ID: 13
+    // Next lower-frequency ID: 45
     //
     // Please keep these alphabetically ordered.
     ApiEvent api_event = 10;
     ApiScopeStart api_scope_start = 11;
-    ApiScopeStartAsync api_scope_start_async = 12;
-    ApiScopeStop api_scope_stop = 13;
-    ApiScopeStopAsync api_scope_stop_async = 14;
-    ApiStringEvent api_string_event = 15;
-    ApiTrackDouble api_track_double = 38;
-    ApiTrackFloat api_track_float = 39;
-    ApiTrackInt api_track_int = 40;
-    ApiTrackInt64 api_track_int64 = 41;
-    ApiTrackUint api_track_uint = 42;
-    ApiTrackUint64 api_track_uint64 = 43;
+    ApiScopeStartAsync api_scope_start_async = 36;
+    ApiScopeStop api_scope_stop = 12;
+    ApiScopeStopAsync api_scope_stop_async = 37;
+    ApiStringEvent api_string_event = 38;
+    ApiTrackDouble api_track_double = 39;
+    ApiTrackFloat api_track_float = 40;
+    ApiTrackInt api_track_int = 41;
+    ApiTrackInt64 api_track_int64 = 42;
+    ApiTrackUint api_track_uint = 43;
+    ApiTrackUint64 api_track_uint64 = 44;
     CallstackSample callstack_sample = 1;
     CaptureStarted capture_started = 23;
     ClockResolutionEvent clock_resolution_event = 32;

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -162,8 +162,7 @@ message ApiScopeStart {
   fixed64 encoded_name_8 = 11;
   bytes encoded_name_additional = 12;
 
-  // "rgba" syntax.
-  uint32 color = 13;
+  uint32 color_rgba = 13;
   uint64 group_id = 14;
   uint64 address_in_function = 15;
 }
@@ -197,8 +196,7 @@ message ApiScopeStartAsync {
   fixed64 encoded_name_8 = 11;
   bytes encoded_name_additional = 12;
 
-  // "rgba" syntax.
-  uint32 color = 13;
+  uint32 color_rgba = 13;
   uint64 id = 14;
   uint64 address_in_function = 15;
 }

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
@@ -518,6 +518,28 @@ void VerifyOrderOfAllEvents(const std::vector<orbit_grpc_protos::ProducerCapture
         UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kApiEvent:
         UNREACHABLE();
+      case orbit_grpc_protos::ProducerCaptureEvent::kApiScopeStart:
+        UNREACHABLE();
+      case orbit_grpc_protos::ProducerCaptureEvent::kApiScopeStartAsync:
+        UNREACHABLE();
+      case orbit_grpc_protos::ProducerCaptureEvent::kApiScopeStop:
+        UNREACHABLE();
+      case orbit_grpc_protos::ProducerCaptureEvent::kApiScopeStopAsync:
+        UNREACHABLE();
+      case orbit_grpc_protos::ProducerCaptureEvent::kApiStringEvent:
+        UNREACHABLE();
+      case orbit_grpc_protos::ProducerCaptureEvent::kApiTrackDouble:
+        UNREACHABLE();
+      case orbit_grpc_protos::ProducerCaptureEvent::kApiTrackFloat:
+        UNREACHABLE();
+      case orbit_grpc_protos::ProducerCaptureEvent::kApiTrackInt:
+        UNREACHABLE();
+      case orbit_grpc_protos::ProducerCaptureEvent::kApiTrackInt64:
+        UNREACHABLE();
+      case orbit_grpc_protos::ProducerCaptureEvent::kApiTrackUint:
+        UNREACHABLE();
+      case orbit_grpc_protos::ProducerCaptureEvent::kApiTrackUint64:
+        UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kWarningEvent:
         UNREACHABLE();
       case orbit_grpc_protos::ProducerCaptureEvent::kClockResolutionEvent:

--- a/src/Service/ProducerEventProcessor.cpp
+++ b/src/Service/ProducerEventProcessor.cpp
@@ -481,6 +481,28 @@ void ProducerEventProcessorImpl::ProcessEvent(uint64_t producer_id, ProducerCapt
     case ProducerCaptureEvent::kApiEvent:
       ProcessApiEventAndTransferOwnership(event.release_api_event());
       break;
+    case orbit_grpc_protos::ProducerCaptureEvent::kApiScopeStart:
+      UNREACHABLE();
+    case orbit_grpc_protos::ProducerCaptureEvent::kApiScopeStartAsync:
+      UNREACHABLE();
+    case orbit_grpc_protos::ProducerCaptureEvent::kApiScopeStop:
+      UNREACHABLE();
+    case orbit_grpc_protos::ProducerCaptureEvent::kApiScopeStopAsync:
+      UNREACHABLE();
+    case orbit_grpc_protos::ProducerCaptureEvent::kApiStringEvent:
+      UNREACHABLE();
+    case orbit_grpc_protos::ProducerCaptureEvent::kApiTrackDouble:
+      UNREACHABLE();
+    case orbit_grpc_protos::ProducerCaptureEvent::kApiTrackFloat:
+      UNREACHABLE();
+    case orbit_grpc_protos::ProducerCaptureEvent::kApiTrackInt:
+      UNREACHABLE();
+    case orbit_grpc_protos::ProducerCaptureEvent::kApiTrackInt64:
+      UNREACHABLE();
+    case orbit_grpc_protos::ProducerCaptureEvent::kApiTrackUint:
+      UNREACHABLE();
+    case orbit_grpc_protos::ProducerCaptureEvent::kApiTrackUint64:
+      UNREACHABLE();
     case ProducerCaptureEvent::kWarningEvent:
       ProcessWarningEventAndTransferOwnership(event.release_warning_event());
       break;


### PR DESCRIPTION
As discussed in go/stadia-orbit-dxvk, we need a couple of extensions
for manual instrumentation:
1. Require larger strings; With this change we allow for 128
   characters "fast" encoded, and arbitrary long strings. Only
   strings are encoded via fixed64 values, not structs anymore.
2. Add a "group id", to group together various synchronous scopes.
3. A program counter from within the function that had the start
   macro.

Note, this change is only adding the protos, neither the processing,
nor the creation is done here.

Follow-up:
1. Process the protos.
2. Create v1 of manual instrumentation to create the data.
3. Convert from old ApiEvents to new events and drop the old
   proto/processing.

Test: Compile
Bug: http://b/194763537; http://b/194764373; http://b/194764259.