### PR TITLE
Process new Api Events on the Service and Send to Client.

### DIFF
--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -200,6 +200,7 @@ message ApiScopeStopAsync {
   int32 pid = 1;
   int32 tid = 2;
   uint64 timestamp_ns = 3;
+  uint64 id = 4;
 }
 
 message ApiStringEvent {

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -155,7 +155,7 @@ message ApiScopeStart {
   fixed64 encoded_name_6 = 9;
   fixed64 encoded_name_7 = 10;
   fixed64 encoded_name_8 = 11;
-  bytes encoded_name_additional = 12;
+  repeated fixed64 encoded_name_additional = 12;
 
   uint32 color_rgba = 13;
   uint64 group_id = 14;
@@ -189,7 +189,7 @@ message ApiScopeStartAsync {
   fixed64 encoded_name_6 = 9;
   fixed64 encoded_name_7 = 10;
   fixed64 encoded_name_8 = 11;
-  bytes encoded_name_additional = 12;
+  repeated fixed64 encoded_name_additional = 12;
 
   uint32 color_rgba = 13;
   uint64 id = 14;
@@ -224,7 +224,7 @@ message ApiStringEvent {
   fixed64 encoded_name_6 = 9;
   fixed64 encoded_name_7 = 10;
   fixed64 encoded_name_8 = 11;
-  bytes encoded_name_additional = 12;
+  repeated fixed64 encoded_name_additional = 12;
 
   uint64 id = 13;
 }

--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -146,7 +146,9 @@ message ApiScopeStart {
   // vector) for short strings. Those allocations have shown a huge performance
   // impact.
   // If the name exceeds the 64 characters, the `encoded_name_additional` will
-  // be used to encode the additional characters.
+  // be used to encode the additional characters. This is also a sequence of
+  // `fixed64` instead of a `bytes` field so that it can be allocated on an
+  // `Arena` (`std::string`s cannot be allocated in `Arena`s).
   fixed64 encoded_name_1 = 4;
   fixed64 encoded_name_2 = 5;
   fixed64 encoded_name_3 = 6;
@@ -180,7 +182,9 @@ message ApiScopeStartAsync {
   // vector) for short strings. Those allocations have shown a huge performance
   // impact.
   // If the name exceeds the 64 characters, the `encoded_name_additional` will
-  // be used to encode the additional characters.
+  // be used to encode the additional characters. This is also a sequence of
+  // `fixed64` instead of a `bytes` field so that it can be allocated on an
+  // `Arena` (`std::string`s cannot be allocated in `Arena`s).
   fixed64 encoded_name_1 = 4;
   fixed64 encoded_name_2 = 5;
   fixed64 encoded_name_3 = 6;
@@ -215,7 +219,9 @@ message ApiStringEvent {
   // vector) for short strings. Those allocations have shown a huge performance
   // impact.
   // If the name exceeds the 64 characters, the `encoded_name_additional` will
-  // be used to encode the additional characters.
+  // be used to encode the additional characters. This is also a sequence of
+  // `fixed64` instead of a `bytes` field so that it can be allocated on an
+  // `Arena` (`std::string`s cannot be allocated in `Arena`s).
   fixed64 encoded_name_1 = 4;
   fixed64 encoded_name_2 = 5;
   fixed64 encoded_name_3 = 6;

--- a/src/Service/ProducerEventProcessor.cpp
+++ b/src/Service/ProducerEventProcessor.cpp
@@ -15,6 +15,17 @@ namespace {
 
 using orbit_grpc_protos::AddressInfo;
 using orbit_grpc_protos::ApiEvent;
+using orbit_grpc_protos::ApiScopeStart;
+using orbit_grpc_protos::ApiScopeStartAsync;
+using orbit_grpc_protos::ApiScopeStop;
+using orbit_grpc_protos::ApiScopeStopAsync;
+using orbit_grpc_protos::ApiStringEvent;
+using orbit_grpc_protos::ApiTrackDouble;
+using orbit_grpc_protos::ApiTrackFloat;
+using orbit_grpc_protos::ApiTrackInt;
+using orbit_grpc_protos::ApiTrackInt64;
+using orbit_grpc_protos::ApiTrackUint;
+using orbit_grpc_protos::ApiTrackUint64;
 using orbit_grpc_protos::Callstack;
 using orbit_grpc_protos::CallstackSample;
 using orbit_grpc_protos::CaptureStarted;
@@ -106,6 +117,17 @@ class ProducerEventProcessorImpl : public ProducerEventProcessor {
   void ProcessFullTracepointEvent(FullTracepointEvent* full_tracepoint_event);
   void ProcessMemoryUsageEventAndTransferOwnership(MemoryUsageEvent* memory_usage_event);
   void ProcessApiEventAndTransferOwnership(ApiEvent* api_event);
+  void ProcessApiScopeStartAndTransferOwnership(ApiScopeStart* api_scope_start);
+  void ProcessApiScopeStartAsyncAndTransferOwnership(ApiScopeStartAsync* api_scope_start_async);
+  void ProcessApiScopeStopAndTransferOwnership(ApiScopeStop* api_scope_stop);
+  void ProcessApiScopeStopAsyncAndTransferOwnership(ApiScopeStopAsync* api_scope_stop_async);
+  void ProcessApiStringEventAndTransferOwnership(ApiStringEvent* api_string_event);
+  void ProcessApiTrackDoubleAndTransferOwnership(ApiTrackDouble* api_track_double);
+  void ProcessApiTrackFloatAndTransferOwnership(ApiTrackFloat* api_track_float);
+  void ProcessApiTrackIntAndTransferOwnership(ApiTrackInt* api_track_int);
+  void ProcessApiTrackInt64AndTransferOwnership(ApiTrackInt64* api_track_int64);
+  void ProcessApiTrackUintAndTransferOwnership(ApiTrackUint* api_track_uint);
+  void ProcessApiTrackUint64AndTransferOwnership(ApiTrackUint64* api_track_uint64);
   void ProcessWarningEventAndTransferOwnership(WarningEvent* warning_event);
   void ProcessClockResolutionEventAndTransferOwnership(
       ClockResolutionEvent* clock_resolution_event);
@@ -379,6 +401,83 @@ void ProducerEventProcessorImpl::ProcessApiEventAndTransferOwnership(ApiEvent* a
   capture_event_buffer_->AddEvent(std::move(event));
 }
 
+void orbit_service::ProducerEventProcessorImpl::ProcessApiScopeStartAndTransferOwnership(
+    ApiScopeStart* api_scope_start) {
+  ClientCaptureEvent event;
+  event.set_allocated_api_scope_start(api_scope_start);
+  capture_event_buffer_->AddEvent(std::move(event));
+}
+
+void orbit_service::ProducerEventProcessorImpl::ProcessApiScopeStartAsyncAndTransferOwnership(
+    ApiScopeStartAsync* api_scope_start_async) {
+  ClientCaptureEvent event;
+  event.set_allocated_api_scope_start_async(api_scope_start_async);
+  capture_event_buffer_->AddEvent(std::move(event));
+}
+
+void orbit_service::ProducerEventProcessorImpl::ProcessApiScopeStopAndTransferOwnership(
+    ApiScopeStop* api_scope_stop) {
+  ClientCaptureEvent event;
+  event.set_allocated_api_scope_stop(api_scope_stop);
+  capture_event_buffer_->AddEvent(std::move(event));
+}
+
+void orbit_service::ProducerEventProcessorImpl::ProcessApiScopeStopAsyncAndTransferOwnership(
+    ApiScopeStopAsync* api_scope_stop_async) {
+  ClientCaptureEvent event;
+  event.set_allocated_api_scope_stop_async(api_scope_stop_async);
+  capture_event_buffer_->AddEvent(std::move(event));
+}
+
+void orbit_service::ProducerEventProcessorImpl::ProcessApiStringEventAndTransferOwnership(
+    ApiStringEvent* api_string_event) {
+  ClientCaptureEvent event;
+  event.set_allocated_api_string_event(api_string_event);
+  capture_event_buffer_->AddEvent(std::move(event));
+}
+
+void orbit_service::ProducerEventProcessorImpl::ProcessApiTrackDoubleAndTransferOwnership(
+    ApiTrackDouble* api_track_double) {
+  ClientCaptureEvent event;
+  event.set_allocated_api_track_double(api_track_double);
+  capture_event_buffer_->AddEvent(std::move(event));
+}
+
+void orbit_service::ProducerEventProcessorImpl::ProcessApiTrackFloatAndTransferOwnership(
+    ApiTrackFloat* api_track_float) {
+  ClientCaptureEvent event;
+  event.set_allocated_api_track_float(api_track_float);
+  capture_event_buffer_->AddEvent(std::move(event));
+}
+
+void orbit_service::ProducerEventProcessorImpl::ProcessApiTrackIntAndTransferOwnership(
+    ApiTrackInt* api_track_int) {
+  ClientCaptureEvent event;
+  event.set_allocated_api_track_int(api_track_int);
+  capture_event_buffer_->AddEvent(std::move(event));
+}
+
+void orbit_service::ProducerEventProcessorImpl::ProcessApiTrackInt64AndTransferOwnership(
+    ApiTrackInt64* api_track_int64) {
+  ClientCaptureEvent event;
+  event.set_allocated_api_track_int64(api_track_int64);
+  capture_event_buffer_->AddEvent(std::move(event));
+}
+
+void orbit_service::ProducerEventProcessorImpl::ProcessApiTrackUintAndTransferOwnership(
+    ApiTrackUint* api_track_uint) {
+  ClientCaptureEvent event;
+  event.set_allocated_api_track_uint(api_track_uint);
+  capture_event_buffer_->AddEvent(std::move(event));
+}
+
+void orbit_service::ProducerEventProcessorImpl::ProcessApiTrackUint64AndTransferOwnership(
+    ApiTrackUint64* api_track_uint64) {
+  ClientCaptureEvent event;
+  event.set_allocated_api_track_uint64(api_track_uint64);
+  capture_event_buffer_->AddEvent(std::move(event));
+}
+
 void ProducerEventProcessorImpl::ProcessWarningEventAndTransferOwnership(
     WarningEvent* warning_event) {
   ClientCaptureEvent event;
@@ -482,27 +581,38 @@ void ProducerEventProcessorImpl::ProcessEvent(uint64_t producer_id, ProducerCapt
       ProcessApiEventAndTransferOwnership(event.release_api_event());
       break;
     case orbit_grpc_protos::ProducerCaptureEvent::kApiScopeStart:
-      UNREACHABLE();
+      ProcessApiScopeStartAndTransferOwnership(event.release_api_scope_start());
+      break;
     case orbit_grpc_protos::ProducerCaptureEvent::kApiScopeStartAsync:
-      UNREACHABLE();
+      ProcessApiScopeStartAsyncAndTransferOwnership(event.release_api_scope_start_async());
+      break;
     case orbit_grpc_protos::ProducerCaptureEvent::kApiScopeStop:
-      UNREACHABLE();
+      ProcessApiScopeStopAndTransferOwnership(event.release_api_scope_stop());
+      break;
     case orbit_grpc_protos::ProducerCaptureEvent::kApiScopeStopAsync:
-      UNREACHABLE();
+      ProcessApiScopeStopAsyncAndTransferOwnership(event.release_api_scope_stop_async());
+      break;
     case orbit_grpc_protos::ProducerCaptureEvent::kApiStringEvent:
-      UNREACHABLE();
+      ProcessApiStringEventAndTransferOwnership(event.release_api_string_event());
+      break;
     case orbit_grpc_protos::ProducerCaptureEvent::kApiTrackDouble:
-      UNREACHABLE();
+      ProcessApiTrackDoubleAndTransferOwnership(event.release_api_track_double());
+      break;
     case orbit_grpc_protos::ProducerCaptureEvent::kApiTrackFloat:
-      UNREACHABLE();
+      ProcessApiTrackFloatAndTransferOwnership(event.release_api_track_float());
+      break;
     case orbit_grpc_protos::ProducerCaptureEvent::kApiTrackInt:
-      UNREACHABLE();
+      ProcessApiTrackIntAndTransferOwnership(event.release_api_track_int());
+      break;
     case orbit_grpc_protos::ProducerCaptureEvent::kApiTrackInt64:
-      UNREACHABLE();
+      ProcessApiTrackInt64AndTransferOwnership(event.release_api_track_int64());
+      break;
     case orbit_grpc_protos::ProducerCaptureEvent::kApiTrackUint:
-      UNREACHABLE();
+      ProcessApiTrackUintAndTransferOwnership(event.release_api_track_uint());
+      break;
     case orbit_grpc_protos::ProducerCaptureEvent::kApiTrackUint64:
-      UNREACHABLE();
+      ProcessApiTrackUint64AndTransferOwnership(event.release_api_track_uint64());
+      break;
     case ProducerCaptureEvent::kWarningEvent:
       ProcessWarningEventAndTransferOwnership(event.release_warning_event());
       break;

--- a/src/Service/ProducerEventProcessorTest.cpp
+++ b/src/Service/ProducerEventProcessorTest.cpp
@@ -4,6 +4,7 @@
 
 #include <GrpcProtos/Constants.h>
 #include <gmock/gmock.h>
+#include <google/protobuf/util/message_differencer.h>
 #include <gtest/gtest.h>
 #include <stdint.h>
 
@@ -66,6 +67,7 @@ using orbit_grpc_protos::ThreadStateSlice;
 using orbit_grpc_protos::TracepointEvent;
 using orbit_grpc_protos::WarningEvent;
 
+using google::protobuf::util::MessageDifferencer;
 using ::testing::ElementsAre;
 using ::testing::SaveArg;
 
@@ -127,7 +129,7 @@ constexpr uint64_t kEncodedName5 = 55;
 constexpr uint64_t kEncodedName6 = 66;
 constexpr uint64_t kEncodedName7 = 77;
 constexpr uint64_t kEncodedName8 = 88;
-constexpr uint8_t kEncodedNameAdditional1 = 99;
+constexpr uint64_t kEncodedNameAdditional1 = 99;
 
 constexpr int32_t kInt = 42;
 constexpr int64_t kInt64 = 64;
@@ -1694,7 +1696,9 @@ TEST(ProducerEventProcessor, ApiScopeStart) {
   api_scope_start->set_encoded_name_6(kEncodedName6);
   api_scope_start->set_encoded_name_7(kEncodedName7);
   api_scope_start->set_encoded_name_8(kEncodedName8);
-  api_scope_start->mutable_encoded_name_additional()->push_back(kEncodedNameAdditional1);
+  api_scope_start->add_encoded_name_additional(kEncodedNameAdditional1);
+
+  ApiScopeStart api_scope_start_copy = *api_scope_start;
 
   MockCaptureEventBuffer buffer;
   auto producer_event_processor = ProducerEventProcessor::Create(&buffer);
@@ -1704,21 +1708,7 @@ TEST(ProducerEventProcessor, ApiScopeStart) {
   producer_event_processor->ProcessEvent(kDefaultProducerId, producer_capture_event);
   ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kApiScopeStart);
   const ApiScopeStart& actual_event = client_capture_event.api_scope_start();
-  EXPECT_EQ(actual_event.pid(), kPid1);
-  EXPECT_EQ(actual_event.tid(), kTid1);
-  EXPECT_EQ(actual_event.timestamp_ns(), kTimestampNs1);
-  EXPECT_EQ(actual_event.color_rgba(), kColor1);
-  EXPECT_EQ(actual_event.group_id(), kGroupId1);
-  EXPECT_EQ(actual_event.address_in_function(), kFunctionId1);
-  EXPECT_EQ(actual_event.encoded_name_1(), kEncodedName1);
-  EXPECT_EQ(actual_event.encoded_name_2(), kEncodedName2);
-  EXPECT_EQ(actual_event.encoded_name_3(), kEncodedName3);
-  EXPECT_EQ(actual_event.encoded_name_4(), kEncodedName4);
-  EXPECT_EQ(actual_event.encoded_name_5(), kEncodedName5);
-  EXPECT_EQ(actual_event.encoded_name_6(), kEncodedName6);
-  EXPECT_EQ(actual_event.encoded_name_7(), kEncodedName7);
-  EXPECT_EQ(actual_event.encoded_name_8(), kEncodedName8);
-  EXPECT_THAT(actual_event.encoded_name_additional(), ElementsAre(kEncodedNameAdditional1));
+  EXPECT_TRUE(MessageDifferencer::Equivalent(api_scope_start_copy, actual_event));
 }
 
 TEST(ProducerEventProcessor, ApiScopeStop) {
@@ -1727,6 +1717,7 @@ TEST(ProducerEventProcessor, ApiScopeStop) {
   api_scope_stop->set_pid(kPid1);
   api_scope_stop->set_tid(kTid1);
   api_scope_stop->set_timestamp_ns(kTimestampNs1);
+  ApiScopeStop api_scope_stop_copy = *api_scope_stop;
 
   MockCaptureEventBuffer buffer;
   auto producer_event_processor = ProducerEventProcessor::Create(&buffer);
@@ -1736,9 +1727,7 @@ TEST(ProducerEventProcessor, ApiScopeStop) {
   producer_event_processor->ProcessEvent(kDefaultProducerId, producer_capture_event);
   ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kApiScopeStop);
   const ApiScopeStop& actual_event = client_capture_event.api_scope_stop();
-  EXPECT_EQ(actual_event.pid(), kPid1);
-  EXPECT_EQ(actual_event.tid(), kTid1);
-  EXPECT_EQ(actual_event.timestamp_ns(), kTimestampNs1);
+  EXPECT_TRUE(MessageDifferencer::Equivalent(api_scope_stop_copy, actual_event));
 }
 
 TEST(ProducerEventProcessor, ApiScopeStartAsync) {
@@ -1759,7 +1748,8 @@ TEST(ProducerEventProcessor, ApiScopeStartAsync) {
   api_scope_start_async->set_encoded_name_6(kEncodedName6);
   api_scope_start_async->set_encoded_name_7(kEncodedName7);
   api_scope_start_async->set_encoded_name_8(kEncodedName8);
-  api_scope_start_async->mutable_encoded_name_additional()->push_back(kEncodedNameAdditional1);
+  api_scope_start_async->add_encoded_name_additional(kEncodedNameAdditional1);
+  ApiScopeStartAsync api_scope_start_async_copy = *api_scope_start_async;
 
   MockCaptureEventBuffer buffer;
   auto producer_event_processor = ProducerEventProcessor::Create(&buffer);
@@ -1769,21 +1759,7 @@ TEST(ProducerEventProcessor, ApiScopeStartAsync) {
   producer_event_processor->ProcessEvent(kDefaultProducerId, producer_capture_event);
   ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kApiScopeStartAsync);
   const ApiScopeStartAsync& actual_event = client_capture_event.api_scope_start_async();
-  EXPECT_EQ(actual_event.pid(), kPid1);
-  EXPECT_EQ(actual_event.tid(), kTid1);
-  EXPECT_EQ(actual_event.timestamp_ns(), kTimestampNs1);
-  EXPECT_EQ(actual_event.color_rgba(), kColor1);
-  EXPECT_EQ(actual_event.id(), kGroupId1);
-  EXPECT_EQ(actual_event.address_in_function(), kFunctionId1);
-  EXPECT_EQ(actual_event.encoded_name_1(), kEncodedName1);
-  EXPECT_EQ(actual_event.encoded_name_2(), kEncodedName2);
-  EXPECT_EQ(actual_event.encoded_name_3(), kEncodedName3);
-  EXPECT_EQ(actual_event.encoded_name_4(), kEncodedName4);
-  EXPECT_EQ(actual_event.encoded_name_5(), kEncodedName5);
-  EXPECT_EQ(actual_event.encoded_name_6(), kEncodedName6);
-  EXPECT_EQ(actual_event.encoded_name_7(), kEncodedName7);
-  EXPECT_EQ(actual_event.encoded_name_8(), kEncodedName8);
-  EXPECT_THAT(actual_event.encoded_name_additional(), ElementsAre(kEncodedNameAdditional1));
+  EXPECT_TRUE(MessageDifferencer::Equivalent(api_scope_start_async_copy, actual_event));
 }
 
 TEST(ProducerEventProcessor, ApiScopeStopAsync) {
@@ -1793,6 +1769,7 @@ TEST(ProducerEventProcessor, ApiScopeStopAsync) {
   api_scope_stop_async->set_tid(kTid1);
   api_scope_stop_async->set_timestamp_ns(kTimestampNs1);
   api_scope_stop_async->set_id(kGroupId1);
+  ApiScopeStopAsync api_scope_stop_async_copy = *api_scope_stop_async;
 
   MockCaptureEventBuffer buffer;
   auto producer_event_processor = ProducerEventProcessor::Create(&buffer);
@@ -1802,10 +1779,7 @@ TEST(ProducerEventProcessor, ApiScopeStopAsync) {
   producer_event_processor->ProcessEvent(kDefaultProducerId, producer_capture_event);
   ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kApiScopeStopAsync);
   const ApiScopeStopAsync& actual_event = client_capture_event.api_scope_stop_async();
-  EXPECT_EQ(actual_event.pid(), kPid1);
-  EXPECT_EQ(actual_event.tid(), kTid1);
-  EXPECT_EQ(actual_event.timestamp_ns(), kTimestampNs1);
-  EXPECT_EQ(actual_event.id(), kGroupId1);
+  EXPECT_TRUE(MessageDifferencer::Equivalent(api_scope_stop_async_copy, actual_event));
 }
 
 TEST(ProducerEventProcessor, ApiStringEvent) {
@@ -1823,7 +1797,8 @@ TEST(ProducerEventProcessor, ApiStringEvent) {
   api_string_event->set_encoded_name_6(kEncodedName6);
   api_string_event->set_encoded_name_7(kEncodedName7);
   api_string_event->set_encoded_name_8(kEncodedName8);
-  api_string_event->mutable_encoded_name_additional()->push_back(kEncodedNameAdditional1);
+  api_string_event->add_encoded_name_additional(kEncodedNameAdditional1);
+  ApiStringEvent api_string_event_copy = *api_string_event;
 
   MockCaptureEventBuffer buffer;
   auto producer_event_processor = ProducerEventProcessor::Create(&buffer);
@@ -1833,19 +1808,7 @@ TEST(ProducerEventProcessor, ApiStringEvent) {
   producer_event_processor->ProcessEvent(kDefaultProducerId, producer_capture_event);
   ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kApiStringEvent);
   const ApiStringEvent& actual_event = client_capture_event.api_string_event();
-  EXPECT_EQ(actual_event.pid(), kPid1);
-  EXPECT_EQ(actual_event.tid(), kTid1);
-  EXPECT_EQ(actual_event.timestamp_ns(), kTimestampNs1);
-  EXPECT_EQ(actual_event.id(), kGroupId1);
-  EXPECT_EQ(actual_event.encoded_name_1(), kEncodedName1);
-  EXPECT_EQ(actual_event.encoded_name_2(), kEncodedName2);
-  EXPECT_EQ(actual_event.encoded_name_3(), kEncodedName3);
-  EXPECT_EQ(actual_event.encoded_name_4(), kEncodedName4);
-  EXPECT_EQ(actual_event.encoded_name_5(), kEncodedName5);
-  EXPECT_EQ(actual_event.encoded_name_6(), kEncodedName6);
-  EXPECT_EQ(actual_event.encoded_name_7(), kEncodedName7);
-  EXPECT_EQ(actual_event.encoded_name_8(), kEncodedName8);
-  EXPECT_THAT(actual_event.encoded_name_additional(), ElementsAre(kEncodedNameAdditional1));
+  EXPECT_TRUE(MessageDifferencer::Equivalent(api_string_event_copy, actual_event));
 }
 
 TEST(ProducerEventProcessor, ApiTrackInt) {
@@ -1855,6 +1818,7 @@ TEST(ProducerEventProcessor, ApiTrackInt) {
   api_track_int->set_tid(kTid1);
   api_track_int->set_timestamp_ns(kTimestampNs1);
   api_track_int->set_data(kInt);
+  ApiTrackInt api_track_int_copy = *api_track_int;
 
   MockCaptureEventBuffer buffer;
   auto producer_event_processor = ProducerEventProcessor::Create(&buffer);
@@ -1864,10 +1828,7 @@ TEST(ProducerEventProcessor, ApiTrackInt) {
   producer_event_processor->ProcessEvent(kDefaultProducerId, producer_capture_event);
   ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kApiTrackInt);
   const ApiTrackInt& actual_event = client_capture_event.api_track_int();
-  EXPECT_EQ(actual_event.pid(), kPid1);
-  EXPECT_EQ(actual_event.tid(), kTid1);
-  EXPECT_EQ(actual_event.timestamp_ns(), kTimestampNs1);
-  EXPECT_EQ(actual_event.data(), kInt);
+  EXPECT_TRUE(MessageDifferencer::Equivalent(api_track_int_copy, actual_event));
 }
 
 TEST(ProducerEventProcessor, ApiTrackInt64) {
@@ -1877,6 +1838,7 @@ TEST(ProducerEventProcessor, ApiTrackInt64) {
   api_track_int64->set_tid(kTid1);
   api_track_int64->set_timestamp_ns(kTimestampNs1);
   api_track_int64->set_data(kInt64);
+  ApiTrackInt64 api_track_int64_copy = *api_track_int64;
 
   MockCaptureEventBuffer buffer;
   auto producer_event_processor = ProducerEventProcessor::Create(&buffer);
@@ -1886,10 +1848,7 @@ TEST(ProducerEventProcessor, ApiTrackInt64) {
   producer_event_processor->ProcessEvent(kDefaultProducerId, producer_capture_event);
   ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kApiTrackInt64);
   const ApiTrackInt64& actual_event = client_capture_event.api_track_int64();
-  EXPECT_EQ(actual_event.pid(), kPid1);
-  EXPECT_EQ(actual_event.tid(), kTid1);
-  EXPECT_EQ(actual_event.timestamp_ns(), kTimestampNs1);
-  EXPECT_EQ(actual_event.data(), kInt64);
+  EXPECT_TRUE(MessageDifferencer::Equivalent(api_track_int64_copy, actual_event));
 }
 
 TEST(ProducerEventProcessor, ApiTrackUint) {
@@ -1899,6 +1858,7 @@ TEST(ProducerEventProcessor, ApiTrackUint) {
   api_track_uint->set_tid(kTid1);
   api_track_uint->set_timestamp_ns(kTimestampNs1);
   api_track_uint->set_data(kUint);
+  ApiTrackUint api_track_uint_copy = *api_track_uint;
 
   MockCaptureEventBuffer buffer;
   auto producer_event_processor = ProducerEventProcessor::Create(&buffer);
@@ -1908,10 +1868,7 @@ TEST(ProducerEventProcessor, ApiTrackUint) {
   producer_event_processor->ProcessEvent(kDefaultProducerId, producer_capture_event);
   ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kApiTrackUint);
   const ApiTrackUint& actual_event = client_capture_event.api_track_uint();
-  EXPECT_EQ(actual_event.pid(), kPid1);
-  EXPECT_EQ(actual_event.tid(), kTid1);
-  EXPECT_EQ(actual_event.timestamp_ns(), kTimestampNs1);
-  EXPECT_EQ(actual_event.data(), kUint);
+  EXPECT_TRUE(MessageDifferencer::Equivalent(api_track_uint_copy, actual_event));
 }
 
 TEST(ProducerEventProcessor, ApiTrackUint64) {
@@ -1921,6 +1878,7 @@ TEST(ProducerEventProcessor, ApiTrackUint64) {
   api_track_uint64->set_tid(kTid1);
   api_track_uint64->set_timestamp_ns(kTimestampNs1);
   api_track_uint64->set_data(kUint64);
+  ApiTrackUint64 api_track_uint64_copy = *api_track_uint64;
 
   MockCaptureEventBuffer buffer;
   auto producer_event_processor = ProducerEventProcessor::Create(&buffer);
@@ -1930,10 +1888,7 @@ TEST(ProducerEventProcessor, ApiTrackUint64) {
   producer_event_processor->ProcessEvent(kDefaultProducerId, producer_capture_event);
   ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kApiTrackUint64);
   const ApiTrackUint64& actual_event = client_capture_event.api_track_uint64();
-  EXPECT_EQ(actual_event.pid(), kPid1);
-  EXPECT_EQ(actual_event.tid(), kTid1);
-  EXPECT_EQ(actual_event.timestamp_ns(), kTimestampNs1);
-  EXPECT_EQ(actual_event.data(), kUint64);
+  EXPECT_TRUE(MessageDifferencer::Equivalent(api_track_uint64_copy, actual_event));
 }
 
 TEST(ProducerEventProcessor, ApiTrackFloat) {
@@ -1943,6 +1898,7 @@ TEST(ProducerEventProcessor, ApiTrackFloat) {
   api_track_float->set_tid(kTid1);
   api_track_float->set_timestamp_ns(kTimestampNs1);
   api_track_float->set_data(kFloat);
+  ApiTrackFloat api_track_float_copy = *api_track_float;
 
   MockCaptureEventBuffer buffer;
   auto producer_event_processor = ProducerEventProcessor::Create(&buffer);
@@ -1952,10 +1908,7 @@ TEST(ProducerEventProcessor, ApiTrackFloat) {
   producer_event_processor->ProcessEvent(kDefaultProducerId, producer_capture_event);
   ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kApiTrackFloat);
   const ApiTrackFloat& actual_event = client_capture_event.api_track_float();
-  EXPECT_EQ(actual_event.pid(), kPid1);
-  EXPECT_EQ(actual_event.tid(), kTid1);
-  EXPECT_EQ(actual_event.timestamp_ns(), kTimestampNs1);
-  EXPECT_EQ(actual_event.data(), kFloat);
+  EXPECT_TRUE(MessageDifferencer::Equivalent(api_track_float_copy, actual_event));
 }
 
 TEST(ProducerEventProcessor, ApiTrackDouble) {
@@ -1965,6 +1918,7 @@ TEST(ProducerEventProcessor, ApiTrackDouble) {
   api_track_double->set_tid(kTid1);
   api_track_double->set_timestamp_ns(kTimestampNs1);
   api_track_double->set_data(kDouble);
+  ApiTrackDouble api_track_double_copy = *api_track_double;
 
   MockCaptureEventBuffer buffer;
   auto producer_event_processor = ProducerEventProcessor::Create(&buffer);
@@ -1974,10 +1928,7 @@ TEST(ProducerEventProcessor, ApiTrackDouble) {
   producer_event_processor->ProcessEvent(kDefaultProducerId, producer_capture_event);
   ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kApiTrackDouble);
   const ApiTrackDouble& actual_event = client_capture_event.api_track_double();
-  EXPECT_EQ(actual_event.pid(), kPid1);
-  EXPECT_EQ(actual_event.tid(), kTid1);
-  EXPECT_EQ(actual_event.timestamp_ns(), kTimestampNs1);
-  EXPECT_EQ(actual_event.data(), kDouble);
+  EXPECT_TRUE(MessageDifferencer::Equivalent(api_track_double_copy, actual_event));
 }
 
 TEST(ProducerEventProcessor, WarningEvent) {

--- a/src/Service/ProducerEventProcessorTest.cpp
+++ b/src/Service/ProducerEventProcessorTest.cpp
@@ -15,6 +15,17 @@ namespace orbit_service {
 namespace {
 
 using orbit_grpc_protos::AddressInfo;
+using orbit_grpc_protos::ApiScopeStart;
+using orbit_grpc_protos::ApiScopeStartAsync;
+using orbit_grpc_protos::ApiScopeStop;
+using orbit_grpc_protos::ApiScopeStopAsync;
+using orbit_grpc_protos::ApiStringEvent;
+using orbit_grpc_protos::ApiTrackDouble;
+using orbit_grpc_protos::ApiTrackFloat;
+using orbit_grpc_protos::ApiTrackInt;
+using orbit_grpc_protos::ApiTrackInt64;
+using orbit_grpc_protos::ApiTrackUint;
+using orbit_grpc_protos::ApiTrackUint64;
 using orbit_grpc_protos::Callstack;
 using orbit_grpc_protos::CallstackSample;
 using orbit_grpc_protos::CaptureOptions;
@@ -56,6 +67,7 @@ using orbit_grpc_protos::TracepointEvent;
 using orbit_grpc_protos::WarningEvent;
 
 using ::testing::SaveArg;
+using ::testing::ElementsAre;
 
 class MockCaptureEventBuffer : public CaptureEventBuffer {
  public:
@@ -102,6 +114,27 @@ constexpr float kAlpha2 = 2.1f;
 constexpr float kRed2 = 2.2f;
 constexpr float kGreen2 = 2.3f;
 constexpr float kBlue2 = 2.4f;
+
+constexpr uint32_t kColor1 = 0x11223344;
+
+constexpr uint64_t kGroupId1 = 42;
+
+constexpr uint64_t kEncodedName1 = 11;
+constexpr uint64_t kEncodedName2 = 22;
+constexpr uint64_t kEncodedName3 = 33;
+constexpr uint64_t kEncodedName4 = 44;
+constexpr uint64_t kEncodedName5 = 55;
+constexpr uint64_t kEncodedName6 = 66;
+constexpr uint64_t kEncodedName7 = 77;
+constexpr uint64_t kEncodedName8 = 88;
+constexpr uint8_t kEncodedNameAdditional1 = 99;
+
+constexpr int32_t kInt = 42;
+constexpr int64_t kInt64 = 64;
+constexpr uint32_t kUint = 42;
+constexpr uint64_t kUint64 = 64;
+constexpr float kFloat = 1.1f;
+constexpr double kDouble = 2.2;
 
 constexpr const char* kExecutablePath = "/path/to/executable";
 constexpr const char* kBuildId1 = "build_id_1";
@@ -1642,6 +1675,308 @@ TEST(ProducerEventProcessor, MemoryUsageEvent) {
   ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kMemoryUsageEvent);
   const MemoryUsageEvent& actual_memory_usage_event = client_capture_event.memory_usage_event();
   ASSERT_EQ(actual_memory_usage_event.SerializeAsString(), memory_usage_event->SerializeAsString());
+}
+
+TEST(ProducerEventProcessor, ApiScopeStart) {
+  ProducerCaptureEvent producer_capture_event;
+  ApiScopeStart* api_scope_start = producer_capture_event.mutable_api_scope_start();
+  api_scope_start->set_pid(kPid1);
+  api_scope_start->set_tid(kTid1);
+  api_scope_start->set_timestamp_ns(kTimestampNs1);
+  api_scope_start->set_color_rgba(kColor1);
+  api_scope_start->set_group_id(kGroupId1);
+  api_scope_start->set_address_in_function(kFunctionId1);
+  api_scope_start->set_encoded_name_1(kEncodedName1);
+  api_scope_start->set_encoded_name_2(kEncodedName2);
+  api_scope_start->set_encoded_name_3(kEncodedName3);
+  api_scope_start->set_encoded_name_4(kEncodedName4);
+  api_scope_start->set_encoded_name_5(kEncodedName5);
+  api_scope_start->set_encoded_name_6(kEncodedName6);
+  api_scope_start->set_encoded_name_7(kEncodedName7);
+  api_scope_start->set_encoded_name_8(kEncodedName8);
+  api_scope_start->mutable_encoded_name_additional()->push_back(kEncodedNameAdditional1);
+
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = ProducerEventProcessor::Create(&buffer);
+  ClientCaptureEvent client_capture_event;
+  EXPECT_CALL(buffer, AddEvent).Times(1).WillOnce(SaveArg<0>(&client_capture_event));
+
+  producer_event_processor->ProcessEvent(kDefaultProducerId, producer_capture_event);
+  ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kApiScopeStart);
+  const ApiScopeStart& actual_event = client_capture_event.api_scope_start();
+  EXPECT_EQ(actual_event.pid(), kPid1);
+  EXPECT_EQ(actual_event.tid(), kTid1);
+  EXPECT_EQ(actual_event.timestamp_ns(), kTimestampNs1);
+  EXPECT_EQ(actual_event.color_rgba(), kColor1);
+  EXPECT_EQ(actual_event.group_id(), kGroupId1);
+  EXPECT_EQ(actual_event.address_in_function(), kFunctionId1);
+  EXPECT_EQ(actual_event.encoded_name_1(), kEncodedName1);
+  EXPECT_EQ(actual_event.encoded_name_2(), kEncodedName2);
+  EXPECT_EQ(actual_event.encoded_name_3(), kEncodedName3);
+  EXPECT_EQ(actual_event.encoded_name_4(), kEncodedName4);
+  EXPECT_EQ(actual_event.encoded_name_5(), kEncodedName5);
+  EXPECT_EQ(actual_event.encoded_name_6(), kEncodedName6);
+  EXPECT_EQ(actual_event.encoded_name_7(), kEncodedName7);
+  EXPECT_EQ(actual_event.encoded_name_8(), kEncodedName8);
+  EXPECT_THAT(actual_event.encoded_name_additional(), ElementsAre(kEncodedNameAdditional1));
+}
+
+TEST(ProducerEventProcessor, ApiScopeStop) {
+  ProducerCaptureEvent producer_capture_event;
+  ApiScopeStop* api_scope_stop = producer_capture_event.mutable_api_scope_stop();
+  api_scope_stop->set_pid(kPid1);
+  api_scope_stop->set_tid(kTid1);
+  api_scope_stop->set_timestamp_ns(kTimestampNs1);
+
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = ProducerEventProcessor::Create(&buffer);
+  ClientCaptureEvent client_capture_event;
+  EXPECT_CALL(buffer, AddEvent).Times(1).WillOnce(SaveArg<0>(&client_capture_event));
+
+  producer_event_processor->ProcessEvent(kDefaultProducerId, producer_capture_event);
+  ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kApiScopeStop);
+  const ApiScopeStop& actual_event = client_capture_event.api_scope_stop();
+  EXPECT_EQ(actual_event.pid(), kPid1);
+  EXPECT_EQ(actual_event.tid(), kTid1);
+  EXPECT_EQ(actual_event.timestamp_ns(), kTimestampNs1);
+}
+
+TEST(ProducerEventProcessor, ApiScopeStartAsync) {
+  ProducerCaptureEvent producer_capture_event;
+  ApiScopeStartAsync* api_scope_start_async = producer_capture_event.mutable_api_scope_start_async();
+  api_scope_start_async->set_pid(kPid1);
+  api_scope_start_async->set_tid(kTid1);
+  api_scope_start_async->set_timestamp_ns(kTimestampNs1);
+  api_scope_start_async->set_color_rgba(kColor1);
+  api_scope_start_async->set_id(kGroupId1);
+  api_scope_start_async->set_address_in_function(kFunctionId1);
+  api_scope_start_async->set_encoded_name_1(kEncodedName1);
+  api_scope_start_async->set_encoded_name_2(kEncodedName2);
+  api_scope_start_async->set_encoded_name_3(kEncodedName3);
+  api_scope_start_async->set_encoded_name_4(kEncodedName4);
+  api_scope_start_async->set_encoded_name_5(kEncodedName5);
+  api_scope_start_async->set_encoded_name_6(kEncodedName6);
+  api_scope_start_async->set_encoded_name_7(kEncodedName7);
+  api_scope_start_async->set_encoded_name_8(kEncodedName8);
+  api_scope_start_async->mutable_encoded_name_additional()->push_back(kEncodedNameAdditional1);
+
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = ProducerEventProcessor::Create(&buffer);
+  ClientCaptureEvent client_capture_event;
+  EXPECT_CALL(buffer, AddEvent).Times(1).WillOnce(SaveArg<0>(&client_capture_event));
+
+  producer_event_processor->ProcessEvent(kDefaultProducerId, producer_capture_event);
+  ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kApiScopeStartAsync);
+  const ApiScopeStartAsync& actual_event = client_capture_event.api_scope_start_async();
+  EXPECT_EQ(actual_event.pid(), kPid1);
+  EXPECT_EQ(actual_event.tid(), kTid1);
+  EXPECT_EQ(actual_event.timestamp_ns(), kTimestampNs1);
+  EXPECT_EQ(actual_event.color_rgba(), kColor1);
+  EXPECT_EQ(actual_event.id(), kGroupId1);
+  EXPECT_EQ(actual_event.address_in_function(), kFunctionId1);
+  EXPECT_EQ(actual_event.encoded_name_1(), kEncodedName1);
+  EXPECT_EQ(actual_event.encoded_name_2(), kEncodedName2);
+  EXPECT_EQ(actual_event.encoded_name_3(), kEncodedName3);
+  EXPECT_EQ(actual_event.encoded_name_4(), kEncodedName4);
+  EXPECT_EQ(actual_event.encoded_name_5(), kEncodedName5);
+  EXPECT_EQ(actual_event.encoded_name_6(), kEncodedName6);
+  EXPECT_EQ(actual_event.encoded_name_7(), kEncodedName7);
+  EXPECT_EQ(actual_event.encoded_name_8(), kEncodedName8);
+  EXPECT_THAT(actual_event.encoded_name_additional(), ElementsAre(kEncodedNameAdditional1));
+}
+
+TEST(ProducerEventProcessor, ApiScopeStopAsync) {
+  ProducerCaptureEvent producer_capture_event;
+  ApiScopeStopAsync* api_scope_stop_async = producer_capture_event.mutable_api_scope_stop_async();
+  api_scope_stop_async->set_pid(kPid1);
+  api_scope_stop_async->set_tid(kTid1);
+  api_scope_stop_async->set_timestamp_ns(kTimestampNs1);
+  api_scope_stop_async->set_id(kGroupId1);
+
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = ProducerEventProcessor::Create(&buffer);
+  ClientCaptureEvent client_capture_event;
+  EXPECT_CALL(buffer, AddEvent).Times(1).WillOnce(SaveArg<0>(&client_capture_event));
+
+  producer_event_processor->ProcessEvent(kDefaultProducerId, producer_capture_event);
+  ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kApiScopeStopAsync);
+  const ApiScopeStopAsync& actual_event = client_capture_event.api_scope_stop_async();
+  EXPECT_EQ(actual_event.pid(), kPid1);
+  EXPECT_EQ(actual_event.tid(), kTid1);
+  EXPECT_EQ(actual_event.timestamp_ns(), kTimestampNs1);
+  EXPECT_EQ(actual_event.id(), kGroupId1);
+}
+
+TEST(ProducerEventProcessor, ApiStringEvent) {
+  ProducerCaptureEvent producer_capture_event;
+  ApiStringEvent* api_string_event = producer_capture_event.mutable_api_string_event();
+  api_string_event->set_pid(kPid1);
+  api_string_event->set_tid(kTid1);
+  api_string_event->set_timestamp_ns(kTimestampNs1);
+  api_string_event->set_id(kGroupId1);
+  api_string_event->set_encoded_name_1(kEncodedName1);
+  api_string_event->set_encoded_name_2(kEncodedName2);
+  api_string_event->set_encoded_name_3(kEncodedName3);
+  api_string_event->set_encoded_name_4(kEncodedName4);
+  api_string_event->set_encoded_name_5(kEncodedName5);
+  api_string_event->set_encoded_name_6(kEncodedName6);
+  api_string_event->set_encoded_name_7(kEncodedName7);
+  api_string_event->set_encoded_name_8(kEncodedName8);
+  api_string_event->mutable_encoded_name_additional()->push_back(kEncodedNameAdditional1);
+
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = ProducerEventProcessor::Create(&buffer);
+  ClientCaptureEvent client_capture_event;
+  EXPECT_CALL(buffer, AddEvent).Times(1).WillOnce(SaveArg<0>(&client_capture_event));
+
+  producer_event_processor->ProcessEvent(kDefaultProducerId, producer_capture_event);
+  ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kApiStringEvent);
+  const ApiStringEvent& actual_event = client_capture_event.api_string_event();
+  EXPECT_EQ(actual_event.pid(), kPid1);
+  EXPECT_EQ(actual_event.tid(), kTid1);
+  EXPECT_EQ(actual_event.timestamp_ns(), kTimestampNs1);
+  EXPECT_EQ(actual_event.id(), kGroupId1);
+  EXPECT_EQ(actual_event.encoded_name_1(), kEncodedName1);
+  EXPECT_EQ(actual_event.encoded_name_2(), kEncodedName2);
+  EXPECT_EQ(actual_event.encoded_name_3(), kEncodedName3);
+  EXPECT_EQ(actual_event.encoded_name_4(), kEncodedName4);
+  EXPECT_EQ(actual_event.encoded_name_5(), kEncodedName5);
+  EXPECT_EQ(actual_event.encoded_name_6(), kEncodedName6);
+  EXPECT_EQ(actual_event.encoded_name_7(), kEncodedName7);
+  EXPECT_EQ(actual_event.encoded_name_8(), kEncodedName8);
+  EXPECT_THAT(actual_event.encoded_name_additional(), ElementsAre(kEncodedNameAdditional1));
+}
+
+TEST(ProducerEventProcessor, ApiTrackInt) {
+  ProducerCaptureEvent producer_capture_event;
+  ApiTrackInt* api_track_int = producer_capture_event.mutable_api_track_int();
+  api_track_int->set_pid(kPid1);
+  api_track_int->set_tid(kTid1);
+  api_track_int->set_timestamp_ns(kTimestampNs1);
+  api_track_int->set_data(kInt);
+
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = ProducerEventProcessor::Create(&buffer);
+  ClientCaptureEvent client_capture_event;
+  EXPECT_CALL(buffer, AddEvent).Times(1).WillOnce(SaveArg<0>(&client_capture_event));
+
+  producer_event_processor->ProcessEvent(kDefaultProducerId, producer_capture_event);
+  ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kApiTrackInt);
+  const ApiTrackInt& actual_event = client_capture_event.api_track_int();
+  EXPECT_EQ(actual_event.pid(), kPid1);
+  EXPECT_EQ(actual_event.tid(), kTid1);
+  EXPECT_EQ(actual_event.timestamp_ns(), kTimestampNs1);
+  EXPECT_EQ(actual_event.data(), kInt);
+}
+
+TEST(ProducerEventProcessor, ApiTrackInt64) {
+  ProducerCaptureEvent producer_capture_event;
+  ApiTrackInt64* api_track_int64 = producer_capture_event.mutable_api_track_int64();
+  api_track_int64->set_pid(kPid1);
+  api_track_int64->set_tid(kTid1);
+  api_track_int64->set_timestamp_ns(kTimestampNs1);
+  api_track_int64->set_data(kInt64);
+
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = ProducerEventProcessor::Create(&buffer);
+  ClientCaptureEvent client_capture_event;
+  EXPECT_CALL(buffer, AddEvent).Times(1).WillOnce(SaveArg<0>(&client_capture_event));
+
+  producer_event_processor->ProcessEvent(kDefaultProducerId, producer_capture_event);
+  ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kApiTrackInt64);
+  const ApiTrackInt64& actual_event = client_capture_event.api_track_int64();
+  EXPECT_EQ(actual_event.pid(), kPid1);
+  EXPECT_EQ(actual_event.tid(), kTid1);
+  EXPECT_EQ(actual_event.timestamp_ns(), kTimestampNs1);
+  EXPECT_EQ(actual_event.data(), kInt64);
+}
+
+TEST(ProducerEventProcessor, ApiTrackUint) {
+  ProducerCaptureEvent producer_capture_event;
+  ApiTrackUint* api_track_uint = producer_capture_event.mutable_api_track_uint();
+  api_track_uint->set_pid(kPid1);
+  api_track_uint->set_tid(kTid1);
+  api_track_uint->set_timestamp_ns(kTimestampNs1);
+  api_track_uint->set_data(kUint);
+
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = ProducerEventProcessor::Create(&buffer);
+  ClientCaptureEvent client_capture_event;
+  EXPECT_CALL(buffer, AddEvent).Times(1).WillOnce(SaveArg<0>(&client_capture_event));
+
+  producer_event_processor->ProcessEvent(kDefaultProducerId, producer_capture_event);
+  ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kApiTrackUint);
+  const ApiTrackUint& actual_event = client_capture_event.api_track_uint();
+  EXPECT_EQ(actual_event.pid(), kPid1);
+  EXPECT_EQ(actual_event.tid(), kTid1);
+  EXPECT_EQ(actual_event.timestamp_ns(), kTimestampNs1);
+  EXPECT_EQ(actual_event.data(), kUint);
+}
+
+TEST(ProducerEventProcessor, ApiTrackUint64) {
+  ProducerCaptureEvent producer_capture_event;
+  ApiTrackUint64* api_track_uint64 = producer_capture_event.mutable_api_track_uint64();
+  api_track_uint64->set_pid(kPid1);
+  api_track_uint64->set_tid(kTid1);
+  api_track_uint64->set_timestamp_ns(kTimestampNs1);
+  api_track_uint64->set_data(kUint64);
+
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = ProducerEventProcessor::Create(&buffer);
+  ClientCaptureEvent client_capture_event;
+  EXPECT_CALL(buffer, AddEvent).Times(1).WillOnce(SaveArg<0>(&client_capture_event));
+
+  producer_event_processor->ProcessEvent(kDefaultProducerId, producer_capture_event);
+  ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kApiTrackUint64);
+  const ApiTrackUint64& actual_event = client_capture_event.api_track_uint64();
+  EXPECT_EQ(actual_event.pid(), kPid1);
+  EXPECT_EQ(actual_event.tid(), kTid1);
+  EXPECT_EQ(actual_event.timestamp_ns(), kTimestampNs1);
+  EXPECT_EQ(actual_event.data(), kUint64);
+}
+
+TEST(ProducerEventProcessor, ApiTrackFloat) {
+  ProducerCaptureEvent producer_capture_event;
+  ApiTrackFloat* api_track_float = producer_capture_event.mutable_api_track_float();
+  api_track_float->set_pid(kPid1);
+  api_track_float->set_tid(kTid1);
+  api_track_float->set_timestamp_ns(kTimestampNs1);
+  api_track_float->set_data(kFloat);
+
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = ProducerEventProcessor::Create(&buffer);
+  ClientCaptureEvent client_capture_event;
+  EXPECT_CALL(buffer, AddEvent).Times(1).WillOnce(SaveArg<0>(&client_capture_event));
+
+  producer_event_processor->ProcessEvent(kDefaultProducerId, producer_capture_event);
+  ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kApiTrackFloat);
+  const ApiTrackFloat& actual_event = client_capture_event.api_track_float();
+  EXPECT_EQ(actual_event.pid(), kPid1);
+  EXPECT_EQ(actual_event.tid(), kTid1);
+  EXPECT_EQ(actual_event.timestamp_ns(), kTimestampNs1);
+  EXPECT_EQ(actual_event.data(), kFloat);
+}
+
+TEST(ProducerEventProcessor, ApiTrackDouble) {
+  ProducerCaptureEvent producer_capture_event;
+  ApiTrackDouble* api_track_double = producer_capture_event.mutable_api_track_double();
+  api_track_double->set_pid(kPid1);
+  api_track_double->set_tid(kTid1);
+  api_track_double->set_timestamp_ns(kTimestampNs1);
+  api_track_double->set_data(kDouble);
+
+  MockCaptureEventBuffer buffer;
+  auto producer_event_processor = ProducerEventProcessor::Create(&buffer);
+  ClientCaptureEvent client_capture_event;
+  EXPECT_CALL(buffer, AddEvent).Times(1).WillOnce(SaveArg<0>(&client_capture_event));
+
+  producer_event_processor->ProcessEvent(kDefaultProducerId, producer_capture_event);
+  ASSERT_EQ(client_capture_event.event_case(), ClientCaptureEvent::kApiTrackDouble);
+  const ApiTrackDouble& actual_event = client_capture_event.api_track_double();
+  EXPECT_EQ(actual_event.pid(), kPid1);
+  EXPECT_EQ(actual_event.tid(), kTid1);
+  EXPECT_EQ(actual_event.timestamp_ns(), kTimestampNs1);
+  EXPECT_EQ(actual_event.data(), kDouble);
 }
 
 TEST(ProducerEventProcessor, WarningEvent) {

--- a/src/Service/ProducerEventProcessorTest.cpp
+++ b/src/Service/ProducerEventProcessorTest.cpp
@@ -66,8 +66,8 @@ using orbit_grpc_protos::ThreadStateSlice;
 using orbit_grpc_protos::TracepointEvent;
 using orbit_grpc_protos::WarningEvent;
 
-using ::testing::SaveArg;
 using ::testing::ElementsAre;
+using ::testing::SaveArg;
 
 class MockCaptureEventBuffer : public CaptureEventBuffer {
  public:
@@ -1743,7 +1743,8 @@ TEST(ProducerEventProcessor, ApiScopeStop) {
 
 TEST(ProducerEventProcessor, ApiScopeStartAsync) {
   ProducerCaptureEvent producer_capture_event;
-  ApiScopeStartAsync* api_scope_start_async = producer_capture_event.mutable_api_scope_start_async();
+  ApiScopeStartAsync* api_scope_start_async =
+      producer_capture_event.mutable_api_scope_start_async();
   api_scope_start_async->set_pid(kPid1);
   api_scope_start_async->set_tid(kTid1);
   api_scope_start_async->set_timestamp_ns(kTimestampNs1);


### PR DESCRIPTION
This is moving the events and sending them to the client.

Follow-up:
1. Processing in the client.
2. Create v1 of manual instrumentation to create the data.
3. Convert from old ApiEvents to new events and drop the old ones.

Test: Compile and run tests.
Bug: http://b/194763537; http://b/194764373; http://b/194764259.