### PR TITLE
Erase name_ in Track

### DIFF
--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -34,8 +34,7 @@ AsyncTrack::AsyncTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                        orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                        const std::string& name, OrbitApp* app,
                        const orbit_client_data::CaptureData* capture_data)
-    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data) {
-  SetName(name);
+    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data), name_(name) {
   SetLabel(name);
 }
 

--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -34,9 +34,7 @@ AsyncTrack::AsyncTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                        orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                        const std::string& name, OrbitApp* app,
                        const orbit_client_data::CaptureData* capture_data)
-    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data), name_(name) {
-  SetLabel(name);
-}
+    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data), name_(name) {}
 
 [[nodiscard]] std::string AsyncTrack::GetBoxTooltip(const Batcher& batcher, PickingId id) const {
   const TimerInfo* timer_info = batcher.GetTimerInfo(id);

--- a/src/OrbitGl/AsyncTrack.h
+++ b/src/OrbitGl/AsyncTrack.h
@@ -29,6 +29,7 @@ class AsyncTrack final : public TimerTrack {
                       const std::string& name, OrbitApp* app,
                       const orbit_client_data::CaptureData* capture_data);
 
+  [[nodiscard]] std::string GetName() const override { return name_; };
   [[nodiscard]] Type GetType() const override { return Type::kAsyncTrack; };
   [[nodiscard]] std::string GetBoxTooltip(const Batcher& batcher, PickingId id) const override;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
@@ -40,6 +41,7 @@ class AsyncTrack final : public TimerTrack {
   [[nodiscard]] Color GetTimerColor(const orbit_client_protos::TimerInfo& timer_info,
                                     bool is_selected, bool is_highlighted) const override;
 
+  std::string name_;
   // Used for determining what row can receive a new timer with no overlap.
   absl::flat_hash_map<uint32_t, uint64_t> max_span_time_by_depth_;
 };

--- a/src/OrbitGl/BasicPageFaultsTrack.cpp
+++ b/src/OrbitGl/BasicPageFaultsTrack.cpp
@@ -20,11 +20,11 @@ static std::array<std::string, kBasicPageFaultsTrackDimension> CreateSeriesName(
 
 BasicPageFaultsTrack::BasicPageFaultsTrack(Track* parent, TimeGraph* time_graph,
                                            orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
-                                           const std::string& name, const std::string& cgroup_name,
+                                           const std::string& cgroup_name,
                                            uint64_t memory_sampling_period_ms,
                                            const orbit_client_data::CaptureData* capture_data)
     : LineGraphTrack<kBasicPageFaultsTrackDimension>(
-          parent, time_graph, viewport, layout, name,
+          parent, time_graph, viewport, layout,
           CreateSeriesName(cgroup_name, capture_data->process_name()), capture_data),
       AnnotationTrack(),
       cgroup_name_(cgroup_name),

--- a/src/OrbitGl/BasicPageFaultsTrack.h
+++ b/src/OrbitGl/BasicPageFaultsTrack.h
@@ -23,8 +23,8 @@ class BasicPageFaultsTrack : public LineGraphTrack<kBasicPageFaultsTrackDimensio
                              public AnnotationTrack {
  public:
   explicit BasicPageFaultsTrack(Track* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
-                                TimeGraphLayout* layout, const std::string& name,
-                                const std::string& cgroup_name, uint64_t memory_sampling_period_ms,
+                                TimeGraphLayout* layout, const std::string& cgroup_name,
+                                uint64_t memory_sampling_period_ms,
                                 const orbit_client_data::CaptureData* capture_data);
 
   [[nodiscard]] Track* GetParent() const override { return parent_; }

--- a/src/OrbitGl/CGroupAndProcessMemoryTrack.cpp
+++ b/src/OrbitGl/CGroupAndProcessMemoryTrack.cpp
@@ -20,7 +20,6 @@ using orbit_capture_client::CaptureEventProcessor;
 using orbit_grpc_protos::kMissingInfo;
 
 const std::string kTrackValueLabelUnit = "MB";
-const std::string kTrackName = absl::StrFormat("Memory Usage: CGroup (%s)", kTrackValueLabelUnit);
 
 static std::array<std::string, kCGroupAndProcessMemoryTrackDimension> CreateSeriesName(
     const std::string& cgroup_name, const std::string& process_name) {
@@ -36,7 +35,7 @@ CGroupAndProcessMemoryTrack::CGroupAndProcessMemoryTrack(
     TimeGraphLayout* layout, const std::string& cgroup_name,
     const orbit_client_data::CaptureData* capture_data)
     : MemoryTrack<kCGroupAndProcessMemoryTrackDimension>(
-          parent, time_graph, viewport, layout, kTrackName,
+          parent, time_graph, viewport, layout,
           CreateSeriesName(cgroup_name, capture_data->process_name()), capture_data),
       cgroup_name_(cgroup_name) {
   SetLabelUnit(kTrackValueLabelUnit);
@@ -58,6 +57,10 @@ CGroupAndProcessMemoryTrack::CGroupAndProcessMemoryTrack(
   const std::string kValueLowerBoundLabel = "Minimum: 0 GB";
   constexpr double kValueLowerBoundRawValue = 0.0;
   TrySetValueLowerBound(kValueLowerBoundLabel, kValueLowerBoundRawValue);
+}
+
+std::string CGroupAndProcessMemoryTrack::GetName() const {
+  return absl::StrFormat("Memory Usage: CGroup (%s)", kTrackValueLabelUnit);
 }
 
 std::string CGroupAndProcessMemoryTrack::GetTooltip() const {

--- a/src/OrbitGl/CGroupAndProcessMemoryTrack.h
+++ b/src/OrbitGl/CGroupAndProcessMemoryTrack.h
@@ -22,6 +22,7 @@ class CGroupAndProcessMemoryTrack final
                                        const std::string& cgroup_name,
                                        const orbit_client_data::CaptureData* capture_data);
 
+  [[nodiscard]] std::string GetName() const override;
   [[nodiscard]] std::string GetTooltip() const override;
 
   void TrySetValueUpperBound(double cgroup_limit_mb);

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -64,7 +64,6 @@ FrameTrack::FrameTrack(CaptureViewElement* parent, TimeGraph* time_graph,
     : TimerTrack(parent, time_graph, viewport, layout, app, capture_data),
       function_(std::move(function)) {
   // TODO(b/169554463): Support manual instrumentation.
-  SetLabel(GetName());
 
   // Frame tracks are collapsed by default.
   collapse_toggle_->SetCollapsed(true);

--- a/src/OrbitGl/FrameTrack.cpp
+++ b/src/OrbitGl/FrameTrack.cpp
@@ -64,9 +64,7 @@ FrameTrack::FrameTrack(CaptureViewElement* parent, TimeGraph* time_graph,
     : TimerTrack(parent, time_graph, viewport, layout, app, capture_data),
       function_(std::move(function)) {
   // TODO(b/169554463): Support manual instrumentation.
-  std::string name = absl::StrFormat("Frame track based on %s", function_.function_name());
-  SetName(name);
-  SetLabel(name);
+  SetLabel(GetName());
 
   // Frame tracks are collapsed by default.
   collapse_toggle_->SetCollapsed(true);

--- a/src/OrbitGl/FrameTrack.h
+++ b/src/OrbitGl/FrameTrack.h
@@ -29,6 +29,9 @@ class FrameTrack : public TimerTrack {
                       orbit_grpc_protos::InstrumentedFunction function, OrbitApp* app,
                       const orbit_client_data::CaptureData* capture_data);
 
+  [[nodiscard]] std::string GetName() const override {
+    return absl::StrFormat("Frame track based on %s", function_.function_name());
+  }
   [[nodiscard]] Type GetType() const override { return Type::kFrameTrack; }
   [[nodiscard]] uint64_t GetFunctionId() const { return function_.function_id(); }
   [[nodiscard]] bool IsCollapsible() const override {

--- a/src/OrbitGl/GpuDebugMarkerTrack.cpp
+++ b/src/OrbitGl/GpuDebugMarkerTrack.cpp
@@ -26,12 +26,18 @@ using orbit_client_protos::TimerInfo;
 
 GpuDebugMarkerTrack::GpuDebugMarkerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                                          orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
-                                         OrbitApp* app,
+                                         uint64_t timeline_hash, OrbitApp* app,
                                          const orbit_client_data::CaptureData* capture_data)
-    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data) {
+    : TimerTrack(parent, time_graph, viewport, layout, app, capture_data),
+      timeline_hash_{timeline_hash} {
   SetLabel("Debug Markers");
   draw_background_ = false;
   string_manager_ = app->GetStringManager();
+}
+
+std::string GpuDebugMarkerTrack::GetName() const {
+  return absl::StrFormat(
+      "%s_marker", string_manager_->Get(timeline_hash_).value_or(std::to_string(timeline_hash_)));
 }
 
 std::string GpuDebugMarkerTrack::GetTooltip() const {

--- a/src/OrbitGl/GpuDebugMarkerTrack.cpp
+++ b/src/OrbitGl/GpuDebugMarkerTrack.cpp
@@ -30,7 +30,6 @@ GpuDebugMarkerTrack::GpuDebugMarkerTrack(CaptureViewElement* parent, TimeGraph* 
                                          const orbit_client_data::CaptureData* capture_data)
     : TimerTrack(parent, time_graph, viewport, layout, app, capture_data),
       timeline_hash_{timeline_hash} {
-  SetLabel("Debug Markers");
   draw_background_ = false;
   string_manager_ = app->GetStringManager();
 }

--- a/src/OrbitGl/GpuDebugMarkerTrack.h
+++ b/src/OrbitGl/GpuDebugMarkerTrack.h
@@ -27,12 +27,14 @@ class TextRenderer;
 class GpuDebugMarkerTrack : public TimerTrack {
  public:
   explicit GpuDebugMarkerTrack(CaptureViewElement* parent, TimeGraph* time_graph,
-                               orbit_gl::Viewport* viewport, TimeGraphLayout* layout, OrbitApp* app,
+                               orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
+                               uint64_t timeline_hash, OrbitApp* app,
                                const orbit_client_data::CaptureData* capture_data);
 
   ~GpuDebugMarkerTrack() override = default;
 
-  // The type is currently only used by the TrackManger. We are moving towards removing it
+  [[nodiscard]] std::string GetName() const override;
+  // The type is currently only used by the TrackManager. We are moving towards removing it
   // completely. For subtracks there is no meaningful type and it should also not be exposed,
   // though we use the unknown type.
   [[nodiscard]] Type GetType() const override { return Type::kUnknown; }
@@ -52,6 +54,7 @@ class GpuDebugMarkerTrack : public TimerTrack {
 
  private:
   orbit_string_manager::StringManager* string_manager_;
+  uint64_t timeline_hash_;
 };
 
 #endif  // ORBIT_GL_GPU_DEBUG_MARKER_TRACK_H_

--- a/src/OrbitGl/GpuDebugMarkerTrack.h
+++ b/src/OrbitGl/GpuDebugMarkerTrack.h
@@ -34,6 +34,7 @@ class GpuDebugMarkerTrack : public TimerTrack {
   ~GpuDebugMarkerTrack() override = default;
 
   [[nodiscard]] std::string GetName() const override;
+  [[nodiscard]] std::string GetLabel() const override { return "Debug Markers"; }
   // The type is currently only used by the TrackManager. We are moving towards removing it
   // completely. For subtracks there is no meaningful type and it should also not be exposed,
   // though we use the unknown type.

--- a/src/OrbitGl/GpuSubmissionTrack.cpp
+++ b/src/OrbitGl/GpuSubmissionTrack.cpp
@@ -34,7 +34,6 @@ GpuSubmissionTrack::GpuSubmissionTrack(Track* parent, TimeGraph* time_graph,
                                        uint64_t timeline_hash, OrbitApp* app,
                                        const orbit_client_data::CaptureData* capture_data)
     : TimerTrack(parent, time_graph, viewport, layout, app, capture_data) {
-  SetLabel("Submissions");
   draw_background_ = false;
   text_renderer_ = time_graph->GetTextRenderer();
   timeline_hash_ = timeline_hash;

--- a/src/OrbitGl/GpuSubmissionTrack.cpp
+++ b/src/OrbitGl/GpuSubmissionTrack.cpp
@@ -42,6 +42,12 @@ GpuSubmissionTrack::GpuSubmissionTrack(Track* parent, TimeGraph* time_graph,
   parent_ = parent;
 }
 
+std::string GpuSubmissionTrack::GetName() const {
+  return absl::StrFormat(
+      "%s_submissions",
+      string_manager_->Get(timeline_hash_).value_or(std::to_string(timeline_hash_)));
+}
+
 std::string GpuSubmissionTrack::GetTooltip() const {
   return "Shows scheduling and execution times for selected GPU job "
          "submissions";

--- a/src/OrbitGl/GpuSubmissionTrack.h
+++ b/src/OrbitGl/GpuSubmissionTrack.h
@@ -36,6 +36,7 @@ class GpuSubmissionTrack : public TimerTrack {
 
   [[nodiscard]] Track* GetParent() const override { return parent_; }
 
+  [[nodiscard]] std::string GetName() const override;
   // The type is currently only used by the TrackManger. We are moving towards removing it
   // completely. For subtracks there is no meaningful type and it should also not be exposed,
   // though we use the unknown type.

--- a/src/OrbitGl/GpuSubmissionTrack.h
+++ b/src/OrbitGl/GpuSubmissionTrack.h
@@ -37,6 +37,7 @@ class GpuSubmissionTrack : public TimerTrack {
   [[nodiscard]] Track* GetParent() const override { return parent_; }
 
   [[nodiscard]] std::string GetName() const override;
+  [[nodiscard]] std::string GetLabel() const override { return "Submissions"; }
   // The type is currently only used by the TrackManger. We are moving towards removing it
   // completely. For subtracks there is no meaningful type and it should also not be exposed,
   // though we use the unknown type.

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -59,8 +59,6 @@ GpuTrack::GpuTrack(CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::
       marker_track_{std::make_shared<GpuDebugMarkerTrack>(this, time_graph, viewport, layout,
                                                           timeline_hash, app, capture_data)},
       timeline_hash_(timeline_hash) {
-  SetLabel(orbit_gl::MapGpuTimelineToTrackLabel(GetName()));
-
   // Gpu are collapsed by default. Their subtracks are expanded by default, but are however not
   // shown while the Gpu track is collapsed.
   collapse_toggle_->SetCollapsed(true);

--- a/src/OrbitGl/GpuTrack.cpp
+++ b/src/OrbitGl/GpuTrack.cpp
@@ -53,20 +53,13 @@ GpuTrack::GpuTrack(CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::
                    TimeGraphLayout* layout, uint64_t timeline_hash, OrbitApp* app,
                    const orbit_client_data::CaptureData* capture_data)
     : Track(parent, time_graph, viewport, layout, capture_data),
+      string_manager_{app->GetStringManager()},
       submission_track_{std::make_shared<GpuSubmissionTrack>(this, time_graph, viewport, layout,
                                                              timeline_hash, app, capture_data)},
-      marker_track_{std::make_shared<GpuDebugMarkerTrack>(this, time_graph, viewport, layout, app,
-                                                          capture_data)} {
-  timeline_hash_ = timeline_hash;
-
-  std::string timeline =
-      app->GetStringManager()->Get(timeline_hash).value_or(std::to_string(timeline_hash));
-  std::string label = orbit_gl::MapGpuTimelineToTrackLabel(timeline);
-  SetName(timeline);
-  SetLabel(label);
-
-  submission_track_->SetName(absl::StrFormat("%s_submissions", timeline));
-  marker_track_->SetName(absl::StrFormat("%s_marker", timeline));
+      marker_track_{std::make_shared<GpuDebugMarkerTrack>(this, time_graph, viewport, layout,
+                                                          timeline_hash, app, capture_data)},
+      timeline_hash_(timeline_hash) {
+  SetLabel(orbit_gl::MapGpuTimelineToTrackLabel(GetName()));
 
   // Gpu are collapsed by default. Their subtracks are expanded by default, but are however not
   // shown while the Gpu track is collapsed.

--- a/src/OrbitGl/GpuTrack.h
+++ b/src/OrbitGl/GpuTrack.h
@@ -55,6 +55,9 @@ class GpuTrack : public Track {
   [[nodiscard]] std::string GetName() const override {
     return string_manager_->Get(timeline_hash_).value_or(std::to_string(timeline_hash_));
   }
+  [[nodiscard]] std::string GetLabel() const override {
+    return orbit_gl::MapGpuTimelineToTrackLabel(GetName());
+  }
   [[nodiscard]] Type GetType() const override { return Type::kGpuTrack; }
   [[nodiscard]] std::string GetTooltip() const override;
   [[nodiscard]] float GetHeight() const override;

--- a/src/OrbitGl/GpuTrack.h
+++ b/src/OrbitGl/GpuTrack.h
@@ -39,6 +39,7 @@ class GpuTrack : public Track {
   explicit GpuTrack(CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
                     TimeGraphLayout* layout, uint64_t timeline_hash, OrbitApp* app,
                     const orbit_client_data::CaptureData* capture_data);
+
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
 
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetLeft(
@@ -51,6 +52,9 @@ class GpuTrack : public Track {
   [[nodiscard]] const orbit_client_protos::TimerInfo* GetDown(
       const orbit_client_protos::TimerInfo& timer_info) const;
 
+  [[nodiscard]] std::string GetName() const override {
+    return string_manager_->Get(timeline_hash_).value_or(std::to_string(timeline_hash_));
+  }
   [[nodiscard]] Type GetType() const override { return Type::kGpuTrack; }
   [[nodiscard]] std::string GetTooltip() const override;
   [[nodiscard]] float GetHeight() const override;
@@ -76,6 +80,7 @@ class GpuTrack : public Track {
 
  private:
   void UpdatePositionOfSubtracks();
+  orbit_string_manager::StringManager* string_manager_;
   const std::shared_ptr<GpuSubmissionTrack> submission_track_;
   const std::shared_ptr<GpuDebugMarkerTrack> marker_track_;
 

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -24,14 +24,10 @@
 template <size_t Dimension>
 GraphTrack<Dimension>::GraphTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                                   orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
-                                  const std::string& name,
                                   std::array<std::string, Dimension> series_names,
                                   const orbit_client_data::CaptureData* capture_data)
     : Track(parent, time_graph, viewport, layout, capture_data),
-      series_(MultivariateTimeSeries<Dimension>(series_names)) {
-  SetName(name);
-  SetLabel(name);
-}
+      series_(MultivariateTimeSeries<Dimension>(series_names)) {}
 
 template <size_t Dimension>
 float GraphTrack<Dimension>::GetHeight() const {
@@ -53,6 +49,7 @@ float GraphTrack<Dimension>::GetLegendHeight() const {
 template <size_t Dimension>
 void GraphTrack<Dimension>::Draw(Batcher& batcher, TextRenderer& text_renderer,
                                  const DrawContext& draw_context) {
+  SetLabel(GetName());
   Track::Draw(batcher, text_renderer, draw_context);
   if (IsEmpty() || IsCollapsed()) return;
 

--- a/src/OrbitGl/GraphTrack.cpp
+++ b/src/OrbitGl/GraphTrack.cpp
@@ -49,7 +49,6 @@ float GraphTrack<Dimension>::GetLegendHeight() const {
 template <size_t Dimension>
 void GraphTrack<Dimension>::Draw(Batcher& batcher, TextRenderer& text_renderer,
                                  const DrawContext& draw_context) {
-  SetLabel(GetName());
   Track::Draw(batcher, text_renderer, draw_context);
   if (IsEmpty() || IsCollapsed()) return;
 

--- a/src/OrbitGl/GraphTrack.h
+++ b/src/OrbitGl/GraphTrack.h
@@ -23,7 +23,7 @@ class GraphTrack : public Track {
  public:
   explicit GraphTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                       orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
-                      const std::string& name, std::array<std::string, Dimension> series_names,
+                      std::array<std::string, Dimension> series_names,
                       const orbit_client_data::CaptureData* capture_data);
 
   [[nodiscard]] Type GetType() const override { return Type::kGraphTrack; }

--- a/src/OrbitGl/LineGraphTrack.h
+++ b/src/OrbitGl/LineGraphTrack.h
@@ -19,10 +19,9 @@ class LineGraphTrack : public GraphTrack<Dimension> {
  public:
   explicit LineGraphTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                           orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
-                          const std::string& name, std::array<std::string, Dimension> series_names,
+                          std::array<std::string, Dimension> series_names,
                           const orbit_client_data::CaptureData* capture_data)
-      : GraphTrack<Dimension>(parent, time_graph, viewport, layout, name, series_names,
-                              capture_data) {}
+      : GraphTrack<Dimension>(parent, time_graph, viewport, layout, series_names, capture_data) {}
   ~LineGraphTrack() override = default;
 
  protected:

--- a/src/OrbitGl/MajorPageFaultsTrack.cpp
+++ b/src/OrbitGl/MajorPageFaultsTrack.cpp
@@ -12,7 +12,7 @@ MajorPageFaultsTrack::MajorPageFaultsTrack(Track* parent, TimeGraph* time_graph,
                                            const std::string& cgroup_name,
                                            uint64_t memory_sampling_period_ms,
                                            const orbit_client_data::CaptureData* capture_data)
-    : BasicPageFaultsTrack(parent, time_graph, viewport, layout, "Page Faults: Major", cgroup_name,
+    : BasicPageFaultsTrack(parent, time_graph, viewport, layout, cgroup_name,
                            memory_sampling_period_ms, capture_data) {
   index_of_series_to_highlight_ = static_cast<size_t>(SeriesIndex::kProcess);
 }

--- a/src/OrbitGl/MajorPageFaultsTrack.h
+++ b/src/OrbitGl/MajorPageFaultsTrack.h
@@ -19,6 +19,7 @@ class MajorPageFaultsTrack final : public BasicPageFaultsTrack {
                                 uint64_t memory_sampling_period_ms,
                                 const orbit_client_data::CaptureData* capture_data);
 
+  [[nodiscard]] std::string GetName() const override { return "Page Faults: Major"; }
   [[nodiscard]] std::string GetTooltip() const override;
 
  private:

--- a/src/OrbitGl/MemoryTrack.h
+++ b/src/OrbitGl/MemoryTrack.h
@@ -21,15 +21,15 @@ class MemoryTrack : public GraphTrack<Dimension>, public AnnotationTrack {
  public:
   explicit MemoryTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                        orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
-                       const std::string& name, std::array<std::string, Dimension> series_names,
+                       std::array<std::string, Dimension> series_names,
                        const orbit_client_data::CaptureData* capture_data)
-      : GraphTrack<Dimension>(parent, time_graph, viewport, layout, name, series_names,
-                              capture_data),
+      : GraphTrack<Dimension>(parent, time_graph, viewport, layout, series_names, capture_data),
         AnnotationTrack() {
     // Memory tracks are collapsed by default.
     this->collapse_toggle_->SetCollapsed(true);
   }
   ~MemoryTrack() override = default;
+
   [[nodiscard]] Track::Type GetType() const override { return Track::Type::kMemoryTrack; }
   void Draw(Batcher& batcher, TextRenderer& text_renderer,
             const CaptureViewElement::DrawContext& draw_context) override;

--- a/src/OrbitGl/MinorPageFaultsTrack.h
+++ b/src/OrbitGl/MinorPageFaultsTrack.h
@@ -18,9 +18,10 @@ class MinorPageFaultsTrack final : public BasicPageFaultsTrack {
                                 TimeGraphLayout* layout, const std::string& cgroup_name,
                                 uint64_t memory_sampling_period_ms,
                                 const orbit_client_data::CaptureData* capture_data)
-      : BasicPageFaultsTrack(parent, time_graph, viewport, layout, "Page Faults: Minor",
-                             cgroup_name, memory_sampling_period_ms, capture_data) {}
+      : BasicPageFaultsTrack(parent, time_graph, viewport, layout, cgroup_name,
+                             memory_sampling_period_ms, capture_data) {}
 
+  [[nodiscard]] std::string GetName() const override { return "Page Faults: Minor"; }
   [[nodiscard]] std::string GetTooltip() const override;
 
  private:

--- a/src/OrbitGl/PageFaultsTrack.cpp
+++ b/src/OrbitGl/PageFaultsTrack.cpp
@@ -31,11 +31,14 @@ PageFaultsTrack::PageFaultsTrack(CaptureViewElement* parent, TimeGraph* time_gra
       minor_page_faults_track_{
           std::make_shared<MinorPageFaultsTrack>(this, time_graph, viewport, layout, cgroup_name,
                                                  memory_sampling_period_ms, capture_data)} {
-  SetLabel(GetName());
 
   // PageFaults track is collapsed by default. The major and minor page faults subtracks are
   // expanded by default, but not shown while the page faults track is collapsed.
   collapse_toggle_->SetCollapsed(true);
+}
+
+std::string PageFaultsTrack::GetLabel() const {
+  return collapse_toggle_->IsCollapsed() ? major_page_faults_track_->GetName() : GetName();
 }
 
 float PageFaultsTrack::GetHeight() const {
@@ -69,8 +72,6 @@ std::string PageFaultsTrack::GetTooltip() const {
 
 void PageFaultsTrack::Draw(Batcher& batcher, TextRenderer& text_renderer,
                            const DrawContext& draw_context) {
-  SetLabel(collapse_toggle_->IsCollapsed() ? major_page_faults_track_->GetName() : GetName());
-
   UpdatePositionOfSubtracks();
   // If being collapsed, the page faults track will show a collapsed version of the major page
   // faults subtrack. Hence, the height of major page faults subtrack should always be updated as

--- a/src/OrbitGl/PageFaultsTrack.cpp
+++ b/src/OrbitGl/PageFaultsTrack.cpp
@@ -31,9 +31,7 @@ PageFaultsTrack::PageFaultsTrack(CaptureViewElement* parent, TimeGraph* time_gra
       minor_page_faults_track_{
           std::make_shared<MinorPageFaultsTrack>(this, time_graph, viewport, layout, cgroup_name,
                                                  memory_sampling_period_ms, capture_data)} {
-  const std::string kTrackName = "Page Faults";
-  SetName(kTrackName);
-  SetLabel(kTrackName);
+  SetLabel(GetName());
 
   // PageFaults track is collapsed by default. The major and minor page faults subtracks are
   // expanded by default, but not shown while the page faults track is collapsed.

--- a/src/OrbitGl/PageFaultsTrack.h
+++ b/src/OrbitGl/PageFaultsTrack.h
@@ -24,6 +24,7 @@ class PageFaultsTrack : public Track {
                            const std::string& cgroup_name, uint64_t memory_sampling_period_ms,
                            const orbit_client_data::CaptureData* capture_data);
 
+  [[nodiscard]] std::string GetName() const override { return "Page Faults"; }
   [[nodiscard]] Type GetType() const override { return Type::kPageFaultsTrack; }
   [[nodiscard]] float GetHeight() const override;
   [[nodiscard]] std::vector<CaptureViewElement*> GetVisibleChildren() override;

--- a/src/OrbitGl/PageFaultsTrack.h
+++ b/src/OrbitGl/PageFaultsTrack.h
@@ -25,6 +25,7 @@ class PageFaultsTrack : public Track {
                            const orbit_client_data::CaptureData* capture_data);
 
   [[nodiscard]] std::string GetName() const override { return "Page Faults"; }
+  [[nodiscard]] std::string GetLabel() const override;
   [[nodiscard]] Type GetType() const override { return Type::kPageFaultsTrack; }
   [[nodiscard]] float GetHeight() const override;
   [[nodiscard]] std::vector<CaptureViewElement*> GetVisibleChildren() override;

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -27,7 +27,6 @@ SchedulerTrack::SchedulerTrack(CaptureViewElement* parent, TimeGraph* time_graph
                                const orbit_client_data::CaptureData* capture_data)
     : TimerTrack(parent, time_graph, viewport, layout, app, capture_data) {
   SetPinned(false);
-  SetName("Scheduler");
   SetLabel("Scheduler (0 cores)");
   num_cores_ = 0;
 }

--- a/src/OrbitGl/SchedulerTrack.cpp
+++ b/src/OrbitGl/SchedulerTrack.cpp
@@ -27,7 +27,6 @@ SchedulerTrack::SchedulerTrack(CaptureViewElement* parent, TimeGraph* time_graph
                                const orbit_client_data::CaptureData* capture_data)
     : TimerTrack(parent, time_graph, viewport, layout, app, capture_data) {
   SetPinned(false);
-  SetLabel("Scheduler (0 cores)");
   num_cores_ = 0;
 }
 
@@ -35,7 +34,6 @@ void SchedulerTrack::OnTimer(const orbit_client_protos::TimerInfo& timer_info) {
   TimerTrack::OnTimer(timer_info);
   if (num_cores_ <= static_cast<uint32_t>(timer_info.processor())) {
     num_cores_ = timer_info.processor() + 1;
-    SetLabel(absl::StrFormat("Scheduler (%u cores)", num_cores_));
   }
 }
 

--- a/src/OrbitGl/SchedulerTrack.h
+++ b/src/OrbitGl/SchedulerTrack.h
@@ -26,6 +26,9 @@ class SchedulerTrack final : public TimerTrack {
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
 
   [[nodiscard]] std::string GetName() const override { return "Scheduler"; }
+  [[nodiscard]] std::string GetLabel() const override {
+    return absl::StrFormat("Scheduler (%u cores)", num_cores_);
+  }
   [[nodiscard]] Type GetType() const override { return Type::kSchedulerTrack; }
   [[nodiscard]] std::string GetTooltip() const override;
 

--- a/src/OrbitGl/SchedulerTrack.h
+++ b/src/OrbitGl/SchedulerTrack.h
@@ -25,6 +25,7 @@ class SchedulerTrack final : public TimerTrack {
   ~SchedulerTrack() override = default;
   void OnTimer(const orbit_client_protos::TimerInfo& timer_info) override;
 
+  [[nodiscard]] std::string GetName() const override { return "Scheduler"; }
   [[nodiscard]] Type GetType() const override { return Type::kSchedulerTrack; }
   [[nodiscard]] std::string GetTooltip() const override;
 

--- a/src/OrbitGl/SystemMemoryTrack.cpp
+++ b/src/OrbitGl/SystemMemoryTrack.cpp
@@ -19,7 +19,6 @@ using orbit_capture_client::CaptureEventProcessor;
 using orbit_grpc_protos::kMissingInfo;
 
 const std::string kTrackValueLabelUnit = "MB";
-const std::string kTrackName = absl::StrFormat("Memory Usage: System (%s)", kTrackValueLabelUnit);
 const std::array<std::string, kSystemMemoryTrackDimension> kSeriesName = {
     "Used", "Buffers / Cached", "Unused"};
 constexpr uint64_t kMegabytesToBytes = 1024 * 1024;
@@ -29,8 +28,8 @@ constexpr uint64_t kMegabytesToBytes = 1024 * 1024;
 SystemMemoryTrack::SystemMemoryTrack(CaptureViewElement* parent, TimeGraph* time_graph,
                                      orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                                      const orbit_client_data::CaptureData* capture_data)
-    : MemoryTrack<kSystemMemoryTrackDimension>(parent, time_graph, viewport, layout, kTrackName,
-                                               kSeriesName, capture_data) {
+    : MemoryTrack<kSystemMemoryTrackDimension>(parent, time_graph, viewport, layout, kSeriesName,
+                                               capture_data) {
   SetLabelUnit(kTrackValueLabelUnit);
 
   constexpr uint8_t kTrackValueDecimalDigits = 2;
@@ -49,6 +48,10 @@ SystemMemoryTrack::SystemMemoryTrack(CaptureViewElement* parent, TimeGraph* time
   const std::string kValueLowerBoundLabel = "Minimum: 0 GB";
   constexpr double kValueLowerBoundRawValue = 0.0;
   TrySetValueLowerBound(kValueLowerBoundLabel, kValueLowerBoundRawValue);
+}
+
+std::string SystemMemoryTrack::GetName() const {
+  return absl::StrFormat("Memory Usage: System (%s)", kTrackValueLabelUnit);
 }
 
 std::string SystemMemoryTrack::GetTooltip() const {

--- a/src/OrbitGl/SystemMemoryTrack.h
+++ b/src/OrbitGl/SystemMemoryTrack.h
@@ -20,6 +20,7 @@ class SystemMemoryTrack final : public MemoryTrack<kSystemMemoryTrackDimension> 
                              orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                              const orbit_client_data::CaptureData* capture_data);
 
+  [[nodiscard]] std::string GetName() const override;
   [[nodiscard]] std::string GetTooltip() const override;
 
   void TrySetValueUpperBound(double total_mb);

--- a/src/OrbitGl/ThreadTrack.cpp
+++ b/src/OrbitGl/ThreadTrack.cpp
@@ -60,20 +60,28 @@ std::string ThreadTrack::GetThreadNameFromTid(uint32_t thread_id) {
   return capture_data_->GetThreadName(thread_id);
 }
 
+std::string ThreadTrack::GetName() const {
+  auto thread_id = GetThreadId();
+  if (thread_id == orbit_base::kAllThreadsOfAllProcessesTid) {
+    return "All tracepoint events";
+  } else if (thread_id == orbit_base::kAllProcessThreadsTid) {
+    return "All Threads";
+  }
+  return capture_data_->GetThreadName(thread_id);
+  ;
+}
+
 void ThreadTrack::InitializeNameAndLabel() {
   if (GetThreadId() == orbit_base::kAllThreadsOfAllProcessesTid) {
-    SetName("All tracepoint events");
     SetLabel("All tracepoint events");
   } else if (GetThreadId() == orbit_base::kAllProcessThreadsTid) {
     // This is the process track.
     std::string process_name = capture_data_->process_name();
-    SetName("All Threads");
     const std::string_view all_threads = " (all_threads)";
     SetLabel(process_name.append(all_threads));
     SetNumberOfPrioritizedTrailingCharacters(all_threads.size() - 1);
   } else {
     const std::string& thread_name = GetThreadNameFromTid(GetThreadId());
-    SetName(thread_name);
     std::string tid_str = std::to_string(GetThreadId());
     std::string track_label = absl::StrFormat("%s [%s]", thread_name, tid_str);
     SetLabel(track_label);

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -34,6 +34,7 @@ class ThreadTrack final : public TimerTrack {
 
   void InitializeNameAndLabel();
 
+  [[nodiscard]] std::string GetName() const override;
   [[nodiscard]] Type GetType() const override { return Type::kThreadTrack; }
   [[nodiscard]] std::string GetTooltip() const override;
 

--- a/src/OrbitGl/ThreadTrack.h
+++ b/src/OrbitGl/ThreadTrack.h
@@ -35,6 +35,8 @@ class ThreadTrack final : public TimerTrack {
   void InitializeNameAndLabel();
 
   [[nodiscard]] std::string GetName() const override;
+  [[nodiscard]] std::string GetLabel() const override;
+  [[nodiscard]] int GetNumberOfPrioritizedTrailingCharacters() const override;
   [[nodiscard]] Type GetType() const override { return Type::kThreadTrack; }
   [[nodiscard]] std::string GetTooltip() const override;
 

--- a/src/OrbitGl/Track.cpp
+++ b/src/OrbitGl/Track.cpp
@@ -23,7 +23,6 @@ using orbit_client_data::TrackData;
 Track::Track(CaptureViewElement* parent, TimeGraph* time_graph, orbit_gl::Viewport* viewport,
              TimeGraphLayout* layout, const orbit_client_data::CaptureData* capture_data)
     : CaptureViewElement(parent, time_graph, viewport, layout),
-      num_prioritized_trailing_characters_{0},
       process_id_{-1},
       pinned_{false},
       layout_(layout),
@@ -169,10 +168,10 @@ void Track::Draw(Batcher& batcher, TextRenderer& text_renderer, const DrawContex
     const Color kColor =
         IsTrackSelected() ? GlCanvas::kTabTextColorSelected : Color(255, 255, 255, 255);
 
-    text_renderer.AddTextTrailingCharsPrioritized(label_.c_str(), indentation_x0 + label_offset_x,
-                                                  toggle_y_pos - label_offset_y, text_z, kColor,
-                                                  GetNumberOfPrioritizedTrailingCharacters(),
-                                                  font_size, label_width - label_offset_x);
+    text_renderer.AddTextTrailingCharsPrioritized(
+        GetLabel().c_str(), indentation_x0 + label_offset_x, toggle_y_pos - label_offset_y, text_z,
+        kColor, GetNumberOfPrioritizedTrailingCharacters(), font_size,
+        label_width - label_offset_x);
   }
 
   // Draw track's content background.

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -69,21 +69,14 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   [[nodiscard]] virtual uint64_t GetMinTime() const = 0;
   [[nodiscard]] virtual uint64_t GetMaxTime() const = 0;
 
-  void SetNumberOfPrioritizedTrailingCharacters(int num_characters) {
-    num_prioritized_trailing_characters_ = num_characters;
-  }
-  [[nodiscard]] int GetNumberOfPrioritizedTrailingCharacters() const {
-    return num_prioritized_trailing_characters_;
-  }
-
   virtual void OnTimer(const orbit_client_protos::TimerInfo& /*timer_info*/) {}
   [[nodiscard]] bool IsPinned() const { return pinned_; }
   void SetPinned(bool value);
 
   [[nodiscard]] bool IsMoving() const { return picked_ && mouse_pos_last_click_ != mouse_pos_cur_; }
   [[nodiscard]] virtual std::string GetName() const = 0;
-  void SetLabel(const std::string& label) { label_ = label; }
-  [[nodiscard]] const std::string& GetLabel() const { return label_; }
+  [[nodiscard]] virtual std::string GetLabel() const { return GetName(); }
+  [[nodiscard]] virtual int GetNumberOfPrioritizedTrailingCharacters() const { return 0; }
 
   [[nodiscard]] virtual Color GetTrackBackgroundColor() const;
 
@@ -110,8 +103,6 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
 
   std::unique_ptr<orbit_accessibility::AccessibleInterface> CreateAccessibleInterface() override;
 
-  std::string label_;
-  int num_prioritized_trailing_characters_;
   int32_t process_id_;
   bool draw_background_ = true;
   bool visible_ = true;

--- a/src/OrbitGl/Track.h
+++ b/src/OrbitGl/Track.h
@@ -81,8 +81,7 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
   void SetPinned(bool value);
 
   [[nodiscard]] bool IsMoving() const { return picked_ && mouse_pos_last_click_ != mouse_pos_cur_; }
-  void SetName(const std::string& name) { name_ = name; }
-  [[nodiscard]] const std::string& GetName() const { return name_; }
+  [[nodiscard]] virtual std::string GetName() const = 0;
   void SetLabel(const std::string& label) { label_ = label; }
   [[nodiscard]] const std::string& GetLabel() const { return label_; }
 
@@ -111,7 +110,6 @@ class Track : public orbit_gl::CaptureViewElement, public std::enable_shared_fro
 
   std::unique_ptr<orbit_accessibility::AccessibleInterface> CreateAccessibleInterface() override;
 
-  std::string name_;
   std::string label_;
   int num_prioritized_trailing_characters_;
   int32_t process_id_;

--- a/src/OrbitGl/VariableTrack.h
+++ b/src/OrbitGl/VariableTrack.h
@@ -23,17 +23,21 @@ class VariableTrack final : public LineGraphTrack<kVariableTrackDimension> {
                          orbit_gl::Viewport* viewport, TimeGraphLayout* layout,
                          const std::string& name,
                          const orbit_client_data::CaptureData* capture_data)
-      : LineGraphTrack<kVariableTrackDimension>(parent, time_graph, viewport, layout, name,
+      : LineGraphTrack<kVariableTrackDimension>(parent, time_graph, viewport, layout,
                                                 std::array<std::string, kVariableTrackDimension>{},
-                                                capture_data) {
+                                                capture_data),
+        name_(name) {
     SetSeriesColors(kVariableTrackColor);
   }
 
   [[nodiscard]] bool IsCollapsible() const override { return false; }
+  [[nodiscard]] std::string GetName() const override { return name_; }
   [[nodiscard]] Track::Type GetType() const override { return Track::Type::kVariableTrack; }
   void AddValue(uint64_t time, double value) { AddValues(time, {value}); }
 
  private:
+  std::string name_;
+
   std::string GetLegendTooltips(size_t /*legend_index*/) const override { return ""; }
 };
 


### PR DESCRIPTION
In the process of moving all data from the Track to TrackData (http://b/194504762), we are trying to clean Tracks a little bit and trying to avoid having not needed data.

In this PR, focusing in erasing SetName, SetLabel, SetNumPrioritizedTrailingCharacters methods for every track (not needed as we were mostly setting Name and Label when constructing) and as we didn't like to have them as a parameters in the constructor, we made inside Track.h:
- a pure virtual GetName() method
- a virtual GetLabel method which by default only returns GetName()
- a virtual GetNumPrioritizedTrailingCharacters (only used in ThreadTrack) to be 0.

And we overwrite this methods when it is needed. We only still have name_ in the Tracks where they have a name defined by the users (AsyncTrack and VariableTrack).

As a regression we are creating and returning a string several times (every time we draw for each track) but I don't think that this could be a problem and as Henning suggested, we can make Get methods mutable and storing a value if it was calculated before if this is needed. 

Another alternative is to have name (and label?) in the constructor of the base classes (Track.h, TimerTrack.h, ...) and in the specialized classes have a function to get the proper name (GetFrameTrackName or GetThreadTrackName) which we will use to pass the name in the base classes. I decided for the virtual Get methods, but if you have better suggestions I'm open to them.