### PR TITLE
Minor additional performance improvements to OrbitService

### DIFF
--- a/src/LinuxTracing/TracerThread.h
+++ b/src/LinuxTracing/TracerThread.h
@@ -129,8 +129,8 @@ class TracerThread {
   static constexpr uint64_t GPU_TRACING_RING_BUFFER_SIZE_KB = 256;
   static constexpr uint64_t INSTRUMENTED_TRACEPOINTS_RING_BUFFER_SIZE_KB = 8 * 1024;
 
-  static constexpr uint32_t IDLE_TIME_ON_EMPTY_RING_BUFFERS_US = 1000;
-  static constexpr uint32_t IDLE_TIME_ON_EMPTY_DEFERRED_EVENTS_US = 1000;
+  static constexpr uint32_t IDLE_TIME_ON_EMPTY_RING_BUFFERS_US = 5000;
+  static constexpr uint32_t IDLE_TIME_ON_EMPTY_DEFERRED_EVENTS_US = 5000;
 
   bool trace_context_switches_;
   pid_t target_pid_;

--- a/src/Service/CaptureEventSender.h
+++ b/src/Service/CaptureEventSender.h
@@ -14,7 +14,7 @@ namespace orbit_service {
 class CaptureEventSender {
  public:
   virtual ~CaptureEventSender() = default;
-  virtual void SendEvents(std::vector<orbit_grpc_protos::ClientCaptureEvent>&& events) = 0;
+  virtual void SendEvents(std::vector<orbit_grpc_protos::ClientCaptureEvent>* events) = 0;
 };
 
 }  // namespace orbit_service

--- a/src/Service/CaptureServiceImpl.cpp
+++ b/src/Service/CaptureServiceImpl.cpp
@@ -4,6 +4,7 @@
 
 #include "CaptureServiceImpl.h"
 
+#include <absl/base/thread_annotations.h>
 #include <absl/container/flat_hash_set.h>
 #include <absl/synchronization/mutex.h>
 #include <absl/time/time.h>
@@ -52,11 +53,11 @@ class SenderThreadCaptureEventBuffer final : public CaptureEventBuffer {
   }
 
   void AddEvent(ClientCaptureEvent&& event) override {
-    absl::MutexLock lock{&event_buffer_mutex_};
+    absl::MutexLock lock{&events_being_buffered_mutex_};
     if (stop_requested_) {
       return;
     }
-    event_buffer_.emplace_back(std::move(event));
+    events_being_buffered_.emplace_back(std::move(event));
   }
 
   void StopAndWait() {
@@ -64,7 +65,7 @@ class SenderThreadCaptureEventBuffer final : public CaptureEventBuffer {
     {
       // Protect stop_requested_ with event_buffer_mutex_ so that we can use stop_requested_
       // in Conditions for Await/LockWhen (specifically, in SenderThread).
-      absl::MutexLock lock{&event_buffer_mutex_};
+      absl::MutexLock lock{&events_being_buffered_mutex_};
       stop_requested_ = true;
     }
     sender_thread_.join();
@@ -83,29 +84,34 @@ class SenderThreadCaptureEventBuffer final : public CaptureEventBuffer {
     bool stopped = false;
     while (!stopped) {
       ORBIT_SCOPE("SenderThread iteration");
-      event_buffer_mutex_.LockWhenWithTimeout(absl::Condition(
-                                                  +[](SenderThreadCaptureEventBuffer* self) {
-                                                    return self->event_buffer_.size() >=
-                                                               kSendEventCountInterval ||
-                                                           self->stop_requested_;
-                                                  },
-                                                  this),
-                                              kSendTimeInterval);
+
+      events_being_buffered_mutex_.LockWhenWithTimeout(
+          absl::Condition(
+              +[](SenderThreadCaptureEventBuffer* self) {
+                return self->events_being_buffered_.size() >= kSendEventCountInterval ||
+                       self->stop_requested_;
+              },
+              this),
+          kSendTimeInterval);
       if (stop_requested_) {
         stopped = true;
       }
-      std::vector<ClientCaptureEvent> buffered_events = std::move(event_buffer_);
-      event_buffer_.clear();
-      event_buffer_mutex_.Unlock();
-      capture_event_sender_->SendEvents(std::move(buffered_events));
+      events_being_buffered_.swap(events_to_send_);
+      events_being_buffered_mutex_.Unlock();
+
+      capture_event_sender_->SendEvents(&events_to_send_);
+      // std::vector::clear() "Leaves the capacity() of the vector unchanged", which is desired.
+      events_to_send_.clear();
     }
   }
 
-  std::vector<ClientCaptureEvent> event_buffer_;
-  absl::Mutex event_buffer_mutex_;
+  std::vector<ClientCaptureEvent> events_being_buffered_
+      ABSL_GUARDED_BY(events_being_buffered_mutex_);
+  absl::Mutex events_being_buffered_mutex_;
+  std::vector<ClientCaptureEvent> events_to_send_;
   CaptureEventSender* capture_event_sender_;
   std::thread sender_thread_;
-  bool stop_requested_ = false;
+  bool stop_requested_ ABSL_GUARDED_BY(events_being_buffered_mutex_) = false;
 };
 
 class GrpcCaptureEventSender final : public CaptureEventSender {
@@ -128,17 +134,18 @@ class GrpcCaptureEventSender final : public CaptureEventSender {
     LOG("Average number of bytes per event: %.2f", average_bytes);
   }
 
-  void SendEvents(std::vector<ClientCaptureEvent>&& events) override {
+  void SendEvents(std::vector<ClientCaptureEvent>* events) override {
     ORBIT_SCOPE_FUNCTION;
-    ORBIT_UINT64("Number of buffered events sent", events.size());
-    if (events.empty()) {
+    CHECK(events != nullptr);
+    ORBIT_UINT64("Number of buffered events sent", events->size());
+    if (events->empty()) {
       return;
     }
 
     constexpr uint64_t kMaxEventsPerResponse = 10'000;
     uint64_t number_of_bytes_sent = 0;
     CaptureResponse response;
-    for (ClientCaptureEvent& event : events) {
+    for (ClientCaptureEvent& event : *events) {
       // We buffer to avoid sending countless tiny messages, but we also want to
       // avoid huge messages, which would cause the capture on the client to jump
       // forward in time in few big steps and not look live anymore.
@@ -154,10 +161,10 @@ class GrpcCaptureEventSender final : public CaptureEventSender {
 
     // Ensure we can divide by 0.f safely.
     static_assert(std::numeric_limits<float>::is_iec559);
-    float average_bytes = static_cast<float>(number_of_bytes_sent) / events.size();
+    float average_bytes = static_cast<float>(number_of_bytes_sent) / events->size();
 
     ORBIT_FLOAT("Average bytes per CaptureEvent", average_bytes);
-    total_number_of_events_sent_ += events.size();
+    total_number_of_events_sent_ += events->size();
     total_number_of_bytes_sent_ += number_of_bytes_sent;
   }
 


### PR DESCRIPTION
#### Use double buffering instead of TracerThread::deferred_events_
This greatly reduced the number of times `std::vector::__emplace_back_slow_path`
is hit for this case (verified by capturing `OrbitService` with `Orbit`).

I've instrumented Trata's
`eva::graphics::rendering::spatial_geometry::world_sphere() const`
(the same as the YHITI tests) and observed the memory usage of `OrbitService`
after 30 s of capture, without noticing any significant difference.

Also switch to `absl::Mutex` as that's what we use in the majority of cases.
#### Double buffer instead of SenderThreadCaptureEventBuffer::event_buffer_
This greatly reduced the number of times `std::vector::__emplace_back_slow_path`
is hit for this case (verified by capturing `OrbitService` with `Orbit`).

I've instrumented Trata's
`eva::graphics::rendering::spatial_geometry::world_sphere() const`
(the same as the YHITI tests) and observed the memory usage of `OrbitService`
after 30 s of capture, without noticing any significant difference.
#### Further increase IDLE_TIME_ON_EMPTY_{RING_BUFFERS,DEFERRED_EVENTS}_US
We have seen in go/stadia-orbit-service-vs-perf that we still spend quite some
time calling `usleep`, so let's increase this further as the sizes of the
`perf_event_open` ring buffers allow for much longer times without being polled
(necessary if `OrbitService` is not scheduled for a while).

When capturing nothing with
```
./OrbitFakeClient --pid=10189 --frame_time=false --gpu_jobs=false \
--scheduling=false --sampling_rate=0
```
CPU utilization of OrbitService goes down from ~1.5% to ~0.5%.

This benefit is even higher on normal captures as the number of context switches
that end up being recorded is lower, as `OrbitService` itself causes fewer.

Test: Comparing with main when instrumenting Trata's `execute_task`: the
frequency of the (rare) lost/discarded events doesn't seem to increase.