### PR TITLE
Fix small nits.

### DIFF
--- a/src/OrbitBase/ExecutablePathLinuxTest.cpp
+++ b/src/OrbitBase/ExecutablePathLinuxTest.cpp
@@ -12,6 +12,10 @@
 #include "OrbitBase/Result.h"
 
 TEST(ExecutablePathLinux, GetExecutablePathWithPid) {
+  /* copybara:insert(executable is named differently)
+  GTEST_SKIP();
+  */
+
   const auto path_or_error = orbit_base::GetExecutablePath(getpid());
   ASSERT_FALSE(path_or_error.has_error()) << path_or_error.error().message();
   EXPECT_EQ(path_or_error.value().filename(), "OrbitBaseTests");

--- a/src/OrbitBase/ExecutablePathTest.cpp
+++ b/src/OrbitBase/ExecutablePathTest.cpp
@@ -10,6 +10,10 @@
 #include "OrbitBase/ExecutablePath.h"
 
 TEST(ExecutablePath, GetExecutablePath) {
+  /* copybara:insert(executable is named differently)
+  GTEST_SKIP();
+  */
+
   std::filesystem::path path = orbit_base::GetExecutablePath();
 #ifdef _WIN32
   const std::string executable_name = "OrbitBaseTests.exe";
@@ -21,5 +25,9 @@ TEST(ExecutablePath, GetExecutablePath) {
 }
 
 TEST(ExecutablePath, GetExecutableDir) {
+  /* copybara:insert(executable's directory is named differently)
+  GTEST_SKIP();
+  */
+
   EXPECT_EQ(orbit_base::GetExecutableDir().filename(), "bin");
 }

--- a/src/OrbitBase/GetProcessIdsLinuxTest.cpp
+++ b/src/OrbitBase/GetProcessIdsLinuxTest.cpp
@@ -62,8 +62,9 @@ TEST(GetProcessIdsLinux, GetTidsOfProcess) {
   }
   thread.join();
 
-  std::vector<pid_t> expected_tids{main_tid, thread_tid};
-  EXPECT_THAT(returned_tids, ::testing::UnorderedElementsAreArray(expected_tids));
+  // There might be more than these two threads (i.e. when compiled with sanitizers enabled)
+  EXPECT_THAT(returned_tids, ::testing::Contains(main_tid));
+  EXPECT_THAT(returned_tids, ::testing::Contains(thread_tid));
 }
 
 TEST(GetProcessIdsLinux, GetTracerPidOfProcess) {

--- a/src/OrbitBase/PromiseHelpersTest.cpp
+++ b/src/OrbitBase/PromiseHelpersTest.cpp
@@ -3,7 +3,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <gtest/gtest-typed-test.h>
 #include <gtest/gtest.h>
 
 #include "OrbitBase/Promise.h"


### PR DESCRIPTION
When compiling in a different environment some assumptions in the tests are not true anymore.

This PR is conditionally disabled the non-working tests when the code is copybarad somewhere else.