### PR TITLE
Start SymbolDirectories component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,7 @@ if(WITH_GUI)
   add_subdirectory(src/SourcePathsMappingUI)
   add_subdirectory(src/Style)
   add_subdirectory(src/SyntaxHighlighter)
+  add_subdirectory(src/SymbolPaths)
 endif()
 
 if(WITH_GUI AND WITH_CRASH_HANDLING)

--- a/src/SymbolPaths/CMakeLists.txt
+++ b/src/SymbolPaths/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright (c) 2021 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+cmake_minimum_required(VERSION 3.15)
+
+project(SymbolPaths)
+add_library(SymbolPaths STATIC)
+
+target_compile_options(SymbolPaths PRIVATE ${STRICT_COMPILE_FLAGS})
+target_include_directories(SymbolPaths PUBLIC include/)
+target_link_libraries(SymbolPaths PUBLIC Qt5::Core)
+
+target_sources(
+  SymbolPaths PUBLIC include/SymbolPaths/QSettingsWrapper.h)
+
+target_sources(SymbolPaths PRIVATE QSettingsWrapper.cpp)
+
+add_executable(SymbolPathsTests)
+target_compile_options(SymbolPathsTests PRIVATE ${STRICT_COMPILE_FLAGS})
+target_sources(SymbolPathsTests PRIVATE QSettingsWrapperTest.cpp)
+
+target_link_libraries(SymbolPathsTests PRIVATE SymbolPaths
+                                               GTest::QtCoreMain)
+
+register_test(SymbolPathsTests)

--- a/src/SymbolPaths/QSettingsWrapper.cpp
+++ b/src/SymbolPaths/QSettingsWrapper.cpp
@@ -1,0 +1,38 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "SymbolPaths/QSettingsWrapper.h"
+
+#include <QSettings>
+#include <filesystem>
+
+constexpr const char* kSymbolPathsSettingsKey = "symbol_directories";
+constexpr const char* kDirectoryPathKey = "directory_path";
+
+namespace orbit_symbol_paths {
+
+std::vector<std::filesystem::path> LoadPaths() {
+  QSettings settings{};
+  const int size = settings.beginReadArray(kSymbolPathsSettingsKey);
+  std::vector<std::filesystem::path> paths{};
+  paths.reserve(size);
+  for (int i = 0; i < size; ++i) {
+    settings.setArrayIndex(i);
+    paths.emplace_back(settings.value(kDirectoryPathKey).toString().toStdString());
+  }
+  settings.endArray();
+  return paths;
+}
+
+void SavePaths(const std::vector<std::filesystem::path>& paths) {
+  QSettings settings{};
+  settings.beginWriteArray(kSymbolPathsSettingsKey, static_cast<int>(paths.size()));
+  for (size_t i = 0; i < paths.size(); ++i) {
+    settings.setArrayIndex(static_cast<int>(i));
+    settings.setValue(kDirectoryPathKey, QString::fromStdString(paths[i].string()));
+  }
+  settings.endArray();
+}
+
+}  // namespace orbit_symbol_paths

--- a/src/SymbolPaths/QSettingsWrapperTest.cpp
+++ b/src/SymbolPaths/QSettingsWrapperTest.cpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <gtest/gtest.h>
+
+#include <QCoreApplication>
+#include <QSettings>
+#include <filesystem>
+
+#include "SymbolPaths/QSettingsWrapper.h"
+
+const std::filesystem::path path0{"/path/to/symbols/path"};
+const std::filesystem::path path1{"/home/src/project/build/"};
+const std::filesystem::path path2{R"(c:\project\build\)"};
+
+constexpr const char* kOrgName = "The Orbit Authors";
+
+namespace orbit_symbol_paths {
+
+TEST(SymbolPathsManager, LoadAndSave) {
+  QCoreApplication::setOrganizationDomain(kOrgName);
+  QCoreApplication::setApplicationName("SymbolPathsManager.SetAndGet");
+
+  {  // clear before test;
+    QSettings settings;
+    settings.clear();
+  }
+
+  EXPECT_EQ(LoadPaths(), std::vector<std::filesystem::path>{});
+
+  std::vector<std::filesystem::path> paths{
+      path0,
+      path1,
+      path2,
+  };
+
+  SavePaths(paths);
+  EXPECT_EQ(LoadPaths(), paths);
+}
+
+}  // namespace orbit_symbol_paths

--- a/src/SymbolPaths/include/SymbolPaths/QSettingsWrapper.h
+++ b/src/SymbolPaths/include/SymbolPaths/QSettingsWrapper.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2021 The Orbit Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SYMBOL_PATHS_QSETTINGS_WRAPPER_H_
+#define SYMBOL_PATHS_QSETTINGS_WRAPPER_H_
+
+#include <filesystem>
+#include <vector>
+
+namespace orbit_symbol_paths {
+
+// This is a simple wrapper around QSettings, which makes this thread safe, see
+// https://doc.qt.io/qt-5/qsettings.html
+void SavePaths(const std::vector<std::filesystem::path>& paths);
+
+// This is a simple wrapper around QSettings, which makes this thread safe, see
+// https://doc.qt.io/qt-5/qsettings.html
+[[nodiscard]] std::vector<std::filesystem::path> LoadPaths();
+
+}  // namespace orbit_symbol_paths
+
+#endif  // SYMBOL_PATHS_QSETTINGS_WRAPPER_H_


### PR DESCRIPTION
This adds the SymbolDirectories component and its first class
orbit_symbol_directories::Manager

http://b/167947773

This is the start of implementing the UI for SymbolPaths.txt. I think the name SymbolDirectories is easier to understand than SymbolPaths, but maybe SymbolFolders is even better. If you have an opinion, please let me know. 

This is heavily inspired by MappingManager