### PR TITLE
Report wall time of capture start

### DIFF
--- a/src/GrpcProtos/capture.proto
+++ b/src/GrpcProtos/capture.proto
@@ -562,11 +562,12 @@ message CaptureFinished {
 }
 
 message CaptureStarted {
-  // NextID: 8
+  // NextID: 9
   int32 process_id = 1;
   string executable_path = 2;
   string executable_build_id = 3;
   uint64 capture_start_timestamp_ns = 4;
+  uint64 capture_start_unix_time_ns = 8;
   uint32 orbit_version_major = 6;
   uint32 orbit_version_minor = 7;
   CaptureOptions capture_options = 5;

--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -311,8 +311,12 @@ void OrbitApp::OnCaptureStarted(const orbit_grpc_protos::CaptureStarted& capture
 
         FireRefreshCallbacks();
 
-        main_window_->AppendToCaptureLog(MainWindowInterface::CaptureLogSeverity::kInfo,
-                                         absl::ZeroDuration(), "Capture started.");
+        main_window_->AppendToCaptureLog(
+            MainWindowInterface::CaptureLogSeverity::kInfo, absl::ZeroDuration(),
+            absl::StrFormat(
+                "Capture started on %s.",
+                absl::FormatTime(absl::FromUnixNanos(capture_started.capture_start_unix_time_ns()),
+                                 absl::LocalTimeZone())));
 
         orbit_version::Version capture_version{capture_started.orbit_version_major(),
                                                capture_started.orbit_version_minor()};


### PR DESCRIPTION
Add wall time to capture start message.

Test: run Orbit check capture log for time.
