### PR TITLE
Handle new manual instrumentation events in OrbitGl.

### DIFF
--- a/src/OrbitGl/App.cpp
+++ b/src/OrbitGl/App.cpp
@@ -410,6 +410,15 @@ void OrbitApp::OnTimer(const TimerInfo& timer_info) {
   frame_track_online_processor_.ProcessTimer(timer_info, func);
 }
 
+void OrbitApp::OnApiStringEvent(const orbit_client_protos::ApiStringEvent& api_string_event) {
+  GetMutableTimeGraph()->ProcessApiStringEvent(api_string_event);
+}
+
+void OrbitApp::OnApiTrackValue(const orbit_client_protos::ApiTrackValue& api_track_value) {
+  metrics_capture_complete_data_.number_of_manual_tracked_value_timers++;
+  GetMutableTimeGraph()->ProcessApiTrackValueEvent(api_track_value);
+}
+
 void OrbitApp::OnKeyAndString(uint64_t key, std::string str) {
   string_manager_.AddIfNotPresent(key, std::move(str));
 }
@@ -2703,6 +2712,12 @@ void OrbitApp::CaptureMetricProcessTimer(const orbit_client_protos::TimerInfo& t
     case orbit_client_protos::TimerInfo_Type_kApiEvent:
       CaptureMetricProcessApiTimer(timer);
       break;
+    case orbit_client_protos::TimerInfo_Type_kApiScope:
+      metrics_capture_complete_data_.number_of_manual_start_timers++;
+      break;
+    case orbit_client_protos::TimerInfo_Type_kApiScopeAsync:
+      metrics_capture_complete_data_.number_of_manual_start_async_timers++;
+      break;
     default:
       break;
   }
@@ -2770,12 +2785,4 @@ void OrbitApp::TrySaveUserDefinedCaptureInfo() {
                                                    write_result.error().message()));
     }
   });
-}
-
-void OrbitApp::OnApiStringEvent(const orbit_client_protos::ApiStringEvent& /*api_string_event*/) {
-  UNREACHABLE();
-}
-
-void OrbitApp::OnApiTrackValue(const orbit_client_protos::ApiTrackValue& /*api_track_value*/) {
-  UNREACHABLE();
 }

--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -44,20 +44,29 @@ AsyncTrack::AsyncTrack(CaptureViewElement* parent, TimeGraph* time_graph,
   const TimerInfo* timer_info = batcher.GetTimerInfo(id);
   if (timer_info == nullptr) return "";
   auto* manual_inst_manager = app_->GetManualInstrumentationManager();
-  orbit_api::Event event = ManualInstrumentationManager::ApiEventFromTimerInfo(*timer_info);
 
   // The FunctionInfo here corresponds to one of the automatically instrumented empty stubs from
   // Orbit.h. Use it to retrieve the module from which the manually instrumented scope originated.
   const InstrumentedFunction* func =
-      capture_data_ ? capture_data_->GetInstrumentedFunctionById(timer_info->function_id())
-                    : nullptr;
-  CHECK(func || timer_info->type() == TimerInfo::kIntrospection ||
-        timer_info->type() == TimerInfo::kApiEvent);
+      capture_data_ != nullptr
+          ? capture_data_->GetInstrumentedFunctionById(timer_info->function_id())
+          : nullptr;
+  CHECK(func != nullptr || timer_info->type() == TimerInfo::kIntrospection ||
+        timer_info->type() == TimerInfo::kApiEvent ||
+        timer_info->type() == TimerInfo::kApiScopeAsync);
+
   std::string module_name =
       func != nullptr
           ? orbit_client_data::function_utils::GetLoadedModuleNameByPath(func->file_path())
           : "unknown";
-  const uint64_t event_id = event.data;
+  uint64_t event_id = 0;
+  if (timer_info->type() == TimerInfo::kApiScopeAsync) {
+    event_id = timer_info->api_async_scope_id();
+  } else {
+    CHECK(timer_info->type() == TimerInfo::kApiEvent);
+    orbit_api::Event event = ManualInstrumentationManager::ApiEventFromTimerInfo(*timer_info);
+    event_id = event.data;
+  }
   std::string function_name = manual_inst_manager->GetString(event_id);
 
   return absl::StrFormat(
@@ -94,9 +103,15 @@ float AsyncTrack::GetDefaultBoxHeight() const {
 std::string AsyncTrack::GetTimesliceText(const TimerInfo& timer_info) const {
   std::string time = GetDisplayTime(timer_info);
 
-  orbit_api::Event event = ManualInstrumentationManager::ApiEventFromTimerInfo(timer_info);
-  const uint64_t event_id = event.data;
-  std::string name = app_->GetManualInstrumentationManager()->GetString(event_id);
+  std::string name{};
+  if (timer_info.type() == TimerInfo::kApiEvent) {
+    orbit_api::Event event = ManualInstrumentationManager::ApiEventFromTimerInfo(timer_info);
+    const uint64_t event_id = event.data;
+    name = app_->GetManualInstrumentationManager()->GetString(event_id);
+  } else {
+    CHECK(timer_info.type() == TimerInfo::kApiScopeAsync);
+    name = timer_info.api_scope_name();
+  }
   return absl::StrFormat("%s %s", name, time);
 }
 
@@ -114,13 +129,31 @@ Color AsyncTrack::GetTimerColor(const TimerInfo& timer_info, bool is_selected,
     return kInactiveColor;
   }
 
-  orbit_api::Event event = ManualInstrumentationManager::ApiEventFromTimerInfo(timer_info);
-  const uint64_t event_id = event.data;
+  if (timer_info.has_color()) {
+    CHECK(timer_info.color().red() < 256);
+    CHECK(timer_info.color().green() < 256);
+    CHECK(timer_info.color().blue() < 256);
+    CHECK(timer_info.color().alpha() < 256);
+    return Color(static_cast<uint8_t>(timer_info.color().red()),
+                 static_cast<uint8_t>(timer_info.color().green()),
+                 static_cast<uint8_t>(timer_info.color().blue()),
+                 static_cast<uint8_t>(timer_info.color().alpha()));
+  }
+
+  uint64_t event_id = 0;
+  if (timer_info.type() == TimerInfo::kApiScopeAsync) {
+    event_id = timer_info.api_async_scope_id();
+  } else {
+    CHECK(timer_info.type() == TimerInfo::kApiEvent);
+    orbit_api::Event event = ManualInstrumentationManager::ApiEventFromTimerInfo(timer_info);
+    event_id = event.data;
+  }
+
   std::string name = app_->GetManualInstrumentationManager()->GetString(event_id);
   Color color = TimeGraph::GetColor(name);
 
   constexpr uint8_t kOddAlpha = 210;
-  if (!(timer_info.depth() & 0x1)) {
+  if ((timer_info.depth() & 0x1) == 0u) {
     color[3] = kOddAlpha;
   }
 

--- a/src/OrbitGl/AsyncTrack.cpp
+++ b/src/OrbitGl/AsyncTrack.cpp
@@ -5,11 +5,10 @@
 #include "AsyncTrack.h"
 
 #include <GteVector.h>
-#include <absl/container/flat_hash_map.h>
 #include <absl/strings/str_format.h>
-#include <absl/time/time.h>
 
 #include <algorithm>
+#include <ctime>
 
 #include "App.h"
 #include "Batcher.h"
@@ -104,13 +103,13 @@ std::string AsyncTrack::GetTimesliceText(const TimerInfo& timer_info) const {
   std::string time = GetDisplayTime(timer_info);
 
   std::string name{};
-  if (timer_info.type() == TimerInfo::kApiEvent) {
+  if (timer_info.type() == TimerInfo::kApiScopeAsync) {
+    name = timer_info.api_scope_name();
+  } else {
+    CHECK(timer_info.type() == TimerInfo::kApiEvent);
     orbit_api::Event event = ManualInstrumentationManager::ApiEventFromTimerInfo(timer_info);
     const uint64_t event_id = event.data;
     name = app_->GetManualInstrumentationManager()->GetString(event_id);
-  } else {
-    CHECK(timer_info.type() == TimerInfo::kApiScopeAsync);
-    name = timer_info.api_scope_name();
   }
   return absl::StrFormat("%s %s", name, time);
 }

--- a/src/OrbitGl/ManualInstrumentationManager.h
+++ b/src/OrbitGl/ManualInstrumentationManager.h
@@ -27,8 +27,10 @@ class ManualInstrumentationManager {
 
   void AddAsyncTimerListener(AsyncTimerInfoListener* listener);
   void RemoveAsyncTimerListener(AsyncTimerInfoListener* listener);
+  [[deprecated]] void ProcessAsyncTimerLegacy(const orbit_client_protos::TimerInfo& timer_info);
+  [[deprecated]] void ProcessStringEventLegacy(const orbit_api::Event& event);
   void ProcessAsyncTimer(const orbit_client_protos::TimerInfo& timer_info);
-  void ProcessStringEvent(const orbit_api::Event& event);
+  void ProcessStringEvent(const orbit_client_protos::ApiStringEvent& string_event);
   [[nodiscard]] std::string GetString(uint32_t id) const {
     return string_manager_.Get(id).value_or("");
   }

--- a/src/OrbitGl/TimeGraph.h
+++ b/src/OrbitGl/TimeGraph.h
@@ -61,6 +61,8 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
 
   void ProcessTimer(const orbit_client_protos::TimerInfo& timer_info,
                     const orbit_grpc_protos::InstrumentedFunction* function);
+  void ProcessApiStringEvent(const orbit_client_protos::ApiStringEvent& string_event);
+  void ProcessApiTrackValueEvent(const orbit_client_protos::ApiTrackValue& track_event);
 
   [[nodiscard]] const orbit_client_data::CaptureData* GetCaptureData() const {
     return capture_data_;
@@ -188,9 +190,12 @@ class TimeGraph : public orbit_gl::CaptureViewElement {
   [[nodiscard]] std::unique_ptr<orbit_accessibility::AccessibleInterface>
   CreateAccessibleInterface() override;
 
-  void ProcessApiEventTimer(const orbit_client_protos::TimerInfo& timer_info);
+  [[deprecated]] void ProcessApiEventTimerLegacy(const orbit_client_protos::TimerInfo& timer_info);
+  void ProcessApiScopeTimer(const orbit_client_protos::TimerInfo& timer_info);
+  void ProcessApiScopeAsyncTimer(const orbit_client_protos::TimerInfo& timer_info);
   void ProcessIntrospectionTimer(const orbit_client_protos::TimerInfo& timer_info);
-  void ProcessValueTrackingTimer(const orbit_client_protos::TimerInfo& timer_info);
+  [[deprecated]] void ProcessValueTrackingTimerLegacy(
+      const orbit_client_protos::TimerInfo& timer_info);
   void ProcessAsyncTimer(const std::string& track_name,
                          const orbit_client_protos::TimerInfo& timer_info);
   void ProcessSystemMemoryTrackingTimer(const orbit_client_protos::TimerInfo& timer_info);


### PR DESCRIPTION
`App` will send the new manual instrumentation events, which are a replacement for the `ApiEvent`, to `TimeGraph` which will delegate the events similar to how it is currently done. The Scopes will still be send to `ThreadTrack`/`AsyncTrack`, so those tracks need to distinguish those from the old ones.

Test: Compile
Bug: http://b/194763537; http://b/194764373; http://b/194764259;